### PR TITLE
feat: add TurboQuant KV cache quantization (PolarQuant + QJL)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(IMP_QUANT_SOURCES
     src/quant/fp8_quant.cu
     src/quant/nvfp4_quant.cu
     src/quant/nvfp4_gemm.cu
+    src/quant/turboquant.cu
 )
 
 set(IMP_COMPUTE_SOURCES
@@ -120,6 +121,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/attention_paged_fp8.cu
     src/compute/attention_paged_int8.cu
     src/compute/attention_paged_int4.cu
+    src/compute/attention_paged_turboquant.cu
     src/compute/attention_tc.cu
     src/compute/attention_blackwell.cu
     src/compute/attention_cublas.cu
@@ -315,6 +317,7 @@ if(IMP_BUILD_TESTS)
         tests/test_fp8_gemm.cu
         tests/test_attention_tc.cu
         tests/test_nvfp4_quant.cu
+        tests/test_turboquant.cu
         tests/test_fp8_kv_cache.cu
         tests/test_speculative.cpp
         tests/test_sampling.cu

--- a/include/imp/config.h
+++ b/include/imp/config.h
@@ -49,7 +49,7 @@ typedef struct {
     int gpu_layers;                // Layers to keep on GPU (-1 = all, 0 = all offloaded)
 
     // KV cache precision
-    ImpDType kv_cache_dtype;       // FP16 (default), FP8_E4M3, or INT8 for half-size KV cache
+    ImpDType kv_cache_dtype;       // FP16 (default), FP8_E4M3, INT8, INT4, or TURBOQUANT
 
     // SSM state precision
     ImpDType ssm_state_dtype;      // FP32 (default) or FP16 for SSM h_state

--- a/include/imp/types.h
+++ b/include/imp/types.h
@@ -16,6 +16,7 @@ typedef enum {
     IMP_DTYPE_INT4      = 6,
     IMP_DTYPE_INT32     = 7,
     IMP_DTYPE_FP4_E2M1  = 8,
+    IMP_DTYPE_TURBOQUANT = 9,   // TurboQuant: PolarQuant INT4 K + QJL sketch + INT4 V
 } ImpDType;
 
 typedef enum {

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -119,6 +119,8 @@ static imp::DType map_dtype(ImpDType dt) {
         case IMP_DTYPE_INT8:     return imp::DType::INT8;
         case IMP_DTYPE_INT4:     return imp::DType::INT4;
         case IMP_DTYPE_INT32:    return imp::DType::INT32;
+        case IMP_DTYPE_FP4_E2M1: return imp::DType::FP4_E2M1;
+        case IMP_DTYPE_TURBOQUANT: return imp::DType::TURBOQUANT;
         default:                 return imp::DType::FP16;
     }
 }

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -69,6 +69,25 @@ void paged_attention_decode_int4(
     float softcap = 0.0f, cudaStream_t stream = nullptr,
     int max_blocks_per_seq = 0);
 
+// TurboQuant Paged attention for decode: PolarQuant INT4 K + QJL sketch + INT4 V.
+// Q: [batch, 1, n_heads, head_dim] FP16
+// K_dir_cache: [num_blocks, block_size, n_kv_heads, head_dim/2] packed INT4 unit directions
+// V_cache: [num_blocks, block_size, n_kv_heads, head_dim/2] packed INT4 values
+// K_norms: [num_blocks, block_size, n_kv_heads] FP16 PolarQuant norms
+// V_scales: [num_blocks, block_size, n_kv_heads] FP16 per-head V scales
+// K_sketches: [num_blocks, block_size, n_kv_heads, sketch_dim/8] packed 1-bit QJL sketches
+// qjl_matrix: [sketch_dim, head_dim/8] packed Rademacher signs
+void paged_attention_decode_turboquant(
+    const Tensor& Q, const Tensor& K_dir_cache, const Tensor& V_cache,
+    Tensor& O,
+    const half* K_norms, const half* V_scales,
+    const uint8_t* K_sketches, const uint8_t* qjl_matrix,
+    const int* block_tables, const int* context_lens,
+    int block_size, float scale, int sketch_dim,
+    int max_context_len, int sliding_window = 0,
+    float softcap = 0.0f, cudaStream_t stream = nullptr,
+    int max_blocks_per_seq = 0);
+
 // Split-K scratch buffer accessor (for use by FP8/INT8 launcher TUs).
 // Returns pointer + size. Either can be nullptr/0 if unset.
 void paged_attention_get_splitk_scratch(void** out_ptr, size_t* out_size);

--- a/src/compute/attention_paged_turboquant.cu
+++ b/src/compute/attention_paged_turboquant.cu
@@ -1,0 +1,641 @@
+#include "compute/attention_paged.h"
+#include "compute/attention_paged_common.cuh"
+#include "compute/attention.h"
+#include "core/logging.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <float.h>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// TurboQuant Paged Attention Decode Kernel
+//
+// K cache: PolarQuant INT4 directions + FP16 norms + QJL 1-bit sketches
+// V cache: Standard INT4 with per-head FP16 scales
+//
+// Q.K estimation:
+//   1. PolarQuant: qk_polar = ||k|| * (q . dir_k_quantized)
+//      where dir_k_quantized is INT4-dequantized unit vector
+//   2. QJL correction: qk_qjl = ||q|| * ||k|| * (2*popcount(XNOR(sketch_q, sketch_k)) - sketch_dim) / sketch_dim
+//   3. Combined: qk = (1 - lambda) * qk_polar + lambda * qk_qjl
+//      lambda = 0.1 (small correction weight from paper)
+//
+// V accumulation: same as INT4 kernel (unpack, dequant with per-head scale)
+// ---------------------------------------------------------------------------
+
+// Unpack INT4 nibble to signed integer [-8, 7]
+__device__ __forceinline__ int tq_unpack_int4_lo(uint8_t packed) {
+    int val = packed & 0xF;
+    return (val >= 8) ? (val - 16) : val;
+}
+
+__device__ __forceinline__ int tq_unpack_int4_hi(uint8_t packed) {
+    int val = (packed >> 4) & 0xF;
+    return (val >= 8) ? (val - 16) : val;
+}
+
+// QJL correction weight (from TurboQuant paper)
+static constexpr float kQJLLambda = 0.1f;
+
+template<int HEAD_DIM>
+__global__ void paged_attention_decode_turboquant_kernel(
+    const half* __restrict__ Q,                // [batch, n_heads, HEAD_DIM]
+    const uint8_t* __restrict__ K_dir_cache,   // INT4 packed normalized directions
+    const uint8_t* __restrict__ V_cache,       // INT4 packed values
+    const half* __restrict__ K_norms,          // [total_blocks, block_size, n_kv_heads] FP16 norms
+    const half* __restrict__ V_scales,         // [total_blocks, block_size, n_kv_heads] FP16 scales
+    const uint8_t* __restrict__ K_sketches,    // [total_blocks, block_size, n_kv_heads, sketch_dim/8] packed bits
+    const uint8_t* __restrict__ qjl_matrix,    // [sketch_dim, head_dim/8] packed Rademacher signs
+    half* __restrict__ O,
+    const int* __restrict__ block_tables,
+    const int* __restrict__ context_lens,
+    int batch_size,
+    int n_heads,
+    int n_kv_heads,
+    int block_size,
+    float scale,
+    int sketch_dim,
+    int max_context_len,
+    int max_num_blocks,
+    int sliding_window,
+    float softcap)
+{
+    static_assert(HEAD_DIM % WARP_SIZE == 0);
+    constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
+
+    const int batch_idx = blockIdx.x;
+    const int head_idx  = blockIdx.y;
+    const int kv_head   = head_idx / (n_heads / n_kv_heads);
+
+    const int ctx_len = context_lens[batch_idx];
+    if (ctx_len <= 0) return;
+
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    const int lane_offset = lane_id * ELEMS;
+
+    // Load Q into registers
+    const half* Q_ptr = Q + (int64_t)batch_idx * n_heads * HEAD_DIM
+                          + (int64_t)head_idx * HEAD_DIM;
+    float q_reg[ELEMS];
+    {
+        const half2* Q_ptr2 = reinterpret_cast<const half2*>(Q_ptr + lane_offset);
+        #pragma unroll
+        for (int i = 0; i < ELEMS / 2; i++) {
+            half2 h2 = Q_ptr2[i];
+            q_reg[2*i]   = __half2float(h2.x);
+            q_reg[2*i+1] = __half2float(h2.y);
+        }
+    }
+
+    // Compute Q norm for QJL correction
+    float q_norm_sq = 0.0f;
+    for (int i = 0; i < ELEMS; i++) q_norm_sq += q_reg[i] * q_reg[i];
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        q_norm_sq += __shfl_xor_sync(0xFFFFFFFF, q_norm_sq, offset);
+    float q_norm = sqrtf(q_norm_sq);
+
+    // Compute Q's QJL sketch: sign(R @ q) for each sketch row
+    // Each lane stores a portion of the sketch in registers.
+    // sketch_dim <= HEAD_DIM typically, and we store as packed uint32 chunks.
+    // We'll compute the sketch in shared memory for broadcasting.
+    extern __shared__ char smem_tq[];
+    // Layout: [sketch_dim/8 bytes for Q sketch] [warp_max + warp_l + warp_o]
+    const int sketch_bytes = sketch_dim / 8;
+    uint8_t* q_sketch = reinterpret_cast<uint8_t*>(smem_tq);
+    float* warp_max_ptr = reinterpret_cast<float*>(q_sketch + ((sketch_bytes + 3) & ~3));  // align to 4
+    float* warp_l_ptr   = warp_max_ptr + NUM_WARPS;
+    float* warp_o_ptr   = warp_l_ptr + NUM_WARPS;
+
+    // Initialize Q sketch to zero
+    for (int i = threadIdx.x; i < sketch_bytes; i += blockDim.x)
+        q_sketch[i] = 0;
+    __syncthreads();
+
+    // Compute Q sketch: each thread handles a subset of sketch rows
+    {
+        const int bytes_per_qjl_row = HEAD_DIM / 8;
+        for (int sr = threadIdx.x; sr < sketch_dim; sr += blockDim.x) {
+            const uint8_t* R_row = qjl_matrix + sr * bytes_per_qjl_row;
+
+            // Compute dot product R[sr] . Q (full head dim)
+            // Each thread needs all Q elements - broadcast from lane 0 via shfl
+            float dot = 0.0f;
+            for (int d = 0; d < HEAD_DIM; d++) {
+                // Get Q[d] from the lane that owns it
+                int owning_lane = d / ELEMS;
+                int local_idx = d % ELEMS;
+                float q_val = __shfl_sync(0xFFFFFFFF, q_reg[local_idx], owning_lane);
+
+                // Get R sign bit
+                uint8_t r_byte = __ldg(&R_row[d / 8]);
+                float r_sign = (r_byte & (1u << (d % 8))) ? 1.0f : -1.0f;
+                dot += r_sign * q_val;
+            }
+
+            // Store sign bit atomically
+            int byte_idx = sr / 8;
+            int bit_idx = sr % 8;
+            if (dot >= 0.0f) {
+                atomicOr(reinterpret_cast<unsigned int*>(&q_sketch[byte_idx & ~3]),
+                         static_cast<unsigned int>(1u << bit_idx) << (8 * (byte_idx & 3)));
+            }
+        }
+    }
+    __syncthreads();
+
+    const int* bt = block_tables + (int64_t)batch_idx * max_num_blocks;
+    const int kv_head_bytes = HEAD_DIM / 2;  // bytes per head per token (INT4 packed)
+    const int kv_block_stride = block_size * n_kv_heads * kv_head_bytes;
+    const int kv_slot_stride  = n_kv_heads * kv_head_bytes;
+    const int scale_block_stride = block_size * n_kv_heads;
+    const int sketch_head_bytes = sketch_dim / 8;
+    const int sketch_slot_stride = n_kv_heads * sketch_head_bytes;
+    const int sketch_kv_block_stride = block_size * sketch_slot_stride;
+
+    int effective_start = 0;
+    if (sliding_window > 0 && ctx_len > sliding_window)
+        effective_start = ctx_len - sliding_window;
+    const int first_block = effective_start / block_size;
+    const int num_ctx_blocks = (ctx_len + block_size - 1) / block_size;
+
+    float m_w = -FLT_MAX;
+    float l_w = 0.0f;
+    float o_reg[ELEMS];
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++) o_reg[i] = 0.0f;
+
+    for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
+        int phys_block = bt[blk];
+        const uint8_t* K_dir_block = K_dir_cache + (int64_t)phys_block * kv_block_stride;
+        const uint8_t* V_block     = V_cache     + (int64_t)phys_block * kv_block_stride;
+        const half* K_norm_block   = K_norms     + (int64_t)phys_block * scale_block_stride;
+        const half* V_sc_block     = V_scales    + (int64_t)phys_block * scale_block_stride;
+        const uint8_t* K_sk_block  = K_sketches  + (int64_t)phys_block * sketch_kv_block_stride;
+
+        int tok_start = blk * block_size;
+        int tok_end   = tok_start + block_size;
+        if (tok_end > ctx_len) tok_end = ctx_len;
+
+        int first_tok = 0;
+        if (tok_start < effective_start) first_tok = effective_start - tok_start;
+
+        for (int t = first_tok; t < (tok_end - tok_start); t++) {
+            const uint8_t* K_dir_tok = K_dir_block + t * kv_slot_stride + kv_head * kv_head_bytes;
+            float k_norm = __half2float(K_norm_block[t * n_kv_heads + kv_head]);
+
+            // PolarQuant Q.K: q . (norm * dir_quantized) = norm * q . dir_quantized
+            float dot_polar = 0.0f;
+            {
+                const uint8_t* k_bytes = K_dir_tok + lane_offset / 2;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = k_bytes[i];
+                    // Dequant: INT4 → float, then divide by 7 to get unit vector component
+                    float d0 = static_cast<float>(tq_unpack_int4_lo(packed)) / 7.0f;
+                    float d1 = static_cast<float>(tq_unpack_int4_hi(packed)) / 7.0f;
+                    dot_polar += q_reg[2*i]   * d0;
+                    dot_polar += q_reg[2*i+1] * d1;
+                }
+            }
+            dot_polar = warp_reduce_sum(dot_polar);
+            dot_polar *= k_norm;
+
+            // QJL correction: compare Q sketch with K sketch
+            float dot_qjl = 0.0f;
+            if (lane_id == 0) {
+                const uint8_t* k_sketch = K_sk_block + t * sketch_slot_stride + kv_head * sketch_head_bytes;
+                int match_count = 0;
+                // XNOR + popcount over sketch_dim bits
+                for (int sb = 0; sb < sketch_bytes / 4; sb++) {
+                    uint32_t q_word = reinterpret_cast<const uint32_t*>(q_sketch)[sb];
+                    uint32_t k_word;
+                    // Safely load potentially unaligned K sketch
+                    memcpy(&k_word, k_sketch + sb * 4, sizeof(uint32_t));
+                    uint32_t xnor = ~(q_word ^ k_word);
+                    match_count += __popc(xnor);
+                }
+                // Handle remaining bytes
+                for (int sb = (sketch_bytes / 4) * 4; sb < sketch_bytes; sb++) {
+                    uint8_t xnor = ~(q_sketch[sb] ^ k_sketch[sb]);
+                    match_count += __popc(static_cast<unsigned int>(xnor) & 0xFF);
+                }
+                // QJL estimator: ||q|| * ||k|| * (2*matches - sketch_dim) / sketch_dim
+                dot_qjl = q_norm * k_norm * static_cast<float>(2 * match_count - sketch_dim)
+                          / static_cast<float>(sketch_dim);
+            }
+            dot_qjl = __shfl_sync(0xFFFFFFFF, dot_qjl, 0);
+
+            // Combined estimate with QJL correction
+            float dot = (1.0f - kQJLLambda) * dot_polar + kQJLLambda * dot_qjl;
+
+            dot *= scale;
+            dot = apply_softcap(dot, softcap);
+
+            float rescale, w_new;
+            online_softmax_step(dot, m_w, l_w, rescale, w_new);
+
+            // V accumulation: standard INT4 path
+            const uint8_t* V_tok = V_block + t * kv_slot_stride + kv_head * kv_head_bytes;
+            float v_scale = __half2float(V_sc_block[t * n_kv_heads + kv_head]);
+            {
+                const uint8_t* v_bytes = V_tok + lane_offset / 2;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = v_bytes[i];
+                    float v0 = static_cast<float>(tq_unpack_int4_lo(packed)) * v_scale;
+                    float v1 = static_cast<float>(tq_unpack_int4_hi(packed)) * v_scale;
+                    o_reg[2*i]   = rescale * o_reg[2*i]   + w_new * v0;
+                    o_reg[2*i+1] = rescale * o_reg[2*i+1] + w_new * v1;
+                }
+            }
+        }
+    }
+
+    // Cross-warp reduction
+    if (lane_id == 0) {
+        warp_max_ptr[warp_id] = m_w;
+        warp_l_ptr[warp_id]   = l_w;
+    }
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++)
+        warp_o_ptr[warp_id * HEAD_DIM + lane_offset + i] = o_reg[i];
+    __syncthreads();
+
+    if (warp_id == 0) {
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = fmaxf(global_max, warp_max_ptr[w]);
+
+        float global_l = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_l += expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+
+        #pragma unroll
+        for (int i = 0; i < ELEMS; i++) {
+            int d = lane_offset + i;
+            float o_val = 0.0f;
+            for (int w = 0; w < NUM_WARPS; w++) {
+                float weight = expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+                o_val += weight * warp_o_ptr[w * HEAD_DIM + d];
+            }
+            if (global_l > 0.0f) o_val /= global_l;
+
+            int out_idx = batch_idx * n_heads * HEAD_DIM
+                        + head_idx * HEAD_DIM + d;
+            O[out_idx] = __float2half(o_val);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Split-K Phase 1: TurboQuant variant
+// ---------------------------------------------------------------------------
+
+template<int HEAD_DIM>
+__global__ void paged_attention_splitk_turboquant_kernel(
+    const half* __restrict__ Q,
+    const uint8_t* __restrict__ K_dir_cache,
+    const uint8_t* __restrict__ V_cache,
+    const half* __restrict__ K_norms,
+    const half* __restrict__ V_scales,
+    const uint8_t* __restrict__ K_sketches,
+    const uint8_t* __restrict__ qjl_matrix,
+    float* __restrict__ partial_out,
+    const int* __restrict__ block_tables,
+    const int* __restrict__ context_lens,
+    int batch_size,
+    int n_heads,
+    int n_kv_heads,
+    int block_size,
+    float scale,
+    int sketch_dim,
+    int max_num_blocks,
+    int num_splits,
+    int sliding_window,
+    float softcap)
+{
+    static_assert(HEAD_DIM % WARP_SIZE == 0);
+    constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
+
+    const int batch_idx = blockIdx.x;
+    const int head_idx  = blockIdx.y;
+    const int split_idx = blockIdx.z;
+    const int kv_head   = head_idx / (n_heads / n_kv_heads);
+
+    const int ctx_len = context_lens[batch_idx];
+    if (ctx_len <= 0) return;
+
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    const int lane_offset = lane_id * ELEMS;
+
+    // Load Q into registers
+    const half* Q_ptr = Q + (int64_t)batch_idx * n_heads * HEAD_DIM
+                          + (int64_t)head_idx * HEAD_DIM;
+    float q_reg[ELEMS];
+    {
+        const half2* Q_ptr2 = reinterpret_cast<const half2*>(Q_ptr + lane_offset);
+        #pragma unroll
+        for (int i = 0; i < ELEMS / 2; i++) {
+            half2 h2 = Q_ptr2[i];
+            q_reg[2*i]   = __half2float(h2.x);
+            q_reg[2*i+1] = __half2float(h2.y);
+        }
+    }
+
+    // Q norm for QJL
+    float q_norm_sq = 0.0f;
+    for (int i = 0; i < ELEMS; i++) q_norm_sq += q_reg[i] * q_reg[i];
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        q_norm_sq += __shfl_xor_sync(0xFFFFFFFF, q_norm_sq, offset);
+    float q_norm = sqrtf(q_norm_sq);
+
+    // Q sketch in shared memory
+    extern __shared__ char smem_tq_sk[];
+    const int sketch_bytes = sketch_dim / 8;
+    uint8_t* q_sketch = reinterpret_cast<uint8_t*>(smem_tq_sk);
+    float* warp_max_ptr = reinterpret_cast<float*>(q_sketch + ((sketch_bytes + 3) & ~3));
+    float* warp_l_ptr   = warp_max_ptr + NUM_WARPS;
+    float* warp_o_ptr   = warp_l_ptr + NUM_WARPS;
+
+    for (int i = threadIdx.x; i < sketch_bytes; i += blockDim.x)
+        q_sketch[i] = 0;
+    __syncthreads();
+
+    // Compute Q sketch
+    {
+        const int bytes_per_qjl_row = HEAD_DIM / 8;
+        for (int sr = threadIdx.x; sr < sketch_dim; sr += blockDim.x) {
+            const uint8_t* R_row = qjl_matrix + sr * bytes_per_qjl_row;
+            float dot = 0.0f;
+            for (int d = 0; d < HEAD_DIM; d++) {
+                int owning_lane = d / ELEMS;
+                int local_idx = d % ELEMS;
+                float q_val = __shfl_sync(0xFFFFFFFF, q_reg[local_idx], owning_lane);
+                uint8_t r_byte = __ldg(&R_row[d / 8]);
+                float r_sign = (r_byte & (1u << (d % 8))) ? 1.0f : -1.0f;
+                dot += r_sign * q_val;
+            }
+            int byte_idx = sr / 8;
+            int bit_idx = sr % 8;
+            if (dot >= 0.0f) {
+                atomicOr(reinterpret_cast<unsigned int*>(&q_sketch[byte_idx & ~3]),
+                         static_cast<unsigned int>(1u << bit_idx) << (8 * (byte_idx & 3)));
+            }
+        }
+    }
+    __syncthreads();
+
+    const int* bt = block_tables + (int64_t)batch_idx * max_num_blocks;
+    const int kv_head_bytes = HEAD_DIM / 2;
+    const int kv_block_stride = block_size * n_kv_heads * kv_head_bytes;
+    const int kv_slot_stride  = n_kv_heads * kv_head_bytes;
+    const int scale_block_stride = block_size * n_kv_heads;
+    const int sketch_head_bytes = sketch_dim / 8;
+    const int sketch_slot_stride = n_kv_heads * sketch_head_bytes;
+    const int sketch_kv_block_stride = block_size * sketch_slot_stride;
+
+    int effective_start = 0;
+    if (sliding_window > 0 && ctx_len > sliding_window)
+        effective_start = ctx_len - sliding_window;
+    const int first_block = effective_start / block_size;
+    const int num_ctx_blocks = (ctx_len + block_size - 1) / block_size;
+
+    // Split-K: this split handles blocks [split_start, split_end)
+    int blocks_per_split = (num_ctx_blocks - first_block + num_splits - 1) / num_splits;
+    int split_start = first_block + split_idx * blocks_per_split;
+    int split_end   = min(split_start + blocks_per_split, num_ctx_blocks);
+
+    if (split_start >= num_ctx_blocks) {
+        write_empty_split_sentinel<HEAD_DIM>(partial_out, batch_idx, n_heads, head_idx,
+                                              num_splits, split_idx, lane_offset);
+        return;
+    }
+
+    float m_w = -FLT_MAX;
+    float l_w = 0.0f;
+    float o_reg[ELEMS];
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++) o_reg[i] = 0.0f;
+
+    for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
+        int phys_block = bt[blk];
+        const uint8_t* K_dir_block = K_dir_cache + (int64_t)phys_block * kv_block_stride;
+        const uint8_t* V_block     = V_cache     + (int64_t)phys_block * kv_block_stride;
+        const half* K_norm_block   = K_norms     + (int64_t)phys_block * scale_block_stride;
+        const half* V_sc_block     = V_scales    + (int64_t)phys_block * scale_block_stride;
+        const uint8_t* K_sk_block  = K_sketches  + (int64_t)phys_block * sketch_kv_block_stride;
+
+        int tok_start = blk * block_size;
+        int tok_end   = tok_start + block_size;
+        if (tok_end > ctx_len) tok_end = ctx_len;
+
+        int first_tok = 0;
+        if (tok_start < effective_start) first_tok = effective_start - tok_start;
+
+        for (int t = first_tok; t < (tok_end - tok_start); t++) {
+            const uint8_t* K_dir_tok = K_dir_block + t * kv_slot_stride + kv_head * kv_head_bytes;
+            float k_norm = __half2float(K_norm_block[t * n_kv_heads + kv_head]);
+
+            // PolarQuant dot product
+            float dot_polar = 0.0f;
+            {
+                const uint8_t* k_bytes = K_dir_tok + lane_offset / 2;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = k_bytes[i];
+                    float d0 = static_cast<float>(tq_unpack_int4_lo(packed)) / 7.0f;
+                    float d1 = static_cast<float>(tq_unpack_int4_hi(packed)) / 7.0f;
+                    dot_polar += q_reg[2*i]   * d0;
+                    dot_polar += q_reg[2*i+1] * d1;
+                }
+            }
+            dot_polar = warp_reduce_sum(dot_polar);
+            dot_polar *= k_norm;
+
+            // QJL correction
+            float dot_qjl = 0.0f;
+            if (lane_id == 0) {
+                const uint8_t* k_sketch = K_sk_block + t * sketch_slot_stride + kv_head * sketch_head_bytes;
+                int match_count = 0;
+                for (int sb = 0; sb < sketch_bytes / 4; sb++) {
+                    uint32_t q_word = reinterpret_cast<const uint32_t*>(q_sketch)[sb];
+                    uint32_t k_word;
+                    memcpy(&k_word, k_sketch + sb * 4, sizeof(uint32_t));
+                    match_count += __popc(~(q_word ^ k_word));
+                }
+                for (int sb = (sketch_bytes / 4) * 4; sb < sketch_bytes; sb++) {
+                    uint8_t xnor = ~(q_sketch[sb] ^ k_sketch[sb]);
+                    match_count += __popc(static_cast<unsigned int>(xnor) & 0xFF);
+                }
+                dot_qjl = q_norm * k_norm * static_cast<float>(2 * match_count - sketch_dim)
+                          / static_cast<float>(sketch_dim);
+            }
+            dot_qjl = __shfl_sync(0xFFFFFFFF, dot_qjl, 0);
+
+            float dot = (1.0f - kQJLLambda) * dot_polar + kQJLLambda * dot_qjl;
+            dot *= scale;
+            dot = apply_softcap(dot, softcap);
+
+            float rescale, w_new;
+            online_softmax_step(dot, m_w, l_w, rescale, w_new);
+
+            // V accumulation
+            const uint8_t* V_tok = V_block + t * kv_slot_stride + kv_head * kv_head_bytes;
+            float v_scale_f = __half2float(V_sc_block[t * n_kv_heads + kv_head]);
+            {
+                const uint8_t* v_bytes = V_tok + lane_offset / 2;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = v_bytes[i];
+                    float v0 = static_cast<float>(tq_unpack_int4_lo(packed)) * v_scale_f;
+                    float v1 = static_cast<float>(tq_unpack_int4_hi(packed)) * v_scale_f;
+                    o_reg[2*i]   = rescale * o_reg[2*i]   + w_new * v0;
+                    o_reg[2*i+1] = rescale * o_reg[2*i+1] + w_new * v1;
+                }
+            }
+        }
+    }
+
+    // Cross-warp reduction → write partial for split-K reduce
+    __syncthreads();
+    if (lane_id == 0) {
+        warp_max_ptr[warp_id] = m_w;
+        warp_l_ptr[warp_id]   = l_w;
+    }
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++)
+        warp_o_ptr[warp_id * HEAD_DIM + lane_offset + i] = o_reg[i];
+    __syncthreads();
+
+    if (warp_id == 0) {
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = fmaxf(global_max, warp_max_ptr[w]);
+        float global_l = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_l += expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+
+        int partial_idx = ((batch_idx * n_heads + head_idx) * num_splits + split_idx);
+        constexpr int partial_stride = 2 + HEAD_DIM;
+        float* out = partial_out + (int64_t)partial_idx * partial_stride;
+
+        if (lane_id == 0) { out[0] = global_max; out[1] = global_l; }
+
+        #pragma unroll
+        for (int i = 0; i < ELEMS; i++) {
+            int d = lane_offset + i;
+            float o_val = 0.0f;
+            for (int w = 0; w < NUM_WARPS; w++) {
+                float weight = expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+                o_val += weight * warp_o_ptr[w * HEAD_DIM + d];
+            }
+            out[2 + d] = o_val;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host launcher -- TurboQuant variant (with Split-K support)
+// ---------------------------------------------------------------------------
+void paged_attention_decode_turboquant(
+    const Tensor& Q, const Tensor& K_dir_cache, const Tensor& V_cache,
+    Tensor& O,
+    const half* K_norms, const half* V_scales,
+    const uint8_t* K_sketches, const uint8_t* qjl_matrix,
+    const int* block_tables, const int* context_lens,
+    int block_size, float scale, int sketch_dim,
+    int max_context_len, int sliding_window,
+    float softcap, cudaStream_t stream,
+    int max_blocks_per_seq)
+{
+    const int batch_size = static_cast<int>(Q.shape[0]);
+    const int n_heads    = static_cast<int>(Q.shape[2]);
+    const int head_dim   = static_cast<int>(Q.shape[3]);
+    const int n_kv_heads = static_cast<int>(K_dir_cache.shape[2]);
+
+    const int max_num_blocks = (max_blocks_per_seq > 0) ? max_blocks_per_seq
+                               : (max_context_len + block_size - 1) / block_size;
+
+    // Shared memory: Q sketch bytes (aligned) + warp reduction arrays
+    const int sketch_bytes = sketch_dim / 8;
+    const int sketch_aligned = (sketch_bytes + 3) & ~3;
+    size_t smem_bytes = sketch_aligned
+                      + NUM_WARPS * sizeof(float)     // warp_max
+                      + NUM_WARPS * sizeof(float)     // warp_l
+                      + NUM_WARPS * head_dim * sizeof(float);  // warp_o
+
+    // Split-K decision
+    void* scratch_ptr = nullptr;
+    int num_splits = compute_splitk_splits(
+        batch_size, n_heads, head_dim, max_context_len, block_size, &scratch_ptr);
+
+    if (num_splits > 1) {
+        float* partial = static_cast<float*>(scratch_ptr);
+
+        dim3 grid1(batch_size, n_heads, num_splits);
+        dim3 block1(BLOCK_THREADS);
+
+        #define LAUNCH_SPLITK_TQ(HD) \
+            paged_attention_splitk_turboquant_kernel<HD><<<grid1, block1, smem_bytes, stream>>>( \
+                reinterpret_cast<const half*>(Q.data), \
+                reinterpret_cast<const uint8_t*>(K_dir_cache.data), \
+                reinterpret_cast<const uint8_t*>(V_cache.data), \
+                K_norms, V_scales, \
+                K_sketches, qjl_matrix, \
+                partial, \
+                block_tables, context_lens, \
+                batch_size, n_heads, n_kv_heads, \
+                block_size, scale, sketch_dim, \
+                max_num_blocks, num_splits, \
+                sliding_window, softcap)
+
+        switch (head_dim) {
+            case 64:  LAUNCH_SPLITK_TQ(64);  break;
+            case 96:  LAUNCH_SPLITK_TQ(96);  break;
+            case 128: LAUNCH_SPLITK_TQ(128); break;
+            case 256: LAUNCH_SPLITK_TQ(256); break;
+            default:
+                IMP_LOG_ERROR("paged_attention_splitk_turboquant: unsupported head_dim %d", head_dim);
+                return;
+        }
+        #undef LAUNCH_SPLITK_TQ
+
+        // Split-K Phase 2: reuse shared reduce launcher
+        paged_attention_launch_reduce(partial, reinterpret_cast<half*>(O.data),
+                                      batch_size, n_heads, head_dim, num_splits, stream);
+    } else {
+        dim3 grid(batch_size, n_heads);
+        dim3 block(BLOCK_THREADS);
+
+        #define LAUNCH_TQ(HD) \
+            paged_attention_decode_turboquant_kernel<HD><<<grid, block, smem_bytes, stream>>>( \
+                reinterpret_cast<const half*>(Q.data), \
+                reinterpret_cast<const uint8_t*>(K_dir_cache.data), \
+                reinterpret_cast<const uint8_t*>(V_cache.data), \
+                K_norms, V_scales, \
+                K_sketches, qjl_matrix, \
+                reinterpret_cast<half*>(O.data), \
+                block_tables, context_lens, \
+                batch_size, n_heads, n_kv_heads, \
+                block_size, scale, sketch_dim, max_context_len, max_num_blocks, \
+                sliding_window, softcap)
+
+        switch (head_dim) {
+            case 64:  LAUNCH_TQ(64);  break;
+            case 96:  LAUNCH_TQ(96);  break;
+            case 128: LAUNCH_TQ(128); break;
+            case 256: LAUNCH_TQ(256); break;
+            default:
+                IMP_LOG_ERROR("paged_attention_decode_turboquant: unsupported head_dim %d", head_dim);
+                return;
+        }
+        #undef LAUNCH_TQ
+    }
+}
+
+} // namespace imp

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -16,6 +16,7 @@ size_t dtype_size(DType dt) {
         case DType::INT4:      return 1; // packed: 2 elements per byte
         case DType::INT32:     return 4;
         case DType::FP4_E2M1:  return 1; // packed: 2 elements per byte
+        case DType::TURBOQUANT: return 1; // packed INT4 directions (2 per byte), sketch stored separately
     }
     return 0;
 }
@@ -31,6 +32,7 @@ const char* dtype_name(DType dt) {
         case DType::INT4:      return "INT4";
         case DType::INT32:     return "INT32";
         case DType::FP4_E2M1:  return "FP4_E2M1";
+        case DType::TURBOQUANT: return "TURBOQUANT";
     }
     return "UNKNOWN";
 }

--- a/src/core/tensor.h
+++ b/src/core/tensor.h
@@ -17,6 +17,7 @@ enum class DType : uint8_t {
     INT4      = 6,
     INT32     = 7,
     FP4_E2M1  = 8,
+    TURBOQUANT = 9,   // TurboQuant: PolarQuant INT4 K + QJL sketch + INT4 V
 };
 
 // Bytes per element. INT4 returns 1 (two elements packed per byte).

--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -8,6 +8,7 @@
 #include "compute/json_constrain.h"
 #include "compute/schema_constrain.h"
 #include "quant/nvfp4_quant.h"
+#include "quant/turboquant.h"
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
 #include "core/tensor.h"
@@ -304,6 +305,10 @@ public:
     // where forward_logits isn't called but the graph writes to this buffer).
     Tensor get_logits_view(int n) const { return view_tokens(logits_, n); }
 
+    // Access QJL projection for TurboQuant (initialized by Engine if kv_cache_dtype == TURBOQUANT)
+    QJLProjection& qjl_projection() { return qjl_proj_; }
+    const QJLProjection& qjl_projection() const { return qjl_proj_; }
+
     // Release the MoE batch dequant buffer when expert weights are on host.
     // Call after weight upload if experts didn't fit on GPU.
     void release_moe_batch_buf();
@@ -437,6 +442,9 @@ private:
     // Scale = absmax / 448.0; used as inv_scale = 1/scale for write, scale for read.
     std::vector<float> kv_scales_;       // [n_kv_layers] per-layer FP8 scale
     std::vector<bool>  kv_calibrated_;   // [n_kv_layers] whether scale has been calibrated
+
+    // TurboQuant QJL projection matrix (shared across all layers, initialized once)
+    QJLProjection qjl_proj_;
 
     // YaRN correction dimension boundaries [2], precomputed at init.
     // yarn_corr_dims_[0] = start (full interpolation below), yarn_corr_dims_[1] = end (full extrapolation above)

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -153,8 +153,33 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
     bool use_fp8 = (cache->dtype() == DType::FP8_E4M3);
     bool use_int8 = (cache->dtype() == DType::INT8);
     bool use_int4 = (cache->dtype() == DType::INT4);
+    bool use_turboquant = (cache->dtype() == DType::TURBOQUANT);
 
-    if (use_int4) {
+    if (use_turboquant) {
+        // TurboQuant KV cache write: PolarQuant INT4 directions + QJL sketch for K, INT4 for V
+        Tensor kv = view_tokens(k_, n);
+        Tensor vv = view_tokens(v_, n);
+        int int4_block_stride = kv_block_size * nkv * hd / 2;
+        int scale_block_stride_tq = kv_block_size * nkv;
+        int sketch_dim = qjl_proj_.sketch_dim;
+        int sketch_block_stride = kv_block_size * nkv * (sketch_dim / 8);
+        dim3 grid_tq(n, 2);
+        write_kv_cache_turboquant_kernel<<<grid_tq, 256, 0, stream>>>(
+            static_cast<const half*>(kv.data),
+            static_cast<const half*>(vv.data),
+            state.positions,
+            state.block_tables,
+            static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
+            static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
+            static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
+            static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)),
+            static_cast<uint8_t*>(cache->k_sketch_ptr(kv_layer, 0)),
+            static_cast<const uint8_t*>(qjl_proj_.matrix),
+            int4_block_stride, scale_block_stride_tq, sketch_block_stride,
+            nkv, hd, sketch_dim,
+            kv_block_size, n,
+            state.max_blocks_per_seq, state.n_sequences);
+    } else if (use_int4) {
         // INT4 quantized KV cache write — 2 values packed per byte, per-head scales
         Tensor kv = view_tokens(k_, n);
         Tensor vv = view_tokens(v_, n);
@@ -744,7 +769,20 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         Tensor k_c(cache->k_ptr(kv_layer, 0), cache_dtype, 4, cs, true);
         Tensor v_c(cache->v_ptr(kv_layer, 0), cache_dtype, 4, cs, true);
 
-        if (cache_dtype == DType::INT4) {
+        if (cache_dtype == DType::TURBOQUANT) {
+            // TurboQuant paged attention: PolarQuant K + QJL correction + INT4 V (Split-K enabled)
+            paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
+            paged_attention_decode_turboquant(q4, k_c, v_c, o4,
+                                        static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
+                                        static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
+                                        static_cast<const uint8_t*>(cache->k_sketch_ptr(kv_layer, 0)),
+                                        static_cast<const uint8_t*>(qjl_proj_.matrix),
+                                        state.block_tables, state.context_lens,
+                                        kv_bs, scale, qjl_proj_.sketch_dim,
+                                        state.max_context_len, layer_sliding_window,
+                                        cfg.attn_logit_softcap, stream,
+                                        state.max_blocks_per_seq);
+        } else if (cache_dtype == DType::INT4) {
             // INT4 paged attention with per-head scales and INT4 unpack (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_int4(q4, k_c, v_c, o4,

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -696,6 +696,192 @@ __global__ void write_kv_cache_int4_kernel(
     }
 }
 
+// ---------------------------------------------------------------------------
+// TurboQuant KV cache write kernel
+//
+// K path (blockIdx.y == 0): PolarQuant decomposition + QJL sketch
+//   1. Compute L2 norm per head
+//   2. Normalize direction to unit vector
+//   3. Uniformly quantize direction to INT4 (range [-1,1] → [-8,7])
+//   4. Compute QJL 1-bit sketch: sign(R @ k) for each sketch row
+//   5. Store: INT4 direction, FP16 norm, packed sketch bits
+//
+// V path (blockIdx.y == 1): Standard INT4 per-head quantization (same as INT4 kernel)
+// ---------------------------------------------------------------------------
+__global__ void write_kv_cache_turboquant_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    const int* __restrict__ positions,
+    const int* __restrict__ block_tables,
+    uint8_t* __restrict__ k_dir_cache_base,
+    uint8_t* __restrict__ v_cache_base,
+    half* __restrict__ k_norm_base,
+    half* __restrict__ v_scale_base,
+    uint8_t* __restrict__ k_sketch_base,
+    const uint8_t* __restrict__ qjl_matrix,
+    int block_stride,
+    int scale_block_stride,
+    int sketch_block_stride,
+    int n_kv_heads,
+    int head_dim,
+    int sketch_dim,
+    int block_size,
+    int n_tokens,
+    int max_blocks_per_seq,
+    int n_sequences)
+{
+    const int token_idx = blockIdx.x;
+    if (token_idx >= n_tokens) return;
+
+    const int pos = positions[token_idx];
+    int slot_in_block;
+    int block_id = kv_resolve_slot(block_tables, pos, block_size,
+                                   token_idx, max_blocks_per_seq, n_sequences,
+                                   slot_in_block);
+
+    const int row_elems = n_kv_heads * head_dim;
+
+    if (blockIdx.y == 0) {
+        // ── K path: PolarQuant + QJL sketch ──
+        const half* src = k_in + static_cast<int64_t>(token_idx) * row_elems;
+        const int row_bytes = n_kv_heads * head_dim / 2;
+        uint8_t* dir_dst = k_dir_cache_base + static_cast<int64_t>(block_id) * block_stride
+                           + static_cast<int64_t>(slot_in_block) * row_bytes;
+        half* norm_dst = k_norm_base + static_cast<int64_t>(block_id) * scale_block_stride
+                         + static_cast<int64_t>(slot_in_block) * n_kv_heads;
+        const int sketch_row_bytes = n_kv_heads * (sketch_dim / 8);
+        uint8_t* sketch_dst = k_sketch_base + static_cast<int64_t>(block_id) * sketch_block_stride
+                              + static_cast<int64_t>(slot_in_block) * sketch_row_bytes;
+
+        const int warp_id = threadIdx.x / 32;
+        const int lane_id = threadIdx.x % 32;
+        const int num_warps = blockDim.x / 32;
+        const int bytes_per_row_qjl = head_dim / 8;
+
+        for (int h = warp_id; h < n_kv_heads; h += num_warps) {
+            const int head_offset = h * head_dim;
+
+            // Step 1: Compute L2 norm squared
+            float norm_sq = 0.0f;
+            for (int d = lane_id; d < head_dim; d += 32) {
+                float val = __half2float(src[head_offset + d]);
+                norm_sq += val * val;
+            }
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                norm_sq += __shfl_xor_sync(0xFFFFFFFF, norm_sq, offset);
+
+            float norm = sqrtf(norm_sq);
+            float inv_norm = (norm > 1e-8f) ? (1.0f / norm) : 0.0f;
+
+            // Step 2: Quantize normalized direction to INT4
+            const int head_byte_offset = h * head_dim / 2;
+            for (int d = lane_id * 2; d < head_dim; d += 64) {
+                float v0 = __half2float(src[head_offset + d]) * inv_norm;
+                float v1 = (d + 1 < head_dim) ? __half2float(src[head_offset + d + 1]) * inv_norm : 0.0f;
+
+                // Uniform quantize [-1, 1] → [-8, 7]
+                int q0 = __float2int_rn(v0 * 7.0f);
+                int q1 = __float2int_rn(v1 * 7.0f);
+                q0 = max(-8, min(7, q0));
+                q1 = max(-8, min(7, q1));
+
+                uint8_t packed = (static_cast<uint8_t>(q0 & 0xF)) |
+                                 (static_cast<uint8_t>(q1 & 0xF) << 4);
+                dir_dst[head_byte_offset + d / 2] = packed;
+            }
+
+            // Step 3: Store norm
+            if (lane_id == 0) {
+                norm_dst[h] = __float2half(norm);
+            }
+
+            // Step 4: QJL sketch = sign(R @ k) for each sketch row
+            // Each sketch row: dot product of Rademacher signs with k values → sign of result
+            // sketch_dim rows, one bit per row, packed into bytes
+            const int sketch_byte_offset = h * (sketch_dim / 8);
+
+            // Each lane computes a subset of sketch rows
+            for (int sr = lane_id; sr < sketch_dim; sr += 32) {
+                const uint8_t* R_row = qjl_matrix + sr * bytes_per_row_qjl;
+
+                // Compute sign(R[sr] . k[h])
+                // R is packed bits: bit j → sign (+1 if 1, -1 if 0)
+                float dot = 0.0f;
+                for (int d = 0; d < head_dim; d += 8) {
+                    uint8_t r_byte = __ldg(&R_row[d / 8]);
+                    #pragma unroll
+                    for (int b = 0; b < 8; b++) {
+                        float sign = (r_byte & (1u << b)) ? 1.0f : -1.0f;
+                        float k_val = __half2float(src[head_offset + d + b]);
+                        dot += sign * k_val;
+                    }
+                }
+
+                // Store 1-bit result: pack sketch bits
+                // We need to write individual bits atomically or gather per-byte
+                int byte_idx = sr / 8;
+                int bit_idx = sr % 8;
+                uint8_t bit_val = (dot >= 0.0f) ? (1u << bit_idx) : 0;
+
+                // Atomic OR to pack bits from different lanes into the same byte
+                atomicOr(reinterpret_cast<unsigned int*>(
+                    &sketch_dst[sketch_byte_offset + (byte_idx & ~3)]),
+                    static_cast<unsigned int>(bit_val) << (8 * (byte_idx & 3)));
+            }
+        }
+    } else {
+        // ── V path: Standard INT4 per-head quantization ──
+        const half* src = v_in + static_cast<int64_t>(token_idx) * row_elems;
+        const int row_bytes = n_kv_heads * head_dim / 2;
+        uint8_t* dst = v_cache_base + static_cast<int64_t>(block_id) * block_stride
+                       + static_cast<int64_t>(slot_in_block) * row_bytes;
+        half* scale_dst = v_scale_base + static_cast<int64_t>(block_id) * scale_block_stride
+                          + static_cast<int64_t>(slot_in_block) * n_kv_heads;
+
+        const int warp_id = threadIdx.x / 32;
+        const int lane_id = threadIdx.x % 32;
+        const int num_warps = blockDim.x / 32;
+
+        for (int h = warp_id; h < n_kv_heads; h += num_warps) {
+            const int head_offset = h * head_dim;
+
+            // Per-head absmax
+            float amax = 0.0f;
+            for (int d = lane_id; d < head_dim; d += 32) {
+                float val = __half2float(src[head_offset + d]);
+                amax = fmaxf(amax, fabsf(val));
+            }
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, offset));
+
+            float sc = amax / 7.0f;
+            float inv_sc = (amax > 1e-8f) ? (7.0f / amax) : 0.0f;
+
+            // Quantize and pack INT4
+            const int head_byte_offset = h * head_dim / 2;
+            for (int d = lane_id * 2; d < head_dim; d += 64) {
+                float v0 = __half2float(src[head_offset + d]);
+                float v1 = (d + 1 < head_dim) ? __half2float(src[head_offset + d + 1]) : 0.0f;
+
+                int q0 = __float2int_rn(v0 * inv_sc);
+                int q1 = __float2int_rn(v1 * inv_sc);
+                q0 = max(-8, min(7, q0));
+                q1 = max(-8, min(7, q1));
+
+                uint8_t packed = (static_cast<uint8_t>(q0 & 0xF)) |
+                                 (static_cast<uint8_t>(q1 & 0xF) << 4);
+                dst[head_byte_offset + d / 2] = packed;
+            }
+
+            if (lane_id == 0) {
+                scale_dst[h] = __float2half(sc);
+            }
+        }
+    }
+}
+
 // Fused KV cache write with RoPE on K: applies RoPE to K during write, copies V directly.
 // blockIdx.x = token index, blockIdx.y = 0 (K+RoPE) or 1 (V copy).
 // Eliminates the separate RoPE kernel launch for K in the decode path.

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -152,6 +152,28 @@ __global__ void write_kv_cache_int4_kernel(
     int max_blocks_per_seq,
     int n_sequences);
 
+__global__ void write_kv_cache_turboquant_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    const int* __restrict__ positions,
+    const int* __restrict__ block_tables,
+    uint8_t* __restrict__ k_dir_cache_base,    // INT4 packed normalized directions
+    uint8_t* __restrict__ v_cache_base,         // INT4 packed values
+    half* __restrict__ k_norm_base,             // FP16 PolarQuant norms (in scale_pool K region)
+    half* __restrict__ v_scale_base,            // FP16 per-head V scales (in scale_pool V region)
+    uint8_t* __restrict__ k_sketch_base,        // QJL 1-bit sketches
+    const uint8_t* __restrict__ qjl_matrix,     // [sketch_dim, head_dim/8] packed Rademacher signs
+    int block_stride,                           // kKVBlockSize * n_kv_heads * head_dim / 2 (bytes)
+    int scale_block_stride,                     // kKVBlockSize * n_kv_heads (half elems)
+    int sketch_block_stride,                    // kKVBlockSize * n_kv_heads * sketch_dim / 8 (bytes)
+    int n_kv_heads,
+    int head_dim,
+    int sketch_dim,
+    int block_size,
+    int n_tokens,
+    int max_blocks_per_seq,
+    int n_sequences);
+
 __global__ void write_kv_cache_rope_fused_kernel(
     const half* __restrict__ k_in,
     const half* __restrict__ v_in,

--- a/src/graph/executor_workspace.cu
+++ b/src/graph/executor_workspace.cu
@@ -1042,6 +1042,9 @@ void GraphExecutor::free_buffers() {
         if (p) { vram_free(vram_alloc_, p); p = nullptr; }
     };
 
+    // Free TurboQuant QJL projection
+    qjl_destroy(qjl_proj_);
+
     // Free LongRoPE frequency tables
     if (longrope_short_freqs_) { cudaFree(longrope_short_freqs_); longrope_short_freqs_ = nullptr; }
     if (longrope_long_freqs_)  { cudaFree(longrope_long_freqs_);  longrope_long_freqs_  = nullptr; }

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -34,7 +34,7 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
     , block_size_(block_size)
     , dtype_(dtype)
     , alloc_(alloc)
-    , block_bytes_((dtype == DType::INT4)
+    , block_bytes_((dtype == DType::INT4 || dtype == DType::TURBOQUANT)
                    ? (static_cast<size_t>(block_size_) * n_kv_heads * head_dim / 2)
                    : (static_cast<size_t>(block_size_) * n_kv_heads * head_dim *
                       dtype_size(dtype))) {
@@ -58,8 +58,9 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
     // Zero-initialize the pool so fresh blocks start clean
     cudaMemset(pool_, 0, total);
 
-    // Allocate separate scale buffer for INT8/INT4 KV cache (per-head-per-token scales)
-    if (dtype == DType::INT8 || dtype == DType::INT4) {
+    // Allocate separate scale buffer for INT8/INT4/TURBOQUANT KV cache (per-head-per-token scales)
+    // For TURBOQUANT: K scales = PolarQuant FP16 norms, V scales = INT4 per-head scales
+    if (dtype == DType::INT8 || dtype == DType::INT4 || dtype == DType::TURBOQUANT) {
         scale_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * sizeof(half);
         size_t scale_total = static_cast<size_t>(n_layers_) * max_blocks_ * 2 * scale_block_bytes_;
         if (alloc_) {
@@ -74,11 +75,37 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
             char msg[256];
             std::snprintf(msg, sizeof(msg),
                           "KVCache: allocation failed for %s scale pool %.2f MiB",
-                          (dtype == DType::INT4) ? "INT4" : "INT8",
+                          dtype_name(dtype),
                           static_cast<double>(scale_total) / (1024.0 * 1024.0));
             throw std::runtime_error(msg);
         }
         cudaMemset(scale_pool_, 0, scale_total);
+    }
+
+    // Allocate QJL 1-bit sketch buffer for TurboQuant K-cache
+    // Layout: same as K portion of pool_ but with sketch_block_bytes_ per block.
+    // sketch_dim = head_dim (paper recommendation), stored as packed bits.
+    if (dtype == DType::TURBOQUANT) {
+        sketch_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * (head_dim / 8);
+        // Only K needs sketches, so n_layers * max_blocks * sketch_block_bytes (no 2x)
+        size_t sketch_total = static_cast<size_t>(n_layers_) * max_blocks_ * sketch_block_bytes_;
+        if (alloc_) {
+            sketch_pool_ = alloc_->allocate(sketch_total, "kv_cache_sketches");
+        } else {
+            cudaError_t serr = cudaMalloc(&sketch_pool_, sketch_total);
+            if (serr != cudaSuccess) sketch_pool_ = nullptr;
+        }
+        if (!sketch_pool_) {
+            if (scale_pool_) { if (alloc_) alloc_->free(scale_pool_); else cudaFree(scale_pool_); scale_pool_ = nullptr; }
+            if (alloc_) alloc_->free(pool_); else cudaFree(pool_);
+            pool_ = nullptr;
+            char msg[256];
+            std::snprintf(msg, sizeof(msg),
+                          "KVCache: allocation failed for TurboQuant sketch pool %.2f MiB",
+                          static_cast<double>(sketch_total) / (1024.0 * 1024.0));
+            throw std::runtime_error(msg);
+        }
+        cudaMemset(sketch_pool_, 0, sketch_total);
     }
 
     // Initialise per-block ref counts (0 = free) and build free list
@@ -90,6 +117,10 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
 }
 
 KVCache::~KVCache() {
+    if (sketch_pool_) {
+        if (alloc_) alloc_->free(sketch_pool_); else cudaFree(sketch_pool_);
+        sketch_pool_ = nullptr;
+    }
     if (scale_pool_) {
         if (alloc_) alloc_->free(scale_pool_); else cudaFree(scale_pool_);
         scale_pool_ = nullptr;
@@ -238,6 +269,28 @@ void* KVCache::v_scale_ptr(int layer, int block_id) {
 
 size_t KVCache::scale_block_bytes() const {
     return scale_block_bytes_;
+}
+
+// ---------------------------------------------------------------------------
+// TurboQuant QJL sketch pointer computation
+// ---------------------------------------------------------------------------
+
+void* KVCache::k_sketch_ptr(int layer, int block_id) {
+    if (!sketch_pool_) return nullptr;
+#ifdef IMP_DEBUG
+    if (layer < 0 || layer >= n_layers_ || block_id < 0 || block_id >= max_blocks_) {
+        IMP_LOG_ERROR("KV cache k_sketch_ptr bounds violation: layer=%d/%d, block=%d/%d",
+                      layer, n_layers_, block_id, max_blocks_);
+    }
+#endif
+    // Sketch pool layout: [layer, block_id] * sketch_block_bytes_ (K only, no V sketches)
+    size_t offset = (static_cast<size_t>(layer) * max_blocks_ +
+                     static_cast<size_t>(block_id)) * sketch_block_bytes_;
+    return static_cast<char*>(sketch_pool_) + offset;
+}
+
+size_t KVCache::sketch_block_bytes() const {
+    return sketch_block_bytes_;
 }
 
 } // namespace imp

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -30,10 +30,14 @@ public:
     void* k_ptr(int layer, int block_id);
     void* v_ptr(int layer, int block_id);
 
-    // INT8 per-head scale access (nullptr if dtype != INT8)
+    // INT8/INT4/TURBOQUANT per-head scale access (nullptr if not applicable)
     void* k_scale_ptr(int layer, int block_id);
     void* v_scale_ptr(int layer, int block_id);
     size_t scale_block_bytes() const;
+
+    // TurboQuant QJL sketch access (nullptr if dtype != TURBOQUANT)
+    void* k_sketch_ptr(int layer, int block_id);
+    size_t sketch_block_bytes() const;
 
     // Capacity queries
     int num_free_blocks() const;
@@ -61,10 +65,17 @@ private:
     std::vector<int> free_list_;
     void* pool_ = nullptr;          // single contiguous GPU allocation
 
-    // INT8 per-head scales: one half per head per token slot.
+    // INT8/INT4/TURBOQUANT per-head scales: one half per head per token slot.
     // Layout mirrors pool_ but with scale_block_bytes_ per block.
+    // For TURBOQUANT: K scales store PolarQuant norms, V scales store INT4 per-head scales.
     void* scale_pool_ = nullptr;
     size_t scale_block_bytes_ = 0;  // block_size * n_kv_heads * sizeof(half)
+
+    // TurboQuant QJL 1-bit sketch storage.
+    // Layout mirrors K portion of pool_ but with sketch_block_bytes_ per block.
+    // Only allocated when dtype == TURBOQUANT.
+    void* sketch_pool_ = nullptr;
+    size_t sketch_block_bytes_ = 0;  // block_size * n_kv_heads * (head_dim / 8)
 };
 
 } // namespace imp

--- a/src/quant/turboquant.cu
+++ b/src/quant/turboquant.cu
@@ -1,0 +1,107 @@
+#include "quant/turboquant.h"
+#include "core/logging.h"
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// QJL projection matrix generation kernel
+//
+// Generates a Rademacher random matrix (±1 entries) using Philox PRNG.
+// Each thread generates one row of the matrix (sketch_dim rows total).
+// The signs are packed as bits: bit j in byte j/8 = sign of R[row][j].
+// ---------------------------------------------------------------------------
+
+__global__ void qjl_generate_matrix_kernel(
+    uint8_t* __restrict__ matrix,   // [sketch_dim, head_dim/8]
+    int sketch_dim,
+    int head_dim,
+    uint64_t seed)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= sketch_dim) return;
+
+    int bytes_per_row = head_dim / 8;
+    uint8_t* row_ptr = matrix + row * bytes_per_row;
+
+    // Initialize Philox PRNG with unique sequence per row
+    curandStatePhilox4_32_10_t state;
+    curand_init(seed, static_cast<unsigned long long>(row), 0, &state);
+
+    // Generate 8 random signs per byte using Rademacher distribution
+    for (int b = 0; b < bytes_per_row; b++) {
+        uint8_t packed = 0;
+        // Generate 4 random values at a time (Philox generates float4)
+        float4 r1 = curand_uniform4(&state);
+        float4 r2 = curand_uniform4(&state);
+
+        // Pack 8 signs: bit = 1 if uniform > 0.5 (i.e., +1), else 0 (i.e., -1)
+        packed |= (r1.x > 0.5f) ? (1u << 0) : 0;
+        packed |= (r1.y > 0.5f) ? (1u << 1) : 0;
+        packed |= (r1.z > 0.5f) ? (1u << 2) : 0;
+        packed |= (r1.w > 0.5f) ? (1u << 3) : 0;
+        packed |= (r2.x > 0.5f) ? (1u << 4) : 0;
+        packed |= (r2.y > 0.5f) ? (1u << 5) : 0;
+        packed |= (r2.z > 0.5f) ? (1u << 6) : 0;
+        packed |= (r2.w > 0.5f) ? (1u << 7) : 0;
+
+        row_ptr[b] = packed;
+    }
+}
+
+bool qjl_init(QJLProjection& proj, int head_dim, int sketch_dim, uint64_t seed,
+              cudaStream_t stream) {
+    if (head_dim <= 0 || sketch_dim <= 0) {
+        IMP_LOG_ERROR("QJL: invalid dimensions head_dim=%d sketch_dim=%d", head_dim, sketch_dim);
+        return false;
+    }
+    if (head_dim % 8 != 0) {
+        IMP_LOG_ERROR("QJL: head_dim=%d must be divisible by 8", head_dim);
+        return false;
+    }
+
+    int bytes_per_row = head_dim / 8;
+    size_t total_bytes = static_cast<size_t>(sketch_dim) * bytes_per_row;
+
+    cudaError_t err = cudaMalloc(&proj.matrix, total_bytes);
+    if (err != cudaSuccess) {
+        IMP_LOG_ERROR("QJL: cudaMalloc failed for %.2f KiB projection matrix",
+                      static_cast<double>(total_bytes) / 1024.0);
+        return false;
+    }
+
+    proj.sketch_dim = sketch_dim;
+    proj.head_dim = head_dim;
+    proj.seed = seed;
+
+    // Launch generation: one thread per row
+    int threads = 256;
+    int blocks = (sketch_dim + threads - 1) / threads;
+    qjl_generate_matrix_kernel<<<blocks, threads, 0, stream>>>(
+        static_cast<uint8_t*>(proj.matrix), sketch_dim, head_dim, seed);
+
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        IMP_LOG_ERROR("QJL: matrix generation kernel failed: %s", cudaGetErrorString(err));
+        cudaFree(proj.matrix);
+        proj.matrix = nullptr;
+        return false;
+    }
+
+    IMP_LOG_INFO("QJL: initialized %dx%d Rademacher projection matrix (%.1f KiB, seed=%llu)",
+                 sketch_dim, head_dim, static_cast<double>(total_bytes) / 1024.0,
+                 static_cast<unsigned long long>(seed));
+    return true;
+}
+
+void qjl_destroy(QJLProjection& proj) {
+    if (proj.matrix) {
+        cudaFree(proj.matrix);
+        proj.matrix = nullptr;
+    }
+    proj.sketch_dim = 0;
+    proj.head_dim = 0;
+}
+
+} // namespace imp

--- a/src/quant/turboquant.h
+++ b/src/quant/turboquant.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// QJL (Quantized Johnson-Lindenstrauss) random projection matrix.
+// Used by TurboQuant for 1-bit error-correction sketches of KV cache keys.
+//
+// The matrix stores Rademacher random signs (±1) as packed bits:
+//   matrix[i * (head_dim/8) + j/8] bit (j%8) = sign of R[i][j]
+//   1 = +1, 0 = -1
+//
+// Shape: [sketch_dim, head_dim], packed as [sketch_dim, head_dim/8] bytes.
+// sketch_dim = head_dim (paper default) for quality-neutral 4-bit quantization.
+struct QJLProjection {
+    void* matrix = nullptr;     // [sketch_dim, head_dim/8] packed bits on GPU
+    int sketch_dim = 0;
+    int head_dim = 0;
+    uint64_t seed = 0;
+};
+
+// Initialize QJL projection matrix with seeded Philox PRNG.
+// sketch_dim should equal head_dim for best accuracy.
+// The matrix is deterministic for a given seed, ensuring reproducibility.
+bool qjl_init(QJLProjection& proj, int head_dim, int sketch_dim, uint64_t seed,
+              cudaStream_t stream = nullptr);
+
+// Free the GPU memory for the projection matrix.
+void qjl_destroy(QJLProjection& proj);
+
+} // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -524,8 +524,7 @@ bool Engine::init_kv_cache() {
                      "(layers=%d/%d, kv_heads=%d, head_dim=%d, block_size=%d)",
                      max_blocks, static_cast<double>(max_blocks) * kv_bs,
                      static_cast<double>(total_kv) / (1024.0 * 1024.0),
-                     kv_dtype == DType::FP8_E4M3 ? "FP8_E4M3" :
-                     kv_dtype == DType::INT8 ? "INT8" : kv_dtype == DType::INT4 ? "INT4" : "FP16",
+                     dtype_name(kv_dtype),
                      n_kv_layers, mcfg.n_layers, mcfg.n_kv_heads, head_dim, kv_bs);
     }
 
@@ -546,6 +545,16 @@ bool Engine::init_kv_cache() {
     }
 
     executor_->set_kv_layer_map(std::move(kv_layer_map));
+
+    // Initialize QJL projection for TurboQuant KV cache
+    if (config_.kv_cache_dtype == DType::TURBOQUANT) {
+        auto& qjl = executor_->qjl_projection();
+        if (!qjl_init(qjl, head_dim, head_dim, /*seed=*/42, stream_)) {
+            IMP_LOG_ERROR("Failed to initialize QJL projection for TurboQuant");
+            return false;
+        }
+    }
+
     if (offload_mgr_) executor_->set_offload_manager(offload_mgr_.get());
     scheduler_->set_kv_manager(kv_manager_.get());
 

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -64,7 +64,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
     // --- 4. Compute KV cache per-block cost ---
     int bs = config.kv_block_size > 0 ? config.kv_block_size : kKVBlockSize;
     size_t single_block_bytes;
-    if (config.kv_cache_dtype == DType::INT4) {
+    if (config.kv_cache_dtype == DType::INT4 || config.kv_cache_dtype == DType::TURBOQUANT) {
         single_block_bytes = static_cast<size_t>(bs) *
                              mcfg.n_kv_heads * head_dim / 2;
     } else {
@@ -72,9 +72,15 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
                              mcfg.n_kv_heads * head_dim * dtype_size(config.kv_cache_dtype);
     }
     size_t per_block_total = single_block_bytes * 2 * n_kv_layers;
-    if (config.kv_cache_dtype == DType::INT8 || config.kv_cache_dtype == DType::INT4) {
+    if (config.kv_cache_dtype == DType::INT8 || config.kv_cache_dtype == DType::INT4
+        || config.kv_cache_dtype == DType::TURBOQUANT) {
         size_t scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * sizeof(half);
         per_block_total += scale_per_block * 2 * n_kv_layers;
+    }
+    if (config.kv_cache_dtype == DType::TURBOQUANT) {
+        // QJL sketch pool: only for K (1x, not 2x)
+        size_t sketch_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * (head_dim / 8);
+        per_block_total += sketch_per_block * n_kv_layers;
     }
 
     int blocks_per_seq = (config.max_seq_len + bs - 1) / bs;

--- a/tests/test_turboquant.cu
+++ b/tests/test_turboquant.cu
@@ -1,0 +1,328 @@
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <random>
+
+#include "memory/kv_cache.h"
+#include "core/tensor.h"
+#include "quant/turboquant.h"
+
+namespace imp {
+namespace {
+
+static bool HasCudaDevice() {
+    int count = 0;
+    cudaError_t err = cudaGetDeviceCount(&count);
+    return err == cudaSuccess && count > 0;
+}
+
+#define SKIP_IF_NO_CUDA()                                                     \
+    do {                                                                       \
+        if (!HasCudaDevice()) {                                                \
+            GTEST_SKIP() << "No CUDA device available";                        \
+        }                                                                      \
+    } while (0)
+
+// ============================================================================
+// Test 1: TurboQuant KV Cache construction — verify block sizes and pools
+// ============================================================================
+TEST(TurboQuantTest, CacheConstruction) {
+    SKIP_IF_NO_CUDA();
+
+    const int n_layers = 4;
+    const int n_kv_heads = 8;
+    const int head_dim = 128;
+    const int max_blocks = 16;
+    const int block_size = 16;
+
+    // TurboQuant cache
+    KVCache tq_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+
+    // Block bytes should match INT4 (packed: block_size * n_kv_heads * head_dim / 2)
+    size_t expected_block_bytes = static_cast<size_t>(block_size) * n_kv_heads * head_dim / 2;
+    EXPECT_EQ(tq_cache.block_bytes(), expected_block_bytes);
+
+    // Scale pool should be allocated (for K norms + V scales)
+    EXPECT_NE(tq_cache.k_scale_ptr(0, 0), nullptr);
+    EXPECT_NE(tq_cache.v_scale_ptr(0, 0), nullptr);
+
+    // Sketch pool should be allocated
+    EXPECT_NE(tq_cache.k_sketch_ptr(0, 0), nullptr);
+
+    // Sketch block bytes: block_size * n_kv_heads * (head_dim / 8)
+    size_t expected_sketch_bytes = static_cast<size_t>(block_size) * n_kv_heads * (head_dim / 8);
+    EXPECT_EQ(tq_cache.sketch_block_bytes(), expected_sketch_bytes);
+
+    // Verify FP16 comparison: TurboQuant should use less memory per block
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks, block_size);
+    EXPECT_LT(tq_cache.block_bytes(), fp16_cache.block_bytes());
+    // INT4 packed = half the FP16 bytes
+    EXPECT_EQ(tq_cache.block_bytes() * 4, fp16_cache.block_bytes());
+
+    // Verify block allocation works
+    int b1 = tq_cache.allocate_block();
+    EXPECT_GE(b1, 0);
+    EXPECT_EQ(tq_cache.ref_count(b1), 1);
+    tq_cache.free_block(b1);
+}
+
+// ============================================================================
+// Test 2: QJL projection matrix initialization
+// ============================================================================
+TEST(TurboQuantTest, QJLInit) {
+    SKIP_IF_NO_CUDA();
+
+    QJLProjection proj;
+    bool ok = qjl_init(proj, /*head_dim=*/128, /*sketch_dim=*/128, /*seed=*/42);
+    ASSERT_TRUE(ok);
+
+    EXPECT_EQ(proj.head_dim, 128);
+    EXPECT_EQ(proj.sketch_dim, 128);
+    EXPECT_EQ(proj.seed, 42u);
+    EXPECT_NE(proj.matrix, nullptr);
+
+    // Read back matrix and verify it contains valid bit patterns
+    int bytes_per_row = 128 / 8;
+    size_t total_bytes = 128 * bytes_per_row;
+    std::vector<uint8_t> host_matrix(total_bytes);
+    cudaMemcpy(host_matrix.data(), proj.matrix, total_bytes, cudaMemcpyDeviceToHost);
+    cudaDeviceSynchronize();
+
+    // Verify matrix is not all-zero or all-one (statistical check)
+    int ones = 0;
+    for (auto b : host_matrix) {
+        ones += __builtin_popcount(b);
+    }
+    int total_bits = static_cast<int>(total_bytes) * 8;
+    // Expect roughly 50% ones (Rademacher distribution)
+    float ratio = static_cast<float>(ones) / total_bits;
+    EXPECT_GT(ratio, 0.3f);
+    EXPECT_LT(ratio, 0.7f);
+
+    // Verify determinism: same seed → same matrix
+    QJLProjection proj2;
+    qjl_init(proj2, 128, 128, 42);
+    std::vector<uint8_t> host_matrix2(total_bytes);
+    cudaMemcpy(host_matrix2.data(), proj2.matrix, total_bytes, cudaMemcpyDeviceToHost);
+    cudaDeviceSynchronize();
+    EXPECT_EQ(host_matrix, host_matrix2);
+
+    qjl_destroy(proj);
+    qjl_destroy(proj2);
+    EXPECT_EQ(proj.matrix, nullptr);
+}
+
+// ============================================================================
+// Test 3: QJL invalid parameters
+// ============================================================================
+TEST(TurboQuantTest, QJLInitInvalid) {
+    SKIP_IF_NO_CUDA();
+
+    QJLProjection proj;
+    // head_dim not divisible by 8
+    EXPECT_FALSE(qjl_init(proj, 127, 128, 42));
+    // Zero dimensions
+    EXPECT_FALSE(qjl_init(proj, 0, 128, 42));
+    EXPECT_FALSE(qjl_init(proj, 128, 0, 42));
+}
+
+// ============================================================================
+// Test 4: KV Cache sketch pointer arithmetic
+// ============================================================================
+TEST(TurboQuantTest, SketchPointers) {
+    SKIP_IF_NO_CUDA();
+
+    const int n_layers = 2;
+    const int n_kv_heads = 4;
+    const int head_dim = 64;
+    const int max_blocks = 8;
+    const int block_size = 16;
+
+    KVCache cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+
+    // Sketch pointers should be different for different layers
+    void* s0_0 = cache.k_sketch_ptr(0, 0);
+    void* s1_0 = cache.k_sketch_ptr(1, 0);
+    EXPECT_NE(s0_0, s1_0);
+
+    // Sketch pointers should be different for different blocks
+    void* s0_1 = cache.k_sketch_ptr(0, 1);
+    EXPECT_NE(s0_0, s0_1);
+
+    // Stride between blocks should equal sketch_block_bytes
+    ptrdiff_t block_stride = static_cast<char*>(s0_1) - static_cast<char*>(s0_0);
+    EXPECT_EQ(static_cast<size_t>(block_stride), cache.sketch_block_bytes());
+
+    // Stride between layers should equal max_blocks * sketch_block_bytes
+    ptrdiff_t layer_stride = static_cast<char*>(s1_0) - static_cast<char*>(s0_0);
+    EXPECT_EQ(static_cast<size_t>(layer_stride), max_blocks * cache.sketch_block_bytes());
+}
+
+// ============================================================================
+// Test 5: PolarQuant roundtrip accuracy check
+// ============================================================================
+TEST(TurboQuantTest, PolarQuantAccuracy) {
+    SKIP_IF_NO_CUDA();
+
+    // Simulate PolarQuant: decompose → quantize → reconstruct
+    const int head_dim = 128;
+    std::mt19937 rng(42);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+
+    // Generate random K vector
+    std::vector<float> k(head_dim);
+    for (auto& v : k) v = dist(rng);
+
+    // Compute norm
+    float norm_sq = 0.0f;
+    for (auto v : k) norm_sq += v * v;
+    float norm = std::sqrt(norm_sq);
+
+    // Normalize
+    std::vector<float> dir(head_dim);
+    for (int i = 0; i < head_dim; i++) dir[i] = k[i] / norm;
+
+    // Quantize direction to INT4 (uniform [-1,1] → [-8,7])
+    std::vector<int8_t> q_dir(head_dim);
+    for (int i = 0; i < head_dim; i++) {
+        int q = static_cast<int>(std::round(dir[i] * 7.0f));
+        q = std::max(-8, std::min(7, q));
+        q_dir[i] = static_cast<int8_t>(q);
+    }
+
+    // Dequantize: reconstruct K' = norm * (q_dir / 7.0)
+    std::vector<float> k_recon(head_dim);
+    for (int i = 0; i < head_dim; i++) {
+        k_recon[i] = norm * (static_cast<float>(q_dir[i]) / 7.0f);
+    }
+
+    // Compute relative error
+    float error_sq = 0.0f;
+    for (int i = 0; i < head_dim; i++) {
+        float diff = k[i] - k_recon[i];
+        error_sq += diff * diff;
+    }
+    float rel_error = std::sqrt(error_sq / norm_sq);
+
+    // PolarQuant with INT4 should have < 15% relative error
+    EXPECT_LT(rel_error, 0.15f);
+
+    // Check dot product preservation with random Q
+    std::vector<float> q(head_dim);
+    for (auto& v : q) v = dist(rng);
+
+    float true_dot = 0.0f;
+    float recon_dot = 0.0f;
+    for (int i = 0; i < head_dim; i++) {
+        true_dot += q[i] * k[i];
+        recon_dot += q[i] * k_recon[i];
+    }
+
+    // Relative dot product error should be reasonable
+    float dot_error = std::abs(true_dot - recon_dot) / std::abs(true_dot);
+    EXPECT_LT(dot_error, 0.2f);
+}
+
+// ============================================================================
+// Test 6: QJL dot product estimation accuracy
+// ============================================================================
+TEST(TurboQuantTest, QJLDotProductEstimate) {
+    SKIP_IF_NO_CUDA();
+
+    // Generate random Q and K, compute QJL estimate, verify correlation
+    const int head_dim = 128;
+    const int sketch_dim = 128;
+    std::mt19937 rng(123);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+
+    // Generate random vectors
+    std::vector<float> q(head_dim), k(head_dim);
+    for (auto& v : q) v = dist(rng);
+    for (auto& v : k) v = dist(rng);
+
+    // True dot product
+    float true_dot = 0.0f;
+    for (int i = 0; i < head_dim; i++) true_dot += q[i] * k[i];
+
+    // Compute norms
+    float q_norm = 0.0f, k_norm = 0.0f;
+    for (int i = 0; i < head_dim; i++) {
+        q_norm += q[i] * q[i];
+        k_norm += k[i] * k[i];
+    }
+    q_norm = std::sqrt(q_norm);
+    k_norm = std::sqrt(k_norm);
+
+    // Generate random Rademacher matrix and compute sketches
+    std::vector<std::vector<int>> R(sketch_dim, std::vector<int>(head_dim));
+    std::bernoulli_distribution bern(0.5);
+    for (int i = 0; i < sketch_dim; i++)
+        for (int j = 0; j < head_dim; j++)
+            R[i][j] = bern(rng) ? 1 : -1;
+
+    // Compute sketches: sign(R @ q), sign(R @ k)
+    std::vector<int> sketch_q(sketch_dim), sketch_k(sketch_dim);
+    for (int i = 0; i < sketch_dim; i++) {
+        float dot_q = 0.0f, dot_k = 0.0f;
+        for (int j = 0; j < head_dim; j++) {
+            dot_q += R[i][j] * q[j];
+            dot_k += R[i][j] * k[j];
+        }
+        sketch_q[i] = (dot_q >= 0) ? 1 : 0;
+        sketch_k[i] = (dot_k >= 0) ? 1 : 0;
+    }
+
+    // XNOR count
+    int match_count = 0;
+    for (int i = 0; i < sketch_dim; i++) {
+        if (sketch_q[i] == sketch_k[i]) match_count++;
+    }
+
+    // QJL estimator
+    float qjl_dot = q_norm * k_norm *
+                     static_cast<float>(2 * match_count - sketch_dim) /
+                     static_cast<float>(sketch_dim);
+
+    // QJL estimate should be in the right ballpark (within 50% for dim=128)
+    // The estimate is unbiased but has variance
+    float abs_error = std::abs(true_dot - qjl_dot);
+    float max_scale = std::max(std::abs(true_dot), q_norm * k_norm * 0.1f);
+    EXPECT_LT(abs_error / max_scale, 2.0f);  // generous bound for single estimate
+}
+
+// ============================================================================
+// Test 7: Memory reduction vs FP16
+// ============================================================================
+TEST(TurboQuantTest, MemoryReduction) {
+    SKIP_IF_NO_CUDA();
+
+    const int n_layers = 32;
+    const int n_kv_heads = 8;
+    const int head_dim = 128;
+    const int max_blocks = 256;
+    const int block_size = 16;
+
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks, block_size);
+    KVCache tq_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+
+    // TurboQuant K+V data pool should be 1/4 of FP16 (INT4 packed for both K dirs and V)
+    double ratio = static_cast<double>(tq_cache.block_bytes()) / fp16_cache.block_bytes();
+    EXPECT_NEAR(ratio, 0.25, 0.01);
+
+    // With scale and sketch overhead, total should still be < 50% of FP16
+    // Scale pool: block_size * n_kv_heads * 2 bytes per block (K norms + V scales)
+    // Sketch pool: block_size * n_kv_heads * (head_dim/8) per K block
+    size_t fp16_total = fp16_cache.block_bytes();
+    size_t tq_total = tq_cache.block_bytes() + tq_cache.scale_block_bytes() + tq_cache.sketch_block_bytes();
+    // Note: scale_block_bytes is for one block (K or V), used for both
+    // and sketch is K only. Exact ratio depends on head_dim
+    double total_ratio = static_cast<double>(tq_total) / fp16_total;
+    EXPECT_LT(total_ratio, 0.55);  // should be well under 50% with all overhead
+}
+
+} // anonymous namespace
+} // namespace imp

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -34,6 +34,7 @@ void print_usage(const char* prog) {
         "  --kv-fp8              Use FP8 E4M3 KV cache (halves KV memory)\n"
         "  --kv-int8             Use INT8 KV cache with dp4a attention (halves KV memory)\n"
         "  --kv-int4             Use INT4 KV cache (quarters KV memory)\n"
+        "  --kv-turboquant       Use TurboQuant KV cache (PolarQuant + QJL, ~3x K reduction)\n"
         "  --ssm-fp16            Use FP16 for SSM h_state (saves ~50%% SSM VRAM)\n"
         "  --cuda-graphs         (default, no-op — graphs enabled by default)\n"
         "  --no-cuda-graphs      Disable CUDA Graph capture for decode\n"
@@ -127,6 +128,8 @@ CliArgs parse_args(int argc, char** argv) {
             args.kv_int8 = true;
         } else if (std::strcmp(arg, "--kv-int4") == 0) {
             args.kv_int4 = true;
+        } else if (std::strcmp(arg, "--kv-turboquant") == 0) {
+            args.kv_turboquant = true;
         } else if (std::strcmp(arg, "--ssm-fp16") == 0) {
             args.ssm_fp16 = true;
         } else if (std::strcmp(arg, "--cuda-graphs") == 0) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -36,6 +36,7 @@ struct CliArgs {
     bool kv_fp8 = false;       // Use FP8 E4M3 KV cache (half size)
     bool kv_int8 = false;      // Use INT8 KV cache with dp4a attention
     bool kv_int4 = false;      // Use INT4 KV cache (quarter size)
+    bool kv_turboquant = false; // Use TurboQuant KV cache (PolarQuant INT4 K + QJL + INT4 V)
     bool ssm_fp16 = false;     // Use FP16 for SSM h_state
     bool no_cuda_graphs = false;  // Disable CUDA Graph capture for decode
     std::string chat_template = "auto";  // auto, none, chatml, llama2, llama3, nemotron, gemma

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -73,6 +73,7 @@ int main(int argc, char** argv) {
     if (args.kv_fp8) config.kv_cache_dtype = IMP_DTYPE_FP8_E4M3;
     if (args.kv_int8) config.kv_cache_dtype = IMP_DTYPE_INT8;
     if (args.kv_int4) config.kv_cache_dtype = IMP_DTYPE_INT4;
+    if (args.kv_turboquant) config.kv_cache_dtype = IMP_DTYPE_TURBOQUANT;
     if (args.ssm_fp16) config.ssm_state_dtype = IMP_DTYPE_FP16;
     if (args.no_cuda_graphs) config.enable_cuda_graphs = 0;
     if (args.prefill_chunk_size > 0) config.prefill_chunk_size = args.prefill_chunk_size;

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -77,6 +77,8 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.kv_int8 = true;
         } else if (std::strcmp(arg, "--kv-int4") == 0) {
             args.kv_int4 = true;
+        } else if (std::strcmp(arg, "--kv-turboquant") == 0) {
+            args.kv_turboquant = true;
         } else if (std::strcmp(arg, "--prefill-chunk-size") == 0 && i + 1 < argc) {
             args.prefill_chunk_size = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--decode-nvfp4") == 0) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -15,6 +15,7 @@ struct ServerArgs {
     bool kv_fp8 = false;
     bool kv_int8 = false;
     bool kv_int4 = false;
+    bool kv_turboquant = false;
     int prefill_chunk_size = 0;
     int decode_nvfp4 = -1;     // -1=auto, 0=off, 1=additive, 2=NVFP4-only
     bool mxfp4_prefill = false;  // --mxfp4-prefill: CUTLASS MXFP4 GEMM for prefill

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -165,9 +165,11 @@ ImpConfig build_config(const ServerArgs& args, const std::string& model_path,
     bool kv_fp8 = overrides.value("kv_fp8", args.kv_fp8);
     bool kv_int8 = overrides.value("kv_int8", args.kv_int8);
     bool kv_int4 = overrides.value("kv_int4", args.kv_int4);
+    bool kv_turboquant = overrides.value("kv_turboquant", args.kv_turboquant);
     if (kv_fp8) config.kv_cache_dtype = IMP_DTYPE_FP8_E4M3;
     if (kv_int8) config.kv_cache_dtype = IMP_DTYPE_INT8;
     if (kv_int4) config.kv_cache_dtype = IMP_DTYPE_INT4;
+    if (kv_turboquant) config.kv_cache_dtype = IMP_DTYPE_TURBOQUANT;
 
     int chunk = overrides.value("prefill_chunk_size", args.prefill_chunk_size);
     // Default to 512-token chunks in server mode so prefill doesn't block decode


### PR DESCRIPTION
Implement TurboQuant from arXiv:2504.19874 for data-oblivious KV cache
quantization. K-cache uses PolarQuant (INT4 direction + FP16 norm) with
QJL 1-bit sketch error correction. V-cache uses standard INT4 per-head
quantization. Achieves ~3x K-cache memory reduction vs FP16.

New files:
- src/quant/turboquant.{h,cu}: QJL Rademacher projection matrix generation
- src/compute/attention_paged_turboquant.cu: Decode kernel with Split-K
- tests/test_turboquant.cu: Unit tests for cache, QJL, PolarQuant accuracy

Modified: DType enum (TURBOQUANT=9), KVCache (sketch_pool_), executor
dispatch, VRAM budget, engine init, CLI (--kv-turboquant), server args.

https://claude.ai/code/session_01GYJBCdTuV5ws6cn6JMwq6A