### PR TITLE
feat: add TurboQuant Lite — QJL sketch-only K cache for sub-4-bit KV compression

### DIFF
--- a/include/imp/config.h
+++ b/include/imp/config.h
@@ -49,7 +49,11 @@ typedef struct {
     int gpu_layers;                // Layers to keep on GPU (-1 = all, 0 = all offloaded)
 
     // KV cache precision
-    ImpDType kv_cache_dtype;       // FP16 (default), FP8_E4M3, INT8, INT4, or TURBOQUANT
+    ImpDType kv_cache_dtype;       // FP16 (default), FP8_E4M3, INT8, INT4, TURBOQUANT, or TURBOQUANT_LITE
+
+    // TurboQuant Lite: QJL sketch dimension = sketch_multiplier * head_dim.
+    // Higher = better quality but more memory. 2 = ~3.1 bits/elem avg, 3 = ~3.6 bits/elem avg.
+    int turboquant_sketch_multiplier; // default 2 (sketch_dim = 2 * head_dim)
 
     // SSM state precision
     ImpDType ssm_state_dtype;      // FP32 (default) or FP16 for SSM h_state

--- a/include/imp/types.h
+++ b/include/imp/types.h
@@ -16,7 +16,8 @@ typedef enum {
     IMP_DTYPE_INT4      = 6,
     IMP_DTYPE_INT32     = 7,
     IMP_DTYPE_FP4_E2M1  = 8,
-    IMP_DTYPE_TURBOQUANT = 9,   // TurboQuant: PolarQuant INT4 K + QJL sketch + INT4 V
+    IMP_DTYPE_TURBOQUANT = 9,       // TurboQuant: PolarQuant INT4 K + QJL sketch + INT4 V
+    IMP_DTYPE_TURBOQUANT_LITE = 10, // TurboQuant Lite: QJL sketch-only K (no INT4 dirs) + INT4 V
 } ImpDType;
 
 typedef enum {

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -68,6 +68,7 @@ ImpConfig imp_config_default(void) {
     config.self_spec_exit_layer = -1;   // auto
     config.self_spec_skip_n = -1;       // auto
     config.mmproj_path = NULL;          // no vision model
+    config.turboquant_sketch_multiplier = 2; // sketch_dim = 2 * head_dim
     return config;
 }
 
@@ -121,6 +122,7 @@ static imp::DType map_dtype(ImpDType dt) {
         case IMP_DTYPE_INT32:    return imp::DType::INT32;
         case IMP_DTYPE_FP4_E2M1: return imp::DType::FP4_E2M1;
         case IMP_DTYPE_TURBOQUANT: return imp::DType::TURBOQUANT;
+        case IMP_DTYPE_TURBOQUANT_LITE: return imp::DType::TURBOQUANT_LITE;
         default:                 return imp::DType::FP16;
     }
 }
@@ -264,6 +266,7 @@ ImpError imp_context_create(ImpModel model, const ImpConfig* config,
         ecfg.self_spec_k = config->self_spec_k;
         ecfg.self_spec_exit_layer = config->self_spec_exit_layer;
         ecfg.self_spec_skip_n = config->self_spec_skip_n;
+        ecfg.turboquant_sketch_multiplier = config->turboquant_sketch_multiplier;
         if (config->mmproj_path)
             ecfg.mmproj_path = config->mmproj_path;
 

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -88,6 +88,21 @@ void paged_attention_decode_turboquant(
     float softcap = 0.0f, cudaStream_t stream = nullptr,
     int max_blocks_per_seq = 0);
 
+// TurboQuant Lite Paged attention for decode: QJL sketch-only K + INT4 V.
+// K is represented only by QJL sketches + FP16 norms (no INT4 directions in pool).
+// Q.K estimated purely via QJL: ||q|| * ||k|| * (2*popcount(XNOR(sketch_q, sketch_k)) - sketch_dim) / sketch_dim
+// V accumulation: standard INT4 with per-head FP16 scales.
+void paged_attention_decode_turboquant_lite(
+    const Tensor& Q, const Tensor& V_cache,
+    Tensor& O,
+    const half* K_norms, const half* V_scales,
+    const uint8_t* K_sketches, const uint8_t* qjl_matrix,
+    const int* block_tables, const int* context_lens,
+    int block_size, float scale, int sketch_dim,
+    int max_context_len, int sliding_window = 0,
+    float softcap = 0.0f, cudaStream_t stream = nullptr,
+    int max_blocks_per_seq = 0);
+
 // Split-K scratch buffer accessor (for use by FP8/INT8 launcher TUs).
 // Returns pointer + size. Either can be nullptr/0 if unset.
 void paged_attention_get_splitk_scratch(void** out_ptr, size_t* out_size);

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -69,14 +69,9 @@ void paged_attention_decode_int4(
     float softcap = 0.0f, cudaStream_t stream = nullptr,
     int max_blocks_per_seq = 0);
 
-// TurboQuant Paged attention for decode: PolarQuant INT4 K + QJL sketch + INT4 V.
-// Q: [batch, 1, n_heads, head_dim] FP16
-// K_dir_cache: [num_blocks, block_size, n_kv_heads, head_dim/2] packed INT4 unit directions
-// V_cache: [num_blocks, block_size, n_kv_heads, head_dim/2] packed INT4 values
-// K_norms: [num_blocks, block_size, n_kv_heads] FP16 PolarQuant norms
-// V_scales: [num_blocks, block_size, n_kv_heads] FP16 per-head V scales
-// K_sketches: [num_blocks, block_size, n_kv_heads, sketch_dim/8] packed 1-bit QJL sketches
-// qjl_matrix: [sketch_dim, head_dim/8] packed Rademacher signs
+// TurboQuant Paged attention for decode: PolarQuant K + QJL sketch + INT4 V.
+// K_dir_cache: packed directions — INT4 uniform (K_mscales=nullptr) or FP4 E2M1 (K_mscales!=nullptr)
+// K_mscales: nullptr → uniform INT4 dequant (/7.0), non-null → MXFP4 FP4 E2M1 + UE8M0 micro-scales
 void paged_attention_decode_turboquant(
     const Tensor& Q, const Tensor& K_dir_cache, const Tensor& V_cache,
     Tensor& O,
@@ -86,7 +81,8 @@ void paged_attention_decode_turboquant(
     int block_size, float scale, int sketch_dim,
     int max_context_len, int sliding_window = 0,
     float softcap = 0.0f, cudaStream_t stream = nullptr,
-    int max_blocks_per_seq = 0);
+    int max_blocks_per_seq = 0,
+    const uint8_t* K_mscales = nullptr);
 
 // TurboQuant Lite Paged attention for decode: QJL sketch-only K + INT4 V.
 // K is represented only by QJL sketches + FP16 norms (no INT4 directions in pool).

--- a/src/compute/attention_paged_turboquant.cu
+++ b/src/compute/attention_paged_turboquant.cu
@@ -638,4 +638,546 @@ void paged_attention_decode_turboquant(
     }
 }
 
+// ===========================================================================
+// TurboQuant Lite: QJL sketch-only K + INT4 V
+//
+// Q.K is estimated purely via QJL (no PolarQuant component):
+//   qk = ||q|| * ||k|| * (2*popcount(XNOR(sketch_q, sketch_k)) - sketch_dim) / sketch_dim
+//
+// V accumulation: same INT4 dequant as standard TurboQuant/INT4 path.
+// ===========================================================================
+
+template<int HEAD_DIM>
+__global__ void paged_attention_decode_turboquant_lite_kernel(
+    const half* __restrict__ Q,                // [batch, n_heads, HEAD_DIM]
+    const uint8_t* __restrict__ V_cache,       // INT4 packed values
+    const half* __restrict__ K_norms,          // [total_blocks, block_size, n_kv_heads] FP16 norms
+    const half* __restrict__ V_scales,         // [total_blocks, block_size, n_kv_heads] FP16 scales
+    const uint8_t* __restrict__ K_sketches,    // [total_blocks, block_size, n_kv_heads, sketch_dim/8]
+    const uint8_t* __restrict__ qjl_matrix,    // [sketch_dim, head_dim/8] packed Rademacher signs
+    half* __restrict__ O,
+    const int* __restrict__ block_tables,
+    const int* __restrict__ context_lens,
+    int batch_size,
+    int n_heads,
+    int n_kv_heads,
+    int block_size,
+    float scale,
+    int sketch_dim,
+    int max_context_len,
+    int max_num_blocks,
+    int sliding_window,
+    float softcap)
+{
+    static_assert(HEAD_DIM % WARP_SIZE == 0);
+    constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
+
+    const int batch_idx = blockIdx.x;
+    const int head_idx  = blockIdx.y;
+    const int kv_head   = head_idx / (n_heads / n_kv_heads);
+
+    const int ctx_len = context_lens[batch_idx];
+    if (ctx_len <= 0) return;
+
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    const int lane_offset = lane_id * ELEMS;
+
+    // Load Q into registers
+    const half* Q_ptr = Q + (int64_t)batch_idx * n_heads * HEAD_DIM
+                          + (int64_t)head_idx * HEAD_DIM;
+    float q_reg[ELEMS];
+    {
+        const half2* Q_ptr2 = reinterpret_cast<const half2*>(Q_ptr + lane_offset);
+        #pragma unroll
+        for (int i = 0; i < ELEMS / 2; i++) {
+            half2 h2 = Q_ptr2[i];
+            q_reg[2*i]   = __half2float(h2.x);
+            q_reg[2*i+1] = __half2float(h2.y);
+        }
+    }
+
+    // Compute Q norm for QJL
+    float q_norm_sq = 0.0f;
+    for (int i = 0; i < ELEMS; i++) q_norm_sq += q_reg[i] * q_reg[i];
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        q_norm_sq += __shfl_xor_sync(0xFFFFFFFF, q_norm_sq, offset);
+    float q_norm = sqrtf(q_norm_sq);
+
+    // Compute Q's QJL sketch in shared memory
+    extern __shared__ char smem_tql[];
+    const int sketch_bytes = sketch_dim / 8;
+    uint8_t* q_sketch = reinterpret_cast<uint8_t*>(smem_tql);
+    float* warp_max_ptr = reinterpret_cast<float*>(q_sketch + ((sketch_bytes + 3) & ~3));
+    float* warp_l_ptr   = warp_max_ptr + NUM_WARPS;
+    float* warp_o_ptr   = warp_l_ptr + NUM_WARPS;
+
+    for (int i = threadIdx.x; i < sketch_bytes; i += blockDim.x)
+        q_sketch[i] = 0;
+    __syncthreads();
+
+    // Compute Q sketch
+    {
+        const int bytes_per_qjl_row = HEAD_DIM / 8;
+        for (int sr = threadIdx.x; sr < sketch_dim; sr += blockDim.x) {
+            const uint8_t* R_row = qjl_matrix + sr * bytes_per_qjl_row;
+            float dot = 0.0f;
+            for (int d = 0; d < HEAD_DIM; d++) {
+                int owning_lane = d / ELEMS;
+                int local_idx = d % ELEMS;
+                float q_val = __shfl_sync(0xFFFFFFFF, q_reg[local_idx], owning_lane);
+                uint8_t r_byte = __ldg(&R_row[d / 8]);
+                float r_sign = (r_byte & (1u << (d % 8))) ? 1.0f : -1.0f;
+                dot += r_sign * q_val;
+            }
+            int byte_idx = sr / 8;
+            int bit_idx = sr % 8;
+            if (dot >= 0.0f) {
+                atomicOr(reinterpret_cast<unsigned int*>(&q_sketch[byte_idx & ~3]),
+                         static_cast<unsigned int>(1u << bit_idx) << (8 * (byte_idx & 3)));
+            }
+        }
+    }
+    __syncthreads();
+
+    const int* bt = block_tables + (int64_t)batch_idx * max_num_blocks;
+    const int kv_head_bytes = HEAD_DIM / 2;  // V: INT4 packed bytes per head per token
+    const int kv_block_stride = block_size * n_kv_heads * kv_head_bytes;
+    const int kv_slot_stride  = n_kv_heads * kv_head_bytes;
+    const int scale_block_stride = block_size * n_kv_heads;
+    const int sketch_head_bytes = sketch_dim / 8;
+    const int sketch_slot_stride = n_kv_heads * sketch_head_bytes;
+    const int sketch_kv_block_stride = block_size * sketch_slot_stride;
+
+    int effective_start = 0;
+    if (sliding_window > 0 && ctx_len > sliding_window)
+        effective_start = ctx_len - sliding_window;
+    const int first_block = effective_start / block_size;
+    const int num_ctx_blocks = (ctx_len + block_size - 1) / block_size;
+
+    float m_w = -FLT_MAX;
+    float l_w = 0.0f;
+    float o_reg[ELEMS];
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++) o_reg[i] = 0.0f;
+
+    for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
+        int phys_block = bt[blk];
+        const uint8_t* V_block     = V_cache     + (int64_t)phys_block * kv_block_stride;
+        const half* K_norm_block   = K_norms     + (int64_t)phys_block * scale_block_stride;
+        const half* V_sc_block     = V_scales    + (int64_t)phys_block * scale_block_stride;
+        const uint8_t* K_sk_block  = K_sketches  + (int64_t)phys_block * sketch_kv_block_stride;
+
+        int tok_start = blk * block_size;
+        int tok_end   = tok_start + block_size;
+        if (tok_end > ctx_len) tok_end = ctx_len;
+
+        int first_tok = 0;
+        if (tok_start < effective_start) first_tok = effective_start - tok_start;
+
+        for (int t = first_tok; t < (tok_end - tok_start); t++) {
+            float k_norm = __half2float(K_norm_block[t * n_kv_heads + kv_head]);
+
+            // Pure QJL dot product estimation
+            float dot_qjl = 0.0f;
+            if (lane_id == 0) {
+                const uint8_t* k_sketch = K_sk_block + t * sketch_slot_stride + kv_head * sketch_head_bytes;
+                int match_count = 0;
+                for (int sb = 0; sb < sketch_bytes / 4; sb++) {
+                    uint32_t q_word = reinterpret_cast<const uint32_t*>(q_sketch)[sb];
+                    uint32_t k_word;
+                    memcpy(&k_word, k_sketch + sb * 4, sizeof(uint32_t));
+                    uint32_t xnor = ~(q_word ^ k_word);
+                    match_count += __popc(xnor);
+                }
+                for (int sb = (sketch_bytes / 4) * 4; sb < sketch_bytes; sb++) {
+                    uint8_t xnor = ~(q_sketch[sb] ^ k_sketch[sb]);
+                    match_count += __popc(static_cast<unsigned int>(xnor) & 0xFF);
+                }
+                dot_qjl = q_norm * k_norm * static_cast<float>(2 * match_count - sketch_dim)
+                          / static_cast<float>(sketch_dim);
+            }
+            dot_qjl = __shfl_sync(0xFFFFFFFF, dot_qjl, 0);
+
+            float dot = dot_qjl * scale;
+            dot = apply_softcap(dot, softcap);
+
+            float rescale, w_new;
+            online_softmax_step(dot, m_w, l_w, rescale, w_new);
+
+            // V accumulation: standard INT4 path
+            const uint8_t* V_tok = V_block + t * kv_slot_stride + kv_head * kv_head_bytes;
+            float v_scale_f = __half2float(V_sc_block[t * n_kv_heads + kv_head]);
+            {
+                const uint8_t* v_bytes = V_tok + lane_offset / 2;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = v_bytes[i];
+                    float v0 = static_cast<float>(tq_unpack_int4_lo(packed)) * v_scale_f;
+                    float v1 = static_cast<float>(tq_unpack_int4_hi(packed)) * v_scale_f;
+                    o_reg[2*i]   = rescale * o_reg[2*i]   + w_new * v0;
+                    o_reg[2*i+1] = rescale * o_reg[2*i+1] + w_new * v1;
+                }
+            }
+        }
+    }
+
+    // Cross-warp reduction
+    if (lane_id == 0) {
+        warp_max_ptr[warp_id] = m_w;
+        warp_l_ptr[warp_id]   = l_w;
+    }
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++)
+        warp_o_ptr[warp_id * HEAD_DIM + lane_offset + i] = o_reg[i];
+    __syncthreads();
+
+    if (warp_id == 0) {
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = fmaxf(global_max, warp_max_ptr[w]);
+
+        float global_l = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_l += expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+
+        #pragma unroll
+        for (int i = 0; i < ELEMS; i++) {
+            int d = lane_offset + i;
+            float o_val = 0.0f;
+            for (int w = 0; w < NUM_WARPS; w++) {
+                float weight = expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+                o_val += weight * warp_o_ptr[w * HEAD_DIM + d];
+            }
+            if (global_l > 0.0f) o_val /= global_l;
+
+            int out_idx = batch_idx * n_heads * HEAD_DIM
+                        + head_idx * HEAD_DIM + d;
+            O[out_idx] = __float2half(o_val);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Split-K Phase 1: TurboQuant Lite variant
+// ---------------------------------------------------------------------------
+
+template<int HEAD_DIM>
+__global__ void paged_attention_splitk_turboquant_lite_kernel(
+    const half* __restrict__ Q,
+    const uint8_t* __restrict__ V_cache,
+    const half* __restrict__ K_norms,
+    const half* __restrict__ V_scales,
+    const uint8_t* __restrict__ K_sketches,
+    const uint8_t* __restrict__ qjl_matrix,
+    float* __restrict__ partial_out,
+    const int* __restrict__ block_tables,
+    const int* __restrict__ context_lens,
+    int batch_size,
+    int n_heads,
+    int n_kv_heads,
+    int block_size,
+    float scale,
+    int sketch_dim,
+    int max_num_blocks,
+    int num_splits,
+    int sliding_window,
+    float softcap)
+{
+    static_assert(HEAD_DIM % WARP_SIZE == 0);
+    constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
+
+    const int batch_idx = blockIdx.x;
+    const int head_idx  = blockIdx.y;
+    const int split_idx = blockIdx.z;
+    const int kv_head   = head_idx / (n_heads / n_kv_heads);
+
+    const int ctx_len = context_lens[batch_idx];
+    if (ctx_len <= 0) return;
+
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    const int lane_offset = lane_id * ELEMS;
+
+    // Load Q
+    const half* Q_ptr = Q + (int64_t)batch_idx * n_heads * HEAD_DIM
+                          + (int64_t)head_idx * HEAD_DIM;
+    float q_reg[ELEMS];
+    {
+        const half2* Q_ptr2 = reinterpret_cast<const half2*>(Q_ptr + lane_offset);
+        #pragma unroll
+        for (int i = 0; i < ELEMS / 2; i++) {
+            half2 h2 = Q_ptr2[i];
+            q_reg[2*i]   = __half2float(h2.x);
+            q_reg[2*i+1] = __half2float(h2.y);
+        }
+    }
+
+    // Q norm
+    float q_norm_sq = 0.0f;
+    for (int i = 0; i < ELEMS; i++) q_norm_sq += q_reg[i] * q_reg[i];
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        q_norm_sq += __shfl_xor_sync(0xFFFFFFFF, q_norm_sq, offset);
+    float q_norm = sqrtf(q_norm_sq);
+
+    // Q sketch
+    extern __shared__ char smem_tql_sk[];
+    const int sketch_bytes = sketch_dim / 8;
+    uint8_t* q_sketch = reinterpret_cast<uint8_t*>(smem_tql_sk);
+    float* warp_max_ptr = reinterpret_cast<float*>(q_sketch + ((sketch_bytes + 3) & ~3));
+    float* warp_l_ptr   = warp_max_ptr + NUM_WARPS;
+    float* warp_o_ptr   = warp_l_ptr + NUM_WARPS;
+
+    for (int i = threadIdx.x; i < sketch_bytes; i += blockDim.x)
+        q_sketch[i] = 0;
+    __syncthreads();
+
+    {
+        const int bytes_per_qjl_row = HEAD_DIM / 8;
+        for (int sr = threadIdx.x; sr < sketch_dim; sr += blockDim.x) {
+            const uint8_t* R_row = qjl_matrix + sr * bytes_per_qjl_row;
+            float dot = 0.0f;
+            for (int d = 0; d < HEAD_DIM; d++) {
+                int owning_lane = d / ELEMS;
+                int local_idx = d % ELEMS;
+                float q_val = __shfl_sync(0xFFFFFFFF, q_reg[local_idx], owning_lane);
+                uint8_t r_byte = __ldg(&R_row[d / 8]);
+                float r_sign = (r_byte & (1u << (d % 8))) ? 1.0f : -1.0f;
+                dot += r_sign * q_val;
+            }
+            int byte_idx = sr / 8;
+            int bit_idx = sr % 8;
+            if (dot >= 0.0f) {
+                atomicOr(reinterpret_cast<unsigned int*>(&q_sketch[byte_idx & ~3]),
+                         static_cast<unsigned int>(1u << bit_idx) << (8 * (byte_idx & 3)));
+            }
+        }
+    }
+    __syncthreads();
+
+    const int* bt = block_tables + (int64_t)batch_idx * max_num_blocks;
+    const int kv_head_bytes = HEAD_DIM / 2;
+    const int kv_block_stride = block_size * n_kv_heads * kv_head_bytes;
+    const int kv_slot_stride  = n_kv_heads * kv_head_bytes;
+    const int scale_block_stride = block_size * n_kv_heads;
+    const int sketch_head_bytes = sketch_dim / 8;
+    const int sketch_slot_stride = n_kv_heads * sketch_head_bytes;
+    const int sketch_kv_block_stride = block_size * sketch_slot_stride;
+
+    int effective_start = 0;
+    if (sliding_window > 0 && ctx_len > sliding_window)
+        effective_start = ctx_len - sliding_window;
+    const int first_block = effective_start / block_size;
+    const int num_ctx_blocks = (ctx_len + block_size - 1) / block_size;
+
+    int blocks_per_split = (num_ctx_blocks - first_block + num_splits - 1) / num_splits;
+    int split_start = first_block + split_idx * blocks_per_split;
+    int split_end   = min(split_start + blocks_per_split, num_ctx_blocks);
+
+    if (split_start >= num_ctx_blocks) {
+        write_empty_split_sentinel<HEAD_DIM>(partial_out, batch_idx, n_heads, head_idx,
+                                              num_splits, split_idx, lane_offset);
+        return;
+    }
+
+    float m_w = -FLT_MAX;
+    float l_w = 0.0f;
+    float o_reg[ELEMS];
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++) o_reg[i] = 0.0f;
+
+    for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
+        int phys_block = bt[blk];
+        const uint8_t* V_block     = V_cache     + (int64_t)phys_block * kv_block_stride;
+        const half* K_norm_block   = K_norms     + (int64_t)phys_block * scale_block_stride;
+        const half* V_sc_block     = V_scales    + (int64_t)phys_block * scale_block_stride;
+        const uint8_t* K_sk_block  = K_sketches  + (int64_t)phys_block * sketch_kv_block_stride;
+
+        int tok_start = blk * block_size;
+        int tok_end   = tok_start + block_size;
+        if (tok_end > ctx_len) tok_end = ctx_len;
+
+        int first_tok = 0;
+        if (tok_start < effective_start) first_tok = effective_start - tok_start;
+
+        for (int t = first_tok; t < (tok_end - tok_start); t++) {
+            float k_norm = __half2float(K_norm_block[t * n_kv_heads + kv_head]);
+
+            // Pure QJL dot product
+            float dot_qjl = 0.0f;
+            if (lane_id == 0) {
+                const uint8_t* k_sketch = K_sk_block + t * sketch_slot_stride + kv_head * sketch_head_bytes;
+                int match_count = 0;
+                for (int sb = 0; sb < sketch_bytes / 4; sb++) {
+                    uint32_t q_word = reinterpret_cast<const uint32_t*>(q_sketch)[sb];
+                    uint32_t k_word;
+                    memcpy(&k_word, k_sketch + sb * 4, sizeof(uint32_t));
+                    match_count += __popc(~(q_word ^ k_word));
+                }
+                for (int sb = (sketch_bytes / 4) * 4; sb < sketch_bytes; sb++) {
+                    uint8_t xnor = ~(q_sketch[sb] ^ k_sketch[sb]);
+                    match_count += __popc(static_cast<unsigned int>(xnor) & 0xFF);
+                }
+                dot_qjl = q_norm * k_norm * static_cast<float>(2 * match_count - sketch_dim)
+                          / static_cast<float>(sketch_dim);
+            }
+            dot_qjl = __shfl_sync(0xFFFFFFFF, dot_qjl, 0);
+
+            float dot = dot_qjl * scale;
+            dot = apply_softcap(dot, softcap);
+
+            float rescale, w_new;
+            online_softmax_step(dot, m_w, l_w, rescale, w_new);
+
+            // V accumulation
+            const uint8_t* V_tok = V_block + t * kv_slot_stride + kv_head * kv_head_bytes;
+            float v_scale_f = __half2float(V_sc_block[t * n_kv_heads + kv_head]);
+            {
+                const uint8_t* v_bytes = V_tok + lane_offset / 2;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = v_bytes[i];
+                    float v0 = static_cast<float>(tq_unpack_int4_lo(packed)) * v_scale_f;
+                    float v1 = static_cast<float>(tq_unpack_int4_hi(packed)) * v_scale_f;
+                    o_reg[2*i]   = rescale * o_reg[2*i]   + w_new * v0;
+                    o_reg[2*i+1] = rescale * o_reg[2*i+1] + w_new * v1;
+                }
+            }
+        }
+    }
+
+    // Cross-warp reduction → write partial
+    __syncthreads();
+    if (lane_id == 0) {
+        warp_max_ptr[warp_id] = m_w;
+        warp_l_ptr[warp_id]   = l_w;
+    }
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++)
+        warp_o_ptr[warp_id * HEAD_DIM + lane_offset + i] = o_reg[i];
+    __syncthreads();
+
+    if (warp_id == 0) {
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = fmaxf(global_max, warp_max_ptr[w]);
+        float global_l = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_l += expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+
+        int partial_idx = ((batch_idx * n_heads + head_idx) * num_splits + split_idx);
+        constexpr int partial_stride = 2 + HEAD_DIM;
+        float* out = partial_out + (int64_t)partial_idx * partial_stride;
+
+        if (lane_id == 0) { out[0] = global_max; out[1] = global_l; }
+
+        #pragma unroll
+        for (int i = 0; i < ELEMS; i++) {
+            int d = lane_offset + i;
+            float o_val = 0.0f;
+            for (int w = 0; w < NUM_WARPS; w++) {
+                float weight = expf(warp_max_ptr[w] - global_max) * warp_l_ptr[w];
+                o_val += weight * warp_o_ptr[w * HEAD_DIM + d];
+            }
+            out[2 + d] = o_val;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host launcher -- TurboQuant Lite variant (with Split-K support)
+// ---------------------------------------------------------------------------
+void paged_attention_decode_turboquant_lite(
+    const Tensor& Q, const Tensor& V_cache,
+    Tensor& O,
+    const half* K_norms, const half* V_scales,
+    const uint8_t* K_sketches, const uint8_t* qjl_matrix,
+    const int* block_tables, const int* context_lens,
+    int block_size, float scale, int sketch_dim,
+    int max_context_len, int sliding_window,
+    float softcap, cudaStream_t stream,
+    int max_blocks_per_seq)
+{
+    const int batch_size = static_cast<int>(Q.shape[0]);
+    const int n_heads    = static_cast<int>(Q.shape[2]);
+    const int head_dim   = static_cast<int>(Q.shape[3]);
+    const int n_kv_heads = static_cast<int>(V_cache.shape[2]);
+
+    const int max_num_blocks = (max_blocks_per_seq > 0) ? max_blocks_per_seq
+                               : (max_context_len + block_size - 1) / block_size;
+
+    const int sketch_bytes = sketch_dim / 8;
+    const int sketch_aligned = (sketch_bytes + 3) & ~3;
+    size_t smem_bytes = sketch_aligned
+                      + NUM_WARPS * sizeof(float)
+                      + NUM_WARPS * sizeof(float)
+                      + NUM_WARPS * head_dim * sizeof(float);
+
+    void* scratch_ptr = nullptr;
+    int num_splits = compute_splitk_splits(
+        batch_size, n_heads, head_dim, max_context_len, block_size, &scratch_ptr);
+
+    if (num_splits > 1) {
+        float* partial = static_cast<float*>(scratch_ptr);
+
+        dim3 grid1(batch_size, n_heads, num_splits);
+        dim3 block1(BLOCK_THREADS);
+
+        #define LAUNCH_SPLITK_TQL(HD) \
+            paged_attention_splitk_turboquant_lite_kernel<HD><<<grid1, block1, smem_bytes, stream>>>( \
+                reinterpret_cast<const half*>(Q.data), \
+                reinterpret_cast<const uint8_t*>(V_cache.data), \
+                K_norms, V_scales, \
+                K_sketches, qjl_matrix, \
+                partial, \
+                block_tables, context_lens, \
+                batch_size, n_heads, n_kv_heads, \
+                block_size, scale, sketch_dim, \
+                max_num_blocks, num_splits, \
+                sliding_window, softcap)
+
+        switch (head_dim) {
+            case 64:  LAUNCH_SPLITK_TQL(64);  break;
+            case 96:  LAUNCH_SPLITK_TQL(96);  break;
+            case 128: LAUNCH_SPLITK_TQL(128); break;
+            case 256: LAUNCH_SPLITK_TQL(256); break;
+            default:
+                IMP_LOG_ERROR("paged_attention_splitk_turboquant_lite: unsupported head_dim %d", head_dim);
+                return;
+        }
+        #undef LAUNCH_SPLITK_TQL
+
+        paged_attention_launch_reduce(partial, reinterpret_cast<half*>(O.data),
+                                      batch_size, n_heads, head_dim, num_splits, stream);
+    } else {
+        dim3 grid(batch_size, n_heads);
+        dim3 block(BLOCK_THREADS);
+
+        #define LAUNCH_TQL(HD) \
+            paged_attention_decode_turboquant_lite_kernel<HD><<<grid, block, smem_bytes, stream>>>( \
+                reinterpret_cast<const half*>(Q.data), \
+                reinterpret_cast<const uint8_t*>(V_cache.data), \
+                K_norms, V_scales, \
+                K_sketches, qjl_matrix, \
+                reinterpret_cast<half*>(O.data), \
+                block_tables, context_lens, \
+                batch_size, n_heads, n_kv_heads, \
+                block_size, scale, sketch_dim, max_context_len, max_num_blocks, \
+                sliding_window, softcap)
+
+        switch (head_dim) {
+            case 64:  LAUNCH_TQL(64);  break;
+            case 96:  LAUNCH_TQL(96);  break;
+            case 128: LAUNCH_TQL(128); break;
+            case 256: LAUNCH_TQL(256); break;
+            default:
+                IMP_LOG_ERROR("paged_attention_decode_turboquant_lite: unsupported head_dim %d", head_dim);
+                return;
+        }
+        #undef LAUNCH_TQL
+    }
+}
+
 } // namespace imp

--- a/src/compute/attention_paged_turboquant.cu
+++ b/src/compute/attention_paged_turboquant.cu
@@ -1,6 +1,7 @@
 #include "compute/attention_paged.h"
 #include "compute/attention_paged_common.cuh"
 #include "compute/attention.h"
+#include "quant/turboquant_fp4.cuh"
 #include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -38,15 +39,16 @@ __device__ __forceinline__ int tq_unpack_int4_hi(uint8_t packed) {
 // QJL correction weight (from TurboQuant paper)
 static constexpr float kQJLLambda = 0.1f;
 
-template<int HEAD_DIM>
+template<int HEAD_DIM, bool USE_MXFP4 = false>
 __global__ void paged_attention_decode_turboquant_kernel(
     const half* __restrict__ Q,                // [batch, n_heads, HEAD_DIM]
-    const uint8_t* __restrict__ K_dir_cache,   // INT4 packed normalized directions
+    const uint8_t* __restrict__ K_dir_cache,   // INT4 or FP4 E2M1 packed normalized directions
     const uint8_t* __restrict__ V_cache,       // INT4 packed values
     const half* __restrict__ K_norms,          // [total_blocks, block_size, n_kv_heads] FP16 norms
     const half* __restrict__ V_scales,         // [total_blocks, block_size, n_kv_heads] FP16 scales
     const uint8_t* __restrict__ K_sketches,    // [total_blocks, block_size, n_kv_heads, sketch_dim/8] packed bits
     const uint8_t* __restrict__ qjl_matrix,    // [sketch_dim, head_dim/8] packed Rademacher signs
+    const uint8_t* __restrict__ K_mscales,     // MXFP4: UE8M0 micro-scales [blocks, block_size, n_kv_heads, hd/32] (nullptr if !USE_MXFP4)
     half* __restrict__ O,
     const int* __restrict__ block_tables,
     const int* __restrict__ context_lens,
@@ -147,13 +149,18 @@ __global__ void paged_attention_decode_turboquant_kernel(
     __syncthreads();
 
     const int* bt = block_tables + (int64_t)batch_idx * max_num_blocks;
-    const int kv_head_bytes = HEAD_DIM / 2;  // bytes per head per token (INT4 packed)
+    const int kv_head_bytes = HEAD_DIM / 2;  // bytes per head per token (INT4/FP4 packed)
     const int kv_block_stride = block_size * n_kv_heads * kv_head_bytes;
     const int kv_slot_stride  = n_kv_heads * kv_head_bytes;
     const int scale_block_stride = block_size * n_kv_heads;
     const int sketch_head_bytes = sketch_dim / 8;
     const int sketch_slot_stride = n_kv_heads * sketch_head_bytes;
     const int sketch_kv_block_stride = block_size * sketch_slot_stride;
+
+    // MXFP4 micro-scale strides (only used when USE_MXFP4 == true)
+    constexpr int N_GROUPS = HEAD_DIM / 32;
+    const int mscale_slot_stride = USE_MXFP4 ? (n_kv_heads * N_GROUPS) : 0;
+    const int mscale_block_stride_v = USE_MXFP4 ? (block_size * mscale_slot_stride) : 0;
 
     int effective_start = 0;
     if (sliding_window > 0 && ctx_len > sliding_window)
@@ -174,6 +181,10 @@ __global__ void paged_attention_decode_turboquant_kernel(
         const half* K_norm_block   = K_norms     + (int64_t)phys_block * scale_block_stride;
         const half* V_sc_block     = V_scales    + (int64_t)phys_block * scale_block_stride;
         const uint8_t* K_sk_block  = K_sketches  + (int64_t)phys_block * sketch_kv_block_stride;
+        // MXFP4 micro-scale block pointer (only valid when USE_MXFP4)
+        const uint8_t* K_ms_block  = USE_MXFP4
+            ? (K_mscales + (int64_t)phys_block * mscale_block_stride_v)
+            : nullptr;
 
         int tok_start = blk * block_size;
         int tok_end   = tok_start + block_size;
@@ -188,12 +199,27 @@ __global__ void paged_attention_decode_turboquant_kernel(
 
             // PolarQuant Q.K: q . (norm * dir_quantized) = norm * q . dir_quantized
             float dot_polar = 0.0f;
-            {
+            if constexpr (USE_MXFP4) {
+                // MXFP4 path: FP4 E2M1 nibbles + per-32-element UE8M0 micro-scales
+                const uint8_t* k_bytes = K_dir_tok + lane_offset / 2;
+                const uint8_t* k_ms = K_ms_block + t * mscale_slot_stride + kv_head * N_GROUPS;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = k_bytes[i];
+                    int elem_idx = lane_offset + 2 * i;
+                    int group_idx = elem_idx / 32;
+                    float ms = tq_fp4_ue8m0_to_float(k_ms[group_idx]);
+                    float d0 = tq_fp4_unpack_lo(packed) * ms;
+                    float d1 = tq_fp4_unpack_hi(packed) * ms;
+                    dot_polar += q_reg[2*i]   * d0;
+                    dot_polar += q_reg[2*i+1] * d1;
+                }
+            } else {
+                // INT4 uniform path: signed INT4 / 7.0
                 const uint8_t* k_bytes = K_dir_tok + lane_offset / 2;
                 #pragma unroll
                 for (int i = 0; i < ELEMS / 2; i++) {
                     uint8_t packed = k_bytes[i];
-                    // Dequant: INT4 → float, then divide by 7 to get unit vector component
                     float d0 = static_cast<float>(tq_unpack_int4_lo(packed)) / 7.0f;
                     float d1 = static_cast<float>(tq_unpack_int4_hi(packed)) / 7.0f;
                     dot_polar += q_reg[2*i]   * d0;
@@ -294,7 +320,7 @@ __global__ void paged_attention_decode_turboquant_kernel(
 // Split-K Phase 1: TurboQuant variant
 // ---------------------------------------------------------------------------
 
-template<int HEAD_DIM>
+template<int HEAD_DIM, bool USE_MXFP4 = false>
 __global__ void paged_attention_splitk_turboquant_kernel(
     const half* __restrict__ Q,
     const uint8_t* __restrict__ K_dir_cache,
@@ -303,6 +329,7 @@ __global__ void paged_attention_splitk_turboquant_kernel(
     const half* __restrict__ V_scales,
     const uint8_t* __restrict__ K_sketches,
     const uint8_t* __restrict__ qjl_matrix,
+    const uint8_t* __restrict__ K_mscales,     // MXFP4 UE8M0 micro-scales (nullptr if !USE_MXFP4)
     float* __restrict__ partial_out,
     const int* __restrict__ block_tables,
     const int* __restrict__ context_lens,
@@ -399,6 +426,10 @@ __global__ void paged_attention_splitk_turboquant_kernel(
     const int sketch_slot_stride = n_kv_heads * sketch_head_bytes;
     const int sketch_kv_block_stride = block_size * sketch_slot_stride;
 
+    constexpr int N_GROUPS_SK = HEAD_DIM / 32;
+    const int mscale_slot_stride_sk = USE_MXFP4 ? (n_kv_heads * N_GROUPS_SK) : 0;
+    const int mscale_block_stride_sk = USE_MXFP4 ? (block_size * mscale_slot_stride_sk) : 0;
+
     int effective_start = 0;
     if (sliding_window > 0 && ctx_len > sliding_window)
         effective_start = ctx_len - sliding_window;
@@ -429,6 +460,9 @@ __global__ void paged_attention_splitk_turboquant_kernel(
         const half* K_norm_block   = K_norms     + (int64_t)phys_block * scale_block_stride;
         const half* V_sc_block     = V_scales    + (int64_t)phys_block * scale_block_stride;
         const uint8_t* K_sk_block  = K_sketches  + (int64_t)phys_block * sketch_kv_block_stride;
+        const uint8_t* K_ms_block_sk = USE_MXFP4
+            ? (K_mscales + (int64_t)phys_block * mscale_block_stride_sk)
+            : nullptr;
 
         int tok_start = blk * block_size;
         int tok_end   = tok_start + block_size;
@@ -443,7 +477,21 @@ __global__ void paged_attention_splitk_turboquant_kernel(
 
             // PolarQuant dot product
             float dot_polar = 0.0f;
-            {
+            if constexpr (USE_MXFP4) {
+                const uint8_t* k_bytes = K_dir_tok + lane_offset / 2;
+                const uint8_t* k_ms = K_ms_block_sk + t * mscale_slot_stride_sk + kv_head * N_GROUPS_SK;
+                #pragma unroll
+                for (int i = 0; i < ELEMS / 2; i++) {
+                    uint8_t packed = k_bytes[i];
+                    int elem_idx = lane_offset + 2 * i;
+                    int group_idx = elem_idx / 32;
+                    float ms = tq_fp4_ue8m0_to_float(k_ms[group_idx]);
+                    float d0 = tq_fp4_unpack_lo(packed) * ms;
+                    float d1 = tq_fp4_unpack_hi(packed) * ms;
+                    dot_polar += q_reg[2*i]   * d0;
+                    dot_polar += q_reg[2*i+1] * d1;
+                }
+            } else {
                 const uint8_t* k_bytes = K_dir_tok + lane_offset / 2;
                 #pragma unroll
                 for (int i = 0; i < ELEMS / 2; i++) {
@@ -551,7 +599,8 @@ void paged_attention_decode_turboquant(
     int block_size, float scale, int sketch_dim,
     int max_context_len, int sliding_window,
     float softcap, cudaStream_t stream,
-    int max_blocks_per_seq)
+    int max_blocks_per_seq,
+    const uint8_t* K_mscales)
 {
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int n_heads    = static_cast<int>(Q.shape[2]);
@@ -561,32 +610,32 @@ void paged_attention_decode_turboquant(
     const int max_num_blocks = (max_blocks_per_seq > 0) ? max_blocks_per_seq
                                : (max_context_len + block_size - 1) / block_size;
 
-    // Shared memory: Q sketch bytes (aligned) + warp reduction arrays
     const int sketch_bytes = sketch_dim / 8;
     const int sketch_aligned = (sketch_bytes + 3) & ~3;
     size_t smem_bytes = sketch_aligned
-                      + NUM_WARPS * sizeof(float)     // warp_max
-                      + NUM_WARPS * sizeof(float)     // warp_l
-                      + NUM_WARPS * head_dim * sizeof(float);  // warp_o
+                      + NUM_WARPS * sizeof(float)
+                      + NUM_WARPS * sizeof(float)
+                      + NUM_WARPS * head_dim * sizeof(float);
 
-    // Split-K decision
     void* scratch_ptr = nullptr;
     int num_splits = compute_splitk_splits(
         batch_size, n_heads, head_dim, max_context_len, block_size, &scratch_ptr);
 
+    const bool use_mxfp4 = (K_mscales != nullptr);
+
     if (num_splits > 1) {
         float* partial = static_cast<float*>(scratch_ptr);
-
         dim3 grid1(batch_size, n_heads, num_splits);
         dim3 block1(BLOCK_THREADS);
 
-        #define LAUNCH_SPLITK_TQ(HD) \
-            paged_attention_splitk_turboquant_kernel<HD><<<grid1, block1, smem_bytes, stream>>>( \
+        // Macro for dispatching split-K kernel with optional MXFP4 template
+        #define LAUNCH_SPLITK_TQ(HD, MX) \
+            paged_attention_splitk_turboquant_kernel<HD, MX><<<grid1, block1, smem_bytes, stream>>>( \
                 reinterpret_cast<const half*>(Q.data), \
                 reinterpret_cast<const uint8_t*>(K_dir_cache.data), \
                 reinterpret_cast<const uint8_t*>(V_cache.data), \
                 K_norms, V_scales, \
-                K_sketches, qjl_matrix, \
+                K_sketches, qjl_matrix, K_mscales, \
                 partial, \
                 block_tables, context_lens, \
                 batch_size, n_heads, n_kv_heads, \
@@ -594,46 +643,55 @@ void paged_attention_decode_turboquant(
                 max_num_blocks, num_splits, \
                 sliding_window, softcap)
 
+        #define DISPATCH_SPLITK_TQ(HD) \
+            if (use_mxfp4) { LAUNCH_SPLITK_TQ(HD, true); } \
+            else            { LAUNCH_SPLITK_TQ(HD, false); }
+
         switch (head_dim) {
-            case 64:  LAUNCH_SPLITK_TQ(64);  break;
-            case 96:  LAUNCH_SPLITK_TQ(96);  break;
-            case 128: LAUNCH_SPLITK_TQ(128); break;
-            case 256: LAUNCH_SPLITK_TQ(256); break;
+            case 64:  DISPATCH_SPLITK_TQ(64);  break;
+            case 96:  DISPATCH_SPLITK_TQ(96);  break;
+            case 128: DISPATCH_SPLITK_TQ(128); break;
+            case 256: DISPATCH_SPLITK_TQ(256); break;
             default:
                 IMP_LOG_ERROR("paged_attention_splitk_turboquant: unsupported head_dim %d", head_dim);
                 return;
         }
+        #undef DISPATCH_SPLITK_TQ
         #undef LAUNCH_SPLITK_TQ
 
-        // Split-K Phase 2: reuse shared reduce launcher
         paged_attention_launch_reduce(partial, reinterpret_cast<half*>(O.data),
                                       batch_size, n_heads, head_dim, num_splits, stream);
     } else {
         dim3 grid(batch_size, n_heads);
         dim3 block(BLOCK_THREADS);
 
-        #define LAUNCH_TQ(HD) \
-            paged_attention_decode_turboquant_kernel<HD><<<grid, block, smem_bytes, stream>>>( \
+        #define LAUNCH_TQ(HD, MX) \
+            paged_attention_decode_turboquant_kernel<HD, MX><<<grid, block, smem_bytes, stream>>>( \
                 reinterpret_cast<const half*>(Q.data), \
                 reinterpret_cast<const uint8_t*>(K_dir_cache.data), \
                 reinterpret_cast<const uint8_t*>(V_cache.data), \
                 K_norms, V_scales, \
-                K_sketches, qjl_matrix, \
+                K_sketches, qjl_matrix, K_mscales, \
                 reinterpret_cast<half*>(O.data), \
                 block_tables, context_lens, \
                 batch_size, n_heads, n_kv_heads, \
                 block_size, scale, sketch_dim, max_context_len, max_num_blocks, \
                 sliding_window, softcap)
 
+        #define DISPATCH_TQ(HD) \
+            if (use_mxfp4) { LAUNCH_TQ(HD, true); } \
+            else            { LAUNCH_TQ(HD, false); }
+
         switch (head_dim) {
-            case 64:  LAUNCH_TQ(64);  break;
-            case 96:  LAUNCH_TQ(96);  break;
-            case 128: LAUNCH_TQ(128); break;
-            case 256: LAUNCH_TQ(256); break;
+            case 64:  DISPATCH_TQ(64);  break;
+            case 96:  DISPATCH_TQ(96);  break;
+            case 128: DISPATCH_TQ(128); break;
+            case 256: DISPATCH_TQ(256); break;
             default:
                 IMP_LOG_ERROR("paged_attention_decode_turboquant: unsupported head_dim %d", head_dim);
                 return;
         }
+        #undef DISPATCH_TQ
         #undef LAUNCH_TQ
     }
 }

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -17,6 +17,7 @@ size_t dtype_size(DType dt) {
         case DType::INT32:     return 4;
         case DType::FP4_E2M1:  return 1; // packed: 2 elements per byte
         case DType::TURBOQUANT: return 1; // packed INT4 directions (2 per byte), sketch stored separately
+        case DType::TURBOQUANT_LITE: return 1; // V is INT4 packed; K stored as sketches separately
     }
     return 0;
 }
@@ -33,6 +34,7 @@ const char* dtype_name(DType dt) {
         case DType::INT32:     return "INT32";
         case DType::FP4_E2M1:  return "FP4_E2M1";
         case DType::TURBOQUANT: return "TURBOQUANT";
+        case DType::TURBOQUANT_LITE: return "TURBOQUANT_LITE";
     }
     return "UNKNOWN";
 }

--- a/src/core/tensor.h
+++ b/src/core/tensor.h
@@ -17,7 +17,8 @@ enum class DType : uint8_t {
     INT4      = 6,
     INT32     = 7,
     FP4_E2M1  = 8,
-    TURBOQUANT = 9,   // TurboQuant: PolarQuant INT4 K + QJL sketch + INT4 V
+    TURBOQUANT = 9,       // TurboQuant: PolarQuant INT4 K + QJL sketch + INT4 V
+    TURBOQUANT_LITE = 10, // TurboQuant Lite: QJL sketch-only K (no INT4 dirs) + INT4 V
 };
 
 // Bytes per element. INT4 returns 1 (two elements packed per byte).

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -180,7 +180,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
             kv_block_size, n,
             state.max_blocks_per_seq, state.n_sequences);
     } else if (use_turboquant) {
-        // TurboQuant KV cache write: PolarQuant INT4 directions + QJL sketch for K, INT4 for V
+        // TurboQuant KV cache write: PolarQuant directions + QJL sketch for K, INT4 for V
         Tensor kv = view_tokens(k_, n);
         Tensor vv = view_tokens(v_, n);
         int int4_block_stride = kv_block_size * nkv * hd / 2;
@@ -188,21 +188,46 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
         int sketch_dim = qjl_proj_.sketch_dim;
         int sketch_block_stride = kv_block_size * nkv * (sketch_dim / 8);
         dim3 grid_tq(n, 2);
-        write_kv_cache_turboquant_kernel<<<grid_tq, 256, 0, stream>>>(
-            static_cast<const half*>(kv.data),
-            static_cast<const half*>(vv.data),
-            state.positions,
-            state.block_tables,
-            static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
-            static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
-            static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
-            static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)),
-            static_cast<uint8_t*>(cache->k_sketch_ptr(kv_layer, 0)),
-            static_cast<const uint8_t*>(qjl_proj_.matrix),
-            int4_block_stride, scale_block_stride_tq, sketch_block_stride,
-            nkv, hd, sketch_dim,
-            kv_block_size, n,
-            state.max_blocks_per_seq, state.n_sequences);
+
+        if (cache->use_mxfp4()) {
+            // MXFP4 path: FP4 E2M1 directions + UE8M0 per-32-element micro-scales
+            int n_groups = hd / 32;
+            int mscale_block_stride = kv_block_size * nkv * n_groups;
+            write_kv_cache_turboquant_mxfp4_kernel<<<grid_tq, 256, 0, stream>>>(
+                static_cast<const half*>(kv.data),
+                static_cast<const half*>(vv.data),
+                state.positions,
+                state.block_tables,
+                static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
+                static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
+                static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
+                static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)),
+                static_cast<uint8_t*>(cache->k_sketch_ptr(kv_layer, 0)),
+                static_cast<uint8_t*>(cache->k_mscale_ptr(kv_layer, 0)),
+                static_cast<const uint8_t*>(qjl_proj_.matrix),
+                int4_block_stride, scale_block_stride_tq, sketch_block_stride,
+                mscale_block_stride,
+                nkv, hd, sketch_dim,
+                kv_block_size, n,
+                state.max_blocks_per_seq, state.n_sequences);
+        } else {
+            // INT4 uniform path
+            write_kv_cache_turboquant_kernel<<<grid_tq, 256, 0, stream>>>(
+                static_cast<const half*>(kv.data),
+                static_cast<const half*>(vv.data),
+                state.positions,
+                state.block_tables,
+                static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
+                static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
+                static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
+                static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)),
+                static_cast<uint8_t*>(cache->k_sketch_ptr(kv_layer, 0)),
+                static_cast<const uint8_t*>(qjl_proj_.matrix),
+                int4_block_stride, scale_block_stride_tq, sketch_block_stride,
+                nkv, hd, sketch_dim,
+                kv_block_size, n,
+                state.max_blocks_per_seq, state.n_sequences);
+        }
     } else if (use_int4) {
         // INT4 quantized KV cache write — 2 values packed per byte, per-head scales
         Tensor kv = view_tokens(k_, n);
@@ -808,7 +833,11 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                         state.max_blocks_per_seq);
         } else if (cache_dtype == DType::TURBOQUANT) {
             // TurboQuant paged attention: PolarQuant K + QJL correction + INT4 V (Split-K enabled)
+            // K_mscales: non-null if MXFP4 path (FP4 E2M1 + UE8M0), null for uniform INT4
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
+            const uint8_t* k_mscales = cache->use_mxfp4()
+                ? static_cast<const uint8_t*>(cache->k_mscale_ptr(kv_layer, 0))
+                : nullptr;
             paged_attention_decode_turboquant(q4, k_c, v_c, o4,
                                         static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
                                         static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
@@ -818,7 +847,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                         kv_bs, scale, qjl_proj_.sketch_dim,
                                         state.max_context_len, layer_sliding_window,
                                         cfg.attn_logit_softcap, stream,
-                                        state.max_blocks_per_seq);
+                                        state.max_blocks_per_seq,
+                                        k_mscales);
         } else if (cache_dtype == DType::INT4) {
             // INT4 paged attention with per-head scales and INT4 unpack (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -154,8 +154,32 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
     bool use_int8 = (cache->dtype() == DType::INT8);
     bool use_int4 = (cache->dtype() == DType::INT4);
     bool use_turboquant = (cache->dtype() == DType::TURBOQUANT);
+    bool use_turboquant_lite = (cache->dtype() == DType::TURBOQUANT_LITE);
 
-    if (use_turboquant) {
+    if (use_turboquant_lite) {
+        // TurboQuant Lite: QJL sketch-only K + INT4 V
+        Tensor kv = view_tokens(k_, n);
+        Tensor vv = view_tokens(v_, n);
+        int int4_block_stride = kv_block_size * nkv * hd / 2;
+        int scale_block_stride_tql = kv_block_size * nkv;
+        int sketch_dim = qjl_proj_.sketch_dim;
+        int sketch_block_stride = kv_block_size * nkv * (sketch_dim / 8);
+        dim3 grid_tql(n, 2);
+        write_kv_cache_turboquant_lite_kernel<<<grid_tql, 256, 0, stream>>>(
+            static_cast<const half*>(kv.data),
+            static_cast<const half*>(vv.data),
+            state.positions,
+            state.block_tables,
+            static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
+            static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
+            static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)),
+            static_cast<uint8_t*>(cache->k_sketch_ptr(kv_layer, 0)),
+            static_cast<const uint8_t*>(qjl_proj_.matrix),
+            int4_block_stride, scale_block_stride_tql, sketch_block_stride,
+            nkv, hd, sketch_dim,
+            kv_block_size, n,
+            state.max_blocks_per_seq, state.n_sequences);
+    } else if (use_turboquant) {
         // TurboQuant KV cache write: PolarQuant INT4 directions + QJL sketch for K, INT4 for V
         Tensor kv = view_tokens(k_, n);
         Tensor vv = view_tokens(v_, n);
@@ -769,7 +793,20 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         Tensor k_c(cache->k_ptr(kv_layer, 0), cache_dtype, 4, cs, true);
         Tensor v_c(cache->v_ptr(kv_layer, 0), cache_dtype, 4, cs, true);
 
-        if (cache_dtype == DType::TURBOQUANT) {
+        if (cache_dtype == DType::TURBOQUANT_LITE) {
+            // TurboQuant Lite paged attention: QJL sketch-only K + INT4 V (Split-K enabled)
+            paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
+            paged_attention_decode_turboquant_lite(q4, v_c, o4,
+                                        static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
+                                        static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
+                                        static_cast<const uint8_t*>(cache->k_sketch_ptr(kv_layer, 0)),
+                                        static_cast<const uint8_t*>(qjl_proj_.matrix),
+                                        state.block_tables, state.context_lens,
+                                        kv_bs, scale, qjl_proj_.sketch_dim,
+                                        state.max_context_len, layer_sliding_window,
+                                        cfg.attn_logit_softcap, stream,
+                                        state.max_blocks_per_seq);
+        } else if (cache_dtype == DType::TURBOQUANT) {
             // TurboQuant paged attention: PolarQuant K + QJL correction + INT4 V (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_turboquant(q4, k_c, v_c, o4,

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -882,6 +882,158 @@ __global__ void write_kv_cache_turboquant_kernel(
     }
 }
 
+// ---------------------------------------------------------------------------
+// TurboQuant Lite: QJL sketch-only K + INT4 V
+//
+// K path (blockIdx.y == 0):
+//   1. Compute L2 norm per head
+//   2. Store FP16 norm
+//   3. Compute QJL sketch: sign(R @ k) — this IS the K representation (no INT4 dirs)
+//
+// V path (blockIdx.y == 1): Standard INT4 per-head quantization (same as INT4/TQ kernel)
+// ---------------------------------------------------------------------------
+__global__ void write_kv_cache_turboquant_lite_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    const int* __restrict__ positions,
+    const int* __restrict__ block_tables,
+    uint8_t* __restrict__ v_cache_base,
+    half* __restrict__ k_norm_base,
+    half* __restrict__ v_scale_base,
+    uint8_t* __restrict__ k_sketch_base,
+    const uint8_t* __restrict__ qjl_matrix,
+    int v_block_stride,
+    int scale_block_stride,
+    int sketch_block_stride,
+    int n_kv_heads,
+    int head_dim,
+    int sketch_dim,
+    int block_size,
+    int n_tokens,
+    int max_blocks_per_seq,
+    int n_sequences)
+{
+    const int token_idx = blockIdx.x;
+    if (token_idx >= n_tokens) return;
+
+    const int pos = positions[token_idx];
+    int slot_in_block;
+    int block_id = kv_resolve_slot(block_tables, pos, block_size,
+                                   token_idx, max_blocks_per_seq, n_sequences,
+                                   slot_in_block);
+
+    const int row_elems = n_kv_heads * head_dim;
+
+    if (blockIdx.y == 0) {
+        // ── K path: norm + QJL sketch only (no INT4 direction quantization) ──
+        const half* src = k_in + static_cast<int64_t>(token_idx) * row_elems;
+        half* norm_dst = k_norm_base + static_cast<int64_t>(block_id) * scale_block_stride
+                         + static_cast<int64_t>(slot_in_block) * n_kv_heads;
+        const int sketch_row_bytes = n_kv_heads * (sketch_dim / 8);
+        uint8_t* sketch_dst = k_sketch_base + static_cast<int64_t>(block_id) * sketch_block_stride
+                              + static_cast<int64_t>(slot_in_block) * sketch_row_bytes;
+
+        const int warp_id = threadIdx.x / 32;
+        const int lane_id = threadIdx.x % 32;
+        const int num_warps = blockDim.x / 32;
+        const int bytes_per_row_qjl = head_dim / 8;
+
+        for (int h = warp_id; h < n_kv_heads; h += num_warps) {
+            const int head_offset = h * head_dim;
+
+            // Step 1: Compute L2 norm
+            float norm_sq = 0.0f;
+            for (int d = lane_id; d < head_dim; d += 32) {
+                float val = __half2float(src[head_offset + d]);
+                norm_sq += val * val;
+            }
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                norm_sq += __shfl_xor_sync(0xFFFFFFFF, norm_sq, offset);
+
+            float norm = sqrtf(norm_sq);
+
+            // Step 2: Store norm
+            if (lane_id == 0) {
+                norm_dst[h] = __float2half(norm);
+            }
+
+            // Step 3: QJL sketch = sign(R @ k) for each sketch row
+            const int sketch_byte_offset = h * (sketch_dim / 8);
+
+            for (int sr = lane_id; sr < sketch_dim; sr += 32) {
+                const uint8_t* R_row = qjl_matrix + sr * bytes_per_row_qjl;
+
+                float dot = 0.0f;
+                for (int d = 0; d < head_dim; d += 8) {
+                    uint8_t r_byte = __ldg(&R_row[d / 8]);
+                    #pragma unroll
+                    for (int b = 0; b < 8; b++) {
+                        float sign = (r_byte & (1u << b)) ? 1.0f : -1.0f;
+                        float k_val = __half2float(src[head_offset + d + b]);
+                        dot += sign * k_val;
+                    }
+                }
+
+                int byte_idx = sr / 8;
+                int bit_idx = sr % 8;
+                uint8_t bit_val = (dot >= 0.0f) ? (1u << bit_idx) : 0;
+
+                atomicOr(reinterpret_cast<unsigned int*>(
+                    &sketch_dst[sketch_byte_offset + (byte_idx & ~3)]),
+                    static_cast<unsigned int>(bit_val) << (8 * (byte_idx & 3)));
+            }
+        }
+    } else {
+        // ── V path: Standard INT4 per-head quantization ──
+        const half* src = v_in + static_cast<int64_t>(token_idx) * row_elems;
+        const int row_bytes = n_kv_heads * head_dim / 2;
+        uint8_t* dst = v_cache_base + static_cast<int64_t>(block_id) * v_block_stride
+                       + static_cast<int64_t>(slot_in_block) * row_bytes;
+        half* scale_dst = v_scale_base + static_cast<int64_t>(block_id) * scale_block_stride
+                          + static_cast<int64_t>(slot_in_block) * n_kv_heads;
+
+        const int warp_id = threadIdx.x / 32;
+        const int lane_id = threadIdx.x % 32;
+        const int num_warps = blockDim.x / 32;
+
+        for (int h = warp_id; h < n_kv_heads; h += num_warps) {
+            const int head_offset = h * head_dim;
+
+            float amax = 0.0f;
+            for (int d = lane_id; d < head_dim; d += 32) {
+                float val = __half2float(src[head_offset + d]);
+                amax = fmaxf(amax, fabsf(val));
+            }
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, offset));
+
+            float sc = amax / 7.0f;
+            float inv_sc = (amax > 1e-8f) ? (7.0f / amax) : 0.0f;
+
+            const int head_byte_offset = h * head_dim / 2;
+            for (int d = lane_id * 2; d < head_dim; d += 64) {
+                float v0 = __half2float(src[head_offset + d]);
+                float v1 = (d + 1 < head_dim) ? __half2float(src[head_offset + d + 1]) : 0.0f;
+
+                int q0 = __float2int_rn(v0 * inv_sc);
+                int q1 = __float2int_rn(v1 * inv_sc);
+                q0 = max(-8, min(7, q0));
+                q1 = max(-8, min(7, q1));
+
+                uint8_t packed = (static_cast<uint8_t>(q0 & 0xF)) |
+                                 (static_cast<uint8_t>(q1 & 0xF) << 4);
+                dst[head_byte_offset + d / 2] = packed;
+            }
+
+            if (lane_id == 0) {
+                scale_dst[h] = __float2half(sc);
+            }
+        }
+    }
+}
+
 // Fused KV cache write with RoPE on K: applies RoPE to K during write, copies V directly.
 // blockIdx.x = token index, blockIdx.y = 0 (K+RoPE) or 1 (V copy).
 // Eliminates the separate RoPE kernel launch for K in the decode path.

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -882,6 +882,226 @@ __global__ void write_kv_cache_turboquant_kernel(
     }
 }
 
+// FP4 E2M1 + UE8M0 helpers for TurboQuant MXFP4 path (shared header)
+#include "quant/turboquant_fp4.cuh"
+
+// Aliases for shorter names in the kernel below
+#define tq_float_abs_to_fp4  tq_fp4_quantize_abs
+#define tq_float_to_ue8m0    tq_fp4_float_to_ue8m0
+#define tq_ue8m0_to_float    tq_fp4_ue8m0_to_float
+
+// ---------------------------------------------------------------------------
+// TurboQuant MXFP4 write kernel
+//
+// K path (blockIdx.y == 0):
+//   1. Compute L2 norm per head
+//   2. Normalize direction to unit vector
+//   3. Per-32-element groups: compute absmax → UE8M0 micro-scale
+//   4. Quantize direction to signed FP4 E2M1 with micro-scale
+//   5. Compute QJL sketch
+//   6. Store: FP4 E2M1 direction, FP16 norm, UE8M0 micro-scales, packed sketch
+//
+// V path (blockIdx.y == 1): Standard INT4 per-head quantization (identical)
+// ---------------------------------------------------------------------------
+__global__ void write_kv_cache_turboquant_mxfp4_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    const int* __restrict__ positions,
+    const int* __restrict__ block_tables,
+    uint8_t* __restrict__ k_dir_cache_base,
+    uint8_t* __restrict__ v_cache_base,
+    half* __restrict__ k_norm_base,
+    half* __restrict__ v_scale_base,
+    uint8_t* __restrict__ k_sketch_base,
+    uint8_t* __restrict__ k_mscale_base,
+    const uint8_t* __restrict__ qjl_matrix,
+    int block_stride,
+    int scale_block_stride,
+    int sketch_block_stride,
+    int mscale_block_stride,
+    int n_kv_heads,
+    int head_dim,
+    int sketch_dim,
+    int block_size,
+    int n_tokens,
+    int max_blocks_per_seq,
+    int n_sequences)
+{
+    const int token_idx = blockIdx.x;
+    if (token_idx >= n_tokens) return;
+
+    const int pos = positions[token_idx];
+    int slot_in_block;
+    int block_id = kv_resolve_slot(block_tables, pos, block_size,
+                                   token_idx, max_blocks_per_seq, n_sequences,
+                                   slot_in_block);
+
+    const int row_elems = n_kv_heads * head_dim;
+    constexpr int GROUP_SIZE = 32;  // MXFP4 micro-scale group
+
+    if (blockIdx.y == 0) {
+        // ── K path: PolarQuant + FP4 E2M1 + UE8M0 micro-scales + QJL ──
+        const half* src = k_in + static_cast<int64_t>(token_idx) * row_elems;
+        const int row_bytes = n_kv_heads * head_dim / 2;
+        uint8_t* dir_dst = k_dir_cache_base + static_cast<int64_t>(block_id) * block_stride
+                           + static_cast<int64_t>(slot_in_block) * row_bytes;
+        half* norm_dst = k_norm_base + static_cast<int64_t>(block_id) * scale_block_stride
+                         + static_cast<int64_t>(slot_in_block) * n_kv_heads;
+        const int sketch_row_bytes = n_kv_heads * (sketch_dim / 8);
+        uint8_t* sketch_dst = k_sketch_base + static_cast<int64_t>(block_id) * sketch_block_stride
+                              + static_cast<int64_t>(slot_in_block) * sketch_row_bytes;
+        const int n_groups = head_dim / GROUP_SIZE;
+        const int mscale_row_bytes = n_kv_heads * n_groups;
+        uint8_t* mscale_dst = k_mscale_base + static_cast<int64_t>(block_id) * mscale_block_stride
+                              + static_cast<int64_t>(slot_in_block) * mscale_row_bytes;
+
+        const int warp_id = threadIdx.x / 32;
+        const int lane_id = threadIdx.x % 32;
+        const int num_warps = blockDim.x / 32;
+        const int bytes_per_row_qjl = head_dim / 8;
+
+        for (int h = warp_id; h < n_kv_heads; h += num_warps) {
+            const int head_offset = h * head_dim;
+
+            // Step 1: Compute L2 norm
+            float norm_sq = 0.0f;
+            for (int d = lane_id; d < head_dim; d += 32) {
+                float val = __half2float(src[head_offset + d]);
+                norm_sq += val * val;
+            }
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                norm_sq += __shfl_xor_sync(0xFFFFFFFF, norm_sq, offset);
+
+            float norm = sqrtf(norm_sq);
+            float inv_norm = (norm > 1e-8f) ? (1.0f / norm) : 0.0f;
+
+            // Step 2: Store norm
+            if (lane_id == 0) {
+                norm_dst[h] = __float2half(norm);
+            }
+
+            // Step 3: Per-group FP4 E2M1 quantization with UE8M0 micro-scales.
+            // Each group of 32 direction elements gets one UE8M0 scale.
+            const int head_byte_offset = h * head_dim / 2;
+            const int head_mscale_offset = h * n_groups;
+
+            for (int g = 0; g < n_groups; g++) {
+                int g_start = g * GROUP_SIZE;
+
+                // 3a: Find per-group absmax of normalized direction
+                float group_amax = 0.0f;
+                for (int d = lane_id; d < GROUP_SIZE; d += 32) {
+                    float dir_val = __half2float(src[head_offset + g_start + d]) * inv_norm;
+                    group_amax = fmaxf(group_amax, fabsf(dir_val));
+                }
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    group_amax = fmaxf(group_amax, __shfl_xor_sync(0xFFFFFFFF, group_amax, offset));
+
+                // 3b: Compute UE8M0 micro-scale = ceil_pow2(group_amax / 6.0)
+                float raw_scale = group_amax / 6.0f;
+                uint8_t ue8m0 = tq_float_to_ue8m0(raw_scale);
+                float actual_scale = tq_ue8m0_to_float(ue8m0);
+                if (actual_scale == 0.0f) actual_scale = 1.0f / (1 << 30);  // avoid div-by-zero
+                float inv_scale = 1.0f / actual_scale;
+
+                // 3c: Store micro-scale
+                if (lane_id == 0) {
+                    mscale_dst[head_mscale_offset + g] = ue8m0;
+                }
+
+                // 3d: Quantize direction elements to signed FP4 E2M1
+                for (int d = lane_id * 2; d < GROUP_SIZE; d += 64) {
+                    float v0 = __half2float(src[head_offset + g_start + d]) * inv_norm;
+                    float v1 = (d + 1 < GROUP_SIZE)
+                        ? __half2float(src[head_offset + g_start + d + 1]) * inv_norm
+                        : 0.0f;
+
+                    // Scale to FP4 range and quantize
+                    float s0 = v0 * inv_scale;
+                    float s1 = v1 * inv_scale;
+                    uint8_t sign0 = (s0 < 0.0f) ? 1u : 0u;
+                    uint8_t sign1 = (s1 < 0.0f) ? 1u : 0u;
+                    uint8_t code0 = tq_float_abs_to_fp4(fabsf(s0));
+                    uint8_t code1 = tq_float_abs_to_fp4(fabsf(s1));
+                    uint8_t fp4_0 = (sign0 << 3) | code0;
+                    uint8_t fp4_1 = (sign1 << 3) | code1;
+
+                    // Pack: low nibble = even, high nibble = odd
+                    uint8_t packed = fp4_0 | (fp4_1 << 4);
+                    dir_dst[head_byte_offset + (g_start + d) / 2] = packed;
+                }
+            }
+
+            // Step 4: QJL sketch (identical to non-MXFP4 path)
+            const int sketch_byte_offset = h * (sketch_dim / 8);
+            for (int sr = lane_id; sr < sketch_dim; sr += 32) {
+                const uint8_t* R_row = qjl_matrix + sr * bytes_per_row_qjl;
+                float dot = 0.0f;
+                for (int d = 0; d < head_dim; d += 8) {
+                    uint8_t r_byte = __ldg(&R_row[d / 8]);
+                    #pragma unroll
+                    for (int b = 0; b < 8; b++) {
+                        float sign = (r_byte & (1u << b)) ? 1.0f : -1.0f;
+                        float k_val = __half2float(src[head_offset + d + b]);
+                        dot += sign * k_val;
+                    }
+                }
+                int byte_idx = sr / 8;
+                int bit_idx = sr % 8;
+                uint8_t bit_val = (dot >= 0.0f) ? (1u << bit_idx) : 0;
+                atomicOr(reinterpret_cast<unsigned int*>(
+                    &sketch_dst[sketch_byte_offset + (byte_idx & ~3)]),
+                    static_cast<unsigned int>(bit_val) << (8 * (byte_idx & 3)));
+            }
+        }
+    } else {
+        // ── V path: Standard INT4 per-head quantization (identical to non-MXFP4) ──
+        const half* src = v_in + static_cast<int64_t>(token_idx) * row_elems;
+        const int row_bytes = n_kv_heads * head_dim / 2;
+        uint8_t* dst = v_cache_base + static_cast<int64_t>(block_id) * block_stride
+                       + static_cast<int64_t>(slot_in_block) * row_bytes;
+        half* scale_dst = v_scale_base + static_cast<int64_t>(block_id) * scale_block_stride
+                          + static_cast<int64_t>(slot_in_block) * n_kv_heads;
+
+        const int warp_id = threadIdx.x / 32;
+        const int lane_id = threadIdx.x % 32;
+        const int num_warps = blockDim.x / 32;
+
+        for (int h = warp_id; h < n_kv_heads; h += num_warps) {
+            const int head_offset = h * head_dim;
+            float amax = 0.0f;
+            for (int d = lane_id; d < head_dim; d += 32) {
+                float val = __half2float(src[head_offset + d]);
+                amax = fmaxf(amax, fabsf(val));
+            }
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, offset));
+
+            float sc = amax / 7.0f;
+            float inv_sc = (amax > 1e-8f) ? (7.0f / amax) : 0.0f;
+
+            const int head_byte_offset = h * head_dim / 2;
+            for (int d = lane_id * 2; d < head_dim; d += 64) {
+                float v0 = __half2float(src[head_offset + d]);
+                float v1 = (d + 1 < head_dim) ? __half2float(src[head_offset + d + 1]) : 0.0f;
+                int q0 = __float2int_rn(v0 * inv_sc);
+                int q1 = __float2int_rn(v1 * inv_sc);
+                q0 = max(-8, min(7, q0));
+                q1 = max(-8, min(7, q1));
+                uint8_t packed = (static_cast<uint8_t>(q0 & 0xF)) |
+                                 (static_cast<uint8_t>(q1 & 0xF) << 4);
+                dst[head_byte_offset + d / 2] = packed;
+            }
+            if (lane_id == 0) {
+                scale_dst[h] = __float2half(sc);
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // TurboQuant Lite: QJL sketch-only K + INT4 V
 //

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -174,6 +174,30 @@ __global__ void write_kv_cache_turboquant_kernel(
     int max_blocks_per_seq,
     int n_sequences);
 
+// TurboQuant Lite: QJL sketch-only K + INT4 V write kernel.
+// K path (blockIdx.y == 0): Compute L2 norm + QJL sketch (no INT4 direction quantization).
+// V path (blockIdx.y == 1): Standard INT4 per-head quantization.
+__global__ void write_kv_cache_turboquant_lite_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    const int* __restrict__ positions,
+    const int* __restrict__ block_tables,
+    uint8_t* __restrict__ v_cache_base,         // INT4 packed values (V only, no K in pool)
+    half* __restrict__ k_norm_base,             // FP16 norms (in scale_pool K region)
+    half* __restrict__ v_scale_base,            // FP16 per-head V scales (in scale_pool V region)
+    uint8_t* __restrict__ k_sketch_base,        // QJL 1-bit sketches (primary K representation)
+    const uint8_t* __restrict__ qjl_matrix,     // [sketch_dim, head_dim/8] packed Rademacher signs
+    int v_block_stride,                         // kKVBlockSize * n_kv_heads * head_dim / 2 (bytes)
+    int scale_block_stride,                     // kKVBlockSize * n_kv_heads (half elems)
+    int sketch_block_stride,                    // kKVBlockSize * n_kv_heads * sketch_dim / 8 (bytes)
+    int n_kv_heads,
+    int head_dim,
+    int sketch_dim,
+    int block_size,
+    int n_tokens,
+    int max_blocks_per_seq,
+    int n_sequences);
+
 __global__ void write_kv_cache_rope_fused_kernel(
     const half* __restrict__ k_in,
     const half* __restrict__ v_in,

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -174,6 +174,33 @@ __global__ void write_kv_cache_turboquant_kernel(
     int max_blocks_per_seq,
     int n_sequences);
 
+// TurboQuant MXFP4 variant: PolarQuant FP4 E2M1 K directions + UE8M0 micro-scales + QJL.
+// K path: normalize → per-32-element UE8M0 scale → FP4 E2M1 quantize → QJL sketch
+// V path: standard INT4 per-head quantization (same as non-MXFP4 variant)
+__global__ void write_kv_cache_turboquant_mxfp4_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    const int* __restrict__ positions,
+    const int* __restrict__ block_tables,
+    uint8_t* __restrict__ k_dir_cache_base,    // FP4 E2M1 packed directions (same layout as INT4)
+    uint8_t* __restrict__ v_cache_base,         // INT4 packed values
+    half* __restrict__ k_norm_base,             // FP16 PolarQuant norms
+    half* __restrict__ v_scale_base,            // FP16 per-head V scales
+    uint8_t* __restrict__ k_sketch_base,        // QJL 1-bit sketches
+    uint8_t* __restrict__ k_mscale_base,        // UE8M0 micro-scales [block, slot, head, head_dim/32]
+    const uint8_t* __restrict__ qjl_matrix,     // [sketch_dim, head_dim/8] packed Rademacher signs
+    int block_stride,                           // kKVBlockSize * n_kv_heads * head_dim / 2 (bytes)
+    int scale_block_stride,                     // kKVBlockSize * n_kv_heads (half elems)
+    int sketch_block_stride,                    // kKVBlockSize * n_kv_heads * sketch_dim / 8 (bytes)
+    int mscale_block_stride,                    // kKVBlockSize * n_kv_heads * (head_dim / 32) (bytes)
+    int n_kv_heads,
+    int head_dim,
+    int sketch_dim,
+    int block_size,
+    int n_tokens,
+    int max_blocks_per_seq,
+    int n_sequences);
+
 // TurboQuant Lite: QJL sketch-only K + INT4 V write kernel.
 // K path (blockIdx.y == 0): Compute L2 norm + QJL sketch (no INT4 direction quantization).
 // V path (blockIdx.y == 1): Standard INT4 per-head quantization.

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -30,13 +30,15 @@ namespace imp {
 // ---------------------------------------------------------------------------
 
 KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
-                 int max_blocks, int block_size, VRAMAllocator* alloc, int sketch_dim)
+                 int max_blocks, int block_size, VRAMAllocator* alloc, int sketch_dim,
+                 bool use_mxfp4)
     : n_layers_(n_layers)
     , n_kv_heads_(n_kv_heads)
     , head_dim_(head_dim)
     , max_blocks_(max_blocks)
     , block_size_(block_size)
     , sketch_dim_(sketch_dim)
+    , use_mxfp4_(use_mxfp4)
     , dtype_(dtype)
     , alloc_(alloc)
     , block_bytes_((dtype == DType::INT4 || dtype == DType::TURBOQUANT
@@ -128,6 +130,33 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
                      n_layers_, max_blocks_);
     }
 
+    // Allocate MXFP4 UE8M0 micro-scale pool for TurboQuant K directions (sm_120 path).
+    // One UE8M0 byte per 32 direction elements per head per token.
+    if (dtype == DType::TURBOQUANT && use_mxfp4_ && head_dim >= kTQMicroScaleGroup) {
+        int n_groups_per_head = head_dim / kTQMicroScaleGroup;
+        mscale_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * n_groups_per_head;
+        // K-only (same indexing as sketch pool)
+        size_t mscale_total = static_cast<size_t>(n_layers_) * max_blocks_ * mscale_block_bytes_;
+        if (alloc_) {
+            mscale_pool_ = alloc_->allocate(mscale_total, "kv_cache_mscales");
+        } else {
+            cudaError_t merr = cudaMalloc(&mscale_pool_, mscale_total);
+            if (merr != cudaSuccess) mscale_pool_ = nullptr;
+        }
+        if (!mscale_pool_) {
+            IMP_LOG_WARN("KVCache: MXFP4 micro-scale pool allocation failed (%.2f KiB), "
+                         "falling back to uniform INT4 quantization",
+                         static_cast<double>(mscale_total) / 1024.0);
+            use_mxfp4_ = false;
+        } else {
+            cudaMemset(mscale_pool_, 0, mscale_total);
+            IMP_LOG_INFO("KVCache: MXFP4 micro-scales enabled for K directions "
+                         "(%d groups/head, %.1f KiB)",
+                         n_groups_per_head,
+                         static_cast<double>(mscale_total) / 1024.0);
+        }
+    }
+
     // Initialise per-block ref counts (0 = free) and build free list
     ref_counts_.resize(max_blocks_, 0);
     free_list_.reserve(max_blocks_);
@@ -137,6 +166,10 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
 }
 
 KVCache::~KVCache() {
+    if (mscale_pool_) {
+        if (alloc_) alloc_->free(mscale_pool_); else cudaFree(mscale_pool_);
+        mscale_pool_ = nullptr;
+    }
     if (sketch_pool_) {
         if (alloc_) alloc_->free(sketch_pool_); else cudaFree(sketch_pool_);
         sketch_pool_ = nullptr;
@@ -320,6 +353,28 @@ void* KVCache::k_sketch_ptr(int layer, int block_id) {
 
 size_t KVCache::sketch_block_bytes() const {
     return sketch_block_bytes_;
+}
+
+// ---------------------------------------------------------------------------
+// TurboQuant MXFP4 micro-scale pointer computation
+// ---------------------------------------------------------------------------
+
+void* KVCache::k_mscale_ptr(int layer, int block_id) {
+    if (!mscale_pool_) return nullptr;
+#ifdef IMP_DEBUG
+    if (layer < 0 || layer >= n_layers_ || block_id < 0 || block_id >= max_blocks_) {
+        IMP_LOG_ERROR("KV cache k_mscale_ptr bounds violation: layer=%d/%d, block=%d/%d",
+                      layer, n_layers_, block_id, max_blocks_);
+    }
+#endif
+    // Same indexing as sketch pool: [layer, block_id] * mscale_block_bytes_ (K only)
+    size_t offset = (static_cast<size_t>(layer) * max_blocks_ +
+                     static_cast<size_t>(block_id)) * mscale_block_bytes_;
+    return static_cast<char*>(mscale_pool_) + offset;
+}
+
+size_t KVCache::mscale_block_bytes() const {
+    return mscale_block_bytes_;
 }
 
 } // namespace imp

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -13,34 +13,48 @@ namespace imp {
 // Constructor: allocate one contiguous GPU buffer for all layers, all blocks,
 // K+V slots.
 //
-// Memory layout (byte offsets):
+// Memory layout (byte offsets) — standard modes (FP16/FP8/INT8/INT4/TURBOQUANT):
 //   Per layer: K blocks contiguous, then V blocks contiguous.
 //
 //   K offset(layer, block_id) = (layer * 2 * max_blocks + block_id) * block_bytes_
 //   V offset(layer, block_id) = (layer * 2 * max_blocks + max_blocks + block_id) * block_bytes_
 //
-// This ensures K (and V) blocks are contiguous within a layer, allowing
-// kernels to stride by block_bytes_ between physical blocks.
+//   Total = n_layers * max_blocks * 2 * block_bytes_
 //
-// Total = n_layers * max_blocks * 2 * block_bytes_
+// Memory layout — TURBOQUANT_LITE:
+//   Pool stores V blocks only (K is represented entirely via sketch pool + scale pool).
+//   V offset(layer, block_id) = (layer * max_blocks + block_id) * block_bytes_
+//   k_ptr() returns nullptr.
+//
+//   Total = n_layers * max_blocks * block_bytes_  (1x, not 2x)
 // ---------------------------------------------------------------------------
 
 KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
-                 int max_blocks, int block_size, VRAMAllocator* alloc)
+                 int max_blocks, int block_size, VRAMAllocator* alloc, int sketch_dim)
     : n_layers_(n_layers)
     , n_kv_heads_(n_kv_heads)
     , head_dim_(head_dim)
     , max_blocks_(max_blocks)
     , block_size_(block_size)
+    , sketch_dim_(sketch_dim)
     , dtype_(dtype)
     , alloc_(alloc)
-    , block_bytes_((dtype == DType::INT4 || dtype == DType::TURBOQUANT)
+    , block_bytes_((dtype == DType::INT4 || dtype == DType::TURBOQUANT
+                    || dtype == DType::TURBOQUANT_LITE)
                    ? (static_cast<size_t>(block_size_) * n_kv_heads * head_dim / 2)
                    : (static_cast<size_t>(block_size_) * n_kv_heads * head_dim *
                       dtype_size(dtype))) {
 
+    bool lite = (dtype == DType::TURBOQUANT_LITE);
+
+    // Resolve sketch_dim default: head_dim for TURBOQUANT, 0 for non-TQ modes
+    if (dtype == DType::TURBOQUANT && sketch_dim_ <= 0) sketch_dim_ = head_dim;
+    if (dtype == DType::TURBOQUANT_LITE && sketch_dim_ <= 0) sketch_dim_ = 2 * head_dim;
+
     // Allocate contiguous GPU pool
-    size_t total = static_cast<size_t>(n_layers_) * max_blocks_ * 2 * block_bytes_;
+    // TURBOQUANT_LITE: V-only (1x), all others: K+V (2x)
+    size_t pool_multiplier = lite ? 1 : 2;
+    size_t total = static_cast<size_t>(n_layers_) * max_blocks_ * pool_multiplier * block_bytes_;
     if (alloc_) {
         pool_ = alloc_->allocate(total, "kv_cache");
     } else {
@@ -58,10 +72,12 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
     // Zero-initialize the pool so fresh blocks start clean
     cudaMemset(pool_, 0, total);
 
-    // Allocate separate scale buffer for INT8/INT4/TURBOQUANT KV cache (per-head-per-token scales)
-    // For TURBOQUANT: K scales = PolarQuant FP16 norms, V scales = INT4 per-head scales
-    if (dtype == DType::INT8 || dtype == DType::INT4 || dtype == DType::TURBOQUANT) {
+    // Allocate separate scale buffer for INT8/INT4/TURBOQUANT/TURBOQUANT_LITE KV cache
+    // For TURBOQUANT_LITE: K scales = FP16 norms, V scales = INT4 per-head scales
+    if (dtype == DType::INT8 || dtype == DType::INT4
+        || dtype == DType::TURBOQUANT || dtype == DType::TURBOQUANT_LITE) {
         scale_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * sizeof(half);
+        // Always 2x: K scales region + V scales region (even for TURBOQUANT_LITE)
         size_t scale_total = static_cast<size_t>(n_layers_) * max_blocks_ * 2 * scale_block_bytes_;
         if (alloc_) {
             scale_pool_ = alloc_->allocate(scale_total, "kv_cache_scales");
@@ -82,11 +98,9 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
         cudaMemset(scale_pool_, 0, scale_total);
     }
 
-    // Allocate QJL 1-bit sketch buffer for TurboQuant K-cache
-    // Layout: same as K portion of pool_ but with sketch_block_bytes_ per block.
-    // sketch_dim = head_dim (paper recommendation), stored as packed bits.
-    if (dtype == DType::TURBOQUANT) {
-        sketch_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * (head_dim / 8);
+    // Allocate QJL 1-bit sketch buffer for TurboQuant / TurboQuant Lite K-cache
+    if (dtype == DType::TURBOQUANT || dtype == DType::TURBOQUANT_LITE) {
+        sketch_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * (sketch_dim_ / 8);
         // Only K needs sketches, so n_layers * max_blocks * sketch_block_bytes (no 2x)
         size_t sketch_total = static_cast<size_t>(n_layers_) * max_blocks_ * sketch_block_bytes_;
         if (alloc_) {
@@ -101,11 +115,17 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
             pool_ = nullptr;
             char msg[256];
             std::snprintf(msg, sizeof(msg),
-                          "KVCache: allocation failed for TurboQuant sketch pool %.2f MiB",
+                          "KVCache: allocation failed for %s sketch pool %.2f MiB",
+                          dtype_name(dtype),
                           static_cast<double>(sketch_total) / (1024.0 * 1024.0));
             throw std::runtime_error(msg);
         }
         cudaMemset(sketch_pool_, 0, sketch_total);
+
+        IMP_LOG_INFO("KVCache: %s sketch_dim=%d, sketch pool %.2f MiB (%d layers, %d blocks)",
+                     dtype_name(dtype), sketch_dim_,
+                     static_cast<double>(sketch_total) / (1024.0 * 1024.0),
+                     n_layers_, max_blocks_);
     }
 
     // Initialise per-block ref counts (0 = free) and build free list
@@ -175,6 +195,9 @@ void KVCache::inc_ref(int block_id) {
 // ---------------------------------------------------------------------------
 
 void* KVCache::k_ptr(int layer, int block_id) {
+    // TURBOQUANT_LITE: no K directions in pool, K is represented by sketches only
+    if (dtype_ == DType::TURBOQUANT_LITE) return nullptr;
+
 #ifdef IMP_DEBUG
     if (layer < 0 || layer >= n_layers_ || block_id < 0 || block_id >= max_blocks_) {
         IMP_LOG_ERROR("KV cache k_ptr bounds violation: layer=%d/%d, block=%d/%d",
@@ -194,7 +217,13 @@ void* KVCache::v_ptr(int layer, int block_id) {
                       layer, n_layers_, block_id, max_blocks_);
     }
 #endif
-    // V blocks: [layer * 2 * max_blocks + max_blocks + block_id] * block_bytes
+    if (dtype_ == DType::TURBOQUANT_LITE) {
+        // V-only pool: [layer * max_blocks + block_id] * block_bytes
+        size_t offset = (static_cast<size_t>(layer) * max_blocks_ +
+                         static_cast<size_t>(block_id)) * block_bytes_;
+        return static_cast<char*>(pool_) + offset;
+    }
+    // Standard K+V pool: V blocks follow K blocks per layer
     size_t offset = (static_cast<size_t>(layer) * 2 * max_blocks_ +
                      max_blocks_ + static_cast<size_t>(block_id)) * block_bytes_;
     return static_cast<char*>(pool_) + offset;
@@ -237,7 +266,7 @@ DType KVCache::dtype() const {
 }
 
 // ---------------------------------------------------------------------------
-// INT8 scale pointer computation
+// Scale pointer computation (same layout for all quantized modes)
 // ---------------------------------------------------------------------------
 
 void* KVCache::k_scale_ptr(int layer, int block_id) {
@@ -248,7 +277,7 @@ void* KVCache::k_scale_ptr(int layer, int block_id) {
                       layer, n_layers_, block_id, max_blocks_);
     }
 #endif
-    // Same offset formula as k_ptr() but using scale_block_bytes_
+    // Scale pool always uses 2x layout (K scales region + V scales region)
     size_t offset = (static_cast<size_t>(layer) * 2 * max_blocks_ +
                      static_cast<size_t>(block_id)) * scale_block_bytes_;
     return static_cast<char*>(scale_pool_) + offset;
@@ -272,7 +301,7 @@ size_t KVCache::scale_block_bytes() const {
 }
 
 // ---------------------------------------------------------------------------
-// TurboQuant QJL sketch pointer computation
+// TurboQuant / TurboQuant Lite QJL sketch pointer computation
 // ---------------------------------------------------------------------------
 
 void* KVCache::k_sketch_ptr(int layer, int block_id) {

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -11,14 +11,20 @@ class VRAMAllocator;  // forward declaration
 
 static constexpr int kKVBlockSize = 16; // default tokens per block
 
+// MXFP4 micro-scale group size (matching CUTLASS MXFP4 SfVecSize)
+static constexpr int kTQMicroScaleGroup = 32;
+
 class KVCache {
 public:
     // sketch_dim: QJL sketch dimension (only used for TURBOQUANT / TURBOQUANT_LITE).
     //   TURBOQUANT: defaults to head_dim if sketch_dim <= 0.
     //   TURBOQUANT_LITE: should be multiplier * head_dim for quality (e.g. 2*head_dim).
+    // use_mxfp4: if true and dtype==TURBOQUANT, use FP4 E2M1 + UE8M0 micro-scales
+    //   instead of uniform INT4 for K direction quantization (sm_120 path).
     KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
             int max_blocks, int block_size = kKVBlockSize,
-            VRAMAllocator* alloc = nullptr, int sketch_dim = 0);
+            VRAMAllocator* alloc = nullptr, int sketch_dim = 0,
+            bool use_mxfp4 = false);
     ~KVCache();
 
     // Block allocation / deallocation
@@ -35,6 +41,7 @@ public:
     void* v_ptr(int layer, int block_id);
 
     // INT8/INT4/TURBOQUANT/TURBOQUANT_LITE per-head scale access (nullptr if not applicable)
+    // For TURBOQUANT: K scales store PolarQuant FP16 norms, V scales store INT4 per-head scales.
     // For TURBOQUANT_LITE: K scales store FP16 norms, V scales store INT4 per-head scales.
     void* k_scale_ptr(int layer, int block_id);
     void* v_scale_ptr(int layer, int block_id);
@@ -43,6 +50,12 @@ public:
     // TurboQuant/TurboQuant Lite QJL sketch access (nullptr if not applicable)
     void* k_sketch_ptr(int layer, int block_id);
     size_t sketch_block_bytes() const;
+
+    // TurboQuant MXFP4 per-32-element UE8M0 micro-scale access for K directions.
+    // nullptr if not TURBOQUANT or mxfp4 not enabled. K-only (no V micro-scales).
+    // Layout: [layer, block_id] * mscale_block_bytes_ (same indexing as sketch_pool_).
+    void* k_mscale_ptr(int layer, int block_id);
+    size_t mscale_block_bytes() const;
 
     // Capacity queries
     int num_free_blocks() const;
@@ -55,6 +68,7 @@ public:
     int n_kv_heads() const;
     int head_dim() const;
     int sketch_dim() const { return sketch_dim_; }
+    bool use_mxfp4() const { return use_mxfp4_; }
     DType dtype() const;
 
 private:
@@ -64,6 +78,7 @@ private:
     int max_blocks_;
     int block_size_;                // tokens per block (default 16)
     int sketch_dim_ = 0;           // QJL sketch dimension (0 if not TurboQuant)
+    bool use_mxfp4_ = false;       // FP4 E2M1 + UE8M0 micro-scales for K dirs (sm_120)
     DType dtype_;
     VRAMAllocator* alloc_ = nullptr;
     size_t block_bytes_;            // cached: block_size * n_kv_heads * head_dim * dtype_size(dtype)
@@ -75,17 +90,22 @@ private:
 
     // INT8/INT4/TURBOQUANT/TURBOQUANT_LITE per-head scales: one half per head per token slot.
     // Layout: 2x blocks per layer (K scales region + V scales region).
-    // For TURBOQUANT: K scales store PolarQuant norms, V scales store INT4 per-head scales.
+    // For TURBOQUANT: K scales store PolarQuant norms, V scales store INT4/FP4 per-head scales.
     // For TURBOQUANT_LITE: K scales store FP16 norms, V scales store INT4 per-head scales.
     void* scale_pool_ = nullptr;
     size_t scale_block_bytes_ = 0;  // block_size * n_kv_heads * sizeof(half)
 
     // TurboQuant / TurboQuant Lite QJL 1-bit sketch storage.
     // Layout: [layer, block_id] * sketch_block_bytes_ (K only, no V sketches).
-    // For TURBOQUANT: sketch_dim = head_dim (error correction).
-    // For TURBOQUANT_LITE: sketch_dim = multiplier * head_dim (primary K representation).
     void* sketch_pool_ = nullptr;
     size_t sketch_block_bytes_ = 0;  // block_size * n_kv_heads * (sketch_dim / 8)
+
+    // TurboQuant MXFP4 per-32-element UE8M0 micro-scales for K direction vectors.
+    // Only allocated when dtype == TURBOQUANT && use_mxfp4_ == true.
+    // Layout: [layer, block_id] * mscale_block_bytes_ (K only, same as sketch indexing).
+    // Each token-head stores head_dim/32 UE8M0 bytes.
+    void* mscale_pool_ = nullptr;
+    size_t mscale_block_bytes_ = 0;  // block_size * n_kv_heads * (head_dim / kTQMicroScaleGroup)
 };
 
 } // namespace imp

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -13,9 +13,12 @@ static constexpr int kKVBlockSize = 16; // default tokens per block
 
 class KVCache {
 public:
+    // sketch_dim: QJL sketch dimension (only used for TURBOQUANT / TURBOQUANT_LITE).
+    //   TURBOQUANT: defaults to head_dim if sketch_dim <= 0.
+    //   TURBOQUANT_LITE: should be multiplier * head_dim for quality (e.g. 2*head_dim).
     KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
             int max_blocks, int block_size = kKVBlockSize,
-            VRAMAllocator* alloc = nullptr);
+            VRAMAllocator* alloc = nullptr, int sketch_dim = 0);
     ~KVCache();
 
     // Block allocation / deallocation
@@ -27,15 +30,17 @@ public:
     void inc_ref(int block_id);
 
     // Pointer access into the contiguous pool
+    // For TURBOQUANT_LITE, k_ptr returns nullptr (K stored only as sketches).
     void* k_ptr(int layer, int block_id);
     void* v_ptr(int layer, int block_id);
 
-    // INT8/INT4/TURBOQUANT per-head scale access (nullptr if not applicable)
+    // INT8/INT4/TURBOQUANT/TURBOQUANT_LITE per-head scale access (nullptr if not applicable)
+    // For TURBOQUANT_LITE: K scales store FP16 norms, V scales store INT4 per-head scales.
     void* k_scale_ptr(int layer, int block_id);
     void* v_scale_ptr(int layer, int block_id);
     size_t scale_block_bytes() const;
 
-    // TurboQuant QJL sketch access (nullptr if dtype != TURBOQUANT)
+    // TurboQuant/TurboQuant Lite QJL sketch access (nullptr if not applicable)
     void* k_sketch_ptr(int layer, int block_id);
     size_t sketch_block_bytes() const;
 
@@ -49,6 +54,7 @@ public:
     int n_layers() const;
     int n_kv_heads() const;
     int head_dim() const;
+    int sketch_dim() const { return sketch_dim_; }
     DType dtype() const;
 
 private:
@@ -57,6 +63,7 @@ private:
     int head_dim_;
     int max_blocks_;
     int block_size_;                // tokens per block (default 16)
+    int sketch_dim_ = 0;           // QJL sketch dimension (0 if not TurboQuant)
     DType dtype_;
     VRAMAllocator* alloc_ = nullptr;
     size_t block_bytes_;            // cached: block_size * n_kv_heads * head_dim * dtype_size(dtype)
@@ -64,18 +71,21 @@ private:
     std::vector<int> ref_counts_;   // per-block reference count
     std::vector<int> free_list_;
     void* pool_ = nullptr;          // single contiguous GPU allocation
+                                    // For TURBOQUANT_LITE: V-only (no K directions in pool)
 
-    // INT8/INT4/TURBOQUANT per-head scales: one half per head per token slot.
-    // Layout mirrors pool_ but with scale_block_bytes_ per block.
+    // INT8/INT4/TURBOQUANT/TURBOQUANT_LITE per-head scales: one half per head per token slot.
+    // Layout: 2x blocks per layer (K scales region + V scales region).
     // For TURBOQUANT: K scales store PolarQuant norms, V scales store INT4 per-head scales.
+    // For TURBOQUANT_LITE: K scales store FP16 norms, V scales store INT4 per-head scales.
     void* scale_pool_ = nullptr;
     size_t scale_block_bytes_ = 0;  // block_size * n_kv_heads * sizeof(half)
 
-    // TurboQuant QJL 1-bit sketch storage.
-    // Layout mirrors K portion of pool_ but with sketch_block_bytes_ per block.
-    // Only allocated when dtype == TURBOQUANT.
+    // TurboQuant / TurboQuant Lite QJL 1-bit sketch storage.
+    // Layout: [layer, block_id] * sketch_block_bytes_ (K only, no V sketches).
+    // For TURBOQUANT: sketch_dim = head_dim (error correction).
+    // For TURBOQUANT_LITE: sketch_dim = multiplier * head_dim (primary K representation).
     void* sketch_pool_ = nullptr;
-    size_t sketch_block_bytes_ = 0;  // block_size * n_kv_heads * (head_dim / 8)
+    size_t sketch_block_bytes_ = 0;  // block_size * n_kv_heads * (sketch_dim / 8)
 };
 
 } // namespace imp

--- a/src/quant/turboquant_fp4.cuh
+++ b/src/quant/turboquant_fp4.cuh
@@ -1,0 +1,70 @@
+#pragma once
+
+// TurboQuant FP4 E2M1 + UE8M0 device helpers.
+// Shared between KV cache write kernels and attention decode kernels.
+
+#include <cstdint>
+
+namespace imp {
+
+// MXFP4 micro-scale group size (32 elements per UE8M0 scale)
+static constexpr int kTQFP4GroupSize = 32;
+
+// FP4 E2M1 dequant LUT: magnitude code [0-7] → float value
+// Values: {0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0}
+__constant__ float kTQFP4DequantLUT[8] = {
+    0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f
+};
+
+// Quantize float magnitude → FP4 E2M1 3-bit code (round-to-nearest)
+__device__ __forceinline__ uint8_t tq_fp4_quantize_abs(float abs_val) {
+    if (abs_val <= 0.0f) return 0;
+    if (abs_val >= 6.0f) return 7;
+    if (abs_val < 0.25f)  return 0;
+    if (abs_val < 0.75f)  return 1;
+    if (abs_val < 1.25f)  return 2;
+    if (abs_val < 1.75f)  return 3;
+    if (abs_val < 2.5f)   return 4;
+    if (abs_val < 3.5f)   return 5;
+    if (abs_val < 5.0f)   return 6;
+    return 7;
+}
+
+// Float → UE8M0 (pure-exponent, value = 2^(bits-127), rounds up to next pow2)
+__device__ __forceinline__ uint8_t tq_fp4_float_to_ue8m0(float val) {
+    if (val <= 0.0f) return 0;
+    uint32_t fbits;
+    memcpy(&fbits, &val, sizeof(float));
+    int f_exp = static_cast<int>((fbits >> 23) & 0xFF);
+    if (fbits & 0x7FFFFF) f_exp++;
+    if (f_exp < 0) return 0;
+    if (f_exp > 254) return 254;
+    return static_cast<uint8_t>(f_exp);
+}
+
+// UE8M0 → float: value = 2^(bits - 127)
+__device__ __forceinline__ float tq_fp4_ue8m0_to_float(uint8_t bits) {
+    if (bits == 0) return 0.0f;
+    uint32_t fp32 = static_cast<uint32_t>(bits) << 23;
+    return __uint_as_float(fp32);
+}
+
+// Dequant one FP4 E2M1 nibble (4 bits: sign[3] | code[2:0]) → float
+__device__ __forceinline__ float tq_fp4_dequant_nibble(uint8_t nibble) {
+    uint8_t sign = (nibble >> 3) & 1;
+    uint8_t code = nibble & 0x7;
+    float val = kTQFP4DequantLUT[code];
+    return sign ? -val : val;
+}
+
+// Unpack + dequant low nibble (bits [3:0]) of a packed byte
+__device__ __forceinline__ float tq_fp4_unpack_lo(uint8_t packed) {
+    return tq_fp4_dequant_nibble(packed & 0xF);
+}
+
+// Unpack + dequant high nibble (bits [7:4]) of a packed byte
+__device__ __forceinline__ float tq_fp4_unpack_hi(uint8_t packed) {
+    return tq_fp4_dequant_nibble((packed >> 4) & 0xF);
+}
+
+} // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -538,9 +538,22 @@ bool Engine::init_kv_cache() {
         kv_sketch_dim = head_dim * mult;
     }
 
+    // Detect sm_120+ for MXFP4 TurboQuant: FP4 E2M1 + UE8M0 micro-scales
+    bool tq_use_mxfp4 = false;
+    if (config_.kv_cache_dtype == DType::TURBOQUANT) {
+        cudaDeviceProp prop;
+        cudaGetDeviceProperties(&prop, config_.device_id);
+        int sm_ver = prop.major * 10 + prop.minor;
+        if (sm_ver >= 120 && (head_dim % 32 == 0)) {
+            tq_use_mxfp4 = true;
+            IMP_LOG_INFO("TurboQuant: sm_%d detected, using MXFP4 FP4 E2M1 + UE8M0 for K directions", sm_ver);
+        }
+    }
+
     auto kv_cache = std::make_unique<KVCache>(
         n_kv_layers, mcfg.n_kv_heads, head_dim,
-        config_.kv_cache_dtype, max_blocks, kv_bs, &vram_alloc_, kv_sketch_dim);
+        config_.kv_cache_dtype, max_blocks, kv_bs, &vram_alloc_, kv_sketch_dim,
+        tq_use_mxfp4);
     kv_cache_raw_ = kv_cache.get();
     kv_manager_ = std::make_unique<KVCacheManager>(std::move(kv_cache));
 

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -528,9 +528,19 @@ bool Engine::init_kv_cache() {
                      n_kv_layers, mcfg.n_layers, mcfg.n_kv_heads, head_dim, kv_bs);
     }
 
+    // Compute sketch_dim for TurboQuant / TurboQuant Lite (0 for other modes)
+    int kv_sketch_dim = 0;
+    if (config_.kv_cache_dtype == DType::TURBOQUANT) {
+        kv_sketch_dim = head_dim;
+    } else if (config_.kv_cache_dtype == DType::TURBOQUANT_LITE) {
+        int mult = config_.turboquant_sketch_multiplier;
+        if (mult <= 0) mult = 2;
+        kv_sketch_dim = head_dim * mult;
+    }
+
     auto kv_cache = std::make_unique<KVCache>(
         n_kv_layers, mcfg.n_kv_heads, head_dim,
-        config_.kv_cache_dtype, max_blocks, kv_bs, &vram_alloc_);
+        config_.kv_cache_dtype, max_blocks, kv_bs, &vram_alloc_, kv_sketch_dim);
     kv_cache_raw_ = kv_cache.get();
     kv_manager_ = std::make_unique<KVCacheManager>(std::move(kv_cache));
 
@@ -546,11 +556,22 @@ bool Engine::init_kv_cache() {
 
     executor_->set_kv_layer_map(std::move(kv_layer_map));
 
-    // Initialize QJL projection for TurboQuant KV cache
-    if (config_.kv_cache_dtype == DType::TURBOQUANT) {
+    // Initialize QJL projection for TurboQuant / TurboQuant Lite KV cache
+    if (config_.kv_cache_dtype == DType::TURBOQUANT
+        || config_.kv_cache_dtype == DType::TURBOQUANT_LITE) {
         auto& qjl = executor_->qjl_projection();
-        if (!qjl_init(qjl, head_dim, head_dim, /*seed=*/42, stream_)) {
-            IMP_LOG_ERROR("Failed to initialize QJL projection for TurboQuant");
+        int sketch_dim;
+        if (config_.kv_cache_dtype == DType::TURBOQUANT_LITE) {
+            int mult = config_.turboquant_sketch_multiplier;
+            if (mult <= 0) mult = 2;
+            sketch_dim = head_dim * mult;
+            IMP_LOG_INFO("TurboQuant Lite: sketch_dim=%d (mult=%d, head_dim=%d)", sketch_dim, mult, head_dim);
+        } else {
+            sketch_dim = head_dim;  // standard TurboQuant: sketch_dim = head_dim
+        }
+        if (!qjl_init(qjl, head_dim, sketch_dim, /*seed=*/42, stream_)) {
+            IMP_LOG_ERROR("Failed to initialize QJL projection for %s",
+                          dtype_name(config_.kv_cache_dtype));
             return false;
         }
     }

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -45,6 +45,9 @@ struct EngineConfig {
     // KV cache dtype: FP16 (default) or FP8_E4M3 for ~50% KV VRAM savings
     DType kv_cache_dtype = DType::FP16;
 
+    // TurboQuant Lite: sketch_dim = turboquant_sketch_multiplier * head_dim
+    int turboquant_sketch_multiplier = 2;
+
     // SSM state dtype: FP32 (default) or FP16 for ~50% VRAM savings on h_state
     DType ssm_state_dtype = DType::FP32;
 

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -92,6 +92,13 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
         size_t sketch_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * (sketch_dim / 8);
         per_block_total += sketch_per_block * n_kv_layers;
     }
+    // MXFP4 micro-scale pool for TurboQuant K directions (sm_120 auto-detected at runtime).
+    // Budget conservatively: always include for TURBOQUANT if head_dim % 32 == 0.
+    if (is_tq && (head_dim % 32 == 0)) {
+        int n_groups = head_dim / 32;
+        size_t mscale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * n_groups;
+        per_block_total += mscale_per_block * n_kv_layers;
+    }
 
     int blocks_per_seq = (config.max_seq_len + bs - 1) / bs;
     int needed_blocks = blocks_per_seq * config.max_batch_size;

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -64,22 +64,32 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
     // --- 4. Compute KV cache per-block cost ---
     int bs = config.kv_block_size > 0 ? config.kv_block_size : kKVBlockSize;
     size_t single_block_bytes;
-    if (config.kv_cache_dtype == DType::INT4 || config.kv_cache_dtype == DType::TURBOQUANT) {
+    bool is_tq = (config.kv_cache_dtype == DType::TURBOQUANT);
+    bool is_tql = (config.kv_cache_dtype == DType::TURBOQUANT_LITE);
+    if (config.kv_cache_dtype == DType::INT4 || is_tq || is_tql) {
         single_block_bytes = static_cast<size_t>(bs) *
                              mcfg.n_kv_heads * head_dim / 2;
     } else {
         single_block_bytes = static_cast<size_t>(bs) *
                              mcfg.n_kv_heads * head_dim * dtype_size(config.kv_cache_dtype);
     }
-    size_t per_block_total = single_block_bytes * 2 * n_kv_layers;
+    // TURBOQUANT_LITE: V-only pool (1x), all others: K+V (2x)
+    size_t pool_multiplier = is_tql ? 1 : 2;
+    size_t per_block_total = single_block_bytes * pool_multiplier * n_kv_layers;
     if (config.kv_cache_dtype == DType::INT8 || config.kv_cache_dtype == DType::INT4
-        || config.kv_cache_dtype == DType::TURBOQUANT) {
+        || is_tq || is_tql) {
         size_t scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * sizeof(half);
-        per_block_total += scale_per_block * 2 * n_kv_layers;
+        per_block_total += scale_per_block * 2 * n_kv_layers;  // K norms + V scales (always 2x)
     }
-    if (config.kv_cache_dtype == DType::TURBOQUANT) {
+    if (is_tq || is_tql) {
         // QJL sketch pool: only for K (1x, not 2x)
-        size_t sketch_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * (head_dim / 8);
+        int sketch_dim = head_dim;
+        if (is_tql) {
+            int mult = config.turboquant_sketch_multiplier;
+            if (mult <= 0) mult = 2;
+            sketch_dim = head_dim * mult;
+        }
+        size_t sketch_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * (sketch_dim / 8);
         per_block_total += sketch_per_block * n_kv_layers;
     }
 

--- a/tests/test_turboquant.cu
+++ b/tests/test_turboquant.cu
@@ -324,5 +324,243 @@ TEST(TurboQuantTest, MemoryReduction) {
     EXPECT_LT(total_ratio, 0.55);  // should be well under 50% with all overhead
 }
 
+// ============================================================================
+// Test 8: TurboQuant Lite KV Cache construction — V-only pool, sketch-only K
+// ============================================================================
+TEST(TurboQuantLiteTest, CacheConstruction) {
+    SKIP_IF_NO_CUDA();
+
+    const int n_layers = 4;
+    const int n_kv_heads = 8;
+    const int head_dim = 128;
+    const int max_blocks = 16;
+    const int block_size = 16;
+    const int sketch_dim = 2 * head_dim;  // multiplier = 2
+
+    KVCache tql_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT_LITE,
+                      max_blocks, block_size, nullptr, sketch_dim);
+
+    // Block bytes should match INT4 V (same as standard INT4)
+    size_t expected_block_bytes = static_cast<size_t>(block_size) * n_kv_heads * head_dim / 2;
+    EXPECT_EQ(tql_cache.block_bytes(), expected_block_bytes);
+
+    // k_ptr should return nullptr (no K directions in pool)
+    EXPECT_EQ(tql_cache.k_ptr(0, 0), nullptr);
+
+    // v_ptr should be valid
+    EXPECT_NE(tql_cache.v_ptr(0, 0), nullptr);
+
+    // Scale pool should be allocated (K norms + V scales)
+    EXPECT_NE(tql_cache.k_scale_ptr(0, 0), nullptr);
+    EXPECT_NE(tql_cache.v_scale_ptr(0, 0), nullptr);
+
+    // Sketch pool should be allocated with larger sketch_dim
+    EXPECT_NE(tql_cache.k_sketch_ptr(0, 0), nullptr);
+
+    // Sketch block bytes: block_size * n_kv_heads * (sketch_dim / 8)
+    size_t expected_sketch_bytes = static_cast<size_t>(block_size) * n_kv_heads * (sketch_dim / 8);
+    EXPECT_EQ(tql_cache.sketch_block_bytes(), expected_sketch_bytes);
+
+    // sketch_dim accessor
+    EXPECT_EQ(tql_cache.sketch_dim(), sketch_dim);
+
+    // Block allocation works
+    int b1 = tql_cache.allocate_block();
+    EXPECT_GE(b1, 0);
+    EXPECT_EQ(tql_cache.ref_count(b1), 1);
+    tql_cache.free_block(b1);
+}
+
+// ============================================================================
+// Test 9: TurboQuant Lite V pointer offsets (V-only pool)
+// ============================================================================
+TEST(TurboQuantLiteTest, VPointerOffsets) {
+    SKIP_IF_NO_CUDA();
+
+    const int n_layers = 2;
+    const int n_kv_heads = 4;
+    const int head_dim = 64;
+    const int max_blocks = 8;
+    const int block_size = 16;
+    const int sketch_dim = 2 * head_dim;
+
+    KVCache cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT_LITE,
+                  max_blocks, block_size, nullptr, sketch_dim);
+
+    // V pointers should differ between blocks
+    void* v0_0 = cache.v_ptr(0, 0);
+    void* v0_1 = cache.v_ptr(0, 1);
+    EXPECT_NE(v0_0, v0_1);
+
+    // Stride between V blocks should equal block_bytes
+    ptrdiff_t block_stride = static_cast<char*>(v0_1) - static_cast<char*>(v0_0);
+    EXPECT_EQ(static_cast<size_t>(block_stride), cache.block_bytes());
+
+    // V pointers should differ between layers
+    void* v1_0 = cache.v_ptr(1, 0);
+    EXPECT_NE(v0_0, v1_0);
+
+    // Stride between layers should be max_blocks * block_bytes (V-only, no 2x)
+    ptrdiff_t layer_stride = static_cast<char*>(v1_0) - static_cast<char*>(v0_0);
+    EXPECT_EQ(static_cast<size_t>(layer_stride), max_blocks * cache.block_bytes());
+}
+
+// ============================================================================
+// Test 10: TurboQuant Lite memory savings vs FP16 and TurboQuant
+// ============================================================================
+TEST(TurboQuantLiteTest, MemorySavings) {
+    SKIP_IF_NO_CUDA();
+
+    const int n_layers = 32;
+    const int n_kv_heads = 8;
+    const int head_dim = 128;
+    const int max_blocks = 256;
+    const int block_size = 16;
+
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks, block_size);
+    KVCache tq_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+
+    // TQ Lite with mult=2: sketch_dim = 256
+    const int sketch_dim_lite = 2 * head_dim;
+    KVCache tql_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT_LITE,
+                      max_blocks, block_size, nullptr, sketch_dim_lite);
+
+    // TQ Lite should use less VRAM than TQ (no INT4 K directions in pool)
+    // FP16 total per block: block_bytes * 2 (K+V)
+    size_t fp16_per_block = fp16_cache.block_bytes() * 2;
+
+    // TQ per block: block_bytes * 2 (K+V INT4) + 2*scale + sketch(head_dim)
+    size_t tq_per_block = tq_cache.block_bytes() * 2
+                          + tq_cache.scale_block_bytes() * 2
+                          + tq_cache.sketch_block_bytes();
+
+    // TQ Lite per block: block_bytes * 1 (V-only INT4) + 2*scale + sketch(2*head_dim)
+    size_t tql_per_block = tql_cache.block_bytes() * 1
+                           + tql_cache.scale_block_bytes() * 2
+                           + tql_cache.sketch_block_bytes();
+
+    // TQ Lite should use less than TQ
+    EXPECT_LT(tql_per_block, tq_per_block);
+
+    // TQ Lite should use less than FP16
+    EXPECT_LT(tql_per_block, fp16_per_block);
+
+    // Compute effective bits per element (K+V combined)
+    // V: 4 bits/elem data + 16 bits/head overhead
+    // K: sketch_dim bits + 16 bits/head overhead
+    double v_bits_per_elem = 4.0 + 16.0 / head_dim;
+    double k_bits_per_elem = static_cast<double>(sketch_dim_lite) / head_dim + 16.0 / head_dim;
+    double avg_bits = (k_bits_per_elem + v_bits_per_elem) / 2.0;
+
+    // With mult=2, head_dim=128: K = 2.125, V = 4.125, avg = 3.125
+    EXPECT_GT(avg_bits, 2.5);
+    EXPECT_LT(avg_bits, 4.0);
+}
+
+// ============================================================================
+// Test 11: QJL with sketch_dim > head_dim (TQ Lite configuration)
+// ============================================================================
+TEST(TurboQuantLiteTest, QJLLargeSketchDim) {
+    SKIP_IF_NO_CUDA();
+
+    QJLProjection proj;
+    // sketch_dim = 3 * head_dim (mult=3)
+    bool ok = qjl_init(proj, /*head_dim=*/128, /*sketch_dim=*/384, /*seed=*/42);
+    ASSERT_TRUE(ok);
+
+    EXPECT_EQ(proj.head_dim, 128);
+    EXPECT_EQ(proj.sketch_dim, 384);
+    EXPECT_NE(proj.matrix, nullptr);
+
+    // Verify matrix dimensions
+    int bytes_per_row = 128 / 8;
+    size_t total_bytes = 384 * bytes_per_row;
+    std::vector<uint8_t> host_matrix(total_bytes);
+    cudaMemcpy(host_matrix.data(), proj.matrix, total_bytes, cudaMemcpyDeviceToHost);
+    cudaDeviceSynchronize();
+
+    // Verify roughly 50% ones (Rademacher distribution)
+    int ones = 0;
+    for (auto b : host_matrix) {
+        ones += __builtin_popcount(b);
+    }
+    int total_bits = static_cast<int>(total_bytes) * 8;
+    float ratio = static_cast<float>(ones) / total_bits;
+    EXPECT_GT(ratio, 0.3f);
+    EXPECT_LT(ratio, 0.7f);
+
+    qjl_destroy(proj);
+}
+
+// ============================================================================
+// Test 12: QJL dot product accuracy improves with larger sketch_dim
+// ============================================================================
+TEST(TurboQuantLiteTest, QJLAccuracyVsSketchDim) {
+    SKIP_IF_NO_CUDA();
+
+    const int head_dim = 128;
+    std::mt19937 rng(456);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+
+    // Generate random Q and K
+    std::vector<float> q(head_dim), k(head_dim);
+    for (auto& v : q) v = dist(rng);
+    for (auto& v : k) v = dist(rng);
+
+    // True dot product
+    float true_dot = 0.0f;
+    for (int i = 0; i < head_dim; i++) true_dot += q[i] * k[i];
+
+    float q_norm = 0.0f, k_norm = 0.0f;
+    for (int i = 0; i < head_dim; i++) {
+        q_norm += q[i] * q[i];
+        k_norm += k[i] * k[i];
+    }
+    q_norm = std::sqrt(q_norm);
+    k_norm = std::sqrt(k_norm);
+
+    // Test two sketch dims: head_dim (1x) vs 3*head_dim (3x)
+    // Average absolute error over multiple random projections
+    auto compute_avg_error = [&](int sketch_dim, int n_trials) {
+        double total_error = 0.0;
+        for (int trial = 0; trial < n_trials; trial++) {
+            std::mt19937 trial_rng(trial * 1000 + sketch_dim);
+            std::bernoulli_distribution bern(0.5);
+
+            std::vector<std::vector<int>> R(sketch_dim, std::vector<int>(head_dim));
+            for (int i = 0; i < sketch_dim; i++)
+                for (int j = 0; j < head_dim; j++)
+                    R[i][j] = bern(trial_rng) ? 1 : -1;
+
+            std::vector<int> sketch_q(sketch_dim), sketch_k(sketch_dim);
+            for (int i = 0; i < sketch_dim; i++) {
+                float dot_q = 0.0f, dot_k = 0.0f;
+                for (int j = 0; j < head_dim; j++) {
+                    dot_q += R[i][j] * q[j];
+                    dot_k += R[i][j] * k[j];
+                }
+                sketch_q[i] = (dot_q >= 0) ? 1 : 0;
+                sketch_k[i] = (dot_k >= 0) ? 1 : 0;
+            }
+
+            int match_count = 0;
+            for (int i = 0; i < sketch_dim; i++)
+                if (sketch_q[i] == sketch_k[i]) match_count++;
+
+            float qjl_dot = q_norm * k_norm *
+                            static_cast<float>(2 * match_count - sketch_dim) /
+                            static_cast<float>(sketch_dim);
+            total_error += std::abs(true_dot - qjl_dot);
+        }
+        return total_error / n_trials;
+    };
+
+    double error_1x = compute_avg_error(head_dim, 50);
+    double error_3x = compute_avg_error(3 * head_dim, 50);
+
+    // 3x sketch_dim should have lower average error than 1x
+    EXPECT_LT(error_3x, error_1x);
+}
+
 } // anonymous namespace
 } // namespace imp

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -35,6 +35,8 @@ void print_usage(const char* prog) {
         "  --kv-int8             Use INT8 KV cache with dp4a attention (halves KV memory)\n"
         "  --kv-int4             Use INT4 KV cache (quarters KV memory)\n"
         "  --kv-turboquant       Use TurboQuant KV cache (PolarQuant + QJL, ~3x K reduction)\n"
+        "  --kv-turboquant-lite  Use TurboQuant Lite (QJL sketch-only K, ~3 bits/elem avg)\n"
+        "  --tq-sketch-mult <n>  TQ Lite sketch multiplier (default: 2, sketch_dim = n*head_dim)\n"
         "  --ssm-fp16            Use FP16 for SSM h_state (saves ~50%% SSM VRAM)\n"
         "  --cuda-graphs         (default, no-op — graphs enabled by default)\n"
         "  --no-cuda-graphs      Disable CUDA Graph capture for decode\n"
@@ -130,6 +132,10 @@ CliArgs parse_args(int argc, char** argv) {
             args.kv_int4 = true;
         } else if (std::strcmp(arg, "--kv-turboquant") == 0) {
             args.kv_turboquant = true;
+        } else if (std::strcmp(arg, "--kv-turboquant-lite") == 0) {
+            args.kv_turboquant_lite = true;
+        } else if (std::strcmp(arg, "--tq-sketch-mult") == 0 && i + 1 < argc) {
+            args.turboquant_sketch_mult = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--ssm-fp16") == 0) {
             args.ssm_fp16 = true;
         } else if (std::strcmp(arg, "--cuda-graphs") == 0) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -37,6 +37,8 @@ struct CliArgs {
     bool kv_int8 = false;      // Use INT8 KV cache with dp4a attention
     bool kv_int4 = false;      // Use INT4 KV cache (quarter size)
     bool kv_turboquant = false; // Use TurboQuant KV cache (PolarQuant INT4 K + QJL + INT4 V)
+    bool kv_turboquant_lite = false; // Use TurboQuant Lite (QJL sketch-only K + INT4 V)
+    int turboquant_sketch_mult = 2;  // sketch_dim = mult * head_dim (for TQ Lite)
     bool ssm_fp16 = false;     // Use FP16 for SSM h_state
     bool no_cuda_graphs = false;  // Disable CUDA Graph capture for decode
     std::string chat_template = "auto";  // auto, none, chatml, llama2, llama3, nemotron, gemma

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -74,6 +74,10 @@ int main(int argc, char** argv) {
     if (args.kv_int8) config.kv_cache_dtype = IMP_DTYPE_INT8;
     if (args.kv_int4) config.kv_cache_dtype = IMP_DTYPE_INT4;
     if (args.kv_turboquant) config.kv_cache_dtype = IMP_DTYPE_TURBOQUANT;
+    if (args.kv_turboquant_lite) {
+        config.kv_cache_dtype = IMP_DTYPE_TURBOQUANT_LITE;
+        config.turboquant_sketch_multiplier = args.turboquant_sketch_mult;
+    }
     if (args.ssm_fp16) config.ssm_state_dtype = IMP_DTYPE_FP16;
     if (args.no_cuda_graphs) config.enable_cuda_graphs = 0;
     if (args.prefill_chunk_size > 0) config.prefill_chunk_size = args.prefill_chunk_size;

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -79,6 +79,10 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.kv_int4 = true;
         } else if (std::strcmp(arg, "--kv-turboquant") == 0) {
             args.kv_turboquant = true;
+        } else if (std::strcmp(arg, "--kv-turboquant-lite") == 0) {
+            args.kv_turboquant_lite = true;
+        } else if (std::strcmp(arg, "--tq-sketch-mult") == 0 && i + 1 < argc) {
+            args.turboquant_sketch_mult = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--prefill-chunk-size") == 0 && i + 1 < argc) {
             args.prefill_chunk_size = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--decode-nvfp4") == 0) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -16,6 +16,8 @@ struct ServerArgs {
     bool kv_int8 = false;
     bool kv_int4 = false;
     bool kv_turboquant = false;
+    bool kv_turboquant_lite = false;
+    int turboquant_sketch_mult = 2;
     int prefill_chunk_size = 0;
     int decode_nvfp4 = -1;     // -1=auto, 0=off, 1=additive, 2=NVFP4-only
     bool mxfp4_prefill = false;  // --mxfp4-prefill: CUTLASS MXFP4 GEMM for prefill

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -166,10 +166,15 @@ ImpConfig build_config(const ServerArgs& args, const std::string& model_path,
     bool kv_int8 = overrides.value("kv_int8", args.kv_int8);
     bool kv_int4 = overrides.value("kv_int4", args.kv_int4);
     bool kv_turboquant = overrides.value("kv_turboquant", args.kv_turboquant);
+    bool kv_turboquant_lite = overrides.value("kv_turboquant_lite", args.kv_turboquant_lite);
     if (kv_fp8) config.kv_cache_dtype = IMP_DTYPE_FP8_E4M3;
     if (kv_int8) config.kv_cache_dtype = IMP_DTYPE_INT8;
     if (kv_int4) config.kv_cache_dtype = IMP_DTYPE_INT4;
     if (kv_turboquant) config.kv_cache_dtype = IMP_DTYPE_TURBOQUANT;
+    if (kv_turboquant_lite) {
+        config.kv_cache_dtype = IMP_DTYPE_TURBOQUANT_LITE;
+        config.turboquant_sketch_multiplier = overrides.value("tq_sketch_mult", args.turboquant_sketch_mult);
+    }
 
     int chunk = overrides.value("prefill_chunk_size", args.prefill_chunk_size);
     // Default to 512-token chunks in server mode so prefill doesn't block decode


### PR DESCRIPTION
Introduces TURBOQUANT_LITE mode where Keys are stored purely as QJL
(Quantized Johnson-Lindenstrauss) 1-bit sketches + FP16 norms, eliminating
the INT4 PolarQuant direction data. Values remain INT4 with per-head scales.

This achieves true sub-4-bit KV cache compression:
- sketch_mult=2 (default): ~3.1 bits/elem avg (K=2.1, V=4.1)
- sketch_mult=3: ~3.6 bits/elem avg (K=3.1, V=4.1)

Key changes:
- New DType TURBOQUANT_LITE (types.h, tensor.h/cpp)
- KV cache V-only pool layout (1x instead of 2x) with larger sketch pool
- Configurable sketch_dim = multiplier * head_dim via --tq-sketch-mult
- QJL-only paged attention kernel (no PolarQuant fallback)
- Dedicated write kernel (norm + sketch for K, INT4 for V)
- VRAM budget accounting for asymmetric K/V storage
- CLI: --kv-turboquant-lite, --tq-sketch-mult <n>
- 5 new GTest cases covering cache layout, memory savings, QJL accuracy

https://claude.ai/code/session_012Q6iJ9zEjA6TE55mYaqj77