### PR TITLE
feat: MXFP4 tensor core prefill attention for sm_120 (Blackwell)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ if(IMP_USE_CUTLASS)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/gemm_cutlass_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/gemm_cutlass_mxfp4_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_cutlass_fmha.cu)
+    list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxfp4_prefill.cu)
 endif()
 
 set(IMP_RUNTIME_SOURCES
@@ -329,6 +330,7 @@ if(IMP_BUILD_TESTS)
         tests/test_tokenizer.cpp
         tests/test_chat_template.cpp
         tests/test_hadamard.cu
+        tests/test_attention_mxfp4.cu
     )
 
     add_executable(imp-tests ${IMP_TEST_SOURCES})

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -6,6 +6,7 @@
 
 #ifdef IMP_USE_CUTLASS
 #include "compute/attention_cutlass_fmha.h"
+#include "compute/attention_mxfp4_prefill.h"
 #endif
 
 namespace imp {
@@ -29,13 +30,23 @@ void attention_prefill_dispatch(
     float scale, bool causal, int sliding_window, float softcap, cudaStream_t stream) {
     int sm = get_device_sm_version();
 #ifdef IMP_USE_CUTLASS
+    // sliding_window that covers entire seq_kv doesn't restrict attention
+    int seq_kv = static_cast<int>(K.shape[1]);
+    bool sw_active = (sliding_window > 0 && sliding_window < seq_kv);
+
+    // MXFP4 tensor core attention: block-scaled FP4 Q·K^T on sm_120+.
+    // ~2x compute throughput over FP16 TC. Enabled with IMP_MXFP4_ATTENTION=1.
+    // Uses O(seq²) memory — falls back for long sequences or unsupported configs.
+    if (attention_mxfp4_available() && sm >= 120 && !sw_active) {
+        if (attention_mxfp4_prefill(Q, K, V, O, scale, causal, softcap, stream)) {
+            return;
+        }
+    }
+
     // CUTLASS FMHA: WGMMA + TMA on sm_90+. ~2x throughput vs WMMA.
     // Supports softcap (Gemma-2/3). Not supported: sliding window (Mistral).
     // Set IMP_NO_CUTLASS_FMHA=1 to force WMMA fallback (for benchmarking).
     static bool use_cutlass = !getenv("IMP_NO_CUTLASS_FMHA");
-    // sliding_window that covers entire seq_kv doesn't restrict attention
-    int seq_kv = static_cast<int>(K.shape[1]);
-    bool sw_active = (sliding_window > 0 && sliding_window < seq_kv);
     if (use_cutlass && sm >= 90 && !sw_active) {
         if (cutlass_fmha_prefill(Q, K, V, O, scale, causal, softcap, stream)) {
             return;

--- a/src/compute/attention_mxfp4_prefill.cu
+++ b/src/compute/attention_mxfp4_prefill.cu
@@ -1,0 +1,499 @@
+// =============================================================================
+// attention_mxfp4_prefill.cu -- MXFP4 tensor core prefill attention (sm_120)
+// =============================================================================
+//
+// Uses CUTLASS block-scaled MXFP4×MXFP4 GEMM for Q·K^T, providing ~2x
+// compute throughput over FP16 tensor cores on Blackwell's 5th-gen TCs.
+// P·V uses cuBLAS FP16 GEMM (compute-light, memory-heavy).
+//
+// Pipeline per (batch, head):
+//   1. Quantize K [seq_kv, hd] → MXFP4  (once per KV head, reused for GQA)
+//   2. Quantize Q [seq_q, hd]  → MXFP4  (per Q head)
+//   3. CUTLASS MXFP4 GEMM: S [seq_q, seq_kv] = Q_mxfp4 @ K_mxfp4^T
+//   4. Fused scale + softcap + causal mask + softmax (in-place on S)
+//   5. cuBLAS FP16 GEMM: O [seq_q, hd] = P @ V
+//
+// Decode path is unaffected — GEMV is memory-bound, scalar dequant suffices.
+// =============================================================================
+
+#include "compute/attention_mxfp4_prefill.h"
+#include "compute/gemm_cutlass_mxfp4_sm120.h"
+#include "core/logging.h"
+
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cassert>
+#include <cfloat>
+#include <cstdlib>
+#include <mutex>
+
+namespace imp {
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+static constexpr int kMxGroupSize  = 32;   // MXFP4 UE8M0 scale group size
+static constexpr int kAtomRows     = 128;
+static constexpr int kAtomKGroups  = 4;
+static constexpr int kAtomKElems   = kMxGroupSize * kAtomKGroups;  // 128
+static constexpr int kAtomSize     = kAtomRows * kAtomKGroups;     // 512
+
+// Maximum S matrix size per head. Beyond this, fall back to flash attention.
+static constexpr size_t kMaxSBytesPerHead = 256ULL * 1024 * 1024;  // 256 MiB
+
+#if IMP_CUDA_13_1
+static constexpr auto kGemmAlgo = CUBLAS_GEMM_AUTOTUNE;
+#else
+static constexpr auto kGemmAlgo = CUBLAS_GEMM_DEFAULT;
+#endif
+
+// =============================================================================
+// Device helpers (self-contained — no cross-TU __device__ linkage)
+// =============================================================================
+
+__device__ __forceinline__ uint8_t mxfp4_float_to_ue8m0(float val) {
+    if (val <= 0.0f) return 0;
+    uint32_t fbits;
+    memcpy(&fbits, &val, sizeof(float));
+    int f_exp = (int)((fbits >> 23) & 0xFF);
+    if (fbits & 0x7FFFFF) f_exp++;
+    if (f_exp < 0) return 0;
+    if (f_exp > 254) return 254;
+    return (uint8_t)f_exp;
+}
+
+__device__ __forceinline__ float mxfp4_ue8m0_to_float(uint8_t bits) {
+    if (bits == 0) return 5.877472e-39f;  // 2^-127
+    uint32_t fp32 = ((uint32_t)bits) << 23;
+    return __uint_as_float(fp32);
+}
+
+__device__ __forceinline__ uint8_t mxfp4_quantize_abs(float abs_val) {
+    if (abs_val <= 0.0f)  return 0;
+    if (abs_val >= 6.0f)  return 7;
+    if (abs_val < 0.25f)  return 0;
+    if (abs_val < 0.75f)  return 1;
+    if (abs_val < 1.25f)  return 2;
+    if (abs_val < 1.75f)  return 3;
+    if (abs_val < 2.5f)   return 4;
+    if (abs_val < 3.5f)   return 5;
+    if (abs_val < 5.0f)   return 6;
+    return 7;
+}
+
+__device__ __forceinline__
+int mxfp4_sfatom_offset(int row, int k_group, int n_k_tiles) {
+    int tile_row  = row / kAtomRows;
+    int tile_k    = k_group / kAtomKGroups;
+    int row_local = row % kAtomRows;
+    int k_local   = k_group % kAtomKGroups;
+    int n0 = row_local % 32;
+    int n1 = row_local / 32;
+    int atom_offset = n0 * 16 + n1 * 4 + k_local;
+    int tile_base   = (tile_row * n_k_tiles + tile_k) * kAtomSize;
+    return tile_base + atom_offset;
+}
+
+// =============================================================================
+// Strided MXFP4 quantization kernel
+// =============================================================================
+//
+// Reads FP16 data with arbitrary row stride (for per-head access in
+// [seq, n_heads*hd] layout), outputs contiguous MXFP4 packed + SfAtom.
+// Each thread processes one group of 32 elements.
+
+__global__ void quantize_fp16_mxfp4_strided_kernel(
+    const half* __restrict__ input,
+    int input_row_stride,                   // in half elements, not bytes
+    uint8_t*    __restrict__ packed_out,     // [M, K/2] contiguous
+    uint8_t*    __restrict__ sf_out,         // SfAtom layout UE8M0
+    int M, int K, int n_k_tiles)
+{
+    int mb_idx   = blockIdx.x * blockDim.x + threadIdx.x;
+    int K_groups = K / kMxGroupSize;
+    int total_mb = M * K_groups;
+    if (mb_idx >= total_mb) return;
+
+    int row     = mb_idx / K_groups;
+    int k_group = mb_idx % K_groups;
+    int base    = row * input_row_stride + k_group * kMxGroupSize;
+
+    // Load 32 FP16 values, track absmax
+    float vals[32];
+    float local_absmax = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 32; i++) {
+        vals[i] = __half2float(input[base + i]);
+        float av = fabsf(vals[i]);
+        if (av > local_absmax) local_absmax = av;
+    }
+
+    // UE8M0 scale = ceil_pow2(absmax / 6.0)
+    uint8_t ue8m0 = mxfp4_float_to_ue8m0(local_absmax / 6.0f);
+    float actual_scale = mxfp4_ue8m0_to_float(ue8m0);
+    if (actual_scale == 0.0f) actual_scale = 5.877472e-39f;
+    float inv_scale = 1.0f / actual_scale;
+
+    // Write scale to SfAtom position
+    sf_out[mxfp4_sfatom_offset(row, k_group, n_k_tiles)] = ue8m0;
+
+    // Pack E2M1 nibbles (output is contiguous [M, K/2])
+    int packed_base = row * (K / 2) + k_group * (kMxGroupSize / 2);
+    #pragma unroll
+    for (int i = 0; i < 32; i += 2) {
+        float s0 = vals[i] * inv_scale;
+        uint8_t sign0 = (s0 < 0.0f) ? 1u : 0u;
+        uint8_t fp4_0 = (sign0 << 3) | mxfp4_quantize_abs(fabsf(s0));
+
+        float s1 = vals[i + 1] * inv_scale;
+        uint8_t sign1 = (s1 < 0.0f) ? 1u : 0u;
+        uint8_t fp4_1 = (sign1 << 3) | mxfp4_quantize_abs(fabsf(s1));
+
+        packed_out[packed_base + i / 2] = (fp4_1 << 4) | fp4_0;
+    }
+}
+
+// =============================================================================
+// Fused scale + softcap + causal mask + softmax (in-place on FP16 S matrix)
+// =============================================================================
+//
+// One block per query row. 3-pass online softmax (max, exp+sum, normalize).
+
+__global__ void mxfp4_attn_softmax_kernel(
+    half* __restrict__ S,
+    int seq_q, int seq_kv,
+    int q_offset,           // global Q position offset (for causal masking)
+    float scale, float softcap, bool causal)
+{
+    int row = blockIdx.x;
+    int tid = threadIdx.x;
+    int n_warps = blockDim.x / 32;
+    int warp_id = tid / 32;
+    int lane_id = tid % 32;
+
+    half* row_ptr = S + (int64_t)row * seq_kv;
+    int gq = q_offset + row;
+
+    // --- Pass 1: row max ---
+    float max_val = -FLT_MAX;
+    for (int j = tid; j < seq_kv; j += blockDim.x) {
+        float val;
+        if (causal && j > gq) {
+            val = -FLT_MAX;
+        } else {
+            val = __half2float(row_ptr[j]) * scale;
+            if (softcap > 0.0f) val = softcap * tanhf(val / softcap);
+        }
+        max_val = fmaxf(max_val, val);
+    }
+
+    // Warp-shuffle + cross-warp reduction
+    for (int mask = 16; mask > 0; mask >>= 1)
+        max_val = fmaxf(max_val, __shfl_xor_sync(0xffffffff, max_val, mask));
+    __shared__ float s_reduce[32];
+    if (lane_id == 0) s_reduce[warp_id] = max_val;
+    __syncthreads();
+    if (tid < 32) {
+        float v = (tid < n_warps) ? s_reduce[tid] : -FLT_MAX;
+        for (int mask = 16; mask > 0; mask >>= 1)
+            v = fmaxf(v, __shfl_xor_sync(0xffffffff, v, mask));
+        s_reduce[0] = v;
+    }
+    __syncthreads();
+    max_val = s_reduce[0];
+
+    // --- Pass 2: exp + sum ---
+    float sum_val = 0.0f;
+    for (int j = tid; j < seq_kv; j += blockDim.x) {
+        float val;
+        if (causal && j > gq) {
+            val = 0.0f;
+        } else {
+            val = __half2float(row_ptr[j]) * scale;
+            if (softcap > 0.0f) val = softcap * tanhf(val / softcap);
+            val = expf(val - max_val);
+        }
+        sum_val += val;
+    }
+
+    for (int mask = 16; mask > 0; mask >>= 1)
+        sum_val += __shfl_xor_sync(0xffffffff, sum_val, mask);
+    if (lane_id == 0) s_reduce[warp_id] = sum_val;
+    __syncthreads();
+    if (tid < 32) {
+        float v = (tid < n_warps) ? s_reduce[tid] : 0.0f;
+        for (int mask = 16; mask > 0; mask >>= 1)
+            v += __shfl_xor_sync(0xffffffff, v, mask);
+        s_reduce[0] = v;
+    }
+    __syncthreads();
+    float inv_sum = (s_reduce[0] > 0.0f) ? (1.0f / s_reduce[0]) : 0.0f;
+
+    // --- Pass 3: normalize and write FP16 ---
+    for (int j = tid; j < seq_kv; j += blockDim.x) {
+        float val;
+        if (causal && j > gq) {
+            val = 0.0f;
+        } else {
+            val = __half2float(row_ptr[j]) * scale;
+            if (softcap > 0.0f) val = softcap * tanhf(val / softcap);
+            val = expf(val - max_val) * inv_sum;
+        }
+        row_ptr[j] = __float2half(val);
+    }
+}
+
+// =============================================================================
+// Static workspace
+// =============================================================================
+
+struct MxFP4AttnWorkspace {
+    void* q_packed = nullptr;       // [max_seq_q, hd/2]
+    void* q_sf     = nullptr;       // SfAtom for Q
+    void* k_packed = nullptr;       // [max_seq_kv, hd/2]
+    void* k_sf     = nullptr;       // SfAtom for K
+    void* s_matrix = nullptr;       // [max_seq_q, max_seq_kv] FP16
+    void* gemm_ws  = nullptr;
+    size_t gemm_ws_size = 0;
+    int alloc_seq_q  = 0;
+    int alloc_seq_kv = 0;
+    int alloc_hd     = 0;
+};
+
+static MxFP4AttnWorkspace s_ws;
+static std::mutex s_ws_mutex;
+
+static void ensure_workspace(int seq_q, int seq_kv, int hd) {
+    std::lock_guard<std::mutex> lock(s_ws_mutex);
+    if (seq_q <= s_ws.alloc_seq_q &&
+        seq_kv <= s_ws.alloc_seq_kv &&
+        hd <= s_ws.alloc_hd)
+        return;
+
+    // Free existing
+    auto safe_free = [](void*& p) { if (p) { cudaFree(p); p = nullptr; } };
+    safe_free(s_ws.q_packed);
+    safe_free(s_ws.q_sf);
+    safe_free(s_ws.k_packed);
+    safe_free(s_ws.k_sf);
+    safe_free(s_ws.s_matrix);
+    safe_free(s_ws.gemm_ws);
+
+    size_t q_packed_bytes = (size_t)seq_q  * (hd / 2);
+    size_t k_packed_bytes = (size_t)seq_kv * (hd / 2);
+    size_t q_sf_bytes = cutlass_mxfp4_sf_size(seq_q, hd);
+    size_t k_sf_bytes = cutlass_mxfp4_sf_size(seq_kv, hd);
+    size_t s_bytes = (size_t)seq_q * seq_kv * sizeof(half);
+
+    cudaMalloc(&s_ws.q_packed, q_packed_bytes);
+    cudaMalloc(&s_ws.q_sf,     q_sf_bytes);
+    cudaMalloc(&s_ws.k_packed, k_packed_bytes);
+    cudaMalloc(&s_ws.k_sf,     k_sf_bytes);
+    cudaMalloc(&s_ws.s_matrix, s_bytes);
+
+    size_t gws = gemm_mxfp4_cutlass_sm120_workspace(seq_q, seq_kv, hd);
+    if (gws > 0) {
+        cudaMalloc(&s_ws.gemm_ws, gws);
+        s_ws.gemm_ws_size = gws;
+    }
+
+    s_ws.alloc_seq_q  = seq_q;
+    s_ws.alloc_seq_kv = seq_kv;
+    s_ws.alloc_hd     = hd;
+
+    IMP_LOG_DEBUG("MXFP4 attn workspace: sq=%d skv=%d hd=%d S=%.1f MiB",
+                  seq_q, seq_kv, hd, s_bytes / (1024.0 * 1024.0));
+}
+
+// =============================================================================
+// cuBLAS handle (separate from gemm.cu to avoid TU coupling)
+// =============================================================================
+
+static cublasHandle_t get_cublas() {
+    static cublasHandle_t h = nullptr;
+    if (!h) {
+        cublasCreate(&h);
+        cublasSetMathMode(h, CUBLAS_TF32_TENSOR_OP_MATH);
+    }
+    return h;
+}
+
+// =============================================================================
+// Main entry point
+// =============================================================================
+
+bool attention_mxfp4_prefill(
+    const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
+    float scale, bool causal, float softcap, cudaStream_t stream)
+{
+    // --- Extract dimensions ---
+    const int batch    = static_cast<int>(Q.shape[0]);
+    const int seq_q    = static_cast<int>(Q.shape[1]);
+    const int n_heads  = static_cast<int>(Q.shape[2]);
+    const int hd       = static_cast<int>(Q.shape[3]);
+    const int seq_kv   = static_cast<int>(K.shape[1]);
+    const int n_kv     = static_cast<int>(K.shape[2]);
+
+    // --- Validate ---
+    if (hd % kMxGroupSize != 0) return false;
+    if (seq_q == 0 || seq_kv == 0) return false;
+    if (!cutlass_sm120_mxfp4_available()) return false;
+
+    size_t s_bytes = (size_t)seq_q * seq_kv * sizeof(half);
+    if (s_bytes > kMaxSBytesPerHead) {
+        IMP_LOG_DEBUG("MXFP4 attn: S too large (%zu MiB), falling back",
+                      s_bytes >> 20);
+        return false;
+    }
+
+    ensure_workspace(seq_q, seq_kv, hd);
+
+    const int gqa_ratio    = n_heads / n_kv;
+    const int q_row_stride = n_heads * hd;
+    const int kv_row_stride = n_kv * hd;
+
+    // Quantization grid
+    const int K_groups   = hd / kMxGroupSize;
+    const int n_k_tiles  = (hd + kAtomKElems - 1) / kAtomKElems;
+    const int q_total_mb = seq_q * K_groups;
+    const int k_total_mb = seq_kv * K_groups;
+    const int q_blocks   = (q_total_mb + 255) / 256;
+    const int k_blocks   = (k_total_mb + 255) / 256;
+
+    size_t q_sf_bytes = cutlass_mxfp4_sf_size(seq_q, hd);
+    size_t k_sf_bytes = cutlass_mxfp4_sf_size(seq_kv, hd);
+
+    // cuBLAS for P·V
+    cublasHandle_t cublas = get_cublas();
+    cublasSetStream(cublas, stream);
+
+    // Reusable K weight descriptor for CUTLASS GEMM
+    CutlassMxFP4Weight k_weight;
+    k_weight.data          = s_ws.k_packed;
+    k_weight.scale_factors = s_ws.k_sf;
+    k_weight.tensor_scale  = 1.0f;   // scales absorbed in UE8M0
+    k_weight.N             = seq_kv;
+    k_weight.K             = hd;
+    k_weight.sf_bytes      = k_sf_bytes;
+
+    half* S = static_cast<half*>(s_ws.s_matrix);
+
+    const half* Q_base = static_cast<const half*>(Q.data);
+    const half* K_base = static_cast<const half*>(K.data);
+    const half* V_base = static_cast<const half*>(V.data);
+    half*       O_base = static_cast<half*>(O.data);
+
+    // Softmax thread count heuristic
+    int sm_threads = (seq_kv <= 128) ? 128 :
+                     (seq_kv <= 256) ? 256 :
+                     (seq_kv <= 512) ? 512 : 1024;
+
+    float one = 1.0f, zero = 0.0f;
+
+    for (int b = 0; b < batch; b++) {
+        const half* Q_b = Q_base + (int64_t)b * seq_q  * q_row_stride;
+        const half* K_b = K_base + (int64_t)b * seq_kv * kv_row_stride;
+        const half* V_b = V_base + (int64_t)b * seq_kv * kv_row_stride;
+        half*       O_b = O_base + (int64_t)b * seq_q  * q_row_stride;
+
+        for (int g = 0; g < n_kv; g++) {
+            // ---- Quantize K for this KV head ----
+            const half* K_head = K_b + g * hd;
+
+            cudaMemsetAsync(s_ws.k_sf, 0, k_sf_bytes, stream);
+            quantize_fp16_mxfp4_strided_kernel<<<k_blocks, 256, 0, stream>>>(
+                K_head, kv_row_stride,
+                static_cast<uint8_t*>(s_ws.k_packed),
+                static_cast<uint8_t*>(s_ws.k_sf),
+                seq_kv, hd, n_k_tiles);
+
+            // ---- Process each Q head in this GQA group ----
+            for (int h_local = 0; h_local < gqa_ratio; h_local++) {
+                int h = g * gqa_ratio + h_local;
+
+                // Quantize Q for this head
+                const half* Q_head = Q_b + h * hd;
+                cudaMemsetAsync(s_ws.q_sf, 0, q_sf_bytes, stream);
+                quantize_fp16_mxfp4_strided_kernel<<<q_blocks, 256, 0, stream>>>(
+                    Q_head, q_row_stride,
+                    static_cast<uint8_t*>(s_ws.q_packed),
+                    static_cast<uint8_t*>(s_ws.q_sf),
+                    seq_q, hd, n_k_tiles);
+
+                // MXFP4 GEMM: S[seq_q, seq_kv] = Q_mxfp4 @ K_mxfp4^T
+                bool ok = gemm_mxfp4_cutlass_sm120(
+                    s_ws.q_packed, s_ws.q_sf,
+                    k_weight,
+                    S, seq_q, seq_kv, hd,
+                    s_ws.gemm_ws, s_ws.gemm_ws_size,
+                    stream);
+                if (!ok) {
+                    IMP_LOG_WARN("MXFP4 attn GEMM failed (b=%d h=%d)", b, h);
+                    return false;
+                }
+
+                // Scale + softcap + causal mask + softmax
+                mxfp4_attn_softmax_kernel<<<seq_q, sm_threads, 0, stream>>>(
+                    S, seq_q, seq_kv, /*q_offset=*/0,
+                    scale, softcap, causal);
+
+                // P·V via cuBLAS: O[seq_q, hd] = S[seq_q, seq_kv] @ V[seq_kv, hd]
+                //
+                // cuBLAS column-major view (D = A @ B):
+                //   A = V^T : [hd, seq_kv],  ld = kv_row_stride
+                //   B = S^T : [seq_kv, seq_q], ld = seq_kv
+                //   D = O^T : [hd, seq_q],  ld = q_row_stride
+                const half* V_head = V_b + g * hd;
+                half*       O_head = O_b + h * hd;
+
+                cublasGemmEx(
+                    cublas,
+                    CUBLAS_OP_N, CUBLAS_OP_N,
+                    hd,       // M
+                    seq_q,    // N
+                    seq_kv,   // K
+                    &one,
+                    V_head, CUDA_R_16F, kv_row_stride,
+                    S,      CUDA_R_16F, seq_kv,
+                    &zero,
+                    O_head, CUDA_R_16F, q_row_stride,
+                    CUBLAS_COMPUTE_32F,
+                    kGemmAlgo);
+            }
+        }
+    }
+
+    return true;
+}
+
+bool attention_mxfp4_available() {
+    static int result = -1;
+    if (result >= 0) return result != 0;
+
+    if (!getenv("IMP_MXFP4_ATTENTION")) {
+        result = 0;
+        return false;
+    }
+    if (!cutlass_sm120_mxfp4_available()) {
+        result = 0;
+        return false;
+    }
+
+    result = 1;
+    IMP_LOG_INFO("MXFP4 tensor core attention enabled for prefill");
+    return true;
+}
+
+size_t attention_mxfp4_workspace_estimate(int seq_q, int seq_kv, int hd) {
+    size_t q_packed = (size_t)seq_q  * (hd / 2);
+    size_t q_sf     = cutlass_mxfp4_sf_size(seq_q, hd);
+    size_t k_packed = (size_t)seq_kv * (hd / 2);
+    size_t k_sf     = cutlass_mxfp4_sf_size(seq_kv, hd);
+    size_t s_matrix = (size_t)seq_q * seq_kv * sizeof(half);
+    return q_packed + q_sf + k_packed + k_sf + s_matrix + (1 << 20);
+}
+
+} // namespace imp

--- a/src/compute/attention_mxfp4_prefill.h
+++ b/src/compute/attention_mxfp4_prefill.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "core/tensor.h"
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace imp {
+
+// MXFP4 tensor core attention for prefill on sm_120 (Blackwell).
+//
+// Uses CUTLASS block-scaled MXFP4×MXFP4 GEMM for Q·K^T, giving ~2x
+// throughput over FP16 tensor cores on Blackwell's 5th-gen Tensor Cores.
+// P·V uses standard cuBLAS FP16 GEMM.
+//
+// This is "chunked" attention — it materializes the full S = Q·K^T score
+// matrix per head, so memory usage is O(seq²). For long sequences, flash
+// attention (attention_blackwell.cu) is the better choice.
+// The decode path remains scalar software-dequant (GEMV is memory-bound).
+//
+// Q:  [batch, seq_q, n_heads, head_dim]     FP16
+// K:  [batch, seq_kv, n_kv_heads, head_dim] FP16
+// V:  [batch, seq_kv, n_kv_heads, head_dim] FP16
+// O:  [batch, seq_q, n_heads, head_dim]     FP16
+//
+// Requirements:
+//   - sm_120+ (Blackwell block-scaled tensor cores)
+//   - head_dim must be multiple of 32 (MXFP4 group size)
+//   - IMP_USE_CUTLASS enabled at compile time
+//   - IMP_MXFP4_ATTENTION=1 environment variable at runtime
+//
+// Returns false if the configuration is unsupported or GEMM fails.
+bool attention_mxfp4_prefill(
+    const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
+    float scale, bool causal, float softcap, cudaStream_t stream);
+
+// Check if MXFP4 attention is available and enabled.
+bool attention_mxfp4_available();
+
+// Workspace estimate for VRAM budget planning.
+size_t attention_mxfp4_workspace_estimate(int seq_q, int seq_kv, int head_dim);
+
+} // namespace imp

--- a/tests/test_attention_mxfp4.cu
+++ b/tests/test_attention_mxfp4.cu
@@ -1,0 +1,370 @@
+// Test for MXFP4 tensor core prefill attention (sm_120).
+//
+// Tests the quantize → MXFP4 GEMM → softmax → P·V pipeline against
+// a reference FP16 attention implementation. Since MXFP4 quantizes
+// to 4 bits, we expect larger error than FP16 but correct behavior.
+
+#include <gtest/gtest.h>
+#include "compute/attention_mxfp4_prefill.h"
+#include "compute/attention.h"
+#include "compute/attention_tc.h"
+#include "core/tensor.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <vector>
+#include <cmath>
+#include <cstdlib>
+
+namespace imp {
+namespace {
+
+class AttentionMxFP4Test : public ::testing::Test {
+protected:
+    void SetUp() override {
+        cudaStreamCreate(&stream_);
+
+        // Check SM version
+        int device = 0;
+        cudaGetDevice(&device);
+        int major = 0, minor = 0;
+        cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
+        cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device);
+        sm_ = major * 10 + minor;
+    }
+    void TearDown() override {
+        cudaStreamDestroy(stream_);
+    }
+
+    bool can_run() const {
+        return sm_ >= 120 && cutlass_sm120_mxfp4_available();
+    }
+
+    cudaStream_t stream_ = nullptr;
+    int sm_ = 0;
+};
+
+// Helper: create random FP16 data on device
+static void fill_random_fp16(void* d_ptr, size_t n, float amp, unsigned seed) {
+    std::vector<half> h(n);
+    for (size_t i = 0; i < n; i++) {
+        // Simple deterministic pseudo-random
+        seed = seed * 1103515245u + 12345u;
+        float val = amp * (static_cast<float>((seed >> 16) & 0x7FFF) / 16384.0f - 1.0f);
+        h[i] = __float2half(val);
+    }
+    cudaMemcpy(d_ptr, h.data(), n * sizeof(half), cudaMemcpyHostToDevice);
+}
+
+// Helper: compute max absolute error and mean absolute error
+static void compute_errors(const half* ref, const half* test, size_t n,
+                           float& max_err, float& mean_err) {
+    max_err = 0.0f;
+    double sum_err = 0.0;
+    for (size_t i = 0; i < n; i++) {
+        float r = __half2float(ref[i]);
+        float t = __half2float(test[i]);
+        float err = std::abs(r - t);
+        if (err > max_err) max_err = err;
+        sum_err += err;
+    }
+    mean_err = static_cast<float>(sum_err / n);
+}
+
+TEST_F(AttentionMxFP4Test, AvailabilityReflectsSM) {
+    // MXFP4 attention requires sm_120+ and CUTLASS
+    if (sm_ < 120) {
+        EXPECT_FALSE(cutlass_sm120_mxfp4_available());
+    }
+    // Note: attention_mxfp4_available() also checks the env var,
+    // so we test the CUTLASS availability directly here.
+}
+
+TEST_F(AttentionMxFP4Test, BasicPrefill) {
+    if (!can_run()) {
+        GTEST_SKIP() << "MXFP4 attention requires sm_120+ with CUTLASS";
+    }
+
+    // batch=1, seq=128, heads=2, head_dim=64
+    const int B = 1, SQ = 128, SKV = 128, NH = 2, NKV = 2, HD = 64;
+    size_t qo_elems = B * SQ * NH * HD;
+    size_t kv_elems = B * SKV * NKV * HD;
+
+    void *d_q, *d_k, *d_v, *d_o;
+    cudaMalloc(&d_q, qo_elems * sizeof(half));
+    cudaMalloc(&d_k, kv_elems * sizeof(half));
+    cudaMalloc(&d_v, kv_elems * sizeof(half));
+    cudaMalloc(&d_o, qo_elems * sizeof(half));
+
+    fill_random_fp16(d_q, qo_elems, 0.5f, 42);
+    fill_random_fp16(d_k, kv_elems, 0.5f, 123);
+    fill_random_fp16(d_v, kv_elems, 0.5f, 456);
+    cudaMemset(d_o, 0, qo_elems * sizeof(half));
+
+    int64_t qo_shape[] = {B, SQ, NH, HD};
+    int64_t kv_shape[] = {B, SKV, NKV, HD};
+    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
+    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
+    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+
+    float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+
+    bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, /*causal=*/true,
+                                       /*softcap=*/0.0f, stream_);
+    cudaStreamSynchronize(stream_);
+
+    ASSERT_TRUE(ok) << "MXFP4 attention returned false";
+
+    cudaError_t err = cudaGetLastError();
+    EXPECT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
+
+    // Check output has finite non-zero values
+    std::vector<half> h_o(qo_elems);
+    cudaMemcpy(h_o.data(), d_o, qo_elems * sizeof(half), cudaMemcpyDeviceToHost);
+
+    int finite_nonzero = 0;
+    for (auto& v : h_o) {
+        float fv = __half2float(v);
+        EXPECT_TRUE(std::isfinite(fv)) << "Non-finite value in output";
+        if (fv != 0.0f) finite_nonzero++;
+    }
+    EXPECT_GT(finite_nonzero, 0) << "All-zero output";
+
+    cudaFree(d_q); cudaFree(d_k); cudaFree(d_v); cudaFree(d_o);
+}
+
+TEST_F(AttentionMxFP4Test, CompareWithFP16Reference) {
+    if (!can_run()) {
+        GTEST_SKIP() << "MXFP4 attention requires sm_120+ with CUTLASS";
+    }
+
+    // Compare MXFP4 output with FP16 Blackwell kernel output
+    const int B = 1, SQ = 64, SKV = 64, NH = 2, NKV = 2, HD = 64;
+    size_t qo_elems = B * SQ * NH * HD;
+    size_t kv_elems = B * SKV * NKV * HD;
+
+    void *d_q, *d_k, *d_v, *d_o_mxfp4, *d_o_ref;
+    cudaMalloc(&d_q, qo_elems * sizeof(half));
+    cudaMalloc(&d_k, kv_elems * sizeof(half));
+    cudaMalloc(&d_v, kv_elems * sizeof(half));
+    cudaMalloc(&d_o_mxfp4, qo_elems * sizeof(half));
+    cudaMalloc(&d_o_ref, qo_elems * sizeof(half));
+
+    fill_random_fp16(d_q, qo_elems, 0.3f, 789);
+    fill_random_fp16(d_k, kv_elems, 0.3f, 101);
+    fill_random_fp16(d_v, kv_elems, 0.3f, 202);
+
+    int64_t qo_shape[] = {B, SQ, NH, HD};
+    int64_t kv_shape[] = {B, SKV, NKV, HD};
+    float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+
+    // MXFP4 path
+    {
+        cudaMemset(d_o_mxfp4, 0, qo_elems * sizeof(half));
+        Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
+        Tensor K(d_k, DType::FP16, 4, kv_shape, true);
+        Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+        Tensor O(d_o_mxfp4, DType::FP16, 4, qo_shape, true);
+        bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
+        ASSERT_TRUE(ok);
+    }
+
+    // FP16 reference (Blackwell or TC kernel)
+    {
+        cudaMemset(d_o_ref, 0, qo_elems * sizeof(half));
+        Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
+        Tensor K(d_k, DType::FP16, 4, kv_shape, true);
+        Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+        Tensor O(d_o_ref, DType::FP16, 4, qo_shape, true);
+        if (sm_ >= 120) {
+            flash_attention_blackwell(Q, K, V, O, scale, true, 0, 0.0f, stream_);
+        } else {
+            flash_attention_prefill_tc(Q, K, V, O, scale, true, 0, 0.0f, stream_);
+        }
+    }
+
+    cudaStreamSynchronize(stream_);
+    cudaError_t err = cudaGetLastError();
+    ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
+
+    // Compare outputs — MXFP4 has quantization error so allow generous tolerance
+    std::vector<half> h_mxfp4(qo_elems), h_ref(qo_elems);
+    cudaMemcpy(h_mxfp4.data(), d_o_mxfp4, qo_elems * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_ref.data(), d_o_ref, qo_elems * sizeof(half), cudaMemcpyDeviceToHost);
+
+    float max_err, mean_err;
+    compute_errors(h_ref.data(), h_mxfp4.data(), qo_elems, max_err, mean_err);
+
+    // FP4 quantization gives roughly 1-2 bits of mantissa, so expect ~10-20%
+    // relative error in attention output. Use generous absolute thresholds.
+    EXPECT_LT(mean_err, 0.1f) << "Mean absolute error too large";
+    EXPECT_LT(max_err, 0.5f) << "Max absolute error too large";
+
+    printf("  MXFP4 vs FP16 attention: max_err=%.4f mean_err=%.6f\n",
+           max_err, mean_err);
+
+    cudaFree(d_q); cudaFree(d_k); cudaFree(d_v);
+    cudaFree(d_o_mxfp4); cudaFree(d_o_ref);
+}
+
+TEST_F(AttentionMxFP4Test, GQASupport) {
+    if (!can_run()) {
+        GTEST_SKIP() << "MXFP4 attention requires sm_120+ with CUTLASS";
+    }
+
+    // GQA: 4 Q heads, 2 KV heads (ratio=2)
+    const int B = 1, SQ = 64, SKV = 64, NH = 4, NKV = 2, HD = 64;
+    size_t qo_elems = B * SQ * NH * HD;
+    size_t kv_elems = B * SKV * NKV * HD;
+
+    void *d_q, *d_k, *d_v, *d_o;
+    cudaMalloc(&d_q, qo_elems * sizeof(half));
+    cudaMalloc(&d_k, kv_elems * sizeof(half));
+    cudaMalloc(&d_v, kv_elems * sizeof(half));
+    cudaMalloc(&d_o, qo_elems * sizeof(half));
+
+    fill_random_fp16(d_q, qo_elems, 0.3f, 333);
+    fill_random_fp16(d_k, kv_elems, 0.3f, 444);
+    fill_random_fp16(d_v, kv_elems, 0.3f, 555);
+    cudaMemset(d_o, 0, qo_elems * sizeof(half));
+
+    int64_t qo_shape[] = {B, SQ, NH, HD};
+    int64_t kv_shape[] = {B, SKV, NKV, HD};
+    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
+    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
+    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+
+    float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+    bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
+    cudaStreamSynchronize(stream_);
+
+    ASSERT_TRUE(ok) << "GQA MXFP4 attention failed";
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+    // Verify finite output
+    std::vector<half> h_o(qo_elems);
+    cudaMemcpy(h_o.data(), d_o, qo_elems * sizeof(half), cudaMemcpyDeviceToHost);
+    for (auto& v : h_o) {
+        EXPECT_TRUE(std::isfinite(__half2float(v)));
+    }
+
+    cudaFree(d_q); cudaFree(d_k); cudaFree(d_v); cudaFree(d_o);
+}
+
+TEST_F(AttentionMxFP4Test, HeadDim128) {
+    if (!can_run()) {
+        GTEST_SKIP() << "MXFP4 attention requires sm_120+ with CUTLASS";
+    }
+
+    const int B = 1, SQ = 64, SKV = 64, NH = 2, NKV = 2, HD = 128;
+    size_t qo_elems = B * SQ * NH * HD;
+    size_t kv_elems = B * SKV * NKV * HD;
+
+    void *d_q, *d_k, *d_v, *d_o;
+    cudaMalloc(&d_q, qo_elems * sizeof(half));
+    cudaMalloc(&d_k, kv_elems * sizeof(half));
+    cudaMalloc(&d_v, kv_elems * sizeof(half));
+    cudaMalloc(&d_o, qo_elems * sizeof(half));
+
+    fill_random_fp16(d_q, qo_elems, 0.3f, 666);
+    fill_random_fp16(d_k, kv_elems, 0.3f, 777);
+    fill_random_fp16(d_v, kv_elems, 0.3f, 888);
+    cudaMemset(d_o, 0, qo_elems * sizeof(half));
+
+    int64_t qo_shape[] = {B, SQ, NH, HD};
+    int64_t kv_shape[] = {B, SKV, NKV, HD};
+    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
+    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
+    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+
+    float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+    bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
+    cudaStreamSynchronize(stream_);
+
+    ASSERT_TRUE(ok) << "head_dim=128 MXFP4 attention failed";
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+    cudaFree(d_q); cudaFree(d_k); cudaFree(d_v); cudaFree(d_o);
+}
+
+TEST_F(AttentionMxFP4Test, RejectsInvalidHeadDim) {
+    if (!can_run()) {
+        GTEST_SKIP() << "MXFP4 attention requires sm_120+ with CUTLASS";
+    }
+
+    // head_dim=48 is not a multiple of 32 — should return false
+    const int B = 1, SQ = 32, SKV = 32, NH = 1, NKV = 1, HD = 48;
+    size_t elems = B * SQ * NH * HD;
+
+    void *d_q, *d_k, *d_v, *d_o;
+    cudaMalloc(&d_q, elems * sizeof(half));
+    cudaMalloc(&d_k, elems * sizeof(half));
+    cudaMalloc(&d_v, elems * sizeof(half));
+    cudaMalloc(&d_o, elems * sizeof(half));
+    cudaMemset(d_q, 0, elems * sizeof(half));
+    cudaMemset(d_k, 0, elems * sizeof(half));
+    cudaMemset(d_v, 0, elems * sizeof(half));
+
+    int64_t shape[] = {B, SQ, NH, HD};
+    Tensor Q(d_q, DType::FP16, 4, shape, true);
+    Tensor K(d_k, DType::FP16, 4, shape, true);
+    Tensor V(d_v, DType::FP16, 4, shape, true);
+    Tensor O(d_o, DType::FP16, 4, shape, true);
+
+    float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+    bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
+    EXPECT_FALSE(ok) << "Should reject head_dim not multiple of 32";
+
+    cudaFree(d_q); cudaFree(d_k); cudaFree(d_v); cudaFree(d_o);
+}
+
+TEST_F(AttentionMxFP4Test, SoftcapSupport) {
+    if (!can_run()) {
+        GTEST_SKIP() << "MXFP4 attention requires sm_120+ with CUTLASS";
+    }
+
+    const int B = 1, SQ = 64, SKV = 64, NH = 2, NKV = 2, HD = 64;
+    size_t qo_elems = B * SQ * NH * HD;
+    size_t kv_elems = B * SKV * NKV * HD;
+
+    void *d_q, *d_k, *d_v, *d_o;
+    cudaMalloc(&d_q, qo_elems * sizeof(half));
+    cudaMalloc(&d_k, kv_elems * sizeof(half));
+    cudaMalloc(&d_v, kv_elems * sizeof(half));
+    cudaMalloc(&d_o, qo_elems * sizeof(half));
+
+    fill_random_fp16(d_q, qo_elems, 0.3f, 999);
+    fill_random_fp16(d_k, kv_elems, 0.3f, 111);
+    fill_random_fp16(d_v, kv_elems, 0.3f, 222);
+    cudaMemset(d_o, 0, qo_elems * sizeof(half));
+
+    int64_t qo_shape[] = {B, SQ, NH, HD};
+    int64_t kv_shape[] = {B, SKV, NKV, HD};
+    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
+    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
+    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+
+    float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+    float softcap = 50.0f;  // Gemma-2/3 style
+
+    bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, softcap, stream_);
+    cudaStreamSynchronize(stream_);
+
+    ASSERT_TRUE(ok) << "Softcap MXFP4 attention failed";
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+    // Output should be finite
+    std::vector<half> h_o(qo_elems);
+    cudaMemcpy(h_o.data(), d_o, qo_elems * sizeof(half), cudaMemcpyDeviceToHost);
+    for (auto& v : h_o) {
+        EXPECT_TRUE(std::isfinite(__half2float(v)));
+    }
+
+    cudaFree(d_q); cudaFree(d_k); cudaFree(d_v); cudaFree(d_o);
+}
+
+} // namespace
+} // namespace imp


### PR DESCRIPTION
Add a new prefill attention path that uses CUTLASS block-scaled
MXFP4×MXFP4 GEMM for the Q·K^T matmul, leveraging Blackwell's
5th-gen tensor cores at ~2x throughput over FP16.

Pipeline per (batch, head):
  1. Quantize Q/K per-head from FP16 → MXFP4 (E2M1 + UE8M0 scales)
     via strided kernel (handles [seq, n_heads*hd] layout directly)
  2. CUTLASS MXFP4 GEMM: S = Q_mxfp4 @ K_mxfp4^T
  3. Fused scale + softcap + causal mask + softmax (in-place on S)
  4. cuBLAS FP16 GEMM: O = P @ V

Key design decisions:
- Chunked attention (materializes full S matrix) — O(seq²) memory,
  so falls back to flash attention for seq > ~11K (256 MiB limit)
- K quantized once per KV head, reused across GQA Q heads
- Decode path unchanged (GEMV is memory-bound, scalar dequant)
- Gated by IMP_MXFP4_ATTENTION=1 env var (opt-in)

Files:
- src/compute/attention_mxfp4_prefill.{h,cu}: implementation
- src/compute/attention_dispatch.cu: dispatch integration
- tests/test_attention_mxfp4.cu: correctness tests
- CMakeLists.txt: build integration

https://claude.ai/code/session_01E4CrUAtLxWnwyaWtGHTgVx