### PR TITLE
graph: cudaDeviceGraphMemTrim on capture lifecycle (F2)

### DIFF
--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -194,6 +194,7 @@ bool CudaGraphCapture::try_update(cudaGraph_t new_graph) {
 }
 
 void CudaGraphCapture::reset() {
+    bool had_exec = (graph_exec_ != nullptr);
     if (graph_exec_) {
         cudaGraphExecDestroy(graph_exec_);
         graph_exec_ = nullptr;
@@ -204,6 +205,15 @@ void CudaGraphCapture::reset() {
     }
     capture_stream_ = nullptr;
     captured_ = false;
+    // Release the per-device graph memory pool. Without this, instantiated
+    // graphs (esp. for 128-expert MoE models) hold reserved VRAM until process
+    // exit, which compounds across re-captures (config changes, batch size
+    // changes). Trim is a no-op when the pool is already empty.
+    if (had_exec) {
+        int dev = 0;
+        cudaGetDevice(&dev);
+        cudaDeviceGraphMemTrim(dev);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -718,6 +728,7 @@ void CudaGraphConditionalRunner::cleanup() {
         launched_ = false;
     }
 
+    bool had_exec = (exec_ != nullptr);
     if (exec_) { cudaGraphExecDestroy(exec_); exec_ = nullptr; }
     if (graph_) { cudaGraphDestroy(graph_); graph_ = nullptr; }
 
@@ -736,6 +747,14 @@ void CudaGraphConditionalRunner::cleanup() {
     d_ring_buffer_ = nullptr;
     if (h_step_counter_) { IMP_CUDA_CHECK_LOG(cudaFreeHost(h_step_counter_)); h_step_counter_ = nullptr; }
     d_step_counter_mapped_ = nullptr;
+
+    // Release the per-device graph memory pool (matches CudaGraphCapture::reset).
+    // Keeps long-running sessions from holding stale graph reservations.
+    if (had_exec) {
+        int dev = 0;
+        cudaGetDevice(&dev);
+        cudaDeviceGraphMemTrim(dev);
+    }
 
     launched_ = false;
     last_read_step_ = 0;


### PR DESCRIPTION
## Summary
Adds `cudaDeviceGraphMemTrim` to `CudaGraphCapture::reset()` and `CudaGraphConditionalRunner::cleanup()`. CUDA graph instantiation reserves per-device memory that survives `cudaGraphExecDestroy`; without trim, long-running sessions accumulate VRAM (especially noticeable on 128-expert MoE models like Gemma-4-26B-A4B and Qwen3-Coder-30B-A3B when batch-size changes trigger re-captures).

Trim is gated on whether an exec was actually instantiated, so it's a no-op when there's nothing to release.

## Validation (RTX 5090, CUDA 13.2, 3-rep avg)
- Gemma-4 Q4_K_M tg256: **202.50 tok/s** (vs 199.84 pre-F2 — within noise)
- Qwen3-4B Q8_0 tg256: **401.64 tok/s** (vs 397.96 — within noise)
- Output correctness preserved: Gemma-4 still emits `<channel|>**Paris**`

## Plan reference
This is Milestone F2 from `/home/kekz/.claude/plans/tidy-orbiting-corbato.md`. F1 (PDL edges) is already active in `apply_pdl_edges` (152 edges → PDL on Gemma-4 conditional body, verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)