### PR TITLE
docker: bump CUDA base images to 13.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # =============================================================================
 # Stage 1: Build imp from source
 # =============================================================================
-FROM nvidia/cuda:13.2.0-devel-ubuntu24.04 AS builder
+FROM nvidia/cuda:13.2.1-devel-ubuntu24.04 AS builder
 
 ARG CMAKE_BUILD_TYPE=Release
 
@@ -41,7 +41,7 @@ RUN cmake -B build -G Ninja \
 # =============================================================================
 # Stage 2: Minimal runtime image
 # =============================================================================
-FROM nvidia/cuda:13.2.0-runtime-ubuntu24.04
+FROM nvidia/cuda:13.2.1-runtime-ubuntu24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages \
         libcublas-13-2 \

--- a/TODO.md
+++ b/TODO.md
@@ -163,7 +163,7 @@ Tensor-core-based decoding with low-bit KV cache. 8.6x vs FP16 FlashDecoding on 
 Residual-based KV compression. 187 tok/s at 128k context on Blackwell PRO 6000. Orthogonal to weight quantization.
 
 ### CUDA 13.2 / CCCL 3.2 Features
-Available in our CUDA 13.2.0 toolkit but not yet used:
+Available in our CUDA 13.2.1 toolkit but not yet used:
 
 **High Priority:**
 - **Grouped GEMM with CUDA Graphs + device-side shapes** (cuBLASLt):


### PR DESCRIPTION
Pick up the latest 13.2.x patch release for both the devel and runtime
stages; update the matching reference in TODO.md.