### PR TITLE
qwen36: scaffold ModelArch::QWEN36_MOE + roadmap

### DIFF
--- a/docs/QWEN36_SUPPORT_ROADMAP.md
+++ b/docs/QWEN36_SUPPORT_ROADMAP.md
@@ -1,0 +1,84 @@
+# Qwen 3.6 Support — Roadmap
+
+## Context
+
+Qwen3.6-35B-A3B was released 2026-04-14 (Apache 2.0, unsloth GGUF + official FP8). It is a **GDN + Gated Attention + MoE hybrid** — the same GDN-Attention interleaving as Qwen 3.5 (3:1 ratio) but with **MoE on every layer** instead of dense FFN.
+
+Architecture summary:
+- 40 layers: 10 × (3 × GDN + 1 × Attention)
+- MoE on all 40 layers (not just attention layers)
+- 35B total / 3B active parameters, 128 experts
+- 262k native context, extensible to 1M
+- Focus: agentic coding, frontend/repo-level reasoning
+
+**vs Qwen3.5 (already supported):**
+- Qwen3.5: 24 GDN + 8 Attn + 32 dense FFN
+- Qwen3.6: 30 GDN + 10 Attn + 40 MoE (all layers)
+
+Both use the same GDN kernels (scan + fused RMSNormGated+SiLU + attention output gate + partial RoPE) and MoE kernels. What's new: the combination.
+
+## Current State (2026-04-20)
+
+**Scaffold added on branch `qwen36-support-scaffolding`:**
+- `ModelArch::QWEN36_MOE` enum + `IMP_ARCH_QWEN36_MOE = 13` in C API
+- `parse_model_arch()` recognizes `"qwen36moe"`, `"qwen3.6_moe"`, `"qwen3.6moe"` strings
+- `ArchRegistry` entry with ChatML chat template + Qwen sampling defaults (T=0.6, top_p=0.95, top_k=20)
+- `chat_template.cpp` routes QWEN36_MOE → CHATML family
+
+**Not yet implemented:**
+- GGUF config parsing for Qwen 3.6 metadata
+- Per-layer dispatch verifying MoE-on-all-layers (not MoE-on-attention-only)
+- SafeTensors loader extension for the FP8 variant
+- E2E test
+
+## Remaining Work
+
+### 1. Model metadata parsing
+Verify which string unsloth uses for `general.architecture` in the GGUF (likely `qwen36moe` based on Qwen naming convention — need to `hexdump` a real file). If different, add to `parse_model_arch()`.
+
+For SafeTensors: `config.json` "model_type" field; check official `Qwen/Qwen3.6-35B-A3B` repo.
+
+### 2. Layer config validation
+Current GGUF loader detects GDN vs attention structurally (from tensor names). Qwen 3.6 uses the same tensor names as Qwen 3.5, so the detection should work. Verify:
+- Layer census correctly reports `30 GDN + 10 attn + 40 MoE` when Qwen3.6-35B-A3B loads
+- MoE is detected for ALL 40 layers (not just the 10 attention layers — Qwen 3.5 only had MoE on attention blocks in the MoE variant)
+
+### 3. Forward pass dispatch
+Most of the forward path should Just Work because:
+- GDN layers: same kernels as Qwen 3.5 (already wired)
+- Attention layers: standard Gated Attention (already wired for Qwen 3.5)
+- MoE FFN: already wired for Qwen3-MoE / Qwen3-Coder-30B-A3B
+
+Risk: does `executor_ssm_gdn.cu` correctly call MoE after the GDN layer? Currently Qwen 3.5 GDN layers use dense FFN. Likely need a branch: `if (arch == QWEN36_MOE) run_moe_ffn(); else run_dense_ffn();` after each GDN block.
+
+### 4. RoPE / context extension
+Qwen 3.6 has 262k native + 1M extended context. Verify RoPE scaling params (likely YaRN or similar) are parsed from metadata. Current Qwen 3.5 RoPE handling should cover native; 1M extension may need extra work.
+
+### 5. E2E test
+- Download `unsloth/Qwen3.6-35B-A3B-GGUF` (Q4_K_M or IQ4_XS variant) — ~18-22 GB
+- Add `Qwen36ModelTest.GenerateCoherentOutput` in `tests/test_e2e_models.cpp`
+- Benchmark: target tg256 ≥ 130 tok/s (similar to Qwen3.5-9B-GDN)
+- Compare against llama.cpp on same quant
+
+## Hardware fit (RTX 5090 32GB)
+
+At Q4_K_M (~18 GB): fits with headroom for 8-12k KV context. Q5_K_M (~22 GB) tighter. Q8_0 (~35 GB) **does not fit** on 32 GB.
+
+## Open Questions
+
+- Does `config.json` contain an explicit `layer_types` array indicating which layers are GDN vs Attention? If yes, parse it directly rather than relying on structural tensor-name detection.
+- Does the official FP8 checkpoint use Model Optimizer NVFP4 prequant format (like Qwen3-Coder-30B-A3B-FP4)? If yes, it can use the existing NVFP4 MoE path (and benefit from the pending CUTLASS 3.x work in PR #22).
+- "Reasoning context from historical messages": is this a model-side behavior or does it require explicit KV-cache reuse API changes?
+
+## Priority vs other work
+
+Depends on:
+- **Blocker**: need a local GGUF download (~20 GB) before we can test
+- **Parallelizable**: PR #22 (CUTLASS 3.x NVFP4 MoE) — if FP8 checkpoint is NVFP4-prequant, #22 completion blocks fastest Qwen 3.6 path
+- **Orthogonal**: native Q4_K_M GEMV wiring (low value) — unrelated to Qwen 3.6
+
+## References
+- Qwen blog (2026-04-14): https://qwen.ai/blog?id=qwen3.6
+- unsloth GGUF: https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF
+- Official FP8: https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8
+- Reference to Qwen 3.5 implementation: `src/graph/executor_ssm_gdn.cu`, `src/compute/gdn.cu`, memory `qwen35_gdn.md`

--- a/include/imp/types.h
+++ b/include/imp/types.h
@@ -34,6 +34,7 @@ typedef enum {
     IMP_ARCH_QWEN35         = 10,
     IMP_ARCH_QWEN35_MOE     = 11,
     IMP_ARCH_GEMMA4         = 12,
+    IMP_ARCH_QWEN36_MOE     = 13,
 } ImpModelArch;
 
 typedef enum {

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -58,6 +58,7 @@ ChatTemplateFamily ChatTemplate::default_family_for_arch(ModelArch arch) {
         case ModelArch::QWEN3_MOE:      return ChatTemplateFamily::CHATML;
         case ModelArch::QWEN35:         return ChatTemplateFamily::CHATML;
         case ModelArch::QWEN35_MOE:     return ChatTemplateFamily::CHATML;
+        case ModelArch::QWEN36_MOE:     return ChatTemplateFamily::CHATML;
         case ModelArch::GEMMA3:         return ChatTemplateFamily::GEMMA;
         case ModelArch::GEMMA4:         return ChatTemplateFamily::GEMMA;
         case ModelArch::LLAMA4:         return ChatTemplateFamily::LLAMA3;

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -93,6 +93,7 @@ enum {
     kApiNemotronHMoe = 4, kApiQwen3 = 5, kApiQwen3Moe = 6,
     kApiGemma3 = 7, kApiLlama4 = 8, kApiGeneric = 9,
     kApiQwen35 = 10, kApiQwen35Moe = 11, kApiGemma4 = 12,
+    kApiQwen36Moe = 13,
 };
 
 static constexpr ArchEntry kArchRegistry[] = {
@@ -106,6 +107,7 @@ static constexpr ArchEntry kArchRegistry[] = {
     {ModelArch::QWEN3_MOE,      "qwen3moe",        kApiQwen3Moe,      -1, 0,    -1, -1, false, true,  0.6f, 0.95f, 20},
     {ModelArch::QWEN35,         "qwen35",          kApiQwen35,        -1, 0,    -1, -1, false, false, 0.6f, 0.95f, 20},
     {ModelArch::QWEN35_MOE,     "qwen35moe",       kApiQwen35Moe,     -1, 0,    -1, -1, false, false, 0.6f, 0.95f, 20},
+    {ModelArch::QWEN36_MOE,     "qwen36moe",       kApiQwen36Moe,     -1, 0,    -1, -1, false, false, 0.6f, 0.95f, 20},
     {ModelArch::GEMMA3,         "gemma3",          kApiGemma3,        -1, 0,     1,   1, false, false, 0.6f, 0.95f, 0},
     {ModelArch::GEMMA4,         "gemma4",          kApiGemma4,        -1, 0,     1,   1, false, true,  0.6f, 0.9f,  20},
     {ModelArch::LLAMA4,         "llama4",          kApiLlama4,         0, 0,    -1, -1, false, false, 0.6f, 0.95f, 0},
@@ -146,6 +148,9 @@ ModelArch parse_model_arch(const std::string& s) {
         {"qwen3moe", ModelArch::QWEN3_MOE},
         {"qwen35", ModelArch::QWEN35},
         {"qwen35moe", ModelArch::QWEN35_MOE},
+        {"qwen36moe", ModelArch::QWEN36_MOE},
+        {"qwen3.6_moe", ModelArch::QWEN36_MOE},
+        {"qwen3.6moe", ModelArch::QWEN36_MOE},
         {"gemma3", ModelArch::GEMMA3},
         {"gemma", ModelArch::GEMMA3},
         {"gemma2", ModelArch::GEMMA3},

--- a/src/model/model_arch.h
+++ b/src/model/model_arch.h
@@ -14,6 +14,7 @@ enum class ModelArch {
     QWEN3_MOE,
     QWEN35,
     QWEN35_MOE,
+    QWEN36_MOE,
     GEMMA3,
     GEMMA4,
     LLAMA4,


### PR DESCRIPTION
## Summary

Qwen3.6-35B-A3B was released 2026-04-14 — a GDN + Gated Attention + MoE hybrid at the same 3:1 GDN:Attn ratio as Qwen 3.5 but with **MoE on every layer** instead of dense FFN. This PR adds only the identity/metadata plumbing. All kernels the model needs already exist in imp (GDN scan from Qwen 3.5, Gated Attention from Qwen 3.5, MoE expert dispatch from Qwen3-MoE / Qwen3-Coder-30B-A3B-FP4).

## Changes

- `include/imp/types.h`: `IMP_ARCH_QWEN36_MOE = 13`
- `src/model/model_arch.h`: `ModelArch::QWEN36_MOE` enum
- `src/model/model.cpp`: ArchRegistry entry (ChatML chat template, Qwen sampling defaults) + `parse_model_arch()` handles `"qwen36moe"`, `"qwen3.6_moe"`, `"qwen3.6moe"` arch strings
- `src/model/chat_template.cpp`: `QWEN36_MOE` → `CHATML` family
- `docs/QWEN36_SUPPORT_ROADMAP.md`: integration plan for remaining work

## Architecture

| | Qwen 3.5 | Qwen 3.6-35B-A3B |
|---|---|---|
| Layers | 64 | 40 |
| GDN layers | 24 | 30 |
| Attention layers | 8 | 10 |
| GDN:Attn ratio | 3:1 | 3:1 (same) |
| FFN | dense (Qwen 3.5) or MoE only on attn layers (Qwen 3.5 MoE) | **MoE on all 40 layers** |
| Total params | — | 35B |
| Active params | — | 3B |
| Native context | — | 262k (extends to 1M) |

## What this PR does NOT do

- No layer-level dispatch changes — the GGUF loader detects GDN vs attention structurally from tensor names (already works), and MoE runs per-layer based on expert-weight presence (already works)
- No runtime behavior change for existing models — this is pure additive metadata
- No model tested yet — the ~20 GB GGUF download is the remaining blocker

## Remaining Work (see `docs/QWEN36_SUPPORT_ROADMAP.md`)

1. Verify unsloth's GGUF uses `qwen36moe` as `general.architecture` (need to hexdump a real file)
2. Confirm MoE runs on all 40 layers (Qwen 3.5 MoE only used MoE on attention blocks, not GDN blocks — need to check whether our per-layer MoE detection handles "MoE after GDN")
3. Verify `executor_ssm_gdn.cu` post-GDN FFN dispatch reaches the MoE path when the arch is `QWEN36_MOE`
4. RoPE scaling for the 262k → 1M extended context
5. E2E test with `unsloth/Qwen3.6-35B-A3B-GGUF` — fits at Q4_K_M / IQ4_XS on 32 GB 5090, does NOT fit at Q8_0

## Test plan
- [x] Build green (scaffold compiles)
- [ ] Full unit tests (no behavior change expected — pure metadata additions)
- [ ] CI green
- [ ] Future: E2E smoke test after model download

## Related
- PR #22: CUTLASS 3.x NVFP4 Grouped GEMM — if Qwen3.6's official FP8 checkpoint uses NVFP4 prequant (like Qwen3-Coder-30B-A3B-FP4), #22 completion blocks the fastest Qwen 3.6 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)