### PR TITLE
gdn: h_state FP32 preservation + PyTorch-style L2 norm + debug dumps

### DIFF
--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -113,7 +113,11 @@ gdn_scan_fused_kernel(
                 if (d < stride) s_reduce[d] += s_reduce[d + stride];
                 __syncthreads();
             }
-            float k_inv = rsqrtf(s_reduce[0] + 1e-6f);
+            // PyTorch-style L2 norm (matches llama's ggml_l2_norm): rsqrtf(max(sum_sq, eps^2)).
+            // Additive eps (sum + eps) over-clamps near-zero heads and produces
+            // 100-1000x too-small normalization scale vs llama, which breaks Qwen 3.6 scan
+            // outputs at layers where some heads have near-zero K (e.g. L1 h19/20/22/25/29).
+            float k_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
 
             s_reduce[d] = q_sq;
             __syncthreads();
@@ -121,7 +125,7 @@ gdn_scan_fused_kernel(
                 if (d < stride) s_reduce[d] += s_reduce[d + stride];
                 __syncthreads();
             }
-            float q_inv = rsqrtf(s_reduce[0] + 1e-6f);
+            float q_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
 
             // Normalize in-place
             if (d < SS) {
@@ -474,7 +478,8 @@ __global__ void gdn_scan_reference_kernel(
             if (d < stride) s_reduce[d] += s_reduce[d + stride];
             __syncthreads();
         }
-        float k_inv = rsqrtf(s_reduce[0] + 1e-6f);
+        // PyTorch-style L2 norm (see note in fused kernel above).
+        float k_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
 
         s_reduce[d] = q_sq;
         __syncthreads();
@@ -482,7 +487,7 @@ __global__ void gdn_scan_reference_kernel(
             if (d < stride) s_reduce[d] += s_reduce[d + stride];
             __syncthreads();
         }
-        float q_inv = rsqrtf(s_reduce[0] + 1e-6f);
+        float q_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
 
         if (d < SS) {
             s_k[d] *= k_inv;
@@ -701,8 +706,9 @@ __global__ void gdn_scan_decode_kernel(
             s_k[s] = ks; s_q[s] = qs;
             k_sq += ks * ks; q_sq += qs * qs;
         }
-        s_k_inv = rsqrtf(k_sq + 1e-6f);
-        s_q_inv = rsqrtf(q_sq + 1e-6f);
+        // PyTorch-style L2 norm: rsqrtf(max(sum_sq, eps^2)), matches llama's ggml_l2_norm.
+        s_k_inv = rsqrtf(fmaxf(k_sq, 1e-12f));
+        s_q_inv = rsqrtf(fmaxf(q_sq, 1e-12f));
         for (int s = 0; s < state_size; s++) {
             s_k[s] *= s_k_inv; s_q[s] *= s_q_inv;
         }

--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -441,6 +441,7 @@ private:
     int max_tokens_ = 0;
     int max_logit_tokens_ = 0;  // max tokens needing LM head projection (= max_batch_size)
     int cur_n_tokens_ = 0;  // set by forward_logits for use by run_ffn
+    int cur_decode_step_ = 0;  // set by forward_logits for debug dump tagging
     bool cur_force_fp16_ = false;  // set by forward_logits, bypasses FP8 GEMM paths
     bool cur_per_row_lm_ = false;  // set by forward_logits, per-row Q8_1 LM head
 

--- a/src/graph/executor_debug.h
+++ b/src/graph/executor_debug.h
@@ -19,6 +19,15 @@ inline bool debug_forward_enabled() {
     return enabled;
 }
 
+// Decode-step counter shared between executor_forward.cu (writer) and
+// executor_ssm_gdn.cu (reader). Prefill passes use step=0; each single-token
+// decode pass increments it. Used for IMP_DUMP_HIDDEN filename tagging so
+// GDN-internal dumps correlate with per-layer snapshots.
+inline int& debug_decode_step() {
+    static int s = 0;
+    return s;
+}
+
 // Hidden-state npy dump for layer-diff analysis against llama.cpp.
 // Returns the directory if IMP_DUMP_HIDDEN is set to a non-empty string, else nullptr.
 // Accepts IMP_DUMP_HIDDEN=1 or "all" for backwards compat (mapped to /tmp).

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -166,10 +166,12 @@ void GraphExecutor::forward_logits(const InferenceState& state,
 
     // Store for use by run_ffn (which doesn't receive the InferenceState).
     cur_n_tokens_ = n;
-    // Decode step counter for debug dump tagging
-    static int s_decode_step = 0;
+    // Decode step counter for debug dump tagging. Shared with GDN path via
+    // debug_decode_step() so run_gdn can tag its dumps with the same step.
+    int& s_decode_step = debug_decode_step();
     if (n == 1) s_decode_step++;
     const int decode_step = (n == 1) ? s_decode_step : 0;
+    cur_decode_step_ = decode_step;
     cur_force_fp16_ = state.force_fp16_gemm;
     cur_per_row_lm_ = state.per_row_lm_head;
 

--- a/src/graph/executor_ssm_gdn.cu
+++ b/src/graph/executor_ssm_gdn.cu
@@ -301,6 +301,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     int64_t proj_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(conv_channels)};
     Tensor proj(ssm_proj_buf_.data, compute_dtype_, 2, proj_shape, true);
     gemm_dispatch(no, ly.ssm_in, ly.ssm_in_qtype, proj, ctx);
+    dump_tensor_npy("gdn_ssm_in_out", proj, stream, layer, cur_decode_step_);
 
     // 3. Conv1d on full projection output [n, conv_channels]
     int64_t conv_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(conv_channels)};
@@ -345,6 +346,14 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
         int blocks = static_cast<int>((total + threads - 1) / threads);
         fp16_to_fp32_kernel<<<blocks, threads, 0, stream>>>(
             static_cast<const half*>(xBC_out.data), conv_f32, total);
+    }
+
+    // Per-element dump: post-conv1d post-SiLU FP32 scan input.
+    // Compare to llama's `conv_output_silu-{layer}` tensor.
+    {
+        int64_t cf_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(conv_channels)};
+        Tensor conv_f32_t(conv_f32, DType::FP32, 2, cf_shape, true);
+        dump_tensor_npy("gdn_conv_f32", conv_f32_t, stream, layer, cur_decode_step_);
     }
 
     // 4b. V-head reorder (tiled → grouped) for asymmetric-head GDN models.
@@ -411,6 +420,10 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
             // Alpha/beta: through gemm_dispatch for consistent MXFP4/FP16/quantized handling.
             gemm_dispatch(no, ly.gdn_alpha, ly.gdn_alpha_qtype, alpha_proj_out, ctx);
             gemm_dispatch(no, ly.gdn_beta, ly.gdn_beta_qtype, beta_proj_out, ctx);
+            // Per-element dump: pre-softplus alpha and pre-sigmoid beta projections.
+            // Compare to llama's `alpha-{layer}` and `beta-{layer}`.
+            dump_tensor_npy("gdn_alpha", alpha_proj_out, stream, layer, cur_decode_step_);
+            dump_tensor_npy("gdn_beta",  beta_proj_out,  stream, layer, cur_decode_step_);
         }
 
         // 5b. Multi-token delta rule scan.
@@ -478,6 +491,14 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     debug_tensor_stats("gdn_after_scan_y", y_buf, stream);
     debug_tensor_stats("gdn_gate_out", gate_out, stream);
 
+    // Per-element dump: raw scan output (FP16), pre-rmsnorm_gated_silu.
+    // Only populated in the default path — FP32_SCAN writes to y_fp32 and only
+    // copies back to y_buf when IMP_DEBUG_FORWARD is set. Compare to llama's
+    // `attn_output-{layer}` from common-eval-callback.
+    if (!use_fp32_scan) {
+        dump_tensor_npy("gdn_y_post_scan", y_buf, stream, layer, cur_decode_step_);
+    }
+
     // 6. Fused RMSNormGated + SiLU: y = rmsnorm(y) * silu(gate)
     // Single kernel launch for all tokens × heads (replaces n×32×2 launches).
     // When IMP_GDN_FP32_SCAN is active, this was already done inline with the
@@ -493,6 +514,10 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
                                 static_cast<const half*>(ly.ssm_norm_w.data),
                                 norm_eps, n, n_heads, head_dim_ssm, stream);
     }
+
+    // Per-element dump: post-rmsnorm-gated scan output (FP16), pre-ssm_out GEMM.
+    // Compare to llama's final_output tensor before build_lora_mm(ssm_out, ...).
+    dump_tensor_npy("gdn_y_post_norm", y_buf, stream, layer, cur_decode_step_);
 
     // 7. ssm_out projection: [n, inner] → [n, d_model]
     // IMP_GDN_FP32_OUT=1: compute the ssm_out GEMM with FP32 output and add the
@@ -527,6 +552,9 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(fp32_out, stream));
     } else {
         gemm_dispatch(y_buf, ly.ssm_out, ly.ssm_out_qtype, out_buf, ctx);
+        // Per-element dump: linear_attn_out post-ssm_out GEMM, pre-residual.
+        // Compare to llama's `linear_attn_out-{layer}` from eval-callback.
+        dump_tensor_npy("gdn_linear_attn_out", out_buf, stream, layer, cur_decode_step_);
         elementwise_add(out_buf, r, stream);
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h.data, out_buf.data, h.nbytes(),
                         cudaMemcpyDeviceToDevice, stream));

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -367,8 +367,19 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     }
 
     // --- Auto-detect SSM state dtype for hybrid models ---
-    // Nemotron-H and similar: use FP16 for SSM h_state (~50% VRAM savings)
-    if (config_.ssm_state_dtype == DType::FP32 && mcfg.ssm_state_size > 0) {
+    // Nemotron-H and similar Mamba models: use FP16 for SSM h_state (~50% VRAM savings).
+    // GDN models (Qwen3.5 / Qwen3.6) MUST keep FP32: the delta-rule scan kernel
+    // writes FP32 (float) into h_state and assumes 4 bytes/element. FP16 allocation
+    // would be half the size, so each layer's scan overflows into the next layer's
+    // state region — shipped bug that corrupted L1+ GDN state on every Qwen 3.6
+    // forward, producing 37% scan-output divergence vs llama.cpp.
+    bool has_gdn_for_dtype = false;
+    if (mcfg.ssm_state_size > 0) {
+        for (int i = 0; i < mcfg.n_layers; i++) {
+            if (model_->layer(i).gdn_gate.data != nullptr) { has_gdn_for_dtype = true; break; }
+        }
+    }
+    if (config_.ssm_state_dtype == DType::FP32 && mcfg.ssm_state_size > 0 && !has_gdn_for_dtype) {
         config_.ssm_state_dtype = DType::FP16;
         IMP_LOG_INFO("SSM state dtype: auto → FP16 (hybrid SSM model, state_size=%d)",
                      mcfg.ssm_state_size);


### PR DESCRIPTION
## Summary
- **h_state dtype gate (c486eec):** Don't auto-downgrade ssm_state_dtype FP32→FP16 for GDN models. The delta-rule scan kernel writes FP32 into h_state; under the Nemotron-H-targeted downgrade the allocation halves and each layer's scan overflows into the next layer's state region → L1+ GDN state corruption and ~37% scan-output divergence vs llama.cpp on every Qwen 3.5/3.6 forward. Mamba2 (Nemotron-H) still gets the 50% VRAM win via the `has_gdn_for_dtype` check.
- **L2 norm formulation (29f4a99):** Scan kernels used `rsqrtf(sum_sq + 1e-6f)` which over-clamps near-zero heads (rsqrtf collapses to ≈1000 instead of true rsqrtf(sum_sq), producing a 100–1000× too-small normalization scale). Switched all three kernel variants (fused / reference / decode) to the PyTorch / llama.cpp formulation `rsqrtf(max(sum_sq, 1e-12f))`. Fixes Qwen 3.6 L1 scan outputs at heads 19/20/22/25/29.
- **Debug dump infrastructure (8fe1592):** Shared decode-step counter via `debug_decode_step()` so `executor_ssm_gdn.cu` can tag `IMP_DUMP_HIDDEN` dumps with the same step as the per-layer snapshot. Adds 6 correlation points in `run_gdn` matching llama.cpp's `common-eval-callback` tensor names for offline layer-diff analysis of the remaining Qwen 3.6 NaN at L38.

## Test plan
- [x] `make test-gpu` — 580/580 passed (23 skipped, model-dependent without mounts)
- [x] `GdnKernelTest.*` + `ForwardPassTest.*` + `KVCacheTest.*` — 50/50 passed
- [x] Qwen3-4B MXFP4 (non-GDN control): coherent "Paris.", tg=124 tok/s
- [x] Gemma-4-26B-A4B Q5_K_M (MoE control): coherent "Paris.", tg=63 tok/s (matches memory baseline 65)
- [ ] Qwen3.5-27B MXFP4: pre-existing IMA on main (not introduced by these commits; see weight-storage-refactor A/B memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)