### PR TITLE
runtime: fix misleading GDN CUDA-graphs log

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -924,7 +924,11 @@ bool Engine::init_kv_cache() {
         for (int i = 0; i < mcfg.n_layers; i++)
             if (model_->layer(i).gdn_gate.data != nullptr) n_gdn++;
         if (n_gdn > 0) {
-            IMP_LOG_INFO("GDN model: %d layers, CUDA graphs enabled (recurrent state in-place)", n_gdn);
+            if (config_.use_cuda_graphs) {
+                IMP_LOG_INFO("GDN model: %d layers, CUDA graphs enabled (recurrent state in-place)", n_gdn);
+            } else {
+                IMP_LOG_INFO("GDN model: %d layers, CUDA graphs disabled (disabled earlier by caller or expert offload)", n_gdn);
+            }
             // GDN recurrent state accumulates small precision errors per token.
             // FP8 E4M3 (3-bit mantissa) amplifies these through the delta rule
             // scan, causing degenerate output after ~50 special tokens in


### PR DESCRIPTION
## Summary

When a GDN model is loaded with experts offloaded to host (Qwen 3.6 35B at default ctx) or \`IMP_NO_CUDA_GRAPH=1\` is set, the engine init log printed two contradictory messages:

\`\`\`
engine.cpp:742: Disabling CUDA graphs: expert weights on host
engine.cpp:927: GDN model: 30 layers, CUDA graphs enabled (recurrent state in-place)
\`\`\`

The second message always fired when n_gdn > 0, independent of the actual \`config_.use_cuda_graphs\` state. Now it reports the real state, so operators can trust the logs.

## Verification

- Qwen 3.5-4B Q8_0 (graphs actually enabled): \`GDN model: 24 layers, CUDA graphs enabled (recurrent state in-place)\` ✅
- Qwen 3.6-35B Q4_K_M (graphs actually disabled by expert offload): \`GDN model: 30 layers, CUDA graphs disabled (disabled earlier by caller or expert offload)\` ✅

## Test plan

- [x] Qwen 3.5 prints enabled
- [x] Qwen 3.6 w/ expert offload prints disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)