### PR TITLE
runtime: hint about IMP_EXPERT_OVERHEAD_PCT for MoE graphs

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -740,6 +740,9 @@ bool Engine::init_weights() {
         }
         if (experts_on_host_ && config_.use_cuda_graphs) {
             IMP_LOG_INFO("Disabling CUDA graphs: expert weights on host");
+            IMP_LOG_INFO("  Tip: if model+KV fits in VRAM, set IMP_EXPERT_OVERHEAD_PCT=10 "
+                         "(default 30) to upload ALL experts and re-enable CUDA graphs "
+                         "(+~180%% decode on Qwen 3.6 35B Q4_K_M).");
             config_.use_cuda_graphs = false;
         }
         if (getenv("IMP_NO_CUDA_GRAPH") && config_.use_cuda_graphs) {


### PR DESCRIPTION
## Summary

When the expert upload heuristic decides experts don't fit, CUDA graphs get disabled. The default \`IMP_EXPERT_OVERHEAD_PCT=30\` is conservative for WDDM/WSL2 safety but leaves ~9 GiB unused on a 32 GiB GPU.

For MoE models like Qwen 3.6 35B Q4_K_M, lowering this to 10 uploads all experts and re-enables graphs — verified **+186% decode throughput**: 50 → 143 tok/s on RTX 5090.

This PR only adds a one-line hint in the existing \"Disabling CUDA graphs\" log so users discover the flag. No default change, no behavior change.

## Before / After

**Default PCT=30:**
\`\`\`
engine.cpp:742: Disabling CUDA graphs: expert weights on host
engine.cpp:930: GDN model: 30 layers, CUDA graphs disabled ...
tg256: 50 tok/s
\`\`\`

**With IMP_EXPERT_OVERHEAD_PCT=10:**
\`\`\`
weight_upload.cu:1154: Expert weights: 18.22 GiB -> uploading ALL to GPU (27.39 GiB free, 2.88 GiB reserve)
engine.cpp:928: GDN model: 30 layers, CUDA graphs enabled
cuda_graph.cu:255: CudaGraphRunner: capturing CUDA graph
tg256: 143 tok/s
\`\`\`

## Test plan

- [x] Hint message appears when graphs are disabled due to experts_on_host
- [x] IMP_EXPERT_OVERHEAD_PCT=10 uploads all experts on Qwen 3.6 35B Q4_K_M
- [x] CUDA graphs successfully captured and decode runs at 143 tok/s
- [x] Output remains coherent (Alex-the-adventurer story)

🤖 Generated with [Claude Code](https://claude.com/claude-code)