### PR TITLE
attention: fix FP8 FMHA S_tile smem overlap (long-context cliff at n>1024)

### DIFF
--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -610,9 +610,14 @@ fmha_sm120_fp8_kernel(
     extern __shared__ char smem[];
 
     uint8_t* Q_fp8   = reinterpret_cast<uint8_t*>(smem);
-    uint8_t* KV_fp8  = Q_fp8 + Bq * head_dim;          // K as FP8
-    half*    KV_fp16 = reinterpret_cast<half*>(KV_fp8); // V as FP16 (reuse same slot)
-    float*   S_tile  = reinterpret_cast<float*>(KV_fp8 + Bkv * head_dim);
+    uint8_t* KV_fp8  = Q_fp8 + Bq * head_dim;          // K as FP8 (first half of KV region)
+    half*    KV_fp16 = reinterpret_cast<half*>(KV_fp8); // V as FP16 (reuses full KV region)
+    // S_tile must live AFTER the full V-as-half region, not after just the
+    // FP8 K region. V writes Bkv * head_dim halves = 2 * Bkv * head_dim bytes,
+    // so advancing only Bkv * head_dim bytes (as the code originally did)
+    // places S_tile inside the V area — V row Bkv/2+ overwrites P values
+    // and poisons the PV MMA output with garbage/NaN.
+    float*   S_tile  = reinterpret_cast<float*>(KV_fp8 + Bkv * head_dim * sizeof(half));
     float*   O_acc   = S_tile + Bq * Bkv;
     float*   row_m   = O_acc + Bq * head_dim;
     float*   row_l   = row_m + Bq;

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -178,5 +178,13 @@ TEST_F(FmhaFP8Test, HD256) {
     run_test(1, 32, 32, 4, 4, 256, true);
 }
 
+// Mimic Qwen3.5-4B attention prefill shape: 16 Q heads, 4 KV heads (GQA 4:1),
+// head_dim=256, 128-token sequence. Multi-tile on both axes with non-zero V
+// throughout — catches the S_tile smem overlap bug that the HD256 test
+// (Sq=Skv=32, zero-padded V) masked by having the reference also near zero.
+TEST_F(FmhaFP8Test, Qwen35LikeHD256_GQA41_SeqMultiTile) {
+    run_test(1, 128, 128, 16, 4, 256, true);
+}
+
 } // namespace
 } // namespace imp


### PR DESCRIPTION
## Summary
- **Root cause of all-models long-context degeneration at prompt > 1024 tokens** in imp: `fmha_sm120_fp8_kernel` placed `S_tile` only `Bkv*head_dim` bytes past `KV_fp8`, but the K-as-FP8 / V-as-half smem slot is reserved for `Bkv*head_dim*sizeof(half)` bytes. V rows `Bkv/2+` overwrote the P values the PV MMA read → NaN output on every attention layer.
- Invisible because `executor_attention.cu:712` routes n≤1024 prefill to cuBLAS, so all `pp512`/`pp1024` benchmarks skipped the FP8 FMHA path. Decode uses paged attention. The unit test `FmhaFP8Test.HD256` used `Sq=Skv=32` with zero-padded V; reference was ~0 and the corrupted output was also ~0, collapsing under the 5% tolerance.
- Fix: advance `S_tile` by the full `Bkv*head_dim*sizeof(half)` bytes so it lives after the entire V-as-half region. No layout changes, no kernel math changes.
- Added regression test `FmhaFP8Test.Qwen35LikeHD256_GQA41_SeqMultiTile` (Sq=Skv=128, NH=16, NKV=4, HD=256) that makes the reference non-zero and asserts `max_err < 0.05`.

## How it was found
- Bisected the cliff: `pp=1013` OK → `pp=1025` immediate `<|endoftext|>` spam on Qwen3.5-4B Q8_0.
- Env-var bisection pinned it to FP8 FMHA: `IMP_NO_FP8_FMHA=1` routes to FP16 FMHA → coherent.
- `IMP_DUMP_HIDDEN=<dir>` layer-diff showed L3 (first attention layer) `B_post_attn` was 100% NaN, while `A_pre_attn` was clean.
- Confirmed on all 5 tested models (Qwen3-4B, Qwen3-8B, Llama-3.2-3B, Qwen3.5-4B, Qwen3.5-9B): all produced garbage at n≥1025, all coherent post-fix.

## Test plan
- [x] `FmhaFP8Test` 8/8 pass (HD64 auto-skip: size unsupported)
- [x] Full `imp-tests`: 581 PASS, 0 FAIL
- [x] `make test-e2e`: 15/15 PASS (Qwen3, Qwen3.5 GDN, Gemma4 model suites)
- [x] Qwen3-4B pp=1024 bench: 27287 tok/s (baseline 27201, no regression)
- [x] Qwen3-4B pp=2048 bench (previously produced garbage): 18692 tok/s
- [x] 5 models at n≈1031 produce coherent text continuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)