### PR TITLE
tokenizer: fix gemma4 byte-fallback on common names

### DIFF
--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -977,7 +977,25 @@ std::vector<int32_t> Tokenizer::encode_gemma4(const std::string& text) const {
             int right = snext[pos];
             if (right >= ns || sdel[right]) continue;
 
-            symbols[pos] = symbols[pos] + symbols[right];
+            // Re-validate: the pair at this position may have changed since
+            // the merge was enqueued (the right neighbor may have merged
+            // with ITS neighbor). Check that the current pair still has
+            // the popped rank.
+            std::string merged = symbols[pos] + symbols[right];
+            {
+                std::string cur_key = symbols[pos] + " " + symbols[right];
+                auto vit = merge_ranks_.find(cur_key);
+                if (vit == merge_ranks_.end() || vit->second != rank) continue;
+            }
+            // Vocab-existence guard: merge_ranks_ contains rules whose output
+            // is not in the final vocab (intermediate merge steps, e.g.
+            // "Lin u → Linu" where "Linu" is not a token). Applying such a
+            // merge produces a symbol that fails vocab lookup and byte-
+            // falls back the entire word. Skipping these keeps sub-parts
+            // that ARE tokens intact. Matches llama.cpp behavior.
+            if (token_to_id_.find(merged) == token_to_id_.end()) continue;
+
+            symbols[pos] = merged;
             sdel[right] = true;
             sseq[pos]++;
             snext[pos] = snext[right];
@@ -1007,14 +1025,31 @@ std::vector<int32_t> Tokenizer::encode_gemma4(const std::string& text) const {
             if (it != token_to_id_.end()) {
                 all_ids.push_back(it->second);
             } else {
-                // Byte fallback: encode each byte as <0xNN>
-                for (unsigned char c : symbols[i]) {
-                    char buf[8];
-                    snprintf(buf, sizeof(buf), "<0x%02X>", c);
-                    auto bit = token_to_id_.find(buf);
-                    if (bit != token_to_id_.end()) {
-                        all_ids.push_back(bit->second);
+                // Fallback: the merge-guard above prevents producing symbols
+                // that aren't in vocab via merging, so we only land here for
+                // initial UTF-8 characters that the vocab doesn't cover. Try
+                // per-character vocab lookup first, then byte fallback.
+                const std::string& sym = symbols[i];
+                for (size_t ci = 0; ci < sym.size(); ) {
+                    int clen = utf8_char_len(static_cast<uint8_t>(sym[ci]));
+                    if (ci + clen > sym.size()) clen = 1;
+                    std::string ch = sym.substr(ci, clen);
+                    auto ch_it = token_to_id_.find(ch);
+                    if (ch_it != token_to_id_.end()) {
+                        all_ids.push_back(ch_it->second);
+                    } else {
+                        for (int bi = 0; bi < clen; bi++) {
+                            char buf[8];
+                            snprintf(buf, sizeof(buf),
+                                     "<0x%02X>",
+                                     static_cast<unsigned char>(sym[ci + bi]));
+                            auto bit = token_to_id_.find(buf);
+                            if (bit != token_to_id_.end()) {
+                                all_ids.push_back(bit->second);
+                            }
+                        }
                     }
+                    ci += clen;
                 }
             }
         }
@@ -1415,6 +1450,15 @@ std::string Tokenizer::decode_spm(const std::vector<int32_t>& tokens) const {
     std::string result;
     for (int32_t tok : tokens) {
         result += decode_spm_token(tok);
+    }
+    // Second pass: byte-fallback tokens contribute single raw bytes that
+    // together may form ▁ (U+2581 = 0xE2 0x96 0x81). The per-token replace
+    // in decode_spm_token can't see across token boundaries, so catch any
+    // remaining ▁ here and convert to ASCII space.
+    size_t pos = 0;
+    while ((pos = result.find(SPIECE_SPACE, pos)) != std::string::npos) {
+        result.replace(pos, SPIECE_SPACE.size(), " ");
+        pos += 1;
     }
     return result;
 }

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -283,6 +283,11 @@ static std::string codepoint_to_utf8(uint32_t cp) {
         s += static_cast<char>(0xE0 | (cp >> 12));
         s += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
         s += static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp <= 0x10FFFF) {
+        s += static_cast<char>(0xF0 | (cp >> 18));
+        s += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+        s += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        s += static_cast<char>(0x80 | (cp & 0x3F));
     }
     return s;
 }
@@ -1329,7 +1334,10 @@ static const NfcEntry kNfcTable[] = {
 
 static constexpr int kNfcTableSize = sizeof(kNfcTable) / sizeof(kNfcTable[0]);
 
-// Decode one UTF-8 codepoint from text at position pos, advance pos
+// Decode one UTF-8 codepoint from text at position pos, advance pos.
+// On truncated input (multi-byte sequence cut short at end of string),
+// returns U+FFFD and advances pos to end-of-string, rather than returning
+// a partial codepoint and advancing past the end.
 static uint32_t nfc_decode_utf8(const std::string& s, size_t& pos) {
     uint8_t c = static_cast<uint8_t>(s[pos]);
     uint32_t cp;
@@ -1339,7 +1347,11 @@ static uint32_t nfc_decode_utf8(const std::string& s, size_t& pos) {
     else if ((c & 0xF0) == 0xE0) { cp = c & 0x0F; len = 3; }
     else if ((c & 0xF8) == 0xF0) { cp = c & 0x07; len = 4; }
     else { pos++; return 0xFFFD; }
-    for (int i = 1; i < len && pos + i < s.size(); i++) {
+    if (pos + static_cast<size_t>(len) > s.size()) {
+        pos = s.size();
+        return 0xFFFD;
+    }
+    for (int i = 1; i < len; i++) {
         cp = (cp << 6) | (static_cast<uint8_t>(s[pos + i]) & 0x3F);
     }
     pos += len;

--- a/tests/test_tokenizer.cpp
+++ b/tests/test_tokenizer.cpp
@@ -503,6 +503,16 @@ TEST(TokenizerGemma4Test, KnownSingleTokenMergesStillWork) {
     EXPECT_EQ(ids[0], tok.find_token("Lin"));
 }
 
+TEST(TokenizerGemma4Test, TruncatedUTF8AtEndDoesNotCrash) {
+    // Regression: nfc_decode_utf8 used to advance pos past end-of-string
+    // on a truncated multi-byte sequence, producing a partial codepoint.
+    // Ensure encoding a truncated UTF-8 tail terminates cleanly.
+    Tokenizer tok = make_gemma4_tokenizer();
+    std::string truncated = "Lin\xe2\x96";   // UTF-8 ▁ missing its 3rd byte
+    auto ids = tok.encode(truncated);
+    EXPECT_GT(ids.size(), 0u);
+}
+
 TEST(TokenizerGemma4Test, DecodeByteFallbackFormsValidUTF8) {
     // Bytes 0xE2 0x96 0x81 in sequence form the UTF-8 of ▁ (U+2581). After
     // Gemma-4 decode, ▁ must be replaced by ASCII space — even when the

--- a/tests/test_tokenizer.cpp
+++ b/tests/test_tokenizer.cpp
@@ -415,5 +415,113 @@ TEST(TokenizerDispatchTest, MaxLength) {
     }
 }
 
+// ---- Gemma-4 Tokenizer Tests ----
+
+// Synthetic Gemma-4 tokenizer reproducing the byte-fallback bug on "Linus".
+// merge_ranks contains "Lin u" → "Linu" as an intermediate rule whose output
+// is NOT in the vocabulary. Buggy code applies the merge unconditionally,
+// producing an unknown symbol that byte-falls-back the entire word.
+//
+// Layout:
+//   0: <unk>  1: <s>  2: </s>
+//   3: ▁
+//   4-14: individual ASCII chars (L, i, n, u, s, ...)
+//   15: "Li"  16: "Lin"  17: "us"
+//   18-273: byte fallback <0x00>..<0xFF>
+static Tokenizer make_gemma4_tokenizer() {
+    std::vector<std::string> tokens = {
+        "<unk>", "<s>", "</s>",
+        "\xe2\x96\x81",  // ▁ (id 3)
+        "L", "i", "n", "u", "s",   // 4-8
+        " ", "\t", "\n",           // 9-11 (raw whitespace, rarely used)
+    };
+    std::vector<float> scores(tokens.size(), 0.0f);
+
+    int Li_id = static_cast<int>(tokens.size());
+    tokens.push_back("Li"); scores.push_back(0.0f);
+
+    int Lin_id = static_cast<int>(tokens.size());
+    tokens.push_back("Lin"); scores.push_back(0.0f);
+
+    int us_id = static_cast<int>(tokens.size());
+    tokens.push_back("us"); scores.push_back(0.0f);
+    (void)Li_id;
+
+    // Byte fallback <0x00>..<0xFF>
+    int byte_base = static_cast<int>(tokens.size());
+    for (int b = 0; b < 256; b++) {
+        char buf[8];
+        std::snprintf(buf, sizeof(buf), "<0x%02X>", b);
+        tokens.push_back(buf);
+        scores.push_back(0.0f);
+    }
+
+    Tokenizer tok;
+    tok.load_vocab(tokens, scores, /*bos_id=*/1, /*eos_id=*/2);
+    tok.set_type("gemma4");
+    tok.set_add_bos(false);
+    tok.set_add_space_prefix(false);  // Gemma handles ▁ internally
+
+    // Merge rules (lower rank = higher priority). Key format: "a b".
+    // "Lin u" → "Linu" is an intermediate merge; "Linu" is NOT in vocab.
+    // A correct BPE implementation (like llama.cpp) skips this merge.
+    std::vector<std::string> merges = {
+        "L i",     // rank 0 → Li   (in vocab)
+        "Li n",    // rank 1 → Lin  (in vocab)
+        "Lin u",   // rank 2 → Linu (NOT in vocab — trigger for bug)
+        "u s",     // rank 3 → us   (in vocab)
+    };
+    tok.load_merges(merges);
+    (void)Lin_id; (void)us_id; (void)byte_base;
+    return tok;
+}
+
+TEST(TokenizerGemma4Test, MergeSkippedWhenResultNotInVocab) {
+    Tokenizer tok = make_gemma4_tokenizer();
+    int Lin_id = tok.find_token("Lin");
+    int us_id = tok.find_token("us");
+    ASSERT_GE(Lin_id, 0);
+    ASSERT_GE(us_id, 0);
+    ASSERT_LT(tok.find_token("Linu"), 0);  // sanity: "Linu" must NOT be in vocab
+
+    // "Linus": buggy code merges all the way to "Linu" (intermediate) then
+    // byte-fallbacks the unknown symbol, producing 5 byte-fallback tokens.
+    // Correct behavior: skip the "Lin u" merge, apply "u s → us" instead,
+    // yielding [Lin, us] — 2 tokens.
+    auto ids = tok.encode("Linus");
+    ASSERT_EQ(ids.size(), 2u) << "expected [Lin, us], got byte-fallback";
+    EXPECT_EQ(ids[0], Lin_id);
+    EXPECT_EQ(ids[1], us_id);
+}
+
+TEST(TokenizerGemma4Test, KnownSingleTokenMergesStillWork) {
+    // Regression guard: even with the merge-guard in place, a string whose
+    // full merge chain stays in-vocab must still produce a single token.
+    Tokenizer tok = make_gemma4_tokenizer();
+    auto ids = tok.encode("Lin");
+    ASSERT_EQ(ids.size(), 1u);
+    EXPECT_EQ(ids[0], tok.find_token("Lin"));
+}
+
+TEST(TokenizerGemma4Test, DecodeByteFallbackFormsValidUTF8) {
+    // Bytes 0xE2 0x96 0x81 in sequence form the UTF-8 of ▁ (U+2581). After
+    // Gemma-4 decode, ▁ must be replaced by ASCII space — even when the
+    // three bytes arrive as three separate byte-fallback tokens.
+    //
+    // Before fix: decode_spm_token runs SPIECE_SPACE replacement per-token,
+    // fails to stitch the 3 bytes together, returns literal "▁Linus".
+    Tokenizer tok = make_gemma4_tokenizer();
+    int byte_base = tok.find_token("<0x00>");
+    ASSERT_GE(byte_base, 0);
+
+    std::vector<int32_t> ids = {
+        byte_base + 0xE2, byte_base + 0x96, byte_base + 0x81,  // ▁
+        byte_base + 'L', byte_base + 'i', byte_base + 'n',
+        byte_base + 'u', byte_base + 's',
+    };
+    std::string decoded = tok.decode(ids);
+    EXPECT_EQ(decoded, " Linus");
+}
+
 } // namespace
 } // namespace imp


### PR DESCRIPTION
## Summary

Fixes a tokenizer bug in `encode_gemma4` where common names like **Linus**, **Hannes**, **Schröder** byte-fallbacked into 5–8 raw-byte tokens instead of 2-3 proper sub-word tokens — causing Gemma-4 models to produce garbage like `▁</i></i>` in place of names.

Reproduced end-to-end on `gemma-4-26B-A4B-it-Q5_K_M.gguf`: a prompt asking for "eine Geschichte über einen jungen namens linus" produced the name as `▁</i></i>` in the output text.

## Root cause

`encode_gemma4` (custom SPM-style BPE, introduced in c12b4c3 when Gemma-4 support was added) applied every BPE merge rule greedily by rank, without checking that the merged symbol was itself a vocab token. Gemma-4's 514k merge rules include intermediate steps (e.g. `Lin u → Linu`) whose output is **not** in the 262k-token vocab. Applying these unconditionally produced a symbol that failed vocab lookup and byte-fell-back the entire word:

```
imp        " Linus" → [464,388,367,314,343,348,355,353]   (8× byte-fallback)
llama.cpp  " Linus" → [9684, 605]                          (▁Lin + us)
```

The `encode_gpt2` path (used by Qwen/Llama-3/DeepSeek) was **not** affected — verified against llama.cpp on Qwen3.6. The bug was isolated to `encode_gemma4`.

## Fixes

### Commit 1: `encode_gemma4` merge-guard + char-level fallback

- Re-validate that the popped pair still has the current rank before applying (mirrors `encode_gpt2`).
- **Skip any merge whose result is not in `token_to_id_`** — matches llama.cpp behavior.
- When an unmerged symbol isn't a vocab token, fall back to per-UTF-8-character lookup **before** raw-byte `<0xNN>` fallback. Gemma-4 has single-char vocab entries for every ASCII letter, so this captures them cleanly.

### Commit 1: `decode_spm` UTF-8 reconstruction

- `decode_spm_token` runs `▁ → " "` replacement per token, so consecutive byte-fallback tokens whose raw bytes together form `▁` (U+2581 = 0xE2 0x96 0x81) never got converted. Added a second pass on the concatenated result to catch `▁` assembled across token boundaries.

### Commit 2: Defensive follow-ups (from tokenizer audit)

- `codepoint_to_utf8` gained the 4-byte UTF-8 branch (`cp >= 0x10000`).
- `nfc_decode_utf8` now returns U+FFFD on truncated multi-byte sequences at end-of-string instead of advancing past EOS with a partial codepoint.

## Test plan

- [x] **3 new unit tests** in `tests/test_tokenizer.cpp` (`TokenizerGemma4Test.*`) using synthetic vocab that reproduces the exact bug pattern (`Lin u → Linu` merge where `Linu` isn't in vocab). Plus a truncated-UTF-8 regression test.
- [x] **Full unit-test suite**: 137/137 passing (1 skipped = optional HF-golden).
- [x] **E2E against llama.cpp** on `gemma-4-26B-A4B-it-Q5_K_M.gguf` — 13 inputs produce identical token sequences, including `Linus`, ` Linus`, `Hannes`, `Schröder`, `Linus.`, `namens Linus heute.`, `Jürgen Schröder`, `Wiederhole: Linus`, `Hello world`, `café`, `中文测试`, `😊`, `Hallo 😊`.
- [x] **Round-trip** ` Linus` → tokens `[9684,605]` → ` Linus` ✓ (before fix: → `▁Linus`).
- [x] **Live chat** via `/v1/chat/completions` on the same model: the name "Linus" appears verbatim in the response (before fix: rendered as `▁</i></i>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)