### PR TITLE
storage-planner: enumerate shared-expert FFN + top-level embeddings/LM head

### DIFF
--- a/src/runtime/storage_planner.cpp
+++ b/src/runtime/storage_planner.cpp
@@ -120,6 +120,11 @@ StoragePlan plan_storage(const Model& model, const ModelConfig& cfg,
         add_tensor(L.w_gate,   TensorKind::W_GATE,   plan, next_id, total, hints);
         add_tensor(L.w_up,     TensorKind::W_UP,     plan, next_id, total, hints);
         add_tensor(L.w_down,   TensorKind::W_DOWN,   plan, next_id, total, hints);
+        // Shared-expert FFN (Nemotron / DeepSeek / Qwen3.5-MoE). Same kinds as
+        // the regular FFN projections — capabilities and tier choice mirror.
+        add_tensor(L.w_gate_shared, TensorKind::W_GATE, plan, next_id, total, hints);
+        add_tensor(L.w_up_shared,   TensorKind::W_UP,   plan, next_id, total, hints);
+        add_tensor(L.w_down_shared, TensorKind::W_DOWN, plan, next_id, total, hints);
         add_tensor(L.ssm_in,   TensorKind::SSM_IN,   plan, next_id, total, hints);
         add_tensor(L.ssm_out,  TensorKind::SSM_OUT,  plan, next_id, total, hints);
         add_tensor(L.gdn_gate, TensorKind::GDN_GATE, plan, next_id, total, hints);
@@ -127,6 +132,13 @@ StoragePlan plan_storage(const Model& model, const ModelConfig& cfg,
         for (const auto& e : L.expert_w_up)   add_tensor(e, TensorKind::EXPERT_UP,   plan, next_id, total, hints);
         for (const auto& e : L.expert_w_down) add_tensor(e, TensorKind::EXPERT_DOWN, plan, next_id, total, hints);
     }
+
+    // Top-level (model-global) tensors. Embeddings and LM head have their own
+    // tier choices (LM head is NVFP4-prequant on Qwen3-Coder-30B-FP4) and must
+    // not be omitted from the plan — the future PlanExecutor owns their GPU
+    // storage allocation too.
+    add_tensor(model.token_embedding(), TensorKind::TOK_EMBED, plan, next_id, total, hints);
+    add_tensor(model.output_proj(),     TensorKind::LM_HEAD,   plan, next_id, total, hints);
 
     // Budget satisfaction: iteratively downgrade the entry with the highest
     // bytes-saved potential until we fit or everything is at required_floor.

--- a/tests/test_weight_registry_preservation.cpp
+++ b/tests/test_weight_registry_preservation.cpp
@@ -198,6 +198,73 @@ TEST(StoragePlanner, DualPathHintRoutesCorrectly) {
 // Byte accounting: projected_vram_bytes matches sum of entry bytes
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Shared-expert FFN enumeration (Nemotron / DeepSeek / Qwen3.5-MoE style).
+// A layer with BOTH regular FFN and a shared-expert FFN must produce plan
+// entries for BOTH — otherwise the storage flip silently drops the shared
+// projection and inference produces garbage.
+// ---------------------------------------------------------------------------
+
+TEST(StoragePlanner, EnumeratesSharedExpertFFN) {
+    Model m;
+    m.config_.n_layers = 1;
+
+    TransformerLayer L;
+    // Regular FFN (3 tensors)
+    L.w_gate = make_tensor_stub(TensorKind::W_GATE, 1024, 1024, 0x1000);
+    L.w_up   = make_tensor_stub(TensorKind::W_UP,   1024, 1024, 0x2000);
+    L.w_down = make_tensor_stub(TensorKind::W_DOWN, 1024, 1024, 0x3000);
+    // Shared-expert FFN (3 additional tensors)
+    L.w_gate_shared = make_tensor_stub(TensorKind::W_GATE, 1024, 1024, 0x4000);
+    L.w_up_shared   = make_tensor_stub(TensorKind::W_UP,   1024, 1024, 0x5000);
+    L.w_down_shared = make_tensor_stub(TensorKind::W_DOWN, 1024, 1024, 0x6000);
+    m.layers_.push_back(std::move(L));
+
+    PlanHints hints;
+    hints.vram_budget_bytes = size_t{10} * 1024 * 1024 * 1024;
+
+    StoragePlan plan = plan_storage(m, m.config_, hints);
+    ASSERT_FALSE(plan.failed) << plan.failure_reason;
+
+    int gate_count = 0, up_count = 0, down_count = 0;
+    for (const auto& e : plan.entries) {
+        if (e.kind == TensorKind::W_GATE) gate_count++;
+        if (e.kind == TensorKind::W_UP)   up_count++;
+        if (e.kind == TensorKind::W_DOWN) down_count++;
+    }
+    EXPECT_EQ(gate_count, 2) << "expected 2 W_GATE entries (regular + shared)";
+    EXPECT_EQ(up_count,   2) << "expected 2 W_UP entries (regular + shared)";
+    EXPECT_EQ(down_count, 2) << "expected 2 W_DOWN entries (regular + shared)";
+}
+
+// ---------------------------------------------------------------------------
+// Top-level tensors (tok_emb, out_proj / LM head) must be enumerated.
+// For NVFP4-prequant models (Qwen3-Coder-30B), out_proj has a choice of tier
+// and would silently vanish from the plan if not enumerated.
+// ---------------------------------------------------------------------------
+
+TEST(StoragePlanner, EnumeratesTopLevelEmbeddingsAndLMHead) {
+    Model m;
+    m.config_.n_layers = 0;  // no layers — only top-level tensors
+
+    m.tok_emb_  = make_tensor_stub(TensorKind::TOK_EMBED, 128256, 4096, 0x1000);
+    m.out_proj_ = make_tensor_stub(TensorKind::LM_HEAD,   128256, 4096, 0x2000);
+
+    PlanHints hints;
+    hints.vram_budget_bytes = size_t{10} * 1024 * 1024 * 1024;
+
+    StoragePlan plan = plan_storage(m, m.config_, hints);
+    ASSERT_FALSE(plan.failed) << plan.failure_reason;
+
+    int tok_count = 0, lm_count = 0;
+    for (const auto& e : plan.entries) {
+        if (e.kind == TensorKind::TOK_EMBED) tok_count++;
+        if (e.kind == TensorKind::LM_HEAD)   lm_count++;
+    }
+    EXPECT_EQ(tok_count, 1) << "expected 1 TOK_EMBED entry";
+    EXPECT_EQ(lm_count,  1) << "expected 1 LM_HEAD entry";
+}
+
 TEST(StoragePlanner, ProjectedVRAMMatchesEntrySum) {
     Model m;
     m.config_.n_layers = 3;


### PR DESCRIPTION
## Summary
- Phase 4 incremental step 1 — close enumeration gaps in `plan_storage` that would silently drop tensors during the future storage flip.
- Shared-expert FFN (`w_{gate,up,down}_shared`, used by Nemotron / DeepSeek / Qwen3.5-MoE) was missing — reuses W_GATE/W_UP/W_DOWN TensorKinds since capabilities mirror.
- Top-level `tok_emb_` (TOK_EMBED) and `out_proj_` (LM_HEAD) added — LM head has a real tier choice on NVFP4-prequant models (Qwen3-Coder-30B-FP4) and would silently vanish from the plan.

## Motivation
The audit of the weight-storage refactor found that `plan_storage` only enumerated the per-layer projections actually present in the smallest test fixtures. Real models hit at least two paths the planner ignores today. With the plan running today only as a diagnostic (line 194 of `executor_pre_dequant.cu`), this is invisible — once Phase 4.2 promotes it to `PlanExecutor`, missing entries become silent storage drops on the affected models.

## Test plan
- [x] New `StoragePlanner.EnumeratesSharedExpertFFN` — fails without the fix
- [x] New `StoragePlanner.EnumeratesTopLevelEmbeddingsAndLMHead` — fails without the fix
- [x] Existing `WeightRegistryPreservation.NVFP4ModeDoesNotDowngradeSSMInOut` — still green (regression guard)
- [x] Full unit test set: 156 / 156 pass (2 model-dependent skipped)
- [x] Defaults: `add_tensor` skips null `Tensor.data` so existing tests with no top-level tensors stay green without changes