### PR TITLE
server: fix Gemma-4 <channel|> swallowing answer body

### DIFF
--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1218,8 +1218,12 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
                     }
                     std::string piece = snap_tok->decode_token(token);
 
-                    // Gemma-4 channel filter: strip "<|channel>NAME\n" / "<channel|>\n"
-                    // structural headers from the content stream.
+                    // Gemma-4 channel filter: strip "<|channel>NAME\n" structural
+                    // headers from the content stream. `<channel|>` is the
+                    // channel-switch marker — strip the token but do NOT enter
+                    // the scan-until-newline mode, because Q5_K_M sometimes
+                    // emits the final answer directly after it with no newline
+                    // (observed: "<|channel>thought\n<channel|>5 + 3 = 8").
                     if (snap_channel_open_id >= 0) {
                         if (channel_header_active) {
                             if (token == snap_channel_newline_id ||
@@ -1228,9 +1232,12 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
                             }
                             continue;
                         }
-                        if (token == snap_channel_open_id ||
-                            token == snap_channel_close_id) {
+                        if (token == snap_channel_open_id) {
                             channel_header_active = true;
+                            continue;
+                        }
+                        if (token == snap_channel_close_id) {
+                            // Drop just the marker; the next token is body.
                             continue;
                         }
                     }

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -163,14 +163,20 @@ void strip_channel_headers(std::string& text) {
         const bool is_close = (!is_open &&
                                i + kCloseLen <= text.size() &&
                                text.compare(i, kCloseLen, kClose) == 0);
-        if (is_open || is_close) {
-            size_t marker_len = is_open ? kOpenLen : kCloseLen;
-            size_t nl = text.find('\n', i + marker_len);
-            if (nl == std::string::npos) {
-                // No closing newline — drop the rest of the text (it's all header).
-                break;
-            }
-            i = nl + 1;
+        if (is_open) {
+            // Open marker: "<|channel>NAME\n" — strip the whole header.
+            // If no newline follows the name, the header is malformed/
+            // truncated; drop just the marker so we don't swallow body text.
+            size_t nl = text.find('\n', i + kOpenLen);
+            i = (nl == std::string::npos) ? (i + kOpenLen) : (nl + 1);
+            continue;
+        }
+        if (is_close) {
+            // Close / channel-switch marker: just drop the marker token itself.
+            // Gemma-4 Q5_K_M emits "<channel|>answer body" directly without a
+            // trailing newline, so we must NOT wait for one here — otherwise
+            // the answer body gets eaten (observed on "What is 5+3?").
+            i += kCloseLen;
             continue;
         }
         out.push_back(text[i++]);


### PR DESCRIPTION
## Summary
- `<channel|>` is the channel-switch marker, not a header opener — Q5_K_M sometimes emits the final answer directly after it with no trailing newline (observed: `<|channel>thought\n<channel|>5 + 3 = 8`).
- Both the streaming path in `handlers.cpp` and the bulk `strip_channel_headers` helper used to scan-until-newline for both markers, eating the entire answer when no newline followed.
- Fix: only `<|channel>` enters scan-until-newline mode; `<channel|>` drops just the marker and falls through to body. Truncated `<|channel>` (no newline) also drops just the marker now, instead of discarding everything to EOS.

## Note
This commit was originally pushed to `feat/anthropic-messages-streaming` after that branch had already been merged via #36, so it never reached main. Re-opening on a fresh branch.

## Test plan
- [x] Local 12-case behavior harness on `strip_channel_headers` (incl. regression `close_no_nl_keeps_body`)
- [x] `imp:latest` builds clean (full CUDA build via `docker compose build imp-server`)