### PR TITLE
executor: extend registry shim + parity diagnostic (Phase 4 step 2)

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1527,6 +1527,10 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         L.w_gate_id   = register_tensor(L.w_gate,   TensorKind::W_GATE);
         L.w_up_id     = register_tensor(L.w_up,     TensorKind::W_UP);
         L.w_down_id   = register_tensor(L.w_down,   TensorKind::W_DOWN);
+        // Shared-expert FFN — matches StoragePlanner enumeration from PR #38.
+        L.w_gate_shared_id = register_tensor(L.w_gate_shared, TensorKind::W_GATE);
+        L.w_up_shared_id   = register_tensor(L.w_up_shared,   TensorKind::W_UP);
+        L.w_down_shared_id = register_tensor(L.w_down_shared, TensorKind::W_DOWN);
         L.ssm_in_id   = register_tensor(L.ssm_in,   TensorKind::SSM_IN);
         L.ssm_out_id  = register_tensor(L.ssm_out,  TensorKind::SSM_OUT);
         L.gdn_gate_id = register_tensor(L.gdn_gate, TensorKind::GDN_GATE);
@@ -1573,9 +1577,44 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     }
     // Register model-level (non-layer) tensors.
     const_cast<Model*>(model_)->out_proj_id = register_tensor(model_->output_proj(), TensorKind::LM_HEAD);
+    const_cast<Model*>(model_)->tok_emb_id  = register_tensor(model_->token_embedding(), TensorKind::TOK_EMBED);
 
     IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)",
                  registry_.size());
+
+    // Phase 4 parity diagnostic: compare registry vs plan. The registry only
+    // carries tensors whose source pointer landed in a wcache_ map (quantize-
+    // able projections). The plan enumerates every TransformerLayer field with
+    // data, which includes some always-FP16/FP32 tensors (norms, rope_freqs)
+    // that bypass wcache_ entirely. To make the comparison apples-to-apples,
+    // count only plan entries whose kind can live in wcache_ (FP16/FP8/NVFP4/
+    // MXFP4 tiers).
+    {
+        StoragePlan parity_plan = plan_storage(*model_, cfg, hints_);
+        size_t plan_registerable = 0;
+        for (const auto& e : parity_plan.entries) {
+            switch (e.tier) {
+                case StorageTier::FP16:
+                case StorageTier::FP8:
+                case StorageTier::NVFP4:
+                case StorageTier::CUTLASS_NVFP4:
+                case StorageTier::MXFP4:
+                    ++plan_registerable; break;
+                default: break;
+            }
+        }
+        size_t registry_count = registry_.size();
+        if (plan_registerable != registry_count) {
+            IMP_LOG_WARN("Phase-4 parity: registry=%zu handles, plan=%zu wcache-tier "
+                         "entries (diff=%zd). Expected to converge by Phase 5.",
+                         registry_count, plan_registerable,
+                         static_cast<ssize_t>(plan_registerable) -
+                             static_cast<ssize_t>(registry_count));
+        } else {
+            IMP_LOG_INFO("Phase-4 parity: registry=%zu handles match plan "
+                         "wcache-tier count", registry_count);
+        }
+    }
 }
 
 } // namespace imp

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -49,6 +49,7 @@ public:
     GGMLQuantType out_proj_qtype_ = GGMLQuantType::NONE;
     TransformerLayer::NvFP4PreQuantWeight nvfp4_out_proj_;  // prequant LM head scales
     TensorID out_proj_id = kInvalidTensorID;  // registry handle for LM head (Task 3.5)
+    TensorID tok_emb_id  = kInvalidTensorID;  // registry handle for token embedding
     std::vector<TransformerLayer> layers_;
     std::unique_ptr<Tokenizer> tokenizer_;
 

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -147,6 +147,11 @@ struct TransformerLayer {
     TensorID w_gate_id   = kInvalidTensorID;
     TensorID w_up_id     = kInvalidTensorID;
     TensorID w_down_id   = kInvalidTensorID;
+    // Shared-expert FFN (Nemotron / DeepSeek / Qwen3.5-MoE). kInvalidTensorID
+    // when the layer has no shared expert branch.
+    TensorID w_gate_shared_id = kInvalidTensorID;
+    TensorID w_up_shared_id   = kInvalidTensorID;
+    TensorID w_down_shared_id = kInvalidTensorID;
     TensorID ssm_in_id   = kInvalidTensorID;
     TensorID ssm_out_id  = kInvalidTensorID;
     TensorID gdn_gate_id = kInvalidTensorID;


### PR DESCRIPTION
## Summary
- Extends the Phase-2 WeightRegistry shim in `pre_dequant_weights` to register shared-expert FFN (`w_{gate,up,down}_shared`) and the token embedding, matching the StoragePlanner enumeration landed in #38.
- Adds `TensorID` fields to `TransformerLayer` (`w_{gate,up,down}_shared_id`) and `Model` (`tok_emb_id`). Default `kInvalidTensorID`; no consumer reads them yet.
- Adds a Phase-4 parity diagnostic that compares `registry_.size()` against the count of plan entries at wcache-capable tiers. FP32-only kinds (norms, rope_freqs) are filtered out so the comparison is apples-to-apples.

## Observed signal
On Qwen3-4B Q4_K_M today the diagnostic prints:
```
StoragePlanner (diagnostic): 254 entries, projected VRAM 3432.81 MiB
WeightRegistry populated with 38 handles (phase-2 shim)
Phase-4 parity: registry=38 handles, plan=254 wcache-tier entries (diff=216)
```
A real, actionable gap. Subsequent steps extend the registry until this converges to 0 — which is the exit condition for the Phase-4 storage flip.

## Test plan
- [x] `imp-tests` full unit filter: 160 / 160 pass (2 model-dependent skipped)
- [x] Real-model smoke on Qwen3-4B-Instruct Q4_K_M: coherent output, ~128 tok/s decode (no regression)
- [x] Parity diagnostic prints WARN at load with diff count; no crash, no behavior change