### PR TITLE
executor: migrate fused_kv / fused_gate_up to registry handles (Phase 4 step 5)

### DIFF
--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -408,14 +408,29 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                               qscratch_.d_act_scale, fp8_hwv->payload.fp8.d_scale, stream);
             } else {
                 // Try fused K+V path: single strided batched GEMM for both projections.
-                // fused_kv is indexed by layer number; no WeightHandle equivalent yet.
-                auto fused_kv_it = wcache_.fused_kv.find(layer);
+                // Prefer registry handle (Phase 4 path); fall back to wcache_
+                // lookup if the handle is invalid (e.g., new layer added but
+                // not yet registered, or registry not yet populated).
                 // Gemma 4 per-layer shapes break strided-batched K+V layout assumptions.
-                if (n > 1 && fused_kv_it != wcache_.fused_kv.end() && !per_layer_shapes) {
+                const Tensor* fused_kv = nullptr;
+                Tensor fused_from_handle;
+                if (ly.fused_kv_id != kInvalidTensorID) {
+                    const auto& h = registry_.handle(ly.fused_kv_id);
+                    if (h.payload.fp16.data) {
+                        fused_from_handle = Tensor(h.payload.fp16.data, DType::FP16,
+                                                   2, h.shape, true);
+                        fused_kv = &fused_from_handle;
+                    }
+                }
+                if (!fused_kv) {
+                    auto it = wcache_.fused_kv.find(layer);
+                    if (it != wcache_.fused_kv.end()) fused_kv = &it->second;
+                }
+                if (n > 1 && fused_kv && !per_layer_shapes) {
                     // Q: still separate (different output dim with GQA)
                     gemm_dispatch(no, ly.wq, ly.wq_qtype, q_target, ctx);
                     // K+V: one batched cuBLAS call
-                    gemm_kv_batched(no, fused_kv_it->second, kk, vv, stream);
+                    gemm_kv_batched(no, *fused_kv, kk, vv, stream);
                 } else {
                     gemm_dispatch(no, ly.wq, ly.wq_qtype, q_target, ctx);
                     gemm_dispatch(no, ly.wk, ly.wk_qtype, kk, ctx);

--- a/src/graph/executor_ffn.cu
+++ b/src/graph/executor_ffn.cu
@@ -214,11 +214,25 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 gemm_cublaslt(fp8_no, fp8_tu, uo, 1.0f, 0.0f,
                               qscratch_.d_act_scale, hwu->payload.fp8.d_scale, stream);
             } else {
-                // fused_gate_up is indexed by layer number; no WeightHandle equivalent yet.
-                auto fused_gu_it = wcache_.fused_gate_up.find(layer);
-                if (n > 1 && fused_gu_it != wcache_.fused_gate_up.end()) {
+                // Prefer registry handle (Phase 4 path); fall back to wcache_
+                // lookup if the handle is invalid.
+                const Tensor* fused_gu = nullptr;
+                Tensor fused_from_handle;
+                if (ly.fused_gate_up_id != kInvalidTensorID) {
+                    const auto& h = registry_.handle(ly.fused_gate_up_id);
+                    if (h.payload.fp16.data) {
+                        fused_from_handle = Tensor(h.payload.fp16.data, DType::FP16,
+                                                   2, h.shape, true);
+                        fused_gu = &fused_from_handle;
+                    }
+                }
+                if (!fused_gu) {
+                    auto it = wcache_.fused_gate_up.find(layer);
+                    if (it != wcache_.fused_gate_up.end()) fused_gu = &it->second;
+                }
+                if (n > 1 && fused_gu) {
                     // Batched gate+up: single cuBLAS call for both projections
-                    gemm_pair_batched(no, fused_gu_it->second, go, uo, stream);
+                    gemm_pair_batched(no, *fused_gu, go, uo, stream);
                 } else {
                     gemm_dispatch(no, ly.w_gate, ly.w_gate_qtype, go, ctx);
                     gemm_dispatch(no, ly.w_up,   ly.w_up_qtype,   uo, ctx);

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1579,6 +1579,27 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     const_cast<Model*>(model_)->out_proj_id = register_tensor(model_->output_proj(), TensorKind::LM_HEAD);
     const_cast<Model*>(model_)->tok_emb_id  = register_tensor(model_->token_embedding(), TensorKind::TOK_EMBED);
 
+    // Register fused KV / gate+up overlays. Layer-keyed (not pointer-keyed)
+    // because a fused tensor is built fresh — the source pointers (wk, wv) are
+    // the *unfused* weights and don't appear in any per-tensor wcache_ map.
+    auto register_fused = [&](TensorKind kind, const Tensor& t) -> TensorID {
+        if (!t.data) return kInvalidTensorID;
+        TensorID id = registry_.reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
+        auto& h = registry_.handle(id);
+        h.primary_tier = StorageTier::FP16;
+        h.payload.fp16.data = static_cast<half*>(t.data);
+        return id;
+    };
+    for (int i = 0; i < cfg.n_layers; ++i) {
+        auto& L = const_cast<Model*>(model_)->layer(i);
+        if (auto it = wcache_.fused_kv.find(i); it != wcache_.fused_kv.end()) {
+            L.fused_kv_id = register_fused(TensorKind::FUSED_KV, it->second);
+        }
+        if (auto it = wcache_.fused_gate_up.find(i); it != wcache_.fused_gate_up.end()) {
+            L.fused_gate_up_id = register_fused(TensorKind::FUSED_GATE_UP, it->second);
+        }
+    }
+
     IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)",
                  registry_.size());
 

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -155,6 +155,11 @@ struct TransformerLayer {
     TensorID ssm_in_id   = kInvalidTensorID;
     TensorID ssm_out_id  = kInvalidTensorID;
     TensorID gdn_gate_id = kInvalidTensorID;
+    // Fused KV / gate+up handles. Populated when the runtime decides to build
+    // a fused weight pair for strided batched prefill GEMM. kInvalidTensorID
+    // means no fused weight was built for this layer (per-layer dispatch path).
+    TensorID fused_kv_id      = kInvalidTensorID;
+    TensorID fused_gate_up_id = kInvalidTensorID;
 
     // Per-expert WeightRegistry indices (populated by pre_dequant_weights, Task 3.4).
     // Parallel to expert_w_gate / expert_w_up / expert_w_down vectors.


### PR DESCRIPTION
## Summary
Phase 4 incremental step 5 — close the last two consumer-side `wcache_` probes (the `fused_kv` / `fused_gate_up` lookups in attention and FFN) by routing them through `WeightRegistry` handles, with a wcache_ fallback for safety.

## Schema
`TransformerLayer` gains:
- `TensorID fused_kv_id` (kind `FUSED_KV`)
- `TensorID fused_gate_up_id` (kind `FUSED_GATE_UP`)

Default `kInvalidTensorID`. Populated by pre_dequant_weights when the runtime decides to build a fused weight pair for the layer.

## Registration
After the fused build loops in Phase 1, walk `wcache_.fused_kv` / `wcache_.fused_gate_up` and register each populated layer (kind `FUSED_KV`/`FUSED_GATE_UP`, tier `FP16`, payload borrows the existing pointer). Layer-keyed registration is separate from the pointer-keyed `register_tensor` because fused weights are runtime-built — there is no source pointer to look up via `infer_tier_from_wcache`.

## Consumer migration
`executor_attention.cu` (line ~412) and `executor_ffn.cu` (line ~218) prefer the registry handle, fall back to the wcache_ map if the handle is invalid. The fallback guarantees no regression even if registration logic has a corner-case miss.

## Three-mode end-to-end verification

### 1. Q4_K_M (no fused built — fallback path)
- `Phase-4 overlay: registry=38 cached / plan-ideal=254`
- Q4_K_M is sub-8-bit, skips Phase 1 entirely; no fused weights built.
- Output: coherent poetry ("Painting the heavens with soft, shifting hues, …"), ~226 tok/s decode.

### 2. Q8_0 default (FP8 prefill mode — registry path, full convergence)
- `Phase-4 overlay: registry=254 cached / plan-ideal=254 (uncached 0)`
- All 252 dense projections in fp8 + cutlass_nvfp4, tok_emb + LM_head registered.
- **First model to hit full parity under Option C semantics.**
- Output: coherent, ~184 tok/s decode.

### 3. Q8_0 with `IMP_DEBUG_RAW=1` (Phase 1 forced — fused KV actually built)
- `Phase-4 overlay: registry=204 / plan-ideal=254`, `wcache fused_kv=4 fused_gate_up=0`
- **Fused KV registered as 4 handles + consumed via the new registry path** (proves the migration is real, not just a no-op).
- Output: coherent ("Clouds drift on silent winds, painting skies with soft, shifting hues, whispers of rain in their silver veils."), ~138 tok/s decode (FP16 path is naturally slower than FP8).

### 4. Qwen3.5-4B Q8_0 GDN (d0e9b03 protection in action)
- Diagnostic: `fp16=48 nvfp4=129 cutlass_nvfp4=129` — **the 48 SSM_IN/SSM_OUT tensors are preserved at FP16** even under NVFP4-only decode mode, exactly as the plan's `required_floor=FP16` capability dictates.
- "GDN/SSM: excluding 48 recurrent projections from NVFP4 cache" → "NVFP4 only mode: preserved 48 FP16 entries (1440.00 MiB)" → registry counts confirm.
- This is the **bug class Phase 4 was designed to prevent** (silent FP16-only tensor drop under NVFP4 mode), now provably caught both at plan-time (existing `WeightRegistryPreservation.NVFP4ModeDoesNotDowngradeSSMInOut` test) and at runtime (the diagnostic numbers match plan expectations).
- Note: Qwen3.5 Q8_0 has a pre-existing repetition tendency on raw completion (see memory note from 2026-04-22); not caused by this refactor.

## Test plan
- [x] 156/156 unit tests pass
- [x] Q4_K_M smoke (fallback path): coherent, no regression
- [x] Q8_0 default (registry path): coherent + full parity
- [x] Q8_0 IMP_DEBUG_RAW (registry path with fused_kv=4 actually built): coherent
- [x] Qwen3.5-4B GDN: SSM tensors preserved at FP16 under NVFP4-only mode (d0e9b03 class)