### PR TITLE
executor: per-kind breakdown in Phase-4 diagnostic (Phase 4 step 6)

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1632,6 +1632,32 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                      "(uncached %zu remain as native GGUF blocks)",
                      registry_count, plan_overlay,
                      plan_overlay > registry_count ? plan_overlay - registry_count : 0);
+
+        // When there is a registry/plan gap, surface the by-kind delta so the
+        // missing TensorKinds are immediately visible. Helps when adding a new
+        // model that has tensor kinds the runtime caches but plan_storage
+        // doesn't yet enumerate (or vice versa).
+        if (registry_count < plan_overlay) {
+            int plan_per_kind[static_cast<int>(TensorKind::_COUNT)]     = {0};
+            int registry_per_kind[static_cast<int>(TensorKind::_COUNT)] = {0};
+            for (const auto& e : ideal_plan.entries) {
+                bool overlay = (e.tier == StorageTier::FP16  || e.tier == StorageTier::FP8 ||
+                                e.tier == StorageTier::NVFP4 || e.tier == StorageTier::CUTLASS_NVFP4 ||
+                                e.tier == StorageTier::MXFP4);
+                if (overlay) ++plan_per_kind[static_cast<int>(e.kind)];
+            }
+            for (TensorID id = 0; id < static_cast<TensorID>(registry_.size()); ++id) {
+                ++registry_per_kind[static_cast<int>(registry_.handle(id).kind)];
+            }
+            for (int k = 0; k < static_cast<int>(TensorKind::_COUNT); ++k) {
+                int diff = plan_per_kind[k] - registry_per_kind[k];
+                if (diff > 0) {
+                    IMP_LOG_INFO("Phase-4 gap by kind: %s plan=%d registry=%d (uncached=%d)",
+                                 tensor_kind_name(static_cast<TensorKind>(k)),
+                                 plan_per_kind[k], registry_per_kind[k], diff);
+                }
+            }
+        }
         IMP_LOG_INFO("Phase-4 plan-ideal tiers: fp16=%zu fp8=%zu nvfp4=%zu "
                      "cutlass_nvfp4=%zu mxfp4=%zu fp32=%zu",
                      plan_fp16, plan_fp8, plan_nvfp4, plan_cutlass_nvfp4,


### PR DESCRIPTION
## Summary
Phase 4 incremental step 6 — when the overlay registry has fewer handles than the plan-ideal, emit one INFO line per `TensorKind` that contributes to the gap. Pure diagnostic; no behavior change.

## Real findings on first run

**Qwen3-4B Q4_K_M:** the 37 NVFP4-cached entries decompose as 18 WV + 18 W_DOWN + 1 LM_HEAD; all other projections (WQ/WK/WO/W_GATE/W_UP) stay as Q4_K_M blocks. Previously you had to read the dequant code to know which.

**Qwen3.5-4B Q8_0 GDN:** \`GDN_GATE plan=24 registry=0\` — has \`ALL_QUANT\` capability but is never cached by the runtime. Likely an intentional skip (similar to SSM_IN/OUT recurrent-precision exclusion) but previously invisible to anyone reading the logs.

## Test plan
- [x] Q4_K_M smoke prints per-kind gap breakdown
- [x] GDN Q8_0 smoke prints per-kind gap breakdown
- [x] No behavior change; coherent inference preserved

## PR-stack
Bases on #42 → #41 → #40.