### PR TITLE
storage-planner: exclude GDN_GATE from overlay enumeration (Phase 4 step 7)

### DIFF
--- a/src/runtime/storage_planner.cpp
+++ b/src/runtime/storage_planner.cpp
@@ -127,7 +127,13 @@ StoragePlan plan_storage(const Model& model, const ModelConfig& cfg,
         add_tensor(L.w_down_shared, TensorKind::W_DOWN, plan, next_id, total, hints);
         add_tensor(L.ssm_in,   TensorKind::SSM_IN,   plan, next_id, total, hints);
         add_tensor(L.ssm_out,  TensorKind::SSM_OUT,  plan, next_id, total, hints);
-        add_tensor(L.gdn_gate, TensorKind::GDN_GATE, plan, next_id, total, hints);
+        // gdn_gate is intentionally NOT enumerated for overlay caching: it is
+        // consumed only by the specialized GDN scan kernel (gdn_kernel.cu) via
+        // the raw `L.gdn_gate.data` pointer, never through `gemm_dispatch`. An
+        // overlay copy would burn VRAM with no consumer. The diagnostic in
+        // pre_dequant_weights would otherwise (correctly) flag a 24-handle
+        // "gap" on every GDN model — see commit 3c7803a for the discovery and
+        // PR #43 for the per-kind gap diagnostic that surfaced this.
         for (const auto& e : L.expert_w_gate) add_tensor(e, TensorKind::EXPERT_GATE, plan, next_id, total, hints);
         for (const auto& e : L.expert_w_up)   add_tensor(e, TensorKind::EXPERT_UP,   plan, next_id, total, hints);
         for (const auto& e : L.expert_w_down) add_tensor(e, TensorKind::EXPERT_DOWN, plan, next_id, total, hints);

--- a/tests/test_weight_registry_preservation.cpp
+++ b/tests/test_weight_registry_preservation.cpp
@@ -195,6 +195,37 @@ TEST(StoragePlanner, DualPathHintRoutesCorrectly) {
 }
 
 // ---------------------------------------------------------------------------
+// GDN_GATE is intentionally excluded from overlay enumeration: the GDN scan
+// kernel consumes the raw weight pointer, never through gemm_dispatch, so an
+// overlay copy would burn VRAM without a consumer. Locking this decision
+// against accidental re-introduction.
+// ---------------------------------------------------------------------------
+
+TEST(StoragePlanner, GDNGateIsNotEnumeratedForOverlay) {
+    Model m;
+    m.config_.n_layers = 2;
+
+    for (int i = 0; i < 2; ++i) {
+        TransformerLayer L;
+        L.gdn_gate = make_tensor_stub(TensorKind::GDN_GATE,
+                                      4096, 4096,
+                                      static_cast<uintptr_t>(i * 100 + 1));
+        m.layers_.push_back(std::move(L));
+    }
+
+    PlanHints hints;
+    hints.vram_budget_bytes = size_t{10} * 1024 * 1024 * 1024;
+
+    StoragePlan plan = plan_storage(m, m.config_, hints);
+    ASSERT_FALSE(plan.failed) << plan.failure_reason;
+
+    for (const auto& e : plan.entries) {
+        EXPECT_NE(e.kind, TensorKind::GDN_GATE)
+            << "GDN_GATE must not appear in overlay plan — see storage_planner.cpp";
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Byte accounting: projected_vram_bytes matches sum of entry bytes
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Phase 4 incremental step 7 — close the GDN_GATE gap surfaced by the per-kind diagnostic in #43.

GDN_GATE is consumed only by the specialized GDN scan kernel via the raw `L.gdn_gate.data` pointer; it never goes through `gemm_dispatch`. An overlay copy would burn VRAM with no consumer, so removing it from `plan_storage` aligns the plan with reality.

## Convergence on Qwen3.5-4B Q8_0 GDN
- Before: registry=178 / plan-ideal=202 (24 GDN_GATE uncached)
- After: registry=178 / plan-ideal=178 (uncached 0)

Second model after Q8_0 dense (Step 5) to hit full parity under Option C.

## Regression guard
`StoragePlanner.GDNGateIsNotEnumeratedForOverlay` locks the decision in.

## PR-stack
Bases on #43 → #42 → #41 → #40.