### PR TITLE
executor: drop wcache_ fallback for fused weights (Phase 4 step 8)

### DIFF
--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -407,10 +407,10 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                 gemm_cublaslt(fp8_no, fp8_tv, vv, 1.0f, 0.0f,
                               qscratch_.d_act_scale, fp8_hwv->payload.fp8.d_scale, stream);
             } else {
-                // Try fused K+V path: single strided batched GEMM for both projections.
-                // Prefer registry handle (Phase 4 path); fall back to wcache_
-                // lookup if the handle is invalid (e.g., new layer added but
-                // not yet registered, or registry not yet populated).
+                // Try fused K+V path: single strided batched GEMM for both
+                // projections. Read via WeightRegistry handle — the wcache_
+                // map is no longer the lookup mechanism (it remains the
+                // storage owner; cleanup happens via wcache_.clear()).
                 // Gemma 4 per-layer shapes break strided-batched K+V layout assumptions.
                 const Tensor* fused_kv = nullptr;
                 Tensor fused_from_handle;
@@ -421,10 +421,6 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                                    2, h.shape, true);
                         fused_kv = &fused_from_handle;
                     }
-                }
-                if (!fused_kv) {
-                    auto it = wcache_.fused_kv.find(layer);
-                    if (it != wcache_.fused_kv.end()) fused_kv = &it->second;
                 }
                 if (n > 1 && fused_kv && !per_layer_shapes) {
                     // Q: still separate (different output dim with GQA)

--- a/src/graph/executor_ffn.cu
+++ b/src/graph/executor_ffn.cu
@@ -214,8 +214,9 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 gemm_cublaslt(fp8_no, fp8_tu, uo, 1.0f, 0.0f,
                               qscratch_.d_act_scale, hwu->payload.fp8.d_scale, stream);
             } else {
-                // Prefer registry handle (Phase 4 path); fall back to wcache_
-                // lookup if the handle is invalid.
+                // Read fused gate+up via WeightRegistry handle — the wcache_
+                // map is no longer the lookup mechanism (it remains the
+                // storage owner; cleanup happens via wcache_.clear()).
                 const Tensor* fused_gu = nullptr;
                 Tensor fused_from_handle;
                 if (ly.fused_gate_up_id != kInvalidTensorID) {
@@ -225,10 +226,6 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                                    2, h.shape, true);
                         fused_gu = &fused_from_handle;
                     }
-                }
-                if (!fused_gu) {
-                    auto it = wcache_.fused_gate_up.find(layer);
-                    if (it != wcache_.fused_gate_up.end()) fused_gu = &it->second;
                 }
                 if (n > 1 && fused_gu) {
                     // Batched gate+up: single cuBLAS call for both projections


### PR DESCRIPTION
Phase 4 step 8 — registry handle is now single source of truth for fused overlay tensors. wcache_ still owns storage (Phase 5 work). Verified on Q8_0+IMP_DEBUG_RAW (fused active) and Q4_K_M (no fused). Bases on #44 → #43 → #42 → #41 → #40.