### PR TITLE
executor: native-layer counterpart to Phase-4 overlay diagnostic (step 9)

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1669,6 +1669,15 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                      wcache_.cutlass_nvfp4.size(), wcache_.cutlass_mxfp4.size(),
                      wcache_.nvfp4_moe.size(), wcache_.fused_kv.size(),
                      wcache_.fused_gate_up.size());
+        // Native layer counterpart to the overlay diagnostic: tensors uploaded
+        // as their on-disk format and dispatched through qtype-specific kernels
+        // (no tier choice, no cascade-bug class). gpu_allocations_ tracks every
+        // GPU pointer the Model owns — Q4_K_M / Q5_K_M / Q6_K / Q8_0 / MXFP4
+        // blocks, norms, embeddings, scratch buffers. Together with the overlay
+        // counts above this gives the full Option-C two-layer storage picture.
+        IMP_LOG_INFO("Phase-4 native: %zu Model::gpu_allocations_ pointers "
+                     "(GGUF blocks + norms + scratch — bypass the overlay layer)",
+                     model_->gpu_allocations_.size());
     }
 }
 


### PR DESCRIPTION
## Summary
Phase 4 incremental step 9 — adds `Model::gpu_allocations_.size()` to the load log, so the **complete two-layer Option-C storage picture** is visible for the first time.

## Multi-model verification

| Model | Format | overlay | plan | parity | native |
|---|---|---:|---:|---:|---:|
| Llama-3.2-3B | Q8_0 dense | 198 | 198 | ✅ full | 255 |
| Qwen3.5-4B GDN | Q8_0 hybrid | 178 | 178 | ✅ full | 426 |
| Qwen3-4B | Q4_K_M dense | 38 | 254 | partial (216 native blocks) | 398 |
| Gemma-3-12B | Q8_0 dense | 260 | 338 | partial (78) | 626 |
| Gemma-4-26B-A4B | Q4_K_M MoE | 19 | 207 | partial (188 expert blocks) | 692 |

**Findings from the table:**
- **Q8_0 dense models converge to full parity** (Llama, Qwen — registry == plan-ideal). The Phase-2 shim already populates everything quantize-able.
- **GDN models converge** after #44 (GDN_GATE skip).
- **Gemma-3 partial gap (78)** — likely sliding-window attention layers caching differently. Per-kind breakdown in #43 will surface which TensorKinds.
- **Q4_K_M / Gemma-4 MoE** — most weights stay as GGUF blocks (native layer), only the largest get NVFP4-cached. Expected; documented by Step 8 (#45).
- **Native pointer counts** scale with model architecture: dense ≈ ~3×layers, GDN+SSM ≈ ~13× per layer, MoE ≈ ~26× per layer (per-expert blocks).

## What this enables
With both layers visible, future Phase-4 work can:
1. Track total VRAM split between native blocks vs overlay caches
2. Spot regressions where overlay caching unexpectedly drops (registry shrinks, native grows)
3. Compare model families on the storage-pattern axis without instrumentation

Pure diagnostic; no behavior change. PR-stack: bases on #45 → #44 → #43 → #42 → #41 → #40.