### PR TITLE
test: strengthen GDN coherence check + document Qwen3.5 GDN regression

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,36 @@
 
 ## Open Work
 
+### Qwen 3.5 GDN Recurrent-State Collapse (REGRESSED from v0.6)
+**Severity: high — blocks production on all Qwen3.5 Q8_0 models.**
+
+Raw-completion and chatml generation both collapse into token repetition after 3–8 tokens on Qwen3.5-4B and Qwen3.5-9B Q8_0:
+
+```
+prompt: "Hello world, my name is"
+output: " my my my my my my my..."
+
+prompt: "Once upon a time in a faraway kingdom..."
+output: " journeyed a time who whoed a time."
+```
+
+Verified on clean main build (2026-04-24): `imp:main` (no Phase 4 changes) reproduces the bug on both Qwen3.5-4B-Q8_0 and Qwen3.5-9B-Q8_0. Qwen3-4B-Q8_0 (dense, non-GDN) does NOT reproduce — isolates bug to GDN scan path.
+
+Attempted workarounds (all fail):
+- `--temperature 0.8 --top-p 0.9 --seed 42` → still repetition (distribution is peaked)
+- `IMP_GDN_REF=1` (reference unfused scan) → same collapse pattern ruling out the fused-scan-register-cache
+- `IMP_DEBUG_RAW=1` (all caches off) → same collapse
+
+Root cause unknown. Likely one of:
+- Recurrent state `H[n_heads, state_size, head_dim]` accumulating toward fixed point
+- Output-gate / RMSNormGated+SiLU applying in a state-erasing way
+- Pre-fill vs. decode state-handoff mismatch
+- Sampling-input logit collapse (layer-diff vs llama.cpp would isolate)
+
+Memory note from 2026-04-23 claimed coherence post PR #30 (launch_bounds + partial-RoPE fixes); that claim does not hold on main today. Likely latent under specific prompts / seeds that the benchmark harness happens to not exercise.
+
+**Next steps:** per-layer tensor diff vs llama.cpp on a 20-token decode run; dump `h_state` across tokens to see if state is actually updating; compare against Qwen3.6-A3B (same GDN architecture, was working).
+
 ### MXFP4 Native GGUF Weight Format
 Plan documented in `docs/MXFP4_GGUF_PLAN.md`. Native MXFP4 weights would feed directly into Blackwell tensor cores via CUTLASS — zero dequant overhead, expected 2-4x prefill speedup vs Q4_K_M.
 

--- a/tests/test_e2e_models.cpp
+++ b/tests/test_e2e_models.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -172,20 +173,49 @@ protected:
 
 TEST_F(GDNModelTest, GenerateCoherentOutput) {
     ImpGenerateParams params = imp_generate_params_default();
-    params.max_tokens = 32;
+    params.max_tokens = 64;   // need ≥10 words to exercise the unique-ratio check
     params.temperature = 0.0f;
     params.apply_chat_template = 1;
 
     char output[4096];
     size_t len = 0;
-    ASSERT_EQ(imp_generate(ctx_, "What is the largest planet in our solar system? One word answer.", &params,
+    // A prompt that forces a longer natural answer — "one word" prompts exit
+    // after 2-3 tokens and never stress the recurrent scan past token 3.
+    ASSERT_EQ(imp_generate(ctx_,
+                           "Write a short paragraph about the planet Jupiter.", &params,
                            output, sizeof(output), &len), IMP_SUCCESS);
     EXPECT_GT(len, 0u);
 
-    // GDN model may not follow instructions well at small sizes.
-    // Verify generation is non-degenerate (not all repetition of a single token).
     std::string text(output, len);
     EXPECT_GT(text.size(), 5u) << "Output too short: " << text;
+
+    // Recurrent-state collapse detector: split on whitespace, count unique
+    // words. A degenerate output like " my my my my my..." has many tokens
+    // but very few unique words. This catches the 2026-04-24 GDN regression
+    // that the length-only check above missed.
+    std::vector<std::string> words;
+    {
+        std::string cur;
+        for (char c : text) {
+            if (c == ' ' || c == '\n' || c == '\t') {
+                if (!cur.empty()) { words.push_back(cur); cur.clear(); }
+            } else {
+                cur.push_back(c);
+            }
+        }
+        if (!cur.empty()) words.push_back(cur);
+    }
+    if (words.size() >= 10) {
+        std::set<std::string> unique(words.begin(), words.end());
+        // Require at least 30 % unique words once we have ≥10 words.
+        // Degenerate " my my my my..." × 30 = 30 words, 1 unique = 3 %.
+        const double unique_ratio = static_cast<double>(unique.size()) / words.size();
+        EXPECT_GE(unique_ratio, 0.30)
+            << "Recurrent-state collapse detected: "
+            << unique.size() << " unique / " << words.size()
+            << " total words (" << (unique_ratio * 100.0) << "%)\n"
+            << "Full output: " << text;
+    }
 }
 
 TEST_F(GDNModelTest, MultiTurnGDNState) {


### PR DESCRIPTION
## Summary
- **Test**: strengthen \`GDNModelTest.GenerateCoherentOutput\` from a size-only check to a token-repetition-ratio check (unique / total ≥ 30 %, fires only when output has ≥10 words)
- **TODO.md**: document the Qwen3.5-4B/9B Q8_0 recurrent-state-collapse regression that reproduces on clean \`imp:main\` today

## Background
Today's audit reproduced severe \`"my my my my..."\` output on Qwen3.5-4B Q8_0 on clean main, across \`IMP_GDN_REF=1\` / \`IMP_DEBUG_RAW=1\` / various sampling. Qwen3-4B (dense) does not reproduce, isolating the bug to GDN scan path. Old test assertion \`text.size() > 5\` trivially passed on such degenerate output. New check catches it.

## Does NOT fix the bug
Separate root-cause work tracked in TODO.md.