### PR TITLE
registry: own fused_kv storage — first Phase 4.2 ownership transfer (step 10)

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1580,14 +1580,21 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     const_cast<Model*>(model_)->tok_emb_id  = register_tensor(model_->token_embedding(), TensorKind::TOK_EMBED);
 
     // Register fused KV / gate+up overlays. Layer-keyed (not pointer-keyed)
-    // because a fused tensor is built fresh — the source pointers (wk, wv) are
-    // the *unfused* weights and don't appear in any per-tensor wcache_ map.
+    // because a fused tensor is built fresh — the source pointers (wk, wv)
+    // are the *unfused* weights and don't appear in any per-tensor wcache_ map.
+    //
+    // Ownership transfer (Phase 4.2): the registry handle takes ownership of
+    // the GPU pointer. `h.owned_bytes` is set to the allocation size so the
+    // registry destructor (`free_owned_storage`) will free it. The wcache_
+    // map entry is erased after transfer so that the workspace cleanup's
+    // wcache_.fused_kv loop becomes a no-op — no double-free.
     auto register_fused = [&](TensorKind kind, const Tensor& t) -> TensorID {
         if (!t.data) return kInvalidTensorID;
         TensorID id = registry_.reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
         auto& h = registry_.handle(id);
         h.primary_tier = StorageTier::FP16;
         h.payload.fp16.data = static_cast<half*>(t.data);
+        h.owned_bytes = static_cast<int64_t>(t.nbytes());
         return id;
     };
     for (int i = 0; i < cfg.n_layers; ++i) {
@@ -1599,6 +1606,12 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             L.fused_gate_up_id = register_fused(TensorKind::FUSED_GATE_UP, it->second);
         }
     }
+    // Transfer storage ownership: clear the wcache_.fused_kv / fused_gate_up
+    // maps so the legacy cleanup loops in executor_workspace_buffers.cu find
+    // them empty. The underlying pointers live on in the registry handles
+    // and are freed by `registry_.free_owned_storage()` in workspace cleanup.
+    wcache_.fused_kv.clear();
+    wcache_.fused_gate_up.clear();
 
     IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)",
                  registry_.size());

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -524,11 +524,17 @@ void GraphExecutor::free_buffers() {
 
     // Free all weight caches (FP16, FP8, NVFP4, CUTLASS, fused KV/gate+up, migrated/overflow)
     {
-        // Fused KV
+        // Registry-owned overlays (Phase 4.2): fused_kv / fused_gate_up
+        // storage is now owned by the WeightRegistry handles, not wcache_.
+        // The maps below are kept empty by `pre_dequant_weights`. This helper
+        // frees any handle whose `owned_bytes > 0`.
+        registry_.free_owned_storage(vram_alloc_);
+        // Legacy loops — both maps must be empty now. Kept as a defensive
+        // fallback in case a code path writes to them without going through
+        // the Phase-4 registration helper.
         for (auto& [idx, tensor] : wcache_.fused_kv)
             if (tensor.data) vram_free(vram_alloc_, tensor.data);
         wcache_.fused_kv.clear();
-        // Fused gate+up
         for (auto& [idx, tensor] : wcache_.fused_gate_up)
             if (tensor.data) vram_free(vram_alloc_, tensor.data);
         wcache_.fused_gate_up.clear();

--- a/src/graph/weight_handle.cu
+++ b/src/graph/weight_handle.cu
@@ -1,4 +1,5 @@
 #include "graph/weight_handle.h"
+#include "memory/vram_allocator.h"
 #include "core/logging.h"
 
 #include <cstring>
@@ -35,6 +36,46 @@ const WeightHandle& WeightRegistry::handle(TensorID id) const {
 
 void WeightRegistry::clear() {
     handles_.clear();
+}
+
+size_t WeightRegistry::free_owned_storage(VRAMAllocator* alloc) {
+    if (!alloc) return 0;
+    size_t freed_bytes = 0;
+    for (auto& h : handles_) {
+        if (h.owned_bytes == 0) continue;
+        // Free the primary-tier payload pointer. Tiers with auxiliary buffers
+        // (NVFP4 scales, CUTLASS sf, MXFP4 scales) are freed by their native
+        // free_nvfp4_result / free_cutlass_nvfp4_weight / etc. helpers in
+        // executor_workspace_buffers.cu — this registry helper is currently
+        // only used by FP16 overlay tensors (fused_kv, fused_gate_up) which
+        // have a single contiguous storage pointer.
+        switch (h.primary_tier) {
+            case StorageTier::FP16:
+                if (h.payload.fp16.data) {
+                    alloc->free(h.payload.fp16.data);
+                    h.payload.fp16.data = nullptr;
+                    freed_bytes += static_cast<size_t>(h.owned_bytes);
+                    h.owned_bytes = 0;
+                }
+                break;
+            case StorageTier::FP32:
+            case StorageTier::FP8:
+            case StorageTier::NVFP4:
+            case StorageTier::CUTLASS_NVFP4:
+            case StorageTier::MXFP4:
+            case StorageTier::Undefined:
+                // Not currently owned by the registry — fall through to
+                // legacy free paths.
+                IMP_LOG_WARN("WeightRegistry::free_owned_storage: handle id=%d "
+                             "kind=%d tier=%d has owned_bytes=%lld but no "
+                             "type-specific free is wired; skipping.",
+                             h.id, static_cast<int>(h.kind),
+                             static_cast<int>(h.primary_tier),
+                             static_cast<long long>(h.owned_bytes));
+                break;
+        }
+    }
+    return freed_bytes;
 }
 
 } // namespace imp

--- a/src/graph/weight_handle.h
+++ b/src/graph/weight_handle.h
@@ -36,6 +36,8 @@ struct WeightHandle {
     bool is_populated() const { return primary_tier != StorageTier::Undefined; }
 };
 
+class VRAMAllocator;
+
 class WeightRegistry {
 public:
     TensorID reserve(TensorKind kind, int64_t rows, int64_t cols);
@@ -44,6 +46,13 @@ public:
     size_t size() const { return handles_.size(); }
 
     void clear();
+
+    // Free VRAM for any handle whose `owned_bytes > 0`. Borrowed handles
+    // (owned_bytes == 0) are left alone — their storage is managed by the
+    // original allocator (e.g. wcache_ maps or Model::gpu_allocations_).
+    // Idempotent: each freed handle's `owned_bytes` is reset to 0 and the
+    // payload pointer to nullptr, so a second call is a no-op.
+    size_t free_owned_storage(VRAMAllocator* alloc);
 
 private:
     std::vector<WeightHandle> handles_;


### PR DESCRIPTION
First real Phase 4.2 work. WeightRegistry now owns fused overlay storage via owned_bytes. Bases on #46.