### PR TITLE
Phase 4 consolidated: gap diagnostic + Option C + fused handle migration + ownership transfer

### DIFF
--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -407,10 +407,10 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                 gemm_cublaslt(fp8_no, fp8_tv, vv, 1.0f, 0.0f,
                               qscratch_.d_act_scale, fp8_hwv->payload.fp8.d_scale, stream);
             } else {
-                // Try fused K+V path: single strided batched GEMM for both projections.
-                // Prefer registry handle (Phase 4 path); fall back to wcache_
-                // lookup if the handle is invalid (e.g., new layer added but
-                // not yet registered, or registry not yet populated).
+                // Try fused K+V path: single strided batched GEMM for both
+                // projections. Read via WeightRegistry handle — the wcache_
+                // map is no longer the lookup mechanism (it remains the
+                // storage owner; cleanup happens via wcache_.clear()).
                 // Gemma 4 per-layer shapes break strided-batched K+V layout assumptions.
                 const Tensor* fused_kv = nullptr;
                 Tensor fused_from_handle;
@@ -421,10 +421,6 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                                    2, h.shape, true);
                         fused_kv = &fused_from_handle;
                     }
-                }
-                if (!fused_kv) {
-                    auto it = wcache_.fused_kv.find(layer);
-                    if (it != wcache_.fused_kv.end()) fused_kv = &it->second;
                 }
                 if (n > 1 && fused_kv && !per_layer_shapes) {
                     // Q: still separate (different output dim with GQA)

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -408,14 +408,29 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                               qscratch_.d_act_scale, fp8_hwv->payload.fp8.d_scale, stream);
             } else {
                 // Try fused K+V path: single strided batched GEMM for both projections.
-                // fused_kv is indexed by layer number; no WeightHandle equivalent yet.
-                auto fused_kv_it = wcache_.fused_kv.find(layer);
+                // Prefer registry handle (Phase 4 path); fall back to wcache_
+                // lookup if the handle is invalid (e.g., new layer added but
+                // not yet registered, or registry not yet populated).
                 // Gemma 4 per-layer shapes break strided-batched K+V layout assumptions.
-                if (n > 1 && fused_kv_it != wcache_.fused_kv.end() && !per_layer_shapes) {
+                const Tensor* fused_kv = nullptr;
+                Tensor fused_from_handle;
+                if (ly.fused_kv_id != kInvalidTensorID) {
+                    const auto& h = registry_.handle(ly.fused_kv_id);
+                    if (h.payload.fp16.data) {
+                        fused_from_handle = Tensor(h.payload.fp16.data, DType::FP16,
+                                                   2, h.shape, true);
+                        fused_kv = &fused_from_handle;
+                    }
+                }
+                if (!fused_kv) {
+                    auto it = wcache_.fused_kv.find(layer);
+                    if (it != wcache_.fused_kv.end()) fused_kv = &it->second;
+                }
+                if (n > 1 && fused_kv && !per_layer_shapes) {
                     // Q: still separate (different output dim with GQA)
                     gemm_dispatch(no, ly.wq, ly.wq_qtype, q_target, ctx);
                     // K+V: one batched cuBLAS call
-                    gemm_kv_batched(no, fused_kv_it->second, kk, vv, stream);
+                    gemm_kv_batched(no, *fused_kv, kk, vv, stream);
                 } else {
                     gemm_dispatch(no, ly.wq, ly.wq_qtype, q_target, ctx);
                     gemm_dispatch(no, ly.wk, ly.wk_qtype, kk, ctx);

--- a/src/graph/executor_ffn.cu
+++ b/src/graph/executor_ffn.cu
@@ -214,11 +214,25 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 gemm_cublaslt(fp8_no, fp8_tu, uo, 1.0f, 0.0f,
                               qscratch_.d_act_scale, hwu->payload.fp8.d_scale, stream);
             } else {
-                // fused_gate_up is indexed by layer number; no WeightHandle equivalent yet.
-                auto fused_gu_it = wcache_.fused_gate_up.find(layer);
-                if (n > 1 && fused_gu_it != wcache_.fused_gate_up.end()) {
+                // Prefer registry handle (Phase 4 path); fall back to wcache_
+                // lookup if the handle is invalid.
+                const Tensor* fused_gu = nullptr;
+                Tensor fused_from_handle;
+                if (ly.fused_gate_up_id != kInvalidTensorID) {
+                    const auto& h = registry_.handle(ly.fused_gate_up_id);
+                    if (h.payload.fp16.data) {
+                        fused_from_handle = Tensor(h.payload.fp16.data, DType::FP16,
+                                                   2, h.shape, true);
+                        fused_gu = &fused_from_handle;
+                    }
+                }
+                if (!fused_gu) {
+                    auto it = wcache_.fused_gate_up.find(layer);
+                    if (it != wcache_.fused_gate_up.end()) fused_gu = &it->second;
+                }
+                if (n > 1 && fused_gu) {
                     // Batched gate+up: single cuBLAS call for both projections
-                    gemm_pair_batched(no, fused_gu_it->second, go, uo, stream);
+                    gemm_pair_batched(no, *fused_gu, go, uo, stream);
                 } else {
                     gemm_dispatch(no, ly.w_gate, ly.w_gate_qtype, go, ctx);
                     gemm_dispatch(no, ly.w_up,   ly.w_up_qtype,   uo, ctx);

--- a/src/graph/executor_ffn.cu
+++ b/src/graph/executor_ffn.cu
@@ -214,8 +214,9 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 gemm_cublaslt(fp8_no, fp8_tu, uo, 1.0f, 0.0f,
                               qscratch_.d_act_scale, hwu->payload.fp8.d_scale, stream);
             } else {
-                // Prefer registry handle (Phase 4 path); fall back to wcache_
-                // lookup if the handle is invalid.
+                // Read fused gate+up via WeightRegistry handle — the wcache_
+                // map is no longer the lookup mechanism (it remains the
+                // storage owner; cleanup happens via wcache_.clear()).
                 const Tensor* fused_gu = nullptr;
                 Tensor fused_from_handle;
                 if (ly.fused_gate_up_id != kInvalidTensorID) {
@@ -225,10 +226,6 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                                    2, h.shape, true);
                         fused_gu = &fused_from_handle;
                     }
-                }
-                if (!fused_gu) {
-                    auto it = wcache_.fused_gate_up.find(layer);
-                    if (it != wcache_.fused_gate_up.end()) fused_gu = &it->second;
                 }
                 if (n > 1 && fused_gu) {
                     // Batched gate+up: single cuBLAS call for both projections

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1632,6 +1632,32 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                      "(uncached %zu remain as native GGUF blocks)",
                      registry_count, plan_overlay,
                      plan_overlay > registry_count ? plan_overlay - registry_count : 0);
+
+        // When there is a registry/plan gap, surface the by-kind delta so the
+        // missing TensorKinds are immediately visible. Helps when adding a new
+        // model that has tensor kinds the runtime caches but plan_storage
+        // doesn't yet enumerate (or vice versa).
+        if (registry_count < plan_overlay) {
+            int plan_per_kind[static_cast<int>(TensorKind::_COUNT)]     = {0};
+            int registry_per_kind[static_cast<int>(TensorKind::_COUNT)] = {0};
+            for (const auto& e : ideal_plan.entries) {
+                bool overlay = (e.tier == StorageTier::FP16  || e.tier == StorageTier::FP8 ||
+                                e.tier == StorageTier::NVFP4 || e.tier == StorageTier::CUTLASS_NVFP4 ||
+                                e.tier == StorageTier::MXFP4);
+                if (overlay) ++plan_per_kind[static_cast<int>(e.kind)];
+            }
+            for (TensorID id = 0; id < static_cast<TensorID>(registry_.size()); ++id) {
+                ++registry_per_kind[static_cast<int>(registry_.handle(id).kind)];
+            }
+            for (int k = 0; k < static_cast<int>(TensorKind::_COUNT); ++k) {
+                int diff = plan_per_kind[k] - registry_per_kind[k];
+                if (diff > 0) {
+                    IMP_LOG_INFO("Phase-4 gap by kind: %s plan=%d registry=%d (uncached=%d)",
+                                 tensor_kind_name(static_cast<TensorKind>(k)),
+                                 plan_per_kind[k], registry_per_kind[k], diff);
+                }
+            }
+        }
         IMP_LOG_INFO("Phase-4 plan-ideal tiers: fp16=%zu fp8=%zu nvfp4=%zu "
                      "cutlass_nvfp4=%zu mxfp4=%zu fp32=%zu",
                      plan_fp16, plan_fp8, plan_nvfp4, plan_cutlass_nvfp4,

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1592,15 +1592,19 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     {
         StoragePlan parity_plan = plan_storage(*model_, cfg, hints_);
         size_t plan_registerable = 0;
+        // Per-tier plan breakdown so we can see which tiers account for the
+        // gap between the plan and the registry. `Undefined` is excluded.
+        size_t plan_fp16 = 0, plan_fp8 = 0, plan_nvfp4 = 0;
+        size_t plan_cutlass_nvfp4 = 0, plan_mxfp4 = 0, plan_fp32 = 0;
         for (const auto& e : parity_plan.entries) {
             switch (e.tier) {
-                case StorageTier::FP16:
-                case StorageTier::FP8:
-                case StorageTier::NVFP4:
-                case StorageTier::CUTLASS_NVFP4:
-                case StorageTier::MXFP4:
-                    ++plan_registerable; break;
-                default: break;
+                case StorageTier::FP16:          ++plan_fp16; ++plan_registerable; break;
+                case StorageTier::FP8:           ++plan_fp8; ++plan_registerable; break;
+                case StorageTier::NVFP4:         ++plan_nvfp4; ++plan_registerable; break;
+                case StorageTier::CUTLASS_NVFP4: ++plan_cutlass_nvfp4; ++plan_registerable; break;
+                case StorageTier::MXFP4:         ++plan_mxfp4; ++plan_registerable; break;
+                case StorageTier::FP32:          ++plan_fp32; break;
+                case StorageTier::Undefined:     break;
             }
         }
         size_t registry_count = registry_.size();
@@ -1614,6 +1618,17 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             IMP_LOG_INFO("Phase-4 parity: registry=%zu handles match plan "
                          "wcache-tier count", registry_count);
         }
+        // Detailed breakdowns to turn the gap into an actionable punch list.
+        IMP_LOG_INFO("Phase-4 plan tiers: fp16=%zu fp8=%zu nvfp4=%zu cutlass_nvfp4=%zu "
+                     "mxfp4=%zu fp32=%zu",
+                     plan_fp16, plan_fp8, plan_nvfp4, plan_cutlass_nvfp4,
+                     plan_mxfp4, plan_fp32);
+        IMP_LOG_INFO("Phase-4 wcache: fp16=%zu fp8=%zu nvfp4=%zu cutlass_nvfp4=%zu "
+                     "cutlass_mxfp4=%zu nvfp4_moe=%zu fused_kv=%zu fused_gate_up=%zu",
+                     wcache_.fp16.size(), wcache_.fp8.size(), wcache_.nvfp4.size(),
+                     wcache_.cutlass_nvfp4.size(), wcache_.cutlass_mxfp4.size(),
+                     wcache_.nvfp4_moe.size(), wcache_.fused_kv.size(),
+                     wcache_.fused_gate_up.size());
     }
 }
 

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1580,14 +1580,21 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     const_cast<Model*>(model_)->tok_emb_id  = register_tensor(model_->token_embedding(), TensorKind::TOK_EMBED);
 
     // Register fused KV / gate+up overlays. Layer-keyed (not pointer-keyed)
-    // because a fused tensor is built fresh — the source pointers (wk, wv) are
-    // the *unfused* weights and don't appear in any per-tensor wcache_ map.
+    // because a fused tensor is built fresh — the source pointers (wk, wv)
+    // are the *unfused* weights and don't appear in any per-tensor wcache_ map.
+    //
+    // Ownership transfer (Phase 4.2): the registry handle takes ownership of
+    // the GPU pointer. `h.owned_bytes` is set to the allocation size so the
+    // registry destructor (`free_owned_storage`) will free it. The wcache_
+    // map entry is erased after transfer so that the workspace cleanup's
+    // wcache_.fused_kv loop becomes a no-op — no double-free.
     auto register_fused = [&](TensorKind kind, const Tensor& t) -> TensorID {
         if (!t.data) return kInvalidTensorID;
         TensorID id = registry_.reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
         auto& h = registry_.handle(id);
         h.primary_tier = StorageTier::FP16;
         h.payload.fp16.data = static_cast<half*>(t.data);
+        h.owned_bytes = static_cast<int64_t>(t.nbytes());
         return id;
     };
     for (int i = 0; i < cfg.n_layers; ++i) {
@@ -1599,6 +1606,12 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             L.fused_gate_up_id = register_fused(TensorKind::FUSED_GATE_UP, it->second);
         }
     }
+    // Transfer storage ownership: clear the wcache_.fused_kv / fused_gate_up
+    // maps so the legacy cleanup loops in executor_workspace_buffers.cu find
+    // them empty. The underlying pointers live on in the registry handles
+    // and are freed by `registry_.free_owned_storage()` in workspace cleanup.
+    wcache_.fused_kv.clear();
+    wcache_.fused_gate_up.clear();
 
     IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)",
                  registry_.size());

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1669,6 +1669,15 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                      wcache_.cutlass_nvfp4.size(), wcache_.cutlass_mxfp4.size(),
                      wcache_.nvfp4_moe.size(), wcache_.fused_kv.size(),
                      wcache_.fused_gate_up.size());
+        // Native layer counterpart to the overlay diagnostic: tensors uploaded
+        // as their on-disk format and dispatched through qtype-specific kernels
+        // (no tier choice, no cascade-bug class). gpu_allocations_ tracks every
+        // GPU pointer the Model owns — Q4_K_M / Q5_K_M / Q6_K / Q8_0 / MXFP4
+        // blocks, norms, embeddings, scratch buffers. Together with the overlay
+        // counts above this gives the full Option-C two-layer storage picture.
+        IMP_LOG_INFO("Phase-4 native: %zu Model::gpu_allocations_ pointers "
+                     "(GGUF blocks + norms + scratch — bypass the overlay layer)",
+                     model_->gpu_allocations_.size());
     }
 }
 

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1579,6 +1579,27 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     const_cast<Model*>(model_)->out_proj_id = register_tensor(model_->output_proj(), TensorKind::LM_HEAD);
     const_cast<Model*>(model_)->tok_emb_id  = register_tensor(model_->token_embedding(), TensorKind::TOK_EMBED);
 
+    // Register fused KV / gate+up overlays. Layer-keyed (not pointer-keyed)
+    // because a fused tensor is built fresh — the source pointers (wk, wv) are
+    // the *unfused* weights and don't appear in any per-tensor wcache_ map.
+    auto register_fused = [&](TensorKind kind, const Tensor& t) -> TensorID {
+        if (!t.data) return kInvalidTensorID;
+        TensorID id = registry_.reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
+        auto& h = registry_.handle(id);
+        h.primary_tier = StorageTier::FP16;
+        h.payload.fp16.data = static_cast<half*>(t.data);
+        return id;
+    };
+    for (int i = 0; i < cfg.n_layers; ++i) {
+        auto& L = const_cast<Model*>(model_)->layer(i);
+        if (auto it = wcache_.fused_kv.find(i); it != wcache_.fused_kv.end()) {
+            L.fused_kv_id = register_fused(TensorKind::FUSED_KV, it->second);
+        }
+        if (auto it = wcache_.fused_gate_up.find(i); it != wcache_.fused_gate_up.end()) {
+            L.fused_gate_up_id = register_fused(TensorKind::FUSED_GATE_UP, it->second);
+        }
+    }
+
     IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)",
                  registry_.size());
 

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1582,49 +1582,42 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)",
                  registry_.size());
 
-    // Phase 4 parity diagnostic: compare registry vs plan. The registry only
-    // carries tensors whose source pointer landed in a wcache_ map (quantize-
-    // able projections). The plan enumerates every TransformerLayer field with
-    // data, which includes some always-FP16/FP32 tensors (norms, rope_freqs)
-    // that bypass wcache_ entirely. To make the comparison apples-to-apples,
-    // count only plan entries whose kind can live in wcache_ (FP16/FP8/NVFP4/
-    // MXFP4 tiers).
+    // Phase 4 (Option C) overlay diagnostic: report ideal vs actual overlay
+    // population. The plan enumerates every quantize-able tensor at its
+    // preferred tier ("ideal overlay"). The registry tracks tensors actually
+    // cached by the runtime ("actual overlay"). Native GGUF blocks (Q4_K_M,
+    // Q5_K_M, Q6_K, Q8_0, MXFP4) stay as mmap'd `Model::gpu_allocations_`
+    // and are dequantized per kernel call — they bypass the overlay layer
+    // entirely, so the diff between plan and registry is informational, not
+    // an error.
     {
-        StoragePlan parity_plan = plan_storage(*model_, cfg, hints_);
-        size_t plan_registerable = 0;
-        // Per-tier plan breakdown so we can see which tiers account for the
-        // gap between the plan and the registry. `Undefined` is excluded.
+        StoragePlan ideal_plan = plan_storage(*model_, cfg, hints_);
+        size_t plan_overlay = 0;
         size_t plan_fp16 = 0, plan_fp8 = 0, plan_nvfp4 = 0;
         size_t plan_cutlass_nvfp4 = 0, plan_mxfp4 = 0, plan_fp32 = 0;
-        for (const auto& e : parity_plan.entries) {
+        for (const auto& e : ideal_plan.entries) {
             switch (e.tier) {
-                case StorageTier::FP16:          ++plan_fp16; ++plan_registerable; break;
-                case StorageTier::FP8:           ++plan_fp8; ++plan_registerable; break;
-                case StorageTier::NVFP4:         ++plan_nvfp4; ++plan_registerable; break;
-                case StorageTier::CUTLASS_NVFP4: ++plan_cutlass_nvfp4; ++plan_registerable; break;
-                case StorageTier::MXFP4:         ++plan_mxfp4; ++plan_registerable; break;
+                case StorageTier::FP16:          ++plan_fp16; ++plan_overlay; break;
+                case StorageTier::FP8:           ++plan_fp8; ++plan_overlay; break;
+                case StorageTier::NVFP4:         ++plan_nvfp4; ++plan_overlay; break;
+                case StorageTier::CUTLASS_NVFP4: ++plan_cutlass_nvfp4; ++plan_overlay; break;
+                case StorageTier::MXFP4:         ++plan_mxfp4; ++plan_overlay; break;
                 case StorageTier::FP32:          ++plan_fp32; break;
                 case StorageTier::Undefined:     break;
             }
         }
         size_t registry_count = registry_.size();
-        if (plan_registerable != registry_count) {
-            IMP_LOG_WARN("Phase-4 parity: registry=%zu handles, plan=%zu wcache-tier "
-                         "entries (diff=%zd). Expected to converge by Phase 5.",
-                         registry_count, plan_registerable,
-                         static_cast<ssize_t>(plan_registerable) -
-                             static_cast<ssize_t>(registry_count));
-        } else {
-            IMP_LOG_INFO("Phase-4 parity: registry=%zu handles match plan "
-                         "wcache-tier count", registry_count);
-        }
-        // Detailed breakdowns to turn the gap into an actionable punch list.
-        IMP_LOG_INFO("Phase-4 plan tiers: fp16=%zu fp8=%zu nvfp4=%zu cutlass_nvfp4=%zu "
-                     "mxfp4=%zu fp32=%zu",
+        IMP_LOG_INFO("Phase-4 overlay: registry=%zu cached / plan-ideal=%zu "
+                     "(uncached %zu remain as native GGUF blocks)",
+                     registry_count, plan_overlay,
+                     plan_overlay > registry_count ? plan_overlay - registry_count : 0);
+        IMP_LOG_INFO("Phase-4 plan-ideal tiers: fp16=%zu fp8=%zu nvfp4=%zu "
+                     "cutlass_nvfp4=%zu mxfp4=%zu fp32=%zu",
                      plan_fp16, plan_fp8, plan_nvfp4, plan_cutlass_nvfp4,
                      plan_mxfp4, plan_fp32);
-        IMP_LOG_INFO("Phase-4 wcache: fp16=%zu fp8=%zu nvfp4=%zu cutlass_nvfp4=%zu "
-                     "cutlass_mxfp4=%zu nvfp4_moe=%zu fused_kv=%zu fused_gate_up=%zu",
+        IMP_LOG_INFO("Phase-4 wcache actual: fp16=%zu fp8=%zu nvfp4=%zu "
+                     "cutlass_nvfp4=%zu cutlass_mxfp4=%zu nvfp4_moe=%zu "
+                     "fused_kv=%zu fused_gate_up=%zu",
                      wcache_.fp16.size(), wcache_.fp8.size(), wcache_.nvfp4.size(),
                      wcache_.cutlass_nvfp4.size(), wcache_.cutlass_mxfp4.size(),
                      wcache_.nvfp4_moe.size(), wcache_.fused_kv.size(),

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -524,11 +524,17 @@ void GraphExecutor::free_buffers() {
 
     // Free all weight caches (FP16, FP8, NVFP4, CUTLASS, fused KV/gate+up, migrated/overflow)
     {
-        // Fused KV
+        // Registry-owned overlays (Phase 4.2): fused_kv / fused_gate_up
+        // storage is now owned by the WeightRegistry handles, not wcache_.
+        // The maps below are kept empty by `pre_dequant_weights`. This helper
+        // frees any handle whose `owned_bytes > 0`.
+        registry_.free_owned_storage(vram_alloc_);
+        // Legacy loops — both maps must be empty now. Kept as a defensive
+        // fallback in case a code path writes to them without going through
+        // the Phase-4 registration helper.
         for (auto& [idx, tensor] : wcache_.fused_kv)
             if (tensor.data) vram_free(vram_alloc_, tensor.data);
         wcache_.fused_kv.clear();
-        // Fused gate+up
         for (auto& [idx, tensor] : wcache_.fused_gate_up)
             if (tensor.data) vram_free(vram_alloc_, tensor.data);
         wcache_.fused_gate_up.clear();

--- a/src/graph/weight_handle.cu
+++ b/src/graph/weight_handle.cu
@@ -1,4 +1,5 @@
 #include "graph/weight_handle.h"
+#include "memory/vram_allocator.h"
 #include "core/logging.h"
 
 #include <cstring>
@@ -35,6 +36,46 @@ const WeightHandle& WeightRegistry::handle(TensorID id) const {
 
 void WeightRegistry::clear() {
     handles_.clear();
+}
+
+size_t WeightRegistry::free_owned_storage(VRAMAllocator* alloc) {
+    if (!alloc) return 0;
+    size_t freed_bytes = 0;
+    for (auto& h : handles_) {
+        if (h.owned_bytes == 0) continue;
+        // Free the primary-tier payload pointer. Tiers with auxiliary buffers
+        // (NVFP4 scales, CUTLASS sf, MXFP4 scales) are freed by their native
+        // free_nvfp4_result / free_cutlass_nvfp4_weight / etc. helpers in
+        // executor_workspace_buffers.cu — this registry helper is currently
+        // only used by FP16 overlay tensors (fused_kv, fused_gate_up) which
+        // have a single contiguous storage pointer.
+        switch (h.primary_tier) {
+            case StorageTier::FP16:
+                if (h.payload.fp16.data) {
+                    alloc->free(h.payload.fp16.data);
+                    h.payload.fp16.data = nullptr;
+                    freed_bytes += static_cast<size_t>(h.owned_bytes);
+                    h.owned_bytes = 0;
+                }
+                break;
+            case StorageTier::FP32:
+            case StorageTier::FP8:
+            case StorageTier::NVFP4:
+            case StorageTier::CUTLASS_NVFP4:
+            case StorageTier::MXFP4:
+            case StorageTier::Undefined:
+                // Not currently owned by the registry — fall through to
+                // legacy free paths.
+                IMP_LOG_WARN("WeightRegistry::free_owned_storage: handle id=%d "
+                             "kind=%d tier=%d has owned_bytes=%lld but no "
+                             "type-specific free is wired; skipping.",
+                             h.id, static_cast<int>(h.kind),
+                             static_cast<int>(h.primary_tier),
+                             static_cast<long long>(h.owned_bytes));
+                break;
+        }
+    }
+    return freed_bytes;
 }
 
 } // namespace imp

--- a/src/graph/weight_handle.h
+++ b/src/graph/weight_handle.h
@@ -36,6 +36,8 @@ struct WeightHandle {
     bool is_populated() const { return primary_tier != StorageTier::Undefined; }
 };
 
+class VRAMAllocator;
+
 class WeightRegistry {
 public:
     TensorID reserve(TensorKind kind, int64_t rows, int64_t cols);
@@ -44,6 +46,13 @@ public:
     size_t size() const { return handles_.size(); }
 
     void clear();
+
+    // Free VRAM for any handle whose `owned_bytes > 0`. Borrowed handles
+    // (owned_bytes == 0) are left alone — their storage is managed by the
+    // original allocator (e.g. wcache_ maps or Model::gpu_allocations_).
+    // Idempotent: each freed handle's `owned_bytes` is reset to 0 and the
+    // payload pointer to nullptr, so a second call is a no-op.
+    size_t free_owned_storage(VRAMAllocator* alloc);
 
 private:
     std::vector<WeightHandle> handles_;

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -155,6 +155,11 @@ struct TransformerLayer {
     TensorID ssm_in_id   = kInvalidTensorID;
     TensorID ssm_out_id  = kInvalidTensorID;
     TensorID gdn_gate_id = kInvalidTensorID;
+    // Fused KV / gate+up handles. Populated when the runtime decides to build
+    // a fused weight pair for strided batched prefill GEMM. kInvalidTensorID
+    // means no fused weight was built for this layer (per-layer dispatch path).
+    TensorID fused_kv_id      = kInvalidTensorID;
+    TensorID fused_gate_up_id = kInvalidTensorID;
 
     // Per-expert WeightRegistry indices (populated by pre_dequant_weights, Task 3.4).
     // Parallel to expert_w_gate / expert_w_up / expert_w_down vectors.

--- a/src/runtime/storage_planner.cpp
+++ b/src/runtime/storage_planner.cpp
@@ -127,7 +127,13 @@ StoragePlan plan_storage(const Model& model, const ModelConfig& cfg,
         add_tensor(L.w_down_shared, TensorKind::W_DOWN, plan, next_id, total, hints);
         add_tensor(L.ssm_in,   TensorKind::SSM_IN,   plan, next_id, total, hints);
         add_tensor(L.ssm_out,  TensorKind::SSM_OUT,  plan, next_id, total, hints);
-        add_tensor(L.gdn_gate, TensorKind::GDN_GATE, plan, next_id, total, hints);
+        // gdn_gate is intentionally NOT enumerated for overlay caching: it is
+        // consumed only by the specialized GDN scan kernel (gdn_kernel.cu) via
+        // the raw `L.gdn_gate.data` pointer, never through `gemm_dispatch`. An
+        // overlay copy would burn VRAM with no consumer. The diagnostic in
+        // pre_dequant_weights would otherwise (correctly) flag a 24-handle
+        // "gap" on every GDN model — see commit 3c7803a for the discovery and
+        // PR #43 for the per-kind gap diagnostic that surfaced this.
         for (const auto& e : L.expert_w_gate) add_tensor(e, TensorKind::EXPERT_GATE, plan, next_id, total, hints);
         for (const auto& e : L.expert_w_up)   add_tensor(e, TensorKind::EXPERT_UP,   plan, next_id, total, hints);
         for (const auto& e : L.expert_w_down) add_tensor(e, TensorKind::EXPERT_DOWN, plan, next_id, total, hints);

--- a/src/runtime/storage_planner.h
+++ b/src/runtime/storage_planner.h
@@ -37,6 +37,19 @@ struct StoragePlan {
 
 // Pure function — no GPU allocations, no side effects. Determines per-tensor
 // storage tier based on capabilities + budget + hints.
+//
+// SCOPE (Phase 4 Option C, decided 2026-04-24): the plan describes the
+// **overlay layer** — tensors whose storage tier is a runtime decision
+// (NVFP4 decode cache, FP8 prefill cache, CUTLASS layouts). Native GGUF
+// block formats (Q4_K_M, Q5_K_M, Q6_K, Q8_0, MXFP4) stay as mmap'd blocks
+// owned by `Model::gpu_allocations_` and are dequantized per-kernel call.
+// They bypass the plan/registry entirely.
+//
+// Today the plan enumerates the **ideal** overlay (every quantize-able
+// tensor at its preferred tier). The runtime caching policy in
+// `pre_dequant_weights` is VRAM-budget-aware and may decide not to cache
+// some entries. The Phase-4 parity diagnostic surfaces the resulting
+// gap as informational; it is not an error.
 StoragePlan plan_storage(const Model& model, const ModelConfig& cfg,
                          const PlanHints& hints);
 

--- a/tests/test_weight_registry_preservation.cpp
+++ b/tests/test_weight_registry_preservation.cpp
@@ -195,6 +195,37 @@ TEST(StoragePlanner, DualPathHintRoutesCorrectly) {
 }
 
 // ---------------------------------------------------------------------------
+// GDN_GATE is intentionally excluded from overlay enumeration: the GDN scan
+// kernel consumes the raw weight pointer, never through gemm_dispatch, so an
+// overlay copy would burn VRAM without a consumer. Locking this decision
+// against accidental re-introduction.
+// ---------------------------------------------------------------------------
+
+TEST(StoragePlanner, GDNGateIsNotEnumeratedForOverlay) {
+    Model m;
+    m.config_.n_layers = 2;
+
+    for (int i = 0; i < 2; ++i) {
+        TransformerLayer L;
+        L.gdn_gate = make_tensor_stub(TensorKind::GDN_GATE,
+                                      4096, 4096,
+                                      static_cast<uintptr_t>(i * 100 + 1));
+        m.layers_.push_back(std::move(L));
+    }
+
+    PlanHints hints;
+    hints.vram_budget_bytes = size_t{10} * 1024 * 1024 * 1024;
+
+    StoragePlan plan = plan_storage(m, m.config_, hints);
+    ASSERT_FALSE(plan.failed) << plan.failure_reason;
+
+    for (const auto& e : plan.entries) {
+        EXPECT_NE(e.kind, TensorKind::GDN_GATE)
+            << "GDN_GATE must not appear in overlay plan — see storage_planner.cpp";
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Byte accounting: projected_vram_bytes matches sum of entry bytes
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Consolidated Phase-4 weight-storage refactor work (steps 3–10) on top of #40. Previous per-step PRs #41–#46 were squash-merged into their respective base branches but never reached main — this PR replays them as 8 clean commits off the current \`main\`.

## What's included

1. **bb9dfa8** — Phase-4 parity diagnostic: per-tier plan breakdown + per-map wcache breakdown
2. **2bc9dcd** — Lock in Phase-4 Option C scope (overlay-only; native GGUF blocks stay in \`Model::gpu_allocations_\`)
3. **ca29ad7** — Migrate fused_kv / fused_gate_up consumers to registry handles (+ wcache_ fallback for safety)
4. **f7eb4bd** — Per-kind breakdown when registry < plan
5. **08bd191** — Exclude GDN_GATE from overlay enumeration (consumed by specialized scan kernel, bypasses gemm_dispatch)
6. **0830cd0** — Drop wcache_ fallback in consumers: registry is single source of truth
7. **351e309** — Native-layer counterpart to the Phase-4 overlay diagnostic (full 2-layer storage picture)
8. **99411ab** — Registry owns fused_kv / fused_gate_up storage (first real Phase 4.2 ownership transfer)

## Verification
- **611 tests / 592 pass / 0 fail** (19 skipped model-dependent)
- **5 model families smoke-tested** — Qwen3-4B dense Q4/Q8, Llama-3.2-3B Q8, Qwen3.5 GDN Q8, Gemma-3-12B Q8 — all coherent
- **Convergence proof**: Q8_0 dense + Qwen3.5 GDN now hit full parity (registry == plan-ideal)
- **d0e9b03 protection**: SSM_IN/SSM_OUT preserved at FP16 under NVFP4-only mode, verified via diagnostic and regression tests

## PR-stack predecessors (superseded by this consolidated PR)
- #41 gap breakdown — content in bb9dfa8
- #42 fused handle migration — content in ca29ad7
- #43 per-kind breakdown — content in f7eb4bd
- #44 GDN_GATE skip — content in 08bd191
- #45 drop fallback — content in 0830cd0
- #46 native diagnostic — content in 351e309
- #49 ownership transfer — content in 99411ab

## What's still open (separate PRs)
- **#48** — strengthen GDN coherence test + document Qwen3.5 GDN recurrent-state collapse regression (unrelated)