### PR TITLE
MoE expert-offload auto-pick (3× default) + Project B feasibility pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(IMP_USE_CUTLASS)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxf4nvf4_probe.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_bench.cu)
+    list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_hw.cu)
 endif()
 
 # Note: TurboQuant paged attention previously required a fast-math override
@@ -376,6 +377,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mxf4nvf4_probe.cu
         tests/test_nvfp4_quant_ref.cu
         tests/test_mxf4nvf4_mma_bench.cu
+        tests/test_nvfp4_quant_hw.cu
         tests/test_softmax.cu
         tests/test_ssm.cu
         tests/test_json_constrain.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ if(IMP_USE_CUTLASS)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_fmha_mxfp4_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxfp4_prefill.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxf4nvf4_probe.cu)
+    list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
 endif()
 
 # Note: TurboQuant paged attention previously required a fast-math override
@@ -372,6 +373,7 @@ if(IMP_BUILD_TESTS)
         tests/test_attention_mxfp4.cu
         tests/test_attention_fmha_mxfp4.cu
         tests/test_mxf4nvf4_probe.cu
+        tests/test_nvfp4_quant_ref.cu
         tests/test_softmax.cu
         tests/test_ssm.cu
         tests/test_json_constrain.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ if(IMP_USE_CUTLASS)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_fmha_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_fmha_mxfp4_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxfp4_prefill.cu)
+    list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxf4nvf4_probe.cu)
 endif()
 
 # Note: TurboQuant paged attention previously required a fast-math override
@@ -370,6 +371,7 @@ if(IMP_BUILD_TESTS)
         tests/test_fmha_fp8.cu
         tests/test_attention_mxfp4.cu
         tests/test_attention_fmha_mxfp4.cu
+        tests/test_mxf4nvf4_probe.cu
         tests/test_softmax.cu
         tests/test_ssm.cu
         tests/test_json_constrain.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ if(IMP_USE_CUTLASS)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxfp4_prefill.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxf4nvf4_probe.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
+    list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_bench.cu)
 endif()
 
 # Note: TurboQuant paged attention previously required a fast-math override
@@ -374,6 +375,7 @@ if(IMP_BUILD_TESTS)
         tests/test_attention_fmha_mxfp4.cu
         tests/test_mxf4nvf4_probe.cu
         tests/test_nvfp4_quant_ref.cu
+        tests/test_mxf4nvf4_mma_bench.cu
         tests/test_softmax.cu
         tests/test_ssm.cu
         tests/test_json_constrain.cu

--- a/docs/PROJECT_B_MXFP4_FMHA_UPGRADE.md
+++ b/docs/PROJECT_B_MXFP4_FMHA_UPGRADE.md
@@ -1,0 +1,208 @@
+# Project B: MXFP4 FMHA Upgrade to `mxf4nvf4.block_scale`
+
+**Target:** replace imp's `attention_fmha_mxfp4_sm120.cu` MMA path from
+`kind::f8f6f4.m16n8k32` (manual per-row scale) to
+`kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64` (hardware-integrated
+block scale, 2× K-dim). Expected gain: **2-4× prefill attention
+throughput** on sm_120f.
+
+**Prior art:** SageAttention3, arxiv 2505.11594, thu-ml/SageAttention.
+Their measurement: **1038 TOPS on RTX 5090** = 5× vs fastest
+FlashAttention on 5090.
+
+## Current state (all committed on `feat/graph-verify-pool`)
+
+| Stage | Commit | Status |
+|---|---|---|
+| 1 — Feasibility gate | `b9ec21a` | ✅ MMA compiles + launches on sm_120f + CUDA 13.2.78 |
+| 2 — Numerical gate | `7298175` | ✅ `A=0 → D=0` verified |
+| 2.5 — Quant math | `7a77063` | ✅ FP16→NVFP4→FP16 round-trip, 9.5% RMSE Gaussian, bit-exact representable |
+
+## Reference files (SageAttention3, in `thu-ml/SageAttention`)
+
+- `sageattention3_blackwell/sageattn3/quantization/fp4_quantization_4d.cu`
+  — quant kernel with HW scale interleaving (lines 134-258)
+- `sageattention3_blackwell/sageattn3/blackwell/cute_extension.h`
+  — MMA wrapper (lines 23-139)
+- `sageattention3_blackwell/sageattn3/blackwell/kernel_traits.h`
+  — tile shape + CuTe layouts
+
+## imp files to modify
+
+| File | Lines | Change |
+|---|---|---|
+| `src/compute/attention_fmha_mxfp4_sm120.cu` | 420-430 | Replace MMA instruction |
+| `src/compute/attention_fmha_mxfp4_sm120.cu` | 42-54 | Update tile constants (MX_MMA_K 32→64) |
+| `src/compute/attention_fmha_mxfp4_sm120.cu` | 56-76 | Replace per-row quant with per-16-elem block quant |
+| `src/compute/attention_fmha_mxfp4_sm120.cu` | 440-470 | Remove manual scale-apply; MMA now does it |
+| `src/compute/attention_fmha_mxfp4_sm120.cu` | SMEM layouts | Scale buffer adds 8 scales per 128-K tile row |
+
+## Stage 3 — Quant kernel port (HW layout)
+
+**Goal:** produce FP16 → NVFP4 + FP8 UE4M3 scales in SageAttention3's
+HW-consumption layout. This is the input contract for the MMA.
+
+**Files to create:**
+- `src/compute/nvfp4_quant_hw.cu` (~250 LOC)
+- `src/compute/nvfp4_quant_hw.h`
+- `tests/test_nvfp4_quant_hw.cu`
+
+**Key formula** (from `fp4_quantization_4d.cu:245-256`):
+```cpp
+// For CVT_FP4_ELTS_PER_THREAD = 16 (head_dim=128 case):
+uint32_t col_id_local = threadIdx.x % NUM_THREADS_PER_TOKEN;  // 0..7
+uint32_t token_id_local = token_id % 64;
+uint32_t offset_local = (col_id_local / 4) * 256
+                      + (col_id_local % 4)
+                      + (token_id_local / 16) * 4
+                      + (token_id_local % 16) * 16;
+```
+
+The `(col/4)*256` splits cols 0-3 vs 4-7 into separate 256-byte blocks.
+Within each, tokens interleave on a 16-way pattern matching MMA fetch.
+
+**Test strategy:**
+1. Golden test: quantize known FP16 input, assert specific scale bytes
+   at specific offsets (hand-computed).
+2. Round-trip with a matching dequant kernel that inverts the layout.
+3. Cross-check against `nvfp4_quant_ref.cu` (Stage 2.5 linear layout):
+   same per-group scale values, different storage order.
+
+## Stage 4 — MMA integration
+
+**Goal:** swap in the new MMA in imp's FMHA, behind env gate.
+
+**File:** `src/compute/attention_fmha_mxfp4_sm120.cu`
+
+**Changes:**
+
+```cpp
+// Old (line 47-54):
+static constexpr int MX_MMA_M = 16;
+static constexpr int MX_MMA_N = 8;
+static constexpr int MX_MMA_K = 32;  // ← change to 64
+
+// Old (line 420-430):
+#if __CUDA_ARCH__ >= 1200
+asm volatile(
+    "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e2m1.e2m1.f32 "
+    "{%0, %1, %2, %3},"
+    "{%4, %5, %6, %7},"
+    "{%8, %9},"
+    "{%10, %11, %12, %13};\n"
+    : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+    : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+      "r"(b0), "r"(b1),
+      "f"(d0), "f"(d1), "f"(d2), "f"(d3));
+#endif
+
+// New:
+#if __CUDA_ARCH__ >= 1200
+asm volatile(
+    "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64"
+    ".row.col.f32.e2m1.e2m1.f32.ue4m3 "
+    "{%0, %1, %2, %3},"
+    "{%4, %5, %6, %7},"
+    "{%8, %9},"
+    "{%10, %11, %12, %13},"
+    "{%14},"
+    "{%15, %16},"
+    "{%17},"
+    "{%18, %19};\n"
+    : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+    : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+      "r"(b0), "r"(b1),
+      "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+      "r"(sfa0), "h"(bidA), "h"(tidA),
+      "r"(sfb0), "h"(bidB), "h"(tidB0));
+#endif
+```
+
+**Remove manual scale (lines ~440-470):**
+```cpp
+// DELETE this block — HW applies scale in MMA now:
+FUSED_STORE(d0, gq0, gk0, qs0, ks0, ...);
+FUSED_STORE(d1, gq0, gk1, qs0, ks1, ...);
+// ...
+
+// Replace with: just store d0..d3, softcap/mask only:
+FUSED_STORE_NOSCALE(d0, gq0, gk0, ...);
+// Where attention_scale is now pre-absorbed into the FP8 UE4M3 scale factor.
+```
+
+**Env gate:**
+```cpp
+static const bool use_blockscale_mma =
+    (std::getenv("IMP_FMHA_BLOCKSCALE") != nullptr);
+if (use_blockscale_mma) {
+    launch_mxf4nvf4_blockscale_kernel(...);
+} else {
+    launch_f8f6f4_legacy_kernel(...);  // existing code path kept intact
+}
+```
+
+**Tests:**
+1. Correctness: same Q/K/V, compare FP16-FMHA output vs new MXFP4-BLOCKSCALE.
+   Expected: cos-similarity > 0.99, max element error < 0.05.
+2. Existing tests in `test_attention_fmha_mxfp4.cu` must still pass with
+   `IMP_FMHA_BLOCKSCALE=1`.
+
+## Stage 5 — Bench + Real-prompt quality
+
+**Bench matrix:**
+```bash
+# Prefill-dominated
+for model in Qwen3-8B-Q8_0 Gemma3-12B-Q8_0; do
+  for ctx in 512 2048 4096 8192; do
+    ./imp-cli --model $model --bench --bench-pp $ctx --bench-reps 3
+    ./imp-cli --model $model --bench --bench-pp $ctx --bench-reps 3 [IMP_FMHA_BLOCKSCALE=1]
+  done
+done
+```
+
+**Target gains (informed by SageAttention3):**
+- pp512 → pp2K: 1.5-3×
+- pp4K → pp8K: 2-4×
+- tg (decode): **0%** (decode uses paged attention, not FMHA — unchanged)
+
+**Quality gates:**
+- Qwen3-8B Fibonacci prompt: both paths produce coherent Python
+- Gemma3-12B chat template + multi-turn: no degeneration
+- Tolerance: same top-1 token on first 20 steps for seed=42, temp=0
+
+## Rollback plan
+
+1. The new kernel lives in `attention_fmha_mxfp4_sm120.cu` behind
+   `IMP_FMHA_BLOCKSCALE` env var. Old code path is UNTOUCHED.
+2. If quality regresses: leave env var unset, ship as opt-in.
+3. If neither path is correct: `git revert` the integration commit,
+   probe + quant_ref files stay as long-term regression harness.
+
+## Risks and unknowns
+
+| Risk | Mitigation |
+|---|---|
+| Scale layout doesn't match HW expectation | Cross-check against SageAttention3's working attention kernel |
+| K=64 changes SMEM footprint | Already using Bkv=64 — tile widens K but halves iterations |
+| FP32 accumulator still gated by MMA instruction | That's fine — we want FP32 accum for flash softmax |
+| Quality regression | FP8-PPL paper data: NVFP4 attention lossless on image/video/text models |
+| `mma.sync.kind::mxf4nvf4` is sm_120a, imp uses sm_120f | f suffix is superset — probe already confirmed compile + run |
+
+## Effort estimate
+
+| Task | Hours |
+|---|---|
+| Stage 3 (HW layout quant + test) | 6-8 |
+| Stage 4 (MMA integration) | 8-12 |
+| Stage 5 (bench matrix + quality check) | 4-6 |
+| Misc (debugging, CI, docs) | 4-6 |
+| **Total** | **~30 hours** |
+
+One focused week or 3-4 half-days.
+
+## References
+
+- SageAttention3 paper: https://arxiv.org/abs/2505.11594
+- SageAttention3 code: https://github.com/thu-ml/SageAttention (Apache-2.0)
+- imp study: `memory/sageattention3_study_2026_04_24.md`
+- PTX ISA for `mma.sync.kind::mxf4nvf4`: NVIDIA PTX ISA 9.4+

--- a/docs/memory-traffic-reduction-catalog.md
+++ b/docs/memory-traffic-reduction-catalog.md
@@ -1,0 +1,115 @@
+# Memory-Traffic Reduction Catalog (imp, RTX 5090 sm_120f)
+
+Brainstormed 2026-04-24. RTX 5090 is **memory-bound at batch=1 decode**
+(28:1 memory:compute ratio per `docs/SM120_OPTIMIZATION_STATUS.md`).
+Further perf comes from reducing bytes moved, not from faster MMA. This
+document catalogs options across weight, KV, activation, and MoE
+traffic, with tradeoff labels and implementation status in imp.
+
+## Legend
+
+- **Gain** — realistic, measured where possible. Not marketing numbers.
+- **VRAM** — impact on GPU memory footprint.
+- **Quality** — PPL / top-1 deltas; `~0` means undetectable.
+- **Effort** — `klein` (≤1 day), `mittel` (2-7 days), `hoch` (≥1 week or per-model work).
+- **Status** — `vorhanden` (shipped), `teilweise` (partial/stubs), `nicht da` (missing).
+
+## Decode @ batch=1 — Weight-Traffic
+
+Weight loads dominate decode bandwidth at batch=1. Every byte shaved off
+weights scales linearly with decode throughput.
+
+| # | Option | Gain | VRAM | Qualität | Aufwand | Status |
+|---|---|---|---|---|---|---|
+| W1 | 2-bit Weight-Quant (AQLM, QuIP#, HQQ-2bit) | +30-60% decode | -50% | -0.5 bis -2 PPL | hoch (Calibration-Pipeline) | nicht da |
+| W2 | Speculative Decoding mit EAGLE-3 | +1.5-2.5× bei Accept >70% | +400MB (draft head) | gleich (lossless) | mittel (lib existiert) | Dead-End historisch, worth revisit |
+| W3 | Medusa Heads (multi-token predict) | +1.3-2× | +300MB | gleich (verify lossless) | mittel | nicht da |
+| W4 | PLE / Prompt-Lookup (strukturierter Kontext) | 2-5× bei JSON/Code | 0 | gleich | klein | N-gram-Spec ist Variante davon |
+| W5 | Batch>1 Coalescing (continuous batching) | 2-8× Throughput | 0 | gleich | teilweise vorhanden | teilweise |
+| W6 | Weight-Tying zwischen Layers | +5-10% bei tied layers | -5-15% VRAM | ~0 per model | hoch (per-model Arbeit) | nicht da |
+
+## KV-Cache — lange Kontexte
+
+KV traffic overtakes weights around ctx=4-8K. At ctx=32K+ it dominates
+entirely.
+
+| # | Option | Gain | VRAM | Qualität | Aufwand | Status |
+|---|---|---|---|---|---|---|
+| K1 | INT4 KV-Cache | 50% KV-Traffic | -50% KV | -0.1 bis -0.3 PPL | mittel | teilweise (Stubs) |
+| K2 | Multi-Head Latent Attention (MLA, DeepSeek) | -90% KV-VRAM | -90% | gleich per model | hoch (per-model impl) | nicht da |
+| K3 | YOCO / Cross-Layer KV-Sharing | -50% KV traffic | -50% | per model unterschiedlich | hoch | nicht da |
+| K4 | Attention Sinks + Sliding Window (StreamingLLM) | konstanter KV, unbounded ctx | fix | minimal (long-range weg) | klein | vorhanden |
+| K5 | Token-Eviction per Attention-Score (H2O, Scissorhands) | -50-70% KV bei langem ctx | dynamisch | -0.2 PPL | mittel | nicht da |
+| K6 | TurboQuant Lite (QJL-Sketch für K) | ~3 bits/elem avg | -60% K | -0.1 PPL | mittel | vorhanden |
+| K7 | Chunked Prefill + KV-Compression between chunks | Prefill-Burst-Traffic reduzieren | 0 | gleich | mittel | nicht da |
+| K8 | KV Offload to CPU pinned (async prefetch) | ermöglicht 100K+ ctx | +RAM | gleich | mittel | nicht da |
+| K9 | SnapKV / PyramidKV (nicht-uniformes Layer-Budget) | -30-50% KV | variable | -0.1 PPL | mittel | nicht da |
+
+## Activation-Traffic
+
+Intermediate tensors (QKV projections, FFN gate/up, attention output)
+between kernels. Fusion removes round-trips to global memory.
+
+| # | Option | Gain | VRAM | Qualität | Aufwand | Status |
+|---|---|---|---|---|---|---|
+| A1 | QKV-Fused Projection | -2 GEMM-Calls/layer | 0 | gleich | klein | vorhanden |
+| A2 | Gate+Up Fused FFN (SwiGLU) | -1 GEMM-Call/layer | 0 | gleich | klein | vorhanden |
+| A3 | In-place RMSNorm+Residual | -1 Alloc/layer | marginal | gleich | klein | vorhanden |
+| A4 | FP16-Accum für Logits (statt FP32) | -50% Logits-Write | 0 | -0.1% top-1 | klein | teilweise |
+| A5 | Fused Attention-Out + Residual + RMSNorm | -2 Kernel-Launches | 0 | gleich | mittel | teilweise |
+| A6 | Fused MoE Routing (alles ohne D2H) | Graph-Safe MoE | 0 | gleich | mittel | teilweise (Gemma-4 Fast-Path) |
+
+## MoE-spezifisch
+
+Expert-Swap zwischen Host und Device dominiert MoE-Traffic wenn Experts
+nicht alle in VRAM passen.
+
+| # | Option | Gain | VRAM | Qualität | Aufwand | Status |
+|---|---|---|---|---|---|---|
+| M1 | Expert-Prefetch basierend auf Router-Top-K | -20-40% Expert-Swap-Wait | 0 | gleich | mittel | nicht da |
+| M2 | Shared-Expert-Pinning (Gemma-4) | -Traffic für shared FFN | marginal | gleich | klein | vorhanden |
+| M3 | Expert-LRU-Cache (VRAM-Pool) | -60% Swap bei Offload | Cache-Budget | gleich | mittel | vorhanden |
+| M4 | Top-K-Stickiness (Reuse-Boost im Router) | +10-20% Cache-Hit | 0 | -0.05 PPL | mittel | nicht da |
+| M5 | Expert-Token-Sort statt Scatter/Gather | -Traffic in Dispatch | 0 | gleich | mittel | vorhanden |
+
+## Cross-Cutting
+
+Nicht "Traffic-Reduktion" im engen Sinn, aber Pipeline-Overlap reduziert
+effektive Wartezeit auf Traffic.
+
+| # | Option | Gain | VRAM | Qualität | Aufwand | Status |
+|---|---|---|---|---|---|---|
+| X1 | L2 Persist für KV (75% L2 reserved) | +2-4% decode | 0 | gleich | klein | vorhanden |
+| X2 | PDL (Programmatic Dep Launch) | Tail/Head-Overlap | 0 | gleich | klein | vorhanden |
+| X3 | Green-Contexts (Prefill/Decode SM-Split) | bessere Pipeline-Overlap | 0 | gleich | klein | vorhanden |
+| X4 | CUDA-Graphs (launch-Overhead) | -300 Launches/token | 0 | gleich | mittel | vorhanden (Verify-Pool + Vision + ExecUpdate 2026-04-24) |
+
+## Top-Kandidaten — ROI-sortiert, noch nicht geshippt
+
+1. **K1 INT4 KV-Cache fertigstellen** — Stubs existieren, größter
+   einzelner ROI für lange Kontexte, ~2-3 Tage. Ohne Per-Model-Arbeit.
+2. **W2 EAGLE-3 Revisit** — dead_ends.md markiert alte Version gescheitert,
+   aber active development bei EAGLE-Repo. Bei Accept-Rate >70%: 1.5-2×
+   decode.
+3. **K5 Token-Eviction (H2O)** — lange Kontexte, moderate Qualitätsverluste,
+   ~1 Woche Arbeit. Orthogonal zu K4/K6.
+4. **M1 Expert-Prefetch** — MoE-Modelle mit Host-Experts. Pipeline-Parallelism
+   zwischen Router-Output und Expert-Load.
+5. **W3 Medusa Heads** — lossless, orthogonal zu EAGLE, kleinere VRAM-Kosten.
+
+## Was bereits gewonnen wurde (Referenz)
+
+- FP8 Prefill Weight-Cache: +40-60% prefill (Q8_0 Modelle)
+- NVFP4 Decode Weight-Cache: +4.7-16% decode (prmt-LUT)
+- NVFP4 Prequant (Model Optimizer): 38 tok/s auf Qwen3-Coder-30B-A3B
+- FP8 KV Cache: 50% KV-Traffic (stabil mit deterministic GEMM workaround)
+- MXFP4 FMHA Prefill: +7-18% über FP8 (seq>=1024)
+- MoE Persistent Work-Queue: -38% TC kernel time
+- CUDA Graphs (Verify + Vision + ExecUpdate): Launch-Overhead-Reduktion
+
+## Referenzen
+
+- `docs/SM120_OPTIMIZATION_STATUS.md` — Bottleneck-Analyse Decode/Prefill
+- `docs/cuda131-optimization-plan.md` — historischer Plan (teilweise realisiert)
+- Memory: `perf_optimizations.md`, `dead_ends.md`, `turbodraft.md`,
+  `nvfp4_prequant_status.md`, `gdn_debug_status.md`

--- a/docs/memory-traffic-reduction-catalog.md
+++ b/docs/memory-traffic-reduction-catalog.md
@@ -110,6 +110,19 @@ effektive Wartezeit auf Traffic.
 - MoE Persistent Work-Queue: -38% TC kernel time
 - CUDA Graphs (Verify + Vision + ExecUpdate): Launch-Overhead-Reduktion
 
+## Counterintuitive finding: Q6_K beats NVFP4 on decode at 30B
+
+Verified 2026-04-24 on Qwen3-Coder-30B-A3B (same model, same HW):
+
+| Quant | pp512 tok/s | tg256 tok/s |
+|---|---|---|
+| Q6_K | 1893 | **87** |
+| NVFP4 | **13471** | 43 |
+
+NVFP4 wins prefill 7×, Q6_K wins decode 2×. Workload-dependent — NVFP4
+only default for RAG/long-ctx, Q6_K better for chat/code/agentic.
+See `memory/nvfp4_vs_q6k_moe_2026_04_24.md`.
+
 ## Referenzen
 
 - `docs/SM120_OPTIMIZATION_STATUS.md` — Bottleneck-Analyse Decode/Prefill

--- a/docs/memory-traffic-reduction-catalog.md
+++ b/docs/memory-traffic-reduction-catalog.md
@@ -35,7 +35,7 @@ entirely.
 
 | # | Option | Gain | VRAM | Qualität | Aufwand | Status |
 |---|---|---|---|---|---|---|
-| K1 | INT4 KV-Cache | 50% KV-Traffic | -50% KV | -0.1 bis -0.3 PPL | mittel | teilweise (Stubs) |
+| K1 | INT4 KV-Cache | **-22% decode @ 20K ctx** (!) | -75% KV | coherent (tested) | mittel | **shipped aber Perf-Regression — siehe [int4_kv_validation_2026_04_24.md](../memory/int4_kv_validation_2026_04_24.md)** |
 | K2 | Multi-Head Latent Attention (MLA, DeepSeek) | -90% KV-VRAM | -90% | gleich per model | hoch (per-model impl) | nicht da |
 | K3 | YOCO / Cross-Layer KV-Sharing | -50% KV traffic | -50% | per model unterschiedlich | hoch | nicht da |
 | K4 | Attention Sinks + Sliding Window (StreamingLLM) | konstanter KV, unbounded ctx | fix | minimal (long-range weg) | klein | vorhanden |
@@ -86,15 +86,18 @@ effektive Wartezeit auf Traffic.
 
 ## Top-Kandidaten — ROI-sortiert, noch nicht geshippt
 
-1. **K1 INT4 KV-Cache fertigstellen** — Stubs existieren, größter
-   einzelner ROI für lange Kontexte, ~2-3 Tage. Ohne Per-Model-Arbeit.
+1. **K1-fix INT4 KV Decode-Kernel** — KV-Cache bereits geshippt aber **Perf-Regression**:
+   -4% @ short ctx, -22% @ 20K ctx (Validation 2026-04-24). Kernel-Investigation
+   nötig — Dequant-Overhead + Scale-Traffic überwiegen Bandwidth-Ersparnis.
+   Wenn fixbar: echter 2× Win @ langer ctx.
 2. **W2 EAGLE-3 Revisit** — dead_ends.md markiert alte Version gescheitert,
    aber active development bei EAGLE-Repo. Bei Accept-Rate >70%: 1.5-2×
    decode.
 3. **K5 Token-Eviction (H2O)** — lange Kontexte, moderate Qualitätsverluste,
    ~1 Woche Arbeit. Orthogonal zu K4/K6.
 4. **M1 Expert-Prefetch** — MoE-Modelle mit Host-Experts. Pipeline-Parallelism
-   zwischen Router-Output und Expert-Load.
+   zwischen Router-Output und Expert-Load. Braucht separaten Copy-Stream
+   + Events für Cross-Layer-Overlap.
 5. **W3 Medusa Heads** — lossless, orthogonal zu EAGLE, kleinere VRAM-Kosten.
 
 ## Was bereits gewonnen wurde (Referenz)

--- a/src/compute/attention_mxf4nvf4_probe.cu
+++ b/src/compute/attention_mxf4nvf4_probe.cu
@@ -1,0 +1,122 @@
+// =============================================================================
+// attention_mxf4nvf4_probe.cu -- Feasibility probe for mxf4nvf4.block_scale MMA
+// =============================================================================
+//
+// Tests whether the SageAttention3-style hardware block-scale MMA compiles
+// and runs on imp's sm_120f + CUDA 13.2 toolchain. Does NOT integrate into
+// the real attention path — this is only a compile + link gate.
+//
+// Upgrade target (vs existing kind::f8f6f4.m16n8k32):
+//   mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3
+//
+// Reference: SageAttention3, thu-ml/SageAttention, cute_extension.h
+// =============================================================================
+
+#include "compute/attention_mxf4nvf4_probe.h"
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+namespace imp {
+
+// Minimal kernel: runs one block-scaled MMA instance with canned inputs.
+// Not correctness-validated against a reference — only exercises the PTX.
+//
+// Inputs:
+//   a[4]  — NVFP4 A operand (m16k64 tile: 16*64*4 bit = 128 bytes = 4 uint32 per lane)
+//   b[2]  — NVFP4 B operand (single m16n8k64 sub-tile: 8*64*4 bit = 64 bytes = 2 uint32 per lane)
+//   sfa   — FP8 UE4M3 A scale packed in uint32
+//   sfb   — FP8 UE4M3 B scale packed in uint32
+// Output:
+//   d[4]  — FP32 accumulator, written to global out
+//
+__global__ void probe_mxf4nvf4_blockscale_kernel(
+    const uint32_t* __restrict__ a_in,   // [4]
+    const uint32_t* __restrict__ b_in,   // [2]
+    uint32_t sfa_in,
+    uint32_t sfb_in,
+    float* __restrict__ d_out)          // [4]
+{
+    // Each lane holds its fragment of the operands (CUTLASS convention).
+    uint32_t a0 = a_in[0];
+    uint32_t a1 = a_in[1];
+    uint32_t a2 = a_in[2];
+    uint32_t a3 = a_in[3];
+    uint32_t b0 = b_in[0];
+    uint32_t b1 = b_in[1];
+
+    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
+
+    constexpr uint16_t tidA = 0;
+    constexpr uint16_t bidA = 0;
+    constexpr uint16_t bidB = 0;
+    constexpr uint16_t tidB0 = 0;
+
+#if __CUDA_ARCH__ >= 1200
+    asm volatile(
+        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+        "{%0, %1, %2, %3},"
+        "{%4, %5, %6, %7},"
+        "{%8, %9},"
+        "{%10, %11, %12, %13},"
+        "{%14},"
+        "{%15, %16},"
+        "{%17},"
+        "{%18, %19};\n"
+        : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+        : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+          "r"(b0), "r"(b1),
+          "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+          "r"(sfa_in), "h"(bidA), "h"(tidA),
+          "r"(sfb_in), "h"(bidB), "h"(tidB0));
+#else
+    // Host-side or pre-sm_120 stub so the file compiles everywhere.
+    d0 = static_cast<float>(a0 & 0xFF);
+    d1 = static_cast<float>(b0 & 0xFF);
+    d2 = static_cast<float>(sfa_in & 0xFF);
+    d3 = static_cast<float>(sfb_in & 0xFF);
+#endif
+
+    if (threadIdx.x == 0) {
+        d_out[0] = d0;
+        d_out[1] = d1;
+        d_out[2] = d2;
+        d_out[3] = d3;
+    }
+}
+
+// Host-callable probe: runs one MMA, returns true on kernel launch success.
+// Does NOT validate numerical correctness.
+bool probe_mxf4nvf4_blockscale(cudaStream_t stream) {
+    static constexpr uint32_t kA[4] = {0x44444444u, 0x44444444u, 0x44444444u, 0x44444444u};
+    static constexpr uint32_t kB[2] = {0x44444444u, 0x44444444u};
+    static constexpr uint32_t kSFA  = 0x38383838u;  // ~1.0 in FP8 UE4M3
+    static constexpr uint32_t kSFB  = 0x38383838u;
+
+    uint32_t* d_a = nullptr;
+    uint32_t* d_b = nullptr;
+    float*    d_out = nullptr;
+
+    if (cudaMalloc(&d_a, sizeof(kA)) != cudaSuccess) return false;
+    if (cudaMalloc(&d_b, sizeof(kB)) != cudaSuccess) { cudaFree(d_a); return false; }
+    if (cudaMalloc(&d_out, 4 * sizeof(float)) != cudaSuccess) {
+        cudaFree(d_a); cudaFree(d_b); return false;
+    }
+
+    cudaMemcpyAsync(d_a, kA, sizeof(kA), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(d_b, kB, sizeof(kB), cudaMemcpyHostToDevice, stream);
+
+    probe_mxf4nvf4_blockscale_kernel<<<1, 32, 0, stream>>>(d_a, d_b, kSFA, kSFB, d_out);
+
+    cudaError_t launch_err = cudaGetLastError();
+    cudaStreamSynchronize(stream);
+    cudaError_t sync_err = cudaGetLastError();
+
+    cudaFree(d_a);
+    cudaFree(d_b);
+    cudaFree(d_out);
+
+    return (launch_err == cudaSuccess) && (sync_err == cudaSuccess);
+}
+
+} // namespace imp

--- a/src/compute/attention_mxf4nvf4_probe.cu
+++ b/src/compute/attention_mxf4nvf4_probe.cu
@@ -85,6 +85,94 @@ __global__ void probe_mxf4nvf4_blockscale_kernel(
     }
 }
 
+// Probe variant that writes the per-thread accumulator of thread 0 to out.
+// Used for numerical assertion tests where the expected output is known.
+__global__ void probe_mxf4nvf4_blockscale_dump_kernel(
+    const uint32_t* __restrict__ a_in,
+    const uint32_t* __restrict__ b_in,
+    uint32_t sfa_in,
+    uint32_t sfb_in,
+    float* __restrict__ d_out)
+{
+    uint32_t a0 = a_in[0];
+    uint32_t a1 = a_in[1];
+    uint32_t a2 = a_in[2];
+    uint32_t a3 = a_in[3];
+    uint32_t b0 = b_in[0];
+    uint32_t b1 = b_in[1];
+
+    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
+
+    constexpr uint16_t tidA = 0;
+    constexpr uint16_t bidA = 0;
+    constexpr uint16_t bidB = 0;
+    constexpr uint16_t tidB0 = 0;
+
+#if __CUDA_ARCH__ >= 1200
+    asm volatile(
+        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+        "{%0, %1, %2, %3},"
+        "{%4, %5, %6, %7},"
+        "{%8, %9},"
+        "{%10, %11, %12, %13},"
+        "{%14},"
+        "{%15, %16},"
+        "{%17},"
+        "{%18, %19};\n"
+        : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+        : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+          "r"(b0), "r"(b1),
+          "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+          "r"(sfa_in), "h"(bidA), "h"(tidA),
+          "r"(sfb_in), "h"(bidB), "h"(tidB0));
+#endif
+
+    if (threadIdx.x == 0) {
+        d_out[0] = d0;
+        d_out[1] = d1;
+        d_out[2] = d2;
+        d_out[3] = d3;
+    }
+}
+
+bool probe_mxf4nvf4_allzero_a(cudaStream_t stream, float out_d[4]) {
+    // A = all-zero E2M1 nibbles → dequant(A) = 0 for every element.
+    // D = C + dequant(A) * dequant(B) * sf_a * sf_b, with C=0 and the
+    // A term zero, must collapse to exactly 0.
+    static constexpr uint32_t kAZero[4] = {0u, 0u, 0u, 0u};
+    // B with arbitrary non-zero content — output must stay 0 regardless.
+    static constexpr uint32_t kB[2]     = {0x55555555u, 0x55555555u};
+    // Scale factors = 1.0 in FP8 UE4M3 (0x38 per byte = exp=7, man=0).
+    static constexpr uint32_t kSFA      = 0x38383838u;
+    static constexpr uint32_t kSFB      = 0x38383838u;
+
+    uint32_t* d_a = nullptr;
+    uint32_t* d_b = nullptr;
+    float*    d_out = nullptr;
+
+    if (cudaMalloc(&d_a, sizeof(kAZero)) != cudaSuccess) return false;
+    if (cudaMalloc(&d_b, sizeof(kB))     != cudaSuccess) { cudaFree(d_a); return false; }
+    if (cudaMalloc(&d_out, 4 * sizeof(float)) != cudaSuccess) {
+        cudaFree(d_a); cudaFree(d_b); return false;
+    }
+
+    cudaMemcpyAsync(d_a, kAZero, sizeof(kAZero), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(d_b, kB,     sizeof(kB),     cudaMemcpyHostToDevice, stream);
+
+    probe_mxf4nvf4_blockscale_dump_kernel<<<1, 32, 0, stream>>>(d_a, d_b, kSFA, kSFB, d_out);
+
+    cudaError_t launch_err = cudaGetLastError();
+    cudaMemcpyAsync(out_d, d_out, 4 * sizeof(float), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+    cudaError_t sync_err = cudaGetLastError();
+
+    cudaFree(d_a);
+    cudaFree(d_b);
+    cudaFree(d_out);
+
+    return (launch_err == cudaSuccess) && (sync_err == cudaSuccess);
+}
+
 // Host-callable probe: runs one MMA, returns true on kernel launch success.
 // Does NOT validate numerical correctness.
 bool probe_mxf4nvf4_blockscale(cudaStream_t stream) {

--- a/src/compute/attention_mxf4nvf4_probe.h
+++ b/src/compute/attention_mxf4nvf4_probe.h
@@ -14,4 +14,14 @@ namespace imp {
 // for whether a full MXFP4 FMHA upgrade project is feasible.
 bool probe_mxf4nvf4_blockscale(cudaStream_t stream);
 
+// Correctness check: runs the same MMA with all-zero A operands. With
+// E2M1 zero-encoded (0x00) in A, any B content, and any scale factors,
+// the fused accumulator `d += (dequant(A) * dequant(B))` must evaluate
+// to exactly 0 across all output lanes.
+//
+// Outputs the first thread's 4 accumulator values via `out_d[4]`. A
+// non-zero return from any element signals the hardware / operand
+// layout assumption is wrong and Project B needs re-investigation.
+bool probe_mxf4nvf4_allzero_a(cudaStream_t stream, float out_d[4]);
+
 } // namespace imp

--- a/src/compute/attention_mxf4nvf4_probe.h
+++ b/src/compute/attention_mxf4nvf4_probe.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace imp {
+
+// Compile + launch gate for the SageAttention3-style MMA instruction
+//   mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64...
+// on sm_120f + CUDA 13.2.
+//
+// Returns true if the kernel launches and synchronizes without CUDA
+// errors. Does NOT validate numerical correctness — this is only a gate
+// for whether a full MXFP4 FMHA upgrade project is feasible.
+bool probe_mxf4nvf4_blockscale(cudaStream_t stream);
+
+} // namespace imp

--- a/src/compute/mxf4nvf4_mma_bench.cu
+++ b/src/compute/mxf4nvf4_mma_bench.cu
@@ -1,0 +1,177 @@
+// =============================================================================
+// mxf4nvf4_mma_bench.cu -- Raw MMA instruction throughput microbench
+// =============================================================================
+//
+// Compares two MMA variants head-to-head on sm_120f:
+//
+// (A) LEGACY — kind::f8f6f4.m16n8k32.f32.e2m1.e2m1.f32
+//     imp's current MXFP4 FMHA path. 16*8*32*2 = 8192 FMA-equivalent ops.
+//
+// (B) BLOCKSCALE — kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
+//     SageAttention3's 5×-speedup path. 16*8*64*2 = 16384 ops. 2× raw
+//     ops per instruction and HW handles per-16-elem scale.
+//
+// Method: each warp issues N iterations of the target MMA in a tight
+// loop with dependency on the accumulator. Measures wall time, computes
+// effective TOPS per warp. Scales to per-GPU estimate by 170 SMs.
+//
+// Expected relative outcome:
+//   - Instruction rate (cycles/MMA): similar if both are ~12-cycle pipeline
+//   - Ops per instruction: 2× for BLOCKSCALE (k=64 vs k=32)
+//   - Effective TOPS: 2× for BLOCKSCALE
+//
+// This is NOT a full attention kernel benchmark — it isolates the MMA
+// pipeline and answers "is this instruction swap worth the integration
+// effort?" (Project B Stage 4 gate.)
+// =============================================================================
+
+#include "compute/mxf4nvf4_mma_bench.h"
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// Legacy kernel: loops kind::f8f6f4.m16n8k32
+// ---------------------------------------------------------------------------
+__global__ void bench_f8f6f4_m16n8k32_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u;
+    uint32_t a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = 0u;  // padding (FP4 uses 2 of 4 A regs)
+    uint32_t a3 = 0u;
+    uint32_t b0 = threadIdx.x * 43u + 3u;
+    uint32_t b1 = 0u;  // padding
+
+    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
+
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e2m1.e2m1.f32 "
+            "{%0, %1, %2, %3},"
+            "{%4, %5, %6, %7},"
+            "{%8, %9},"
+            "{%10, %11, %12, %13};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3));
+    }
+#endif
+
+    // Sink to prevent DCE. Only thread 0 writes.
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        sink[0] = d0 + d1 + d2 + d3;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Blockscale kernel: loops kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
+// ---------------------------------------------------------------------------
+__global__ void bench_mxf4nvf4_blockscale_m16n8k64_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u;
+    uint32_t a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = threadIdx.x * 43u + 3u;
+    uint32_t a3 = threadIdx.x * 47u + 4u;
+    uint32_t b0 = threadIdx.x * 53u + 5u;
+    uint32_t b1 = threadIdx.x * 59u + 6u;
+    uint32_t sfa = 0x38383838u;  // FP8 UE4M3 ~ 1.0
+    uint32_t sfb = 0x38383838u;
+
+    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
+
+    constexpr uint16_t tidA = 0;
+    constexpr uint16_t bidA = 0;
+    constexpr uint16_t bidB = 0;
+    constexpr uint16_t tidB0 = 0;
+
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+            "{%0, %1, %2, %3},"
+            "{%4, %5, %6, %7},"
+            "{%8, %9},"
+            "{%10, %11, %12, %13},"
+            "{%14},"
+            "{%15, %16},"
+            "{%17},"
+            "{%18, %19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa), "h"(bidA), "h"(tidA),
+              "r"(sfb), "h"(bidB), "h"(tidB0));
+    }
+#endif
+
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        sink[0] = d0 + d1 + d2 + d3;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host-side measurement
+// ---------------------------------------------------------------------------
+static float run_bench(void(*kernel)(int, float*), int warps, int iterations,
+                       cudaStream_t stream) {
+    float* d_sink = nullptr;
+    if (cudaMalloc(&d_sink, sizeof(float)) != cudaSuccess) return -1.0f;
+
+    // Warmup
+    kernel<<<warps, 32, 0, stream>>>(iterations / 10, d_sink);
+    cudaStreamSynchronize(stream);
+
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    constexpr int NUM_REPS = 5;
+    float total_ms = 0.0f;
+    for (int rep = 0; rep < NUM_REPS; ++rep) {
+        cudaEventRecord(start, stream);
+        kernel<<<warps, 32, 0, stream>>>(iterations, d_sink);
+        cudaEventRecord(stop, stream);
+        cudaEventSynchronize(stop);
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, start, stop);
+        total_ms += ms;
+    }
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    cudaFree(d_sink);
+
+    return total_ms / NUM_REPS;  // avg ms per rep
+}
+
+MmaBenchResult bench_mma_comparison(int warps, int iterations, cudaStream_t stream) {
+    MmaBenchResult r;
+
+    float legacy_ms = run_bench(bench_f8f6f4_m16n8k32_kernel, warps, iterations, stream);
+    float block_ms  = run_bench(bench_mxf4nvf4_blockscale_m16n8k64_kernel,
+                                 warps, iterations, stream);
+
+    r.legacy_ms = legacy_ms;
+    r.blockscale_ms = block_ms;
+
+    // Ops per MMA instruction (FMA counted as 2 ops):
+    //   legacy  m16n8k32: 16*8*32*2 = 8192
+    //   blockscale m16n8k64: 16*8*64*2 = 16384
+    constexpr double kLegacyOps = 16.0 * 8.0 * 32.0 * 2.0;
+    constexpr double kBlockOps  = 16.0 * 8.0 * 64.0 * 2.0;
+
+    const double total_mmas = static_cast<double>(warps) * iterations;
+    // TOPS = ops_per_mma * total_mmas / seconds / 1e12
+    r.legacy_tops     = (kLegacyOps * total_mmas) / (legacy_ms * 1e-3) / 1e12;
+    r.blockscale_tops = (kBlockOps  * total_mmas) / (block_ms  * 1e-3) / 1e12;
+    r.speedup         = r.blockscale_tops / r.legacy_tops;
+
+    return r;
+}
+
+} // namespace imp

--- a/src/compute/mxf4nvf4_mma_bench.h
+++ b/src/compute/mxf4nvf4_mma_bench.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace imp {
+
+struct MmaBenchResult {
+    float legacy_ms;         // avg ms per rep — kind::f8f6f4.m16n8k32
+    float blockscale_ms;     // avg ms per rep — kind::mxf4nvf4.block_scale.m16n8k64
+    double legacy_tops;      // effective TOPS across all warps
+    double blockscale_tops;
+    double speedup;          // blockscale_tops / legacy_tops
+};
+
+// Run a raw-MMA throughput microbench for both instructions and return
+// per-warp effective TOPS. Answers the "is Project B Stage 4 worth the
+// integration effort?" question with a concrete number.
+//
+// warps: number of resident warps (1 per SM for 170 warps = full
+//        sm_120f on RTX 5090; smaller values isolate single-SM perf).
+// iterations: MMA issues per warp per rep. 1M is a reasonable default.
+MmaBenchResult bench_mma_comparison(int warps, int iterations, cudaStream_t stream);
+
+} // namespace imp

--- a/src/compute/nvfp4_quant_hw.cu
+++ b/src/compute/nvfp4_quant_hw.cu
@@ -1,0 +1,355 @@
+// =============================================================================
+// nvfp4_quant_hw.cu -- NVFP4 quantization with HW MMA scale layout
+// =============================================================================
+//
+// Adapted from thu-ml/SageAttention3 (Apache-2.0 License),
+// sageattention3_blackwell/sageattn3/quantization/fp4_quantization_4d.cu.
+// Copyright (c) 2025 SageAttention team.
+//
+// Modifications from the original:
+//   - Stripped the `permute` path (imp's attention doesn't need it at the
+//     quant step — permutation happens inside the FMHA tile loop).
+//   - Adapted to imp's coding style, logging, and namespace.
+//   - Simplified dispatch: only head_dim ∈ {64, 128} supported.
+//   - Added a matching dequant kernel that inverts the HW layout for
+//     round-trip validation.
+//
+// Key PTX instruction:
+//   cvt.rn.satfinite.e2m1x2.f32 byte, f32_hi, f32_lo
+//
+// Scale layout (critical for MMA consumption) — from lines 245-256 of the
+// upstream file. For CVT_FP4_ELTS_PER_THREAD=16 (head_dim=128):
+//   offset_local = (col_id_local / 4) * 256
+//                + (col_id_local % 4)
+//                + (token_id_local / 16) * 4
+//                + (token_id_local % 16) * 16
+//   where col_id_local = 0..7  (scale groups along K dim)
+//         token_id_local = 0..63 (row within the current 64-token block)
+//
+// For CVT_FP4_ELTS_PER_THREAD=8 (head_dim=64):
+//   Only even threadIdx writes scale, after cross-lane max combine.
+//
+// =============================================================================
+
+#include "compute/nvfp4_quant_hw.h"
+#include "core/logging.h"
+#include <cuda_fp8.h>
+#include <cstdint>
+
+namespace imp {
+
+constexpr int CVT_FP4_ELTS_PER_THREAD = 16;
+
+// ---------------------------------------------------------------------------
+// FP32→E2M1 packed conversion (4 float2 → uint32 holding 8 E2M1 nibbles).
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ uint32_t fp32x8_to_e2m1x8_hw(const float2* v) {
+    uint32_t out;
+    asm volatile(
+        "{\n"
+        ".reg .b8 b0, b1, b2, b3;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 b0, %2, %1;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 b1, %4, %3;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 b2, %6, %5;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 b3, %8, %7;\n"
+        "mov.b32 %0, {b0, b1, b2, b3};\n"
+        "}"
+        : "=r"(out)
+        : "f"(v[0].x), "f"(v[0].y),
+          "f"(v[1].x), "f"(v[1].y),
+          "f"(v[2].x), "f"(v[2].y),
+          "f"(v[3].x), "f"(v[3].y));
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// E2M1 (4-bit) → FP32 LUT (for dequant reference).
+// E2M1 encoding (sign + 3-bit mag): ±{0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0}.
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ float e2m1_to_fp32_hw(uint8_t nib) {
+    static const float mags[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+    float m = mags[nib & 0x7];
+    return (nib & 0x8) ? -m : m;
+}
+
+// ---------------------------------------------------------------------------
+// HW scale offset for CVT_FP4_ELTS_PER_THREAD=16 (head_dim=128).
+// Formula from upstream fp4_quantization_4d.cu:245-249.
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ uint32_t hw_scale_offset_hd128(
+    uint32_t col_id_local,    // 0..7 (scale group along K)
+    uint32_t token_id_local)  // 0..63 (row in current 64-token block)
+{
+    return (col_id_local / 4) * 256
+         + (col_id_local % 4)
+         + (token_id_local / 16) * 4
+         + (token_id_local % 16) * 16;
+}
+
+// ---------------------------------------------------------------------------
+// Vector type
+// ---------------------------------------------------------------------------
+template <typename T>
+struct PackedVec16 {
+    // For T=half, each slot holds 2 elements (half2). 16 elems = 8 slots.
+    typename std::conditional<std::is_same<T, half>::value, half2, half2>::type elts[8];
+};
+
+// ---------------------------------------------------------------------------
+// Quant kernel: each thread handles 16 elements (one scale group).
+// Grid layout:
+//   blockIdx.x = token_block (covers BLOCK_SIZE tokens; BLOCK_SIZE = 64)
+//   blockIdx.y = batch
+//   blockIdx.z = head
+//   threadIdx.x = (token_within_block * NUM_THREADS_PER_TOKEN) + col_scale_group
+// ---------------------------------------------------------------------------
+template <uint32_t HEAD_DIM, uint32_t BLOCK_SIZE>
+__global__ void nvfp4_quant_hw_kernel(
+    const half* __restrict__ input,
+    uint8_t* __restrict__ nvfp4_out,
+    uint8_t* __restrict__ sf_out,
+    int batch_size, int n_heads, int n_tokens,
+    int stride_bz_input, int stride_h_input, int stride_seq_input,
+    int stride_bz_output, int stride_h_output, int stride_seq_output,
+    int stride_bz_output_sf, int stride_h_output_sf, int stride_seq_output_sf)
+{
+    constexpr uint32_t NUM_THREADS_PER_TOKEN = HEAD_DIM / CVT_FP4_ELTS_PER_THREAD;
+    // head_dim=128 → 8 threads/token, head_dim=64 → 4 threads/token
+    static_assert(HEAD_DIM == 64 || HEAD_DIM == 128, "Only 64 and 128 supported");
+
+    const int batch_id       = blockIdx.y;
+    const int head_id        = blockIdx.z;
+    const int token_block_id = blockIdx.x;
+
+    const int token_id = token_block_id * BLOCK_SIZE + threadIdx.x / NUM_THREADS_PER_TOKEN;
+
+    // Load 16 FP16 elements assigned to this thread.
+    PackedVec16<half> in_vec;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        reinterpret_cast<uint32_t&>(in_vec.elts[i]) = 0u;
+    }
+
+    if (token_id < n_tokens) {
+        const half* src = input
+            + batch_id * stride_bz_input
+            + head_id  * stride_h_input
+            + token_id * stride_seq_input
+            + (threadIdx.x % NUM_THREADS_PER_TOKEN) * CVT_FP4_ELTS_PER_THREAD;
+        in_vec = *reinterpret_cast<const PackedVec16<half>*>(src);
+    }
+
+    // Max-abs across 16 elements.
+    auto local_max = __habs2(in_vec.elts[0]);
+    #pragma unroll
+    for (int i = 1; i < 8; ++i) {
+        local_max = __hmax2(local_max, __habs2(in_vec.elts[i]));
+    }
+    // For 8-elems-per-thread (HEAD_DIM=64), combine adjacent threads.
+    if constexpr (CVT_FP4_ELTS_PER_THREAD == 8) {
+        local_max = __hmax2(__shfl_xor_sync(0xffffffffu, local_max, 1, 32), local_max);
+    }
+    float vec_max = float(__hmax(local_max.x, local_max.y));
+
+    // Scale = max / 6.0 (E2M1 max = 6.0), round-trip through FP8 UE4M3.
+    float sc = vec_max / 6.0f;
+    uint8_t sc_fp8;
+    reinterpret_cast<__nv_fp8_e4m3&>(sc_fp8) = __nv_fp8_e4m3(sc);
+    sc = float(reinterpret_cast<__nv_fp8_e4m3&>(sc_fp8));
+    float inv_sc = (sc == 0.0f) ? 0.0f : 1.0f / sc;
+
+    // Apply inverse scale → FP32 pairs.
+    float2 fp2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        fp2[i] = __half22float2(in_vec.elts[i]);
+        fp2[i].x *= inv_sc;
+        fp2[i].y *= inv_sc;
+    }
+
+    // Pack to 2× uint32 (16 E2M1 nibbles = 8 bytes).
+    uint32_t e2m1_lo = fp32x8_to_e2m1x8_hw(&fp2[0]);
+    uint32_t e2m1_hi = fp32x8_to_e2m1x8_hw(&fp2[4]);
+
+    // Store NVFP4 bytes (contiguous in output row).
+    uint8_t* dst = nvfp4_out
+        + batch_id * stride_bz_output
+        + head_id  * stride_h_output
+        + token_id * stride_seq_output
+        + (threadIdx.x % NUM_THREADS_PER_TOKEN) * CVT_FP4_ELTS_PER_THREAD / 2;
+
+    if (token_id < n_tokens) {
+        reinterpret_cast<uint64_t*>(dst)[0] =
+            (static_cast<uint64_t>(e2m1_hi) << 32) | e2m1_lo;
+    }
+
+    // Store scale at HW offset.
+    uint8_t* sf_base = sf_out
+        + batch_id * stride_bz_output_sf
+        + head_id  * stride_h_output_sf
+        + (token_id / 64) * 64 * stride_seq_output_sf;
+    uint32_t token_id_local = token_id % 64;
+
+    if constexpr (CVT_FP4_ELTS_PER_THREAD == 16) {
+        uint32_t col_id_local = threadIdx.x % NUM_THREADS_PER_TOKEN;
+        uint32_t offset_local = hw_scale_offset_hd128(col_id_local, token_id_local);
+        if (token_id < n_tokens) sf_base[offset_local] = sc_fp8;
+    } else {
+        // head_dim=64 case: only even threads write (scale is shared with odd).
+        if ((threadIdx.x % 2) == 0) {
+            uint32_t col_id_local = (threadIdx.x % NUM_THREADS_PER_TOKEN) / 2;
+            uint32_t offset_local = (col_id_local / 4) * 256
+                                  + (col_id_local % 4)
+                                  + (token_id_local / 16) * 4
+                                  + (token_id_local % 16) * 16;
+            if (token_id < n_tokens) sf_base[offset_local] = sc_fp8;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dequant kernel: inverse of the above for round-trip validation.
+// Same grid: one thread per 16-element group.
+// ---------------------------------------------------------------------------
+template <uint32_t HEAD_DIM, uint32_t BLOCK_SIZE>
+__global__ void nvfp4_dequant_hw_kernel(
+    const uint8_t* __restrict__ nvfp4_in,
+    const uint8_t* __restrict__ sf_in,
+    half* __restrict__ output,
+    int batch_size, int n_heads, int n_tokens,
+    int stride_bz_input, int stride_h_input, int stride_seq_input,
+    int stride_bz_output, int stride_h_output, int stride_seq_output,
+    int stride_bz_input_sf, int stride_h_input_sf, int stride_seq_input_sf)
+{
+    constexpr uint32_t NUM_THREADS_PER_TOKEN = HEAD_DIM / CVT_FP4_ELTS_PER_THREAD;
+    static_assert(HEAD_DIM == 64 || HEAD_DIM == 128, "Only 64 and 128 supported");
+
+    const int batch_id       = blockIdx.y;
+    const int head_id        = blockIdx.z;
+    const int token_block_id = blockIdx.x;
+    const int token_id = token_block_id * BLOCK_SIZE + threadIdx.x / NUM_THREADS_PER_TOKEN;
+
+    if (token_id >= n_tokens) return;
+
+    // Load scale from HW offset.
+    const uint8_t* sf_base = sf_in
+        + batch_id * stride_bz_input_sf
+        + head_id  * stride_h_input_sf
+        + (token_id / 64) * 64 * stride_seq_input_sf;
+    uint32_t token_id_local = token_id % 64;
+    uint32_t col_id_local   = threadIdx.x % NUM_THREADS_PER_TOKEN;
+    uint32_t offset_local;
+    if constexpr (CVT_FP4_ELTS_PER_THREAD == 16) {
+        offset_local = hw_scale_offset_hd128(col_id_local, token_id_local);
+    } else {
+        uint32_t col_half = col_id_local / 2;
+        offset_local = (col_half / 4) * 256
+                     + (col_half % 4)
+                     + (token_id_local / 16) * 4
+                     + (token_id_local % 16) * 16;
+    }
+    uint8_t sc_fp8 = sf_base[offset_local];
+    float sc = float(reinterpret_cast<const __nv_fp8_e4m3&>(sc_fp8));
+
+    // Load 8 NVFP4 bytes (16 nibbles).
+    const uint8_t* src = nvfp4_in
+        + batch_id * stride_bz_input
+        + head_id  * stride_h_input
+        + token_id * stride_seq_input
+        + (threadIdx.x % NUM_THREADS_PER_TOKEN) * CVT_FP4_ELTS_PER_THREAD / 2;
+
+    half* dst = output
+        + batch_id * stride_bz_output
+        + head_id  * stride_h_output
+        + token_id * stride_seq_output
+        + (threadIdx.x % NUM_THREADS_PER_TOKEN) * CVT_FP4_ELTS_PER_THREAD;
+
+    #pragma unroll
+    for (int i = 0; i < 16; ++i) {
+        int byte_idx = i / 2;
+        uint8_t byte = src[byte_idx];
+        uint8_t nib  = (i & 1) ? (byte >> 4) : (byte & 0xF);
+        float v = e2m1_to_fp32_hw(nib) * sc;
+        dst[i] = __float2half(v);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host entry points
+// ---------------------------------------------------------------------------
+bool nvfp4_quant_hw_fp16(
+    const half* d_input, uint8_t* d_nvfp4, uint8_t* d_sf,
+    int batch_size, int n_heads, int n_tokens, int head_dim,
+    int stride_bz_input, int stride_h_input, int stride_seq_input,
+    int stride_bz_output, int stride_h_output, int stride_seq_output,
+    int stride_bz_output_sf, int stride_h_output_sf, int stride_seq_output_sf,
+    cudaStream_t stream)
+{
+    constexpr int BLOCK_SIZE = 64;  // tokens per threadblock
+    if (head_dim != 64 && head_dim != 128) {
+        IMP_LOG_ERROR("nvfp4_quant_hw: head_dim %d unsupported (only 64 / 128)", head_dim);
+        return false;
+    }
+    if (n_tokens <= 0 || batch_size <= 0 || n_heads <= 0) {
+        IMP_LOG_ERROR("nvfp4_quant_hw: invalid dims batch=%d heads=%d tokens=%d",
+                      batch_size, n_heads, n_tokens);
+        return false;
+    }
+
+    dim3 grid((n_tokens + BLOCK_SIZE - 1) / BLOCK_SIZE, batch_size, n_heads);
+    int threads_per_token = head_dim / CVT_FP4_ELTS_PER_THREAD;
+    dim3 block(BLOCK_SIZE * threads_per_token, 1, 1);
+
+    if (head_dim == 128) {
+        nvfp4_quant_hw_kernel<128, BLOCK_SIZE><<<grid, block, 0, stream>>>(
+            d_input, d_nvfp4, d_sf,
+            batch_size, n_heads, n_tokens,
+            stride_bz_input, stride_h_input, stride_seq_input,
+            stride_bz_output, stride_h_output, stride_seq_output,
+            stride_bz_output_sf, stride_h_output_sf, stride_seq_output_sf);
+    } else {
+        nvfp4_quant_hw_kernel<64, BLOCK_SIZE><<<grid, block, 0, stream>>>(
+            d_input, d_nvfp4, d_sf,
+            batch_size, n_heads, n_tokens,
+            stride_bz_input, stride_h_input, stride_seq_input,
+            stride_bz_output, stride_h_output, stride_seq_output,
+            stride_bz_output_sf, stride_h_output_sf, stride_seq_output_sf);
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool nvfp4_dequant_hw_fp16(
+    const uint8_t* d_nvfp4, const uint8_t* d_sf, half* d_output,
+    int batch_size, int n_heads, int n_tokens, int head_dim,
+    int stride_bz_input, int stride_h_input, int stride_seq_input,
+    int stride_bz_output, int stride_h_output, int stride_seq_output,
+    int stride_bz_input_sf, int stride_h_input_sf, int stride_seq_input_sf,
+    cudaStream_t stream)
+{
+    constexpr int BLOCK_SIZE = 64;
+    if (head_dim != 64 && head_dim != 128) return false;
+    if (n_tokens <= 0 || batch_size <= 0 || n_heads <= 0) return false;
+
+    dim3 grid((n_tokens + BLOCK_SIZE - 1) / BLOCK_SIZE, batch_size, n_heads);
+    int threads_per_token = head_dim / CVT_FP4_ELTS_PER_THREAD;
+    dim3 block(BLOCK_SIZE * threads_per_token, 1, 1);
+
+    if (head_dim == 128) {
+        nvfp4_dequant_hw_kernel<128, BLOCK_SIZE><<<grid, block, 0, stream>>>(
+            d_nvfp4, d_sf, d_output,
+            batch_size, n_heads, n_tokens,
+            stride_bz_input, stride_h_input, stride_seq_input,
+            stride_bz_output, stride_h_output, stride_seq_output,
+            stride_bz_input_sf, stride_h_input_sf, stride_seq_input_sf);
+    } else {
+        nvfp4_dequant_hw_kernel<64, BLOCK_SIZE><<<grid, block, 0, stream>>>(
+            d_nvfp4, d_sf, d_output,
+            batch_size, n_heads, n_tokens,
+            stride_bz_input, stride_h_input, stride_seq_input,
+            stride_bz_output, stride_h_output, stride_seq_output,
+            stride_bz_input_sf, stride_h_input_sf, stride_seq_input_sf);
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
+} // namespace imp

--- a/src/compute/nvfp4_quant_hw.h
+++ b/src/compute/nvfp4_quant_hw.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+namespace imp {
+
+// =========================================================================
+// NVFP4 quantization — HW-consumption layout
+// =========================================================================
+//
+// Adapted from thu-ml/SageAttention3 (Apache-2.0), specifically
+// scaled_fp4_quant_kernel in sageattention3_blackwell/.../fp4_quantization_4d.cu.
+// This is the layout required by
+//   mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
+// for the `sfa`/`sfb` scale operand. Unlike nvfp4_quant_ref (linear), here
+// the scale bytes are stored in a specific interleaved pattern that
+// matches the hardware MMA fetch.
+//
+// Input shape:  [batch, n_heads, n_tokens, head_dim] FP16 or BF16
+// Output NVFP4: [batch, n_heads, n_tokens, head_dim/2] packed uint8
+// Output SF:    FP8 UE4M3 scale per 16-element group, in hardware layout.
+//               Allocated size = (n_tokens_rounded_64) * 128 bytes per
+//               (batch, head) where n_tokens_rounded_64 = ceil(n_tokens/64)*64.
+//
+// Constraints:
+//   - head_dim must be 64 or 128
+//   - head_dim must be divisible by 16 (always true for 64, 128)
+// =========================================================================
+
+// Host-callable entry: quantize a 4D FP16/BF16 tensor to NVFP4 + HW-layout
+// FP8 UE4M3 scales. Returns false on invalid parameters. Lays out the
+// scale buffer in the format consumed by the block-scaled MMA.
+bool nvfp4_quant_hw_fp16(
+    const half* d_input,
+    uint8_t* d_nvfp4,
+    uint8_t* d_sf,
+    int batch_size,
+    int n_heads,
+    int n_tokens,
+    int head_dim,
+    int stride_bz_input,     // elements
+    int stride_h_input,
+    int stride_seq_input,
+    int stride_bz_output,    // bytes (nvfp4 is 1/2 byte per elem)
+    int stride_h_output,
+    int stride_seq_output,
+    int stride_bz_output_sf,
+    int stride_h_output_sf,
+    int stride_seq_output_sf,
+    cudaStream_t stream);
+
+// Dequantize back to FP16 using the same HW layout — inverse of the
+// quant kernel. Used for round-trip validation. Production attention
+// kernels do not need this because the MMA dequants implicitly.
+bool nvfp4_dequant_hw_fp16(
+    const uint8_t* d_nvfp4,
+    const uint8_t* d_sf,
+    half* d_output,
+    int batch_size,
+    int n_heads,
+    int n_tokens,
+    int head_dim,
+    int stride_bz_input,
+    int stride_h_input,
+    int stride_seq_input,
+    int stride_bz_output,
+    int stride_h_output,
+    int stride_seq_output,
+    int stride_bz_input_sf,
+    int stride_h_input_sf,
+    int stride_seq_input_sf,
+    cudaStream_t stream);
+
+} // namespace imp

--- a/src/compute/nvfp4_quant_ref.cu
+++ b/src/compute/nvfp4_quant_ref.cu
@@ -1,0 +1,178 @@
+// =============================================================================
+// nvfp4_quant_ref.cu -- Reference NVFP4 quantization (round-trip validation)
+// =============================================================================
+//
+// Port of SageAttention3's scaled_fp4_quant_kernel, simplified to a linear
+// storage layout. Used to validate that the FP16→NVFP4 quant math
+// produces sensible values before Project B's Stage-3 integration
+// into the actual FMHA kernel (which needs the HW scale-interleaving).
+//
+// Key PTX instruction: cvt.rn.satfinite.e2m1x2.f32
+//   (sm_120 + CUDA 13.2 — verified by probe commit b9ec21a)
+// =============================================================================
+
+#include "compute/nvfp4_quant_ref.h"
+#include <cuda_fp8.h>
+#include <cstdint>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// FP32 → 2× E2M1 nibbles (packed in one byte). Hardware instruction.
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ uint32_t fp32x8_to_e2m1x8(const float2* vals /* [4] */) {
+    // Produces 8 E2M1 nibbles = 4 bytes = 1 uint32.
+    uint32_t val;
+    asm volatile(
+        "{\n"
+        ".reg .b8 b0, b1, b2, b3;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 b0, %2, %1;\n"  // pair 0: (x0, y0) low-high
+        "cvt.rn.satfinite.e2m1x2.f32 b1, %4, %3;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 b2, %6, %5;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 b3, %8, %7;\n"
+        "mov.b32 %0, {b0, b1, b2, b3};\n"
+        "}"
+        : "=r"(val)
+        : "f"(vals[0].x), "f"(vals[0].y),
+          "f"(vals[1].x), "f"(vals[1].y),
+          "f"(vals[2].x), "f"(vals[2].y),
+          "f"(vals[3].x), "f"(vals[3].y));
+    return val;
+}
+
+// ---------------------------------------------------------------------------
+// E2M1 (4-bit) → FP32 LUT. E2M1 values: {±0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}.
+// Code layout (SageAttention3 & NVFP4 standard):
+//   bit 3 = sign, bits 2..0 = magnitude code 0..7
+//   magnitude: 0→0, 1→0.5, 2→1.0, 3→1.5, 4→2.0, 5→3.0, 6→4.0, 7→6.0
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ float e2m1_nibble_to_fp32(uint8_t nib) {
+    static const float mags[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+    float m = mags[nib & 0x7];
+    return (nib & 0x8) ? -m : m;
+}
+
+// ---------------------------------------------------------------------------
+// Quant kernel: each thread handles 16 FP16 elements.
+//   blockDim.x = threads; gridDim.x covers ceil(n_elements / (16 * blockDim.x))
+// ---------------------------------------------------------------------------
+__global__ void nvfp4_quant_linear_kernel(
+    const half* __restrict__ input,
+    uint8_t* __restrict__ nvfp4_out,   // [n_elements / 2]
+    uint8_t* __restrict__ sf_out,      // [n_elements / 16]
+    int n_elements)
+{
+    const int group_id = blockIdx.x * blockDim.x + threadIdx.x;  // one group = 16 FP16 elems
+    const int start    = group_id * 16;
+    if (start >= n_elements) return;
+
+    // 1. Load 16 FP16 elements into 8 half2 (via vectorized cast).
+    half2 h2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        int idx = start + i * 2;
+        h2[i] = __halves2half2(
+            (idx < n_elements)     ? input[idx]     : __float2half(0.0f),
+            (idx + 1 < n_elements) ? input[idx + 1] : __float2half(0.0f));
+    }
+
+    // 2. Per-group absmax (over 16 elements).
+    half2 maxabs = __habs2(h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 8; ++i) {
+        maxabs = __hmax2(maxabs, __habs2(h2[i]));
+    }
+    float vec_max = float(__hmax(maxabs.x, maxabs.y));
+
+    // 3. Scale (FP8 UE4M3). E2M1 representable max = 6.0 → sc = max / 6.
+    //    Round-trip through FP8 so quantized scale matches storage.
+    float sc = vec_max / 6.0f;
+    uint8_t sc_fp8;
+    reinterpret_cast<__nv_fp8_e4m3&>(sc_fp8) = __nv_fp8_e4m3(sc);
+    sc = float(reinterpret_cast<__nv_fp8_e4m3&>(sc_fp8));
+    float inv_sc = (sc == 0.0f) ? 0.0f : 1.0f / sc;
+
+    // 4. Apply inverse scale and convert to float2 pairs.
+    float2 fp2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        fp2[i]   = __half22float2(h2[i]);
+        fp2[i].x = fp2[i].x * inv_sc;
+        fp2[i].y = fp2[i].y * inv_sc;
+    }
+
+    // 5. Pack: 4 float2 → 1 uint32 (8 nibbles). Two uint32 per group of 16.
+    uint32_t lo = fp32x8_to_e2m1x8(&fp2[0]);
+    uint32_t hi = fp32x8_to_e2m1x8(&fp2[4]);
+
+    // 6. Store. 16 nibbles = 8 bytes per group.
+    uint32_t* dst = reinterpret_cast<uint32_t*>(nvfp4_out + start / 2);
+    dst[0] = lo;
+    dst[1] = hi;
+
+    // 7. Store scale.
+    sf_out[group_id] = sc_fp8;
+}
+
+// ---------------------------------------------------------------------------
+// Dequant kernel: inverse, for round-trip testing.
+// ---------------------------------------------------------------------------
+__global__ void nvfp4_dequant_linear_kernel(
+    const uint8_t* __restrict__ nvfp4_in,
+    const uint8_t* __restrict__ sf_in,
+    half* __restrict__ output,
+    int n_elements)
+{
+    const int group_id = blockIdx.x * blockDim.x + threadIdx.x;
+    const int start    = group_id * 16;
+    if (start >= n_elements) return;
+
+    // Load scale (FP8 UE4M3 → FP32).
+    uint8_t sc_fp8 = sf_in[group_id];
+    float sc = float(reinterpret_cast<const __nv_fp8_e4m3&>(sc_fp8));
+
+    // Load 8 packed bytes (16 NVFP4 nibbles).
+    #pragma unroll
+    for (int i = 0; i < 16; ++i) {
+        int idx = start + i;
+        if (idx >= n_elements) break;
+        int byte_idx = idx / 2;
+        uint8_t byte = nvfp4_in[byte_idx];
+        uint8_t nib = (idx & 1) ? (byte >> 4) : (byte & 0xF);
+        float val = e2m1_nibble_to_fp32(nib) * sc;
+        output[idx] = __float2half(val);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host entry points
+// ---------------------------------------------------------------------------
+void nvfp4_quant_linear_fp16(
+    const half* d_input,
+    uint8_t* d_nvfp4,
+    uint8_t* d_sf,
+    int n_elements,
+    cudaStream_t stream)
+{
+    const int threads = 256;
+    const int groups  = (n_elements + 15) / 16;
+    const int blocks  = (groups + threads - 1) / threads;
+    nvfp4_quant_linear_kernel<<<blocks, threads, 0, stream>>>(
+        d_input, d_nvfp4, d_sf, n_elements);
+}
+
+void nvfp4_dequant_linear_fp16(
+    const uint8_t* d_nvfp4,
+    const uint8_t* d_sf,
+    half* d_output,
+    int n_elements,
+    cudaStream_t stream)
+{
+    const int threads = 256;
+    const int groups  = (n_elements + 15) / 16;
+    const int blocks  = (groups + threads - 1) / threads;
+    nvfp4_dequant_linear_kernel<<<blocks, threads, 0, stream>>>(
+        d_nvfp4, d_sf, d_output, n_elements);
+}
+
+} // namespace imp

--- a/src/compute/nvfp4_quant_ref.h
+++ b/src/compute/nvfp4_quant_ref.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+namespace imp {
+
+// Reference-style NVFP4 quantization, linear layout (no hardware-MMA
+// scale interleaving). Each thread processes 16 consecutive FP16
+// elements, computes one FP8 UE4M3 scale factor, and writes 16 NVFP4
+// nibbles (8 bytes) + 1 scale byte.
+//
+// Storage layout:
+//   nvfp4[i / 2]  — low nibble = element i (even), high nibble = element i+1 (odd)
+//   sf[i / 16]    — FP8 UE4M3 scale for the 16-element group [16*g .. 16*g+15]
+//
+// Input shape: [n_elements] FP16/BF16, contiguous
+// Output nvfp4: [n_elements / 2] uint8 (packed nibbles)
+// Output sf:    [n_elements / 16] uint8 (FP8 UE4M3)
+//
+// NOT used for MMA consumption — the hardware MMA requires a specific
+// scale interleaving (see sageattention3_blackwell). This is only for
+// round-trip correctness validation of the quant math.
+void nvfp4_quant_linear_fp16(
+    const half* d_input,
+    uint8_t* d_nvfp4,
+    uint8_t* d_sf,
+    int n_elements,
+    cudaStream_t stream);
+
+// Inverse: NVFP4 + FP8 UE4M3 scale → FP16. Linear layout reverse.
+void nvfp4_dequant_linear_fp16(
+    const uint8_t* d_nvfp4,
+    const uint8_t* d_sf,
+    half* d_output,
+    int n_elements,
+    cudaStream_t stream);
+
+} // namespace imp

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1125,16 +1125,48 @@ static bool upload_expert_weights(
         // CUDA driver overhead on WSL2/WDDM: cudaMalloc alignment, page tables,
         // and WDDM shared memory management consume ~30% beyond the requested size.
         // Empirical on RTX 5090 WSL2: 22 GiB expert alloc leaves 0 MiB from 28.7 GiB free.
-        // IMP_EXPERT_OVERHEAD_PCT: override default 30% (integer 0..50). Useful for
-        // debugging: lowering forces more experts onto GPU, tests host-resident path.
-        int overhead_pct = 30;
+        //
+        // Auto-pick default: use 10% (aggressive) if ALL experts would fit with
+        // that overhead, else 30% (conservative). This saves users from a
+        // silent 3× perf penalty on Qwen3-Coder-30B / Qwen3.6-35B-class MoE
+        // models where the conservative default unnecessarily offloads experts
+        // to host (measured: 77 → 237 tok/s with 10% vs 30% on Qwen3-Coder-30B
+        // Q6_K, RTX 5090 native Linux).
+        //
+        // IMP_EXPERT_OVERHEAD_PCT: explicit override (integer 0..50). Required
+        // on WSL2/WDDM where the 10% auto-aggressive path may OOM at alloc time.
+        int overhead_pct;
+        bool user_set_overhead = false;
         if (const char* s = getenv("IMP_EXPERT_OVERHEAD_PCT")) {
             int v = atoi(s);
-            if (v >= 0 && v <= 50) overhead_pct = v;
+            if (v >= 0 && v <= 50) {
+                overhead_pct = v;
+                user_set_overhead = true;
+            } else {
+                overhead_pct = 30;
+            }
+        } else {
+            // Auto-pick: probe with aggressive 10%. If all experts fit, use it.
+            // Else fall back to conservative 30%.
+            size_t aggressive_overhead = static_cast<size_t>(free_mem * 10 / 100);
+            size_t aggressive_reserve  = expert_reserve_bytes + aggressive_overhead;
+            size_t aggressive_budget   = (free_mem > aggressive_reserve)
+                                         ? (free_mem - aggressive_reserve) : 0;
+            if (aggressive_budget >= total_expert_bytes) {
+                overhead_pct = 10;
+                IMP_LOG_INFO("Expert offload: all experts fit with 10%% overhead "
+                             "(%.2f GiB experts, %.2f GiB free) — picking aggressive. "
+                             "Set IMP_EXPERT_OVERHEAD_PCT=30 to force conservative.",
+                             total_expert_bytes / (1024.0*1024.0*1024.0),
+                             free_mem / (1024.0*1024.0*1024.0));
+            } else {
+                overhead_pct = 30;
+            }
         }
         size_t overhead = static_cast<size_t>(free_mem * overhead_pct / 100);
         size_t total_reserve = expert_reserve_bytes + overhead;
         size_t budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
+        (void)user_set_overhead;
 
         // IMP_FORCE_HOST_EXPERTS=N: debug flag to force the last N MoE layers
         // off-GPU regardless of budget. Use for reproducing host-resident path

--- a/tests/test_mxf4nvf4_mma_bench.cu
+++ b/tests/test_mxf4nvf4_mma_bench.cu
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+#include "compute/mxf4nvf4_mma_bench.h"
+#include <cuda_runtime.h>
+#include <cstdio>
+
+namespace imp {
+namespace {
+
+// Raw-instruction perf comparison. Logs the numbers, doesn't assert a
+// specific ratio — that would be fragile. But asserts BLOCKSCALE is at
+// least faster than LEGACY, which is the go/no-go gate for Stage 4.
+TEST(Mxf4nvf4MmaBenchTest, BlockScaleBeatsLegacy) {
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+    // 170 warps = 1 per SM on RTX 5090 (full occupancy for the
+    // instruction pipeline). Iterations tuned so total wall time
+    // ≈ 100ms per variant.
+    constexpr int WARPS = 170;
+    constexpr int ITERATIONS = 1 << 20;  // 1M per warp
+
+    MmaBenchResult r = bench_mma_comparison(WARPS, ITERATIONS, stream);
+    cudaStreamDestroy(stream);
+
+    std::printf("\n=== MMA instruction throughput (170 warps × 1M iters) ===\n");
+    std::printf("  kind::f8f6f4.m16n8k32               %7.2f ms  %7.2f TOPS\n",
+                r.legacy_ms, r.legacy_tops);
+    std::printf("  kind::mxf4nvf4.block_scale.m16n8k64 %7.2f ms  %7.2f TOPS\n",
+                r.blockscale_ms, r.blockscale_tops);
+    std::printf("  Speedup (blockscale / legacy):      %5.2fx\n\n", r.speedup);
+
+    // Numerical guards
+    EXPECT_GT(r.legacy_tops, 0.0);
+    EXPECT_GT(r.blockscale_tops, 0.0);
+
+    // The key assertion: the new instruction is at least AS FAST as the
+    // old one. If this fails, Stage 4 integration wouldn't help.
+    EXPECT_GT(r.blockscale_tops, r.legacy_tops)
+        << "mxf4nvf4.block_scale is slower than f8f6f4 — Project B Stage 4 "
+        << "wouldn't deliver a perf win. Re-check the pipelines before "
+        << "committing to the integration.";
+}
+
+} // namespace
+} // namespace imp

--- a/tests/test_mxf4nvf4_probe.cu
+++ b/tests/test_mxf4nvf4_probe.cu
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include "compute/attention_mxf4nvf4_probe.h"
+#include <cuda_runtime.h>
+
+namespace imp {
+namespace {
+
+// Gate for Project B feasibility: does the SageAttention3-style block-scale
+// MMA instruction actually launch and run on sm_120f hardware with CUDA 13.2?
+// Compile already demonstrated PTX acceptance — this test covers runtime.
+TEST(Mxf4nvf4ProbeTest, BlockScaleMMA_LaunchesCleanly) {
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+    bool ok = probe_mxf4nvf4_blockscale(stream);
+
+    cudaStreamDestroy(stream);
+    EXPECT_TRUE(ok) << "mma.sync.kind::mxf4nvf4.block_scale failed at runtime "
+                    << "on sm_120f — Project B (MXFP4 FMHA hardware block-scale "
+                    << "upgrade) is blocked until this is resolved.";
+}
+
+} // namespace
+} // namespace imp

--- a/tests/test_mxf4nvf4_probe.cu
+++ b/tests/test_mxf4nvf4_probe.cu
@@ -20,5 +20,23 @@ TEST(Mxf4nvf4ProbeTest, BlockScaleMMA_LaunchesCleanly) {
                     << "upgrade) is blocked until this is resolved.";
 }
 
+// Numerical sanity: A=0 must force D=0 regardless of B and scale factors.
+// If this fails, our assumptions about operand encoding or layout are
+// wrong and Stage 3 (full integration) would be building on shaky ground.
+TEST(Mxf4nvf4ProbeTest, BlockScaleMMA_ZeroAZeroesOutput) {
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+    float d[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    bool ok = probe_mxf4nvf4_allzero_a(stream, d);
+
+    cudaStreamDestroy(stream);
+    ASSERT_TRUE(ok) << "Kernel launch or memcpy failed";
+    EXPECT_FLOAT_EQ(d[0], 0.0f);
+    EXPECT_FLOAT_EQ(d[1], 0.0f);
+    EXPECT_FLOAT_EQ(d[2], 0.0f);
+    EXPECT_FLOAT_EQ(d[3], 0.0f);
+}
+
 } // namespace
 } // namespace imp

--- a/tests/test_nvfp4_quant_hw.cu
+++ b/tests/test_nvfp4_quant_hw.cu
@@ -1,0 +1,143 @@
+#include <gtest/gtest.h>
+#include "compute/nvfp4_quant_hw.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <vector>
+#include <random>
+#include <cmath>
+#include <iostream>
+
+namespace imp {
+namespace {
+
+// Round-trip with HW-layout scales: validates that the offset formula
+// is self-consistent (quant writes scale at offset X, dequant reads the
+// same scale at offset X). If the formula is broken on one side only,
+// error will be catastrophic. Self-consistent means the round-trip
+// works even without a matching MMA.
+class Nvfp4QuantHwTest : public ::testing::Test {
+protected:
+    void run_roundtrip(int batch, int heads, int tokens, int head_dim, float sigma) {
+        const int64_t in_elems   = (int64_t)batch * heads * tokens * head_dim;
+        const int64_t nvfp4_bytes = in_elems / 2;
+        // HW scale layout rounds tokens up to 64 per batch-head block. 8 scales
+        // per token (hd=128) or 4 (hd=64). Minimum footprint: 128 bytes per
+        // 64-token block per (batch, head).
+        const int64_t tokens_rounded = ((tokens + 63) / 64) * 64;
+        const int64_t sf_bytes = (int64_t)batch * heads * tokens_rounded * (head_dim / 16);
+
+        // Generate input.
+        std::mt19937 rng(42);
+        std::normal_distribution<float> dist(0.0f, sigma);
+        std::vector<half> h_input(in_elems);
+        double input_ss = 0.0;
+        for (int64_t i = 0; i < in_elems; ++i) {
+            float v = dist(rng);
+            h_input[i] = __float2half(v);
+            input_ss += v * v;
+        }
+        double input_rms = std::sqrt(input_ss / in_elems);
+
+        half*    d_input  = nullptr;
+        uint8_t* d_nvfp4  = nullptr;
+        uint8_t* d_sf     = nullptr;
+        half*    d_output = nullptr;
+
+        ASSERT_EQ(cudaMalloc(&d_input,  in_elems * sizeof(half)), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_nvfp4,  nvfp4_bytes),             cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_sf,     sf_bytes),                cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_output, in_elems * sizeof(half)), cudaSuccess);
+
+        cudaMemset(d_sf, 0, sf_bytes);
+        cudaMemcpy(d_input, h_input.data(), in_elems * sizeof(half), cudaMemcpyHostToDevice);
+
+        // Strides (contiguous, row-major [B, H, T, D]).
+        int s_bz = heads * tokens * head_dim;
+        int s_h  = tokens * head_dim;
+        int s_t  = head_dim;
+
+        int s_bz_out = heads * tokens * head_dim / 2;
+        int s_h_out  = tokens * head_dim / 2;
+        int s_t_out  = head_dim / 2;
+
+        // Scale strides: HW layout stores (head_dim/16) bytes per token.
+        // Kernel advances base by (token_id/64) * 64 * s_t_sf to reach the
+        // next 64-token block, so s_t_sf must equal (head_dim/16) bytes/token.
+        int s_t_sf  = head_dim / 16;
+        int s_h_sf  = tokens_rounded * s_t_sf;
+        int s_bz_sf = heads * s_h_sf;
+
+        bool q_ok = nvfp4_quant_hw_fp16(
+            d_input, d_nvfp4, d_sf,
+            batch, heads, tokens, head_dim,
+            s_bz, s_h, s_t,
+            s_bz_out, s_h_out, s_t_out,
+            s_bz_sf, s_h_sf, s_t_sf,
+            0);
+        ASSERT_TRUE(q_ok);
+
+        bool dq_ok = nvfp4_dequant_hw_fp16(
+            d_nvfp4, d_sf, d_output,
+            batch, heads, tokens, head_dim,
+            s_bz_out, s_h_out, s_t_out,
+            s_bz, s_h, s_t,
+            s_bz_sf, s_h_sf, s_t_sf,
+            0);
+        ASSERT_TRUE(dq_ok);
+
+        cudaDeviceSynchronize();
+
+        std::vector<half> h_output(in_elems);
+        cudaMemcpy(h_output.data(), d_output, in_elems * sizeof(half), cudaMemcpyDeviceToHost);
+
+        cudaFree(d_input);
+        cudaFree(d_nvfp4);
+        cudaFree(d_sf);
+        cudaFree(d_output);
+
+        double err_ss = 0.0;
+        for (int64_t i = 0; i < in_elems; ++i) {
+            float a = __half2float(h_input[i]);
+            float b = __half2float(h_output[i]);
+            double d = a - b;
+            err_ss += d * d;
+        }
+        double err_rms = std::sqrt(err_ss / in_elems);
+        double rel     = err_rms / input_rms;
+
+        std::cout << "[  INFO    ] HW round-trip (b=" << batch
+                  << " h=" << heads << " t=" << tokens << " d=" << head_dim
+                  << " σ=" << sigma << "): RMSE " << (rel * 100.0) << "% of input RMS"
+                  << std::endl;
+
+        // Self-consistency bound: if the scale layout formula matches on both
+        // sides, round-trip should be equivalent to the linear-layout case.
+        // Reference from nvfp4_quant_ref: ~9.5% for σ=1 Gaussian.
+        EXPECT_LT(rel, 0.15);
+    }
+};
+
+TEST_F(Nvfp4QuantHwTest, HeadDim128_Single64TokenBlock) {
+    // Exactly one 64-token block, single batch/head — simplest case for the
+    // layout formula.
+    run_roundtrip(/*batch=*/1, /*heads=*/1, /*tokens=*/64, /*head_dim=*/128, 1.0f);
+}
+
+TEST_F(Nvfp4QuantHwTest, HeadDim128_MultipleBlocks) {
+    // Several 64-token blocks exercise the (token_id / 64) stride in the
+    // scale buffer.
+    run_roundtrip(1, 1, 256, 128, 1.0f);
+}
+
+TEST_F(Nvfp4QuantHwTest, HeadDim128_BatchAndHeads) {
+    // Non-trivial batch + head dims.
+    run_roundtrip(2, 4, 128, 128, 1.0f);
+}
+
+TEST_F(Nvfp4QuantHwTest, HeadDim64_SingleBlock) {
+    // head_dim=64 path uses CVT_FP4_ELTS_PER_THREAD=8 (different layout).
+    run_roundtrip(1, 1, 64, 64, 1.0f);
+}
+
+} // namespace
+} // namespace imp

--- a/tests/test_nvfp4_quant_ref.cu
+++ b/tests/test_nvfp4_quant_ref.cu
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+#include "compute/nvfp4_quant_ref.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <vector>
+#include <random>
+#include <cmath>
+
+namespace imp {
+namespace {
+
+// Round-trip validation: FP16 → NVFP4 (with FP8 UE4M3 scale) → FP16.
+// Measures relative error. E2M1 with 8 representable magnitudes
+// plus per-16-element scale should give worst-case ~1/8 = 12.5%
+// quantization step per group; averaged over a Gaussian input
+// distribution the RMSE should be a few percent of the std.
+TEST(Nvfp4QuantRefTest, RoundTripGaussian1024) {
+    constexpr int N = 1024;
+
+    // Generate Gaussian input (deterministic seed for stability).
+    std::vector<half> h_input(N);
+    std::mt19937 rng(12345);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+    float input_ss = 0.0f;
+    for (int i = 0; i < N; ++i) {
+        float v = dist(rng);
+        h_input[i] = __float2half(v);
+        input_ss += v * v;
+    }
+    float input_rms = std::sqrt(input_ss / N);
+
+    half*    d_input  = nullptr;
+    uint8_t* d_nvfp4  = nullptr;
+    uint8_t* d_sf     = nullptr;
+    half*    d_output = nullptr;
+
+    ASSERT_EQ(cudaMalloc(&d_input,  N * sizeof(half)),    cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_nvfp4,  N / 2),               cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_sf,     (N + 15) / 16),       cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_output, N * sizeof(half)),    cudaSuccess);
+
+    cudaMemcpy(d_input, h_input.data(), N * sizeof(half), cudaMemcpyHostToDevice);
+
+    nvfp4_quant_linear_fp16  (d_input, d_nvfp4, d_sf, N, 0);
+    nvfp4_dequant_linear_fp16(d_nvfp4, d_sf, d_output, N, 0);
+    cudaDeviceSynchronize();
+
+    std::vector<half> h_output(N);
+    cudaMemcpy(h_output.data(), d_output, N * sizeof(half), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_input);
+    cudaFree(d_nvfp4);
+    cudaFree(d_sf);
+    cudaFree(d_output);
+
+    // Error metric: RMSE as fraction of input RMS.
+    float err_ss = 0.0f;
+    for (int i = 0; i < N; ++i) {
+        float a = __half2float(h_input[i]);
+        float b = __half2float(h_output[i]);
+        float d = a - b;
+        err_ss += d * d;
+    }
+    float err_rms     = std::sqrt(err_ss / N);
+    float rel_err_rms = err_rms / input_rms;
+
+    // E2M1 with per-16-elem scale: expected RMSE ≈ 2-6% of input RMS for
+    // Gaussian data. Fail if > 15% (something fundamentally wrong).
+    EXPECT_LT(rel_err_rms, 0.15f)
+        << "NVFP4 round-trip RMSE " << (rel_err_rms * 100.0f)
+        << "% of input RMS — quant math likely wrong.";
+
+    // Informational — not a failure condition.
+    std::cout << "[  INFO    ] NVFP4 round-trip relative RMSE: "
+              << (rel_err_rms * 100.0f) << "%" << std::endl;
+}
+
+// Representable-value invariance: if every input is already exactly in
+// the E2M1 value set scaled by a representable FP8 scale, the round-trip
+// should be bit-exact (modulo FP16 rounding).
+TEST(Nvfp4QuantRefTest, RepresentableValuesAreBitExact) {
+    constexpr int N = 16;  // one group
+
+    // E2M1 magnitudes × scale 1.0 → all representable.
+    std::vector<half> h_input(N);
+    float vals[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+    for (int i = 0; i < N; ++i) {
+        float v = vals[i % 8];
+        if (i >= 8) v = -v;
+        h_input[i] = __float2half(v);
+    }
+
+    half*    d_input  = nullptr;
+    uint8_t* d_nvfp4  = nullptr;
+    uint8_t* d_sf     = nullptr;
+    half*    d_output = nullptr;
+
+    ASSERT_EQ(cudaMalloc(&d_input,  N * sizeof(half)),    cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_nvfp4,  N / 2),               cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_sf,     1),                   cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_output, N * sizeof(half)),    cudaSuccess);
+
+    cudaMemcpy(d_input, h_input.data(), N * sizeof(half), cudaMemcpyHostToDevice);
+
+    nvfp4_quant_linear_fp16  (d_input, d_nvfp4, d_sf, N, 0);
+    nvfp4_dequant_linear_fp16(d_nvfp4, d_sf, d_output, N, 0);
+    cudaDeviceSynchronize();
+
+    std::vector<half> h_output(N);
+    cudaMemcpy(h_output.data(), d_output, N * sizeof(half), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_input);
+    cudaFree(d_nvfp4);
+    cudaFree(d_sf);
+    cudaFree(d_output);
+
+    // Each value should round-trip within FP16 tolerance.
+    for (int i = 0; i < N; ++i) {
+        float a = __half2float(h_input[i]);
+        float b = __half2float(h_output[i]);
+        EXPECT_NEAR(a, b, 0.01f) << "idx " << i << ": in=" << a << " out=" << b;
+    }
+}
+
+} // namespace
+} // namespace imp


### PR DESCRIPTION
## Summary

Two orthogonal wins built on top of main (post PR #51/#52/#53):

### 🎯 User-facing: 3.08× MoE default speedup (`49c8d3d`)

Qwen3-30B-A3B SMB benchmark paper (arxiv 2512.23029) reported llama.cpp at
**192 tok/s** on RTX 5090 with Q6_K. imp's default hit **77 tok/s** on
Qwen3-Coder-30B-A3B Q6_K (2.2× gap). Root cause: `IMP_EXPERT_OVERHEAD_PCT`
hard-coded at 30% (calibrated for WSL2/WDDM overhead) pessimistically
offloaded experts to host even when they fit in native-Linux VRAM.

Fix auto-probes with 10% overhead first, falls back to 30% only if the
aggressive budget can't fit all experts. Explicit `IMP_EXPERT_OVERHEAD_PCT`
env var still overrides for WSL2.

**Measurement on RTX 5090 native Linux:**
- Before (default 30%):     77.81 tok/s  (partial offload, CUDA graphs off)
- After  (auto-pick 10%):  234.00 tok/s  (all on GPU, CUDA graphs on)
- Speedup: **3.01×**, **1.22× faster than paper's llama.cpp baseline**

Non-MoE models unaffected (expert-upload branch not entered).

### 🧪 Project B pipeline — 2.60× MMA speedup proven, integration cleared

SageAttention3 (arxiv 2505.11594) reports 1038 TOPS FP4 attention on RTX
5090 using `mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64` —
a hardware block-scale MMA that imp's current MXFP4 FMHA doesn't use.
This PR lays all the groundwork for adopting it (Stage 4 FMHA integration
is a separate push).

| Stage | Commit | Result |
|---|---|---|
| 1 Feasibility gate | `f50221e` | MMA compiles + launches on sm_120f + CUDA 13.2.78 |
| 2 Numerical gate | `e7615f3` | A=0 → D=0 verified |
| 2.5 Quant math (linear) | `4baf0d7` | FP16→NVFP4→FP16 round-trip, 9.5% RMSE Gaussian |
| 3 MMA throughput | `b9fbb66` | **2.60× raw speedup vs legacy** (100 → 260 TOPS) |
| 3.1 HW scale layout | `30e827f` | Quant + dequant with HW-interleaved scale layout, 4/4 tests pass |
| Implementation plan | `98ffabd` | File-level plan for Stage 4 integration |

**Probe artifacts stay as regression tests** — if NVIDIA ever breaks the
instruction, or we upgrade CUDA/CUTLASS, these catch it immediately.

### 📝 Research + catalog docs

- `e3d4b92` — Memory-traffic-reduction catalog (KV / weight / activation / MoE options with status labels)
- `dd0c651` — INT4 KV validation: shipped but -22% decode @ 20K ctx. Kept INT4 code on main but documented the regression.
- `3b258ce` — NVFP4 vs Q6_K on 30B-MoE: Q6_K decode wins by 2× on Qwen3-Coder-30B (same model), NVFP4 prefill wins 7×. Workload-dependent.

## Test plan

- [x] Full regression suite: 583 tests pass (was 574, +9 new)
- [x] Llama-3.2-3B Q8_0 bench: pp=27000+ tok/s, tg=305 tok/s (unchanged from main)
- [x] Qwen3-Coder-30B Q6_K default bench: tg=234 tok/s with auto-pick log visible
- [x] `IMP_EXPERT_OVERHEAD_PCT=10` manual override still works
- [x] `IMP_EXPERT_OVERHEAD_PCT=30` forces conservative (for WSL2 users)
- [x] Probe + quant reference tests run clean on sm_120f
- [ ] WSL2 behavior (no WSL2 test env here — see caveats)

## Caveats

- **WSL2/WDDM users:** the 10% auto-pick might OOM at `cudaMalloc` because
  of WDDM driver overhead. Explicit `IMP_EXPERT_OVERHEAD_PCT=30` bypasses
  the auto-probe. Future work: uname-detect WSL2 and force conservative
  there.
- **Very tight fits:** if model+KV leaves less than ~2 GiB headroom at
  10%, runtime OOM surfaces as a hard error. Obvious from the cudaMalloc
  failure.

## Not included (future PRs)

- Project B Stage 4 (actual MMA swap in `attention_fmha_mxfp4_sm120.cu`)
  — ~30h effort, plan in `docs/PROJECT_B_MXFP4_FMHA_UPGRADE.md`
- INT4 KV removal — main kept INT4 in place for compatibility; removal is
  a separate decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)