### PR TITLE
compute: SM120 FMHA optimization pass — +12.6% Q8_0 prefill, Project B complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # Build
 build/
+build-*/
 *.o
 *.so
 *.a
 *.d
+a.out
 compile_commands.json
 
 # Model files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(IMP_USE_CUTLASS)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxf4nvf4_probe.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_bench.cu)
+    list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_variants_bench.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_hw.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_fmha_mxf4nvf4_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_qkt_validate.cu)
@@ -379,6 +380,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mxf4nvf4_probe.cu
         tests/test_nvfp4_quant_ref.cu
         tests/test_mxf4nvf4_mma_bench.cu
+        tests/test_mxf4nvf4_mma_variants_bench.cu
         tests/test_nvfp4_quant_hw.cu
         tests/test_mxf4nvf4_qkt_validate.cu
         tests/test_softmax.cu

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -29,24 +29,28 @@ void attention_prefill_dispatch(
     const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
     float scale, bool causal, int sliding_window, float softcap, cudaStream_t stream) {
 
-    // MXFP4 Flash Attention: tiled FP4 E2M1 Q·K^T (m16n8k64) with online softmax.
+    // MXFP4 Flash Attention: tiled FP4 E2M1 Q·K^T with online softmax.
     // O(n) memory, ~4x score throughput over FP16, ~2x over FP8.
-    // Requires head_dim % 64 == 0. Enabled with IMP_MXFP4_ATTENTION=1.
+    // Enabled with IMP_MXFP4_ATTENTION=1.
+    //
+    // By default uses kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64 with
+    // per-16-element UE4M3 scales (+1.8% vs legacy at HD=128). head_dim=96
+    // internally falls back to legacy kind::f8f6f4.m16n8k32 (not multiple of 64).
+    // Set IMP_FMHA_BLOCKSCALE=0 to force the legacy path entirely (A/B testing).
     if (attention_mxfp4_available()) {
-        // Stage 4 blockscale-MMA path (IMP_FMHA_BLOCKSCALE=1). Currently
-        // delegates to the legacy kernel — kernel body is WIP. Dispatch
-        // preserves the same true/false contract for fallback chaining.
-        if (mxf4nvf4_blockscale_enabled()) {
+        static const bool use_blockscale = !mxf4nvf4_blockscale_disabled();
+        if (use_blockscale) {
             if (fmha_sm120_mxf4nvf4_prefill(Q, K, V, O, scale, causal,
                                              sliding_window, softcap, stream)) {
                 return;
             }
         } else {
-            if (fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream)) {
+            if (fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal,
+                                          sliding_window, softcap, stream)) {
                 return;
             }
         }
-        // Fall through: head_dim not supported (e.g. 96), use FP8/FP16 path
+        // Fall through: head_dim not supported (e.g. < 32), use FP8/FP16 path
     }
 
     // Native sm_120 FP8 FMHA: QK^T in FP8 E4M3 (m16n8k32) for 2x score throughput.

--- a/src/compute/attention_fmha_mxf4nvf4_sm120.cu
+++ b/src/compute/attention_fmha_mxf4nvf4_sm120.cu
@@ -1,40 +1,26 @@
 // =============================================================================
-// attention_fmha_mxf4nvf4_sm120.cu -- Stage 4 scaffolding for the MXFP4 FMHA
-// hardware-blockscale MMA upgrade (kind::mxf4nvf4.block_scale.m16n8k64).
+// attention_fmha_mxf4nvf4_sm120.cu -- Stage 4 blockscale FMHA entry point.
 // =============================================================================
 //
-// This file is the landing pad for the Stage 4 integration. Upstream work:
-//   - Raw MMA instruction: verified to compile + launch (b9ec21a / f50221e)
-//   - A=0 → D=0 invariant: verified (7298175 / e7615f3)
-//   - Quant math round-trip (linear layout): 9.5% RMSE (7a77063 / 4baf0d7)
-//   - Quant math round-trip (HW scale layout): 9.5% RMSE (8148801 / 30e827f)
-//   - Raw MMA throughput: 2.60× vs legacy (b623cda / b9fbb66)
+// The kernel body lives in attention_fmha_mxfp4_sm120.cu — template parameter
+// UseBlockScaleMma switches the Phase 1 MMA between:
+//   legacy: mma.sync.kind::f8f6f4.m16n8k32          (2× K-chunks per issue)
+//   new:    mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
+//           (merges 2 K-chunks → half the MMA issue count)
 //
-// What's here:
-//   - mxf4nvf4_blockscale_enabled(): checks IMP_FMHA_BLOCKSCALE env var
-//   - fmha_sm120_mxf4nvf4_prefill(): entry point for the dispatcher
-//     Currently delegates to the legacy f8f6f4.m16n8k32 kernel with a
-//     diagnostic log — the actual kernel body is WIP.
+// Uniform scale=1.0 (sfa=sfb=0x38383838) keeps post-MMA manual per-row scaling
+// unchanged, so output is bit-equivalent to the legacy path on m16n8k64 math.
 //
-// What's missing to land the 2.60× speedup:
-//   - Per-thread CUTLASS ALayout / SFALayout translation to match the
-//     (T32,V32)→(M16,K64) mapping expected by the HW MMA (see
-//     sageattention3_blackwell/sageattn3/blackwell/cute_extension.h:157+).
-//   - Per-16-element FP8 UE4M3 scale storage in SMEM (nvfp4_quant_hw
-//     already produces this layout — needs integration here).
-//   - Update the Q/K quantization loop in the kernel to emit the new
-//     scale layout.
-//   - Swap the MMA issue from kind::f8f6f4 to kind::mxf4nvf4.block_scale
-//     (see mxf4nvf4_mma_bench.cu for the PTX template).
+// Operand layout for the new MMA is verified byte-exact in
+// tests/test_mxf4nvf4_qkt_validate.cu (4 tests, 128/128 correct). The CuTe
+// (T32,V32)→(M16,K64) layout is column-major — offset = k*M + m — which
+// matches the legacy register distribution when 2 legacy chunks are merged
+// into {a0,a1,a2,a3} = {chunk0_row_T1, chunk0_row_T1+8, chunk1_row_T1,
+// chunk1_row_T1+8}. No SFA/SFB changes (uniform scale).
 //
-// Why deferred: the CUTLASS CuTe ALayout decomposition is not a one-pass
-// translation — it distributes a thread's 32 FP4 values across 4 rows
-// and 8 k-positions-per-row in a non-row-major pattern. Without running
-// the MMA with reference data to cross-check, operand layout bugs are
-// hard to catch. Future session should start with an end-to-end Q·K^T
-// correctness harness against FP32 reference (see the rejected prototype
-// attempt in the session transcript for context), then wire into the
-// kernel.
+// Raw MMA bench: 2.50× throughput (254.62 vs 101.87 TOPS @ 170 warps × 1M
+// iters). Actual kernel speedup is lower because Phase 1 is only a fraction
+// of total kernel time (softmax, PV, load/store add overhead).
 // =============================================================================
 
 #include "compute/attention_fmha_mxf4nvf4_sm120.h"
@@ -46,45 +32,29 @@
 
 namespace imp {
 
-// ---------------------------------------------------------------------------
-// Env-var gate. IMP_FMHA_BLOCKSCALE=1 activates the new kernel path.
-// Cached on first lookup.
-// ---------------------------------------------------------------------------
 bool mxf4nvf4_blockscale_enabled() {
     static int cached = -1;
     if (cached < 0) {
         const char* v = std::getenv("IMP_FMHA_BLOCKSCALE");
         cached = (v != nullptr && std::strcmp(v, "0") != 0) ? 1 : 0;
         if (cached) {
-            IMP_LOG_INFO("IMP_FMHA_BLOCKSCALE set: routing MXFP4 prefill through "
-                         "the Stage 4 landing pad (currently delegates to the legacy "
-                         "kind::f8f6f4 kernel — the blockscale-MMA kernel body is WIP). "
-                         "Expected raw MMA speedup: 2.60× once the CUTLASS SFALayout "
-                         "translation is implemented.");
+            IMP_LOG_INFO("IMP_FMHA_BLOCKSCALE=1: Phase 1 MMA routed through "
+                         "kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64 "
+                         "(halves MMA issue count on head_dim%%64==0 configs; "
+                         "head_dim=96 falls back to legacy).");
         }
     }
     return cached == 1;
 }
 
-// ---------------------------------------------------------------------------
-// Entry point for the dispatcher.
-// Returns the same contract as the legacy fmha_sm120_mxfp4_prefill:
-//   true  → handled
-//   false → config unsupported, caller should try next fallback
-// ---------------------------------------------------------------------------
 bool fmha_sm120_mxf4nvf4_prefill(
     const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
     float scale, bool causal, int sliding_window, float softcap,
     cudaStream_t stream)
 {
-    // TODO(Stage 4 completion): replace this delegate with a proper
-    // kernel launch that uses kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.
-    // See file-level comment for the outstanding work items.
-    //
-    // Until then, delegate to the legacy kernel so the code path is exercised
-    // and regression tests still cover us under IMP_FMHA_BLOCKSCALE=1.
     return fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal,
-                                     sliding_window, softcap, stream);
+                                     sliding_window, softcap, stream,
+                                     /*use_blockscale=*/true);
 }
 
 } // namespace imp

--- a/src/compute/attention_fmha_mxf4nvf4_sm120.cu
+++ b/src/compute/attention_fmha_mxf4nvf4_sm120.cu
@@ -32,19 +32,24 @@
 
 namespace imp {
 
-bool mxf4nvf4_blockscale_enabled() {
+bool mxf4nvf4_blockscale_disabled() {
     static int cached = -1;
     if (cached < 0) {
         const char* v = std::getenv("IMP_FMHA_BLOCKSCALE");
-        cached = (v != nullptr && std::strcmp(v, "0") != 0) ? 1 : 0;
+        cached = (v != nullptr && std::strcmp(v, "0") == 0) ? 1 : 0;
         if (cached) {
-            IMP_LOG_INFO("IMP_FMHA_BLOCKSCALE=1: Phase 1 MMA routed through "
-                         "kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64 "
-                         "(halves MMA issue count on head_dim%%64==0 configs; "
-                         "head_dim=96 falls back to legacy).");
+            IMP_LOG_INFO("IMP_FMHA_BLOCKSCALE=0: MXFP4 attention forced to "
+                         "legacy kind::f8f6f4.m16n8k32 path (A/B debug only).");
         }
     }
     return cached == 1;
+}
+
+bool mxf4nvf4_blockscale_enabled() {
+    // Default ON — the per-16-element block_scale path is +1.8% vs legacy
+    // at HD=128 and functionally equivalent. Can be disabled via
+    // IMP_FMHA_BLOCKSCALE=0 for A/B testing.
+    return !mxf4nvf4_blockscale_disabled();
 }
 
 bool fmha_sm120_mxf4nvf4_prefill(

--- a/src/compute/attention_fmha_mxf4nvf4_sm120.h
+++ b/src/compute/attention_fmha_mxf4nvf4_sm120.h
@@ -20,18 +20,21 @@ namespace imp {
 //   - Scale layout matches SageAttention3 HW-consumption formula (see
 //     nvfp4_quant_hw.cu for the layout details)
 //
-// Activated via IMP_FMHA_BLOCKSCALE=1 env var. Falls back to the legacy
-// kernel when not set. Returns false if config is unsupported (caller
-// falls through to next fallback in the dispatcher).
+// Default path for MXFP4 attention prefill since 2026-04-25 (+1.8% vs
+// legacy at HD=128). Set IMP_FMHA_BLOCKSCALE=0 to force the legacy path
+// (A/B debug). Returns false if config is unsupported (caller falls
+// through to next fallback in the dispatcher).
 //
-// Requirements: sm_120+, head_dim ∈ {64, 128}.
+// Requirements: sm_120+, head_dim ∈ {64, 128, 256} (HD=96 falls through
+// internally to legacy kind::f8f6f4 because 96 % 64 != 0).
 bool fmha_sm120_mxf4nvf4_prefill(
     const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
     float scale, bool causal, int sliding_window, float softcap,
     cudaStream_t stream);
 
-// Reports whether the mxf4nvf4 blockscale path is enabled for this
-// session (IMP_FMHA_BLOCKSCALE=1 env var). Cheap cached lookup.
+// Reports whether the blockscale path is active (default ON; false only
+// when IMP_FMHA_BLOCKSCALE=0 explicitly disables it).
 bool mxf4nvf4_blockscale_enabled();
+bool mxf4nvf4_blockscale_disabled();
 
 } // namespace imp

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -79,7 +79,12 @@ __device__ __forceinline__ uint8_t pack_fp4_pair(float v0, float v1) {
 // Kernel template
 // =============================================================================
 
-template <int Bq, int HD>
+// UseBlockScaleMma=false: legacy kind::f8f6f4.m16n8k32 (2× K-chunks, padded regs).
+// UseBlockScaleMma=true:  new kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
+//                         (merges 2 legacy K-chunks per issue, half the MMA count).
+// Scale=1.0 uniform (sfa=sfb=0x38383838) keeps the post-MMA manual per-row scaling
+// path identical to the legacy kernel — only the MMA instruction changes.
+template <int Bq, int HD, bool UseBlockScaleMma = false>
 __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1)
 fmha_sm120_mxfp4_kernel(
     const half* __restrict__ Q,
@@ -394,6 +399,65 @@ fmha_sm120_mxfp4_kernel(
             const int thread_in_group = lane_id % 4;
             const int byte_offset = thread_in_group * 4;  // 4 bytes = 8 FP4 nibbles
 
+            if constexpr (UseBlockScaleMma) {
+                // New path: kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
+                // Each issue consumes 64 K-elements (2× legacy). With uniform
+                // scale=1.0 (sfa=sfb=0x38383838), the block-scale MMA reduces
+                // to a plain E2M1 × E2M1 dot product — output is bit-equivalent
+                // to two legacy m16n8k32 issues summed.
+                // Register distribution (per CUTLASS ALayout/BLayout in
+                // mma_traits_sm120.hpp:136, column-major (M,K) / (N,K)):
+                //   a0: row[group_id],   k-stripe 2k
+                //   a1: row[group_id+8], k-stripe 2k
+                //   a2: row[group_id],   k-stripe 2k+1
+                //   a3: row[group_id+8], k-stripe 2k+1
+                //   b0: col[group_id],   k-stripe 2k
+                //   b1: col[group_id],   k-stripe 2k+1
+                const int k_pairs = hd_chunks_fp4 / 2;
+                for (int k = 0; k < k_pairs; k++) {
+                    const int k0 = 2 * k;
+                    const int k1 = k0 + 1;
+                    const uint8_t* q_base0 = Q_fp4 + ri * MX_MMA_M * hd_half_padded + k0 * FP4_K_BYTES;
+                    const uint8_t* q_base1 = Q_fp4 + ri * MX_MMA_M * hd_half_padded + k1 * FP4_K_BYTES;
+                    uint32_t a0 = *reinterpret_cast<const uint32_t*>(
+                        q_base0 + group_id * hd_half_padded + byte_offset);
+                    uint32_t a1 = *reinterpret_cast<const uint32_t*>(
+                        q_base0 + (group_id + 8) * hd_half_padded + byte_offset);
+                    uint32_t a2 = *reinterpret_cast<const uint32_t*>(
+                        q_base1 + group_id * hd_half_padded + byte_offset);
+                    uint32_t a3 = *reinterpret_cast<const uint32_t*>(
+                        q_base1 + (group_id + 8) * hd_half_padded + byte_offset);
+
+                    const uint8_t* k_base0 = KV_fp4 + ci * MX_MMA_N * hd_half_padded + k0 * FP4_K_BYTES;
+                    const uint8_t* k_base1 = KV_fp4 + ci * MX_MMA_N * hd_half_padded + k1 * FP4_K_BYTES;
+                    uint32_t b0 = *reinterpret_cast<const uint32_t*>(
+                        k_base0 + group_id * hd_half_padded + byte_offset);
+                    uint32_t b1 = *reinterpret_cast<const uint32_t*>(
+                        k_base1 + group_id * hd_half_padded + byte_offset);
+
+                    constexpr uint32_t sfa = 0x38383838u;  // FP8 UE4M3 = 1.0 × 4
+                    constexpr uint32_t sfb = 0x38383838u;
+                    constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+#if __CUDA_ARCH__ >= 1200
+                    asm volatile(
+                        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+                        "{%0, %1, %2, %3},"
+                        "{%4, %5, %6, %7},"
+                        "{%8, %9},"
+                        "{%10, %11, %12, %13},"
+                        "{%14},"
+                        "{%15, %16},"
+                        "{%17},"
+                        "{%18, %19};\n"
+                        : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+                          "r"(b0), "r"(b1),
+                          "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+                          "r"(sfa), "h"(bidA), "h"(tidA),
+                          "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+                }
+            } else {
             for (int k = 0; k < hd_chunks_fp4; k++) {
                 // Load A fragment: a0=row[groupID], a1=row[groupID+8], a2=a3=0
                 uint32_t a0, a1;
@@ -428,6 +492,7 @@ fmha_sm120_mxfp4_kernel(
                       "r"(b0), "r"(b1),
                       "f"(d0), "f"(d1), "f"(d2), "f"(d3));
 #endif
+            }
             }
 
             // Store 16×8 result to S_tile with fused scale + mask (Opt 2).
@@ -635,9 +700,15 @@ static size_t compute_smem_mxfp4(int Bq, int Bkv, int head_dim) {
 bool fmha_sm120_mxfp4_prefill(
     const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
     float scale, bool causal, int sliding_window, float softcap,
-    cudaStream_t stream)
+    cudaStream_t stream,
+    bool use_blockscale)
 {
     if (Q.dtype != DType::FP16) return false;
+    // Blockscale MMA operates on K=64 per issue; head_dim must be a multiple of 64.
+    // head_dim=96 (Gemma-class) is a multiple of 32 but NOT 64 → fall back to legacy.
+    if (use_blockscale && (static_cast<int>(Q.shape[3]) % 64 != 0)) {
+        use_blockscale = false;
+    }
 
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int seq_q      = static_cast<int>(Q.shape[1]);
@@ -685,20 +756,20 @@ bool fmha_sm120_mxfp4_prefill(
                   batch_size, seq_q, seq_kv, n_heads, n_kv_heads, head_dim,
                   Bq, MX_Bkv, smem, causal, sliding_window, softcap);
 
-    #define LAUNCH_FMHA_MXFP4(BQ, HD) do { \
+    #define LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, BS) do { \
         cudaError_t attr_err = cudaFuncSetAttribute( \
-            fmha_sm120_mxfp4_kernel<BQ, HD>, \
+            fmha_sm120_mxfp4_kernel<BQ, HD, BS>, \
             cudaFuncAttributeMaxDynamicSharedMemorySize, \
             static_cast<int>(smem)); \
         if (attr_err != cudaSuccess) { \
-            IMP_LOG_WARN("FMHA MXFP4: cudaFuncSetAttribute failed Bq=%d HD=%d smem=%zu: %s", \
-                         BQ, HD, smem, cudaGetErrorString(attr_err)); \
+            IMP_LOG_WARN("FMHA MXFP4: cudaFuncSetAttribute failed Bq=%d HD=%d bs=%d smem=%zu: %s", \
+                         BQ, HD, (int)BS, smem, cudaGetErrorString(attr_err)); \
             return false; \
         } \
-        cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD>, \
+        cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS>, \
             cudaFuncAttributePreferredSharedMemoryCarveout, \
             cudaSharedmemCarveoutMaxShared); \
-        fmha_sm120_mxfp4_kernel<BQ, HD><<<grid, block, smem, stream>>>( \
+        fmha_sm120_mxfp4_kernel<BQ, HD, BS><<<grid, block, smem, stream>>>( \
             reinterpret_cast<const half*>(Q.data), \
             reinterpret_cast<const half*>(K.data), \
             reinterpret_cast<const half*>(V.data), \
@@ -706,6 +777,11 @@ bool fmha_sm120_mxfp4_prefill(
             batch_size, seq_q, seq_kv, \
             n_heads, n_kv_heads, \
             scale, causal, sliding_window, softcap); \
+    } while (0)
+
+    #define LAUNCH_FMHA_MXFP4(BQ, HD) do { \
+        if (use_blockscale) LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true); \
+        else                LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, false); \
     } while (0)
 
     if (Bq == 128) {
@@ -735,6 +811,7 @@ bool fmha_sm120_mxfp4_prefill(
     }
 
     #undef LAUNCH_FMHA_MXFP4
+    #undef LAUNCH_FMHA_MXFP4_IMPL
     return false;
 }
 

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -205,14 +205,20 @@ fmha_sm120_mxfp4_kernel(
         // Opt 4: Load Q FP16 → S_tile (as staging), then read from shared for both passes.
         half* Q_stage = reinterpret_cast<half*>(S_tile);
         {
-            const int total = Bq * head_dim;
-            for (int i = tid; i < total; i += MX_BLOCK_THREADS) {
+            // float4 = 8 halves per iter (all supported HDs are multiples of 8)
+            const int total_vec8 = (Bq * head_dim) / 8;
+            for (int vi = tid; vi < total_vec8; vi += MX_BLOCK_THREADS) {
+                int i = vi * 8;
                 int r = i / head_dim;
                 int d = i % head_dim;
-                if (q_start + r < seq_q)
-                    Q_stage[i] = Q_ptr[(int64_t)r * q_row_stride + d];
-                else
-                    Q_stage[i] = __float2half(0.0f);
+                float4* dst = reinterpret_cast<float4*>(&Q_stage[i]);
+                if (q_start + r < seq_q) {
+                    const float4* src = reinterpret_cast<const float4*>(
+                        &Q_ptr[(int64_t)r * q_row_stride + d]);
+                    *dst = *src;
+                } else {
+                    *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+                }
             }
         }
         __syncthreads();
@@ -283,8 +289,12 @@ fmha_sm120_mxfp4_kernel(
 
     // Zero O accumulator + init softmax state
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += MX_BLOCK_THREADS) O_acc[i] = 0.0f;
+        // float4 = 4 FP32 zeros per iter
+        const int total_vec4 = (Bq * head_dim) / 4;
+        const float4 zero = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+        for (int vi = tid; vi < total_vec4; vi += MX_BLOCK_THREADS) {
+            reinterpret_cast<float4*>(O_acc)[vi] = zero;
+        }
     }
     if (tid < Bq) { row_m[tid] = -FLT_MAX; row_l[tid] = 0.0f; }
     bool first_kv_iter = true;  // skip O_acc rescale on first tile (l_old=0 → rescale=0)
@@ -318,16 +328,22 @@ fmha_sm120_mxfp4_kernel(
         // ---- Quantize K tile to FP4 (Opt 1: shared-memory staging) ----
         if constexpr (can_stage_in_stile) {
             // Load K FP16 → S_tile (as staging buffer), then read from shared
+            // float4 = 8 halves per iter
             half* K_stage = reinterpret_cast<half*>(S_tile);
             {
-                const int total = Bkv * head_dim;
-                for (int i = tid; i < total; i += MX_BLOCK_THREADS) {
+                const int total_vec8 = (Bkv * head_dim) / 8;
+                for (int vi = tid; vi < total_vec8; vi += MX_BLOCK_THREADS) {
+                    int i = vi * 8;
                     int r = i / head_dim;
                     int d = i % head_dim;
-                    if (kv_start + r < seq_kv)
-                        K_stage[i] = K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d];
-                    else
-                        K_stage[i] = __float2half(0.0f);
+                    float4* dst = reinterpret_cast<float4*>(&K_stage[i]);
+                    if (kv_start + r < seq_kv) {
+                        const float4* src = reinterpret_cast<const float4*>(
+                            &K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]);
+                        *dst = *src;
+                    } else {
+                        *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+                    }
                 }
             }
             __syncthreads();
@@ -684,13 +700,21 @@ fmha_sm120_mxfp4_kernel(
         __syncthreads();
     }
 
-    // ---- Write final output to global memory ----
+    // ---- Write final output (vectorized: 4 FP32 → 4 FP16 per iter) ----
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += MX_BLOCK_THREADS) {
+        const int total_vec4 = (Bq * head_dim) / 4;
+        for (int vi = tid; vi < total_vec4; vi += MX_BLOCK_THREADS) {
+            int i = vi * 4;
             int r = i / head_dim;
-            if (q_start + r < seq_q)
-                O_ptr[(int64_t)r * q_row_stride + (i % head_dim)] = __float2half(O_acc[i]);
+            if (q_start + r >= seq_q) continue;
+            float4 v = reinterpret_cast<const float4*>(O_acc)[vi];
+            half2 lo = __float22half2_rn(make_float2(v.x, v.y));
+            half2 hi = __float22half2_rn(make_float2(v.z, v.w));
+            uint2 packed;
+            packed.x = *reinterpret_cast<const uint32_t*>(&lo);
+            packed.y = *reinterpret_cast<const uint32_t*>(&hi);
+            *reinterpret_cast<uint2*>(
+                &O_ptr[(int64_t)r * q_row_stride + (i % head_dim)]) = packed;
         }
     }
 }

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -300,7 +300,24 @@ fmha_sm120_mxfp4_kernel(
         }
     } else {
         // Fallback: 2-pass global reads (for Bq=32, HD>64)
-        {
+        if constexpr (UseBlockScaleMma) {
+            // Per-(row, k_group) absmax from global. Each thread owns one or
+            // more (r, kg) pairs via a stride loop. No cross-thread reduction.
+            const int total_groups = Bq * n_k_groups;
+            for (int idx = tid; idx < total_groups; idx += MX_BLOCK_THREADS) {
+                int r = idx / n_k_groups;
+                int kg = idx % n_k_groups;
+                float absmax = 0.0f;
+                if (q_start + r < seq_q) {
+                    const half* row = &Q_ptr[(int64_t)r * q_row_stride + kg * 16];
+                    #pragma unroll
+                    for (int i = 0; i < 16; i++)
+                        absmax = fmaxf(absmax, fabsf(__half2float(row[i])));
+                }
+                float raw = absmax / 6.0f;
+                q_scales_fp8[r * n_k_groups + kg] = float_to_fp8_e4m3(raw * sqrt_scale);
+            }
+        } else {
             const int r = sm_row;
             float local_max = 0.0f;
             if (r < Bq && q_start + r < seq_q) {
@@ -310,20 +327,8 @@ fmha_sm120_mxfp4_kernel(
             #pragma unroll
             for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                 local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-            if (sm_lane == 0 && r < Bq) {
-                if constexpr (UseBlockScaleMma) {
-                    // Fallback path: use per-row absmax, replicate across all k_groups
-                    // (loses the per-16 granularity benefit, but the fallback is only
-                    // for Bq=32 + HD>64 which is rarely hit).
-                    float raw = local_max / 6.0f;
-                    uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
-                    #pragma unroll
-                    for (int kg = 0; kg < n_k_groups; kg++)
-                        q_scales_fp8[r * n_k_groups + kg] = ue4m3;
-                } else {
-                    q_scales[r] = local_max / 6.0f * sqrt_scale;
-                }
-            }
+            if (sm_lane == 0 && r < Bq)
+                q_scales[r] = local_max / 6.0f * sqrt_scale;
         }
         __syncthreads();
 
@@ -480,7 +485,23 @@ fmha_sm120_mxfp4_kernel(
             __syncthreads();
         } else {
             // Fallback: 2-pass global reads
-            {
+            if constexpr (UseBlockScaleMma) {
+                // Per-(row, k_group) absmax from global
+                const int total_groups = Bkv * n_k_groups;
+                for (int idx = tid; idx < total_groups; idx += MX_BLOCK_THREADS) {
+                    int r = idx / n_k_groups;
+                    int kg = idx % n_k_groups;
+                    float absmax = 0.0f;
+                    if (kv_start + r < seq_kv) {
+                        const half* row = &K_ptr[(int64_t)(kv_start + r) * kv_row_stride + kg * 16];
+                        #pragma unroll
+                        for (int i = 0; i < 16; i++)
+                            absmax = fmaxf(absmax, fabsf(__half2float(row[i])));
+                    }
+                    float raw = absmax / 6.0f;
+                    k_scales_fp8[r * n_k_groups + kg] = float_to_fp8_e4m3(raw * sqrt_scale);
+                }
+            } else {
                 const int r = sm_row;
                 float local_max = 0.0f;
                 if (r < Bkv && kv_start + r < seq_kv) {
@@ -490,17 +511,8 @@ fmha_sm120_mxfp4_kernel(
                 #pragma unroll
                 for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                     local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-                if (sm_lane == 0 && r < Bkv) {
-                    if constexpr (UseBlockScaleMma) {
-                        float raw = local_max / 6.0f;
-                        uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
-                        #pragma unroll
-                        for (int kg = 0; kg < n_k_groups; kg++)
-                            k_scales_fp8[r * n_k_groups + kg] = ue4m3;
-                    } else {
-                        k_scales[r] = local_max / 6.0f * sqrt_scale;
-                    }
-                }
+                if (sm_lane == 0 && r < Bkv)
+                    k_scales[r] = local_max / 6.0f * sqrt_scale;
             }
             __syncthreads();
 
@@ -886,16 +898,7 @@ bool fmha_sm120_mxfp4_prefill(
     if (Q.dtype != DType::FP16) return false;
     // Blockscale MMA operates on K=64 per issue; head_dim must be a multiple of 64.
     // head_dim=96 (Gemma-class) is a multiple of 32 but NOT 64 → fall back to legacy.
-    const int hd_check = static_cast<int>(Q.shape[3]);
-    if (use_blockscale && (hd_check % 64 != 0)) {
-        use_blockscale = false;
-    }
-    // Blockscale is only beneficial when the Q/K FP16-staging fast path fits
-    // (HD ≤ 2*Bq). At HD=256, Bq must drop to 32 → can_stage_in_stile=false,
-    // which forces the scalar global-read fallback where the per-16-element
-    // granularity benefit is lost but the per-k_group dequant overhead remains.
-    // Measured -2.7% on Gemma-4 HD=256 Q4_K_M; route such configs to legacy.
-    if (use_blockscale && hd_check > 128) {
+    if (use_blockscale && (static_cast<int>(Q.shape[3]) % 64 != 0)) {
         use_blockscale = false;
     }
 

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -239,17 +239,33 @@ fmha_sm120_mxfp4_kernel(
         }
         __syncthreads();
 
-        // Quantize from shared → Q_fp4 (padded stride for bank conflict avoidance)
+        // Quantize from shared → Q_fp4 (vectorized: 8 halves = 4 bytes/iter, uint32 store)
         {
-            const int total_packed = Bq * hd_half;
-            for (int idx = tid; idx < total_packed; idx += MX_BLOCK_THREADS) {
-                int r = idx / hd_half;
-                int d_byte = idx % hd_half;
-                int d = d_byte * 2;
+            // hd_half ≥ 4 for all supported HDs (32, 48, 64, 128). Stride hd_half_padded
+            // is always 4-byte aligned (hd_half + 4 bytes pad).
+            const int total_packed_u32 = (Bq * hd_half) / 4;
+            for (int idx = tid; idx < total_packed_u32; idx += MX_BLOCK_THREADS) {
+                int r = idx / (hd_half / 4);
+                int b4 = idx % (hd_half / 4);     // which 4-byte chunk in this row
+                int d = b4 * 8;                   // starting half index
                 float inv_scale = (q_scales[r] > 0.0f) ? (sqrt_scale / q_scales[r]) : 0.0f;
-                float v0 = __half2float(Q_stage[r * head_dim + d]) * inv_scale;
-                float v1 = __half2float(Q_stage[r * head_dim + d + 1]) * inv_scale;
-                Q_fp4[r * hd_half_padded + d_byte] = pack_fp4_pair(v0, v1);
+                const half* src = &Q_stage[r * head_dim + d];
+                // Load 8 halves via 2× half2 (4 bytes each)
+                half2 h01 = reinterpret_cast<const half2*>(src)[0];
+                half2 h23 = reinterpret_cast<const half2*>(src)[1];
+                half2 h45 = reinterpret_cast<const half2*>(src)[2];
+                half2 h67 = reinterpret_cast<const half2*>(src)[3];
+                uint32_t b0 = pack_fp4_pair(__half2float(h01.x) * inv_scale,
+                                             __half2float(h01.y) * inv_scale);
+                uint32_t b1 = pack_fp4_pair(__half2float(h23.x) * inv_scale,
+                                             __half2float(h23.y) * inv_scale);
+                uint32_t b2 = pack_fp4_pair(__half2float(h45.x) * inv_scale,
+                                             __half2float(h45.y) * inv_scale);
+                uint32_t b3 = pack_fp4_pair(__half2float(h67.x) * inv_scale,
+                                             __half2float(h67.y) * inv_scale);
+                uint32_t packed = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+                *reinterpret_cast<uint32_t*>(
+                    &Q_fp4[r * hd_half_padded + b4 * 4]) = packed;
             }
         }
     } else {
@@ -364,17 +380,30 @@ fmha_sm120_mxfp4_kernel(
             }
             __syncthreads();
 
-            // Quantize from shared → KV_fp4 (padded stride)
+            // Quantize from shared → KV_fp4 (vectorized: 8 halves = 4 bytes/iter)
             {
-                const int total_packed = Bkv * hd_half;
-                for (int idx = tid; idx < total_packed; idx += MX_BLOCK_THREADS) {
-                    int r = idx / hd_half;
-                    int d_byte = idx % hd_half;
-                    int d = d_byte * 2;
+                const int total_packed_u32 = (Bkv * hd_half) / 4;
+                for (int idx = tid; idx < total_packed_u32; idx += MX_BLOCK_THREADS) {
+                    int r = idx / (hd_half / 4);
+                    int b4 = idx % (hd_half / 4);
+                    int d = b4 * 8;
                     float inv_scale = (k_scales[r] > 0.0f) ? (sqrt_scale / k_scales[r]) : 0.0f;
-                    float v0 = __half2float(K_stage[r * head_dim + d]) * inv_scale;
-                    float v1 = __half2float(K_stage[r * head_dim + d + 1]) * inv_scale;
-                    KV_fp4[r * hd_half_padded + d_byte] = pack_fp4_pair(v0, v1);
+                    const half* src = &K_stage[r * head_dim + d];
+                    half2 h01 = reinterpret_cast<const half2*>(src)[0];
+                    half2 h23 = reinterpret_cast<const half2*>(src)[1];
+                    half2 h45 = reinterpret_cast<const half2*>(src)[2];
+                    half2 h67 = reinterpret_cast<const half2*>(src)[3];
+                    uint32_t b0 = pack_fp4_pair(__half2float(h01.x) * inv_scale,
+                                                 __half2float(h01.y) * inv_scale);
+                    uint32_t b1 = pack_fp4_pair(__half2float(h23.x) * inv_scale,
+                                                 __half2float(h23.y) * inv_scale);
+                    uint32_t b2 = pack_fp4_pair(__half2float(h45.x) * inv_scale,
+                                                 __half2float(h45.y) * inv_scale);
+                    uint32_t b3 = pack_fp4_pair(__half2float(h67.x) * inv_scale,
+                                                 __half2float(h67.y) * inv_scale);
+                    uint32_t packed = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+                    *reinterpret_cast<uint32_t*>(
+                        &KV_fp4[r * hd_half_padded + b4 * 4]) = packed;
                 }
             }
             __syncthreads();

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -23,6 +23,7 @@
 #include "compute/attention_fmha_mxfp4_sm120.h"
 #include "compute/attention_paged_common.cuh"
 #include "core/logging.h"
+#include "quant/fp8_utils.cuh"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <float.h>
@@ -187,6 +188,10 @@ fmha_sm120_mxfp4_kernel(
     float*   O_acc    = S_tile + Bq * Bkv;
     float*   row_m    = O_acc + Bq * head_dim;
     float*   row_l    = row_m + Bq;
+    // Per-row UE4M3 scales for blockscale-MMA sfa/sfb operands (only populated
+    // when UseBlockScaleMma=true; uninitialized otherwise). Placed at the tail.
+    uint8_t* q_scales_fp8 = reinterpret_cast<uint8_t*>(row_l + Bq);
+    uint8_t* k_scales_fp8 = q_scales_fp8 + Bq;
 
     // Pre-compute sqrt(attention_scale) to absorb into Q and K scales (Opt 3).
     // S_true[i,j] = q_scale[i] * k_scale[j] * mma[i,j], and we want the result
@@ -234,8 +239,22 @@ fmha_sm120_mxfp4_kernel(
             #pragma unroll
             for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                 local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-            if (sm_lane == 0 && r < Bq)
-                q_scales[r] = local_max / 6.0f * sqrt_scale;  // Opt 3: absorb sqrt(scale)
+            if (sm_lane == 0 && r < Bq) {
+                if constexpr (UseBlockScaleMma) {
+                    // Blockscale path: encode per-row scale × sqrt(attention_scale) as
+                    // UE4M3, store both the dequanted float (for self-consistent quant)
+                    // and the byte (for sfa operand).
+                    float raw = local_max / 6.0f;
+                    uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
+                    q_scales_fp8[r] = ue4m3;
+                    // Use dequanted value divided by sqrt_scale (so that inv_scale =
+                    // sqrt_scale / q_scales[r] = 1/dequanted_raw_scale).
+                    float dequant = fp8_e4m3_to_float_fast(ue4m3);
+                    q_scales[r] = dequant;  // store sqrt_scale*raw_dq (MMA sfa quantity)
+                } else {
+                    q_scales[r] = local_max / 6.0f * sqrt_scale;  // legacy
+                }
+            }
         }
         __syncthreads();
 
@@ -280,8 +299,16 @@ fmha_sm120_mxfp4_kernel(
             #pragma unroll
             for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                 local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-            if (sm_lane == 0 && r < Bq)
-                q_scales[r] = local_max / 6.0f * sqrt_scale;  // Opt 3
+            if (sm_lane == 0 && r < Bq) {
+                if constexpr (UseBlockScaleMma) {
+                    float raw = local_max / 6.0f;
+                    uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
+                    q_scales_fp8[r] = ue4m3;
+                    q_scales[r] = fp8_e4m3_to_float_fast(ue4m3);
+                } else {
+                    q_scales[r] = local_max / 6.0f * sqrt_scale;
+                }
+            }
         }
         __syncthreads();
 
@@ -375,8 +402,16 @@ fmha_sm120_mxfp4_kernel(
                 #pragma unroll
                 for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                     local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-                if (sm_lane == 0 && r < Bkv)
-                    k_scales[r] = local_max / 6.0f * sqrt_scale;  // Opt 3: absorb sqrt(scale)
+                if (sm_lane == 0 && r < Bkv) {
+                    if constexpr (UseBlockScaleMma) {
+                        float raw = local_max / 6.0f;
+                        uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
+                        k_scales_fp8[r] = ue4m3;
+                        k_scales[r] = fp8_e4m3_to_float_fast(ue4m3);
+                    } else {
+                        k_scales[r] = local_max / 6.0f * sqrt_scale;
+                    }
+                }
             }
             __syncthreads();
 
@@ -419,8 +454,16 @@ fmha_sm120_mxfp4_kernel(
                 #pragma unroll
                 for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                     local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-                if (sm_lane == 0 && r < Bkv)
-                    k_scales[r] = local_max / 6.0f * sqrt_scale;  // Opt 3
+                if (sm_lane == 0 && r < Bkv) {
+                    if constexpr (UseBlockScaleMma) {
+                        float raw = local_max / 6.0f;
+                        uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
+                        k_scales_fp8[r] = ue4m3;
+                        k_scales[r] = fp8_e4m3_to_float_fast(ue4m3);
+                    } else {
+                        k_scales[r] = local_max / 6.0f * sqrt_scale;
+                    }
+                }
             }
             __syncthreads();
 
@@ -498,8 +541,22 @@ fmha_sm120_mxfp4_kernel(
                     uint32_t b1 = *reinterpret_cast<const uint32_t*>(
                         k_base1 + group_id * hd_half_padded + byte_offset);
 
-                    constexpr uint32_t sfa = 0x38383838u;  // FP8 UE4M3 = 1.0 × 4
-                    constexpr uint32_t sfb = 0x38383838u;
+                    // Real block-scale: load per-row UE4M3 scales from SMEM and replicate
+                    // to uint32 (all 4 scales per thread cover the same row's k-groups).
+                    // SFA layout: thread T's sfa → row m_sfa = (T/4) + (T%2)*8.
+                    // SFB layout: thread T's sfb → col n_sfb = T/4.
+                    const int m_sfa = (lane_id / 4) + (lane_id % 2) * 8;
+                    const int n_sfb = lane_id / 4;
+                    uint8_t qs_byte = q_scales_fp8[ri * MX_MMA_M + m_sfa];
+                    uint8_t ks_byte = k_scales_fp8[ci * MX_MMA_N + n_sfb];
+                    uint32_t sfa = (uint32_t)qs_byte
+                                 | ((uint32_t)qs_byte << 8)
+                                 | ((uint32_t)qs_byte << 16)
+                                 | ((uint32_t)qs_byte << 24);
+                    uint32_t sfb = (uint32_t)ks_byte
+                                 | ((uint32_t)ks_byte << 8)
+                                 | ((uint32_t)ks_byte << 16)
+                                 | ((uint32_t)ks_byte << 24);
                     constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;
 #if __CUDA_ARCH__ >= 1200
                     asm volatile(
@@ -568,12 +625,19 @@ fmha_sm120_mxfp4_kernel(
                 int r0 = (lane_id / 4) % 8;
                 int c0 = (lane_id % 4) * 2;
 
-                // Scale correction: q_scales already includes sqrt(attention_scale),
-                // k_scales also includes sqrt(attention_scale), so product = full scale.
-                float qs0 = q_scales[base_row + r0];
-                float qs1 = q_scales[base_row + r0 + 8];
-                float ks0 = k_scales[base_col + c0];
-                float ks1 = k_scales[base_col + c0 + 1];
+                // Scale correction: in legacy mode, q_scales/k_scales include
+                // sqrt(attention_scale), and their product applies the full scale
+                // factor. In real blockscale mode, HW already applied per-row
+                // sfa/sfb during MMA, so val is already the attention score.
+                float qs0, qs1, ks0, ks1;
+                if constexpr (UseBlockScaleMma) {
+                    qs0 = qs1 = ks0 = ks1 = 1.0f;  // HW already scaled
+                } else {
+                    qs0 = q_scales[base_row + r0];
+                    qs1 = q_scales[base_row + r0 + 8];
+                    ks0 = k_scales[base_col + c0];
+                    ks1 = k_scales[base_col + c0 + 1];
+                }
 
                 // Compute global Q/K positions for masking
                 int gq0 = q_start + base_row + r0;
@@ -761,7 +825,8 @@ static size_t compute_smem_mxfp4(int Bq, int Bkv, int head_dim) {
     size_t s_tile   = (size_t)Bq * Bkv * sizeof(float);          // S_tile
     size_t o_acc    = (size_t)Bq * head_dim * sizeof(float);     // O_acc
     size_t softmax  = 2 * (size_t)Bq * sizeof(float);            // row_m + row_l
-    return q_fp4 + q_scales + align + kv_buf + k_scales + s_tile + o_acc + softmax;
+    size_t scales_fp8 = (size_t)(Bq + Bkv);                      // UE4M3 per-row scales (blockscale)
+    return q_fp4 + q_scales + align + kv_buf + k_scales + s_tile + o_acc + softmax + scales_fp8;
 }
 
 // =============================================================================

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -553,30 +553,33 @@ fmha_sm120_mxfp4_kernel(
         //   A: row = groupID (+8 for a1), k_offset = threadID * 4 bytes (8 FP4)
         //   B: col = groupID (0-7 for n=8), k_offset = threadID * 4 bytes
         // Iteration strategy:
-        //   UseBlockScaleMma=true:  outer iterates over (ri, ci_pair) where each
-        //     pair covers 2 consecutive ci values (16x16 output via 2 MMAs).
-        //     A operand loaded once per k-pair iteration and reused across the
-        //     2 MMAs (one per ci). Halves Q_fp4 SMEM-A bandwidth in Phase 1.
+        //   UseBlockScaleMma=true:  outer iterates over (ri, ci_meta) where each
+        //     meta covers 4 consecutive ci values (16x32 output via 4 MMAs).
+        //     A operand + sfa loaded once per k iteration and reused across the
+        //     4 MMAs. Quarters Q_fp4 SMEM-A bandwidth in Phase 1.
         //   UseBlockScaleMma=false: original single-tile distribution.
-        const int s_col_tile_pairs = s_col_tiles_half / 2;  // groups of 2 ci's
-        const int s_pair_total_tiles = s_row_tiles * s_col_tile_pairs;
-        const int outer_total = UseBlockScaleMma ? s_pair_total_tiles : s_total_tiles;
+        constexpr int CI_PER_META = 4;
+        const int s_col_tile_metas = s_col_tiles_half / CI_PER_META;
+        const int s_meta_total_tiles = s_row_tiles * s_col_tile_metas;
+        const int outer_total = UseBlockScaleMma ? s_meta_total_tiles : s_total_tiles;
 
         for (int tile_idx = warp_id; tile_idx < outer_total; tile_idx += MX_NUM_WARPS) {
             int ri, ci;
-            int ci_pair_base = 0;
+            int ci_meta_base = 0;
             if constexpr (UseBlockScaleMma) {
-                ri = tile_idx / s_col_tile_pairs;
-                ci_pair_base = (tile_idx % s_col_tile_pairs) * 2;
-                ci = ci_pair_base;  // first ci in pair (used for legacy-shared globals)
+                ri = tile_idx / s_col_tile_metas;
+                ci_meta_base = (tile_idx % s_col_tile_metas) * CI_PER_META;
+                ci = ci_meta_base;  // first ci (used by code shared with legacy)
             } else {
                 ri = tile_idx / s_col_tiles_half;
                 ci = tile_idx % s_col_tiles_half;
             }
 
             float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
-            // Second-ci accumulators (only used in blockscale 2-issue path)
+            // Extra accumulators for ci_meta_base + 1..3 (4-issue blockscale only)
             float d4 = 0.0f, d5 = 0.0f, d6 = 0.0f, d7 = 0.0f;
+            float d8 = 0.0f, d9 = 0.0f, dA = 0.0f, dB = 0.0f;
+            float dC = 0.0f, dD = 0.0f, dE = 0.0f, dF = 0.0f;
 
             const int group_id = lane_id / 4;
             const int thread_in_group = lane_id % 4;
@@ -599,14 +602,31 @@ fmha_sm120_mxfp4_kernel(
                 const int k_pairs = hd_chunks_fp4 / 2;
                 const int m_sfa = (lane_id / 4) + (lane_id % 2) * 8;
                 const int n_sfb = lane_id / 4;
-                const int ci_a = ci_pair_base;
-                const int ci_b = ci_pair_base + 1;
+                constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+                #define MXF4_MMA(d_a, d_b, d_c, d_d, b_lo, b_hi, sfb_) \
+                    asm volatile( \
+                        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 " \
+                        "{%0, %1, %2, %3}," \
+                        "{%4, %5, %6, %7}," \
+                        "{%8, %9}," \
+                        "{%10, %11, %12, %13}," \
+                        "{%14}," \
+                        "{%15, %16}," \
+                        "{%17}," \
+                        "{%18, %19};\n" \
+                        : "=f"(d_a), "=f"(d_b), "=f"(d_c), "=f"(d_d) \
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), \
+                          "r"(b_lo), "r"(b_hi), \
+                          "f"(d_a), "f"(d_b), "f"(d_c), "f"(d_d), \
+                          "r"(sfa), "h"(bidA), "h"(tidA), \
+                          "r"(sfb_), "h"(bidB), "h"(tidB))
+
                 for (int k = 0; k < k_pairs; k++) {
                     const int k0 = 2 * k;
                     const int k1 = k0 + 1;
                     const uint8_t* q_base0 = Q_fp4 + ri * MX_MMA_M * hd_half_padded + k0 * FP4_K_BYTES;
                     const uint8_t* q_base1 = Q_fp4 + ri * MX_MMA_M * hd_half_padded + k1 * FP4_K_BYTES;
-                    // A loaded once, reused for both ci's
+                    // A loaded once, reused for all 4 ci's
                     uint32_t a0 = *reinterpret_cast<const uint32_t*>(
                         q_base0 + group_id * hd_half_padded + byte_offset);
                     uint32_t a1 = *reinterpret_cast<const uint32_t*>(
@@ -616,72 +636,32 @@ fmha_sm120_mxfp4_kernel(
                     uint32_t a3 = *reinterpret_cast<const uint32_t*>(
                         q_base1 + (group_id + 8) * hd_half_padded + byte_offset);
 
-                    // sfa shared across both ci's (depends only on row + k_group)
+                    // sfa shared across all 4 ci's
                     const int kg_base = k * 4;
                     uint32_t sfa = *reinterpret_cast<const uint32_t*>(
                         &q_scales_fp8[(ri * MX_MMA_M + m_sfa) * n_k_groups + kg_base]);
-                    constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;
 
-                    // ---- ci_a ----
-                    {
-                        const uint8_t* k_base0 = KV_fp4 + ci_a * MX_MMA_N * hd_half_padded + k0 * FP4_K_BYTES;
-                        const uint8_t* k_base1 = KV_fp4 + ci_a * MX_MMA_N * hd_half_padded + k1 * FP4_K_BYTES;
+                    // 4 MMAs for ci_meta_base + 0..3, all sharing A and sfa
+                    #pragma unroll
+                    for (int co = 0; co < CI_PER_META; co++) {
+                        int ci_local = ci_meta_base + co;
+                        const uint8_t* k_base0 = KV_fp4 + ci_local * MX_MMA_N * hd_half_padded + k0 * FP4_K_BYTES;
+                        const uint8_t* k_base1 = KV_fp4 + ci_local * MX_MMA_N * hd_half_padded + k1 * FP4_K_BYTES;
                         uint32_t b0 = *reinterpret_cast<const uint32_t*>(
                             k_base0 + group_id * hd_half_padded + byte_offset);
                         uint32_t b1 = *reinterpret_cast<const uint32_t*>(
                             k_base1 + group_id * hd_half_padded + byte_offset);
                         uint32_t sfb = *reinterpret_cast<const uint32_t*>(
-                            &k_scales_fp8[(ci_a * MX_MMA_N + n_sfb) * n_k_groups + kg_base]);
+                            &k_scales_fp8[(ci_local * MX_MMA_N + n_sfb) * n_k_groups + kg_base]);
 #if __CUDA_ARCH__ >= 1200
-                        asm volatile(
-                            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
-                            "{%0, %1, %2, %3},"
-                            "{%4, %5, %6, %7},"
-                            "{%8, %9},"
-                            "{%10, %11, %12, %13},"
-                            "{%14},"
-                            "{%15, %16},"
-                            "{%17},"
-                            "{%18, %19};\n"
-                            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
-                            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
-                              "r"(b0), "r"(b1),
-                              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
-                              "r"(sfa), "h"(bidA), "h"(tidA),
-                              "r"(sfb), "h"(bidB), "h"(tidB));
-#endif
-                    }
-
-                    // ---- ci_b (same A, different B + sfb) ----
-                    {
-                        const uint8_t* k_base0 = KV_fp4 + ci_b * MX_MMA_N * hd_half_padded + k0 * FP4_K_BYTES;
-                        const uint8_t* k_base1 = KV_fp4 + ci_b * MX_MMA_N * hd_half_padded + k1 * FP4_K_BYTES;
-                        uint32_t b0 = *reinterpret_cast<const uint32_t*>(
-                            k_base0 + group_id * hd_half_padded + byte_offset);
-                        uint32_t b1 = *reinterpret_cast<const uint32_t*>(
-                            k_base1 + group_id * hd_half_padded + byte_offset);
-                        uint32_t sfb = *reinterpret_cast<const uint32_t*>(
-                            &k_scales_fp8[(ci_b * MX_MMA_N + n_sfb) * n_k_groups + kg_base]);
-#if __CUDA_ARCH__ >= 1200
-                        asm volatile(
-                            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
-                            "{%0, %1, %2, %3},"
-                            "{%4, %5, %6, %7},"
-                            "{%8, %9},"
-                            "{%10, %11, %12, %13},"
-                            "{%14},"
-                            "{%15, %16},"
-                            "{%17},"
-                            "{%18, %19};\n"
-                            : "=f"(d4), "=f"(d5), "=f"(d6), "=f"(d7)
-                            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
-                              "r"(b0), "r"(b1),
-                              "f"(d4), "f"(d5), "f"(d6), "f"(d7),
-                              "r"(sfa), "h"(bidA), "h"(tidA),
-                              "r"(sfb), "h"(bidB), "h"(tidB));
+                        if (co == 0)      { MXF4_MMA(d0, d1, d2, d3, b0, b1, sfb); }
+                        else if (co == 1) { MXF4_MMA(d4, d5, d6, d7, b0, b1, sfb); }
+                        else if (co == 2) { MXF4_MMA(d8, d9, dA, dB, b0, b1, sfb); }
+                        else              { MXF4_MMA(dC, dD, dE, dF, b0, b1, sfb); }
 #endif
                     }
                 }
+                #undef MXF4_MMA
             } else {
             for (int k = 0; k < hd_chunks_fp4; k++) {
                 // Load A fragment: a0=row[groupID], a1=row[groupID+8], a2=a3=0
@@ -740,21 +720,21 @@ fmha_sm120_mxfp4_kernel(
                 int gq1 = q_start + base_row + r0 + 8;
 
                 if constexpr (UseBlockScaleMma) {
-                    // 2-issue path: store both ci's, scales already HW-applied
-                    int base_col_a = ci_pair_base * MX_MMA_N;
-                    int base_col_b = (ci_pair_base + 1) * MX_MMA_N;
-                    int gk0_a = kv_start + base_col_a + c0;
-                    int gk1_a = kv_start + base_col_a + c0 + 1;
-                    int gk0_b = kv_start + base_col_b + c0;
-                    int gk1_b = kv_start + base_col_b + c0 + 1;
-                    FUSED_STORE(d0, gq0, gk0_a, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_a + c0);
-                    FUSED_STORE(d1, gq0, gk1_a, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_a + c0 + 1);
-                    FUSED_STORE(d2, gq1, gk0_a, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_a + c0);
-                    FUSED_STORE(d3, gq1, gk1_a, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_a + c0 + 1);
-                    FUSED_STORE(d4, gq0, gk0_b, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_b + c0);
-                    FUSED_STORE(d5, gq0, gk1_b, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_b + c0 + 1);
-                    FUSED_STORE(d6, gq1, gk0_b, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_b + c0);
-                    FUSED_STORE(d7, gq1, gk1_b, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_b + c0 + 1);
+                    // 4-issue path: store 4 ci's, scales already HW-applied
+                    #define STORE_CI(d_a, d_b, d_c, d_d, ci_off) do { \
+                        int base_col_x = (ci_meta_base + ci_off) * MX_MMA_N; \
+                        int gk0_x = kv_start + base_col_x + c0; \
+                        int gk1_x = kv_start + base_col_x + c0 + 1; \
+                        FUSED_STORE(d_a, gq0, gk0_x, 1.0f, 1.0f, (base_row + r0)     * Bkv + base_col_x + c0); \
+                        FUSED_STORE(d_b, gq0, gk1_x, 1.0f, 1.0f, (base_row + r0)     * Bkv + base_col_x + c0 + 1); \
+                        FUSED_STORE(d_c, gq1, gk0_x, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_x + c0); \
+                        FUSED_STORE(d_d, gq1, gk1_x, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_x + c0 + 1); \
+                    } while (0)
+                    STORE_CI(d0, d1, d2, d3, 0);
+                    STORE_CI(d4, d5, d6, d7, 1);
+                    STORE_CI(d8, d9, dA, dB, 2);
+                    STORE_CI(dC, dD, dE, dF, 3);
+                    #undef STORE_CI
                 } else {
                     // Legacy single-tile path
                     int base_col = ci * MX_MMA_N;

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -99,10 +99,11 @@ __device__ __forceinline__ uint8_t pack_fp4_pair(float v0, float v1) {
 // =============================================================================
 
 // UseBlockScaleMma=false: legacy kind::f8f6f4.m16n8k32 (2× K-chunks, padded regs).
-// UseBlockScaleMma=true:  new kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
-//                         (merges 2 legacy K-chunks per issue, half the MMA count).
-// Scale=1.0 uniform (sfa=sfb=0x38383838) keeps the post-MMA manual per-row scaling
-// path identical to the legacy kernel — only the MMA instruction changes.
+// UseBlockScaleMma=true:  kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64 with
+//                         per-16-element UE4M3 scales applied in the MMA instruction.
+//                         Quantization uses per-k_group (16 elements) absmax,
+//                         preserving local precision vs per-row. Post-MMA manual
+//                         scaling is dropped — HW scales during the dot product.
 template <int Bq, int HD, bool UseBlockScaleMma = false>
 __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1)
 fmha_sm120_mxfp4_kernel(
@@ -188,10 +189,12 @@ fmha_sm120_mxfp4_kernel(
     float*   O_acc    = S_tile + Bq * Bkv;
     float*   row_m    = O_acc + Bq * head_dim;
     float*   row_l    = row_m + Bq;
-    // Per-row UE4M3 scales for blockscale-MMA sfa/sfb operands (only populated
-    // when UseBlockScaleMma=true; uninitialized otherwise). Placed at the tail.
+    // Per-k_group UE4M3 scales for blockscale-MMA sfa/sfb operands.
+    // Each row has n_k_groups = HD/16 scales (one per 16-K-block).
+    // Only populated when UseBlockScaleMma=true. Placed at the tail.
+    constexpr int n_k_groups = HD / 16;
     uint8_t* q_scales_fp8 = reinterpret_cast<uint8_t*>(row_l + Bq);
-    uint8_t* k_scales_fp8 = q_scales_fp8 + Bq;
+    uint8_t* k_scales_fp8 = q_scales_fp8 + Bq * n_k_groups;
 
     // Pre-compute sqrt(attention_scale) to absorb into Q and K scales (Opt 3).
     // S_true[i,j] = q_scale[i] * k_scale[j] * mma[i,j], and we want the result
@@ -228,8 +231,23 @@ fmha_sm120_mxfp4_kernel(
         }
         __syncthreads();
 
-        // Absmax from shared memory (fast L1 reads)
-        {
+        if constexpr (UseBlockScaleMma) {
+            // Per-k_group absmax + UE4M3 encoding. Each thread owns one (row,
+            // k_group) pair; 16 elements scanned directly.
+            const int total_groups = Bq * n_k_groups;
+            for (int idx = tid; idx < total_groups; idx += MX_BLOCK_THREADS) {
+                int r = idx / n_k_groups;
+                int kg = idx % n_k_groups;
+                float absmax = 0.0f;
+                const half* row_start = &Q_stage[r * head_dim + kg * 16];
+                #pragma unroll
+                for (int i = 0; i < 16; i++)
+                    absmax = fmaxf(absmax, fabsf(__half2float(row_start[i])));
+                float raw = absmax / 6.0f;
+                q_scales_fp8[r * n_k_groups + kg] = float_to_fp8_e4m3(raw * sqrt_scale);
+            }
+        } else {
+            // Absmax from shared memory (fast L1 reads) — per-row (legacy)
             const int r = sm_row;
             float local_max = 0.0f;
             if (r < Bq) {
@@ -239,37 +257,30 @@ fmha_sm120_mxfp4_kernel(
             #pragma unroll
             for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                 local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-            if (sm_lane == 0 && r < Bq) {
-                if constexpr (UseBlockScaleMma) {
-                    // Blockscale path: encode per-row scale × sqrt(attention_scale) as
-                    // UE4M3, store both the dequanted float (for self-consistent quant)
-                    // and the byte (for sfa operand).
-                    float raw = local_max / 6.0f;
-                    uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
-                    q_scales_fp8[r] = ue4m3;
-                    // Use dequanted value divided by sqrt_scale (so that inv_scale =
-                    // sqrt_scale / q_scales[r] = 1/dequanted_raw_scale).
-                    float dequant = fp8_e4m3_to_float_fast(ue4m3);
-                    q_scales[r] = dequant;  // store sqrt_scale*raw_dq (MMA sfa quantity)
-                } else {
-                    q_scales[r] = local_max / 6.0f * sqrt_scale;  // legacy
-                }
-            }
+            if (sm_lane == 0 && r < Bq)
+                q_scales[r] = local_max / 6.0f * sqrt_scale;
         }
         __syncthreads();
 
         // Quantize from shared → Q_fp4 (vectorized: 8 halves = 4 bytes/iter, uint32 store)
+        // In blockscale mode: each 8-halves chunk (b4) falls in exactly one k_group
+        // (kg = b4/2), so we dequant one UE4M3 byte per chunk and apply the resulting
+        // inverse scale to all 8 values.
         {
-            // hd_half ≥ 4 for all supported HDs (32, 48, 64, 128). Stride hd_half_padded
-            // is always 4-byte aligned (hd_half + 4 bytes pad).
             const int total_packed_u32 = (Bq * hd_half) / 4;
             for (int idx = tid; idx < total_packed_u32; idx += MX_BLOCK_THREADS) {
                 int r = idx / (hd_half / 4);
-                int b4 = idx % (hd_half / 4);     // which 4-byte chunk in this row
-                int d = b4 * 8;                   // starting half index
-                float inv_scale = (q_scales[r] > 0.0f) ? (sqrt_scale / q_scales[r]) : 0.0f;
+                int b4 = idx % (hd_half / 4);
+                int d = b4 * 8;
+                float inv_scale;
+                if constexpr (UseBlockScaleMma) {
+                    int kg = b4 / 2;  // 8 halves fit inside a 16-half k_group
+                    float dequant = fp8_e4m3_to_float_fast(q_scales_fp8[r * n_k_groups + kg]);
+                    inv_scale = (dequant > 0.0f) ? (sqrt_scale / dequant) : 0.0f;
+                } else {
+                    inv_scale = (q_scales[r] > 0.0f) ? (sqrt_scale / q_scales[r]) : 0.0f;
+                }
                 const half* src = &Q_stage[r * head_dim + d];
-                // Load 8 halves via 2× half2 (4 bytes each)
                 half2 h01 = reinterpret_cast<const half2*>(src)[0];
                 half2 h23 = reinterpret_cast<const half2*>(src)[1];
                 half2 h45 = reinterpret_cast<const half2*>(src)[2];
@@ -301,10 +312,14 @@ fmha_sm120_mxfp4_kernel(
                 local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
             if (sm_lane == 0 && r < Bq) {
                 if constexpr (UseBlockScaleMma) {
+                    // Fallback path: use per-row absmax, replicate across all k_groups
+                    // (loses the per-16 granularity benefit, but the fallback is only
+                    // for Bq=32 + HD>64 which is rarely hit).
                     float raw = local_max / 6.0f;
                     uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
-                    q_scales_fp8[r] = ue4m3;
-                    q_scales[r] = fp8_e4m3_to_float_fast(ue4m3);
+                    #pragma unroll
+                    for (int kg = 0; kg < n_k_groups; kg++)
+                        q_scales_fp8[r * n_k_groups + kg] = ue4m3;
                 } else {
                     q_scales[r] = local_max / 6.0f * sqrt_scale;
                 }
@@ -319,7 +334,15 @@ fmha_sm120_mxfp4_kernel(
                 int d_byte = idx % hd_half;
                 int d = d_byte * 2;
                 if (q_start + r < seq_q) {
-                    float inv_scale = (q_scales[r] > 0.0f) ? (sqrt_scale / q_scales[r]) : 0.0f;
+                    float inv_scale;
+                    if constexpr (UseBlockScaleMma) {
+                        int kg = d / 16;
+                        float dequant = fp8_e4m3_to_float_fast(
+                            q_scales_fp8[r * n_k_groups + kg]);
+                        inv_scale = (dequant > 0.0f) ? (sqrt_scale / dequant) : 0.0f;
+                    } else {
+                        inv_scale = (q_scales[r] > 0.0f) ? (sqrt_scale / q_scales[r]) : 0.0f;
+                    }
                     float v0 = __half2float(Q_ptr[(int64_t)r * q_row_stride + d]) * inv_scale;
                     float v1 = __half2float(Q_ptr[(int64_t)r * q_row_stride + d + 1]) * inv_scale;
                     Q_fp4[r * hd_half_padded + d_byte] = pack_fp4_pair(v0, v1);
@@ -391,8 +414,22 @@ fmha_sm120_mxfp4_kernel(
             }
             __syncthreads();
 
-            // Absmax from shared (fast L1 reads)
-            {
+            if constexpr (UseBlockScaleMma) {
+                // Per-k_group absmax for K tile
+                const int total_groups = Bkv * n_k_groups;
+                for (int idx = tid; idx < total_groups; idx += MX_BLOCK_THREADS) {
+                    int r = idx / n_k_groups;
+                    int kg = idx % n_k_groups;
+                    float absmax = 0.0f;
+                    const half* row_start = &K_stage[r * head_dim + kg * 16];
+                    #pragma unroll
+                    for (int i = 0; i < 16; i++)
+                        absmax = fmaxf(absmax, fabsf(__half2float(row_start[i])));
+                    float raw = absmax / 6.0f;
+                    k_scales_fp8[r * n_k_groups + kg] = float_to_fp8_e4m3(raw * sqrt_scale);
+                }
+            } else {
+                // Per-row absmax (legacy)
                 const int r = sm_row;
                 float local_max = 0.0f;
                 if (r < Bkv) {
@@ -402,16 +439,8 @@ fmha_sm120_mxfp4_kernel(
                 #pragma unroll
                 for (int offset = TPR / 2; offset >= 1; offset >>= 1)
                     local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, offset));
-                if (sm_lane == 0 && r < Bkv) {
-                    if constexpr (UseBlockScaleMma) {
-                        float raw = local_max / 6.0f;
-                        uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
-                        k_scales_fp8[r] = ue4m3;
-                        k_scales[r] = fp8_e4m3_to_float_fast(ue4m3);
-                    } else {
-                        k_scales[r] = local_max / 6.0f * sqrt_scale;
-                    }
-                }
+                if (sm_lane == 0 && r < Bkv)
+                    k_scales[r] = local_max / 6.0f * sqrt_scale;
             }
             __syncthreads();
 
@@ -422,7 +451,14 @@ fmha_sm120_mxfp4_kernel(
                     int r = idx / (hd_half / 4);
                     int b4 = idx % (hd_half / 4);
                     int d = b4 * 8;
-                    float inv_scale = (k_scales[r] > 0.0f) ? (sqrt_scale / k_scales[r]) : 0.0f;
+                    float inv_scale;
+                    if constexpr (UseBlockScaleMma) {
+                        int kg = b4 / 2;
+                        float dequant = fp8_e4m3_to_float_fast(k_scales_fp8[r * n_k_groups + kg]);
+                        inv_scale = (dequant > 0.0f) ? (sqrt_scale / dequant) : 0.0f;
+                    } else {
+                        inv_scale = (k_scales[r] > 0.0f) ? (sqrt_scale / k_scales[r]) : 0.0f;
+                    }
                     const half* src = &K_stage[r * head_dim + d];
                     half2 h01 = reinterpret_cast<const half2*>(src)[0];
                     half2 h23 = reinterpret_cast<const half2*>(src)[1];
@@ -458,8 +494,9 @@ fmha_sm120_mxfp4_kernel(
                     if constexpr (UseBlockScaleMma) {
                         float raw = local_max / 6.0f;
                         uint8_t ue4m3 = float_to_fp8_e4m3(raw * sqrt_scale);
-                        k_scales_fp8[r] = ue4m3;
-                        k_scales[r] = fp8_e4m3_to_float_fast(ue4m3);
+                        #pragma unroll
+                        for (int kg = 0; kg < n_k_groups; kg++)
+                            k_scales_fp8[r * n_k_groups + kg] = ue4m3;
                     } else {
                         k_scales[r] = local_max / 6.0f * sqrt_scale;
                     }
@@ -474,7 +511,15 @@ fmha_sm120_mxfp4_kernel(
                     int d_byte = idx % hd_half;
                     int d = d_byte * 2;
                     if (kv_start + r < seq_kv) {
-                        float inv_scale = (k_scales[r] > 0.0f) ? (sqrt_scale / k_scales[r]) : 0.0f;
+                        float inv_scale;
+                        if constexpr (UseBlockScaleMma) {
+                            int kg = d / 16;
+                            float dequant = fp8_e4m3_to_float_fast(
+                                k_scales_fp8[r * n_k_groups + kg]);
+                            inv_scale = (dequant > 0.0f) ? (sqrt_scale / dequant) : 0.0f;
+                        } else {
+                            inv_scale = (k_scales[r] > 0.0f) ? (sqrt_scale / k_scales[r]) : 0.0f;
+                        }
                         float v0 = __half2float(K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]) * inv_scale;
                         float v1 = __half2float(K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d + 1]) * inv_scale;
                         KV_fp4[r * hd_half_padded + d_byte] = pack_fp4_pair(v0, v1);
@@ -541,22 +586,20 @@ fmha_sm120_mxfp4_kernel(
                     uint32_t b1 = *reinterpret_cast<const uint32_t*>(
                         k_base1 + group_id * hd_half_padded + byte_offset);
 
-                    // Real block-scale: load per-row UE4M3 scales from SMEM and replicate
-                    // to uint32 (all 4 scales per thread cover the same row's k-groups).
-                    // SFA layout: thread T's sfa → row m_sfa = (T/4) + (T%2)*8.
-                    // SFB layout: thread T's sfb → col n_sfb = T/4.
+                    // Real block-scale with per-k_group UE4M3 scales. For this MMA
+                    // issue covering K-range [k*64, k*64+64), each thread needs 4
+                    // scales (for 4 k-groups of 16 elements each).
+                    // SFA layout: thread T's sfa → row m_sfa = (T/4) + (T%2)*8,
+                    //            4 bytes covering k_group indices k*4..k*4+3.
+                    // SFB layout: thread T's sfb → col n_sfb = T/4,
+                    //            same k_group positions.
                     const int m_sfa = (lane_id / 4) + (lane_id % 2) * 8;
                     const int n_sfb = lane_id / 4;
-                    uint8_t qs_byte = q_scales_fp8[ri * MX_MMA_M + m_sfa];
-                    uint8_t ks_byte = k_scales_fp8[ci * MX_MMA_N + n_sfb];
-                    uint32_t sfa = (uint32_t)qs_byte
-                                 | ((uint32_t)qs_byte << 8)
-                                 | ((uint32_t)qs_byte << 16)
-                                 | ((uint32_t)qs_byte << 24);
-                    uint32_t sfb = (uint32_t)ks_byte
-                                 | ((uint32_t)ks_byte << 8)
-                                 | ((uint32_t)ks_byte << 16)
-                                 | ((uint32_t)ks_byte << 24);
+                    const int kg_base = k * 4;  // 4 k_groups per m16n8k64 issue
+                    uint32_t sfa = *reinterpret_cast<const uint32_t*>(
+                        &q_scales_fp8[(ri * MX_MMA_M + m_sfa) * n_k_groups + kg_base]);
+                    uint32_t sfb = *reinterpret_cast<const uint32_t*>(
+                        &k_scales_fp8[(ci * MX_MMA_N + n_sfb) * n_k_groups + kg_base]);
                     constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;
 #if __CUDA_ARCH__ >= 1200
                     asm volatile(
@@ -825,7 +868,8 @@ static size_t compute_smem_mxfp4(int Bq, int Bkv, int head_dim) {
     size_t s_tile   = (size_t)Bq * Bkv * sizeof(float);          // S_tile
     size_t o_acc    = (size_t)Bq * head_dim * sizeof(float);     // O_acc
     size_t softmax  = 2 * (size_t)Bq * sizeof(float);            // row_m + row_l
-    size_t scales_fp8 = (size_t)(Bq + Bkv);                      // UE4M3 per-row scales (blockscale)
+    int n_k_groups = head_dim / 16;
+    size_t scales_fp8 = (size_t)(Bq + Bkv) * n_k_groups;          // UE4M3 per-16-K scales (blockscale)
     return q_fp4 + q_scales + align + kv_buf + k_scales + s_tile + o_acc + softmax + scales_fp8;
 }
 

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -57,22 +57,40 @@ static constexpr int MX_WMMA_K = 16;
 // Device helpers: FP4 E2M1 quantization
 // =============================================================================
 
-// Branchless quantize: |val| → 3-bit E2M1 magnitude code (0..7).
-// Midpoint thresholds: 0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0
-__device__ __forceinline__ uint8_t fp4_quantize_abs(float abs_val) {
-    return (abs_val >= 0.25f) + (abs_val >= 0.75f) + (abs_val >= 1.25f)
-         + (abs_val >= 1.75f) + (abs_val >= 2.5f)  + (abs_val >= 3.5f)
-         + (abs_val >= 5.0f);
-}
-
-// Pack two FP32 values into one FP4 E2M1 byte (low nibble = first, high = second).
-// Values must already be scaled to [-6, 6] range.
+// Pack two FP32 values into one FP4 E2M1 byte via hardware instruction.
+// Layout: low nibble = v0, high nibble = v1. Values must already be scaled
+// so that |v| ≤ 6 (values outside saturate to ±6).
+//
+// Uses the PTX hardware conversion on sm_120+ (works on CUDA 13.2+; the
+// `f16x2` variant is broken per dead_ends.md, but the `f32` variant is
+// correct — see sageattention3_study_2026_04_24 memory). Single PTX
+// instruction replaces the former branchless cascade (14 compares +
+// sign handling per call). Rounding is RNE (IEEE round-to-nearest-even)
+// vs the software midpoint cascade — tiny output divergence on boundary
+// values is acceptable (validated via A/B test against legacy path).
 __device__ __forceinline__ uint8_t pack_fp4_pair(float v0, float v1) {
+#if __CUDA_ARCH__ >= 1200
+    uint32_t out;
+    asm volatile(
+        "{ .reg .b8 b;\n"
+        "  cvt.rn.satfinite.e2m1x2.f32 b, %2, %1;\n"
+        "  cvt.u32.u8 %0, b; }\n"
+        : "=r"(out)
+        : "f"(v0), "f"(v1));
+    return static_cast<uint8_t>(out);
+#else
+    // Software fallback: branchless compare cascade (E2M1 magnitudes
+    // {0, 0.5, 1, 1.5, 2, 3, 4, 6} with midpoint thresholds).
+    auto quant_abs = [](float a) -> uint8_t {
+        return (a >= 0.25f) + (a >= 0.75f) + (a >= 1.25f) + (a >= 1.75f)
+             + (a >= 2.5f)  + (a >= 3.5f)  + (a >= 5.0f);
+    };
     uint8_t sign0 = (v0 < 0.0f) ? 1u : 0u;
-    uint8_t code0 = (sign0 << 3) | fp4_quantize_abs(fabsf(v0));
+    uint8_t code0 = (sign0 << 3) | quant_abs(fabsf(v0));
     uint8_t sign1 = (v1 < 0.0f) ? 1u : 0u;
-    uint8_t code1 = (sign1 << 3) | fp4_quantize_abs(fabsf(v1));
+    uint8_t code1 = (sign1 << 3) | quant_abs(fabsf(v1));
     return (code1 << 4) | code0;
+#endif
 }
 
 // =============================================================================

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -886,7 +886,16 @@ bool fmha_sm120_mxfp4_prefill(
     if (Q.dtype != DType::FP16) return false;
     // Blockscale MMA operates on K=64 per issue; head_dim must be a multiple of 64.
     // head_dim=96 (Gemma-class) is a multiple of 32 but NOT 64 → fall back to legacy.
-    if (use_blockscale && (static_cast<int>(Q.shape[3]) % 64 != 0)) {
+    const int hd_check = static_cast<int>(Q.shape[3]);
+    if (use_blockscale && (hd_check % 64 != 0)) {
+        use_blockscale = false;
+    }
+    // Blockscale is only beneficial when the Q/K FP16-staging fast path fits
+    // (HD ≤ 2*Bq). At HD=256, Bq must drop to 32 → can_stage_in_stile=false,
+    // which forces the scalar global-read fallback where the per-16-element
+    // granularity benefit is lost but the per-k_group dequant overhead remains.
+    // Measured -2.7% on Gemma-4 HD=256 Q4_K_M; route such configs to legacy.
+    if (use_blockscale && hd_check > 128) {
         use_blockscale = false;
     }
 

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -552,11 +552,31 @@ fmha_sm120_mxfp4_kernel(
         // Thread mapping: groupID = lane/4 (0-7), threadID = lane%4 (0-3).
         //   A: row = groupID (+8 for a1), k_offset = threadID * 4 bytes (8 FP4)
         //   B: col = groupID (0-7 for n=8), k_offset = threadID * 4 bytes
-        for (int tile_idx = warp_id; tile_idx < s_total_tiles; tile_idx += MX_NUM_WARPS) {
-            int ri = tile_idx / s_col_tiles_half;
-            int ci = tile_idx % s_col_tiles_half;
+        // Iteration strategy:
+        //   UseBlockScaleMma=true:  outer iterates over (ri, ci_pair) where each
+        //     pair covers 2 consecutive ci values (16x16 output via 2 MMAs).
+        //     A operand loaded once per k-pair iteration and reused across the
+        //     2 MMAs (one per ci). Halves Q_fp4 SMEM-A bandwidth in Phase 1.
+        //   UseBlockScaleMma=false: original single-tile distribution.
+        const int s_col_tile_pairs = s_col_tiles_half / 2;  // groups of 2 ci's
+        const int s_pair_total_tiles = s_row_tiles * s_col_tile_pairs;
+        const int outer_total = UseBlockScaleMma ? s_pair_total_tiles : s_total_tiles;
+
+        for (int tile_idx = warp_id; tile_idx < outer_total; tile_idx += MX_NUM_WARPS) {
+            int ri, ci;
+            int ci_pair_base = 0;
+            if constexpr (UseBlockScaleMma) {
+                ri = tile_idx / s_col_tile_pairs;
+                ci_pair_base = (tile_idx % s_col_tile_pairs) * 2;
+                ci = ci_pair_base;  // first ci in pair (used for legacy-shared globals)
+            } else {
+                ri = tile_idx / s_col_tiles_half;
+                ci = tile_idx % s_col_tiles_half;
+            }
 
             float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
+            // Second-ci accumulators (only used in blockscale 2-issue path)
+            float d4 = 0.0f, d5 = 0.0f, d6 = 0.0f, d7 = 0.0f;
 
             const int group_id = lane_id / 4;
             const int thread_in_group = lane_id % 4;
@@ -577,11 +597,16 @@ fmha_sm120_mxfp4_kernel(
                 //   b0: col[group_id],   k-stripe 2k
                 //   b1: col[group_id],   k-stripe 2k+1
                 const int k_pairs = hd_chunks_fp4 / 2;
+                const int m_sfa = (lane_id / 4) + (lane_id % 2) * 8;
+                const int n_sfb = lane_id / 4;
+                const int ci_a = ci_pair_base;
+                const int ci_b = ci_pair_base + 1;
                 for (int k = 0; k < k_pairs; k++) {
                     const int k0 = 2 * k;
                     const int k1 = k0 + 1;
                     const uint8_t* q_base0 = Q_fp4 + ri * MX_MMA_M * hd_half_padded + k0 * FP4_K_BYTES;
                     const uint8_t* q_base1 = Q_fp4 + ri * MX_MMA_M * hd_half_padded + k1 * FP4_K_BYTES;
+                    // A loaded once, reused for both ci's
                     uint32_t a0 = *reinterpret_cast<const uint32_t*>(
                         q_base0 + group_id * hd_half_padded + byte_offset);
                     uint32_t a1 = *reinterpret_cast<const uint32_t*>(
@@ -591,46 +616,71 @@ fmha_sm120_mxfp4_kernel(
                     uint32_t a3 = *reinterpret_cast<const uint32_t*>(
                         q_base1 + (group_id + 8) * hd_half_padded + byte_offset);
 
-                    const uint8_t* k_base0 = KV_fp4 + ci * MX_MMA_N * hd_half_padded + k0 * FP4_K_BYTES;
-                    const uint8_t* k_base1 = KV_fp4 + ci * MX_MMA_N * hd_half_padded + k1 * FP4_K_BYTES;
-                    uint32_t b0 = *reinterpret_cast<const uint32_t*>(
-                        k_base0 + group_id * hd_half_padded + byte_offset);
-                    uint32_t b1 = *reinterpret_cast<const uint32_t*>(
-                        k_base1 + group_id * hd_half_padded + byte_offset);
-
-                    // Real block-scale with per-k_group UE4M3 scales. For this MMA
-                    // issue covering K-range [k*64, k*64+64), each thread needs 4
-                    // scales (for 4 k-groups of 16 elements each).
-                    // SFA layout: thread T's sfa → row m_sfa = (T/4) + (T%2)*8,
-                    //            4 bytes covering k_group indices k*4..k*4+3.
-                    // SFB layout: thread T's sfb → col n_sfb = T/4,
-                    //            same k_group positions.
-                    const int m_sfa = (lane_id / 4) + (lane_id % 2) * 8;
-                    const int n_sfb = lane_id / 4;
-                    const int kg_base = k * 4;  // 4 k_groups per m16n8k64 issue
+                    // sfa shared across both ci's (depends only on row + k_group)
+                    const int kg_base = k * 4;
                     uint32_t sfa = *reinterpret_cast<const uint32_t*>(
                         &q_scales_fp8[(ri * MX_MMA_M + m_sfa) * n_k_groups + kg_base]);
-                    uint32_t sfb = *reinterpret_cast<const uint32_t*>(
-                        &k_scales_fp8[(ci * MX_MMA_N + n_sfb) * n_k_groups + kg_base]);
                     constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+
+                    // ---- ci_a ----
+                    {
+                        const uint8_t* k_base0 = KV_fp4 + ci_a * MX_MMA_N * hd_half_padded + k0 * FP4_K_BYTES;
+                        const uint8_t* k_base1 = KV_fp4 + ci_a * MX_MMA_N * hd_half_padded + k1 * FP4_K_BYTES;
+                        uint32_t b0 = *reinterpret_cast<const uint32_t*>(
+                            k_base0 + group_id * hd_half_padded + byte_offset);
+                        uint32_t b1 = *reinterpret_cast<const uint32_t*>(
+                            k_base1 + group_id * hd_half_padded + byte_offset);
+                        uint32_t sfb = *reinterpret_cast<const uint32_t*>(
+                            &k_scales_fp8[(ci_a * MX_MMA_N + n_sfb) * n_k_groups + kg_base]);
 #if __CUDA_ARCH__ >= 1200
-                    asm volatile(
-                        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
-                        "{%0, %1, %2, %3},"
-                        "{%4, %5, %6, %7},"
-                        "{%8, %9},"
-                        "{%10, %11, %12, %13},"
-                        "{%14},"
-                        "{%15, %16},"
-                        "{%17},"
-                        "{%18, %19};\n"
-                        : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
-                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
-                          "r"(b0), "r"(b1),
-                          "f"(d0), "f"(d1), "f"(d2), "f"(d3),
-                          "r"(sfa), "h"(bidA), "h"(tidA),
-                          "r"(sfb), "h"(bidB), "h"(tidB));
+                        asm volatile(
+                            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+                            "{%0, %1, %2, %3},"
+                            "{%4, %5, %6, %7},"
+                            "{%8, %9},"
+                            "{%10, %11, %12, %13},"
+                            "{%14},"
+                            "{%15, %16},"
+                            "{%17},"
+                            "{%18, %19};\n"
+                            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+                            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+                              "r"(b0), "r"(b1),
+                              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+                              "r"(sfa), "h"(bidA), "h"(tidA),
+                              "r"(sfb), "h"(bidB), "h"(tidB));
 #endif
+                    }
+
+                    // ---- ci_b (same A, different B + sfb) ----
+                    {
+                        const uint8_t* k_base0 = KV_fp4 + ci_b * MX_MMA_N * hd_half_padded + k0 * FP4_K_BYTES;
+                        const uint8_t* k_base1 = KV_fp4 + ci_b * MX_MMA_N * hd_half_padded + k1 * FP4_K_BYTES;
+                        uint32_t b0 = *reinterpret_cast<const uint32_t*>(
+                            k_base0 + group_id * hd_half_padded + byte_offset);
+                        uint32_t b1 = *reinterpret_cast<const uint32_t*>(
+                            k_base1 + group_id * hd_half_padded + byte_offset);
+                        uint32_t sfb = *reinterpret_cast<const uint32_t*>(
+                            &k_scales_fp8[(ci_b * MX_MMA_N + n_sfb) * n_k_groups + kg_base]);
+#if __CUDA_ARCH__ >= 1200
+                        asm volatile(
+                            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+                            "{%0, %1, %2, %3},"
+                            "{%4, %5, %6, %7},"
+                            "{%8, %9},"
+                            "{%10, %11, %12, %13},"
+                            "{%14},"
+                            "{%15, %16},"
+                            "{%17},"
+                            "{%18, %19};\n"
+                            : "=f"(d4), "=f"(d5), "=f"(d6), "=f"(d7)
+                            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+                              "r"(b0), "r"(b1),
+                              "f"(d4), "f"(d5), "f"(d6), "f"(d7),
+                              "r"(sfa), "h"(bidA), "h"(tidA),
+                              "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+                    }
                 }
             } else {
             for (int k = 0; k < hd_chunks_fp4; k++) {
@@ -670,37 +720,13 @@ fmha_sm120_mxfp4_kernel(
             }
             }
 
-            // Store 16×8 result to S_tile with fused scale + mask (Opt 2).
-            // Fuses: per-row scale correction, attention_scale (pre-absorbed via
-            // sqrt_scale in q/k_scales), softcap, causal mask, sliding window.
-            // Eliminates the separate apply_score_masks pass + __syncthreads.
+            // Store 16×8 (or 16×16 for 2-issue blockscale) result to S_tile.
+            // Fuses scale, softcap, causal mask, sliding window.
             {
                 int base_row = ri * MX_MMA_M;
-                int base_col = ci * MX_MMA_N;
                 int r0 = (lane_id / 4) % 8;
                 int c0 = (lane_id % 4) * 2;
 
-                // Scale correction: in legacy mode, q_scales/k_scales include
-                // sqrt(attention_scale), and their product applies the full scale
-                // factor. In real blockscale mode, HW already applied per-row
-                // sfa/sfb during MMA, so val is already the attention score.
-                float qs0, qs1, ks0, ks1;
-                if constexpr (UseBlockScaleMma) {
-                    qs0 = qs1 = ks0 = ks1 = 1.0f;  // HW already scaled
-                } else {
-                    qs0 = q_scales[base_row + r0];
-                    qs1 = q_scales[base_row + r0 + 8];
-                    ks0 = k_scales[base_col + c0];
-                    ks1 = k_scales[base_col + c0 + 1];
-                }
-
-                // Compute global Q/K positions for masking
-                int gq0 = q_start + base_row + r0;
-                int gq1 = q_start + base_row + r0 + 8;
-                int gk0 = kv_start + base_col + c0;
-                int gk1 = kv_start + base_col + c0 + 1;
-
-                // Inline score computation + masking for all 4 output elements
                 #define FUSED_STORE(val, gq, gk, qs, ks, idx) do { \
                     float s = (val) * (qs) * (ks); \
                     if (softcap > 0.0f) s = softcap * tanhf(s / softcap); \
@@ -710,10 +736,39 @@ fmha_sm120_mxfp4_kernel(
                     S_tile[idx] = s; \
                 } while (0)
 
-                FUSED_STORE(d0, gq0, gk0, qs0, ks0, (base_row + r0) * Bkv + base_col + c0);
-                FUSED_STORE(d1, gq0, gk1, qs0, ks1, (base_row + r0) * Bkv + base_col + c0 + 1);
-                FUSED_STORE(d2, gq1, gk0, qs1, ks0, (base_row + r0 + 8) * Bkv + base_col + c0);
-                FUSED_STORE(d3, gq1, gk1, qs1, ks1, (base_row + r0 + 8) * Bkv + base_col + c0 + 1);
+                int gq0 = q_start + base_row + r0;
+                int gq1 = q_start + base_row + r0 + 8;
+
+                if constexpr (UseBlockScaleMma) {
+                    // 2-issue path: store both ci's, scales already HW-applied
+                    int base_col_a = ci_pair_base * MX_MMA_N;
+                    int base_col_b = (ci_pair_base + 1) * MX_MMA_N;
+                    int gk0_a = kv_start + base_col_a + c0;
+                    int gk1_a = kv_start + base_col_a + c0 + 1;
+                    int gk0_b = kv_start + base_col_b + c0;
+                    int gk1_b = kv_start + base_col_b + c0 + 1;
+                    FUSED_STORE(d0, gq0, gk0_a, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_a + c0);
+                    FUSED_STORE(d1, gq0, gk1_a, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_a + c0 + 1);
+                    FUSED_STORE(d2, gq1, gk0_a, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_a + c0);
+                    FUSED_STORE(d3, gq1, gk1_a, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_a + c0 + 1);
+                    FUSED_STORE(d4, gq0, gk0_b, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_b + c0);
+                    FUSED_STORE(d5, gq0, gk1_b, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_b + c0 + 1);
+                    FUSED_STORE(d6, gq1, gk0_b, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_b + c0);
+                    FUSED_STORE(d7, gq1, gk1_b, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_b + c0 + 1);
+                } else {
+                    // Legacy single-tile path
+                    int base_col = ci * MX_MMA_N;
+                    float qs0 = q_scales[base_row + r0];
+                    float qs1 = q_scales[base_row + r0 + 8];
+                    float ks0 = k_scales[base_col + c0];
+                    float ks1 = k_scales[base_col + c0 + 1];
+                    int gk0 = kv_start + base_col + c0;
+                    int gk1 = kv_start + base_col + c0 + 1;
+                    FUSED_STORE(d0, gq0, gk0, qs0, ks0, (base_row + r0) * Bkv + base_col + c0);
+                    FUSED_STORE(d1, gq0, gk1, qs0, ks1, (base_row + r0) * Bkv + base_col + c0 + 1);
+                    FUSED_STORE(d2, gq1, gk0, qs1, ks0, (base_row + r0 + 8) * Bkv + base_col + c0);
+                    FUSED_STORE(d3, gq1, gk1, qs1, ks1, (base_row + r0 + 8) * Bkv + base_col + c0 + 1);
+                }
                 #undef FUSED_STORE
             }
         }

--- a/src/compute/attention_fmha_mxfp4_sm120.h
+++ b/src/compute/attention_fmha_mxfp4_sm120.h
@@ -23,9 +23,18 @@ namespace imp {
 //   - Supported head_dim: 64, 96, 128, 256
 //
 // Returns false if config unsupported (caller falls back to FP8/FP16 FMHA).
+// When use_blockscale=true, swaps the Phase 1 MMA from
+//   mma.sync.kind::f8f6f4.m16n8k32   (legacy, 2× K-chunks per issue)
+// to
+//   mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64  (half MMA count)
+// with uniform sfa=sfb=1.0 so output is bit-equivalent. head_dim must be a
+// multiple of 64 (legacy path requires only multiple of 32); unsupported
+// head_dim 96 falls through to the legacy path. Up to ~1.5-2× Phase 1
+// speedup measured on raw MMA (254 vs 102 TOPS).
 bool fmha_sm120_mxfp4_prefill(
     const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
     float scale, bool causal, int sliding_window, float softcap,
-    cudaStream_t stream);
+    cudaStream_t stream,
+    bool use_blockscale = false);
 
 } // namespace imp

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -622,23 +622,25 @@ fmha_sm120_fp8_kernel(
     float*   row_m   = O_acc + Bq * head_dim;
     float*   row_l   = row_m + Bq;
 
-    // Load Q tile and convert to FP8 E4M3
+    // Load Q tile and convert to FP8 E4M3 (vectorized: 4 halves → 4 FP8 bytes per cvt pair).
+    // HW cvt.rn.satfinite.e4m3x2.f16x2 already clamps to ±448 — no manual saturate.
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+        const int total_vec4 = (Bq * head_dim) / 4;
+        for (int vi = tid; vi < total_vec4; vi += SM120_BLOCK_THREADS) {
+            int i = vi * 4;
             int r = i / head_dim;
             int d = i % head_dim;
-            if (q_start + r < seq_q) {
-                half val = Q_ptr[(int64_t)r * q_row_stride + d];
-                // Saturate FP16 → FP8 E4M3 (range [-448, 448])
-                float fv = __half2float(val);
-                fv = fminf(fmaxf(fv, -448.0f), 448.0f);
-                // Simple scalar FP16→FP8: use hardware cvt if available
-                Q_fp8[i] = static_cast<uint8_t>(__nv_fp8_e4m3(fv).__x);
-            } else {
-                Q_fp8[i] = 0;
+            // Out-of-range rows zero-fill as u32 (4 bytes)
+            if (q_start + r >= seq_q) {
+                reinterpret_cast<uint32_t*>(Q_fp8)[vi] = 0;
+                continue;
             }
+            // 4 consecutive halves are always within head_dim (HD % 4 == 0 for Bq multiples).
+            const half* src = &Q_ptr[(int64_t)r * q_row_stride + d];
+            reinterpret_cast<uint32_t*>(Q_fp8)[vi] = cvt_4xfp16_to_4xe4m3(src);
         }
+        // Scalar tail if Bq*head_dim isn't a multiple of 4 (shouldn't happen on
+        // supported HDs: 64,96,128,256 × Bq divisible configs all hit the vec4 fast path).
     }
 
     // Zero O_acc + init softmax
@@ -673,20 +675,19 @@ fmha_sm120_fp8_kernel(
     for (int j = first_kv_tile; j < num_kv_tiles; j++) {
         const int kv_start = j * Bkv;
 
-        // Load K tile and convert to FP8
+        // Load K tile and convert to FP8 (vectorized: 4 halves → 4 FP8 bytes).
         {
-            const int total = Bkv * head_dim;
-            for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+            const int total_vec4 = (Bkv * head_dim) / 4;
+            for (int vi = tid; vi < total_vec4; vi += SM120_BLOCK_THREADS) {
+                int i = vi * 4;
                 int r = i / head_dim;
                 int d = i % head_dim;
-                if (kv_start + r < seq_kv) {
-                    half val = K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d];
-                    float fv = __half2float(val);
-                    fv = fminf(fmaxf(fv, -448.0f), 448.0f);
-                    KV_fp8[i] = static_cast<uint8_t>(__nv_fp8_e4m3(fv).__x);
-                } else {
-                    KV_fp8[i] = 0;
+                if (kv_start + r >= seq_kv) {
+                    reinterpret_cast<uint32_t*>(KV_fp8)[vi] = 0;
+                    continue;
                 }
+                const half* src = &K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d];
+                reinterpret_cast<uint32_t*>(KV_fp8)[vi] = cvt_4xfp16_to_4xe4m3(src);
             }
         }
         __syncthreads();

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -131,16 +131,20 @@ fmha_sm120_kernel(
     float* row_m    = O_acc + Bq * head_dim;
     float* row_l    = row_m + Bq;
 
-    // ---- load Q tile --------------------------------------------------------
+    // ---- load Q tile (vectorized float4 = 8 halves per iter) ---------------
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+        const int total_vec8 = (Bq * head_dim) / 8;
+        for (int vi = tid; vi < total_vec8; vi += SM120_BLOCK_THREADS) {
+            int i = vi * 8;
             int r = i / head_dim;
             int d = i % head_dim;
+            float4* dst = reinterpret_cast<float4*>(&Q_tile[i]);
             if (q_start + r < seq_q) {
-                Q_tile[i] = Q_ptr[(int64_t)r * q_row_stride + d];
+                const float4* src = reinterpret_cast<const float4*>(
+                    &Q_ptr[(int64_t)r * q_row_stride + d]);
+                *dst = *src;
             } else {
-                Q_tile[i] = __float2half(0.0f);
+                *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
             }
         }
     }
@@ -179,16 +183,20 @@ fmha_sm120_kernel(
     for (int j = first_kv_tile; j < num_kv_tiles; j++) {
         const int kv_start = j * Bkv;
 
-        // ---- Load K tile ----
+        // ---- Load K tile (vectorized float4 = 8 halves per iter) ----
         {
-            const int total = Bkv * head_dim;
-            for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+            const int total_vec8 = (Bkv * head_dim) / 8;
+            for (int vi = tid; vi < total_vec8; vi += SM120_BLOCK_THREADS) {
+                int i = vi * 8;
                 int r = i / head_dim;
                 int d = i % head_dim;
+                float4* dst = reinterpret_cast<float4*>(&KV_tile[i]);
                 if (kv_start + r < seq_kv) {
-                    KV_tile[i] = K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d];
+                    const float4* src = reinterpret_cast<const float4*>(
+                        &K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]);
+                    *dst = *src;
                 } else {
-                    KV_tile[i] = __float2half(0.0f);
+                    *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
                 }
             }
         }
@@ -317,16 +325,22 @@ fmha_sm120_kernel(
         }
         __syncthreads();
 
-        // ---- Load V tile ----
+        // ---- Load V tile (vectorized: float4 = 8 halves per iter) ----
         {
-            const int total = Bkv * head_dim;
-            for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+            // All supported head_dims (64, 96, 128, 256) are multiples of 8,
+            // so float4 loads are always aligned and in-bounds per row.
+            const int total_vec8 = (Bkv * head_dim) / 8;
+            for (int vi = tid; vi < total_vec8; vi += SM120_BLOCK_THREADS) {
+                int i = vi * 8;
                 int r = i / head_dim;
                 int d = i % head_dim;
+                float4* dst = reinterpret_cast<float4*>(&KV_tile[i]);
                 if (kv_start + r < seq_kv) {
-                    KV_tile[i] = V_ptr[(int64_t)(kv_start + r) * kv_row_stride + d];
+                    const float4* src = reinterpret_cast<const float4*>(
+                        &V_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]);
+                    *dst = *src;
                 } else {
-                    KV_tile[i] = __float2half(0.0f);
+                    *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
                 }
             }
         }
@@ -829,16 +843,21 @@ fmha_sm120_fp8_kernel(
         }
         __syncthreads();
 
-        // Load V tile as FP16 (PV stays in FP16 for value precision)
+        // Load V tile as FP16 (vectorized float4 = 8 halves per iter)
         {
-            const int total = Bkv * head_dim;
-            for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+            const int total_vec8 = (Bkv * head_dim) / 8;
+            for (int vi = tid; vi < total_vec8; vi += SM120_BLOCK_THREADS) {
+                int i = vi * 8;
                 int r = i / head_dim;
                 int d = i % head_dim;
-                if (kv_start + r < seq_kv)
-                    KV_fp16[i] = V_ptr[(int64_t)(kv_start + r) * kv_row_stride + d];
-                else
-                    KV_fp16[i] = __float2half(0.0f);
+                float4* dst = reinterpret_cast<float4*>(&KV_fp16[i]);
+                if (kv_start + r < seq_kv) {
+                    const float4* src = reinterpret_cast<const float4*>(
+                        &V_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]);
+                    *dst = *src;
+                } else {
+                    *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+                }
             }
         }
         __syncthreads();

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -151,9 +151,12 @@ fmha_sm120_kernel(
 
     // ---- zero output accumulator + init running softmax state ---------------
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
-            O_acc[i] = 0.0f;
+        // float4 = 4 FP32 zeros per store. Bq*HD is always a multiple of 4
+        // (HD ∈ {64,96,128,256}, Bq ∈ {32,64,128}).
+        const int total_vec4 = (Bq * head_dim) / 4;
+        const float4 zero = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+        for (int vi = tid; vi < total_vec4; vi += SM120_BLOCK_THREADS) {
+            reinterpret_cast<float4*>(O_acc)[vi] = zero;
         }
     }
     if (tid < Bq) {
@@ -384,15 +387,22 @@ fmha_sm120_kernel(
         __syncthreads();
     }
 
-    // ---- write final output to global memory ----
+    // ---- write final output to global memory (vectorized: 4 FP32 → 4 FP16 per iter) ----
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+        const int total_vec4 = (Bq * head_dim) / 4;
+        for (int vi = tid; vi < total_vec4; vi += SM120_BLOCK_THREADS) {
+            int i = vi * 4;
             int r = i / head_dim;
-            if (q_start + r < seq_q) {
-                O_ptr[(int64_t)r * q_row_stride + (i % head_dim)] =
-                    __float2half(O_acc[i]);
-            }
+            if (q_start + r >= seq_q) continue;
+            // 4 FP32 → 2 half2 via __float22half2_rn → store as float (= 4 halves packed)
+            float4 v = reinterpret_cast<const float4*>(O_acc)[vi];
+            half2 lo = __float22half2_rn(make_float2(v.x, v.y));
+            half2 hi = __float22half2_rn(make_float2(v.z, v.w));
+            uint2 packed;
+            packed.x = *reinterpret_cast<const uint32_t*>(&lo);
+            packed.y = *reinterpret_cast<const uint32_t*>(&hi);
+            *reinterpret_cast<uint2*>(
+                &O_ptr[(int64_t)r * q_row_stride + (i % head_dim)]) = packed;
         }
     }
 }
@@ -657,10 +667,13 @@ fmha_sm120_fp8_kernel(
         // supported HDs: 64,96,128,256 × Bq divisible configs all hit the vec4 fast path).
     }
 
-    // Zero O_acc + init softmax
+    // Zero O_acc (vectorized float4 = 4 FP32 zeros/iter) + init softmax
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += SM120_BLOCK_THREADS) O_acc[i] = 0.0f;
+        const int total_vec4 = (Bq * head_dim) / 4;
+        const float4 zero = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+        for (int vi = tid; vi < total_vec4; vi += SM120_BLOCK_THREADS) {
+            reinterpret_cast<float4*>(O_acc)[vi] = zero;
+        }
     }
     if (tid < Bq) { row_m[tid] = -FLT_MAX; row_l[tid] = 0.0f; }
     __syncthreads();
@@ -896,13 +909,21 @@ fmha_sm120_fp8_kernel(
         __syncthreads();
     }
 
-    // Write output
+    // Write output (vectorized: 4 FP32 → 4 FP16 per iter)
     {
-        const int total = Bq * head_dim;
-        for (int i = tid; i < total; i += SM120_BLOCK_THREADS) {
+        const int total_vec4 = (Bq * head_dim) / 4;
+        for (int vi = tid; vi < total_vec4; vi += SM120_BLOCK_THREADS) {
+            int i = vi * 4;
             int r = i / head_dim;
-            if (q_start + r < seq_q)
-                O_ptr[(int64_t)r * q_row_stride + (i % head_dim)] = __float2half(O_acc[i]);
+            if (q_start + r >= seq_q) continue;
+            float4 v = reinterpret_cast<const float4*>(O_acc)[vi];
+            half2 lo = __float22half2_rn(make_float2(v.x, v.y));
+            half2 hi = __float22half2_rn(make_float2(v.z, v.w));
+            uint2 packed;
+            packed.x = *reinterpret_cast<const uint32_t*>(&lo);
+            packed.y = *reinterpret_cast<const uint32_t*>(&hi);
+            *reinterpret_cast<uint2*>(
+                &O_ptr[(int64_t)r * q_row_stride + (i % head_dim)]) = packed;
         }
     }
 }

--- a/src/compute/attention_mxfp4_prefill.cu
+++ b/src/compute/attention_mxfp4_prefill.cu
@@ -75,6 +75,28 @@ __device__ __forceinline__ uint8_t mxfp4_quantize_abs(float abs_val) {
     return code;  // 0..7
 }
 
+// HW FP4 conversion: two scaled FP32 values → one byte of packed E2M1
+// nibbles (low = v0, high = v1). Replaces the SW cascade above for
+// sm_120+. Rounding is IEEE RNE (differs from SW midpoint on boundary).
+__device__ __forceinline__ uint8_t mxfp4_pack_pair_hw(float v0, float v1) {
+#if __CUDA_ARCH__ >= 1200
+    uint32_t out;
+    asm volatile(
+        "{ .reg .b8 b;\n"
+        "  cvt.rn.satfinite.e2m1x2.f32 b, %2, %1;\n"
+        "  cvt.u32.u8 %0, b; }\n"
+        : "=r"(out)
+        : "f"(v0), "f"(v1));
+    return static_cast<uint8_t>(out);
+#else
+    uint8_t sign0 = (v0 < 0.0f) ? 1u : 0u;
+    uint8_t code0 = (sign0 << 3) | mxfp4_quantize_abs(fabsf(v0));
+    uint8_t sign1 = (v1 < 0.0f) ? 1u : 0u;
+    uint8_t code1 = (sign1 << 3) | mxfp4_quantize_abs(fabsf(v1));
+    return (code1 << 4) | code0;
+#endif
+}
+
 __device__ __forceinline__
 int mxfp4_sfatom_offset(int row, int k_group, int n_k_tiles) {
     int tile_row  = row / kAtomRows;
@@ -137,15 +159,9 @@ __global__ void quantize_fp16_mxfp4_strided_kernel(
     int packed_base = row * (K / 2) + k_group * (kMxGroupSize / 2);
     #pragma unroll
     for (int i = 0; i < 32; i += 2) {
-        float s0 = vals[i] * inv_scale;
-        uint8_t sign0 = (s0 < 0.0f) ? 1u : 0u;
-        uint8_t fp4_0 = (sign0 << 3) | mxfp4_quantize_abs(fabsf(s0));
-
+        float s0 = vals[i]     * inv_scale;
         float s1 = vals[i + 1] * inv_scale;
-        uint8_t sign1 = (s1 < 0.0f) ? 1u : 0u;
-        uint8_t fp4_1 = (sign1 << 3) | mxfp4_quantize_abs(fabsf(s1));
-
-        packed_out[packed_base + i / 2] = (fp4_1 << 4) | fp4_0;
+        packed_out[packed_base + i / 2] = mxfp4_pack_pair_hw(s0, s1);
     }
 }
 

--- a/src/compute/gemm_cutlass_mxfp4_sm120.cu
+++ b/src/compute/gemm_cutlass_mxfp4_sm120.cu
@@ -467,6 +467,27 @@ __device__ __forceinline__ uint8_t quantize_abs_to_fp4_mx(float abs_val) {
     return code;  // 0..7
 }
 
+// HW FP4 conversion: two scaled FP32 → packed byte (low=v0, high=v1).
+// IEEE RNE rounding; sm_120+ only.
+__device__ __forceinline__ uint8_t pack_fp4_pair_hw_mx(float v0, float v1) {
+#if __CUDA_ARCH__ >= 1200
+    uint32_t out;
+    asm volatile(
+        "{ .reg .b8 b;\n"
+        "  cvt.rn.satfinite.e2m1x2.f32 b, %2, %1;\n"
+        "  cvt.u32.u8 %0, b; }\n"
+        : "=r"(out)
+        : "f"(v0), "f"(v1));
+    return static_cast<uint8_t>(out);
+#else
+    uint8_t sign0 = (v0 < 0.0f) ? 1u : 0u;
+    uint8_t sign1 = (v1 < 0.0f) ? 1u : 0u;
+    uint8_t c0 = (sign0 << 3) | quantize_abs_to_fp4_mx(fabsf(v0));
+    uint8_t c1 = (sign1 << 3) | quantize_abs_to_fp4_mx(fabsf(v1));
+    return (c1 << 4) | c0;
+#endif
+}
+
 __device__ __forceinline__ float ue8m0_to_float(uint8_t bits) {
     // UE8M0: value = 2^(bits - 127)
     if (bits == 0) return 5.877472e-39f;  // 2^-127
@@ -513,21 +534,13 @@ __global__ void quantize_fp16_mxfp4_cutlass_kernel(
     int sf_idx = mx_sfatom_offset(row, k_group, n_k_tiles);
     sf_out[sf_idx] = ue8m0;
 
-    // Quantize and pack FP4 values (2 per byte)
+    // Quantize and pack FP4 values (2 per byte) via HW conversion
     int packed_base = row * (K / 2) + k_group * (kMxSFVecSize / 2);
     #pragma unroll
     for (int i = 0; i < 32; i += 2) {
-        float s0 = vals[i] * inv_scale;
-        uint8_t sign0 = (s0 < 0.0f) ? 1u : 0u;
-        uint8_t code0 = quantize_abs_to_fp4_mx(fabsf(s0));
-        uint8_t fp4_0 = (sign0 << 3) | code0;
-
+        float s0 = vals[i]     * inv_scale;
         float s1 = vals[i + 1] * inv_scale;
-        uint8_t sign1 = (s1 < 0.0f) ? 1u : 0u;
-        uint8_t code1 = quantize_abs_to_fp4_mx(fabsf(s1));
-        uint8_t fp4_1 = (sign1 << 3) | code1;
-
-        packed_out[packed_base + i / 2] = (fp4_1 << 4) | fp4_0;
+        packed_out[packed_base + i / 2] = pack_fp4_pair_hw_mx(s0, s1);
     }
 }
 

--- a/src/compute/gemm_cutlass_sm120.cu
+++ b/src/compute/gemm_cutlass_sm120.cu
@@ -194,6 +194,27 @@ __device__ __forceinline__ uint8_t quantize_abs_to_fp4(float abs_val) {
     return code;  // 0..7
 }
 
+// HW FP4 conversion: two scaled FP32 → packed byte (low=v0, high=v1).
+// IEEE RNE rounding; sm_120+ only.
+__device__ __forceinline__ uint8_t pack_fp4_pair_hw(float v0, float v1) {
+#if __CUDA_ARCH__ >= 1200
+    uint32_t out;
+    asm volatile(
+        "{ .reg .b8 b;\n"
+        "  cvt.rn.satfinite.e2m1x2.f32 b, %2, %1;\n"
+        "  cvt.u32.u8 %0, b; }\n"
+        : "=r"(out)
+        : "f"(v0), "f"(v1));
+    return static_cast<uint8_t>(out);
+#else
+    uint8_t sign0 = (v0 < 0.0f) ? 1u : 0u;
+    uint8_t sign1 = (v1 < 0.0f) ? 1u : 0u;
+    uint8_t c0 = (sign0 << 3) | quantize_abs_to_fp4(fabsf(v0));
+    uint8_t c1 = (sign1 << 3) | quantize_abs_to_fp4(fabsf(v1));
+    return (c1 << 4) | c0;
+#endif
+}
+
 // Given 16 pre-computed float values + their absmax, encode UE4M3 scale and
 // pack FP4 bytes. The caller supplies the values (so this helper is reusable
 // for fused paths like SwiGLU+quantize where values come from a computation
@@ -222,17 +243,9 @@ __device__ __forceinline__ void quantize_micro_block_nvfp4_from_vals(
     uint8_t* packed_at = packed_out_row + k_group * (kSFVecSize / 2);
     #pragma unroll
     for (int i = 0; i < kSFVecSize; i += 2) {
-        float s0 = vals[i] * inv_scale;
-        uint8_t sign0 = (s0 < 0.0f) ? 1u : 0u;
-        uint8_t code0 = quantize_abs_to_fp4(fabsf(s0));
-        uint8_t fp4_0 = (sign0 << 3) | code0;
-
+        float s0 = vals[i]     * inv_scale;
         float s1 = vals[i + 1] * inv_scale;
-        uint8_t sign1 = (s1 < 0.0f) ? 1u : 0u;
-        uint8_t code1 = quantize_abs_to_fp4(fabsf(s1));
-        uint8_t fp4_1 = (sign1 << 3) | code1;
-
-        packed_at[i / 2] = (fp4_1 << 4) | fp4_0;
+        packed_at[i / 2] = pack_fp4_pair_hw(s0, s1);
     }
 }
 

--- a/src/compute/mxf4nvf4_mma_variants_bench.cu
+++ b/src/compute/mxf4nvf4_mma_variants_bench.cu
@@ -1,0 +1,329 @@
+// =============================================================================
+// mxf4nvf4_mma_variants_bench.cu -- Microbench all sm_120 FP4/FP8 MMA variants
+// =============================================================================
+//
+// Compares throughput of every relevant block_scale + sparse PTX MMA the
+// CUTLASS sm120 headers expose (mma_sm120.hpp + mma_sm120_sparse.hpp).
+// Goal: identify any variant beyond `kind::mxf4nvf4.block_scale.scale_vec::
+// 4X.m16n8k64.ue4m3` (Project B's current default) that would beat it on
+// raw throughput for our QK^T workload.
+//
+// What we test (all dense; sparse requires 2:4 metadata, also tested):
+//
+//   Dense, no scaling:
+//     [DENSE_F8F6F4_K32]   kind::f8f6f4.m16n8k32              (legacy, baseline)
+//
+//   Dense block_scale variants:
+//     [BS_NVFP4_4X_E4M3]   mxf4nvf4 vec::4X k64 ue4m3  (current default)
+//     [BS_MXFP4_4X_E8M0]   mxf4nvf4 vec::4X k64 ue8m0  (NVFP4 layout, MXFP4 scale)
+//     [BS_MXFP4_2X_E8M0]   mxf4nvf4 vec::2X k64 ue8m0  (per-32 scales, half scale loads)
+//     [BS_MXF8F6F4_1X_44]  mxf8f6f4 vec::1X k32 ue8m0 e4m3.e4m3  (FP8 × FP8 mixed)
+//     [BS_MXF8F6F4_1X_41]  mxf8f6f4 vec::1X k32 ue8m0 e4m3.e2m1  (FP8 Q × FP4 K)
+//     [BS_MXF8F6F4_1X_11]  mxf8f6f4 vec::1X k32 ue8m0 e2m1.e2m1  (FP4 × FP4 with HW scale)
+//
+//   Sparse (require 2:4 sparsity on A):
+//     [SP_F8F6F4_K64]      f8f6f4.sp::ordered_metadata k64
+//     [SP_NVFP4_4X_K128]   mxf4nvf4 vec::4X.sp k128 ue4m3
+//
+// Sparse ones double K per issue → 2× raw throughput vs dense if 2:4 sparsity
+// is achievable. Mixed-precision ones don't change K but enable Q-precision
+// trade-offs.
+// =============================================================================
+
+#include "compute/mxf4nvf4_mma_variants_bench.h"
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+namespace imp {
+
+// Helper: stable input registers (different per thread to defeat any
+// constant-folding) plus 0x38 UE4M3 / 0x7f UE8M0 ≈ 1.0 scales.
+#define BENCH_PREAMBLE \
+    uint32_t a0 = threadIdx.x * 37u + 1u; \
+    uint32_t a1 = threadIdx.x * 41u + 2u; \
+    uint32_t a2 = threadIdx.x * 43u + 3u; \
+    uint32_t a3 = threadIdx.x * 47u + 4u; \
+    uint32_t b0 = threadIdx.x * 53u + 5u; \
+    uint32_t b1 = threadIdx.x * 59u + 6u; \
+    uint32_t b2 = threadIdx.x * 61u + 7u; \
+    uint32_t b3 = threadIdx.x * 67u + 8u; \
+    uint32_t sfa_e4m3 = 0x38383838u; /* UE4M3 ≈ 1.0 */ \
+    uint32_t sfb_e4m3 = 0x38383838u; \
+    uint32_t sfa_e8m0 = 0x7f7f7f7fu; /* UE8M0 = 2^0 = 1.0 */ \
+    uint32_t sfb_e8m0 = 0x7f7f7f7fu; \
+    uint32_t metadata = 0x44444444u;  /* 2:4 sparse: select positions 0,1 of every 4 */ \
+    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f; \
+    constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0; \
+    (void)a0; (void)a1; (void)a2; (void)a3; \
+    (void)b0; (void)b1; (void)b2; (void)b3; \
+    (void)sfa_e4m3; (void)sfb_e4m3; (void)sfa_e8m0; (void)sfb_e8m0; \
+    (void)metadata; (void)bidA; (void)tidA; (void)bidB; (void)tidB
+
+#define BENCH_SINK_STORE \
+    if (threadIdx.x == 0 && blockIdx.x == 0) sink[0] = d0 + d1 + d2 + d3
+
+// ---------------------------------------------------------------------------
+// (1) DENSE_F8F6F4_K32 — legacy baseline (no scaling)
+// ---------------------------------------------------------------------------
+__global__ void bench_v_dense_f8f6f4_k32(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e2m1.e2m1.f32 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(0), "r"(0),
+              "r"(b0), "r"(0),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (2) BS_NVFP4_4X_E4M3 — current Project B default
+// ---------------------------------------------------------------------------
+__global__ void bench_v_nvfp4_4x_e4m3(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},{%14},{%15,%16},{%17},{%18,%19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa_e4m3), "h"(bidA), "h"(tidA),
+              "r"(sfb_e4m3), "h"(bidB), "h"(tidB));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (3) BS_MXFP4_4X_E8M0 — same K=64 NVFP4 layout, alternative UE8M0 scale type
+// ---------------------------------------------------------------------------
+__global__ void bench_v_nvfp4_4x_e8m0(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale.scale_vec::4X.f32.e2m1.e2m1.f32.ue8m0 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},{%14},{%15,%16},{%17},{%18,%19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa_e8m0), "h"(bidA), "h"(tidA),
+              "r"(sfb_e8m0), "h"(bidB), "h"(tidB));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (4) BS_MXFP4_2X_E8M0 — per-32 scales (vs ::4X per-16). Half the SF traffic.
+// ---------------------------------------------------------------------------
+__global__ void bench_v_mxfp4_2x_e8m0(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue8m0 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},{%14},{%15,%16},{%17},{%18,%19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa_e8m0), "h"(bidA), "h"(tidA),
+              "r"(sfb_e8m0), "h"(bidB), "h"(tidB));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (5) BS_MXF8F6F4_1X_E2M1 — FP4 × FP4 at K=32 with HW scale (alternative to
+//     legacy + manual scale; same K so should be ~same throughput as legacy).
+// ---------------------------------------------------------------------------
+__global__ void bench_v_mxf8f6f4_1x_e2m1(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::mxf8f6f4.block_scale.scale_vec::1X.m16n8k32.row.col.f32.e2m1.e2m1.f32.ue8m0 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},{%14},{%15,%16},{%17},{%18,%19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa_e8m0), "h"(bidA), "h"(tidA),
+              "r"(sfb_e8m0), "h"(bidB), "h"(tidB));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (6) BS_MXF8F6F4_1X_E4M3 — FP8 × FP8 (Q FP8 quality, half the K of K=64)
+// ---------------------------------------------------------------------------
+__global__ void bench_v_mxf8f6f4_1x_e4m3(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::mxf8f6f4.block_scale.scale_vec::1X.m16n8k32.row.col.f32.e4m3.e4m3.f32.ue8m0 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},{%14},{%15,%16},{%17},{%18,%19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa_e8m0), "h"(bidA), "h"(tidA),
+              "r"(sfb_e8m0), "h"(bidB), "h"(tidB));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (7) BS_MXF8F6F4_1X_E4M3xE2M1 — Q in FP8, K in FP4 (asymmetric quality)
+// ---------------------------------------------------------------------------
+__global__ void bench_v_mxf8f6f4_1x_e4m3_e2m1(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::mxf8f6f4.block_scale.scale_vec::1X.m16n8k32.row.col.f32.e4m3.e2m1.f32.ue8m0 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},{%14},{%15,%16},{%17},{%18,%19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa_e8m0), "h"(bidA), "h"(tidA),
+              "r"(sfb_e8m0), "h"(bidB), "h"(tidB));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (8) SP_F8F6F4_K64 — sparse f8f6f4 at K=64 (no scaling; 2× K vs dense legacy)
+// ---------------------------------------------------------------------------
+__global__ void bench_v_sparse_f8f6f4_k64(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+#if __CUDA_ARCH__ >= 1200
+    #pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::f8f6f4.sp::ordered_metadata.m16n8k64.row.col.f32.e2m1.e2m1.f32 "
+            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9,%10,%11},{%12,%13,%14,%15},%16,0x0;\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1), "r"(b2), "r"(b3),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(metadata));
+    }
+#endif
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// (9) SP_NVFP4_4X_K128 — DISABLED. ptxas rejects the instruction on sm_120f:
+// "Feature '.kind::mxf4nvf4 with .sp modifier' not supported on .target 'sm_120f'".
+// CUTLASS exposes the PTX template in mma_sm120_sparse.hpp but the actual
+// hardware doesn't have it on consumer Blackwell. Marking as a dead end.
+// ---------------------------------------------------------------------------
+__global__ void bench_v_sparse_nvfp4_k128(int iterations, float* sink) {
+    BENCH_PREAMBLE;
+    // Intentionally empty — see comment above.
+    BENCH_SINK_STORE;
+}
+
+// ---------------------------------------------------------------------------
+// Host launcher
+// ---------------------------------------------------------------------------
+static float run_one(void(*kernel)(int, float*), int warps, int iterations,
+                     cudaStream_t stream) {
+    float* d_sink = nullptr;
+    if (cudaMalloc(&d_sink, sizeof(float)) != cudaSuccess) return -1.0f;
+
+    kernel<<<warps, 32, 0, stream>>>(iterations / 10, d_sink);
+    cudaStreamSynchronize(stream);
+    if (cudaGetLastError() != cudaSuccess) {
+        cudaFree(d_sink);
+        return -2.0f;  // launch failure
+    }
+
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    constexpr int NUM_REPS = 5;
+    float total_ms = 0.0f;
+    for (int rep = 0; rep < NUM_REPS; ++rep) {
+        cudaEventRecord(start, stream);
+        kernel<<<warps, 32, 0, stream>>>(iterations, d_sink);
+        cudaEventRecord(stop, stream);
+        cudaEventSynchronize(stop);
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, start, stop);
+        total_ms += ms;
+    }
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    cudaFree(d_sink);
+    return total_ms / NUM_REPS;
+}
+
+MmaVariantsBenchResult bench_mma_variants(int warps, int iterations,
+                                           cudaStream_t stream) {
+    MmaVariantsBenchResult r{};
+
+    struct Entry {
+        const char* label;
+        void (*kernel)(int, float*);
+        double ops_per_mma;  // FMAs * 2 = m * n * k * 2 for dense; sparse same since metadata selects
+    };
+    Entry entries[] = {
+        {"dense_f8f6f4_k32",      bench_v_dense_f8f6f4_k32,      16.0 * 8.0 * 32.0  * 2.0},
+        {"bs_nvfp4_4x_e4m3_k64",  bench_v_nvfp4_4x_e4m3,         16.0 * 8.0 * 64.0  * 2.0},
+        {"bs_nvfp4_4x_e8m0_k64",  bench_v_nvfp4_4x_e8m0,         16.0 * 8.0 * 64.0  * 2.0},
+        {"bs_mxfp4_2x_e8m0_k64",  bench_v_mxfp4_2x_e8m0,         16.0 * 8.0 * 64.0  * 2.0},
+        {"bs_mxf8f6f4_1x_e2m1",   bench_v_mxf8f6f4_1x_e2m1,      16.0 * 8.0 * 32.0  * 2.0},
+        {"bs_mxf8f6f4_1x_e4m3",   bench_v_mxf8f6f4_1x_e4m3,      16.0 * 8.0 * 32.0  * 2.0},
+        {"bs_mxf8f6f4_1x_e4m3xe2m1", bench_v_mxf8f6f4_1x_e4m3_e2m1, 16.0 * 8.0 * 32.0 * 2.0},
+        {"sp_f8f6f4_k64",         bench_v_sparse_f8f6f4_k64,     16.0 * 8.0 * 64.0  * 2.0},
+        // sp_nvfp4_4x_k128: ptxas rejects on sm_120f. See comment above kernel.
+    };
+
+    int n = sizeof(entries) / sizeof(entries[0]);
+    if (n > MmaVariantsBenchResult::kMaxEntries) n = MmaVariantsBenchResult::kMaxEntries;
+    r.count = n;
+
+    const double total_mmas = static_cast<double>(warps) * iterations;
+    for (int i = 0; i < n; ++i) {
+        float ms = run_one(entries[i].kernel, warps, iterations, stream);
+        r.entries[i].label = entries[i].label;
+        r.entries[i].ms = ms;
+        if (ms > 0.0f) {
+            r.entries[i].tops =
+                (entries[i].ops_per_mma * total_mmas) / (ms * 1e-3) / 1e12;
+        } else {
+            r.entries[i].tops = -1.0;  // launch failed
+        }
+    }
+    return r;
+}
+
+} // namespace imp

--- a/src/compute/mxf4nvf4_mma_variants_bench.h
+++ b/src/compute/mxf4nvf4_mma_variants_bench.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace imp {
+
+struct MmaVariantsBenchResult {
+    static constexpr int kMaxEntries = 16;
+    struct Entry {
+        const char* label;
+        float ms;
+        double tops;
+    };
+    Entry entries[kMaxEntries];
+    int count = 0;
+};
+
+// Benchmarks all sm120 FP4/FP8 MMA variants exposed by CUTLASS headers.
+// `warps`: number of warps (CTAs of 32 threads each) to launch.
+// `iterations`: tight-loop iterations per warp.
+// Result.entries[i].tops < 0 indicates the variant failed to launch
+// (likely missing CUTE_ARCH_*_ENABLED defines or invalid PTX).
+MmaVariantsBenchResult bench_mma_variants(int warps, int iterations,
+                                           cudaStream_t stream);
+
+} // namespace imp

--- a/src/compute/mxf4nvf4_qkt_validate.cu
+++ b/src/compute/mxf4nvf4_qkt_validate.cu
@@ -6,17 +6,22 @@
 //   mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
 // with uniform scale = 1.0, and writes D[M, N] as FP32.
 //
-// Uses CUTLASS (T32,V32)→(M16,K64) layout derived from cute_extension.h:
+// Uses CUTLASS MMA_Traits from mma_traits_sm120.hpp:
 //   ALayout = Layout<Shape <Shape <  _4,_8>,Shape < _8,_2,  _2>>,
-//                    Stride<Stride<_128,_1>,Stride<_16,_8,_512>>>
-// For thread t at value v:
-//   t_outer = t / 8, t_inner = t % 8
-//   v0 = v % 8, v1 = (v/8) % 2, v2 = (v/16) % 2
-//   logical_offset = t_outer*128 + t_inner + v0*16 + v1*8 + v2*512
-//   m = offset / 64, k = offset % 64
+//                    Stride<Stride<_128,_1>,Stride<_16,_8,_512>>>   // (T32,V32)→(M16,K64)
+//   BLayout = Layout<Shape <Shape < _4,_8>,Shape <_8,  _2>>,
+//                    Stride<Stride<_64,_1>,Stride<_8,_256>>>         // (T32,V16)→(N8,K64)
+//   CLayout = SM80_16x8_Row                                          // (T32,V4)→(M16,N8)
 //
-// With scale_vec::4X, only 1 of 4 MMA issues is used here (tidB=0), so B
-// covers N=[0, 8) of the 32-N total extent.
+// KEY INSIGHT: CuTe layouts `(T,V)→(M,K)` are COLUMN-MAJOR over the
+// (M,K) coord space — offset = k*M + m, NOT m*K + k. This means per
+// thread t=(T0=t%4, T1=t/4), v=(V0=v%8, V1=(v>>3)&1, V2=(v>>4)&1):
+//   A: m = T1 + V1*8, k = T0*8 + V0 + V2*32
+//   B: n = T1,        k = T0*8 + V0 + V1*32
+//   C: m = T1 + V1*8, n = T0*2 + V0 (V0 = v%2, V1 = v>>1)
+//
+// Scale = 1.0 uniform (FP8 UE4M3 byte 0x38) so the MMA reduces to plain
+// E2M1 × E2M1 dot product.
 // =============================================================================
 
 #include "compute/mxf4nvf4_qkt_validate.h"
@@ -58,21 +63,22 @@ __global__ void qkt_mxf4nvf4_kernel(
     const int tid = threadIdx.x;
     if (tid >= 32) return;
 
-    // CuTe column-major: Shape<_4,_8>, Stride<_128,_1>.
-    // Linear t decomposes as t.0 = t%4 (inner, shape 4), t.1 = t/4 (outer, shape 8).
-    // Thread offset = (t%4) * 128 + (t/4) * 1.
-    const int t_outer = tid % 4;   // t.0, stride 128 (row group)
-    const int t_inner = tid / 4;   // t.1, stride 1 (k-offset)
+    // CuTe: T = T0 + T1*4, T0=t%4 (inner, stride 128 for A), T1=t/4.
+    const int T0 = tid % 4;
+    const int T1 = tid / 4;
 
     // --- Load A operand: 32 FP4 values per thread into 4 uint32 ---
+    // Per-thread coverage (column-major (M,K) linearization):
+    //   m = T1 + V1*8       with V1 ∈ {0,1}
+    //   k = T0*8 + V0 + V2*32  with V0 ∈ [0,8), V2 ∈ {0,1}
+    // Register packing: nibble offset (v&7) = V0, register (v>>3) = V1+V2*2.
     uint32_t a0 = 0, a1 = 0, a2 = 0, a3 = 0;
     for (int v = 0; v < 32; ++v) {
-        int v0 = v & 7;
-        int v1 = (v >> 3) & 1;
-        int v2 = (v >> 4) & 1;
-        int offset = t_outer * 128 + t_inner + v0 * 16 + v1 * 8 + v2 * 512;
-        int m = offset / KD;
-        int k = offset % KD;
+        int V0 = v & 7;
+        int V1 = (v >> 3) & 1;
+        int V2 = (v >> 4) & 1;
+        int m = T1 + V1 * 8;
+        int k = T0 * 8 + V0 + V2 * 32;
         float val = (m < M && k < KD) ? __half2float(Q[m * KD + k]) : 0.0f;
         uint8_t nibble = fp32_to_e2m1(val);
         int reg_idx = v >> 3;
@@ -85,25 +91,16 @@ __global__ void qkt_mxf4nvf4_kernel(
     }
 
     // --- Load B operand: 16 FP4 values per thread into 2 uint32 ---
-    // BLayout for single tidB=0 subtile (N=8, K=64):
-    //   Shape <_4,_8>, stride (_256, _1)  — same thread decomposition pattern
-    //   Values: 16 per thread for one tidB issue
-    // For this single-tile validation we use an analogous mapping over N=8.
-    // Since N=8 is smaller than M=16, the t_outer only needs to iterate
-    // over half the rows. Threads t_outer ∈ [0, 1) cover N=[0, 8), the
-    // upper t_outer values would cover further N extents in the 4-issue
-    // variant — here we just reuse the pattern reduced to N=8.
+    // Per-thread coverage (column-major (N,K) linearization):
+    //   n = T1                          (one n-value per thread group of 4)
+    //   k = T0*8 + V0 + V1*32     with V0 ∈ [0,8), V1 ∈ {0,1}
+    // Register packing: nib (v&7) = V0, register (v>>3) = V1.
     uint32_t b0 = 0, b1 = 0;
     for (int v = 0; v < 16; ++v) {
-        int v0 = v & 7;
-        int v1 = (v >> 3) & 1;
-        // For N=8 single tile: n-stride smaller since only 8 rows
-        // Simplify: treat the B layout as (T,V)→(N,K) with N=8
-        //   n = (t_outer * 8 + (v0 < 4 ? 0 : 4)) % 8  — placeholder; iterate
-        // TODO: derive exact single-tile B layout from SageAttention3 BLayout
-        int n = (t_outer * 2 + (v >> 4)) % N;
-        int k_sub = t_inner + v0 * 8 + v1 * 16;  // within the t_inner stride
-        int k = k_sub % KD;
+        int V0 = v & 7;
+        int V1 = (v >> 3) & 1;
+        int n = T1;
+        int k = T0 * 8 + V0 + V1 * 32;
         float val = (n < N && k < KD) ? __half2float(Kmat[n * KD + k]) : 0.0f;
         uint8_t nibble = fp32_to_e2m1(val);
         int reg_idx = v >> 3;
@@ -144,21 +141,21 @@ __global__ void qkt_mxf4nvf4_kernel(
 #endif
 
     // --- Write D outputs ---
-    // D layout (T32,V4)→(M16,N8) per CUTLASS convention:
-    //   d0..d3 per thread map to specific (m, n) pairs.
-    //   For m16n8: each thread holds 4 values at (m=lane_id/4*2, n=lane_id%4*2)
-    //   offset pattern. Standard m16n8 FP32 output layout:
-    //     d0, d1 → row (tid/4), columns (tid%4)*2, (tid%4)*2+1
-    //     d2, d3 → row (tid/4)+8, same columns
-    const int out_row0 = tid / 4;        // 0..7
-    const int out_row1 = (tid / 4) + 8;  // 8..15
-    const int out_col0 = (tid % 4) * 2;
-    const int out_col1 = out_col0 + 1;
+    // CLayout (T32,V4)→(M16,N8), column-major: offset = n*M + m.
+    // For thread (T0, T1), V=(V0=v%2, V1=v>>1):
+    //   m = T1 + V1*8
+    //   n = T0*2 + V0
+    // d0 → (T1,   T0*2);     d1 → (T1,   T0*2+1)
+    // d2 → (T1+8, T0*2);     d3 → (T1+8, T0*2+1)
+    const int m0 = T1;
+    const int m1 = T1 + 8;
+    const int n0 = T0 * 2;
+    const int n1 = n0 + 1;
 
-    if (out_row0 < M && out_col0 < N) D[out_row0 * N + out_col0] = d0;
-    if (out_row0 < M && out_col1 < N) D[out_row0 * N + out_col1] = d1;
-    if (out_row1 < M && out_col0 < N) D[out_row1 * N + out_col0] = d2;
-    if (out_row1 < M && out_col1 < N) D[out_row1 * N + out_col1] = d3;
+    if (m0 < M && n0 < N) D[m0 * N + n0] = d0;
+    if (m0 < M && n1 < N) D[m0 * N + n1] = d1;
+    if (m1 < M && n0 < N) D[m1 * N + n0] = d2;
+    if (m1 < M && n1 < N) D[m1 * N + n1] = d3;
 }
 
 bool qkt_mxf4nvf4_validate(const half* d_Q, const half* d_K, float* d_D,

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -69,6 +69,28 @@ __device__ __forceinline__ uint8_t float_abs_to_fp4_e2m1(float abs_val)
     return code;  // 0..7
 }
 
+// HW FP32 pair → packed E2M1 byte (low = v0, high = v1). IEEE RNE rounding,
+// saturates to ±6. Single PTX instruction on sm_120+.
+__device__ __forceinline__ uint8_t nvfp4_pack_pair_hw(float v0, float v1)
+{
+#if __CUDA_ARCH__ >= 1200
+    uint32_t out;
+    asm volatile(
+        "{ .reg .b8 b;\n"
+        "  cvt.rn.satfinite.e2m1x2.f32 b, %2, %1;\n"
+        "  cvt.u32.u8 %0, b; }\n"
+        : "=r"(out)
+        : "f"(v0), "f"(v1));
+    return static_cast<uint8_t>(out);
+#else
+    uint8_t sign0 = (v0 < 0.0f) ? 1u : 0u;
+    uint8_t sign1 = (v1 < 0.0f) ? 1u : 0u;
+    uint8_t c0 = (sign0 << 3) | float_abs_to_fp4_e2m1(fabsf(v0));
+    uint8_t c1 = (sign1 << 3) | float_abs_to_fp4_e2m1(fabsf(v1));
+    return (c1 << 4) | c0;
+#endif
+}
+
 // float_to_fp8_e4m3() and fp8_e4m3_to_float() are provided by fp8_utils.cuh.
 
 // ---------------------------------------------------------------------------
@@ -125,20 +147,9 @@ __device__ __forceinline__ void quantize_micro_block_nvfp4(
 
     #pragma unroll
     for (int i = 0; i < kMicroBlockSize; i += 2) {
-        // Quantize even element (low nibble).
-        float scaled0 = vals[i] * inv_combined_scale;
-        uint8_t sign0 = (scaled0 < 0.0f) ? 1u : 0u;
-        uint8_t code0 = float_abs_to_fp4_e2m1(fabsf(scaled0));
-        uint8_t fp4_0 = (sign0 << 3) | code0;
-
-        // Quantize odd element (high nibble).
-        float scaled1 = vals[i + 1] * inv_combined_scale;
-        uint8_t sign1 = (scaled1 < 0.0f) ? 1u : 0u;
-        uint8_t code1 = float_abs_to_fp4_e2m1(fabsf(scaled1));
-        uint8_t fp4_1 = (sign1 << 3) | code1;
-
-        // Pack: low nibble = even, high nibble = odd.
-        packed_out[packed_base + i / 2] = (fp4_1 << 4) | fp4_0;
+        float s0 = vals[i]     * inv_combined_scale;
+        float s1 = vals[i + 1] * inv_combined_scale;
+        packed_out[packed_base + i / 2] = nvfp4_pack_pair_hw(s0, s1);
     }
 }
 

--- a/src/quant/turboquant_fp4.cuh
+++ b/src/quant/turboquant_fp4.cuh
@@ -34,9 +34,22 @@ __device__ __forceinline__ uint8_t tq_fp4_quantize_signed(float val) {
     return (sign << 3) | code;
 }
 
-// Pack two signed FP4 nibbles into one byte (lo=even, hi=odd)
+// Pack two signed FP4 nibbles into one byte (lo=even, hi=odd).
+// Uses HW cvt.rn.satfinite.e2m1x2.f32 on sm_120+ (single PTX instruction,
+// IEEE RNE rounding, saturates to ±6). SW fallback for older archs.
 __device__ __forceinline__ uint8_t tq_fp4_pack_pair(float v0, float v1) {
+#if __CUDA_ARCH__ >= 1200
+    uint32_t out;
+    asm volatile(
+        "{ .reg .b8 b;\n"
+        "  cvt.rn.satfinite.e2m1x2.f32 b, %2, %1;\n"
+        "  cvt.u32.u8 %0, b; }\n"
+        : "=r"(out)
+        : "f"(v0), "f"(v1));
+    return static_cast<uint8_t>(out);
+#else
     return tq_fp4_quantize_signed(v0) | (tq_fp4_quantize_signed(v1) << 4);
+#endif
 }
 
 // Float → UE8M0 (pure-exponent, value = 2^(bits-127), rounds up to next pow2)

--- a/tests/test_attention_fmha_mxfp4.cu
+++ b/tests/test_attention_fmha_mxfp4.cu
@@ -211,6 +211,110 @@ TEST_F(FhmaMxFP4Test, HD64_LongSeq) {
                      0.5f, 0.1f, stream_, sm_);
 }
 
+// Compare legacy vs blockscale paths. Both paths share the same Q/K quant
+// and post-MMA scale application; only the MMA instruction differs.
+// kind::mxf4nvf4.m16n8k64 internally sums 64 FP4 products per issue in FP32,
+// whereas legacy f8f6f4.m16n8k32 sums 32 products per issue and then adds
+// the partials. FP32 is not associative, so per-element differences at the
+// ULP × sqrt(K) level are expected. After the softmax+PV pipeline, those
+// tiny score deltas can propagate into a few-percent output outliers
+// (max_err ~0.1), while mean_err stays at noise level (~1e-3).
+static void run_blockscale_ab_test(int B, int SQ, int SKV, int NH, int NKV,
+                                    int HD, bool causal, int sliding_window,
+                                    float softcap, float max_err_limit,
+                                    float mean_err_limit,
+                                    cudaStream_t stream, int sm) {
+    ASSERT_EQ(HD % 64, 0) << "Blockscale requires HD % 64 == 0";
+    size_t qo_elems = (size_t)B * SQ * NH * HD;
+    size_t kv_elems = (size_t)B * SKV * NKV * HD;
+
+    void *d_q, *d_k, *d_v, *d_o_leg, *d_o_bs;
+    cudaMalloc(&d_q, qo_elems * sizeof(half));
+    cudaMalloc(&d_k, kv_elems * sizeof(half));
+    cudaMalloc(&d_v, kv_elems * sizeof(half));
+    cudaMalloc(&d_o_leg, qo_elems * sizeof(half));
+    cudaMalloc(&d_o_bs, qo_elems * sizeof(half));
+
+    fill_random_fp16(d_q, qo_elems, 0.3f, 42 + HD);
+    fill_random_fp16(d_k, kv_elems, 0.3f, 123 + HD);
+    fill_random_fp16(d_v, kv_elems, 0.3f, 456 + HD);
+
+    int64_t qo_shape[] = {B, SQ, NH, HD};
+    int64_t kv_shape[] = {B, SKV, NKV, HD};
+    float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+
+    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
+    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
+    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+
+    {
+        cudaMemset(d_o_leg, 0, qo_elems * sizeof(half));
+        Tensor O(d_o_leg, DType::FP16, 4, qo_shape, true);
+        bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal,
+                                             sliding_window, softcap, stream,
+                                             /*use_blockscale=*/false);
+        ASSERT_TRUE(ok);
+    }
+    {
+        cudaMemset(d_o_bs, 0, qo_elems * sizeof(half));
+        Tensor O(d_o_bs, DType::FP16, 4, qo_shape, true);
+        bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal,
+                                             sliding_window, softcap, stream,
+                                             /*use_blockscale=*/true);
+        ASSERT_TRUE(ok);
+    }
+
+    cudaStreamSynchronize(stream);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    std::vector<half> h_leg(qo_elems), h_bs(qo_elems);
+    cudaMemcpy(h_leg.data(), d_o_leg, qo_elems * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_bs.data(), d_o_bs, qo_elems * sizeof(half), cudaMemcpyDeviceToHost);
+
+    float max_err, mean_err;
+    compute_errors(h_leg.data(), h_bs.data(), qo_elems, max_err, mean_err);
+
+    std::printf("  [AB] HD=%d SQ=%d SKV=%d causal=%d sw=%d softcap=%.1f: "
+                "max_err=%.4f mean_err=%.6f\n",
+                HD, SQ, SKV, causal, sliding_window, softcap, max_err, mean_err);
+
+    EXPECT_LT(mean_err, mean_err_limit);
+    EXPECT_LT(max_err, max_err_limit);
+
+    cudaFree(d_q); cudaFree(d_k); cudaFree(d_v);
+    cudaFree(d_o_leg); cudaFree(d_o_bs);
+}
+
+TEST_F(FhmaMxFP4Test, Blockscale_MatchesLegacy_HD64) {
+    if (!can_run()) GTEST_SKIP() << "Requires sm_120+";
+    run_blockscale_ab_test(1, 256, 256, 4, 2, 64, true, 0, 0.0f,
+                           0.25f, 0.01f, stream_, sm_);
+}
+
+TEST_F(FhmaMxFP4Test, Blockscale_MatchesLegacy_HD128) {
+    if (!can_run()) GTEST_SKIP() << "Requires sm_120+";
+    run_blockscale_ab_test(1, 256, 256, 4, 2, 128, true, 0, 0.0f,
+                           0.25f, 0.01f, stream_, sm_);
+}
+
+TEST_F(FhmaMxFP4Test, Blockscale_MatchesLegacy_HD128_LongSeq) {
+    if (!can_run()) GTEST_SKIP() << "Requires sm_120+";
+    run_blockscale_ab_test(1, 1024, 1024, 4, 2, 128, true, 0, 0.0f,
+                           0.25f, 0.01f, stream_, sm_);
+}
+
+TEST_F(FhmaMxFP4Test, Blockscale_MatchesLegacy_Softcap) {
+    if (!can_run()) GTEST_SKIP() << "Requires sm_120+";
+    run_blockscale_ab_test(1, 256, 256, 4, 2, 128, true, 0, 50.0f,
+                           0.25f, 0.01f, stream_, sm_);
+}
+
+TEST_F(FhmaMxFP4Test, Blockscale_MatchesLegacy_SlidingWindow) {
+    if (!can_run()) GTEST_SKIP() << "Requires sm_120+";
+    run_blockscale_ab_test(1, 512, 512, 4, 2, 128, true, 64, 0.0f,
+                           0.25f, 0.01f, stream_, sm_);
+}
+
 TEST_F(FhmaMxFP4Test, RejectsHD48) {
     if (!can_run()) GTEST_SKIP() << "Requires sm_120+";
     // HD=48 is not a multiple of 32

--- a/tests/test_mxf4nvf4_mma_variants_bench.cu
+++ b/tests/test_mxf4nvf4_mma_variants_bench.cu
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include "compute/mxf4nvf4_mma_variants_bench.h"
+#include <cuda_runtime.h>
+#include <cstdio>
+
+namespace imp {
+
+TEST(MmaVariantsBench, Compare) {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    constexpr int WARPS = 170;       // matches RTX 5090 SM count
+    constexpr int ITERATIONS = 1 << 20;  // 1M iters per warp
+
+    auto r = bench_mma_variants(WARPS, ITERATIONS, stream);
+
+    std::printf("\n=== sm_120 MMA variant throughput (%d warps × %d iters) ===\n",
+                WARPS, ITERATIONS);
+    std::printf("  %-32s %10s %10s\n", "variant", "ms/run", "TOPS");
+    for (int i = 0; i < r.count; ++i) {
+        if (r.entries[i].tops < 0) {
+            std::printf("  %-32s   FAILED  (kernel could not launch — likely PTX rejection)\n",
+                        r.entries[i].label);
+        } else {
+            std::printf("  %-32s %10.2f %10.2f\n",
+                        r.entries[i].label,
+                        r.entries[i].ms,
+                        r.entries[i].tops);
+        }
+    }
+    std::printf("\n");
+
+    // Diagnostic — none of the variants are required to launch successfully.
+    // The test PASSES regardless. The output reveals which variants are
+    // viable and their relative throughput.
+    SUCCEED();
+
+    cudaStreamDestroy(stream);
+}
+
+} // namespace imp

--- a/tests/test_mxf4nvf4_qkt_validate.cu
+++ b/tests/test_mxf4nvf4_qkt_validate.cu
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cmath>
 #include <cstdio>
+#include <random>
 
 namespace imp {
 namespace {
@@ -83,9 +84,8 @@ TEST(Mxf4nvf4QkTest, UniformInputs_AllOnes) {
     for (int n = 0; n < N; ++n) std::printf("%.2f ", h_D[n]);
     std::printf("\n");
 
-    // Don't assert yet — this is exploratory. If it's 100% right, great.
-    // If not, the correct count + max_err tell us how close.
-    SUCCEED();
+    EXPECT_EQ(correct, total);
+    EXPECT_LT(max_err, 1e-3f);
 }
 
 // Row-indicator test: Q[m][:] = m (so row m has values all equal to m).
@@ -144,17 +144,9 @@ TEST(Mxf4nvf4QkTest, RowIndicator) {
     std::printf("[  INFO    ] D[:][0] rows = ");
     for (int m = 0; m < M; ++m) std::printf("%.1f ", h_D[m * N]);
     std::printf("\n");
-    std::printf("[  INFO    ] Expected    = ");
-    for (int m = 0; m < M; ++m) std::printf("%.1f ", expected_per_row[m]);
-    std::printf("\n");
 
-    // Diagnostic only — documenting layout mismatch. Current B/A operand
-    // mapping passes the uniform-sum test but fails position-identifying
-    // tests, indicating per-thread CUTLASS (T32,V32)→(M16,K64) layout
-    // isn't fully matched yet. Tracked as TODO in Stage 4 kernel.
-    SUCCEED() << "RowIndicator correct=" << correct << "/" << (M*N)
-              << " max_err=" << max_err
-              << " (diagnostic — layout work-in-progress)";
+    EXPECT_EQ(correct, M*N);
+    EXPECT_LT(max_err, 1e-3f);
 }
 
 // Col-indicator test: K[n][:] = n-magnitude (representable E2M1). Q = 1.
@@ -186,13 +178,60 @@ TEST(Mxf4nvf4QkTest, ColIndicator) {
     std::printf("[  INFO    ] D[0][:] cols = ");
     for (int n = 0; n < N; ++n) std::printf("%.1f ", h_D[n]);
     std::printf("\n");
-    std::printf("[  INFO    ] Expected     = ");
-    for (int n = 0; n < N; ++n) std::printf("%.1f ", mag[n] * 64.0f);
-    std::printf("\n");
 
-    SUCCEED() << "ColIndicator correct=" << correct << "/" << (M*N)
-              << " max_err=" << max_err
-              << " (diagnostic — layout work-in-progress)";
+    EXPECT_EQ(correct, M*N);
+    EXPECT_LT(max_err, 1e-3f);
+}
+
+// Random E2M1 inputs. Both Q and K are drawn from the E2M1 magnitude set
+// (scaled so that values stay representable). Compute FP32 reference via
+// a plain triple loop with the on-device quant applied to each value.
+TEST(Mxf4nvf4QkTest, RandomE2M1_Regression) {
+    constexpr int M = 16, K = 64, N = 8;
+    std::mt19937 rng(20260424);
+    std::uniform_int_distribution<int> mag_idx(0, 7);
+    std::bernoulli_distribution sign(0.5);
+    const float mags[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+
+    std::vector<half> h_Q(M * K), h_K(N * K);
+    for (auto& q : h_Q) {
+        float v = mags[mag_idx(rng)] * (sign(rng) ? 1.0f : -1.0f);
+        q = __float2half(v);
+    }
+    for (auto& k : h_K) {
+        float v = mags[mag_idx(rng)] * (sign(rng) ? 1.0f : -1.0f);
+        k = __float2half(v);
+    }
+
+    std::vector<float> h_D;
+    run_and_compare(h_Q, h_K, h_D);
+
+    // FP32 reference: each Q/K element is already E2M1-exact, so the reference
+    // is the plain matmul with those values.
+    std::vector<float> ref(M * N, 0.0f);
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            float acc = 0.0f;
+            for (int k = 0; k < K; ++k) {
+                acc += __half2float(h_Q[m * K + k]) * __half2float(h_K[n * K + k]);
+            }
+            ref[m * N + n] = acc;
+        }
+    }
+
+    int correct = 0;
+    float max_err = 0.0f;
+    for (int i = 0; i < M * N; ++i) {
+        float err = std::fabs(h_D[i] - ref[i]);
+        max_err = std::max(max_err, err);
+        // FP32 accumulator, lossless E2M1 input — exact agreement expected.
+        if (err < 1e-3f) correct++;
+    }
+    std::printf("[  INFO    ] RandomE2M1: correct=%d/%d max_err=%.4f\n",
+                correct, M * N, max_err);
+
+    EXPECT_EQ(correct, M * N);
+    EXPECT_LT(max_err, 1e-3f);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

19-commit FMHA optimization pass on SM120 attention kernels. **+12.6% prefill on Qwen3-4B Q8_0** at pp=8192, **+16.2% on Qwen3-4B MXFP4** at pp=8192 from a fully realized SageAttention3-style hardware block-scale path with 4-issue metaTile pattern.

## Project B — SHIPPED, then optimized further

The `kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64` HW block-scale MMA path is default-on for `IMP_MXFP4_ATTENTION=1`:

1. Verified column-major CuTe operand layout byte-exact (4 QKT tests, 128/128 vs FP32 ref)
2. Integrated MMA with uniform sfa=1.0 (placeholder)
3. Real per-row UE4M3 sfa/sfb (HW scaling, dropped manual post-MMA mult)
4. Per-16-element UE4M3 (SageAttention3 pattern, finer granularity)
5. Default-on; `IMP_FMHA_BLOCKSCALE=0` for legacy A/B
6. Per-16 absmax in HD=256 fallback path (parity on Gemma-4)
7. **2-issue MMA (A-reuse across 2 ci's)** — +2.0% over legacy
8. **4-issue MMA (SageAttention3 metaTile, A-reuse across 4 ci's)** — +2.5% over legacy

## FMHA vectorization

- HW `cvt.rn.satfinite.e2m1x2.f32` replacing SW compare-cascade FP4 quant (7 files)
- HW `cvt_4xfp16_to_4xe4m3` for FP8 quantization
- Vectorized float4 = 8-halves Q/K/V tile loads (FP16 + FP8 + MXFP4 kernels)
- Vectorized float4 O_acc init + packed half2 O writeback
- uint32 packed writes for MXFP4 Q/K FP4-pack loops

## Final perf (RTX 5090)

| Model | Setting | Tokens | Baseline | Now | Δ |
|-------|---------|--------|----------|-----|---|
| Qwen3-4B Q8_0 | default | pp4096 | ~13800 | 14859 | ~+8% |
| Qwen3-4B Q8_0 | default | pp8192 | 12942 | 14572 | **+12.6%** |
| Qwen3-8B Q8_0 | default | pp4096 | ~10500 | 11915 | ~+13% |
| Llama-3.2-3B Q8_0 | default | pp4096 | ~21200 | 23256 | ~+10% |
| **Qwen3-4B MXFP4** | IMP_MXFP4_ATTENTION=1 | pp8192 | 9676 | **11244** | **+16.2%** |
| Qwen3-4B MXFP4 (BLOCKSCALE=0) | legacy | pp8192 | 9676 | 10966 | +13.3% |
| Gemma-4 Q4_K_M HD=256 | IMP_MXFP4_ATTENTION=1 | pp2048 | ~1604 | ~1610 | parity |
| Decode (any) | default | tg256 | same | same | 0% |

Decode unchanged — FMHA is prefill-only; decode uses paged attention.

## Test plan

- [x] Full regression: 610/629 pass (0 fail, 19 skipped model-dependent)
- [x] 4 new QKT layout tests (128/128 byte-exact vs FP32 reference)
- [x] 5 new Blockscale_MatchesLegacy A/B tests (max_err < 0.25, mean_err < 0.01)
- [x] Multi-prompt coherence test on 3 Q8_0 models (~2500 tok prompts)
- [x] Multi-turn chat: context retention + correct multi-step computation
- [x] Seed-42 reproducibility on Qwen3-4B MXFP4 ("The capital of France is Paris.")
- [x] Gemma-4 HD=256 path verified parity (no regression on mixed-HD models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)