### PR TITLE
runtime: fix Qwen3.5 GDN Q8_0 α/β qtype mismatch (state collapse)

### DIFF
--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -724,7 +724,7 @@ struct UploadCtx {
 static bool upload_embeddings_and_output(
         Tensor& tok_emb, GGMLQuantType& tok_emb_qtype,
         Tensor& out_norm, GGMLQuantType out_norm_qtype,
-        Tensor& out_proj, GGMLQuantType out_proj_qtype,
+        Tensor& out_proj, GGMLQuantType& out_proj_qtype,
         const UploadCtx& ctx) {
     // Upload token embedding
     // Embedding lookup only supports Q8_0/Q6_K natively; other quant types
@@ -777,6 +777,12 @@ static bool upload_embeddings_and_output(
                                            /*raw_quant=*/raw_ok)) {
                 IMP_LOG_ERROR("Failed to upload output projection");
                 return false;
+            }
+            // Mirror tok_emb: if upload host-dequanted to FP16, update the qtype
+            // so downstream LM-head dispatch uses the FP16 path instead of
+            // re-interpreting the FP16 bytes as the original quant block format.
+            if (!raw_ok && out_proj.dtype == DType::FP16) {
+                out_proj_qtype = GGMLQuantType::F16;
             }
         }
     }

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1066,23 +1066,25 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i,
         }
     }
 
-    // Gated DeltaNet (GDN) weights (Qwen3.5)
+    // Gated DeltaNet (GDN) weights (Qwen3.5).
+    // GDN alpha/beta: dispatched via gemm_dispatch like every other quantized
+    // weight. Earlier code used raw_quant=false to pre-dequant to FP16 on host,
+    // but upload_weight() does not update L.gdn_*_qtype after conversion, so
+    // gemm_dispatch still saw qtype=Q8_0 and re-interpreted the FP16 bytes as
+    // Q8_0 blocks → ~80× too-large alpha/beta and immediate state collapse.
+    // Uploading raw Q8_0 keeps the qtype consistent with the bytes on device.
+    Tensor gdn_dummy_scales;
     if (L.gdn_gate.data && !L.gdn_gate.on_device) {
-        Tensor dummy_scales;
-        UPLOAD_OR_FAIL(L.gdn_gate, L.gdn_gate_qtype, dummy_scales,
+        UPLOAD_OR_FAIL(L.gdn_gate, L.gdn_gate_qtype, gdn_dummy_scales,
                        "gdn_gate", i, ctx);
     }
-    // GDN alpha/beta: used in direct gemm() for small projections.
-    // Must be FP16 on device (NOT raw quantized) for cuBLAS GEMM.
     if (L.gdn_alpha.data && !L.gdn_alpha.on_device) {
-        Tensor dummy_scales;
-        UPLOAD_OR_FAIL_RAW(L.gdn_alpha, L.gdn_alpha_qtype, dummy_scales,
-                           /*raw_quant=*/false, "gdn_alpha", i, ctx);
+        UPLOAD_OR_FAIL(L.gdn_alpha, L.gdn_alpha_qtype, gdn_dummy_scales,
+                       "gdn_alpha", i, ctx);
     }
     if (L.gdn_beta.data && !L.gdn_beta.on_device) {
-        Tensor dummy_scales;
-        UPLOAD_OR_FAIL_RAW(L.gdn_beta, L.gdn_beta_qtype, dummy_scales,
-                           /*raw_quant=*/false, "gdn_beta", i, ctx);
+        UPLOAD_OR_FAIL(L.gdn_beta, L.gdn_beta_qtype, gdn_dummy_scales,
+                       "gdn_beta", i, ctx);
     }
 
     return true;


### PR DESCRIPTION
## Summary

- `upload_weight()` for `gdn_alpha` / `gdn_beta` ran with `raw_quant=false`, which host-dequants Q8_0 → FP16 and overwrites `weight.data`, but **never updates `L.gdn_*_qtype`**. `gemm_dispatch` then saw `qtype=Q8_0` and re-interpreted the FP16 bytes as Q8_0 blocks → ~80× too-large α/β projection → `g_t = exp(A_h * softplus(±300))` collapses to 0/1, recurrent state decays in 2-3 tokens, output degenerates to `" the the the …"`.
- Fix: drop the `_RAW(false)` carve-out so α/β upload like every other Q8_0 weight (raw blocks on GPU, qtype consistent, dispatcher routes correctly).

## Why earlier launch_bounds and partial-RoPE fixes weren't enough

Both were real bugs in their own right but masked the qtype mismatch via "different garbage patterns." The α/β output magnitude (~80× expected) only showed up after layer dumps, and was traced to upload by comparing imp's GPU bytes against `gguf-py.dequantize()` — they didn't match, isolating the bug to the upload pipeline.

## Test plan

- [x] `imp-cli` reproduction pre-fix collapses to `" the the the …"`
- [x] Same prompt post-fix: `", 1900. The world is on the brink of a great change. The Industrial Revolution has brought about unprecedented advancements in technology, but"`
- [x] Qwen3.5-9B Q8_0 same fix, coherent: `" in a magical land of numbers, there lived a group of little number friends. One day, they decided to play a fun game…"`
- [x] Qwen3.6-35B Q4_K_M (regression check): still emits "Paris."
- [x] `imp-tests --gtest_brief=1`: 79/94 pass, 15 skipped (model-dependent)
- [x] `DegenerationTest`: 4/4 pass
- [x] `GDNModelTest` with `IMP_TEST_MODEL_GDN=/models/Qwen3.5-4B-Q8_0.gguf`: 2/2 pass (`GenerateCoherentOutput`, `MultiTurnGDNState`)

## Performance after fix (RTX 5090, default flags)

| Model | pp512 | tg256 |
|---|---|---|
| Qwen3.5-4B Q8_0 | 13676 | **220** |
| Qwen3.5-9B Q8_0 | 9483 | **140** |
| Qwen3.6-35B Q4_K_M (overhead_pct=10) | 1762 | 235 (no regression) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)