### PR TITLE
feat(loader): Mistral3 NVFP4 prefix + config_groups recipe (Phase 2 Item 1)

### DIFF
--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -17,6 +17,7 @@ ModelArch HFConfigLoader::map_architecture(const std::string& hf_arch) {
     static const std::unordered_map<std::string, ModelArch> arch_map = {
         {"LlamaForCausalLM",        ModelArch::LLAMA},
         {"MistralForCausalLM",      ModelArch::MISTRAL},
+        {"Mistral3ForConditionalGeneration", ModelArch::MISTRAL},
         {"MixtralForCausalLM",      ModelArch::MIXTRAL},
         {"Qwen2ForCausalLM",        ModelArch::QWEN3},
         {"Qwen2MoeForCausalLM",     ModelArch::QWEN3_MOE},

--- a/src/model/llm_compressor_loader.cpp
+++ b/src/model/llm_compressor_loader.cpp
@@ -91,8 +91,13 @@ std::vector<std::string> parse_bracket_array(std::string_view body) {
 NameTranslation translate_name(const std::string& in, TranslationCounters& counters) {
     std::string out = in;
 
-    // Step 1: skip patterns (vision tower) — check raw input before any mutation.
-    if (starts_with(out, "model.vision_tower.") || starts_with(out, "model.visual.")) {
+    // Step 1: skip patterns (vision tower / multimodal projector). Cover both
+    // the Gemma-4 nesting (model.vision_tower.*) and the Mistral3-style raw
+    // top-level layout (vision_tower.* / multi_modal_projector.*).
+    if (starts_with(out, "model.vision_tower.") ||
+        starts_with(out, "model.visual.") ||
+        starts_with(out, "vision_tower.") ||
+        starts_with(out, "multi_modal_projector.")) {
         counters.vision_skipped++;
         return {NameTranslation::SKIP, ""};
     }
@@ -112,13 +117,23 @@ NameTranslation translate_name(const std::string& in, TranslationCounters& count
         // else fall through (pass-through handles it).
     }
 
-    // Step 3: prefix strip (multimodal language_model wrapper).
-    static constexpr const char kMultimodalPrefix[] = "model.language_model.";
-    static constexpr size_t kMultimodalPrefixLen = sizeof(kMultimodalPrefix) - 1;
-    if (starts_with(out, kMultimodalPrefix)) {
-        out = "model." + out.substr(kMultimodalPrefixLen);
+    // Step 3: prefix strip. Two multimodal wrappers seen in the wild:
+    //   (a) Gemma-4-style: `model.language_model.<rest>` → `model.<rest>`
+    //   (b) Mistral3-style: `language_model.<rest>` → `<rest>` (so e.g.
+    //       `language_model.model.layers.0.q.weight_packed` becomes
+    //       `model.layers.0.q.weight_packed`, and `language_model.lm_head.weight`
+    //       becomes `lm_head.weight`).
+    // (a) wins when both could match because it is a strict superset prefix.
+    static constexpr const char kGemma4Prefix[] = "model.language_model.";
+    static constexpr size_t kGemma4PrefixLen = sizeof(kGemma4Prefix) - 1;
+    static constexpr const char kMistral3Prefix[] = "language_model.";
+    static constexpr size_t kMistral3PrefixLen = sizeof(kMistral3Prefix) - 1;
+    if (starts_with(out, kGemma4Prefix)) {
+        out = "model." + out.substr(kGemma4PrefixLen);
         counters.prefix_strips++;
-        // Continue to suffix-rename step below.
+    } else if (starts_with(out, kMistral3Prefix)) {
+        out = out.substr(kMistral3PrefixLen);
+        counters.prefix_strips++;
     }
 
     // Step 4: suffix renames (mutually exclusive).
@@ -150,6 +165,17 @@ void log_summary(const TranslationCounters& c) {
                  c.passed_through);
 }
 
+// Count leading spaces (tabs counted as 4) to track YAML block scope.
+static int count_indent(const std::string& line) {
+    int n = 0;
+    for (char c : line) {
+        if (c == ' ') n++;
+        else if (c == '\t') n += 4;
+        else break;
+    }
+    return n;
+}
+
 bool parse_recipe_yaml(const std::string& model_dir,
                        imp::HFConfigLoader::NvFP4Config& cfg) {
     std::ifstream in(model_dir + "/recipe.yaml");
@@ -159,18 +185,89 @@ bool parse_recipe_yaml(const std::string& model_dir,
     std::vector<std::string> ignore_list;
     bool seen_quant_mod = false;
 
+    // Indent-aware tracking for the elaborate `config_groups: group_0: weights: {...}`
+    // schema (Mistral3 / SmoothQuant pipelines). When weights_indent >= 0 we are
+    // inside the `weights:` block of `config_groups.group_0` and capture the
+    // numeric quantization signature.
+    int config_groups_indent = -1;
+    int weights_indent = -1;
+    int weights_num_bits = -1;
+    std::string weights_type;
+    int weights_group_size = -1;
+
+    // Multi-line bracket-array accumulator for `ignore: [..., ..., \n  ...]`.
+    std::string ignore_buf;
+    bool collecting_ignore = false;
+
     std::string line;
     while (std::getline(in, line)) {
+        if (collecting_ignore) {
+            ignore_buf.push_back(' ');
+            ignore_buf.append(line);
+            if (ignore_buf.find(']') != std::string::npos) {
+                ignore_list = parse_bracket_array(ignore_buf);
+                collecting_ignore = false;
+                ignore_buf.clear();
+            }
+            continue;
+        }
+
+        int indent = count_indent(line);
         std::string_view sv(line);
         while (!sv.empty() && (sv.front() == ' ' || sv.front() == '\t')) sv.remove_prefix(1);
 
-        if (sv.find("QuantizationModifier:") == 0) { seen_quant_mod = true; continue; }
+        // Indent-based exits — only fire on non-empty content lines so blank
+        // lines don't bogusly close a block.
+        if (!sv.empty()) {
+            if (weights_indent >= 0 && indent <= weights_indent) {
+                weights_indent = -1;
+            }
+            if (config_groups_indent >= 0 && indent <= config_groups_indent) {
+                config_groups_indent = -1;
+                weights_indent = -1;
+            }
+        }
+
+        if (sv.find("QuantizationModifier:") == 0) {
+            seen_quant_mod = true;
+            // A new modifier block resets any prior config_groups state.
+            config_groups_indent = -1;
+            weights_indent = -1;
+            continue;
+        }
         if (!seen_quant_mod) continue;
+
+        if (sv.find("config_groups:") == 0) {
+            config_groups_indent = indent;
+            continue;
+        }
+        if (config_groups_indent >= 0 && sv.find("weights:") == 0) {
+            weights_indent = indent;
+            continue;
+        }
+
+        if (weights_indent >= 0) {
+            if (sv.find("num_bits:") == 0) {
+                try { weights_num_bits = std::stoi(trim_value(sv.substr(9))); } catch (...) {}
+            } else if (sv.find("type:") == 0) {
+                weights_type = trim_value(sv.substr(5));
+            } else if (sv.find("group_size:") == 0) {
+                try { weights_group_size = std::stoi(trim_value(sv.substr(11))); } catch (...) {}
+            }
+            continue;
+        }
 
         if (sv.find("scheme:") == 0) {
             scheme = trim_value(sv.substr(7));
         } else if (sv.find("ignore:") == 0) {
-            ignore_list = parse_bracket_array(sv.substr(7));
+            std::string body(sv.substr(7));
+            if (body.find('[') != std::string::npos &&
+                body.find(']') == std::string::npos) {
+                ignore_buf = std::move(body);
+                collecting_ignore = true;
+            } else {
+                ignore_list = parse_bracket_array(body);
+            }
         } else if (sv.find("group_size:") == 0) {
             try { cfg.group_size = std::stoi(trim_value(sv.substr(11))); }
             catch (...) { /* keep default */ }
@@ -181,6 +278,14 @@ bool parse_recipe_yaml(const std::string& model_dir,
         IMP_LOG_ERROR("recipe.yaml has no QuantizationModifier block");
         return false;
     }
+
+    // If no simple `scheme:` line appeared, infer NVFP4 from the elaborate
+    // `config_groups.group_0.weights.{num_bits: 4, type: float}` shape.
+    if (scheme.empty() && weights_num_bits == 4 && weights_type == "float") {
+        scheme = "NVFP4";
+        if (weights_group_size > 0) cfg.group_size = weights_group_size;
+    }
+
     if (scheme != "NVFP4" && scheme != "NVFP4_W4A16") {
         IMP_LOG_ERROR("recipe.yaml scheme '%s' not supported (need NVFP4 or NVFP4_W4A16)",
                       scheme.c_str());

--- a/tests/test_e2e_llm_compressor.cpp
+++ b/tests/test_e2e_llm_compressor.cpp
@@ -77,29 +77,22 @@ TEST_F(LlmCompressorE2E, Gemma4_GeneratesNonEmptyOutput) {
     imp_model_free(model);
 }
 
-// Mistral-Small was intended as the dense coherence gate for Phase 1, but
-// RedHatAI/Mistral-Small-3.2-24B-Instruct-2506-NVFP4 is actually
-// Mistral3ForConditionalGeneration (multimodal Mistral with vision_tower)
-// and uses two format wrinkles outside Phase 1 scope:
-//   1. Tensor prefix `language_model.model.layers.*` (not `model.language_model.*`
-//      like Gemma-4). Phase 1 prefix-strip rule does not match.
-//   2. recipe.yaml uses the elaborate config_groups schema
-//      (`config_groups: group_0: weights: {num_bits: 4, type: float}`) instead of
-//      `scheme: NVFP4`. Phase 1 mini-parser does not recognize this.
-//
-// Both issues are tractable but qualify as Phase 2 work. Test is left in
-// place (skipped) so the regression marker remains for when those fixes land.
-// Real coherence validation in Phase 1 falls back to the Modelopt regression
-// test below (proves we did not regress the existing modelopt path).
-TEST_F(LlmCompressorE2E, DISABLED_MistralSmall_LoadsAndGeneratesCoherent) {
+// Mistral3 dense coherence gate. Mistral-Small-3.2 is multimodal
+// (Mistral3ForConditionalGeneration), but with vision_tower / multi_modal_projector
+// tensors skipped at load time the language model alone runs as a standard
+// dense LLM. Phase 2 added two pieces to make this work:
+//   1. translate_name() now strips the Mistral3-style `language_model.` prefix
+//      (`language_model.model.layers.0.q.weight_packed` →
+//       `model.layers.0.q.weight_packed`), and skips raw `vision_tower.*` /
+//      `multi_modal_projector.*` (no `model.` wrapper) at the top level.
+//   2. parse_recipe_yaml() recognizes the elaborate
+//      `config_groups: group_0: weights: {num_bits: 4, type: float}` schema as
+//      NVFP4, and handles the multi-line bracket-array `ignore: [...]` form.
+TEST_F(LlmCompressorE2E, MistralSmall_LoadsAndGeneratesCoherent) {
     if (!dir_exists(kMistralDir)) {
         GTEST_SKIP() << "Model not present at " << kMistralDir;
     }
-    GTEST_SKIP() << "Phase 2 — Mistral3 multimodal (language_model.model.* prefix + "
-                    "config_groups recipe schema) not handled by Phase 1 loader";
 
-    // Body retained for re-enablement once Phase 2 lands the prefix +
-    // parser extensions:
     ImpModel model = nullptr;
     ASSERT_EQ(imp_model_load(kMistralDir, IMP_FORMAT_SAFETENSORS, &model), IMP_SUCCESS);
     ImpConfig cfg = imp_config_default();
@@ -117,7 +110,8 @@ TEST_F(LlmCompressorE2E, DISABLED_MistralSmall_LoadsAndGeneratesCoherent) {
     ASSERT_EQ(imp_generate(ctx, "The capital of France is", &params,
                            output, sizeof(output), &len), IMP_SUCCESS);
     std::string result(output, len);
-    EXPECT_NE(result.find("Paris"), std::string::npos);
+    EXPECT_NE(result.find("Paris"), std::string::npos)
+        << "Generated text: " << result;
     imp_context_free(ctx);
     imp_model_free(model);
 }

--- a/tests/test_llm_compressor_loader.cpp
+++ b/tests/test_llm_compressor_loader.cpp
@@ -94,6 +94,60 @@ TEST(LlmCompressorTranslate, DoesNotSkipProjScale) {
     EXPECT_EQ(c.gemma4_extra_skipped, 0);
 }
 
+// Mistral3 layout: `language_model.model.layers.*` (no leading `model.`).
+// Strip the `language_model.` wrapper entirely so the rest matches imp's
+// canonical `model.layers.*` naming.
+TEST(LlmCompressorTranslate, StripsMistral3LanguageModelPrefix) {
+    TranslationCounters c{};
+    auto t = translate_name(
+        "language_model.model.layers.0.self_attn.q_proj.weight_packed", c);
+    EXPECT_EQ(t.action, NameTranslation::EMIT);
+    EXPECT_EQ(t.out_name, "model.layers.0.self_attn.q_proj.weight");
+    EXPECT_EQ(c.suffix_renames, 1);
+    EXPECT_EQ(c.prefix_strips, 1);
+}
+
+// Mistral3 stores lm_head directly under `language_model.` (not under
+// `language_model.model.`). After strip → `lm_head.weight` (top-level), which
+// is the canonical name imp expects for the output projection.
+TEST(LlmCompressorTranslate, StripsMistral3LmHead) {
+    TranslationCounters c{};
+    auto t = translate_name("language_model.lm_head.weight", c);
+    EXPECT_EQ(t.action, NameTranslation::EMIT);
+    EXPECT_EQ(t.out_name, "lm_head.weight");
+    EXPECT_EQ(c.prefix_strips, 1);
+    EXPECT_EQ(c.passed_through, 1);
+}
+
+// Gemma-4-style nesting MUST take precedence over the Mistral3-style strip
+// (the Gemma-4 prefix `model.language_model.` is a strict superset of
+// `language_model.`, so order matters).
+TEST(LlmCompressorTranslate, Gemma4PrefixStillWinsOverMistral3) {
+    TranslationCounters c{};
+    auto t = translate_name(
+        "model.language_model.layers.0.self_attn.q_proj.weight_packed", c);
+    EXPECT_EQ(t.action, NameTranslation::EMIT);
+    EXPECT_EQ(t.out_name, "model.layers.0.self_attn.q_proj.weight");
+    EXPECT_EQ(c.prefix_strips, 1);
+}
+
+// Mistral3 vision tower at top level (no `model.` wrapper).
+TEST(LlmCompressorTranslate, SkipsRawVisionTower) {
+    TranslationCounters c{};
+    auto t = translate_name("vision_tower.transformer.layers.0.attention.q.weight", c);
+    EXPECT_EQ(t.action, NameTranslation::SKIP);
+    EXPECT_EQ(c.vision_skipped, 1);
+}
+
+// Multimodal projector tensors connect vision → language; we skip them in
+// Phase 2 (full multimodal support is a separate Phase 3 effort).
+TEST(LlmCompressorTranslate, SkipsMultiModalProjector) {
+    TranslationCounters c{};
+    auto t = translate_name("multi_modal_projector.linear_1.weight", c);
+    EXPECT_EQ(t.action, NameTranslation::SKIP);
+    EXPECT_EQ(c.vision_skipped, 1);
+}
+
 #include <fstream>
 #include <cstdlib>
 #include <unistd.h>
@@ -174,6 +228,67 @@ TEST(LlmCompressorRecipe, ReturnsFalseOnMissingFile) {
     imp::HFConfigLoader::NvFP4Config cfg;
     bool ok = imp::llm_compressor::parse_recipe_yaml("/tmp/nonexistent_dir_xyz", cfg);
     EXPECT_FALSE(ok);
+}
+
+// Mistral3-style recipe: no `scheme:` line; NVFP4 is implicit in the
+// `config_groups.group_0.weights.{num_bits: 4, type: float}` schema. Also
+// exercises multi-line bracket-array `ignore:` parsing.
+TEST(LlmCompressorRecipe, ParsesConfigGroupsSchema) {
+    std::string dir = write_temp_recipe(R"(default_stage:
+  default_modifiers:
+    SmoothQuantModifier:
+      smoothing_strength: 0.9
+      mappings: []
+    QuantizationModifier:
+      config_groups:
+        group_0:
+          targets: [Linear]
+          weights:
+            num_bits: 4
+            type: float
+            symmetric: true
+            group_size: 16
+            strategy: tensor_group
+          input_activations:
+            num_bits: 4
+            type: float
+            group_size: 16
+          output_activations: null
+          format: null
+      targets: [Linear]
+      ignore: ['re:.*lm_head.*', 're:.*multi_modal_projector.*', 're:.*vision_tower.*', 're:.*model.norm.*',
+        're:.*embed_tokens.*']
+)");
+    imp::HFConfigLoader::NvFP4Config cfg;
+    bool ok = imp::llm_compressor::parse_recipe_yaml(dir, cfg);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(cfg.group_size, 16);
+    ASSERT_EQ(cfg.exclude_modules.size(), 5u);
+    EXPECT_EQ(cfg.exclude_modules[0], "re:.*lm_head.*");
+    EXPECT_EQ(cfg.exclude_modules[4], "re:.*embed_tokens.*");
+    cleanup_temp_recipe(dir);
+}
+
+// Make sure config_groups detection doesn't false-positive on non-NVFP4
+// numeric signatures (e.g. W8A8: num_bits=8, type=int).
+TEST(LlmCompressorRecipe, RejectsConfigGroupsW8A8) {
+    std::string dir = write_temp_recipe(R"(default_stage:
+  default_modifiers:
+    QuantizationModifier:
+      config_groups:
+        group_0:
+          targets: [Linear]
+          weights:
+            num_bits: 8
+            type: int
+            group_size: 128
+      targets: [Linear]
+      ignore: [lm_head]
+)");
+    imp::HFConfigLoader::NvFP4Config cfg;
+    bool ok = imp::llm_compressor::parse_recipe_yaml(dir, cfg);
+    EXPECT_FALSE(ok);
+    cleanup_temp_recipe(dir);
 }
 
 TEST(LlmCompressorFormatDetect, PrefersModeloptWhenBothPresent) {


### PR DESCRIPTION
## Summary

Phase 2 Item 1 of the [llm-compressor NVFP4 loader backlog](docs/llm-compressor-validation-results.md#phase-2-backlog-priority-ordered) — reactivates the previously `DISABLED_MistralSmall_LoadsAndGeneratesCoherent` regression marker. `RedHatAI/Mistral-Small-3.2-24B-Instruct-2506-NVFP4` now loads and emits coherent output on RTX 5090 (sm_120f) at **tg ≈ 81 tok/s decode**.

Three pieces:

1. **`translate_name()`** — strip the Mistral3-style `language_model.` prefix (no leading `model.`), so `language_model.model.layers.0.q.weight_packed` → `model.layers.0.q.weight`, and `language_model.lm_head.weight` → `lm_head.weight`. The Gemma-4-style `model.language_model.` strip wins when both could match (strict superset). Also skip raw `vision_tower.*` / `multi_modal_projector.*` (Mistral3 stores those at the top level without a `model.` wrapper).

2. **`parse_recipe_yaml()`** — recognize the elaborate `config_groups: group_0: weights: {num_bits: 4, type: float, group_size: N}` schema as NVFP4. Indent-aware tracking gates the inference so `num_bits` from `input_activations:` (W4A4) doesn't pollute the weights signal, and non-NVFP4 numeric shapes (W8A8) are rejected. Also handles multi-line bracket-array `ignore: [...]` since Mistral3 recipes wrap the list.

3. **`hf_config_loader`** — add `Mistral3ForConditionalGeneration` → `ModelArch::MISTRAL` to the arch_map. `text_config` nesting was already handled, so this one-line addition is all the LLM-side wiring needs.

Greedy "The capital of France is" → _"Paris. It is the capital of France. It is located in the north of the country, on the river Seine, at the heart of the Île-de…"_

## Test plan

- [x] `test-core --gtest_filter="LlmCompressor*"` — 25 pass (18 prior + 7 new translate/recipe scenarios)
- [x] `test-e2e --gtest_filter="LlmCompressorE2E.*"` — 4/4 pass:
  - `Gemma4_LoadsWithoutIMA` ✅
  - `Gemma4_GeneratesNonEmptyOutput` ✅
  - `MistralSmall_LoadsAndGeneratesCoherent` ✅ (re-enabled, ~7 s)
  - `Modelopt_QwenCoder30B_StillWorks` ✅ (regression gate held)
- [x] Manual coherence + perf check on Mistral-Small-3.2-24B-NVFP4: pp 143 tok/s, tg 81 tok/s, real factual continuation about Paris

## Phase 2 backlog still open

- Custom Gemma-4 `layer_scalar` / `per_expert_scale` / `scale` multiplier kernel (R1 — Gemma-4 NVFP4 incoherent because skipped scales are load-bearing). ~2-3 days.
- W4A16 fallback path validation (~0.5 day).
- GDN+NVFP4 integration (~5-7 days).
- Multimodal/vision support (~2-3 weeks).
- `convert_scales_sfatom` fusion + SFA pointer cache (~1-2 days, NVFP4 MoE decode perf, separate spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)