### PR TITLE
feat(loader): emit Gemma-4 NVFP4 scaling extras (Phase 2 Item 2, partial)

### DIFF
--- a/src/compute/weight_dispatch.cu
+++ b/src/compute/weight_dispatch.cu
@@ -83,17 +83,18 @@ void gemm_dispatch(cublasLtHandle_t, const WeightHandle& w,
             NvFP4QuantResult tmp;
             tmp.packed_data  = w.payload.nvfp4.data;
             tmp.micro_scales = w.payload.nvfp4.block_scales;
-            // tensor_scale: if the payload carries a device ptr read it back;
-            // otherwise fall back to 1.0f (known limitation of phase-2 shim).
-            if (w.payload.nvfp4.tensor_scale != nullptr) {
-                cudaMemcpyAsync(&tmp.tensor_scale, w.payload.nvfp4.tensor_scale,
-                                sizeof(float), cudaMemcpyDeviceToHost, stream);
-                cudaStreamSynchronize(stream);
-            } else {
-                tmp.tensor_scale = 1.0f;
-            }
+            // tensor_scale: payload.nvfp4.tensor_scale is a HOST float pointer
+            // borrowed from the wcache_.nvfp4 entry (stable address). Read it
+            // directly — using cudaMemcpyDeviceToHost on a host pointer is
+            // undefined and silently corrupts the scale.  This was the Phase-1
+            // fix in executor_pre_dequant.cu / executor_ffn.cu / etc.; this
+            // dispatch path was missed.
+            tmp.tensor_scale = (w.payload.nvfp4.tensor_scale != nullptr)
+                              ? *w.payload.nvfp4.tensor_scale : 1.0f;
             tmp.N = w.shape[0];
-            tmp.K = w.shape[1];
+            // shape[1] holds the PACKED column count (K/2 for FP4).  Logical K
+            // is 2x that — the kernel needs the logical dimension.
+            tmp.K = w.shape[1] * 2;
 
             int M = static_cast<int>(x.shape[0]);
             if (M == 1) {
@@ -298,15 +299,13 @@ void gemv_dispatch(const WeightHandle& w, const Tensor& x, Tensor& y,
             NvFP4QuantResult tmp;
             tmp.packed_data  = w.payload.nvfp4.data;
             tmp.micro_scales = w.payload.nvfp4.block_scales;
-            if (w.payload.nvfp4.tensor_scale != nullptr) {
-                cudaMemcpyAsync(&tmp.tensor_scale, w.payload.nvfp4.tensor_scale,
-                                sizeof(float), cudaMemcpyDeviceToHost, stream);
-                cudaStreamSynchronize(stream);
-            } else {
-                tmp.tensor_scale = 1.0f;
-            }
+            // tensor_scale: HOST pointer borrowed from wcache_.nvfp4 — read
+            // directly. cudaMemcpyDeviceToHost on a host pointer is undefined.
+            tmp.tensor_scale = (w.payload.nvfp4.tensor_scale != nullptr)
+                              ? *w.payload.nvfp4.tensor_scale : 1.0f;
             tmp.N = w.shape[0];
-            tmp.K = w.shape[1];
+            // shape[1] holds packed K/2 for FP4; kernel needs logical K.
+            tmp.K = w.shape[1] * 2;
             gemv_nvfp4_kpar(tmp,
                             reinterpret_cast<const half*>(x.data),
                             reinterpret_cast<half*>(y.data),

--- a/src/graph/executor.cu
+++ b/src/graph/executor.cu
@@ -242,6 +242,24 @@ std::vector<int32_t> GraphExecutor::sample_from_logits(const Tensor& logits,
         } else if (st.json_constrainer) {
             st.json_constrainer->apply_mask(lp, vocab, stream);
         }
+        // Ban special tokens (chat template delimiters etc.). MUST happen
+        // before sampling — without this, greedy can pick a banned token
+        // (e.g. Gemma-4 NVFP4 picks `<|channel>` as the natural argmax) and
+        // the request finishes immediately because is_stop_token treats banned
+        // tokens as stop tokens. forward() (line 88) already does this; the
+        // sample_from_logits / sample_single_from_logits / use_event_sync
+        // prefill paths historically forgot to. Match forward()'s impl.
+        if (st.banned_tokens != nullptr && st.n_banned_tokens > 0) {
+            float neg_inf = -1e30f;
+            for (int bi = 0; bi < st.n_banned_tokens; bi++) {
+                int32_t tid = st.banned_tokens[bi];
+                if (tid >= 0 && tid < vocab) {
+                    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(
+                        lp + tid, &neg_inf, sizeof(float),
+                        cudaMemcpyHostToDevice, stream));
+                }
+            }
+        }
         if (st.min_p > 0.0f) {
             apply_min_p(lp, vocab, st.min_p, stream);
         }

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1612,17 +1612,28 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             int N_dim = static_cast<int>(nw.N);
             int K_dim = static_cast<int>(nw.K);
             int M = static_cast<int>(a.shape[0]);
+
             if (M == 1) {
-                // Single-token decode: direct NVFP4 GEMV
+                // Single-token decode: direct NVFP4 GEMV (verified coherent).
                 gemv_nvfp4_kpar(nw, static_cast<const half*>(a.data),
                                static_cast<half*>(c.data), N_dim, K_dim, stream);
             } else {
-                // Multi-token: per-row GEMV (each row is one token)
-                for (int r = 0; r < M; r++) {
-                    const half* a_row = static_cast<const half*>(a.data) + r * K_dim;
-                    half* c_row = static_cast<half*>(c.data) + r * N_dim;
-                    gemv_nvfp4_kpar(nw, a_row, c_row, N_dim, K_dim, stream);
-                }
+                // Multi-token (legacy MoE prefill): the per-row gemv_nvfp4_kpar
+                // loop produces wrong output on Gemma-4 NVFP4 experts even though
+                // it works for Mistral dense decode at the same kernel/dimensions
+                // (see commit message + memory/llm_compressor_phase2_item2…). The
+                // dense-path mirror — gemm_nvfp4 (NVFP4 → FP16 dequant + cuBLAS
+                // gemm) — is correct on Gemma-4 and is what Mistral dense prefill
+                // already uses, so route the multi-token expert prefill through
+                // it. Bisected via IMP_EXPERT_NVFP4_DEQUANT_MR=1 on 2026-04-27:
+                // M=1 on gemv_kpar + M>1 on gemm_nvfp4 → "The capital of France
+                // is Paris."; M>1 on gemv_kpar → token-stuck loop.
+                int64_t a_shape[2] = {static_cast<int64_t>(M), static_cast<int64_t>(K_dim)};
+                int64_t c_shape[2] = {static_cast<int64_t>(M), static_cast<int64_t>(N_dim)};
+                Tensor a_t(const_cast<void*>(static_cast<const void*>(a.data)),
+                           DType::FP16, 2, a_shape, true);
+                Tensor c_t(c.data, DType::FP16, 2, c_shape, true);
+                gemm_nvfp4(nw, a_t, c_t, stream);
             }
             return;
         }

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1972,7 +1972,9 @@ moe_after_experts:
     }
 
     // Shared expert: enabled by default. Gemma 4: requires post_ffw_norm_1 to be uploaded.
-    if (ly.w_up_shared.data != nullptr) {
+    // DIAGNOSTIC: IMP_NO_SHARED_MLP=1 skips this branch (Gemma-4 NVFP4 audit).
+    static const bool s_no_shared_mlp = (getenv("IMP_NO_SHARED_MLP") != nullptr);
+    if (ly.w_up_shared.data != nullptr && !s_no_shared_mlp) {
         int eff_shared = static_cast<int>(ly.w_up_shared.shape[0]);
         bool shared_gated = (ly.w_gate_shared.data != nullptr);
 

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -145,6 +145,17 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // Configure shared workspace for MoE phase
     configure_moe_workspace(shared_workspace_max_tokens_);
 
+    // DIAGNOSTIC (Phase 2 Item 2 follow-up): zero MoE workspace buffers so any
+    // legacy-serial-fallback uninit reads become deterministic zero reads.
+    // Set IMP_MOE_ZERO_WORKSPACE=1 to enable. Cheap (~1 MiB total memset).
+    if (getenv("IMP_MOE_ZERO_WORKSPACE")) {
+        cudaMemsetAsync(moe_.expert_gate.data, 0, moe_.expert_gate.nbytes(), stream);
+        cudaMemsetAsync(moe_.expert_up.data, 0, moe_.expert_up.nbytes(), stream);
+        cudaMemsetAsync(moe_.expert_swiglu.data, 0, moe_.expert_swiglu.nbytes(), stream);
+        cudaMemsetAsync(moe_.expert_down.data, 0, moe_.expert_down.nbytes(), stream);
+        cudaMemsetAsync(moe_.gathered.data, 0, moe_.gathered.nbytes(), stream);
+    }
+
     const auto& cfg = model_->config();
     const auto& ly  = model_->layer(layer);
 

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -244,6 +244,28 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
                     is_swa ? cfg.n_kv_heads
                            : (num_global_kv > 0 ? num_global_kv : cfg.n_kv_heads));
             }
+            // Scalar head_dim = max(per-layer head_dim) so KV-cache buffers and
+            // attention workspace are sized for the *largest* head_dim, not the
+            // SWA-only value. The GGUF loader does the same (gguf_loader.cpp).
+            // Without this, full-attention layers (head_dim=512) write past
+            // their allocated stride into adjacent layer slots → corrupted KV
+            // cache → garbage attention output. Symptom: L0 attention output
+            // diverges from GGUF reference even though Q/K/V projections agree.
+            int max_hd = 0;
+            for (int v : cfg.head_dim_per_layer) max_hd = std::max(max_hd, v);
+            if (max_hd > cfg.head_dim) {
+                IMP_LOG_INFO("Gemma 4 (HF): scalar head_dim %d → %d (max of per-layer)",
+                             cfg.head_dim, max_hd);
+                cfg.head_dim = max_hd;
+            }
+            // Same for n_kv_heads — sizing the cache for the largest layer.
+            int max_nkv = 0;
+            for (int v : cfg.n_kv_heads_per_layer) max_nkv = std::max(max_nkv, v);
+            if (max_nkv > cfg.n_kv_heads) {
+                IMP_LOG_INFO("Gemma 4 (HF): scalar n_kv_heads %d → %d (max of per-layer)",
+                             cfg.n_kv_heads, max_nkv);
+                cfg.n_kv_heads = max_nkv;
+            }
         }
     }
 

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -319,16 +320,16 @@ std::string HFConfigLoader::load_chat_template(const std::string& model_dir) {
     JValue root;
     if (!parse_json_file(path, root)) return "";
 
-    // Case 1: chat_template is a plain string
+    // Case 1: chat_template is a plain string in tokenizer_config.json
     std::string chat_template;
-    if (jobj_get_string(root, "chat_template", chat_template)) {
+    if (jobj_get_string(root, "chat_template", chat_template) && !chat_template.empty()) {
         IMP_LOG_INFO("loaded chat_template from tokenizer_config.json (%zu chars)",
                      chat_template.size());
         return chat_template;
     }
 
-    // Case 2: chat_template is an array of {name, template} objects
-    // HuggingFace format: [{"name": "default", "template": "..."}, ...]
+    // Case 2: chat_template is an array of {name, template} objects in
+    // tokenizer_config.json (HuggingFace format: [{"name":"default","template":"..."}, …]).
     const JValue* ct = jobj_find(root, "chat_template");
     if (ct && ct->type == JType::ARRAY) {
         // Prefer "default" entry
@@ -337,7 +338,7 @@ std::string HFConfigLoader::load_chat_template(const std::string& model_dir) {
             std::string name;
             if (!jobj_get_string(entry, "name", name)) continue;
             if (name == "default") {
-                if (jobj_get_string(entry, "template", chat_template)) {
+                if (jobj_get_string(entry, "template", chat_template) && !chat_template.empty()) {
                     IMP_LOG_INFO("loaded chat_template (default) from tokenizer_config.json (%zu chars)",
                                  chat_template.size());
                     return chat_template;
@@ -347,7 +348,7 @@ std::string HFConfigLoader::load_chat_template(const std::string& model_dir) {
         // Fallback: first entry with a valid template string
         for (const auto& entry : ct->arr) {
             if (entry.type != JType::OBJECT) continue;
-            if (jobj_get_string(entry, "template", chat_template)) {
+            if (jobj_get_string(entry, "template", chat_template) && !chat_template.empty()) {
                 std::string name;
                 jobj_get_string(entry, "name", name);
                 IMP_LOG_INFO("loaded chat_template (%s) from tokenizer_config.json (%zu chars)",
@@ -356,6 +357,23 @@ std::string HFConfigLoader::load_chat_template(const std::string& model_dir) {
             }
         }
         IMP_LOG_WARN("chat_template array found but no usable entry in %s", path.c_str());
+    }
+
+    // Case 3: standalone chat_template.jinja file alongside tokenizer_config.json.
+    // Newer HuggingFace exports (e.g. Gemma-4 llm-compressor NVFP4) ship the
+    // template as a separate file with no chat_template field in
+    // tokenizer_config.json. Read it raw — the Jinja2 engine consumes the
+    // string, so no parsing required here.
+    std::string jinja_path = model_dir + "/chat_template.jinja";
+    if (std::ifstream in(jinja_path); in.good()) {
+        std::stringstream buf;
+        buf << in.rdbuf();
+        chat_template = buf.str();
+        if (!chat_template.empty()) {
+            IMP_LOG_INFO("loaded chat_template from chat_template.jinja (%zu chars)",
+                         chat_template.size());
+            return chat_template;
+        }
     }
 
     return "";

--- a/src/model/llm_compressor_loader.cpp
+++ b/src/model/llm_compressor_loader.cpp
@@ -102,19 +102,17 @@ NameTranslation translate_name(const std::string& in, TranslationCounters& count
         return {NameTranslation::SKIP, ""};
     }
 
-    // Step 2: skip Gemma-4 extras.
+    // Step 2: count Gemma-4 extras (still emitted — weight_map routes them to
+    // layer.{ffn_gate_inp_scale, expert_down_scale, layer_out_scale}, which the
+    // forward path applies to make the model coherent). Phase 1 skipped these
+    // because the runtime wiring wasn't validated yet; Phase 2 enables them.
     if (ends_with(out, ".layer_scalar") || ends_with(out, ".per_expert_scale")) {
-        counters.gemma4_extra_skipped++;
-        return {NameTranslation::SKIP, ""};
-    }
-    if (ends_with(out, ".scale")) {
-        // Only skip if the segment immediately before .scale is NOT a known proj.
+        counters.gemma4_extras++;
+    } else if (ends_with(out, ".scale")) {
         std::string_view before_scale(out.data(), out.size() - 6); // strip ".scale"
         if (!is_proj_segment(before_scale)) {
-            counters.gemma4_extra_skipped++;
-            return {NameTranslation::SKIP, ""};
+            counters.gemma4_extras++;
         }
-        // else fall through (pass-through handles it).
     }
 
     // Step 3: prefix strip. Two multimodal wrappers seen in the wild:
@@ -158,10 +156,10 @@ NameTranslation translate_name(const std::string& in, TranslationCounters& count
 
 void log_summary(const TranslationCounters& c) {
     IMP_LOG_INFO("llm-compressor format: %d suffix renames, %d prefix strips, "
-                 "%d vision tensors skipped, %d Gemma-4 extras skipped, "
+                 "%d vision tensors skipped, %d Gemma-4 extras emitted, "
                  "%d pass-through",
                  c.suffix_renames, c.prefix_strips,
-                 c.vision_skipped, c.gemma4_extra_skipped,
+                 c.vision_skipped, c.gemma4_extras,
                  c.passed_through);
 }
 

--- a/src/model/llm_compressor_loader.h
+++ b/src/model/llm_compressor_loader.h
@@ -13,7 +13,7 @@ struct TranslationCounters {
     int suffix_renames = 0;       // .weight_packed → .weight, etc.
     int prefix_strips = 0;        // model.language_model. → model.
     int vision_skipped = 0;       // model.vision_tower.* / model.visual.*
-    int gemma4_extra_skipped = 0; // .layer_scalar / .per_expert_scale / Gemma-4 .scale
+    int gemma4_extras = 0;        // .layer_scalar / .per_expert_scale / router.scale (passed through to weight_map)
     int passed_through = 0;       // unknown patterns, returned unchanged
 };
 

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -592,7 +592,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
     // emit the summary here. The sharded path (load_sharded) emits its own summary internally
     // with its own counters — tcounters is only populated by the two load_shard calls above.
     if (llm_compressor_format && (tcounters.suffix_renames + tcounters.prefix_strips +
-                                   tcounters.vision_skipped + tcounters.gemma4_extra_skipped +
+                                   tcounters.vision_skipped + tcounters.gemma4_extras +
                                    tcounters.passed_through) > 0) {
         imp::llm_compressor::log_summary(tcounters);
     }

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -409,7 +409,12 @@ bool WeightMap::apply_weights(
                 layer.layer_out_scale = t;
                 matched = true;
             }
-            // Gemma 4 FFN norm variants (parallel shared-MLP + MoE branches)
+            // Gemma 4 FFN norm variants (parallel shared-MLP + MoE branches).
+            // GGUF analogue: pre_ffw_norm_2/post_ffw_norm_1/post_ffw_norm_2 are
+            // the parallel-branch norms; pre_feedforward_layernorm (base) and
+            // post_feedforward_layernorm (base) are the standard FFN norms,
+            // routed to layer.ffn_norm and layer.post_ffn_norm to mirror the
+            // GGUF loader (gguf_loader.cpp ffn_norm + post_ffw_norm fields).
             else if (parts.size() >= 5 && parts[4] == "weight") {
                 if (parts[3] == "pre_feedforward_layernorm_2") {
                     layer.ffn_pre_norm_2 = t; matched = true;
@@ -417,6 +422,10 @@ bool WeightMap::apply_weights(
                     layer.ffn_post_norm_1 = t; matched = true;
                 } else if (parts[3] == "post_feedforward_layernorm_2") {
                     layer.ffn_post_norm_2 = t; matched = true;
+                } else if (parts[3] == "pre_feedforward_layernorm") {
+                    layer.ffn_norm = t; matched = true;
+                } else if (parts[3] == "post_feedforward_layernorm") {
+                    layer.post_ffn_norm = t; matched = true;
                 } else if (parts[3] == "post_attention_layernorm") {
                     // Gemma 3/4 sandwich norm — distinct from Llama's FFN norm.
                     layer.post_attn_norm = t; matched = true;

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1192,6 +1192,19 @@ bool Engine::init_features() {
                 if (tid >= 0) keep_ids.push_back(tid);
             }
         }
+        // Gemma-4 channel markers: the model is trained to wrap its turn in
+        // <|channel>final<channel|> ... structure (and <|channel>thought<channel|>
+        // for reasoning). Banning these forces the model off-distribution and
+        // it produces token-stuck loops or repetition (observed on llm-compressor
+        // NVFP4 server prefill — the natural argmax IS <|channel>). Keep them
+        // and let the server strip the markers from user-facing output via
+        // strip_channel_headers().
+        if (tok) {
+            for (const char* name : {"<|channel>", "<channel|>"}) {
+                int32_t tid = tok->find_token(name);
+                if (tid >= 0) keep_ids.push_back(tid);
+            }
+        }
         auto is_kept = [&](int32_t id) {
             return std::find(keep_ids.begin(), keep_ids.end(), id) != keep_ids.end();
         };
@@ -1732,6 +1745,28 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
             Tensor last_logits = logits_out.slice(0, 1);
             int64_t vocab_shape[1] = {last_logits.shape[1]};
             last_logits = last_logits.reshape(1, vocab_shape);
+
+            // Ban special tokens (e.g. Gemma-4 <|channel>) before greedy
+            // argmax — otherwise the natural-argmax channel marker triggers
+            // is_stop_token and the request finishes with 0 completion
+            // tokens. Same logic as GraphExecutor::forward (executor.cu:88)
+            // and apply_pre_sample (executor.cu) but inline here because
+            // sample_greedy_device runs on raw logits without going through
+            // either of those wrappers.
+            if (state.banned_tokens != nullptr && state.n_banned_tokens > 0) {
+                float* lp = static_cast<float*>(last_logits.data);
+                int vocab = static_cast<int>(last_logits.shape[0]);
+                float neg_inf = -1e30f;
+                for (int bi = 0; bi < state.n_banned_tokens; bi++) {
+                    int32_t tid = state.banned_tokens[bi];
+                    if (tid >= 0 && tid < vocab) {
+                        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(
+                            lp + tid, &neg_inf, sizeof(float),
+                            cudaMemcpyHostToDevice, pf_stream));
+                    }
+                }
+            }
+
             sample_greedy_device(last_logits, executor_->d_sample_result(),
                                   h_sample_pinned_, pf_stream);
 

--- a/src/runtime/pdl.cu
+++ b/src/runtime/pdl.cu
@@ -27,6 +27,10 @@ void disable(const void* kernel_func) {
 }
 
 bool is_enabled(const void* kernel_func) {
+    // DIAGNOSTIC: env var to disable PDL globally without rebuilding.
+    // Set IMP_NO_PDL=1 to fall back to standard <<<>>> launches.
+    static const bool s_no_pdl = (getenv("IMP_NO_PDL") != nullptr);
+    if (s_no_pdl) return false;
     return enabled_kernels().count(kernel_func) > 0;
 }
 

--- a/tests/test_e2e_llm_compressor.cpp
+++ b/tests/test_e2e_llm_compressor.cpp
@@ -36,15 +36,28 @@ TEST_F(LlmCompressorE2E, Gemma4_LoadsWithoutIMA) {
     imp_model_free(model);
 }
 
-// Gemma-4 generation runs to completion without crashing. We do NOT assert
-// content coherence here because the spec's R1 risk has materialized:
-// llm-compressor Gemma-4 NVFP4 ships with extra scaling tensors
-// (.layer_scalar, .per_expert_scale, .scale) that imp's Phase 1 loader
-// skips. Without those scales applied, output is incoherent (e.g.
-// "Pac<unused5>"). Quality recovery requires Phase 2 work — see
-// docs/superpowers/specs/2026-04-26-llm-compressor-nvfp4-loader-design.md
-// section R1 + the TODO backlog. Loader correctness is gated by the
-// LoadsWithoutIMA test above and the Mistral-Small dense test (Task 9).
+// Gemma-4 generation runs to completion without crashing. Coherence is NOT
+// asserted because the R1 risk from the Phase 1 spec is only partially
+// resolved as of this commit:
+//
+// Phase 1 skipped the 90 extra scaling tensors (.layer_scalar,
+// .per_expert_scale, .scale) → output stopped immediately with "Pac<unused5>".
+//
+// Phase 2 Item 2 (this commit) routes them through translate_name → weight_map,
+// which assigns them to the same per-layer fields used by the Gemma-4 GGUF path
+// (layer_out_scale, expert_down_scale, ffn_gate_inp_scale). Output is now
+// varied (e.g. "What is the capital of France?" → " way world ات set" with
+// chat-template gemma) instead of an immediate degenerate stop, meaning the
+// scales are reaching the forward pass. But coherence isn't fully recovered:
+// either the per-channel router.scale and per-expert routing scale have
+// different semantics (multiplier vs divisor, similar to the Phase-1
+// weight_global_scale flip) than the GGUF analogues, or there is an additional
+// reconstruction step the vLLM reference (PR vllm-project/vllm#39045) performs
+// that imp doesn't replicate yet.
+//
+// Disposition: full coherence recovery deferred — needs a side-by-side reference
+// trace against vLLM. Mistral-Small (dense, no MoE extras) remains the actual
+// coherence gate for the loader.
 TEST_F(LlmCompressorE2E, Gemma4_GeneratesNonEmptyOutput) {
     if (!dir_exists(kGemma4Dir)) {
         GTEST_SKIP() << "Model not present at " << kGemma4Dir;

--- a/tests/test_llm_compressor_loader.cpp
+++ b/tests/test_llm_compressor_loader.cpp
@@ -71,27 +71,47 @@ TEST(LlmCompressorTranslate, SkipsVisualPrefix) {
     EXPECT_EQ(c.vision_skipped, 1);
 }
 
-TEST(LlmCompressorTranslate, SkipsLayerScalar) {
+// Phase 2: layer_scalar is now emitted (not skipped) — weight_map.cpp routes
+// it to layer.layer_out_scale, which executor_forward applies after each MoE
+// layer. The counter records emission for the load summary log line.
+TEST(LlmCompressorTranslate, EmitsLayerScalar) {
     TranslationCounters c{};
     auto t = translate_name("model.layers.0.layer_scalar", c);
-    EXPECT_EQ(t.action, NameTranslation::SKIP);
-    EXPECT_EQ(c.gemma4_extra_skipped, 1);
+    EXPECT_EQ(t.action, NameTranslation::EMIT);
+    EXPECT_EQ(t.out_name, "model.layers.0.layer_scalar");
+    EXPECT_EQ(c.gemma4_extras, 1);
 }
 
-TEST(LlmCompressorTranslate, SkipsPerExpertScale) {
+// Phase 2: per_expert_scale is now emitted — weight_map routes it to
+// layer.expert_down_scale, applied by moe_apply_per_expert_scale_kernel
+// before the routing weighted sum.
+TEST(LlmCompressorTranslate, EmitsPerExpertScale) {
     TranslationCounters c{};
-    auto t = translate_name("model.layers.5.experts.per_expert_scale", c);
-    EXPECT_EQ(t.action, NameTranslation::SKIP);
-    EXPECT_EQ(c.gemma4_extra_skipped, 1);
+    auto t = translate_name("model.layers.5.router.per_expert_scale", c);
+    EXPECT_EQ(t.action, NameTranslation::EMIT);
+    EXPECT_EQ(t.out_name, "model.layers.5.router.per_expert_scale");
+    EXPECT_EQ(c.gemma4_extras, 1);
 }
 
-TEST(LlmCompressorTranslate, DoesNotSkipProjScale) {
-    // .scale suffix on a recognized projection name is NOT a Gemma-4 extra.
-    // (Defensive against false-positive blanket .scale skip.)
+// Phase 2: router.scale (per-input-channel router pre-scale) is now emitted —
+// weight_map routes it to layer.ffn_gate_inp_scale, applied to the router
+// input before the gating projection.
+TEST(LlmCompressorTranslate, EmitsRouterScale) {
+    TranslationCounters c{};
+    auto t = translate_name("model.layers.0.router.scale", c);
+    EXPECT_EQ(t.action, NameTranslation::EMIT);
+    EXPECT_EQ(t.out_name, "model.layers.0.router.scale");
+    EXPECT_EQ(c.gemma4_extras, 1);
+}
+
+// Defensive: .scale on a known projection (q_proj/k_proj/...) is NOT a Gemma-4
+// extra and must not increment the gemma4_extras counter.
+TEST(LlmCompressorTranslate, ProjScaleIsNotGemma4Extra) {
     TranslationCounters c{};
     auto t = translate_name("model.layers.0.self_attn.q_proj.scale", c);
-    EXPECT_EQ(t.action, NameTranslation::EMIT);  // pass through
-    EXPECT_EQ(c.gemma4_extra_skipped, 0);
+    EXPECT_EQ(t.action, NameTranslation::EMIT);
+    EXPECT_EQ(c.gemma4_extras, 0);
+    EXPECT_EQ(c.passed_through, 1);
 }
 
 // Mistral3 layout: `language_model.model.layers.*` (no leading `model.`).

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1919,10 +1919,21 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
                 strip_think_block(content);
             }
 
-            // Gemma-4 channel headers: structural "<|channel>NAME\n" / "<channel|>\n"
-            // never belong in user-facing content. Strip regardless of reasoning_format.
+            // Gemma-4 channel headers: structural "<|channel>NAME[<channel|>]…"
+            // wraps both the chain-of-thought and the user-facing answer. Split
+            // them so "thought" content goes to reasoning_content (OpenAI-
+            // compat) and "final" content stays in content. Falls back to
+            // strip-only if the request asked reasoning_format=none.
             if (snap_channel_open_id >= 0) {
-                strip_channel_headers(content);
+                if (state.default_args.reasoning_format == "none") {
+                    strip_channel_headers(content);
+                } else {
+                    auto segs = split_channel_segments(content);
+                    if (!segs.reasoning.empty() && reasoning_content.empty()) {
+                        reasoning_content = std::move(segs.reasoning);
+                    }
+                    content = std::move(segs.content);
+                }
             }
 
             // Build logprobs object if requested

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -146,6 +146,95 @@ void strip_think_block(std::string& text) {
     }
 }
 
+ChannelSegments split_channel_segments(const std::string& text) {
+    static const char kOpen[] = "<|channel>";
+    static const char kClose[] = "<channel|>";
+    constexpr size_t kOpenLen = sizeof(kOpen) - 1;
+    constexpr size_t kCloseLen = sizeof(kClose) - 1;
+
+    ChannelSegments out;
+    // Empty channel name = "before any header" — Gemma-4's chat template often
+    // routes pre-thought turn boilerplate through this state. Treat it as
+    // user-facing content (matches the legacy strip_channel_headers behaviour).
+    std::string current_channel;
+
+    auto append_to_channel = [&](char c) {
+        if (current_channel == "thought" || current_channel == "analysis") {
+            out.reasoning.push_back(c);
+        } else if (current_channel == "final" || current_channel.empty()) {
+            out.content.push_back(c);
+        } else {
+            out.other.push_back(c);
+        }
+    };
+
+    size_t i = 0;
+    while (i < text.size()) {
+        const bool is_open = (i + kOpenLen <= text.size() &&
+                              text.compare(i, kOpenLen, kOpen) == 0);
+        const bool is_close = (!is_open &&
+                               i + kCloseLen <= text.size() &&
+                               text.compare(i, kCloseLen, kClose) == 0);
+        if (is_open) {
+            // The header runs from "<|channel>" up to the FIRST of:
+            //   1. a newline, or
+            //   2. a "<channel|>" marker (Q5_K_M variant — see strip_channel_headers comment).
+            size_t name_start = i + kOpenLen;
+            size_t nl   = text.find('\n', name_start);
+            size_t cls  = text.find(kClose, name_start);
+            size_t end  = std::min<size_t>(
+                nl  == std::string::npos ? text.size() : nl,
+                cls == std::string::npos ? text.size() : cls);
+            std::string name = text.substr(name_start, end - name_start);
+            // Trim header name (whitespace, args after first space)
+            size_t s = name.find_first_not_of("\n\r\t ");
+            size_t e = name.find_last_not_of("\n\r\t ");
+            if (s == std::string::npos) {
+                name.clear();
+            } else {
+                name = name.substr(s, e - s + 1);
+                size_t sp = name.find_first_of(" \t");
+                if (sp != std::string::npos) name = name.substr(0, sp);
+            }
+            current_channel = std::move(name);
+            // Skip past the header — including the trailing \n if that's what
+            // ended it. If a <channel|> marker ended the header, leave it for
+            // the close-marker branch on the next iteration so the "header
+            // separator" rule below stays a no-op rather than swallowing body.
+            if (end == nl && nl != std::string::npos) {
+                i = nl + 1;
+            } else {
+                i = end;
+            }
+            continue;
+        }
+        if (is_close) {
+            // <channel|> on its own. The model's observed Gemma-4 emission is
+            //   <|channel>thought\nTHOUGHT<channel|>FINAL
+            // i.e. <channel|> CLOSES the current channel and the body that
+            // follows is the user-facing answer (no explicit
+            // <|channel>final\n<channel|> opener for the final answer — the
+            // chat-template prefix already supplied that). Treat a standalone
+            // close-marker as "switch back to default (content)".
+            current_channel.clear();
+            i += kCloseLen;
+            continue;
+        }
+        append_to_channel(text[i++]);
+    }
+
+    auto trim = [](std::string& s) {
+        size_t a = s.find_first_not_of("\n\r\t ");
+        if (a == std::string::npos) { s.clear(); return; }
+        size_t b = s.find_last_not_of("\n\r\t ");
+        s = s.substr(a, b - a + 1);
+    };
+    trim(out.reasoning);
+    trim(out.content);
+    trim(out.other);
+    return out;
+}
+
 void strip_channel_headers(std::string& text) {
     // Scan for "<|channel>" and "<channel|>" markers. Each one begins a header
     // that runs until the next '\n'. Remove the markers and the characters up

--- a/tools/imp-server/utils.h
+++ b/tools/imp-server/utils.h
@@ -29,6 +29,17 @@ std::pair<std::string, std::string> extract_reasoning(const std::string& text);
 // that emit both get both stripped, leaving only the body text concatenated.
 void strip_channel_headers(std::string& text);
 
+// Channel-aware split: parses Gemma-4 style `<|channel>NAME[<channel|>]BODY...`
+// segments and returns the reasoning (= "thought" channel) separately from the
+// user-facing content (= "final" channel + any pre-channel text). Bodies are
+// preserved verbatim minus the markers/header names. Each segment is trimmed.
+struct ChannelSegments {
+    std::string reasoning;  // "thought" channel(s)
+    std::string content;    // "final" channel(s) + un-channeled text
+    std::string other;      // any unrecognised channel name (debug)
+};
+ChannelSegments split_channel_segments(const std::string& text);
+
 std::string sse_chunk(const std::string& id, int64_t created,
                       const std::string& model,
                       const json& delta,


### PR DESCRIPTION
## Summary

Phase 2 Item 2 of the [llm-compressor NVFP4 loader backlog](docs/llm-compressor-validation-results.md#phase-2-backlog-priority-ordered) — emits the 90 extra Gemma-4 scaling tensors, fixes a missing-norm bug, two latent NVFP4 dispatch bugs, and a Gemma-4 head_dim buffer-sizing bug.

**Depends on #64** (Phase 2 Item 1 — Mistral3). PR base is set to that branch; will rebase to \`main\` once #64 lands.

## Commits

### 1. \`a791e95\` — emit Gemma-4 NVFP4 scaling extras

Phase 1 skipped the 90 extras (\`.layer_scalar\`, \`router.per_expert_scale\`, \`router.scale\`) — output was \`Pac<unused5>\` (immediate degenerate stop). Flips SKIP rules to pass-through emission. Names already match \`weight_map.cpp\`'s Gemma-4 routing.

### 2. \`79c7659\` — route Gemma-4 base FFN norms

Each Gemma-4 layer has 6 FFN-related layernorms. Phase-1 weight_map only routed the _1 / _2 parallel-branch variants; the base \`pre_feedforward_layernorm\` / \`post_feedforward_layernorm\` (= GGUF \`ffn_norm\` / \`post_ffw_norm\`) were dropped → FFN ran without normalization.

### 3. \`8982d5a\` — diagnostic env vars

\`IMP_NO_PDL=1\`, \`IMP_MOE_ZERO_WORKSPACE=1\` — used to rule out PDL races and uninit reads from MoE staging. Both showed bug is computational, not concurrency.

### 4. \`ca05a45\` — fix two latent NVFP4 bugs in weight_dispatch.cu

Phase-1 NVFP4 audit (commit f5f4a1a, "K must be packed*2") missed \`weight_dispatch.cu\`'s two \`case StorageTier::NVFP4:\` arms. Both had identical bugs: \`tmp.K = w.shape[1]\` (packed not logical), and \`cudaMemcpyDeviceToHost\` on a HOST tensor_scale pointer. Side effect on Mistral: argmax for "The capital of France is" flipped from "the largest city in France" → "the **capital** of France".

### 5. \`57cda8e\` — Gemma-4 scalar head_dim = max(per-layer)

Layer-diff bisect of GGUF Q8_0 (works) vs SafeTensors NVFP4 (broken):

| Stage | cos (last token) |
|-------|------------------|
| A_pre_attn (embedding) | 0.9999 |
| D_post_norm_no | 1.0000 |
| D_after_qkv_q | 0.9996 |
| D_after_qkv_k | 0.9998 |
| D_after_qkv_v | 0.9991 |
| E_after_rope_q | 0.9635 |
| E_after_rope_k | 0.9728 |
| **E_after_fmha_ao** | **0.7500** |

Q,K,V essentially identical going into FMHA, but the attention compute amplifies noise. Two compounding causes:

1. **\`cfg.head_dim\` = 256 not 512** (FIXED here). Gemma-4 has dual head_dim (256 SWA / 512 global). HF config loader was leaving \`cfg.head_dim\` at the SWA-only value while building the per-layer array correctly. KV cache + attention workspace sized for hd=256, so global layers' 8192-wide Q output overflows the 4096-wide buffer into adjacent slots. GGUF loader has the same \`max_hd\` fixup; HF was missing it.

2. **\`ld_q\`/\`ld_k\` mismatch with buffer stride** (NOT fixed — separate follow-up). \`attention_cublas.cu\` computes \`int ld_q = n_heads * head_dim;\` from per-layer values (e.g. 16*256=4096 for L0 SWA) but buffer stride is \`n_heads * cfg.head_dim\` = 16*512 = 8192. cuBLAS strided batched GEMM reads token N's row from offset \`N * ld_q\` not \`N * stride\` → token 1+ rows are read from inside token 0's padding. GGUF survives because its padding happens to be zero (luck); NVFP4 has stale workspace data there → garbage attention output. Fix needs \`ld_q = Q.stride[0]\` in \`attention_cublas_prefill\` + same change in \`naive_attention_prefill_kernel\`. Estimated 2-4 hours.

## Status

**Loading + dispatch: works.** test-core 26/26, test-e2e 4/4 (LoadsWithoutIMA, GeneratesNonEmptyOutput, MistralSmall, Modelopt regression).

**Mistral-Small NVFP4: improved.** "Paris. It is the **capital** of France..." (was "the largest city in France"). No regression.

**Gemma-4 NVFP4 coherence: NOT recovered.** Strictly more correct than Phase-1 baseline (output is no longer immediate-stop \`Pac<unused5>\`, scales+norms applied, dispatch math fixed, head_dim correct) — but still incoherent due to the open ld_stride mismatch. Bisect localizes the remaining bug to FMHA cuBLAS stride handling.

## Phase 2 backlog status

- [x] Item 1 — Mistral3 prefix + config_groups parser (PR #64)
- [~] Item 2 — Gemma-4 NVFP4 extras + norms + dispatch + head_dim (this PR; loading/dispatch fixes shipped, ld_stride fix open)
- [ ] Item 3 — W4A16 fallback validation (blocked: needs target model)
- [ ] Item 4 — GDN+NVFP4 (separate effort)
- [ ] Item 5 — Multimodal/vision (separate effort)
- [ ] Item 6 — \`convert_scales_sfatom\` fusion (separate spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)