### PR TITLE
test: strengthen Gemma-4 NVFP4 e2e gate to Paris coherence assertion

### DIFF
--- a/tests/test_e2e_llm_compressor.cpp
+++ b/tests/test_e2e_llm_compressor.cpp
@@ -36,29 +36,27 @@ TEST_F(LlmCompressorE2E, Gemma4_LoadsWithoutIMA) {
     imp_model_free(model);
 }
 
-// Gemma-4 generation runs to completion without crashing. Coherence is NOT
-// asserted because the R1 risk from the Phase 1 spec is only partially
-// resolved as of this commit:
+// Gemma-4 MoE coherence gate. Greedy "What is the capital of France?" with
+// the model's own chat template applied must produce text containing "Paris".
 //
-// Phase 1 skipped the 90 extra scaling tensors (.layer_scalar,
-// .per_expert_scale, .scale) → output stopped immediately with "Pac<unused5>".
+// Why chat-template instead of base completion: Gemma-4-it is heavily
+// instruction-tuned and degenerates into a repetition loop on raw
+// completion prompts (e.g. "The capital of France is " →
+// " the most of the most of the most..."). The Mistral test uses base
+// completion because Mistral-Small-3.2 holds together on raw prompts; for
+// Gemma-4-it we need the chat-template wrap to land on a sane decoding
+// trajectory. The model dir ships a chat_template.jinja that imp picks up
+// automatically when apply_chat_template=1.
 //
-// Phase 2 Item 2 (this commit) routes them through translate_name → weight_map,
-// which assigns them to the same per-layer fields used by the Gemma-4 GGUF path
-// (layer_out_scale, expert_down_scale, ffn_gate_inp_scale). Output is now
-// varied (e.g. "What is the capital of France?" → " way world ات set" with
-// chat-template gemma) instead of an immediate degenerate stop, meaning the
-// scales are reaching the forward pass. But coherence isn't fully recovered:
-// either the per-channel router.scale and per-expert routing scale have
-// different semantics (multiplier vs divisor, similar to the Phase-1
-// weight_global_scale flip) than the GGUF analogues, or there is an additional
-// reconstruction step the vLLM reference (PR vllm-project/vllm#39045) performs
-// that imp doesn't replicate yet.
-//
-// Disposition: full coherence recovery deferred — needs a side-by-side reference
-// trace against vLLM. Mistral-Small (dense, no MoE extras) remains the actual
-// coherence gate for the loader.
-TEST_F(LlmCompressorE2E, Gemma4_GeneratesNonEmptyOutput) {
+// Coherence path landed in two pieces, both on main:
+//   - PR #65 routes the 90 Gemma-4 extras (layer_scalar, router.scale,
+//     router.per_expert_scale) through translate_name → weight_map →
+//     existing GGUF Gemma-4 forward path (no new kernels).
+//   - The same PR's MoE per-expert NVFP4 prefill bypass in
+//     executor_forward_moe.cu (M>1 → gemm_nvfp4 dequant→cuBLAS instead of
+//     per-row gemv_nvfp4_kpar) eliminated the corruption that produced
+//     "way world ات set" pre-fix.
+TEST_F(LlmCompressorE2E, Gemma4_LoadsAndGeneratesCoherent) {
     if (!dir_exists(kGemma4Dir)) {
         GTEST_SKIP() << "Model not present at " << kGemma4Dir;
     }
@@ -76,15 +74,17 @@ TEST_F(LlmCompressorE2E, Gemma4_GeneratesNonEmptyOutput) {
     ASSERT_NE(ctx, nullptr);
 
     ImpGenerateParams params = imp_generate_params_default();
-    params.max_tokens = 16;
+    params.max_tokens = 32;
     params.temperature = 0.0f;
-    params.apply_chat_template = 0;
+    params.apply_chat_template = 1;
 
     char output[2048];
     size_t len = 0;
-    ImpError rc = imp_generate(ctx, "What is 2+2?", &params,
-                               output, sizeof(output), &len);
-    EXPECT_EQ(rc, IMP_SUCCESS) << "Generation must complete (no crash, no IMA)";
+    ASSERT_EQ(imp_generate(ctx, "What is the capital of France?", &params,
+                           output, sizeof(output), &len), IMP_SUCCESS);
+    std::string result(output, len);
+    EXPECT_NE(result.find("Paris"), std::string::npos)
+        << "Generated text: " << result;
 
     imp_context_free(ctx);
     imp_model_free(model);


### PR DESCRIPTION
## Summary
- Replaces the no-crash-only `Gemma4_GeneratesNonEmptyOutput` stub (which remained from the Phase-2-Item-2 deferred-coherence comment block) with a real coherence gate `Gemma4_LoadsAndGeneratesCoherent` that mirrors the Mistral test
- Greedy "What is the capital of France?" with the model's bundled chat template applied must produce text containing "Paris"
- Pins the post-PR-#65 fix (per-expert NVFP4 prefill bypass + Gemma-4 extras routing) into a regression gate

## Why chat-template instead of base completion
Gemma-4-it is heavily instruction-tuned and degenerates into a repetition loop on raw base completion ("The capital of France is " → " the most of the most of the most..." — verified empirically). The Mistral test holds together on raw prompts because Mistral-Small-3.2 is less aggressively tuned. With `apply_chat_template=1` the model's `chat_template.jinja` is auto-applied and greedy produces "The capital of France is Paris." at ~50 tok/s decode.

## Test plan
- [x] `test-e2e --gtest_filter='LlmCompressorE2E.*'` → 4/4 pass:
  - `Gemma4_LoadsWithoutIMA` ✓
  - `Gemma4_LoadsAndGeneratesCoherent` (new) ✓ — output contains "Paris"
  - `MistralSmall_LoadsAndGeneratesCoherent` ✓ (no regression)
  - `Modelopt_QwenCoder30B_StillWorks` ✓ (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)