### PR TITLE
fix(verify): auto re-exec verify.sh in imp:test when host cmake missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ FROM nvidia/cuda:13.2.1-runtime-ubuntu24.04
 RUN apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages \
         libcublas-13-2 \
         curl \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy built binaries

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -17,12 +17,40 @@
 #   IMP_VERIFY_MODELS=models
 #   IMP_VERIFY_BASELINE=tests/perf_baseline.json
 #   IMP_VERIFY_SKIP_BUILD=1   skip cmake build step
+#   IMP_VERIFY_IN_DOCKER=1    sentinel set by the auto-re-exec block; do not set manually
+#
+# Auto-Docker fallback: if cmake is not on PATH (Clean-Host workflow), the
+# script re-execs itself inside the imp:test container, mounting the repo at
+# /src and using the prebuilt /usr/local/bin/imp-cli + imp-tests. Requires
+# 'make build' to have produced the imp:test image first.
 #
 set -uo pipefail
 
-MODE="${1:-fast}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
+
+# Auto re-exec in the imp:test container when cmake is unavailable on the host
+# (Clean-Host workflow: no language toolchains installed). The runtime image
+# has prebuilt binaries at /usr/local/bin/, so we skip the build step and point
+# IMP_VERIFY_BIN/TESTS at them. IMP_VERIFY_IN_DOCKER guards against infinite
+# re-exec if the runtime image somehow also lacks cmake.
+if ! command -v cmake >/dev/null 2>&1 && [ "${IMP_VERIFY_IN_DOCKER:-0}" != "1" ]; then
+    if ! docker image inspect imp:test >/dev/null 2>&1; then
+        echo "verify: cmake not found on host and imp:test image not built." >&2
+        echo "        Run 'make build' first, then re-run." >&2
+        exit 1
+    fi
+    echo "verify: host cmake unavailable — re-executing in imp:test container"
+    exec docker run --rm --gpus all \
+        -v "$ROOT":/src -w /src \
+        -e IMP_VERIFY_IN_DOCKER=1 \
+        -e IMP_VERIFY_BIN=/usr/local/bin/imp-cli \
+        -e IMP_VERIFY_TESTS=/usr/local/bin/imp-tests \
+        -e IMP_VERIFY_SKIP_BUILD=1 \
+        --entrypoint bash imp:test scripts/verify.sh "$@"
+fi
+
+MODE="${1:-fast}"
 
 BIN="${IMP_VERIFY_BIN:-build/imp-cli}"
 TESTS_BIN="${IMP_VERIFY_TESTS:-build/imp-tests}"
@@ -81,6 +109,8 @@ if [ ! -f "$BASELINE" ]; then
     skip "no $BASELINE — run scripts/gen_perf_baseline.sh to create one"
 elif [ ! -x "$BIN" ]; then
     fail "$BIN not found"
+elif ! command -v jq >/dev/null 2>&1; then
+    skip "jq not installed (needed to parse $BASELINE)"
 else
     BL_MODEL=$(jq -r '.model' "$BASELINE")
     BL_TG=$(jq -r '.metrics.decode_tps.tg128' "$BASELINE")


### PR DESCRIPTION
## Summary
- `scripts/verify.sh` now detects missing host `cmake` and auto re-execs itself inside the `imp:test` container, mounting the repo at `/src` and using prebuilt `/usr/local/bin/imp-cli` + `imp-tests` (skips the build step)
- Removes the friction that forced `--no-verify` on every push from a Clean-Host workflow (no language toolchains on WSL host per `~/.claude/CLAUDE.md`)
- Drive-by: adds `jq` to the runtime image (verify.sh perf step parses `perf_baseline.json` with jq — was silently cascading empty values when missing)
- Drive-by: verify.sh perf step now gates on `command -v jq` and SKIPs with a clear message if jq is unavailable

## Why
PR #67 added the verify-fast pre-push gate but assumed `cmake` is on PATH (line 46 calls `cmake --build build` directly). That assumption breaks Clean-Host — every push touching `src/`, `include/`, `tools/`, `tests/` failed with `cmake: command not found` and required `--no-verify` to land.

## Design
- New auto re-exec block at top of `scripts/verify.sh`:
  - If `cmake` is on PATH → run natively (existing behavior)
  - Else if `imp:test` image exists → `exec docker run --rm --gpus all -v $ROOT:/src -w /src ... imp:test bash scripts/verify.sh "$@"`, with env: `IMP_VERIFY_IN_DOCKER=1` (loop guard), `IMP_VERIFY_BIN=/usr/local/bin/imp-cli`, `IMP_VERIFY_TESTS=/usr/local/bin/imp-tests`, `IMP_VERIFY_SKIP_BUILD=1`
  - Else fail with "Run 'make build' first"
- `IMP_VERIFY_IN_DOCKER=1` sentinel guards against infinite re-exec if the runtime image somehow also lacks cmake

## Test plan
- [x] On Clean-Host (no cmake): `make verify-fast` → re-execs into imp:test, `build=SKIP`, `tests=PASS`, `perf` parses baseline correctly with jq, `smoke=PASS Qwen3-4B Q8_0 (Paris)`
- [x] Pre-push hook on a separate branch with src changes → verify-fast now self-rescues (no `--no-verify` needed)

## Notes
A ~60% decode regression vs baseline (Qwen3-8B-Q8_0 tg128: 102 vs 258) was observed during testing. Baseline timestamp is `2026-03-27` (a month old) and the regression appears unrelated to this script change — recommend separate investigation + `scripts/gen_perf_baseline.sh` refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)