### PR TITLE
Type-system + config refactor: unified QType, Tensor sidecars, imp.conf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ cmake -B build-asan -DIMP_SANITIZERS=ON -DCMAKE_BUILD_TYPE=Debug
 ### Dependencies
 
 - **CUDA Toolkit 13.2+** (required) — cudart, cuda_driver, cublas, cublasLt
-- **CUTLASS v4.4.1** (fetched via FetchContent) — SM120 FMHA (FP16/FP8/MXFP4), NVFP4/MXFP4 GEMM, MoE Grouped GEMM
+- **CUTLASS v4.4.2** (fetched via FetchContent) — SM120 FMHA (FP16/FP8/MXFP4), NVFP4/MXFP4 GEMM, MoE Grouped GEMM
 - **Google Test v1.14.0** (fetched via FetchContent when tests enabled)
 - **stb_image / stb_image_resize2** (vendored in `third_party/stb/`) — image loading for vision
 - **pthread** (linked privately)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,24 +280,59 @@ Hybrid architecture: 24 GDN layers (recurrent) + 8 attention layers + 32 dense F
 - Nemotron-H (Mamba2 + Attention + MoE hybrid)
 - Generic fallback
 
-### Environment Variables
+### Runtime Configuration
 
-Runtime knobs (set via shell env or `docker-compose.yml`):
+Runtime knobs are read from `imp.conf` (TOML-subset). All previous
+`IMP_*`-prefixed environment variables (~50 of them) have been replaced
+by sectioned keys in this file. See `imp.conf.example` in the repo root
+for the full schema with defaults and inline comments.
 
-| Variable | Effect |
-|---|---|
-| `IMP_KV_FP8` | Use FP8 E4M3 KV cache (recommended sweet spot vs FP16) |
-| `IMP_KV_INT8` | Use INT8 KV cache (lower VRAM, mild quality loss) |
-| `IMP_DECODE_NVFP4` | NVFP4 decode KV cache (max VRAM compression) |
-| `IMP_NO_CUDA_GRAPHS` | Disable CUDA graph capture (required for some MoE configs) |
-| `IMP_SSM_FP16` | Force FP16 SSM/GDN scan instead of FP32 gate path |
-| `IMP_PREFILL_CHUNK_SIZE` | Chunked prefill split size (default auto) |
-| `IMP_THINK_BUDGET` | Max thinking tokens for reasoning models |
-| `IMP_EXPERT_OVERHEAD_PCT` | MoE expert offload overhead estimate (10 = enable auto-probe; 30 = fallback) |
-| `IMP_MMPROJ` | Path to mmproj.gguf for vision models |
-| `IMP_MXFP4_ATTENTION` | Enable MXFP4 prefill FMHA path |
-| `IMP_NO_FP8_FMHA` | Force FP16 FMHA (debug) |
-| `IMP_NO_FMHA_SM120` | Force WMMA fallback attention (debug) |
+**Loading precedence** (first non-empty wins):
+1. `--config <path>` CLI flag
+2. `$IMP_CONFIG` environment variable
+3. `./imp.conf` (working directory)
+4. `~/.config/imp/imp.conf`
+5. embedded defaults (no file)
+
+**Per-run overrides** on top of the loaded config:
+
+```bash
+imp-cli --set kv_cache.dtype=fp8 --set runtime.cuda_graphs=never \
+        --model X.gguf --prompt "..."
+```
+
+**Common keys** (excerpt — see `imp.conf.example` for the rest):
+
+| Section / Key | Default | Effect |
+|---|---|---|
+| `runtime.cuda_graphs` | `"auto"` | `auto` / `always` / `never` |
+| `runtime.deterministic_gemm` | `false` | Pin cuBLAS algo for byte-stable runs |
+| `runtime.warmup` | `true` | Run warmup forward at engine init |
+| `runtime.no_pdl` | `false` | Disable Programmatic Dependent Launch |
+| `kv_cache.dtype` | `"fp16"` | `fp16` / `fp8` / `int8` / `int4` / `nvfp4` |
+| `attention.fp8_prefill` | `"auto"` | `auto` / `never` |
+| `attention.fp8_fmha` | `"auto"` | `auto` / `never` |
+| `attention.fmha_sm120` | `"auto"` | `auto` / `never` |
+| `attention.mxfp4` | `"auto"` | `auto` / `always` (MXFP4 prefill FMHA) |
+| `moe.expert_overhead_pct` | `10` | 10 = aggressive, 30 = conservative |
+| `moe.force_host_experts` | `0` | Force last N MoE layers to host |
+| `gdn.fp32_scan` | `false` | FP32 GDN scan (slower, higher precision) |
+| `gemma4.no_graphs` | `false` | Bypass Gemma-4 CUDA graph capture |
+| `generation.think_budget` | `0` | Max tokens spent in `<think>...</think>` |
+| `paths.mmproj` | `""` | mmproj.gguf for vision (Gemma-3) |
+| `diagnostics.dump_hidden_dir` | `""` | Per-layer hidden-state .npy dumps |
+| `diagnostics.exit_layer` | `-1` | Stop forward at layer N |
+
+**Build-time only env vars** (kept as ENV because they shape the build):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `IMP_BUILD_TESTS` | ON | Build the GTest suite |
+| `IMP_BUILD_TOOLS` | ON | Build imp-cli and imp-bench |
+| `IMP_BUILD_BENCH` | ON | Build benchmark tool |
+| `IMP_BUILD_SERVER` | ON | Build imp-server |
+| `IMP_SANITIZERS` | OFF | ASAN + UBSAN (host C++ code only) |
+| `IMP_CONFIG` | unset | Path to imp.conf (overrides search-path) |
 
 ### Vision (Multimodal)
 Gemma-3 vision uses a frozen 400M-parameter SigLIP ViT that produces 256 image tokens per image, projected into the LLM's embedding space. The vision encoder weights ship as a separate `mmproj.gguf` file. The pipeline: load image → resize 896x896 → normalize → extract 14x14 patches → 27 SigLIP transformer layers → 4x4 avg pool → RMSNorm + linear projection → replace `<image_soft_token>` embeddings before LLM prefill.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ endif()
 # (ptxas C7600 on sm_120a). This is resolved by using sm_120f instead.
 
 set(IMP_RUNTIME_SOURCES
+    src/runtime/config.cpp
     src/runtime/green_ctx.cu
     src/runtime/scheduler.cpp
     src/runtime/request.cpp
@@ -371,6 +372,7 @@ if(IMP_BUILD_TESTS)
         tests/test_kv_cache.cpp
         tests/test_gguf_loader.cpp
         tests/test_llm_compressor_loader.cpp
+        tests/test_config.cpp
     )
 
     imp_add_test_module(test-text SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 # --- Core library sources ---
 set(IMP_CORE_SOURCES
     src/core/tensor.cpp
+    src/core/qtype.cpp
     src/core/buffer.cpp
     src/core/allocator.cpp
     src/core/logging.cpp

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -1,0 +1,109 @@
+# imp.conf — central runtime configuration for the imp inference engine.
+#
+# Loading precedence (first non-empty wins):
+#   1. --config <path>              CLI flag
+#   2. $IMP_CONFIG                  environment variable
+#   3. ./imp.conf                   working-dir relative
+#   4. ~/.config/imp/imp.conf       user config directory
+#   5. embedded defaults            (no file, all values below)
+#
+# Per-run overrides on top via:
+#   imp --set kv_cache.dtype=fp8 --set runtime.cuda_graphs=never ...
+#
+# Lines starting with '#' are comments; section headers in [brackets].
+
+[runtime]
+# Force deterministic GEMM (cuBLASLt no_reduce_split). Slower but reproducible.
+deterministic_gemm   = false
+# CUDA Graph capture: "auto" picks per-model based on architecture support;
+# "always" forces capture (fails for MoE with D2H routing); "never" disables.
+cuda_graphs          = "auto"
+# Run a warmup forward pass at engine init to prime cuBLAS handles + L2 cache.
+warmup               = true
+# Override the model's max_seq_len (0 = use the model default).
+max_seq_len          = 0
+# Disable Programmatic Dependent Launch (PDL). Diagnostic; small perf impact.
+no_pdl               = false
+
+[kv_cache]
+# KV-cache element type: fp16 | fp8 | int8 | int4 | nvfp4
+dtype                       = "fp16"
+# Allow cuBLASLt non-deterministic algorithms with FP8 KV. Slightly faster
+# but reproducibility is lost.
+allow_nondeterministic_fp8  = false
+
+[attention]
+# Each "auto" key picks the kernel automatically based on weight type +
+# context length. Override only for benchmarking or compatibility tests.
+fp8_prefill          = "auto"
+fp8_fmha             = "auto"
+fmha_sm120           = "auto"
+mxfp4                = "auto"
+mxfp4_fp16_fallback  = false
+fmha_blockscale      = "auto"
+naive                = false
+no_cublas            = false
+force_cublas_decode  = false
+no_qknorm_fused      = false
+no_naive_swa         = false
+splitk_pipe          = true
+gate_concat          = false
+
+[moe]
+# Expected per-expert overhead (% of expert size) before deciding to upload
+# all experts vs. host-fall-back. 10 = aggressive, 30 = conservative.
+expert_overhead_pct  = 10
+force_host_experts   = false
+skip                 = false
+force_fp16_sync      = false
+no_expert_cache      = false
+
+[gdn]
+# FP32 scan/output for Gated-DeltaNet (Qwen3.5/3.6). Slightly slower but
+# eliminates FP16 precision drift at long context.
+fp32_scan            = false
+fp32_out             = false
+# 0 = use the model's rms_norm_eps; otherwise override (diagnostic).
+norm_eps_override    = 0.0
+ref_kernel           = false
+vhead_reorder        = false
+
+[gemm]
+# dp4a = INT8 4-element packed multiply-accumulate. mmvq = matrix*vec
+# quantized GEMM. Disabling forces dequant->cuBLAS path (diagnostic).
+no_dp4a              = false
+no_dp4a_gemv         = false
+no_dp4a_lm           = false
+no_mmvq              = false
+no_mmvq_q8_0         = false
+
+[gemma4]
+fp32_gemm_out        = false
+no_graphs            = false
+force_mmvq           = false
+
+[generation]
+no_logit_softcap     = false
+lm_dequant_fp16      = false
+# Max tokens spent in <think>...</think> blocks (0 = unlimited).
+think_budget         = 0
+
+[paths]
+# Path to a vision projector .gguf file (Gemma-3, Mistral3 multimodal).
+mmproj               = ""
+
+[diagnostics]
+# Verbose per-layer forward dumps. Heavy I/O — use only for bisecting bugs.
+debug_forward        = false
+debug_raw            = false
+debug_gemm_dispatch  = false
+# If non-empty, dump per-layer hidden states as .npy files to this directory.
+dump_hidden_dir      = ""
+dump_logits          = false
+dump_routing         = false
+dump_tokens          = false
+# Stop forward pass after layer N (-1 = run full forward).
+exit_layer           = -1
+profile              = false
+graph_diag           = false
+graph_dump_dir       = ""

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -24,6 +24,10 @@ warmup               = true
 max_seq_len          = 0
 # Disable Programmatic Dependent Launch (PDL). Diagnostic; small perf impact.
 no_pdl               = false
+# Naked FP16 path with FP8/NVFP4/graphs/warmup all forced off.
+debug_raw            = false
+# Disable SigLIP vision encoder CUDA-graph capture (debug).
+no_vision_graph      = false
 
 [kv_cache]
 # KV-cache element type: fp16 | fp8 | int8 | int4 | nvfp4
@@ -31,6 +35,8 @@ dtype                       = "fp16"
 # Allow cuBLASLt non-deterministic algorithms with FP8 KV. Slightly faster
 # but reproducibility is lost.
 allow_nondeterministic_fp8  = false
+# Restore the legacy auto-upgrade-to-FP8 behavior (off-by-default since 2026-04).
+fp8_auto_legacy             = false
 
 [attention]
 # Each "auto" key picks the kernel automatically based on weight type +
@@ -51,12 +57,22 @@ gate_concat          = false
 
 [moe]
 # Expected per-expert overhead (% of expert size) before deciding to upload
-# all experts vs. host-fall-back. 10 = aggressive, 30 = conservative.
+# all experts vs. host-fall-back. 10 = aggressive auto-pick, 30 = conservative.
 expert_overhead_pct  = 10
-force_host_experts   = false
+# Force the LAST N MoE layers off-GPU regardless of budget (debug path).
+# 0 = disabled (auto-pick).
+force_host_experts   = 0
 skip                 = false
 force_fp16_sync      = false
 no_expert_cache      = false
+# Zero MoE workspace buffers each layer (memory-safety bisect).
+zero_workspace       = false
+# Skip Gemma-4/Qwen3-Next/3.6 always-active shared MLP branch.
+no_shared_mlp        = false
+# Skip Qwen3-Next/3.6 sigmoid gate on shared expert output.
+no_shexp_gate        = false
+# Force-disable CUTLASS 3.x grouped MoE GEMM path (legacy fallback).
+no_cutlass3x         = false
 
 [gdn]
 # FP32 scan/output for Gated-DeltaNet (Qwen3.5/3.6). Slightly slower but
@@ -81,12 +97,32 @@ no_mmvq_q8_0         = false
 fp32_gemm_out        = false
 no_graphs            = false
 force_mmvq           = false
+# FP32 expert-down GEMM (Gemma-4 numerical-parity diagnostic).
+fp32_expert_down     = false
+# Disable the decode fast-path (debug bisect).
+no_decode_fast       = false
+# Disable post-FFW norm 1 in the parallel-branch path (debug).
+no_post_ffw_1        = false
+# Force ggml-style prefill matmul for Gemma-4 (debug A/B path).
+ggml_prefill         = false
 
 [generation]
 no_logit_softcap     = false
 lm_dequant_fp16      = false
 # Max tokens spent in <think>...</think> blocks (0 = unlimited).
 think_budget         = 0
+# Force-prepend BOS token even when the tokenizer says no.
+force_bos            = false
+
+[server]
+# OpenAI-compatible HTTP server: prefix caching breaks per-request
+# determinism (cached blocks get different physical KV addresses); off
+# by default.
+prefix_cache         = false
+
+[bench]
+# imp-cli --bench: also run Engine::generate() loop for accurate timing.
+generate             = false
 
 [paths]
 # Path to a vision projector .gguf file (Gemma-3, Mistral3 multimodal).
@@ -95,12 +131,17 @@ mmproj               = ""
 [diagnostics]
 # Verbose per-layer forward dumps. Heavy I/O — use only for bisecting bugs.
 debug_forward        = false
-debug_raw            = false
 debug_gemm_dispatch  = false
+# Print intermediate Jinja2 chat-template rendering steps.
+debug_template       = false
 # If non-empty, dump per-layer hidden states as .npy files to this directory.
+# Special values: "1" or "all" → /tmp.
 dump_hidden_dir      = ""
-dump_logits          = false
-dump_routing         = false
+# If non-empty, dump MoE gate logits (pre-topk) and routing weights to file.
+# Special value "all" dumps every layer (default: only last + selected layers).
+dump_logits_dir      = ""
+dump_routing_dir     = ""
+# Print prefill token IDs to stderr (truncated to 20).
 dump_tokens          = false
 # Stop forward pass after layer N (-1 = run full forward).
 exit_layer           = -1

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -17,6 +17,9 @@
 #   IMP_VERIFY_MODELS=models
 #   IMP_VERIFY_BASELINE=tests/perf_baseline.json
 #   IMP_VERIFY_SKIP_BUILD=1   skip cmake build step
+#   IMP_VERIFY_SKIP_PERF=1    skip perf-baseline regression check (use when the
+#                             baseline is known-stale; refresh with
+#                             scripts/gen_perf_baseline.sh)
 #   IMP_VERIFY_IN_DOCKER=1    sentinel set by the auto-re-exec block; do not set manually
 #
 # Auto-Docker fallback: if cmake is not on PATH (Clean-Host workflow), the
@@ -47,6 +50,7 @@ if ! command -v cmake >/dev/null 2>&1 && [ "${IMP_VERIFY_IN_DOCKER:-0}" != "1" ]
         -e IMP_VERIFY_BIN=/usr/local/bin/imp-cli \
         -e IMP_VERIFY_TESTS=/usr/local/bin/imp-tests \
         -e IMP_VERIFY_SKIP_BUILD=1 \
+        -e IMP_VERIFY_SKIP_PERF="${IMP_VERIFY_SKIP_PERF:-0}" \
         --entrypoint bash imp:test scripts/verify.sh "$@"
 fi
 
@@ -125,7 +129,9 @@ fi
 
 # --------------------------------------------------------------------- 3. perf
 section "perf vs baseline"
-if [ ! -f "$BASELINE" ]; then
+if [ "${IMP_VERIFY_SKIP_PERF:-0}" = "1" ]; then
+    skip "perf gate (IMP_VERIFY_SKIP_PERF=1)"
+elif [ ! -f "$BASELINE" ]; then
     skip "no $BASELINE — run scripts/gen_perf_baseline.sh to create one"
 elif [ ! -x "$BIN" ]; then
     fail "$BIN not found"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -36,6 +36,26 @@ pass()    { echo "${GRN}PASS${RST} $*"; }
 fail()    { echo "${RED}FAIL${RST} $*"; FAIL=$((FAIL+1)); }
 skip()    { echo "${YLW}SKIP${RST} $*"; }
 
+# Docker-only host (e.g. WSL2 with the "clean host" policy from CLAUDE.md):
+# host has neither cmake nor a build/ directory. Run the canonical Docker
+# build, then exit early — the test / perf / smoke gates below need the
+# host build artefacts and there's no clean way to reach them from here.
+# Override with IMP_VERIFY_SKIP_BUILD=1 if cmake-on-host is preferred.
+if [ "${IMP_VERIFY_SKIP_BUILD:-0}" != "1" ] && ! command -v cmake >/dev/null 2>&1; then
+    section "build (docker — host has no cmake)"
+    if make build >/tmp/imp_verify_build.log 2>&1; then
+        pass "docker build"
+    else
+        fail "docker build (see /tmp/imp_verify_build.log)"
+        tail -20 /tmp/imp_verify_build.log
+        exit 1
+    fi
+    section "remaining gates (skipped — Docker-only host)"
+    skip "tests / perf / smoke require host build artefacts; run 'make test-gpu'"
+    skip "and 'make verify' inside Docker manually for the full pre-merge gate"
+    exit 0
+fi
+
 # -------------------------------------------------------------------- 1. build
 section "build"
 if [ "${IMP_VERIFY_SKIP_BUILD:-0}" = "1" ]; then

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -116,22 +116,22 @@ const char* imp_version(void) {
     return "0.7.0";
 }
 
-// --- Helper: map ImpDType to imp::DType ---
+// --- Helper: map ImpDType to imp::QType ---
 
-static imp::DType map_dtype(ImpDType dt) {
+static imp::QType map_dtype(ImpDType dt) {
     switch (dt) {
-        case IMP_DTYPE_FP32:     return imp::DType::FP32;
-        case IMP_DTYPE_FP16:     return imp::DType::FP16;
-        case IMP_DTYPE_BF16:     return imp::DType::BF16;
-        case IMP_DTYPE_FP8_E4M3: return imp::DType::FP8_E4M3;
-        case IMP_DTYPE_FP8_E5M2: return imp::DType::FP8_E5M2;
-        case IMP_DTYPE_INT8:     return imp::DType::INT8;
-        case IMP_DTYPE_INT4:     return imp::DType::INT4;
-        case IMP_DTYPE_INT32:    return imp::DType::INT32;
-        case IMP_DTYPE_FP4_E2M1: return imp::DType::FP4_E2M1;
-        case IMP_DTYPE_TURBOQUANT: return imp::DType::TURBOQUANT;
-        case IMP_DTYPE_TURBOQUANT_LITE: return imp::DType::TURBOQUANT_LITE;
-        default:                 return imp::DType::FP16;
+        case IMP_DTYPE_FP32:     return imp::QType::F32;
+        case IMP_DTYPE_FP16:     return imp::QType::F16;
+        case IMP_DTYPE_BF16:     return imp::QType::BF16;
+        case IMP_DTYPE_FP8_E4M3: return imp::QType::FP8_E4M3;
+        case IMP_DTYPE_FP8_E5M2: return imp::QType::FP8_E5M2;
+        case IMP_DTYPE_INT8:     return imp::QType::INT8;
+        case IMP_DTYPE_INT4:     return imp::QType::INT4;
+        case IMP_DTYPE_INT32:    return imp::QType::INT32;
+        case IMP_DTYPE_FP4_E2M1: return imp::QType::FP4_E2M1;
+        case IMP_DTYPE_TURBOQUANT: return imp::QType::TURBOQUANT;
+        case IMP_DTYPE_TURBOQUANT_LITE: return imp::QType::TURBOQUANT_LITE;
+        default:                 return imp::QType::F16;
     }
 }
 

--- a/src/compute/activation.cu
+++ b/src/compute/activation.cu
@@ -254,8 +254,8 @@ static void dispatch_gated_activation(
     bool pdl_enabled, cudaStream_t stream)
 {
     const int block = 256;
-    switch (gate.dtype) {
-        case DType::FP32:
+    switch (gate.qtype) {
+        case QType::F32:
             if (n % 4 == 0 && n >= 4) {
                 const int grid = static_cast<int>((n / 4 + block - 1) / block);
                 fp32_vec4<<<grid, block, 0, stream>>>(
@@ -270,7 +270,7 @@ static void dispatch_gated_activation(
                     static_cast<float*>(out.data), n);
             }
             break;
-        case DType::FP16: {
+        case QType::F16: {
             const int64_t half_n = (n + 1) / 2;
             const int grid = static_cast<int>((half_n + block - 1) / block);
             if (pdl_enabled) {
@@ -325,8 +325,8 @@ void gelu(const Tensor& x, Tensor& out, cudaStream_t stream)
     if (n == 0) return;
 
     const int block = 256;
-    switch (x.dtype) {
-        case DType::FP32:
+    switch (x.qtype) {
+        case QType::F32:
             if (n % 4 == 0 && n >= 4) {
                 const int grid = static_cast<int>((n / 4 + block - 1) / block);
                 gelu_fp32_vec4_kernel<<<grid, block, 0, stream>>>(
@@ -339,7 +339,7 @@ void gelu(const Tensor& x, Tensor& out, cudaStream_t stream)
                     static_cast<float*>(out.data), n);
             }
             break;
-        case DType::FP16: {
+        case QType::F16: {
             const int64_t half_n = (n + 1) / 2;
             const int grid = static_cast<int>((half_n + block - 1) / block);
             gelu_fp16_kernel<<<grid, block, 0, stream>>>(

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -1,6 +1,7 @@
 #include "compute/attention.h"
 #include "compute/attention_tc.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cstdlib>
 
@@ -55,7 +56,8 @@ void attention_prefill_dispatch(
 
     // Native sm_120 FP8 FMHA: QK^T in FP8 E4M3 (m16n8k32) for 2x score throughput.
     // PV stays FP16. Set IMP_NO_FP8_FMHA=1 to force FP16 path.
-    static bool use_fp8_fmha = !getenv("IMP_NO_FP8_FMHA");
+    // [attention] fp8_fmha: "auto" (default ON) | "never"
+    const bool use_fp8_fmha = RuntimeConfig::current().attention.fp8_fmha != "never";
     if (use_fp8_fmha) {
         bool fp8_ok = fmha_sm120_fp8_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream);
         if (fp8_ok) {
@@ -67,7 +69,7 @@ void attention_prefill_dispatch(
     // Native sm_120 FP16 FMHA: WMMA for Blackwell with sliding window support.
     // Fallback when FP8 is disabled or unsupported config.
     // Set IMP_NO_FMHA_SM120=1 to skip and use WMMA fallback.
-    static bool use_fmha_sm120 = !getenv("IMP_NO_FMHA_SM120");
+    const bool use_fmha_sm120 = RuntimeConfig::current().attention.fmha_sm120 != "never";
     if (use_fmha_sm120) {
         if (fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream)) {
             return;

--- a/src/compute/attention_fmha_mxf4nvf4_sm120.cu
+++ b/src/compute/attention_fmha_mxf4nvf4_sm120.cu
@@ -26,6 +26,7 @@
 #include "compute/attention_fmha_mxf4nvf4_sm120.h"
 #include "compute/attention_fmha_mxfp4_sm120.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cstdlib>
 #include <cstring>
@@ -33,16 +34,8 @@
 namespace imp {
 
 bool mxf4nvf4_blockscale_disabled() {
-    static int cached = -1;
-    if (cached < 0) {
-        const char* v = std::getenv("IMP_FMHA_BLOCKSCALE");
-        cached = (v != nullptr && std::strcmp(v, "0") == 0) ? 1 : 0;
-        if (cached) {
-            IMP_LOG_INFO("IMP_FMHA_BLOCKSCALE=0: MXFP4 attention forced to "
-                         "legacy kind::f8f6f4.m16n8k32 path (A/B debug only).");
-        }
-    }
-    return cached == 1;
+    // [attention] fmha_blockscale = "auto" (default) | "off"
+    return RuntimeConfig::current().attention.fmha_blockscale == "off";
 }
 
 bool mxf4nvf4_blockscale_enabled() {

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -930,7 +930,7 @@ bool fmha_sm120_mxfp4_prefill(
     cudaStream_t stream,
     bool use_blockscale)
 {
-    if (Q.dtype != DType::FP16) return false;
+    if (Q.qtype != QType::F16) return false;
     // Blockscale MMA operates on K=64 per issue; head_dim must be a multiple of 64.
     // head_dim=96 (Gemma-class) is a multiple of 32 but NOT 64 → fall back to legacy.
     if (use_blockscale && (static_cast<int>(Q.shape[3]) % 64 != 0)) {

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -428,7 +428,7 @@ bool fmha_sm120_prefill(
     float scale, bool causal, int sliding_window, float softcap,
     cudaStream_t stream)
 {
-    if (Q.dtype != DType::FP16) return false;
+    if (Q.qtype != QType::F16) return false;
 
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int seq_q      = static_cast<int>(Q.shape[1]);
@@ -942,7 +942,7 @@ bool fmha_sm120_fp8_prefill(
     float scale, bool causal, int sliding_window, float softcap,
     cudaStream_t stream)
 {
-    if (Q.dtype != DType::FP16) return false;
+    if (Q.qtype != QType::F16) return false;
 
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int seq_q      = static_cast<int>(Q.shape[1]);

--- a/src/compute/attention_mxfp4_prefill.cu
+++ b/src/compute/attention_mxfp4_prefill.cu
@@ -19,6 +19,7 @@
 #include "compute/attention_mxfp4_prefill.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
@@ -482,7 +483,11 @@ bool attention_mxfp4_available() {
     static int result = -1;
     if (result >= 0) return result != 0;
 
-    if (!getenv("IMP_MXFP4_ATTENTION")) {
+    // [attention] mxfp4 = "auto" enables when supported; default "auto" is OFF
+    // for FMHA (the legacy IMP_MXFP4_ATTENTION env was opt-in). Set to "always"
+    // to force the MXFP4 prefill path on.
+    const std::string& mode = RuntimeConfig::current().attention.mxfp4;
+    if (mode != "always") {
         result = 0;
         return false;
     }

--- a/src/compute/attention_paged.cu
+++ b/src/compute/attention_paged.cu
@@ -2,6 +2,7 @@
 #include "compute/attention_paged_common.cuh"
 #include "compute/attention.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cooperative_groups.h>
@@ -1451,7 +1452,7 @@ void paged_attention_decode(
         // Use pipelined cp.async kernel on sm_90+ for better memory/compute overlap.
         // IMP_SPLITK_NO_PIPE forces non-pipeline as a bisect escape hatch.
         static int sm_ver = get_device_sm_version();
-        static bool force_non_pipe = getenv("IMP_SPLITK_NO_PIPE") != nullptr;
+        const bool force_non_pipe = !RuntimeConfig::current().attention.splitk_pipe;
         if (sm_ver >= 90 && !force_non_pipe) {
             // Pipeline smem: 8 warps * 3 * head_dim * 2B (FP16)
             // Must be at least as large as reduction smem

--- a/src/compute/embedding.cu
+++ b/src/compute/embedding.cu
@@ -1,5 +1,5 @@
 #include "compute/embedding.h"
-#include "model/model_config.h"  // GGMLQuantType
+#include "model/model_config.h"  // QType
 #include "core/tensor.h"
 #include "core/logging.h"
 #include <cuda_runtime.h>
@@ -190,8 +190,8 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids,
 
     if (n_tokens == 0) return;
 
-    switch (table.dtype) {
-        case DType::FP32: {
+    switch (table.qtype) {
+        case QType::F32: {
             if (d_model % 4 == 0) {
                 embedding_lookup_vec_kernel<float><<<n_tokens, block, 0, stream>>>(
                     static_cast<const float*>(table.data),
@@ -207,7 +207,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids,
             }
             break;
         }
-        case DType::FP16: {
+        case QType::F16: {
             if (d_model % 4 == 0) {
                 embedding_lookup_vec_kernel<__half><<<n_tokens, block, 0, stream>>>(
                     static_cast<const __half*>(table.data),
@@ -223,7 +223,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids,
             }
             break;
         }
-        case DType::BF16: {
+        case QType::BF16: {
             embedding_lookup_vec_kernel<uint16_t><<<n_tokens, block, 0, stream>>>(
                 static_cast<const uint16_t*>(table.data),
                 token_ids,
@@ -242,7 +242,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids,
 // --------------------------------------------------------------------------
 void embedding_lookup(const Tensor& table, const int32_t* token_ids,
                       int n_tokens, Tensor& out,
-                      GGMLQuantType qtype,
+                      QType qtype,
                       cudaStream_t stream)
 {
     if (n_tokens == 0) return;
@@ -250,7 +250,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids,
     const int d_model = static_cast<int>(table.shape[1]);
     const int block = 256;
 
-    if (qtype == GGMLQuantType::Q8_0) {
+    if (qtype == QType::Q8_0) {
         embedding_lookup_q8_0_kernel<<<n_tokens, block, 0, stream>>>(
             static_cast<const uint8_t*>(table.data),
             token_ids,
@@ -259,7 +259,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids,
         return;
     }
 
-    if (qtype == GGMLQuantType::Q6_K) {
+    if (qtype == QType::Q6_K) {
         embedding_lookup_q6k_kernel<<<n_tokens, block, 0, stream>>>(
             static_cast<const uint8_t*>(table.data),
             token_ids,
@@ -344,13 +344,13 @@ void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id
     const int d_model = static_cast<int>(table.shape[1]);
     const int block = 256;
 
-    if (table.dtype == DType::FP16) {
+    if (table.qtype == QType::F16) {
         embedding_lookup_fp16_device_kernel<<<1, block, 0, stream>>>(
             static_cast<const __half*>(table.data),
             d_token_id,
             static_cast<__half*>(out.data),
             d_model);
-    } else if (table.dtype == DType::FP32) {
+    } else if (table.qtype == QType::F32) {
         // For FP32 tables, fall back to regular path with a device-to-host copy
         // (FP32 embedding tables are uncommon in quantized models)
         int32_t h_token;
@@ -362,12 +362,12 @@ void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id
 }
 
 void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id,
-                                   Tensor& out, GGMLQuantType qtype,
+                                   Tensor& out, QType qtype,
                                    cudaStream_t stream) {
     const int d_model = static_cast<int>(table.shape[1]);
     const int block = 256;
 
-    if (qtype == GGMLQuantType::Q8_0) {
+    if (qtype == QType::Q8_0) {
         embedding_lookup_q8_0_device_kernel<<<1, block, 0, stream>>>(
             static_cast<const uint8_t*>(table.data),
             d_token_id,
@@ -376,7 +376,7 @@ void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id
         return;
     }
 
-    if (qtype == GGMLQuantType::Q6_K) {
+    if (qtype == QType::Q6_K) {
         embedding_lookup_q6k_device_kernel<<<1, block, 0, stream>>>(
             static_cast<const uint8_t*>(table.data),
             d_token_id,

--- a/src/compute/embedding.h
+++ b/src/compute/embedding.h
@@ -6,8 +6,6 @@
 
 namespace imp {
 
-enum class GGMLQuantType : uint32_t;  // forward declaration
-
 void embedding_lookup(const Tensor& table, const int32_t* token_ids,
                       int n_tokens, Tensor& out,
                       cudaStream_t stream = nullptr);
@@ -16,7 +14,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids,
 // Dequantizes only the needed rows on the fly.
 void embedding_lookup(const Tensor& table, const int32_t* token_ids,
                       int n_tokens, Tensor& out,
-                      GGMLQuantType qtype,
+                      QType qtype,
                       cudaStream_t stream);
 
 // Device-side embedding lookup: reads token ID from device memory (d_token_id[0]).
@@ -25,7 +23,7 @@ void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id
                                    Tensor& out, cudaStream_t stream = nullptr);
 
 void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id,
-                                   Tensor& out, GGMLQuantType qtype,
+                                   Tensor& out, QType qtype,
                                    cudaStream_t stream);
 
 } // namespace imp

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -1,6 +1,7 @@
 #include "compute/gemm.h"
 #include "core/logging.h"
 #include "runtime/pdl.h"
+#include "runtime/config.h"
 
 #include <cublas_v2.h>
 #include <cublasLt.h>
@@ -322,9 +323,9 @@ static void benchmark_and_select_algo(
     cublasLtMatmulPreferenceDestroy(pref);
 
     if (nresults <= 0) { entry.has_algo = false; entry.workspace_size = 0; return; }
-    // IMP_DETERMINISTIC_GEMM=1 skips timing-based selection so repeat runs
-    // produce bitwise-identical prefill outputs (needed for layer-drift A/B).
-    static const bool s_deterministic_gemm = getenv("IMP_DETERMINISTIC_GEMM") != nullptr;
+    // [runtime] deterministic_gemm = true skips timing-based selection so
+    // repeat runs produce bitwise-identical prefill outputs.
+    const bool s_deterministic_gemm = RuntimeConfig::current().runtime.deterministic_gemm;
     if (s_deterministic_gemm || nresults == 1) {
         entry.algo = results[0].algo;
         entry.workspace_size = (results[0].workspaceSize <= s_workspace_size)

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -127,17 +127,17 @@ void gemm_init() {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: map DType -> cudaDataType
+// Helper: map QType -> cudaDataType
 // ---------------------------------------------------------------------------
-static cudaDataType_t dtype_to_cuda(DType dt) {
+static cudaDataType_t dtype_to_cuda(QType dt) {
     switch (dt) {
-        case DType::FP32:     return CUDA_R_32F;
-        case DType::FP16:     return CUDA_R_16F;
-        case DType::BF16:     return CUDA_R_16BF;
-        case DType::FP8_E4M3: return CUDA_R_8F_E4M3;
-        case DType::FP8_E5M2: return CUDA_R_8F_E5M2;
-        case DType::INT8:     return CUDA_R_8I;
-        case DType::INT32:    return CUDA_R_32I;
+        case QType::F32:     return CUDA_R_32F;
+        case QType::F16:     return CUDA_R_16F;
+        case QType::BF16:     return CUDA_R_16BF;
+        case QType::FP8_E4M3: return CUDA_R_8F_E4M3;
+        case QType::FP8_E5M2: return CUDA_R_8F_E5M2;
+        case QType::INT8:     return CUDA_R_8I;
+        case QType::INT32:    return CUDA_R_32I;
         default:
             fprintf(stderr, "imp::gemm: unsupported dtype %d\n", (int)dt);
             return CUDA_R_16F;  // fallback (caller guard should prevent reaching here)
@@ -147,14 +147,14 @@ static cudaDataType_t dtype_to_cuda(DType dt) {
 // ---------------------------------------------------------------------------
 // Helper: choose cuBLAS compute type for a given operand dtype
 // ---------------------------------------------------------------------------
-static cublasComputeType_t dtype_to_compute(DType dt) {
+static cublasComputeType_t dtype_to_compute(QType dt) {
     switch (dt) {
-        case DType::FP32:     return CUBLAS_COMPUTE_32F;
-        case DType::FP16:     return CUBLAS_COMPUTE_32F;   // accumulate in FP32 for accuracy
-        case DType::BF16:     return CUBLAS_COMPUTE_32F;
-        case DType::FP8_E4M3: return CUBLAS_COMPUTE_32F;
-        case DType::FP8_E5M2: return CUBLAS_COMPUTE_32F;
-        case DType::INT8:     return CUBLAS_COMPUTE_32I;
+        case QType::F32:     return CUBLAS_COMPUTE_32F;
+        case QType::F16:     return CUBLAS_COMPUTE_32F;   // accumulate in FP32 for accuracy
+        case QType::BF16:     return CUBLAS_COMPUTE_32F;
+        case QType::FP8_E4M3: return CUBLAS_COMPUTE_32F;
+        case QType::FP8_E5M2: return CUBLAS_COMPUTE_32F;
+        case QType::INT8:     return CUBLAS_COMPUTE_32I;
         default:              return CUBLAS_COMPUTE_32F;
     }
 }
@@ -408,15 +408,15 @@ static bool gemm_try_gemv(const Tensor& A, const Tensor& B, Tensor& C,
                            float alpha, float beta, cudaStream_t stream) {
     const int64_t M = A.shape[0];
     if (M != 1 || alpha != 1.0f || beta != 0.0f) return false;
-    if (A.dtype != B.dtype || A.dtype != C.dtype) return false;
-    if (A.dtype != DType::FP16 && A.dtype != DType::FP32 && A.dtype != DType::BF16) return false;
+    if (A.qtype != B.qtype || A.qtype != C.qtype) return false;
+    if (A.qtype != QType::F16 && A.qtype != QType::F32 && A.qtype != QType::BF16) return false;
 
     const int64_t K = A.shape[1];
     const int64_t N = B.shape[0];
 
     Tensor x_vec;
     x_vec.data = A.data;
-    x_vec.dtype = A.dtype;
+    x_vec.qtype = A.qtype;
     x_vec.ndim = 1;
     x_vec.shape[0] = K;
     x_vec.stride[0] = 1;
@@ -424,7 +424,7 @@ static bool gemm_try_gemv(const Tensor& A, const Tensor& B, Tensor& C,
 
     Tensor y_vec;
     y_vec.data = C.data;
-    y_vec.dtype = C.dtype;
+    y_vec.qtype = C.qtype;
     y_vec.ndim = 1;
     y_vec.shape[0] = N;
     y_vec.stride[0] = 1;
@@ -440,7 +440,7 @@ static bool gemm_try_gemv(const Tensor& A, const Tensor& B, Tensor& C,
 // Returns true if handled.
 static bool gemm_try_sgemm(const Tensor& A, const Tensor& B, Tensor& C,
                              float alpha, float beta, cudaStream_t stream) {
-    if (A.dtype != DType::FP32 || B.dtype != DType::FP32 || C.dtype != DType::FP32)
+    if (A.qtype != QType::F32 || B.qtype != QType::F32 || C.qtype != QType::F32)
         return false;
 
     const int64_t M = A.shape[0];
@@ -480,10 +480,10 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C,
         return;  // Skip empty weight
     }
 
-    cudaDataType_t cuda_dtype_A = dtype_to_cuda(A.dtype);
-    cudaDataType_t cuda_dtype_B = dtype_to_cuda(B.dtype);
-    cudaDataType_t cuda_dtype_C = dtype_to_cuda(C.dtype);
-    cublasComputeType_t compute_type = dtype_to_compute(A.dtype);
+    cudaDataType_t cuda_dtype_A = dtype_to_cuda(A.qtype);
+    cudaDataType_t cuda_dtype_B = dtype_to_cuda(B.qtype);
+    cudaDataType_t cuda_dtype_C = dtype_to_cuda(C.qtype);
+    cublasComputeType_t compute_type = dtype_to_compute(A.qtype);
 
     // Mixed-precision output (e.g. FP16×FP16 → FP32 for diagnostic precision
     // probes): bypass cuBLASLt and use cublasGemmEx directly. cuBLASLt's
@@ -491,8 +491,8 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C,
     // FP16→FP32 dimensions on sm_120 (sums in the billions while real
     // attention output is ±100). cublasGemmEx is the legacy, well-tested API
     // that handles FP16×FP16→FP32 with CUBLAS_COMPUTE_32F correctly.
-    if (A.dtype != C.dtype && A.dtype == DType::FP16 && B.dtype == DType::FP16
-        && C.dtype == DType::FP32) {
+    if (A.qtype != C.qtype && A.qtype == QType::F16 && B.qtype == QType::F16
+        && C.qtype == QType::F32) {
         cublasHandle_t fb_handle = get_cublas_handle();
         cublasSetStream(fb_handle, stream);
         cublasStatus_t st = cublasGemmEx(fb_handle,
@@ -530,7 +530,7 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C,
             create_gemm_descriptors(new_entry, compute_type, scale_type,
                 cuda_dtype_A, cuda_dtype_B, cuda_dtype_C, (int)K, (int)M, (int)N);
 
-            size_t c_bytes = (size_t)M * N * dtype_size(C.dtype);
+            size_t c_bytes = (size_t)M * N * dtype_size(C.qtype);
             benchmark_and_select_algo(lt, new_entry,
                 A.data, B.data, c_bytes, alpha, beta,
                 (compute_type == CUBLAS_COMPUTE_32I), stream);
@@ -627,7 +627,7 @@ void gemm(const Tensor& A, const Tensor& B, Tensor& C,
     // that should have been handled by the FP16 weight cache path.
     // Passing raw quantized data to cuBLAS causes illegal memory access
     // (cuBLAS reads sizeof(FP16)*numel bytes but only sizeof(quant)*numel exist).
-    if (B.dtype == DType::INT4) {
+    if (B.qtype == QType::INT4) {
         // This should never be reached — FP16 cache or gemm_dispatch should
         // handle quantized weights. If we get here, output will be zero (safe).
         return;
@@ -855,8 +855,8 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y,
     const int blocks = gemv_blocks(M);
 
     for (int b = 0; b < batch; ++b) {
-        switch (A.dtype) {
-            case DType::FP32: {
+        switch (A.qtype) {
+            case QType::F32: {
                 const float* A_ptr = static_cast<const float*>(A.data);
                 const float* x_ptr = static_cast<const float*>(x.data) + (int64_t)b * K;
                 float* y_ptr       = static_cast<float*>(y.data)       + (int64_t)b * M;
@@ -864,7 +864,7 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y,
                     A_ptr, x_ptr, y_ptr, M, K);
                 break;
             }
-            case DType::FP16: {
+            case QType::F16: {
                 const half* A_ptr = static_cast<const half*>(A.data);
                 const half* x_ptr = static_cast<const half*>(x.data) + (int64_t)b * K;
                 half* y_ptr       = static_cast<half*>(y.data)       + (int64_t)b * M;
@@ -872,7 +872,7 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y,
                     A_ptr, x_ptr, y_ptr, M, K);
                 break;
             }
-            case DType::BF16: {
+            case QType::BF16: {
                 const __nv_bfloat16* A_ptr = static_cast<const __nv_bfloat16*>(A.data);
                 const __nv_bfloat16* x_ptr = static_cast<const __nv_bfloat16*>(x.data) + (int64_t)b * K;
                 __nv_bfloat16* y_ptr       = static_cast<__nv_bfloat16*>(y.data)       + (int64_t)b * M;
@@ -884,8 +884,8 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y,
                 // Fallback: use cuBLAS gemv for other dtypes via gemm with N=1.
                 // Construct a temporary Tensor view for the column vectors.
                 Tensor x_col;
-                x_col.data = static_cast<char*>(x.data) + b * K * dtype_size(x.dtype);
-                x_col.dtype = x.dtype;
+                x_col.data = static_cast<char*>(x.data) + b * K * dtype_size(x.qtype);
+                x_col.qtype = x.qtype;
                 x_col.ndim = 2;
                 x_col.shape[0] = K;
                 x_col.shape[1] = 1;
@@ -894,8 +894,8 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y,
                 x_col.on_device = true;
 
                 Tensor y_col;
-                y_col.data = static_cast<char*>(y.data) + b * M * dtype_size(y.dtype);
-                y_col.dtype = y.dtype;
+                y_col.data = static_cast<char*>(y.data) + b * M * dtype_size(y.qtype);
+                y_col.qtype = y.qtype;
                 y_col.ndim = 2;
                 y_col.shape[0] = M;
                 y_col.shape[1] = 1;
@@ -926,9 +926,9 @@ void gemm_cublaslt(const Tensor& A, const Tensor& B, Tensor& C,
 
     // Cache key: (M, K, N, dtypes, beta) — scale pointers vary per-call but
     // don't affect descriptor/algo selection, only set via opDesc attribute.
-    cudaDataType_t cuda_dtype_A = dtype_to_cuda(A.dtype);
-    cudaDataType_t cuda_dtype_B = dtype_to_cuda(B.dtype);
-    cudaDataType_t cuda_dtype_C = dtype_to_cuda(C.dtype);
+    cudaDataType_t cuda_dtype_A = dtype_to_cuda(A.qtype);
+    cudaDataType_t cuda_dtype_B = dtype_to_cuda(B.qtype);
+    cudaDataType_t cuda_dtype_C = dtype_to_cuda(C.qtype);
     GemmCacheKey cache_key{cuda_dtype_A, cuda_dtype_B, cuda_dtype_C, CUBLAS_COMPUTE_32F,
                            bucket_m(M), K, N, (aScale != nullptr)};
 
@@ -948,7 +948,7 @@ void gemm_cublaslt(const Tensor& A, const Tensor& B, Tensor& C,
             // Set scale pointers before benchmarking so FP8 algos run correctly
             set_gemm_scale_pointers(new_entry.opDesc, aScale, bScale);
 
-            size_t c_bytes = (size_t)M * N * dtype_size(C.dtype);
+            size_t c_bytes = (size_t)M * N * dtype_size(C.qtype);
             benchmark_and_select_algo(lt, new_entry,
                 A.data, B.data, c_bytes, alpha, beta, false, stream);
 
@@ -1638,7 +1638,7 @@ void gemm_kv_batched(const Tensor& input, const Tensor& weight_kv,
     cublasHandle_t handle = get_cublas_handle();
     cublasSetStream(handle, stream);
 
-    cudaDataType_t dt = dtype_to_cuda(input.dtype);
+    cudaDataType_t dt = dtype_to_cuda(input.qtype);
     float alpha = 1.0f, beta = 0.0f;
 
     // Col-major interpretation (same trick as gemm()):
@@ -1679,14 +1679,14 @@ void gemm_pair_batched(const Tensor& input, const Tensor& weight_fused,
     cublasHandle_t handle = get_cublas_handle();
     cublasSetStream(handle, stream);
 
-    cudaDataType_t dt = dtype_to_cuda(input.dtype);
+    cudaDataType_t dt = dtype_to_cuda(input.qtype);
     float alpha = 1.0f, beta = 0.0f;
 
     long long weight_stride = static_cast<long long>(N) * K;
     // Compute actual byte offset between out1 and out2, then convert to element offset
     long long output_stride = (static_cast<const char*>(out2.data) -
                                static_cast<const char*>(out1.data)) /
-                              dtype_size(input.dtype);
+                              dtype_size(input.qtype);
 
     cublasStatus_t st = cublasGemmStridedBatchedEx(
         handle,

--- a/src/compute/gemm.h
+++ b/src/compute/gemm.h
@@ -6,8 +6,6 @@
 
 namespace imp {
 
-enum class GGMLQuantType : uint32_t;  // forward declaration
-
 // Pre-initialize cuBLAS handle and workspace. Call early (before weight upload)
 // to ensure workspace is allocated while GPU memory is available.
 void gemm_init();
@@ -150,7 +148,7 @@ void gemv_q3_k_q8_1_residual(const void* W, const block_q8_1* q8_1, const float*
 void gemv_gate_up_fused(const void* gate_weights, const void* up_weights,
                          const block_q8_1* q8_1, const float* d8,
                          half* y_gate, half* y_up,
-                         int M, int K, GGMLQuantType qtype,
+                         int M, int K, QType qtype,
                          cudaStream_t stream = nullptr);
 
 // ---------------------------------------------------------------------------

--- a/src/compute/gemm_dp4a.cu
+++ b/src/compute/gemm_dp4a.cu
@@ -1,7 +1,7 @@
 #include "compute/gemm.h"
 #include "compute/gemv_dp4a_traits.cuh"
 #include "runtime/pdl.h"
-#include "model/model_config.h"  // GGMLQuantType
+#include "model/model_config.h"  // QType
 
 #include <cuda_fp16.h>
 #include <cstdio>
@@ -407,7 +407,7 @@ IMP_DP4A_QUANT_TYPES(IMP_DEFINE_GEMV_DP4A_QKV)
 void gemv_gate_up_fused(const void* gate_weights, const void* up_weights,
                          const block_q8_1* q8_1, const float* d8,
                          half* y_gate, half* y_up,
-                         int M, int K, GGMLQuantType qtype,
+                         int M, int K, QType qtype,
                          cudaStream_t stream) {
     const int threads_per_block = 256;
     const int warps_per_block = threads_per_block / 32;
@@ -450,13 +450,13 @@ void gemv_gate_up_fused(const void* gate_weights, const void* up_weights,
         LAUNCH_GATE_UP_NR(QT, 1); \
     } while(0)
 
-    if      (qtype == GGMLQuantType::Q6_K) { DISPATCH_GATE_UP(Q6_K_Traits); }
-    else if (qtype == GGMLQuantType::Q8_0) { DISPATCH_GATE_UP(Q8_0_Traits); }
-    else if (qtype == GGMLQuantType::Q4_0) { DISPATCH_GATE_UP(Q4_0_Traits); }
-    else if (qtype == GGMLQuantType::Q4_K) { DISPATCH_GATE_UP(Q4_K_Traits); }
-    else if (qtype == GGMLQuantType::Q5_K) { DISPATCH_GATE_UP(Q5_K_Traits); }
-    else if (qtype == GGMLQuantType::Q2_K) { DISPATCH_GATE_UP(Q2_K_Traits); }
-    else if (qtype == GGMLQuantType::Q3_K) { DISPATCH_GATE_UP(Q3_K_Traits); }
+    if      (qtype == QType::Q6_K) { DISPATCH_GATE_UP(Q6_K_Traits); }
+    else if (qtype == QType::Q8_0) { DISPATCH_GATE_UP(Q8_0_Traits); }
+    else if (qtype == QType::Q4_0) { DISPATCH_GATE_UP(Q4_0_Traits); }
+    else if (qtype == QType::Q4_K) { DISPATCH_GATE_UP(Q4_K_Traits); }
+    else if (qtype == QType::Q5_K) { DISPATCH_GATE_UP(Q5_K_Traits); }
+    else if (qtype == QType::Q2_K) { DISPATCH_GATE_UP(Q2_K_Traits); }
+    else if (qtype == QType::Q3_K) { DISPATCH_GATE_UP(Q3_K_Traits); }
 
 #undef DISPATCH_GATE_UP
 #undef LAUNCH_GATE_UP_NR

--- a/src/compute/gemm_grouped.cu
+++ b/src/compute/gemm_grouped.cu
@@ -34,17 +34,17 @@ static cublasHandle_t get_cublas_handle() {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: map DType -> cudaDataType
+// Helper: map QType -> cudaDataType
 // ---------------------------------------------------------------------------
-static cudaDataType_t dtype_to_cuda(DType dt) {
+static cudaDataType_t dtype_to_cuda(QType dt) {
     switch (dt) {
-        case DType::FP32:     return CUDA_R_32F;
-        case DType::FP16:     return CUDA_R_16F;
-        case DType::BF16:     return CUDA_R_16BF;
-        case DType::FP8_E4M3: return CUDA_R_8F_E4M3;
-        case DType::FP8_E5M2: return CUDA_R_8F_E5M2;
-        case DType::INT8:     return CUDA_R_8I;
-        case DType::INT32:    return CUDA_R_32I;
+        case QType::F32:     return CUDA_R_32F;
+        case QType::F16:     return CUDA_R_16F;
+        case QType::BF16:     return CUDA_R_16BF;
+        case QType::FP8_E4M3: return CUDA_R_8F_E4M3;
+        case QType::FP8_E5M2: return CUDA_R_8F_E5M2;
+        case QType::INT8:     return CUDA_R_8I;
+        case QType::INT32:    return CUDA_R_32I;
         default:
             fprintf(stderr, "imp::gemm_grouped: unsupported dtype %d\n", (int)dt);
             abort();
@@ -54,14 +54,14 @@ static cudaDataType_t dtype_to_cuda(DType dt) {
 // ---------------------------------------------------------------------------
 // Helper: choose cuBLAS compute type for a given operand dtype
 // ---------------------------------------------------------------------------
-static cublasComputeType_t dtype_to_compute(DType dt) {
+static cublasComputeType_t dtype_to_compute(QType dt) {
     switch (dt) {
-        case DType::FP32:     return CUBLAS_COMPUTE_32F;
-        case DType::FP16:     return CUBLAS_COMPUTE_32F;
-        case DType::BF16:     return CUBLAS_COMPUTE_32F;
-        case DType::FP8_E4M3: return CUBLAS_COMPUTE_32F;
-        case DType::FP8_E5M2: return CUBLAS_COMPUTE_32F;
-        case DType::INT8:     return CUBLAS_COMPUTE_32I;
+        case QType::F32:     return CUBLAS_COMPUTE_32F;
+        case QType::F16:     return CUBLAS_COMPUTE_32F;
+        case QType::BF16:     return CUBLAS_COMPUTE_32F;
+        case QType::FP8_E4M3: return CUBLAS_COMPUTE_32F;
+        case QType::FP8_E5M2: return CUBLAS_COMPUTE_32F;
+        case QType::INT8:     return CUBLAS_COMPUTE_32I;
         default:              return CUBLAS_COMPUTE_32F;
     }
 }
@@ -85,10 +85,10 @@ static void run_expert_matmul(cublasHandle_t handle,
 
     if (Mi == 0) return;
 
-    cudaDataType_t cuda_dt_A = dtype_to_cuda(Ai.dtype);
-    cudaDataType_t cuda_dt_B = dtype_to_cuda(Bi.dtype);
-    cudaDataType_t cuda_dt_C = dtype_to_cuda(Ci.dtype);
-    cublasComputeType_t compute_type = dtype_to_compute(Ai.dtype);
+    cudaDataType_t cuda_dt_A = dtype_to_cuda(Ai.qtype);
+    cudaDataType_t cuda_dt_B = dtype_to_cuda(Bi.qtype);
+    cudaDataType_t cuda_dt_C = dtype_to_cuda(Ci.qtype);
+    cublasComputeType_t compute_type = dtype_to_compute(Ai.qtype);
 
     cublasSetStream(handle, stream);
 
@@ -182,11 +182,11 @@ void gemm_grouped(const std::vector<Tensor>& A,
 void gemm_moe_batched(const void* a_base, void* c_base,
                       const int32_t* offsets,
                       const void* const* b_ptrs,
-                      int K, int N, DType dtype,
+                      int K, int N, QType dtype,
                       int n_experts,
                       cudaStream_t stream,
                       void** d_work_ptrs,
-                      DType output_dtype,
+                      QType output_dtype,
                       const float* a_scales,
                       const float* b_scales)
 {
@@ -214,7 +214,7 @@ void gemm_moe_batched(const void* a_base, void* c_base,
     size_t elem_sz = dtype_size(dtype);
 
     // Output type: defaults to input type if not specified
-    DType out_dt = (output_dtype != DType(255)) ? output_dtype : dtype;
+    QType out_dt = (output_dtype != QType(255)) ? output_dtype : dtype;
     cudaDataType_t cuda_dt_c = dtype_to_cuda(out_dt);
     size_t out_elem_sz = dtype_size(out_dt);
 

--- a/src/compute/gemm_grouped.h
+++ b/src/compute/gemm_grouped.h
@@ -37,11 +37,11 @@ void gemm_grouped(const std::vector<Tensor>& A,
 void gemm_moe_batched(const void* a_base, void* c_base,
                       const int32_t* offsets,
                       const void* const* b_ptrs,
-                      int K, int N, DType dtype,
+                      int K, int N, QType dtype,
                       int n_experts,
                       cudaStream_t stream = nullptr,
                       void** d_work_ptrs = nullptr,
-                      DType output_dtype = DType(255),
+                      QType output_dtype = QType(255),
                       const float* a_scales = nullptr,
                       const float* b_scales = nullptr);
 

--- a/src/compute/gemv_dp4a_traits.cuh
+++ b/src/compute/gemv_dp4a_traits.cuh
@@ -17,8 +17,8 @@ namespace imp {
 // With stride 9: lane i starts at bank (i*9)%32 — all unique, zero conflicts.
 static constexpr int kSmemQ8Stride = 9;
 
-// Tag enum for template dispatch (separate from GGMLQuantType)
-enum class QType { Q4_0, Q8_0, Q6_K, Q4_K, Q5_K, Q2_K, Q3_K, Q5_1 };
+// File-local tag enum for template dispatch (distinct from imp::QType).
+enum class DPQTag { Q4_0, Q8_0, Q6_K, Q4_K, Q5_K, Q2_K, Q3_K, Q5_1 };
 
 // ============================================================================
 // Helper device functions (moved from gemm.cu, unchanged)
@@ -174,7 +174,7 @@ __device__ __forceinline__ float q5k_dp4a_sub(
 }
 
 // ============================================================================
-// DequantTraits<QType> — compile-time constants + dp4a_block() per type
+// DequantTraits<DPQTag> — compile-time constants + dp4a_block() per type
 //
 // dp4a_block(bp, sub, xi, dq, q8_sum):
 //   bp      — pointer to the start of the weight block/super-block
@@ -184,9 +184,9 @@ __device__ __forceinline__ float q5k_dp4a_sub(
 //   q8_sum  — sum of Q8_1 int8 values (only used by Q4_0)
 // ============================================================================
 
-template<QType Q> struct DequantTraits;
+template<DPQTag Q> struct DequantTraits;
 
-template<> struct DequantTraits<QType::Q6_K> {
+template<> struct DequantTraits<DPQTag::Q6_K> {
     static constexpr int kBlockBytes   = 210;
     static constexpr int kBlockElems   = 256;
     static constexpr int kQ8PerWeight  = 8;
@@ -204,7 +204,7 @@ template<> struct DequantTraits<QType::Q6_K> {
     }
 };
 
-template<> struct DequantTraits<QType::Q8_0> {
+template<> struct DequantTraits<DPQTag::Q8_0> {
     static constexpr int kBlockBytes   = 34;
     static constexpr int kBlockElems   = 32;
     static constexpr int kQ8PerWeight  = 1;
@@ -236,7 +236,7 @@ template<> struct DequantTraits<QType::Q8_0> {
     }
 };
 
-template<> struct DequantTraits<QType::Q4_0> {
+template<> struct DequantTraits<DPQTag::Q4_0> {
     static constexpr int kBlockBytes   = 18;
     static constexpr int kBlockElems   = 32;
     static constexpr int kQ8PerWeight  = 1;
@@ -276,7 +276,7 @@ template<> struct DequantTraits<QType::Q4_0> {
     }
 };
 
-template<> struct DequantTraits<QType::Q4_K> {
+template<> struct DequantTraits<DPQTag::Q4_K> {
     static constexpr int kBlockBytes   = 144;
     static constexpr int kBlockElems   = 256;
     static constexpr int kQ8PerWeight  = 8;
@@ -301,7 +301,7 @@ template<> struct DequantTraits<QType::Q4_K> {
     }
 };
 
-template<> struct DequantTraits<QType::Q5_K> {
+template<> struct DequantTraits<DPQTag::Q5_K> {
     static constexpr int kBlockBytes   = 176;
     static constexpr int kBlockElems   = 256;
     static constexpr int kQ8PerWeight  = 8;
@@ -327,7 +327,7 @@ template<> struct DequantTraits<QType::Q5_K> {
     }
 };
 
-template<> struct DequantTraits<QType::Q2_K> {
+template<> struct DequantTraits<DPQTag::Q2_K> {
     static constexpr int kBlockBytes   = 84;
     static constexpr int kBlockElems   = 256;
     static constexpr int kQ8PerWeight  = 8;
@@ -391,7 +391,7 @@ template<> struct DequantTraits<QType::Q2_K> {
     }
 };
 
-template<> struct DequantTraits<QType::Q3_K> {
+template<> struct DequantTraits<DPQTag::Q3_K> {
     static constexpr int kBlockBytes   = 110;
     static constexpr int kBlockElems   = 256;
     static constexpr int kQ8PerWeight  = 8;
@@ -482,7 +482,7 @@ template<> struct DequantTraits<QType::Q3_K> {
 // Convenience aliases
 // Q5_1: 24 bytes per 32 elements: [2B delta_fp16] [2B min_fp16] [16B low_nibbles] [4B high_bits]
 // Dequant: val = q5 * delta + min, where q5 = low4 | (hi1 << 4), range 0..31
-template<> struct DequantTraits<QType::Q5_1> {
+template<> struct DequantTraits<DPQTag::Q5_1> {
     static constexpr int kBlockBytes   = 24;
     static constexpr int kBlockElems   = 32;
     static constexpr int kQ8PerWeight  = 1;
@@ -531,14 +531,14 @@ template<> struct DequantTraits<QType::Q5_1> {
     }
 };
 
-using Q5_1_Traits = DequantTraits<QType::Q5_1>;
-using Q4_0_Traits = DequantTraits<QType::Q4_0>;
-using Q8_0_Traits = DequantTraits<QType::Q8_0>;
-using Q6_K_Traits = DequantTraits<QType::Q6_K>;
-using Q4_K_Traits = DequantTraits<QType::Q4_K>;
-using Q5_K_Traits = DequantTraits<QType::Q5_K>;
-using Q2_K_Traits = DequantTraits<QType::Q2_K>;
-using Q3_K_Traits = DequantTraits<QType::Q3_K>;
+using Q5_1_Traits = DequantTraits<DPQTag::Q5_1>;
+using Q4_0_Traits = DequantTraits<DPQTag::Q4_0>;
+using Q8_0_Traits = DequantTraits<DPQTag::Q8_0>;
+using Q6_K_Traits = DequantTraits<DPQTag::Q6_K>;
+using Q4_K_Traits = DequantTraits<DPQTag::Q4_K>;
+using Q5_K_Traits = DequantTraits<DPQTag::Q5_K>;
+using Q2_K_Traits = DequantTraits<DPQTag::Q2_K>;
+using Q3_K_Traits = DequantTraits<DPQTag::Q3_K>;
 
 // ============================================================================
 // K-parallel helpers and occupancy heuristic

--- a/src/compute/ggml_mmvq.cu
+++ b/src/compute/ggml_mmvq.cu
@@ -440,10 +440,10 @@ static __device__ __forceinline__ float vec_dot_q8_0_q8_1(
 // MMVQ kernel — warp-per-row, simplified from ggml mul_mat_vec_q
 // -------------------------------------------------------------------------
 
-// Template tag for dispatch
-enum class QType { Q4_K, Q5_1, Q5_K, Q8_0 };
+// File-local template tag for dispatch (distinct from imp::QType).
+enum class MMVQTag { Q4_K, Q5_1, Q5_K, Q8_0 };
 
-template <QType qtype>
+template <MMVQTag qtype>
 static __global__ void mmvq_kernel(
     const void* __restrict__ W,
     const ggml_block_q8_1* __restrict__ x_q8,
@@ -454,15 +454,15 @@ static __global__ void mmvq_kernel(
     // Grid: (N, M), Block: (32, nwarps)
     constexpr int nwarps = 4;
 
-    constexpr int qk  = (qtype == QType::Q4_K) ? QK4_K
-                       : (qtype == QType::Q5_K) ? QK5_K
-                       : (qtype == QType::Q8_0) ? QK8_0 : QK5_1;
-    constexpr int qi  = (qtype == QType::Q4_K) ? QI4_K
-                       : (qtype == QType::Q5_K) ? QI5_K
-                       : (qtype == QType::Q8_0) ? QI8_0 : QI5_1;
-    constexpr int vdr = (qtype == QType::Q4_K) ? VDR_Q4_K
-                       : (qtype == QType::Q5_K) ? VDR_Q5_K
-                       : (qtype == QType::Q8_0) ? VDR_Q8_0 : VDR_Q5_1;
+    constexpr int qk  = (qtype == MMVQTag::Q4_K) ? QK4_K
+                       : (qtype == MMVQTag::Q5_K) ? QK5_K
+                       : (qtype == MMVQTag::Q8_0) ? QK8_0 : QK5_1;
+    constexpr int qi  = (qtype == MMVQTag::Q4_K) ? QI4_K
+                       : (qtype == MMVQTag::Q5_K) ? QI5_K
+                       : (qtype == MMVQTag::Q8_0) ? QI8_0 : QI5_1;
+    constexpr int vdr = (qtype == MMVQTag::Q4_K) ? VDR_Q4_K
+                       : (qtype == MMVQTag::Q5_K) ? VDR_Q5_K
+                       : (qtype == MMVQTag::Q8_0) ? VDR_Q8_0 : VDR_Q5_1;
     constexpr int blocks_per_iter = vdr * nwarps * WARP_SIZE / qi;
 
     const int tid = WARP_SIZE * threadIdx.y + threadIdx.x;
@@ -482,11 +482,11 @@ static __global__ void mmvq_kernel(
         const int kby = kbx * (qk / QK8_1);
         const int kqs = vdr * (tid % (qi / vdr));
 
-        if constexpr (qtype == QType::Q4_K) {
+        if constexpr (qtype == MMVQTag::Q4_K) {
             tmp += vec_dot_q4_K_q8_1(W, &yq[kby], row * blocks_per_row + kbx, kqs);
-        } else if constexpr (qtype == QType::Q5_K) {
+        } else if constexpr (qtype == MMVQTag::Q5_K) {
             tmp += vec_dot_q5_K_q8_1(W, &yq[kby], row * blocks_per_row + kbx, kqs);
-        } else if constexpr (qtype == QType::Q8_0) {
+        } else if constexpr (qtype == MMVQTag::Q8_0) {
             tmp += vec_dot_q8_0_q8_1(W, &yq[kby], row * blocks_per_row + kbx, kqs);
         } else {
             tmp += vec_dot_q5_1_q8_1(W, &yq[kby], row * blocks_per_row + kbx, kqs);
@@ -542,7 +542,7 @@ void ggml_mmvq_q4k(
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
-        mmvq_kernel<QType::Q4_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        mmvq_kernel<MMVQTag::Q4_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
     }
 }
 
@@ -570,7 +570,7 @@ void ggml_mmvq_q5_1(
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
-        mmvq_kernel<QType::Q5_1><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        mmvq_kernel<MMVQTag::Q5_1><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
     }
 }
 
@@ -596,7 +596,7 @@ void ggml_mmvq_q4k_f32(
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
-        mmvq_kernel<QType::Q4_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        mmvq_kernel<MMVQTag::Q4_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
     }
 }
 
@@ -624,7 +624,7 @@ void ggml_mmvq_q5k(
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
-        mmvq_kernel<QType::Q5_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        mmvq_kernel<MMVQTag::Q5_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
     }
 }
 
@@ -649,7 +649,7 @@ void ggml_mmvq_q8_0(
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
-        mmvq_kernel<QType::Q8_0><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        mmvq_kernel<MMVQTag::Q8_0><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
     }
 }
 

--- a/src/compute/layernorm.cu
+++ b/src/compute/layernorm.cu
@@ -301,15 +301,15 @@ void rmsnorm(const Tensor& x, const Tensor& weight, Tensor& out,
 
     if (rows == 0 || d_model == 0) return;
 
-    switch (x.dtype) {
-        case DType::FP32:
+    switch (x.qtype) {
+        case QType::F32:
             pdl::launch(rmsnorm_fp32_kernel, dim3(rows), dim3(block), 0, stream,
                 static_cast<const float*>(x.data),
                 static_cast<const float*>(weight.data),
                 static_cast<float*>(out.data),
                 d_model, eps, weight_offset);
             break;
-        case DType::FP16:
+        case QType::F16:
             pdl::launch(rmsnorm_fp16_kernel, dim3(rows), dim3(block), 0, stream,
                 static_cast<const __half*>(x.data),
                 static_cast<const __half*>(weight.data),
@@ -435,8 +435,8 @@ void rmsnorm_residual(const Tensor& x, const Tensor& residual,
 
     if (rows == 0 || d_model == 0) return;
 
-    switch (x.dtype) {
-        case DType::FP32:
+    switch (x.qtype) {
+        case QType::F32:
             pdl::launch(rmsnorm_residual_fp32_kernel, dim3(rows), dim3(block), 0, stream,
                 static_cast<float*>(x.data),
                 static_cast<const float*>(residual.data),
@@ -444,7 +444,7 @@ void rmsnorm_residual(const Tensor& x, const Tensor& residual,
                 static_cast<float*>(out.data),
                 d_model, eps, weight_offset);
             break;
-        case DType::FP16:
+        case QType::F16:
             pdl::launch(rmsnorm_residual_fp16_kernel, dim3(rows), dim3(block), 0, stream,
                 static_cast<__half*>(x.data),
                 static_cast<const __half*>(residual.data),

--- a/src/compute/moe_routing.cu
+++ b/src/compute/moe_routing.cu
@@ -599,10 +599,10 @@ __global__ void zero_float_kernel(float* data, int n) {
 // Helper to set up a Tensor descriptor
 // ============================================================================
 
-static Tensor make_tensor_1d(void* data, DType dtype, int64_t size, bool on_device) {
+static Tensor make_tensor_1d(void* data, QType dtype, int64_t size, bool on_device) {
     Tensor t;
     t.data = data;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = 1;
     t.shape[0] = size;
     t.shape[1] = 0;
@@ -616,10 +616,10 @@ static Tensor make_tensor_1d(void* data, DType dtype, int64_t size, bool on_devi
     return t;
 }
 
-static Tensor make_tensor_2d(void* data, DType dtype, int64_t d0, int64_t d1, bool on_device) {
+static Tensor make_tensor_2d(void* data, QType dtype, int64_t d0, int64_t d1, bool on_device) {
     Tensor t;
     t.data = data;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = 2;
     t.shape[0] = d0;
     t.shape[1] = d1;
@@ -711,15 +711,15 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k,
         d_sorted_token_ids, d_sorted_flat_idx, d_expert_offsets, nullptr);
 
     // ---- Fill result struct ----
-    result.expert_indices = make_tensor_2d(d_expert_indices, DType::INT32,
+    result.expert_indices = make_tensor_2d(d_expert_indices, QType::INT32,
                                            n_tokens, top_k, true);
-    result.expert_weights = make_tensor_2d(d_expert_weights, DType::FP32,
+    result.expert_weights = make_tensor_2d(d_expert_weights, QType::F32,
                                            n_tokens, top_k, true);
     // sorted_token_ids: we expose the full allocation (includes flat_idx)
     // but the tensor shape only covers the token IDs part.
-    result.sorted_token_ids = make_tensor_1d(d_sorted_token_ids, DType::INT32,
+    result.sorted_token_ids = make_tensor_1d(d_sorted_token_ids, QType::INT32,
                                              total_assignments, true);
-    result.expert_offsets = make_tensor_1d(d_expert_offsets, DType::INT32,
+    result.expert_offsets = make_tensor_1d(d_expert_offsets, QType::INT32,
                                            n_experts + 1, true);
 }
 
@@ -736,7 +736,7 @@ void moe_gather(const Tensor& input, const MoeRoutingResult& routing,
 
     (void)n_tokens_orig;
 
-    if (input.dtype == DType::FP16) {
+    if (input.qtype == QType::F16) {
         const half* d_input = static_cast<const half*>(input.data);
         half* d_gathered    = static_cast<half*>(gathered.data);
         moe_gather_kernel_impl<<<total_tokens, BLOCK_SIZE, 0, stream>>>(
@@ -773,7 +773,7 @@ void moe_scatter(const Tensor& expert_output, const MoeRoutingResult& routing,
     float* d_output = static_cast<float*>(output.data);
     zero_float_kernel<<<grid_z, BLOCK_SIZE, 0, stream>>>(d_output, total_out_elems);
 
-    if (expert_output.dtype == DType::FP16) {
+    if (expert_output.qtype == QType::F16) {
         const half* d_expert_out = static_cast<const half*>(expert_output.data);
         moe_scatter_kernel_impl<<<total_tokens, BLOCK_SIZE, 0, stream>>>(
             d_expert_out, d_sorted_token_ids, d_sorted_flat_idx,
@@ -889,13 +889,13 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k,
     // Fill result struct (no ownership -- memory belongs to buffers)
     result.owns_memory = false;
     result.token_to_expanded = buffers.token_to_expanded;
-    result.expert_indices = make_tensor_2d(d_expert_indices, DType::INT32,
+    result.expert_indices = make_tensor_2d(d_expert_indices, QType::INT32,
                                            n_tokens, top_k, true);
-    result.expert_weights = make_tensor_2d(d_expert_weights, DType::FP32,
+    result.expert_weights = make_tensor_2d(d_expert_weights, QType::F32,
                                            n_tokens, top_k, true);
-    result.sorted_token_ids = make_tensor_1d(d_sorted_token_ids, DType::INT32,
+    result.sorted_token_ids = make_tensor_1d(d_sorted_token_ids, QType::INT32,
                                              total_assignments, true);
-    result.expert_offsets = make_tensor_1d(d_expert_offsets, DType::INT32,
+    result.expert_offsets = make_tensor_1d(d_expert_offsets, QType::INT32,
                                            n_experts + 1, true);
 }
 
@@ -1045,13 +1045,13 @@ void moe_gate_topk_fused(const void* W_gate, const void* x,
 
     // Fill result struct (no ownership — memory belongs to buffers)
     result.owns_memory = false;
-    result.expert_indices = make_tensor_2d(buffers.expert_indices, DType::INT32,
+    result.expert_indices = make_tensor_2d(buffers.expert_indices, QType::INT32,
                                            1, top_k, true);
-    result.expert_weights = make_tensor_2d(buffers.expert_weights, DType::FP32,
+    result.expert_weights = make_tensor_2d(buffers.expert_weights, QType::F32,
                                            1, top_k, true);
-    result.sorted_token_ids = make_tensor_1d(buffers.sorted_token_ids, DType::INT32,
+    result.sorted_token_ids = make_tensor_1d(buffers.sorted_token_ids, QType::INT32,
                                              top_k, true);
-    result.expert_offsets = make_tensor_1d(buffers.expert_offsets, DType::INT32,
+    result.expert_offsets = make_tensor_1d(buffers.expert_offsets, QType::INT32,
                                            n_experts + 1, true);
 }
 

--- a/src/compute/reduce.cu
+++ b/src/compute/reduce.cu
@@ -371,7 +371,7 @@ void reduce_sum(const Tensor& input, Tensor& output, int dim,
     if (dim == input.ndim - 1) {
         // Reduce along last dimension (contiguous access)
         int num_rows = outer_size;  // inner_size == 1 for last-dim reduction
-        if (input.dtype == DType::FP16) {
+        if (input.qtype == QType::F16) {
             const half* d_input = static_cast<const half*>(input.data);
             reduce_sum_last_dim_fp16_kernel<<<num_rows, BLOCK_SIZE, 0, stream>>>(
                 d_input, d_output, reduce_size);
@@ -383,7 +383,7 @@ void reduce_sum(const Tensor& input, Tensor& output, int dim,
     } else {
         // General case: reduce along arbitrary dimension
         int num_output = outer_size * inner_size;
-        if (input.dtype == DType::FP16) {
+        if (input.qtype == QType::F16) {
             const half* d_input = static_cast<const half*>(input.data);
             reduce_sum_general_fp16_kernel<<<num_output, BLOCK_SIZE, 0, stream>>>(
                 d_input, d_output, outer_size, reduce_size, inner_size);
@@ -406,7 +406,7 @@ void reduce_max(const Tensor& input, Tensor& output, int dim,
 
     if (dim == input.ndim - 1) {
         int num_rows = outer_size;
-        if (input.dtype == DType::FP16) {
+        if (input.qtype == QType::F16) {
             const half* d_input = static_cast<const half*>(input.data);
             reduce_max_last_dim_fp16_kernel<<<num_rows, BLOCK_SIZE, 0, stream>>>(
                 d_input, d_output, reduce_size);
@@ -417,7 +417,7 @@ void reduce_max(const Tensor& input, Tensor& output, int dim,
         }
     } else {
         int num_output = outer_size * inner_size;
-        if (input.dtype == DType::FP16) {
+        if (input.qtype == QType::F16) {
             const half* d_input = static_cast<const half*>(input.data);
             reduce_max_general_fp16_kernel<<<num_output, BLOCK_SIZE, 0, stream>>>(
                 d_input, d_output, outer_size, reduce_size, inner_size);

--- a/src/compute/rope.cu
+++ b/src/compute/rope.cu
@@ -194,8 +194,8 @@ void rope_forward(Tensor& Q, Tensor& K,
         cd1 = corr_dims[1];
     }
 
-    switch (Q.dtype) {
-        case DType::FP32:
+    switch (Q.qtype) {
+        case QType::F32:
             pdl::launch(rope_forward_kernel<float>, grid, block, 0, stream,
                 static_cast<float*>(Q.data),
                 static_cast<float*>(K.data),
@@ -205,7 +205,7 @@ void rope_forward(Tensor& Q, Tensor& K,
                 ext_factor, attn_factor, cd0, cd1,
                 longrope_inv_freqs);
             break;
-        case DType::FP16:
+        case QType::F16:
             pdl::launch(rope_forward_kernel<__half>, grid, block, 0, stream,
                 static_cast<__half*>(Q.data),
                 static_cast<__half*>(K.data),

--- a/src/compute/softmax.cu
+++ b/src/compute/softmax.cu
@@ -183,14 +183,14 @@ void softmax(const Tensor& input, Tensor& output,
     const int block = 256;
     const int grid  = static_cast<int>(rows);
 
-    switch (input.dtype) {
-        case DType::FP32:
+    switch (input.qtype) {
+        case QType::F32:
             softmax_fp32_kernel<<<grid, block, 0, stream>>>(
                 static_cast<const float*>(input.data),
                 static_cast<float*>(output.data),
                 static_cast<int>(cols));
             break;
-        case DType::FP16:
+        case QType::F16:
             softmax_fp16_kernel<<<grid, block, 0, stream>>>(
                 static_cast<const __half*>(input.data),
                 static_cast<__half*>(output.data),

--- a/src/compute/ssm.cu
+++ b/src/compute/ssm.cu
@@ -22,7 +22,7 @@ void silu_inplace(Tensor& x, cudaStream_t stream) {
     int64_t n = x.numel();
     int threads = 256;
     int blocks = static_cast<int>((n + threads - 1) / threads);
-    if (x.dtype == DType::FP16) {
+    if (x.qtype == QType::F16) {
         silu_inplace_fp16_kernel<<<blocks, threads, 0, stream>>>(
             static_cast<half*>(x.data), n);
     }
@@ -46,7 +46,7 @@ void relu_sqr_inplace(Tensor& x, cudaStream_t stream) {
     int64_t n = x.numel();
     int threads = 256;
     int blocks = static_cast<int>((n + threads - 1) / threads);
-    if (x.dtype == DType::FP16) {
+    if (x.qtype == QType::F16) {
         relu_sqr_inplace_fp16_kernel<<<blocks, threads, 0, stream>>>(
             static_cast<half*>(x.data), n);
     }
@@ -75,7 +75,7 @@ void sigmoid_mul(const Tensor& a, const Tensor& b, Tensor& out,
     int64_t n = a.numel();
     int threads = 256;
     int blocks = static_cast<int>((n + threads - 1) / threads);
-    if (a.dtype == DType::FP16) {
+    if (a.qtype == QType::F16) {
         sigmoid_mul_fp16_kernel<<<blocks, threads, 0, stream>>>(
             static_cast<const half*>(a.data),
             static_cast<const half*>(b.data),
@@ -99,7 +99,7 @@ void elementwise_mul(const Tensor& a, const Tensor& b, Tensor& out,
     int64_t n = a.numel();
     int threads = 256;
     int blocks = static_cast<int>((n + threads - 1) / threads);
-    if (a.dtype == DType::FP16) {
+    if (a.qtype == QType::F16) {
         elementwise_mul_fp16_kernel<<<blocks, threads, 0, stream>>>(
             static_cast<const half*>(a.data),
             static_cast<const half*>(b.data),
@@ -472,7 +472,7 @@ static void ssm_scan_launch(const half* x, const half* B, const half* C,
                              const float* dt_bias, void* h_state, half* y,
                              const half* z,
                              int n_tokens, int n_heads, int head_dim_ssm,
-                             int state_size, int n_groups, DType h_dtype,
+                             int state_size, int n_groups, QType h_dtype,
                              cudaStream_t stream) {
     // Pick s_tiles to maximize thread count per block (power of 2, up to 1024 threads)
     int hd = std::max(head_dim_ssm, 1);
@@ -483,7 +483,7 @@ static void ssm_scan_launch(const half* x, const half* B, const half* C,
     int threads = hd * s_tiles;
     size_t smem_bytes = (s_tiles > 1) ? static_cast<size_t>(hd) * s_tiles * sizeof(float) : 0;
 
-    bool fp16 = (h_dtype == DType::FP16);
+    bool fp16 = (h_dtype == QType::F16);
     bool fused = (z != nullptr);
 
     #define SSM_SCAN_LAUNCH(H_FP16_V, FUSE_V) \
@@ -507,7 +507,7 @@ void ssm_scan_decode(const Tensor& x, const Tensor& B, const Tensor& C,
                      Tensor& y, const void* z,
                      int n_heads, int head_dim_ssm,
                      int state_size, int n_groups,
-                     DType h_dtype,
+                     QType h_dtype,
                      cudaStream_t stream) {
     ssm_scan_launch(static_cast<const half*>(x.data),
                     static_cast<const half*>(B.data),
@@ -528,7 +528,7 @@ void ssm_scan_prefill(const Tensor& x, const Tensor& B, const Tensor& C,
                       Tensor& y, const void* z,
                       int n_tokens, int n_heads, int head_dim_ssm,
                       int state_size, int n_groups,
-                      DType h_dtype,
+                      QType h_dtype,
                       cudaStream_t stream) {
     ssm_scan_launch(static_cast<const half*>(x.data),
                     static_cast<const half*>(B.data),

--- a/src/compute/ssm.h
+++ b/src/compute/ssm.h
@@ -54,7 +54,7 @@ void ssm_conv1d_prefill_f32_silu(void* conv_state, const Tensor& x_in,
 // y:        [inner_size] compute_dtype (output)
 // z:        [inner_size] compute_dtype (gate input, nullptr = no fusion)
 //           When non-null, output is y * SiLU(z) (fused gating, saves 2 kernels).
-// h_dtype: DType of h_state storage (FP32 default, FP16 for VRAM savings).
+// h_dtype: QType of h_state storage (FP32 default, FP16 for VRAM savings).
 // Computation always in FP32; FP16 only affects load/store.
 void ssm_scan_decode(const Tensor& x, const Tensor& B, const Tensor& C,
                      const Tensor& dt, const Tensor& A_log, const Tensor& D,
@@ -62,7 +62,7 @@ void ssm_scan_decode(const Tensor& x, const Tensor& B, const Tensor& C,
                      Tensor& y, const void* z,
                      int n_heads, int head_dim_ssm,
                      int state_size, int n_groups,
-                     DType h_dtype = DType::FP32,
+                     QType h_dtype = QType::F32,
                      cudaStream_t stream = nullptr);
 
 // SSM scan prefill: iterate scan_decode over all tokens sequentially.
@@ -73,7 +73,7 @@ void ssm_scan_prefill(const Tensor& x, const Tensor& B, const Tensor& C,
                       Tensor& y, const void* z,
                       int n_tokens, int n_heads, int head_dim_ssm,
                       int state_size, int n_groups,
-                      DType h_dtype = DType::FP32,
+                      QType h_dtype = QType::F32,
                       cudaStream_t stream = nullptr);
 
 // Group RMSNorm: normalize each of n_groups groups independently.

--- a/src/compute/weight_dispatch.cu
+++ b/src/compute/weight_dispatch.cu
@@ -46,7 +46,7 @@ void gemm_dispatch(cublasLtHandle_t, const WeightHandle& w,
         // ---- FP16 -------------------------------------------------------
         case StorageTier::FP16: {
             int64_t wshape[2] = {w.shape[0], w.shape[1]};
-            Tensor w_tensor(w.payload.fp16.data, DType::FP16, 2, wshape, true);
+            Tensor w_tensor(w.payload.fp16.data, QType::F16, 2, wshape, true);
             gemm(w_tensor, x, y, alpha, beta, stream);
             return;
         }
@@ -59,7 +59,7 @@ void gemm_dispatch(cublasLtHandle_t, const WeightHandle& w,
         // handles mixed dtype via cuBLASLt algorithm selection).
         case StorageTier::FP8: {
             int64_t wshape[2] = {w.shape[0], w.shape[1]};
-            Tensor w_tensor(w.payload.fp8.data, DType::FP8_E4M3, 2, wshape, true);
+            Tensor w_tensor(w.payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
             // aScale: activation scale.  For FP8 x the caller has already
             // embedded the scale in the tensor metadata; pass nullptr and let
             // cuBLASLt use default scale=1.0.  For FP16 x no aScale is needed.
@@ -272,7 +272,7 @@ void gemv_dispatch(const WeightHandle& w, const Tensor& x, Tensor& y,
         // ---- FP16 -------------------------------------------------------
         case StorageTier::FP16: {
             int64_t wshape[2] = {w.shape[0], w.shape[1]};
-            Tensor w_tensor(w.payload.fp16.data, DType::FP16, 2, wshape, true);
+            Tensor w_tensor(w.payload.fp16.data, QType::F16, 2, wshape, true);
             gemm(w_tensor, x, y, 1.0f, 0.0f, stream);
             return;
         }
@@ -288,7 +288,7 @@ void gemv_dispatch(const WeightHandle& w, const Tensor& x, Tensor& y,
                                 sizeof(float), cudaMemcpyDeviceToHost, stream);
                 cudaStreamSynchronize(stream);
             }
-            Tensor w_tensor(w.payload.fp8.data, DType::FP8_E4M3, 2, wshape, true);
+            Tensor w_tensor(w.payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
             gemv_fp8(w_tensor, x, y, host_scale, stream);
             return;
         }
@@ -420,7 +420,7 @@ void gemm_grouped_dispatch(cublasLtHandle_t /*lt*/,
 
             gemm_moe_batched(x_flat.data, y_flat.data,
                              offsets.data(), b_ptrs.data(),
-                             K, N, DType::FP16, ne, stream,
+                             K, N, QType::F16, ne, stream,
                              /*d_work_ptrs=*/nullptr);
             return;
         }

--- a/src/core/qtype.cpp
+++ b/src/core/qtype.cpp
@@ -1,0 +1,83 @@
+#include "core/qtype.h"
+
+namespace imp {
+
+size_t qtype_elem_bytes(QType q) {
+    switch (q) {
+        case QType::F32:       return 4;
+        case QType::F16:       return 2;
+        case QType::BF16:      return 2;
+        case QType::FP8_E4M3:  return 1;
+        case QType::FP8_E5M2:  return 1;
+        case QType::INT8:      return 1;
+        case QType::INT4:      return 1;  // 2 elems/byte (caller handles packing)
+        case QType::INT32:     return 4;
+        case QType::FP4_E2M1:  return 1;  // 2 elems/byte
+        case QType::TURBOQUANT:      return 1;
+        case QType::TURBOQUANT_LITE: return 1;
+        default:               return 0;
+    }
+}
+
+size_t qtype_row_bytes(QType q, int64_t cols) {
+    switch (q) {
+        case QType::Q6_K:  return static_cast<size_t>(cols / 256) * 210;
+        case QType::Q8_0:  return static_cast<size_t>(cols / 32)  * 34;
+        case QType::Q4_0:  return static_cast<size_t>(cols / 32)  * 18;
+        case QType::Q8_1:  return static_cast<size_t>(cols / 32)  * 36;
+        case QType::Q4_1:  return static_cast<size_t>(cols / 32)  * 20;
+        case QType::Q5_0:  return static_cast<size_t>(cols / 32)  * 22;
+        case QType::Q5_1:  return static_cast<size_t>(cols / 32)  * 24;
+        case QType::Q2_K:  return static_cast<size_t>(cols / 256) * 84;
+        case QType::Q3_K:  return static_cast<size_t>(cols / 256) * 110;
+        case QType::Q4_K:  return static_cast<size_t>(cols / 256) * 144;
+        case QType::Q5_K:  return static_cast<size_t>(cols / 256) * 176;
+        case QType::Q8_K:  return static_cast<size_t>(cols / 256) * 292;
+        case QType::F16:
+        case QType::BF16:  return static_cast<size_t>(cols) * 2;
+        case QType::F32:   return static_cast<size_t>(cols) * 4;
+        case QType::INT4:
+        case QType::FP4_E2M1:
+        case QType::MXFP4: return static_cast<size_t>((cols + 1) / 2);
+        case QType::NVFP4: return static_cast<size_t>((cols + 1) / 2);  // packed; scales separate
+        case QType::FP8_E4M3:
+        case QType::FP8_E5M2:
+        case QType::INT8:  return static_cast<size_t>(cols);
+        case QType::INT32: return static_cast<size_t>(cols) * 4;
+        default:           return static_cast<size_t>(cols) * 2;  // safe fallback
+    }
+}
+
+const char* qtype_name(QType q) {
+    switch (q) {
+        case QType::F32:        return "F32";
+        case QType::F16:        return "F16";
+        case QType::Q4_0:       return "Q4_0";
+        case QType::Q4_1:       return "Q4_1";
+        case QType::Q5_0:       return "Q5_0";
+        case QType::Q5_1:       return "Q5_1";
+        case QType::Q8_0:       return "Q8_0";
+        case QType::Q8_1:       return "Q8_1";
+        case QType::Q2_K:       return "Q2_K";
+        case QType::Q3_K:       return "Q3_K";
+        case QType::Q4_K:       return "Q4_K";
+        case QType::Q5_K:       return "Q5_K";
+        case QType::Q6_K:       return "Q6_K";
+        case QType::Q8_K:       return "Q8_K";
+        case QType::BF16:       return "BF16";
+        case QType::MXFP4:      return "MXFP4";
+        case QType::NONE:       return "NONE";
+        case QType::FP8_E4M3:   return "FP8_E4M3";
+        case QType::FP8_E5M2:   return "FP8_E5M2";
+        case QType::INT8:       return "INT8";
+        case QType::INT4:       return "INT4";
+        case QType::INT32:      return "INT32";
+        case QType::FP4_E2M1:   return "FP4_E2M1";
+        case QType::NVFP4:      return "NVFP4";
+        case QType::TURBOQUANT:      return "TURBOQUANT";
+        case QType::TURBOQUANT_LITE: return "TURBOQUANT_LITE";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace imp

--- a/src/core/qtype.h
+++ b/src/core/qtype.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace imp {
+
+// Unified data-type tag for tensors. Replaces the previous split between
+// the compute-side dtype enum and the block-quant qtype enum.
+//
+// Wire-stable values 0..31 match the on-disk block-quant numbering used by
+// GGUF and similar formats. Values >= 64 are engine-internal types that have
+// no on-disk representation.
+enum class QType : uint16_t {
+    // Wire-stable 0..31 (kompatibel mit GGUF block-quant Wire-Format)
+    F32   = 0,
+    F16   = 1,
+    Q4_0  = 2,
+    Q4_1  = 3,
+    Q5_0  = 6,
+    Q5_1  = 7,
+    Q8_0  = 8,
+    Q8_1  = 9,
+    Q2_K  = 10,
+    Q3_K  = 11,
+    Q4_K  = 12,
+    Q5_K  = 13,
+    Q6_K  = 14,
+    Q8_K  = 15,
+    BF16  = 30,
+    MXFP4 = 31,
+
+    // Engine-internal (>= 64, kollidiert nie mit künftigen Wire-Werten)
+    NONE      = 64,
+    FP8_E4M3  = 65,
+    FP8_E5M2  = 66,
+    INT8      = 67,
+    INT4      = 68,
+    INT32     = 69,
+    FP4_E2M1  = 70,
+    NVFP4     = 71,
+    TURBOQUANT      = 80,
+    TURBOQUANT_LITE = 81,
+};
+
+// True for block-quantised disk formats (Q*_K, Q*_0, Q*_1, MXFP4, NVFP4).
+// These types require a Sidecar scales tensor for reconstruction.
+constexpr bool is_block_quant(QType q) {
+    auto v = static_cast<uint16_t>(q);
+    return (v >= 2 && v <= 15) || q == QType::MXFP4 || q == QType::NVFP4;
+}
+
+// True for compute-side dtypes that map directly to a hardware FP/INT type.
+// These tensors store raw values; no Sidecar scales needed.
+constexpr bool is_compute_dtype(QType q) {
+    switch (q) {
+        case QType::F32:
+        case QType::F16:
+        case QType::BF16:
+        case QType::FP8_E4M3:
+        case QType::FP8_E5M2:
+        case QType::INT8:
+        case QType::INT4:
+        case QType::INT32:
+        case QType::FP4_E2M1:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Bytes-per-row for a tensor of `cols` elements at the given qtype.
+// For block-quantised types this includes the per-block overhead.
+// Returns 0 for QType::NONE or unknown types.
+size_t qtype_row_bytes(QType q, int64_t cols);
+
+// Bytes-per-element for compute dtypes. INT4/FP4_E2M1 return 1 (two
+// values packed per byte — caller must account for the packing).
+size_t qtype_elem_bytes(QType q);
+
+// Human-readable name (for logs/debug).
+const char* qtype_name(QType q);
+
+// Compile-time wire-format stability assertions. If a future change shifts
+// any value, the assert fires at build time.
+static_assert(static_cast<uint16_t>(QType::F32)   == 0,  "QType::F32 wire value");
+static_assert(static_cast<uint16_t>(QType::F16)   == 1,  "QType::F16 wire value");
+static_assert(static_cast<uint16_t>(QType::Q4_0)  == 2,  "QType::Q4_0 wire value");
+static_assert(static_cast<uint16_t>(QType::Q4_K)  == 12, "QType::Q4_K wire value");
+static_assert(static_cast<uint16_t>(QType::Q6_K)  == 14, "QType::Q6_K wire value");
+static_assert(static_cast<uint16_t>(QType::Q8_0)  == 8,  "QType::Q8_0 wire value");
+static_assert(static_cast<uint16_t>(QType::BF16)  == 30, "QType::BF16 wire value");
+static_assert(static_cast<uint16_t>(QType::MXFP4) == 31, "QType::MXFP4 wire value");
+
+} // namespace imp

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -64,7 +64,7 @@ Tensor Tensor::reshape(int new_ndim, const int64_t* new_shape) const {
     t.data = data;
     t.qtype = qtype;
     t.scales = scales;
-    t.tensor_scale = tensor_scale;
+    t.tensor_scale = tensor_scale;  // copies the float by value
     t.ndim = new_ndim;
     t.on_device = on_device;
     t.kind = kind;

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -5,42 +5,8 @@
 
 namespace imp {
 
-size_t dtype_size(DType dt) {
-    switch (dt) {
-        case DType::FP32:     return 4;
-        case DType::FP16:     return 2;
-        case DType::BF16:     return 2;
-        case DType::FP8_E4M3: return 1;
-        case DType::FP8_E5M2: return 1;
-        case DType::INT8:     return 1;
-        case DType::INT4:      return 1; // packed: 2 elements per byte
-        case DType::INT32:     return 4;
-        case DType::FP4_E2M1:  return 1; // packed: 2 elements per byte
-        case DType::TURBOQUANT: return 1; // packed INT4 directions (2 per byte), sketch stored separately
-        case DType::TURBOQUANT_LITE: return 1; // V is INT4 packed; K stored as sketches separately
-    }
-    return 0;
-}
-
-const char* dtype_name(DType dt) {
-    switch (dt) {
-        case DType::FP32:     return "FP32";
-        case DType::FP16:     return "FP16";
-        case DType::BF16:     return "BF16";
-        case DType::FP8_E4M3: return "FP8_E4M3";
-        case DType::FP8_E5M2: return "FP8_E5M2";
-        case DType::INT8:     return "INT8";
-        case DType::INT4:      return "INT4";
-        case DType::INT32:     return "INT32";
-        case DType::FP4_E2M1:  return "FP4_E2M1";
-        case DType::TURBOQUANT: return "TURBOQUANT";
-        case DType::TURBOQUANT_LITE: return "TURBOQUANT_LITE";
-    }
-    return "UNKNOWN";
-}
-
-Tensor::Tensor(void* data, DType dtype, int ndim, const int64_t* shape, bool on_device)
-    : data(data), dtype(dtype), ndim(ndim), on_device(on_device) {
+Tensor::Tensor(void* data, QType qtype, int ndim, const int64_t* shape, bool on_device)
+    : data(data), qtype(qtype), ndim(ndim), on_device(on_device) {
     assert(ndim >= 0 && ndim <= kMaxDims);
     for (int i = 0; i < ndim; ++i) {
         this->shape[i] = shape[i];
@@ -48,9 +14,9 @@ Tensor::Tensor(void* data, DType dtype, int ndim, const int64_t* shape, bool on_
     compute_strides();
 }
 
-Tensor::Tensor(void* data, DType dtype, int ndim, const int64_t* shape,
+Tensor::Tensor(void* data, QType qtype, int ndim, const int64_t* shape,
                const int64_t* stride, bool on_device)
-    : data(data), dtype(dtype), ndim(ndim), on_device(on_device) {
+    : data(data), qtype(qtype), ndim(ndim), on_device(on_device) {
     assert(ndim >= 0 && ndim <= kMaxDims);
     for (int i = 0; i < ndim; ++i) {
         this->shape[i] = shape[i];
@@ -69,10 +35,10 @@ int64_t Tensor::numel() const {
 
 size_t Tensor::nbytes() const {
     int64_t n = numel();
-    if (dtype == DType::INT4 || dtype == DType::FP4_E2M1) {
+    if (qtype == QType::INT4 || qtype == QType::FP4_E2M1) {
         return static_cast<size_t>((n + 1) / 2); // 2 elements per byte
     }
-    return static_cast<size_t>(n) * dtype_size(dtype);
+    return static_cast<size_t>(n) * qtype_elem_bytes(qtype);
 }
 
 bool Tensor::is_contiguous() const {
@@ -96,9 +62,12 @@ void Tensor::compute_strides() {
 Tensor Tensor::reshape(int new_ndim, const int64_t* new_shape) const {
     Tensor t;
     t.data = data;
-    t.dtype = dtype;
+    t.qtype = qtype;
+    t.scales = scales;
+    t.tensor_scale = tensor_scale;
     t.ndim = new_ndim;
     t.on_device = on_device;
+    t.kind = kind;
 
     int64_t new_numel = 1;
     for (int i = 0; i < new_ndim; ++i) {
@@ -120,7 +89,7 @@ Tensor Tensor::slice(int64_t start, int64_t end) const {
 
     Tensor t = *this;
     t.shape[0] = end - start;
-    t.data = static_cast<char*>(data) + start * stride[0] * static_cast<int64_t>(dtype_size(dtype));
+    t.data = static_cast<char*>(data) + start * stride[0] * static_cast<int64_t>(qtype_elem_bytes(qtype));
     return t;
 }
 
@@ -131,7 +100,7 @@ std::string Tensor::to_string() const {
         if (i > 0) ss << ", ";
         ss << shape[i];
     }
-    ss << "], dtype=" << dtype_name(dtype);
+    ss << "], qtype=" << qtype_name(qtype);
     ss << ", " << (on_device ? "cuda" : "cpu") << ")";
     return ss.str();
 }

--- a/src/core/tensor.h
+++ b/src/core/tensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/qtype.h"
 #include "imp/tensor_kind.h"
 #include <cstdint>
 #include <cstddef>
@@ -8,63 +9,47 @@
 
 namespace imp {
 
-enum class DType : uint8_t {
-    FP32      = 0,
-    FP16      = 1,
-    BF16      = 2,
-    FP8_E4M3  = 3,
-    FP8_E5M2  = 4,
-    INT8      = 5,
-    INT4      = 6,
-    INT32     = 7,
-    FP4_E2M1  = 8,
-    TURBOQUANT = 9,       // TurboQuant: PolarQuant INT4 K + QJL sketch + INT4 V
-    TURBOQUANT_LITE = 10, // TurboQuant Lite: QJL sketch-only K (no INT4 dirs) + INT4 V
-};
-
-// Bytes per element. INT4 returns 1 (two elements packed per byte).
-size_t dtype_size(DType dt);
-const char* dtype_name(DType dt);
+// Legacy aliases. Prefer qtype_elem_bytes / qtype_name in new code.
+inline size_t dtype_size(QType q) { return qtype_elem_bytes(q); }
+inline const char* dtype_name(QType q) { return qtype_name(q); }
 
 static constexpr int kMaxDims = 4;
 
 struct Tensor {
-    void* data       = nullptr;
-    DType dtype      = DType::FP32;
-    int ndim         = 0;
+    void*   data         = nullptr;
+    QType   qtype        = QType::NONE;
+    int     ndim         = 0;
     int64_t shape[kMaxDims]  = {};
     int64_t stride[kMaxDims] = {};
-    bool on_device   = false;
-    TensorKind kind  = TensorKind::UNKNOWN;
+    bool    on_device    = false;
+    TensorKind kind      = TensorKind::UNKNOWN;
+
+    // Sidecar pointers for block-quantised tensors. Borrowed; lifetime
+    // managed by the loader/WeightCaches that allocated them.
+    //   scales       — per-block scales (FP8 micro-scales for NVFP4,
+    //                  FP16 per-group scales for FP8 weights, etc.)
+    //   tensor_scale — per-tensor scalar (FP32) for two-level schemes
+    //                  like NVFP4 and absolute FP8.
+    void*   scales       = nullptr;
+    void*   tensor_scale = nullptr;
 
     Tensor() = default;
 
     // Create a tensor descriptor (does not allocate memory)
-    Tensor(void* data, DType dtype, int ndim, const int64_t* shape, bool on_device);
+    Tensor(void* data, QType qtype, int ndim, const int64_t* shape, bool on_device);
 
     // Create with explicit strides
-    Tensor(void* data, DType dtype, int ndim, const int64_t* shape,
+    Tensor(void* data, QType qtype, int ndim, const int64_t* shape,
            const int64_t* stride, bool on_device);
 
-    // Total number of elements
     int64_t numel() const;
+    size_t  nbytes() const;
+    bool    is_contiguous() const;
+    void    compute_strides();
 
-    // Total size in bytes
-    size_t nbytes() const;
-
-    // Check if memory layout is contiguous (row-major)
-    bool is_contiguous() const;
-
-    // Compute row-major strides from shape
-    void compute_strides();
-
-    // Reshape (must have same numel). Returns new descriptor with same data ptr.
     Tensor reshape(int new_ndim, const int64_t* new_shape) const;
-
-    // View a sub-range along dimension 0
     Tensor slice(int64_t start, int64_t end) const;
 
-    // Debug string: "Tensor(shape=[...], dtype=FP16, device=cuda)"
     std::string to_string() const;
 };
 

--- a/src/core/tensor.h
+++ b/src/core/tensor.h
@@ -24,14 +24,17 @@ struct Tensor {
     bool    on_device    = false;
     TensorKind kind      = TensorKind::UNKNOWN;
 
-    // Sidecar pointers for block-quantised tensors. Borrowed; lifetime
-    // managed by the loader/WeightCaches that allocated them.
-    //   scales       — per-block scales (FP8 micro-scales for NVFP4,
-    //                  FP16 per-group scales for FP8 weights, etc.)
-    //   tensor_scale — per-tensor scalar (FP32) for two-level schemes
-    //                  like NVFP4 and absolute FP8.
-    void*   scales       = nullptr;
-    void*   tensor_scale = nullptr;
+    // Sidecar metadata for block-quantised tensors:
+    //   scales       — borrowed device pointer to per-block scales
+    //                  (FP8 E4M3 micro-scales for NVFP4 [N, K/16],
+    //                  FP16 per-group scales for split Q4_0, etc.)
+    //   tensor_scale — per-tensor scalar (FP32, by value) for two-level
+    //                  schemes like NVFP4. Default 1.0 = no-op
+    //                  (multiplicative identity). For llm-compressor
+    //                  NVFP4 the loader pre-applies the 1/x reciprocal
+    //                  so the runtime can always multiply.
+    void* scales        = nullptr;
+    float tensor_scale  = 1.0f;
 
     Tensor() = default;
 

--- a/src/core/tensor_view.h
+++ b/src/core/tensor_view.h
@@ -11,14 +11,14 @@ public:
     TensorView() = default;
 
     explicit TensorView(const Tensor& t)
-        : data_(t.data), dtype_(t.dtype), ndim_(t.ndim), on_device_(t.on_device) {
+        : data_(t.data), dtype_(t.qtype), ndim_(t.ndim), on_device_(t.on_device) {
         for (int i = 0; i < t.ndim; ++i) {
             shape_[i] = t.shape[i];
             stride_[i] = t.stride[i];
         }
     }
 
-    TensorView(const void* data, DType dtype, int ndim,
+    TensorView(const void* data, QType dtype, int ndim,
                const int64_t* shape, const int64_t* stride, bool on_device)
         : data_(data), dtype_(dtype), ndim_(ndim), on_device_(on_device) {
         for (int i = 0; i < ndim; ++i) {
@@ -28,7 +28,7 @@ public:
     }
 
     const void* data() const { return data_; }
-    DType dtype() const { return dtype_; }
+    QType qtype() const { return dtype_; }
     int ndim() const { return ndim_; }
     bool on_device() const { return on_device_; }
     int64_t shape(int i) const { return shape_[i]; }
@@ -43,7 +43,7 @@ public:
 
     size_t nbytes() const {
         int64_t n = numel();
-        if (dtype_ == DType::INT4) return static_cast<size_t>((n + 1) / 2);
+        if (dtype_ == QType::INT4) return static_cast<size_t>((n + 1) / 2);
         return static_cast<size_t>(n) * dtype_size(dtype_);
     }
 
@@ -59,7 +59,7 @@ public:
 
 private:
     const void* data_ = nullptr;
-    DType dtype_       = DType::FP32;
+    QType dtype_       = QType::F32;
     int ndim_          = 0;
     int64_t shape_[kMaxDims]  = {};
     int64_t stride_[kMaxDims] = {};

--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -299,7 +299,7 @@ public:
 
     // Phase 1: Initialize model reference, compute workspace sizes, enable PDL.
     // Does NOT allocate GPU memory — call allocate_workspaces() after weight upload.
-    [[nodiscard]] bool init(const Model& model, DType compute_dtype = DType::FP16, bool use_pdl = false,
+    [[nodiscard]] bool init(const Model& model, QType compute_dtype = QType::F16, bool use_pdl = false,
                             int max_batch_size = 1, int max_seq_len = 0, bool use_fp8_prefill = false,
                             int use_nvfp4_decode = 0, bool use_mxfp4_prefill = false);
 
@@ -434,7 +434,7 @@ private:
 
     class VRAMAllocator* vram_alloc_ = nullptr;
     const Model* model_ = nullptr;
-    DType compute_dtype_ = DType::FP16;
+    QType compute_dtype_ = QType::F16;
     float norm_w_off_ = 0.0f;  // Gemma: 1.0 (norms use w+1 instead of w)
     void* v_norm_ones_buf_ = nullptr;  // Gemma 4: ones buffer for V-norm (no learned weight)
     bool initialized_ = false;

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -50,19 +50,19 @@ namespace imp {
 // is_dp4a_qtype() and dispatch_dp4a_gemv() are defined in executor_kernels.h
 
 // Fused QKV GEMV dispatch by quant type (all share identical signatures).
-static void dispatch_gemv_qkv_fused(GGMLQuantType qtype,
+static void dispatch_gemv_qkv_fused(QType qtype,
                                      const void* W_q, const void* W_k, const void* W_v,
                                      const block_q8_1* q8_1, const float* d8,
                                      half* y_q, half* y_k, half* y_v,
                                      int q_rows, int k_rows, int v_rows, int K,
                                      cudaStream_t stream) {
     switch (qtype) {
-        case GGMLQuantType::Q6_K: gemv_qkv_fused_q6k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
-        case GGMLQuantType::Q4_0: gemv_qkv_fused_q4_0_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
-        case GGMLQuantType::Q4_K: gemv_qkv_fused_q4_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
-        case GGMLQuantType::Q5_K: gemv_qkv_fused_q5_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
-        case GGMLQuantType::Q2_K: gemv_qkv_fused_q2_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
-        case GGMLQuantType::Q3_K: gemv_qkv_fused_q3_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
+        case QType::Q6_K: gemv_qkv_fused_q6k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
+        case QType::Q4_0: gemv_qkv_fused_q4_0_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
+        case QType::Q4_K: gemv_qkv_fused_q4_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
+        case QType::Q5_K: gemv_qkv_fused_q5_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
+        case QType::Q2_K: gemv_qkv_fused_q2_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
+        case QType::Q3_K: gemv_qkv_fused_q3_k_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
         default:                  gemv_qkv_fused_q8_0_q8_1(W_q, W_k, W_v, q8_1, d8, y_q, y_k, y_v, q_rows, k_rows, v_rows, K, stream); break;
     }
 }
@@ -232,11 +232,11 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
     const StorageTier wo_tier = (ly.wo_id != kInvalidTensorID)
                                     ? registry_.handle(ly.wo_id).primary_tier
                                     : StorageTier::Undefined;
-    bool will_fuse_o_nvfp4 = (!has_post_attn_norm && n == 1 && h.dtype == DType::FP16 &&
+    bool will_fuse_o_nvfp4 = (!has_post_attn_norm && n == 1 && h.qtype == QType::F16 &&
                                wo_tier == StorageTier::NVFP4);
     bool will_fuse_o_residual = (!has_post_attn_norm && !will_fuse_o_nvfp4 &&
                                   n == 1 && qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr &&
-                                  h.dtype == DType::FP16 && is_dp4a_qtype(ly.wo_qtype));
+                                  h.qtype == QType::F16 && is_dp4a_qtype(ly.wo_qtype));
     bool will_fuse_o_beta1 = (!has_post_attn_norm && !will_fuse_o_residual && !will_fuse_o_nvfp4 &&
                                n > 1 &&
                                (wo_tier == StorageTier::FP16 || wo_tier == StorageTier::FP8));
@@ -280,7 +280,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // Gemma-4: disable fused QKV when FP32 accum is active — the fused kernel
         // reads FP16 h instead of fp32_hidden_, losing precision through 128-expert routing.
         bool fused_qkv = (!has_attn_output_gate && n == 1 && q8 != nullptr && qscratch_.d8_buf != nullptr &&
-                          no.dtype == DType::FP16 &&
+                          no.qtype == QType::F16 &&
                           ly.wq_qtype == ly.wk_qtype && ly.wk_qtype == ly.wv_qtype &&
                           is_dp4a_qtype(ly.wq_qtype) &&
                           !(using_fp32_accum && cfg.arch == ModelArch::GEMMA4));
@@ -388,13 +388,13 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
             if (n > 1 && !state.force_fp16_gemm &&
                 fp8_qkv_available &&
                 qscratch_.fp8_act != nullptr && qscratch_.d_act_scale != nullptr) {
-                Tensor fp8_no(qscratch_.fp8_act, DType::FP8_E4M3, no.ndim, no.shape, true);
+                Tensor fp8_no(qscratch_.fp8_act, QType::FP8_E4M3, no.ndim, no.shape, true);
                 quantize_fp16_to_fp8_e4m3(no, fp8_no, qscratch_.d_act_scale, stream,
                                           qscratch_.d_fp8_block_maxes, qscratch_.d_fp8_absmax, qscratch_.fp8_max_grid);
                 // Reconstruct FP8 weight tensors from handle payloads.
                 auto make_fp8_tensor = [](const WeightHandle* hw) {
                     int64_t wshape[2] = {hw->shape[0], hw->shape[1]};
-                    return Tensor(hw->payload.fp8.data, DType::FP8_E4M3, 2, wshape, true);
+                    return Tensor(hw->payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
                 };
                 Tensor fp8_tq = make_fp8_tensor(fp8_hwq);
                 Tensor fp8_tk = make_fp8_tensor(fp8_hwk);
@@ -416,7 +416,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                 if (ly.fused_kv_id != kInvalidTensorID) {
                     const auto& h = registry_.handle(ly.fused_kv_id);
                     if (h.payload.fp16.data) {
-                        fused_from_handle = Tensor(h.payload.fp16.data, DType::FP16,
+                        fused_from_handle = Tensor(h.payload.fp16.data, QType::F16,
                                                    2, h.shape, true);
                         fused_kv = &fused_from_handle;
                     }
@@ -447,7 +447,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
     // valid V tensor.
     if (cfg.arch == ModelArch::GEMMA4 && ly.wv.data == nullptr &&
         kk.data != nullptr && vv.data != nullptr) {
-        size_t kv_bytes = static_cast<size_t>(n) * nkv * hd * dtype_size(kk.dtype);
+        size_t kv_bytes = static_cast<size_t>(n) * nkv * hd * dtype_size(kk.qtype);
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(vv.data, kk.data, kv_bytes,
                         cudaMemcpyDeviceToDevice, stream));
     }
@@ -457,9 +457,9 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
     // Required for both K=V-shared global layers and standard SWA layers.
     if (cfg.arch == ModelArch::GEMMA4 && v_norm_ones_buf_ != nullptr) {
         int64_t vflat_shape[4] = {static_cast<int64_t>(n) * nkv, hd, 0, 0};
-        Tensor v_flat(vv.data, vv.dtype, 2, vflat_shape, true);
+        Tensor v_flat(vv.data, vv.qtype, 2, vflat_shape, true);
         int64_t ones_shape[4] = {hd, 0, 0, 0};
-        Tensor ones_w(v_norm_ones_buf_, DType::FP16, 1, ones_shape, true);
+        Tensor ones_w(v_norm_ones_buf_, QType::F16, 1, ones_shape, true);
         rmsnorm(v_flat, ones_w, v_flat, eps, stream, 0.0f);
     }
 
@@ -585,9 +585,9 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         bool has_qk_norm = (ly.attn_q_norm.data != nullptr && ly.attn_k_norm.data != nullptr);
         // Determine if we can fuse K-RoPE into KV cache write
         bool can_fuse_rope_kv = (!state.is_prefill && n == 1 &&
-                                  qv.dtype == DType::FP16 &&
+                                  qv.qtype == QType::F16 &&
                                   state.kv_cache &&
-                                  state.kv_cache->dtype() == DType::FP16);
+                                  state.kv_cache->qtype() == QType::F16);
         // Per-layer rope_dim. Gemma 4: both SWA and global layers rotate the
         // full head_dim. Global layers' freq_factors (loaded into
         // longrope_freqs above) zero out most pairs to realize the
@@ -599,7 +599,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
             fused_rope_dim = hd;
         }
         static bool no_qknorm_fused = getenv("IMP_NO_QKNORM_FUSED") != nullptr;
-        if (has_qk_norm && n == 1 && qv.dtype == DType::FP16 && !no_qknorm_fused) {
+        if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused) {
             // Fused: QK-norm + RoPE in one kernel launch (decode only, n=1).
             // Keeps norm intermediate values in FP32 shared memory.
             qknorm_rope_fused(static_cast<half*>(qv.data),
@@ -840,13 +840,13 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
             // Reshape for cuBLAS attention: Q[1,nh,hd], K[ctx_len,nkv,hd], V[ctx_len,nkv,hd]
             int64_t k_shape[2] = {ctx_len, nkv * hd};
             int64_t v_shape[2] = {ctx_len, nkv * hd};
-            Tensor k_cont(k_flat, DType::FP16, 2, k_shape, true);
-            Tensor v_cont(v_flat, DType::FP16, 2, v_shape, true);
+            Tensor k_cont(k_flat, QType::F16, 2, k_shape, true);
+            Tensor v_cont(v_flat, QType::F16, 2, v_shape, true);
             // Use n=1 cuBLAS attention with causal=false (all context visible)
             int64_t s_shape[3] = {(int64_t)nh, 1, (int64_t)ctx_len};
             half* s_buf = nullptr;
             cudaMalloc(&s_buf, nh * ctx_len * sizeof(half));
-            Tensor s_view(s_buf, DType::FP16, 3, s_shape, true);
+            Tensor s_view(s_buf, QType::F16, 3, s_shape, true);
             attention_cublas_prefill(qv, k_cont, v_cont, ao, s_view,
                                      nh, nkv, hd, scale, /*causal=*/false,
                                      cfg.attn_logit_softcap, stream);
@@ -867,7 +867,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         KVCache* cache = state.kv_cache;
         const int kv_bs = cache->block_size();
         int total_blk  = cache->total_blocks();
-        DType cache_dtype = cache->dtype();
+        QType cache_dtype = cache->qtype();
         int64_t cs[4]  = {static_cast<int64_t>(total_blk),
                           static_cast<int64_t>(kv_bs),
                           static_cast<int64_t>(nkv),
@@ -881,7 +881,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // RTX 5090 has 96 MB L2 — enough for ~3K tokens of KV at FP8.
         set_l2_persist_kv(stream, k_c.data, k_c.nbytes() + v_c.nbytes());
 
-        if (cache_dtype == DType::TURBOQUANT_LITE) {
+        if (cache_dtype == QType::TURBOQUANT_LITE) {
             // TurboQuant Lite paged attention: QJL sketch-only K + INT4 V (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_turboquant_lite(q4, v_c, o4,
@@ -894,7 +894,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                         state.max_context_len, layer_sliding_window,
                                         cfg.attn_logit_softcap, stream,
                                         state.max_blocks_per_seq);
-        } else if (cache_dtype == DType::TURBOQUANT) {
+        } else if (cache_dtype == QType::TURBOQUANT) {
             // TurboQuant paged attention: PolarQuant K + QJL correction + INT4 V (Split-K enabled)
             // K_mscales: non-null if MXFP4 path (FP4 E2M1 + UE8M0), null for uniform INT4
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
@@ -912,7 +912,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                         cfg.attn_logit_softcap, stream,
                                         state.max_blocks_per_seq,
                                         k_mscales);
-        } else if (cache_dtype == DType::INT4) {
+        } else if (cache_dtype == QType::INT4) {
             // INT4 paged attention with per-head scales and INT4 unpack (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_int4(q4, k_c, v_c, o4,
@@ -923,7 +923,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                         state.max_context_len, layer_sliding_window,
                                         cfg.attn_logit_softcap, stream,
                                         state.max_blocks_per_seq);
-        } else if (cache_dtype == DType::INT8) {
+        } else if (cache_dtype == QType::INT8) {
             // INT8 dp4a paged attention with per-head scales (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_int8(q4, k_c, v_c, o4,
@@ -934,7 +934,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                         state.max_context_len, layer_sliding_window,
                                         cfg.attn_logit_softcap, stream,
                                         state.max_blocks_per_seq);
-        } else if (cache_dtype == DType::FP8_E4M3) {
+        } else if (cache_dtype == QType::FP8_E4M3) {
             // FP8 paged attention with on-the-fly dequant (Split-K enabled)
             float kv_scale = (!kv_scales_.empty() && kv_layer < static_cast<int>(kv_scales_.size()))
                              ? kv_scales_[kv_layer] : 1.0f;
@@ -1013,8 +1013,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // FP8 beta=1: hidden = fp8(attn_out) @ fp8(wo)^T + hidden
         const WeightHandle& wo_h = registry_.handle(ly.wo_id);
         int64_t wshape[2] = {wo_h.shape[0], wo_h.shape[1]};
-        Tensor fp8_wo(wo_h.payload.fp8.data, DType::FP8_E4M3, 2, wshape, true);
-        Tensor fp8_ao(qscratch_.fp8_act, DType::FP8_E4M3, ao.ndim, ao.shape, true);
+        Tensor fp8_wo(wo_h.payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
+        Tensor fp8_ao(qscratch_.fp8_act, QType::FP8_E4M3, ao.ndim, ao.shape, true);
         quantize_fp16_to_fp8_e4m3(ao, fp8_ao, qscratch_.d_act_scale, stream,
                                   qscratch_.d_fp8_block_maxes, qscratch_.d_fp8_absmax, qscratch_.fp8_max_grid);
         gemm_cublaslt(fp8_ao, fp8_wo, h, 1.0f, 1.0f, qscratch_.d_act_scale, wo_h.payload.fp8.d_scale, stream);
@@ -1039,7 +1039,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // preserve cuBLAS's internal FP32 accumulator precision through the
         // post-attention rmsnorm. Uses the cublasGemmEx FP16×FP16→FP32 path
         // (gemm.cu mixed-precision short-circuit). Skips the FP16-only mmvq
-        // and dp4a fast paths via output.dtype==FP32 guards in dispatch.
+        // and dp4a fast paths via output.qtype==FP32 guards in dispatch.
         const bool fp32_attn_out = (model_->config().arch == ModelArch::GEMMA4 &&
             using_fp32_accum &&
             std::getenv("IMP_GEMMA4_FP32_GEMM_OUT") != nullptr);
@@ -1049,7 +1049,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
             IMP_CUDA_CHECK_LOG(cudaMallocAsync(&po_fp32_buf, bytes, stream));
             int64_t shape[2] = {static_cast<int64_t>(n),
                                 static_cast<int64_t>(model_->config().d_model)};
-            Tensor po_fp32(po_fp32_buf, DType::FP32, 2, shape, true);
+            Tensor po_fp32(po_fp32_buf, QType::F32, 2, shape, true);
             gemm_dispatch(ao, ly.wo, ly.wo_qtype, po_fp32, ctx);
         } else {
             gemm_dispatch(ao, ly.wo, ly.wo_qtype, po, ctx);

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -237,7 +237,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                wo_tier == StorageTier::NVFP4);
     bool will_fuse_o_residual = (!has_post_attn_norm && !will_fuse_o_nvfp4 &&
                                   n == 1 && qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr &&
-                                  h.qtype == QType::F16 && is_dp4a_qtype(ly.wo_qtype));
+                                  h.qtype == QType::F16 && is_dp4a_qtype(ly.wo.qtype));
     bool will_fuse_o_beta1 = (!has_post_attn_norm && !will_fuse_o_residual && !will_fuse_o_nvfp4 &&
                                n > 1 &&
                                (wo_tier == StorageTier::FP16 || wo_tier == StorageTier::FP8));
@@ -245,7 +245,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
     bool will_fuse_o_dequant_beta1 = (!has_post_attn_norm && !will_fuse_o_residual &&
                                       !will_fuse_o_nvfp4 && !will_fuse_o_beta1 &&
                                       n > 1 && qscratch_.dequant != nullptr &&
-                                      dequant_gpu_supported(ly.wo_qtype));
+                                      dequant_gpu_supported(ly.wo.qtype));
     if (!will_fuse_o_residual && !will_fuse_o_beta1 && !will_fuse_o_dequant_beta1 &&
         !will_fuse_o_nvfp4 && !using_fp32_accum) {
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(r.data, h.data, h.nbytes(),
@@ -282,8 +282,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // reads FP16 h instead of fp32_hidden_, losing precision through 128-expert routing.
         bool fused_qkv = (!has_attn_output_gate && n == 1 && q8 != nullptr && qscratch_.d8_buf != nullptr &&
                           no.qtype == QType::F16 &&
-                          ly.wq_qtype == ly.wk_qtype && ly.wk_qtype == ly.wv_qtype &&
-                          is_dp4a_qtype(ly.wq_qtype) &&
+                          ly.wq.qtype == ly.wk.qtype && ly.wk.qtype == ly.wv.qtype &&
+                          is_dp4a_qtype(ly.wq.qtype) &&
                           !(using_fp32_accum && cfg.arch == ModelArch::GEMMA4));
         if (mxfp4_qkv) {
             // MXFP4 fused QKV: RMSNorm, optional Hadamard, then MXFP4 GEMV
@@ -359,7 +359,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
             int q_rows = static_cast<int>(ly.wq.shape[0]);
             int k_rows = static_cast<int>(ly.wk.shape[0]);
             int v_rows = static_cast<int>(ly.wv.shape[0]);
-            dispatch_gemv_qkv_fused(ly.wq_qtype,
+            dispatch_gemv_qkv_fused(ly.wq.qtype,
                                      ly.wq.data, ly.wk.data, ly.wv.data,
                                      q8, qscratch_.d8_buf,
                                      static_cast<half*>(qv.data),
@@ -1004,7 +1004,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         const half* residual_ptr = static_cast<const half*>(h.data);
         quantize_fp16_to_q8_1(attn_fp16, static_cast<block_q8_1*>(qscratch_.q8_1_buf),
                                qscratch_.d8_buf, K_o, stream);
-        dispatch_gemv_residual(ly.wo_qtype, ly.wo.data,
+        dispatch_gemv_residual(ly.wo.qtype, ly.wo.data,
                                static_cast<block_q8_1*>(qscratch_.q8_1_buf),
                                qscratch_.d8_buf, static_cast<half*>(h.data), residual_ptr,
                                M_o, K_o, stream);
@@ -1024,7 +1024,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // Safe: hidden is only READ (never written) between attn_norm and here.
         gemm_dispatch(ao, ly.wo, h, ctx.with_beta(1.0f));
     } else if ((will_fuse_o_beta1 || will_fuse_o_dequant_beta1) &&
-               qscratch_.dequant != nullptr && dequant_gpu_supported(ly.wo_qtype) &&
+               qscratch_.dequant != nullptr && dequant_gpu_supported(ly.wo.qtype) &&
                !per_layer_shapes) {  // Gemma 4: workspace stride mismatch with narrow ao
         // Dequant beta=1: dequant weights on-the-fly, then FP16 GEMM + residual
         gemm_dispatch(ao, ly.wo, h, ctx.with_beta(1.0f));
@@ -1062,7 +1062,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
             debug_tensor_rows    ("ao_pre_wo-0",    view_tokens(ao, n), stream);
             // dump wo weight shape info
             fprintf(stderr, "[DEBUG_FWD] wo_shape: ndim=%d shape=[%ld,%ld] qtype=%d\n",
-                    ly.wo.ndim, (long)ly.wo.shape[0], (long)ly.wo.shape[1], (int)ly.wo_qtype);
+                    ly.wo.ndim, (long)ly.wo.shape[0], (long)ly.wo.shape[1], (int)ly.wo.qtype);
         }
         if (has_post_attn_norm && using_fp32_accum) {
             // Sandwich norm with FP32 accumulator (Gemma-3):

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -423,14 +423,14 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                 }
                 if (n > 1 && fused_kv && !per_layer_shapes) {
                     // Q: still separate (different output dim with GQA)
-                    gemm_dispatch(no, ly.wq, ly.wq_qtype, q_target, ctx);
+                    gemm_dispatch(no, ly.wq, q_target, ctx);
                     // K+V: one batched cuBLAS call
                     gemm_kv_batched(no, *fused_kv, kk, vv, stream);
                 } else {
-                    gemm_dispatch(no, ly.wq, ly.wq_qtype, q_target, ctx);
-                    gemm_dispatch(no, ly.wk, ly.wk_qtype, kk, ctx);
+                    gemm_dispatch(no, ly.wq, q_target, ctx);
+                    gemm_dispatch(no, ly.wk, kk, ctx);
                     if (ly.wv.data != nullptr) {
-                        gemm_dispatch(no, ly.wv, ly.wv_qtype, vv, ctx);
+                        gemm_dispatch(no, ly.wv, vv, ctx);
                     }
                     // else: K=V sharing path — vv populated below from kk.
                 }
@@ -1021,12 +1021,12 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
     } else if (will_fuse_o_beta1 && wo_tier == StorageTier::FP16) {
         // Fused: hidden = attn_out @ wo^T + hidden (cuBLAS beta=1).
         // Safe: hidden is only READ (never written) between attn_norm and here.
-        gemm_dispatch(ao, ly.wo, ly.wo_qtype, h, ctx.with_beta(1.0f));
+        gemm_dispatch(ao, ly.wo, h, ctx.with_beta(1.0f));
     } else if ((will_fuse_o_beta1 || will_fuse_o_dequant_beta1) &&
                qscratch_.dequant != nullptr && dequant_gpu_supported(ly.wo_qtype) &&
                !per_layer_shapes) {  // Gemma 4: workspace stride mismatch with narrow ao
         // Dequant beta=1: dequant weights on-the-fly, then FP16 GEMM + residual
-        gemm_dispatch(ao, ly.wo, ly.wo_qtype, h, ctx.with_beta(1.0f));
+        gemm_dispatch(ao, ly.wo, h, ctx.with_beta(1.0f));
     } else {
         // Fallback: separate O-projection + optional post-norm + residual add.
         // Diagnostic: when IMP_GEMMA4_FP32_GEMM_OUT is set on Gemma-4, after the
@@ -1050,9 +1050,9 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
             int64_t shape[2] = {static_cast<int64_t>(n),
                                 static_cast<int64_t>(model_->config().d_model)};
             Tensor po_fp32(po_fp32_buf, QType::F32, 2, shape, true);
-            gemm_dispatch(ao, ly.wo, ly.wo_qtype, po_fp32, ctx);
+            gemm_dispatch(ao, ly.wo, po_fp32, ctx);
         } else {
-            gemm_dispatch(ao, ly.wo, ly.wo_qtype, po, ctx);
+            gemm_dispatch(ao, ly.wo, po, ctx);
         }
         if (debug_attn_steps) {
             debug_tensor_stats_all("L0_ao_pre_wo",  view_tokens(ao, n), stream);

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -32,6 +32,7 @@
 #include "core/logging.h"
 #include "memory/kv_cache.h"
 #include "runtime/pdl.h"
+#include "runtime/config.h"
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -536,7 +537,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         int64_t gate_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(q_actual_dim)};
         attn_gate_buf = Tensor(ssm_z_buf_.data, compute_dtype_, 2, gate_shape, true);
 
-        static const bool use_concat = std::getenv("IMP_ATTN_GATE_CONCAT") != nullptr;
+        const bool use_concat = RuntimeConfig::current().attention.gate_concat;
         if (use_concat) {
             // Feature-dim concat: Q = src[:, :q_actual_dim]; gate = src[:, q_actual_dim:]
             // One 2D copy each, width = q_actual_dim bytes per row.
@@ -598,7 +599,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         } else if (fused_rope_dim > hd || fused_rope_dim <= 0) {
             fused_rope_dim = hd;
         }
-        static bool no_qknorm_fused = getenv("IMP_NO_QKNORM_FUSED") != nullptr;
+        const bool no_qknorm_fused = RuntimeConfig::current().attention.no_qknorm_fused;
         if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused) {
             // Fused: QK-norm + RoPE in one kernel launch (decode only, n=1).
             // Keeps norm intermediate values in FP32 shared memory.
@@ -697,8 +698,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // Set IMP_NO_CUBLAS_ATTN=1 to force flash attention (for benchmarking).
         // Gemma 4: flash attention kernels don't support head_dim=512, so we MUST
         // use cuBLAS attention for all layers (it handles arbitrary head_dim).
-        static bool no_cublas_attn = getenv("IMP_NO_CUBLAS_ATTN");
-        static bool use_naive_attn = getenv("IMP_NAIVE_ATTN") != nullptr;
+        const bool no_cublas_attn = RuntimeConfig::current().attention.no_cublas;
+        const bool use_naive_attn = RuntimeConfig::current().attention.naive;
         bool force_cublas_attn = per_layer_shapes;  // Gemma 4 dual head_dim
         // Gemma-4 long-context workarounds. Two failure modes at n > 1024:
         //   (a) SWA layers (hd=256) with sliding_active → FMHA chain emits
@@ -718,7 +719,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
                                        && n > cublas_cap);
         bool use_naive_for_swa = ((gemma4_swa_broken || gemma4_global_too_long)
                                   && n <= 8192
-                                  && getenv("IMP_NO_NAIVE_SWA") == nullptr);
+                                  && !RuntimeConfig::current().attention.no_naive_swa);
         if ((use_naive_attn && n <= 2048) || use_naive_for_swa) {
             // Naive reference attention: simple FP32, no optimization.
             if (layer == 0 && use_naive_for_swa && !use_naive_attn)
@@ -811,7 +812,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
 
         // DEBUG: force cuBLAS attention for decode to isolate paged attention bugs.
         // When enabled, uses the same materialized QK^T path as prefill.
-        static bool force_cublas_decode = (getenv("IMP_FORCE_CUBLAS_DECODE") != nullptr);
+        const bool force_cublas_decode = RuntimeConfig::current().attention.force_cublas_decode;
         if (force_cublas_decode && n == 1 && attn_scores_buf_) {
             // Reconstruct K/V from cache for this position
             KVCache* cache_dbg = state.kv_cache;
@@ -1042,7 +1043,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state,
         // and dp4a fast paths via output.qtype==FP32 guards in dispatch.
         const bool fp32_attn_out = (model_->config().arch == ModelArch::GEMMA4 &&
             using_fp32_accum &&
-            std::getenv("IMP_GEMMA4_FP32_GEMM_OUT") != nullptr);
+            RuntimeConfig::current().gemma4.fp32_gemm_out);
         void* po_fp32_buf = nullptr;
         if (fp32_attn_out) {
             size_t bytes = static_cast<size_t>(n) * model_->config().d_model * sizeof(float);

--- a/src/graph/executor_debug.h
+++ b/src/graph/executor_debug.h
@@ -77,7 +77,7 @@ inline void dump_tensor_npy(const char* tag, const Tensor& t, cudaStream_t strea
                             int layer, int step) {
     const char* dir = dump_hidden_dir();
     if (!dir) return;
-    if (t.dtype != DType::FP16 && t.dtype != DType::FP32) return;
+    if (t.qtype != QType::F16 && t.qtype != QType::F32) return;
     int cols = static_cast<int>(t.shape[t.ndim - 1]);
     int rows = (t.ndim >= 2) ? static_cast<int>(t.shape[0]) : 1;
     int64_t row_stride = (t.ndim >= 2 && t.stride[0] > 0) ? t.stride[0] : cols;
@@ -85,7 +85,7 @@ inline void dump_tensor_npy(const char* tag, const Tensor& t, cudaStream_t strea
 
     std::vector<float> host(n);
     cudaStreamSynchronize(stream);
-    if (t.dtype == DType::FP16) {
+    if (t.qtype == QType::F16) {
         std::vector<half> tmp(n);
         if (row_stride == cols) {
             cudaMemcpy(tmp.data(), t.data, n * sizeof(half), cudaMemcpyDeviceToHost);
@@ -127,18 +127,18 @@ inline void debug_tensor_stats(const char* name, const Tensor& t, cudaStream_t s
     int n = cols * nrows;
     std::vector<float> host(n);
 
-    if (t.dtype == DType::FP16) {
+    if (t.qtype == QType::F16) {
         std::vector<half> tmp(n);
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(tmp.data(), static_cast<const half*>(t.data) + (int64_t)row * cols,
                          n * sizeof(half), cudaMemcpyDeviceToHost, stream));
         cudaStreamSynchronize(stream);
         for (int i = 0; i < n; i++) host[i] = __half2float(tmp[i]);
-    } else if (t.dtype == DType::FP32) {
+    } else if (t.qtype == QType::F32) {
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(host.data(), static_cast<const float*>(t.data) + (int64_t)row * cols,
                          n * sizeof(float), cudaMemcpyDeviceToHost, stream));
         cudaStreamSynchronize(stream);
     } else {
-        fprintf(stderr, "[DEBUG_FWD] %s: unsupported dtype %d\n", name, (int)t.dtype);
+        fprintf(stderr, "[DEBUG_FWD] %s: unsupported dtype %d\n", name, (int)t.qtype);
         return;
     }
 
@@ -174,16 +174,16 @@ inline void debug_tensor_rows(const char* name, const Tensor& t, cudaStream_t st
     // stride[0] is in elements, not bytes. For contiguous [n, cols] it equals cols,
     // but for a slice view of a [max_tokens, cols] buffer it still equals cols.
     int64_t row_stride = (t.ndim >= 2 && t.stride[0] > 0) ? t.stride[0] : cols;
-    if (t.dtype != DType::FP16 && t.dtype != DType::FP32) return;
+    if (t.qtype != QType::F16 && t.qtype != QType::F32) return;
     const int max_rows = (nrows < 6) ? nrows : 6;
-    const size_t elem_sz = (t.dtype == DType::FP16) ? sizeof(half) : sizeof(float);
+    const size_t elem_sz = (t.qtype == QType::F16) ? sizeof(half) : sizeof(float);
     // Print one header line with shape/stride so layout bugs are visible.
     fprintf(stderr, "[DEBUG_FWD_ROW] %s: shape=[%d,%d] stride0=%lld nrows_dump=%d\n",
             name, nrows, cols, (long long)row_stride, max_rows);
     std::vector<float> row_f(cols);
     for (int r = 0; r < max_rows; r++) {
         const char* src = static_cast<const char*>(t.data) + (int64_t)r * row_stride * elem_sz;
-        if (t.dtype == DType::FP16) {
+        if (t.qtype == QType::F16) {
             std::vector<half> tmp(cols);
             cudaMemcpy(tmp.data(), src, cols * sizeof(half), cudaMemcpyDeviceToHost);
             for (int i = 0; i < cols; i++) row_f[i] = __half2float(tmp[i]);
@@ -206,12 +206,12 @@ inline void debug_tensor_stats_all(const char* name, const Tensor& t, cudaStream
     int cols = static_cast<int>(t.shape[t.ndim - 1]);
     int nrows = static_cast<int>(t.shape[0]);
     int64_t n = static_cast<int64_t>(cols) * nrows;
-    if (t.dtype != DType::FP16 && t.dtype != DType::FP32) {
-        fprintf(stderr, "[DEBUG_FWD_ALL] %s: unsupported dtype %d\n", name, (int)t.dtype);
+    if (t.qtype != QType::F16 && t.qtype != QType::F32) {
+        fprintf(stderr, "[DEBUG_FWD_ALL] %s: unsupported dtype %d\n", name, (int)t.qtype);
         return;
     }
     std::vector<float> host(n);
-    if (t.dtype == DType::FP16) {
+    if (t.qtype == QType::F16) {
         std::vector<half> tmp(n);
         cudaMemcpy(tmp.data(), t.data, n * sizeof(half), cudaMemcpyDeviceToHost);
         for (int64_t i = 0; i < n; i++) host[i] = __half2float(tmp[i]);

--- a/src/graph/executor_debug.h
+++ b/src/graph/executor_debug.h
@@ -2,6 +2,7 @@
 
 #include "core/tensor.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdio>
@@ -15,8 +16,7 @@
 namespace imp {
 
 inline bool debug_forward_enabled() {
-    static const bool enabled = (std::getenv("IMP_DEBUG_FORWARD") != nullptr);
-    return enabled;
+    return RuntimeConfig::current().diagnostics.debug_forward;
 }
 
 // Decode-step counter shared between executor_forward.cu (writer) and
@@ -29,16 +29,14 @@ inline int& debug_decode_step() {
 }
 
 // Hidden-state npy dump for layer-diff analysis against llama.cpp.
-// Returns the directory if IMP_DUMP_HIDDEN is set to a non-empty string, else nullptr.
-// Accepts IMP_DUMP_HIDDEN=1 or "all" for backwards compat (mapped to /tmp).
+// Returns the directory if [diagnostics] dump_hidden_dir is non-empty, else
+// nullptr. Accepts "1" or "all" as shorthand for /tmp (matches the legacy
+// IMP_DUMP_HIDDEN=1 behaviour).
 inline const char* dump_hidden_dir() {
-    static const char* dir = []() -> const char* {
-        const char* v = std::getenv("IMP_DUMP_HIDDEN");
-        if (!v || !*v) return nullptr;
-        if (std::strcmp(v, "1") == 0 || std::strcmp(v, "all") == 0) return "/tmp";
-        return v;
-    }();
-    return dir;
+    const std::string& d = RuntimeConfig::current().diagnostics.dump_hidden_dir;
+    if (d.empty()) return nullptr;
+    if (d == "1" || d == "all") return "/tmp";
+    return d.c_str();
 }
 
 // Writes a numpy .npy v1.0 file with a 2D FP32 array.

--- a/src/graph/executor_ffn.cu
+++ b/src/graph/executor_ffn.cu
@@ -228,8 +228,8 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                     // Batched gate+up: single cuBLAS call for both projections
                     gemm_pair_batched(no, *fused_gu, go, uo, stream);
                 } else {
-                    gemm_dispatch(no, ly.w_gate, ly.w_gate_qtype, go, ctx);
-                    gemm_dispatch(no, ly.w_up,   ly.w_up_qtype,   uo, ctx);
+                    gemm_dispatch(no, ly.w_gate, go, ctx);
+                    gemm_dispatch(no, ly.w_up,   uo, ctx);
                 }
             }
         }
@@ -421,13 +421,13 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 gemm_cublaslt(fp8_so, fp8_wd, h, 1.0f, 1.0f, qscratch_.d_act_scale, hwd->payload.fp8.d_scale, stream);
             } else if (will_fuse_down_beta1 && wd_tier == StorageTier::FP16) {
                 // Fused: hidden = swiglu_out @ w_down^T + hidden (cuBLAS beta=1).
-                gemm_dispatch(so, ly.w_down, ly.w_down_qtype, h, ctx.with_beta(1.0f));
+                gemm_dispatch(so, ly.w_down, h, ctx.with_beta(1.0f));
             } else if ((will_fuse_down_beta1 || will_fuse_down_dequant_beta1) &&
                        qscratch_.dequant != nullptr && dequant_gpu_supported(ly.w_down_qtype)) {
                 // Dequant into scratch, then beta=1.0 GEMM directly into hidden (which holds residual)
-                gemm_dispatch(so, ly.w_down, ly.w_down_qtype, h, ctx.with_beta(1.0f));
+                gemm_dispatch(so, ly.w_down, h, ctx.with_beta(1.0f));
             } else {
-                gemm_dispatch(so, ly.w_down, ly.w_down_qtype, fo, ctx);
+                gemm_dispatch(so, ly.w_down, fo, ctx);
                 if (has_post_ffn_norm && using_fp32_accum) {
                     // Post-FFN norm → FP32 accumulation (no D2D copy needed)
                     Tensor fp32_h = view_tokens(fp32_hidden_, n);

--- a/src/graph/executor_ffn.cu
+++ b/src/graph/executor_ffn.cu
@@ -87,7 +87,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                   wd_tier == StorageTier::NVFP4);
     bool will_fuse_down_residual = (!has_post_ffn_norm && !will_fuse_down_nvfp4 &&
                                      n == 1 && qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr &&
-                                     h.qtype == QType::F16 && is_dp4a_qtype(ly.w_down_qtype));
+                                     h.qtype == QType::F16 && is_dp4a_qtype(ly.w_down.qtype));
     bool will_fuse_down_beta1 = (!has_post_ffn_norm && !will_fuse_down_residual &&
                                   !will_fuse_down_nvfp4 && n > 1 &&
                                   (wd_tier == StorageTier::FP16 || wd_tier == StorageTier::FP8));
@@ -95,7 +95,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                           !will_fuse_down_nvfp4 &&
                                           !will_fuse_down_beta1 && n > 1 &&
                                           qscratch_.dequant != nullptr &&
-                                          dequant_gpu_supported(ly.w_down_qtype));
+                                          dequant_gpu_supported(ly.w_down.qtype));
     if (!will_fuse_down_residual && !will_fuse_down_beta1 &&
         !will_fuse_down_dequant_beta1 && !will_fuse_down_nvfp4 && !will_fuse_down_mxfp4 &&
         !using_fp32_accum) {
@@ -126,7 +126,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                           hwg && hwg->primary_tier == StorageTier::NVFP4 &&
                           hwu && hwu->primary_tier == StorageTier::NVFP4);
         bool fused_ffn_norm = (n == 1 && q8 != nullptr && qscratch_.d8_buf != nullptr &&
-                               h.qtype == QType::F16 && is_dp4a_qtype(ly.w_gate_qtype));
+                               h.qtype == QType::F16 && is_dp4a_qtype(ly.w_gate.qtype));
         if (mxfp4_ffn) {
             // MXFP4 gate+up: RMSNorm, optional Hadamard, then MXFP4 fused GEMV
             rmsnorm(h, ffn_norm_w, no, eps, stream, norm_w_off_);
@@ -186,7 +186,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
             gemv_gate_up_fused(ly.w_gate.data, ly.w_up.data, q8, qscratch_.d8_buf,
                                 static_cast<half*>(go.data),
                                 static_cast<half*>(uo.data),
-                                ffn_rows, d, ly.w_gate_qtype, stream);
+                                ffn_rows, d, ly.w_gate.qtype, stream);
         } else {
             rmsnorm(h, ffn_norm_w, no, eps, stream, norm_w_off_);
 
@@ -243,7 +243,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
         auto* q8 = static_cast<block_q8_1*>(qscratch_.q8_1_buf);
         bool fused_down_residual = (!has_post_ffn_norm &&
                                      n == 1 && q8 != nullptr && qscratch_.d8_buf != nullptr &&
-                                     so.qtype == QType::F16 && is_dp4a_qtype(ly.w_down_qtype));
+                                     so.qtype == QType::F16 && is_dp4a_qtype(ly.w_down.qtype));
         if (will_fuse_down_mxfp4) {
             int K_d = static_cast<int>(ly.w_down.shape[1]);
             int M_d = static_cast<int>(ly.w_down.shape[0]);
@@ -349,7 +349,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
             }
             // Use h.data as residual source (memcpy was skipped)
             const half* residual_ptr = static_cast<const half*>(h.data);
-            dispatch_gemv_residual(ly.w_down_qtype, ly.w_down.data, q8, qscratch_.d8_buf,
+            dispatch_gemv_residual(ly.w_down.qtype, ly.w_down.data, q8, qscratch_.d8_buf,
                                    static_cast<half*>(h.data), residual_ptr,
                                    M_d, K_d, stream);
         } else if (has_post_ffn_norm && using_fp32_accum && n == 1 &&
@@ -380,7 +380,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 cfg.d_model, eps, norm_w_off_);
         } else if (has_post_ffn_norm && using_fp32_accum && n == 1 &&
                    q8 != nullptr && qscratch_.d8_buf != nullptr &&
-                   is_dp4a_qtype(ly.w_down_qtype)) {
+                   is_dp4a_qtype(ly.w_down.qtype)) {
             // Post-norm FP32 accum decode: fused activation→Q8_1 + GEMV + fused post-norm.
             // Saves 3 kernel launches per layer vs the fallback path.
             int K_d = static_cast<int>(ly.w_down.shape[1]);
@@ -394,7 +394,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                     static_cast<const half*>(uo.data),
                                     q8, qscratch_.d8_buf, K_d, stream);
             half* fo_ptr = static_cast<half*>(fo.data);
-            dispatch_dp4a_gemv(ly.w_down_qtype, ly.w_down.data, q8, qscratch_.d8_buf,
+            dispatch_dp4a_gemv(ly.w_down.qtype, ly.w_down.data, q8, qscratch_.d8_buf,
                                fo_ptr, M_d, K_d, stream);
             Tensor fp32_h = view_tokens(fp32_hidden_, n);
             rmsnorm_fp32_accum_to_fp16_kernel<<<n, 256, 0, stream>>>(
@@ -423,7 +423,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 // Fused: hidden = swiglu_out @ w_down^T + hidden (cuBLAS beta=1).
                 gemm_dispatch(so, ly.w_down, h, ctx.with_beta(1.0f));
             } else if ((will_fuse_down_beta1 || will_fuse_down_dequant_beta1) &&
-                       qscratch_.dequant != nullptr && dequant_gpu_supported(ly.w_down_qtype)) {
+                       qscratch_.dequant != nullptr && dequant_gpu_supported(ly.w_down.qtype)) {
                 // Dequant into scratch, then beta=1.0 GEMM directly into hidden (which holds residual)
                 gemm_dispatch(so, ly.w_down, h, ctx.with_beta(1.0f));
             } else {

--- a/src/graph/executor_ffn.cu
+++ b/src/graph/executor_ffn.cu
@@ -79,15 +79,15 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                ? &registry_.handle(ly.w_down_id) : nullptr;
     const StorageTier wd_tier = hwd ? hwd->primary_tier : StorageTier::Undefined;
 
-    bool will_fuse_down_mxfp4 = (!has_post_ffn_norm && n == 1 && h.dtype == DType::FP16 &&
+    bool will_fuse_down_mxfp4 = (!has_post_ffn_norm && n == 1 && h.qtype == QType::F16 &&
                                   wd_tier == StorageTier::MXFP4 &&
                                   hwd->payload.mxfp4.linear_scales != nullptr);
     bool will_fuse_down_nvfp4 = (!has_post_ffn_norm && !will_fuse_down_mxfp4 &&
-                                  n == 1 && h.dtype == DType::FP16 &&
+                                  n == 1 && h.qtype == QType::F16 &&
                                   wd_tier == StorageTier::NVFP4);
     bool will_fuse_down_residual = (!has_post_ffn_norm && !will_fuse_down_nvfp4 &&
                                      n == 1 && qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr &&
-                                     h.dtype == DType::FP16 && is_dp4a_qtype(ly.w_down_qtype));
+                                     h.qtype == QType::F16 && is_dp4a_qtype(ly.w_down_qtype));
     bool will_fuse_down_beta1 = (!has_post_ffn_norm && !will_fuse_down_residual &&
                                   !will_fuse_down_nvfp4 && n > 1 &&
                                   (wd_tier == StorageTier::FP16 || wd_tier == StorageTier::FP8));
@@ -126,7 +126,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                           hwg && hwg->primary_tier == StorageTier::NVFP4 &&
                           hwu && hwu->primary_tier == StorageTier::NVFP4);
         bool fused_ffn_norm = (n == 1 && q8 != nullptr && qscratch_.d8_buf != nullptr &&
-                               h.dtype == DType::FP16 && is_dp4a_qtype(ly.w_gate_qtype));
+                               h.qtype == QType::F16 && is_dp4a_qtype(ly.w_gate_qtype));
         if (mxfp4_ffn) {
             // MXFP4 gate+up: RMSNorm, optional Hadamard, then MXFP4 fused GEMV
             rmsnorm(h, ffn_norm_w, no, eps, stream, norm_w_off_);
@@ -199,9 +199,9 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 // Reconstruct FP8 weight tensors from handle payloads.
                 auto make_fp8_tensor = [](const WeightHandle* hw) {
                     int64_t wshape[2] = {hw->shape[0], hw->shape[1]};
-                    return Tensor(hw->payload.fp8.data, DType::FP8_E4M3, 2, wshape, true);
+                    return Tensor(hw->payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
                 };
-                Tensor fp8_no(qscratch_.fp8_act, DType::FP8_E4M3, no.ndim, no.shape, true);
+                Tensor fp8_no(qscratch_.fp8_act, QType::FP8_E4M3, no.ndim, no.shape, true);
                 quantize_fp16_to_fp8_e4m3(no, fp8_no, qscratch_.d_act_scale, stream,
                                           qscratch_.d_fp8_block_maxes, qscratch_.d_fp8_absmax, qscratch_.fp8_max_grid);
                 Tensor fp8_tg = make_fp8_tensor(hwg);
@@ -219,7 +219,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 if (ly.fused_gate_up_id != kInvalidTensorID) {
                     const auto& h = registry_.handle(ly.fused_gate_up_id);
                     if (h.payload.fp16.data) {
-                        fused_from_handle = Tensor(h.payload.fp16.data, DType::FP16,
+                        fused_from_handle = Tensor(h.payload.fp16.data, QType::F16,
                                                    2, h.shape, true);
                         fused_gu = &fused_from_handle;
                     }
@@ -243,7 +243,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
         auto* q8 = static_cast<block_q8_1*>(qscratch_.q8_1_buf);
         bool fused_down_residual = (!has_post_ffn_norm &&
                                      n == 1 && q8 != nullptr && qscratch_.d8_buf != nullptr &&
-                                     so.dtype == DType::FP16 && is_dp4a_qtype(ly.w_down_qtype));
+                                     so.qtype == QType::F16 && is_dp4a_qtype(ly.w_down_qtype));
         if (will_fuse_down_mxfp4) {
             int K_d = static_cast<int>(ly.w_down.shape[1]);
             int M_d = static_cast<int>(ly.w_down.shape[0]);
@@ -353,7 +353,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                    static_cast<half*>(h.data), residual_ptr,
                                    M_d, K_d, stream);
         } else if (has_post_ffn_norm && using_fp32_accum && n == 1 &&
-                   wd_tier == StorageTier::NVFP4 && h.dtype == DType::FP16) {
+                   wd_tier == StorageTier::NVFP4 && h.qtype == QType::F16) {
             // NVFP4 post-norm FP32 accum decode: activation → NVFP4 GEMV → post-norm.
             // ~40% less weight traffic than dp4a Q8_0 path.
             NvFP4QuantResult wd_nvfp4;
@@ -413,11 +413,11 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 wd_tier == StorageTier::FP8 &&
                 qscratch_.fp8_act != nullptr && qscratch_.d_act_scale != nullptr) {
                 // FP8 beta=1: hidden = fp8(swiglu_out) @ fp8(w_down)^T + hidden
-                Tensor fp8_so(qscratch_.fp8_act, DType::FP8_E4M3, so.ndim, so.shape, true);
+                Tensor fp8_so(qscratch_.fp8_act, QType::FP8_E4M3, so.ndim, so.shape, true);
                 quantize_fp16_to_fp8_e4m3(so, fp8_so, qscratch_.d_act_scale, stream,
                                           qscratch_.d_fp8_block_maxes, qscratch_.d_fp8_absmax, qscratch_.fp8_max_grid);
                 int64_t wshape[2] = {hwd->shape[0], hwd->shape[1]};
-                Tensor fp8_wd(hwd->payload.fp8.data, DType::FP8_E4M3, 2, wshape, true);
+                Tensor fp8_wd(hwd->payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
                 gemm_cublaslt(fp8_so, fp8_wd, h, 1.0f, 1.0f, qscratch_.d_act_scale, hwd->payload.fp8.d_scale, stream);
             } else if (will_fuse_down_beta1 && wd_tier == StorageTier::FP16) {
                 // Fused: hidden = swiglu_out @ w_down^T + hidden (cuBLAS beta=1).

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -48,16 +48,16 @@ namespace imp {
 // Layer methods: executor_attention.cu, executor_ffn.cu, executor_ssm_gdn.cu
 
 // LM head dp4a GEMV dispatch: y = W @ x (FP32 output for logits).
-static void dispatch_gemv_fp32(GGMLQuantType qtype,
+static void dispatch_gemv_fp32(QType qtype,
                                 const void* W, const block_q8_1* q8_1, const float* d8,
                                 float* y, int M, int K, cudaStream_t stream) {
     switch (qtype) {
-        case GGMLQuantType::Q6_K: gemv_q6k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q4_0: gemv_q4_0_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q4_K: gemv_q4_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q5_K: gemv_q5_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q2_K: gemv_q2_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q3_K: gemv_q3_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q6_K: gemv_q6k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q4_0: gemv_q4_0_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q4_K: gemv_q4_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q5_K: gemv_q5_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q2_K: gemv_q2_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q3_K: gemv_q3_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
         default:                  gemv_q8_0_q8_1_fp32(W, q8_1, d8, y, M, K, stream); break;
     }
 }
@@ -101,14 +101,14 @@ void debug_top_logits(const Tensor& logits, cudaStream_t stream, int topk = 10) 
     // Dump the LAST row (the one that actually gets sampled from for the next token).
     int row = nrows - 1;
     int64_t row_stride = (logits.ndim >= 2 && logits.stride[0] > 0) ? logits.stride[0] : vocab;
-    const size_t elem_sz = (logits.dtype == DType::FP32) ? sizeof(float) : sizeof(half);
+    const size_t elem_sz = (logits.qtype == QType::F32) ? sizeof(float) : sizeof(half);
     const char* src = static_cast<const char*>(logits.data) + (int64_t)row * row_stride * elem_sz;
     std::vector<float> host(vocab);
 
-    if (logits.dtype == DType::FP32) {
+    if (logits.qtype == QType::F32) {
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(host.data(), src, vocab * sizeof(float),
                          cudaMemcpyDeviceToHost, stream));
-    } else if (logits.dtype == DType::FP16) {
+    } else if (logits.qtype == QType::F16) {
         std::vector<half> tmp(vocab);
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(tmp.data(), src, vocab * sizeof(half),
                          cudaMemcpyDeviceToHost, stream));
@@ -247,7 +247,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
                      model_->tok_emb_qtype_, stream);
 
     // Gemma: scale embeddings by sqrt(d_model)
-    if (cfg.embed_scale > 0.0f && h.dtype == DType::FP16) {
+    if (cfg.embed_scale > 0.0f && h.qtype == QType::F16) {
         int64_t total = static_cast<int64_t>(n) * cfg.d_model;
         int threads = 256;
         int blocks = static_cast<int>((total / 2 + threads - 1) / threads);
@@ -389,7 +389,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
         {
             const auto& ly = model_->layer(i);
             if (ly.layer_out_scale.data != nullptr && ly.layer_out_scale.on_device &&
-                h.dtype == DType::FP16) {
+                h.qtype == QType::F16) {
                 int64_t total = static_cast<int64_t>(n) * cfg.d_model;
                 int threads = 256;
                 int blocks = static_cast<int>((total / 2 + threads - 1) / threads);
@@ -522,7 +522,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
     // use fused RMSNorm→Q8_1 + dp4a GEMV with FP32 output. Saves ~2.45x VRAM
     // bandwidth vs cuBLAS FP16 path (reads quantized weights directly).
     const auto out_qtype = model_->out_proj_qtype_;
-    const bool use_dp4a_lm = qscratch_.q8_1_buf && compute_dtype_ == DType::FP16 &&
+    const bool use_dp4a_lm = qscratch_.q8_1_buf && compute_dtype_ == QType::F16 &&
         is_dp4a_qtype(out_qtype) && getenv("IMP_NO_DP4A_LM") == nullptr;
 
     // GemmContext for LM head GEMM dispatches.
@@ -593,7 +593,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
                 IMP_CUDA_CHECK_LOG(cudaMallocAsync(&w_fp16_dev, fp16_bytes, stream));
                 dequant_gpu(model_->output_proj().data, w_fp16_dev, out_qtype, N, K, stream);
                 int64_t w_shape[2] = {N, K};
-                Tensor w_fp16(w_fp16_dev, DType::FP16, 2, w_shape, true);
+                Tensor w_fp16(w_fp16_dev, QType::F16, 2, w_shape, true);
                 gemm(no_last, w_fp16, lg, 1.0f, 0.0f, stream);
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(w_fp16_dev, stream));
                 fprintf(stderr, "[DEBUG_FWD] LM head via dequant->FP16->cuBLAS path\n");
@@ -720,8 +720,8 @@ void GraphExecutor::forward_logits(const InferenceState& state,
             // Raw gemm() can't handle Q8_0/Q6_K weights with cuBLAS.
             if (lm_tier == StorageTier::FP8 && qscratch_.fp8_act != nullptr && qscratch_.d_act_scale != nullptr) {
                 int64_t wshape[2] = {lm_h->shape[0], lm_h->shape[1]};
-                Tensor fp8_lm_w(lm_h->payload.fp8.data, DType::FP8_E4M3, 2, wshape, true);
-                Tensor fp8_no(qscratch_.fp8_act, DType::FP8_E4M3, no_final.ndim, no_final.shape, true);
+                Tensor fp8_lm_w(lm_h->payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
+                Tensor fp8_no(qscratch_.fp8_act, QType::FP8_E4M3, no_final.ndim, no_final.shape, true);
                 quantize_fp16_to_fp8_e4m3(no_final, fp8_no, qscratch_.d_act_scale, stream,
                                           qscratch_.d_fp8_block_maxes, qscratch_.d_fp8_absmax, qscratch_.fp8_max_grid);
                 gemm_cublaslt(fp8_no, fp8_lm_w, lg, 1.0f, 0.0f,

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -245,7 +245,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
     }
     Tensor h = view_tokens(hidden_, n);
     embedding_lookup(model_->token_embedding(), state.token_ids, n, h,
-                     model_->tok_emb_qtype_, stream);
+                     model_->tok_emb_.qtype, stream);
 
     // Gemma: scale embeddings by sqrt(d_model)
     if (cfg.embed_scale > 0.0f && h.qtype == QType::F16) {
@@ -519,7 +519,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
     // For raw Q6_K/Q8_0 output projection with single token (n=1 or prefill last):
     // use fused RMSNorm→Q8_1 + dp4a GEMV with FP32 output. Saves ~2.45x VRAM
     // bandwidth vs cuBLAS FP16 path (reads quantized weights directly).
-    const auto out_qtype = model_->out_proj_qtype_;
+    const auto out_qtype = model_->out_proj_.qtype;
     const bool use_dp4a_lm = qscratch_.q8_1_buf && compute_dtype_ == QType::F16 &&
         is_dp4a_qtype(out_qtype) && !RuntimeConfig::current().gemm.no_dp4a_lm;
 

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -613,7 +613,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
             rmsnorm(h_last, model_->output_norm(), no_last, cfg.rms_norm_eps, stream, norm_w_off_);
             debug_tensor_stats("after_final_rmsnorm", no_last, stream);
             // LM head fallback: use gemm_dispatch for consistent MXFP4/FP16 handling
-            gemm_dispatch(no_last, model_->output_proj(), model_->out_proj_qtype_, lg, ctx);
+            gemm_dispatch(no_last, model_->output_proj(), lg, ctx);
         }
         logits_out = lg;
         debug_top_logits(lg, stream);
@@ -692,7 +692,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
             if (lm_tier == StorageTier::FP16) {
                 Tensor no_final = view_tokens(norm_out_, n);
                 rmsnorm(h_final, model_->output_norm(), no_final, cfg.rms_norm_eps, stream, norm_w_off_);
-                gemm_dispatch(no_final, model_->output_proj(), model_->out_proj_qtype_, lg, ctx);
+                gemm_dispatch(no_final, model_->output_proj(), lg, ctx);
                 goto lm_head_done;
             }
             auto* q8 = static_cast<block_q8_1*>(qscratch_.q8_1_buf);
@@ -728,7 +728,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
                               qscratch_.d_act_scale, lm_h->payload.fp8.d_scale, stream);
             } else {
                 // Fallback: gemm_dispatch handles FP16 cache, MXFP4, quantized, etc.
-                gemm_dispatch(no_final, model_->output_proj(), model_->out_proj_qtype_, lg, ctx);
+                gemm_dispatch(no_final, model_->output_proj(), lg, ctx);
             }
         }
     lm_head_done:

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -3,6 +3,7 @@
 #include "graph/executor_helpers.h"
 #include "graph/executor_debug.h"
 #include "graph/gemm_context.h"
+#include "runtime/config.h"
 #include "compute/embedding.h"
 #include "compute/layernorm.h"
 #include "compute/rope.h"
@@ -182,7 +183,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
     // ---- Optional per-component profiling (IMP_PROFILE=1) ----
     // Profiling disables CUDA graph capture (they are incompatible).
     // Use IMP_PROFILE=1 for diagnostic runs only.
-    static const bool do_profile = (std::getenv("IMP_PROFILE") != nullptr);
+    const bool do_profile = RuntimeConfig::current().diagnostics.profile;
     static int profile_step_ = 0;
     static float acc_total = 0, acc_attn = 0, acc_ffn = 0, acc_lm = 0;
     bool profiling = do_profile;
@@ -290,7 +291,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
                 decode_step, tmp[0], tmp[1], tmp[2], tmp[3]);
     }
     // Binary dump: write the full FP16 hidden state to file
-    if (getenv("IMP_DUMP_HIDDEN")) {
+    if (!RuntimeConfig::current().diagnostics.dump_hidden_dir.empty()) {
         std::vector<half> h_buf(n * cfg.d_model);
         cudaMemcpy(h_buf.data(), h.data, h_buf.size() * sizeof(half), cudaMemcpyDeviceToHost);
         char fname[256];
@@ -306,13 +307,9 @@ void GraphExecutor::forward_logits(const InferenceState& state,
     int max_layer = (state.exit_layer > 0)
                     ? std::min(state.exit_layer, cfg.n_layers)
                     : cfg.n_layers;
-    // Debug: allow IMP_EXIT_LAYER=N to run only N layers
+    // [diagnostics] exit_layer = N runs only N layers (-1 = full forward).
     {
-        static int s_exit = -1;
-        if (s_exit < 0) {
-            const char* e = getenv("IMP_EXIT_LAYER");
-            s_exit = e ? atoi(e) : 0;
-        }
+        const int s_exit = RuntimeConfig::current().diagnostics.exit_layer;
         if (s_exit > 0) max_layer = std::min(max_layer, s_exit);
     }
     const int skip_start = state.skip_layer_start;
@@ -362,7 +359,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
 
 
         // FFN: MoE, dense, or none (attention-only layers may have no FFN)
-        static bool skip_moe = (getenv("IMP_SKIP_MOE") != nullptr);
+        const bool skip_moe = RuntimeConfig::current().moe.skip;
         if (skip_moe) {
             // Debug: skip all FFN/MoE to isolate attention bugs
         } else if (layer_has_moe(i)) {
@@ -430,11 +427,12 @@ void GraphExecutor::forward_logits(const InferenceState& state,
                                 __half2float(h_tmp[4]), __half2float(h_tmp[5]),
                                 __half2float(h_tmp[6]), __half2float(h_tmp[7]));
                     }
-                    // Binary dump: full hidden state for selected layers
-                    // IMP_DUMP_HIDDEN=1: default layers 0/5/15/29.
-                    // IMP_DUMP_HIDDEN=all: every layer (for host-expert A/B debugging).
-                    if (const char* dh = getenv("IMP_DUMP_HIDDEN")) {
-                        bool dump_all = (strcmp(dh, "all") == 0);
+                    // Binary dump: full hidden state for selected layers.
+                    // [diagnostics] dump_hidden_dir = "<path>"  → layers 0/5/15/29.
+                    // [diagnostics] dump_hidden_dir = "all"     → every layer.
+                    const std::string& dh = RuntimeConfig::current().diagnostics.dump_hidden_dir;
+                    if (!dh.empty()) {
+                        const bool dump_all = (dh == "all");
                         bool sel = dump_all || (i == 0 || i == 5 || i == 15 || i == 29);
                         if (sel) {
                             std::vector<half> h_buf(n * cfg.d_model);
@@ -466,7 +464,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
         // Only sync when the MoE path did NOT go through the FP32 accum kernel
         // (e.g. layer has no post_ffn_norm or residual was fused into decode path).
         if (fp32_accum_buf_ && cfg.arch == ModelArch::GEMMA4 &&
-            getenv("IMP_FORCE_MOE_FP16_SYNC") != nullptr) {
+            RuntimeConfig::current().moe.force_fp16_sync) {
             Tensor fp32_h = view_tokens(fp32_hidden_, n);
             int64_t total = static_cast<int64_t>(n) * cfg.d_model;
             int threads = 256;
@@ -523,7 +521,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
     // bandwidth vs cuBLAS FP16 path (reads quantized weights directly).
     const auto out_qtype = model_->out_proj_qtype_;
     const bool use_dp4a_lm = qscratch_.q8_1_buf && compute_dtype_ == QType::F16 &&
-        is_dp4a_qtype(out_qtype) && getenv("IMP_NO_DP4A_LM") == nullptr;
+        is_dp4a_qtype(out_qtype) && !RuntimeConfig::current().gemm.no_dp4a_lm;
 
     // GemmContext for LM head GEMM dispatches.
     auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
@@ -583,7 +581,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
             // Dequant output_proj to FP16 temp buffer, cuBLAS FP16 GEMM into FP32 logits.
             // If this gives llama-matching top logit (~+2.07) then the dp4a path is buggy;
             // if it still gives +8.83 then the bug is in hidden state or output_norm.
-            if (getenv("IMP_LM_DEQUANT_FP16") != nullptr) {
+            if (RuntimeConfig::current().generation.lm_dequant_fp16) {
                 Tensor no_last = view_tokens(norm_out_, 1);
                 rmsnorm(h_last, model_->output_norm(), no_last, cfg.rms_norm_eps, stream, norm_w_off_);
                 int N = cfg.vocab_size;
@@ -737,7 +735,7 @@ void GraphExecutor::forward_logits(const InferenceState& state,
     }
 
     // ---- Final logit soft-capping (Gemma-2/3/4, cap=30) ----
-    bool skip_softcap = (getenv("IMP_NO_LOGIT_SOFTCAP") != nullptr);
+    const bool skip_softcap = RuntimeConfig::current().generation.no_logit_softcap;
     if (cfg.final_logit_softcap > 0.0f && !skip_softcap) {
         int64_t n_logits = static_cast<int64_t>(logits_out.shape[0]) * cfg.vocab_size;
         int threads = 256;

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -13,6 +13,7 @@
 #include "graph/executor_kernels.h"
 #include "graph/gemm_context.h"
 #include "graph/executor_debug.h"
+#include "runtime/config.h"
 #include "compute/embedding.h"
 #include "compute/gemv_ggml_compat.h"
 #include "compute/ggml_mmvq.h"
@@ -148,7 +149,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // DIAGNOSTIC (Phase 2 Item 2 follow-up): zero MoE workspace buffers so any
     // legacy-serial-fallback uninit reads become deterministic zero reads.
     // Set IMP_MOE_ZERO_WORKSPACE=1 to enable. Cheap (~1 MiB total memset).
-    if (getenv("IMP_MOE_ZERO_WORKSPACE")) {
+    if (RuntimeConfig::current().moe.zero_workspace) {
         cudaMemsetAsync(moe_.expert_gate.data, 0, moe_.expert_gate.nbytes(), stream);
         cudaMemsetAsync(moe_.expert_up.data, 0, moe_.expert_up.nbytes(), stream);
         cudaMemsetAsync(moe_.expert_swiglu.data, 0, moe_.expert_swiglu.nbytes(), stream);
@@ -227,7 +228,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // at GEMM output) to isolate precision drift. Allocated below in the FP16
     // batch path; freed at moe_after_experts. Other prefill paths ignore this.
     const bool fp32_down_active = (cfg.arch == ModelArch::GEMMA4 &&
-        std::getenv("IMP_GEMMA4_FP32_EXPERT_DOWN") != nullptr);
+        RuntimeConfig::current().gemma4.fp32_expert_down);
     void* fp32_down_buf = nullptr;
     bool moe_fused_norm_q8 = (n == 1 && qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr &&
                                h.qtype == QType::F16 && !nvfp4_covers_layer && !gemma4_fp32_norm);
@@ -327,7 +328,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // Gemma 4: dp4a decode fast path ENABLED by default. dp4a matches llama's
     // Q4_K×Q8_1 accumulation for MoE experts, preventing the routing drift that
     // occurs with FP16 dequant+cuBLAS. Set IMP_G4_NO_DECODE_FAST=1 to disable.
-    if (cfg.arch == ModelArch::GEMMA4 && getenv("IMP_G4_NO_DECODE_FAST")) {
+    if (cfg.arch == ModelArch::GEMMA4 && RuntimeConfig::current().gemma4.no_decode_fast) {
         will_decode_fast = false;
     }
 
@@ -343,8 +344,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         Tensor gate_logits_f32 = slice_rows(moe_.gate_logits, n);
         // Diagnostic: dump gate logits pre-topk when IMP_DUMP_LOGITS is set.
         // Compares imp's softmax-input against llama.cpp's ffn_moe_probs-N.
-        if (const char* dl = getenv("IMP_DUMP_LOGITS")) {
-            bool dump_all = (std::strcmp(dl, "all") == 0);
+        if (const std::string& dl = RuntimeConfig::current().diagnostics.dump_logits_dir; !dl.empty()) {
+            bool dump_all = (dl == "all");
             if (layer == 29 || dump_all) {
                 int last_tok = n - 1;
                 std::vector<float> h_logits(ne);
@@ -419,8 +420,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     last_tok, rsum, std::sqrt(rss), rl[0], rl[1], rl[2]);
         }
         // IMP_DUMP_LOGITS=all: dump top-8-by-value of gate logits per layer.
-        if (const char* dl = getenv("IMP_DUMP_LOGITS")) {
-            bool dump_all = (std::strcmp(dl, "all") == 0);
+        if (const std::string& dl = RuntimeConfig::current().diagnostics.dump_logits_dir; !dl.empty()) {
+            bool dump_all = (dl == "all");
             if (layer == 29 || dump_all) {
                 int last_tok = n - 1;
                 std::vector<float> h_logits(ne);
@@ -446,10 +447,10 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         }
     }
 
-    // Dump routing for last token (use direct getenv, not debug_forward_enabled).
-    // IMP_DUMP_ROUTING=1: only layer 0. IMP_DUMP_ROUTING=all: every layer.
-    if (const char* drv = getenv("IMP_DUMP_ROUTING")) {
-        bool dump_all = (std::strcmp(drv, "all") == 0);
+    // Dump routing for last token. [diagnostics] dump_routing_dir = "<path>"
+    // dumps layer 0 only; dump_routing_dir = "all" dumps every layer.
+    if (const std::string& drv = RuntimeConfig::current().diagnostics.dump_routing_dir; !drv.empty()) {
+        bool dump_all = (drv == "all");
         if (layer == 0 || dump_all) {
             int last_tok = n - 1;
             std::vector<int32_t> h_idx(top_k);
@@ -716,7 +717,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             if (!non_gated_experts) {
                 // Fused activation → Q8_1 (1 kernel instead of 2)
                 if (cfg.ffn_activation == FFNActivation::GEGLU) {
-                    if (layer == 0 && getenv("IMP_DEBUG_FORWARD"))
+                    if (layer == 0 && RuntimeConfig::current().diagnostics.debug_forward)
                         fprintf(stderr, "[DEBUG_MoE] Using GEGLU activation for MoE experts\n");
                     geglu_quantize_q8_1(gate_buf, up_buf, q8, qscratch_.d8_buf,
                                          top_k * eff, stream);
@@ -893,7 +894,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         }
 
         // Falls through to scatter (step 7)
-    } else if (getenv("IMP_G4_GGML_PREFILL") && cfg.arch == ModelArch::GEMMA4 &&
+    } else if (RuntimeConfig::current().gemma4.ggml_prefill && cfg.arch == ModelArch::GEMMA4 &&
                ly.expert_gate_packed.on_device && ly.expert_up_packed.on_device &&
                ly.expert_down_packed.on_device) {
     // =========================================================================
@@ -1367,7 +1368,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         //   Decode n=1:    ~48 tok/s (vs legacy ~38)     — 25% win
         // After shared-quantize gate+up (2026-04-20), 3.x beats legacy at all n.
         // `IMP_NO_CUTLASS3X_MOE=1` forces legacy (for debugging).
-        static const bool force_off = std::getenv("IMP_NO_CUTLASS3X_MOE") != nullptr;
+        static const bool force_off = RuntimeConfig::current().moe.no_cutlass3x;
         if (force_off) return false;
         if (!cutlass_grouped_3x_nvfp4_available()) return false;
         if (!moe_.cutlass3x_packed || !moe_.cutlass3x_sf) return false;
@@ -1984,7 +1985,7 @@ moe_after_experts:
 
     // Shared expert: enabled by default. Gemma 4: requires post_ffw_norm_1 to be uploaded.
     // DIAGNOSTIC: IMP_NO_SHARED_MLP=1 skips this branch (Gemma-4 NVFP4 audit).
-    static const bool s_no_shared_mlp = (getenv("IMP_NO_SHARED_MLP") != nullptr);
+    static const bool s_no_shared_mlp = RuntimeConfig::current().moe.no_shared_mlp;
     if (ly.w_up_shared.data != nullptr && !s_no_shared_mlp) {
         int eff_shared = static_cast<int>(ly.w_up_shared.shape[0]);
         bool shared_gated = (ly.w_gate_shared.data != nullptr);
@@ -2042,7 +2043,7 @@ moe_after_experts:
         }
         // Gemma 4: apply post_ffw_norm_1 on shared MLP output (sh_down).
         if (cfg.arch == ModelArch::GEMMA4 && ly.ffn_post_norm_1.data != nullptr &&
-            getenv("IMP_G4_NO_POST_FFW_1") == nullptr) {
+            !RuntimeConfig::current().gemma4.no_post_ffw_1) {
             rmsnorm(sh_down, ly.ffn_post_norm_1, sh_down, eps, stream, norm_w_off_);
         }
 
@@ -2058,7 +2059,7 @@ moe_after_experts:
         //   gate[r] = sigmoid(sum_d no[r,d] * W_gate_inp_shexp[d])
         //   sh_down[r, :] *= gate[r]
         // Absent in Qwen3 MoE / Gemma-4 (tensor pointer is null → skip).
-        static const bool skip_shexp_gate = std::getenv("IMP_NO_SHEXP_GATE") != nullptr;
+        static const bool skip_shexp_gate = RuntimeConfig::current().moe.no_shexp_gate;
         if (!skip_shexp_gate &&
             ly.shared_expert_gate_inp.data != nullptr &&
             ly.shared_expert_gate_inp.on_device &&

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -2001,12 +2001,12 @@ moe_after_experts:
         // Up projection (dp4a MMVQ for decode)
         {
             auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
-            gemm_dispatch(no, ly.w_up_shared, ly.w_up_shared_qtype, sh_up, ctx);
+            gemm_dispatch(no, ly.w_up_shared, sh_up, ctx);
 
             if (shared_gated) {
                 // Gated: gate + SwiGLU
                 Tensor sh_gate(moe_.expert_gate.data, compute_dtype_, 2, sh_shape, true);
-                gemm_dispatch(no, ly.w_gate_shared, ly.w_gate_shared_qtype, sh_gate, ctx);
+                gemm_dispatch(no, ly.w_gate_shared, sh_gate, ctx);
                 if (cfg.ffn_activation == FFNActivation::GEGLU)
                     geglu(sh_gate, sh_up, sh_swiglu, stream);
                 else
@@ -2025,7 +2025,7 @@ moe_after_experts:
             // Down projection (reads from sh_up for non-gated since relu² was in-place)
             Tensor& sh_act = shared_gated ? sh_swiglu : sh_up;
             if (layer == 0) debug_tensor_stats_all("L0_sh_act_preDown", sh_act, stream);
-            gemm_dispatch(sh_act, ly.w_down_shared, ly.w_down_shared_qtype, sh_down, ctx);
+            gemm_dispatch(sh_act, ly.w_down_shared, sh_down, ctx);
         }
 
         if (layer == 0) {

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -97,16 +97,16 @@ namespace {
 // quantization format, the dequant buffer exists, and compute dtype is FP16.
 // ---------------------------------------------------------------------------
 static bool can_decode_fast(int n, const Tensor& expert_up_packed,
-                            GGMLQuantType up_qtype, void* dequant_buf,
-                            DType compute_dtype) {
+                            QType up_qtype, void* dequant_buf,
+                            QType compute_dtype) {
     return (n == 1 &&
             expert_up_packed.data != nullptr && dequant_buf != nullptr &&
-            compute_dtype == DType::FP16 &&
+            compute_dtype == QType::F16 &&
             expert_up_packed.on_device &&
-            (up_qtype == GGMLQuantType::Q6_K || up_qtype == GGMLQuantType::Q8_0 ||
-             up_qtype == GGMLQuantType::Q4_0 || up_qtype == GGMLQuantType::Q4_K ||
-             up_qtype == GGMLQuantType::Q5_K || up_qtype == GGMLQuantType::Q2_K ||
-             up_qtype == GGMLQuantType::Q3_K || up_qtype == GGMLQuantType::Q5_1));
+            (up_qtype == QType::Q6_K || up_qtype == QType::Q8_0 ||
+             up_qtype == QType::Q4_0 || up_qtype == QType::Q4_K ||
+             up_qtype == QType::Q5_K || up_qtype == QType::Q2_K ||
+             up_qtype == QType::Q3_K || up_qtype == QType::Q5_1));
 }
 
 // ---------------------------------------------------------------------------
@@ -115,7 +115,7 @@ static bool can_decode_fast(int n, const Tensor& expert_up_packed,
 // ---------------------------------------------------------------------------
 static void apply_expert_activation(void* gate_data, void* up_data, void* swiglu_data,
                                     bool non_gated, int64_t rows, int64_t eff,
-                                    DType compute_dtype, FFNActivation act_type,
+                                    QType compute_dtype, FFNActivation act_type,
                                     cudaStream_t stream) {
     int64_t act_shape[2] = {rows, eff};
     if (non_gated) {
@@ -133,10 +133,10 @@ static void apply_expert_activation(void* gate_data, void* up_data, void* swiglu
 // ---------------------------------------------------------------------------
 // Compute expert stride (bytes between experts in a packed tensor).
 // ---------------------------------------------------------------------------
-static size_t expert_stride(const Tensor& packed, GGMLQuantType qtype) {
+static size_t expert_stride(const Tensor& packed, QType qtype) {
     int64_t rows = packed.shape[1];
     int64_t cols = packed.shape[2];
-    return static_cast<size_t>(rows) * ggml_quant_row_bytes(qtype, cols);
+    return static_cast<size_t>(rows) * qtype_row_bytes(qtype, cols);
 }
 
 } // anonymous namespace
@@ -192,7 +192,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // Pre-check: does NVFP4 MoE cache cover all expert tensors for this layer?
     // If so, the NVFP4 path doesn't need Q8_1 quantization (takes FP16 directly).
     bool nvfp4_covers_layer = false;
-    if (n == 1 && compute_dtype_ == DType::FP16) {
+    if (n == 1 && compute_dtype_ == QType::F16) {
         bool has_up   = (ly.nvfp4_moe_up_ptr   != nullptr);
         bool has_down = (ly.nvfp4_moe_down_ptr  != nullptr);
         nvfp4_covers_layer = has_up && has_down;
@@ -230,7 +230,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         std::getenv("IMP_GEMMA4_FP32_EXPERT_DOWN") != nullptr);
     void* fp32_down_buf = nullptr;
     bool moe_fused_norm_q8 = (n == 1 && qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr &&
-                               h.dtype == DType::FP16 && !nvfp4_covers_layer && !gemma4_fp32_norm);
+                               h.qtype == QType::F16 && !nvfp4_covers_layer && !gemma4_fp32_norm);
     if (moe_fused_norm_q8) {
         // Fused: RMSNorm + Q8_1 (also writes FP16 norm_out for gate logits)
         rmsnorm_quantize_q8_1(static_cast<const half*>(h.data),
@@ -321,7 +321,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     bool use_sigmoid = cfg.moe_sigmoid_gating;
     bool norm_weights = cfg.expert_weights_norm;
 
-    GGMLQuantType up_qtype = ly.expert_up_qtype;
+    QType up_qtype = ly.expert_up_qtype;
     bool will_decode_fast = can_decode_fast(n, ly.expert_up_packed, up_qtype,
                                             moe_.dequant_buf, compute_dtype_);
     // Gemma 4: dp4a decode fast path ENABLED by default. dp4a matches llama's
@@ -370,7 +370,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             moe_topk_gating(gate_logits_f32, top_k, routing, stream, use_sigmoid, norm_weights, router_bias_ptr);
         }
     } else if (ne <= kMaxFusedExperts &&
-        n == 1 && compute_dtype_ == DType::FP16 && ly.moe_gate.dtype == DType::FP16 &&
+        n == 1 && compute_dtype_ == QType::F16 && ly.moe_gate.qtype == QType::F16 &&
         moe_.routing_buffers.pool && will_decode_fast) {
         // Fused: gate GEMV + softmax/sigmoid + top-k in one kernel (1 launch)
         moe_gate_topk_fused(static_cast<const half*>(ly.moe_gate.data),
@@ -382,7 +382,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         // Separate: gate GEMV → intermediate logits → topk gating
         Tensor gate_logits_f32 = slice_rows(moe_.gate_logits, n);
 
-        if (n == 1 && compute_dtype_ == DType::FP16 && ly.moe_gate.dtype == DType::FP16) {
+        if (n == 1 && compute_dtype_ == QType::F16 && ly.moe_gate.qtype == QType::F16) {
             gemv_gate_fp32(static_cast<const half*>(ly.moe_gate.data),
                            static_cast<const half*>(router_in.data),
                            static_cast<float*>(gate_logits_f32.data),
@@ -395,7 +395,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             int64_t numel = static_cast<int64_t>(n) * ne;
             int threads = 256;
             int blocks = static_cast<int>((numel + threads - 1) / threads);
-            if (compute_dtype_ == DType::FP16) {
+            if (compute_dtype_ == QType::F16) {
                 fp16_to_fp32_kernel<<<blocks, threads, 0, stream>>>(
                     static_cast<const half*>(gate_logits_tmp.data),
                     static_cast<float*>(gate_logits_f32.data),
@@ -606,37 +606,37 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             // 5'+6'. Fused gate+up projection (single kernel launch)
             if (!non_gated_experts) {
                 size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_qtype);
-                if (up_qtype == GGMLQuantType::Q6_K) {
+                if (up_qtype == QType::Q6_K) {
                     gemv_q6k_q8_1_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, q8, qscratch_.d8_buf, gate_buf, up_buf,
                         eff, d, gate_stride, up_stride_bytes,
                         /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
-                } else if (up_qtype == GGMLQuantType::Q4_K) {
+                } else if (up_qtype == QType::Q4_K) {
                     gemv_q4_k_q8_1_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, q8, qscratch_.d8_buf, gate_buf, up_buf,
                         eff, d, gate_stride, up_stride_bytes,
                         /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
-                } else if (up_qtype == GGMLQuantType::Q5_K) {
+                } else if (up_qtype == QType::Q5_K) {
                     gemv_q5_k_q8_1_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, q8, qscratch_.d8_buf, gate_buf, up_buf,
                         eff, d, gate_stride, up_stride_bytes,
                         /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
-                } else if (up_qtype == GGMLQuantType::Q4_0) {
+                } else if (up_qtype == QType::Q4_0) {
                     gemv_q4_0_q8_1_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, q8, qscratch_.d8_buf, gate_buf, up_buf,
                         eff, d, gate_stride, up_stride_bytes,
                         /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
-                } else if (up_qtype == GGMLQuantType::Q2_K) {
+                } else if (up_qtype == QType::Q2_K) {
                     gemv_q2_k_q8_1_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, q8, qscratch_.d8_buf, gate_buf, up_buf,
                         eff, d, gate_stride, up_stride_bytes,
                         /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
-                } else if (up_qtype == GGMLQuantType::Q3_K) {
+                } else if (up_qtype == QType::Q3_K) {
                     gemv_q3_k_q8_1_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, q8, qscratch_.d8_buf, gate_buf, up_buf,
@@ -651,17 +651,17 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 }
             } else {
                 // Non-gated: up projection only
-                auto moe_gemv_dp4a = (up_qtype == GGMLQuantType::Q6_K)
+                auto moe_gemv_dp4a = (up_qtype == QType::Q6_K)
                     ? gemv_q6k_q8_1_moe_decode
-                    : (up_qtype == GGMLQuantType::Q4_0)
+                    : (up_qtype == QType::Q4_0)
                     ? gemv_q4_0_q8_1_moe_decode
-                    : (up_qtype == GGMLQuantType::Q4_K)
+                    : (up_qtype == QType::Q4_K)
                     ? gemv_q4_k_q8_1_moe_decode
-                    : (up_qtype == GGMLQuantType::Q5_K)
+                    : (up_qtype == QType::Q5_K)
                     ? gemv_q5_k_q8_1_moe_decode
-                    : (up_qtype == GGMLQuantType::Q2_K)
+                    : (up_qtype == QType::Q2_K)
                     ? gemv_q2_k_q8_1_moe_decode
-                    : (up_qtype == GGMLQuantType::Q3_K)
+                    : (up_qtype == QType::Q3_K)
                     ? gemv_q3_k_q8_1_moe_decode : gemv_q8_0_q8_1_moe_decode;
                 moe_gemv_dp4a(ly.expert_up_packed.data, expert_indices,
                               q8, qscratch_.d8_buf, up_buf,
@@ -674,13 +674,13 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
             if (!non_gated_experts) {
                 size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_qtype);
-                if (up_qtype == GGMLQuantType::Q6_K) {
+                if (up_qtype == QType::Q6_K) {
                     gemv_q6k_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, norm_ptr, gate_buf, up_buf,
                         eff, d, gate_stride, up_stride_bytes,
                         /*x_stride=*/0, top_k, stream);
-                } else if (up_qtype == GGMLQuantType::Q8_0) {
+                } else if (up_qtype == QType::Q8_0) {
                     gemv_q8_0_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
                         expert_indices, norm_ptr, gate_buf, up_buf,
@@ -690,11 +690,11 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     IMP_LOG_ERROR("MoE non-dp4a gate_up_fused: no kernel for qtype %d, skipping GEMV", (int)up_qtype);
                 }
             } else {
-                if (up_qtype == GGMLQuantType::Q6_K) {
+                if (up_qtype == QType::Q6_K) {
                     gemv_q6k_moe_decode(ly.expert_up_packed.data, expert_indices,
                                         norm_ptr, up_buf,
                                         eff, d, up_stride_bytes, /*x_stride=*/0, top_k, stream);
-                } else if (up_qtype == GGMLQuantType::Q8_0) {
+                } else if (up_qtype == QType::Q8_0) {
                     gemv_q8_0_moe_decode(ly.expert_up_packed.data, expert_indices,
                                          norm_ptr, up_buf,
                                          eff, d, up_stride_bytes, /*x_stride=*/0, top_k, stream);
@@ -730,20 +730,20 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             }
 
             // Down projection with dp4a GEMV — use down_qtype, NOT up_qtype
-            GGMLQuantType dqt = ly.expert_down_qtype;
-            auto moe_gemv_dp4a_down = (dqt == GGMLQuantType::Q6_K)
+            QType dqt = ly.expert_down_qtype;
+            auto moe_gemv_dp4a_down = (dqt == QType::Q6_K)
                 ? gemv_q6k_q8_1_moe_decode
-                : (dqt == GGMLQuantType::Q4_0)
+                : (dqt == QType::Q4_0)
                 ? gemv_q4_0_q8_1_moe_decode
-                : (dqt == GGMLQuantType::Q4_K)
+                : (dqt == QType::Q4_K)
                 ? gemv_q4_k_q8_1_moe_decode
-                : (dqt == GGMLQuantType::Q5_K)
+                : (dqt == QType::Q5_K)
                 ? gemv_q5_k_q8_1_moe_decode
-                : (dqt == GGMLQuantType::Q2_K)
+                : (dqt == QType::Q2_K)
                 ? gemv_q2_k_q8_1_moe_decode
-                : (dqt == GGMLQuantType::Q3_K)
+                : (dqt == QType::Q3_K)
                 ? gemv_q3_k_q8_1_moe_decode
-                : (dqt == GGMLQuantType::Q5_1)
+                : (dqt == QType::Q5_1)
                 ? gemv_q5_1_q8_1_moe_decode
                 : gemv_q8_0_q8_1_moe_decode;
             size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_qtype);
@@ -759,11 +759,11 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                     compute_dtype_, cfg.ffn_activation, stream);
             size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_qtype);
             half* down_input = non_gated_experts ? up_buf : act_buf;
-            if (ly.expert_down_qtype == GGMLQuantType::Q6_K) {
+            if (ly.expert_down_qtype == QType::Q6_K) {
                 gemv_q6k_moe_decode(ly.expert_down_packed.data, expert_indices,
                                     down_input, down_buf,
                                     d, eff, down_stride, /*x_stride=*/eff, top_k, stream);
-            } else if (ly.expert_down_qtype == GGMLQuantType::Q8_0) {
+            } else if (ly.expert_down_qtype == QType::Q8_0) {
                 gemv_q8_0_moe_decode(ly.expert_down_packed.data, expert_indices,
                                      down_input, down_buf,
                                      d, eff, down_stride, /*x_stride=*/eff, top_k, stream);
@@ -800,13 +800,13 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     bool can_fused_q6k = (ne > 16 &&
                           ly.expert_up_packed.data && ly.expert_up_packed.on_device &&
                           ly.expert_down_packed.data && ly.expert_down_packed.on_device &&
-                          up_qtype == GGMLQuantType::Q6_K &&
-                          ly.expert_down_qtype == GGMLQuantType::Q6_K &&
-                          compute_dtype_ == DType::FP16);
+                          up_qtype == QType::Q6_K &&
+                          ly.expert_down_qtype == QType::Q6_K &&
+                          compute_dtype_ == QType::F16);
     if (can_fused_q6k && !non_gated_experts)
         can_fused_q6k = (ly.expert_gate_packed.data &&
                          ly.expert_gate_packed.on_device &&
-                         ly.expert_gate_qtype == GGMLQuantType::Q6_K);
+                         ly.expert_gate_qtype == QType::Q6_K);
 
     bool use_tc = can_fused_q6k && (expanded > ne * 12);
     bool use_scalar = can_fused_q6k && !use_tc && (expanded <= ne * 12);
@@ -944,7 +944,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         if (fp32_accum_buf_ != nullptr) {
             int64_t tok_shape[2] = {1, static_cast<int64_t>(d)};
             Tensor fp32_tok(static_cast<float*>(fp32_hidden_.data) + static_cast<int64_t>(t) * d,
-                           DType::FP32, 2, tok_shape, true);
+                           QType::F32, 2, tok_shape, true);
             rmsnorm_fp32_to_fp32(fp32_tok, norm_w, s_norm_fp32, 1, d,
                                 eps, stream, norm_w_off_);
         } else {
@@ -965,10 +965,10 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             const uint8_t* up_w = static_cast<const uint8_t*>(ly.expert_up_packed.data)
                                 + static_cast<size_t>(eid) * up_stride;
 
-            auto do_mmvq = [&](const uint8_t* w, half* out, GGMLQuantType qt) {
+            auto do_mmvq = [&](const uint8_t* w, half* out, QType qt) {
                 if (tok_norm_f32) {
                     switch (qt) {
-                        case GGMLQuantType::Q4_K:
+                        case QType::Q4_K:
                             ggml_mmvq_q4k_f32(w, tok_norm_f32, out, 1, eff, d, s_q8_scratch, s_q8_scratch_size, stream);
                             break;
                         default:
@@ -978,10 +978,10 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 } else {
                     const half* tok_norm_fp16 = static_cast<const half*>(no.data) + static_cast<int64_t>(t) * d;
                     switch (qt) {
-                        case GGMLQuantType::Q4_K:
+                        case QType::Q4_K:
                             ggml_mmvq_q4k(w, tok_norm_fp16, out, 1, eff, d, s_q8_scratch, s_q8_scratch_size, stream);
                             break;
-                        case GGMLQuantType::Q8_0:
+                        case QType::Q8_0:
                             ggml_mmvq_q8_0(w, tok_norm_fp16, out, 1, eff, d, s_q8_scratch, s_q8_scratch_size, stream);
                             break;
                         default:
@@ -1009,16 +1009,16 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             half* out_k = down_buf + static_cast<int64_t>(k) * d;
 
             switch (ly.expert_down_qtype) {
-                case GGMLQuantType::Q4_K:
+                case QType::Q4_K:
                     ggml_mmvq_q4k(w_down, act_k, out_k, 1, d, eff, s_q8_scratch, s_q8_scratch_size, stream);
                     break;
-                case GGMLQuantType::Q5_K:
+                case QType::Q5_K:
                     ggml_mmvq_q5k(w_down, act_k, out_k, 1, d, eff, s_q8_scratch, s_q8_scratch_size, stream);
                     break;
-                case GGMLQuantType::Q8_0:
+                case QType::Q8_0:
                     ggml_mmvq_q8_0(w_down, act_k, out_k, 1, d, eff, s_q8_scratch, s_q8_scratch_size, stream);
                     break;
-                case GGMLQuantType::Q5_1:
+                case QType::Q5_1:
                     ggml_mmvq_q5_1(w_down, act_k, out_k, 1, d, eff, s_q8_scratch, s_q8_scratch_size, stream);
                     break;
                 default:
@@ -1086,14 +1086,14 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                           moe_.batch_dequant_buf_size >= fp8_buf_needed &&
                           ly.expert_up_packed.data && ly.expert_up_packed.on_device &&
                           ly.expert_down_packed.data && ly.expert_down_packed.on_device &&
-                          up_qtype == GGMLQuantType::Q6_K &&
-                          ly.expert_down_qtype == GGMLQuantType::Q6_K &&
-                          compute_dtype_ == DType::FP16 &&
+                          up_qtype == QType::Q6_K &&
+                          ly.expert_down_qtype == QType::Q6_K &&
+                          compute_dtype_ == QType::F16 &&
                           ly.fp16_packed_up_cache == nullptr);
     if (can_fp8_batch && !non_gated_experts)
         can_fp8_batch = (ly.expert_gate_packed.data &&
                          ly.expert_gate_packed.on_device &&
-                         ly.expert_gate_qtype == GGMLQuantType::Q6_K);
+                         ly.expert_gate_qtype == QType::Q6_K);
 
     if (debug_forward_enabled() && layer == 0) {
         int64_t gs[2] = {static_cast<int64_t>(expanded), static_cast<int64_t>(d)};
@@ -1130,10 +1130,10 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             IMP_CUDA_CHECK_LOG(cudaMallocAsync(&fp32_down_buf, fp32_bytes, stream));
         }
 
-        auto batch_dequant_gemm = [&](const Tensor& packed, GGMLQuantType qtype,
+        auto batch_dequant_gemm = [&](const Tensor& packed, QType qtype,
                                        const char* a_base, char* c_base,
                                        int K_dim, int N_dim,
-                                       DType out_dtype = DType::FP16) {
+                                       QType out_dtype = QType::F16) {
             int64_t rows = packed.shape[1];
             int64_t cols = packed.shape[2];
             size_t expert_fp16_sz = static_cast<size_t>(rows) * cols * sizeof(half);
@@ -1147,7 +1147,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
             gemm_moe_batched(a_base, c_base,
                              h_offsets.data(), b_ptrs.data(),
-                             K_dim, N_dim, DType::FP16, ne, stream,
+                             K_dim, N_dim, QType::F16, ne, stream,
                              moe_.d_work_ptrs,
                              out_dtype);
         };
@@ -1186,7 +1186,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         char* down_target = fp32_down_active
             ? static_cast<char*>(fp32_down_buf)
             : expert_down_base;
-        DType down_out_dtype = fp32_down_active ? DType::FP32 : DType::FP16;
+        QType down_out_dtype = fp32_down_active ? QType::F32 : QType::F16;
         batch_dequant_gemm(ly.expert_down_packed, ly.expert_down_qtype,
                             down_act, down_target, eff, d, down_out_dtype);
         if (debug_forward_enabled() && layer == 0 && !fp32_down_active) {
@@ -1205,7 +1205,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         char* buf = static_cast<char*>(moe_.batch_dequant_buf);
 
         // FP8 batched GEMM lambda: dequant Q6_K→FP8, quantize FP16 acts→FP8, cuBLAS FP8 GEMM→FP16
-        auto chunked_fp8_gemm = [&](const Tensor& packed, GGMLQuantType qtype,
+        auto chunked_fp8_gemm = [&](const Tensor& packed, QType qtype,
                                      const char* a_base_fp16, char* c_base_fp16,
                                      int K_dim, int N_dim) {
             int64_t rows = packed.shape[1];
@@ -1261,8 +1261,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
             gemm_moe_batched(fp8_acts, c_base_fp16,
                              h_offsets.data(), weight_ptrs.data(),
-                             K_dim, N_dim, DType::FP8_E4M3, ne, stream,
-                             moe_.d_work_ptrs, /*output_dtype=*/DType::FP16,
+                             K_dim, N_dim, QType::FP8_E4M3, ne, stream,
+                             moe_.d_work_ptrs, /*output_dtype=*/QType::F16,
                              moe_.d_fp8_scales ? h_act_scales.data() : nullptr);
         };
 
@@ -1335,7 +1335,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
             gemm_moe_batched(a_base, c_base,
                              h_offsets.data(), b_ptrs.data(),
-                             K_dim, N_dim, DType::FP16, ne, stream,
+                             K_dim, N_dim, QType::F16, ne, stream,
                              moe_.d_work_ptrs);
         };
 
@@ -1527,11 +1527,11 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // Returns a Tensor view into the scratch buffer with shape [rows, cols], FP16.
     // Uses slot 0 always -- safe because all ops are on the same stream, so the previous
     // GEMM reading from slot 0 completes before the next dequant writes to it.
-    auto dequant_expert = [&](const Tensor& packed, GGMLQuantType qtype,
+    auto dequant_expert = [&](const Tensor& packed, QType qtype,
                               int expert_idx) -> Tensor {
         int64_t rows = packed.shape[1];
         int64_t cols = packed.shape[2];
-        size_t row_bytes = ggml_quant_row_bytes(qtype, cols);
+        size_t row_bytes = qtype_row_bytes(qtype, cols);
         size_t expert_raw = static_cast<size_t>(rows) * row_bytes;
         size_t total_raw = static_cast<size_t>(packed.shape[0]) * expert_raw;
         size_t offset = static_cast<size_t>(expert_idx) * expert_raw;
@@ -1580,7 +1580,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         dequant_gpu(src, dst, qtype, static_cast<int>(rows), static_cast<int>(cols), stream);
 
         int64_t shape[2] = {rows, cols};
-        return Tensor(dst, DType::FP16, 2, shape, true);
+        return Tensor(dst, QType::F16, 2, shape, true);
     };
 
     // Helper: try fused quantized GEMV for count=1 decode (dequant+dot in one kernel),
@@ -1588,7 +1588,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // For host-resident experts: H2D to staging buffer, then fused GEMV on staging —
     // eliminates separate dequant_gpu + cuBLAS gemm overhead.
     auto expert_gemm = [&](const Tensor& a, Tensor& c,
-                            const Tensor& packed, GGMLQuantType qtype,
+                            const Tensor& packed, QType qtype,
                             const std::vector<Tensor>& fallback,
                             const std::vector<TensorID>& fallback_ids, int eidx) {
         // NVFP4 prequant path: native NVFP4 GEMV (any batch size)
@@ -1631,18 +1631,18 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 int64_t a_shape[2] = {static_cast<int64_t>(M), static_cast<int64_t>(K_dim)};
                 int64_t c_shape[2] = {static_cast<int64_t>(M), static_cast<int64_t>(N_dim)};
                 Tensor a_t(const_cast<void*>(static_cast<const void*>(a.data)),
-                           DType::FP16, 2, a_shape, true);
-                Tensor c_t(c.data, DType::FP16, 2, c_shape, true);
+                           QType::F16, 2, a_shape, true);
+                Tensor c_t(c.data, QType::F16, 2, c_shape, true);
                 gemm_nvfp4(nw, a_t, c_t, stream);
             }
             return;
         }
         if (a.shape[0] == 1 && use_packed_dequant &&
-            compute_dtype_ == DType::FP16 &&
-            (qtype == GGMLQuantType::Q6_K || qtype == GGMLQuantType::Q8_0)) {
+            compute_dtype_ == QType::F16 &&
+            (qtype == QType::Q6_K || qtype == QType::Q8_0)) {
             int64_t rows = packed.shape[1];
             int64_t cols = packed.shape[2];
-            size_t rb = ggml_quant_row_bytes(qtype, cols);
+            size_t rb = qtype_row_bytes(qtype, cols);
             const void* w = nullptr;
 
             if (packed.on_device) {
@@ -1665,7 +1665,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             }
 
             if (w) {
-                auto fn = (qtype == GGMLQuantType::Q6_K) ? gemv_q6k : gemv_q8_0;
+                auto fn = (qtype == QType::Q6_K) ? gemv_q6k : gemv_q8_0;
                 fn(w, static_cast<const half*>(a.data), static_cast<half*>(c.data),
                    static_cast<int>(rows), static_cast<int>(cols), stream);
                 return;
@@ -1689,7 +1689,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
         // Helper: get FP16 expert weight pointer from pre-dequant cache or unpacked weights.
         // fp16_cache is the borrowed Tensor* for the packed tensor's FP16 cache entry.
-        auto get_fp16_expert_ptr = [&](const Tensor& packed, GGMLQuantType /*qtype*/,
+        auto get_fp16_expert_ptr = [&](const Tensor& packed, QType /*qtype*/,
                                         const std::vector<Tensor>& fallback,
                                         const Tensor* fp16_cache,
                                         int eidx) -> const void* {
@@ -1700,7 +1700,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 return static_cast<const char*>(fp16_cache->data) + expert_offset;
             }
             if (!fallback.empty() && static_cast<size_t>(eidx) < fallback.size() &&
-                fallback[eidx].data && fallback[eidx].dtype == DType::FP16 &&
+                fallback[eidx].data && fallback[eidx].qtype == QType::F16 &&
                 fallback[eidx].on_device) {
                 return fallback[eidx].data;
             }
@@ -1710,7 +1710,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         // Helper: batch dequant all experts + single grouped GEMM.
         // Dequants all experts to FP16, then runs a single batched GEMM.
         // CUTLASS 2.x GemmGrouped provides lower launch overhead than cuBLAS.
-        auto chunked_dequant_gemm = [&](const Tensor& packed, GGMLQuantType qtype,
+        auto chunked_dequant_gemm = [&](const Tensor& packed, QType qtype,
                                         const std::vector<Tensor>& fallback,
                                         const std::vector<TensorID>& fallback_ids,
                                         const char* a_base, char* c_base,
@@ -1719,7 +1719,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             int64_t cols = packed.shape[2];
             size_t expert_fp16_sz = static_cast<size_t>(rows) * cols * sizeof(half);
             size_t expert_raw_sz = static_cast<size_t>(rows)
-                                   * ggml_quant_row_bytes(qtype, cols);
+                                   * qtype_row_bytes(qtype, cols);
 
             if (!moe_.batch_dequant_buf || expert_fp16_sz == 0) {
                 // No buffer — serial fallback
@@ -1759,7 +1759,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             // individual cublasLtMatmul calls).
             gemm_moe_batched(a_base, c_base,
                              h_offsets.data(), b_ptrs.data(),
-                             K_dim, N_dim, DType::FP16, ne, stream,
+                             K_dim, N_dim, QType::F16, ne, stream,
                              moe_.d_work_ptrs);
         };
 
@@ -1795,10 +1795,10 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             if (!non_gated_experts)
                 gemm_moe_batched(gathered_base, expert_gate_base,
                                   h_offsets.data(), gate_w_ptrs.data(),
-                                  d, eff, DType::FP16, ne, stream, moe_.d_work_ptrs);
+                                  d, eff, QType::F16, ne, stream, moe_.d_work_ptrs);
             gemm_moe_batched(gathered_base, expert_up_base,
                               h_offsets.data(), up_w_ptrs.data(),
-                              d, eff, DType::FP16, ne, stream, moe_.d_work_ptrs);
+                              d, eff, QType::F16, ne, stream, moe_.d_work_ptrs);
 
             apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data,
                                     moe_.expert_swiglu.data, non_gated_experts,
@@ -1808,7 +1808,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 char* batch_down_act = non_gated_experts ? expert_up_base : expert_swiglu_base;
                 gemm_moe_batched(batch_down_act, expert_down_base,
                                   h_offsets.data(), down_w_ptrs.data(),
-                                  eff, d, DType::FP16, ne, stream, moe_.d_work_ptrs);
+                                  eff, d, QType::F16, ne, stream, moe_.d_work_ptrs);
             }
 
         } else if (can_dequant_batch) {
@@ -1899,7 +1899,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     //      Fallback: atomicAdd scatter + FP32->FP16 convert.
     {
         bool has_shared_expert = (ly.w_up_shared.data != nullptr);
-        if (routing.token_to_expanded && compute_dtype_ == DType::FP16) {
+        if (routing.token_to_expanded && compute_dtype_ == QType::F16) {
             // Fused token-centric scatter: no atomics, no FP32 intermediate buffer.
             // If no shared expert, also fuse residual add.
             // Gemma-4 FP32 path: defer residual to post_ffn_norm (FP32 accumulator).
@@ -1934,7 +1934,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             int64_t numel = static_cast<int64_t>(n) * d;
             int threads = 256;
             int blocks = static_cast<int>((numel + threads - 1) / threads);
-            if (compute_dtype_ == DType::FP16) {
+            if (compute_dtype_ == QType::F16) {
                 fp32_to_fp16_kernel<<<blocks, threads, 0, stream>>>(
                     static_cast<const float*>(moe_.scatter_out.data),
                     static_cast<half*>(h.data),
@@ -2062,7 +2062,7 @@ moe_after_experts:
         if (!skip_shexp_gate &&
             ly.shared_expert_gate_inp.data != nullptr &&
             ly.shared_expert_gate_inp.on_device &&
-            compute_dtype_ == DType::FP16) {
+            compute_dtype_ == QType::F16) {
             shared_expert_gate_scale(
                 no.data,
                 ly.shared_expert_gate_inp.data,

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1678,6 +1678,37 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 ? dequant_expert(packed, qtype, eidx)
                 : fallback[eidx];
             if (!b.data) return;  // dequant_expert failed (OOB or buffer too small)
+
+            // SafeTensors NVFP4 prequant: per-expert weights got promoted to
+            // qtype=NVFP4 + scales/tensor_scale sidecars at engine init
+            // (executor_pre_dequant.cu Phase 0). The legacy fallback below
+            // expects an FP16 weight; calling cuBLAS gemm with qtype=NVFP4
+            // would crash with "unsupported dtype 71". Route through the
+            // native NVFP4 path — same logic as the WeightHandle-driven
+            // has_nvfp4_id branch above.
+            if (b.qtype == QType::NVFP4 && b.scales != nullptr) {
+                NvFP4QuantResult nw;
+                nw.packed_data  = b.data;
+                nw.micro_scales = b.scales;
+                nw.tensor_scale = b.tensor_scale;
+                nw.N = static_cast<int>(b.shape[0]);
+                nw.K = static_cast<int>(b.shape[1]) * 2;  // packed → logical
+                if (a.shape[0] == 1) {
+                    gemv_nvfp4_kpar(nw, static_cast<const half*>(a.data),
+                                    static_cast<half*>(c.data),
+                                    static_cast<int>(nw.N),
+                                    static_cast<int>(nw.K), stream);
+                } else {
+                    int64_t a_shape[2] = {a.shape[0], static_cast<int64_t>(nw.K)};
+                    int64_t c_shape[2] = {a.shape[0], static_cast<int64_t>(nw.N)};
+                    Tensor a_t(const_cast<void*>(static_cast<const void*>(a.data)),
+                               QType::F16, 2, a_shape, true);
+                    Tensor c_t(c.data, QType::F16, 2, c_shape, true);
+                    gemm_nvfp4(nw, a_t, c_t, stream);
+                }
+                return;
+            }
+
             gemm(a, b, c, 1.0f, 0.0f, stream);
         }
     };

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -204,7 +204,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
     // Pre-check decode fast path (same logic as will_decode_fast below)
     bool will_skip_residual_copy = can_decode_fast(n, ly.expert_up_packed,
-        ly.expert_up_qtype, moe_.dequant_buf, compute_dtype_) &&
+        ly.expert_up_packed.qtype, moe_.dequant_buf, compute_dtype_) &&
         ly.w_up_shared.data == nullptr;  // must not have shared expert for full residual fusion
 
     if (!will_skip_residual_copy) {
@@ -322,7 +322,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     bool use_sigmoid = cfg.moe_sigmoid_gating;
     bool norm_weights = cfg.expert_weights_norm;
 
-    QType up_qtype = ly.expert_up_qtype;
+    QType up_qtype = ly.expert_up_packed.qtype;
     bool will_decode_fast = can_decode_fast(n, ly.expert_up_packed, up_qtype,
                                             moe_.dequant_buf, compute_dtype_);
     // Gemma 4: dp4a decode fast path ENABLED by default. dp4a matches llama's
@@ -606,7 +606,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
             // 5'+6'. Fused gate+up projection (single kernel launch)
             if (!non_gated_experts) {
-                size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_qtype);
+                size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype);
                 if (up_qtype == QType::Q6_K) {
                     gemv_q6k_q8_1_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
@@ -674,7 +674,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             size_t up_stride_bytes = expert_stride(ly.expert_up_packed, up_qtype);
 
             if (!non_gated_experts) {
-                size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_qtype);
+                size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype);
                 if (up_qtype == QType::Q6_K) {
                     gemv_q6k_moe_gate_up_fused(
                         ly.expert_gate_packed.data, ly.expert_up_packed.data,
@@ -731,7 +731,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             }
 
             // Down projection with dp4a GEMV — use down_qtype, NOT up_qtype
-            QType dqt = ly.expert_down_qtype;
+            QType dqt = ly.expert_down_packed.qtype;
             auto moe_gemv_dp4a_down = (dqt == QType::Q6_K)
                 ? gemv_q6k_q8_1_moe_decode
                 : (dqt == QType::Q4_0)
@@ -747,7 +747,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 : (dqt == QType::Q5_1)
                 ? gemv_q5_1_q8_1_moe_decode
                 : gemv_q8_0_q8_1_moe_decode;
-            size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_qtype);
+            size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype);
             moe_gemv_dp4a_down(ly.expert_down_packed.data, expert_indices,
                           q8, qscratch_.d8_buf, down_buf,
                           d, eff, down_stride,
@@ -758,18 +758,18 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             apply_expert_activation(gate_buf, up_buf, act_buf,
                                     non_gated_experts, top_k, eff,
                                     compute_dtype_, cfg.ffn_activation, stream);
-            size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_qtype);
+            size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype);
             half* down_input = non_gated_experts ? up_buf : act_buf;
-            if (ly.expert_down_qtype == QType::Q6_K) {
+            if (ly.expert_down_packed.qtype == QType::Q6_K) {
                 gemv_q6k_moe_decode(ly.expert_down_packed.data, expert_indices,
                                     down_input, down_buf,
                                     d, eff, down_stride, /*x_stride=*/eff, top_k, stream);
-            } else if (ly.expert_down_qtype == QType::Q8_0) {
+            } else if (ly.expert_down_packed.qtype == QType::Q8_0) {
                 gemv_q8_0_moe_decode(ly.expert_down_packed.data, expert_indices,
                                      down_input, down_buf,
                                      d, eff, down_stride, /*x_stride=*/eff, top_k, stream);
             } else {
-                IMP_LOG_ERROR("MoE non-dp4a down projection: no kernel for qtype %d, skipping GEMV", (int)ly.expert_down_qtype);
+                IMP_LOG_ERROR("MoE non-dp4a down projection: no kernel for qtype %d, skipping GEMV", (int)ly.expert_down_packed.qtype);
             }
         }
 
@@ -802,12 +802,12 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                           ly.expert_up_packed.data && ly.expert_up_packed.on_device &&
                           ly.expert_down_packed.data && ly.expert_down_packed.on_device &&
                           up_qtype == QType::Q6_K &&
-                          ly.expert_down_qtype == QType::Q6_K &&
+                          ly.expert_down_packed.qtype == QType::Q6_K &&
                           compute_dtype_ == QType::F16);
     if (can_fused_q6k && !non_gated_experts)
         can_fused_q6k = (ly.expert_gate_packed.data &&
                          ly.expert_gate_packed.on_device &&
-                         ly.expert_gate_qtype == QType::Q6_K);
+                         ly.expert_gate_packed.qtype == QType::Q6_K);
 
     bool use_tc = can_fused_q6k && (expanded > ne * 12);
     bool use_scalar = can_fused_q6k && !use_tc && (expanded <= ne * 12);
@@ -833,7 +833,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     ly.expert_gate_packed.data,
                     no.data, expert_gate_base, d_offsets,
                     eff, d,
-                    expert_stride(ly.expert_gate_packed, ly.expert_gate_qtype),
+                    expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype),
                     ne, stream, d_sorted);
 
             // Up projection
@@ -859,7 +859,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     ly.expert_gate_packed.data,
                     gathered_base, expert_gate_base, d_offsets,
                     eff, d,
-                    expert_stride(ly.expert_gate_packed, ly.expert_gate_qtype),
+                    expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype),
                     ne, stream);
 
             gemm_q6k_fused_moe_prefill(
@@ -882,14 +882,14 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 ly.expert_down_packed.data,
                 fused_down_act, expert_down_base, d_offsets,
                 d, eff,
-                expert_stride(ly.expert_down_packed, ly.expert_down_qtype),
+                expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype),
                 ne, stream);
         } else {
             gemm_q6k_fused_moe_prefill(
                 ly.expert_down_packed.data,
                 fused_down_act, expert_down_base, d_offsets,
                 d, eff,
-                expert_stride(ly.expert_down_packed, ly.expert_down_qtype),
+                expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype),
                 ne, stream);
         }
 
@@ -908,9 +908,9 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     half* up_buf   = static_cast<half*>(moe_.expert_up.data);
     half* down_buf = static_cast<half*>(moe_.expert_down.data);
 
-    size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_qtype);
+    size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype);
     size_t up_stride = expert_stride(ly.expert_up_packed, up_qtype);
-    size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_qtype);
+    size_t down_stride = expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype);
 
     // Dedicated Q8_1 scratch buffer (persistent, sized for max of gate/up input d and down input eff)
     static void* s_q8_scratch = nullptr;
@@ -991,7 +991,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     }
                 }
             };
-            do_mmvq(gate_w, gate_buf + static_cast<int64_t>(k) * eff, ly.expert_gate_qtype);
+            do_mmvq(gate_w, gate_buf + static_cast<int64_t>(k) * eff, ly.expert_gate_packed.qtype);
             do_mmvq(up_w, up_buf + static_cast<int64_t>(k) * eff, up_qtype);
         }
 
@@ -1009,7 +1009,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             half* act_k = swiglu_buf + static_cast<int64_t>(k) * eff;
             half* out_k = down_buf + static_cast<int64_t>(k) * d;
 
-            switch (ly.expert_down_qtype) {
+            switch (ly.expert_down_packed.qtype) {
                 case QType::Q4_K:
                     ggml_mmvq_q4k(w_down, act_k, out_k, 1, d, eff, s_q8_scratch, s_q8_scratch_size, stream);
                     break;
@@ -1067,11 +1067,11 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         ly.expert_up_packed.data && ly.expert_up_packed.on_device &&
         ly.expert_down_packed.data && ly.expert_down_packed.on_device &&
         dequant_gpu_supported(up_qtype) &&
-        dequant_gpu_supported(ly.expert_down_qtype));
+        dequant_gpu_supported(ly.expert_down_packed.qtype));
     if (can_fp16_batch_nosync && !non_gated_experts)
         can_fp16_batch_nosync = (ly.expert_gate_packed.data &&
                                   ly.expert_gate_packed.on_device &&
-                                  dequant_gpu_supported(ly.expert_gate_qtype));
+                                  dequant_gpu_supported(ly.expert_gate_packed.qtype));
 
     // FP8 batch check: fallback when FP16 batch isn't available
     size_t up_fp8_sz   = static_cast<size_t>(ne) * ly.expert_up_packed.shape[1]
@@ -1088,13 +1088,13 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                           ly.expert_up_packed.data && ly.expert_up_packed.on_device &&
                           ly.expert_down_packed.data && ly.expert_down_packed.on_device &&
                           up_qtype == QType::Q6_K &&
-                          ly.expert_down_qtype == QType::Q6_K &&
+                          ly.expert_down_packed.qtype == QType::Q6_K &&
                           compute_dtype_ == QType::F16 &&
                           ly.fp16_packed_up_cache == nullptr);
     if (can_fp8_batch && !non_gated_experts)
         can_fp8_batch = (ly.expert_gate_packed.data &&
                          ly.expert_gate_packed.on_device &&
-                         ly.expert_gate_qtype == QType::Q6_K);
+                         ly.expert_gate_packed.qtype == QType::Q6_K);
 
     if (debug_forward_enabled() && layer == 0) {
         int64_t gs[2] = {static_cast<int64_t>(expanded), static_cast<int64_t>(d)};
@@ -1155,7 +1155,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
         // Gate projection
         if (!non_gated_experts)
-            batch_dequant_gemm(ly.expert_gate_packed, ly.expert_gate_qtype,
+            batch_dequant_gemm(ly.expert_gate_packed, ly.expert_gate_packed.qtype,
                                 gathered_base, expert_gate_base, d, eff);
         if (debug_forward_enabled() && layer == 0) {
             int64_t sh[2] = {static_cast<int64_t>(expanded), static_cast<int64_t>(eff)};
@@ -1188,7 +1188,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             ? static_cast<char*>(fp32_down_buf)
             : expert_down_base;
         QType down_out_dtype = fp32_down_active ? QType::F32 : QType::F16;
-        batch_dequant_gemm(ly.expert_down_packed, ly.expert_down_qtype,
+        batch_dequant_gemm(ly.expert_down_packed, ly.expert_down_packed.qtype,
                             down_act, down_target, eff, d, down_out_dtype);
         if (debug_forward_enabled() && layer == 0 && !fp32_down_active) {
             int64_t sh[2] = {static_cast<int64_t>(expanded), static_cast<int64_t>(d)};
@@ -1275,7 +1275,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
         // Gate projection (gated models only)
         if (!non_gated_experts)
-            chunked_fp8_gemm(ly.expert_gate_packed, ly.expert_gate_qtype,
+            chunked_fp8_gemm(ly.expert_gate_packed, ly.expert_gate_packed.qtype,
                              gathered_base, expert_gate_base, d, eff);
 
         // Up projection
@@ -1289,7 +1289,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
         // Down projection: up buffer for non-gated (relu² in-place), swiglu for gated
         char* fp8_down_act = non_gated_experts ? expert_up_base : expert_swiglu_base;
-        chunked_fp8_gemm(ly.expert_down_packed, ly.expert_down_qtype,
+        chunked_fp8_gemm(ly.expert_down_packed, ly.expert_down_packed.qtype,
                          fp8_down_act, expert_down_base, eff, d);
 
         // Falls through to existing scatter (step 7)
@@ -1774,7 +1774,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         bool can_dequant_batch = (moe_.batch_dequant_buf != nullptr &&
                                    ly.expert_up_packed.data != nullptr &&
                                    ly.expert_up_packed.on_device &&
-                                   dequant_gpu_supported(ly.expert_up_qtype));
+                                   dequant_gpu_supported(ly.expert_up_packed.qtype));
 
         if (has_precached_up) {
             // Pre-cached FP16 path — all expert packs in fp16_packed_*_cache
@@ -1784,12 +1784,12 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             std::vector<const void*> down_w_ptrs(ne, nullptr);
 
             for (int e = 0; e < ne; e++) {
-                up_w_ptrs[e] = get_fp16_expert_ptr(ly.expert_up_packed, ly.expert_up_qtype,
+                up_w_ptrs[e] = get_fp16_expert_ptr(ly.expert_up_packed, ly.expert_up_packed.qtype,
                                                      ly.expert_w_up, ly.fp16_packed_up_cache, e);
                 if (!non_gated_experts)
-                    gate_w_ptrs[e] = get_fp16_expert_ptr(ly.expert_gate_packed, ly.expert_gate_qtype,
+                    gate_w_ptrs[e] = get_fp16_expert_ptr(ly.expert_gate_packed, ly.expert_gate_packed.qtype,
                                                            ly.expert_w_gate, ly.fp16_packed_gate_cache, e);
-                down_w_ptrs[e] = get_fp16_expert_ptr(ly.expert_down_packed, ly.expert_down_qtype,
+                down_w_ptrs[e] = get_fp16_expert_ptr(ly.expert_down_packed, ly.expert_down_packed.qtype,
                                                        ly.expert_w_down, ly.fp16_packed_down_cache, e);
             }
 
@@ -1817,10 +1817,10 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
             // Dequant all experts to FP16, then single grouped GEMM via CUTLASS.
 
             if (!non_gated_experts)
-                chunked_dequant_gemm(ly.expert_gate_packed, ly.expert_gate_qtype,
+                chunked_dequant_gemm(ly.expert_gate_packed, ly.expert_gate_packed.qtype,
                                      ly.expert_w_gate, ly.expert_gate_ids,
                                      gathered_base, expert_gate_base, d, eff);
-            chunked_dequant_gemm(ly.expert_up_packed, ly.expert_up_qtype,
+            chunked_dequant_gemm(ly.expert_up_packed, ly.expert_up_packed.qtype,
                                  ly.expert_w_up, ly.expert_up_ids,
                                  gathered_base, expert_up_base, d, eff);
 
@@ -1830,7 +1830,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
 
             {
                 char* dequant_down_act = non_gated_experts ? expert_up_base : expert_swiglu_base;
-                chunked_dequant_gemm(ly.expert_down_packed, ly.expert_down_qtype,
+                chunked_dequant_gemm(ly.expert_down_packed, ly.expert_down_packed.qtype,
                                      ly.expert_w_down, ly.expert_down_ids,
                                      dequant_down_act, expert_down_base, eff, d);
             }
@@ -1853,7 +1853,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     Tensor c_view(expert_gate_base + static_cast<size_t>(start) * eff * es,
                                   compute_dtype_, 2, c_shape, true);
                     expert_gemm(a_view, c_view, ly.expert_gate_packed,
-                                ly.expert_gate_qtype, ly.expert_w_gate, ly.expert_gate_ids, e);
+                                ly.expert_gate_packed.qtype, ly.expert_w_gate, ly.expert_gate_ids, e);
                 }
 
                 {
@@ -1861,7 +1861,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     Tensor c_view(expert_up_base + static_cast<size_t>(start) * eff * es,
                                   compute_dtype_, 2, c_shape, true);
                     expert_gemm(a_view, c_view, ly.expert_up_packed,
-                                ly.expert_up_qtype, ly.expert_w_up, ly.expert_up_ids, e);
+                                ly.expert_up_packed.qtype, ly.expert_w_up, ly.expert_up_ids, e);
                 }
             }
 
@@ -1886,7 +1886,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                 Tensor c_view(expert_down_base + static_cast<size_t>(start) * d * es,
                               compute_dtype_, 2, c_shape, true);
                 expert_gemm(a_view, c_view, ly.expert_down_packed,
-                            ly.expert_down_qtype, ly.expert_w_down, ly.expert_down_ids, e);
+                            ly.expert_down_packed.qtype, ly.expert_w_down, ly.expert_down_ids, e);
             }
         }
     }

--- a/src/graph/executor_gemv_helpers.h
+++ b/src/graph/executor_gemv_helpers.h
@@ -8,17 +8,17 @@ namespace imp {
 
 // Residual-fused GEMV dispatch by quant type: y[i] = dot(W[i], x) + residual[i].
 // Shared by executor_attention.cu and executor_ffn.cu.
-static void dispatch_gemv_residual(GGMLQuantType qtype,
+static void dispatch_gemv_residual(QType qtype,
                                     const void* W, const block_q8_1* q8_1, const float* d8,
                                     half* y, const half* residual,
                                     int M, int K, cudaStream_t stream) {
     switch (qtype) {
-        case GGMLQuantType::Q6_K: gemv_q6k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
-        case GGMLQuantType::Q4_0: gemv_q4_0_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
-        case GGMLQuantType::Q4_K: gemv_q4_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
-        case GGMLQuantType::Q5_K: gemv_q5_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
-        case GGMLQuantType::Q2_K: gemv_q2_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
-        case GGMLQuantType::Q3_K: gemv_q3_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
+        case QType::Q6_K: gemv_q6k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
+        case QType::Q4_0: gemv_q4_0_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
+        case QType::Q4_K: gemv_q4_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
+        case QType::Q5_K: gemv_q5_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
+        case QType::Q2_K: gemv_q2_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
+        case QType::Q3_K: gemv_q3_k_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
         default:                  gemv_q8_0_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream); break;
     }
 }

--- a/src/graph/executor_helpers.h
+++ b/src/graph/executor_helpers.h
@@ -12,7 +12,7 @@ namespace imp {
 
 static inline size_t align256(size_t x) { return (x + 255) & ~size_t(255); }
 
-static inline Tensor make_workspace_tensor(char*& ptr, DType dtype,
+static inline Tensor make_workspace_tensor(char*& ptr, QType dtype,
                                            int64_t rows, int64_t cols, size_t aligned_sz) {
     int64_t shape[2] = {rows, cols};
     Tensor t(ptr, dtype, 2, shape, true);

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -2140,16 +2140,17 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
 }
 
 // ---------------------------------------------------------------------------
-// New GemmContext-based dispatch: delegates to the legacy 23-parameter version.
-// Callers use this simplified interface; the legacy version will be inlined
-// once all call sites are migrated.
+// GemmContext-based dispatch: reads the weight's qtype directly off the
+// tensor (no separate parameter needed) and delegates to the file-private
+// gemm_dispatch_impl helper.
 // ---------------------------------------------------------------------------
 void gemm_dispatch(const Tensor& input, const Tensor& weight,
-                   QType qtype, Tensor& output,
-                   const GemmContext& ctx) {
+                   Tensor& output, const GemmContext& ctx) {
     const auto* wc = ctx.wcache;
     const auto* qs = ctx.qscratch;
     if (!wc || !qs) return;
+
+    const QType qtype = weight.qtype;
 
     // Residual-add fuse (beta != 0): only FP16 weight cache or dequantable-to-FP16
     // is supported. GEMV and block-scaled quant paths don't honor beta — callers

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -2,6 +2,7 @@
 #include "graph/gemm_context.h"
 #include "graph/executor.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 #include "compute/gemm.h"
 #include "compute/gemm_q6k.h"
 #include "compute/gemm_cutlass_sm120.h"
@@ -2001,7 +2002,7 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
     // with non-standard strides from per-layer narrow tensors).
     bool prefer_fp16_cache = (fp16_cache != nullptr && fp16_cache->count(weight.data) > 0 &&
                                input.stride[0] != weight.shape[1]);  // non-contiguous input
-    if (getenv("IMP_DEBUG_GEMM_DISPATCH") != nullptr) {
+    if (RuntimeConfig::current().diagnostics.debug_gemm_dispatch) {
         fprintf(stderr, "[GEMM_DISP] w=%p qtype=%d M=%lld N=%lld K=%lld prefer_fp16=%d "
                 "in_fp16_cache=%d in_fp8_cache=%d dp4a_ok=%d has_dequant=%d\n",
                 weight.data, (int)qtype,
@@ -2012,18 +2013,18 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
                 (int)(is_dp4a_qtype(qtype) && q8_1_buf && d8_buf),
                 (int)(dequant_scratch != nullptr));
     }
-    static bool no_dp4a_gemv = (getenv("IMP_NO_DP4A_GEMV") != nullptr);
+    const bool no_dp4a_gemv = RuntimeConfig::current().gemm.no_dp4a_gemv;
     // MMVQ: ggml-compatible quantized GEMM for llama.cpp numerical parity.
     // Auto-enabled for Gemma-4 via engine.cpp setenv. Non-static to pick up
     // env var set during engine init (after static init of other flags).
     // IMP_NO_MMVQ_Q8_0 / IMP_NO_MMVQ: debug bypass for suspected Q8_0 MMVQ bug.
-    static const bool no_mmvq_q8_0 = (getenv("IMP_NO_MMVQ_Q8_0") != nullptr);
-    static const bool no_mmvq_all  = (getenv("IMP_NO_MMVQ") != nullptr);
+    const bool no_mmvq_q8_0 = RuntimeConfig::current().gemm.no_mmvq_q8_0;
+    const bool no_mmvq_all  = RuntimeConfig::current().gemm.no_mmvq;
     // FP16-only fast paths (mmvq, dp4a, gemv_q6k, gemv_q8_0) write directly to
     // half* — must skip when caller requested FP32 output, otherwise the FP16
     // bytes get interpreted as FP32 and produce billions-magnitude garbage.
     const bool fp32_output = (output.qtype == QType::F32);
-    bool use_mmvq = (getenv("IMP_GEMMA4_FORCE_MMVQ") != nullptr) &&
+    bool use_mmvq = RuntimeConfig::current().gemma4.force_mmvq &&
                     !prefer_fp16_cache && input.qtype == QType::F16 && !fp32_output &&
                     (qtype == QType::Q4_K || qtype == QType::Q5_K ||
                      qtype == QType::Q5_1 || qtype == QType::Q8_0) &&
@@ -2113,7 +2114,7 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
     } else if (fp16_cache != nullptr && (dequant_gpu_supported(qtype) || qtype == QType::MXFP4)) {
         // Pre-dequantized FP16 cache: zero per-GEMM dequant overhead
         auto it = fp16_cache->find(weight.data);
-        if (getenv("IMP_DEBUG_GEMM_DISPATCH") != nullptr) fprintf(stderr, "[GEMM_DISP]   -> fp16_cache hit=%d\n", (int)(it != fp16_cache->end()));
+        if (RuntimeConfig::current().diagnostics.debug_gemm_dispatch) fprintf(stderr, "[GEMM_DISP]   -> fp16_cache hit=%d\n", (int)(it != fp16_cache->end()));
         if (it != fp16_cache->end()) {
             gemm(input, it->second, output, 1.0f, beta, stream);
         } else if (dequant_scratch != nullptr && qtype != QType::MXFP4) {

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -52,16 +52,16 @@ __device__ __forceinline__ int kv_resolve_slot(
 
 // Dispatch dp4a GEMV by quant type: y = W @ q8_1 (FP16 output).
 // Defined here, declared in executor_kernels.h for use by executor_forward.cu.
-void dispatch_dp4a_gemv(GGMLQuantType qtype,
+void dispatch_dp4a_gemv(QType qtype,
                         const void* W, const block_q8_1* q8_1, const float* d8,
                         half* y, int M, int K, cudaStream_t stream) {
     switch (qtype) {
-        case GGMLQuantType::Q6_K: gemv_q6k_q8_1(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q4_0: gemv_q4_0_q8_1(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q4_K: gemv_q4_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q5_K: gemv_q5_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q2_K: gemv_q2_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
-        case GGMLQuantType::Q3_K: gemv_q3_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q6_K: gemv_q6k_q8_1(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q4_0: gemv_q4_0_q8_1(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q4_K: gemv_q4_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q5_K: gemv_q5_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q2_K: gemv_q2_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
+        case QType::Q3_K: gemv_q3_k_q8_1(W, q8_1, d8, y, M, K, stream); break;
         default:                  gemv_q8_0_q8_1(W, q8_1, d8, y, M, K, stream); break;
     }
 }
@@ -1548,7 +1548,7 @@ __global__ __launch_bounds__(256) void fp32_to_fp16_kernel(const float* __restri
 
 void elementwise_add(Tensor& a, const Tensor& b, cudaStream_t stream) {
     int64_t n = a.numel();
-    if (a.dtype == DType::FP16) {
+    if (a.qtype == QType::F16) {
         int64_t n2 = (n + 1) / 2;
         int threads = 256;
         int blocks = static_cast<int>((n2 + threads - 1) / threads);
@@ -1885,7 +1885,7 @@ Tensor slice_rows(const Tensor& buf, int n_tokens) {
 // - dp4a MMVQ path (M=1 + q8_1_buf/d8_buf): pre-quantize input to Q8_1, dot
 //   products via native INT8 SIMD (~2x faster than FP16 dequant for Q6_K/Q8_0).
 static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
-                           const Tensor& scales, GGMLQuantType qtype,
+                           const Tensor& scales, QType qtype,
                            Tensor& output, void* dequant_scratch,
                            cudaStream_t stream,
                            block_q8_1* q8_1_buf,
@@ -1911,7 +1911,7 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
     // beta != 0 (residual-fused GEMM) is only supported on FP16/dequant/FP8 paths
     // below; callers must ensure their preconditions route there.
     // Native MXFP4 GGUF: GEMV for M=1, CUTLASS for M>1.
-    if (mxfp4_cache != nullptr && input.dtype == DType::FP16) {
+    if (mxfp4_cache != nullptr && input.qtype == QType::F16) {
         auto mx_it = mxfp4_cache->find(weight.data);
         if (mx_it != mxfp4_cache->end() && mx_it->second.linear_scales) {
             if (input.shape[0] == 1) {
@@ -1937,14 +1937,14 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
                 size_t fp16_bytes = static_cast<size_t>(N) * K * sizeof(half);
                 dequant_mxfp4_to_fp16(mx_it->second.data, N, K, dequant_scratch, stream);
                 int64_t w_shape[2] = {N, K};
-                Tensor w_fp16(dequant_scratch, DType::FP16, 2, w_shape, true);
+                Tensor w_fp16(dequant_scratch, QType::F16, 2, w_shape, true);
                 gemm(input, w_fp16, output, 1.0f, beta, stream);
                 return;
             }
         }
     }
     // NVFP4 cache path: GEMV for M=1 (decode), CUTLASS/dequant for M>1 (prefill).
-    if (nvfp4_cache != nullptr && input.dtype == DType::FP16) {
+    if (nvfp4_cache != nullptr && input.qtype == QType::F16) {
         auto it = nvfp4_cache->find(weight.data);
         if (it != nvfp4_cache->end()) {
             if (input.shape[0] == 1) {
@@ -2022,16 +2022,16 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
     // FP16-only fast paths (mmvq, dp4a, gemv_q6k, gemv_q8_0) write directly to
     // half* — must skip when caller requested FP32 output, otherwise the FP16
     // bytes get interpreted as FP32 and produce billions-magnitude garbage.
-    const bool fp32_output = (output.dtype == DType::FP32);
+    const bool fp32_output = (output.qtype == QType::F32);
     bool use_mmvq = (getenv("IMP_GEMMA4_FORCE_MMVQ") != nullptr) &&
-                    !prefer_fp16_cache && input.dtype == DType::FP16 && !fp32_output &&
-                    (qtype == GGMLQuantType::Q4_K || qtype == GGMLQuantType::Q5_K ||
-                     qtype == GGMLQuantType::Q5_1 || qtype == GGMLQuantType::Q8_0) &&
+                    !prefer_fp16_cache && input.qtype == QType::F16 && !fp32_output &&
+                    (qtype == QType::Q4_K || qtype == QType::Q5_K ||
+                     qtype == QType::Q5_1 || qtype == QType::Q8_0) &&
                     (weight.shape[1] % 32 == 0) &&
-                    !(no_mmvq_q8_0 && qtype == GGMLQuantType::Q8_0) &&
+                    !(no_mmvq_q8_0 && qtype == QType::Q8_0) &&
                     !no_mmvq_all;
     bool use_dp4a = !no_dp4a_gemv && !prefer_fp16_cache && input.shape[0] == 1 &&
-                    input.dtype == DType::FP16 && !fp32_output &&
+                    input.qtype == QType::F16 && !fp32_output &&
                     q8_1_buf != nullptr && d8_buf != nullptr && is_dp4a_qtype(qtype);
     if (use_mmvq) {
         int M = static_cast<int>(input.shape[0]);
@@ -2046,19 +2046,19 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
             cudaMalloc(&s_mmvq_scratch, q8_need * 2);
             s_mmvq_scratch_size = q8_need * 2;
         }
-        if (qtype == GGMLQuantType::Q4_K)
+        if (qtype == QType::Q4_K)
             ggml_mmvq_q4k(weight.data, static_cast<const half*>(input.data),
                           static_cast<half*>(output.data), M, N, K,
                           s_mmvq_scratch, s_mmvq_scratch_size, stream);
-        else if (qtype == GGMLQuantType::Q5_K)
+        else if (qtype == QType::Q5_K)
             ggml_mmvq_q5k(weight.data, static_cast<const half*>(input.data),
                           static_cast<half*>(output.data), M, N, K,
                           s_mmvq_scratch, s_mmvq_scratch_size, stream);
-        else if (qtype == GGMLQuantType::Q5_1)
+        else if (qtype == QType::Q5_1)
             ggml_mmvq_q5_1(weight.data, static_cast<const half*>(input.data),
                            static_cast<half*>(output.data), M, N, K,
                            s_mmvq_scratch, s_mmvq_scratch_size, stream);
-        else if (qtype == GGMLQuantType::Q8_0)
+        else if (qtype == QType::Q8_0)
             ggml_mmvq_q8_0(weight.data, static_cast<const half*>(input.data),
                            static_cast<half*>(output.data), M, N, K,
                            s_mmvq_scratch, s_mmvq_scratch_size, stream);
@@ -2069,7 +2069,7 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
                                q8_1_buf, d8_buf, K, stream);
         dispatch_dp4a_gemv(qtype, weight.data, q8_1_buf, d8_buf,
                            static_cast<half*>(output.data), N, K, stream);
-    } else if (qtype == GGMLQuantType::Q4_1 && fp16_cache != nullptr) {
+    } else if (qtype == QType::Q4_1 && fp16_cache != nullptr) {
         // Prefer pre-dequantized FP16 cache (P3 optimization)
         auto it = fp16_cache->find(weight.data);
         if (it != fp16_cache->end()) {
@@ -2077,17 +2077,17 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
         } else {
             quant_gemm_int4(input, weight, scales, output, stream);
         }
-    } else if (qtype == GGMLQuantType::Q4_1) {
+    } else if (qtype == QType::Q4_1) {
         // weight is [N, K/2] packed nibbles, scales is [N, num_groups]
         quant_gemm_int4(input, weight, scales, output, stream);
-    } else if (input.shape[0] == 1 && input.dtype == DType::FP16 &&
-               dequant_scratch != nullptr && qtype == GGMLQuantType::Q6_K) {
+    } else if (input.shape[0] == 1 && input.qtype == QType::F16 &&
+               dequant_scratch != nullptr && qtype == QType::Q6_K) {
         // Fallback: Fused Q6_K GEMV (FP16 dequant path)
         gemv_q6k(weight.data, static_cast<const half*>(input.data),
                  static_cast<half*>(output.data),
                  static_cast<int>(weight.shape[0]), static_cast<int>(weight.shape[1]), stream);
-    } else if (input.shape[0] == 1 && input.dtype == DType::FP16 &&
-               dequant_scratch != nullptr && qtype == GGMLQuantType::Q8_0) {
+    } else if (input.shape[0] == 1 && input.qtype == QType::F16 &&
+               dequant_scratch != nullptr && qtype == QType::Q8_0) {
         // Fallback: Fused Q8_0 GEMV (FP16 dequant path)
         gemv_q8_0(weight.data, static_cast<const half*>(input.data),
                   static_cast<half*>(output.data),
@@ -2096,7 +2096,7 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
         // FP8 cache: quantize activation → FP8, then FP8×FP8 cuBLASLt GEMM (2x throughput on sm_120)
         auto it = fp8_cache->find(weight.data);
         if (it != fp8_cache->end()) {
-            Tensor fp8_act(fp8_act_buf, DType::FP8_E4M3, input.ndim, input.shape, true);
+            Tensor fp8_act(fp8_act_buf, QType::FP8_E4M3, input.ndim, input.shape, true);
             quantize_fp16_to_fp8_e4m3(input, fp8_act, d_act_scale, stream,
                                        d_fp8_block_maxes, d_fp8_absmax, fp8_max_grid);
             gemm_cublaslt(fp8_act, it->second.weight, output, 1.0f, beta,
@@ -2105,23 +2105,23 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
             int rows = static_cast<int>(weight.shape[0]);
             int cols = static_cast<int>(weight.shape[1]);
             dequant_gpu(weight.data, dequant_scratch, qtype, rows, cols, stream);
-            Tensor w_fp16(dequant_scratch, DType::FP16, weight.ndim, weight.shape, true);
+            Tensor w_fp16(dequant_scratch, QType::F16, weight.ndim, weight.shape, true);
             gemm(input, w_fp16, output, 1.0f, beta, stream);
         } else {
             gemm(input, weight, output, 1.0f, beta, stream);
         }
-    } else if (fp16_cache != nullptr && (dequant_gpu_supported(qtype) || qtype == GGMLQuantType::MXFP4)) {
+    } else if (fp16_cache != nullptr && (dequant_gpu_supported(qtype) || qtype == QType::MXFP4)) {
         // Pre-dequantized FP16 cache: zero per-GEMM dequant overhead
         auto it = fp16_cache->find(weight.data);
         if (getenv("IMP_DEBUG_GEMM_DISPATCH") != nullptr) fprintf(stderr, "[GEMM_DISP]   -> fp16_cache hit=%d\n", (int)(it != fp16_cache->end()));
         if (it != fp16_cache->end()) {
             gemm(input, it->second, output, 1.0f, beta, stream);
-        } else if (dequant_scratch != nullptr && qtype != GGMLQuantType::MXFP4) {
+        } else if (dequant_scratch != nullptr && qtype != QType::MXFP4) {
             // Cache miss (shouldn't happen) — fall back to on-the-fly dequant
             int rows = static_cast<int>(weight.shape[0]);
             int cols = static_cast<int>(weight.shape[1]);
             dequant_gpu(weight.data, dequant_scratch, qtype, rows, cols, stream);
-            Tensor w_fp16(dequant_scratch, DType::FP16, weight.ndim, weight.shape, true);
+            Tensor w_fp16(dequant_scratch, QType::F16, weight.ndim, weight.shape, true);
             gemm(input, w_fp16, output, 1.0f, beta, stream);
         } else {
             gemm(input, weight, output, 1.0f, beta, stream);
@@ -2131,7 +2131,7 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
         int rows = static_cast<int>(weight.shape[0]);
         int cols = static_cast<int>(weight.shape[1]);
         dequant_gpu(weight.data, dequant_scratch, qtype, rows, cols, stream);
-        Tensor w_fp16(dequant_scratch, DType::FP16, weight.ndim, weight.shape, true);
+        Tensor w_fp16(dequant_scratch, QType::F16, weight.ndim, weight.shape, true);
         gemm(input, w_fp16, output, 1.0f, beta, stream);
     } else {
         // Standard FP16/BF16 GEMM
@@ -2145,7 +2145,7 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
 // once all call sites are migrated.
 // ---------------------------------------------------------------------------
 void gemm_dispatch(const Tensor& input, const Tensor& weight,
-                   GGMLQuantType qtype, Tensor& output,
+                   QType qtype, Tensor& output,
                    const GemmContext& ctx) {
     const auto* wc = ctx.wcache;
     const auto* qs = ctx.qscratch;
@@ -2164,11 +2164,11 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight,
             int rows = static_cast<int>(weight.shape[0]);
             int cols = static_cast<int>(weight.shape[1]);
             dequant_gpu(weight.data, qs->dequant, qtype, rows, cols, ctx.stream);
-            Tensor w_fp16(qs->dequant, DType::FP16, weight.ndim, weight.shape, true);
+            Tensor w_fp16(qs->dequant, QType::F16, weight.ndim, weight.shape, true);
             gemm(input, w_fp16, output, 1.0f, ctx.beta, ctx.stream);
             return;
         }
-        if (weight.dtype == DType::FP16 || weight.dtype == DType::BF16) {
+        if (weight.qtype == QType::F16 || weight.qtype == QType::BF16) {
             gemm(input, weight, output, 1.0f, ctx.beta, ctx.stream);
             return;
         }

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -1944,23 +1944,41 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
             }
         }
     }
-    // NVFP4 cache path: GEMV for M=1 (decode), CUTLASS/dequant for M>1 (prefill).
-    if (nvfp4_cache != nullptr && input.qtype == QType::F16) {
+    // NVFP4 dispatch: Tensor sidecars (prequant load path, qtype=NVFP4 set
+    // directly on the weight) take precedence over the legacy nvfp4_cache
+    // (decode-cache path, FP16/Q*_K weights converted on-the-fly during init).
+    // Build NvFP4QuantResult on-the-fly when the sidecars are populated;
+    // otherwise fall through to the cache lookup.
+    NvFP4QuantResult nvfp4_tmp;
+    const NvFP4QuantResult* nvfp4_view = nullptr;
+    if (input.qtype == QType::F16 && weight.qtype == QType::NVFP4 &&
+        weight.scales != nullptr) {
+        nvfp4_tmp.packed_data  = weight.data;
+        nvfp4_tmp.micro_scales = weight.scales;
+        nvfp4_tmp.tensor_scale = weight.tensor_scale;
+        nvfp4_tmp.N            = weight.shape[0];
+        // shape[1] holds packed K/2 for FP4 → kernel needs logical K
+        nvfp4_tmp.K            = weight.shape[1] * 2;
+        nvfp4_view             = &nvfp4_tmp;
+    } else if (nvfp4_cache != nullptr && input.qtype == QType::F16) {
         auto it = nvfp4_cache->find(weight.data);
-        if (it != nvfp4_cache->end()) {
-            if (input.shape[0] == 1) {
-                gemv_nvfp4_kpar(it->second,
-                                reinterpret_cast<const half*>(input.data),
-                                reinterpret_cast<half*>(output.data),
-                                static_cast<int>(it->second.N),
-                                static_cast<int>(it->second.K), stream);
-            } else if (cutlass_nvfp4_cache != nullptr && cutlass_act_data != nullptr) {
+        if (it != nvfp4_cache->end()) nvfp4_view = &it->second;
+    }
+    if (nvfp4_view != nullptr) {
+        const NvFP4QuantResult& res = *nvfp4_view;
+        if (input.shape[0] == 1) {
+            gemv_nvfp4_kpar(res,
+                            reinterpret_cast<const half*>(input.data),
+                            reinterpret_cast<half*>(output.data),
+                            static_cast<int>(res.N),
+                            static_cast<int>(res.K), stream);
+        } else if (cutlass_nvfp4_cache != nullptr && cutlass_act_data != nullptr) {
                 // Native FP4 GEMM: try cuBLASLt first, then CUTLASS sm_120
                 auto ct_it = cutlass_nvfp4_cache->find(weight.data);
                 if (ct_it != cutlass_nvfp4_cache->end()) {
                     int M = static_cast<int>(input.shape[0]);
                     int K = static_cast<int>(input.shape[1]);
-                    int N = static_cast<int>(it->second.N);
+                    int N = static_cast<int>(res.N);
                     quantize_fp16_to_nvfp4_cutlass(input.data, cutlass_act_data,
                                                     cutlass_act_sf, M, K, stream);
 
@@ -1992,11 +2010,10 @@ static void gemm_dispatch_impl(const Tensor& input, const Tensor& weight,
                     if (ok) return;
                 }
             }
-            if (input.shape[0] > 1) {
-                gemm_nvfp4(it->second, input, output, stream);
-            }
-            return;
+        if (input.shape[0] > 1) {
+            gemm_nvfp4(res, input, output, stream);
         }
+        return;
     }
     // Gemma 4: if FP16 cache has the weight, use it (dp4a dispatch has issues
     // with non-standard strides from per-layer narrow tensors).

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "core/tensor.h"
-#include "model/model_config.h" // GGMLQuantType (Q6_K, Q4_0, etc.)
+#include "model/model_config.h" // QType (Q6_K, Q4_0, etc.)
 #include "compute/gemm.h"       // block_q8_1
 
 #include <cuda_runtime.h>
@@ -276,15 +276,15 @@ __global__ __launch_bounds__(256) void fp32_to_fp16_kernel(const float* __restri
 // ---------------------------------------------------------------------------
 
 // Returns true if the quant type supports dp4a (Q8_1-input) GEMV kernels.
-inline bool is_dp4a_qtype(GGMLQuantType qt) {
-    return qt == GGMLQuantType::Q6_K || qt == GGMLQuantType::Q8_0 ||
-           qt == GGMLQuantType::Q4_0 || qt == GGMLQuantType::Q4_K ||
-           qt == GGMLQuantType::Q5_K || qt == GGMLQuantType::Q2_K ||
-           qt == GGMLQuantType::Q3_K;
+inline bool is_dp4a_qtype(QType qt) {
+    return qt == QType::Q6_K || qt == QType::Q8_0 ||
+           qt == QType::Q4_0 || qt == QType::Q4_K ||
+           qt == QType::Q5_K || qt == QType::Q2_K ||
+           qt == QType::Q3_K;
 }
 
 // Dispatch dp4a GEMV by quant type: y = W @ q8_1 (FP16 output).
-void dispatch_dp4a_gemv(GGMLQuantType qtype,
+void dispatch_dp4a_gemv(QType qtype,
                         const void* W, const block_q8_1* q8_1, const float* d8,
                         half* y, int M, int K, cudaStream_t stream);
 
@@ -336,7 +336,7 @@ Tensor slice_rows(const Tensor& buf, int n_tokens);
 // inside executor_kernels.cu.
 struct GemmContext;  // forward decl — defined in gemm_context.h
 void gemm_dispatch(const Tensor& input, const Tensor& weight,
-                   GGMLQuantType qtype, Tensor& output,
+                   QType qtype, Tensor& output,
                    const GemmContext& ctx);
 
 } // namespace imp

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -331,12 +331,11 @@ void rmsnorm_add_residual(const Tensor& input, const Tensor& weight,
 
 Tensor slice_rows(const Tensor& buf, int n_tokens);
 
-// GemmContext-based dispatch. The only public gemm_dispatch signature —
-// the legacy 23-parameter overload has been folded into a file-private helper
-// inside executor_kernels.cu.
+// GemmContext-based dispatch. The qtype parameter was dropped — the weight
+// tensor's own .qtype field carries the type. Callers no longer need to
+// pass a separate *_qtype mirror.
 struct GemmContext;  // forward decl — defined in gemm_context.h
 void gemm_dispatch(const Tensor& input, const Tensor& weight,
-                   QType qtype, Tensor& output,
-                   const GemmContext& ctx);
+                   Tensor& output, const GemmContext& ctx);
 
 } // namespace imp

--- a/src/graph/executor_kv_write.cu
+++ b/src/graph/executor_kv_write.cu
@@ -46,11 +46,11 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
 
     int threads = std::min(row_elems, 256);
 
-    bool use_fp8 = (cache->dtype() == DType::FP8_E4M3);
-    bool use_int8 = (cache->dtype() == DType::INT8);
-    bool use_int4 = (cache->dtype() == DType::INT4);
-    bool use_turboquant = (cache->dtype() == DType::TURBOQUANT);
-    bool use_turboquant_lite = (cache->dtype() == DType::TURBOQUANT_LITE);
+    bool use_fp8 = (cache->qtype() == QType::FP8_E4M3);
+    bool use_int8 = (cache->qtype() == QType::INT8);
+    bool use_int4 = (cache->qtype() == QType::INT4);
+    bool use_turboquant = (cache->qtype() == QType::TURBOQUANT);
+    bool use_turboquant_lite = (cache->qtype() == QType::TURBOQUANT_LITE);
 
     if (use_turboquant_lite) {
         // TurboQuant Lite: QJL sketch-only K + INT4 V

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -207,65 +207,77 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         }
     }
 
-    // --- Phase 0: Register NVFP4 pre-quantized weights directly (no quantization needed) ---
+    // --- Phase 0: Promote NVFP4 pre-quantized weights to Tensor sidecars ---
+    //
+    // Reads the (now-deprecated) NvFP4PreQuantWeight slots populated by the
+    // SafeTensors loader and writes the corresponding metadata directly onto
+    // the main weight tensor:
+    //   weight.qtype        = QType::NVFP4
+    //   weight.scales       = nw.weight_scale.data   (FP8 E4M3 micro-scales)
+    //   weight.tensor_scale = scalar from weight_scale_2 (with the
+    //                         llm-compressor reciprocal trick pre-applied
+    //                         so the runtime can always multiply)
+    //
+    // After this loop runs, gemm_dispatch / gemv_nvfp4_kpar can read the
+    // metadata straight from the weight tensor — no map lookup, no per-call
+    // reconstruction. The legacy wcache_.nvfp4 map is gone.
     if (cfg.is_nvfp4_prequant) {
         int prequant_count = 0;
-        auto register_prequant = [&](const TransformerLayer::NvFP4PreQuantWeight& nw,
-                                      const Tensor& weight) {
-            if (!nw.valid() || !weight.data) return;
-            NvFP4QuantResult result;
-            result.packed_data = weight.data;       // FP4 packed [N, K/2]
-            result.micro_scales = nw.weight_scale.data;  // FP8 E4M3 [N, K/group_size]
-            result.N = weight.shape[0];
-            // K is packed: shape[1] stores K/2 for FP4
-            result.K = weight.shape[1] * 2;
-            // tensor_scale from weight_scale_2 (scalar FP32, may be on host or device).
-            // Modelopt: val = fp4 * micro_scale * tensor_scale  (multiply)
-            // llm-compressor: val = fp4 * micro_scale / tensor_scale (divide → store 1/x)
+        auto promote = [&](const TransformerLayer::NvFP4PreQuantWeight& nw,
+                            Tensor& w) {
+            if (!nw.valid() || !w.data) return;
+            if (!w.on_device || !nw.weight_scale.on_device) {
+                IMP_LOG_DEBUG("NVFP4 prequant: skipping %p (data_dev=%d, scale_dev=%d)",
+                              w.data, w.on_device, nw.weight_scale.on_device);
+                return;
+            }
+            float h_scale = 1.0f;
             if (nw.weight_scale_2.data) {
-                float h_scale = 1.0f;
                 if (nw.weight_scale_2.on_device) {
                     cudaMemcpy(&h_scale, nw.weight_scale_2.data, sizeof(float), cudaMemcpyDeviceToHost);
                 } else {
                     memcpy(&h_scale, nw.weight_scale_2.data, sizeof(float));
                 }
-                result.tensor_scale = cfg.is_llm_compressor_nvfp4 ? (1.0f / h_scale) : h_scale;
             }
-            // Only register if both data and scales are on device
-            if (weight.on_device && nw.weight_scale.on_device) {
-                wcache_.nvfp4[weight.data] = result;
-                prequant_count++;
-            } else {
-                IMP_LOG_DEBUG("NVFP4 prequant: skipping %p (data_dev=%d, scale_dev=%d)",
-                              weight.data, weight.on_device, nw.weight_scale.on_device);
-            }
+            // Modelopt:        val = fp4 * micro_scale * tensor_scale  (multiply)
+            // llm-compressor:  val = fp4 * micro_scale / tensor_scale  (divide → store 1/x)
+            w.qtype        = QType::NVFP4;
+            w.scales       = nw.weight_scale.data;
+            w.tensor_scale = cfg.is_llm_compressor_nvfp4 ? (1.0f / h_scale) : h_scale;
+            prequant_count++;
         };
 
+        // model_ is held as const Model* in the executor; the prequant
+        // promote step is the one place we deliberately mutate it after
+        // load (writing qtype/scales/tensor_scale onto already-uploaded
+        // weight tensors). const_cast is local and bounded to this loop.
+        Model* mut_model = const_cast<Model*>(model_);
         for (int i = 0; i < cfg.n_layers; i++) {
-            const auto& L = model_->layer(i);
+            auto& L = mut_model->layers_[i];
             // Dense weights
-            register_prequant(L.nvfp4_q, L.wq);
-            register_prequant(L.nvfp4_k, L.wk);
-            register_prequant(L.nvfp4_v, L.wv);
-            register_prequant(L.nvfp4_o, L.wo);
+            promote(L.nvfp4_q, L.wq);
+            promote(L.nvfp4_k, L.wk);
+            promote(L.nvfp4_v, L.wv);
+            promote(L.nvfp4_o, L.wo);
             // For Gemma-4, mlp.{gate,up,down}_proj weights are stored in w_{gate,up,down}_shared
             // (not w_{gate,up,down}) because weight_map.cpp routes them there. Fall back to
-            // shared weights when the primary dense-layer pointers are null.
-            register_prequant(L.nvfp4_gate, L.w_gate.data ? L.w_gate : L.w_gate_shared);
-            register_prequant(L.nvfp4_up,   L.w_up.data   ? L.w_up   : L.w_up_shared);
-            register_prequant(L.nvfp4_down, L.w_down.data ? L.w_down : L.w_down_shared);
-            // Expert weights
+            // shared when primary is null.
+            promote(L.nvfp4_gate, L.w_gate.data ? L.w_gate : L.w_gate_shared);
+            promote(L.nvfp4_up,   L.w_up.data   ? L.w_up   : L.w_up_shared);
+            promote(L.nvfp4_down, L.w_down.data ? L.w_down : L.w_down_shared);
+            // Per-expert weights
             for (size_t e = 0; e < L.expert_nvfp4_gate.size(); e++) {
-                if (e < L.expert_w_gate.size()) register_prequant(L.expert_nvfp4_gate[e], L.expert_w_gate[e]);
-                if (e < L.expert_w_up.size())   register_prequant(L.expert_nvfp4_up[e],   L.expert_w_up[e]);
-                if (e < L.expert_w_down.size()) register_prequant(L.expert_nvfp4_down[e], L.expert_w_down[e]);
+                if (e < L.expert_w_gate.size()) promote(L.expert_nvfp4_gate[e], L.expert_w_gate[e]);
+                if (e < L.expert_w_up.size())   promote(L.expert_nvfp4_up[e],   L.expert_w_up[e]);
+                if (e < L.expert_w_down.size()) promote(L.expert_nvfp4_down[e], L.expert_w_down[e]);
             }
         }
         // LM head (output projection)
-        register_prequant(model_->nvfp4_out_proj(), model_->output_proj());
+        promote(mut_model->nvfp4_out_proj_, mut_model->out_proj_);
 
         if (prequant_count > 0) {
-            IMP_LOG_INFO("NVFP4 pre-quantized: registered %d weights directly (no quantization)", prequant_count);
+            IMP_LOG_INFO("NVFP4 pre-quantized: promoted %d weights to Tensor sidecars",
+                         prequant_count);
         }
     }
 

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -147,21 +147,21 @@ template <typename Fn>
 static void for_each_dense_weight(const Model& model, const ModelConfig& cfg, Fn&& fn) {
     for (int i = 0; i < cfg.n_layers; i++) {
         const auto& L = model.layer(i);
-        fn(L.wq, L.wq_qtype);
-        fn(L.wk, L.wk_qtype);
-        fn(L.wv, L.wv_qtype);
-        fn(L.wo, L.wo_qtype);
+        fn(L.wq, L.wq.qtype);
+        fn(L.wk, L.wk.qtype);
+        fn(L.wv, L.wv.qtype);
+        fn(L.wo, L.wo.qtype);
     }
     for (int i = 0; i < cfg.n_layers; i++) {
         const auto& L = model.layer(i);
-        fn(L.ssm_in, L.ssm_in_qtype);
-        fn(L.ssm_out, L.ssm_out_qtype);
-        fn(L.w_gate_shared, L.w_gate_shared_qtype);
-        fn(L.w_up_shared, L.w_up_shared_qtype);
-        fn(L.w_down_shared, L.w_down_shared_qtype);
-        fn(L.w_gate, L.w_gate_qtype);
-        fn(L.w_up, L.w_up_qtype);
-        fn(L.w_down, L.w_down_qtype);
+        fn(L.ssm_in, L.ssm_in.qtype);
+        fn(L.ssm_out, L.ssm_out.qtype);
+        fn(L.w_gate_shared, L.w_gate_shared.qtype);
+        fn(L.w_up_shared, L.w_up_shared.qtype);
+        fn(L.w_down_shared, L.w_down_shared.qtype);
+        fn(L.w_gate, L.w_gate.qtype);
+        fn(L.w_up, L.w_up.qtype);
+        fn(L.w_down, L.w_down.qtype);
     }
 }
 
@@ -346,28 +346,28 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         // before SSM weights exhaust the VRAM budget.
         for (int i = 0; i < cfg.n_layers; i++) {
             const auto& L = model_->layer(i);
-            cache_weight(L.wq, L.wq_qtype);
-            cache_weight(L.wk, L.wk_qtype);
-            cache_weight(L.wv, L.wv_qtype);
-            cache_weight(L.wo, L.wo_qtype);
+            cache_weight(L.wq, L.wq.qtype);
+            cache_weight(L.wk, L.wk.qtype);
+            cache_weight(L.wv, L.wv.qtype);
+            cache_weight(L.wo, L.wo.qtype);
         }
         for (int i = 0; i < cfg.n_layers; i++) {
             const auto& L = model_->layer(i);
-            cache_weight(L.ssm_in, L.ssm_in_qtype);
-            cache_weight(L.ssm_out, L.ssm_out_qtype);
-            cache_weight(L.w_gate_shared, L.w_gate_shared_qtype);
-            cache_weight(L.w_up_shared, L.w_up_shared_qtype);
-            cache_weight(L.w_down_shared, L.w_down_shared_qtype);
+            cache_weight(L.ssm_in, L.ssm_in.qtype);
+            cache_weight(L.ssm_out, L.ssm_out.qtype);
+            cache_weight(L.w_gate_shared, L.w_gate_shared.qtype);
+            cache_weight(L.w_up_shared, L.w_up_shared.qtype);
+            cache_weight(L.w_down_shared, L.w_down_shared.qtype);
             // When NVFP4 decode is active, skip dense FFN FP16 cache for eligible
             // weights.  Decode benefits more from NVFP4 (~47% BW reduction) than
             // prefill loses from on-the-fly dequant.  NVFP4 is also ~3.5x smaller
             // per tensor, so skipping FFN FP16 frees massive VRAM for full NVFP4.
-            if (wcache_.nvfp4_decode_mode == 0 || !nvfp4_beneficial(L.w_gate_qtype))
-                cache_weight(L.w_gate, L.w_gate_qtype);
-            if (wcache_.nvfp4_decode_mode == 0 || !nvfp4_beneficial(L.w_up_qtype))
-                cache_weight(L.w_up, L.w_up_qtype);
-            if (wcache_.nvfp4_decode_mode == 0 || !nvfp4_beneficial(L.w_down_qtype))
-                cache_weight(L.w_down, L.w_down_qtype);
+            if (wcache_.nvfp4_decode_mode == 0 || !nvfp4_beneficial(L.w_gate.qtype))
+                cache_weight(L.w_gate, L.w_gate.qtype);
+            if (wcache_.nvfp4_decode_mode == 0 || !nvfp4_beneficial(L.w_up.qtype))
+                cache_weight(L.w_up, L.w_up.qtype);
+            if (wcache_.nvfp4_decode_mode == 0 || !nvfp4_beneficial(L.w_down.qtype))
+                cache_weight(L.w_down, L.w_down.qtype);
         }
 
         // Create fused KV weights for strided batched prefill GEMM.
@@ -619,7 +619,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         };
 
         // LM head first: largest single weight (vocab × d_model), biggest bandwidth win.
-        collect_weight_nvfp4(model_->output_proj(), model_->out_proj_qtype_);
+        collect_weight_nvfp4(model_->output_proj(), model_->out_proj_.qtype);
 
         // Dense attention + FFN: every tensor benefits every decode step.
         for_each_dense_weight(*model_, cfg, collect_weight_nvfp4);
@@ -1076,11 +1076,11 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 };
                 for (int i = 0; i < cfg.n_layers && !has_mxfp4; i++) {
                     const auto& L = model_->layer(i);
-                    check_mxfp4(L.wq, L.wq_qtype);
-                    check_mxfp4(L.wk, L.wk_qtype);
-                    check_mxfp4(L.w_gate, L.w_gate_qtype);
-                    check_mxfp4(L.ssm_in, L.ssm_in_qtype);
-                    check_mxfp4(L.ssm_out, L.ssm_out_qtype);
+                    check_mxfp4(L.wq, L.wq.qtype);
+                    check_mxfp4(L.wk, L.wk.qtype);
+                    check_mxfp4(L.w_gate, L.w_gate.qtype);
+                    check_mxfp4(L.ssm_in, L.ssm_in.qtype);
+                    check_mxfp4(L.ssm_out, L.ssm_out.qtype);
                 }
 
                 // Allocate MXFP4 scratch if needed and not already allocated
@@ -1173,21 +1173,21 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             };
             for (int i = 0; i < cfg.n_layers; i++) {
                 const auto& L = model_->layer(i);
-                register_if_mxfp4(L.wq, L.wq_qtype, true);
-                register_if_mxfp4(L.wk, L.wk_qtype, true);
-                register_if_mxfp4(L.wv, L.wv_qtype, true);
-                register_if_mxfp4(L.wo, L.wo_qtype, true);
-                register_if_mxfp4(L.w_up, L.w_up_qtype, false);
-                register_if_mxfp4(L.w_gate, L.w_gate_qtype, false);
-                register_if_mxfp4(L.w_down, L.w_down_qtype, false);
+                register_if_mxfp4(L.wq, L.wq.qtype, true);
+                register_if_mxfp4(L.wk, L.wk.qtype, true);
+                register_if_mxfp4(L.wv, L.wv.qtype, true);
+                register_if_mxfp4(L.wo, L.wo.qtype, true);
+                register_if_mxfp4(L.w_up, L.w_up.qtype, false);
+                register_if_mxfp4(L.w_gate, L.w_gate.qtype, false);
+                register_if_mxfp4(L.w_down, L.w_down.qtype, false);
                 // GDN-specific weights (Qwen3.5)
-                register_if_mxfp4(L.ssm_in, L.ssm_in_qtype, true);
-                register_if_mxfp4(L.ssm_out, L.ssm_out_qtype, true);
-                register_if_mxfp4(L.gdn_gate, L.gdn_gate_qtype, true);
-                register_if_mxfp4(L.gdn_alpha, L.gdn_alpha_qtype, true);
-                register_if_mxfp4(L.gdn_beta, L.gdn_beta_qtype, true);
+                register_if_mxfp4(L.ssm_in, L.ssm_in.qtype, true);
+                register_if_mxfp4(L.ssm_out, L.ssm_out.qtype, true);
+                register_if_mxfp4(L.gdn_gate, L.gdn_gate.qtype, true);
+                register_if_mxfp4(L.gdn_alpha, L.gdn_alpha.qtype, true);
+                register_if_mxfp4(L.gdn_beta, L.gdn_beta.qtype, true);
             }
-            register_if_mxfp4(model_->output_proj(), model_->out_proj_qtype_);
+            register_if_mxfp4(model_->output_proj(), model_->out_proj_.qtype);
             if (mx_native > 0) {
                 IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
                 wcache_.cutlass_mxfp4_bytes += mx_native_bytes;
@@ -1323,22 +1323,22 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     };
                     for (int i = 0; i < cfg.n_layers; i++) {
                         TransformerLayer& L = const_cast<Model*>(model_)->layer(i);
-                        replace_weight(L.wq, L.wq_qtype);
-                        replace_weight(L.wk, L.wk_qtype);
-                        replace_weight(L.wv, L.wv_qtype);
-                        replace_weight(L.wo, L.wo_qtype);
-                        replace_weight(L.w_up, L.w_up_qtype);
-                        replace_weight(L.w_gate, L.w_gate_qtype);
-                        replace_weight(L.w_down, L.w_down_qtype);
+                        replace_weight(L.wq, L.wq.qtype);
+                        replace_weight(L.wk, L.wk.qtype);
+                        replace_weight(L.wv, L.wv.qtype);
+                        replace_weight(L.wo, L.wo.qtype);
+                        replace_weight(L.w_up, L.w_up.qtype);
+                        replace_weight(L.w_gate, L.w_gate.qtype);
+                        replace_weight(L.w_down, L.w_down.qtype);
                         // GDN-specific weights (Qwen3.5)
-                        replace_weight(L.ssm_in, L.ssm_in_qtype);
-                        replace_weight(L.ssm_out, L.ssm_out_qtype);
-                        replace_weight(L.gdn_gate, L.gdn_gate_qtype);
-                        replace_weight(L.gdn_alpha, L.gdn_alpha_qtype);
-                        replace_weight(L.gdn_beta, L.gdn_beta_qtype);
+                        replace_weight(L.ssm_in, L.ssm_in.qtype);
+                        replace_weight(L.ssm_out, L.ssm_out.qtype);
+                        replace_weight(L.gdn_gate, L.gdn_gate.qtype);
+                        replace_weight(L.gdn_alpha, L.gdn_alpha.qtype);
+                        replace_weight(L.gdn_beta, L.gdn_beta.qtype);
                     }
                     replace_weight(const_cast<Model*>(model_)->out_proj_,
-                                   const_cast<Model*>(model_)->out_proj_qtype_);
+                                   const_cast<Model*>(model_)->out_proj_.qtype);
                     IMP_LOG_INFO("MXFP4 → FP16: replaced %d weight tensor pointers", (int)wcache_.fp16.size());
                 }
             }
@@ -1398,9 +1398,9 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 
         for (int i = 0; i < cfg.n_layers; i++) {
             const auto& L = model_->layer(i);
-            cache_moe_expert_nvfp4(L.expert_gate_packed, L.expert_gate_qtype);
-            cache_moe_expert_nvfp4(L.expert_up_packed,   L.expert_up_qtype);
-            cache_moe_expert_nvfp4(L.expert_down_packed,  L.expert_down_qtype);
+            cache_moe_expert_nvfp4(L.expert_gate_packed, L.expert_gate_packed.qtype);
+            cache_moe_expert_nvfp4(L.expert_up_packed,   L.expert_up_packed.qtype);
+            cache_moe_expert_nvfp4(L.expert_down_packed,  L.expert_down_packed.qtype);
         }
 
         if (nvfp4_moe_count > 0) {
@@ -1420,8 +1420,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         bool has_mxfp4 = false;
         for (int i = 0; i < cfg.n_layers && !has_mxfp4; i++) {
             const auto& L = model_->layer(i);
-            if (L.wq_qtype == QType::MXFP4 || L.w_gate_qtype == QType::MXFP4 ||
-                L.ssm_in_qtype == QType::MXFP4 || L.ssm_out_qtype == QType::MXFP4)
+            if (L.wq.qtype == QType::MXFP4 || L.w_gate.qtype == QType::MXFP4 ||
+                L.ssm_in.qtype == QType::MXFP4 || L.ssm_out.qtype == QType::MXFP4)
                 has_mxfp4 = true;
         }
         if (has_mxfp4) {
@@ -1459,8 +1459,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                         small_weights.push_back({w.data, w.shape[0], w.shape[1]});
                         fp16_total += static_cast<size_t>(w.shape[0]) * w.shape[1] * sizeof(half);
                     };
-                    collect(L.gdn_alpha, L.gdn_alpha_qtype);
-                    collect(L.gdn_beta, L.gdn_beta_qtype);
+                    collect(L.gdn_alpha, L.gdn_alpha.qtype);
+                    collect(L.gdn_beta, L.gdn_beta.qtype);
                 }
                 if (fp16_total > 0) {
                     void* d_fp16_bulk = nullptr;
@@ -1486,8 +1486,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                                     w = it->second; qt = QType::F16;
                                 }
                             };
-                            replace(L.gdn_alpha, L.gdn_alpha_qtype);
-                            replace(L.gdn_beta, L.gdn_beta_qtype);
+                            replace(L.gdn_alpha, L.gdn_alpha.qtype);
+                            replace(L.gdn_beta, L.gdn_beta.qtype);
                         }
                     }
                 }
@@ -1508,20 +1508,20 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             };
             for (int i = 0; i < cfg.n_layers; i++) {
                 const auto& L = model_->layer(i);
-                register_mx(L.wq, L.wq_qtype, true);
-                register_mx(L.wk, L.wk_qtype, true);
-                register_mx(L.wv, L.wv_qtype, true);
-                register_mx(L.wo, L.wo_qtype, true);
-                register_mx(L.w_up, L.w_up_qtype, false);
-                register_mx(L.w_gate, L.w_gate_qtype, false);
-                register_mx(L.w_down, L.w_down_qtype, false);
-                register_mx(L.ssm_in, L.ssm_in_qtype, true);
-                register_mx(L.ssm_out, L.ssm_out_qtype, true);
-                register_mx(L.gdn_gate, L.gdn_gate_qtype, true);
-                register_mx(L.gdn_alpha, L.gdn_alpha_qtype, true);
-                register_mx(L.gdn_beta, L.gdn_beta_qtype, true);
+                register_mx(L.wq, L.wq.qtype, true);
+                register_mx(L.wk, L.wk.qtype, true);
+                register_mx(L.wv, L.wv.qtype, true);
+                register_mx(L.wo, L.wo.qtype, true);
+                register_mx(L.w_up, L.w_up.qtype, false);
+                register_mx(L.w_gate, L.w_gate.qtype, false);
+                register_mx(L.w_down, L.w_down.qtype, false);
+                register_mx(L.ssm_in, L.ssm_in.qtype, true);
+                register_mx(L.ssm_out, L.ssm_out.qtype, true);
+                register_mx(L.gdn_gate, L.gdn_gate.qtype, true);
+                register_mx(L.gdn_alpha, L.gdn_alpha.qtype, true);
+                register_mx(L.gdn_beta, L.gdn_beta.qtype, true);
             }
-            register_mx(model_->output_proj(), model_->out_proj_qtype_, true);
+            register_mx(model_->output_proj(), model_->out_proj_.qtype, true);
             if (mx_count > 0) {
                 IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
                 wcache_.use_mxfp4 = true;

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -9,6 +9,7 @@
 #include "core/logging.h"
 #include "memory/vram_allocator.h"
 #include "runtime/storage_planner.h"
+#include "runtime/config.h"
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -1196,7 +1197,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 // 14) cascade we have not yet root-caused. Tracking in
                 // qwen35_27b_mxfp4_ima_2026_04_25.md. Until that's resolved,
                 // honor the historical fallback path.
-                bool force_fallback = (std::getenv("IMP_MXFP4_FP16_FALLBACK") != nullptr);
+                bool force_fallback = RuntimeConfig::current().attention.mxfp4_fp16_fallback;
                 bool has_gdn = (cfg.ssm_inner_size > 0);
                 bool mxfp4_gemv_available = !force_fallback && !has_gdn;
                 for (auto& [p, m] : wcache_.cutlass_mxfp4)
@@ -1232,8 +1233,13 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                         static_cast<size_t>(2) * 1024 * 1024 * 1024;
                     bool oversubscribe = (free_mem <= kRuntimeHeadroom ||
                                            fp16_total + kRuntimeHeadroom > free_mem);
-                    const char* force = std::getenv("IMP_MXFP4_FP16_FALLBACK");
-                    bool allow_force = (force && std::string(force) == "force");
+                    // The "force anyway despite oversubscription" path is gone —
+                    // attention.mxfp4_fp16_fallback is a plain bool now. If the
+                    // user explicitly opts in via imp.conf the oversubscribe
+                    // check still gates them; this matches the previous
+                    // IMP_MXFP4_FP16_FALLBACK=1 semantics. The legacy
+                    // =force escape hatch is obsolete.
+                    bool allow_force = false;
                     if (oversubscribe && !allow_force) {
                         IMP_LOG_ERROR(
                             "MXFP4 FP16 fallback would oversubscribe VRAM "

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -137,7 +137,7 @@ static bool create_fused_weight_pair(
                      cudaMemcpyDeviceToDevice, stream));
 
     int64_t shape[2] = {2 * a_rows, static_cast<int64_t>(K)};
-    out_map[layer_idx] = Tensor(fused_buf, DType::FP16, 2, shape, true);
+    out_map[layer_idx] = Tensor(fused_buf, QType::F16, 2, shape, true);
     total_cache_bytes += 2 * one_sz;
     return true;
 }
@@ -269,10 +269,10 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     }
 
     // Helper: does this qtype benefit from NVFP4 conversion? (> 4.5 bits/elem)
-    auto nvfp4_beneficial = [](GGMLQuantType qt) -> bool {
+    auto nvfp4_beneficial = [](QType qt) -> bool {
         switch (qt) {
-            case GGMLQuantType::Q8_0: case GGMLQuantType::Q8_K:
-            case GGMLQuantType::Q6_K: case GGMLQuantType::Q5_K:
+            case QType::Q8_0: case QType::Q8_K:
+            case QType::Q6_K: case QType::Q5_K:
                 return true;
             default: return false;
         }
@@ -293,7 +293,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                      "VRAM reserved for NVFP4 decode cache");
     } else {
         // --- Phase 1: FP16 weight cache + fused KV + fused gate+up ---
-        auto cache_weight = [&](const Tensor& w, GGMLQuantType qtype) {
+        auto cache_weight = [&](const Tensor& w, QType qtype) {
             if (!w.data || !dequant_gpu_supported(qtype)) return;
             if (wcache_.fp16.count(w.data)) return;  // already cached
             if (budget_exhausted) return;
@@ -321,7 +321,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 
             dequant_gpu(w.data, fp16_buf, qtype, rows, cols, stream);
 
-            Tensor fp16_tensor(fp16_buf, DType::FP16, w.ndim, w.shape, true);
+            Tensor fp16_tensor(fp16_buf, QType::F16, w.ndim, w.shape, true);
             wcache_.fp16[w.data] = fp16_tensor;
             total_cache_bytes += fp16_bytes;
             cached_count++;
@@ -418,12 +418,12 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         struct FP8OverflowEntry {
             const void* orig_ptr;
             Tensor weight;
-            GGMLQuantType qtype;
+            QType qtype;
             size_t n_elems;
         };
         std::vector<FP8OverflowEntry> fp8_entries;
 
-        auto collect_weight_fp8 = [&](const Tensor& w, GGMLQuantType qtype) {
+        auto collect_weight_fp8 = [&](const Tensor& w, QType qtype) {
             if (!w.data || !dequant_gpu_supported(qtype)) return;
             if (wcache_.fp16.count(w.data)) return;
             if (wcache_.fp8.count(w.data)) return;
@@ -496,7 +496,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     d_block_maxes, max_grid,
                     d_absmax, d_scales_all + static_cast<ptrdiff_t>(i), stream);
 
-                Tensor fp8_t(fp8_buf, DType::FP8_E4M3, e.weight.ndim, e.weight.shape, true);
+                Tensor fp8_t(fp8_buf, QType::FP8_E4M3, e.weight.ndim, e.weight.shape, true);
                 wcache_.fp8[e.orig_ptr] = {fp8_t, 0.0f, d_scales_all + static_cast<ptrdiff_t>(i)};
                 actual_count++;
             }
@@ -585,12 +585,12 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         struct NvFP4Entry {
             const void* orig_ptr;
             Tensor weight;
-            GGMLQuantType qtype;
+            QType qtype;
             bool from_scratch;
         };
         std::vector<NvFP4Entry> nvfp4_entries;
 
-        auto collect_weight_nvfp4 = [&](const Tensor& w, GGMLQuantType qtype) {
+        auto collect_weight_nvfp4 = [&](const Tensor& w, QType qtype) {
             if (!w.data) return;
             if (!nvfp4_beneficial(qtype)) return;
             if (wcache_.nvfp4.count(w.data)) return;
@@ -667,7 +667,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     fp16_ptr = reinterpret_cast<const half*>(it->second.data);
                 }
 
-                Tensor fp16_view(const_cast<half*>(fp16_ptr), DType::FP16, 2,
+                Tensor fp16_view(const_cast<half*>(fp16_ptr), QType::F16, 2,
                                  e.weight.shape, true);
 
                 NvFP4QuantResult result;
@@ -766,7 +766,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     fp16_ptr = reinterpret_cast<const half*>(it->second.data);
                 }
 
-                Tensor fp16_view(const_cast<half*>(fp16_ptr), DType::FP16, 2,
+                Tensor fp16_view(const_cast<half*>(fp16_ptr), QType::F16, 2,
                                  e.weight.shape, true);
 
                 NvFP4QuantResult result;
@@ -862,7 +862,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                             d_block_maxes, max_grid,
                             d_absmax, d_scales_all + i, stream);
 
-                        Tensor fp8_t(fp8_buf, DType::FP8_E4M3, e.fp16_tensor.ndim,
+                        Tensor fp8_t(fp8_buf, QType::FP8_E4M3, e.fp16_tensor.ndim,
                                      e.fp16_tensor.shape, true);
                         wcache_.fp8[e.orig_ptr] = {fp8_t, 0.0f, d_scales_all + static_cast<ptrdiff_t>(i)};
                         migrated++;
@@ -973,7 +973,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 }
                 dequant_gpu(e.weight.data, dq_buf, e.qtype, rows, cols, stream);
 
-                Tensor fp16_view(reinterpret_cast<half*>(dq_buf), DType::FP16, 2,
+                Tensor fp16_view(reinterpret_cast<half*>(dq_buf), QType::F16, 2,
                                  e.weight.shape, true);
                 NvFP4QuantResult result;
                 quantize_fp16_to_nvfp4_async(fp16_view, result,
@@ -1058,8 +1058,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             if (cutlass_sm120_mxfp4_available()) {
                 // Check if any layer has MXFP4 weights
                 bool has_mxfp4 = false;
-                auto check_mxfp4 = [&](const Tensor&, GGMLQuantType qt) {
-                    if (qt == GGMLQuantType::MXFP4) has_mxfp4 = true;
+                auto check_mxfp4 = [&](const Tensor&, QType qt) {
+                    if (qt == QType::MXFP4) has_mxfp4 = true;
                 };
                 for (int i = 0; i < cfg.n_layers && !has_mxfp4; i++) {
                     const auto& L = model_->layer(i);
@@ -1146,8 +1146,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         if (qscratch_.mxfp4_act_sf != nullptr && cutlass_sm120_mxfp4_available()) {
             int mx_native = 0;
             size_t mx_native_bytes = 0;
-            auto register_if_mxfp4 = [&](const Tensor& w, GGMLQuantType qt, bool is_attn = true) {
-                if (qt != GGMLQuantType::MXFP4 || !w.data || !w.on_device) return;
+            auto register_if_mxfp4 = [&](const Tensor& w, QType qt, bool is_attn = true) {
+                if (qt != QType::MXFP4 || !w.data || !w.on_device) return;
                 if (w.ndim < 2 || w.shape[1] % 32 != 0) return;
                 if (wcache_.cutlass_mxfp4.count(w.data)) return;  // already registered
                 CutlassMxFP4Weight mw;
@@ -1282,7 +1282,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     // correctly (data first, scales at offset N*K/2).
                     dequant_mxfp4_to_fp16(ptr, mw.N, mw.K, d_fp16, stream);
                     int64_t shape[2] = {mw.N, mw.K};
-                    wcache_.fp16[ptr] = Tensor(d_fp16, DType::FP16, 2, shape, true);
+                    wcache_.fp16[ptr] = Tensor(d_fp16, QType::F16, 2, shape, true);
                     }
                 }  // end if (d_fp16_bulk)
 
@@ -1296,11 +1296,11 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     // Replace model weight tensor pointers with FP16 data.
                     // This ensures ALL code paths (GEMV, direct gemm, etc.) see
                     // valid FP16 data instead of raw MXFP4 blocks.
-                    auto replace_weight = [&](Tensor& w, GGMLQuantType& qt) {
+                    auto replace_weight = [&](Tensor& w, QType& qt) {
                         auto it = wcache_.fp16.find(w.data);
-                        if (it != wcache_.fp16.end() && qt == GGMLQuantType::MXFP4) {
+                        if (it != wcache_.fp16.end() && qt == QType::MXFP4) {
                             w = it->second;
-                            qt = GGMLQuantType::F16;
+                            qt = QType::F16;
                         }
                     };
                     for (int i = 0; i < cfg.n_layers; i++) {
@@ -1341,7 +1341,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         }
         bool moe_budget_exhausted = false;
 
-        auto cache_moe_expert_nvfp4 = [&](const Tensor& packed, GGMLQuantType qtype) {
+        auto cache_moe_expert_nvfp4 = [&](const Tensor& packed, QType qtype) {
             if (!packed.data) return;
             if (!nvfp4_beneficial(qtype)) return;
             if (wcache_.nvfp4_moe.count(packed.data)) return;
@@ -1402,8 +1402,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         bool has_mxfp4 = false;
         for (int i = 0; i < cfg.n_layers && !has_mxfp4; i++) {
             const auto& L = model_->layer(i);
-            if (L.wq_qtype == GGMLQuantType::MXFP4 || L.w_gate_qtype == GGMLQuantType::MXFP4 ||
-                L.ssm_in_qtype == GGMLQuantType::MXFP4 || L.ssm_out_qtype == GGMLQuantType::MXFP4)
+            if (L.wq_qtype == QType::MXFP4 || L.w_gate_qtype == QType::MXFP4 ||
+                L.ssm_in_qtype == QType::MXFP4 || L.ssm_out_qtype == QType::MXFP4)
                 has_mxfp4 = true;
         }
         if (has_mxfp4) {
@@ -1436,8 +1436,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 std::vector<SmallWeight> small_weights;
                 for (int i = 0; i < cfg.n_layers; i++) {
                     const auto& L = model_->layer(i);
-                    auto collect = [&](const Tensor& w, GGMLQuantType qt) {
-                        if (qt != GGMLQuantType::MXFP4 || !w.data) return;
+                    auto collect = [&](const Tensor& w, QType qt) {
+                        if (qt != QType::MXFP4 || !w.data) return;
                         small_weights.push_back({w.data, w.shape[0], w.shape[1]});
                         fp16_total += static_cast<size_t>(w.shape[0]) * w.shape[1] * sizeof(half);
                     };
@@ -1455,17 +1455,17 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                             offset += bytes;
                             dequant_mxfp4_to_fp16(sw.ptr, sw.N, sw.K, d_fp16, stream);
                             int64_t shape[2] = {sw.N, sw.K};
-                            wcache_.fp16[sw.ptr] = Tensor(d_fp16, DType::FP16, 2, shape, true);
+                            wcache_.fp16[sw.ptr] = Tensor(d_fp16, QType::F16, 2, shape, true);
                         }
                         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
                         IMP_LOG_INFO("MXFP4 → FP16 (alpha/beta): %.2f MiB (%d tensors)",
                                      fp16_total / (1024.0 * 1024.0), (int)small_weights.size());
                         for (int i = 0; i < cfg.n_layers; i++) {
                             TransformerLayer& L = const_cast<Model*>(model_)->layer(i);
-                            auto replace = [&](Tensor& w, GGMLQuantType& qt) {
+                            auto replace = [&](Tensor& w, QType& qt) {
                                 auto it = wcache_.fp16.find(w.data);
-                                if (it != wcache_.fp16.end() && qt == GGMLQuantType::MXFP4) {
-                                    w = it->second; qt = GGMLQuantType::F16;
+                                if (it != wcache_.fp16.end() && qt == QType::MXFP4) {
+                                    w = it->second; qt = QType::F16;
                                 }
                             };
                             replace(L.gdn_alpha, L.gdn_alpha_qtype);
@@ -1477,8 +1477,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 
             // THEN: register + unpack MXFP4 weights (in-place compaction)
             int mx_count = 0;
-            auto register_mx = [&](const Tensor& w, GGMLQuantType qt, bool is_attn) {
-                if (qt != GGMLQuantType::MXFP4 || !w.data || !w.on_device) return;
+            auto register_mx = [&](const Tensor& w, QType qt, bool is_attn) {
+                if (qt != QType::MXFP4 || !w.data || !w.on_device) return;
                 if (w.ndim < 2 || w.shape[1] % 32 != 0) return;
                 if (wcache_.cutlass_mxfp4.count(w.data)) return;
                 CutlassMxFP4Weight mw;

--- a/src/graph/executor_ssm_gdn.cu
+++ b/src/graph/executor_ssm_gdn.cu
@@ -167,7 +167,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state,
         // For n=1 decode this is just pointer arithmetic (no copy needed).
         // For n>1 prefill, we must de-interleave.
 
-        DType h_dtype = (state.ssm_state) ? state.ssm_state->h_dtype() : DType::FP32;
+        QType h_dtype = (state.ssm_state) ? state.ssm_state->h_dtype() : QType::F32;
 
         if (n == 1) {
             // Decode: single token, just pass pointers directly into xBC_out row
@@ -352,7 +352,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     // Compare to llama's `conv_output_silu-{layer}` tensor.
     {
         int64_t cf_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(conv_channels)};
-        Tensor conv_f32_t(conv_f32, DType::FP32, 2, cf_shape, true);
+        Tensor conv_f32_t(conv_f32, QType::F32, 2, cf_shape, true);
         dump_tensor_npy("gdn_conv_f32", conv_f32_t, stream, layer, cur_decode_step_);
     }
 
@@ -532,7 +532,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
         void* fp32_out = nullptr;
         IMP_CUDA_CHECK_LOG(cudaMallocAsync(&fp32_out, fp32_bytes, stream));
         int64_t out_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(cfg.d_model)};
-        Tensor fp32_out_t(fp32_out, DType::FP32, 2, out_shape, true);
+        Tensor fp32_out_t(fp32_out, QType::F32, 2, out_shape, true);
 
         // NOTE: when FP32_SCAN is also active, the post-norm-gated tensor lives
         // in FP32 memory, but we can't pass it directly to gemm_dispatch because

--- a/src/graph/executor_ssm_gdn.cu
+++ b/src/graph/executor_ssm_gdn.cu
@@ -72,7 +72,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state,
     // 2. ssm_in projection: [n, d_model] @ ssm_in^T -> [n, ssm_in_dim]
     //    ssm_in_dim = inner(z) + conv_channels(xBC) + n_heads(dt)
     Tensor proj = view_tokens(ssm_proj_buf_, n);
-    gemm_dispatch(no, ly.ssm_in, ly.ssm_in_qtype, proj, ctx);
+    gemm_dispatch(no, ly.ssm_in, proj, ctx);
 
     // 3. Split projection output [n, total_dim] into z, xBC, dt by column slices.
     //    proj layout: each row has [z(inner) | xBC(conv_channels) | dt(n_heads)].
@@ -252,7 +252,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state,
 
     // 10. ssm_out projection: [n, inner] @ ssm_out^T -> [n, d_model]
     Tensor out_buf = view_tokens(ssm_out_buf_, n);
-    gemm_dispatch(y_buf, ly.ssm_out, ly.ssm_out_qtype, out_buf, ctx);
+    gemm_dispatch(y_buf, ly.ssm_out, out_buf, ctx);
 
     // 11. Residual add: hidden = output + residual
     elementwise_add(out_buf, r, stream);
@@ -300,7 +300,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     //    ssm_proj_buf_ is [max_tokens, ssm_in_dim] but we only need [n, conv_channels].
     int64_t proj_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(conv_channels)};
     Tensor proj(ssm_proj_buf_.data, compute_dtype_, 2, proj_shape, true);
-    gemm_dispatch(no, ly.ssm_in, ly.ssm_in_qtype, proj, ctx);
+    gemm_dispatch(no, ly.ssm_in, proj, ctx);
     dump_tensor_npy("gdn_ssm_in_out", proj, stream, layer, cur_decode_step_);
 
     // 3. Conv1d on full projection output [n, conv_channels]
@@ -399,7 +399,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     // Gate projection — computed before scan, used after in RMSNormGated
     int64_t gate_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(inner)};
     Tensor gate_out(ssm_z_buf_.data, compute_dtype_, 2, gate_shape, true);
-    gemm_dispatch(no, ly.gdn_gate, ly.gdn_gate_qtype, gate_out, ctx);
+    gemm_dispatch(no, ly.gdn_gate, gate_out, ctx);
 
     static const bool use_fp32_scan = std::getenv("IMP_GDN_FP32_SCAN") != nullptr;
 
@@ -418,8 +418,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
             beta_proj_out = Tensor(beta_ptr, compute_dtype_, 2, ab_shape, true);
 
             // Alpha/beta: through gemm_dispatch for consistent MXFP4/FP16/quantized handling.
-            gemm_dispatch(no, ly.gdn_alpha, ly.gdn_alpha_qtype, alpha_proj_out, ctx);
-            gemm_dispatch(no, ly.gdn_beta, ly.gdn_beta_qtype, beta_proj_out, ctx);
+            gemm_dispatch(no, ly.gdn_alpha, alpha_proj_out, ctx);
+            gemm_dispatch(no, ly.gdn_beta, beta_proj_out, ctx);
             // Per-element dump: pre-softplus alpha and pre-sigmoid beta projections.
             // Compare to llama's `alpha-{layer}` and `beta-{layer}`.
             dump_tensor_npy("gdn_alpha", alpha_proj_out, stream, layer, cur_decode_step_);
@@ -539,7 +539,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
         // cuBLAS FP32-input × FP16-cached-weight path silently produces zeros on
         // sm_120 with CUBLAS_COMPUTE_32F (tested 2026-04-21). Stay on FP16 y_buf
         // input; precision benefit from FP32 scan is limited to the rmsnorm stage.
-        gemm_dispatch(y_buf, ly.ssm_out, ly.ssm_out_qtype, fp32_out_t, ctx);
+        gemm_dispatch(y_buf, ly.ssm_out, fp32_out_t, ctx);
 
         // FP16 residual → FP32 + add + FP16 writeback to h in one kernel.
         int64_t total = static_cast<int64_t>(n) * cfg.d_model;
@@ -551,7 +551,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
             static_cast<__half*>(h.data), total);
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(fp32_out, stream));
     } else {
-        gemm_dispatch(y_buf, ly.ssm_out, ly.ssm_out_qtype, out_buf, ctx);
+        gemm_dispatch(y_buf, ly.ssm_out, out_buf, ctx);
         // Per-element dump: linear_attn_out post-ssm_out GEMM, pre-residual.
         // Compare to llama's `linear_attn_out-{layer}` from eval-callback.
         dump_tensor_npy("gdn_linear_attn_out", out_buf, stream, layer, cur_decode_step_);

--- a/src/graph/executor_ssm_gdn.cu
+++ b/src/graph/executor_ssm_gdn.cu
@@ -9,6 +9,7 @@
 #include "memory/gdn_state.h"
 #include "core/logging.h"
 #include "runtime/pdl.h"
+#include "runtime/config.h"
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -362,7 +363,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     // layout. Qwen 3.6 uses 16K/32V asymmetric heads and triggers this
     // mismatch. Gated by IMP_GDN_VHEAD_REORDER to avoid regressing symmetric
     // models or models whose converters already emit grouped layout.
-    static const bool vhead_reorder = std::getenv("IMP_GDN_VHEAD_REORDER") != nullptr;
+    const bool vhead_reorder = RuntimeConfig::current().gdn.vhead_reorder;
     if (vhead_reorder && n_groups != n_heads) {
         const int inner_v = n_heads * head_dim_ssm;  // V channels = 32 * 128 = 4096 for Qwen 3.6
         const int BC_size_vh = n_groups * ssize;      // Q/K per-group size = 16 * 128 = 2048
@@ -401,7 +402,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     Tensor gate_out(ssm_z_buf_.data, compute_dtype_, 2, gate_shape, true);
     gemm_dispatch(no, ly.gdn_gate, gate_out, ctx);
 
-    static const bool use_fp32_scan = std::getenv("IMP_GDN_FP32_SCAN") != nullptr;
+    const bool use_fp32_scan = RuntimeConfig::current().gdn.fp32_scan;
 
     if (h_st) {
         size_t es = dtype_size(compute_dtype_);
@@ -435,7 +436,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
         // IMP_GDN_FP32_SCAN=1: keep scan output in FP32 through RMSNorm+Gate.
         //   FP16 subnormal truncation (~6e-5) breaks RMS for near-zero heads on
         //   models with sparse scan activations (Qwen 3.6 L1 head 0).
-        static const bool use_ref = std::getenv("IMP_GDN_REF") != nullptr;
+        const bool use_ref = RuntimeConfig::current().gdn.ref_kernel;
         if (use_fp32_scan) {
             // Layout in conv_f32 tail:
             //   [n*conv_channels)                : conv_f32 (done)
@@ -503,10 +504,10 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     // Single kernel launch for all tokens × heads (replaces n×32×2 launches).
     // When IMP_GDN_FP32_SCAN is active, this was already done inline with the
     // scan above (FP32-input variant). Skip to avoid double-applying.
-    // IMP_GDN_NORM_EPS env can override eps (diagnostic).
+    // [gdn] norm_eps_override > 0 can override eps (diagnostic).
     float norm_eps = eps;
-    if (const char* e = std::getenv("IMP_GDN_NORM_EPS")) {
-        norm_eps = strtof(e, nullptr);
+    if (RuntimeConfig::current().gdn.norm_eps_override > 0.0f) {
+        norm_eps = RuntimeConfig::current().gdn.norm_eps_override;
     }
     if (!use_fp32_scan) {
         gdn_rmsnorm_gated_silu(static_cast<half*>(y_buf.data),
@@ -524,7 +525,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
     // residual in FP32 before downcast. FP16 accumulation here drifts ~5% per
     // element vs llama.cpp; that small drift amplifies to sign flips in
     // downstream near-zero projections and breaks Qwen 3.6.
-    static const bool use_fp32_out = std::getenv("IMP_GDN_FP32_OUT") != nullptr;
+    const bool use_fp32_out = RuntimeConfig::current().gdn.fp32_out;
     Tensor out_buf = view_tokens(ssm_out_buf_, n);
     if (use_fp32_out) {
         // Allocate FP32 scratch via cudaMallocAsync (small: n * d_model * 4 bytes)

--- a/src/graph/executor_workspace.cu
+++ b/src/graph/executor_workspace.cu
@@ -39,7 +39,7 @@ GraphExecutor::~GraphExecutor() {
     free_buffers();
 }
 
-bool GraphExecutor::init(const Model& model, DType compute_dtype, bool use_pdl,
+bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl,
                          int max_batch_size, int max_seq_len, bool use_fp8_prefill,
                          int use_nvfp4_decode, bool use_mxfp4_prefill) {
     if (initialized_) {
@@ -433,7 +433,7 @@ bool GraphExecutor::allocate_persistent_workspace(int max_tokens) {
 
     {
         int64_t shape[2] = {static_cast<int64_t>(max_logit_tokens_), static_cast<int64_t>(v)};
-        logits_ = Tensor(ptr, DType::FP32, 2, shape, true);
+        logits_ = Tensor(ptr, QType::F32, 2, shape, true);
         ptr += logits_sz;
     }
 
@@ -446,7 +446,7 @@ bool GraphExecutor::allocate_persistent_workspace(int max_tokens) {
         cudaError_t e2 = cudaMalloc(&fp32_accum_buf_, fp32_sz);
         if (e2 == cudaSuccess) {
             int64_t shape[2] = {static_cast<int64_t>(max_tokens), static_cast<int64_t>(d)};
-            fp32_hidden_ = Tensor(fp32_accum_buf_, DType::FP32, 2, shape, true);
+            fp32_hidden_ = Tensor(fp32_accum_buf_, QType::F32, 2, shape, true);
             IMP_LOG_INFO("FP32 residual accumulator: %.2f MiB (post-norm architecture)",
                          fp32_sz / (1024.0 * 1024.0));
         } else {

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -8,6 +8,7 @@
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
 #include "compute/sampling.h"
+#include "runtime/config.h"
 #include "quant/quant_gemm.h"
 #include "quant/dequant_gpu.h"
 #include "quant/nvfp4_gemm.h"
@@ -249,7 +250,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                     break;
                 }
             }
-            if (has_host_experts && !getenv("IMP_NO_EXPERT_CACHE")) {
+            if (has_host_experts && !RuntimeConfig::current().moe.no_expert_cache) {
                 // Budget: proportional to free VRAM (15%) instead of flat cap.
                 // KV cache + weight caches (FP8/NVFP4) need the remaining VRAM,
                 // so expert cache must not over-commit.

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -179,7 +179,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 int64_t s_shape[3] = {static_cast<int64_t>(nh),
                                       static_cast<int64_t>(attn_seq),
                                       static_cast<int64_t>(attn_seq)};
-                attn_scores_ = Tensor(attn_scores_buf_, DType::FP16, 3, s_shape, true);
+                attn_scores_ = Tensor(attn_scores_buf_, QType::F16, 3, s_shape, true);
                 IMP_LOG_INFO("cuBLAS attention S-matrix: %.2f MiB (%d heads x %d x %d)",
                              s_sz / (1024.0 * 1024.0), nh, attn_seq, attn_seq);
             }
@@ -213,9 +213,9 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         {
             for (int li = 0; li < model_->n_layers(); li++) {
                 const auto& L = model_->layer(li);
-                auto check = [&](const Tensor& p, GGMLQuantType qt) {
+                auto check = [&](const Tensor& p, QType qt) {
                     if (!p.data || p.ndim < 3) return;
-                    size_t rb = ggml_quant_row_bytes(qt, p.shape[2]);
+                    size_t rb = qtype_row_bytes(qt, p.shape[2]);
                     size_t expert_raw = static_cast<size_t>(p.shape[1]) * rb;
                     max_expert_raw = std::max(max_expert_raw, expert_raw);
                 };

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -220,9 +220,9 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                     size_t expert_raw = static_cast<size_t>(p.shape[1]) * rb;
                     max_expert_raw = std::max(max_expert_raw, expert_raw);
                 };
-                check(L.expert_up_packed, L.expert_up_qtype);
-                check(L.expert_down_packed, L.expert_down_qtype);
-                check(L.expert_gate_packed, L.expert_gate_qtype);
+                check(L.expert_up_packed, L.expert_up_packed.qtype);
+                check(L.expert_down_packed, L.expert_down_packed.qtype);
+                check(L.expert_gate_packed, L.expert_gate_packed.qtype);
             }
             if (max_expert_raw > 0) {
                 moe_.raw_staging_buf = vram_alloc(vram_alloc_, max_expert_raw, "moe_staging");

--- a/src/graph/executor_workspace_config.cu
+++ b/src/graph/executor_workspace_config.cu
@@ -72,7 +72,7 @@ void GraphExecutor::configure_moe_workspace(int max_tokens) {
     char* ptr = static_cast<char*>(shared_workspace_);
 
     // gate_logits: FP32
-    moe_.gate_logits = make_workspace_tensor(ptr, DType::FP32, max_tokens, ne,
+    moe_.gate_logits = make_workspace_tensor(ptr, QType::F32, max_tokens, ne,
                                              align256(static_cast<size_t>(max_tokens) * ne * sizeof(float)));
 
     moe_.gathered      = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
@@ -85,7 +85,7 @@ void GraphExecutor::configure_moe_workspace(int max_tokens) {
                                                align256(static_cast<size_t>(expanded) * eff * es));
     moe_.expert_down   = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
                                                align256(static_cast<size_t>(expanded) * d * es));
-    moe_.scatter_out   = make_workspace_tensor(ptr, DType::FP32, max_tokens, d,
+    moe_.scatter_out   = make_workspace_tensor(ptr, QType::F32, max_tokens, d,
                                                align256(static_cast<size_t>(max_tokens) * d * sizeof(float)));
 }
 
@@ -240,19 +240,19 @@ void GraphExecutor::use_workspace(int slot) {
         int mb = decode_max_batch_;
         char* p = static_cast<char*>(decode_workspace_);
         int64_t shape_mb[2] = {mb, dm};
-        hidden_ = Tensor(p, DType::FP16, 2, shape_mb, true);
+        hidden_ = Tensor(p, QType::F16, 2, shape_mb, true);
         p += static_cast<size_t>(dm) * sizeof(half) * mb;
-        residual_ = Tensor(p, DType::FP16, 2, shape_mb, true);
+        residual_ = Tensor(p, QType::F16, 2, shape_mb, true);
         p += static_cast<size_t>(dm) * sizeof(half) * mb;
-        norm_out_ = Tensor(p, DType::FP16, 2, shape_mb, true);
+        norm_out_ = Tensor(p, QType::F16, 2, shape_mb, true);
         p += static_cast<size_t>(dm) * sizeof(half) * mb;
         int64_t shape_logits[2] = {mb, cfg.vocab_size};
-        logits_ = Tensor(p, DType::FP32, 2, shape_logits, true);
+        logits_ = Tensor(p, QType::F32, 2, shape_logits, true);
         p += static_cast<size_t>(cfg.vocab_size) * sizeof(float) * mb;
         if (saved_prefill_ws_.fp32_accum) {
             fp32_accum_buf_ = p;
             int64_t shape_fp32[2] = {mb, dm};
-            fp32_hidden_ = Tensor(p, DType::FP32, 2, shape_fp32, true);
+            fp32_hidden_ = Tensor(p, QType::F32, 2, shape_fp32, true);
         }
 
         active_workspace_ = 1;

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -31,7 +31,7 @@ namespace imp {
 //   Total = n_layers * max_blocks * block_bytes_  (1x, not 2x)
 // ---------------------------------------------------------------------------
 
-KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
+KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, QType dtype,
                  int max_blocks, int block_size, VRAMAllocator* alloc, int sketch_dim,
                  bool use_mxfp4)
     : n_layers_(n_layers)
@@ -43,17 +43,17 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
     , use_mxfp4_(use_mxfp4)
     , dtype_(dtype)
     , alloc_(alloc)
-    , block_bytes_((dtype == DType::INT4 || dtype == DType::TURBOQUANT
-                    || dtype == DType::TURBOQUANT_LITE)
+    , block_bytes_((dtype == QType::INT4 || dtype == QType::TURBOQUANT
+                    || dtype == QType::TURBOQUANT_LITE)
                    ? (static_cast<size_t>(block_size_) * n_kv_heads * head_dim / 2)
                    : (static_cast<size_t>(block_size_) * n_kv_heads * head_dim *
                       dtype_size(dtype))) {
 
-    bool lite = (dtype == DType::TURBOQUANT_LITE);
+    bool lite = (dtype == QType::TURBOQUANT_LITE);
 
     // Resolve sketch_dim default: head_dim for TURBOQUANT, 0 for non-TQ modes
-    if (dtype == DType::TURBOQUANT && sketch_dim_ <= 0) sketch_dim_ = head_dim;
-    if (dtype == DType::TURBOQUANT_LITE && sketch_dim_ <= 0) sketch_dim_ = 2 * head_dim;
+    if (dtype == QType::TURBOQUANT && sketch_dim_ <= 0) sketch_dim_ = head_dim;
+    if (dtype == QType::TURBOQUANT_LITE && sketch_dim_ <= 0) sketch_dim_ = 2 * head_dim;
 
     // Allocate contiguous GPU pool
     // TURBOQUANT_LITE: V-only (1x), all others: K+V (2x)
@@ -78,8 +78,8 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
 
     // Allocate separate scale buffer for INT8/INT4/TURBOQUANT/TURBOQUANT_LITE KV cache
     // For TURBOQUANT_LITE: K scales = FP16 norms, V scales = INT4 per-head scales
-    if (dtype == DType::INT8 || dtype == DType::INT4
-        || dtype == DType::TURBOQUANT || dtype == DType::TURBOQUANT_LITE) {
+    if (dtype == QType::INT8 || dtype == QType::INT4
+        || dtype == QType::TURBOQUANT || dtype == QType::TURBOQUANT_LITE) {
         scale_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * sizeof(half);
         // Always 2x: K scales region + V scales region (even for TURBOQUANT_LITE)
         size_t scale_total = static_cast<size_t>(n_layers_) * max_blocks_ * 2 * scale_block_bytes_;
@@ -103,7 +103,7 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
     }
 
     // Allocate QJL 1-bit sketch buffer for TurboQuant / TurboQuant Lite K-cache
-    if (dtype == DType::TURBOQUANT || dtype == DType::TURBOQUANT_LITE) {
+    if (dtype == QType::TURBOQUANT || dtype == QType::TURBOQUANT_LITE) {
         sketch_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * (sketch_dim_ / 8);
         // Only K needs sketches, so n_layers * max_blocks * sketch_block_bytes (no 2x)
         size_t sketch_total = static_cast<size_t>(n_layers_) * max_blocks_ * sketch_block_bytes_;
@@ -134,7 +134,7 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
 
     // Allocate MXFP4 UE8M0 micro-scale pool for TurboQuant K directions (sm_120 path).
     // One UE8M0 byte per 32 direction elements per head per token.
-    if (dtype == DType::TURBOQUANT && use_mxfp4_ && head_dim >= kTQMicroScaleGroup) {
+    if (dtype == QType::TURBOQUANT && use_mxfp4_ && head_dim >= kTQMicroScaleGroup) {
         int n_groups_per_head = head_dim / kTQMicroScaleGroup;
         mscale_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * n_groups_per_head;
         // K-only (same indexing as sketch pool)
@@ -173,7 +173,7 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
 KVCache::KVCache(int n_layers,
                  const std::vector<int>& n_kv_heads_per_layer,
                  const std::vector<int>& head_dim_per_layer,
-                 DType dtype,
+                 QType dtype,
                  int max_blocks, int block_size,
                  VRAMAllocator* alloc)
     : n_layers_(n_layers)
@@ -184,11 +184,11 @@ KVCache::KVCache(int n_layers,
 {
     // Only FP16, BF16, FP8, INT8, INT4 supported for per-layer variant.
     // (TurboQuant / sketches / mscales aren't per-layer aware yet.)
-    if (dtype == DType::TURBOQUANT || dtype == DType::TURBOQUANT_LITE) {
+    if (dtype == QType::TURBOQUANT || dtype == QType::TURBOQUANT_LITE) {
         throw std::runtime_error("KVCache per-layer shape: TurboQuant variants not supported");
     }
 
-    size_t elem_size = (dtype == DType::INT4)
+    size_t elem_size = (dtype == QType::INT4)
         ? 0  // INT4 uses /2 below
         : dtype_size(dtype);
 
@@ -211,7 +211,7 @@ KVCache::KVCache(int n_layers,
         max_nkv = std::max(max_nkv, nkv);
         max_hd  = std::max(max_hd, hd);
 
-        size_t bb = (dtype == DType::INT4)
+        size_t bb = (dtype == QType::INT4)
             ? (static_cast<size_t>(block_size_) * nkv * hd / 2)
             : (static_cast<size_t>(block_size_) * nkv * hd * elem_size);
         layer_block_bytes_[l] = bb;
@@ -227,7 +227,7 @@ KVCache::KVCache(int n_layers,
     // Populate scalar fallback fields with max values (for external queries)
     n_kv_heads_ = max_nkv;
     head_dim_   = max_hd;
-    block_bytes_ = (dtype == DType::INT4)
+    block_bytes_ = (dtype == QType::INT4)
         ? (static_cast<size_t>(block_size_) * max_nkv * max_hd / 2)
         : (static_cast<size_t>(block_size_) * max_nkv * max_hd * elem_size);
 
@@ -248,7 +248,7 @@ KVCache::KVCache(int n_layers,
     IMP_CUDA_CHECK_LOG(cudaMemset(pool_, 0, total));
 
     // INT8/INT4 per-layer scales not yet supported in per-layer mode.
-    if (dtype == DType::INT8 || dtype == DType::INT4) {
+    if (dtype == QType::INT8 || dtype == QType::INT4) {
         throw std::runtime_error("KVCache per-layer shape: INT8/INT4 scale pools not yet supported");
     }
 
@@ -345,7 +345,7 @@ void KVCache::inc_ref(int block_id) {
 
 void* KVCache::k_ptr(int layer, int block_id) {
     // TURBOQUANT_LITE: no K directions in pool, K is represented by sketches only
-    if (dtype_ == DType::TURBOQUANT_LITE) return nullptr;
+    if (dtype_ == QType::TURBOQUANT_LITE) return nullptr;
 
 #ifdef IMP_DEBUG
     if (layer < 0 || layer >= n_layers_ || block_id < 0 || block_id >= max_blocks_) {
@@ -372,7 +372,7 @@ void* KVCache::v_ptr(int layer, int block_id) {
                       layer, n_layers_, block_id, max_blocks_);
     }
 #endif
-    if (dtype_ == DType::TURBOQUANT_LITE) {
+    if (dtype_ == QType::TURBOQUANT_LITE) {
         // V-only pool: [layer * max_blocks + block_id] * block_bytes
         size_t offset = (static_cast<size_t>(layer) * max_blocks_ +
                          static_cast<size_t>(block_id)) * block_bytes_;
@@ -422,7 +422,7 @@ int KVCache::head_dim() const {
     return head_dim_;
 }
 
-DType KVCache::dtype() const {
+QType KVCache::qtype() const {
     return dtype_;
 }
 

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -21,7 +21,7 @@ public:
     //   TURBOQUANT_LITE: should be multiplier * head_dim for quality (e.g. 2*head_dim).
     // use_mxfp4: if true and dtype==TURBOQUANT, use FP4 E2M1 + UE8M0 micro-scales
     //   instead of uniform INT4 for K direction quantization (sm_120 path).
-    KVCache(int n_layers, int n_kv_heads, int head_dim, DType dtype,
+    KVCache(int n_layers, int n_kv_heads, int head_dim, QType dtype,
             int max_blocks, int block_size = kKVBlockSize,
             VRAMAllocator* alloc = nullptr, int sketch_dim = 0,
             bool use_mxfp4 = false);
@@ -32,7 +32,7 @@ public:
     KVCache(int n_layers,
             const std::vector<int>& n_kv_heads_per_layer,
             const std::vector<int>& head_dim_per_layer,
-            DType dtype,
+            QType dtype,
             int max_blocks, int block_size,
             VRAMAllocator* alloc);
     ~KVCache();
@@ -79,7 +79,7 @@ public:
     int head_dim() const;
     int sketch_dim() const { return sketch_dim_; }
     bool use_mxfp4() const { return use_mxfp4_; }
-    DType dtype() const;
+    QType qtype() const;
 
 private:
     int n_layers_;
@@ -89,7 +89,7 @@ private:
     int block_size_;                // tokens per block (default 16)
     int sketch_dim_ = 0;           // QJL sketch dimension (0 if not TurboQuant)
     bool use_mxfp4_ = false;       // FP4 E2M1 + UE8M0 micro-scales for K dirs (sm_120)
-    DType dtype_;
+    QType dtype_;
     VRAMAllocator* alloc_ = nullptr;
     size_t block_bytes_;            // cached: block_size * n_kv_heads * head_dim * dtype_size(dtype)
 

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -707,7 +707,7 @@ int KVCacheManager::save_prefix_cache(const std::string& path, cudaStream_t stre
     hdr.n_layers = static_cast<uint32_t>(nl);
     hdr.n_kv_heads = static_cast<uint32_t>(cache_->n_kv_heads());
     hdr.head_dim = static_cast<uint32_t>(cache_->head_dim());
-    hdr.dtype = static_cast<uint32_t>(cache_->dtype());
+    hdr.dtype = static_cast<uint32_t>(cache_->qtype());
     hdr.block_bytes = bb;
 
     if (fwrite(&hdr, sizeof(hdr), 1, f) != 1) {
@@ -829,12 +829,12 @@ int KVCacheManager::load_prefix_cache(const std::string& path, cudaStream_t stre
     if (hdr.n_layers != static_cast<uint32_t>(cache_->n_layers()) ||
         hdr.n_kv_heads != static_cast<uint32_t>(cache_->n_kv_heads()) ||
         hdr.head_dim != static_cast<uint32_t>(cache_->head_dim()) ||
-        hdr.dtype != static_cast<uint32_t>(cache_->dtype()) ||
+        hdr.dtype != static_cast<uint32_t>(cache_->qtype()) ||
         hdr.block_bytes != cache_->block_bytes()) {
         IMP_LOG_WARN("Prefix cache: config mismatch (layers=%u/%d, heads=%u/%d, "
                      "dim=%u/%d, dtype=%u/%d)",
                      hdr.n_layers, cache_->n_layers(), hdr.n_kv_heads, cache_->n_kv_heads(),
-                     hdr.head_dim, cache_->head_dim(), hdr.dtype, static_cast<int>(cache_->dtype()));
+                     hdr.head_dim, cache_->head_dim(), hdr.dtype, static_cast<int>(cache_->qtype()));
         fclose(f);
         return -1;
     }

--- a/src/memory/ssm_state.cu
+++ b/src/memory/ssm_state.cu
@@ -16,7 +16,7 @@ SSMState::~SSMState() {
 bool SSMState::init(int n_ssm_layers, int max_sequences,
                     int conv_channels, int conv_kernel,
                     int n_heads, int head_dim_ssm, int state_size,
-                    DType h_dtype, VRAMAllocator* alloc) {
+                    QType h_dtype, VRAMAllocator* alloc) {
     n_ssm_layers_ = n_ssm_layers;
     max_sequences_ = max_sequences;
     h_dtype_ = h_dtype;

--- a/src/memory/ssm_state.h
+++ b/src/memory/ssm_state.h
@@ -21,11 +21,11 @@ public:
     ~SSMState();
 
     // Allocate state for the given configuration.
-    // h_dtype: DType::FP32 (default) or DType::FP16 for h_state storage.
+    // h_dtype: QType::F32 (default) or QType::F16 for h_state storage.
     bool init(int n_ssm_layers, int max_sequences,
               int conv_channels, int conv_kernel,
               int n_heads, int head_dim_ssm, int state_size,
-              DType h_dtype = DType::FP32,
+              QType h_dtype = QType::F32,
               VRAMAllocator* alloc = nullptr);
 
     // Get pointers into the state pool for a given sequence and SSM layer index.
@@ -37,14 +37,14 @@ public:
 
     int max_sequences() const { return max_sequences_; }
     int n_ssm_layers() const { return n_ssm_layers_; }
-    DType h_dtype() const { return h_dtype_; }
+    QType h_dtype() const { return h_dtype_; }
 
 private:
     VRAMAllocator* alloc_ = nullptr;
     void* pool_ = nullptr;
     int n_ssm_layers_ = 0;
     int max_sequences_ = 0;
-    DType h_dtype_ = DType::FP32;
+    QType h_dtype_ = QType::F32;
     size_t conv_bytes_ = 0;      // per (seq, layer) conv state
     size_t h_bytes_ = 0;         // per (seq, layer) h state
     size_t per_layer_bytes_ = 0; // conv_bytes_ + h_bytes_

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -1,5 +1,6 @@
 #include "model/chat_template.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 
 #include <algorithm>
 #include <functional>
@@ -342,7 +343,7 @@ std::vector<int32_t> ChatTemplate::apply_chatml(
     auto asst_ids = tok.encode("assistant\n");
     tokens.insert(tokens.end(), asst_ids.begin(), asst_ids.end());
 
-    if (static const bool dbg_tpl = (getenv("IMP_DEBUG_TEMPLATE") != nullptr); dbg_tpl) {
+    if (RuntimeConfig::current().diagnostics.debug_template) {
         fprintf(stderr, "[DEBUG_TPL] chatml %zu tokens:", tokens.size());
         for (size_t i = 0; i < tokens.size(); i++)
             fprintf(stderr, " %d", tokens[i]);
@@ -493,7 +494,7 @@ std::vector<int32_t> ChatTemplate::apply_gemma(
     tokens.insert(tokens.end(), model_ids.begin(), model_ids.end());
 
     // Debug: print template token IDs
-    if (static const bool dbg_tpl = (getenv("IMP_DEBUG_TEMPLATE") != nullptr); dbg_tpl) {
+    if (RuntimeConfig::current().diagnostics.debug_template) {
         fprintf(stderr, "[DEBUG_TPL] %zu tokens:", tokens.size());
         for (size_t i = 0; i < tokens.size(); i++)
             fprintf(stderr, " %d", tokens[i]);
@@ -573,7 +574,7 @@ std::vector<int32_t> ChatTemplate::apply_phi(
     tokens.insert(tokens.end(), nl_ids.begin(), nl_ids.end());
 
     // Debug: print template token IDs
-    if (static const bool dbg_tpl = (getenv("IMP_DEBUG_TEMPLATE") != nullptr); dbg_tpl) {
+    if (RuntimeConfig::current().diagnostics.debug_template) {
         fprintf(stderr, "[DEBUG_TPL] phi %zu tokens:", tokens.size());
         for (size_t i = 0; i < tokens.size(); i++)
             fprintf(stderr, " %d", tokens[i]);
@@ -908,7 +909,7 @@ std::vector<int32_t> ChatTemplate::apply_jinja(
         return {};
     }
     IMP_LOG_DEBUG("Jinja2 rendered (%zu chars)", rendered.size());
-    if (getenv("IMP_DEBUG_TEMPLATE")) {
+    if (RuntimeConfig::current().diagnostics.debug_template) {
         std::string escaped;
         for (char c : rendered) {
             if (c == '\n') escaped += "\\n";

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -101,19 +101,31 @@ size_t gguf_row_size(GgufWireType type, int64_t n_elements) {
 }
 
 QType gguf_type_to_qtype(GgufWireType type) {
+    // Wire-stable values 0..31 in QType match the GGUF on-disk numbering,
+    // so the cast is exact for every supported block-quant type. Anything
+    // outside the 0..31 range falls through to NONE.
     switch (type) {
-        case GgufWireType::F32:  return QType::F32;
-        case GgufWireType::F16:  return QType::F16;
-        case GgufWireType::BF16: return QType::BF16;
-        case GgufWireType::I8:   return QType::INT8;
-        case GgufWireType::I32:  return QType::INT32;
-        // Quantized types: use INT4 for 4-bit, INT8 as proxy for others
-        case GgufWireType::Q4_0: case GgufWireType::Q4_1:
-        case GgufWireType::Q4_K: case GgufWireType::IQ4_NL: case GgufWireType::IQ4_XS:
-        case GgufWireType::MXFP4:
-            return QType::INT4;
+        case GgufWireType::F32:   return QType::F32;
+        case GgufWireType::F16:   return QType::F16;
+        case GgufWireType::BF16:  return QType::BF16;
+        case GgufWireType::Q4_0:  return QType::Q4_0;
+        case GgufWireType::Q4_1:  return QType::Q4_1;
+        case GgufWireType::Q5_0:  return QType::Q5_0;
+        case GgufWireType::Q5_1:  return QType::Q5_1;
+        case GgufWireType::Q8_0:  return QType::Q8_0;
+        case GgufWireType::Q8_1:  return QType::Q8_1;
+        case GgufWireType::Q2_K:  return QType::Q2_K;
+        case GgufWireType::Q3_K:  return QType::Q3_K;
+        case GgufWireType::Q4_K:  return QType::Q4_K;
+        case GgufWireType::Q5_K:  return QType::Q5_K;
+        case GgufWireType::Q6_K:  return QType::Q6_K;
+        case GgufWireType::Q8_K:  return QType::Q8_K;
+        case GgufWireType::MXFP4: return QType::MXFP4;
+        case GgufWireType::I8:    return QType::INT8;
+        case GgufWireType::I32:   return QType::INT32;
         default:
-            return QType::INT8;  // other quantized types stored as blocks
+            // IQ4_NL/IQ4_XS/etc. — no native QType yet; mark unsupported.
+            return QType::NONE;
     }
 }
 

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -21,133 +21,133 @@ namespace imp {
 
 // ---- GGML type tables ----
 
-int ggml_blck_size(GGMLType type) {
+int gguf_blck_size(GgufWireType type) {
     switch (type) {
-        case GGMLType::F32:     return 1;
-        case GGMLType::F16:     return 1;
-        case GGMLType::BF16:    return 1;
-        case GGMLType::F64:     return 1;
-        case GGMLType::I8:      return 1;
-        case GGMLType::I16:     return 1;
-        case GGMLType::I32:     return 1;
-        case GGMLType::I64:     return 1;
-        case GGMLType::Q4_0:    return 32;
-        case GGMLType::Q4_1:    return 32;
-        case GGMLType::Q5_0:    return 32;
-        case GGMLType::Q5_1:    return 32;
-        case GGMLType::Q8_0:    return 32;
-        case GGMLType::Q8_1:    return 32;
-        case GGMLType::IQ4_NL:  return 32;
-        case GGMLType::Q2_K:    return 256;
-        case GGMLType::Q3_K:    return 256;
-        case GGMLType::Q4_K:    return 256;
-        case GGMLType::Q5_K:    return 256;
-        case GGMLType::Q6_K:    return 256;
-        case GGMLType::Q8_K:    return 256;
-        case GGMLType::IQ2_XXS: return 256;
-        case GGMLType::IQ2_XS:  return 256;
-        case GGMLType::IQ2_S:   return 256;
-        case GGMLType::IQ3_XXS: return 256;
-        case GGMLType::IQ3_S:   return 256;
-        case GGMLType::IQ1_S:   return 256;
-        case GGMLType::IQ1_M:   return 256;
-        case GGMLType::IQ4_XS:  return 256;
-        case GGMLType::MXFP4:   return 32;
+        case GgufWireType::F32:     return 1;
+        case GgufWireType::F16:     return 1;
+        case GgufWireType::BF16:    return 1;
+        case GgufWireType::F64:     return 1;
+        case GgufWireType::I8:      return 1;
+        case GgufWireType::I16:     return 1;
+        case GgufWireType::I32:     return 1;
+        case GgufWireType::I64:     return 1;
+        case GgufWireType::Q4_0:    return 32;
+        case GgufWireType::Q4_1:    return 32;
+        case GgufWireType::Q5_0:    return 32;
+        case GgufWireType::Q5_1:    return 32;
+        case GgufWireType::Q8_0:    return 32;
+        case GgufWireType::Q8_1:    return 32;
+        case GgufWireType::IQ4_NL:  return 32;
+        case GgufWireType::Q2_K:    return 256;
+        case GgufWireType::Q3_K:    return 256;
+        case GgufWireType::Q4_K:    return 256;
+        case GgufWireType::Q5_K:    return 256;
+        case GgufWireType::Q6_K:    return 256;
+        case GgufWireType::Q8_K:    return 256;
+        case GgufWireType::IQ2_XXS: return 256;
+        case GgufWireType::IQ2_XS:  return 256;
+        case GgufWireType::IQ2_S:   return 256;
+        case GgufWireType::IQ3_XXS: return 256;
+        case GgufWireType::IQ3_S:   return 256;
+        case GgufWireType::IQ1_S:   return 256;
+        case GgufWireType::IQ1_M:   return 256;
+        case GgufWireType::IQ4_XS:  return 256;
+        case GgufWireType::MXFP4:   return 32;
         default: return 0;
     }
 }
 
-size_t ggml_type_size(GGMLType type) {
+size_t gguf_type_size(GgufWireType type) {
     switch (type) {
-        case GGMLType::F32:     return 4;
-        case GGMLType::F16:     return 2;
-        case GGMLType::BF16:    return 2;
-        case GGMLType::F64:     return 8;
-        case GGMLType::I8:      return 1;
-        case GGMLType::I16:     return 2;
-        case GGMLType::I32:     return 4;
-        case GGMLType::I64:     return 8;
-        case GGMLType::Q4_0:    return 18;   // 32*4/8 + 2 (fp16 scale)
-        case GGMLType::Q4_1:    return 20;   // 32*4/8 + 2 + 2 (scale + min)
-        case GGMLType::Q5_0:    return 22;   // 32*5/8 + 4 (high bits) + 2
-        case GGMLType::Q5_1:    return 24;   // 32*5/8 + 4 + 2 + 2
-        case GGMLType::Q8_0:    return 34;   // 32*1 + 2
-        case GGMLType::Q8_1:    return 36;   // 32*1 + 2 + 2
-        case GGMLType::Q2_K:    return 84;
-        case GGMLType::Q3_K:    return 110;
-        case GGMLType::Q4_K:    return 144;
-        case GGMLType::Q5_K:    return 176;
-        case GGMLType::Q6_K:    return 210;
-        case GGMLType::Q8_K:    return 292;
-        case GGMLType::IQ2_XXS: return 66;
-        case GGMLType::IQ2_XS:  return 74;
-        case GGMLType::IQ2_S:   return 82;
-        case GGMLType::IQ3_XXS: return 98;
-        case GGMLType::IQ3_S:   return 110;
-        case GGMLType::IQ1_S:   return 50;
-        case GGMLType::IQ1_M:   return 56;
-        case GGMLType::IQ4_NL:  return 18;
-        case GGMLType::IQ4_XS:  return 136;
-        case GGMLType::MXFP4:   return 17;   // 32*4/8 + 1 (UE8M0 scale)
+        case GgufWireType::F32:     return 4;
+        case GgufWireType::F16:     return 2;
+        case GgufWireType::BF16:    return 2;
+        case GgufWireType::F64:     return 8;
+        case GgufWireType::I8:      return 1;
+        case GgufWireType::I16:     return 2;
+        case GgufWireType::I32:     return 4;
+        case GgufWireType::I64:     return 8;
+        case GgufWireType::Q4_0:    return 18;   // 32*4/8 + 2 (fp16 scale)
+        case GgufWireType::Q4_1:    return 20;   // 32*4/8 + 2 + 2 (scale + min)
+        case GgufWireType::Q5_0:    return 22;   // 32*5/8 + 4 (high bits) + 2
+        case GgufWireType::Q5_1:    return 24;   // 32*5/8 + 4 + 2 + 2
+        case GgufWireType::Q8_0:    return 34;   // 32*1 + 2
+        case GgufWireType::Q8_1:    return 36;   // 32*1 + 2 + 2
+        case GgufWireType::Q2_K:    return 84;
+        case GgufWireType::Q3_K:    return 110;
+        case GgufWireType::Q4_K:    return 144;
+        case GgufWireType::Q5_K:    return 176;
+        case GgufWireType::Q6_K:    return 210;
+        case GgufWireType::Q8_K:    return 292;
+        case GgufWireType::IQ2_XXS: return 66;
+        case GgufWireType::IQ2_XS:  return 74;
+        case GgufWireType::IQ2_S:   return 82;
+        case GgufWireType::IQ3_XXS: return 98;
+        case GgufWireType::IQ3_S:   return 110;
+        case GgufWireType::IQ1_S:   return 50;
+        case GgufWireType::IQ1_M:   return 56;
+        case GgufWireType::IQ4_NL:  return 18;
+        case GgufWireType::IQ4_XS:  return 136;
+        case GgufWireType::MXFP4:   return 17;   // 32*4/8 + 1 (UE8M0 scale)
         default: return 0;
     }
 }
 
-size_t ggml_row_size(GGMLType type, int64_t n_elements) {
-    int bs = ggml_blck_size(type);
+size_t gguf_row_size(GgufWireType type, int64_t n_elements) {
+    int bs = gguf_blck_size(type);
     if (bs == 0) return 0;
-    return static_cast<size_t>((n_elements + bs - 1) / bs) * ggml_type_size(type);
+    return static_cast<size_t>((n_elements + bs - 1) / bs) * gguf_type_size(type);
 }
 
-DType ggml_type_to_dtype(GGMLType type) {
+QType gguf_type_to_qtype(GgufWireType type) {
     switch (type) {
-        case GGMLType::F32:  return DType::FP32;
-        case GGMLType::F16:  return DType::FP16;
-        case GGMLType::BF16: return DType::BF16;
-        case GGMLType::I8:   return DType::INT8;
-        case GGMLType::I32:  return DType::INT32;
+        case GgufWireType::F32:  return QType::F32;
+        case GgufWireType::F16:  return QType::F16;
+        case GgufWireType::BF16: return QType::BF16;
+        case GgufWireType::I8:   return QType::INT8;
+        case GgufWireType::I32:  return QType::INT32;
         // Quantized types: use INT4 for 4-bit, INT8 as proxy for others
-        case GGMLType::Q4_0: case GGMLType::Q4_1:
-        case GGMLType::Q4_K: case GGMLType::IQ4_NL: case GGMLType::IQ4_XS:
-        case GGMLType::MXFP4:
-            return DType::INT4;
+        case GgufWireType::Q4_0: case GgufWireType::Q4_1:
+        case GgufWireType::Q4_K: case GgufWireType::IQ4_NL: case GgufWireType::IQ4_XS:
+        case GgufWireType::MXFP4:
+            return QType::INT4;
         default:
-            return DType::INT8;  // other quantized types stored as blocks
+            return QType::INT8;  // other quantized types stored as blocks
     }
 }
 
-const char* ggml_type_name(GGMLType type) {
+const char* gguf_type_name(GgufWireType type) {
     switch (type) {
-        case GGMLType::F32:     return "F32";
-        case GGMLType::F16:     return "F16";
-        case GGMLType::BF16:    return "BF16";
-        case GGMLType::F64:     return "F64";
-        case GGMLType::I8:      return "I8";
-        case GGMLType::I16:     return "I16";
-        case GGMLType::I32:     return "I32";
-        case GGMLType::I64:     return "I64";
-        case GGMLType::Q4_0:    return "Q4_0";
-        case GGMLType::Q4_1:    return "Q4_1";
-        case GGMLType::Q5_0:    return "Q5_0";
-        case GGMLType::Q5_1:    return "Q5_1";
-        case GGMLType::Q8_0:    return "Q8_0";
-        case GGMLType::Q8_1:    return "Q8_1";
-        case GGMLType::Q2_K:    return "Q2_K";
-        case GGMLType::Q3_K:    return "Q3_K";
-        case GGMLType::Q4_K:    return "Q4_K";
-        case GGMLType::Q5_K:    return "Q5_K";
-        case GGMLType::Q6_K:    return "Q6_K";
-        case GGMLType::Q8_K:    return "Q8_K";
-        case GGMLType::IQ2_XXS: return "IQ2_XXS";
-        case GGMLType::IQ2_XS:  return "IQ2_XS";
-        case GGMLType::IQ2_S:   return "IQ2_S";
-        case GGMLType::IQ3_XXS: return "IQ3_XXS";
-        case GGMLType::IQ3_S:   return "IQ3_S";
-        case GGMLType::IQ1_S:   return "IQ1_S";
-        case GGMLType::IQ1_M:   return "IQ1_M";
-        case GGMLType::IQ4_NL:  return "IQ4_NL";
-        case GGMLType::IQ4_XS:  return "IQ4_XS";
-        case GGMLType::MXFP4:   return "MXFP4";
+        case GgufWireType::F32:     return "F32";
+        case GgufWireType::F16:     return "F16";
+        case GgufWireType::BF16:    return "BF16";
+        case GgufWireType::F64:     return "F64";
+        case GgufWireType::I8:      return "I8";
+        case GgufWireType::I16:     return "I16";
+        case GgufWireType::I32:     return "I32";
+        case GgufWireType::I64:     return "I64";
+        case GgufWireType::Q4_0:    return "Q4_0";
+        case GgufWireType::Q4_1:    return "Q4_1";
+        case GgufWireType::Q5_0:    return "Q5_0";
+        case GgufWireType::Q5_1:    return "Q5_1";
+        case GgufWireType::Q8_0:    return "Q8_0";
+        case GgufWireType::Q8_1:    return "Q8_1";
+        case GgufWireType::Q2_K:    return "Q2_K";
+        case GgufWireType::Q3_K:    return "Q3_K";
+        case GgufWireType::Q4_K:    return "Q4_K";
+        case GgufWireType::Q5_K:    return "Q5_K";
+        case GgufWireType::Q6_K:    return "Q6_K";
+        case GgufWireType::Q8_K:    return "Q8_K";
+        case GgufWireType::IQ2_XXS: return "IQ2_XXS";
+        case GgufWireType::IQ2_XS:  return "IQ2_XS";
+        case GgufWireType::IQ2_S:   return "IQ2_S";
+        case GgufWireType::IQ3_XXS: return "IQ3_XXS";
+        case GgufWireType::IQ3_S:   return "IQ3_S";
+        case GgufWireType::IQ1_S:   return "IQ1_S";
+        case GgufWireType::IQ1_M:   return "IQ1_M";
+        case GgufWireType::IQ4_NL:  return "IQ4_NL";
+        case GgufWireType::IQ4_XS:  return "IQ4_XS";
+        case GgufWireType::MXFP4:   return "MXFP4";
         default:                return "UNKNOWN";
     }
 }
@@ -338,8 +338,8 @@ static std::vector<std::string> split(const std::string& s, char delim) {
 // ---- Assign a single tensor to the model by GGUF name ----
 
 static bool assign_tensor(Model& model, const std::string& name,
-                           const Tensor& tensor, GGMLType gtype) {
-    auto qtype = static_cast<GGMLQuantType>(static_cast<uint32_t>(gtype));
+                           const Tensor& tensor, GgufWireType gtype) {
+    auto qtype = static_cast<QType>(static_cast<uint32_t>(gtype));
     if (name == "token_embd.weight") {
         model.tok_emb_ = tensor;
         model.tok_emb_qtype_ = qtype;
@@ -424,19 +424,19 @@ static bool assign_tensor(Model& model, const std::string& name,
                 // so q_rows = total_rows - k_rows - v_rows (not just n_heads * head_dim).
                 int q_rows = cfg.n_heads * cfg.head_dim;
                 int k_rows = cfg.n_kv_heads * cfg.head_dim;
-                size_t row_bytes = ggml_quant_row_bytes(qtype, d_model);
+                size_t row_bytes = qtype_row_bytes(qtype, d_model);
 
                 uint8_t* base = static_cast<uint8_t*>(tensor.data);
                 int64_t q_shape[4] = {q_rows, d_model, 1, 1};
                 int64_t kv_shape[4] = {k_rows, d_model, 1, 1};
 
-                layer.wq = Tensor(base, tensor.dtype, 2, q_shape, tensor.on_device);
+                layer.wq = Tensor(base, tensor.qtype, 2, q_shape, tensor.on_device);
                 layer.wq_qtype = qtype;
                 layer.wk = Tensor(base + static_cast<size_t>(q_rows) * row_bytes,
-                                   tensor.dtype, 2, kv_shape, tensor.on_device);
+                                   tensor.qtype, 2, kv_shape, tensor.on_device);
                 layer.wk_qtype = qtype;
                 layer.wv = Tensor(base + static_cast<size_t>(q_rows + k_rows) * row_bytes,
-                                   tensor.dtype, 2, kv_shape, tensor.on_device);
+                                   tensor.qtype, 2, kv_shape, tensor.on_device);
                 layer.wv_qtype = qtype;
             }
         }
@@ -575,7 +575,7 @@ static void parse_tensor_infos(BinaryReader& reader, uint64_t tensor_count,
         for (uint32_t d = info.n_dims; d < 4; d++) {
             info.dims[d] = 1;
         }
-        info.type = static_cast<GGMLType>(reader.read_u32());
+        info.type = static_cast<GgufWireType>(reader.read_u32());
         info.offset = reader.read_u64();
         out.push_back(std::move(info));
     }
@@ -1097,14 +1097,14 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
             shape[d] = info.dims[ndim - 1 - d];
         }
 
-        Tensor t(tensor_data, ggml_type_to_dtype(info.type), ndim, shape, /*on_device=*/false);
+        Tensor t(tensor_data, gguf_type_to_qtype(info.type), ndim, shape, /*on_device=*/false);
         t.kind = match_tensor_kind(info.name);
 
         if (assign_tensor(*model, info.name, t, info.type)) {
             assigned++;
         } else {
             IMP_LOG_DEBUG("Unassigned tensor: %s [%s] shape=[%ld,%ld,%ld,%ld]",
-                          info.name.c_str(), ggml_type_name(info.type),
+                          info.name.c_str(), gguf_type_name(info.type),
                           (long)info.dims[0], (long)info.dims[1],
                           (long)info.dims[2], (long)info.dims[3]);
             skipped++;
@@ -1134,15 +1134,15 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
                 ly.w_up.shape[0] == 2 * cfg.d_ff) {
                 int64_t d_model = ly.w_up.shape[1];
                 int64_t d_ff = cfg.d_ff;
-                size_t row_bytes = ggml_quant_row_bytes(ly.w_up_qtype, d_model);
+                size_t row_bytes = qtype_row_bytes(ly.w_up_qtype, d_model);
 
                 uint8_t* base = static_cast<uint8_t*>(ly.w_up.data);
                 int64_t half_shape[4] = {d_ff, d_model, 1, 1};
 
-                ly.w_gate = Tensor(base, ly.w_up.dtype, 2, half_shape, ly.w_up.on_device);
+                ly.w_gate = Tensor(base, ly.w_up.qtype, 2, half_shape, ly.w_up.on_device);
                 ly.w_gate_qtype = ly.w_up_qtype;
                 ly.w_up = Tensor(base + static_cast<size_t>(d_ff) * row_bytes,
-                                  ly.w_up.dtype, 2, half_shape, ly.w_up.on_device);
+                                  ly.w_up.qtype, 2, half_shape, ly.w_up.on_device);
                 // w_up_qtype unchanged
                 fused_count++;
             }
@@ -1180,9 +1180,9 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
                 ly.w_gate_shared = ly.w_gate;   ly.w_gate_shared_qtype = ly.w_gate_qtype;
                 ly.w_up_shared   = ly.w_up;     ly.w_up_shared_qtype   = ly.w_up_qtype;
                 ly.w_down_shared = ly.w_down;   ly.w_down_shared_qtype = ly.w_down_qtype;
-                ly.w_gate = Tensor();  ly.w_gate_qtype = GGMLQuantType::NONE;
-                ly.w_up   = Tensor();  ly.w_up_qtype   = GGMLQuantType::NONE;
-                ly.w_down = Tensor();  ly.w_down_qtype = GGMLQuantType::NONE;
+                ly.w_gate = Tensor();  ly.w_gate_qtype = QType::NONE;
+                ly.w_up   = Tensor();  ly.w_up_qtype   = QType::NONE;
+                ly.w_down = Tensor();  ly.w_down_qtype = QType::NONE;
                 n_remapped++;
                 has_shared = true;
             }
@@ -1239,7 +1239,7 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
         // expects ready-to-use freq values, so do the math on the host.
         if (cfg.arch == ModelArch::GEMMA4 && !cfg.swa_layers.empty() &&
             model->layers_[0].rope_freqs.data != nullptr &&
-            model->layers_[0].rope_freqs.dtype == DType::FP32) {
+            model->layers_[0].rope_freqs.qtype == QType::F32) {
             const Tensor& src = model->layers_[0].rope_freqs;
             int n_pairs = static_cast<int>(src.shape[0]);  // hd/2 for global layer
             int hd_global = n_pairs * 2;
@@ -1257,7 +1257,7 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
                 effective[p] = base_freq / divisors[p];
             }
             int64_t shape[4] = {n_pairs, 0, 0, 0};
-            Tensor eff_tensor(effective, DType::FP32, 1, shape, /*on_device=*/false);
+            Tensor eff_tensor(effective, QType::F32, 1, shape, /*on_device=*/false);
             int n_global = 0;
             for (int i = 0; i < cfg.n_layers; ++i) {
                 bool is_swa = (i < (int)cfg.swa_layers.size() && cfg.swa_layers[i]);

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -350,7 +350,7 @@ static bool assign_tensor(Model& model, const std::string& name,
         return true;
     }
     if (name == "rope_freqs.weight") {
-        assign(model.layers_[0].rope_freqs, tensor);
+        model.layers_[0].rope_freqs = tensor;
         return true;
     }
     if (name == "output.weight") {
@@ -375,8 +375,8 @@ static bool assign_tensor(Model& model, const std::string& name,
     // 3-part: "blk.{i}.{name}" — SSM scalar/vector tensors without .weight/.bias suffix
     if (parts.size() == 3) {
         const auto& field = parts[2];
-        if      (field == "ssm_a") assign(layer.ssm_a, tensor);
-        else if (field == "ssm_d") assign(layer.ssm_d, tensor);
+        if      (field == "ssm_a") layer.ssm_a = tensor;
+        else if (field == "ssm_d") layer.ssm_d = tensor;
         else return false;
         return true;
     }
@@ -388,21 +388,21 @@ static bool assign_tensor(Model& model, const std::string& name,
 
         // Attention projections: distinguish weight vs bias
         if (field == "attn_q") {
-            if (suffix == "bias")       assign(layer.q_bias, tensor);
+            if (suffix == "bias")       layer.q_bias = tensor;
             else                        assign_quant(layer.wq, layer.wq_qtype, tensor);
         }
         else if (field == "attn_k") {
-            if (suffix == "bias")       assign(layer.k_bias, tensor);
+            if (suffix == "bias")       layer.k_bias = tensor;
             else                        assign_quant(layer.wk, layer.wk_qtype, tensor);
         }
         else if (field == "attn_v") {
-            if (suffix == "bias")       assign(layer.v_bias, tensor);
+            if (suffix == "bias")       layer.v_bias = tensor;
             else                        assign_quant(layer.wv, layer.wv_qtype, tensor);
         }
         else if (field == "attn_output") assign_quant(layer.wo, layer.wo_qtype, tensor);
-        else if (field == "attn_norm")   assign(layer.attn_norm, tensor);
-        else if (field == "attn_q_norm") assign(layer.attn_q_norm, tensor);
-        else if (field == "attn_k_norm") assign(layer.attn_k_norm, tensor);
+        else if (field == "attn_norm")   layer.attn_norm = tensor;
+        else if (field == "attn_q_norm") layer.attn_q_norm = tensor;
+        else if (field == "attn_k_norm") layer.attn_k_norm = tensor;
         // Fused QKV: either standard attention (Phi-4) or GDN (Qwen3.5)
         else if (field == "attn_qkv") {
             const auto& cfg = model.config();
@@ -438,14 +438,14 @@ static bool assign_tensor(Model& model, const std::string& name,
             }
         }
         // Post-layer norms (Gemma-3)
-        else if (field == "post_attention_norm") assign(layer.post_attn_norm, tensor);
-        else if (field == "post_ffw_norm")       assign(layer.post_ffn_norm, tensor);
+        else if (field == "post_attention_norm") layer.post_attn_norm = tensor;
+        else if (field == "post_ffw_norm")       layer.post_ffn_norm = tensor;
         // Gemma 4: parallel shared MLP + MoE expert branch norms
-        else if (field == "pre_ffw_norm_2")      assign(layer.ffn_pre_norm_2, tensor);
-        else if (field == "post_ffw_norm_1")     assign(layer.ffn_post_norm_1, tensor);
-        else if (field == "post_ffw_norm_2")     assign(layer.ffn_post_norm_2, tensor);
-        else if (field == "layer_output_scale")  assign(layer.layer_out_scale, tensor);
-        else if (field == "rope_freqs")          assign(layer.rope_freqs, tensor);
+        else if (field == "pre_ffw_norm_2")      layer.ffn_pre_norm_2 = tensor;
+        else if (field == "post_ffw_norm_1")     layer.ffn_post_norm_1 = tensor;
+        else if (field == "post_ffw_norm_2")     layer.ffn_post_norm_2 = tensor;
+        else if (field == "layer_output_scale")  layer.layer_out_scale = tensor;
+        else if (field == "rope_freqs")          layer.rope_freqs = tensor;
         // Gemma 4: fused gate+up experts: [n_experts, n_ff_exp*2, d_model]
         // We keep it packed; the MoE executor handles de-interleaving at dispatch.
         else if (field == "ffn_gate_up_exps") {
@@ -457,13 +457,13 @@ static bool assign_tensor(Model& model, const std::string& name,
         else if (field == "ffn_gate")    assign_quant(layer.w_gate, layer.w_gate_qtype, tensor);
         else if (field == "ffn_up")      assign_quant(layer.w_up,   layer.w_up_qtype,   tensor);
         else if (field == "ffn_down")    assign_quant(layer.w_down, layer.w_down_qtype, tensor);
-        else if (field == "ffn_norm")    assign(layer.ffn_norm, tensor);
+        else if (field == "ffn_norm")    layer.ffn_norm = tensor;
         else if (field == "ffn_gate_inp") {
             // Distinguish .weight (the gate matrix) from .scale (per-channel multiplier).
             // Gemma 4 stores `blk.X.ffn_gate_inp.scale` as a 4-part tensor name; without
             // this branch the scale would be silently misassigned to layer.moe_gate.
-            if (suffix == "scale") assign(layer.ffn_gate_inp_scale, tensor);
-            else                   assign(layer.moe_gate, tensor);
+            if (suffix == "scale") layer.ffn_gate_inp_scale = tensor;
+            else                   layer.moe_gate = tensor;
         }
         // Packed expert tensors: 3D [n_experts, rows, cols]
         else if (field == "ffn_gate_exps") assign_quant(layer.expert_gate_packed, layer.expert_gate_qtype, tensor);
@@ -473,7 +473,7 @@ static bool assign_tensor(Model& model, const std::string& name,
             // (per-expert output multiplier, shape [n_expert]). Same 4-part-name
             // bug as ffn_gate_inp.scale: the scale tensor would otherwise overwrite
             // expert_down_packed.
-            if (suffix == "scale") assign(layer.expert_down_scale, tensor);
+            if (suffix == "scale") layer.expert_down_scale = tensor;
             else                   assign_quant(layer.expert_down_packed, layer.expert_down_qtype, tensor);
         }
         // Shared expert (always-active, e.g. Nemotron/DeepSeek)
@@ -482,7 +482,7 @@ static bool assign_tensor(Model& model, const std::string& name,
         else if (field == "ffn_down_shexp") assign_quant(layer.w_down_shared, layer.w_down_shared_qtype, tensor);
         // Qwen3-Next / Qwen3.6 per-token sigmoid gate on the shared expert
         // output. 1D [d_model] FP32 projection; sigmoid(cur @ W) yields [M, 1].
-        else if (field == "ffn_gate_inp_shexp") assign(layer.shared_expert_gate_inp, tensor);
+        else if (field == "ffn_gate_inp_shexp") layer.shared_expert_gate_inp = tensor;
         // SSM weights (Mamba2)
         else if (field == "ssm_in")   assign_quant(layer.ssm_in,  layer.ssm_in_qtype,  tensor);
         else if (field == "ssm_out")  assign_quant(layer.ssm_out, layer.ssm_out_qtype, tensor);
@@ -493,15 +493,15 @@ static bool assign_tensor(Model& model, const std::string& name,
             // weight → ssm_a (per-head A_log). Without this branch the weight
             // silently overwrites the bias and ssm_a stays null, causing the
             // GDN scan kernel to NULL-deref A_log[h] on first launch.
-            if (suffix == "bias")        assign(layer.ssm_dt_b, tensor);
-            else if (suffix == "weight") assign(layer.ssm_a, tensor);
+            if (suffix == "bias")        layer.ssm_dt_b = tensor;
+            else if (suffix == "weight") layer.ssm_a = tensor;
             else return false;
         }
-        else if (field == "ssm_norm")   assign(layer.ssm_norm_w, tensor);
+        else if (field == "ssm_norm")   layer.ssm_norm_w = tensor;
         // SSM conv1d: "blk.{i}.ssm_conv1d.weight" / "blk.{i}.ssm_conv1d.bias"
         else if (field == "ssm_conv1d") {
-            if (suffix == "weight")     assign(layer.ssm_conv1d_w, tensor);
-            else if (suffix == "bias")  assign(layer.ssm_conv1d_b, tensor);
+            if (suffix == "weight")     layer.ssm_conv1d_w = tensor;
+            else if (suffix == "bias")  layer.ssm_conv1d_b = tensor;
             else return false;
         }
         // Gated DeltaNet (GDN) weights (Qwen3.5)
@@ -509,7 +509,7 @@ static bool assign_tensor(Model& model, const std::string& name,
         else if (field == "ssm_alpha")  assign_quant(layer.gdn_alpha, layer.gdn_alpha_qtype, tensor);
         else if (field == "ssm_beta")   assign_quant(layer.gdn_beta,  layer.gdn_beta_qtype,  tensor);
         // Router bias (Nemotron MoE)
-        else if (field == "exp_probs_b") assign(layer.moe_router_bias, tensor);
+        else if (field == "exp_probs_b") layer.moe_router_bias = tensor;
         else return false;
         return true;
     }
@@ -523,13 +523,13 @@ static bool assign_tensor(Model& model, const std::string& name,
         // Gemma 4 scale tensors
         if (subfield == "scale") {
             if (field == "ffn_gate_inp") {
-                assign(layer.ffn_gate_inp_scale, tensor);
+                layer.ffn_gate_inp_scale = tensor;
                 return true;
             }
             if (field == "ffn_down_exps") {
                 // Per-expert output scale. Not yet consumed by the executor — store as
                 // router bias slot so weight_upload at least preserves it.
-                assign(layer.moe_router_bias, tensor);
+                layer.moe_router_bias = tensor;
                 return true;
             }
             return false;
@@ -546,15 +546,15 @@ static bool assign_tensor(Model& model, const std::string& name,
         // Per-expert vectors: assign to slot N. The layer-wide qtype mirror is
         // populated only on the first expert (all experts share the same qtype).
         if (field == "ffn_gate") {
-            assign(layer.expert_w_gate[expert_idx], tensor);
+            layer.expert_w_gate[expert_idx] = tensor;
             if (expert_idx == 0) layer.expert_gate_qtype = qtype;
         }
         else if (field == "ffn_up") {
-            assign(layer.expert_w_up[expert_idx], tensor);
+            layer.expert_w_up[expert_idx] = tensor;
             if (expert_idx == 0) layer.expert_up_qtype = qtype;
         }
         else if (field == "ffn_down") {
-            assign(layer.expert_w_down[expert_idx], tensor);
+            layer.expert_w_down[expert_idx] = tensor;
             if (expert_idx == 0) layer.expert_down_qtype = qtype;
         }
         else return false;

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -1,4 +1,5 @@
 #include "model/gguf_loader.h"
+#include "model/loader_assign.h"
 #include "model/model_arch.h"
 #include "model/tensor_kind_matcher.h"
 #include "quant/dequant_gpu.h"
@@ -341,22 +342,19 @@ static bool assign_tensor(Model& model, const std::string& name,
                            const Tensor& tensor, GgufWireType gtype) {
     auto qtype = static_cast<QType>(static_cast<uint32_t>(gtype));
     if (name == "token_embd.weight") {
-        model.tok_emb_ = tensor;
-        model.tok_emb_qtype_ = qtype;
+        assign_quant(model.tok_emb_, model.tok_emb_qtype_, tensor);
         return true;
     }
     if (name == "output_norm.weight") {
-        model.out_norm_ = tensor;
-        model.out_norm_qtype_ = qtype;
+        assign_quant(model.out_norm_, model.out_norm_qtype_, tensor);
         return true;
     }
     if (name == "rope_freqs.weight") {
-        model.layers_[0].rope_freqs = tensor;
+        assign(model.layers_[0].rope_freqs, tensor);
         return true;
     }
     if (name == "output.weight") {
-        model.out_proj_ = tensor;
-        model.out_proj_qtype_ = qtype;
+        assign_quant(model.out_proj_, model.out_proj_qtype_, tensor);
         return true;
     }
 
@@ -377,8 +375,8 @@ static bool assign_tensor(Model& model, const std::string& name,
     // 3-part: "blk.{i}.{name}" — SSM scalar/vector tensors without .weight/.bias suffix
     if (parts.size() == 3) {
         const auto& field = parts[2];
-        if      (field == "ssm_a") layer.ssm_a = tensor;
-        else if (field == "ssm_d") layer.ssm_d = tensor;
+        if      (field == "ssm_a") assign(layer.ssm_a, tensor);
+        else if (field == "ssm_d") assign(layer.ssm_d, tensor);
         else return false;
         return true;
     }
@@ -390,21 +388,21 @@ static bool assign_tensor(Model& model, const std::string& name,
 
         // Attention projections: distinguish weight vs bias
         if (field == "attn_q") {
-            if (suffix == "bias")       { layer.q_bias = tensor; }
-            else                        { layer.wq = tensor; layer.wq_qtype = qtype; }
+            if (suffix == "bias")       assign(layer.q_bias, tensor);
+            else                        assign_quant(layer.wq, layer.wq_qtype, tensor);
         }
         else if (field == "attn_k") {
-            if (suffix == "bias")       { layer.k_bias = tensor; }
-            else                        { layer.wk = tensor; layer.wk_qtype = qtype; }
+            if (suffix == "bias")       assign(layer.k_bias, tensor);
+            else                        assign_quant(layer.wk, layer.wk_qtype, tensor);
         }
         else if (field == "attn_v") {
-            if (suffix == "bias")       { layer.v_bias = tensor; }
-            else                        { layer.wv = tensor; layer.wv_qtype = qtype; }
+            if (suffix == "bias")       assign(layer.v_bias, tensor);
+            else                        assign_quant(layer.wv, layer.wv_qtype, tensor);
         }
-        else if (field == "attn_output") { layer.wo = tensor; layer.wo_qtype = qtype; }
-        else if (field == "attn_norm")     layer.attn_norm = tensor;
-        else if (field == "attn_q_norm") layer.attn_q_norm = tensor;
-        else if (field == "attn_k_norm") layer.attn_k_norm = tensor;
+        else if (field == "attn_output") assign_quant(layer.wo, layer.wo_qtype, tensor);
+        else if (field == "attn_norm")   assign(layer.attn_norm, tensor);
+        else if (field == "attn_q_norm") assign(layer.attn_q_norm, tensor);
+        else if (field == "attn_k_norm") assign(layer.attn_k_norm, tensor);
         // Fused QKV: either standard attention (Phi-4) or GDN (Qwen3.5)
         else if (field == "attn_qkv") {
             const auto& cfg = model.config();
@@ -416,8 +414,7 @@ static bool assign_tensor(Model& model, const std::string& name,
                                     2 * cfg.ssm_group_count * cfg.ssm_state_size;
             if (cfg.ssm_inner_size > 0 && total_rows == ssm_conv_channels) {
                 // GDN layer: treat attn_qkv as ssm_in (fused projection → conv1d input)
-                layer.ssm_in = tensor;
-                layer.ssm_in_qtype = qtype;
+                assign_quant(layer.ssm_in, layer.ssm_in_qtype, tensor);
             } else {
                 // Standard fused QKV: split into separate Q, K, V
                 // For Qwen3.5 attention: Q has 2× output (Q + gate interleaved),
@@ -430,65 +427,65 @@ static bool assign_tensor(Model& model, const std::string& name,
                 int64_t q_shape[4] = {q_rows, d_model, 1, 1};
                 int64_t kv_shape[4] = {k_rows, d_model, 1, 1};
 
-                layer.wq = Tensor(base, tensor.qtype, 2, q_shape, tensor.on_device);
-                layer.wq_qtype = qtype;
-                layer.wk = Tensor(base + static_cast<size_t>(q_rows) * row_bytes,
-                                   tensor.qtype, 2, kv_shape, tensor.on_device);
-                layer.wk_qtype = qtype;
-                layer.wv = Tensor(base + static_cast<size_t>(q_rows + k_rows) * row_bytes,
-                                   tensor.qtype, 2, kv_shape, tensor.on_device);
-                layer.wv_qtype = qtype;
+                Tensor q_t(base, tensor.qtype, 2, q_shape, tensor.on_device);
+                Tensor k_t(base + static_cast<size_t>(q_rows) * row_bytes,
+                           tensor.qtype, 2, kv_shape, tensor.on_device);
+                Tensor v_t(base + static_cast<size_t>(q_rows + k_rows) * row_bytes,
+                           tensor.qtype, 2, kv_shape, tensor.on_device);
+                assign_quant(layer.wq, layer.wq_qtype, q_t);
+                assign_quant(layer.wk, layer.wk_qtype, k_t);
+                assign_quant(layer.wv, layer.wv_qtype, v_t);
             }
         }
         // Post-layer norms (Gemma-3)
-        else if (field == "post_attention_norm") layer.post_attn_norm = tensor;
-        else if (field == "post_ffw_norm")       layer.post_ffn_norm = tensor;
+        else if (field == "post_attention_norm") assign(layer.post_attn_norm, tensor);
+        else if (field == "post_ffw_norm")       assign(layer.post_ffn_norm, tensor);
         // Gemma 4: parallel shared MLP + MoE expert branch norms
-        else if (field == "pre_ffw_norm_2")      layer.ffn_pre_norm_2 = tensor;
-        else if (field == "post_ffw_norm_1")     layer.ffn_post_norm_1 = tensor;
-        else if (field == "post_ffw_norm_2")     layer.ffn_post_norm_2 = tensor;
-        else if (field == "layer_output_scale")  layer.layer_out_scale = tensor;
-        else if (field == "rope_freqs")          layer.rope_freqs = tensor;
+        else if (field == "pre_ffw_norm_2")      assign(layer.ffn_pre_norm_2, tensor);
+        else if (field == "post_ffw_norm_1")     assign(layer.ffn_post_norm_1, tensor);
+        else if (field == "post_ffw_norm_2")     assign(layer.ffn_post_norm_2, tensor);
+        else if (field == "layer_output_scale")  assign(layer.layer_out_scale, tensor);
+        else if (field == "rope_freqs")          assign(layer.rope_freqs, tensor);
         // Gemma 4: fused gate+up experts: [n_experts, n_ff_exp*2, d_model]
         // We keep it packed; the MoE executor handles de-interleaving at dispatch.
         else if (field == "ffn_gate_up_exps") {
-            layer.expert_gate_packed = tensor;  // reuse gate packed slot with full fused tensor
-            layer.expert_gate_qtype = qtype;
+            // Reuses gate packed slot with full fused tensor.
             // Mark fused by leaving expert_up_packed null — executor detects this.
+            assign_quant(layer.expert_gate_packed, layer.expert_gate_qtype, tensor);
         }
         // FFN
-        else if (field == "ffn_gate")    { layer.w_gate = tensor; layer.w_gate_qtype = qtype; }
-        else if (field == "ffn_up")      { layer.w_up = tensor; layer.w_up_qtype = qtype; }
-        else if (field == "ffn_down")    { layer.w_down = tensor; layer.w_down_qtype = qtype; }
-        else if (field == "ffn_norm")      layer.ffn_norm = tensor;
+        else if (field == "ffn_gate")    assign_quant(layer.w_gate, layer.w_gate_qtype, tensor);
+        else if (field == "ffn_up")      assign_quant(layer.w_up,   layer.w_up_qtype,   tensor);
+        else if (field == "ffn_down")    assign_quant(layer.w_down, layer.w_down_qtype, tensor);
+        else if (field == "ffn_norm")    assign(layer.ffn_norm, tensor);
         else if (field == "ffn_gate_inp") {
             // Distinguish .weight (the gate matrix) from .scale (per-channel multiplier).
             // Gemma 4 stores `blk.X.ffn_gate_inp.scale` as a 4-part tensor name; without
             // this branch the scale would be silently misassigned to layer.moe_gate.
-            if (suffix == "scale") layer.ffn_gate_inp_scale = tensor;
-            else                   layer.moe_gate = tensor;
+            if (suffix == "scale") assign(layer.ffn_gate_inp_scale, tensor);
+            else                   assign(layer.moe_gate, tensor);
         }
         // Packed expert tensors: 3D [n_experts, rows, cols]
-        else if (field == "ffn_gate_exps") { layer.expert_gate_packed = tensor; layer.expert_gate_qtype = qtype; }
-        else if (field == "ffn_up_exps")   { layer.expert_up_packed = tensor; layer.expert_up_qtype = qtype; }
+        else if (field == "ffn_gate_exps") assign_quant(layer.expert_gate_packed, layer.expert_gate_qtype, tensor);
+        else if (field == "ffn_up_exps")   assign_quant(layer.expert_up_packed,   layer.expert_up_qtype,   tensor);
         else if (field == "ffn_down_exps") {
             // Distinguish .weight (the per-expert FFN down weights) from .scale
             // (per-expert output multiplier, shape [n_expert]). Same 4-part-name
             // bug as ffn_gate_inp.scale: the scale tensor would otherwise overwrite
             // expert_down_packed.
-            if (suffix == "scale") layer.expert_down_scale = tensor;
-            else                   { layer.expert_down_packed = tensor; layer.expert_down_qtype = qtype; }
+            if (suffix == "scale") assign(layer.expert_down_scale, tensor);
+            else                   assign_quant(layer.expert_down_packed, layer.expert_down_qtype, tensor);
         }
         // Shared expert (always-active, e.g. Nemotron/DeepSeek)
-        else if (field == "ffn_gate_shexp") { layer.w_gate_shared = tensor; layer.w_gate_shared_qtype = qtype; }
-        else if (field == "ffn_up_shexp")   { layer.w_up_shared = tensor; layer.w_up_shared_qtype = qtype; }
-        else if (field == "ffn_down_shexp") { layer.w_down_shared = tensor; layer.w_down_shared_qtype = qtype; }
+        else if (field == "ffn_gate_shexp") assign_quant(layer.w_gate_shared, layer.w_gate_shared_qtype, tensor);
+        else if (field == "ffn_up_shexp")   assign_quant(layer.w_up_shared,   layer.w_up_shared_qtype,   tensor);
+        else if (field == "ffn_down_shexp") assign_quant(layer.w_down_shared, layer.w_down_shared_qtype, tensor);
         // Qwen3-Next / Qwen3.6 per-token sigmoid gate on the shared expert
         // output. 1D [d_model] FP32 projection; sigmoid(cur @ W) yields [M, 1].
-        else if (field == "ffn_gate_inp_shexp") { layer.shared_expert_gate_inp = tensor; }
+        else if (field == "ffn_gate_inp_shexp") assign(layer.shared_expert_gate_inp, tensor);
         // SSM weights (Mamba2)
-        else if (field == "ssm_in")   { layer.ssm_in = tensor; layer.ssm_in_qtype = qtype; }
-        else if (field == "ssm_out")  { layer.ssm_out = tensor; layer.ssm_out_qtype = qtype; }
+        else if (field == "ssm_in")   assign_quant(layer.ssm_in,  layer.ssm_in_qtype,  tensor);
+        else if (field == "ssm_out")  assign_quant(layer.ssm_out, layer.ssm_out_qtype, tensor);
         else if (field == "ssm_dt") {
             // Some converters (Qwen3.5-27B-mxfp4) emit A_log under the name
             // "ssm_dt.weight" — a 1D vector of shape [n_heads]. Differentiate
@@ -496,23 +493,23 @@ static bool assign_tensor(Model& model, const std::string& name,
             // weight → ssm_a (per-head A_log). Without this branch the weight
             // silently overwrites the bias and ssm_a stays null, causing the
             // GDN scan kernel to NULL-deref A_log[h] on first launch.
-            if (suffix == "bias")        layer.ssm_dt_b = tensor;
-            else if (suffix == "weight") layer.ssm_a = tensor;
+            if (suffix == "bias")        assign(layer.ssm_dt_b, tensor);
+            else if (suffix == "weight") assign(layer.ssm_a, tensor);
             else return false;
         }
-        else if (field == "ssm_norm")   layer.ssm_norm_w = tensor;
+        else if (field == "ssm_norm")   assign(layer.ssm_norm_w, tensor);
         // SSM conv1d: "blk.{i}.ssm_conv1d.weight" / "blk.{i}.ssm_conv1d.bias"
         else if (field == "ssm_conv1d") {
-            if (suffix == "weight")     layer.ssm_conv1d_w = tensor;
-            else if (suffix == "bias")  layer.ssm_conv1d_b = tensor;
+            if (suffix == "weight")     assign(layer.ssm_conv1d_w, tensor);
+            else if (suffix == "bias")  assign(layer.ssm_conv1d_b, tensor);
             else return false;
         }
         // Gated DeltaNet (GDN) weights (Qwen3.5)
-        else if (field == "attn_gate")  { layer.gdn_gate  = tensor; layer.gdn_gate_qtype  = qtype; }
-        else if (field == "ssm_alpha")  { layer.gdn_alpha = tensor; layer.gdn_alpha_qtype = qtype; }
-        else if (field == "ssm_beta")   { layer.gdn_beta  = tensor; layer.gdn_beta_qtype  = qtype; }
+        else if (field == "attn_gate")  assign_quant(layer.gdn_gate,  layer.gdn_gate_qtype,  tensor);
+        else if (field == "ssm_alpha")  assign_quant(layer.gdn_alpha, layer.gdn_alpha_qtype, tensor);
+        else if (field == "ssm_beta")   assign_quant(layer.gdn_beta,  layer.gdn_beta_qtype,  tensor);
         // Router bias (Nemotron MoE)
-        else if (field == "exp_probs_b") layer.moe_router_bias = tensor;
+        else if (field == "exp_probs_b") assign(layer.moe_router_bias, tensor);
         else return false;
         return true;
     }
@@ -526,13 +523,13 @@ static bool assign_tensor(Model& model, const std::string& name,
         // Gemma 4 scale tensors
         if (subfield == "scale") {
             if (field == "ffn_gate_inp") {
-                layer.ffn_gate_inp_scale = tensor;
+                assign(layer.ffn_gate_inp_scale, tensor);
                 return true;
             }
             if (field == "ffn_down_exps") {
                 // Per-expert output scale. Not yet consumed by the executor — store as
                 // router bias slot so weight_upload at least preserves it.
-                layer.moe_router_bias = tensor;
+                assign(layer.moe_router_bias, tensor);
                 return true;
             }
             return false;
@@ -546,9 +543,20 @@ static bool assign_tensor(Model& model, const std::string& name,
         int n_experts = model.config().n_experts;
         if (expert_idx < 0 || expert_idx >= n_experts) return false;
 
-        if      (field == "ffn_gate") { layer.expert_w_gate[expert_idx] = tensor; if (expert_idx == 0) layer.expert_gate_qtype = qtype; }
-        else if (field == "ffn_up")   { layer.expert_w_up[expert_idx] = tensor; if (expert_idx == 0) layer.expert_up_qtype = qtype; }
-        else if (field == "ffn_down") { layer.expert_w_down[expert_idx] = tensor; if (expert_idx == 0) layer.expert_down_qtype = qtype; }
+        // Per-expert vectors: assign to slot N. The layer-wide qtype mirror is
+        // populated only on the first expert (all experts share the same qtype).
+        if (field == "ffn_gate") {
+            assign(layer.expert_w_gate[expert_idx], tensor);
+            if (expert_idx == 0) layer.expert_gate_qtype = qtype;
+        }
+        else if (field == "ffn_up") {
+            assign(layer.expert_w_up[expert_idx], tensor);
+            if (expert_idx == 0) layer.expert_up_qtype = qtype;
+        }
+        else if (field == "ffn_down") {
+            assign(layer.expert_w_down[expert_idx], tensor);
+            if (expert_idx == 0) layer.expert_down_qtype = qtype;
+        }
         else return false;
         return true;
     }

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -354,11 +354,11 @@ static bool assign_tensor(Model& model, const std::string& name,
                            const Tensor& tensor, GgufWireType gtype) {
     auto qtype = static_cast<QType>(static_cast<uint32_t>(gtype));
     if (name == "token_embd.weight") {
-        assign_quant(model.tok_emb_, model.tok_emb_qtype_, tensor);
+        assign_quant(model.tok_emb_, tensor);
         return true;
     }
     if (name == "output_norm.weight") {
-        assign_quant(model.out_norm_, model.out_norm_qtype_, tensor);
+        assign_quant(model.out_norm_, tensor);
         return true;
     }
     if (name == "rope_freqs.weight") {
@@ -366,7 +366,7 @@ static bool assign_tensor(Model& model, const std::string& name,
         return true;
     }
     if (name == "output.weight") {
-        assign_quant(model.out_proj_, model.out_proj_qtype_, tensor);
+        assign_quant(model.out_proj_, tensor);
         return true;
     }
 
@@ -401,17 +401,17 @@ static bool assign_tensor(Model& model, const std::string& name,
         // Attention projections: distinguish weight vs bias
         if (field == "attn_q") {
             if (suffix == "bias")       layer.q_bias = tensor;
-            else                        assign_quant(layer.wq, layer.wq_qtype, tensor);
+            else                        assign_quant(layer.wq, tensor);
         }
         else if (field == "attn_k") {
             if (suffix == "bias")       layer.k_bias = tensor;
-            else                        assign_quant(layer.wk, layer.wk_qtype, tensor);
+            else                        assign_quant(layer.wk, tensor);
         }
         else if (field == "attn_v") {
             if (suffix == "bias")       layer.v_bias = tensor;
-            else                        assign_quant(layer.wv, layer.wv_qtype, tensor);
+            else                        assign_quant(layer.wv, tensor);
         }
-        else if (field == "attn_output") assign_quant(layer.wo, layer.wo_qtype, tensor);
+        else if (field == "attn_output") assign_quant(layer.wo, tensor);
         else if (field == "attn_norm")   layer.attn_norm = tensor;
         else if (field == "attn_q_norm") layer.attn_q_norm = tensor;
         else if (field == "attn_k_norm") layer.attn_k_norm = tensor;
@@ -426,7 +426,7 @@ static bool assign_tensor(Model& model, const std::string& name,
                                     2 * cfg.ssm_group_count * cfg.ssm_state_size;
             if (cfg.ssm_inner_size > 0 && total_rows == ssm_conv_channels) {
                 // GDN layer: treat attn_qkv as ssm_in (fused projection → conv1d input)
-                assign_quant(layer.ssm_in, layer.ssm_in_qtype, tensor);
+                assign_quant(layer.ssm_in, tensor);
             } else {
                 // Standard fused QKV: split into separate Q, K, V
                 // For Qwen3.5 attention: Q has 2× output (Q + gate interleaved),
@@ -444,9 +444,9 @@ static bool assign_tensor(Model& model, const std::string& name,
                            tensor.qtype, 2, kv_shape, tensor.on_device);
                 Tensor v_t(base + static_cast<size_t>(q_rows + k_rows) * row_bytes,
                            tensor.qtype, 2, kv_shape, tensor.on_device);
-                assign_quant(layer.wq, layer.wq_qtype, q_t);
-                assign_quant(layer.wk, layer.wk_qtype, k_t);
-                assign_quant(layer.wv, layer.wv_qtype, v_t);
+                assign_quant(layer.wq, q_t);
+                assign_quant(layer.wk, k_t);
+                assign_quant(layer.wv, v_t);
             }
         }
         // Post-layer norms (Gemma-3)
@@ -463,12 +463,12 @@ static bool assign_tensor(Model& model, const std::string& name,
         else if (field == "ffn_gate_up_exps") {
             // Reuses gate packed slot with full fused tensor.
             // Mark fused by leaving expert_up_packed null — executor detects this.
-            assign_quant(layer.expert_gate_packed, layer.expert_gate_qtype, tensor);
+            assign_quant(layer.expert_gate_packed, tensor);
         }
         // FFN
-        else if (field == "ffn_gate")    assign_quant(layer.w_gate, layer.w_gate_qtype, tensor);
-        else if (field == "ffn_up")      assign_quant(layer.w_up,   layer.w_up_qtype,   tensor);
-        else if (field == "ffn_down")    assign_quant(layer.w_down, layer.w_down_qtype, tensor);
+        else if (field == "ffn_gate")    assign_quant(layer.w_gate, tensor);
+        else if (field == "ffn_up")      assign_quant(layer.w_up, tensor);
+        else if (field == "ffn_down")    assign_quant(layer.w_down, tensor);
         else if (field == "ffn_norm")    layer.ffn_norm = tensor;
         else if (field == "ffn_gate_inp") {
             // Distinguish .weight (the gate matrix) from .scale (per-channel multiplier).
@@ -478,26 +478,26 @@ static bool assign_tensor(Model& model, const std::string& name,
             else                   layer.moe_gate = tensor;
         }
         // Packed expert tensors: 3D [n_experts, rows, cols]
-        else if (field == "ffn_gate_exps") assign_quant(layer.expert_gate_packed, layer.expert_gate_qtype, tensor);
-        else if (field == "ffn_up_exps")   assign_quant(layer.expert_up_packed,   layer.expert_up_qtype,   tensor);
+        else if (field == "ffn_gate_exps") assign_quant(layer.expert_gate_packed, tensor);
+        else if (field == "ffn_up_exps")   assign_quant(layer.expert_up_packed, tensor);
         else if (field == "ffn_down_exps") {
             // Distinguish .weight (the per-expert FFN down weights) from .scale
             // (per-expert output multiplier, shape [n_expert]). Same 4-part-name
             // bug as ffn_gate_inp.scale: the scale tensor would otherwise overwrite
             // expert_down_packed.
             if (suffix == "scale") layer.expert_down_scale = tensor;
-            else                   assign_quant(layer.expert_down_packed, layer.expert_down_qtype, tensor);
+            else                   assign_quant(layer.expert_down_packed, tensor);
         }
         // Shared expert (always-active, e.g. Nemotron/DeepSeek)
-        else if (field == "ffn_gate_shexp") assign_quant(layer.w_gate_shared, layer.w_gate_shared_qtype, tensor);
-        else if (field == "ffn_up_shexp")   assign_quant(layer.w_up_shared,   layer.w_up_shared_qtype,   tensor);
-        else if (field == "ffn_down_shexp") assign_quant(layer.w_down_shared, layer.w_down_shared_qtype, tensor);
+        else if (field == "ffn_gate_shexp") assign_quant(layer.w_gate_shared, tensor);
+        else if (field == "ffn_up_shexp")   assign_quant(layer.w_up_shared, tensor);
+        else if (field == "ffn_down_shexp") assign_quant(layer.w_down_shared, tensor);
         // Qwen3-Next / Qwen3.6 per-token sigmoid gate on the shared expert
         // output. 1D [d_model] FP32 projection; sigmoid(cur @ W) yields [M, 1].
         else if (field == "ffn_gate_inp_shexp") layer.shared_expert_gate_inp = tensor;
         // SSM weights (Mamba2)
-        else if (field == "ssm_in")   assign_quant(layer.ssm_in,  layer.ssm_in_qtype,  tensor);
-        else if (field == "ssm_out")  assign_quant(layer.ssm_out, layer.ssm_out_qtype, tensor);
+        else if (field == "ssm_in")   assign_quant(layer.ssm_in, tensor);
+        else if (field == "ssm_out")  assign_quant(layer.ssm_out, tensor);
         else if (field == "ssm_dt") {
             // Some converters (Qwen3.5-27B-mxfp4) emit A_log under the name
             // "ssm_dt.weight" — a 1D vector of shape [n_heads]. Differentiate
@@ -517,9 +517,9 @@ static bool assign_tensor(Model& model, const std::string& name,
             else return false;
         }
         // Gated DeltaNet (GDN) weights (Qwen3.5)
-        else if (field == "attn_gate")  assign_quant(layer.gdn_gate,  layer.gdn_gate_qtype,  tensor);
-        else if (field == "ssm_alpha")  assign_quant(layer.gdn_alpha, layer.gdn_alpha_qtype, tensor);
-        else if (field == "ssm_beta")   assign_quant(layer.gdn_beta,  layer.gdn_beta_qtype,  tensor);
+        else if (field == "attn_gate")  assign_quant(layer.gdn_gate, tensor);
+        else if (field == "ssm_alpha")  assign_quant(layer.gdn_alpha, tensor);
+        else if (field == "ssm_beta")   assign_quant(layer.gdn_beta, tensor);
         // Router bias (Nemotron MoE)
         else if (field == "exp_probs_b") layer.moe_router_bias = tensor;
         else return false;
@@ -559,15 +559,15 @@ static bool assign_tensor(Model& model, const std::string& name,
         // populated only on the first expert (all experts share the same qtype).
         if (field == "ffn_gate") {
             layer.expert_w_gate[expert_idx] = tensor;
-            if (expert_idx == 0) layer.expert_gate_qtype = qtype;
+            if (expert_idx == 0) layer.expert_gate_packed.qtype = qtype;
         }
         else if (field == "ffn_up") {
             layer.expert_w_up[expert_idx] = tensor;
-            if (expert_idx == 0) layer.expert_up_qtype = qtype;
+            if (expert_idx == 0) layer.expert_up_packed.qtype = qtype;
         }
         else if (field == "ffn_down") {
             layer.expert_w_down[expert_idx] = tensor;
-            if (expert_idx == 0) layer.expert_down_qtype = qtype;
+            if (expert_idx == 0) layer.expert_down_packed.qtype = qtype;
         }
         else return false;
         return true;
@@ -1140,7 +1140,7 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
     // Weight tying: if no output.weight, share token_embd
     if (model->out_proj_.data == nullptr && model->tok_emb_.data != nullptr) {
         model->out_proj_ = model->tok_emb_;
-        model->out_proj_qtype_ = model->tok_emb_qtype_;
+        model->out_proj_.qtype = model->tok_emb_.qtype;
         IMP_LOG_INFO("Weight tying: output projection shares token embedding");
     }
 
@@ -1154,13 +1154,13 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
                 ly.w_up.shape[0] == 2 * cfg.d_ff) {
                 int64_t d_model = ly.w_up.shape[1];
                 int64_t d_ff = cfg.d_ff;
-                size_t row_bytes = qtype_row_bytes(ly.w_up_qtype, d_model);
+                size_t row_bytes = qtype_row_bytes(ly.w_up.qtype, d_model);
 
                 uint8_t* base = static_cast<uint8_t*>(ly.w_up.data);
                 int64_t half_shape[4] = {d_ff, d_model, 1, 1};
 
                 ly.w_gate = Tensor(base, ly.w_up.qtype, 2, half_shape, ly.w_up.on_device);
-                ly.w_gate_qtype = ly.w_up_qtype;
+                ly.w_gate.qtype = ly.w_up.qtype;
                 ly.w_up = Tensor(base + static_cast<size_t>(d_ff) * row_bytes,
                                   ly.w_up.qtype, 2, half_shape, ly.w_up.on_device);
                 // w_up_qtype unchanged
@@ -1197,12 +1197,12 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
             // alongside expert tensors → remap dense FFN to shared expert.
             // Some GGUF converters output shared experts as ffn_gate/ffn_up/ffn_down.
             if (has_moe && has_dense && !has_shared) {
-                ly.w_gate_shared = ly.w_gate;   ly.w_gate_shared_qtype = ly.w_gate_qtype;
-                ly.w_up_shared   = ly.w_up;     ly.w_up_shared_qtype   = ly.w_up_qtype;
-                ly.w_down_shared = ly.w_down;   ly.w_down_shared_qtype = ly.w_down_qtype;
-                ly.w_gate = Tensor();  ly.w_gate_qtype = QType::NONE;
-                ly.w_up   = Tensor();  ly.w_up_qtype   = QType::NONE;
-                ly.w_down = Tensor();  ly.w_down_qtype = QType::NONE;
+                ly.w_gate_shared = ly.w_gate;   ly.w_gate_shared.qtype = ly.w_gate.qtype;
+                ly.w_up_shared   = ly.w_up;     ly.w_up_shared.qtype   = ly.w_up.qtype;
+                ly.w_down_shared = ly.w_down;   ly.w_down_shared.qtype = ly.w_down.qtype;
+                ly.w_gate = Tensor();  ly.w_gate.qtype = QType::NONE;
+                ly.w_up   = Tensor();  ly.w_up.qtype   = QType::NONE;
+                ly.w_down = Tensor();  ly.w_down.qtype = QType::NONE;
                 n_remapped++;
                 has_shared = true;
             }

--- a/src/model/gguf_loader.h
+++ b/src/model/gguf_loader.h
@@ -31,7 +31,7 @@ enum class GGUFValueType : uint32_t {
 };
 
 // GGML tensor quantization types
-enum class GGMLType : uint32_t {
+enum class GgufWireType : uint32_t {
     F32     = 0,
     F16     = 1,
     Q4_0    = 2,
@@ -66,25 +66,25 @@ enum class GGMLType : uint32_t {
 };
 
 // Block size (number of elements per quantization block)
-int ggml_blck_size(GGMLType type);
+int gguf_blck_size(GgufWireType type);
 
 // Bytes per block for quantized types, bytes per element for unquantized
-size_t ggml_type_size(GGMLType type);
+size_t gguf_type_size(GgufWireType type);
 
 // Total bytes for a row of n_elements of given type
-size_t ggml_row_size(GGMLType type, int64_t n_elements);
+size_t gguf_row_size(GgufWireType type, int64_t n_elements);
 
-// Convert GGML type to our DType (lossy for quantized types)
-DType ggml_type_to_dtype(GGMLType type);
+// Convert GGML type to our QType (lossy for quantized types)
+QType gguf_type_to_qtype(GgufWireType type);
 
-const char* ggml_type_name(GGMLType type);
+const char* gguf_type_name(GgufWireType type);
 
 // Tensor info parsed from GGUF file
 struct GGUFTensorInfo {
     std::string name;
     uint32_t n_dims;
     int64_t dims[4];     // GGUF order: dims[0] = innermost (fastest-changing)
-    GGMLType type;
+    GgufWireType type;
     uint64_t offset;     // relative to start of tensor data section
     const uint8_t* data_base = nullptr;  // shard data base pointer (for split GGUF)
 };

--- a/src/model/loader_assign.h
+++ b/src/model/loader_assign.h
@@ -34,10 +34,4 @@ inline void assign_quant_with_scales(Tensor& slot, QType& slot_qtype,
     slot_qtype = src.qtype;
 }
 
-// Plain assign for slots without a *_qtype mirror (norms, biases, RoPE
-// freqs, embeddings). The tensor's own qtype carries the type.
-inline void assign(Tensor& slot, const Tensor& src) {
-    slot = src;
-}
-
 } // namespace imp

--- a/src/model/loader_assign.h
+++ b/src/model/loader_assign.h
@@ -12,26 +12,21 @@
 
 namespace imp {
 
-// Assign a parsed tensor to a layer slot AND its qtype mirror field.
-// The tensor's own qtype is the canonical source; the mirror field is a
-// deprecated copy that gets read by some legacy dispatch sites. This
-// helper guarantees the two stay in sync.
-inline void assign_quant(Tensor& slot, QType& slot_qtype, const Tensor& src) {
+// Assign a parsed tensor to a layer slot. The tensor's own qtype field
+// carries the type — Stage G removed the per-layer *_qtype mirrors.
+inline void assign_quant(Tensor& slot, const Tensor& src) {
     slot = src;
-    slot_qtype = src.qtype;
 }
 
-// Variant that also wires NVFP4 / FP8 sidecar pointers on the tensor
-// itself. Used by SafeTensors / llm-compressor loaders where the
-// per-tensor scales come in as separate parsed tensors.
-inline void assign_quant_with_scales(Tensor& slot, QType& slot_qtype,
-                                     const Tensor& src,
+// Variant that also wires NVFP4 / FP8 sidecar pointers on the tensor.
+// Used by SafeTensors / llm-compressor loaders where the per-tensor
+// scales come in as separate parsed tensors.
+inline void assign_quant_with_scales(Tensor& slot, const Tensor& src,
                                      void* scales,
                                      float tensor_scale = 1.0f) {
     slot = src;
     slot.scales = scales;
     slot.tensor_scale = tensor_scale;
-    slot_qtype = src.qtype;
 }
 
 } // namespace imp

--- a/src/model/loader_assign.h
+++ b/src/model/loader_assign.h
@@ -27,7 +27,7 @@ inline void assign_quant(Tensor& slot, QType& slot_qtype, const Tensor& src) {
 inline void assign_quant_with_scales(Tensor& slot, QType& slot_qtype,
                                      const Tensor& src,
                                      void* scales,
-                                     void* tensor_scale = nullptr) {
+                                     float tensor_scale = 1.0f) {
     slot = src;
     slot.scales = scales;
     slot.tensor_scale = tensor_scale;

--- a/src/model/loader_assign.h
+++ b/src/model/loader_assign.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Loader helpers that keep tensor + qtype + sidecar-scales in lockstep so
+// no loader can silently forget to populate one of them. Used by the GGUF,
+// SafeTensors, and llm-compressor loaders.
+//
+// Once Stage G lands, the *_qtype mirror fields on TransformerLayer go
+// away entirely; the helpers will collapse to single-Tensor assigns then.
+
+#include "core/tensor.h"
+#include "core/qtype.h"
+
+namespace imp {
+
+// Assign a parsed tensor to a layer slot AND its qtype mirror field.
+// The tensor's own qtype is the canonical source; the mirror field is a
+// deprecated copy that gets read by some legacy dispatch sites. This
+// helper guarantees the two stay in sync.
+inline void assign_quant(Tensor& slot, QType& slot_qtype, const Tensor& src) {
+    slot = src;
+    slot_qtype = src.qtype;
+}
+
+// Variant that also wires NVFP4 / FP8 sidecar pointers on the tensor
+// itself. Used by SafeTensors / llm-compressor loaders where the
+// per-tensor scales come in as separate parsed tensors.
+inline void assign_quant_with_scales(Tensor& slot, QType& slot_qtype,
+                                     const Tensor& src,
+                                     void* scales,
+                                     void* tensor_scale = nullptr) {
+    slot = src;
+    slot.scales = scales;
+    slot.tensor_scale = tensor_scale;
+    slot_qtype = src.qtype;
+}
+
+// Plain assign for slots without a *_qtype mirror (norms, biases, RoPE
+// freqs, embeddings). The tensor's own qtype carries the type.
+inline void assign(Tensor& slot, const Tensor& src) {
+    slot = src;
+}
+
+} // namespace imp

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -44,9 +44,7 @@ public:
 
     ModelConfig config_;
     Tensor tok_emb_, out_norm_, out_proj_;
-    QType tok_emb_qtype_ = QType::NONE;
-    QType out_norm_qtype_ = QType::NONE;
-    QType out_proj_qtype_ = QType::NONE;
+    // (qtype mirrors removed in Stage G — read tok_emb_.qtype directly.)
     TransformerLayer::NvFP4PreQuantWeight nvfp4_out_proj_;  // prequant LM head scales
     TensorID out_proj_id = kInvalidTensorID;  // registry handle for LM head (Task 3.5)
     TensorID tok_emb_id  = kInvalidTensorID;  // registry handle for token embedding

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -30,7 +30,7 @@ public:
     // For Q8_0: dequantizes to FP16 on GPU.
     // For F16/BF16: direct upload.
     // For F32: converts to compute_dtype and uploads.
-    bool upload_weights_gpu(DType compute_dtype = DType::FP16, cudaStream_t stream = nullptr,
+    bool upload_weights_gpu(QType compute_dtype = QType::F16, cudaStream_t stream = nullptr,
                             size_t expert_reserve_bytes = 1ULL << 30);
 
     bool gpu_weights_ready() const { return gpu_weights_ready_; }
@@ -44,9 +44,9 @@ public:
 
     ModelConfig config_;
     Tensor tok_emb_, out_norm_, out_proj_;
-    GGMLQuantType tok_emb_qtype_ = GGMLQuantType::NONE;
-    GGMLQuantType out_norm_qtype_ = GGMLQuantType::NONE;
-    GGMLQuantType out_proj_qtype_ = GGMLQuantType::NONE;
+    QType tok_emb_qtype_ = QType::NONE;
+    QType out_norm_qtype_ = QType::NONE;
+    QType out_proj_qtype_ = QType::NONE;
     TransformerLayer::NvFP4PreQuantWeight nvfp4_out_proj_;  // prequant LM head scales
     TensorID out_proj_id = kInvalidTensorID;  // registry handle for LM head (Task 3.5)
     TensorID tok_emb_id  = kInvalidTensorID;  // registry handle for token embedding

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -103,15 +103,9 @@ struct TransformerLayer {
     // Packed expert tensors (3D: [n_experts, rows, cols]) loaded from GGUF *_exps
     // These are temporary: weight_upload slices them into the per-expert vectors above.
     Tensor expert_gate_packed, expert_up_packed, expert_down_packed;
-    QType expert_gate_qtype = QType::NONE;
-    QType expert_up_qtype   = QType::NONE;
-    QType expert_down_qtype = QType::NONE;
 
     // Shared expert (always-active, e.g. Nemotron/DeepSeek)
     Tensor w_up_shared, w_down_shared, w_gate_shared;
-    QType w_up_shared_qtype   = QType::NONE;
-    QType w_down_shared_qtype = QType::NONE;
-    QType w_gate_shared_qtype = QType::NONE;
 
     // Qwen3-Next / Qwen3.6 shared-expert input gate: a [d_model] FP32 projection
     // that, after sigmoid, produces a per-token scalar used to gate the shared
@@ -119,18 +113,11 @@ struct TransformerLayer {
     // `blk.{i}.ffn_gate_inp_shexp.weight`. Absent for Qwen2-MoE / Qwen3 MoE.
     Tensor shared_expert_gate_inp;
 
-    // Per-group scales for quantized weights (GPU, FP16)
-    Tensor wq_scales, wk_scales, wv_scales, wo_scales;
-    Tensor w_gate_scales, w_up_scales, w_down_scales;
-
-    // Store original GGML quant types for dequant dispatch
-    QType wq_qtype = QType::NONE;
-    QType wk_qtype = QType::NONE;
-    QType wv_qtype = QType::NONE;
-    QType wo_qtype = QType::NONE;
-    QType w_gate_qtype = QType::NONE;
-    QType w_up_qtype = QType::NONE;
-    QType w_down_qtype = QType::NONE;
+    // (Per-group scales now ride along on each tensor's .scales field —
+    //  see core/tensor.h. The legacy *_scales mirror fields were removed
+    //  in Stage F.)
+    //
+    // (qtype mirrors removed in Stage G — read tensor.qtype directly.)
 
     // WeightRegistry indices (populated by pre_dequant_weights, Phase 2+).
     // kInvalidTensorID means the corresponding Tensor is absent on this layer
@@ -185,16 +172,11 @@ struct TransformerLayer {
     Tensor ssm_dt_b;                      // dt bias
     Tensor ssm_a, ssm_d;                  // A (log) and D (skip connection)
     Tensor ssm_norm_w;                    // Group RMSNorm weight
-    QType ssm_in_qtype = QType::NONE;
-    QType ssm_out_qtype = QType::NONE;
 
     // Gated DeltaNet (GDN) weights (Qwen3.5 hybrid)
     Tensor gdn_gate;     // [d_model, inner_size] output gating projection
     Tensor gdn_alpha;    // [d_model, n_gdn_heads] delta rule decay
     Tensor gdn_beta;     // [d_model, n_gdn_heads] delta rule learning rate
-    QType gdn_gate_qtype  = QType::NONE;
-    QType gdn_alpha_qtype = QType::NONE;
-    QType gdn_beta_qtype  = QType::NONE;
 
     // Router bias (Nemotron MoE)
     Tensor moe_router_bias;

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -13,15 +13,6 @@ enum class FFNActivation { SWIGLU, GEGLU, RELU_SQR };
 // Norm placement relative to residual connection
 enum class NormPlacement { PRE_NORM, POST_NORM };
 
-// GGML quantization type stored alongside tensor for dequant dispatch
-enum class GGMLQuantType : uint32_t {
-    NONE = 0,
-    F32 = 0, F16 = 1, Q4_0 = 2, Q4_1 = 3,
-    Q5_0 = 6, Q5_1 = 7, Q8_0 = 8, Q8_1 = 9,
-    Q2_K = 10, Q3_K = 11, Q4_K = 12, Q5_K = 13,
-    Q6_K = 14, Q8_K = 15, BF16 = 30, MXFP4 = 31,
-};
-
 struct ModelConfig {
     ModelArch arch = ModelArch::GENERIC;
     int n_layers = 0, n_heads = 0, n_kv_heads = 0;
@@ -112,15 +103,15 @@ struct TransformerLayer {
     // Packed expert tensors (3D: [n_experts, rows, cols]) loaded from GGUF *_exps
     // These are temporary: weight_upload slices them into the per-expert vectors above.
     Tensor expert_gate_packed, expert_up_packed, expert_down_packed;
-    GGMLQuantType expert_gate_qtype = GGMLQuantType::NONE;
-    GGMLQuantType expert_up_qtype   = GGMLQuantType::NONE;
-    GGMLQuantType expert_down_qtype = GGMLQuantType::NONE;
+    QType expert_gate_qtype = QType::NONE;
+    QType expert_up_qtype   = QType::NONE;
+    QType expert_down_qtype = QType::NONE;
 
     // Shared expert (always-active, e.g. Nemotron/DeepSeek)
     Tensor w_up_shared, w_down_shared, w_gate_shared;
-    GGMLQuantType w_up_shared_qtype   = GGMLQuantType::NONE;
-    GGMLQuantType w_down_shared_qtype = GGMLQuantType::NONE;
-    GGMLQuantType w_gate_shared_qtype = GGMLQuantType::NONE;
+    QType w_up_shared_qtype   = QType::NONE;
+    QType w_down_shared_qtype = QType::NONE;
+    QType w_gate_shared_qtype = QType::NONE;
 
     // Qwen3-Next / Qwen3.6 shared-expert input gate: a [d_model] FP32 projection
     // that, after sigmoid, produces a per-token scalar used to gate the shared
@@ -133,13 +124,13 @@ struct TransformerLayer {
     Tensor w_gate_scales, w_up_scales, w_down_scales;
 
     // Store original GGML quant types for dequant dispatch
-    GGMLQuantType wq_qtype = GGMLQuantType::NONE;
-    GGMLQuantType wk_qtype = GGMLQuantType::NONE;
-    GGMLQuantType wv_qtype = GGMLQuantType::NONE;
-    GGMLQuantType wo_qtype = GGMLQuantType::NONE;
-    GGMLQuantType w_gate_qtype = GGMLQuantType::NONE;
-    GGMLQuantType w_up_qtype = GGMLQuantType::NONE;
-    GGMLQuantType w_down_qtype = GGMLQuantType::NONE;
+    QType wq_qtype = QType::NONE;
+    QType wk_qtype = QType::NONE;
+    QType wv_qtype = QType::NONE;
+    QType wo_qtype = QType::NONE;
+    QType w_gate_qtype = QType::NONE;
+    QType w_up_qtype = QType::NONE;
+    QType w_down_qtype = QType::NONE;
 
     // WeightRegistry indices (populated by pre_dequant_weights, Phase 2+).
     // kInvalidTensorID means the corresponding Tensor is absent on this layer
@@ -194,16 +185,16 @@ struct TransformerLayer {
     Tensor ssm_dt_b;                      // dt bias
     Tensor ssm_a, ssm_d;                  // A (log) and D (skip connection)
     Tensor ssm_norm_w;                    // Group RMSNorm weight
-    GGMLQuantType ssm_in_qtype = GGMLQuantType::NONE;
-    GGMLQuantType ssm_out_qtype = GGMLQuantType::NONE;
+    QType ssm_in_qtype = QType::NONE;
+    QType ssm_out_qtype = QType::NONE;
 
     // Gated DeltaNet (GDN) weights (Qwen3.5 hybrid)
     Tensor gdn_gate;     // [d_model, inner_size] output gating projection
     Tensor gdn_alpha;    // [d_model, n_gdn_heads] delta rule decay
     Tensor gdn_beta;     // [d_model, n_gdn_heads] delta rule learning rate
-    GGMLQuantType gdn_gate_qtype  = GGMLQuantType::NONE;
-    GGMLQuantType gdn_alpha_qtype = GGMLQuantType::NONE;
-    GGMLQuantType gdn_beta_qtype  = GGMLQuantType::NONE;
+    QType gdn_gate_qtype  = QType::NONE;
+    QType gdn_alpha_qtype = QType::NONE;
+    QType gdn_beta_qtype  = QType::NONE;
 
     // Router bias (Nemotron MoE)
     Tensor moe_router_bias;

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -221,23 +221,23 @@ static const JValue* jobj_find(const JValue& obj, const std::string& key) {
     return nullptr;
 }
 
-// ---- SafeTensors dtype string to DType ----
+// ---- SafeTensors dtype string to QType ----
 
-static DType safetensors_dtype(const std::string& s) {
-    if (s == "F32")  return DType::FP32;
-    if (s == "F16")  return DType::FP16;
-    if (s == "BF16") return DType::BF16;
-    if (s == "F64")  return DType::FP32;  // closest proxy
-    if (s == "I8")   return DType::INT8;
-    if (s == "U8")   return DType::INT8;   // treat unsigned byte as INT8
-    if (s == "I16")  return DType::INT32;  // closest proxy
-    if (s == "I32")  return DType::INT32;
-    if (s == "I64")  return DType::INT32;  // closest proxy
-    if (s == "BOOL") return DType::INT8;
-    if (s == "F8_E4M3") return DType::FP8_E4M3;
-    if (s == "F8_E5M2") return DType::FP8_E4M3;  // closest proxy
+static QType safetensors_dtype(const std::string& s) {
+    if (s == "F32")  return QType::F32;
+    if (s == "F16")  return QType::F16;
+    if (s == "BF16") return QType::BF16;
+    if (s == "F64")  return QType::F32;  // closest proxy
+    if (s == "I8")   return QType::INT8;
+    if (s == "U8")   return QType::INT8;   // treat unsigned byte as INT8
+    if (s == "I16")  return QType::INT32;  // closest proxy
+    if (s == "I32")  return QType::INT32;
+    if (s == "I64")  return QType::INT32;  // closest proxy
+    if (s == "BOOL") return QType::INT8;
+    if (s == "F8_E4M3") return QType::FP8_E4M3;
+    if (s == "F8_E5M2") return QType::FP8_E4M3;  // closest proxy
     IMP_LOG_WARN("Unknown SafeTensors dtype '%s', defaulting to FP32", s.c_str());
-    return DType::FP32;
+    return QType::F32;
 }
 
 // ---- Architecture detection from weight names ----
@@ -434,7 +434,7 @@ static bool load_shard(const std::string& path,
 
         const JValue* dtype_val = jobj_find(tensor_meta, "dtype");
         if (!dtype_val || dtype_val->type != JType::STRING) continue;
-        DType dtype = safetensors_dtype(dtype_val->str_val);
+        QType dtype = safetensors_dtype(dtype_val->str_val);
 
         const JValue* shape_val = jobj_find(tensor_meta, "shape");
         if (!shape_val || shape_val->type != JType::ARRAY) continue;

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -3,6 +3,7 @@
 #include "quant/dequant_gpu.h"
 #include "quant/dequant_gptq.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <algorithm>
@@ -1156,48 +1157,37 @@ static bool upload_expert_weights(
         //
         // IMP_EXPERT_OVERHEAD_PCT: explicit override (integer 0..50). Required
         // on WSL2/WDDM where the 10% auto-aggressive path may OOM at alloc time.
-        int overhead_pct;
-        bool user_set_overhead = false;
-        if (const char* s = getenv("IMP_EXPERT_OVERHEAD_PCT")) {
-            int v = atoi(s);
-            if (v >= 0 && v <= 50) {
-                overhead_pct = v;
-                user_set_overhead = true;
-            } else {
-                overhead_pct = 30;
-            }
-        } else {
+        // [moe] expert_overhead_pct: explicit override (0..50). Default 10
+        // requests aggressive auto-pick; values outside the range fall back
+        // to the conservative 30% reserve.
+        int overhead_pct = RuntimeConfig::current().moe.expert_overhead_pct;
+        if (overhead_pct < 0 || overhead_pct > 50) {
+            overhead_pct = 30;
+        } else if (overhead_pct == 10) {
             // Auto-pick: probe with aggressive 10%. If all experts fit, use it.
             // Else fall back to conservative 30%.
             size_t aggressive_overhead = static_cast<size_t>(free_mem * 10 / 100);
             size_t aggressive_reserve  = expert_reserve_bytes + aggressive_overhead;
             size_t aggressive_budget   = (free_mem > aggressive_reserve)
                                          ? (free_mem - aggressive_reserve) : 0;
-            if (aggressive_budget >= total_expert_bytes) {
-                overhead_pct = 10;
+            if (aggressive_budget < total_expert_bytes) {
+                overhead_pct = 30;
+            } else {
                 IMP_LOG_INFO("Expert offload: all experts fit with 10%% overhead "
-                             "(%.2f GiB experts, %.2f GiB free) — picking aggressive. "
-                             "Set IMP_EXPERT_OVERHEAD_PCT=30 to force conservative.",
+                             "(%.2f GiB experts, %.2f GiB free) — picking aggressive.",
                              total_expert_bytes / (1024.0*1024.0*1024.0),
                              free_mem / (1024.0*1024.0*1024.0));
-            } else {
-                overhead_pct = 30;
             }
         }
         size_t overhead = static_cast<size_t>(free_mem * overhead_pct / 100);
         size_t total_reserve = expert_reserve_bytes + overhead;
         size_t budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
-        (void)user_set_overhead;
 
-        // IMP_FORCE_HOST_EXPERTS=N: debug flag to force the last N MoE layers
-        // off-GPU regardless of budget. Use for reproducing host-resident path
-        // bugs (Q8_0 Gemma-4 gibberish) on a smaller quant that would normally
-        // fit entirely on GPU.
-        int force_host_n = 0;
-        if (const char* s = getenv("IMP_FORCE_HOST_EXPERTS")) {
-            force_host_n = atoi(s);
-            if (force_host_n < 0) force_host_n = 0;
-        }
+        // [moe] force_host_experts = N: debug flag forcing the last N MoE
+        // layers off-GPU regardless of budget. Use for reproducing host-
+        // resident path bugs on a smaller quant.
+        int force_host_n = RuntimeConfig::current().moe.force_host_experts;
+        if (force_host_n < 0) force_host_n = 0;
 
         if (budget >= total_expert_bytes && force_host_n == 0) {
             // All experts fit

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1056,21 +1056,56 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i,
             }
         }
     }
-    // SSM tensors that MUST stay F32: A_log, D, dt_bias (scan kernel uses float*)
+    // SSM scalar/vector tensors that MUST end up as FP32 on device, because
+    // the GDN/Mamba scan kernels read them as `const float*` (A_log, D,
+    // dt_bias). GGUF emits them as F32 — direct upload. SafeTensors with
+    // bfloat16 model dtype emits them as BF16, and a previous engine version
+    // simply h2d_copy'd the bytes — the scan kernel then reinterpreted BF16
+    // as F32 (sign/exponent/mantissa all wrong) and produced NaN within the
+    // first GDN layer. Convert on host before upload so the scan always sees
+    // real FP32 values.
     for (Tensor* t : {&L.ssm_a, &L.ssm_d, &L.ssm_dt_b}) {
-        if (t->data && !t->on_device) {
-            size_t bytes = t->nbytes();
-            void* d_data = nullptr;
-            checked_cuda_malloc(&d_data, bytes);
-            if (!d_data) {
-                IMP_LOG_ERROR("Failed to allocate GPU memory for SSM F32 tensor in layer %d", i);
-                return false;
-            }
-            h2d_copy(d_data, t->data, bytes, ctx.stream);
-            ctx.gpu_allocs.push_back(d_data);
-            t->data = d_data;
-            t->on_device = true;
+        if (!t->data || t->on_device) continue;
+        const int64_t n_elem = t->numel();
+        const size_t fp32_bytes = static_cast<size_t>(n_elem) * sizeof(float);
+        void* d_data = nullptr;
+        checked_cuda_malloc(&d_data, fp32_bytes);
+        if (!d_data) {
+            IMP_LOG_ERROR("Failed to allocate GPU memory for SSM F32 tensor in layer %d", i);
+            return false;
         }
+
+        if (t->qtype == QType::F32 || t->qtype == QType::NONE) {
+            // GGUF path — already FP32.
+            h2d_copy(d_data, t->data, fp32_bytes, ctx.stream);
+        } else if (t->qtype == QType::BF16) {
+            // SafeTensors path — convert BF16 → F32 on host.
+            std::vector<float> h_fp32(static_cast<size_t>(n_elem));
+            const uint16_t* src = static_cast<const uint16_t*>(t->data);
+            for (int64_t k = 0; k < n_elem; ++k) {
+                uint32_t bits = static_cast<uint32_t>(src[k]) << 16;
+                std::memcpy(&h_fp32[k], &bits, sizeof(float));
+            }
+            h2d_copy(d_data, h_fp32.data(), fp32_bytes, ctx.stream);
+        } else if (t->qtype == QType::F16) {
+            // Defensive: F16 weight → F32 (no model emits this for SSM scalars
+            // currently, but keep symmetric with BF16).
+            std::vector<float> h_fp32(static_cast<size_t>(n_elem));
+            const uint16_t* src = static_cast<const uint16_t*>(t->data);
+            for (int64_t k = 0; k < n_elem; ++k) {
+                h_fp32[k] = fp16_to_float(src[k]);
+            }
+            h2d_copy(d_data, h_fp32.data(), fp32_bytes, ctx.stream);
+        } else {
+            IMP_LOG_ERROR("SSM scalar tensor has unexpected qtype %u (layer %d)",
+                          static_cast<unsigned>(t->qtype), i);
+            return false;
+        }
+
+        ctx.gpu_allocs.push_back(d_data);
+        t->data = d_data;
+        t->qtype = QType::F32;
+        t->on_device = true;
     }
 
     // Gated DeltaNet (GDN) weights (Qwen3.5).

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -226,9 +226,9 @@ static uint16_t float_to_fp16(float val) {
 // For F32: converts to FP16 on host, uploads. scales_out stays empty.
 // ---------------------------------------------------------------------------
 
-static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
+static bool upload_weight(Tensor& weight, QType qtype,
                           Tensor& scales_out,
-                          DType compute_dtype,
+                          QType compute_dtype,
                           cudaStream_t stream,
                           std::vector<void*>& gpu_allocs,
                           bool raw_quant = true) {
@@ -243,7 +243,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
     // Split on CPU: upload only the 16-byte data portion to GPU.
     // Saves ~6% VRAM (1 byte/block scale overhead eliminated from GPU buffer).
     // Scales are extracted to a separate host buffer, uploaded in executor_workspace.
-    if (qtype == GGMLQuantType::MXFP4) {
+    if (qtype == QType::MXFP4) {
         if (weight.ndim < 2) return false;
         int64_t N = weight.shape[0];
         int64_t K = weight.shape[1];
@@ -268,14 +268,14 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
         h2d_copy(d_data, h_buf.data(), total_bytes, stream);
         gpu_allocs.push_back(d_data);
         int64_t new_shape[4] = {N, K, 0, 0};
-        weight = Tensor(d_data, DType::INT4, 2, new_shape, true);
+        weight = Tensor(d_data, QType::INT4, 2, new_shape, true);
         IMP_LOG_DEBUG("  MXFP4 upload: [%lld, %lld] %.2f MiB (data+scales split)",
                      (long long)N, (long long)K, total_bytes / (1024.0 * 1024.0));
         return true;
     }
 
     // ---- Q4_0 ----
-    if (qtype == GGMLQuantType::Q4_0) {
+    if (qtype == QType::Q4_0) {
         if (weight.ndim < 2) {
             IMP_LOG_WARN("Q4_0 weight has < 2 dims, skipping upload");
             return false;
@@ -287,7 +287,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
         // Raw upload: keep quantized bytes on GPU for dp4a GEMV decode path.
         // Prefill uses fp16_cache or on-the-fly dequant_gpu → cuBLAS GEMM.
         if (raw_quant) {
-            size_t raw_bytes = static_cast<size_t>(N) * ggml_quant_row_bytes(qtype, K);
+            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
             void* d_data = nullptr;
             checked_cuda_malloc(&d_data, raw_bytes);
             if (!d_data) return false;
@@ -296,7 +296,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
 
             // Logical shape [N, K] — qtype tells executor data is raw quantized
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, DType::FP16, 2, new_shape, true);
+            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
             return true;
         }
 
@@ -347,17 +347,17 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
 
         // Update weight tensor to point to packed nibbles on GPU
         int64_t new_shape[4] = {N, static_cast<int64_t>(half_K), 0, 0};
-        weight = Tensor(d_nibbles, DType::INT4, 2, new_shape, true);
+        weight = Tensor(d_nibbles, QType::INT4, 2, new_shape, true);
 
         // Set scales output
         int64_t scales_shape[4] = {N, static_cast<int64_t>(num_groups), 0, 0};
-        scales_out = Tensor(d_scales, DType::FP16, 2, scales_shape, true);
+        scales_out = Tensor(d_scales, QType::F16, 2, scales_shape, true);
 
         return true;
     }
 
     // ---- Q8_0 ----
-    if (qtype == GGMLQuantType::Q8_0) {
+    if (qtype == QType::Q8_0) {
         if (weight.ndim < 2) {
             IMP_LOG_WARN("Q8_0 weight has < 2 dims, skipping upload");
             return false;
@@ -368,7 +368,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
 
         // Raw upload: keep quantized bytes on GPU, dequant on-the-fly in executor
         if (raw_quant) {
-            size_t raw_bytes = static_cast<size_t>(N) * ggml_quant_row_bytes(qtype, K);
+            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
             void* d_data = nullptr;
             checked_cuda_malloc(&d_data, raw_bytes);
             if (!d_data) return false;
@@ -377,7 +377,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
 
             // Logical shape [N, K] — qtype tells executor data is raw quantized
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, DType::FP16, 2, new_shape, true);
+            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
             return true;
         }
 
@@ -414,12 +414,12 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
         gpu_allocs.push_back(d_data);
 
         int64_t new_shape[4] = {N, K, 0, 0};
-        weight = Tensor(d_data, DType::FP16, 2, new_shape, true);
+        weight = Tensor(d_data, QType::F16, 2, new_shape, true);
         return true;
     }
 
     // ---- Q6_K ----
-    if (qtype == GGMLQuantType::Q6_K) {
+    if (qtype == QType::Q6_K) {
         if (weight.ndim < 2) {
             IMP_LOG_WARN("Q6_K weight has < 2 dims, skipping upload");
             return false;
@@ -430,7 +430,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
 
         // Raw upload: keep quantized bytes on GPU, dequant on-the-fly in executor
         if (raw_quant) {
-            size_t raw_bytes = static_cast<size_t>(N) * ggml_quant_row_bytes(qtype, K);
+            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
             void* d_data = nullptr;
             checked_cuda_malloc(&d_data, raw_bytes);
             if (!d_data) return false;
@@ -438,7 +438,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
             gpu_allocs.push_back(d_data);
 
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, DType::FP16, 2, new_shape, true);
+            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
             return true;
         }
 
@@ -489,7 +489,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
         gpu_allocs.push_back(d_data);
 
         int64_t new_shape[4] = {N, K, 0, 0};
-        weight = Tensor(d_data, DType::FP16, 2, new_shape, true);
+        weight = Tensor(d_data, QType::F16, 2, new_shape, true);
         return true;
     }
 
@@ -501,7 +501,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
 
         if (raw_quant) {
             // Upload raw quantized bytes — executor dequants on-the-fly
-            size_t raw_bytes = static_cast<size_t>(N) * ggml_quant_row_bytes(qtype, K);
+            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
             void* d_data = nullptr;
             checked_cuda_malloc(&d_data, raw_bytes);
             if (!d_data) return false;
@@ -515,11 +515,11 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
             IMP_LOG_DEBUG("Upload raw qtype=%u [%ldx%ld] %zu bytes -> GPU %p",
                           (unsigned)qtype, (long)N, (long)K, raw_bytes, d_data);
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, DType::FP16, 2, new_shape, true);
+            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
             return true;
         } else {
             // Dequant on GPU: upload raw → dequant to FP16 → free raw
-            size_t raw_bytes = static_cast<size_t>(N) * ggml_quant_row_bytes(qtype, K);
+            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
             void* d_raw = nullptr;
             checked_cuda_malloc(&d_raw, raw_bytes);
             if (!d_raw) return false;
@@ -536,13 +536,13 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
             IMP_CUDA_CHECK_LOG(cudaFree(d_raw));
             gpu_allocs.push_back(d_fp16);
 
-            weight = Tensor(d_fp16, DType::FP16, weight.ndim, weight.shape, true);
+            weight = Tensor(d_fp16, QType::F16, weight.ndim, weight.shape, true);
             return true;
         }
     }
 
     // ---- F16: direct upload ----
-    if (qtype == GGMLQuantType::F16) {
+    if (qtype == QType::F16) {
         size_t bytes = weight.nbytes();
         void* d_data = nullptr;
         checked_cuda_malloc(&d_data, bytes);
@@ -555,7 +555,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
         return true;
     }
     // ---- BF16 (GGUF): convert to FP16 on host, then upload ----
-    if (qtype == GGMLQuantType::BF16) {
+    if (qtype == QType::BF16) {
         int64_t n_elem = weight.numel();
         const uint16_t* src = static_cast<const uint16_t*>(weight.data);
         std::vector<uint16_t> h_fp16(static_cast<size_t>(n_elem));
@@ -571,14 +571,14 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
         if (!d_data) return false;
         h2d_copy(d_data, h_fp16.data(), bytes, stream);
         gpu_allocs.push_back(d_data);
-        weight = Tensor(d_data, DType::FP16, weight.ndim, weight.shape, true);
+        weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
         return true;
     }
 
     // ---- F32: convert to FP16 on host, then upload ----
-    if (qtype == GGMLQuantType::F32 || qtype == GGMLQuantType::NONE) {
+    if (qtype == QType::F32 || qtype == QType::NONE) {
         // BF16 (SafeTensors non-quantized weights): convert to FP16
-        if (weight.dtype == DType::BF16) {
+        if (weight.qtype == QType::BF16) {
             int64_t n_elem = weight.numel();
             const uint16_t* src = static_cast<const uint16_t*>(weight.data);
             std::vector<uint16_t> h_fp16(static_cast<size_t>(n_elem));
@@ -595,11 +595,11 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
             if (!d_data) return false;
             h2d_copy(d_data, h_fp16.data(), bytes, stream);
             gpu_allocs.push_back(d_data);
-            weight = Tensor(d_data, DType::FP16, weight.ndim, weight.shape, true);
+            weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
             return true;
         }
         // NONE maps to F32 (both are enum value 0)
-        if (weight.dtype != DType::FP32) {
+        if (weight.qtype != QType::F32) {
             // If it's not actually FP32 data (e.g. INT8/U8 packed FP4), direct upload
             size_t bytes = weight.nbytes();
             void* d_data = nullptr;
@@ -627,7 +627,7 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
         h2d_copy(d_data, h_fp16.data(), bytes, stream);
         gpu_allocs.push_back(d_data);
 
-        weight = Tensor(d_data, DType::FP16, weight.ndim, weight.shape, true);
+        weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
         return true;
     }
 
@@ -642,8 +642,8 @@ static bool upload_weight(Tensor& weight, GGMLQuantType qtype,
 // ---------------------------------------------------------------------------
 
 static bool upload_unquantized_weight(Tensor& weight,
-                                      GGMLQuantType qtype,
-                                      DType compute_dtype,
+                                      QType qtype,
+                                      QType compute_dtype,
                                       cudaStream_t stream,
                                       std::vector<void*>& gpu_allocs,
                                       bool raw_quant = true) {
@@ -660,9 +660,9 @@ size_t Model::estimate_expert_bytes() const {
     size_t total = 0;
     for (int i = 0; i < n_layers(); ++i) {
         const TransformerLayer& L = layers_[i];
-        auto add_packed = [&](const Tensor& p, GGMLQuantType qt) {
+        auto add_packed = [&](const Tensor& p, QType qt) {
             if (!p.data || p.ndim < 3 || !dequant_gpu_supported(qt)) return;
-            size_t row_bytes = ggml_quant_row_bytes(qt, p.shape[2]);
+            size_t row_bytes = qtype_row_bytes(qt, p.shape[2]);
             total += static_cast<size_t>(p.shape[0]) * p.shape[1] * row_bytes;
         };
         add_packed(L.expert_gate_packed, L.expert_gate_qtype);
@@ -677,7 +677,7 @@ size_t Model::estimate_expert_bytes() const {
 // Passed by reference to avoid >8 params on every helper call.
 // ---------------------------------------------------------------------------
 struct UploadCtx {
-    DType compute_dtype;
+    QType compute_dtype;
     cudaStream_t stream;
     std::vector<void*>& gpu_allocs;
     std::vector<void*>& host_pinned;
@@ -709,7 +709,7 @@ struct UploadCtx {
 #define UPLOAD_UNQUANT_OR_FAIL(tensor, msg, layer_idx, ctx) \
     do { \
         if ((tensor).data && !(tensor).on_device) { \
-            if (!upload_unquantized_weight((tensor), GGMLQuantType::NONE, \
+            if (!upload_unquantized_weight((tensor), QType::NONE, \
                                            (ctx).compute_dtype, (ctx).stream, \
                                            (ctx).gpu_allocs)) { \
                 IMP_LOG_ERROR("Failed to upload " msg " for layer %d", (layer_idx)); \
@@ -722,9 +722,9 @@ struct UploadCtx {
 // upload_embeddings_and_output: token embedding, output norm, output projection
 // ---------------------------------------------------------------------------
 static bool upload_embeddings_and_output(
-        Tensor& tok_emb, GGMLQuantType& tok_emb_qtype,
-        Tensor& out_norm, GGMLQuantType out_norm_qtype,
-        Tensor& out_proj, GGMLQuantType& out_proj_qtype,
+        Tensor& tok_emb, QType& tok_emb_qtype,
+        Tensor& out_norm, QType out_norm_qtype,
+        Tensor& out_proj, QType& out_proj_qtype,
         const UploadCtx& ctx) {
     // Upload token embedding
     // Embedding lookup only supports Q8_0/Q6_K natively; other quant types
@@ -732,8 +732,8 @@ static bool upload_embeddings_and_output(
     // embedding gather works.
     const void* tok_emb_host_ptr = tok_emb.data;  // save for weight-tying check below
     if (tok_emb.data && !tok_emb.on_device) {
-        bool emb_raw = (tok_emb_qtype == GGMLQuantType::Q8_0 ||
-                        tok_emb_qtype == GGMLQuantType::Q6_K);
+        bool emb_raw = (tok_emb_qtype == QType::Q8_0 ||
+                        tok_emb_qtype == QType::Q6_K);
         if (!upload_unquantized_weight(tok_emb, tok_emb_qtype, ctx.compute_dtype,
                                        ctx.stream, ctx.gpu_allocs, emb_raw)) {
             IMP_LOG_ERROR("Failed to upload token embedding");
@@ -741,8 +741,8 @@ static bool upload_embeddings_and_output(
         }
         // If we dequanted to FP16, update the qtype so embedding_lookup
         // uses the FP16 path.
-        if (!emb_raw && tok_emb.dtype == DType::FP16) {
-            tok_emb_qtype = GGMLQuantType::F16;
+        if (!emb_raw && tok_emb.qtype == QType::F16) {
+            tok_emb_qtype = QType::F16;
         }
     }
 
@@ -769,9 +769,9 @@ static bool upload_embeddings_and_output(
             out_proj = tok_emb;
             IMP_LOG_INFO("Output projection shares GPU data with token embedding (weight tying)");
         } else {
-            bool raw_ok = (out_proj_qtype == GGMLQuantType::Q6_K ||
-                           out_proj_qtype == GGMLQuantType::Q8_0 ||
-                           out_proj_qtype == GGMLQuantType::Q4_0);
+            bool raw_ok = (out_proj_qtype == QType::Q6_K ||
+                           out_proj_qtype == QType::Q8_0 ||
+                           out_proj_qtype == QType::Q4_0);
             if (!upload_unquantized_weight(out_proj, out_proj_qtype, ctx.compute_dtype,
                                            ctx.stream, ctx.gpu_allocs,
                                            /*raw_quant=*/raw_ok)) {
@@ -781,8 +781,8 @@ static bool upload_embeddings_and_output(
             // Mirror tok_emb: if upload host-dequanted to FP16, update the qtype
             // so downstream LM-head dispatch uses the FP16 path instead of
             // re-interpreting the FP16 bytes as the original quant block format.
-            if (!raw_ok && out_proj.dtype == DType::FP16) {
-                out_proj_qtype = GGMLQuantType::F16;
+            if (!raw_ok && out_proj.qtype == QType::F16) {
+                out_proj_qtype = QType::F16;
             }
         }
     }
@@ -880,7 +880,7 @@ static bool upload_gptq_weight(const TransformerLayer::GPTQWeight& gptq,
 
     // 8. Set output tensor
     int64_t out_shape[4] = {N, K, 0, 0};
-    output = Tensor(d_out, DType::FP16, 2, out_shape, true);
+    output = Tensor(d_out, QType::F16, 2, out_shape, true);
     gpu_allocs.push_back(d_out);
 
     return true;
@@ -923,7 +923,7 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i,
     // Attention biases (Qwen2-style Q/K/V biases, F32)
     for (auto* bias : {&L.q_bias, &L.k_bias, &L.v_bias}) {
         if (bias->data && !bias->on_device) {
-            if (!upload_unquantized_weight(*bias, GGMLQuantType::NONE,
+            if (!upload_unquantized_weight(*bias, QType::NONE,
                                            ctx.compute_dtype, ctx.stream,
                                            ctx.gpu_allocs)) {
                 IMP_LOG_ERROR("Failed to upload attention bias for layer %d", i);
@@ -938,7 +938,7 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i,
                        &L.ffn_gate_inp_scale, &L.layer_out_scale,
                        &L.expert_down_scale}) {
         if (norm->data && !norm->on_device) {
-            if (!upload_unquantized_weight(*norm, GGMLQuantType::NONE,
+            if (!upload_unquantized_weight(*norm, QType::NONE,
                                            ctx.compute_dtype, ctx.stream,
                                            ctx.gpu_allocs)) {
                 IMP_LOG_ERROR("Failed to upload post-layer norm for layer %d", i);
@@ -950,7 +950,7 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i,
     // rope_freqs: upload as raw FP32 (NOT converted to FP16).
     // The RoPE kernel reads these as float* — FP16 conversion would corrupt them.
     if (L.rope_freqs.data && !L.rope_freqs.on_device &&
-        L.rope_freqs.dtype == DType::FP32) {
+        L.rope_freqs.qtype == QType::F32) {
         IMP_LOG_INFO("Layer %d: uploading rope_freqs as raw FP32 (%lld elements)",
                      i, L.rope_freqs.numel());
         size_t bytes = L.rope_freqs.nbytes();
@@ -1026,7 +1026,7 @@ static bool upload_layer_ffn_weights(TransformerLayer& L, int i,
     // Qwen3-Next / Qwen3.6 shared-expert input gate (FP32 [d_model]).
     if (L.shared_expert_gate_inp.data && !L.shared_expert_gate_inp.on_device) {
         Tensor dummy_scales;
-        UPLOAD_OR_FAIL(L.shared_expert_gate_inp, GGMLQuantType::F32, dummy_scales,
+        UPLOAD_OR_FAIL(L.shared_expert_gate_inp, QType::F32, dummy_scales,
                        "shared_expert_gate_inp", i, ctx);
     }
 
@@ -1048,7 +1048,7 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i,
     // SSM tensors that convert to compute_dtype (FP16): conv1d weights, norm
     for (Tensor* t : {&L.ssm_conv1d_w, &L.ssm_conv1d_b, &L.ssm_norm_w}) {
         if (t->data && !t->on_device) {
-            if (!upload_unquantized_weight(*t, GGMLQuantType::NONE, ctx.compute_dtype,
+            if (!upload_unquantized_weight(*t, QType::NONE, ctx.compute_dtype,
                                            ctx.stream, ctx.gpu_allocs)) {
                 IMP_LOG_ERROR("Failed to upload SSM tensor for layer %d", i);
                 return false;
@@ -1110,9 +1110,9 @@ static bool upload_expert_weights(
     std::vector<size_t> layer_expert_bytes(n_layers, 0);
     for (int i = 0; i < n_layers; ++i) {
         const TransformerLayer& L = layers[i];
-        auto add_packed = [&](const Tensor& p, GGMLQuantType qt) {
+        auto add_packed = [&](const Tensor& p, QType qt) {
             if (!p.data || p.ndim < 3 || !dequant_gpu_supported(qt)) return;
-            size_t row_bytes = ggml_quant_row_bytes(qt, p.shape[2]);
+            size_t row_bytes = qtype_row_bytes(qt, p.shape[2]);
             size_t bytes = static_cast<size_t>(p.shape[0]) * p.shape[1] * row_bytes;
             layer_expert_bytes[i] += bytes;
             total_expert_bytes += bytes;
@@ -1264,7 +1264,7 @@ static bool upload_expert_weights(
         //    - For F16/BF16/F32: dequant/upload and slice into per-expert views.
         // B) Per-expert 2D tensors: upload individually (legacy per-expert GGUF format)
 
-        auto upload_packed_experts = [&](Tensor& packed, GGMLQuantType qtype,
+        auto upload_packed_experts = [&](Tensor& packed, QType qtype,
                                          std::vector<Tensor>& expert_vec,
                                          const char* name) -> bool {
             if (!packed.data || packed.ndim < 3) return true;  // nothing to do
@@ -1277,7 +1277,7 @@ static bool upload_expert_weights(
             // Path A1: Quantized types -- upload raw bytes to GPU if they fit,
             // otherwise keep on host (mmap'd) with optional pinning for H2D.
             if (dequant_gpu_supported(qtype)) {
-                size_t row_bytes = ggml_quant_row_bytes(qtype, cols);
+                size_t row_bytes = qtype_row_bytes(qtype, cols);
                 size_t expert_raw = static_cast<size_t>(rows) * row_bytes;
                 size_t total_raw = static_cast<size_t>(n_experts) * expert_raw;
 
@@ -1332,8 +1332,8 @@ static bool upload_expert_weights(
                         ctx.host_pinned.push_back(packed.data);
                         IMP_LOG_DEBUG("  %s: %d experts, raw %s pinned on host (%.2f MiB)",
                                       name, n_experts,
-                                      qtype == GGMLQuantType::Q6_K ? "Q6_K" :
-                                      qtype == GGMLQuantType::Q8_0 ? "Q8_0" : "Q4_0",
+                                      qtype == QType::Q6_K ? "Q6_K" :
+                                      qtype == QType::Q8_0 ? "Q8_0" : "Q4_0",
                                       total_raw / (1024.0 * 1024.0));
                     } else {
                         IMP_LOG_WARN("  %s: cudaHostRegister failed (%s), H2D will be slower",
@@ -1346,7 +1346,7 @@ static bool upload_expert_weights(
 
             // Path A2: Unquantized (F16/BF16/F32) -- dequant to FP16, slice per-expert.
             int64_t flat_shape[4] = {static_cast<int64_t>(n_experts) * rows, cols, 0, 0};
-            Tensor flat(packed.data, packed.dtype, 2, flat_shape, packed.on_device);
+            Tensor flat(packed.data, packed.qtype, 2, flat_shape, packed.on_device);
 
             Tensor dummy_scales;
             if (!upload_weight(flat, qtype, dummy_scales, ctx.compute_dtype,
@@ -1360,7 +1360,7 @@ static bool upload_expert_weights(
             for (int e = 0; e < n_experts; e++) {
                 char* ptr = static_cast<char*>(flat.data) + e * expert_bytes;
                 int64_t eshape[4] = {rows, cols, 0, 0};
-                expert_vec[e] = Tensor(ptr, DType::FP16, 2, eshape, true);
+                expert_vec[e] = Tensor(ptr, QType::F16, 2, eshape, true);
             }
             packed = Tensor();
             return true;
@@ -1395,7 +1395,7 @@ static bool upload_expert_weights(
             int64_t fused_rows = L.expert_gate_packed.shape[1];
             int64_t cols = L.expert_gate_packed.shape[2];
             int64_t half_rows = fused_rows / 2;
-            size_t row_bytes = ggml_quant_row_bytes(L.expert_gate_qtype, cols);
+            size_t row_bytes = qtype_row_bytes(L.expert_gate_qtype, cols);
             size_t half_raw = static_cast<size_t>(n_exp) * half_rows * row_bytes;
             size_t src_pitch = static_cast<size_t>(fused_rows) * row_bytes;
             size_t dst_pitch = static_cast<size_t>(half_rows) * row_bytes;
@@ -1426,8 +1426,8 @@ static bool upload_expert_weights(
             }
 
             int64_t split_shape[4] = {n_exp, half_rows, cols, 0};
-            L.expert_gate_packed = Tensor(gate_buf, L.expert_gate_packed.dtype, 3, split_shape, false);
-            L.expert_up_packed   = Tensor(up_buf,   L.expert_gate_packed.dtype, 3, split_shape, false);
+            L.expert_gate_packed = Tensor(gate_buf, L.expert_gate_packed.qtype, 3, split_shape, false);
+            L.expert_up_packed   = Tensor(up_buf,   L.expert_gate_packed.qtype, 3, split_shape, false);
             L.expert_up_qtype    = L.expert_gate_qtype;
             ctx.host_pinned_allocs.push_back(gate_buf);
             ctx.host_pinned_allocs.push_back(up_buf);
@@ -1445,7 +1445,7 @@ static bool upload_expert_weights(
             int64_t fused_rows = L.expert_gate_packed.shape[1];
             int64_t cols = L.expert_gate_packed.shape[2];
             int64_t half_rows = fused_rows / 2;
-            size_t row_bytes = ggml_quant_row_bytes(L.expert_gate_qtype, cols);
+            size_t row_bytes = qtype_row_bytes(L.expert_gate_qtype, cols);
             size_t half_raw = static_cast<size_t>(n_exp) * half_rows * row_bytes;
 
             // Memory-efficient split: allocate only ONE half-sized buffer for the
@@ -1500,8 +1500,8 @@ static bool upload_expert_weights(
             // Reuse fused buffer (now compacted to half size) as gate_packed.
             int64_t split_shape[4] = {n_exp, half_rows, cols, 0};
             void* gate_buf = L.expert_gate_packed.data;
-            L.expert_gate_packed = Tensor(gate_buf, L.expert_gate_packed.dtype, 3, split_shape, true);
-            L.expert_up_packed = Tensor(up_buf, L.expert_gate_packed.dtype, 3, split_shape, true);
+            L.expert_gate_packed = Tensor(gate_buf, L.expert_gate_packed.qtype, 3, split_shape, true);
+            L.expert_up_packed = Tensor(up_buf, L.expert_gate_packed.qtype, 3, split_shape, true);
             L.expert_up_qtype = L.expert_gate_qtype;
             // gate_buf is already in ctx.gpu_allocs from the original upload.
             ctx.gpu_allocs.push_back(up_buf);
@@ -1557,7 +1557,7 @@ static bool upload_expert_weights(
 // Model::upload_weights_gpu
 // ---------------------------------------------------------------------------
 
-bool Model::upload_weights_gpu(DType compute_dtype, cudaStream_t stream,
+bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream,
                                 size_t expert_reserve_bytes) {
     if (gpu_weights_ready_) {
         IMP_LOG_WARN("Weights already uploaded to GPU");

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -268,7 +268,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
         h2d_copy(d_data, h_buf.data(), total_bytes, stream);
         gpu_allocs.push_back(d_data);
         int64_t new_shape[4] = {N, K, 0, 0};
-        weight = Tensor(d_data, QType::INT4, 2, new_shape, true);
+        weight = Tensor(d_data, qtype, 2, new_shape, true);
         IMP_LOG_DEBUG("  MXFP4 upload: [%lld, %lld] %.2f MiB (data+scales split)",
                      (long long)N, (long long)K, total_bytes / (1024.0 * 1024.0));
         return true;
@@ -296,7 +296,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
 
             // Logical shape [N, K] — qtype tells executor data is raw quantized
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+            weight = Tensor(d_data, qtype, 2, new_shape, true);
             return true;
         }
 
@@ -347,7 +347,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
 
         // Update weight tensor to point to packed nibbles on GPU
         int64_t new_shape[4] = {N, static_cast<int64_t>(half_K), 0, 0};
-        weight = Tensor(d_nibbles, QType::INT4, 2, new_shape, true);
+        weight = Tensor(d_nibbles, qtype, 2, new_shape, true);
 
         // Set scales output
         int64_t scales_shape[4] = {N, static_cast<int64_t>(num_groups), 0, 0};
@@ -377,7 +377,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
 
             // Logical shape [N, K] — qtype tells executor data is raw quantized
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+            weight = Tensor(d_data, qtype, 2, new_shape, true);
             return true;
         }
 
@@ -438,7 +438,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
             gpu_allocs.push_back(d_data);
 
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+            weight = Tensor(d_data, qtype, 2, new_shape, true);
             return true;
         }
 
@@ -515,7 +515,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
             IMP_LOG_DEBUG("Upload raw qtype=%u [%ldx%ld] %zu bytes -> GPU %p",
                           (unsigned)qtype, (long)N, (long)K, raw_bytes, d_data);
             int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+            weight = Tensor(d_data, qtype, 2, new_shape, true);
             return true;
         } else {
             // Dequant on GPU: upload raw → dequant to FP16 → free raw

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -228,7 +228,6 @@ static uint16_t float_to_fp16(float val) {
 // ---------------------------------------------------------------------------
 
 static bool upload_weight(Tensor& weight, QType qtype,
-                          Tensor& scales_out,
                           QType compute_dtype,
                           cudaStream_t stream,
                           std::vector<void*>& gpu_allocs,
@@ -346,13 +345,11 @@ static bool upload_weight(Tensor& weight, QType qtype,
         h2d_copy(d_scales, h_scales.data(), scales_bytes, stream);
         gpu_allocs.push_back(d_scales);
 
-        // Update weight tensor to point to packed nibbles on GPU
+        // Update weight tensor to point to packed nibbles on GPU; the
+        // FP16 scales buffer rides along as Tensor::scales (sidecar).
         int64_t new_shape[4] = {N, static_cast<int64_t>(half_K), 0, 0};
         weight = Tensor(d_nibbles, qtype, 2, new_shape, true);
-
-        // Set scales output
-        int64_t scales_shape[4] = {N, static_cast<int64_t>(num_groups), 0, 0};
-        scales_out = Tensor(d_scales, QType::F16, 2, scales_shape, true);
+        weight.scales = d_scales;
 
         return true;
     }
@@ -632,9 +629,27 @@ static bool upload_weight(Tensor& weight, QType qtype,
         return true;
     }
 
-    IMP_LOG_WARN("Unsupported quant type %u for GPU upload, skipping",
-                 static_cast<unsigned>(qtype));
-    return false;
+    // Fallback: raw direct upload of opaque bytes (preserves qtype). Used for
+    // NVFP4/MXFP4/FP4_E2M1/INT8/INT4 packed-byte payloads that the SafeTensors
+    // loader categorises as "raw bytes" — e.g. NVFP4 prequant `weight_packed`
+    // arrives with qtype=INT8 (U8 wire dtype) and is later promoted to
+    // qtype=NVFP4 by executor_pre_dequant.cu Phase 0.
+    {
+        size_t bytes = weight.nbytes();
+        if (bytes == 0) {
+            IMP_LOG_WARN("Empty raw weight for qtype %u, skipping",
+                         static_cast<unsigned>(qtype));
+            return false;
+        }
+        void* d_data = nullptr;
+        checked_cuda_malloc(&d_data, bytes);
+        if (!d_data) return false;
+        h2d_copy(d_data, weight.data, bytes, stream);
+        gpu_allocs.push_back(d_data);
+        weight.data = d_data;
+        weight.on_device = true;
+        return true;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -648,8 +663,7 @@ static bool upload_unquantized_weight(Tensor& weight,
                                       cudaStream_t stream,
                                       std::vector<void*>& gpu_allocs,
                                       bool raw_quant = true) {
-    Tensor dummy_scales;
-    return upload_weight(weight, qtype, dummy_scales, compute_dtype,
+    return upload_weight(weight, qtype, compute_dtype,
                          stream, gpu_allocs, raw_quant);
 }
 
@@ -666,9 +680,9 @@ size_t Model::estimate_expert_bytes() const {
             size_t row_bytes = qtype_row_bytes(qt, p.shape[2]);
             total += static_cast<size_t>(p.shape[0]) * p.shape[1] * row_bytes;
         };
-        add_packed(L.expert_gate_packed, L.expert_gate_qtype);
-        add_packed(L.expert_up_packed, L.expert_up_qtype);
-        add_packed(L.expert_down_packed, L.expert_down_qtype);
+        add_packed(L.expert_gate_packed, L.expert_gate_packed.qtype);
+        add_packed(L.expert_up_packed, L.expert_up_packed.qtype);
+        add_packed(L.expert_down_packed, L.expert_down_packed.qtype);
     }
     return total;
 }
@@ -689,18 +703,18 @@ struct UploadCtx {
 // UPLOAD_OR_FAIL / UPLOAD_UNQUANT_OR_FAIL: reduces the per-weight boilerplate
 // of calling upload_weight() + error log + early return.
 // ---------------------------------------------------------------------------
-#define UPLOAD_OR_FAIL(tensor, qtype, scales, msg, layer_idx, ctx) \
+#define UPLOAD_OR_FAIL(tensor, qtype, msg, layer_idx, ctx) \
     do { \
-        if (!upload_weight((tensor), (qtype), (scales), (ctx).compute_dtype, \
+        if (!upload_weight((tensor), (qtype), (ctx).compute_dtype, \
                            (ctx).stream, (ctx).gpu_allocs)) { \
             IMP_LOG_ERROR("Failed to upload " msg " for layer %d", (layer_idx)); \
             return false; \
         } \
     } while (0)
 
-#define UPLOAD_OR_FAIL_RAW(tensor, qtype, scales, raw, msg, layer_idx, ctx) \
+#define UPLOAD_OR_FAIL_RAW(tensor, qtype, raw, msg, layer_idx, ctx) \
     do { \
-        if (!upload_weight((tensor), (qtype), (scales), (ctx).compute_dtype, \
+        if (!upload_weight((tensor), (qtype), (ctx).compute_dtype, \
                            (ctx).stream, (ctx).gpu_allocs, (raw))) { \
             IMP_LOG_ERROR("Failed to upload " msg " for layer %d", (layer_idx)); \
             return false; \
@@ -723,33 +737,30 @@ struct UploadCtx {
 // upload_embeddings_and_output: token embedding, output norm, output projection
 // ---------------------------------------------------------------------------
 static bool upload_embeddings_and_output(
-        Tensor& tok_emb, QType& tok_emb_qtype,
-        Tensor& out_norm, QType out_norm_qtype,
-        Tensor& out_proj, QType& out_proj_qtype,
+        Tensor& tok_emb,
+        Tensor& out_norm,
+        Tensor& out_proj,
         const UploadCtx& ctx) {
     // Upload token embedding
     // Embedding lookup only supports Q8_0/Q6_K natively; other quant types
     // need to be dequanted to FP16 (raw_quant=false) so the standard FP16
-    // embedding gather works.
+    // embedding gather works. tok_emb.qtype is updated in-place by
+    // upload_weight if a host-side dequant occurs.
     const void* tok_emb_host_ptr = tok_emb.data;  // save for weight-tying check below
+    const QType tok_emb_orig_qtype = tok_emb.qtype;
     if (tok_emb.data && !tok_emb.on_device) {
-        bool emb_raw = (tok_emb_qtype == QType::Q8_0 ||
-                        tok_emb_qtype == QType::Q6_K);
-        if (!upload_unquantized_weight(tok_emb, tok_emb_qtype, ctx.compute_dtype,
+        const bool emb_raw = (tok_emb.qtype == QType::Q8_0 ||
+                              tok_emb.qtype == QType::Q6_K);
+        if (!upload_unquantized_weight(tok_emb, tok_emb.qtype, ctx.compute_dtype,
                                        ctx.stream, ctx.gpu_allocs, emb_raw)) {
             IMP_LOG_ERROR("Failed to upload token embedding");
             return false;
-        }
-        // If we dequanted to FP16, update the qtype so embedding_lookup
-        // uses the FP16 path.
-        if (!emb_raw && tok_emb.qtype == QType::F16) {
-            tok_emb_qtype = QType::F16;
         }
     }
 
     // Upload output norm
     if (out_norm.data && !out_norm.on_device) {
-        if (!upload_unquantized_weight(out_norm, out_norm_qtype, ctx.compute_dtype,
+        if (!upload_unquantized_weight(out_norm, out_norm.qtype, ctx.compute_dtype,
                                        ctx.stream, ctx.gpu_allocs)) {
             IMP_LOG_ERROR("Failed to upload output norm");
             return false;
@@ -762,28 +773,21 @@ static bool upload_embeddings_and_output(
     if (out_proj.data && !out_proj.on_device) {
         // Weight tying: share GPU data only if both point to the same host tensor
         // (i.e. GGUF had no output.weight and the loader aliased out_proj = tok_emb).
-        // Checking the host pointer prevents incorrectly sharing when a model has
-        // separate output.weight and token_embd.weight tensors of the same qtype.
-        bool actually_tied = (out_proj.data == tok_emb_host_ptr &&
-                              out_proj_qtype == tok_emb_qtype);
+        // Compare against the ORIGINAL pre-upload qtype since out_proj still holds it.
+        const bool actually_tied = (out_proj.data == tok_emb_host_ptr &&
+                                    out_proj.qtype == tok_emb_orig_qtype);
         if (actually_tied && tok_emb.on_device) {
             out_proj = tok_emb;
             IMP_LOG_INFO("Output projection shares GPU data with token embedding (weight tying)");
         } else {
-            bool raw_ok = (out_proj_qtype == QType::Q6_K ||
-                           out_proj_qtype == QType::Q8_0 ||
-                           out_proj_qtype == QType::Q4_0);
-            if (!upload_unquantized_weight(out_proj, out_proj_qtype, ctx.compute_dtype,
+            const bool raw_ok = (out_proj.qtype == QType::Q6_K ||
+                                 out_proj.qtype == QType::Q8_0 ||
+                                 out_proj.qtype == QType::Q4_0);
+            if (!upload_unquantized_weight(out_proj, out_proj.qtype, ctx.compute_dtype,
                                            ctx.stream, ctx.gpu_allocs,
                                            /*raw_quant=*/raw_ok)) {
                 IMP_LOG_ERROR("Failed to upload output projection");
                 return false;
-            }
-            // Mirror tok_emb: if upload host-dequanted to FP16, update the qtype
-            // so downstream LM-head dispatch uses the FP16 path instead of
-            // re-interpreting the FP16 bytes as the original quant block format.
-            if (!raw_ok && out_proj.qtype == QType::F16) {
-                out_proj_qtype = QType::F16;
             }
         }
     }
@@ -893,10 +897,10 @@ static bool upload_gptq_weight(const TransformerLayer::GPTQWeight& gptq,
 static bool upload_layer_attention_weights(TransformerLayer& L, int i,
                                            const UploadCtx& ctx) {
     // Attention weights — try regular upload first, fall back to GPTQ dequant
-    UPLOAD_OR_FAIL(L.wq, L.wq_qtype, L.wq_scales, "wq", i, ctx);
-    UPLOAD_OR_FAIL(L.wk, L.wk_qtype, L.wk_scales, "wk", i, ctx);
-    UPLOAD_OR_FAIL(L.wv, L.wv_qtype, L.wv_scales, "wv", i, ctx);
-    UPLOAD_OR_FAIL(L.wo, L.wo_qtype, L.wo_scales, "wo", i, ctx);
+    UPLOAD_OR_FAIL(L.wq, L.wq.qtype, "wq", i, ctx);
+    UPLOAD_OR_FAIL(L.wk, L.wk.qtype, "wk", i, ctx);
+    UPLOAD_OR_FAIL(L.wv, L.wv.qtype, "wv", i, ctx);
+    UPLOAD_OR_FAIL(L.wo, L.wo.qtype, "wo", i, ctx);
 
     // GPTQ fallback: if regular weight is missing but GPTQ tensors are present
     struct { Tensor& w; TransformerLayer::GPTQWeight& gptq; const char* name; } attn_gptq[] = {
@@ -978,9 +982,9 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i,
 static bool upload_layer_ffn_weights(TransformerLayer& L, int i,
                                      const UploadCtx& ctx) {
     // FFN weights (dense path)
-    UPLOAD_OR_FAIL(L.w_gate, L.w_gate_qtype, L.w_gate_scales, "w_gate", i, ctx);
-    UPLOAD_OR_FAIL(L.w_up, L.w_up_qtype, L.w_up_scales, "w_up", i, ctx);
-    UPLOAD_OR_FAIL(L.w_down, L.w_down_qtype, L.w_down_scales, "w_down", i, ctx);
+    UPLOAD_OR_FAIL(L.w_gate, L.w_gate.qtype, "w_gate", i, ctx);
+    UPLOAD_OR_FAIL(L.w_up, L.w_up.qtype, "w_up", i, ctx);
+    UPLOAD_OR_FAIL(L.w_down, L.w_down.qtype, "w_down", i, ctx);
 
     // GPTQ fallback for FFN weights
     struct { Tensor& w; TransformerLayer::GPTQWeight& gptq; const char* name; } ffn_gptq[] = {
@@ -1010,24 +1014,20 @@ static bool upload_layer_ffn_weights(TransformerLayer& L, int i,
 
     // Shared expert weights (Nemotron/DeepSeek style)
     if (L.w_up_shared.data && !L.w_up_shared.on_device) {
-        Tensor dummy_scales;
-        UPLOAD_OR_FAIL(L.w_up_shared, L.w_up_shared_qtype, dummy_scales,
+        UPLOAD_OR_FAIL(L.w_up_shared, L.w_up_shared.qtype,
                        "w_up_shared", i, ctx);
     }
     if (L.w_down_shared.data && !L.w_down_shared.on_device) {
-        Tensor dummy_scales;
-        UPLOAD_OR_FAIL(L.w_down_shared, L.w_down_shared_qtype, dummy_scales,
+        UPLOAD_OR_FAIL(L.w_down_shared, L.w_down_shared.qtype,
                        "w_down_shared", i, ctx);
     }
     if (L.w_gate_shared.data && !L.w_gate_shared.on_device) {
-        Tensor dummy_scales;
-        UPLOAD_OR_FAIL(L.w_gate_shared, L.w_gate_shared_qtype, dummy_scales,
+        UPLOAD_OR_FAIL(L.w_gate_shared, L.w_gate_shared.qtype,
                        "w_gate_shared", i, ctx);
     }
     // Qwen3-Next / Qwen3.6 shared-expert input gate (FP32 [d_model]).
     if (L.shared_expert_gate_inp.data && !L.shared_expert_gate_inp.on_device) {
-        Tensor dummy_scales;
-        UPLOAD_OR_FAIL(L.shared_expert_gate_inp, QType::F32, dummy_scales,
+        UPLOAD_OR_FAIL(L.shared_expert_gate_inp, QType::F32,
                        "shared_expert_gate_inp", i, ctx);
     }
 
@@ -1041,10 +1041,10 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i,
                                      const UploadCtx& ctx) {
     // SSM weights (Mamba2)
     if (L.ssm_in.data && !L.ssm_in.on_device) {
-        UPLOAD_OR_FAIL(L.ssm_in, L.ssm_in_qtype, L.wq_scales, "ssm_in", i, ctx);
+        UPLOAD_OR_FAIL(L.ssm_in, L.ssm_in.qtype, "ssm_in", i, ctx);
     }
     if (L.ssm_out.data && !L.ssm_out.on_device) {
-        UPLOAD_OR_FAIL(L.ssm_out, L.ssm_out_qtype, L.wo_scales, "ssm_out", i, ctx);
+        UPLOAD_OR_FAIL(L.ssm_out, L.ssm_out.qtype, "ssm_out", i, ctx);
     }
     // SSM tensors that convert to compute_dtype (FP16): conv1d weights, norm
     for (Tensor* t : {&L.ssm_conv1d_w, &L.ssm_conv1d_b, &L.ssm_norm_w}) {
@@ -1080,17 +1080,16 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i,
     // gemm_dispatch still saw qtype=Q8_0 and re-interpreted the FP16 bytes as
     // Q8_0 blocks → ~80× too-large alpha/beta and immediate state collapse.
     // Uploading raw Q8_0 keeps the qtype consistent with the bytes on device.
-    Tensor gdn_dummy_scales;
     if (L.gdn_gate.data && !L.gdn_gate.on_device) {
-        UPLOAD_OR_FAIL(L.gdn_gate, L.gdn_gate_qtype, gdn_dummy_scales,
+        UPLOAD_OR_FAIL(L.gdn_gate, L.gdn_gate.qtype,
                        "gdn_gate", i, ctx);
     }
     if (L.gdn_alpha.data && !L.gdn_alpha.on_device) {
-        UPLOAD_OR_FAIL(L.gdn_alpha, L.gdn_alpha_qtype, gdn_dummy_scales,
+        UPLOAD_OR_FAIL(L.gdn_alpha, L.gdn_alpha.qtype,
                        "gdn_alpha", i, ctx);
     }
     if (L.gdn_beta.data && !L.gdn_beta.on_device) {
-        UPLOAD_OR_FAIL(L.gdn_beta, L.gdn_beta_qtype, gdn_dummy_scales,
+        UPLOAD_OR_FAIL(L.gdn_beta, L.gdn_beta.qtype,
                        "gdn_beta", i, ctx);
     }
 
@@ -1118,9 +1117,9 @@ static bool upload_expert_weights(
             layer_expert_bytes[i] += bytes;
             total_expert_bytes += bytes;
         };
-        add_packed(L.expert_gate_packed, L.expert_gate_qtype);
-        add_packed(L.expert_up_packed, L.expert_up_qtype);
-        add_packed(L.expert_down_packed, L.expert_down_qtype);
+        add_packed(L.expert_gate_packed, L.expert_gate_packed.qtype);
+        add_packed(L.expert_up_packed, L.expert_up_packed.qtype);
+        add_packed(L.expert_down_packed, L.expert_down_packed.qtype);
 
         // Also account for per-expert 2D tensors (e.g. NVFP4 llm-compressor format).
         // These are NOT packed 3D, so add_packed misses them.
@@ -1338,8 +1337,7 @@ static bool upload_expert_weights(
             int64_t flat_shape[4] = {static_cast<int64_t>(n_experts) * rows, cols, 0, 0};
             Tensor flat(packed.data, packed.qtype, 2, flat_shape, packed.on_device);
 
-            Tensor dummy_scales;
-            if (!upload_weight(flat, qtype, dummy_scales, ctx.compute_dtype,
+            if (!upload_weight(flat, qtype, ctx.compute_dtype,
                                ctx.stream, ctx.gpu_allocs)) {
                 IMP_LOG_ERROR("Failed to upload packed %s for layer %d", name, i);
                 return false;
@@ -1356,7 +1354,7 @@ static bool upload_expert_weights(
             return true;
         };
 
-        if (!upload_packed_experts(L.expert_gate_packed, L.expert_gate_qtype,
+        if (!upload_packed_experts(L.expert_gate_packed, L.expert_gate_packed.qtype,
                                    L.expert_w_gate, "expert_gate_exps"))
             return false;
 
@@ -1379,13 +1377,13 @@ static bool upload_expert_weights(
             L.expert_up_packed.data == nullptr &&
             L.expert_gate_packed.ndim >= 3 &&
             (L.expert_gate_packed.shape[1] & 1) == 0 &&
-            dequant_gpu_supported(L.expert_gate_qtype)) {
+            dequant_gpu_supported(L.expert_gate_packed.qtype)) {
 
             int64_t n_exp = L.expert_gate_packed.shape[0];
             int64_t fused_rows = L.expert_gate_packed.shape[1];
             int64_t cols = L.expert_gate_packed.shape[2];
             int64_t half_rows = fused_rows / 2;
-            size_t row_bytes = qtype_row_bytes(L.expert_gate_qtype, cols);
+            size_t row_bytes = qtype_row_bytes(L.expert_gate_packed.qtype, cols);
             size_t half_raw = static_cast<size_t>(n_exp) * half_rows * row_bytes;
             size_t src_pitch = static_cast<size_t>(fused_rows) * row_bytes;
             size_t dst_pitch = static_cast<size_t>(half_rows) * row_bytes;
@@ -1418,7 +1416,7 @@ static bool upload_expert_weights(
             int64_t split_shape[4] = {n_exp, half_rows, cols, 0};
             L.expert_gate_packed = Tensor(gate_buf, L.expert_gate_packed.qtype, 3, split_shape, false);
             L.expert_up_packed   = Tensor(up_buf,   L.expert_gate_packed.qtype, 3, split_shape, false);
-            L.expert_up_qtype    = L.expert_gate_qtype;
+            L.expert_up_packed.qtype    = L.expert_gate_packed.qtype;
             ctx.host_pinned_allocs.push_back(gate_buf);
             ctx.host_pinned_allocs.push_back(up_buf);
             IMP_LOG_INFO("Gemma 4: host-split fused gate_up_exps layer %d (n_ff_exp=%ld, %.1f MiB each)",
@@ -1429,13 +1427,13 @@ static bool upload_expert_weights(
             L.expert_up_packed.data == nullptr &&
             L.expert_gate_packed.ndim >= 3 &&
             (L.expert_gate_packed.shape[1] & 1) == 0 &&
-            dequant_gpu_supported(L.expert_gate_qtype)) {
+            dequant_gpu_supported(L.expert_gate_packed.qtype)) {
 
             int64_t n_exp = L.expert_gate_packed.shape[0];
             int64_t fused_rows = L.expert_gate_packed.shape[1];
             int64_t cols = L.expert_gate_packed.shape[2];
             int64_t half_rows = fused_rows / 2;
-            size_t row_bytes = qtype_row_bytes(L.expert_gate_qtype, cols);
+            size_t row_bytes = qtype_row_bytes(L.expert_gate_packed.qtype, cols);
             size_t half_raw = static_cast<size_t>(n_exp) * half_rows * row_bytes;
 
             // Memory-efficient split: allocate only ONE half-sized buffer for the
@@ -1492,17 +1490,17 @@ static bool upload_expert_weights(
             void* gate_buf = L.expert_gate_packed.data;
             L.expert_gate_packed = Tensor(gate_buf, L.expert_gate_packed.qtype, 3, split_shape, true);
             L.expert_up_packed = Tensor(up_buf, L.expert_gate_packed.qtype, 3, split_shape, true);
-            L.expert_up_qtype = L.expert_gate_qtype;
+            L.expert_up_packed.qtype = L.expert_gate_packed.qtype;
             // gate_buf is already in ctx.gpu_allocs from the original upload.
             ctx.gpu_allocs.push_back(up_buf);
             IMP_LOG_INFO("Gemma 4: split fused gate_up_exps layer %d (n_ff_exp=%ld, %.1f MiB each)",
                           i, (long)half_rows, half_raw / (1024.0 * 1024.0));
         }
 
-        if (!upload_packed_experts(L.expert_up_packed, L.expert_up_qtype,
+        if (!upload_packed_experts(L.expert_up_packed, L.expert_up_packed.qtype,
                                    L.expert_w_up, "expert_up_exps"))
             return false;
-        if (!upload_packed_experts(L.expert_down_packed, L.expert_down_qtype,
+        if (!upload_packed_experts(L.expert_down_packed, L.expert_down_packed.qtype,
                                    L.expert_w_down, "expert_down_exps"))
             return false;
 
@@ -1512,8 +1510,7 @@ static bool upload_expert_weights(
         if (experts_upload_layer[i]) {
             for (size_t e = 0; e < L.expert_w_gate.size(); ++e) {
                 if (!L.expert_w_gate[e].data || L.expert_w_gate[e].on_device) continue;
-                Tensor dummy_scales;
-                if (!upload_weight(L.expert_w_gate[e], L.expert_gate_qtype, dummy_scales,
+                if (!upload_weight(L.expert_w_gate[e], L.expert_gate_packed.qtype,
                                    ctx.compute_dtype, ctx.stream, ctx.gpu_allocs)) {
                     IMP_LOG_ERROR("Failed to upload expert_w_gate[%zu] for layer %d", e, i);
                     return false;
@@ -1521,8 +1518,7 @@ static bool upload_expert_weights(
             }
             for (size_t e = 0; e < L.expert_w_up.size(); ++e) {
                 if (!L.expert_w_up[e].data || L.expert_w_up[e].on_device) continue;
-                Tensor dummy_scales;
-                if (!upload_weight(L.expert_w_up[e], L.expert_up_qtype, dummy_scales,
+                if (!upload_weight(L.expert_w_up[e], L.expert_up_packed.qtype,
                                    ctx.compute_dtype, ctx.stream, ctx.gpu_allocs)) {
                     IMP_LOG_ERROR("Failed to upload expert_w_up[%zu] for layer %d", e, i);
                     return false;
@@ -1530,8 +1526,7 @@ static bool upload_expert_weights(
             }
             for (size_t e = 0; e < L.expert_w_down.size(); ++e) {
                 if (!L.expert_w_down[e].data || L.expert_w_down[e].on_device) continue;
-                Tensor dummy_scales;
-                if (!upload_weight(L.expert_w_down[e], L.expert_down_qtype, dummy_scales,
+                if (!upload_weight(L.expert_w_down[e], L.expert_down_packed.qtype,
                                    ctx.compute_dtype, ctx.stream, ctx.gpu_allocs)) {
                     IMP_LOG_ERROR("Failed to upload expert_w_down[%zu] for layer %d", e, i);
                     return false;
@@ -1596,9 +1591,7 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream,
                   host_pinned_, host_pinned_allocs_};
 
     // --- Embeddings, output norm, output projection ---
-    if (!upload_embeddings_and_output(tok_emb_, tok_emb_qtype_,
-                                      out_norm_, out_norm_qtype_,
-                                      out_proj_, out_proj_qtype_, ctx)) {
+    if (!upload_embeddings_and_output(tok_emb_, out_norm_, out_proj_, ctx)) {
         return false;
     }
 

--- a/src/quant/dequant_gpu.cu
+++ b/src/quant/dequant_gpu.cu
@@ -6,44 +6,21 @@
 
 namespace imp {
 
-// ---------------------------------------------------------------------------
-// Raw byte count per row for GGML quantized formats
-// ---------------------------------------------------------------------------
+// qtype_row_bytes lives in src/core/qtype.cpp now.
 
-size_t ggml_quant_row_bytes(GGMLQuantType qtype, int64_t cols) {
+bool dequant_gpu_supported(QType qtype) {
     switch (qtype) {
-        case GGMLQuantType::Q6_K:  return static_cast<size_t>(cols / 256) * 210;
-        case GGMLQuantType::Q8_0:  return static_cast<size_t>(cols / 32) * 34;
-        case GGMLQuantType::Q4_0:  return static_cast<size_t>(cols / 32) * 18;
-        case GGMLQuantType::Q8_1:  return static_cast<size_t>(cols / 32) * 36;
-        case GGMLQuantType::Q4_1:  return static_cast<size_t>(cols / 32) * 20;
-        case GGMLQuantType::Q5_0:  return static_cast<size_t>(cols / 32) * 22;
-        case GGMLQuantType::Q5_1:  return static_cast<size_t>(cols / 32) * 24;
-        case GGMLQuantType::Q2_K:  return static_cast<size_t>(cols / 256) * 84;
-        case GGMLQuantType::Q3_K:  return static_cast<size_t>(cols / 256) * 110;
-        case GGMLQuantType::Q4_K:  return static_cast<size_t>(cols / 256) * 144;
-        case GGMLQuantType::Q5_K:  return static_cast<size_t>(cols / 256) * 176;
-        case GGMLQuantType::Q8_K:  return static_cast<size_t>(cols / 256) * 292;
-        case GGMLQuantType::F16:
-        case GGMLQuantType::BF16:  return static_cast<size_t>(cols) * 2;
-        case GGMLQuantType::F32:   return static_cast<size_t>(cols) * 4;  // NONE == F32 == 0
-        default:                   return static_cast<size_t>(cols) * 2;
-    }
-}
-
-bool dequant_gpu_supported(GGMLQuantType qtype) {
-    switch (qtype) {
-        case GGMLQuantType::Q6_K:
-        case GGMLQuantType::Q8_0:
-        case GGMLQuantType::Q4_0:
-        case GGMLQuantType::Q4_1:
-        case GGMLQuantType::Q5_0:
-        case GGMLQuantType::Q5_1:
-        case GGMLQuantType::Q2_K:
-        case GGMLQuantType::Q3_K:
-        case GGMLQuantType::Q4_K:
-        case GGMLQuantType::Q5_K:
-        case GGMLQuantType::Q8_K:
+        case QType::Q6_K:
+        case QType::Q8_0:
+        case QType::Q4_0:
+        case QType::Q4_1:
+        case QType::Q5_0:
+        case QType::Q5_1:
+        case QType::Q2_K:
+        case QType::Q3_K:
+        case QType::Q4_K:
+        case QType::Q5_K:
+        case QType::Q8_K:
             return true;
         default:
             return false;
@@ -791,13 +768,13 @@ __global__ void dequant_q6k_to_fp8_kernel(
 // Dispatch: Q6_K → FP8 E4M3
 // ---------------------------------------------------------------------------
 
-void dequant_gpu_fp8(const void* src, void* dst, GGMLQuantType qtype,
+void dequant_gpu_fp8(const void* src, void* dst, QType qtype,
                      int rows, int cols, cudaStream_t stream)
 {
     if (rows == 0 || cols == 0) return;
 
     switch (qtype) {
-        case GGMLQuantType::Q6_K: {
+        case QType::Q6_K: {
             int total_blocks = rows * (cols / 256);
             dequant_q6k_to_fp8_kernel<<<total_blocks, 128, 0, stream>>>(
                 static_cast<const uint8_t*>(src),
@@ -817,14 +794,14 @@ void dequant_gpu_fp8(const void* src, void* dst, GGMLQuantType qtype,
 
 // Macro for scalar dequant kernels that share (src_u8, dst_fp16, rows, cols) signature.
 #define DEQUANT_CASE(QTYPE, KERNEL) \
-    case GGMLQuantType::QTYPE: \
+    case QType::QTYPE: \
         KERNEL<<<blocks, threads, 0, stream>>>( \
             static_cast<const uint8_t*>(src), \
             static_cast<half*>(dst), \
             rows, cols); \
         break;
 
-void dequant_gpu(const void* src, void* dst, GGMLQuantType qtype,
+void dequant_gpu(const void* src, void* dst, QType qtype,
                  int rows, int cols, cudaStream_t stream)
 {
     int64_t total = static_cast<int64_t>(rows) * cols;
@@ -834,7 +811,7 @@ void dequant_gpu(const void* src, void* dst, GGMLQuantType qtype,
     int blocks = static_cast<int>((total + threads - 1) / threads);
 
     switch (qtype) {
-        case GGMLQuantType::Q6_K: {
+        case QType::Q6_K: {
             // Q6_K uses block-centric v2 kernel with different grid/thread config.
             int total_q6k_blocks = rows * (cols / 256);
             dequant_q6k_v2_kernel<<<total_q6k_blocks, 128, 0, stream>>>(

--- a/src/quant/dequant_gpu.h
+++ b/src/quant/dequant_gpu.h
@@ -1,36 +1,30 @@
 #pragma once
 
-#include "model/model_config.h"  // GGMLQuantType
+#include "core/qtype.h"
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <cstddef>
 
 namespace imp {
 
-// Compute raw byte count for one row of quantized GGML data with given column count.
-// For Q6_K: (cols / 256) * 210
-// For Q8_0: (cols / 32) * 34
-// For Q4_0: (cols / 32) * 18
-// For F16:  cols * 2
-// For F32:  cols * 4
-size_t ggml_quant_row_bytes(GGMLQuantType qtype, int64_t cols);
+// qtype_row_bytes lives in core/qtype.h — included above.
 
 // Returns true if the quant type supports on-GPU dequant to FP16.
-bool dequant_gpu_supported(GGMLQuantType qtype);
+bool dequant_gpu_supported(QType qtype);
 
 // Dequantize one expert's weight matrix from raw GGML block format to FP16 on GPU.
 //
-// src:  raw quantized bytes on GPU (one expert matrix: rows * ggml_quant_row_bytes(qtype, cols))
+// src:  raw quantized bytes on GPU (one expert matrix: rows * qtype_row_bytes(qtype, cols))
 // dst:  output FP16 buffer on GPU (must hold rows * cols * sizeof(half))
 // rows: number of rows in the weight matrix
 // cols: number of columns (must be divisible by the quant block size)
-void dequant_gpu(const void* src, void* dst, GGMLQuantType qtype,
+void dequant_gpu(const void* src, void* dst, QType qtype,
                  int rows, int cols, cudaStream_t stream);
 
 // Dequantize raw GGML quantized data to FP8 E4M3 on GPU.
 // Same interface as dequant_gpu() but writes FP8 E4M3 (1 byte/element).
 // Currently supports Q6_K only. Q6_K values are within FP8 E4M3 range (±448).
-void dequant_gpu_fp8(const void* src, void* dst, GGMLQuantType qtype,
+void dequant_gpu_fp8(const void* src, void* dst, QType qtype,
                      int rows, int cols, cudaStream_t stream);
 
 } // namespace imp

--- a/src/quant/fp8_quant.cu
+++ b/src/quant/fp8_quant.cu
@@ -343,7 +343,7 @@ void quantize_fp16_to_fp8_e4m3(const Tensor& input, Tensor& output,
         IMP_LOG_ERROR("quantize_fp16_to_fp8_e4m3: output must be a pre-allocated device tensor");
         return;
     }
-    if (input.dtype != DType::FP16) {
+    if (input.qtype != QType::F16) {
         IMP_LOG_ERROR("quantize_fp16_to_fp8_e4m3: input dtype must be FP16");
         return;
     }

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -1389,8 +1389,8 @@ void gemv_nvfp4(const NvFP4QuantResult& A, const Tensor& x, Tensor& y,
     assert(A.packed_data != nullptr && "A must be quantized");
     assert(x.on_device && "x must be on device");
     assert(y.on_device && "y must be on device");
-    assert(x.dtype == DType::FP16 && "x must be FP16");
-    assert(y.dtype == DType::FP16 && "y must be FP16");
+    assert(x.qtype == QType::F16 && "x must be FP16");
+    assert(y.qtype == QType::F16 && "y must be FP16");
 
     int M = static_cast<int>(A.N);
     int K = static_cast<int>(A.K);
@@ -1474,7 +1474,7 @@ void gemm_nvfp4(const NvFP4QuantResult& A, const Tensor& B, Tensor& C,
     dequantize_nvfp4_to_fp16(A, dequant_buf, stream);
 
     int64_t A_shape[2] = {N, K};
-    Tensor A_fp16(dequant_buf, DType::FP16, 2, A_shape, /*on_device=*/true);
+    Tensor A_fp16(dequant_buf, QType::F16, 2, A_shape, /*on_device=*/true);
 
     gemm(B, A_fp16, C, 1.0f, 0.0f, stream);
 }

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -318,7 +318,7 @@ float calibrate_nvfp4_scales(const Tensor& input, cudaStream_t stream,
                               float* d_reusable_max)
 {
     assert(input.on_device && "input must be on device");
-    assert(input.dtype == DType::FP16 && "input must be FP16");
+    assert(input.qtype == QType::F16 && "input must be FP16");
 
     int64_t n_elements = input.numel();
 
@@ -363,7 +363,7 @@ void quantize_fp16_to_nvfp4(const Tensor& input, NvFP4QuantResult& result,
                              cudaStream_t stream)
 {
     assert(input.on_device && "input must be on device");
-    assert(input.dtype == DType::FP16 && "input must be FP16");
+    assert(input.qtype == QType::F16 && "input must be FP16");
     assert(input.ndim == 2 && "input must be 2D [N, K]");
 
     int64_t N = input.shape[0];
@@ -412,7 +412,7 @@ void quantize_fp16_to_nvfp4_async(const Tensor& input, NvFP4QuantResult& result,
                                    cudaStream_t stream)
 {
     assert(input.on_device && "input must be on device");
-    assert(input.dtype == DType::FP16 && "input must be FP16");
+    assert(input.qtype == QType::F16 && "input must be FP16");
     assert(input.ndim == 2 && "input must be 2D [N, K]");
 
     int64_t N = input.shape[0];
@@ -574,7 +574,7 @@ void free_nvfp4_result(NvFP4QuantResult& result)
 // ---------------------------------------------------------------------------
 
 void quantize_packed_experts_to_nvfp4(
-    const void* packed_ggml_data, GGMLQuantType qtype,
+    const void* packed_ggml_data, QType qtype,
     int n_experts, int eff, int K,
     void* dequant_scratch,
     NvFP4MoEQuantResult& result,
@@ -599,7 +599,7 @@ void quantize_packed_experts_to_nvfp4(
     IMP_CUDA_CHECK_LOG(cudaMalloc(&d_tensor_scales, n_experts * sizeof(float)));
 
     // Compute expert stride in source GGML data
-    size_t src_expert_stride = static_cast<size_t>(eff) * ggml_quant_row_bytes(qtype, K);
+    size_t src_expert_stride = static_cast<size_t>(eff) * qtype_row_bytes(qtype, K);
 
     // Temporary device buffer for absmax reduction
     float* d_global_max = nullptr;

--- a/src/quant/nvfp4_quant.h
+++ b/src/quant/nvfp4_quant.h
@@ -6,8 +6,6 @@
 
 namespace imp {
 
-enum class GGMLQuantType : uint32_t;  // forward declaration
-
 // NVFP4 (FP4 E2M1) quantization with two-level scaling:
 //   Level 1: FP8 E4M3 micro-scale per 16 values (micro-block)
 //   Level 2: FP32 tensor-scale (global)
@@ -69,7 +67,7 @@ struct NvFP4MoEQuantResult {
 // Quantize packed 3D expert weights (raw GGML format) to NVFP4.
 // dequant_scratch: [eff, K] FP16 scratch buffer on device (reused per expert).
 void quantize_packed_experts_to_nvfp4(
-    const void* packed_ggml_data, GGMLQuantType qtype,
+    const void* packed_ggml_data, QType qtype,
     int n_experts, int eff, int K,
     void* dequant_scratch,
     NvFP4MoEQuantResult& result,

--- a/src/quant/quant_types.h
+++ b/src/quant/quant_types.h
@@ -5,8 +5,8 @@
 namespace imp {
 
 struct QuantConfig {
-    DType quant_dtype = DType::FP16;   // quantized storage type
-    DType compute_dtype = DType::FP16; // compute type
+    QType quant_dtype = QType::F16;   // quantized storage type
+    QType compute_dtype = QType::F16; // compute type
     int group_size = 128;
     bool has_zero_point = false;
     Tensor scales;      // per-channel or per-group scales

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -1,0 +1,252 @@
+#include "runtime/config.h"
+#include "core/logging.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <unistd.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+namespace imp {
+
+namespace {
+
+// ----- Tiny INI/TOML-subset parser ---------------------------------------
+//
+// Supports:
+//   [section]            section header
+//   key = value          plain
+//   key = "value"        quoted string
+//   key = true | false   booleans
+//   key = 42             integers
+//   key = 3.14           floats
+//   # comment            line comment
+//
+// This is a minimal subset of TOML — enough for imp.conf which is flat
+// (no nested tables, no arrays). When the project picks up tomlplusplus
+// the parser body here can be replaced without touching the call sites.
+
+std::string trim(const std::string& s) {
+    size_t b = 0, e = s.size();
+    while (b < e && (s[b] == ' ' || s[b] == '\t' || s[b] == '\r')) ++b;
+    while (e > b && (s[e-1] == ' ' || s[e-1] == '\t' || s[e-1] == '\r')) --e;
+    return s.substr(b, e - b);
+}
+
+std::string strip_quotes(const std::string& s) {
+    if (s.size() >= 2 && ((s.front() == '"' && s.back() == '"') ||
+                          (s.front() == '\'' && s.back() == '\''))) {
+        return s.substr(1, s.size() - 2);
+    }
+    return s;
+}
+
+bool parse_bool(const std::string& v, bool fallback) {
+    if (v == "true"  || v == "True"  || v == "1" || v == "yes" || v == "on")  return true;
+    if (v == "false" || v == "False" || v == "0" || v == "no"  || v == "off") return false;
+    return fallback;
+}
+
+int parse_int(const std::string& v, int fallback) {
+    if (v.empty()) return fallback;
+    try { return std::stoi(v); } catch (...) { return fallback; }
+}
+
+float parse_float(const std::string& v, float fallback) {
+    if (v.empty()) return fallback;
+    try { return std::stof(v); } catch (...) { return fallback; }
+}
+
+// Apply a single dotted key (e.g. "kv_cache.dtype") with raw value string.
+// Logs a warning for unknown keys but keeps going.
+void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::string& raw) {
+    std::string val = strip_quotes(trim(raw));
+
+    auto eq = [&](const char* k) { return dotted_key == k; };
+
+    // [runtime]
+    if      (eq("runtime.deterministic_gemm")) cfg.runtime.deterministic_gemm = parse_bool(val, cfg.runtime.deterministic_gemm);
+    else if (eq("runtime.cuda_graphs"))        cfg.runtime.cuda_graphs        = val;
+    else if (eq("runtime.warmup"))             cfg.runtime.warmup             = parse_bool(val, cfg.runtime.warmup);
+    else if (eq("runtime.max_seq_len"))        cfg.runtime.max_seq_len        = parse_int(val, cfg.runtime.max_seq_len);
+    else if (eq("runtime.no_pdl"))             cfg.runtime.no_pdl             = parse_bool(val, cfg.runtime.no_pdl);
+
+    // [kv_cache]
+    else if (eq("kv_cache.dtype"))                       cfg.kv_cache.dtype                      = val;
+    else if (eq("kv_cache.allow_nondeterministic_fp8"))  cfg.kv_cache.allow_nondeterministic_fp8 = parse_bool(val, cfg.kv_cache.allow_nondeterministic_fp8);
+
+    // [attention]
+    else if (eq("attention.fp8_prefill"))         cfg.attention.fp8_prefill         = val;
+    else if (eq("attention.fp8_fmha"))            cfg.attention.fp8_fmha            = val;
+    else if (eq("attention.fmha_sm120"))          cfg.attention.fmha_sm120          = val;
+    else if (eq("attention.mxfp4"))               cfg.attention.mxfp4               = val;
+    else if (eq("attention.mxfp4_fp16_fallback")) cfg.attention.mxfp4_fp16_fallback = parse_bool(val, cfg.attention.mxfp4_fp16_fallback);
+    else if (eq("attention.fmha_blockscale"))     cfg.attention.fmha_blockscale     = val;
+    else if (eq("attention.naive"))               cfg.attention.naive               = parse_bool(val, cfg.attention.naive);
+    else if (eq("attention.no_cublas"))           cfg.attention.no_cublas           = parse_bool(val, cfg.attention.no_cublas);
+    else if (eq("attention.force_cublas_decode")) cfg.attention.force_cublas_decode = parse_bool(val, cfg.attention.force_cublas_decode);
+    else if (eq("attention.no_qknorm_fused"))     cfg.attention.no_qknorm_fused     = parse_bool(val, cfg.attention.no_qknorm_fused);
+    else if (eq("attention.no_naive_swa"))        cfg.attention.no_naive_swa        = parse_bool(val, cfg.attention.no_naive_swa);
+    else if (eq("attention.splitk_pipe"))         cfg.attention.splitk_pipe         = parse_bool(val, cfg.attention.splitk_pipe);
+    else if (eq("attention.gate_concat"))         cfg.attention.gate_concat         = parse_bool(val, cfg.attention.gate_concat);
+
+    // [moe]
+    else if (eq("moe.expert_overhead_pct")) cfg.moe.expert_overhead_pct = parse_int(val, cfg.moe.expert_overhead_pct);
+    else if (eq("moe.force_host_experts"))  cfg.moe.force_host_experts  = parse_bool(val, cfg.moe.force_host_experts);
+    else if (eq("moe.skip"))                cfg.moe.skip                = parse_bool(val, cfg.moe.skip);
+    else if (eq("moe.force_fp16_sync"))     cfg.moe.force_fp16_sync     = parse_bool(val, cfg.moe.force_fp16_sync);
+    else if (eq("moe.no_expert_cache"))     cfg.moe.no_expert_cache     = parse_bool(val, cfg.moe.no_expert_cache);
+
+    // [gdn]
+    else if (eq("gdn.fp32_scan"))         cfg.gdn.fp32_scan         = parse_bool(val, cfg.gdn.fp32_scan);
+    else if (eq("gdn.fp32_out"))          cfg.gdn.fp32_out          = parse_bool(val, cfg.gdn.fp32_out);
+    else if (eq("gdn.norm_eps_override")) cfg.gdn.norm_eps_override = parse_float(val, cfg.gdn.norm_eps_override);
+    else if (eq("gdn.ref_kernel"))        cfg.gdn.ref_kernel        = parse_bool(val, cfg.gdn.ref_kernel);
+    else if (eq("gdn.vhead_reorder"))     cfg.gdn.vhead_reorder     = parse_bool(val, cfg.gdn.vhead_reorder);
+
+    // [gemm]
+    else if (eq("gemm.no_dp4a"))      cfg.gemm.no_dp4a      = parse_bool(val, cfg.gemm.no_dp4a);
+    else if (eq("gemm.no_dp4a_gemv")) cfg.gemm.no_dp4a_gemv = parse_bool(val, cfg.gemm.no_dp4a_gemv);
+    else if (eq("gemm.no_dp4a_lm"))   cfg.gemm.no_dp4a_lm   = parse_bool(val, cfg.gemm.no_dp4a_lm);
+    else if (eq("gemm.no_mmvq"))      cfg.gemm.no_mmvq      = parse_bool(val, cfg.gemm.no_mmvq);
+    else if (eq("gemm.no_mmvq_q8_0")) cfg.gemm.no_mmvq_q8_0 = parse_bool(val, cfg.gemm.no_mmvq_q8_0);
+
+    // [gemma4]
+    else if (eq("gemma4.fp32_gemm_out")) cfg.gemma4.fp32_gemm_out = parse_bool(val, cfg.gemma4.fp32_gemm_out);
+    else if (eq("gemma4.no_graphs"))     cfg.gemma4.no_graphs     = parse_bool(val, cfg.gemma4.no_graphs);
+    else if (eq("gemma4.force_mmvq"))    cfg.gemma4.force_mmvq    = parse_bool(val, cfg.gemma4.force_mmvq);
+
+    // [generation]
+    else if (eq("generation.no_logit_softcap")) cfg.generation.no_logit_softcap = parse_bool(val, cfg.generation.no_logit_softcap);
+    else if (eq("generation.lm_dequant_fp16"))  cfg.generation.lm_dequant_fp16  = parse_bool(val, cfg.generation.lm_dequant_fp16);
+    else if (eq("generation.think_budget"))     cfg.generation.think_budget     = parse_int(val, cfg.generation.think_budget);
+
+    // [paths]
+    else if (eq("paths.mmproj"))                  cfg.paths.mmproj = val;
+
+    // [diagnostics]
+    else if (eq("diagnostics.debug_forward"))       cfg.diagnostics.debug_forward       = parse_bool(val, cfg.diagnostics.debug_forward);
+    else if (eq("diagnostics.debug_raw"))           cfg.diagnostics.debug_raw           = parse_bool(val, cfg.diagnostics.debug_raw);
+    else if (eq("diagnostics.debug_gemm_dispatch")) cfg.diagnostics.debug_gemm_dispatch = parse_bool(val, cfg.diagnostics.debug_gemm_dispatch);
+    else if (eq("diagnostics.dump_hidden_dir"))     cfg.diagnostics.dump_hidden_dir     = val;
+    else if (eq("diagnostics.dump_logits"))         cfg.diagnostics.dump_logits         = parse_bool(val, cfg.diagnostics.dump_logits);
+    else if (eq("diagnostics.dump_routing"))        cfg.diagnostics.dump_routing        = parse_bool(val, cfg.diagnostics.dump_routing);
+    else if (eq("diagnostics.dump_tokens"))         cfg.diagnostics.dump_tokens         = parse_bool(val, cfg.diagnostics.dump_tokens);
+    else if (eq("diagnostics.exit_layer"))          cfg.diagnostics.exit_layer          = parse_int(val, cfg.diagnostics.exit_layer);
+    else if (eq("diagnostics.profile"))             cfg.diagnostics.profile             = parse_bool(val, cfg.diagnostics.profile);
+    else if (eq("diagnostics.graph_diag"))          cfg.diagnostics.graph_diag          = parse_bool(val, cfg.diagnostics.graph_diag);
+    else if (eq("diagnostics.graph_dump_dir"))      cfg.diagnostics.graph_dump_dir      = val;
+
+    else {
+        IMP_LOG_WARN("imp.conf: unknown key '%s' (value '%s') — ignoring",
+                     dotted_key.c_str(), val.c_str());
+    }
+}
+
+bool file_exists(const std::string& path) {
+    if (path.empty()) return false;
+    struct stat st;
+    return stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
+}
+
+std::string home_dir() {
+    if (const char* h = std::getenv("HOME")) return h;
+    if (struct passwd* pw = getpwuid(getuid())) return pw->pw_dir;
+    return {};
+}
+
+} // anonymous namespace
+
+// -----------------------------------------------------------------------
+
+std::string RuntimeConfig::find_default_path() {
+    if (const char* p = std::getenv("IMP_CONFIG")) {
+        if (file_exists(p)) return p;
+    }
+    if (file_exists("./imp.conf")) return "./imp.conf";
+    std::string home = home_dir();
+    if (!home.empty()) {
+        std::string user_path = home + "/.config/imp/imp.conf";
+        if (file_exists(user_path)) return user_path;
+    }
+    return {};
+}
+
+bool RuntimeConfig::load_from_file(const std::string& path) {
+    std::ifstream ifs(path);
+    if (!ifs) {
+        IMP_LOG_ERROR("imp.conf: cannot open %s", path.c_str());
+        return false;
+    }
+
+    std::string line;
+    std::string section;
+    int line_no = 0;
+    while (std::getline(ifs, line)) {
+        ++line_no;
+        // Strip comment from '#' onwards (unless inside quotes — we ignore that
+        // edge case for the minimal parser; quote a value with " to keep #).
+        size_t hash = line.find('#');
+        if (hash != std::string::npos) {
+            // Don't strip if inside quotes
+            size_t q1 = line.find('"');
+            size_t q2 = (q1 == std::string::npos) ? std::string::npos : line.find('"', q1 + 1);
+            if (!(q1 != std::string::npos && q2 != std::string::npos && q1 < hash && hash < q2)) {
+                line = line.substr(0, hash);
+            }
+        }
+        std::string s = trim(line);
+        if (s.empty()) continue;
+
+        if (s.front() == '[' && s.back() == ']') {
+            section = trim(s.substr(1, s.size() - 2));
+            continue;
+        }
+
+        size_t eq = s.find('=');
+        if (eq == std::string::npos) {
+            IMP_LOG_WARN("imp.conf:%d: ignoring malformed line: %s", line_no, s.c_str());
+            continue;
+        }
+        std::string key = trim(s.substr(0, eq));
+        std::string val = trim(s.substr(eq + 1));
+
+        std::string dotted = section.empty() ? key : (section + "." + key);
+        apply_one(*this, dotted, val);
+    }
+    return true;
+}
+
+void RuntimeConfig::apply_overrides(const std::vector<std::string>& kvs) {
+    for (const auto& kv : kvs) {
+        size_t eq = kv.find('=');
+        if (eq == std::string::npos) {
+            IMP_LOG_WARN("imp.conf override: ignoring malformed '%s' (expected key=value)", kv.c_str());
+            continue;
+        }
+        std::string key = trim(kv.substr(0, eq));
+        std::string val = trim(kv.substr(eq + 1));
+        apply_one(*this, key, val);
+    }
+}
+
+RuntimeConfig RuntimeConfig::load(const std::string& explicit_path,
+                                   const std::vector<std::string>& overrides) {
+    RuntimeConfig cfg;
+    std::string path = explicit_path.empty() ? find_default_path() : explicit_path;
+    if (!path.empty()) {
+        if (cfg.load_from_file(path)) {
+            IMP_LOG_INFO("imp.conf loaded from %s", path.c_str());
+        }
+    } else {
+        IMP_LOG_INFO("imp.conf: no config file found, using built-in defaults");
+    }
+    cfg.apply_overrides(overrides);
+    return cfg;
+}
+
+} // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -74,10 +74,13 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     else if (eq("runtime.warmup"))             cfg.runtime.warmup             = parse_bool(val, cfg.runtime.warmup);
     else if (eq("runtime.max_seq_len"))        cfg.runtime.max_seq_len        = parse_int(val, cfg.runtime.max_seq_len);
     else if (eq("runtime.no_pdl"))             cfg.runtime.no_pdl             = parse_bool(val, cfg.runtime.no_pdl);
+    else if (eq("runtime.debug_raw"))          cfg.runtime.debug_raw          = parse_bool(val, cfg.runtime.debug_raw);
+    else if (eq("runtime.no_vision_graph"))    cfg.runtime.no_vision_graph    = parse_bool(val, cfg.runtime.no_vision_graph);
 
     // [kv_cache]
     else if (eq("kv_cache.dtype"))                       cfg.kv_cache.dtype                      = val;
     else if (eq("kv_cache.allow_nondeterministic_fp8"))  cfg.kv_cache.allow_nondeterministic_fp8 = parse_bool(val, cfg.kv_cache.allow_nondeterministic_fp8);
+    else if (eq("kv_cache.fp8_auto_legacy"))             cfg.kv_cache.fp8_auto_legacy            = parse_bool(val, cfg.kv_cache.fp8_auto_legacy);
 
     // [attention]
     else if (eq("attention.fp8_prefill"))         cfg.attention.fp8_prefill         = val;
@@ -96,10 +99,14 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
 
     // [moe]
     else if (eq("moe.expert_overhead_pct")) cfg.moe.expert_overhead_pct = parse_int(val, cfg.moe.expert_overhead_pct);
-    else if (eq("moe.force_host_experts"))  cfg.moe.force_host_experts  = parse_bool(val, cfg.moe.force_host_experts);
+    else if (eq("moe.force_host_experts"))  cfg.moe.force_host_experts  = parse_int(val, cfg.moe.force_host_experts);
     else if (eq("moe.skip"))                cfg.moe.skip                = parse_bool(val, cfg.moe.skip);
     else if (eq("moe.force_fp16_sync"))     cfg.moe.force_fp16_sync     = parse_bool(val, cfg.moe.force_fp16_sync);
     else if (eq("moe.no_expert_cache"))     cfg.moe.no_expert_cache     = parse_bool(val, cfg.moe.no_expert_cache);
+    else if (eq("moe.zero_workspace"))      cfg.moe.zero_workspace      = parse_bool(val, cfg.moe.zero_workspace);
+    else if (eq("moe.no_shared_mlp"))       cfg.moe.no_shared_mlp       = parse_bool(val, cfg.moe.no_shared_mlp);
+    else if (eq("moe.no_shexp_gate"))       cfg.moe.no_shexp_gate       = parse_bool(val, cfg.moe.no_shexp_gate);
+    else if (eq("moe.no_cutlass3x"))        cfg.moe.no_cutlass3x        = parse_bool(val, cfg.moe.no_cutlass3x);
 
     // [gdn]
     else if (eq("gdn.fp32_scan"))         cfg.gdn.fp32_scan         = parse_bool(val, cfg.gdn.fp32_scan);
@@ -116,25 +123,36 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     else if (eq("gemm.no_mmvq_q8_0")) cfg.gemm.no_mmvq_q8_0 = parse_bool(val, cfg.gemm.no_mmvq_q8_0);
 
     // [gemma4]
-    else if (eq("gemma4.fp32_gemm_out")) cfg.gemma4.fp32_gemm_out = parse_bool(val, cfg.gemma4.fp32_gemm_out);
-    else if (eq("gemma4.no_graphs"))     cfg.gemma4.no_graphs     = parse_bool(val, cfg.gemma4.no_graphs);
-    else if (eq("gemma4.force_mmvq"))    cfg.gemma4.force_mmvq    = parse_bool(val, cfg.gemma4.force_mmvq);
+    else if (eq("gemma4.fp32_gemm_out"))    cfg.gemma4.fp32_gemm_out    = parse_bool(val, cfg.gemma4.fp32_gemm_out);
+    else if (eq("gemma4.no_graphs"))        cfg.gemma4.no_graphs        = parse_bool(val, cfg.gemma4.no_graphs);
+    else if (eq("gemma4.force_mmvq"))       cfg.gemma4.force_mmvq       = parse_bool(val, cfg.gemma4.force_mmvq);
+    else if (eq("gemma4.fp32_expert_down")) cfg.gemma4.fp32_expert_down = parse_bool(val, cfg.gemma4.fp32_expert_down);
+    else if (eq("gemma4.no_decode_fast"))   cfg.gemma4.no_decode_fast   = parse_bool(val, cfg.gemma4.no_decode_fast);
+    else if (eq("gemma4.no_post_ffw_1"))    cfg.gemma4.no_post_ffw_1    = parse_bool(val, cfg.gemma4.no_post_ffw_1);
+    else if (eq("gemma4.ggml_prefill"))     cfg.gemma4.ggml_prefill     = parse_bool(val, cfg.gemma4.ggml_prefill);
 
     // [generation]
     else if (eq("generation.no_logit_softcap")) cfg.generation.no_logit_softcap = parse_bool(val, cfg.generation.no_logit_softcap);
     else if (eq("generation.lm_dequant_fp16"))  cfg.generation.lm_dequant_fp16  = parse_bool(val, cfg.generation.lm_dequant_fp16);
     else if (eq("generation.think_budget"))     cfg.generation.think_budget     = parse_int(val, cfg.generation.think_budget);
+    else if (eq("generation.force_bos"))        cfg.generation.force_bos        = parse_bool(val, cfg.generation.force_bos);
+
+    // [server]
+    else if (eq("server.prefix_cache")) cfg.server.prefix_cache = parse_bool(val, cfg.server.prefix_cache);
+
+    // [bench]
+    else if (eq("bench.generate"))      cfg.bench.generate      = parse_bool(val, cfg.bench.generate);
 
     // [paths]
     else if (eq("paths.mmproj"))                  cfg.paths.mmproj = val;
 
     // [diagnostics]
     else if (eq("diagnostics.debug_forward"))       cfg.diagnostics.debug_forward       = parse_bool(val, cfg.diagnostics.debug_forward);
-    else if (eq("diagnostics.debug_raw"))           cfg.diagnostics.debug_raw           = parse_bool(val, cfg.diagnostics.debug_raw);
     else if (eq("diagnostics.debug_gemm_dispatch")) cfg.diagnostics.debug_gemm_dispatch = parse_bool(val, cfg.diagnostics.debug_gemm_dispatch);
+    else if (eq("diagnostics.debug_template"))      cfg.diagnostics.debug_template      = parse_bool(val, cfg.diagnostics.debug_template);
     else if (eq("diagnostics.dump_hidden_dir"))     cfg.diagnostics.dump_hidden_dir     = val;
-    else if (eq("diagnostics.dump_logits"))         cfg.diagnostics.dump_logits         = parse_bool(val, cfg.diagnostics.dump_logits);
-    else if (eq("diagnostics.dump_routing"))        cfg.diagnostics.dump_routing        = parse_bool(val, cfg.diagnostics.dump_routing);
+    else if (eq("diagnostics.dump_logits_dir"))     cfg.diagnostics.dump_logits_dir     = val;
+    else if (eq("diagnostics.dump_routing_dir"))    cfg.diagnostics.dump_routing_dir    = val;
     else if (eq("diagnostics.dump_tokens"))         cfg.diagnostics.dump_tokens         = parse_bool(val, cfg.diagnostics.dump_tokens);
     else if (eq("diagnostics.exit_layer"))          cfg.diagnostics.exit_layer          = parse_int(val, cfg.diagnostics.exit_layer);
     else if (eq("diagnostics.profile"))             cfg.diagnostics.profile             = parse_bool(val, cfg.diagnostics.profile);
@@ -247,6 +265,23 @@ RuntimeConfig RuntimeConfig::load(const std::string& explicit_path,
     }
     cfg.apply_overrides(overrides);
     return cfg;
+}
+
+// ---- Process-wide singleton ---------------------------------------------
+
+namespace {
+RuntimeConfig& mutable_current() {
+    static RuntimeConfig instance;
+    return instance;
+}
+} // anonymous namespace
+
+const RuntimeConfig& RuntimeConfig::current() {
+    return mutable_current();
+}
+
+void RuntimeConfig::install(const RuntimeConfig& cfg) {
+    mutable_current() = cfg;
 }
 
 } // namespace imp

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -28,11 +28,14 @@ struct RuntimeConfig {
         bool        warmup             = true;
         int         max_seq_len        = 0;        // 0 = use model default
         bool        no_pdl             = false;
+        bool        debug_raw          = false;    // raw stream debug
+        bool        no_vision_graph    = false;    // disable SigLIP graph capture
     } runtime;
 
     struct KVCache {
         std::string dtype                       = "fp16";  // fp16 | fp8 | int8 | int4 | nvfp4
         bool        allow_nondeterministic_fp8  = false;
+        bool        fp8_auto_legacy             = false;   // legacy IMP_KV_FP8_AUTO compat
     } kv_cache;
 
     struct Attention {
@@ -53,10 +56,14 @@ struct RuntimeConfig {
 
     struct MoE {
         int  expert_overhead_pct = 10;
-        bool force_host_experts  = false;
+        int  force_host_experts  = 0;     // last N layers forced to host (0 = none)
         bool skip                = false;
         bool force_fp16_sync     = false;
         bool no_expert_cache     = false;
+        bool zero_workspace      = false;
+        bool no_shared_mlp       = false;
+        bool no_shexp_gate       = false;
+        bool no_cutlass3x        = false;
     } moe;
 
     struct GDN {
@@ -76,16 +83,29 @@ struct RuntimeConfig {
     } gemm;
 
     struct Gemma4 {
-        bool fp32_gemm_out = false;
-        bool no_graphs     = false;
-        bool force_mmvq    = false;
+        bool fp32_gemm_out    = false;
+        bool no_graphs        = false;
+        bool force_mmvq       = false;
+        bool fp32_expert_down = false;
+        bool no_decode_fast   = false;
+        bool no_post_ffw_1    = false;
+        bool ggml_prefill     = false;
     } gemma4;
 
     struct Generation {
         bool no_logit_softcap = false;
         bool lm_dequant_fp16  = false;
         int  think_budget     = 0;
+        bool force_bos        = false;
     } generation;
+
+    struct Server {
+        bool prefix_cache = false;
+    } server;
+
+    struct Bench {
+        bool generate = false;
+    } bench;
 
     struct Paths {
         std::string mmproj;
@@ -93,11 +113,11 @@ struct RuntimeConfig {
 
     struct Diagnostics {
         bool        debug_forward       = false;
-        bool        debug_raw           = false;
         bool        debug_gemm_dispatch = false;
+        bool        debug_template      = false;
         std::string dump_hidden_dir;
-        bool        dump_logits         = false;
-        bool        dump_routing        = false;
+        std::string dump_logits_dir;     // path or empty
+        std::string dump_routing_dir;    // path or empty
         bool        dump_tokens         = false;
         int         exit_layer          = -1;
         bool        profile             = false;
@@ -124,6 +144,22 @@ struct RuntimeConfig {
     // Pass empty path to use the search-path default.
     static RuntimeConfig load(const std::string& explicit_path,
                               const std::vector<std::string>& overrides);
+
+    // ---- Process-wide singleton -----------------------------------------
+    //
+    // Engine init calls install() once with the loaded RuntimeConfig.
+    // All ~80 former getenv("IMP_*") call sites read via current(), which
+    // returns a const reference to the installed config (or a default-
+    // constructed one if install() was never called).
+    //
+    // This is intentionally a process-wide singleton because the runtime
+    // configuration is global state — there is no expectation of two
+    // engines with different runtime configs in the same process. If
+    // that ever changes, threading a const RuntimeConfig& through every
+    // executor call site is a mechanical refactor; the read-side API
+    // (current().runtime.no_pdl etc.) does not need to change.
+    static const RuntimeConfig& current();
+    static void install(const RuntimeConfig& cfg);
 };
 
 } // namespace imp

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -1,0 +1,129 @@
+#pragma once
+
+// imp.conf — central runtime configuration.
+//
+// Replaces ~50 ad-hoc IMP_*-prefixed environment variables that were scattered
+// over ~80 getenv() call sites in src/runtime/ and src/graph/. The same values
+// now flow through a single RuntimeConfig struct loaded once at startup,
+// optionally from a TOML file, with CLI-flag overrides on top.
+//
+// Loading precedence (first non-empty wins):
+//   1. --config <path>              CLI flag (passed via load_with_path)
+//   2. $IMP_CONFIG                  environment variable
+//   3. ./imp.conf                   working-dir relative
+//   4. ~/.config/imp/imp.conf       user config directory
+//   5. embedded defaults            (no file)
+//
+// Per-run overrides come on top via apply_overrides({"section.field=value"}).
+
+#include <string>
+#include <vector>
+
+namespace imp {
+
+struct RuntimeConfig {
+    struct Runtime {
+        bool        deterministic_gemm = false;
+        std::string cuda_graphs        = "auto";   // "auto" | "always" | "never"
+        bool        warmup             = true;
+        int         max_seq_len        = 0;        // 0 = use model default
+        bool        no_pdl             = false;
+    } runtime;
+
+    struct KVCache {
+        std::string dtype                       = "fp16";  // fp16 | fp8 | int8 | int4 | nvfp4
+        bool        allow_nondeterministic_fp8  = false;
+    } kv_cache;
+
+    struct Attention {
+        std::string fp8_prefill          = "auto";
+        std::string fp8_fmha             = "auto";
+        std::string fmha_sm120           = "auto";
+        std::string mxfp4                = "auto";
+        bool        mxfp4_fp16_fallback  = false;
+        std::string fmha_blockscale      = "auto";
+        bool        naive                = false;
+        bool        no_cublas            = false;
+        bool        force_cublas_decode  = false;
+        bool        no_qknorm_fused      = false;
+        bool        no_naive_swa         = false;
+        bool        splitk_pipe          = true;
+        bool        gate_concat          = false;
+    } attention;
+
+    struct MoE {
+        int  expert_overhead_pct = 10;
+        bool force_host_experts  = false;
+        bool skip                = false;
+        bool force_fp16_sync     = false;
+        bool no_expert_cache     = false;
+    } moe;
+
+    struct GDN {
+        bool  fp32_scan          = false;
+        bool  fp32_out           = false;
+        float norm_eps_override  = 0.0f;   // 0 = use model default
+        bool  ref_kernel         = false;
+        bool  vhead_reorder      = false;
+    } gdn;
+
+    struct GEMM {
+        bool no_dp4a      = false;
+        bool no_dp4a_gemv = false;
+        bool no_dp4a_lm   = false;
+        bool no_mmvq      = false;
+        bool no_mmvq_q8_0 = false;
+    } gemm;
+
+    struct Gemma4 {
+        bool fp32_gemm_out = false;
+        bool no_graphs     = false;
+        bool force_mmvq    = false;
+    } gemma4;
+
+    struct Generation {
+        bool no_logit_softcap = false;
+        bool lm_dequant_fp16  = false;
+        int  think_budget     = 0;
+    } generation;
+
+    struct Paths {
+        std::string mmproj;
+    } paths;
+
+    struct Diagnostics {
+        bool        debug_forward       = false;
+        bool        debug_raw           = false;
+        bool        debug_gemm_dispatch = false;
+        std::string dump_hidden_dir;
+        bool        dump_logits         = false;
+        bool        dump_routing        = false;
+        bool        dump_tokens         = false;
+        int         exit_layer          = -1;
+        bool        profile             = false;
+        bool        graph_diag          = false;
+        std::string graph_dump_dir;
+    } diagnostics;
+
+    // ----- Loading -----
+
+    // Find a config file in the search-path order documented above.
+    // Returns empty string if no file is found.
+    static std::string find_default_path();
+
+    // Load from disk; returns true on success. On parse error, the struct
+    // is left at its default state and an error is logged.
+    bool load_from_file(const std::string& path);
+
+    // Apply key=value strings (e.g. "kv_cache.dtype=fp8"). Each entry is
+    // parsed via dotted-section lookup. Unknown keys log a warning but
+    // don't stop loading.
+    void apply_overrides(const std::vector<std::string>& kvs);
+
+    // Convenience: locate + load + apply overrides + log a one-line summary.
+    // Pass empty path to use the search-path default.
+    static RuntimeConfig load(const std::string& explicit_path,
+                              const std::vector<std::string>& overrides);
+};
+
+} // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -500,7 +500,7 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
 
     // FP8 prefill auto-disable for sub-8-bit models
     if (config_.use_fp8_prefill) {
-        auto qtype = model_->layer(0).wq_qtype;
+        auto qtype = model_->layer(0).wq.qtype;
         bool sub_8bit = (qtype == QType::Q4_0 || qtype == QType::Q4_K ||
                          qtype == QType::Q5_0 || qtype == QType::Q5_K ||
                          qtype == QType::Q3_K || qtype == QType::Q2_K ||
@@ -1323,7 +1323,7 @@ void Engine::warmup() {
     // and attempt to use raw MXFP4 data as FP16 weights.
     bool has_mxfp4_weights = false;
     for (int i = 0; i < model_->config().n_layers && !has_mxfp4_weights; i++) {
-        if (model_->layer(i).wq_qtype == QType::MXFP4) has_mxfp4_weights = true;
+        if (model_->layer(i).wq.qtype == QType::MXFP4) has_mxfp4_weights = true;
     }
     if (has_mxfp4_weights) {
         IMP_LOG_INFO("Warmup skipped (MXFP4 model)");

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1,4 +1,5 @@
 #include "runtime/engine.h"
+#include "runtime/config.h"
 #include "runtime/vram_budget.h"
 #include "runtime/speculative.h"
 #include "runtime/self_speculative.h"
@@ -337,12 +338,11 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // --- IMP_DEBUG_RAW: disable all optimization/cache/approximation paths ---
     // Meta-flag for debugging: forces the engine into a "naked" FP16 forward pass
     // for reproducible byte-level comparison against a reference implementation
-    // (e.g. llama.cpp). Sets downstream env vars before the auto-detect logic so
-    // that FP8/NVFP4/warmup/graphs are all forced off and cuBLAS is deterministic.
-    // User can still override individual knobs by setting the specific env before.
-    const bool debug_raw_ = (std::getenv("IMP_DEBUG_RAW") != nullptr);
+    // (e.g. llama.cpp). Forces downstream paths off (FP8/NVFP4/warmup/graphs)
+    // and cuBLAS to deterministic. Triggered via [runtime] debug_raw = true.
+    const bool debug_raw_ = RuntimeConfig::current().runtime.debug_raw;
     if (debug_raw_) {
-        IMP_LOG_INFO("IMP_DEBUG_RAW=1: naked FP16 path (FP8/NVFP4/graphs/warmup/FP8-KV off; deterministic cuBLAS)");
+        IMP_LOG_INFO("[runtime] debug_raw=true: naked FP16 path (FP8/NVFP4/graphs/warmup/FP8-KV off; deterministic cuBLAS)");
         // Weight storage: keep FP16 (skip the lossy cache paths)
         config_.use_fp8_prefill  = 0;
         config_.use_nvfp4_decode = 0;
@@ -375,12 +375,12 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // savings explicitly ask for FP8 via the existing flag.
     //
     // Legacy escape hatches kept for compatibility:
-    // - IMP_KV_FP16=1   forces FP16 (no-op under the new default; useful when
-    //                   something else re-enables FP8 downstream).
-    // - IMP_KV_FP8_AUTO=1 restores the old opt-out auto-upgrade behavior for
-    //                   users who rely on it for batch-serving VRAM budgets.
-    const bool force_kv_fp16  = (std::getenv("IMP_KV_FP16") != nullptr);
-    const bool fp8_auto_legacy = (std::getenv("IMP_KV_FP8_AUTO") != nullptr);
+    // - [kv_cache] dtype = "fp16" forces FP16 (no-op under the new default).
+    // - [kv_cache] fp8_auto_legacy = true restores the old opt-out auto-
+    //              upgrade behavior for users who rely on it for batch-
+    //              serving VRAM budgets.
+    const bool force_kv_fp16   = (RuntimeConfig::current().kv_cache.dtype == "fp16");
+    const bool fp8_auto_legacy = RuntimeConfig::current().kv_cache.fp8_auto_legacy;
     if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16) {
         config_.kv_cache_dtype = QType::FP8_E4M3;
         IMP_LOG_INFO("KV cache dtype: IMP_KV_FP8_AUTO=1 → FP8_E4M3 (legacy opt-out)");
@@ -403,13 +403,16 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // model is fine with non-deterministic FP8 KV can opt out via
     // IMP_ALLOW_NONDETERMINISTIC_FP8_KV=1.
     if (config_.kv_cache_dtype == QType::FP8_E4M3 &&
-        !getenv("IMP_ALLOW_NONDETERMINISTIC_FP8_KV") &&
-        !getenv("IMP_DETERMINISTIC_GEMM")) {
-        setenv("IMP_DETERMINISTIC_GEMM", "1", 1);
+        !RuntimeConfig::current().kv_cache.allow_nondeterministic_fp8 &&
+        !RuntimeConfig::current().runtime.deterministic_gemm) {
+        // Promote the runtime config in-place so downstream readers see it.
+        RuntimeConfig promoted = RuntimeConfig::current();
+        promoted.runtime.deterministic_gemm = true;
+        RuntimeConfig::install(promoted);
         setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", 0);
-        IMP_LOG_INFO("FP8 KV cache: forcing IMP_DETERMINISTIC_GEMM=1 "
+        IMP_LOG_INFO("FP8 KV cache: forcing runtime.deterministic_gemm=true "
                      "(non-deterministic cuBLAS + FP8 round-trip → NaN). "
-                     "Set IMP_ALLOW_NONDETERMINISTIC_FP8_KV=1 to opt out.");
+                     "Set kv_cache.allow_nondeterministic_fp8=true to opt out.");
     }
     // NOTE: compound FP8 precision loss (stacking FP8 KV on top of FP8
     // prefill + NVFP4 decode) is model-dependent. Mistral-Small-3.1 and
@@ -462,12 +465,12 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     }
 
     // --- Auto-detect FP8 prefill ---
-    // Under IMP_DEBUG_RAW or explicit IMP_NO_FP8_PREFILL, keep disabled.
-    // IMP_NO_FP8_PREFILL=1 is the user-facing escape hatch: some models
-    // (e.g. DeepSeek-R1-Distill-Qwen-14B Q6_K) produce garbage decode with
-    // FP8 weight cache active — accumulated dequant error through deep
-    // narrow-GQA stacks.
-    const bool no_fp8_prefill = (std::getenv("IMP_NO_FP8_PREFILL") != nullptr);
+    // Under runtime.debug_raw or [attention] fp8_prefill = "never", keep
+    // disabled. The "never" escape hatch is for models (e.g. DeepSeek-R1-
+    // Distill-Qwen-14B Q6_K) that produce garbage decode with FP8 weight
+    // cache active — accumulated dequant error through deep narrow-GQA
+    // stacks.
+    const bool no_fp8_prefill = (RuntimeConfig::current().attention.fp8_prefill == "never");
     if (!config_.use_fp8_prefill && !debug_raw_ && !no_fp8_prefill) {
         config_.use_fp8_prefill = true;
         IMP_LOG_INFO("FP8 prefill: auto → enabled");
@@ -549,26 +552,28 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         // from cuBLAS algo autotuning / split-K atomics amplifies into wildly
         // different top-1 picks (coherent " Paris" vs garbage "\n"). Force
         // deterministic GEMM paths so generation is stable run-to-run.
-        if (!getenv("IMP_DETERMINISTIC_GEMM")) {
-            setenv("IMP_DETERMINISTIC_GEMM", "1", 1);
-            IMP_LOG_INFO("Gemma 4: enabling IMP_DETERMINISTIC_GEMM (output_norm outliers amplify algo jitter)");
+        if (!RuntimeConfig::current().runtime.deterministic_gemm) {
+            RuntimeConfig promoted = RuntimeConfig::current();
+            promoted.runtime.deterministic_gemm = true;
+            RuntimeConfig::install(promoted);
+            IMP_LOG_INFO("Gemma 4: enabling runtime.deterministic_gemm (output_norm outliers amplify algo jitter)");
         }
         if (!getenv("CUBLAS_WORKSPACE_CONFIG")) {
             setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", 1);
             IMP_LOG_INFO("Gemma 4: setting CUBLAS_WORKSPACE_CONFIG=:4096:8 for deterministic grouped GEMM");
         }
-        // Gemma 4: CUDA graphs are fully enabled. forward_decode_async() now
-        // delegates to forward_logits() (the canonical path), eliminating the
-        // earlier divergence that caused EOS-at-step-0. Override with
-        // IMP_GEMMA4_NO_GRAPHS=1 for bisecting regressions.
-        if (getenv("IMP_GEMMA4_NO_GRAPHS")) {
-            IMP_LOG_INFO("Gemma 4: disabling all CUDA graphs (IMP_GEMMA4_NO_GRAPHS=1)");
+        // Gemma 4: CUDA graphs are fully enabled by default. The user can opt
+        // out via [gemma4] no_graphs = true for bisecting regressions.
+        if (RuntimeConfig::current().gemma4.no_graphs) {
+            IMP_LOG_INFO("Gemma 4: disabling all CUDA graphs (gemma4.no_graphs=true)");
             config_.use_cuda_graphs = false;
         }
         // Enable MMVQ for all weight GEMMs — quantized matmul matching llama.cpp's
         // accumulation behavior, critical for 128-expert MoE precision.
-        if (!getenv("IMP_GEMMA4_FORCE_MMVQ")) {
-            setenv("IMP_GEMMA4_FORCE_MMVQ", "1", 0);
+        if (!RuntimeConfig::current().gemma4.force_mmvq) {
+            RuntimeConfig promoted = RuntimeConfig::current();
+            promoted.gemma4.force_mmvq = true;
+            RuntimeConfig::install(promoted);
             IMP_LOG_INFO("Gemma 4: enabling MMVQ for all weight GEMMs (numerical parity with llama.cpp)");
         }
     }
@@ -576,9 +581,9 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // --- Auto-detect max_seq_len ---
     // Runs AFTER model-specific overrides (Gemma-4 forces FP16 KV etc.) so the
     // per-token cost reflects the actual dtype that will be allocated.
-    if (const char* env_msl = std::getenv("IMP_MAX_SEQ_LEN")) {
-        int v = std::atoi(env_msl);
-        if (v > 0) { config_.max_seq_len = v; IMP_LOG_INFO("max_seq_len: env IMP_MAX_SEQ_LEN=%d", v); }
+    if (int v = RuntimeConfig::current().runtime.max_seq_len; v > 0) {
+        config_.max_seq_len = v;
+        IMP_LOG_INFO("max_seq_len: runtime.max_seq_len=%d", v);
     }
     if (config_.max_seq_len <= 0) {
         int model_ctx = mcfg.max_seq_len;  // from GGUF metadata
@@ -619,8 +624,8 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     if (!init_weights()) return false;
     if (!init_kv_cache()) return false;
     if (!init_features()) return false;
-    if (getenv("IMP_NO_WARMUP")) {
-        IMP_LOG_INFO("Warmup SKIPPED (IMP_NO_WARMUP)");
+    if (!RuntimeConfig::current().runtime.warmup) {
+        IMP_LOG_INFO("Warmup SKIPPED (runtime.warmup=false)");
     } else {
         warmup();
     }
@@ -815,8 +820,8 @@ bool Engine::init_weights() {
                          "(+~180%% decode on Qwen 3.6 35B Q4_K_M).");
             config_.use_cuda_graphs = false;
         }
-        if (getenv("IMP_NO_CUDA_GRAPH") && config_.use_cuda_graphs) {
-            IMP_LOG_INFO("Disabling CUDA graphs: IMP_NO_CUDA_GRAPH set");
+        if (RuntimeConfig::current().runtime.cuda_graphs == "never" && config_.use_cuda_graphs) {
+            IMP_LOG_INFO("Disabling CUDA graphs: runtime.cuda_graphs=never");
             config_.use_cuda_graphs = false;
         }
         // MoE decode fast path is fully device-side (no D2H memcpy) — graph-safe.
@@ -2068,7 +2073,7 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
     std::vector<int32_t> tokens;
     Tensor decode_logits_out;
 
-    static const bool profiling = (std::getenv("IMP_PROFILE") != nullptr);
+    const bool profiling = RuntimeConfig::current().diagnostics.profile;
     int graph_idx = gpu_batch.n_sequences - 1;
     if (config_.use_cuda_graphs && !profiling &&
         gpu_batch.n_sequences > 0 &&

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -381,10 +381,10 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     //                   users who rely on it for batch-serving VRAM budgets.
     const bool force_kv_fp16  = (std::getenv("IMP_KV_FP16") != nullptr);
     const bool fp8_auto_legacy = (std::getenv("IMP_KV_FP8_AUTO") != nullptr);
-    if (fp8_auto_legacy && config_.kv_cache_dtype == DType::FP16 && !debug_raw_ && !force_kv_fp16) {
-        config_.kv_cache_dtype = DType::FP8_E4M3;
+    if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16) {
+        config_.kv_cache_dtype = QType::FP8_E4M3;
         IMP_LOG_INFO("KV cache dtype: IMP_KV_FP8_AUTO=1 → FP8_E4M3 (legacy opt-out)");
-    } else if (config_.kv_cache_dtype == DType::FP16) {
+    } else if (config_.kv_cache_dtype == QType::F16) {
         IMP_LOG_INFO("KV cache dtype: FP16 (default — pass --kv-fp8 for FP8 E4M3 memory savings)");
     }
 
@@ -402,7 +402,7 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // choice, does not disable tensor cores). Users who've verified their
     // model is fine with non-deterministic FP8 KV can opt out via
     // IMP_ALLOW_NONDETERMINISTIC_FP8_KV=1.
-    if (config_.kv_cache_dtype == DType::FP8_E4M3 &&
+    if (config_.kv_cache_dtype == QType::FP8_E4M3 &&
         !getenv("IMP_ALLOW_NONDETERMINISTIC_FP8_KV") &&
         !getenv("IMP_DETERMINISTIC_GEMM")) {
         setenv("IMP_DETERMINISTIC_GEMM", "1", 1);
@@ -455,8 +455,8 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
             if (model_->layer(i).gdn_gate.data != nullptr) { has_gdn_for_dtype = true; break; }
         }
     }
-    if (config_.ssm_state_dtype == DType::FP32 && mcfg.ssm_state_size > 0 && !has_gdn_for_dtype) {
-        config_.ssm_state_dtype = DType::FP16;
+    if (config_.ssm_state_dtype == QType::F32 && mcfg.ssm_state_size > 0 && !has_gdn_for_dtype) {
+        config_.ssm_state_dtype = QType::F16;
         IMP_LOG_INFO("SSM state dtype: auto → FP16 (hybrid SSM model, state_size=%d)",
                      mcfg.ssm_state_size);
     }
@@ -498,10 +498,10 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // FP8 prefill auto-disable for sub-8-bit models
     if (config_.use_fp8_prefill) {
         auto qtype = model_->layer(0).wq_qtype;
-        bool sub_8bit = (qtype == GGMLQuantType::Q4_0 || qtype == GGMLQuantType::Q4_K ||
-                         qtype == GGMLQuantType::Q5_0 || qtype == GGMLQuantType::Q5_K ||
-                         qtype == GGMLQuantType::Q3_K || qtype == GGMLQuantType::Q2_K ||
-                         qtype == GGMLQuantType::Q4_1 || qtype == GGMLQuantType::Q5_1);
+        bool sub_8bit = (qtype == QType::Q4_0 || qtype == QType::Q4_K ||
+                         qtype == QType::Q5_0 || qtype == QType::Q5_K ||
+                         qtype == QType::Q3_K || qtype == QType::Q2_K ||
+                         qtype == QType::Q4_1 || qtype == QType::Q5_1);
         if (sub_8bit) {
             config_.use_fp8_prefill = 0;
             IMP_LOG_INFO("FP8 prefill cache: auto-disabled (sub-8-bit weights)");
@@ -541,9 +541,9 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
             config_.dual_path_quant = false;
         }
         // Force FP16 KV cache (FP8 KV cache calibration reads narrow stride incorrectly)
-        if (config_.kv_cache_dtype == DType::FP8_E4M3) {
+        if (config_.kv_cache_dtype == QType::FP8_E4M3) {
             IMP_LOG_INFO("Gemma 4: forcing FP16 KV cache (FP8 stride mismatch)");
-            config_.kv_cache_dtype = DType::FP16;
+            config_.kv_cache_dtype = QType::F16;
         }
         // Gemma 4 output_norm has extreme outliers (max=588). Small numeric jitter
         // from cuBLAS algo autotuning / split-K atomics amplifies into wildly
@@ -587,8 +587,8 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         int head_dim = mcfg.head_dim > 0 ? mcfg.head_dim : (mcfg.d_model / mcfg.n_heads);
         // Per-token KV bytes for the real kv dtype (INT4/TQ pack 2 elems/byte).
         auto kv = config_.kv_cache_dtype;
-        bool packed_int4 = (kv == DType::INT4 || kv == DType::TURBOQUANT ||
-                            kv == DType::TURBOQUANT_LITE);
+        bool packed_int4 = (kv == QType::INT4 || kv == QType::TURBOQUANT ||
+                            kv == QType::TURBOQUANT_LITE);
         size_t per_tok_elems = static_cast<size_t>(mcfg.n_kv_heads) * head_dim *
                                mcfg.n_layers * 2;  // K+V, per KV head, all layers
         size_t kv_bytes_per_token = packed_int4 ? (per_tok_elems / 2)
@@ -656,7 +656,7 @@ bool Engine::init_weights() {
             // quantized variants don't yet skip -1 sentinels in their block
             // tables. Refuse to enable streaming with non-FP16 KV caches so
             // we never call evict_middle_blocks for an unsupported path.
-            if (config_.kv_cache_dtype != DType::FP16) {
+            if (config_.kv_cache_dtype != QType::F16) {
                 IMP_LOG_WARN("StreamingLLM smart KV cache requires FP16 KV cache "
                              "(requested %d) — disabling streaming.",
                              static_cast<int>(config_.kv_cache_dtype));
@@ -873,7 +873,7 @@ bool Engine::init_kv_cache() {
         ? config_.kv_cache_max_blocks : vram_budget.kv_max_blocks;
 
     {
-        DType kv_dtype = config_.kv_cache_dtype;
+        QType kv_dtype = config_.kv_cache_dtype;
         size_t block_bytes = static_cast<size_t>(kv_bs) * mcfg.n_kv_heads * head_dim * dtype_size(kv_dtype);
         size_t total_kv = static_cast<size_t>(n_kv_layers) * max_blocks * 2 * block_bytes;
         IMP_LOG_INFO("KV cache: %d blocks (%.0f tokens), %.2f MiB, dtype=%s "
@@ -886,9 +886,9 @@ bool Engine::init_kv_cache() {
 
     // Compute sketch_dim for TurboQuant / TurboQuant Lite (0 for other modes)
     int kv_sketch_dim = 0;
-    if (config_.kv_cache_dtype == DType::TURBOQUANT) {
+    if (config_.kv_cache_dtype == QType::TURBOQUANT) {
         kv_sketch_dim = head_dim;
-    } else if (config_.kv_cache_dtype == DType::TURBOQUANT_LITE) {
+    } else if (config_.kv_cache_dtype == QType::TURBOQUANT_LITE) {
         int mult = config_.turboquant_sketch_multiplier;
         if (mult <= 0) mult = 2;
         kv_sketch_dim = head_dim * mult;
@@ -896,7 +896,7 @@ bool Engine::init_kv_cache() {
 
     // MXFP4 TurboQuant: FP4 E2M1 + UE8M0 micro-scales (requires head_dim % 32 == 0)
     bool tq_use_mxfp4 = false;
-    if (config_.kv_cache_dtype == DType::TURBOQUANT && (head_dim % 32 == 0)) {
+    if (config_.kv_cache_dtype == QType::TURBOQUANT && (head_dim % 32 == 0)) {
         tq_use_mxfp4 = true;
         IMP_LOG_INFO("TurboQuant: using MXFP4 FP4 E2M1 + UE8M0 for K directions");
     }
@@ -905,10 +905,10 @@ bool Engine::init_kv_cache() {
     // nkv/hd arrays restricted to attention layers (hybrid models may have non-attn layers).
     std::unique_ptr<KVCache> kv_cache;
     if (!mcfg.head_dim_per_layer.empty() &&
-        config_.kv_cache_dtype != DType::TURBOQUANT &&
-        config_.kv_cache_dtype != DType::TURBOQUANT_LITE &&
-        config_.kv_cache_dtype != DType::INT8 &&
-        config_.kv_cache_dtype != DType::INT4) {
+        config_.kv_cache_dtype != QType::TURBOQUANT &&
+        config_.kv_cache_dtype != QType::TURBOQUANT_LITE &&
+        config_.kv_cache_dtype != QType::INT8 &&
+        config_.kv_cache_dtype != QType::INT4) {
         std::vector<int> per_layer_nkv(n_kv_layers, 0);
         std::vector<int> per_layer_hd(n_kv_layers, 0);
         for (int l = 0, k = 0; l < mcfg.n_layers && k < n_kv_layers; l++) {
@@ -951,11 +951,11 @@ bool Engine::init_kv_cache() {
     executor_->set_kv_layer_map(std::move(kv_layer_map));
 
     // Initialize QJL projection for TurboQuant / TurboQuant Lite KV cache
-    if (config_.kv_cache_dtype == DType::TURBOQUANT
-        || config_.kv_cache_dtype == DType::TURBOQUANT_LITE) {
+    if (config_.kv_cache_dtype == QType::TURBOQUANT
+        || config_.kv_cache_dtype == QType::TURBOQUANT_LITE) {
         auto& qjl = executor_->qjl_projection();
         int sketch_dim;
-        if (config_.kv_cache_dtype == DType::TURBOQUANT_LITE) {
+        if (config_.kv_cache_dtype == QType::TURBOQUANT_LITE) {
             int mult = config_.turboquant_sketch_multiplier;
             if (mult <= 0) mult = 2;
             sketch_dim = head_dim * mult;
@@ -1318,7 +1318,7 @@ void Engine::warmup() {
     // and attempt to use raw MXFP4 data as FP16 weights.
     bool has_mxfp4_weights = false;
     for (int i = 0; i < model_->config().n_layers && !has_mxfp4_weights; i++) {
-        if (model_->layer(i).wq_qtype == GGMLQuantType::MXFP4) has_mxfp4_weights = true;
+        if (model_->layer(i).wq_qtype == QType::MXFP4) has_mxfp4_weights = true;
     }
     if (has_mxfp4_weights) {
         IMP_LOG_INFO("Warmup skipped (MXFP4 model)");

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -34,7 +34,7 @@ struct EngineConfig {
     float green_ctx_prefill_ratio = 0.8f;
     bool use_cuda_graphs = true;
     bool use_pdl = true;
-    DType compute_dtype = DType::FP16;
+    QType compute_dtype = QType::F16;
 
     // Default sampling parameters
     float temperature = 1.0f;
@@ -43,13 +43,13 @@ struct EngineConfig {
     int seed = -1;
 
     // KV cache dtype: FP16 (default) or FP8_E4M3 for ~50% KV VRAM savings
-    DType kv_cache_dtype = DType::FP16;
+    QType kv_cache_dtype = QType::F16;
 
     // TurboQuant Lite: sketch_dim = turboquant_sketch_multiplier * head_dim
     int turboquant_sketch_multiplier = 2;
 
     // SSM state dtype: FP32 (default) or FP16 for ~50% VRAM savings on h_state
-    DType ssm_state_dtype = DType::FP32;
+    QType ssm_state_dtype = QType::F32;
 
     // VRAM budget: max GPU memory to use (MiB), 0 = use all available
     size_t vram_budget_mb = 0;

--- a/src/runtime/graph_diag.h
+++ b/src/runtime/graph_diag.h
@@ -1,12 +1,13 @@
 #pragma once
 
 // Diagnostics for CUDA-graph capture/replay (Milestone A1).
-// Activated via environment variables:
-//   IMP_GRAPH_DIAG=1           — enable post-launch error checks and logging
-//   IMP_GRAPH_DUMP=<path>      — dump verbose DOT of each captured graph
+// Activated via imp.conf:
+//   [diagnostics] graph_diag = true        — post-launch error checks + logging
+//   [diagnostics] graph_dump_dir = "<path>" — dump verbose DOT per graph
 // Off by default; no overhead when unset.
 
 #include "core/logging.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cstdlib>
 #include <cstring>
@@ -20,13 +21,12 @@ enum class Phase { NORMAL, CAPTURE, REPLAY };
 inline thread_local Phase g_phase = Phase::NORMAL;
 
 inline bool enabled() {
-    static const bool v = (std::getenv("IMP_GRAPH_DIAG") != nullptr);
-    return v;
+    return RuntimeConfig::current().diagnostics.graph_diag;
 }
 
 inline const char* dump_path() {
-    static const char* v = std::getenv("IMP_GRAPH_DUMP");
-    return v;
+    const std::string& d = RuntimeConfig::current().diagnostics.graph_dump_dir;
+    return d.empty() ? nullptr : d.c_str();
 }
 
 inline const char* phase_name(Phase p) {

--- a/src/runtime/ngram_spec.cpp
+++ b/src/runtime/ngram_spec.cpp
@@ -1,4 +1,5 @@
 #include "runtime/ngram_spec.h"
+#include "runtime/config.h"
 #include "core/logging.h"
 #include "compute/sampling.h"
 #include <cuda_runtime.h>
@@ -35,8 +36,8 @@ bool NgramSpecDecoder::init(GraphExecutor* executor, KVCacheManager* kv_manager,
 
     // Graph pool for verify forward pass (one per n_verify ∈ [2, spec_k+1]).
     // Sampling stays eager after replay — same pattern as self_speculative.
-    // Honors IMP_NO_CUDA_GRAPH: empty pool forces eager forward in verify().
-    if (!getenv("IMP_NO_CUDA_GRAPH")) {
+    // Honors [runtime] cuda_graphs = "never": empty pool forces eager forward.
+    if (RuntimeConfig::current().runtime.cuda_graphs != "never") {
         verify_graphs_.resize(max_tokens + 1);
         verify_graph_max_blocks_.assign(max_tokens + 1, -1);
         for (int i = 2; i <= max_tokens; ++i) {

--- a/src/runtime/pdl.cu
+++ b/src/runtime/pdl.cu
@@ -1,4 +1,5 @@
 #include "runtime/pdl.h"
+#include "runtime/config.h"
 #include "core/logging.h"
 #include <cuda_runtime.h>
 #include <unordered_set>
@@ -27,10 +28,8 @@ void disable(const void* kernel_func) {
 }
 
 bool is_enabled(const void* kernel_func) {
-    // DIAGNOSTIC: env var to disable PDL globally without rebuilding.
-    // Set IMP_NO_PDL=1 to fall back to standard <<<>>> launches.
-    static const bool s_no_pdl = (getenv("IMP_NO_PDL") != nullptr);
-    if (s_no_pdl) return false;
+    // Disable PDL globally via [runtime] no_pdl = true in imp.conf.
+    if (RuntimeConfig::current().runtime.no_pdl) return false;
     return enabled_kernels().count(kernel_func) > 0;
 }
 

--- a/src/runtime/self_speculative.cpp
+++ b/src/runtime/self_speculative.cpp
@@ -1,5 +1,6 @@
 #include "runtime/self_speculative.h"
 #include "runtime/speculative_common.h"
+#include "runtime/config.h"
 #include "compute/sampling.h"
 #include "core/logging.h"
 #include <cstring>
@@ -72,9 +73,9 @@ bool SelfSpeculativeDecoder::init(GraphExecutor* executor,
 
     // Pre-size verify graph pool for n_verify ∈ [2, spec_k+1]. One graph per
     // batch size avoids padding compute when draft shorter than K. Honors
-    // IMP_NO_CUDA_GRAPH — leaving the pool empty forces the eager forward
-    // path inside verify().
-    if (!getenv("IMP_NO_CUDA_GRAPH")) {
+    // [runtime] cuda_graphs = "never" leaves the pool empty, forcing the
+    // eager forward path inside verify().
+    if (RuntimeConfig::current().runtime.cuda_graphs != "never") {
         verify_graphs_.resize(max_n + 1);  // slot 0..1 unused, slots 2..max_n active
         verify_graph_max_blocks_.assign(max_n + 1, -1);
         for (int i = 2; i <= max_n; ++i) {

--- a/src/runtime/speculative.cpp
+++ b/src/runtime/speculative.cpp
@@ -246,10 +246,10 @@ SpeculativeDecoder::verify(const std::vector<int32_t>& draft,
     int vocab_size = static_cast<int>(logits.shape[logits.ndim - 1]);
 
     // Download logits to host for acceptance checking.
-    size_t logits_bytes = n_verify * vocab_size * dtype_size(logits.dtype);
+    size_t logits_bytes = n_verify * vocab_size * dtype_size(logits.qtype);
     std::vector<float> h_logits(n_verify * vocab_size);
 
-    if (logits.dtype == DType::FP32) {
+    if (logits.qtype == QType::F32) {
         IMP_CUDA_CHECK_LOG(cudaMemcpy(h_logits.data(), logits.data, logits_bytes, cudaMemcpyDeviceToHost));
     } else {
         // For FP16/BF16 logits, we need a conversion -- but for now, the
@@ -257,7 +257,7 @@ SpeculativeDecoder::verify(const std::vector<int32_t>& draft,
         // If not FP32, fall back to copying raw bytes and interpreting.
         // This path should not normally be hit since logits are computed in FP32.
         IMP_LOG_WARN("speculative: logits dtype is %s, expected FP32",
-                     dtype_name(logits.dtype));
+                     dtype_name(logits.qtype));
         IMP_CUDA_CHECK_LOG(cudaMemcpy(h_logits.data(), logits.data,
                    n_verify * vocab_size * sizeof(float), cudaMemcpyDeviceToHost));
     }

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -14,10 +14,10 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
 
     // --- 1. Classify model quantization ---
     auto qtype = model.layer(0).wq_qtype;
-    bool sub_8bit = (qtype == GGMLQuantType::Q4_0 || qtype == GGMLQuantType::Q4_K ||
-                     qtype == GGMLQuantType::Q5_0 || qtype == GGMLQuantType::Q5_K ||
-                     qtype == GGMLQuantType::Q3_K || qtype == GGMLQuantType::Q2_K ||
-                     qtype == GGMLQuantType::Q4_1 || qtype == GGMLQuantType::Q5_1);
+    bool sub_8bit = (qtype == QType::Q4_0 || qtype == QType::Q4_K ||
+                     qtype == QType::Q5_0 || qtype == QType::Q5_K ||
+                     qtype == QType::Q3_K || qtype == QType::Q2_K ||
+                     qtype == QType::Q4_1 || qtype == QType::Q5_1);
 
     // --- 2. Choose strategy ---
     if (config.use_nvfp4_decode == 0) {
@@ -64,9 +64,9 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
     // --- 4. Compute KV cache per-block cost ---
     int bs = config.kv_block_size > 0 ? config.kv_block_size : kKVBlockSize;
     size_t single_block_bytes;
-    bool is_tq = (config.kv_cache_dtype == DType::TURBOQUANT);
-    bool is_tql = (config.kv_cache_dtype == DType::TURBOQUANT_LITE);
-    if (config.kv_cache_dtype == DType::INT4 || is_tq || is_tql) {
+    bool is_tq = (config.kv_cache_dtype == QType::TURBOQUANT);
+    bool is_tql = (config.kv_cache_dtype == QType::TURBOQUANT_LITE);
+    if (config.kv_cache_dtype == QType::INT4 || is_tq || is_tql) {
         single_block_bytes = static_cast<size_t>(bs) *
                              mcfg.n_kv_heads * head_dim / 2;
     } else {
@@ -76,7 +76,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
     // TURBOQUANT_LITE: V-only pool (1x), all others: K+V (2x)
     size_t pool_multiplier = is_tql ? 1 : 2;
     size_t per_block_total = single_block_bytes * pool_multiplier * n_kv_layers;
-    if (config.kv_cache_dtype == DType::INT8 || config.kv_cache_dtype == DType::INT4
+    if (config.kv_cache_dtype == QType::INT8 || config.kv_cache_dtype == QType::INT4
         || is_tq || is_tql) {
         size_t scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * sizeof(half);
         per_block_total += scale_per_block * 2 * n_kv_layers;  // K norms + V scales (always 2x)
@@ -104,8 +104,8 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
     int needed_blocks = blocks_per_seq * config.max_batch_size;
 
     // --- 5. Estimate NVFP4-eligible weight cache size ---
-    auto nvfp4_beneficial = [](GGMLQuantType qt) -> bool {
-        using enum GGMLQuantType;
+    auto nvfp4_beneficial = [](QType qt) -> bool {
+        using enum QType;
         switch (qt) {
             case Q8_0: case Q8_K:
             case Q6_K: case Q5_K:
@@ -115,7 +115,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
     };
 
     size_t nvfp4_elems = 0;
-    auto count_nvfp4 = [&](const Tensor& w, GGMLQuantType qt) {
+    auto count_nvfp4 = [&](const Tensor& w, QType qt) {
         if (!w.data || !nvfp4_beneficial(qt)) return;
         if (w.shape[1] % 16 != 0) return;
         nvfp4_elems += static_cast<size_t>(w.shape[0]) * w.shape[1];

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -13,7 +13,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
     const auto& mcfg = model.config();
 
     // --- 1. Classify model quantization ---
-    auto qtype = model.layer(0).wq_qtype;
+    auto qtype = model.layer(0).wq.qtype;
     bool sub_8bit = (qtype == QType::Q4_0 || qtype == QType::Q4_K ||
                      qtype == QType::Q5_0 || qtype == QType::Q5_K ||
                      qtype == QType::Q3_K || qtype == QType::Q2_K ||
@@ -121,21 +121,21 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config,
         nvfp4_elems += static_cast<size_t>(w.shape[0]) * w.shape[1];
     };
 
-    count_nvfp4(model.output_proj(), model.out_proj_qtype_);
+    count_nvfp4(model.output_proj(), model.out_proj_.qtype);
     for (int i = 0; i < mcfg.n_layers; i++) {
         const auto& L = model.layer(i);
-        count_nvfp4(L.wq, L.wq_qtype);
-        count_nvfp4(L.wk, L.wk_qtype);
-        count_nvfp4(L.wv, L.wv_qtype);
-        count_nvfp4(L.wo, L.wo_qtype);
-        count_nvfp4(L.w_gate, L.w_gate_qtype);
-        count_nvfp4(L.w_up, L.w_up_qtype);
-        count_nvfp4(L.w_down, L.w_down_qtype);
-        count_nvfp4(L.ssm_in, L.ssm_in_qtype);
-        count_nvfp4(L.ssm_out, L.ssm_out_qtype);
-        count_nvfp4(L.w_gate_shared, L.w_gate_shared_qtype);
-        count_nvfp4(L.w_up_shared, L.w_up_shared_qtype);
-        count_nvfp4(L.w_down_shared, L.w_down_shared_qtype);
+        count_nvfp4(L.wq, L.wq.qtype);
+        count_nvfp4(L.wk, L.wk.qtype);
+        count_nvfp4(L.wv, L.wv.qtype);
+        count_nvfp4(L.wo, L.wo.qtype);
+        count_nvfp4(L.w_gate, L.w_gate.qtype);
+        count_nvfp4(L.w_up, L.w_up.qtype);
+        count_nvfp4(L.w_down, L.w_down.qtype);
+        count_nvfp4(L.ssm_in, L.ssm_in.qtype);
+        count_nvfp4(L.ssm_out, L.ssm_out.qtype);
+        count_nvfp4(L.w_gate_shared, L.w_gate_shared.qtype);
+        count_nvfp4(L.w_up_shared, L.w_up_shared.qtype);
+        count_nvfp4(L.w_down_shared, L.w_down_shared.qtype);
     }
 
     size_t nvfp4_estimate = nvfp4_elems / 2 + nvfp4_elems / 16;

--- a/src/vision/vision_encoder.cu
+++ b/src/vision/vision_encoder.cu
@@ -2,6 +2,7 @@
 #include "compute/warp_reduce.cuh"
 #include "memory/vram_allocator.h"
 #include "core/logging.h"
+#include "runtime/config.h"
 
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
@@ -436,8 +437,8 @@ bool VisionEncoder::encode(const half* d_pixels, half* d_output, cudaStream_t st
     // the per-kernel launch overhead. The graph is keyed on (d_pixels,
     // d_output); any pointer change invalidates the captured slot.
     //
-    // Env override: IMP_NO_VISION_GRAPH=1 forces the eager path (debugging).
-    static const bool disable_graph = (std::getenv("IMP_NO_VISION_GRAPH") != nullptr);
+    // [runtime] no_vision_graph = true forces the eager path (debugging).
+    const bool disable_graph = RuntimeConfig::current().runtime.no_vision_graph;
     if (disable_graph) {
         return encode_impl(d_pixels, d_output, stream);
     }

--- a/src/vision/vision_loader.cpp
+++ b/src/vision/vision_loader.cpp
@@ -157,7 +157,7 @@ uint64_t val_uint(const VGGUFValue& v) {
 
 // Upload raw tensor data to GPU as FP16.
 // Handles F32 -> FP16 conversion and F16 passthrough.
-bool upload_tensor_fp16(const void* src, GGMLType type,
+bool upload_tensor_fp16(const void* src, GgufWireType type,
                         int64_t n_elements, void** d_out,
                         std::vector<void*>& gpu_allocs) {
     size_t fp16_bytes = static_cast<size_t>(n_elements) * sizeof(half);
@@ -168,9 +168,9 @@ bool upload_tensor_fp16(const void* src, GGMLType type,
     }
     gpu_allocs.push_back(d_ptr);
 
-    if (type == GGMLType::F16) {
+    if (type == GgufWireType::F16) {
         IMP_CUDA_CHECK_LOG(cudaMemcpy(d_ptr, src, fp16_bytes, cudaMemcpyHostToDevice));
-    } else if (type == GGMLType::F32) {
+    } else if (type == GgufWireType::F32) {
         // Convert F32 -> F16 on host, then upload
         const float* f32 = static_cast<const float*>(src);
         std::vector<half> h_fp16(static_cast<size_t>(n_elements));
@@ -178,7 +178,7 @@ bool upload_tensor_fp16(const void* src, GGMLType type,
             h_fp16[i] = __float2half(f32[i]);
         }
         IMP_CUDA_CHECK_LOG(cudaMemcpy(d_ptr, h_fp16.data(), fp16_bytes, cudaMemcpyHostToDevice));
-    } else if (type == GGMLType::BF16) {
+    } else if (type == GgufWireType::BF16) {
         // Convert BF16 -> FP16 on host
         const uint16_t* bf16 = static_cast<const uint16_t*>(src);
         std::vector<half> h_fp16(static_cast<size_t>(n_elements));
@@ -269,7 +269,7 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
         std::string name;
         uint32_t n_dims;
         int64_t dims[4];
-        GGMLType type;
+        GgufWireType type;
         uint64_t offset;
     };
 
@@ -286,7 +286,7 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
             reader.read_u64();
         for (uint32_t d = info.n_dims; d < 4; d++)
             info.dims[d] = 1;
-        info.type = static_cast<GGMLType>(reader.read_u32());
+        info.type = static_cast<GgufWireType>(reader.read_u32());
         info.offset = reader.read_u64();
         tensor_infos.push_back(std::move(info));
     }
@@ -380,7 +380,7 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
         }
 
         // Create Tensor (on_device = true)
-        Tensor t(d_ptr, DType::FP16, static_cast<int>(info.n_dims), shape, true);
+        Tensor t(d_ptr, QType::F16, static_cast<int>(info.n_dims), shape, true);
 
         const auto& name = info.name;
 

--- a/tests/test_activation.cu
+++ b/tests/test_activation.cu
@@ -12,19 +12,19 @@
 namespace imp {
 namespace {
 
-Tensor make_gpu_tensor(const float* host_data, DType dtype,
+Tensor make_gpu_tensor(const float* host_data, QType dtype,
                        std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
     t.compute_strides();
     t.on_device = true;
     cudaMalloc(&t.data, t.nbytes());
-    if (dtype == DType::FP32) {
+    if (dtype == QType::F32) {
         cudaMemcpy(t.data, host_data, t.nbytes(), cudaMemcpyHostToDevice);
-    } else if (dtype == DType::FP16) {
+    } else if (dtype == QType::F16) {
         std::vector<half> h(t.numel());
         for (int64_t j = 0; j < t.numel(); j++)
             h[j] = __float2half(host_data[j]);
@@ -33,9 +33,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     return t;
 }
 
-Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) {
+Tensor alloc_gpu_tensor(QType dtype, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -48,9 +48,9 @@ Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) 
 
 std::vector<float> read_gpu_tensor(const Tensor& t) {
     std::vector<float> result(t.numel());
-    if (t.dtype == DType::FP32) {
+    if (t.qtype == QType::F32) {
         cudaMemcpy(result.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
-    } else if (t.dtype == DType::FP16) {
+    } else if (t.qtype == QType::F16) {
         std::vector<half> h(t.numel());
         cudaMemcpy(h.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
         for (int64_t j = 0; j < t.numel(); j++)
@@ -90,9 +90,9 @@ TEST(ActivationTest, SwiGLUBasicFP32) {
     for (int i = 0; i < N; i++)
         h_ref[i] = cpu_silu(h_gate[i]) * h_up[i];
 
-    Tensor d_gate = make_gpu_tensor(h_gate.data(), DType::FP32, {N});
-    Tensor d_up   = make_gpu_tensor(h_up.data(), DType::FP32, {N});
-    Tensor d_out  = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_gate = make_gpu_tensor(h_gate.data(), QType::F32, {N});
+    Tensor d_up   = make_gpu_tensor(h_up.data(), QType::F32, {N});
+    Tensor d_out  = alloc_gpu_tensor(QType::F32, {N});
 
     swiglu(d_gate, d_up, d_out);
     cudaDeviceSynchronize();
@@ -114,9 +114,9 @@ TEST(ActivationTest, SwiGLUZeroGate) {
     std::vector<float> h_gate(N, 0.0f);
     std::vector<float> h_up = {1.0f, 2.0f, 3.0f, 4.0f};
 
-    Tensor d_gate = make_gpu_tensor(h_gate.data(), DType::FP32, {N});
-    Tensor d_up   = make_gpu_tensor(h_up.data(), DType::FP32, {N});
-    Tensor d_out  = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_gate = make_gpu_tensor(h_gate.data(), QType::F32, {N});
+    Tensor d_up   = make_gpu_tensor(h_up.data(), QType::F32, {N});
+    Tensor d_out  = alloc_gpu_tensor(QType::F32, {N});
 
     swiglu(d_gate, d_up, d_out);
     cudaDeviceSynchronize();
@@ -144,9 +144,9 @@ TEST(ActivationTest, SwiGLUFP16) {
         h_ref[i] = cpu_silu(g) * u;
     }
 
-    Tensor d_gate = make_gpu_tensor(h_gate.data(), DType::FP16, {N});
-    Tensor d_up   = make_gpu_tensor(h_up.data(), DType::FP16, {N});
-    Tensor d_out  = alloc_gpu_tensor(DType::FP16, {N});
+    Tensor d_gate = make_gpu_tensor(h_gate.data(), QType::F16, {N});
+    Tensor d_up   = make_gpu_tensor(h_up.data(), QType::F16, {N});
+    Tensor d_out  = alloc_gpu_tensor(QType::F16, {N});
 
     swiglu(d_gate, d_up, d_out);
     cudaDeviceSynchronize();
@@ -172,9 +172,9 @@ TEST(ActivationTest, SwiGLULargeVector) {
         h_ref[i] = cpu_silu(h_gate[i]) * h_up[i];
     }
 
-    Tensor d_gate = make_gpu_tensor(h_gate.data(), DType::FP32, {N});
-    Tensor d_up   = make_gpu_tensor(h_up.data(), DType::FP32, {N});
-    Tensor d_out  = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_gate = make_gpu_tensor(h_gate.data(), QType::F32, {N});
+    Tensor d_up   = make_gpu_tensor(h_up.data(), QType::F32, {N});
+    Tensor d_out  = alloc_gpu_tensor(QType::F32, {N});
 
     swiglu(d_gate, d_up, d_out);
     cudaDeviceSynchronize();
@@ -200,9 +200,9 @@ TEST(ActivationTest, SwiGLUNonAligned) {
     for (int i = 0; i < N; i++)
         h_ref[i] = cpu_silu(h_gate[i]) * h_up[i];
 
-    Tensor d_gate = make_gpu_tensor(h_gate.data(), DType::FP32, {N});
-    Tensor d_up   = make_gpu_tensor(h_up.data(), DType::FP32, {N});
-    Tensor d_out  = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_gate = make_gpu_tensor(h_gate.data(), QType::F32, {N});
+    Tensor d_up   = make_gpu_tensor(h_up.data(), QType::F32, {N});
+    Tensor d_out  = alloc_gpu_tensor(QType::F32, {N});
 
     swiglu(d_gate, d_up, d_out);
     cudaDeviceSynchronize();
@@ -230,8 +230,8 @@ TEST(ActivationTest, GELUBasicFP32) {
     for (int i = 0; i < N; i++)
         h_ref[i] = cpu_gelu(h_x[i]);
 
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {N});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {N});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {N});
 
     gelu(d_x, d_out);
     cudaDeviceSynchronize();
@@ -249,8 +249,8 @@ TEST(ActivationTest, GELUBasicFP32) {
 TEST(ActivationTest, GELUZero) {
     // gelu(0) = 0
     std::vector<float> h_x = {0.0f};
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {1});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {1});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {1});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {1});
 
     gelu(d_x, d_out);
     cudaDeviceSynchronize();
@@ -266,8 +266,8 @@ TEST(ActivationTest, GELUSymmetry) {
     // gelu(-x) should be close to -x * sigmoid(-1.702*x) for the tanh approx
     // More practically: gelu(large_positive) ≈ x, gelu(large_negative) ≈ 0
     std::vector<float> h_x = {10.0f, -10.0f};
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {2});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {2});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {2});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {2});
 
     gelu(d_x, d_out);
     cudaDeviceSynchronize();
@@ -290,8 +290,8 @@ TEST(ActivationTest, GELUFP16) {
         h_ref[i] = cpu_gelu(x);
     }
 
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP16, {N});
-    Tensor d_out = alloc_gpu_tensor(DType::FP16, {N});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F16, {N});
+    Tensor d_out = alloc_gpu_tensor(QType::F16, {N});
 
     gelu(d_x, d_out);
     cudaDeviceSynchronize();
@@ -323,9 +323,9 @@ TEST(ActivationTest, GeGLUBasicFP16) {
         h_ref[i] = cpu_gelu(g) * u;
     }
 
-    Tensor d_gate = make_gpu_tensor(h_gate.data(), DType::FP16, {N});
-    Tensor d_up   = make_gpu_tensor(h_up.data(), DType::FP16, {N});
-    Tensor d_out  = alloc_gpu_tensor(DType::FP16, {N});
+    Tensor d_gate = make_gpu_tensor(h_gate.data(), QType::F16, {N});
+    Tensor d_up   = make_gpu_tensor(h_up.data(), QType::F16, {N});
+    Tensor d_out  = alloc_gpu_tensor(QType::F16, {N});
 
     geglu(d_gate, d_up, d_out);
     cudaDeviceSynchronize();
@@ -350,9 +350,9 @@ TEST(ActivationTest, GeGLUBasicFP32) {
     for (int i = 0; i < N; i++)
         h_ref[i] = cpu_gelu(h_gate[i]) * h_up[i];
 
-    Tensor d_gate = make_gpu_tensor(h_gate.data(), DType::FP32, {N});
-    Tensor d_up   = make_gpu_tensor(h_up.data(), DType::FP32, {N});
-    Tensor d_out  = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_gate = make_gpu_tensor(h_gate.data(), QType::F32, {N});
+    Tensor d_up   = make_gpu_tensor(h_up.data(), QType::F32, {N});
+    Tensor d_out  = alloc_gpu_tensor(QType::F32, {N});
 
     geglu(d_gate, d_up, d_out);
     cudaDeviceSynchronize();
@@ -374,8 +374,8 @@ TEST(ActivationTest, GeluInfInput) {
     float inf = std::numeric_limits<float>::infinity();
     std::vector<float> h_x = {inf, -inf, 0.0f, 1.0f};
 
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {N});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {N});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {N});
 
     gelu(d_x, d_out);
     cudaDeviceSynchronize();
@@ -404,8 +404,8 @@ TEST(SoftmaxTest, BasicFP32) {
         1.0f, 1.0f, 1.0f, 1.0f   // row 1: uniform => all 0.25
     };
 
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {rows, cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {rows, cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {rows, cols});
 
     softmax(d_x, d_out);
     cudaDeviceSynchronize();
@@ -445,8 +445,8 @@ TEST(SoftmaxTest, NumericalStability) {
     }
     for (int i = 0; i < N; i++) h_ref[i] /= sum;
 
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {1, N});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {1, N});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {1, N});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {1, N});
 
     softmax(d_x, d_out);
     cudaDeviceSynchronize();
@@ -465,8 +465,8 @@ TEST(SoftmaxTest, NumericalStability) {
 
 TEST(SoftmaxTest, SingleElement) {
     std::vector<float> h_x = {5.0f};
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {1, 1});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {1, 1});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {1, 1});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {1, 1});
 
     softmax(d_x, d_out);
     cudaDeviceSynchronize();
@@ -483,8 +483,8 @@ TEST(SoftmaxTest, FP16) {
     constexpr int cols = 8;
     std::vector<float> h_x = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f};
 
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP16, {rows, cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP16, {rows, cols});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F16, {rows, cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F16, {rows, cols});
 
     softmax(d_x, d_out);
     cudaDeviceSynchronize();
@@ -510,8 +510,8 @@ TEST(SoftmaxTest, LargeRow) {
     for (int i = 0; i < cols; i++)
         h_x[i] = std::sin(static_cast<float>(i) * 0.01f);
 
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {1, cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {1, cols});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {1, cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {1, cols});
 
     softmax(d_x, d_out);
     cudaDeviceSynchronize();

--- a/tests/test_attention_fmha_mxfp4.cu
+++ b/tests/test_attention_fmha_mxfp4.cu
@@ -84,10 +84,10 @@ void run_compare_test(int B, int SQ, int SKV, int NH, int NKV, int HD,
     // MXFP4 Flash Attention
     {
         cudaMemset(d_o_mxfp4, 0, qo_elems * sizeof(half));
-        Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-        Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-        Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-        Tensor O(d_o_mxfp4, DType::FP16, 4, qo_shape, true);
+        Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+        Tensor K(d_k, QType::F16, 4, kv_shape, true);
+        Tensor V(d_v, QType::F16, 4, kv_shape, true);
+        Tensor O(d_o_mxfp4, QType::F16, 4, qo_shape, true);
         bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal,
                                             sliding_window, softcap, stream);
         ASSERT_TRUE(ok) << "MXFP4 FMHA returned false for HD=" << HD;
@@ -96,10 +96,10 @@ void run_compare_test(int B, int SQ, int SKV, int NH, int NKV, int HD,
     // FP16 reference
     {
         cudaMemset(d_o_ref, 0, qo_elems * sizeof(half));
-        Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-        Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-        Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-        Tensor O(d_o_ref, DType::FP16, 4, qo_shape, true);
+        Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+        Tensor K(d_k, QType::F16, 4, kv_shape, true);
+        Tensor V(d_v, QType::F16, 4, kv_shape, true);
+        Tensor O(d_o_ref, QType::F16, 4, qo_shape, true);
         if (sm >= 120)
             flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream);
         else
@@ -243,13 +243,13 @@ static void run_blockscale_ab_test(int B, int SQ, int SKV, int NH, int NKV,
     int64_t kv_shape[] = {B, SKV, NKV, HD};
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
 
-    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
+    Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
 
     {
         cudaMemset(d_o_leg, 0, qo_elems * sizeof(half));
-        Tensor O(d_o_leg, DType::FP16, 4, qo_shape, true);
+        Tensor O(d_o_leg, QType::F16, 4, qo_shape, true);
         bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal,
                                              sliding_window, softcap, stream,
                                              /*use_blockscale=*/false);
@@ -257,7 +257,7 @@ static void run_blockscale_ab_test(int B, int SQ, int SKV, int NH, int NKV,
     }
     {
         cudaMemset(d_o_bs, 0, qo_elems * sizeof(half));
-        Tensor O(d_o_bs, DType::FP16, 4, qo_shape, true);
+        Tensor O(d_o_bs, QType::F16, 4, qo_shape, true);
         bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal,
                                              sliding_window, softcap, stream,
                                              /*use_blockscale=*/true);
@@ -332,10 +332,10 @@ TEST_F(FhmaMxFP4Test, RejectsHD48) {
 
     int64_t qo_shape[] = {B, SQ, NH, HD};
     int64_t kv_shape[] = {B, SKV, NKV, HD};
-    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+    Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, qo_shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
     bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, true, 0, 0.0f, stream_);

--- a/tests/test_attention_fmha_sm120.cu
+++ b/tests/test_attention_fmha_sm120.cu
@@ -127,10 +127,10 @@ protected:
 
         int64_t q_shape[]  = {B, Sq, NH, HD};
         int64_t kv_shape[] = {B, Skv, NKV, HD};
-        Tensor Qt(d_q, DType::FP16, 4, q_shape, true);
-        Tensor Kt(d_k, DType::FP16, 4, kv_shape, true);
-        Tensor Vt(d_v, DType::FP16, 4, kv_shape, true);
-        Tensor Ot(d_o, DType::FP16, 4, q_shape, true);
+        Tensor Qt(d_q, QType::F16, 4, q_shape, true);
+        Tensor Kt(d_k, QType::F16, 4, kv_shape, true);
+        Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
+        Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
         bool ok = fmha_sm120_prefill(Qt, Kt, Vt, Ot, scale, causal,
                                       sliding_window, softcap, stream_);
@@ -260,10 +260,10 @@ TEST_F(FmhaSm120Test, DISABLED_DispatchManual) {
     cudaMemsetAsync(d_o, 0, bytes, stream_);
 
     int64_t shape[] = {B, S, NH, HD};
-    Tensor Q(d_q, DType::FP16, 4, shape, true);
-    Tensor K(d_k, DType::FP16, 4, shape, true);
-    Tensor V(d_v, DType::FP16, 4, shape, true);
-    Tensor O(d_o, DType::FP16, 4, shape, true);
+    Tensor Q(d_q, QType::F16, 4, shape, true);
+    Tensor K(d_k, QType::F16, 4, shape, true);
+    Tensor V(d_v, QType::F16, 4, shape, true);
+    Tensor O(d_o, QType::F16, 4, shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
 

--- a/tests/test_attention_mxfp4.cu
+++ b/tests/test_attention_mxfp4.cu
@@ -103,10 +103,10 @@ TEST_F(AttentionMxFP4Test, BasicPrefill) {
 
     int64_t qo_shape[] = {B, SQ, NH, HD};
     int64_t kv_shape[] = {B, SKV, NKV, HD};
-    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+    Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, qo_shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
 
@@ -162,10 +162,10 @@ TEST_F(AttentionMxFP4Test, CompareWithFP16Reference) {
     // MXFP4 path
     {
         cudaMemset(d_o_mxfp4, 0, qo_elems * sizeof(half));
-        Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-        Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-        Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-        Tensor O(d_o_mxfp4, DType::FP16, 4, qo_shape, true);
+        Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+        Tensor K(d_k, QType::F16, 4, kv_shape, true);
+        Tensor V(d_v, QType::F16, 4, kv_shape, true);
+        Tensor O(d_o_mxfp4, QType::F16, 4, qo_shape, true);
         bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
         ASSERT_TRUE(ok);
     }
@@ -173,10 +173,10 @@ TEST_F(AttentionMxFP4Test, CompareWithFP16Reference) {
     // FP16 reference (Blackwell or TC kernel)
     {
         cudaMemset(d_o_ref, 0, qo_elems * sizeof(half));
-        Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-        Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-        Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-        Tensor O(d_o_ref, DType::FP16, 4, qo_shape, true);
+        Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+        Tensor K(d_k, QType::F16, 4, kv_shape, true);
+        Tensor V(d_v, QType::F16, 4, kv_shape, true);
+        Tensor O(d_o_ref, QType::F16, 4, qo_shape, true);
         if (sm_ >= 120) {
             flash_attention_blackwell(Q, K, V, O, scale, true, 0, 0.0f, stream_);
         } else {
@@ -231,10 +231,10 @@ TEST_F(AttentionMxFP4Test, GQASupport) {
 
     int64_t qo_shape[] = {B, SQ, NH, HD};
     int64_t kv_shape[] = {B, SKV, NKV, HD};
-    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+    Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, qo_shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
     bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
@@ -275,10 +275,10 @@ TEST_F(AttentionMxFP4Test, HeadDim128) {
 
     int64_t qo_shape[] = {B, SQ, NH, HD};
     int64_t kv_shape[] = {B, SKV, NKV, HD};
-    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+    Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, qo_shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
     bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
@@ -309,10 +309,10 @@ TEST_F(AttentionMxFP4Test, RejectsInvalidHeadDim) {
     cudaMemset(d_v, 0, elems * sizeof(half));
 
     int64_t shape[] = {B, SQ, NH, HD};
-    Tensor Q(d_q, DType::FP16, 4, shape, true);
-    Tensor K(d_k, DType::FP16, 4, shape, true);
-    Tensor V(d_v, DType::FP16, 4, shape, true);
-    Tensor O(d_o, DType::FP16, 4, shape, true);
+    Tensor Q(d_q, QType::F16, 4, shape, true);
+    Tensor K(d_k, QType::F16, 4, shape, true);
+    Tensor V(d_v, QType::F16, 4, shape, true);
+    Tensor O(d_o, QType::F16, 4, shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
     bool ok = attention_mxfp4_prefill(Q, K, V, O, scale, true, 0.0f, stream_);
@@ -343,10 +343,10 @@ TEST_F(AttentionMxFP4Test, SoftcapSupport) {
 
     int64_t qo_shape[] = {B, SQ, NH, HD};
     int64_t kv_shape[] = {B, SKV, NKV, HD};
-    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+    Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, qo_shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
     float softcap = 50.0f;  // Gemma-2/3 style

--- a/tests/test_attention_tc.cu
+++ b/tests/test_attention_tc.cu
@@ -65,10 +65,10 @@ TEST_F(AttentionTCTest, SmallPrefill) {
 
     int64_t qo_shape[] = {B, S, NH, HD};
     int64_t kv_shape[] = {B, S, NH, HD};
-    Tensor Q(d_q, DType::FP16, 4, qo_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, qo_shape, true);
+    Tensor Q(d_q, QType::F16, 4, qo_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, qo_shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
     flash_attention_prefill_tc(Q, K, V, O, scale, true, 0, 0.0f, stream_);
@@ -111,10 +111,10 @@ TEST_F(AttentionTCTest, DispatchSelectsCorrectKernel) {
     cudaMemset(d_o, 0, bytes);
 
     int64_t shape[] = {B, S, NH, HD};
-    Tensor Q(d_q, DType::FP16, 4, shape, true);
-    Tensor K(d_k, DType::FP16, 4, shape, true);
-    Tensor V(d_v, DType::FP16, 4, shape, true);
-    Tensor O(d_o, DType::FP16, 4, shape, true);
+    Tensor Q(d_q, QType::F16, 4, shape, true);
+    Tensor K(d_k, QType::F16, 4, shape, true);
+    Tensor V(d_v, QType::F16, 4, shape, true);
+    Tensor O(d_o, QType::F16, 4, shape, true);
 
     float scale = 1.0f / std::sqrt(static_cast<float>(HD));
     EXPECT_NO_THROW(attention_prefill_dispatch(Q, K, V, O, scale, true, 0, 0.0f, stream_));
@@ -240,10 +240,10 @@ protected:
 
         int64_t q_shape[]  = {B, Sq, NH, HD};
         int64_t kv_shape[] = {B, Skv, NKV, HD};
-        Tensor Qt(d_q, DType::FP16, 4, q_shape, true);
-        Tensor Kt(d_k, DType::FP16, 4, kv_shape, true);
-        Tensor Vt(d_v, DType::FP16, 4, kv_shape, true);
-        Tensor Ot(d_o, DType::FP16, 4, q_shape, true);
+        Tensor Qt(d_q, QType::F16, 4, q_shape, true);
+        Tensor Kt(d_k, QType::F16, 4, kv_shape, true);
+        Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
+        Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
         flash_attention_blackwell(Qt, Kt, Vt, Ot, scale, causal, 0, 0.0f, stream_);
         cudaStreamSynchronize(stream_);
@@ -395,10 +395,10 @@ TEST_F(AttentionBlackwellTest, SlidingWindow) {
 
     int64_t q_shape[]  = {B, Sq, NH, HD};
     int64_t kv_shape[] = {B, Skv, NKV, HD};
-    Tensor Qt(d_q, DType::FP16, 4, q_shape, true);
-    Tensor Kt(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor Vt(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor Ot(d_o, DType::FP16, 4, q_shape, true);
+    Tensor Qt(d_q, QType::F16, 4, q_shape, true);
+    Tensor Kt(d_k, QType::F16, 4, kv_shape, true);
+    Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
+    Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
     flash_attention_blackwell(Qt, Kt, Vt, Ot, scale, /*causal=*/true,
                               sliding_window, 0.0f, stream_);

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+#include "runtime/config.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+namespace imp {
+namespace {
+
+// Helper to write a temporary config file and clean it up.
+struct TempFile {
+    std::string path;
+    explicit TempFile(const std::string& body) {
+        path = "/tmp/imp_test_config_" + std::to_string(::getpid()) + ".conf";
+        std::ofstream ofs(path);
+        ofs << body;
+    }
+    ~TempFile() { std::remove(path.c_str()); }
+};
+
+TEST(RuntimeConfigTest, DefaultsAreSane) {
+    RuntimeConfig cfg;
+    EXPECT_FALSE(cfg.runtime.deterministic_gemm);
+    EXPECT_EQ(cfg.runtime.cuda_graphs, "auto");
+    EXPECT_TRUE(cfg.runtime.warmup);
+    EXPECT_EQ(cfg.kv_cache.dtype, "fp16");
+    EXPECT_EQ(cfg.moe.expert_overhead_pct, 10);
+    EXPECT_FALSE(cfg.gdn.fp32_scan);
+    EXPECT_EQ(cfg.diagnostics.exit_layer, -1);
+}
+
+TEST(RuntimeConfigTest, ParsesBasicSections) {
+    TempFile f(R"(
+[runtime]
+deterministic_gemm = true
+cuda_graphs = "never"
+
+[kv_cache]
+dtype = "fp8"
+
+[moe]
+expert_overhead_pct = 30
+)");
+
+    RuntimeConfig cfg;
+    ASSERT_TRUE(cfg.load_from_file(f.path));
+    EXPECT_TRUE(cfg.runtime.deterministic_gemm);
+    EXPECT_EQ(cfg.runtime.cuda_graphs, "never");
+    EXPECT_EQ(cfg.kv_cache.dtype, "fp8");
+    EXPECT_EQ(cfg.moe.expert_overhead_pct, 30);
+}
+
+TEST(RuntimeConfigTest, IgnoresCommentsAndBlankLines) {
+    TempFile f(R"(
+# top comment
+[runtime]
+# inline comment
+
+deterministic_gemm = true   # trailing comment
+warmup              = false
+)");
+
+    RuntimeConfig cfg;
+    ASSERT_TRUE(cfg.load_from_file(f.path));
+    EXPECT_TRUE(cfg.runtime.deterministic_gemm);
+    EXPECT_FALSE(cfg.runtime.warmup);
+}
+
+TEST(RuntimeConfigTest, ApplyOverrides) {
+    RuntimeConfig cfg;
+    cfg.apply_overrides({
+        "kv_cache.dtype=fp8",
+        "runtime.cuda_graphs=never",
+        "moe.expert_overhead_pct=30",
+        "gdn.fp32_scan=true",
+    });
+    EXPECT_EQ(cfg.kv_cache.dtype, "fp8");
+    EXPECT_EQ(cfg.runtime.cuda_graphs, "never");
+    EXPECT_EQ(cfg.moe.expert_overhead_pct, 30);
+    EXPECT_TRUE(cfg.gdn.fp32_scan);
+}
+
+TEST(RuntimeConfigTest, OverrideWinsOverFile) {
+    TempFile f(R"(
+[kv_cache]
+dtype = "fp16"
+)");
+
+    RuntimeConfig cfg;
+    cfg.load_from_file(f.path);
+    EXPECT_EQ(cfg.kv_cache.dtype, "fp16");
+    cfg.apply_overrides({"kv_cache.dtype=fp8"});
+    EXPECT_EQ(cfg.kv_cache.dtype, "fp8");
+}
+
+TEST(RuntimeConfigTest, BoolParsingIsLenient) {
+    RuntimeConfig cfg;
+    cfg.apply_overrides({"runtime.warmup=false"});
+    EXPECT_FALSE(cfg.runtime.warmup);
+    cfg.apply_overrides({"runtime.warmup=on"});
+    EXPECT_TRUE(cfg.runtime.warmup);
+    cfg.apply_overrides({"runtime.warmup=0"});
+    EXPECT_FALSE(cfg.runtime.warmup);
+    cfg.apply_overrides({"runtime.warmup=1"});
+    EXPECT_TRUE(cfg.runtime.warmup);
+}
+
+TEST(RuntimeConfigTest, UnknownKeyIsIgnored) {
+    // Should not crash; just log a warning.
+    RuntimeConfig cfg;
+    cfg.apply_overrides({"runtime.does_not_exist=42"});
+    // Default is unchanged.
+    EXPECT_FALSE(cfg.runtime.deterministic_gemm);
+}
+
+TEST(RuntimeConfigTest, MissingFileFallsBackToDefaults) {
+    RuntimeConfig cfg;
+    EXPECT_FALSE(cfg.load_from_file("/nonexistent/path/imp.conf"));
+    // Defaults still in place.
+    EXPECT_EQ(cfg.kv_cache.dtype, "fp16");
+}
+
+} // namespace
+} // namespace imp

--- a/tests/test_continuous_batching.cpp
+++ b/tests/test_continuous_batching.cpp
@@ -365,7 +365,7 @@ TEST(SchedulerTest, MemoryAwareScheduling) {
     // Create a small KV cache with limited blocks
     auto cache = std::make_unique<KVCache>(
         /*n_layers=*/2, /*n_kv_heads=*/4, /*head_dim=*/64,
-        DType::FP16, /*max_blocks=*/4);
+        QType::F16, /*max_blocks=*/4);
 
     auto mgr = std::make_unique<KVCacheManager>(std::move(cache));
 
@@ -957,7 +957,7 @@ TEST(SchedulerTest, MemoryAwareSkipsLargeAdmitsSmall) {
     // 4 blocks total, block_size=16
     auto cache = std::make_unique<KVCache>(
         /*n_layers=*/1, /*n_kv_heads=*/1, /*head_dim=*/64,
-        DType::FP16, /*max_blocks=*/4);
+        QType::F16, /*max_blocks=*/4);
     auto mgr = std::make_unique<KVCacheManager>(std::move(cache));
 
     Scheduler sched(16);
@@ -990,7 +990,7 @@ TEST(SchedulerTest, AllRequestsTooLargeForMemory) {
 
     auto cache = std::make_unique<KVCache>(
         /*n_layers=*/1, /*n_kv_heads=*/1, /*head_dim=*/64,
-        DType::FP16, /*max_blocks=*/2);
+        QType::F16, /*max_blocks=*/2);
     auto mgr = std::make_unique<KVCacheManager>(std::move(cache));
 
     Scheduler sched(16);

--- a/tests/test_cutlass_grouped_3x_nvfp4.cu
+++ b/tests/test_cutlass_grouped_3x_nvfp4.cu
@@ -56,7 +56,7 @@ static void make_expert(SyntheticExpert& e, int N, int K, float wscale,
     cudaMemcpy(d_w_fp16, e.weight_fp16.data(),
                e.weight_fp16.size() * sizeof(half), cudaMemcpyHostToDevice);
     int64_t w_shape[2] = {N, K};
-    Tensor w_input(d_w_fp16, DType::FP16, 2, w_shape, true);
+    Tensor w_input(d_w_fp16, QType::F16, 2, w_shape, true);
     quantize_fp16_to_nvfp4(w_input, e.nvfp4, stream);
     cudaFree(d_w_fp16);
 

--- a/tests/test_embedding.cu
+++ b/tests/test_embedding.cu
@@ -10,19 +10,19 @@
 namespace imp {
 namespace {
 
-Tensor make_gpu_tensor(const float* host_data, DType dtype,
+Tensor make_gpu_tensor(const float* host_data, QType dtype,
                        std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
     t.compute_strides();
     t.on_device = true;
     cudaMalloc(&t.data, t.nbytes());
-    if (dtype == DType::FP32) {
+    if (dtype == QType::F32) {
         cudaMemcpy(t.data, host_data, t.nbytes(), cudaMemcpyHostToDevice);
-    } else if (dtype == DType::FP16) {
+    } else if (dtype == QType::F16) {
         std::vector<half> h(t.numel());
         for (int64_t j = 0; j < t.numel(); j++)
             h[j] = __float2half(host_data[j]);
@@ -31,9 +31,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     return t;
 }
 
-Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) {
+Tensor alloc_gpu_tensor(QType dtype, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -46,9 +46,9 @@ Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) 
 
 std::vector<float> read_gpu_tensor(const Tensor& t) {
     std::vector<float> result(t.numel());
-    if (t.dtype == DType::FP32) {
+    if (t.qtype == QType::F32) {
         cudaMemcpy(result.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
-    } else if (t.dtype == DType::FP16) {
+    } else if (t.qtype == QType::F16) {
         std::vector<half> h(t.numel());
         cudaMemcpy(h.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
         for (int64_t j = 0; j < t.numel(); j++)
@@ -87,8 +87,8 @@ TEST(EmbeddingTest, BasicFP32) {
     int n_tokens = static_cast<int>(token_ids.size());
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP32, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP32, {n_tokens, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F32, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F32, {n_tokens, d_model});
 
     embedding_lookup(d_table, d_ids, n_tokens, d_out);
     cudaDeviceSynchronize();
@@ -127,8 +127,8 @@ TEST(EmbeddingTest, SingleToken) {
     std::vector<int32_t> token_ids = {1};
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP32, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP32, {1, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F32, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F32, {1, d_model});
 
     embedding_lookup(d_table, d_ids, 1, d_out);
     cudaDeviceSynchronize();
@@ -155,8 +155,8 @@ TEST(EmbeddingTest, RepeatedTokens) {
     std::vector<int32_t> token_ids = {1, 1, 1};
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP32, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP32, {3, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F32, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F32, {3, d_model});
 
     embedding_lookup(d_table, d_ids, 3, d_out);
     cudaDeviceSynchronize();
@@ -188,8 +188,8 @@ TEST(EmbeddingTest, FP16Lookup) {
     std::vector<int32_t> token_ids = {3, 1};
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP16, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP16, {2, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F16, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F16, {2, d_model});
 
     embedding_lookup(d_table, d_ids, 2, d_out);
     cudaDeviceSynchronize();
@@ -229,8 +229,8 @@ TEST(EmbeddingTest, LargeDModel) {
     std::vector<int32_t> token_ids = {5, 0, 7};
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP32, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP32, {3, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F32, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F32, {3, d_model});
 
     embedding_lookup(d_table, d_ids, 3, d_out);
     cudaDeviceSynchronize();
@@ -260,8 +260,8 @@ TEST(EmbeddingTest, NonAlignedDModel) {
     std::vector<int32_t> token_ids = {2, 0};
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP32, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP32, {2, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F32, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F32, {2, d_model});
 
     embedding_lookup(d_table, d_ids, 2, d_out);
     cudaDeviceSynchronize();
@@ -296,8 +296,8 @@ TEST(EmbeddingTest, DeviceSideLookup) {
     cudaMalloc(&d_token_id, sizeof(int32_t));
     cudaMemcpy(d_token_id, &token_id, sizeof(int32_t), cudaMemcpyHostToDevice);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP16, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP16, {1, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F16, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F16, {1, d_model});
 
     embedding_lookup_from_device(d_table, d_token_id, d_out);
     cudaDeviceSynchronize();
@@ -330,8 +330,8 @@ TEST(EmbeddingTest, BoundaryTokenIds) {
     std::vector<int32_t> token_ids = {0, vocab - 1};
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP32, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP32, {2, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F32, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F32, {2, d_model});
 
     embedding_lookup(d_table, d_ids, 2, d_out);
     cudaDeviceSynchronize();
@@ -376,8 +376,8 @@ TEST(EmbeddingTest, LargeVocab) {
     int n_tokens = static_cast<int>(token_ids.size());
     int32_t* d_ids = upload_token_ids(token_ids);
 
-    Tensor d_table = make_gpu_tensor(h_table.data(), DType::FP32, {vocab, d_model});
-    Tensor d_out   = alloc_gpu_tensor(DType::FP32, {n_tokens, d_model});
+    Tensor d_table = make_gpu_tensor(h_table.data(), QType::F32, {vocab, d_model});
+    Tensor d_out   = alloc_gpu_tensor(QType::F32, {n_tokens, d_model});
 
     embedding_lookup(d_table, d_ids, n_tokens, d_out);
     cudaDeviceSynchronize();

--- a/tests/test_engine_integration.cu
+++ b/tests/test_engine_integration.cu
@@ -22,8 +22,8 @@ static EngineConfig test_engine_config() {
     cfg.use_pdl = false;
     cfg.use_fp8_prefill = false;
     cfg.use_nvfp4_decode = 0;
-    cfg.kv_cache_dtype = DType::FP16;
-    cfg.compute_dtype = DType::FP16;
+    cfg.kv_cache_dtype = QType::F16;
+    cfg.compute_dtype = QType::F16;
     cfg.kv_block_size = 16;
     cfg.use_green_contexts = false;
     cfg.gpu_layers = -1;

--- a/tests/test_executor_kernels.cu
+++ b/tests/test_executor_kernels.cu
@@ -15,7 +15,7 @@ namespace {
 
 Tensor make_gpu_fp16(const float* host_data, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -31,7 +31,7 @@ Tensor make_gpu_fp16(const float* host_data, std::initializer_list<int64_t> shap
 
 Tensor make_gpu_fp32(const float* host_data, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = DType::FP32;
+    t.qtype = QType::F32;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -42,9 +42,9 @@ Tensor make_gpu_fp32(const float* host_data, std::initializer_list<int64_t> shap
     return t;
 }
 
-Tensor alloc_gpu(DType dtype, std::initializer_list<int64_t> shape_list) {
+Tensor alloc_gpu(QType dtype, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -146,7 +146,7 @@ TEST(ExecutorKernelsTest, ElementwiseAddStoreFP16) {
 
     Tensor a = make_gpu_fp16(ha.data(), {N});
     Tensor b = make_gpu_fp16(hb.data(), {N});
-    Tensor out = alloc_gpu(DType::FP16, {N});
+    Tensor out = alloc_gpu(QType::F16, {N});
 
     elementwise_add_store(a, b, out, nullptr);
     cudaDeviceSynchronize();
@@ -230,8 +230,8 @@ TEST(ExecutorKernelsTest, FP16ToFP32Roundtrip) {
     for (int i = 0; i < N; i++) h_data[i] = static_cast<float>(i) * 0.1f - 25.0f;
 
     Tensor fp16_in = make_gpu_fp16(h_data.data(), {N});
-    Tensor fp32_mid = alloc_gpu(DType::FP32, {N});
-    Tensor fp16_out = alloc_gpu(DType::FP16, {N});
+    Tensor fp32_mid = alloc_gpu(QType::F32, {N});
+    Tensor fp16_out = alloc_gpu(QType::F16, {N});
 
     int threads = 256;
     int blocks = (N + threads - 1) / threads;
@@ -321,7 +321,7 @@ TEST(ExecutorKernelsTest, ElementwiseAddOddLength) {
 // =========================================================================
 
 TEST(ExecutorKernelsTest, SliceRows) {
-    Tensor buf = alloc_gpu(DType::FP16, {8, 128});
+    Tensor buf = alloc_gpu(QType::F16, {8, 128});
     Tensor sliced = slice_rows(buf, 3);
 
     EXPECT_EQ(sliced.shape[0], 3);
@@ -383,7 +383,7 @@ TEST(ExecutorKernelsTest, ResidualAddRMSNorm) {
     Tensor hidden = make_gpu_fp16(h_hidden.data(), {1, d});
     Tensor residual = make_gpu_fp16(h_residual.data(), {1, d});
     Tensor weight = make_gpu_fp16(h_weight.data(), {d});
-    Tensor output = alloc_gpu(DType::FP16, {1, d});
+    Tensor output = alloc_gpu(QType::F16, {1, d});
 
     residual_add_rmsnorm(hidden, residual, weight, output, 1e-5f, nullptr);
     cudaDeviceSynchronize();
@@ -419,7 +419,7 @@ TEST(ExecutorKernelsTest, AddRMSNormInplace) {
 
     Tensor a = make_gpu_fp16(h_a.data(), {1, d});
     Tensor b = make_gpu_fp16(h_b.data(), {1, d});
-    Tensor h = alloc_gpu(DType::FP16, {1, d});
+    Tensor h = alloc_gpu(QType::F16, {1, d});
     Tensor w = make_gpu_fp16(h_w.data(), {d});
 
     add_rmsnorm_inplace(a, b, h, w, 1e-5f, nullptr);
@@ -446,7 +446,7 @@ TEST(ExecutorKernelsTest, RMSNormAddResidual) {
     Tensor input = make_gpu_fp16(h_in.data(), {1, d});
     Tensor w = make_gpu_fp16(h_w.data(), {d});
     Tensor r = make_gpu_fp16(h_r.data(), {1, d});
-    Tensor output = alloc_gpu(DType::FP16, {1, d});
+    Tensor output = alloc_gpu(QType::F16, {1, d});
 
     rmsnorm_add_residual(input, w, r, output, 1e-5f, nullptr);
     cudaDeviceSynchronize();

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -108,10 +108,10 @@ protected:
 
         int64_t q_shape[] = {B, Sq, NH, HD};
         int64_t kv_shape[] = {B, Skv, NKV, HD};
-        Tensor Qt(d_q, DType::FP16, 4, q_shape, true);
-        Tensor Kt(d_k, DType::FP16, 4, kv_shape, true);
-        Tensor Vt(d_v, DType::FP16, 4, kv_shape, true);
-        Tensor Ot(d_o, DType::FP16, 4, q_shape, true);
+        Tensor Qt(d_q, QType::F16, 4, q_shape, true);
+        Tensor Kt(d_k, QType::F16, 4, kv_shape, true);
+        Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
+        Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
         bool ok = fmha_sm120_fp8_prefill(Qt, Kt, Vt, Ot, scale, causal, sw, softcap, stream_);
         if (!ok) {

--- a/tests/test_forward_pass.cu
+++ b/tests/test_forward_pass.cu
@@ -122,10 +122,10 @@ TEST(ForwardPassTest, SyntheticModelForwardLogits) {
     auto tm = DenseTestModel::create(128, 512, 256, 1, 4, 4, 64);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false, 1, 64));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false, 1, 64));
     ASSERT_TRUE(executor.allocate_workspaces());
 
-    KVCache cache(1, 4, 32, DType::FP16, 8);
+    KVCache cache(1, 4, 32, QType::F16, 8);
     Tensor logits = run_prefill(executor, cache, {1, 42, 100, 200});
 
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
@@ -145,10 +145,10 @@ TEST(ForwardPassTest, SyntheticModelDecodeAfterPrefill) {
     auto tm = DenseTestModel::create(128, 512, 256, 1, 4, 4, 64);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false, 1, 64));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false, 1, 64));
     ASSERT_TRUE(executor.allocate_workspaces());
 
-    KVCache cache(1, 4, 32, DType::FP16, 8);
+    KVCache cache(1, 4, 32, QType::F16, 8);
 
     // Prefill 3 tokens
     run_prefill(executor, cache, {1, 2, 3});
@@ -172,10 +172,10 @@ TEST(ForwardPassTest, MultiLayerPrefill) {
 
     GraphExecutor executor;
     gemm_init();
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false, 1, 64));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false, 1, 64));
     ASSERT_TRUE(executor.allocate_workspaces());
 
-    KVCache cache(4, 4, 32, DType::FP16, 8);
+    KVCache cache(4, 4, 32, QType::F16, 8);
     Tensor logits = run_prefill(executor, cache, {1, 2, 3, 4, 5, 6, 7, 8});
 
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
@@ -196,11 +196,11 @@ TEST(ForwardPassTest, GQAForwardPass) {
 
     GraphExecutor executor;
     gemm_init();
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false, 1, 64));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false, 1, 64));
     ASSERT_TRUE(executor.allocate_workspaces());
 
     // n_kv_heads=2 for KVCache
-    KVCache cache(2, 2, 32, DType::FP16, 8);
+    KVCache cache(2, 2, 32, QType::F16, 8);
 
     // Prefill
     run_prefill(executor, cache, {1, 2, 3, 4});
@@ -223,10 +223,10 @@ TEST(ForwardPassTest, MultiStepDecode) {
     auto tm = DenseTestModel::create(128, 512, 256, 1, 4, 4, 64);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false, 1, 64));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false, 1, 64));
     ASSERT_TRUE(executor.allocate_workspaces());
 
-    KVCache cache(1, 4, 32, DType::FP16, 8);
+    KVCache cache(1, 4, 32, QType::F16, 8);
 
     // Prefill 4 tokens
     run_prefill(executor, cache, {1, 2, 3, 4});
@@ -260,19 +260,19 @@ TEST(ForwardPassTest, DeterministicLogits) {
     auto tm = DenseTestModel::create(128, 512, 256, 1, 4, 4, 64);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false, 1, 64));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false, 1, 64));
     ASSERT_TRUE(executor.allocate_workspaces());
 
     std::vector<int32_t> tokens = {1, 42, 100};
 
     // Run 1
-    KVCache cache1(1, 4, 32, DType::FP16, 8);
+    KVCache cache1(1, 4, 32, QType::F16, 8);
     Tensor logits1 = run_prefill(executor, cache1, tokens);
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
     auto h1 = read_logits(logits1, 256);
 
     // Run 2 (fresh KV cache)
-    KVCache cache2(1, 4, 32, DType::FP16, 8);
+    KVCache cache2(1, 4, 32, QType::F16, 8);
     Tensor logits2 = run_prefill(executor, cache2, tokens);
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
     auto h2 = read_logits(logits2, 256);
@@ -295,11 +295,11 @@ TEST(ForwardPassTest, LongSequencePrefill) {
     auto tm = DenseTestModel::create(128, 512, 256, 1, 4, 4, 64);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false, 1, 64));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false, 1, 64));
     ASSERT_TRUE(executor.allocate_workspaces());
 
     // 32 tokens need 2 KV blocks (block_size=16)
-    KVCache cache(1, 4, 32, DType::FP16, 8);
+    KVCache cache(1, 4, 32, QType::F16, 8);
 
     std::vector<int32_t> tokens(32);
     for (int i = 0; i < 32; i++) tokens[i] = (i + 1) % 256;

--- a/tests/test_fp8_gemm.cu
+++ b/tests/test_fp8_gemm.cu
@@ -43,9 +43,9 @@ TEST_F(FP8GemmTest, GemmCublasLtFP16) {
     int64_t a_shape[] = {M, K};
     int64_t b_shape[] = {N, K};
     int64_t c_shape[] = {M, N};
-    Tensor A(d_a, DType::FP16, 2, a_shape, true);
-    Tensor B(d_b, DType::FP16, 2, b_shape, true);
-    Tensor C(d_c, DType::FP16, 2, c_shape, true);
+    Tensor A(d_a, QType::F16, 2, a_shape, true);
+    Tensor B(d_b, QType::F16, 2, b_shape, true);
+    Tensor C(d_c, QType::F16, 2, c_shape, true);
 
     gemm_cublaslt(A, B, C, 1.0f, 0.0f, nullptr, nullptr, stream_);
     cudaStreamSynchronize(stream_);
@@ -79,9 +79,9 @@ TEST_F(FP8GemmTest, GemvFP8Basic) {
     int64_t a_shape[] = {M, K};
     int64_t x_shape[] = {K};
     int64_t y_shape[] = {M};
-    Tensor A(d_a, DType::FP8_E4M3, 2, a_shape, true);
-    Tensor x(d_x, DType::FP16, 1, x_shape, true);
-    Tensor y(d_y, DType::FP16, 1, y_shape, true);
+    Tensor A(d_a, QType::FP8_E4M3, 2, a_shape, true);
+    Tensor x(d_x, QType::F16, 1, x_shape, true);
+    Tensor y(d_y, QType::F16, 1, y_shape, true);
 
     gemv_fp8(A, x, y, scale, stream_);
     cudaStreamSynchronize(stream_);

--- a/tests/test_fp8_kv_cache.cu
+++ b/tests/test_fp8_kv_cache.cu
@@ -39,11 +39,11 @@ TEST(FP8KVCache, Construction) {
     const int max_blocks = 16;
 
     // FP16 cache
-    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks);
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks);
     size_t fp16_block_bytes = fp16_cache.block_bytes();
 
     // FP8 cache
-    KVCache fp8_cache(n_layers, n_kv_heads, head_dim, DType::FP8_E4M3, max_blocks);
+    KVCache fp8_cache(n_layers, n_kv_heads, head_dim, QType::FP8_E4M3, max_blocks);
     size_t fp8_block_bytes = fp8_cache.block_bytes();
 
     // FP8 blocks should be exactly half the size of FP16
@@ -53,7 +53,7 @@ TEST(FP8KVCache, Construction) {
     EXPECT_EQ(fp8_cache.n_layers(), n_layers);
     EXPECT_EQ(fp8_cache.n_kv_heads(), n_kv_heads);
     EXPECT_EQ(fp8_cache.head_dim(), head_dim);
-    EXPECT_EQ(fp8_cache.dtype(), DType::FP8_E4M3);
+    EXPECT_EQ(fp8_cache.qtype(), QType::FP8_E4M3);
     EXPECT_EQ(fp8_cache.total_blocks(), max_blocks);
     EXPECT_EQ(fp8_cache.num_free_blocks(), max_blocks);
 
@@ -92,7 +92,7 @@ TEST(FP8KVCache, ScaleCalibration) {
     cudaMemcpy(d_data, h_data.data(), n * k * sizeof(half), cudaMemcpyHostToDevice);
 
     int64_t shape[2] = {n, k};
-    Tensor t(d_data, DType::FP16, 2, shape, true);
+    Tensor t(d_data, QType::F16, 2, shape, true);
 
     float scale = calibrate_fp8_scale(t, nullptr);
     cudaDeviceSynchronize();
@@ -121,7 +121,7 @@ TEST(FP8KVCache, ScaleCalibrationZeros) {
     cudaMemset(d_data, 0, n * k * sizeof(half));
 
     int64_t shape[2] = {n, k};
-    Tensor t(d_data, DType::FP16, 2, shape, true);
+    Tensor t(d_data, QType::F16, 2, shape, true);
 
     float scale = calibrate_fp8_scale(t, nullptr);
     cudaDeviceSynchronize();
@@ -143,13 +143,13 @@ TEST(FP8KVCache, BlockBytesMatchesDTypeSize) {
     const int head_dim = 128;
     const int max_blocks = 8;
 
-    KVCache cache(1, n_kv_heads, head_dim, DType::FP8_E4M3, max_blocks);
+    KVCache cache(1, n_kv_heads, head_dim, QType::FP8_E4M3, max_blocks);
 
     // block_bytes = kKVBlockSize * n_kv_heads * head_dim * dtype_size(FP8_E4M3)
     size_t expected = static_cast<size_t>(kKVBlockSize) * n_kv_heads * head_dim *
-                      dtype_size(DType::FP8_E4M3);
+                      dtype_size(QType::FP8_E4M3);
     EXPECT_EQ(cache.block_bytes(), expected);
-    EXPECT_EQ(dtype_size(DType::FP8_E4M3), 1u);  // FP8 = 1 byte per element
+    EXPECT_EQ(dtype_size(QType::FP8_E4M3), 1u);  // FP8 = 1 byte per element
 }
 
 // ============================================================================
@@ -220,8 +220,8 @@ TEST(FP8KVCache, SplitKConsistency) {
     // ---- Quantize KV to FP8 ----
     int64_t q_shape[4] = {batch_size, 1, n_heads, head_dim};
     int64_t kv_shape[4] = {num_blocks, block_size, n_kv_heads, head_dim};
-    Tensor t_k16(d_k_fp16, DType::FP16, 4, kv_shape, true);
-    Tensor t_v16(d_v_fp16, DType::FP16, 4, kv_shape, true);
+    Tensor t_k16(d_k_fp16, QType::F16, 4, kv_shape, true);
+    Tensor t_v16(d_v_fp16, QType::F16, 4, kv_shape, true);
 
     float k_scale = calibrate_fp8_scale(t_k16, nullptr);
     cudaDeviceSynchronize();
@@ -238,9 +238,9 @@ TEST(FP8KVCache, SplitKConsistency) {
     quantize_fp16_to_fp8_e4m3_scaled(d_v_fp16, d_v_fp8, total_kv_elems, kv_scale, nullptr);
     cudaDeviceSynchronize();
 
-    Tensor t_q(d_q, DType::FP16, 4, q_shape, true);
-    Tensor t_k8(d_k_fp8, DType::FP8_E4M3, 4, kv_shape, true);
-    Tensor t_v8(d_v_fp8, DType::FP8_E4M3, 4, kv_shape, true);
+    Tensor t_q(d_q, QType::F16, 4, q_shape, true);
+    Tensor t_k8(d_k_fp8, QType::FP8_E4M3, 4, kv_shape, true);
+    Tensor t_v8(d_v_fp8, QType::FP8_E4M3, 4, kv_shape, true);
 
     // ---- Output buffers ----
     void* d_o_nosplit = nullptr;
@@ -251,7 +251,7 @@ TEST(FP8KVCache, SplitKConsistency) {
     cudaMemset(d_o_splitk, 0, q_elems * sizeof(half));
 
     // ---- Run FP8 decode WITHOUT Split-K (reference) ----
-    Tensor t_o_nosplit(d_o_nosplit, DType::FP16, 4, q_shape, true);
+    Tensor t_o_nosplit(d_o_nosplit, QType::F16, 4, q_shape, true);
     paged_attention_set_splitk_scratch(nullptr, 0);  // force non-split-K
     paged_attention_decode_fp8(t_q, t_k8, t_v8, t_o_nosplit,
                                d_bt, d_ctx, block_size, scale, kv_scale,
@@ -265,7 +265,7 @@ TEST(FP8KVCache, SplitKConsistency) {
     void* d_scratch = nullptr;
     cudaMalloc(&d_scratch, scratch_size);
 
-    Tensor t_o_splitk(d_o_splitk, DType::FP16, 4, q_shape, true);
+    Tensor t_o_splitk(d_o_splitk, QType::F16, 4, q_shape, true);
     paged_attention_set_splitk_scratch(d_scratch, scratch_size);
     paged_attention_decode_fp8(t_q, t_k8, t_v8, t_o_splitk,
                                d_bt, d_ctx, block_size, scale, kv_scale,
@@ -325,18 +325,18 @@ TEST(INT8KVCache, Construction) {
     const int max_blocks = 16;
 
     // FP16 cache for size comparison
-    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks);
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks);
     size_t fp16_block_bytes = fp16_cache.block_bytes();
 
     // INT8 cache
-    KVCache int8_cache(n_layers, n_kv_heads, head_dim, DType::INT8, max_blocks);
+    KVCache int8_cache(n_layers, n_kv_heads, head_dim, QType::INT8, max_blocks);
     size_t int8_block_bytes = int8_cache.block_bytes();
 
     // INT8 blocks should be exactly half the size of FP16
     EXPECT_EQ(int8_block_bytes * 2, fp16_block_bytes);
 
     // Verify accessors
-    EXPECT_EQ(int8_cache.dtype(), DType::INT8);
+    EXPECT_EQ(int8_cache.qtype(), QType::INT8);
     EXPECT_EQ(int8_cache.n_kv_heads(), n_kv_heads);
     EXPECT_EQ(int8_cache.head_dim(), head_dim);
 
@@ -479,9 +479,9 @@ TEST(INT8KVCache, SplitKConsistency) {
     // ---- Create tensors ----
     int64_t q_shape[4] = {batch_size, 1, n_heads, head_dim};
     int64_t kv_shape[4] = {num_blocks, block_size, n_kv_heads, head_dim};
-    Tensor t_q(d_q, DType::FP16, 4, q_shape, true);
-    Tensor t_k_i8(d_k_int8, DType::INT8, 4, kv_shape, true);
-    Tensor t_v_i8(d_v_int8, DType::INT8, 4, kv_shape, true);
+    Tensor t_q(d_q, QType::F16, 4, q_shape, true);
+    Tensor t_k_i8(d_k_int8, QType::INT8, 4, kv_shape, true);
+    Tensor t_v_i8(d_v_int8, QType::INT8, 4, kv_shape, true);
 
     // ---- Output buffers ----
     void* d_o_nosplit = nullptr;
@@ -492,7 +492,7 @@ TEST(INT8KVCache, SplitKConsistency) {
     cudaMemset(d_o_splitk, 0, q_elems * sizeof(half));
 
     // ---- Run INT8 decode WITHOUT Split-K ----
-    Tensor t_o_nosplit(d_o_nosplit, DType::FP16, 4, q_shape, true);
+    Tensor t_o_nosplit(d_o_nosplit, QType::F16, 4, q_shape, true);
     paged_attention_set_splitk_scratch(nullptr, 0);
     paged_attention_decode_int8(t_q, t_k_i8, t_v_i8, t_o_nosplit,
                                 static_cast<const half*>(d_k_scales),
@@ -508,7 +508,7 @@ TEST(INT8KVCache, SplitKConsistency) {
     void* d_scratch = nullptr;
     cudaMalloc(&d_scratch, scratch_size);
 
-    Tensor t_o_splitk(d_o_splitk, DType::FP16, 4, q_shape, true);
+    Tensor t_o_splitk(d_o_splitk, QType::F16, 4, q_shape, true);
     paged_attention_set_splitk_scratch(d_scratch, scratch_size);
     paged_attention_decode_int8(t_q, t_k_i8, t_v_i8, t_o_splitk,
                                 static_cast<const half*>(d_k_scales),
@@ -581,7 +581,7 @@ TEST(FP8KVCache, QuantDequantRoundtrip) {
 
     // Calibrate scale
     int64_t shape[1] = {n_elements};
-    Tensor t_input(d_input, DType::FP16, 1, shape, true);
+    Tensor t_input(d_input, QType::F16, 1, shape, true);
     float scale = calibrate_fp8_scale(t_input, nullptr);
     cudaDeviceSynchronize();
     ASSERT_GT(scale, 0.0f);
@@ -677,8 +677,8 @@ TEST(FP8KVCache, PagedAttentionDecodeFP8vsFP16) {
 
     // ---- Quantize KV to FP8 ----
     int64_t kv_shape[4] = {num_blocks, block_size, n_kv_heads, head_dim};
-    Tensor t_k16(d_k_fp16, DType::FP16, 4, kv_shape, true);
-    Tensor t_v16(d_v_fp16, DType::FP16, 4, kv_shape, true);
+    Tensor t_k16(d_k_fp16, QType::F16, 4, kv_shape, true);
+    Tensor t_v16(d_v_fp16, QType::F16, 4, kv_shape, true);
 
     float k_scale = calibrate_fp8_scale(t_k16, nullptr);
     cudaDeviceSynchronize();
@@ -709,15 +709,15 @@ TEST(FP8KVCache, PagedAttentionDecodeFP8vsFP16) {
 
     // ---- Tensors ----
     int64_t q_shape[4] = {batch_size, 1, n_heads, head_dim};
-    Tensor t_q(d_q, DType::FP16, 4, q_shape, true);
-    Tensor t_k8(d_k_fp8, DType::FP8_E4M3, 4, kv_shape, true);
-    Tensor t_v8(d_v_fp8, DType::FP8_E4M3, 4, kv_shape, true);
+    Tensor t_q(d_q, QType::F16, 4, q_shape, true);
+    Tensor t_k8(d_k_fp8, QType::FP8_E4M3, 4, kv_shape, true);
+    Tensor t_v8(d_v_fp8, QType::FP8_E4M3, 4, kv_shape, true);
 
     // ---- Run FP16 decode (reference) ----
     void* d_o_fp16 = nullptr;
     cudaMalloc(&d_o_fp16, q_elems * sizeof(half));
     cudaMemset(d_o_fp16, 0, q_elems * sizeof(half));
-    Tensor t_o_fp16(d_o_fp16, DType::FP16, 4, q_shape, true);
+    Tensor t_o_fp16(d_o_fp16, QType::F16, 4, q_shape, true);
     paged_attention_set_splitk_scratch(nullptr, 0);
     paged_attention_decode(t_q, t_k16, t_v16, t_o_fp16,
                            d_bt, d_ctx, block_size, scale,
@@ -728,7 +728,7 @@ TEST(FP8KVCache, PagedAttentionDecodeFP8vsFP16) {
     void* d_o_fp8 = nullptr;
     cudaMalloc(&d_o_fp8, q_elems * sizeof(half));
     cudaMemset(d_o_fp8, 0, q_elems * sizeof(half));
-    Tensor t_o_fp8(d_o_fp8, DType::FP16, 4, q_shape, true);
+    Tensor t_o_fp8(d_o_fp8, QType::F16, 4, q_shape, true);
     paged_attention_decode_fp8(t_q, t_k8, t_v8, t_o_fp8,
                                d_bt, d_ctx, block_size, scale, kv_scale,
                                ctx_len, 0, 0.0f, nullptr);
@@ -839,8 +839,8 @@ TEST(FP8KVCache, SplitKHD256) {
     // Quantize KV to FP8
     int64_t q_shape[4] = {batch_size, 1, n_heads, head_dim};
     int64_t kv_shape[4] = {num_blocks, block_size, n_kv_heads, head_dim};
-    Tensor t_k16(d_k_fp16, DType::FP16, 4, kv_shape, true);
-    Tensor t_v16(d_v_fp16, DType::FP16, 4, kv_shape, true);
+    Tensor t_k16(d_k_fp16, QType::F16, 4, kv_shape, true);
+    Tensor t_v16(d_v_fp16, QType::F16, 4, kv_shape, true);
 
     float k_scale = calibrate_fp8_scale(t_k16, nullptr);
     cudaDeviceSynchronize();
@@ -857,9 +857,9 @@ TEST(FP8KVCache, SplitKHD256) {
     quantize_fp16_to_fp8_e4m3_scaled(d_v_fp16, d_v_fp8, total_kv_elems, kv_scale, nullptr);
     cudaDeviceSynchronize();
 
-    Tensor t_q(d_q, DType::FP16, 4, q_shape, true);
-    Tensor t_k8(d_k_fp8, DType::FP8_E4M3, 4, kv_shape, true);
-    Tensor t_v8(d_v_fp8, DType::FP8_E4M3, 4, kv_shape, true);
+    Tensor t_q(d_q, QType::F16, 4, q_shape, true);
+    Tensor t_k8(d_k_fp8, QType::FP8_E4M3, 4, kv_shape, true);
+    Tensor t_v8(d_v_fp8, QType::FP8_E4M3, 4, kv_shape, true);
 
     // Output buffers
     void* d_o_nosplit = nullptr;
@@ -870,7 +870,7 @@ TEST(FP8KVCache, SplitKHD256) {
     cudaMemset(d_o_splitk, 0, q_elems * sizeof(half));
 
     // Run FP8 decode WITHOUT Split-K (reference — uses non-pipelined kernel)
-    Tensor t_o_nosplit(d_o_nosplit, DType::FP16, 4, q_shape, true);
+    Tensor t_o_nosplit(d_o_nosplit, QType::F16, 4, q_shape, true);
     paged_attention_set_splitk_scratch(nullptr, 0);
     paged_attention_decode_fp8(t_q, t_k8, t_v8, t_o_nosplit,
                                d_bt, d_ctx, block_size, scale, kv_scale,
@@ -884,7 +884,7 @@ TEST(FP8KVCache, SplitKHD256) {
     void* d_scratch = nullptr;
     cudaMalloc(&d_scratch, scratch_size);
 
-    Tensor t_o_splitk(d_o_splitk, DType::FP16, 4, q_shape, true);
+    Tensor t_o_splitk(d_o_splitk, QType::F16, 4, q_shape, true);
     paged_attention_set_splitk_scratch(d_scratch, scratch_size);
     paged_attention_decode_fp8(t_q, t_k8, t_v8, t_o_splitk,
                                d_bt, d_ctx, block_size, scale, kv_scale,

--- a/tests/test_gemm.cu
+++ b/tests/test_gemm.cu
@@ -13,19 +13,19 @@ namespace {
 
 // ---- GPU tensor helpers (same pattern as other test files) ----
 
-Tensor make_gpu_tensor(const float* host_data, DType dtype,
+Tensor make_gpu_tensor(const float* host_data, QType dtype,
                        std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
     t.compute_strides();
     t.on_device = true;
     cudaMalloc(&t.data, t.nbytes());
-    if (dtype == DType::FP32) {
+    if (dtype == QType::F32) {
         cudaMemcpy(t.data, host_data, t.nbytes(), cudaMemcpyHostToDevice);
-    } else if (dtype == DType::FP16) {
+    } else if (dtype == QType::F16) {
         std::vector<half> h(t.numel());
         for (int64_t j = 0; j < t.numel(); j++)
             h[j] = __float2half(host_data[j]);
@@ -34,9 +34,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     return t;
 }
 
-Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) {
+Tensor alloc_gpu_tensor(QType dtype, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -49,9 +49,9 @@ Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) 
 
 std::vector<float> read_gpu_fp32(const Tensor& t) {
     std::vector<float> result(t.numel());
-    if (t.dtype == DType::FP32) {
+    if (t.qtype == QType::F32) {
         cudaMemcpy(result.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
-    } else if (t.dtype == DType::FP16) {
+    } else if (t.qtype == QType::F16) {
         std::vector<half> h(t.numel());
         cudaMemcpy(h.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
         for (int64_t j = 0; j < t.numel(); j++)
@@ -104,9 +104,9 @@ TEST_F(GemmTest, FP32_Square) {
     std::vector<float> h_C(N * N, 0.0f);
     cpu_gemm(h_A.data(), h_B.data(), h_C.data(), N, N, N, 1.0f, 0.0f);
 
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP32, {N, N});
-    Tensor d_B = make_gpu_tensor(h_B.data(), DType::FP32, {N, N});
-    Tensor d_C = alloc_gpu_tensor(DType::FP32, {N, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F32, {N, N});
+    Tensor d_B = make_gpu_tensor(h_B.data(), QType::F32, {N, N});
+    Tensor d_C = alloc_gpu_tensor(QType::F32, {N, N});
 
     gemm(d_A, d_B, d_C);
     cudaDeviceSynchronize();
@@ -128,9 +128,9 @@ TEST_F(GemmTest, FP32_NonSquare) {
     std::vector<float> h_C(M * N, 0.0f);
     cpu_gemm(h_A.data(), h_B.data(), h_C.data(), M, N, K, 1.0f, 0.0f);
 
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP32, {M, K});
-    Tensor d_B = make_gpu_tensor(h_B.data(), DType::FP32, {N, K});
-    Tensor d_C = alloc_gpu_tensor(DType::FP32, {M, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F32, {M, K});
+    Tensor d_B = make_gpu_tensor(h_B.data(), QType::F32, {N, K});
+    Tensor d_C = alloc_gpu_tensor(QType::F32, {M, N});
 
     gemm(d_A, d_B, d_C);
     cudaDeviceSynchronize();
@@ -153,9 +153,9 @@ TEST_F(GemmTest, FP32_AlphaBeta) {
     std::vector<float> h_C = h_C_init;
     cpu_gemm(h_A.data(), h_B.data(), h_C.data(), M, N, K, 2.0f, 0.5f);
 
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP32, {M, K});
-    Tensor d_B = make_gpu_tensor(h_B.data(), DType::FP32, {N, K});
-    Tensor d_C = make_gpu_tensor(h_C_init.data(), DType::FP32, {M, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F32, {M, K});
+    Tensor d_B = make_gpu_tensor(h_B.data(), QType::F32, {N, K});
+    Tensor d_C = make_gpu_tensor(h_C_init.data(), QType::F32, {M, N});
 
     gemm(d_A, d_B, d_C, 2.0f, 0.5f);
     cudaDeviceSynchronize();
@@ -176,9 +176,9 @@ TEST_F(GemmTest, FP32_Identity) {
     for (int i = 0; i < N; i++) h_I[i * N + i] = 1.0f;
 
     // C = A @ I^T = A (identity is symmetric)
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP32, {N, N});
-    Tensor d_I = make_gpu_tensor(h_I.data(), DType::FP32, {N, N});
-    Tensor d_C = alloc_gpu_tensor(DType::FP32, {N, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F32, {N, N});
+    Tensor d_I = make_gpu_tensor(h_I.data(), QType::F32, {N, N});
+    Tensor d_C = alloc_gpu_tensor(QType::F32, {N, N});
 
     gemm(d_A, d_I, d_C);
     cudaDeviceSynchronize();
@@ -206,9 +206,9 @@ TEST_F(GemmTest, FP16_Square) {
     std::vector<float> h_C(N * N, 0.0f);
     cpu_gemm(h_A.data(), h_B.data(), h_C.data(), N, N, N, 1.0f, 0.0f);
 
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP16, {N, N});
-    Tensor d_B = make_gpu_tensor(h_B.data(), DType::FP16, {N, N});
-    Tensor d_C = alloc_gpu_tensor(DType::FP16, {N, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F16, {N, N});
+    Tensor d_B = make_gpu_tensor(h_B.data(), QType::F16, {N, N});
+    Tensor d_C = alloc_gpu_tensor(QType::F16, {N, N});
 
     gemm(d_A, d_B, d_C);
     cudaDeviceSynchronize();
@@ -230,9 +230,9 @@ TEST_F(GemmTest, FP16_Large) {
     std::vector<float> h_C(M * N, 0.0f);
     cpu_gemm(h_A.data(), h_B.data(), h_C.data(), M, N, K, 1.0f, 0.0f);
 
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP16, {M, K});
-    Tensor d_B = make_gpu_tensor(h_B.data(), DType::FP16, {N, K});
-    Tensor d_C = alloc_gpu_tensor(DType::FP16, {M, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F16, {M, K});
+    Tensor d_B = make_gpu_tensor(h_B.data(), QType::F16, {N, K});
+    Tensor d_C = alloc_gpu_tensor(QType::F16, {M, N});
 
     gemm(d_A, d_B, d_C);
     cudaDeviceSynchronize();
@@ -261,9 +261,9 @@ TEST_F(GemmTest, GEMV_FP16) {
         for (int k = 0; k < K; k++)
             h_y[i] += h_W[i * K + k] * h_x[k];
 
-    Tensor d_W = make_gpu_tensor(h_W.data(), DType::FP16, {N, K});
-    Tensor d_x = make_gpu_tensor(h_x.data(), DType::FP16, {K});
-    Tensor d_y = alloc_gpu_tensor(DType::FP16, {N});
+    Tensor d_W = make_gpu_tensor(h_W.data(), QType::F16, {N, K});
+    Tensor d_x = make_gpu_tensor(h_x.data(), QType::F16, {K});
+    Tensor d_y = alloc_gpu_tensor(QType::F16, {N});
 
     gemv(d_W, d_x, d_y);
     cudaDeviceSynchronize();
@@ -287,9 +287,9 @@ TEST_F(GemmTest, GEMV_FP32) {
         for (int k = 0; k < K; k++)
             h_y[i] += h_W[i * K + k] * h_x[k];
 
-    Tensor d_W = make_gpu_tensor(h_W.data(), DType::FP32, {N, K});
-    Tensor d_x = make_gpu_tensor(h_x.data(), DType::FP32, {K});
-    Tensor d_y = alloc_gpu_tensor(DType::FP32, {N});
+    Tensor d_W = make_gpu_tensor(h_W.data(), QType::F32, {N, K});
+    Tensor d_x = make_gpu_tensor(h_x.data(), QType::F32, {K});
+    Tensor d_y = alloc_gpu_tensor(QType::F32, {N});
 
     gemv(d_W, d_x, d_y);
     cudaDeviceSynchronize();
@@ -316,9 +316,9 @@ TEST_F(GemmTest, GemmDispatchToGEMV) {
     std::vector<float> h_C(N, 0.0f);
     cpu_gemm(h_A.data(), h_B.data(), h_C.data(), 1, N, K, 1.0f, 0.0f);
 
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP16, {1, K});
-    Tensor d_B = make_gpu_tensor(h_B.data(), DType::FP16, {N, K});
-    Tensor d_C = alloc_gpu_tensor(DType::FP16, {1, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F16, {1, K});
+    Tensor d_B = make_gpu_tensor(h_B.data(), QType::F16, {N, K});
+    Tensor d_C = alloc_gpu_tensor(QType::F16, {1, N});
 
     gemm(d_A, d_B, d_C);
     cudaDeviceSynchronize();
@@ -382,9 +382,9 @@ TEST_F(GemmTest, ZeroMatrix) {
     constexpr int M = 4, N = 4, K = 4;
     std::vector<float> h_A(M * K, 0.0f), h_B(N * K, 1.0f);
 
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP32, {M, K});
-    Tensor d_B = make_gpu_tensor(h_B.data(), DType::FP32, {N, K});
-    Tensor d_C = alloc_gpu_tensor(DType::FP32, {M, N});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F32, {M, K});
+    Tensor d_B = make_gpu_tensor(h_B.data(), QType::F32, {N, K});
+    Tensor d_C = alloc_gpu_tensor(QType::F32, {M, N});
 
     gemm(d_A, d_B, d_C);
     cudaDeviceSynchronize();

--- a/tests/test_gguf_loader.cpp
+++ b/tests/test_gguf_loader.cpp
@@ -38,34 +38,34 @@ TEST(GgufLoaderTest, LoadNonexistentFile) {
 
 TEST(GgufLoaderTest, GGMLTypeHelpers) {
     // Block sizes
-    EXPECT_EQ(ggml_blck_size(GGMLType::F32), 1);
-    EXPECT_EQ(ggml_blck_size(GGMLType::F16), 1);
-    EXPECT_EQ(ggml_blck_size(GGMLType::Q4_0), 32);
-    EXPECT_EQ(ggml_blck_size(GGMLType::Q8_0), 32);
-    EXPECT_EQ(ggml_blck_size(GGMLType::Q4_K), 256);
+    EXPECT_EQ(gguf_blck_size(GgufWireType::F32), 1);
+    EXPECT_EQ(gguf_blck_size(GgufWireType::F16), 1);
+    EXPECT_EQ(gguf_blck_size(GgufWireType::Q4_0), 32);
+    EXPECT_EQ(gguf_blck_size(GgufWireType::Q8_0), 32);
+    EXPECT_EQ(gguf_blck_size(GgufWireType::Q4_K), 256);
 
     // Type sizes
-    EXPECT_EQ(ggml_type_size(GGMLType::F32), 4u);
-    EXPECT_EQ(ggml_type_size(GGMLType::F16), 2u);
-    EXPECT_EQ(ggml_type_size(GGMLType::BF16), 2u);
-    EXPECT_EQ(ggml_type_size(GGMLType::Q4_0), 18u);
-    EXPECT_EQ(ggml_type_size(GGMLType::Q8_0), 34u);
+    EXPECT_EQ(gguf_type_size(GgufWireType::F32), 4u);
+    EXPECT_EQ(gguf_type_size(GgufWireType::F16), 2u);
+    EXPECT_EQ(gguf_type_size(GgufWireType::BF16), 2u);
+    EXPECT_EQ(gguf_type_size(GgufWireType::Q4_0), 18u);
+    EXPECT_EQ(gguf_type_size(GgufWireType::Q8_0), 34u);
 
     // Row size
-    EXPECT_EQ(ggml_row_size(GGMLType::F32, 4096), 4096u * 4);
-    EXPECT_EQ(ggml_row_size(GGMLType::F16, 4096), 4096u * 2);
+    EXPECT_EQ(gguf_row_size(GgufWireType::F32, 4096), 4096u * 4);
+    EXPECT_EQ(gguf_row_size(GgufWireType::F16, 4096), 4096u * 2);
     // Q4_0: 4096 elements / 32 elements_per_block * 18 bytes_per_block
-    EXPECT_EQ(ggml_row_size(GGMLType::Q4_0, 4096), (4096u / 32) * 18);
+    EXPECT_EQ(gguf_row_size(GgufWireType::Q4_0, 4096), (4096u / 32) * 18);
 
     // Type names
-    EXPECT_STREQ(ggml_type_name(GGMLType::F32), "F32");
-    EXPECT_STREQ(ggml_type_name(GGMLType::Q4_K), "Q4_K");
+    EXPECT_STREQ(gguf_type_name(GgufWireType::F32), "F32");
+    EXPECT_STREQ(gguf_type_name(GgufWireType::Q4_K), "Q4_K");
 
-    // DType conversion
-    EXPECT_EQ(ggml_type_to_dtype(GGMLType::F32), DType::FP32);
-    EXPECT_EQ(ggml_type_to_dtype(GGMLType::F16), DType::FP16);
-    EXPECT_EQ(ggml_type_to_dtype(GGMLType::BF16), DType::BF16);
-    EXPECT_EQ(ggml_type_to_dtype(GGMLType::Q4_0), DType::INT4);
+    // QType conversion
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::F32), QType::F32);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::F16), QType::F16);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::BF16), QType::BF16);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::Q4_0), QType::INT4);
 }
 
 TEST(GgufLoaderTest, InvalidMagic) {

--- a/tests/test_gguf_loader.cpp
+++ b/tests/test_gguf_loader.cpp
@@ -61,11 +61,15 @@ TEST(GgufLoaderTest, GGMLTypeHelpers) {
     EXPECT_STREQ(gguf_type_name(GgufWireType::F32), "F32");
     EXPECT_STREQ(gguf_type_name(GgufWireType::Q4_K), "Q4_K");
 
-    // QType conversion
+    // QType conversion: wire-stable values map exactly to QType.
     EXPECT_EQ(gguf_type_to_qtype(GgufWireType::F32), QType::F32);
     EXPECT_EQ(gguf_type_to_qtype(GgufWireType::F16), QType::F16);
     EXPECT_EQ(gguf_type_to_qtype(GgufWireType::BF16), QType::BF16);
-    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::Q4_0), QType::INT4);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::Q4_0), QType::Q4_0);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::Q4_K), QType::Q4_K);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::Q8_0), QType::Q8_0);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::Q6_K), QType::Q6_K);
+    EXPECT_EQ(gguf_type_to_qtype(GgufWireType::MXFP4), QType::MXFP4);
 }
 
 TEST(GgufLoaderTest, InvalidMagic) {

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -171,19 +171,19 @@ TEST(KVCacheTest, KVCacheConstruction) {
     const int head_dim   = 64;
     const int max_blocks = 8;
 
-    KVCache cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks);
+    KVCache cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks);
 
     EXPECT_EQ(cache.n_layers(), n_layers);
     EXPECT_EQ(cache.n_kv_heads(), n_kv_heads);
     EXPECT_EQ(cache.head_dim(), head_dim);
-    EXPECT_EQ(cache.dtype(), DType::FP16);
+    EXPECT_EQ(cache.qtype(), QType::F16);
     EXPECT_EQ(cache.total_blocks(), max_blocks);
     EXPECT_EQ(cache.num_free_blocks(), max_blocks);
 
     // block_bytes = kKVBlockSize * n_kv_heads * head_dim * dtype_size(FP16)
     //            = 16 * 4 * 64 * 2 = 8192
     size_t expected_block_bytes =
-        static_cast<size_t>(kKVBlockSize) * n_kv_heads * head_dim * dtype_size(DType::FP16);
+        static_cast<size_t>(kKVBlockSize) * n_kv_heads * head_dim * dtype_size(QType::F16);
     EXPECT_EQ(cache.block_bytes(), expected_block_bytes);
     EXPECT_EQ(expected_block_bytes, 8192u);
 }
@@ -193,7 +193,7 @@ TEST(KVCacheTest, KVCacheBlockAllocation) {
     SKIP_IF_NO_CUDA();
 
     const int max_blocks = 8;
-    KVCache cache(2, 4, 64, DType::FP16, max_blocks);
+    KVCache cache(2, 4, 64, QType::F16, max_blocks);
 
     // Allocate all 8 blocks and verify IDs are 0..7 in order.
     std::vector<int> ids;
@@ -218,7 +218,7 @@ TEST(KVCacheTest, KVCacheBlockFree) {
     SKIP_IF_NO_CUDA();
 
     const int max_blocks = 8;
-    KVCache cache(2, 4, 64, DType::FP16, max_blocks);
+    KVCache cache(2, 4, 64, QType::F16, max_blocks);
 
     // Allocate 4 blocks.
     std::vector<int> ids;
@@ -243,7 +243,7 @@ TEST(KVCacheTest, KVCacheRefCounting) {
     SKIP_IF_NO_CUDA();
 
     const int max_blocks = 8;
-    KVCache cache(2, 4, 64, DType::FP16, max_blocks);
+    KVCache cache(2, 4, 64, QType::F16, max_blocks);
 
     int block = cache.allocate_block();
     ASSERT_GE(block, 0);
@@ -275,7 +275,7 @@ TEST(KVCacheTest, KVCachePointers) {
     const int head_dim   = 64;
     const int max_blocks = 8;
 
-    KVCache cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks);
+    KVCache cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks);
     size_t bb = cache.block_bytes();
 
     int b0 = cache.allocate_block();
@@ -345,7 +345,7 @@ TEST(KVCacheTest, KVCacheReadWriteData) {
     const int head_dim   = 32;
     const int max_blocks = 4;
 
-    KVCache cache(n_layers, n_kv_heads, head_dim, DType::FP32, max_blocks);
+    KVCache cache(n_layers, n_kv_heads, head_dim, QType::F32, max_blocks);
     size_t bb = cache.block_bytes();
 
     int block = cache.allocate_block();
@@ -407,7 +407,7 @@ static std::unique_ptr<KVCacheManager> MakeManager(int max_blocks,
                                                     int n_layers   = 2,
                                                     int n_kv_heads = 4,
                                                     int head_dim   = 64,
-                                                    DType dtype    = DType::FP16) {
+                                                    QType dtype    = QType::F16) {
     auto cache = std::make_unique<KVCache>(n_layers, n_kv_heads, head_dim,
                                            dtype, max_blocks);
     return std::make_unique<KVCacheManager>(std::move(cache));

--- a/tests/test_layernorm.cu
+++ b/tests/test_layernorm.cu
@@ -15,10 +15,10 @@ namespace {
 // ---------------------------------------------------------------------------
 // Helper: create a GPU tensor from host float data, with optional FP16 conversion
 // ---------------------------------------------------------------------------
-Tensor make_gpu_tensor(const float* host_data, DType dtype,
+Tensor make_gpu_tensor(const float* host_data, QType dtype,
                        std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim  = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -26,9 +26,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     t.on_device = true;
     cudaMalloc(&t.data, t.nbytes());
 
-    if (dtype == DType::FP32) {
+    if (dtype == QType::F32) {
         cudaMemcpy(t.data, host_data, t.nbytes(), cudaMemcpyHostToDevice);
-    } else if (dtype == DType::FP16) {
+    } else if (dtype == QType::F16) {
         std::vector<half> h(t.numel());
         for (int64_t j = 0; j < t.numel(); j++)
             h[j] = __float2half(host_data[j]);
@@ -40,9 +40,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
 // ---------------------------------------------------------------------------
 // Helper: allocate a zeroed GPU tensor (output buffer)
 // ---------------------------------------------------------------------------
-Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) {
+Tensor alloc_gpu_tensor(QType dtype, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim  = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -58,9 +58,9 @@ Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) 
 // ---------------------------------------------------------------------------
 std::vector<float> read_gpu_tensor(const Tensor& t) {
     std::vector<float> result(t.numel());
-    if (t.dtype == DType::FP32) {
+    if (t.qtype == QType::F32) {
         cudaMemcpy(result.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
-    } else if (t.dtype == DType::FP16) {
+    } else if (t.qtype == QType::F16) {
         std::vector<half> h(t.numel());
         cudaMemcpy(h.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
         for (int64_t j = 0; j < t.numel(); j++)
@@ -142,9 +142,9 @@ TEST(LayerNormTest, RMSNormBasic) {
     cpu_rmsnorm(h_x.data(), h_w.data(), h_ref.data(), rows, cols, eps);
 
     // GPU computation
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {rows, cols});
-    Tensor d_w   = make_gpu_tensor(h_w.data(), DType::FP32, {cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {rows, cols});
+    Tensor d_w   = make_gpu_tensor(h_w.data(), QType::F32, {cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {rows, cols});
 
     rmsnorm(d_x, d_w, d_out, eps, nullptr);
     cudaDeviceSynchronize();
@@ -188,10 +188,10 @@ TEST(LayerNormTest, RMSNormResidual) {
     // GPU computation
     // Note: the kernel modifies x in-place (x <- x + residual), so we use
     // a separate copy for x.
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {rows, cols});
-    Tensor d_res = make_gpu_tensor(h_residual.data(), DType::FP32, {rows, cols});
-    Tensor d_w   = make_gpu_tensor(h_w.data(), DType::FP32, {cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {rows, cols});
+    Tensor d_res = make_gpu_tensor(h_residual.data(), QType::F32, {rows, cols});
+    Tensor d_w   = make_gpu_tensor(h_w.data(), QType::F32, {cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {rows, cols});
 
     rmsnorm_residual(d_x, d_res, d_w, d_out, eps, nullptr);
     cudaDeviceSynchronize();
@@ -248,9 +248,9 @@ TEST(LayerNormTest, RMSNormFP16) {
     cpu_rmsnorm(h_x_fp16.data(), h_w_fp16.data(), h_ref.data(), rows, cols, eps);
 
     // GPU computation in FP16
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP16, {rows, cols});
-    Tensor d_w   = make_gpu_tensor(h_w.data(), DType::FP16, {cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP16, {rows, cols});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F16, {rows, cols});
+    Tensor d_w   = make_gpu_tensor(h_w.data(), QType::F16, {cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F16, {rows, cols});
 
     rmsnorm(d_x, d_w, d_out, eps, nullptr);
     cudaDeviceSynchronize();
@@ -291,9 +291,9 @@ TEST(LayerNormTest, RMSNormLargeRow) {
     cpu_rmsnorm(h_x.data(), h_w.data(), h_ref.data(), rows, cols, eps);
 
     // GPU
-    Tensor d_x   = make_gpu_tensor(h_x.data(), DType::FP32, {rows, cols});
-    Tensor d_w   = make_gpu_tensor(h_w.data(), DType::FP32, {cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_x   = make_gpu_tensor(h_x.data(), QType::F32, {rows, cols});
+    Tensor d_w   = make_gpu_tensor(h_w.data(), QType::F32, {cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {rows, cols});
 
     rmsnorm(d_x, d_w, d_out, eps, nullptr);
     cudaDeviceSynchronize();
@@ -343,17 +343,17 @@ TEST(LayerNormTest, EpsilonEffect) {
         << "CPU references for different eps values should differ on near-zero input";
 
     // GPU with small eps
-    Tensor d_x_s   = make_gpu_tensor(h_x.data(), DType::FP32, {rows, cols});
-    Tensor d_w_s   = make_gpu_tensor(h_w.data(), DType::FP32, {cols});
-    Tensor d_out_s = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_x_s   = make_gpu_tensor(h_x.data(), QType::F32, {rows, cols});
+    Tensor d_w_s   = make_gpu_tensor(h_w.data(), QType::F32, {cols});
+    Tensor d_out_s = alloc_gpu_tensor(QType::F32, {rows, cols});
     rmsnorm(d_x_s, d_w_s, d_out_s, eps_small, nullptr);
     cudaDeviceSynchronize();
     auto h_out_small = read_gpu_tensor(d_out_s);
 
     // GPU with large eps
-    Tensor d_x_l   = make_gpu_tensor(h_x.data(), DType::FP32, {rows, cols});
-    Tensor d_w_l   = make_gpu_tensor(h_w.data(), DType::FP32, {cols});
-    Tensor d_out_l = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_x_l   = make_gpu_tensor(h_x.data(), QType::F32, {rows, cols});
+    Tensor d_w_l   = make_gpu_tensor(h_w.data(), QType::F32, {cols});
+    Tensor d_out_l = alloc_gpu_tensor(QType::F32, {rows, cols});
     rmsnorm(d_x_l, d_w_l, d_out_l, eps_large, nullptr);
     cudaDeviceSynchronize();
     auto h_out_large = read_gpu_tensor(d_out_l);

--- a/tests/test_model_builder.h
+++ b/tests/test_model_builder.h
@@ -41,7 +41,7 @@ inline Tensor make_random_weight(int64_t rows, int64_t cols,
     }
 
     Tensor t;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     t.ndim = 2;
     t.shape[0] = rows;
     t.shape[1] = cols;
@@ -58,7 +58,7 @@ inline Tensor make_norm_weight(int64_t dim) {
     std::vector<half> h_data(dim, __float2half(1.0f));
 
     Tensor t;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     t.ndim = 1;
     t.shape[0] = dim;
     t.compute_strides();
@@ -82,7 +82,7 @@ inline void free_tensor(Tensor& t) {
 // ---------------------------------------------------------------------------
 inline void verify_logits_finite(const Tensor& logits, int vocab_size) {
     std::vector<float> h_logits(vocab_size);
-    if (logits.dtype == DType::FP32) {
+    if (logits.qtype == QType::F32) {
         cudaMemcpy(h_logits.data(), logits.data, vocab_size * sizeof(float),
                    cudaMemcpyDeviceToHost);
     } else {
@@ -109,7 +109,7 @@ inline void verify_logits_finite(const Tensor& logits, int vocab_size) {
 // ---------------------------------------------------------------------------
 inline std::vector<float> read_logits(const Tensor& logits, int count) {
     std::vector<float> h(count);
-    if (logits.dtype == DType::FP32) {
+    if (logits.qtype == QType::F32) {
         cudaMemcpy(h.data(), logits.data, count * sizeof(float),
                    cudaMemcpyDeviceToHost);
     } else {
@@ -323,7 +323,7 @@ inline Tensor make_q8_0_weight(int64_t rows, int64_t cols,
     }
 
     Tensor t;
-    t.dtype = DType::FP16;  // logical dtype for shape computation
+    t.qtype = QType::F16;  // logical dtype for shape computation
     t.ndim = 2;
     t.shape[0] = rows;
     t.shape[1] = cols;
@@ -375,7 +375,7 @@ struct Q8DenseTestModel {
         result.all_tensors.push_back(result.model->out_norm_);
 
         result.model->out_proj_ = make_random_weight(vocab_size, d_model, rng);
-        result.model->out_proj_qtype_ = GGMLQuantType::NONE;
+        result.model->out_proj_qtype_ = QType::NONE;
         result.all_tensors.push_back(result.model->out_proj_);
 
         result.model->layers_.resize(n_layers);
@@ -387,10 +387,10 @@ struct Q8DenseTestModel {
             ly.wk = make_q8_0_weight(n_kv_heads * head_dim, d_model, rng);
             ly.wv = make_q8_0_weight(n_kv_heads * head_dim, d_model, rng);
             ly.wo = make_q8_0_weight(d_model, n_heads * head_dim, rng);
-            ly.wq_qtype = GGMLQuantType::Q8_0;
-            ly.wk_qtype = GGMLQuantType::Q8_0;
-            ly.wv_qtype = GGMLQuantType::Q8_0;
-            ly.wo_qtype = GGMLQuantType::Q8_0;
+            ly.wq_qtype = QType::Q8_0;
+            ly.wk_qtype = QType::Q8_0;
+            ly.wv_qtype = QType::Q8_0;
+            ly.wo_qtype = QType::Q8_0;
 
             // Norms stay FP16
             ly.attn_norm = make_norm_weight(d_model);
@@ -400,9 +400,9 @@ struct Q8DenseTestModel {
             ly.w_gate = make_q8_0_weight(d_ff, d_model, rng);
             ly.w_up = make_q8_0_weight(d_ff, d_model, rng);
             ly.w_down = make_q8_0_weight(d_model, d_ff, rng);
-            ly.w_gate_qtype = GGMLQuantType::Q8_0;
-            ly.w_up_qtype = GGMLQuantType::Q8_0;
-            ly.w_down_qtype = GGMLQuantType::Q8_0;
+            ly.w_gate_qtype = QType::Q8_0;
+            ly.w_up_qtype = QType::Q8_0;
+            ly.w_down_qtype = QType::Q8_0;
 
             result.all_tensors.push_back(ly.wq);
             result.all_tensors.push_back(ly.wk);

--- a/tests/test_model_builder.h
+++ b/tests/test_model_builder.h
@@ -375,7 +375,7 @@ struct Q8DenseTestModel {
         result.all_tensors.push_back(result.model->out_norm_);
 
         result.model->out_proj_ = make_random_weight(vocab_size, d_model, rng);
-        result.model->out_proj_qtype_ = QType::NONE;
+        result.model->out_proj_.qtype = QType::NONE;
         result.all_tensors.push_back(result.model->out_proj_);
 
         result.model->layers_.resize(n_layers);
@@ -387,10 +387,10 @@ struct Q8DenseTestModel {
             ly.wk = make_q8_0_weight(n_kv_heads * head_dim, d_model, rng);
             ly.wv = make_q8_0_weight(n_kv_heads * head_dim, d_model, rng);
             ly.wo = make_q8_0_weight(d_model, n_heads * head_dim, rng);
-            ly.wq_qtype = QType::Q8_0;
-            ly.wk_qtype = QType::Q8_0;
-            ly.wv_qtype = QType::Q8_0;
-            ly.wo_qtype = QType::Q8_0;
+            ly.wq.qtype = QType::Q8_0;
+            ly.wk.qtype = QType::Q8_0;
+            ly.wv.qtype = QType::Q8_0;
+            ly.wo.qtype = QType::Q8_0;
 
             // Norms stay FP16
             ly.attn_norm = make_norm_weight(d_model);
@@ -400,9 +400,9 @@ struct Q8DenseTestModel {
             ly.w_gate = make_q8_0_weight(d_ff, d_model, rng);
             ly.w_up = make_q8_0_weight(d_ff, d_model, rng);
             ly.w_down = make_q8_0_weight(d_model, d_ff, rng);
-            ly.w_gate_qtype = QType::Q8_0;
-            ly.w_up_qtype = QType::Q8_0;
-            ly.w_down_qtype = QType::Q8_0;
+            ly.w_gate.qtype = QType::Q8_0;
+            ly.w_up.qtype = QType::Q8_0;
+            ly.w_down.qtype = QType::Q8_0;
 
             result.all_tensors.push_back(ly.wq);
             result.all_tensors.push_back(ly.wk);

--- a/tests/test_moe.cu
+++ b/tests/test_moe.cu
@@ -20,10 +20,10 @@ static constexpr float kTolerance = 1e-4f;
 
 // Create a device-resident Tensor from host data. Caller must free with
 // free_device_tensor().
-Tensor make_device_tensor(const void* host_data, DType dtype,
+Tensor make_device_tensor(const void* host_data, QType dtype,
                           int ndim, const int64_t* shape) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = ndim;
     for (int i = 0; i < ndim; ++i) t.shape[i] = shape[i];
     t.compute_strides();
@@ -39,10 +39,10 @@ Tensor make_device_tensor(const void* host_data, DType dtype,
 }
 
 // Allocate a zero-initialized device tensor (no host source).
-Tensor make_device_tensor_zeros(DType dtype, int ndim,
+Tensor make_device_tensor_zeros(QType dtype, int ndim,
                                 const int64_t* shape) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = ndim;
     for (int i = 0; i < ndim; ++i) t.shape[i] = shape[i];
     t.compute_strides();
@@ -145,7 +145,7 @@ protected:
 
     void SetUp() override {
         int64_t shape[2] = {kNTokens, kNExperts};
-        d_gate = make_device_tensor(gate_logits.data(), DType::FP32, 2, shape);
+        d_gate = make_device_tensor(gate_logits.data(), QType::F32, 2, shape);
 
         moe_topk_gating(d_gate, kTopK, routing, /*stream=*/nullptr);
         ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
@@ -165,12 +165,12 @@ TEST_F(MoERoutingTest, TopKSelection) {
     ASSERT_EQ(routing.expert_indices.ndim, 2);
     ASSERT_EQ(routing.expert_indices.shape[0], kNTokens);
     ASSERT_EQ(routing.expert_indices.shape[1], kTopK);
-    ASSERT_EQ(routing.expert_indices.dtype, DType::INT32);
+    ASSERT_EQ(routing.expert_indices.qtype, QType::INT32);
 
     ASSERT_EQ(routing.expert_weights.ndim, 2);
     ASSERT_EQ(routing.expert_weights.shape[0], kNTokens);
     ASSERT_EQ(routing.expert_weights.shape[1], kTopK);
-    ASSERT_EQ(routing.expert_weights.dtype, DType::FP32);
+    ASSERT_EQ(routing.expert_weights.qtype, QType::F32);
 
     auto h_indices = to_host<int32_t>(routing.expert_indices);
 
@@ -244,7 +244,7 @@ TEST_F(MoERoutingTest, WeightNormalization) {
 // Test 3: ExpertOffsets
 // ---------------------------------------------------------------------------
 TEST_F(MoERoutingTest, ExpertOffsets) {
-    ASSERT_EQ(routing.expert_offsets.dtype, DType::INT32);
+    ASSERT_EQ(routing.expert_offsets.qtype, QType::INT32);
 
     // expert_offsets should have n_experts + 1 elements
     int64_t expected_len = kNExperts + 1;
@@ -277,7 +277,7 @@ TEST_F(MoERoutingTest, ExpertOffsets) {
 // ---------------------------------------------------------------------------
 TEST_F(MoERoutingTest, SortedTokenIds) {
     int total = kNTokens * kTopK;
-    ASSERT_EQ(routing.sorted_token_ids.dtype, DType::INT32);
+    ASSERT_EQ(routing.sorted_token_ids.qtype, QType::INT32);
     ASSERT_EQ(routing.sorted_token_ids.numel(), total);
 
     auto h_sorted   = to_host<int32_t>(routing.sorted_token_ids);
@@ -330,12 +330,12 @@ TEST_F(MoERoutingTest, GatherScatter) {
     }
 
     int64_t input_shape[2] = {kNTokens, kDModel};
-    Tensor d_input = make_device_tensor(h_input.data(), DType::FP32, 2,
+    Tensor d_input = make_device_tensor(h_input.data(), QType::F32, 2,
                                         input_shape);
 
     // ---- Gather ----
     int64_t gathered_shape[2] = {total, kDModel};
-    Tensor d_gathered = make_device_tensor_zeros(DType::FP32, 2,
+    Tensor d_gathered = make_device_tensor_zeros(QType::F32, 2,
                                                  gathered_shape);
 
     moe_gather(d_input, routing, d_gathered, /*stream=*/nullptr);
@@ -365,7 +365,7 @@ TEST_F(MoERoutingTest, GatherScatter) {
     //   output[t] = sum_k  weight[t][k] * input[t]
     //             = input[t]   (because weights sum to 1)
     int64_t output_shape[2] = {kNTokens, kDModel};
-    Tensor d_output = make_device_tensor_zeros(DType::FP32, 2, output_shape);
+    Tensor d_output = make_device_tensor_zeros(QType::F32, 2, output_shape);
 
     moe_scatter(d_gathered, routing, d_output, /*stream=*/nullptr);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
@@ -435,7 +435,7 @@ TEST(MoERoutingEdgeTest, EmptyExpert) {
     };
 
     int64_t shape[2] = {kN, kE};
-    Tensor d_gate = make_device_tensor(logits.data(), DType::FP32, 2, shape);
+    Tensor d_gate = make_device_tensor(logits.data(), QType::F32, 2, shape);
 
     MoeRoutingResult routing{};
     moe_topk_gating(d_gate, kK, routing, /*stream=*/nullptr);
@@ -482,7 +482,7 @@ TEST(MoERoutingEdgeTest, AllTokensSameExpert) {
     }
 
     int64_t shape[2] = {kN, kE};
-    Tensor d_gate = make_device_tensor(logits.data(), DType::FP32, 2, shape);
+    Tensor d_gate = make_device_tensor(logits.data(), QType::F32, 2, shape);
 
     MoeRoutingResult routing{};
     moe_topk_gating(d_gate, kK, routing, /*stream=*/nullptr);

--- a/tests/test_moe_executor.cu
+++ b/tests/test_moe_executor.cu
@@ -31,7 +31,7 @@ TEST(MoEExecutorTest, InitSucceeds) {
         /*n_experts=*/4, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
 
     tm.cleanup();
 }
@@ -48,7 +48,7 @@ TEST(MoEExecutorTest, ForwardProducesValidOutput) {
         /*n_experts=*/4, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -113,7 +113,7 @@ TEST(MoEExecutorTest, ForwardSamplesToken) {
         /*n_experts=*/4, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -160,7 +160,7 @@ TEST(MoEExecutorTest, Deterministic) {
         /*n_experts=*/4, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -208,7 +208,7 @@ TEST(MoEExecutorTest, MultiLayer) {
         /*n_experts=*/4, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -254,7 +254,7 @@ TEST(MoEExecutorTest, EightExperts) {
         /*n_experts=*/8, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -300,7 +300,7 @@ TEST(MoEExecutorTest, SingleToken) {
         /*n_experts=*/4, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -353,10 +353,10 @@ TEST(MoEExecutorTest, MoEVsDenseDiffer) {
         /*max_seq_len=*/512, /*seed=*/200, /*weight_scale=*/0.5f);
 
     GraphExecutor dense_exec, moe_exec;
-    ASSERT_TRUE(dense_exec.init(*dense.model, DType::FP16, false));
+    ASSERT_TRUE(dense_exec.init(*dense.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(dense_exec.allocate_workspaces(false));
-    ASSERT_TRUE(moe_exec.init(*moe.model, DType::FP16, false));
+    ASSERT_TRUE(moe_exec.init(*moe.model, QType::F16, false));
     ASSERT_TRUE(moe_exec.allocate_workspaces(false));
 
     const int n_tokens = 4;
@@ -439,7 +439,7 @@ TEST(MoEExecutorTest, LogitsShape) {
         /*n_experts=*/4, /*n_experts_active=*/2, /*expert_d_ff=*/128);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -516,7 +516,7 @@ TEST(MoEExecutorTest, MixedMoEDense) {
     tm.all_tensors.push_back(ly0.w_down);
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*tm.model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*tm.model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 

--- a/tests/test_nvfp4_quant.cu
+++ b/tests/test_nvfp4_quant.cu
@@ -45,7 +45,7 @@ TEST_F(NVFP4QuantTest, QuantDequantRoundtrip) {
     cudaMemcpy(d_input, h_input.data(), fp16_bytes, cudaMemcpyHostToDevice);
 
     int64_t input_shape[] = {N, K};
-    Tensor input(d_input, DType::FP16, 2, input_shape, true);
+    Tensor input(d_input, QType::F16, 2, input_shape, true);
 
     // Just verify no crash (actual quantization correctness depends on implementation)
     EXPECT_NO_THROW(cudaStreamSynchronize(stream_));

--- a/tests/test_paged_attention.cu
+++ b/tests/test_paged_attention.cu
@@ -22,7 +22,7 @@ static constexpr int BLOCK_SIZE = 16;
 Tensor make_gpu_tensor_fp16(const float* host_data,
                             std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -38,7 +38,7 @@ Tensor make_gpu_tensor_fp16(const float* host_data,
 
 Tensor alloc_gpu_tensor_fp16(std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     t.ndim = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -1036,7 +1036,7 @@ TEST(PagedAttentionINT4Test, DecodeSingleHead) {
 
     // INT4 cache: [num_blocks, block_size, n_kv_heads, head_dim/2]
     Tensor d_K_cache, d_V_cache;
-    d_K_cache.dtype = DType::INT8;  // raw bytes
+    d_K_cache.qtype = QType::INT8;  // raw bytes
     d_K_cache.ndim = 4;
     d_K_cache.shape[0] = num_blocks; d_K_cache.shape[1] = BLOCK_SIZE;
     d_K_cache.shape[2] = n_kv_heads; d_K_cache.shape[3] = half_hd;
@@ -1044,7 +1044,7 @@ TEST(PagedAttentionINT4Test, DecodeSingleHead) {
     cudaMalloc(&d_K_cache.data, cache_bytes);
     cudaMemcpy(d_K_cache.data, k_int4.data(), cache_bytes, cudaMemcpyHostToDevice);
 
-    d_V_cache.dtype = DType::INT8;
+    d_V_cache.qtype = QType::INT8;
     d_V_cache.ndim = 4;
     d_V_cache.shape[0] = num_blocks; d_V_cache.shape[1] = BLOCK_SIZE;
     d_V_cache.shape[2] = n_kv_heads; d_V_cache.shape[3] = half_hd;

--- a/tests/test_quant.cu
+++ b/tests/test_quant.cu
@@ -22,10 +22,10 @@ namespace {
 // ===========================================================================
 
 // Create a GPU tensor from host float data, with optional FP16 conversion.
-Tensor make_gpu_tensor(const float* host_data, DType dtype,
+Tensor make_gpu_tensor(const float* host_data, QType dtype,
                        std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim  = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -33,9 +33,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     t.on_device = true;
     cudaMalloc(&t.data, t.nbytes());
 
-    if (dtype == DType::FP32) {
+    if (dtype == QType::F32) {
         cudaMemcpy(t.data, host_data, t.nbytes(), cudaMemcpyHostToDevice);
-    } else if (dtype == DType::FP16) {
+    } else if (dtype == QType::F16) {
         std::vector<half> h(t.numel());
         for (int64_t j = 0; j < t.numel(); j++)
             h[j] = __float2half(host_data[j]);
@@ -45,9 +45,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
 }
 
 // Allocate a zeroed GPU tensor (output buffer).
-Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) {
+Tensor alloc_gpu_tensor(QType dtype, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim  = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -61,9 +61,9 @@ Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) 
 // Read a GPU tensor back to host as floats.
 std::vector<float> read_gpu_tensor(const Tensor& t) {
     std::vector<float> result(t.numel());
-    if (t.dtype == DType::FP32) {
+    if (t.qtype == QType::F32) {
         cudaMemcpy(result.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
-    } else if (t.dtype == DType::FP16) {
+    } else if (t.qtype == QType::F16) {
         std::vector<half> h(t.numel());
         cudaMemcpy(h.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
         for (int64_t j = 0; j < t.numel(); j++)
@@ -126,8 +126,8 @@ void cpu_matmul(const float* A, const float* B_T, float* C,
 // ===========================================================================
 TEST(QuantTest, QuantConfigDefaults) {
     QuantConfig config;
-    EXPECT_EQ(config.quant_dtype, DType::FP16);
-    EXPECT_EQ(config.compute_dtype, DType::FP16);
+    EXPECT_EQ(config.quant_dtype, QType::F16);
+    EXPECT_EQ(config.compute_dtype, QType::F16);
     EXPECT_EQ(config.group_size, 128);
     EXPECT_FALSE(config.has_zero_point);
 }
@@ -546,11 +546,11 @@ TEST(QuantTest, QuantGemmINT4Basic) {
     cpu_matmul(h_A.data(), h_B_dequant.data(), h_C_ref.data(), M, N, K);
 
     // --- GPU tensors ---
-    Tensor d_A = make_gpu_tensor(h_A.data(), DType::FP16, {M, K});
+    Tensor d_A = make_gpu_tensor(h_A.data(), QType::F16, {M, K});
 
     // B_quant: raw bytes, use INT4 dtype. Shape [N, K/2].
     Tensor d_B;
-    d_B.dtype = DType::INT4;
+    d_B.qtype = QType::INT4;
     d_B.ndim = 2;
     d_B.shape[0] = N;
     d_B.shape[1] = half_K;
@@ -561,11 +561,11 @@ TEST(QuantTest, QuantGemmINT4Basic) {
                cudaMemcpyHostToDevice);
 
     // Scales: FP16 [N, num_groups]
-    Tensor d_scales = make_gpu_tensor(h_scales.data(), DType::FP16,
+    Tensor d_scales = make_gpu_tensor(h_scales.data(), QType::F16,
                                        {N, num_groups});
 
     // Output: C [M, N]
-    Tensor d_C = alloc_gpu_tensor(DType::FP16, {M, N});
+    Tensor d_C = alloc_gpu_tensor(QType::F16, {M, N});
 
     // --- Run fused quant GEMM ---
     quant_gemm_int4(d_A, d_B, d_scales, d_C, nullptr);

--- a/tests/test_quant_integration.cu
+++ b/tests/test_quant_integration.cu
@@ -181,17 +181,17 @@ static std::unique_ptr<Model> make_test_model(
     // Token embedding [vocab_size, d_model]
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model, rng);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = QType::F16;
+    model->tok_emb_.qtype = QType::F16;
 
     // Output norm [d_model]
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = QType::F16;
+    model->out_norm_.qtype = QType::F16;
 
     // Output projection [vocab_size, d_model]
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model, rng);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = QType::F16;
+    model->out_proj_.qtype = QType::F16;
 
     // Layers
     model->layers_.resize(n_layers);
@@ -202,48 +202,48 @@ static std::unique_ptr<Model> make_test_model(
         if (use_q4_0) {
             // Attention weights in Q4_0
             auto [wq_buf, wq] = make_q4_0_weight(n_heads * head_dim, d_model);
-            ly.wq = wq; ly.wq_qtype = QType::Q4_0;
+            ly.wq = wq; ly.wq.qtype = QType::Q4_0;
 
             auto [wk_buf, wk] = make_q4_0_weight(n_kv_heads * head_dim, d_model);
-            ly.wk = wk; ly.wk_qtype = QType::Q4_0;
+            ly.wk = wk; ly.wk.qtype = QType::Q4_0;
 
             auto [wv_buf, wv] = make_q4_0_weight(n_kv_heads * head_dim, d_model);
-            ly.wv = wv; ly.wv_qtype = QType::Q4_0;
+            ly.wv = wv; ly.wv.qtype = QType::Q4_0;
 
             auto [wo_buf, wo] = make_q4_0_weight(d_model, n_heads * head_dim);
-            ly.wo = wo; ly.wo_qtype = QType::Q4_0;
+            ly.wo = wo; ly.wo.qtype = QType::Q4_0;
 
             // FFN weights in Q4_0
             auto [wg_buf, wg] = make_q4_0_weight(d_ff, d_model);
-            ly.w_gate = wg; ly.w_gate_qtype = QType::Q4_0;
+            ly.w_gate = wg; ly.w_gate.qtype = QType::Q4_0;
 
             auto [wu_buf, wu] = make_q4_0_weight(d_ff, d_model);
-            ly.w_up = wu; ly.w_up_qtype = QType::Q4_0;
+            ly.w_up = wu; ly.w_up.qtype = QType::Q4_0;
 
             auto [wd_buf, wd] = make_q4_0_weight(d_model, d_ff);
-            ly.w_down = wd; ly.w_down_qtype = QType::Q4_0;
+            ly.w_down = wd; ly.w_down.qtype = QType::Q4_0;
         } else {
             // Attention weights in FP16
             auto [wq_buf, wq] = make_fp16_weight(n_heads * head_dim, d_model, rng);
-            ly.wq = wq; ly.wq_qtype = QType::F16;
+            ly.wq = wq; ly.wq.qtype = QType::F16;
 
             auto [wk_buf, wk] = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-            ly.wk = wk; ly.wk_qtype = QType::F16;
+            ly.wk = wk; ly.wk.qtype = QType::F16;
 
             auto [wv_buf, wv] = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-            ly.wv = wv; ly.wv_qtype = QType::F16;
+            ly.wv = wv; ly.wv.qtype = QType::F16;
 
             auto [wo_buf, wo] = make_fp16_weight(d_model, n_heads * head_dim, rng);
-            ly.wo = wo; ly.wo_qtype = QType::F16;
+            ly.wo = wo; ly.wo.qtype = QType::F16;
 
             auto [wg_buf, wg] = make_fp16_weight(d_ff, d_model, rng);
-            ly.w_gate = wg; ly.w_gate_qtype = QType::F16;
+            ly.w_gate = wg; ly.w_gate.qtype = QType::F16;
 
             auto [wu_buf, wu] = make_fp16_weight(d_ff, d_model, rng);
-            ly.w_up = wu; ly.w_up_qtype = QType::F16;
+            ly.w_up = wu; ly.w_up.qtype = QType::F16;
 
             auto [wd_buf, wd] = make_fp16_weight(d_model, d_ff, rng);
-            ly.w_down = wd; ly.w_down_qtype = QType::F16;
+            ly.w_down = wd; ly.w_down.qtype = QType::F16;
         }
 
         // Norm weights always FP16
@@ -316,17 +316,17 @@ static std::unique_ptr<Model> make_q8_0_test_model(
     // Token embedding in FP16 (small values)
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = QType::F16;
+    model->tok_emb_.qtype = QType::F16;
 
     // Output norm
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = QType::F16;
+    model->out_norm_.qtype = QType::F16;
 
     // Output projection in FP16
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = QType::F16;
+    model->out_proj_.qtype = QType::F16;
 
     // Layers with Q8_0 weights
     model->layers_.resize(n_layers);
@@ -334,25 +334,25 @@ static std::unique_ptr<Model> make_q8_0_test_model(
         auto& ly = model->layers_[l];
 
         auto [wq_buf, wq] = make_q8_0_weight(n_heads * head_dim, d_model);
-        ly.wq = wq; ly.wq_qtype = QType::Q8_0;
+        ly.wq = wq; ly.wq.qtype = QType::Q8_0;
 
         auto [wk_buf, wk] = make_q8_0_weight(n_kv_heads * head_dim, d_model);
-        ly.wk = wk; ly.wk_qtype = QType::Q8_0;
+        ly.wk = wk; ly.wk.qtype = QType::Q8_0;
 
         auto [wv_buf, wv] = make_q8_0_weight(n_kv_heads * head_dim, d_model);
-        ly.wv = wv; ly.wv_qtype = QType::Q8_0;
+        ly.wv = wv; ly.wv.qtype = QType::Q8_0;
 
         auto [wo_buf, wo] = make_q8_0_weight(d_model, n_heads * head_dim);
-        ly.wo = wo; ly.wo_qtype = QType::Q8_0;
+        ly.wo = wo; ly.wo.qtype = QType::Q8_0;
 
         auto [wg_buf, wg] = make_q8_0_weight(d_ff, d_model);
-        ly.w_gate = wg; ly.w_gate_qtype = QType::Q8_0;
+        ly.w_gate = wg; ly.w_gate.qtype = QType::Q8_0;
 
         auto [wu_buf, wu] = make_q8_0_weight(d_ff, d_model);
-        ly.w_up = wu; ly.w_up_qtype = QType::Q8_0;
+        ly.w_up = wu; ly.w_up.qtype = QType::Q8_0;
 
         auto [wd_buf, wd] = make_q8_0_weight(d_model, d_ff);
-        ly.w_down = wd; ly.w_down_qtype = QType::Q8_0;
+        ly.w_down = wd; ly.w_down.qtype = QType::Q8_0;
 
         auto [an_buf, an] = make_norm_weight(d_model);
         ly.attn_norm = an;
@@ -455,7 +455,7 @@ TEST(QuantIntegrationTest, Q8_0WeightUpload) {
     int64_t shape[4] = {rows, cols, 0, 0};
     model->layers_.resize(1);
     model->layers_[0].wq = Tensor(q8_buf, QType::INT8, 2, shape, false);
-    model->layers_[0].wq_qtype = QType::Q8_0;
+    model->layers_[0].wq.qtype = QType::Q8_0;
 
     // Set other weights to minimal FP16 (just need wq for this test)
     auto make_fp16 = [](int r, int c) -> Tensor {
@@ -473,21 +473,21 @@ TEST(QuantIntegrationTest, Q8_0WeightUpload) {
     };
 
     auto& ly = model->layers_[0];
-    ly.wk = make_fp16(32, 32); ly.wk_qtype = QType::F16;
-    ly.wv = make_fp16(32, 32); ly.wv_qtype = QType::F16;
-    ly.wo = make_fp16(32, 32); ly.wo_qtype = QType::F16;
-    ly.w_gate = make_fp16(64, 32); ly.w_gate_qtype = QType::F16;
-    ly.w_up = make_fp16(64, 32); ly.w_up_qtype = QType::F16;
-    ly.w_down = make_fp16(32, 64); ly.w_down_qtype = QType::F16;
+    ly.wk = make_fp16(32, 32); ly.wk.qtype = QType::F16;
+    ly.wv = make_fp16(32, 32); ly.wv.qtype = QType::F16;
+    ly.wo = make_fp16(32, 32); ly.wo.qtype = QType::F16;
+    ly.w_gate = make_fp16(64, 32); ly.w_gate.qtype = QType::F16;
+    ly.w_up = make_fp16(64, 32); ly.w_up.qtype = QType::F16;
+    ly.w_down = make_fp16(32, 64); ly.w_down.qtype = QType::F16;
     ly.attn_norm = make_norm(32);
     ly.ffn_norm = make_norm(32);
 
     model->tok_emb_ = make_fp16(32, 32);
-    model->tok_emb_qtype_ = QType::F16;
+    model->tok_emb_.qtype = QType::F16;
     model->out_norm_ = make_norm(32);
-    model->out_norm_qtype_ = QType::F16;
+    model->out_norm_.qtype = QType::F16;
     model->out_proj_ = make_fp16(32, 32);
-    model->out_proj_qtype_ = QType::F16;
+    model->out_proj_.qtype = QType::F16;
 
     // Upload
     ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
@@ -553,7 +553,7 @@ TEST(QuantIntegrationTest, F32WeightUpload) {
 
     int64_t shape[4] = {rows, cols, 0, 0};
     model->tok_emb_ = Tensor(f32_buf, QType::F32, 2, shape, false);
-    model->tok_emb_qtype_ = QType::F32;
+    model->tok_emb_.qtype = QType::F32;
 
     // Minimal other weights
     auto make_fp16 = [](int r, int c) -> Tensor {
@@ -570,19 +570,19 @@ TEST(QuantIntegrationTest, F32WeightUpload) {
     };
 
     model->out_norm_ = make_norm(32);
-    model->out_norm_qtype_ = QType::F16;
+    model->out_norm_.qtype = QType::F16;
     model->out_proj_ = make_fp16(32, 32);
-    model->out_proj_qtype_ = QType::F16;
+    model->out_proj_.qtype = QType::F16;
 
     model->layers_.resize(1);
     auto& ly = model->layers_[0];
-    ly.wq = make_fp16(32, 32); ly.wq_qtype = QType::F16;
-    ly.wk = make_fp16(32, 32); ly.wk_qtype = QType::F16;
-    ly.wv = make_fp16(32, 32); ly.wv_qtype = QType::F16;
-    ly.wo = make_fp16(32, 32); ly.wo_qtype = QType::F16;
-    ly.w_gate = make_fp16(64, 32); ly.w_gate_qtype = QType::F16;
-    ly.w_up = make_fp16(64, 32); ly.w_up_qtype = QType::F16;
-    ly.w_down = make_fp16(32, 64); ly.w_down_qtype = QType::F16;
+    ly.wq = make_fp16(32, 32); ly.wq.qtype = QType::F16;
+    ly.wk = make_fp16(32, 32); ly.wk.qtype = QType::F16;
+    ly.wv = make_fp16(32, 32); ly.wv.qtype = QType::F16;
+    ly.wo = make_fp16(32, 32); ly.wo.qtype = QType::F16;
+    ly.w_gate = make_fp16(64, 32); ly.w_gate.qtype = QType::F16;
+    ly.w_up = make_fp16(64, 32); ly.w_up.qtype = QType::F16;
+    ly.w_down = make_fp16(32, 64); ly.w_down.qtype = QType::F16;
     ly.attn_norm = make_norm(32);
     ly.ffn_norm = make_norm(32);
 
@@ -1245,42 +1245,42 @@ static std::unique_ptr<Model> make_q4_k_test_model(
     // Token embedding [vocab_size, d_model] in FP16
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = QType::F16;
+    model->tok_emb_.qtype = QType::F16;
 
     // Output norm [d_model]
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = QType::F16;
+    model->out_norm_.qtype = QType::F16;
 
     // Output projection [vocab_size, d_model] in FP16
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = QType::F16;
+    model->out_proj_.qtype = QType::F16;
 
     model->layers_.resize(n_layers);
     for (int l = 0; l < n_layers; ++l) {
         auto& ly = model->layers_[l];
 
         auto [wq_buf, wq] = make_q4_k_weight(n_heads * head_dim, d_model);
-        ly.wq = wq; ly.wq_qtype = QType::Q4_K;
+        ly.wq = wq; ly.wq.qtype = QType::Q4_K;
 
         auto [wk_buf, wk] = make_q4_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wk = wk; ly.wk_qtype = QType::Q4_K;
+        ly.wk = wk; ly.wk.qtype = QType::Q4_K;
 
         auto [wv_buf, wv] = make_q4_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wv = wv; ly.wv_qtype = QType::Q4_K;
+        ly.wv = wv; ly.wv.qtype = QType::Q4_K;
 
         auto [wo_buf, wo] = make_q4_k_weight(d_model, n_heads * head_dim);
-        ly.wo = wo; ly.wo_qtype = QType::Q4_K;
+        ly.wo = wo; ly.wo.qtype = QType::Q4_K;
 
         auto [wg_buf, wg] = make_q4_k_weight(d_ff, d_model);
-        ly.w_gate = wg; ly.w_gate_qtype = QType::Q4_K;
+        ly.w_gate = wg; ly.w_gate.qtype = QType::Q4_K;
 
         auto [wu_buf, wu] = make_q4_k_weight(d_ff, d_model);
-        ly.w_up = wu; ly.w_up_qtype = QType::Q4_K;
+        ly.w_up = wu; ly.w_up.qtype = QType::Q4_K;
 
         auto [wd_buf, wd] = make_q4_k_weight(d_model, d_ff);
-        ly.w_down = wd; ly.w_down_qtype = QType::Q4_K;
+        ly.w_down = wd; ly.w_down.qtype = QType::Q4_K;
 
         auto [an_buf, an] = make_norm_weight(d_model);
         ly.attn_norm = an;
@@ -1347,40 +1347,40 @@ static std::unique_ptr<Model> make_q5_k_test_model(
 
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = QType::F16;
+    model->tok_emb_.qtype = QType::F16;
 
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = QType::F16;
+    model->out_norm_.qtype = QType::F16;
 
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = QType::F16;
+    model->out_proj_.qtype = QType::F16;
 
     model->layers_.resize(n_layers);
     for (int l = 0; l < n_layers; ++l) {
         auto& ly = model->layers_[l];
 
         auto [wq_buf, wq] = make_q5_k_weight(n_heads * head_dim, d_model);
-        ly.wq = wq; ly.wq_qtype = QType::Q5_K;
+        ly.wq = wq; ly.wq.qtype = QType::Q5_K;
 
         auto [wk_buf, wk] = make_q5_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wk = wk; ly.wk_qtype = QType::Q5_K;
+        ly.wk = wk; ly.wk.qtype = QType::Q5_K;
 
         auto [wv_buf, wv] = make_q5_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wv = wv; ly.wv_qtype = QType::Q5_K;
+        ly.wv = wv; ly.wv.qtype = QType::Q5_K;
 
         auto [wo_buf, wo] = make_q5_k_weight(d_model, n_heads * head_dim);
-        ly.wo = wo; ly.wo_qtype = QType::Q5_K;
+        ly.wo = wo; ly.wo.qtype = QType::Q5_K;
 
         auto [wg_buf, wg] = make_q5_k_weight(d_ff, d_model);
-        ly.w_gate = wg; ly.w_gate_qtype = QType::Q5_K;
+        ly.w_gate = wg; ly.w_gate.qtype = QType::Q5_K;
 
         auto [wu_buf, wu] = make_q5_k_weight(d_ff, d_model);
-        ly.w_up = wu; ly.w_up_qtype = QType::Q5_K;
+        ly.w_up = wu; ly.w_up.qtype = QType::Q5_K;
 
         auto [wd_buf, wd] = make_q5_k_weight(d_model, d_ff);
-        ly.w_down = wd; ly.w_down_qtype = QType::Q5_K;
+        ly.w_down = wd; ly.w_down.qtype = QType::Q5_K;
 
         auto [an_buf, an] = make_norm_weight(d_model);
         ly.attn_norm = an;

--- a/tests/test_quant_integration.cu
+++ b/tests/test_quant_integration.cu
@@ -151,7 +151,7 @@ static std::unique_ptr<Model> make_test_model(
 
         // Tensor shape is logical: [rows, cols]
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, QType::INT4, 2, shape, false);
+        Tensor t(buf, QType::Q4_0, 2, shape, false);
         return {buf, t};
     };
 
@@ -381,10 +381,12 @@ TEST(QuantIntegrationTest, Q4_0WeightUpload) {
     ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
     EXPECT_TRUE(model->gpu_weights_ready());
 
-    // Check layer 0 wq: raw upload keeps logical shape [N, K] and FP16 dtype
+    // Check layer 0 wq: raw upload keeps logical shape [N, K] and Q4_0 qtype
+    // (post-Stage-D: weight.qtype carries the source quant type so dispatch
+    //  can read it directly without a separate qtype parameter).
     const auto& ly = model->layer(0);
     EXPECT_TRUE(ly.wq.on_device);
-    EXPECT_EQ(ly.wq.qtype, QType::F16);
+    EXPECT_EQ(ly.wq.qtype, QType::Q4_0);
     EXPECT_EQ(ly.wq.ndim, 2);
     // wq shape: [n_heads * head_dim, d_model] = [32, 32]
     EXPECT_EQ(ly.wq.shape[0], 32);
@@ -491,9 +493,9 @@ TEST(QuantIntegrationTest, Q8_0WeightUpload) {
     ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     // After upload, wq should be on device with logical shape [N, K]
-    // Data is raw Q8_0 bytes (not dequanted FP16)
+    // Data is raw Q8_0 bytes; weight.qtype carries the source qtype now.
     EXPECT_TRUE(ly.wq.on_device);
-    EXPECT_EQ(ly.wq.qtype, QType::F16);
+    EXPECT_EQ(ly.wq.qtype, QType::Q8_0);
     EXPECT_EQ(ly.wq.shape[0], rows);
     EXPECT_EQ(ly.wq.shape[1], cols);
 
@@ -1218,7 +1220,7 @@ static std::unique_ptr<Model> make_q4_k_test_model(
             std::memcpy(buf + i * 144, blk.data(), 144);
         }
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, QType::INT4, 2, shape, false);
+        Tensor t(buf, QType::Q4_K, 2, shape, false);
         return {buf, t};
     };
 
@@ -1321,7 +1323,7 @@ static std::unique_ptr<Model> make_q5_k_test_model(
             std::memcpy(buf + i * 176, blk.data(), 176);
         }
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, QType::INT4, 2, shape, false);
+        Tensor t(buf, QType::Q5_K, 2, shape, false);
         return {buf, t};
     };
 

--- a/tests/test_quant_integration.cu
+++ b/tests/test_quant_integration.cu
@@ -133,7 +133,7 @@ static std::unique_ptr<Model> make_test_model(
             buf[i] = float_to_fp16(dist(rng));
         }
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::FP16, 2, shape, false);
+        Tensor t(buf, QType::F16, 2, shape, false);
         return {buf, t};
     };
 
@@ -151,7 +151,7 @@ static std::unique_ptr<Model> make_test_model(
 
         // Tensor shape is logical: [rows, cols]
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::INT4, 2, shape, false);
+        Tensor t(buf, QType::INT4, 2, shape, false);
         return {buf, t};
     };
 
@@ -161,7 +161,7 @@ static std::unique_ptr<Model> make_test_model(
         uint16_t one = float_to_fp16(1.0f);
         for (int i = 0; i < dim; ++i) buf[i] = one;
         int64_t shape[4] = {static_cast<int64_t>(dim), 0, 0, 0};
-        Tensor t(buf, DType::FP16, 1, shape, false);
+        Tensor t(buf, QType::F16, 1, shape, false);
         return {buf, t};
     };
 
@@ -181,17 +181,17 @@ static std::unique_ptr<Model> make_test_model(
     // Token embedding [vocab_size, d_model]
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model, rng);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = GGMLQuantType::F16;
+    model->tok_emb_qtype_ = QType::F16;
 
     // Output norm [d_model]
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = GGMLQuantType::F16;
+    model->out_norm_qtype_ = QType::F16;
 
     // Output projection [vocab_size, d_model]
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model, rng);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = GGMLQuantType::F16;
+    model->out_proj_qtype_ = QType::F16;
 
     // Layers
     model->layers_.resize(n_layers);
@@ -202,48 +202,48 @@ static std::unique_ptr<Model> make_test_model(
         if (use_q4_0) {
             // Attention weights in Q4_0
             auto [wq_buf, wq] = make_q4_0_weight(n_heads * head_dim, d_model);
-            ly.wq = wq; ly.wq_qtype = GGMLQuantType::Q4_0;
+            ly.wq = wq; ly.wq_qtype = QType::Q4_0;
 
             auto [wk_buf, wk] = make_q4_0_weight(n_kv_heads * head_dim, d_model);
-            ly.wk = wk; ly.wk_qtype = GGMLQuantType::Q4_0;
+            ly.wk = wk; ly.wk_qtype = QType::Q4_0;
 
             auto [wv_buf, wv] = make_q4_0_weight(n_kv_heads * head_dim, d_model);
-            ly.wv = wv; ly.wv_qtype = GGMLQuantType::Q4_0;
+            ly.wv = wv; ly.wv_qtype = QType::Q4_0;
 
             auto [wo_buf, wo] = make_q4_0_weight(d_model, n_heads * head_dim);
-            ly.wo = wo; ly.wo_qtype = GGMLQuantType::Q4_0;
+            ly.wo = wo; ly.wo_qtype = QType::Q4_0;
 
             // FFN weights in Q4_0
             auto [wg_buf, wg] = make_q4_0_weight(d_ff, d_model);
-            ly.w_gate = wg; ly.w_gate_qtype = GGMLQuantType::Q4_0;
+            ly.w_gate = wg; ly.w_gate_qtype = QType::Q4_0;
 
             auto [wu_buf, wu] = make_q4_0_weight(d_ff, d_model);
-            ly.w_up = wu; ly.w_up_qtype = GGMLQuantType::Q4_0;
+            ly.w_up = wu; ly.w_up_qtype = QType::Q4_0;
 
             auto [wd_buf, wd] = make_q4_0_weight(d_model, d_ff);
-            ly.w_down = wd; ly.w_down_qtype = GGMLQuantType::Q4_0;
+            ly.w_down = wd; ly.w_down_qtype = QType::Q4_0;
         } else {
             // Attention weights in FP16
             auto [wq_buf, wq] = make_fp16_weight(n_heads * head_dim, d_model, rng);
-            ly.wq = wq; ly.wq_qtype = GGMLQuantType::F16;
+            ly.wq = wq; ly.wq_qtype = QType::F16;
 
             auto [wk_buf, wk] = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-            ly.wk = wk; ly.wk_qtype = GGMLQuantType::F16;
+            ly.wk = wk; ly.wk_qtype = QType::F16;
 
             auto [wv_buf, wv] = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-            ly.wv = wv; ly.wv_qtype = GGMLQuantType::F16;
+            ly.wv = wv; ly.wv_qtype = QType::F16;
 
             auto [wo_buf, wo] = make_fp16_weight(d_model, n_heads * head_dim, rng);
-            ly.wo = wo; ly.wo_qtype = GGMLQuantType::F16;
+            ly.wo = wo; ly.wo_qtype = QType::F16;
 
             auto [wg_buf, wg] = make_fp16_weight(d_ff, d_model, rng);
-            ly.w_gate = wg; ly.w_gate_qtype = GGMLQuantType::F16;
+            ly.w_gate = wg; ly.w_gate_qtype = QType::F16;
 
             auto [wu_buf, wu] = make_fp16_weight(d_ff, d_model, rng);
-            ly.w_up = wu; ly.w_up_qtype = GGMLQuantType::F16;
+            ly.w_up = wu; ly.w_up_qtype = QType::F16;
 
             auto [wd_buf, wd] = make_fp16_weight(d_model, d_ff, rng);
-            ly.w_down = wd; ly.w_down_qtype = GGMLQuantType::F16;
+            ly.w_down = wd; ly.w_down_qtype = QType::F16;
         }
 
         // Norm weights always FP16
@@ -289,7 +289,7 @@ static std::unique_ptr<Model> make_q8_0_test_model(
         }
 
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::INT8, 2, shape, false);
+        Tensor t(buf, QType::INT8, 2, shape, false);
         return {buf, t};
     };
 
@@ -299,7 +299,7 @@ static std::unique_ptr<Model> make_q8_0_test_model(
         auto* buf = new uint16_t[n];
         for (size_t i = 0; i < n; ++i) buf[i] = float_to_fp16(0.01f);
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::FP16, 2, shape, false);
+        Tensor t(buf, QType::F16, 2, shape, false);
         return {buf, t};
     };
 
@@ -309,24 +309,24 @@ static std::unique_ptr<Model> make_q8_0_test_model(
         uint16_t one = float_to_fp16(1.0f);
         for (int i = 0; i < dim; ++i) buf[i] = one;
         int64_t shape[4] = {static_cast<int64_t>(dim), 0, 0, 0};
-        Tensor t(buf, DType::FP16, 1, shape, false);
+        Tensor t(buf, QType::F16, 1, shape, false);
         return {buf, t};
     };
 
     // Token embedding in FP16 (small values)
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = GGMLQuantType::F16;
+    model->tok_emb_qtype_ = QType::F16;
 
     // Output norm
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = GGMLQuantType::F16;
+    model->out_norm_qtype_ = QType::F16;
 
     // Output projection in FP16
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = GGMLQuantType::F16;
+    model->out_proj_qtype_ = QType::F16;
 
     // Layers with Q8_0 weights
     model->layers_.resize(n_layers);
@@ -334,25 +334,25 @@ static std::unique_ptr<Model> make_q8_0_test_model(
         auto& ly = model->layers_[l];
 
         auto [wq_buf, wq] = make_q8_0_weight(n_heads * head_dim, d_model);
-        ly.wq = wq; ly.wq_qtype = GGMLQuantType::Q8_0;
+        ly.wq = wq; ly.wq_qtype = QType::Q8_0;
 
         auto [wk_buf, wk] = make_q8_0_weight(n_kv_heads * head_dim, d_model);
-        ly.wk = wk; ly.wk_qtype = GGMLQuantType::Q8_0;
+        ly.wk = wk; ly.wk_qtype = QType::Q8_0;
 
         auto [wv_buf, wv] = make_q8_0_weight(n_kv_heads * head_dim, d_model);
-        ly.wv = wv; ly.wv_qtype = GGMLQuantType::Q8_0;
+        ly.wv = wv; ly.wv_qtype = QType::Q8_0;
 
         auto [wo_buf, wo] = make_q8_0_weight(d_model, n_heads * head_dim);
-        ly.wo = wo; ly.wo_qtype = GGMLQuantType::Q8_0;
+        ly.wo = wo; ly.wo_qtype = QType::Q8_0;
 
         auto [wg_buf, wg] = make_q8_0_weight(d_ff, d_model);
-        ly.w_gate = wg; ly.w_gate_qtype = GGMLQuantType::Q8_0;
+        ly.w_gate = wg; ly.w_gate_qtype = QType::Q8_0;
 
         auto [wu_buf, wu] = make_q8_0_weight(d_ff, d_model);
-        ly.w_up = wu; ly.w_up_qtype = GGMLQuantType::Q8_0;
+        ly.w_up = wu; ly.w_up_qtype = QType::Q8_0;
 
         auto [wd_buf, wd] = make_q8_0_weight(d_model, d_ff);
-        ly.w_down = wd; ly.w_down_qtype = GGMLQuantType::Q8_0;
+        ly.w_down = wd; ly.w_down_qtype = QType::Q8_0;
 
         auto [an_buf, an] = make_norm_weight(d_model);
         ly.attn_norm = an;
@@ -378,13 +378,13 @@ TEST(QuantIntegrationTest, Q4_0WeightUpload) {
     ASSERT_FALSE(model->gpu_weights_ready());
 
     // Upload weights to GPU
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
     EXPECT_TRUE(model->gpu_weights_ready());
 
     // Check layer 0 wq: raw upload keeps logical shape [N, K] and FP16 dtype
     const auto& ly = model->layer(0);
     EXPECT_TRUE(ly.wq.on_device);
-    EXPECT_EQ(ly.wq.dtype, DType::FP16);
+    EXPECT_EQ(ly.wq.qtype, QType::F16);
     EXPECT_EQ(ly.wq.ndim, 2);
     // wq shape: [n_heads * head_dim, d_model] = [32, 32]
     EXPECT_EQ(ly.wq.shape[0], 32);
@@ -452,8 +452,8 @@ TEST(QuantIntegrationTest, Q8_0WeightUpload) {
 
     int64_t shape[4] = {rows, cols, 0, 0};
     model->layers_.resize(1);
-    model->layers_[0].wq = Tensor(q8_buf, DType::INT8, 2, shape, false);
-    model->layers_[0].wq_qtype = GGMLQuantType::Q8_0;
+    model->layers_[0].wq = Tensor(q8_buf, QType::INT8, 2, shape, false);
+    model->layers_[0].wq_qtype = QType::Q8_0;
 
     // Set other weights to minimal FP16 (just need wq for this test)
     auto make_fp16 = [](int r, int c) -> Tensor {
@@ -461,39 +461,39 @@ TEST(QuantIntegrationTest, Q8_0WeightUpload) {
         auto* buf = new uint16_t[n];
         for (size_t i = 0; i < n; ++i) buf[i] = float_to_fp16(0.01f);
         int64_t s[4] = {static_cast<int64_t>(r), static_cast<int64_t>(c), 0, 0};
-        return Tensor(buf, DType::FP16, 2, s, false);
+        return Tensor(buf, QType::F16, 2, s, false);
     };
     auto make_norm = [](int d) -> Tensor {
         auto* buf = new uint16_t[d];
         for (int i = 0; i < d; ++i) buf[i] = float_to_fp16(1.0f);
         int64_t s[4] = {static_cast<int64_t>(d), 0, 0, 0};
-        return Tensor(buf, DType::FP16, 1, s, false);
+        return Tensor(buf, QType::F16, 1, s, false);
     };
 
     auto& ly = model->layers_[0];
-    ly.wk = make_fp16(32, 32); ly.wk_qtype = GGMLQuantType::F16;
-    ly.wv = make_fp16(32, 32); ly.wv_qtype = GGMLQuantType::F16;
-    ly.wo = make_fp16(32, 32); ly.wo_qtype = GGMLQuantType::F16;
-    ly.w_gate = make_fp16(64, 32); ly.w_gate_qtype = GGMLQuantType::F16;
-    ly.w_up = make_fp16(64, 32); ly.w_up_qtype = GGMLQuantType::F16;
-    ly.w_down = make_fp16(32, 64); ly.w_down_qtype = GGMLQuantType::F16;
+    ly.wk = make_fp16(32, 32); ly.wk_qtype = QType::F16;
+    ly.wv = make_fp16(32, 32); ly.wv_qtype = QType::F16;
+    ly.wo = make_fp16(32, 32); ly.wo_qtype = QType::F16;
+    ly.w_gate = make_fp16(64, 32); ly.w_gate_qtype = QType::F16;
+    ly.w_up = make_fp16(64, 32); ly.w_up_qtype = QType::F16;
+    ly.w_down = make_fp16(32, 64); ly.w_down_qtype = QType::F16;
     ly.attn_norm = make_norm(32);
     ly.ffn_norm = make_norm(32);
 
     model->tok_emb_ = make_fp16(32, 32);
-    model->tok_emb_qtype_ = GGMLQuantType::F16;
+    model->tok_emb_qtype_ = QType::F16;
     model->out_norm_ = make_norm(32);
-    model->out_norm_qtype_ = GGMLQuantType::F16;
+    model->out_norm_qtype_ = QType::F16;
     model->out_proj_ = make_fp16(32, 32);
-    model->out_proj_qtype_ = GGMLQuantType::F16;
+    model->out_proj_qtype_ = QType::F16;
 
     // Upload
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     // After upload, wq should be on device with logical shape [N, K]
     // Data is raw Q8_0 bytes (not dequanted FP16)
     EXPECT_TRUE(ly.wq.on_device);
-    EXPECT_EQ(ly.wq.dtype, DType::FP16);
+    EXPECT_EQ(ly.wq.qtype, QType::F16);
     EXPECT_EQ(ly.wq.shape[0], rows);
     EXPECT_EQ(ly.wq.shape[1], cols);
 
@@ -507,7 +507,7 @@ TEST(QuantIntegrationTest, Q8_0WeightUpload) {
     // Verify on-the-fly dequant produces correct FP16 values
     void* d_fp16 = nullptr;
     cudaMalloc(&d_fp16, static_cast<size_t>(rows * cols) * sizeof(uint16_t));
-    dequant_gpu(ly.wq.data, d_fp16, GGMLQuantType::Q8_0, rows, cols, nullptr);
+    dequant_gpu(ly.wq.data, d_fp16, QType::Q8_0, rows, cols, nullptr);
     cudaDeviceSynchronize();
 
     std::vector<uint16_t> h_fp16(rows * cols);
@@ -550,45 +550,45 @@ TEST(QuantIntegrationTest, F32WeightUpload) {
     }
 
     int64_t shape[4] = {rows, cols, 0, 0};
-    model->tok_emb_ = Tensor(f32_buf, DType::FP32, 2, shape, false);
-    model->tok_emb_qtype_ = GGMLQuantType::F32;
+    model->tok_emb_ = Tensor(f32_buf, QType::F32, 2, shape, false);
+    model->tok_emb_qtype_ = QType::F32;
 
     // Minimal other weights
     auto make_fp16 = [](int r, int c) -> Tensor {
         auto* buf = new uint16_t[static_cast<size_t>(r) * c];
         for (int i = 0; i < r * c; ++i) buf[i] = float_to_fp16(0.01f);
         int64_t s[4] = {static_cast<int64_t>(r), static_cast<int64_t>(c), 0, 0};
-        return Tensor(buf, DType::FP16, 2, s, false);
+        return Tensor(buf, QType::F16, 2, s, false);
     };
     auto make_norm = [](int d) -> Tensor {
         auto* buf = new uint16_t[d];
         for (int i = 0; i < d; ++i) buf[i] = float_to_fp16(1.0f);
         int64_t s[4] = {static_cast<int64_t>(d), 0, 0, 0};
-        return Tensor(buf, DType::FP16, 1, s, false);
+        return Tensor(buf, QType::F16, 1, s, false);
     };
 
     model->out_norm_ = make_norm(32);
-    model->out_norm_qtype_ = GGMLQuantType::F16;
+    model->out_norm_qtype_ = QType::F16;
     model->out_proj_ = make_fp16(32, 32);
-    model->out_proj_qtype_ = GGMLQuantType::F16;
+    model->out_proj_qtype_ = QType::F16;
 
     model->layers_.resize(1);
     auto& ly = model->layers_[0];
-    ly.wq = make_fp16(32, 32); ly.wq_qtype = GGMLQuantType::F16;
-    ly.wk = make_fp16(32, 32); ly.wk_qtype = GGMLQuantType::F16;
-    ly.wv = make_fp16(32, 32); ly.wv_qtype = GGMLQuantType::F16;
-    ly.wo = make_fp16(32, 32); ly.wo_qtype = GGMLQuantType::F16;
-    ly.w_gate = make_fp16(64, 32); ly.w_gate_qtype = GGMLQuantType::F16;
-    ly.w_up = make_fp16(64, 32); ly.w_up_qtype = GGMLQuantType::F16;
-    ly.w_down = make_fp16(32, 64); ly.w_down_qtype = GGMLQuantType::F16;
+    ly.wq = make_fp16(32, 32); ly.wq_qtype = QType::F16;
+    ly.wk = make_fp16(32, 32); ly.wk_qtype = QType::F16;
+    ly.wv = make_fp16(32, 32); ly.wv_qtype = QType::F16;
+    ly.wo = make_fp16(32, 32); ly.wo_qtype = QType::F16;
+    ly.w_gate = make_fp16(64, 32); ly.w_gate_qtype = QType::F16;
+    ly.w_up = make_fp16(64, 32); ly.w_up_qtype = QType::F16;
+    ly.w_down = make_fp16(32, 64); ly.w_down_qtype = QType::F16;
     ly.attn_norm = make_norm(32);
     ly.ffn_norm = make_norm(32);
 
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     // Token embedding should now be FP16 on device
     EXPECT_TRUE(model->tok_emb_.on_device);
-    EXPECT_EQ(model->tok_emb_.dtype, DType::FP16);
+    EXPECT_EQ(model->tok_emb_.qtype, QType::F16);
 
     // Read back and verify conversion
     std::vector<uint16_t> h_result(rows * cols);
@@ -614,11 +614,11 @@ TEST(QuantIntegrationTest, UploadIdempotent) {
 
     auto model = make_test_model(32, 64, 4, 4, 1, 32, false);
 
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
     EXPECT_TRUE(model->gpu_weights_ready());
 
     // Second call should succeed without re-uploading
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
     EXPECT_TRUE(model->gpu_weights_ready());
 }
 
@@ -629,10 +629,10 @@ TEST(QuantIntegrationTest, FP16ForwardPass) {
     SKIP_IF_NO_CUDA();
 
     auto model = make_test_model(32, 64, 4, 4, 1, 32, false);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -677,10 +677,10 @@ TEST(QuantIntegrationTest, Q4_0ForwardPass) {
     // Use nibble=9 for small nonzero weights: (9-8)*0.01 = 0.01
     auto model = make_test_model(32, 64, 4, 4, 1, 32, true,
                                   /*scale=*/0.01f, /*nibble=*/9);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -745,10 +745,10 @@ TEST(QuantIntegrationTest, Q4_0Deterministic) {
     SKIP_IF_NO_CUDA();
 
     auto model = make_test_model(32, 64, 4, 4, 1, 32, true, 0.01f, 9);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -786,10 +786,10 @@ TEST(QuantIntegrationTest, Q4_0LogitsShape) {
     SKIP_IF_NO_CUDA();
 
     auto model = make_test_model(32, 64, 4, 4, 1, 32, true, 0.01f, 9);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -819,7 +819,7 @@ TEST(QuantIntegrationTest, Q4_0LogitsShape) {
     EXPECT_EQ(logits.ndim, 2);
     EXPECT_EQ(logits.shape[0], 1);  // prefill: last token only
     EXPECT_EQ(logits.shape[1], 32); // vocab_size
-    EXPECT_EQ(logits.dtype, DType::FP32); // logits are FP32 for sampling precision
+    EXPECT_EQ(logits.qtype, QType::F32); // logits are FP32 for sampling precision
     EXPECT_TRUE(logits.on_device);
 
     cudaFree(d_tokens);
@@ -834,10 +834,10 @@ TEST(QuantIntegrationTest, Q4_0MultiLayer) {
 
     // 4 layers to test multi-layer quantized forward pass
     auto model = make_test_model(32, 64, 4, 4, 4, 32, true, 0.01f, 9);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -875,10 +875,10 @@ TEST(QuantIntegrationTest, Q8_0ForwardPass) {
     SKIP_IF_NO_CUDA();
 
     auto model = make_q8_0_test_model(32, 64, 4, 4, 1, 32, 0.01f, 2);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -940,10 +940,10 @@ TEST(QuantIntegrationTest, Q8_0MultiLayer) {
     SKIP_IF_NO_CUDA();
 
     auto model = make_q8_0_test_model(32, 64, 4, 4, 4, 32, 0.01f, 2);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -1064,10 +1064,10 @@ TEST(QuantIntegrationTest, QuantGemmInt4LargerMatrix) {
     int64_t s_shape[4] = {N, static_cast<int64_t>(num_groups), 0, 0};
     int64_t c_shape[4] = {M, N, 0, 0};
 
-    Tensor t_A(d_A, DType::FP16, 2, a_shape, true);
-    Tensor t_B(d_B, DType::INT4, 2, b_shape, true);
-    Tensor t_S(d_scales, DType::FP16, 2, s_shape, true);
-    Tensor t_C(d_C, DType::FP16, 2, c_shape, true);
+    Tensor t_A(d_A, QType::F16, 2, a_shape, true);
+    Tensor t_B(d_B, QType::INT4, 2, b_shape, true);
+    Tensor t_S(d_scales, QType::F16, 2, s_shape, true);
+    Tensor t_C(d_C, QType::F16, 2, c_shape, true);
 
     quant_gemm_int4(t_A, t_B, t_S, t_C, nullptr);
     cudaDeviceSynchronize();
@@ -1218,7 +1218,7 @@ static std::unique_ptr<Model> make_q4_k_test_model(
             std::memcpy(buf + i * 144, blk.data(), 144);
         }
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::INT4, 2, shape, false);
+        Tensor t(buf, QType::INT4, 2, shape, false);
         return {buf, t};
     };
 
@@ -1227,7 +1227,7 @@ static std::unique_ptr<Model> make_q4_k_test_model(
         auto* buf = new uint16_t[n];
         for (size_t i = 0; i < n; ++i) buf[i] = float_to_fp16(0.01f);
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::FP16, 2, shape, false);
+        Tensor t(buf, QType::F16, 2, shape, false);
         return {buf, t};
     };
 
@@ -1236,49 +1236,49 @@ static std::unique_ptr<Model> make_q4_k_test_model(
         uint16_t one = float_to_fp16(1.0f);
         for (int i = 0; i < dim; ++i) buf[i] = one;
         int64_t shape[4] = {static_cast<int64_t>(dim), 0, 0, 0};
-        Tensor t(buf, DType::FP16, 1, shape, false);
+        Tensor t(buf, QType::F16, 1, shape, false);
         return {buf, t};
     };
 
     // Token embedding [vocab_size, d_model] in FP16
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = GGMLQuantType::F16;
+    model->tok_emb_qtype_ = QType::F16;
 
     // Output norm [d_model]
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = GGMLQuantType::F16;
+    model->out_norm_qtype_ = QType::F16;
 
     // Output projection [vocab_size, d_model] in FP16
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = GGMLQuantType::F16;
+    model->out_proj_qtype_ = QType::F16;
 
     model->layers_.resize(n_layers);
     for (int l = 0; l < n_layers; ++l) {
         auto& ly = model->layers_[l];
 
         auto [wq_buf, wq] = make_q4_k_weight(n_heads * head_dim, d_model);
-        ly.wq = wq; ly.wq_qtype = GGMLQuantType::Q4_K;
+        ly.wq = wq; ly.wq_qtype = QType::Q4_K;
 
         auto [wk_buf, wk] = make_q4_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wk = wk; ly.wk_qtype = GGMLQuantType::Q4_K;
+        ly.wk = wk; ly.wk_qtype = QType::Q4_K;
 
         auto [wv_buf, wv] = make_q4_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wv = wv; ly.wv_qtype = GGMLQuantType::Q4_K;
+        ly.wv = wv; ly.wv_qtype = QType::Q4_K;
 
         auto [wo_buf, wo] = make_q4_k_weight(d_model, n_heads * head_dim);
-        ly.wo = wo; ly.wo_qtype = GGMLQuantType::Q4_K;
+        ly.wo = wo; ly.wo_qtype = QType::Q4_K;
 
         auto [wg_buf, wg] = make_q4_k_weight(d_ff, d_model);
-        ly.w_gate = wg; ly.w_gate_qtype = GGMLQuantType::Q4_K;
+        ly.w_gate = wg; ly.w_gate_qtype = QType::Q4_K;
 
         auto [wu_buf, wu] = make_q4_k_weight(d_ff, d_model);
-        ly.w_up = wu; ly.w_up_qtype = GGMLQuantType::Q4_K;
+        ly.w_up = wu; ly.w_up_qtype = QType::Q4_K;
 
         auto [wd_buf, wd] = make_q4_k_weight(d_model, d_ff);
-        ly.w_down = wd; ly.w_down_qtype = GGMLQuantType::Q4_K;
+        ly.w_down = wd; ly.w_down_qtype = QType::Q4_K;
 
         auto [an_buf, an] = make_norm_weight(d_model);
         ly.attn_norm = an;
@@ -1321,7 +1321,7 @@ static std::unique_ptr<Model> make_q5_k_test_model(
             std::memcpy(buf + i * 176, blk.data(), 176);
         }
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::INT4, 2, shape, false);
+        Tensor t(buf, QType::INT4, 2, shape, false);
         return {buf, t};
     };
 
@@ -1330,7 +1330,7 @@ static std::unique_ptr<Model> make_q5_k_test_model(
         auto* buf = new uint16_t[n];
         for (size_t i = 0; i < n; ++i) buf[i] = float_to_fp16(0.01f);
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        Tensor t(buf, DType::FP16, 2, shape, false);
+        Tensor t(buf, QType::F16, 2, shape, false);
         return {buf, t};
     };
 
@@ -1339,46 +1339,46 @@ static std::unique_ptr<Model> make_q5_k_test_model(
         uint16_t one = float_to_fp16(1.0f);
         for (int i = 0; i < dim; ++i) buf[i] = one;
         int64_t shape[4] = {static_cast<int64_t>(dim), 0, 0, 0};
-        Tensor t(buf, DType::FP16, 1, shape, false);
+        Tensor t(buf, QType::F16, 1, shape, false);
         return {buf, t};
     };
 
     auto [tok_emb_buf, tok_emb] = make_fp16_weight(vocab_size, d_model);
     model->tok_emb_ = tok_emb;
-    model->tok_emb_qtype_ = GGMLQuantType::F16;
+    model->tok_emb_qtype_ = QType::F16;
 
     auto [out_norm_buf, out_norm] = make_norm_weight(d_model);
     model->out_norm_ = out_norm;
-    model->out_norm_qtype_ = GGMLQuantType::F16;
+    model->out_norm_qtype_ = QType::F16;
 
     auto [out_proj_buf, out_proj] = make_fp16_weight(vocab_size, d_model);
     model->out_proj_ = out_proj;
-    model->out_proj_qtype_ = GGMLQuantType::F16;
+    model->out_proj_qtype_ = QType::F16;
 
     model->layers_.resize(n_layers);
     for (int l = 0; l < n_layers; ++l) {
         auto& ly = model->layers_[l];
 
         auto [wq_buf, wq] = make_q5_k_weight(n_heads * head_dim, d_model);
-        ly.wq = wq; ly.wq_qtype = GGMLQuantType::Q5_K;
+        ly.wq = wq; ly.wq_qtype = QType::Q5_K;
 
         auto [wk_buf, wk] = make_q5_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wk = wk; ly.wk_qtype = GGMLQuantType::Q5_K;
+        ly.wk = wk; ly.wk_qtype = QType::Q5_K;
 
         auto [wv_buf, wv] = make_q5_k_weight(n_kv_heads * head_dim, d_model);
-        ly.wv = wv; ly.wv_qtype = GGMLQuantType::Q5_K;
+        ly.wv = wv; ly.wv_qtype = QType::Q5_K;
 
         auto [wo_buf, wo] = make_q5_k_weight(d_model, n_heads * head_dim);
-        ly.wo = wo; ly.wo_qtype = GGMLQuantType::Q5_K;
+        ly.wo = wo; ly.wo_qtype = QType::Q5_K;
 
         auto [wg_buf, wg] = make_q5_k_weight(d_ff, d_model);
-        ly.w_gate = wg; ly.w_gate_qtype = GGMLQuantType::Q5_K;
+        ly.w_gate = wg; ly.w_gate_qtype = QType::Q5_K;
 
         auto [wu_buf, wu] = make_q5_k_weight(d_ff, d_model);
-        ly.w_up = wu; ly.w_up_qtype = GGMLQuantType::Q5_K;
+        ly.w_up = wu; ly.w_up_qtype = QType::Q5_K;
 
         auto [wd_buf, wd] = make_q5_k_weight(d_model, d_ff);
-        ly.w_down = wd; ly.w_down_qtype = GGMLQuantType::Q5_K;
+        ly.w_down = wd; ly.w_down_qtype = QType::Q5_K;
 
         auto [an_buf, an] = make_norm_weight(d_model);
         ly.attn_norm = an;
@@ -1398,7 +1398,7 @@ TEST(QuantIntegrationTest, Q4_KWeightUpload) {
     auto model = make_q4_k_test_model(
         /*d_model=*/256, /*d_ff=*/256, /*n_heads=*/4, /*n_kv_heads=*/4,
         /*n_layers=*/1, /*vocab_size=*/32);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     const auto& ly = model->layer(0);
     EXPECT_TRUE(ly.wq.on_device);
@@ -1432,10 +1432,10 @@ TEST(QuantIntegrationTest, Q4_KForwardPass) {
     auto model = make_q4_k_test_model(
         /*d_model=*/256, /*d_ff=*/256, /*n_heads=*/4, /*n_kv_heads=*/4,
         /*n_layers=*/1, /*vocab_size=*/32);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -1494,10 +1494,10 @@ TEST(QuantIntegrationTest, Q4_KDeterministic) {
     auto model = make_q4_k_test_model(
         /*d_model=*/256, /*d_ff=*/256, /*n_heads=*/4, /*n_kv_heads=*/4,
         /*n_layers=*/1, /*vocab_size=*/32);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -1537,10 +1537,10 @@ TEST(QuantIntegrationTest, Q4_KMultiLayer) {
     auto model = make_q4_k_test_model(
         /*d_model=*/256, /*d_ff=*/256, /*n_heads=*/4, /*n_kv_heads=*/4,
         /*n_layers=*/4, /*vocab_size=*/32);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -1580,7 +1580,7 @@ TEST(QuantIntegrationTest, Q5_KWeightUpload) {
     auto model = make_q5_k_test_model(
         /*d_model=*/256, /*d_ff=*/256, /*n_heads=*/4, /*n_kv_heads=*/4,
         /*n_layers=*/1, /*vocab_size=*/32);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     const auto& ly = model->layer(0);
     EXPECT_TRUE(ly.wq.on_device);
@@ -1607,10 +1607,10 @@ TEST(QuantIntegrationTest, Q5_KForwardPass) {
     auto model = make_q5_k_test_model(
         /*d_model=*/256, /*d_ff=*/256, /*n_heads=*/4, /*n_kv_heads=*/4,
         /*n_layers=*/1, /*vocab_size=*/32);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -1669,10 +1669,10 @@ TEST(QuantIntegrationTest, Q5_KMultiLayer) {
     auto model = make_q5_k_test_model(
         /*d_model=*/256, /*d_ff=*/256, /*n_heads=*/4, /*n_kv_heads=*/4,
         /*n_layers=*/4, /*vocab_size=*/32);
-    ASSERT_TRUE(model->upload_weights_gpu(DType::FP16, nullptr));
+    ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
 
     GraphExecutor executor;
-    ASSERT_TRUE(executor.init(*model, DType::FP16, false));
+    ASSERT_TRUE(executor.init(*model, QType::F16, false));
     gemm_init();
     ASSERT_TRUE(executor.allocate_workspaces(false));
 
@@ -1728,7 +1728,7 @@ TEST(QuantIntegrationTest, Q4_KDequantCorrectness) {
     // Dequant on GPU
     void* d_fp16 = nullptr;
     cudaMalloc(&d_fp16, cols * sizeof(uint16_t));
-    dequant_gpu(d_raw, d_fp16, GGMLQuantType::Q4_K, rows, cols, nullptr);
+    dequant_gpu(d_raw, d_fp16, QType::Q4_K, rows, cols, nullptr);
     cudaDeviceSynchronize();
 
     // Read back
@@ -1775,7 +1775,7 @@ TEST(QuantIntegrationTest, Q5_KDequantCorrectness) {
 
     void* d_fp16_0 = nullptr;
     cudaMalloc(&d_fp16_0, cols * sizeof(uint16_t));
-    dequant_gpu(d_raw0, d_fp16_0, GGMLQuantType::Q5_K, rows, cols, nullptr);
+    dequant_gpu(d_raw0, d_fp16_0, QType::Q5_K, rows, cols, nullptr);
     cudaDeviceSynchronize();
 
     std::vector<uint16_t> h_fp16_0(cols);
@@ -1800,7 +1800,7 @@ TEST(QuantIntegrationTest, Q5_KDequantCorrectness) {
 
     void* d_fp16_1 = nullptr;
     cudaMalloc(&d_fp16_1, cols * sizeof(uint16_t));
-    dequant_gpu(d_raw1, d_fp16_1, GGMLQuantType::Q5_K, rows, cols, nullptr);
+    dequant_gpu(d_raw1, d_fp16_1, QType::Q5_K, rows, cols, nullptr);
     cudaDeviceSynchronize();
 
     std::vector<uint16_t> h_fp16_1(cols);

--- a/tests/test_reduce.cu
+++ b/tests/test_reduce.cu
@@ -15,18 +15,18 @@ namespace {
 
 // ---- GPU tensor helpers ----
 
-Tensor make_gpu_tensor(const float* host_data, DType dtype,
+Tensor make_gpu_tensor(const float* host_data, QType dtype,
                        int ndim, const int64_t* shape) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = ndim;
     for (int i = 0; i < ndim; i++) t.shape[i] = shape[i];
     t.compute_strides();
     t.on_device = true;
     cudaMalloc(&t.data, t.nbytes());
-    if (dtype == DType::FP32) {
+    if (dtype == QType::F32) {
         cudaMemcpy(t.data, host_data, t.nbytes(), cudaMemcpyHostToDevice);
-    } else if (dtype == DType::FP16) {
+    } else if (dtype == QType::F16) {
         std::vector<half> h(t.numel());
         for (int64_t j = 0; j < t.numel(); j++)
             h[j] = __float2half(host_data[j]);
@@ -35,9 +35,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     return t;
 }
 
-Tensor alloc_gpu_tensor(DType dtype, int ndim, const int64_t* shape) {
+Tensor alloc_gpu_tensor(QType dtype, int ndim, const int64_t* shape) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim = ndim;
     for (int i = 0; i < ndim; i++) t.shape[i] = shape[i];
     t.compute_strides();
@@ -73,8 +73,8 @@ TEST(ReduceTest, SumLastDimFP32) {
 
     int64_t in_shape[] = {rows, cols};
     int64_t out_shape[] = {rows};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_sum(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -101,8 +101,8 @@ TEST(ReduceTest, SumLastDimFP16) {
 
     int64_t in_shape[] = {rows, cols};
     int64_t out_shape[] = {rows};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP16, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F16, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_sum(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -128,8 +128,8 @@ TEST(ReduceTest, SumFirstDim) {
 
     int64_t in_shape[] = {3, 4};
     int64_t out_shape[] = {4};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_sum(d_in, d_out, 0);
     cudaDeviceSynchronize();
@@ -147,8 +147,8 @@ TEST(ReduceTest, SumSingleElement) {
     std::vector<float> h_in = {42.0f};
     int64_t in_shape[] = {1, 1};
     int64_t out_shape[] = {1};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_sum(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -172,8 +172,8 @@ TEST(ReduceTest, SumLargeRow) {
 
     int64_t in_shape[] = {rows, cols};
     int64_t out_shape[] = {rows};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_sum(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -195,8 +195,8 @@ TEST(ReduceTest, SumNegativeDim) {
 
     int64_t in_shape[] = {rows, cols};
     int64_t out_shape[] = {rows};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_sum(d_in, d_out, -1);
     cudaDeviceSynchronize();
@@ -230,8 +230,8 @@ TEST(ReduceTest, Sum3DMiddleDim) {
 
     int64_t in_shape[] = {d0, d1, d2};
     int64_t out_shape[] = {d0, d2};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 3, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 2, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 3, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 2, out_shape);
 
     reduce_sum(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -260,8 +260,8 @@ TEST(ReduceTest, MaxLastDimFP32) {
 
     int64_t in_shape[] = {rows, cols};
     int64_t out_shape[] = {rows};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_max(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -286,8 +286,8 @@ TEST(ReduceTest, MaxFirstDim) {
 
     int64_t in_shape[] = {3, 3};
     int64_t out_shape[] = {3};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_max(d_in, d_out, 0);
     cudaDeviceSynchronize();
@@ -308,8 +308,8 @@ TEST(ReduceTest, MaxNegativeValues) {
 
     int64_t in_shape[] = {2, 3};
     int64_t out_shape[] = {2};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_max(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -339,8 +339,8 @@ TEST(ReduceTest, MaxFP16) {
 
     int64_t in_shape[] = {rows, cols};
     int64_t out_shape[] = {rows};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP16, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F16, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_max(d_in, d_out, 1);
     cudaDeviceSynchronize();
@@ -365,8 +365,8 @@ TEST(ReduceTest, MaxLargeRow) {
 
     int64_t in_shape[] = {rows, cols};
     int64_t out_shape[] = {rows};
-    Tensor d_in = make_gpu_tensor(h_in.data(), DType::FP32, 2, in_shape);
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, 1, out_shape);
+    Tensor d_in = make_gpu_tensor(h_in.data(), QType::F32, 2, in_shape);
+    Tensor d_out = alloc_gpu_tensor(QType::F32, 1, out_shape);
 
     reduce_max(d_in, d_out, 1);
     cudaDeviceSynchronize();

--- a/tests/test_rope.cu
+++ b/tests/test_rope.cu
@@ -39,7 +39,7 @@ std::vector<T> to_host(const T* dev, size_t count) {
 }
 
 // Build a contiguous 4-D Tensor descriptor on the device.
-Tensor make_device_tensor(void* dev_ptr, DType dtype,
+Tensor make_device_tensor(void* dev_ptr, QType dtype,
                           int64_t d0, int64_t d1, int64_t d2, int64_t d3) {
     int64_t shape[4] = {d0, d1, d2, d3};
     return Tensor(dev_ptr, dtype, 4, shape, /*on_device=*/true);
@@ -134,8 +134,8 @@ TEST(RoPETest, RopeBasicFP32) {
     float* k_dev = to_device(k_host.data(), k_count);
     int*  pos_dev = to_device(pos_host.data(), pos_host.size());
 
-    Tensor Q = make_device_tensor(q_dev, DType::FP32, batch, seq_len, n_heads, head_dim);
-    Tensor K = make_device_tensor(k_dev, DType::FP32, batch, seq_len, n_kv_heads, head_dim);
+    Tensor Q = make_device_tensor(q_dev, QType::F32, batch, seq_len, n_heads, head_dim);
+    Tensor K = make_device_tensor(k_dev, QType::F32, batch, seq_len, n_kv_heads, head_dim);
 
     rope_forward(Q, K, pos_dev, head_dim, theta, scaling);
     CUDA_CHECK(cudaDeviceSynchronize());
@@ -200,8 +200,8 @@ TEST(RoPETest, RopeBasicFP16) {
     __half* k_dev = to_device(k_half.data(), k_count);
     int*  pos_dev = to_device(pos_host.data(), pos_host.size());
 
-    Tensor Q = make_device_tensor(q_dev, DType::FP16, batch, seq_len, n_heads, head_dim);
-    Tensor K = make_device_tensor(k_dev, DType::FP16, batch, seq_len, n_kv_heads, head_dim);
+    Tensor Q = make_device_tensor(q_dev, QType::F16, batch, seq_len, n_heads, head_dim);
+    Tensor K = make_device_tensor(k_dev, QType::F16, batch, seq_len, n_kv_heads, head_dim);
 
     rope_forward(Q, K, pos_dev, head_dim, theta, scaling);
     CUDA_CHECK(cudaDeviceSynchronize());
@@ -258,8 +258,8 @@ TEST(RoPETest, RopePositionInvariance) {
     float* k_dev = to_device(k_host.data(), k_count);
     int* pos_dev = to_device(pos_host.data(), pos_host.size());
 
-    Tensor Q = make_device_tensor(q_dev, DType::FP32, batch, seq_len, n_heads, head_dim);
-    Tensor K = make_device_tensor(k_dev, DType::FP32, batch, seq_len, n_kv_heads, head_dim);
+    Tensor Q = make_device_tensor(q_dev, QType::F32, batch, seq_len, n_heads, head_dim);
+    Tensor K = make_device_tensor(k_dev, QType::F32, batch, seq_len, n_kv_heads, head_dim);
 
     rope_forward(Q, K, pos_dev, head_dim, 10000.0f, 1.0f);
     CUDA_CHECK(cudaDeviceSynchronize());
@@ -311,8 +311,8 @@ TEST(RoPETest, RopeThetaScaling) {
     float* k_dev1 = to_device(k_host.data(), k_count);
     int* pos_dev = to_device(pos_host.data(), pos_host.size());
 
-    Tensor Q1 = make_device_tensor(q_dev1, DType::FP32, batch, seq_len, n_heads, head_dim);
-    Tensor K1 = make_device_tensor(k_dev1, DType::FP32, batch, seq_len, n_kv_heads, head_dim);
+    Tensor Q1 = make_device_tensor(q_dev1, QType::F32, batch, seq_len, n_heads, head_dim);
+    Tensor K1 = make_device_tensor(k_dev1, QType::F32, batch, seq_len, n_kv_heads, head_dim);
 
     rope_forward(Q1, K1, pos_dev, head_dim, 10000.0f, 1.0f);
     CUDA_CHECK(cudaDeviceSynchronize());
@@ -324,8 +324,8 @@ TEST(RoPETest, RopeThetaScaling) {
     float* q_dev2 = to_device(q_host.data(), q_count);
     float* k_dev2 = to_device(k_host.data(), k_count);
 
-    Tensor Q2 = make_device_tensor(q_dev2, DType::FP32, batch, seq_len, n_heads, head_dim);
-    Tensor K2 = make_device_tensor(k_dev2, DType::FP32, batch, seq_len, n_kv_heads, head_dim);
+    Tensor Q2 = make_device_tensor(q_dev2, QType::F32, batch, seq_len, n_heads, head_dim);
+    Tensor K2 = make_device_tensor(k_dev2, QType::F32, batch, seq_len, n_kv_heads, head_dim);
 
     rope_forward(Q2, K2, pos_dev, head_dim, 1000000.0f, 1.0f);
     CUDA_CHECK(cudaDeviceSynchronize());
@@ -390,8 +390,8 @@ TEST(RoPETest, RopeLargerDim) {
     float* k_dev = to_device(k_host.data(), k_count);
     int*  pos_dev = to_device(pos_host.data(), pos_host.size());
 
-    Tensor Q = make_device_tensor(q_dev, DType::FP32, batch, seq_len, n_heads, head_dim);
-    Tensor K = make_device_tensor(k_dev, DType::FP32, batch, seq_len, n_kv_heads, head_dim);
+    Tensor Q = make_device_tensor(q_dev, QType::F32, batch, seq_len, n_heads, head_dim);
+    Tensor K = make_device_tensor(k_dev, QType::F32, batch, seq_len, n_kv_heads, head_dim);
 
     rope_forward(Q, K, pos_dev, head_dim, theta, scaling);
     CUDA_CHECK(cudaDeviceSynchronize());
@@ -480,8 +480,8 @@ TEST(RoPETest, PartialRoPE) {
     float* k_dev  = to_device(k_host.data(), k_count);
     int*  pos_dev = to_device(pos_host.data(), pos_host.size());
 
-    Tensor Q = make_device_tensor(q_dev, DType::FP32, batch, seq_len, n_heads, head_dim);
-    Tensor K = make_device_tensor(k_dev, DType::FP32, batch, seq_len, n_kv_heads, head_dim);
+    Tensor Q = make_device_tensor(q_dev, QType::F32, batch, seq_len, n_heads, head_dim);
+    Tensor K = make_device_tensor(k_dev, QType::F32, batch, seq_len, n_kv_heads, head_dim);
 
     rope_forward(Q, K, pos_dev, head_dim, theta, scaling, rope_dim);
     CUDA_CHECK(cudaDeviceSynchronize());

--- a/tests/test_sampling.cu
+++ b/tests/test_sampling.cu
@@ -16,7 +16,7 @@ namespace {
 // Helper: create a 1D FP32 GPU tensor from host data
 Tensor make_logits(const float* data, int64_t vocab_size) {
     Tensor t;
-    t.dtype = DType::FP32;
+    t.qtype = QType::F32;
     t.ndim = 1;
     t.shape[0] = vocab_size;
     t.compute_strides();

--- a/tests/test_softmax.cu
+++ b/tests/test_softmax.cu
@@ -16,10 +16,10 @@ namespace {
 // ---------------------------------------------------------------------------
 // Helpers (same pattern as test_layernorm.cu)
 // ---------------------------------------------------------------------------
-Tensor make_gpu_tensor(const float* host_data, DType dtype,
+Tensor make_gpu_tensor(const float* host_data, QType dtype,
                        std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim  = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -27,9 +27,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     t.on_device = true;
     cudaMalloc(&t.data, t.nbytes());
 
-    if (dtype == DType::FP32) {
+    if (dtype == QType::F32) {
         cudaMemcpy(t.data, host_data, t.nbytes(), cudaMemcpyHostToDevice);
-    } else if (dtype == DType::FP16) {
+    } else if (dtype == QType::F16) {
         std::vector<half> h(t.numel());
         for (int64_t j = 0; j < t.numel(); j++)
             h[j] = __float2half(host_data[j]);
@@ -38,9 +38,9 @@ Tensor make_gpu_tensor(const float* host_data, DType dtype,
     return t;
 }
 
-Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) {
+Tensor alloc_gpu_tensor(QType dtype, std::initializer_list<int64_t> shape_list) {
     Tensor t;
-    t.dtype = dtype;
+    t.qtype = dtype;
     t.ndim  = static_cast<int>(shape_list.size());
     int i = 0;
     for (auto s : shape_list) t.shape[i++] = s;
@@ -53,9 +53,9 @@ Tensor alloc_gpu_tensor(DType dtype, std::initializer_list<int64_t> shape_list) 
 
 std::vector<float> read_gpu_tensor(const Tensor& t) {
     std::vector<float> result(t.numel());
-    if (t.dtype == DType::FP32) {
+    if (t.qtype == QType::F32) {
         cudaMemcpy(result.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
-    } else if (t.dtype == DType::FP16) {
+    } else if (t.qtype == QType::F16) {
         std::vector<half> h(t.numel());
         cudaMemcpy(h.data(), t.data, t.nbytes(), cudaMemcpyDeviceToHost);
         for (int64_t j = 0; j < t.numel(); j++)
@@ -79,8 +79,8 @@ TEST(SoftmaxTest, OutputSumsToOne) {
     for (int i = 0; i < rows * cols; i++)
         h_in[i] = std::sin(static_cast<float>(i) * 0.3f) * 2.0f;
 
-    Tensor d_in  = make_gpu_tensor(h_in.data(), DType::FP16, {rows, cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP16, {rows, cols});
+    Tensor d_in  = make_gpu_tensor(h_in.data(), QType::F16, {rows, cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F16, {rows, cols});
 
     softmax(d_in, d_out, nullptr);
     cudaDeviceSynchronize();
@@ -108,8 +108,8 @@ TEST(SoftmaxTest, OutputSumsToOneFP32) {
     for (int i = 0; i < rows * cols; i++)
         h_in[i] = std::cos(static_cast<float>(i) * 0.17f) * 5.0f;
 
-    Tensor d_in  = make_gpu_tensor(h_in.data(), DType::FP32, {rows, cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_in  = make_gpu_tensor(h_in.data(), QType::F32, {rows, cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {rows, cols});
 
     softmax(d_in, d_out, nullptr);
     cudaDeviceSynchronize();
@@ -135,8 +135,8 @@ TEST(SoftmaxTest, AllEqualInput) {
     constexpr int rows = 1, cols = 32;
     std::vector<float> h_in(cols, 3.0f);  // all equal
 
-    Tensor d_in  = make_gpu_tensor(h_in.data(), DType::FP32, {rows, cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {rows, cols});
+    Tensor d_in  = make_gpu_tensor(h_in.data(), QType::F32, {rows, cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {rows, cols});
 
     softmax(d_in, d_out, nullptr);
     cudaDeviceSynchronize();
@@ -158,8 +158,8 @@ TEST(SoftmaxTest, SingleElement) {
     SKIP_IF_NO_CUDA();
 
     std::vector<float> h_in = {42.0f};
-    Tensor d_in  = make_gpu_tensor(h_in.data(), DType::FP32, {1, 1});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {1, 1});
+    Tensor d_in  = make_gpu_tensor(h_in.data(), QType::F32, {1, 1});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {1, 1});
 
     softmax(d_in, d_out, nullptr);
     cudaDeviceSynchronize();
@@ -183,8 +183,8 @@ TEST(SoftmaxTest, NegativeInfMasking) {
     std::vector<float> h_in = {neg_inf, 1.0f, neg_inf, 2.0f,
                                 neg_inf, 3.0f, neg_inf, 0.5f};
 
-    Tensor d_in  = make_gpu_tensor(h_in.data(), DType::FP32, {1, cols});
-    Tensor d_out = alloc_gpu_tensor(DType::FP32, {1, cols});
+    Tensor d_in  = make_gpu_tensor(h_in.data(), QType::F32, {1, cols});
+    Tensor d_out = alloc_gpu_tensor(QType::F32, {1, cols});
 
     softmax(d_in, d_out, nullptr);
     cudaDeviceSynchronize();

--- a/tests/test_ssm.cu
+++ b/tests/test_ssm.cu
@@ -17,7 +17,7 @@ namespace {
 // ---------------------------------------------------------------------------
 Tensor make_fp16_gpu(const float* host, std::initializer_list<int64_t> shape) {
     Tensor t;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     t.ndim  = static_cast<int>(shape.size());
     int i = 0;
     for (auto s : shape) t.shape[i++] = s;
@@ -33,7 +33,7 @@ Tensor make_fp16_gpu(const float* host, std::initializer_list<int64_t> shape) {
 
 Tensor alloc_fp16_gpu(std::initializer_list<int64_t> shape) {
     Tensor t;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     t.ndim  = static_cast<int>(shape.size());
     int i = 0;
     for (auto s : shape) t.shape[i++] = s;
@@ -48,7 +48,7 @@ Tensor make_empty_tensor() {
     Tensor t;
     t.data = nullptr;
     t.ndim = 0;
-    t.dtype = DType::FP16;
+    t.qtype = QType::F16;
     return t;
 }
 

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -10,7 +10,7 @@ TEST(TensorTest, DefaultConstruction) {
     EXPECT_EQ(t.ndim, 0);
     EXPECT_EQ(t.qtype, QType::NONE);
     EXPECT_EQ(t.scales, nullptr);
-    EXPECT_EQ(t.tensor_scale, nullptr);
+    EXPECT_EQ(t.tensor_scale, 1.0f);  // default = multiplicative identity
     EXPECT_FALSE(t.on_device);
 }
 

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -8,31 +8,33 @@ TEST(TensorTest, DefaultConstruction) {
     Tensor t;
     EXPECT_EQ(t.data, nullptr);
     EXPECT_EQ(t.ndim, 0);
-    EXPECT_EQ(t.dtype, DType::FP32);
+    EXPECT_EQ(t.qtype, QType::NONE);
+    EXPECT_EQ(t.scales, nullptr);
+    EXPECT_EQ(t.tensor_scale, nullptr);
     EXPECT_FALSE(t.on_device);
 }
 
 TEST(TensorTest, Numel) {
     int64_t shape[] = {2, 3, 4};
-    Tensor t(nullptr, DType::FP32, 3, shape, false);
+    Tensor t(nullptr, QType::F32, 3, shape, false);
     EXPECT_EQ(t.numel(), 24);
 }
 
 TEST(TensorTest, Nbytes) {
     int64_t shape[] = {2, 3, 4};
-    Tensor t(nullptr, DType::FP32, 3, shape, false);
+    Tensor t(nullptr, QType::F32, 3, shape, false);
     EXPECT_EQ(t.nbytes(), 24 * sizeof(float));
 }
 
 TEST(TensorTest, NbytesFP16) {
     int64_t shape[] = {8, 16};
-    Tensor t(nullptr, DType::FP16, 2, shape, false);
+    Tensor t(nullptr, QType::F16, 2, shape, false);
     EXPECT_EQ(t.nbytes(), 8 * 16 * 2);  // FP16 = 2 bytes
 }
 
 TEST(TensorTest, Strides) {
     int64_t shape[] = {2, 3, 4};
-    Tensor t(nullptr, DType::FP32, 3, shape, false);
+    Tensor t(nullptr, QType::F32, 3, shape, false);
     t.compute_strides();
     EXPECT_EQ(t.stride[0], 12);  // 3 * 4
     EXPECT_EQ(t.stride[1], 4);   // 4
@@ -41,14 +43,14 @@ TEST(TensorTest, Strides) {
 
 TEST(TensorTest, IsContiguous) {
     int64_t shape[] = {2, 3, 4};
-    Tensor t(nullptr, DType::FP32, 3, shape, false);
+    Tensor t(nullptr, QType::F32, 3, shape, false);
     t.compute_strides();
     EXPECT_TRUE(t.is_contiguous());
 }
 
 TEST(TensorTest, Reshape) {
     int64_t shape[] = {2, 3, 4};
-    Tensor t(nullptr, DType::FP32, 3, shape, false);
+    Tensor t(nullptr, QType::F32, 3, shape, false);
     t.compute_strides();
 
     int64_t new_shape[] = {6, 4};
@@ -61,7 +63,7 @@ TEST(TensorTest, Reshape) {
 
 TEST(TensorTest, ToString) {
     int64_t shape[] = {2, 3};
-    Tensor t(nullptr, DType::FP16, 2, shape, true);
+    Tensor t(nullptr, QType::F16, 2, shape, true);
     std::string s = t.to_string();
     EXPECT_FALSE(s.empty());
     // Should contain shape and dtype info
@@ -70,19 +72,19 @@ TEST(TensorTest, ToString) {
 }
 
 TEST(TensorTest, DTypeSizeAndName) {
-    EXPECT_EQ(dtype_size(DType::FP32), 4u);
-    EXPECT_EQ(dtype_size(DType::FP16), 2u);
-    EXPECT_EQ(dtype_size(DType::BF16), 2u);
-    EXPECT_EQ(dtype_size(DType::INT8), 1u);
-    EXPECT_EQ(dtype_size(DType::INT32), 4u);
+    EXPECT_EQ(dtype_size(QType::F32), 4u);
+    EXPECT_EQ(dtype_size(QType::F16), 2u);
+    EXPECT_EQ(dtype_size(QType::BF16), 2u);
+    EXPECT_EQ(dtype_size(QType::INT8), 1u);
+    EXPECT_EQ(dtype_size(QType::INT32), 4u);
 
-    EXPECT_STREQ(dtype_name(DType::FP32), "FP32");
-    EXPECT_STREQ(dtype_name(DType::FP16), "FP16");
+    EXPECT_STREQ(dtype_name(QType::F32), "F32");
+    EXPECT_STREQ(dtype_name(QType::F16), "F16");
 }
 
 TEST(TensorTest, ScalarTensor) {
     int64_t shape[] = {1};
-    Tensor t(nullptr, DType::FP32, 1, shape, false);
+    Tensor t(nullptr, QType::F32, 1, shape, false);
     EXPECT_EQ(t.numel(), 1);
     EXPECT_EQ(t.nbytes(), sizeof(float));
 }

--- a/tests/test_turboquant.cu
+++ b/tests/test_turboquant.cu
@@ -40,7 +40,7 @@ TEST(TurboQuantTest, CacheConstruction) {
     const int block_size = 16;
 
     // TurboQuant cache
-    KVCache tq_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+    KVCache tq_cache(n_layers, n_kv_heads, head_dim, QType::TURBOQUANT, max_blocks, block_size);
 
     // Block bytes should match INT4 (packed: block_size * n_kv_heads * head_dim / 2)
     size_t expected_block_bytes = static_cast<size_t>(block_size) * n_kv_heads * head_dim / 2;
@@ -58,7 +58,7 @@ TEST(TurboQuantTest, CacheConstruction) {
     EXPECT_EQ(tq_cache.sketch_block_bytes(), expected_sketch_bytes);
 
     // Verify FP16 comparison: TurboQuant should use less memory per block
-    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks, block_size);
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks, block_size);
     EXPECT_LT(tq_cache.block_bytes(), fp16_cache.block_bytes());
     // INT4 packed = half the FP16 bytes
     EXPECT_EQ(tq_cache.block_bytes() * 4, fp16_cache.block_bytes());
@@ -142,7 +142,7 @@ TEST(TurboQuantTest, SketchPointers) {
     const int max_blocks = 8;
     const int block_size = 16;
 
-    KVCache cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+    KVCache cache(n_layers, n_kv_heads, head_dim, QType::TURBOQUANT, max_blocks, block_size);
 
     // Sketch pointers should be different for different layers
     void* s0_0 = cache.k_sketch_ptr(0, 0);
@@ -309,8 +309,8 @@ TEST(TurboQuantTest, MemoryReduction) {
     const int max_blocks = 256;
     const int block_size = 16;
 
-    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks, block_size);
-    KVCache tq_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks, block_size);
+    KVCache tq_cache(n_layers, n_kv_heads, head_dim, QType::TURBOQUANT, max_blocks, block_size);
 
     // TurboQuant K+V data pool should be 1/4 of FP16 (INT4 packed for both K dirs and V)
     double ratio = static_cast<double>(tq_cache.block_bytes()) / fp16_cache.block_bytes();
@@ -340,7 +340,7 @@ TEST(TurboQuantLiteTest, CacheConstruction) {
     const int block_size = 16;
     const int sketch_dim = 2 * head_dim;  // multiplier = 2
 
-    KVCache tql_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT_LITE,
+    KVCache tql_cache(n_layers, n_kv_heads, head_dim, QType::TURBOQUANT_LITE,
                       max_blocks, block_size, nullptr, sketch_dim);
 
     // Block bytes should match INT4 V (same as standard INT4)
@@ -387,7 +387,7 @@ TEST(TurboQuantLiteTest, VPointerOffsets) {
     const int block_size = 16;
     const int sketch_dim = 2 * head_dim;
 
-    KVCache cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT_LITE,
+    KVCache cache(n_layers, n_kv_heads, head_dim, QType::TURBOQUANT_LITE,
                   max_blocks, block_size, nullptr, sketch_dim);
 
     // V pointers should differ between blocks
@@ -420,12 +420,12 @@ TEST(TurboQuantLiteTest, MemorySavings) {
     const int max_blocks = 256;
     const int block_size = 16;
 
-    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, DType::FP16, max_blocks, block_size);
-    KVCache tq_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT, max_blocks, block_size);
+    KVCache fp16_cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks, block_size);
+    KVCache tq_cache(n_layers, n_kv_heads, head_dim, QType::TURBOQUANT, max_blocks, block_size);
 
     // TQ Lite with mult=2: sketch_dim = 256
     const int sketch_dim_lite = 2 * head_dim;
-    KVCache tql_cache(n_layers, n_kv_heads, head_dim, DType::TURBOQUANT_LITE,
+    KVCache tql_cache(n_layers, n_kv_heads, head_dim, QType::TURBOQUANT_LITE,
                       max_blocks, block_size, nullptr, sketch_dim_lite);
 
     // TQ Lite should use less VRAM than TQ (no INT4 K directions in pool)

--- a/tests/test_weight_dispatch.cu
+++ b/tests/test_weight_dispatch.cu
@@ -81,10 +81,10 @@ TEST_F(WeightDispatchTest, FP16_GemmMatchesDirect) {
     half* d_y_disp;   cudaMalloc(&d_y_disp,    M * N * sizeof(half));
 
     int64_t wshape[2] = {M, K}, xshape[2] = {N, K}, yshape[2] = {M, N};
-    Tensor w_t(d_w, DType::FP16, 2, wshape, true);
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
-    Tensor y_direct(d_y_direct, DType::FP16, 2, yshape, true);
-    Tensor y_disp(d_y_disp, DType::FP16, 2, yshape, true);
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_direct(d_y_direct, QType::F16, 2, yshape, true);
+    Tensor y_disp(d_y_disp, QType::F16, 2, yshape, true);
 
     gemm(w_t, x_t, y_direct, 1.0f, 0.0f, stream_);
     cudaStreamSynchronize(stream_);
@@ -122,10 +122,10 @@ TEST_F(WeightDispatchTest, FP16_GemvMatchesDirect) {
     half* d_y_disp;   cudaMalloc(&d_y_disp,   M * sizeof(half));
 
     int64_t wshape[2] = {M, K}, xshape[2] = {1, K}, yshape[2] = {M, 1};
-    Tensor w_t(d_w, DType::FP16, 2, wshape, true);
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
-    Tensor y_direct(d_y_direct, DType::FP16, 2, yshape, true);
-    Tensor y_disp(d_y_disp,   DType::FP16, 2, yshape, true);
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_direct(d_y_direct, QType::F16, 2, yshape, true);
+    Tensor y_disp(d_y_disp,   QType::F16, 2, yshape, true);
 
     gemm(w_t, x_t, y_direct, 1.0f, 0.0f, stream_);
     cudaStreamSynchronize(stream_);
@@ -181,10 +181,10 @@ TEST_F(WeightDispatchTest, FP8_GemmMatchesDirect) {
     float* d_x_scale;  cudaMalloc(&d_x_scale,  sizeof(float));
 
     int64_t wshape[2] = {M, K}, xshape[2] = {N, K};
-    Tensor w_fp16_t(d_w_fp16, DType::FP16, 2, wshape, true);
-    Tensor w_fp8_t(d_w_fp8, DType::FP8_E4M3, 2, wshape, true);
-    Tensor x_fp16_t(d_x_fp16, DType::FP16, 2, xshape, true);
-    Tensor x_fp8_t(d_x_fp8, DType::FP8_E4M3, 2, xshape, true);
+    Tensor w_fp16_t(d_w_fp16, QType::F16, 2, wshape, true);
+    Tensor w_fp8_t(d_w_fp8, QType::FP8_E4M3, 2, wshape, true);
+    Tensor x_fp16_t(d_x_fp16, QType::F16, 2, xshape, true);
+    Tensor x_fp8_t(d_x_fp8, QType::FP8_E4M3, 2, xshape, true);
 
     quantize_fp16_to_fp8_e4m3(w_fp16_t, w_fp8_t, d_w_scale, stream_);
     quantize_fp16_to_fp8_e4m3(x_fp16_t, x_fp8_t, d_x_scale, stream_);
@@ -193,8 +193,8 @@ TEST_F(WeightDispatchTest, FP8_GemmMatchesDirect) {
     int64_t yshape[2] = {M, N};
     half* d_y_direct; cudaMalloc(&d_y_direct, M * N * sizeof(half));
     half* d_y_disp;   cudaMalloc(&d_y_disp,   M * N * sizeof(half));
-    Tensor y_direct(d_y_direct, DType::FP16, 2, yshape, true);
-    Tensor y_disp(d_y_disp,   DType::FP16, 2, yshape, true);
+    Tensor y_direct(d_y_direct, QType::F16, 2, yshape, true);
+    Tensor y_disp(d_y_disp,   QType::F16, 2, yshape, true);
 
     // Direct call: gemm_cublaslt(fp8_x, fp8_w, fp16_y, alpha, beta, aScale, bScale)
     gemm_cublaslt(x_fp8_t, w_fp8_t, y_direct, 1.0f, 0.0f, d_x_scale, d_w_scale, stream_);
@@ -249,8 +249,8 @@ TEST_F(WeightDispatchTest, FP8_GemvMatchesDirect) {
     float* d_scale; cudaMalloc(&d_scale, sizeof(float));
 
     int64_t wshape[2] = {M, K};
-    Tensor w_fp16_t(d_w_fp16, DType::FP16, 2, wshape, true);
-    Tensor w_fp8_t(d_w_fp8, DType::FP8_E4M3, 2, wshape, true);
+    Tensor w_fp16_t(d_w_fp16, QType::F16, 2, wshape, true);
+    Tensor w_fp8_t(d_w_fp8, QType::FP8_E4M3, 2, wshape, true);
     quantize_fp16_to_fp8_e4m3(w_fp16_t, w_fp8_t, d_scale, stream_);
     cudaStreamSynchronize(stream_);
 
@@ -259,12 +259,12 @@ TEST_F(WeightDispatchTest, FP8_GemvMatchesDirect) {
     cudaMemcpy(&host_scale, d_scale, sizeof(float), cudaMemcpyDeviceToHost);
 
     int64_t xshape[2] = {1, K}, yshape[2] = {M, 1};
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
 
     half* d_y_direct; cudaMalloc(&d_y_direct, M * sizeof(half));
     half* d_y_disp;   cudaMalloc(&d_y_disp,   M * sizeof(half));
-    Tensor y_direct(d_y_direct, DType::FP16, 2, yshape, true);
-    Tensor y_disp(d_y_disp,   DType::FP16, 2, yshape, true);
+    Tensor y_direct(d_y_direct, QType::F16, 2, yshape, true);
+    Tensor y_disp(d_y_disp,   QType::F16, 2, yshape, true);
 
     gemv_fp8(w_fp8_t, x_t, y_direct, host_scale, stream_);
     cudaStreamSynchronize(stream_);
@@ -313,7 +313,7 @@ TEST_F(WeightDispatchTest, NVFP4_GemmMatchesDirect) {
     half* d_x = dev_alloc_copy(h_x);
 
     int64_t wshape[2] = {M, K};
-    Tensor w_t(d_w, DType::FP16, 2, wshape, true);
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
 
     // Quantize to NVFP4
     NvFP4QuantResult qr;
@@ -326,12 +326,12 @@ TEST_F(WeightDispatchTest, NVFP4_GemmMatchesDirect) {
     qr.tensor_scale = 1.0f;
 
     int64_t xshape[2] = {N, K}, yshape[2] = {M, N};
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
 
     half* d_y_direct; cudaMalloc(&d_y_direct, M * N * sizeof(half));
     half* d_y_disp;   cudaMalloc(&d_y_disp,   M * N * sizeof(half));
-    Tensor y_direct(d_y_direct, DType::FP16, 2, yshape, true);
-    Tensor y_disp(d_y_disp,   DType::FP16, 2, yshape, true);
+    Tensor y_direct(d_y_direct, QType::F16, 2, yshape, true);
+    Tensor y_disp(d_y_disp,   QType::F16, 2, yshape, true);
 
     gemm_nvfp4(qr, x_t, y_direct, stream_);
     cudaStreamSynchronize(stream_);
@@ -380,7 +380,7 @@ TEST_F(WeightDispatchTest, NVFP4_GemvMatchesDirect) {
     half* d_x = dev_alloc_copy(h_x);
 
     int64_t wshape[2] = {M, K};
-    Tensor w_t(d_w, DType::FP16, 2, wshape, true);
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
 
     NvFP4QuantResult qr;
     quantize_fp16_to_nvfp4(w_t, qr, stream_);
@@ -396,8 +396,8 @@ TEST_F(WeightDispatchTest, NVFP4_GemvMatchesDirect) {
     cudaStreamSynchronize(stream_);
 
     int64_t xshape[2] = {1, K}, yshape[2] = {M, 1};
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
-    Tensor y_disp(d_y_disp, DType::FP16, 2, yshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_disp(d_y_disp, QType::F16, 2, yshape, true);
 
     WeightHandle h;
     h.kind = TensorKind::WQ;
@@ -456,7 +456,7 @@ TEST_F(WeightDispatchTest, CUTLASS_NVFP4_GemmMatchesDirect) {
     half* d_x = dev_alloc_copy(h_x);
 
     int64_t wshape[2] = {N, K};
-    Tensor w_t(d_w, DType::FP16, 2, wshape, true);
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
 
     NvFP4QuantResult qr;
     quantize_fp16_to_nvfp4(w_t, qr, stream_);
@@ -502,8 +502,8 @@ TEST_F(WeightDispatchTest, CUTLASS_NVFP4_GemmMatchesDirect) {
     h.payload.cutlass_nvfp4.global_scale = const_cast<float*>(&cw.tensor_scale);
 
     int64_t xshape[2] = {M, K}, yshape[2] = {M, N};
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
-    Tensor y_disp(d_y_disp, DType::FP16, 2, yshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_disp(d_y_disp, QType::F16, 2, yshape, true);
 
     // Workspace layout: [act_data | act_sf | cutlass_ws]
     // Must fit in kWorkspaceBytes (64 MiB)
@@ -558,8 +558,8 @@ TEST_F(WeightDispatchTest, CUTLASS_NVFP4_GemvIsStub) {
     cudaMemset(d_y, 0, M * sizeof(half));
 
     int64_t xshape[2] = {1, K}, yshape[2] = {M, 1};
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
-    Tensor y_t(d_y, DType::FP16, 2, yshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_t(d_y, QType::F16, 2, yshape, true);
 
     // Must not crash; output buffer is unchanged (stub returns early)
     EXPECT_NO_THROW(gemv_dispatch(h, x_t, y_t, stream_));
@@ -594,7 +594,7 @@ TEST_F(WeightDispatchTest, MXFP4_GemmMatchesDirect) {
     half* d_x = dev_alloc_copy(h_x);
 
     int64_t wshape[2] = {N, K};
-    Tensor w_t(d_w, DType::FP16, 2, wshape, true);
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
 
     // Quantize: FP16 → NVFP4 → MXFP4
     NvFP4QuantResult qr;
@@ -640,8 +640,8 @@ TEST_F(WeightDispatchTest, MXFP4_GemmMatchesDirect) {
     h.payload.mxfp4.linear_scales = mw.linear_scales;
 
     int64_t xshape[2] = {M, K}, yshape[2] = {M, N};
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
-    Tensor y_disp(d_y_disp, DType::FP16, 2, yshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_disp(d_y_disp, QType::F16, 2, yshape, true);
 
     ASSERT_LE(act_data_bytes + act_sf_bytes + ws_needed, kWorkspaceBytes);
 
@@ -680,7 +680,7 @@ TEST_F(WeightDispatchTest, MXFP4_GemvMatchesDirect) {
     half* d_x = dev_alloc_copy(h_x);
 
     int64_t wshape[2] = {M, K};
-    Tensor w_t(d_w, DType::FP16, 2, wshape, true);
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
 
     NvFP4QuantResult qr;
     quantize_fp16_to_nvfp4(w_t, qr, stream_);
@@ -703,8 +703,8 @@ TEST_F(WeightDispatchTest, MXFP4_GemvMatchesDirect) {
 
     // Dispatch call
     int64_t xshape[2] = {1, K}, yshape[2] = {M, 1};
-    Tensor x_t(d_x, DType::FP16, 2, xshape, true);
-    Tensor y_disp(d_y_disp, DType::FP16, 2, yshape, true);
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_disp(d_y_disp, QType::F16, 2, yshape, true);
 
     WeightHandle h;
     h.kind = TensorKind::WQ;

--- a/tests/test_weight_registry_preservation.cpp
+++ b/tests/test_weight_registry_preservation.cpp
@@ -17,7 +17,7 @@ static Tensor make_tensor_stub(TensorKind kind, int64_t rows, int64_t cols,
                                uintptr_t ptr_sentinel) {
     Tensor t;
     t.data       = reinterpret_cast<void*>(ptr_sentinel);
-    t.dtype      = DType::FP16;
+    t.qtype      = QType::F16;
     t.ndim       = 2;
     t.shape[0]   = rows;
     t.shape[1]   = cols;

--- a/tools/imp-bench/bench_attention.cu
+++ b/tools/imp-bench/bench_attention.cu
@@ -65,10 +65,10 @@ static float bench_kernel(
     int64_t kv_shape[4] = {batch, seq_len, cfg.n_kv_heads, cfg.head_dim};
     int64_t o_shape[4]  = {batch, seq_len, cfg.n_heads, cfg.head_dim};
 
-    Tensor Q(d_q, DType::FP16, 4, q_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, o_shape, true);
+    Tensor Q(d_q, QType::F16, 4, q_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, o_shape, true);
 
     // Select kernel path
     auto run_kernel = [&]() {
@@ -208,14 +208,14 @@ void bench_attention() {
                     int64_t qs[4] = {batch, seq, c.n_heads, c.head_dim};
                     int64_t ks[4] = {batch, seq, c.n_kv_heads, c.head_dim};
 
-                    Tensor Q(dq, DType::FP16, 4, qs, true);
-                    Tensor K(dk, DType::FP16, 4, ks, true);
-                    Tensor V(dv, DType::FP16, 4, ks, true);
+                    Tensor Q(dq, QType::F16, 4, qs, true);
+                    Tensor K(dk, QType::F16, 4, ks, true);
+                    Tensor V(dv, QType::F16, 4, ks, true);
 
                     // FP8 FMHA
                     float ms_fp8 = -1.0f;
                     {
-                        Tensor O(dofp8, DType::FP16, 4, qs, true);
+                        Tensor O(dofp8, QType::F16, 4, qs, true);
                         for (int i = 0; i < warmup; i++)
                             fmha_sm120_fp8_prefill(Q, K, V, O, sc, true, 0, 0.0f, s);
                         cudaStreamSynchronize(s);
@@ -234,7 +234,7 @@ void bench_attention() {
                     // MXFP4 FMHA
                     float ms_mxfp4 = -1.0f;
                     {
-                        Tensor O(domx, DType::FP16, 4, qs, true);
+                        Tensor O(domx, QType::F16, 4, qs, true);
                         for (int i = 0; i < warmup; i++)
                             fmha_sm120_mxfp4_prefill(Q, K, V, O, sc, true, 0, 0.0f, s);
                         cudaStreamSynchronize(s);
@@ -336,10 +336,10 @@ static float bench_paged_decode_kernel(
     int64_t kv_shape[4] = {num_kv_blocks, block_size, cfg.n_kv_heads, cfg.head_dim};
     int64_t o_shape[4] = {batch, 1, cfg.n_heads, cfg.head_dim};
 
-    Tensor Q(d_q, DType::FP16, 4, q_shape, true);
-    Tensor K(d_k, DType::FP16, 4, kv_shape, true);
-    Tensor V(d_v, DType::FP16, 4, kv_shape, true);
-    Tensor O(d_o, DType::FP16, 4, o_shape, true);
+    Tensor Q(d_q, QType::F16, 4, q_shape, true);
+    Tensor K(d_k, QType::F16, 4, kv_shape, true);
+    Tensor V(d_v, QType::F16, 4, kv_shape, true);
+    Tensor O(d_o, QType::F16, 4, o_shape, true);
 
     auto run = [&]() {
         paged_attention_decode(Q, K, V, O, d_block_tables, d_context_lens,

--- a/tools/imp-bench/bench_e2e.cpp
+++ b/tools/imp-bench/bench_e2e.cpp
@@ -68,7 +68,7 @@ static std::unique_ptr<Model> make_bench_model(
             buf[i] = float_to_fp16(dist(rng));
         }
         int64_t shape[4] = {static_cast<int64_t>(rows), static_cast<int64_t>(cols), 0, 0};
-        return Tensor(buf, DType::FP16, 2, shape, false);
+        return Tensor(buf, QType::F16, 2, shape, false);
     };
 
     // Helper: create 1D FP16 norm weight on host (all 1.0).
@@ -77,22 +77,22 @@ static std::unique_ptr<Model> make_bench_model(
         uint16_t one = float_to_fp16(1.0f);
         for (int i = 0; i < dim; ++i) buf[i] = one;
         int64_t shape[4] = {static_cast<int64_t>(dim), 0, 0, 0};
-        return Tensor(buf, DType::FP16, 1, shape, false);
+        return Tensor(buf, QType::F16, 1, shape, false);
     };
 
     std::mt19937 rng(42);
 
     // Token embedding [vocab_size, d_model]
     model->tok_emb_ = make_fp16_weight(vocab_size, d_model, rng);
-    model->tok_emb_qtype_ = GGMLQuantType::F16;
+    model->tok_emb_qtype_ = QType::F16;
 
     // Output norm [d_model]
     model->out_norm_ = make_norm_weight(d_model);
-    model->out_norm_qtype_ = GGMLQuantType::F16;
+    model->out_norm_qtype_ = QType::F16;
 
     // Output projection [vocab_size, d_model]
     model->out_proj_ = make_fp16_weight(vocab_size, d_model, rng);
-    model->out_proj_qtype_ = GGMLQuantType::F16;
+    model->out_proj_qtype_ = QType::F16;
 
     // Layers
     model->layers_.resize(n_layers);
@@ -101,25 +101,25 @@ static std::unique_ptr<Model> make_bench_model(
         auto& ly = model->layers_[l];
 
         ly.wq = make_fp16_weight(n_heads * head_dim, d_model, rng);
-        ly.wq_qtype = GGMLQuantType::F16;
+        ly.wq_qtype = QType::F16;
 
         ly.wk = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-        ly.wk_qtype = GGMLQuantType::F16;
+        ly.wk_qtype = QType::F16;
 
         ly.wv = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-        ly.wv_qtype = GGMLQuantType::F16;
+        ly.wv_qtype = QType::F16;
 
         ly.wo = make_fp16_weight(d_model, n_heads * head_dim, rng);
-        ly.wo_qtype = GGMLQuantType::F16;
+        ly.wo_qtype = QType::F16;
 
         ly.w_gate = make_fp16_weight(d_ff, d_model, rng);
-        ly.w_gate_qtype = GGMLQuantType::F16;
+        ly.w_gate_qtype = QType::F16;
 
         ly.w_up = make_fp16_weight(d_ff, d_model, rng);
-        ly.w_up_qtype = GGMLQuantType::F16;
+        ly.w_up_qtype = QType::F16;
 
         ly.w_down = make_fp16_weight(d_model, d_ff, rng);
-        ly.w_down_qtype = GGMLQuantType::F16;
+        ly.w_down_qtype = QType::F16;
 
         ly.attn_norm = make_norm_weight(d_model);
         ly.ffn_norm = make_norm_weight(d_model);
@@ -165,14 +165,14 @@ void bench_e2e() {
     // Build and upload model
     auto model = make_bench_model(d_model, d_ff, n_heads, n_kv_heads,
                                   n_layers, vocab_size, max_seq_len);
-    if (!model->upload_weights_gpu(DType::FP16, nullptr)) {
+    if (!model->upload_weights_gpu(QType::F16, nullptr)) {
         printf("bench_e2e: failed to upload weights to GPU\n");
         return;
     }
 
     // Initialize executor
     GraphExecutor executor;
-    if (!executor.init(*model, DType::FP16, false)) {
+    if (!executor.init(*model, QType::F16, false)) {
         printf("bench_e2e: failed to initialize GraphExecutor\n");
         return;
     }

--- a/tools/imp-bench/bench_e2e.cpp
+++ b/tools/imp-bench/bench_e2e.cpp
@@ -84,15 +84,15 @@ static std::unique_ptr<Model> make_bench_model(
 
     // Token embedding [vocab_size, d_model]
     model->tok_emb_ = make_fp16_weight(vocab_size, d_model, rng);
-    model->tok_emb_qtype_ = QType::F16;
+    model->tok_emb_.qtype = QType::F16;
 
     // Output norm [d_model]
     model->out_norm_ = make_norm_weight(d_model);
-    model->out_norm_qtype_ = QType::F16;
+    model->out_norm_.qtype = QType::F16;
 
     // Output projection [vocab_size, d_model]
     model->out_proj_ = make_fp16_weight(vocab_size, d_model, rng);
-    model->out_proj_qtype_ = QType::F16;
+    model->out_proj_.qtype = QType::F16;
 
     // Layers
     model->layers_.resize(n_layers);
@@ -101,25 +101,25 @@ static std::unique_ptr<Model> make_bench_model(
         auto& ly = model->layers_[l];
 
         ly.wq = make_fp16_weight(n_heads * head_dim, d_model, rng);
-        ly.wq_qtype = QType::F16;
+        ly.wq.qtype = QType::F16;
 
         ly.wk = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-        ly.wk_qtype = QType::F16;
+        ly.wk.qtype = QType::F16;
 
         ly.wv = make_fp16_weight(n_kv_heads * head_dim, d_model, rng);
-        ly.wv_qtype = QType::F16;
+        ly.wv.qtype = QType::F16;
 
         ly.wo = make_fp16_weight(d_model, n_heads * head_dim, rng);
-        ly.wo_qtype = QType::F16;
+        ly.wo.qtype = QType::F16;
 
         ly.w_gate = make_fp16_weight(d_ff, d_model, rng);
-        ly.w_gate_qtype = QType::F16;
+        ly.w_gate.qtype = QType::F16;
 
         ly.w_up = make_fp16_weight(d_ff, d_model, rng);
-        ly.w_up_qtype = QType::F16;
+        ly.w_up.qtype = QType::F16;
 
         ly.w_down = make_fp16_weight(d_model, d_ff, rng);
-        ly.w_down_qtype = QType::F16;
+        ly.w_down.qtype = QType::F16;
 
         ly.attn_norm = make_norm_weight(d_model);
         ly.ffn_norm = make_norm_weight(d_model);

--- a/tools/imp-bench/bench_gemm.cu
+++ b/tools/imp-bench/bench_gemm.cu
@@ -77,9 +77,9 @@ static float bench_fp16_gemm(const GemmSize& sz) {
     int64_t shape_A[] = {M, K};
     int64_t shape_B[] = {K, N};
     int64_t shape_C[] = {M, N};
-    Tensor A(d_A, DType::FP16, 2, shape_A, true);
-    Tensor B(d_B, DType::FP16, 2, shape_B, true);
-    Tensor C(d_C, DType::FP16, 2, shape_C, true);
+    Tensor A(d_A, QType::F16, 2, shape_A, true);
+    Tensor B(d_B, QType::F16, 2, shape_B, true);
+    Tensor C(d_C, QType::F16, 2, shape_C, true);
 
     // Warmup
     for (int i = 0; i < kWarmupIters; ++i) {
@@ -157,10 +157,10 @@ static float bench_int4_gemm(const GemmSize& sz) {
     int64_t shape_scales[] = {N, num_groups};
     int64_t shape_C[]      = {M, N};
 
-    Tensor A(d_A, DType::FP16, 2, shape_A, true);
-    Tensor B_quant(d_Bq, DType::INT4, 2, shape_Bq, true);
-    Tensor scales(d_scales, DType::FP16, 2, shape_scales, true);
-    Tensor C(d_C, DType::FP16, 2, shape_C, true);
+    Tensor A(d_A, QType::F16, 2, shape_A, true);
+    Tensor B_quant(d_Bq, QType::INT4, 2, shape_Bq, true);
+    Tensor scales(d_scales, QType::F16, 2, shape_scales, true);
+    Tensor C(d_C, QType::F16, 2, shape_C, true);
 
     // Warmup
     for (int i = 0; i < kWarmupIters; ++i) {

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -88,6 +88,10 @@ CliArgs parse_args(int argc, char** argv) {
         if (std::strcmp(arg, "--help") == 0 || std::strcmp(arg, "-h") == 0) {
             print_usage(argv[0]);
             std::exit(0);
+        } else if (std::strcmp(arg, "--config") == 0 && i + 1 < argc) {
+            args.config_path = argv[++i];
+        } else if (std::strcmp(arg, "--set") == 0 && i + 1 < argc) {
+            args.config_overrides.push_back(argv[++i]);
         } else if (std::strcmp(arg, "--model") == 0 && i + 1 < argc) {
             args.model_path = argv[++i];
         } else if (std::strcmp(arg, "--revision") == 0 && i + 1 < argc) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -4,6 +4,12 @@
 #include <vector>
 
 struct CliArgs {
+    // imp.conf integration. --config overrides the search-path default;
+    // --set is a repeatable key=value (e.g. --set kv_cache.dtype=fp8) that
+    // applies on top of the loaded config. See imp.conf.example for keys.
+    std::string config_path;
+    std::vector<std::string> config_overrides;
+
     std::string model_path;
     std::string revision;      // --revision: HuggingFace model revision (branch/tag/commit)
     std::string prompt;

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -5,6 +5,7 @@
 #include "model/tokenizer.h"
 #include <sys/stat.h>
 #include "runtime/presets.h"
+#include "runtime/config.h"
 
 #include <chrono>
 #include <cstdio>
@@ -15,6 +16,12 @@
 
 int main(int argc, char** argv) {
     CliArgs args = parse_args(argc, argv);
+
+    // Load imp.conf (if present) + apply --set overrides; install as the
+    // process-wide RuntimeConfig so all downstream code reads through
+    // RuntimeConfig::current() instead of getenv("IMP_*").
+    imp::RuntimeConfig::install(
+        imp::RuntimeConfig::load(args.config_path, args.config_overrides));
 
     if (args.model_path.empty()) {
         print_usage(argv[0]);
@@ -497,13 +504,13 @@ int main(int argc, char** argv) {
                 tokens = tok->encode(args.prompt);
                 // Prepend BOS when the tokenizer requires it (e.g. Gemma)
                 bool add_bos = tok->add_bos();
-                if (getenv("IMP_FORCE_BOS")) add_bos = true;
+                if (imp::RuntimeConfig::current().generation.force_bos) add_bos = true;
                 if (add_bos) {
                     tokens.insert(tokens.begin(), static_cast<int32_t>(tok->bos_id()));
                 }
             }
             int n_prompt_tokens = static_cast<int>(tokens.size());
-            if (getenv("IMP_DUMP_TOKENS")) {
+            if (imp::RuntimeConfig::current().diagnostics.dump_tokens) {
                 fprintf(stderr, "[DUMP_TOKENS] n=%d:", n_prompt_tokens);
                 for (int ti = 0; ti < n_prompt_tokens && ti < 20; ti++)
                     fprintf(stderr, " %d", tokens[ti]);
@@ -602,7 +609,7 @@ int main(int argc, char** argv) {
 
             // Benchmark using Engine::generate() (conditional graph loop) for comparison.
             // This eliminates per-step host overhead — shows true GPU-limited throughput.
-            if (std::getenv("IMP_BENCH_GENERATE")) {
+            if (imp::RuntimeConfig::current().bench.generate) {
                 // Reset context for fresh generation
                 imp_context_reset(ctx);
 

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -54,6 +54,10 @@ ServerArgs parse_server_args(int argc, char** argv) {
         if (std::strcmp(arg, "--help") == 0 || std::strcmp(arg, "-h") == 0) {
             print_server_usage(argv[0]);
             std::exit(0);
+        } else if (std::strcmp(arg, "--config") == 0 && i + 1 < argc) {
+            args.config_path = argv[++i];
+        } else if (std::strcmp(arg, "--set") == 0 && i + 1 < argc) {
+            args.config_overrides.push_back(argv[++i]);
         } else if (std::strcmp(arg, "--model") == 0 && i + 1 < argc) {
             args.model_path = argv[++i];
         } else if (std::strcmp(arg, "--revision") == 0 && i + 1 < argc) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -1,8 +1,14 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 struct ServerArgs {
+    // imp.conf integration. --config overrides the search-path default;
+    // --set is a repeatable key=value applied on top.
+    std::string config_path;
+    std::vector<std::string> config_overrides;
+
     std::string model_path;
     std::string revision;      // --revision: HuggingFace model revision (branch/tag/commit)
     std::string host = "127.0.0.1";

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -5,6 +5,7 @@
 
 #include "api/imp_internal.h"
 #include "model/hf_hub.h"
+#include "runtime/config.h"
 
 #include <chrono>
 #include <cmath>
@@ -279,10 +280,11 @@ ImpConfig build_config(const ServerArgs& args, const std::string& model_path,
         config.ngram_spec_k = args.ngram_spec_k;
     }
 
-    // Prefix caching: enable with IMP_PREFIX_CACHE=1 (off by default — cached
-    // blocks get different physical KV addresses, causing FP rounding differences
-    // in attention kernels and breaking determinism for identical requests).
-    config.use_prefix_caching = (std::getenv("IMP_PREFIX_CACHE") != nullptr) ? 1 : 0;
+    // Prefix caching: enable with [server] prefix_cache = true (off by default —
+    // cached blocks get different physical KV addresses, causing FP rounding
+    // differences in attention kernels and breaking determinism for identical
+    // requests).
+    config.use_prefix_caching = imp::RuntimeConfig::current().server.prefix_cache ? 1 : 0;
 
     // Green Contexts: SM partitioning for concurrent prefill/decode (CUDA 13.1+)
     config.enable_green_contexts = 1;

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -1,6 +1,7 @@
 #include "args.h"
 #include "handlers.h"
 #include "model/hf_hub.h"
+#include "runtime/config.h"
 
 #include <httplib.h>
 #include <nlohmann/json.hpp>
@@ -13,6 +14,11 @@ using json = nlohmann::json;
 
 int main(int argc, char** argv) {
     ServerArgs args = parse_server_args(argc, argv);
+
+    // Load imp.conf (if present) + apply --set overrides; install as the
+    // process-wide RuntimeConfig.
+    imp::RuntimeConfig::install(
+        imp::RuntimeConfig::load(args.config_path, args.config_overrides));
 
     if (args.model_path.empty()) {
         fprintf(stderr, "Error: --model is required\n");


### PR DESCRIPTION
## Summary

Architecture refactor that collapses three parallel type-tracking systems
into a single self-describing `Tensor` and replaces ~50 ad-hoc `IMP_*`
environment variables with a single `imp.conf` (TOML) file. The change
that started this — Qwen3.6-NVFP4 silently corrupting `A_log` because
SafeTensors stored it as BF16 but the upload path treated it as FP32 —
is fixed structurally as the last step.

Eight stages, each green-tested independently:

| | | |
|---|---|---|
| A | `321c8a0` | Unified `QType` enum, `GGML*` symbols deleted (1:1 wire→QType for GGUF) |
| B | `3b88204` | `assign_quant()` helper, GGUF loader migrated to one-shot routing |
| I | `63f1e35` | `imp.conf` TOML loader + `RuntimeConfig` schema + 8 unit tests |
| D | `7389e77` | `gemm_dispatch` qtype-parameter dropped (54 callsites). `upload_weight()` preserves source qtype instead of overwriting to F16/INT4 |
| J | `70f6958` | 69 `getenv("IMP_*")` sites migrated to `RuntimeConfig::current()`. `--config <path>` and repeatable `--set key=val` on CLI/Server |
| E | `7575ab4` | NVFP4 prequant collapsed into `Tensor.qtype/scales/tensor_scale`. `wcache_.nvfp4` no longer populated by the prequant path |
| F+G | `2397c2c` | Hard cut: 16 `*_qtype` mirror fields + 7 `*_scales` mirror fields on TransformerLayer + 3 on Model. `assign_quant()` shrinks 3-arg → 2-arg |
| H | `a7a44ca` | `upload_layer_ssm_weights()` converts BF16 `A_log/D/dt_bias` to FP32 instead of `h2d_copy`'ing the bytes. The Qwen3.6-NVFP4 NaN root cause |

### What's now true

- **One Tensor knows its own type.** `weight.qtype`, `weight.scales`,
  `weight.tensor_scale` are canonical. The old `wq_qtype` / `wq_scales`
  mirror fields are gone, so a new loader can no longer silently forget
  to populate one of them.
- **One config file.** `imp.conf` (TOML subset) plus `--config` / `--set`
  CLI flags replace the env-var grab bag. Build-time vars like
  `IMP_BUILD_TESTS` plus `IMP_CONFIG` for the path override are the
  only `IMP_*` env vars left.
- **One ENV-free hot path.** All 69 runtime `getenv()` calls migrated.
  CLI/Server install `RuntimeConfig` before any engine code runs.
- **No GGML symbol leaks.** `GGMLQuantType`, `ggml_type_to_dtype`,
  `ggml_quant_row_bytes`, etc. renamed or deleted. GGUF lives only in
  `gguf_loader.cpp` (locally scoped `enum class GgufWireType`).

### Known residual

`NvFP4PreQuantWeight` struct + `nvfp4_q/k/v/o`, `nvfp4_w_*_shared`,
`expert_nvfp4_*` slots still exist as load-time scratch. The runtime
hot path no longer reads them — they're consumed once at engine init
by the `promote()` step that copies their data onto `Tensor.scales` /
`Tensor.tensor_scale`. Removing them needs the SafeTensors NVFP4 link
step to write directly to the main weight tensor's sidecars at load
time. Follow-up PR.

## Test plan

- [x] `make test-gpu` — full GTest suite green
  - 109 test-core, 140 test-text, 115 test-compute, 67 test-attention,
    31 test-kv, 35 test-moe-gdn, 68 test-quant (575 total)
  - 1 pre-existing fail (`WeightDispatchTest.NVFP4_GemvMatchesDirect`,
    also fails on main; shape-vs-stride mismatch in the Phase-2 shim,
    unrelated to this refactor)
  - 8 new `RuntimeConfigTest` cases covering parse, override, defaults
- [x] E2E coherence on the four model classes that exercise the
  affected paths:
  - Qwen3-4B Q8_0 GGUF (dense, generic) — 79 tok/s
  - Qwen3.5-9B Q8_0 GGUF (GDN hybrid, verifies F32 upload path) — 54 tok/s
  - Qwen3.6-35B-A3B Q4_K_M GGUF (GDN + MoE) — 42 tok/s, "Paris."
  - Mistral-Small-NVFP4 SafeTensors (llm-compressor reciprocal scaling) — pass
- [x] CLI: `imp-cli --set kv_cache.dtype=fp8 --model X.gguf` reads the
  override through `RuntimeConfig::current()`
- [x] Server: `imp-server --config /etc/imp.conf --port 8080` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)