### PR TITLE
refactor(nvfp4): collapse load-time scratch into a single Model map

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -209,78 +209,106 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 
     // --- Phase 0: Promote NVFP4 pre-quantized weights to Tensor sidecars ---
     //
-    // Reads the (now-deprecated) NvFP4PreQuantWeight slots populated by the
-    // SafeTensors loader and writes the corresponding metadata directly onto
-    // the main weight tensor:
-    //   weight.qtype        = QType::NVFP4
-    //   weight.scales       = nw.weight_scale.data   (FP8 E4M3 micro-scales)
-    //   weight.tensor_scale = scalar from weight_scale_2 (with the
-    //                         llm-compressor reciprocal trick pre-applied
-    //                         so the runtime can always multiply)
+    // The SafeTensors loader + weight_map.cpp deposit each scale tensor into
+    // model_->nvfp4_scratch_, keyed by canonical slot name (e.g. "L5.wq",
+    // "L5.expert_w_gate.7", "out_proj"). Every entry's weight_scale /
+    // weight_scale_2 / input_scale tensors are uploaded to the GPU by
+    // weight_upload.cu before this phase runs.
     //
-    // After this loop runs, gemm_dispatch / gemv_nvfp4_kpar can read the
-    // metadata straight from the weight tensor — no map lookup, no per-call
-    // reconstruction. The legacy wcache_.nvfp4 map is gone.
+    // For each entry: resolve the key back to the corresponding main weight
+    // tensor (layer.wq, layer.expert_w_gate[e], etc.) and copy the device
+    // pointers + the FP32 tensor scalar (with the llm-compressor reciprocal
+    // trick pre-applied) onto its .qtype / .scales / .tensor_scale sidecar
+    // fields. After the loop runs, the runtime hot path reads NVFP4 metadata
+    // straight off the weight tensor — no cache lookup, no per-call
+    // reconstruction. The scratch map is then cleared.
     if (cfg.is_nvfp4_prequant) {
-        int prequant_count = 0;
-        auto promote = [&](const TransformerLayer::NvFP4PreQuantWeight& nw,
-                            Tensor& w) {
-            if (!nw.valid() || !w.data) return;
-            if (!w.on_device || !nw.weight_scale.on_device) {
-                IMP_LOG_DEBUG("NVFP4 prequant: skipping %p (data_dev=%d, scale_dev=%d)",
-                              w.data, w.on_device, nw.weight_scale.on_device);
-                return;
+        // model_ is held as const Model* in the executor; the prequant
+        // promote step is the one place we deliberately mutate it after
+        // load. const_cast is local and bounded to this block.
+        Model* mut_model = const_cast<Model*>(model_);
+
+        auto promote = [&](const NvFP4PreQuantWeight& sc, Tensor& w,
+                            const char* key) {
+            if (!sc.valid() || !w.data) return false;
+            if (!w.on_device || !sc.weight_scale.on_device) {
+                IMP_LOG_DEBUG("NVFP4 prequant: skipping %s (data_dev=%d, scale_dev=%d)",
+                              key, w.on_device, sc.weight_scale.on_device);
+                return false;
             }
             float h_scale = 1.0f;
-            if (nw.weight_scale_2.data) {
-                if (nw.weight_scale_2.on_device) {
-                    cudaMemcpy(&h_scale, nw.weight_scale_2.data, sizeof(float), cudaMemcpyDeviceToHost);
+            if (sc.weight_scale_2.data) {
+                if (sc.weight_scale_2.on_device) {
+                    cudaMemcpy(&h_scale, sc.weight_scale_2.data, sizeof(float), cudaMemcpyDeviceToHost);
                 } else {
-                    memcpy(&h_scale, nw.weight_scale_2.data, sizeof(float));
+                    memcpy(&h_scale, sc.weight_scale_2.data, sizeof(float));
                 }
             }
             // Modelopt:        val = fp4 * micro_scale * tensor_scale  (multiply)
             // llm-compressor:  val = fp4 * micro_scale / tensor_scale  (divide → store 1/x)
             w.qtype        = QType::NVFP4;
-            w.scales       = nw.weight_scale.data;
+            w.scales       = sc.weight_scale.data;
             w.tensor_scale = cfg.is_llm_compressor_nvfp4 ? (1.0f / h_scale) : h_scale;
-            prequant_count++;
+            return true;
         };
 
-        // model_ is held as const Model* in the executor; the prequant
-        // promote step is the one place we deliberately mutate it after
-        // load (writing qtype/scales/tensor_scale onto already-uploaded
-        // weight tensors). const_cast is local and bounded to this loop.
-        Model* mut_model = const_cast<Model*>(model_);
-        for (int i = 0; i < cfg.n_layers; i++) {
-            auto& L = mut_model->layers_[i];
-            // Dense weights
-            promote(L.nvfp4_q, L.wq);
-            promote(L.nvfp4_k, L.wk);
-            promote(L.nvfp4_v, L.wv);
-            promote(L.nvfp4_o, L.wo);
-            // For Gemma-4, mlp.{gate,up,down}_proj weights are stored in w_{gate,up,down}_shared
-            // (not w_{gate,up,down}) because weight_map.cpp routes them there. Fall back to
-            // shared when primary is null.
-            promote(L.nvfp4_gate, L.w_gate.data ? L.w_gate : L.w_gate_shared);
-            promote(L.nvfp4_up,   L.w_up.data   ? L.w_up   : L.w_up_shared);
-            promote(L.nvfp4_down, L.w_down.data ? L.w_down : L.w_down_shared);
-            // Shared-expert dense MLP NVFP4 (Qwen3.5/3.6: per-layer always-
-            // active dense MLP alongside the routed experts). promote() is a
-            // no-op when nw.valid()=false, so this is safe for archs that
-            // don't populate nvfp4_w_*_shared (Gemma-4 etc.).
-            promote(L.nvfp4_w_gate_shared, L.w_gate_shared);
-            promote(L.nvfp4_w_up_shared,   L.w_up_shared);
-            promote(L.nvfp4_w_down_shared, L.w_down_shared);
-            // Per-expert weights
-            for (size_t e = 0; e < L.expert_nvfp4_gate.size(); e++) {
-                if (e < L.expert_w_gate.size()) promote(L.expert_nvfp4_gate[e], L.expert_w_gate[e]);
-                if (e < L.expert_w_up.size())   promote(L.expert_nvfp4_up[e],   L.expert_w_up[e]);
-                if (e < L.expert_w_down.size()) promote(L.expert_nvfp4_down[e], L.expert_w_down[e]);
+        // Resolve "L{idx}.{slot}" / "out_proj" / "L{idx}.expert_w_*.{e}"
+        // back to the corresponding main weight tensor. Returns nullptr for
+        // unknown / out-of-range keys.
+        auto resolve = [&](const std::string& key) -> Tensor* {
+            if (key == "out_proj") return &mut_model->out_proj_;
+            if (key.size() < 3 || key[0] != 'L') return nullptr;
+            size_t dot = key.find('.', 1);
+            if (dot == std::string::npos) return nullptr;
+            int idx = std::atoi(key.substr(1, dot - 1).c_str());
+            if (idx < 0 || idx >= cfg.n_layers) return nullptr;
+            auto& L = mut_model->layers_[idx];
+            std::string slot = key.substr(dot + 1);
+
+            // Per-expert: "expert_w_{kind}.{e}"
+            if (slot.rfind("expert_w_", 0) == 0) {
+                size_t dot2 = slot.find('.');
+                if (dot2 == std::string::npos) return nullptr;
+                std::string kind = slot.substr(0, dot2);
+                int e = std::atoi(slot.substr(dot2 + 1).c_str());
+                std::vector<Tensor>* vec = nullptr;
+                if      (kind == "expert_w_gate") vec = &L.expert_w_gate;
+                else if (kind == "expert_w_up")   vec = &L.expert_w_up;
+                else if (kind == "expert_w_down") vec = &L.expert_w_down;
+                if (!vec || e < 0 || e >= static_cast<int>(vec->size())) return nullptr;
+                return &(*vec)[e];
             }
+
+            // Per-layer dense / shared.
+            if (slot == "wq") return &L.wq;
+            if (slot == "wk") return &L.wk;
+            if (slot == "wv") return &L.wv;
+            if (slot == "wo") return &L.wo;
+            // Gemma-4: mlp.{gate,up,down}_proj weights land in w_*_shared
+            // (weight_map.cpp routes them there). Fall back to shared when
+            // primary is null.
+            if (slot == "w_gate") return L.w_gate.data ? &L.w_gate : &L.w_gate_shared;
+            if (slot == "w_up")   return L.w_up.data   ? &L.w_up   : &L.w_up_shared;
+            if (slot == "w_down") return L.w_down.data ? &L.w_down : &L.w_down_shared;
+            if (slot == "w_gate_shared") return &L.w_gate_shared;
+            if (slot == "w_up_shared")   return &L.w_up_shared;
+            if (slot == "w_down_shared") return &L.w_down_shared;
+            return nullptr;
+        };
+
+        int prequant_count = 0;
+        for (auto& [key, sc] : mut_model->nvfp4_scratch_) {
+            Tensor* w = resolve(key);
+            if (!w) {
+                IMP_LOG_WARN("NVFP4 prequant: unresolved scratch key '%s'", key.c_str());
+                continue;
+            }
+            if (promote(sc, *w, key.c_str())) prequant_count++;
         }
-        // LM head (output projection)
-        promote(mut_model->nvfp4_out_proj_, mut_model->out_proj_);
+        // Drop the scratch — its data pointers (weight_scale, weight_scale_2,
+        // input_scale) are now device pointers borrowed by the main tensors,
+        // and the host-side metadata isn't needed anymore.
+        mut_model->nvfp4_scratch_.clear();
 
         if (prequant_count > 0) {
             IMP_LOG_INFO("NVFP4 pre-quantized: promoted %d weights to Tensor sidecars",

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -2,6 +2,8 @@
 
 #include "model/model_config.h"
 #include "model/tokenizer.h"
+#include <string>
+#include <unordered_map>
 #include <vector>
 #include <memory>
 #include <cuda_runtime.h>
@@ -19,7 +21,6 @@ public:
     const Tensor& token_embedding() const { return tok_emb_; }
     const Tensor& output_norm() const { return out_norm_; }
     const Tensor& output_proj() const { return out_proj_; }
-    const TransformerLayer::NvFP4PreQuantWeight& nvfp4_out_proj() const { return nvfp4_out_proj_; }
     int n_layers() const { return static_cast<int>(layers_.size()); }
 
     Tokenizer* tokenizer() const { return tokenizer_.get(); }
@@ -45,11 +46,22 @@ public:
     ModelConfig config_;
     Tensor tok_emb_, out_norm_, out_proj_;
     // (qtype mirrors removed in Stage G — read tok_emb_.qtype directly.)
-    TransformerLayer::NvFP4PreQuantWeight nvfp4_out_proj_;  // prequant LM head scales
     TensorID out_proj_id = kInvalidTensorID;  // registry handle for LM head (Task 3.5)
     TensorID tok_emb_id  = kInvalidTensorID;  // registry handle for token embedding
     std::vector<TransformerLayer> layers_;
     std::unique_ptr<Tokenizer> tokenizer_;
+
+    // Load-time scratch for NVFP4 prequant scale tensors.
+    // Keys:
+    //   "L{idx}.{slot}"          per-layer dense (e.g. "L5.wq", "L5.w_gate_shared")
+    //   "L{idx}.expert_w_{kind}.{e}"  per-expert (e.g. "L5.expert_w_gate.7")
+    //   "out_proj"               LM head
+    // Populated by safetensors_loader → weight_map.cpp on the SafeTensors
+    // NVFP4-prequant load path. Cleared after executor_pre_dequant.cu's
+    // Phase 0 promote() copies the device-side scale pointers and the FP32
+    // tensor scalar onto each main weight tensor's .scales / .tensor_scale
+    // sidecars. Empty for GGUF and non-NVFP4 SafeTensors models.
+    std::unordered_map<std::string, NvFP4PreQuantWeight> nvfp4_scratch_;
 
     void* mmap_base_ = nullptr;
     size_t mmap_size_ = 0;

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -83,6 +83,25 @@ struct ModelConfig {
 // Used by nvfp4_moe_*_ptr borrowed pointers below.
 struct NvFP4MoEQuantResult;
 
+// Pre-quantized NVFP4 weights (from Model Optimizer / llm-compressor via
+// SafeTensors). Lives only on the Model::nvfp4_scratch_ load-time map —
+// once executor_pre_dequant.cu Phase 0 promotes the scale pointers onto
+// the corresponding main weight tensor's .scales / .tensor_scale fields,
+// the entry is dropped.
+//
+//   weight_scale     [N, K/group_size]  FP8 E4M3 micro-scales
+//   weight_scale_2   [1] or scalar      FP32 tensor-scale
+//   input_scale      [1]                FP32 activation scale (optional)
+//
+// `valid()` only requires weight_scale; weight_scale_2 is permitted to be
+// missing for some Modelopt variants.
+struct NvFP4PreQuantWeight {
+    Tensor weight_scale;
+    Tensor weight_scale_2;
+    Tensor input_scale;
+    bool valid() const { return weight_scale.data != nullptr; }
+};
+
 struct TransformerLayer {
     Tensor wq, wk, wv, wo, attn_norm;
     Tensor q_bias, k_bias, v_bias;    // Attention biases (Qwen2)
@@ -185,29 +204,6 @@ struct TransformerLayer {
     // expert's down-projection output BEFORE the routing weighted sum. Loaded
     // from `blk.X.ffn_down_exps.scale` (shape [n_expert]).
     Tensor expert_down_scale;
-
-    // Pre-quantized NVFP4 weights (from Model Optimizer via SafeTensors).
-    // weight_scale: FP8 E4M3 micro-scales per group_size elements
-    // weight_scale_2: FP32 tensor-scale (single value per tensor)
-    // input_scale: FP32 activation scale (optional, for FP8 activations)
-    struct NvFP4PreQuantWeight {
-        Tensor weight;          // [N, K/2] packed FP4 E2M1 nibbles
-        Tensor weight_scale;    // [N, K/group_size] FP8 E4M3 micro-scales
-        Tensor weight_scale_2;  // [1] or scalar FP32 tensor-scale
-        Tensor input_scale;     // [1] optional FP32 activation scale
-        bool valid() const { return weight.data != nullptr && weight_scale.data != nullptr; }
-    };
-    NvFP4PreQuantWeight nvfp4_q, nvfp4_k, nvfp4_v, nvfp4_o;
-    NvFP4PreQuantWeight nvfp4_gate, nvfp4_up, nvfp4_down;
-
-    // Shared-expert NVFP4 (Qwen3.5/3.6 MoE: per-layer always-active dense FFN
-    // alongside the routed experts). Loader populates these from
-    // mlp.shared_expert.{gate,up,down}_proj.{weight_packed,weight_scale,
-    //   weight_global_scale,input_global_scale}.
-    NvFP4PreQuantWeight nvfp4_w_gate_shared, nvfp4_w_up_shared, nvfp4_w_down_shared;
-
-    // Per-expert NVFP4 weights (MoE models with pre-quantized expert weights)
-    std::vector<NvFP4PreQuantWeight> expert_nvfp4_gate, expert_nvfp4_up, expert_nvfp4_down;
 
     // GPTQ quantized weights (temporary — dequantized to FP16 during upload)
     struct GPTQWeight {

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -672,58 +672,19 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
                      gptq_cfg.desc_act ? "true" : "false");
     }
 
-    // 6c. NVFP4 config: link weight tensors to NvFP4PreQuantWeight structs
+    // 6c. NVFP4 config detection. Scale tensors were already routed into
+    // model->nvfp4_scratch_ by weight_map.cpp during the layer-pattern pass;
+    // executor_pre_dequant.cu's Phase 0 promote() resolves each scratch key
+    // back to the main weight tensor and writes the device pointer onto its
+    // .scales / .tensor_scale sidecars. No load-side linking needed here.
     HFConfigLoader::NvFP4Config nvfp4_cfg;
     bool is_nvfp4 = HFConfigLoader::load_nvfp4_config(model_dir, nvfp4_cfg);
     if (is_nvfp4) {
         cfg.is_nvfp4_prequant = true;
         cfg.nvfp4_group_size = nvfp4_cfg.group_size;
         cfg.is_llm_compressor_nvfp4 = (nvfp4_cfg.format == HFConfigLoader::NvFP4Format::LLM_COMPRESSOR);
-        // Link the main weight tensors to nvfp4 structs (they share the same data pointer)
-        for (auto& layer : model->layers_) {
-            auto link = [](TransformerLayer::NvFP4PreQuantWeight& nw, const Tensor& w) {
-                if (nw.weight_scale.data != nullptr) nw.weight = w;
-            };
-            // Dense weights
-            link(layer.nvfp4_q, layer.wq);
-            link(layer.nvfp4_k, layer.wk);
-            link(layer.nvfp4_v, layer.wv);
-            link(layer.nvfp4_o, layer.wo);
-            // For Gemma-4, mlp.{gate,up,down}_proj weights land in w_{gate,up,down}_shared
-            // (weight_map.cpp routes them there). Fall back to shared when primary is null.
-            link(layer.nvfp4_gate, layer.w_gate.data ? layer.w_gate : layer.w_gate_shared);
-            link(layer.nvfp4_up,   layer.w_up.data   ? layer.w_up   : layer.w_up_shared);
-            link(layer.nvfp4_down, layer.w_down.data ? layer.w_down : layer.w_down_shared);
-            // Qwen3.5/3.6: per-layer shared dense MLP alongside routed experts.
-            // mlp.shared_expert.{gate,up,down}_proj.{weight,...} → w_*_shared
-            // and the matching scale variants → nvfp4_w_*_shared. Link them so
-            // executor_pre_dequant.cu's register_prequant() can register the
-            // shared MLP into wcache_.nvfp4 alongside attention/expert weights.
-            link(layer.nvfp4_w_gate_shared, layer.w_gate_shared);
-            link(layer.nvfp4_w_up_shared,   layer.w_up_shared);
-            link(layer.nvfp4_w_down_shared, layer.w_down_shared);
-            // Expert weights
-            for (size_t e = 0; e < layer.expert_nvfp4_gate.size(); e++) {
-                if (e < layer.expert_w_gate.size()) link(layer.expert_nvfp4_gate[e], layer.expert_w_gate[e]);
-                if (e < layer.expert_w_up.size())   link(layer.expert_nvfp4_up[e],   layer.expert_w_up[e]);
-                if (e < layer.expert_w_down.size()) link(layer.expert_nvfp4_down[e], layer.expert_w_down[e]);
-            }
-        }
-        int nvfp4_count = 0;
-        int nvfp4_expert_count = 0;
-        for (const auto& layer : model->layers_) {
-            for (const auto* nw : {&layer.nvfp4_q, &layer.nvfp4_k, &layer.nvfp4_v, &layer.nvfp4_o,
-                                   &layer.nvfp4_gate, &layer.nvfp4_up, &layer.nvfp4_down}) {
-                if (nw->valid()) nvfp4_count++;
-            }
-            for (const auto* vec : {&layer.expert_nvfp4_gate, &layer.expert_nvfp4_up, &layer.expert_nvfp4_down}) {
-                for (const auto& nw : *vec) {
-                    if (nw.valid()) nvfp4_expert_count++;
-                }
-            }
-        }
-        IMP_LOG_INFO("NVFP4 pre-quantized: %d dense + %d expert weight tensors (group_size=%d)",
-                     nvfp4_count, nvfp4_expert_count, nvfp4_cfg.group_size);
+        IMP_LOG_INFO("NVFP4 pre-quantized: %zu scratch entries (group_size=%d)",
+                     model->nvfp4_scratch_.size(), nvfp4_cfg.group_size);
     }
 
     // 7. Tie output projection if not found

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -52,12 +52,17 @@ static void ensure_expert(TransformerLayer& layer, int idx) {
         layer.expert_w_up.resize(needed);
     if (static_cast<int>(layer.expert_w_down.size()) < needed)
         layer.expert_w_down.resize(needed);
-    if (static_cast<int>(layer.expert_nvfp4_gate.size()) < needed)
-        layer.expert_nvfp4_gate.resize(needed);
-    if (static_cast<int>(layer.expert_nvfp4_up.size()) < needed)
-        layer.expert_nvfp4_up.resize(needed);
-    if (static_cast<int>(layer.expert_nvfp4_down.size()) < needed)
-        layer.expert_nvfp4_down.resize(needed);
+}
+
+// Helper: write one of weight_scale / weight_scale_2 / input_scale into
+// model.nvfp4_scratch_[key], depending on `kind`. Used by every NVFP4-
+// prequant scale-routing branch in apply_weights().
+static void route_nvfp4_scale(Model& model, const std::string& key,
+                               const std::string& kind, const Tensor& t) {
+    auto& sc = model.nvfp4_scratch_[key];
+    if      (kind == "weight_scale")    sc.weight_scale = t;
+    else if (kind == "weight_scale_2")  sc.weight_scale_2 = t;
+    else if (kind == "input_scale")     sc.input_scale = t;
 }
 
 // ---------------------------------------------------------------------------
@@ -291,22 +296,17 @@ bool WeightMap::apply_weights(
             ++assigned;
             continue;
         }
-        // NVFP4 prequant LM head scales (Model Optimizer)
-        if (name == "lm_head.weight_scale") {
-            model.nvfp4_out_proj_.weight_scale = t;
-            IMP_LOG_DEBUG("  assigned: %s -> nvfp4_out_proj.weight_scale", name.c_str());
-            ++assigned;
-            continue;
-        }
-        if (name == "lm_head.weight_scale_2") {
-            model.nvfp4_out_proj_.weight_scale_2 = t;
-            IMP_LOG_DEBUG("  assigned: %s -> nvfp4_out_proj.weight_scale_2", name.c_str());
-            ++assigned;
-            continue;
-        }
-        if (name == "lm_head.input_scale") {
-            model.nvfp4_out_proj_.input_scale = t;
-            IMP_LOG_DEBUG("  assigned: %s -> nvfp4_out_proj.input_scale", name.c_str());
+        // NVFP4 prequant LM head scales (Model Optimizer / llm-compressor).
+        // Routed into the load-time scratch map under key "out_proj"; Phase 0
+        // promote() in executor_pre_dequant.cu copies the device pointer onto
+        // model.out_proj_'s sidecars and clears the entry.
+        if (name == "lm_head.weight_scale" ||
+            name == "lm_head.weight_scale_2" ||
+            name == "lm_head.input_scale") {
+            const std::string kind = name.substr(8);  // strip "lm_head."
+            route_nvfp4_scale(model, "out_proj", kind, t);
+            IMP_LOG_DEBUG("  assigned: %s -> nvfp4_scratch_[out_proj].%s",
+                          name.c_str(), kind.c_str());
             ++assigned;
             continue;
         }
@@ -443,33 +443,36 @@ bool WeightMap::apply_weights(
 
         // -- NVFP4 scale tensors (ModelOpt pre-quantized) --
         // self_attn.{q,k,v,o}_proj.{weight_scale,weight_scale_2,input_scale}
+        const std::string layer_key_prefix = "L" + std::to_string(layer_idx) + ".";
+
+        // self_attn.{q,k,v,o}_proj.{weight_scale,weight_scale_2,input_scale}
         if (!matched && parts.size() >= 6 && parts[3] == "self_attn" &&
             (parts[5] == "weight_scale" || parts[5] == "weight_scale_2" || parts[5] == "input_scale")) {
             const std::string& proj = parts[4];
             const std::string& kind = parts[5];
-            auto assign = [&](TransformerLayer::NvFP4PreQuantWeight& nw) {
-                if (kind == "weight_scale")   nw.weight_scale = t;
-                else if (kind == "weight_scale_2") nw.weight_scale_2 = t;
-                else if (kind == "input_scale")    nw.input_scale = t;
-            };
-            if (proj == "q_proj") { assign(layer.nvfp4_q); matched = true; }
-            else if (proj == "k_proj") { assign(layer.nvfp4_k); matched = true; }
-            else if (proj == "v_proj") { assign(layer.nvfp4_v); matched = true; }
-            else if (proj == "o_proj") { assign(layer.nvfp4_o); matched = true; }
+            const char* slot = nullptr;
+            if      (proj == "q_proj") slot = "wq";
+            else if (proj == "k_proj") slot = "wk";
+            else if (proj == "v_proj") slot = "wv";
+            else if (proj == "o_proj") slot = "wo";
+            if (slot) {
+                route_nvfp4_scale(model, layer_key_prefix + slot, kind, t);
+                matched = true;
+            }
         }
         // mlp.{gate,up,down}_proj.{weight_scale,weight_scale_2,input_scale}
         if (!matched && parts.size() >= 6 && parts[3] == "mlp" &&
             (parts[5] == "weight_scale" || parts[5] == "weight_scale_2" || parts[5] == "input_scale")) {
             const std::string& proj = parts[4];
             const std::string& kind = parts[5];
-            auto assign = [&](TransformerLayer::NvFP4PreQuantWeight& nw) {
-                if (kind == "weight_scale")   nw.weight_scale = t;
-                else if (kind == "weight_scale_2") nw.weight_scale_2 = t;
-                else if (kind == "input_scale")    nw.input_scale = t;
-            };
-            if (proj == "gate_proj") { assign(layer.nvfp4_gate); matched = true; }
-            else if (proj == "up_proj") { assign(layer.nvfp4_up); matched = true; }
-            else if (proj == "down_proj") { assign(layer.nvfp4_down); matched = true; }
+            const char* slot = nullptr;
+            if      (proj == "gate_proj") slot = "w_gate";
+            else if (proj == "up_proj")   slot = "w_up";
+            else if (proj == "down_proj") slot = "w_down";
+            if (slot) {
+                route_nvfp4_scale(model, layer_key_prefix + slot, kind, t);
+                matched = true;
+            }
         }
 
         // -----------------------------------------------------------------
@@ -537,14 +540,16 @@ bool WeightMap::apply_weights(
                     ensure_expert(layer, expert_idx);
                     const std::string& proj = parts[6];
                     const std::string& kind = parts[7];
-                    auto assign = [&](TransformerLayer::NvFP4PreQuantWeight& nw) {
-                        if (kind == "weight_scale")   nw.weight_scale = t;
-                        else if (kind == "weight_scale_2") nw.weight_scale_2 = t;
-                        else if (kind == "input_scale")    nw.input_scale = t;
-                    };
-                    if (proj == "gate_proj") { assign(layer.expert_nvfp4_gate[expert_idx]); matched = true; }
-                    else if (proj == "up_proj") { assign(layer.expert_nvfp4_up[expert_idx]); matched = true; }
-                    else if (proj == "down_proj") { assign(layer.expert_nvfp4_down[expert_idx]); matched = true; }
+                    const char* slot = nullptr;
+                    if      (proj == "gate_proj") slot = "expert_w_gate";
+                    else if (proj == "up_proj")   slot = "expert_w_up";
+                    else if (proj == "down_proj") slot = "expert_w_down";
+                    if (slot) {
+                        route_nvfp4_scale(model,
+                            layer_key_prefix + slot + "." + std::to_string(expert_idx),
+                            kind, t);
+                        matched = true;
+                    }
                 }
             }
             // Shared expert: mlp.shared_expert.{gate,up,down}_proj.weight
@@ -561,14 +566,14 @@ bool WeightMap::apply_weights(
                       parts[6] == "input_scale")) {
                 const std::string& proj = parts[5];
                 const std::string& kind = parts[6];
-                auto assign = [&](TransformerLayer::NvFP4PreQuantWeight& nw) {
-                    if (kind == "weight_scale")        nw.weight_scale = t;
-                    else if (kind == "weight_scale_2") nw.weight_scale_2 = t;
-                    else if (kind == "input_scale")    nw.input_scale = t;
-                };
-                if (proj == "gate_proj")      { assign(layer.nvfp4_w_gate_shared); matched = true; }
-                else if (proj == "up_proj")   { assign(layer.nvfp4_w_up_shared);   matched = true; }
-                else if (proj == "down_proj") { assign(layer.nvfp4_w_down_shared); matched = true; }
+                const char* slot = nullptr;
+                if      (proj == "gate_proj") slot = "w_gate_shared";
+                else if (proj == "up_proj")   slot = "w_up_shared";
+                else if (proj == "down_proj") slot = "w_down_shared";
+                if (slot) {
+                    route_nvfp4_scale(model, layer_key_prefix + slot, kind, t);
+                    matched = true;
+                }
             }
             // Shared-expert sigmoid gate (Qwen3-Next/3.5/3.6):
             //   mlp.shared_expert_gate.weight   ->   shared_expert_gate_inp
@@ -597,14 +602,17 @@ bool WeightMap::apply_weights(
                     else if (proj == "down_proj") { layer.expert_w_down[expert_idx] = t; matched = true; }
                 } else if (field == "weight_scale" || field == "weight_scale_2" || field == "input_scale") {
                     ensure_expert(layer, expert_idx);
-                    auto assign = [&](TransformerLayer::NvFP4PreQuantWeight& nw) {
-                        if (field == "weight_scale")        nw.weight_scale = t;
-                        else if (field == "weight_scale_2") nw.weight_scale_2 = t;
-                        else if (field == "input_scale")    nw.input_scale = t;
-                    };
-                    if (proj == "gate_proj") { assign(layer.expert_nvfp4_gate[expert_idx]); matched = true; }
-                    else if (proj == "up_proj") { assign(layer.expert_nvfp4_up[expert_idx]); matched = true; }
-                    else if (proj == "down_proj") { assign(layer.expert_nvfp4_down[expert_idx]); matched = true; }
+                    const char* slot = nullptr;
+                    if      (proj == "gate_proj") slot = "expert_w_gate";
+                    else if (proj == "up_proj")   slot = "expert_w_up";
+                    else if (proj == "down_proj") slot = "expert_w_down";
+                    if (slot) {
+                        const std::string layer_key_prefix2 = "L" + std::to_string(layer_idx) + ".";
+                        route_nvfp4_scale(model,
+                            layer_key_prefix2 + slot + "." + std::to_string(expert_idx),
+                            field, t);
+                        matched = true;
+                    }
                 }
             }
         }

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1677,7 +1677,8 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream,
         return false;
     }
 
-    // Upload NVFP4 pre-quantized scale tensors (weight_scale, weight_scale_2, input_scale)
+    // Upload NVFP4 pre-quantized scale tensors. Single scratch map keyed by
+    // canonical slot name; replaced the per-layer NvFP4PreQuantWeight slots.
     if (config_.is_nvfp4_prequant) {
         int scale_count = 0;
         auto upload_scale = [&](Tensor& t) {
@@ -1691,28 +1692,11 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream,
             t.on_device = true;
             scale_count++;
         };
-
-        for (auto& L : layers_) {
-            for (auto* nw : {&L.nvfp4_q, &L.nvfp4_k, &L.nvfp4_v, &L.nvfp4_o,
-                             &L.nvfp4_gate, &L.nvfp4_up, &L.nvfp4_down,
-                             &L.nvfp4_w_gate_shared, &L.nvfp4_w_up_shared,
-                             &L.nvfp4_w_down_shared}) {
-                upload_scale(nw->weight_scale);
-                upload_scale(nw->weight_scale_2);
-                upload_scale(nw->input_scale);
-            }
-            for (auto* vec : {&L.expert_nvfp4_gate, &L.expert_nvfp4_up, &L.expert_nvfp4_down}) {
-                for (auto& nw : *vec) {
-                    upload_scale(nw.weight_scale);
-                    upload_scale(nw.weight_scale_2);
-                    upload_scale(nw.input_scale);
-                }
-            }
+        for (auto& [_, sc] : nvfp4_scratch_) {
+            upload_scale(sc.weight_scale);
+            upload_scale(sc.weight_scale_2);
+            upload_scale(sc.input_scale);
         }
-        // LM head (output projection) scales
-        upload_scale(nvfp4_out_proj_.weight_scale);
-        upload_scale(nvfp4_out_proj_.weight_scale_2);
-        upload_scale(nvfp4_out_proj_.input_scale);
         if (scale_count > 0)
             IMP_LOG_INFO("NVFP4 prequant: uploaded %d scale tensors to GPU", scale_count);
     }


### PR DESCRIPTION
## Summary

Final cleanup of the NVFP4-prequant load path. Stage E (PR #72)
moved the runtime hot-path off the per-layer `NvFP4PreQuantWeight`
slots — dispatch reads from `Tensor.scales` / `Tensor.tensor_scale`
directly. The slots themselves remained as load-time scratch only
and were the last residual scaffolding in the type system.

This PR removes them.

### Changes

- 13 `NvFP4PreQuantWeight` slots on `TransformerLayer` deleted
  (`nvfp4_q/k/v/o`, `nvfp4_gate/up/down`, `nvfp4_w_*_shared`)
- 3 `std::vector<NvFP4PreQuantWeight>` per-expert slots deleted
  (`expert_nvfp4_gate/up/down`)
- `Model::nvfp4_out_proj_` deleted
- `NvFP4PreQuantWeight` moved out of `TransformerLayer` to a free
  struct in `model_config.h` (loses now-unused `weight` field;
  `valid()` checks `weight_scale.data` only)
- New single `Model::nvfp4_scratch_` —
  `std::unordered_map<std::string, NvFP4PreQuantWeight>` keyed by
  canonical slot name:
    - `"L{idx}.{slot}"` for per-layer (`"L5.wq"`, `"L5.w_gate_shared"`)
    - `"L{idx}.expert_w_{kind}.{e}"` for per-expert
    - `"out_proj"` for LM head
- `weight_map.cpp` routes every NVFP4 scale into the map via a new
  `route_nvfp4_scale(model, key, kind, t)` helper. Replaces 4
  `assign` lambdas that wrote into the per-slot structs.
- `weight_upload.cu` iterates the map (single loop, ~30 LoC) instead
  of walking 16 per-layer slots × 3 fields each
- `executor_pre_dequant.cu` Phase 0 walks the map, `resolve()` parses
  the key back to the corresponding main weight tensor, `promote()`
  copies the device pointers + the FP32 tensor scalar onto its
  sidecars. Scratch is `clear()`ed at end.
- `safetensors_loader.cpp` drops the old "link" step entirely — it
  existed only to set `NvFP4PreQuantWeight.weight` so `.valid()`
  could return true; that field is gone

### Architecture impact

`TransformerLayer` is now a plain description of the runtime weights
with no load-time scaffolding mixed in. Adding a new NVFP4 quant
variant (W4A16, future llm-compressor revisions, etc.) only touches
`weight_map.cpp` (routing) and `executor_pre_dequant.cu` (resolve
key → tensor). No more per-projection per-slot field churn.

Net diff: 6 files, +202 / -213 (~11 LoC reduction, -16 fields,
-3 vectors, -1 nested struct).

## Test plan

- [x] `make test-gpu` — 575 PASSED across 7 suites (1 pre-existing
  fail unchanged).
- [x] LlmCompressorE2E.MistralSmall_LoadsAndGeneratesCoherent
  (llm-compressor reciprocal scaling path) — PASSED
- [x] LlmCompressorE2E.Modelopt_QwenCoder30B_StillWorks
  (Modelopt multiplicative scaling path) — PASSED
- [x] Qwen3-4B-Q8_0 GGUF smoke — 76 tok/s coherent (proves no
  regression on the non-NVFP4 path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)