### PR TITLE
feat(loader): plumb generation_config.json sampling defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ if(IMP_BUILD_TESTS)
         tests/test_kv_cache.cpp
         tests/test_gguf_loader.cpp
         tests/test_llm_compressor_loader.cpp
+        tests/test_hf_config_loader.cpp
         tests/test_config.cpp
     )
 

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -340,30 +340,43 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
 // ---- load_generation_config ----
 
 bool HFConfigLoader::load_generation_config(const std::string& model_dir,
-                                             std::vector<int32_t>& eos_token_ids) {
+                                             GenerationConfig& cfg) {
     std::string path = model_dir + "/generation_config.json";
     JValue root;
     if (!parse_json_file(path, root)) return false;
 
-    const JValue* eos = jobj_find(root, "eos_token_id");
-    if (!eos) return false;
-
-    if (eos->type == JType::NUMBER) {
-        // Single EOS token ID
-        eos_token_ids.push_back(static_cast<int32_t>(eos->num_val));
-    } else if (eos->type == JType::ARRAY) {
-        // Array of EOS token IDs
-        for (const auto& v : eos->arr) {
-            if (v.type == JType::NUMBER) {
-                eos_token_ids.push_back(static_cast<int32_t>(v.num_val));
+    // EOS IDs (single number or array)
+    if (const JValue* eos = jobj_find(root, "eos_token_id")) {
+        if (eos->type == JType::NUMBER) {
+            cfg.eos_token_ids.push_back(static_cast<int32_t>(eos->num_val));
+        } else if (eos->type == JType::ARRAY) {
+            for (const auto& v : eos->arr) {
+                if (v.type == JType::NUMBER) {
+                    cfg.eos_token_ids.push_back(static_cast<int32_t>(v.num_val));
+                }
             }
         }
-    } else {
-        return false;
     }
 
-    IMP_LOG_INFO("loaded %zu EOS token IDs from generation_config.json",
-                 eos_token_ids.size());
+    // Sampling defaults. Each field is only overwritten if the JSON has it;
+    // otherwise the struct's sentinel survives.
+    jobj_get_float(root, "temperature",        cfg.temperature);
+    jobj_get_float(root, "top_p",              cfg.top_p);
+    jobj_get_int  (root, "top_k",              cfg.top_k);
+    jobj_get_float(root, "repetition_penalty", cfg.repetition_penalty);
+
+    // do_sample=false → force greedy. Authors set this when they want
+    // deterministic output regardless of temperature.
+    if (const JValue* ds = jobj_find(root, "do_sample")) {
+        if (ds->type == JType::NUMBER && ds->num_val == 0.0) {
+            cfg.temperature = 0.0f;
+        }
+    }
+
+    IMP_LOG_INFO("generation_config.json: eos=%zu temp=%.3g top_p=%.3g top_k=%d "
+                 "rep_penalty=%.3g",
+                 cfg.eos_token_ids.size(),
+                 cfg.temperature, cfg.top_p, cfg.top_k, cfg.repetition_penalty);
     return true;
 }
 

--- a/src/model/hf_config_loader.h
+++ b/src/model/hf_config_loader.h
@@ -15,10 +15,22 @@ struct HFConfigLoader {
     // Only overwrites cfg fields that are present in the JSON.
     static bool load_config(const std::string& model_dir, ModelConfig& cfg);
 
-    // Load generation_config.json — populates eos_token_ids.
-    // Returns true if file found and parsed.
+    // Sampling and stop-condition defaults shipped by the model author in
+    // generation_config.json. Sentinel values (<0 for floats, -1 for ints,
+    // empty vector for eos) mean "not present in JSON" — caller falls back
+    // to arch-family defaults or the hard-coded ImpGenerateParams baseline.
+    struct GenerationConfig {
+        float temperature        = -1.0f;
+        float top_p              = -1.0f;
+        int   top_k              = -1;
+        float repetition_penalty = -1.0f;
+        std::vector<int32_t> eos_token_ids;
+    };
+
+    // Load generation_config.json. Returns true if file found and parsed.
+    // Only fields present in the JSON are populated; the rest stay at sentinel.
     static bool load_generation_config(const std::string& model_dir,
-                                       std::vector<int32_t>& eos_token_ids);
+                                       GenerationConfig& cfg);
 
     // Load chat_template string from tokenizer_config.json.
     // Returns empty string if not found.

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "model/hf_config_loader.h"
 #include "model/model_config.h"
 #include "model/tokenizer.h"
 #include <string>
@@ -16,6 +17,13 @@ public:
     ~Model();
 
     const ModelConfig& config() const { return config_; }
+
+    // Sampling/EOS defaults shipped by the model author in
+    // generation_config.json (SafeTensors only; empty for GGUF). Sentinel
+    // values (<0) mean the field was not present.
+    const HFConfigLoader::GenerationConfig& generation_config() const {
+        return generation_config_;
+    }
     const TransformerLayer& layer(int i) const { return layers_[i]; }
     TransformerLayer& layer(int i) { return layers_[i]; }
     const Tensor& token_embedding() const { return tok_emb_; }
@@ -44,6 +52,7 @@ public:
     size_t estimate_expert_bytes() const;
 
     ModelConfig config_;
+    HFConfigLoader::GenerationConfig generation_config_;
     Tensor tok_emb_, out_norm_, out_proj_;
     // (qtype mirrors removed in Stage G — read tok_emb_.qtype directly.)
     TensorID out_proj_id = kInvalidTensorID;  // registry handle for LM head (Task 3.5)

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -728,6 +728,19 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
         cfg.vocab_size = static_cast<int>(model->tok_emb_.shape[0]);
     }
 
+    // 10. generation_config.json — sampling/EOS defaults shipped by the model
+    // author. Loaded into model->generation_config_ for engine + CLI consumers.
+    // EOS IDs additionally pushed onto the tokenizer's eos list so the engine's
+    // existing stop-condition path picks them up without further plumbing.
+    if (!model_dir.empty()) {
+        HFConfigLoader::load_generation_config(model_dir, model->generation_config_);
+        if (model->tokenizer_) {
+            for (int32_t eid : model->generation_config_.eos_token_ids) {
+                model->tokenizer_->add_eos_id(eid);
+            }
+        }
+    }
+
     IMP_LOG_INFO("SafeTensors model loaded successfully from %s", path.c_str());
     return model;
 }

--- a/tests/test_hf_config_loader.cpp
+++ b/tests/test_hf_config_loader.cpp
@@ -1,0 +1,102 @@
+#include "model/hf_config_loader.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using imp::HFConfigLoader;
+
+namespace {
+
+class GenerationConfigTest : public ::testing::Test {
+protected:
+    std::filesystem::path tmp_dir_;
+
+    void SetUp() override {
+        tmp_dir_ = std::filesystem::temp_directory_path() /
+                   ("imp_test_gencfg_" + std::to_string(::getpid()));
+        std::filesystem::create_directories(tmp_dir_);
+    }
+
+    void TearDown() override {
+        std::filesystem::remove_all(tmp_dir_);
+    }
+
+    void write_gen_config(const std::string& json) {
+        std::ofstream f(tmp_dir_ / "generation_config.json");
+        f << json;
+    }
+};
+
+// Mistral-3.2-style: ships only `temperature`. Other fields stay at sentinel
+// so the CLI cascade falls through to the arch-family preset.
+TEST_F(GenerationConfigTest, PartialFieldsLeaveSentinels) {
+    write_gen_config(R"({
+        "bos_token_id": 1,
+        "do_sample": true,
+        "eos_token_id": 2,
+        "pad_token_id": 11,
+        "temperature": 0.15
+    })");
+
+    HFConfigLoader::GenerationConfig cfg;
+    ASSERT_TRUE(HFConfigLoader::load_generation_config(tmp_dir_.string(), cfg));
+
+    EXPECT_FLOAT_EQ(cfg.temperature, 0.15f);
+    EXPECT_LT(cfg.top_p, 0.0f);
+    EXPECT_LT(cfg.top_k, 0);
+    EXPECT_LT(cfg.repetition_penalty, 0.0f);
+    ASSERT_EQ(cfg.eos_token_ids.size(), 1u);
+    EXPECT_EQ(cfg.eos_token_ids[0], 2);
+}
+
+// Qwen3-Coder-30B-style: ships all four sampling fields plus a multi-EOS array.
+TEST_F(GenerationConfigTest, AllSamplingFieldsAndEosArray) {
+    write_gen_config(R"({
+        "do_sample": true,
+        "eos_token_id": [151645, 151643],
+        "pad_token_id": 151643,
+        "repetition_penalty": 1.05,
+        "temperature": 0.7,
+        "top_k": 20,
+        "top_p": 0.8
+    })");
+
+    HFConfigLoader::GenerationConfig cfg;
+    ASSERT_TRUE(HFConfigLoader::load_generation_config(tmp_dir_.string(), cfg));
+
+    EXPECT_FLOAT_EQ(cfg.temperature, 0.7f);
+    EXPECT_FLOAT_EQ(cfg.top_p, 0.8f);
+    EXPECT_EQ(cfg.top_k, 20);
+    EXPECT_FLOAT_EQ(cfg.repetition_penalty, 1.05f);
+    ASSERT_EQ(cfg.eos_token_ids.size(), 2u);
+    EXPECT_EQ(cfg.eos_token_ids[0], 151645);
+    EXPECT_EQ(cfg.eos_token_ids[1], 151643);
+}
+
+// do_sample=false overrides whatever temperature was specified — author wants
+// deterministic greedy regardless of the per-model temperature default.
+TEST_F(GenerationConfigTest, DoSampleFalseForcesGreedy) {
+    write_gen_config(R"({
+        "do_sample": false,
+        "eos_token_id": 2,
+        "temperature": 0.7
+    })");
+
+    HFConfigLoader::GenerationConfig cfg;
+    ASSERT_TRUE(HFConfigLoader::load_generation_config(tmp_dir_.string(), cfg));
+
+    EXPECT_FLOAT_EQ(cfg.temperature, 0.0f);
+}
+
+// Missing file is a soft failure — caller falls back to family preset.
+TEST_F(GenerationConfigTest, MissingFileReturnsFalse) {
+    HFConfigLoader::GenerationConfig cfg;
+    EXPECT_FALSE(HFConfigLoader::load_generation_config(tmp_dir_.string(), cfg));
+    EXPECT_LT(cfg.temperature, 0.0f);
+    EXPECT_TRUE(cfg.eos_token_ids.empty());
+}
+
+} // namespace

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -122,6 +122,7 @@ CliArgs parse_args(int argc, char** argv) {
             args.typical_p = static_cast<float>(std::atof(argv[++i]));
         } else if (std::strcmp(arg, "--repeat-penalty") == 0 && i + 1 < argc) {
             args.repetition_penalty = static_cast<float>(std::atof(argv[++i]));
+            args.repetition_penalty_set = true;
         } else if (std::strcmp(arg, "--frequency-penalty") == 0 && i + 1 < argc) {
             args.frequency_penalty = static_cast<float>(std::atof(argv[++i]));
         } else if (std::strcmp(arg, "--presence-penalty") == 0 && i + 1 < argc) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -25,6 +25,7 @@ struct CliArgs {
     bool temperature_set = false;
     bool top_p_set = false;
     bool top_k_set = false;
+    bool repetition_penalty_set = false;
     int seed = -1;
     float min_p = 0.0f;
     float typical_p = 1.0f;        // Locally typical sampling (1.0 = disabled)

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -73,8 +73,14 @@ int main(int argc, char** argv) {
 
     ImpConfig config = imp_config_default();
 
-    // Get model-family sampling defaults
+    // Sampling defaults: CLI flag > generation_config.json (SafeTensors only) >
+    // arch-family preset. Author-shipped values from generation_config.json are
+    // signalled by sentinel >= 0; sentinel <0 falls through to the family preset.
     imp::SamplingDefaults sampling = imp::get_sampling_defaults(model->model->config().arch);
+    const auto& gen = model->model->generation_config();
+    if (gen.temperature        >= 0.0f) sampling.temperature = gen.temperature;
+    if (gen.top_p              >= 0.0f) sampling.top_p       = gen.top_p;
+    if (gen.top_k              >= 0)    sampling.top_k       = gen.top_k;
 
     // CLI flags override auto-detection (only when explicitly set)
     config.device_id = args.device;
@@ -150,7 +156,10 @@ int main(int argc, char** argv) {
     params.seed = args.seed;
     params.min_p = args.min_p;
     params.typical_p = args.typical_p;
-    params.repetition_penalty = args.repetition_penalty;
+    params.repetition_penalty = args.repetition_penalty_set
+        ? args.repetition_penalty
+        : (gen.repetition_penalty >= 0.0f ? gen.repetition_penalty
+                                          : args.repetition_penalty);
     params.frequency_penalty = args.frequency_penalty;
     params.presence_penalty = args.presence_penalty;
     params.repeat_last_n = args.repeat_last_n;


### PR DESCRIPTION
## Summary
- `HFConfigLoader::load_generation_config` existed in tree but was **never called** — every SafeTensors model was dropping its author-shipped sampling defaults on the floor
- Plumbs `temperature`, `top_p`, `top_k`, `repetition_penalty`, EOS IDs out of `generation_config.json` and into the runtime
- Sampling cascade in imp-cli: **CLI flag > generation_config.json > arch-family preset**
- 4 unit tests + e2e gate green for Gemma-4-NVFP4 + Mistral-Small-3.2-NVFP4

## What it does
- New `HFConfigLoader::GenerationConfig` struct (sentinel `<0` / empty-vector = field absent in JSON)
- SafeTensors loader calls it after tokenizer init, pushes EOS IDs onto the tokenizer so the engine's existing stop-condition path picks them up automatically
- `do_sample=false` → forces `temperature=0` (greedy, per HF semantics)
- imp-cli reads `model->generation_config()` and overlays it on the family preset before applying user CLI flags

## Why
The `/tmp/imp_nvfp4_quality` sweep showed users currently have to pass `--temperature 0.7 --top-p 0.9` etc. manually for every model, even though the model author's `generation_config.json` already specifies what the model wants. With this PR:

| Model | Now picks up automatically |
|---|---|
| Mistral-Small-3.2-NVFP4 | `temperature=0.15` |
| Qwen3-Coder-30B Modelopt | `temp=0.7 top_p=0.8 top_k=20 repetition_penalty=1.05` |
| Gemma-4-26B-NVFP4 | `temp=1.0 top_p=0.95 top_k=64` |

## Files
- `src/model/hf_config_loader.{h,cpp}` — extended struct + parser
- `src/model/model.h` — new `generation_config()` accessor
- `src/model/safetensors_loader.cpp` — wire the call + EOS push
- `tools/imp-cli/{args.h,args.cpp,main.cpp}` — `repetition_penalty_set` flag + cascade
- `tests/test_hf_config_loader.cpp` (new) — 4 unit tests in `test-core`

## Test plan
- [x] `test-core --gtest_filter='GenerationConfigTest.*'` → 4/4 pass
- [x] `test-core` full → 72/72 pass (no regression)
- [x] `test-text` full → 140/140 pass
- [x] `test-e2e --gtest_filter='LlmCompressorE2E.{Gemma4*,Mistral*}'` → 3/3 pass with chat-template-gated coherence
- [x] CLI smoke: Mistral-3.2-NVFP4, Qwen3-Coder-30B, Gemma-4-NVFP4 all log expected fields from `generation_config.json`

## Note on perf gate
`make verify-fast` perf gate was skipped via documented `IMP_VERIFY_SKIP_PERF=1` because the baseline in `tests/perf_baseline.json` is currently stale on `main` itself — Qwen3-8B Q8_0 measures `tg=156` vs `258` baseline on **both** branches (verified by checking out main and re-running the same bench). This PR's diff doesn't touch any GGUF code path, so it cannot affect Qwen3-8B Q8_0 throughput. Baseline refresh via `scripts/gen_perf_baseline.sh` is a separate hygiene task.

## Scope note
Orthogonal to the open Mistral-Small-3.2-NVFP4 long-form coherence loop. Sampling defaults are not the root cause of that bug, but they were a shipped coverage gap worth filling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)