### PR TITLE
feat(loader): plumb tokenizer_config.json add_bos/add_eos/add_prefix_space

### DIFF
--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -525,6 +525,32 @@ bool HFConfigLoader::load_special_tokens_map(const std::string& model_dir,
     return true;
 }
 
+// ---- load_tokenizer_flags ----
+
+bool HFConfigLoader::load_tokenizer_flags(const std::string& model_dir,
+                                           TokenizerFlags& out) {
+    std::string path = model_dir + "/tokenizer_config.json";
+    JValue root;
+    if (!parse_json_file(path, root)) return false;
+
+    auto read_bool = [&](const char* key, int& field) {
+        const JValue* v = jobj_find(root, key);
+        if (v && v->type == JType::NUMBER) {
+            field = (v->num_val != 0.0) ? 1 : 0;
+        }
+    };
+
+    read_bool("add_bos_token",    out.add_bos_token);
+    read_bool("add_eos_token",    out.add_eos_token);
+    read_bool("add_prefix_space", out.add_prefix_space);
+
+    IMP_LOG_INFO("tokenizer_config.json: add_bos=%s add_eos=%s add_prefix_space=%s",
+                 out.add_bos_token < 0    ? "unset" : (out.add_bos_token    ? "true" : "false"),
+                 out.add_eos_token < 0    ? "unset" : (out.add_eos_token    ? "true" : "false"),
+                 out.add_prefix_space < 0 ? "unset" : (out.add_prefix_space ? "true" : "false"));
+    return true;
+}
+
 // ---- load_gptq_config ----
 
 bool HFConfigLoader::load_gptq_config(const std::string& model_dir, GPTQConfig& cfg) {

--- a/src/model/hf_config_loader.h
+++ b/src/model/hf_config_loader.h
@@ -60,6 +60,22 @@ struct HFConfigLoader {
     static bool load_special_tokens_map(const std::string& model_dir,
                                         SpecialTokensMap& out);
 
+    // Tokenizer-side flags from tokenizer_config.json. The corresponding
+    // GGUF metadata is `tokenizer.ggml.add_bos_token` and
+    // `tokenizer.ggml.add_space_prefix` — `gguf_loader.cpp` already wires
+    // those. SafeTensors loader needs an equivalent path.
+    //
+    // Sentinel: -1 = field not present, 0 = false, 1 = true. Caller falls
+    // back to its own default (matching GGUF: gpt2-style tokenizers default
+    // add_bos=false, everything else true).
+    struct TokenizerFlags {
+        int add_bos_token    = -1;
+        int add_eos_token    = -1;
+        int add_prefix_space = -1;
+    };
+    static bool load_tokenizer_flags(const std::string& model_dir,
+                                     TokenizerFlags& out);
+
     // GPTQ quantization config from quantize_config.json
     struct GPTQConfig {
         int bits = 0;        // 4 or 8

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -723,6 +723,29 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
         }
     }
 
+    // 9b. tokenizer_config.json — tokenizer-side flags (add_bos_token,
+    // add_prefix_space). Mirrors gguf_loader.cpp's read of
+    // tokenizer.ggml.add_bos_token / add_space_prefix. Without this the
+    // SafeTensors path used Tokenizer's hardcoded default `add_bos_=true`
+    // — wrong for any model that ships add_bos_token=false in its config
+    // (e.g. Qwen3-Coder-30B-A3B-FP4 which auto-prepends <|endoftext|>
+    // unwantedly otherwise).
+    if (!model_dir.empty() && model->tokenizer_) {
+        HFConfigLoader::TokenizerFlags tflags;
+        if (HFConfigLoader::load_tokenizer_flags(model_dir, tflags)) {
+            if (tflags.add_bos_token >= 0) {
+                model->tokenizer_->set_add_bos(tflags.add_bos_token != 0);
+            } else if (model->tokenizer_->type() == "gpt2") {
+                // Match GGUF default: BPE tokenizers without an explicit
+                // flag don't add BOS.
+                model->tokenizer_->set_add_bos(false);
+            }
+            if (tflags.add_prefix_space >= 0) {
+                model->tokenizer_->set_add_space_prefix(tflags.add_prefix_space != 0);
+            }
+        }
+    }
+
     // Re-infer vocab_size from token embedding if needed
     if (cfg.vocab_size == 0 && model->tok_emb_.data != nullptr) {
         cfg.vocab_size = static_cast<int>(model->tok_emb_.shape[0]);

--- a/tests/test_hf_config_loader.cpp
+++ b/tests/test_hf_config_loader.cpp
@@ -176,4 +176,86 @@ TEST_F(SpecialTokensMapTest, MissingFileReturnsFalse) {
     EXPECT_TRUE(stm.additional_special_tokens.empty());
 }
 
+// ---------------------------------------------------------------------------
+// tokenizer_config.json — author-side flags (add_bos_token, etc.)
+// ---------------------------------------------------------------------------
+
+class TokenizerFlagsTest : public ::testing::Test {
+protected:
+    std::filesystem::path tmp_dir_;
+
+    void SetUp() override {
+        tmp_dir_ = std::filesystem::temp_directory_path() /
+                   ("imp_test_tflags_" + std::to_string(::getpid()));
+        std::filesystem::create_directories(tmp_dir_);
+    }
+
+    void TearDown() override {
+        std::filesystem::remove_all(tmp_dir_);
+    }
+
+    void write_config(const std::string& json) {
+        std::ofstream f(tmp_dir_ / "tokenizer_config.json");
+        f << json;
+    }
+};
+
+// Qwen3-Coder-style: BPE tokenizer that explicitly disables auto-BOS.
+// Without this fix the SafeTensors path silently auto-prepended the
+// pad/eos token to every prompt.
+TEST_F(TokenizerFlagsTest, AddBosFalse) {
+    write_config(R"({
+        "add_bos_token": false,
+        "add_prefix_space": false,
+        "tokenizer_class": "Qwen2Tokenizer"
+    })");
+
+    HFConfigLoader::TokenizerFlags flags;
+    ASSERT_TRUE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+
+    EXPECT_EQ(flags.add_bos_token, 0);
+    EXPECT_EQ(flags.add_prefix_space, 0);
+    EXPECT_LT(flags.add_eos_token, 0);  // unset
+}
+
+// Mistral-3.2-style: BOS yes, EOS no, prefix_space null (treated as unset).
+TEST_F(TokenizerFlagsTest, MistralBosTrueEosFalse) {
+    write_config(R"({
+        "add_bos_token": true,
+        "add_eos_token": false,
+        "add_prefix_space": null,
+        "tokenizer_class": "LlamaTokenizer"
+    })");
+
+    HFConfigLoader::TokenizerFlags flags;
+    ASSERT_TRUE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+
+    EXPECT_EQ(flags.add_bos_token, 1);
+    EXPECT_EQ(flags.add_eos_token, 0);
+    EXPECT_LT(flags.add_prefix_space, 0);  // null → unset
+}
+
+// Gemma-4-style: tokenizer_config.json doesn't declare any of these flags;
+// metadata lives in tokenizer.json instead. All fields stay at sentinel,
+// caller falls back to its tokenizer-type-driven default.
+TEST_F(TokenizerFlagsTest, AllUnsetFallsThrough) {
+    write_config(R"({
+        "tokenizer_class": "Gemma4Tokenizer",
+        "padding_side": "left"
+    })");
+
+    HFConfigLoader::TokenizerFlags flags;
+    ASSERT_TRUE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+
+    EXPECT_LT(flags.add_bos_token, 0);
+    EXPECT_LT(flags.add_eos_token, 0);
+    EXPECT_LT(flags.add_prefix_space, 0);
+}
+
+TEST_F(TokenizerFlagsTest, MissingFileReturnsFalse) {
+    HFConfigLoader::TokenizerFlags flags;
+    EXPECT_FALSE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+    EXPECT_LT(flags.add_bos_token, 0);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
Mirrors `gguf_loader.cpp:1335-1354` for the SafeTensors path. `gguf_loader` already reads `tokenizer.ggml.add_bos_token` and `tokenizer.ggml.add_space_prefix` from GGUF metadata and applies them to the Tokenizer. The SafeTensors path never did the equivalent → `add_bos_=true` hardcoded default won, regardless of what the model author shipped.

**Stacked on top of #75** — base branch is `feat/special-tokens-map-defensive-stacked`. After #74 + #75 merge, retarget to `main`.

## Real-world miss this fixes
- **Qwen3-Coder-30B-A3B-FP4** ships `tokenizer_config.add_bos_token: false` (BPE tokenizer, doesn't want auto-BOS). Pre-fix imp auto-prepended `<|endoftext|>` (token 151643) to every prompt, silently diverging from vLLM / HF Transformers reference behavior
- **Mistral-Small-3.2-NVFP4** ships `add_bos: true, add_eos: false` — matched our default for BOS by accident
- **Gemma-4-NVFP4** doesn't ship these in tokenizer_config; falls through to existing tokenizer.json-side metadata

## What it does
- `HFConfigLoader::TokenizerFlags` struct with `-1` / `0` / `1` sentinels (distinguishes missing-from-JSON vs explicitly-false vs explicitly-true)
- `safetensors_loader.cpp` step 9b applies the flags after tokenizer.json load, with the same gpt2-default-false fallback `gguf_loader` uses for BPE tokenizers

## Files
- `src/model/hf_config_loader.{h,cpp}` — new struct + parser
- `src/model/safetensors_loader.cpp` — wire after tokenizer load
- `tests/test_hf_config_loader.cpp` — 4 unit tests

## Test plan
- [x] `test-core --gtest_filter='TokenizerFlagsTest.*'` → 4/4 pass (Qwen-style add_bos=false, Mistral asymmetric, Gemma all-unset, missing file)
- [x] `test-core` full → 79/79 pass (was 75 in #75; +4 TokenizerFlagsTest)
- [x] `test-text` full → 148/148 pass (no regression)
- [x] `test-e2e --gtest_filter='LlmCompressorE2E.{Gemma4,Mistral}*'` → 3/3 pass
- [x] CLI smoke confirms log line per model:
  - Qwen3-Coder: `add_bos=false add_eos=unset add_prefix_space=false`
  - Mistral 3.2: `add_bos=true add_eos=false add_prefix_space=unset`
  - Gemma-4: `add_bos=unset add_eos=unset add_prefix_space=unset` (falls through)

## Note on perf gate
Same as #74 / #75: `IMP_VERIFY_SKIP_PERF=1` documented skip — baseline is stale on `main` itself (Qwen3-8B Q8_0 measures `tg=156` vs `258` baseline on both branches). This PR doesn't touch any GGUF or compute code path.

## Closes the JSON coverage gap thread
With #74 + #75 + this PR merged, every author-shipped HF config file relevant for text-only inference is consumed:
- ✅ `config.json` — already
- ✅ `generation_config.json` — #74
- ✅ `special_tokens_map.json` — #75
- ✅ `tokenizer_config.json` (chat_template, added_tokens) — already
- ✅ `tokenizer_config.json` (add_bos/add_eos/add_prefix_space) — **this PR**
- ✅ `chat_template.jinja` — already
- ✅ `model.safetensors.index.json` — already
- ✅ `recipe.yaml` / `hf_quant_config.json` — already
- ⏭️ `tokenizer.json::post_processor` — more precise BOS/EOS source, follow-up if a model ships only post_processor without tokenizer_config flags
- ⏭️ `tekken.json` / `processor_config.json` / `preprocessor_config.json` — out of scope (multimodal pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)