### PR TITLE
feat(loader): JSON config plumbing — special_tokens_map + Mistral V3 + tokenizer_config flags

### DIFF
--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -9,10 +9,11 @@ namespace imp {
 
 const char* chat_template_family_name(ChatTemplateFamily family) {
     switch (family) {
-        case ChatTemplateFamily::RAW:      return "raw";
-        case ChatTemplateFamily::CHATML:   return "chatml";
-        case ChatTemplateFamily::LLAMA2:   return "llama2";
-        case ChatTemplateFamily::LLAMA3:   return "llama3";
+        case ChatTemplateFamily::RAW:         return "raw";
+        case ChatTemplateFamily::CHATML:      return "chatml";
+        case ChatTemplateFamily::LLAMA2:      return "llama2";
+        case ChatTemplateFamily::MISTRAL_V3:  return "mistral_v3";
+        case ChatTemplateFamily::LLAMA3:      return "llama3";
         case ChatTemplateFamily::NEMOTRON:    return "nemotron";
         case ChatTemplateFamily::GEMMA:       return "gemma";
         case ChatTemplateFamily::DEEPSEEK_R1: return "deepseek_r1";
@@ -34,6 +35,13 @@ ChatTemplateFamily ChatTemplate::detect_family(const std::string& jinja2_str) {
     // Gemma-4 uses <|turn> instead of <start_of_turn>
     if (jinja2_str.find("<|turn>") != std::string::npos)
         return ChatTemplateFamily::GEMMA;
+    // Mistral V3-Tekken (Mistral-Small-3.x, Mistral-Nemo, Mixtral-8x22B):
+    // adds [TOOL_CALLS] / [AVAILABLE_TOOLS] / [TOOL_RESULTS] markers on top of
+    // the V1/V2 [INST] core. Check BEFORE the LLAMA2 [INST] fallback so newer
+    // Mistrals don't get misclassified as the older family.
+    if (jinja2_str.find("[TOOL_CALLS]") != std::string::npos ||
+        jinja2_str.find("[AVAILABLE_TOOLS]") != std::string::npos)
+        return ChatTemplateFamily::MISTRAL_V3;
     if (jinja2_str.find("[INST]") != std::string::npos)
         return ChatTemplateFamily::LLAMA2;
     if (jinja2_str.find("<extra_id_0>") != std::string::npos)
@@ -72,6 +80,8 @@ ChatTemplateFamily ChatTemplate::parse_family(const std::string& name) {
     if (name == "none")     return ChatTemplateFamily::RAW;
     if (name == "chatml")   return ChatTemplateFamily::CHATML;
     if (name == "llama2")   return ChatTemplateFamily::LLAMA2;
+    if (name == "mistral_v3" || name == "mistral-v3" || name == "mistralv3")
+        return ChatTemplateFamily::MISTRAL_V3;
     if (name == "llama3")   return ChatTemplateFamily::LLAMA3;
     if (name == "nemotron") return ChatTemplateFamily::NEMOTRON;
     if (name == "gemma")   return ChatTemplateFamily::GEMMA;
@@ -134,11 +144,16 @@ bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer,
             stop_token_ids_.push_back(eot_id_);
             break;
         }
-        case ChatTemplateFamily::LLAMA2: {
+        case ChatTemplateFamily::LLAMA2:
+        case ChatTemplateFamily::MISTRAL_V3: {
+            // Both share the [INST]/[/INST] core. V3 adds tool-call markers
+            // ([TOOL_CALLS], [AVAILABLE_TOOLS], [TOOL_RESULTS]) which are
+            // emitted via the Jinja2 path when present in chat_template.jinja
+            // — the hardcoded apply method only handles the message-frame.
             inst_start_id_ = tokenizer.find_token("[INST]");
             inst_end_id_   = tokenizer.find_token("[/INST]");
             if (inst_start_id_ < 0 || inst_end_id_ < 0) {
-                IMP_LOG_WARN("Llama2 template: missing special tokens "
+                IMP_LOG_WARN("Mistral/Llama2 template: missing special tokens "
                              "(inst_start=%d, inst_end=%d), falling back to raw",
                              inst_start_id_, inst_end_id_);
                 family_ = ChatTemplateFamily::RAW;
@@ -263,7 +278,9 @@ std::vector<int32_t> ChatTemplate::apply(
     switch (family_) {
         case ChatTemplateFamily::CHATML:   return apply_chatml(tok, messages, suppress_thinking);
         case ChatTemplateFamily::LLAMA3:   return apply_llama3(tok, messages);
-        case ChatTemplateFamily::LLAMA2:   return apply_llama2(tok, messages);
+        case ChatTemplateFamily::LLAMA2:
+        case ChatTemplateFamily::MISTRAL_V3:
+            return apply_llama2(tok, messages);
         case ChatTemplateFamily::NEMOTRON:    return apply_nemotron(tok, messages);
         case ChatTemplateFamily::GEMMA:       return apply_gemma(tok, messages);
         case ChatTemplateFamily::DEEPSEEK_R1: return apply_deepseek_r1(tok, messages);

--- a/src/model/chat_template.h
+++ b/src/model/chat_template.h
@@ -13,7 +13,8 @@ namespace imp {
 enum class ChatTemplateFamily {
     RAW,        // No template — pass raw text
     CHATML,     // <|im_start|>...<|im_end|> (Qwen3, etc.)
-    LLAMA2,     // [INST]...[/INST] (Llama 2, Mistral)
+    LLAMA2,     // [INST]...[/INST] (Llama 2, older Mistral V1/V2)
+    MISTRAL_V3, // [INST]...[/INST] + [TOOL_CALLS]/[AVAILABLE_TOOLS] (Mistral V3-Tekken: 3.x family)
     LLAMA3,     // <|start_header_id|>...<|end_header_id|>...<|eot_id|>
     NEMOTRON,   // <extra_id_0>System\n...<extra_id_1>\n<extra_id_0>User\n...
     GEMMA,      // <start_of_turn>user\n...<end_of_turn>\n<start_of_turn>model\n

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -525,6 +525,32 @@ bool HFConfigLoader::load_special_tokens_map(const std::string& model_dir,
     return true;
 }
 
+// ---- load_tokenizer_flags ----
+
+bool HFConfigLoader::load_tokenizer_flags(const std::string& model_dir,
+                                           TokenizerFlags& out) {
+    std::string path = model_dir + "/tokenizer_config.json";
+    JValue root;
+    if (!parse_json_file(path, root)) return false;
+
+    auto read_bool = [&](const char* key, int& field) {
+        const JValue* v = jobj_find(root, key);
+        if (v && v->type == JType::NUMBER) {
+            field = (v->num_val != 0.0) ? 1 : 0;
+        }
+    };
+
+    read_bool("add_bos_token",    out.add_bos_token);
+    read_bool("add_eos_token",    out.add_eos_token);
+    read_bool("add_prefix_space", out.add_prefix_space);
+
+    IMP_LOG_INFO("tokenizer_config.json: add_bos=%s add_eos=%s add_prefix_space=%s",
+                 out.add_bos_token < 0    ? "unset" : (out.add_bos_token    ? "true" : "false"),
+                 out.add_eos_token < 0    ? "unset" : (out.add_eos_token    ? "true" : "false"),
+                 out.add_prefix_space < 0 ? "unset" : (out.add_prefix_space ? "true" : "false"));
+    return true;
+}
+
 // ---- load_gptq_config ----
 
 bool HFConfigLoader::load_gptq_config(const std::string& model_dir, GPTQConfig& cfg) {

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -477,6 +477,54 @@ std::vector<HFConfigLoader::AddedToken> HFConfigLoader::load_added_tokens(
     return result;
 }
 
+// ---- load_special_tokens_map ----
+
+namespace {
+
+// Token entry in special_tokens_map.json comes in two shapes:
+//   "<unk>"                                    (plain string)
+//   {"content": "<s>", "lstrip": false, ...}   (object with metadata)
+// Extract the content string from either; returns empty if neither matches.
+std::string extract_token_content(const JValue& v) {
+    if (v.type == JType::STRING) return v.str_val;
+    if (v.type == JType::OBJECT) {
+        std::string s;
+        jobj_get_string(v, "content", s);
+        return s;
+    }
+    return {};
+}
+
+} // namespace
+
+bool HFConfigLoader::load_special_tokens_map(const std::string& model_dir,
+                                              SpecialTokensMap& out) {
+    std::string path = model_dir + "/special_tokens_map.json";
+    JValue root;
+    if (!parse_json_file(path, root)) return false;
+
+    if (const JValue* arr = jobj_find(root, "additional_special_tokens");
+        arr && arr->type == JType::ARRAY) {
+        out.additional_special_tokens.reserve(arr->arr.size());
+        for (const auto& v : arr->arr) {
+            std::string s = extract_token_content(v);
+            if (!s.empty()) out.additional_special_tokens.push_back(std::move(s));
+        }
+    }
+
+    if (const JValue* bos = jobj_find(root, "bos_token"))   out.bos_token = extract_token_content(*bos);
+    if (const JValue* eos = jobj_find(root, "eos_token"))   out.eos_token = extract_token_content(*eos);
+    if (const JValue* pad = jobj_find(root, "pad_token"))   out.pad_token = extract_token_content(*pad);
+    if (const JValue* unk = jobj_find(root, "unk_token"))   out.unk_token = extract_token_content(*unk);
+
+    IMP_LOG_INFO("special_tokens_map.json: %zu additional_special_tokens, "
+                 "bos='%s' eos='%s' pad='%s' unk='%s'",
+                 out.additional_special_tokens.size(),
+                 out.bos_token.c_str(), out.eos_token.c_str(),
+                 out.pad_token.c_str(), out.unk_token.c_str());
+    return true;
+}
+
 // ---- load_gptq_config ----
 
 bool HFConfigLoader::load_gptq_config(const std::string& model_dir, GPTQConfig& cfg) {

--- a/src/model/hf_config_loader.h
+++ b/src/model/hf_config_loader.h
@@ -60,6 +60,22 @@ struct HFConfigLoader {
     static bool load_special_tokens_map(const std::string& model_dir,
                                         SpecialTokensMap& out);
 
+    // Tokenizer-side flags from tokenizer_config.json. The corresponding
+    // GGUF metadata is `tokenizer.ggml.add_bos_token` and
+    // `tokenizer.ggml.add_space_prefix` — `gguf_loader.cpp` already wires
+    // those. SafeTensors loader needs an equivalent path.
+    //
+    // Sentinel: -1 = field not present, 0 = false, 1 = true. Caller falls
+    // back to its own default (matching GGUF: gpt2-style tokenizers default
+    // add_bos=false, everything else true).
+    struct TokenizerFlags {
+        int add_bos_token    = -1;
+        int add_eos_token    = -1;
+        int add_prefix_space = -1;
+    };
+    static bool load_tokenizer_flags(const std::string& model_dir,
+                                     TokenizerFlags& out);
+
     // GPTQ quantization config from quantize_config.json
     struct GPTQConfig {
         int bits = 0;        // 4 or 8

--- a/src/model/hf_config_loader.h
+++ b/src/model/hf_config_loader.h
@@ -45,6 +45,21 @@ struct HFConfigLoader {
     };
     static std::vector<AddedToken> load_added_tokens(const std::string& model_dir);
 
+    // Authoritative special-token declarations from special_tokens_map.json.
+    // The model author lists every string that should be treated as a control
+    // token; tokenizer.json's `special: true` flag is normally a faithful copy
+    // but conversions can drop the flag. Cross-checking lets the loader patch
+    // the gap before the engine builds its banned-token list.
+    struct SpecialTokensMap {
+        std::vector<std::string> additional_special_tokens;
+        std::string bos_token;  // empty if not specified
+        std::string eos_token;
+        std::string pad_token;
+        std::string unk_token;
+    };
+    static bool load_special_tokens_map(const std::string& model_dir,
+                                        SpecialTokensMap& out);
+
     // GPTQ quantization config from quantize_config.json
     struct GPTQConfig {
         int bits = 0;        // 4 or 8

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -741,6 +741,31 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
         }
     }
 
+    // 11. Cross-check special_tokens_map.json against the loaded tokenizer's
+    // special-flag column. The model author's list is authoritative; if a
+    // string from `additional_special_tokens` exists in vocab but isn't
+    // marked CONTROL (token_type=3), patch it. Caught by the engine's
+    // banned-token scan in engine.cpp.
+    if (!model_dir.empty() && model->tokenizer_) {
+        HFConfigLoader::SpecialTokensMap stm;
+        if (HFConfigLoader::load_special_tokens_map(model_dir, stm)) {
+            int patched = 0, missing = 0;
+            for (const auto& s : stm.additional_special_tokens) {
+                int32_t id = model->tokenizer_->find_token(s);
+                if (id < 0) { missing++; continue; }
+                if (!model->tokenizer_->is_control_token(id)) {
+                    model->tokenizer_->mark_as_control(id);
+                    patched++;
+                }
+            }
+            if (patched > 0 || missing > 0) {
+                IMP_LOG_INFO("special_tokens_map: cross-check patched %d, "
+                             "missing-from-vocab %d",
+                             patched, missing);
+            }
+        }
+    }
+
     IMP_LOG_INFO("SafeTensors model loaded successfully from %s", path.c_str());
     return model;
 }

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -723,6 +723,29 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
         }
     }
 
+    // 9b. tokenizer_config.json — tokenizer-side flags (add_bos_token,
+    // add_prefix_space). Mirrors gguf_loader.cpp's read of
+    // tokenizer.ggml.add_bos_token / add_space_prefix. Without this the
+    // SafeTensors path used Tokenizer's hardcoded default `add_bos_=true`
+    // — wrong for any model that ships add_bos_token=false in its config
+    // (e.g. Qwen3-Coder-30B-A3B-FP4 which auto-prepends <|endoftext|>
+    // unwantedly otherwise).
+    if (!model_dir.empty() && model->tokenizer_) {
+        HFConfigLoader::TokenizerFlags tflags;
+        if (HFConfigLoader::load_tokenizer_flags(model_dir, tflags)) {
+            if (tflags.add_bos_token >= 0) {
+                model->tokenizer_->set_add_bos(tflags.add_bos_token != 0);
+            } else if (model->tokenizer_->type() == "gpt2") {
+                // Match GGUF default: BPE tokenizers without an explicit
+                // flag don't add BOS.
+                model->tokenizer_->set_add_bos(false);
+            }
+            if (tflags.add_prefix_space >= 0) {
+                model->tokenizer_->set_add_space_prefix(tflags.add_prefix_space != 0);
+            }
+        }
+    }
+
     // Re-infer vocab_size from token embedding if needed
     if (cfg.vocab_size == 0 && model->tok_emb_.data != nullptr) {
         cfg.vocab_size = static_cast<int>(model->tok_emb_.shape[0]);

--- a/src/model/tokenizer.h
+++ b/src/model/tokenizer.h
@@ -85,6 +85,18 @@ public:
         return id >= 0 && id < static_cast<int>(token_types_.size()) && token_types_[id] != 1;
     }
 
+    // Defensive overlay: mark a token as CONTROL even when it wasn't tagged
+    // by the source tokenizer. Used to cross-check special_tokens_map.json
+    // against tokenizer.json's special-flag column for HF model directories.
+    // No-op when id is invalid; allocates the type vector lazily if empty.
+    void mark_as_control(int32_t id) {
+        if (id < 0 || id >= static_cast<int32_t>(vocab_.size())) return;
+        if (token_types_.empty()) {
+            token_types_.assign(vocab_.size(), 1);  // default NORMAL=1
+        }
+        token_types_[id] = 3;  // CONTROL
+    }
+
 private:
     // UTF-8 helper: returns byte length of character starting at c
     static int utf8_char_len(uint8_t c);

--- a/tests/test_chat_template.cpp
+++ b/tests/test_chat_template.cpp
@@ -123,6 +123,39 @@ TEST(ChatTemplateDetectTest, Llama2) {
               ChatTemplateFamily::LLAMA2);
 }
 
+// Mistral V3-Tekken (Mistral-Small-3.x, Mistral-Nemo, Mixtral-8x22B): superset
+// of Llama2 with [TOOL_CALLS] / [AVAILABLE_TOOLS]. Must be detected as V3
+// before falling through to the LLAMA2 [INST] check.
+TEST(ChatTemplateDetectTest, MistralV3_ToolCalls) {
+    EXPECT_EQ(ChatTemplate::detect_family(
+                  "[INST] {{ message.content }} [/INST]"
+                  "{% if tool_calls %}[TOOL_CALLS]{% endif %}"),
+              ChatTemplateFamily::MISTRAL_V3);
+}
+
+TEST(ChatTemplateDetectTest, MistralV3_AvailableTools) {
+    EXPECT_EQ(ChatTemplate::detect_family(
+                  "{% if available_tools %}[AVAILABLE_TOOLS]{{ available_tools }}"
+                  "[/AVAILABLE_TOOLS]{% endif %}[INST] {{ content }} [/INST]"),
+              ChatTemplateFamily::MISTRAL_V3);
+}
+
+// Plain Mistral V1/V2 (no tool markers) still detects as LLAMA2 — preserves
+// behavior for older Mistral and Llama-2 GGUFs.
+TEST(ChatTemplateDetectTest, OldMistralStillLlama2) {
+    EXPECT_EQ(ChatTemplate::detect_family("[INST] hi [/INST] hello"),
+              ChatTemplateFamily::LLAMA2);
+}
+
+TEST(ChatTemplateDetectTest, ParseFamilyMistralV3) {
+    EXPECT_EQ(ChatTemplate::parse_family("mistral_v3"),
+              ChatTemplateFamily::MISTRAL_V3);
+    EXPECT_EQ(ChatTemplate::parse_family("mistral-v3"),
+              ChatTemplateFamily::MISTRAL_V3);
+    EXPECT_STREQ(chat_template_family_name(ChatTemplateFamily::MISTRAL_V3),
+                 "mistral_v3");
+}
+
 TEST(ChatTemplateDetectTest, Nemotron) {
     EXPECT_EQ(ChatTemplate::detect_family("<extra_id_0>System\n"),
               ChatTemplateFamily::NEMOTRON);

--- a/tests/test_hf_config_loader.cpp
+++ b/tests/test_hf_config_loader.cpp
@@ -176,4 +176,86 @@ TEST_F(SpecialTokensMapTest, MissingFileReturnsFalse) {
     EXPECT_TRUE(stm.additional_special_tokens.empty());
 }
 
+// ---------------------------------------------------------------------------
+// tokenizer_config.json — author-side flags (add_bos_token, etc.)
+// ---------------------------------------------------------------------------
+
+class TokenizerFlagsTest : public ::testing::Test {
+protected:
+    std::filesystem::path tmp_dir_;
+
+    void SetUp() override {
+        tmp_dir_ = std::filesystem::temp_directory_path() /
+                   ("imp_test_tflags_" + std::to_string(::getpid()));
+        std::filesystem::create_directories(tmp_dir_);
+    }
+
+    void TearDown() override {
+        std::filesystem::remove_all(tmp_dir_);
+    }
+
+    void write_config(const std::string& json) {
+        std::ofstream f(tmp_dir_ / "tokenizer_config.json");
+        f << json;
+    }
+};
+
+// Qwen3-Coder-style: BPE tokenizer that explicitly disables auto-BOS.
+// Without this fix the SafeTensors path silently auto-prepended the
+// pad/eos token to every prompt.
+TEST_F(TokenizerFlagsTest, AddBosFalse) {
+    write_config(R"({
+        "add_bos_token": false,
+        "add_prefix_space": false,
+        "tokenizer_class": "Qwen2Tokenizer"
+    })");
+
+    HFConfigLoader::TokenizerFlags flags;
+    ASSERT_TRUE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+
+    EXPECT_EQ(flags.add_bos_token, 0);
+    EXPECT_EQ(flags.add_prefix_space, 0);
+    EXPECT_LT(flags.add_eos_token, 0);  // unset
+}
+
+// Mistral-3.2-style: BOS yes, EOS no, prefix_space null (treated as unset).
+TEST_F(TokenizerFlagsTest, MistralBosTrueEosFalse) {
+    write_config(R"({
+        "add_bos_token": true,
+        "add_eos_token": false,
+        "add_prefix_space": null,
+        "tokenizer_class": "LlamaTokenizer"
+    })");
+
+    HFConfigLoader::TokenizerFlags flags;
+    ASSERT_TRUE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+
+    EXPECT_EQ(flags.add_bos_token, 1);
+    EXPECT_EQ(flags.add_eos_token, 0);
+    EXPECT_LT(flags.add_prefix_space, 0);  // null → unset
+}
+
+// Gemma-4-style: tokenizer_config.json doesn't declare any of these flags;
+// metadata lives in tokenizer.json instead. All fields stay at sentinel,
+// caller falls back to its tokenizer-type-driven default.
+TEST_F(TokenizerFlagsTest, AllUnsetFallsThrough) {
+    write_config(R"({
+        "tokenizer_class": "Gemma4Tokenizer",
+        "padding_side": "left"
+    })");
+
+    HFConfigLoader::TokenizerFlags flags;
+    ASSERT_TRUE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+
+    EXPECT_LT(flags.add_bos_token, 0);
+    EXPECT_LT(flags.add_eos_token, 0);
+    EXPECT_LT(flags.add_prefix_space, 0);
+}
+
+TEST_F(TokenizerFlagsTest, MissingFileReturnsFalse) {
+    HFConfigLoader::TokenizerFlags flags;
+    EXPECT_FALSE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+    EXPECT_LT(flags.add_bos_token, 0);
+}
+
 } // namespace

--- a/tests/test_hf_config_loader.cpp
+++ b/tests/test_hf_config_loader.cpp
@@ -99,4 +99,81 @@ TEST_F(GenerationConfigTest, MissingFileReturnsFalse) {
     EXPECT_TRUE(cfg.eos_token_ids.empty());
 }
 
+// ---------------------------------------------------------------------------
+// special_tokens_map.json — authoritative additional_special_tokens list
+// ---------------------------------------------------------------------------
+
+class SpecialTokensMapTest : public ::testing::Test {
+protected:
+    std::filesystem::path tmp_dir_;
+
+    void SetUp() override {
+        tmp_dir_ = std::filesystem::temp_directory_path() /
+                   ("imp_test_stm_" + std::to_string(::getpid()));
+        std::filesystem::create_directories(tmp_dir_);
+    }
+
+    void TearDown() override {
+        std::filesystem::remove_all(tmp_dir_);
+    }
+
+    void write_stm(const std::string& json) {
+        std::ofstream f(tmp_dir_ / "special_tokens_map.json");
+        f << json;
+    }
+};
+
+// Mistral-3.2-style: object form for bos/eos/pad/unk + flat-string array for
+// additional_special_tokens (with [INST], [TOOL_CALLS], etc.).
+TEST_F(SpecialTokensMapTest, MistralObjectFormParsing) {
+    write_stm(R"({
+        "additional_special_tokens": [
+            "<unk>", "<s>", "</s>", "[INST]", "[/INST]",
+            "[AVAILABLE_TOOLS]", "[TOOL_CALLS]"
+        ],
+        "bos_token": {"content": "<s>", "lstrip": false},
+        "eos_token": {"content": "</s>", "lstrip": false},
+        "pad_token": {"content": "<pad>", "lstrip": false},
+        "unk_token": {"content": "<unk>", "lstrip": false}
+    })");
+
+    HFConfigLoader::SpecialTokensMap stm;
+    ASSERT_TRUE(HFConfigLoader::load_special_tokens_map(tmp_dir_.string(), stm));
+
+    ASSERT_EQ(stm.additional_special_tokens.size(), 7u);
+    EXPECT_EQ(stm.additional_special_tokens[3], "[INST]");
+    EXPECT_EQ(stm.additional_special_tokens[6], "[TOOL_CALLS]");
+    EXPECT_EQ(stm.bos_token, "<s>");
+    EXPECT_EQ(stm.eos_token, "</s>");
+    EXPECT_EQ(stm.pad_token, "<pad>");
+    EXPECT_EQ(stm.unk_token, "<unk>");
+}
+
+// Qwen3-Coder-style: plain-string form for eos/pad, no bos/unk declared.
+TEST_F(SpecialTokensMapTest, QwenPlainStringForm) {
+    write_stm(R"({
+        "additional_special_tokens": [
+            "<|im_start|>", "<|im_end|>", "<|object_ref_start|>"
+        ],
+        "eos_token": "<|endoftext|>",
+        "pad_token": "<|endoftext|>"
+    })");
+
+    HFConfigLoader::SpecialTokensMap stm;
+    ASSERT_TRUE(HFConfigLoader::load_special_tokens_map(tmp_dir_.string(), stm));
+
+    ASSERT_EQ(stm.additional_special_tokens.size(), 3u);
+    EXPECT_EQ(stm.additional_special_tokens[0], "<|im_start|>");
+    EXPECT_EQ(stm.eos_token, "<|endoftext|>");
+    EXPECT_EQ(stm.pad_token, "<|endoftext|>");
+    EXPECT_TRUE(stm.bos_token.empty());
+    EXPECT_TRUE(stm.unk_token.empty());
+}
+
+TEST_F(SpecialTokensMapTest, MissingFileReturnsFalse) {
+    HFConfigLoader::SpecialTokensMap stm;
+    EXPECT_FALSE(HFConfigLoader::load_special_tokens_map(tmp_dir_.string(), stm));
+    EXPECT_TRUE(stm.additional_special_tokens.empty());
+}
+
 } // namespace

--- a/tests/test_tokenizer.cpp
+++ b/tests/test_tokenizer.cpp
@@ -533,5 +533,54 @@ TEST(TokenizerGemma4Test, DecodeByteFallbackFormsValidUTF8) {
     EXPECT_EQ(decoded, " Linus");
 }
 
+// mark_as_control: defensive overlay used by the SafeTensors loader to patch
+// missing CONTROL flags from special_tokens_map.json's authoritative list.
+TEST(TokenizerControlTest, MarkAsControlAllocatesAndSets) {
+    Tokenizer tok = make_spm_tokenizer();
+    // Fixture has no token_types yet → has_token_types() is false.
+    EXPECT_FALSE(tok.has_token_types());
+
+    int32_t id_unk = 0;  // <unk> in the fixture
+    EXPECT_FALSE(tok.is_control_token(id_unk));  // empty types → false
+
+    tok.mark_as_control(id_unk);
+    EXPECT_TRUE(tok.has_token_types());      // lazy alloc
+    EXPECT_TRUE(tok.is_control_token(id_unk));
+
+    // Other vocab entries default to NORMAL=1 (not CONTROL).
+    EXPECT_FALSE(tok.is_control_token(4));  // 'H'
+    EXPECT_FALSE(tok.is_control_token(25)); // 'Hello'
+}
+
+TEST(TokenizerControlTest, MarkAsControlIsIdempotent) {
+    Tokenizer tok = make_spm_tokenizer();
+    tok.mark_as_control(2);  // </s>
+    tok.mark_as_control(2);  // again
+    EXPECT_TRUE(tok.is_control_token(2));
+}
+
+TEST(TokenizerControlTest, MarkAsControlIgnoresInvalidIds) {
+    Tokenizer tok = make_spm_tokenizer();
+    tok.mark_as_control(-1);                 // invalid
+    tok.mark_as_control(tok.vocab_size());   // out of range
+    EXPECT_FALSE(tok.has_token_types());     // no allocation triggered
+}
+
+TEST(TokenizerControlTest, PreservesExistingTypes) {
+    Tokenizer tok = make_spm_tokenizer();
+    // Pre-populate with a custom type vector (e.g. simulating GGUF metadata).
+    std::vector<int32_t> types(tok.vocab_size(), 1);  // all NORMAL
+    types[1] = 3;  // <s> = CONTROL
+    types[2] = 3;  // </s> = CONTROL
+    tok.load_token_types(types);
+
+    // Patching a previously-NORMAL token must not clobber the others.
+    tok.mark_as_control(0);  // <unk>
+    EXPECT_TRUE(tok.is_control_token(0));
+    EXPECT_TRUE(tok.is_control_token(1));
+    EXPECT_TRUE(tok.is_control_token(2));
+    EXPECT_FALSE(tok.is_control_token(4));  // 'H' still normal
+}
+
 } // namespace
 } // namespace imp


### PR DESCRIPTION
## Summary
Combines the rebased content of the previously-orphaned PRs #75 + #76, which got stuck behind a stacking issue when their base branches were merged/deleted. Both PRs' diffs land cleanly on top of current `main` (which already has #74).

Both commits preserved as separate commits for reviewability:

1. **`special_tokens_map.json` overlay + Mistral V3-Tekken family** (was #75)
2. **`tokenizer_config.json` add_bos/add_eos/add_prefix_space plumbing** (was #76)

## Why one PR
PRs #75 and #76 were independent topical changes, but they're small enough (and adjacent in scope) that one stacked review is cheaper than two separate threads. Each commit can be reviewed/cherry-picked individually.

## 1. special_tokens_map.json + Mistral V3
- New `HFConfigLoader::SpecialTokensMap` parser: object form (Mistral) + plain-string form (Qwen)
- `Tokenizer::mark_as_control(id)` defensive method (lazy-allocates type vector)
- SafeTensors loader cross-checks `additional_special_tokens` against the tokenizer's CONTROL flag column; missing tags get patched
- New `ChatTemplateFamily::MISTRAL_V3` enum value with `[TOOL_CALLS]` / `[AVAILABLE_TOOLS]` substring detection BEFORE the LLAMA2 `[INST]` fallback
- **Fixes** Mistral-Small-3.2 misclassification: was logging `Chat template: llama2` despite Tekken-format jinja; now logs `mistral_v3`

## 2. tokenizer_config.json author flags
- `HFConfigLoader::TokenizerFlags` struct + `load_tokenizer_flags()` parser
- SafeTensors loader applies `add_bos_token` / `add_prefix_space` to the tokenizer (mirrors `gguf_loader.cpp:1335-1354`'s GGUF-side handling)
- **Fixes** Qwen3-Coder-30B-A3B-FP4 silent BOS injection: ships `add_bos_token: false` but pre-fix imp auto-prepended `<|endoftext|>` (token 151643) to every prompt
- gpt2-default-false fallback when JSON is missing the flag, matching GGUF behavior

## Test plan
- [x] `test-core` → 79/79 pass (was 72 on main; +3 SpecialTokensMapTest, +4 TokenizerFlagsTest)
- [x] `test-text` → 148/148 pass (was 140; +5 ChatTemplateDetectTest, +4 TokenizerControlTest)
- [x] `test-e2e --gtest_filter='LlmCompressorE2E.{Gemma4,Mistral}*'` → 3/3 pass (Gemma-4 NVFP4 coherent, Mistral-Small-3.2 NVFP4 "Paris" gate)
- [x] CLI smoke confirms log per model:
  - Mistral 3.2: `add_bos=true add_eos=false add_prefix_space=unset` + `1000 additional_special_tokens, 0 patched`
  - Qwen3-Coder: `add_bos=false add_eos=unset add_prefix_space=false`
  - Gemma-4: `add_bos=unset add_eos=unset add_prefix_space=unset` (falls through to existing tokenizer.json metadata)

## Note on perf gate
`IMP_VERIFY_SKIP_PERF=1` documented skip — baseline currently stale on `main` itself (Qwen3-8B Q8_0 measures `tg=156` vs `258` baseline; same on this branch and on `main`). This PR doesn't touch any GGUF or compute code path.

## Closes JSON coverage
With #74 already merged + this PR, every author-shipped HF config relevant for text-only inference is consumed:
- ✅ `config.json`, `model.safetensors.index.json`, `chat_template.jinja`, `recipe.yaml`, `hf_quant_config.json`, `tokenizer.json`, `tokenizer_config.json` (chat_template + added_tokens) — pre-existing
- ✅ `generation_config.json` — #74
- ✅ `special_tokens_map.json` — this PR
- ✅ `tokenizer_config.json` (add_bos/add_eos/add_prefix_space) — this PR

⏭️ Out of scope (multimodal pipeline, separate effort): `tokenizer.json::post_processor`, `tekken.json`, `processor_config.json`, `preprocessor_config.json`.

## Closes #75, #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)