### PR TITLE
feat(loader): respect tokenizer_config use_default_system_prompt=false

### DIFF
--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -262,29 +262,47 @@ bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer,
     return true;
 }
 
+// Honor `tokenizer_config.json::use_default_system_prompt: false`. When the
+// model author opts out and the caller didn't provide an explicit system
+// message, prepend an empty one so the Jinja template's "if no system →
+// inject default_system_message" branch doesn't fire (Mistral-Small-3.2
+// otherwise auto-injects ~600 tokens of boilerplate).
+static std::vector<ChatMessage> maybe_suppress_default_system(
+    const Tokenizer& tok, const std::vector<ChatMessage>& messages)
+{
+    if (tok.use_default_system_prompt()) return messages;
+    if (!messages.empty() && messages.front().role == "system") return messages;
+    std::vector<ChatMessage> out;
+    out.reserve(messages.size() + 1);
+    out.push_back({"system", ""});
+    for (const auto& m : messages) out.push_back(m);
+    return out;
+}
+
 std::vector<int32_t> ChatTemplate::apply(
     const Tokenizer& tok,
     const std::vector<ChatMessage>& messages,
     bool suppress_thinking) const
 {
+    auto eff_msgs = maybe_suppress_default_system(tok, messages);
     // Prefer Jinja2 rendering when available (data-driven from GGUF).
     // Falls back to hardcoded families if Jinja rendering fails.
     if (use_jinja_ && jinja_tpl_) {
-        auto tokens = apply_jinja(tok, messages, true, suppress_thinking);
+        auto tokens = apply_jinja(tok, eff_msgs, true, suppress_thinking);
         if (!tokens.empty()) return tokens;
         IMP_LOG_WARN("Jinja2 render produced empty result, falling back to hardcoded template");
     }
 
     switch (family_) {
-        case ChatTemplateFamily::CHATML:   return apply_chatml(tok, messages, suppress_thinking);
-        case ChatTemplateFamily::LLAMA3:   return apply_llama3(tok, messages);
+        case ChatTemplateFamily::CHATML:   return apply_chatml(tok, eff_msgs, suppress_thinking);
+        case ChatTemplateFamily::LLAMA3:   return apply_llama3(tok, eff_msgs);
         case ChatTemplateFamily::LLAMA2:
         case ChatTemplateFamily::MISTRAL_V3:
-            return apply_llama2(tok, messages);
-        case ChatTemplateFamily::NEMOTRON:    return apply_nemotron(tok, messages);
-        case ChatTemplateFamily::GEMMA:       return apply_gemma(tok, messages);
-        case ChatTemplateFamily::DEEPSEEK_R1: return apply_deepseek_r1(tok, messages);
-        case ChatTemplateFamily::PHI:          return apply_phi(tok, messages);
+            return apply_llama2(tok, eff_msgs);
+        case ChatTemplateFamily::NEMOTRON:    return apply_nemotron(tok, eff_msgs);
+        case ChatTemplateFamily::GEMMA:       return apply_gemma(tok, eff_msgs);
+        case ChatTemplateFamily::DEEPSEEK_R1: return apply_deepseek_r1(tok, eff_msgs);
+        case ChatTemplateFamily::PHI:          return apply_phi(tok, eff_msgs);
         default: break;
     }
     return {};
@@ -1016,7 +1034,8 @@ std::vector<int32_t> ChatTemplate::apply_with_tools(
     // Try Jinja2 tools-aware path. Returns empty if Jinja2 is unavailable or
     // rendering fails, signaling the caller to fall back to text-based tool injection.
     if (use_jinja_ && jinja_tpl_ && !tools.empty()) {
-        auto tokens = apply_jinja_with_tools(tok, messages, tools, tool_choice,
+        auto eff_msgs = maybe_suppress_default_system(tok, messages);
+        auto tokens = apply_jinja_with_tools(tok, eff_msgs, tools, tool_choice,
                                               true, suppress_thinking);
         if (!tokens.empty()) return tokens;
         IMP_LOG_WARN("Jinja2 tools render failed, caller should inject text-based tool prompt");

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -540,14 +540,18 @@ bool HFConfigLoader::load_tokenizer_flags(const std::string& model_dir,
         }
     };
 
-    read_bool("add_bos_token",    out.add_bos_token);
-    read_bool("add_eos_token",    out.add_eos_token);
-    read_bool("add_prefix_space", out.add_prefix_space);
+    read_bool("add_bos_token",             out.add_bos_token);
+    read_bool("add_eos_token",             out.add_eos_token);
+    read_bool("add_prefix_space",          out.add_prefix_space);
+    read_bool("use_default_system_prompt", out.use_default_system_prompt);
 
-    IMP_LOG_INFO("tokenizer_config.json: add_bos=%s add_eos=%s add_prefix_space=%s",
+    IMP_LOG_INFO("tokenizer_config.json: add_bos=%s add_eos=%s add_prefix_space=%s "
+                 "use_default_system_prompt=%s",
                  out.add_bos_token < 0    ? "unset" : (out.add_bos_token    ? "true" : "false"),
                  out.add_eos_token < 0    ? "unset" : (out.add_eos_token    ? "true" : "false"),
-                 out.add_prefix_space < 0 ? "unset" : (out.add_prefix_space ? "true" : "false"));
+                 out.add_prefix_space < 0 ? "unset" : (out.add_prefix_space ? "true" : "false"),
+                 out.use_default_system_prompt < 0 ? "unset"
+                     : (out.use_default_system_prompt ? "true" : "false"));
     return true;
 }
 

--- a/src/model/hf_config_loader.h
+++ b/src/model/hf_config_loader.h
@@ -69,9 +69,15 @@ struct HFConfigLoader {
     // back to its own default (matching GGUF: gpt2-style tokenizers default
     // add_bos=false, everything else true).
     struct TokenizerFlags {
-        int add_bos_token    = -1;
-        int add_eos_token    = -1;
-        int add_prefix_space = -1;
+        int add_bos_token             = -1;
+        int add_eos_token             = -1;
+        int add_prefix_space          = -1;
+        // When the model author sets `use_default_system_prompt: false`, the
+        // chat-template apply path must NOT auto-fill the template's hardcoded
+        // default system message (e.g. Mistral-Small-3.2's 600-token default
+        // injected by chat_template.jinja line 158 when no system message is
+        // supplied).
+        int use_default_system_prompt = -1;
     };
     static bool load_tokenizer_flags(const std::string& model_dir,
                                      TokenizerFlags& out);

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -743,6 +743,10 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
             if (tflags.add_prefix_space >= 0) {
                 model->tokenizer_->set_add_space_prefix(tflags.add_prefix_space != 0);
             }
+            if (tflags.use_default_system_prompt >= 0) {
+                model->tokenizer_->set_use_default_system_prompt(
+                    tflags.use_default_system_prompt != 0);
+            }
         }
     }
 

--- a/src/model/tokenizer.h
+++ b/src/model/tokenizer.h
@@ -44,6 +44,15 @@ public:
     void set_chat_template_str(const std::string& tpl) { chat_template_str_ = tpl; }
     const std::string& chat_template_str() const { return chat_template_str_; }
 
+    // Author-shipped flag from tokenizer_config.json::use_default_system_prompt.
+    // When false, the chat-template apply path must inject an empty system
+    // message so the template's "no-system → default_system_message" branch
+    // doesn't fire (e.g. Mistral-Small-3.2 ships this flag false but its
+    // chat_template.jinja line 158 still injects a 600-token default unless
+    // an explicit system message is present).
+    void set_use_default_system_prompt(bool v) { use_default_system_prompt_ = v; }
+    bool use_default_system_prompt() const { return use_default_system_prompt_; }
+
     // Encode text to token IDs
     // no_prefix=true skips SPM space prefix (for chat template pieces after special tokens)
     std::vector<int32_t> encode(const std::string& text, bool no_prefix = false) const;
@@ -128,6 +137,7 @@ private:
     std::string pre_tokenizer_;     // Pre-tokenizer type from GGUF tokenizer.ggml.pre
     bool add_bos_ = true;
     bool add_space_prefix_ = true;  // SentencePiece ▁ prefix (false for Gemma)
+    bool use_default_system_prompt_ = true;  // false → skip template's hardcoded default system
     std::string chat_template_str_;  // Raw Jinja2 template from GGUF
 
     // GPT2 BPE merge ranks: "token1 token2" -> rank (lower = higher priority)

--- a/tests/test_chat_template.cpp
+++ b/tests/test_chat_template.cpp
@@ -340,6 +340,62 @@ TEST(ChatTemplateApplyTest, ChatMLBasicStructure) {
     EXPECT_GT(last_im_start, 0);
 }
 
+// Author-driven flag: when tokenizer ships use_default_system_prompt=false,
+// apply() must inject an empty system message before the user message so that
+// any chat template (Jinja or hardcoded) which has a "no system → default
+// system" branch instead sees an explicit system slot. Mistral-Small-3.2's
+// chat_template.jinja line 158 otherwise injects a 600-token default that
+// triggers the model's long-context regression.
+TEST(ChatTemplateApplyTest, UseDefaultSystemPromptFalseInjectsSystem) {
+    Tokenizer tok = make_chat_tokenizer();
+    tok.set_use_default_system_prompt(false);
+
+    ChatTemplate tpl;
+    tpl.init(ChatTemplateFamily::CHATML, tok);
+
+    std::vector<ChatMessage> msgs = {{"user", "Hi"}};
+    auto ids = tpl.apply(tok, msgs);
+
+    ASSERT_FALSE(ids.empty());
+    // Three <|im_start|> markers: system(empty) + user + assistant prefix.
+    int im_start_count = std::count(ids.begin(), ids.end(), IM_START);
+    EXPECT_EQ(im_start_count, 3);
+}
+
+TEST(ChatTemplateApplyTest, UseDefaultSystemPromptTrueDoesNotInject) {
+    Tokenizer tok = make_chat_tokenizer();
+    // Default — ensure the prior test didn't leak state.
+    EXPECT_TRUE(tok.use_default_system_prompt());
+
+    ChatTemplate tpl;
+    tpl.init(ChatTemplateFamily::CHATML, tok);
+
+    std::vector<ChatMessage> msgs = {{"user", "Hi"}};
+    auto ids = tpl.apply(tok, msgs);
+
+    // Two <|im_start|> markers: user + assistant prefix only.
+    int im_start_count = std::count(ids.begin(), ids.end(), IM_START);
+    EXPECT_EQ(im_start_count, 2);
+}
+
+// If caller already supplies a system message, the suppression helper must
+// be a no-op — never prepend a second empty system slot.
+TEST(ChatTemplateApplyTest, UseDefaultSystemPromptFalseRespectsExplicitSystem) {
+    Tokenizer tok = make_chat_tokenizer();
+    tok.set_use_default_system_prompt(false);
+
+    ChatTemplate tpl;
+    tpl.init(ChatTemplateFamily::CHATML, tok);
+
+    std::vector<ChatMessage> msgs = {{"system", "Be brief."}, {"user", "Hi"}};
+    auto ids = tpl.apply(tok, msgs);
+
+    // Three <|im_start|> markers: caller's system + user + assistant prefix.
+    // Crucially still 3 — no additional empty system was injected.
+    int im_start_count = std::count(ids.begin(), ids.end(), IM_START);
+    EXPECT_EQ(im_start_count, 3);
+}
+
 TEST(ChatTemplateApplyTest, ChatMLNoBOSWhenDisabled) {
     Tokenizer tok = make_chat_tokenizer();
     tok.set_add_bos(false);

--- a/tests/test_hf_config_loader.cpp
+++ b/tests/test_hf_config_loader.cpp
@@ -235,6 +235,20 @@ TEST_F(TokenizerFlagsTest, MistralBosTrueEosFalse) {
     EXPECT_LT(flags.add_prefix_space, 0);  // null → unset
 }
 
+// Mistral-3.2-style: author opts out of the chat_template.jinja's hardcoded
+// default system prompt. Flag must propagate so apply() can suppress it.
+TEST_F(TokenizerFlagsTest, UseDefaultSystemPromptFalse) {
+    write_config(R"({
+        "add_bos_token": true,
+        "use_default_system_prompt": false
+    })");
+
+    HFConfigLoader::TokenizerFlags flags;
+    ASSERT_TRUE(HFConfigLoader::load_tokenizer_flags(tmp_dir_.string(), flags));
+
+    EXPECT_EQ(flags.use_default_system_prompt, 0);
+}
+
 // Gemma-4-style: tokenizer_config.json doesn't declare any of these flags;
 // metadata lives in tokenizer.json instead. All fields stay at sentinel,
 // caller falls back to its tokenizer-type-driven default.


### PR DESCRIPTION
## Summary
Honors the model author's `tokenizer_config.json::use_default_system_prompt = false` flag during chat-template apply. **Fixes** Mistral-Small-3.2-NVFP4 chat-template Q&A producing garbage like *"I am the capital of France?"* instead of *"Paris"*.

## Why
Mistral-Small-3.2's `chat_template.jinja` line 158 hardcodes a ~600-token corporate boilerplate as the default system prompt:

> *"You are Mistral-Small-3.2-24B-Instruct-2506, a Large Language Model created by Mistral AI, a French startup headquartered in Paris…"*

The author ships `use_default_system_prompt: false` in `tokenizer_config.json` to tell the calling layer **not** to trigger that branch. imp ignored it. Every chat-template-wrapped prompt got ~600 tokens prepended, which exposed an NVFP4 long-context regression: the model copied input tokens or hallucinated wildly off-topic.

Bisection (separate diagnostic session) showed:
- ~17 tokens raw + greedy → "Paris" ✓
- ~80 tokens raw → coherent ✓
- ~130 tokens with `[SYSTEM_PROMPT]` markers → broken ✗
- ~600 tokens (default system) → "events. events. events…" ✗
- RoPE / banned-tokens / FP8-prefill / FMHA-SM120 / cuBLAS-attention / naive-FP32 attention all ruled out

Honoring the author's flag is **the right thing regardless** of the long-context regression — it lands on the spec'd input shape and the model produces correct output for typical chat prompts.

## What it does
1. `HFConfigLoader::TokenizerFlags` gains `use_default_system_prompt` (-1 unset / 0 false / 1 true)
2. `safetensors_loader.cpp` applies it to the loaded `Tokenizer`
3. `chat_template.cpp` adds `maybe_suppress_default_system()` helper — when flag is `false` and caller didn't supply a system message, prepends `{"system", ""}` so the template's "no-system → default" branch doesn't fire. Wired into `apply()`, `apply_with_image()` (via fall-through), and `apply_with_tools()`

## Verified end-to-end on Mistral-Small-3.2-NVFP4
Greedy temp=0, chat-template auto, prompt: *"What is the capital of France?"*

**Before:**
> *"I am the capital of France? I can be the capital of France is the capital of France is the capital of France?…"*

**After:**
> *"The capital of France is **Paris**. It is known for its art, culture, fashion, and iconic landmarks such as the Eiffel Tower."*

## Tests
- `TokenizerFlagsTest.UseDefaultSystemPromptFalse` — parser correctness
- `ChatTemplateApplyTest.UseDefaultSystemPromptFalseInjectsSystem` — flag=false + user-only msgs prepends empty system slot (3 `<|im_start|>` markers in output)
- `ChatTemplateApplyTest.UseDefaultSystemPromptTrueDoesNotInject` — default behavior unchanged (2 markers)
- `ChatTemplateApplyTest.UseDefaultSystemPromptFalseRespectsExplicitSystem` — caller-supplied system message wins, no double-injection (3 markers, the original system survives)

CI gates:
- [x] `test-core` 79/79 pass
- [x] `test-text` 151/151 pass
- [x] `LlmCompressorE2E.{Gemma4,Mistral}*` 3/3 pass
- [x] CLI smoke confirms `tokenizer_config.json: ... use_default_system_prompt=false` log line for Mistral-3.2

## Scope note
This is a workaround for the **trigger** of an underlying NVFP4 long-context regression that still surfaces at ~500 raw prompt tokens. That regression is a separate item. With this PR, typical chat-style prompts produce coherent output for Mistral-Small-3.2-NVFP4.

## Note on perf gate
`IMP_VERIFY_SKIP_PERF=1` documented skip — baseline currently stale on `main` itself. This PR doesn't touch any GGUF or compute code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)