### PR TITLE
fix(loader): six Qwen3.5/3.6-NVFP4 SafeTensors bugs blocking coherent decode

### DIFF
--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -10,7 +10,7 @@ __global__ void gdn_scan_decode_kernel(
     const float*, const float*, const float*,
     const half*, const half*, const float*, const float*,
     float*, half*, const half*,
-    int, int, int, int);
+    int, int, int, int, int);
 
 // ---------------------------------------------------------------------------
 // Fused multi-token GDN Delta Rule Scan kernel.
@@ -38,13 +38,20 @@ gdn_scan_fused_kernel(
     const float* __restrict__ dt_bias,    // [n_heads] FP32
     float*       __restrict__ h_state,    // [n_heads, SS, HD] FP32
     YOut*        __restrict__ y_out,      // [n_tokens, n_heads * HD] FP16 or FP32
-    int n_tokens, int n_heads, int n_groups, int conv_channels)
+    int n_tokens, int n_heads, int n_groups, int conv_channels,
+    int grouped_layout)
 {
     const int h = blockIdx.x;
     if (h >= n_heads) return;
     const int d = threadIdx.x;
 
-    const int g = h % n_groups;
+    // Head-to-K-group mapping. GGUF stores heads in tiled layout where head h's
+    // group is `h % n_groups`. HF SafeTensors (Qwen3.5/3.6) stores heads in
+    // grouped layout where head h's group is `h / (n_heads / n_groups)`.
+    // grouped_layout=1 selects the HF formula.
+    const int g = grouped_layout
+        ? (h / (n_heads / n_groups))
+        : (h % n_groups);
     const int inner = n_heads * HD;
     const int BC_size = n_groups * SS;
     const float scale = rsqrtf(static_cast<float>(HD));
@@ -300,13 +307,16 @@ void vhead_tiled_to_grouped_f32(const float* src, float* dst,
 
 // Fused scan: processes all tokens in one kernel launch.
 // conv_f32: [n_tokens, conv_channels] FP32 — full conv output (Q|K|V interleaved per token)
+// grouped_layout: 0 = GGUF tiled (g = h % n_groups), 1 = HF SafeTensors grouped
+//                 (g = h / n_v_per_k). See kernel comment for details.
 void gdn_scan_fused_f32(const float* conv_f32, int conv_channels,
                          const half* alpha, const half* beta,
                          const float* A_log, const float* dt_bias,
                          float* h_state, half* y,
                          int n_tokens, int n_heads, int head_dim_ssm,
                          int state_size, int n_groups,
-                         cudaStream_t stream) {
+                         cudaStream_t stream,
+                         int grouped_layout) {
     // Shared memory: K_norm[SS] + Q_norm[SS] + reduce[HD]
     size_t smem = (2 * state_size + head_dim_ssm) * sizeof(float);
 
@@ -314,11 +324,11 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels,
     if (head_dim_ssm == 128 && state_size == 128) {
         gdn_scan_fused_kernel<128, 128, half><<<n_heads, 128, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state, y,
-            n_tokens, n_heads, n_groups, conv_channels);
+            n_tokens, n_heads, n_groups, conv_channels, grouped_layout);
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, half><<<n_heads, 64, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state, y,
-            n_tokens, n_heads, n_groups, conv_channels);
+            n_tokens, n_heads, n_groups, conv_channels, grouped_layout);
     } else {
         // Fallback: per-token loop (for unsupported HD/SS sizes)
         int inner = n_heads * head_dim_ssm;
@@ -331,7 +341,7 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels,
                 alpha + t * n_heads, beta + t * n_heads,
                 A_log, dt_bias, h_state,
                 y + t * inner, nullptr,
-                n_heads, head_dim_ssm, state_size, n_groups);
+                n_heads, head_dim_ssm, state_size, n_groups, grouped_layout);
         }
     }
 }
@@ -344,16 +354,17 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels,
                              float* h_state, float* y_fp32,
                              int n_tokens, int n_heads, int head_dim_ssm,
                              int state_size, int n_groups,
-                             cudaStream_t stream) {
+                             cudaStream_t stream,
+                             int grouped_layout) {
     size_t smem = (2 * state_size + head_dim_ssm) * sizeof(float);
     if (head_dim_ssm == 128 && state_size == 128) {
         gdn_scan_fused_kernel<128, 128, float><<<n_heads, 128, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32,
-            n_tokens, n_heads, n_groups, conv_channels);
+            n_tokens, n_heads, n_groups, conv_channels, grouped_layout);
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, float><<<n_heads, 64, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32,
-            n_tokens, n_heads, n_groups, conv_channels);
+            n_tokens, n_heads, n_groups, conv_channels, grouped_layout);
     } else {
         // No FP32 fallback: supported sizes are HD=SS=128 / 64 only.
         // Fall back to FP16 path + post-hoc upcast (precision loss intact).
@@ -370,7 +381,7 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels,
                 alpha + t * n_heads, beta + t * n_heads,
                 A_log, dt_bias, h_state,
                 scratch_dev + t * inner, nullptr,
-                n_heads, head_dim_ssm, state_size, n_groups);
+                n_heads, head_dim_ssm, state_size, n_groups, grouped_layout);
         }
         // Convert FP16 scratch → FP32. Simple elementwise cast kernel not
         // present; do it via cuda memcpy + cast on device via small kernel.
@@ -405,7 +416,8 @@ __global__ void gdn_scan_reference_kernel(
     float*       __restrict__ h_state,    // [n_heads, state_size, head_dim_v] FP32
     half*        __restrict__ y_out,      // [n_tokens, n_heads * head_dim_v] FP16
     int n_tokens, int n_heads, int n_groups,
-    int head_dim_v, int state_size, int conv_channels)
+    int head_dim_v, int state_size, int conv_channels,
+    int grouped_layout)
 {
     const int h = blockIdx.x;
     if (h >= n_heads) return;
@@ -413,7 +425,9 @@ __global__ void gdn_scan_reference_kernel(
     const int SS = state_size;
     const int HD = head_dim_v;
 
-    const int g = h % n_groups;
+    const int g = grouped_layout
+        ? (h / (n_heads / n_groups))
+        : (h % n_groups);
     const int inner = n_heads * HD;
     const int BC_size = n_groups * SS;
 
@@ -536,7 +550,8 @@ void gdn_scan_reference_f32(const float* conv_f32, int conv_channels,
                              float* h_state, half* y,
                              int n_tokens, int n_heads, int head_dim_ssm,
                              int state_size, int n_groups,
-                             cudaStream_t stream) {
+                             cudaStream_t stream,
+                             int grouped_layout) {
     // Shared memory: state slab [SS*HD] + K[SS] + Q[SS] + V[HD] + reduce[HD]
     // For Qwen 3.6 (SS=128, HD=128): ~66 KB — exceeds 48 KB default per block,
     // needs the opt-in dynamic-shared attribute.
@@ -552,7 +567,8 @@ void gdn_scan_reference_f32(const float* conv_f32, int conv_channels,
     }
     gdn_scan_reference_kernel<<<n_heads, head_dim_ssm, smem, stream>>>(
         conv_f32, alpha, beta, A_log, dt_bias, h_state, y,
-        n_tokens, n_heads, n_groups, head_dim_ssm, state_size, conv_channels);
+        n_tokens, n_heads, n_groups, head_dim_ssm, state_size, conv_channels,
+        grouped_layout);
 }
 
 // FP32-input variant: reads y as FP32, writes FP16. Used together with
@@ -674,14 +690,17 @@ __global__ void gdn_scan_decode_kernel(
     float*       __restrict__ h_state,
     half*        __restrict__ y,
     const half*  __restrict__ z,
-    int n_heads, int head_dim_ssm, int state_size, int n_groups)
+    int n_heads, int head_dim_ssm, int state_size, int n_groups,
+    int grouped_layout)
 {
     const int h = blockIdx.x;
     if (h >= n_heads) return;
     const int d = threadIdx.x;
     if (d >= head_dim_ssm) return;
 
-    const int g = h % n_groups;
+    const int g = grouped_layout
+        ? (h / (n_heads / n_groups))
+        : (h % n_groups);
     float* H = h_state + static_cast<size_t>(h) * state_size * head_dim_ssm;
     const float* K_g = B_in + g * state_size;
     const float* Q_g = C_in + g * state_size;
@@ -735,11 +754,12 @@ void gdn_scan_decode_f32(const float* x, const float* B, const float* C,
                          float* h_state, half* y, const half* z,
                          int n_heads, int head_dim_ssm,
                          int state_size, int n_groups,
-                         cudaStream_t stream) {
+                         cudaStream_t stream,
+                         int grouped_layout) {
     size_t smem = 2 * state_size * sizeof(float) + 2 * sizeof(float);
     gdn_scan_decode_kernel<<<n_heads, head_dim_ssm, smem, stream>>>(
         x, B, C, alpha, beta, A_log, dt_bias, h_state, y, z,
-        n_heads, head_dim_ssm, state_size, n_groups);
+        n_heads, head_dim_ssm, state_size, n_groups, grouped_layout);
 }
 
 void gdn_scan_prefill_f32(const float* x, const float* B, const float* C,
@@ -748,7 +768,8 @@ void gdn_scan_prefill_f32(const float* x, const float* B, const float* C,
                           float* h_state, half* y, const half* z,
                           int n_tokens, int n_heads, int head_dim_ssm,
                           int state_size, int n_groups,
-                          cudaStream_t stream) {
+                          cudaStream_t stream,
+                          int grouped_layout) {
     int inner = n_heads * head_dim_ssm;
     int BC_size = n_groups * state_size;
     size_t smem = 2 * state_size * sizeof(float) + 2 * sizeof(float);
@@ -757,7 +778,7 @@ void gdn_scan_prefill_f32(const float* x, const float* B, const float* C,
             x + t * inner, B + t * BC_size, C + t * BC_size,
             alpha + t * n_heads, beta + t * n_heads,
             A_log, dt_bias, h_state, y + t * inner, nullptr,
-            n_heads, head_dim_ssm, state_size, n_groups);
+            n_heads, head_dim_ssm, state_size, n_groups, grouped_layout);
     }
 }
 

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -11,13 +11,17 @@ namespace imp {
 // conv_f32: [n_tokens, conv_channels] FP32 — full conv+SiLU output per token
 //           layout per token: [Q(BC_size), K(BC_size), V(inner)]
 // ---------------------------------------------------------------------------
+// grouped_layout: 0 = GGUF/tiled (kernel uses g = h % n_groups; default).
+//                 1 = HF SafeTensors/grouped (g = h / (n_heads / n_groups);
+//                     used by Qwen3.5/3.6 NVFP4 SafeTensors).
 void gdn_scan_fused_f32(const float* conv_f32, int conv_channels,
                          const half* alpha, const half* beta,
                          const float* A_log, const float* dt_bias,
                          float* h_state, half* y,
                          int n_tokens, int n_heads, int head_dim_ssm,
                          int state_size, int n_groups,
-                         cudaStream_t stream);
+                         cudaStream_t stream,
+                         int grouped_layout = 0);
 
 // Fused RMSNormGated + SiLU: y = rmsnorm(y) * silu(gate)
 // Processes all tokens × heads in one launch.
@@ -49,7 +53,8 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels,
                              float* h_state, float* y_fp32,
                              int n_tokens, int n_heads, int head_dim_ssm,
                              int state_size, int n_groups,
-                             cudaStream_t stream);
+                             cudaStream_t stream,
+                             int grouped_layout = 0);
 
 // ---------------------------------------------------------------------------
 // Reference multi-token GDN scan.
@@ -64,7 +69,8 @@ void gdn_scan_reference_f32(const float* conv_f32, int conv_channels,
                              float* h_state, half* y,
                              int n_tokens, int n_heads, int head_dim_ssm,
                              int state_size, int n_groups,
-                             cudaStream_t stream);
+                             cudaStream_t stream,
+                             int grouped_layout = 0);
 
 // ---------------------------------------------------------------------------
 // Legacy per-token interfaces (kept for fallback / testing)
@@ -75,7 +81,8 @@ void gdn_scan_decode_f32(const float* x, const float* B, const float* C,
                          float* h_state, half* y, const half* z,
                          int n_heads, int head_dim_ssm,
                          int state_size, int n_groups,
-                         cudaStream_t stream);
+                         cudaStream_t stream,
+                         int grouped_layout = 0);
 
 void gdn_scan_prefill_f32(const float* x, const float* B, const float* C,
                           const half* alpha, const half* beta,
@@ -83,7 +90,8 @@ void gdn_scan_prefill_f32(const float* x, const float* B, const float* C,
                           float* h_state, half* y, const half* z,
                           int n_tokens, int n_heads, int head_dim_ssm,
                           int state_size, int n_groups,
-                          cudaStream_t stream);
+                          cudaStream_t stream,
+                          int grouped_layout = 0);
 
 // V-head reorder: tiled → grouped (FP16 variant, for post-scan y_buf).
 void vhead_tiled_to_grouped(const half* src, half* dst,

--- a/src/graph/executor_ssm_gdn.cu
+++ b/src/graph/executor_ssm_gdn.cu
@@ -447,6 +447,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
             // ~3-4 bits of per-element precision (root cause of Qwen 3.6 L0 drift).
             float* y_fp32 = conv_f32 + static_cast<size_t>(n) * conv_channels;
             float* y_fp32_postnorm = y_fp32 + static_cast<size_t>(n) * n_heads * head_dim_ssm;
+            const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
             gdn_scan_fused_fp32out(conv_f32, conv_channels,
                                 static_cast<const half*>(alpha_proj_out.data),
                                 static_cast<const half*>(beta_proj_out.data),
@@ -454,14 +455,18 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
                                 static_cast<const float*>(ly.ssm_dt_b.data),
                                 static_cast<float*>(h_st),
                                 y_fp32,
-                                n, n_heads, head_dim_ssm, ssize, n_groups, stream);
+                                n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl);
             // FP32-in, FP32-out RMSNorm+Gate+SiLU: preserves precision for the
-            // ssm_out matmul. Ancillary copy to FP16 y_buf only for debug prints.
+            // ssm_out matmul. The FP32→FP16 copy below is REQUIRED, not optional
+            // — the !use_fp32_out path of ssm_out reads y_buf as FP16 input. The
+            // older code gated this on debug_forward_enabled() which left y_buf
+            // uninitialized in production runs (= ssm_out fed zeros) and only
+            // appeared coherent under IMP_DEBUG_FORWARD=1.
             gdn_rmsnorm_gated_silu_fp32inout(y_fp32_postnorm, y_fp32,
                                               static_cast<const half*>(gate_out.data),
                                               static_cast<const half*>(ly.ssm_norm_w.data),
                                               eps, n, n_heads, head_dim_ssm, stream);
-            if (debug_forward_enabled()) {
+            {
                 int64_t total = static_cast<int64_t>(n) * n_heads * head_dim_ssm;
                 int threads_ = 256;
                 int blocks_ = static_cast<int>((total + threads_ - 1) / threads_);
@@ -469,6 +474,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
                     y_fp32_postnorm, static_cast<__half*>(y_buf.data), total);
             }
         } else if (use_ref) {
+            const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
             gdn_scan_reference_f32(conv_f32, conv_channels,
                                 static_cast<const half*>(alpha_proj_out.data),
                                 static_cast<const half*>(beta_proj_out.data),
@@ -476,8 +482,9 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
                                 static_cast<const float*>(ly.ssm_dt_b.data),
                                 static_cast<float*>(h_st),
                                 static_cast<half*>(y_buf.data),
-                                n, n_heads, head_dim_ssm, ssize, n_groups, stream);
+                                n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl);
         } else {
+            const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
             gdn_scan_fused_f32(conv_f32, conv_channels,
                                 static_cast<const half*>(alpha_proj_out.data),
                                 static_cast<const half*>(beta_proj_out.data),
@@ -485,7 +492,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state,
                                 static_cast<const float*>(ly.ssm_dt_b.data),
                                 static_cast<float*>(h_st),
                                 static_cast<half*>(y_buf.data),
-                                n, n_heads, head_dim_ssm, ssize, n_groups, stream);
+                                n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl);
         }
     }
 

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -123,8 +123,31 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
         jobj_get_float(eff, "layer_norm_eps", cfg.rms_norm_eps);
     }
 
-    // RoPE
+    // RoPE. Newer HF configs (Qwen3.5/3.6, Qwen3-Next) move `rope_theta` and
+    // `partial_rotary_factor` under a nested `rope_parameters` object. Read the
+    // top-level keys first (older convention) then fall back to the nested
+    // `rope_parameters.*` to override. Without this, Qwen3.6 silently runs with
+    // theta=10000 instead of 10000000 (1000× wrong base) and full-dim RoPE.
     jobj_get_float(eff, "rope_theta", cfg.rope_theta);
+    float partial_factor = 0.0f;
+    jobj_get_float(eff, "partial_rotary_factor", partial_factor);
+    {
+        const JValue* rope_params = jobj_find(eff, "rope_parameters");
+        if (rope_params && rope_params->type == JType::OBJECT) {
+            jobj_get_float(*rope_params, "rope_theta", cfg.rope_theta);
+            jobj_get_float(*rope_params, "partial_rotary_factor", partial_factor);
+        }
+    }
+    if (partial_factor > 0.0f && partial_factor < 1.0f) {
+        int hd_for_rope = (cfg.head_dim > 0)
+                          ? cfg.head_dim
+                          : (cfg.n_heads > 0 ? cfg.d_model / cfg.n_heads : 0);
+        if (hd_for_rope > 0) {
+            cfg.rope_dim = static_cast<int>(hd_for_rope * partial_factor);
+            IMP_LOG_INFO("Partial RoPE: partial_rotary_factor=%.3f head_dim=%d → rope_dim=%d",
+                         partial_factor, hd_for_rope, cfg.rope_dim);
+        }
+    }
 
     // RoPE scaling (object with type, factor, and optional YaRN/LongRoPE params)
     const JValue* rope_scaling = jobj_find(eff, "rope_scaling");
@@ -221,6 +244,13 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
     //   linear_conv_kernel_dim                         → ssm_conv_kernel
     if (cfg.arch == ModelArch::QWEN36_MOE || cfg.arch == ModelArch::QWEN35_MOE ||
         cfg.arch == ModelArch::QWEN35) {
+        // HF SafeTensors stores GDN heads in grouped order (heads 0..n_v_per_k-1
+        // belong to group 0, etc). The scan kernel's default `g = h % n_groups`
+        // formula assumes the GGUF tiled layout (heads 0..n_groups-1 are replica
+        // 0). Set the flag so executor_ssm_gdn passes grouped_layout=1 to the
+        // kernel for HF-loaded checkpoints.
+        cfg.gdn_grouped_head_layout = true;
+
         int lin_v_heads = 0, lin_v_hdim = 0;
         int lin_k_heads = 0, lin_k_hdim = 0;
         int lin_conv = 0;

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -38,6 +38,12 @@ Model::~Model() {
     }
     host_pinned_allocs_.clear();
 
+    // Free heap-allocated permuted weight buffers (Qwen3.5/3.6 GDN reorder).
+    for (void* ptr : host_owned_buffers_) {
+        if (ptr) std::free(ptr);
+    }
+    host_owned_buffers_.clear();
+
     gpu_weights_ready_ = false;
 
 #ifdef __linux__

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -80,6 +80,9 @@ public:
     std::vector<void*> gpu_allocations_;
     std::vector<void*> host_pinned_;        // mmap regions pinned via cudaHostRegister
     std::vector<void*> host_pinned_allocs_; // cudaHostAlloc'd expert buffers (WSL2 DMA path)
+    // Heap-allocated buffers used to hold permuted weight copies (e.g. Qwen3.5/3.6
+    // GDN head reordering grouped→tiled). Freed with std::free() in destructor.
+    std::vector<void*> host_owned_buffers_;
 };
 
 } // namespace imp

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -37,6 +37,13 @@ struct ModelConfig {
     int ssm_group_count = 0;    // 8
     int ssm_inner_size = 0;     // 4096
     int ssm_dt_rank = 0;        // 64
+    // Asymmetric-head GDN (n_v_heads > n_k_heads) head storage layout.
+    // false (default): heads in tiled order (h % n_groups gives group_id).
+    //                  GGUF Qwen3.5/3.6 converters use this layout.
+    // true:            heads in grouped order (h / n_v_per_k gives group_id).
+    //                  HF SafeTensors Qwen3.5/3.6 use this. Set by the
+    //                  SafeTensors loader; GGUF loader leaves it false.
+    bool gdn_grouped_head_layout = false;
     int rope_dim = 0;           // 0 = full head_dim, 84 = partial
     bool rope_neox = true;      // true = NeoX/split (i, i+d/2), false = interleaved (2i, 2i+1)
 

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -231,7 +231,13 @@ static bool upload_weight(Tensor& weight, QType qtype,
                           QType compute_dtype,
                           cudaStream_t stream,
                           std::vector<void*>& gpu_allocs,
-                          bool raw_quant = true) {
+                          bool raw_quant = true,
+                          float weight_offset = 0.0f) {
+    // weight_offset: added to each FP32 element BEFORE FP16 conversion. Only
+    // applied on BF16-source paths (qtype==BF16 or qtype==F32/NONE with
+    // weight.qtype==BF16). F32-source paths leave it unused — GGUF norms
+    // already carry the offset baked in by the converter; SafeTensors stores
+    // the delta `W` (where actual gamma = 1 + W) for Qwen3.5/3.6 block norms.
     if (weight.data == nullptr || weight.on_device) return true;
     if (weight.ndim < 1) return true;
 
@@ -561,6 +567,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
             uint32_t bits = static_cast<uint32_t>(src[i]) << 16;
             float f;
             std::memcpy(&f, &bits, sizeof(float));
+            f += weight_offset;
             h_fp16[i] = float_to_fp16(f);
         }
         size_t bytes = static_cast<size_t>(n_elem) * sizeof(uint16_t);
@@ -585,6 +592,7 @@ static bool upload_weight(Tensor& weight, QType qtype,
                 uint32_t bits = static_cast<uint32_t>(src[i]) << 16;
                 float f;
                 std::memcpy(&f, &bits, sizeof(float));
+                f += weight_offset;
                 h_fp16[i] = float_to_fp16(f);
             }
             size_t bytes = static_cast<size_t>(n_elem) * sizeof(uint16_t);
@@ -697,6 +705,11 @@ struct UploadCtx {
     std::vector<void*>& gpu_allocs;
     std::vector<void*>& host_pinned;
     std::vector<void*>& host_pinned_allocs;
+    // Architecture-specific norm-weight offset. Qwen3.5/3.6 SafeTensors stores
+    // block-norm gammas as deltas (gamma = 1 + W) while GGUF bakes the +1 in
+    // at conversion time. Applied only on BF16-source paths in upload_weight().
+    // Set to 1.0f for QWEN35[_MOE]/QWEN36_MOE, 0.0f otherwise.
+    float arch_norm_offset = 0.0f;
 };
 
 // ---------------------------------------------------------------------------
@@ -918,12 +931,34 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i,
         }
     }
 
-    // Attention norm (typically F32/F16, no quant)
-    UPLOAD_UNQUANT_OR_FAIL(L.attn_norm, "attn_norm", i, ctx);
+    // Attention norm (typically F32/F16, no quant). For Qwen3.5/3.6
+    // SafeTensors, the BF16 weight stores `W` (delta from 1.0) and the actual
+    // gamma is `1 + W`; ctx.arch_norm_offset bakes that +1 in during BF16→FP16
+    // conversion. GGUF F32 norms already carry the offset and are unaffected.
+    if (L.attn_norm.data && !L.attn_norm.on_device) {
+        if (!upload_weight(L.attn_norm, QType::NONE, ctx.compute_dtype,
+                           ctx.stream, ctx.gpu_allocs, true, ctx.arch_norm_offset)) {
+            IMP_LOG_ERROR("Failed to upload attn_norm for layer %d", i);
+            return false;
+        }
+    }
 
-    // QK-norm weights (Qwen3-style per-head RMSNorm, F32 [head_dim])
-    UPLOAD_UNQUANT_OR_FAIL(L.attn_q_norm, "attn_q_norm", i, ctx);
-    UPLOAD_UNQUANT_OR_FAIL(L.attn_k_norm, "attn_k_norm", i, ctx);
+    // QK-norm weights (Qwen3-style per-head RMSNorm, F32 [head_dim]).
+    // Qwen3.5/3.6 also use the `1 + W` convention here.
+    if (L.attn_q_norm.data && !L.attn_q_norm.on_device) {
+        if (!upload_weight(L.attn_q_norm, QType::NONE, ctx.compute_dtype,
+                           ctx.stream, ctx.gpu_allocs, true, ctx.arch_norm_offset)) {
+            IMP_LOG_ERROR("Failed to upload attn_q_norm for layer %d", i);
+            return false;
+        }
+    }
+    if (L.attn_k_norm.data && !L.attn_k_norm.on_device) {
+        if (!upload_weight(L.attn_k_norm, QType::NONE, ctx.compute_dtype,
+                           ctx.stream, ctx.gpu_allocs, true, ctx.arch_norm_offset)) {
+            IMP_LOG_ERROR("Failed to upload attn_k_norm for layer %d", i);
+            return false;
+        }
+    }
 
     // Attention biases (Qwen2-style Q/K/V biases, F32)
     for (auto* bias : {&L.q_bias, &L.k_bias, &L.v_bias}) {
@@ -1003,8 +1038,16 @@ static bool upload_layer_ffn_weights(TransformerLayer& L, int i,
         }
     }
 
-    // FFN norm (typically F32/F16, no quant)
-    UPLOAD_UNQUANT_OR_FAIL(L.ffn_norm, "ffn_norm", i, ctx);
+    // FFN norm (typically F32/F16, no quant). Qwen3.5/3.6 SafeTensors stores
+    // it as delta `W` (actual gamma = 1 + W); ctx.arch_norm_offset adds the +1
+    // during BF16→FP16 conversion. GGUF F32 norms unaffected.
+    if (L.ffn_norm.data && !L.ffn_norm.on_device) {
+        if (!upload_weight(L.ffn_norm, QType::NONE, ctx.compute_dtype,
+                           ctx.stream, ctx.gpu_allocs, true, ctx.arch_norm_offset)) {
+            IMP_LOG_ERROR("Failed to upload ffn_norm for layer %d", i);
+            return false;
+        }
+    }
 
     // MoE gate (routing weights, typically F32/F16)
     UPLOAD_UNQUANT_OR_FAIL(L.moe_gate, "moe_gate", i, ctx);
@@ -1064,8 +1107,18 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i,
     // as F32 (sign/exponent/mantissa all wrong) and produced NaN within the
     // first GDN layer. Convert on host before upload so the scan always sees
     // real FP32 values.
+    // ssm_a needs an extra HF-vs-GGUF transform: imp's GDN scan kernel computes
+    //   g = exp(A_log * softplus(alpha + dt_bias))
+    // which matches GGUF semantics — the Unsloth/llama.cpp converter pre-applies
+    // `-exp()` to the original HF A_log so kernel reads the post-transform value.
+    // HF SafeTensors carries the RAW HF `A_log` (mean ~3.3 positive). Without
+    // applying `-exp()` at load time, the kernel produces exp(positive*positive)
+    // and the recurrent state grows exponentially → garbage decode.
+    // Verified: GGUF[i] == -exp(NVFP4_A_log_HF[head_perm(i)]) elementwise on L0.
     for (Tensor* t : {&L.ssm_a, &L.ssm_d, &L.ssm_dt_b}) {
         if (!t->data || t->on_device) continue;
+        const bool is_ssm_a_hf = (t == &L.ssm_a) &&
+                                 (t->qtype == QType::BF16 || t->qtype == QType::F16);
         const int64_t n_elem = t->numel();
         const size_t fp32_bytes = static_cast<size_t>(n_elem) * sizeof(float);
         void* d_data = nullptr;
@@ -1075,32 +1128,44 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i,
             return false;
         }
 
+        std::vector<float> h_fp32(static_cast<size_t>(n_elem));
         if (t->qtype == QType::F32 || t->qtype == QType::NONE) {
-            // GGUF path — already FP32.
+            // GGUF path — already FP32, ssm_a already pre-transformed by converter.
             h2d_copy(d_data, t->data, fp32_bytes, ctx.stream);
+            ctx.gpu_allocs.push_back(d_data);
+            t->data = d_data;
+            t->qtype = QType::F32;
+            t->on_device = true;
+            continue;
         } else if (t->qtype == QType::BF16) {
-            // SafeTensors path — convert BF16 → F32 on host.
-            std::vector<float> h_fp32(static_cast<size_t>(n_elem));
             const uint16_t* src = static_cast<const uint16_t*>(t->data);
             for (int64_t k = 0; k < n_elem; ++k) {
                 uint32_t bits = static_cast<uint32_t>(src[k]) << 16;
                 std::memcpy(&h_fp32[k], &bits, sizeof(float));
             }
-            h2d_copy(d_data, h_fp32.data(), fp32_bytes, ctx.stream);
         } else if (t->qtype == QType::F16) {
-            // Defensive: F16 weight → F32 (no model emits this for SSM scalars
-            // currently, but keep symmetric with BF16).
-            std::vector<float> h_fp32(static_cast<size_t>(n_elem));
             const uint16_t* src = static_cast<const uint16_t*>(t->data);
             for (int64_t k = 0; k < n_elem; ++k) {
                 h_fp32[k] = fp16_to_float(src[k]);
             }
-            h2d_copy(d_data, h_fp32.data(), fp32_bytes, ctx.stream);
         } else {
             IMP_LOG_ERROR("SSM scalar tensor has unexpected qtype %u (layer %d)",
                           static_cast<unsigned>(t->qtype), i);
             return false;
         }
+
+        // Apply HF-to-GGUF A_log transform: A_log_GGUF = -exp(A_log_HF).
+        // Only for ssm_a, only when source is BF16/F16 (= HF SafeTensors path).
+        if (is_ssm_a_hf) {
+            for (int64_t k = 0; k < n_elem; ++k) {
+                h_fp32[k] = -std::exp(h_fp32[k]);
+            }
+            if (i == 0) {
+                IMP_LOG_INFO("HF GDN A_log: applied -exp() transform to ssm_a (layer 0 first 4 values: %.4f %.4f %.4f %.4f)",
+                             h_fp32[0], h_fp32[1], h_fp32[2], h_fp32[3]);
+            }
+        }
+        h2d_copy(d_data, h_fp32.data(), fp32_bytes, ctx.stream);
 
         ctx.gpu_allocs.push_back(d_data);
         t->data = d_data;
@@ -1622,8 +1687,17 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream,
                       total_mem / (1024.0 * 1024.0 * 1024.0));
     }
 
+    // Qwen3.5/3.6 SafeTensors stores block-norm gammas as deltas (gamma = 1+W).
+    // GGUF stores the post-+1 values directly. We bake the +1 in during the
+    // BF16→FP16 upload conversion; F32-source norms (GGUF) are unaffected.
+    const float arch_norm_offset =
+        (config_.arch == ModelArch::QWEN35 ||
+         config_.arch == ModelArch::QWEN35_MOE ||
+         config_.arch == ModelArch::QWEN36_MOE)
+        ? 1.0f : 0.0f;
     UploadCtx ctx{compute_dtype, stream, gpu_allocations_,
-                  host_pinned_, host_pinned_allocs_};
+                  host_pinned_, host_pinned_allocs_,
+                  arch_norm_offset};
 
     // --- Embeddings, output norm, output projection ---
     if (!upload_embeddings_and_output(tok_emb_, out_norm_, out_proj_, ctx)) {


### PR DESCRIPTION
## Summary

End-to-end Qwen3.6-35B-A3B-NVFP4 was emitting garbage tokens (default flags collapsed to repeated `<|im_start|>` via a CUDA-graph-capture failure cascade). Per-layer hidden-state diff vs the Qwen3.6-Q4_K_M GGUF oracle revealed the HF SafeTensors path silently mishandled **six independent items** the GGUF converter had absorbed at conversion time.

Result: `Qwen3.6-NVFP4 "The capital of France is" → " Paris. The capital of France is Paris."` matching the GGUF oracle, all 40 layers >0.99 correlation.

## The six bugs

1. **RMSNorm `(1+W)` convention** — HF stores delta `W` (init=zeros, applies `x * (1 + W)`); GGUF bakes the `+1` in. imp's SafeTensors loader read deltas (mean_abs ~0.04) directly → 25× too small norm gain. Fix: `UploadCtx::arch_norm_offset` applied during BF16→FP16 conversion of `attn_norm`/`ffn_norm`/`attn_q_norm`/`attn_k_norm` for QWEN35*/QWEN36_MOE.

2. **GDN heads grouped vs tiled** — HF stores GDN heads grouped (heads 0,1=group 0; 2,3=group 1; …); GGUF stores tiled. Scan kernel hardcoded `g = h % n_groups` (tiled-only). Fix: `int grouped_layout` param threaded through all three GDN scan kernels; selects between `h / n_v_per_k` (grouped/HF) and `h % n_groups` (tiled/GGUF). `cfg.gdn_grouped_head_layout` set in HF config loader.

3. **`partial_rotary_factor` ignored** — Qwen3.6 needs `rope_dim = head_dim*0.25 = 64`. imp had no read → `cfg.rope_dim=0` → full 256-dim RoPE applied to every attention layer.

4. **`rope_theta` lives at `text_config.rope_parameters.rope_theta`** — actual value 10000000 nested under `rope_parameters`; imp fell back to default 10000 → **1000× wrong RoPE base**.

5. **`A_log` HF→GGUF math transform missing** — HF: `g = -exp(A_log) * softplus(...)`, with `exp(g)` applied inside `chunk_gated_delta_rule`. GGUF stores `ssm_a = -exp(A_log_HF)` pre-applied, so imp's kernel formula `exp(A * softplus(...))` is correct *iff* A is pre-transformed. For raw HF (`A_log` mean ~3.3 positive) the kernel computed `exp(positive*positive)` → recurrent state grew exponentially → garbage. Fix: apply `value = -exp(value)` to `ssm_a` only on the BF16/F16-source path. Element-wise verified: `GGUF[i] == -exp(NVFP4_A_log_HF[head_perm(i)])`.

6. **`fp32_scan` path required `debug_forward=true` to populate `y_buf`** — the FP32→FP16 copy that fills the FP16 ssm_out input was gated on `debug_forward_enabled()`, leaving `y_buf` uninitialized in production runs. Diagnostic flag was masking a correctness bug. Fix: always run the conversion when fp32_scan is active.

## Verification

Per-layer correlation NVFP4 vs GGUF Q4_K_M (n=5 prefill, `gdn.fp32_scan=true`):

| Layer | corr | rmse |
|---|---|---|
| L0 (GDN) | 0.9991 | 0.0008 |
| L1 (GDN) | 0.9990 | 0.0010 |
| L2 (GDN) | 0.9990 | 0.0014 |
| L3 (Attn) | 0.9970 | 0.0028 |

Per-layer error sits at Q4_K_M quant noise floor (~0.1-0.3%). All 40 layers correlate >0.99 with the GGUF oracle.

End-to-end with **default flags**:

```
docker run --rm --gpus all -v /home/kekz/models:/home/kekz/models:ro imp:bringup \
  imp-cli --model /home/kekz/models/Qwen3.6-35B-A3B-NVFP4 \
  --prompt "The capital of France is" --max-tokens 16 --temperature 0 --seed 0 \
  --chat-template none
# →  Paris. The capital of France is Paris.
```

Decode: ~25 tok/s on RTX 5090 (35B-A3B GDN+MoE, 8 active experts of 256, 30 GDN + 10 attention layers).

Regression-clean:
- Mistral-Small-3.2-NVFP4 → " Paris. It is the capital of France and the country..."
- Qwen3-Coder-30B-A3B-FP4 → " Paris. The capital of Belgium is Brussels..."

## Lessons for future HF-loader audits

The pattern (six bugs in a single drill) suggests the right preventive workflow:

1. **`grep` discipline.** Bugs 3+4 were trivially missing reads. A sweep:
   ```bash
   for f in $(jq -r '.text_config | keys[]' config.json); do
       grep -q "\"$f\"" src/model/hf_config_loader.cpp || echo "MISSING: $f"
   done
   ```
   would have caught them in seconds. (Caveat: bug 4's nested location won't show up — needs recursive flatten.)

2. **HF source as oracle, not GGUF.** Bugs 1+5 were math-convention transforms the GGUF converter pre-applies. imp's GGUF math worked, but only because it consumed already-transformed inputs. Verifying against `Qwen3_5MoeRMSNorm.forward()` and `Qwen3_5MoeLinearAttention.forward()` directly would have caught both.

3. **Diagnostic flags can mask production bugs.** Bug 6 only fired without `debug_forward`. End-to-end coherence checks must run with default flags before declaring a fix done.

## Test plan

- [x] Qwen3.6-NVFP4 produces "Paris. The capital of France is Paris." with default flags
- [x] All 40 layers correlate >0.99 vs GGUF Q4_K_M reference
- [x] Mistral-Small-3.2-NVFP4 still produces coherent output
- [x] Qwen3-Coder-30B-A3B-FP4 still produces coherent output
- [ ] CI green (will trigger on push)
- [ ] Add `LlmCompressorE2E.Qwen36_Paris` test in follow-up PR (mirroring Mistral/Gemma-4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)