### PR TITLE
fix(nvfp4): unlock decode fast-path for prequant MoE (Qwen3.6 + Gemma-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ imp/
 │   ├── imp-server/       # OpenAI-compatible HTTP server (SSE streaming)
 │   └── imp-bench/        # Benchmark tool: GEMM, attention, end-to-end
 ├── third_party/stb/      # stb_image headers (image loading for vision)
-├── tests/                # Google Test suite (58 test files, 606 tests)
+├── tests/                # Google Test suite (63 test files, ~700 tests)
 ├── scripts/              # verify.sh, gen_perf_baseline.sh, pre-push.hook, imp-pull.py
 ├── docs/                 # SM120 status, MXFP4, Qwen3.6 roadmap, gemv plan, layer-diff dumps
 ├── cmake/                # Custom CMake modules (CompilerFlags, FindCUDAToolkit131)
@@ -145,8 +145,9 @@ make install-hooks       # install pre-push hook → runs verify-fast on src/inc
 
 # Host build (no Docker)
 cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)
-./build/imp-tests                                  # 606 tests across 58 files
+./build/imp-tests                                  # ~700 tests across 63 files
 ./build/imp-tests --gtest_filter="TensorTest.*"    # specific suite
+./build/imp-tests --gtest_filter="LlmCompressorE2E.*"   # NVFP4 SafeTensors prequant (Mistral, Gemma-4, Qwen-Coder-30B, Qwen3.6)
 ```
 
 Test files live in `tests/` (Google Test). Most CUDA tests require sm_120; CPU-only tests are filtered by `make test-unit`.
@@ -242,7 +243,7 @@ Live baselines: `tests/perf_baseline.json` (consumed by the verify gate). Refres
 Runtime dispatch (SM120 only, no architecture checks):
 - **Prefill**: MXFP4 FMHA (`attention_fmha_mxfp4_sm120.cu`, if enabled) → FP8 FMHA (`attention_fmha_sm120.cu`) → FP16 FMHA → Blackwell WMMA 128x64 (`attention_blackwell.cu`)
 - **Decode**: Paged attention with split-K (`attention_paged.cu`, `attention_paged_fp8.cu`)
-- Environment overrides: `IMP_MXFP4_ATTENTION=1` (enable MXFP4), `IMP_NO_FP8_FMHA=1` (force FP16), `IMP_NO_FMHA_SM120=1` (force WMMA fallback)
+- Overrides via `imp.conf`: `attention.mxfp4 = "always"` (force MXFP4 prefill), `attention.fp8_fmha = "never"` (force FP16), `attention.fmha_sm120 = "never"` (force WMMA fallback). Per-run via `--set` CLI flag. Legacy `IMP_MXFP4_ATTENTION` / `IMP_NO_FP8_FMHA` / `IMP_NO_FMHA_SM120` env vars still work as dev escape hatches in `attention_dispatch.cu` but are no longer the supported interface.
 
 ### Quantization Support
 - **FP8 E4M3**: Per-tensor scale, FP8 GEMM via cuBLAS
@@ -250,6 +251,8 @@ Runtime dispatch (SM120 only, no architecture checks):
 - **INT4 (Q4_0, Q4_K_M)**: GGML-compatible block formats
 - **NVFP4 (FP4_E2M1)**: Blackwell-native, two-level micro-scale + tensor-scale
 - **NVFP4 Prequant (Model Optimizer)**: SafeTensors models with calibrated NVFP4 weights (AWQ/SmoothQuant). Loaded directly — no re-quantization. BF16 non-quantized weights (norms, router, embeddings) auto-converted to FP16.
+  - **Shape convention**: SafeTensors NVFP4 `weight` arrives as `U8` (loader → INT8 → Phase-0 promote → NVFP4) with `shape[1] = K_logical/2` (two FP4 nibbles per byte). Phase-0 promote in `executor_pre_dequant.cu` only changes qtype + populates `.scales` / `.tensor_scale` sidecars — it does **not** change shape. Existing dispatch in `executor_attention.cu` / `executor_ffn.cu` recovers logical K via `tmp.K = hw->shape[1] * 2`.
+  - **MoE path**: For SafeTensors prequant the loader writes per-expert tensors only (`expert_w_*[e]`); `expert_*_packed.data` is null. `cache_moe_native_nvfp4` (`executor_pre_dequant.cu`) builds one contiguous `[ne, N, K_packed]` packed buffer per layer per projection by D2D-memcpy from the per-expert tensors, populates `wcache_.nvfp4_moe`, and frees the per-expert allocations inline (the legacy fallback can't reach a layer where `nvfp4_moe_*_ptr` is non-null, and keeping both copies wouldn't fit in 32 GiB on Qwen3.6-35B-A3B). Without this path the legacy FP16 dequant + cuBLAS sm_80 WMMA fallback fires per layer per token, killing CUDA Graphs.
 
 ### Gated DeltaNet (GDN) — Qwen3.5
 Hybrid architecture: 24 GDN layers (recurrent) + 8 attention layers + 32 dense FFN layers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ Hybrid architecture: 24 GDN layers (recurrent) + 8 attention layers + 32 dense F
 ### CUDA 13.2 Features
 - **Green Contexts**: SM partitioning for concurrent prefill/decode (`green_ctx.cu`)
 - **PDL (Programmatic Dependent Launch)**: Overlaps kernel tails with next kernel heads (`pdl.cu`)
-- **CUDA Graphs**: Captured decode iterations for reduced launch overhead (`cuda_graph.cu`). Disabled for MoE models (routing requires D2H memcpy incompatible with graph capture).
+- **CUDA Graphs**: Captured decode iterations for reduced launch overhead (`cuda_graph.cu`). NVFP4-prequant MoE models (Qwen3.6, Gemma-4 llm-compressor NVFP4) capture cleanly — `cache_moe_native_nvfp4` builds the contiguous per-layer expert buffer and the decode fast-path runs entirely device-side (no D2H expert-offsets sync). GGUF MoE decode still falls through the legacy expert-routing path with a D2H sync per layer per token and is graph-incompatible. Prefill is never captured (variable n).
 
 ### Supported Model Architectures
 - LLaMA (dense transformer)

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -107,7 +107,8 @@ static bool can_decode_fast(int n, const Tensor& expert_up_packed,
             (up_qtype == QType::Q6_K || up_qtype == QType::Q8_0 ||
              up_qtype == QType::Q4_0 || up_qtype == QType::Q4_K ||
              up_qtype == QType::Q5_K || up_qtype == QType::Q2_K ||
-             up_qtype == QType::Q3_K || up_qtype == QType::Q5_1));
+             up_qtype == QType::Q3_K || up_qtype == QType::Q5_1 ||
+             up_qtype == QType::NVFP4));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1431,11 +1431,190 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             nvfp4_moe_count++;
         };
 
+        // NVFP4-prequant SafeTensors path: experts arrive as per-expert tensors
+        // (expert_w_gate[e] / expert_w_up[e] / expert_w_down[e]) with NVFP4
+        // qtype + .scales / .tensor_scale sidecars promoted in Phase 0. The 3D
+        // expert_*_packed tensors are NULL (the loader only stamps them for
+        // GGUF and Gemma-4). Without this branch, cache_moe_expert_nvfp4 would
+        // early-return at `!packed.data` and the legacy FP16 dequant + cuBLAS
+        // sm_80 WMMA fallback fires per layer per token, killing CUDA Graphs.
+        //
+        // We allocate one contiguous packed_data + micro_scales + tensor_scales
+        // buffer per layer per projection, copy the per-expert pointers in,
+        // and stamp `packed.data` so wcache lookups (line below the layer loop)
+        // and the consumer dispatch in executor_forward_moe.cu (lookup via
+        // expert_*_packed.data) wire up automatically. After a successful copy
+        // for a layer the per-expert allocations are freed inline — at 35B-A3B
+        // the duplicate (per-expert + contiguous) would peak at ~30 GiB which
+        // doesn't fit in 32 GiB, and the legacy fallback can't fire for layers
+        // where nvfp4_moe_*_ptr is non-null anyway.
+        auto cache_moe_native_nvfp4 = [&](Tensor& packed,
+                                          std::vector<Tensor>& experts) -> bool {
+            if (experts.empty() || !experts[0].data) return false;
+            if (experts[0].qtype != QType::NVFP4 || experts[0].scales == nullptr) return false;
+            if (packed.data && wcache_.nvfp4_moe.count(packed.data)) return false;
+            if (moe_budget_exhausted) return false;
+
+            int ne = static_cast<int>(experts.size());
+            // SafeTensors NVFP4 prequant: per-expert weight tensor on-disk
+            // dtype is U8 (loader → INT8 → Phase-0 promote → NVFP4) and shape
+            // is [N, K_packed] where K_packed = K_logical/2 (two FP4 nibbles
+            // per byte). The same packed-shape convention is what the
+            // existing executor_attention.cu / executor_ffn.cu NVFP4 dispatch
+            // expects when computing `tmp.K = hw->shape[1] * 2`. Match that.
+            int64_t N        = experts[0].shape[0];
+            int64_t K_packed = experts[0].shape[1];
+            int64_t K        = K_packed * 2;          // logical inner dim
+            if (K % 16 != 0) return false;
+
+            size_t expert_packed_bytes = static_cast<size_t>(N) * K_packed;
+            size_t expert_ms_bytes     = static_cast<size_t>(N) * (K / 16);
+            size_t total_packed = static_cast<size_t>(ne) * expert_packed_bytes;
+            size_t total_ms     = static_cast<size_t>(ne) * expert_ms_bytes;
+            size_t total_ts     = static_cast<size_t>(ne) * sizeof(float);
+            size_t add_bytes    = total_packed + total_ms + total_ts;
+
+            // Refresh free memory before each allocation. Per-layer free of
+            // expert_w_*[e] returns ~one-layer-worth back to the device pool
+            // after each successful build, but `moe_budget` was computed once
+            // at function entry. Re-read free memory to pick up the freed
+            // bytes; otherwise the contiguous cache stops at ~110/120 tensors
+            // (33 layers + partial 33) for Qwen3.6-35B-A3B.
+            {
+                size_t free_mem = 0, total_mem = 0;
+                IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
+                constexpr size_t kMoeReserve = 128ULL * 1024 * 1024;
+                size_t avail = (free_mem > kMoeReserve) ? (free_mem - kMoeReserve) : 0;
+                if (add_bytes > avail) {
+                    moe_budget_exhausted = true;
+                    IMP_LOG_INFO("NVFP4 MoE native cache: VRAM budget reached after %d "
+                                 "tensors (%.1f MiB cached, %.1f MiB free, need %.1f MiB)",
+                                 nvfp4_moe_count,
+                                 nvfp4_moe_total / (1024.0 * 1024.0),
+                                 free_mem / (1024.0 * 1024.0),
+                                 add_bytes / (1024.0 * 1024.0));
+                    return false;
+                }
+            }
+
+            void* d_packed = vram_alloc(vram_alloc_, total_packed,
+                                         "nvfp4_moe_packed_native");
+            void* d_ms     = vram_alloc(vram_alloc_, total_ms,
+                                         "nvfp4_moe_ms_native");
+            void* d_ts_raw = vram_alloc(vram_alloc_, total_ts,
+                                         "nvfp4_moe_ts_native");
+            if (!d_packed || !d_ms || !d_ts_raw) {
+                if (d_packed) vram_free(vram_alloc_, d_packed);
+                if (d_ms)     vram_free(vram_alloc_, d_ms);
+                if (d_ts_raw) vram_free(vram_alloc_, d_ts_raw);
+                moe_budget_exhausted = true;
+                return false;
+            }
+            float* d_ts = static_cast<float*>(d_ts_raw);
+
+            std::vector<float> h_ts(ne);
+            for (int e = 0; e < ne; ++e) {
+                const auto& w = experts[e];
+                if (w.shape[0] != N || w.shape[1] != K_packed ||
+                    !w.data || !w.scales) {
+                    IMP_LOG_WARN("NVFP4 MoE native: expert %d shape/data mismatch, "
+                                 "rolling back layer", e);
+                    vram_free(vram_alloc_, d_packed);
+                    vram_free(vram_alloc_, d_ms);
+                    vram_free(vram_alloc_, d_ts_raw);
+                    return false;
+                }
+                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(
+                    static_cast<char*>(d_packed) + static_cast<size_t>(e) * expert_packed_bytes,
+                    w.data, expert_packed_bytes,
+                    cudaMemcpyDeviceToDevice, stream));
+                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(
+                    static_cast<char*>(d_ms) + static_cast<size_t>(e) * expert_ms_bytes,
+                    w.scales, expert_ms_bytes,
+                    cudaMemcpyDeviceToDevice, stream));
+                h_ts[e] = w.tensor_scale;
+            }
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_ts, h_ts.data(), total_ts,
+                                                cudaMemcpyHostToDevice, stream));
+
+            NvFP4MoEQuantResult r;
+            r.packed_data = d_packed;
+            r.micro_scales = d_ms;
+            r.tensor_scales = d_ts;
+            r.n_experts = ne;
+            r.N = N;
+            r.K = K;
+            r.expert_stride_packed = expert_packed_bytes;
+            r.expert_stride_ms = expert_ms_bytes;
+
+            // Stamp the packed Tensor so wcache_.nvfp4_moe key + consumer
+            // wiring (expert_*_packed.data lookup) work uniformly with the
+            // GGUF path. Logical K (NOT K/2) per cache_moe_expert_nvfp4
+            // convention at shape[2].
+            int64_t shape[3] = {static_cast<int64_t>(ne), N, K};
+            packed = Tensor(d_packed, QType::NVFP4, 3, shape, /*on_device=*/true);
+
+            wcache_.nvfp4_moe[d_packed] = r;
+            nvfp4_moe_total += add_bytes;
+            nvfp4_moe_count++;
+
+            // Free per-expert GPU allocations now — the legacy fallback path
+            // (executor_forward_moe.cu:expert_gemm + chunked_dequant_gemm) can
+            // no longer fire for this layer because nvfp4_moe_*_ptr is non-null
+            // after the cache populates and stamps `packed`. Without freeing,
+            // we hold the same NVFP4 weights twice (per-expert + contiguous);
+            // the duplicate exhausts VRAM around layer 33 of Qwen3.6-35B-A3B
+            // and breaks layers 33-39's fast path. Per-layer free keeps total
+            // overhead bounded — only the just-copied 384 expert pointers are
+            // released, and only after the contiguous copy succeeded.
+            //
+            // Sync the stream so the in-flight D2D copies (which read from
+            // experts[e].data / .scales) finish before we cudaFree the source.
+            IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+            auto* mut_model = const_cast<Model*>(model_);
+            for (int e = 0; e < ne; ++e) {
+                auto& w = experts[e];
+                if (w.data) {
+                    mut_model->release_gpu_allocation(w.data);
+                    IMP_CUDA_CHECK_LOG(cudaFree(w.data));
+                    w.data = nullptr;
+                    w.on_device = false;
+                }
+                if (w.scales) {
+                    mut_model->release_gpu_allocation(w.scales);
+                    IMP_CUDA_CHECK_LOG(cudaFree(w.scales));
+                    w.scales = nullptr;
+                }
+            }
+            return true;
+        };
+
         for (int i = 0; i < cfg.n_layers; i++) {
-            const auto& L = model_->layer(i);
-            cache_moe_expert_nvfp4(L.expert_gate_packed, L.expert_gate_packed.qtype);
-            cache_moe_expert_nvfp4(L.expert_up_packed,   L.expert_up_packed.qtype);
-            cache_moe_expert_nvfp4(L.expert_down_packed,  L.expert_down_packed.qtype);
+            // Need mutable access to expert_*_packed for cache_moe_native_nvfp4
+            // to stamp the contiguous buffer pointer. const_cast follows the
+            // existing pattern at e.g. lines 1517 / 1598 of weight_upload.cu.
+            auto& L = const_cast<Model*>(model_)->layer(i);
+
+            bool g = false, u = false, d = false;
+            if (cfg.is_nvfp4_prequant) {
+                g = cache_moe_native_nvfp4(L.expert_gate_packed, L.expert_w_gate);
+                u = cache_moe_native_nvfp4(L.expert_up_packed,   L.expert_w_up);
+                d = cache_moe_native_nvfp4(L.expert_down_packed, L.expert_w_down);
+                if ((g || u || d) && !(g && u && d)) {
+                    IMP_LOG_WARN("Layer %d: partial NVFP4 MoE native cache "
+                                 "(g=%d u=%d d=%d) — fast path may not engage",
+                                 i, (int)g, (int)u, (int)d);
+                }
+            }
+
+            // GGUF / re-quant path: only run when native didn't populate.
+            // For GGUF NVFP4-target models the source qtype is Q*_K/Q8_0 and
+            // packed.data is non-null; for prequant SafeTensors all three
+            // native calls succeeded above and these are no-ops because
+            // packed.data now points into wcache_.nvfp4_moe.
+            if (!g) cache_moe_expert_nvfp4(L.expert_gate_packed, L.expert_gate_packed.qtype);
+            if (!u) cache_moe_expert_nvfp4(L.expert_up_packed,   L.expert_up_packed.qtype);
+            if (!d) cache_moe_expert_nvfp4(L.expert_down_packed, L.expert_down_packed.qtype);
         }
 
         if (nvfp4_moe_count > 0) {

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -536,8 +536,27 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
             config_.use_fp8_prefill = 0;
         }
         if (config_.use_nvfp4_decode) {
-            IMP_LOG_INFO("Gemma 4: disabling NVFP4 decode cache (per-layer head_dim not yet supported)");
-            config_.use_nvfp4_decode = 0;
+            // Prequant SafeTensors NVFP4 weights are already in NVFP4 layout on
+            // disk. Phase 3a (Q*_K → NVFP4 conversion) and Phase 3b
+            // (NVFP4 → CUTLASS sm_120) iterate `wcache_.nvfp4` which stays
+            // empty for prequant, so they are no-ops. Phase 3-MoE (the
+            // cache_moe_native_nvfp4 lambda in executor_pre_dequant.cu) IS
+            // load-bearing — it builds the contiguous per-layer expert buffer
+            // that lights up the M=1 decode fast path (gemv_nvfp4_*) and lets
+            // CUDA Graphs capture decode without D2H expert_offsets sync.
+            // Disabling it for Gemma-4 prequant forces the legacy FP16
+            // fallback (sm_80 WMMA + per-layer D2H sync), which both
+            // tanks decode tok/s and breaks graph capture. The "per-layer
+            // head_dim" caveat applies to attention CUTLASS paths, not MoE
+            // experts, so leaving the cache enabled is safe for prequant.
+            if (model_->config().is_nvfp4_prequant) {
+                IMP_LOG_INFO("Gemma 4 + NVFP4 prequant: keeping use_nvfp4_decode=%d "
+                             "(Phase 3-MoE cache build needed for fast-path decode)",
+                             config_.use_nvfp4_decode);
+            } else {
+                IMP_LOG_INFO("Gemma 4: disabling NVFP4 decode cache (per-layer head_dim not yet supported)");
+                config_.use_nvfp4_decode = 0;
+            }
         }
         if (config_.dual_path_quant) {
             IMP_LOG_INFO("Gemma 4: disabling dual_path_quant");


### PR DESCRIPTION
## Summary

Unlocks the NVFP4 decode fast-path for **Qwen3.6-35B-A3B-NVFP4** and **Gemma-4-26B-A4B-it-NVFP4** SafeTensors models. Both now produce coherent output with CUDA Graphs captured in decode.

## What was broken

- **Qwen3.6-NVFP4** (already shipped on this branch as `615758a`): three bugs blocked the decode fast-path — `can_decode_fast` whitelist missing NVFP4, no `cache_moe_native_nvfp4` for SafeTensors per-expert NVFP4 layout, and missing per-layer free of per-expert allocations to fit in 32 GiB. tg256 was 8.34 → 142 tok/s.

- **Gemma-4-NVFP4** (this PR's new commit `3901600`): `engine.cpp` was unconditionally setting `use_nvfp4_decode = 0` for any Gemma-4 model to dodge unsupported NVFP4 attention CUTLASS paths under per-layer `head_dim` (256 SWA / 512 global). That over-broad disable also skipped Phase 3-MoE (`cache_moe_native_nvfp4`), forcing the legacy FP16 fallback (sm_80 WMMA + per-layer D2H expert-offsets sync). Consequences: CUDA Graph capture IMA cascade at decode step 1, decode tg ~42 tok/s, output stuck on the user's prompt instead of an answer.

## What changed

- `src/runtime/engine.cpp` (+21/-2): when `model.config().is_nvfp4_prequant` is true for Gemma-4, keep `use_nvfp4_decode` at its auto value. Phase 3a (Q*_K → NVFP4) and Phase 3b (NVFP4 → CUTLASS sm_120) iterate `wcache_.nvfp4`, which is empty for prequant models — they are no-ops. Only Phase 3-MoE does load-bearing work, and that's the single thing the disable was preventing. The "per-layer head_dim" caveat applies to attention CUTLASS kernels, not MoE expert caching.

- `CLAUDE.md`: refresh the CUDA-Graphs note. NVFP4-prequant MoE models capture cleanly post-fix; only legacy GGUF MoE decode (which still does per-layer D2H expert-offsets sync) remains graph-incompatible. Prefill is never captured (variable n).

## Result on Gemma-4-26B-A4B-it-NVFP4 (RTX 5090, default config)

| Metric | Before | After |
|---|---|---|
| Phase-4 wcache `nvfp4_moe` | 0 | 90 (30 layers × 3 projections) |
| CUDA Graph capture step 1 | IMA cascade → fallback | 152 PDL edges, AsyncGraphLoop on |
| MoE prefill: legacy fallback log | every iter | only n>1 prefill batch path |
| Decode tg | 42.86 tok/s | **166 tok/s** (~3.9× speedup) |
| Output | `<channel\|>thought\nThe user is asking…` (stuck) | `<channel\|>thought\n…The capital of France is **Paris**.` |

## Cross-model regression check

- **Qwen3.6-35B-A3B-NVFP4**: tg = 142–155 tok/s, `nvfp4_moe=120`, output coherent — unchanged ✓
- **Gemma-4 GGUF Q8_0 / Q4_K_M**: untouched, runs through the non-prequant `else` branch — preserved ✓
- **Mistral-Small-3.2-NVFP4** (dense, no MoE): not on this code path — unaffected ✓

## Test plan

- [x] Greedy decode `"The capital of France is"` → contains "Paris" (Qwen3.6, 16 tokens)
- [x] Greedy decode `"What is the capital of France?"` → contains "Paris" (Gemma-4, 128 tokens; needs CoT budget)
- [x] Sampled coherence T=0.7 top_p=0.9 256 tokens (both models, Rayleigh-scattering / sky-blue prompt) — coherent prose ✓
- [x] Long-context smoke ~430 prefill tokens — no NVFP4 long-context drift ✓
- [x] Perf sweep at 128 / 1024 / 4096 ctx — both models above plan baseline (Qwen3.6 ≥ 117 tok/s, Gemma-4 ≥ 34 tok/s) ✓
- [x] CUDA Graph capture confirmed via logs (`ConditionalRunner`, `AsyncGraphLoop`) for both ✓

Pre-push verify-fast hook flagged a 3% decode regression on Qwen3-8B Q8_0 — unrelated dense GGUF model, no code path touched by this PR; almost certainly cuBLAS-autotune variance from a warm GPU after extended NVFP4 testing. Bypassed with `--no-verify` per author request after manual cross-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)