### PR TITLE
fix(kv-cache): FP8 KV scale poisoned by warmup; high-water-mark calibration

### DIFF
--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -370,6 +370,18 @@ public:
         kv_calibrated_.assign(n_kv, false);
     }
 
+    // Drop kv_calibrated_ flags so the next prefill (re-)calibrates the FP8
+    // KV per-layer scale and combines it with the existing high-water mark
+    // (kv_scales_) via std::max. Call this after warmup so the first real
+    // prefill can promote the scale if its activations need a wider range
+    // than the synthetic BOS-token warmup observed (broke Llama-3.2-3B with
+    // `--kv-fp8` until 2026-05-01: warmup absmax was too small, real
+    // generation overflowed FP8 dynamic range, output degenerated within
+    // ~30 tokens).
+    void reset_kv_calibration() {
+        std::fill(kv_calibrated_.begin(), kv_calibrated_.end(), false);
+    }
+
     // Set layer offload manager (optional, for weight offloading)
     void set_offload_manager(LayerOffloadManager* mgr) { offload_mgr_ = mgr; }
 

--- a/src/graph/executor_kv_write.cu
+++ b/src/graph/executor_kv_write.cu
@@ -164,6 +164,16 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
             state.max_blocks_per_seq, state.n_sequences);
     } else if (use_fp8) {
         // FP8 E4M3 quantized KV cache write path with online calibration.
+        //
+        // Calibration strategy: high-water-mark per layer. The first prefill
+        // for a given kv_calibrated_ slot sets the initial scale; subsequent
+        // prefills (after Engine::warmup() resets the calibrated_ flag) only
+        // promote the scale if their absmax exceeds the stored value. The
+        // scale is never reduced, which avoids the warmup-pollution failure
+        // mode where synthetic BOS tokens produced a too-small scale and
+        // real generation overflowed FP8_MAX (was: Llama-3.2-3B with
+        // --kv-fp8 → " France, and, 2008, 201, …"; now: " The capital of
+        // Italy is Rome…").
         float inv_scale;
         if (!kv_calibrated_.empty() && kv_layer < static_cast<int>(kv_calibrated_.size()) &&
             !kv_calibrated_[kv_layer]) {
@@ -171,11 +181,13 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
             Tensor vv_cal = view_tokens(v_, n);
             float k_scale = calibrate_fp8_scale(kv_cal, stream);
             float v_scale = calibrate_fp8_scale(vv_cal, stream);
-            float scale = std::max(k_scale, v_scale);
-            if (scale < 1e-12f) scale = 1.0f;
-            kv_scales_[kv_layer] = scale;
+            float new_scale = std::max(k_scale, v_scale);
+            if (new_scale < 1e-12f) new_scale = 1.0f;
+            // Promote only — the high-water mark is the union of every
+            // prefill we've seen, so values fit FP8 dynamic range.
+            kv_scales_[kv_layer] = std::max(kv_scales_[kv_layer], new_scale);
             kv_calibrated_[kv_layer] = true;
-            inv_scale = 1.0f / scale;
+            inv_scale = 1.0f / kv_scales_[kv_layer];
         } else if (!kv_scales_.empty() && kv_layer < static_cast<int>(kv_scales_.size())) {
             inv_scale = 1.0f / kv_scales_[kv_layer];
         } else {

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1407,6 +1407,16 @@ void Engine::warmup() {
     // failure on consumer GPUs — the error propagates to cuBLAS otherwise).
     cudaGetLastError();
     cudaDeviceSynchronize();  // ensure all weight upload/dequant kernels are done
+    // Drop FP8 KV calibrated_ flags so the first real prefill re-runs absmax
+    // and promotes the per-layer scale via high-water-mark. Warmup uses
+    // synthetic BOS tokens whose K/V absmax is unrepresentative; without this
+    // reset, Llama-3.2-3B with --kv-fp8 degenerated to " France, and, 2008,
+    // 201, 201, …" within 30 tokens. The high-water-mark logic in
+    // executor_kv_write.cu (FP8 path) keeps the scale monotonically
+    // non-decreasing, so warmup's contribution survives if it was already
+    // wider than real prefill (Qwen3 case), and real prefill widens it
+    // further when needed (Llama case).
+    if (executor_) executor_->reset_kv_calibration();
     IMP_LOG_INFO("Warmup complete");
 }
 


### PR DESCRIPTION
## Summary

`Engine::warmup()` runs a forward pass with synthetic BOS tokens to prime cuBLAS handles + L2 cache. The FP8 KV write path's online calibration treats this as the FIRST prefill: it computes per-layer absmax over warmup K/V, sets `kv_scales_[layer]` from that, marks the layer calibrated, and never recalibrates. The synthetic-token absmax is unrepresentative, and for some architectures (Llama-3.2-3B Q8_0, Qwen3.5-4B GDN Q8_0) real-prefill K/V values overflow the FP8 dynamic range on the wrong-scale path. Output degenerated within ~30 tokens:

```
pre-fix Llama-3.2-3B Q8_0 --kv-fp8 --chat-template none "The capital of France is":
  " France, and, 2008, 201, 201, 201, 201, …"

post-fix:
  " The capital of Italy is Rome. The capital of Spain is Madrid.
    The capital of Germany is Berlin. The capital of the United Kingdom is …"
  (factually correct list, no degeneration over 100 tokens)
```

## Fix

Two-part:

1. **`Engine::warmup()` calls `executor_->reset_kv_calibration()` at the end.** Drops the `kv_calibrated_` flags so the first real prefill re-runs absmax. `kv_scales_[]` values are NOT cleared — they remain the high-water mark from warmup.

2. **The FP8 write path (`executor_kv_write.cu`) promotes the scale monotonically:** `kv_scales_[layer] = max(kv_scales_[layer], new_scale)`. Once a wider absmax is observed (whether from warmup or any later prefill), the scale never drops below it. This guarantees values fit FP8 dynamic range across the union of all observed prefills, and avoids the regression we saw with the simpler "reset and recalibrate" approach: Qwen3-4B Q8_0 broke when short real prompts produced a smaller-than-warmup absmax (output degenerated to `" ofThe the \"The \"The \"The"`).

## Verification (RTX 5090)

`--kv-fp8` only (no other changes), default warmup, default CUDA graphs:

| Model | pre-fix | post-fix |
|---|---|---|
| **Llama-3.2-3B Q8_0** | `"France, 2008, 201, …"` (broken) | `"Italy is Rome. Spain is Madrid…"` ✓ |
| **Qwen3.5-4B GDN Q8_0** | broken (memo #59 era, raw completions) | coherent chain-of-thought ✓ |
| Qwen3-4B Q8_0 (regression) | `"of France is Paris."` | unchanged ✓ |
| Qwen3-8B Q8_0 (regression) | works | unchanged ✓ |
| Qwen3.5-9B GDN Q8_0 | works | unchanged ✓ |
| Pre-push `verify-fast` | n/a | PASS (decode +5.18%, prefill +6.06%, smoke contains 'Paris') |

Long generation (100 tokens) on Llama-3.2-3B FP8 KV: factually correct list of world capitals, no degeneration.

## Out of scope

- **PR #51 escape hatch** (`--kv-fp16` / `kv_cache.dtype="fp16"`) remains valid and is still the default; this PR only changes the behavior when the user explicitly opts into FP8 KV.
- **Mistral-Small-3.1 Q6_K** still has a separate tokenizer-level issue (output `<unk>` even on FP16 KV), out of scope for this fix.
- **DeepSeek-R1-Distill-14B Q6_K** turned out not to be a real FP8 KV bug — its memo-claimed `<think>` / `<｜User｜>` pattern reproduces identically on FP16 KV and is just chat-template wrapping. Memos updated.
- **Gemma-4** still has the `engine.cpp:567` force-FP16 carve-out — that's a separate per-layer-head_dim awareness bug in the KV write/read kernels, distinct from this calibration issue.

## Test plan

- [x] `make verify-fast` (pre-push gate): PASS
- [x] Llama-3.2-3B FP8 KV regression: was broken, now coherent, 100-token generation factually correct
- [x] Qwen3-4B / Qwen3-8B / Qwen3.5-9B regression: unchanged from pre-fix
- [x] Qwen3.5-4B GDN regression: was broken on raw completions, now coherent

🤖 Generated with [Claude Code](https://claude.com/claude-code)