### PR TITLE
fix(kv-cache): Gemma-4 FP8 KV — narrow calibration view + drop force-FP16 carve-out

### DIFF
--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -370,15 +370,18 @@ public:
         kv_calibrated_.assign(n_kv, false);
     }
 
-    // Drop kv_calibrated_ flags so the next prefill (re-)calibrates the FP8
-    // KV per-layer scale and combines it with the existing high-water mark
-    // (kv_scales_) via std::max. Call this after warmup so the first real
-    // prefill can promote the scale if its activations need a wider range
-    // than the synthetic BOS-token warmup observed (broke Llama-3.2-3B with
-    // `--kv-fp8` until 2026-05-01: warmup absmax was too small, real
-    // generation overflowed FP8 dynamic range, output degenerated within
-    // ~30 tokens).
+    // Drop both the calibrated_ flag and the per-layer scale so the next
+    // prefill recalibrates from a clean slate. Call this after warmup —
+    // synthetic BOS tokens produce unrepresentative K/V absmax statistics
+    // (Llama: too-small absmax, scale locked too tight, real data
+    // overflowed FP8_MAX → degenerate output; Gemma-4: too-large absmax
+    // from extreme output_norm outliers, scale locked too wide, real
+    // data quantized to too-coarse FP8 grid → "Federer" garbage).
+    // Resetting the scale value (not just the flag) avoids both failure
+    // modes. High-water-mark within a single generation still applies
+    // via the std::max in executor_kv_write.cu.
     void reset_kv_calibration() {
+        std::fill(kv_scales_.begin(), kv_scales_.end(), 1.0f);
         std::fill(kv_calibrated_.begin(), kv_calibrated_.end(), false);
     }
 

--- a/src/graph/executor_kv_write.cu
+++ b/src/graph/executor_kv_write.cu
@@ -177,8 +177,24 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state,
         float inv_scale;
         if (!kv_calibrated_.empty() && kv_layer < static_cast<int>(kv_calibrated_.size()) &&
             !kv_calibrated_[kv_layer]) {
+            // Narrow the calibration view to the per-layer K/V shape. The k_/v_
+            // workspaces are sized for max_nkv * max_head_dim across all layers
+            // (Gemma-4 dual head_dim 256 SWA / 512 global; uniform on Llama / Qwen).
+            // Without narrowing, calibrate_fp8_scale would absmax-reduce over
+            // uninitialized memory beyond the live data region for layers with
+            // smaller head_dim, producing a scale derived from junk and
+            // permanently locking the FP8 dynamic range to the wrong value
+            // (was the root cause of the Gemma-4 force-FP16 carve-out at
+            // engine.cpp:567).
             Tensor kv_cal = view_tokens(k_, n);
             Tensor vv_cal = view_tokens(v_, n);
+            const int64_t live_cols = static_cast<int64_t>(nkv) * hd;
+            if (kv_cal.shape[1] != live_cols) {
+                kv_cal.shape[1] = live_cols; kv_cal.compute_strides();
+            }
+            if (vv_cal.shape[1] != live_cols) {
+                vv_cal.shape[1] = live_cols; vv_cal.compute_strides();
+            }
             float k_scale = calibrate_fp8_scale(kv_cal, stream);
             float v_scale = calibrate_fp8_scale(vv_cal, stream);
             float new_scale = std::max(k_scale, v_scale);

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -562,11 +562,13 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
             IMP_LOG_INFO("Gemma 4: disabling dual_path_quant");
             config_.dual_path_quant = false;
         }
-        // Force FP16 KV cache (FP8 KV cache calibration reads narrow stride incorrectly)
-        if (config_.kv_cache_dtype == QType::FP8_E4M3) {
-            IMP_LOG_INFO("Gemma 4: forcing FP16 KV cache (FP8 stride mismatch)");
-            config_.kv_cache_dtype = QType::F16;
-        }
+        // (Gemma-4 force-FP16 KV carve-out removed 2026-05-01.) The original
+        // bug was the FP8 KV calibration reading garbage beyond the per-layer
+        // live K/V region — Gemma-4 has dual head_dim (256 SWA / 512 global)
+        // and the workspace is allocated for max_head_dim, leaving a
+        // tail-region of uninitialized memory on SWA layers. The fix in
+        // src/graph/executor_kv_write.cu narrows the calibration view to
+        // `nkv * hd` per layer; FP8 KV is now safe to opt into on Gemma-4.
         // Gemma 4 output_norm has extreme outliers (max=588). Small numeric jitter
         // from cuBLAS algo autotuning / split-K atomics amplifies into wildly
         // different top-1 picks (coherent " Paris" vs garbage "\n"). Force


### PR DESCRIPTION
## Summary

Removes the `engine.cpp:567` Gemma-4 force-FP16 KV carve-out that has been forcing Gemma-4 onto FP16 KV regardless of the user's `--kv-fp8` request. With this PR Gemma-4 can opt into FP8 KV for the standard ~50% KV memory saving, the same as the other architectures.

The carve-out blocked FP8 KV because of two compounding bugs that PR #89 didn't address:

### Bug 1 — Calibration reads garbage on per-layer-shape models

The `k_/v_` workspaces are sized for `max_nkv * max_head_dim` across ALL layers (Gemma-4 dual head_dim 256 SWA / 512 global; uniform on Llama / Qwen). For SWA layers, `narrow_cols` in `run_attention()` shapes the local `kk` Tensor to the per-layer dim before the cuBLAS QKV gemm, so cuBLAS writes packed at the front of each row. The trailing `(max_hd - hd) * nkv` columns are left as **uninitialized memory** (or stale data from a previous layer's wider write).

`write_kv_cache()` then opens a fresh `view_tokens(k_, n)` view that picks up the FULL `max_nkv * max_head_dim` shape. `calibrate_fp8_scale()` absmax-reduces over the full view → reads junk → produces a per-layer scale derived from uninitialized memory.

**Fix**: explicitly narrow the calibration tensor to `[n, nkv * hd]` before calling `calibrate_fp8_scale`. (The kernel call itself is unaffected — it uses `row_elems = nkv * hd` directly, not the Tensor shape.)

### Bug 2 — Warmup-derived scale is unrepresentative on Gemma-4

Even with Bug 1 fixed, Gemma-4 produced `" Federer ... "` garbage with `--kv-fp8` because Gemma-4's **extreme `output_norm` outliers** (max=588 per the `engine.cpp:578` comment) make warmup BOS-token K/V values far larger in absmax than real-prompt values. PR #89's high-water-mark calibration locked the per-layer scale to that wide warmup value; real generation then quantized through a too-coarse FP8 grid → precision loss in attention dot products → wrong logits.

**Fix**: `reset_kv_calibration()` now clears `kv_scales_[]` (not just the `kv_calibrated_` flags). Warmup contributes nothing to the stored scale; real prefill calibrates from scratch. The high-water-mark within a single generation still applies via `std::max` in the write path.

These two failure modes are **opposite** (Llama: warmup absmax too small / Gemma-4: warmup absmax too large). Resetting the scale on warmup-end neutralises both.

## Verification (RTX 5090, `--kv-fp8`, default warmup, default CUDA graphs)

| Model | pre-PR-#89 | post-PR-#89 | this PR |
|---|---|---|---|
| Llama-3.2-3B Q8_0 | broken | "Italy is Rome" ✓ | unchanged ✓ |
| Qwen3-4B Q8_0 | works | works | works ✓ |
| Qwen3-8B Q8_0 | works | works | works ✓ |
| Qwen3.5-9B GDN | broken | works ✓ | works ✓ |
| **Gemma-4 Q5_K_M** | **force-FP16** | "Federer" garbage | "Paris" ✓ |

Pre-push `verify-fast` gate: PASS (decode within 3% threshold, prefill within 5%, smoke prompt distinct=8 contains 'Paris').

## Out of scope

- Mistral-Small-3.1 Q6_K still has its separate tokenizer-level issue (output `<unk>` even on FP16 KV) unrelated to FP8 KV.
- DeepSeek-R1-Distill-14B — already debunked in PR #89's description as a chat-template marker artifact, not an FP8 bug.
- Gemma-4 Q4_K_M output quality on complex code-gen prompts — separate FP16-drift issue, addressed by using Q5/Q8.

## Test plan

- [x] `make verify-fast` (pre-push gate): PASS
- [x] Llama-3.2-3B FP8 KV: factual world-capitals list (no regression vs PR #89)
- [x] Gemma-4 Q5_K_M FP8 KV: "The capital of France is Paris" (was force-FP16 / "Federer" garbage)
- [x] Qwen3-4B/8B/9B-GDN FP8 KV: regression check, all coherent

🤖 Generated with [Claude Code](https://claude.com/claude-code)