### PR TITLE
fix(nvfp4): skip CUTLASS path for llm-compressor — produces wrong output

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -330,7 +330,23 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         // Build the CUTLASS cache directly from the Tensor sidecars (data
         // pointer, scales, tensor_scale, shape) so the prefill dispatch
         // at executor_kernels.cu:1975 zündet on the native FP4×FP4 path.
-        if (cutlass_sm120_nvfp4_available()) {
+        //
+        // EXCLUSION (added 2026-05-02): the llm-compressor format produces
+        // wrong output through the CUTLASS NVFP4×NVFP4 path. Layer-0 QKV
+        // gemm output blows up to FP16-saturating values (max=65k, Inf=836)
+        // even though dequant_to_fp16 produces correct weight magnitudes
+        // (max ~0.117). The same dequant→cuBLAS fallback path produces
+        // coherent output ("Your cat is called Whiskers" / "476 AD"
+        // retrievals work). Modelopt-format NVFP4 (`is_llm_compressor=false`)
+        // is unaffected and remains on CUTLASS.
+        //
+        // Net effect for llm-compressor: prefill drops from 12k tok/s
+        // (CUTLASS) back to ~280 tok/s (dequant→cuBLAS) but output is
+        // coherent. Decode is unchanged (M=1 GEMV path). Until the
+        // CUTLASS+llm-compressor numerical mismatch is rooted, prefer
+        // correctness over speed.
+        const bool skip_cutlass_for_llm_compressor = cfg.is_llm_compressor_nvfp4;
+        if (cutlass_sm120_nvfp4_available() && !skip_cutlass_for_llm_compressor) {
             int ct_count = 0;
             size_t ct_total = 0;
             auto register_prequant = [&](const Tensor& w) {
@@ -371,6 +387,11 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 IMP_LOG_INFO("CUTLASS sm_120 NVFP4 cache (prequant): %d tensors, %.2f MiB",
                              ct_count, ct_total / (1024.0 * 1024.0));
             }
+        } else if (skip_cutlass_for_llm_compressor) {
+            IMP_LOG_INFO("CUTLASS sm_120 NVFP4 cache: skipped for llm-compressor "
+                         "format (uses dequant→cuBLAS fallback for prefill — "
+                         "CUTLASS path produces wrong output, see memory/"
+                         "stress_test_safetensors_2026_05_01.md)");
         }
     }
 


### PR DESCRIPTION
## Summary

PR #88 lit up the CUTLASS sm_120 NVFP4×NVFP4 prefill path for prequant SafeTensors (~10× prefill speedup, fixed Lorem-ipsum kernel garbage on Mistral-3.2). But subsequent stress testing revealed that for **llm-compressor format models specifically** (Mistral-3.2, Gemma-4, Qwen3.6), the CUTLASS path produces wrong output on any non-trivial generation past ~30 tokens.

## Symptom

```
Mistral-3.2-NVFP4 200-tok "why is the sky blue":
  "...blue light is scattered more than other colors because blue light
  is scattered more than other colors because blue light has a shorter
  wavelength..."  [infinite loop]

Mistral-3.2-NVFP4 multi-turn ("My cat is Whiskers, what's its name?"):
  "It looks like there might be a small typo in your message..."  [forgot]

Mistral-3.2-NVFP4 long-context retrieval:
  "Here is now modern-day. The empire covered approximately
  1111111111111111111..."  [numerical garbage]
```

## Diagnosis (debug_forward + bisect)

**Per-layer hidden state dump** localised the blow-up:
```
after_embedding   max=0.017, L2=0.16    [sane]
L0_after_qkv_q    max=65472, L2=1.8M, Inf=836  [FP16 saturated]
L0_after_paged_attn  NaN=4096  [completely NaN]
```

**Verified that all the obvious suspects are correct:**
- `tensor_scale=0.00162338` confirmed at Phase 0b promote (DBG log) and at the CUTLASS GEMM call site (DBG log).
- `dequantize_nvfp4_to_fp16` produces sane weight magnitudes for llm-compressor (`max|w|=0.117, mean|w|=0.0023`), comparable to Modelopt's `max=0.040, mean=0.0071`.
- Python decode of FP4 bytes + FP8 micro-scales matches imp's runtime output.

**Bisect via env-flag (`IMP_DBG_DISABLE_CUTLASS=1`)** disables only the CUTLASS dispatch, forcing fall-through to `gemm_nvfp4` (dequant → cuBLAS). With CUTLASS disabled:
- Mistral-3.2 produces 3 coherent sentences ("The sky appears blue due to a phenomenon called Rayleigh scattering...")
- Multi-turn: "Your cat is called Whiskers." ✓
- Long-context: "The Western Roman Empire fell in 476 AD." ✓
- Modelopt-format Qwen3-Coder **unchanged** — same CUTLASS path produces correct output for that format.

So the bug is exclusively in the **CUTLASS NVFP4×NVFP4 + llm-compressor format combination**, not in CUTLASS itself or imp's dequant logic.

## Fix

Same pattern as PR #65 (Gemma-4 NVFP4 MoE per-row gemv): when one specific quantizer-format combo produces wrong output, route through the slower-but-correct fallback. Phase 0b in `executor_pre_dequant.cu` now skips the CUTLASS cache registration when `cfg.is_llm_compressor_nvfp4` is true; dispatch at `executor_kernels.cu:1975` then falls through to `gemm_nvfp4` (dequant once to FP16, then cuBLAS).

Modelopt-format NVFP4 (`is_llm_compressor=false`) is unaffected and keeps the CUTLASS speedup.

## Performance impact

**llm-compressor models only** (Mistral-3.2, Gemma-4, Qwen3.6 NVFP4):
- Prefill: ~12k tok/s → ~280 tok/s (one-time 40 MiB scratch alloc per Linear). Slower but correct.
- Decode (M=1, gemv_nvfp4_kpar): unchanged.

**Modelopt models** (Qwen3-Coder etc.): no change, full PR #88 speedup retained.

## Verification (RTX 5090)

| Test | Pre-fix | Post-fix |
|---|---|---|
| Mistral-3.2 200-tok coherence | repetition loop | "Rayleigh scattering... 3 sentences" |
| Mistral-3.2 multi-turn | "small typo" (forgot) | "Your cat is called Whiskers." ✓ |
| Mistral-3.2 long-ctx | "1111…" garbage | "476 AD" extracted ✓ |
| Qwen3.6-NVFP4 multi-turn | empty / wrong | "Alice is asking about her cat's name..." ✓ |
| Qwen3-Coder Modelopt regression | "Paris." ✓ | "The capital of France is Paris." ✓ unchanged |
| Pre-push `verify-fast` | n/a | PASS (decode +4.74%, prefill -1.91%, smoke contains 'Paris') |

## Out of scope

- **Root cause within CUTLASS+llm-compressor** still unidentified. Candidates: FP8 micro-scale interpretation differences vs Modelopt convention; activation NVFP4 quantisation noise interaction with SmoothQuant-baked weights; SfAtom layout edge case at K=5120. Proper investigation needs vLLM cross-frame comparison or a synthetic NVFP4 GEMM unit test. This PR ships the workaround so users can use llm-compressor NVFP4 models in production today.
- **Gemma-4-NVFP4 OpenAI API empty `content`** — separate issue (chat-template `<channel|>` filter), not affected by this PR.

## Test plan

- [x] `make verify-fast` (pre-push gate): PASS
- [x] Mistral-3.2 200-tok / multi-turn / long-ctx: now coherent
- [x] Qwen3.6-NVFP4 multi-turn: now coherent
- [x] Modelopt Qwen3-Coder regression: unchanged

## Memos

- `memory/stress_test_safetensors_2026_05_01.md` — full investigation
- `memory/nvfp4_long_context_regression_2026_04_28.md` — original bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)