### PR TITLE
chore(gitignore): ignore _audit/ output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ test_detail.json
 .claude/*.lock
 .claude/worktrees/
 .claude/settings.local.json
+_audit/


### PR DESCRIPTION
## Summary
- Add `_audit/` to .gitignore so audit-output directories don't leak into commits.

## Test plan
- [ ] N/A (gitignore-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)