### PR TITLE
ci: target sm_120 only (drop sm_90a + sm_100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             -DIMP_BUILD_TESTS=ON \
             -DIMP_BUILD_TOOLS=ON \
             -DIMP_BUILD_BENCH=ON \
-            -DCMAKE_CUDA_ARCHITECTURES="90a;100"
+            -DCMAKE_CUDA_ARCHITECTURES="120"
 
       - name: Build
         run: cmake --build build -j$(nproc)


### PR DESCRIPTION
## Summary
- imp is sm_120-exclusive (per CLAUDE.md and hardcoded in CMakeLists.txt) but the CI was building for `sm_90a;100` (Hopper + B200) — pure waste since neither runs anywhere on this project.
- Drop both, target `sm_120` only.

## Expected impact
- **~50% CI build time reduction** (~8min → ~4min). Each `.cu` is compiled per arch; halving archs halves nvcc work for the dominant phase of the build.

## Test plan
- [ ] CI run on this PR validates the build still succeeds
- [ ] Compare run duration to recent main runs (~8min baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)