### PR TITLE
ci: publish Docker image to GHCR on release

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,59 @@
+name: Release Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g. v0.8.0). Defaults to "manual" for ad-hoc runs.'
+        required: false
+        default: 'manual'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and push image to GHCR
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # First-time package visibility must be flipped to public manually:
+      # GitHub repo → Packages → imp → Package settings → Change visibility → Public.
+      # GITHUB_TOKEN cannot set this; subsequent pushes inherit the chosen visibility.


### PR DESCRIPTION
Builds and pushes the multi-stage CUDA image to ghcr.io/kekzl/imp
whenever a GitHub release is published. Tags include the full semver,
major.minor, major, and `latest` (for non-prerelease releases).

Note: the package's visibility must be flipped to public once after
the first push — GITHUB_TOKEN cannot do this from a workflow.