### PR TITLE
fix(nemotron-h): KV cache floor + MoE forward + dynamic NVFP4 MoE reserve

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1564,7 +1564,13 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         if (wcache_.nvfp4_decode_mode == 2) {
             size_t free_mem = 0, total_mem = 0;
             IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
-            constexpr size_t kMoeReserve = 128ULL * 1024 * 1024;
+            // 1 GiB reserve so the KV cache (sized after this in init_kv_cache)
+            // can fit at least `min_kv_tokens` (default 16K) + workspaces. The
+            // previous 128 MiB reserve was too tight — on Nemotron-H NVFP4 (22
+            // GiB model on 32 GiB GPU) it left vram_budget with available=0,
+            // making the KV cache fall back to its 16-block / 512-token floor.
+            // Any prompt past 512 tokens then sat in pending_ forever (#102).
+            constexpr size_t kMoeReserve = 1024ULL * 1024 * 1024;
             moe_budget = (free_mem > kMoeReserve) ? (free_mem - kMoeReserve) : 0;
         } else {
             moe_budget = (remaining_budget > wcache_.nvfp4_bytes) ? (remaining_budget - wcache_.nvfp4_bytes)

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1570,7 +1570,20 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             // GiB model on 32 GiB GPU) it left vram_budget with available=0,
             // making the KV cache fall back to its 16-block / 512-token floor.
             // Any prompt past 512 tokens then sat in pending_ forever (#102).
-            constexpr size_t kMoeReserve = 1024ULL * 1024 * 1024;
+            //
+            // Override via IMP_MOE_RESERVE_MIB for VRAM-tight setups: lowering it
+            // (e.g. to 768) frees room for the NVFP4 MoE cache on Nemotron-H —
+            // decode jumps from ~44 to ~310 tok/s (7×) by enabling the MoE
+            // fast-path under CUDA graphs. Trade-off: KV capacity shrinks
+            // (Nemotron-H drops from 19k → 2.5k tokens), so prompts longer than
+            // the new KV ceiling won't fit. Use only when prompts are bounded.
+            size_t moe_reserve_mib = 1024;
+            if (const char* env = std::getenv("IMP_MOE_RESERVE_MIB")) {
+                int v = std::atoi(env);
+                if (v >= 128 && v <= 4096)
+                    moe_reserve_mib = static_cast<size_t>(v);
+            }
+            const size_t kMoeReserve = moe_reserve_mib * 1024ULL * 1024ULL;
             moe_budget = (free_mem > kMoeReserve) ? (free_mem - kMoeReserve) : 0;
         } else {
             moe_budget = (remaining_budget > wcache_.nvfp4_bytes) ? (remaining_budget - wcache_.nvfp4_bytes)

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1564,26 +1564,46 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         if (wcache_.nvfp4_decode_mode == 2) {
             size_t free_mem = 0, total_mem = 0;
             IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
-            // 1 GiB reserve so the KV cache (sized after this in init_kv_cache)
-            // can fit at least `min_kv_tokens` (default 16K) + workspaces. The
-            // previous 128 MiB reserve was too tight — on Nemotron-H NVFP4 (22
-            // GiB model on 32 GiB GPU) it left vram_budget with available=0,
-            // making the KV cache fall back to its 16-block / 512-token floor.
-            // Any prompt past 512 tokens then sat in pending_ forever (#102).
+            // Reserve VRAM so the KV cache (sized after this in init_kv_cache)
+            // can fit `min_kv_tokens` (default 16K) + workspaces. Computed from
+            // the model's actual attention layout — the previous 1 GiB constant
+            // was over-cautious for hybrid models (Nemotron-H: 6/52 attn layers,
+            // <100 MiB KV at 16K) where it starved the NVFP4 MoE cache and
+            // forced decode through the legacy D2H-sync fallback.
             //
-            // Override via IMP_MOE_RESERVE_MIB for VRAM-tight setups: lowering it
-            // (e.g. to 768) frees room for the NVFP4 MoE cache on Nemotron-H —
-            // decode jumps from ~44 to ~310 tok/s (7×) by enabling the MoE
-            // fast-path under CUDA graphs. Trade-off: KV capacity shrinks
-            // (Nemotron-H drops from 19k → 2.5k tokens), so prompts longer than
-            // the new KV ceiling won't fit. Use only when prompts are bounded.
-            size_t moe_reserve_mib = 1024;
+            // Capped at 1 GiB (the previous static value) so this can only
+            // RELEASE budget, never tighten it vs the previous behavior. Floor
+            // at 256 MiB to keep workspace + scratch room.
+            //
+            // IMP_MOE_RESERVE_MIB still overrides for manual tuning (range
+            // 128-4096 MiB).
+            int n_attn_layers = 0;
+            for (int i = 0; i < cfg.n_layers; i++) {
+                if (model_->layer(i).wq.data != nullptr &&
+                    model_->layer(i).gdn_gate.data == nullptr)
+                    n_attn_layers++;
+            }
+            if (n_attn_layers == 0)
+                n_attn_layers = cfg.n_layers;
+            int hd = cfg.head_dim > 0 ? cfg.head_dim : (cfg.d_model / cfg.n_heads);
+            int kv_heads = cfg.n_kv_heads > 0 ? cfg.n_kv_heads : cfg.n_heads;
+            // 16K tokens × n_attn × 2 (K+V) × kv_heads × hd × FP16
+            constexpr int kKvFloorTokens = 16384;
+            size_t per_token_kv = static_cast<size_t>(n_attn_layers) * 2 *
+                                  static_cast<size_t>(kv_heads) * static_cast<size_t>(hd) * 2;
+            size_t kv_reserve = static_cast<size_t>(kKvFloorTokens) * per_token_kv;
+            constexpr size_t kWorkspaceSafety = 256ULL * 1024 * 1024;
+            constexpr size_t kReserveCap = 1024ULL * 1024 * 1024;
+            constexpr size_t kReserveFloor = 256ULL * 1024 * 1024;
+            size_t kMoeReserve = std::clamp(kv_reserve + kWorkspaceSafety, kReserveFloor, kReserveCap);
             if (const char* env = std::getenv("IMP_MOE_RESERVE_MIB")) {
                 int v = std::atoi(env);
                 if (v >= 128 && v <= 4096)
-                    moe_reserve_mib = static_cast<size_t>(v);
+                    kMoeReserve = static_cast<size_t>(v) * 1024ULL * 1024ULL;
             }
-            const size_t kMoeReserve = moe_reserve_mib * 1024ULL * 1024ULL;
+            IMP_LOG_DEBUG("MoE reserve: %.0f MiB (n_attn=%d, kv_heads=%d, hd=%d → %.0f MiB KV at 16K + 256 MiB workspace)",
+                          kMoeReserve / (1024.0 * 1024.0), n_attn_layers, kv_heads, hd,
+                          kv_reserve / (1024.0 * 1024.0));
             moe_budget = (free_mem > kMoeReserve) ? (free_mem - kMoeReserve) : 0;
         } else {
             moe_budget = (remaining_budget > wcache_.nvfp4_bytes) ? (remaining_budget - wcache_.nvfp4_bytes)

--- a/src/graph/executor_workspace.cu
+++ b/src/graph/executor_workspace.cu
@@ -262,16 +262,7 @@ bool GraphExecutor::allocate_workspaces(bool experts_on_host) {
     // the serial path (major perf regression; was a correctness regression
     // before the host gate_up split fix since serial path had undefined
     // behavior for Gemma-4 host experts).
-    //
-    // Exception: NVFP4-prequant MoE models (Modelopt SafeTensors) never feed
-    // through the L2-resident dequant path — experts are already NVFP4 and the
-    // forward path uses the contiguous nvfp4_moe cache built in
-    // pre_dequant_weights. Allocating moe_batch_dequant here (~1.2 GiB on
-    // Nemotron-H 30B-A3B) would unnecessarily eat the budget that
-    // pre_dequant_weights and init_kv_cache later compete for, collapsing the
-    // KV cache to its 16-block / 512-token floor and hanging long prompts.
-    const bool skip_dequant_buf = model_->config().is_nvfp4_prequant;
-    allocate_auxiliary_buffers(/*skip_batch_dequant=*/skip_dequant_buf);
+    allocate_auxiliary_buffers(/*skip_batch_dequant=*/false);
     (void)experts_on_host;
 
     return true;

--- a/src/graph/executor_workspace.cu
+++ b/src/graph/executor_workspace.cu
@@ -262,7 +262,16 @@ bool GraphExecutor::allocate_workspaces(bool experts_on_host) {
     // the serial path (major perf regression; was a correctness regression
     // before the host gate_up split fix since serial path had undefined
     // behavior for Gemma-4 host experts).
-    allocate_auxiliary_buffers(/*skip_batch_dequant=*/false);
+    //
+    // Exception: NVFP4-prequant MoE models (Modelopt SafeTensors) never feed
+    // through the L2-resident dequant path — experts are already NVFP4 and the
+    // forward path uses the contiguous nvfp4_moe cache built in
+    // pre_dequant_weights. Allocating moe_batch_dequant here (~1.2 GiB on
+    // Nemotron-H 30B-A3B) would unnecessarily eat the budget that
+    // pre_dequant_weights and init_kv_cache later compete for, collapsing the
+    // KV cache to its 16-block / 512-token floor and hanging long prompts.
+    const bool skip_dequant_buf = model_->config().is_nvfp4_prequant;
+    allocate_auxiliary_buffers(/*skip_batch_dequant=*/skip_dequant_buf);
     (void)experts_on_host;
 
     return true;

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -276,6 +276,17 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         // writing the FP16 intermediate to DRAM entirely, saving ~5x DRAM traffic.
         // Skip allocation if experts are on host (batch dequant only useful for on-device experts).
         if (!skip_batch_dequant) {
+            // Cap at the actual remaining free VRAM minus a reserve for KV
+            // cache + workspaces (init_kv_cache runs after this and sees what's
+            // left). On Nemotron-H NVFP4 (32 GiB GPU, 22 GiB model) the full
+            // n_experts target hit ~1.2 GiB and starved the KV cache → 16-block
+            // floor → long-prompt hang. Leaving ≥ 1 GiB free here covers
+            // vram_budget reserve (~768 MiB) plus a useful KV cache.
+            size_t free_now = 0, total_now = 0;
+            cudaMemGetInfo(&free_now, &total_now);
+            constexpr size_t kPostBufReserve = 1024ULL * 1024 * 1024;
+            size_t cap_bytes = (free_now > kPostBufReserve) ? (free_now - kPostBufReserve) : 0;
+
             int targets[] = {cfg.n_experts, cfg.n_experts / 2, 32, 16};
             bool allocated = false;
             for (int ne_try : targets) {
@@ -283,6 +294,11 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                     continue;
                 ne_try = std::min(ne_try, cfg.n_experts);
                 size_t sz = static_cast<size_t>(ne_try) * eff * d * sizeof(half);
+                if (cap_bytes > 0 && sz > cap_bytes) {
+                    IMP_LOG_DEBUG("MoE dequant: skipping %d experts (%.0f MiB > cap %.0f MiB)", ne_try,
+                                  sz / (1024.0 * 1024.0), cap_bytes / (1024.0 * 1024.0));
+                    continue;
+                }
                 moe_.batch_dequant_buf = vram_alloc(vram_alloc_, sz, "moe_batch_dequant");
                 if (!moe_.batch_dequant_buf) {
                     IMP_LOG_DEBUG("MoE dequant buf alloc failed for %d experts", ne_try);

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -1,6 +1,7 @@
 #include "runtime/scheduler.h"
 #include "memory/kv_cache_manager.h"
 #include "memory/kv_cache.h"
+#include "core/logging.h"
 #include <algorithm>
 #include <ranges>
 
@@ -44,7 +45,24 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
                 const int bs = kv_manager_->kv_cache()->block_size();
                 int blocks_needed = (ctx_len + bs - 1) / bs;
                 if (!kv_manager_->can_allocate(blocks_needed)) {
-                    // Not enough memory -- skip, try smaller requests
+                    // If the request needs more blocks than the KV cache can
+                    // ever hold, no eviction will free enough — leaving the
+                    // request in pending_ would busy-loop the worker forever
+                    // (observed on Nemotron-H NVFP4 where the KV cache fell
+                    // back to the 16-block / 512-token floor and any longer
+                    // prompt looped here indefinitely). Cancel up front so
+                    // the caller gets a clear error instead of a 30s timeout.
+                    int cap = kv_manager_->kv_cache()->total_blocks();
+                    if (blocks_needed > cap) {
+                        IMP_LOG_ERROR(
+                            "Scheduler: request %d needs %d KV blocks but cache capacity is %d "
+                            "(ctx_len=%d, block_size=%d) — cancelling (KV cache too small for prompt)",
+                            req->id, blocks_needed, cap, ctx_len, bs);
+                        req->status = RequestStatus::CANCELLED;
+                        it = pending_.erase(it);
+                        continue;
+                    }
+                    // Otherwise: not enough memory right now, try smaller requests
                     ++it;
                     continue;
                 }

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -36,13 +36,20 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
     if (config.use_fp8_prefill)
         budget.reserve_bytes += 128ULL * 1024 * 1024;
     budget.reserve_bytes = std::max(budget.reserve_bytes, static_cast<size_t>(512ULL * 1024 * 1024));
-    // At least 10% of total VRAM as headroom
+    // At least 10% of total VRAM as headroom — but skipped for second-pass
+    // NVFP4 (mode 2). In that mode the NVFP4 MoE caching path already enforced
+    // its own ~1 GiB reserve before this runs; piling another 10% on top here
+    // pushed `available` to 0 on Nemotron-H NVFP4 (32 GiB GPU → 3.2 GiB extra
+    // reserve > what the MoE pass left free), which collapsed the KV cache to
+    // the 16-block floor and left long-prompt requests stuck in pending_.
     size_t total_vram = 0;
     {
         size_t f;
         cudaMemGetInfo(&f, &total_vram);
     }
-    budget.reserve_bytes = std::max(budget.reserve_bytes, total_vram / 10);
+    if (config.use_nvfp4_decode != 2) {
+        budget.reserve_bytes = std::max(budget.reserve_bytes, total_vram / 10);
+    }
 
     // Estimate SSM footprint
     size_t ssm_footprint = 0;

--- a/tests/test_continuous_batching.cpp
+++ b/tests/test_continuous_batching.cpp
@@ -953,7 +953,7 @@ TEST(SchedulerTest, MemoryAwareSkipsLargeAdmitsSmall) {
     Scheduler sched(16);
     sched.set_kv_manager(mgr.get());
 
-    // Large request: 80 tokens = 5 blocks (exceeds 4 total)
+    // Large request: 80 tokens = 5 blocks (exceeds 4 total — infeasible, cancelled)
     auto large = std::make_shared<Request>();
     large->id = 1;
     large->input_tokens.resize(80, 0);
@@ -968,13 +968,17 @@ TEST(SchedulerTest, MemoryAwareSkipsLargeAdmitsSmall) {
     std::vector<std::shared_ptr<Request>> prefill, decode;
     sched.schedule(prefill, decode);
 
-    // Small request admitted, large request skipped (still pending)
+    // Small admitted; large is infeasible (exceeds total cache capacity) so the
+    // scheduler cancels it up-front rather than leaving it pending — leaving
+    // a never-admittable request in pending_ would busy-loop the worker
+    // (Nemotron-H regression that prompted the cancel-on-infeasible path).
     ASSERT_EQ(prefill.size(), 1u);
     EXPECT_EQ(prefill[0]->id, 2);
-    EXPECT_TRUE(sched.has_pending());
+    EXPECT_EQ(large->status, RequestStatus::CANCELLED);
+    EXPECT_FALSE(sched.has_pending());
 }
 
-// 29. All requests too large for memory — nothing admitted
+// 29. All requests too large for memory — all cancelled (none feasible)
 TEST(SchedulerTest, AllRequestsTooLargeForMemory) {
     SKIP_IF_NO_CUDA();
 
@@ -985,11 +989,13 @@ TEST(SchedulerTest, AllRequestsTooLargeForMemory) {
     Scheduler sched(16);
     sched.set_kv_manager(mgr.get());
 
-    // 3 requests each needing 3+ blocks but only 2 available
+    // 3 requests each needing 3 blocks but only 2 available — all infeasible
+    std::vector<std::shared_ptr<Request>> reqs;
     for (int i = 0; i < 3; i++) {
         auto req = std::make_shared<Request>();
         req->input_tokens.resize(48, 0);  // 48 tokens = 3 blocks
         sched.add_request(req);
+        reqs.push_back(req);
     }
 
     std::vector<std::shared_ptr<Request>> prefill, decode;
@@ -997,7 +1003,9 @@ TEST(SchedulerTest, AllRequestsTooLargeForMemory) {
 
     EXPECT_EQ(prefill.size(), 0u);
     EXPECT_EQ(decode.size(), 0u);
-    EXPECT_TRUE(sched.has_pending());
+    EXPECT_FALSE(sched.has_pending());
+    for (const auto& r : reqs)
+        EXPECT_EQ(r->status, RequestStatus::CANCELLED);
 }
 
 // 30. Concurrent new prefill while others decoding


### PR DESCRIPTION
## Summary
Five-commit cluster that resolves Nemotron-H multi-chunk hang and unlocks NVFP4 MoE decode fast-path.

1. **fix KV cache 16-block floor on NVFP4 hybrid models** — three interacting bugs caused Nemotron-H NVFP4 to fall back to a 16-block / 512-token KV-cache floor: \`moe_batch_dequant\` was running unnecessarily for NVFP4-prequant, the vram_budget 10% floor doubled MoE reserve, and \`kMoeReserve\` was too tight. 200-rep prompt: HANG → 1s. KV: 16 → 599 blocks (37×). Plus scheduler cancel path for infeasible requests.
2. **fix skip-batch-dequant broke MoE forward** — the skip path missed a buffer-size constraint; restructured to cap buffer size instead.
3. **test scheduler cancel-on-infeasible** — aligns continuous-batching test with the new cancel behavior introduced by the previous fix.
4. **feat IMP_MOE_RESERVE_MIB env var** — manual override that unlocks NVFP4 MoE decode-fast-path on Nemotron-H. Validates the dynamic-reserve hypothesis before turning it into the default.
5. **perf compute MoE reserve from model attention layout** — replaces the static 1 GiB reserve with \`per_token_kv × 16K + 256 MiB safety, clamped [256 MiB, 1 GiB]\`. Nemotron-H gets ~352 MiB instead of static 1 GiB → MoE cache fits → tg128 42.54 → 319.03 tok/s (+650%) without env var. Other NVFP4 MoE models (Qwen3-Coder/Qwen3.6/Gemma-4/Qwen3-30B-Modelopt) clamp at 1 GiB → unchanged.

## Why
Nemotron-H NVFP4 was the only loaded model where decode would hang on long prompts. Three bugs interacted to push KV-cache below usable size, and the static MoE reserve assumed every NVFP4-MoE model has Qwen3-Coder's attention layout. Both root-caused and fixed.

## Test plan
- [x] \`make build\`
- [x] \`make verify-fast\` via pre-push hook
- [x] Nemotron-H NVFP4: 200-rep prompt no longer hangs
- [x] Nemotron-H NVFP4 tg128: 42.54 → 319.03 tok/s confirmed
- [x] Long-context: \`--min-kv-tokens 16000\` works on Nemotron-H (6/52 attention layers × 16K = 93 MiB KV + 256 MiB safety = 349 MiB; tg64 = 291 tok/s)
- [x] Other NVFP4 MoE models (Qwen3-Coder, Qwen3.6, Gemma-4, Qwen3-30B-Modelopt) unchanged
- [x] Scheduler cancel-on-infeasible test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)