### PR TITLE
perf(attention): close 1024→4096 prefill cliff via S-matrix budget

### DIFF
--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -729,8 +729,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                     static_cast<const half*>(vv.data), static_cast<half*>(ao.data), n, nh,
                                     nkv, hd, scale, cfg.attn_logit_softcap, stream, layer_sliding_window);
         } else if ((force_cublas_attn || !no_cublas_attn) && attn_scores_buf_ &&
-                   n <= static_cast<int>(attn_scores_.shape[1]) && (force_cublas_attn || n <= 1024) &&
-                   !sliding_active) {
+                   n <= static_cast<int>(attn_scores_.shape[1]) && !sliding_active) {
             // The n<=1024 heuristic below picks Flash Attention for long contexts
             // (O(1) memory) over cuBLAS (O(n^2) S-matrix). Gemma-4 with mixed
             // head_dims (256 SWA / 512 global) MUST stay on cuBLAS for the

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -155,7 +155,12 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
     // for long sequences or when VRAM-constrained.
     if (!skip_batch_dequant) {
         int nh = cfg.n_heads;
-        constexpr size_t kMaxAttnScoresMiB = 256;  // cap at 256 MiB
+        // 512 MiB → ~2896 attn_seq for 32-head models. Lets cuBLAS prefill
+        // run at pp ~2400-2900 where it still beats FMHA by ~15-20%; the
+        // earlier 256 MiB cap pushed the cliff in at pp=2048 (post-cbe083a
+        // n<=1024 heuristic removal). Falls through to FMHA on alloc failure
+        // (line 174), so VRAM-constrained setups still work.
+        constexpr size_t kMaxAttnScoresMiB = 512;
         size_t max_s_sz = kMaxAttnScoresMiB << 20;
         // max seq = sqrt(budget / (n_heads * sizeof(half)))
         int attn_seq = max_tokens_;

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -160,7 +160,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         // earlier 256 MiB cap pushed the cliff in at pp=2048 (post-cbe083a
         // n<=1024 heuristic removal). Falls through to FMHA on alloc failure
         // (line 174), so VRAM-constrained setups still work.
-        constexpr size_t kMaxAttnScoresMiB = 512;
+        constexpr size_t kMaxAttnScoresMiB = 1024;
         size_t max_s_sz = kMaxAttnScoresMiB << 20;
         // max seq = sqrt(budget / (n_heads * sizeof(half)))
         int attn_seq = max_tokens_;


### PR DESCRIPTION
## Summary
Three-commit cluster that closes the small-dense-model prefill cliff at 1024+ tokens.

1. **drop n<=1024 cuBLAS cap, gate only on S-matrix capacity** — the old cap was a stale workaround for an S-matrix-budget exhaustion that the next two commits address directly.
2. **raise cuBLAS S-matrix budget 256 → 512 MiB** — first bump.
3. **raise cuBLAS S-matrix budget 512 → 1024 MiB** — second bump; covers the full curve up to ctx 4096 on 32-head dense models.

## Why
Closes the roadmap "1024 → 2048 prefill cliff on small dense models" item. Combined effect:

- **Qwen3-4B Q8_0**: pp=1280 +27.0%, pp=2048 +16.8%, pp=2400 +21.0%, pp=2800 +22.9%, pp=3200 +25.9%, pp=4096 **+28.3%**
- **Qwen3-8B Q8_0**: pp=1280 +14.2%, pp=2400 +16.8%, pp=2800 +15.2%, pp=3200 +17.0%, pp=4096 **+17.6%**
- **Llama-3.2-3B Q8_0**: pp=1280 +21.4%, pp=2048 +18.3%, pp=4096 **+24.2%**

Cliff now appears at 4096→4112 on 32-head models (next ceiling, separate problem). Total VRAM cost: +768 MiB (2.4% on 32 GiB) for the full curve.

## Test plan
- [x] \`make build\`
- [x] \`make verify-fast\` via pre-push hook (delta within thresholds)
- [x] Combined bench Qwen3-4B/8B + Llama-3.2-3B as above
- [x] No regression on tg256 across all three models
- [x] Decode baselines hold (3% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)