### PR TITLE
ci: cache build dir + Docker dep layer + bench gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,11 @@ on:
 
 jobs:
   build:
-    name: Build (CUDA ${{ matrix.cuda }})
+    name: Build (CUDA 13.2)
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        cuda: ['13.2']
-        build_type: [Release]
 
     container:
-      image: nvidia/cuda:${{ matrix.cuda }}.0-devel-ubuntu24.04
+      image: nvidia/cuda:13.2.0-devel-ubuntu24.04
 
     steps:
       - uses: actions/checkout@v5
@@ -26,16 +22,31 @@ jobs:
           apt-get update
           apt-get install -y cmake g++ git python3
 
+      # Cache the entire build tree (incl. _deps FetchContent clones and Ninja
+      # objects). On code-only PRs Ninja relinks only changed TUs instead of
+      # re-doing the ~5min cold CUDA build. Cache key tracks CMake config files
+      # plus the full source tree so a clean key always matches incrementally.
+      - name: Cache build directory
+        uses: actions/cache@v4
+        with:
+          path: build
+          key: imp-build-${{ runner.os }}-cuda13.2-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**', 'tests/**') }}
+          restore-keys: |
+            imp-build-${{ runner.os }}-cuda13.2-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-
+            imp-build-${{ runner.os }}-cuda13.2-
+
       - name: Configure
         run: |
           cmake -B build \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_BUILD_TYPE=Release \
             -DIMP_BUILD_TESTS=ON \
             -DIMP_BUILD_TOOLS=ON \
-            -DIMP_BUILD_BENCH=ON
-          # CMakeLists.txt pins arch=compute_120f,code=sm_120 directly via
+            -DIMP_BUILD_BENCH=OFF
+          # CMakeLists.txt pins arch=compute_120a,code=sm_120a directly via
           # gencode and sets CMAKE_CUDA_ARCHITECTURES=OFF. CI compiles PTX/SASS
-          # for sm_120 only; runtime tests need a self-hosted RTX 5090 runner.
+          # for sm_120a only; runtime tests need a self-hosted RTX 5090 runner.
+          # IMP_BUILD_BENCH=OFF skips ~30-60s of mxf4nvf4 microbench TUs that
+          # are bench-only — production server builds don't link them.
 
       - name: Build
         run: cmake --build build -j$(nproc)
@@ -46,7 +57,6 @@ jobs:
           name: imp-build
           path: |
             build/imp-cli
-            build/imp-bench
             build/imp-tests
             build/test-core
             build/test-text

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,13 +167,17 @@ if(IMP_USE_CUTLASS)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_fmha_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_fmha_mxfp4_sm120.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxfp4_prefill.cu)
-    list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxf4nvf4_probe.cu)
-    list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
-    list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_bench.cu)
-    list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_variants_bench.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_hw.cu)
     list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_fmha_mxf4nvf4_sm120.cu)
-    list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_qkt_validate.cu)
+    # Bench/probe/validate TUs: only consumed by tests and microbenches, never
+    # by production runtime. Skip in server-only builds to cut ~30-60s nvcc.
+    if(IMP_BUILD_TESTS OR IMP_BUILD_BENCH)
+        list(APPEND IMP_COMPUTE_SOURCES src/compute/attention_mxf4nvf4_probe.cu)
+        list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
+        list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_bench.cu)
+        list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_mma_variants_bench.cu)
+        list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_qkt_validate.cu)
+    endif()
 endif()
 
 # Note: TurboQuant paged attention previously required a fast-math override

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,21 @@ RUN { sed -i 's|archive.ubuntu.com|de.archive.ubuntu.com|g; s|security.ubuntu.co
     && rm /tmp/cmake.sh \
     && rm -rf /var/lib/apt/lists/*
 
+# Pre-clone third-party deps into their own layer. Only invalidated when the
+# pinned tags below change — code-only edits keep this layer cached, saving
+# the FetchContent git-clone step (~30-60s) on every Docker rebuild.
+# Tags must mirror the FetchContent_Declare entries in CMakeLists.txt.
+RUN git clone --depth=1 --branch v1.17.0 https://github.com/google/googletest.git /deps/googletest \
+ && git clone --depth=1 --branch v4.4.2  https://github.com/NVIDIA/cutlass.git    /deps/cutlass    \
+ && git clone --depth=1 --branch v0.42.0 https://github.com/yhirose/cpp-httplib.git /deps/httplib  \
+ && git clone --depth=1 --branch v3.12.0 https://github.com/nlohmann/json.git     /deps/json
+
 WORKDIR /src
 COPY . .
 
 # Override -march=native with portable -march=x86-64-v3 for Docker portability
 RUN sed -i 's/-march=native/-march=x86-64-v3/g' cmake/CompilerFlags.cmake
 
-# BuildKit cache mount persists the build directory across Docker builds.
-# On code-only changes, Ninja recompiles only modified translation units
-# instead of rebuilding from scratch (~30s vs ~5min for full CUDA rebuild).
 ARG IMP_BUILD_TESTS=OFF
 ARG IMP_BUILD_BENCH=OFF
 
@@ -37,6 +43,10 @@ RUN cmake -B build -G Ninja \
         -DIMP_BUILD_BENCH=${IMP_BUILD_BENCH} \
         -DIMP_BUILD_TOOLS=ON \
         -DIMP_BUILD_SERVER=ON \
+        -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=/deps/googletest \
+        -DFETCHCONTENT_SOURCE_DIR_CUTLASS=/deps/cutlass \
+        -DFETCHCONTENT_SOURCE_DIR_HTTPLIB=/deps/httplib \
+        -DFETCHCONTENT_SOURCE_DIR_NLOHMANN_JSON=/deps/json \
     && cmake --build build -j$(nproc) \
     && cp build/imp-server build/imp-cli /tmp/ \
     && if [ -f build/imp-tests ]; then \


### PR DESCRIPTION
## Summary
Three speed-up changes for the build pipeline, no runtime impact.

- **`build(cmake)`**: gate `mxf4nvf4_*_bench`, `_probe`, `_qkt_validate`, `nvfp4_quant_ref` source files behind `IMP_BUILD_TESTS OR IMP_BUILD_BENCH`. Server-only Docker (default `OFF/OFF`) skips ~30-60s of CUTLASS-template nvcc.
- **`build(docker)`**: pre-clone googletest / cutlass / httplib / nlohmann_json into `/deps/*` in their own RUN, pass via `FETCHCONTENT_SOURCE_DIR_*`. Layer is reused across every code-edit rebuild and only invalidated on tag bump. Stops re-cloning ~30-60s of git on every cold layer.
- **`ci`**: `actions/cache@v4` over `build/` with two-tier restore-key (CMakeLists+cmake/ exact, then full-source exact, then any-cuda fallback). Flips configure to `IMP_BUILD_BENCH=OFF`. Drops the 1×1 strategy.matrix and the unused `imp-bench` upload-artifact entry.

## Expected CI impact
- Warm PRs: ~5 min cold CUDA build → <1 min Ninja-incremental relink (typical case where a few TUs change).
- Cold runs (cache miss): unchanged total time minus ~30-60s saved by `IMP_BUILD_BENCH=OFF`.
- `release-docker.yml` (GHA layer cache) keeps the deps layer warm permanently — code-only release rebuilds skip the FetchContent clone phase.

## Local verification
- Server-only Docker build: 1m12s.
- `make build` with `IMP_BUILD_TESTS=ON`: all 8 test binaries shipped, GPU suite **681/681 PASS** in 44s, unit suite 37/37 PASS in 3.8s.
- Content-edit rebuild: deps layer **CACHED**, CMake reports `Using the multi-header code from /deps/json/include/` confirming the FetchContent override took effect.
- Pre-push hook `verify-fast` PASS.

## Test plan
- [x] Local: full Docker build (TESTS=ON) succeeds
- [x] Local: full GPU test suite passes
- [x] Local: warm rebuild after content edit reuses deps layer
- [ ] CI: `Build (CUDA 13.2)` job passes (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)