### PR TITLE
fix(constrain+server): close JSON-schema preamble + tools coordination gaps

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,9 @@ Non-Gemma-4 / non-NVFP4-prequant MoE decode falls through the legacy expert-rout
 
 Reasoning models (Qwen3.6, DeepSeek-R1, Gemma-4-thinking) emit `<think>...</think>` before every response. Strict JSON / JSON-Schema enforcement starting at token 0 masks the `<think>` opener, leaving the model with no valid token to sample. Auto-detected via the tokenizer (presence of `<think>` + `</think>` special tokens) and handled by `PreambleGate` (`src/compute/preamble_gate.h`): the gate lets all tokens pass until the close marker, an `{` / `[` is observed, or a budget cap is hit, then strict enforcement kicks in.
 
-Open follow-ups: tool-calling response-format combinations (`tools` + `response_format=json_schema`) aren't covered yet; lenient grammar prefixes for non-reasoning preambles like markdown fences (` ```json `) would generalise the same pattern.
+Non-reasoning models (Llama-3.2 etc.) get the same gate in budget-only mode (8-token slack) so markdown-fence preambles like ` ```json ` and short verbal openers ("Sure! ") pass through cleanly.
+
+When a request sets both `tools` and `response_format=json_schema`/`json_object`, the schema mask would block the `<` of `<tool_call>`/`<function=` openers and prevent any tool call from being emitted. The server logs a warning and drops `response_format` in that case; tool argument validation still flows through each tool's own `parameters` schema. Lifting this to "schema applies only when the model didn't call a tool" needs runtime coordination between the handler-side tool-tag scanner and the engine-side FSM mask.
 
 ## Performance work
 
@@ -53,10 +55,6 @@ CUTLASS MXFP4 GEMM is fully implemented today (`attention.mxfp4 = "always"`), bu
 ### Closing the TurboQuant–FP8 gap
 
 TurboQuant currently runs ~23% behind FP8 on Qwen3-8B Q8_0 decode (191 vs 248 tok/s). The gap is algorithm-inherent — QJL sketch computation adds per-token overhead. Closing it would need to drop QJL and switch to MXFP4 K directions with group micro-scales.
-
-### 1024→2048 prefill cliff on small dense models
-
-Qwen3-4B Q8_0 drops from 27k to 19k tok/s at the dispatch boundary where cuBLAS attention hands off to FP8 FMHA. Output stays correct; the FP8-FMHA kernel is just less tuned for the small-model regime. Options: raise the cuBLAS cap past 1024, or tune FP8-FMHA occupancy / Bq.
 
 ### `pp=512` on large dense models
 

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -75,8 +75,11 @@ public:
     // Get max tokens to finish (force-close open structures near limit)
     int closing_tokens_needed() const { return static_cast<int>(state_stack_.size()); }
 
-    // Allow the model to emit a free-form preamble (e.g. <think>...</think>)
-    // before strict JSON enforcement starts. Pass close_token=-1 to disable.
+    // Allow the model to emit a free-form preamble before strict JSON
+    // enforcement starts. close_token>=0 enables close-token mode (reasoning
+    // models with </think>); close_token<0 + max_tokens>0 enables budget-only
+    // mode (markdown-fence preambles). Both modes also exit on the first
+    // `{` / `[` seen. Pass close_token=-1 with max_tokens<=0 to fully disable.
     void set_preamble(int32_t close_token, int max_tokens = 8192) {
         preamble_.configure(close_token, max_tokens);
     }

--- a/src/compute/preamble_gate.h
+++ b/src/compute/preamble_gate.h
@@ -6,8 +6,18 @@
 namespace imp {
 
 // Gate that lets a model emit a free-form preamble before strict JSON
-// enforcement kicks in — needed for reasoning models (Qwen3.6, DeepSeek-R1,
-// Gemma-4 thinking) that prepend `<think>...</think>` to every response.
+// enforcement kicks in. Two modes:
+//
+//   1. close-token mode (close_token >= 0)
+//      Reasoning models (Qwen3.6, DeepSeek-R1, Gemma-4 thinking) prepend
+//      `<think>...</think>` to every response. Gate stays active until the
+//      close token is observed; budget acts as a safety cap.
+//
+//   2. budget-only mode (close_token < 0, max_tokens > 0)
+//      Non-reasoning models that wrap JSON in markdown fences (` ```json `)
+//      or short verbal preambles ("Sure! ") need a small slack window
+//      before strict enforcement. Gate transitions on the first `{`/`[`
+//      seen, or when the budget is exhausted.
 //
 // State:
 //   active=true   →  apply_mask is a no-op, all tokens accepted
@@ -20,9 +30,11 @@ namespace imp {
 class PreambleGate {
 public:
     void configure(int32_t close_token, int max_tokens) {
-        configured_ = (close_token >= 0);
-        close_token_ = close_token;
         max_tokens_ = max_tokens > 0 ? max_tokens : 0;
+        close_token_ = close_token;
+        // Activate if either a close-token is set, or a positive budget is
+        // configured (budget-only mode for markdown-fence preambles).
+        configured_ = (close_token >= 0) || (max_tokens_ > 0);
         reset();
     }
 
@@ -42,8 +54,10 @@ public:
 
         seen_++;
 
-        // Close token (e.g. </think>) — consume and transition.
-        if (token == close_token_) {
+        // Close token (e.g. </think>) — consume and transition. Only checked
+        // in close-token mode; budget-only mode passes through to the
+        // {/[ + budget exits below.
+        if (close_token_ >= 0 && token == close_token_) {
             active_ = false;
             return true;
         }

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -75,8 +75,8 @@ public:
 
     bool is_initialized() const { return initialized_; }
 
-    // Allow the model to emit a free-form preamble (e.g. <think>...</think>)
-    // before strict schema enforcement starts. Pass close_token=-1 to disable.
+    // See JsonConstrainer::set_preamble for semantics — close-token mode for
+    // reasoning models (</think>) or budget-only mode for markdown fences.
     void set_preamble(int32_t close_token, int max_tokens = 8192) {
         preamble_.configure(close_token, max_tokens);
     }

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -30,13 +30,19 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
     active_schema_ = false;
 
     const int32_t think_close = detect_think_close(tokenizer);
+    // Reasoning models get a large budget (free-form thinking can run for
+    // hundreds of tokens). Non-reasoning models get a small slack window
+    // for markdown fences (` ```json `) or short verbal preambles ("Sure! ").
+    // Either way the gate exits on the first `{` / `[` seen, so this is a
+    // hard cap, not the typical case.
+    const int preamble_budget = (think_close >= 0) ? 8192 : 8;
 
     // Schema mode takes priority over plain JSON mode
     if (!json_schema.empty()) {
         if (schema_constrainer_ && schema_constrainer_->is_initialized() &&
             json_schema == cached_schema_string_) {
             // Reuse cached constrainer — just reset FSM state.
-            schema_constrainer_->set_preamble(think_close);
+            schema_constrainer_->set_preamble(think_close, preamble_budget);
             schema_constrainer_->reset();
             active_schema_ = true;
         } else {
@@ -45,7 +51,7 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
                 schema_constrainer_ = std::make_unique<SchemaConstrainer>();
                 if (tokenizer && schema_constrainer_->init(*tokenizer, std::move(schema))) {
                     cached_schema_string_ = json_schema;
-                    schema_constrainer_->set_preamble(think_close);
+                    schema_constrainer_->set_preamble(think_close, preamble_budget);
                     schema_constrainer_->reset();
                     active_schema_ = true;
                 } else {
@@ -69,7 +75,7 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
                 return;
             }
         }
-        json_constrainer_->set_preamble(think_close);
+        json_constrainer_->set_preamble(think_close, preamble_budget);
         json_constrainer_->reset();
         active_json_ = true;
     }

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -165,11 +165,55 @@ TEST(PreambleGateTest, DisabledByDefault) {
     EXPECT_FALSE(g.absorb(TOK_TEXT, "hi"));  // gate inactive → don't absorb
 }
 
-TEST(PreambleGateTest, ConfigureNegativeCloseTokenStaysDisabled) {
+TEST(PreambleGateTest, ConfigureNoCloseTokenAndNoBudgetStaysDisabled) {
     PreambleGate g;
-    g.configure(-1, 8192);
+    g.configure(-1, 0);
     EXPECT_FALSE(g.active());
     EXPECT_FALSE(g.absorb(TOK_TEXT, "hi"));
+}
+
+TEST(PreambleGateTest, BudgetOnlyModeActivates) {
+    // Non-reasoning model: no </think> token, but we still want a small
+    // slack window for markdown fences (```json) or short verbal preambles.
+    PreambleGate g;
+    g.configure(-1, 8);
+    EXPECT_TRUE(g.active());
+}
+
+TEST(PreambleGateTest, BudgetOnlyModeAbsorbsMarkdownFenceTokens) {
+    PreambleGate g;
+    g.configure(-1, 8);
+
+    // Tokens like "```", "json", "\n" all absorbed.
+    EXPECT_TRUE(g.absorb(TOK_TEXT, "```"));
+    EXPECT_TRUE(g.absorb(TOK_TEXT, "json"));
+    EXPECT_TRUE(g.absorb(TOK_TEXT, "\n"));
+    EXPECT_TRUE(g.active());
+
+    // Then `{` triggers transition (forwarded to FSM).
+    EXPECT_FALSE(g.absorb(TOK_OPEN_BRACE, "{"));
+    EXPECT_FALSE(g.active());
+}
+
+TEST(PreambleGateTest, BudgetOnlyModeBudgetExhaustionForcesTransition) {
+    PreambleGate g;
+    g.configure(-1, 3);
+    for (int i = 0; i < 2; i++) {
+        EXPECT_TRUE(g.absorb(TOK_TEXT, "blah"));
+        EXPECT_TRUE(g.active());
+    }
+    EXPECT_TRUE(g.absorb(TOK_TEXT, "blah"));
+    EXPECT_FALSE(g.active());
+}
+
+TEST(PreambleGateTest, BudgetOnlyModeIgnoresNegativeTokenIds) {
+    // close_token_=-1 should not match any real token. Use TOK_THINK_CLOSE
+    // as a stand-in for "any non-{ token" and verify it's absorbed (not
+    // treated as a close-match).
+    PreambleGate g;
+    g.configure(-1, 8);
+    EXPECT_TRUE(g.absorb(TOK_THINK_CLOSE, "</think>"));
+    EXPECT_TRUE(g.active());
 }
 
 TEST(PreambleGateTest, ActivatesAfterConfigure) {

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -611,6 +611,20 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
     json tool_choice = body.value("tool_choice", json("auto"));
     bool has_tools = !tools.empty() && !(tool_choice.is_string() && tool_choice.get<std::string>() == "none");
 
+    // tools + response_format=json_schema/json_object: the schema constraint
+    // would mask the `<` / `{"name":` opener that tool calls need (the model
+    // emits `<tool_call>` for ChatML or `<function=...>` for Llama-3, neither
+    // of which match a JSON-schema mask). Until proper runtime coordination
+    // exists between the tool-tag scanner (handler-side) and the FSM mask
+    // (engine-side), prefer tools and drop the schema with a warning. Users
+    // can still validate tool arguments via each tool's `parameters` schema.
+    if (has_tools && (json_mode || !json_schema_str.empty())) {
+        IMP_LOG_INFO("response_format dropped: tools take priority over JSON schema/mode "
+                     "in this request (tools and response_format both set)");
+        json_mode = false;
+        json_schema_str.clear();
+    }
+
     // Convert JSON messages to ChatMessage vector, extracting image data if present
     std::vector<imp::ChatMessage> chat_msgs;
     std::vector<uint8_t> image_data;  // decoded image bytes (if any)


### PR DESCRIPTION
## Summary

Closes the two open follow-ups from the **Reasoning models + JSON schema** roadmap section (`docs/roadmap.md`).

- **Budget-only PreambleGate** — non-reasoning models (Llama-3.2 etc.) in JSON/schema mode previously had strict enforcement from token 0, masking ` \`\`\`json ` markdown fences and short verbal preambles. Gate now activates with a small budget (8 tokens) even when no `</think>` close-token exists. The `{` / `[` early-exit and budget-exhaustion fallbacks still apply, so degenerate input is bounded.
- **Tools + response_format=json_schema** — the schema mask blocked the `<` opener of `<tool_call>` / `<function=`, making tool calls impossible when both were set. Server now drops `response_format` with an info log when tools are also requested. Tool argument validation still flows through each tool's own `parameters` schema.

Reasoning-model behavior unchanged: 8192-token budget for `</think>` mode, identical close-token semantics.

## Test plan

- [x] All 14 `PreambleGateTest.*` pass (4 new + 10 existing)
- [x] `make verify-fast` clean — decode tg128 154.89 (+4.76% vs baseline), prefill pp512 14126.06 (+6.39%), smoke prompt OK
- [x] `make test-gpu` exits 0
- [ ] Optional follow-up: add API integration test for `tools + response_format=json_schema` combo (requires running server fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)