### PR TITLE
fix(moe): Nemotron-H non-gated NVFP4 — wire expert_gemm into MoE batch cache

### DIFF
--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1552,6 +1552,62 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                         auto expert_gemm = [&](const Tensor& a, Tensor& c, const Tensor& packed, QType qtype,
                                                const std::vector<Tensor>& fallback,
                                                const std::vector<TensorID>& fallback_ids, int eidx) {
+                            // NVFP4 MoE batch cache path (Nemotron-H non-gated, and any
+                            // NVFP4 MoE model when batch_dequant_buf is too small to fire
+                            // the NVFP4→FP16 batch path). After cache_moe_native_nvfp4
+                            // builds the contiguous buffer and frees per-expert allocs,
+                            // `fallback[eidx].data` is nullptr and dequant_expert can't
+                            // dispatch NVFP4. Slice the cached MoE result instead.
+                            if (qtype == QType::NVFP4) {
+                                auto it = wcache_.nvfp4_moe.find(packed.data);
+                                if (it != wcache_.nvfp4_moe.end()) {
+                                    const auto& moe_cache = it->second;
+                                    size_t pkd_off = static_cast<size_t>(eidx) *
+                                                     moe_cache.expert_stride_packed;
+                                    size_t ms_off = static_cast<size_t>(eidx) *
+                                                    moe_cache.expert_stride_ms;
+                                    // tensor_scale per expert: device array, sync read.
+                                    // For prefill this fires once per active expert per
+                                    // layer (~128*3*23 = ~9k syncs for 200-token prompt).
+                                    // Optimization: pre-cache to host at promote time
+                                    // (left as follow-up; correctness first).
+                                    float ts_h = 1.0f;
+                                    if (moe_cache.tensor_scales) {
+                                        cudaMemcpyAsync(&ts_h,
+                                                        moe_cache.tensor_scales + eidx,
+                                                        sizeof(float),
+                                                        cudaMemcpyDeviceToHost, stream);
+                                        cudaStreamSynchronize(stream);
+                                    }
+                                    NvFP4QuantResult nw;
+                                    nw.packed_data = static_cast<char*>(moe_cache.packed_data) +
+                                                     pkd_off;
+                                    nw.micro_scales = static_cast<char*>(moe_cache.micro_scales) +
+                                                      ms_off;
+                                    nw.tensor_scale = ts_h;
+                                    nw.N = static_cast<int>(moe_cache.N);
+                                    nw.K = static_cast<int>(moe_cache.K);
+                                    int M = static_cast<int>(a.shape[0]);
+                                    if (M == 1) {
+                                        gemv_nvfp4_kpar(nw, static_cast<const half*>(a.data),
+                                                        static_cast<half*>(c.data),
+                                                        static_cast<int>(nw.N),
+                                                        static_cast<int>(nw.K), stream);
+                                    } else {
+                                        int64_t a_shape[2] = {a.shape[0],
+                                                              static_cast<int64_t>(nw.K)};
+                                        int64_t c_shape[2] = {a.shape[0],
+                                                              static_cast<int64_t>(nw.N)};
+                                        Tensor a_t(
+                                            const_cast<void*>(static_cast<const void*>(a.data)),
+                                            QType::F16, 2, a_shape, true);
+                                        Tensor c_t(c.data, QType::F16, 2, c_shape, true);
+                                        gemm_nvfp4(nw, a_t, c_t, stream);
+                                    }
+                                    return;
+                                }
+                            }
+
                             // NVFP4 prequant path: native NVFP4 GEMV (any batch size)
                             const bool has_nvfp4_id = (!fallback_ids.empty() &&
                                                        static_cast<size_t>(eidx) < fallback_ids.size() &&

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1842,7 +1842,14 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 g = cache_moe_native_nvfp4(L.expert_gate_packed, L.expert_w_gate);
                 u = cache_moe_native_nvfp4(L.expert_up_packed, L.expert_w_up);
                 d = cache_moe_native_nvfp4(L.expert_down_packed, L.expert_w_down);
-                if ((g || u || d) && !(g && u && d)) {
+                // Non-gated MoE (e.g. Nemotron-H NemotronHForCausalLM): no gate
+                // projection exists, so g=0 is expected when up and down cached.
+                // Suppress the misleading warning in that case; expert_gemm's
+                // wcache_.nvfp4_moe lookup handles the missing-gate path.
+                bool non_gated = (L.expert_gate_packed.data == nullptr &&
+                                  (L.expert_w_gate.empty() ||
+                                   L.expert_w_gate[0].data == nullptr));
+                if ((g || u || d) && !(g && u && d) && !(non_gated && u && d)) {
                     IMP_LOG_WARN(
                         "Layer %d: partial NVFP4 MoE native cache "
                         "(g=%d u=%d d=%d) — fast path may not engage",


### PR DESCRIPTION
## Summary

Nemotron-3-Nano-30B-A3B-NVFP4 produced output completely unrelated to the prompt — Python imports, document-extraction commentary, etc. The model wasn't broken; the fast NVFP4 expert dispatch was silently corrupting weights.

## Root cause

Nemotron-H (`NemotronHForCausalLM`) is a **non-gated MoE** — only `up_proj` and `down_proj` exist in SafeTensors, no `gate_proj`. `cache_moe_native_nvfp4` correctly skips gate (returns false because experts vector is empty) and successfully caches up + down (`g=0 u=1 d=1`). The per-expert source allocations are then freed at `executor_pre_dequant.cu:1856` once the contiguous NVFP4 buffer is built.

When the prefill NVFP4 batch path predicate at `executor_forward_moe.cu:1240` fails — e.g. `moe_.batch_dequant_buf` was sized for fewer experts than the model has (Nemotron-H needs 128, buffer fit 64 in this VRAM-constrained run) — control falls through to the legacy fallback. There `expert_gemm` calls `dequant_expert` which calls `dequant_gpu` with `qtype=NVFP4 (71)`. `dequant_gpu` only handles legacy GGUF Q-types and silently logs "unsupported qtype 71" without writing to the destination buffer. Garbage feeds the GEMM. Output is plausible but unrelated to the prompt.

## Fix

In `expert_gemm`, before falling through to `dequant_expert`, check if `qtype == NVFP4` and `wcache_.nvfp4_moe[packed.data]` exists. If yes, slice the cached `NvFP4MoEQuantResult` for the requested expert (`packed_data + e*expert_stride_packed`, `micro_scales + e*expert_stride_ms`, `tensor_scales[e]`) and dispatch through the existing `gemv_nvfp4_kpar` / `gemm_nvfp4` paths.

Also suppresses the misleading `"Layer X: partial NVFP4 MoE native cache (g=0 u=1 d=1) — fast path may not engage"` warning when the architecture is genuinely non-gated. The `expert_gemm` lookup handles the missing gate cleanly.

## Empirical result on Nemotron-3-Nano-30B-A3B-NVFP4

| | before fix | after fix |
|---|:---:|:---:|
| Phase 4 battery (20 prompts) | **0/20 PASS** | **12/20 PASS** |
| `qtype 71` errors per request | ~3000+ | **0** |
| `factual_capital` output | `\`\`\`python import re...` | `Paris.` (after thinking block) |

Remaining 8/20 failures are mostly validator-prompt-mismatches:
- prompts 1, 2: model thinks out loud as plain text ("The user says..."); validator's `first_n_tokens=5` check fails on chain-of-thought tokens, but answer contains the correct needle later
- prompt 6: `long_context_recall` — separate chunked-prefill bug (PR #114)
- prompt 19: Fibonacci 5-vs-6 convention disagreement (validator artifact, see PR #113)
- prompts 5, 9, 11, 20: real edge cases (long-context recall, translation, counting, tool-format)

## Performance follow-up

The current fix calls `cudaMemcpyAsync(&tensor_scale_h, ...)` synchronously per active expert per layer. For Nemotron-H (128 experts × 3 projections × 23 MoE layers) this is ~9k syncs per prompt — a real but bounded cost. Pre-caching `tensor_scales` to host at promote time would eliminate the syncs. Left as follow-up; correctness first.

## Test plan

- [x] `make verify-fast` clean (Qwen3-4B Q8_0 unchanged: decode +5%, prefill +8%, smoke pass)
- [x] Nemotron-H phase4 battery: 0/20 → 12/20
- [x] No `qtype 71` errors in docker logs (was 8000+ per prompt session)
- [ ] Cross-check Qwen3-Coder-NVFP4 / Qwen3.6-NVFP4 unchanged (gated MoE, took fast path before, should still take it)
- [ ] Performance impact on Nemotron-H prefill (sync overhead documented as known cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)