### PR TITLE
fix(server): single-chunk prefill default — fixes Gemma-4 long-context recall

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,31 +12,15 @@ Gemma-4's dual head_dim layout (256 SWA / 512 global) doesn't fit the FP8 KV wri
 
 Default KV dtype is FP16; FP8 is opt-in via `--kv-fp8` (or `kv_cache.dtype = "fp8"` in `imp.conf`). Coherent on Qwen3 dense, Qwen3.5/3.6 GDN, and Llama-3.2.
 
-### Gemma-4 long-context recall — confirmed imp bug (not model-inherent)
+### Chunked prefill: missing past-KV in attention (paged-prefill kernel pending)
 
-The 2048-token sentinel-recall test in `tests/fixtures/battery_prompts.json` fails on Gemma-4 in every format imp can serve (llm-compressor NVFP4, Q8_0 GGUF). Doc-length sweep 128–2048 tokens shows failure starts at the 768–1024 boundary and is consistent above.
+Root-caused 2026-05-07 via cross-engine A/B (same `gemma-4-26B-A4B-it-Q8_0.gguf`, llama.cpp v9049 vs imp at chunk=512). imp's chunked prefill at `src/graph/executor_attention.cu:188-190` extracts Q/K/V views over the current chunk only (size n=chunk_len). The attention path computes scores over [chunk_len, chunk_len] without reading past chunks' K/V from the cache — chunk N's queries cannot attend to positions [0, offset).
 
-Cross-engine A/B 2026-05-07 on the **same `gemma-4-26B-A4B-it-Q8_0.gguf` file**:
+For full-attention models (Qwen3, Llama) decode recovers via paged attention on the first generated token. For Gemma-4's 5:1 SWA:full architecture the bug bites hard: propagated hidden states are corrupted enough that decode cannot recover. Long-context sentinel recall fails ≥1024 tokens.
 
-| doc tokens | imp | llama.cpp (`ghcr.io/ggml-org/llama.cpp:server-cuda` v9049) |
-|---:|:---:|:---:|
-| 128–512 | mostly ✓ | ✓ |
-| 768 | ✓ on Q8_0 | ✓ |
-| 1024 | ✗ regurgitates doc | ✓ |
-| 1280 | ✗ "not in text" | ✓ |
-| 1536 | ✗ "not in text" | ✓ |
-| 1800 | ✗ corrupted "MERIDIAN→WORD" | ✓ |
-| 2048 | ✗ "moon could read its spine" | ✓ |
+PR #114 (`fix(server): drop 512-token prefill chunking default`) ships the practical mitigation: default `prefill_chunk_size=0` means "single-chunk up to executor max_tokens", clamped by `engine.cpp:1644`. This avoids triggering the bug for typical prompts at the cost of decode blocking during long single-shot prefills. Multi-tenant servers that need decode-latency guarantees should set `--prefill-chunk-size` explicitly. Result: Gemma-4-NVFP4 phase4 battery 18/20 → 19/20 (the remaining failure is a Fibonacci-convention validator artifact, not a recall bug). Doc-length sweep 128–3000 token: 11/11 pass (was 4/11).
 
-llama.cpp passes every size. Same model, same prompt, same sentinel. So **imp has a Gemma-4 long-context bug** — not a model limitation, not an NVFP4 path issue (Q8_0 fails the same way), and not imp's general long-context (Qwen3-30B-Modelopt passes 128–2048 in imp).
-
-Suspected: interaction of Gemma-4's 5:1 SWA:full architecture with imp's attention dispatch at `executor_attention.cu:688-763`. A workaround comment at `:701-712` already acknowledges "FMHA chain emits 'own owners and' garbage" for SWA at sliding_active and routes through `naive_attention_prefill`, but per the cross-engine A/B that workaround doesn't fully fix recall. Code paths affected at the failure boundary:
-
-- SWA layer (hd=256), n=1024 exactly: cuBLAS path with causal-only mask (sliding_window not plumbed through `attention_cublas_prefill`).
-- SWA layer at n>1024: `naive_attention_prefill` with window — but recall still fails; root cause not yet isolated.
-- Global layer at n>1024: cuBLAS path (no sliding window applies). FP32 S-matrix.
-
-Real fix needs per-layer numerical comparison vs llama.cpp at long context to identify the exact divergence (RoPE? Q-norm? cuBLAS algorithm choice? KV cache layout?). See `memory/llm_compressor_input_scale_dead_end_2026_05_07.md` for the full sweep + bracket recipe.
+The deeper bug (chunked prefill not reading past KV) remains for explicit-chunk callers. The proper fix is a paged-prefill kernel that reads K/V from cache during chunked attention — separate, larger work.
 
 ### NVFP4 SmoothQuant input_scale (Mistral-3.2 NVFP4)
 

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -254,9 +254,16 @@ ImpConfig build_config(const ServerArgs& args, const std::string& model_path, co
     }
 
     int chunk = overrides.value("prefill_chunk_size", args.prefill_chunk_size);
-    // Default to 512-token chunks in server mode so prefill doesn't block decode
-    if (chunk <= 0)
-        chunk = 512;
+    // Default chunk = 0 means "single chunk up to executor max_tokens"
+    // (capped in engine.cpp:1644). Earlier 512-token default for "decode
+    // doesn't block" is wrong: chunked prefill currently computes attention
+    // only within each chunk — past-chunk K/V in the cache is not included.
+    // For Gemma-4 (5:1 SWA:full architecture) this corrupts long-context
+    // recall above ~1024 tokens; cross-engine A/B vs llama.cpp confirmed
+    // imp fails 1024+ tok sentinel recall while llama.cpp passes (memory/
+    // llm_compressor_input_scale_dead_end_2026_05_07.md). Multi-tenant
+    // servers that need decode-latency guarantees should set chunk
+    // explicitly via --prefill-chunk-size.
     config.prefill_chunk_size = chunk;
 
     int nvfp4 = overrides.value("decode_nvfp4", args.decode_nvfp4);


### PR DESCRIPTION
## Summary

- Drops the `prefill_chunk_size <= 0 → 512` default; effective chunk now equals executor `max_tokens` (typically 4096+), giving single-chunk prefill for typical prompts.
- Roadmap doc rewrite: long-context section now correctly identifies the issue as "chunked prefill missing past KV", not the previously-suspected attention-path bug.

## Why

`executor_attention.cu:188-190` extracts Q/K/V views over the current chunk only, so for chunk N at offset > 0 the attention scores compute over `[chunk_len, chunk_len]` without reading past chunks' K/V from the cache. Queries can't attend to positions `[0, offset)`.

Full-attention models (Qwen3 etc.) mask this because decode reads the full KV cache via paged attention and recovers the answer. **Gemma-4's 5:1 SWA:full architecture** bites hard: the SWA window=1024 spans far into past chunks that the prefill ignored, and the propagated hidden states are corrupted past recovery.

Cross-engine A/B 2026-05-07 confirmed: same `gemma-4-26B-A4B-it-Q8_0.gguf` file passes the 2048-token sentinel-recall test on llama.cpp v9049 at all sizes 128–2048; on imp it fails at ≥1024.

The proper fix (paged-prefill kernel that reads past KV from cache during chunked prefill attention) is a separate, larger work item. Until then, single-chunk prefill is the correct default.

## Empirical results — `gemma-4-26B-A4B-it-Q8_0`

| Test                                            | Before | After |
|-------------------------------------------------|--------|-------|
| Doc-length sweep 128–3000 (max_tokens=512)      | 4/11   | **11/11** |
| Gemma-4-NVFP4 phase4 battery                    | 18/20  | **19/20** |

Remaining failure: prompt 19 spec_decoding_compat (Fibonacci 5-vs-6 convention validator artifact, not a recall bug).

## Trade-off

Multi-tenant servers that need decode-latency guarantees during large prefills can pass `--prefill-chunk-size` explicitly. The default now favours correctness for typical single-tenant usage.

## Test plan

- [x] `make verify-fast` passes (full unit + perf gate + Qwen3-4B Q8_0 smoke prompt).
- [x] Pre-push hook (`verify-fast`) confirms.
- [ ] Recommended manual smoke: Gemma-4 long-context prompts ≥1024 tokens with sentinel recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)