### PR TITLE
fix(nvfp4): graph-safe gemm_nvfp4 dequant fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,7 @@ if(IMP_BUILD_TESTS)
         tests/test_nvfp4_quant_ref.cu
         tests/test_nvfp4_quant_hw.cu
         tests/test_nvfp4_gemv_kpar_loop.cu
+        tests/test_nvfp4_gemm_graph_capture.cu
         tests/test_turboquant.cu
         tests/test_cutlass_grouped_3x_nvfp4.cu
         tests/test_cutlass_nvfp4_alpha.cu

--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -359,6 +359,13 @@ public:
     // budget: VRAM budget with per-phase caps computed by Engine::plan_vram_budget().
     void pre_dequant_weights(cudaStream_t stream, const VRAMBudget& budget);
 
+    // Allocate the gemm_nvfp4 dequant workspace based on max NVFP4 weight size.
+    // Must be called AFTER pre_dequant_weights() so wcache_.nvfp4 is populated.
+    // Skips allocation if no NVFP4 weights exist or if the largest weight
+    // exceeds a sanity cap (currently 512 MiB) — in those cases the gemm_nvfp4
+    // fallback continues to use lazy cudaMalloc on non-captured streams.
+    bool allocate_nvfp4_dequant_workspace();
+
     // Set KV layer mapping (must be called before forward pass for hybrid models)
     void set_kv_layer_map(std::vector<int> map) {
         kv_layer_map_ = std::move(map);
@@ -532,6 +539,13 @@ private:
     // LRU cache for host-resident expert weights on GPU.
     // Keeps recently-used experts in VRAM to avoid repeated H2D copies.
     ExpertLRUCache expert_cache_;
+
+    // Pre-allocated dequant scratch for the gemm_nvfp4 fallback (M>1 only).
+    // Set up by allocate_nvfp4_dequant_workspace() and registered with the
+    // free function via set_nvfp4_dequant_workspace(). Allows the fallback
+    // path to run inside CUDA stream capture without crashing on cudaMalloc.
+    void* nvfp4_dequant_ws_buf_ = nullptr;
+    size_t nvfp4_dequant_ws_size_ = 0;
 
     // Weight caches (FP16, FP8, NVFP4, CUTLASS NVFP4/MXFP4, fused KV/gate+up)
     WeightCaches wcache_;

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -618,6 +618,47 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
     }
 }
 
+bool GraphExecutor::allocate_nvfp4_dequant_workspace() {
+    // Iterate populated NVFP4 weight cache to find the largest weight matrix.
+    // The gemm_nvfp4 fallback dequantizes one weight at a time to FP16 — the
+    // workspace only needs to fit the LARGEST single weight (N × K × 2 bytes).
+    size_t max_bytes = 0;
+    for (const auto& [ptr, qr] : wcache_.nvfp4) {
+        size_t bytes = static_cast<size_t>(qr.N) * qr.K * sizeof(half);
+        if (bytes > max_bytes)
+            max_bytes = bytes;
+    }
+    if (max_bytes == 0) {
+        // No NVFP4 weights — nothing to do. The fallback won't fire.
+        return true;
+    }
+
+    // Sanity cap: skip workspace alloc for huge weights (e.g. NVFP4 LM head
+    // would be ~1.5 GiB for Qwen3.6-class models). The fallback continues
+    // to use lazy cudaMalloc on non-captured streams; graph capture will
+    // fail-loud via the cudaStreamIsCapturing guard.
+    constexpr size_t kCap = 512ULL * 1024 * 1024;  // 512 MiB
+    if (max_bytes > kCap) {
+        IMP_LOG_WARN(
+            "gemm_nvfp4 dequant workspace: largest NVFP4 weight is %.2f MiB > %.0f MiB cap, "
+            "skipping pre-alloc. M>1 fallback during graph capture will fail-loud.",
+            max_bytes / (1024.0 * 1024.0), kCap / (1024.0 * 1024.0));
+        return false;
+    }
+
+    nvfp4_dequant_ws_buf_ = vram_alloc(vram_alloc_, max_bytes, "nvfp4_dequant");
+    if (!nvfp4_dequant_ws_buf_) {
+        IMP_LOG_WARN("gemm_nvfp4 dequant workspace: alloc failed (%zu bytes)", max_bytes);
+        nvfp4_dequant_ws_size_ = 0;
+        return false;
+    }
+    nvfp4_dequant_ws_size_ = max_bytes;
+    set_nvfp4_dequant_workspace(nvfp4_dequant_ws_buf_, nvfp4_dequant_ws_size_);
+    IMP_LOG_INFO("gemm_nvfp4 dequant workspace: %.2f MiB (graph-safe M>1 fallback)",
+                 max_bytes / (1024.0 * 1024.0));
+    return true;
+}
+
 void GraphExecutor::release_moe_batch_buf() {
     if (moe_.batch_dequant_buf) {
         size_t freed = moe_.batch_dequant_buf_size;
@@ -754,6 +795,14 @@ void GraphExecutor::free_buffers() {
 
     moe_.free(vram_alloc_);
     expert_cache_.destroy();
+
+    // Free gemm_nvfp4 dequant workspace and unregister from the free function.
+    if (nvfp4_dequant_ws_buf_) {
+        set_nvfp4_dequant_workspace(nullptr, 0);
+        vram_free(vram_alloc_, nvfp4_dequant_ws_buf_);
+        nvfp4_dequant_ws_buf_ = nullptr;
+        nvfp4_dequant_ws_size_ = 0;
+    }
     if (d_sample_result_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_sample_result_));
         d_sample_result_ = nullptr;

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -1180,8 +1180,45 @@ static void* s_nvfp4_dequant_buf = nullptr;
 static size_t s_nvfp4_dequant_buf_size = 0;
 static std::mutex s_nvfp4_dequant_mtx;
 
+// Pre-allocated workspace from the executor. When set, ensure_dequant_buffer
+// uses this instead of the lazy cudaMalloc path — which would fail inside
+// CUDA stream capture. Lifetime owned by caller of set_nvfp4_dequant_workspace.
+static void* s_nvfp4_dequant_ws_buf = nullptr;
+static size_t s_nvfp4_dequant_ws_size = 0;
+
+void set_nvfp4_dequant_workspace(void* buf, size_t size_bytes) {
+    std::lock_guard<std::mutex> lock(s_nvfp4_dequant_mtx);
+    s_nvfp4_dequant_ws_buf = buf;
+    s_nvfp4_dequant_ws_size = size_bytes;
+}
+
+size_t nvfp4_lazy_dequant_buf_size_for_testing() {
+    std::lock_guard<std::mutex> lock(s_nvfp4_dequant_mtx);
+    return s_nvfp4_dequant_buf_size;
+}
+
 // Must be called with s_nvfp4_dequant_mtx held.
-static void* ensure_dequant_buffer(size_t needed) {
+static void* ensure_dequant_buffer(size_t needed, cudaStream_t stream) {
+    // Prefer the pre-allocated workspace (graph-safe path).
+    if (s_nvfp4_dequant_ws_buf && needed <= s_nvfp4_dequant_ws_size)
+        return s_nvfp4_dequant_ws_buf;
+
+    // If the stream is in capture mode, cudaMalloc would fail with "operation
+    // not permitted when stream is capturing". Refuse cleanly with a clear
+    // error rather than letting the runtime crash the capture state.
+    cudaStreamCaptureStatus cap_status = cudaStreamCaptureStatusNone;
+    if (cudaStreamIsCapturing(stream, &cap_status) == cudaSuccess &&
+        cap_status == cudaStreamCaptureStatusActive) {
+        IMP_LOG_ERROR(
+            "gemm_nvfp4: dequant fallback called inside CUDA stream capture but no "
+            "pre-allocated workspace covers %zu bytes (have %zu). cudaMalloc inside "
+            "capture would fail. Pre-allocate via set_nvfp4_dequant_workspace() "
+            "before capture begins.",
+            needed, s_nvfp4_dequant_ws_size);
+        return nullptr;
+    }
+
+    // Non-capture path: legacy lazy cudaMalloc (re-grows as needed).
     if (needed <= s_nvfp4_dequant_buf_size)
         return s_nvfp4_dequant_buf;
     if (s_nvfp4_dequant_buf)
@@ -1233,7 +1270,7 @@ void gemm_nvfp4(const NvFP4QuantResult& A, const Tensor& B, Tensor& C, cudaStrea
     std::lock_guard<std::mutex> lock(s_nvfp4_dequant_mtx);
 
     size_t A_fp16_bytes = (size_t)(N * K) * sizeof(half);
-    void* dequant_buf = ensure_dequant_buffer(A_fp16_bytes);
+    void* dequant_buf = ensure_dequant_buffer(A_fp16_bytes, stream);
     if (!dequant_buf)
         return;
 

--- a/src/quant/nvfp4_gemm.h
+++ b/src/quant/nvfp4_gemm.h
@@ -77,4 +77,22 @@ void gemv_nvfp4_moe_gate_up_fused(const NvFP4MoEQuantResult& gate, const NvFP4Mo
 // PDL registration for all NVFP4 GEMV kernels (called at init when PDL enabled).
 void nvfp4_gemv_pdl_register();
 
+// Set the pre-allocated dequant scratch buffer for the gemm_nvfp4 fallback
+// path (M>1 dequant→FP16→cuBLAS). When set and large enough, gemm_nvfp4
+// reuses this buffer instead of attempting a cudaMalloc — which would fail
+// inside CUDA stream capture. Pass nullptr/0 to clear (e.g., on engine
+// destroy).
+//
+// The fallback path only fires for M>1, so the buffer is sized for the
+// FP16 dequant of the LARGEST NVFP4 weight matrix in the model (N×K×2
+// bytes). The caller is responsible for the buffer's lifetime — this
+// function only stores the pointer and size for later use by ensure_dequant_buffer().
+void set_nvfp4_dequant_workspace(void* buf, size_t size_bytes);
+
+// Test probe: returns the current size of the lazy cudaMalloc'd dequant
+// buffer (the legacy non-graph-safe path). When a workspace is set via
+// set_nvfp4_dequant_workspace(), subsequent gemm_nvfp4 calls should not
+// grow this buffer. Exposed for tests to assert workspace-vs-lazy choice.
+size_t nvfp4_lazy_dequant_buf_size_for_testing();
+
 }  // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1166,6 +1166,13 @@ bool Engine::init_kv_cache() {
     executor_->pre_dequant_weights(stream_, vram_budget);
     dequant_done_ = true;
     cudaStreamSynchronize(stream_);
+
+    // Pre-allocate the gemm_nvfp4 fallback dequant workspace. Sized from
+    // wcache_.nvfp4 which is populated by pre_dequant_weights above, so this
+    // call must come AFTER. Lets the M>1 fallback path (used by future
+    // multi-token verify / spec-decode) run inside CUDA stream capture
+    // without crashing on cudaMalloc.
+    (void)executor_->allocate_nvfp4_dequant_workspace();
     if (config_.use_fp8_prefill)
         IMP_LOG_INFO("Weight cache: FP8 E4M3 (2x prefill throughput on sm_120)");
 

--- a/tests/test_nvfp4_gemm_graph_capture.cu
+++ b/tests/test_nvfp4_gemm_graph_capture.cu
@@ -1,0 +1,202 @@
+// Regression tests for the gemm_nvfp4 fallback's CUDA-stream-capture safety.
+//
+// The M>1 fallback in gemm_nvfp4 dequantizes the NVFP4 weight to FP16 and
+// calls cuBLAS GEMM. Historically the dequant scratch buffer was lazy-allocated
+// via cudaMalloc on first use, which crashes when the call happens inside a
+// captured CUDA stream ("operation not permitted when stream is capturing").
+// Memo: spec_decode_qwen36_broken_2026_05_02.md (Failure 2).
+//
+// Fix: pre-allocated workspace registered via set_nvfp4_dequant_workspace().
+// When set and large enough, ensure_dequant_buffer() reuses it instead of
+// touching the host allocator. When the workspace is missing AND the stream
+// is in capture mode, the path now fails-loud (clear log, returns nullptr)
+// instead of crashing the runtime via cudaMalloc.
+//
+// NOTE: this fix addresses the cudaMalloc-during-capture bug, NOT the
+// orthogonal fact that cuBLAS GEMM itself isn't reliably graph-safe in some
+// configurations (algo reselect under capture can fail with internal errors).
+// These tests therefore verify the workspace decision and the capture-guard,
+// without trying to actually replay the captured graph.
+
+#include "quant/nvfp4_quant.h"
+#include "quant/nvfp4_gemm.h"
+#include "core/tensor.h"
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <vector>
+
+namespace imp {
+namespace {
+
+class NvFP4GemmGraphCapture : public ::testing::Test {
+protected:
+    void SetUp() override { cudaStreamCreate(&stream_); }
+    void TearDown() override {
+        if (stream_)
+            cudaStreamDestroy(stream_);
+        // Always clear workspace so tests don't pollute each other.
+        set_nvfp4_dequant_workspace(nullptr, 0);
+        // Drain any sticky CUDA error state from this test (e.g. abandoned
+        // captures) so subsequent test suites start with a clean runtime.
+        cudaGetLastError();
+    }
+    cudaStream_t stream_ = nullptr;
+};
+
+// Build a tiny NVFP4 weight matrix sized so the dequant workspace fits
+// comfortably (well below typical sanity caps). N×K=64×64 FP16 = 8 KiB.
+struct TinyNvFP4 {
+    half *d_w = nullptr, *d_a = nullptr, *d_c = nullptr;
+    NvFP4QuantResult qr{};
+    int N = 64, K = 64, M = 4;
+
+    void create(cudaStream_t stream) {
+        std::vector<half> h_w(static_cast<size_t>(N) * K);
+        std::vector<half> h_a(static_cast<size_t>(M) * K);
+        for (size_t i = 0; i < h_w.size(); ++i)
+            h_w[i] = __float2half(((static_cast<int>(i * 17u) % 31) - 15) * 0.01f);
+        for (size_t i = 0; i < h_a.size(); ++i)
+            h_a[i] = __float2half(((static_cast<int>(i * 23u) % 29) - 14) * 0.02f);
+
+        cudaMalloc(&d_w, h_w.size() * sizeof(half));
+        cudaMalloc(&d_a, h_a.size() * sizeof(half));
+        cudaMalloc(&d_c, static_cast<size_t>(M) * N * sizeof(half));
+        cudaMemcpy(d_w, h_w.data(), h_w.size() * sizeof(half), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_a, h_a.data(), h_a.size() * sizeof(half), cudaMemcpyHostToDevice);
+
+        int64_t wshape[2] = {N, K};
+        Tensor w_t(d_w, QType::F16, 2, wshape, /*on_device=*/true);
+        quantize_fp16_to_nvfp4(w_t, qr, stream);
+        cudaStreamSynchronize(stream);
+    }
+
+    void destroy() {
+        free_nvfp4_result(qr);
+        if (d_w)
+            cudaFree(d_w);
+        if (d_a)
+            cudaFree(d_a);
+        if (d_c)
+            cudaFree(d_c);
+    }
+};
+
+// When a workspace is registered and large enough, gemm_nvfp4 must NOT grow
+// the legacy lazy cudaMalloc buffer — the workspace is the graph-safe path
+// and proves it's the active branch.
+TEST_F(NvFP4GemmGraphCapture, WorkspaceIsPreferredOverLazyAlloc) {
+    TinyNvFP4 tw;
+    tw.create(stream_);
+
+    // Pre-allocate workspace sized for one full FP16 dequant of the weight.
+    size_t ws_bytes = static_cast<size_t>(tw.N) * tw.K * sizeof(half);
+    void* ws = nullptr;
+    ASSERT_EQ(cudaMalloc(&ws, ws_bytes), cudaSuccess);
+    set_nvfp4_dequant_workspace(ws, ws_bytes);
+
+    size_t lazy_before = nvfp4_lazy_dequant_buf_size_for_testing();
+
+    int64_t ashape[2] = {tw.M, tw.K};
+    int64_t cshape[2] = {tw.M, tw.N};
+    Tensor a_t(tw.d_a, QType::F16, 2, ashape, /*on_device=*/true);
+    Tensor c_t(tw.d_c, QType::F16, 2, cshape, /*on_device=*/true);
+    cudaMemsetAsync(tw.d_c, 0, static_cast<size_t>(tw.M) * tw.N * sizeof(half), stream_);
+    gemm_nvfp4(tw.qr, a_t, c_t, stream_);
+    cudaStreamSynchronize(stream_);
+
+    size_t lazy_after = nvfp4_lazy_dequant_buf_size_for_testing();
+    EXPECT_EQ(lazy_after, lazy_before)
+        << "Workspace was set with " << ws_bytes
+        << " bytes (>= needed) yet the legacy lazy buffer grew from " << lazy_before << " to "
+        << lazy_after << " — the workspace branch was bypassed";
+
+    // Also check the GEMM produced something (the dequant + cuBLAS path
+    // ran end-to-end against the workspace, not just bailed out).
+    std::vector<half> h_c(static_cast<size_t>(tw.M) * tw.N);
+    cudaMemcpy(h_c.data(), tw.d_c, h_c.size() * sizeof(half), cudaMemcpyDeviceToHost);
+    int n_nonzero = 0;
+    for (auto v : h_c) {
+        if (__half2float(v) != 0.0f)
+            ++n_nonzero;
+    }
+    EXPECT_GT(n_nonzero, 0) << "GEMM via workspace produced all-zero output";
+
+    set_nvfp4_dequant_workspace(nullptr, 0);
+    cudaFree(ws);
+    tw.destroy();
+}
+
+// Without a pre-allocated workspace, gemm_nvfp4 inside CUDA stream capture
+// must NOT crash the runtime via cudaMalloc. The cudaStreamIsCapturing guard
+// in ensure_dequant_buffer logs an error and returns nullptr, gemm_nvfp4
+// early-returns. We verify by checking the runtime stays usable for further
+// ordinary work afterwards.
+TEST_F(NvFP4GemmGraphCapture, FallbackInsideCaptureWithoutWorkspaceFailsLoud) {
+    TinyNvFP4 tw;
+    tw.create(stream_);
+
+    // Explicitly clear any previously-set workspace.
+    set_nvfp4_dequant_workspace(nullptr, 0);
+
+    ASSERT_EQ(cudaStreamBeginCapture(stream_, cudaStreamCaptureModeRelaxed), cudaSuccess);
+
+    int64_t ashape[2] = {tw.M, tw.K};
+    int64_t cshape[2] = {tw.M, tw.N};
+    Tensor a_t(tw.d_a, QType::F16, 2, ashape, /*on_device=*/true);
+    Tensor c_t(tw.d_c, QType::F16, 2, cshape, /*on_device=*/true);
+    // Should NOT crash — guarded by cudaStreamIsCapturing inside ensure_dequant_buffer.
+    gemm_nvfp4(tw.qr, a_t, c_t, stream_);
+
+    cudaGraph_t graph = nullptr;
+    cudaError_t end_err = cudaStreamEndCapture(stream_, &graph);
+    if (graph)
+        cudaGraphDestroy(graph);
+    // We don't assert end_err here — cuBLAS-or-other internal state may have
+    // invalidated the capture before our guard fired. The point is that the
+    // runtime is still usable below.
+    (void)end_err;
+
+    // Drain sticky errors and verify the CUDA runtime is still healthy.
+    cudaGetLastError();
+    void* probe = nullptr;
+    EXPECT_EQ(cudaMalloc(&probe, 16), cudaSuccess) << "Runtime still in error state after failed capture";
+    if (probe)
+        cudaFree(probe);
+
+    tw.destroy();
+}
+
+// Outside capture, with no workspace set, gemm_nvfp4 must continue to lazy-
+// allocate (legacy behaviour) — this is the path used by prefill on
+// non-graph code today.
+TEST_F(NvFP4GemmGraphCapture, FallbackOutsideCaptureUsesLazyAllocAsBefore) {
+    TinyNvFP4 tw;
+    tw.create(stream_);
+
+    set_nvfp4_dequant_workspace(nullptr, 0);
+
+    int64_t ashape[2] = {tw.M, tw.K};
+    int64_t cshape[2] = {tw.M, tw.N};
+    Tensor a_t(tw.d_a, QType::F16, 2, ashape, /*on_device=*/true);
+    Tensor c_t(tw.d_c, QType::F16, 2, cshape, /*on_device=*/true);
+    cudaMemsetAsync(tw.d_c, 0, static_cast<size_t>(tw.M) * tw.N * sizeof(half), stream_);
+
+    gemm_nvfp4(tw.qr, a_t, c_t, stream_);
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_c(static_cast<size_t>(tw.M) * tw.N);
+    cudaMemcpy(h_c.data(), tw.d_c, h_c.size() * sizeof(half), cudaMemcpyDeviceToHost);
+    int n_nonzero = 0;
+    for (auto v : h_c) {
+        if (__half2float(v) != 0.0f)
+            ++n_nonzero;
+    }
+    EXPECT_GT(n_nonzero, 0) << "Lazy-alloc path produced all-zero output";
+
+    tw.destroy();
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Summary

- gemm_nvfp4's M>1 dequant fallback lazy-allocated its FP16 scratch via cudaMalloc on first use, which crashes inside CUDA stream capture (\"operation not permitted when stream is capturing\"). Memo: spec_decode_qwen36_broken_2026_05_02.md (Failure 2). Bug is dormant in current code paths but blocks future spec-decode/MTP integration.
- Pre-allocates the dequant workspace at executor init (sized for the largest NVFP4 weight, capped 512 MiB) and registers it via new \`set_nvfp4_dequant_workspace()\` API. \`ensure_dequant_buffer\` prefers the workspace over the lazy path.
- \`cudaStreamIsCapturing\` guard inside \`ensure_dequant_buffer\`: when capture is active and no workspace covers the request, log a clear error and return nullptr instead of crashing on cudaMalloc.

Note: this fix addresses the cudaMalloc-during-capture bug. The orthogonal fact that cuBLAS GEMM itself isn't reliably graph-safe in some configurations (algo reselect under capture) is a larger issue this PR does not attempt.

## Test plan

- [x] 3 new tests in \`tests/test_nvfp4_gemm_graph_capture.cu\` — workspace preference, capture-guard, lazy-alloc preserved
- [x] Full test-quant suite (78 tests) green
- [x] \`make verify-fast\` green: decode +0.79%, prefill +3.89%, smoke pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)