### PR TITLE
ci: auto-enable squash auto-merge on owner PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,30 @@
+name: Auto-merge own PRs
+
+# Enables auto-merge (squash) automatically on PRs opened by the repo owner.
+# GitHub then merges the PR as soon as required checks pass and the branch
+# is mergeable. Saves the manual "Enable auto-merge" click on every PR.
+#
+# Scope:
+# - Only PRs authored by the repo owner; community PRs still need manual review.
+# - Skips drafts; transitions to ready_for_review re-fire and enable auto-merge.
+# - Squash mode (matches the repo default visible in `viewerDefaultMergeMethod`).
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login == github.repository_owner
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

GitHub's auto-merge feature is already enabled at the repo level (\`allow_auto_merge=true\`) but must be activated **per-PR** via the \"Enable auto-merge\" button. This workflow does that automatically for PRs opened by the repo owner.

After this lands: open a PR, wait for CI green, GitHub squash-merges automatically. Zero clicks.

**Scope:**
- Only PRs authored by the repo owner (community contributions still require manual review).
- Skips drafts; transitions to \`ready_for_review\` / \`reopened\` re-fire and enable auto-merge then.
- Squash mode (matches the repo's \`viewerDefaultMergeMethod=SQUASH\`).

## Test plan

- [ ] After merge, open a small docs/test PR. Auto-merge should be enabled within seconds (visible in PR sidebar). Once CI passes, PR merges automatically as squash.
- [ ] Optional: open a draft PR — workflow should skip. Marking ready_for_review should fire it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)