### PR TITLE
chore(skills): commit imp-specific Claude Code skills

### DIFF
--- a/.claude/skills/benchmark-cuda/SKILL.md
+++ b/.claude/skills/benchmark-cuda/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: benchmark-cuda
+description: Use when benchmarking, profiling, or A/B-testing CUDA kernels in the imp inference engine on RTX 5090 (sm_120). Triggers on "benchmark kernel", "profile cuda", "ncu", "nsys", "kernel timing", "occupancy", "bandwidth bound", "compute bound", "roofline", "perf baseline", "kernel feels slow", "is this regression real".
+---
+
+# CUDA Kernel Benchmarking — imp / sm_120 / RTX 5090
+
+Pair with `sm120-cuda-expert` for optimization decisions.
+
+## STOP — read first
+
+**Decode (`tg256`) is the only reliable A/B signal.** `pp512` varies up to **2.6× across container restarts** because cuBLAS picks different algorithms each cold start. Never gate on prefill-only numbers; always show decode delta too. The CI gate (`tests/perf_baseline.json`) reflects this: 3% decode threshold, 5% prefill threshold.
+
+## Theoretical peaks (RTX 5090)
+
+| Metric | Peak |
+|--------|------|
+| HBM bandwidth | 1,792 GB/s |
+| FP16 TC | 838 TFLOPS |
+| FP8 TC | 1,677 TFLOPS |
+| FP4 TC | 3,354 TOPS |
+| L2 cache | 96 MB |
+
+Below 60% bandwidth (memory-bound) or 50% compute (compute-bound) → investigate.
+
+## Pick the right tool
+
+| Goal | Tool | Notes |
+|------|------|-------|
+| End-to-end engine perf | `make bench` → `tools/imp-bench/` | runs across baseline models, reports tg/pp |
+| Per-config sweep with MBU/MFU/TTFT/TBT | `bench/bench.py` | CSV output, optional llama.cpp compare |
+| Refresh perf baseline | `scripts/gen_perf_baseline.sh` | run after intentional perf changes; writes `tests/perf_baseline.json` |
+| Regression gate | `make verify-fast` | reads `tests/perf_baseline.json`, 3%/5% thresholds |
+| Single kernel — wall-clock A/B | `cudaEvent` in launcher | see Step 1 |
+| Single kernel — metrics, occupancy, stalls | `ncu` | see Step 2 |
+| Multi-kernel timeline / launch overhead / graph behavior | `nsys` | see Step 3 |
+| Compare imp vs llama.cpp | `bench/profile.sh` | apples-to-apples on same models |
+
+## Step 1: cudaEvent in-code (quick A/B)
+
+```cpp
+cudaEvent_t start, stop;
+cudaEventCreate(&start); cudaEventCreate(&stop);
+
+// Warmup — always >=3 iterations (first launch has JIT/cache penalty)
+for (int i = 0; i < 3; i++) kernel<<<...>>>(...);
+cudaDeviceSynchronize();
+
+cudaEventRecord(start);
+for (int i = 0; i < N_ITER; i++) kernel<<<...>>>(...);
+cudaEventRecord(stop);
+cudaEventSynchronize(stop);
+
+float ms;
+cudaEventElapsedTime(&ms, start, stop);
+float avg_us = (ms / N_ITER) * 1000.0f;
+```
+
+Rules: warmup ≥3, N_ITER ≥100 for kernels <100µs, lock clocks (`sudo nvidia-smi -lgc 2400,2400`; reset `-rgc`), kill concurrent GPU consumers.
+
+## Step 2: Nsight Compute (ncu) — per-kernel metrics
+
+Use the helper to get a consistent metric set:
+
+```bash
+./.claude/skills/benchmark-cuda/ncu-basic.sh "my_kernel.*" ./build/imp-bench
+```
+
+Or invoke directly with the canonical metric list — see `ncu-basic.sh` for the full set. Key metrics to read:
+
+| Metric | Meaning | Target |
+|--------|---------|--------|
+| `sm__throughput.avg.pct_of_peak_sustained_elapsed` | SM utilization | >70% compute-bound |
+| `dram__throughput.avg.pct_of_peak_sustained_elapsed` | HBM bandwidth | >70% memory-bound |
+| `sm__warps_active.avg.pct_of_peak_sustained_active` | Achieved occupancy | context-dependent |
+| `smsp__inst_executed_pipe_tensor_op_*` | TC activity | non-zero if TC kernel |
+| `l1tex__t_sector_hit_rate` | L1 hit rate | >90% for cached |
+| `stall_*` | Where warps stall | lowest = bottleneck |
+
+Always `--launch-skip 3 --launch-count N` to skip warmup. Compile with `-lineinfo` for source-correlated stalls (`--set detailed --import-source yes`).
+
+## Step 3: Nsight Systems (nsys) — timeline
+
+When you suspect: launch overhead, H2D/D2H stalls, stream serialization, CUDA Graph behavior.
+
+```bash
+nsys profile --stats=true -t cuda,nvtx,osrt \
+    --cuda-memory-usage=true -o timeline \
+    --force-overwrite=true ./build/imp-bench
+nsys stats timeline.nsys-rep
+```
+
+**`nsys` needs `--no-cuda-graphs`** when measuring per-kernel times — graph replay hides individual kernel timings.
+
+Red flags: gaps between launches >10µs (CPU-bound) · H2D/D2H during compute without overlap · CUDA Graph not collapsing launches (graph disabled or stream-captured wrong).
+
+## Step 4: Roofline (one-liner)
+
+`AI = total_flops / total_bytes_moved` (matmul FLOPs = `2·M·N·K`; bytes from `dram__bytes.sum` in ncu). Ridge points: FP16=468, FP8=936, FP4=1873 FLOP/byte. AI < ridge → memory-bound; AI > ridge → compute-bound.
+
+## Report template
+
+```
+Kernel: <name>, config: <block=X, grid=Y, smem=Z>
+  Wall:        <us> µs (N=<iters>, warmup=3)
+  DRAM:        <pct>% of 1792 GB/s
+  SM:          <pct>% of peak
+  Occup:       <pct>%
+  TC util:     <pct>%
+  Bound by:    <memory|compute|latency|stalls>  reason: <top stall>
+  vs baseline: <±X%>
+```
+
+## Red flags — STOP and re-run
+
+- Reporting `pp512` delta without `tg256` delta → variance is up to 2.6×, you're seeing noise
+- Skipping warmup → first launch 2–10× worse (JIT + cold caches)
+- Profiling with clocks unlocked → thermal throttling skews A/B
+- Including `cudaMalloc/Free` in timing → allocate once outside the loop
+- Trusting `ncu` wall-clock → ncu serializes/replays kernels; use `nsys` or `cudaEvent` for real time
+- `ncu` without `-lineinfo` → no source correlation
+- Comparing against wrong peak → FP16 ≠ FP8 ≠ FP4 TOPS; pick the kernel's dtype
+- Small `N_ITER` on noisy kernels → run ≥100, check stddev not just mean
+- A/B without graphs both ON and OFF → graph replay can hide silent fallback (see `check-degeneration` skill)

--- a/.claude/skills/benchmark-cuda/ncu-basic.sh
+++ b/.claude/skills/benchmark-cuda/ncu-basic.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ncu-basic.sh — canonical Nsight Compute metric set for imp kernels on sm_120.
+#
+# Usage:
+#   ./ncu-basic.sh "<kernel-regex>" <binary> [<binary-args>...]
+#
+# Example:
+#   ./ncu-basic.sh "fmha.*" ./build/imp-bench --model models/Qwen3-4B-Q8_0.gguf
+#
+# Skips 3 warmup launches, captures 10. Compile with `-lineinfo` and add
+# `--set detailed --import-source yes` for source-correlated stalls.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <kernel-regex> <binary> [<binary-args>...]" >&2
+  exit 1
+fi
+
+KERNEL_REGEX="$1"
+shift
+
+METRICS=(
+  sm__throughput.avg.pct_of_peak_sustained_elapsed
+  gpu__time_duration.sum
+  dram__throughput.avg.pct_of_peak_sustained_elapsed
+  dram__bytes.sum
+  l1tex__t_bytes_pipe_lsu_mem_global_op_ld.sum
+  l1tex__t_sector_hit_rate
+  smsp__inst_executed_pipe_tensor_op_hmma.sum
+  smsp__inst_executed_pipe_tensor_op_qmma.sum
+  sm__warps_active.avg.pct_of_peak_sustained_active
+  smsp__average_warps_issue_stalled_long_scoreboard_per_issue_active.ratio
+  smsp__average_warps_issue_stalled_short_scoreboard_per_issue_active.ratio
+  smsp__average_warps_issue_stalled_mio_throttle_per_issue_active.ratio
+)
+
+# Join metrics with comma
+IFS=,
+METRIC_ARG="${METRICS[*]}"
+unset IFS
+
+exec ncu \
+  --kernel-name "regex:${KERNEL_REGEX}" \
+  --launch-skip 3 \
+  --launch-count 10 \
+  --metrics "${METRIC_ARG}" \
+  "$@"

--- a/.claude/skills/check-degeneration/SKILL.md
+++ b/.claude/skills/check-degeneration/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: check-degeneration
+description: Use when verifying that a model in the imp inference engine produces coherent output without repetition loops, token-stuck states, or state corruption across turns. Triggers on "degenerates", "check degeneration", "repetition loop", "own own own", "stuck token", "multi-turn regression", "does it still work", and after enabling CUDA graphs / changing forward pass / MoE routing / KV cache / GDN state.
+---
+
+# Degeneration Check — imp Inference Engine
+
+Models in imp regress in specific, recurring ways. Run the battery whenever you touch the forward pass, graph capture, MoE routing, KV cache, or GDN state.
+
+## Historical failure modes (what we are guarding against)
+
+| Pattern | Looks like | Root-cause class |
+|---|---|---|
+| Repetition loop | ` own own own…`, ` the the the…` | MoE router precision drift / graph stale pointers / sampling NaN |
+| Short OK, long fails | 15 tokens sensible then loop | KV-block boundary in graph replay; D2H memcpy in captured region |
+| ~3-token abort | `<eos>` or stop_id at step 0–3 | `forward_decode_async` ≠ `forward_logits`; sampler divergence |
+| Multi-turn garble | Turn 1 OK, turn 2 `The I…` | KV not reset; GDN recurrent state leaked; warmup CUDA error |
+| Stuck single token | ` a a a a a` | Logits NaN/Inf; banned mask wrong value; argmax on zeroed buffer |
+| Structurally valid garbage | Grammatical but wrong language mid-stream | Weight-upload bug; quant dequant layout |
+
+## Pass criteria (quantitative)
+
+A run **passes** only when ALL of these hold:
+
+1. **No verbatim repetition**: no token repeats >4 times in a row, no 3-gram repeats >3 times.
+2. **No early abort**: ≥10 generated tokens before any stop condition (unless prompt is single-word factual like "Paris").
+3. **stderr clean**: no match for the grep pattern below (silent fallback masks the bug).
+4. **Decode within 30% of baseline** in `tests/perf_baseline.json` for the same model. >30% drop almost always means graphs fell back silently.
+5. **Multi-turn**: turn 2+ output is grammatical and topical for the new question; KV/state from turn 1 didn't leak.
+
+## The battery
+
+Use existing tooling — do **not** write parallel inline checks.
+
+### 1. GTest battery (covers Short / Second-request / Long / NoLeakedSpecialTokens)
+
+```bash
+make test-gpu GTEST_FILTER="DegenerationTest.*"
+# or with an explicit model:
+IMP_TEST_MODEL=/models/<MODEL>.gguf \
+  ./build/imp-tests --gtest_filter="DegenerationTest.*"
+```
+
+Source: `tests/test_degeneration.cpp` — uses the same imp C API the production engine uses, default model `Qwen3-8B-Q8_0.gguf`.
+
+### 2. Smoke + perf gate (covers real-prompt detector + baseline regression)
+
+```bash
+make verify-fast    # build + filtered tests + perf baseline + 1 smoke prompt (~90s)
+```
+
+Source: `scripts/verify.sh` — runs the canonical degeneration detector against a real model and fails on >3% decode regression vs. `tests/perf_baseline.json`.
+
+### 3. Cross-stack docker smoke (covers tokenizer / chat-template / vision)
+
+```bash
+docker run --rm --gpus all -v $PWD/models:/models imp:test \
+  bash /scripts/smoke_test.sh
+```
+
+Source: `scripts/smoke_test.sh` — runs unit + GPU + E2E + tokenizer + chat-template checks in 6 stages.
+
+### 4. Graphs vs no-graphs parity (only when graph capture / MoE fast-path / async loop changed)
+
+```bash
+# graphs off
+./build/imp-cli --set runtime.cuda_graphs=never \
+  --model models/<MODEL>.gguf --prompt "..." --max-tokens 64 \
+  --temperature 0 --seed 42 > /tmp/no_graph.txt
+
+# graphs on (default)
+./build/imp-cli \
+  --model models/<MODEL>.gguf --prompt "..." --max-tokens 64 \
+  --temperature 0 --seed 42 > /tmp/graph.txt
+
+diff /tmp/no_graph.txt /tmp/graph.txt
+```
+
+**Pass**: identical output for greedy (`temperature=0`). First ~16 tokens identical is a strong signal; later drift is allowed only if non-degenerate.
+
+## Reading stderr (mandatory even if output looks fine)
+
+A silent fallback to per-step decode masks the real bug. Use word boundaries — plain `Inf` matches the normal `Inferred vocab_size=` log line:
+
+```bash
+grep -E "CUDA error|capture failed|falling back|warmup.*invalid|\bNaN\b|is NaN|is Inf" <log>
+```
+
+Any match = **fail**, even if output passed the heuristic. Cross-check measured `tg/s` against the model's row in `tests/perf_baseline.json`; if measured tg is >30% below baseline, graphs almost certainly fell back silently.
+
+## Model-specific known-good probes
+
+| Model | Prompt | Expected contains |
+|---|---|---|
+| Qwen3-4B Q8_0 | "What is the capital of France?" | `Paris` |
+| Qwen3.5-GDN Q8_0 | "Say hello." | non-empty, len ≥ 5 |
+| Gemma-4-26B-A4B Q4_K_M | "What is the capital of France?" | `Paris` (after `<|channel>thought` block) |
+| Llama-3.2-3B | "The capital of France is" | `Paris` |
+
+Pick the first model from this table whose family matches your change. Stable prompts give stable regressions — do not invent new probes.
+
+## Red flags — STOP and re-run
+
+- Judging by short prompt alone → long-decode bugs pass `--max-tokens 30`. Use ≥64.
+- Skipping the stderr grep → silent graph-capture fallback produces wrong output at 20% normal speed.
+- Testing only one model after a shared-code change → MoE / GDN / dense paths diverge; pick 2+ probes.
+- Declaring success on a single seed → for borderline cases re-run with seeds 42, 1, 7.
+- Trusting "looks fine" on multi-turn without a turn-2 probe → KV/GDN state bugs only show up turn 2+.
+
+## When the battery fails
+
+Run `make test-e2e` first — it exercises `Gemma4GraphsTest.LongDecodeStaysCoherent`, `PrimaryModelTest.MultiTurnConversation`, `GDNModelTest.MultiTurnGDNState` which together cover all three state-management classes. Narrow to the failing model + class **before** editing.

--- a/.claude/skills/sm120-cuda-expert/SKILL.md
+++ b/.claude/skills/sm120-cuda-expert/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: sm120-cuda-expert
+description: Use when writing, reviewing, or optimizing CUDA kernels targeting sm_120a (RTX 5090 / Consumer Blackwell, GB202) in the imp inference engine. Triggers on CUDA/PTX kernel code, shared-memory layout, tensor-core MMA, GEMV/GEMM/attention/quantization kernels, decode tok/s under expected, kernel emitting HMMA instead of mxf4nvf4, occupancy or register-pressure questions. Pair with `benchmark-cuda` for measurement and `check-degeneration` after hot-path changes.
+---
+
+# sm_120 CUDA Kernel Expert — imp Inference Engine
+
+Optimal-kernel reference for RTX 5090 (GB202, **sm_120a** — consumer Blackwell). For PTX inline-assembly templates see `references/ptx-patterns.md`. For dead ends, version-dependent gotchas, and root-cause references see `references/known-issues.md`.
+
+## Architecture quick reference
+
+| Spec | Value |
+|------|-------|
+| SMs · CUDA cores · TC | 170 · 21,760 · 680 (4/SM, 5th gen) |
+| L1/SMEM per SM | 128 KB configurable (~99 KB opt-in shared, query `cudaDeviceProp::sharedMemPerBlockOptin`) |
+| L2 cache | 96 MB unified |
+| VRAM | 32 GB GDDR7, 1,792 GB/s |
+| Boost clock | 2,407 MHz |
+| FP4 / FP8 / FP16 TC | 3,354 TOPS / 1,677 TFLOPS / 838 TFLOPS |
+| Native MMA shapes | FP16 `m16n8k16`, FP8 `m16n8k32`, FP4 block-scaled `m16n8k64` |
+
+**sm_120 has NO `tcgen05` / TMEM / `wgmma` / 2-CTA cluster MMA** — those are SM100 (B200) only. Peak path is register-based `mma.sync` with block-scaling, FA2-style.
+
+## The three laws
+
+1. **Decode at batch=1 is launch-overhead-bound first, memory-bound second.** With ~80–120 launches per layer, per-launch µs costs dominate once GEMM is fast. Order of operations: (a) make per-launch GEMM fast (CUTLASS sm_120 NVFP4 fast-path, not slow `gemm_nvfp4` dequant→cuBLAS fallback); (b) capture decode in CUDA Graph (`AsyncGraphLoop`); (c) only then chase memory traffic. A faster kernel alone shows little tok/s gain — but it *enables* graph capture to win because launches no longer hide behind GEMM. Always re-bench graphs ON after a hot-path patch.
+
+2. **Occupancy is king.** Keep registers ≤48/thread for 100% occupancy. **Don't add `__launch_bounds__`** on regular GEMV/attention paths — overrides cost -4.5% to -20%. Two known correct exceptions: HD=128 GDN kernel needs `(HD,1)` to avoid a miscompile; FMHA `(256,1)` is correct on SMEM-limited kernels (~69 KB → 1 block/SM anyway, allows max register allocation).
+
+3. **Quantization type determines kernel strategy.** Q8_0 (simple dequant) → bandwidth-bound → row-parallel + smem-cached activations. Q6_K (complex dequant) → compute-influenced → K-parallel + warp-level work division. NVFP4 prequant → must hit `StorageTier::CUTLASS_NVFP4` (SfAtom layout) for the sm_120a fast path; plain `StorageTier::NVFP4` falls through to slow `gemm_nvfp4`. No universal "best" GEMV.
+
+## What works (top hits)
+
+| Technique | Gain | Detail |
+|-----------|------|--------|
+| **CUDA Graph decode + AsyncGraphLoop** | **+95–376% decode** | Conditional graph w/ PDL, `max_steps=255`. Biggest gain on small-GEMM models. Requires CUTLASS NVFP4 fast-path active first. |
+| CUTLASS sm_120a NVFP4 weight cache | enables graph win | `StorageTier::CUTLASS_NVFP4`. Verify via init log; `StorageTier::NVFP4` = slowpath. |
+| `mma.sync.kind::mxf4nvf4.block_scale` | 2.6× raw MMA over f8f6f4 | k=64 vs k=32; HW applies UE4M3 scale inside MMA. Needs `compute_120a` (see Compile flags). |
+| FP8 prefill cache | +40–60% prefill | FP8×FP8 cuBLAS = 2× TC throughput |
+| NVFP4 prmt register LUT | +4.7–16% | `prmt.b32` replaces SMEM LUT |
+| Inline Q8_1 in O-projection | +5–10% | Eliminates 1 launch + 1 DRAM round-trip |
+| `__ldcs` on KV cache reads | +2–4% decode | Bypass L1, evict-first L2. **KV only, NOT weights.** |
+| 8-warp Blackwell attention | better SM util | 256 threads vs Hopper's 128 |
+
+PTX templates for all of these → `references/ptx-patterns.md`.
+
+## Shared-memory budget
+
+Max opt-in: **~99 KB per block** (NOT H100's 228 KB — query `cudaDeviceProp::sharedMemPerBlockOptin`).
+
+| head_dim | Bq | SMEM | Notes |
+|----|----|----|-------|
+| 64 | 128 | ~89 KB | Double-buffer KV +16 KB |
+| 128 | 64 | ~81 KB | Standard |
+| 256 | 32 | ~88 KB | Qwen3.5 GDN partial-RoPE |
+
+```cuda
+cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+```
+
+## Compile flags
+
+**Target `sm_120a`** (the `a` arch suffix — superset of `120f` that adds `mma.sync.kind::mxf4nvf4.block_scale` and TMA-WS-Grouped-GEMM, both required for the CUTLASS NVFP4 fast path on Mamba2 shapes). Do NOT target `sm_120` or `sm_120f`. Do NOT add a generic `compute_120` PTX fallback (lacks FP8 MMA + block-scale).
+
+```cmake
+set(IMP_SM120_FLAGS "--generate-code=arch=compute_120a,code=sm_120a")
+# also:
+--expt-relaxed-constexpr --extended-lambda
+# Release: -O3 --use_fast_math
+```
+
+`compute_120a` unlocks: `mma.sync.aligned.kind::mxf4nvf4.block_scale`, extended `cp.async.bulk.tensor` (TMA Multicast), Cluster-Launch + CLC, extended mbarrier phases, hardware FP4 saturation `F2FP.SATFINITE.E2M1`. Does NOT unlock `tcgen05.*`, TMEM, `wgmma` — SM100 only.
+
+Guard sm_120 code: `#if __CUDA_ARCH__ >= 1200`.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Targeting `sm_120` / `sm_120f` instead of `sm_120a` | `compute_120a/sm_120a`. `120f` blocks `mxf4nvf4.block_scale` + TMA-WS-grouped-GEMM → forces GDN/Mamba2 onto slow `gemm_nvfp4`. |
+| Routing decode through slow `gemm_nvfp4` (dequant→cuBLAS) | Promote weight to `StorageTier::CUTLASS_NVFP4`. Verify `cutlass_nvfp4 weight cache` log line at init. |
+| Forgetting CUDA Graph re-bench after a kernel speedup | Compute speedup alone doesn't show in tok/s — pair every hot-path patch with graphs-ON A/B. |
+| Assuming H100 SMEM (228 KB) | RTX 5090 max = 99 KB opt-in. Query `cudaDeviceProp::sharedMemPerBlockOptin`. |
+| `__launch_bounds__` on regular paths | -4.5% to -20%. Exceptions: HD=128 GDN miscompile, FMHA SMEM-limited (`256,1`). |
+| `reinterpret_cast` on Q8_0 blocks | 34-byte blocks NOT 4-aligned. Use `memcpy()`. |
+| `__noinline__` on device helpers | Spills to Local Memory (DRAM). Use `__forceinline__`. |
+| Missing `__syncthreads()` after `cp.async wait` | Race on SMEM reads. |
+| Pointer advance without `sizeof(T)` | See FP8 FMHA S_tile bug — `references/known-issues.md`. |
+| Register pressure > 48/thread | `--ptxas-options=-v` and refactor. |
+
+## Where to look next
+
+- **PTX templates** (mxf4nvf4, f8f6f4, cp.async, prmt LUT, FP16→FP8 cvt, warp shuffle, `__ldcs`) → `references/ptx-patterns.md`
+- **Dead ends, version-dependent retries, resolved issues** → `references/known-issues.md`
+- **Repo-internal docs**: `docs/sm120.md` (kernel notes), `docs/sm120-real-perf-plan.md` (active perf plan), `docs/performance.md` (baselines + methodology)
+- **Hot-path source**: `src/compute/` (attention, gemm, NVFP4), `src/quant/` (dequant), `tools/imp-bench/`

--- a/.claude/skills/sm120-cuda-expert/references/known-issues.md
+++ b/.claude/skills/sm120-cuda-expert/references/known-issues.md
@@ -1,0 +1,78 @@
+# sm_120a Known Issues, Dead Ends, Root-Cause Reference
+
+Heavy reference for the `sm120-cuda-expert` skill. Things that don't work, things that *used* to not work but now do, and historical bugs whose fixes are load-bearing for current hot-path code.
+
+---
+
+## Pre-flight before non-trivial kernel work
+
+1. Check the dead-ends list below — many "obvious" optimizations are proven failures on sm_120.
+2. If the installed CUDA version differs from when a dead end was tested (check `nvcc --version`), see "Version-dependent dead ends" — some are worth retrying.
+
+For small edits (parameter tweak, kernel-signature change, fusing two existing kernels), skip pre-flight and go straight to the patterns.
+
+---
+
+## Version-dependent dead ends (worth retrying when CUDA version changes)
+
+| Dead end | Blocked by | Retry on |
+|----------|-----------|----------|
+| cuBLASLt grouped layout sm_120 | Zero algorithms for consumer Blackwell | New cuBLAS release (check algorithm count) |
+| CUTLASS TC GEMM at M=1 | Activation quant + TMA overhead | CUTLASS 4.5+ |
+| `cp.async.bulk` with `.ignore_oob` | Requires TMA descriptor rewrite | CUDA 13.3+ |
+| `st.async .b128` to global | PTX 9.2 only targets `shared::cluster` | New PTX ISA |
+| CUTLASS NVFP4 sm_120 graph-determinism | Universally non-deterministic for `cudaGraphExecUpdate` re-capture (verified 2026-05-05) | Future CUTLASS NVFP4 deterministic mode |
+| Native FP4 GEMM faster than dequant→cuBLAS on sm_120 | Marlin-style dequant→cuBLAS measured *faster* than FlashInfer-CUTLASS-NVFP4 on consumer Blackwell. Storage-format wins (4× VRAM) but compute-speed parity is open. | Future custom kernel or upstream CUTLASS fix |
+
+---
+
+## Resolved (no longer dead ends)
+
+- **PTX `cvt.rn.satfinite.e2m1x2.{f32,f16x2,bf16x2}`** and reverse direction work on both `sm_120f` and `sm_120a` under CUDA 13.2.1 (re-verified 2026-05-04). Correct usage routes the FP4 byte through a `.b8` register — see `references/ptx-patterns.md` "FP4 ↔ FP16/FP32/BF16 packed conversion". SASS confirms hardware emission: `F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`.
+
+- **Build target `sm_120a`** (was historically blocked by a `ptxas` C7600 bug on `120f` that needed the `f` workaround). As of CUDA 13.2.1 the `a` arch suffix is the correct target — superset of `120f`, adds `mma.sync.kind::mxf4nvf4.block_scale` and TMA-WS-Grouped-GEMM. Switched 2026-05-04 (commit `6568652`).
+
+- **CUDA Graphs + prequant-NVFP4 MoE.** Earlier "non-Gemma-4 MoE blocks graph capture" claim was stale. The MoE decode fast-path (`executor_forward_moe.cu:524`) is fully device-side, no D2H sync — graph-safe. Verified 2026-05-07 across Qwen3-Coder, Qwen3.6, Gemma-4 NVFP4 (all +193%–234% decode vs `--no-cuda-graphs`). GGUF MoE prefill paths still use D2H sync, but prefill isn't graph-captured anyway. Hybrid Mamba2 (Nemotron-H) does NOT benefit yet — SSM layers don't fast-path.
+
+- **Lever 1 SSM dispatch (commit `5b2c5db`).** Registered `ssm_in`/`ssm_out` in the `cutlass_nvfp4_cache` so GDN/SSM weights hit the fast NVFP4 GEMM path. Showed +95–376% decode on Qwen3.5/3.6 GDN families on 2026-05-04 — but the gain came from CUDA Graph capture *enabled by* the faster GEMM, not the GEMM speedup itself. **Always re-bench graphs ON after a hot-path kernel change.**
+
+---
+
+## Load-bearing root-cause fixes (don't regress these)
+
+These bugs were diagnosed at high cost. The current kernels assume the fix is in place.
+
+| Fix | Symptom if regressed | Where |
+|-----|----------------------|-------|
+| **FP8 FMHA S_tile pointer advance** | Long-context cliff at prompt > 1024 tokens | `attention_fmha_sm120.cu` — pointer must advance with `sizeof(half)`. Regression test in tree. |
+| **Qwen3.5/3.6 GDN `__launch_bounds__(HD,1)` not `(HD,2)`** | HD=128 GDN miscompile, garbage output | GDN kernel — keep `(HD,1)`. |
+| **Qwen3.5 partial RoPE pair offset `+ rope_pairs` (not `+ head_dim/2`)** | Sister bug to launch_bounds; partial-RoPE corruption | RoPE kernel. |
+| **Qwen3.5 Q8 α/β qtype consistency** | Pre-dequanted Q8→FP16 without updating qtype → dispatcher mis-interprets bytes → state collapse | `upload_weight` path — keep qtype tag in sync with stored bytes. |
+| **Qwen 3.6 h_state FP32 gate + PyTorch L2 norm** | NaN at L38 in GDN | h_state must be FP32, not FP16/BF16. |
+| **Gemma-4 per-layer `rope_freqs` for non-SWA layers, `n_rot=hd`** | L13/L14 drift 11–15% (was) → <2% (fixed) | Pass per-layer rope_freqs through. |
+| **MoE expert-offload auto-probe at 10% before falling back to 30%** | Qwen3-Coder-30B Q6_K decode 234 → 77 tok/s | `executor_moe.cu` — keep the 10% probe. |
+| **L2 access-policy window `num_bytes` clamp to `cudaDevAttrMaxAccessPolicyWindowSize`** | Silent CUDA error / IMA on 5090 (128 MiB max) | `set_l2_streaming` / `set_l2_persist_kv` in `runtime/`. |
+| **NVFP4 dequant graph-safe fallback (PR #121)** | `cudaMallocAsync` inside captured graph crash | `set_nvfp4_dequant_workspace()` + capture-guard in `ensure_dequant_buffer`. |
+
+---
+
+## Performance-relevant scaling rules
+
+| Rule | Source |
+|------|--------|
+| Decode at batch=1: launch overhead first, memory second (post Lever 1) | Three Laws #1 in main SKILL.md |
+| `__launch_bounds__` cost on regular paths: -4.5% to -20% | Repeated benchmarks 2026-04 to 2026-05 |
+| `mxf4nvf4.block_scale` raw MMA: 2.60× over f8f6f4 | `mxf4nvf4_mma_bench` 2026-04-25 |
+| CUDA Graph decode on prequant NVFP4 MoE: +193% to +234% | Qwen3-Coder, Qwen3.6, Gemma-4 NVFP4 — verified 2026-05-07 |
+| pp512 cuBLAS-autotune variance: up to 2.6× across container restarts | Use `tg256` for A/B; see `benchmark-cuda` skill |
+
+---
+
+## Negative results (don't repeat)
+
+- **Generic `compute_120` PTX fallback.** Lacks FP8 MMA + block-scale. Always pin `compute_120a/sm_120a`.
+- **WMMA / `wgmma`-style on consumer Blackwell.** Not available — sm_120 is register-`mma.sync` only. `tcgen05` / TMEM are SM100 (B200) exclusives.
+- **`__noinline__` on device inner-loop helpers.** Spills to Local Memory (DRAM). Use `__forceinline__`.
+- **`reinterpret_cast` on Q8_0 blocks.** 34-byte blocks NOT 4-aligned. Use `memcpy()`.
+- **Skipping graph re-bench after a hot-path patch.** Compute speedup alone often shows ~0% in tok/s — the win is graph-replay-mediated. Always re-bench graphs ON.
+- **Increasing SMEM beyond `cudaDeviceProp::sharedMemPerBlockOptin`** assuming H100's 228 KB. RTX 5090 max is ~99 KB.

--- a/.claude/skills/sm120-cuda-expert/references/ptx-patterns.md
+++ b/.claude/skills/sm120-cuda-expert/references/ptx-patterns.md
@@ -1,0 +1,124 @@
+# sm_120a PTX Inline Assembly Patterns
+
+Heavy reference for the `sm120-cuda-expert` skill. Templates verified on RTX 5090 / GB202 under CUDA 13.2.1, `compute_120a / sm_120a`.
+
+Guard all sm_120 code: `#if __CUDA_ARCH__ >= 1200`.
+
+---
+
+## NVFP4 block-scaled MMA — `kind::mxf4nvf4` (peak path)
+
+The peak NVFP4 path on consumer Blackwell. `mma.sync.aligned.kind::mxf4nvf4.block_scale` with FP32 accumulator in registers (FA2-style + block-scaling). Hardware applies the per-16-element UE4M3 scale **inside** the MMA — no manual scale-apply. K=64 per MMA (vs k=32 for f8f6f4) → half the MMA count for the same tile. Raw MMA speedup measured **2.60×** on RTX 5090 (`mxf4nvf4_mma_bench`); end-to-end attention gain expected 1.5–2.5× post softmax + P·V.
+
+```cuda
+// scale_vec::4X.m16n8k64, e2m1 inputs, e2m1 inputs, f32 accumulator, ue4m3 scales
+asm volatile(
+    "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+    "{%0,%1,%2,%3},"          // D fragments (FP32)
+    "{%4,%5,%6,%7},"          // A fragments (NVFP4 packed)
+    "{%8,%9},"                 // B fragments (NVFP4 packed)
+    "{%10,%11,%12,%13},"      // C fragments (FP32 accumulator-in)
+    "{%14},"                   // sfa_in (UE4M3 scale, packed)
+    "{%15,%16},"              // bidA, tidA (block/thread id within scale group)
+    "{%17},"                   // sfb_in
+    "{%18,%19};\n"            // bidB, tidB
+    : "=f"(d0),"=f"(d1),"=f"(d2),"=f"(d3)
+    : "r"(a0),"r"(a1),"r"(a2),"r"(a3), "r"(b0),"r"(b1),
+      "f"(c0),"f"(c1),"f"(c2),"f"(c3),
+      "r"(sfa_in), "h"(bidA), "h"(tidA),
+      "r"(sfb_in), "h"(bidB), "h"(tidB));
+```
+
+**Requires `compute_120a`** (NOT `compute_120` / `compute_120f` — `block_scale` modifier and TMA-WS-grouped-GEMM are gated on the `a` arch suffix).
+
+References in repo:
+- `src/compute/attention_mxf4nvf4_probe.cu` — canned-input probe
+- `src/compute/attention_fmha_mxf4nvf4_sm120.h` — FMHA upgrade target
+
+---
+
+## FP8 MMA — `kind::f8f6f4` (legacy / fallback)
+
+Used when block-scaled NVFP4 isn't applicable (FP8 weights, FP8 KV).
+
+```cuda
+asm volatile(
+    "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+    : "=f"(d0),"=f"(d1),"=f"(d2),"=f"(d3)
+    : "r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1),
+      "f"(c0),"f"(c1),"f"(c2),"f"(c3));
+```
+
+---
+
+## FP16 → FP8 packed conversion
+
+```cuda
+asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;\n" : "=r"(fp8x2) : "r"(fp16x2));
+```
+
+---
+
+## FP4 (E2M1) ↔ FP16 / FP32 / BF16 packed conversion
+
+The naive `cvt.rn.satfinite.e2m1x2.{f32,f16x2,bf16x2}` instruction looks unsupported on sm_120 if you target a `.b32` register, but it works when you route the FP4 byte through a `.b8` register. SASS confirms hardware emission: `F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`.
+
+```cuda
+// f16x2 -> e2m1x2 packed (1 byte holds 2 FP4 values)
+asm volatile(
+  "{ .reg .b8 b;"
+  "  cvt.rn.satfinite.e2m1x2.f16x2 b, %1;"
+  "  cvt.u32.u8 %0, b; }"
+  : "=r"(fp4x2_u32) : "r"(fp16x2));
+```
+
+Verified 2026-05-04 under CUDA 13.2.1 on both `sm_120f` and `sm_120a`. See `references/known-issues.md` "Resolved" section for history.
+
+---
+
+## NVFP4 prmt register LUT (replaces SMEM dequant table)
+
+The `prmt.b32` instruction permutes 4 bytes from two source registers into a result, indexed by 4 nibbles in a selector register. Two uint32 constants encode the 8 FP4-decoded FP16 values; one `prmt` decodes 4 NVFP4 values into 4 packed FP16. Zero SMEM, zero L2, register-only.
+
+```cuda
+constexpr uint32_t kLutLo = 0x3E3C3800u;  // FP16: [0.0, 0.5, 1.0, 1.5]
+constexpr uint32_t kLutHi = 0x46444240u;  // FP16: [2.0, 3.0, 4.0, 6.0]
+asm volatile("prmt.b32 %0, %1, %2, %3;\n"
+             : "=r"(out) : "r"(kLutLo), "r"(kLutHi), "r"(selector));
+```
+
+---
+
+## `cp.async` for paged KV (16-byte vector load)
+
+```cuda
+asm volatile("cp.async.ca.shared.global [%0], [%1], 16;\n" :: "r"(smem), "l"(glob));
+asm volatile("cp.async.commit_group;\n");
+asm volatile("cp.async.wait_group 0;\n");
+__syncthreads();  // REQUIRED before reading smem — race on SMEM otherwise
+```
+
+---
+
+## Warp-XOR shuffle reduce
+
+Single-warp sum/max reduction in 5 instructions (32-lane warp).
+
+```cuda
+#pragma unroll
+for (int o = 16; o >= 1; o >>= 1)
+    val += __shfl_xor_sync(0xFFFFFFFF, val, o);
+```
+
+---
+
+## KV cache streaming load (`__ldcs`, bypass L1)
+
+KV reads are one-shot per generated token — caching them in L1 evicts useful weights. `__ldcs` issues a streaming load that bypasses L1 and uses evict-first L2.
+
+```cuda
+const float4 kv = __ldcs(reinterpret_cast<const float4*>(kv_ptr));
+```
+
+**KV only.** Do NOT use on weights — weights are reused across batches and benefit from L1 caching.

--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,5 @@ _audit/
 
 # Local AI-agent state (must never be published)
 CLAUDE.md
-.claude/
+.claude/*
+!.claude/skills/


### PR DESCRIPTION
## Summary

- Commit `.claude/skills/` so contributors share the kernel-optimization, profiling, and degeneration guard rails this project relies on. Settings and per-user state in `.claude/` stay ignored.
- Three skills, optimized before committing: `benchmark-cuda`, `check-degeneration`, `sm120-cuda-expert`.

## What changed

- All skills are English-only with descriptions tightened around concrete trigger symptoms.
- `benchmark-cuda`: pp512 cuBLAS-autotune variance warning hoisted into a STOP-block at the top, canonical Nsight Compute metric set extracted into `ncu-basic.sh`, explicit red-flags list at the end.
- `check-degeneration`: quantitative pass criteria added (no >4-token repetition, no early abort, stderr-clean grep, ≤30% decode regression, multi-turn topical), MEMORY-only references replaced with `tests/perf_baseline.json`.
- `sm120-cuda-expert`: split 1710 → 966 words. PTX inline-assembly templates moved to `references/ptx-patterns.md` (mxf4nvf4 first as the peak path, f8f6f4 second as legacy). Dead ends, version-dependent retries, and load-bearing root-cause fixes moved to `references/known-issues.md`. Cross-refs now point at repo paths (`docs/sm120.md`, `docs/performance.md`, `docs/sm120-real-perf-plan.md`).
- `.gitignore`: `.claude/` → `.claude/* + !.claude/skills/`.

## Test plan

- [x] All three SKILL.md frontmatter blocks parse (descriptions <1024 chars, valid YAML).
- [x] `ncu-basic.sh` shellcheck-clean (`bash -n`).
- [x] All file paths and Make targets referenced in skills exist in the tree (`tests/perf_baseline.json`, `tests/test_degeneration.cpp`, `scripts/verify.sh`, `scripts/smoke_test.sh`, `make test-e2e`, `bench/profile.sh`, `tools/imp-bench/`, `docs/sm120.md`, `docs/performance.md`, `docs/sm120-real-perf-plan.md`).
- [ ] CI build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)