### PR TITLE
audit: SafeTensors + NVFP4 hardening 2026-05 (F1-F8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ if(IMP_BUILD_TESTS)
         tests/test_gguf_loader.cpp
         tests/test_llm_compressor_loader.cpp
         tests/test_hf_config_loader.cpp
+        tests/test_safetensors_loader.cpp
         tests/test_config.cpp
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ if(IMP_BUILD_TESTS)
         tests/test_nvfp4_quant.cu
         tests/test_nvfp4_quant_ref.cu
         tests/test_nvfp4_quant_hw.cu
+        tests/test_nvfp4_compressed_tensors_ref.cu
         tests/test_nvfp4_gemv_kpar_loop.cu
         tests/test_nvfp4_gemm_graph_capture.cu
         tests/test_turboquant.cu

--- a/docs/audit/DONE.md
+++ b/docs/audit/DONE.md
@@ -1,0 +1,128 @@
+# Run Completion Summary — 2026-05-08
+
+Objective 1 (SafeTensors + NVFP4 hardening) closed cleanly under the strict Quality Gate. Objective 2 (roadmap execution) deferred entirely — by design: every roadmap item the inventory enumerated was either INFEASIBLE within a single autonomous run, OBSOLETE, or UNCERTAIN-and-deferred per the conditional model.
+
+## Loader / NVFP4 findings (this run)
+
+| ID | Severity | Status | Closing commit |
+|----|----------|--------|----------------|
+| F1 — NVFP4 compressed-tensors reference numerical test | P0 | closed | `168f847` |
+| F2 — Modelopt NVFP4 weight_scale_2 isfinite guard | P1 | closed | `bb8c54c` |
+| F3 — Header-size validation overflow | P1 | closed | `5d9b28f` |
+| F4 — Tensor offset/size validation | P1 | closed | `6ede041` |
+| F5 — Malformed-tensor-entry WARN + summary | P2 | closed | `369a806` |
+| F6 — NVFP4 packed-vs-scale shape validation | P2 | closed | `4d9b640` |
+| F7 — Header-size 128 MiB soft cap | P2 | closed (combined w/ F3) | `5d9b28f` |
+| F8 — NVFP4 weight_scale dtype enforcement | P2 | closed | `03b8996` |
+| F9 — Header 8-byte alignment | P3 | deferred (spec-compliance only) | — |
+| F10 — Unrecognized-tensor list retention | P3 | deferred (UX only) | — |
+
+**P0 closed: 1 / 1.  P1 closed: 3 / 3.  P2 closed: 4 / 4.  P3 deferred: 2 / 2.**
+
+## Roadmap items
+
+The Phase 0 inventory `docs/audit/roadmap_inventory_2026-05.md` enumerated 27 items:
+
+- **0 FEASIBLE** — none entered the master plan
+- **1 UNCERTAIN** (AU2 native SentencePiece parser) — re-evaluated and deferred this run; reason in `docs/audit/followups.md`
+- **21 INFEASIBLE** — all deferred with specific reasoning in `docs/audit/followups.md`
+- **5 OBSOLETE** — already shipped or shelved before this run
+
+A run that closes objective 1 fully and defers every roadmap item is a successful run per the mission spec, provided each deferral has a documented reason that holds up. Each entry in `followups.md` includes a `Pre-conditions to revisit` line for future runs.
+
+## Reference validation harness
+
+ADR `0001-reference-harness-pure-cpp.md`. Pure-C++ reference dequant in `tests/test_nvfp4_compressed_tensors_ref.cu`. 4 cases pass on first run, demonstrating that imp's `gemv_nvfp4_kpar` matches the compressed-tensors NVFP4 spec at max-abs-diff < 1e-2 in FP16 output for unity, varying-scale, zero-tensor-scale, and negative-weight cases.
+
+## ADRs written
+
+- `0001-reference-harness-pure-cpp.md` — pure-C++ over Python harness for unit numerics
+- `0002-header-size-cap.md` — 128 MiB SafeTensors header soft cap
+
+## Test suite status
+
+Pre-run: ~574 GTest tests across 45+ files.
+Post-run additions: **40 new unit tests** across 3 new test fixtures:
+
+- `tests/test_nvfp4_compressed_tensors_ref.cu` — 25 tests (NvFP4CompressedTensorsRef + NvFP4PromoteWeightScale2 + NvFP4ValidateWeightScaleDtype + NvFP4ValidatePackedScaleShapes)
+- `tests/test_safetensors_loader.cpp` — 15 tests (SafeTensorsValidateHeaderSize + SafeTensorsValidateTensorOffsets + SafeTensorsMalformedEntryWarnings)
+
+Aggregated across all test binaries (final state):
+- test-core: 149 / 149 (1 skipped: TensorKindCoverage.NoUnknownKindsInSmallQwen)
+- test-text: 152 / 152 (1 skipped: TokenizerCompatTest)
+- test-compute: 115 / 115
+- test-attention: 69 / 69 (2 skipped: AttentionTCTest.SmallPrefill, FmhaFP8Test.HD64)
+- test-quant: 103 / 103
+- test-kv: 31 / 31
+- test-moe-gdn: 59 / 59
+- test-e2e/models: 91 / 91 (18 skipped — model-dependent, no model files in test-gpu env)
+
+**Total: 769 ran, 747 passed, 22 skipped, 0 failed.**
+
+## Benchmark deltas
+
+`make verify-fast` post-run measurement:
+
+| Metric | Pre-run baseline | Post-run | Delta |
+|---|---|---|---|
+| Decode tg128 | 147.85 tok/s | 155.94 tok/s | +5.47% (improvement, well within 3% regression threshold) |
+| Prefill pp512 | 13277.98 tok/s | 14362.41 tok/s | +8.17% (improvement, within 5% threshold) |
+
+The improvements come entirely from prior commits (`3eb7ef5` vectorized FP4 dequant, `454ca58` graph-safe NVFP4 fallback) that landed before this run. This run's changes are loader-time / promote-time and do not touch the hot path; the deltas are noise + cumulative benefit from the commit base.
+
+Smoke test: Qwen3-4B Q8_0 generates "Paris" with distinct=8 distinct tokens.
+
+## Conflicts encountered and resolution
+
+None. The pre-existing audit `docs/audit/safetensors_audit.md` (Phase 1 + Phase 2) handled the broad-scope items; this run only added findings the prior audit didn't catch (F1–F8) plus deferred the items it explicitly named "truly unresolved" (GLM, native SPM, AWQ kernel, MLA, multimodal, Tiktoken).
+
+F3 and F7 were combined into one commit (`5d9b28f`) because both rules live in the same `validate_header_size` helper function. Splitting them into separate commits would have required artificial double-touching of the same lines. The master plan `Item 3` and `Item 8` headers reflect this with cross-references; both items are marked `closed-in-5d9b28f`.
+
+## Quality Gate compliance
+
+Every commit that closed a finding satisfied:
+- ✅ Numerical correctness verified — F1 and the per-test reference computations
+- ✅ No regression — full test suite green at every commit, verify-fast smoke OK
+- ✅ No new dependencies — `CMakeLists.txt` `FetchContent` block unchanged
+- ✅ No `// TODO` / `// FIXME` / `// XXX` introduced
+- ✅ Error paths covered — every new validation function has test cases for both accept and reject branches
+- ✅ No tests skipped or expected-fail at end of commit
+- ✅ No commented-out code left behind
+- ✅ No print-debugging — all logging via the existing `IMP_LOG_*` macros
+- ✅ Documentation updated — audit, plan, inventory, followups, ADRs, progress log
+- ✅ Root-cause oriented — each fix addresses the underlying class of bug, not a single symptom
+
+## Constraints honored
+
+- `CMAKE_CUDA_STANDARD = 20` (verified at audit time, line 6 of `CMakeLists.txt`)
+- `.cu` files: pre-existing C++20 — unchanged
+- `.cpp` files: pre-existing C++20 — unchanged
+- Pure-host validators in `nvfp4_quant.cu` and `safetensors_loader.cpp` use only C++20 features
+- No new third-party dependencies in any manifest
+- No new Python in any test path
+- sm_120a build pin (`compute_120a,code=sm_120a`) unchanged
+- All hot-path kernels untouched
+
+## Files added or modified
+
+Source:
+- `src/model/safetensors_loader.h` (added `safetensors_internal::validate_*` declarations + 128 MiB constant)
+- `src/model/safetensors_loader.cpp` (validators + WARN-on-drop + per-shard summary)
+- `src/quant/nvfp4_quant.h` (added `nvfp4_promote_weight_scale_2`, `nvfp4_validate_weight_scale_dtype`, `nvfp4_validate_packed_scale_shapes`)
+- `src/quant/nvfp4_quant.cu` (implementations)
+- `src/graph/executor_pre_dequant.cu` (uses new helpers; removed inline math)
+- `CMakeLists.txt` (added two test files to the test-quant / test-core modules)
+
+Tests (new):
+- `tests/test_nvfp4_compressed_tensors_ref.cu` (25 tests across 4 fixtures)
+- `tests/test_safetensors_loader.cpp` (15 tests across 3 fixtures)
+
+Docs (new):
+- `docs/audit/roadmap_inventory_2026-05.md`
+- `docs/audit/safetensors_nvfp4_audit_2026-05.md`
+- `docs/audit/master_plan_2026-05.md`
+- `docs/audit/followups.md`
+- `docs/audit/progress.log`
+- `docs/audit/decisions/0001-reference-harness-pure-cpp.md`
+- `docs/audit/decisions/0002-header-size-cap.md`
+- `docs/audit/DONE.md` (this file)

--- a/docs/audit/decisions/0001-reference-harness-pure-cpp.md
+++ b/docs/audit/decisions/0001-reference-harness-pure-cpp.md
@@ -1,0 +1,13 @@
+# ADR 0001 — Reference validation harness uses pure C++
+
+**Date:** 2026-05-08
+**Status:** Accepted
+**Context:** Mission requires a numerical reference for compressed-tensors NVFP4 dequant.
+
+## Decision
+
+Pure C++ reference dequant in `tests/test_nvfp4_compressed_tensors_ref.cu`, computing `val = fp4_to_fp32(nibble) * fp8_e4m3_to_fp32(weight_scale_block) * weight_scale_2_fp32` element-wise on the host, compared against imp's `gemv_nvfp4_kpar` GEMV at max-abs-diff < 1e-2. Choice over (1) imp Python infra (none wired for unit-numerics) and (2) external venv subprocess (would add cross-process fixture complexity and runtime dependency on the user's HF cache). Pure C++ is dependency-free, deterministic, and bit-exact for the dequant formula.
+
+## Consequences
+
+Catches dequant bugs (sign-flip, nibble-order, missing factor) but not full end-to-end logit drift; that is covered separately by `scripts/validate_safetensors.py`'s phase-4 battery at integration level.

--- a/docs/audit/decisions/0002-header-size-cap.md
+++ b/docs/audit/decisions/0002-header-size-cap.md
@@ -1,0 +1,13 @@
+# ADR 0002 — SafeTensors header-size soft cap at 128 MiB
+
+**Date:** 2026-05-08
+**Status:** Accepted
+**Context:** Phase 1 finding F7 — `header_size` was bounded only by `file_size - 8`, allowing pathological files that claim multi-GB JSON headers.
+
+## Decision
+
+Soft-cap `header_size` at 128 MiB (`134217728` bytes). Above the cap, return false with `IMP_LOG_ERROR` naming the file path and the declared header size. 128 MiB is ~1000× larger than any real model header (Llama-3.1-405B's index is ~100 KiB), so the cap is far above legitimate use and far below pathological inputs that would force the JSON parser to scan multi-GB.
+
+## Consequences
+
+Rejects malicious / corrupt files faster (before the JSON parser allocates). No effect on real checkpoints. Hard-coded constant (not configurable) — if someone releases a model with a >128 MiB header in the future, this becomes a friction point and we'll re-evaluate. Recorded in `safetensors_loader.cpp` as a named constant.

--- a/docs/audit/followups.md
+++ b/docs/audit/followups.md
@@ -1,0 +1,93 @@
+# Deferred Roadmap Items — 2026-05-08
+
+Every item listed in `docs/audit/roadmap_inventory_2026-05.md` that did not enter the master plan, with the reason it was deferred. Quality Gate is non-negotiable; deferral is the correct outcome when an item can't be landed at full quality in this run.
+
+## Format
+
+`<id> <one-line title>` then `Reason:` and `Pre-conditions to revisit:`.
+
+---
+
+### L1 — FP8 KV cache: Gemma-4 carve-out
+
+Reason: Per-layer head_dim awareness needed in KV write/read kernels. Single-stride assumption is hard-coded across the FP8 paged-attention path. Multi-day kernel work + multi-model regression sweep, and the workaround (default `--kv-fp16` for Gemma-4) ships today.
+Pre-conditions: dedicated branch, full Gemma-4 long-context regression baseline, kernel rewrite with per-layer stride tables.
+
+### L2 — Chunked prefill: paged-prefill kernel pending
+
+Reason: Mitigation already shipped (PR #114 single-chunk default at `engine.cpp:1644`). The proper fix is a paged-prefill kernel reading K/V from cache during chunked attention — separate, larger work. Cannot be done within this run's Quality Gate.
+Pre-conditions: paged-prefill kernel design + multi-tenant decode-latency test fleet.
+
+### L3 — NVFP4 SmoothQuant `input_scale`
+
+Reason: Direct absorption refuted by A/B (`llm_compressor_input_scale_dead_end_2026_05_07.md`). Real fix needs per-channel scaling vector applied during activation quantization, not a scalar alpha modifier. Single test model (Mistral-3.2-NVFP4); workaround PR #78 (default-system-prompt skip) lives today.
+Pre-conditions: extra calibrated test models with SmoothQuant scaling, per-channel activation quant path.
+
+### L4 — Qwen3.5-27B MXFP4 fails at load
+
+Reason: 12 GiB MXFP4 + 48 GiB FP16 fallback oversubscribes VRAM. Real fix needs host-dequant + StoragePlanner — large change for a single-model unlock. PR #60 already added a clear diagnostic.
+Pre-conditions: StoragePlanner extension, host-dequant kernel, layer-tier policy.
+
+### L5 — Gemma-4 Q4_K_M code-gen drift
+
+Reason: Accumulated FP16 drift across 30 layers is precision-architectural. Quant rework, no clean low-risk lever. Workaround "use Q5_K_M / Q8_0" documented.
+Pre-conditions: per-layer FP32 accumulator audit + selective dequant policy.
+
+### L6 — MoE expert offload disables CUDA Graphs
+
+Reason: Needs device-side LRU prefetch with async pipeline. Significant runtime kernel work. Tip `IMP_EXPERT_OVERHEAD_PCT` ships today.
+Pre-conditions: async expert prefetch design + multi-model regression coverage.
+
+### P1 — Closing TurboQuant–FP8 gap
+
+Reason: "Algorithm-inherent" per roadmap. Needs QJL → MXFP4-K direction redesign.
+Pre-conditions: MXFP4-K-direction kernel.
+
+### P2 — pp=512 on large dense models
+
+Reason: cuBLAS autotune variance; "not gating any user" per roadmap.
+Pre-conditions: deterministic-cuBLAS audit on these specific shapes.
+
+### P3 — Speculative decoding
+
+Reason: Investigated and shelved per roadmap. CLI flags removed in `7380ea8`. OBSOLETE.
+
+### R1–R10 — Research-interest items (CUDA 13.2 features, PTX 9.2, KV-compression research)
+
+Reason: Each is a multi-day-to-multi-week kernel project with no in-tree benchmark/regression scaffold appropriate for one-run sign-off. Most are dead-ends or zero-net (R5 already shipped, R7 quality-risky, Lv5 SFU-exp2 net-zero).
+Pre-conditions: dedicated dev cycle per item.
+
+### Lv3 — CLC-persistent kernel for continuous batching
+
+Reason: Listed payoff is multi-tenant only; imp is "single-author single-target experiment" (`docs/roadmap.md`). No multi-tenant validation harness.
+Pre-conditions: multi-tenant decode benchmark + workload model.
+
+### AU1 — GLM architecture
+
+Reason: GLM diverges from LLAMA enough that mapping `GlmForCausalLM → LLAMA` would silently produce wrong outputs. Real fix needs `GLM` enum + dedicated forward path. Multi-week.
+Pre-conditions: GLM model in test fleet, dedicated forward path.
+
+### AU2 — Native SentencePiece (`.model`) parser
+
+Reason: "few hundred LoC" but the testing harness (byte-fallback handling, Unigram protobuf decode, tokenization-roundtrip golden against real Llama2/Mistral checkpoints) is the bulk of the work. Defer to a dedicated session that can land it cleanly.
+Pre-conditions: golden roundtrip fixtures from real `.model` files; protobuf decoder.
+
+### AU3 — AWQ INT4 dequant kernel
+
+Reason: Column-packed + interleave-permutation kernel; "multi-week" per audit. MVP path is dequant-to-FP16 + cuBLAS, but even that needs careful AWQ-vs-GPTQ packing convention validation.
+Pre-conditions: AWQ test models with golden FP32 reference.
+
+### AU4 — DeepSeek MLA attention
+
+Reason: Multi-head latent attention path is "multi-week effort" per audit. Affects `q_lora_rank`, `kv_lora_rank`, `qk_rope_head_dim`, `qk_nope_head_dim`, `v_head_dim` across attention layout. Out of scope.
+Pre-conditions: DeepSeek-V2/V3 SafeTensors test model, MLA-specific attention kernel.
+
+### AU5 — Multimodal SafeTensors loaders
+
+Reason: Per-family work (Qwen-VL, Llava, Pixtral, Gemma-3 vision-from-SafeTensors), each with its own vision-tower loader, prefix-injection wiring, encoder. Multi-week.
+Pre-conditions: per-family test models + dedicated vision development cycle.
+
+### AU6 — Tiktoken parser
+
+Reason: Uncommon in supported families per audit; explicit `ignored`.
+Pre-conditions: User-driven request from a Tiktoken-only family.

--- a/docs/audit/master_plan_2026-05.md
+++ b/docs/audit/master_plan_2026-05.md
@@ -1,0 +1,130 @@
+# Master Plan — 2026-05-08
+
+Combines the Phase 1 audit findings (`docs/audit/safetensors_nvfp4_audit_2026-05.md`) with the Phase 0 roadmap inventory (`docs/audit/roadmap_inventory_2026-05.md`).
+
+The roadmap inventory yielded 0 FEASIBLE items and 1 UNCERTAIN (deferred). The master plan therefore consists entirely of loader/NVFP4 hardening findings F1–F8.
+
+## Reference-validation harness decision
+
+**Choice: Option 3 (pure C++ reference).**
+
+ADR `0001-reference-harness-pure-cpp.md` records the rationale. Briefly:
+- Option 1 (existing imp Python infra): no `transformers` / `vllm` venv is wired into imp's tests today; only `tests/api/` uses Python and that's HTTP-level testing, not numerics.
+- Option 2 (subprocess into the user's `~/.cache/huggingface` venv): would require detection logic, dependency-availability handling at test time, and a cross-process fixture. The mission says "use what imp has"; imp doesn't have a Python harness for unit-level numerics.
+- Option 3 (pure C++ reference): mechanical, dependency-free, deterministic, exact for the dequant formula. Trade-off is "catches dequant bugs but not full end-to-end logit drift" — but logit drift is what the existing scripts/validate_safetensors.py harness already handles at integration level (Phase-4 battery, etc.). Unit-level numerics is the gap, and a pure-C++ reference fills it precisely.
+
+Tolerance: max-abs-diff < 1e-2 in FP16 (FMA-order divergence between sequential reference and imp's parallel-warp accumulator dominates). 1e-5 (the option-3 default in the mission spec) would only apply to a per-element bit-exact check, which is feasible only for representable values; the broader GEMV correctness needs the looser tolerance.
+
+## Plan items
+
+Ordered: P0 first, then P1, then P2. Within each tier, dependency order: harness/reference comes first because every subsequent test re-uses it.
+
+### Item 1 — F1: compressed-tensors NVFP4 reference test (P0)
+
+**Change:** add `tests/test_nvfp4_compressed_tensors_ref.cu`. Builds a synthetic compressed-tensors weight in memory exactly per the spec (`weight_packed` uint8 nibble-packed FP4, `weight_scale` FP8 E4M3 group_size=16, `weight_scale_2` FP32 scalar), constructs a Tensor view with `qtype=NVFP4`, and routes it through `gemv_nvfp4_kpar`. A pure-host reference dequant computes the expected output `Y = X · W^T` from the spec formula `val = fp4 * fp8_e4m3_to_fp32(weight_scale) * weight_scale_2`. Verifies max-abs-diff < 1e-2.
+
+**Files touched:** `tests/test_nvfp4_compressed_tensors_ref.cu` (new), `tests/CMakeLists.txt` (add to test list).
+
+**Risk/blast radius:** test-only, no source changes. Worst case: test fails on first run → I have evidence that imp's NVFP4 dequant disagrees with the spec. Best case: test passes → spec compliance is now CI-enforced and any future regression breaks the test.
+
+**Quality Gate:** numerical correctness ✓, no regression (test-only) ✓, no new deps ✓, no TODO ✓, error path tested via separate sub-cases (NaN scale, zero scale) ✓, no skip ✓, doc unchanged (test, not API) ✓, root-cause oriented (the test IS the root-cause-prevention mechanism) ✓.
+
+### Item 2 — F2: Modelopt NVFP4 weight_scale_2 isfinite guard (P1)
+
+**Change:** in `executor_pre_dequant.cu:262-279`, extend the existing zero/non-finite guard to also cover the Modelopt branch (`promoted_scale = h_scale;` at line 277-278 today). New behavior: if `!std::isfinite(h_scale)` for either format, set `promoted_scale = 0.0f` and bump a counter; if `h_scale == 0.0f` for Modelopt (currently silent), log INFO that the layer's weights are intentionally null. Update the end-of-loop summary to surface both Modelopt and llm-compressor counts.
+
+**Files touched:** `src/graph/executor_pre_dequant.cu`, `tests/test_nvfp4_compressed_tensors_ref.cu` (extend with NaN/Inf cases — depends on Item 1's fixture infrastructure).
+
+**Risk/blast radius:** isolated to the promote function. Existing llm-compressor path is unchanged. New guard is a strict superset of the old one — same behavior for finite inputs, defensive zero for non-finite.
+
+**Quality Gate:** unit test exercising both NaN and +Inf weight_scale_2 in both Modelopt and llm-compressor paths; the test asserts the layer produces zero output (not NaN/Inf) and the WARN counter increments. No new deps. No TODO.
+
+### Item 3 — F3: header-size validation overflow fix (P1)
+
+**Change:** `src/model/safetensors_loader.cpp:519-524` — replace `8 + header_size > file_size` with `header_size > file_size - 8`. Uses pre-existing invariant `file_size >= 8` from line 495.
+
+**Files touched:** `src/model/safetensors_loader.cpp`, `tests/test_safetensors_loader.cpp` (new).
+
+**Risk/blast radius:** affects only the malformed-file rejection path. Real-world SafeTensors files have header_size < a few MB and file_size > 1 GB, so the overflow case is unreachable in practice — but a hostile/corrupted file could trip it.
+
+**Quality Gate:** new unit test writes a 16-byte file with `header_size = UINT64_MAX` and asserts `load_safetensors` returns false without crashing. Companion test with `header_size = file_size - 7` (off-by-one) asserts rejection.
+
+### Item 4 — F4: tensor offset/size validation (P1)
+
+**Change:** `src/model/safetensors_loader.cpp:572-580` — add three checks:
+1. `offset_start <= offset_end` (else WARN + skip tensor)
+2. `tensor_data_offset + offset_start <= file_size` (else WARN + skip)
+3. `offset_end - offset_start == expected_nbytes(shape, dtype)` where `expected_nbytes` multiplies the shape with `dtype_bytes(QType)` (else WARN + skip)
+
+Add `dtype_bytes` helper (private to the .cpp, mapping `QType::F16 → 2`, `QType::F32 → 4`, `QType::FP8_E4M3 → 1`, `QType::INT8 → 1`, `QType::INT32 → 4`, `QType::BF16 → 2`).
+
+**Files touched:** `src/model/safetensors_loader.cpp`, `tests/test_safetensors_loader.cpp`.
+
+**Risk/blast radius:** adds rejections that previously slipped through silently. Existing valid checkpoints emit `offset_end - offset_start == nelem * sizeof(dtype)` per spec — they will continue to load.
+
+**Quality Gate:** unit tests for each of the three sub-cases (start>end, oob start, size mismatch). All produce a WARN and skip the tensor without crashing.
+
+### Item 5 — F8: NVFP4 weight_scale dtype enforcement (P2)
+
+**Change:** `src/graph/executor_pre_dequant.cu:237-287` — in `promote()`, before applying the formula, verify `sc.weight_scale.qtype == QType::FP8_E4M3`. If not, WARN naming the key and the actual qtype, and return false (skip promotion — weight stays in its loaded state for the dequant→cuBLAS fallback path to handle).
+
+**Files touched:** `src/graph/executor_pre_dequant.cu`, `tests/test_nvfp4_compressed_tensors_ref.cu` (extend).
+
+**Risk/blast radius:** isolated check. Real Modelopt + llm-compressor checkpoints use FP8 E4M3 for `weight_scale`; the only way this triggers is on a NVFP4↔MXFP4 cross-misrouted file.
+
+**Quality Gate:** unit test that supplies a `weight_scale` with `qtype = QType::INT8` (UE8M0 bytes) and verifies `promote` rejects it.
+
+### Item 6 — F6: NVFP4 packed shape vs scale shape validation (P2)
+
+**Change:** in the same `promote()` function, add `sc.weight_scale.shape[1] * 16 == w.shape[1] * 2` (where `w.shape[1]` is the packed-half K, so logical K = `w.shape[1] * 2`). On mismatch, WARN + skip promotion.
+
+**Files touched:** `src/graph/executor_pre_dequant.cu`, `tests/test_nvfp4_compressed_tensors_ref.cu`.
+
+**Risk/blast radius:** adds a rejection. Real checkpoints always satisfy this; the check is defense against group_size != 16 or a transposed `weight_scale`.
+
+**Quality Gate:** unit test feeding mismatched shapes; verifies skip + WARN.
+
+### Item 7 — F5: malformed tensor entry warnings (P2)
+
+**Change:** `src/model/safetensors_loader.cpp:554-580` — replace each silent `continue` with `IMP_LOG_WARN("safetensors: dropping tensor '%s' — <reason>")` and an end-of-shard summary count. Reasons: missing dtype, missing shape, ndim>kMaxDims, missing data_offsets.
+
+**Files touched:** `src/model/safetensors_loader.cpp`, `tests/test_safetensors_loader.cpp`.
+
+**Risk/blast radius:** behavior-equivalent (still skips). Adds log lines; no functional change for valid files.
+
+**Quality Gate:** unit test crafting a SafeTensors blob where one tensor has malformed shape and asserting (a) the load returns success with the other tensors present, (b) the malformed tensor name appears in the WARN log via gtest's stderr capture.
+
+### Item 8 — F7: header-size upper bound (P2)
+
+**Change:** `src/model/safetensors_loader.cpp:519` — soft-cap header_size at 128 MiB (a 128 MiB header would represent a >50 M-tensor checkpoint; real models are O(1000) tensors). Above the cap: ERROR + return false.
+
+**Files touched:** `src/model/safetensors_loader.cpp`, `tests/test_safetensors_loader.cpp`.
+
+**Risk/blast radius:** rejects pathological files. Real models have headers <100 KiB.
+
+**Quality Gate:** unit test constructing a file with `header_size = 200 MiB` and verifying rejection. Recorded in ADR `0002-header-size-cap.md`.
+
+## Global ordering
+
+1. **Item 1** (F1, P0) — reference test; depends on nothing
+2. **Item 2** (F2, P1) — Modelopt isfinite; reuses Item 1 fixture
+3. **Item 3** (F3, P1) — header overflow; new test file
+4. **Item 4** (F4, P1) — offset validation; same test file as Item 3
+5. **Item 5** (F8, P2) — weight_scale dtype check; reuses Item 1 fixture
+6. **Item 6** (F6, P2) — packed shape check; reuses Item 1 fixture
+7. **Item 7** (F5, P2) — malformed-tensor warnings; reuses Item 3 test infrastructure
+8. **Item 8** (F7, P2) — header upper bound; reuses Item 3 test infrastructure
+
+This ordering means:
+- the synthetic NVFP4 fixture in `tests/test_nvfp4_compressed_tensors_ref.cu` is built once (Item 1) and reused by Items 2/5/6
+- the synthetic SafeTensors blob fixture in `tests/test_safetensors_loader.cpp` is built once (Item 3) and reused by Items 4/7/8
+
+No conflicts with existing roadmap items (none are FEASIBLE this run).
+
+## Per-item Quality-Gate feasibility statement
+
+For each item: every Quality Gate bullet can be met because the change is small, isolated, has a deterministic synthetic test fixture, doesn't require GPU model files at runtime (the existing 322-test suite on the audit branch is the regression base, and these new tests slot into the same `IMP_BUILD_TESTS=ON` GTest harness), needs no new dependencies, and has clear root-cause-vs-symptom delineation (each item fixes a specific silent-correctness path).
+
+## Benchmark baseline
+
+`tests/perf_baseline.json` is unchanged through Phase 2 (PR #116). All eight items are loader-time / promote-time changes that do not touch the hot path. Decode tok/s is observed only via `make verify-fast` smoke (Qwen3-4B Q8_0 capital-of-France) per the existing pre-push hook. No compute kernel modifications planned.

--- a/docs/audit/master_plan_2026-05.md
+++ b/docs/audit/master_plan_2026-05.md
@@ -19,7 +19,7 @@ Tolerance: max-abs-diff < 1e-2 in FP16 (FMA-order divergence between sequential 
 
 Ordered: P0 first, then P1, then P2. Within each tier, dependency order: harness/reference comes first because every subsequent test re-uses it.
 
-### Item 1 — F1: compressed-tensors NVFP4 reference test (P0)
+### Item 1 — F1: compressed-tensors NVFP4 reference test (P0) — `closed-in-168f847`
 
 **Change:** add `tests/test_nvfp4_compressed_tensors_ref.cu`. Builds a synthetic compressed-tensors weight in memory exactly per the spec (`weight_packed` uint8 nibble-packed FP4, `weight_scale` FP8 E4M3 group_size=16, `weight_scale_2` FP32 scalar), constructs a Tensor view with `qtype=NVFP4`, and routes it through `gemv_nvfp4_kpar`. A pure-host reference dequant computes the expected output `Y = X · W^T` from the spec formula `val = fp4 * fp8_e4m3_to_fp32(weight_scale) * weight_scale_2`. Verifies max-abs-diff < 1e-2.
 
@@ -29,7 +29,7 @@ Ordered: P0 first, then P1, then P2. Within each tier, dependency order: harness
 
 **Quality Gate:** numerical correctness ✓, no regression (test-only) ✓, no new deps ✓, no TODO ✓, error path tested via separate sub-cases (NaN scale, zero scale) ✓, no skip ✓, doc unchanged (test, not API) ✓, root-cause oriented (the test IS the root-cause-prevention mechanism) ✓.
 
-### Item 2 — F2: Modelopt NVFP4 weight_scale_2 isfinite guard (P1)
+### Item 2 — F2: Modelopt NVFP4 weight_scale_2 isfinite guard (P1) — `closed-in-bb8c54c`
 
 **Change:** in `executor_pre_dequant.cu:262-279`, extend the existing zero/non-finite guard to also cover the Modelopt branch (`promoted_scale = h_scale;` at line 277-278 today). New behavior: if `!std::isfinite(h_scale)` for either format, set `promoted_scale = 0.0f` and bump a counter; if `h_scale == 0.0f` for Modelopt (currently silent), log INFO that the layer's weights are intentionally null. Update the end-of-loop summary to surface both Modelopt and llm-compressor counts.
 
@@ -39,7 +39,7 @@ Ordered: P0 first, then P1, then P2. Within each tier, dependency order: harness
 
 **Quality Gate:** unit test exercising both NaN and +Inf weight_scale_2 in both Modelopt and llm-compressor paths; the test asserts the layer produces zero output (not NaN/Inf) and the WARN counter increments. No new deps. No TODO.
 
-### Item 3 — F3: header-size validation overflow fix (P1)
+### Item 3 — F3 + F7: header-size overflow-safe validation + 128 MiB cap (P1+P2) — `closed-in-5d9b28f`
 
 **Change:** `src/model/safetensors_loader.cpp:519-524` — replace `8 + header_size > file_size` with `header_size > file_size - 8`. Uses pre-existing invariant `file_size >= 8` from line 495.
 
@@ -49,7 +49,7 @@ Ordered: P0 first, then P1, then P2. Within each tier, dependency order: harness
 
 **Quality Gate:** new unit test writes a 16-byte file with `header_size = UINT64_MAX` and asserts `load_safetensors` returns false without crashing. Companion test with `header_size = file_size - 7` (off-by-one) asserts rejection.
 
-### Item 4 — F4: tensor offset/size validation (P1)
+### Item 4 — F4: tensor offset/size validation (P1) — `closed-in-6ede041`
 
 **Change:** `src/model/safetensors_loader.cpp:572-580` — add three checks:
 1. `offset_start <= offset_end` (else WARN + skip tensor)
@@ -64,7 +64,7 @@ Add `dtype_bytes` helper (private to the .cpp, mapping `QType::F16 → 2`, `QTyp
 
 **Quality Gate:** unit tests for each of the three sub-cases (start>end, oob start, size mismatch). All produce a WARN and skip the tensor without crashing.
 
-### Item 5 — F8: NVFP4 weight_scale dtype enforcement (P2)
+### Item 5 — F8: NVFP4 weight_scale dtype enforcement (P2) — `closed-in-03b8996`
 
 **Change:** `src/graph/executor_pre_dequant.cu:237-287` — in `promote()`, before applying the formula, verify `sc.weight_scale.qtype == QType::FP8_E4M3`. If not, WARN naming the key and the actual qtype, and return false (skip promotion — weight stays in its loaded state for the dequant→cuBLAS fallback path to handle).
 
@@ -74,7 +74,7 @@ Add `dtype_bytes` helper (private to the .cpp, mapping `QType::F16 → 2`, `QTyp
 
 **Quality Gate:** unit test that supplies a `weight_scale` with `qtype = QType::INT8` (UE8M0 bytes) and verifies `promote` rejects it.
 
-### Item 6 — F6: NVFP4 packed shape vs scale shape validation (P2)
+### Item 6 — F6: NVFP4 packed shape vs scale shape validation (P2) — `closed-in-4d9b640`
 
 **Change:** in the same `promote()` function, add `sc.weight_scale.shape[1] * 16 == w.shape[1] * 2` (where `w.shape[1]` is the packed-half K, so logical K = `w.shape[1] * 2`). On mismatch, WARN + skip promotion.
 
@@ -84,7 +84,7 @@ Add `dtype_bytes` helper (private to the .cpp, mapping `QType::F16 → 2`, `QTyp
 
 **Quality Gate:** unit test feeding mismatched shapes; verifies skip + WARN.
 
-### Item 7 — F5: malformed tensor entry warnings (P2)
+### Item 7 — F5: malformed tensor entry warnings (P2) — `closed-in-369a806`
 
 **Change:** `src/model/safetensors_loader.cpp:554-580` — replace each silent `continue` with `IMP_LOG_WARN("safetensors: dropping tensor '%s' — <reason>")` and an end-of-shard summary count. Reasons: missing dtype, missing shape, ndim>kMaxDims, missing data_offsets.
 
@@ -94,7 +94,7 @@ Add `dtype_bytes` helper (private to the .cpp, mapping `QType::F16 → 2`, `QTyp
 
 **Quality Gate:** unit test crafting a SafeTensors blob where one tensor has malformed shape and asserting (a) the load returns success with the other tensors present, (b) the malformed tensor name appears in the WARN log via gtest's stderr capture.
 
-### Item 8 — F7: header-size upper bound (P2)
+### Item 8 — F7: header-size upper bound (P2) — `closed-in-5d9b28f` (combined with F3, see Item 3)
 
 **Change:** `src/model/safetensors_loader.cpp:519` — soft-cap header_size at 128 MiB (a 128 MiB header would represent a >50 M-tensor checkpoint; real models are O(1000) tensors). Above the cap: ERROR + return false.
 

--- a/docs/audit/progress.log
+++ b/docs/audit/progress.log
@@ -1,0 +1,10 @@
+2026-05-08T00:00:00Z da71f8d Phase0 closed inventory: 0 FEASIBLE, 1 UNCERTAIN deferred, 21 INFEASIBLE, 5 OBSOLETE
+2026-05-08T00:00:00Z 314de37 Phase1 closed audit F1-F10 identified, 8 in plan, 2 deferred (P3 spec-compliance/UX)
+2026-05-08T00:00:00Z 0f67fbb Phase2 closed master plan + 2 ADRs (pure-C++ ref harness, 128MiB header cap)
+2026-05-08T00:00:00Z 168f847 F1 closed compressed-tensors NVFP4 reference test (4 new cases all pass, 82/82 quant suite green)
+2026-05-08T00:00:00Z bb8c54c F2 closed Modelopt NVFP4 weight_scale_2 defensive zeroing (9 new tests, 91/91 quant suite)
+2026-05-08T00:00:00Z 5d9b28f F3+F7 closed safetensors header overflow-safe + 128 MiB cap (6 new tests, 139/139 core suite)
+2026-05-08T00:00:00Z 6ede041 F4 closed safetensors per-tensor offset/size validation (7 new tests, 146/146 core)
+2026-05-08T00:00:00Z 03b8996 F8 closed NVFP4 weight_scale dtype validation (5 new tests, 96/96 quant)
+2026-05-08T00:00:00Z 4d9b640 F6 closed NVFP4 packed/scale shape validation (7 new tests, 103/103 quant)
+2026-05-08T00:00:00Z 369a806 F5 closed safetensors malformed-entry WARN with stderr-capture tests (2 new tests, 148/148 core)

--- a/docs/audit/roadmap_inventory_2026-05.md
+++ b/docs/audit/roadmap_inventory_2026-05.md
@@ -1,0 +1,105 @@
+# Roadmap Inventory — 2026-05-08
+
+Purpose: discover and classify every roadmap-like artifact in the repo so the master plan only includes items that can plausibly meet the Quality Gate in this run.
+
+## Sources scanned
+
+- `docs/roadmap.md` — primary roadmap (7 known limitations + 3 perf items + research interest)
+- `docs/sm120-real-perf-plan.md` — five-lever sm_120a perf plan
+- `docs/audit/safetensors_audit.md` — Phase 1 + Phase 2 outcomes, list of remaining-unresolved items
+- `git log --oneline -200` — recent merges + memory pointers
+- `gh issue list --state open --limit 50` — none open
+- `gh pr list --state open --limit 30` — none open
+- `rg -i "TODO|FIXME|XXX" src/` — no priority/owner-tagged markers in src
+
+## Quality-Gate baseline
+
+A roadmap item is **FEASIBLE** only if it can be landed in this run without:
+- adding any new third-party dependency,
+- skipping/disabling tests to ship green,
+- shipping a partial kernel without a numerical reference,
+- multi-week kernel rewrites or new compute architecture,
+- shortcut/symptom-mask fixes that don't address root cause.
+
+Borderline calls go to UNCERTAIN, not FEASIBLE.
+
+## Items
+
+### A. `docs/roadmap.md` — Known limitations
+
+| # | Item | Severity | Feasibility | Reasoning |
+|---|---|---|---|---|
+| L1 | FP8 KV cache: Gemma-4 carve-out | P2 | INFEASIBLE | Per-layer head_dim awareness in KV write/read kernels — multi-day kernel work + multi-model regression sweep |
+| L2 | Chunked prefill: paged-prefill kernel pending | P2 | INFEASIBLE | New paged-prefill attention kernel + multi-context regression suite. Mitigation already shipped in PR #114 (single-chunk default) |
+| L3 | NVFP4 SmoothQuant `input_scale` (Mistral-3.2) | P2 | INFEASIBLE | Refuted as scalar-alpha; real fix needs per-channel SmoothQuant scaling vector applied during activation quant — multi-week, only one test model |
+| L4 | Qwen3.5-27B MXFP4 fails at load | P3 | INFEASIBLE | Needs host-dequant path + StoragePlanner integration — large change, single-model unlock |
+| L5 | Gemma-4 Q4_K_M code-gen drift | P3 | INFEASIBLE | FP16 accumulator drift across 30 layers; "use Q5/Q8" workaround documented |
+| L6 | MoE expert offload disables CUDA Graphs | P2 | INFEASIBLE | Needs device-side LRU prefetch + async pipeline — significant runtime kernel work |
+
+### B. `docs/roadmap.md` — Performance work
+
+| # | Item | Severity | Feasibility | Reasoning |
+|---|---|---|---|---|
+| P1 | Closing TurboQuant–FP8 gap | P3 | INFEASIBLE | "Algorithm-inherent" per roadmap — needs MXFP4 K-direction redesign |
+| P2 | pp=512 on large dense models | P3 | INFEASIBLE | cuBLAS autotune variance, "not gating any user" per roadmap |
+| P3 | Speculative decoding | P3 | OBSOLETE | Investigated and shelved per roadmap; CLI flags already removed in `7380ea8` |
+
+### C. `docs/roadmap.md` — Research interest
+
+| # | Item | Severity | Feasibility | Reasoning |
+|---|---|---|---|---|
+| R1 | `cudaMemcpyWithAttributesAsync` L2 hints | P3 | INFEASIBLE | Narrow benefit (single-transfer L2 persist), no benchmark scaffolding |
+| R2 | `add.f32x2` native PTX | P3 | UNCERTAIN→INFEASIBLE | Like SFU-exp2 lever (`memory/lever5_sfu_exp2_neutral_2026_05_06.md`): mathematically tempting, likely net-zero on imp's HMMA-pipe-bound paths. Without bench harness change, can't prove benefit |
+| R3 | `cp.async.bulk` `.ignore_oob` | P3 | INFEASIBLE | Paged-attention kernel rewrite with TMA descriptors |
+| R4 | `st.async.b128` 16B async stores | P3 | INFEASIBLE | KV writeback rewrite |
+| R5 | `cvt .bf16x2 ↔ narrow (.e2m1x2, .e4m3x2)` | P2 | OBSOLETE | Shipped in PR #125 (commit `3eb7ef5`, vectorized FP4 dequant in paged KV decode +25.6%) |
+| R6 | `.scale_vec::4X` with `.ue8m0` for MXFP4 MMA | P3 | INFEASIBLE | MXFP4 SafeTensors path does not exist on imp — no test fleet |
+| R7 | FP4 PV (Phase-3 P×V in attention) | P2 | INFEASIBLE | "Quality-risky"; prereq is PV-only A/B test harness which doesn't exist; SageAttention3-style two-level accumulator is multi-week |
+| R8a | K2 MLA (DeepSeek latent KV) | P2 | INFEASIBLE | Multi-week — separate attention path |
+| R8b | K5 H2O token eviction | P3 | INFEASIBLE | Score-based eviction kernel + scheduler change |
+| R8c | K8 CPU offload async prefetch | P3 | INFEASIBLE | Significant runtime + memory-tier work |
+| R9 | BitDecoding (MXFP4 KV) | P3 | INFEASIBLE | Builds on MXFP4 KV which is research-grade |
+| R10 | DeltaKV residual KV compression | P3 | INFEASIBLE | New KV compression algorithm + kernel |
+
+### D. `docs/sm120-real-perf-plan.md` — Five-lever plan
+
+| # | Lever | Status (per memory) | Feasibility now |
+|---|---|---|---|
+| Lv1 | SSM-Layer in `cutlass_nvfp4_cache` | OBSOLETE | DONE — `fb92be9` registers `ssm_in/ssm_out` at `executor_pre_dequant.cu:466-467` |
+| Lv2 | NVFP4 KV-cache with HW absmax | OBSOLETE | DONE 2026-05-07 (PR #108) + vectorized PTX cvt 2026-05-08 (PR #125) |
+| Lv3 | CLC-persistent for continuous batching | INFEASIBLE | "Multi-user only, +10-20%"; single-author single-target experiment, no multi-tenant validation harness |
+| Lv4 | Tile-tuning for 99-KiB SMEM (correction from 228) | OBSOLETE | A/B'd 2026-05-06: baseline `<128,128,128>` wins all variants per `memory/lever4_tile_tuning_baseline_wins_2026_05_06.md` |
+| Lv5 | Online-softmax SFU-exp2 micro-opt | OBSOLETE | Shipped+reverted 2026-05-06 (`memory/lever5_sfu_exp2_neutral_2026_05_06.md`). Net-zero |
+
+### E. `docs/audit/safetensors_audit.md` — items "truly unresolved"
+
+| # | Item | Severity | Feasibility | Reasoning |
+|---|---|---|---|---|
+| AU1 | GLM architecture mapping | P2 | INFEASIBLE | Needs new `GLM` enum + dedicated forward path (multi-week per audit note) |
+| AU2 | Native SentencePiece (`.model`) parser | P2 | UNCERTAIN | "~few hundred LoC" but full byte-fallback/Unigram protobuf decode + tokenization-roundtrip golden against actual checkpoints is a significant testing burden. Defer in favor of correctness-hardening work this run |
+| AU3 | AWQ INT4 dequant kernel | P2 | INFEASIBLE | "Multi-week" per audit, requires column-packed + interleave-permutation kernel |
+| AU4 | DeepSeek MLA attention | P1 | INFEASIBLE | "Multi-week effort" per audit |
+| AU5 | Multimodal SafeTensors loaders | P2 | INFEASIBLE | Per-family work for Qwen-VL / Llava / Pixtral / Gemma-3 vision |
+| AU6 | Tiktoken parser | P3 | INFEASIBLE | Out of scope per audit ("uncommon in supported families; ignored") |
+
+## Summary
+
+**FEASIBLE: 0**
+**UNCERTAIN: 1** (AU2 — SentencePiece native parser; deferred this run in favor of correctness-hardening)
+**INFEASIBLE: 21**
+**OBSOLETE: 5** (P3 spec-decode, R5 cvt narrow PTX, Lv1 SSM cache, Lv2 NVFP4 KV, Lv4 tile-tuning, Lv5 SFU-exp2)
+
+This is consistent with imp's mature state: most listed items are either explicit dead-ends (already investigated, documented, dropped) or multi-week kernel/architecture work that no autonomous single-run can land at full Quality Gate.
+
+**Decision:** Per the mission's conditional model, this run focuses entirely on Objective 1 — SafeTensors + NVFP4 hardening. Every roadmap entry is captured in `docs/audit/followups.md` with reasoning. AU2 stays UNCERTAIN and is re-evaluated only if Objective-1 work completes with runway.
+
+## Open commits cross-reference
+
+`git log` since the audit branch landed (`b6c2b9c`):
+- `3eb7ef5` perf(nvfp4): vectorized FP4 dequant in paged KV decode (+25.6%) — closes R5
+- `7539949` chore(skills): commit imp-specific Claude Code skills
+- `8c39b8f` ci: auto-enable squash auto-merge
+- `79051f4` ci: ccache + base image bump
+- `454ca58` fix(nvfp4): graph-safe gemm_nvfp4 dequant fallback — Lever 2 stage 1
+
+No `roadmap:` / `next:` / `followup:` markers in the last 200 commits beyond historical references already absorbed by `docs/roadmap.md`.

--- a/docs/audit/roadmap_inventory_2026-05.md
+++ b/docs/audit/roadmap_inventory_2026-05.md
@@ -84,9 +84,9 @@ Borderline calls go to UNCERTAIN, not FEASIBLE.
 
 ## Summary
 
-**FEASIBLE: 0**
-**UNCERTAIN: 1** (AU2 — SentencePiece native parser; deferred this run in favor of correctness-hardening)
-**INFEASIBLE: 21**
+**FEASIBLE: 0** — none entered the master plan
+**UNCERTAIN: 1** (AU2 — SentencePiece native parser; deferred this run in favor of correctness-hardening) — `Status: deferred (see followups.md)`
+**INFEASIBLE: 21** — all in `docs/audit/followups.md`
 **OBSOLETE: 5** (P3 spec-decode, R5 cvt narrow PTX, Lv1 SSM cache, Lv2 NVFP4 KV, Lv4 tile-tuning, Lv5 SFU-exp2)
 
 This is consistent with imp's mature state: most listed items are either explicit dead-ends (already investigated, documented, dropped) or multi-week kernel/architecture work that no autonomous single-run can land at full Quality Gate.

--- a/docs/audit/safetensors_nvfp4_audit_2026-05.md
+++ b/docs/audit/safetensors_nvfp4_audit_2026-05.md
@@ -1,0 +1,167 @@
+# SafeTensors + NVFP4 Hardening Audit (2026-05-08)
+
+**Scope:** read-only audit on top of the existing `docs/audit/safetensors_audit.md` (Phase 1 + Phase 2, PR #116). Focus: gaps that Phase 2 left open or that surfaced after the cv-narrow shipping in PR #125. Each finding cites `file:line`, with severity (P0–P3), one-paragraph explanation, and a regression-test target.
+
+This audit complements rather than replaces the prior one. The prior audit's "Items that remain truly unresolved" section enumerates P2-class deferred work (GLM, native SentencePiece, AWQ kernel, DeepSeek MLA, multimodal); those are tracked in `docs/audit/followups.md`. The findings below are smaller hardening items that *can* land at full Quality Gate inside this run.
+
+## Audit method
+
+- Re-read every file Phase 1 named, plus the post-Phase-2 commits (`454ca58`, `3eb7ef5`, `b6c2b9c`).
+- Re-read every NVFP4 test fixture (`tests/test_nvfp4_*.cu`).
+- Inspected real on-disk checkpoints (`/home/kekz/models/Gemma-4-26B-A4B-it-NVFP4/`, `/home/kekz/models/Qwen3-30B-A3B-NVFP4-Modelopt/`) for `weight_packed` / `weight_scale` / `weight_scale_2` shape and dtype.
+- Walked the dequant code path end-to-end: `safetensors_loader.cpp` → `weight_map.cpp` → `weight_upload.cu` → `executor_pre_dequant.cu` (Phase 0 promote) → `nvfp4_gemm.cu` (`gemv_nvfp4_row` formula).
+
+## Findings
+
+### F1 — No reference-numerical test for compressed-tensors NVFP4 dequant — **P0**
+
+**Where:** `tests/test_nvfp4_*.cu` — every existing test either uses imp's own `quantize_fp16_to_nvfp4` and round-trips through the same kernel pair (`test_nvfp4_quant_ref.cu`, `test_nvfp4_quant_hw.cu`, `test_nvfp4_gemv_kpar_loop.cu`), or is a no-op crash-check (`test_nvfp4_quant.cu`).
+
+**Why this is P0:** The mission's guarantee is "no silent correctness bugs". The compressed-tensors NVFP4 spec is explicit about three-component dequant `val = fp4 * fp8_e4m3_to_fp32(weight_scale_block) * weight_scale_2_fp32`. Roundtrip-only tests cannot detect a bug where imp's quantizer and dequantizer have a paired sign-flip or nibble-swap convention that disagrees with the on-disk format produced by Modelopt / llm-compressor. They can also not detect a missing factor — e.g. dropping `weight_scale_2` would still pass the existing roundtrip, but produce 1×–448× wrong output on real checkpoints.
+
+**Regression target:** unit test in `tests/test_nvfp4_compressed_tensors_ref.cu` that:
+1. Constructs a synthetic `weight_packed` (uint8 nibble-packed FP4 values), `weight_scale` (FP8 E4M3, group_size=16), `weight_scale_2` (FP32 scalar) on the host.
+2. Computes the expected output `Y = X · W^T` using a pure-host reference dequant strictly from the spec.
+3. Routes the same buffers through imp's `gemv_nvfp4_kpar` GEMV path.
+4. Verifies max-abs-diff < 1e-2 (HW-cvt FP4 path is bit-exact for representable values; FMA-order is the only divergence source).
+
+Tolerance from the mission's harness rules ("Option 3: max abs diff < 1e-5") is too tight for FP16 GEMM accumulation order; 1e-2 is realistic for K=128 FP16 dot-product.
+
+### F2 — Modelopt NVFP4 `weight_scale_2` not isfinite-checked — **P1**
+
+**Where:** `src/graph/executor_pre_dequant.cu:262-279`.
+
+PR #113 added a defensive guard for the **llm-compressor** path: if `h_scale == 0` or `1.0f / h_scale` is non-finite, the promoted scale is set to 0.0 (zeroing the layer's contribution rather than producing NaN/Inf). The **Modelopt** branch at the `else` clause (`promoted_scale = h_scale;`) has no such guard. A malformed Modelopt checkpoint with `weight_scale_2 = NaN` or `±Inf` would propagate non-finite values into the GEMM output, contaminating the entire layer's hidden state and likely the KV cache.
+
+**Regression target:** unit test that calls the promote helper (or a thin integration test through `executor_pre_dequant.cu` Phase 0) with both NaN and +Inf weight_scale_2 values, and verifies promoted_scale is zeroed defensively for both.
+
+### F3 — Header-size validation has integer overflow — **P1**
+
+**Where:** `src/model/safetensors_loader.cpp:519-524`.
+
+```cpp
+uint64_t header_size = 0;
+std::memcpy(&header_size, data, sizeof(uint64_t));
+if (8 + header_size > file_size) {       // <-- overflow
+    munmap(mmap_base, file_size);
+    return false;
+}
+```
+
+A malicious/corrupt SafeTensors file that declares `header_size = UINT64_MAX - 4` makes `8 + header_size` wrap to `3`. The check `3 > file_size` is false, so the loader proceeds and constructs `JsonParser(json_data, static_cast<size_t>(header_size))` with a length far past the mmap region. The parser does bounded reads, but they read past the end of the mapped region → SIGSEGV.
+
+**Regression target:** unit test that writes a synthetic 16-byte file containing `header_size = UINT64_MAX` and verifies `load_safetensors` returns false without crashing.
+
+**Fix:** change to `header_size > file_size - 8` (with explicit ordering to avoid underflow when `file_size < 8`, but `file_size >= 8` is already enforced at line 495).
+
+### F4 — Tensor offsets not validated against shape × dtype — **P1**
+
+**Where:** `src/model/safetensors_loader.cpp:572-584`.
+
+```cpp
+uint64_t offset_start = static_cast<uint64_t>(offsets_val->arr[0].as_int());
+uint64_t offset_end = static_cast<uint64_t>(offsets_val->arr[1].as_int());
+if (tensor_data_offset + offset_end > file_size)
+    continue;
+```
+
+Three real bugs:
+1. `offset_start` is read but never used in validation. A malformed file with `offset_start > offset_end` would compute a negative "size" and the consuming kernel would read *backwards* into adjacent tensor data.
+2. `offset_end - offset_start` is not compared to `nelem(shape) * sizeof(dtype)`. A file declaring an FP16 tensor of shape [1024, 1024] but with `offset_end - offset_start = 1024` (1KB instead of 2MB) would silently load 0.05% of the actual weight data, then return zeroes (or unrelated bytes) for the rest.
+3. `tensor_data_offset + offset_start > file_size` is not checked — the start of the buffer might be past EOF even if the (truncated) `offset_end` is in-bounds (which can happen with a corrupted-but-self-consistent file).
+
+**Regression target:** unit tests for each of the three malformed cases.
+
+**Fix:** validate `offset_start <= offset_end`, `offset_end - offset_start == expected_nbytes(shape, dtype)`, and `tensor_data_offset + offset_end <= file_size`. Compute expected_nbytes via a small `dtype_bytes(QType)` helper.
+
+### F5 — Silent drop of malformed tensor entries — **P2**
+
+**Where:** `src/model/safetensors_loader.cpp:554-580`.
+
+Five `continue` statements silently skip tensor entries when:
+- `dtype` is missing (`!dtype_val`)
+- `dtype` value is not a string
+- `shape` is missing
+- `shape` is not an array
+- `ndim > kMaxDims`
+- `data_offsets` is missing/wrong arity
+- offset bounds fail (post-fix from F4 above)
+
+A user with a corrupt checkpoint sees `tensor_map` come back partially populated; the model loads as if some tensors are absent; downstream null-checks make load look "successful". No log line is emitted indicating which tensors were dropped or why.
+
+**Regression target:** unit tests that craft a SafeTensors blob where one tensor's `shape` is malformed, and verify a WARN line is emitted naming the tensor and the reason.
+
+**Fix:** replace each silent `continue` with a counter-bumped `IMP_LOG_WARN` summarized at end of `load_shard`.
+
+### F6 — NVFP4 `weight_packed` shape vs `weight_scale` shape not validated — **P2**
+
+**Where:** `src/graph/executor_pre_dequant.cu:237-287` (promote) and `src/quant/nvfp4_gemm.cu:96-108` (kernel).
+
+The kernel hard-assumes group_size=16 (`kMicroBlockSize = 16` at `nvfp4_gemm.cu:31`) and reads `n_mb = K / 16` micro-scales per row. The loader/promote step never verifies that the loaded `weight_scale` has shape `[N, K/16]`. A pathological checkpoint with `weight_scale.shape == [N, K/8]` (group_size=8) would silently load: every other micro-scale would be misinterpreted as the "next" group's scale, producing 12.5% step quant noise on roughly half the elements. Output would not crash — it would just be subtly wrong.
+
+**Regression target:** unit test that constructs `weight_scale` with the wrong group dimension and verifies promote rejects it (warns + skips promotion, leaving the weight in its non-NVFP4 state where the dequant→cuBLAS fallback will run).
+
+**Fix:** add a shape sanity check in `promote()` that compares `sc.weight_scale.shape[1]` against `w.shape[1] / 16` (or equivalently `w.shape[1] * 2 / 16` for the packed-K-half storage). Skip promotion + WARN on mismatch.
+
+### F7 — Header-size upper bound missing — **P2**
+
+**Where:** `src/model/safetensors_loader.cpp:519-524`.
+
+`header_size` is bounded above only by `file_size - 8`. A pathological file of size 1 GiB with `header_size = 1 GiB - 8` (i.e. claiming the entire file is JSON header) would have `JsonParser` allocate / scan a 1 GiB JSON. The parser doesn't impose a separate ceiling. For real-world checkpoints, the header is typically <100 KiB; a multi-megabyte header is suspicious.
+
+**Regression target:** unit test that constructs a 64 KiB file with `header_size = 65528` (just under file_size) and verifies the loader either accepts or rejects it deterministically.
+
+**Fix:** soft-cap `header_size` at, say, 128 MiB; emit ERROR + return false above the cap. Documented in an ADR.
+
+### F8 — `weight_scale` dtype not enforced — **P2**
+
+**Where:** loader silently accepts whatever dtype `weight_scale` was written in. The compressed-tensors spec mandates `float8_e4m3fn` for NVFP4 and `uint8` (UE8M0) for MXFP4. A model marked NVFP4 in `recipe.yaml` but with `weight_scale.dtype == "U8"` would still load through the NVFP4 promote path, then `gemv_nvfp4_row` would interpret the UE8M0 bytes as E4M3 and produce ~2× wrong scales (powers of two interpreted as E4M3 normals).
+
+This is a NVFP4↔MXFP4 cross-misrouting risk. Phase 1 of the prior audit listed it as a P0 cross-cutting concern but Phase 2 didn't add an explicit guard.
+
+**Regression target:** unit test that constructs a synthetic prequant scratch entry where `weight_scale.qtype = QType::INT8` (UE8M0 bytes) and verifies promote rejects it with WARN + skips promotion.
+
+**Fix:** validate `sc.weight_scale.qtype == QType::FP8_E4M3` in `promote()` before applying the formula. Skip + WARN on mismatch.
+
+### F9 — `header_size` not aligned check — **P3** (spec-compliance only)
+
+**Where:** `src/model/safetensors_loader.cpp:519-534`.
+
+The SafeTensors spec recommends 8-byte alignment of the JSON header end (so tensor data begins at an 8-byte boundary). imp doesn't enforce or warn. Files produced by reference SafeTensors libraries always satisfy this, so it's spec-compliance, not correctness. Skip in this run unless a regression model surfaces.
+
+### F10 — `unrecognized layer weights` counter not summarized for SafeTensors — **P3**
+
+**Where:** `src/model/weight_map.cpp:1053`.
+
+The counter exists but only fires per-tensor at log-level WARN. End-of-load summary line gives counts but the PER-TENSOR list is not retained. For diagnosing why a model loads but produces wrong output, a top-N list of unrecognized tensor names would speed user debugging. Not a correctness bug.
+
+## Findings summary
+
+| ID | Title | Severity | Action |
+|----|---|---|---|
+| F1 | Reference numerical test for compressed-tensors NVFP4 dequant absent | P0 | Add new unit test |
+| F2 | Modelopt NVFP4 weight_scale_2 not isfinite-checked | P1 | Extend guard + unit test |
+| F3 | Header-size validation has integer overflow | P1 | Reorder check + unit test |
+| F4 | Tensor offsets not validated against shape × dtype | P1 | Validate + unit test |
+| F5 | Silent drop of malformed tensor entries | P2 | WARN + summary + unit test |
+| F6 | NVFP4 weight_packed vs weight_scale shape not validated | P2 | Promote-time check + unit test |
+| F7 | Header-size upper bound missing | P2 | Soft-cap + ERROR + unit test |
+| F8 | NVFP4 weight_scale dtype not enforced | P2 | Promote-time check + unit test |
+| F9 | Header-size 8-byte alignment | P3 | Skip (spec-compliance only) |
+| F10 | Unrecognized-tensor list not retained | P3 | Skip (UX, not correctness) |
+
+P0: 1 — ships first, mandatory under Quality Gate.
+P1: 3 — all silent correctness bugs.
+P2: 4 — all silent correctness bugs that need contrived inputs to trigger.
+P3: 2 — deferred; documented here for future reference.
+
+## Cross-cutting items not in scope this run
+
+These appear in the prior audit and remain unresolved; they are not actionable at full Quality Gate within a single autonomous run. Deferred to `docs/audit/followups.md`.
+
+- GLM architecture mapping
+- Native SentencePiece (`.model`) parser
+- AWQ INT4 dequant kernel
+- DeepSeek MLA attention path
+- Multimodal SafeTensors loaders
+- Tiktoken parser

--- a/docs/audit/safetensors_nvfp4_audit_2026-05.md
+++ b/docs/audit/safetensors_nvfp4_audit_2026-05.md
@@ -137,18 +137,18 @@ The counter exists but only fires per-tensor at log-level WARN. End-of-load summ
 
 ## Findings summary
 
-| ID | Title | Severity | Action |
-|----|---|---|---|
-| F1 | Reference numerical test for compressed-tensors NVFP4 dequant absent | P0 | Add new unit test |
-| F2 | Modelopt NVFP4 weight_scale_2 not isfinite-checked | P1 | Extend guard + unit test |
-| F3 | Header-size validation has integer overflow | P1 | Reorder check + unit test |
-| F4 | Tensor offsets not validated against shape × dtype | P1 | Validate + unit test |
-| F5 | Silent drop of malformed tensor entries | P2 | WARN + summary + unit test |
-| F6 | NVFP4 weight_packed vs weight_scale shape not validated | P2 | Promote-time check + unit test |
-| F7 | Header-size upper bound missing | P2 | Soft-cap + ERROR + unit test |
-| F8 | NVFP4 weight_scale dtype not enforced | P2 | Promote-time check + unit test |
-| F9 | Header-size 8-byte alignment | P3 | Skip (spec-compliance only) |
-| F10 | Unrecognized-tensor list not retained | P3 | Skip (UX, not correctness) |
+| ID | Title | Severity | Action | Status |
+|----|---|---|---|---|
+| F1 | Reference numerical test for compressed-tensors NVFP4 dequant absent | P0 | Add new unit test | closed-in-168f847 |
+| F2 | Modelopt NVFP4 weight_scale_2 not isfinite-checked | P1 | Extend guard + unit test | closed-in-bb8c54c |
+| F3 | Header-size validation has integer overflow | P1 | Reorder check + unit test | closed-in-5d9b28f |
+| F4 | Tensor offsets not validated against shape × dtype | P1 | Validate + unit test | closed-in-6ede041 |
+| F5 | Silent drop of malformed tensor entries | P2 | WARN + summary + unit test | closed-in-369a806 |
+| F6 | NVFP4 weight_packed vs weight_scale shape not validated | P2 | Promote-time check + unit test | closed-in-4d9b640 |
+| F7 | Header-size upper bound missing | P2 | Soft-cap + ERROR + unit test | closed-in-5d9b28f (combined with F3 — same `validate_header_size`) |
+| F8 | NVFP4 weight_scale dtype not enforced | P2 | Promote-time check + unit test | closed-in-03b8996 |
+| F9 | Header-size 8-byte alignment | P3 | Skip (spec-compliance only) | deferred (P3, no real-world trigger) |
+| F10 | Unrecognized-tensor list not retained | P3 | Skip (UX, not correctness) | deferred (P3, UX only) |
 
 P0: 1 — ships first, mandatory under Quality Gate.
 P1: 3 — all silent correctness bugs.

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -250,32 +250,37 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     memcpy(&h_scale, sc.weight_scale_2.data, sizeof(float));
                 }
             }
-            // Modelopt:        val = fp4 * micro_scale * tensor_scale  (multiply)
-            // llm-compressor:  val = fp4 * micro_scale / tensor_scale  (divide → store 1/x)
-            //
-            // Defensive guard: a zero h_scale would make 1/x = +Inf and
-            // contaminate the entire layer's output via the GEMM. This
-            // happens for layers with all-zero weights (rare but observed
-            // in some llm-compressor exports). Fall back to 0 so the
-            // weight contribution is null instead of NaN/Inf.
-            float promoted_scale;
-            if (cfg.is_llm_compressor_nvfp4) {
-                if (h_scale == 0.0f) {
-                    n_zero_scale++;
-                    promoted_scale = 0.0f;
-                    IMP_LOG_WARN("NVFP4 prequant: %s has weight_scale_2=0 — zeroing tensor_scale "
-                                 "(would otherwise produce Inf via reciprocal flip)", key);
-                } else {
-                    promoted_scale = 1.0f / h_scale;
-                    if (!std::isfinite(promoted_scale)) {
+            // Defensive promotion: zero, NaN, ±Inf weight_scale_2 → 0.0f. Both
+            // Modelopt (multiply) and llm-compressor (divide → 1/x) paths are
+            // guarded; see nvfp4_promote_weight_scale_2 in quant/nvfp4_quant.h.
+            // Without this guard a non-finite scale would propagate through the
+            // GEMM and contaminate the entire layer's hidden state.
+            bool was_zeroed = false;
+            float promoted_scale = nvfp4_promote_weight_scale_2(h_scale, cfg.is_llm_compressor_nvfp4,
+                                                                &was_zeroed);
+            if (was_zeroed) {
+                if (cfg.is_llm_compressor_nvfp4) {
+                    if (h_scale == 0.0f) {
+                        n_zero_scale++;
+                        IMP_LOG_WARN("NVFP4 prequant: %s has weight_scale_2=0 — zeroing tensor_scale "
+                                     "(would otherwise produce Inf via reciprocal flip)", key);
+                    } else {
                         n_nonfinite_after_flip++;
-                        promoted_scale = 0.0f;
                         IMP_LOG_WARN("NVFP4 prequant: %s reciprocal flip produced non-finite scale "
                                      "from h_scale=%.6g — zeroing", key, h_scale);
                     }
+                } else {
+                    if (h_scale == 0.0f) {
+                        n_zero_scale++;
+                        // Modelopt with h_scale=0 is intentional: a calibrated
+                        // null layer. Log at INFO, no WARN.
+                        IMP_LOG_DEBUG("NVFP4 prequant: %s has weight_scale_2=0 (Modelopt null layer)", key);
+                    } else {
+                        n_nonfinite_after_flip++;
+                        IMP_LOG_WARN("NVFP4 prequant: %s has non-finite weight_scale_2=%.6g — zeroing "
+                                     "tensor_scale", key, h_scale);
+                    }
                 }
-            } else {
-                promoted_scale = h_scale;
             }
             if (sc.input_scale.data) {
                 n_with_input_scale++;
@@ -374,8 +379,9 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         if (prequant_count > 0) {
             IMP_LOG_INFO("NVFP4 pre-quantized: promoted %d weights to Tensor sidecars", prequant_count);
             if (n_zero_scale > 0 || n_nonfinite_after_flip > 0) {
-                IMP_LOG_WARN("NVFP4 prequant: %d zero weight_scale_2 / %d non-finite reciprocal flips "
-                             "(weights zeroed defensively)", n_zero_scale, n_nonfinite_after_flip);
+                IMP_LOG_WARN("NVFP4 prequant: %d zero weight_scale_2 / %d non-finite weight_scale_2 "
+                             "(weights zeroed defensively, applies to both Modelopt and llm-compressor)",
+                             n_zero_scale, n_nonfinite_after_flip);
             }
             if (cfg.is_llm_compressor_nvfp4 && n_with_input_scale > 0) {
                 // input_scale is a SmoothQuant-style activation-rescaling vector

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -234,12 +234,25 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         int n_zero_scale = 0;
         int n_nonfinite_after_flip = 0;
         int n_with_input_scale = 0;
+        int n_wrong_scale_dtype = 0;
         auto promote = [&](const NvFP4PreQuantWeight& sc, Tensor& w, const char* key) {
             if (!sc.valid() || !w.data)
                 return false;
             if (!w.on_device || !sc.weight_scale.on_device) {
                 IMP_LOG_DEBUG("NVFP4 prequant: skipping %s (data_dev=%d, scale_dev=%d)", key, w.on_device,
                               sc.weight_scale.on_device);
+                return false;
+            }
+            // F8: enforce compressed-tensors NVFP4 spec: weight_scale must be
+            // float8_e4m3fn. Defending against NVFP4↔MXFP4 cross-misrouting
+            // (where weight_scale would be U8 / UE8M0 power-of-two) and other
+            // accidental dtype mismatches that would silently corrupt output
+            // through the FP8 E4M3 decoder.
+            std::string scale_dtype_err;
+            if (!nvfp4_validate_weight_scale_dtype(sc.weight_scale.qtype, &scale_dtype_err)) {
+                n_wrong_scale_dtype++;
+                IMP_LOG_WARN("NVFP4 prequant: %s — %s. Skipping promotion (weight stays in "
+                             "dequant->cuBLAS fallback path).", key, scale_dtype_err.c_str());
                 return false;
             }
             float h_scale = 1.0f;
@@ -382,6 +395,11 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 IMP_LOG_WARN("NVFP4 prequant: %d zero weight_scale_2 / %d non-finite weight_scale_2 "
                              "(weights zeroed defensively, applies to both Modelopt and llm-compressor)",
                              n_zero_scale, n_nonfinite_after_flip);
+            }
+            if (n_wrong_scale_dtype > 0) {
+                IMP_LOG_WARN("NVFP4 prequant: %d weights had non-FP8_E4M3 weight_scale dtype "
+                             "(skipped — possible NVFP4/MXFP4 cross-misroute or corrupt checkpoint)",
+                             n_wrong_scale_dtype);
             }
             if (cfg.is_llm_compressor_nvfp4 && n_with_input_scale > 0) {
                 // input_scale is a SmoothQuant-style activation-rescaling vector

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -255,6 +255,24 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                              "dequant->cuBLAS fallback path).", key, scale_dtype_err.c_str());
                 return false;
             }
+
+            // F6: enforce group_size=16 between weight_packed [N, K/2] and
+            // weight_scale [N, K/16]. The kernel hard-codes kMicroBlockSize=16
+            // (nvfp4_gemm.cu:31); a shape mismatch would silently produce
+            // 12.5% per-element step quant noise on roughly half the elements
+            // (group_size != 16) or align scales onto wrong rows
+            // (transposed weight_scale). Both routes are 2D at promote time
+            // (per-expert weights have been split by weight_upload.cu).
+            if (w.ndim == 2 && sc.weight_scale.ndim == 2) {
+                std::string shape_err;
+                if (!nvfp4_validate_packed_scale_shapes(w.shape[0], w.shape[1],
+                                                       sc.weight_scale.shape[0], sc.weight_scale.shape[1],
+                                                       &shape_err)) {
+                    n_wrong_scale_dtype++;
+                    IMP_LOG_WARN("NVFP4 prequant: %s — %s. Skipping promotion.", key, shape_err.c_str());
+                    return false;
+                }
+            }
             float h_scale = 1.0f;
             if (sc.weight_scale_2.data) {
                 if (sc.weight_scale_2.on_device) {

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -25,6 +25,34 @@
 
 namespace imp {
 
+namespace safetensors_internal {
+
+bool validate_header_size(uint64_t file_size, uint64_t declared_header_size, std::string* err) {
+    if (file_size < 8) {
+        if (err)
+            *err = "file truncated below the 8-byte header_size prefix";
+        return false;
+    }
+    // Overflow-safe form: declared_header_size > (file_size - 8) cannot
+    // overflow because file_size - 8 is a valid subtraction (file_size >= 8).
+    // The naive 8 + declared_header_size > file_size would wrap to a small
+    // value when declared_header_size approaches UINT64_MAX, bypassing the
+    // check.
+    if (declared_header_size > file_size - 8) {
+        if (err)
+            *err = "declared header_size exceeds file size (file may be truncated or corrupt)";
+        return false;
+    }
+    if (declared_header_size > kMaxHeaderBytes) {
+        if (err)
+            *err = "declared header_size exceeds 128 MiB cap (suspicious file or pathological input)";
+        return false;
+    }
+    return true;
+}
+
+}  // namespace safetensors_internal
+
 // ---- Minimal JSON parser for SafeTensors headers ----
 
 // JSON value types we care about
@@ -518,9 +546,14 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
     auto data = reinterpret_cast<const uint8_t*>(mmap_base);
     uint64_t header_size = 0;
     std::memcpy(&header_size, data, sizeof(uint64_t));
-    if (8 + header_size > file_size) {
-        munmap(mmap_base, file_size);
-        return false;
+    {
+        std::string vh_err;
+        if (!safetensors_internal::validate_header_size(file_size, header_size, &vh_err)) {
+            IMP_LOG_ERROR("SafeTensors %s: %s (file_size=%zu, header_size=%llu)", path.c_str(),
+                          vh_err.c_str(), file_size, static_cast<unsigned long long>(header_size));
+            munmap(mmap_base, file_size);
+            return false;
+        }
     }
 
     const char* json_data = reinterpret_cast<const char*>(data + 8);

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -51,6 +51,35 @@ bool validate_header_size(uint64_t file_size, uint64_t declared_header_size, std
     return true;
 }
 
+bool validate_tensor_offsets(uint64_t offset_start, uint64_t offset_end, uint64_t expected_nbytes,
+                             uint64_t tensor_data_offset, uint64_t file_size, std::string* err) {
+    if (offset_start > offset_end) {
+        if (err)
+            *err = "offset_start > offset_end (data_offsets swap or corrupt)";
+        return false;
+    }
+    // Overflow-safe: tensor_data_offset + offset_end > file_size becomes
+    // offset_end > file_size - tensor_data_offset. file_size >= tensor_data_offset
+    // is guaranteed by the upstream validate_header_size check
+    // (tensor_data_offset = 8 + header_size, header_size <= file_size - 8).
+    if (tensor_data_offset > file_size) {
+        if (err)
+            *err = "tensor_data_offset > file_size (header_size validation invariant violated)";
+        return false;
+    }
+    if (offset_end > file_size - tensor_data_offset) {
+        if (err)
+            *err = "tensor offset_end past end of file (file truncated or corrupt)";
+        return false;
+    }
+    if (offset_end - offset_start != expected_nbytes) {
+        if (err)
+            *err = "tensor byte count does not match shape × dtype width";
+        return false;
+    }
+    return true;
+}
+
 }  // namespace safetensors_internal
 
 // ---- Minimal JSON parser for SafeTensors headers ----
@@ -312,6 +341,26 @@ static const JValue* jobj_find(const JValue& obj, const std::string& key) {
             return &kv.second;
     }
     return nullptr;
+}
+
+// ---- SafeTensors wire dtype string -> bytes-per-element ----
+//
+// Used by validate_tensor_offsets to compute expected_nbytes from shape ×
+// dtype width. Returns 0 for unknown dtype strings (validation is then
+// skipped for that tensor — the existing safetensors_dtype() WARN covers
+// the unknown-type case).
+static size_t safetensors_wire_dtype_bytes(const std::string& s) {
+    if (s == "F64")
+        return 8;
+    if (s == "F32" || s == "I32" || s == "U32")
+        return 4;
+    if (s == "F16" || s == "BF16" || s == "I16" || s == "U16")
+        return 2;
+    if (s == "F8_E4M3" || s == "F8_E5M2" || s == "I8" || s == "U8" || s == "BOOL")
+        return 1;
+    if (s == "I64" || s == "U64")
+        return 8;
+    return 0;
 }
 
 // ---- SafeTensors dtype string to QType ----
@@ -609,8 +658,25 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
         uint64_t offset_start = static_cast<uint64_t>(offsets_val->arr[0].as_int());
         uint64_t offset_end = static_cast<uint64_t>(offsets_val->arr[1].as_int());
 
-        if (tensor_data_offset + offset_end > file_size)
-            continue;
+        // Per-tensor offset/size validation (F4): reject swap, OOB end, and
+        // shape-vs-byte-count mismatch. expected_nbytes = nelem × wire_dtype_bytes.
+        size_t wire_bytes = safetensors_wire_dtype_bytes(dtype_val->str_val);
+        if (wire_bytes == 0) {
+            // Unknown wire dtype — skip strict validation but keep the soft
+            // OOB check below. safetensors_dtype()'s WARN already fires for
+            // unknown wire types when the tensor is actually emitted.
+            if (tensor_data_offset + offset_end > file_size)
+                continue;
+        } else {
+            int64_t nelem = 1;
+            for (int d = 0; d < ndim; d++)
+                nelem *= shape[d];
+            uint64_t expected_nbytes = static_cast<uint64_t>(nelem) * static_cast<uint64_t>(wire_bytes);
+            if (!safetensors_internal::validate_tensor_offsets(
+                    offset_start, offset_end, expected_nbytes, tensor_data_offset, file_size, nullptr)) {
+                continue;
+            }
+        }
 
         void* tensor_ptr = tensor_data_base + offset_start;
         Tensor t(tensor_ptr, dtype, ndim, shape, /*on_device=*/false);

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -616,6 +616,18 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
     size_t tensor_data_offset = 8 + static_cast<size_t>(header_size);
     uint8_t* tensor_data_base = const_cast<uint8_t*>(data + tensor_data_offset);
 
+    // Counters for malformed-entry diagnostics (F5). Each silent skip is
+    // counted; a per-shard summary is logged at end of load_shard so users
+    // can see which checkpoints have structural issues.
+    int n_dropped_no_dtype = 0;
+    int n_dropped_no_shape = 0;
+    int n_dropped_too_many_dims = 0;
+    int n_dropped_no_offsets = 0;
+    int n_dropped_offset_validation = 0;
+    auto warn_drop = [&](const char* tensor_name, const char* reason) {
+        IMP_LOG_WARN("SafeTensors %s: dropping tensor '%s' — %s", path.c_str(), tensor_name, reason);
+    };
+
     for (const auto& kv : root.obj) {
         std::string tensor_name = kv.first;  // copy — may be mutated by translation
         const JValue& tensor_meta = kv.second;
@@ -634,17 +646,26 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
         }
 
         const JValue* dtype_val = jobj_find(tensor_meta, "dtype");
-        if (!dtype_val || dtype_val->type != JType::STRING)
+        if (!dtype_val || dtype_val->type != JType::STRING) {
+            n_dropped_no_dtype++;
+            warn_drop(tensor_name.c_str(), "missing or non-string 'dtype' field");
             continue;
+        }
         QType dtype = safetensors_dtype(dtype_val->str_val);
 
         const JValue* shape_val = jobj_find(tensor_meta, "shape");
-        if (!shape_val || shape_val->type != JType::ARRAY)
+        if (!shape_val || shape_val->type != JType::ARRAY) {
+            n_dropped_no_shape++;
+            warn_drop(tensor_name.c_str(), "missing or non-array 'shape' field");
             continue;
+        }
 
         int ndim = static_cast<int>(shape_val->arr.size());
-        if (ndim > kMaxDims)
+        if (ndim > kMaxDims) {
+            n_dropped_too_many_dims++;
+            warn_drop(tensor_name.c_str(), "shape ndim exceeds engine kMaxDims");
             continue;
+        }
 
         int64_t shape[kMaxDims] = {};
         for (int d = 0; d < ndim; d++) {
@@ -652,8 +673,11 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
         }
 
         const JValue* offsets_val = jobj_find(tensor_meta, "data_offsets");
-        if (!offsets_val || offsets_val->type != JType::ARRAY || offsets_val->arr.size() != 2)
+        if (!offsets_val || offsets_val->type != JType::ARRAY || offsets_val->arr.size() != 2) {
+            n_dropped_no_offsets++;
+            warn_drop(tensor_name.c_str(), "missing or malformed 'data_offsets' field");
             continue;
+        }
 
         uint64_t offset_start = static_cast<uint64_t>(offsets_val->arr[0].as_int());
         uint64_t offset_end = static_cast<uint64_t>(offsets_val->arr[1].as_int());
@@ -665,15 +689,22 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
             // Unknown wire dtype — skip strict validation but keep the soft
             // OOB check below. safetensors_dtype()'s WARN already fires for
             // unknown wire types when the tensor is actually emitted.
-            if (tensor_data_offset + offset_end > file_size)
+            if (tensor_data_offset + offset_end > file_size) {
+                n_dropped_offset_validation++;
+                warn_drop(tensor_name.c_str(),
+                          "offset_end past EOF (unknown wire dtype, lenient check)");
                 continue;
+            }
         } else {
             int64_t nelem = 1;
             for (int d = 0; d < ndim; d++)
                 nelem *= shape[d];
             uint64_t expected_nbytes = static_cast<uint64_t>(nelem) * static_cast<uint64_t>(wire_bytes);
+            std::string vt_err;
             if (!safetensors_internal::validate_tensor_offsets(
-                    offset_start, offset_end, expected_nbytes, tensor_data_offset, file_size, nullptr)) {
+                    offset_start, offset_end, expected_nbytes, tensor_data_offset, file_size, &vt_err)) {
+                n_dropped_offset_validation++;
+                warn_drop(tensor_name.c_str(), vt_err.c_str());
                 continue;
             }
         }
@@ -687,6 +718,15 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
                       ndim > 1 ? std::to_string(shape[1]).c_str() : "", ndim > 2 ? "," : "",
                       ndim > 2 ? std::to_string(shape[2]).c_str() : "", (unsigned long)offset_start,
                       (unsigned long)offset_end);
+    }
+
+    int n_total_dropped = n_dropped_no_dtype + n_dropped_no_shape + n_dropped_too_many_dims +
+                          n_dropped_no_offsets + n_dropped_offset_validation;
+    if (n_total_dropped > 0) {
+        IMP_LOG_WARN("SafeTensors %s: dropped %d malformed tensors (no_dtype=%d no_shape=%d "
+                     "too_many_dims=%d no_offsets=%d offset_validation=%d)",
+                     path.c_str(), n_total_dropped, n_dropped_no_dtype, n_dropped_no_shape,
+                     n_dropped_too_many_dims, n_dropped_no_offsets, n_dropped_offset_validation);
     }
 
     return true;

--- a/src/model/safetensors_loader.h
+++ b/src/model/safetensors_loader.h
@@ -34,6 +34,23 @@ constexpr uint64_t kMaxHeaderBytes = 128ULL * 1024ULL * 1024ULL;
 // `err` (when non-null) is populated with a one-line reason on failure.
 bool validate_header_size(uint64_t file_size, uint64_t declared_header_size, std::string* err);
 
+// Validate per-tensor data_offsets [start, end) against the file/header layout.
+// `expected_nbytes` is the byte count implied by the tensor's shape × dtype
+// width (for SafeTensors wire dtypes — none of which are block-quantised).
+// `tensor_data_offset` is `8 + header_size` (start of the tensor data block).
+//
+// Three rules:
+//   1. offset_start <= offset_end                                   (no swap)
+//   2. tensor_data_offset + offset_end <= file_size                 (no OOB)
+//   3. offset_end - offset_start == expected_nbytes                 (size match)
+//
+// Overflow-safe; uses subtractions in the safe ordering.
+//
+// `err` (when non-null) is populated with the first violated rule's reason.
+bool validate_tensor_offsets(uint64_t offset_start, uint64_t offset_end,
+                             uint64_t expected_nbytes, uint64_t tensor_data_offset,
+                             uint64_t file_size, std::string* err);
+
 }  // namespace safetensors_internal
 
 }  // namespace imp

--- a/src/model/safetensors_loader.h
+++ b/src/model/safetensors_loader.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "model/model.h"
-#include <string>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <string>
 
 namespace imp {
 
@@ -11,5 +13,27 @@ namespace imp {
 //   - A single .safetensors file
 //   - A directory containing .safetensors files (+ config.json, etc.)
 std::unique_ptr<Model> load_safetensors(const std::string& path);
+
+// ---- Test-visible validation helpers ----
+//
+// These mirror the production validation rules in load_shard()
+// (safetensors_loader.cpp). They are exposed so unit tests can drive them
+// directly with synthetic blobs without constructing a full Model.
+namespace safetensors_internal {
+
+// Maximum legal SafeTensors JSON header size. Real models have headers below
+// 1 MiB; 128 MiB is far above legitimate use and far below pathological
+// inputs that would force the JSON parser to scan multi-GB regions. See
+// docs/audit/decisions/0002-header-size-cap.md.
+constexpr uint64_t kMaxHeaderBytes = 128ULL * 1024ULL * 1024ULL;
+
+// Validate the SafeTensors 8-byte header_size prefix in isolation. Returns
+// true if (8 + header_size <= file_size) and (header_size <= kMaxHeaderBytes).
+// Overflow-safe: works for file_size >= 8 and any uint64_t header_size.
+//
+// `err` (when non-null) is populated with a one-line reason on failure.
+bool validate_header_size(uint64_t file_size, uint64_t declared_header_size, std::string* err);
+
+}  // namespace safetensors_internal
 
 }  // namespace imp

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -12,6 +12,34 @@
 
 namespace imp {
 
+// Spec-compliance check for the NVFP4 weight_packed/weight_scale shape pair.
+bool nvfp4_validate_packed_scale_shapes(int64_t packed_outer, int64_t packed_inner,
+                                        int64_t scale_outer, int64_t scale_inner, std::string* err) {
+    if (packed_outer != scale_outer) {
+        if (err) {
+            char buf[160];
+            std::snprintf(buf, sizeof(buf),
+                          "weight_packed outer dim %lld != weight_scale outer dim %lld",
+                          static_cast<long long>(packed_outer), static_cast<long long>(scale_outer));
+            *err = buf;
+        }
+        return false;
+    }
+    // packed_inner = K/2, scale_inner = K/16, ratio must be 8 (group_size=16).
+    if (scale_inner <= 0 || packed_inner != scale_inner * 8) {
+        if (err) {
+            char buf[256];
+            std::snprintf(buf, sizeof(buf),
+                          "weight_scale inner dim %lld * 8 != weight_packed inner dim %lld "
+                          "(group_size != 16 or shape mismatch)",
+                          static_cast<long long>(scale_inner), static_cast<long long>(packed_inner));
+            *err = buf;
+        }
+        return false;
+    }
+    return true;
+}
+
 // Spec-compliance check for the NVFP4 weight_scale tensor's wire dtype.
 bool nvfp4_validate_weight_scale_dtype(QType qt, std::string* err) {
     if (qt == QType::FP8_E4M3)

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -12,6 +12,40 @@
 
 namespace imp {
 
+// Defensive promotion of weight_scale_2 → GEMM tensor_scale. Pure host fn.
+// See header comment in quant/nvfp4_quant.h for the formula details.
+float nvfp4_promote_weight_scale_2(float h_scale, bool is_llm_compressor, bool* was_zeroed) {
+    if (was_zeroed)
+        *was_zeroed = false;
+    if (!std::isfinite(h_scale)) {
+        if (was_zeroed)
+            *was_zeroed = true;
+        return 0.0f;
+    }
+    if (is_llm_compressor) {
+        if (h_scale == 0.0f) {
+            if (was_zeroed)
+                *was_zeroed = true;
+            return 0.0f;
+        }
+        float promoted = 1.0f / h_scale;
+        if (!std::isfinite(promoted)) {
+            if (was_zeroed)
+                *was_zeroed = true;
+            return 0.0f;
+        }
+        return promoted;
+    }
+    // Modelopt: multiplicative. Zero is a legitimate "null this layer" value;
+    // we still mark it as zeroed so the caller can surface the count, but we
+    // keep the value itself as 0.0f (no flip → no Inf).
+    if (h_scale == 0.0f) {
+        if (was_zeroed)
+            *was_zeroed = true;
+    }
+    return h_scale;
+}
+
 // ---------------------------------------------------------------------------
 // NVFP4 (FP4 E2M1) quantization with two-level scaling.
 //

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -12,6 +12,17 @@
 
 namespace imp {
 
+// Spec-compliance check for the NVFP4 weight_scale tensor's wire dtype.
+bool nvfp4_validate_weight_scale_dtype(QType qt, std::string* err) {
+    if (qt == QType::FP8_E4M3)
+        return true;
+    if (err) {
+        *err = std::string("weight_scale qtype is ") + qtype_name(qt) +
+               ", expected FP8_E4M3 (compressed-tensors NVFP4 spec)";
+    }
+    return false;
+}
+
 // Defensive promotion of weight_scale_2 → GEMM tensor_scale. Pure host fn.
 // See header comment in quant/nvfp4_quant.h for the formula details.
 float nvfp4_promote_weight_scale_2(float h_scale, bool is_llm_compressor, bool* was_zeroed) {

--- a/src/quant/nvfp4_quant.h
+++ b/src/quant/nvfp4_quant.h
@@ -103,4 +103,16 @@ float nvfp4_promote_weight_scale_2(float h_scale, bool is_llm_compressor, bool* 
 // instead of silently producing wrong output through the FP8 decoder.
 bool nvfp4_validate_weight_scale_dtype(QType qt, std::string* err);
 
+// Verify that weight_scale's inner dimension matches weight_packed's inner
+// dimension at the spec's group_size=16. weight_packed is stored as [N, K/2]
+// (packed halves) and weight_scale must be [N, K/16] = [N, weight_packed_K/8].
+//
+// Mismatch on outer dim or inner-dim ratio rejects promotion.
+//   packed_inner_dim is `weight.shape[1]` from the SafeTensors loader (= K/2).
+//   scale_inner_dim is `weight_scale.shape[1]`.
+//   packed_outer_dim/scale_outer_dim are shape[0] of each.
+bool nvfp4_validate_packed_scale_shapes(int64_t packed_outer_dim, int64_t packed_inner_dim,
+                                        int64_t scale_outer_dim, int64_t scale_inner_dim,
+                                        std::string* err);
+
 }  // namespace imp

--- a/src/quant/nvfp4_quant.h
+++ b/src/quant/nvfp4_quant.h
@@ -3,6 +3,7 @@
 #include "core/tensor.h"
 #include <cuda_runtime.h>
 #include <cstdint>
+#include <string>
 
 namespace imp {
 
@@ -94,5 +95,12 @@ void free_nvfp4_moe_result(NvFP4MoEQuantResult& result);
 //
 // Pure host function — testable without CUDA. Defined in nvfp4_quant.cu.
 float nvfp4_promote_weight_scale_2(float h_scale, bool is_llm_compressor, bool* was_zeroed);
+
+// Valid wire dtype for NVFP4 weight_scale per compressed-tensors spec.
+// Spec mandates float8_e4m3fn. NVFP4/MXFP4 cross-misroutes and corrupt
+// checkpoints would arrive here with U8/I8 (UE8M0) or other dtypes — those
+// must be rejected at promote time so the slow dequant→cuBLAS fallback runs
+// instead of silently producing wrong output through the FP8 decoder.
+bool nvfp4_validate_weight_scale_dtype(QType qt, std::string* err);
 
 }  // namespace imp

--- a/src/quant/nvfp4_quant.h
+++ b/src/quant/nvfp4_quant.h
@@ -75,4 +75,24 @@ void dequantize_nvfp4_moe_to_fp16(const NvFP4MoEQuantResult& result, void* outpu
 // Free NvFP4MoEQuantResult device memory.
 void free_nvfp4_moe_result(NvFP4MoEQuantResult& result);
 
+// ---------------------------------------------------------------------------
+// Defensive promotion of weight_scale_2 into the GEMM-internal tensor_scale.
+//
+// Modelopt:        val = fp4 * micro_scale * weight_scale_2  (multiply)
+// llm-compressor:  val = fp4 * micro_scale / weight_scale_2  (divide → store 1/x)
+//
+// A weight_scale_2 of 0, NaN, or ±Inf would produce non-finite GEMM output and
+// contaminate the entire layer's hidden state. This helper folds in defensive
+// zeroing for both formats:
+//   - non-finite h_scale         → 0.0f
+//   - llm-compressor h_scale=0   → 0.0f (1/0 would be Inf)
+//   - llm-compressor 1/h_scale non-finite → 0.0f
+//   - Modelopt h_scale=0         → 0.0f (intentionally null layer)
+//
+// `*was_zeroed` is set true when defensive zeroing fired (used for diagnostic
+// counters at end of load).
+//
+// Pure host function — testable without CUDA. Defined in nvfp4_quant.cu.
+float nvfp4_promote_weight_scale_2(float h_scale, bool is_llm_compressor, bool* was_zeroed);
+
 }  // namespace imp

--- a/tests/test_nvfp4_compressed_tensors_ref.cu
+++ b/tests/test_nvfp4_compressed_tensors_ref.cu
@@ -482,5 +482,53 @@ TEST(NvFP4ValidateWeightScaleDtype, RejectsNone) {
     EXPECT_FALSE(err.empty());
 }
 
+// ---- F6: weight_packed vs weight_scale shape validation ----
+
+TEST(NvFP4ValidatePackedScaleShapes, AcceptsTypicalQwen3) {
+    // Qwen3-MoE q_proj: logical [4096, 2048]. Packed = [4096, 1024].
+    // weight_scale = [4096, 128] (2048/16).
+    std::string err;
+    EXPECT_TRUE(nvfp4_validate_packed_scale_shapes(4096, 1024, 4096, 128, &err)) << err;
+}
+
+TEST(NvFP4ValidatePackedScaleShapes, AcceptsSmallGemma4Expert) {
+    // Gemma-4 expert dim: 256 rows × packed-K 1408 → scale [256, 176].
+    std::string err;
+    EXPECT_TRUE(nvfp4_validate_packed_scale_shapes(256, 1408, 256, 176, &err)) << err;
+}
+
+TEST(NvFP4ValidatePackedScaleShapes, RejectsOuterDimMismatch) {
+    // Transposed weight_scale would put N as inner dim and K as outer.
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_packed_scale_shapes(4096, 1024, 1024, 4096, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(NvFP4ValidatePackedScaleShapes, RejectsGroupSize8) {
+    // group_size=8: scale would be [N, K/8] = [4096, 256]. Not the spec.
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_packed_scale_shapes(4096, 1024, 4096, 256, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(NvFP4ValidatePackedScaleShapes, RejectsGroupSize32) {
+    // group_size=32: scale = [N, K/32] = [4096, 64].
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_packed_scale_shapes(4096, 1024, 4096, 64, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(NvFP4ValidatePackedScaleShapes, RejectsZeroScaleInner) {
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_packed_scale_shapes(4096, 1024, 4096, 0, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(NvFP4ValidatePackedScaleShapes, AcceptsTinyTestShape) {
+    // [16, 64] packed inner with [16, 8] scale inner — used by the F1 baseline test.
+    std::string err;
+    EXPECT_TRUE(nvfp4_validate_packed_scale_shapes(16, 64, 16, 8, &err)) << err;
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_nvfp4_compressed_tensors_ref.cu
+++ b/tests/test_nvfp4_compressed_tensors_ref.cu
@@ -29,6 +29,7 @@
 #include <cuda_fp16.h>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 namespace imp {
@@ -366,6 +367,78 @@ TEST_F(NvFP4CompressedTensorsRef, NegativeWeightsSignPreserved) {
         EXPECT_NEAR(v, expected, 1e-2f) << "Row " << n << " expected " << expected << " got " << v
                                         << " — sign bit dropped in nibble decode?";
     }
+}
+
+// Test 5 (F2): Modelopt path defensively zeros NaN/+Inf weight_scale_2.
+TEST(NvFP4PromoteWeightScale2, ModeloptNaNZeroes) {
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(std::nanf(""), /*is_llm_compressor=*/false, &zeroed);
+    EXPECT_EQ(r, 0.0f);
+    EXPECT_TRUE(zeroed);
+    EXPECT_FALSE(std::isnan(r));
+}
+
+TEST(NvFP4PromoteWeightScale2, ModeloptPlusInfZeroes) {
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(std::numeric_limits<float>::infinity(),
+                                           /*is_llm_compressor=*/false, &zeroed);
+    EXPECT_EQ(r, 0.0f);
+    EXPECT_TRUE(zeroed);
+}
+
+TEST(NvFP4PromoteWeightScale2, ModeloptNegInfZeroes) {
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(-std::numeric_limits<float>::infinity(),
+                                           /*is_llm_compressor=*/false, &zeroed);
+    EXPECT_EQ(r, 0.0f);
+    EXPECT_TRUE(zeroed);
+}
+
+TEST(NvFP4PromoteWeightScale2, ModeloptZeroIsZeroFlagged) {
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(0.0f, /*is_llm_compressor=*/false, &zeroed);
+    EXPECT_EQ(r, 0.0f);
+    EXPECT_TRUE(zeroed);  // Modelopt zero is a legitimate "null layer" but we still flag for diagnostic
+}
+
+TEST(NvFP4PromoteWeightScale2, ModeloptFinitePassesThrough) {
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(0.125f, /*is_llm_compressor=*/false, &zeroed);
+    EXPECT_FLOAT_EQ(r, 0.125f);
+    EXPECT_FALSE(zeroed);
+}
+
+TEST(NvFP4PromoteWeightScale2, LlmCompressorNaNZeroes) {
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(std::nanf(""), /*is_llm_compressor=*/true, &zeroed);
+    EXPECT_EQ(r, 0.0f);
+    EXPECT_TRUE(zeroed);
+}
+
+TEST(NvFP4PromoteWeightScale2, LlmCompressorZeroNoInf) {
+    // The bug PR #113 first guarded: 1/0 = +Inf without the defensive zeroing.
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(0.0f, /*is_llm_compressor=*/true, &zeroed);
+    EXPECT_EQ(r, 0.0f);
+    EXPECT_FALSE(std::isinf(r));
+    EXPECT_TRUE(zeroed);
+}
+
+TEST(NvFP4PromoteWeightScale2, LlmCompressorTinyNonFiniteFlip) {
+    // Subnormal where 1/x overflows to +Inf — must be defensively zeroed.
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(std::numeric_limits<float>::denorm_min(),
+                                           /*is_llm_compressor=*/true, &zeroed);
+    EXPECT_EQ(r, 0.0f);
+    EXPECT_FALSE(std::isinf(r));
+    EXPECT_TRUE(zeroed);
+}
+
+TEST(NvFP4PromoteWeightScale2, LlmCompressorFiniteFlipsCorrectly) {
+    bool zeroed = false;
+    float r = nvfp4_promote_weight_scale_2(8.0f, /*is_llm_compressor=*/true, &zeroed);
+    EXPECT_FLOAT_EQ(r, 0.125f);
+    EXPECT_FALSE(zeroed);
 }
 
 }  // namespace

--- a/tests/test_nvfp4_compressed_tensors_ref.cu
+++ b/tests/test_nvfp4_compressed_tensors_ref.cu
@@ -441,5 +441,46 @@ TEST(NvFP4PromoteWeightScale2, LlmCompressorFiniteFlipsCorrectly) {
     EXPECT_FALSE(zeroed);
 }
 
+// ---- F8: weight_scale dtype validation ----
+
+TEST(NvFP4ValidateWeightScaleDtype, AcceptsFp8E4m3) {
+    std::string err;
+    EXPECT_TRUE(nvfp4_validate_weight_scale_dtype(QType::FP8_E4M3, &err)) << err;
+    EXPECT_TRUE(err.empty());
+}
+
+TEST(NvFP4ValidateWeightScaleDtype, RejectsUInt8MxFP4Crossroute) {
+    // INT8 maps from the wire 'U8' / 'I8' string that MXFP4 / GPTQ ship
+    // weight_scale (UE8M0 power-of-two) bytes in. Cross-misrouting would
+    // happen if the loader/promote step misclassifies an MXFP4 model as
+    // NVFP4 — the weight_scale bytes would be UE8M0 but read as E4M3.
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_weight_scale_dtype(QType::INT8, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(NvFP4ValidateWeightScaleDtype, RejectsFp8E5m2) {
+    // E5M2 is range-extended FP8 used for activations, never weight scales
+    // in the compressed-tensors spec. Reject defensively.
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_weight_scale_dtype(QType::FP8_E5M2, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(NvFP4ValidateWeightScaleDtype, RejectsF16) {
+    // Some pipelines emit weight_scale as FP16 directly — that's not the
+    // compressed-tensors spec.
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_weight_scale_dtype(QType::F16, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(NvFP4ValidateWeightScaleDtype, RejectsNone) {
+    // Sentinel "no qtype set" must never accidentally pass.
+    std::string err;
+    EXPECT_FALSE(nvfp4_validate_weight_scale_dtype(QType::NONE, &err));
+    EXPECT_FALSE(err.empty());
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_nvfp4_compressed_tensors_ref.cu
+++ b/tests/test_nvfp4_compressed_tensors_ref.cu
@@ -1,0 +1,372 @@
+// Reference numerical test for compressed-tensors NVFP4 dequant.
+//
+// Closes audit finding F1 from docs/audit/safetensors_nvfp4_audit_2026-05.md.
+// Existing NVFP4 unit tests (test_nvfp4_quant_ref.cu, test_nvfp4_quant_hw.cu,
+// test_nvfp4_gemv_kpar_loop.cu) all roundtrip imp's own quantizer through
+// imp's own dequantizer. They cannot detect a paired sign-flip / nibble-order
+// bug, nor a missing factor (e.g. dropping weight_scale_2), since both sides
+// of the roundtrip would deviate together.
+//
+// This test starts from the on-disk format directly:
+//   - weight_packed: uint8 nibble-packed E2M1 (low nibble = even k, high = odd k)
+//   - weight_scale:  float8_e4m3fn, [N, K/16] one FP8 byte per 16-element micro-block
+//   - weight_scale_2: FP32 scalar (per-tensor)
+//
+// and asserts that imp's gemv_nvfp4_kpar produces the same Y = W·X as a pure-host
+// reference dequant computing val = e2m1_to_f32(nibble) * fp8_e4m3_to_f32(scale)
+// * weight_scale_2 element-wise.
+//
+// Tolerance: max-abs-diff < 1e-2 in FP16 output. FMA-order divergence between
+// the sequential reference and imp's parallel-warp accumulator dominates;
+// 1e-5 is unrealistic for K=128 FP16 dot-product reductions. Smaller than 1e-2
+// would catch bit-exact bugs only for representable values.
+
+#include "quant/nvfp4_quant.h"
+#include "quant/nvfp4_gemm.h"
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// Pure-host reference E2M1 -> FP32 decode following the OCP NVFP4 spec.
+// Magnitude set: {0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0}.
+// Bit layout: bit3=sign, bits2:0=magnitude index.
+float e2m1_nibble_to_f32_ref(uint8_t nibble) {
+    static const float magnitudes[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+    float mag = magnitudes[nibble & 0x07];
+    return (nibble & 0x08) ? -mag : mag;
+}
+
+// Pure-host reference FP8 E4M3-fn -> FP32 decode mirroring the device's
+// fp8_e4m3_to_float_fast (in src/quant/fp8_utils.cuh). Independently
+// derived from the spec to avoid the bug-amplifying mistake of testing
+// the device kernel against a rephrased copy of itself.
+float fp8_e4m3_to_f32_ref(uint8_t bits) {
+    uint32_t sign = (bits >> 7) & 1;
+    uint32_t exp = (bits >> 3) & 0x0F;
+    uint32_t man = bits & 0x07;
+    float magnitude;
+    if (exp == 0) {
+        magnitude = static_cast<float>(man) / 512.0f;
+    } else {
+        // (1 + m/8) * 2^(exp-7), bias=7
+        magnitude = (1.0f + static_cast<float>(man) / 8.0f) * std::ldexp(1.0f, static_cast<int>(exp) - 7);
+    }
+    return sign ? -magnitude : magnitude;
+}
+
+// Encode an FP32 in [0, 448] into FP8 E4M3 bits. Test-only — bit-exact for
+// values that ARE in the FP8 E4M3 representable set; near-misses round to
+// the nearest FP8. Used only to construct test fixtures with known scales.
+uint8_t f32_to_fp8_e4m3_bits(float val) {
+    uint32_t sign = (val < 0.0f) ? 1u : 0u;
+    float abs_val = std::fabs(val);
+    if (abs_val == 0.0f)
+        return static_cast<uint8_t>(sign << 7);
+    if (abs_val < 1.0f / 512.0f)
+        return static_cast<uint8_t>(sign << 7);  // round to ±0
+    int exp;
+    float m = std::frexp(abs_val, &exp);  // m in [0.5, 1)
+    // Want (1 + man/8) * 2^(e-7) ≈ abs_val, where exp_field = e (in [1,15]).
+    int exp_field = exp - 1 + 7;  // because frexp yields m*2^e, m in [.5,1) → 2^(e-1) is the leading bit
+    if (exp_field <= 0)
+        exp_field = 0;
+    if (exp_field > 15)
+        exp_field = 15;
+    float scaled = abs_val / std::ldexp(1.0f, exp_field - 7);
+    int man = static_cast<int>(std::round((scaled - 1.0f) * 8.0f));
+    if (man < 0)
+        man = 0;
+    if (man > 7)
+        man = 7;
+    if (exp_field == 15 && man == 7)
+        man = 6;  // saturate NaN slot to max normal
+    return static_cast<uint8_t>((sign << 7) | ((exp_field & 0x0F) << 3) | (man & 0x07));
+}
+
+class NvFP4CompressedTensorsRef : public ::testing::Test {
+protected:
+    void SetUp() override { ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess); }
+    void TearDown() override { cudaStreamDestroy(stream_); }
+    cudaStream_t stream_ = nullptr;
+};
+
+// Test 1: Mixed-magnitude weights, FP8 scale = 1.0 (bits 0x38), tensor_scale = 1.0.
+// All factors at unity: any spec-deviation in nibble decode or alignment is exposed.
+TEST_F(NvFP4CompressedTensorsRef, BaselineUnityScales) {
+    constexpr int N = 64;
+    constexpr int K = 128;
+    static_assert(K % 16 == 0, "K must be multiple of group_size=16");
+
+    const int n_mb = K / 16;
+
+    // Build weight_packed deterministically: 2 nibbles per byte, low=even k, high=odd k.
+    std::vector<uint8_t> h_packed(N * K / 2);
+    for (int n = 0; n < N; ++n) {
+        for (int kb = 0; kb < K / 2; ++kb) {
+            uint8_t nib_low = static_cast<uint8_t>(((n + 2 * kb) * 5u) & 0x0F);
+            uint8_t nib_high = static_cast<uint8_t>(((n + 2 * kb + 1) * 5u) & 0x0F);
+            h_packed[n * (K / 2) + kb] = static_cast<uint8_t>((nib_high << 4) | nib_low);
+        }
+    }
+
+    // weight_scale = all 1.0f (FP8 E4M3 bits = 0x38 = exp=7, man=0).
+    constexpr uint8_t kFp8Bits_one = 0x38;
+    std::vector<uint8_t> h_scale_e4m3(N * n_mb, kFp8Bits_one);
+    ASSERT_NEAR(fp8_e4m3_to_f32_ref(kFp8Bits_one), 1.0f, 0.0f);
+
+    const float tensor_scale = 1.0f;
+
+    // Activation X: linspace [-1, 1] over K.
+    std::vector<half> h_x(K);
+    for (int k = 0; k < K; ++k)
+        h_x[k] = __float2half(-1.0f + 2.0f * k / static_cast<float>(K - 1));
+
+    // ---- Pure-host reference Y[n] = sum_k W[n,k] * X[k] ----
+    std::vector<float> y_ref_f32(N, 0.0f);
+    for (int n = 0; n < N; ++n) {
+        for (int k = 0; k < K; ++k) {
+            int kb = k / 2;
+            uint8_t byte = h_packed[n * (K / 2) + kb];
+            uint8_t nibble = (k & 1) ? ((byte >> 4) & 0x0F) : (byte & 0x0F);
+            float w = e2m1_nibble_to_f32_ref(nibble);
+            float scale_e4m3 = fp8_e4m3_to_f32_ref(h_scale_e4m3[n * n_mb + (k / 16)]);
+            float x = __half2float(h_x[k]);
+            y_ref_f32[n] += w * scale_e4m3 * tensor_scale * x;
+        }
+    }
+
+    // ---- imp path via gemv_nvfp4_kpar ----
+    void *d_packed = nullptr, *d_scale = nullptr, *d_x = nullptr, *d_y = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_packed, h_packed.size()), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_scale, h_scale_e4m3.size()), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_x, K * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_y, N * sizeof(half)), cudaSuccess);
+    cudaMemcpy(d_packed, h_packed.data(), h_packed.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_scale, h_scale_e4m3.data(), h_scale_e4m3.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, h_x.data(), K * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_y, 0, N * sizeof(half));
+
+    NvFP4QuantResult A;
+    A.packed_data = d_packed;
+    A.micro_scales = d_scale;
+    A.tensor_scale = tensor_scale;
+    A.N = N;
+    A.K = K;
+
+    gemv_nvfp4_kpar(A, reinterpret_cast<const half*>(d_x), reinterpret_cast<half*>(d_y), N, K, stream_);
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    std::vector<half> h_y(N);
+    cudaMemcpy(h_y.data(), d_y, N * sizeof(half), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_packed);
+    cudaFree(d_scale);
+    cudaFree(d_x);
+    cudaFree(d_y);
+
+    // Compare: max-abs-diff should be < 1e-2 (FP16 FMA-order noise dominates).
+    float max_abs_diff = 0.0f;
+    int worst_idx = -1;
+    for (int n = 0; n < N; ++n) {
+        float imp_v = __half2float(h_y[n]);
+        float diff = std::fabs(imp_v - y_ref_f32[n]);
+        if (diff > max_abs_diff) {
+            max_abs_diff = diff;
+            worst_idx = n;
+        }
+    }
+    EXPECT_LT(max_abs_diff, 1e-2f) << "Compressed-tensors NVFP4 GEMV diverges from spec reference. "
+                                   << "Worst row n=" << worst_idx
+                                   << " imp=" << __half2float(h_y[worst_idx])
+                                   << " ref=" << y_ref_f32[worst_idx]
+                                   << " (max_abs_diff=" << max_abs_diff << ").";
+}
+
+// Test 2: Per-block scales vary (FP8 != 1.0) and tensor_scale != 1.0.
+// Stresses two-level scaling: a sign-flipped or missing factor would break.
+TEST_F(NvFP4CompressedTensorsRef, TwoLevelScalingVaryingPerBlock) {
+    constexpr int N = 32;
+    constexpr int K = 128;
+    const int n_mb = K / 16;
+
+    std::vector<uint8_t> h_packed(N * K / 2);
+    for (size_t i = 0; i < h_packed.size(); ++i)
+        h_packed[i] = static_cast<uint8_t>((i * 11u + 3u) & 0xFF);
+
+    // Per-block scales cycle through {0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 0.25}.
+    static const float scale_values[8] = {0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f, 0.25f};
+    std::vector<uint8_t> h_scale_e4m3(N * n_mb);
+    for (size_t i = 0; i < h_scale_e4m3.size(); ++i)
+        h_scale_e4m3[i] = f32_to_fp8_e4m3_bits(scale_values[i % 8]);
+
+    const float tensor_scale = 0.125f;  // Non-trivial multiplier — cannot be silently dropped.
+
+    std::vector<half> h_x(K);
+    for (int k = 0; k < K; ++k)
+        h_x[k] = __float2half(0.5f * std::sin(0.1f * k));
+
+    std::vector<float> y_ref_f32(N, 0.0f);
+    for (int n = 0; n < N; ++n) {
+        for (int k = 0; k < K; ++k) {
+            uint8_t byte = h_packed[n * (K / 2) + (k / 2)];
+            uint8_t nibble = (k & 1) ? ((byte >> 4) & 0x0F) : (byte & 0x0F);
+            float w = e2m1_nibble_to_f32_ref(nibble);
+            float scale_e4m3 = fp8_e4m3_to_f32_ref(h_scale_e4m3[n * n_mb + (k / 16)]);
+            float x = __half2float(h_x[k]);
+            y_ref_f32[n] += w * scale_e4m3 * tensor_scale * x;
+        }
+    }
+
+    void *d_packed = nullptr, *d_scale = nullptr, *d_x = nullptr, *d_y = nullptr;
+    cudaMalloc(&d_packed, h_packed.size());
+    cudaMalloc(&d_scale, h_scale_e4m3.size());
+    cudaMalloc(&d_x, K * sizeof(half));
+    cudaMalloc(&d_y, N * sizeof(half));
+    cudaMemcpy(d_packed, h_packed.data(), h_packed.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_scale, h_scale_e4m3.data(), h_scale_e4m3.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, h_x.data(), K * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_y, 0, N * sizeof(half));
+
+    NvFP4QuantResult A;
+    A.packed_data = d_packed;
+    A.micro_scales = d_scale;
+    A.tensor_scale = tensor_scale;
+    A.N = N;
+    A.K = K;
+
+    gemv_nvfp4_kpar(A, reinterpret_cast<const half*>(d_x), reinterpret_cast<half*>(d_y), N, K, stream_);
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_y(N);
+    cudaMemcpy(h_y.data(), d_y, N * sizeof(half), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_packed);
+    cudaFree(d_scale);
+    cudaFree(d_x);
+    cudaFree(d_y);
+
+    float max_abs_diff = 0.0f;
+    for (int n = 0; n < N; ++n) {
+        float diff = std::fabs(__half2float(h_y[n]) - y_ref_f32[n]);
+        if (diff > max_abs_diff)
+            max_abs_diff = diff;
+    }
+    EXPECT_LT(max_abs_diff, 1e-2f);
+}
+
+// Test 3: Zero tensor_scale → output must be exactly zero (defensive zeroing
+// as PR #113 / new F2 fix). Validates that promoted_scale=0 actually produces
+// 0 GEMV output, not NaN/Inf, regardless of garbage in weight_packed.
+TEST_F(NvFP4CompressedTensorsRef, ZeroTensorScaleProducesZeroOutput) {
+    constexpr int N = 16;
+    constexpr int K = 64;
+    const int n_mb = K / 16;
+
+    std::vector<uint8_t> h_packed(N * K / 2);
+    for (size_t i = 0; i < h_packed.size(); ++i)
+        h_packed[i] = 0xFF;  // every nibble = -6.0 (max negative magnitude)
+
+    std::vector<uint8_t> h_scale_e4m3(N * n_mb, f32_to_fp8_e4m3_bits(64.0f));  // big scale
+    const float tensor_scale = 0.0f;  // zeroes everything
+
+    std::vector<half> h_x(K, __float2half(1.0f));
+
+    void *d_packed = nullptr, *d_scale = nullptr, *d_x = nullptr, *d_y = nullptr;
+    cudaMalloc(&d_packed, h_packed.size());
+    cudaMalloc(&d_scale, h_scale_e4m3.size());
+    cudaMalloc(&d_x, K * sizeof(half));
+    cudaMalloc(&d_y, N * sizeof(half));
+    cudaMemcpy(d_packed, h_packed.data(), h_packed.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_scale, h_scale_e4m3.data(), h_scale_e4m3.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, h_x.data(), K * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_y, 0, N * sizeof(half));
+
+    NvFP4QuantResult A;
+    A.packed_data = d_packed;
+    A.micro_scales = d_scale;
+    A.tensor_scale = tensor_scale;
+    A.N = N;
+    A.K = K;
+
+    gemv_nvfp4_kpar(A, reinterpret_cast<const half*>(d_x), reinterpret_cast<half*>(d_y), N, K, stream_);
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_y(N);
+    cudaMemcpy(h_y.data(), d_y, N * sizeof(half), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_packed);
+    cudaFree(d_scale);
+    cudaFree(d_x);
+    cudaFree(d_y);
+
+    for (int n = 0; n < N; ++n) {
+        float v = __half2float(h_y[n]);
+        EXPECT_EQ(v, 0.0f) << "Row " << n << " has non-zero output " << v
+                           << " despite tensor_scale=0; layer-zero defensive path is broken.";
+        EXPECT_FALSE(std::isnan(v)) << "Row " << n << " is NaN under tensor_scale=0.";
+        EXPECT_FALSE(std::isinf(v)) << "Row " << n << " is Inf under tensor_scale=0.";
+    }
+}
+
+// Test 4: Negative weights → output sign is correct.
+// Catches a sign-bit drop in the nibble decode path (which the HW PTX cvt
+// instruction handles, but a future SW fallback must too).
+TEST_F(NvFP4CompressedTensorsRef, NegativeWeightsSignPreserved) {
+    constexpr int N = 8;
+    constexpr int K = 32;
+    const int n_mb = K / 16;
+
+    // Every nibble = 0x0A → sign=1, magnitude index=2 → -1.0
+    std::vector<uint8_t> h_packed(N * K / 2, 0xAA);
+
+    std::vector<uint8_t> h_scale_e4m3(N * n_mb, f32_to_fp8_e4m3_bits(1.0f));
+    const float tensor_scale = 1.0f;
+
+    std::vector<half> h_x(K, __float2half(1.0f));
+
+    void *d_packed = nullptr, *d_scale = nullptr, *d_x = nullptr, *d_y = nullptr;
+    cudaMalloc(&d_packed, h_packed.size());
+    cudaMalloc(&d_scale, h_scale_e4m3.size());
+    cudaMalloc(&d_x, K * sizeof(half));
+    cudaMalloc(&d_y, N * sizeof(half));
+    cudaMemcpy(d_packed, h_packed.data(), h_packed.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_scale, h_scale_e4m3.data(), h_scale_e4m3.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, h_x.data(), K * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_y, 0, N * sizeof(half));
+
+    NvFP4QuantResult A;
+    A.packed_data = d_packed;
+    A.micro_scales = d_scale;
+    A.tensor_scale = tensor_scale;
+    A.N = N;
+    A.K = K;
+
+    gemv_nvfp4_kpar(A, reinterpret_cast<const half*>(d_x), reinterpret_cast<half*>(d_y), N, K, stream_);
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_y(N);
+    cudaMemcpy(h_y.data(), d_y, N * sizeof(half), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_packed);
+    cudaFree(d_scale);
+    cudaFree(d_x);
+    cudaFree(d_y);
+
+    // Each row: K=32 elements × -1.0 × 1.0 × 1.0 = -32.
+    const float expected = -static_cast<float>(K);
+    for (int n = 0; n < N; ++n) {
+        float v = __half2float(h_y[n]);
+        EXPECT_NEAR(v, expected, 1e-2f) << "Row " << n << " expected " << expected << " got " << v
+                                        << " — sign bit dropped in nibble decode?";
+    }
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_safetensors_loader.cpp
+++ b/tests/test_safetensors_loader.cpp
@@ -1,0 +1,86 @@
+// Unit tests for the SafeTensors loader's blob-level validation surface.
+// Exercises the test-visible helpers in safetensors_internal:: directly with
+// synthetic blob bytes — no Model construction, no GPU.
+//
+// Closes audit findings F3, F4, F5, F7, F8 from
+// docs/audit/safetensors_nvfp4_audit_2026-05.md.
+
+#include "model/safetensors_loader.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace imp {
+namespace {
+
+// ---- F3: header_size validation ----
+
+TEST(SafeTensorsValidateHeaderSize, RejectsFileTruncatedBelow8) {
+    std::string err;
+    EXPECT_FALSE(safetensors_internal::validate_header_size(0, 0, &err));
+    EXPECT_FALSE(err.empty());
+    err.clear();
+    EXPECT_FALSE(safetensors_internal::validate_header_size(7, 0, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(SafeTensorsValidateHeaderSize, AcceptsExactMinimum) {
+    std::string err;
+    // 8-byte file with declared header_size=0: legal but empty header.
+    EXPECT_TRUE(safetensors_internal::validate_header_size(8, 0, &err)) << err;
+}
+
+TEST(SafeTensorsValidateHeaderSize, AcceptsTypicalSize) {
+    std::string err;
+    // file_size = 1 MiB, header_size = 64 KiB. Plenty of room for tensor data.
+    EXPECT_TRUE(safetensors_internal::validate_header_size(1u << 20, 64 * 1024, &err)) << err;
+}
+
+TEST(SafeTensorsValidateHeaderSize, RejectsHeaderExceedingFile) {
+    std::string err;
+    // file_size = 1 KiB but declared header_size = 1 KiB → leaves no room for
+    // the 8-byte prefix and would overflow the JSON parser bounds.
+    EXPECT_FALSE(safetensors_internal::validate_header_size(1024, 1024, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(SafeTensorsValidateHeaderSize, RejectsUInt64MaxOverflowAttack) {
+    // The bug fixed: prior code computed `8 + header_size > file_size`. With
+    // header_size = UINT64_MAX-4 the addition wrapped to 3, which is NOT
+    // greater than any legitimate file size — the check silently bypassed.
+    // The new overflow-safe check rejects this.
+    std::string err;
+    EXPECT_FALSE(safetensors_internal::validate_header_size(
+        16, std::numeric_limits<uint64_t>::max(), &err));
+    EXPECT_FALSE(err.empty()) << "validator should produce a reason string";
+
+    err.clear();
+    EXPECT_FALSE(safetensors_internal::validate_header_size(
+        16, std::numeric_limits<uint64_t>::max() - 4, &err));
+    EXPECT_FALSE(err.empty());
+
+    err.clear();
+    EXPECT_FALSE(safetensors_internal::validate_header_size(
+        16, std::numeric_limits<uint64_t>::max() - 7, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(SafeTensorsValidateHeaderSize, RejectsAboveSoftCap) {
+    // Soft cap is 128 MiB per ADR 0002. Any larger declared header is rejected
+    // even when the file claims to be that big.
+    constexpr uint64_t k129MiB = 129ULL * 1024ULL * 1024ULL;
+    std::string err;
+    EXPECT_FALSE(safetensors_internal::validate_header_size(
+        k129MiB + 8, k129MiB, &err));
+    EXPECT_FALSE(err.empty());
+
+    // 128 MiB exactly is within the cap.
+    constexpr uint64_t k128MiB = 128ULL * 1024ULL * 1024ULL;
+    err.clear();
+    EXPECT_TRUE(safetensors_internal::validate_header_size(k128MiB + 8, k128MiB, &err)) << err;
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_safetensors_loader.cpp
+++ b/tests/test_safetensors_loader.cpp
@@ -82,5 +82,57 @@ TEST(SafeTensorsValidateHeaderSize, RejectsAboveSoftCap) {
     EXPECT_TRUE(safetensors_internal::validate_header_size(k128MiB + 8, k128MiB, &err)) << err;
 }
 
+// ---- F4: per-tensor offset validation ----
+
+TEST(SafeTensorsValidateTensorOffsets, AcceptsTypicalValid) {
+    // file_size = 1 KiB, tensor_data_offset = 256 (header occupies first 256 B),
+    // tensor at [0, 64) inside data block — i.e. 32 FP16 elements.
+    std::string err;
+    EXPECT_TRUE(safetensors_internal::validate_tensor_offsets(
+        /*start=*/0, /*end=*/64, /*expected=*/64, /*tdo=*/256, /*file=*/1024, &err))
+        << err;
+}
+
+TEST(SafeTensorsValidateTensorOffsets, RejectsStartAfterEnd) {
+    std::string err;
+    EXPECT_FALSE(safetensors_internal::validate_tensor_offsets(100, 64, 64, 256, 1024, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(SafeTensorsValidateTensorOffsets, RejectsEndPastFile) {
+    std::string err;
+    // file_size = 1024, tdo = 256 → max offset_end is 768. Setting end=1024
+    // would put real bytes at file offset 1280 — past EOF.
+    EXPECT_FALSE(safetensors_internal::validate_tensor_offsets(0, 1024, 1024, 256, 1024, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(SafeTensorsValidateTensorOffsets, RejectsByteCountMismatch) {
+    // 32 FP16 elements declared but only 32 bytes (= 16 FP16) of data on disk.
+    std::string err;
+    EXPECT_FALSE(safetensors_internal::validate_tensor_offsets(0, 32, 64, 256, 1024, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(SafeTensorsValidateTensorOffsets, ZeroSizeTensorIsValid) {
+    // Some checkpoints emit metadata-only entries with size 0.
+    std::string err;
+    EXPECT_TRUE(safetensors_internal::validate_tensor_offsets(0, 0, 0, 256, 1024, &err)) << err;
+}
+
+TEST(SafeTensorsValidateTensorOffsets, RejectsHeaderSizeInvariantViolation) {
+    // tdo > file_size should never reach this validator (header_size check
+    // upstream prevents it), but defend in depth.
+    std::string err;
+    EXPECT_FALSE(safetensors_internal::validate_tensor_offsets(0, 64, 64, /*tdo=*/2000, /*file=*/1024, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(SafeTensorsValidateTensorOffsets, EndExactlyAtFileBoundary) {
+    // tdo = 8, file_size = 1024 → max usable end is 1016. Exactly that should pass.
+    std::string err;
+    EXPECT_TRUE(safetensors_internal::validate_tensor_offsets(0, 1016, 1016, 8, 1024, &err)) << err;
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_safetensors_loader.cpp
+++ b/tests/test_safetensors_loader.cpp
@@ -9,11 +9,44 @@
 
 #include <gtest/gtest.h>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
 #include <limits>
 #include <string>
+#include <vector>
 
 namespace imp {
 namespace {
+
+// Helper: write a synthetic single-shard SafeTensors blob to a temp file.
+// header_json is the inner JSON header text; tensor_payload_size is how
+// much trailing tensor data to allocate (zeroed).
+std::string write_temp_blob(const std::string& header_json, size_t tensor_payload_size) {
+    char tmpl[] = "/tmp/imp_test_st_XXXXXX";
+    int fd = ::mkstemp(tmpl);
+    if (fd < 0)
+        return "";
+    std::string path = tmpl;
+    // Add ".safetensors" suffix so load_safetensors path-detection works.
+    std::string final_path = path + ".safetensors";
+    ::close(fd);
+    ::rename(path.c_str(), final_path.c_str());
+
+    std::ofstream out(final_path, std::ios::binary);
+    if (!out)
+        return "";
+    uint64_t hsize = static_cast<uint64_t>(header_json.size());
+    out.write(reinterpret_cast<const char*>(&hsize), sizeof(hsize));
+    out.write(header_json.data(), header_json.size());
+    if (tensor_payload_size > 0) {
+        std::vector<char> zeros(tensor_payload_size, 0);
+        out.write(zeros.data(), zeros.size());
+    }
+    out.close();
+    return final_path;
+}
 
 // ---- F3: header_size validation ----
 
@@ -132,6 +165,54 @@ TEST(SafeTensorsValidateTensorOffsets, EndExactlyAtFileBoundary) {
     // tdo = 8, file_size = 1024 → max usable end is 1016. Exactly that should pass.
     std::string err;
     EXPECT_TRUE(safetensors_internal::validate_tensor_offsets(0, 1016, 1016, 8, 1024, &err)) << err;
+}
+
+// ---- F5: malformed-tensor-entry warnings ----
+
+// Loads a synthetic blob with one tensor missing 'dtype' and one with malformed
+// 'shape'. load_safetensors returns nullptr (no config.json → cannot build a
+// Model) but the per-shard load must drop both bad tensors with a WARN naming
+// each, AND log an end-of-shard summary. We capture stderr and check.
+TEST(SafeTensorsMalformedEntryWarnings, MissingDtypeAndShapeWarn) {
+    // Two malformed tensors; offsets are valid in case they get past the dtype/shape checks.
+    const std::string header =
+        "{\"bad_no_dtype\": {\"shape\": [4], \"data_offsets\": [0, 16]},"
+        " \"bad_no_shape\": {\"dtype\": \"F32\", \"data_offsets\": [0, 16]}}";
+    std::string path = write_temp_blob(header, 16);
+    ASSERT_FALSE(path.empty());
+
+    testing::internal::CaptureStderr();
+    auto model = load_safetensors(path);
+    std::string captured = testing::internal::GetCapturedStderr();
+    std::remove(path.c_str());
+
+    // Model build fails (no config.json) — but the per-shard scan must have run
+    // and emitted the WARN lines.
+    EXPECT_EQ(model.get(), nullptr);
+    EXPECT_NE(captured.find("bad_no_dtype"), std::string::npos)
+        << "Expected WARN naming the dtype-less tensor. Captured: " << captured;
+    EXPECT_NE(captured.find("bad_no_shape"), std::string::npos)
+        << "Expected WARN naming the shape-less tensor. Captured: " << captured;
+    EXPECT_NE(captured.find("dropped"), std::string::npos)
+        << "Expected end-of-shard summary line. Captured: " << captured;
+}
+
+TEST(SafeTensorsMalformedEntryWarnings, OffsetByteCountMismatchWarns) {
+    // 4 FP32 elements declared, but only 8 bytes of tensor data (= 2 FP32).
+    const std::string header =
+        "{\"size_mismatch\": {\"dtype\": \"F32\", \"shape\": [4], \"data_offsets\": [0, 8]}}";
+    std::string path = write_temp_blob(header, 16);
+    ASSERT_FALSE(path.empty());
+
+    testing::internal::CaptureStderr();
+    auto model = load_safetensors(path);
+    std::string captured = testing::internal::GetCapturedStderr();
+    std::remove(path.c_str());
+
+    EXPECT_EQ(model.get(), nullptr);
+    EXPECT_NE(captured.find("size_mismatch"), std::string::npos) << captured;
+    // The WARN includes the validate_tensor_offsets reason text.
+    EXPECT_NE(captured.find("byte count"), std::string::npos) << captured;
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Closes 8 silent-correctness findings in the SafeTensors loader and NVFP4 dequant path that survived Phase 2 (PR #116). Each fix is gated by a numerical or behavioural unit test; **40 new tests across 7 fixtures**, full suite **769/769** with 0 failures, `verify-fast` smoke OK.

## Findings closed

| ID | Severity | Title | Closing commit |
|----|----------|-------|----------------|
| F1 | P0 | NVFP4 compressed-tensors reference numerical test | `168f847` |
| F2 | P1 | Modelopt NVFP4 `weight_scale_2` isfinite guard | `bb8c54c` |
| F3 | P1 | Header-size validation overflow (`UINT64_MAX`-4 wrap bypass) | `5d9b28f` |
| F4 | P1 | Per-tensor offset/size validation (start>end, OOB, byte-count) | `6ede041` |
| F5 | P2 | Malformed-tensor-entry WARN + per-shard summary | `369a806` |
| F6 | P2 | NVFP4 `weight_packed`/`weight_scale` shape pair check | `4d9b640` |
| F7 | P2 | Header-size 128 MiB soft cap | `5d9b28f` (combined w/ F3) |
| F8 | P2 | NVFP4 `weight_scale` dtype enforcement (FP8_E4M3 only) | `03b8996` |

P3 items F9 (header 8-byte alignment) and F10 (UX-only) deferred.

## Roadmap inventory

`docs/audit/roadmap_inventory_2026-05.md` enumerated 27 items across `docs/roadmap.md` + `docs/sm120-real-perf-plan.md` + the prior audit's "truly unresolved" list. Result under the strict Quality Gate: **0 FEASIBLE, 1 UNCERTAIN deferred, 21 INFEASIBLE deferred, 5 OBSOLETE.** Every deferral has a documented reason + pre-conditions to revisit in `docs/audit/followups.md`.

By design — this run focuses on Objective 1 (loader + NVFP4 hardening) and defers all roadmap items, exactly as the conditional model prescribes. A run that closes Objective 1 fully and defers every roadmap item is a successful run when each deferral holds up; see `docs/audit/DONE.md`.

## Constraints honoured

- **No new third-party dependencies.** `CMakeLists.txt` `FetchContent` block unchanged.
- **`CMAKE_CUDA_STANDARD = 20`** unchanged.
- **Hot path untouched** — every change is loader-time / promote-time.
- **Quality Gate held on every commit** — numerical correctness, no regression, no skipped tests, no `// TODO`, no print-debugging, root-cause oriented.

## ADRs

- `docs/audit/decisions/0001-reference-harness-pure-cpp.md` — pure-C++ reference over Python harness.
- `docs/audit/decisions/0002-header-size-cap.md` — 128 MiB SafeTensors header soft cap.

## Test plan

- [x] `make build` — Docker build, sm_120a target, no new deps
- [x] `make test-gpu` — full suite 769/769 (22 skipped: 18 model-dependent E2E without mounted models, 4 hardware-feature-dependent)
- [x] `make verify-fast` — decode 155.94 tok/s (baseline 147.85, +5.47%), prefill 14362.41 tok/s (baseline 13277.98, +8.17%), Qwen3-4B Q8_0 capital-of-France smoke OK
- [ ] CI matrix on push

## Files changed

Source (5):
- `src/model/safetensors_loader.{h,cpp}` — `validate_header_size`, `validate_tensor_offsets`, WARN-on-drop summary
- `src/quant/nvfp4_quant.{h,cu}` — `nvfp4_promote_weight_scale_2`, `nvfp4_validate_weight_scale_dtype`, `nvfp4_validate_packed_scale_shapes`
- `src/graph/executor_pre_dequant.cu` — calls into the new helpers; inline math removed
- `CMakeLists.txt` — wires the two new test files into `test-quant` / `test-core`

Tests (2 new files, 40 tests):
- `tests/test_nvfp4_compressed_tensors_ref.cu` — 25 tests across 4 fixtures
- `tests/test_safetensors_loader.cpp` — 15 tests across 3 fixtures

Docs (8 new in `docs/audit/`):
- `roadmap_inventory_2026-05.md`, `safetensors_nvfp4_audit_2026-05.md`, `master_plan_2026-05.md`
- `followups.md`, `progress.log`, `DONE.md`
- `decisions/0001-reference-harness-pure-cpp.md`, `decisions/0002-header-size-cap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)