### PR TITLE
ci: gate Test job on HAS_GPU_RUNNER repo variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,13 @@ jobs:
   test:
     name: Test
     needs: build
-    runs-on: ubuntu-24.04
-    # GPU tests require self-hosted runner with NVIDIA GPU.
-    # Uncomment the line below and remove ubuntu-24.04 when a GPU runner is available.
-    # runs-on: [self-hosted, gpu, cuda]
-    if: false  # Skip until GPU runner is configured
+    # GPU tests need a self-hosted runner with NVIDIA GPU. Set the repo variable
+    # HAS_GPU_RUNNER=true (Settings → Secrets and variables → Actions → Variables)
+    # once a runner labeled [self-hosted, gpu, cuda] is registered. Until then,
+    # this job is skipped — same effective behavior as the prior `if: false`,
+    # but flips automatically when a runner appears.
+    if: ${{ vars.HAS_GPU_RUNNER == 'true' }}
+    runs-on: [self-hosted, gpu, cuda]
 
     steps:
       - uses: actions/checkout@v5
@@ -122,5 +124,6 @@ jobs:
 
       - name: Run tests
         run: |
-          chmod +x build/imp-tests
-          cd build && ctest --output-on-failure
+          chmod +x build/imp-tests || true
+          chmod +x build/test-* 2>/dev/null || true
+          cd build && ctest --output-on-failure --timeout 120


### PR DESCRIPTION
## Summary

The Test job in \`.github/workflows/ci.yml\` was hard-skipped (\`if: false\`) since introduction because GitHub-hosted Ubuntu runners have no GPU and CUDA tests fail at startup. The hard-skip stays off forever, even after a self-hosted runner is registered.

This swap gates the job on a repo variable \`HAS_GPU_RUNNER\` so the test job flips on automatically once the runner exists.

## Activation steps (for after merge)

1. Register a self-hosted runner on the host with the RTX 5090 (Settings → Actions → Runners → New self-hosted runner). Apply labels: \`self-hosted\`, \`gpu\`, \`cuda\`.
2. Set repo variable \`HAS_GPU_RUNNER=true\` (Settings → Secrets and variables → Actions → Variables).
3. Next PR will trigger the Test job, which downloads the built artifacts from the Build job and runs \`ctest --timeout 120\`.

Until step 2 fires, behavior is identical to the prior hard-skip.

## Test plan

- [x] No source changes; pre-push hook (verify-fast) skipped correctly because no src/include/tools/tests touched
- [ ] Build job (this PR) green — confirms YAML parses
- [ ] Test job (this PR) skipped — confirms gate fires correctly with HAS_GPU_RUNNER unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)