### PR TITLE
docs(audit): expand AU3 (AWQ) deferral note with acquisition recipe

### DIFF
--- a/docs/audit/followups.md
+++ b/docs/audit/followups.md
@@ -74,8 +74,22 @@ Pre-conditions: golden roundtrip fixtures from real `.model` files; protobuf dec
 
 ### AU3 — AWQ INT4 dequant kernel
 
-Reason: Column-packed + interleave-permutation kernel; "multi-week" per audit. MVP path is dequant-to-FP16 + cuBLAS, but even that needs careful AWQ-vs-GPTQ packing convention validation.
-Pre-conditions: AWQ test models with golden FP32 reference.
+Reason: Two coupled blockers, both fixture-related:
+
+1. **No AWQ checkpoint in the local model fleet.** `find /home/kekz/models /home/kekz/.cache -iname "*awq*"` returns nothing as of 2026-05-08. Implementing the dequant kernel without a real-world checkpoint to integration-test against would ship a synthetic-only-validated kernel — the Quality Gate's "anti-pattern: stubs/mocks/placeholders behind a flag" forbids that even when synthetic tests pass.
+
+2. **AWQ packing convention has subtle differences from GPTQ.** AWQ exports column-pack the INT4 weights with an interleave permutation (qweight[i,j] high/low nibble for sequential rows in a packing block), whereas GPTQ row-packs. Misinterpreting the packing produces output that compiles fine, runs without crash, and silently drifts. Cross-validating against a Python `autoawq` reference is the only way to be sure — that requires a real model file.
+
+Detection is already in place: PR #116 commit `7c0b8c8` parses `awq_config.json` and emits a load-time WARN with bits/group_size. So users get a clear "this model needs work" signal today; they're directed to GPTQ or NVFP4 variants.
+
+**Acquisition path for next session:**
+- Download a small AWQ checkpoint (~2-4 GB), e.g. `TheBloke/Llama-2-7B-Chat-AWQ` (HF Hub) or `casperhansen/llama-3-8b-instruct-awq`. Place under `/home/kekz/models/`.
+- Cross-reference output against Python `autoawq`'s `AutoAWQForCausalLM` on a fixed prompt with `temperature=0`. Use the existing `scripts/validate_safetensors.py` harness pattern.
+- Implement dequant-to-FP16 path first (~150 LoC kernel + cuBLAS dispatch); native AWQ-INT4×FP16 GEMV is a follow-up.
+
+**LoC estimate (post-fixture):** 150-300 LoC kernel + 100 LoC loader integration + 200 LoC tests. ~1 session.
+
+Pre-conditions: AWQ test model with golden FP32 reference from `autoawq`.
 
 ### AU4 — DeepSeek MLA attention
 


### PR DESCRIPTION
## Summary

Documentation-only follow-up. Replaces the brief AU3 deferral in \`docs/audit/followups.md\` with concrete next-session acceptance criteria so the AWQ kernel work can be picked up without re-discovering the constraints.

## Why deferred (kept)

Two coupled blockers, both fixture-related:

1. **No AWQ checkpoint in the local model fleet.** \`find /home/kekz/models /home/kekz/.cache -iname "*awq*"\` returns nothing as of 2026-05-08. Implementing the dequant kernel without a real-world checkpoint to integration-test against would ship a synthetic-only-validated kernel — the Quality Gate's "anti-pattern: stubs/mocks/placeholders behind a flag" forbids that even when synthetic tests pass.

2. **AWQ packing convention has subtle differences from GPTQ.** AWQ exports column-pack the INT4 weights with an interleave permutation, whereas GPTQ row-packs. Misinterpreting produces output that compiles, runs, and silently drifts. Cross-validation against \`autoawq\` is the only sound check.

## What's added

- Concrete acquisition path: candidate model URLs (\`TheBloke/Llama-2-7B-Chat-AWQ\` or \`casperhansen/llama-3-8b-instruct-awq\`, ~2-4 GB)
- Cross-validation strategy: \`autoawq\` Python reference at \`temperature=0\` via the existing \`scripts/validate_safetensors.py\` harness
- LoC estimate post-fixture: 150-300 LoC kernel + 100 LoC loader + 200 LoC tests = ~1 session

## Test plan

- [x] No source changes; pre-push hook (verify-fast) skipped — only \`docs/\` touched
- [ ] Build job (this PR) green — confirms no spurious doc-format issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)