### PR TITLE
fix(engine): size d_pf_block_tables_ from max_blocks (closes roadmap item)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1192,7 +1192,11 @@ bool Engine::init_kv_cache() {
     {
         size_t tok_bytes = config_.max_seq_len * sizeof(int32_t);
         size_t pos_bytes = config_.max_seq_len * sizeof(int);
-        size_t bt_bytes = blocks_per_seq * sizeof(int);
+        // A single request's block_table can grow to the entire KV cache
+        // pool (max_blocks), not just max_seq_len/block_size. Size from
+        // max_blocks so the H2D copy at the prefill metadata upload site
+        // doesn't overflow on long-cumulative-KV requests.
+        size_t bt_bytes = static_cast<size_t>(max_blocks) * sizeof(int);
         size_t cl_bytes = sizeof(int);
         prefill_pool_size_ = tok_bytes + pos_bytes + bt_bytes + cl_bytes;
         prefill_pool_ = vram_alloc_.allocate(prefill_pool_size_, "prefill_pool");


### PR DESCRIPTION
## Summary

Closes the `docs/roadmap.md` "**`d_pf_block_tables_` undersized for prompts ≥ max_seq_len**" known limitation.

A request's per-sequence block_table can grow to the entire KV cache pool (`max_blocks`), not just `max_seq_len/block_size`. Chunked prefill across many chunks accumulates more block-table entries than the pool was sized for, overflowing the H2D `cudaMemcpyAsync` at `engine.cpp:1825`.

## Change

`src/runtime/engine.cpp:1195`:
```cpp
- size_t bt_bytes = blocks_per_seq * sizeof(int);
+ // A single request's block_table can grow to the entire KV cache
+ // pool (max_blocks), not just max_seq_len/block_size. Size from
+ // max_blocks so the H2D copy at the prefill metadata upload site
+ // doesn't overflow on long-cumulative-KV requests.
+ size_t bt_bytes = static_cast<size_t>(max_blocks) * sizeof(int);
```

`max_blocks` is the total KV cache pool count, declared at `engine.cpp:997`. It's >> `blocks_per_seq` in normal configurations (thousands vs. hundreds), so the buffer grows but stays well within VRAM headroom. No code-path change.

## Test plan

- [x] `make build` clean
- [x] `make test-gpu`: 78 PASSED, 18 SKIPPED, 0 FAILED
- [x] `make verify-fast` green: decode -1.38% / prefill -1.63%, both within 3% / 5% thresholds (with warm GPU at P0 / 2910 MHz)

## Roadmap follow-up

`docs/roadmap.md` "Known limitations" still has this entry — separate doc commit will strike it through after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)