### PR TITLE
fix(engine): correct Gemma-4 FP8-prefill carve-out reason (perf, not correctness)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -632,7 +632,16 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         // device-side (dp4a GEMV, no D2H memcpy), so graph capture works.
         // Only the MoE prefill path uses D2H sync, but prefill is never graph-captured.
         if (config_.use_fp8_prefill) {
-            IMP_LOG_INFO("Gemma 4: disabling FP8 prefill (per-layer head_dim not yet supported)");
+            // FP8 prefill on Gemma-4 is correctness-OK (output matches FP16 path
+            // bit-for-bit on the smoke "capital of France is Paris" prompt) but
+            // ~5-19% slower on prefill (measured 2026-05-09 on Q4_K_M: pp=123 was
+            // 270 vs 334 tok/s, pp=833 was 1086 vs 1141 tok/s — both runs FP8 < FP16).
+            // Likely cause: cuBLASLt FP8 algos for Gemma-4's per-layer head_dim
+            // shape (256/512 split) lose to FP16 cuBLAS at our tile sizes. The
+            // earlier "per-layer head_dim not yet supported" comment was inherited
+            // from the FP8 KV story and inaccurate — the issue is perf, not
+            // correctness. Auto-disable for default-perf.
+            IMP_LOG_INFO("Gemma 4: disabling FP8 prefill (~5-19%% slower than FP16 on this arch)");
             config_.use_fp8_prefill = 0;
         }
         if (config_.use_nvfp4_decode) {


### PR DESCRIPTION
## Summary

The Gemma-4 FP8-prefill carve-out (`engine.cpp:634-637`) said "per-layer head_dim not yet supported" — inherited from the FP8 KV story (PR #91 confirmed that was a red herring). Empirical A/B testing today shows the actual behavior:

| Test | FP8 prefill | FP16 prefill | Δ |
|---|---|---|---|
| Output (Paris prompt) | "...Paris." | "...Paris." | identical |
| pp=123 | 270.91 tok/s | 334.27 tok/s | **-19%** |
| pp=833 | 1086.70 tok/s | 1141.02 tok/s | **-5%** |

So FP8 prefill on Gemma-4 is **correctness-OK but consistently slower** than FP16. Likely cause: cuBLASLt FP8 algos for Gemma-4's head_dim shapes (256/512) lose to FP16 cuBLAS at imp's tile sizes.

## Change

`src/runtime/engine.cpp:634-643`:
- Carve-out itself preserved (auto-disable keeps default perf).
- Comment rewritten to record the empirical A/B and root cause.
- Log message updated: `"per-layer head_dim not yet supported"` → `"~5-19% slower than FP16 on this arch"`.

## Test plan

- [x] `make build` clean
- [x] `make test-gpu`: 78 PASSED, 0 FAILED
- [x] `make verify-fast` (pre-push hook): green
- [x] Smoke prompt on Gemma-4 Q4_K_M: "Paris" with both FP8 prefill on and off (output bit-identical)

## Roadmap

`docs/roadmap.md` "Gemma-4 remaining carve-outs" section in PR #136 will need a follow-up edit to reflect the perf finding (currently says "needs investigation"). I'll send that as a separate doc PR after this and #136 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)