### PR TITLE
BitDecoding Phase 3 — multi-seq + spill fix + splitk path + graph-safe (parity)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,14 @@ compile_commands.json
 *.fatbin
 *.cubin
 
+# Compiled microbench / probe binaries in tools/analysis (sources tracked, binaries not)
+tools/analysis/probe_*
+!tools/analysis/probe_*.cu
+!tools/analysis/probe_*.sh
+tools/analysis/bench_*
+!tools/analysis/bench_*.cu
+!tools/analysis/bench_*.sh
+
 # Logs (debug runs, repro logs, smoke tests)
 *.log
 bringup_artifacts/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,6 +415,7 @@ if(IMP_BUILD_TESTS)
         tests/test_attention_fmha_mxfp4.cu
         tests/test_paged_attention.cu
         tests/test_attention_paged_nvfp4_tc.cu
+        tests/test_attention_paged_nvfp4_tc_residual.cu
         tests/test_attention_chunked.cu
     )
 

--- a/prompts/nsys_profiling.md
+++ b/prompts/nsys_profiling.md
@@ -1,0 +1,195 @@
+# imp: Systematic Nsight Systems Profiling & Optimization
+
+## Mission
+
+Conduct a rigorous end-to-end performance audit of `imp` using Nsight Systems (`nsys`) on the RTX 5090 (SM120). Identify the top 5–10 optimization opportunities ranked by expected tok/s impact, and produce a prioritized action list with concrete patches.
+
+This is a **measurement-first** workflow. No speculative optimization. Every claim is backed by a profile.
+
+---
+
+## Phase 0: Environment & Build Setup
+
+1. Verify toolchain:
+   - `nsys --version` (require ≥ 2025.3 for Blackwell support)
+   - `nvidia-smi` confirms RTX 5090, driver, CUDA runtime
+   - imp built with `-lineinfo` and **NVTX ranges enabled** (`-DIMP_ENABLE_NVTX=ON`)
+   - Release build with `-O3`, but `-g` symbols retained for kernel attribution
+
+2. If NVTX is not yet wired in, **add it first** before profiling. Annotate at minimum:
+   - `imp::Engine::generate()` (top-level)
+   - Prefill vs. decode phases (separate ranges)
+   - Per-layer: attention, FFN/MoE, sampling
+   - KV cache ops (copy, append, evict)
+   - Host-side: tokenization, scheduler, batching
+   - Use `nvtxRangePushA`/`PopA` with descriptive names; categories per subsystem
+
+3. Lock GPU clocks for reproducibility:
+   ```
+   nvidia-smi -lgc <base_clock>
+   nvidia-smi -lmc <mem_clock>
+   ```
+   Document chosen frequencies.
+
+---
+
+## Phase 1: Baseline Profile Collection
+
+Collect three reference workloads. For each, capture both `nsys` (timeline) and a separate `ncu` summary (per-kernel metrics) so we can cross-reference.
+
+**Workloads:**
+- **W1 — Long-context prefill:** single request, 8k input, 64 output tokens. Stresses FMHA prefill, weight loads, scheduler overhead is amortized.
+- **W2 — Decode-heavy:** single request, 256 input, 2048 output. Stresses KV cache, decode-phase FMHA, sampling, host-GPU sync.
+- **W3 — Batched serving:** 16 concurrent requests, mixed lengths. Stresses scheduler, KV layout, MoE expert routing if applicable.
+
+**Capture command template:**
+```bash
+nsys profile \
+  --trace=cuda,nvtx,osrt,cudnn,cublas \
+  --cuda-memory-usage=true \
+  --cuda-um-cpu-page-faults=true \
+  --capture-range=cudaProfilerApi \
+  --capture-range-end=stop \
+  --gpu-metrics-devices=0 \
+  --gpu-metrics-frequency=20000 \
+  -o profiles/W<N>_baseline \
+  ./build/imp_server <args>
+```
+
+Use `cudaProfilerStart()`/`cudaProfilerStop()` in the test harness to skip warmup and exclude shutdown noise. Profile **steady state only**.
+
+For each workload also record:
+- Wall-clock tok/s (prefill tok/s and decode tok/s separately)
+- Peak and average VRAM
+- Power draw (`nvidia-smi dmon -s pucvmet`)
+
+Save raw `.nsys-rep` files; do not delete after analysis.
+
+---
+
+## Phase 2: Timeline Analysis — Where Does Time Go?
+
+Open each profile in the Nsight Systems GUI **and** export stats via CLI for grep-able artifacts:
+
+```bash
+nsys stats --report cuda_gpu_kern_sum,cuda_gpu_mem_time_sum,cuda_api_sum,nvtx_sum \
+  --format csv --output profiles/W<N>_baseline profiles/W<N>_baseline.nsys-rep
+```
+
+For each workload, produce a structured report answering:
+
+### 2.1 Kernel time breakdown
+- Top 20 kernels by total GPU time. Group by logical phase using NVTX ranges.
+- For each: % of total runtime, invocation count, avg duration, occupancy hint.
+- Flag any kernel that is unexpectedly hot (e.g., a `memset`, a small reduction, a layout transform consuming >2% — these are usually the easy wins).
+
+### 2.2 GPU idle / bubbles
+- What fraction of wall time is the GPU actually executing kernels vs. idle?
+- Where are the largest idle gaps on the timeline? Cross-reference with NVTX to identify the host-side cause (e.g., `cudaMemcpyAsync` on default stream stalling, scheduler decisions, tokenizer on hot path, allocator calls).
+- Are there `cudaStreamSynchronize` / `cudaDeviceSynchronize` calls on the critical path that should not be there?
+
+### 2.3 Host-GPU concurrency
+- Is the host issuing work fast enough to keep the GPU saturated? Look for "kernel launch latency" gaps (>5–10 µs between kernels with no host work).
+- Are CUDA Graphs being used for the decode loop? If not, this is almost certainly a top-3 finding.
+- Check for malloc/free in the steady-state hot loop (any `cudaMalloc`/`cudaFree` after warmup is a bug).
+
+### 2.4 Memory subsystem
+- HBM read/write bandwidth utilization (from `--gpu-metrics`). If decode kernels are below 70% of theoretical (1.79 TB/s on RTX 5090), there's headroom.
+- H2D / D2H transfers: any in the hot path? (Tokenization output, sampling output — pinned memory? batched?)
+- KV cache: pattern of writes per token, layout (paged?), fragmentation.
+
+### 2.5 Stream usage
+- How many CUDA streams? Is there real overlap between compute streams and copy engine, or is everything on stream 0?
+- For batched serving: is per-request work on separate streams to enable kernel overlap? (Probably not worth it for compute-bound kernels, but worth checking for small ops.)
+
+### 2.6 NVFP4 / MXFP4 path verification
+- Confirm the FMHA + GEMM kernels actually being dispatched are the NVFP4/MXFP4 variants, not BF16/FP16 fallbacks. Kernel name in `nsys` should make this obvious; if there's any FP16 GEMM in the hot path on SM120 it's running at half speed and is an immediate bug.
+- For the MXFP4 FMHA: confirm it's the new kernel and not an older path still resident in the binary.
+
+---
+
+## Phase 3: Per-Kernel Deep-Dive (selective)
+
+For the top 5 hottest kernels identified in Phase 2, run `ncu` for detailed metrics. **Only** the top 5 — `ncu` is slow, don't profile everything.
+
+```bash
+ncu --set full \
+    --target-processes all \
+    --kernel-name regex:"<pattern>" \
+    --launch-skip 50 --launch-count 10 \
+    -o profiles/ncu_<kernel_name> \
+    ./build/imp_server <args>
+```
+
+For each kernel, extract:
+- Achieved occupancy vs. theoretical
+- Memory throughput vs. peak (HBM, L2, shared)
+- Tensor core utilization (NVFP4 SM120 path)
+- Register pressure / spills
+- Warp stall reasons (top 3)
+- Roofline position: compute-bound or memory-bound?
+
+Compare against the published peak for SM120 for that precision/op. The gap is the headroom.
+
+---
+
+## Phase 4: Findings & Prioritized Action List
+
+Produce `nsys_findings.md` with the following structure:
+
+For each finding (target 8–12 findings):
+
+```
+### Finding N: <short title>
+**Workload(s):** W1 / W2 / W3
+**Evidence:** <screenshot/excerpt from nsys, kernel name, % of runtime, metric values>
+**Root cause:** <what is actually happening>
+**Expected impact:** <estimated tok/s gain, with reasoning>
+**Effort:** S / M / L
+**Risk:** <regressions, complexity>
+**Proposed fix:** <concrete code change, file paths, kernel/host>
+**Validation plan:** <which metric must move, by how much>
+```
+
+Then a summary table sorted by `expected_impact / effort` (ROI), with the top 3 marked as immediate work.
+
+Common findings to specifically check for (do not assume present, but look):
+- Decode loop not using CUDA Graphs → graph capture per batch shape, cache by shape key
+- Sampling kernel launching many small CUB calls per step → fuse, or use `cub::DeviceTopK` (CUDA 13.2)
+- KV append pattern doing layout transforms that could be fused into attention output write
+- Any BF16/FP16 GEMM on SM120 hot path (running at half speed — must move to NVFP4/MXFP4)
+- Host-side scheduler decisions blocking the launch queue
+- `cudaMemcpyAsync` on the default stream when it should be on a copy stream
+- Attention kernel not saturating tensor cores during decode (low arithmetic intensity — can it be merged with adjacent ops?)
+- MoE expert dispatch: scatter/gather kernels dominating over expert GEMMs
+- Tokenizer or detokenizer running on the critical path of the response loop instead of overlapped
+
+---
+
+## Phase 5: Iterate
+
+After implementing the top 1–3 fixes:
+1. Re-run the **identical** capture commands from Phase 1.
+2. Diff against baseline using `nsys stats` CSV outputs.
+3. Confirm: did the targeted metric move as predicted? Any regressions elsewhere?
+4. Update the findings doc with actuals vs. predicted.
+5. Repeat.
+
+Each iteration must include the `.nsys-rep` files in `profiles/` so improvements are auditable.
+
+---
+
+## Deliverables
+
+- `profiles/` — all `.nsys-rep` and `ncu-rep` files (baseline + each iteration)
+- `profiles/*.csv` — exported stats per workload
+- `nsys_findings.md` — prioritized findings as described above
+- `nsys_methodology.md` — exact reproduction steps (clocks, build flags, harness commands)
+- A short PR per implemented fix, each linking to the finding ID and showing before/after numbers
+
+## Constraints
+
+- Do not optimize anything that isn't backed by a profile.
+- Do not change kernel correctness without a numerical equivalence test.
+- Keep all NVTX ranges in the final build — always-on profiling is a feature.
+- If the GUI shows something `nsys stats` doesn't, screenshot it and put it in the findings doc.

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -116,7 +116,14 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
                                      int residual_seq_stride_elems = 0,
                                      const int* d_residual_seq_slots = nullptr,
                                      const int* d_residual_counts = nullptr,
-                                     const int* d_residual_write_idxes = nullptr);
+                                     const int* d_residual_write_idxes = nullptr,
+                                     // Graph-safe per-slot ring state (KVCacheManager's persistent
+                                     // device buffers). When non-null AND d_residual_seq_slots is set,
+                                     // kernel reads fc/widx via slot indirection — graph-capture-safe
+                                     // because nothing is rebuilt per step. Replaces d_residual_counts/
+                                     // d_residual_write_idxes when both pairs are set.
+                                     const int* d_residual_fc_per_slot = nullptr,
+                                     const int* d_residual_widx_per_slot = nullptr);
 
 // TurboQuant Paged attention for decode: PolarQuant K + QJL sketch + INT4 V.
 // K_dir_cache: packed directions — INT4 uniform (K_mscales=nullptr) or FP4 E2M1 (K_mscales!=nullptr)

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -73,14 +73,30 @@ void paged_attention_decode_nvfp4(const Tensor& Q, const Tensor& K_cache, const 
 
 // BitDecoding-style TC variant: same signature + semantics as
 // paged_attention_decode_nvfp4 but routes the inner Q.K dot through
-// nvcuda::wmma 16×16×16 Tensor Core MMA. Phase 1 of the BitDecoding
-// port (docs/superpowers/plans/2026-05-09-bitdecoding-port.md). V
-// accumulation remains scalar in Phase 1.
+// nvcuda::wmma 16×16×16 Tensor Core MMA.
+//
+// Phase 3b residual addendum: optional FP16 ring-buffer holding the newest
+// `residual_count` KV tokens (write-through duplicate of paged tail). When
+// `K_residual != nullptr && residual_count > 0`, the kernel splits attention
+// into paged tokens [0, ctx_len - residual_count) (NVFP4 dequant path) and
+// residual tokens [ctx_len - residual_count, ctx_len) (direct FP16 path),
+// merging via the same online-softmax invariant as the paged loop. Single-
+// sequence (batch_size==1) only — caller passes the (seq,layer) pointer slice.
+//
+// Layout of K_residual / V_residual: [residual_n_tokens, n_kv_heads, head_dim]
+// FP16, ring-indexed; the chronologically-i-th most recent token is at slot
+// `(residual_write_idx + residual_n_tokens - residual_count + i) % residual_n_tokens`.
+//
+// Split-K is forced off when residual is active (residual writes only the
+// non-split kernel; split kernel ignores the args).
 void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, const Tensor& V_cache, Tensor& O,
                                      const uint8_t* K_scales, const uint8_t* V_scales, const int* block_tables,
                                      const int* context_lens, int block_size, float scale, int max_context_len,
                                      int sliding_window = 0, float softcap = 0.0f,
-                                     cudaStream_t stream = nullptr, int max_blocks_per_seq = 0, int n_sinks = 0);
+                                     cudaStream_t stream = nullptr, int max_blocks_per_seq = 0, int n_sinks = 0,
+                                     const half* K_residual = nullptr, const half* V_residual = nullptr,
+                                     int residual_count = 0, int residual_n_tokens = 0,
+                                     int residual_write_idx = 0);
 
 // TurboQuant Paged attention for decode: PolarQuant K + QJL sketch + INT4 V.
 // K_dir_cache: packed directions — INT4 uniform (K_mscales=nullptr) or FP4 E2M1 (K_mscales!=nullptr)

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -77,26 +77,46 @@ void paged_attention_decode_nvfp4(const Tensor& Q, const Tensor& K_cache, const 
 //
 // Phase 3b residual addendum: optional FP16 ring-buffer holding the newest
 // `residual_count` KV tokens (write-through duplicate of paged tail). When
-// `K_residual != nullptr && residual_count > 0`, the kernel splits attention
-// into paged tokens [0, ctx_len - residual_count) (NVFP4 dequant path) and
-// residual tokens [ctx_len - residual_count, ctx_len) (direct FP16 path),
-// merging via the same online-softmax invariant as the paged loop. Single-
-// sequence (batch_size==1) only — caller passes the (seq,layer) pointer slice.
+// active, the kernel splits attention into paged tokens [0, ctx_len -
+// residual_count) (NVFP4 dequant path) and residual tokens [ctx_len -
+// residual_count, ctx_len) (direct FP16 path), merging via the same online-
+// softmax invariant as the paged loop.
 //
-// Layout of K_residual / V_residual: [residual_n_tokens, n_kv_heads, head_dim]
-// FP16, ring-indexed; the chronologically-i-th most recent token is at slot
-// `(residual_write_idx + residual_n_tokens - residual_count + i) % residual_n_tokens`.
+// Two activation forms:
+//   1. Single-seq scalar form (batch_size==1):
+//      pass K_residual / V_residual + residual_count / residual_write_idx
+//      as scalars. d_residual_seq_slots stays nullptr.
 //
-// Split-K is forced off when residual is active (residual writes only the
+//   2. Multi-seq array form (batch_size >= 1):
+//      pass K_residual_base / V_residual_base = layer-base pointers (slot 0),
+//      residual_seq_stride_elems = FP16 elems between slots,
+//      d_residual_seq_slots / d_residual_counts / d_residual_write_idxes =
+//      device arrays of length batch_size. Kernel reads per blockIdx.x and
+//      computes K_for_seq = K_residual_base + slot * stride.
+//
+// Layout of FP16 residual data per slot:
+//   [residual_n_tokens, n_kv_heads, head_dim] half, ring-indexed; the
+//   chronologically-i-th most recent token is at slot
+//   `(write_idx + residual_n_tokens - residual_count + i) % residual_n_tokens`.
+//
+// Split-K is forced off when residual is active (residual reads only the
 // non-split kernel; split kernel ignores the args).
 void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, const Tensor& V_cache, Tensor& O,
                                      const uint8_t* K_scales, const uint8_t* V_scales, const int* block_tables,
                                      const int* context_lens, int block_size, float scale, int max_context_len,
                                      int sliding_window = 0, float softcap = 0.0f,
                                      cudaStream_t stream = nullptr, int max_blocks_per_seq = 0, int n_sinks = 0,
+                                     // Single-seq scalar form
                                      const half* K_residual = nullptr, const half* V_residual = nullptr,
                                      int residual_count = 0, int residual_n_tokens = 0,
-                                     int residual_write_idx = 0);
+                                     int residual_write_idx = 0,
+                                     // Multi-seq array form (overrides the scalars when d_residual_seq_slots != nullptr)
+                                     const half* K_residual_base = nullptr,
+                                     const half* V_residual_base = nullptr,
+                                     int residual_seq_stride_elems = 0,
+                                     const int* d_residual_seq_slots = nullptr,
+                                     const int* d_residual_counts = nullptr,
+                                     const int* d_residual_write_idxes = nullptr);
 
 // TurboQuant Paged attention for decode: PolarQuant K + QJL sketch + INT4 V.
 // K_dir_cache: packed directions — INT4 uniform (K_mscales=nullptr) or FP4 E2M1 (K_mscales!=nullptr)

--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -792,13 +792,20 @@ __global__ void paged_attention_residual_reduce_kernel(
     const half* __restrict__ K_residual,
     const half* __restrict__ V_residual,
     int residual_count_scalar, int residual_write_idx_scalar,
-    // Multi-seq array form:
+    // Multi-seq / per-slot array form. Two indirection styles:
+    //   (a) per-batch arrays:   d_residual_counts[batch_idx], d_residual_write_idxes[batch_idx]
+    //   (b) per-slot arrays:    d_residual_widx_per_slot[slot], d_residual_fc_per_slot[slot]
+    //                           (slot looked up via d_residual_seq_slots[batch_idx])
+    // (b) is graph-capture-safe — kv_manager_'s persistent ring state is used
+    // directly. (a) is the legacy form (engine builds per-step host buffer).
     const half* __restrict__ K_residual_base,
     const half* __restrict__ V_residual_base,
     int residual_seq_stride_elems,
     const int* __restrict__ d_residual_seq_slots,
     const int* __restrict__ d_residual_counts,
-    const int* __restrict__ d_residual_write_idxes) {
+    const int* __restrict__ d_residual_write_idxes,
+    const int* __restrict__ d_residual_fc_per_slot,
+    const int* __restrict__ d_residual_widx_per_slot) {
     static_assert(HEAD_DIM % WARP_SIZE == 0, "HEAD_DIM must be divisible by WARP_SIZE");
     constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
     constexpr int partial_stride = 2 + HEAD_DIM;
@@ -820,8 +827,16 @@ __global__ void paged_attention_residual_reduce_kernel(
     int rc = 0, rwi = 0;
     if (d_residual_seq_slots != nullptr && K_residual_base != nullptr && residual_n_tokens > 0) {
         int slot = d_residual_seq_slots[batch_idx];
-        int rc_b = (d_residual_counts != nullptr) ? d_residual_counts[batch_idx] : 0;
-        int rw_b = (d_residual_write_idxes != nullptr) ? d_residual_write_idxes[batch_idx] : 0;
+        int rc_b, rw_b;
+        if (d_residual_fc_per_slot != nullptr && d_residual_widx_per_slot != nullptr && slot >= 0) {
+            // Graph-safe per-slot read.
+            rc_b = d_residual_fc_per_slot[slot];
+            rw_b = d_residual_widx_per_slot[slot];
+        } else {
+            // Legacy per-batch read.
+            rc_b = (d_residual_counts != nullptr) ? d_residual_counts[batch_idx] : 0;
+            rw_b = (d_residual_write_idxes != nullptr) ? d_residual_write_idxes[batch_idx] : 0;
+        }
         if (slot >= 0 && rc_b > 0) {
             K_res = K_residual_base + (int64_t)slot * residual_seq_stride_elems;
             V_res = V_residual_base + (int64_t)slot * residual_seq_stride_elems;
@@ -1030,7 +1045,8 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
                                   int residual_count, int residual_n_tokens, int residual_write_idx,
                                   const half* K_residual_base, const half* V_residual_base,
                                   int residual_seq_stride_elems, const int* d_residual_seq_slots,
-                                  const int* d_residual_counts, const int* d_residual_write_idxes) {
+                                  const int* d_residual_counts, const int* d_residual_write_idxes,
+                                  const int* d_residual_fc_per_slot, const int* d_residual_widx_per_slot) {
     (void)n_sinks;  // streaming not yet wired
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int n_heads = static_cast<int>(Q.shape[2]);
@@ -1137,7 +1153,9 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
         residual_active_multiseq ? residual_seq_stride_elems : 0,                                             \
         residual_active_multiseq ? d_residual_seq_slots : nullptr,                                            \
         residual_active_multiseq ? d_residual_counts : nullptr,                                               \
-        residual_active_multiseq ? d_residual_write_idxes : nullptr)
+        residual_active_multiseq ? d_residual_write_idxes : nullptr,                                          \
+        residual_active_multiseq ? d_residual_fc_per_slot : nullptr,                                          \
+        residual_active_multiseq ? d_residual_widx_per_slot : nullptr)
             switch (head_dim) {
                 case 64:  LAUNCH_RESIDUAL_REDUCE(64);  break;
                 case 128: LAUNCH_RESIDUAL_REDUCE(128); break;

--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -50,19 +50,12 @@ __device__ __forceinline__ half2 fp4_byte_to_half2(uint32_t byte_val) {
 // Non-Split-K NVFP4 decode kernel
 // ---------------------------------------------------------------------------
 
-// __launch_bounds__(maxThreadsPerBlock, minBlocksPerSM): with the residual
-// pass adding ~5 WMMA fragments of register pressure on top of the paged
-// path, the default heuristic packed 4+ blocks per SM and forced a 64-byte
-// per-thread local-memory spill (cuobjdump --dump-resource-usage showed
-// STACK:64 for HD>=128). The spilled stack lives in DRAM-backed local
-// memory; every access is a global-memory round-trip, which on the hot
-// per-decode-step path turned into a 3× tg/s regression. Pinning to 1
-// block per SM trades occupancy (8 warps × 1 block = 8 warps per SM,
-// vs the kernel's preferred 4 blocks for paged-only) for a higher register
-// budget per thread (~128 vs 64), eliminating the spill. Net win on long-
-// context decode: residual+graphs-off ≥ paged-only baseline.
+// Kernel uses no __launch_bounds__: with the dots/weights moved to shared
+// mem (warp-shfl reduction, see block-softmax section) the spill is gone
+// (cuobjdump STACK:0 across HD ∈ {64,128,256,512}); the compiler picks the
+// best occupancy/register trade-off automatically.
 template <int HEAD_DIM>
-__global__ __launch_bounds__(BLOCK_THREADS, 1) void paged_attention_decode_nvfp4_tc_kernel(
+__global__ void paged_attention_decode_nvfp4_tc_kernel(
     const half* __restrict__ Q,
     const uint8_t* __restrict__ K_cache,    // packed FP4 pairs
     const uint8_t* __restrict__ V_cache,    // packed FP4 pairs
@@ -287,32 +280,51 @@ __global__ __launch_bounds__(BLOCK_THREADS, 1) void paged_attention_decode_nvfp4
         // invariant.
         // ---------------------------------------------------------------
 
-        // Pass 1: read all 16 dots, find local max
-        float dots_scaled[16];
-        float m_local = -FLT_MAX;
-#pragma unroll
-        for (int t = 0; t < 16; t++) {
-            float d = -FLT_MAX;
-            if (t >= first_tok && t < n_toks) {
-                d = __half2float(sK_w[t]) * scale;
-                d = apply_softcap(d, softcap);
-                m_local = fmaxf(m_local, d);
-            }
-            dots_scaled[t] = d;
+        // Block-softmax with shared-mem dots/weights to avoid the per-thread
+        // float[16] arrays (forced a 64-byte stack spill into DRAM-backed
+        // local memory at HD>=128, dominated decode tg/s).
+        //
+        // Lanes 0..15 each compute one entry; full 32-lane warp-shfl reduce
+        // for m_local / l_local so EVERY lane sees the same scalar (the
+        // sQ_w fill below has lanes 16..31 also reading weights[col], so
+        // they need consistent l_inv).
+        float* dots_smem_p = reinterpret_cast<float*>(sK_w) + 16 * 16 / 2;  // alias unused half region
+        // Use the front of sFV_w for dots/weights — sFV_w is per-warp (1024B
+        // floats = 256 entries) and only used after this for V WMMA store.
+        float* dots_smem = sFV_w;
+        float* weights_smem = sFV_w + 16;
+
+        const bool t_active_p = (lane_id < 16) && (lane_id >= first_tok) && (lane_id < n_toks);
+        float my_dot_p = -FLT_MAX;
+        if (t_active_p) {
+            my_dot_p = __half2float(sK_w[lane_id]) * scale;
+            my_dot_p = apply_softcap(my_dot_p, softcap);
+        }
+        if (lane_id < 16) dots_smem[lane_id] = my_dot_p;
+        __syncwarp();
+
+        float m_local = my_dot_p;
+        #pragma unroll
+        for (int off = 16; off > 0; off >>= 1) {
+            m_local = fmaxf(m_local, __shfl_xor_sync(0xffffffff, m_local, off));
         }
 
         float m_new = fmaxf(m_w, m_local);
         float exp_diff = (m_w == -FLT_MAX) ? 0.0f : __expf(m_w - m_new);
 
-        // Pass 2: per-token un-normalized weights + l_local
-        float weights[16];
-        float l_local = 0.0f;
-#pragma unroll
-        for (int t = 0; t < 16; t++) {
-            float w = (dots_scaled[t] > -FLT_MAX) ? __expf(dots_scaled[t] - m_new) : 0.0f;
-            weights[t] = w;
-            l_local += w;
+        float my_weight_p = 0.0f;
+        if (t_active_p && my_dot_p > -FLT_MAX) {
+            my_weight_p = __expf(my_dot_p - m_new);
         }
+        if (lane_id < 16) weights_smem[lane_id] = my_weight_p;
+        __syncwarp();
+
+        float l_local = my_weight_p;
+        #pragma unroll
+        for (int off = 16; off > 0; off >>= 1) {
+            l_local += __shfl_xor_sync(0xffffffff, l_local, off);
+        }
+        (void)dots_smem_p;  // alias not used; keep dots in sFV_w for clarity
 
         float l_new = exp_diff * l_w + l_local;
         // Normalized rescale: (exp_diff * l_w_old) / l_new — same role as
@@ -341,10 +353,12 @@ __global__ __launch_bounds__(BLOCK_THREADS, 1) void paged_attention_decode_nvfp4
         const int my_chunk = lane_id / LANES_PER_CHUNK;
         const int my_offset_in_chunk = (lane_id % LANES_PER_CHUNK) * ELEMS;
 
-        // Replicate normalized weights into sQ_w[16, 16]: A[m, k] = w_norm[k]
+        // Replicate normalized weights into sQ_w[16, 16]: A[m, k] = w_norm[k].
+        // Reads weights_smem[col] (not a per-thread array) — bank-conflict-free
+        // since 32 lanes broadcast-read 16 distinct addresses.
         for (int i = lane_id; i < 16 * 16; i += WARP_SIZE) {
             int col = i % 16;
-            sQ_w[i] = __float2half(weights[col] * l_inv);
+            sQ_w[i] = __float2half(weights_smem[col] * l_inv);
         }
         __syncwarp();
 

--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -50,8 +50,19 @@ __device__ __forceinline__ half2 fp4_byte_to_half2(uint32_t byte_val) {
 // Non-Split-K NVFP4 decode kernel
 // ---------------------------------------------------------------------------
 
+// __launch_bounds__(maxThreadsPerBlock, minBlocksPerSM): with the residual
+// pass adding ~5 WMMA fragments of register pressure on top of the paged
+// path, the default heuristic packed 4+ blocks per SM and forced a 64-byte
+// per-thread local-memory spill (cuobjdump --dump-resource-usage showed
+// STACK:64 for HD>=128). The spilled stack lives in DRAM-backed local
+// memory; every access is a global-memory round-trip, which on the hot
+// per-decode-step path turned into a 3× tg/s regression. Pinning to 1
+// block per SM trades occupancy (8 warps × 1 block = 8 warps per SM,
+// vs the kernel's preferred 4 blocks for paged-only) for a higher register
+// budget per thread (~128 vs 64), eliminating the spill. Net win on long-
+// context decode: residual+graphs-off ≥ paged-only baseline.
 template <int HEAD_DIM>
-__global__ void paged_attention_decode_nvfp4_tc_kernel(
+__global__ __launch_bounds__(BLOCK_THREADS, 1) void paged_attention_decode_nvfp4_tc_kernel(
     const half* __restrict__ Q,
     const uint8_t* __restrict__ K_cache,    // packed FP4 pairs
     const uint8_t* __restrict__ V_cache,    // packed FP4 pairs
@@ -60,11 +71,20 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
     half* __restrict__ O, const int* __restrict__ block_tables,
     const int* __restrict__ context_lens, int batch_size, int n_heads, int n_kv_heads, int block_size,
     float scale, int max_context_len, int max_num_blocks, int sliding_window, float softcap,
-    // Phase 3b residual args. Active when K_residual != nullptr && residual_count > 0.
-    // Pointer points to the (seq, layer) slice; layout
-    //   [residual_n_tokens, n_kv_heads, head_dim] FP16 (ring-indexed).
+    // Phase 3b residual args.
+    // Single-seq form (batch_size==1): K_residual / V_residual point at the
+    //   (seq, layer) slice; residual_count_scalar / residual_write_idx_scalar
+    //   carry per-seq state. Layout [residual_n_tokens, n_kv_heads, head_dim].
+    // Multi-seq form (batch_size>=1): K_residual_base / V_residual_base point at
+    //   slot 0's (K|V) data for this layer; residual_seq_stride_elems is the FP16
+    //   stride between slots; d_residual_seq_slots/_counts/_write_idxes are device
+    //   arrays of length batch_size, indexed by blockIdx.x.
+    // Multi-seq is selected when d_residual_seq_slots != nullptr.
     const half* __restrict__ K_residual, const half* __restrict__ V_residual,
-    int residual_count, int residual_n_tokens, int residual_write_idx) {
+    int residual_count_scalar, int residual_n_tokens, int residual_write_idx_scalar,
+    const half* __restrict__ K_residual_base, const half* __restrict__ V_residual_base,
+    int residual_seq_stride_elems, const int* __restrict__ d_residual_seq_slots,
+    const int* __restrict__ d_residual_counts, const int* __restrict__ d_residual_write_idxes) {
     static_assert(HEAD_DIM % WARP_SIZE == 0, "HEAD_DIM must be divisible by WARP_SIZE");
     static_assert(HEAD_DIM % 16 == 0, "HEAD_DIM must be divisible by 16 (NVFP4 group size)");
     constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
@@ -114,11 +134,37 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
     if (sliding_window > 0 && ctx_len > sliding_window)
         effective_start = ctx_len - sliding_window;
 
-    // Phase 3b: split absolute KV range into paged-tail-clipped + residual.
-    // residual_active: residual ring is enabled AND has at least one entry that
-    // falls within ctx_len AND falls within effective_start..ctx_len window.
-    const bool residual_have = (K_residual != nullptr) && (V_residual != nullptr) &&
-                               (residual_n_tokens > 0) && (residual_count > 0);
+    // Phase 3b: pick residual form (single-seq scalar vs multi-seq array)
+    // and resolve per-batch K/V residual pointer + count + write_idx.
+    const half* K_res_ptr = nullptr;
+    const half* V_res_ptr = nullptr;
+    int residual_count = 0;
+    int residual_write_idx = 0;
+    if (d_residual_seq_slots != nullptr && K_residual_base != nullptr && residual_n_tokens > 0) {
+        // Multi-seq array form
+        int seq_slot = d_residual_seq_slots[batch_idx];
+        int rc = (d_residual_counts != nullptr) ? d_residual_counts[batch_idx] : 0;
+        int rw = (d_residual_write_idxes != nullptr) ? d_residual_write_idxes[batch_idx] : 0;
+        if (seq_slot >= 0 && rc > 0) {
+            K_res_ptr = K_residual_base + (int64_t)seq_slot * residual_seq_stride_elems;
+            V_res_ptr = V_residual_base + (int64_t)seq_slot * residual_seq_stride_elems;
+            residual_count = rc;
+            residual_write_idx = rw;
+        }
+    } else if (K_residual != nullptr && V_residual != nullptr && residual_count_scalar > 0 &&
+               residual_n_tokens > 0) {
+        // Single-seq scalar form
+        K_res_ptr = K_residual;
+        V_res_ptr = V_residual;
+        residual_count = residual_count_scalar;
+        residual_write_idx = residual_write_idx_scalar;
+    }
+
+    // Split absolute KV range into paged-tail-clipped + residual.
+    // residual_have: residual is enabled for this batch AND has at least one
+    // entry within both ctx_len and the [effective_start, ctx_len) window.
+    const bool residual_have = (K_res_ptr != nullptr) && (V_res_ptr != nullptr) &&
+                               (residual_count > 0);
     int residual_active_count = 0;
     int residual_first_abs = ctx_len;  // start of residual chronological range
     int residual_skip = 0;             // chronologically-stale residual entries to skip
@@ -374,18 +420,22 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
 
         constexpr int K_TILES_R = HEAD_DIM / 16;
 
-        using namespace nvcuda;
-        wmma::fragment<wmma::matrix_a, 16, 16, 16, __half, wmma::row_major> a_frag;
-        wmma::fragment<wmma::matrix_b, 16, 16, 16, __half, wmma::col_major> b_frag;
-        wmma::fragment<wmma::matrix_b, 16, 16, 16, __half, wmma::row_major> b_frag_v;
-        wmma::fragment<wmma::accumulator, 16, 16, 16, __half> c_frag;
-        wmma::fragment<wmma::accumulator, 16, 16, 16, float> v_frag;
-
         const int n_tiles_r = (residual_active_count + 15) / 16;
         const int slot_base = (residual_write_idx + residual_n_tokens - residual_count + residual_skip)
                               % residual_n_tokens;
 
+        // Fragments declared INSIDE the loop so they don't allocate registers
+        // for warps that skip the loop entirely (register pressure cuts kernel
+        // occupancy and slows the paged loop, which is the dominant cost at
+        // long context — verified via A/B at ctx=1024 vs 4096).
         for (int tile = warp_id; tile < n_tiles_r; tile += NUM_WARPS) {
+            using namespace nvcuda;
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, __half, wmma::row_major> a_frag;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, __half, wmma::col_major> b_frag;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, __half, wmma::row_major> b_frag_v;
+            wmma::fragment<wmma::accumulator, 16, 16, 16, __half> c_frag;
+            wmma::fragment<wmma::accumulator, 16, 16, 16, float> v_frag;
+
             const int tile_first = tile * 16;
             int tile_count = residual_active_count - tile_first;
             if (tile_count > 16) tile_count = 16;
@@ -409,8 +459,8 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
                     int hd_global = hd_off + hd_local;
                     if (t < tile_count) {
                         int slot = (slot_base + tile_first + t) % residual_n_tokens;
-                        sK_r[i] = K_residual[(int64_t)slot * slot_stride_res +
-                                             kv_head * kv_head_stride_res + hd_global];
+                        sK_r[i] = K_res_ptr[(int64_t)slot * slot_stride_res +
+                                            kv_head * kv_head_stride_res + hd_global];
                     } else {
                         sK_r[i] = __float2half(0.0f);
                     }
@@ -427,29 +477,54 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
             __syncwarp();
 
             // Block-softmax (mirrors paged loop's normalized-rescale invariant).
-            float dots_scaled[16];
-            float m_local = -FLT_MAX;
-#pragma unroll
-            for (int t = 0; t < 16; t++) {
-                float d = -FLT_MAX;
-                if (t < tile_count) {
-                    d = __half2float(sK_r[t]) * scale;
-                    d = apply_softcap(d, softcap);
-                    m_local = fmaxf(m_local, d);
-                }
-                dots_scaled[t] = d;
+            //
+            // dots and weights live in shared memory rather than per-thread
+            // register arrays. Per-thread `float[16]` forced a 64-byte stack
+            // spill (cuobjdump STACK:64 at HD>=128) that turned the residual
+            // pass into a 3× tg/s regression on the long-context decode path
+            // — every spilled access is a DRAM round-trip. With shared-mem
+            // tables, lanes 0..15 each compute one entry, the warp shfl-
+            // reduces for m_local / l_local, and the V-phase A-operand fill
+            // reads from shared memory instead of registers. Reuses the front
+            // 32 floats of sFV_r (which is 16×16=256 floats so plenty of room).
+            float* dots_smem = sFV_r;             // [16] floats per warp
+            float* weights_smem = sFV_r + 16;     // [16] floats per warp
+
+            const bool t_active = (lane_id < 16) && (lane_id < tile_count);
+            float my_dot = -FLT_MAX;
+            if (t_active) {
+                my_dot = __half2float(sK_r[lane_id]) * scale;
+                my_dot = apply_softcap(my_dot, softcap);
+            }
+            if (lane_id < 16) dots_smem[lane_id] = my_dot;
+            __syncwarp();
+
+            // Full 32-lane warp reduce so EVERY lane (including 16..31, which
+            // have my_dot = -FLT_MAX) sees the same m_local. Skipping the
+            // off=16 step would leave lanes 16..31 with m_local=-FLT_MAX,
+            // diverging the subsequent m_new / exp_diff / l_inv computation
+            // and corrupting the per-lane sQ_r weight fill (each lane writes
+            // some rows of the A operand; inconsistent l_inv → garbage WMMA).
+            float m_local = my_dot;
+            #pragma unroll
+            for (int off = 16; off > 0; off >>= 1) {
+                m_local = fmaxf(m_local, __shfl_xor_sync(0xffffffff, m_local, off));
             }
 
             float m_new = fmaxf(m_w, m_local);
             float exp_diff = (m_w == -FLT_MAX) ? 0.0f : __expf(m_w - m_new);
 
-            float weights[16];
-            float l_local = 0.0f;
-#pragma unroll
-            for (int t = 0; t < 16; t++) {
-                float w = (dots_scaled[t] > -FLT_MAX) ? __expf(dots_scaled[t] - m_new) : 0.0f;
-                weights[t] = w;
-                l_local += w;
+            float my_weight = 0.0f;
+            if (t_active && my_dot > -FLT_MAX) {
+                my_weight = __expf(my_dot - m_new);
+            }
+            if (lane_id < 16) weights_smem[lane_id] = my_weight;
+            __syncwarp();
+
+            float l_local = my_weight;
+            #pragma unroll
+            for (int off = 16; off > 0; off >>= 1) {
+                l_local += __shfl_xor_sync(0xffffffff, l_local, off);
             }
 
             float l_new = exp_diff * l_w + l_local;
@@ -462,10 +537,12 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
 #pragma unroll
             for (int i = 0; i < ELEMS; i++) o_reg[i] *= rescale_norm;
 
-            // Replicate normalized weights into sQ_r (A operand).
+            // Replicate normalized weights into sQ_r (A operand). Each lane
+            // reads its column's weight from shared mem — bank-conflict-free
+            // since 32 lanes broadcast-read 16 distinct addresses.
             for (int i = lane_id; i < 16 * 16; i += WARP_SIZE) {
                 int col = i % 16;
-                sQ_r[i] = __float2half(weights[col] * l_inv);
+                sQ_r[i] = __float2half(weights_smem[col] * l_inv);
             }
             __syncwarp();
 
@@ -484,8 +561,8 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
                     int hd_global = hd_off + hd_local;
                     if (t < tile_count) {
                         int slot = (slot_base + tile_first + t) % residual_n_tokens;
-                        sK_r[i] = V_residual[(int64_t)slot * slot_stride_res +
-                                             kv_head * kv_head_stride_res + hd_global];
+                        sK_r[i] = V_res_ptr[(int64_t)slot * slot_stride_res +
+                                            kv_head * kv_head_stride_res + hd_global];
                     } else {
                         sK_r[i] = __float2half(0.0f);
                     }
@@ -678,7 +755,10 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
                                   int sliding_window, float softcap, cudaStream_t stream,
                                   int max_blocks_per_seq, int n_sinks,
                                   const half* K_residual, const half* V_residual,
-                                  int residual_count, int residual_n_tokens, int residual_write_idx) {
+                                  int residual_count, int residual_n_tokens, int residual_write_idx,
+                                  const half* K_residual_base, const half* V_residual_base,
+                                  int residual_seq_stride_elems, const int* d_residual_seq_slots,
+                                  const int* d_residual_counts, const int* d_residual_write_idxes) {
     (void)n_sinks;  // streaming not yet wired
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int n_heads = static_cast<int>(Q.shape[2]);
@@ -688,10 +768,18 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
     const int max_num_blocks = (max_blocks_per_seq > 0) ? max_blocks_per_seq
                                                         : (max_context_len + block_size - 1) / block_size;
 
-    // Phase 3b: residual is single-sequence only and not wired into the
-    // split-K scaffold. Force non-split path when residual is active.
-    const bool residual_active = (K_residual != nullptr) && (V_residual != nullptr) &&
-                                 (residual_count > 0) && (residual_n_tokens > 0) && (batch_size == 1);
+    // Phase 3b: residual is not wired into the split-K scaffold.  Force
+    // non-split path when EITHER form is active. Multi-seq form is selected
+    // by d_residual_seq_slots != nullptr; single-seq scalar form requires
+    // K_residual && residual_count > 0 && batch_size == 1.
+    const bool residual_active_multiseq =
+        (d_residual_seq_slots != nullptr) && (K_residual_base != nullptr) &&
+        (V_residual_base != nullptr) && (residual_n_tokens > 0);
+    const bool residual_active_scalar =
+        (K_residual != nullptr) && (V_residual != nullptr) &&
+        (residual_count > 0) && (residual_n_tokens > 0) && (batch_size == 1) &&
+        !residual_active_multiseq;
+    const bool residual_active = residual_active_multiseq || residual_active_scalar;
 
     // BitDecoding TC variant adds NUM_WARPS * 2048 bytes of WMMA scratch
     // (16x16 sQ halves + 16x16 sK halves + 16x16 sFV floats per warp).
@@ -754,9 +842,17 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
         reinterpret_cast<const uint8_t*>(V_cache.data), K_scales, V_scales, reinterpret_cast<half*>(O.data),   \
         block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len,       \
         max_num_blocks, sliding_window, softcap,                                                               \
-        residual_active ? K_residual : nullptr, residual_active ? V_residual : nullptr,                        \
-        residual_active ? residual_count : 0, residual_active ? residual_n_tokens : 0,                         \
-        residual_active ? residual_write_idx : 0)
+        residual_active_scalar ? K_residual : nullptr,                                                         \
+        residual_active_scalar ? V_residual : nullptr,                                                         \
+        residual_active_scalar ? residual_count : 0,                                                           \
+        residual_active ? residual_n_tokens : 0,                                                               \
+        residual_active_scalar ? residual_write_idx : 0,                                                       \
+        residual_active_multiseq ? K_residual_base : nullptr,                                                  \
+        residual_active_multiseq ? V_residual_base : nullptr,                                                  \
+        residual_active_multiseq ? residual_seq_stride_elems : 0,                                              \
+        residual_active_multiseq ? d_residual_seq_slots : nullptr,                                             \
+        residual_active_multiseq ? d_residual_counts : nullptr,                                                \
+        residual_active_multiseq ? d_residual_write_idxes : nullptr)
 
         switch (head_dim) {
             case 64:

--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -749,6 +749,264 @@ __global__ void paged_attention_splitk_nvfp4_tc_kernel(
                                       num_splits, split_idx);
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3b residual + reduce kernel.
+//
+// Replaces `paged_attention_reduce_kernel` for the residual path. Reads the
+// per-split paged partials from `partial_out` (written by the existing splitk
+// paged kernel), processes the FP16 residual ring tokens, and emits the final
+// merged O.
+//
+// Why a fused kernel: profiling (nsys, 2026-05-09) showed the original Phase 3b
+// design — embed the residual pass into the non-splitk decode kernel — forced
+// the launcher onto the slow non-splitk path (414 µs/call vs splitk at 33
+// µs/call, 12× regression). Letting splitk run normally and folding residual
+// into the reduce kernel preserves the splitk parallelism while still matching
+// the residual-FP16 contribution.
+//
+// Math (write-through residual: paged contains all tokens, residual contains
+// the same tail tokens at higher precision):
+//   m_paged   = max over paged splits of m_s
+//   l_paged   = sum_s exp(m_s - m_paged) * l_s
+//   O_paged_unnorm[d] = sum_s exp(m_s - m_paged) * partial_out[s, 2+d]
+//                     = sum over all paged tokens of exp(d_t - m_paged) V_t
+//   m_res, l_res, O_res_unnorm[d]: same accumulation over residual tokens.
+//   m_global  = max(m_paged, m_res)
+//   l_global  = exp(m_paged - m_global) * l_paged + exp(m_res - m_global) * l_res
+//   O_final[d] = (exp(m_paged - m_global) * O_paged_unnorm[d] +
+//                 exp(m_res - m_global) * O_res_unnorm[d]) / l_global
+//
+// One block per (batch, head). NUM_WARPS warps cooperatively process the
+// residual tokens (round-robin); thread 0 reduces paged partials.
+// ---------------------------------------------------------------------------
+template <int HEAD_DIM>
+__global__ void paged_attention_residual_reduce_kernel(
+    const float* __restrict__ partial_out,           // [b, h, num_paged_splits, 2+HD]
+    const half* __restrict__ Q,                      // [b, 1, n_heads, hd]
+    half* __restrict__ O,                            // [b, 1, n_heads, hd]
+    const int* __restrict__ context_lens,            // [b]
+    int n_heads, int n_kv_heads, int num_paged_splits,
+    float scale, int sliding_window, float softcap,
+    int residual_n_tokens,
+    // Single-seq scalar form (active when d_residual_seq_slots == nullptr):
+    const half* __restrict__ K_residual,
+    const half* __restrict__ V_residual,
+    int residual_count_scalar, int residual_write_idx_scalar,
+    // Multi-seq array form:
+    const half* __restrict__ K_residual_base,
+    const half* __restrict__ V_residual_base,
+    int residual_seq_stride_elems,
+    const int* __restrict__ d_residual_seq_slots,
+    const int* __restrict__ d_residual_counts,
+    const int* __restrict__ d_residual_write_idxes) {
+    static_assert(HEAD_DIM % WARP_SIZE == 0, "HEAD_DIM must be divisible by WARP_SIZE");
+    constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
+    constexpr int partial_stride = 2 + HEAD_DIM;
+
+    const int batch_idx = blockIdx.x;
+    const int head_idx = blockIdx.y;
+    const int kv_head = head_idx / (n_heads / n_kv_heads);
+
+    const int ctx_len = context_lens[batch_idx];
+    if (ctx_len <= 0) return;
+
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    const int lane_offset = lane_id * ELEMS;
+
+    // Resolve residual data (single-seq scalar OR multi-seq array form).
+    const half* K_res = nullptr;
+    const half* V_res = nullptr;
+    int rc = 0, rwi = 0;
+    if (d_residual_seq_slots != nullptr && K_residual_base != nullptr && residual_n_tokens > 0) {
+        int slot = d_residual_seq_slots[batch_idx];
+        int rc_b = (d_residual_counts != nullptr) ? d_residual_counts[batch_idx] : 0;
+        int rw_b = (d_residual_write_idxes != nullptr) ? d_residual_write_idxes[batch_idx] : 0;
+        if (slot >= 0 && rc_b > 0) {
+            K_res = K_residual_base + (int64_t)slot * residual_seq_stride_elems;
+            V_res = V_residual_base + (int64_t)slot * residual_seq_stride_elems;
+            rc = rc_b;
+            rwi = rw_b;
+        }
+    } else if (K_residual != nullptr && V_residual != nullptr && residual_count_scalar > 0 &&
+               residual_n_tokens > 0) {
+        K_res = K_residual;
+        V_res = V_residual;
+        rc = residual_count_scalar;
+        rwi = residual_write_idx_scalar;
+    }
+
+    int effective_start = 0;
+    if (sliding_window > 0 && ctx_len > sliding_window)
+        effective_start = ctx_len - sliding_window;
+    int res_active = 0;
+    int res_skip = 0;
+    if (K_res != nullptr) {
+        int rh = (rc > ctx_len) ? ctx_len : rc;
+        int rcf = ctx_len - rh;
+        int rfa = (effective_start > rcf) ? effective_start : rcf;
+        res_active = ctx_len - rfa;
+        res_skip = rh - res_active;
+        if (res_active < 0) res_active = 0;
+    }
+
+    // Step 1: compute (m_paged, l_paged) from per-split partials. Single-thread
+    // reduction over a small (≤ 32) split count — same pattern as the standard
+    // reduce kernel.
+    const float* paged_base = partial_out +
+        (int64_t)((batch_idx * n_heads + head_idx) * num_paged_splits) * partial_stride;
+
+    __shared__ float s_m_paged;
+    __shared__ float s_l_paged;
+    __shared__ float s_m_res;
+    __shared__ float s_l_res;
+
+    if (threadIdx.x == 0) {
+        float gmax = -FLT_MAX;
+        for (int s = 0; s < num_paged_splits; s++) {
+            gmax = fmaxf(gmax, paged_base[s * partial_stride]);
+        }
+        s_m_paged = gmax;
+        float gl = 0.0f;
+        for (int s = 0; s < num_paged_splits; s++) {
+            float m = paged_base[s * partial_stride];
+            float l = paged_base[s * partial_stride + 1];
+            gl += expf(m - gmax) * l;
+        }
+        s_l_paged = gl;
+    }
+    __syncthreads();
+
+    const float m_paged = s_m_paged;
+    const float l_paged = s_l_paged;
+
+    // Step 2: process residual tokens. Round-robin distribution across warps;
+    // each warp tracks its own (m_w, l_w, o_reg) state.
+    extern __shared__ char smem_red[];
+    float* warp_max = reinterpret_cast<float*>(smem_red);   // [NUM_WARPS]
+    float* warp_l   = warp_max + NUM_WARPS;                  // [NUM_WARPS]
+    float* warp_o   = warp_l + NUM_WARPS;                    // [NUM_WARPS * HEAD_DIM]
+
+    if (res_active > 0) {
+        const half* Q_ptr = Q + (int64_t)batch_idx * n_heads * HEAD_DIM + (int64_t)head_idx * HEAD_DIM;
+        float q_reg[ELEMS];
+        const half2* Q_ptr2 = reinterpret_cast<const half2*>(Q_ptr + lane_offset);
+#pragma unroll
+        for (int i = 0; i < ELEMS / 2; i++) {
+            half2 h2 = Q_ptr2[i];
+            q_reg[2 * i] = __half2float(h2.x);
+            q_reg[2 * i + 1] = __half2float(h2.y);
+        }
+
+        const int slot_stride = n_kv_heads * HEAD_DIM;
+        const int sb = (rwi + residual_n_tokens - rc + res_skip) % residual_n_tokens;
+
+        float m_w = -FLT_MAX;
+        float l_w = 0.0f;
+        float o_reg[ELEMS];
+#pragma unroll
+        for (int i = 0; i < ELEMS; i++) o_reg[i] = 0.0f;
+
+        for (int t = warp_id; t < res_active; t += NUM_WARPS) {
+            int slot = (sb + t) % residual_n_tokens;
+            const half* K_tok = K_res + (int64_t)slot * slot_stride + kv_head * HEAD_DIM;
+            const half* V_tok = V_res + (int64_t)slot * slot_stride + kv_head * HEAD_DIM;
+
+            float dot = 0.0f;
+            const half2* k_h2 = reinterpret_cast<const half2*>(K_tok + lane_offset);
+#pragma unroll
+            for (int i = 0; i < ELEMS / 2; i++) {
+                half2 kh = k_h2[i];
+                float2 kf = __half22float2(kh);
+                dot = __fmaf_rn(q_reg[2 * i], kf.x, dot);
+                dot = __fmaf_rn(q_reg[2 * i + 1], kf.y, dot);
+            }
+            dot = warp_reduce_sum(dot);
+            dot *= scale;
+            dot = apply_softcap(dot, softcap);
+
+            float rescale, w_new;
+            online_softmax_step(dot, m_w, l_w, rescale, w_new);
+
+            const half2* v_h2 = reinterpret_cast<const half2*>(V_tok + lane_offset);
+#pragma unroll
+            for (int i = 0; i < ELEMS / 2; i++) {
+                half2 vh = v_h2[i];
+                float2 vf = __half22float2(vh);
+                o_reg[2 * i] = __fmaf_rn(w_new, vf.x, rescale * o_reg[2 * i]);
+                o_reg[2 * i + 1] = __fmaf_rn(w_new, vf.y, rescale * o_reg[2 * i + 1]);
+            }
+        }
+
+        // Stash per-warp (m, l, o) into smem.
+        if (lane_id == 0) {
+            warp_max[warp_id] = m_w;
+            warp_l[warp_id] = l_w;
+        }
+#pragma unroll
+        for (int i = 0; i < ELEMS; i++)
+            warp_o[warp_id * HEAD_DIM + lane_offset + i] = o_reg[i];
+        __syncthreads();
+
+        if (threadIdx.x == 0) {
+            float m_global = -FLT_MAX;
+            for (int w = 0; w < NUM_WARPS; w++) m_global = fmaxf(m_global, warp_max[w]);
+            float l_global = 0.0f;
+            for (int w = 0; w < NUM_WARPS; w++)
+                l_global += expf(warp_max[w] - m_global) * warp_l[w];
+            s_m_res = m_global;
+            s_l_res = l_global;
+        }
+    } else {
+        if (threadIdx.x == 0) {
+            s_m_res = -FLT_MAX;
+            s_l_res = 0.0f;
+        }
+    }
+    __syncthreads();
+
+    const float m_res = s_m_res;
+    const float l_res = s_l_res;
+
+    // Step 3: combined merge (paged + residual) per dim, parallelized across threads.
+    float m_global, w_paged, w_res, inv_l;
+    if (res_active > 0) {
+        m_global = fmaxf(m_paged, m_res);
+        w_paged = expf(m_paged - m_global);
+        w_res = expf(m_res - m_global);
+        float l_global = w_paged * l_paged + w_res * l_res;
+        inv_l = (l_global > 0.0f) ? (1.0f / l_global) : 0.0f;
+    } else {
+        m_global = m_paged;
+        w_paged = 1.0f;
+        w_res = 0.0f;
+        inv_l = (l_paged > 0.0f) ? (1.0f / l_paged) : 0.0f;
+    }
+
+    for (int d = threadIdx.x; d < HEAD_DIM; d += blockDim.x) {
+        // Aggregate paged partials at m_paged basis: sum_s exp(m_s - m_paged) * partial[s, 2+d]
+        float o_paged_unnorm = 0.0f;
+        for (int s = 0; s < num_paged_splits; s++) {
+            float m_s = paged_base[s * partial_stride];
+            float weight_s = expf(m_s - m_paged);
+            o_paged_unnorm += weight_s * paged_base[s * partial_stride + 2 + d];
+        }
+
+        // Aggregate residual partials at m_res basis: sum_w exp(m_w - m_res) * l_w * warp_o[w, d]
+        float o_res_unnorm = 0.0f;
+        if (res_active > 0) {
+            for (int w = 0; w < NUM_WARPS; w++) {
+                float weight_w = expf(warp_max[w] - m_res) * warp_l[w];
+                o_res_unnorm += weight_w * warp_o[w * HEAD_DIM + d];
+            }
+        }
+
+        float final_o = inv_l * (w_paged * o_paged_unnorm + w_res * o_res_unnorm);
+        int out_idx = batch_idx * n_heads * HEAD_DIM + head_idx * HEAD_DIM + d;
+        O[out_idx] = __float2half(final_o);
+    }
+}
+
 // Note: a pipelined splitk variant (double-buffered K + V via smem, mirroring
 // `paged_attention_splitk_int4_pipeline_kernel`) was tested 2026-05-08 and
 // regressed Qwen3-8B Q8 + NVFP4 KV decode by ~3% (147.0 → 142.7 tok/s,
@@ -807,11 +1065,23 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
     void* scratch_ptr = nullptr;
     int num_splits = compute_splitk_splits(batch_size, n_heads, head_dim, max_context_len, block_size,
                                            &scratch_ptr);
-    if (residual_active) {
-        num_splits = 1;  // residual ring read only wired in non-split kernel
-    }
 
-    if (num_splits > 1) {
+    // Residual path: ALWAYS use splitk + residual_reduce_kernel even if
+    // compute_splitk_splits returned 1. Embedding the residual pass into the
+    // non-splitk decode kernel was the previous design and forced a 12× slow
+    // path (414 µs/call vs splitk at 33 µs/call) per nsys profile (2026-05-09).
+    // The splitk paged kernel runs unmodified (writes per-split partials);
+    // residual_reduce_kernel folds in the FP16 residual contribution as part
+    // of the reduce. Requires scratch_ptr to be allocated — caller (engine
+    // workspace) provides this when NVFP4 KV is enabled.
+    if (residual_active && scratch_ptr == nullptr) {
+        IMP_LOG_WARN("paged_attention_decode_nvfp4_tc: residual active but no splitk "
+                     "scratch — falling back to non-splitk path (slow)");
+    }
+    const bool use_residual_reduce = residual_active && scratch_ptr != nullptr;
+    if (use_residual_reduce && num_splits < 1) num_splits = 1;
+
+    if (num_splits > 1 || use_residual_reduce) {
         float* partial = static_cast<float*>(scratch_ptr);
         dim3 grid1(batch_size, n_heads, num_splits);
         dim3 block1(BLOCK_THREADS);
@@ -844,8 +1114,44 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
         }
 #undef LAUNCH_SPLITK_NVFP4
 
-        paged_attention_launch_reduce(partial, reinterpret_cast<half*>(O.data), batch_size, n_heads, head_dim,
-                                      num_splits, stream);
+        if (use_residual_reduce) {
+            // Combined paged-reduce + residual-merge. Smem layout:
+            //   warp_max[NUM_WARPS] + warp_l[NUM_WARPS] + warp_o[NUM_WARPS * HEAD_DIM] floats.
+            const size_t reduce_smem =
+                NUM_WARPS * sizeof(float) + NUM_WARPS * sizeof(float) +
+                NUM_WARPS * head_dim * sizeof(float);
+            dim3 grid_red(batch_size, n_heads);
+            dim3 block_red(BLOCK_THREADS);
+
+#define LAUNCH_RESIDUAL_REDUCE(HD)                                                                            \
+    paged_attention_residual_reduce_kernel<HD><<<grid_red, block_red, reduce_smem, stream>>>(                 \
+        partial, reinterpret_cast<const half*>(Q.data), reinterpret_cast<half*>(O.data),                      \
+        context_lens, n_heads, n_kv_heads, num_splits, scale, sliding_window, softcap,                        \
+        residual_n_tokens,                                                                                    \
+        residual_active_scalar ? K_residual : nullptr,                                                        \
+        residual_active_scalar ? V_residual : nullptr,                                                        \
+        residual_active_scalar ? residual_count : 0,                                                          \
+        residual_active_scalar ? residual_write_idx : 0,                                                      \
+        residual_active_multiseq ? K_residual_base : nullptr,                                                 \
+        residual_active_multiseq ? V_residual_base : nullptr,                                                 \
+        residual_active_multiseq ? residual_seq_stride_elems : 0,                                             \
+        residual_active_multiseq ? d_residual_seq_slots : nullptr,                                            \
+        residual_active_multiseq ? d_residual_counts : nullptr,                                               \
+        residual_active_multiseq ? d_residual_write_idxes : nullptr)
+            switch (head_dim) {
+                case 64:  LAUNCH_RESIDUAL_REDUCE(64);  break;
+                case 128: LAUNCH_RESIDUAL_REDUCE(128); break;
+                case 256: LAUNCH_RESIDUAL_REDUCE(256); break;
+                case 512: LAUNCH_RESIDUAL_REDUCE(512); break;
+                default:
+                    IMP_LOG_ERROR("paged_attention_residual_reduce: unsupported head_dim %d", head_dim);
+                    return;
+            }
+#undef LAUNCH_RESIDUAL_REDUCE
+        } else {
+            paged_attention_launch_reduce(partial, reinterpret_cast<half*>(O.data), batch_size, n_heads,
+                                          head_dim, num_splits, stream);
+        }
     } else {
         dim3 grid(batch_size, n_heads);
         dim3 block(BLOCK_THREADS);

--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -59,7 +59,12 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
     const uint8_t* __restrict__ V_scales,   // UE4M3 per group
     half* __restrict__ O, const int* __restrict__ block_tables,
     const int* __restrict__ context_lens, int batch_size, int n_heads, int n_kv_heads, int block_size,
-    float scale, int max_context_len, int max_num_blocks, int sliding_window, float softcap) {
+    float scale, int max_context_len, int max_num_blocks, int sliding_window, float softcap,
+    // Phase 3b residual args. Active when K_residual != nullptr && residual_count > 0.
+    // Pointer points to the (seq, layer) slice; layout
+    //   [residual_n_tokens, n_kv_heads, head_dim] FP16 (ring-indexed).
+    const half* __restrict__ K_residual, const half* __restrict__ V_residual,
+    int residual_count, int residual_n_tokens, int residual_write_idx) {
     static_assert(HEAD_DIM % WARP_SIZE == 0, "HEAD_DIM must be divisible by WARP_SIZE");
     static_assert(HEAD_DIM % 16 == 0, "HEAD_DIM must be divisible by 16 (NVFP4 group size)");
     constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
@@ -108,8 +113,29 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
     int effective_start = 0;
     if (sliding_window > 0 && ctx_len > sliding_window)
         effective_start = ctx_len - sliding_window;
+
+    // Phase 3b: split absolute KV range into paged-tail-clipped + residual.
+    // residual_active: residual ring is enabled AND has at least one entry that
+    // falls within ctx_len AND falls within effective_start..ctx_len window.
+    const bool residual_have = (K_residual != nullptr) && (V_residual != nullptr) &&
+                               (residual_n_tokens > 0) && (residual_count > 0);
+    int residual_active_count = 0;
+    int residual_first_abs = ctx_len;  // start of residual chronological range
+    int residual_skip = 0;             // chronologically-stale residual entries to skip
+    if (residual_have) {
+        int res_have = residual_count;
+        if (res_have > ctx_len) res_have = ctx_len;
+        int res_chrono_first = ctx_len - res_have;
+        residual_first_abs = (effective_start > res_chrono_first) ? effective_start : res_chrono_first;
+        residual_active_count = ctx_len - residual_first_abs;
+        residual_skip = res_have - residual_active_count;
+        if (residual_active_count <= 0) {
+            residual_active_count = 0;  // window excludes all residual entries
+        }
+    }
+    const int paged_end_token = ctx_len - residual_active_count;
     const int first_block = effective_start / block_size;
-    const int num_ctx_blocks = (ctx_len + block_size - 1) / block_size;
+    const int num_paged_blocks = (paged_end_token + block_size - 1) / block_size;
 
     float m_w = -FLT_MAX;
     float l_w = 0.0f;
@@ -118,7 +144,7 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
     for (int i = 0; i < ELEMS; i++)
         o_reg[i] = 0.0f;
 
-    for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
+    for (int blk = first_block + warp_id; blk < num_paged_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
@@ -127,8 +153,8 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
 
         int tok_start = blk * block_size;
         int tok_end = tok_start + block_size;
-        if (tok_end > ctx_len)
-            tok_end = ctx_len;
+        if (tok_end > paged_end_token)
+            tok_end = paged_end_token;
 
         int first_tok = 0;
         if (tok_start < effective_start)
@@ -325,6 +351,165 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
         }
     }
 
+    // ------------------------------------------------------------------
+    // Phase 3b: residual FP16 pass over the newest `residual_active_count`
+    // tokens. Same WMMA QK + block-softmax + WMMA V structure as the paged
+    // loop, but reads K/V directly as FP16 from the residual ring (no FP4
+    // dequant, no UE4M3 fold). Tiles distribute round-robin across warps;
+    // each warp's m_w/l_w/o_reg evolves independently and the cross-warp
+    // reduce later integrates them correctly.
+    //
+    // Ring slot for chronological position i in the active range:
+    //   slot = (residual_write_idx + residual_n_tokens - residual_count
+    //          + residual_skip + i) % residual_n_tokens
+    // ------------------------------------------------------------------
+    if (residual_active_count > 0) {
+        const int kv_head_stride_res = HEAD_DIM;            // FP16 elems per (slot, kv_head)
+        const int slot_stride_res = n_kv_heads * HEAD_DIM;  // FP16 elems per slot
+
+        // Per-warp scratch (same layout as paged path)
+        __half* sQ_r = tc_smem + warp_id * WARP_TC_HALVES;
+        __half* sK_r = sQ_r + 16 * 16;
+        float*  sFV_r = reinterpret_cast<float*>(sK_r + 16 * 16);
+
+        constexpr int K_TILES_R = HEAD_DIM / 16;
+
+        using namespace nvcuda;
+        wmma::fragment<wmma::matrix_a, 16, 16, 16, __half, wmma::row_major> a_frag;
+        wmma::fragment<wmma::matrix_b, 16, 16, 16, __half, wmma::col_major> b_frag;
+        wmma::fragment<wmma::matrix_b, 16, 16, 16, __half, wmma::row_major> b_frag_v;
+        wmma::fragment<wmma::accumulator, 16, 16, 16, __half> c_frag;
+        wmma::fragment<wmma::accumulator, 16, 16, 16, float> v_frag;
+
+        const int n_tiles_r = (residual_active_count + 15) / 16;
+        const int slot_base = (residual_write_idx + residual_n_tokens - residual_count + residual_skip)
+                              % residual_n_tokens;
+
+        for (int tile = warp_id; tile < n_tiles_r; tile += NUM_WARPS) {
+            const int tile_first = tile * 16;
+            int tile_count = residual_active_count - tile_first;
+            if (tile_count > 16) tile_count = 16;
+
+            wmma::fill_fragment(c_frag, __float2half(0.0f));
+
+#pragma unroll
+            for (int k_tile = 0; k_tile < K_TILES_R; k_tile++) {
+                const int hd_off = k_tile * 16;
+
+                // Replicate Q[hd_off..hd_off+16] across all 16 rows of sQ_r.
+                for (int i = lane_id; i < 16 * 16; i += WARP_SIZE) {
+                    int col = i % 16;
+                    sQ_r[i] = Q_ptr[hd_off + col];
+                }
+
+                // Load FP16 K from residual ring. Out-of-tile slots → 0.
+                for (int i = lane_id; i < 16 * 16; i += WARP_SIZE) {
+                    int t = i / 16;
+                    int hd_local = i % 16;
+                    int hd_global = hd_off + hd_local;
+                    if (t < tile_count) {
+                        int slot = (slot_base + tile_first + t) % residual_n_tokens;
+                        sK_r[i] = K_residual[(int64_t)slot * slot_stride_res +
+                                             kv_head * kv_head_stride_res + hd_global];
+                    } else {
+                        sK_r[i] = __float2half(0.0f);
+                    }
+                }
+                __syncwarp();
+
+                wmma::load_matrix_sync(a_frag, sQ_r, 16);
+                wmma::load_matrix_sync(b_frag, sK_r, 16);
+                wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);
+                __syncwarp();
+            }
+
+            wmma::store_matrix_sync(sK_r, c_frag, 16, wmma::mem_row_major);
+            __syncwarp();
+
+            // Block-softmax (mirrors paged loop's normalized-rescale invariant).
+            float dots_scaled[16];
+            float m_local = -FLT_MAX;
+#pragma unroll
+            for (int t = 0; t < 16; t++) {
+                float d = -FLT_MAX;
+                if (t < tile_count) {
+                    d = __half2float(sK_r[t]) * scale;
+                    d = apply_softcap(d, softcap);
+                    m_local = fmaxf(m_local, d);
+                }
+                dots_scaled[t] = d;
+            }
+
+            float m_new = fmaxf(m_w, m_local);
+            float exp_diff = (m_w == -FLT_MAX) ? 0.0f : __expf(m_w - m_new);
+
+            float weights[16];
+            float l_local = 0.0f;
+#pragma unroll
+            for (int t = 0; t < 16; t++) {
+                float w = (dots_scaled[t] > -FLT_MAX) ? __expf(dots_scaled[t] - m_new) : 0.0f;
+                weights[t] = w;
+                l_local += w;
+            }
+
+            float l_new = exp_diff * l_w + l_local;
+            float rescale_norm = (l_new > 0.0f) ? (exp_diff * l_w / l_new) : 0.0f;
+            float l_inv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
+
+            m_w = m_new;
+            l_w = l_new;
+
+#pragma unroll
+            for (int i = 0; i < ELEMS; i++) o_reg[i] *= rescale_norm;
+
+            // Replicate normalized weights into sQ_r (A operand).
+            for (int i = lane_id; i < 16 * 16; i += WARP_SIZE) {
+                int col = i % 16;
+                sQ_r[i] = __float2half(weights[col] * l_inv);
+            }
+            __syncwarp();
+
+            constexpr int LANES_PER_CHUNK_R = (16 / ELEMS) > 0 ? (16 / ELEMS) : 1;
+            const int my_chunk_r = lane_id / LANES_PER_CHUNK_R;
+            const int my_offset_in_chunk_r = (lane_id % LANES_PER_CHUNK_R) * ELEMS;
+
+#pragma unroll
+            for (int kt = 0; kt < K_TILES_R; kt++) {
+                const int hd_off = kt * 16;
+
+                // Load FP16 V from residual ring.
+                for (int i = lane_id; i < 16 * 16; i += WARP_SIZE) {
+                    int t = i / 16;
+                    int hd_local = i % 16;
+                    int hd_global = hd_off + hd_local;
+                    if (t < tile_count) {
+                        int slot = (slot_base + tile_first + t) % residual_n_tokens;
+                        sK_r[i] = V_residual[(int64_t)slot * slot_stride_res +
+                                             kv_head * kv_head_stride_res + hd_global];
+                    } else {
+                        sK_r[i] = __float2half(0.0f);
+                    }
+                }
+                __syncwarp();
+
+                wmma::fill_fragment(v_frag, 0.0f);
+                wmma::load_matrix_sync(a_frag, sQ_r, 16);
+                wmma::load_matrix_sync(b_frag_v, sK_r, 16);
+                wmma::mma_sync(v_frag, a_frag, b_frag_v, v_frag);
+                wmma::store_matrix_sync(sFV_r, v_frag, 16, wmma::mem_row_major);
+                __syncwarp();
+
+                if (my_chunk_r == kt) {
+#pragma unroll
+                    for (int e = 0; e < ELEMS; e++) {
+                        o_reg[e] += sFV_r[my_offset_in_chunk_r + e];
+                    }
+                }
+                __syncwarp();
+            }
+        }
+    }
+
     // crosswarp reduce smem starts AFTER the per-warp TC scratch region
     // (NUM_WARPS * WARP_TC_HALVES halves = NUM_WARPS * 1024 bytes).
     char* crosswarp_smem = tc_smem_raw + NUM_WARPS * WARP_TC_HALVES * sizeof(__half);
@@ -491,7 +676,9 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
                                   const uint8_t* K_scales, const uint8_t* V_scales, const int* block_tables,
                                   const int* context_lens, int block_size, float scale, int max_context_len,
                                   int sliding_window, float softcap, cudaStream_t stream,
-                                  int max_blocks_per_seq, int n_sinks) {
+                                  int max_blocks_per_seq, int n_sinks,
+                                  const half* K_residual, const half* V_residual,
+                                  int residual_count, int residual_n_tokens, int residual_write_idx) {
     (void)n_sinks;  // streaming not yet wired
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int n_heads = static_cast<int>(Q.shape[2]);
@@ -500,6 +687,11 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
 
     const int max_num_blocks = (max_blocks_per_seq > 0) ? max_blocks_per_seq
                                                         : (max_context_len + block_size - 1) / block_size;
+
+    // Phase 3b: residual is single-sequence only and not wired into the
+    // split-K scaffold. Force non-split path when residual is active.
+    const bool residual_active = (K_residual != nullptr) && (V_residual != nullptr) &&
+                                 (residual_count > 0) && (residual_n_tokens > 0) && (batch_size == 1);
 
     // BitDecoding TC variant adds NUM_WARPS * 2048 bytes of WMMA scratch
     // (16x16 sQ halves + 16x16 sK halves + 16x16 sFV floats per warp).
@@ -513,6 +705,9 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
     void* scratch_ptr = nullptr;
     int num_splits = compute_splitk_splits(batch_size, n_heads, head_dim, max_context_len, block_size,
                                            &scratch_ptr);
+    if (residual_active) {
+        num_splits = 1;  // residual ring read only wired in non-split kernel
+    }
 
     if (num_splits > 1) {
         float* partial = static_cast<float*>(scratch_ptr);
@@ -553,12 +748,15 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
         dim3 grid(batch_size, n_heads);
         dim3 block(BLOCK_THREADS);
 
-#define LAUNCH_NVFP4(HD)                                                                                     \
-    paged_attention_decode_nvfp4_tc_kernel<HD><<<grid, block, smem_bytes, stream>>>(                            \
-        reinterpret_cast<const half*>(Q.data), reinterpret_cast<const uint8_t*>(K_cache.data),               \
-        reinterpret_cast<const uint8_t*>(V_cache.data), K_scales, V_scales, reinterpret_cast<half*>(O.data), \
-        block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len,     \
-        max_num_blocks, sliding_window, softcap)
+#define LAUNCH_NVFP4(HD)                                                                                       \
+    paged_attention_decode_nvfp4_tc_kernel<HD><<<grid, block, smem_bytes, stream>>>(                              \
+        reinterpret_cast<const half*>(Q.data), reinterpret_cast<const uint8_t*>(K_cache.data),                 \
+        reinterpret_cast<const uint8_t*>(V_cache.data), K_scales, V_scales, reinterpret_cast<half*>(O.data),   \
+        block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len,       \
+        max_num_blocks, sliding_window, softcap,                                                               \
+        residual_active ? K_residual : nullptr, residual_active ? V_residual : nullptr,                        \
+        residual_active ? residual_count : 0, residual_active ? residual_n_tokens : 0,                         \
+        residual_active ? residual_write_idx : 0)
 
         switch (head_dim) {
             case 64:

--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -127,13 +127,28 @@ struct InferenceState {
     class GDNState* gdn_state = nullptr;
     int gdn_seq_id = 0;
 
-    // BitDecoding Phase 3 residual KV cache: per-sequence ring buffer of the
-    // newest-N FP16 KV entries. -1 = disabled. Single-sequence only — multi-seq
-    // batch decode bypasses the residual pass even when this is set.
+    // BitDecoding Phase 3 residual KV cache.
+    //
+    // Two activation modes: single-seq scalar OR multi-seq array. The
+    // attention dispatcher prefers the multi-seq form whenever the engine
+    // sets up the device arrays (see d_residual_seq_slots below).
+    //
+    // Single-seq mode (legacy / batch_size==1):
+    //   `kv_seq_id` carries the seq_id (= request id) used to look up the
+    //   ring state via KVCacheManager. -1 disables.
     int kv_seq_id = -1;
-    // KVCacheManager owning the residual buffer + ring-state map. Set when
-    // kv_seq_id >= 0 to give the executor access to residual_k_ptr / advance_residual.
+    // KVCacheManager owning the residual buffer + ring-state map.
     class KVCacheManager* kv_manager = nullptr;
+    // Multi-seq array form: device pointers to per-batch metadata, all of
+    // length n_sequences. Built by the engine on each forward step before
+    // the attention call. Each element matches the corresponding row of
+    // block_tables / context_lens. nullptr = multi-seq form inactive.
+    const int* d_residual_seq_slots = nullptr;     // [n_sequences] slot in [0, residual_max_seqs)
+    const int* d_residual_counts = nullptr;         // [n_sequences] fill_count
+    const int* d_residual_write_idxes = nullptr;    // [n_sequences] write_idx
+    // Host array of per-batch seq_ids (request ids), used by the KV write path
+    // to call KVCacheManager::advance_residual per seq. Length = n_sequences.
+    const int* h_residual_seq_ids = nullptr;
 
     // Batching
     int n_sequences = 1;         // number of sequences in the batch

--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -127,6 +127,14 @@ struct InferenceState {
     class GDNState* gdn_state = nullptr;
     int gdn_seq_id = 0;
 
+    // BitDecoding Phase 3 residual KV cache: per-sequence ring buffer of the
+    // newest-N FP16 KV entries. -1 = disabled. Single-sequence only — multi-seq
+    // batch decode bypasses the residual pass even when this is set.
+    int kv_seq_id = -1;
+    // KVCacheManager owning the residual buffer + ring-state map. Set when
+    // kv_seq_id >= 0 to give the executor access to residual_k_ptr / advance_residual.
+    class KVCacheManager* kv_manager = nullptr;
+
     // Batching
     int n_sequences = 1;         // number of sequences in the batch
     int max_blocks_per_seq = 0;  // max blocks per sequence (for 2D block_table indexing)

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -1002,25 +1002,44 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 return env && env[0] == '1';
             }();
             if (use_bitdecoding_tc) {
-                // Phase 3b residual read: single-sequence only, gated on
-                // KVCacheManager having an enabled residual buffer AND state
-                // exposing a non-negative kv_seq_id. Multi-seq batch decode
-                // bypasses by passing nullptr/0.
+                // Phase 3b residual read. Two activation paths:
+                //   (multi-seq) state.d_residual_seq_slots != nullptr: kernel
+                //     reads per-batch metadata from the device arrays. Used by
+                //     batched decode.
+                //   (single-seq legacy) state.kv_seq_id >= 0: kernel uses the
+                //     scalar form. Used by single-seq decode that hasn't been
+                //     migrated to the array form (e.g. early-init smoke).
                 const half* k_res = nullptr;
                 const half* v_res = nullptr;
                 int res_count = 0;
                 int res_n = 0;
                 int res_widx = 0;
-                if (state.kv_manager != nullptr && state.kv_manager->residual_enabled() &&
-                    state.n_sequences == 1 && state.kv_seq_id >= 0) {
-                    k_res = static_cast<const half*>(
-                        state.kv_manager->residual_k_ptr(state.kv_seq_id, kv_layer));
-                    v_res = static_cast<const half*>(
-                        state.kv_manager->residual_v_ptr(state.kv_seq_id, kv_layer));
-                    auto rs = state.kv_manager->residual_state(state.kv_seq_id);
-                    res_count = rs.fill_count;
+                const half* k_res_base = nullptr;
+                const half* v_res_base = nullptr;
+                int res_seq_stride_elems = 0;
+
+                const bool residual_on = state.kv_manager != nullptr &&
+                                         state.kv_manager->residual_enabled();
+                if (residual_on) {
                     res_n = state.kv_manager->residual_n_tokens();
-                    res_widx = rs.write_idx;
+                    if (state.d_residual_seq_slots != nullptr) {
+                        // Multi-seq array form
+                        k_res_base = static_cast<const half*>(
+                            state.kv_manager->residual_k_layer_base(kv_layer));
+                        v_res_base = static_cast<const half*>(
+                            state.kv_manager->residual_v_layer_base(kv_layer));
+                        res_seq_stride_elems = static_cast<int>(
+                            state.kv_manager->residual_seq_stride_bytes() / sizeof(__half));
+                    } else if (state.n_sequences == 1 && state.kv_seq_id >= 0) {
+                        // Single-seq scalar form
+                        k_res = static_cast<const half*>(
+                            state.kv_manager->residual_k_ptr(state.kv_seq_id, kv_layer));
+                        v_res = static_cast<const half*>(
+                            state.kv_manager->residual_v_ptr(state.kv_seq_id, kv_layer));
+                        auto rs = state.kv_manager->residual_state(state.kv_seq_id);
+                        res_count = rs.fill_count;
+                        res_widx = rs.write_idx;
+                    }
                 }
                 paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4,
                                                 static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
@@ -1028,7 +1047,11 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                                 state.block_tables, state.context_lens, kv_bs, scale,
                                                 state.max_context_len, layer_sliding_window,
                                                 cfg.attn_logit_softcap, stream, state.max_blocks_per_seq, 0,
-                                                k_res, v_res, res_count, res_n, res_widx);
+                                                k_res, v_res, res_count, res_n, res_widx,
+                                                k_res_base, v_res_base, res_seq_stride_elems,
+                                                state.d_residual_seq_slots,
+                                                state.d_residual_counts,
+                                                state.d_residual_write_idxes);
             } else {
                 paged_attention_decode_nvfp4(q4, k_c, v_c, o4,
                                              static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -1,6 +1,7 @@
 #include "graph/executor.h"
 #include "graph/executor_kernels.h"
 #include "graph/executor_helpers.h"
+#include "memory/kv_cache_manager.h"
 #include "graph/executor_gemv_helpers.h"
 #include "graph/executor_debug.h"
 #include "graph/gemm_context.h"
@@ -1001,12 +1002,33 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 return env && env[0] == '1';
             }();
             if (use_bitdecoding_tc) {
+                // Phase 3b residual read: single-sequence only, gated on
+                // KVCacheManager having an enabled residual buffer AND state
+                // exposing a non-negative kv_seq_id. Multi-seq batch decode
+                // bypasses by passing nullptr/0.
+                const half* k_res = nullptr;
+                const half* v_res = nullptr;
+                int res_count = 0;
+                int res_n = 0;
+                int res_widx = 0;
+                if (state.kv_manager != nullptr && state.kv_manager->residual_enabled() &&
+                    state.n_sequences == 1 && state.kv_seq_id >= 0) {
+                    k_res = static_cast<const half*>(
+                        state.kv_manager->residual_k_ptr(state.kv_seq_id, kv_layer));
+                    v_res = static_cast<const half*>(
+                        state.kv_manager->residual_v_ptr(state.kv_seq_id, kv_layer));
+                    auto rs = state.kv_manager->residual_state(state.kv_seq_id);
+                    res_count = rs.fill_count;
+                    res_n = state.kv_manager->residual_n_tokens();
+                    res_widx = rs.write_idx;
+                }
                 paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4,
                                                 static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
                                                 static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
                                                 state.block_tables, state.context_lens, kv_bs, scale,
                                                 state.max_context_len, layer_sliding_window,
-                                                cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
+                                                cfg.attn_logit_softcap, stream, state.max_blocks_per_seq, 0,
+                                                k_res, v_res, res_count, res_n, res_widx);
             } else {
                 paged_attention_decode_nvfp4(q4, k_c, v_c, o4,
                                              static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -1051,7 +1051,9 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                                 k_res_base, v_res_base, res_seq_stride_elems,
                                                 state.d_residual_seq_slots,
                                                 state.d_residual_counts,
-                                                state.d_residual_write_idxes);
+                                                state.d_residual_write_idxes,
+                                                residual_on ? state.kv_manager->d_residual_fc_ptr() : nullptr,
+                                                residual_on ? state.kv_manager->d_residual_widx_ptr() : nullptr);
             } else {
                 paged_attention_decode_nvfp4(q4, k_c, v_c, o4,
                                              static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),

--- a/src/graph/executor_forward.cu
+++ b/src/graph/executor_forward.cu
@@ -23,6 +23,8 @@
 #include "compute/sampling.h"
 #include "compute/ssm.h"
 #include "compute/gdn.h"
+#include "memory/kv_cache_manager.h"
+#include "graph/executor_kernels.h"
 #include "memory/gdn_state.h"
 #include "quant/quant_gemm.h"
 #include "quant/dequant_gpu.h"
@@ -536,6 +538,23 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         // Release offloaded layer (restore host pointers)
         if (offload_mgr_) {
             offload_mgr_->release_layer(i);
+        }
+    }
+
+    // BitDecoding Phase 3: advance the residual ring state once per decode
+    // step. Has to happen INSIDE the captured graph (otherwise replays would
+    // reuse the captured-time write_idx). Must come AFTER the layer loop —
+    // each layer reads the same write_idx for its KV write/attention so the
+    // bump applies starting next step. Decode-only (n==1 or n==n_sequences).
+    if (!state.is_prefill && state.kv_manager != nullptr &&
+        state.kv_manager->residual_enabled() && state.kv_seq_id >= 0) {
+        int slot = state.kv_manager->residual_slot_of(state.kv_seq_id);
+        if (slot >= 0) {
+            advance_residual_state_kernel<<<1, 1, 0, stream>>>(
+                state.kv_manager->d_residual_widx_ptr(),
+                state.kv_manager->d_residual_fc_ptr(),
+                slot,
+                state.kv_manager->residual_n_tokens());
         }
     }
 

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -819,6 +819,54 @@ __global__ __launch_bounds__(256) void write_kv_cache_nvfp4_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// BitDecoding Phase 3c: FP16 residual ring write.
+//
+// blockIdx.x = token_idx (0..n_tokens-1); blockIdx.y selects K (0) or V (1).
+// blockDim.x threads stripe across slot_elems = n_kv_heads * head_dim. The
+// per-token destination pointer (already resolved on the host to the right
+// (seq_slot, layer, K|V, ring_slot) location) is read from the per-token
+// pointer array.
+//
+// Replaces a pair of `cudaMemcpyAsync(dst, src, slot_elems*sizeof(half),
+// cudaMemcpyDeviceToDevice, stream)` calls per layer, which were observed
+// to serialize on the copy engine and dominate decode tg/s when residual
+// was enabled (-3× regression on Qwen3-4B Q8 NVFP4-KV bench at 4K ctx).
+// ---------------------------------------------------------------------------
+__global__ void residual_kv_write_single_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    half* __restrict__ residual_k_dst,
+    half* __restrict__ residual_v_dst,
+    int slot_elems) {
+    const bool is_v = (blockIdx.x == 1);
+    half* dst = is_v ? residual_v_dst : residual_k_dst;
+    if (dst == nullptr) return;
+    const half* src = is_v ? v_in : k_in;
+    const int i = threadIdx.x + blockIdx.y * blockDim.x;
+    if (i < slot_elems) {
+        dst[i] = src[i];
+    }
+}
+
+__global__ void residual_kv_write_multi_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    half* const* __restrict__ residual_k_dst_ptrs,
+    half* const* __restrict__ residual_v_dst_ptrs,
+    int slot_elems) {
+    const int token_idx = blockIdx.x;
+    const bool is_v = (blockIdx.y == 1);
+
+    half* dst = is_v ? residual_v_dst_ptrs[token_idx] : residual_k_dst_ptrs[token_idx];
+    if (dst == nullptr) return;
+    const half* src = (is_v ? v_in : k_in) + static_cast<int64_t>(token_idx) * slot_elems;
+
+    for (int i = threadIdx.x; i < slot_elems; i += blockDim.x) {
+        dst[i] = src[i];
+    }
+}
+
+// ---------------------------------------------------------------------------
 // TurboQuant KV cache write kernel
 //
 // K path (blockIdx.y == 0): PolarQuant decomposition + QJL sketch

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -866,6 +866,44 @@ __global__ void residual_kv_write_multi_kernel(
     }
 }
 
+// Graph-safe single-seq variant: reads write_idx from a device pointer at
+// kernel execution time, so the captured kernel sees the current ring state
+// across graph replays. blockIdx.x ∈ {0, 1} selects K or V; threads stripe
+// across slot_elems.
+__global__ void residual_kv_write_indirect_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    half* __restrict__ residual_k_layer_seq_base,
+    half* __restrict__ residual_v_layer_seq_base,
+    const int* __restrict__ d_residual_widx_ptr,
+    int seq_slot,
+    int slot_elems) {
+    const bool is_v = (blockIdx.x == 1);
+    half* base = is_v ? residual_v_layer_seq_base : residual_k_layer_seq_base;
+    if (base == nullptr) return;
+    const half* src = is_v ? v_in : k_in;
+    const int widx = d_residual_widx_ptr[seq_slot];
+    half* dst = base + static_cast<int64_t>(widx) * slot_elems;
+
+    const int i = threadIdx.x + blockIdx.y * blockDim.x;
+    if (i < slot_elems) {
+        dst[i] = src[i];
+    }
+}
+
+__global__ void advance_residual_state_kernel(
+    int* __restrict__ d_widx,
+    int* __restrict__ d_fc,
+    int slot,
+    int residual_n_tokens) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        int w = d_widx[slot];
+        int f = d_fc[slot];
+        d_widx[slot] = (w + 1) % residual_n_tokens;
+        d_fc[slot] = (f < residual_n_tokens) ? (f + 1) : f;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // TurboQuant KV cache write kernel
 //

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -108,6 +108,29 @@ __global__ __launch_bounds__(256) void write_kv_cache_nvfp4_kernel(
     int scale_block_stride,                    // kKVBlockSize * n_kv_heads * (head_dim / 16) (bytes)
     int n_kv_heads, int head_dim, int block_size, int n_tokens, int max_blocks_per_seq, int n_sequences);
 
+// BitDecoding Phase 3c residual write — copies one (K, V) FP16 row pair per
+// token into the per-(seq, layer) residual ring slot. Replaces a pair of
+// `cudaMemcpyAsync` we used to launch per layer; the device-to-device copy
+// engine path serialized small transfers and dominated decode tg/s
+// (-3× regression on Qwen3-4B Q8 NVFP4-KV bench at 4K ctx).
+//
+// Single-seq form (n_tokens == 1): pass the resolved (slot, ring_slot)
+// destination pointers directly via residual_k_dst / residual_v_dst.
+// Multi-seq form: pass n_tokens > 1 with the device pointer arrays.
+__global__ void residual_kv_write_single_kernel(
+    const half* __restrict__ k_in,         // single token's K row
+    const half* __restrict__ v_in,
+    half* __restrict__ residual_k_dst,     // (slot, layer, ring_slot) destination
+    half* __restrict__ residual_v_dst,
+    int slot_elems);
+
+__global__ void residual_kv_write_multi_kernel(
+    const half* __restrict__ k_in,                  // [n_tokens, slot_elems]
+    const half* __restrict__ v_in,                  // [n_tokens, slot_elems]
+    half* const* __restrict__ residual_k_dst_ptrs,  // [n_tokens] device array of dst pointers
+    half* const* __restrict__ residual_v_dst_ptrs,  // [n_tokens] device array of dst pointers
+    int slot_elems);
+
 __global__ __launch_bounds__(256) void write_kv_cache_turboquant_kernel(
     const half* __restrict__ k_in, const half* __restrict__ v_in, const int* __restrict__ positions,
     const int* __restrict__ block_tables,

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -131,6 +131,28 @@ __global__ void residual_kv_write_multi_kernel(
     half* const* __restrict__ residual_v_dst_ptrs,  // [n_tokens] device array of dst pointers
     int slot_elems);
 
+// Graph-capture-safe variant. Resolves the destination ring slot at kernel
+// execution time by reading the device-resident `widx` (one int per seq slot)
+// pointer + the persistent slot index. Caller passes the per-(seq_slot, layer)
+// K/V base pointer (NOT the ring slot — that's computed inside the kernel).
+__global__ void residual_kv_write_indirect_kernel(
+    const half* __restrict__ k_in,
+    const half* __restrict__ v_in,
+    half* __restrict__ residual_k_layer_seq_base,    // (slot, layer, K=0) base
+    half* __restrict__ residual_v_layer_seq_base,    // (slot, layer, V=1) base
+    const int* __restrict__ d_residual_widx_ptr,     // [max_seqs] device array
+    int seq_slot,                                     // index into d_residual_widx_ptr
+    int slot_elems);
+
+// Advance the residual ring state for one slot. Single-thread kernel:
+//   d_widx[slot] = (d_widx[slot] + 1) % residual_n_tokens
+//   d_fc[slot]   = min(d_fc[slot] + 1, residual_n_tokens)
+__global__ void advance_residual_state_kernel(
+    int* __restrict__ d_widx,
+    int* __restrict__ d_fc,
+    int slot,
+    int residual_n_tokens);
+
 __global__ __launch_bounds__(256) void write_kv_cache_turboquant_kernel(
     const half* __restrict__ k_in, const half* __restrict__ v_in, const int* __restrict__ positions,
     const int* __restrict__ block_tables,

--- a/src/graph/executor_kv_write.cu
+++ b/src/graph/executor_kv_write.cu
@@ -7,6 +7,7 @@
 #include "quant/fp8_quant.h"
 #include "core/logging.h"
 #include "memory/kv_cache.h"
+#include "memory/kv_cache_manager.h"
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -222,6 +223,44 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
             state.block_tables, static_cast<half*>(cache->k_ptr(kv_layer, 0)),
             static_cast<half*>(cache->v_ptr(kv_layer, 0)), block_stride, row_elems, kv_block_size, n,
             state.max_blocks_per_seq, state.n_sequences);
+    }
+
+    // ─── Phase 3c: BitDecoding residual write-through (decode only) ────────
+    //
+    // Append the just-computed FP16 K/V (one token, n_sequences==1) to the
+    // residual ring. The paged write above already cached the same data in
+    // its native dtype; the residual is a lookaside copy that lets the TC
+    // attention kernel skip dequant on the freshest tokens. Eviction-free:
+    // when the ring fills, the slot at write_idx is overwritten and the
+    // older copy stays in paged. Skipped on prefill (warm-up writes only),
+    // multi-seq batches, and non-NVFP4 caches (residual is gated to NVFP4
+    // by KVCacheManager::enable_residual_buffer).
+    if (!state.is_prefill && use_nvfp4 && state.kv_manager != nullptr &&
+        state.kv_manager->residual_enabled() && state.n_sequences == 1 &&
+        state.kv_seq_id >= 0 && n == 1) {
+        const int res_n_kv = cache->n_kv_heads();
+        const int res_hd = cache->head_dim();
+        // Per-layer geometry must match the residual's allocated stride
+        // (uniform-head_dim guard from enable_residual_buffer); skip on
+        // mismatch (e.g. Gemma-4 dual-head_dim layers).
+        if (res_n_kv == nkv && res_hd == hd) {
+            void* dst_k = state.kv_manager->residual_k_ptr(state.kv_seq_id, kv_layer);
+            void* dst_v = state.kv_manager->residual_v_ptr(state.kv_seq_id, kv_layer);
+            if (dst_k != nullptr && dst_v != nullptr) {
+                auto rs = state.kv_manager->residual_state(state.kv_seq_id);
+                const size_t slot_elems = static_cast<size_t>(nkv) * hd;
+                const size_t slot_bytes = slot_elems * sizeof(__half);
+                half* k_dst = static_cast<half*>(dst_k) + rs.write_idx * slot_elems;
+                half* v_dst = static_cast<half*>(dst_v) + rs.write_idx * slot_elems;
+                Tensor kv_src = view_tokens(k_, n);
+                Tensor vv_src = view_tokens(v_, n);
+                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(k_dst, kv_src.data, slot_bytes,
+                                                   cudaMemcpyDeviceToDevice, stream));
+                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(v_dst, vv_src.data, slot_bytes,
+                                                   cudaMemcpyDeviceToDevice, stream));
+                state.kv_manager->advance_residual(state.kv_seq_id);
+            }
+        }
     }
 }
 

--- a/src/graph/executor_kv_write.cu
+++ b/src/graph/executor_kv_write.cu
@@ -13,6 +13,8 @@
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 #include <algorithm>
+#include <cstdlib>
+#include <vector>
 
 namespace imp {
 
@@ -227,38 +229,105 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
 
     // ─── Phase 3c: BitDecoding residual write-through (decode only) ────────
     //
-    // Append the just-computed FP16 K/V (one token, n_sequences==1) to the
-    // residual ring. The paged write above already cached the same data in
-    // its native dtype; the residual is a lookaside copy that lets the TC
-    // attention kernel skip dequant on the freshest tokens. Eviction-free:
-    // when the ring fills, the slot at write_idx is overwritten and the
-    // older copy stays in paged. Skipped on prefill (warm-up writes only),
-    // multi-seq batches, and non-NVFP4 caches (residual is gated to NVFP4
-    // by KVCacheManager::enable_residual_buffer).
-    if (!state.is_prefill && use_nvfp4 && state.kv_manager != nullptr &&
-        state.kv_manager->residual_enabled() && state.n_sequences == 1 &&
-        state.kv_seq_id >= 0 && n == 1) {
+    // Append each seq's just-computed FP16 K/V (one token per seq,
+    // n_sequences ≥ 1, n_tokens == n_sequences) to its residual ring slot.
+    // The paged write above already cached the same data in its native dtype;
+    // the residual is a lookaside copy that lets the TC attention kernel skip
+    // dequant on the freshest tokens. Eviction-free: when the ring fills, the
+    // slot at write_idx is overwritten and the older copy stays in paged.
+    // Skipped on prefill (warm-up writes only), and non-NVFP4 caches (residual
+    // is gated to NVFP4 by KVCacheManager::enable_residual_buffer).
+    //
+    // Two seq-id sources, mirroring the attention dispatcher:
+    //   - state.h_residual_seq_ids: host array of length n_sequences (multi-seq)
+    //   - state.kv_seq_id: single int (legacy single-seq, used when h_… is null)
+    static const bool skip_residual_write = []() {
+        const char* e = std::getenv("IMP_BITDECODING_SKIP_WRITE");
+        return e && e[0] == '1';
+    }();
+    if (!skip_residual_write && !state.is_prefill && use_nvfp4 && state.kv_manager != nullptr &&
+        state.kv_manager->residual_enabled() && n == state.n_sequences) {
         const int res_n_kv = cache->n_kv_heads();
         const int res_hd = cache->head_dim();
         // Per-layer geometry must match the residual's allocated stride
         // (uniform-head_dim guard from enable_residual_buffer); skip on
         // mismatch (e.g. Gemma-4 dual-head_dim layers).
         if (res_n_kv == nkv && res_hd == hd) {
-            void* dst_k = state.kv_manager->residual_k_ptr(state.kv_seq_id, kv_layer);
-            void* dst_v = state.kv_manager->residual_v_ptr(state.kv_seq_id, kv_layer);
-            if (dst_k != nullptr && dst_v != nullptr) {
-                auto rs = state.kv_manager->residual_state(state.kv_seq_id);
-                const size_t slot_elems = static_cast<size_t>(nkv) * hd;
-                const size_t slot_bytes = slot_elems * sizeof(__half);
-                half* k_dst = static_cast<half*>(dst_k) + rs.write_idx * slot_elems;
-                half* v_dst = static_cast<half*>(dst_v) + rs.write_idx * slot_elems;
-                Tensor kv_src = view_tokens(k_, n);
-                Tensor vv_src = view_tokens(v_, n);
-                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(k_dst, kv_src.data, slot_bytes,
-                                                   cudaMemcpyDeviceToDevice, stream));
-                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(v_dst, vv_src.data, slot_bytes,
-                                                   cudaMemcpyDeviceToDevice, stream));
-                state.kv_manager->advance_residual(state.kv_seq_id);
+            const int slot_elems = nkv * hd;
+            Tensor kv_src = view_tokens(k_, n);
+            Tensor vv_src = view_tokens(v_, n);
+            const half* src_k_base = static_cast<const half*>(kv_src.data);
+            const half* src_v_base = static_cast<const half*>(vv_src.data);
+            constexpr int kThreads = 256;
+            const int blocks_y = (slot_elems + kThreads - 1) / kThreads;
+
+            if (state.n_sequences == 1) {
+                // Single-seq fast path: resolve destination on the host and
+                // pass scalar pointers — avoids per-step device-pointer-array
+                // upload. Two cudaMemcpyAsync had been the bottleneck here
+                // (-3× decode regression at 4K ctx); a single kernel launch
+                // is several × cheaper.
+                int seq_id;
+                if (state.h_residual_seq_ids != nullptr) {
+                    seq_id = state.h_residual_seq_ids[0];
+                } else if (state.kv_seq_id >= 0) {
+                    seq_id = state.kv_seq_id;
+                } else {
+                    seq_id = -1;
+                }
+                if (seq_id >= 0) {
+                    void* dst_k = state.kv_manager->residual_k_ptr(seq_id, kv_layer);
+                    void* dst_v = state.kv_manager->residual_v_ptr(seq_id, kv_layer);
+                    if (dst_k != nullptr && dst_v != nullptr) {
+                        auto rs = state.kv_manager->residual_state(seq_id);
+                        half* k_dst = static_cast<half*>(dst_k) + rs.write_idx * slot_elems;
+                        half* v_dst = static_cast<half*>(dst_v) + rs.write_idx * slot_elems;
+                        // Diagnostic env to skip the kernel launch but still advance ring state.
+                        static const bool no_kernel_launch = []() {
+                            const char* e = std::getenv("IMP_BITDECODING_NO_LAUNCH");
+                            return e && e[0] == '1';
+                        }();
+                        if (!no_kernel_launch) {
+                            dim3 grid_single(2, blocks_y);
+                            residual_kv_write_single_kernel<<<grid_single, kThreads, 0, stream>>>(
+                                src_k_base, src_v_base, k_dst, v_dst, slot_elems);
+                        }
+                        state.kv_manager->advance_residual(seq_id);
+                    }
+                }
+            } else if (state.h_residual_seq_ids != nullptr) {
+                // Multi-seq: build device pointer arrays per layer (host-side,
+                // upload via the per-step residual_meta buffer is left to the
+                // engine to pre-upload — we fall back to per-call upload here
+                // for simplicity; n_sequences > 1 is rare so this is OK).
+                std::vector<half*> k_ptrs(n, nullptr), v_ptrs(n, nullptr);
+                for (int s = 0; s < n; s++) {
+                    int seq_id = state.h_residual_seq_ids[s];
+                    if (seq_id < 0) continue;
+                    void* dst_k = state.kv_manager->residual_k_ptr(seq_id, kv_layer);
+                    void* dst_v = state.kv_manager->residual_v_ptr(seq_id, kv_layer);
+                    if (dst_k == nullptr || dst_v == nullptr) continue;
+                    auto rs = state.kv_manager->residual_state(seq_id);
+                    k_ptrs[s] = static_cast<half*>(dst_k) + rs.write_idx * slot_elems;
+                    v_ptrs[s] = static_cast<half*>(dst_v) + rs.write_idx * slot_elems;
+                }
+                half** d_k_ptrs = nullptr;
+                half** d_v_ptrs = nullptr;
+                cudaMallocAsync(&d_k_ptrs, n * sizeof(half*), stream);
+                cudaMallocAsync(&d_v_ptrs, n * sizeof(half*), stream);
+                cudaMemcpyAsync(d_k_ptrs, k_ptrs.data(), n * sizeof(half*),
+                                cudaMemcpyHostToDevice, stream);
+                cudaMemcpyAsync(d_v_ptrs, v_ptrs.data(), n * sizeof(half*),
+                                cudaMemcpyHostToDevice, stream);
+                dim3 grid_multi(n, 2);
+                residual_kv_write_multi_kernel<<<grid_multi, kThreads, 0, stream>>>(
+                    src_k_base, src_v_base, d_k_ptrs, d_v_ptrs, slot_elems);
+                cudaFreeAsync(d_k_ptrs, stream);
+                cudaFreeAsync(d_v_ptrs, stream);
+                for (int s = 0; s < n; s++) {
+                    int seq_id = state.h_residual_seq_ids[s];
+                    if (seq_id >= 0) state.kv_manager->advance_residual(seq_id);
+                }
             }
         }
     }

--- a/src/graph/executor_kv_write.cu
+++ b/src/graph/executor_kv_write.cu
@@ -276,23 +276,28 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
                     seq_id = -1;
                 }
                 if (seq_id >= 0) {
-                    void* dst_k = state.kv_manager->residual_k_ptr(seq_id, kv_layer);
-                    void* dst_v = state.kv_manager->residual_v_ptr(seq_id, kv_layer);
-                    if (dst_k != nullptr && dst_v != nullptr) {
-                        auto rs = state.kv_manager->residual_state(seq_id);
-                        half* k_dst = static_cast<half*>(dst_k) + rs.write_idx * slot_elems;
-                        half* v_dst = static_cast<half*>(dst_v) + rs.write_idx * slot_elems;
-                        // Diagnostic env to skip the kernel launch but still advance ring state.
+                    int slot = state.kv_manager->residual_slot_of(seq_id);
+                    void* base_k = state.kv_manager->residual_k_ptr(seq_id, kv_layer);
+                    void* base_v = state.kv_manager->residual_v_ptr(seq_id, kv_layer);
+                    if (slot >= 0 && base_k != nullptr && base_v != nullptr) {
+                        // Diagnostic env to skip the kernel launch.
                         static const bool no_kernel_launch = []() {
                             const char* e = std::getenv("IMP_BITDECODING_NO_LAUNCH");
                             return e && e[0] == '1';
                         }();
                         if (!no_kernel_launch) {
+                            // Graph-safe: kernel reads write_idx from device at execution
+                            // time. Per-step advance happens once at end of forward_logits
+                            // (a tiny advance_residual_state_kernel), inside the captured
+                            // graph — replays update ring state correctly.
                             dim3 grid_single(2, blocks_y);
-                            residual_kv_write_single_kernel<<<grid_single, kThreads, 0, stream>>>(
-                                src_k_base, src_v_base, k_dst, v_dst, slot_elems);
+                            residual_kv_write_indirect_kernel<<<grid_single, kThreads, 0, stream>>>(
+                                src_k_base, src_v_base,
+                                static_cast<half*>(base_k), static_cast<half*>(base_v),
+                                state.kv_manager->d_residual_widx_ptr(), slot, slot_elems);
                         }
-                        state.kv_manager->advance_residual(seq_id);
+                        // No host advance_residual: ring state lives on device, advanced
+                        // once per step by advance_residual_state_kernel in forward_logits.
                     }
                 }
             } else if (state.h_residual_seq_ids != nullptr) {

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -83,28 +83,83 @@ bool KVCacheManager::enable_residual_buffer(int max_seqs, int residual_n, VRAMAl
     residual_n_tokens_ = residual_n;
     residual_max_seqs_ = max_seqs;
 
+    // Initialize the slot free list. LIFO push so slot 0 is allocated first.
+    residual_free_slots_.clear();
+    residual_free_slots_.reserve(max_seqs);
+    for (int i = max_seqs - 1; i >= 0; i--) {
+        residual_free_slots_.push_back(i);
+    }
+    residual_seq_slot_.clear();
+
     IMP_LOG_INFO("KVCacheManager: residual buffer enabled — max_seqs=%d, residual_n=%d, %.2f MiB",
                  max_seqs, residual_n, static_cast<double>(total) / (1024.0 * 1024.0));
     return true;
 }
 
+int KVCacheManager::allocate_residual_slot(int seq_id) {
+    if (!residual_pool_) return -1;
+    auto it = residual_seq_slot_.find(seq_id);
+    if (it != residual_seq_slot_.end()) return it->second;
+    if (residual_free_slots_.empty()) return -1;
+    int slot = residual_free_slots_.back();
+    residual_free_slots_.pop_back();
+    residual_seq_slot_[seq_id] = slot;
+    return slot;
+}
+
+void KVCacheManager::release_residual_slot(int seq_id) {
+    if (!residual_pool_) return;
+    auto it = residual_seq_slot_.find(seq_id);
+    if (it == residual_seq_slot_.end()) return;
+    residual_free_slots_.push_back(it->second);
+    residual_seq_slot_.erase(it);
+    seq_residual_state_.erase(seq_id);
+}
+
+int KVCacheManager::residual_slot_of(int seq_id) const {
+    auto it = residual_seq_slot_.find(seq_id);
+    if (it == residual_seq_slot_.end()) return -1;
+    return it->second;
+}
+
 void* KVCacheManager::residual_k_ptr(int seq_id, int layer) const {
-    if (!residual_pool_ || seq_id < 0 || seq_id >= residual_max_seqs_) return nullptr;
+    if (!residual_pool_) return nullptr;
+    int slot = residual_slot_of(seq_id);
+    if (slot < 0) return nullptr;
     if (layer < 0 || layer >= residual_n_layers_) return nullptr;
     auto* base = static_cast<char*>(residual_pool_);
-    base += static_cast<size_t>(seq_id) * residual_per_seq_bytes_;
+    base += static_cast<size_t>(slot) * residual_per_seq_bytes_;
     base += static_cast<size_t>(layer) * 2 * residual_per_layer_bytes_;
     // K is k_or_v=0 → offset 0
     return base;
 }
 
 void* KVCacheManager::residual_v_ptr(int seq_id, int layer) const {
-    if (!residual_pool_ || seq_id < 0 || seq_id >= residual_max_seqs_) return nullptr;
+    if (!residual_pool_) return nullptr;
+    int slot = residual_slot_of(seq_id);
+    if (slot < 0) return nullptr;
     if (layer < 0 || layer >= residual_n_layers_) return nullptr;
     auto* base = static_cast<char*>(residual_pool_);
-    base += static_cast<size_t>(seq_id) * residual_per_seq_bytes_;
+    base += static_cast<size_t>(slot) * residual_per_seq_bytes_;
     base += static_cast<size_t>(layer) * 2 * residual_per_layer_bytes_;
     base += residual_per_layer_bytes_;  // V is k_or_v=1
+    return base;
+}
+
+void* KVCacheManager::residual_k_layer_base(int layer) const {
+    if (!residual_pool_) return nullptr;
+    if (layer < 0 || layer >= residual_n_layers_) return nullptr;
+    auto* base = static_cast<char*>(residual_pool_);
+    base += static_cast<size_t>(layer) * 2 * residual_per_layer_bytes_;
+    return base;
+}
+
+void* KVCacheManager::residual_v_layer_base(int layer) const {
+    if (!residual_pool_) return nullptr;
+    if (layer < 0 || layer >= residual_n_layers_) return nullptr;
+    auto* base = static_cast<char*>(residual_pool_);
+    base += static_cast<size_t>(layer) * 2 * residual_per_layer_bytes_;
+    base += residual_per_layer_bytes_;
     return base;
 }
 
@@ -239,7 +294,9 @@ void KVCacheManager::free_sequence(int seq_id) {
 
     seq_blocks_.erase(it);
     seq_block_hashes_.erase(seq_id);
-    seq_residual_state_.erase(seq_id);  // Phase 3: reset residual ring state
+    // Phase 3: reset residual ring state AND return the slot to the free list.
+    // release_residual_slot is a no-op if no slot was allocated for this seq.
+    release_residual_slot(seq_id);
 
     // Remove from LRU tracking.
     auto lru_it = lru_map_.find(seq_id);

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -41,6 +41,14 @@ KVCacheManager::~KVCacheManager() {
         residual_alloc_->free(residual_pool_);
         residual_pool_ = nullptr;
     }
+    if (d_residual_widx_) {
+        cudaFree(d_residual_widx_);
+        d_residual_widx_ = nullptr;
+    }
+    if (d_residual_fc_) {
+        cudaFree(d_residual_fc_);
+        d_residual_fc_ = nullptr;
+    }
 }
 
 // ─── BitDecoding Phase 3: residual FP16 cache ────────────────────────
@@ -91,6 +99,22 @@ bool KVCacheManager::enable_residual_buffer(int max_seqs, int residual_n, VRAMAl
     }
     residual_seq_slot_.clear();
 
+    // Allocate device-resident ring state buffers (graph-capture-safe path).
+    // Zero-initialized so that newly-allocated slots start with write_idx=0,
+    // fill_count=0 without an extra reset call.
+    const size_t state_bytes = static_cast<size_t>(max_seqs) * sizeof(int);
+    if (cudaMalloc(&d_residual_widx_, state_bytes) != cudaSuccess ||
+        cudaMalloc(&d_residual_fc_, state_bytes) != cudaSuccess) {
+        IMP_LOG_ERROR("KVCacheManager: residual state buffer alloc failed (%zu bytes)", state_bytes);
+        if (d_residual_widx_) { cudaFree(d_residual_widx_); d_residual_widx_ = nullptr; }
+        if (d_residual_fc_) { cudaFree(d_residual_fc_); d_residual_fc_ = nullptr; }
+        alloc->free(residual_pool_);
+        residual_pool_ = nullptr;
+        return false;
+    }
+    cudaMemset(d_residual_widx_, 0, state_bytes);
+    cudaMemset(d_residual_fc_, 0, state_bytes);
+
     IMP_LOG_INFO("KVCacheManager: residual buffer enabled — max_seqs=%d, residual_n=%d, %.2f MiB",
                  max_seqs, residual_n, static_cast<double>(total) / (1024.0 * 1024.0));
     return true;
@@ -104,6 +128,13 @@ int KVCacheManager::allocate_residual_slot(int seq_id) {
     int slot = residual_free_slots_.back();
     residual_free_slots_.pop_back();
     residual_seq_slot_[seq_id] = slot;
+    // Zero device-resident ring state for this slot. Synchronous — runs once
+    // per request admission, not on the hot decode path.
+    if (d_residual_widx_) {
+        int zero = 0;
+        cudaMemcpy(d_residual_widx_ + slot, &zero, sizeof(int), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_residual_fc_ + slot, &zero, sizeof(int), cudaMemcpyHostToDevice);
+    }
     return slot;
 }
 
@@ -111,9 +142,15 @@ void KVCacheManager::release_residual_slot(int seq_id) {
     if (!residual_pool_) return;
     auto it = residual_seq_slot_.find(seq_id);
     if (it == residual_seq_slot_.end()) return;
-    residual_free_slots_.push_back(it->second);
+    int slot = it->second;
+    residual_free_slots_.push_back(slot);
     residual_seq_slot_.erase(it);
     seq_residual_state_.erase(seq_id);
+    if (d_residual_widx_) {
+        int zero = 0;
+        cudaMemcpy(d_residual_widx_ + slot, &zero, sizeof(int), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_residual_fc_ + slot, &zero, sizeof(int), cudaMemcpyHostToDevice);
+    }
 }
 
 int KVCacheManager::residual_slot_of(int seq_id) const {

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -187,11 +187,42 @@ public:
     bool residual_enabled() const { return residual_pool_ != nullptr; }
     int residual_n_tokens() const { return residual_n_tokens_; }
     int residual_max_seqs() const { return residual_max_seqs_; }
+    int residual_n_kv_heads() const { return residual_n_kv_heads_; }
+    int residual_head_dim() const { return residual_head_dim_; }
 
     // Per-(seq, layer) K/V pointer into the residual pool. Returns nullptr if
-    // residual is not enabled OR seq_id is out of range.
+    // residual is not enabled, seq_id has no allocated slot, or layer is out
+    // of range. Uses the slot allocator (allocate_residual_slot) — falls back
+    // to nullptr if the seq has not been admitted yet.
     void* residual_k_ptr(int seq_id, int layer) const;
     void* residual_v_ptr(int seq_id, int layer) const;
+
+    // Layer-base pointers (pointer to slot 0's K or V data for the given
+    // layer). Combined with `residual_seq_stride_bytes()` this lets a kernel
+    // address per-batch-idx data: `K_for_slot_s = K_layer_base + s * stride`.
+    // Returns nullptr if residual not enabled or layer out of range.
+    void* residual_k_layer_base(int layer) const;
+    void* residual_v_layer_base(int layer) const;
+
+    // Stride (in bytes) between consecutive seq slots in the residual pool.
+    // Same value for K and V — the (slot, layer, K|V) layout makes this
+    // the per-slot row stride independent of layer.
+    size_t residual_seq_stride_bytes() const { return residual_per_seq_bytes_; }
+
+    // ── Slot allocation (multi-seq batch support) ────────────────────
+    //
+    // Each active sequence holds one slot in [0, residual_max_seqs_) for
+    // the duration of its decode. Allocation is FIFO from a free-list.
+    // Returns the assigned slot, or -1 if residual not enabled / pool full.
+    // Idempotent: re-allocating for the same seq returns the existing slot.
+    int allocate_residual_slot(int seq_id);
+
+    // Release a sequence's slot (no-op if not allocated). Called on
+    // free_sequence; safe to call eagerly. Resets the ring state too.
+    void release_residual_slot(int seq_id);
+
+    // Look up a sequence's slot, or -1 if not allocated.
+    int residual_slot_of(int seq_id) const;
 
     // Per-sequence ring state. Returns {0, 0} for unknown / out-of-range seq.
     ResidualRingState residual_state(int seq_id) const;
@@ -200,7 +231,8 @@ public:
     // Increments write_idx (mod residual_n) and fill_count (capped at residual_n).
     void advance_residual(int seq_id);
 
-    // Reset ring state for a sequence (called from free_sequence).
+    // Reset ring state for a sequence (called from free_sequence). Does NOT
+    // release the slot — use release_residual_slot for that.
     void reset_residual(int seq_id);
 
     // ── Hashing utility (public for testing) ─────────────────────────
@@ -275,6 +307,13 @@ private:
     int residual_n_kv_heads_ = 0;             // cached from cache_->n_kv_heads()
     int residual_head_dim_ = 0;               // cached from cache_->head_dim()
     std::unordered_map<int, ResidualRingState> seq_residual_state_;
+    // ── Slot allocator (multi-seq batch) ─────────────────────────────
+    // Free list of unused slot indices in [0, residual_max_seqs_). When
+    // a sequence is admitted we pop one off the back (LIFO for cache-
+    // friendliness); on release we push back. seq_slot_map_ tracks the
+    // currently-assigned slot per active seq_id.
+    std::vector<int> residual_free_slots_;
+    std::unordered_map<int, int> residual_seq_slot_;
 };
 
 }  // namespace imp

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -209,6 +209,13 @@ public:
     // the per-slot row stride independent of layer.
     size_t residual_seq_stride_bytes() const { return residual_per_seq_bytes_; }
 
+    // Device-resident ring state buffers ([max_seqs] ints each). Replaces the
+    // per-step host upload of write_idx/fill_count — kernels read directly,
+    // and an `advance_residual_state_kernel` updates them once per decode step
+    // (graph-capture-safe). Zeroed on slot allocation and release.
+    int* d_residual_widx_ptr() const { return d_residual_widx_; }
+    int* d_residual_fc_ptr() const { return d_residual_fc_; }
+
     // ── Slot allocation (multi-seq batch support) ────────────────────
     //
     // Each active sequence holds one slot in [0, residual_max_seqs_) for
@@ -314,6 +321,9 @@ private:
     // currently-assigned slot per active seq_id.
     std::vector<int> residual_free_slots_;
     std::unordered_map<int, int> residual_seq_slot_;
+    // Device-resident ring state, [max_seqs] ints each. Zeroed at alloc.
+    int* d_residual_widx_ = nullptr;
+    int* d_residual_fc_ = nullptr;
 };
 
 }  // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1924,7 +1924,10 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     state.prefill_offset = offset;  // absolute pos of state.positions[0]
     state.kv_manager = kv_manager_.get();
     if (kv_manager_ && kv_manager_->residual_enabled()) {
-        state.kv_seq_id = req->id % kv_manager_->residual_max_seqs();
+        // Slot lookup happens inside KVCacheManager::residual_k_ptr; if no
+        // slot is allocated yet (prefill before first decode), the residual
+        // pointers return nullptr and the kernel skips the residual pass.
+        state.kv_seq_id = req->id;
     }
     fill_sampling_params(*req, state);
 
@@ -2199,8 +2202,51 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
     state.max_context_len = max_ctx;
     state.is_prefill = false;
     state.kv_manager = kv_manager_.get();
-    if (kv_manager_ && kv_manager_->residual_enabled() && gpu_batch.n_sequences == 1) {
-        state.kv_seq_id = valid_decode[0]->id % kv_manager_->residual_max_seqs();
+    if (kv_manager_ && kv_manager_->residual_enabled()) {
+        // Allocate / refresh per-seq residual metadata for this decode step.
+        // Slot allocation is idempotent (returns existing slot on re-call).
+        const int N = gpu_batch.n_sequences;
+        residual_meta_h_seq_ids_.resize(N);
+        for (int i = 0; i < N; i++) {
+            int sid = valid_decode[i]->id;
+            residual_meta_h_seq_ids_[i] = sid;
+            kv_manager_->allocate_residual_slot(sid);
+        }
+        if (N == 1) {
+            // Single-seq fast path: scalar kernel form, no per-step device
+            // upload. The attention dispatcher reads ring state directly via
+            // residual_k_ptr / residual_state on the host side and passes
+            // scalar args.
+            state.kv_seq_id = valid_decode[0]->id;
+            state.h_residual_seq_ids = residual_meta_h_seq_ids_.data();
+        } else {
+            // Multi-seq path: build per-batch metadata arrays + upload to
+            // a per-step device buffer.
+            residual_meta_h_slots_.resize(N);
+            residual_meta_h_counts_.resize(N);
+            residual_meta_h_widxes_.resize(N);
+            for (int i = 0; i < N; i++) {
+                int sid = residual_meta_h_seq_ids_[i];
+                residual_meta_h_slots_[i] = kv_manager_->residual_slot_of(sid);
+                auto rs = kv_manager_->residual_state(sid);
+                residual_meta_h_counts_[i] = rs.fill_count;
+                residual_meta_h_widxes_[i] = rs.write_idx;
+            }
+            const size_t meta_bytes = static_cast<size_t>(3) * N * sizeof(int);
+            if (cudaMallocAsync(&residual_meta_d_buf_, meta_bytes, dec_stream) == cudaSuccess) {
+                int* base = residual_meta_d_buf_;
+                cudaMemcpyAsync(base + 0 * N, residual_meta_h_slots_.data(), N * sizeof(int),
+                                cudaMemcpyHostToDevice, dec_stream);
+                cudaMemcpyAsync(base + 1 * N, residual_meta_h_counts_.data(), N * sizeof(int),
+                                cudaMemcpyHostToDevice, dec_stream);
+                cudaMemcpyAsync(base + 2 * N, residual_meta_h_widxes_.data(), N * sizeof(int),
+                                cudaMemcpyHostToDevice, dec_stream);
+                state.d_residual_seq_slots = base + 0 * N;
+                state.d_residual_counts = base + 1 * N;
+                state.d_residual_write_idxes = base + 2 * N;
+                state.h_residual_seq_ids = residual_meta_h_seq_ids_.data();
+            }
+        }
     }
     fill_sampling_params(*valid_decode[0], state);
 
@@ -2327,6 +2373,14 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
 
     if (!decode_batch_pool_.is_allocated()) {
         gpu_batch.free();
+    }
+
+    // Free per-step residual metadata buffer (allocated in step_decode_forward
+    // when residual is enabled). cudaFreeAsync orders behind the just-issued
+    // forward + sample on dec_stream.
+    if (residual_meta_d_buf_ != nullptr) {
+        IMP_CUDA_CHECK_LOG(cudaFreeAsync(residual_meta_d_buf_, dec_stream));
+        residual_meta_d_buf_ = nullptr;
     }
 
     // Process outputs: logprobs extraction + token distribution

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -96,6 +96,10 @@ Engine::~Engine() {
         vram_alloc_.free(d_penalty_tokens_);
         d_penalty_tokens_ = nullptr;
     }
+    if (d_kv_slot_buf_) {
+        cudaFree(d_kv_slot_buf_);
+        d_kv_slot_buf_ = nullptr;
+    }
     if (h_sample_pinned_) {
         IMP_CUDA_CHECK_LOG(cudaFreeHost(h_sample_pinned_));
         h_sample_pinned_ = nullptr;
@@ -1066,23 +1070,24 @@ bool Engine::init_kv_cache() {
     kv_manager_ = std::make_unique<KVCacheManager>(std::move(kv_cache));
 
     // BitDecoding Phase 3: residual FP16 cache (opt-in).
+    //
+    // Ring state (write_idx / fill_count per slot) lives in device memory
+    // (kv_manager_->d_residual_widx_ptr / d_residual_fc_ptr). Updated by a
+    // tiny advance_residual_state_kernel at the end of forward_logits; the
+    // residual write/read kernels read the state at execution time. This
+    // makes the whole path graph-capture-safe — graphs stay enabled.
     {
         const auto& rcfg = RuntimeConfig::current();
         int residual_n = rcfg.kv_cache.bitdecoding_residual_tokens;
         if (residual_n > 0 && config_.kv_cache_dtype == QType::NVFP4) {
             int max_seqs = config_.max_batch_size > 0 ? config_.max_batch_size : 1;
             if (kv_manager_->enable_residual_buffer(max_seqs, residual_n, &vram_alloc_)) {
-                // Phase 3 residual ring state lives on the host (write_idx /
-                // fill_count update per step). CUDA graphs would capture the
-                // values at trace-time, freezing them at every replay → wrong
-                // ring slot reads + writes. Disable graph capture while
-                // residual is active.
-                if (config_.use_cuda_graphs) {
-                    IMP_LOG_INFO(
-                        "BitDecoding residual buffer enabled — disabling CUDA graph capture "
-                        "(host-side ring state incompatible with capture; non-graph decode path used)");
-                    config_.use_cuda_graphs = false;
-                }
+                // Persistent batch→slot lookup buffer (graph-safe). [max_batch_size] ints.
+                size_t slot_bytes = static_cast<size_t>(max_seqs) * sizeof(int);
+                cudaMalloc(&d_kv_slot_buf_, slot_bytes);
+                std::vector<int> init_slots(max_seqs, -1);
+                cudaMemcpy(d_kv_slot_buf_, init_slots.data(), slot_bytes, cudaMemcpyHostToDevice);
+                d_kv_slot_last_uploaded_.assign(max_seqs, -1);
             }
         } else if (residual_n > 0) {
             IMP_LOG_INFO("kv_cache.bitdecoding_residual_tokens=%d ignored (only active with kv_cache_dtype=NVFP4)",
@@ -2213,12 +2218,23 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             kv_manager_->allocate_residual_slot(sid);
         }
         if (N == 1) {
-            // Single-seq fast path: scalar kernel form, no per-step device
-            // upload. The attention dispatcher reads ring state directly via
-            // residual_k_ptr / residual_state on the host side and passes
-            // scalar args.
+            // Single-seq path: kernel reads ring state from kv_manager's
+            // persistent device buffers. Slot is a constant per-request
+            // value uploaded into d_kv_slot_buf_[0]; only re-uploads when
+            // it changes (i.e. when the active request rotates).
             state.kv_seq_id = valid_decode[0]->id;
             state.h_residual_seq_ids = residual_meta_h_seq_ids_.data();
+            int slot_for_req = kv_manager_->residual_slot_of(valid_decode[0]->id);
+            if (d_kv_slot_buf_ != nullptr) {
+                if (d_kv_slot_last_uploaded_.empty() ||
+                    d_kv_slot_last_uploaded_[0] != slot_for_req) {
+                    cudaMemcpyAsync(d_kv_slot_buf_, &slot_for_req, sizeof(int),
+                                    cudaMemcpyHostToDevice, dec_stream);
+                    if (d_kv_slot_last_uploaded_.empty()) d_kv_slot_last_uploaded_.assign(1, -1);
+                    d_kv_slot_last_uploaded_[0] = slot_for_req;
+                }
+                state.d_residual_seq_slots = d_kv_slot_buf_;
+            }
         } else {
             // Multi-seq path: build per-batch metadata arrays + upload to
             // a per-step device buffer.

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1071,7 +1071,19 @@ bool Engine::init_kv_cache() {
         int residual_n = rcfg.kv_cache.bitdecoding_residual_tokens;
         if (residual_n > 0 && config_.kv_cache_dtype == QType::NVFP4) {
             int max_seqs = config_.max_batch_size > 0 ? config_.max_batch_size : 1;
-            (void)kv_manager_->enable_residual_buffer(max_seqs, residual_n, &vram_alloc_);
+            if (kv_manager_->enable_residual_buffer(max_seqs, residual_n, &vram_alloc_)) {
+                // Phase 3 residual ring state lives on the host (write_idx /
+                // fill_count update per step). CUDA graphs would capture the
+                // values at trace-time, freezing them at every replay → wrong
+                // ring slot reads + writes. Disable graph capture while
+                // residual is active.
+                if (config_.use_cuda_graphs) {
+                    IMP_LOG_INFO(
+                        "BitDecoding residual buffer enabled — disabling CUDA graph capture "
+                        "(host-side ring state incompatible with capture; non-graph decode path used)");
+                    config_.use_cuda_graphs = false;
+                }
+            }
         } else if (residual_n > 0) {
             IMP_LOG_INFO("kv_cache.bitdecoding_residual_tokens=%d ignored (only active with kv_cache_dtype=NVFP4)",
                          residual_n);
@@ -1910,6 +1922,10 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     state.max_blocks_per_seq = 0;
     state.is_prefill = true;
     state.prefill_offset = offset;  // absolute pos of state.positions[0]
+    state.kv_manager = kv_manager_.get();
+    if (kv_manager_ && kv_manager_->residual_enabled()) {
+        state.kv_seq_id = req->id % kv_manager_->residual_max_seqs();
+    }
     fill_sampling_params(*req, state);
 
     // Constraints via ConstraintManager
@@ -2182,6 +2198,10 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
     state.context_lens = gpu_batch.d_context_lens;
     state.max_context_len = max_ctx;
     state.is_prefill = false;
+    state.kv_manager = kv_manager_.get();
+    if (kv_manager_ && kv_manager_->residual_enabled() && gpu_batch.n_sequences == 1) {
+        state.kv_seq_id = valid_decode[0]->id % kv_manager_->residual_max_seqs();
+    }
     fill_sampling_params(*valid_decode[0], state);
 
     // Derive per-step seed: mix request seed with output count so each

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -208,14 +208,20 @@ private:
     size_t d_penalty_tokens_capacity_ = 0;
 
     // ── BitDecoding Phase 3 residual metadata (per-step) ─────────────
-    // Host vectors are reused across decode steps to avoid reallocs.
-    // The device buffer is allocated/freed within step_decode_continuous
-    // (cudaMallocAsync / cudaFreeAsync on the decode stream).
+    // residual_meta_d_buf_ is the legacy multi-seq metadata buffer
+    // (cudaMallocAsync per step in step_decode_continuous). d_kv_slot_buf_ is
+    // a persistent [max_batch_size] device array of slot indices indexed by
+    // batch position, updated lazily via cudaMemcpyAsync when the batch
+    // composition changes — graph-capture-safe (kernels read from a stable
+    // device pointer; host updates between graph replays).
     int* residual_meta_d_buf_ = nullptr;
+    int* d_kv_slot_buf_ = nullptr;
     std::vector<int> residual_meta_h_seq_ids_;
     std::vector<int> residual_meta_h_slots_;
     std::vector<int> residual_meta_h_counts_;
     std::vector<int> residual_meta_h_widxes_;
+    // Last-uploaded slot per batch position; only re-upload when changed.
+    std::vector<int> d_kv_slot_last_uploaded_;
 
     // ── Banned tokens (special/control tokens that must not be generated) ──
     std::vector<int32_t> banned_token_ids_;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -207,6 +207,16 @@ private:
     int32_t* d_penalty_tokens_ = nullptr;
     size_t d_penalty_tokens_capacity_ = 0;
 
+    // ── BitDecoding Phase 3 residual metadata (per-step) ─────────────
+    // Host vectors are reused across decode steps to avoid reallocs.
+    // The device buffer is allocated/freed within step_decode_continuous
+    // (cudaMallocAsync / cudaFreeAsync on the decode stream).
+    int* residual_meta_d_buf_ = nullptr;
+    std::vector<int> residual_meta_h_seq_ids_;
+    std::vector<int> residual_meta_h_slots_;
+    std::vector<int> residual_meta_h_counts_;
+    std::vector<int> residual_meta_h_widxes_;
+
     // ── Banned tokens (special/control tokens that must not be generated) ──
     std::vector<int32_t> banned_token_ids_;
 

--- a/tests/test_attention_paged_nvfp4_tc_residual.cu
+++ b/tests/test_attention_paged_nvfp4_tc_residual.cu
@@ -1,0 +1,516 @@
+#include <gtest/gtest.h>
+#include "compute/attention_paged.h"
+#include "core/tensor.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <vector>
+#include <cmath>
+#include <cstring>
+
+namespace imp {
+namespace {
+
+// Phase 3b numerical-equivalence test for the residual-FP16 read path.
+//
+// Setup:
+//   - Build a 64-token NVFP4 paged KV cache with controlled, in-range FP4
+//     magnitudes (nibbles ∈ {0,1,2,3,4}) and uniform UE4M3 scale = 1.0
+//     (byte 0x38). Avoids the NaN trap the existing PagedAttentionNvfp4TCTest
+//     comments call out for unconstrained random NVFP4 input.
+//   - Compute the kernel's exact dequant on the host for the last 4 tokens
+//     (FP4 nibble → half via the same E2M1 LUT, multiplied by UE4M3 = 1.0).
+//   - Run the TC kernel two ways:
+//        (A) residual_count=0, K_residual=nullptr → all-paged baseline
+//        (B) residual_count=4 with K/V_residual pointing at the dequant buffer
+//            → kernel clips paged to first 60 tokens, reads last 4 from residual
+//   - Outputs must match within FP16 ulp tolerance because the residual holds
+//     the exact dequant of the paged tail; the only delta is the code path.
+//
+// This guards against:
+//   - paged_end_token / num_paged_blocks miscomputation
+//   - residual slot indexing (slot_base, residual_skip)
+//   - block-softmax merge of the residual contribution into the running m_w/l_w/o_reg
+//   - V WMMA per-lane scatter (LANES_PER_CHUNK_R / my_chunk_r) for the residual pass
+
+// Host-side E2M1 → float matching `cvt.rn.f16x2.e2m1x2` semantics.
+// Bias = 1, sign | exp(2) | mantissa(1).
+static float e2m1_to_float(uint8_t nibble) {
+    static constexpr float kMag[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+    float v = kMag[nibble & 0x7];
+    return (nibble & 0x8) ? -v : v;
+}
+
+static float ue4m3_byte_to_float(uint8_t b) {
+    __nv_fp8_e4m3 v;
+    std::memcpy(&v, &b, 1);
+    return static_cast<float>(v);
+}
+
+class PagedAttentionNvfp4TCResidualTest : public ::testing::Test {
+protected:
+    void SetUp() override { cudaStreamCreate(&stream_); }
+    void TearDown() override { cudaStreamDestroy(stream_); }
+    cudaStream_t stream_ = nullptr;
+};
+
+TEST_F(PagedAttentionNvfp4TCResidualTest, ResidualSplitMatchesAllPaged_HD128) {
+    constexpr int batch = 1;
+    constexpr int n_heads = 8;
+    constexpr int n_kv_heads = 8;
+    constexpr int HEAD_DIM = 128;
+    constexpr int block_size = 16;
+    constexpr int seqlen_kv = 64;        // 4 full blocks
+    constexpr int residual_count = 4;    // last 4 tokens served from residual
+    constexpr int residual_n_tokens = 8; // ring size; we use 4 of 8 slots
+    constexpr int n_blocks = seqlen_kv / block_size;
+    constexpr int kv_head_bytes = HEAD_DIM / 2;
+    constexpr int sc_groups = HEAD_DIM / 16;
+
+    // Q: small bounded values (< 0.5) to keep dot products in FP16 range.
+    std::vector<half> h_Q(batch * n_heads * HEAD_DIM);
+    for (size_t i = 0; i < h_Q.size(); i++)
+        h_Q[i] = __float2half(0.05f * static_cast<float>((i % 7) - 3));
+
+    // K/V: each byte holds two FP4 nibbles. Restrict nibbles to {0..4} so
+    // dequant magnitudes stay ≤ 2.0; combined with scale=1.0 keeps Q.K well
+    // inside FP16 range across 64 tokens × 128 dims.
+    const size_t kv_bytes = static_cast<size_t>(n_blocks) * block_size * n_kv_heads * kv_head_bytes;
+    const size_t sc_bytes = static_cast<size_t>(n_blocks) * block_size * n_kv_heads * sc_groups;
+    std::vector<uint8_t> h_K(kv_bytes), h_V(kv_bytes);
+    std::vector<uint8_t> h_Ks(sc_bytes, 0x38), h_Vs(sc_bytes, 0x38);  // 0x38 = UE4M3 1.0
+
+    auto rng = [](int seed) {
+        // Deterministic small spread: nibbles cycle through 0..4.
+        return static_cast<uint8_t>((seed * 13 + 7) % 5);
+    };
+    for (size_t i = 0; i < kv_bytes; i++) {
+        uint8_t lo = rng(static_cast<int>(2 * i));
+        uint8_t hi = rng(static_cast<int>(2 * i + 1));
+        h_K[i] = (hi << 4) | lo;
+        h_V[i] = (rng(static_cast<int>(3 * i + 11)) << 4) | rng(static_cast<int>(3 * i + 17));
+    }
+
+    // Host dequant of the LAST `residual_count` tokens into the residual layout
+    // [residual_n_tokens, n_kv_heads, HEAD_DIM] half. Slot i (0-indexed within
+    // the active range) gets token (seqlen_kv - residual_count + i).
+    const size_t res_slot_elems = static_cast<size_t>(n_kv_heads) * HEAD_DIM;
+    std::vector<half> h_K_res(static_cast<size_t>(residual_n_tokens) * res_slot_elems, __float2half(0.0f));
+    std::vector<half> h_V_res(static_cast<size_t>(residual_n_tokens) * res_slot_elems, __float2half(0.0f));
+
+    auto dequant_token = [&](const std::vector<uint8_t>& kv_packed,
+                             const std::vector<uint8_t>& kv_scales, int abs_t,
+                             half* dst /* [n_kv_heads, head_dim] */) {
+        const int blk = abs_t / block_size;
+        const int t_in_block = abs_t % block_size;
+        const int kv_block_stride = block_size * n_kv_heads * kv_head_bytes;
+        const int kv_slot_stride = n_kv_heads * kv_head_bytes;
+        const int sc_block_stride = block_size * n_kv_heads * sc_groups;
+        const int sc_slot_stride = n_kv_heads * sc_groups;
+        const uint8_t* K_block = kv_packed.data() + (size_t)blk * kv_block_stride;
+        const uint8_t* sc_block = kv_scales.data() + (size_t)blk * sc_block_stride;
+        for (int kv_h = 0; kv_h < n_kv_heads; kv_h++) {
+            const uint8_t* K_tok = K_block + t_in_block * kv_slot_stride + kv_h * kv_head_bytes;
+            const uint8_t* sc_tok = sc_block + t_in_block * sc_slot_stride + kv_h * sc_groups;
+            for (int hd = 0; hd < HEAD_DIM; hd++) {
+                uint8_t byte = K_tok[hd / 2];
+                uint8_t nibble = (hd & 1) ? ((byte >> 4) & 0xF) : (byte & 0xF);
+                float v = e2m1_to_float(nibble);
+                float scale = ue4m3_byte_to_float(sc_tok[hd / 16]);
+                dst[kv_h * HEAD_DIM + hd] = __float2half(v * scale);
+            }
+        }
+    };
+
+    // Slot mapping: write_idx=4, fill_count=4, residual_count=4 ⇒ slot_base = 0.
+    // Chronological tokens [60..63] go to slots 0..3.
+    constexpr int residual_write_idx = residual_count;  // ring "next-write" position
+    for (int i = 0; i < residual_count; i++) {
+        int abs_t = seqlen_kv - residual_count + i;
+        int slot = (residual_write_idx + residual_n_tokens - residual_count + i) % residual_n_tokens;
+        dequant_token(h_K, h_Ks, abs_t, h_K_res.data() + (size_t)slot * res_slot_elems);
+        dequant_token(h_V, h_Vs, abs_t, h_V_res.data() + (size_t)slot * res_slot_elems);
+    }
+
+    // Device allocation
+    void *d_Q = nullptr, *d_K = nullptr, *d_V = nullptr, *d_Ks = nullptr, *d_Vs = nullptr;
+    void *d_O_paged = nullptr, *d_O_resid = nullptr;
+    void *d_K_res = nullptr, *d_V_res = nullptr;
+    int *d_bt = nullptr, *d_cl = nullptr;
+    const size_t q_bytes = h_Q.size() * sizeof(half);
+    const size_t res_bytes = h_K_res.size() * sizeof(half);
+
+    cudaMalloc(&d_Q, q_bytes);
+    cudaMalloc(&d_K, kv_bytes);
+    cudaMalloc(&d_V, kv_bytes);
+    cudaMalloc(&d_Ks, sc_bytes);
+    cudaMalloc(&d_Vs, sc_bytes);
+    cudaMalloc(&d_O_paged, q_bytes);
+    cudaMalloc(&d_O_resid, q_bytes);
+    cudaMalloc(&d_K_res, res_bytes);
+    cudaMalloc(&d_V_res, res_bytes);
+    cudaMalloc(&d_bt, n_blocks * sizeof(int));
+    cudaMalloc(&d_cl, sizeof(int));
+
+    cudaMemcpyAsync(d_Q, h_Q.data(), q_bytes, cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(d_K, h_K.data(), kv_bytes, cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(d_V, h_V.data(), kv_bytes, cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(d_Ks, h_Ks.data(), sc_bytes, cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(d_Vs, h_Vs.data(), sc_bytes, cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(d_K_res, h_K_res.data(), res_bytes, cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(d_V_res, h_V_res.data(), res_bytes, cudaMemcpyHostToDevice, stream_);
+
+    std::vector<int> bt(n_blocks);
+    for (int i = 0; i < n_blocks; i++) bt[i] = i;
+    cudaMemcpyAsync(d_bt, bt.data(), n_blocks * sizeof(int), cudaMemcpyHostToDevice, stream_);
+    int ctx_len = seqlen_kv;
+    cudaMemcpyAsync(d_cl, &ctx_len, sizeof(int), cudaMemcpyHostToDevice, stream_);
+    cudaMemsetAsync(d_O_paged, 0, q_bytes, stream_);
+    cudaMemsetAsync(d_O_resid, 0, q_bytes, stream_);
+
+    int64_t Q_shape[]  = {batch, 1, n_heads, HEAD_DIM};
+    int64_t KV_shape[] = {n_blocks, block_size, n_kv_heads, HEAD_DIM / 2};
+    Tensor Q_t(d_Q, QType::F16, 4, Q_shape, true);
+    Tensor K_t(d_K, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor V_t(d_V, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor O_paged(d_O_paged, QType::F16, 4, Q_shape, true);
+    Tensor O_resid(d_O_resid, QType::F16, 4, Q_shape, true);
+
+    const float scale = 1.0f / std::sqrt(static_cast<float>(HEAD_DIM));
+
+    // (A) all-paged baseline
+    paged_attention_decode_nvfp4_tc(Q_t, K_t, V_t, O_paged,
+                                    static_cast<const uint8_t*>(d_Ks),
+                                    static_cast<const uint8_t*>(d_Vs),
+                                    d_bt, d_cl, block_size, scale, ctx_len,
+                                    /*sliding_window=*/0, /*softcap=*/0.0f, stream_);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "all-paged launch failed";
+
+    // (B) split path: residual covers the last 4 tokens
+    paged_attention_decode_nvfp4_tc(Q_t, K_t, V_t, O_resid,
+                                    static_cast<const uint8_t*>(d_Ks),
+                                    static_cast<const uint8_t*>(d_Vs),
+                                    d_bt, d_cl, block_size, scale, ctx_len,
+                                    /*sliding_window=*/0, /*softcap=*/0.0f, stream_,
+                                    /*max_blocks_per_seq=*/0, /*n_sinks=*/0,
+                                    static_cast<const half*>(d_K_res),
+                                    static_cast<const half*>(d_V_res),
+                                    residual_count, residual_n_tokens, residual_write_idx);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "split path launch failed";
+
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_O_paged(h_Q.size()), h_O_resid(h_Q.size());
+    cudaMemcpy(h_O_paged.data(), d_O_paged, q_bytes, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_O_resid.data(), d_O_resid, q_bytes, cudaMemcpyDeviceToHost);
+
+    // FP16 ulp tolerance: the only difference between paths is associative
+    // reordering of the same FMA chain, so absolute error on values in the
+    // ~[-1, 1] range stays within a few ulp (~5e-3). We require <1% rel.
+    double max_abs = 0.0, max_rel = 0.0;
+    for (size_t i = 0; i < h_O_paged.size(); i++) {
+        float a = __half2float(h_O_paged[i]);
+        float b = __half2float(h_O_resid[i]);
+        ASSERT_FALSE(std::isnan(a)) << "all-paged NaN at " << i;
+        ASSERT_FALSE(std::isnan(b)) << "split path NaN at " << i;
+        double abs_e = std::fabs(static_cast<double>(a) - static_cast<double>(b));
+        double denom = std::max(std::fabs(static_cast<double>(a)), 1e-3);
+        double rel_e = abs_e / denom;
+        if (abs_e > max_abs) max_abs = abs_e;
+        if (rel_e > max_rel) max_rel = rel_e;
+    }
+
+    EXPECT_LT(max_abs, 5e-3) << "max abs error too large between residual and all-paged paths";
+    EXPECT_LT(max_rel, 1e-2) << "max rel error too large between residual and all-paged paths";
+
+    cudaFree(d_Q);
+    cudaFree(d_K);
+    cudaFree(d_V);
+    cudaFree(d_Ks);
+    cudaFree(d_Vs);
+    cudaFree(d_O_paged);
+    cudaFree(d_O_resid);
+    cudaFree(d_K_res);
+    cudaFree(d_V_res);
+    cudaFree(d_bt);
+    cudaFree(d_cl);
+}
+
+// Multi-seq batch test: batch_size=2, each seq has its own residual range
+// at a different ring slot. Verifies the kernel reads d_residual_seq_slots /
+// d_residual_counts / d_residual_write_idxes correctly per blockIdx.x.
+TEST_F(PagedAttentionNvfp4TCResidualTest, MultiSeqBatchArrayForm_HD64) {
+    constexpr int batch = 2;
+    constexpr int n_heads = 4;
+    constexpr int n_kv_heads = 4;
+    constexpr int HEAD_DIM = 64;
+    constexpr int block_size = 16;
+    constexpr int seqlen_kv = 32;          // 2 blocks
+    constexpr int residual_count = 4;
+    constexpr int residual_n_tokens = 8;
+    constexpr int n_blocks_per_seq = seqlen_kv / block_size;
+    constexpr int n_blocks_total = batch * n_blocks_per_seq;
+    constexpr int kv_head_bytes = HEAD_DIM / 2;
+    constexpr int sc_groups = HEAD_DIM / 16;
+
+    std::vector<half> h_Q(batch * n_heads * HEAD_DIM, __float2half(0.05f));
+    const size_t kv_bytes = (size_t)n_blocks_total * block_size * n_kv_heads * kv_head_bytes;
+    const size_t sc_bytes = (size_t)n_blocks_total * block_size * n_kv_heads * sc_groups;
+    std::vector<uint8_t> h_K(kv_bytes), h_V(kv_bytes);
+    std::vector<uint8_t> h_Ks(sc_bytes, 0x38), h_Vs(sc_bytes, 0x38);
+    auto rng = [](int seed) { return static_cast<uint8_t>((seed * 13 + 7) % 5); };
+    for (size_t i = 0; i < kv_bytes; i++) {
+        h_K[i] = (rng(2 * (int)i + 1) << 4) | rng(2 * (int)i);
+        h_V[i] = (rng(3 * (int)i + 11) << 4) | rng(3 * (int)i + 17);
+    }
+
+    // Residual pool layout (batch slots × n_kv_heads × HEAD_DIM × residual_n).
+    // Use slots 0 and 1; build per-seq ring data from the dequant of each seq's
+    // last 4 paged tokens. residual_seq_stride_elems = residual_n × n_kv_heads × HEAD_DIM.
+    const int seq_stride_elems = residual_n_tokens * n_kv_heads * HEAD_DIM;
+    std::vector<half> h_K_pool((size_t)batch * seq_stride_elems, __float2half(0.0f));
+    std::vector<half> h_V_pool((size_t)batch * seq_stride_elems, __float2half(0.0f));
+
+    auto dequant_token = [&](const std::vector<uint8_t>& packed, const std::vector<uint8_t>& sc,
+                             int seq_idx, int abs_t, half* dst) {
+        const int blk_global = seq_idx * n_blocks_per_seq + (abs_t / block_size);
+        const int t_in_block = abs_t % block_size;
+        const int kv_block_stride = block_size * n_kv_heads * kv_head_bytes;
+        const int kv_slot_stride = n_kv_heads * kv_head_bytes;
+        const int sc_block_stride = block_size * n_kv_heads * sc_groups;
+        const int sc_slot_stride = n_kv_heads * sc_groups;
+        const uint8_t* K_block = packed.data() + (size_t)blk_global * kv_block_stride;
+        const uint8_t* sc_block = sc.data() + (size_t)blk_global * sc_block_stride;
+        for (int kh = 0; kh < n_kv_heads; kh++) {
+            const uint8_t* K_tok = K_block + t_in_block * kv_slot_stride + kh * kv_head_bytes;
+            const uint8_t* sc_tok = sc_block + t_in_block * sc_slot_stride + kh * sc_groups;
+            for (int hd = 0; hd < HEAD_DIM; hd++) {
+                uint8_t byte = K_tok[hd / 2];
+                uint8_t nibble = (hd & 1) ? ((byte >> 4) & 0xF) : (byte & 0xF);
+                float v = e2m1_to_float(nibble);
+                float s = ue4m3_byte_to_float(sc_tok[hd / 16]);
+                dst[kh * HEAD_DIM + hd] = __float2half(v * s);
+            }
+        }
+    };
+
+    constexpr int residual_write_idx = residual_count;
+    for (int seq = 0; seq < batch; seq++) {
+        for (int i = 0; i < residual_count; i++) {
+            int abs_t = seqlen_kv - residual_count + i;
+            int slot_in_ring = (residual_write_idx + residual_n_tokens - residual_count + i) % residual_n_tokens;
+            half* k_dst = h_K_pool.data() + (size_t)seq * seq_stride_elems +
+                          (size_t)slot_in_ring * n_kv_heads * HEAD_DIM;
+            half* v_dst = h_V_pool.data() + (size_t)seq * seq_stride_elems +
+                          (size_t)slot_in_ring * n_kv_heads * HEAD_DIM;
+            dequant_token(h_K, h_Ks, seq, abs_t, k_dst);
+            dequant_token(h_V, h_Vs, seq, abs_t, v_dst);
+        }
+    }
+
+    void *d_Q = nullptr, *d_K = nullptr, *d_V = nullptr, *d_Ks = nullptr, *d_Vs = nullptr;
+    void *d_O_paged = nullptr, *d_O_resid = nullptr;
+    void *d_K_pool = nullptr, *d_V_pool = nullptr;
+    int *d_bt = nullptr, *d_cl = nullptr;
+    int *d_seq_slots = nullptr, *d_counts = nullptr, *d_widxes = nullptr;
+    const size_t q_bytes = h_Q.size() * sizeof(half);
+    const size_t pool_bytes = h_K_pool.size() * sizeof(half);
+
+    cudaMalloc(&d_Q, q_bytes);
+    cudaMalloc(&d_K, kv_bytes); cudaMalloc(&d_V, kv_bytes);
+    cudaMalloc(&d_Ks, sc_bytes); cudaMalloc(&d_Vs, sc_bytes);
+    cudaMalloc(&d_O_paged, q_bytes); cudaMalloc(&d_O_resid, q_bytes);
+    cudaMalloc(&d_K_pool, pool_bytes); cudaMalloc(&d_V_pool, pool_bytes);
+    cudaMalloc(&d_bt, n_blocks_total * sizeof(int));
+    cudaMalloc(&d_cl, batch * sizeof(int));
+    cudaMalloc(&d_seq_slots, batch * sizeof(int));
+    cudaMalloc(&d_counts, batch * sizeof(int));
+    cudaMalloc(&d_widxes, batch * sizeof(int));
+
+    cudaMemcpy(d_Q, h_Q.data(), q_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_K, h_K.data(), kv_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_V, h_V.data(), kv_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_Ks, h_Ks.data(), sc_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_Vs, h_Vs.data(), sc_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_K_pool, h_K_pool.data(), pool_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_V_pool, h_V_pool.data(), pool_bytes, cudaMemcpyHostToDevice);
+
+    // Per-seq block_table: seq 0 owns blocks [0, 1], seq 1 owns blocks [2, 3].
+    // 2D padded block_table layout: [batch, max_blocks_per_seq] = [2, 2].
+    int bt_padded[batch * n_blocks_per_seq];
+    for (int s = 0; s < batch; s++)
+        for (int b = 0; b < n_blocks_per_seq; b++)
+            bt_padded[s * n_blocks_per_seq + b] = s * n_blocks_per_seq + b;
+    cudaMemcpy(d_bt, bt_padded, sizeof(bt_padded), cudaMemcpyHostToDevice);
+    int cl_arr[batch] = {seqlen_kv, seqlen_kv};
+    cudaMemcpy(d_cl, cl_arr, sizeof(cl_arr), cudaMemcpyHostToDevice);
+    int slot_arr[batch] = {0, 1};
+    int count_arr[batch] = {residual_count, residual_count};
+    int widx_arr[batch] = {residual_write_idx, residual_write_idx};
+    cudaMemcpy(d_seq_slots, slot_arr, sizeof(slot_arr), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_counts, count_arr, sizeof(count_arr), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_widxes, widx_arr, sizeof(widx_arr), cudaMemcpyHostToDevice);
+    cudaMemset(d_O_paged, 0, q_bytes);
+    cudaMemset(d_O_resid, 0, q_bytes);
+
+    int64_t Q_shape[]  = {batch, 1, n_heads, HEAD_DIM};
+    int64_t KV_shape[] = {n_blocks_total, block_size, n_kv_heads, HEAD_DIM / 2};
+    Tensor Q_t(d_Q, QType::F16, 4, Q_shape, true);
+    Tensor K_t(d_K, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor V_t(d_V, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor O_paged(d_O_paged, QType::F16, 4, Q_shape, true);
+    Tensor O_resid(d_O_resid, QType::F16, 4, Q_shape, true);
+
+    const float scale = 1.0f / std::sqrt((float)HEAD_DIM);
+
+    // (A) all-paged baseline
+    paged_attention_decode_nvfp4_tc(Q_t, K_t, V_t, O_paged,
+                                    static_cast<const uint8_t*>(d_Ks),
+                                    static_cast<const uint8_t*>(d_Vs),
+                                    d_bt, d_cl, block_size, scale, seqlen_kv,
+                                    /*sliding_window=*/0, /*softcap=*/0.0f, stream_,
+                                    /*max_blocks_per_seq=*/n_blocks_per_seq);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    // (B) multi-seq array form
+    paged_attention_decode_nvfp4_tc(Q_t, K_t, V_t, O_resid,
+                                    static_cast<const uint8_t*>(d_Ks),
+                                    static_cast<const uint8_t*>(d_Vs),
+                                    d_bt, d_cl, block_size, scale, seqlen_kv,
+                                    /*sliding_window=*/0, /*softcap=*/0.0f, stream_,
+                                    /*max_blocks_per_seq=*/n_blocks_per_seq, /*n_sinks=*/0,
+                                    /*K_residual=*/nullptr, /*V_residual=*/nullptr,
+                                    /*residual_count=*/0,
+                                    /*residual_n_tokens=*/residual_n_tokens,
+                                    /*residual_write_idx=*/0,
+                                    static_cast<const half*>(d_K_pool),
+                                    static_cast<const half*>(d_V_pool),
+                                    /*residual_seq_stride_elems=*/seq_stride_elems,
+                                    d_seq_slots, d_counts, d_widxes);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_O_paged(h_Q.size()), h_O_resid(h_Q.size());
+    cudaMemcpy(h_O_paged.data(), d_O_paged, q_bytes, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_O_resid.data(), d_O_resid, q_bytes, cudaMemcpyDeviceToHost);
+
+    double max_abs = 0.0, max_rel = 0.0;
+    for (size_t i = 0; i < h_O_paged.size(); i++) {
+        float a = __half2float(h_O_paged[i]);
+        float b = __half2float(h_O_resid[i]);
+        ASSERT_FALSE(std::isnan(a)) << "all-paged NaN at " << i;
+        ASSERT_FALSE(std::isnan(b)) << "multi-seq NaN at " << i;
+        double abs_e = std::fabs((double)a - (double)b);
+        double denom = std::max(std::fabs((double)a), 1e-3);
+        double rel_e = abs_e / denom;
+        if (abs_e > max_abs) max_abs = abs_e;
+        if (rel_e > max_rel) max_rel = rel_e;
+    }
+    EXPECT_LT(max_abs, 5e-3) << "max abs error too large between multi-seq array and all-paged";
+    EXPECT_LT(max_rel, 1e-2) << "max rel error too large between multi-seq array and all-paged";
+
+    cudaFree(d_Q); cudaFree(d_K); cudaFree(d_V); cudaFree(d_Ks); cudaFree(d_Vs);
+    cudaFree(d_O_paged); cudaFree(d_O_resid);
+    cudaFree(d_K_pool); cudaFree(d_V_pool);
+    cudaFree(d_bt); cudaFree(d_cl);
+    cudaFree(d_seq_slots); cudaFree(d_counts); cudaFree(d_widxes);
+}
+
+// Sanity test: ctx_len < residual_n_tokens (residual covers all tokens, paged
+// loop runs 0 iterations). Validates the early-context edge case.
+TEST_F(PagedAttentionNvfp4TCResidualTest, ResidualOnlyShortContext_HD64) {
+    constexpr int batch = 1;
+    constexpr int n_heads = 4;
+    constexpr int n_kv_heads = 4;
+    constexpr int HEAD_DIM = 64;
+    constexpr int block_size = 16;
+    constexpr int seqlen_kv = 3;          // less than residual_n_tokens
+    constexpr int residual_count = 3;
+    constexpr int residual_n_tokens = 8;
+    constexpr int n_blocks = 1;           // one (mostly-empty) page block
+    constexpr int kv_head_bytes = HEAD_DIM / 2;
+    constexpr int sc_groups = HEAD_DIM / 16;
+
+    std::vector<half> h_Q(batch * n_heads * HEAD_DIM, __float2half(0.1f));
+    const size_t kv_bytes = (size_t)n_blocks * block_size * n_kv_heads * kv_head_bytes;
+    const size_t sc_bytes = (size_t)n_blocks * block_size * n_kv_heads * sc_groups;
+    std::vector<uint8_t> h_K(kv_bytes, 0x22);  // both nibbles = 1.0
+    std::vector<uint8_t> h_V(kv_bytes, 0x22);
+    std::vector<uint8_t> h_Ks(sc_bytes, 0x38), h_Vs(sc_bytes, 0x38);
+
+    const size_t res_slot_elems = (size_t)n_kv_heads * HEAD_DIM;
+    std::vector<half> h_K_res((size_t)residual_n_tokens * res_slot_elems, __float2half(1.0f));
+    std::vector<half> h_V_res((size_t)residual_n_tokens * res_slot_elems, __float2half(1.0f));
+
+    void *d_Q = nullptr, *d_K = nullptr, *d_V = nullptr, *d_Ks = nullptr, *d_Vs = nullptr;
+    void *d_O = nullptr, *d_K_res = nullptr, *d_V_res = nullptr;
+    int *d_bt = nullptr, *d_cl = nullptr;
+    cudaMalloc(&d_Q, h_Q.size() * sizeof(half));
+    cudaMalloc(&d_K, kv_bytes);
+    cudaMalloc(&d_V, kv_bytes);
+    cudaMalloc(&d_Ks, sc_bytes);
+    cudaMalloc(&d_Vs, sc_bytes);
+    cudaMalloc(&d_O, h_Q.size() * sizeof(half));
+    cudaMalloc(&d_K_res, h_K_res.size() * sizeof(half));
+    cudaMalloc(&d_V_res, h_V_res.size() * sizeof(half));
+    cudaMalloc(&d_bt, n_blocks * sizeof(int));
+    cudaMalloc(&d_cl, sizeof(int));
+
+    cudaMemcpy(d_Q, h_Q.data(), h_Q.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_K, h_K.data(), kv_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_V, h_V.data(), kv_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_Ks, h_Ks.data(), sc_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_Vs, h_Vs.data(), sc_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_K_res, h_K_res.data(), h_K_res.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_V_res, h_V_res.data(), h_V_res.size() * sizeof(half), cudaMemcpyHostToDevice);
+    int bt[1] = {0};
+    int cl = seqlen_kv;
+    cudaMemcpy(d_bt, bt, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_cl, &cl, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemset(d_O, 0, h_Q.size() * sizeof(half));
+
+    int64_t Q_shape[]  = {batch, 1, n_heads, HEAD_DIM};
+    int64_t KV_shape[] = {n_blocks, block_size, n_kv_heads, HEAD_DIM / 2};
+    Tensor Q_t(d_Q, QType::F16, 4, Q_shape, true);
+    Tensor K_t(d_K, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor V_t(d_V, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor O_t(d_O, QType::F16, 4, Q_shape, true);
+
+    const float scale = 1.0f / std::sqrt((float)HEAD_DIM);
+    constexpr int residual_write_idx = residual_count;
+    paged_attention_decode_nvfp4_tc(Q_t, K_t, V_t, O_t,
+                                    static_cast<const uint8_t*>(d_Ks),
+                                    static_cast<const uint8_t*>(d_Vs),
+                                    d_bt, d_cl, block_size, scale, cl,
+                                    /*sliding_window=*/0, /*softcap=*/0.0f, stream_,
+                                    /*max_blocks_per_seq=*/0, /*n_sinks=*/0,
+                                    static_cast<const half*>(d_K_res),
+                                    static_cast<const half*>(d_V_res),
+                                    residual_count, residual_n_tokens, residual_write_idx);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+    cudaStreamSynchronize(stream_);
+
+    // V_residual is all 1s ⇒ output should be ≈ 1.0 across all heads/dims
+    // (uniform softmax over identical V tokens = mean(V) = 1).
+    std::vector<half> h_O(h_Q.size());
+    cudaMemcpy(h_O.data(), d_O, h_Q.size() * sizeof(half), cudaMemcpyDeviceToHost);
+    for (size_t i = 0; i < h_O.size(); i++) {
+        float v = __half2float(h_O[i]);
+        ASSERT_FALSE(std::isnan(v));
+        EXPECT_NEAR(v, 1.0f, 5e-3f) << "elem " << i;
+    }
+
+    cudaFree(d_Q);
+    cudaFree(d_K);
+    cudaFree(d_V);
+    cudaFree(d_Ks);
+    cudaFree(d_Vs);
+    cudaFree(d_O);
+    cudaFree(d_K_res);
+    cudaFree(d_V_res);
+    cudaFree(d_bt);
+    cudaFree(d_cl);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Summary

Closes BitDecoding Phase 3 perf chase. Six commits; final state: residual=8 at parity with no-residual baseline (193 tok/s, graphs ON).

## Bench (Qwen3-4B Q8 + --kv-nvfp4, pp=4096 tg=256, graphs ON)

| Phase | tg/s | vs baseline |
|---|---|---|
| no residual (production default) | 193 | — |
| residual=8 vor Fixes | 50 | -74% |
| residual=8 final | **193** | **0%** |

## Commits

1. \`7c23536\` — Phase 3b/3c: kernel residual reads + write-through (initial impl, regressed)
2. \`61d004c\` — multi-seq batch + equivalence test + perf probe
3. \`7fa8a07\` — STACK:64 spill fix (shared-mem dots/weights + warp-shfl)
4. \`0f150d7\` — splitk + residual_reduce architecture (replace standard reduce)
5. \`18abb9e\` — graph-safe device ring state + once-per-step advance (full parity)
6. \`941c565\` — nsys profiling playbook

## Test plan
- [x] \`make test-gpu\` — 771 tests pass
- [x] Residual smoke: 'The capital of France is Paris.' coherent
- [x] nsys verifies splitk paged kernel (33.6 µs/call) instead of slow non-splitk (414 µs/call)
- [x] CUDA graphs work with residual enabled
- [x] Output divergence test confirms residual contributes (was reading garbage VRAM before per-layer-advance bug fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)