### PR TITLE
fix(nvfp4): chunked prefill on NVFP4 KV + correct attn_scores guard

### DIFF
--- a/src/compute/kv_gather.cu
+++ b/src/compute/kv_gather.cu
@@ -1,4 +1,6 @@
 #include "compute/kv_gather.h"
+#include <cstdint>
+#include <cstring>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
@@ -110,6 +112,81 @@ void paged_kv_gather_fp8_to_fp16(half* dst, const __nv_fp8_e4m3* src, const int*
     int threads = 256;
     paged_kv_gather_fp8_to_fp16_kernel<<<grid, threads, 0, stream>>>(dst, src, block_table, kv_scale,
                                                                       n_past, block_size, nkv, hd);
+}
+
+// NVFP4 → FP16 dequant gather. Same TOKENS_PER_BLOCK / threads_per_token grid
+// as the FP16/FP8 variants. Per (token, hd) elem: read packed FP4 byte → decode
+// to half2 via `cvt.rn.f16x2.e2m1x2` PTX → pick the correct nibble's half →
+// multiply by per-group-of-16 UE4M3 scale → store as FP16. Matches the write
+// path in `write_kv_cache_nvfp4_kernel`.
+__global__ void paged_kv_gather_nvfp4_to_fp16_kernel(
+    half* __restrict__ dst,
+    const uint8_t* __restrict__ src_packed,    // [block, slot, nkv, hd/2]
+    const uint8_t* __restrict__ src_scales,    // [block, slot, nkv, hd/16] UE4M3
+    const int* __restrict__ block_table,
+    int n_past, int block_size, int nkv, int hd) {
+    constexpr int kGroup = 16;
+
+    const int block_group = blockIdx.x;
+    const int kv_head = blockIdx.y;
+    const int tid = threadIdx.x;
+    const int threads_per_token = blockDim.x / TOKENS_PER_BLOCK;
+    const int token_in_block = tid / threads_per_token;
+    const int d_lane = tid % threads_per_token;
+
+    const int pos = block_group * TOKENS_PER_BLOCK + token_in_block;
+    if (pos >= n_past)
+        return;
+
+    const int blk_idx = pos / block_size;
+    const int slot = pos % block_size;
+    const int phys_block = block_table[blk_idx];
+
+    const int kv_block_stride_bytes = block_size * nkv * (hd / 2);
+    const int kv_slot_stride_bytes = nkv * (hd / 2);
+    const int sc_block_stride = block_size * nkv * (hd / kGroup);
+    const int sc_slot_stride = nkv * (hd / kGroup);
+
+    const uint8_t* src_row = src_packed + (size_t)phys_block * kv_block_stride_bytes
+                                        + (size_t)slot * kv_slot_stride_bytes
+                                        + (size_t)kv_head * (hd / 2);
+    const uint8_t* sc_row = src_scales + (size_t)phys_block * sc_block_stride
+                                       + (size_t)slot * sc_slot_stride
+                                       + (size_t)kv_head * (hd / kGroup);
+    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
+
+    for (int d = d_lane; d < hd; d += threads_per_token) {
+        // FP4 nibble decode: PTX cvt produces a half2 from two packed nibbles.
+        const unsigned char byte =
+            __ldcs(reinterpret_cast<const unsigned char*>(src_row + (d / 2)));
+        unsigned int fp16x2;
+        asm("{ .reg .b8 t; cvt.u8.u32 t, %1; cvt.rn.f16x2.e2m1x2 %0, t; }"
+            : "=r"(fp16x2) : "r"((unsigned int)byte));
+        half2 hh = *reinterpret_cast<half2*>(&fp16x2);
+        half v = (d & 1) ? hh.y : hh.x;
+
+        // UE4M3 scale (per group of 16 hd elems).
+        unsigned char sc_byte =
+            __ldcs(reinterpret_cast<const unsigned char*>(sc_row + (d / kGroup)));
+        __nv_fp8_e4m3 sc_fp8;
+        memcpy(&sc_fp8, &sc_byte, 1);
+        float scale = static_cast<float>(sc_fp8);
+
+        dst_row[d] = __float2half(__half2float(v) * scale);
+    }
+}
+
+void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
+                                   const uint8_t* src_scales, const int* block_table,
+                                   int n_past, int block_size, int nkv, int hd,
+                                   cudaStream_t stream) {
+    if (n_past <= 0 || nkv <= 0 || hd <= 0)
+        return;
+    int n_block_groups = (n_past + TOKENS_PER_BLOCK - 1) / TOKENS_PER_BLOCK;
+    dim3 grid(n_block_groups, nkv);
+    int threads = 256;
+    paged_kv_gather_nvfp4_to_fp16_kernel<<<grid, threads, 0, stream>>>(
+        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd);
 }
 
 }  // namespace imp

--- a/src/compute/kv_gather.h
+++ b/src/compute/kv_gather.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
@@ -25,5 +26,15 @@ void paged_kv_gather_fp16(half* dst, const half* src, const int* block_table,
 void paged_kv_gather_fp8_to_fp16(half* dst, const __nv_fp8_e4m3* src, const int* block_table,
                                  float kv_scale, int n_past, int block_size, int nkv, int hd,
                                  cudaStream_t stream);
+
+// NVFP4 paged → FP16 flat with per-group-of-16 UE4M3 scale dequant.
+// src_packed layout: [num_blocks, block_size, nkv, hd/2] uint8 (2 FP4 nibbles/byte).
+// src_scales layout: [num_blocks, block_size, nkv, hd/16] uint8 (UE4M3 bytes).
+// Matches `write_kv_cache_nvfp4_kernel` writes / `paged_attention_decode_nvfp4` reads.
+// Used by chunked prefill to materialize past-chunk K/V into FP16 for cuBLAS attention.
+void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
+                                   const uint8_t* src_scales, const int* block_table,
+                                   int n_past, int block_size, int nkv, int hd,
+                                   cudaStream_t stream);
 
 }  // namespace imp

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -704,8 +704,9 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             KVCache* cache = state.kv_cache;
             QType kvt = cache->qtype();
             // Defense-in-depth: engine resolves out-of-scope models to chunk_size=0,
-            // so this code only runs for FP16 / FP8 KV without SWA / dual-head_dim.
-            if ((kvt != QType::F16 && kvt != QType::FP8_E4M3) || sliding_active || per_layer_shapes) {
+            // so this code only runs for FP16 / FP8 / NVFP4 KV without SWA / dual-head_dim.
+            const bool kvt_ok = (kvt == QType::F16 || kvt == QType::FP8_E4M3 || kvt == QType::NVFP4);
+            if (!kvt_ok || sliding_active || per_layer_shapes) {
                 IMP_LOG_ERROR(
                     "chunked_prefill: unsupported config (kv=%d swa=%d per_layer=%d) at L%d — "
                     "engine should have prevented this",
@@ -716,17 +717,24 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             int kv_layer = get_kv_layer(kv_layer_map_, layer);
             int kv_bs = cache->block_size();
             int ctx_len = q_offset + n;
-            // attn_scores_ is sized [nh, max_seq, max_seq] (square). Chunked use needs
-            // q_len * kv_len = n * ctx_len ≤ max_seq^2 elements per head. Guard
-            // explicitly: refuse to enter if ctx_len exceeds the buffer's row capacity.
-            // Engine's resolve_prefill_chunk_size() ensures ctx_len ≤ max_seq, so this
-            // is defense-in-depth.
+            // attn_scores_ is sized [nh, s_cap, s_cap] (square). Chunked use stores
+            // an [nh, n, ctx_len] FP16 matrix (or FP32 = 2× when use_fp32_s). The
+            // capacity constraint is `n * ctx_len <= s_cap²`, NOT `ctx_len <= s_cap`
+            // (which was the previous guard — overly strict, wrongly aborted at any
+            // chunked step where the cumulative ctx_len crossed s_cap even though
+            // the actual matrix size still fit). FP32 takes 2× — same gate as
+            // attention_cublas_prefill::use_fp32_s; if FP32 would overflow, the
+            // attention call falls back to FP16-S automatically. So we only need to
+            // guard the FP16 footprint here.
             int s_cap = attn_scores_buf_ ? static_cast<int>(attn_scores_.shape[1]) : 0;
-            if (s_cap == 0 || ctx_len > s_cap || n > s_cap) {
+            int64_t fp16_elems_needed = static_cast<int64_t>(n) * ctx_len;
+            int64_t fp16_elems_avail  = static_cast<int64_t>(s_cap) * s_cap;
+            if (s_cap == 0 || fp16_elems_needed > fp16_elems_avail || n > s_cap) {
                 IMP_LOG_ERROR(
-                    "chunked_prefill: attn_scores_ capacity (%d) too small for ctx_len=%d "
-                    "n=%d at L%d — engine should have prevented this",
-                    s_cap, ctx_len, n, layer);
+                    "chunked_prefill: attn_scores_ capacity %d×%d=%lld too small for "
+                    "n=%d × ctx_len=%d = %lld at L%d — engine should have prevented this",
+                    s_cap, s_cap, (long long)fp16_elems_avail, n, ctx_len,
+                    (long long)fp16_elems_needed, layer);
                 std::abort();
             }
             size_t full_bytes = (size_t)ctx_len * nkv * hd * sizeof(half);
@@ -742,7 +750,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                      state.block_tables, q_offset, kv_bs, nkv, hd, stream);
                 paged_kv_gather_fp16(v_full, static_cast<const half*>(cache->v_ptr(kv_layer, 0)),
                                      state.block_tables, q_offset, kv_bs, nkv, hd, stream);
-            } else {  // FP8_E4M3
+            } else if (kvt == QType::FP8_E4M3) {
                 float kv_scale = (!kv_scales_.empty() && kv_layer < (int)kv_scales_.size())
                                      ? kv_scales_[kv_layer] : 1.0f;
                 paged_kv_gather_fp8_to_fp16(
@@ -751,6 +759,15 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 paged_kv_gather_fp8_to_fp16(
                     v_full, static_cast<const __nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)),
                     state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
+            } else {  // NVFP4
+                paged_kv_gather_nvfp4_to_fp16(
+                    k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
+                    static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
+                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_nvfp4_to_fp16(
+                    v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
+                    static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
+                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
             }
 
             // Append current chunk's K/V at offset q_offset.

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1698,10 +1698,11 @@ bool Engine::supports_chunked_prefill_() const {
     if (cfg.arch == ModelArch::QWEN35_MOE) return false;
     if (cfg.arch == ModelArch::QWEN36_MOE) return false;
     if (cfg.arch == ModelArch::NEMOTRON_H_MOE) return false;
-    // Out-of-scope KV dtypes: only FP16 + FP8 are wired through paged_kv_gather.
+    // KV dtypes wired through paged_kv_gather: FP16, FP8_E4M3, NVFP4. Others
+    // (INT4/INT8/TurboQuant) would need their own gather kernels.
     if (kv_cache_raw_) {
         QType kvt = kv_cache_raw_->qtype();
-        if (kvt != QType::F16 && kvt != QType::FP8_E4M3)
+        if (kvt != QType::F16 && kvt != QType::FP8_E4M3 && kvt != QType::NVFP4)
             return false;
     }
     return true;


### PR DESCRIPTION
## Summary

Two related bugs blocked prompts >4K with \`--kv-nvfp4\` (memo: \`chunked_prefill_attn_scores_capacity_bug_2026_05_09.md\`). Fixes unblock long-context residual A/B benches that the BitDecoding work needed.

## Bugs

**A. NVFP4 not supported in chunked prefill** — \`executor_attention.cu:708\` aborted \"unsupported config (kv=...)\" because the chunked path only had FP16 / FP8 gather kernels.

**B. \`attn_scores_\` capacity guard was wrong** — \`executor_attention.cu:725\` aborted on \`ctx_len > s_cap\` even though the attn_scores buffer is \`[nh, s_cap, s_cap]\` and the real constraint is \`n * ctx_len ≤ s_cap²\`. Wrongly aborted at \`ctx_len=4608, n=512, s_cap=4096\` even though the matrix (2.4M elems) easily fit (16.8M elem capacity).

## Fixes

- Add \`paged_kv_gather_nvfp4_to_fp16\` kernel in \`compute/kv_gather.cu\` — decodes packed FP4 via \`cvt.rn.f16x2.e2m1x2\` PTX + applies per-group-of-16 UE4M3 scale. Same grid shape as the FP16/FP8 gathers.
- Wire the new gather into the chunked-prefill dispatch (\`executor_attention.cu:741\`).
- Lift NVFP4 in \`Engine::supports_chunked_prefill_()\`.
- Replace the \`ctx_len > s_cap\` guard with a proper \`n * ctx_len > s_cap²\` check + an \`n > s_cap\` row-count guard.

## Bench (Qwen3-8B Q8 + --kv-nvfp4, graphs ON)

| ctx | no residual | residual=8 |
|---|---|---|
| 4K | 130.68 | 130.75 |
| 8K | 116.52 | 117.67 |
| 16K | 94.77 | 94.41 |

(Was: aborted at 8K and 16K.)

Long-context A/B shows parity, not the BitDecoding paper's claimed speedup. Residual is a precision opt-in, not a perf default — but at least it now functions across all context lengths.

## Test plan
- [x] \`make test-gpu\` — 771 tests pass
- [x] Qwen3-8B Q8 + --kv-nvfp4 + bench pp ∈ {4096, 8192, 16384} all complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)