### PR TITLE
perf(gdn): fuse alpha+beta into single GEMV for decode

### DIFF
--- a/src/graph/executor_ssm_gdn.cu
+++ b/src/graph/executor_ssm_gdn.cu
@@ -402,9 +402,22 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                              ((static_cast<size_t>(n) * n_heads * es + 255) & ~size_t(255));
             beta_proj_out = Tensor(beta_ptr, compute_dtype_, 2, ab_shape, true);
 
-            // Alpha/beta: through gemm_dispatch for consistent MXFP4/FP16/quantized handling.
-            gemm_dispatch(no, ly.gdn_alpha, alpha_proj_out, ctx);
-            gemm_dispatch(no, ly.gdn_beta, beta_proj_out, ctx);
+            // Decode (n=1) fused path: single GEMV against the [d_model,
+            // 2*n_heads] packed weight produces [α₀..α_{H-1}, β₀..β_{H-1}]
+            // contiguous in ssm_dt_buf_. Saves one gemv_fp16_kernel launch
+            // per GDN layer per decode step.
+            if (n == 1 && ly.gdn_alpha_beta_packed.data) {
+                int64_t ab2_shape[2] = {1, static_cast<int64_t>(2 * n_heads)};
+                Tensor ab_packed_out(ssm_dt_buf_.data, compute_dtype_, 2, ab2_shape, true);
+                // β slice now sits immediately after α (no 256-byte padding gap).
+                beta_proj_out = Tensor(static_cast<char*>(ssm_dt_buf_.data) + n_heads * es, compute_dtype_, 2,
+                                       ab_shape, true);
+                gemm_dispatch(no, ly.gdn_alpha_beta_packed, ab_packed_out, ctx);
+            } else {
+                // Alpha/beta: through gemm_dispatch for consistent MXFP4/FP16/quantized handling.
+                gemm_dispatch(no, ly.gdn_alpha, alpha_proj_out, ctx);
+                gemm_dispatch(no, ly.gdn_beta, beta_proj_out, ctx);
+            }
             // Per-element dump: pre-softplus alpha and pre-sigmoid beta projections.
             // Compare to llama's `alpha-{layer}` and `beta-{layer}`.
             dump_tensor_npy("gdn_alpha", alpha_proj_out, stream, layer, cur_decode_step_);

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -237,6 +237,13 @@ struct TransformerLayer {
     Tensor gdn_alpha;  // [d_model, n_gdn_heads] delta rule decay
     Tensor gdn_beta;   // [d_model, n_gdn_heads] delta rule learning rate
 
+    // Decode-only fused weight: gdn_alpha and gdn_beta interleaved along N
+    // as [d_model, 2*n_gdn_heads]. Fires the M=1 path with a single GEMV
+    // launch instead of two. Built at load-time when both alpha and beta are
+    // FP16/BF16 + same shape; left null on GGUF/MXFP4 paths so the dispatcher
+    // falls back to the two-call path.
+    Tensor gdn_alpha_beta_packed;
+
     // Router bias (Nemotron MoE)
     Tensor moe_router_bias;
 

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1221,6 +1221,43 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i, const UploadCtx
         UPLOAD_OR_FAIL(L.gdn_beta, L.gdn_beta.qtype, "gdn_beta", i, ctx);
     }
 
+    // GDN alpha/beta packed for decode (M=1) GEMV fusion. Interleaves the two
+    // weights along N as [d_model, 2*n_heads] so the executor can replace two
+    // tiny gemv_fp16_kernel launches with one. Output layout for n=1:
+    // [α₀..α_{H-1}, β₀..β_{H-1}] contiguous; alpha_proj_out / beta_proj_out
+    // become trivial offset views. Skipped (left null) if either weight is
+    // raw-quant (Q*_K, MXFP4, NVFP4) — those paths fall back to the two-call
+    // dispatcher unchanged.
+    if (L.gdn_alpha.data && L.gdn_alpha.on_device && L.gdn_beta.data && L.gdn_beta.on_device &&
+        L.gdn_alpha.ndim == 2 && L.gdn_beta.ndim == 2 && L.gdn_alpha.qtype == L.gdn_beta.qtype &&
+        (L.gdn_alpha.qtype == QType::F16 || L.gdn_alpha.qtype == QType::BF16) &&
+        L.gdn_alpha.shape[0] == L.gdn_beta.shape[0] && L.gdn_alpha.shape[1] == L.gdn_beta.shape[1]) {
+        int64_t d_model = L.gdn_alpha.shape[0];
+        int64_t n_heads = L.gdn_alpha.shape[1];
+        size_t es = 2;  // F16 and BF16 are both 2 bytes per element
+        size_t row_bytes = static_cast<size_t>(n_heads) * es;
+        size_t total_bytes = static_cast<size_t>(d_model) * 2 * row_bytes;
+        void* d_packed = nullptr;
+        cudaError_t err = cudaMalloc(&d_packed, total_bytes);
+        if (err == cudaSuccess && d_packed) {
+            ctx.gpu_allocs.push_back(d_packed);
+            // alpha → packed[d, 0:n_heads]
+            IMP_CUDA_CHECK_LOG(cudaMemcpy2DAsync(d_packed, 2 * row_bytes, L.gdn_alpha.data, row_bytes,
+                                                 row_bytes, d_model, cudaMemcpyDeviceToDevice, ctx.stream));
+            // beta  → packed[d, n_heads:2*n_heads]
+            IMP_CUDA_CHECK_LOG(cudaMemcpy2DAsync(static_cast<char*>(d_packed) + row_bytes, 2 * row_bytes,
+                                                 L.gdn_beta.data, row_bytes, row_bytes, d_model,
+                                                 cudaMemcpyDeviceToDevice, ctx.stream));
+            int64_t packed_shape[2] = {d_model, 2 * n_heads};
+            L.gdn_alpha_beta_packed = Tensor(d_packed, L.gdn_alpha.qtype, 2, packed_shape, true);
+            IMP_LOG_DEBUG("  layer %d: gdn_alpha_beta_packed [%lld, %lld] %.2f KiB", i, (long long)d_model,
+                          (long long)(2 * n_heads), total_bytes / 1024.0);
+        } else {
+            IMP_LOG_WARN("layer %d: gdn_alpha_beta_packed alloc failed (%zu bytes), falling back to 2-call",
+                         i, total_bytes);
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
## Summary

Two tiny `[d_model, n_heads]` matvecs (`gdn_alpha` and `gdn_beta`) that share the same input `no` are replaced with one matvec against an interleaved `[d_model, 2*n_heads]` packed weight built at load time. For `n=1` decode the output is `[α₀..α_{H-1}, β₀..β_{H-1}]` contiguous in `ssm_dt_buf_`, so `alpha_proj_out` and `beta_proj_out` are trivial offset views — no deinterleave kernel needed.

Prefill (`n>1`) and any non-FP16/BF16 weight (Q*_K, MXFP4, NVFP4 raw-quant) keep the original 2-call dispatcher untouched.

## Why this PR

PR #151's nsys findings flagged 5 FP16 internal projections per GDN layer × 60 layers as dominating ~21.7 % of Qwen3.6-NVFP4 decode kernel time. With CUDA Graphs ON (default), launch overhead is largely amortised so the practical headroom from fusing tiny launches is bounded. This is the smallest-possible first cut: alpha + beta share input, are tiny enough that interleave-into-one-buffer-and-take-views is the entire change, and don't touch the storage planner.

## Bench

RTX 5090, identical seed/prompt, 256-token decode, graphs ON:

| Model                    | clean main | + fusion | Δ       |
|--------------------------|-----------:|---------:|--------:|
| Qwen3.6-35B-A3B-NVFP4    | 171.20     | 173.28   | **+1.2 %** |
| Qwen3.5-4B-GDN Q8_0      | 193.45     | 193.83   | unchanged (fusion inactive — Q8_0 weights) |

`make verify-fast`: PASS (decode/prefill within thresholds, graphs gate 1.62×, smoke coherent).

## Filter

Fusion only fires when:
- both `gdn_alpha` and `gdn_beta` are on-device
- both have `qtype == F16 || qtype == BF16`
- shapes match `[d_model, n_heads]`

Q8_0 / Q4_K / MXFP4 GDN models stay on the raw-quant 2-call path (which they have to use anyway for correct dequant dispatch). NVFP4-prequant Qwen3.6 / Qwen3.5 hybrid paths see the fusion fire because SSM-internal projections are kept FP16 (they're excluded from the NVFP4 cache for accuracy — see `weight_map.cpp:842`).

## VRAM cost

Per layer: `2 × d_model × n_heads × 2` bytes for the packed buffer (originals stay live for the prefill path). Qwen3.6-35B: 2048 × 16 × 4 = 128 KB × 60 GDN layers = ~7.7 MB total. Negligible.

## Out of scope (separate PR)

4-way fusion (`ssm_in + gdn_gate + alpha + beta`) — closes more of the 21.7 % path but needs storage planner + NVFP4 cache co-ordination because `ssm_in` and `gdn_gate` are bigger, have different output dims, and `ssm_in`'s output is already sliced into z/xBC/dt downstream. Treating that as a follow-up keeps this PR small and reviewable.

## Test plan

- [x] `make verify-fast` (build + tests + perf + smoke + graphs gate)
- [x] Qwen3.6-NVFP4 coherent decode (\"capital of France\" smoke)
- [x] Qwen3.5-GDN Q8_0 coherent decode (Babbage essay)
- [x] Bench A/B clean-main vs patched on Qwen3.6-NVFP4 + Qwen3.5-GDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)