### PR TITLE
fix(engine): correct auto max_seq_len for hybrid models + 16K default cap

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -726,20 +726,42 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         size_t free_vram = 0, total_vram = 0;
         cudaMemGetInfo(&free_vram, &total_vram);
         int head_dim = mcfg.head_dim > 0 ? mcfg.head_dim : (mcfg.d_model / mcfg.n_heads);
+        // Hybrid models (Qwen3.5/3.6 GDN, Nemotron-H Mamba2) populate
+        // n_kv_heads_per_layer with zeros for non-attention layers — those don't
+        // contribute to the KV cache. Counting only nonzero entries avoids a
+        // 4-9× per-token-bytes overestimate that clamped max_seq_len far below
+        // VRAM-feasible (e.g. Qwen3.5-4B GDN: 32 total / 8 attention = 4×).
+        int kv_layer_count = mcfg.n_layers;
+        if (!mcfg.n_kv_heads_per_layer.empty()) {
+            int populated = 0;
+            for (int v : mcfg.n_kv_heads_per_layer)
+                if (v > 0)
+                    ++populated;
+            if (populated > 0)
+                kv_layer_count = populated;
+        }
         // Per-token KV bytes for the real kv dtype (INT4/TQ pack 2 elems/byte).
         auto kv = config_.kv_cache_dtype;
         bool packed_int4 = (kv == QType::INT4 || kv == QType::TURBOQUANT || kv == QType::TURBOQUANT_LITE);
-        size_t per_tok_elems = static_cast<size_t>(mcfg.n_kv_heads) * head_dim * mcfg.n_layers *
-                               2;  // K+V, per KV head, all layers
+        size_t per_tok_elems = static_cast<size_t>(mcfg.n_kv_heads) * head_dim * kv_layer_count *
+                               2;  // K+V, per KV head, attention layers only
         size_t kv_bytes_per_token = packed_int4 ? (per_tok_elems / 2) : (per_tok_elems * dtype_size(kv));
         // The budget planner downstream uses 80% of free VRAM for KV. Cap the
         // auto-detect at ~60% so it doesn't undershoot what the planner can
         // afford. (Was 30%, calibrated when weight caches competed at FP16.)
         int max_by_vram = (kv_bytes_per_token > 0) ? static_cast<int>(free_vram * 0.6 / kv_bytes_per_token)
                                                    : 131072;
-        config_.max_seq_len = std::min(model_ctx, std::max(max_by_vram, 4096));
-        IMP_LOG_INFO("max_seq_len: auto → %d (model=%d, vram_cap=%d, kv=%zu B/tok)", config_.max_seq_len,
-                     model_ctx, max_by_vram, kv_bytes_per_token);
+        // Conservative auto-default: cap at 16K even when model + VRAM both
+        // allow more. Long contexts (Qwen3.6 256K, Qwen3 40K) consume a lot of
+        // VRAM and most workloads don't need them. Users requesting longer
+        // context pass --max-seq-len explicitly; the cap doesn't apply when
+        // the user sets it.
+        constexpr int kAutoMaxSeqLenCap = 16384;
+        config_.max_seq_len = std::min({model_ctx, std::max(max_by_vram, 4096), kAutoMaxSeqLenCap});
+        IMP_LOG_INFO(
+            "max_seq_len: auto → %d (model=%d, vram_cap=%d, auto_cap=%d, kv=%zu B/tok, attn_layers=%d/%d)",
+            config_.max_seq_len, model_ctx, max_by_vram, kAutoMaxSeqLenCap, kv_bytes_per_token,
+            kv_layer_count, mcfg.n_layers);
     }
 
     // --- Core initialization ---

--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -3,15 +3,15 @@
   "gpu": "NVIDIA GeForce RTX 5090",
   "cuda": "13.2",
   "vram_total_mb": 32607,
-  "timestamp": "2026-05-09T21:45:57Z",
+  "timestamp": "2026-05-09T22:16:50Z",
   "reps": 5,
   "metrics": {
     "prefill_tps": {
-      "pp128": 5712.19,
-      "pp512": 14139.76
+      "pp128": 6139.88,
+      "pp512": 14547.60
     },
     "decode_tps": {
-      "tg128": 149.09
+      "tg128": 151.16
     },
     "memory_mb": {
       "model_weights": 8608


### PR DESCRIPTION
## Summary

Two related changes to `Engine::init()`'s auto max_seq_len detection:

1. **Layer-count fix**: per-token KV bytes formula used `cfg.n_layers` (total layers), but the actual KV cache only allocates for attention layers. For hybrid models (Qwen3.5/3.6 GDN HF, Nemotron-H Mamba2 HF) this overestimated by 4–9× and clamped `max_seq_len` far below VRAM-feasible.

2. **16K auto-cap**: even when model + VRAM both allow more, cap auto-detect at 16K. Long contexts (Qwen3.6 256K, Qwen3 40K) consume substantial VRAM and most workloads don't need them. Users who want longer set `--max-seq-len <n>` (CLI) or `[runtime] max_seq_len` (`imp.conf`).

## Examples (from local smoke runs)

| Model | Pre-fix auto | Post-fix auto | Override `--max-seq-len 65536` |
|---|---|---|---|
| Qwen3.5-4B GDN GGUF | 148449 (over-clamp bug) | 16384 | 65536 ✓ |
| Qwen3.6-35B-A3B-NVFP4 HF | varies | 16384 | honored |
| Qwen3-8B Q8_0 (dense) | 40960 (model_ctx) | 16384 | honored |

For HF hybrids the per-token KV-bytes calculation now correctly uses attention-layer count (e.g. Qwen3.6 NVFP4: 10/40, Qwen3.5-4B HF GDN: 8/32). For GGUF hybrids the loader doesn't populate `n_kv_heads_per_layer` so the layer-count fix is a no-op there — but the 16K cap masks the over-estimate either way at default VRAM levels.

## Behavioral change

Dense models (Qwen3-8B 40K → 16K, Llama 8K-128K → 16K) also drop to 16K auto. Users running long-prompt workloads now need an explicit override. Aligns the auto default with the existing `min_kv_tokens=16384` in `vram_budget.cpp`.

## Test plan

- [x] Qwen3.5-4B-Q8_0 GDN: 148449 → 16384 (cap), KV pool 2530→512 MiB
- [x] Qwen3.5-4B-Q8_0 GDN with `--max-seq-len 65536`: cap bypassed, KV pool 2048 MiB
- [x] Qwen3-8B-Q8_0 (full attention): cap kicks in (40960 → 16384)
- [x] Qwen3.6-35B-A3B-NVFP4 HF: layer-count fix correctly identifies 10/40 attn layers
- [x] `make verify-fast` green (decode within 3%, prefill within 5%, graphs ON 1.84× speedup)

## Out of scope

GGUF hybrid loaders (Qwen3.5/3.6 GDN GGUF) don't populate `n_kv_heads_per_layer`. Adding it there would also flip `executor_attention.cu`'s `per_layer_shapes` predicate, regressing the fused-KV path (line 440) and forcing cuBLAS attention (line 793). PR #156 (`feat/chunked-prefill-hybrid`) adds an `attn_shapes_vary` predicate that handles this safely; if/when that merges, populating `n_kv_heads_per_layer` for GGUF hybrids becomes safe and would extend the layer-count fix to those models too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)