### PR TITLE
perf(moe): NVFP4 MoE prefill +11-39% via device-args dispatch (default on)

### DIFF
--- a/src/compute/gemm_cutlass_grouped_3x.cu
+++ b/src/compute/gemm_cutlass_grouped_3x.cu
@@ -350,3 +350,277 @@ void gemm_grouped_3x_nvfp4_cleanup() {
 static_assert(sizeof(GrpGemm) > 0, "GrpGemm type must instantiate");
 
 }  // namespace imp
+
+// ===========================================================================
+// Phase 3b: device-args wrapper. Same kernel call (s_gemm->run) as the host-
+// args variant, but the staging buffer is filled by a device kernel reading
+// d_M_per / d_expert_offsets / d_sfa_offsets / d_alpha — no host loop, no
+// D2H or H2D copies on the dispatch path. Graph-capturable.
+// ===========================================================================
+
+namespace imp {
+
+using DeviceArgsElemA = typename GrpGemm::ElementA;
+using DeviceArgsElemB = typename GrpGemm::ElementB;
+using DeviceArgsElemC = typename GrpGemm::ElementC;
+using DeviceArgsElemD = typename GrpGemm::EpilogueOutputOp::ElementOutput;
+
+}  // namespace imp
+
+// One thread per expert. n_experts <= 256, single block with 256 threads.
+__global__ void build_grouped_3x_staging_kernel(
+    // Staging-buffer outputs (typed pointers; host wrapper computes offsets).
+    GrpUnderlyingShape* __restrict__ shapes,
+    GrpStrideA*  __restrict__ stA,
+    GrpStrideB*  __restrict__ stB,
+    GrpStrideC*  __restrict__ stC,
+    GrpStrideD*  __restrict__ stD,
+    GrpLayoutSFA* __restrict__ lSFA,
+    GrpLayoutSFB* __restrict__ lSFB,
+    const imp::DeviceArgsElemA**  __restrict__ ptrA,
+    const imp::DeviceArgsElemB**  __restrict__ ptrB,
+    const GrpElementSF**          __restrict__ ptrSFA,
+    const GrpElementSF**          __restrict__ ptrSFB,
+    const imp::DeviceArgsElemC**  __restrict__ ptrC,
+    imp::DeviceArgsElemD**        __restrict__ ptrD,
+    float* __restrict__ alpha_block,
+    float** __restrict__ aPtr,
+    // Device-resident inputs.
+    const int32_t* __restrict__ d_M_per,
+    const int32_t* __restrict__ d_expert_offsets,
+    const int64_t* __restrict__ d_sfa_offsets,
+    const float*   __restrict__ d_alpha,
+    // Base pointers + per-expert strides (host scalars, passed by value).
+    const void* base_A_packed,
+    const void* base_A_sf,
+    const void* base_B_packed,
+    int64_t     b_expert_stride_packed,
+    const void* base_B_sf,
+    int64_t     b_expert_stride_sf,
+    void*       base_D,
+    // Shared shape dims.
+    int N, int K, int n_experts)
+{
+    int e = threadIdx.x;
+    if (e >= n_experts) return;
+
+    int     M_e          = d_M_per[e];
+    int64_t row_offset_e = static_cast<int64_t>(d_expert_offsets[e]);
+    int64_t sfa_offset_e = d_sfa_offsets[e];
+
+    // 1. Per-expert problem shape {M_e, N, K}.
+    shapes[e] = GrpUnderlyingShape{M_e, N, K};
+
+    // 2. Packed strides via CUTLASS helper (CUTLASS_HOST_DEVICE).
+    //    The relevant Stride types ignore M_i in the body and only set
+    //    get<0|1>(stride) = get<0|1>(shape), so the result is constant
+    //    across experts in practice. Writing them inline keeps the kernel
+    //    self-contained (no separate pre-bake step).
+    stA[e] = cutlass::make_cute_packed_stride(GrpStrideA{}, {M_e, K, 1});
+    stB[e] = cutlass::make_cute_packed_stride(GrpStrideB{}, {N,   K, 1});
+    stC[e] = cutlass::make_cute_packed_stride(GrpStrideC{}, {M_e, N, 1});
+    stD[e] = cutlass::make_cute_packed_stride(GrpStrideD{}, {M_e, N, 1});
+
+    // 3. SFA / SFB CUTE layouts via SfAtom helper (CUTE_HOST_DEVICE).
+    lSFA[e] = GrpSm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+        cute::make_shape(M_e, N, K, 1));
+    lSFB[e] = GrpSm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+        cute::make_shape(M_e, N, K, 1));
+
+    // 4. Per-expert pointer arrays.
+    //   A activations: contiguous, K/2 bytes per row, offset_e rows.
+    int64_t a_row_bytes = static_cast<int64_t>(K) / 2;
+    ptrA[e] = reinterpret_cast<const imp::DeviceArgsElemA*>(
+        static_cast<const char*>(base_A_packed) + row_offset_e * a_row_bytes);
+    //   SFA: SfAtom-padded slab, byte offset from prefix sum.
+    ptrSFA[e] = reinterpret_cast<const GrpElementSF*>(
+        static_cast<const char*>(base_A_sf) + sfa_offset_e);
+    //   B weights: per-expert fixed byte stride.
+    ptrB[e] = reinterpret_cast<const imp::DeviceArgsElemB*>(
+        static_cast<const char*>(base_B_packed) + static_cast<int64_t>(e) * b_expert_stride_packed);
+    //   SFB: per-expert fixed byte stride.
+    ptrSFB[e] = reinterpret_cast<const GrpElementSF*>(
+        static_cast<const char*>(base_B_sf) + static_cast<int64_t>(e) * b_expert_stride_sf);
+    //   C/D outputs alias the FP16 result buffer (beta=0).
+    void* dst_e =
+        static_cast<char*>(base_D) +
+        row_offset_e * static_cast<int64_t>(N) * static_cast<int64_t>(sizeof(half));
+    ptrC[e] = reinterpret_cast<const imp::DeviceArgsElemC*>(dst_e);
+    ptrD[e] = reinterpret_cast<imp::DeviceArgsElemD*>(dst_e);
+
+    // 5. Per-expert alpha value + alpha-pointer-array slot.
+    alpha_block[e] = d_alpha[e];
+    aPtr[e] = alpha_block + e;
+}
+
+namespace imp {
+
+// Persistent host shapes (max-M dummy) for can_implement validation.
+// can_implement only checks alignment (which depends on N, K and element
+// types — not on per-group M values), so any safely-aligned M works.
+static std::vector<GrpUnderlyingShape>* s_host_shapes_max = nullptr;
+
+bool gemm_grouped_cutlass_3x_nvfp4_device_args(
+    int n_experts, int N, int K,
+    const GroupedNvfp4DeviceArgs& args,
+    cudaStream_t stream) {
+    if (n_experts <= 0)
+        return true;
+    if (n_experts > 256) {
+        IMP_LOG_ERROR("CUTLASS 3x grouped device-args: n_experts=%d > 256 not supported",
+                      n_experts);
+        return false;
+    }
+
+    // Flush sticky CUDA errors so CUTLASS TMA setup does not see stale state.
+    {
+        cudaError_t prior = cudaGetLastError();
+        if (prior != cudaSuccess) {
+            IMP_LOG_ERROR("CUTLASS 3x grouped device-args: prior CUDA error: %s",
+                          cudaGetErrorString(prior));
+            return false;
+        }
+    }
+
+    // Same staging-buffer layout as the host-args variant — re-use s_staging.
+    const size_t n = static_cast<size_t>(n_experts);
+    struct Offs {
+        size_t shape, stA, stB, stC, stD, lSFA, lSFB;
+        size_t ptrA, ptrB, ptrSFA, ptrSFB, ptrC, ptrD;
+        size_t alpha, aPtr, total;
+    } o;
+    o.shape  = 0;
+    o.stA    = align128(o.shape  + n * sizeof(GrpUnderlyingShape));
+    o.stB    = align128(o.stA    + n * sizeof(GrpStrideA));
+    o.stC    = align128(o.stB    + n * sizeof(GrpStrideB));
+    o.stD    = align128(o.stC    + n * sizeof(GrpStrideC));
+    o.lSFA   = align128(o.stD    + n * sizeof(GrpStrideD));
+    o.lSFB   = align128(o.lSFA   + n * sizeof(GrpLayoutSFA));
+    o.ptrA   = align128(o.lSFB   + n * sizeof(GrpLayoutSFB));
+    o.ptrB   = align128(o.ptrA   + n * sizeof(void*));
+    o.ptrSFA = align128(o.ptrB   + n * sizeof(void*));
+    o.ptrSFB = align128(o.ptrSFA + n * sizeof(void*));
+    o.ptrC   = align128(o.ptrSFB + n * sizeof(void*));
+    o.ptrD   = align128(o.ptrC   + n * sizeof(void*));
+    o.alpha  = align128(o.ptrD   + n * sizeof(void*));
+    o.aPtr   = align128(o.alpha  + n * sizeof(float));
+    o.total  = align128(o.aPtr   + n * sizeof(float*));
+
+    ensure_staging(o.total);
+    char* d_base = static_cast<char*>(s_staging);
+
+    auto d_shapes = reinterpret_cast<GrpUnderlyingShape*>(d_base + o.shape);
+    auto d_stA    = reinterpret_cast<GrpStrideA*>(d_base + o.stA);
+    auto d_stB    = reinterpret_cast<GrpStrideB*>(d_base + o.stB);
+    auto d_stC    = reinterpret_cast<GrpStrideC*>(d_base + o.stC);
+    auto d_stD    = reinterpret_cast<GrpStrideD*>(d_base + o.stD);
+    auto d_lSFA   = reinterpret_cast<GrpLayoutSFA*>(d_base + o.lSFA);
+    auto d_lSFB   = reinterpret_cast<GrpLayoutSFB*>(d_base + o.lSFB);
+    auto d_ptrA   = reinterpret_cast<const DeviceArgsElemA**>(d_base + o.ptrA);
+    auto d_ptrB   = reinterpret_cast<const DeviceArgsElemB**>(d_base + o.ptrB);
+    auto d_ptrSFA = reinterpret_cast<const GrpElementSF**>(d_base + o.ptrSFA);
+    auto d_ptrSFB = reinterpret_cast<const GrpElementSF**>(d_base + o.ptrSFB);
+    auto d_ptrC   = reinterpret_cast<const DeviceArgsElemC**>(d_base + o.ptrC);
+    auto d_ptrD   = reinterpret_cast<DeviceArgsElemD**>(d_base + o.ptrD);
+    auto d_alpha_block = reinterpret_cast<float*>(d_base + o.alpha);
+    auto d_aPtrArr     = reinterpret_cast<float**>(d_base + o.aPtr);
+
+    // Build/refresh persistent host_shapes for can_implement on first (N,K).
+    if (!s_host_shapes_max)
+        s_host_shapes_max = new std::vector<GrpUnderlyingShape>();
+    if ((int)s_host_shapes_max->size() < n_experts) {
+        // Dummy alignment-safe M (multiple of 128 covers all TMA alignments
+        // we use). Actual per-expert M is on device via d_M_per.
+        s_host_shapes_max->assign(n_experts, GrpUnderlyingShape{128, N, K});
+    } else {
+        // Refresh N, K (could change across calls — alignment depends on them).
+        for (int i = 0; i < n_experts; ++i) {
+            (*s_host_shapes_max)[i] = GrpUnderlyingShape{128, N, K};
+        }
+    }
+    GrpUnderlyingShape* h_shapes = s_host_shapes_max->data();
+
+    // Launch the device-side staging-build kernel.
+    build_grouped_3x_staging_kernel<<<1, 256, 0, stream>>>(
+        d_shapes, d_stA, d_stB, d_stC, d_stD, d_lSFA, d_lSFB,
+        d_ptrA, d_ptrB, d_ptrSFA, d_ptrSFB, d_ptrC, d_ptrD,
+        d_alpha_block, d_aPtrArr,
+        args.d_M_per, args.d_expert_offsets, args.d_sfa_offsets, args.d_alpha,
+        args.base_A_packed, args.base_A_sf,
+        args.base_B_packed, args.b_expert_stride_packed,
+        args.base_B_sf,     args.b_expert_stride_sf,
+        args.base_D,
+        N, K, n_experts);
+
+    // ----- Build Arguments -----
+    typename GrpGemm::Arguments arguments;
+    {
+        decltype(arguments.epilogue.thread) fusion_args;
+        fusion_args.alpha = 0.f;
+        fusion_args.beta  = 0.f;
+        fusion_args.alpha_ptr = nullptr;
+        fusion_args.beta_ptr  = nullptr;
+        fusion_args.alpha_ptr_array = d_aPtrArr;
+        fusion_args.beta_ptr_array  = nullptr;
+        fusion_args.dAlpha = {cute::_0{}, cute::_0{}, 1};
+        fusion_args.dBeta  = {cute::_0{}, cute::_0{}, 0};
+
+        cutlass::KernelHardwareInfo hw_info;
+        hw_info.device_id = 0;
+        hw_info.sm_count  = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(0);
+
+        typename GrpGemm::GemmKernel::TileSchedulerArguments scheduler;
+
+        arguments = typename GrpGemm::Arguments{
+            cutlass::gemm::GemmUniversalMode::kGrouped,
+            {n_experts, d_shapes, h_shapes},
+            {d_ptrA, d_stA, d_ptrB, d_stB, d_ptrSFA, d_lSFA, d_ptrSFB, d_lSFB},
+            {fusion_args, d_ptrC, d_stC, d_ptrD, d_stD},
+            hw_info,
+            scheduler};
+    }
+
+    if (s_gemm == nullptr)
+        s_gemm = new GrpGemm();
+
+    // can_implement memoized per (N, K).
+    if (N != s_can_impl_N || K != s_can_impl_K) {
+        cutlass::Status st = s_gemm->can_implement(arguments);
+        if (st != cutlass::Status::kSuccess) {
+            IMP_LOG_WARN(
+                "CUTLASS 3x grouped device-args: can_implement failed (%d) ne=%d N=%d K=%d",
+                (int)st, n_experts, N, K);
+            return false;
+        }
+        s_can_impl_N = N;
+        s_can_impl_K = K;
+    }
+
+    size_t needed = GrpGemm::get_workspace_size(arguments);
+    ensure_workspace(needed);
+
+    cutlass::Status st;
+    if (!s_gemm_initialized) {
+        st = s_gemm->initialize(arguments, s_workspace, stream);
+        if (st != cutlass::Status::kSuccess) {
+            IMP_LOG_ERROR("CUTLASS 3x grouped device-args: initialize failed (%d)", (int)st);
+            return false;
+        }
+        s_gemm_initialized = true;
+    } else {
+        st = s_gemm->update(arguments, s_workspace);
+        if (st != cutlass::Status::kSuccess) {
+            IMP_LOG_ERROR("CUTLASS 3x grouped device-args: update failed (%d)", (int)st);
+            return false;
+        }
+    }
+
+    st = s_gemm->run(stream);
+    if (st != cutlass::Status::kSuccess) {
+        IMP_LOG_ERROR("CUTLASS 3x grouped device-args: run failed (%d)", (int)st);
+        return false;
+    }
+    return true;
+}
+
+}  // namespace imp

--- a/src/compute/gemm_cutlass_grouped_3x.cu
+++ b/src/compute/gemm_cutlass_grouped_3x.cu
@@ -397,6 +397,11 @@ __global__ void build_grouped_3x_staging_kernel(
     int64_t     b_expert_stride_packed,
     const void* base_B_sf,
     int64_t     b_expert_stride_sf,
+    // Optional per-expert B/SFB pointer arrays (mode (b)). When non-null,
+    // these override base_B_*/b_expert_stride_* — used by registry-handle
+    // MoE weight layout (CUTLASS 3.x prefill in executor_forward_moe.cu).
+    const void* const* d_B_ptrs,
+    const void* const* d_SFB_ptrs,
     void*       base_D,
     // Shared shape dims.
     int N, int K, int n_experts)
@@ -435,12 +440,17 @@ __global__ void build_grouped_3x_staging_kernel(
     //   SFA: SfAtom-padded slab, byte offset from prefix sum.
     ptrSFA[e] = reinterpret_cast<const GrpElementSF*>(
         static_cast<const char*>(base_A_sf) + sfa_offset_e);
-    //   B weights: per-expert fixed byte stride.
-    ptrB[e] = reinterpret_cast<const imp::DeviceArgsElemB*>(
-        static_cast<const char*>(base_B_packed) + static_cast<int64_t>(e) * b_expert_stride_packed);
-    //   SFB: per-expert fixed byte stride.
-    ptrSFB[e] = reinterpret_cast<const GrpElementSF*>(
-        static_cast<const char*>(base_B_sf) + static_cast<int64_t>(e) * b_expert_stride_sf);
+    //   B weights: mode (b) per-expert pointer array if provided, else mode
+    //   (a) base + per-expert byte stride.
+    if (d_B_ptrs != nullptr) {
+        ptrB[e]   = reinterpret_cast<const imp::DeviceArgsElemB*>(d_B_ptrs[e]);
+        ptrSFB[e] = reinterpret_cast<const GrpElementSF*>(d_SFB_ptrs[e]);
+    } else {
+        ptrB[e]   = reinterpret_cast<const imp::DeviceArgsElemB*>(
+            static_cast<const char*>(base_B_packed) + static_cast<int64_t>(e) * b_expert_stride_packed);
+        ptrSFB[e] = reinterpret_cast<const GrpElementSF*>(
+            static_cast<const char*>(base_B_sf) + static_cast<int64_t>(e) * b_expert_stride_sf);
+    }
     //   C/D outputs alias the FP16 result buffer (beta=0).
     void* dst_e =
         static_cast<char*>(base_D) +
@@ -549,6 +559,7 @@ bool gemm_grouped_cutlass_3x_nvfp4_device_args(
         args.base_A_packed, args.base_A_sf,
         args.base_B_packed, args.b_expert_stride_packed,
         args.base_B_sf,     args.b_expert_stride_sf,
+        args.d_B_ptrs, args.d_SFB_ptrs,
         args.base_D,
         N, K, n_experts);
 

--- a/src/compute/gemm_cutlass_grouped_3x.h
+++ b/src/compute/gemm_cutlass_grouped_3x.h
@@ -35,6 +35,44 @@ bool gemm_grouped_cutlass_3x_nvfp4(
     const float* host_alpha,          // [n_experts] per-expert tensor_scale (alpha)
     cudaStream_t stream);
 
+// Phase 3b: graph-capturable variant. All per-expert state lives on the
+// device — the staging buffer is built by an in-stream device kernel
+// (no host iteration, no D2H/H2D sync). Designed to replace the host-args
+// wrapper above inside the MoE prefill dispatch once Phase 3c wires it.
+//
+// Activation buffer layout assumptions (matching executor_forward_moe.cu's
+// CUTLASS 3.x quantize_once lambda):
+//   - A packed FP4: contiguous, K/2 bytes per row.
+//                   ptr_A[e] = base_A_packed + d_expert_offsets[e] * (K/2)
+//   - SFA UE4M3:    SfAtom-padded slab, byte offsets from d_sfa_offsets.
+//                   ptr_SFA[e] = base_A_sf + d_sfa_offsets[e]
+//   - B packed FP4: per-expert, fixed byte stride.
+//                   ptr_B[e] = base_B_packed + e * b_expert_stride_packed
+//   - SFB UE4M3:    per-expert, fixed byte stride.
+//                   ptr_SFB[e] = base_B_sf + e * b_expert_stride_sf
+//   - D FP16:       contiguous output (alias for C, beta=0).
+//                   ptr_D[e] = base_D + d_expert_offsets[e] * N * sizeof(half)
+struct GroupedNvfp4DeviceArgs {
+    const int32_t* d_M_per;           // [n_experts]   per-expert token count
+    const int32_t* d_expert_offsets;  // [n_experts+1] exclusive prefix sum of M_per
+    const int64_t* d_sfa_offsets;     // [n_experts+1] exclusive prefix sum of cutlass_nvfp4_sf_size
+    const float*   d_alpha;           // [n_experts]   per-expert alpha (act_ts * weight_ts)
+
+    const void* base_A_packed;        // contiguous activation packed FP4 base
+    const void* base_A_sf;            // SfAtom-padded SFA base
+    const void* base_B_packed;        // expert weight packed FP4 base
+    int64_t     b_expert_stride_packed;
+    const void* base_B_sf;            // expert SFB base
+    int64_t     b_expert_stride_sf;
+    void*       base_D;               // FP16 output base
+};
+
+bool gemm_grouped_cutlass_3x_nvfp4_device_args(
+    int n_experts,
+    int N, int K,
+    const GroupedNvfp4DeviceArgs& args,
+    cudaStream_t stream);
+
 void gemm_grouped_3x_nvfp4_cleanup();
 
 }  // namespace imp

--- a/src/compute/gemm_cutlass_grouped_3x.h
+++ b/src/compute/gemm_cutlass_grouped_3x.h
@@ -60,11 +60,25 @@ struct GroupedNvfp4DeviceArgs {
 
     const void* base_A_packed;        // contiguous activation packed FP4 base
     const void* base_A_sf;            // SfAtom-padded SFA base
-    const void* base_B_packed;        // expert weight packed FP4 base
+
+    // B/SFB storage. Two modes (mutually exclusive — Phase 3c-MVP design):
+    //
+    //   (a) Contiguous slab + per-expert stride. Set base_B_packed + b_expert_stride_packed
+    //       (same for SFB). Set d_B_ptrs = d_SFB_ptrs = nullptr.
+    //       Used by NvFP4MoEQuantResult-style native MoE weights (smallM path).
+    //
+    //   (b) Per-expert device pointer array. Set d_B_ptrs and d_SFB_ptrs to
+    //       [n_experts] device-resident pointer arrays. base_B_*/b_expert_stride_*
+    //       are ignored when these are non-null.
+    //       Used by registry-handle-style per-expert weights (CUTLASS 3.x prefill).
+    const void* base_B_packed;        // mode (a) only
     int64_t     b_expert_stride_packed;
-    const void* base_B_sf;            // expert SFB base
+    const void* base_B_sf;            // mode (a) only
     int64_t     b_expert_stride_sf;
-    void*       base_D;               // FP16 output base
+    const void* const* d_B_ptrs;      // mode (b): [n_experts] device array, or nullptr
+    const void* const* d_SFB_ptrs;    // mode (b): [n_experts] device array, or nullptr
+
+    void* base_D;                     // FP16 output base
 };
 
 bool gemm_grouped_cutlass_3x_nvfp4_device_args(

--- a/src/compute/quantize_fp16_nvfp4_moe_native.cu
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.cu
@@ -20,6 +20,7 @@
 #include <cuda_fp16.h>
 #include <cstdint>
 #include <cfloat>
+#include <cassert>
 
 namespace imp {
 
@@ -369,6 +370,67 @@ void compute_M_per_from_offsets_device(
     int blocks  = (n_experts + threads - 1) / threads;
     moe_compute_M_per_kernel<<<blocks, threads, 0, stream>>>(
         d_expert_offsets, d_M_per_out, n_experts);
+}
+
+// ---------------------------------------------------------------------------
+// compact_alpha_active: order-preserving stream compaction of d_alpha
+// to only the entries where d_M_per[e] > 0. Single block, block-level
+// inclusive prefix sum (Hillis–Steele) in shared memory.
+// n_experts is bounded by 256 (typical 64-128); 8 scan steps total.
+// ---------------------------------------------------------------------------
+__global__ void compact_alpha_active_kernel(
+    const float*   __restrict__ d_alpha,
+    const int32_t* __restrict__ d_M_per,
+    float*         __restrict__ d_alpha_compact,
+    int32_t*       __restrict__ d_na_out,
+    int n_experts)
+{
+    constexpr int MAX_NE = 256;
+    __shared__ int s_scan[MAX_NE];
+
+    int e = threadIdx.x;
+    int active = (e < n_experts && d_M_per[e] > 0) ? 1 : 0;
+    s_scan[e] = active;
+    __syncthreads();
+
+    // Hillis–Steele inclusive prefix sum.
+    for (int off = 1; off < MAX_NE; off <<= 1) {
+        int v = (e >= off) ? s_scan[e - off] : 0;
+        __syncthreads();
+        s_scan[e] += v;
+        __syncthreads();
+    }
+
+    int incl = s_scan[e];
+    if (active) {
+        int excl = incl - 1;          // active=1 → excl = incl - active
+        d_alpha_compact[excl] = d_alpha[e];
+    }
+    if (e == 0) {
+        // The final inclusive total lives at index n_experts-1 (or 0 if ne==0).
+        *d_na_out = (n_experts > 0) ? s_scan[n_experts - 1] : 0;
+    }
+}
+
+void compact_alpha_active(
+    const float* d_alpha,
+    const int32_t* d_M_per,
+    float* d_alpha_compact,
+    int32_t* d_na_out,
+    int n_experts,
+    cudaStream_t stream)
+{
+    if (n_experts <= 0) {
+        if (d_na_out)
+            cudaMemsetAsync(d_na_out, 0, sizeof(int32_t), stream);
+        return;
+    }
+    // Single-block kernel uses a fixed 256-thread layout — n_experts must fit.
+    // Production MoE models have ≤ 128 experts; the limit is documented in the
+    // header. Caller is responsible for honoring it.
+    assert(n_experts <= 256);
+    compact_alpha_active_kernel<<<1, 256, 0, stream>>>(
+        d_alpha, d_M_per, d_alpha_compact, d_na_out, n_experts);
 }
 
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.cu
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.cu
@@ -433,4 +433,76 @@ void compact_alpha_active(
         d_alpha, d_M_per, d_alpha_compact, d_na_out, n_experts);
 }
 
+// ---------------------------------------------------------------------------
+// compute_sfa_offsets_device: exclusive prefix sum of cutlass_nvfp4_sf_size
+// (per-expert SfAtom-padded SFA byte size). Single block, Hillis–Steele scan
+// over int64 in shared memory. Phase 3a of MoE-prefill-graphs lever.
+// ---------------------------------------------------------------------------
+//
+// Padding constants must stay in lockstep with kAtomRows/kAtomKElems/kAtomSize
+// in src/compute/gemm_cutlass_sm120.cu (CUTLASS SfAtom = 128 rows × 64 K-elems
+// × 512 bytes). Kept here as constexpr to avoid a host-only include from a
+// device translation unit.
+namespace {
+constexpr int kSfAtomRows   = 128;
+constexpr int kSfAtomKElems = 64;
+constexpr int kSfAtomSize   = 512;
+}  // anonymous
+
+__global__ void compute_sfa_offsets_kernel(
+    const int32_t* __restrict__ d_M_per,
+    int64_t*       __restrict__ d_sfa_offsets_out,
+    int n_experts,
+    int K)
+{
+    constexpr int MAX_NE = 256;
+    __shared__ int64_t s_scan[MAX_NE];
+
+    int e = threadIdx.x;
+    int n_k_tiles = (K + kSfAtomKElems - 1) / kSfAtomKElems;
+
+    int64_t bytes = 0;
+    if (e < n_experts) {
+        int M_e = d_M_per[e];
+        int n_row_tiles = (M_e + kSfAtomRows - 1) / kSfAtomRows;
+        bytes = static_cast<int64_t>(n_row_tiles) * n_k_tiles * kSfAtomSize;
+    }
+    s_scan[e] = bytes;
+    __syncthreads();
+
+    // Hillis–Steele inclusive prefix sum.
+    for (int off = 1; off < MAX_NE; off <<= 1) {
+        int64_t v = (e >= off) ? s_scan[e - off] : 0;
+        __syncthreads();
+        s_scan[e] += v;
+        __syncthreads();
+    }
+
+    // Output exclusive prefix sum: d_sfa_offsets_out[e] = inclusive - bytes_e
+    if (e < n_experts) {
+        d_sfa_offsets_out[e] = s_scan[e] - bytes;
+    }
+    if (e == n_experts) {
+        // Trailing total at slot ne (inclusive sum of ne-1).
+        d_sfa_offsets_out[n_experts] = (n_experts > 0) ? s_scan[n_experts - 1] : 0;
+    }
+}
+
+void compute_sfa_offsets_device(
+    const int32_t* d_M_per,
+    int64_t* d_sfa_offsets_out,
+    int n_experts,
+    int K,
+    cudaStream_t stream)
+{
+    if (n_experts <= 0) {
+        if (d_sfa_offsets_out)
+            cudaMemsetAsync(d_sfa_offsets_out, 0, sizeof(int64_t), stream);
+        return;
+    }
+    assert(n_experts <= 256);
+    compute_sfa_offsets_kernel<<<1, 256, 0, stream>>>(
+        d_M_per, d_sfa_offsets_out, n_experts, K);
+}
+
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.cu
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.cu
@@ -505,4 +505,33 @@ void compute_sfa_offsets_device(
         d_M_per, d_sfa_offsets_out, n_experts, K);
 }
 
+// ---------------------------------------------------------------------------
+// build_sfa_bases_device: trivial pointer-arithmetic kernel that writes
+// d_sfa_bases_out[e] = base_sf + d_sfa_offsets[e].  One thread per expert.
+// ---------------------------------------------------------------------------
+__global__ void build_sfa_bases_kernel(
+    uint8_t**      __restrict__ d_sfa_bases_out,
+    uint8_t*       __restrict__ base_sf,
+    const int64_t* __restrict__ d_sfa_offsets,
+    int n_experts)
+{
+    int e = blockIdx.x * blockDim.x + threadIdx.x;
+    if (e < n_experts)
+        d_sfa_bases_out[e] = base_sf + d_sfa_offsets[e];
+}
+
+void build_sfa_bases_device(
+    uint8_t** d_sfa_bases_out,
+    void* base_sf,
+    const int64_t* d_sfa_offsets,
+    int n_experts,
+    cudaStream_t stream)
+{
+    if (n_experts <= 0) return;
+    int threads = std::min(n_experts, 256);
+    int blocks  = (n_experts + threads - 1) / threads;
+    build_sfa_bases_kernel<<<blocks, threads, 0, stream>>>(
+        d_sfa_bases_out, static_cast<uint8_t*>(base_sf), d_sfa_offsets, n_experts);
+}
+
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.cu
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.cu
@@ -344,4 +344,31 @@ void compute_moe_alpha_device(
         d_act_scales, d_weight_scales, d_alpha_out, n_experts);
 }
 
+// ---------------------------------------------------------------------------
+// compute_M_per_from_offsets_device: per-expert token count from offset scan.
+// One thread per expert; single block (n_experts typically ≤ 256).
+// ---------------------------------------------------------------------------
+__global__ void moe_compute_M_per_kernel(
+    const int32_t* __restrict__ d_offsets,
+    int32_t* __restrict__ d_M_per_out,
+    int n_experts)
+{
+    int e = blockIdx.x * blockDim.x + threadIdx.x;
+    if (e < n_experts)
+        d_M_per_out[e] = d_offsets[e + 1] - d_offsets[e];
+}
+
+void compute_M_per_from_offsets_device(
+    const int32_t* d_expert_offsets,
+    int32_t* d_M_per_out,
+    int n_experts,
+    cudaStream_t stream)
+{
+    if (n_experts <= 0) return;
+    int threads = std::min(n_experts, 256);
+    int blocks  = (n_experts + threads - 1) / threads;
+    moe_compute_M_per_kernel<<<blocks, threads, 0, stream>>>(
+        d_expert_offsets, d_M_per_out, n_experts);
+}
+
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.h
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <cstdint>
 
 namespace imp {
 
@@ -138,6 +139,26 @@ void compute_sfa_offsets_device(
     int64_t* d_sfa_offsets_out,
     int n_experts,
     int K,
+    cudaStream_t stream);
+
+// Build a device-resident array of per-expert base pointers into the
+// SfAtom-padded SFA staging slab. Replaces the host-side loop in
+// executor_forward_moe.cu's quantize_once lambda that builds h_sfa_bases
+// and then cudaMemcpyAsync's it to moe_.cutlass3x_sfa_ptrs. Eliminates
+// that H2D from the dispatch path (Phase 3c-full Step 2 prerequisite).
+//
+// Formula: d_sfa_bases_out[e] = base_sf + d_sfa_offsets[e]
+//
+// d_sfa_offsets   : [n_experts+1] device int64 — output of compute_sfa_offsets_device
+// base_sf         : host pointer to the start of the contiguous SFA slab (device addr)
+// d_sfa_bases_out : [n_experts] device uint8_t** — written by callee
+// Single-block 256-thread launch; safe inside a captured CUDA graph.
+// Requires n_experts <= 256.
+void build_sfa_bases_device(
+    uint8_t** d_sfa_bases_out,
+    void* base_sf,
+    const int64_t* d_sfa_offsets,
+    int n_experts,
     cudaStream_t stream);
 
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.h
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.h
@@ -117,4 +117,27 @@ void compact_alpha_active(
     int n_experts,
     cudaStream_t stream);
 
+// Compute device-resident per-expert offsets into a SfAtom-padded SFA buffer
+// (Phase 3 of moe_prefill_graphs_plan_2026_05_10). Output is exclusive prefix
+// sum of `cutlass_nvfp4_sf_size(M_per[e], K)` so that
+//   ptr_SFA[e] = base_SFA + d_sfa_offsets_out[e]
+// matches the host-side staging layout used by the existing CUTLASS 3.x
+// grouped NVFP4 wrapper (gemm_cutlass_grouped_3x.cu).
+//
+// Padding math (SfAtom): n_row_tiles = ceil(M_e/128); n_k_tiles = ceil(K/64);
+//                        bytes = n_row_tiles * n_k_tiles * 512
+// (See cutlass_nvfp4_sf_size in gemm_cutlass_sm120.cu for the host version.)
+//
+// d_M_per          : [n_experts]      device int32 — per-expert token count
+// d_sfa_offsets_out: [n_experts + 1]  device int64 — exclusive prefix sum
+// K                : shared K dimension (host int)
+// Single-block 256-thread launch; safe inside a captured CUDA graph.
+// Requires n_experts <= 256.
+void compute_sfa_offsets_device(
+    const int32_t* d_M_per,
+    int64_t* d_sfa_offsets_out,
+    int n_experts,
+    int K,
+    cudaStream_t stream);
+
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.h
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.h
@@ -69,4 +69,24 @@ void compute_moe_alpha_device(
     int n_experts,
     cudaStream_t stream);
 
+// Compute per-expert M_per values from device-resident expert_offsets array.
+// M_per[e] = expert_offsets[e+1] - expert_offsets[e]   (token count routed to expert e)
+//
+// Replaces the host-side  `cudaMemcpyAsync(h_offsets, d_offsets, ...) +
+// cudaStreamSynchronize + for(e) M_per[e]=h_offsets[e+1]-h_offsets[e]`  pattern
+// used in MoE prefill dispatch (executor_forward_moe.cu). Eliminating that D2H
+// sync is the prerequisite for CUDA-graph capture of MoE prefill — the decode
+// fast-path already does no D2H but the prefill path falls back to host-driven
+// dispatch.
+//
+// d_expert_offsets : [n_experts + 1] device int32 — exclusive scan of token counts
+// d_M_per_out      : [n_experts]     device int32 — written by callee
+//
+// Launches a single tiny block; safe inside a captured CUDA graph.
+void compute_M_per_from_offsets_device(
+    const int32_t* d_expert_offsets,
+    int32_t* d_M_per_out,
+    int n_experts,
+    cudaStream_t stream);
+
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.h
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.h
@@ -89,4 +89,32 @@ void compute_M_per_from_offsets_device(
     int n_experts,
     cudaStream_t stream);
 
+// Compact per-expert alpha values to only the active experts (M_per[e] > 0).
+// Reads d_alpha[n_experts] + d_M_per[n_experts]; writes d_alpha_compact[na]
+// and d_na (single int32) with the active-expert count.
+//
+// Replaces the host-side  `D2H d_alpha + cudaStreamSynchronize + for(e) if
+// (M_per[e]>0) compact.push_back(alpha[e]) + cudaMallocAsync + H2D compact`
+// pattern at executor_forward_moe.cu:1492-1514. Eliminating both syncs is the
+// second graph-capture prerequisite for MoE prefill (Phase 2 of
+// moe_prefill_graphs_plan_2026_05_10).
+//
+// d_alpha         : [n_experts] device floats — full per-expert alpha
+// d_M_per         : [n_experts] device int32  — token count per expert
+// d_alpha_compact : [n_experts] device floats — output (first `na` entries valid)
+// d_na_out        : [1]         device int32  — output, active-expert count
+//
+// The compaction order matches the source order (active experts in ascending
+// index), preserving the host-loop semantics that downstream Phase 4 device-
+// built ptr arrays will mirror. Single-block 256-thread launch — safe inside
+// a captured CUDA graph. Requires n_experts <= 256 (production models have
+// up to 128 experts).
+void compact_alpha_active(
+    const float* d_alpha,
+    const int32_t* d_M_per,
+    float* d_alpha_compact,
+    int32_t* d_na_out,
+    int n_experts,
+    cudaStream_t stream);
+
 }  // namespace imp

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1295,6 +1295,14 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_offsets.data(), routing.expert_offsets.data,
                                                        static_cast<size_t>(ne + 1) * sizeof(int32_t),
                                                        cudaMemcpyDeviceToHost, stream));
+                    // Populate device-resident d_M_per in parallel with the D2H copy.
+                    // Phase 1 of MoE-prefill-graphs lever: foundation for graph-safe
+                    // dispatch (Phase 2+ migrates host M_per[] uses to this buffer).
+                    if (moe_.d_M_per && moe_.d_M_per_count >= ne) {
+                        imp::compute_M_per_from_offsets_device(
+                            static_cast<const int32_t*>(routing.expert_offsets.data),
+                            moe_.d_M_per, ne, stream);
+                    }
                     cudaStreamSynchronize(stream);
 
                     std::vector<int> M_per(ne);

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -14,6 +14,7 @@
 #include "graph/gemm_context.h"
 #include "graph/executor_debug.h"
 #include "runtime/config.h"
+#include <atomic>
 #include "compute/embedding.h"
 #include "compute/gemv_ggml_compat.h"
 #include "compute/ggml_mmvq.h"
@@ -1301,9 +1302,15 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     // back to the legacy path on any dispatch failure.
                     bool device_args_done = false;
                     {
+                        // Default ON since 2026-05-14: 4-model A/B showed +11–39%
+                        // pp512 vs the legacy host-args + smallM dispatch on
+                        // Qwen3-Coder / Qwen3.6 / Qwen3-30B-Modelopt / Gemma-4
+                        // NVFP4 (decode unchanged). Set IMP_NVFP4_DEVICE_ARGS=0
+                        // to force the legacy path for A/B or workarounds.
                         const char* da_env = ::getenv("IMP_NVFP4_DEVICE_ARGS");
+                        const bool da_enabled = !da_env || std::atoi(da_env) != 0;
                         const bool use_device_args =
-                            da_env && std::atoi(da_env) != 0 &&
+                            da_enabled &&
                             moe_.d_M_per && moe_.d_M_per_count >= ne &&
                             moe_.d_sfa_offsets && moe_.d_B_ptrs_cache &&
                             moe_.d_SFB_ptrs_cache && moe_.d_alpha_full &&
@@ -1311,10 +1318,14 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                             moe_.cutlass3x_sfa_ptrs &&
                             moe_.cutlass3x_sfa_ptrs_count >= ne;
                         if (use_device_args) {
-                            if (layer == 0)
+                            // Log once per process; layer==0 fires on every
+                            // forward, but only the first ever needs to flag
+                            // the path choice.
+                            static std::atomic<bool> s_da_logged{false};
+                            if (layer == 0 && !s_da_logged.exchange(true))
                                 IMP_LOG_INFO(
                                     "MoE prefill: CUTLASS 3.x device-args full path "
-                                    "(opt-in via IMP_NVFP4_DEVICE_ARGS=1)");
+                                    "(default; set IMP_NVFP4_DEVICE_ARGS=0 to disable)");
                             // Populate device-resident d_M_per (no D2H).
                             imp::compute_M_per_from_offsets_device(
                                 static_cast<const int32_t*>(routing.expert_offsets.data),

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1679,7 +1679,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     const bool use_device_args =
                         device_args_env && std::atoi(device_args_env) != 0 &&
                         moe_.d_M_per && moe_.d_M_per_count >= ne &&
-                        moe_.d_sfa_offsets;
+                        moe_.d_sfa_offsets && moe_.d_B_ptrs_cache &&
+                        moe_.d_SFB_ptrs_cache && moe_.d_alpha_full;
                     auto grouped_gemm_device = [&](const std::vector<TensorID>& weight_ids,
                                                    char* c_base, int K_in, int N_out) -> bool {
                         // Per-expert host arrays (registry handles). Built for ALL
@@ -1694,21 +1695,13 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                                 ? *h.payload.cutlass_nvfp4.global_scale
                                                 : 1.0f;
                         }
-                        // Per-call device staging for the 3 arrays. Tiny (~3 KB
-                        // total for 128 experts). cudaMallocAsync/FreeAsync are
-                        // graph-safe with the stream-ordered allocator; Phase 3c-
-                        // full will cache these at model-load time.
-                        const void** d_B_ptrs   = nullptr;
-                        const void** d_SFB_ptrs = nullptr;
-                        float*       d_alpha    = nullptr;
-                        cudaMallocAsync(&d_B_ptrs,   ne * sizeof(const void*), stream);
-                        cudaMallocAsync(&d_SFB_ptrs, ne * sizeof(const void*), stream);
-                        cudaMallocAsync(&d_alpha,    ne * sizeof(float),       stream);
-                        cudaMemcpyAsync(d_B_ptrs,   h_B_ptrs.data(),
+                        // Upload host arrays into workspace-cached device
+                        // buffers (Phase 3c-full Step 1). No per-call cudaMalloc.
+                        cudaMemcpyAsync(moe_.d_B_ptrs_cache,   h_B_ptrs.data(),
                                         ne * sizeof(const void*), cudaMemcpyHostToDevice, stream);
-                        cudaMemcpyAsync(d_SFB_ptrs, h_SFB_ptrs.data(),
+                        cudaMemcpyAsync(moe_.d_SFB_ptrs_cache, h_SFB_ptrs.data(),
                                         ne * sizeof(const void*), cudaMemcpyHostToDevice, stream);
-                        cudaMemcpyAsync(d_alpha,    h_alpha.data(),
+                        cudaMemcpyAsync(moe_.d_alpha_full,     h_alpha.data(),
                                         ne * sizeof(float),       cudaMemcpyHostToDevice, stream);
                         // SFA byte-offset prefix sum on device (Phase 3a kernel).
                         imp::compute_sfa_offsets_device(moe_.d_M_per, moe_.d_sfa_offsets,
@@ -1719,20 +1712,15 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                         dargs.d_expert_offsets =
                             static_cast<const int32_t*>(routing.expert_offsets.data);
                         dargs.d_sfa_offsets    = moe_.d_sfa_offsets;
-                        dargs.d_alpha          = d_alpha;
+                        dargs.d_alpha          = moe_.d_alpha_full;
                         dargs.base_A_packed    = moe_.cutlass3x_packed;
                         dargs.base_A_sf        = moe_.cutlass3x_sf;
-                        dargs.d_B_ptrs         = d_B_ptrs;
-                        dargs.d_SFB_ptrs       = d_SFB_ptrs;
+                        dargs.d_B_ptrs         = moe_.d_B_ptrs_cache;
+                        dargs.d_SFB_ptrs       = moe_.d_SFB_ptrs_cache;
                         dargs.base_D           = c_base;
 
-                        bool ok = imp::gemm_grouped_cutlass_3x_nvfp4_device_args(
+                        return imp::gemm_grouped_cutlass_3x_nvfp4_device_args(
                             ne, N_out, K_in, dargs, stream);
-
-                        cudaFreeAsync(d_B_ptrs,   stream);
-                        cudaFreeAsync(d_SFB_ptrs, stream);
-                        cudaFreeAsync(d_alpha,    stream);
-                        return ok;
                     };
 
                     // Dispatch a grouped GEMM given already-quantized activations.

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1666,9 +1666,88 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                         return true;
                     };
 
+                    // Opt-in: device-args wrapper path (Phase 3c-MVP wire).
+                    // Uses imp::gemm_grouped_cutlass_3x_nvfp4_device_args, which
+                    // builds the per-expert staging buffer in a device kernel
+                    // from device-resident d_M_per / d_expert_offsets /
+                    // d_sfa_offsets / d_alpha + per-expert ptr arrays. Note:
+                    // upstream of this lambda still does the h_offsets D2H+sync,
+                    // so this MVP does NOT yet enable CUDA-graph capture of the
+                    // prefill path — Phase 3c-full removes that residual sync.
+                    // Enable via IMP_NVFP4_DEVICE_ARGS=1.
+                    const char* device_args_env = ::getenv("IMP_NVFP4_DEVICE_ARGS");
+                    const bool use_device_args =
+                        device_args_env && std::atoi(device_args_env) != 0 &&
+                        moe_.d_M_per && moe_.d_M_per_count >= ne &&
+                        moe_.d_sfa_offsets;
+                    auto grouped_gemm_device = [&](const std::vector<TensorID>& weight_ids,
+                                                   char* c_base, int K_in, int N_out) -> bool {
+                        // Per-expert host arrays (registry handles). Built for ALL
+                        // experts — CUTLASS skips empty groups via M=0 internally.
+                        std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
+                        std::vector<float> h_alpha(ne);
+                        for (int e = 0; e < ne; ++e) {
+                            const auto& h = registry_.handle(weight_ids[e]);
+                            h_B_ptrs[e]   = h.payload.cutlass_nvfp4.weight;
+                            h_SFB_ptrs[e] = h.payload.cutlass_nvfp4.sf;
+                            h_alpha[e]    = h.payload.cutlass_nvfp4.global_scale
+                                                ? *h.payload.cutlass_nvfp4.global_scale
+                                                : 1.0f;
+                        }
+                        // Per-call device staging for the 3 arrays. Tiny (~3 KB
+                        // total for 128 experts). cudaMallocAsync/FreeAsync are
+                        // graph-safe with the stream-ordered allocator; Phase 3c-
+                        // full will cache these at model-load time.
+                        const void** d_B_ptrs   = nullptr;
+                        const void** d_SFB_ptrs = nullptr;
+                        float*       d_alpha    = nullptr;
+                        cudaMallocAsync(&d_B_ptrs,   ne * sizeof(const void*), stream);
+                        cudaMallocAsync(&d_SFB_ptrs, ne * sizeof(const void*), stream);
+                        cudaMallocAsync(&d_alpha,    ne * sizeof(float),       stream);
+                        cudaMemcpyAsync(d_B_ptrs,   h_B_ptrs.data(),
+                                        ne * sizeof(const void*), cudaMemcpyHostToDevice, stream);
+                        cudaMemcpyAsync(d_SFB_ptrs, h_SFB_ptrs.data(),
+                                        ne * sizeof(const void*), cudaMemcpyHostToDevice, stream);
+                        cudaMemcpyAsync(d_alpha,    h_alpha.data(),
+                                        ne * sizeof(float),       cudaMemcpyHostToDevice, stream);
+                        // SFA byte-offset prefix sum on device (Phase 3a kernel).
+                        imp::compute_sfa_offsets_device(moe_.d_M_per, moe_.d_sfa_offsets,
+                                                        ne, K_in, stream);
+
+                        imp::GroupedNvfp4DeviceArgs dargs{};
+                        dargs.d_M_per          = moe_.d_M_per;
+                        dargs.d_expert_offsets =
+                            static_cast<const int32_t*>(routing.expert_offsets.data);
+                        dargs.d_sfa_offsets    = moe_.d_sfa_offsets;
+                        dargs.d_alpha          = d_alpha;
+                        dargs.base_A_packed    = moe_.cutlass3x_packed;
+                        dargs.base_A_sf        = moe_.cutlass3x_sf;
+                        dargs.d_B_ptrs         = d_B_ptrs;
+                        dargs.d_SFB_ptrs       = d_SFB_ptrs;
+                        dargs.base_D           = c_base;
+
+                        bool ok = imp::gemm_grouped_cutlass_3x_nvfp4_device_args(
+                            ne, N_out, K_in, dargs, stream);
+
+                        cudaFreeAsync(d_B_ptrs,   stream);
+                        cudaFreeAsync(d_SFB_ptrs, stream);
+                        cudaFreeAsync(d_alpha,    stream);
+                        return ok;
+                    };
+
                     // Dispatch a grouped GEMM given already-quantized activations.
                     auto grouped_gemm = [&](const std::vector<TensorID>& weight_ids, char* c_base, int K_in,
                                             int N_out, const std::vector<size_t>& sfa_offsets) {
+                        if (use_device_args) {
+                            if (layer == 0)
+                                IMP_LOG_INFO(
+                                    "MoE prefill: CUTLASS 3.x device-args path "
+                                    "(opt-in via IMP_NVFP4_DEVICE_ARGS=1)");
+                            if (grouped_gemm_device(weight_ids, c_base, K_in, N_out))
+                                return;
+                            IMP_LOG_ERROR(
+                                "device-args dispatch failed; falling back to host-args");
+                        }
                         char* all_packed = static_cast<char*>(moe_.cutlass3x_packed);
                         uint8_t* all_sfa = static_cast<uint8_t*>(moe_.cutlass3x_sf);
                         // Active experts only (CUTLASS 3.x wants non-empty groups).

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1291,6 +1291,131 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     // Gated by IMP_CUTLASS3X_MOE=1. Zero dequant overhead vs the nvfp4→FP16
                     // batch path; per-group alpha via CUTLASS fusion_args.alpha_ptr_array.
                     // =========================================================================
+                    //
+                    // Phase 3c-full Step 2b: optional fully device-args dispatch placed
+                    // BEFORE the D2H+sync. When IMP_NVFP4_DEVICE_ARGS=1 and all required
+                    // workspace buffers exist, runs gate / up / activation / down end-
+                    // to-end via device-resident kernels and skips the legacy code path
+                    // below. No host iteration over M_per / h_offsets, no D2H+sync —
+                    // prerequisite for graph capture of the MoE prefill path. Falls
+                    // back to the legacy path on any dispatch failure.
+                    bool device_args_done = false;
+                    {
+                        const char* da_env = ::getenv("IMP_NVFP4_DEVICE_ARGS");
+                        const bool use_device_args =
+                            da_env && std::atoi(da_env) != 0 &&
+                            moe_.d_M_per && moe_.d_M_per_count >= ne &&
+                            moe_.d_sfa_offsets && moe_.d_B_ptrs_cache &&
+                            moe_.d_SFB_ptrs_cache && moe_.d_alpha_full &&
+                            moe_.cutlass3x_packed && moe_.cutlass3x_sf &&
+                            moe_.cutlass3x_sfa_ptrs &&
+                            moe_.cutlass3x_sfa_ptrs_count >= ne;
+                        if (use_device_args) {
+                            if (layer == 0)
+                                IMP_LOG_INFO(
+                                    "MoE prefill: CUTLASS 3.x device-args full path "
+                                    "(opt-in via IMP_NVFP4_DEVICE_ARGS=1)");
+                            // Populate device-resident d_M_per (no D2H).
+                            imp::compute_M_per_from_offsets_device(
+                                static_cast<const int32_t*>(routing.expert_offsets.data),
+                                moe_.d_M_per, ne, stream);
+
+                            char* gathered_base    = static_cast<char*>(moe_.gathered.data);
+                            char* expert_gate_base = static_cast<char*>(moe_.expert_gate.data);
+                            char* expert_up_base   = static_cast<char*>(moe_.expert_up.data);
+                            char* expert_swiglu_base =
+                                static_cast<char*>(moe_.expert_swiglu.data);
+                            char* expert_down_base = static_cast<char*>(moe_.expert_down.data);
+
+                            auto quantize_device = [&](const char* a_base, int K_in) {
+                                imp::compute_sfa_offsets_device(
+                                    moe_.d_M_per, moe_.d_sfa_offsets, ne, K_in, stream);
+                                imp::build_sfa_bases_device(
+                                    reinterpret_cast<uint8_t**>(moe_.cutlass3x_sfa_ptrs),
+                                    moe_.cutlass3x_sf, moe_.d_sfa_offsets, ne, stream);
+                                // Zero the active SFA region. The padded rows of the
+                                // SfAtom layout must be 0 for clean CUTLASS reads.
+                                // We zero the whole staging buffer — graph-capturable
+                                // alternative to host-computed total_sfa. Cost is ~2 MB
+                                // memset (~3 µs at 1.8 TB/s).
+                                cudaMemsetAsync(moe_.cutlass3x_sf, 0,
+                                                moe_.cutlass3x_sf_size, stream);
+                                imp::quantize_fp16_to_nvfp4_cutlass_moe(
+                                    a_base, moe_.cutlass3x_packed,
+                                    reinterpret_cast<uint8_t* const*>(moe_.cutlass3x_sfa_ptrs),
+                                    static_cast<const int*>(routing.expert_offsets.data),
+                                    expanded, K_in, ne, stream);
+                            };
+
+                            auto dispatch_device =
+                                [&](const std::vector<TensorID>& weight_ids, char* c_base,
+                                    int K_in, int N_out) -> bool {
+                                    std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
+                                    std::vector<float> h_alpha(ne);
+                                    for (int e = 0; e < ne; ++e) {
+                                        const auto& h = registry_.handle(weight_ids[e]);
+                                        h_B_ptrs[e]   = h.payload.cutlass_nvfp4.weight;
+                                        h_SFB_ptrs[e] = h.payload.cutlass_nvfp4.sf;
+                                        h_alpha[e] =
+                                            h.payload.cutlass_nvfp4.global_scale
+                                                ? *h.payload.cutlass_nvfp4.global_scale
+                                                : 1.0f;
+                                    }
+                                    cudaMemcpyAsync(moe_.d_B_ptrs_cache, h_B_ptrs.data(),
+                                                    ne * sizeof(const void*),
+                                                    cudaMemcpyHostToDevice, stream);
+                                    cudaMemcpyAsync(moe_.d_SFB_ptrs_cache, h_SFB_ptrs.data(),
+                                                    ne * sizeof(const void*),
+                                                    cudaMemcpyHostToDevice, stream);
+                                    cudaMemcpyAsync(moe_.d_alpha_full, h_alpha.data(),
+                                                    ne * sizeof(float),
+                                                    cudaMemcpyHostToDevice, stream);
+
+                                    imp::GroupedNvfp4DeviceArgs dargs{};
+                                    dargs.d_M_per          = moe_.d_M_per;
+                                    dargs.d_expert_offsets = static_cast<const int32_t*>(
+                                        routing.expert_offsets.data);
+                                    dargs.d_sfa_offsets    = moe_.d_sfa_offsets;
+                                    dargs.d_alpha          = moe_.d_alpha_full;
+                                    dargs.base_A_packed    = moe_.cutlass3x_packed;
+                                    dargs.base_A_sf        = moe_.cutlass3x_sf;
+                                    dargs.d_B_ptrs         = moe_.d_B_ptrs_cache;
+                                    dargs.d_SFB_ptrs       = moe_.d_SFB_ptrs_cache;
+                                    dargs.base_D           = c_base;
+                                    return imp::gemm_grouped_cutlass_3x_nvfp4_device_args(
+                                        ne, N_out, K_in, dargs, stream);
+                                };
+
+                            // Gate / Up share input quantization (K_in = d).
+                            quantize_device(gathered_base, d);
+                            bool ok = true;
+                            if (!non_gated_experts)
+                                ok = ok && dispatch_device(ly.expert_gate_ids,
+                                                           expert_gate_base, d, eff);
+                            ok = ok && dispatch_device(ly.expert_up_ids,
+                                                       expert_up_base, d, eff);
+                            if (ok) {
+                                apply_expert_activation(
+                                    moe_.expert_gate.data, moe_.expert_up.data,
+                                    moe_.expert_swiglu.data, non_gated_experts, expanded,
+                                    eff, compute_dtype_, cfg.ffn_activation, stream);
+                                char* down_act =
+                                    non_gated_experts ? expert_up_base : expert_swiglu_base;
+                                quantize_device(down_act, eff);
+                                ok = dispatch_device(ly.expert_down_ids,
+                                                     expert_down_base, eff, d);
+                            }
+                            if (ok) {
+                                device_args_done = true;
+                            } else {
+                                IMP_LOG_ERROR(
+                                    "device-args full path failed; falling back to legacy");
+                            }
+                        }
+                    }
+
+                    if (!device_args_done) {
+                    // Legacy D2H+sync + smallM + non-smallM dispatch path.
                     std::vector<int32_t> h_offsets(ne + 1);
                     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_offsets.data(), routing.expert_offsets.data,
                                                        static_cast<size_t>(ne + 1) * sizeof(int32_t),
@@ -1870,6 +1995,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                         grouped_gemm(ly.expert_down_ids, expert_down_base, eff, d, sfa_offs);
                     }
                     }  // !smallM_done
+                    }  // !device_args_done
 
                     // Falls through to scatter (step 7)
 

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1347,40 +1347,66 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                     expanded, K_in, ne, stream);
                             };
 
+                            // Per-layer pre-cached arrays (Phase 3c-full Step 3).
+                            // When ready, all three projections feed dispatch_device with
+                            // device-resident ptr arrays — no per-call host iteration,
+                            // no H2D. Falls back to the per-call upload via the workspace
+                            // caches from Step 1 when the pre-cache isn't built.
+                            const bool da_cache_ready =
+                                layer < static_cast<int>(moe_.per_layer_da_cache.size()) &&
+                                moe_.per_layer_da_cache[layer].ready;
+                            const auto& da_cache =
+                                da_cache_ready
+                                    ? moe_.per_layer_da_cache[layer]
+                                    : MoEWorkspace::PerLayerNvfp4DeviceArgsCache{};
+
                             auto dispatch_device =
-                                [&](const std::vector<TensorID>& weight_ids, char* c_base,
-                                    int K_in, int N_out) -> bool {
-                                    std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
-                                    std::vector<float> h_alpha(ne);
-                                    for (int e = 0; e < ne; ++e) {
-                                        const auto& h = registry_.handle(weight_ids[e]);
-                                        h_B_ptrs[e]   = h.payload.cutlass_nvfp4.weight;
-                                        h_SFB_ptrs[e] = h.payload.cutlass_nvfp4.sf;
-                                        h_alpha[e] =
-                                            h.payload.cutlass_nvfp4.global_scale
-                                                ? *h.payload.cutlass_nvfp4.global_scale
-                                                : 1.0f;
+                                [&](const std::vector<TensorID>& weight_ids,
+                                    const void** pre_d_B, const void** pre_d_SFB,
+                                    float* pre_d_alpha, char* c_base, int K_in,
+                                    int N_out) -> bool {
+                                    const void** d_B   = pre_d_B;
+                                    const void** d_SFB = pre_d_SFB;
+                                    float*       d_a   = pre_d_alpha;
+                                    if (!d_B || !d_SFB || !d_a) {
+                                        // Pre-cache miss — fall back to per-call H2D
+                                        // into the workspace caches from Step 1.
+                                        std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
+                                        std::vector<float> h_alpha(ne);
+                                        for (int e = 0; e < ne; ++e) {
+                                            const auto& h = registry_.handle(weight_ids[e]);
+                                            h_B_ptrs[e]   = h.payload.cutlass_nvfp4.weight;
+                                            h_SFB_ptrs[e] = h.payload.cutlass_nvfp4.sf;
+                                            h_alpha[e] =
+                                                h.payload.cutlass_nvfp4.global_scale
+                                                    ? *h.payload.cutlass_nvfp4.global_scale
+                                                    : 1.0f;
+                                        }
+                                        cudaMemcpyAsync(moe_.d_B_ptrs_cache, h_B_ptrs.data(),
+                                                        ne * sizeof(const void*),
+                                                        cudaMemcpyHostToDevice, stream);
+                                        cudaMemcpyAsync(moe_.d_SFB_ptrs_cache,
+                                                        h_SFB_ptrs.data(),
+                                                        ne * sizeof(const void*),
+                                                        cudaMemcpyHostToDevice, stream);
+                                        cudaMemcpyAsync(moe_.d_alpha_full, h_alpha.data(),
+                                                        ne * sizeof(float),
+                                                        cudaMemcpyHostToDevice, stream);
+                                        d_B   = moe_.d_B_ptrs_cache;
+                                        d_SFB = moe_.d_SFB_ptrs_cache;
+                                        d_a   = moe_.d_alpha_full;
                                     }
-                                    cudaMemcpyAsync(moe_.d_B_ptrs_cache, h_B_ptrs.data(),
-                                                    ne * sizeof(const void*),
-                                                    cudaMemcpyHostToDevice, stream);
-                                    cudaMemcpyAsync(moe_.d_SFB_ptrs_cache, h_SFB_ptrs.data(),
-                                                    ne * sizeof(const void*),
-                                                    cudaMemcpyHostToDevice, stream);
-                                    cudaMemcpyAsync(moe_.d_alpha_full, h_alpha.data(),
-                                                    ne * sizeof(float),
-                                                    cudaMemcpyHostToDevice, stream);
 
                                     imp::GroupedNvfp4DeviceArgs dargs{};
                                     dargs.d_M_per          = moe_.d_M_per;
                                     dargs.d_expert_offsets = static_cast<const int32_t*>(
                                         routing.expert_offsets.data);
                                     dargs.d_sfa_offsets    = moe_.d_sfa_offsets;
-                                    dargs.d_alpha          = moe_.d_alpha_full;
+                                    dargs.d_alpha          = d_a;
                                     dargs.base_A_packed    = moe_.cutlass3x_packed;
                                     dargs.base_A_sf        = moe_.cutlass3x_sf;
-                                    dargs.d_B_ptrs         = moe_.d_B_ptrs_cache;
-                                    dargs.d_SFB_ptrs       = moe_.d_SFB_ptrs_cache;
+                                    dargs.d_B_ptrs         = d_B;
+                                    dargs.d_SFB_ptrs       = d_SFB;
                                     dargs.base_D           = c_base;
                                     return imp::gemm_grouped_cutlass_3x_nvfp4_device_args(
                                         ne, N_out, K_in, dargs, stream);
@@ -1391,8 +1417,14 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                             bool ok = true;
                             if (!non_gated_experts)
                                 ok = ok && dispatch_device(ly.expert_gate_ids,
+                                                           da_cache.d_gate_B_ptrs,
+                                                           da_cache.d_gate_SFB_ptrs,
+                                                           da_cache.d_gate_alpha,
                                                            expert_gate_base, d, eff);
                             ok = ok && dispatch_device(ly.expert_up_ids,
+                                                       da_cache.d_up_B_ptrs,
+                                                       da_cache.d_up_SFB_ptrs,
+                                                       da_cache.d_up_alpha,
                                                        expert_up_base, d, eff);
                             if (ok) {
                                 apply_expert_activation(
@@ -1403,6 +1435,9 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                     non_gated_experts ? expert_up_base : expert_swiglu_base;
                                 quantize_device(down_act, eff);
                                 ok = dispatch_device(ly.expert_down_ids,
+                                                     da_cache.d_down_B_ptrs,
+                                                     da_cache.d_down_SFB_ptrs,
+                                                     da_cache.d_down_alpha,
                                                      expert_down_base, eff, d);
                             }
                             if (ok) {

--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -2386,6 +2386,87 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
             "(GGUF blocks + norms + scratch — bypass the overlay layer)",
             model_->gpu_allocations_.size());
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 3c-full Step 3: pre-cache per-layer NVFP4 device-args ptr arrays.
+    // -----------------------------------------------------------------------
+    // The CUTLASS 3.x device-args dispatch (Phase 3c-full Step 2b, opt-in via
+    // IMP_NVFP4_DEVICE_ARGS=1) consumes per-expert weight pointers as
+    // device-resident arrays. Per-call host iteration + 3× cudaMemcpyAsync
+    // (~3 KiB total) was the residual overhead blocking full CUDA-graph
+    // capture of the MoE prefill. Build the caches once here while the
+    // handle payloads are guaranteed populated; the forward path then uses
+    // the device pointers directly.
+    //
+    // Conditions: model is MoE (ne > 0) and at least one layer has all three
+    // projections backed by CUTLASS NVFP4 handles (post-Phase-3 setup).
+    {
+        const auto& cfg = model_->config();
+        const int ne = cfg.n_experts;
+        const int n_layers = cfg.n_layers;
+        if (ne > 0) {
+        moe_.per_layer_da_cache.assign(n_layers, MoEWorkspace::PerLayerNvfp4DeviceArgsCache{});
+
+        std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
+        std::vector<float>       h_alpha(ne);
+        bool any_built = false;
+
+        auto build_proj =
+            [&](const std::vector<TensorID>& ids, const void**& d_B,
+                const void**& d_SFB, float*& d_alpha) -> bool {
+                if (static_cast<int>(ids.size()) != ne)
+                    return false;
+                for (int e = 0; e < ne; ++e) {
+                    if (ids[e] == kInvalidTensorID)
+                        return false;
+                    const auto& h = registry_.handle(ids[e]);
+                    if (!h.payload.cutlass_nvfp4.weight ||
+                        !h.payload.cutlass_nvfp4.sf)
+                        return false;
+                    h_B_ptrs[e]   = h.payload.cutlass_nvfp4.weight;
+                    h_SFB_ptrs[e] = h.payload.cutlass_nvfp4.sf;
+                    h_alpha[e]    = h.payload.cutlass_nvfp4.global_scale
+                                        ? *h.payload.cutlass_nvfp4.global_scale
+                                        : 1.0f;
+                }
+                cudaError_t err;
+                err = cudaMalloc(&d_B,   ne * sizeof(const void*)); if (err != cudaSuccess) return false;
+                err = cudaMalloc(&d_SFB, ne * sizeof(const void*)); if (err != cudaSuccess) return false;
+                err = cudaMalloc(&d_alpha, ne * sizeof(float));     if (err != cudaSuccess) return false;
+                cudaMemcpy(const_cast<void**>(d_B),   h_B_ptrs.data(),
+                           ne * sizeof(const void*), cudaMemcpyHostToDevice);
+                cudaMemcpy(const_cast<void**>(d_SFB), h_SFB_ptrs.data(),
+                           ne * sizeof(const void*), cudaMemcpyHostToDevice);
+                cudaMemcpy(d_alpha, h_alpha.data(),
+                           ne * sizeof(float),       cudaMemcpyHostToDevice);
+                return true;
+            };
+
+        for (int li = 0; li < n_layers; ++li) {
+            const auto& L = model_->layer(li);
+            auto& c = moe_.per_layer_da_cache[li];
+            bool g_ok = !L.expert_gate_ids.empty() &&
+                        build_proj(L.expert_gate_ids, c.d_gate_B_ptrs,
+                                   c.d_gate_SFB_ptrs, c.d_gate_alpha);
+            bool u_ok = build_proj(L.expert_up_ids, c.d_up_B_ptrs,
+                                   c.d_up_SFB_ptrs, c.d_up_alpha);
+            bool d_ok = build_proj(L.expert_down_ids, c.d_down_B_ptrs,
+                                   c.d_down_SFB_ptrs, c.d_down_alpha);
+            // For non-gated experts (e.g. Gemma-4 SwiGLU absorbing W_gate),
+            // expert_gate_ids may be empty by design — accept up+down only.
+            c.ready = (g_ok || L.expert_gate_ids.empty()) && u_ok && d_ok;
+            any_built = any_built || c.ready;
+        }
+        if (any_built) {
+            IMP_LOG_INFO(
+                "Pre-cached per-layer NVFP4 device-args ptr arrays for "
+                "%d layers × 3 projections × %d experts (~%.1f KiB)",
+                n_layers, ne,
+                (n_layers * 3.0 * ne * (2 * sizeof(void*) + sizeof(float))) /
+                    1024.0);
+        }
+        }  // ne > 0
+    }
 }
 
 }  // namespace imp

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -444,6 +444,16 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 moe_.d_na = nullptr;
             }
 
+            // SFA byte-offsets prefix sum (Phase 3 staging). n_experts+1 int64
+            // = trivial (<2 KiB for 128 experts).
+            err = cudaMalloc(&moe_.d_sfa_offsets,
+                             static_cast<size_t>(cfg.n_experts + 1) * sizeof(int64_t));
+            if (err != cudaSuccess) {
+                IMP_LOG_DEBUG("Optional MoE d_sfa_offsets alloc failed: %s",
+                              cudaGetErrorString(err));
+                moe_.d_sfa_offsets = nullptr;
+            }
+
             // Device-side weight pointer array for device-grouped GEMM.
             size_t wptr_bytes = static_cast<size_t>(cfg.n_experts) * sizeof(void*);
             err = cudaMalloc(&moe_.d_weight_ptrs, wptr_bytes);

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -415,6 +415,19 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 moe_.d_fp8_scales = nullptr;
             }
 
+            // Per-expert device-resident token-count buffer (n_experts × 4 bytes).
+            // Populated each forward by compute_M_per_from_offsets_device, replacing
+            // the host D2H+sync+loop pattern in the MoE prefill dispatch path.
+            size_t m_per_bytes = static_cast<size_t>(cfg.n_experts) * sizeof(int32_t);
+            err = cudaMalloc(&moe_.d_M_per, m_per_bytes);
+            if (err == cudaSuccess) {
+                moe_.d_M_per_count = cfg.n_experts;
+            } else {
+                IMP_LOG_DEBUG("Optional MoE d_M_per alloc failed: %s", cudaGetErrorString(err));
+                moe_.d_M_per = nullptr;
+                moe_.d_M_per_count = 0;
+            }
+
             // Device-side weight pointer array for device-grouped GEMM.
             size_t wptr_bytes = static_cast<size_t>(cfg.n_experts) * sizeof(void*);
             err = cudaMalloc(&moe_.d_weight_ptrs, wptr_bytes);

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -428,6 +428,22 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 moe_.d_M_per_count = 0;
             }
 
+            // Compact-alpha output buffer + active-expert counter. Populated by
+            // compact_alpha_active. Sized for max n_experts (only first d_na
+            // entries used at dispatch).
+            err = cudaMalloc(&moe_.d_alpha_compact,
+                             static_cast<size_t>(cfg.n_experts) * sizeof(float));
+            if (err != cudaSuccess) {
+                IMP_LOG_DEBUG("Optional MoE d_alpha_compact alloc failed: %s",
+                              cudaGetErrorString(err));
+                moe_.d_alpha_compact = nullptr;
+            }
+            err = cudaMalloc(&moe_.d_na, sizeof(int32_t));
+            if (err != cudaSuccess) {
+                IMP_LOG_DEBUG("Optional MoE d_na alloc failed: %s", cudaGetErrorString(err));
+                moe_.d_na = nullptr;
+            }
+
             // Device-side weight pointer array for device-grouped GEMM.
             size_t wptr_bytes = static_cast<size_t>(cfg.n_experts) * sizeof(void*);
             err = cudaMalloc(&moe_.d_weight_ptrs, wptr_bytes);

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -454,6 +454,30 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 moe_.d_sfa_offsets = nullptr;
             }
 
+            // Phase 3c-full Step 1 — device-args ptr/alpha caches. n_experts ×
+            // (2 × sizeof(void*) + sizeof(float)) ≈ 2.5 KiB for 128 experts.
+            err = cudaMalloc(&moe_.d_B_ptrs_cache,
+                             static_cast<size_t>(cfg.n_experts) * sizeof(const void*));
+            if (err != cudaSuccess) {
+                IMP_LOG_DEBUG("Optional MoE d_B_ptrs_cache alloc failed: %s",
+                              cudaGetErrorString(err));
+                moe_.d_B_ptrs_cache = nullptr;
+            }
+            err = cudaMalloc(&moe_.d_SFB_ptrs_cache,
+                             static_cast<size_t>(cfg.n_experts) * sizeof(const void*));
+            if (err != cudaSuccess) {
+                IMP_LOG_DEBUG("Optional MoE d_SFB_ptrs_cache alloc failed: %s",
+                              cudaGetErrorString(err));
+                moe_.d_SFB_ptrs_cache = nullptr;
+            }
+            err = cudaMalloc(&moe_.d_alpha_full,
+                             static_cast<size_t>(cfg.n_experts) * sizeof(float));
+            if (err != cudaSuccess) {
+                IMP_LOG_DEBUG("Optional MoE d_alpha_full alloc failed: %s",
+                              cudaGetErrorString(err));
+                moe_.d_alpha_full = nullptr;
+            }
+
             // Device-side weight pointer array for device-grouped GEMM.
             size_t wptr_bytes = static_cast<size_t>(cfg.n_experts) * sizeof(void*);
             err = cudaMalloc(&moe_.d_weight_ptrs, wptr_bytes);

--- a/src/graph/moe_workspace.cu
+++ b/src/graph/moe_workspace.cu
@@ -37,6 +37,12 @@ void MoEWorkspace::free(VRAMAllocator* alloc) {
         d_fp8_scales = nullptr;
     }
 
+    if (d_M_per) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_M_per));
+        d_M_per = nullptr;
+        d_M_per_count = 0;
+    }
+
     if (d_weight_ptrs) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_weight_ptrs));
         d_weight_ptrs = nullptr;

--- a/src/graph/moe_workspace.cu
+++ b/src/graph/moe_workspace.cu
@@ -43,6 +43,16 @@ void MoEWorkspace::free(VRAMAllocator* alloc) {
         d_M_per_count = 0;
     }
 
+    if (d_alpha_compact) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_alpha_compact));
+        d_alpha_compact = nullptr;
+    }
+
+    if (d_na) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_na));
+        d_na = nullptr;
+    }
+
     if (d_weight_ptrs) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_weight_ptrs));
         d_weight_ptrs = nullptr;

--- a/src/graph/moe_workspace.cu
+++ b/src/graph/moe_workspace.cu
@@ -58,6 +58,19 @@ void MoEWorkspace::free(VRAMAllocator* alloc) {
         d_sfa_offsets = nullptr;
     }
 
+    if (d_B_ptrs_cache) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_B_ptrs_cache));
+        d_B_ptrs_cache = nullptr;
+    }
+    if (d_SFB_ptrs_cache) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_SFB_ptrs_cache));
+        d_SFB_ptrs_cache = nullptr;
+    }
+    if (d_alpha_full) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_alpha_full));
+        d_alpha_full = nullptr;
+    }
+
     if (d_weight_ptrs) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_weight_ptrs));
         d_weight_ptrs = nullptr;

--- a/src/graph/moe_workspace.cu
+++ b/src/graph/moe_workspace.cu
@@ -71,6 +71,16 @@ void MoEWorkspace::free(VRAMAllocator* alloc) {
         d_alpha_full = nullptr;
     }
 
+    // Phase 3c-full Step 3 per-layer caches.
+    for (auto& c : per_layer_da_cache) {
+        auto cfree = [](void* p) { if (p) IMP_CUDA_CHECK_LOG(cudaFree(p)); };
+        cfree(c.d_gate_B_ptrs);   cfree(c.d_gate_SFB_ptrs);   cfree(c.d_gate_alpha);
+        cfree(c.d_up_B_ptrs);     cfree(c.d_up_SFB_ptrs);     cfree(c.d_up_alpha);
+        cfree(c.d_down_B_ptrs);   cfree(c.d_down_SFB_ptrs);   cfree(c.d_down_alpha);
+        c = {};
+    }
+    per_layer_da_cache.clear();
+
     if (d_weight_ptrs) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_weight_ptrs));
         d_weight_ptrs = nullptr;

--- a/src/graph/moe_workspace.cu
+++ b/src/graph/moe_workspace.cu
@@ -53,6 +53,11 @@ void MoEWorkspace::free(VRAMAllocator* alloc) {
         d_na = nullptr;
     }
 
+    if (d_sfa_offsets) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_sfa_offsets));
+        d_sfa_offsets = nullptr;
+    }
+
     if (d_weight_ptrs) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_weight_ptrs));
         d_weight_ptrs = nullptr;

--- a/src/graph/moe_workspace.h
+++ b/src/graph/moe_workspace.h
@@ -50,6 +50,14 @@ struct MoEWorkspace {
     // Per-expert FP8 scale buffer: [n_experts] floats on device.
     float* d_fp8_scales = nullptr;
 
+    // Per-expert token-count buffer: [n_experts] int32 on device.
+    // Populated by compute_M_per_from_offsets_device from routing.expert_offsets.
+    // Replaces the host-side D2H + sync + loop pattern in MoE prefill dispatch
+    // (executor_forward_moe.cu). Prerequisite for CUDA-graph capture of the
+    // prefill path. See plan moe_prefill_graphs_plan_2026_05_10.
+    int32_t* d_M_per = nullptr;
+    int d_M_per_count = 0;
+
     // Device-side weight pointer array for device-grouped GEMM.
     void** d_weight_ptrs = nullptr;
     int d_weight_ptrs_count = 0;

--- a/src/graph/moe_workspace.h
+++ b/src/graph/moe_workspace.h
@@ -58,6 +58,13 @@ struct MoEWorkspace {
     int32_t* d_M_per = nullptr;
     int d_M_per_count = 0;
 
+    // Compact-alpha output buffer: [n_experts] floats on device. Populated by
+    // compact_alpha_active and consumed by the grouped GEMM dispatch when not
+    // all experts are active. First d_na valid entries; rest unused.
+    float* d_alpha_compact = nullptr;
+    // Active-expert count: [1] int32 on device. Written by compact_alpha_active.
+    int32_t* d_na = nullptr;
+
     // Device-side weight pointer array for device-grouped GEMM.
     void** d_weight_ptrs = nullptr;
     int d_weight_ptrs_count = 0;

--- a/src/graph/moe_workspace.h
+++ b/src/graph/moe_workspace.h
@@ -65,6 +65,13 @@ struct MoEWorkspace {
     // Active-expert count: [1] int32 on device. Written by compact_alpha_active.
     int32_t* d_na = nullptr;
 
+    // Per-expert SFA byte-offsets into the CUTLASS 3.x SfAtom-padded staging
+    // buffer (Phase 3 of moe_prefill_graphs_plan_2026_05_10). Exclusive prefix
+    // sum of cutlass_nvfp4_sf_size(M_per[e], K) — populated each forward by
+    // compute_sfa_offsets_device. Replaces the host-side sfa_offsets loop in
+    // executor_forward_moe.cu's quantize_once lambda. [n_experts+1] int64.
+    int64_t* d_sfa_offsets = nullptr;
+
     // Device-side weight pointer array for device-grouped GEMM.
     void** d_weight_ptrs = nullptr;
     int d_weight_ptrs_count = 0;

--- a/src/graph/moe_workspace.h
+++ b/src/graph/moe_workspace.h
@@ -72,6 +72,17 @@ struct MoEWorkspace {
     // executor_forward_moe.cu's quantize_once lambda. [n_experts+1] int64.
     int64_t* d_sfa_offsets = nullptr;
 
+    // Phase 3c-full Step 1 caches for the device-args wrapper:
+    // - d_B_ptrs_cache:   [n_experts] device array of per-expert weight pointers
+    // - d_SFB_ptrs_cache: [n_experts] device array of per-expert SFB pointers
+    // - d_alpha_full:     [n_experts] device floats per-expert alpha
+    // Filled per-call from the registry handles (host) via cudaMemcpyAsync;
+    // shared across all three projections (gate / up / down) inside one
+    // forward layer. Replaces the per-call cudaMallocAsync of the MVP wire.
+    const void** d_B_ptrs_cache   = nullptr;
+    const void** d_SFB_ptrs_cache = nullptr;
+    float*       d_alpha_full     = nullptr;
+
     // Device-side weight pointer array for device-grouped GEMM.
     void** d_weight_ptrs = nullptr;
     int d_weight_ptrs_count = 0;

--- a/src/graph/moe_workspace.h
+++ b/src/graph/moe_workspace.h
@@ -79,9 +79,32 @@ struct MoEWorkspace {
     // Filled per-call from the registry handles (host) via cudaMemcpyAsync;
     // shared across all three projections (gate / up / down) inside one
     // forward layer. Replaces the per-call cudaMallocAsync of the MVP wire.
+    // Superseded by per_layer_da_cache below when da_cache_ready is true —
+    // these stay around for any future per-call fallback path.
     const void** d_B_ptrs_cache   = nullptr;
     const void** d_SFB_ptrs_cache = nullptr;
     float*       d_alpha_full     = nullptr;
+
+    // Phase 3c-full Step 3: per-layer pre-cached device-args ptr arrays.
+    // Built once at model-load time (pre_dequant_weights) when handle payloads
+    // are populated; reused on every forward call with no host iteration and
+    // no per-call H2D. Prerequisite for CUDA-graph capture of the MoE prefill.
+    struct PerLayerNvfp4DeviceArgsCache {
+        const void** d_gate_B_ptrs   = nullptr;
+        const void** d_gate_SFB_ptrs = nullptr;
+        float*       d_gate_alpha    = nullptr;
+        const void** d_up_B_ptrs     = nullptr;
+        const void** d_up_SFB_ptrs   = nullptr;
+        float*       d_up_alpha      = nullptr;
+        const void** d_down_B_ptrs   = nullptr;
+        const void** d_down_SFB_ptrs = nullptr;
+        float*       d_down_alpha    = nullptr;
+        // True if all 9 buffers above are non-null AND populated. Tested in
+        // the device-args dispatch to gate whether the pre-cache fast-path
+        // can fire (otherwise fall back to per-call H2D into d_B_ptrs_cache).
+        bool ready = false;
+    };
+    std::vector<PerLayerNvfp4DeviceArgsCache> per_layer_da_cache;
 
     // Device-side weight pointer array for device-grouped GEMM.
     void** d_weight_ptrs = nullptr;

--- a/tests/test_cutlass_grouped_3x_nvfp4.cu
+++ b/tests/test_cutlass_grouped_3x_nvfp4.cu
@@ -323,6 +323,7 @@ TEST_F(CutlassGrouped3xNvfp4Test, DeviceArgsMatchesHostArgs) {
     cudaMemcpy(d_sfa_offsets, h_sfa_offsets.data(), (ne + 1) * sizeof(int64_t), cudaMemcpyHostToDevice);
     cudaMemcpy(d_alpha,       hAlpha.data(),        ne * sizeof(float),         cudaMemcpyHostToDevice);
 
+    // Mode (a): contiguous B/SFB slab + per-expert byte stride.
     GroupedNvfp4DeviceArgs dargs{};
     dargs.d_M_per                = d_M_per;
     dargs.d_expert_offsets       = d_offsets;
@@ -334,6 +335,8 @@ TEST_F(CutlassGrouped3xNvfp4Test, DeviceArgsMatchesHostArgs) {
     dargs.b_expert_stride_packed = static_cast<int64_t>(b_packed_per_expert);
     dargs.base_B_sf              = d_B_sf_slab;
     dargs.b_expert_stride_sf     = static_cast<int64_t>(sfb_per_expert);
+    dargs.d_B_ptrs               = nullptr;  // mode (a) — base + stride
+    dargs.d_SFB_ptrs             = nullptr;
     dargs.base_D                 = d_dev_out;
 
     ASSERT_TRUE(gemm_grouped_cutlass_3x_nvfp4_device_args(ne, N, K, dargs, stream_))
@@ -353,8 +356,55 @@ TEST_F(CutlassGrouped3xNvfp4Test, DeviceArgsMatchesHostArgs) {
         max_abs_err = std::max<double>(max_abs_err, err);
     }
     EXPECT_EQ(mismatches, 0)
-        << "device-args output differs from host-args (" << mismatches << " / "
+        << "device-args (mode a) output differs from host-args (" << mismatches << " / "
         << ref_out.size() << " mismatches, max_err=" << max_abs_err << ")";
+
+    // ----- Mode (b): per-expert pointer arrays. Builds device-resident ptr
+    //       arrays that point into the SAME slab — both modes must yield the
+    //       same output. -----
+    void* d_dev_out_b = nullptr;
+    cudaMalloc(&d_dev_out_b, static_cast<size_t>(M_total) * N * sizeof(half));
+    cudaMemset(d_dev_out_b, 0, static_cast<size_t>(M_total) * N * sizeof(half));
+
+    std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
+    for (int e = 0; e < ne; ++e) {
+        h_B_ptrs[e]   = static_cast<const char*>(d_B_packed_slab) + e * b_packed_per_expert;
+        h_SFB_ptrs[e] = static_cast<const char*>(d_B_sf_slab)     + e * sfb_per_expert;
+    }
+    const void** d_B_ptrs   = nullptr;
+    const void** d_SFB_ptrs = nullptr;
+    cudaMalloc(&d_B_ptrs,   ne * sizeof(const void*));
+    cudaMalloc(&d_SFB_ptrs, ne * sizeof(const void*));
+    cudaMemcpy(d_B_ptrs,   h_B_ptrs.data(),   ne * sizeof(const void*), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_SFB_ptrs, h_SFB_ptrs.data(), ne * sizeof(const void*), cudaMemcpyHostToDevice);
+
+    GroupedNvfp4DeviceArgs dargs_b = dargs;
+    dargs_b.base_B_packed          = nullptr;  // ignored when d_B_ptrs set
+    dargs_b.b_expert_stride_packed = 0;
+    dargs_b.base_B_sf              = nullptr;
+    dargs_b.b_expert_stride_sf     = 0;
+    dargs_b.d_B_ptrs               = d_B_ptrs;
+    dargs_b.d_SFB_ptrs             = d_SFB_ptrs;
+    dargs_b.base_D                 = d_dev_out_b;
+
+    ASSERT_TRUE(gemm_grouped_cutlass_3x_nvfp4_device_args(ne, N, K, dargs_b, stream_))
+        << "device-args wrapper (mode b) failed";
+    cudaStreamSynchronize(stream_);
+    std::vector<half> dev_out_b(static_cast<size_t>(M_total) * N);
+    cudaMemcpy(dev_out_b.data(), d_dev_out_b, dev_out_b.size() * sizeof(half), cudaMemcpyDeviceToHost);
+
+    int mismatches_b = 0;
+    double max_abs_err_b = 0.0;
+    for (size_t i = 0; i < ref_out.size(); ++i) {
+        float a = __half2float(ref_out[i]);
+        float b = __half2float(dev_out_b[i]);
+        float err = std::fabs(a - b);
+        if (err > 0.0f) mismatches_b++;
+        max_abs_err_b = std::max<double>(max_abs_err_b, err);
+    }
+    EXPECT_EQ(mismatches_b, 0)
+        << "device-args (mode b) output differs from host-args (" << mismatches_b << " / "
+        << ref_out.size() << " mismatches, max_err=" << max_abs_err_b << ")";
 
     // ----- Cleanup -----
     for (int i = 0; i < ne; ++i) free_expert(experts[i]);
@@ -365,10 +415,13 @@ TEST_F(CutlassGrouped3xNvfp4Test, DeviceArgsMatchesHostArgs) {
     cudaFree(d_B_sf_slab);
     cudaFree(d_ref_out);
     cudaFree(d_dev_out);
+    cudaFree(d_dev_out_b);
     cudaFree(d_M_per);
     cudaFree(d_offsets);
     cudaFree(d_sfa_offsets);
     cudaFree(d_alpha);
+    cudaFree(d_B_ptrs);
+    cudaFree(d_SFB_ptrs);
 }
 
 }  // namespace

--- a/tests/test_cutlass_grouped_3x_nvfp4.cu
+++ b/tests/test_cutlass_grouped_3x_nvfp4.cu
@@ -193,5 +193,183 @@ TEST_F(CutlassGrouped3xNvfp4Test, GroupedMatchesPerExpertSingle) {
     cudaFree(d_grp_out);
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3b: device-args wrapper must produce bit-identical output to the
+// host-args wrapper on the same per-expert problem (both call the same
+// underlying CUTLASS adapter; only the staging buffer build differs).
+// ---------------------------------------------------------------------------
+TEST_F(CutlassGrouped3xNvfp4Test, DeviceArgsMatchesHostArgs) {
+    if (sm_ < 120) {
+        GTEST_SKIP() << "SM120 required";
+    }
+    if (!cutlass_sm120_nvfp4_available()) {
+        GTEST_SKIP() << "CUTLASS NVFP4 disabled";
+    }
+    if (!cutlass_grouped_3x_nvfp4_available()) {
+        GTEST_SKIP() << "CUTLASS 3x grouped NVFP4 disabled";
+    }
+
+    const int ne = 4;
+    const int N  = 256;
+    const int K  = 256;
+    const std::vector<int> M_per = {32, 16, 48, 64};
+    int M_total = 0;
+    for (int m : M_per) M_total += m;
+
+    // ----- 4 synthetic experts with CONTIGUOUS B/SFB (so b_expert_stride_*
+    //       are constant — required by the device-args base+stride layout). -----
+    std::vector<SyntheticExpert> experts(ne);
+    for (int i = 0; i < ne; ++i) {
+        make_expert(experts[i], N, K, /*wscale=*/0.5f, /*seed=*/200 + i, stream_);
+    }
+    // Stack per-expert B/SFB into a single contiguous slab.
+    const size_t b_packed_per_expert = static_cast<size_t>(N) * K / 2;
+    const size_t sfb_per_expert      = cutlass_nvfp4_sf_size(N, K);
+    void* d_B_packed_slab = nullptr;
+    void* d_B_sf_slab     = nullptr;
+    cudaMalloc(&d_B_packed_slab, b_packed_per_expert * ne);
+    cudaMalloc(&d_B_sf_slab,     sfb_per_expert * ne);
+    for (int i = 0; i < ne; ++i) {
+        cudaMemcpyAsync(static_cast<char*>(d_B_packed_slab) + i * b_packed_per_expert,
+                        experts[i].cutlass_w.data, b_packed_per_expert,
+                        cudaMemcpyDeviceToDevice, stream_);
+        cudaMemcpyAsync(static_cast<char*>(d_B_sf_slab) + i * sfb_per_expert,
+                        experts[i].cutlass_w.scale_factors, sfb_per_expert,
+                        cudaMemcpyDeviceToDevice, stream_);
+    }
+    cudaStreamSynchronize(stream_);
+
+    // ----- FP16 activations [M_total, K], quantize to a CONTIGUOUS A slab -----
+    std::mt19937 agen(43);
+    std::uniform_real_distribution<float> adist(-1.0f, 1.0f);
+    std::vector<half> h_A(static_cast<size_t>(M_total) * K);
+    for (auto& v : h_A) v = __float2half(adist(agen));
+    void* d_A_fp16 = nullptr;
+    cudaMalloc(&d_A_fp16, h_A.size() * sizeof(half));
+    cudaMemcpy(d_A_fp16, h_A.data(), h_A.size() * sizeof(half), cudaMemcpyHostToDevice);
+
+    // Contiguous packed A slab: total_packed = sum(M_per * K / 2).
+    // Contiguous SFA slab:      total_sfa    = sum(cutlass_nvfp4_sf_size(M_per, K)).
+    size_t total_packed = 0;
+    std::vector<int>     h_offsets(ne + 1, 0);
+    std::vector<int64_t> h_sfa_offsets(ne + 1, 0);
+    for (int e = 0; e < ne; ++e) {
+        total_packed     += static_cast<size_t>(M_per[e]) * K / 2;
+        h_offsets[e + 1]      = h_offsets[e] + M_per[e];
+        h_sfa_offsets[e + 1]  = h_sfa_offsets[e] +
+                                static_cast<int64_t>(cutlass_nvfp4_sf_size(M_per[e], K));
+    }
+    void* d_A_packed_slab = nullptr;
+    void* d_A_sf_slab     = nullptr;
+    cudaMalloc(&d_A_packed_slab, total_packed);
+    cudaMalloc(&d_A_sf_slab,     h_sfa_offsets[ne]);
+    // Quantize each expert's chunk into the contiguous slab.
+    int row_offset = 0;
+    for (int i = 0; i < ne; ++i) {
+        const half* a_src =
+            reinterpret_cast<const half*>(d_A_fp16) + static_cast<size_t>(row_offset) * K;
+        void* dst_packed =
+            static_cast<char*>(d_A_packed_slab) + static_cast<size_t>(row_offset) * K / 2;
+        void* dst_sf =
+            static_cast<char*>(d_A_sf_slab) + h_sfa_offsets[i];
+        quantize_fp16_to_nvfp4_cutlass(a_src, dst_packed, dst_sf, M_per[i], K, stream_);
+        row_offset += M_per[i];
+    }
+    cudaStreamSynchronize(stream_);
+
+    // ----- Reference: host-args wrapper -----
+    void* d_ref_out = nullptr;
+    cudaMalloc(&d_ref_out, static_cast<size_t>(M_total) * N * sizeof(half));
+    cudaMemset(d_ref_out, 0, static_cast<size_t>(M_total) * N * sizeof(half));
+
+    std::vector<const void*> hA(ne), hSFA(ne), hB(ne), hSFB(ne);
+    std::vector<void*> hD(ne);
+    std::vector<float> hAlpha(ne);
+    int dst_row = 0;
+    for (int e = 0; e < ne; ++e) {
+        hA[e]   = static_cast<const char*>(d_A_packed_slab) +
+                  static_cast<size_t>(h_offsets[e]) * K / 2;
+        hSFA[e] = static_cast<const char*>(d_A_sf_slab) + h_sfa_offsets[e];
+        hB[e]   = static_cast<const char*>(d_B_packed_slab) + e * b_packed_per_expert;
+        hSFB[e] = static_cast<const char*>(d_B_sf_slab)     + e * sfb_per_expert;
+        hD[e]   = static_cast<char*>(d_ref_out) +
+                  static_cast<size_t>(dst_row) * N * sizeof(half);
+        hAlpha[e] = experts[e].cutlass_w.tensor_scale;
+        dst_row += M_per[e];
+    }
+    ASSERT_TRUE(gemm_grouped_cutlass_3x_nvfp4(ne, M_per.data(), N, K, hA.data(), hSFA.data(),
+                                              hB.data(), hSFB.data(), hD.data(), hAlpha.data(),
+                                              stream_))
+        << "host-args wrapper failed";
+    cudaStreamSynchronize(stream_);
+    std::vector<half> ref_out(static_cast<size_t>(M_total) * N);
+    cudaMemcpy(ref_out.data(), d_ref_out, ref_out.size() * sizeof(half), cudaMemcpyDeviceToHost);
+
+    // ----- Device-args wrapper: same inputs, device-resident metadata -----
+    void* d_dev_out = nullptr;
+    cudaMalloc(&d_dev_out, static_cast<size_t>(M_total) * N * sizeof(half));
+    cudaMemset(d_dev_out, 0, static_cast<size_t>(M_total) * N * sizeof(half));
+
+    int32_t* d_M_per   = nullptr;
+    int32_t* d_offsets = nullptr;
+    int64_t* d_sfa_offsets = nullptr;
+    float*   d_alpha   = nullptr;
+    cudaMalloc(&d_M_per,       ne       * sizeof(int32_t));
+    cudaMalloc(&d_offsets,     (ne + 1) * sizeof(int32_t));
+    cudaMalloc(&d_sfa_offsets, (ne + 1) * sizeof(int64_t));
+    cudaMalloc(&d_alpha,       ne       * sizeof(float));
+    cudaMemcpy(d_M_per,       M_per.data(),         ne * sizeof(int32_t),       cudaMemcpyHostToDevice);
+    cudaMemcpy(d_offsets,     h_offsets.data(),     (ne + 1) * sizeof(int32_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_sfa_offsets, h_sfa_offsets.data(), (ne + 1) * sizeof(int64_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha,       hAlpha.data(),        ne * sizeof(float),         cudaMemcpyHostToDevice);
+
+    GroupedNvfp4DeviceArgs dargs{};
+    dargs.d_M_per                = d_M_per;
+    dargs.d_expert_offsets       = d_offsets;
+    dargs.d_sfa_offsets          = d_sfa_offsets;
+    dargs.d_alpha                = d_alpha;
+    dargs.base_A_packed          = d_A_packed_slab;
+    dargs.base_A_sf              = d_A_sf_slab;
+    dargs.base_B_packed          = d_B_packed_slab;
+    dargs.b_expert_stride_packed = static_cast<int64_t>(b_packed_per_expert);
+    dargs.base_B_sf              = d_B_sf_slab;
+    dargs.b_expert_stride_sf     = static_cast<int64_t>(sfb_per_expert);
+    dargs.base_D                 = d_dev_out;
+
+    ASSERT_TRUE(gemm_grouped_cutlass_3x_nvfp4_device_args(ne, N, K, dargs, stream_))
+        << "device-args wrapper failed";
+    cudaStreamSynchronize(stream_);
+    std::vector<half> dev_out(static_cast<size_t>(M_total) * N);
+    cudaMemcpy(dev_out.data(), d_dev_out, dev_out.size() * sizeof(half), cudaMemcpyDeviceToHost);
+
+    // ----- Compare: both wrappers use the same CUTLASS adapter, so bit-exact -----
+    int mismatches = 0;
+    double max_abs_err = 0.0;
+    for (size_t i = 0; i < ref_out.size(); ++i) {
+        float a = __half2float(ref_out[i]);
+        float b = __half2float(dev_out[i]);
+        float err = std::fabs(a - b);
+        if (err > 0.0f) mismatches++;
+        max_abs_err = std::max<double>(max_abs_err, err);
+    }
+    EXPECT_EQ(mismatches, 0)
+        << "device-args output differs from host-args (" << mismatches << " / "
+        << ref_out.size() << " mismatches, max_err=" << max_abs_err << ")";
+
+    // ----- Cleanup -----
+    for (int i = 0; i < ne; ++i) free_expert(experts[i]);
+    cudaFree(d_A_fp16);
+    cudaFree(d_A_packed_slab);
+    cudaFree(d_A_sf_slab);
+    cudaFree(d_B_packed_slab);
+    cudaFree(d_B_sf_slab);
+    cudaFree(d_ref_out);
+    cudaFree(d_dev_out);
+    cudaFree(d_M_per);
+    cudaFree(d_offsets);
+    cudaFree(d_sfa_offsets);
+    cudaFree(d_alpha);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_quantize_fp16_nvfp4_moe_native.cu
+++ b/tests/test_quantize_fp16_nvfp4_moe_native.cu
@@ -404,6 +404,38 @@ TEST(QuantizeMoeNative, ComputeSfaOffsetsDeviceMatchesHost) {
     cudaStreamDestroy(stream);
 }
 
+// build_sfa_bases_device must write base + d_sfa_offsets[e] per expert.
+// Phase 3c-full Step 2a foundation.
+TEST(QuantizeMoeNative, BuildSfaBasesDevice) {
+    const int ne = 4;
+    // Simulate base SFA slab via a known device pointer (any aligned alloc).
+    void* d_base = nullptr;
+    cudaMalloc(&d_base, 65536);  // 64 KiB sentinel buffer (only addresses matter)
+    const int64_t h_offsets[ne + 1] = {0, 512, 1024, 1024, 2560};  // bytes
+    int64_t*  d_offsets = nullptr;
+    uint8_t** d_bases   = nullptr;
+    cudaMalloc(&d_offsets, (ne + 1) * sizeof(int64_t));
+    cudaMalloc(&d_bases,   ne       * sizeof(uint8_t*));
+    cudaMemcpy(d_offsets, h_offsets, (ne + 1) * sizeof(int64_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::build_sfa_bases_device(d_bases, d_base, d_offsets, ne, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    uint8_t* got[ne] = {};
+    cudaMemcpy(got, d_bases, ne * sizeof(uint8_t*), cudaMemcpyDeviceToHost);
+    for (int e = 0; e < ne; ++e) {
+        uint8_t* expected = static_cast<uint8_t*>(d_base) + h_offsets[e];
+        EXPECT_EQ(got[e], expected) << "base[" << e << "] mismatch";
+    }
+
+    cudaFree(d_base);
+    cudaFree(d_offsets);
+    cudaFree(d_bases);
+    cudaStreamDestroy(stream);
+}
+
 // n_experts == 0: trailing slot 0 must be 0, no kernel work.
 TEST(QuantizeMoeNative, ComputeSfaOffsetsDeviceEmpty) {
     int64_t* d_offsets = nullptr;

--- a/tests/test_quantize_fp16_nvfp4_moe_native.cu
+++ b/tests/test_quantize_fp16_nvfp4_moe_native.cu
@@ -253,5 +253,132 @@ TEST(QuantizeMoeNative, ComputeMPerFromOffsetsDeviceEmpty) {
     cudaStreamDestroy(stream);
 }
 
+// ---------------------------------------------------------------------------
+// Test: compact_alpha_active — order-preserving stream compaction of d_alpha
+// to active-only experts. Phase 2 of moe_prefill_graphs_plan_2026_05_10.
+// ---------------------------------------------------------------------------
+TEST(QuantizeMoeNative, CompactAlphaActiveBasic) {
+    const int ne = 4;
+    const float    h_alpha[ne]   = {1.0f, 2.0f, 3.0f, 4.0f};
+    const int32_t  h_M_per[ne]   = {5, 0, 3, 0};
+    // Expected: na=2, alpha_compact=[1.0, 3.0] (active experts in source order).
+    const float    expected_compact[2] = {1.0f, 3.0f};
+    const int32_t  expected_na = 2;
+
+    float*   d_alpha   = nullptr;
+    int32_t* d_M_per   = nullptr;
+    float*   d_compact = nullptr;
+    int32_t* d_na      = nullptr;
+    cudaMalloc(&d_alpha,   ne * sizeof(float));
+    cudaMalloc(&d_M_per,   ne * sizeof(int32_t));
+    cudaMalloc(&d_compact, ne * sizeof(float));
+    cudaMalloc(&d_na,           sizeof(int32_t));
+    cudaMemcpy(d_alpha, h_alpha, ne * sizeof(float),   cudaMemcpyHostToDevice);
+    cudaMemcpy(d_M_per, h_M_per, ne * sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compact_alpha_active(d_alpha, d_M_per, d_compact, d_na, ne, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    int32_t got_na = -1;
+    cudaMemcpy(&got_na, d_na, sizeof(int32_t), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(got_na, expected_na);
+
+    float got_compact[2] = {};
+    cudaMemcpy(got_compact, d_compact, 2 * sizeof(float), cudaMemcpyDeviceToHost);
+    EXPECT_FLOAT_EQ(got_compact[0], expected_compact[0]);
+    EXPECT_FLOAT_EQ(got_compact[1], expected_compact[1]);
+
+    cudaFree(d_alpha); cudaFree(d_M_per);
+    cudaFree(d_compact); cudaFree(d_na);
+    cudaStreamDestroy(stream);
+}
+
+// All experts active: alpha_compact == alpha, na == n_experts.
+TEST(QuantizeMoeNative, CompactAlphaActiveAllActive) {
+    const int ne = 3;
+    const float   h_alpha[ne] = {0.5f, 1.5f, 2.5f};
+    const int32_t h_M[ne]     = {2, 4, 1};
+
+    float*   d_alpha   = nullptr;
+    int32_t* d_M       = nullptr;
+    float*   d_compact = nullptr;
+    int32_t* d_na      = nullptr;
+    cudaMalloc(&d_alpha,   ne * sizeof(float));
+    cudaMalloc(&d_M,       ne * sizeof(int32_t));
+    cudaMalloc(&d_compact, ne * sizeof(float));
+    cudaMalloc(&d_na,           sizeof(int32_t));
+    cudaMemcpy(d_alpha, h_alpha, ne * sizeof(float),   cudaMemcpyHostToDevice);
+    cudaMemcpy(d_M,     h_M,     ne * sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compact_alpha_active(d_alpha, d_M, d_compact, d_na, ne, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    int32_t got_na = -1;
+    cudaMemcpy(&got_na, d_na, sizeof(int32_t), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(got_na, ne);
+
+    float got[ne] = {};
+    cudaMemcpy(got, d_compact, ne * sizeof(float), cudaMemcpyDeviceToHost);
+    for (int i = 0; i < ne; ++i)
+        EXPECT_FLOAT_EQ(got[i], h_alpha[i]);
+
+    cudaFree(d_alpha); cudaFree(d_M); cudaFree(d_compact); cudaFree(d_na);
+    cudaStreamDestroy(stream);
+}
+
+// No active experts: na=0; compact buffer untouched.
+TEST(QuantizeMoeNative, CompactAlphaActiveNoneActive) {
+    const int ne = 4;
+    const float   h_alpha[ne] = {1.0f, 2.0f, 3.0f, 4.0f};
+    const int32_t h_M[ne]     = {0, 0, 0, 0};
+
+    float*   d_alpha   = nullptr;
+    int32_t* d_M       = nullptr;
+    float*   d_compact = nullptr;
+    int32_t* d_na      = nullptr;
+    cudaMalloc(&d_alpha,   ne * sizeof(float));
+    cudaMalloc(&d_M,       ne * sizeof(int32_t));
+    cudaMalloc(&d_compact, ne * sizeof(float));
+    cudaMalloc(&d_na,           sizeof(int32_t));
+    cudaMemcpy(d_alpha, h_alpha, ne * sizeof(float),   cudaMemcpyHostToDevice);
+    cudaMemcpy(d_M,     h_M,     ne * sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compact_alpha_active(d_alpha, d_M, d_compact, d_na, ne, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    int32_t got_na = -1;
+    cudaMemcpy(&got_na, d_na, sizeof(int32_t), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(got_na, 0);
+
+    cudaFree(d_alpha); cudaFree(d_M); cudaFree(d_compact); cudaFree(d_na);
+    cudaStreamDestroy(stream);
+}
+
+// n_experts == 0: na written as 0, no kernel launch needed.
+TEST(QuantizeMoeNative, CompactAlphaActiveEmpty) {
+    int32_t* d_na = nullptr;
+    cudaMalloc(&d_na, sizeof(int32_t));
+    int32_t init = 999;
+    cudaMemcpy(d_na, &init, sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compact_alpha_active(nullptr, nullptr, nullptr, d_na, 0, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    int32_t got = -1;
+    cudaMemcpy(&got, d_na, sizeof(int32_t), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(got, 0);
+
+    cudaFree(d_na);
+    cudaStreamDestroy(stream);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_quantize_fp16_nvfp4_moe_native.cu
+++ b/tests/test_quantize_fp16_nvfp4_moe_native.cu
@@ -210,5 +210,48 @@ TEST(QuantizeMoeNative, EmptyExpertNocrash) {
     cudaStreamDestroy(stream);
 }
 
+// ---------------------------------------------------------------------------
+// Test: compute_M_per_from_offsets_device — device-side per-expert token count.
+// Replaces the host-side cudaMemcpyAsync(D2H) + sync + loop pattern in MoE
+// prefill dispatch. Required for CUDA-graph capture (Phase 1 of MoE-prefill-
+// graphs lever, plan moe_prefill_graphs_plan_2026_05_10).
+// ---------------------------------------------------------------------------
+TEST(QuantizeMoeNative, ComputeMPerFromOffsetsDevice) {
+    const int ne = 4;
+    // Offsets: [0, 3, 3, 7, 10] → M_per: [3, 0, 4, 3]
+    const int32_t h_offsets[ne + 1] = {0, 3, 3, 7, 10};
+    const int32_t expected_M[ne]    = {3, 0, 4, 3};
+
+    int32_t* d_offsets = nullptr;
+    int32_t* d_M_per   = nullptr;
+    cudaMalloc(&d_offsets, (ne + 1) * sizeof(int32_t));
+    cudaMalloc(&d_M_per,   ne       * sizeof(int32_t));
+    cudaMemcpy(d_offsets, h_offsets, (ne + 1) * sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compute_M_per_from_offsets_device(d_offsets, d_M_per, ne, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    int32_t got_M[ne] = {};
+    cudaMemcpy(got_M, d_M_per, ne * sizeof(int32_t), cudaMemcpyDeviceToHost);
+
+    for (int e = 0; e < ne; ++e)
+        EXPECT_EQ(got_M[e], expected_M[e]) << "M_per[" << e << "] mismatch";
+
+    cudaFree(d_offsets);
+    cudaFree(d_M_per);
+    cudaStreamDestroy(stream);
+}
+
+// n_experts == 0 must not launch a kernel and must not segfault.
+TEST(QuantizeMoeNative, ComputeMPerFromOffsetsDeviceEmpty) {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compute_M_per_from_offsets_device(nullptr, nullptr, 0, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    cudaStreamDestroy(stream);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_quantize_fp16_nvfp4_moe_native.cu
+++ b/tests/test_quantize_fp16_nvfp4_moe_native.cu
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "compute/quantize_fp16_nvfp4_moe_native.h"
+#include "compute/gemm_cutlass_sm120.h"  // cutlass_nvfp4_sf_size (host reference)
 #include "quant/nvfp4_quant.h"
 #include "core/tensor.h"
 #include <cuda_runtime.h>
@@ -357,6 +358,69 @@ TEST(QuantizeMoeNative, CompactAlphaActiveNoneActive) {
     EXPECT_EQ(got_na, 0);
 
     cudaFree(d_alpha); cudaFree(d_M); cudaFree(d_compact); cudaFree(d_na);
+    cudaStreamDestroy(stream);
+}
+
+// ---------------------------------------------------------------------------
+// Test: compute_sfa_offsets_device — exclusive prefix sum of SfAtom-padded SFA
+// byte sizes must match host cutlass_nvfp4_sf_size formula. Phase 3a of
+// moe_prefill_graphs_plan_2026_05_10.
+// ---------------------------------------------------------------------------
+TEST(QuantizeMoeNative, ComputeSfaOffsetsDeviceMatchesHost) {
+    // Mixed M values exercise the ceil(M/128) padding edge: 0, exactly 128,
+    // just-under-tile (127), small (1), and a couple of multi-tile values.
+    const int ne = 6;
+    const int K  = 256;  // n_k_tiles = ceil(256/64) = 4
+    const int32_t h_M[ne] = {0, 1, 127, 128, 129, 256};
+
+    int32_t* d_M = nullptr;
+    int64_t* d_offsets = nullptr;
+    cudaMalloc(&d_M,      ne       * sizeof(int32_t));
+    cudaMalloc(&d_offsets,(ne + 1) * sizeof(int64_t));
+    cudaMemcpy(d_M, h_M, ne * sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compute_sfa_offsets_device(d_M, d_offsets, ne, K, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    int64_t got[ne + 1] = {};
+    cudaMemcpy(got, d_offsets, (ne + 1) * sizeof(int64_t), cudaMemcpyDeviceToHost);
+
+    // Reference: exclusive prefix sum using host cutlass_nvfp4_sf_size.
+    int64_t expected[ne + 1] = {};
+    for (int e = 0; e < ne; ++e) {
+        expected[e + 1] = expected[e] +
+                          static_cast<int64_t>(imp::cutlass_nvfp4_sf_size(h_M[e], K));
+    }
+
+    for (int e = 0; e <= ne; ++e) {
+        EXPECT_EQ(got[e], expected[e])
+            << "sfa offset[" << e << "] mismatch (M_per=[0,1,127,128,129,256], K=" << K << ")";
+    }
+
+    cudaFree(d_M);
+    cudaFree(d_offsets);
+    cudaStreamDestroy(stream);
+}
+
+// n_experts == 0: trailing slot 0 must be 0, no kernel work.
+TEST(QuantizeMoeNative, ComputeSfaOffsetsDeviceEmpty) {
+    int64_t* d_offsets = nullptr;
+    cudaMalloc(&d_offsets, sizeof(int64_t));
+    int64_t init = 999;
+    cudaMemcpy(d_offsets, &init, sizeof(int64_t), cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    imp::compute_sfa_offsets_device(nullptr, d_offsets, 0, 256, stream);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    int64_t got = -1;
+    cudaMemcpy(&got, d_offsets, sizeof(int64_t), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(got, 0);
+
+    cudaFree(d_offsets);
     cudaStreamDestroy(stream);
 }
 

--- a/tools/analysis/sass_omma_audit.sh
+++ b/tools/analysis/sass_omma_audit.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Re-runnable SASS audit: enumerate every kernel in imp's sm_120a build that
+# emits OMMA (hardware FP4 block-scaled MMA), bucket by source file, and
+# flag suspicious absences (kernels you'd expect to use OMMA but don't).
+#
+# Why: the FP4 hot-path on consumer-Blackwell SM120 is `OMMA.SF.16864` —
+# *not* HMMA, *not* TCGEN05/UMMA/BMMA. Two earlier audit memos
+# (`sass_audit_120a_no_tcgen05_2026_05_04`,
+#  `nvfp4_moe_prefill_landscape_2026_05_10`) drew opposite conclusions
+# about which opcode actually drives FP4. This script gives a definitive
+# per-kernel breakdown so future kernel changes can be checked against it.
+#
+# Run after each significant NVFP4/MXFP4 change to verify:
+#   1) New CUTLASS dispatch sites still emit OMMA (not silent FP16 fallback).
+#   2) Hand-rolled FP4 kernels (smallM, FMHA-MXFP4) keep their OMMA count.
+#   3) No regression to `MUFU`-heavy software-dequant pattern.
+#
+# Usage: bash tools/analysis/sass_omma_audit.sh
+set -euo pipefail
+
+BIN="${IMP_CLI_BIN:-/usr/local/bin/imp-cli}"
+CUOBJDUMP=${CUOBJDUMP:-/usr/local/cuda/bin/cuobjdump}
+NVDISASM=${NVDISASM:-/usr/local/cuda/bin/nvdisasm}
+
+if [ ! -x "$BIN" ]; then
+    CID=$(docker create imp:test)
+    BIN=/tmp/imp-cli-omma-audit
+    docker cp "${CID}:/usr/local/bin/imp-cli" "$BIN"
+    docker rm "$CID" > /dev/null
+fi
+
+CUBIN=/tmp/imp-omma-audit.sm_120a.cubin
+SASS=/tmp/imp-omma-audit.sass
+rm -f "$CUBIN" "$SASS"
+
+TMPDIR=$(mktemp -d)
+pushd "$TMPDIR" > /dev/null
+ELF_NAME=$("$CUOBJDUMP" --list-elf "$BIN" 2>/dev/null \
+            | grep -oE "[A-Za-z0-9_.-]+\.sm_120a\.cubin" | head -1)
+if [ -z "$ELF_NAME" ]; then
+    echo "ERROR: no sm_120a cubin embedded in $BIN" >&2
+    exit 1
+fi
+"$CUOBJDUMP" --extract-elf "$ELF_NAME" "$BIN" > /dev/null
+mv "$ELF_NAME" "$CUBIN"
+popd > /dev/null
+rm -rf "$TMPDIR"
+
+"$NVDISASM" -c -ndf "$CUBIN" 2>/dev/null > "$SASS"
+
+echo "=== imp sm_120a SASS audit — OMMA inventory ==="
+echo "binary:  $BIN"
+echo "cubin:   $CUBIN ($(stat -c %s "$CUBIN") bytes)"
+echo "sass:    $SASS ($(stat -c %s "$SASS") bytes)"
+echo
+
+echo "--- aggregate tensor-core opcode counts ---"
+grep -oE "(OMMA|HMMA|IMMA|BMMA|TCGEN05|UMMA)\.[A-Z0-9.]*" "$SASS" \
+    | sort | uniq -c | sort -rn | head -20
+echo
+
+# Per-kernel OMMA / HMMA breakdown
+awk '
+/^\/\/-+ \.text\.[^ ]+ -+$/ {
+    if (kernel != "" && (omma > 0 || hmma > 0)) {
+        print kernel "\t" omma "\t" hmma
+    }
+    kernel = $2; sub(/^\.text\./, "", kernel)
+    omma = 0; hmma = 0
+    next
+}
+{
+    n = gsub(/OMMA\.SF/, "&"); omma += n
+    n = gsub(/HMMA\./,  "&"); hmma += n
+}
+END {
+    if (omma > 0 || hmma > 0) print kernel "\t" omma "\t" hmma
+}
+' "$SASS" > /tmp/imp-omma-audit.kernels.tsv
+
+echo "--- OMMA emitters bucketed by source file ---"
+python3 - <<'PY'
+import collections, re
+
+buckets = collections.defaultdict(lambda: {"omma": 0, "hmma": 0, "n": 0})
+suspicious = []  # kernels with hot-path-sounding names but 0 OMMA
+
+with open('/tmp/imp-omma-audit.kernels.tsv') as f:
+    for line in f:
+        line = line.rstrip('\n')
+        if not line:
+            continue
+        kern, omma, hmma = line.split('\t')
+        omma, hmma = int(omma), int(hmma)
+
+        if 'gemm_grouped_nvfp4_smallM_cu' in kern:
+            label = 'src/compute/gemm_grouped_nvfp4_smallM.cu (opt-in IMP_NVFP4_SMALLM)'
+        elif 'gemm_cutlass_mxfp4_sm120_cu' in kern:
+            label = 'src/compute/gemm_cutlass_mxfp4_sm120.cu'
+        elif 'gemm_cutlass_grouped_3x_cu' in kern:
+            label = 'src/compute/gemm_cutlass_grouped_3x.cu (MoE NVFP4 grouped)'
+        elif 'gemm_cutlass_sm120_cu' in kern:
+            label = 'src/compute/gemm_cutlass_sm120.cu (single-batch NVFP4)'
+        elif 'fmha_sm120_mxfp4_kernel' in kern:
+            label = 'src/compute/attention_fmha_mxfp4_sm120.cu (FMHA MXFP4-KV)'
+        elif re.search(r'(probe|bench|smoke).*(mxf4|nvfp4|mxfp4|blockscale)', kern):
+            label = 'probe/bench/smoke (microbench, not hot-path)'
+        elif 'cutlass' in kern and 'device_kernel' in kern:
+            label = 'cutlass<other> ' + ('grouped' if 'PtrArray' in kern else 'single')
+        else:
+            label = 'OTHER: ' + kern[:70]
+
+        if omma > 0:
+            b = buckets[label]
+            b["omma"] += omma
+            b["hmma"] += hmma
+            b["n"] += 1
+        elif hmma > 16 and any(s in kern for s in (
+                'nvfp4', 'mxfp4', 'blackwell', 'fp4'
+        )):
+            suspicious.append((kern, hmma))
+
+print(f"  {'kernels':>7}  {'OMMA':>6}  {'HMMA':>6}  source")
+print('  ' + '-' * 86)
+total = collections.Counter()
+for label, b in sorted(buckets.items(), key=lambda kv: -kv[1]['omma']):
+    print(f"  {b['n']:>7}  {b['omma']:>6}  {b['hmma']:>6}  {label}")
+    total["n"] += b["n"]; total["omma"] += b["omma"]; total["hmma"] += b["hmma"]
+print('  ' + '-' * 86)
+print(f"  {total['n']:>7}  {total['omma']:>6}  {total['hmma']:>6}  TOTAL")
+
+if suspicious:
+    print()
+    print('--- suspicious absences (FP4-named kernels with 0 OMMA, HMMA-only) ---')
+    for kern, hmma in suspicious[:10]:
+        print(f"  {hmma:>4} HMMA, 0 OMMA  —  {kern[:90]}")
+    print('  (these may legitimately dequant FP4→FP16 before HMMA — verify intentional)')
+PY
+
+echo
+echo "Re-run after kernel changes; compare against memory file"
+echo "  memory/sass_audit_120a_no_tcgen05_2026_05_04.md"


### PR DESCRIPTION
## Summary

NVFP4 MoE **prefill** ported into a fully device-args dispatch path, bypassing the upstream D2H+sync that was blocking CUDA-graph capture (Tier-2.2 lever from `hw_capability_audit_complete_2026_05_10`). **Now default on** after broad cross-model validation; `IMP_NVFP4_DEVICE_ARGS=0` forces the legacy path for A/B or workarounds.

🎯 **A/B (50 reps, same session per model):**
| Model | Default | Device-args | Δ |
|---|---:|---:|---:|
| Qwen3-Coder-30B-A3B-NVFP4 | 9388 | **13082** | **+39.4%** |
| Qwen3-30B-A3B-NVFP4-Modelopt | 10906 | **13864** | **+27.1%** |
| Qwen3.6-35B-A3B-NVFP4 | 7306 | **9019** | **+23.4%** |
| Gemma-4-26B-A4B-NVFP4 | 8349 | **9305** | **+11.4%** |

Decode unchanged or slightly improved (within ±2% noise band) on all four models. Output bit-identical for short prompts; long prompts diverge in wording but remain coherent (numerical drift from M=0 expert handling in CUTLASS — confirmed via the check-degeneration battery: stderr clean, no repetition loops, no NaN/Inf, no fallback, multi-prompt variety green).

## Phases shipped

**Phase 1 — device-resident `d_M_per`**
- `compute_M_per_from_offsets_device` kernel + 2 unit tests
- `moe_.d_M_per` workspace field

**Phase 2 — `compact_alpha_active` kernel + workspace**
- Order-preserving stream compaction via Hillis–Steele in shmem + 4 unit tests
- `moe_.d_alpha_compact` + `moe_.d_na` workspace fields

**Phase 3a — `compute_sfa_offsets_device` kernel + workspace**
- Int64 prefix sum of `cutlass_nvfp4_sf_size(M_per[e], K)` + 2 unit tests (parity vs host)
- `moe_.d_sfa_offsets` workspace field

**Phase 3b — device staging-build kernel + wrapper**
- `__global__ build_grouped_3x_staging_kernel` calls CUTLASS HOST_DEVICE primitives directly from device context.
- `gemm_grouped_cutlass_3x_nvfp4_device_args` wrapper variant.
- Mode (a) base+stride and Mode (b) per-expert ptr arrays.
- `CutlassGrouped3xNvfp4Test.DeviceArgsMatchesHostArgs` → **0 mismatches** vs host-args (bit-identical).

**Phase 3c-MVP wire — `IMP_NVFP4_DEVICE_ARGS=1`** (-16% pp512 per-call malloc cost — closed in Step 1)

**Phase 3c-full Step 1 — workspace cache for ptr arrays / alpha**
- Pre-allocates `moe_.d_B_ptrs_cache` / `d_SFB_ptrs_cache` / `d_alpha_full` (~3 KiB).

**Phase 3c-full Step 2a — `build_sfa_bases_device` kernel**
- Fills `moe_.cutlass3x_sfa_ptrs[e] = base + d_sfa_offsets[e]` device-side.

**Phase 3c-full Step 2b — full device-args dispatch path**
- New dispatch block at the top of the CUTLASS 3.x prefill, **before** the legacy D2H+sync.
- Runs gate / up / activation / down end-to-end via device-resident kernels.
- Skips smallM + non-smallM legacy via `if (!device_args_done) { ... legacy ... }`.

**Phase 3c-full Step 3 — pre-cache device-args ptr arrays at model load**
- Builds per-layer per-projection `d_B_ptrs / d_SFB_ptrs / d_alpha` at end of `pre_dequant_weights`.
- Eliminates per-call host iteration + 3× cudaMemcpyAsync.
- ~360 KiB total for Qwen3-Coder-30B (48 layers × 3 × 128 experts × 24 B).

**Default flip — IMP_NVFP4_DEVICE_ARGS on by default**
- Env-flag semantics inverted: default ON, set to `0` to force legacy.

## CUTLASS feasibility (confirmed during Phase 3b)

- `GroupProblemShape::problem_shapes` is a device pointer; SM120 grouped block-scaled mainloop reads per-group strides/layouts/problem-shapes from device-resident arrays. `tensormaps_replace_global_address` + `tensormaps_replace_global_tensor_properties` patch TMA descriptors per-group at runtime.
- `tile_atom_to_shape_SFA/B` is CUTE_HOST_DEVICE; callable from a device kernel.
- Strides A/B/C/D ignore M_i — constant across experts.
- Example 92 + `MoEProblemShape` are SM100-only, not applicable on SM120.

## What's NOT in this PR (future work)

- **CUDA-graph capture of prefill**: now structurally possible (no D2H+sync, all device-resident), but adding prefill capture to the runtime's graph loop is a separate refactor. Decode fast-path graph gives +193–234%; analogous prefill gain plausible.
- **M=0 expert compaction**: would close the long-prompt wording divergence (currently slight numerical drift, output remains coherent).

## Test plan

- [x] 10 new GTests across `tests/test_quantize_fp16_nvfp4_moe_native.cu` and `tests/test_cutlass_grouped_3x_nvfp4.cu`. All pass.
- [x] `make verify-fast` green on every commit.
- [x] **Cross-model A/B (4 NVFP4 MoE models)**: consistent +11–39% pp512.
- [x] Smoke: identical token IDs for short prompts on Qwen3-Coder and Gemma-4.
- [x] Degeneration battery (skill `check-degeneration`): stderr clean, no repetition loops, multi-prompt variety green.
- [x] Pre-push hook re-ran verify-fast on the final commit set.

## Refs

- Plan memo: `moe_prefill_graphs_plan_2026_05_10`
- Landscape memo: `nvfp4_moe_prefill_landscape_2026_05_10`
- Audit (lever origin): `hw_capability_audit_complete_2026_05_10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)