### PR TITLE
perf(cutlass): bump pin v4.4.2 → v4.5.0 — +4.7% NVFP4 MoE prefill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ option(IMP_USE_CUTLASS "Use CUTLASS for MoE GEMM (requires sm_90+)" ON)
 if(IMP_USE_CUTLASS)
     FetchContent_Declare(cutlass
         GIT_REPOSITORY https://github.com/NVIDIA/cutlass.git
-        GIT_TAG v4.4.2
+        GIT_TAG v4.5.0
         GIT_SHALLOW TRUE
         EXCLUDE_FROM_ALL
     )


### PR DESCRIPTION
## Summary

CUTLASS v4.5.0 (tagged 2026-05-12) lands SM120 BlockScaled **Small-Tile-N** support — new tile shapes 128x32xK and 128x64xK in the grouped MoE GEMM mainloop (commit [b46b16d0](https://github.com/NVIDIA/cutlass/commit/b46b16d0), "Small Tile N BlockScaled GEMM + Grouped GEMM"). The release notes claim "up to 30% on Blackwell SM121"; on SM120 (RTX 5090) the actual gain is more modest but reproducible.

## A/B (50-rep stable bench, same Docker session, only CMakeLists.txt pin change)

| Model | v4.4.2 pp512 | v4.5.0 pp512 | Δ |
|---|---:|---:|---:|
| Qwen3-Coder-30B-A3B-NVFP4 | 12280 | 12857 | **+4.7%** |
| Gemma-4-26B-A4B-NVFP4 | 8708 | 9118 | **+4.7%** |

Decode unchanged (within 0.4% noise band on both models). `make verify-fast` on Qwen3-4B Q8_0: decode +3.7%, prefill +2.9% — also positive at slightly smaller magnitudes, the auto-tuner picks up new tile options on the dense GEMM path too.

## Why earlier 'no win' memo was wrong

The memo `cutlass_4_5_sm120_research_2026_05_10` benched commit `cb37157d` (pre-release, "v4.5 tag update") and concluded "no win" — that commit was **before** b46b16d0 landed the SM120 tile additions. The tagged v4.5.0 release does include them.

## Compat

- No API breaks for our usage.
- Deprecated `ab_dtype` parameter in `make_trivial_tiled_mma` — not used in imp.
- All other v4.5.0 SM-arch features (B200 MMA, MoEProblemShape, etc.) are SM100-only and irrelevant to imp.

## Test plan

- [x] `make build` clean on v4.5.0 (no header conflicts, no template errors)
- [x] `make verify-fast` green — decode +3.72% / prefill +2.90% on Qwen3-4B Q8_0, graphs 1.61× decode speedup, 'Paris' smoke coherent
- [x] Cross-model NVFP4 MoE A/B (Qwen3-Coder + Gemma-4) — both +4.7% prefill, decode flat
- [x] Pre-push hook re-ran verify-fast on the final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)