### PR TITLE
perf(nvfp4): size dequant workspace from MoE + per-layer NVFP4 tensors

### DIFF
--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -717,14 +717,65 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
 }
 
 bool GraphExecutor::allocate_nvfp4_dequant_workspace() {
-    // Iterate populated NVFP4 weight cache to find the largest weight matrix.
-    // The gemm_nvfp4 fallback dequantizes one weight at a time to FP16 — the
-    // workspace only needs to fit the LARGEST single weight (N × K × 2 bytes).
+    // Iterate populated NVFP4 weight caches to find the largest single dequant
+    // target. The gemm_nvfp4 fallback dequantizes one weight at a time to FP16
+    // — the workspace only needs to fit the LARGEST single weight (N × K × 2
+    // bytes). MoE caches contribute per-expert weights (callers slice one
+    // expert at a time into a synthetic NvFP4QuantResult before invoking
+    // gemm_nvfp4 — see executor_forward_moe.cu).
     size_t max_bytes = 0;
-    for (const auto& [ptr, qr] : wcache_.nvfp4) {
-        size_t bytes = static_cast<size_t>(qr.N) * qr.K * sizeof(half);
+    auto consider = [&max_bytes](int64_t N, int64_t K) {
+        size_t bytes = static_cast<size_t>(N) * static_cast<size_t>(K) * sizeof(half);
         if (bytes > max_bytes)
             max_bytes = bytes;
+    };
+    for (const auto& [ptr, qr] : wcache_.nvfp4)
+        consider(qr.N, qr.K);
+    for (const auto& [ptr, moe] : wcache_.nvfp4_moe)
+        consider(moe.N, moe.K);  // single-expert dequant slice
+    for (const auto& [ptr, cw] : wcache_.cutlass_nvfp4)
+        consider(cw.N, cw.K);
+    // SafeTensors NVFP4 prequant: per-tensor and per-expert NVFP4 storage lives
+    // on the Layer struct (qtype=NVFP4 with scales sidecar), not in wcache_.
+    // The gemm_nvfp4 fallback (executor_forward_moe.cu line ~2369 for MoE
+    // experts, and executor_kernels.cu:2052 for dense weights including shared
+    // experts) constructs a synthetic NvFP4QuantResult with N=t.shape[0],
+    // K=t.shape[1]*2 (logical, since shape[1] is FP4-packed bytes). Iterate
+    // every NVFP4 tensor on the layer to find the largest dequant target.
+    if (model_ != nullptr) {
+        const int n_layers = model_->n_layers();
+        for (int li = 0; li < n_layers; ++li) {
+            const auto& L = model_->layer(li);
+            auto consider_t = [&](const Tensor& t) {
+                if (t.qtype != QType::NVFP4 || t.data == nullptr || t.ndim < 2)
+                    return;
+                // 2D dense weight [N, K_packed] → dequant target N × K_logical
+                // 3D MoE packed [n_experts, N, K_packed] → per-expert N × K_logical
+                int64_t N = (t.ndim == 2) ? t.shape[0] : t.shape[1];
+                int64_t K_packed = (t.ndim == 2) ? t.shape[1] : t.shape[2];
+                consider(N, K_packed * 2);
+            };
+            // Attention weights
+            consider_t(L.wq);
+            consider_t(L.wk);
+            consider_t(L.wv);
+            consider_t(L.wo);
+            // Dense MLP (used for shared experts in MoE models like Gemma-4)
+            consider_t(L.w_gate);
+            consider_t(L.w_up);
+            consider_t(L.w_down);
+            consider_t(L.w_gate_shared);
+            consider_t(L.w_up_shared);
+            consider_t(L.w_down_shared);
+            // MoE per-expert vectors
+            for (const auto& t : L.expert_w_gate) consider_t(t);
+            for (const auto& t : L.expert_w_up) consider_t(t);
+            for (const auto& t : L.expert_w_down) consider_t(t);
+            // MoE packed 3D
+            consider_t(L.expert_gate_packed);
+            consider_t(L.expert_up_packed);
+            consider_t(L.expert_down_packed);
+        }
     }
     if (max_bytes == 0) {
         // No NVFP4 weights — nothing to do. The fallback won't fire.
@@ -752,8 +803,12 @@ bool GraphExecutor::allocate_nvfp4_dequant_workspace() {
     }
     nvfp4_dequant_ws_size_ = max_bytes;
     set_nvfp4_dequant_workspace(nvfp4_dequant_ws_buf_, nvfp4_dequant_ws_size_);
-    IMP_LOG_INFO("gemm_nvfp4 dequant workspace: %.2f MiB (graph-safe M>1 fallback)",
-                 max_bytes / (1024.0 * 1024.0));
+    IMP_LOG_INFO(
+        "gemm_nvfp4 dequant workspace: %.2f MiB (graph-safe M>1 fallback; "
+        "covers dense=%zu, moe=%zu, cutlass=%zu cache entries + per-layer "
+        "SafeTensors NVFP4 expert tensors)",
+        max_bytes / (1024.0 * 1024.0), wcache_.nvfp4.size(), wcache_.nvfp4_moe.size(),
+        wcache_.cutlass_nvfp4.size());
     return true;
 }
 


### PR DESCRIPTION
## Summary

Blocker A from the prefill-graph diagnostic experiment (memo `prefill_graph_blockers_2026_05_14`, branch `experiment/prefill-graph-diagnostic`).

`GraphExecutor::allocate_nvfp4_dequant_workspace()` iterated only `wcache_.nvfp4` (dense decode cache). It missed:
1. `wcache_.nvfp4_moe` and `wcache_.cutlass_nvfp4` (per-expert MoE NVFP4 caches)
2. **Per-layer SafeTensors NVFP4 tensors** — attention weights (wq/wk/wv/wo), dense MLP weights (w_gate/up/down + shared variants for MoE models), and MoE per-expert vectors + 3D packed tensors

For SafeTensors-loaded NVFP4 MoE models (Gemma-4-NVFP4, Qwen3.6-NVFP4, Qwen3-Coder-NVFP4), the per-expert NVFP4 weights live on `Layer` Tensor fields with `qtype=NVFP4` — they are not registered in any `wcache_` map. The legacy `gemm_nvfp4` fallback (`executor_forward_moe.cu` line ~2369 for MoE experts; `executor_kernels.cu:2052` for dense weights) builds a synthetic `NvFP4QuantResult` from those Tensors and calls into `gemm_nvfp4`, which needs `N × K_logical × sizeof(half)` bytes of dequant scratch. Inside CUDA stream capture, `cudaMalloc` is illegal — the capture-guard fail-loud fired hundreds of times per prefill step on the diagnostic branch.

This change scans every NVFP4 tensor on every layer and sizes the workspace to the largest single dequant target.

## Validation

**Diagnostic re-run on Gemma-4-26B-A4B-NVFP4** (`experiment/prefill-graph-diagnostic` + this fix cherry-picked):
- Workspace before fix: `0 MiB`, blocker-error hit count `205`
- Workspace after fix: `44.00 MiB` (= largest single Gemma-4 dequant target), blocker-error hit count `0`
- Bench completes (Blocker B's CUTLASS-under-capture IMAs are a separate wild-card issue, documented in the diagnostic memo)

**verify-fast on this branch (off main):**
- decode tg128: +3.01% vs baseline (PASS 3% gate)
- prefill pp512: +2.77% vs baseline (PASS 5% gate)
- graphs ON: 1.83× decode speedup
- Paris smoke coherent
- 3/3 `NvFP4GemmGraphCapture` unit tests pass

## Why this matters even without prefill graphs

The slow `gemm_nvfp4` fallback can fire from any captured stream context — decode graphs already use this code path. The workspace was correctly pre-allocated for dense NVFP4 weights but silently incomplete for MoE/CUTLASS NVFP4 storage. If a future code path triggers this fallback during decode-graph capture on a MoE NVFP4 model, the capture would hard-fail.

Eager (non-captured) calls are unaffected — the lazy `cudaMalloc` path still works there.

## Test plan

- [x] `make build` clean
- [x] `make verify-fast` green (decode +3.01% / prefill +2.77%, graphs 1.83×, Paris smoke)
- [x] 3/3 `NvFP4GemmGraphCapture` unit tests pass
- [x] Cross-validated against `experiment/prefill-graph-diagnostic`: Gemma-4-NVFP4 `IMP_PREFILL_GRAPH=1` bench shows 0 × `nvfp4_gemm.cu:1212` errors (was 205)

🤖 Generated with [Claude Code](https://claude.com/claude-code)