### PR TITLE
diag(graph): IMP_GRAPH_CAPTURE_MODE env (Blocker B partial — hang gone, H2D-ptr blockers next)

### DIFF
--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -5,10 +5,35 @@
 #include "compute/sampling.h"
 #include "core/logging.h"
 #include <cuda_runtime.h>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
 namespace imp {
+
+// IMP_GRAPH_CAPTURE_MODE = "global" (default) | "relaxed" | "thread_local"
+// Selects the cudaStreamCaptureMode used by CudaGraphCapture::begin_capture and
+// the ConditionalRunner body-graph capture. Probed at first call and cached.
+//
+// Why this exists: CUTLASS 3.x grouped GEMM hangs under cudaStreamCaptureModeGlobal
+// for some NVFP4 MoE configs (see prefill_graph_blockers_2026_05_14). Relaxed
+// drops the cross-thread synchronization constraint and may avoid the deadlock.
+static cudaStreamCaptureMode get_capture_mode() {
+    static cudaStreamCaptureMode cached = []() {
+        const char* env = std::getenv("IMP_GRAPH_CAPTURE_MODE");
+        if (env == nullptr) return cudaStreamCaptureModeGlobal;
+        if (std::strcmp(env, "relaxed") == 0) {
+            IMP_LOG_INFO("CudaGraphCapture: using cudaStreamCaptureModeRelaxed (IMP_GRAPH_CAPTURE_MODE=relaxed)");
+            return cudaStreamCaptureModeRelaxed;
+        }
+        if (std::strcmp(env, "thread_local") == 0) {
+            IMP_LOG_INFO("CudaGraphCapture: using cudaStreamCaptureModeThreadLocal (IMP_GRAPH_CAPTURE_MODE=thread_local)");
+            return cudaStreamCaptureModeThreadLocal;
+        }
+        return cudaStreamCaptureModeGlobal;
+    }();
+    return cached;
+}
 
 // ---------------------------------------------------------------------------
 // apply_pdl_edges — convert kernel→kernel edges to PDL edges in a graph
@@ -137,7 +162,7 @@ bool CudaGraphCapture::begin_capture(cudaStream_t stream) {
         return false;
     }
 
-    cudaError_t err = cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal);
+    cudaError_t err = cudaStreamBeginCapture(stream, get_capture_mode());
     if (err != cudaSuccess) {
         IMP_LOG_ERROR("CudaGraphCapture: begin_capture failed: %s", cudaGetErrorString(err));
         return false;
@@ -752,7 +777,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         cudaStreamSynchronize(stream);
 
         err = cudaStreamBeginCaptureToGraph(stream, body_graph, nullptr, nullptr, 0,
-                                            cudaStreamCaptureModeGlobal);
+                                            get_capture_mode());
         if (err != cudaSuccess) {
             IMP_LOG_ERROR(
                 "ConditionalRunner: capture failed — falling back to per-step decode "


### PR DESCRIPTION
## Summary

Adds `IMP_GRAPH_CAPTURE_MODE` env var to swap the `cudaStreamCaptureMode` used in `CudaGraphCapture::begin_capture` and `ConditionalRunner` body-graph capture between `global` (default), `relaxed`, and `thread_local`.

- **Default unchanged** — `cudaStreamCaptureModeGlobal`, zero behavior change for any user.
- Opt-in only via env. Useful for diagnostic / power-user runs.
- verify-fast green: decode +2.27%, prefill +3.27%, graphs ON 2.11×.

## Why

The 2026-05-14 prefill-graph diagnostic experiment (see [memory file](https://github.com/...) — `prefill_graph_blockers_2026_05_14`) documented Blocker B as a **silent hang** inside `gemm_grouped_cutlass_3x_nvfp4_device_args()` under `cudaStreamCaptureModeGlobal`. Memo proposed the cheap experiment of swapping to `Relaxed` / `ThreadLocal`. This commit ships that experiment.

## Empirical results

Qwen3-Coder-30B-A3B-Instruct-FP4 + Gemma-4-26B-A4B-it-NVFP4 with `IMP_PREFILL_GRAPH=1`:

| Mode | Hang? | Capture? | Replay? |
|---|---|---|---|
| `global` (default) | **YES** — 120s timeout @ capture rep 2 | — | — |
| `relaxed` | NO | OK in ~15s | **IMA** |
| `thread_local` | NO | OK | **IMA** |

## What this means

The documented Blocker B (silent CUTLASS hang under capture) **is solved** by mode swap. But the silent hang was masking deeper structural blockers in the prefill path that were not visible until capture could complete:

- `src/compute/attention_cublas.cu:410-458` — 6 `cudaMemcpyAsync` per attention call copying host-stack pointer arrays (`const void* h_A[256]` etc.) to device. Host pointers are invalid on replay.
- `src/runtime/batch.cpp:222-248` — 4 `cudaMemcpyAsync` copying `std::vector` data (token_ids, positions, context_lens, block_tables) from host per-call.

The structural fix is multi-week: device-side pointer-array kernels, stable pre-allocated device buffers for batch metadata, capture-region boundary moved past batch upload. Per the original memo's decision criteria (1 dev-week time-box), the opportunity cost vs. M=0 expert compaction / BitDecoding follow-ons is higher than the prefill-graph win.

## What this PR ships

- The cheap-experiment outcome as documented diagnostic infrastructure.
- **NOT** production prefill-graph enablement — that's still gated behind the multi-week structural refactor.

The env is useful for: (a) future investigation of newly-revealed blockers, (b) power users debugging custom capture paths, (c) reproducing the mode-specific behavior matrix above.

## Test plan
- [x] Build clean (`make build`)
- [x] verify-fast green with default mode (decode +2.27%, prefill +3.27%, graphs ON 2.11×)
- [x] Empirical mode-swap matrix on Qwen3-Coder-30B + Gemma-4-26B (see above)
- [x] No behavior change unless `IMP_GRAPH_CAPTURE_MODE` is explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)