### PR TITLE
test(degeneration): re-enable GreedyDeterminism + audit remaining open bugs

### DIFF
--- a/tests/test_attention_fmha_sm120.cu
+++ b/tests/test_attention_fmha_sm120.cu
@@ -221,8 +221,18 @@ TEST_F(FmhaSm120Test, DispatchSelectsSm120FMHA) {
 }
 
 TEST_F(FmhaSm120Test, DISABLED_DispatchManual) {
-    // Manual dispatch test — currently produces zero output for unknown reasons.
-    // The kernel works correctly when called through run_test().
+    // INVESTIGATION 2026-05-14: when called via this manual path, the kernel
+    // produces NaN output even with the IDENTICAL data pattern as run_test()
+    // which works for the same shape (B=1, S=64, NH=4, HD=128, causal). Both
+    // paths route through fmha_sm120_prefill → fmha_sm120_kernel with the
+    // same arguments. Diff is the surrounding setup; likely a CUDA stream /
+    // initialization state issue specific to invoking the kernel from a
+    // top-level TEST_F body rather than the run_test() helper. Reproduced
+    // via gtest_also_run_disabled_tests; debug prints show Q=correct, kernel
+    // returns true, no CUDA error, but O[0..7]=NaN. The kernel works fine
+    // when called via run_test() — see e.g. DispatchSelectsSm120FMHA which
+    // exercises this exact shape and passes.
+    // Leaving DISABLED until someone reproduces under nsys/compute-sanitizer.
     const int B = 1, S = 64, NH = 4, HD = 128;
     size_t bytes = B * S * NH * HD * sizeof(half);
 
@@ -232,13 +242,19 @@ TEST_F(FmhaSm120Test, DISABLED_DispatchManual) {
     cudaMalloc(&d_v, bytes);
     cudaMalloc(&d_o, bytes);
 
-    std::vector<half> h_data(B * S * NH * HD);
-    for (size_t i = 0; i < h_data.size(); i++)
-        h_data[i] = __float2half(0.02f * static_cast<float>((i % 7) - 3));
-    cudaMemcpy(d_q, h_data.data(), bytes, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_k, h_data.data(), bytes, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_v, h_data.data(), bytes, cudaMemcpyHostToDevice);
-    cudaMemsetAsync(d_o, 0, bytes, stream_);
+    std::vector<half> h_q(B * S * NH * HD), h_k(B * S * NH * HD), h_v(B * S * NH * HD);
+    for (size_t i = 0; i < h_q.size(); i++) {
+        h_q[i] = __float2half(0.02f * static_cast<float>(((i * 7 + 3) % 13) - 6));
+    }
+    for (size_t i = 0; i < h_k.size(); i++) {
+        h_k[i] = __float2half(0.02f * static_cast<float>(((i * 11 + 5) % 13) - 6));
+        h_v[i] = __float2half(0.02f * static_cast<float>(((i * 13 + 7) % 13) - 6));
+    }
+    cudaMemcpy(d_q, h_q.data(), bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_k, h_k.data(), bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v, h_v.data(), bytes, cudaMemcpyHostToDevice);
+    cudaMemset(d_o, 0, bytes);
+    cudaDeviceSynchronize();
 
     int64_t shape[] = {B, S, NH, HD};
     Tensor Q(d_q, QType::F16, 4, shape, true);
@@ -280,6 +296,12 @@ TEST_F(FmhaSm120Test, DISABLED_DispatchManual) {
             q_nonzero++;
     fprintf(stderr, "DEBUG: Q nonzero=%d, O nonzero=%d (of %d)\n", q_nonzero, finite_nonzero,
             B * S * NH * HD);
+    fprintf(stderr, "DEBUG: O[0..7] = %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f\n",
+            __half2float(h_o[0]), __half2float(h_o[1]), __half2float(h_o[2]), __half2float(h_o[3]),
+            __half2float(h_o[4]), __half2float(h_o[5]), __half2float(h_o[6]), __half2float(h_o[7]));
+    fprintf(stderr, "DEBUG: V[0..7] = %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f\n",
+            __half2float(h_v[0]), __half2float(h_v[1]), __half2float(h_v[2]), __half2float(h_v[3]),
+            __half2float(h_v[4]), __half2float(h_v[5]), __half2float(h_v[6]), __half2float(h_v[7]));
 
     EXPECT_GT(finite_nonzero, 0)
         << "Dispatch produced all-zero output on sm_120 (expected sm120 FMHA to run)";

--- a/tests/test_degeneration.cpp
+++ b/tests/test_degeneration.cpp
@@ -110,6 +110,15 @@ protected:
     ImpModel model_ = nullptr;
     ImpContext ctx_ = nullptr;
 
+    // Set CUBLAS_WORKSPACE_CONFIG=:4096:8 once per test suite. Required for
+    // greedy-deterministic behavior on Blackwell sm_120; harmless on others.
+    // Set before any test creates a cuBLAS handle. setenv is idempotent.
+    static void SetUpTestSuite() {
+        // The 0 (overwrite) means: only set if not already set in env.
+        // Production environments that need a different value can override.
+        setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", /*overwrite=*/0);
+    }
+
     void SetUp() override {
         SKIP_IF_NO_MODEL();
 
@@ -182,12 +191,18 @@ TEST_F(DegenerationTest, LongGenerationStability) {
 
 // Test 4: Greedy (temp=0) should be deterministic across calls
 // Greedy (temp=0) should be deterministic across context resets.
-// DISABLED: cuBLAS on Blackwell (sm_120) selects different GEMM algorithms
-// on the second call within the same process, producing different FP16
-// rounding that cascades into completely different greedy output.
-// This is a fundamental cuBLAS behavior, not an imp bug.
-// Fix: set CUBLAS_WORKSPACE_CONFIG=:4096:8 before process start.
-TEST_F(DegenerationTest, DISABLED_GreedyDeterminism) {
+//
+// Fixed 2026-05-14: set CUBLAS_WORKSPACE_CONFIG=:4096:8 in the test process
+// before the cuBLAS handle is created (via setenv in the test body). On
+// Blackwell sm_120 without this, cuBLAS picks different algorithms on
+// successive calls within the same process, producing FP16 rounding drift
+// that cascades into divergent greedy output. The env var pins the
+// workspace size and forces deterministic algo selection.
+//
+// Note: the env var must be set BEFORE any cuBLAS call in this process.
+// Test class SetUp() builds the engine which creates the cuBLAS handle, so
+// setenv must run before that. We use SetUpTestSuite (once per fixture).
+TEST_F(DegenerationTest, GreedyDeterminism) {
     auto gen_greedy = [&](const std::string& prompt) {
         imp_context_reset(ctx_);
         ImpGenerateParams p = imp_generate_params_default();


### PR DESCRIPTION
Re-enables DISABLED_GreedyDeterminism. Pre-existing gotcha (cuBLAS algo non-determinism on Blackwell sm_120 without CUBLAS_WORKSPACE_CONFIG) — fix is setenv in SetUpTestSuite. Validates imp is deterministic given a deterministic GEMM. Also documents DISABLED_DispatchManual investigation (NaN output when invoked manually vs run_test() helper — root cause not isolated, kept DISABLED with debug recipe). Open-bug audit summary in commit message.