### PR TITLE
chore(build): clean all compile warnings — 156 → 0

### DIFF
--- a/src/compute/fmha_v_load_bench.cu
+++ b/src/compute/fmha_v_load_bench.cu
@@ -197,8 +197,9 @@ static bool build_v_tma_desc(CUtensorMap* desc, void* gmem,
     if (pfn == nullptr) {
         cudaDriverEntryPointQueryResult q;
         void* p = nullptr;
-        cudaError_t err = cudaGetDriverEntryPoint("cuTensorMapEncodeTiled",
-                                                   &p, cudaEnableDefault, &q);
+        cudaError_t err = cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled",
+                                                            &p, CUDA_VERSION,
+                                                            cudaEnableDefault, &q);
         if (err != cudaSuccess || q != cudaDriverEntryPointSuccess || p == nullptr) {
             std::fprintf(stderr, "cuTensorMapEncodeTiled lookup failed\n");
             return false;

--- a/src/compute/gemm_grouped_nvfp4_smallM.cu
+++ b/src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -710,8 +710,9 @@ static PFN_cuTensorMapEncodeTiled_t resolve_tensor_map_encode() {
     if (pfn) return pfn;
     cudaDriverEntryPointQueryResult q;
     void* p = nullptr;
-    cudaError_t err = cudaGetDriverEntryPoint("cuTensorMapEncodeTiled",
-                                               &p, cudaEnableDefault, &q);
+    cudaError_t err = cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled",
+                                                        &p, CUDA_VERSION,
+                                                        cudaEnableDefault, &q);
     if (err != cudaSuccess || q != cudaDriverEntryPointSuccess || p == nullptr) {
         return nullptr;
     }

--- a/src/compute/mxf4nvf4_mma_variants_bench.cu
+++ b/src/compute/mxf4nvf4_mma_variants_bench.cu
@@ -39,40 +39,25 @@
 namespace imp {
 
 // Helper: stable input registers (different per thread to defeat any
-// constant-folding) plus 0x38 UE4M3 / 0x7f UE8M0 ≈ 1.0 scales.
-#define BENCH_PREAMBLE                                                                 \
-    uint32_t a0 = threadIdx.x * 37u + 1u;                                              \
-    uint32_t a1 = threadIdx.x * 41u + 2u;                                              \
-    uint32_t a2 = threadIdx.x * 43u + 3u;                                              \
-    uint32_t a3 = threadIdx.x * 47u + 4u;                                              \
-    uint32_t b0 = threadIdx.x * 53u + 5u;                                              \
-    uint32_t b1 = threadIdx.x * 59u + 6u;                                              \
-    uint32_t b2 = threadIdx.x * 61u + 7u;                                              \
-    uint32_t b3 = threadIdx.x * 67u + 8u;                                              \
-    uint32_t sfa_e4m3 = 0x38383838u; /* UE4M3 ≈ 1.0 */                               \
-    uint32_t sfb_e4m3 = 0x38383838u;                                                   \
-    uint32_t sfa_e8m0 = 0x7f7f7f7fu; /* UE8M0 = 2^0 = 1.0 */                           \
-    uint32_t sfb_e8m0 = 0x7f7f7f7fu;                                                   \
-    uint32_t metadata = 0x44444444u; /* 2:4 sparse: select positions 0,1 of every 4 */ \
-    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;                                  \
-    constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;                         \
-    (void)a0;                                                                          \
-    (void)a1;                                                                          \
-    (void)a2;                                                                          \
-    (void)a3;                                                                          \
-    (void)b0;                                                                          \
-    (void)b1;                                                                          \
-    (void)b2;                                                                          \
-    (void)b3;                                                                          \
-    (void)sfa_e4m3;                                                                    \
-    (void)sfb_e4m3;                                                                    \
-    (void)sfa_e8m0;                                                                    \
-    (void)sfb_e8m0;                                                                    \
-    (void)metadata;                                                                    \
-    (void)bidA;                                                                        \
-    (void)tidA;                                                                        \
-    (void)bidB;                                                                        \
-    (void)tidB
+// constant-folding) plus 0x38 UE4M3 / 0x7f UE8M0 ≈ 1.0 scales. Each kernel
+// below references a subset of these; [[maybe_unused]] silences NVCC #550-D
+// for the regs a given variant doesn't consume.
+#define BENCH_PREAMBLE                                                                   \
+    [[maybe_unused]] uint32_t a0 = threadIdx.x * 37u + 1u;                               \
+    [[maybe_unused]] uint32_t a1 = threadIdx.x * 41u + 2u;                               \
+    [[maybe_unused]] uint32_t a2 = threadIdx.x * 43u + 3u;                               \
+    [[maybe_unused]] uint32_t a3 = threadIdx.x * 47u + 4u;                               \
+    [[maybe_unused]] uint32_t b0 = threadIdx.x * 53u + 5u;                               \
+    [[maybe_unused]] uint32_t b1 = threadIdx.x * 59u + 6u;                               \
+    [[maybe_unused]] uint32_t b2 = threadIdx.x * 61u + 7u;                               \
+    [[maybe_unused]] uint32_t b3 = threadIdx.x * 67u + 8u;                               \
+    [[maybe_unused]] uint32_t sfa_e4m3 = 0x38383838u; /* UE4M3 ≈ 1.0 */                  \
+    [[maybe_unused]] uint32_t sfb_e4m3 = 0x38383838u;                                    \
+    [[maybe_unused]] uint32_t sfa_e8m0 = 0x7f7f7f7fu; /* UE8M0 = 2^0 = 1.0 */            \
+    [[maybe_unused]] uint32_t sfb_e8m0 = 0x7f7f7f7fu;                                    \
+    [[maybe_unused]] uint32_t metadata = 0x44444444u; /* 2:4 sparse: positions 0,1 of 4 */ \
+    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;                                    \
+    [[maybe_unused]] constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0
 
 #define BENCH_SINK_STORE                     \
     if (threadIdx.x == 0 && blockIdx.x == 0) \

--- a/src/compute/tma_block_scale_bench.cu
+++ b/src/compute/tma_block_scale_bench.cu
@@ -33,7 +33,7 @@
 #include <cstdio>
 #include <cstring>
 
-// Resolve cuTensorMapEncodeTiled via cudaGetDriverEntryPoint (runtime API,
+// Resolve cuTensorMapEncodeTiled via cudaGetDriverEntryPointByVersion (runtime API,
 // no DT_NEEDED on libcuda.so.1) to keep test discovery working in CI builders
 // without GPU drivers installed. Same trick CUTLASS uses
 // (cutlass/cuda_host_adapter.hpp).
@@ -242,10 +242,11 @@ static bool make_tma_2d_u8(CUtensorMap* desc, void* gmem, int rows, int cols, in
     if (pfn == nullptr) {
         cudaDriverEntryPointQueryResult q;
         void* p = nullptr;
-        cudaError_t err = cudaGetDriverEntryPoint("cuTensorMapEncodeTiled",
-                                                   &p, cudaEnableDefault, &q);
+        cudaError_t err = cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled",
+                                                            &p, CUDA_VERSION,
+                                                            cudaEnableDefault, &q);
         if (err != cudaSuccess || q != cudaDriverEntryPointSuccess || p == nullptr) {
-            std::fprintf(stderr, "cudaGetDriverEntryPoint(cuTensorMapEncodeTiled) failed (q=%d)\n", (int)q);
+            std::fprintf(stderr, "cudaGetDriverEntryPointByVersion(cuTensorMapEncodeTiled) failed (q=%d)\n", (int)q);
             return false;
         }
         pfn = reinterpret_cast<PFN_cuTensorMapEncodeTiled_t>(p);

--- a/src/model/tensor_kind_name.cpp
+++ b/src/model/tensor_kind_name.cpp
@@ -82,6 +82,8 @@ const char* tensor_kind_name(TensorKind k) {
             return "SIGLIP_NORM";
         case TensorKind::MM_PROJ:
             return "MM_PROJ";
+        case TensorKind::_COUNT:
+            break;
     }
     return "UNKNOWN";
 }

--- a/src/quant/mxfp4_gemm.cu
+++ b/src/quant/mxfp4_gemm.cu
@@ -180,7 +180,7 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_mxfp4_kpar_fp32_kernel(
 // Multi-row GEMV: NR rows per block, 256 threads (8 warps).
 // ---------------------------------------------------------------------------
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_mxfp4_multirow_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_mxfp4_multirow_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ linear_scales,
     const half* __restrict__ x, half* __restrict__ y, int N, int K) {
     const int block_row_base = blockIdx.x * NR;
@@ -203,7 +203,7 @@ __global__ void __launch_bounds__(kMRThreads, 8) gemv_mxfp4_multirow_kernel(
 }
 
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_mxfp4_multirow_fp32_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_mxfp4_multirow_fp32_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ linear_scales,
     const half* __restrict__ x, float* __restrict__ y, int N, int K) {
     const int block_row_base = blockIdx.x * NR;

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -219,7 +219,7 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_nvfp4_kpar_fp32_kernel(
 // Amortizes block launch overhead and improves occupancy for small K.
 // ---------------------------------------------------------------------------
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_multirow_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_multirow_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
     const half* __restrict__ x, half* __restrict__ y, int M, int K) {
     const int block_row_base = blockIdx.x * NR;
@@ -248,7 +248,7 @@ __global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_multirow_kernel(
 
 // FP32 output multi-row variant for LM head projection.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_multirow_fp32_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_multirow_fp32_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
     const half* __restrict__ x, float* __restrict__ y, int M, int K) {
     const int block_row_base = blockIdx.x * NR;
@@ -525,7 +525,7 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_nvfp4_gate_up_fused_ker
 
 // Multi-row QKV fused: each warp determines its matrix and row independently.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_qkv_fused_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_qkv_fused_mr_kernel(
     const uint8_t* __restrict__ packed_q, const uint8_t* __restrict__ ms_q, float ts_q,
     const uint8_t* __restrict__ packed_k, const uint8_t* __restrict__ ms_k, float ts_k,
     const uint8_t* __restrict__ packed_v, const uint8_t* __restrict__ ms_v, float ts_v,
@@ -578,7 +578,7 @@ __global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_qkv_fused_mr_kernel(
 
 // Multi-row gate+up fused.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_gate_up_fused_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_gate_up_fused_mr_kernel(
     const uint8_t* __restrict__ packed_g, const uint8_t* __restrict__ ms_g, float ts_g,
     const uint8_t* __restrict__ packed_u, const uint8_t* __restrict__ ms_u, float ts_u,
     const half* __restrict__ x, half* __restrict__ yg, half* __restrict__ yu, int rows, int K) {
@@ -623,7 +623,7 @@ __global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_gate_up_fused_mr_ker
 
 // Multi-row residual.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_residual_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_residual_mr_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
     const half* __restrict__ x, half* __restrict__ y, const half* __restrict__ residual, int M, int K) {
     const int warp_id = threadIdx.x / 32;
@@ -649,7 +649,7 @@ __global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_residual_mr_kernel(
 
 // Multi-row SwiGLU + residual.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_swiglu_residual_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_swiglu_residual_mr_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
     const half* __restrict__ gate, const half* __restrict__ up, half* __restrict__ y,
     const half* __restrict__ residual, int M, int K) {
@@ -681,7 +681,7 @@ __global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_swiglu_residual_mr_k
 
 // Multi-row GeGLU + residual.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_geglu_residual_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_geglu_residual_mr_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
     const half* __restrict__ gate, const half* __restrict__ up, half* __restrict__ y,
     const half* __restrict__ residual, int M, int K) {
@@ -929,7 +929,7 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_nvfp4_moe_gate_up_fused
 // Multi-row MoE gate+up with blockIdx.y split (gate=0, up=1).
 // Same approach as original but NR rows per block for reduced launch count.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_moe_gate_up_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_gate_up_mr_kernel(
     const uint8_t* __restrict__ gate_packed, const uint8_t* __restrict__ gate_ms,
     const float* __restrict__ gate_ts, const uint8_t* __restrict__ up_packed,
     const uint8_t* __restrict__ up_ms, const float* __restrict__ up_ts,
@@ -970,7 +970,7 @@ __global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_moe_gate_up_mr_kerne
 
 // Multi-row MoE NVFP4 decode (single weight matrix, e.g., non-gated up or down).
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_moe_decode_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_decode_mr_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales,
     const float* __restrict__ tensor_scales, const int32_t* __restrict__ expert_indices,
     const half* __restrict__ x, half* __restrict__ y, int rows, int K, size_t expert_stride_packed,
@@ -1094,7 +1094,7 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_nvfp4_moe_swiglu_decode
 // Multi-row SwiGLU + MoE NVFP4 GEMV for down projection.
 // NR rows per block, 256 threads (8 warps).
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads, 8) gemv_nvfp4_moe_swiglu_mr_kernel(
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_swiglu_mr_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales,
     const float* __restrict__ tensor_scales, const int32_t* __restrict__ expert_indices,
     const half* __restrict__ gate, const half* __restrict__ up, half* __restrict__ y, int rows, int K,

--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -3,15 +3,15 @@
   "gpu": "NVIDIA GeForce RTX 5090",
   "cuda": "13.2",
   "vram_total_mb": 32607,
-  "timestamp": "2026-05-14T20:34:06Z",
+  "timestamp": "2026-05-14T21:59:55Z",
   "reps": 5,
   "metrics": {
     "prefill_tps": {
-      "pp128": 4760.21,
-      "pp512": 14260.84
+      "pp128": 6139.37,
+      "pp512": 14419.79
     },
     "decode_tps": {
-      "tg128": 148.15
+      "tg128": 152.01
     },
     "memory_mb": {
       "model_weights": 8608

--- a/tests/test_llm_compressor_loader.cpp
+++ b/tests/test_llm_compressor_loader.cpp
@@ -1,7 +1,19 @@
 #include "model/llm_compressor_loader.h"
 #include <gtest/gtest.h>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unistd.h>
 
 using namespace imp::llm_compressor;
+
+namespace {
+std::string tmpdir() {
+    const char* t = std::getenv("TMPDIR");
+    return t ? t : "/tmp";
+}
+}  // namespace
 
 TEST(LlmCompressorTranslate, RenamesWeightPacked) {
     TranslationCounters c{};
@@ -171,12 +183,8 @@ TEST(LlmCompressorTranslate, SkipsMultiModalProjector) {
 namespace {
 
 std::string write_temp_recipe(const std::string& content) {
-    std::string path = std::string(std::getenv("TMPDIR") ? std::getenv("TMPDIR") : "/tmp") + "/recipe_" +
-                       std::to_string(::getpid()) + ".yaml";
-    // Create a temp dir and place recipe.yaml inside it.
-    std::string dir = path + ".d";
-    std::string mkdir_cmd = "mkdir -p '" + dir + "'";
-    std::system(mkdir_cmd.c_str());
+    std::string dir = tmpdir() + "/recipe_" + std::to_string(::getpid()) + ".yaml.d";
+    std::filesystem::create_directories(dir);
     std::ofstream out(dir + "/recipe.yaml");
     out << content;
     out.close();
@@ -184,8 +192,8 @@ std::string write_temp_recipe(const std::string& content) {
 }
 
 void cleanup_temp_recipe(const std::string& dir) {
-    std::string rm = "rm -rf '" + dir + "'";
-    std::system(rm.c_str());
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
 }
 
 }  // namespace
@@ -308,9 +316,8 @@ TEST(LlmCompressorRecipe, RejectsConfigGroupsW8A8) {
 }
 
 TEST(LlmCompressorFormatDetect, PrefersModeloptWhenBothPresent) {
-    std::string dir = std::string(std::getenv("TMPDIR") ?: "/tmp") + "/fmt_both_" +
-                      std::to_string(::getpid());
-    std::system(("mkdir -p '" + dir + "'").c_str());
+    std::string dir = tmpdir() + "/fmt_both_" + std::to_string(::getpid());
+    std::filesystem::create_directories(dir);
     std::ofstream(dir + "/hf_quant_config.json") << R"({"quantization":{"quant_algo":"NVFP4"}})";
     std::ofstream(dir + "/recipe.yaml")
         << "default_stage:\n  default_modifiers:\n    QuantizationModifier:\n      scheme: NVFP4\n";
@@ -320,12 +327,13 @@ TEST(LlmCompressorFormatDetect, PrefersModeloptWhenBothPresent) {
     EXPECT_TRUE(ok);
     EXPECT_EQ(cfg.format, imp::HFConfigLoader::NvFP4Format::MODELOPT);
 
-    std::system(("rm -rf '" + dir + "'").c_str());
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
 }
 
 TEST(LlmCompressorFormatDetect, DetectsLlmCompressorByRecipeYaml) {
-    std::string dir = std::string(std::getenv("TMPDIR") ?: "/tmp") + "/fmt_lc_" + std::to_string(::getpid());
-    std::system(("mkdir -p '" + dir + "'").c_str());
+    std::string dir = tmpdir() + "/fmt_lc_" + std::to_string(::getpid());
+    std::filesystem::create_directories(dir);
     std::ofstream(dir + "/recipe.yaml") << R"(default_stage:
   default_modifiers:
     QuantizationModifier:
@@ -338,16 +346,17 @@ TEST(LlmCompressorFormatDetect, DetectsLlmCompressorByRecipeYaml) {
     EXPECT_TRUE(ok);
     EXPECT_EQ(cfg.format, imp::HFConfigLoader::NvFP4Format::LLM_COMPRESSOR);
 
-    std::system(("rm -rf '" + dir + "'").c_str());
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
 }
 
 TEST(LlmCompressorFormatDetect, ReturnsFalseWhenNoConfigPresent) {
-    std::string dir = std::string(std::getenv("TMPDIR") ?: "/tmp") + "/fmt_none_" +
-                      std::to_string(::getpid());
-    std::system(("mkdir -p '" + dir + "'").c_str());
+    std::string dir = tmpdir() + "/fmt_none_" + std::to_string(::getpid());
+    std::filesystem::create_directories(dir);
     // Empty dir, no config files.
     imp::HFConfigLoader::NvFP4Config cfg;
     bool ok = imp::HFConfigLoader::load_nvfp4_config(dir, cfg);
     EXPECT_FALSE(ok);
-    std::system(("rm -rf '" + dir + "'").c_str());
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
 }


### PR DESCRIPTION
## Summary

Fix every warning emitted by `make build` (test build included). 156 → 0.

## Warning classes addressed

| # | Source | Diagnostic | Fix |
|---|---|---|---|
| 1 | `src/compute/*.cu` (3 files) | `cudaGetDriverEntryPoint deprecated` | Migrate to `cudaGetDriverEntryPointByVersion` with `CUDA_VERSION` |
| 2 | `src/model/tensor_kind_name.cpp` | `-Wswitch: _COUNT not handled` | Add `_COUNT` case → falls through to UNKNOWN return |
| 3 | `src/quant/{nvfp4,mxfp4}_gemm.cu` (12 kernels) | `ptxas: minnctapersm out of range` | Drop ignored `, 8` hint from `__launch_bounds__` — SM120 caps at 1536 threads/SM, 8×256=2048 exceeded it and ptxas was silently dropping the hint anyway. SASS unchanged. |
| 4 | `tests/test_llm_compressor_loader.cpp` | `-Wunused-result` (~11×) + `-Wpedantic` (3×) | Replace `system("mkdir -p")`/`system("rm -rf")` with `std::filesystem::create_directories`/`remove_all`; replace GNU `?:` shortcut with `tmpdir()` helper |
| 5 | `src/compute/mxf4nvf4_mma_variants_bench.cu` BENCH_PREAMBLE | NVCC `#550-D: set but never used` (~140×) | `(void)var;` doesn't silence NVCC #550-D — replace with C++17 `[[maybe_unused]]` attribute on declarations |

## Baseline refresh

`tests/perf_baseline.json` was last set during the MTP work earlier today; container/cuBLAS state has since shifted (multiple Docker rebuilds in this session). Refresh against the current container raises the gate slightly: tg128 148.15 → 152.01 tok/s, pp512 14260.84 → 14419.79 tok/s. Both metrics improved — refresh tightens the regression threshold rather than loosening it.

## Validation

- `make build` → 0 warnings, 0 errors
- `make verify-fast` → all gates green (decode +0%, prefill -2.68%, graphs-ON 1.91× decode speedup, smoke prompts coherent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)