### PR TITLE
diag(graph): log prefill graph node composition

### DIFF
--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -262,6 +262,11 @@ bool CudaGraphCapture::end_capture_and_update() {
         return false;
     }
 
+    // Log node composition (gated by diagnostics.graph_diag in imp.conf). Symmetric
+    // with the end_capture() / ConditionalRunner paths so prefill/decode graphs are
+    // comparable. Useful for diagnosing memcpy-density across models.
+    graph_diag::log_kernel_nodes(new_graph, "capture.update");
+
     // PDL edge conversion before update/instantiate so both paths have it.
     if (pdl::is_available()) {
         int converted = apply_pdl_edges(new_graph);


### PR DESCRIPTION
## Summary
Symmetric one-line addition: `end_capture()` already logs graph composition via `graph_diag::log_kernel_nodes()` (label `capture.plain`). The `end_capture_and_update()` path the prefill graph runner uses didn't, so prefill graph composition was invisible. Now both paths log under their respective labels (`capture.plain` / `capture.update` / `capture.cond_body`).

Gated by `diagnostics.graph_diag = true` in `imp.conf` — zero behavior change in default config.

## Why this is useful (verified during PR #181 investigation)

Surveyed prefill graph composition across the 3 production NVFP4 MoE models:

| Model | Total nodes | Kernel | Memcpy |
|---|---:|---:|---:|
| Qwen3-Coder-30B (48 layers) | 819 | 771 | 48 (1.0/layer) |
| Qwen3.6-35B (48 layers) | 993 | 853 | **140 (2.9/layer)** |
| Gemma-4-26B (28 layers) | 1057 | 1022 | 35 (1.25/layer) |

Qwen3.6 carries ~3× more memcpy nodes per layer than the other models — load-bearing data point for future graph-overhead-reduction work. (Side note: Qwen3.6 was the model with smallest GRAPH=1 perf change in the proper-methodology bench, so memcpy density doesn't directly drive E2E regression. But it's a measurable per-model property worth tracking.)

## Test plan
- [x] `make build` clean
- [x] With `diagnostics.graph_diag = true`, prefill graph capture logs `[graph_diag:capture.update] N nodes (kernel=K memcpy=M …)` once per capture
- [x] Default config: no new log spam (gate enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)