### PR TITLE
feat(prefill): chunked prefill for INT4 KV (sub-byte gather)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## Unreleased
 
+- **Chunked prefill for INT4 KV** (sub-byte gather). New `paged_kv_gather_int4_to_fp16`
+  kernel mirrors the existing FP16/FP8/NVFP4 gather variants: symmetric 4-bit
+  packed nibbles + per-head FP16 scale (matches `write_kv_cache_int4_kernel`).
+  `Engine::supports_chunked_prefill_()` now allows `--kv-int4`. INT4's
+  pre-existing long-context quality regression (-22% decode at 20K ctx;
+  output degenerates on long prompts) is independent of chunked prefill —
+  short-prompt smoke is fine (`The capital of France is` → `Paris.`), long-
+  prompt chunked vs single-chunk produce equivalent (equally-degenerate)
+  output. Closes the INT4 entry in the "Sub-byte KV cache dtypes" out-of-scope
+  list.
 - **Chunked prefill for Gemma-4** (SWA + dual head_dim 256/512). `attention_cublas_prefill`'s
   three softmax kernels now accept a `sliding_window` parameter; the mask zeros
   positions outside `[abs_row - sliding_window + 1, abs_row]`. Gemma-4 SWA layers

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,17 +17,17 @@ Two Gemma-4 carve-outs are still active in `engine.cpp:630-660`:
 
 Default KV dtype is FP16; FP8 is opt-in via `--kv-fp8` (or `kv_cache.dtype = "fp8"` in `imp.conf`). Coherent on Qwen3 dense, Qwen3.5/3.6 GDN, Llama-3.2, and Gemma-4 (post PR #91).
 
-### Chunked prefill scope (full-attention + hybrid GDN/Mamba2 + Gemma-4; FP16/FP8/NVFP4 KV)
+### Chunked prefill scope (full-attention + hybrid GDN/Mamba2 + Gemma-4; FP16/FP8/NVFP4/INT4 KV)
 
-Default `prefill_chunk_size = 512` for full-attention models (Qwen3, Llama, Mistral), hybrid GDN+MoE / Mamba2+MoE models (Qwen3.5/3.6, Nemotron-H), and **Gemma-4** with FP16, FP8, or NVFP4 KV cache. Past chunks' K/V are read from the paged cache via `paged_kv_gather_*` and concatenated with the current chunk before a rectangular `attention_cublas_prefill` with `q_offset`-aware causal masking + `sliding_window`-aware mask (added 2026-05-15 for Gemma-4 SWA layers; the same path now replaces the naive FP32 workaround for Gemma-4 SWA in non-chunked prefill too). PR #114 mitigation (default `prefill_chunk_size = 0`) is replaced by `Engine::resolve_prefill_chunk_size_()` which clamps to 0 for out-of-scope archs.
+Default `prefill_chunk_size = 512` for full-attention models (Qwen3, Llama, Mistral), hybrid GDN+MoE / Mamba2+MoE models (Qwen3.5/3.6, Nemotron-H), and **Gemma-4** with FP16, FP8, NVFP4, or INT4 KV cache. Past chunks' K/V are read from the paged cache via `paged_kv_gather_*` and concatenated with the current chunk before a rectangular `attention_cublas_prefill` with `q_offset`-aware causal masking + `sliding_window`-aware mask (added 2026-05-15 for Gemma-4 SWA layers; the same path now replaces the naive FP32 workaround for Gemma-4 SWA in non-chunked prefill too). INT4 dequant gather added 2026-05-15 (symmetric 4-bit + per-head FP16 scale; INT4 KV's pre-existing long-context quality regression is independent of chunked prefill). PR #114 mitigation (default `prefill_chunk_size = 0`) is replaced by `Engine::resolve_prefill_chunk_size_()` which clamps to 0 for out-of-scope archs.
 
 **Out-of-scope** — stay at `prefill_chunk_size = 0` via per-arch default; explicit `--prefill-chunk-size N` is logged + clamped to 0:
 
 - Gemma-3 (SWA, no test model in repo — kernel work is identical to Gemma-4, just unverified)
 - Llama-4 (MoE + SWA)
-- Sub-byte KV cache dtypes (INT4, TurboQuant, TurboQuant Lite)
+- TurboQuant / TurboQuant Lite KV dtypes (QJL-sketch storage; would need a sketch-aware gather)
 
-Each excluded class is a separate larger work item (paged-prefill kernel with sub-byte dequant during gather for the INT4/TQ branch; Llama-4 needs MoE-SWA validation).
+Each excluded class is a separate larger work item.
 
 ### ~~`d_pf_block_tables_` undersized for prompts ≥ max_seq_len~~ — FIXED #134
 

--- a/src/compute/kv_gather.cu
+++ b/src/compute/kv_gather.cu
@@ -189,4 +189,70 @@ void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
         dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd);
 }
 
+// INT4 → FP16 dequant gather. Symmetric 4-bit, per-head FP16 scale.
+// Packed layout: low nibble = even d, high nibble = odd d (sign-extend 4-bit
+// signed → int8 → multiply by half scale → store FP16). Matches
+// write_kv_cache_int4_kernel / paged_attention_decode_int4.
+__global__ void paged_kv_gather_int4_to_fp16_kernel(
+    half* __restrict__ dst,
+    const uint8_t* __restrict__ src_packed,  // [block, slot, nkv, hd/2]
+    const half* __restrict__ src_scales,     // [block, slot, nkv]
+    const int* __restrict__ block_table,
+    int n_past, int block_size, int nkv, int hd) {
+    const int block_group = blockIdx.x;
+    const int kv_head = blockIdx.y;
+    const int tid = threadIdx.x;
+    const int threads_per_token = blockDim.x / TOKENS_PER_BLOCK;
+    const int token_in_block = tid / threads_per_token;
+    const int d_lane = tid % threads_per_token;
+
+    const int pos = block_group * TOKENS_PER_BLOCK + token_in_block;
+    if (pos >= n_past)
+        return;
+
+    const int blk_idx = pos / block_size;
+    const int slot = pos % block_size;
+    const int phys_block = block_table[blk_idx];
+
+    const int kv_block_stride_bytes = block_size * nkv * (hd / 2);
+    const int kv_slot_stride_bytes = nkv * (hd / 2);
+    const int sc_block_stride = block_size * nkv;
+    const int sc_slot_stride = nkv;
+
+    const uint8_t* src_row = src_packed + (size_t)phys_block * kv_block_stride_bytes
+                                        + (size_t)slot * kv_slot_stride_bytes
+                                        + (size_t)kv_head * (hd / 2);
+    half scale_h = src_scales[(size_t)phys_block * sc_block_stride
+                              + (size_t)slot * sc_slot_stride
+                              + (size_t)kv_head];
+    float scale = __half2float(scale_h);
+    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
+
+    // Each lane writes 2 FP16 values per byte read. We iterate in steps of 2
+    // along head_dim so each thread handles one packed byte.
+    for (int d = d_lane * 2; d < hd; d += threads_per_token * 2) {
+        unsigned char byte =
+            __ldcs(reinterpret_cast<const unsigned char*>(src_row + (d / 2)));
+        // Sign-extend 4-bit signed: low nibble = q0 (d), high nibble = q1 (d+1).
+        int q0 = static_cast<int8_t>(static_cast<int8_t>(byte << 4) >> 4);
+        int q1 = static_cast<int8_t>(static_cast<int8_t>(byte) >> 4);
+        dst_row[d] = __float2half(static_cast<float>(q0) * scale);
+        if (d + 1 < hd)
+            dst_row[d + 1] = __float2half(static_cast<float>(q1) * scale);
+    }
+}
+
+void paged_kv_gather_int4_to_fp16(half* dst, const uint8_t* src_packed,
+                                  const half* src_scales, const int* block_table,
+                                  int n_past, int block_size, int nkv, int hd,
+                                  cudaStream_t stream) {
+    if (n_past <= 0 || nkv <= 0 || hd <= 0)
+        return;
+    int n_block_groups = (n_past + TOKENS_PER_BLOCK - 1) / TOKENS_PER_BLOCK;
+    dim3 grid(n_block_groups, nkv);
+    int threads = 256;
+    paged_kv_gather_int4_to_fp16_kernel<<<grid, threads, 0, stream>>>(
+        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd);
+}
+
 }  // namespace imp

--- a/src/compute/kv_gather.h
+++ b/src/compute/kv_gather.h
@@ -37,4 +37,13 @@ void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
                                    int n_past, int block_size, int nkv, int hd,
                                    cudaStream_t stream);
 
+// INT4 paged → FP16 flat with per-head FP16 scale dequant (symmetric, range [-8,7]).
+// src_packed layout: [num_blocks, block_size, nkv, hd/2] uint8 (low nibble=even d, high=odd d).
+// src_scales layout: [num_blocks, block_size, nkv]      FP16 (one scale per head per token).
+// Matches `write_kv_cache_int4_kernel`. Used by chunked prefill for INT4 KV.
+void paged_kv_gather_int4_to_fp16(half* dst, const uint8_t* src_packed,
+                                  const half* src_scales, const int* block_table,
+                                  int n_past, int block_size, int nkv, int hd,
+                                  cudaStream_t stream);
+
 }  // namespace imp

--- a/src/graph/executor_attention.cu
+++ b/src/graph/executor_attention.cu
@@ -695,7 +695,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             QType kvt = cache->qtype();
             // Defense-in-depth: engine resolves out-of-scope models to chunk_size=0,
             // so this code only runs for FP16 / FP8 / NVFP4 KV.
-            const bool kvt_ok = (kvt == QType::F16 || kvt == QType::FP8_E4M3 || kvt == QType::NVFP4);
+            const bool kvt_ok = (kvt == QType::F16 || kvt == QType::FP8_E4M3 ||
+                                  kvt == QType::NVFP4 || kvt == QType::INT4);
             // sliding_active and attn_shapes_vary are now both supported:
             //   - cuBLAS softmax accepts a sliding_window argument (PR feat(attn): sw),
             //   - the rectangular cuBLAS path dispatches per-layer with nh/nkv/hd.
@@ -753,7 +754,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 paged_kv_gather_fp8_to_fp16(
                     v_full, static_cast<const __nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)),
                     state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
-            } else {  // NVFP4
+            } else if (kvt == QType::NVFP4) {
                 paged_kv_gather_nvfp4_to_fp16(
                     k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                     static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
@@ -761,6 +762,15 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 paged_kv_gather_nvfp4_to_fp16(
                     v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
                     static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
+                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+            } else {  // INT4 — symmetric 4-bit with per-head FP16 scale
+                paged_kv_gather_int4_to_fp16(
+                    k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
+                    static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
+                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_int4_to_fp16(
+                    v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
+                    static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
                     state.block_tables, q_offset, kv_bs, nkv, hd, stream);
             }
 

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1943,11 +1943,12 @@ bool Engine::supports_chunked_prefill_() const {
             if (cfg.arch != ModelArch::GEMMA4) return false;
         }
     }
-    // KV dtypes wired through paged_kv_gather: FP16, FP8_E4M3, NVFP4. Others
-    // (INT4/INT8/TurboQuant) would need their own gather kernels.
+    // KV dtypes wired through paged_kv_gather: FP16, FP8_E4M3, NVFP4, INT4.
+    // INT8 and TurboQuant variants would need their own gather kernels.
     if (kv_cache_raw_) {
         QType kvt = kv_cache_raw_->qtype();
-        if (kvt != QType::F16 && kvt != QType::FP8_E4M3 && kvt != QType::NVFP4)
+        if (kvt != QType::F16 && kvt != QType::FP8_E4M3 &&
+            kvt != QType::NVFP4 && kvt != QType::INT4)
             return false;
     }
     return true;


### PR DESCRIPTION
## Summary

Closes the **INT4** entry in the `docs/roadmap.md` "Sub-byte KV cache dtypes" out-of-scope list (parallel to #183 which closed Gemma-4 SWA). Two-file change:

1. **`paged_kv_gather_int4_to_fp16`** in `src/compute/kv_gather.{h,cu}` — mirrors the existing FP16 / FP8 / NVFP4 gather variants. Packed-nibble layout `[block, slot, nkv, hd/2]` + per-head FP16 scale `[block, slot, nkv]` (matches `write_kv_cache_int4_kernel`). Sign-extend low nibble (even d) and high nibble (odd d) via `int8` arithmetic shift, multiply by scale, emit FP16. `__ldcs` streaming load matches the other variants.

2. **Dispatch + gate** in `src/graph/executor_attention.cu` and `src/runtime/engine.cpp` — chunked-prefill branch dispatches INT4 alongside FP16/FP8/NVFP4; `Engine::supports_chunked_prefill_()` accepts INT4.

## Test plan

- [x] `test-attention` 77/77 PASS.
- [x] `test-kv` 34/34 PASS.
- [x] `make verify-fast` PASS — decode -1.03 %, prefill +1.37 %, both inside 3 % / 5 % thresholds.
- [x] **Qwen3-4B Q8_0 + `--kv-int4`** short prompt (`The capital of France is`): coherent — `Paris.`.
- [x] **Qwen3-4B Q8_0 + `--kv-int4` + `--prefill-chunk-size 512`** with a 736-token prompt: chunked output matches single-chunk output. Both equally degenerate due to INT4's pre-existing long-context quality regression (memory `int4_kv_validation_2026_04_24`: -22 % decode at 20K ctx, output degenerates). This is orthogonal to chunking; the gather is correct.

## Note on INT4 quality

INT4 KV has a known pre-existing quality regression at long contexts. This PR does **not** address that — it just makes the chunked-prefill path technically work on `--kv-int4` so memory-efficient long-prompt processing is available. Users should still treat INT4 KV as opt-in for short-context VRAM savings.

## Out-of-scope (still)

- **TurboQuant / TurboQuant Lite** KV dtypes — QJL-sketch storage; would need a sketch-aware gather (different layout entirely).
- **Gemma-3 / Llama-4** — separate items, see #183 description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)