### PR TITLE
docs(perf): pp=512 large-dense diagnostic + analysis harness

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,7 +70,15 @@ TurboQuant currently runs ~23% behind FP8 on Qwen3-8B Q8_0 decode (191 vs 248 to
 
 ### `pp=512` on large dense models
 
-Qwen3-32B Q4_K_M and Mistral-24B Q6_K sit at ~0.5–0.6× llama.cpp at `pp=512`. Suspected cuBLAS autotuning variance + launch-overhead-bound regime. Output is correct; not gating any user.
+Qwen3-32B Q4_K_M sits at ~0.5–0.6× llama.cpp at `pp=512` (1888 tok/s, RTX 5090). Profiled 2026-05-15 (`tools/analysis/profile_pp512_large_dense.sh`):
+
+- 4.4 % FP16 compute utilization, 3.4 % memory-bandwidth utilization — neither compute- nor memory-bound.
+- **GPU time: 64 % in `cutlass_80` FP16 GEMM kernels, 25 % in `dequant_q4k_kernel`** (1153 invocations × 223 µs avg = 257 ms — the FP16 cache can't fit so every weight tensor is dequant'd per forward).
+- **Host time: 23 % in sync `cudaMalloc` (939 calls) + `cudaFree` (930 calls)** — violates `CLAUDE.md`'s no-cudaMalloc-in-hot-loops rule; likely cuBLAS workspace allocation per problem shape.
+
+Real fix is a **direct Q4_K_M GEMM kernel** (mmq-style, mirroring llama.cpp's `mmq_x_q4_K_q8_1`) — multi-week kernel work, would close most of the gap. Multi-stream dequant↔GEMM overlap is a 1-2 day modest win. Pinning a single cuBLAS workspace might shave the alloc overhead.
+
+Suspected cuBLAS autotuning variance is NOT the cause — `bench-reps=5` median is stable. Output is correct; not gating any user. Full diagnostic at memory `pp512_large_dense_perf_2026_05_15.md`.
 
 ### Speculative decoding — investigated and shelved
 

--- a/tools/analysis/profile_pp512_large_dense.sh
+++ b/tools/analysis/profile_pp512_large_dense.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Profile pp=512 on a large dense Q4_K_M model and dump the top-kernel +
+# host-API breakdown. Re-run after any prefill-perf change to track the
+# Q4_K_M dequant ratio + cudaMalloc overhead documented in
+# `pp512_large_dense_perf_2026_05_15.md`.
+#
+# Usage:
+#   tools/analysis/profile_pp512_large_dense.sh [model_path]
+#
+# Default model: models/Qwen3-32B-Q4_K_M.gguf. Output report:
+#   /tmp/pp512_analysis/qwen32b_q4.nsys-rep
+#
+# Requires: imp:test docker image + /opt/nvidia/nsight-systems on host.
+
+set -e
+MODEL_PATH="${1:-/m/Qwen3-32B-Q4_K_M.gguf}"
+MODELS_DIR="${MODELS_DIR:-$(pwd)/models}"
+OUT_DIR="${OUT_DIR:-/tmp/pp512_analysis}"
+
+mkdir -p "$OUT_DIR"
+chmod 777 "$OUT_DIR"
+
+echo "=== Profile: $MODEL_PATH at pp=512, no-cuda-graphs ==="
+
+docker run --rm --gpus all \
+  -v "$MODELS_DIR":/m \
+  -v /usr/local/cuda:/usr/local/cuda:ro \
+  -v /opt/nvidia/nsight-systems:/opt/nvidia/nsight-systems:ro \
+  -v "$OUT_DIR":/out \
+  imp:test bash -c "
+    /usr/local/cuda/bin/nsys profile -t cuda,nvtx -o /out/qwen32b_q4 --force-overwrite=true \
+      imp-cli --model '$MODEL_PATH' \
+      --bench --bench-pp 512 --bench-reps 1 --max-tokens 1 --temperature 0 --no-cuda-graphs 2>&1 | tail -5
+  "
+
+echo ""
+echo "=== Top GPU kernels by total time ==="
+docker run --rm \
+  -v /usr/local/cuda:/usr/local/cuda:ro \
+  -v /opt/nvidia/nsight-systems:/opt/nvidia/nsight-systems:ro \
+  -v "$OUT_DIR":/out \
+  imp:test \
+  /usr/local/cuda/bin/nsys stats --report cuda_gpu_kern_sum --format csv \
+    --force-export=true /out/qwen32b_q4.nsys-rep 2>/dev/null | head -12
+
+echo ""
+echo "=== Top host-side API calls ==="
+docker run --rm \
+  -v /usr/local/cuda:/usr/local/cuda:ro \
+  -v /opt/nvidia/nsight-systems:/opt/nvidia/nsight-systems:ro \
+  -v "$OUT_DIR":/out \
+  imp:test \
+  /usr/local/cuda/bin/nsys stats --report cuda_api_sum --format csv \
+    /out/qwen32b_q4.nsys-rep 2>/dev/null | head -10
+
+echo ""
+echo "Full report: $OUT_DIR/qwen32b_q4.nsys-rep"
+echo "Open in Nsight Systems UI for the timeline view."


### PR DESCRIPTION
## Summary

Investigates the long-standing **\"\`pp=512\` on large dense models\"** entry in the roadmap (~0.5-0.6× llama.cpp on Qwen3-32B Q4_K_M / Mistral-24B Q6_K). nsys-based profile + diagnostic memo + re-runnable harness; no engine code changed.

## Findings (Qwen3-32B-Q4_K_M, RTX 5090, `bench --bench-pp 512 --bench-reps 5 --temperature 0`)

| Config | pp512 tok/s | tg32 tok/s |
|---|---|---|
| graphs ON (default) | 1888 | 56 |
| graphs OFF | 1895 | 49 |

Graphs don't help prefill (prefill is graph-uncaptured). 4.4 % FP16 compute utilization / 3.4 % memory bandwidth utilization — neither compute- nor memory-bound.

### GPU kernel time breakdown

| % | Kernel | Calls | Avg µs | Total ms |
|---:|---|---:|---:|---:|
| 27.2 | `cutlass_80_f16_s16816gemm_relu_f16_64x256_32x4` | 696 | 405 | 282 |
| **24.8** | **`dequant_q4k_kernel`** | **1153** | **223** | **257** |
| 21.8 | `cutlass_80_f16_s16816gemm_relu_f16_128x64_64x3` | 488 | 462 | 226 |
| 5.2 | `cutlass_80_f16_s16816gemm_relu_f16_64x64_32x6` | 120 | 450 | 54 |
| 5.0 | `cutlass_80_f16_s16816gemm_relu_f16_256x64_32x4` | 208 | 249 | 52 |

**GEMM ≈ 64 %, Dequant ≈ 28 %.** Every Q4_K_M weight goes through a host-allocated FP16 scratch (`gemm_dispatch` → `dequant_gpu` → cuBLAS GEMM) because the FP16 cache can't fit (~64 GB > 32 GB VRAM).

### Host-API time breakdown

| % | API | Calls | Total ms |
|---:|---|---:|---:|
| 24.0 | `cudaEventSynchronize` | 781 | 605 |
| **13.9** | **`cudaMalloc` (sync)** | **939** | **351** |
| 13.4 | `cudaHostAlloc` (one-time) | 8 | 337 |
| **9.3** | **`cudaFree` (sync)** | **930** | **235** |
| 6.6 | `cudaLaunchKernel` | 3 449 | 166 |

**Sync `cudaMalloc` + `cudaFree` = 23 % of host-side time = 586 ms wall** — violates CLAUDE.md's no-cudaMalloc-in-hot-loops rule. Likely cuBLAS workspace allocation per problem shape.

## Why imp sits at 0.5-0.6× llama.cpp

llama.cpp's CUDA backend uses **direct mmq (matrix-mul-quantized)** kernels for Q4_K_M (`mmq_x_q4_K_q8_1`, dp4a-based) which read Q4_K_M weights directly without a separate dequant step. imp's prefill path adds the ~25 % dequant overhead.

imp's dp4a GEMV path (`gemv_dp4a_kpar_kernel`) IS direct-quantized but M=1 only — doesn't generalize to GEMM.

## Where the fix lives

| Approach | Effort | Expected | Note |
|---|---|---|---|
| Direct Q4_K_M GEMM kernel | multi-week | pp512 +33 % (1888 → ~2500) | Closes most of the gap |
| Multi-stream dequant↔GEMM overlap | 1-2 days | up to +25 % | Doesn't reduce work, only overlaps |
| Pin single cuBLAS workspace | 1 day | unclear | If GEMMs are GPU-bound, alloc overlaps and removal is a wash |

## What's in this PR

- `tools/analysis/profile_pp512_large_dense.sh` — re-runnable nsys harness (top-kernel + host-API breakdown). Tracks dequant ratio + cudaMalloc count after future prefill changes.
- `docs/roadmap.md` — updates the \`pp=512\` section with concrete profile numbers replacing the prior \"suspected cuBLAS autotuning variance + launch-overhead-bound\" wording.
- Memory file `pp512_large_dense_perf_2026_05_15.md` with full breakdown (lives outside the repo per `.claude/projects/`).

No engine code touched. The actual fix is multi-week kernel work, deferred per the roadmap's \"not gating any user\" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)