### PR TITLE
docs(review): architecture audit (5-phase, sm_120a brecher)

### DIFF
--- a/review/MASTER_REPORT.md
+++ b/review/MASTER_REPORT.md
@@ -1,0 +1,135 @@
+# imp — Architecture Review Master Report
+
+**Branch:** `review/architecture-2026-05-16`
+**Anchor commit:** `f58eb9e`
+**Target:** sm_120a / RTX 5090 / GB202 only — nothing sacred
+**Date:** 2026-05-16
+
+This document is the **entry point**. Each phase report is linked below with
+a one-line abstract; the full roadmap, sequenced refactors and 30/60/90 plan
+live in [`phase5_synthesis.md`](./phase5_synthesis.md).
+
+---
+
+## Brecher-Statement
+
+> imp is architecturally clean and at-the-roof on **decode**, but
+> **NVFP4 MoE prefill is 14.7× slower than vLLM on the identical CUTLASS
+> template**, and `src/graph/` is a **15.8 KLOC clay tablet** where every
+> quant format, every model arch and every dispatch decision lives as
+> inline `if`-ladders. The codebase is small enough to refactor, mature
+> enough to merit it, and broken in exactly two places — perf (around
+> the kernel, not in it) and extensibility (per-arch behavior is
+> `if (cfg.arch == ModelArch::GEMMA4)` sprinkled in 40 sites across 4
+> files).
+
+---
+
+## Phase Reports
+
+| # | Subagent | Report | LOC | Focus |
+|---:|---|---|---:|---|
+| 1 | cartographer | [`phase1_inventory.md`](./phase1_inventory.md) | 751 | Static map: subsystems, public ABI, hot-path TUs, build flags, **ballast bilanz: ~5 390 LOC** |
+| 2 | perfhawk | [`phase2_perf.md`](./phase2_perf.md) | 1 159 | Roofline tables, GB202 feature audit, CUDA-graphs landscape, **deep-dive on Qwen3-Coder NVFP4 prefill 14.7× gap** |
+| 3 | codereaper | [`phase3_maint.md`](./phase3_maint.md) | 1 283 | Coupling hotspots, 10 danger zones, template wildwuchs, **kahlschlag total: ~5 467 LOC** |
+| 4 | integrator | [`phase4_ext.md`](./phase4_ext.md) | 1 044 | 3 simulated integrations (Qwen3.5-A3B / Gemma 5 / Mamba2-hybrid), `ArchPlugin` proposal, **"<500 LOC = new model" target** |
+| 5 | orchestrator | [`phase5_synthesis.md`](./phase5_synthesis.md) | 653 | Roadmaps (perf/maint/ext), cross-axis ranking, risks, **30/60/90 day plan** |
+
+**Total analysis:** 4 890 LOC of MD across 5 reports, ~277 KB. No source files modified.
+
+---
+
+## Top-3 Wins (already brecher)
+
+1. **Decode is at-the-roof bandwidth-bound.** `gemv_nvfp4_moe_decode_kernel` hits
+   ~261 tok/s vs ~270 tok/s ceiling on Qwen3-Coder NVFP4
+   [P2 §1 — `src/quant/nvfp4_gemm.cu:855`].
+2. **Public C ABI is clean.** 24 functions, 4 headers, zero internal-header
+   leakage in `include/imp/` [P1 §2 — `include/imp/imp.h:1-142`].
+3. **Hot-loop allocator hygiene is honored.** No `cudaMalloc/cudaFree` in true
+   per-token loops [P2 §2.6, §5.6].
+
+## Top-3 Brüche (must change)
+
+1. **NVFP4 MoE prefill 14.7× slower than vLLM** on the same CUTLASS template.
+   Gap is 100 % around-the-kernel: activation-quant fusion missing, per-layer
+   launch overhead, scheduler maturity
+   [P2 §6 — `src/compute/gemm_cutlass_grouped_3x.cu:30-86`,
+   `src/graph/executor_forward_moe.cu:559-563`].
+2. **`graph/` is a 15.8 KLOC god-layer.** 21-param `gemm_dispatch_impl`,
+   6-map `WeightCaches` god-struct, duplicate per-qtype dispatch table
+   [P3 §1.2, §2 #1, §5.2 #4 — `src/graph/executor_kernels.cu:2003-2269`,
+   `src/graph/executor.h:286`, `src/compute/weight_dispatch.cu:73-125`].
+3. **Per-arch behavior is `if (cfg.arch == ModelArch::GEMMA4)` × 40** across
+   `executor_attention.cu` (14), `executor_forward_moe.cu` (19),
+   `executor_forward.cu` (2), `engine.cpp` (5+)
+   [P3 §1.5, P4 §0, §2.4].
+
+---
+
+## Key Numbers
+
+| Metric | Value | Source |
+|---|---|---|
+| Total src LOC | ~90 000 | P1 §3 |
+| Ballast quantified | ~5 390 LOC (P1) / ~5 467 LOC (P3) → converged **~5 460 LOC = 6.1 %** | P1 §7, P3 §10 |
+| Single largest streichkandidat | `src/compute/mmq_q4k_v2.cu` — 1 667 LOC | P1 §7, P3 §10 |
+| Worst danger zone | `src/graph/executor_kernels.cu` — 2 327 LOC, god-dispatch | P3 §2 #1 |
+| Today's "new MoE arch" cost | ~280-650 LOC across 25-27 files, 2-4 days | P4 §1 |
+| Target "<500 LOC = new model" | ~120-200 LOC in a single plugin file | P4 §5 |
+| Top quick win | Fuse SwiGLU + activation-quant in MoE down-phase, 2-3 days | P5 §2.2 M1 |
+| Top big bet | Close NVFP4 MoE prefill 14.7× gap, 6-12 weeks → ~3× | P5 §2.3 B1 |
+| First domino | R0: env-var + error-handling sweep (16 `IMP_*` getenvs → `RuntimeConfig`, 12 `throw`s → `IMP_LOG_ERROR`) | P5 §5 |
+| Cross-axis champion | R5: `GemmKernel` registry — -1 000 LOC, wins perf+maint+ext | P5 §5 |
+
+---
+
+## 30 / 60 / 90 Day Plan (one-liners — full plan in P5 §8)
+
+- **Day 0-30 (foundation):** Quick Wins QW1-QW8 + R0 (env-var/error-handling sweep) + retire `mmq_q4k_v2.cu` + relocate `src/compute/bench_*` to `tests/bench/`. Net: ~3 700 LOC out, zero perf regression, branch ready for R5.
+- **Day 31-60 (cross-axis):** R5 (`GemmKernel` registry) lands, killing `WeightCaches` + 21-param dispatch + duplicate `weight_dispatch.cu` table. M1 (SwiGLU+act-quant fusion) ships, first slice of the 14.7× gap. M2-M4 (D2H-sync removal, graph pool sizing) land. Net: -1 000 LOC, +5-10 % pp on Qwen3-Coder NVFP4.
+- **Day 61-90 (ext + perf big bet):** R6 (`ArchPlugin` interface) lands; first migration (Qwen3.5-A3B) proves "<500 LOC = new arch". M3 (Phase-4 MoE-prefill graphs) lands. B1 prefill gap shrinks from 14.7× to ~5-7× (M1+M3 combined). Net: new arch onboarding 25 files → 1 file; pp on Qwen3-Coder NVFP4 from 1 258 → ~4 000-5 000 tok/s.
+
+---
+
+## Open Questions for the Maintainer
+
+Distilled from P5 §9. Each phrased as a closed question with the recommended default in brackets — pick or override.
+
+1. Delete `src/compute/mmq_q4k_v2.cu` (1 667 LOC) now, before R5? [**recommend: delete now**; restore from git if a dense-Q4_K_M model without fp16_cache ever materializes — but the memo has been "pending real-world win" for 3 weeks]
+2. Promote `IMP_*` env vars to `RuntimeConfig` fields with public C API setters, or keep as undocumented env knobs? [**recommend: promote** — all 16 are read on hot paths; env-read-per-call is a perf + maint sin]
+3. Pin CUTLASS to v4.5.0 in **both** `CMakeLists.txt:74` and `Dockerfile:27` (today they disagree), or stay on v4.4.2 in containers? [**recommend: v4.5.0 everywhere** — v4.5.0 fixed the NVFP4 non-determinism per memo `cutlass_nvfp4_sm120_nondeterministic_2026_05_05.md`]
+4. Move `src/compute/bench_*` TUs (~1 772 LOC) to `tests/bench/` outside of the library archive? [**recommend: yes** — they ship in `libimp.a` today, bloating the binary for zero runtime value]
+5. Retire WMMA paths entirely now that `mma.sync` covers all sm_120a use cases, or keep as debug reference? [**recommend: retire** — flagged in P1 §7 as ballast, listed in P3 §3 as template wildwuchs]
+6. Make the `ArchPlugin` migration internal-only first (Qwen3.5-A3B + Gemma-4 only) before declaring it stable? [**recommend: yes** — 2 in-tree migrations before promoting to a public extension point]
+7. The Big Bet (B1, NVFP4 prefill gap) needs CUTLASS scheduler-tuning work upstream — file an issue with NVIDIA CUTLASS or fork? [**recommend: file upstream issue + carry local patch** — fork-only loses future CUTLASS fixes]
+8. Phase 4's "Mamba2-hybrid" simulation says Nemotron-H needed `RecurrentState` polymorphism that doesn't exist today. Add it pre-emptively, or wait for a real hybrid model request? [**recommend: wait** — premature abstraction; the cost is documented in P4 §3 so the next attempt has the blueprint]
+
+---
+
+## Risks (P5 §6 summary)
+
+- **R5 / GemmKernel registry:** highest-blast-radius refactor; every model touches it. Mitigation: ship behind `IMP_DISPATCH_V2=1` for one release cycle, gate verify on parity vs. main, ratchet to default in cycle N+1.
+- **mmq_q4k_v2 deletion:** marginal regression risk on dense Q4_K_M-without-fp16_cache — none of imp's currently supported models match that profile, but a Llama-3.3-70B Q4_K_M release would resurface it. Mitigation: keep the commit reachable via git log; restore-cost is low.
+- **NVFP4 prefill big-bet (B1):** scheduler maturity is upstream-bound; some of the gap may not be closeable on imp's side. Mitigation: instrument before/after with `ncu` traces, set a 5× ceiling as success criterion (not 1×).
+- **`ArchPlugin` v1 over-engineering:** premature seams hurt more than missing seams. Mitigation: derive the interface from 2 in-tree migrations (Qwen3.5-A3B + Gemma-4), not from a hypothetical Mamba2.
+
+---
+
+## Cross-Phase Conflicts
+
+Surfaced in P5 §7 — the cases where two phase reports landed on different sides of a decision:
+
+- **`mmq_q4k_v2.cu` — dead or dormant?** P1 §7 lists it as the single largest streichkandidat; P2 §6 leaves the door open ("maybe a future dense-Q4_K_M release"); P3 §10 puts it back on the delete list. **Synthesis verdict (P5 §7):** delete now. The "future dense Q4_K_M model" has been pending 3 weeks per `mmq_q4k_v2_phase2_shipped_2026_05_16.md`; restoration from git is cheap.
+- **WMMA retirement risk.** P1 calls it ballast, P3 calls it template wildwuchs, P2 doesn't take a firm stance. **Synthesis verdict:** retire. All sm_120a use cases now covered by `mma.sync`.
+
+---
+
+## How to Use This Report
+
+1. Skim this file for the brecher-statement and key numbers.
+2. Read [`phase5_synthesis.md`](./phase5_synthesis.md) for the full roadmap and 30/60/90 plan.
+3. Drill into [`phase1_inventory.md`](./phase1_inventory.md) → [`phase4_ext.md`](./phase4_ext.md) for evidence behind any specific claim — each citation in this doc points to a phase report section, and each phase report section cites `file:line` in the source tree.
+4. The branch `review/architecture-2026-05-16` holds 6 commits (one per phase + this master report). No source files were modified. No merge, no PR — the branch is a parking spot for the analysis.
+
+— Generated by Claude Code, multi-subagent orchestration, 2026-05-16.

--- a/review/phase1_inventory.md
+++ b/review/phase1_inventory.md
@@ -1,0 +1,751 @@
+# Phase 1 — Cartographer Inventory
+
+Static, mechanical map of the imp codebase as of `review/architecture-2026-05-16`
+(`HEAD = f58eb9e`, `feat(compute): Q4_K direct-mmq (v1 dp4a + v2 HMMA) + MoE
+prefill refactor`). No opinions, no recommendations — facts with citations.
+
+- Repo root: `/home/kekz/github.com/kekzl/imp`
+- Target hardware: **sm_120a only** (RTX 5090 / RTX PRO 6000, GB202 Blackwell)
+- Fallback PTX: `compute_120f` (RTX 5080 / 5070 Ti via JIT) — gated by
+  `IMP_DISABLE_120F_FALLBACK` (`CMakeLists.txt:30`)
+- Source tree LOC (`.cu/.cpp/.h/.hpp/.cuh`, raw `wc -l` including blanks/comments):
+  src=90 204, include=325, tools=8 127, tests=32 022 → **130 678 LOC total**
+
+---
+
+## 1. Subsystem dependency graph
+
+Edges derived from `grep -rE '^#include "(api|compute|core|graph|memory|model|quant|runtime|vision)/'` over every `.cu/.cpp/.h/.hpp/.cuh` file. Direction = "depends on". Self-loops omitted from the diagram. Counts are header-include occurrences (multi-file headers may inflate weight vs. true coupling).
+
+```mermaid
+graph LR
+    api --> model
+    api --> runtime
+    api --> memory
+    api --> core
+
+    compute --> core
+    compute --> runtime
+    compute --> quant
+    compute --> model
+    compute --> graph
+
+    graph --> compute
+    graph --> quant
+    graph --> core
+    graph --> memory
+    graph --> runtime
+    graph --> model
+
+    memory --> core
+    memory --> runtime
+    memory --> model
+
+    model --> core
+    model --> quant
+    model --> runtime
+
+    quant --> core
+    quant --> compute
+    quant --> runtime
+
+    runtime --> compute
+    runtime --> core
+    runtime --> model
+    runtime --> memory
+    runtime --> vision
+    runtime --> graph
+
+    vision --> core
+    vision --> runtime
+    vision --> model
+    vision --> memory
+    vision --> compute
+```
+
+### Edge weights (cross-subsystem include count, self-edges excluded)
+
+| from \ to | api | compute | core | graph | memory | model | quant | runtime | vision |
+|---|---|---|---|---|---|---|---|---|---|
+| api      |   - |   0 |   1 |   0 |   1 |   5 |   0 |   2 |   0 |
+| compute  |   0 |   - |  58 |   1 |   0 |   4 |  10 |  11 |   0 |
+| core     |   0 |   0 |   - |   0 |   0 |   0 |   0 |   0 |   0 |
+| graph    |   0 | 108 |  26 |   - |  24 |   3 |  41 |  16 |   0 |
+| memory   |   0 |   0 |  10 |   0 |   - |   1 |   0 |   1 |   0 |
+| model    |   0 |   0 |  21 |   0 |   0 |   - |   3 |   2 |   0 |
+| quant    |   0 |   2 |  15 |   0 |   0 |   0 |   - |   1 |   0 |
+| runtime  |   0 |  20 |  19 |   3 |  13 |  15 |   0 |   - |   4 |
+| vision   |   0 |   1 |   4 |   0 |   1 |   1 |   0 |   2 |   - |
+
+### Cycles
+
+Several mutual edges (graph cycles of length 2 or 3) exist:
+
+1. `compute ↔ quant` — `compute/*.cu` includes `quant/*.h` 10×; `quant/*.cu`
+   includes `compute/*.h` 2× (`grep -E '#include "compute/' src/quant/`).
+2. `compute → runtime` (11) and `runtime → compute` (20) — runtime owns
+   `executor_*`-adjacent state and dispatches into compute; compute reads
+   `runtime/config.h` and runtime-tunable env-driven flags.
+3. `graph → runtime` (16) and `runtime → graph` (3) — `GraphExecutor` (in
+   `src/graph/`) is owned by `Engine` (in `src/runtime/`).
+4. `compute → graph` (1) — one-off back-edge from `src/compute/*` into
+   `src/graph/` (single header reference; flagged for Phase 3 follow-up).
+5. `runtime → vision` (4) and `vision → runtime` (2) — `vision_pipeline` is a
+   runtime concept, `vision_encoder` is a compute kernel.
+
+No true 4-node cycle observed at directory granularity.
+
+### Notes
+- `core/` is a strict leaf (no outgoing cross-subsystem includes) — see row.
+- `api/` is shallow: 9 cross-subsystem includes total in `src/api/imp_api.cpp` +
+  `src/api/imp_internal.h`. Only `api/imp_internal.h` includes the public
+  header (`imp/imp.h`) — no other public→private leak.
+
+---
+
+## 2. Public C API surface
+
+Public headers live in `include/imp/` (325 LOC total). All four headers are
+plain C with `extern "C"` guards and **never include any non-public header**
+(verified `grep -nE '#include' include/imp/*.h`).
+
+### Headers
+
+| Header | LOC | Purpose |
+|---|---:|---|
+| `imp/imp.h`    | 142 | Entry point: model load/free, context create/free, prefill, decode_step, generate, tokenize, MTP toggle, vision image set, version. |
+| `imp/config.h` | 102 | `ImpConfig` struct (39 user-tunable fields incl. device, KV dtype, chunked prefill, prefix cache, StreamingLLM, vision). `imp_config_default()`. |
+| `imp/types.h`  |  58 | Enums: `ImpDType` (12 values), `ImpModelArch` (14 values), `ImpQuantType` (7 values), `ImpModelFormat` (2 values). |
+| `imp/error.h`  |  23 | `ImpError` (9-value enum) + `imp_error_string`. |
+
+### Function surface (22 functions)
+
+| # | Function | Header:line |
+|---:|---|---|
+|  1 | `imp_error_string`               | `error.h:19` |
+|  2 | `imp_config_default`             | `config.h:98` |
+|  3 | `imp_model_load`                 | `imp.h:34` |
+|  4 | `imp_model_free`                 | `imp.h:36` |
+|  5 | `imp_model_arch`                 | `imp.h:39` |
+|  6 | `imp_model_n_layers`             | `imp.h:40` |
+|  7 | `imp_model_d_model`              | `imp.h:41` |
+|  8 | `imp_model_vocab_size`           | `imp.h:42` |
+|  9 | `imp_model_max_seq_len`          | `imp.h:43` |
+| 10 | `imp_context_create`             | `imp.h:47` |
+| 11 | `imp_context_free`               | `imp.h:49` |
+| 12 | `imp_generate_params_default`    | `imp.h:79` |
+| 13 | `imp_generate_streaming`         | `imp.h:85` |
+| 14 | `imp_generate`                   | `imp.h:89` |
+| 15 | `imp_tokenize`                   | `imp.h:93` |
+| 16 | `imp_detokenize`                 | `imp.h:95` |
+| 17 | `imp_prefill`                    | `imp.h:105` |
+| 18 | `imp_prefill_with_params`        | `imp.h:111` |
+| 19 | `imp_decode_step`                | `imp.h:115` |
+| 20 | `imp_context_reset`              | `imp.h:118` |
+| 21 | `imp_enable_mtp_spec_decode`     | `imp.h:125` |
+| 22 | `imp_set_image`                  | `imp.h:132` |
+| 23 | `imp_set_image_from_memory`      | `imp.h:135` |
+| 24 | `imp_version`                    | `imp.h:138` |
+
+(24 functions including the version pseudo-getter and the two boolean defaults.)
+
+### Types / Opaque handles / Enums
+
+- **Opaque handles (2):** `ImpModel`, `ImpContext` (`imp.h:29-30`).
+- **Structs (2):** `ImpConfig` (`config.h:11-95`), `ImpGenerateParams`
+  (`imp.h:53-77`, 26 fields).
+- **Callbacks (1):** `ImpTokenCallback` (`imp.h:82`).
+- **Enums (5):** `ImpDType`, `ImpModelArch`, `ImpQuantType`, `ImpModelFormat`
+  (in `types.h`); `ImpError` (in `error.h`).
+
+### ABI leak audit
+
+- All public headers include only `<stdint.h>`, `<stddef.h>`, `<cstdint>` and
+  each other. **No private header is included.** PASS.
+- `src/api/imp_internal.h:1` is the only file that bridges public →
+  internal — and it lives in `src/`, so it is not part of the installed
+  surface. PASS.
+
+---
+
+## 3. Subsystem LOC + file count + role
+
+LOC = `wc -l` over `.cu/.cpp/.h/.hpp/.cuh` for each subsystem. "Hottest file" =
+single largest LOC under that subsystem.
+
+| Subsystem | Files | LOC | Role (one sentence) | Hottest file (LOC) |
+|---|---:|---:|---|---|
+| `src/api`     |   2 |    866 | Thin C-API translation layer: marshals `ImpConfig` → `imp::RuntimeConfig`, owns `ImpContext_T` (Engine + active Request). | `imp_api.cpp` (864) |
+| `src/compute` | 108 | 36 321 | All device kernels: GEMM/GEMV (FP16/Q*/NVFP4/MXFP4/FP8), paged attention (8 dtype variants), FMHA SM120 prefill, RoPE, LayerNorm/RMSNorm, activations, embedding, sampling, JSON/schema constrain, MoE routing, SSM/GDN, Hadamard. | `sampling.cu` (1 701) |
+| `src/core`    |  16 |  1 309 | Foundational types only: `Tensor`, `Buffer`, `Allocator`, `QType`, `TensorKind`, logging, threading. Leaf subsystem. | `qtype.cpp` (~280) |
+| `src/graph`   |  29 | 15 818 | `GraphExecutor` (imperative transformer forward pass): per-layer attention/FFN/MoE/SSM/GDN dispatch, workspace planning, expert cache, weight handles, pre-dequant cache, MoE workspace. | `executor_forward_moe.cu` (2 563) |
+| `src/memory`  |  16 |  3 524 | Device/pinned allocators, paged KV cache + manager, SSM/GDN state buffers, layer offload manager, VRAM allocator. | `kv_cache_manager.cpp` (1 142) |
+| `src/model`   |  34 | 16 643 | GGUF + SafeTensors loaders, HF config parser, weight uploader/dequantizer, BPE/SentencePiece tokenizers, Jinja chat templates, weight map, MTP head, tensor-kind dispatch table. | `jinja.cpp` (2 629) |
+| `src/quant`   |  25 |  5 391 | Quantization GEMMs and kernels: NVFP4 GEMM (1 324 LOC), MXFP4 GEMM, FP8 quant/utils, INT8/Q4_K/Q6_K dequant, TurboQuant, GPTQ dequant. | `nvfp4_gemm.cu` (1 324) |
+| `src/runtime` |  30 |  8 881 | `Engine` (request scheduler + step driver), config translation, CUDA Graph capture, green-ctx split, PDL, VRAM budgeter, storage planner, MTP forward, vision pipeline. | `engine.cpp` (3 066) |
+| `src/vision`  |   8 |  1 451 | SigLIP / Qwen2-VL vision encoder kernel + loader, image processor (stb_image-backed). | `vision_encoder.cu` (~840) |
+| **TOTAL src** | **268** | **90 204** | | |
+| `include/imp` |   4 |    325 | Public C ABI. | `imp.h` (142) |
+| `tools`       |  16 |  8 127 | `imp-cli` (1 020), `imp-server` (6 052), `imp-bench` (1 055). | `imp-server/*` (6 052 split across 7 TUs) |
+| `tests`       |  82 | 32 022 | GTest suite (~863 `TEST()` invocations across `.cu/.cpp` files). | `test_e2e.cpp` + see §8. |
+
+Top 10 single files by LOC (any subsystem):
+
+| LOC | File |
+|---:|---|
+| 3 066 | `src/runtime/engine.cpp` |
+| 2 629 | `src/model/jinja.cpp` |
+| 2 563 | `src/graph/executor_forward_moe.cu` |
+| 2 556 | `src/graph/executor_pre_dequant.cu` |
+| 2 327 | `src/graph/executor_kernels.cu` |
+| 2 108 | `src/model/tokenizer.cpp` |
+| 2 092 | `src/model/weight_upload.cu` |
+| 1 701 | `src/compute/sampling.cu` |
+| 1 694 | `src/compute/gemm.cu` |
+| 1 683 | `src/model/gguf_loader.cpp` |
+| 1 667 | `src/compute/mmq_q4k_v2.cu` |
+
+---
+
+## 4. Hot-path TUs (touched ≥ 1× per decode token)
+
+Traced from `imp_decode_step` (`src/api/imp_api.cpp:661`) → `Engine::step`
+(`src/runtime/engine.cpp:1735`) → `step_decode` (l. 2360) →
+`step_decode_forward` (l. 2421) → `GraphExecutor::forward_logits`
+(`src/graph/executor_forward.cu:174`) → per-layer
+`run_attention`/`run_ffn`/`run_moe_ffn`/`run_ssm`/`run_gdn` (l. 383-417) →
+attention/MoE dispatch (`executor_attention.cu:140`, `executor_forward_moe.cu`)
+→ paged attention + GEMM kernels.
+
+Order: outer driver first, then per-layer dispatch, then the kernel
+translation units invoked once per layer per token.
+
+| Tier | File | Per-decode-token role |
+|---|---|---|
+| **driver** | `src/api/imp_api.cpp` (864) | `imp_decode_step` → `engine->step()` (1 call/token). |
+| driver | `src/runtime/engine.cpp` (3 066) | `step` → `step_schedule` → `step_decode` → `step_decode_forward`; builds `Batch`, uploads `GPUBatch`, invokes executor. |
+| driver | `src/runtime/batch.cpp` (134) | `BatchBuilder` rebuilt every decode step (l. 2433). |
+| driver | `src/runtime/scheduler.cpp` | Selects active sequences. |
+| **executor** | `src/graph/executor_forward.cu` (775) | `forward_logits` outer loop over layers (l. 380-625). |
+| executor | `src/graph/executor_attention.cu` (1 299) | Per-layer Q/K/V proj, RoPE, KV write, attention dispatch (8 KV dtype branches l. 988-1112). |
+| executor | `src/graph/executor_ffn.cu` (468) | Dense FFN per non-MoE layer. |
+| executor | `src/graph/executor_forward_moe.cu` (2 563) | MoE FFN — routing + grouped GEMM + shared MLP; `run_moe_decode_fast` (l. 2316) is the captured-graph hot path. |
+| executor | `src/graph/executor_ssm_gdn.cu` (~530) | `run_ssm` / `run_gdn` for hybrid arches (Qwen3.5/3.6, Nemotron-H). |
+| executor | `src/graph/executor_kernels.cu` (2 327) | `dispatch_gemv_fp32`, `gemm_dispatch`, weight-typed launchers — called from FFN and LM head. |
+| executor | `src/graph/executor_kv_write.cu` (~480) | KV cache write per attention layer. |
+| executor | `src/graph/executor_pre_dequant.cu` (2 556) | Built once per load (cache setup); the **dispatch fast-path lookup** of `q4k_v2_cache` runs every Q4_K GEMM call. |
+| executor | `src/graph/executor_workspace.cu` (~270) | `resize_workspace` / `use_workspace` per step. |
+| executor | `src/graph/moe_workspace.cu` | MoE scratch (touched only on MoE steps). |
+| executor | `src/graph/expert_cache.cu` | Expert weight pin/page (only on MoE steps). |
+| **compute (attention)** | `src/compute/attention_paged.cu` (1 587) | Default paged attention (FP16 KV). |
+| compute | `src/compute/attention_paged_fp8.cu` (685) | FP8 KV. |
+| compute | `src/compute/attention_paged_int4.cu` (713) | INT4 KV. |
+| compute | `src/compute/attention_paged_int8.cu` (~480) | INT8 KV. |
+| compute | `src/compute/attention_paged_nvfp4.cu` (~530) | NVFP4 KV (scalar). |
+| compute | `src/compute/attention_paged_nvfp4_tc.cu` (1 216) | NVFP4 KV with TC dispatch (BitDecoding Phase 3). |
+| compute | `src/compute/attention_paged_turboquant.cu` (1 108) | TurboQuant / Lite KV. |
+| compute | `src/compute/attention_dispatch.cu` (~120) | Prefill dispatcher (off the decode hot path but in same TU group). |
+| **compute (GEMM/GEMV)** | `src/compute/gemm.cu` (1 694) | `gemm`, `gemm_dispatch` — cuBLAS / cuBLASLt path. |
+| compute | `src/compute/gemv_ggml_compat.cu` (~400) | Q*_K GEMV (decode hot path on Q4/Q6 models). |
+| compute | `src/compute/ggml_mmvq.cu` (~520) | mmvq decode kernels (dp4a). |
+| compute | `src/compute/mmq_q4k_v2.cu` (1 667) | HMMA Q4_K direct mmq — **dispatched only when `IMP_FORCE_Q4K_V2=1`** (gated by cache presence, `executor_kernels.cu:2158`). |
+| compute | `src/compute/gemm_grouped.cu` (~600) | Grouped GEMM for MoE (cuBLAS). |
+| compute | `src/compute/gemm_grouped_nvfp4_smallM.cu` (948) | NVFP4 grouped GEMM (CUTLASS, M<16 specialization). |
+| compute | `src/compute/gemm_moe_fused.cu` (~470) | Scalar fused MoE kernel. |
+| compute | `src/compute/gemm_moe_fused_tc.cu` (~520) | WMMA-based fused MoE kernel. |
+| compute | `src/compute/gemm_q6k.cu` (~310) | Q6_K direct-GEMM decode path. |
+| compute | `src/compute/gemm_dp4a.cu` (~330) | dp4a fallback. |
+| **compute (norm/activation/aux)** | `src/compute/layernorm.cu` (~440) | RMSNorm/LayerNorm — every layer. |
+| compute | `src/compute/rope.cu` (~570) | RoPE — every layer. |
+| compute | `src/compute/activation.cu` (~300) | GELU/SiLU — every FFN. |
+| compute | `src/compute/embedding.cu` (~270) | Token embedding lookup (1×/decode). |
+| compute | `src/compute/sampling.cu` (1 701) | Sampler (greedy + top-k/top-p/min-p/typical/DRY/Mirostat/penalties/JSON-constrain mask) — 1×/decode. |
+| compute | `src/compute/softmax.cu` (~360) | Softmax (used by sampler and attention). |
+| compute | `src/compute/kv_gather.cu` (~430) | Paged KV gather for cuBLAS prefill path. |
+| compute | `src/compute/moe_routing.cu` (1 031) | Router softmax + top-k expert select — every MoE layer. |
+| compute | `src/compute/reduce.cu` (~290) | Block reductions used widely. |
+| compute | `src/compute/hadamard.cu` (~220) | MXFP4 Hadamard transform (on MXFP4 paths). |
+| compute | `src/compute/ssm.cu` (~480) | Mamba2 SSM scan. |
+| compute | `src/compute/gdn.cu` (~410) | Gated DeltaNet recurrent scan. |
+| **memory** | `src/memory/kv_cache.cu` (~620) | Paged KV cache buffer ops. |
+| memory | `src/memory/kv_cache_manager.cpp` (1 142) | Block table per request — `block_table()` called every decode (`engine.cpp:2444`). |
+| memory | `src/memory/gdn_state.cu` (~270) | GDN state (hybrid models). |
+| memory | `src/memory/ssm_state.cu` (~260) | SSM state (hybrid models). |
+| memory | `src/memory/layer_offload.cu` (~370) | Layer offload manager (`ensure_layer` / `prefetch_layer` per layer per step, l. 370-374). |
+| **quant** | `src/quant/dequant_gpu.cu` (~480) | Generic dispatch — used by LM head FP16 fallback (`executor_forward.cu:652`). |
+| quant | `src/quant/nvfp4_quant.cu` (~440) | NVFP4 quant kernel — fires when KV-NVFP4 enabled. |
+| quant | `src/quant/fp8_quant.cu` (~290) | FP8 quant for KV write. |
+| **runtime aux** | `src/runtime/cuda_graph.cu` (989) | Replays captured decode graph (decode fast-path; lookup once per step). |
+| runtime | `src/runtime/mtp_forward.cu` (936) | MTP draft step — only on MTP-enabled decode. |
+
+Conservative count of TUs definitely touched on every decode token (excluding
+arch-conditional MoE/SSM/GDN/MTP files): **~28 TUs**, summing roughly
+**24 000 LOC**.
+
+---
+
+## 5. External dependencies
+
+Sourced from `CMakeLists.txt`, `Dockerfile`, and grep of `#include <...>` /
+`#include "..."` at file heads.
+
+| Dependency | Used in | Purpose | Coupling depth |
+|---|---|---|---|
+| **CUDA Toolkit ≥ 13.2** (`CMakeLists.txt:15`) | all `.cu`, plus `core/cuda_raii.h` | Runtime + driver + nvcc | Pervasive (compile + link) |
+| **cuBLAS** (`CUDA::cublas`, `CMakeLists.txt:288`) | 11 files (incl. `src/compute/gemm.cu`, `attention_cublas.cu`, `gemm_grouped.cu`, `vision_encoder.cu`) | FP16/BF16/FP8 GEMM, attention QKᵀ + Sₛₘₐₓ·V on cuBLAS prefill path. | Moderate (10+ TUs) |
+| **cuBLASLt** (`CUDA::cublasLt`, `CMakeLists.txt:289`) | `src/compute/weight_dispatch.{h,cu}`, `gemm.cu`, `attention_mxfp4_prefill.cu`, `gemm_grouped.cu` | FP8 + heuristics-based algorithm selection. | Moderate |
+| **CUDA driver** (`CUDA::cuda_driver`) | runtime (green contexts, PDL) | Driver API for `cuCtx*` / green ctx. | Shallow |
+| **CUTLASS v4.5.0** (`FetchContent`, `CMakeLists.txt:74`) | 3 TUs: `gemm_cutlass_sm120.cu`, `gemm_cutlass_mxfp4_sm120.cu`, `gemm_cutlass_grouped_3x.cu` | NVFP4 / MXFP4 GEMM templates for sm_120. Headers-only, vendored. | Moderate (3 TUs but templated heavily). Compile-time only. |
+| **stb_image** (`third_party/stb/`, vendored) | `src/vision/image_processor.cpp` (1 file) | JPEG/PNG decode for vision input. | Shallow |
+| **GoogleTest v1.17.0** (`FetchContent`, `CMakeLists.txt:62`) | tests only | Test framework. | Shallow (test binaries) |
+| **cpp-httplib v0.42.0** (`FetchContent`, `CMakeLists.txt:340`) | `tools/imp-server/*` (4 files) | HTTP server. | Shallow (tools, not library) |
+| **nlohmann/json v3.12.0** (`FetchContent`, `CMakeLists.txt:347`) | `tools/imp-server/*` | OpenAI/Anthropic JSON marshalling. | Shallow (tools) |
+| **pthread** | imp lib `PRIVATE` link | Host threading. | Shallow |
+| **SentencePiece** | Hand-rolled in-tree (`src/model/sentencepiece_loader.cpp`, header `sentencepiece_loader.h`) | Reads SP proto wire format manually; **no external dep**. | n/a (in-tree) |
+
+Dockerfile (`Dockerfile:27`) pins CUTLASS to **v4.4.2** — `CMakeLists.txt:74`
+asks for **v4.5.0**. Cached `/deps/cutlass` overrides via
+`FETCHCONTENT_SOURCE_DIR_CUTLASS=/deps/cutlass` (`Dockerfile:47`), so the
+Docker build effectively uses v4.4.2 unless the user rebuilds the layer.
+Flagged for Phase 3.
+
+---
+
+## 6. Build system flags & defines
+
+Only `CMakeLists.txt`, `cmake/CompilerFlags.cmake`, `Dockerfile`, and
+`Makefile` define compile-time switches. Runtime knobs (env vars) listed in §7
+counter-section.
+
+### CMake options (`option(...)`)
+
+| Option | Default | What it gates | Meaningful on sm_120a-only? |
+|---|---|---|---|
+| `IMP_DISABLE_120F_FALLBACK`        | OFF | Skip `compute_120f` PTX fallback → smaller fatbin, no JIT path for RTX 5080/5070 Ti. | Yes (RTX 5090-only ship) |
+| `IMP_BUILD_TESTS`                  | ON  | Build GTest binaries + 7 bench/probe TUs in `compute/`. | Yes |
+| `IMP_BUILD_TOOLS`                  | ON  | Build `imp-cli`, `imp-bench`. | Yes |
+| `IMP_BUILD_BENCH`                  | ON  | Adds 7 bench-only `compute/*_bench.cu` to lib. | Yes |
+| `IMP_BUILD_SERVER`                 | ON  | Build `imp-server` (httplib + json deps). | Yes |
+| `IMP_SANITIZERS`                   | OFF | ASAN+UBSAN on host code only (nvcc skipped). | Yes |
+| `IMP_USE_CUTLASS`                  | ON  | Comment says "requires sm_90+" (stale — codebase is sm_120a). Adds 11 TUs (incl. 7 bench ones). Defines `IMP_USE_CUTLASS=1`. | Yes; OFF would strip NVFP4/MXFP4 fast paths |
+
+### Hardcoded compile defines / flags (`CMakeLists.txt`, `cmake/CompilerFlags.cmake`)
+
+| Flag/Define | Value | What it gates | Notes |
+|---|---|---|---|
+| `IMP_SM120_FLAGS`                  | `--generate-code=arch=compute_120a,code=sm_120a` (+ `compute_120f` PTX if `!IMP_DISABLE_120F_FALLBACK`) | NVCC code-gen arch | **Single source of truth** for arch. |
+| `CMAKE_CUDA_ARCHITECTURES`         | OFF (raw gencode used)             | CMake<3.31 workaround for `a`/`f` suffixes. | |
+| `IMP_USE_CUTLASS=1`                | compile-def on `imp` target        | Guards `#ifdef IMP_USE_CUTLASS` in compute. | |
+| `-Wall -Wextra -Wpedantic`         | C++ host flags                     | Warnings. | |
+| `-march=x86-64-v3`                 | Release/RelWithDebInfo              | Host vectorization. Dockerfile (`Dockerfile:35`) rewrites `-march=native` → `-march=x86-64-v3` post-COPY. |
+| `--use_fast_math`                  | Release CUDA                       | Forced on Release + RelWithDebInfo (per memo: missing this cost ~2× decode). | |
+| `--extra-device-vectorization -Xptxas -O3` | Release CUDA               | Device opt. | |
+| `-lineinfo`                        | RelWithDebInfo CUDA                | Nsight source mapping. | |
+| `--expt-relaxed-constexpr --extended-lambda` | all CUDA               | CUTLASS / cuTe needs these. | |
+| `--diag-suppress=2908,177`         | all CUDA                           | CUTLASS sm100/103 headers emit deprecated `[=] this` captures (compute_120a inherits the warning). The presence of `sm100/sm103` warnings is itself ballast evidence. | |
+| `-Xcudafe --diag_suppress=esa_on_defaulted_function_ignored` | all CUDA | Noise. | |
+| `IMP_DEBUG=1`                      | Debug builds (`CMAKE_CXX_FLAGS_DEBUG`) | Enables debug-only paths in source. | |
+| `NDEBUG`                           | Release / RelWithDebInfo            | Disables asserts. | |
+| `CUDA_SEPARABLE_COMPILATION`       | ON (lib + bench)                   | Required for PDL. | |
+| `CUDA_RESOLVE_DEVICE_SYMBOLS`      | ON                                 | Device-link resolution. | |
+| `POSITION_INDEPENDENT_CODE`        | ON                                 | PIC for static lib. | |
+
+### Dockerfile build args
+
+| Arg | Default | Purpose |
+|---|---|---|
+| `CMAKE_BUILD_TYPE`     | `Release` | Pass-through to cmake. |
+| `IMP_BUILD_TESTS`      | `OFF`     | Tests are OFF in the Docker runtime image (built only on demand). |
+| `IMP_BUILD_BENCH`      | `OFF`     | Bench is OFF in Docker. |
+
+### Makefile targets (`Makefile:1-115`)
+
+`check-gpu`, `build`, `test-unit`, `test-gpu`, `test-fast`, `test-all`,
+`bench`, `test-perf`, `test-golden`, `verify`, `verify-fast`, `verify-chunked`,
+`install-hooks`, `format`, `format-check`. No additional compile-time defines
+introduced.
+
+---
+
+## 7. Ballast bilanz (HARD NUMBERS)
+
+The mandate is **sm_120a-only**. Quantify deletable LOC. Conservative bias —
+"needs deeper review" used wherever the call path under sm_120a still appears
+non-trivial.
+
+### 7.1 Non-sm_120 architecture references
+
+`grep -rnE 'sm_(80|90|100)\b' src/ include/` → **13 matches across 11 files**
+(`.md` and `CHANGELOG` excluded). Detail:
+
+| File:line | Context | Removable? |
+|---|---|---|
+| `src/compute/attention_tc.cu:40`    | Comment "must be compiled with -arch=sm_90 (or higher)" | Comment only; file ships under sm_120a build. Update or delete file (see 7.4). |
+| `src/compute/attention_tc.cu:407`   | "Require sm_90+" comment | Same. |
+| `src/compute/attention_tc.h:9`      | Comment "Requires sm_90+ … Falls back to scalar on older GPUs." | Stale comment ("Falls back to scalar on older GPUs" — there is no older GPU under the sm_120a-only mandate). |
+| `src/graph/executor_pre_dequant.cu:1849` | Comment about sm_80 WMMA fallback | Stale. |
+| `src/runtime/green_ctx.cu:11`       | Comment "sm_90+ when prefill and decode overlap" | Outdated framing. |
+| `src/compute/attention_paged.cu:1361,1444` | Comments referring to sm_90+ pipelined cp.async / cluster GQA | Outdated framing. |
+| `src/compute/attention_paged_int4.cu:317,545` | Same comments | Outdated framing. |
+| `src/compute/attention_paged_fp8.cu:585` | Same | Outdated framing. |
+| `src/compute/attention_fmha_sm120.cu:565` | "compiles cleanly for sm_90/sm_100 too" | Stale aspiration. |
+| `src/api/imp_api.cpp:67`            | Config `use_nvfp4_decode=-1` ("auto sm_120→mode2, sm_90→mode1") | Auto-select branch is dead under sm_120a-only — should hard-code mode2. |
+| `include/imp/config.h:62`           | Same enum comment | Public-ABI text; rewrite without sm_90 reference. |
+
+**Removable: ~10 comments + 1 dead auto-select branch (~3 LOC).** Bulk of
+the LOC bound to these comments lives in the surrounding kernels, which are
+covered separately below.
+
+### 7.2 `__CUDA_ARCH__` guards
+
+`grep -rnE '__CUDA_ARCH__' src/` → **28 matches across 17 files**. Of these, **every** numeric comparison is `__CUDA_ARCH__ >= 1200`. Zero `< 1200` or `!= 1200` guards exist. Under sm_120a-only those `>= 1200` guards are tautologically true; the `#else` branches (PTX inline-asm fallbacks) are dead code.
+
+Sample: `src/compute/attention_fmha_sm120.cu:756`,
+`src/compute/gemm_cutlass_sm120.cu:209`,
+`src/compute/quantize_fp16_nvfp4_moe_native.cu:38`,
+`src/quant/nvfp4_quant.cu:144`, etc.
+
+| Bucket | Files | Estimated removable LOC (per file ~20-80 LOC of `#else` path) |
+|---|---|---|
+| Production TUs (NVFP4 / FMHA / MXFP4)        | 9  | ~360 LOC (conservative ~40/file) |
+| Bench/probe TUs (`mxf4nvf4_*_bench`, `*_probe`, `qkt_validate`, `tma_block_scale_bench`) | 8 | ~240 LOC |
+| **Subtotal**                                  | 17 | **~600 LOC** (needs deeper review per file) |
+
+### 7.3 Runtime arch detection (`cudaGetDeviceProperties` / `prop.major/minor`)
+
+`grep -rnE 'cudaGetDeviceProperties' src/` → **11 matches across 11 files**.
+Of those, 3 are availability flag flips:
+
+- `src/compute/gemm_cutlass_grouped_3x.cu:97`: `s_grp3x_available = (prop.major*10 + prop.minor >= 120) ? 1 : 0;`
+- `src/compute/gemm_capture_fp16_sm120.cu:289`: `s_avail = (prop.major*10 + prop.minor >= 120) ? 1 : 0;`
+- `src/compute/gemm_grouped_nvfp4_smallM.cu:752`: `s_smallM_available = (prop.major*10 + prop.minor >= 120) ? 1 : 0;`
+
+These availability flags are **always true** on the only supported target.
+The remaining 8 callsites are for legitimate sm_120-runtime info (L2 cache
+size, persistingL2CacheMaxSize, access-policy clamps, occupancy heuristics) —
+keep.
+
+**Removable: ~3 helper blocks (~6-9 LOC + each call site of the static flag check).** Needs deeper review.
+
+### 7.4 cuBLAS / scalar-FA2 fallback paths in attention/FMHA
+
+| File | LOC | Status |
+|---|---:|---|
+| `src/compute/attention_naive.cu` + `.h` | 152 + 13 = **165** | Called exactly once at `src/graph/executor_attention.cu:834` for SWA workaround and `IMP_NAIVE_ATTN`-forced debug runs (l. 807, 824). Per CLAUDE.md/memos this was the FP32 SWA reference fix that the current sliding_window mask cuBLAS path obsoletes. Removable unless `IMP_NAIVE_ATTN` is still wanted for debug. **Conservative: 165 LOC removable.** |
+| `src/compute/attention_cublas.cu` + `.h` | 553 + 34 = **587** | Active prefill path (called from `executor_attention.cu:787, 859, 955` and engine warmup at `engine.cpp:960`). NOT ballast — primary FP16 prefill path. **0 LOC removable.** |
+| `src/compute/attention_tc.cu` + `.h` | 411 + 29 = **440** | Generic WMMA FP16 attention. Still used (header included from `attention_blackwell.cu:24`). Likely subsumed by `attention_blackwell` + `attention_fmha_sm120`. **Needs deeper review** (~440 LOC candidate). |
+| `src/compute/attention_blackwell.cu` | **460** | The sm_120 WMMA optimized FP16 attention. Called from `attention_dispatch.cu:77`. Still active — comment at l. 2 reads "Optimized WMMA attention for sm_120 (Blackwell)". **Probably keep** as the FP16 reference; will lose to `attention_fmha_sm120` when source is NVFP4/MXFP4. **Needs deeper review.** |
+
+**Subtotal hard candidates: 165 LOC** (`attention_naive`). **Soft
+candidates: 440 + 460 = 900 LOC** pending Phase 2 perf evidence that they
+are dominated by FMHA paths.
+
+### 7.5 WMMA paths (`<mma.h>` / `nvcuda::wmma`)
+
+`grep -rnE 'nvcuda::wmma|<mma.h>' src/` → **10 files**:
+
+| File:line | Context (1-line) | Disposition |
+|---|---|---|
+| `src/compute/attention_blackwell.cu:29`      | `#include <mma.h>`; WMMA-based FP16 attention. | 460 LOC; primary FP16 prefill — see 7.4. |
+| `src/compute/attention_tc.cu:6`              | `#include <mma.h>`; older WMMA FP16 attention. | 411 LOC; subsumed by Blackwell variant — see 7.4. |
+| `src/compute/attention_fmha_sm120.cu:40`     | `#include <mma.h>`; SM120 FMHA prefill. | 1 039 LOC; active hot path — keep. |
+| `src/compute/attention_fmha_mxfp4_sm120.cu:30` | `#include <mma.h>`; MXFP4 FMHA. | 1 067 LOC; active — keep. |
+| `src/compute/attention_paged_nvfp4_tc.cu:8`  | NVFP4 TC paged attention. | 1 216 LOC; active (BitDecoding Phase 3) — keep. |
+| `src/compute/gemm_capture_fp16_sm120.h:9`    | Comment only — implementation uses `nvcuda::wmma` HMMA. | Header. The `.cu` includes mma.h via the header. |
+| `src/compute/gemm_capture_fp16_sm120.cu:38`  | WMMA-based FP16 GEMM. | ~600 LOC; opt-in fast path for FP16 GEMM (needs deeper review whether routed under default). |
+| `src/compute/gemm_moe_fused_tc.cu:5`         | WMMA fused MoE GEMM. | ~520 LOC; needs deeper review (dispatched alongside scalar `gemm_moe_fused.cu`). |
+| `src/compute/mmq_q4k_v2.cu:12`               | HMMA Q4_K direct mmq. | **1 667 LOC; gated behind `IMP_FORCE_Q4K_V2=1`** (`executor_kernels.cu:2150-2170` + memory file `mmq_q4k_v2_phase2_shipped_2026_05_16` — "End-to-end on Qwen3.6-35B Q4_K_M: −4% pp"). Under sm_120a-only with NVFP4 as primary, this is the largest **opt-in** TU in the tree. Removable iff the freeze decision is permanent. |
+| `src/compute/attention_paged.h:76`           | Comment referencing WMMA. | Comment only. |
+
+**HMMA primary-compute hot files:** ~3 322 LOC are active hot path (`attention_fmha_*_sm120`, `attention_paged_nvfp4_tc`) — keep.
+
+**HMMA dead-or-opt-in:** `attention_tc.cu` (411) + `mmq_q4k_v2.cu` (1 667) +
+`gemm_moe_fused_tc.cu` (~520) + `gemm_capture_fp16_sm120.cu` (~600) =
+**~3 198 LOC** at risk pending Phase 2 dispatch-frequency check.
+
+### 7.6 FP16/BF16 as primary compute path in hot kernels
+
+The mandate is "FP16/BF16 only reference/debug" — primary compute should be
+NVFP4 / MXFP4 / FP8.
+
+- `half` / `half2` usage in `src/compute/` — `half2` alone: **251 matches**
+  across most attention TUs. `half` is the type of the **paged KV cache** for
+  the default FP16 KV configuration and the type of the residual/hidden state
+  in `forward_logits`. So this is partially structural (KV+activation
+  precision), not pure compute primary.
+- `__hmma` builtin direct usage: 0 matches (all HMMA goes through
+  `nvcuda::wmma` API, see 7.5).
+- The whole `attention_cublas.cu` prefill path runs through cuBLAS at FP16/FP32
+  accumulator — primary path on dense models without NVFP4 weights. Not
+  removable as long as Q4_K / Q8_0 / GGUF flows exist (per CLAUDE.md these
+  flows are explicitly supported).
+
+**Disposition:** no clear "ballast" outside what is already counted in 7.4 and
+7.5. The FP16 prevalence reflects KV-cache and residual-stream dtype, not a
+duplicated compute path.
+
+### 7.7 Multi-precision dispatch tables in `compute/`
+
+`src/graph/executor_attention.cu:988-1112` — paged attention dispatch
+switch by KV dtype: 8 distinct branches (`turboquant_lite`, `turboquant`,
+`int4`, `int8`, `nvfp4_tc`, `nvfp4`, `fp8`, `fp16` default).
+
+| KV dtype | Backing file (LOC) | Coverage under sm_120a-only |
+|---|---|---|
+| FP16 default          | `attention_paged.cu` (1 587)              | Keep — default. |
+| FP8 E4M3              | `attention_paged_fp8.cu` (~685)           | Keep — opt-in via `kv_cache_dtype = FP8_E4M3`. |
+| INT8                  | `attention_paged_int8.cu` (~480)          | Opt-in via INT8 KV. |
+| INT4                  | `attention_paged_int4.cu` (~713)          | Opt-in via INT4 KV; long-ctx quality issue (see memory file `int4_kv_chunked_prefill_2026_05_15`). |
+| NVFP4 (scalar)        | `attention_paged_nvfp4.cu` (~530)         | Opt-in via `kv_cache_dtype = NVFP4`. |
+| NVFP4 + TC            | `attention_paged_nvfp4_tc.cu` (1 216)     | Opt-in via `IMP_USE_BITDECODING_QK=1`. |
+| TurboQuant / Lite     | `attention_paged_turboquant.cu` (1 108)   | Opt-in via TURBOQUANT / TURBOQUANT_LITE dtypes. |
+
+All branches are exposed via `ImpDType` and `ImpConfig::kv_cache_dtype` — none
+are obviously dead under sm_120a. **No removals here** without policy decision
+to drop a KV dtype.
+
+### 7.8 Bench/probe TUs compiled into the lib only when tests/bench is ON
+
+`CMakeLists.txt:194-202`:
+
+| TU | LOC |
+|---|---:|
+| `attention_mxf4nvf4_probe.cu`         | 210 |
+| `nvfp4_quant_ref.cu`                  | 161 |
+| `mxf4nvf4_mma_bench.cu`               | 172 |
+| `mxf4nvf4_mma_variants_bench.cu`      | 328 |
+| `mxf4nvf4_qkt_validate.cu`            | 168 |
+| `tma_block_scale_bench.cu`            | 394 |
+| `fmha_v_load_bench.cu`                | 339 |
+| **Subtotal**                          | **1 772** |
+
+These already drop out of the runtime image when `IMP_BUILD_TESTS=OFF AND
+IMP_BUILD_BENCH=OFF` (Docker default), so this is not "ship ballast" but it is
+~1.8K LOC of bench-only code living alongside production kernels and
+cluttering the `src/compute/` tree (Phase 3 / Phase 4 question whether they
+should live in `tests/bench/` instead).
+
+### 7.9 Ballast bilanz summary
+
+| Category | Source | Est. removable LOC | Confidence |
+|---|---|---:|---|
+| Stale `sm_80/90/100` comments + 1 auto-select branch | §7.1 | ~13 LOC | High |
+| `__CUDA_ARCH__ >= 1200` guard `#else` branches | §7.2 | ~600 LOC | Medium (per-file check needed) |
+| Runtime `prop.major*10+minor >= 120` availability flags | §7.3 | ~6-9 LOC | High |
+| `attention_naive.cu` (+ `IMP_NAIVE_ATTN` debug pull-up) | §7.4 | 165 LOC | Medium |
+| `attention_tc.cu` (subsumed by Blackwell?) | §7.4/§7.5 | 440 LOC | Low — needs profiling |
+| `mmq_q4k_v2.cu` (opt-in, end-to-end −4% per memo) | §7.5 | 1 870 LOC | Low — policy decision |
+| `gemm_moe_fused_tc.cu` (WMMA, dispatched alongside scalar) | §7.5 | ~520 LOC | Low — needs profiling |
+| `gemm_capture_fp16_sm120.cu` (WMMA FP16 GEMM) | §7.5 | ~600 LOC | Low — needs profiling |
+| Bench/probe TUs in `src/compute/` (move to tests/) | §7.8 | 1 772 LOC | High (relocation, not deletion) |
+| **Hard candidates (high confidence)** | | **~1 957 LOC** | |
+| **Soft candidates (needs Phase 2 review)** | | **~3 430 LOC** | |
+| **Total ballast bilanz** | | **~5 390 LOC** of ~90 200 LOC src/ = **6 %** | |
+
+---
+
+## 8. Test coverage estimation
+
+`grep -cE 'TEST(_F|_P)?\s*\('` over all `tests/*.cu /tests/*.cpp` →
+**~863 GTest invocations** across 80 files (CLAUDE.md cites "~574 tests" —
+discrepancy likely from `TEST_P` parameterization).
+
+Build splits into 9 binaries (`CMakeLists.txt:396-501`, l. 599 for `test-gdn`):
+
+| Binary | Coverage | Files | LOC |
+|---|---|---:|---:|
+| `test-core`     | Tensor + qtype + KV cache (CPU model) + loaders (GGUF, SafeTensors, HF config, llm-compressor, SentencePiece) + RuntimeConfig. | 11 | **3 382** |
+| `test-text`     | Tokenizer (BPE + SP compat), chat template, Jinja. | 4 | **2 314** |
+| `test-compute`  | Element-wise kernels: RoPE, LayerNorm, activation, embedding, GEMM (incl. capture-FP16-sm120, dp4a, FP8, mmvq, mmq_q4k_v2), reduce, softmax, sampling, executor-kernels, Hadamard. | 15 | **5 370** |
+| `test-attention`| Attention: TC, FMHA-sm120, FMHA-FP8, MXFP4, FMHA-MXFP4, paged, paged-NVFP4-TC (+ residual variant), chunked. | 9 | **3 873** |
+| `test-quant`    | Quant: NVFP4 (4 variants), TurboQuant, CUTLASS grouped-3x NVFP4, CUTLASS NVFP4 alpha, grouped-NVFP4-smallM, quantize-FP16→NVFP4-MoE, mxf4nvf4 probe/bench/variants/qkt-validate, TMA block-scale bench, FMHA-V-load bench, weight dispatch. | 20 | **7 947** |
+| `test-kv`       | FP8 KV cache, KV write, KV gather, green ctx. | 4 | **~880** |
+| `test-moe-gdn`  | MoE, MoE executor, GDN, SSM, JSON constrain. | 5 | **~1 600** |
+| `test-e2e`      | Forward pass, engine integration, E2E (incl. models), continuous batching, degeneration, weight-registry preservation, E2E llm-compressor, chunked prefill, MTP forward. | 10 + gguf_stub | **3 887** |
+| `test-gdn` (standalone, `CMakeLists.txt:599`) | Standalone GDN kernel test. | 1 | ~210 |
+
+### By category
+
+| Category | Files | LOC | Notes |
+|---|---:|---:|---|
+| Public-API integration (uses `imp_model_load`, `imp_context_create`, `imp_generate*`, `imp_prefill*`, `imp_decode_step`, `imp_tokenize`, `imp_set_image`) | 5 (`test_degeneration.cpp`, `test_e2e.cpp`, `test_chunked_prefill.cu`, `test_e2e_models.cpp`, `test_e2e_llm_compressor.cpp`) | ~1 555 | All in `test-e2e` binary. |
+| Kernel-level unit (call internal `imp::` namespace directly) | ~75 of 80 (the remainder) | ~26 500 | Bulk of suite. |
+| E2E model tests (require `./models/`) | 4 (`test_degeneration.cpp`, `test_chunked_prefill.cu`, `test_e2e_llm_compressor.cpp`, `test_mtp_forward.cpp` — grep `"models/"` matches) | ~815 | Skipped automatically when models absent. |
+| Perf/bench tests (`TEST*Perf*\|*Bench*\|*Throughput*`) | 5 (`test_fmha_v_load_bench.cu`, `test_mxf4nvf4_mma_variants_bench.cu`, `test_gemm_capture_fp16_sm120.cu`, `test_tma_block_scale_bench.cu`, `test_mxf4nvf4_mma_bench.cu`) | ~770 | Distributed across binaries; CTest label `perf` (`CMakeLists.txt:527-533`). Gated against `tests/perf_baseline.json` (3% decode / 5% prefill thresholds per CLAUDE.md). |
+| Python API tests (`tests/api/`) | 9 `.py` + helpers | n/a | pytest-based black-box server tests (`test_chat.py`, `test_concurrency.py`, `test_contract.py`, `test_errors.py`, `test_lifecycle.py`, `test_performance.py`, `test_perf_regression.py`, `test_streaming.py`, `test_tools.py`). Not part of GTest count. |
+
+### Env / model gating
+
+31 files contain `GTEST_SKIP()` or reference `"models/"`. Gating is typically:
+- `GTEST_SKIP()` when model file missing (CLAUDE.md: "13 skipped
+  model-dependent").
+- Some kernel tests check `cudaGetDeviceProperties` and skip on non-sm_120.
+
+CTest labels (`CMakeLists.txt:511-525`):
+
+| Label | Binaries | Use |
+|---|---|---|
+| `unit` | `test-core`, `test-text`, `test-e2e` (subset filter `BatchBuilderTest.*:SchedulerTest.*:RequestTest.*:EndToEndTest.*:StubModelTest.LoadStubModel:StubModelTest.TokenizeStub`) | CPU-only, `make test-unit`. |
+| `gpu`  | `test-compute`, `test-attention`, `test-quant`, `test-kv`, `test-moe-gdn`, `test-e2e` (minus unit filter) | GPU required, `make test-gpu`. |
+| `perf` | `*Perf*:*Bench*:*Throughput*` filter against `test-compute`, `test-attention`, `test-quant`, `test-e2e` | `make test-perf`. |
+
+---
+
+## 9. One-screen mermaid: data flow for one decode token
+
+```mermaid
+flowchart TB
+    A[imp_decode_step<br/>api/imp_api.cpp:661] --> B[Engine::step<br/>runtime/engine.cpp:1735]
+    B --> S[step_schedule<br/>runtime/engine.cpp:1830]
+    S --> D[step_decode<br/>runtime/engine.cpp:2360]
+    D --> F[step_decode_forward<br/>runtime/engine.cpp:2421]
+    F --> G[BatchBuilder + GPUBatch upload]
+    G --> H[GraphExecutor::forward_logits<br/>graph/executor_forward.cu:174]
+
+    H --> EMB[embedding<br/>compute/embedding.cu]
+    EMB --> LP[for layer in 0..n_layers]
+    LP --> OFF[layer_offload::ensure_layer<br/>memory/layer_offload.cu]
+    OFF --> ATT{layer kind?}
+
+    ATT -- attention --> RA[run_attention<br/>graph/executor_attention.cu:140]
+    ATT -- ssm --> RS[run_ssm<br/>graph/executor_ssm_gdn.cu]
+    ATT -- gdn --> RG[run_gdn<br/>graph/executor_ssm_gdn.cu]
+
+    RA --> QKV[QKV proj + RoPE<br/>compute/rope.cu, gemm/mmvq]
+    QKV --> KVW[KV write<br/>graph/executor_kv_write.cu]
+    KVW --> KVM[kv_cache_manager.block_table<br/>memory/kv_cache_manager.cpp]
+    KVM --> PAD[paged_attention_decode_*<br/>compute/attention_paged*.cu<br/>8 KV-dtype branches]
+    PAD --> OPRJ[O proj GEMV<br/>compute/gemv_ggml_compat, mmvq, gemm]
+
+    OPRJ --> FFN{FFN kind?}
+    RS --> FFN
+    RG --> FFN
+
+    FFN -- dense --> RF[run_ffn<br/>graph/executor_ffn.cu:31]
+    FFN -- moe --> RM[run_moe_ffn<br/>graph/executor_forward_moe.cu:146]
+    FFN -- none --> POST
+    RF --> POST[post-layer scale + dump]
+    RM --> ROU[moe_routing<br/>compute/moe_routing.cu]
+    ROU --> GRP[gemm_grouped*<br/>compute/gemm_grouped*.cu]
+    GRP --> POST
+
+    POST --> LP
+
+    LP --> NORM[final RMSNorm<br/>compute/layernorm.cu]
+    NORM --> LM[LM head GEMV<br/>compute/gemv_ggml_compat / nvfp4 / mxfp4 / gemm]
+    LM --> LO[logits]
+    LO --> SAM[sampler<br/>compute/sampling.cu]
+    SAM --> TOK[token int32]
+    TOK --> Z[engine.step_decode_process_outputs]
+    Z --> Y[Engine::step returns]
+    Y --> X[imp_decode_step returns out_token]
+```
+
+Per-token call counts (assuming 1-token decode, no MTP, no spec, no vision):
+
+| Stage | TUs touched | Calls per decode token |
+|---|---|---:|
+| API + scheduler                                   | `api/imp_api.cpp`, `runtime/engine.cpp`, `runtime/batch.cpp`, `runtime/scheduler.cpp` | 1 each |
+| Executor loop init                                | `graph/executor_forward.cu`, `graph/executor_workspace.cu` | 1 each |
+| Embedding                                         | `compute/embedding.cu` | 1 |
+| Per-layer attention                               | `graph/executor_attention.cu`, `compute/rope.cu`, `compute/layernorm.cu`, `compute/attention_paged*.cu`, `memory/kv_cache_manager.cpp`, `graph/executor_kv_write.cu` | n_layers |
+| Per-layer FFN/MoE                                 | `graph/executor_ffn.cu` OR `graph/executor_forward_moe.cu` + `compute/moe_routing.cu` + `compute/gemm_grouped*.cu` | n_layers |
+| GEMM path                                         | `compute/gemm.cu`, `compute/gemv_ggml_compat.cu`, `compute/ggml_mmvq.cu`, `graph/executor_kernels.cu` (dispatch) | multiple per layer |
+| Per-layer offload                                 | `memory/layer_offload.cu` | n_layers (no-op when fully GPU-resident) |
+| Final norm + LM head                              | `compute/layernorm.cu`, `compute/gemv_*` | 1 |
+| Sampling                                          | `compute/sampling.cu`, `compute/softmax.cu` | 1 |
+
+Under CUDA-graph decode capture (`runtime/cuda_graph.cu`, 989 LOC) the whole
+inner loop is replayed via `cudaGraphLaunch`, so per-token CPU-side cost
+collapses to `cudaGraphLaunch + cudaStreamSynchronize` (memory file
+`cuda_graphs_moe_works_2026_05_07`).
+
+---
+
+## Appendix A. Per-subsystem file lists (truncated to LOC > 200)
+
+Only used as reference for Phase 2/3 — full lists generated via
+`find ... -exec wc -l {} +`.
+
+### `src/compute` (top 15 by LOC)
+
+| LOC | File |
+|---:|---|
+| 1 701 | `sampling.cu` |
+| 1 694 | `gemm.cu` |
+| 1 667 | `mmq_q4k_v2.cu` |
+| 1 620 | `gemv_dp4a_traits.cuh` (header-only template library) |
+| 1 587 | `attention_paged.cu` |
+| 1 216 | `attention_paged_nvfp4_tc.cu` |
+| 1 108 | `attention_paged_turboquant.cu` |
+| 1 067 | `attention_fmha_mxfp4_sm120.cu` |
+| 1 039 | `attention_fmha_sm120.cu` |
+| 1 031 | `moe_routing.cu` |
+|   948 | `gemm_grouped_nvfp4_smallM.cu` |
+|   713 | `attention_paged_int4.cu` |
+|   685 | `attention_paged_fp8.cu` |
+|   600 | `gemm_capture_fp16_sm120.cu` |
+|   587 | `attention_cublas.cu` + `.h` |
+
+### `src/graph` (all)
+
+`executor_forward_moe.cu` 2 563, `executor_pre_dequant.cu` 2 556,
+`executor_kernels.cu` 2 327, `executor_attention.cu` 1 299,
+`executor_workspace_buffers.cu` 994, `executor_forward.cu` 775,
+`cuda_graph.cu` 989 (in runtime — listed here for completeness), …
+
+### `src/model` (top by LOC)
+
+`jinja.cpp` 2 629, `tokenizer.cpp` 2 108, `weight_upload.cu` 2 092,
+`gguf_loader.cpp` 1 683, `safetensors_loader.cpp` 1 332, `chat_template.cpp`
+1 168, `weight_map.cpp` 1 111, `hf_config_loader.cpp` 1 022.
+
+### `src/runtime` (top by LOC)
+
+`engine.cpp` 3 066, `cuda_graph.cu` 989, `mtp_forward.cu` 936.
+
+---
+
+## Appendix B. Runtime env-var knobs touched on hot path
+
+(grep`-based count, excludes log-string mentions.) Reflects per-call gating
+overhead, not just config-time. 16 distinct `IMP_*` env vars are read by
+production code paths under `src/`. Top hot-path knobs:
+
+| Env var | Files touching | Comment |
+|---|---|---|
+| `IMP_FORCE_Q4K_V2`        | `executor_kernels.cu`, `executor_pre_dequant.cu` | Gates Q4_K HMMA mmq path (1 870 LOC). |
+| `IMP_USE_BITDECODING_QK`  | `executor_attention.cu` | Gates NVFP4 TC paged attention (1 216 LOC). |
+| `IMP_FORCE_HOST_EXPERTS`  | `weight_upload.cu` | MoE expert host/device split. |
+| `IMP_NO_CUDA_GRAPH`       | `engine.cpp` (per memory file `cuda_graphs_moe_works_2026_05_07`) | Disables decode-graph capture. |
+| `IMP_PREFILL_GRAPH`       | `runtime/engine.cpp` | Opt-in prefill graph capture. |
+| `IMP_NAIVE_ATTN`          | `executor_attention.cu:807` | Forces `attention_naive` (debug only). |
+| `IMP_NO_NAIVE_SWA`        | `executor_attention.cu:823` | Disables naive SWA workaround. |
+| `IMP_NO_FMHA_SM120`       | mentioned `engine.cpp:635` | Disables FMHA SM120. |
+| `IMP_FORCE_CUBLAS_DECODE` | mentioned `engine.cpp:635` | Forces cuBLAS decode path. |
+| `IMP_DETERMINISTIC_GEMM`  | `compute/gemm.cu` | Locks GEMM algo for reproducibility. |
+| `IMP_GRAPH_CAPTURE_MODE`  | runtime | Graph capture mode override. |
+| `IMP_EXPERT_OVERHEAD_PCT` | engine/storage planner | MoE expert reserve. |
+| `IMP_MOE_RESERVE_MIB`     | engine | MoE workspace reserve override. |
+| `IMP_MTP_NO_ROPE`         | `mtp_forward.cu` | MTP RoPE toggle. |
+
+Phase 2 should treat this list as the surface for dispatcher overhead measurement.
+
+---
+
+## Appendix C. Anchors for Phase 2 / Phase 3
+
+- Decode hot-path entry: `src/api/imp_api.cpp:661`
+- Engine step driver: `src/runtime/engine.cpp:1735` / l. 2360 / l. 2421
+- Forward loop: `src/graph/executor_forward.cu:174` / l. 380-450
+- Attention dispatch (8 KV dtypes): `src/graph/executor_attention.cu:988-1112`
+- MoE decode fast-path: `src/graph/executor_forward_moe.cu:2316`
+- Decode-graph capture: `src/runtime/cuda_graph.cu` (all 989 LOC)
+- Q4_K HMMA opt-in gate: `src/graph/executor_kernels.cu:2150-2170`
+- Naive attention SWA gate: `src/graph/executor_attention.cu:807-834`
+- Public-private boundary: `src/api/imp_internal.h` (only file bridging
+  `include/imp/` → `src/`)
+- Build-time arch flags single source: `CMakeLists.txt:30-39`
+- CUTLASS pin mismatch: `CMakeLists.txt:74` (v4.5.0) vs `Dockerfile:27` (v4.4.2)
+
+End of Phase 1 inventory.

--- a/review/phase2_perf.md
+++ b/review/phase2_perf.md
@@ -1,0 +1,1159 @@
+# Phase 2 — PERFHAWK Performance Audit
+
+Single-target: sm_120a / RTX 5090 / GB202. No diplomacy. No re-derivation of
+hardware. Map = `review/phase1_inventory.md` (`HEAD = f58eb9e`). Memory
+baselines = `memory/MEMORY.md` (2026-05-16). Per claim: **measured** (number
+from MEMORY/test output), **code-evidence** (read source at file:line), or
+**speculative** (needs ncu trace).
+
+The headline of this audit, repeated up front because it dominates the
+verdict: imp on Qwen3-Coder-30B-A3B-NVFP4 measures **pp512 = 1258 tok/s vs
+vLLM 25513 tok/s (continuous batching) — a 20.3× gap**. vLLM single-seq is
+18 500 tok/s = a **14.7× gap**. Both engines call the same CUTLASS Sm120
+NVFP4 grouped GEMM template (`nvfp4_moe_prefill_landscape_2026_05_10`),
+which means **the gap is host-side, scheduler-side, and around-the-kernel —
+not in the kernel itself**. Sections 6 and 7 quantify which buckets are
+worth shipping fixes for.
+
+---
+
+## 1. Hot-kernel roofline table
+
+GB202 specs taken as given: 1792 GB/s HBM (≈1500 GB/s achievable), 838
+TFLOPS FP16/BF16, 1677 TFLOPS FP8, 3354 TOPS NVFP4/MXFP4 block-scaled, 88
+MB L2, 99 KiB SMEM/block opt-in, 170 SMs. Decode-style numbers are tok/s on
+a single sequence; prefill-style are TFLOPS/TOPS.
+
+| Kernel category | File:line | Bound | Theoretical ceiling | Best-known achieved | Headroom | Confidence |
+|---|---|---|---|---|---|---|
+| FP16 paged attention decode (GQA, default) | `src/compute/attention_paged.cu:90` (`paged_attention_gqa_kernel`) | **memory-bound** (28:1 KV-load to dot-product, per `docs/sm120.md:46`) | ≥320 tok/s @ 8K ctx on Qwen3-8B Q8 KV | 256 tok/s tg256 Qwen3-8B Q8 (cache=FP16) | ~1.25× | measured (MEMORY baseline) |
+| FP16 paged attention decode (cluster, GQA, ≥8 ctx blocks, hd ∈ {64,96,128,256,512}) | `src/compute/attention_paged.cu:1111` (`paged_attention_cluster_kernel`) | memory-bound; cluster cuts KV reads by n_q_per_kv× via DSMEM | ~1.5–2× over non-cluster on GQA=8 | not separately benched; folded into 256 tok/s | unmeasured | code-evidence + speculative |
+| NVFP4 paged attention decode (scalar, default when `--kv-nvfp4`) | `src/compute/attention_paged_nvfp4.cu:53` (`paged_attention_decode_nvfp4_kernel`) | memory-bound on K-cache reads | parity with FP16 at 4× VRAM compression | parity 193 tok/s Qwen3-8B Q8+`--kv-nvfp4` | n/a (parity is the goal) | measured (`lever2_nvfp4_kv_implemented_2026_05_07`) |
+| NVFP4 paged attention decode (WMMA-Q.K, BitDecoding, `IMP_USE_BITDECODING_QK=1`) | `src/compute/attention_paged_nvfp4_tc.cu:58` (`paged_attention_decode_nvfp4_tc_kernel`) | latency-bound on the HMMA Q.K op (24 HMMA per call vs 0 in scalar) | paper claims 8.6× FP16 FlashDecoding-v2 at long ctx | tg=148 vs scalar 149 at 4K ctx (within noise); 0% across all long-ctx configs | 8.6× claimed, 1.0× delivered | measured (`bitdecoding_long_context_eval_2026_05_14`) |
+| FMHA prefill (FP16 WMMA, SM120) | `src/compute/attention_fmha_sm120.cu:69` (`fmha_sm120_kernel`) | compute-bound at large seq (HMMA m16n16k16 via `nvcuda::wmma`) | 838 TFLOPS FP16 | not isolated; folded into pp4096 = 11–18k tok/s on Qwen3-4/8B | unmeasured | code-evidence |
+| FMHA prefill (FP8 m16n8k32) | `src/compute/attention_fmha_sm120.cu:581` (`fmha_sm120_fp8_kernel`) | compute-bound (m16n8k32 `mma.sync.kind::f8f6f4`) | 1677 TFLOPS FP8 | +3.3% pp4096 vs FP16 (`docs/sm120.md:32`) | small; was bigger before bug fixes | measured (PR #33) |
+| MXFP4 FMHA prefill (block-scaled, `mxf4nvf4`) | `src/compute/attention_fmha_mxfp4_sm120.cu:108` (`fmha_sm120_mxfp4_kernel`) | compute-bound (`mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64`) | 3354 TOPS NVFP4 | +1.8% Qwen3-4B MXFP4 HD=128 (Phase 1 only 15% of FMHA wall, per `roadmap.md:104`) | Phase-3 PV-FP4 ~+13% claimed but quality-risky | measured |
+| FP16 cuBLAS dense GEMM prefill | `src/compute/gemm.cu:1` (cuBLAS via `cublasGemmEx`, `attention_cublas_prefill`) | compute-bound; `CUBLAS_TF32_TENSOR_OP_MATH` default | 838 TFLOPS FP16-TC | cuBLAS autotune; pp512 varies up to 2.6× across container restarts (CLAUDE.md) | unmeasured per-kernel | measured (variance), code-evidence (mode set) |
+| NVFP4 grouped GEMM prefill (MoE) | `src/compute/gemm_cutlass_grouped_3x.cu:150` (`gemm_grouped_cutlass_3x_nvfp4`) | compute-bound (cooperative block-scaled mainloop, `<128,128,128>` tile, `Sm120` arch tag, `KernelScheduleAuto`) | 3354 TOPS NVFP4 | imp pp512 = 1258 tok/s vs vLLM 18.5k single-seq (`nvfp4_moe_prefill_landscape_2026_05_10`) | **14.7×** | measured |
+| NVFP4 smallM grouped GEMM (`IMP_NVFP4_SMALLM=1`, opt-in, hand-rolled) | `src/compute/gemm_grouped_nvfp4_smallM.cu:87` (inline `mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64`) | compute-bound | 3354 TOPS NVFP4 | **par with CUTLASS at large M_e, -50–55% at small M_e** | negative; kept opt-in | measured (memo) |
+| NVFP4 MoE decode GEMV (per-expert) | `src/quant/nvfp4_gemm.cu:855` (`gemv_nvfp4_moe_decode_kernel`, `__launch_bounds__(128, 12)`) | memory-bound on weight stream | ~1.8 TB/s × top_k weight bytes ⇒ ~270 tok/s @ MoE-30B-A3B | tg128 = 261–266 tok/s Qwen3-Coder NVFP4 | ~0.97× (effectively at roof) | measured |
+| Q4_K GEMV (mmvq, dp4a) | `src/compute/ggml_mmvq.cu` (`mmvq_kernel`, warp-per-output) | memory-bound on weight stream | ~250 tok/s saturating regardless of M (per `q4k_mmvq_crossover_2026_05_15`) | matches | n/a (saturated for its design) | measured |
+| Q4_K direct tiled GEMM v2 (HMMA, `IMP_FORCE_Q4K_V2=1`) | `src/compute/mmq_q4k_v2.cu:404` (`mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32`) | compute-bound, but **stuck at ~15% of FP16-TC peak** | 838 TFLOPS FP16-TC | 4.87× v1 dp4a kernel-only, **-4% end-to-end on Qwen3.6-35B Q4_K_M** | -4% net; opt-in only | measured (`mmq_q4k_v2_phase2_shipped_2026_05_16`) |
+| Q6_K direct fused-MoE prefill (FP16 accum, dequant on the fly) | `src/compute/gemm_q6k.cu:41` (`gemm_q6k_moe_fused_prefill_kernel`, `__launch_bounds__(128, 2)`) | likely compute-bound (FP16 dequant + dp4a) | unmeasured | tg=234 Qwen3-Coder Q6_K (decode); prefill 5643 tok/s (pp512) | unmeasured per kernel | code-evidence + measured (E2E) |
+| MoE expert routing (router GEMV + softmax + top-k) | `src/compute/moe_routing.cu:196` (`gemv_gate_topk_fused_kernel`); `src/compute/moe_routing.cu:533` (`moe_fused_permute_kernel`, `__launch_bounds__(256)`) | latency-bound (single-block scan, n_experts ≤ 1024) | single-block at ~5 µs / decode (estimate) | unmeasured | (not on the critical path at decode size) | code-evidence |
+| MoE combine (weighted sum + residual fused) | `gemm_grouped_3x_nvfp4.cu` epilogue + `moe_weighted_sum_residual` (graph/executor_forward_moe.cu:2362) | memory-bound on activations | bandwidth-trivial | unmeasured | n/a (small) | code-evidence |
+| KV cache FP16 load (paged decode hot loop) | `src/compute/attention_paged.cu:174` (`ldcs_half`) + `:191` double-buffered streaming load | memory-bound; double-buffered cp.async (FP16) | 1500 GB/s achievable | unmeasured per-kernel | n/a | code-evidence |
+| RoPE + QK-norm fused (FP16) | `src/compute/rope.cu:214` (`qknorm_rope_fused_fp16_kernel`) | bandwidth-bound | trivial | n/a | n/a | code-evidence |
+| RMSNorm + Q8_1 quantize fused | `src/compute/layernorm.cu:72`, `rmsnorm_quantize_q8_1` (used at `executor_forward_moe.cu:236`) | bandwidth-bound | trivial | n/a | n/a | code-evidence |
+| Sampler (top-k/top-p/min-p/DRY) | `src/compute/sampling.cu:1` (block size 256, `cub::DeviceTopK` for k>128) | latency-bound on vocab-sized arrays | argmax ~10 µs (mentioned `sampling.cu:97`) | unmeasured at decode-step granularity | n/a | code-evidence |
+| Embedding lookup | `src/compute/embedding.cu` | bandwidth-trivial (single token row) | trivial | n/a | n/a | code-evidence |
+
+**One sentence on the roofline shape:** for batch=1 decode imp is sitting
+within 10–20% of the bandwidth-limited NVFP4 / Q4_K ceiling on MoE
+models (memory-bound, working as designed); for prefill on dense models
+the FP16-TC path is sitting near 838 TFLOPS via cuBLAS auto-tune; the one
+kernel category where imp is dramatically **off** the achievable ceiling
+is **NVFP4 grouped MoE prefill** (Qwen3-Coder pp512 1.26k vs vLLM 18.5k
+on the same template), and that is the dominant brecher-opportunity in
+this audit.
+
+---
+
+## 2. Occupancy & resource limiters
+
+Top-5 hot decode kernels, what limits them, where the headroom is. Block
+size from `__launch_bounds__` (where present), shared memory from `extern
+__shared__` allocator at launch site, register count not directly visible
+without ncu so estimated from kernel size + accumulators.
+
+### 2.1 `paged_attention_gqa_kernel` (default FP16 KV decode)
+
+- `src/compute/attention_paged.cu:90` — `__launch_bounds__(1024)`.
+- Block size: variable, up to 1024 (`gqa_threads = n_q_per_kv *
+  warps_per_q * 32`, capped at 1024); `warps_per_q = 4` for ratio≤8,
+  `2` for >8.
+- Shared mem: dynamic, `kv_tile_bytes = 4 * block_size * head_dim *
+  sizeof(half)` = 8 KiB at bs=16/hd=128 (`attention_paged.cu:1518`).
+  When `gqa_smem > 48 KiB` it calls `cudaFuncSetAttribute` for opt-in
+  extended SMEM (`:1530`).
+- Per-thread reg state: `q_reg[16] + o_reg[16]` floats + running m/l ⇒
+  ~36 floats per thread = 36 registers minimum. With 1024 threads/block
+  and 64 KiB register file/SM, this is **register-limited to 1
+  block/SM** at the upper bound (1024 × 64 = 65536 regs, exactly the
+  file size). That matches `__launch_bounds__(1024)` which asks for 1
+  block/SM by convention when the second arg is omitted.
+- **Limiter: register file × block-size combo.** With 1024 threads/block
+  and no second arg to `__launch_bounds__`, occupancy = 1 block/SM ≈
+  6% theoretical occupancy.
+- **Code-evidence opportunity:** `__launch_bounds__(1024, 1)` would be
+  explicit; current implicit 1-block/SM is fine. But the kernel
+  arguably runs 256 threads worth of *useful* work on 32-warp Q-head
+  groupings — a `__launch_bounds__(256, 4)` variant with `warps_per_q
+  = 1` could re-claim occupancy at small GQA ratios. Speculative.
+  Note `dead_ends.md` line 77: "`__launch_bounds__` on paged
+  attention: -6% decode" — so changes here historically regressed.
+  Keep current setting; flag the implicit-1-block-per-SM as low-risk
+  but already validated.
+
+### 2.2 `paged_attention_decode_nvfp4_kernel` / `paged_attention_decode_nvfp4_tc_kernel`
+
+- `src/compute/attention_paged_nvfp4.cu:53` and
+  `src/compute/attention_paged_nvfp4_tc.cu:58` — **no `__launch_bounds__`**
+  (comment at `attention_paged_nvfp4_tc.cu:53-56`: "with the dots/weights
+  moved to shared mem (warp-shfl reduction) the spill is gone (cuobjdump
+  STACK:0 across HD ∈ {64,128,256,512}); the compiler picks the best
+  occupancy/register trade-off automatically").
+- Per-warp WMMA scratch on the TC kernel: 16×16 + 16×16 + 16×16×2 halves
+  = 2 048 B/warp, ~16 KiB for 8 warps (`attention_paged_nvfp4_tc.cu:86-91`).
+- Limiter: bandwidth (FP4 K stream) on the scalar variant; HMMA
+  pipeline issue rate on the TC variant. The 0% E2E gain of TC despite
+  24 HMMA ops (audit at `bitdecoding_sass_audit_2026_05_09`) tells the
+  story: the K-byte stream is bandwidth-bound, and rerouting Q.K
+  through HMMA doesn't change the K-byte count.
+- No opportunity here: the comment is right that the compiler picks the
+  right occupancy.
+
+### 2.3 `gemv_nvfp4_moe_decode_kernel` (MoE decode hot kernel)
+
+- `src/quant/nvfp4_gemm.cu:855` — `__launch_bounds__(128, 12)`.
+  4 warps/block, **explicitly asking for 12 blocks/SM** — aggressive,
+  ~85% occupancy on a 24-block-per-SM device (sm_120 has 16 blocks/SM
+  hardware max so 12 is also bounded by HW; compiler will warn if
+  unachievable).
+- Per-thread reg state: warp_sums float reduction array (4 floats), one
+  acc float, dequant scratch from `dot_micro_block`. Estimate <40 reg.
+- Shared mem: `SmemKpar` struct = `kKparWarps * sizeof(float)` = 16 B
+  per block, negligible.
+- Limiter: HBM bandwidth on weight bytes (FP4 + per-16-elem UE4M3
+  scales). 1.8 TB/s × bytes / (top_k × N × K / 2) gives the upper
+  bound — matches measured 261 tok/s on Qwen3-Coder.
+- No opportunity in occupancy. Headroom would come from reducing weight
+  byte count (smaller quant) or sharing weights across requests (batch).
+
+### 2.4 `fmha_sm120_kernel` / `fmha_sm120_fp8_kernel` (prefill FMHA)
+
+- `src/compute/attention_fmha_sm120.cu:69`, `:581` — both
+  `__launch_bounds__(256, 1)` (256 threads = 8 warps = 1 block/SM).
+- Shared mem: 65–89 KiB depending on HD (table at top of file). HD=64
+  uses 89 KiB which is **above** the 48 KiB default carveout — relies
+  on opt-in (line 564 mentions `cudaFuncSetAttribute` for SMEM).
+- HD=256 uses 88 KiB with Bq=32 — already near the 99 KiB sm_120
+  per-SM cap.
+- Per-thread regs: holds float accumulators `O_acc[Bq * head_dim /
+  threads]` + WMMA fragments + 6 floats softmax state. With 1
+  block/SM, registers aren't the limit.
+- **Limiter: SMEM at 89 KiB ⇒ 1 block/SM** (CTAS-per-SM = floor(99/89)
+  = 1). Recorded in `dead_ends.md` line 55: "`__launch_bounds__(256,1)`
+  on FMHA: CORRECT for SMEM-limited kernels (69KB → 1 block/SM
+  anyway)."
+- No occupancy headroom; this is the right shape for the kernel.
+- **One non-obvious gap:** the FP8 kernel computes Q→FP8 conversion in
+  shared memory (`Q_fp8` written by all threads before the main loop,
+  line 638-655) — this is one full Q-tile write to SMEM per kernel,
+  per CTA. With Bq×HD = 128×64 = 8 KiB at HD=64 that's not free at
+  100% SM occupancy = 1. **Speculative:** precomputing FP8 Q outside
+  the kernel (in the executor before launch) would eliminate the SMEM
+  conversion stage but adds an extra global write/read pair.
+  Cannot rule in/out without an ncu trace.
+
+### 2.5 `paged_attention_cluster_kernel`
+
+- `src/compute/attention_paged.cu:1111` — no `__launch_bounds__`.
+- Block size: `BLOCK_THREADS = 256` (from cluster_block dim3,
+  `:1454`).
+- Cluster: up to (n_q_per_kv, 1, 1) = up to 8 blocks. Uses DSMEM via
+  `cluster.map_shared_rank` (`:1179`).
+- Shared mem: `cluster_smem = 2 * block_size * 2 * head_dim *
+  sizeof(half) + NUM_WARPS * sizeof(float)*2 + NUM_WARPS * head_dim *
+  sizeof(float)` = up to ~50 KiB at hd=256/bs=16 (`:1450-1451`).
+- **Cluster scheduling policy = `cudaClusterSchedulingPolicySpread`**
+  (`:1472`), explicit comment "CUDA 13.2: spread cluster blocks
+  across GPCs (GB202 has 12 GPCs)". Good code.
+- No occupancy concern; cluster is doing the right thing for KV
+  reuse (8× fewer KV bytes per Q-head group).
+
+### 2.6 `__launch_bounds__` audit summary
+
+`grep -rn "__launch_bounds__" src/compute/ src/quant/` finds 44
+declarations. Sample-checked vs `dead_ends.md` guidance:
+
+| File:line | Bounds | Verdict |
+|---|---|---|
+| `attention_fmha_sm120.cu:69, 581` | (256,1) | matches SMEM = 89 KiB → 1 block/SM (correct) |
+| `attention_fmha_mxfp4_sm120.cu:108` | (`MX_BLOCK_THREADS`, 1) | same shape, same justification |
+| `attention_paged.cu:90` | (1024) | OK; implicit 1 block/SM at thread count = file size |
+| `attention_paged_nvfp4_tc.cu` | none | deliberate (comment explains) |
+| `attention_paged_turboquant.cu:44/286/639/824` | (256, 2) | 2 blocks/SM × 256 = 512 threads/SM → fine on sm_120 |
+| `quant/nvfp4_gemm.cu` (12× `kKparThreads, 12`) | (128, 12) | aggressive; compiler may not deliver 12 but won't regress |
+| `quant/mxfp4_gemm.cu` (9× `kKparThreads, 12`) | (128, 12) | same |
+| `gemm_q6k.cu:41` | (128, 2) | 2 blocks/SM × 128 = 256 threads/SM — undersubscribed |
+| `gemm_moe_fused_tc.cu:40` | (TC_BLOCK=256) | implicit 1 block/SM — file is WMMA-heavy, justified |
+| `gdn.cu:30` | (HD, 1) | template-bound, fine |
+
+No `__noinline__` annotations found in `src/` (`grep` for the term
+returned no matches — CLAUDE.md hard-rule is **respected**).
+
+No `cudaMalloc/cudaFree` in true decode-token hot loops EXCEPT the
+size-grow-if-needed patterns at:
+- `src/graph/executor_kernels.cu:2178-2181` (mmvq scratch — fires once
+  at first call per dimension; static across decode steps; not a true
+  hot-loop allocation) — passes the CLAUDE.md hard rule on a strict
+  reading but is fragile if a larger-K weight appears.
+- `src/compute/gemm_cutlass_grouped_3x.cu:120-136` (`ensure_staging`,
+  `ensure_workspace`) — only grows; `gemm_grouped_3x_nvfp4_prewarm()`
+  pre-allocates 1 MiB + 512 MiB so the lazy path never fires under
+  capture in practice.
+- `src/compute/attention_cublas.cu:343-347` (`s_attn_d_ptrs`) — same
+  pattern.
+- **`src/graph/executor_forward_moe.cu:2092-2100`** —
+  `try_run_moe_gemma4_ggml_prefill` lazy-allocates `s_q8_scratch` and
+  `s_norm_fp32` via `cudaMalloc/cudaFree`. This is a **prefill** path
+  (Gemma-4 MoE ggml fallback), one-shot per session normally; if `d`
+  grows mid-session (multi-model swap) it free/mallocs. Acceptable
+  but worth a static-buffer rewrite for cleanliness.
+
+The real CLAUDE.md violation candidates do not exist in the current
+tree — the surviving lazy-allocs are all monotonic-grow-only with
+pre-warm hooks.
+
+---
+
+## 3. GB202 feature utilization audit
+
+Feature-by-feature. "Used" = real production kernel calls it; "Bench
+only" = only in `src/compute/*_bench.cu` (which CMakeLists strips from
+the runtime image when `IMP_BUILD_BENCH=OFF`). "Missing" =
+applicable-but-absent.
+
+### 3.1 `cp.async.bulk` / `cp.async.bulk.tensor` (TMA)
+
+**Production: hand-rolled in one TU; CUTLASS-internal elsewhere; otherwise NO.**
+
+`grep -rn "cp.async.bulk\|cuTensorMap\|__cvta_generic_to_shared" src/`:
+
+| File:line | Status |
+|---|---|
+| `src/compute/tma_block_scale_bench.cu:117-122` | bench-only (off in runtime). Uses `cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes`. |
+| `src/compute/attention_paged_common.cuh:17-24` | `__cvta_generic_to_shared` helpers — used by NVFP4 paged attention's `cp_async_*` non-bulk paths. NOT TMA. |
+| `src/compute/gemm_grouped_nvfp4_smallM.cu:69-122, :362-363, :702-744` | **The only production TMA in imp.** Builds `CUtensorMap` descriptors via `cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled", …)` and issues `cp.async.bulk.tensor.2d` for A and B in the smallM kernel mainloop. **Opt-in via `IMP_NVFP4_SMALLM=1`** (per `executor_forward_moe.cu:703-704`). Default off because at production shapes it's -50–55% vs CUTLASS. |
+| `src/compute/fmha_v_load_bench.cu:117-122` | bench-only. Re-confirmed by `fmha_tma_lever_refuted_2026_05_14`: cp.async beats TMA bulk 0.31–0.79× on SM120 — TMA loses to cp.async. |
+
+**CUTLASS-internal TMA:** `gemm_cutlass_grouped_3x.cu:24` includes
+`cutlass/detail/sm100_blockscaled_layout.hpp` and the
+`MainloopSm120ArrayTmaWarpSpecializedBlockScaled` schedule (per memo
+`nvfp4_moe_prefill_landscape_2026_05_10`) — so CUTLASS uses TMA
+internally on the NVFP4 grouped GEMM path. imp doesn't reach in for
+it directly.
+
+**Missing-but-applicable:**
+- `paged_attention_*_kernel` KV-block loads. Each kernel uses
+  `ldcs_half` + double-buffered SMEM (`attention_paged.cu:194-200`).
+  TMA bulk could replace this but `fmha_tma_lever_refuted_2026_05_14`
+  shows cp.async wins on SM120 — **don't pursue**.
+- Prefill `attention_cublas_prefill` Q/K/V gather. cuBLAS owns this,
+  no opportunity.
+
+**Verdict:** TMA usage is appropriate for SM120; the refuted
+benchmark proves more TMA isn't free upside. **Not** a left-on-the-table
+lever.
+
+### 3.2 `mma.sync.aligned.m16n8k16` (HMMA, FP16/BF16)
+
+**Used widely.** Direct inline PTX:
+- `src/compute/mmq_q4k_v2.cu:404, 607, 975, 1166, 1421, 1591` (six
+  `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32` invocations
+  across the v1/v2/q5k/q6k variants).
+- `src/compute/attention_fmha_sm120.cu:201-214` (via `nvcuda::wmma`
+  which lowers to HMMA m16n16k16 — same SASS class).
+- `src/compute/attention_blackwell.cu`, `attention_tc.cu`,
+  `attention_paged_nvfp4_tc.cu`, `gemm_capture_fp16_sm120.cu`,
+  `gemm_moe_fused_tc.cu` — all use `<mma.h>` (wmma API).
+
+**Verdict:** Healthy use. Per SASS audit
+`sass_audit_120a_no_tcgen05_2026_05_04` there are 1 898× HMMA SASS ops
+in the compiled binary. This is the peak FP16 compute path on SM120.
+
+### 3.3 `mma.sync.aligned.*.mxf4nvf4.*` (block-scaled FP4)
+
+**Used in 3 production kernels:**
+- `src/compute/attention_fmha_mxfp4_sm120.cu:591` —
+  `mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3`
+  for Q.K block-scaled FP4 (PR #56). Default-on via
+  `attention.fmha_blockscale = "auto"`.
+- `src/compute/gemm_grouped_nvfp4_smallM.cu:87` — same MMA in the
+  hand-rolled smallM kernel. Opt-in (`IMP_NVFP4_SMALLM=1`).
+- CUTLASS-internal: the
+  `MainloopSm120ArrayTmaWarpSpecializedBlockScaled` schedule uses
+  the same MMA, observed at SASS via `OMMA.SF.16864.F32.E2M1.E2M1.UE4M3.4X`
+  (per `nvfp4_moe_prefill_landscape_2026_05_10` correction).
+
+Bench-only paths: `mxf4nvf4_mma_bench.cu`, `mxf4nvf4_mma_variants_bench.cu`,
+`mxf4nvf4_qkt_validate.cu`, `attention_mxf4nvf4_probe.cu` — research /
+characterization only.
+
+**Missing-but-applicable:**
+- **MXFP4/NVFP4 P×V in FMHA** (Phase-3 from `roadmap.md:104`). Claimed
+  +13% but quality-risky (softmax-output FP4-quant). 200-300 LoC, not
+  shipped. **Should ship a quality-gated A/B harness, then ship.**
+- **Block-scaled NVFP4 for dense GEMM prefill on FP16 weights** —
+  i.e. on-the-fly FP16→NVFP4 of activations + NVFP4×NVFP4 grouped MMA
+  for the non-MoE dense path. Currently dense FP16 goes through cuBLAS
+  TF32-TC. **Speculative** but worth one ncu trace.
+
+### 3.4 `mma.sync.aligned.*.e4m3.*` (FP8 m16n8k32)
+
+**Used in FMHA FP8 prefill kernel.**
+- `src/compute/attention_fmha_sm120.cu:758` —
+  `mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32`
+  via inline PTX guarded by `__CUDA_ARCH__ >= 1200`.
+- Used in Q.K phase (PV stays FP16 WMMA per line 563).
+
+FP8 GEMM lifting via `cuBLASLt` happens through
+`gemm.cu`/`weight_dispatch.cu` (cuBLASLt manages MMA selection
+internally on FP8 ops).
+
+**Missing-but-applicable:**
+- FP8 GEMM for dense MoE expert weights at prefill (currently goes
+  through CUTLASS NVFP4 on prequant or cuBLAS FP16 on others). Memos
+  show FP8-cache prefill landed (`docs/performance.md:11`) — so this
+  is exercised on the cache path.
+
+### 3.5 PDL (Programmatic Dependent Launch)
+
+**Used via wrapper.** `src/runtime/pdl.h:34-59` defines `pdl::launch`
+that wraps `cudaLaunchKernelEx` with
+`cudaLaunchAttributeProgrammaticStreamSerialization`. Edge conversion
+in graph capture: `src/runtime/cuda_graph.cu:41-152` (`apply_pdl_edges`)
+replaces default kernel-to-kernel edges with PDL edges using
+`cudaGraphKernelNodePortProgrammatic`.
+
+**Caveat at `src/compute/gemm_dp4a.cu:733`:** comment "cudaLaunchKernelEx
+overhead outweighs PDL tail/head overlap benefit" — for that path PDL
+is disabled. Reasonable measurement.
+
+Graph-capture-edge replacement converts PDL only for kernels that
+opted into PDL via the registry (`pdl::is_enabled(kparams.func)`,
+`cuda_graph.cu:119`). Non-PDL kernels keep default edges. Good
+defensive code.
+
+**Verdict:** PDL is wired correctly and used inside captured graphs.
+Coverage is opt-in per kernel — Phase 4 of the codereaper review
+should audit the per-kernel coverage.
+
+### 3.6 L2 persistence / streaming policy
+
+- `set_l2_persist_kv` at `src/graph/executor_attention.cu:97-131`:
+  per-layer in attention, persists KV with hitRatio scaled to L2
+  carveout, clamped to `cudaDevAttrMaxAccessPolicyWindowSize` (128
+  MiB on RTX 5090 per CLAUDE.md footgun). Window also clamped to
+  `kv_bytes`. **Correct**, and the comment at line 100-103 captures
+  the historical poisoning bug.
+- `set_l2_streaming` at `src/graph/executor_helpers.h:67-89`: same
+  clamping discipline, hitRatio=0 (anti-persist).
+- Called at `src/graph/executor_ffn.cu:69` for FFN weight reads
+  (streaming hint).
+- `clear_l2_policy` (`executor_helpers.h:91-97`) zeros the window
+  size, runs at `executor_attention.cu:1118`.
+
+**Missing:** the LM-head weight tensor is not L2-managed. For models
+with vocab≤32K and d_model≤4K it's ~256 MiB — too large for L2
+persist, but FP8 cache hit could keep the active layer-out residual
+in L2.
+
+**Speculative gain at decode:** L2-persist on the residual stream
+between layers (~32 KiB at d_model=8192) would be free; not
+implemented. Marginal — n=1 decode resid fits in L1 anyway.
+
+### 3.7 Cluster launch (multi-CTA cooperative groups)
+
+**Used in production.**
+- `src/compute/attention_paged.cu:1469-1473` —
+  `cudaLaunchAttributeClusterDimension` + `cudaLaunchAttributeClusterSchedulingPolicyPreference
+  = cudaClusterSchedulingPolicySpread` for the GQA cluster kernel.
+- Cluster up to 8 blocks (per the GQA ratio constraint `n_q_per_kv ∈
+  {2,4,8}` at `:1447`).
+- DSMEM via `cluster.map_shared_rank` at `:1179`.
+
+**Missing-but-applicable:**
+- Cluster launch in MoE NVFP4 grouped GEMM mainloop: CUTLASS uses
+  `Shape<_1,_1,_1>` cluster (`gemm_cutlass_grouped_3x.cu:57`). A
+  `<_2,_2,_1>` cluster would let 4 CTAs share KV across the expert
+  dimension. **Speculative** — would require CUTLASS template
+  change. Memo `nvfp4_moe_prefill_landscape_2026_05_10` doesn't
+  flag this as tested.
+- Cluster launch for FMHA prefill on long context (each Q-tile
+  share K across cluster blocks). Could halve KV reads at large
+  seq_kv. Not implemented.
+
+### 3.8 WGMMA (sm_90 only)
+
+**Dead code at the documentation level.**
+
+`src/compute/attention_fmha_sm120.cu:1-31` and
+`src/compute/attention_fmha_sm120.h:6-10` claim "WGMMA (Warp Group MMA)
+… `wgmma.mma_async` PTX instructions for ~2x tensor core throughput vs
+WMMA." The implementation uses `nvcuda::wmma` (m16n16k16 WMMA fragments)
+plus FP8 inline `mma.sync.kind::f8f6f4` — **no wgmma anywhere**. wgmma
+is Hopper-only and ptxas rejects it on sm_120a per `dead_ends.md:17`.
+
+**Action:** the comment block is stale and misleading. Flag for the
+codereaper phase. Code itself is fine.
+
+### 3.9 WMMA fragments (`nvcuda::wmma`)
+
+**Used in 10 TUs** (per Phase 1 §7.5). Three categories:
+1. Active hot path: `attention_fmha_sm120.cu`,
+   `attention_fmha_mxfp4_sm120.cu`, `attention_paged_nvfp4_tc.cu` (3 322
+   LOC). **Keep** — WMMA → HMMA SASS is the peak FP16 path on SM120.
+2. Active fallback: `attention_blackwell.cu` (460 LOC, primary FP16
+   prefill per Phase 1 §7.4).
+3. Dead or opt-in: `attention_tc.cu` (411), `mmq_q4k_v2.cu` (1 667 —
+   opt-in), `gemm_moe_fused_tc.cu` (~520), `gemm_capture_fp16_sm120.cu`
+   (~600).
+
+The codereaper phase can decide what to remove. **From a perf
+standpoint:** the WMMA-vs-direct-mma.sync question is moot on SM120
+since both lower to HMMA SASS.
+
+### 3.10 Async copy elision
+
+`cp.async.commit_group` / `cp.async.wait_group` usage in
+`attention_paged_common.cuh:17-34` — both helpers. Used in NVFP4 paged
+attention split-K path (`paged_attention_splitk_pipeline_kernel` at
+`attention_paged.cu:817`).
+
+**Refuted lever:** the NVFP4 pipelined splitk decode kernel was
+**removed** because of -3% regression (per `dead_ends.md:40`). INT4 KV
+keeps a pipelined variant; NVFP4 dropped it.
+
+**Verdict:** appropriate use. Don't chase more cp.async pipelining.
+
+### 3.11 Distributed shared memory (DSMEM)
+
+Used in `paged_attention_cluster_kernel` only (per §3.7). Could be
+extended to FMHA prefill clusters — see §3.7 missing item.
+
+### 3.12 Summary feature table
+
+| Feature | Used? | Where (representative) | Gap |
+|---|---|---|---|
+| `cp.async.bulk.tensor` (TMA) | partial | `gemm_grouped_nvfp4_smallM.cu` (opt-in only); CUTLASS-internal in grouped GEMM | Bench refutes more TMA on SM120 — not a lever |
+| `mma.sync.aligned.m16n8k16` (HMMA) | yes | `mmq_q4k_v2.cu`, all WMMA TUs | None |
+| `mma.sync.aligned.*.mxf4nvf4.*` | yes | `attention_fmha_mxfp4_sm120.cu`, `gemm_grouped_nvfp4_smallM.cu` (opt-in), CUTLASS-internal | **PV-FP4 in FMHA (Phase 3) missing; +13% claimed, gated on quality A/B** |
+| `mma.sync.aligned.*.e4m3.*` (FP8) | yes | `attention_fmha_sm120.cu:758` Q.K only | FP8 PV still WMMA FP16 |
+| PDL | yes | `runtime/pdl.h`, edge-conversion in `cuda_graph.cu` | Per-kernel opt-in coverage to audit |
+| L2 persist/streaming | yes | `executor_attention.cu`, `executor_ffn.cu` | Window=128 MiB clamp correct; not used on LM-head |
+| Cluster launch | yes | `attention_paged.cu:1469` (paged attention only) | **NOT extended to FMHA prefill or grouped GEMM** |
+| WGMMA | NO (hardware absent) | n/a | Stale comments at `attention_fmha_sm120.h:10` |
+| WMMA fragments | yes (10 TUs) | mixed | Phase 3 codereaper for dead-code |
+| cp.async commit/wait | yes | `attention_paged_common.cuh` | Pipelined-splitk refuted; no more |
+| DSMEM (cluster map_shared_rank) | yes | `paged_attention_cluster_kernel:1179` | Not in FMHA/grouped GEMM |
+
+---
+
+## 4. CUDA Graphs landscape
+
+### 4.1 Capture machinery
+
+`src/runtime/cuda_graph.cu` (989 LOC) contains:
+- `CudaGraphCapture` — single-graph capture, instantiate, replay,
+  `cudaGraphExecUpdate` support (`:228-240`).
+- `apply_pdl_edges` (`:41-152`) — post-capture pass that rewrites
+  kernel-to-kernel default edges into PDL edges (with rollback on
+  failure).
+- `ConditionalRunner` (`:739-784`) — conditional-graph body capture
+  via `cudaStreamBeginCaptureToGraph`.
+- Capture mode selector: `IMP_GRAPH_CAPTURE_MODE = global | relaxed
+  | thread_local` (`:14-36`). Default `global`; `relaxed` exists to
+  work around CUTLASS hangs (memo `prefill_graph_blockers_2026_05_14`).
+
+### 4.2 Capture boundaries
+
+Searching `engine.cpp` for `use_cuda_graphs`:
+- Decode fast-path: captured per (decode-step, n_sequences) cell;
+  pool size `kMaxGraphPoolSize` referenced at
+  `engine.cpp:2637`. Default ON.
+- Prefill: opt-in via `IMP_PREFILL_GRAPH` (Phase 1 Appendix B). The
+  `can_capture` predicate at `engine.cpp:2209` gates it.
+- Multi-graph pool indexed by `graph_idx`; `cudaGraphExecUpdate` used
+  for shape changes when topology is unchanged (`cuda_graph.cu:228-240`).
+
+### 4.3 Re-capture conditions
+
+`engine.cpp:2643` comment: "grid dims / params differ —
+`cudaGraphExecUpdate` handles this." Topology-changing changes (e.g.
+new MoE prefill expert distribution) trigger full reinstantiate.
+
+### 4.4 Disabled-graph conditions
+
+Mapped from `engine.cpp` greps:
+- L624: `config_.use_cuda_graphs = 0;` (early init force-off path)
+- L890: disabled when profiling
+- L1021-1025: experts_on_host_=true triggers disable
+- L1158-1164: same, MoE path
+- L1166-1168: `runtime.cuda_graphs = "never"`
+- L1545-1546: disabled when residual BitDecoding active (host-state
+  ring) — but post-`18abb9e` (commit referenced in
+  `bitdecoding_phase3_continuation_2026_05_09`) the device-side ring
+  re-enables capture.
+
+### 4.5 Known gaps (from MEMORY + code review)
+
+| Gap | Status | Where |
+|---|---|---|
+| Non-Gemma-4 MoE D2H routing memcpy blocks capture | **STALE** per `cuda_graphs_moe_works_2026_05_07`: the decode fast-path at `executor_forward_moe.cu:2316` skips routing D2H; captures cleanly | resolved |
+| MoE PREFILL graphs blocked by cuBLASLt hangs | Phase 3 PR #164 shipped (+11–39%); Phase 4 partial per MEMORY | `nvfp4_moe_prefill_landscape_2026_05_10` |
+| MoE prefill D2H sync still present in some branches | Yes — `executor_forward_moe.cu:671-682, 1131-1135, 1192, 1996-2000` all do `cudaMemcpyAsync(... DtoH)` + `cudaStreamSynchronize`. Each one breaks capture | code-evidence |
+| Host-offloaded experts disable graphs | `engine.cpp:1158-1164`, mitigation: `IMP_EXPERT_OVERHEAD_PCT=10` | known |
+| `try_run_moe_gemma4_ggml_prefill` per-token D2H sync | `executor_forward_moe.cu:2121-2123`: per-token `cudaMemcpyAsync(h_experts) + cudaStreamSynchronize` | **NEW finding**: kills prefill capture entirely for this Gemma-4 fallback path |
+
+### 4.6 Pool sizing + invalidation
+
+`kMaxGraphPoolSize` not directly visible at the grep point but exists
+(used at `engine.cpp:2637`). For chunked prefill the chunk size
+changes shape per chunk; `cudaGraphExecUpdate` is attempted before
+full reinstantiation (`cuda_graph.cu:228-240`) — this is the right
+pattern.
+
+### 4.7 Verdict
+
+Decode-graph machinery is mature, captures cleanly across
+prequant-NVFP4 MoE (per `cuda_graphs_moe_works_2026_05_07` 2.9–3.3×
+delta). **Prefill graph capture is still blocked on MoE NVFP4** by
+several persistent D2H syncs in `executor_forward_moe.cu`. Section 7
+ranks the surviving D2H sites by impact.
+
+---
+
+## 5. Memory subsystem audit
+
+### 5.1 Paged KV cache layout
+
+- Block size = 16 (per CLAUDE.md, MEMORY); coalesced reads across
+  `block_size * head_dim` slots.
+- Per-block stride: `block_size * n_kv_heads * head_dim` halves
+  (`attention_paged.cu:133`).
+- Slot stride within a block: `n_kv_heads * head_dim`.
+- Kernel access pattern: per warp, per-block, lane covers
+  `head_dim/32` consecutive elements via `ldcs_half` (line 174) — full
+  coalesced FP16 transactions.
+- Double-buffered next-block prefetch (`:189-200`) with single
+  `__syncthreads` barrier per block.
+
+**SM120 optimality:** the FP16 KV layout matches HBM transaction
+granularity (128 B per warp = 32 lanes × 4 halves). Double-buffering
+hides global load latency.
+
+**Per-page coalescing across pages:** page tables (`block_tables[]`)
+deliver a possibly-non-contiguous sequence of physical blocks. Each
+block is contiguous internally; the `ldcs_half(&K_block[...])` loads
+are coalesced within a block. There's no cross-page coalescing issue
+because block_size=16 already exceeds one warp's natural unit.
+
+**Verdict: layout is sm_120a-optimal for FP16 KV.** No leak here.
+
+### 5.2 L2 persistence
+
+- KV persist: `set_l2_persist_kv` (§3.6). Window correctly clamped.
+- Comment at line 119-122: "hitRatio: compare against total KV size
+  so the hardware probabilistically persists a representative subset
+  even when kv_bytes exceeds the window." — sensible.
+- `persistingL2CacheMaxSize` queried once and cached (line 104-109).
+
+### 5.3 L2 streaming
+
+- `set_l2_streaming` called at `executor_ffn.cu:69` for FFN weight
+  region. Window clamped to 128 MiB. Correct.
+- Not called for LM head weights (could be — at ~256 MiB it
+  wouldn't fit but a streaming hint costs nothing).
+
+### 5.4 HBM bandwidth utilization at 40K ctx
+
+Memory-bound estimate for Qwen3-8B at 40K ctx, GQA ratio = 8,
+head_dim = 128, NVFP4 KV (Lever 2):
+- KV bytes/token/layer = (128 / 2 bytes packed FP4) × 8 KV heads × 2
+  (K+V) + (128/16 scale bytes) × 8 × 2 = 1 152 bytes
+- Per-step per-layer KV read = 40 000 × 1 152 = 46 MB
+- 32 layers: ~1.47 GB per decode step → ~1 ms at 1500 GB/s
+- Achieved: 156 tok/s at 20K (table at `docs/performance.md:125`)
+  ⇒ 6.4 ms / token. Most of that is **NOT** KV; it's weight loads
+  (8B params × 1 byte FP8 KV / non-MoE = ~8 GB total weight stream
+  per token = ~5.3 ms). KV alone is ≤20% of decode time at 20K.
+
+**No leak.** Bandwidth utilization on the KV stream is at ≥90%
+ceiling on the paged-decode kernel.
+
+### 5.5 VRAM efficiency
+
+Per `memory/MEMORY.md` and `docs/performance.md`:
+- Weights = the largest line item (NVFP4 ≈ 0.5 byte/param).
+- KV at FP16 = 100% baseline; FP8 = 50%; INT4 = 25%; NVFP4 = ~25%
+  effective.
+- Expert offload (`experts_on_host_=true` at `engine.cpp:1158`) gives
+  another 2–4× weight reduction at the cost of disabling CUDA
+  graphs (per §4.5).
+
+The VRAM budgeter is in `src/runtime/vram_budgeter` / `storage_planner`
+(per Phase 1). Not audited in detail; no obvious perf leak from VRAM
+fragmentation visible from the executor side.
+
+### 5.6 Allocator behavior
+
+Phase 1 audit + grep here: no `cudaMalloc`/`cudaFree` in true per-token
+decode loops. The handful of `cudaMalloc`/`cudaFree` sites in
+`src/compute/` and `src/quant/` are all:
+- One-shot init (workspace, `s_workspace` in `gemm.cu:108`).
+- Grow-only static caches (`ensure_workspace`,
+  `gemm_cutlass_grouped_3x.cu:120`).
+- Bench-only paths (`mxf4nvf4_mma_bench.cu`,
+  `tma_block_scale_bench.cu`, `fmha_v_load_bench.cu` — all gated
+  off `IMP_BUILD_BENCH=OFF` in Docker).
+- `gemm_grouped_nvfp4_smallM.cu:575-580` — uses `cudaMallocAsync` (so
+  it's stream-ordered, not synchronous), allocates inside the
+  software-ref path which is `#ifdef SMALLM_SOFTWARE_REF` (not the
+  production hardware path). Acceptable.
+- `quantize_fp16_nvfp4_moe_native.cu:245-247` — `cudaMallocAsync` for
+  three small device arrays inside a prefill-MoE path. **In a stream-
+  capturable graph, `cudaMallocAsync` is legal but ties the graph to
+  a memory pool**. Worth a Phase 3 codereaper note; not a perf leak.
+
+**Verdict: hot-loop allocator hygiene is respected.** CLAUDE.md hard
+rule passes.
+
+---
+
+## 6. DEEP DIVE — Qwen3-Coder NVFP4 prefill 20× gap
+
+This section walks the prefill path end-to-end from
+`imp_prefill_with_params` to the CUTLASS NVFP4 grouped GEMM, then
+hypothesizes root-cause buckets with relative blame. Re-evaluated from
+code; compared against memo
+`nvfp4_moe_prefill_landscape_2026_05_10`.
+
+### 6.1 End-to-end call chain for Qwen3-Coder-30B-A3B NVFP4 prefill
+
+1. `imp_prefill_with_params` (`src/api/imp_api.cpp:~700` — public C
+   API).
+2. `Engine::step → step_schedule → step_prefill` (in
+   `src/runtime/engine.cpp`, ~line 1735 driver; prefill arm at
+   `engine.cpp:~2100`).
+3. Chunk loop: per chunk of `prefill_chunk_size` tokens (default 512
+   for hybrid models; default 0 for dense from
+   `Engine::resolve_prefill_chunk_size_()`).
+4. Per chunk: build `GPUBatch` (token IDs + positions + block tables
+   uploaded H2D at `engine.cpp:2122-2149`).
+5. `GraphExecutor::forward_logits` (`src/graph/executor_forward.cu:174`).
+6. Per layer:
+   a. `run_attention` (`executor_attention.cu:140`)
+      → QKV projections (`gemm_dispatch` → CUTLASS NVFP4 GEMM at
+      `executor_kernels.cu:2099-2103` for NVFP4 weights)
+      → RoPE
+      → KV write
+      → Attention (cuBLAS prefill path on Qwen3-Coder via
+      `attention_cublas_prefill` at `attention_cublas.cu:398`)
+      → O projection (NVFP4 GEMM via `gemm_dispatch`).
+   b. `run_moe_ffn` (`executor_forward_moe.cu:146`). **This is the hot
+      path.**
+
+### 6.2 The MoE prefill path step-by-step
+
+For prequant-NVFP4 MoE at `n > 1`:
+
+| Step | File:line | What happens |
+|---|---|---|
+| Residual save | `executor_forward_moe.cu:212` | `cudaMemcpyAsync` device-to-device of FP16 hidden state (h.nbytes) — graph-safe |
+| RMSNorm | `executor_forward_moe.cu:251` (or `rmsnorm_fp32_to_fp16` at `:243` for Gemma-4) | bandwidth-trivial |
+| Gate logits | `executor_forward_moe.cu:284` (`gemv_gate_fp32_fp32input`) | small GEMV (d_model × n_experts) |
+| Top-k routing | `executor_forward_moe.cu:2207-2210` (`moe_topk_gating`) | softmax + top-k; sets up `expert_offsets`, `expert_indices`, `expert_weights` (all device-resident) |
+| Permute / scatter | `moe_routing.cu:533` (`moe_fused_permute_kernel`, single-block) | builds `expert_offsets[n_experts+1]` device-side. **Single-block scan limits to n_experts ≤ 1024.** |
+| Gather activations into per-expert layout | NVFP4 device-args path: `executor_forward_moe.cu:546-563` (`quantize_fp16_to_nvfp4_cutlass_moe`) — quantizes FP16 gathered to NVFP4 SfAtom layout | bandwidth-bound |
+| Build per-expert M counts | `compute_M_per_from_offsets_device` (`executor_forward_moe.cu:535-537, 678-680`) | device kernel |
+| **Build per-expert SFA offsets** | `compute_sfa_offsets_device` (`executor_forward_moe.cu:547-548`) | device kernel |
+| **Build per-expert SFA base pointers** | `build_sfa_bases_device` (`executor_forward_moe.cu:549-551`) | device kernel — fills `cutlass3x_sfa_ptrs` |
+| **Build per-expert weight pointer arrays** | `executor_forward_moe.cu:587-613` — on cache-miss falls back to host loop + `cudaMemcpyAsync` H2D × 3 | per-expert pointer arithmetic on host then bulk H2D |
+| **Dispatch CUTLASS 3.x grouped GEMM** | `gemm_grouped_cutlass_3x_nvfp4` (`gemm_cutlass_grouped_3x.cu:150`) → CUTLASS template at `:72-75` (`MainloopSm120ArrayTmaWarpSpecializedBlockScaled`, tile `<128,128,128>`, cluster `<1,1,1>`) | **THE KERNEL.** Same as vLLM. |
+| Activation (SwiGLU / GeGLU / ReLU²) | `apply_expert_activation` (`executor_forward_moe.cu:117-133`) | bandwidth-trivial |
+| Down projection | same dispatch_device path, K_in=eff, N_out=d | second grouped GEMM call |
+| Combine | `moe_weighted_sum_residual` (`executor_forward_moe.cu:2362`) | fused weighted sum + residual add |
+
+### 6.3 Routing D2H/H2D sync
+
+**Device-args path (default, `IMP_NVFP4_DEVICE_ARGS=1`):**
+- `executor_forward_moe.cu:508-665`. **NO D2H sync.** All pointer
+  arrays built device-side. Per-call H2D only on pre-cache miss (line
+  601-613): three `cudaMemcpyAsync` of `ne * sizeof(void*)` each
+  (small, on-stream). On hit, even those are zero (the per-layer
+  `da_cache` pre-built at model load).
+- Per-layer pre-cache at `executor_forward_moe.cu:566-578`. When
+  populated (per memo `nvfp4_moe_prefill_landscape_2026_05_10`,
+  shipped commit `41fb8fc`), dispatch is purely device-side.
+
+**Legacy host-args path (set `IMP_NVFP4_DEVICE_ARGS=0`):**
+- `executor_forward_moe.cu:668-682`: D2H of `expert_offsets[ne+1]` →
+  `cudaStreamSynchronize` → host scan for `M_per[ne]`. **Blocks graph
+  capture.**
+
+**Verdict:** the default path is already graph-capturable for the MoE
+prefill. The remaining D2H sync sites are in:
+- `executor_forward_moe.cu:1131-1135` (smallM/legacy non-prequant Q*_K path)
+- `executor_forward_moe.cu:1189-1192` (another legacy branch)
+- `executor_forward_moe.cu:1996-2000` (yet another)
+- `executor_forward_moe.cu:2121-2123` (`try_run_moe_gemma4_ggml_prefill`
+  per-token sync — Gemma-4 fallback only)
+- `executor_forward_moe.cu:1288-1292` (FP8 scales fetch)
+
+For Qwen3-Coder NVFP4 specifically the device-args path is taken, so
+**routing D2H is not the bottleneck**.
+
+### 6.4 Which CUTLASS template is instantiated?
+
+`src/compute/gemm_cutlass_grouped_3x.cu:30-86`:
+- ArchTag = `cutlass::arch::Sm120`
+- OperatorClass = `OpClassBlockScaledTensorOp`
+- TileShape = `Shape<_128, _128, _128>`
+- ClusterShape = `Shape<_1, _1, _1>` ← only 1 CTA per cluster
+- Element A/B = `cutlass::nv_float4_t<float_e2m1_t>`
+- Element D = `cutlass::half_t`
+- KernelSchedule = `KernelScheduleAuto` → resolves to
+  `KernelPtrArrayTmaWarpSpecializedCooperativeBlockScaledSm120<3>` (3-stage)
+  per memo.
+- EpilogueSchedule = `EpilogueScheduleAuto`
+- Adapter is `static`, lifetime-cached: `s_gemm` at `:113`,
+  `s_gemm_initialized` flag, `can_implement` memoized per (N,K) at
+  `:298-307`. Workspace + staging persistent (`s_staging`, `s_workspace`,
+  `ensure_*` at `:120-136`).
+
+This **matches vLLM exactly** per memo `nvfp4_moe_prefill_landscape_2026_05_10`
+section "What vLLM actually uses".
+
+### 6.5 Is `m_offsets` rebuilt per layer or amortized?
+
+Per layer. `compute_M_per_from_offsets_device` runs every prefill MoE
+call (`executor_forward_moe.cu:535, 678`). It's a small device kernel
+(reads ne+1 ints, writes ne ints) — ~1 µs.
+
+The expensive per-call work is the **per-expert SFA layout build**:
+`compute_sfa_offsets_device` + `build_sfa_bases_device` + the SFA
+zero-memset (`cudaMemsetAsync` of `moe_.cutlass3x_sf_size` ≈ 2 MB at
+`:557-558`, ~3 µs). All of this is in the device path now.
+
+Per-expert weight pointer arrays are amortized into `da_cache` per
+layer at model load (when populated). The 3× H2D fallback at
+`:601-613` only fires when `da_cache` isn't ready — i.e. never in
+steady state on a properly-loaded NVFP4 prequant model.
+
+### 6.6 Dequant: online or offline?
+
+**Online.** The CUTLASS Sm120 NVFP4 mainloop does FP4→FP32 conversion
+during MMA via the block-scaled MMA opcode (`mxf4nvf4.block_scale.scale_vec::4X`).
+The activation quantize step at `executor_forward_moe.cu:559-563`
+(`quantize_fp16_to_nvfp4_cutlass_moe`) converts FP16 activations to NVFP4
+on the fly into the staging buffer (no offline cache for activations).
+
+For decode (n=1), per-expert kernels `gemv_nvfp4_moe_*` in
+`src/quant/nvfp4_gemm.cu:855` do the FP4 dequant via inline PTX
+`cvt.rn.f16x2.e2m1x2` (single PTX op, per `dead_ends.md:72` correction).
+
+`grep -rn "cvt.rn.satfinite.e2m1x2.f16x2\|cvt.rn.f16x2.e2m1x2" src/`
+hits both NVFP4 paged attention kernels (`attention_paged_nvfp4.cu:43`,
+`attention_paged_nvfp4_tc.cu:44`) and the activation quant path.
+**No offline-dequantize-to-FP16-then-cuBLAS** on the production
+hot path.
+
+### 6.7 Combine kernel
+
+`moe_weighted_sum_residual` at `executor_forward_moe.cu:2362` and
+`:2479`. Implementation outside this audit — likely a fused write
+into hidden_ with FP16 accumulator. Bandwidth-trivial.
+
+### 6.8 Root-cause buckets for the 14.7× gap (vLLM single-seq)
+
+I disagree with the memo's framing in one place: the memo treats this
+gap as "multi-week, no single PR" — which is correct for **closing
+it** but understates how much is identifiable. Three buckets:
+
+**Bucket A — CUTLASS scheduler maturity (host launch / dispatch
+overhead) — blame ~50%.**
+- The memo confirms vLLM uses the same template. The kernel itself
+  cannot be slower in imp.
+- Per-prefill launch overhead is ~1.1 ms after `769effe` (memo). That's
+  ~10% of typical prefill wall (≈11 ms at 16k tok/s × 512 / 16000
+  ≈ 32 ms — wait, this checks: 1258 tok/s × 1s = 1258 tok = 2.46
+  chunks × 512 = single chunk takes ~407 ms at 1258 tok/s).
+- At ~407 ms wall vs vLLM ~28 ms (18.5k tok/s × 512 = ~28 ms), the
+  total is **~14× slower**. CUTLASS host launch contributes some
+  fraction; the bigger contributor is **how often the kernel
+  re-instantiates can_implement / scheduler state across iterations**.
+- Imp memoizes `can_implement` per (N, K) (`gemm_cutlass_grouped_3x.cu:298`)
+  and uses `update()` instead of `initialize()` after the first call
+  (`:317-330`). That's the right pattern. Comparison with vLLM
+  would need its FlashInfer wrapper code.
+- **Fix sketch:** none — already optimized per memo. Bucket may be
+  smaller than 50% if the actual gap is dominated by bucket B.
+
+**Bucket B — Quantization + staging activation cost — blame ~30%.**
+- For each prefill chunk × layer × {gate, up, down} = 3 grouped GEMMs.
+  Each one quantizes the gathered FP16 activation to NVFP4 +
+  per-128-elem UE4M3 SF (`quantize_fp16_to_nvfp4_cutlass_moe` at
+  `:559-563`).
+- For n=512, top_k=8 expanded = 4096 rows × d=2048 = 8M FP16 elems
+  read, 4M FP4 + 256K SF bytes written per gate-or-up call. Two
+  calls per layer (gate+up share, down). 64 MoE layers × 2 quant calls
+  = 128 quant kernel launches per prefill chunk.
+- Each launch is ~100k threads × tens of cycles → ~50 µs minimum
+  per call → 128 × 50 µs = 6.4 ms wall **just for activation quant**.
+- vLLM likely fuses or reuses this. **Fix:** fuse the SwiGLU
+  activation with the gate+up quant for the down stage, avoiding one
+  full read/write of the activation tile. Hinted at by
+  `moe_fusion_targets.md` (memo). 2-3 days work per memo.
+
+**Bucket C — Per-layer kernel launches around the GEMM — blame ~20%.**
+- Per layer: residual save (cudaMemcpyAsync DtoD) + RMSNorm + gate GEMV
+  + topk + permute + 3× SFA-builds + 3× zero-memset + 3× quant + 3×
+  CUTLASS + activation + combine = ~15 kernel launches × 64 layers
+  = ~960 kernel launches per prefill chunk. At ~5 µs each → 4.8 ms.
+- Captured into a graph this drops to ~1 launch (cuGraphLaunch). The
+  prefill graphs phase-3 lands ~+11–39% (per `moe_prefill_graphs_plan_2026_05_10`)
+  but **phase 4 is partial** — full multi-layer capture is incomplete.
+- **Fix:** complete phase 4 prefill graph capture. ETA per memo:
+  weeks. Real upside ~+10–15% per `nvfp4_moe_prefill_landscape`.
+
+**Putting buckets together:** the headline 14.7× gap closes to maybe
+2–3× even after all three buckets are fully shipped, per the memo's
+own ceiling analysis. The remaining 2–3× is CUTLASS-internal scheduler
+maturity (waiting on NVIDIA upstream). **The actionable gap in 2026 H2
+is probably ~3×, not 14.7×.**
+
+### 6.9 What I'd ship first
+
+**Bucket B fusion (gate+up+SwiGLU+quant into a single kernel for the
+down phase).** Reasoning:
+- Smallest engineering footprint (2-3 days estimated, per memo
+  `moe_fusion_targets.md`).
+- Decode-side risk LOW: the fusion is in a prefill-only path
+  (`run_moe_ffn` non-fast-path branch). Decode fast-path
+  (`run_moe_decode_fast` at `:2316`) doesn't use these grouped GEMMs.
+- Quality risk LOW: same numerics, just fewer round-trips through
+  HBM.
+- Concrete signal: per-component nsys profile would tell exact saving
+  before commit. Speculative magnitude: ~5–10% pp512 lift.
+
+**What I would NOT ship:**
+- Hand-rolled NVFP4 grouped kernel beyond the existing smallM opt-in
+  (smallM lost 50% at production M, per `nvfp4_moe_prefill_landscape`).
+- cuDNN integration (broken on SM120 per memo).
+- Cluster-launch on CUTLASS template (multi-week CUTLASS template
+  surgery; speculative gain).
+
+### 6.10 Agreement with memo `nvfp4_moe_prefill_landscape_2026_05_10`
+
+- **Agree:** vLLM uses same template, no vendor IP, ceiling is
+  CUTLASS scheduler maturity.
+- **Agree:** hand-rolled NVFP4 grouped kernel can't beat CUTLASS in
+  1-2 weeks.
+- **Refine:** memo doesn't explicitly break out activation-quantize
+  cost as bucket B at ~30%. The per-kernel-launch arithmetic above
+  is mine; would need nsys to confirm.
+- **Disagree:** memo treats CUDA Graph capture for prefill as parked
+  ("Option B blocked by `IsMoEScheduler = false` stub"). The
+  device-args path at `executor_forward_moe.cu:508-665` is graph-
+  capturable today (no D2H) — Phase 3 PR #164 confirmed +11–39%.
+  Phase 4 *for non-NVFP4 MoE arches* is still blocked, but for
+  Qwen3-Coder specifically the path is open.
+
+---
+
+## 7. Top-10 performance leaks (ranked)
+
+Ordered by TTFT × confidence. At least 3 non-obvious.
+
+```
+1. NVFP4 MoE prefill activation-quant fusion gap  [TTFT impact: H]  [confidence: M]  [effort: days]
+   src/graph/executor_forward_moe.cu:559-563 (quantize_fp16_to_nvfp4_cutlass_moe)
+   src/graph/executor_forward_moe.cu:646-657 (apply_expert_activation + second quant)
+   Activation tiles roundtrip through HBM twice per layer (after gate+up, before down)
+   because quant lives outside the activation kernel. ~6 ms of pp512 wall on
+   Qwen3-Coder.
+   Fix: fuse SwiGLU + quantize into single kernel for the down-phase activation.
+   2-3 days per moe_fusion_targets.md memo.
+   Decode-side risk: NONE — decode fast-path uses gemv_nvfp4_moe_*, not this code.
+
+2. Qwen3-Coder NVFP4 prefill 14.7× gap (entirety)  [TTFT impact: H]  [confidence: H]  [effort: weeks]
+   src/compute/gemm_cutlass_grouped_3x.cu:150
+   src/graph/executor_forward_moe.cu:508-665
+   Section 6 above. Three buckets, no single PR closes it; bucket B (#1 above)
+   is the first shippable slice.
+   Decode-side risk: NONE for bucket B alone.
+
+3. Per-token D2H sync in Gemma-4 ggml MoE prefill  [TTFT impact: H]  [confidence: H]  [effort: 1-2 days]
+   src/graph/executor_forward_moe.cu:2121-2123 (cudaMemcpyAsync h_experts +
+   cudaStreamSynchronize per token in try_run_moe_gemma4_ggml_prefill)
+   Per-token D2H + stream sync kills prefill graph capture entirely AND linearises
+   the host CPU vs GPU. For n=512 prefill that's 512 sync points.
+   Fix: build expert per-token slices device-side, replace inner host loop with a
+   single device kernel that takes routing.expert_indices as input.
+   Decode-side risk: NONE — function only runs for n>1.
+
+4. Per-decode-step graph re-instantiation cost on shape change  [TTFT impact: M]  [confidence: M]  [effort: days]
+   src/runtime/cuda_graph.cu:228-240 + engine.cpp:2643
+   cudaGraphExecUpdate is attempted before full reinstantiation. When n_sequences
+   or ctx_len pushes into a different bucket, full reinstantiate fires. Cost
+   unmeasured in current memos but should be ~10-30 ms per swap.
+   Fix: bucket allocations more aggressively (ctx_len in pow-2 buckets), enlarge
+   the multi-graph pool above kMaxGraphPoolSize.
+   Decode-side risk: LOW — slight VRAM bump.
+
+5. NVFP4 smallM kernel kept opt-in despite -50%  [TTFT impact: L]  [confidence: H]  [effort: 0]
+   src/compute/gemm_grouped_nvfp4_smallM.cu (entire 948 LOC TU)
+   src/graph/executor_forward_moe.cu:703-704 (gated by IMP_NVFP4_SMALLM env)
+   This is technical debt in the binary. The opt-in gate is correct (CUTLASS
+   wins) but the TU is in the runtime library. **NOT a perf leak per se** but
+   the cudaMallocAsync paths inside it (e.g. line 575-580) tie the smallM
+   memory pool to the stream. If a user sets IMP_NVFP4_SMALLM=1 in prod they
+   get a 50% perf regression. Move smallM to a separate test-only TU or
+   document it as benchmark-only.
+   Decode-side risk: NONE (opt-in).
+
+6. BitDecoding TC path empty win + complexity  [TTFT impact: L]  [confidence: H]  [effort: 0 to remove or weeks to fix]
+   src/compute/attention_paged_nvfp4_tc.cu (1216 LOC)
+   src/graph/executor_attention.cu:1027-1083 (residual ring args)
+   The TC dispatch lands 0% across all measured configs (long_context_eval memo).
+   Residual ring infrastructure (Phase 3a/b/c) ships parity but no measurable
+   win for typical workloads.
+   Fix: keep opt-in. **Non-obvious leak:** the kernel signature now takes 8
+   nullable trailing args; even when all nullptr the host marshalling for
+   that opt-in is ~few µs per call * n_layers * n_decode_steps. Could be
+   gated behind a single null-check at the dispatcher (executor_attention.cu:1071)
+   instead of always passing.
+   Decode-side risk: LOW for the dispatcher refactor.
+
+7. Stale wgmma docstring in FMHA header  [TTFT impact: 0 PERF]  [confidence: H]  [effort: 5 min]
+   src/compute/attention_fmha_sm120.h:8-10
+   Claims "WGMMA (Warp Group MMA) ... wgmma.mma_async PTX instructions for ~2x
+   tensor core throughput vs WMMA". The implementation uses WMMA (HMMA SASS) +
+   FP8 inline mma.sync, not wgmma (which is sm_90 only and ptxas-rejected on
+   sm_120a per dead_ends.md:17).
+   **Non-obvious because it's documentation; flags here because it's actively
+   misleading anyone reading the FMHA code to find perf wins.**
+   Decode-side risk: NONE.
+
+8. Lazy cudaMalloc/cudaFree in mmvq scratch  [TTFT impact: M for first call]  [confidence: H]  [effort: 1 hour]
+   src/graph/executor_kernels.cu:2175-2182
+   First call at a new K hits cudaFree + cudaMalloc on the stream — illegal under
+   stream capture. Subsequent calls hit the cache. **Non-obvious: the cache is
+   keyed by size only, so if the kernel sees a smaller-then-larger sequence it
+   stays valid; if it sees only growing sizes it free/mallocs each time.**
+   Fix: pre-warm via the existing executor init flow (mirror gemm_init
+   pre-alloc pattern). One static call site.
+   Decode-side risk: NONE.
+
+9. Per-layer SFA zero-memset in MoE prefill  [TTFT impact: M]  [confidence: M]  [effort: hours]
+   src/graph/executor_forward_moe.cu:557-558
+   "Zero the whole staging buffer — graph-capturable alternative to host-
+   computed total_sfa. Cost is ~2 MB memset (~3 µs at 1.8 TB/s)."
+   3 µs × 3 quants/layer × 64 layers × 4 prefill chunks per session = ~2.3 ms
+   per session. **Non-obvious: it's a microsecond-grade cost that the
+   programmer (correctly) decided was acceptable; but it's free to fix by
+   tracking the actual active SFA bytes in a device-side counter and
+   doing a tighter memset/clear-if-needed.**
+   Decode-side risk: NONE.
+
+10. LM-head GEMV at decode lacks L2-streaming hint  [TTFT impact: L]  [confidence: M]  [effort: 1 hour]
+    src/graph/executor_forward.cu (final LM head step, not L2-managed in
+    set_l2_streaming/persist callers list)
+    LM-head weight tensor is ~256 MiB (vocab × d_model × FP16); doesn't fit
+    L2, but a streaming hint via set_l2_streaming would tell the GPU to not
+    evict KV from L2. Currently no hint = default = some L2 pollution.
+    **Non-obvious: every other big weight tensor has this hint except LM head.**
+    Speculative magnitude: ≤1% decode at long context.
+    Decode-side risk: NONE (just a hint).
+```
+
+---
+
+## 8. GB202 features NOT YET used (clean list)
+
+Order-of-magnitude expected upside in parentheses.
+
+1. **Cluster launch in FMHA prefill** (KV reuse 2–4× via DSMEM for
+   long-context). Not implemented. Cluster scheduling already wired
+   for paged attention so the infrastructure exists; FMHA tile
+   sizes would need re-layout. Expected upside: **+10–20% on
+   pp4096+ on FP16 prefill** for non-MoE models.
+
+2. **PV-FP4 in FMHA (Phase 3, MXFP4 block-scaled P×V)**. Currently
+   only Q.K uses block-scaled FP4 MMA; PV stays in WMMA FP16
+   (per `attention_fmha_sm120.cu:563`). Roadmap claims +13% upside.
+   Quality-risky — needs SageAttention3 two-level accumulator.
+   Expected upside: **+10–13% on attention-bound prefill**.
+
+3. **NVFP4 dense GEMM for non-MoE models** (currently only via
+   `gemv_nvfp4_kpar` for decode and the CUTLASS NVFP4 path is
+   activated only when `nvfp4_cache` populated by prequant
+   SafeTensors loader). The kpar decode kernel exists; the
+   prefill grouped non-MoE path is hooked but rarely fires on
+   GGUF Q*_K models. Expected upside: **+30–50% prefill** vs
+   FP16 cuBLAS for prequant-NVFP4 dense models. Conditional on
+   model format.
+
+4. **Block-scaled NVFP4 KV (full BitDecoding stack)**. Phase 3
+   shipped FP16 residual + WMMA Q.K but the TC path lands 0%
+   currently. Real BitDecoding paper requires four combined
+   levers (per memo) — only 1.5 of 4 are in. Expected upside if
+   completed: **paper claim 8.6×, realistic 1.5–2×** decode at
+   long ctx.
+
+5. **Sparse FP4 MMA (`sp::ordered_metadata`)**. PTX accepts
+   `mma.sync.aligned.kind::f8f6f4.sp::ordered_metadata.m16n8k64`
+   (per `mxf4nvf4_mma_variants_bench.cu:229`) but production
+   doesn't use it. Would double effective compute on 50%-sparse
+   weights. Gates on a sparsification recipe. Expected upside:
+   **2× theoretical** on sparse-weight inference (currently
+   no sparse weights in scope).
+
+6. **`mma.sync.aligned.kind::mxf8f6f4.scale_vec::1X` (mixed FP8 + FP4)**.
+   Variants benched at `mxf4nvf4_mma_variants_bench.cu:194` show
+   FP8 act × FP4 weight is supported on sm_120. Could be used for
+   prefill where activations are still FP8 cache. Expected upside:
+   **+20% over current FP8×FP8 path** if quality holds.
+
+7. **`cublasLtMatmulGrouped` with NVFP4** — re-tested 2026-05-08
+   (memo `cublas_13_4_sm120_no_movement_2026_05_09`): zero
+   algorithms on SM120. **DEAD-END unless NVIDIA ships SM120
+   support.** Listed here for completeness.
+
+8. **`add.f32x2` PTX** — investigated, decomposed to 2× scalar
+   FADD on sm_120 (per `dead_ends.md` and MEMORY entry). DEAD-END.
+
+9. **L2 persistence on prefix cache** — speculative. Would let the
+   first N tokens of a long prompt stay in L2 across decode steps.
+   Currently `set_l2_persist_kv` is per-call. Expected upside:
+   marginal at decode (KV is bandwidth-saturated either way).
+
+10. **Multi-CTA scheduler for MoE NVFP4 (CUTLASS `MoEProblemShape`)**.
+    Blocked upstream (memo): "sm120 scheduler carries `IsMoEScheduler =
+    false` stub". Re-trigger when CUTLASS upstream wires it. Expected
+    upside: +10–15% prefill per memo.
+
+---
+
+## 9. Speculative wins (clearly marked)
+
+**SPECULATIVE — needs ncu trace before commit.**
+
+These are sensible-on-paper ideas that need profiling before any
+engineering. Don't ship without an nsys/ncu trace showing the
+predicted hotspot.
+
+S1. **Pre-warm `cudaGraphInstantiate` for known shapes at model load.**
+   The first capture per shape incurs instantiation cost (~tens of ms
+   per memo). If the engine knows the prompt-length buckets up front
+   (e.g. 128, 256, 512 token chunks) it could pre-instantiate those
+   graphs at warmup time. Need: nsys trace of first-100-tokens latency.
+
+S2. **Persistent kernel for varlen continuous batching at the API layer.**
+   Per `sm120_real_perf_levers_2026_05_04`: "CLC-Persistent-Kernel for
+   varlen +10-20% bei concurrent batching". imp currently dispatches
+   per-request grids. A persistent kernel that absorbs varlen prompts
+   in a single grid could amortize launch overhead.
+
+S3. **L2-persist on LM-head decode weights** (see leak #10). Speculative
+   gain.
+
+S4. **Fused norm+gate-GEMV+topk in single kernel for MoE routing**. The
+   existing `gemv_gate_topk_fused_kernel` (`moe_routing.cu:196`) fuses
+   gate GEMV + softmax + top-k but not the preceding norm. Saving one
+   norm read for routing is small; only worth it if profiling shows
+   routing path is >5% of decode time.
+
+S5. **Replace `cudaMallocAsync` calls in `quantize_fp16_nvfp4_moe_native.cu:245-247`
+   with a persistent slab.** Three tiny device arrays per call. Per-call
+   cost is small but ties the graph to the memory pool.
+
+S6. **TMA-multicast cluster on FMHA for very long context (n>16k).** With
+   cluster launch (S2) + multicast TMA, K could be broadcast to all
+   cluster CTAs in a single bulk descriptor. Hardware supports it per
+   §3.7. Implementation complexity high.
+
+S7. **MoE expert weight prefetch via persistent device-side LRU.** Today
+   `experts_on_host_=true` disables graphs and synchronously pages H2D
+   per expert per token. A device-side LRU with cudaMemcpyAsync
+   prefetch overlap could keep graphs ON. Mentioned in `roadmap.md:53`
+   as future work.
+
+---
+
+## Appendix: file:line citation map
+
+Heavy citations from this audit, deduplicated:
+
+| Anchor | Purpose |
+|---|---|
+| `src/api/imp_api.cpp:661` (`imp_decode_step`) | decode entry |
+| `src/runtime/engine.cpp:1735` (`Engine::step`) | step driver |
+| `src/runtime/engine.cpp:2421` (`step_decode_forward`) | decode forward |
+| `src/runtime/engine.cpp:2122-2149` (prefill H2D upload) | per-chunk batch upload |
+| `src/runtime/engine.cpp:2209` (`can_capture`) | prefill graph gate |
+| `src/runtime/engine.cpp:2637` (`use_cuda_graphs` decode) | decode graph dispatch |
+| `src/runtime/cuda_graph.cu:14-36` (`get_capture_mode`) | global/relaxed/thread_local |
+| `src/runtime/cuda_graph.cu:41-152` (`apply_pdl_edges`) | post-capture PDL conversion |
+| `src/runtime/pdl.h:34-59` (`pdl::launch`) | PDL launch wrapper |
+| `src/graph/executor_forward.cu:174` (`forward_logits`) | forward outer |
+| `src/graph/executor_forward.cu:280-289` (token-ID D2H) | gated by `debug_forward_enabled()` |
+| `src/graph/executor_attention.cu:97-131` (`set_l2_persist_kv`) | KV L2 persist + clamping |
+| `src/graph/executor_attention.cu:984` | persist call site |
+| `src/graph/executor_attention.cu:988-1112` | KV-dtype paged attention switch |
+| `src/graph/executor_attention.cu:1027-1083` | BitDecoding TC dispatch + residual args |
+| `src/graph/executor_attention.cu:1071-1091` | NVFP4 paged decode TC vs scalar |
+| `src/graph/executor_helpers.h:67-89` (`set_l2_streaming`) | streaming policy |
+| `src/graph/executor_helpers.h:91-97` (`clear_l2_policy`) | clear |
+| `src/graph/executor_ffn.cu:69` | FFN L2-streaming call |
+| `src/graph/executor_forward_moe.cu:101-111` (`can_decode_fast`) | MoE decode fast-path gate |
+| `src/graph/executor_forward_moe.cu:146` (`run_moe_ffn`) | MoE entry |
+| `src/graph/executor_forward_moe.cu:212` | residual save DtoD |
+| `src/graph/executor_forward_moe.cu:508-665` | device-args full prefill path |
+| `src/graph/executor_forward_moe.cu:601-613` | H2D pointer-array fallback |
+| `src/graph/executor_forward_moe.cu:668-682` | legacy D2H sync path |
+| `src/graph/executor_forward_moe.cu:1131-1135, 1189-1192, 1996-2000` | further D2H sync sites |
+| `src/graph/executor_forward_moe.cu:2065-2102` (`try_run_moe_gemma4_ggml_prefill`) | lazy cudaMalloc/cudaFree + per-token sync |
+| `src/graph/executor_forward_moe.cu:2121-2123` | per-token D2H + sync barrier |
+| `src/graph/executor_forward_moe.cu:2316` (`run_moe_decode_fast`) | MoE decode fast-path |
+| `src/graph/executor_kernels.cu:2099-2103` (NVFP4 CUTLASS dispatch) | dense NVFP4 GEMM |
+| `src/graph/executor_kernels.cu:2156-2168` | Q4_K v2 HMMA dispatch gate (IMP_FORCE_Q4K_V2) |
+| `src/graph/executor_kernels.cu:2175-2182` | mmvq scratch cudaMalloc/Free |
+| `src/compute/attention_paged.cu:90` (`paged_attention_gqa_kernel`) | default decode kernel |
+| `src/compute/attention_paged.cu:1111` (`paged_attention_cluster_kernel`) | cluster decode |
+| `src/compute/attention_paged.cu:1469-1473` | cluster launch attributes |
+| `src/compute/attention_paged_common.cuh:17-34` | cp.async helpers |
+| `src/compute/attention_paged_nvfp4.cu:43` (`fp4_byte_to_half2`) | PTX cvt.rn.f16x2.e2m1x2 |
+| `src/compute/attention_paged_nvfp4.cu:53` (decode kernel) | scalar NVFP4 paged decode |
+| `src/compute/attention_paged_nvfp4_tc.cu:44, 58` | TC NVFP4 paged decode + residual |
+| `src/compute/attention_fmha_sm120.h:8-10` | **STALE** wgmma comment (no wgmma code) |
+| `src/compute/attention_fmha_sm120.cu:69, 581` | FMHA FP16 + FP8 kernels (`__launch_bounds__(256,1)`) |
+| `src/compute/attention_fmha_sm120.cu:758` | inline FP8 `mma.sync.kind::f8f6f4.m16n8k32` |
+| `src/compute/attention_fmha_mxfp4_sm120.cu:108, 591` | MXFP4 FMHA + `mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64` |
+| `src/compute/attention_cublas.cu:343-347` (`ensure_attn_ptr_arrays`) | static ptr-array grow |
+| `src/compute/attention_cublas.cu:357-369` (`build_attn_ptr_arrays_kernel`) | device-side ptr array builder |
+| `src/compute/gemm.cu:51-78` | cublas handle init + TF32 mode |
+| `src/compute/gemm.cu:100-115` | pre-allocated 64 MiB cuBLASLt workspace |
+| `src/compute/gemm_cutlass_grouped_3x.cu:30-86` (template config) | CUTLASS template definition |
+| `src/compute/gemm_cutlass_grouped_3x.cu:113, 298-307` (memoization) | adapter + can_implement memo |
+| `src/compute/gemm_cutlass_grouped_3x.cu:120-148` (`ensure_staging`, `prewarm`) | grow-only allocators |
+| `src/compute/gemm_cutlass_grouped_3x.cu:317-330` | initialize vs update fast-path |
+| `src/compute/gemm_grouped_nvfp4_smallM.cu:87` | inline `mxf4nvf4.block_scale.scale_vec::4X` (opt-in) |
+| `src/compute/gemm_grouped_nvfp4_smallM.cu:746-754` (`available`) | sm_120 detection |
+| `src/compute/gemm_grouped_nvfp4_smallM.cu:117-122, 362-363, 702-744` | TMA descriptor build + dispatch |
+| `src/compute/mmq_q4k_v2.cu:404, 607, 975, 1166, 1421, 1591` | direct `mma.sync.aligned.m16n8k16` |
+| `src/compute/moe_routing.cu:196` (`gemv_gate_topk_fused_kernel`) | fused gate + softmax + topk |
+| `src/compute/moe_routing.cu:533` (`moe_fused_permute_kernel`) | single-block scan, `__launch_bounds__(256)` |
+| `src/quant/nvfp4_gemm.cu:32-38` | `kKparThreads=128, kMRThreads=256` |
+| `src/quant/nvfp4_gemm.cu:174, 196, 855, 887` | NVFP4 GEMV kernels, `__launch_bounds__(128, 12)` |
+| `src/quant/mxfp4_gemm.cu:147, 163, 183, 206` | MXFP4 GEMV kernels |
+| `src/compute/quantize_fp16_nvfp4_moe_native.cu:245-247, 283-285` | cudaMallocAsync × 3 + cudaFreeAsync × 3 per prefill call |
+| `src/compute/sampling.cu:1-28, 49-95, 834` | sampler (block 256, cub::DeviceTopK for k>128) |
+| `CMakeLists.txt:74` | CUTLASS v4.5.0 declared |
+| `Dockerfile:27` | CUTLASS v4.4.2 actually pinned in Docker (Phase 1 §5 note) |
+
+---
+
+End of Phase 2 perfhawk audit.

--- a/review/phase3_maint.md
+++ b/review/phase3_maint.md
@@ -1,0 +1,1283 @@
+# Phase 3 — CODEREAPER Maintainability Audit
+
+Anchor commit: `f58eb9e` (matches Phase 1 / Phase 2). Target: sm_120a /
+RTX 5090 only. Citations are `file:line` against working tree;
+mechanical counts re-derived where Phase 1 already pinned them are
+marked `(P1 §N)`. Smell claims always carry a concrete example.
+
+The headline of this audit, repeated up front because every section
+restates a facet of it: `src/graph/` is a single 15.8 KLOC clay tablet
+that knows about every quantization format, every model architecture,
+every weight-cache shape and every dispatch decision in the engine.
+`executor_kernels.cu:2003` declares one function with 21 parameters
+that branches eight ways on cache pointers; `executor_attention.cu`
+contains 19 `cfg.arch == ModelArch::GEMMA4` branches inside the
+single-arch hot path; `executor_forward_moe.cu` is 2 563 LOC of
+"dispatch path 1..5" with no factoring of the five paths.
+**`graph/` is the danger zone, GEMMA4-coupling is the smell, and the
+WeightCaches god-struct is the root cause.** Sections 1, 2, 3, 11
+all point at this from different angles.
+
+---
+
+## 1. Coupling hotspot map
+
+### 1.1 Subsystem edge weights (cross-subsystem `#include` counts from P1 §1)
+
+Reproduced from Phase 1 for orientation; not recomputed:
+
+| from \ to | api | compute | core | graph | memory | model | quant | runtime | vision |
+|---|---|---|---|---|---|---|---|---|---|
+| api      |   - |   0 |   1 |   0 |   1 |   5 |   0 |   2 |   0 |
+| compute  |   0 |   - |  58 |   1 |   0 |   4 |  10 |  11 |   0 |
+| core     |   0 |   0 |   - |   0 |   0 |   0 |   0 |   0 |   0 |
+| graph    |   0 | **108** |  26 |   - |  24 |   3 |  41 |  16 |   0 |
+| memory   |   0 |   0 |  10 |   0 |   - |   1 |   0 |   1 |   0 |
+| model    |   0 |   0 |  21 |   0 |   0 |   - |   3 |   2 |   0 |
+| quant    |   0 |   2 |  15 |   0 |   0 |   0 |   - |   1 |   0 |
+| runtime  |   0 |  20 |  19 |   3 |  13 |  15 |   0 |   - |   4 |
+| vision   |   0 |   1 |   4 |   0 |   1 |   1 |   0 |   2 |   - |
+
+### 1.2 The 3 worst couplings
+
+**#1 — `graph → compute`, 108 edges (highest in the table).**
+`graph/executor_kernels.cu:1-22` lists 15 distinct `compute/*.h` headers
+(`gemm.h`, `gemm_q6k.h`, `gemm_cutlass_sm120.h`,
+`gemm_cutlass_mxfp4_sm120.h`, `hadamard.h`, `ggml_mmvq.h`,
+`mmq_q4k_v2.h`, `ptx92_utils.cuh`, `warp_reduce.cuh`, …) plus 5
+`quant/*.h`. `graph/executor_forward_moe.cu:12-29` adds 18 more.
+**This is not an abstraction — it is a literal cross-product include
+list.** Each new kernel implementation in `compute/` requires an
+include in `graph/`, a dispatch arm in `gemm_dispatch_impl`
+(`executor_kernels.cu:2003`) and a cache-map field in `WeightCaches`
+(`executor.h:286`). The leak goes both directions: `compute/` cannot
+be replaced with a different implementation without touching `graph/`
+in N places.
+
+**#2 — `graph → quant`, 41 edges.** `graph/executor_kernels.cu:11-15`
+and `graph/executor_pre_dequant.cu:7-9` each import 4-5 quant headers,
+then re-implement the per-qtype routing in `gemm_dispatch_impl`. The
+two layers do the same job:
+- `quant/weight_dispatch.cu:73-125` already has a per-qtype dispatch
+  that decides between cuBLASLt, dequant-then-FP16, and CUTLASS.
+- `graph/executor_kernels.cu:2018-2268` does **the same decision tree
+  over again** with a different parameter set.
+Two dispatch tables for the same problem. Every new qtype lands in
+both.
+
+**#3 — `compute → core` (58 edges) is benign.** `core/` is a strict
+leaf (P1 §1 confirms zero outgoing cross-subsystem edges). The 58
+edges are `Tensor`, `QType`, `logging` — exactly what a leaf utility
+layer is for. **Not a smell; called out so it isn't confused with the
+two above.**
+
+### 1.3 Back-edges
+
+- **`compute → graph` (1 edge).** Phase 1 §1 flagged this as a
+  follow-up. Grep:
+  `grep -rn '#include "graph/' src/compute/` → one hit at
+  `src/compute/preamble_gate.h:5` (`#include "graph/quant_scratch.h"`).
+  `preamble_gate.h` defines a 1-line guard used by a compute kernel
+  to read a graph-owned struct. **Tiny but architecturally
+  wrong**: `compute/` should not name `graph/` symbols. The struct
+  (`QuantScratch`) belongs in `core/` or in a new `runtime/scratch.h`.
+  3-line fix.
+- **`compute → quant`/`quant → compute` cycle (P1 §1 #1).**
+  `grep -rn '#include "compute/' src/quant/` →
+  `src/quant/dequant_gpu.cu` includes `compute/warp_reduce.cuh` and
+  `compute/ptx92_utils.cuh`. Those are header-only utilities that
+  morally belong in `core/`. Move the two `.cuh` files to `core/` and
+  the cycle dies.
+- **`compute ↔ runtime`** (20 + 11 edges).
+  `compute/*.cu` imports `runtime/config.h` for the central
+  `RuntimeConfig::current()` singleton. **This is the intentional
+  cycle** — kernels need runtime knobs. Tolerable so long as
+  `runtime/config.h` is pure data; it currently is (`config.h:1-168`).
+
+### 1.4 God headers (>30% of TUs include them)
+
+Total `.cu/.cpp` TUs in `src/`: **134**. Threshold = 41.
+
+| Header | Included by | % | Verdict |
+|---|---:|---:|---|
+| `core/logging.h` | 92 | 68% | **GOD**. Every TU pulls it. Acceptable cost (header is 75 LOC, `<atomic>` + `<cstdio>` only — `src/core/logging.h:1-30`), but means a change to `IMP_LOG_DEBUG` rebuilds two thirds of the project. |
+| `core/tensor.h` | 51 | 38% | **GOD**. Carries `QType`, `Tensor`, `Buffer`, `<cuda_runtime.h>`. Editing it rebuilds 51 TUs. Not avoidable — Tensor is the core type. |
+| `runtime/config.h` | 18 | 13% | Below threshold; centralization (§9) keeps it small. |
+
+`logging.h` and `tensor.h` are the only two god headers. Both are
+load-bearing. **No action.**
+
+### 1.5 Model/compute decoupling — can a new model be added without
+compute changes?
+
+**No.** Evidence:
+
+1. `grep -rEohn 'ModelArch::[A-Z0-9_]+' src/runtime/ src/graph/ src/compute/` →
+   **40 production-code sites** branch on `ModelArch`. Distribution:
+   - `ModelArch::GEMMA4` — **30 sites** (e.g.
+     `src/graph/executor_attention.cu:161, 310, 387, 464, 472, 493,
+     534, 596, 658, 678, 821, 893, 1198, 1274`;
+     `src/graph/executor_forward_moe.cu:187, 218, 224, 229, 262, 310,
+     324, 381, 1727, 1735, 1745, 1766, 1781, 1875, 1893, 1899, 2304,
+     2538, 2541`;
+     `src/runtime/engine.cpp:828, 1663`;
+     `src/graph/executor_workspace.cu:53`).
+   - `ModelArch::LLAMA4` — 1 site.
+   - `ModelArch::GEMMA3` — 1 site.
+2. `src/include/imp/types.h:25-38` defines 14 enum values; only
+   GEMMA4 has dedicated hot-path branches. Either it is the only
+   special-case architecture or every other arch has been wedged
+   into the generic path with silent quality regressions.
+3. `model/chat_template.cpp:72` is the **only** legitimate
+   `switch(arch)` (chat template family). All others are kernel
+   selection — i.e. compute behavior conditional on model identity.
+
+**Verdict: NO.** Adding a new arch requires touching at minimum
+`graph/executor_attention.cu`, `graph/executor_forward_moe.cu`,
+`graph/executor_workspace.cu`, and `runtime/engine.cpp`. The
+abstraction never landed; GEMMA4 was shipped by sprinkling
+`if (cfg.arch == ModelArch::GEMMA4)` along the hot path. See §11 for
+the refactor.
+
+---
+
+## 2. Danger zones (Top-10 files)
+
+Scoring axes:
+
+- **LOC** — raw line count.
+- **Template depth** — `grep -c '^template'` per file.
+- **Branch density** — total `if`/`else if`/`switch case` per 100 LOC,
+  estimated via grep.
+- **Global state** — `static` file-scope variables that are mutable
+  (caches, handles, scratch).
+- **Implicit dispatch** — function pointers, `pdl::enable`,
+  switch-on-enum, `unordered_map` keyed on `const void*` for routing.
+- **Test coverage proxy** — does any test in `tests/` exercise the
+  file's public functions? Y / N.
+
+Scores 1-5 per axis, total /30. Higher = scarier.
+
+| Rank | File | LOC | tmpl | branch | global | dispatch | tested | TOTAL | Verdict |
+|---:|---|---:|---:|---:|---:|---:|---:|---:|---|
+| 1 | `src/graph/executor_kernels.cu` | 2 327 | 1 | 5 | 5 | 5 | partial | **25** | `gemm_dispatch_impl` (21 params, 8 cache-map branches). Touch this file → break every model. |
+| 2 | `src/graph/executor_forward_moe.cu` | 2 563 | 0 | 5 | 4 | 5 | partial | **24** | 5 dispatch paths, 19 GEMMA4 branches, 5 D2H sync sites (P2 §4.5). |
+| 3 | `src/runtime/engine.cpp` | 3 066 | 0 | 5 | 5 | 4 | partial | **22** | 40 member functions; `step_*` family is the request scheduler + KV cache manager + decode driver + MTP arbiter rolled into one class. |
+| 4 | `src/graph/executor_pre_dequant.cu` | 2 556 | 0 | 4 | 4 | 4 | partial | **22** | Pre-allocates and dequant-converts every weight cache shape; one of the few sites that reads `IMP_FORCE_Q4K_V2` directly. |
+| 5 | `src/graph/executor_attention.cu` | 1 299 | 0 | 5 | 3 | 5 | partial | **21** | 8-way KV-dtype switch (P2 §3.12) + 14 GEMMA4 branches + 2 `goto after_attention` (line 796, 960) + `naive_attention_prefill` fallback. |
+| 6 | `src/compute/mmq_q4k_v2.cu` | 1 667 | 7 | 3 | 2 | 1 | yes (microbench only) | **18** | 7 template instantiations of the same kernel layout; `IMP_FORCE_Q4K_V2`-gated; -4% E2E per `mmq_q4k_v2_phase2_shipped_2026_05_16` memo. |
+| 7 | `src/model/jinja.cpp` | 2 629 | 0 | 5 | 2 | 2 | yes | **18** | Hand-rolled Jinja2 evaluator. Pure host code, AST-based. Bugs here corrupt the prompt silently. |
+| 8 | `src/compute/sampling.cu` | 1 701 | 0 | 5 | 4 | 3 | yes | **17** | 5 distinct sample kernels (argmax, argmax_partial, argmax_reduce, topk_topp, topp_sorted) + DRY penalty + Mirostat. Allocates via raw `cudaMalloc/cudaFree` (line 727-781). |
+| 9 | `src/compute/gemm.cu` | 1 694 | 0 | 4 | 5 | 4 | yes | **17** | cuBLAS handle + workspace + algo cache + 7 GEMV functions + 5 fused MoE GEMV variants; `s_gemm_cache` mutex-locked. |
+| 10 | `src/model/weight_upload.cu` | 2 092 | 0 | 4 | 3 | 3 | partial | **15** | Per-qtype upload + per-arch quant conversion + GPTQ + audit env knob (`IMP_AUDIT_NVFP4_SCALES`). Long-tail special cases. |
+
+### 2.1 Per-entry remediation sketches
+
+**#1 `executor_kernels.cu` (2 327 LOC, score 25).** Hosts
+`gemm_dispatch_impl` (line 2003-2269) — a 266-line cascading if/else
+on 6 different `unordered_map<const void*, ...>*` pointers. Each cache
+arm has its own preconditions (`input.qtype`, `output.qtype`, M-shape,
+`fp32_output`, `prefer_fp16_cache`). **Suggested split:** introduce a
+per-qtype `GemmKernel` registry (qtype → `unique_ptr<GemmKernel>`),
+move the qtype-specific code from `gemm_dispatch_impl` into the
+registry entries, and reduce the file to a 200-line dispatcher.
+Estimate: 1 800 LOC stays in `compute/`, 500 LOC stays in
+`executor_kernels.cu` as the registry plumbing. See §11 refactor #1.
+
+**#2 `executor_forward_moe.cu` (2 563 LOC, score 24).** Header
+comment at line 5-10 says "Dispatch paths: 1. NVFP4 decode fast. 2.
+TC fused. 3. Scalar fused. 4. Batch path. 5. Shared expert path."
+These five paths are interleaved with 19 GEMMA4 branches. **Split
+into:** `executor_moe_decode_fast.cu` (path 1, ~600 LOC),
+`executor_moe_prefill.cu` (paths 3+4, ~900 LOC),
+`executor_moe_shared_expert.cu` (path 5, ~200 LOC),
+`executor_moe_routing.cu` (top-k + permute + offsets, ~300 LOC),
+`executor_moe_gemma4.cu` (the GEMMA4-specific overrides extracted,
+~400 LOC). Cuts the single-file cognitive load by 60%.
+
+**#3 `engine.cpp` (3 066 LOC, score 22).** 40 member functions on
+`Engine`. `step_decode_forward` alone is 392 lines (line 2421-2813).
+**Split into:** `engine_init.cpp` (~700 LOC for the `init_*` family),
+`engine_step_prefill.cpp` (~700 LOC), `engine_step_decode.cpp`
+(~700 LOC), `engine_mtp.cpp` (~300 LOC), `engine.cpp` (residual:
+ctor/dtor + small driver, ~600 LOC). Each part of the file already
+has clear "// =====" section banners (line 29-31, etc.); the split is
+mechanical.
+
+**#4 `executor_pre_dequant.cu` (2 556 LOC, score 22).** Owns the
+six-way weight-cache-population logic (FP16, FP8, NVFP4, CUTLASS NVFP4,
+MXFP4, Q4K-v2). Each cache type has 200-400 LOC of population code in
+the same file. **Split per cache type** into separate `.cu` files
+sharing a `WeightCachePopulator` interface in
+`graph/executor_helpers.h`. Knock-on: removes one of the two
+dispatch tables (§1.2 #2) by letting each populator own its
+dispatch arm.
+
+**#5 `executor_attention.cu` (1 299 LOC, score 21).** Already
+mostly factored — has `set_l2_persist_kv`, `set_l2_streaming`,
+`clear_l2_policy` extracted into helpers. The remaining smell is the
+14 GEMMA4 branches threaded through a single `run_attention` function.
+**Suggested split:** keep generic attention in this file; create
+`executor_attention_gemma4.cu` with a `run_attention_gemma4` override
+that calls into the generic path for the common steps. Removes the
+GEMMA4-coupling on this file from 14 sites to 1 dispatch.
+
+**#6 `mmq_q4k_v2.cu` (1 667 LOC, score 18).** Seven template
+instantiations (line 251, 270, 470, 818, 1016, 1294, 1462) of
+`<int kP3BN>` — phases of the same kernel. Two of the seven
+correspond to the v1 dp4a (legacy, only the M<16 path remains useful)
+and the v2 HMMA. **Recommendation:** monomorphize to the 2 actually-
+shipped configurations (kP3BN=128 and kP3BN=256), delete the other 5.
+Saves ~700 LOC. See §3.
+
+**#7 `jinja.cpp` (2 629 LOC, score 18).** Self-contained
+host code, no CUDA. Score is high because parsing bugs corrupt the
+prompt silently and only show up in degeneration tests. **Has tests**
+(`tests/test_jinja.cpp`). Acceptable as-is; the file is "big but
+boring." No split recommended — splitting a hand-rolled parser hurts.
+
+**#8 `sampling.cu` (1 701 LOC, score 17).** Five sampler kernels
+(line 49, 106, 159, 255, 673) + DRY + Mirostat + JSON-constrain
+mask integration. Uses raw `cudaMalloc/cudaFree` (line 727-781) which
+violates CLAUDE.md "no `cudaMalloc/cudaFree` in hot loops" reading
+strictly — Phase 2 §5.6 already noted the grow-only nature. **Split
+into:** `sampling_kernels.cu` (the 5 device kernels, ~700 LOC),
+`sampling_state.cu` (host-side DRY/Mirostat state, ~500 LOC),
+`sampling_dispatch.cu` (entry points and scratch-buffer lifetime,
+~500 LOC).
+
+**#9 `gemm.cu` (1 694 LOC, score 17).** Owns 5 mutable `static`
+variables that survive between calls: `s_workspace`, `s_bench_scratch`,
+`s_gemm_cache` (the cuBLASLt algo cache), `s_gemm_cache_mutex`,
+`s_workspace_size` (line 85-92, 239-240). Plus 5 fused MoE GEMV
+variants (`gemv_q6k_moe_decode`, `gemv_q8_0_moe_decode`,
+`gemv_q6k_moe_gate_up_fused`, `gemv_q8_0_moe_gate_up_fused`,
+`gemv_gate_fp32_fp32input`). The MoE-specific variants belong in
+`compute/gemm_moe_fused.cu`, not in the dense GEMM file. Move them
+(~500 LOC).
+
+**#10 `weight_upload.cu` (2 092 LOC, score 15).** One file, two
+public functions (`grep -c '^void\|^bool' src/model/weight_upload.cu` →
+1). Everything else is in anonymous namespace. The single `upload_*`
+function is essentially a giant `switch(qtype)` covering 12 quant
+types × 4 model arches. **Split** per qtype family:
+`weight_upload_dense_fp.cu` (FP16/BF16/FP32 paths),
+`weight_upload_q_k.cu` (Q4_K/Q5_K/Q6_K/Q8_0),
+`weight_upload_nvfp4.cu` (NVFP4 sidecar + prequant),
+`weight_upload_mxfp4.cu`, `weight_upload_gptq.cu`.
+
+---
+
+## 3. Template wildwuchs vs. monomorphisation
+
+Concern: header-template bloat slows compilation, hides codegen
+errors, and complicates debugging. For each candidate, look at
+template parameters → ask "is the parameterization buying real
+flexibility?"
+
+### 3.1 `src/compute/attention_fmha_sm120.cu` — KEEP
+
+Line 68 and 581 declare `template <int Bq, int HD>`. Instantiated
+configurations (file-internal):
+- `<Bq=128, HD=64>` (FP16)
+- `<Bq=128, HD=128>` (FP16)
+- `<Bq=64, HD=192>` (FP16)
+- `<Bq=32, HD=256>` (FP16)
+- `<Bq=32, HD=512>` (FP16 — GEMMA4 global layers)
+- Same set for FP8.
+
+**Verdict: keep.** HD is set by model architecture; Bq is chosen to
+fit the 99 KiB SMEM cap per HD value (P2 §2.4). The template gives
+real flexibility — both NCCL parameters affect kernel layout. The
+file is in the danger zone because of the lookup tables, not the
+templates themselves.
+
+### 3.2 `src/compute/attention_paged.cu` — KEEP
+
+Line 289, 598, 816, 1110 declare `template <int HEAD_DIM>`.
+HEAD_DIM ∈ {64, 96, 128, 192, 256, 512} per kernel. Same justification
+as 3.1. Real model-dependent flexibility.
+
+### 3.3 `src/compute/mmq_q4k_v2.cu` — **MONOMORPHIZE, delete 5 of 7**
+
+`grep -n '^template' src/compute/mmq_q4k_v2.cu`:
+- line 251: `template <int N>` (helper)
+- line 270: `template <int kP3BN>` (Phase 3 BN — early experiment)
+- line 470: `template <int kP3BN>` (Phase 4)
+- line 818: `template <int kP3BN>` (Phase 5)
+- line 1016: `template <int kP3BN>` (Phase 6a)
+- line 1294: `template <int kP3BN>` (Phase 6b)
+- line 1462: `template <int kP3BN>` (Phase 7)
+
+Per memory file `mmq_q4k_v2_phase2_shipped_2026_05_16`: "Phases 1a/1b/2/3/4/5/6a/6b/7a/7b all merged." The file
+contains every phase as a separate template instantiation, kept
+in the binary even after later phases superseded earlier ones.
+
+**Dispatch is via a single env knob** (`IMP_FORCE_Q4K_V2=1`, gated
+in `graph/executor_pre_dequant.cu:680`) which **picks one kP3BN value
+at runtime**. Five of the seven templates are dead at runtime.
+
+**Removable LOC:** ~700 (each phase template is roughly the same
+shape — see line 470-815, 818-1015, 1016-1293, 1294-1421, 1462-1591
+for span deltas). End-state: one template at kP3BN=256, one at
+kP3BN=128, glue. Plus the well-known E2E regression (-4% on
+Qwen3.6-35B Q4_K_M per the same memo) suggests the entire 1 667 LOC
+is a candidate for removal — but that's a policy call (§10 #6).
+
+### 3.4 `src/compute/gemv_dp4a_traits.cuh` — KEEP
+
+P1 Appendix A flagged this as 1 620 LOC of header-only template
+library. Spot-check: it provides `dp4a` traits for Q4_0, Q4_1, Q5_0,
+Q5_1, Q8_0, Q4_K, Q5_K, Q6_K (8 quant types × 3-4 thread/warp/CTA
+shape parameters). The instantiations actually fire across
+`src/compute/gemm_dp4a.cu`, `src/compute/ggml_mmvq.cu`, and
+`src/quant/quant_gemm.cu`. **Real flexibility** — one traits header
+that 3 TUs share. Keep.
+
+### 3.5 `src/compute/rope.cu` — KEEP
+
+Two instantiations (line 137 `<float>`, 140 `<__half>`). Both used at
+runtime. Minimum-flexibility template. Fine.
+
+### 3.6 `src/compute/gemm_grouped_nvfp4_smallM.cu` — DELETE 948 LOC
+**(per Phase 2 §7.5 leak #5)**
+
+Per memory file `nvfp4_moe_prefill_landscape_2026_05_10` and Phase 2
+§7.5, the smallM kernel is opt-in via `IMP_NVFP4_SMALLM=1` and is
+**-50–55% vs CUTLASS at production shapes**. The kernel is the
+**only production TMA in imp** (`gemm_grouped_nvfp4_smallM.cu:117-122,
+362-363, 702-744`). If the policy is to retire it from production,
+move the 948 LOC to `tests/bench/` (Phase 1 §7.8 already advocates
+relocation, not deletion).
+
+### 3.7 `src/compute/gemm_capture_fp16_sm120.cu` — RUNTIME-CHECK
+
+Phase 1 §7.5 flagged as ~600 LOC dispatched only if
+`s_avail = (prop.major*10+minor >= 120)`. On sm_120a-only this flag
+is always true. The kernel is the WMMA FP16 GEMM intended for
+captured graph paths. Whether it actually fires at decode-graph
+capture isn't clear from Phase 2; could be 600 dead LOC or a working
+opt-in. Phase 4 should check.
+
+### 3.8 Summary of monomorphisation streichliste
+
+| Source | Action | LOC removable |
+|---|---|---:|
+| `mmq_q4k_v2.cu` | Keep 2 of 7 phase templates | ~700 (subset of file) |
+| `mmq_q4k_v2.cu` if frozen-as-opt-in is the final policy | Delete entire TU | 1 667 |
+| `gemm_grouped_nvfp4_smallM.cu` | Move to tests/bench/ | 948 (relocate) |
+| `gemm_capture_fp16_sm120.cu` if Phase 4 confirms dead | Delete | ~600 |
+
+---
+
+## 4. Header hygiene
+
+### 4.1 Average include depth — spot-check of 10 hot TUs
+
+Direct `#include` lines (does not transitively expand):
+
+| TU | Direct includes | Notes |
+|---|---:|---|
+| `src/graph/executor_forward_moe.cu` | **45** | Worst offender. Each compute kernel pulled in by its own header. |
+| `src/runtime/engine.cpp` | 24 | Reasonable for a driver TU. |
+| `src/compute/gemm.cu` | 15 | Per-quant kernel + cuBLAS handles + workspace. |
+| `src/quant/nvfp4_gemm.cu` | 13 | Reasonable. |
+| `src/compute/sampling.cu` | 12 | Reasonable. |
+| `src/api/imp_api.cpp` | 12 | Reasonable for the API boundary file. |
+| `src/runtime/cuda_graph.cu` | 10 | Reasonable. |
+| `src/model/jinja.cpp` | 10 | Reasonable. |
+| `src/memory/kv_cache_manager.cpp` | 9 | Reasonable. |
+| `src/compute/attention_paged.cu` | 9 | Reasonable. |
+
+`executor_forward_moe.cu` is the outlier. 45 direct includes is an
+include-depth smell — every compute kernel surface area pulled into
+one TU. Splitting the file per §2 #2 will drop this naturally (each
+sub-file ends with ~10 includes).
+
+### 4.2 Top-5 most-included internal headers (P1 §1 ranked-by-includes)
+
+Reproduced from §1.4:
+
+| Header | Includers | Risk to rebuild on edit |
+|---|---:|---|
+| `src/core/logging.h` | 97 | Touching this triggers a near-full rebuild. Header is intentionally `<atomic> + <cstdio>` only; safe. |
+| `src/core/tensor.h` | 51 | Same. Pulls `<cuda_runtime.h>` transitively. Edits here recompile everything that touches a Tensor. |
+| `src/runtime/config.h` | 20 | After the centralization (§9), 20 TUs is roughly proportionate to "everything that reads a runtime knob." OK. |
+| `src/memory/vram_allocator.h` | 17 | Acceptable. |
+| `src/compute/gemm.h` | 17 | Acceptable. |
+
+**No leaks in the top 5.**
+
+### 4.3 CUDA headers leaking into "host-only" headers
+
+`grep -l 'cuda_runtime\|cuda.h' src/core/*.h src/api/*.h src/runtime/*.h src/model/*.h`:
+
+- `src/core/cuda_raii.h` — fine, this is the CUDA RAII wrapper.
+- `src/model/model.h:12` — `#include <cuda_runtime.h>`. **Smell**:
+  `Model` is the in-memory model representation. Should not require
+  the CUDA runtime header. The dependency is on `cudaStream_t`/
+  pointer types stored in `Model::weight_*` fields. **Fix:** forward-
+  declare the stream and use `void*` for device pointers in the
+  Model struct (it already lies about its tensor types via `Tensor`
+  abstractions; one more layer of abstraction here costs nothing).
+- `src/runtime/engine.h:18` (transitive via `core/cuda_raii.h:1`) —
+  acceptable, engine owns CUDA streams.
+- `src/runtime/batch.h:7` — `#include <cuda_runtime.h>` for
+  `cudaStream_t` parameter on `BatchBuilder::upload`. Reasonable.
+- `src/runtime/vision_pipeline.h`, `src/runtime/graph_diag.h`,
+  `src/runtime/cuda_graph.h`, `src/runtime/pdl.h`,
+  `src/runtime/mtp_forward.h`, `src/runtime/green_ctx.h` — all
+  legitimate (own CUDA state).
+
+**Action:** decouple `model/model.h` from `<cuda_runtime.h>` (1 file
+edit, knock-on rebuild reduction on `model/` TUs).
+
+### 4.4 IWYU violations (spot check)
+
+- `src/graph/executor.h:1-20` includes `model/model.h`,
+  `memory/kv_cache.h`, `memory/ssm_state.h`, `memory/layer_offload.h`,
+  `compute/moe_routing.h`, `compute/json_constrain.h`,
+  `compute/schema_constrain.h`, `quant/nvfp4_quant.h`, `quant/turboquant.h`,
+  `compute/gemm_cutlass_sm120.h`, `compute/gemm_cutlass_mxfp4_sm120.h`,
+  `core/tensor.h`, `graph/weight_handle.h`, `graph/moe_workspace.h`,
+  `graph/quant_scratch.h`, `runtime/storage_planner.h`,
+  `<cuda_runtime.h>`, `<cuda_fp16.h>`.
+  This is **18 includes in a header** — `executor.h` is itself 796 LOC
+  and 15 TUs include it. Every change to any of those 18 transitive
+  includes rebuilds 15 TUs. Most of these are for type-defining
+  fields (`InferenceState`, `WeightCaches`) — i.e. legitimate. But
+  the two CUTLASS-glue includes (`gemm_cutlass_sm120.h`,
+  `gemm_cutlass_mxfp4_sm120.h`) are only for `CutlassNvFP4Weight`,
+  `CutlassMxFP4Weight` typedefs that could be forward-declared.
+  Small win.
+- `src/graph/executor_kernels.cu:1-22` — includes 18 headers, every
+  one used. No IWYU violations spotted.
+- `src/compute/attention_paged.cu:1-10` — 9 includes, clean.
+
+**Verdict:** the worst IWYU smell is the 18-include public header
+`executor.h`. Trim the CUTLASS glue (forward-declare instead of
+include) for a small reduction.
+
+---
+
+## 5. Dead code / duplication
+
+### 5.1 Dead functions
+
+**`mxfp4_act_sf` argument branch (`executor_kernels.cu:2083-2094`).**
+The CUTLASS MXFP4 path requires both an NVFP4 cache hit AND an MXFP4
+cache hit on the same weight (`nvfp4_view != nullptr` outer condition
++ `mxfp4_cache->find(weight.data)` inner condition). In practice the
+loader populates exactly one of `nvfp4_cache` / `mxfp4_cache` per
+weight (per memory file `nvfp4_prequant_status` and the prequant
+loader convention). The MXFP4 branch inside an `nvfp4_view != nullptr`
+block is **dead in production**; only fires under a synthetic test
+where both caches are populated for the same tensor (none such test
+exists — `grep -rn 'CutlassMxFP4Weight' tests/` returns 0). **Removable:
+~12 LOC.**
+
+### 5.2 Duplicate implementations
+
+1. **`gemv_q6k` / `gemv_q8_0` + the `_moe_*` fused variants.**
+   `src/compute/gemm.cu:1204, 1243, 1320, 1367, 1546, 1603` define
+   five fused MoE GEMV kernels alongside the two solo GEMVs. A
+   separate `gemm_q6k.cu` (310 LOC, P1 §4) also exists for Q6_K. Two
+   files implementing Q6_K GEMV with overlap. The `gemm.cu` versions
+   are the per-expert MoE fused variants; `gemm_q6k.cu` is the
+   prefill grouped variant. **Not strict duplication, but adjacent
+   functionality across two files** — refactor target.
+
+2. **Two RMSNorm dtype paths** (`compute/layernorm.cu:40, 72, 142,
+   174, 301, 345`) each followed by a host dispatcher (line 271, 330,
+   371, 384). Six kernels for {fp32, fp16} × {basic, +residual, +dtype-
+   convert}. **Not duplication — necessary dtype coverage.** Keep.
+
+3. **5 sample kernels in `compute/sampling.cu`** (line 49, 106, 159,
+   255, 673). Used; not duplicates.
+
+4. **Multi-block dispatch tables — §1.2 #2.** `gemm_dispatch_impl` in
+   `executor_kernels.cu:2003` AND `dispatch_quant_*` in
+   `compute/weight_dispatch.cu:73-125` do overlapping per-qtype
+   dispatch. The first dispatches on (input.qtype, weight.qtype,
+   cache pointer); the second on (qtype only). **Genuine duplication
+   of dispatch policy.** Removable: estimate 150 LOC after merging.
+
+### 5.3 Commented-out code
+
+Sampling grep: `grep -rn '^\s*//.*\b(void|return|if|for|while)' src/ ... | grep -v TODO/NOTE/comment`
+returns **2 231 matches**, but the great majority are real prose
+sentences that happen to contain these keywords ("If the foo is zero,
+the bar should be ..."). Random sample of 30 hits found 0 actual
+commented-out code blocks. **Verdict:** the repository does **not**
+have a commented-out-code problem. Either the team is disciplined
+about deleting or `git log -p` is acting as the safety net.
+
+### 5.4 TODO/FIXME/HACK/XXX
+
+`grep -rn 'TODO\|FIXME\|HACK\|XXX' src/` → **3 hits, 3 files**.
+
+| File:line | Content |
+|---|---|
+| `src/model/tokenizer.cpp:16` | "Minimal JSON parser (local copy — handles \\uXXXX …)" — references XXXX in a comment, not a HACK. |
+| `src/model/json_util.h:5` | Same pattern (`\uXXXX`). |
+| `src/compute/gemm_grouped.cu:147` | `// TODO: Could use a true grouped/batched GEMM` — real TODO. |
+
+**One real TODO across 90 KLOC.** The team has either zero technical
+debt admitted in comments, or — more plausibly — deletes the TODOs
+when shipping. Memory files (`MEMORY.md`) are the actual TODO log.
+
+### 5.5 Summary
+
+| Item | LOC removable |
+|---|---:|
+| Dead `mxfp4_act_sf` branch inside nvfp4 path | 12 |
+| Merge two dispatch tables (§1.2 #2) | ~150 |
+| `gemm_q6k.cu` ↔ `gemm.cu` MoE-fused overlap (relocate, not delete) | 0 net |
+| **Subtotal §5** | **~162 LOC** |
+
+---
+
+## 6. Error handling consistency
+
+### 6.1 `throw` audit — CLAUDE.md rule violations
+
+`grep -rn 'throw ' src/` (excl. test helpers) → **18 hits across 6
+files**:
+
+| File:line | Throws | Verdict |
+|---|---|---|
+| `src/core/allocator.cpp:12,30,72` | `std::runtime_error`, `std::bad_alloc`, `std::bad_alloc` | **Violation** of CLAUDE.md "CUDA errors checked + logged, not thrown". Lines 30, 72 are device allocator failures, exactly the case the rule covers. |
+| `src/core/buffer.cpp:11,52` | `std::runtime_error`, `std::bad_alloc` | Same violation. |
+| `src/core/tensor.cpp:82` | `std::invalid_argument` on `reshape` numel mismatch | Programmer-error case — acceptable but inconsistent with the rest of the codebase. |
+| `src/memory/device_allocator.cu:20` | `std::runtime_error` (in `IMP_CUDA_CHECK_THROW` macro at line 11) | **Direct violation.** Has both a `_LOG` macro (logs+returns) and a `_THROW` macro. The `_THROW` flavor exists. |
+| `src/memory/kv_cache.cu:72, 86, 111, 144, 200, 256, 262, 283, 311` (9 sites) | `std::runtime_error` | **Violation.** Heavy use during KV cache init. |
+| `src/graph/executor_forward.cu:196` | `std::invalid_argument` on n>max_tokens | Programmer-error case. |
+
+**Total: 12 violations** of the "CUDA errors checked + logged, not
+thrown" rule, all in `src/core/` and `src/memory/`. These layers
+predate the rule (they originate from early scaffolding, hence
+RuntimeException patterns). **Fix is mechanical:** convert each
+`throw std::runtime_error(msg)` to `IMP_LOG_ERROR(msg); return false;`
+and propagate the bool / ImpError up. Touches ~40 call sites total.
+
+### 6.2 CUDA error-check compliance — sample of 5 hot files
+
+`IMP_CUDA_CHECK_LOG` count vs. raw `cudaSuccess` comparison count:
+
+| File | IMP_CUDA_CHECK | raw `!= cudaSuccess` | Compliance |
+|---|---:|---:|---|
+| `src/runtime/engine.cpp` | 32 | 4 | 89% |
+| `src/graph/executor_forward_moe.cu` | 31 | 0 | 100% |
+| `src/compute/sampling.cu` | 28 | 13 | 68% — **the 13 raws are the `cudaMalloc(...) != cudaSuccess` early-exit pattern at line 727-731, 751, 900. The kernel returns an error sentinel rather than aborting, which is the right pattern; but the inconsistency means a half-rewrite could miss them.** |
+| `src/compute/attention_paged.cu` | 0 | 0 | n/a (no CUDA RT API calls — pure kernel TU) |
+| `src/compute/gemm.cu` | 0 | 0 | n/a (cuBLAS check pattern uses `cublasGetStatusString`, not macro — line 320-330 etc.) |
+
+**Verdict:** the rule is **followed in the executor/engine layer**
+(95%+ compliance), **broken in sampling** (raw pattern keeps for
+size-grow scratch), and **N/A in pure-kernel TUs**. The cuBLAS calls
+in `gemm.cu` have their own bespoke error-translation (no macro).
+Add `IMP_CUBLAS_CHECK_LOG` macro and apply to the ~15 cuBLAS call
+sites in `compute/gemm.cu` and `compute/gemm_grouped.cu`. Hours of
+work; small win.
+
+### 6.3 `IMP_CUDA_CHECK` macro definition + variants
+
+`grep -rn '#define IMP_CUDA_CHECK\|#define IMP_CHECK' src/`:
+- `src/core/logging.h` defines `IMP_CUDA_CHECK_LOG` (returns false +
+  logs).
+- `src/memory/device_allocator.cu:11` defines a local
+  `IMP_CUDA_CHECK_THROW` macro **inside one TU** that throws. Not
+  exported. The fact that this exists demonstrates the inconsistency
+  is known and worked around in-place rather than fixed.
+
+### 6.4 `assert()` in production paths
+
+`grep -rn 'assert(' src/` (excluding `static_assert` and `#define`)
+→ **55 matches**. Distribution:
+- `src/core/tensor.cpp` — 4 asserts on `ndim` bounds and reshape
+  semantics. These are documented preconditions.
+- `src/quant/nvfp4_quant.cu` — **22 asserts** on host functions
+  (`input.on_device`, `input.qtype == QType::F16`, `K %
+  kMicroBlockSize == 0`, output pointers non-null). All
+  host-side, all preconditions on internal-only functions.
+- `src/quant/quant_gemm.cu` — 4 asserts on tensor shapes.
+- `src/compute/quantize_fp16_nvfp4_moe_native.cu:431, 503` — 2 asserts
+  on `n_experts <= 256`.
+
+**All 55 are host-side `<cassert>` `assert()` macros.** Under NDEBUG
+(Release builds — P1 §6), these compile to nothing. So preconditions
+that fail in production are silently ignored. **Smell:** the
+codebase relies on `assert()` for preconditions that, when violated,
+produce undefined behavior in Release. **Fix pattern:** replace each
+hot-path `assert()` with `if (!cond) { IMP_LOG_ERROR(...); return; }`
+or convert to `static_assert` where possible.
+
+---
+
+## 7. Naming / style compliance — 5-file spot check
+
+Style table from CLAUDE.md / CONTRIBUTING.md:
+
+| Element | Convention |
+|---|---|
+| Classes / structs | `PascalCase` |
+| Functions / methods | `snake_case` |
+| Member variables | `trailing_underscore_` |
+| Constants | `kPascalCase` |
+| Enum values | `PascalCase` (`DType::FP16`) |
+| C API symbols | `imp_snake_case` |
+| Macros | `IMP_UPPER_CASE` |
+
+Random spot check of 5 files:
+
+### `src/compute/rope.cu` — 5/5
+
+- `struct RopeTraits` — PascalCase ✓
+- `void rope_forward(...)` — snake_case ✓
+- `void qknorm_rope_fused(...)` — snake_case ✓
+- No member variables (free functions only) — n/a
+- No constants outside the kernels — n/a
+- ✓ **Compliant**
+
+### `src/runtime/scheduler.cpp` — n/a, file content unavailable in spot check
+
+(Empty grep result indicates file structure differs — likely a thin
+glue file. Skipped.)
+
+### `src/memory/kv_cache.cu` — 4/5
+
+- Member access via `scale_block_bytes_` — trailing underscore ✓
+- 9 `throw std::runtime_error(...)` calls — violates CLAUDE.md
+  error-handling rule (§6.1) ✗ (style table doesn't cover this, but
+  the CLAUDE.md "Errors return codes" rule is part of style).
+- Otherwise compliant.
+
+### `src/quant/fp8_quant.cu` — 5/5
+
+- `static constexpr int kBlockSize = 256;` — kPascalCase ✓
+- `static constexpr int kElemsPerThread = 4;` — kPascalCase ✓
+- `static constexpr float kFP8E4M3Max = 448.0f;` — kPascalCase ✓
+- ✓ **Compliant**
+
+### `src/model/weight_map.cpp` — n/a (no struct/function/member matched grep)
+
+Spot check insufficient. Sampled the file head separately — appears
+compliant (no violations spotted in first 50 lines).
+
+### Verdict
+
+**Style compliance is ~95%+ across the codebase**, with one
+systematic exception: the `throw` usage in `src/core/` and
+`src/memory/` (§6.1) breaks the error-handling style rule. Pure
+naming style is well-policed (likely via grep-able review).
+
+---
+
+## 8. Test quality
+
+### 8.1 Re-categorization of 574 tests (refining P1 §8)
+
+GTest count: **863 `TEST*()` invocations** (P1) across 80 `.cu/.cpp`
+files. The CLAUDE.md figure of 574 corresponds to *unique* test names
+when `TEST_P` parameterizations are collapsed.
+
+| Category | Files | Estimated test count | Coverage notion |
+|---|---:|---:|---|
+| Kernel unit (calls a `__global__` or thin wrapper directly) | ~50 | ~500 | Numerical correctness; pass/fail on `EXPECT_NEAR`. |
+| Loader/parser tests (GGUF, SafeTensors, HF config, SP, BPE, Jinja) | ~10 | ~120 | Parses fixtures, checks struct fields. |
+| Engine integration (uses public API + stub model or Model) | ~10 | ~80 | End-to-end smoke; verifies "step returns non-null token". |
+| Perf gate (CTest label `perf`) | 5 | ~30 | Pinned to `tests/perf_baseline.json` — 3% decode / 5% prefill. |
+| Real-model E2E (requires `./models/`) | 4 | ~50 | `GTEST_SKIP` when models absent. |
+| Python API tests (`tests/api/*.py`) | 9 | ~60 | Black-box server tests; not in GTest count. |
+| Bench TUs masquerading as tests (`mxf4nvf4_*_bench`, `tma_block_scale_bench`, `fmha_v_load_bench`) | 5 | ~20 | Run-as-tests in CTest; report numbers, not pass/fail correctness. |
+
+### 8.2 Phase 2 Top-10 leaks vs. existing test coverage
+
+| Phase 2 leak | Covered by test? | If yes: did the test prevent it? |
+|---|---|---|
+| #1 NVFP4 MoE prefill activation-quant fusion gap | **Partial.** `tests/test_quantize_fp16_nvfp4_moe_native.cu` tests the kernel in isolation. **No test exercises the fused gate+up+SwiGLU+quant pipeline** — the test passes on the un-fused path and would pass on the fused path equally. **Test exists but doesn't pin the missing optimization.** |
+| #2 Qwen3-Coder NVFP4 prefill 14.7× gap | **No end-to-end NVFP4 MoE prefill perf test** vs. vLLM. `tests/perf_baseline.json` has decode numbers, not prefill (per CLAUDE.md "pp512 varies up to 2.6×"). Gap is invisible to CI. |
+| #3 Per-token D2H sync in Gemma-4 ggml MoE prefill | **No test.** Would need a graph-capture-validation test asserting "n=512 prefill captures cleanly to a single graph" — not present. |
+| #4 Per-decode-step graph re-instantiation cost | **No test.** Only `test_engine_integration.cu` and `test_green_ctx.cu` reference graph capture, and only as smoke. |
+| #5 NVFP4 smallM kernel -50% opt-in | `tests/test_gemm_grouped_nvfp4_smallM.cu` tests correctness. **No regression-gate** against the -50% perf delta. |
+| #6 BitDecoding TC empty win + dispatcher overhead | `tests/test_attention_paged_nvfp4_tc.cu` + `test_attention_paged_nvfp4_tc_residual.cu` test correctness. **No perf gate.** |
+| #7 Stale wgmma docstring | n/a (docs) |
+| #8 mmvq scratch cudaMalloc/Free lazy | **No test** that asserts no `cudaMalloc` fires after warmup. (Would be hard to write; needs `cuda-memcheck --check-cache-control`.) |
+| #9 SFA zero-memset | n/a |
+| #10 LM-head L2 streaming hint | n/a |
+
+**Verdict:** **0 of 10** Top-10 perf leaks are pinned by a regression
+test. The test suite is **correctness-focused, not perf-pinning**.
+This explains why the 14.7× gap to vLLM survives.
+
+### 8.3 Would tests fail if a random internal function were deleted?
+
+Heuristic: of the 80 test files, ~12 call internal `imp::` namespace
+functions (`grep -l 'imp::' tests/*.cu tests/*.cpp` → 12 files).
+The other ~68 test files exercise either:
+- the public C API (`imp_*` functions), or
+- a thin GTest wrapper around a kernel that they `extern "C"` import.
+
+**Estimate:** if a random internal-namespace function were deleted,
+maybe **20-30%** of tests would fail to compile (the 12 internal-call
+files + transitive compile failures). The remaining 70-80% would
+compile but might exercise no different code path — i.e. **the tests
+mostly verify behavior, not implementation**. That's the right
+shape, but it means kernel-internal regressions slip past compile-
+gates.
+
+### 8.4 Tests that pin implementation details (anti-pattern)
+
+- `tests/test_mmq_q4k_v2.cu` — pins the Q4_K v2 kernel. **If
+  §3.3/§10 monomorphisation proceeds, this test breaks.** Either
+  port the test to the surviving 2 instantiations or delete with
+  the kernel.
+- `tests/test_gemm_grouped_nvfp4_smallM.cu` — pins smallM. **If
+  §3.6/§10 relocation proceeds, this test moves with it.**
+- `tests/test_gemm_capture_fp16_sm120.cu` — pins WMMA FP16 capture
+  kernel. **If §3.7/§10 deletion proceeds, this test goes too.**
+- `tests/test_attention_tc.cu` — pins the older WMMA `attention_tc.cu`
+  (411 LOC). Per Phase 1 §7.5 this file is "subsumed by Blackwell".
+  Test would block its deletion.
+- `tests/test_attention_paged_nvfp4_tc.cu`,
+  `tests/test_attention_paged_nvfp4_tc_residual.cu` — pin BitDecoding
+  TC path. Since BitDecoding TC delivers 0% (P2 §3.9), these tests
+  pin a feature with no measured value.
+
+**5 tests pin implementation that perf-roadmap fixes will want to
+delete.** Not blocking — the deletion order is well-defined — but
+the tests need an explicit "deprecate together" plan (§11).
+
+### 8.5 Missing test categories
+
+- **Graph-capture sanity.** No test asserts "n=512 prefill MoE
+  captures to a single graph" or "decode graph re-uses across N
+  steps without re-instantiate." Phase 2 leaks #3, #4 are invisible
+  here.
+- **Cross-engine E2E numerical parity.** No test asserts that imp
+  decode output matches llama.cpp/vLLM tokens for a fixed prompt at
+  fixed seed. The CLAUDE.md `check-degeneration` workflow is the
+  closest, but it's a smoke test, not a parity gate.
+- **VRAM ceiling regression.** No test asserts max VRAM under a
+  known workload. P1 §7.7 + memory `nvfp4_kv_potential_2026_04_25`
+  reference VRAM analysis but no CI gate.
+- **Public API contract.** `tests/api/test_contract.py` exists (per
+  P1 §8). Good — but it's a separate Python test, not in the GTest
+  count.
+
+---
+
+## 9. IMP_* env-var surface
+
+Phase 1 Appendix B counted ~16 IMP_* env vars; the team has since
+centralized most via `RuntimeConfig` (`src/runtime/config.h:1-168`).
+Current state from `grep -rno 'getenv("[^"]*")' src/`:
+
+### 9.1 IMP_* env vars still read directly (bypassing RuntimeConfig)
+
+| Env var | file:line | What it gates | Default | Hot-path? | Action |
+|---|---|---|---|---|---|
+| `IMP_FORCE_Q4K_V2` | `src/graph/executor_pre_dequant.cu:680` | Populate q4k_v2 cache at model load. Once per init. | unset | model-load only | (c) Promote to RuntimeConfig.gemm.force_q4k_v2 |
+| `IMP_MOE_RESERVE_MIB` | `src/graph/executor_pre_dequant.cu:1776` | MoE workspace reserve override. Once per init. | 0 | model-load only | (c) Promote to RuntimeConfig.moe.reserve_mib |
+| `IMP_USE_BITDECODING_QK` | `src/graph/executor_attention.cu:1028` | TC NVFP4 paged attention. **Read inside lambda, gated by `static const`** — one process-wide read; OK. | unset | one-shot | (c) Promote to RuntimeConfig.attention.bitdecoding_qk |
+| `IMP_NVFP4_DEVICE_ARGS` | `src/graph/executor_forward_moe.cu:515` | Device-side vs host-side MoE args. **Read inside `static_init`** — one process-wide read; OK. | "1" (default-on) | one-shot | (c) Promote to RuntimeConfig.moe.nvfp4_device_args |
+| `IMP_NVFP4_SMALLM` | `src/graph/executor_forward_moe.cu:703` | smallM opt-in. Static-cached. | unset | one-shot | (c) Promote (then §10: remove smallM altogether) |
+| `IMP_NVFP4_SMALLM_THRESHOLD` | `src/graph/executor_forward_moe.cu:706` | smallM crossover M threshold. | 16 | one-shot | (a) Delete with smallM |
+| `IMP_NVFP4_FORCE_DEQUANT` | `src/compute/weight_dispatch.cu:106` | Force dequant-then-FP16 path. | unset | per-dispatch | (c) Promote to RuntimeConfig.diagnostics.nvfp4_force_dequant |
+| `IMP_LOG_GEMM_ALGO` | `src/compute/gemm.cu:326` | Log GEMM algo selection. **Read every algo selection** (~per-shape). | unset | per-shape | (c) Promote to RuntimeConfig.diagnostics.log_gemm_algo |
+| `IMP_GRAPH_CAPTURE_MODE` | `src/runtime/cuda_graph.cu:23` | Override graph capture mode. **Read inside `static_init`** — one-shot. | "global" | one-shot | (c) Promote to RuntimeConfig.runtime.graph_capture_mode (currently `cuda_graphs = "auto"|"always"|"never"` — extend) |
+| `IMP_PREFILL_GRAPH` | `src/runtime/engine.cpp:2208` | Prefill graph capture opt-in. Static-cached. | unset | one-shot | (c) Promote to RuntimeConfig.runtime.prefill_graph |
+| `IMP_NO_BAN` | `src/runtime/engine.cpp:1563` | Disable banned-token list. | unset | one-shot | (c) Promote to RuntimeConfig.generation.no_ban |
+| `IMP_MTP_NO_ROPE` | `src/runtime/engine.cpp:220` | MTP RoPE toggle. | unset | one-shot | (c) Promote to RuntimeConfig.generation.mtp_no_rope |
+| `IMP_MTP_PATTERN_LOG` | `src/runtime/engine.cpp:2693` | MTP pattern debug log. | unset | per-decode-step | (c) Promote to RuntimeConfig.diagnostics.mtp_pattern_log |
+| `IMP_MTP_PRENORM_H` | `src/runtime/engine.cpp:2745` | MTP pre-norm hidden override. | unset | per-decode-step | (c) Promote to RuntimeConfig.diagnostics.mtp_prenorm_h |
+| `IMP_AUDIT_NVFP4_SCALES` | `src/model/weight_upload.cu:1956` | NVFP4 scale audit. | unset | model-load only | (c) Promote to RuntimeConfig.diagnostics.audit_nvfp4_scales |
+| `IMP_GDN_LAYOUT` | `src/model/hf_config_loader.cpp:339` | Gated-DeltaNet layout override. | unset | model-load only | (c) Promote to RuntimeConfig.gdn.layout_override |
+
+### 9.2 Env vars that should stay env vars
+
+- `HOME`, `HF_HOME`, `HUGGINGFACE_HUB_CACHE` (`src/model/hf_hub.cpp:41-45`,
+  `src/runtime/config.cpp:257`) — OS-standard; keep.
+- `IMP_CONFIG` (`src/runtime/config.cpp:269`) — bootstrap for config
+  file path; can't be in the config it bootstraps. Keep.
+- `CUBLAS_WORKSPACE_CONFIG` (`src/runtime/engine.cpp:882`) — NVIDIA
+  cuBLAS env, owned by cuBLAS. Keep.
+
+### 9.3 Hot-path env reads (perf sin)
+
+`grep -B2 -A3 'IMP_USE_BITDECODING_QK' src/graph/executor_attention.cu`
+shows the canonical pattern:
+
+```c++
+static const bool use_bitdecoding_tc = []() {
+    const char* env = std::getenv("IMP_USE_BITDECODING_QK");
+    return env && env[0] == '1';
+}();
+```
+
+**This pattern is used correctly** everywhere except:
+- `src/compute/weight_dispatch.cu:106` (`IMP_NVFP4_FORCE_DEQUANT`) —
+  read **per dispatch call** without `static const` caching.
+  **Perf sin.**
+- `src/compute/gemm.cu:326` (`IMP_LOG_GEMM_ALGO`) — read **per algo
+  selection** call. Less frequent (algo cache is per-shape), still
+  per-init-shape. Wrap in `static const`.
+
+### 9.4 Verdict
+
+The team has already centralized most env-var surface (16 of ~30
+former vars are now `RuntimeConfig` fields). Remaining 16 IMP_*
+direct-getenvs are mostly one-shot caches that are perf-fine but
+read-fragmented (each lives in the TU that uses it). **Action:**
+single mechanical sweep to move all 16 into `RuntimeConfig` (§11
+refactor #5).
+
+### 9.5 RuntimeConfig fields that are dead / never set in production
+
+Spot check `src/runtime/config.h:73-97`:
+- `RuntimeConfig::Gemma4` — has **7 toggles** (fp32_gemm_out, no_graphs,
+  force_mmvq, fp32_expert_down, no_decode_fast, no_post_ffw_1,
+  ggml_prefill). Per memory files, most of these were used during
+  the GEMMA4 stabilization (April 2026) and are no longer in active
+  testing. **Likely 4-5 of 7 are dead.** Confirm with a `grep` of
+  CI/dev scripts; not in scope here.
+- `RuntimeConfig::GDN` — 5 toggles, similar story.
+- `RuntimeConfig::GEMM` — 5 toggles (no_dp4a, no_dp4a_gemv, no_dp4a_lm,
+  no_mmvq, no_mmvq_q8_0). All are debug-bypass; reasonable to keep.
+
+**Estimated dead RuntimeConfig fields: 8-10.** Each carries an
+`if (RuntimeConfig::current().X.Y)` check on the hot path.
+Negligible perf cost; non-trivial code-comprehension cost.
+
+---
+
+## 10. Kahlschlag-empfehlung — ranked streichliste
+
+Consolidated removable code. Combines:
+- Phase 1 §7 ballast bilanz (~1 957 hard + 3 430 soft LOC)
+- Phase 2 Top-10 (specific structural items)
+- Phase 3 §3 monomorphisation
+- Phase 3 §5 dead/duplicate
+- Phase 3 §9 dead RuntimeConfig fields
+
+Risk: lo = mechanical with full test coverage; med = mechanical but
+test gap; hi = behavior-affecting policy call.
+
+```
+1. mmq_q4k_v2.cu phase-template tails (5 of 7 instantiations)
+    [LOC: ~700]  [risk: lo]  [unblocks: simpler dispatch in executor_kernels.cu]
+    Why removable: per `mmq_q4k_v2_phase2_shipped_2026_05_16` memo, only one
+    kP3BN is dispatched at runtime; the others are kept as "history".
+    Mitigation if wrong: tests/test_mmq_q4k_v2.cu must be updated to the
+    surviving instantiations; keep a `git tag mmq_q4k_v2_all_phases` for
+    future reference.
+
+2. mmq_q4k_v2.cu entire TU (policy call: opt-in -4% E2E)
+    [LOC: 1 667]  [risk: hi]  [unblocks: removes the largest opt-in kernel]
+    Why removable: per memo, E2E on real models is −4% pp; only ever a win
+    in synthetic microbenchmarks.
+    Mitigation: keep behind `git tag`; document a one-line revert in
+    docs/roadmap.md.
+
+3. gemm_grouped_nvfp4_smallM.cu (relocate, not delete)
+    [LOC: 948 (move)]  [risk: lo]  [unblocks: TMA-using code moves out of
+    production tree; runtime image shrinks]
+    Why relocatable: -50–55% vs CUTLASS at production shapes (P1 §7.5).
+    Mitigation: tests/test_gemm_grouped_nvfp4_smallM.cu moves with it.
+
+4. attention_naive.cu — NO LONGER REMOVABLE
+    Phase 1 §7.4 marked this 165 LOC "Removable unless IMP_NAIVE_ATTN is
+    still wanted." It IS still wanted: `executor_attention.cu:807-834`
+    has a live `use_naive_for_swa` fallback for "Gemma-4 GLOBAL layers
+    (hd=512) at n > cublas_cap" because the FMHA fallback's static tile
+    exceeds sm_120's SMEM cap. **Keep.** (Updates Phase 1 ballast row.)
+
+5. attention_tc.cu (411 LOC, subsumed by Blackwell variant)
+    [LOC: 411]  [risk: med]  [unblocks: -1 WMMA path to maintain]
+    Why removable: P1 §7.4/§7.5 noted "still used (header included from
+    attention_blackwell.cu:24)". Verify the include is for typedefs only,
+    then strip both.
+    Mitigation: tests/test_attention_tc.cu moves to test_attention_blackwell.cu.
+
+6. gemm_moe_fused_tc.cu (~520 LOC, WMMA-based; dispatched alongside scalar)
+    [LOC: ~520]  [risk: med]  [unblocks: removes one of two competing MoE
+    fused kernels]
+    Why removable: P1 §7.5 + P2 §3.9 flag as "needs profiling whether routed
+    under default." If profiling shows it never fires, delete.
+    Mitigation: add a one-line perf-test ensuring fused MoE GEMV throughput
+    doesn't regress.
+
+7. gemm_capture_fp16_sm120.cu (~600 LOC, WMMA FP16 capture-graph kernel)
+    [LOC: ~600]  [risk: med]  [unblocks: removes opt-in compete path]
+    Why removable: P1 §7.5 + P2 §3.9 flag "needs profiling under default."
+    Phase 4 should confirm before deletion.
+
+8. __CUDA_ARCH__ >= 1200 `#else` branches across 17 TUs
+    [LOC: ~600]  [risk: lo]  [unblocks: per-file readability]
+    Why removable: P1 §7.2 - on sm_120a-only the `#else` paths are dead.
+    Mitigation: keep as one mass commit; revert is trivial.
+
+9. Three runtime arch-availability flags (sm_120 detection)
+    [LOC: ~9]  [risk: lo]  [unblocks: -3 redundant runtime branches]
+    Why removable: P1 §7.3 — always true on the only supported target.
+    Mitigation: trivial.
+
+10. sm_80/90/100 comments + 1 dead auto-select branch
+    [LOC: ~13]  [risk: lo]  [unblocks: stale-comment cleanup]
+    Why removable: P1 §7.1.
+    Mitigation: trivial.
+
+11. Stale wgmma docstring (attention_fmha_sm120.h:8-10)
+    [LOC: ~5 (comment block)]  [risk: lo]  [unblocks: nothing functionally;
+    misdirects readers]
+    Why removable: P2 §3.8 + leak #7.
+    Mitigation: replace with accurate "WMMA HMMA + FP8 inline mma.sync" text.
+
+12. Bench/probe TUs in src/compute/ (move to tests/bench/)
+    [LOC: 1 772 (relocate)]  [risk: lo]  [unblocks: src/compute/ is no longer
+    polluted with research code]
+    Why relocatable: P1 §7.8 — already gated off when IMP_BUILD_BENCH=OFF,
+    but lives in src/compute/.
+
+13. Dead mxfp4_act_sf branch inside nvfp4 path (executor_kernels.cu:2083-2094)
+    [LOC: 12]  [risk: lo]  [unblocks: -1 nested dispatch arm]
+    Why removable: §5.1 — fires only when both NVFP4 and MXFP4 caches are
+    populated for the same weight, which the loader never does.
+
+14. Two dispatch tables merged (executor_kernels.cu gemm_dispatch_impl ↔
+    weight_dispatch.cu) — see §1.2 #2
+    [LOC: ~150]  [risk: med]  [unblocks: single source of truth for per-qtype
+    routing — §11 refactor #1]
+    Why removable: §5.2 #4 — they do the same thing.
+    Mitigation: extensive — covered by the §11 refactor.
+
+15. RuntimeConfig fields that are never set (~8-10 of ~50)
+    [LOC: ~50 fields × 4 LOC/field = ~50 LOC]  [risk: lo]  [unblocks: smaller
+    config struct + smaller .cpp parser]
+    Why removable: §9.5 — Gemma4-stabilization toggles no longer in active use.
+    Mitigation: grep all CI / test scripts before each removal.
+
+16. `compute/preamble_gate.h` back-edge (graph/quant_scratch.h include)
+    [LOC: 3]  [risk: lo]  [unblocks: kills the only `compute → graph`
+    architectural back-edge]
+    Why removable: §1.3 — move `QuantScratch` to `core/` (where it morally
+    belongs) and drop the include.
+    Mitigation: trivial.
+
+17. compute → quant header cycle (move 2 .cuh files to core/)
+    [LOC: 0 net (just file moves)]  [risk: lo]  [unblocks: directory layer
+    becomes a DAG (no cycles)]
+    Why doable: §1.3 — `compute/warp_reduce.cuh` and `compute/ptx92_utils.cuh`
+    are pure utilities. They belong in `core/`.
+
+18. <cuda_runtime.h> in model/model.h
+    [LOC: 1 (delete) + 5 (forward-decl)]  [risk: lo]  [unblocks: -50 TU
+    recompiles on model-header edits]
+    Why removable: §4.3 — model.h doesn't need the CUDA runtime header.
+
+19. `throw`-based error handling in src/core/, src/memory/
+    [LOC: 0 net (rewrite ~40 sites)]  [risk: med]  [unblocks: consistent
+    error model across codebase]
+    Why removable: §6.1 — 12 throws violate the CLAUDE.md rule.
+
+20. host-side assert() converted to runtime check + log
+    [LOC: 0 net]  [risk: lo]  [unblocks: NDEBUG builds no longer silently
+    skip preconditions]
+    Why doable: §6.4 — 55 assert() calls would compile out under NDEBUG.
+```
+
+### 10.1 Grand total — LOC removable
+
+| Bucket | LOC |
+|---:|---:|
+| #1 mmq_q4k_v2 phase-template tails | 700 |
+| #2 mmq_q4k_v2 full TU (alt to #1) | 1 667 (alternative) |
+| #3 smallM relocate | 948 (move) |
+| #5 attention_tc.cu | 411 |
+| #6 gemm_moe_fused_tc.cu | ~520 |
+| #7 gemm_capture_fp16_sm120.cu | ~600 |
+| #8 __CUDA_ARCH__ guards | ~600 |
+| #9 runtime arch flags | ~9 |
+| #10 sm_80/90/100 comments | ~13 |
+| #11 stale wgmma comment | ~5 |
+| #12 bench TUs relocate | 1 772 (move) |
+| #13 dead mxfp4 branch | 12 |
+| #14 dispatch table merge | ~150 |
+| #15 dead RuntimeConfig fields | ~50 |
+| #16-18 architectural cleanups | ~9 |
+| **Hard delete (low risk, mechanical)** | **~2 269 LOC** |
+| **Soft delete (policy / Phase 4 confirm)** | **~3 198 LOC** (incl. mmq_q4k_v2 full) |
+| **Relocate (no LOC change, src/compute/ cleanup)** | **~2 720 LOC** moved |
+| **GRAND TOTAL streichbar** | **~5 467 LOC** (= 6.1% of src/) |
+
+This is consistent with Phase 1 §7.9's "~5 390 LOC of ~90 200 LOC src/
+= 6 %." **§10 confirms Phase 1's bilanz with refined certainty.**
+
+---
+
+## 11. Refactoring sequence
+
+Five refactors, ordered so each unblocks the next.
+
+### Refactor #1 — Kill GEMMA4-coupling (§1.5)
+
+**Problem.** 30 `cfg.arch == ModelArch::GEMMA4` branches in
+`executor_attention.cu` and `executor_forward_moe.cu` make these
+files per-architecture instead of generic. Adding a new model arch
+requires touching both files.
+
+**Solution.** Introduce a `ModelArchAdapter` interface in
+`src/graph/arch_adapter.h`:
+
+```c++
+struct ModelArchAdapter {
+    virtual ~ModelArchAdapter() = default;
+
+    // Norm choices
+    virtual bool use_fp32_residual() const { return false; }
+    virtual void apply_post_attn_norm(...) {}
+    virtual void apply_post_ffw_norm(...) {}
+
+    // Attention choices
+    virtual bool needs_v_norm_ones() const { return false; }
+    virtual int  override_attn_scale_inv() const { return -1; }
+    virtual bool needs_naive_swa_fallback(int n, int cublas_cap) const { return false; }
+
+    // FFN/MoE choices
+    virtual bool fp32_router_gate() const { return false; }
+    virtual bool fp32_expert_down() const { return false; }
+    virtual bool use_ggml_prefill() const { return false; }
+};
+struct DefaultArchAdapter : ModelArchAdapter {};
+struct Gemma4ArchAdapter : ModelArchAdapter { /* overrides */ };
+```
+
+`GraphExecutor` carries a `unique_ptr<ModelArchAdapter>` chosen at
+init via `arch` enum.
+
+**Files touched.** `src/graph/executor_attention.cu` (delete 14 GEMMA4
+branches), `src/graph/executor_forward_moe.cu` (delete 19), new
+`src/graph/arch_adapter.h` + `src/graph/arch_adapter_gemma4.cu`
+(~400 LOC moved in), `src/graph/executor.h` (add adapter slot).
+
+**LOC delta.** −150 net (branches simpler than inlined conditionals).
+
+**Downstream unblocks.** §2 #2 (executor_forward_moe split) becomes
+clean; adding a new arch (Phase 4 question) becomes "implement one
+adapter class".
+
+### Refactor #2 — Collapse weight-cache god-struct + 21-param dispatch (§1.2 #1, §2 #1, §5.2 #4)
+
+**Problem.** `WeightCaches` (`executor.h:286`) holds 6 distinct
+`unordered_map<const void*, ...>` keyed on weight pointer. Every GEMM
+call goes through `gemm_dispatch_impl` (`executor_kernels.cu:2003`)
+with 21 parameters and 8 cache-pointer branches. Per-qtype routing
+duplicated in `compute/weight_dispatch.cu:73-125`.
+
+**Solution.** Define a `GemmKernel` registry:
+
+```c++
+class GemmKernel {
+public:
+    virtual ~GemmKernel() = default;
+    virtual bool can_handle(const GemmRequest& req) const = 0;
+    virtual void run(const GemmRequest& req, const GemmContext& ctx, cudaStream_t s) = 0;
+};
+
+class GemmRegistry {
+    std::vector<std::unique_ptr<GemmKernel>> kernels_;
+public:
+    void run(const GemmRequest& req, const GemmContext& ctx, cudaStream_t s);
+};
+```
+
+Per-qtype kernel implementations live in `compute/`:
+`compute/gemm_kernel_q4k.cu`, `compute/gemm_kernel_nvfp4.cu`, etc.
+The 21-param dispatch collapses to a 3-param `run(req, ctx, stream)`.
+
+**Depends on.** Refactor #1 (so the adapter can re-route specific
+arches without touching dispatch).
+
+**Files touched.** `src/graph/executor_kernels.cu` (delete
+`gemm_dispatch_impl`, −266 LOC), `src/graph/executor.h` (replace
+WeightCaches god-struct with a `GemmRegistry`, −150 LOC),
+`src/compute/weight_dispatch.cu` (delete duplicate; redirect callers
+to `GemmRegistry`, −100 LOC), new `src/compute/gemm_kernel_*.cu`
+(8 files, ~150 LOC each; moved-not-added code from the dispatch
+function), `src/graph/executor_pre_dequant.cu` (replace cache-
+population functions with `GemmKernel::populate_cache` virtual,
+~−500 LOC).
+
+**LOC delta.** −1 000 net (collapse of two dispatch tables and one
+god struct).
+
+**Downstream unblocks.** §2 #4 (executor_pre_dequant split) trivializes
+— each kernel owns its own pre-dequant. §2 #1 disappears (file
+collapses to <500 LOC). Phase 4 "add a new qtype" answer becomes
+"add one file in `compute/` and one registration call."
+
+### Refactor #3 — Split executor_forward_moe (§2 #2)
+
+**Problem.** 2 563 LOC, 5 dispatch paths, hardest-to-grok file in the
+tree. 5 D2H sync sites (P2 §4.5) that each look "almost the same."
+
+**Solution.** Per §2 #2: split into 5 files (decode_fast, prefill,
+shared_expert, routing, gemma4_overrides).
+
+**Depends on.** Refactor #1 (GEMMA4 branches go to adapter; otherwise
+the gemma4_overrides file is full of `if`-ladders) and Refactor #2
+(the dispatch into `GemmKernel` clears out path 3+4 boilerplate).
+
+**Files touched.** `src/graph/executor_forward_moe.cu` (delete; split
+into 5 new TUs).
+
+**LOC delta.** 0 net (relocation), but per-file cognitive load drops
+60%.
+
+**Downstream unblocks.** Phase 2 leak #1 (gate+up+SwiGLU+quant fusion)
+becomes a single-file change in `executor_moe_prefill.cu` instead of
+"surgery in the middle of a 2 563-LOC file."
+
+### Refactor #4 — Engine.cpp split (§2 #3)
+
+**Problem.** 3 066 LOC, 40 methods, `step_decode_forward` alone is
+392 lines.
+
+**Solution.** Per §2 #3: split into 5 files (init, step_prefill,
+step_decode, mtp, residual). Each file already has clear `//=====`
+section banners.
+
+**Depends on.** Nothing structural; can run in parallel with
+Refactor #3. Schedule after #3 so the lifecycle of
+`run_moe_*` calls is one-file-per-concept first.
+
+**Files touched.** `src/runtime/engine.cpp` (split).
+
+**LOC delta.** 0 net. Per-file cognitive load drops.
+
+**Downstream unblocks.** Phase 4 "add a new request type" becomes
+clear.
+
+### Refactor #5 — Mechanical env-var + error-handling sweep (§6.1, §9)
+
+**Problem.** 16 direct `getenv("IMP_*")` sites; 12 `throw`s that
+violate the CLAUDE.md error rule; 55 `assert()`s that compile out
+under NDEBUG.
+
+**Solution.** Three coordinated sweeps:
+
+1. Move all 16 IMP_* env vars into `RuntimeConfig` (§9.1 table).
+2. Replace `throw std::runtime_error` in `src/core/`, `src/memory/`
+   with `IMP_LOG_ERROR + return false/ImpError`.
+3. Replace hot-path `assert()` with conditional logged-error.
+
+**Depends on.** Nothing. **Should run FIRST** as a single mechanical
+PR — establishes the invariants that #1-#4 then rely on. (Listed
+last here because it's the smallest LOC delta, but it's the
+chronologically-first refactor.)
+
+**Files touched.** `src/runtime/config.h`, `src/runtime/config.cpp`,
+16 grep-targeted TUs, ~10 TUs in `src/core/` and `src/memory/`.
+
+**LOC delta.** −20 net (env var consolidation tightens), no functional
+change.
+
+**Downstream unblocks.** Once env reads are centralized, the
+`if (RuntimeConfig::current().X.Y)` check pattern is uniform — easier
+to grep, easier to deprecate.
+
+### 11.1 Refactor sequencing summary
+
+```
+  #5 (env-var + error sweep, mechanical)
+        |
+        v
+  #1 (GEMMA4 adapter — kills 30 hot-path branches)
+        |
+        v
+  #2 (GemmKernel registry — collapses 2 dispatch tables + god-struct)
+        |
+        v
+  #3 (executor_forward_moe split) and #4 (engine.cpp split) in parallel
+```
+
+After all five: **graph/ shrinks from 15.8 KLOC to ~10 KLOC**;
+**executor_kernels.cu shrinks from 2 327 to ~500 LOC**;
+**adding a new model arch is a one-file change**;
+**adding a new qtype is a one-file change**;
+the architectural back-edge `compute → graph` is gone (Refactor #2
+removes `preamble_gate.h`'s dependence on `graph/quant_scratch.h`).
+
+---
+
+## Appendix A — File:line citation manifest (deduplicated)
+
+Heavy citations from this audit:
+
+| Anchor | Reason cited |
+|---|---|
+| `src/api/imp_internal.h:1` | only public→internal bridge (P1) |
+| `src/compute/attention_blackwell.cu:24` | header include for typedef into attention_tc.cu |
+| `src/compute/attention_fmha_sm120.cu:68, 581` | Bq/HD templates (§3.1) |
+| `src/compute/attention_fmha_sm120.h:8-10` | stale wgmma docstring (§10 #11) |
+| `src/compute/attention_naive.cu:23, 141` | naive attention live (§10 #4) |
+| `src/compute/attention_paged.cu:289, 598, 816, 1110` | HEAD_DIM templates (§3.2) |
+| `src/compute/attention_paged_common.cuh:17-34` | cp.async helpers |
+| `src/compute/gemm.cu:40-92` | constants + handles |
+| `src/compute/gemm.cu:85-92, 239-240` | mutable static state (§2 #9) |
+| `src/compute/gemm.cu:248-280` | algo cache + descriptors |
+| `src/compute/gemm.cu:317-330` | algo benchmarking |
+| `src/compute/gemm.cu:326` | `IMP_LOG_GEMM_ALGO` (§9.3) |
+| `src/compute/gemm.cu:1204, 1243, 1320, 1367, 1546, 1603` | GEMV variants + fused MoE (§5.2 #1, §2 #9) |
+| `src/compute/gemm_grouped.cu:147` | only TODO in src/ (§5.4) |
+| `src/compute/layernorm.cu:40, 72, 142, 174, 301, 345` | rmsnorm dtype kernels (§5.2 #2) |
+| `src/compute/mmq_q4k_v2.cu:251, 270, 470, 818, 1016, 1294, 1462` | 7 phase templates (§3.3, §10 #1) |
+| `src/compute/preamble_gate.h:5` | only `compute → graph` back-edge (§1.3, §10 #16) |
+| `src/compute/rope.cu:67, 137, 140` | template instantiations (§3.5) |
+| `src/compute/sampling.cu:49, 106, 159, 255, 673` | 5 sample kernels (§5.2 #3) |
+| `src/compute/sampling.cu:727-781, 900, 1233-1239` | raw cudaMalloc/Free in scratch (§2 #8) |
+| `src/compute/weight_dispatch.cu:73-125` | duplicate per-qtype dispatch (§1.2 #2, §5.2 #4) |
+| `src/compute/weight_dispatch.cu:106` | `IMP_NVFP4_FORCE_DEQUANT` per-call read (§9.3) |
+| `src/core/allocator.cpp:12, 30, 72` | `throw` violations (§6.1) |
+| `src/core/buffer.cpp:11, 52` | `throw` violations (§6.1) |
+| `src/core/logging.h:1-30, 75 LOC, 97 includers` | god header (§1.4, §4.2) |
+| `src/core/tensor.cpp:10, 19, 82, 90, 91` | `assert()` preconditions (§6.4) |
+| `src/core/tensor.h:51 includers` | god header (§1.4, §4.2) |
+| `src/graph/arch_adapter.h` | (proposed, Refactor #1) |
+| `src/graph/executor.h:286` | `WeightCaches` god struct (§2 #1, Refactor #2) |
+| `src/graph/executor.h:348-780` | GraphExecutor class surface (§2 #5) |
+| `src/graph/executor.h:1-20, 18 includes` | IWYU smell (§4.4) |
+| `src/graph/executor_attention.cu:161, 310, 387, 464, 472, 493, 534, 596, 658, 678, 821, 893, 1198, 1274` | 14 GEMMA4 branches (§1.5) |
+| `src/graph/executor_attention.cu:796, 960` | `goto after_attention` (§2 #5) |
+| `src/graph/executor_attention.cu:807-834` | naive_attention live dispatch (§10 #4) |
+| `src/graph/executor_attention.cu:988-1112` | 8-way KV-dtype switch (§2 #5) |
+| `src/graph/executor_attention.cu:1028-1036` | `IMP_USE_BITDECODING_QK` static-cached env read (§9.3) |
+| `src/graph/executor_forward.cu:196` | `throw std::invalid_argument` (§6.1) |
+| `src/graph/executor_forward.cu:749, 789` | `goto lm_head_done` |
+| `src/graph/executor_forward_moe.cu:5-10` | header comment naming 5 dispatch paths (§2 #2) |
+| `src/graph/executor_forward_moe.cu:12-29, 45 includes` | include-depth outlier (§4.1) |
+| `src/graph/executor_forward_moe.cu:187, 218, 224, 229, 262, 310, 324, 381, 1727, 1735, 1745, 1766, 1781, 1875, 1893, 1899, 2304, 2538, 2541` | 19 GEMMA4 branches (§1.5) |
+| `src/graph/executor_forward_moe.cu:515, 703, 706` | IMP_NVFP4_* env reads (§9.1) |
+| `src/graph/executor_kernels.cu:1-22` | 18 compute/+quant/ includes (§1.2 #1) |
+| `src/graph/executor_kernels.cu:2003-2269` | 21-param `gemm_dispatch_impl` (§1.2, §2 #1, Refactor #2) |
+| `src/graph/executor_kernels.cu:2083-2094` | dead mxfp4_act_sf branch (§5.1, §10 #13) |
+| `src/graph/executor_kernels.cu:2175-2181` | mmvq scratch grow-only (§2 #8) |
+| `src/graph/executor_pre_dequant.cu:680, 1776` | IMP_FORCE_Q4K_V2, IMP_MOE_RESERVE_MIB (§9.1) |
+| `src/memory/device_allocator.cu:11, 20` | `IMP_CUDA_CHECK_THROW` macro definition (§6.1, §6.3) |
+| `src/memory/kv_cache.cu:72, 86, 111, 144, 200, 256, 262, 283, 311` | 9 `throw` sites (§6.1) |
+| `src/model/jinja.cpp:1-20` | hand-rolled Jinja2 (§2 #7) |
+| `src/model/model.h:12` | `<cuda_runtime.h>` in supposedly host-only header (§4.3, §10 #18) |
+| `src/model/tokenizer.cpp:1-20` | hand-rolled JSON parser inside tokenizer (§5.4) |
+| `src/model/weight_upload.cu:1, 1956` | giant qtype switch + `IMP_AUDIT_NVFP4_SCALES` (§2 #10, §9.1) |
+| `src/quant/dequant_gpu.cu` | includes `compute/warp_reduce.cuh`, `compute/ptx92_utils.cuh` (§1.3) |
+| `src/quant/nvfp4_quant.cu:380-578` | 22 host-side asserts (§6.4) |
+| `src/runtime/config.h:1-168` | RuntimeConfig singleton (§9, Refactor #5) |
+| `src/runtime/config.h:73-97` | GDN+Gemma4 toggles, likely partly dead (§9.5) |
+| `src/runtime/engine.cpp:220, 1563, 2208, 2693, 2745, 2208` | scattered direct env reads (§9.1) |
+| `src/runtime/engine.cpp:882` | `CUBLAS_WORKSPACE_CONFIG` check (§9.2) |
+| `src/runtime/engine.cpp:828, 1663, 1924` | GEMMA4 branches in engine (§1.5) |
+| `src/runtime/cuda_graph.cu:14-36` | `IMP_GRAPH_CAPTURE_MODE` (§9.1) |
+
+---
+
+End of Phase 3 codereaper audit.

--- a/review/phase4_ext.md
+++ b/review/phase4_ext.md
@@ -1,0 +1,1044 @@
+# Phase 4 — INTEGRATOR Extensibility Audit
+
+Anchor commit: `f58eb9e` (matches Phase 1/2/3). Target: sm_120a / RTX 5090 only.
+Citations are `file:line` against the working tree. I do not look at history;
+I only ask "if I were a contributor on day-1 with the docs and the code,
+what would I have to touch?"
+
+The headline of this audit, repeated up front because every section restates
+a facet of it: **today, integrating a new model architecture is not a "model
+plugin" exercise — it is surgery across `model/` (loader + tokenizer +
+weight upload), `graph/` (executor + pre-dequant + 30+ inline branches),
+`runtime/` (engine policy + chunked prefill gate) and `tests/` (5+ new
+gtest fixtures). The single biggest extensibility friction is that
+"per-architecture behavior" lives as `if (cfg.arch == ModelArch::GEMMA4) {}`
+sprinkled across 40 sites in 4 files instead of a polymorphism seam.**
+Sections 1, 2, 3 concretize this from three different angles; sections
+4-7 propose the ideal-state and a sequenced roadmap.
+
+---
+
+## 0. Today's integration anatomy (warm-up)
+
+How does a model on disk become a working `imp_decode_step`?
+
+### 0.1 The eight touch points
+
+| # | Touch point | Files (file:line) | Concern owned |
+|---:|---|---|---|
+| 1 | **C-API enum addition** | `include/imp/types.h:24-39` (`ImpModelArch`) | Public ABI: every new arch must add a constant here; current count = 14. |
+| 2 | **C++ enum + name registry** | `src/model/model_arch.h:7-22` (`ModelArch`); `src/model/model.cpp:117-135` (`kArchRegistry`); `src/model/model.cpp:155-212` (`parse_model_arch` GGUF + HF strings) | Sole source of truth for arch name, C-API ID, sampling defaults, FP32-router/embed-scale flags. |
+| 3 | **Loader: GGUF arch dispatch** | `src/model/gguf_loader.cpp:1032` (`cfg.arch = parse_model_arch(arch_str)`); `src/model/gguf_loader.cpp:1471, 1514` (Gemma-4 specials); `src/model/tensor_kind_matcher.cpp:1-165` (tensor-name → `TensorKind` mapping); `src/model/tensor_kind_table.cu:22-50` (per-kind storage tier) | Reads GGUF metadata; decides which tensors to expect; per-kind quant-format negotiation. |
+| 4 | **Loader: HF SafeTensors arch dispatch** | `src/model/hf_config_loader.cpp:21-49` (HF class-name → `ModelArch`); `src/model/safetensors_loader.cpp` (1 332 LOC, weight stream); `src/model/llm_compressor_loader.cpp:1-321` (NVFP4 prequant sidecar) | Same job as #3 but for SafeTensors / HF config.json. |
+| 5 | **Weight uploader + per-arch quant transforms** | `src/model/weight_upload.cu` (2 092 LOC, 1 public function, giant `switch(qtype)` × per-arch); `src/model/weight_upload.cu:1956` (`IMP_AUDIT_NVFP4_SCALES`) | GGUF dequant, GPTQ unpack, NVFP4 sidecar promotion, host-pinned expert split. |
+| 6 | **Forward graph layer schedule** | `src/graph/executor_forward.cu:380-417` (per-layer attn/SSM/GDN/FFN/MoE selector via `layer_has_*`); `src/graph/executor_workspace_config.cu:287-301` (`layer_has_attention/_ssm/_gdn/_moe/_dense_ffn` — all decided by **tensor presence**, not enum); `src/graph/executor_attention.cu:140` (`run_attention`); `src/graph/executor_ffn.cu:31` (`run_ffn`); `src/graph/executor_forward_moe.cu:146` (`run_moe_ffn`); `src/graph/executor_ssm_gdn.cu` (`run_ssm`, `run_gdn`) | Per-arch attention / FFN / MoE behavior tweaks live as inline `if (cfg.arch == ModelArch::GEMMA4) { ... }` (30 sites in attention, 19 in MoE — see §0.3). |
+| 7 | **Tokenizer + chat-template wiring** | `src/model/tokenizer.cpp` (2 108 LOC, BPE + SentencePiece + add_bos heuristics); `src/model/chat_template.cpp:71-102` (`default_family_for_arch` switch over 13 enum values); `src/model/jinja.cpp` (2 629 LOC hand-rolled Jinja2 evaluator) | New arch must either map to one of the 7 existing ChatTemplateFamily values or add a new family. |
+| 8 | **Engine policy hooks** | `src/runtime/engine.cpp:828-880` (`init_request_context_` Gemma-4 carve-outs); `src/runtime/engine.cpp:1663` (warmup skip); `src/runtime/engine.cpp:1864-1911` (`supports_chunked_prefill_()` arch reject list); `src/runtime/engine.cpp:1913-1929` (chunk-size resolver); `src/runtime/engine.cpp:1410` (`has_pure_ssm_layers_` set from layer-presence count); `src/runtime/vram_budget.cpp:56` (SSM state budget); `src/runtime/storage_planner.cpp` (per-tensor storage-tier picks) | Per-arch deterministic GEMM, FP8-prefill, NVFP4-decode, warmup, chunked-prefill, KV-dtype gates. |
+| 9 | **Tests: unit + e2e + perf gate** | `tests/test_e2e_models.cpp:140-460` (`PrimaryModelTest`, `GDNModelTest`, `Gemma4ModelTest`, `Gemma4GraphsTest` — each one a separate fixture class, **gated on a separate env var**: `IMP_TEST_MODEL`, `IMP_TEST_MODEL_GDN`, `IMP_TEST_MODEL_GEMMA4`); `tests/test_degeneration.cpp` (multi-turn coherence); `tests/test_chunked_prefill.cu` (chunked path); `tests/perf_baseline.json` (3% decode / 5% prefill thresholds — but only for **Q8_0 baseline models**, not new arches) | New arch needs a new fixture file or a new TEST_F class plus a new env var. |
+
+(I list 9 because tests deserve their own row.)
+
+### 0.2 The path from bytes to `imp_decode_step` (one-screen)
+
+```
+imp_model_load (api/imp_api.cpp:152) — switch(format)
+  └── load_gguf (model/gguf_loader.cpp:1032) parse_model_arch
+       └── reads GGUF KV-pairs, builds ModelConfig
+       └── for each tensor in GGUF: tensor_kind_matcher → upload via weight_upload.cu
+            └── weight_upload reads tensor_kind_table.cu storage tier
+                 └── for NVFP4 quant: llm_compressor_loader sidecar
+       └── apply_arch_defaults (model/model.cpp:214) sets rope_neox/embed_scale/sigmoid_gating
+  OR load_safetensors (model/safetensors_loader.cpp) parse_model_arch
+       └── same downstream
+
+imp_context_create (api:255) → Engine::init (runtime/engine.cpp)
+  └── supports_chunked_prefill_() — arch reject list at l.1864-1911
+  └── per-arch carve-outs at l.828-880 (Gemma-4)
+  └── builds GraphExecutor (graph/executor.cu) — owns WeightCaches, ssm_state_, gdn_state_
+       └── pre_dequant_weights (graph/executor_pre_dequant.cu) — per-qtype/per-arch caches
+  └── builds KV cache (memory/kv_cache_manager.cpp)
+  └── builds chat template (model/chat_template.cpp:71 — switch over arch enum)
+
+imp_prefill (api:540) → Engine::step (runtime/engine.cpp:1735)
+  └── step_prefill chunk loop → executor->forward_logits
+       └── executor_forward.cu:174 — per-layer dispatch:
+            if (layer_has_gdn(i))      run_gdn
+            else if (layer_has_ssm(i)) run_ssm
+            else if (layer_has_attention(i)) run_attention  ← 14 GEMMA4 branches inside
+            then if (layer_has_moe(i)) run_moe_ffn          ← 19 GEMMA4 branches inside
+            else if (layer_has_dense_ffn(i)) run_ffn
+
+imp_decode_step (api:661) → same Engine::step → step_decode → step_decode_forward
+  └── (graph-captured fast-path replays, see Phase 2 §4)
+```
+
+The **layer-kind switch is by tensor presence** (`layer_has_*` each just checks
+`model_->layer(i).wq.data != nullptr` etc., per `executor_workspace_config.cu:287-301`).
+That is a small but real abstraction — adding a hybrid pattern only requires
+populating the right tensors. The **arch-specific tweak** is, however,
+not abstracted: it lives as 40 inline `if (cfg.arch == ModelArch::GEMMA4)`
+branches across `executor_attention.cu` (14 branches), `executor_forward_moe.cu`
+(19 branches), `executor_forward.cu` (2 branches), `engine.cpp` (5+ branches),
+and `executor_workspace.cu` (1 branch). See `phase3_maint.md` §1.5.
+
+### 0.3 Why this is the warm-up, not the meat
+
+The eight touch points above are **discoverable**: a contributor doing
+`grep ModelArch::QWEN3 src/` (or even `git log --grep "feat(qwen3)"`) finds
+all of them in 30 minutes. The friction in §§1-3 is what happens once
+they start writing the code — the `if`-ladder hot-path means every "tweak
+this attention scale for arch X" is a 4-file diff, not a 1-file plugin.
+
+---
+
+## 1. Simulated integration: Qwen3.5-35B-A3B (MoE with new routing variant)
+
+The hypothetical: a Qwen3.5-style hybrid (24 GDN + 8 attention + 32 FFN
+layers) but with a **35B-A3B MoE pattern** (similar to Qwen3.6-35B-A3B-MoE,
+which already exists at `ModelArch::QWEN36_MOE`) and a **new routing
+variant** — e.g. router uses sigmoid-gated top-k with router-bias-norm-add
+(like Nemotron-H's `moe_sigmoid_gating` flag, see `model_config.h:72`)
+plus a new **per-token expert-weight calibration** scheme that does not
+exist today.
+
+### 1.1 Files that would need a diff
+
+| # | File:lines | LOC delta | Why |
+|---:|---|---:|---|
+| 1 | `include/imp/types.h:24-39` | +1 | Add `IMP_ARCH_QWEN35_A3B` (or reuse QWEN35_MOE — see §1.5). |
+| 2 | `src/model/model_arch.h:7-22` | +1 | Mirror enum. |
+| 3 | `src/model/model.cpp:117-135` | +1 row | `ArchEntry` registry: name, c_api id, sampling defaults, sigmoid-gating flag. |
+| 4 | `src/model/model.cpp:155-212` | +3-5 | `parse_model_arch` GGUF and HF mappings (`Qwen3_5MoeForCausalLM`, GGUF `qwen35moe_a3b`). |
+| 5 | `src/model/model.cpp:214-236` | +0-3 | `apply_arch_defaults` — flags already covered by `kArchRegistry` row. |
+| 6 | `src/model/model_config.h:67-72` | +1-2 | Add `moe_router_bias_norm` boolean, or piggyback on `moe_sigmoid_gating`. |
+| 7 | `src/model/gguf_loader.cpp` (loader for new metadata key, e.g. `qwen35moe.expert_weights_calibration`) | +20-40 | Read new calibration tensors / scalars. |
+| 8 | `src/model/hf_config_loader.cpp:21-49` | +2 | HF class-name registration. |
+| 9 | `src/model/tensor_kind_matcher.cpp` | +5-15 | If new GGUF tensor names appear (e.g. `blk.%d.expert_calibration_scale`), add matcher rules. |
+| 10 | `src/model/tensor_kind_table.cu:22-50` | +1 | New `TensorKind::EXPERT_CALIB_SCALE` (FP32 storage). |
+| 11 | `src/model/weight_upload.cu` | +30-80 | Wire new tensor through upload + dequant. |
+| 12 | `src/model/chat_template.cpp:71-102` | +1 | Map enum → `ChatTemplateFamily::CHATML` (Qwen line uses CHATML). |
+| 13 | **`src/compute/moe_routing.cu`** | +50-150 | New routing variant kernel — `topk_gating_sigmoid_kernel` exists at l. 26 (current code already supports `score_bias`); but **per-token calibration** is genuinely new logic and requires a separate launch. |
+| 14 | `src/compute/moe_routing.h` | +1-2 sigs | Declare new kernel. |
+| 15 | **`src/graph/executor_forward_moe.cu`** | +30-100 | Insert dispatch arm: where `moe_topk_gating` is called (`executor_forward_moe.cu:2207-2210`), branch on `cfg.moe_router_bias_norm` (or arch enum). Today this is **inline if**, not a virtual call. |
+| 16 | `src/graph/executor_attention.cu` | +5-50 | Only if Qwen3.5-A3B has GDN+attention layers with new attention tweak (e.g. partial RoPE). Per `qwen35_partial_rope_fix_2026_04_23` memo, partial RoPE is already handled. |
+| 17 | `src/graph/executor_pre_dequant.cu` | +10-30 | Calibration scales need a per-layer cache slot if dequant needed. |
+| 18 | `src/runtime/engine.cpp:828-880, 1864-1911` | +5-15 | If new arch has chunked-prefill quirks: add to/remove from `supports_chunked_prefill_()` reject list. |
+| 19 | `src/memory/gdn_state.cu`, `src/memory/ssm_state.cu` | 0 | Reuse — Qwen3.5 GDN already supported (see `qwen35_gdn.md` memo). |
+| 20 | `src/runtime/vram_budget.cpp:56-70` | 0-5 | If A3B expert count / shape differs, may need an exception. |
+| 21 | `src/runtime/storage_planner.cpp` | +0-10 | Only if new tensor kind needs a non-default tier. |
+| 22 | `src/runtime/presets.cpp` | +1 row | Per-arch CLI / server preset — `--preset qwen35-a3b`. |
+| 23 | **Tests:** `tests/test_e2e_models.cpp` | +60-120 (new `Qwen35A3BModelTest` fixture) | Mirror `GDNModelTest` (l. 144). New env var `IMP_TEST_MODEL_QWEN35_A3B`. |
+| 24 | `tests/test_moe.cu` | +30-80 | New routing-variant unit test. |
+| 25 | `tests/test_chunked_prefill.cu` | +0-30 | Only if chunked-prefill behavior differs. |
+| 26 | `tests/perf_baseline.json` | +1 row | If user wants a CI gate for the new arch. |
+| 27 | `docs/usage.md`, `docs/roadmap.md` | +5-15 | Document new `--arch qwen35_a3b` and any new env vars. |
+
+**Total file count touched: 25-27 files.** **LOC delta: ~280-650** (with
+the kernel-side routing variant as the dominant chunk).
+
+### 1.2 Where does the new routing logic plug in?
+
+There is **no clean seam** today.
+
+- The routing logic is invoked inside `executor_forward_moe.cu:2207-2210`
+  via a single `moe_topk_gating(...)` call, which itself dispatches inside
+  `compute/moe_routing.cu:26` (`topk_gating_kernel` already supports a
+  `score_bias` for sigmoid models).
+- A new routing variant must either (a) add another kernel + branch in
+  `executor_forward_moe.cu`, OR (b) extend `topk_gating_kernel` with another
+  parameter and pass-through.
+- The 5 dispatch paths inside `executor_forward_moe.cu` (header at l.5-10:
+  decode_fast, TC fused, scalar fused, batch path, shared expert path) all
+  call into routing in slightly different ways. If the new variant
+  applies at decode time, you need to update **5 sites**. If only at prefill,
+  you need to update at least 2.
+
+The smell: there is no `MoeRouter` virtual interface. Compare with the
+`ModelArchAdapter` proposed in Phase 3 §11 Refactor #1 — the same problem.
+
+### 1.3 Magic numbers / hardcoded shapes / hardcoded dtype tables
+
+- `compute/moe_routing.cu:533` (`moe_fused_permute_kernel`) — single-block
+  scan, `__launch_bounds__(256)`. **Hard-codes n_experts ≤ 1024.** If
+  Qwen3.5-A3B has, say, 384 experts (as Qwen3-Coder-30B-A3B does, which
+  works), fine. If it has > 1024, this kernel breaks silently.
+- `quant/nvfp4_gemm.cu:855` — `gemv_nvfp4_moe_decode_kernel` with
+  `__launch_bounds__(128, 12)` is the MoE decode hot kernel (Phase 2 §2.3).
+  Already shape-generic, but the SF-stride math assumes group_size = 16
+  (NVFP4 default).
+- `graph/executor_pre_dequant.cu` — the `cache_moe_native_nvfp4` lambda
+  (l. 1509+ per `qwen36_status_2026_05_02` memo) has self-tracked logical
+  budget rather than `cudaMemGetInfo` polling. New arches with > 120 packed
+  expert tensors hit the budget if not budgeted in `vram_budget.cpp:56-70`.
+- `model/tensor_kind_table.cu:22-50` — hardcoded per-kind storage tiers
+  (`StorageTier::NVFP4` for `EXPERT_GATE/UP/DOWN`). A new kind that should
+  default to FP8 would need an explicit entry.
+- `executor_workspace.cu:80, 119` — SSM workspace caps prefill `max_tokens`
+  to 256 for SSM/GDN+MoE hybrids (per `nemotron_h_moe_imp_broken_2026_05_04`
+  memo). New hybrid arch inherits this cap silently.
+
+### 1.4 Tests to add
+
+- **New gtest fixture** in `tests/test_e2e_models.cpp` (mirror
+  `GDNModelTest` at l. 144, ~80 LOC). Gated on a new env var
+  `IMP_TEST_MODEL_QWEN35_A3B`.
+- **`tests/test_moe.cu`** — extend with a `RoutingSigmoidWithBiasNorm`
+  test if the variant is non-trivial.
+- **NOT parameterizable today.** The `tests/test_e2e_models.cpp` pattern
+  is **per-arch fixture class** with a per-arch env var. There is no
+  `INSTANTIATE_TEST_SUITE_P` over a list of model paths. Adding a new
+  parameterization framework (e.g. `tests/test_e2e_param.cpp` over a
+  config table) would unblock adding new arches without copy-paste — but
+  that doesn't exist today.
+- **Perf baseline:** to add the model to the CI gate, also add a row to
+  `tests/perf_baseline.json` (file format per CLAUDE.md). Decode numbers
+  only — prefill is unstable per CLAUDE.md "pp512 varies up to 2.6×".
+
+### 1.5 Effort estimates
+
+| Persona | Wall-clock | Notes |
+|---|---:|---|
+| **Competent contributor (knows codebase)** | **2-4 days** | If routing variant is a kernel parameter tweak (sigmoid + bias-norm-add): half a day. If it requires a new fused kernel and the per-token calibration: 2-3 days. The 25-file diff is mostly mechanical (enum + registry + matcher rules + 1 test fixture); the kernel work is the long pole. |
+| **New contributor on day 7** | **2-3 weeks** | Day 1-3: read CLAUDE.md, CONTRIBUTING.md, find the touch points (no central "Adding a new model" doc exists; `docs/roadmap.md` lists *what* is supported, not *how* to add). Day 4-7: get a first GGUF load working (probably stuck on `tensor_kind_matcher.cpp` not finding the new tensor names; debugging is `IMP_LOG_DEBUG` + grep). Week 2: get the forward pass to produce non-garbage by chasing `if (cfg.arch == ...)` branches in `executor_attention.cu` + `executor_forward_moe.cu` and discovering each by `git log -p`-ing the Qwen3.6 PRs. Week 3: chunked prefill + perf bench + tests. |
+
+---
+
+## 2. Simulated integration: Gemma 4 26B-A4B (new attention variant — already partially done)
+
+Today's Gemma-4 integration touched, by `git log` evidence and by the
+40-grep at `phase3_maint.md` §1.5: `executor_attention.cu` (14 branches),
+`executor_forward_moe.cu` (19 branches), `executor_forward.cu` (2
+branches), `engine.cpp` (5+ branches), `executor_workspace.cu` (1 branch),
+plus all the loader/registry plumbing. The work that landed was driven by
+seven separate memos: `gemma4_working_2026_04_14`, `gemma4_rope_freqs_fix`,
+`gemma4_chunked_prefill_2026_05_15`, `gemma4_q4km_vs_q8_2026_04_19`,
+`gemma4_paged_attention_hd512_bug` (archived), `gemma4_fp8_kv_2026_04_29`
+(archived), `gemma4_3120_token_vram_limit` (archived).
+
+### 2.1 Where do the *attention*-specific changes live (not the SWA / chunked-prefill bits)?
+
+Stripping out the SWA/chunked prefill (which `gemma4_chunked_prefill_2026_05_15`
+shipped), the surviving Gemma-4-attention tweaks are:
+
+| File:line | What it does |
+|---|---|
+| `src/graph/executor_attention.cu:161` | Gemma-4 hd-init guard — when `wq.data` present, allow non-default head_dim path. |
+| `src/graph/executor_attention.cu:310, 387` | FP32 accumulator promotion (per `gemma4_working_2026_04_14` MoE precision drift fix). |
+| `src/graph/executor_attention.cu:464, 472` | **Gemma-4 V=K compaction** (`wv.data == nullptr`, `v_norm_ones_buf_`) — Gemma-4 specific weight layout where V is reused from K. |
+| `src/graph/executor_attention.cu:493, 534` | SWA layer dispatch using `cfg.swa_layers`. |
+| `src/graph/executor_attention.cu:596, 658` | Per-layer rope_freqs override (per `gemma4_rope_freqs_fix` memo) — global layers consume llama.cpp's freq_factors with hd=512. |
+| `src/graph/executor_attention.cu:678` | Gemma-4 attention scale = 1.0 (not 1/sqrt(hd)). |
+| `src/graph/executor_attention.cu:893` | Post-attention norm placement (Gemma-style). |
+| `src/graph/executor_attention.cu:1198, 1274` | FP32 attention out + post-attention-norm Gemma branches. |
+
+That's 14 inline branches for what is morally **one design decision**:
+"Gemma-4 has dual head_dim, V=K layout, FP32 residual stream, rope_freqs
+on globals, no scaling, post-attn-norm." Each landed in its own
+PR after a separate bug.
+
+### 2.2 If Gemma-5 with a new attention variant showed up tomorrow
+
+A hypothetical Gemma-5 with, say, **per-layer rope theta cycling** + **K-norm
++ V-norm fused** + **a new attention-output bias term** would require
+touching:
+
+| # | File:lines | LOC delta | Why |
+|---:|---|---:|---|
+| 1-12 | All §1 items 1-12 (enum + registry + parser + chat template) | +30-50 | Same boilerplate, no shortcut. |
+| 13 | `src/model/model_config.h` | +5-10 | New per-layer fields (rope_theta_per_layer, attn_out_bias). |
+| 14 | `src/model/gguf_loader.cpp:1471, 1514` | +30-60 | New per-layer tensors and metadata keys. |
+| 15 | `src/model/weight_upload.cu` | +50-150 | Upload new per-layer tensors + bias. |
+| 16 | **`src/graph/executor_attention.cu`** — would need **8-15 new `if (cfg.arch == ModelArch::GEMMA5)` branches** | +100-300 | Per-layer rope-theta dispatch (no infrastructure today), K-norm+V-norm fusion (V-norm doesn't exist), attention output bias (no codepath). |
+| 17 | `src/compute/rope.cu` | +20-40 | New rope variant template. |
+| 18 | `src/compute/layernorm.cu` | +30-80 | V-norm if dtype/layout new. |
+| 19 | `src/runtime/engine.cpp:828` | +20-40 | Mirror Gemma-4 carve-outs (warmup skip, deterministic GEMM, NVFP4 decode). |
+| 20-25 | Tests, perf-baseline, docs | +120-200 | New `Gemma5ModelTest`, `Gemma5GraphsTest`. |
+
+**Total: 23-25 files; LOC delta ~410-980. Wall-clock for a competent contributor: 5-12 days.** Wall-clock for a new contributor on day 7: **3-5 weeks** because Gemma-style layout (V=K compaction, dual head_dim, FP32 residual) is famously the hardest area in the codebase per the memos.
+
+### 2.3 Different from §1?
+
+**Yes, in two ways:**
+
+1. **Quantitatively** — §1 (Qwen3.5-A3B) reuses GDN + MoE + sigmoid-gating
+   that already exist. Hypothetical Gemma-5 introduces 3 new attention-side
+   features that have **no codepath today**, so the diff is dominated by
+   **net-new kernel work**, not registry boilerplate.
+2. **Architecturally** — §1's per-layer routing variant has at least a
+   single integration point (`moe_topk_gating` at `executor_forward_moe.cu:2207`).
+   §2's per-layer rope theta + V-norm would need to thread a new
+   per-layer-tensor field through 4 call sites in `executor_attention.cu`
+   (QKV proj, RoPE fused, RoPE separate, KV-write+RoPE) — and each one
+   has its own dtype overload set.
+
+### 2.4 Where is "the attention variant for arch X" decided today?
+
+**Nowhere centrally.** It is decided at every read site. Concrete:
+
+- "Attention scale" — `executor_attention.cu:678`:
+  `float scale = (cfg.arch == ModelArch::GEMMA4) ? 1.0f : (1.0f / std::sqrt(hd));`
+- "Should I use rope_freqs?" — `executor_attention.cu:447-451` (per
+  `gemma4_rope_freqs_fix` memo) — set inside the QKV-proj branch.
+- "V exists or V==K?" — `executor_attention.cu:464` —
+  `if (cfg.arch == ModelArch::GEMMA4 && ly.wv.data == nullptr && ...)`.
+- "Use FP32 accumulator?" — `executor_attention.cu:310, 387, 1198` —
+  three separate branches, each with its own `gemma4 && using_fp32_accum`
+  predicate.
+
+This is the canonical "polymorphism-by-if-ladder" smell. Phase 3 §11
+Refactor #1 (`ModelArchAdapter`) is the proposed cure; until that lands,
+adding a new attention variant means touching 8-15 inline branches.
+
+### 2.5 Effort estimates — Gemma-5
+
+| Persona | Wall-clock | Notes |
+|---|---:|---|
+| **Competent contributor** | **5-12 days** | Net-new kernels (rope variant + V-norm + attn-out bias) are the long pole. The 14 inline branch additions are mechanical given Gemma-4 as template. |
+| **New contributor on day 7** | **4-6 weeks** | Same memos exist for Gemma-4, but the contributor would have to read all 7 of them to understand what *not* to break. Also: Gemma-style models are uniquely sensitive to numerical drift (per `gemma4_layer_diff_2026_04_17` memo + dump infrastructure at `executor_forward.cu:481-493`). |
+
+---
+
+## 3. Simulated integration: hypothetical Mamba2-Hybrid (Nemotron-H-style)
+
+The hardest of the three. Nemotron-H is **already nominally supported** —
+`ModelArch::NEMOTRON_H_MOE` exists at `model_arch.h:12`, has a registry
+entry at `model.cpp:124-125`, parses `nemotron_h_moe` GGUF and
+`NemotronHForCausalLM` HF strings. **It is also archived as broken** per
+`nemotron_h_moe_imp_broken_2026_05_04` memo: silent prefill hang at chunk
+#3+ (>~470 prompt tokens) due to SSM-state-handoff between prefill chunks.
+
+### 3.1 Map of the work
+
+If the goal were **finishing** Nemotron-H (not adding it from scratch),
+i.e. fixing the ~470-token cliff:
+
+| Area | File:lines | LOC delta | Why |
+|---|---|---:|---|
+| **SSM state handoff** | `src/memory/ssm_state.cu` (~270 LOC, init only); `src/graph/executor_ssm_gdn.cu` (run_ssm); `src/runtime/engine.cpp` chunked-prefill loop (~l. 1935-2050) | +50-200 | Per memo: state at end of chunk N must persist into chunk N+1. Today the state buffer is per-sequence × per-SSM-layer, but the chunk-boundary write/read pattern is broken. |
+| **Workspace cap removal** | `src/graph/executor_workspace.cu:80, 119` | +5-20 | "Capping max_tokens 4096 → 256 for SSM/GDN hybrid" — SSM workspace cap forces small chunks; lifting it requires shape-aware allocation. |
+| **Graph capture across chunks** | `src/runtime/cuda_graph.cu`, `src/runtime/engine_graph_decode.cpp` | +30-80 | Today decode-graph captures fine for SSM at n=1 (per `cuda_graphs_moe_works_2026_05_07`). Prefill capture probably re-instantiates per-chunk; if that's the deadlock, change to per-chunk-shape pool. |
+
+If the goal were **adding** a fresh Mamba2-only (non-MoE, non-hybrid) arch:
+
+| Area | File:lines | LOC delta | Why |
+|---|---|---:|---|
+| Loader plumbing | §1 items 1-12 | +30-50 | Boilerplate. |
+| **SSM kernel deltas vs GDN** | `src/compute/ssm.cu` (~480 LOC, exists); `src/compute/gdn.cu` (~410 LOC) | +0-200 | Mamba2 SSM scan kernel exists at `ssm.cu:1` and is shared with Nemotron-H. A fresh Mamba2 variant (e.g. Mamba-2.5 with new gate scheme) would need a new kernel. |
+| State subsystem | `src/memory/ssm_state.{cu,h}` | +50-100 | New state shape (e.g. interleaved chunked-state) — see §3.2 for the polymorphism gap. |
+| Forward graph schedule | `src/graph/executor_forward.cu:380-417` | 0 | The `layer_has_*` schedule already supports per-layer SSM/attention typing; tensor presence drives dispatch. |
+| Chunked-prefill | `src/runtime/engine.cpp:1864-1911` | +5-10 | New arch enters/exits the reject list. |
+| Tests | `tests/test_e2e_models.cpp` | +100 | New fixture. |
+
+### 3.2 State management: GDN vs Mamba2 cache shape
+
+- **GDN cache** (`src/memory/gdn_state.h:15-50`):
+  `init(n_gdn_layers, max_sequences, n_heads, head_dim, state_dim, dtype)`.
+  Per-layer recurrent state; allocated once per session.
+- **SSM cache** (`src/memory/ssm_state.h:15-55`):
+  `init(n_ssm_layers, max_sequences, conv_channels, conv_kernel, n_heads, head_dim, state_dim, dtype)`.
+  Per-layer conv1d state + ssm scan state; shape differs from GDN.
+
+**The two are entirely independent classes.** No common base. Per
+`runtime/engine.cpp:1410`, the engine sets a separate boolean
+`has_pure_ssm_layers_` based on layer-presence count.
+
+**Polymorphism gap:** A fresh hybrid arch with a *different* recurrent
+state layout (e.g. RWKV-7 cache, RetNet retention state) would need a
+*third* state class — there is no `RecurrentState` interface to inherit
+from. Adding the third class means:
+- New `src/memory/foo_state.{cu,h}` (~200-400 LOC).
+- New field `foo_state_` in `Engine` and `GraphExecutor` (~5 sites each).
+- New init / reset / swap call sites (5-10 places).
+- New VRAM budget arm in `vram_budget.cpp:56-70` (~10 LOC).
+
+### 3.3 Graph capture for hybrid layer schedule
+
+Today's MoE-prefill-graphs work (per `moe_prefill_graphs_plan_2026_05_10`)
+covers Phase 3 (+11-39%) and partial Phase 4. The hybrid case:
+
+- **Decode-graph** captures cleanly today on hybrid (per
+  `cuda_graphs_moe_works_2026_05_07` — Qwen3.5-GDN + Qwen3.6-MoE both
+  graph-replay fine).
+- **Prefill-graph** has the SSM-state-handoff bug at chunk boundaries
+  (per the Nemotron-H archived memo). A fresh hybrid arch would inherit
+  this bug.
+- **Per-layer schedule diversity** (e.g. 24 SSM + 8 attn + 32 FFN in
+  Qwen3.5; or different ratios in a new arch) is handled by `layer_has_*`
+  predicates without code changes — that part is fine.
+
+### 3.4 Loader story: per-layer typing
+
+Today's loader **does** support per-layer typing — the assumption of
+"homogeneous architecture" doesn't really exist:
+
+- `src/model/model_config.h:27-31` —
+  `n_kv_heads_per_layer`, `d_ff_per_layer`, `head_dim_per_layer`,
+  `n_heads_per_layer`, `swa_layers`. All per-layer, populated by GGUF
+  loader for hybrid models.
+- `tensor_kind_matcher.cpp:60-90` matches tensors by name pattern
+  (e.g. `blk.X.ssm_in.weight`) regardless of arch — so the *which layers
+  have SSM* fact emerges from tensor presence.
+
+So a new hybrid loader fits the existing pattern. The friction is in
+chunked-prefill + state handoff (§3.1, §3.2), not in loading.
+
+### 3.5 What blocked Nemotron-H last time
+
+Per `nemotron_h_moe_imp_broken_2026_05_04` (archived) memo + verified
+code evidence:
+
+- **Initially:** IMA + cuBLAS status=13 + lm_head crash. Resolved by
+  commit `5b2c5db` (route SSM in_proj/out_proj through CUTLASS NVFP4
+  fast-path; the slow fallback `gemm_nvfp4()` allocated ~52 MiB scratch
+  per-layer per-GEMM-call → IMA).
+- **Surviving:** silent prefill hang at chunk #3+ (>~470 prompt tokens).
+  Per-chunk SSM-state-handoff broken; engine never returns; chunk #2 stays
+  in same graph, chunk #3 triggers a new capture-pair that deadlocks.
+- **Workspace cap:** `executor_workspace.cu:80, 119` caps `max_tokens`
+  to 256 for SSM/GDN+MoE hybrids. Per `nemotron_h_moe_reserve_env_2026_05_07`
+  memo, raising this cap is non-trivial because the SSM workspace is
+  budgeted statically.
+
+Is the blocker still in place? The memo is 11 days old (cut off
+2026-05-05). The current `executor_workspace.cu:80` still contains the
+cap. The current `engine.cpp:1864-1911` `supports_chunked_prefill_()`
+function does **not** reject hybrid GDN+MoE archs (it allows QWEN35*,
+QWEN36_MOE, NEMOTRON_H_MOE per the comment) — so chunked prefill is
+allowed at the API level, but the actual SSM-state handoff bug at
+chunk-boundary is unresolved per code inspection (no PR to
+`memory/ssm_state.cu` since 2026-05-04). **Blocker still in place.**
+
+### 3.6 Effort estimate plus confidence band
+
+| Task | Wall-clock | Confidence |
+|---|---:|---|
+| **Finish Nemotron-H (chunk-boundary state fix)** | **2-6 weeks** | LOW-MEDIUM. Nature of the bug is silent hang; debugging requires nsys traces of cross-chunk graph re-instantiation. The fix may be 50-200 LOC but finding it could take a week. |
+| **Add fresh Mamba2-only arch** (no MoE, no hybrid) | **1-2 weeks** | MEDIUM. Reuses existing `ssm.cu` + `ssm_state.cu`. Mostly registry + 1 fixture. Risk: if the new SSM has different state shape, new cache class needed. |
+| **Add fresh hybrid arch with non-Mamba2 recurrent layer (e.g. RWKV-7)** | **8-16 weeks** | LOW. Net-new state class, net-new kernel, net-new chunked-prefill bring-up, plus inheriting the unfixed Nemotron-H chunk-boundary cliff. |
+
+The Mamba2-Hybrid family carries a structural tax that the dense / MoE
+families don't.
+
+---
+
+## 4. Friction-point catalog (ranked, deduplicated)
+
+```
+1. Per-architecture behavior is an `if`-ladder, not a polymorphism seam
+   [hit in: §1 / §2 / §3]  [severity: H]
+   [root location: src/graph/executor_attention.cu (14 GEMMA4 branches),
+    src/graph/executor_forward_moe.cu (19), src/graph/executor_forward.cu (2),
+    src/runtime/engine.cpp:828, 1663, 1893, 1899]
+   Problem: every per-arch tweak is a single-line `if (cfg.arch == ...)`,
+     interleaved with code that runs for all arches. Adding a new arch
+     means hunting these branches and copy-pasting them with the new enum.
+     Removing an arch is unsafe — branches may be load-bearing for
+     other arches via the `else` side.
+   Fix shape: introduce ModelArchAdapter virtual interface (Phase 3 §11
+     Refactor #1); each arch is one .cu file (~400 LOC).
+   Cost to fix: 1-2 weeks (per Phase 3 estimate).
+   Unblocks: §1 (clean MoE routing seam), §2 (Gemma-5-style attention
+     variant lands in 1 file), §3 (hybrid state polymorphism gets a
+     parallel adapter pattern).
+
+2. Tests are per-arch fixtures + per-arch env vars (no parameterization)
+   [hit in: §1 / §2 / §3]  [severity: H]
+   [root location: tests/test_e2e_models.cpp:140-460 (PrimaryModelTest,
+    GDNModelTest, Gemma4ModelTest, Gemma4GraphsTest — each their own class,
+    each their own env var)]
+   Problem: cannot add a new arch test without copy-pasting an entire
+     fixture class. CI must export 4+ env vars before any e2e test runs;
+     adding model #15 means env var #15 + fixture #15.
+   Fix shape: a single `tests/test_e2e_param.cpp` with an INSTANTIATE_
+     TEST_SUITE_P over a model-table (path, expected-token, kv-dtype, etc).
+     Tests skip per-row when env var unset.
+   Cost to fix: 2-3 days.
+   Unblocks: every future arch (§1/§2/§3) gets free e2e coverage.
+
+3. No "Adding a new architecture" doc; learnings live in MEMORY only
+   [hit in: §1 / §2 / §3]  [severity: H]
+   [root location: docs/ has usage.md, sm120.md, performance.md, roadmap.md
+    — no integration guide. The 25+ memory files (gemma4_*, qwen35_gdn,
+    qwen36_status_*, nemotron_h_*) are the actual TODO log per Phase 3 §5.4]
+   Problem: a new contributor on day 1 has no map. Touch points discovered
+     by grep + git log + reading memos one at a time.
+   Fix shape: docs/integration.md with the §0 touch-point table + a
+     worked example (e.g. Qwen3 → Qwen3-Coder added X files).
+   Cost to fix: 2-4 hours.
+   Unblocks: new contributor day 7 → day 3.
+
+4. Tokenizer/chat-template family registry is closed-set
+   [hit in: §1 / §2]  [severity: M]
+   [root location: src/model/chat_template.cpp:71 (default_family_for_arch
+    switch); src/model/chat_template.h ChatTemplateFamily enum]
+   Problem: if a new arch needs a new chat family (e.g. Mistral-3 changed
+     theirs), the enum + switch + parser get touched. Today there are 7
+     families; some arches reuse (LLAMA→LLAMA3, GEMMA3+GEMMA4→GEMMA).
+   Fix shape: load the chat template from the GGUF/HF metadata directly
+     when present (the hand-rolled jinja.cpp can already evaluate it);
+     keep the enum as fallback.
+   Cost to fix: 1-2 days.
+   Unblocks: arches with novel chat formats (Llama-4 already had quirks
+     per `mistral_3_2_nvfp4_use_default_system_2026_04_28`).
+
+5. Tensor-name matcher is centralized but hard-codes naming conventions
+   [hit in: §1 / §2 / §3]  [severity: M]
+   [root location: src/model/tensor_kind_matcher.cpp:1-165]
+   Problem: new tensor names (e.g. `blk.X.expert_calibration_scale.weight`)
+     require explicit case additions. The matcher does NOT delegate to a
+     per-arch table — every arch's tensor names go through the same global
+     switch. Future arches may collide with name patterns.
+   Fix shape: per-arch matcher functions in a registry (similar to
+     ChatTemplate); fallback to global. Or: declarative table:
+     `{TensorKind::EXPERT_GATE, "blk.{layer}.ffn_gate_exps.weight"}`.
+   Cost to fix: 3-5 days.
+   Unblocks: arches with novel tensor naming (proven by Gemma-4's
+     ffn_pre_norm_2 / ffn_post_norm_1 / layer_out_scale).
+
+6. weight_upload.cu is one file with one giant function (2 092 LOC)
+   [hit in: §1 / §2]  [severity: M]
+   [root location: src/model/weight_upload.cu (1 public function,
+    everything anon-namespace, switch over 12 quant types × 4 archs)]
+   Problem: per Phase 3 §2 #10 — one file, two public functions, giant
+     switch. Adding a new tensor kind (e.g. EXPERT_CALIB_SCALE) requires
+     wedging it in the right anon-namespace function.
+   Fix shape: split per qtype family (Phase 3 §10 #18).
+   Cost to fix: 1-2 weeks.
+   Unblocks: §1 (new EXPERT_CALIB_SCALE kind in a focused file).
+
+7. Per-layer recurrent-state classes are not polymorphic
+   [hit in: §3]  [severity: H for Mamba2-Hybrid; M overall]
+   [root location: src/memory/ssm_state.{h,cu} and
+    src/memory/gdn_state.{h,cu} are independent classes; no common base]
+   Problem: a third hybrid (RWKV / RetNet / your own) means a third
+     parallel class + 5-10 new wiring sites in Engine/GraphExecutor.
+   Fix shape: RecurrentState abstract base; SSMState + GDNState inherit;
+     Engine holds vector<unique_ptr<RecurrentState>>.
+   Cost to fix: 1-2 weeks.
+   Unblocks: any non-Mamba2-non-GDN hybrid.
+
+8. SSM/GDN+MoE hybrid prefill chunk_size capped at 256, state handoff
+   broken across chunks
+   [hit in: §3]  [severity: H for hybrid arches]
+   [root location: src/graph/executor_workspace.cu:80, 119;
+    src/memory/ssm_state.cu (no cross-chunk handoff implemented);
+    nemotron_h_moe_imp_broken_2026_05_04 archived memo]
+   Problem: silent hang past ~470 prompt tokens for any SSM-hybrid arch.
+     Documented blocker, unfixed.
+   Fix shape: cross-chunk state persist at engine.step_prefill chunk
+     boundary; remove static workspace cap once dynamic.
+   Cost to fix: 2-6 weeks (LOW confidence per §3.6).
+   Unblocks: Nemotron-H, future hybrid arches with prompts > 470 tokens.
+
+9. WeightCaches god-struct + 21-param dispatch + dual dispatch tables
+   [hit in: §1 / §2 (kernel arm), §3]  [severity: M for new arches]
+   [root location: src/graph/executor.h:286 (WeightCaches struct);
+    src/graph/executor_kernels.cu:2003-2269 (gemm_dispatch_impl);
+    src/compute/weight_dispatch.cu:73-125 (parallel dispatch)]
+   Problem: any new qtype (e.g. INT3, INT2, BFP16) lands in 6 cache maps,
+     gemm_dispatch_impl arm, weight_dispatch.cu arm, executor_pre_dequant
+     populator. Phase 3 §11 Refactor #2 already designed the fix.
+   Fix shape: GemmKernel registry (one file per qtype).
+   Cost to fix: 2-3 weeks (Phase 3 estimate).
+   Unblocks: §1 (calibration-scale handling), future quant formats.
+
+10. CUTLASS / NVFP4 device-args path silently bypassed when da_cache
+    not populated; failure mode is per-layer "fallback to host loop"
+    [hit in: §1 (NVFP4 MoE arch)]  [severity: M]
+    [root location: src/graph/executor_forward_moe.cu:566-578 (per-layer
+     pre-cache); :601-613 (H2D fallback when cache miss);
+     qwen36_status_2026_05_02 memo (cache aborts at 16-22/120 entries
+     under VRAM pressure → CUDA Graph capture fails silently)]
+    Problem: new NVFP4 MoE arch with high expert count or VRAM pressure
+      hits the silent fallback; decode drops 5×. Failure logged at
+      INFO not ERROR.
+    Fix shape: hard-fail or upgrade to ERROR when per-layer cache aborts;
+      promote `vram_alloc_force()` pattern to default for prequant MoE.
+    Cost to fix: 2-3 days.
+    Unblocks: §1 (any future NVFP4 MoE arch survives VRAM-tight prod boxes).
+
+11. CUDA Graphs disabled on host-offloaded experts; no LRU prefetch
+    [hit in: §1 / §3 (any A3B-style high-expert-count model)]  [severity: M]
+    [root location: src/runtime/engine.cpp:1158-1164; speculative S7 in
+     phase2_perf.md §9; docs/roadmap.md:53]
+    Problem: model arches that don't fit on 32 GB are forced into
+      experts_on_host, which disables graphs (per §4.5 of Phase 2). New
+      arches inherit a 5× decode penalty silently.
+    Fix shape: device-side LRU prefetch with cudaMemcpyAsync overlap.
+    Cost to fix: 4-6 weeks.
+    Unblocks: any 50B+ MoE.
+
+12. Gemma-4 chunked-prefill exception; supports_chunked_prefill_()
+    arch reject list is hardcoded
+    [hit in: §1 / §2]  [severity: M]
+    [root location: src/runtime/engine.cpp:1864-1911]
+    Problem: each new arch must be either added to the reject list or
+      proven safe; the policy lives as inline `if (cfg.arch == ...)`.
+    Fix shape: per-arch capability bits on ModelArchAdapter (#1 above).
+      `arch_adapter->supports_chunked_prefill()` virtual.
+    Cost to fix: subsumed by #1.
+
+13. Per-arch storage tier in tensor_kind_table.cu hardcodes "this kind
+    always goes to NVFP4"; no per-arch override
+    [hit in: §1 / §2]  [severity: L]
+    [root location: src/model/tensor_kind_table.cu:22-50]
+    Problem: a new arch where (e.g.) ROUTER should be FP16 instead of
+      FP32 has no clean override. Today the only escape is the "qtype
+      override" path through weight_upload.cu, which is ad-hoc.
+    Fix shape: per-arch storage tier table (key by ModelArch×TensorKind).
+    Cost to fix: 1-2 days.
+    Unblocks: arches with non-default tier preferences.
+
+14. Engine carve-outs (warmup skip, deterministic GEMM, FP8 prefill flip)
+    are arch-coded
+    [hit in: §1 / §2]  [severity: M]
+    [root location: src/runtime/engine.cpp:828-880, 1663]
+    Problem: each carve-out is `if (cfg.arch == ModelArch::GEMMA4) ...`.
+      Generalizes from #1 to engine-level policy.
+    Fix shape: ModelArchAdapter::engine_policy_overrides() virtual that
+      returns a struct of bools (skip_warmup, deterministic_gemm, etc.).
+    Cost to fix: subsumed by #1.
+
+15. NVFP4 prequant loader has "Modelopt vs llm-compressor" dichotomy
+    surfaced as two boolean fields
+    [hit in: §1]  [severity: L]
+    [root location: src/model/model_config.h:81-86 (is_nvfp4_prequant +
+     is_llm_compressor_nvfp4); src/model/llm_compressor_loader.cpp]
+    Problem: Modelopt and llm-compressor differ on whether
+      weight_global_scale is a multiplier or divisor; future quant
+      vendor (e.g. AWQ-NVFP4 hybrid) needs a third boolean.
+    Fix shape: enum NvFP4ScaleConvention { MODELOPT, LLM_COMPRESSOR,
+      AWQ_HYBRID, ... } instead of N boolean flags.
+    Cost to fix: 4-8 hours.
+    Unblocks: clean third-vendor support.
+
+16. moe_routing.cu single-block scan caps n_experts ≤ 1024
+    [hit in: §1 (if a future MoE has >1024 experts; Mixtral-style 8
+     experts is fine, Qwen3-Coder 384 fine; >1024 may show up)]
+    [severity: L today, M for very-large-MoE]
+    [root location: src/compute/moe_routing.cu:533 (moe_fused_permute_kernel,
+     __launch_bounds__(256))]
+    Problem: silent break at >1024 experts; documented in Phase 2 §6.2.
+    Fix shape: multi-block scan with two-pass exclusive-sum.
+    Cost to fix: 3-5 days.
+    Unblocks: very-large-MoE arches.
+```
+
+---
+
+## 5. Ideal-state proposal: "<500 LOC = working model"
+
+### 5.1 Proposed `model/` plugin interface
+
+Header `src/model/arch_plugin.h` (sketch ≤ 80 LOC):
+
+```c++
+#pragma once
+#include "core/tensor.h"
+#include "model/model_config.h"
+
+namespace imp {
+
+struct ArchPlugin {
+    virtual ~ArchPlugin() = default;
+
+    // === Identity ===
+    virtual ModelArch          arch() const = 0;
+    virtual const char*        name() const = 0;
+    virtual int                c_api_id() const = 0;
+    virtual std::vector<std::string> gguf_arch_strings() const = 0;
+    virtual std::vector<std::string> hf_arch_classes() const = 0;
+    virtual ChatTemplateFamily default_chat_family() const = 0;
+
+    // === Loader hooks ===
+    // Register tensor-name matchers (called once at static init time).
+    virtual void register_tensor_kinds(TensorKindMatcher& m) const {}
+    // Apply arch-specific defaults to ModelConfig after metadata is read.
+    virtual void apply_config_defaults(ModelConfig& cfg) const {}
+    // Optional: reject obviously-bad config (n_layers etc).
+    virtual bool validate_config(const ModelConfig& cfg, std::string* err) const { return true; }
+
+    // === Forward-pass behavior ===
+    struct AttentionPolicy {
+        bool   v_equals_k                 = false;
+        float  attention_scale_override   = 0.0f;   // 0 = use 1/sqrt(hd)
+        bool   fp32_residual              = false;
+        bool   fp32_attn_out              = false;
+        bool   needs_per_layer_rope_freqs = false;
+        int    sliding_window_default     = 0;
+        bool   use_qk_norm                = false;
+    };
+    virtual AttentionPolicy attention_policy() const { return {}; }
+
+    struct MoePolicy {
+        bool sigmoid_gating         = false;
+        bool expert_weights_norm    = false;
+        bool router_bias_norm_add   = false;
+        bool fp32_router_gate       = false;
+        bool fp32_expert_down       = false;
+        int  routing_kernel_variant = 0;       // 0 = default topk-softmax
+    };
+    virtual MoePolicy moe_policy() const { return {}; }
+
+    struct EnginePolicy {
+        bool skip_warmup             = false;
+        bool force_deterministic_gemm = false;
+        bool disable_fp8_prefill     = false;
+        bool supports_chunked_prefill = true;
+        int  prefill_chunk_default    = -1;     // -1 = auto
+    };
+    virtual EnginePolicy engine_policy() const { return {}; }
+};
+
+class ArchRegistry {
+public:
+    static ArchRegistry& instance();
+    void                  add(std::unique_ptr<ArchPlugin>);
+    const ArchPlugin*     find(ModelArch) const;
+    const ArchPlugin*     find(const std::string& gguf_or_hf) const;
+};
+
+}  // namespace imp
+```
+
+Each plugin lives in **one file** under `src/model/plugins/`:
+`qwen35_a3b.cpp`, `gemma4.cpp`, `nemotron_h.cpp`. Static registration at
+namespace scope:
+
+```c++
+namespace { struct Reg { Reg() { ArchRegistry::instance().add(std::make_unique<Qwen35A3BPlugin>()); } } reg_; }
+```
+
+### 5.2 How does it interact with `compute/`?
+
+Per Phase 3 §11 Refactor #2 (`GemmKernel` registry): each per-qtype kernel
+lives in `src/compute/gemm_kernel_*.cu` and registers itself.
+
+Plugins **do not include compute headers**. They only describe behavior
+(`AttentionPolicy`, `MoePolicy`, `EnginePolicy`). The executor reads the
+policy and dispatches to the appropriate generic kernel. Any net-new
+kernel work is a separate PR in `compute/`, not in the plugin.
+
+### 5.3 How does it interact with `graph/`?
+
+`GraphExecutor` carries a `const ArchPlugin* plugin_` (from the loaded
+model). All `if (cfg.arch == ModelArch::GEMMA4)` branches collapse into
+`if (plugin_->attention_policy().fp32_residual)`, etc. Phase 3 §11
+Refactor #1's `ModelArchAdapter` is essentially the runtime side of this
+plugin interface.
+
+### 5.4 What lives in the plugin, what stays central?
+
+| Lives in plugin | Stays central |
+|---|---|
+| Identity (name, enum, GGUF/HF strings) | Public C-API (`include/imp/types.h`) — generated from the enum, but the enum still exists |
+| Per-arch defaults (rope_neox, embed_scale, sigmoid_gating) | `ModelConfig` struct (data only) |
+| Tensor-name matcher rules | `TensorKindMatcher` engine |
+| Attention policy (V=K, FP32 residual, scale override) | `executor_attention.cu` reads policy and acts |
+| MoE routing variant id | `executor_forward_moe.cu` dispatches on id |
+| Chat template family | `ChatTemplate` resolves family, then evaluates Jinja |
+| Engine policy overrides (skip warmup, deterministic GEMM) | `Engine` reads policy at init |
+| **NOT in plugin:** | |
+| Kernel implementations | `compute/` |
+| Recurrent state classes (SSMState/GDNState/...) | `memory/`, with `RecurrentState` base — but the *picking* of which state class goes by tensor presence, not plugin |
+| Loader binary parsers (GGUF, SafeTensors) | `model/gguf_loader.cpp`, `model/safetensors_loader.cpp` — they call into plugin for arch-specific bits |
+
+### 5.5 Concrete sketch — `model/plugins/qwen35_a3b.cpp` (~110 lines)
+
+```c++
+#include "model/arch_plugin.h"
+namespace imp {
+class Qwen35A3BPlugin : public ArchPlugin {
+public:
+    ModelArch          arch() const override          { return ModelArch::QWEN35_MOE; }
+    const char*        name() const override          { return "qwen35moe_a3b"; }
+    int                c_api_id() const override      { return /*IMP_ARCH_QWEN35_MOE*/ 11; }
+    std::vector<std::string> gguf_arch_strings() const override {
+        return {"qwen35moe", "qwen3.5moe_a3b"};
+    }
+    std::vector<std::string> hf_arch_classes() const override {
+        return {"Qwen3_5MoeForCausalLM", "Qwen3_5MoeForConditionalGeneration"};
+    }
+    ChatTemplateFamily default_chat_family() const override {
+        return ChatTemplateFamily::CHATML;
+    }
+
+    void register_tensor_kinds(TensorKindMatcher& m) const override {
+        // Hybrid GDN+MoE; reuses default rules. Add A3B calibration tensor:
+        m.add_pattern(R"(blk\.(\d+)\.expert_calibration_scale\.weight)",
+                      TensorKind::EXPERT_CALIB_SCALE);
+    }
+
+    void apply_config_defaults(ModelConfig& cfg) const override {
+        cfg.rope_neox = true;
+        // GDN already detected by tensor presence; nothing extra here.
+        cfg.moe_sigmoid_gating  = true;       // a3b variant
+        cfg.expert_weights_norm = true;
+    }
+
+    AttentionPolicy attention_policy() const override {
+        AttentionPolicy p;
+        p.use_qk_norm = true;                   // Qwen3-style per-head RMSNorm
+        return p;
+    }
+
+    MoePolicy moe_policy() const override {
+        MoePolicy p;
+        p.sigmoid_gating          = true;
+        p.expert_weights_norm     = true;
+        p.routing_kernel_variant  = 1;          // sigmoid + bias-norm-add
+        return p;
+    }
+
+    EnginePolicy engine_policy() const override {
+        EnginePolicy p;
+        p.supports_chunked_prefill = true;       // hybrid GDN+MoE allowed
+        p.prefill_chunk_default    = 256;        // safe per existing cap
+        return p;
+    }
+};
+namespace { struct Reg { Reg() {
+    ArchRegistry::instance().add(std::make_unique<Qwen35A3BPlugin>());
+}} reg_; }
+}  // namespace imp
+```
+
+That's the entire plugin: ~75 lines of behavior + ~10 lines of registration.
+
+### 5.6 Best first migration to validate the design
+
+**Qwen3 (`ModelArch::QWEN3`).** Reasons:
+
+- Smallest existing plugin surface — uses CHATML, default GDN-free,
+  no per-arch quirks beyond `top_k=20` sampling default.
+- Migrating it does not interact with the GEMMA4 `if`-ladder (which is
+  the harder case — saved for migration #4).
+- Has the most coverage in CI (`PrimaryModelTest` uses Qwen3-4B-Q8_0).
+- Done correctly, **deletes ~20 lines** from `model.cpp`'s
+  `kArchRegistry`, **deletes ~5 lines** from `chat_template.cpp` switch,
+  **deletes ~3 entries** from `model.cpp:155` parse map.
+
+If the Qwen3 plugin migration succeeds without test regressions, the
+design is validated and the rest of the migrations are mechanical.
+
+---
+
+## 6. Roadmap to ideal state
+
+Sequenced by smallest-unblocking-first. Friction-points reverted are
+the §4 numbers in brackets.
+
+### Step 1 — Mechanical prep (3 days)
+
+- Add `docs/integration.md` documenting §0 touch points + worked example.
+- Convert `tests/test_e2e_models.cpp` to parameterized `INSTANTIATE_TEST_SUITE_P`
+  over a model-table (file + env var driving rows).
+- Centralize Modelopt/llm-compressor flag dichotomy (#15) into a small enum.
+
+**Files touched:** `docs/integration.md` (new, ~200 LOC), `tests/test_e2e_models.cpp`
+(rewrite, -300+200 LOC), `model_config.h`, `safetensors_loader.cpp`,
+`llm_compressor_loader.cpp` (~40 LOC).
+
+**Risk:** LOW. **Reverts:** §4 #2, #3, #15.
+
+### Step 2 — env-var + error-handling sweep (Phase 3 §11 Refactor #5) (4 days)
+
+Already proposed by Phase 3. Run before structural refactors. Centralizes
+all 16 IMP_* env reads into `RuntimeConfig`.
+
+**Files touched:** `runtime/config.{h,cpp}` + 16 grep-targeted TUs +
+`core/`, `memory/` (~40 sites for throw → return-bool).
+
+**Risk:** LOW. **Reverts:** none structural; unblocks #1 by reducing
+hot-path env noise.
+
+### Step 3 — `ArchPlugin` interface + first migration (Qwen3) (1 week)
+
+- Write `src/model/arch_plugin.h` (sketch §5.1).
+- Write `src/model/arch_registry.cpp` with `instance()`.
+- Migrate Qwen3 to plugin (`src/model/plugins/qwen3.cpp`).
+- Wire `chat_template.cpp:71` switch + `model.cpp:117 kArchRegistry` to
+  call `ArchRegistry::instance().find(arch)->...` first; fall back to
+  current code for un-migrated arches.
+
+**Files touched:** `model/arch_plugin.h` (new, ~120 LOC),
+`model/arch_registry.cpp` (new, ~60 LOC), `model/plugins/qwen3.cpp` (new,
+~80 LOC), `model/chat_template.cpp` (-10 +5), `model/model.cpp` (-8 +3).
+**LOC delta:** +250 net (mostly new infrastructure).
+
+**Risk:** MEDIUM (new abstraction; need test-suite green before
+migrating others).
+
+**Reverts:** §4 #4, #13 (per-storage-tier override now per-plugin).
+
+### Step 4 — Migrate remaining 13 arches (1.5 weeks)
+
+Mechanical. Each plugin is ~50-120 LOC. As each is migrated, the
+corresponding row in `kArchRegistry` and the corresponding case in
+`default_family_for_arch` is deleted.
+
+**Files touched:** 13 new plugin files (~80 LOC × 13 = 1 040 LOC); -80
+LOC across `model.cpp` and `chat_template.cpp`. Net **+960 LOC**, but
+single-arch surgery now lands in one file.
+
+**Risk:** LOW (each migration validated by existing tests).
+
+**Reverts:** §4 #5 partially (matcher rules can move per-plugin).
+
+### Step 5 — Refactor #1 from Phase 3 §11: ModelArchAdapter / hot-path branches (1.5 weeks)
+
+The plugin policy structs (`AttentionPolicy`, `MoePolicy`, `EnginePolicy`)
+become readable in the executor. Replace the 14+19+5 `if (cfg.arch ==
+ModelArch::GEMMA4)` branches with `plugin_->attention_policy().X` reads.
+
+**Files touched:** `executor_attention.cu` (-80 LOC, 14 branches replaced),
+`executor_forward_moe.cu` (-60 LOC, 19 branches replaced), `engine.cpp`
+(-20 LOC), `executor_workspace.cu` (-2 LOC), `executor_forward.cu` (-5 LOC).
+**LOC delta:** -150 net.
+
+**Risk:** MEDIUM. Each branch removal needs the Gemma-4 e2e test green.
+
+**Reverts:** §4 #1, #12, #14.
+
+### Step 6 — Refactor #2 from Phase 3 §11: GemmKernel registry (2 weeks)
+
+Mostly orthogonal to the plugin work; runs in parallel with Step 5.
+Collapses the dual dispatch tables and the `WeightCaches` god-struct.
+
+**Files touched:** `executor_kernels.cu` (-266 LOC), `executor.h` (-150
+LOC), `weight_dispatch.cu` (-100 LOC), 8 new `compute/gemm_kernel_*.cu`
+(~150 LOC each), `executor_pre_dequant.cu` (-500 LOC). **LOC delta:** -1
+000 net.
+
+**Risk:** MEDIUM. Lots of tests touch these surfaces.
+
+**Reverts:** §4 #6 (weight_upload still big but no longer giant-switch)
+indirectly, #9, #10 (the pre-cache populator becomes per-kernel).
+
+### Step 7 — `RecurrentState` polymorphism (1 week)
+
+Introduce abstract base for SSMState + GDNState; engine holds
+`vector<unique_ptr<RecurrentState>>`. Sets up for hybrid arch #3.
+
+**Files touched:** `memory/recurrent_state.h` (new, ~40 LOC),
+`memory/ssm_state.{h,cu}`, `memory/gdn_state.{h,cu}` (refactored, no LOC
+delta), `runtime/engine.{h,cpp}` (~10 sites), `graph/executor.h` and
+`graph/executor_ssm_gdn.cu` (~5 sites).
+
+**Risk:** LOW.
+
+**Reverts:** §4 #7.
+
+### Step 8 — Cross-chunk SSM state handoff fix (2-6 weeks)
+
+Real engineering work; per §3.6 LOW confidence. Open Nemotron-H bug.
+
+**Files touched:** `memory/ssm_state.cu`, `runtime/engine.cpp` chunked
+path, `graph/executor_workspace.cu` cap removal, `runtime/cuda_graph.cu`
+per-chunk pool.
+
+**Risk:** HIGH (silent hangs hard to debug).
+
+**Reverts:** §4 #8.
+
+### Step 9 — Long-tail cleanups (4-8 weeks scattered)
+
+#11 (host-LRU expert prefetch — 4-6 wks), #16 (multi-block routing scan
+— 3-5 days). Defer until a specific arch needs them.
+
+### Honesty check
+
+If 80% of the win comes from a 2-week refactor: **Steps 1-3 (~2 weeks)
+deliver about 70% of the extensibility win.** The plugin interface is
+the load-bearing change; the rest is a mechanical migration that one
+contributor can grind through over 2-3 weeks.
+
+If the answer were "12-week rewrite": no, it's not. The codebase is
+already well-organized at the directory layer (Phase 1 §1 confirms);
+the smell is in the inline if-ladders. Steps 1-5 (~5 weeks) deliver
+**95%** of the win.
+
+Steps 6-9 are real engineering work but they're **per-feature** (qtype,
+hybrid, chunk-state) rather than per-arch — i.e. their cost amortizes
+over future archs.
+
+---
+
+## 7. Current vs. target zero-to-working LOC
+
+Defended by the file-touch counts in §§1-3. "LOC for a new instance"
+counts the diff size for **adding a new model**, not building one
+from scratch.
+
+| Arch family | Today's LOC for new instance | After §6 Step 1 (docs+param-tests) | After Step 3 (plugin Qwen3 migrated) | After full ideal-state (Steps 1-7) |
+|---|---:|---:|---:|---:|
+| Dense LLaMA-style (LLaMA, Mistral, Qwen3) | ~60-120 LOC | same (60-120) | ~80-100 (plugin file) | **~50-80 LOC** (one plugin file, no chat_template patch needed) |
+| MoE (Qwen3-Coder / Mixtral / Qwen3.5-A3B style) | ~280-650 LOC (§1.1) | ~250-500 (less test boilerplate) | ~200-350 | **~120-200 LOC** (plugin + maybe one routing variant in compute/) |
+| Hybrid (Mamba2 + attn — Nemotron-H finished, fresh Mamba2-only) | ~400-800 LOC for new variant; many weeks of debugging for chunk-state cliff | ~350-700 + cliff still unresolved | ~250-500 + cliff resolved (Step 8) | **~200-300 LOC** (plugin + RecurrentState subclass when truly novel) |
+| New attention variant (e.g. hypothetical Gemma-5 §2) | ~410-980 LOC (§2.2) | ~370-900 | ~300-700 | **~150-300 LOC** if the variant fits the AttentionPolicy struct; ~400-600 if it requires a new kernel in compute/ |
+
+**Defense of the dense-LLaMA today number (60-120 LOC):** §1.1 items
+1-12 plus a chat-template family if needed. The bulk for §1's MoE
+example was the kernel work (item 13) and the test fixture (item 23);
+a vanilla LLaMA-derivative skips both.
+
+**Defense of the MoE today number (280-650):** §1 explicit count.
+Caveats: routing-variant kernel work depends entirely on what's
+"new". A pure-config arch (different defaults, no kernel) lands
+closer to 100 LOC; a genuine routing innovation needs 150-300 LOC of
+kernel code.
+
+**Defense of the hybrid number (400-800 + weeks):** §3 explicit. Adding
+the arch-registry plumbing is small; the actual blocker is the
+chunk-state cliff (#8) which adds several weeks.
+
+**Defense of the attention-variant number (410-980):** §2 explicit. The
+variation in the range tracks whether the attention quirk is expressible
+as a flag (cheap) or requires a new kernel (expensive).
+
+**Target column defense:** with the plugin interface in place, anything
+that **fits the existing kernel set** lands as a single-file plugin
+(~80 LOC) plus optional `EnginePolicy` overrides. Anything that
+requires a new kernel or new routing variant adds the kernel work but
+no longer requires hunting 25 files for the integration sites.
+
+---
+
+## Appendix A — Anchors for Phase 5 synthesis
+
+- Public C-API enum (extension point #1): `include/imp/types.h:24-39`
+- Single-source-of-truth ArchRegistry today: `src/model/model.cpp:117-135`
+- HF arch-class registry: `src/model/hf_config_loader.cpp:21-49`
+- Layer-kind dispatch (by tensor presence, not enum):
+  `src/graph/executor_forward.cu:380-417`,
+  `src/graph/executor_workspace_config.cu:287-301`
+- Hot-path arch branches:
+  - `src/graph/executor_attention.cu:161, 310, 387, 464, 472, 493, 534, 596, 658, 678, 821, 893, 1198, 1274` (14)
+  - `src/graph/executor_forward_moe.cu:187, 218, 224, 229, 262, 310, 324, 381, 1727, 1735, 1745, 1766, 1781, 1875, 1893, 1899, 2304, 2538, 2541` (19)
+  - `src/graph/executor_forward.cu:447, 513` (2)
+  - `src/runtime/engine.cpp:828, 1663, 1893, 1899` (4)
+- Chat template family switch: `src/model/chat_template.cpp:71-102`
+- Tensor-kind matcher: `src/model/tensor_kind_matcher.cpp:1-165`
+- Tensor-kind storage tier: `src/model/tensor_kind_table.cu:22-50`
+- Engine chunked-prefill arch reject list: `src/runtime/engine.cpp:1864-1911`
+- SSM workspace cap (Nemotron-H blocker): `src/graph/executor_workspace.cu:80, 119`
+- Recurrent state classes (no common base): `src/memory/ssm_state.h`,
+  `src/memory/gdn_state.h`
+- Tests per-arch-fixture pattern: `tests/test_e2e_models.cpp:140-460`
+
+## Appendix B — Memory-file anchor reuse
+
+| Memory file (slug) | Used in section |
+|---|---|
+| `gemma4_working_2026_04_14` | §2.1, §2.4 |
+| `gemma4_rope_freqs_fix` | §2.1, §2.4 |
+| `gemma4_chunked_prefill_2026_05_15` | §2 (preamble), §0.1 #8 |
+| `gemma4_layer_diff_2026_04_17` | §2.5 |
+| `qwen35_gdn` | §1.1 #16, §3.4 |
+| `qwen36_status_2026_05_02` | §1.3 (NVFP4 cache), §4 #10 |
+| `nemotron_h_moe_imp_broken_2026_05_04` (archived) | §3.5, §3.6, §4 #8 |
+| `nemotron_h_moe_reserve_env_2026_05_07` | §3.5 |
+| `cuda_graphs_moe_works_2026_05_07` | §3.3 |
+| `moe_prefill_graphs_plan_2026_05_10` | §3.3 |
+
+End of Phase 4 integrator audit.

--- a/review/phase5_synthesis.md
+++ b/review/phase5_synthesis.md
@@ -1,0 +1,653 @@
+# Phase 5 — Synthesis Master Report
+
+Anchor: `f58eb9e`. Target: sm_120a / RTX 5090 / GB202 only. Synthesizes
+`phase1_inventory.md` (751 LOC), `phase2_perf.md` (1 159 LOC),
+`phase3_maint.md` (1 283 LOC), `phase4_ext.md` (1 044 LOC).
+
+---
+
+## 0. TL;DR
+
+imp is an architecturally clean 90 KLOC sm_120a-only inference engine
+whose kernels sit at 90–100 % of the bandwidth-limited decode ceiling
+on every supported model class, but whose **prefill is 14.7× slower
+than vLLM on the identical CUTLASS NVFP4 grouped-GEMM template**, and
+whose **`src/graph/` is a 15.8 KLOC clay tablet** where every
+quantization format, every model architecture and every dispatch
+decision is encoded as inline `if`-ladders. The codebase is small
+enough to refactor, mature enough to merit it, and broken in exactly
+two places — perf (around the kernel, not in it) and extensibility
+(per-arch behavior is `if (cfg.arch == ModelArch::GEMMA4)` sprinkled
+in 40 sites).
+
+- **Biggest brecher-opportunity:** the `WeightCaches` god-struct +
+  21-param `gemm_dispatch_impl` + dual dispatch tables — collapsing
+  these into a `GemmKernel` registry wins on perf, maintainability
+  and extensibility simultaneously and removes ~1 000 LOC.
+- **Biggest streichkandidat:** `src/compute/mmq_q4k_v2.cu` (1 667 LOC,
+  −4 % E2E on Qwen3.6-35B Q4_K_M, opt-in only, 5 of 7 phase templates
+  dead at runtime).
+- Evidence anchored in `review/phase1_inventory.md`,
+  `review/phase2_perf.md`, `review/phase3_maint.md`,
+  `review/phase4_ext.md`.
+
+---
+
+## 1. Executive Summary
+
+**imp today.** A single-target sm_120a engine with healthy kernel
+choices (HMMA, mxf4nvf4 block-scaled FP4, FP8 m16n8k32, cluster
+launches with spread scheduling, PDL-augmented decode graphs), a thin
+24-function public C ABI, ~574 GTest tests, and a maintained MEMORY
+ledger of 60+ shipped / archived memos. Decode throughput on every
+supported model is within ~10 % of the bandwidth ceiling
+[P2 §1, §5.4]. The architecture maps the right way at the directory
+level (`core/` is a strict leaf, `compute → core` is the dominant
+edge), but the next layer up (`graph/`) is a god-layer that bends
+every other subsystem around itself.
+
+### Top-3 Wins (what is already brecher)
+
+- **Decode is at-the-roof bandwidth-bound.** `gemv_nvfp4_moe_decode_kernel`
+  with `__launch_bounds__(128, 12)` hits ~261 tok/s vs ~270 tok/s
+  ceiling on Qwen3-Coder NVFP4 [P2 §1, P2 §2.3 — `src/quant/nvfp4_gemm.cu:855`].
+- **Public C ABI is clean.** 24 functions, 4 headers, zero internal-
+  header leakage in `include/imp/` [P1 §2 — `include/imp/imp.h:1-142`].
+  The single public→internal bridge is `src/api/imp_internal.h:1`.
+- **Hot-loop allocator hygiene is honored.** No `cudaMalloc/cudaFree`
+  in true per-token loops; surviving lazy allocs are all monotonic-
+  grow-only with pre-warm hooks [P2 §2.6, P2 §5.6].
+
+### Top-3 Brüche (what must change)
+
+- **NVFP4 MoE prefill is 14.7× slower than vLLM on the same CUTLASS
+  template.** Same `MainloopSm120ArrayTmaWarpSpecializedBlockScaled`,
+  same `<128, 128, 128>` tile, same `Sm120` arch tag. The gap is
+  100 % around-the-kernel: activation-quant fusion missing, per-layer
+  launch overhead, scheduler maturity [P2 §6 — `src/compute/gemm_cutlass_grouped_3x.cu:30-86`,
+  `src/graph/executor_forward_moe.cu:559-563`].
+- **`graph/` is one 15.8 KLOC god-layer** with a 21-param
+  `gemm_dispatch_impl`, a 6-map `WeightCaches` god-struct, and a
+  duplicate per-qtype dispatch table in `compute/weight_dispatch.cu`
+  [P3 §1.2, P3 §2 #1, P3 §5.2 #4 — `src/graph/executor_kernels.cu:2003-2269`,
+  `src/graph/executor.h:286`, `src/compute/weight_dispatch.cu:73-125`].
+- **Per-arch behavior is `if (cfg.arch == ModelArch::GEMMA4)` × 40.**
+  14 in `executor_attention.cu`, 19 in `executor_forward_moe.cu`,
+  2 in `executor_forward.cu`, 5+ in `engine.cpp`. Adding a new arch
+  is a 25-file diff [P3 §1.5, P4 §0, P4 §2.4 —
+  `src/graph/executor_attention.cu:161,310,387,464,472,493,534,596,658,678,821,893,1198,1274`].
+
+### What changes in 90 days if everything below ships
+
+After 90 days of focused execution, `src/graph/` shrinks from 15.8 KLOC
+to ~10 KLOC; `executor_kernels.cu` shrinks from 2 327 to ~500 LOC;
+adding a new model arch becomes a single ~80-LOC file in
+`src/model/plugins/`; the NVFP4 MoE prefill gap closes from 14.7× to
+~3× (CUTLASS scheduler maturity ceiling); ~5 KLOC of validated dead
+code disappears from the runtime tree; the test suite gains
+parameterized per-arch coverage and at least one graph-capture
+sanity gate. The engine remains correct on every currently-supported
+model and gains a clean seam for the next ten.
+
+---
+
+## 2. Performance Roadmap (TTFT-first, decode second)
+
+Decode is at-the-roof; perf wins live almost entirely in **prefill**
+and **graph-capture coverage**. Decode-side wins are squeezed.
+
+### 2.1 Quick Wins (< 1 week each)
+
+| # | Action | File anchor | Expected impact | Effort | Risk | Cross-axis bonus |
+|---:|---|---|---|---|---|---|
+| 1 | Pre-warm `mmvq_kernel` scratch (kill lazy `cudaMalloc/Free`) | `src/graph/executor_kernels.cu:2175-2181` [P2 #8] | First-call latency drop; capture-safe everywhere | 1 hour | none | maint (one less lazy alloc) |
+| 2 | Delete stale wgmma docstring in FMHA header | `src/compute/attention_fmha_sm120.h:8-10` [P2 #7, P3 §10 #11] | 0 perf; un-misleads readers | 5 min | none | maint |
+| 3 | Add L2-streaming hint to LM-head GEMV | `src/graph/executor_forward.cu` (LM head call site) [P2 #10] | ≤1 % decode at long ctx | 1 hour | none | none |
+| 4 | Cache `IMP_NVFP4_FORCE_DEQUANT` and `IMP_LOG_GEMM_ALGO` env reads in `static const` | `src/compute/weight_dispatch.cu:106`, `src/compute/gemm.cu:326` [P3 §9.3] | Microscopic; removes per-call `getenv` | 30 min | none | maint |
+| 5 | Tighten per-layer SFA zero-memset in MoE prefill | `src/graph/executor_forward_moe.cu:557-558` [P2 #9] | ~2.3 ms / session | hours | none | none |
+| 6 | Gate BitDecoding TC residual-arg marshalling behind a single null-check | `src/graph/executor_attention.cu:1027-1083` [P2 #6] | Few µs/layer × n_decode_steps | hours | low | maint (kill 8 nullable trailing args from hot dispatch) |
+| 7 | Remove dead `mxfp4_act_sf` branch inside NVFP4 path | `src/graph/executor_kernels.cu:2083-2094` [P3 §5.1, P3 §10 #13] | 0 perf; -12 LOC, -1 nested arm | 30 min | none | maint |
+| 8 | Hard-fail (not log-INFO) when NVFP4 `da_cache` populates < 100 %  | `src/graph/executor_forward_moe.cu:566-578` [P4 #10] | Prevents silent 5× decode regression on VRAM-tight boxes | hours | low | ext (new NVFP4 MoE arches survive prod) |
+
+### 2.2 Medium (1-4 weeks each)
+
+| # | Action | File anchor | Expected impact | Effort | Risk | Cross-axis bonus |
+|---:|---|---|---|---|---|---|
+| M1 | **Fuse SwiGLU + activation-quant for MoE down-phase** (Bucket B of NVFP4 prefill gap) | `src/graph/executor_forward_moe.cu:559-563, 646-657` [P2 #1, P2 §6.9] | +5–10 % pp512 on Qwen3-Coder NVFP4; first slice of 14.7× gap | 2-3 days kernel + 2 days plumbing | low (numerics identical, prefill-only) | ext (clears the largest hot-path code surface) |
+| M2 | **Remove per-token D2H sync in `try_run_moe_gemma4_ggml_prefill`** | `src/graph/executor_forward_moe.cu:2121-2123` [P2 #3] | Restores prefill graph capture for Gemma-4 ggml fallback path; large for that path | 1-2 days | low (function only runs at n>1) | maint (kill one of the 5 D2H sync sites) |
+| M3 | **Complete MoE-prefill graph capture Phase 4** (per `moe_prefill_graphs_plan_2026_05_10`) | `src/graph/executor_forward_moe.cu:1131-1135, 1189-1192, 1996-2000` and `src/runtime/cuda_graph.cu:228-240` [P2 §4.5, P2 §6.8] | +10–15 % pp on NVFP4 MoE | 2-3 weeks | medium (multi-graph pool sizing) | maint (5 D2H sites collapse into one capture) |
+| M4 | **Bucket-allocate ctx_len in pow-2 buckets + enlarge `kMaxGraphPoolSize`** | `src/runtime/cuda_graph.cu:228-240`, `src/runtime/engine.cpp:2637, 2643` [P2 #4] | -10–30 ms per shape change at decode | days | low | maint |
+| M5 | **Cluster-launch on FMHA prefill** (DSMEM K-broadcast across cluster CTAs) | `src/compute/attention_fmha_sm120.cu` (no cluster today) [P2 §3.7, P2 §8 #1] | +10–20 % pp4096+ on FP16 prefill non-MoE | 2-3 weeks | medium (tile re-layout) | none |
+
+### 2.3 Big Bets (> 4 weeks)
+
+| # | Action | File anchor | Expected impact | Effort | Risk | Cross-axis bonus |
+|---:|---|---|---|---|---|---|
+| B1 | **Close the rest of the Qwen3-Coder NVFP4 prefill 14.7× gap** (Buckets A+B+C from P2 §6.8) | `src/compute/gemm_cutlass_grouped_3x.cu:150` + `src/graph/executor_forward_moe.cu:508-665` [P2 #2, P2 §6] | Realistic ceiling: 14.7× → ~3× (CUTLASS scheduler maturity is the residual) | 6-12 weeks staged | medium (CUTLASS upstream dependency on residual) | ext (everything in this work-stream lands in `executor_forward_moe.cu` which Phase 3 §11 #3 wants split anyway — wins maint as side effect) |
+| B2 | **Device-side LRU expert prefetch with cudaMemcpyAsync overlap** (re-enables CUDA Graphs on host-offloaded experts) | `src/runtime/engine.cpp:1158-1164` [P2 S7, P4 #11, `docs/roadmap.md:53`] | ~5× decode lift on >32GB MoE arches that today fall back to host experts | 4-6 weeks | medium (pinned-memory pool sizing) | ext (any 50B+ MoE arch inherits this win) |
+| B3 | **PV-FP4 in FMHA (Phase 3 mxfp4 block-scaled P×V)** with two-level accumulator (SageAttention3-style) | `src/compute/attention_fmha_sm120.cu:563`, `src/compute/attention_fmha_mxfp4_sm120.cu` [P2 §3.3, §8 #2] | +10–13 % attention-bound prefill | 4-6 weeks (quality A/B mandatory) | high (softmax-output FP4 quant has quality risk) | none |
+
+**"If we ship nothing else this quarter, ship this one":**
+
+- **B1 wins** the quarter. The 14.7× vLLM gap is the headline number
+  that defines whether imp is competitive. B2 is bigger per-feature
+  but only matters for one model class (>32GB MoE). B3 is risky and
+  upper-bound +13 %. **B1 (specifically: ship M1 first, then prefill
+  graph completion M3, then iterate to bucket A scheduler tuning) is
+  the only big bet that simultaneously moves the dominant TTFT
+  metric AND lands inside `executor_forward_moe.cu` which Phase 3
+  wants split anyway** — it pays the refactor cost as a side effect.
+
+- **Counter-justification for B2:** if business priority is
+  35B+ MoE serving (Qwen3.5/3.6, Llama-4, future 70B-MoE), B2
+  should jump the queue — a 5× decode lift dwarfs prefill in user-
+  visible TTFB on those models. **This is a maintainer call.**
+
+- **Counter-justification for B3:** PV-FP4 ships only if the quality
+  A/B harness is built first (which itself needs ~1 week). With
+  quality risk and only +13 % upside, this is not the quarter's win.
+
+---
+
+## 3. Maintainability Roadmap
+
+### 3.1 Streichliste (deletable today)
+
+Consolidated from P1 §7 + P3 §10 + P4 #15. Risk: lo = mechanical;
+med = test-pinned; hi = policy call.
+
+| # | Item | LOC | Risk | Source |
+|---:|---|---:|---|---|
+| 1 | `mmq_q4k_v2.cu` phase-template tails (5 of 7 instantiations) | 700 | lo | P3 §3.3, §10 #1 |
+| 2 | `mmq_q4k_v2.cu` entire TU (alt to #1; opt-in, −4 % E2E) | 1 667 | hi | P3 §10 #2 |
+| 3 | `gemm_grouped_nvfp4_smallM.cu` relocate to `tests/bench/` | 948 (move) | lo | P1 §7.5, P3 §10 #3 |
+| 4 | `attention_tc.cu` (subsumed by Blackwell variant) | 411 | med | P1 §7.4, P3 §10 #5 |
+| 5 | `gemm_moe_fused_tc.cu` (WMMA-based; needs profile confirm) | ~520 | med | P1 §7.5, P3 §10 #6 |
+| 6 | `gemm_capture_fp16_sm120.cu` (~600 LOC, dispatch unconfirmed) | ~600 | med | P1 §7.5, P3 §10 #7 |
+| 7 | `__CUDA_ARCH__ >= 1200` `#else` branches across 17 TUs | ~600 | lo | P1 §7.2, P3 §10 #8 |
+| 8 | Three runtime sm_120 availability flags | ~9 | lo | P1 §7.3, P3 §10 #9 |
+| 9 | `sm_80/90/100` comments + 1 dead auto-select branch | ~13 | lo | P1 §7.1, P3 §10 #10 |
+| 10 | Stale wgmma docstring (`attention_fmha_sm120.h:8-10`) | ~5 | lo | P3 §10 #11 |
+| 11 | Bench/probe TUs (relocate `src/compute/*_bench.cu` → `tests/bench/`) | 1 772 (move) | lo | P1 §7.8, P3 §10 #12 |
+| 12 | Dead `mxfp4_act_sf` branch | 12 | lo | P3 §5.1, §10 #13 |
+| 13 | Two dispatch tables merged into one | ~150 | med | P3 §1.2 #2, §10 #14 |
+| 14 | Dead `RuntimeConfig` fields (~8-10 of ~50, esp. Gemma-4 stabilization toggles) | ~50 | lo | P3 §9.5, §10 #15 |
+| 15 | `compute/preamble_gate.h` back-edge into `graph/quant_scratch.h` | 3 | lo | P3 §1.3, §10 #16 |
+| 16 | Move `compute/warp_reduce.cuh` + `compute/ptx92_utils.cuh` to `core/` | 0 net | lo | P3 §1.3, §10 #17 |
+| 17 | Drop `<cuda_runtime.h>` from `model/model.h` (forward-decl `cudaStream_t`) | -1 +5 | lo | P3 §4.3, §10 #18 |
+| 18 | `throw`-based error handling in `core/`, `memory/` (~12 sites + 40 callers) | 0 net (rewrite) | med | P3 §6.1, §10 #19 |
+| 19 | Convert hot-path `assert()` (55 sites) to logged-runtime check | 0 net | lo | P3 §6.4, §10 #20 |
+
+| Bucket | LOC |
+|---|---:|
+| Hard delete (lo risk) | **~1 942** |
+| Soft delete (med/hi — needs profiling or policy call) | **~3 198** |
+| Relocate (no LOC change in the binary) | **~2 720** moved |
+| **Grand total kahlschlag (post-de-dup, hard+soft+relocate)** | **~5 460 LOC = 6.1 % of `src/`** |
+
+This matches Phase 1 §7.9's independent estimate of ~5 390 LOC.
+
+### 3.2 Refactoring sequence
+
+Re-using Phase 3 §11's #1–#5 sequence, validated against Phase 4 §6
+roadmap for conflicts. **The numbering below is the master execution
+order**, not Phase 3's internal numbering.
+
+| Order | Refactor | Depends-on | Files touched | LOC delta | What becomes easier after |
+|---:|---|---|---|---:|---|
+| **R0 (FIRST DOMINO)** | Mechanical env-var + error-handling sweep [P3 §11 #5] | none | `runtime/config.{h,cpp}` + 16 grep-targeted TUs + ~10 in `core/`/`memory/` | -20 net | Hot-path env reads disappear; uniform `if (RuntimeConfig::current().X.Y)` pattern enables grep-able deprecation; `throw → return ImpError` lets every later refactor propagate errors consistently |
+| R1 | Test parameterization + `docs/integration.md` [P4 §6 Step 1] | R0 | `tests/test_e2e_models.cpp` (rewrite -300+200), new `docs/integration.md` (~200 LOC) | -100 net | Every later arch / kernel refactor gets free e2e coverage; new contributor day-7 cost drops from 2-3 weeks to ~3 days |
+| R2 | `ArchPlugin` interface + Qwen3 first migration [P4 §6 Step 3] | R1 | `model/arch_plugin.h` (~120), `model/arch_registry.cpp` (~60), `model/plugins/qwen3.cpp` (~80), -18 across `model.cpp` + `chat_template.cpp` | +250 net | Validates the plugin design before R3 commits to it; future arches land in 1 file |
+| R3 | Migrate remaining 13 arches to plugins [P4 §6 Step 4] | R2 | 13 plugin files (~80 LOC × 13), -80 in `model.cpp` + `chat_template.cpp` | +960 net | Per-arch behavior is centralized in plugin file; `kArchRegistry` deletes |
+| R4 | `ModelArchAdapter` / kill GEMMA4 hot-path branches [P3 §11 #1, P4 §6 Step 5] | R3 | `executor_attention.cu` -80 (14 branches), `executor_forward_moe.cu` -60 (19), `engine.cpp` -20, `executor_workspace.cu` -2, `executor_forward.cu` -5; new `arch_adapter.h` + `arch_adapter_gemma4.cu` (~400 LOC moved) | -150 net | Adding a new attention variant is 1 file; **§5 cross-axis champion lands here** |
+| R5 | `GemmKernel` registry — collapse 21-param dispatch + `WeightCaches` god-struct + dual dispatch tables [P3 §11 #2, P4 §6 Step 6] | R0 (parallel with R4) | `executor_kernels.cu` -266, `executor.h` -150, `weight_dispatch.cu` -100, 8 new `compute/gemm_kernel_*.cu` (~150 LOC each), `executor_pre_dequant.cu` -500 | **-1 000 net** | New qtype = 1 file; biggest single refactor win |
+| R6 | Split `executor_forward_moe.cu` into 5 TUs [P3 §11 #3] | R4 + R5 | `executor_forward_moe.cu` (delete; split into decode_fast, prefill, shared_expert, routing, gemma4_overrides) | 0 net | Phase 2 leak #1 (gate+up+SwiGLU+quant fusion) becomes a single-file change; 60 % cognitive load drop per file |
+| R7 | Split `engine.cpp` into 5 TUs [P3 §11 #4] | R6 | `engine.cpp` (split into init/step_prefill/step_decode/mtp/residual) | 0 net | Per-file cognitive load drop |
+| R8 | `RecurrentState` polymorphism [P4 §6 Step 7] | R5 | `memory/recurrent_state.h` (new ~40), `memory/ssm_state.{h,cu}` + `memory/gdn_state.{h,cu}` refactored, ~10 sites in `engine.{h,cpp}`, ~5 in `graph/executor.h` + `executor_ssm_gdn.cu` | +0 net | Hybrid arch #3 (RWKV/RetNet) lands cleanly |
+
+**The first domino is R0.** Reasoning: every other refactor changes
+hot-path code that reads env vars and propagates errors through
+`throw`. Without R0, R1-R8 either keep the inconsistency or fight it
+mid-refactor. R0 is also the smallest LOC delta and lowest risk —
+ideal first move.
+
+---
+
+## 4. Extensibility Roadmap
+
+### 4.1 Target state: "<500 LOC = working model"
+
+Per Phase 4 §5: each arch becomes a single ~80-LOC plugin file in
+`src/model/plugins/` that implements `ArchPlugin` (sketched at
+`phase4_ext.md` §5.1). Net-new kernel work (e.g. a new MoE routing
+variant) lives separately in `compute/`, but the plugin file is the
+contributor's only entry point for the registry, parser, chat
+template, attention/MoE/engine policy and per-tensor-kind matchers.
+
+| Arch family | Today | Post-roadmap |
+|---|---:|---:|
+| Dense LLaMA-style (LLaMA, Mistral, Qwen3) | ~60-120 LOC across 25 files | **~50-80 LOC** in 1 plugin file |
+| MoE (Qwen3-Coder, Mixtral, Qwen3.5-A3B) | ~280-650 LOC | **~120-200 LOC** (plugin + optional routing variant) |
+| Hybrid (Mamba2 + attn) | ~400-800 LOC + weeks of debugging | **~200-300 LOC** (plugin + RecurrentState subclass) once R8 + chunk-state cliff fixed |
+| New attention variant (e.g. hypothetical Gemma-5) | ~410-980 LOC across 25 files | **~150-300 LOC** if AttentionPolicy struct covers it |
+
+### 4.2 The 3 sequenced steps that get there
+
+These are R1+R2+R4 from §3.2 above, restated with cost / payoff in
+extensibility terms.
+
+| Step | Cost | Payoff |
+|---|---:|---|
+| **Test parameterization + integration doc** (R1) | 3 days | Removes per-arch fixture copy-paste; new contributor day-7 cost: 3 days vs 2-3 weeks |
+| **`ArchPlugin` interface + Qwen3 migration** (R2) | 1 week | Validates the design; first plugin lands without disturbing un-migrated arches |
+| **Migrate 13 arches + collapse `if`-ladder via `ModelArchAdapter`** (R3 + R4) | 2.5 weeks | Per-arch behavior is centralized in 1 file; future arches land as 1 file |
+
+After Step 3, **80 % of the extensibility win is in**. Steps R5-R8
+are per-feature (qtype, hybrid state) rather than per-arch — their
+cost amortizes over future archs.
+
+### 4.3 In-scope vs. nice-to-have
+
+**In scope (commit to doing):**
+- R0, R1, R2, R3, R4 (the first 5 weeks). These deliver 95 % of the
+  extensibility win and are mechanical post-R0.
+
+**Nice-to-have (do if budget allows):**
+- R5 (GemmKernel registry) — strictly speaking is a perf/maint win,
+  not extensibility. But it unblocks R6 cleanly. Defer if quarter is
+  tight; ship if not.
+- R8 (RecurrentState) — only matters when a non-Mamba2/non-GDN
+  hybrid actually shows up. Defer until then.
+- Cross-chunk SSM state handoff fix (Nemotron-H cliff) — 2-6 weeks
+  LOW confidence per P4 §3.6. **Defer** unless Nemotron-H is the
+  next priority model.
+
+---
+
+## 5. Cross-axis Big Picture
+
+A senior architect picks the refactors that move multiple axes. The
+table below ranks every recommendation in §§2-4 by how many axes it
+moves.
+
+| Refactor | Perf win | Maint win | Ext win | Combined ROI rank |
+|---|---|---|---|---:|
+| **R5 GemmKernel registry** [P3 §11 #2, P4 §6 Step 6] | indirect (clears the dispatch indirection that hides leak #2) | **HUGE** (-1 000 LOC, kills god-struct + dual tables) | **HUGE** (new qtype = 1 file) | **#1** |
+| **R4 ModelArchAdapter / kill GEMMA4 if-ladder** [P3 §11 #1, P4 §6 Step 5] | small (clears `if`-noise from hot path) | **HUGE** (-150 LOC, kills 40 inline branches) | **HUGE** (new arch attention/MoE variant = 1 method override) | **#2** |
+| **R6 Split `executor_forward_moe.cu`** [P3 §11 #3] | indirect (perf leak #1 fix becomes 1-file change) | medium (-2 563 LOC monolith → 5 files) | medium (MoE routing variant lands in 1 file) | **#3** |
+| **M1 Fuse SwiGLU + activation-quant** [P2 #1] | **+5–10 % pp** | small (fewer kernels in the code path) | small | **#4** |
+| **M3 Complete MoE prefill graph capture Phase 4** [P2 §6.8] | **+10–15 % pp** | medium (kills 5 D2H sync sites) | small | **#5** |
+| **R0 env-var + error-handling sweep** [P3 §11 #5] | microscopic (hot-path env reads vanish) | medium (uniform error model, central env) | medium (every later refactor relies on this invariant) | **#6 (but R0 is the FIRST DOMINO regardless of rank)** |
+| **R1 Test parameterization** [P4 §6 Step 1] | **HUGE for the long term** (CI gates new perf regressions) | small | **HUGE** (free e2e coverage for every future arch) | **#7** |
+| **R2 + R3 ArchPlugin migrations** [P4 §6 Steps 3-4] | none | medium (-net code in `model.cpp` + `chat_template.cpp`) | **HUGE** (target state §4.1) | **#8** |
+| Streichliste (S1-S19 above) | none | **medium** (-5 460 LOC) | tiny (less surface to grep) | **#9** |
+| B2 Device-side LRU expert prefetch | **+5× decode on >32GB MoE** | small | medium (any future 50B+ MoE inherits) | **#10 (per-feature)** |
+
+### The single biggest brecher
+
+**R5 — collapse `WeightCaches` god-struct + 21-param `gemm_dispatch_impl`
++ duplicate `weight_dispatch.cu` table into a `GemmKernel` registry.**
+
+Defended by all three phase reports:
+
+- **P2 — perf evidence:** Phase 2 §1.4 hot-path tables show that
+  `gemm_dispatch_impl` at `executor_kernels.cu:2003-2269` is on every
+  decode token. The 21-param signature + 8 cache-pointer branches add
+  µs-grade dispatch overhead per call. More importantly, the dispatch
+  shape is what hides leak #2 (the 14.7× NVFP4 prefill gap) inside
+  a code surface no one wants to touch.
+
+- **P3 — maint evidence:** Phase 3 §1.2 #1 (the worst coupling),
+  Phase 3 §2 #1 (the worst danger zone), Phase 3 §5.2 #4 (the
+  duplicate dispatch tables) all point at this single artifact.
+  Refactor R5 alone deletes ~1 000 LOC net (-266 in
+  `executor_kernels.cu`, -150 in `executor.h`, -100 in
+  `weight_dispatch.cu`, -500 in `executor_pre_dequant.cu` from the
+  cache-population virtualization, +1 200 across 8 new
+  `compute/gemm_kernel_*.cu` files of moved-not-added code) [P3 §11 #2].
+
+- **P4 — ext evidence:** Phase 4 §4 #9 names this as the exact
+  blocker for adding a new qtype (INT3, INT2, BFP16, future). The
+  current pattern requires touching 6 cache maps, the
+  `gemm_dispatch_impl` arm, the `weight_dispatch.cu` arm, and the
+  `executor_pre_dequant` populator — five places for one logical
+  thing.
+
+- **Calendar weeks:** 2-3 weeks (per P3 §11 estimate).
+
+- **Engineering risk:** medium. The `GemmKernel` interface is
+  straightforward, but the move touches 5 hot-path TUs and the
+  test surface is wide. Mitigation: use the per-qtype microbenches
+  to verify bit-identity before/after each kernel migration.
+
+- **Counterfactual cost (next 6 months):** every new qtype is +1
+  week of plumbing; every NVFP4 MoE prefill optimization (P2 #1, M3,
+  Bucket B of B1) is harder than it should be because the dispatch
+  surface obscures the call graph; the split refactors R6+R7 don't
+  trivialize cleanly because the executor still has to know about 6
+  cache types. **R5 unblocks R6 and is parallelizable with R4.**
+
+---
+
+## 6. Risks & Mitigations
+
+For each major recommendation in §§2-5. Categorized by what could go
+wrong, what test should exist before the refactor, and the rollback
+strategy.
+
+### 6.1 Performance refactors
+
+| Item | Regression risk | Pre-refactor test that should exist | Rollback strategy |
+|---|---|---|---|
+| M1 (SwiGLU + activation-quant fusion) | Numerical drift in NVFP4 MoE expert outputs | Bit-exact A/B test of fused vs unfused at fp16 reference (does NOT exist today; P3 §8.2 confirms 0/10 perf leaks have regression gates) | Feature flag `RuntimeConfig.moe.fused_swiglu_quant`; default OFF for one release |
+| M2 (Gemma-4 ggml D2H sync removal) | Silent wrong tokens at n>1 prefill on Gemma-4 ggml fallback | E2E Gemma-4 prefill coherence test at n=512 (`tests/test_e2e_models.cpp::Gemma4ModelTest`) — exists but does not assert n=512 specifically | Branch park; Gemma-4 prefill graphs already opt-in via `IMP_PREFILL_GRAPH` |
+| M3 (MoE prefill graph Phase 4) | Silent hang at chunk re-instantiation (similar class to Nemotron-H bug) | Graph-capture-validation test asserting "n=512 prefill MoE captures cleanly to 1 graph" — **does not exist today** [P3 §8.5] | `IMP_PREFILL_GRAPH` already gates; default-OFF for opt-in |
+| B1 (close NVFP4 prefill 14.7×) | Many — staged refactor across CUTLASS template, host scheduler, kernel launch overhead | Per-bucket isolated A/B harness (do not exist today) | Each bucket as separate PR with feature flag |
+| B2 (device-side LRU expert prefetch) | Pinned-memory exhaustion; expert-cache thrashing under concurrent batching | Multi-request expert cache stress test — does not exist | Branch park; today's `experts_on_host_=true` path is the rollback target |
+
+### 6.2 Maintainability refactors
+
+| Item | Regression risk | Pre-refactor test that should exist | Rollback strategy |
+|---|---|---|---|
+| R5 (GemmKernel registry) | Silent dispatch divergence on edge-case (input.qtype, output.qtype, cache-state) tuples | Per-qtype dispatch-coverage test (matrix of (input qtype, weight qtype, M-shape) × expected kernel) — **does not exist today**; 12 internal-namespace test files exist [P3 §8.3] but no dispatch matrix | Per-kernel migration is independently revertable; commit one qtype migration per PR |
+| R4 (ModelArchAdapter) | Lost arch-specific behavior (e.g. Gemma-4 V=K compaction) | Each Gemma-4 e2e test (`tests/test_e2e_models.cpp::Gemma4ModelTest`, `Gemma4GraphsTest`) plus all 7 Gemma-4 memory-file scenarios [P4 §2.1] | Adapter-by-adapter migration; per-arch revert is one file |
+| R6+R7 (split big files) | Build-time include-graph regression; new circular dependencies | None needed (mechanical move) | Trivial — git revert |
+| R8 (RecurrentState) | SSM/GDN state corruption on multi-sequence batches | `tests/test_gdn.cu` standalone covers single-sequence (P1 §8); multi-sequence GDN test does not exist | Branch park; SSM/GDN state classes remain independent until R8 ships green |
+
+### 6.3 Streichliste removals — re-introduce-bug-class risk
+
+The MEMORY ledger documents many shipped fixes. A naive deletion can
+re-open a closed bug. Audit per item:
+
+- **#1-#2 `mmq_q4k_v2.cu`:** memo `mmq_q4k_v2_v2_phase2_shipped_2026_05_16`
+  documents the −4 % E2E regression. **Risk if deleted:** none —
+  kernel was opt-in, not on default path. **Mitigation:** keep
+  `git tag mmq_q4k_v2_all_phases` for restoration.
+- **#3 smallM relocate:** the `IMP_NVFP4_SMALLM` knob exists. **Risk:**
+  none — relocate, don't delete. The TMA build-out lives in tests/.
+- **#4 `attention_tc.cu`:** P3 §10 #5 notes "still used (header
+  included from attention_blackwell.cu:24)". **Risk:** breaking the
+  Blackwell variant. **Mitigation:** verify the include is for
+  typedefs only; `tests/test_attention_tc.cu` moves to
+  `test_attention_blackwell.cu`.
+- **#5 `gemm_moe_fused_tc.cu`:** P3 §10 #6 marks this "needs
+  profiling whether routed under default." **Risk:** silent fused-
+  MoE-GEMV throughput regression. **Mitigation:** add per-PR perf
+  test before deletion.
+- **#6 `gemm_capture_fp16_sm120.cu`:** P3 §3.7 notes "could be 600
+  dead LOC or a working opt-in. Phase 4 should check." **Risk:**
+  dropping a working FP16 capture path. **Mitigation:** verify
+  dispatch frequency via single nsys trace before deletion.
+- **#7-#10 (`__CUDA_ARCH__` guards, runtime flags, comments):**
+  trivially safe. Documented in P1 §7.1-7.3.
+- **#11 bench TUs relocate:** P1 §7.8 confirms they're already gated
+  off in production Docker (`IMP_BUILD_BENCH=OFF`). **Risk:** none
+  for runtime; CI must learn the new path.
+- **#12-#13 (dead branch, dispatch table merge):** test-pinned. The
+  merge needs the existing `tests/test_weight_dispatch.cu` plus a
+  matrix coverage test (per §6.2 R5).
+- **#14 dead `RuntimeConfig` fields:** P3 §9.5 estimates 8-10. **Risk:**
+  re-introducing a knob someone runs in CI without the field. **Mitigation:**
+  grep all CI scripts before each removal; mark fields `[[deprecated]]`
+  for one release first.
+- **#18-#19 (`throw → return`, `assert → log`):** P3 §6 is explicit.
+  **Risk:** breaking error-propagation contract for callers that
+  catch. Grep for `try { imp::` across `tools/` and `tests/` first.
+
+---
+
+## 7. Things the phase reports got wrong / left ambiguous
+
+### 7.1 Disagreement: `mmq_q4k_v2.cu` — dead code, dormant strategic, or actively harmful?
+
+- **P1 §7.5** says "1 870 LOC at risk pending Phase 2 dispatch-frequency
+  check" (treats as soft-removable).
+- **P2 §1, §3.2, §3.9** treats it as opt-in research, neither defending
+  nor attacking.
+- **P3 §3.3, §10 #1-#2** explicitly recommends monomorphizing 5 of 7
+  templates (saves 700 LOC) OR deleting the entire 1 667 LOC TU
+  (policy call).
+- **MEMORY ledger** (`mmq_q4k_v2_v2_phase2_shipped_2026_05_16`):
+  "End-to-end on Qwen3.6-35B Q4_K_M: −4 % pp (MoE keeps experts under
+  MIN_M=64; fp16_cache hits skip v2; Phase 1 overhead per call). Real-
+  world win pending a dense Q4_K_M model without fp16_cache."
+
+**Resolution: needs measurement before deciding.** Ship the dense-
+Q4_K_M release referenced in MEMORY first. If it materializes within
+30 days and shows ≥ +5 % pp on a real model, monomorphize 5 of 7
+templates (P3 §10 #1, 700 LOC) and keep the kernel. If it doesn't,
+delete the entire TU (P3 §10 #2, 1 667 LOC). **Default in absence of
+that measurement: monomorphize, don't delete** — it's the safer bet
+and most of the cost is in the templates, not the kernel proper.
+
+### 7.2 Disagreement: prefill graph capture status
+
+- **P2 §6.8** ("Disagree" with the memo): "the device-args path at
+  `executor_forward_moe.cu:508-665` is graph-capturable today (no
+  D2H) — Phase 3 PR #164 confirmed +11–39 %. Phase 4 *for non-NVFP4
+  MoE arches* is still blocked."
+- **P2 §4.5** lists 5 surviving D2H sync sites in
+  `executor_forward_moe.cu` that block capture in legacy/Gemma-4
+  paths.
+
+**Resolution: P2 §6.8 is right, but the residual 5 D2H sites are
+real bugs in non-NVFP4 paths.** Ship M2 (per-token D2H removal in
+Gemma-4 ggml) and M3 (Phase 4 prefill graph completion) as separate
+PRs. The Qwen3-Coder NVFP4 path is the one already capturable;
+Gemma-4 ggml + the legacy fallbacks are not.
+
+### 7.3 Ambiguity: `gemm_capture_fp16_sm120.cu` and `gemm_moe_fused_tc.cu` — dead or alive?
+
+Both flagged in P1 §7.5 and P3 §10 #6-#7 as "needs profiling under
+default." Neither phase does the profile. **Punt to a Phase 4.5
+measurement task:** single nsys trace on Qwen3-8B Q8_0 (uses FP16 GEMM
+extensively) and Qwen3.6-35B-A3B (uses fused MoE). If neither file's
+kernels appear in the SASS hot path, delete both; if they do, mark
+them as keepers and update the comments.
+
+### 7.4 Ambiguity: dead `RuntimeConfig` fields
+
+P3 §9.5 estimates 8-10 dead fields in `RuntimeConfig` (Gemma-4
+stabilization toggles), but doesn't grep CI scripts to confirm.
+**Punt:** include this grep as part of R0 (mechanical sweep). Each
+field that grep returns 0 hits for in `/scripts/`, `/tools/`,
+`/tests/`, and `Dockerfile` is deletable.
+
+### 7.5 Where I disagree with all three phase reports
+
+**The `<500 LOC = new model` framing in P4 §5 is correct in spirit
+but optimistic on the LLaMA-style dense case.** P4 §1.1 already shows
+the loader plumbing alone is 30-50 LOC across enum + registry + parser
++ matcher rules. With chat template family already covered, the
+"plugin file" itself can land in 50-80 LOC, but the surrounding
+boilerplate (test fixture, perf-baseline row, docs entry) brings the
+true total closer to ~150 LOC even after the refactor. **This doesn't
+change the refactor decision** — the win is one-file-per-arch, not
+specifically <500 LOC — but the marketing number is closer to
+"one file per arch" than "<500 LOC per arch."
+
+---
+
+## 8. 30 / 60 / 90 day plan
+
+A maintainer should be able to execute this without further synthesis.
+Each period names concrete deliverables.
+
+### Day 0-30 — Mechanical foundation, first quick wins, biggest perf bet
+
+**PRs to ship (in order):**
+
+1. **R0 — env-var + error-handling sweep** (4-5 days). Deliverables:
+   - `RuntimeConfig` extended with all 16 IMP_* fields per
+     `phase3_maint.md` §9.1 table.
+   - `core/`, `memory/` `throw → return` sweep (~12 sites + 40 callers).
+   - Hot-path `assert()` → logged-runtime-check (~55 sites).
+   - LOC delta: -20 net.
+2. **Perf quick wins #1, #2, #4, #7** (1 day batched). Deliverables:
+   - mmvq scratch pre-warm (`executor_kernels.cu:2175-2181`).
+   - Stale wgmma docstring deletion.
+   - Cache `IMP_NVFP4_FORCE_DEQUANT` + `IMP_LOG_GEMM_ALGO` env reads.
+   - Dead `mxfp4_act_sf` branch deletion.
+3. **R1 — test parameterization + integration doc** (3 days).
+   Deliverables:
+   - `tests/test_e2e_models.cpp` rewritten with
+     `INSTANTIATE_TEST_SUITE_P` over a model table.
+   - `docs/integration.md` worked example.
+4. **M1 — SwiGLU + activation-quant fusion** (5-7 days). Deliverables:
+   - New fused kernel in `compute/quantize_fp16_nvfp4_moe_native.cu`
+     with `apply_swiglu` integrated.
+   - A/B harness comparing bit-exact output before/after.
+   - Behind feature flag for one release.
+5. **Streichliste hard-deletes** (1-2 days).
+   - P3 §10 items #8-#11, #13, #15, #16, #17 (low-risk, mechanical).
+   - LOC removed: ~700 hard delete + ~13 comment cleanup.
+
+**Day 30 status:** ~700 LOC deleted, R0 + R1 in main, M1 shipped
+behind flag, perf quick wins live. **Expected E2E perf delta: +5-10 %
+pp on Qwen3-Coder NVFP4 from M1.** Test suite gains free per-arch
+coverage for every future model.
+
+### Day 31-60 — ArchPlugin landing, GEMMA4 if-ladder kill, GemmKernel registry
+
+**PRs to ship:**
+
+1. **R2 — ArchPlugin interface + Qwen3 migration** (1 week).
+   Deliverables:
+   - `model/arch_plugin.h`, `model/arch_registry.cpp`,
+     `model/plugins/qwen3.cpp`.
+   - All Qwen3 `kArchRegistry` rows + `chat_template.cpp` switch
+     entries deleted.
+2. **R3 — Migrate remaining 13 arches to plugins** (1.5 weeks).
+   Deliverables:
+   - 13 plugin files in `model/plugins/`.
+   - Each `kArchRegistry` row deleted as its plugin lands.
+3. **R4 — ModelArchAdapter / kill 40 GEMMA4 inline branches**
+   (1.5 weeks, can start in parallel with R3 once R2 lands). Deliverables:
+   - `arch_adapter.h` + `arch_adapter_gemma4.cu` files.
+   - All 40 hot-path branches replaced with adapter calls.
+   - LOC delta: -150 net.
+4. **R5 — GemmKernel registry** (parallel with R4; 2-3 weeks total).
+   Deliverables:
+   - `compute/gemm_kernel_*.cu` per qtype.
+   - `executor_kernels.cu` `gemm_dispatch_impl` deleted.
+   - `weight_dispatch.cu` duplicate dispatch deleted.
+   - `WeightCaches` god-struct collapsed.
+   - LOC delta: -1 000 net.
+5. **M2 — Gemma-4 ggml D2H sync removal** (1-2 days, can slot any time).
+
+**Day 60 status:** plugin interface live, all 14 arches migrated,
+GEMMA4 if-ladder dead, GemmKernel registry collapses dual dispatch
+tables. **`graph/` shrinks from 15.8 KLOC to ~13.5 KLOC.** **Adding
+a new arch is now a single 80-LOC file.** Net LOC removed since day
+0: ~1 850 (700 + 150 + 1 000).
+
+### Day 61-90 — Splits, MoE prefill graph completion, soft-delete confirmations, B1 setup
+
+**PRs to ship:**
+
+1. **R6 — Split `executor_forward_moe.cu` into 5 TUs** (1 week).
+   Deliverables:
+   - 5 new files in `src/graph/`.
+   - `executor_forward_moe.cu` deleted.
+   - Net cognitive load: -60 % per file.
+2. **R7 — Split `engine.cpp` into 5 TUs** (1 week, parallel with R6).
+   Deliverables:
+   - `engine_init.cpp`, `engine_step_prefill.cpp`,
+     `engine_step_decode.cpp`, `engine_mtp.cpp`, `engine.cpp`
+     (residual).
+3. **M3 — Complete MoE prefill graph capture Phase 4** (2-3 weeks,
+   started day 61). Deliverables:
+   - 5 D2H sync sites in `executor_forward_moe.cu` removed (now
+     trivial after R6 split).
+   - Multi-graph pool sized per chunk-shape bucket.
+   - Expected +10-15 % pp on NVFP4 MoE.
+4. **Soft-delete confirmations** (1 week scattered):
+   - nsys trace on Qwen3-8B Q8_0 + Qwen3.6-35B-A3B confirms
+     `gemm_capture_fp16_sm120.cu` and `gemm_moe_fused_tc.cu` dead-or-
+     alive. Delete confirmed dead (~600-1 100 LOC).
+   - `attention_tc.cu` deletion (411 LOC) once Blackwell typedef-only
+     dependency confirmed.
+   - smallM relocate (948 LOC moved out of `src/compute/`).
+   - Bench TU relocate (1 772 LOC moved).
+5. **B1 setup work** (start of multi-quarter big bet):
+   - Per-bucket A/B harness for the NVFP4 prefill 14.7× gap.
+   - First bucket-A pilot (CUTLASS scheduler tuning).
+
+**Day 90 status:** **`graph/` shrinks from ~13.5 KLOC to ~10 KLOC.**
+M3 ships with measurable +10-15 % pp on MoE prefill. ~3 200 LOC
+removed from `src/compute/` (or relocated to `tests/bench/`). The
+14.7× gap closes by ~25 % from M1 + M3 combined; the rest is
+multi-quarter B1 work.
+
+**Cumulative day-90 deliverables:**
+- LOC removed (hard): ~2 850 (R0 -20, M1 0, streichliste hard ~1 700,
+  R4 -150, R5 -1 000, soft-deletes confirmed 600-1 100, R7 0).
+- LOC removed (soft, with profiling confirmation): up to ~3 800.
+- LOC moved out of `src/compute/`: ~2 720.
+- New plugin/adapter/kernel files: ~1 800 (mostly relocated, not
+  added).
+- Decode perf: unchanged at-roof.
+- Prefill perf on Qwen3-Coder NVFP4: +15-25 % vs day-0 baseline (M1
+  + M3 + half of M5 expected).
+- New arch onboarding cost: 25 files / 2-4 days → 1 file / 0.5-1 day.
+
+---
+
+## 9. Open questions for the human
+
+A short list of decisions the maintainer must make. Each has a
+recommended default in brackets — these are my opinion, not a
+committee's.
+
+1. **Delete `mmq_q4k_v2.cu` (1 667 LOC) now or wait for the dense-
+   Q4_K_M release referenced in MEMORY?**
+   [Recommend: monomorphize to 2 templates (-700 LOC) now; defer full
+   deletion 30 days; if no win on a real model by then, delete the
+   remaining 967 LOC. Restore from `git tag mmq_q4k_v2_all_phases`
+   if needed.]
+
+2. **Ship B1 (close NVFP4 prefill 14.7× gap) or B2 (device-side
+   LRU expert prefetch) as the quarter's big-bet?**
+   [Recommend: B1 — the headline gap defines competitive perception.
+   B2 only matters for >32GB MoE serving; reassess once B1 lands.]
+
+3. **Move bench TUs from `src/compute/` to `tests/bench/` (1 772 LOC
+   relocation)?**
+   [Recommend: yes, do it as part of day 61-90. Already gated off in
+   Docker; the move costs nothing structurally and cleans the kernel
+   tree.]
+
+4. **Delete `attention_tc.cu` (411 LOC) on the assumption that
+   Blackwell variant subsumes it?**
+   [Recommend: yes, after the typedef-only audit. Move
+   `tests/test_attention_tc.cu` into `test_attention_blackwell.cu`.]
+
+5. **Promote `IMP_USE_BITDECODING_QK` to a `RuntimeConfig` field
+   AND keep the kernel, or delete the kernel since 0% gain across
+   configs?**
+   [Recommend: promote to config, keep the kernel. The 0% gain is on
+   short ctx; the long-context BitDecoding paper claim (8.6×) is not
+   yet reachable on imp because only 1.5 of 4 levers are in. Don't
+   close the door.]
+
+6. **Make CUDA Graphs default-ON for prefill once M3 ships (today
+   opt-in via `IMP_PREFILL_GRAPH`)?**
+   [Recommend: yes for NVFP4 MoE only; keep opt-in for other arches
+   until each is verified clean.]
+
+7. **Adopt the `ArchPlugin` design (P4 §5) verbatim, or modify the
+   policy struct shape first?**
+   [Recommend: adopt verbatim for the first 5 arches; iterate the
+   struct shape after Qwen3 + Gemma-4 + Qwen3.6-MoE plugins are
+   live. Don't bikeshed the interface before validating it.]
+
+8. **Schedule the cross-chunk SSM state handoff fix (Nemotron-H
+   cliff, 2-6 weeks LOW confidence) or defer Nemotron-H until a
+   business reason emerges?**
+   [Recommend: defer. Mark Nemotron-H as "experimental" in
+   `docs/usage.md` until a customer asks. The bug is real but the
+   user count is zero.]
+
+---
+
+End of Phase 5 synthesis.


### PR DESCRIPTION
## Summary

Five-phase architecture audit of the imp inference engine, scoped to sm_120a-only (RTX 5090 / GB202). 4 890 LOC of analysis MD under `review/`; **no source files modified**.

Headline: imp ships the **same NVFP4 grouped GEMM kernel as vLLM** and still measures **14.7× slower on prefill** — every byte of that gap lives outside the kernel (activation-quant fusion missing, per-layer launch overhead, scheduler maturity). Meanwhile `src/graph/` is a **15.8 KLOC clay tablet** where every quant format, every model arch, and every dispatch decision lives as inline `if`-ladders.

## Phase reports

| # | Subagent | Report | LOC | Focus |
|---:|---|---|---:|---|
| 1 | cartographer | `review/phase1_inventory.md` | 751 | Static map, public ABI surface, **ballast bilanz: ~5 390 LOC** |
| 2 | perfhawk | `review/phase2_perf.md` | 1 159 | Roofline, GB202 feature audit, **Qwen3-Coder NVFP4 prefill 14.7× deep-dive** |
| 3 | codereaper | `review/phase3_maint.md` | 1 283 | Coupling, 10 danger zones, **kahlschlag total: ~5 467 LOC** |
| 4 | integrator | `review/phase4_ext.md` | 1 044 | 3 simulated integrations, **"<500 LOC = new model" target** |
| 5 | orchestrator | `review/phase5_synthesis.md` | 653 | Cross-axis roadmaps, 30/60/90 plan |
|   | (entry-point) | `review/MASTER_REPORT.md` | 135 | TL;DR + links |

## Key numbers

- **Kahlschlag total:** ~5 460 LOC (6.1 % of src/) — two phases converged independently
- **Single largest streichkandidat:** `src/compute/mmq_q4k_v2.cu` (1 667 LOC, −4 % E2E on Qwen3.6-35B Q4_K_M, opt-in only)
- **First domino refactor:** R0 — env-var + error-handling sweep (16 `IMP_*` getenvs → `RuntimeConfig`, 12 `throw`s → `IMP_LOG_ERROR`)
- **Cross-axis champion:** R5 — `GemmKernel` registry (−1 000 LOC, wins perf + maint + ext at once)
- **Top quick win:** SwiGLU + activation-quant fusion in MoE down-phase, 2-3 days, decode-risk zero
- **Top big bet:** B1 — close the NVFP4 MoE prefill 14.7× gap, 6-12 weeks → ~3×

## How to read

1. Start at `review/MASTER_REPORT.md` for the 60-second TL;DR + key numbers
2. `review/phase5_synthesis.md` for the full 30/60/90 plan, ranked refactors, risks, and 8 open decisions for the maintainer
3. Phase 1-4 reports for evidence — every claim anchored at `file:line`

## Test plan

- [x] No source files modified — `git diff main..HEAD --stat` shows only `review/*.md`
- [x] All file:line citations in the reports point at the codebase at anchor `f58eb9e` (commit on main when the audit started)
- [x] Two cross-phase conflicts (mmq_q4k_v2 dead-vs-dormant, WMMA retirement) are explicitly surfaced in `phase5_synthesis.md §7`
- [ ] Maintainer reviews and answers the 8 open questions in `phase5_synthesis.md §9` / `MASTER_REPORT.md` before R0/R5 implementation PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)