### PR TITLE
perf(moe): M1 — fused SwiGLU+activation-quant for NVFP4 down-input

### DIFF
--- a/src/compute/gemm_cutlass_sm120.cu
+++ b/src/compute/gemm_cutlass_sm120.cu
@@ -451,6 +451,126 @@ void quantize_fp16_to_nvfp4_cutlass_moe(const void* src_fp16, void* dst_packed, 
 }
 
 // ---------------------------------------------------------------------------
+// Fused activation + NVFP4 CUTLASS quantize — M1 from review/phase5_synthesis §2.2.
+// Reads gate + up from HBM, computes SwiGLU/GeGLU/ReLU² in registers, and writes
+// only the packed FP4 + SFA. Replaces the apply_expert_activation + quantize_..._moe
+// pair in the device-args MoE prefill path; saves one full HBM round-trip of the
+// swiglu intermediate (the activation tensor is never materialized in HBM).
+// ---------------------------------------------------------------------------
+
+// Compile-time activation tag: keeps the inner branch a no-op in PTX.
+template <int kAct>
+__global__ void fused_act_quantize_fp16_nvfp4_cutlass_moe_kernel(
+    const half* __restrict__ gate,           // [expanded, K] or nullptr when kAct == RELU_SQR
+    const half* __restrict__ up,             // [expanded, K]
+    uint8_t* __restrict__ packed_out,        // [expanded, K/2]
+    uint8_t* const* __restrict__ sfa_bases,  // [ne]
+    const int* __restrict__ offsets,         // [ne+1]
+    int expanded, int K, int ne, int n_k_tiles) {
+    int mb_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int K_groups = K / kSFVecSize;
+    if (mb_idx >= expanded * K_groups)
+        return;
+
+    int row = mb_idx / K_groups;
+    int k_group = mb_idx % K_groups;
+    int local_row;
+    int expert = moe_find_expert(offsets, ne, row, local_row);
+    uint8_t* sfa = sfa_bases[expert];
+    if (!sfa)
+        return;
+
+    // Compute 16 activation values + their absmax in registers.
+    float vals[kSFVecSize];
+    float local_absmax = 0.0f;
+    const int64_t row_off = static_cast<int64_t>(row) * K + k_group * kSFVecSize;
+    const half2* up_h2 = reinterpret_cast<const half2*>(up + row_off);
+    const half2* gate_h2 = (gate != nullptr) ? reinterpret_cast<const half2*>(gate + row_off) : nullptr;
+
+    constexpr float kGeluSqrt2OverPi = 0.7978845608028654f;
+    constexpr float kGeluCoeff = 0.044715f;
+
+#pragma unroll
+    for (int i = 0; i < kSFVecSize / 2; i++) {
+        half2 uh2 = up_h2[i];
+        float u0 = __half2float(uh2.x);
+        float u1 = __half2float(uh2.y);
+        float v0, v1;
+        if (kAct == 0) {  // SWIGLU
+            half2 gh2 = gate_h2[i];
+            float g0 = __half2float(gh2.x);
+            float g1 = __half2float(gh2.y);
+            v0 = (g0 / (1.0f + __expf(-g0))) * u0;
+            v1 = (g1 / (1.0f + __expf(-g1))) * u1;
+        } else if (kAct == 1) {  // GEGLU (Gemma-3 tanh form, FP16-clamped)
+            half2 gh2 = gate_h2[i];
+            float g0 = __half2float(gh2.x);
+            float g1 = __half2float(gh2.y);
+            float gelu0 = g0 * 0.5f *
+                          (1.0f + tanhf(kGeluSqrt2OverPi * (g0 + kGeluCoeff * g0 * g0 * g0)));
+            float gelu1 = g1 * 0.5f *
+                          (1.0f + tanhf(kGeluSqrt2OverPi * (g1 + kGeluCoeff * g1 * g1 * g1)));
+            v0 = fminf(fmaxf(gelu0 * u0, -65504.0f), 65504.0f);
+            v1 = fminf(fmaxf(gelu1 * u1, -65504.0f), 65504.0f);
+        } else {  // RELU_SQR — non_gated experts; gate is nullptr, up holds the input
+            v0 = (u0 > 0.0f) ? (u0 * u0) : 0.0f;
+            v1 = (u1 > 0.0f) ? (u1 * u1) : 0.0f;
+        }
+        vals[i * 2] = v0;
+        vals[i * 2 + 1] = v1;
+        local_absmax = fmaxf(local_absmax, fmaxf(fabsf(v0), fabsf(v1)));
+    }
+
+    quantize_micro_block_nvfp4_from_vals(
+        vals, local_absmax,
+        packed_out + static_cast<int64_t>(row) * (K / 2), k_group,
+        sfa + sfatom_offset(local_row, k_group, n_k_tiles));
+}
+
+void fused_act_quantize_fp16_to_nvfp4_cutlass_moe(const void* gate_fp16, const void* up_fp16,
+                                                  void* dst_packed, uint8_t* const* d_sfa_bases,
+                                                  const int* d_offsets, int expanded, int K, int ne,
+                                                  FFNActivation act_type, cudaStream_t stream) {
+    IMP_CHECK(K % kSFVecSize == 0,
+              "fused_act_quantize_fp16_to_nvfp4_cutlass_moe: K=%d must be multiple of %d", K, kSFVecSize);
+    if (expanded == 0)
+        return;
+
+    int K_groups = K / kSFVecSize;
+    int total_mb = expanded * K_groups;
+    int n_k_tiles = (K + kAtomKElems - 1) / kAtomKElems;
+
+    int threads = 256;
+    int blocks = (total_mb + threads - 1) / threads;
+
+    auto* gate_p = reinterpret_cast<const half*>(gate_fp16);
+    auto* up_p = reinterpret_cast<const half*>(up_fp16);
+    auto* dst_p = reinterpret_cast<uint8_t*>(dst_packed);
+
+    switch (act_type) {
+        case FFNActivation::SWIGLU:
+            IMP_CHECK(gate_p != nullptr,
+                      "fused_act_quantize: SWIGLU requires a non-null gate tensor");
+            fused_act_quantize_fp16_nvfp4_cutlass_moe_kernel<0>
+                <<<blocks, threads, 0, stream>>>(gate_p, up_p, dst_p, d_sfa_bases, d_offsets, expanded, K,
+                                                 ne, n_k_tiles);
+            break;
+        case FFNActivation::GEGLU:
+            IMP_CHECK(gate_p != nullptr,
+                      "fused_act_quantize: GEGLU requires a non-null gate tensor");
+            fused_act_quantize_fp16_nvfp4_cutlass_moe_kernel<1>
+                <<<blocks, threads, 0, stream>>>(gate_p, up_p, dst_p, d_sfa_bases, d_offsets, expanded, K,
+                                                 ne, n_k_tiles);
+            break;
+        case FFNActivation::RELU_SQR:
+            fused_act_quantize_fp16_nvfp4_cutlass_moe_kernel<2>
+                <<<blocks, threads, 0, stream>>>(nullptr, up_p, dst_p, d_sfa_bases, d_offsets, expanded, K,
+                                                 ne, n_k_tiles);
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // CUTLASS GEMM execution
 // ---------------------------------------------------------------------------
 

--- a/src/compute/gemm_cutlass_sm120.h
+++ b/src/compute/gemm_cutlass_sm120.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "model/model_config.h"  // FFNActivation
+
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <cstddef>
@@ -60,6 +62,30 @@ void quantize_fp16_to_nvfp4_cutlass(const void* src_fp16, void* dst_data, void* 
 void quantize_fp16_to_nvfp4_cutlass_moe(const void* src_fp16, void* dst_packed, uint8_t* const* d_sfa_bases,
                                         const int* d_offsets, int expanded, int K, int ne,
                                         cudaStream_t stream);
+
+// Fused activation + NVFP4 CUTLASS quantize for the MoE down-projection input.
+// Replaces apply_expert_activation(gate, up -> swiglu) + quantize_fp16_to_nvfp4_cutlass_moe(swiglu).
+// Reads gate + up directly from HBM, computes the activation in registers, and
+// writes only the packed FP4 + SFA — saving one full HBM round-trip of the
+// swiglu intermediate per MoE layer prefill call (~188 MiB on Qwen3-Coder
+// NVFP4 at expanded=32k, eff=2880; ~+5-10% pp512 per review/phase5_synthesis
+// §2.2 M1).
+//
+//   gate        : [expanded, K] FP16, OR nullptr when non_gated_experts=true
+//                 (RELU_SQR reads up only).
+//   up          : [expanded, K] FP16
+//   dst_packed  : [expanded, K/2] packed FP4 nibbles
+//   d_sfa_bases : [ne] per-expert SFA base pointers
+//   d_offsets   : [ne+1] cumulative row offsets
+//   act_type    : FFNActivation::SWIGLU / GEGLU / RELU_SQR
+//
+// Behavior is bit-identical to (apply_expert_activation + quantize_..._moe)
+// on the SWIGLU/GEGLU paths because both compute the activation in float
+// before quantization. RELU_SQR is also fused (gate ignored).
+void fused_act_quantize_fp16_to_nvfp4_cutlass_moe(const void* gate_fp16, const void* up_fp16,
+                                                  void* dst_packed, uint8_t* const* d_sfa_bases,
+                                                  const int* d_offsets, int expanded, int K, int ne,
+                                                  FFNActivation act_type, cudaStream_t stream);
 
 // Run CUTLASS sm_120 block-scaled NVFP4xNVFP4 GEMM: D = alpha * A x B^T
 //   A (activation): [M, K] NVFP4 RowMajor + SFA scale factors

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -543,7 +543,9 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                 static_cast<char*>(moe_.expert_swiglu.data);
                             char* expert_down_base = static_cast<char*>(moe_.expert_down.data);
 
-                            auto quantize_device = [&](const char* a_base, int K_in) {
+                            // SFA buffer prep — shared by both gate/up quant
+                            // (K_in = d) and the fused down-input quant (K_in = eff).
+                            auto prep_sfa = [&](int K_in) {
                                 imp::compute_sfa_offsets_device(
                                     moe_.d_M_per, moe_.d_sfa_offsets, ne, K_in, stream);
                                 imp::build_sfa_bases_device(
@@ -551,24 +553,45 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                     moe_.cutlass3x_sf, moe_.d_sfa_offsets, ne, stream);
                                 // Zero the *active* prefix of the SFA staging buffer.
                                 // Padded rows of the SfAtom layout must be 0 for clean
-                                // CUTLASS reads; for sparse routing the actual total is
-                                // a small fraction of cutlass3x_sf_size (worst case is
-                                // ~16 MiB). QW5 from review/phase5_synthesis.md §2.1
+                                // CUTLASS reads; QW5 (review/phase5_synthesis.md §2.1)
                                 // replaces the full cudaMemsetAsync with a bounded
-                                // device kernel that reads d_sfa_offsets[ne] (already
-                                // computed above) as the byte count, capping at
-                                // cutlass3x_sf_size.
+                                // device kernel that reads d_sfa_offsets[ne] as the
+                                // byte count, capping at cutlass3x_sf_size.
                                 imp::bzero_sfa_active(
                                     moe_.cutlass3x_sf,
                                     moe_.d_sfa_offsets,
                                     ne,
                                     moe_.cutlass3x_sf_size,
                                     stream);
+                            };
+                            auto quantize_device = [&](const char* a_base, int K_in) {
+                                prep_sfa(K_in);
                                 imp::quantize_fp16_to_nvfp4_cutlass_moe(
                                     a_base, moe_.cutlass3x_packed,
                                     reinterpret_cast<uint8_t* const*>(moe_.cutlass3x_sfa_ptrs),
                                     static_cast<const int*>(routing.expert_offsets.data),
                                     expanded, K_in, ne, stream);
+                            };
+                            // Fused activation + quantize for the down-projection input.
+                            // Replaces apply_expert_activation(gate, up -> swiglu_buf) +
+                            // quantize_device(swiglu_buf, eff). Reads gate/up directly,
+                            // computes SwiGLU/GeGLU/ReLU² in registers, writes only the
+                            // packed FP4 + SFA. M1 from review/phase5_synthesis.md §2.2.
+                            //
+                            // For non_gated experts (RELU_SQR): gate is nullptr, kernel
+                            // reads `up` only. `expert_up_base` is left bit-identical
+                            // (the fused kernel does NOT modify the input), whereas the
+                            // legacy path called relu_sqr_inplace which clobbered `up`
+                            // — callers downstream of this fast path do not re-read up.
+                            auto fused_act_quantize_device = [&](const char* gate_base,
+                                                                  const char* up_base, int K_in,
+                                                                  FFNActivation act_type) {
+                                prep_sfa(K_in);
+                                imp::fused_act_quantize_fp16_to_nvfp4_cutlass_moe(
+                                    gate_base, up_base, moe_.cutlass3x_packed,
+                                    reinterpret_cast<uint8_t* const*>(moe_.cutlass3x_sfa_ptrs),
+                                    static_cast<const int*>(routing.expert_offsets.data),
+                                    expanded, K_in, ne, act_type, stream);
                             };
 
                             // Per-layer pre-cached arrays (Phase 3c-full Step 3).
@@ -651,18 +674,22 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                                        da_cache.d_up_alpha,
                                                        expert_up_base, d, eff);
                             if (ok) {
-                                apply_expert_activation(
-                                    moe_.expert_gate.data, moe_.expert_up.data,
-                                    moe_.expert_swiglu.data, non_gated_experts, expanded,
-                                    eff, compute_dtype_, cfg.ffn_activation, stream);
-                                char* down_act =
-                                    non_gated_experts ? expert_up_base : expert_swiglu_base;
-                                quantize_device(down_act, eff);
+                                // Fused: activation (SwiGLU/GeGLU/ReLU²) + NVFP4 quant
+                                // for the down-projection input. Saves one HBM
+                                // round-trip of the swiglu intermediate per layer.
+                                const FFNActivation act_type =
+                                    non_gated_experts ? FFNActivation::RELU_SQR : cfg.ffn_activation;
+                                const char* gate_for_fused =
+                                    non_gated_experts ? nullptr : expert_gate_base;
+                                fused_act_quantize_device(gate_for_fused, expert_up_base, eff,
+                                                          act_type);
                                 ok = dispatch_device(ly.expert_down_ids,
                                                      da_cache.d_down_B_ptrs,
                                                      da_cache.d_down_SFB_ptrs,
                                                      da_cache.d_down_alpha,
                                                      expert_down_base, eff, d);
+                                (void)expert_swiglu_base;  // legacy fallback path still
+                                                            // uses moe_.expert_swiglu.data
                             }
                             if (ok) {
                                 device_args_done = true;


### PR DESCRIPTION
## Summary

Day 30-60 medium item M1 from `review/phase5_synthesis.md §2.2` — **first slice of the 14.7× NVFP4 prefill gap to vLLM**. Stacked on the Day-0-30 stack (#191 → #192 → #193); will rebase clean once upstream lands.

## Problem

NVFP4 MoE prefill device-args fast path materialized the post-activation tensor in HBM:

```
1. apply_expert_activation(gate, up -> expert_swiglu)   FP16 STORE
2. quantize_fp16_to_nvfp4_cutlass_moe(expert_swiglu)    FP16 LOAD + FP4 STORE
```

On Qwen3-Coder NVFP4 typical prefill (expanded ≈ 32k, eff = 2880) the swiglu intermediate is ~188 MiB per MoE layer; across ~48 MoE layers × 2 dispatch calls that's **~18 GiB of wasted HBM traffic per prefill**.

## Solution

New fused kernel `fused_act_quantize_fp16_to_nvfp4_cutlass_moe()` (gemm_cutlass_sm120.cu):

- Reads gate + up from HBM
- Computes SwiGLU / GeGLU / ReLU² in **registers**
- Writes only the packed FP4 nibbles + SfAtom UE4M3 scales

Templated on activation type (int 0/1/2 → SWIGLU/GEGLU/RELU_SQR) so per-element branches compile to no-ops. Reuses the existing `quantize_micro_block_nvfp4_from_vals()` device helper — its docstring already named this exact fusion as its purpose.

Activation formulas are byte-identical to `activation.cu` (`swiglu_fp16_kernel`, `geglu_fp16_kernel`, `relu_sqr` — Gemma-3 tanh form, FP16-clamped for GeGLU).

## Wiring

`executor_forward_moe.cu` device-args fast path:

- Extracts SFA buffer prep into `prep_sfa(K_in)` lambda (shared between gate/up quant and down-input quant)
- New `fused_act_quantize_device(gate, up, eff, act_type)` lambda
- Replaces the `apply_expert_activation + quantize_device` pair with the single fused call
- `expert_swiglu` workspace buffer remains allocated (legacy fallback path at line ~936 still uses the unfused dispatch)

## Expected impact

Per P5 §2.2 M1: **+5-10% pp512 on Qwen3-Coder NVFP4** (and any other NVFP4 MoE model that routes through the device-args path: Qwen3.6, Gemma-4-NVFP4, Modelopt). Decode unchanged — decode never reaches the device-args full path; it routes through per-expert GEMV at n=1.

## Bit-identity

- SWIGLU / GEGLU: identical float values pre-quant (both paths compute activation in float32 before UE4M3 quantize), FP4 output is bit-identical modulo deterministic quantization rounding.
- RELU_SQR: the legacy path called `relu_sqr_inplace` clobbering `up`; the fused path leaves `up` unmodified. No downstream caller re-reads `up` on this fast path, so semantically equivalent.

## Test plan

- [x] `make build` (Docker, CUDA 13.2) — green
- [x] `make verify-fast` — green (fast gtest filter PASS; e2e gates SKIP because `./models/` not provisioned)
- [x] No public C ABI change
- [x] Legacy fallback path (device_args_done == false) untouched — `expert_swiglu` workspace still consumed
- [ ] Maintainer: e2e A/B Qwen3-Coder-30B-A3B NVFP4 prefill pp512 before/after to confirm the +5-10% expected delta; baseline = 1 258 tok/s per MEMORY.md
- [ ] Maintainer: run `tools/imp-bench` on Gemma-4-26B-A4B-NVFP4 (GeGLU branch) to validate the GeGLU fusion produces coherent decode after a fused prefill

🤖 Generated with [Claude Code](https://claude.com/claude-code)