### PR TITLE
perf(moe+engine): M2 D2H sync batching + M4 graph-pool sizing

### DIFF
--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -2134,9 +2134,27 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
         s_norm_fp32_d = d;
     }
 
+    // M2 from review/phase5_synthesis.md §2.2: batch the per-token expert-
+    // index D2H + sync into a single prefetch at function entry. Reduces
+    // 2 * n syncs (one per token, three GEMVs each) down to ONE sync per
+    // layer call. Restores the prefill graph-capture story up to (but not
+    // including) the grouped-mmvq kernel work that would eliminate the
+    // remaining sync — see follow-up: replacing this function with a
+    // device-indexed grouped mmvq lets the whole layer capture cleanly.
+    //
+    // top_k is bounded by FFN active-expert count (max 32 per kernel
+    // launch guard at line ~2154 in the old per-token form). Use a
+    // std::vector since n*top_k can exceed the old 32-entry stack array.
+    std::vector<int32_t> h_all_experts(static_cast<size_t>(n) * top_k);
+    cudaMemcpyAsync(h_all_experts.data(), routing.expert_indices.data,
+                    static_cast<size_t>(n) * top_k * sizeof(int32_t),
+                    cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+
     for (int t = 0; t < n; t++) {
-        const int32_t* tok_experts = static_cast<const int32_t*>(routing.expert_indices.data) +
-                                     static_cast<int64_t>(t) * top_k;
+        const int32_t* tok_experts_dev = static_cast<const int32_t*>(routing.expert_indices.data) +
+                                         static_cast<int64_t>(t) * top_k;
+        (void)tok_experts_dev;  // device pointer kept around for clarity; reads come from host array
         const float* tok_weights = static_cast<const float*>(routing.expert_weights.data) +
                                    static_cast<int64_t>(t) * top_k;
 
@@ -2150,10 +2168,10 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
             tok_norm_f32 = nullptr;
         }
 
-        int32_t h_experts[32];
-        cudaMemcpyAsync(h_experts, tok_experts, top_k * sizeof(int32_t), cudaMemcpyDeviceToHost,
-                        stream);
-        cudaStreamSynchronize(stream);
+        // Per-token expert IDs: read from the pre-fetched host array (no D2H,
+        // no sync). Old form: stack `int32_t h_experts[32]` + per-token
+        // cudaMemcpyAsync + cudaStreamSynchronize — M2 batched both above.
+        const int32_t* h_experts = h_all_experts.data() + static_cast<size_t>(t) * top_k;
 
         auto do_mmvq = [&](const uint8_t* w, half* out, QType qt, int rows, int cols) {
             if (tok_norm_f32) {

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -2639,12 +2639,29 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
         decode_batch_pool_.is_allocated()) {
         auto& graph_runner = decode_graph_pool_[graph_idx];
 
-        if (gpu_batch.max_blocks_per_seq != last_decode_max_blocks_per_graph_[graph_idx]) {
+        // P5 §2.2 M4: pow-2 bucket the max_blocks_per_seq before comparing.
+        // The decode_batch_pool_ padding (engine.cpp:2456-2468) already lifts
+        // batch.max_blocks_per_seq to pool_max, so in practice this comparison
+        // never trips during steady-state decode — but if a future path
+        // bypasses the pool (e.g. spec-decode verify), pow-2 bucketing caps
+        // the re-capture frequency to log2(max_blocks) events per decode
+        // instead of one per 16-token boundary. Re-capture cost is
+        // dominated by the eager forward that builds the new graph
+        // (~5-10 ms on Qwen3-8B Q8_0) so the bucket pays back across long
+        // contexts.
+        auto bucket_pow2 = [](int x) -> int {
+            if (x <= 1) return 1;
+            int b = 1;
+            while (b < x) b <<= 1;
+            return b;
+        };
+        const int bucketed_max_blocks = bucket_pow2(gpu_batch.max_blocks_per_seq);
+        if (bucketed_max_blocks != last_decode_max_blocks_per_graph_[graph_idx]) {
             // Topology stable across max_blocks growth (same kernels, only
             // grid dims / params differ) — cudaGraphExecUpdate handles this
             // without tearing down the exec + graph mem pool.
             graph_runner.invalidate_for_update();
-            last_decode_max_blocks_per_graph_[graph_idx] = gpu_batch.max_blocks_per_seq;
+            last_decode_max_blocks_per_graph_[graph_idx] = bucketed_max_blocks;
         }
         // Graph captures ONLY forward_logits — sampling runs eager after
         Tensor logits_out;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -220,7 +220,15 @@ private:
     // ── CUDA Graphs ──────────────────────────────────────────────────
     // Per-batch-size graph pool: avoids re-capture when batch size changes
     // during continuous batching (key = n_sequences).
-    static constexpr int kMaxGraphPoolSize = 32;
+    //
+    // Pool size 64 (was 32 — P5 §2.2 M4): the imp-server's continuous-batching
+    // path can dispatch up to config.max_batch_size sequences per decode step.
+    // Default max_batch_size is 64 in the server profile; with the old pool of
+    // 32 entries any batch beyond 32 sequences fell off the captured fast path
+    // into eager forward, costing ~10× per-step latency. Raising the cap to 64
+    // covers the default deployment without extra VRAM (a CudaGraphRunner is a
+    // few empty pointers until first capture).
+    static constexpr int kMaxGraphPoolSize = 64;
     CudaGraphRunner decode_graph_pool_[kMaxGraphPoolSize];  // index = n_sequences - 1
     int last_decode_max_blocks_per_graph_[kMaxGraphPoolSize] = {};
 


### PR DESCRIPTION
## Summary

Day 30-60 medium items **M2 + M4** from `review/phase5_synthesis.md §2.2`, bundled into one PR (per `pr_batching_2026_05_15` — prefer fewer, batched PRs over per-fix branches). Stacked on the M1 fusion (#194).

### Commit 1 — `d4fe5df` M2: batch per-token D2H expert-index sync in Gemma-4 ggml prefill

`try_run_moe_gemma4_ggml_prefill` issued a `cudaMemcpyAsync` + `cudaStreamSynchronize` **per token** to read `top_k` expert IDs to host so the per-expert ggml mmvq dispatch could index its packed weight base by expert offset:

```cpp
int32_t h_experts[32];
cudaMemcpyAsync(h_experts, tok_experts, top_k * 4, D2H, stream);
cudaStreamSynchronize(stream);    // <-- per-token sync
```

At n=4096 tokens that's 4 096 sync round-trips per MoE layer call (~1-5 µs each = ~4-20 ms wasted per layer × ~24 MoE layers ≈ 100-500 ms wasted on this fallback path).

Replaces with a single batched prefetch at function entry:

```cpp
std::vector<int32_t> h_all_experts(n * top_k);
cudaMemcpyAsync(h_all_experts.data(), routing.expert_indices.data,
                n * top_k * 4, D2H, stream);
cudaStreamSynchronize(stream);    // <-- ONE sync per layer call
```

**Scope note:** P5 §2.2 M2 also promised "restore prefill graph capture" for this path. That requires a *grouped-mmvq* variant for Q4_K / Q5_K / Q5_1 / Q8_0 (consume the expert-index array on device, eliminating the remaining sync). That's a separate multi-week kernel project tracked as follow-up. For now this single-sync form still blocks graph capture, but ~99.97% fewer sync round-trips on n=4096 makes the fallback usable for interactive prefill on Q4_K_M / Q5_K_M Gemma-4 builds that don't have an NVFP4 prequant.

### Commit 2 — `2298c72` M4: pow-2 bucket decode graph-key + raise pool size to 64

**Pool size 32 → 64.** The imp-server's continuous-batching path can dispatch up to `config.max_batch_size` sequences per decode step; the default server profile uses 64. With the old pool of 32 entries any batch beyond 32 sequences fell off the captured fast path into eager forward, costing ~5-10× per-step latency. A `CudaGraphRunner` is a few empty pointers until first capture — VRAM cost essentially zero.

**Pow-2 bucket `max_blocks_per_seq` before the graph-key compare.** Tracing showed the existing `decode_batch_pool_` padding (engine.cpp:2456-2468) already lifts `batch.max_blocks_per_seq` to `pool_max` (= worst-case `max_seq_len/kv_bs`), so in steady-state decode the graph key never trips on `max_blocks` growth. The pow-2 bucket is a **defensive guard**: if a future path bypasses the pool (e.g. spec-decode verify, manual batch upload), bucketing caps re-capture frequency to O(log2(max_blocks)) events instead of one per 16-token boundary. Re-capture cost dominated by the eager forward that builds the new graph (~5-10 ms), so the bucket pays back even on rare bypass paths.

Honest note: P5's "10-30 ms per shape change at decode" estimate doesn't match the current code reality where pool padding already absorbs the variability. The pow-2 bucket is therefore a correctness/safety guard rather than a measurable steady-state perf win.

## Test plan

- [x] `make build` — green for each commit
- [x] `make verify-fast` — green (fast gtest filter PASS; e2e gates SKIP)
- [x] No public C ABI change
- [ ] Maintainer: verify `imp-server` config typically targets `max_batch_size <= 64`; if higher, push the pool further (e.g. 128)
- [ ] Maintainer: future grouped-mmvq work for Q4_K/Q5_K/Q5_1/Q8_0 would close the remaining sync in M2 and restore full graph capture for the Gemma-4 ggml fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)