### PR TITLE
perf(runtime): M3-probe — flip default capture mode to relaxed for prefill-graph unblock

### DIFF
--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -31,11 +31,21 @@ struct RuntimeConfig {
         bool debug_raw = false;        // raw stream debug
         bool no_vision_graph = false;  // disable SigLIP graph capture
         // cudaStreamCaptureMode passed to begin_capture / conditional bodies:
-        // "global" (default) | "relaxed" | "thread_local". "relaxed" drops the
-        // cross-thread sync constraint and may avoid CUTLASS 3.x grouped-GEMM
-        // hangs (see prefill_graph_blockers_2026_05_14). Legacy env:
-        // IMP_GRAPH_CAPTURE_MODE.
-        std::string graph_capture_mode = "global";
+        // "global" | "relaxed" (default) | "thread_local". "relaxed" drops the
+        // cross-thread sync constraint that CUTLASS 3.x grouped-GEMM
+        // collective scheduler is suspected to deadlock on under prefill
+        // capture (Blocker B in prefill_graph_blockers_2026_05_14). Default
+        // flipped to "relaxed" 2026-05-16 as the M3-probe for prefill_graph
+        // unblock — `cudaStreamCaptureModeRelaxed` is a strict superset of
+        // capturable behaviors so the decode fast path that previously
+        // worked under "global" continues to work, while the prefill path
+        // gets a real chance of capturing without hanging.
+        //
+        // Set graph_capture_mode = "global" via imp.conf to opt back into
+        // the legacy strict mode (any decode regression should also be
+        // investigated under "thread_local" before assuming relaxed is the
+        // cause). Legacy env: IMP_GRAPH_CAPTURE_MODE.
+        std::string graph_capture_mode = "relaxed";
         // Opt-in: capture prefill into a CUDA graph (in addition to decode).
         // Legacy env: IMP_PREFILL_GRAPH.
         bool prefill_graph = false;

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -12,26 +12,50 @@
 
 namespace imp {
 
-// runtime.graph_capture_mode = "global" (default) | "relaxed" | "thread_local"
+// runtime.graph_capture_mode = "global" | "relaxed" (default) | "thread_local"
 // (legacy env: IMP_GRAPH_CAPTURE_MODE). Selects the cudaStreamCaptureMode
 // used by CudaGraphCapture::begin_capture and the ConditionalRunner body-graph
 // capture. Probed at first call and cached.
 //
-// Why this exists: CUTLASS 3.x grouped GEMM hangs under cudaStreamCaptureModeGlobal
-// for some NVFP4 MoE configs (see prefill_graph_blockers_2026_05_14). Relaxed
-// drops the cross-thread synchronization constraint and may avoid the deadlock.
+// Why "relaxed" became the default (M3-probe, 2026-05-16): CUTLASS 3.x grouped
+// GEMM was observed to silently HANG under cudaStreamCaptureModeGlobal during
+// NVFP4 MoE prefill capture (Blocker B in prefill_graph_blockers_2026_05_14
+// memo). Relaxed drops the cross-thread synchronization constraint that the
+// CUTLASS collective scheduler is suspected to deadlock on, and is a strict
+// superset of capturable behaviors — the decode fast path that previously
+// worked under "global" continues to work under "relaxed".
 static cudaStreamCaptureMode get_capture_mode() {
     static cudaStreamCaptureMode cached = []() {
-        const std::string& mode = RuntimeConfig::current().runtime.graph_capture_mode;
-        if (mode == "relaxed") {
-            IMP_LOG_INFO("CudaGraphCapture: using cudaStreamCaptureModeRelaxed (runtime.graph_capture_mode=relaxed)");
-            return cudaStreamCaptureModeRelaxed;
+        const auto& cfg = RuntimeConfig::current();
+        const std::string& mode = cfg.runtime.graph_capture_mode;
+        if (mode == "global") {
+            // Warn loudly when the user has both opted into prefill_graph AND
+            // the known-deadlocking strict capture mode — most common cause of
+            // a silent hang at first NVFP4 MoE prefill replay.
+            if (cfg.runtime.prefill_graph) {
+                IMP_LOG_WARN(
+                    "CudaGraphCapture: runtime.graph_capture_mode=\"global\" + "
+                    "runtime.prefill_graph=true is the known-hangy combination "
+                    "(prefill_graph_blockers_2026_05_14 memo Blocker B). "
+                    "Recommended: keep graph_capture_mode=\"relaxed\" (current "
+                    "default) when prefill_graph is enabled.");
+            }
+            IMP_LOG_INFO("CudaGraphCapture: using cudaStreamCaptureModeGlobal");
+            return cudaStreamCaptureModeGlobal;
         }
         if (mode == "thread_local") {
             IMP_LOG_INFO("CudaGraphCapture: using cudaStreamCaptureModeThreadLocal (runtime.graph_capture_mode=thread_local)");
             return cudaStreamCaptureModeThreadLocal;
         }
-        return cudaStreamCaptureModeGlobal;
+        // Default + "relaxed" branch:
+        if (mode != "relaxed") {
+            IMP_LOG_WARN(
+                "CudaGraphCapture: unknown runtime.graph_capture_mode=\"%s\", "
+                "falling back to \"relaxed\".",
+                mode.c_str());
+        }
+        IMP_LOG_INFO("CudaGraphCapture: using cudaStreamCaptureModeRelaxed (default for prefill-safe capture)");
+        return cudaStreamCaptureModeRelaxed;
     }();
     return cached;
 }


### PR DESCRIPTION
## Summary

M3-probe slice — flips the default `runtime.graph_capture_mode` from `"global"` to `"relaxed"` to unblock the next attempt at `prefill_graph` capture. Stacked on the M2+M4 batch (#195).

The full M3 plan (`review/phase5_synthesis.md §2.2` + memory `moe_prefill_graphs_plan_2026_05_10`) is currently blocked on **Blocker B** from memory `prefill_graph_blockers_2026_05_14`:

> CUTLASS 3.x grouped GEMM **silently HANG** under `cudaStreamCaptureModeGlobal` during NVFP4 MoE prefill capture (Qwen3-Coder-30B-A3B-NVFP4 killed by 120s timeout at first replay; no error log).

The hypothesis: CUTLASS's collective scheduler deadlocks on the cross-thread synchronization constraint that `"global"` enforces. Per CUDA Runtime docs, `cudaStreamCaptureModeRelaxed` is a **strict superset** of capturable behaviors — correctness-equivalent for graphs that captured cleanly under `"global"`, but permissive enough that CUTLASS internals should no longer deadlock.

## What this probe does

1. **Flip default** `runtime.graph_capture_mode` from `"global"` → `"relaxed"` (`src/runtime/config.h`).
2. **Defensive logging** in `src/runtime/cuda_graph.cu:get_capture_mode()`:
   - WARN if user explicitly sets `graph_capture_mode = "global"` AND `prefill_graph = true` (most common cause of silent hang at first MoE prefill replay).
   - Unknown mode strings now warn and fall back to `"relaxed"` instead of silently choosing `"global"`.
   - Active mode logged at INFO on first capture so any future hang is at least visible in the trace.
3. **Comments and seed_from_env semantics** kept compatible — `IMP_GRAPH_CAPTURE_MODE` legacy env still seeds the field.

## Why this is "the probe" and not "the fix"

I can't run a real model in this environment, so I can't confirm Blocker B is actually fixed by the relaxed mode. What this PR does:

- Makes it easy for the maintainer to A/B test prefill capture with one config flip
- Pre-warns about the known-bad combo so a future user doesn't burn a debugging session on it
- Stays correctness-equivalent on the decode fast path (which already worked under "global")

Empirical next step (maintainer-side): set `runtime.prefill_graph = true` and bench Qwen3-Coder-30B-A3B-NVFP4 prefill. If it captures cleanly: Phase 4 of M3 can flip `prefill_graph` to default-on. If it still hangs: Blocker B needs the deeper CUTLASS investigation (~1 dev-week per memo).

## Test plan

- [x] `make build` — green
- [x] `make verify-fast` — green (fast gtest filter PASS; decode graph capture still works at the new relaxed default)
- [x] No public C ABI change
- [ ] Maintainer: bench `imp-bench` with `runtime.prefill_graph = true` on Qwen3-Coder-30B-A3B-NVFP4 to confirm the hang resolves under relaxed
- [ ] Maintainer: if decode regression under "relaxed" appears in production, investigate "thread_local" mode before assuming relaxed is the cause (`thread_local` is the middle-strict variant)

## Rollback

`graph_capture_mode = "global"` in `imp.conf` (or `IMP_GRAPH_CAPTURE_MODE=global` env) reverts to legacy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)