### PR TITLE
refactor(graph): R5 Slice 1 — GemmKernel registry interface + FP16 proof

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ set(IMP_GRAPH_SOURCES
     src/graph/graph.cpp
     src/graph/executor.cu
     src/graph/executor_kernels.cu
+    src/graph/gemm_kernel_registry.cu
     src/graph/executor_workspace.cu
     src/graph/executor_workspace_buffers.cu
     src/graph/executor_kv_write.cu
@@ -422,6 +423,7 @@ if(IMP_BUILD_TESTS)
         tests/test_gemm.cu
         tests/test_gemm_capture_fp16_sm120.cu
         tests/test_gemm_dp4a.cu
+        tests/test_gemm_kernel_registry.cu
         tests/test_fp8_gemm.cu
         tests/test_mmvq.cu
         tests/test_reduce.cu

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -1,5 +1,6 @@
 #include "graph/executor_kernels.h"
 #include "graph/gemm_context.h"
+#include "graph/gemm_kernel_registry.h"
 #include "graph/executor.h"
 #include "core/logging.h"
 #include "runtime/config.h"
@@ -2364,6 +2365,38 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
     const auto* nv4 = (wc->nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->nvfp4;
     const auto* ct4 = (wc->cutlass_nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_nvfp4;
     const auto* mx4 = (wc->cutlass_mxfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_mxfp4;
+
+    // R5 Slice 1: when gemm.use_kernel_registry is enabled, try the new
+    // dispatch table first. Only the FP16 tier is wired in Slice 1; other
+    // tiers fall through to the legacy gemm_dispatch_impl below.
+    if (RuntimeConfig::current().gemm.use_kernel_registry) {
+        // The FP16 path is structurally simple — direct cuBLAS via the
+        // fp16 weight cache OR the raw weight when it's already FP16/BF16.
+        // Match the legacy preconditions: prefer the cache, then raw weight.
+        if (auto it = wc->fp16.find(weight.data); it != wc->fp16.end()) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.weight_payload = &it->second;
+            const int M = static_cast<int>(input.shape[0]);
+            GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        }
+        if ((qtype == QType::F16 || qtype == QType::BF16) && weight.qtype == QType::F16) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.weight_payload = &weight;
+            const int M = static_cast<int>(input.shape[0]);
+            GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        }
+        // Fall through: registry returned NoMatch for this strategy — use legacy.
+    }
 
     gemm_dispatch_impl(input, weight, Tensor(), qtype, output, qs->dequant, ctx.stream,
                        static_cast<block_q8_1*>(qs->q8_1_buf), qs->d8_buf, fp16, fp8, qs->fp8_act,

--- a/src/graph/gemm_kernel_registry.cu
+++ b/src/graph/gemm_kernel_registry.cu
@@ -1,0 +1,84 @@
+#include "graph/gemm_kernel_registry.h"
+#include "compute/gemm.h"
+#include "core/logging.h"
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// Singleton storage
+// ---------------------------------------------------------------------------
+GemmKernelRegistry& GemmKernelRegistry::instance() {
+    static GemmKernelRegistry registry;
+    return registry;
+}
+
+void GemmKernelRegistry::register_kernel(GemmStrategy strategy, GemmKernelFn fn) {
+    IMP_CHECK(fn != nullptr, "GemmKernelRegistry::register_kernel: fn is null");
+    // Check for existing entry (slice 1 expects at most one per strategy).
+    for (std::size_t i = 0; i < count_; ++i) {
+        if (entries_[i].strategy == strategy) {
+            IMP_LOG_WARN(
+                "GemmKernelRegistry: overriding existing entry (tier=%d qtype=%d m_is_one=%d)",
+                static_cast<int>(strategy.tier), static_cast<int>(strategy.weight_qtype),
+                strategy.m_is_one ? 1 : 0);
+            entries_[i].fn = fn;
+            return;
+        }
+    }
+    IMP_CHECK(count_ < (sizeof(entries_) / sizeof(entries_[0])),
+              "GemmKernelRegistry: capacity exceeded (max=%zu)",
+              sizeof(entries_) / sizeof(entries_[0]));
+    entries_[count_].strategy = strategy;
+    entries_[count_].fn = fn;
+    ++count_;
+}
+
+GemmDispatchResult GemmKernelRegistry::dispatch(const GemmStrategy& strategy,
+                                                const GemmKernelArgs& args) const {
+    for (std::size_t i = 0; i < count_; ++i) {
+        if (entries_[i].strategy == strategy)
+            return entries_[i].fn(args);
+    }
+    return GemmDispatchResult::NoMatch;
+}
+
+std::size_t GemmKernelRegistry::size() const noexcept { return count_; }
+
+// ---------------------------------------------------------------------------
+// FP16 tier — proof-of-concept registration. Input + weight + output all
+// FP16; delegate to the existing cuBLAS-backed `gemm()` host wrapper.
+//
+// Strategy: tier=FP16, weight_qtype=F16, m_is_one == either (cuBLAS
+// handles both M=1 GEMV and M>1 GEMM through the same API; no need to
+// register a separate GEMV strategy for FP16).
+// ---------------------------------------------------------------------------
+static GemmDispatchResult fp16_gemm_kernel(const GemmKernelArgs& args) {
+    IMP_CHECK(args.input != nullptr, "fp16_gemm_kernel: input is null");
+    IMP_CHECK(args.output != nullptr, "fp16_gemm_kernel: output is null");
+    IMP_CHECK(args.weight_payload != nullptr, "fp16_gemm_kernel: weight_payload is null");
+
+    const Tensor& weight = *static_cast<const Tensor*>(args.weight_payload);
+    IMP_CHECK(weight.qtype == QType::F16, "fp16_gemm_kernel: weight qtype=%d, expected F16",
+              static_cast<int>(weight.qtype));
+    gemm(*args.input, weight, *args.output, /*alpha=*/1.0f, args.beta, args.stream);
+    return GemmDispatchResult::Ok;
+}
+
+// Static registration. The .cu translation unit gets linked into libimp
+// when the registry header is included downstream; this static initializer
+// runs at library load. Slice 1 registers only FP16 (m_is_one=false; the
+// dispatcher uses this entry for both M=1 and M>1 — see GemmKernelArgs.m_is_one
+// comment in the header).
+namespace {
+struct FP16Registration {
+    FP16Registration() {
+        GemmKernelRegistry::instance().register_kernel(
+            GemmStrategy{StorageTier::FP16, QType::F16, /*m_is_one=*/false}, &fp16_gemm_kernel);
+        GemmKernelRegistry::instance().register_kernel(
+            GemmStrategy{StorageTier::FP16, QType::F16, /*m_is_one=*/true}, &fp16_gemm_kernel);
+    }
+};
+static FP16Registration s_fp16_registration;
+}  // namespace
+
+}  // namespace imp

--- a/src/graph/gemm_kernel_registry.h
+++ b/src/graph/gemm_kernel_registry.h
@@ -1,0 +1,146 @@
+#pragma once
+
+// GemmKernel registry — R5 first-domino cross-axis refactor (slice 1).
+//
+// Replaces the 21-parameter `gemm_dispatch_impl` god-dispatcher (review
+// phase3_maint.md §2 #1) with a single small args struct and a (Strategy
+// -> function pointer) registry. Adding a new qtype/quantization tier
+// becomes a single-file change: register an entry; nothing else moves.
+//
+// Slice 1 scope: define the interface, register only the FP16 tier as
+// proof-of-concept. Live dispatch tries the registry first when the
+// runtime config flag `gemm.use_kernel_registry` is true and falls back
+// to the legacy `gemm_dispatch_impl` for tiers not yet registered.
+// Default flag is OFF so production behavior is unchanged.
+//
+// Future slices migrate FP8, NVFP4, CUTLASS_NVFP4, MXFP4 tiers one at a
+// time; once every dispatch site is covered the legacy path can be
+// deleted (the cross-axis maintainability + extensibility win from
+// review phase5_synthesis.md §5).
+
+#include "core/storage_tier.h"
+#include "core/tensor.h"
+#include "model/model_config.h"  // QType
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace imp {
+
+// Forward-declared payload structs (defined in their owning TUs).
+struct FP8CacheEntry;
+struct NvFP4QuantResult;
+struct CutlassNvFP4Weight;
+struct CutlassMxFP4Weight;
+
+// ---------------------------------------------------------------------------
+// Strategy key — fully describes which kernel handles a dispatch request.
+// `qtype` is the WEIGHT qtype (input qtype is always FP16 on the dispatch
+// hot path today). `m_is_one` separates GEMV (M==1, decode) from GEMM
+// (M>1, prefill) because the two reach different kernels even within the
+// same tier (e.g. NVFP4 GEMV vs NVFP4 dequant->GEMM).
+// ---------------------------------------------------------------------------
+struct GemmStrategy {
+    StorageTier tier = StorageTier::Undefined;
+    QType weight_qtype = QType::F16;
+    bool m_is_one = false;
+
+    bool operator==(const GemmStrategy& o) const noexcept {
+        return tier == o.tier && weight_qtype == o.weight_qtype && m_is_one == o.m_is_one;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Args struct — replaces the 21 trailing parameters of the legacy
+// gemm_dispatch_impl. Per-tier handlers cast `weight_payload` to the
+// tier-appropriate pointer type (Tensor* for FP16, FP8CacheEntry* for
+// FP8, NvFP4QuantResult* for NVFP4, etc.).
+// ---------------------------------------------------------------------------
+struct GemmKernelArgs {
+    // Required across every tier
+    const Tensor* input = nullptr;        // [M, K] FP16
+    Tensor* output = nullptr;             // [M, N] FP16 (or FP32 for some LM-head paths)
+    cudaStream_t stream = nullptr;
+    float beta = 0.0f;                    // residual-fused GEMM on FP16 paths only
+
+    // Tier-specific weight handle. Casts:
+    //   FP16            -> const Tensor*
+    //   FP8             -> const FP8CacheEntry*
+    //   NVFP4           -> const NvFP4QuantResult*
+    //   CUTLASS_NVFP4   -> const CutlassNvFP4Weight*
+    //   MXFP4           -> const CutlassMxFP4Weight*
+    const void* weight_payload = nullptr;
+
+    // Workspace pointers — only some tiers consume them. nullptr means the
+    // caller did not supply that workspace; the kernel must either degrade
+    // (fall back to a non-workspace path) or fail loud via IMP_CHECK.
+    void* dequant_scratch = nullptr;
+    size_t dequant_scratch_size = 0;
+    void* cutlass_act_data = nullptr;
+    void* cutlass_act_sf = nullptr;
+    void* cutlass_workspace = nullptr;
+    size_t cutlass_workspace_size = 0;
+    void* mxfp4_act_sf = nullptr;
+    void* mxfp4_workspace = nullptr;
+    size_t mxfp4_workspace_size = 0;
+    void* fp8_act_buf = nullptr;
+    float* d_act_scale = nullptr;
+    float* d_fp8_block_maxes = nullptr;
+    float* d_fp8_absmax = nullptr;
+    int fp8_max_grid = 0;
+};
+
+// Result of a dispatch attempt.
+enum class GemmDispatchResult {
+    Ok = 0,             // kernel ran; caller is done
+    NoMatch = 1,        // no registered kernel for this strategy; caller falls back
+    PreconditionFail = 2, // kernel rejected the args (e.g. workspace nullptr); caller falls back
+};
+
+// Per-kernel function signature.
+using GemmKernelFn = GemmDispatchResult (*)(const GemmKernelArgs& args);
+
+// ---------------------------------------------------------------------------
+// Registry singleton.
+//
+// `register_kernel` populates the table at static-init time (each tier's
+// .cu file calls it from a `__attribute__((constructor))` or
+// `static const int _reg = (register_kernel(...), 0);` idiom). `dispatch`
+// is the hot-path entry — does a linear scan over the (small) table and
+// invokes the matching kernel.
+// ---------------------------------------------------------------------------
+class GemmKernelRegistry {
+public:
+    static GemmKernelRegistry& instance();
+
+    // Idempotent: re-registering the same strategy overrides the prior
+    // entry and logs IMP_LOG_WARN. Slice 1 expects at most one registration
+    // per strategy.
+    void register_kernel(GemmStrategy strategy, GemmKernelFn fn);
+
+    // Returns NoMatch if no registered handler covers `strategy`. Otherwise
+    // invokes the kernel and propagates its result. Hot-path safe (no
+    // allocation, no mutex acquisition after init).
+    GemmDispatchResult dispatch(const GemmStrategy& strategy, const GemmKernelArgs& args) const;
+
+    // Diagnostic: returns the number of registered strategies. Useful for
+    // tests asserting that the static registration ran.
+    std::size_t size() const noexcept;
+
+private:
+    GemmKernelRegistry() = default;
+    GemmKernelRegistry(const GemmKernelRegistry&) = delete;
+    GemmKernelRegistry& operator=(const GemmKernelRegistry&) = delete;
+
+    // Small-N linear scan — production table holds at most ~8 entries
+    // even after the full migration; std::vector + linear scan beats a
+    // hash map for this size and avoids the std::unordered_map alloc.
+    struct Entry {
+        GemmStrategy strategy;
+        GemmKernelFn fn;
+    };
+    Entry entries_[16] = {};
+    std::size_t count_ = 0;
+};
+
+}  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -194,6 +194,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.no_mmvq = parse_bool(val, cfg.gemm.no_mmvq);
     else if (eq("gemm.no_mmvq_q8_0"))
         cfg.gemm.no_mmvq_q8_0 = parse_bool(val, cfg.gemm.no_mmvq_q8_0);
+    else if (eq("gemm.use_kernel_registry"))
+        cfg.gemm.use_kernel_registry = parse_bool(val, cfg.gemm.use_kernel_registry);
 
     // [gemma4]
     else if (eq("gemma4.fp32_gemm_out"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -121,6 +121,12 @@ struct RuntimeConfig {
         bool no_dp4a_lm = false;
         bool no_mmvq = false;
         bool no_mmvq_q8_0 = false;
+        // R5 (review/phase5_synthesis.md §5): opt into the new GemmKernel
+        // registry. Slice 1 has only the FP16 tier wired; remaining tiers
+        // (FP8, NVFP4, CUTLASS_NVFP4, MXFP4) still go through the legacy
+        // gemm_dispatch_impl regardless of this flag. Default OFF until
+        // every tier is migrated.
+        bool use_kernel_registry = false;
     } gemm;
 
     struct Gemma4 {

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -1,0 +1,119 @@
+#include "graph/gemm_kernel_registry.h"
+#include "compute/gemm.h"
+#include "core/tensor.h"
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <vector>
+#include <cmath>
+
+using namespace imp;
+
+// ---------------------------------------------------------------------------
+// R5 Slice 1 — GemmKernel registry tests.
+//
+// Pin the public contract of the registry so future migrations of FP8 /
+// NVFP4 / CUTLASS_NVFP4 / MXFP4 tiers don't accidentally reshape the
+// dispatch surface.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+class GemmKernelRegistryTest : public ::testing::Test {
+protected:
+    void SetUp() override { cudaStreamCreate(&stream_); }
+    void TearDown() override { cudaStreamDestroy(stream_); }
+    cudaStream_t stream_ = nullptr;
+};
+
+// The FP16 kernel is registered at static-init via the FP16Registration
+// struct in gemm_kernel_registry.cu. We expect entries for both
+// (m_is_one=true) and (m_is_one=false) FP16 strategies.
+TEST_F(GemmKernelRegistryTest, Fp16KernelIsRegisteredAtStaticInit) {
+    const auto& reg = GemmKernelRegistry::instance();
+    EXPECT_GE(reg.size(), 2u) << "FP16 kernel (M==1 and M>1) expected to be pre-registered";
+}
+
+TEST_F(GemmKernelRegistryTest, UnregisteredStrategyReturnsNoMatch) {
+    const auto& reg = GemmKernelRegistry::instance();
+    // CUTLASS_NVFP4 is not registered yet — Slice 1 has only FP16.
+    GemmStrategy unregistered{StorageTier::CUTLASS_NVFP4, QType::F16, /*m_is_one=*/true};
+    GemmKernelArgs args{};
+    args.stream = stream_;
+    EXPECT_EQ(reg.dispatch(unregistered, args), GemmDispatchResult::NoMatch);
+}
+
+// End-to-end correctness: register-then-dispatch produces the same output
+// as calling gemm() directly. Uses small dims so the test is fast.
+TEST_F(GemmKernelRegistryTest, Fp16RegistryDispatchMatchesDirectGemm) {
+    constexpr int M = 4;
+    constexpr int N = 8;
+    constexpr int K = 16;
+
+    // Initialize input + weight with deterministic FP16 values.
+    std::vector<__half> h_input(M * K);
+    std::vector<__half> h_weight(N * K);
+    for (int i = 0; i < M * K; ++i) h_input[i] = __float2half((i % 7) * 0.125f - 0.5f);
+    for (int i = 0; i < N * K; ++i) h_weight[i] = __float2half((i % 11) * 0.0625f - 0.25f);
+
+    __half *d_input, *d_weight, *d_out_direct, *d_out_registry;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_weight, sizeof(__half) * N * K);
+    cudaMalloc(&d_out_direct, sizeof(__half) * M * N);
+    cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_weight, h_weight.data(), sizeof(__half) * N * K, cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(d_weight, QType::F16, 2, w_shape, /*on_device=*/true);
+    Tensor out_direct(d_out_direct, QType::F16, 2, out_shape, /*on_device=*/true);
+    Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    // Path 1: direct gemm()
+    gemm(input, weight, out_direct, /*alpha=*/1.0f, /*beta=*/0.0f, stream_);
+
+    // Path 2: registry dispatch
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out_registry;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    GemmStrategy strat{StorageTier::FP16, QType::F16, /*m_is_one=*/false};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+
+    cudaStreamSynchronize(stream_);
+
+    // Compare bit-identical (both paths invoke the same gemm() backend).
+    std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);
+    cudaMemcpy(h_out_direct.data(), d_out_direct, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_out_registry.data(), d_out_registry, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+
+    for (int i = 0; i < M * N; ++i) {
+        EXPECT_EQ(__half_as_ushort(h_out_direct[i]), __half_as_ushort(h_out_registry[i]))
+            << "Mismatch at i=" << i << " (direct=" << __half2float(h_out_direct[i])
+            << " registry=" << __half2float(h_out_registry[i]) << ")";
+    }
+
+    cudaFree(d_input);
+    cudaFree(d_weight);
+    cudaFree(d_out_direct);
+    cudaFree(d_out_registry);
+}
+
+// Pin the GemmStrategy operator== contract — used by the linear-scan
+// lookup in dispatch().
+TEST(GemmStrategy, EqualityIsByValue) {
+    GemmStrategy a{StorageTier::FP16, QType::F16, /*m_is_one=*/true};
+    GemmStrategy b{StorageTier::FP16, QType::F16, /*m_is_one=*/true};
+    GemmStrategy c{StorageTier::FP16, QType::F16, /*m_is_one=*/false};
+    GemmStrategy d{StorageTier::FP8, QType::F16, /*m_is_one=*/true};
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a == c);
+    EXPECT_FALSE(a == d);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

First domino of R5 (`review/phase5_synthesis.md §5` — the cross-axis champion: kills `WeightCaches` god-struct + 21-param `gemm_dispatch_impl` + duplicate `weight_dispatch.cu` table once every tier is migrated). This slice ships the **foundation** without changing any production behavior. Stacked on M3-probe (#196).

## What's here

| File | Role |
|---|---|
| `src/graph/gemm_kernel_registry.h` (new) | Abstract interface: `GemmStrategy` key + `GemmKernelArgs` struct + `GemmKernelFn` typedef + `GemmKernelRegistry` singleton (small-N linear scan, max 16 entries) |
| `src/graph/gemm_kernel_registry.cu` (new) | Registry storage + FP16 kernel registration (delegates to `compute/gemm.h` cuBLAS wrapper). Both `M==1` and `M>1` strategies wired |
| `src/runtime/config.{h,cpp}` | New flag `gemm.use_kernel_registry` (default **off**) |
| `src/graph/executor_kernels.cu` | `gemm_dispatch` tries the registry when the flag is on; falls through to legacy `gemm_dispatch_impl` for unregistered tiers |
| `tests/test_gemm_kernel_registry.cu` (new) | 4 GTest cases: static-init pinning, NoMatch fall-through, bit-identical vs `gemm()` direct, `GemmStrategy::operator==` invariant |

## Behavior

- `gemm.use_kernel_registry = false` (default): production unchanged; every call goes through `gemm_dispatch_impl`.
- `gemm.use_kernel_registry = true`: FP16 GEMMs route through the registry; everything else (FP8, NVFP4, CUTLASS_NVFP4, MXFP4, raw Q_K) falls through to legacy.

## Why FP16 first

Simplest tier — no workspace, no quantize-input step, no special-case M==1 vs M>1 dispatch. Validates the args-struct + registry pattern before the harder tiers are migrated.

## Per-tier migration path (future slices)

| Slice | Tier | Notes |
|---|---|---|
| 2 | FP8 | FP8CacheEntry weight payload + fp8_act_buf + d_act_scale |
| 3 | NVFP4 GEMV | NvFP4QuantResult, M==1 strategy |
| 4 | NVFP4 GEMM | M>1 strategy with dequant fallback |
| 5 | CUTLASS_NVFP4 | CutlassNvFP4Weight + cutlass_act_data + sf + workspace |
| 6 | MXFP4 | CutlassMxFP4Weight + workspace |
| 7 | dp4a / mmvq | Q*_K paths with q8_1_buf + d8_buf |
| 8 | **Delete** `gemm_dispatch_impl` + `WeightCaches` god-struct |

After Slice 8: **adding a new qtype = register one strategy in one file**. The cross-axis maintainability + extensibility win promised in P5 §5 (and the perf win — the dispatch indirection that hides the 14.7× NVFP4 prefill gap becomes a single function call).

## Test plan

- [x] `make build` — green
- [x] `make verify-fast` — green (`GemmKernelRegistryTest` 4/4 pass; production tests unaffected because flag defaults off)
- [x] No public C ABI change
- [ ] Maintainer: opt into `gemm.use_kernel_registry = true` in CI for a release cycle to validate the FP16 hot path under real workloads before Slice 2 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)