### PR TITLE
perf(runtime): M5 Slice 1 — cluster-launch helper for FMHA prefill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,7 @@ if(IMP_BUILD_TESTS)
         tests/test_gemm_capture_fp16_sm120.cu
         tests/test_gemm_dp4a.cu
         tests/test_gemm_kernel_registry.cu
+        tests/test_cluster_launch.cu
         tests/test_fp8_gemm.cu
         tests/test_mmvq.cu
         tests/test_reduce.cu

--- a/src/compute/attention_paged.cu
+++ b/src/compute/attention_paged.cu
@@ -2,6 +2,7 @@
 #include "compute/attention_paged_common.cuh"
 #include "compute/attention.h"
 #include "core/logging.h"
+#include "runtime/cluster_launch.h"
 #include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -1453,25 +1454,17 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
             dim3 cluster_grid(batch_size * n_q_per_kv, n_kv_heads);
             dim3 cluster_block(BLOCK_THREADS);
 
-            cudaLaunchConfig_t config = {};
-            config.gridDim = cluster_grid;
-            config.blockDim = cluster_block;
-            config.dynamicSmemBytes = cluster_smem;
-            config.stream = stream;
-
             // CUDA 13.2: spread cluster blocks across GPCs (GB202 has 12 GPCs).
             // Default "load-balancing" packs clusters per-GPC, which oversubscribes
             // a single GPC's L1/SMEM/tensor-core resources when only a handful of
             // clusters are live. Spread gives each cluster its own GPC on RTX 5090
             // as long as the grid is small enough, keeping DSMEM traffic local and
             // freeing other GPCs for concurrent decode work on a separate stream.
+            // M5 Slice 1: cluster_launch.h hides the attribute boilerplate.
             cudaLaunchAttribute attrs[2];
-            attrs[0].id = cudaLaunchAttributeClusterDimension;
-            attrs[0].val.clusterDim = {(unsigned int)n_q_per_kv, 1, 1};
-            attrs[1].id = cudaLaunchAttributeClusterSchedulingPolicyPreference;
-            attrs[1].val.clusterSchedulingPolicyPreference = cudaClusterSchedulingPolicySpread;
-            config.attrs = attrs;
-            config.numAttrs = 2;
+            cudaLaunchConfig_t config = cluster::build_cluster_config(
+                cluster_grid, cluster_block, cluster_smem, stream, attrs,
+                /*cluster_x=*/static_cast<unsigned int>(n_q_per_kv));
 
 #define LAUNCH_CLUSTER(HD)                                                                                 \
     cudaLaunchKernelEx(&config, paged_attention_cluster_kernel<HD>, reinterpret_cast<const half*>(Q.data), \

--- a/src/runtime/cluster_launch.h
+++ b/src/runtime/cluster_launch.h
@@ -1,0 +1,99 @@
+#pragma once
+
+// Cluster launch helper — wraps the cudaLaunchKernelEx + cluster-dimension
+// + GPC-spread scheduling boilerplate that paged_attention_cluster_kernel
+// established for DSMEM K-broadcast across Q-heads (sm_90+; works on
+// sm_120a / Consumer Blackwell with the same calling convention).
+//
+// M5 Slice 1 from review/phase5_synthesis.md §2.2:
+//   - The existing decode-path GQA cluster launcher at
+//     src/compute/attention_paged.cu:1456-1474 is the working reference.
+//   - Slice 1 extracts that boilerplate into a reusable
+//     cluster_launch(kernel, ...) template so a future FMHA-prefill
+//     migration (Slice 2) can opt into cluster launch without copying
+//     20 lines of attribute setup.
+//
+// GB202 specifics:
+//   - 12 GPCs. Default cluster scheduling packs clusters per-GPC which
+//     oversubscribes when only a handful are live. `Spread` gives each
+//     cluster its own GPC for small grids, keeping DSMEM traffic local
+//     and freeing remaining GPCs for concurrent work on other streams.
+//   - Cluster dimension must be a power of 2 (CUDA requirement).
+//   - DSMEM is part of distributed shared memory: blocks within a cluster
+//     can read each other's smem via `cluster.map_shared_rank(...)`.
+
+#include <cuda_runtime.h>
+
+namespace imp {
+
+namespace cluster {
+
+// Default cluster scheduling on GB202: Spread across GPCs for small
+// grids. Override with cudaClusterSchedulingPolicyDefault if grids are
+// large enough to saturate every GPC organically (in practice, every
+// imp cluster launch today is in the spread-favorable regime).
+inline cudaLaunchAttribute spread_attr() {
+    cudaLaunchAttribute attr = {};
+    attr.id = cudaLaunchAttributeClusterSchedulingPolicyPreference;
+    attr.val.clusterSchedulingPolicyPreference = cudaClusterSchedulingPolicySpread;
+    return attr;
+}
+
+inline cudaLaunchAttribute cluster_dim_attr(unsigned int x, unsigned int y = 1, unsigned int z = 1) {
+    cudaLaunchAttribute attr = {};
+    attr.id = cudaLaunchAttributeClusterDimension;
+    attr.val.clusterDim = {x, y, z};
+    return attr;
+}
+
+// Build a cudaLaunchConfig_t for a cluster launch. `attrs` must point to
+// storage with lifetime spanning the launch call (caller-owned). The
+// helper writes (cluster_dim, spread_policy) into attrs[0..1] and sets
+// config.attrs/numAttrs accordingly. Callers can append more attributes
+// (PDL, access-policy window) after the helper returns by extending
+// attrs[] and bumping numAttrs.
+//
+// Returns by value; callers pass `&config` to cudaLaunchKernelEx.
+inline cudaLaunchConfig_t build_cluster_config(dim3 grid, dim3 block, size_t dyn_smem,
+                                               cudaStream_t stream, cudaLaunchAttribute* attrs,
+                                               unsigned int cluster_x, unsigned int cluster_y = 1,
+                                               unsigned int cluster_z = 1) {
+    attrs[0] = cluster_dim_attr(cluster_x, cluster_y, cluster_z);
+    attrs[1] = spread_attr();
+    cudaLaunchConfig_t config = {};
+    config.gridDim = grid;
+    config.blockDim = block;
+    config.dynamicSmemBytes = dyn_smem;
+    config.stream = stream;
+    config.attrs = attrs;
+    config.numAttrs = 2;
+    return config;
+}
+
+// Convenience: launch a cluster kernel with (cluster_x, 1, 1) cluster
+// dimension + GPC-spread scheduling. For more complex attribute mixes
+// (cluster + PDL, cluster + access-policy), build the config + attr
+// array by hand using the helpers above.
+//
+// Returns cudaLaunchKernelEx's status — caller is responsible for
+// IMP_CUDA_CHECK_LOG / abort on failure.
+template <typename KernelFunc, typename... Args>
+cudaError_t launch_cluster_1d(KernelFunc func, dim3 grid, dim3 block, size_t dyn_smem,
+                              cudaStream_t stream, unsigned int cluster_x, Args... args) {
+    cudaLaunchAttribute attrs[2];
+    cudaLaunchConfig_t config = build_cluster_config(grid, block, dyn_smem, stream, attrs, cluster_x);
+    return cudaLaunchKernelEx(&config, func, args...);
+}
+
+// Cluster dimension validity check (CUDA requires power-of-2 in each axis
+// and total cluster size ≤ 16 on GB202). Use at launch sites that
+// dispatch on a runtime value (e.g. n_q_per_kv in GQA attention).
+inline bool valid_cluster_dim(unsigned int x, unsigned int y = 1, unsigned int z = 1) {
+    auto is_pow2 = [](unsigned int v) { return v > 0 && (v & (v - 1)) == 0; };
+    if (!is_pow2(x) || !is_pow2(y) || !is_pow2(z)) return false;
+    return (x * y * z) <= 16u;
+}
+
+}  // namespace cluster
+
+}  // namespace imp

--- a/tests/test_cluster_launch.cu
+++ b/tests/test_cluster_launch.cu
@@ -1,0 +1,71 @@
+#include "runtime/cluster_launch.h"
+
+#include <gtest/gtest.h>
+
+using namespace imp;
+
+// ---------------------------------------------------------------------------
+// M5 Slice 1 — cluster_launch helper unit tests.
+//
+// These pin the pure-host helpers (config builders, validity checks)
+// without requiring a GPU launch. The full cluster kernel A/B that
+// validates DSMEM K-broadcast performance lives in the FMHA prefill
+// migration (Slice 2 of M5).
+// ---------------------------------------------------------------------------
+
+TEST(ClusterLaunch, ValidClusterDimsArePow2AndLeq16) {
+    EXPECT_TRUE(cluster::valid_cluster_dim(1));
+    EXPECT_TRUE(cluster::valid_cluster_dim(2));
+    EXPECT_TRUE(cluster::valid_cluster_dim(4));
+    EXPECT_TRUE(cluster::valid_cluster_dim(8));
+    EXPECT_TRUE(cluster::valid_cluster_dim(16));
+    EXPECT_TRUE(cluster::valid_cluster_dim(2, 2));   // 4 total
+    EXPECT_TRUE(cluster::valid_cluster_dim(4, 4));   // 16 total
+    EXPECT_TRUE(cluster::valid_cluster_dim(8, 2));   // 16 total
+}
+
+TEST(ClusterLaunch, InvalidClusterDimsRejected) {
+    EXPECT_FALSE(cluster::valid_cluster_dim(0));      // zero is not pow-2
+    EXPECT_FALSE(cluster::valid_cluster_dim(3));      // not pow-2
+    EXPECT_FALSE(cluster::valid_cluster_dim(5));
+    EXPECT_FALSE(cluster::valid_cluster_dim(6));
+    EXPECT_FALSE(cluster::valid_cluster_dim(7));
+    EXPECT_FALSE(cluster::valid_cluster_dim(32));     // >16 total
+    EXPECT_FALSE(cluster::valid_cluster_dim(8, 4));   // 32 total
+    EXPECT_FALSE(cluster::valid_cluster_dim(4, 8));   // 32 total
+}
+
+TEST(ClusterLaunch, BuildConfigPopulatesAttrsAndDims) {
+    cudaLaunchAttribute attrs[2];
+    const dim3 grid(64, 1);
+    const dim3 block(128);
+    const size_t smem = 32 * 1024;
+    cudaLaunchConfig_t cfg =
+        cluster::build_cluster_config(grid, block, smem, /*stream=*/nullptr, attrs, /*cluster_x=*/4);
+
+    EXPECT_EQ(cfg.gridDim.x, grid.x);
+    EXPECT_EQ(cfg.gridDim.y, grid.y);
+    EXPECT_EQ(cfg.blockDim.x, block.x);
+    EXPECT_EQ(cfg.dynamicSmemBytes, smem);
+    EXPECT_EQ(cfg.stream, nullptr);
+    EXPECT_EQ(cfg.numAttrs, 2u);
+    EXPECT_EQ(cfg.attrs, attrs);
+
+    EXPECT_EQ(attrs[0].id, cudaLaunchAttributeClusterDimension);
+    EXPECT_EQ(attrs[0].val.clusterDim.x, 4u);
+    EXPECT_EQ(attrs[0].val.clusterDim.y, 1u);
+    EXPECT_EQ(attrs[0].val.clusterDim.z, 1u);
+
+    EXPECT_EQ(attrs[1].id, cudaLaunchAttributeClusterSchedulingPolicyPreference);
+    EXPECT_EQ(attrs[1].val.clusterSchedulingPolicyPreference, cudaClusterSchedulingPolicySpread);
+}
+
+TEST(ClusterLaunch, BuildConfig3D) {
+    cudaLaunchAttribute attrs[2];
+    cudaLaunchConfig_t cfg = cluster::build_cluster_config(dim3(1, 1), dim3(32), 0, nullptr, attrs,
+                                                            /*cluster_x=*/2, /*cluster_y=*/2,
+                                                            /*cluster_z=*/2);  // 8 total
+    EXPECT_EQ(attrs[0].val.clusterDim.x, 2u);
+    EXPECT_EQ(attrs[0].val.clusterDim.y, 2u);
+    EXPECT_EQ(attrs[0].val.clusterDim.z, 2u);
+}


### PR DESCRIPTION
## Summary

First slice of **M5** (`review/phase5_synthesis.md §2.2`): the FMHA prefill path needs DSMEM K-broadcast across cluster CTAs to recover **+10-20% pp4096+** on FP16 non-MoE prefill. Before that kernel work starts, this slice extracts the cluster-launch boilerplate into a reusable helper. Stacked on R5 Slice 1 (#197).

## What's here

`src/runtime/cluster_launch.h` (new):

- `cluster::valid_cluster_dim(x, [y, z])` — pow-2 + total ≤ 16 check
- `cluster::build_cluster_config(...)` — writes cluster_dim + spread-policy attrs, returns `cudaLaunchConfig_t`
- `cluster::launch_cluster_1d(...)` — templated all-in-one launcher
- `cluster::spread_attr()` / `cluster_dim_attr()` — building blocks for custom attr mixes (cluster + PDL + L2 etc.)

`tests/test_cluster_launch.cu` (new) — 4 pure-host gtest cases pinning the helper contract.

`src/compute/attention_paged.cu` — refactors the existing decode-GQA cluster launcher (lines 1456-1474) to use `cluster::build_cluster_config`. **Proof that the API is usable from a real call site.** Behavior bit-identical (verified by `verify-fast`).

## Why a dedicated helper

GB202 has 12 GPCs. Default cluster scheduling packs clusters per-GPC, oversubscribing one GPC's L1/SMEM/tensor-core resources when only a handful are live. `Spread` gives each cluster its own GPC for small grids, keeping DSMEM traffic local. Cluster dimension must be pow-2, total ≤ 16. The helper bakes in these GB202-specific defaults so future cluster-launch sites pick them up automatically.

## M5 Slice 2 (next, not in this PR)

Port the FMHA prefill kernel (`src/compute/attention_fmha_sm120.cu`) to a clustered variant that shares K-blocks via DSMEM across the GQA Q-heads, modelled after the working `paged_attention_cluster_kernel<HD>` template. Uses the helpers from this PR.

## Test plan

- [x] `make build` — green
- [x] `make verify-fast` — green (4 new `ClusterLaunch` tests pass; existing paged-attention decode tests unaffected by the refactor)
- [x] No public C ABI change
- [x] No behavior change (helper extraction only; decode cluster launch produces bit-identical attribute mix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)