### PR TITLE
perf(compute): M5 Slice 2.2 — FP8 FMHA prefill cluster variant

### DIFF
--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -942,6 +942,13 @@ bool fmha_sm120_fp8_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
     if (Q.qtype != QType::F16)
         return false;
 
+    // M5 Slice 2.2: prefer the FP8 cluster kernel on eligible GQA configs.
+    // Same gate as the FP16 variant plus HD%32==0 (FP8 MMA requirement, so
+    // HD=96 falls through to the legacy per-head kernel).
+    if (try_fmha_sm120_fp8_cluster_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream)) {
+        return true;
+    }
+
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int seq_q = static_cast<int>(Q.shape[1]);
     const int n_heads = static_cast<int>(Q.shape[2]);

--- a/src/compute/attention_fmha_sm120.h
+++ b/src/compute/attention_fmha_sm120.h
@@ -45,4 +45,13 @@ bool fmha_sm120_fp8_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
 bool try_fmha_sm120_cluster_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                                     bool causal, int sliding_window, float softcap, cudaStream_t stream);
 
+// FP8 variant of the cluster kernel. DSMEM still carries FP16 K so the
+// staging copy stays symmetric with the FP16 cluster path; each block
+// converts its staged FP16 K to FP8 E4M3 once per iter before the
+// m16n8k32 MMA. PV stays FP16 WMMA. Rejects HD % 32 != 0 (FP8 MMA
+// requirement — drops HD=96 from the eligible set).
+bool try_fmha_sm120_fp8_cluster_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
+                                        float scale, bool causal, int sliding_window, float softcap,
+                                        cudaStream_t stream);
+
 }  // namespace imp

--- a/src/compute/attention_fmha_sm120_cluster.cu
+++ b/src/compute/attention_fmha_sm120_cluster.cu
@@ -468,6 +468,453 @@ int select_cluster_Bq(int HD, int max_smem) {
         }                                                                                                   \
     } while (0)
 
+// =========================================================================
+// FP8 cluster kernel (Slice 2.2)
+// =========================================================================
+//
+// Mirrors the FP16 cluster kernel above but routes QK^T through SM120 FP8
+// E4M3 m16n8k32 MMA (same inline-PTX path as fmha_sm120_fp8_kernel in
+// attention_fmha_sm120.cu). DSMEM still carries FP16 K so the cluster
+// staging copy doesn't have to assume FP8 quantization happened correctly
+// in block 0; each block converts its locally-staged FP16 K → FP8 once
+// per KV tile (matching the per-block cost of the legacy FP8 kernel).
+//
+// Smem layout per block (vs the FP16 cluster):
+//   Q_fp8         : Bq  × HD  uint8  — Q tile converted to E4M3 once at start
+//   K_fp16_local  : Bkv × HD  half   — block 0 canonical, siblings stage from
+//                                      K_remote each iter
+//   V_fp16_local  : Bkv × HD  half   — block 0 canonical, siblings stage from
+//                                      V_remote each iter
+//   K_fp8_local   : Bkv × HD  uint8  — per-block, written by the local
+//                                      FP16→FP8 conversion before Phase 1
+//   S_tile        : Bq  × Bkv float  — score buffer (P_half overlay)
+//   O_acc         : Bq  × HD  float  — output accumulator
+//   row_m,row_l   : 2 × Bq    float
+//
+// We keep K_fp16_local *and* K_fp8_local distinct (no aliasing) so the
+// per-block FP8 conversion can happen in lockstep across all blocks (block
+// 0 isn't a special case for the convert step — it reads its own canonical
+// K_fp16_local). The smem overhead (Bkv·HD bytes for K_fp8) is well below
+// the optin limit at Bq=64 for every supported HD.
+
+__device__ __forceinline__ uint32_t cluster_cvt_4xfp16_to_4xe4m3(const half* src) {
+    uint16_t lo, hi;
+    const uint32_t* src32 = reinterpret_cast<const uint32_t*>(src);
+    asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(lo) : "r"(src32[0]));
+    asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(hi) : "r"(src32[1]));
+    return static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 16);
+}
+
+size_t cluster_fp8_smem_bytes(int Bq, int Bkv, int HD) {
+    return (size_t)Bq * HD * sizeof(uint8_t)        // Q_fp8
+           + 2 * (size_t)Bkv * HD * sizeof(half)    // K_fp16_local + V_fp16_local
+           + (size_t)Bkv * HD * sizeof(uint8_t)     // K_fp8_local
+           + (size_t)Bq * Bkv * sizeof(float)       // S_tile
+           + (size_t)Bq * HD * sizeof(float)        // O_acc
+           + 2 * (size_t)Bq * sizeof(float);        // row_m + row_l
+}
+
+template <int Bq, int HD>
+__global__ void fmha_sm120_fp8_cluster_kernel(
+    const half* __restrict__ Q, const half* __restrict__ K, const half* __restrict__ V, half* __restrict__ O,
+    int batch_size, int seq_q, int seq_kv, int n_heads, int n_kv_heads, int n_q_per_kv, float scale,
+    bool causal, int sliding_window, float softcap) {
+    namespace cg = cooperative_groups;
+    auto cluster = cg::this_cluster();
+
+    constexpr int Bkv = CL_Bkv;
+    constexpr int TPR = CL_BLOCK_THREADS / Bq;
+    static_assert(TPR >= 1 && (TPR & (TPR - 1)) == 0, "TPR must be power of 2");
+    static_assert(HD % 32 == 0, "FP8 MMA requires HD % 32 == 0");
+
+    const int q_local = cluster.block_rank();
+    const int tile_q = blockIdx.x / n_q_per_kv;
+    const int batch_idx = blockIdx.y / n_kv_heads;
+    const int kv_head = blockIdx.y % n_kv_heads;
+    const int head_idx = kv_head * n_q_per_kv + q_local;
+    const int q_start = tile_q * Bq;
+
+    if (head_idx >= n_heads || batch_idx >= batch_size)
+        return;
+
+    const int tid = threadIdx.x + threadIdx.y * blockDim.x;
+    const int warp_id = tid / CL_WARP_SIZE;
+    const int lane_id = tid % CL_WARP_SIZE;
+    const int sm_row = tid / TPR;
+    const int sm_lane = tid % TPR;
+
+    const int64_t q_row_stride = (int64_t)n_heads * HD;
+    const int64_t kv_row_stride = (int64_t)n_kv_heads * HD;
+
+    const half* Q_ptr = Q + (int64_t)batch_idx * seq_q * q_row_stride + (int64_t)q_start * q_row_stride +
+                        (int64_t)head_idx * HD;
+    const half* K_ptr = K + (int64_t)batch_idx * seq_kv * kv_row_stride + (int64_t)kv_head * HD;
+    const half* V_ptr = V + (int64_t)batch_idx * seq_kv * kv_row_stride + (int64_t)kv_head * HD;
+    half* O_ptr = O + (int64_t)batch_idx * seq_q * q_row_stride + (int64_t)q_start * q_row_stride +
+                  (int64_t)head_idx * HD;
+
+    extern __shared__ char smem[];
+    uint8_t* Q_fp8 = reinterpret_cast<uint8_t*>(smem);
+    half* K_fp16_local = reinterpret_cast<half*>(Q_fp8 + Bq * HD);
+    half* V_fp16_local = K_fp16_local + Bkv * HD;
+    uint8_t* K_fp8_local = reinterpret_cast<uint8_t*>(V_fp16_local + Bkv * HD);
+    float* S_tile = reinterpret_cast<float*>(K_fp8_local + Bkv * HD);
+    float* O_acc = S_tile + Bq * Bkv;
+    float* row_m = O_acc + Bq * HD;
+    float* row_l = row_m + Bq;
+
+    half* K_remote = cluster.map_shared_rank(K_fp16_local, 0);
+    half* V_remote = cluster.map_shared_rank(V_fp16_local, 0);
+
+    // ---- Load + convert Q tile (FP16 → FP8 E4M3, vec4 = 4 halves per cvt pair)
+    {
+        const int total_vec4 = (Bq * HD) / 4;
+        for (int vi = tid; vi < total_vec4; vi += CL_BLOCK_THREADS) {
+            int i = vi * 4;
+            int r = i / HD;
+            int d = i % HD;
+            if (q_start + r >= seq_q) {
+                reinterpret_cast<uint32_t*>(Q_fp8)[vi] = 0;
+                continue;
+            }
+            const half* src = &Q_ptr[(int64_t)r * q_row_stride + d];
+            reinterpret_cast<uint32_t*>(Q_fp8)[vi] = cluster_cvt_4xfp16_to_4xe4m3(src);
+        }
+    }
+
+    // ---- Zero O_acc + init softmax state
+    {
+        const int total_vec4 = (Bq * HD) / 4;
+        const float4 zero = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+        for (int vi = tid; vi < total_vec4; vi += CL_BLOCK_THREADS) {
+            reinterpret_cast<float4*>(O_acc)[vi] = zero;
+        }
+    }
+    if (tid < Bq) {
+        row_m[tid] = -FLT_MAX;
+        row_l[tid] = 0.0f;
+    }
+
+    // ---- KV tile bounds
+    int num_kv_tiles, first_kv_tile;
+    compute_kv_tile_bounds(q_start, Bq, Bkv, seq_q, seq_kv, causal, sliding_window, first_kv_tile,
+                           num_kv_tiles);
+
+    // FP8 MMA constants
+    constexpr int S_M = 16;
+    constexpr int S_N = 8;
+    constexpr int S_K = 32;
+    const int hd_chunks_fp8 = HD / S_K;
+    const int s_row_tiles = Bq / S_M;
+    const int s_col_tiles_half = Bkv / S_N;
+    const int s_total_tiles = s_row_tiles * s_col_tiles_half;
+
+    // FP16 WMMA constants for PV
+    const int o_row_tiles = Bq / CL_WMMA_M;
+    const int o_col_tiles = HD / CL_WMMA_N;
+    const int o_total_tiles = o_row_tiles * o_col_tiles;
+    const int pv_chunks = Bkv / CL_WMMA_K;
+
+    const int kv_total_vec8 = (Bkv * HD) / 8;
+
+    // ---- Prologue: block 0 loads first K tile as FP16
+    if (q_local == 0 && first_kv_tile < num_kv_tiles) {
+        const int kv_start0 = first_kv_tile * Bkv;
+        for (int vi = tid; vi < kv_total_vec8; vi += CL_BLOCK_THREADS) {
+            int i = vi * 8;
+            int r = i / HD;
+            int d = i % HD;
+            float4* dst = reinterpret_cast<float4*>(&K_fp16_local[i]);
+            if (kv_start0 + r < seq_kv) {
+                const float4* src =
+                    reinterpret_cast<const float4*>(&K_ptr[(int64_t)(kv_start0 + r) * kv_row_stride + d]);
+                *dst = *src;
+            } else {
+                *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+            }
+        }
+    }
+    cluster.sync();
+
+    for (int j = first_kv_tile; j < num_kv_tiles; j++) {
+        const int kv_start = j * Bkv;
+
+        // ---- Siblings: stage K_remote (FP16) → my K_fp16_local
+        if (q_local != 0) {
+            for (int vi = tid; vi < kv_total_vec8; vi += CL_BLOCK_THREADS) {
+                int i = vi * 8;
+                reinterpret_cast<float4*>(&K_fp16_local[i])[0] =
+                    reinterpret_cast<const float4*>(&K_remote[i])[0];
+            }
+        }
+        __syncthreads();
+
+        // ---- All blocks: convert K_fp16_local → K_fp8_local (vec4 per cvt pair)
+        {
+            const int total_vec4 = (Bkv * HD) / 4;
+            for (int vi = tid; vi < total_vec4; vi += CL_BLOCK_THREADS) {
+                int i = vi * 4;
+                reinterpret_cast<uint32_t*>(K_fp8_local)[vi] =
+                    cluster_cvt_4xfp16_to_4xe4m3(&K_fp16_local[i]);
+            }
+        }
+        __syncthreads();
+
+        // ============================================================
+        // Phase 1: S = Q_fp8 @ K_fp8_local^T via FP8 m16n8k32 MMA
+        // ============================================================
+        for (int tile_idx = warp_id; tile_idx < s_total_tiles; tile_idx += CL_NUM_WARPS) {
+            int ri = tile_idx / s_col_tiles_half;
+            int ci = tile_idx % s_col_tiles_half;
+
+            float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
+
+            for (int k = 0; k < hd_chunks_fp8; k++) {
+                uint32_t a0, a1, a2, a3;
+                {
+                    const uint8_t* q_base = Q_fp8 + ri * S_M * HD + k * S_K;
+                    int row_in_tile = lane_id / 4;
+                    int col_base = (lane_id % 4) * 4;
+                    const uint32_t* q_row0 = reinterpret_cast<const uint32_t*>(
+                        q_base + row_in_tile * HD + col_base);
+                    const uint32_t* q_row8 = reinterpret_cast<const uint32_t*>(
+                        q_base + (row_in_tile + 8) * HD + col_base);
+                    a0 = q_row0[0];
+                    a1 = q_row0[4];
+                    a2 = q_row8[0];
+                    a3 = q_row8[4];
+                }
+
+                uint32_t b0, b1;
+                {
+                    const uint8_t* k_base = K_fp8_local + ci * S_N * HD + k * S_K;
+                    int col_in_tile = lane_id / 4;
+                    int k_base_offset = (lane_id % 4) * 4;
+                    const uint32_t* k_ptr0 = reinterpret_cast<const uint32_t*>(
+                        k_base + col_in_tile * HD + k_base_offset);
+                    b0 = k_ptr0[0];
+                    b1 = k_ptr0[4];
+                }
+
+#if __CUDA_ARCH__ >= 1200
+                asm volatile(
+                    "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+                    "{%0, %1, %2, %3},"
+                    "{%4, %5, %6, %7},"
+                    "{%8, %9},"
+                    "{%10, %11, %12, %13};\n"
+                    : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0), "f"(d1), "f"(d2),
+                      "f"(d3));
+#endif
+            }
+
+            // Write 16×8 result to S_tile using canonical m16n8 mapping
+            {
+                int base_row = ri * S_M;
+                int base_col = ci * S_N;
+                int r0 = (lane_id / 4) % 8;
+                int c0 = (lane_id % 4) * 2;
+                S_tile[(base_row + r0) * Bkv + base_col + c0] = d0;
+                S_tile[(base_row + r0) * Bkv + base_col + c0 + 1] = d1;
+                S_tile[(base_row + r0 + 8) * Bkv + base_col + c0] = d2;
+                S_tile[(base_row + r0 + 8) * Bkv + base_col + c0 + 1] = d3;
+            }
+        }
+        __syncthreads();
+
+        apply_score_masks(S_tile, Bq, Bkv, CL_BLOCK_THREADS, tid, q_start, kv_start, seq_q, seq_kv, scale,
+                          softcap, causal, sliding_window);
+        __syncthreads();
+
+        // ============================================================
+        // Phase 2: online softmax (per-block; identical structure to FP16 cluster)
+        // ============================================================
+        {
+            half* SP_half = reinterpret_cast<half*>(S_tile);
+            const int r = sm_row;
+            const bool row_valid = (r < Bq) && (q_start + r < seq_q);
+
+            float partial_max = -FLT_MAX;
+            if (row_valid) {
+                for (int c = sm_lane; c < Bkv; c += TPR)
+                    partial_max = fmaxf(partial_max, S_tile[r * Bkv + c]);
+            }
+#pragma unroll
+            for (int offset = TPR / 2; offset >= 1; offset >>= 1)
+                partial_max = fmaxf(partial_max, __shfl_xor_sync(0xffffffff, partial_max, offset));
+            float m_ij = partial_max;
+
+            float m_old = row_valid ? row_m[r] : -FLT_MAX;
+            float m_new = fmaxf(m_old, m_ij);
+            float alpha = __expf(m_old - m_new);
+
+            float partial_sum = 0.0f;
+            if (row_valid) {
+                for (int c = sm_lane; c < Bkv; c += TPR) {
+                    float s_val = S_tile[r * Bkv + c];
+                    float p = (s_val <= -FLT_MAX * 0.5f) ? 0.0f : __expf(s_val - m_new);
+                    partial_sum += p;
+                    S_tile[r * Bkv + c] = p;
+                }
+            }
+#pragma unroll
+            for (int offset = TPR / 2; offset >= 1; offset >>= 1)
+                partial_sum += __shfl_xor_sync(0xffffffff, partial_sum, offset);
+
+            float l_old = row_valid ? row_l[r] : 0.0f;
+            float l_new = alpha * l_old + partial_sum;
+            if (sm_lane == 0 && row_valid) {
+                row_m[r] = m_new;
+                row_l[r] = l_new;
+            }
+
+            float rescale = (l_old > 0.0f) ? (alpha * l_old / l_new) : 0.0f;
+            if (row_valid) {
+                for (int d = sm_lane; d < HD; d += TPR)
+                    O_acc[r * HD + d] *= rescale;
+            }
+
+            float spv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
+            if (row_valid) {
+                for (int c = sm_lane; c < Bkv; c += TPR)
+                    SP_half[r * Bkv + c] = __float2half(S_tile[r * Bkv + c] * spv);
+            } else if (r < Bq) {
+                for (int c = sm_lane; c < Bkv; c += TPR)
+                    SP_half[r * Bkv + c] = __float2half(0.0f);
+            }
+        }
+        __syncthreads();
+
+        // ---- Block 0: load V[j] (FP16) → V_fp16_local
+        if (q_local == 0) {
+            for (int vi = tid; vi < kv_total_vec8; vi += CL_BLOCK_THREADS) {
+                int i = vi * 8;
+                int r = i / HD;
+                int d = i % HD;
+                float4* dst = reinterpret_cast<float4*>(&V_fp16_local[i]);
+                if (kv_start + r < seq_kv) {
+                    const float4* src =
+                        reinterpret_cast<const float4*>(&V_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]);
+                    *dst = *src;
+                } else {
+                    *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+                }
+            }
+        }
+        cluster.sync();
+
+        // ---- Siblings: stage V_remote → V_fp16_local
+        if (q_local != 0) {
+            for (int vi = tid; vi < kv_total_vec8; vi += CL_BLOCK_THREADS) {
+                int i = vi * 8;
+                reinterpret_cast<float4*>(&V_fp16_local[i])[0] =
+                    reinterpret_cast<const float4*>(&V_remote[i])[0];
+            }
+        }
+        __syncthreads();
+
+        // ============================================================
+        // Phase 3: O_acc += P @ V_fp16_local via FP16 WMMA
+        // ============================================================
+        {
+            half* P_half = reinterpret_cast<half*>(S_tile);
+            for (int tile_idx = warp_id; tile_idx < o_total_tiles; tile_idx += CL_NUM_WARPS) {
+                int ri = tile_idx / o_col_tiles;
+                int di = tile_idx % o_col_tiles;
+
+                wmma::fragment<wmma::accumulator, CL_WMMA_M, CL_WMMA_N, CL_WMMA_K, float> o_frag;
+                wmma::load_matrix_sync(o_frag, O_acc + ri * CL_WMMA_M * HD + di * CL_WMMA_N, HD,
+                                       wmma::mem_row_major);
+
+                for (int k = 0; k < pv_chunks; k++) {
+                    wmma::fragment<wmma::matrix_a, CL_WMMA_M, CL_WMMA_N, CL_WMMA_K, half, wmma::row_major>
+                        p_frag;
+                    wmma::load_matrix_sync(p_frag, P_half + ri * CL_WMMA_M * Bkv + k * CL_WMMA_K, Bkv);
+
+                    wmma::fragment<wmma::matrix_b, CL_WMMA_M, CL_WMMA_N, CL_WMMA_K, half, wmma::row_major>
+                        v_frag;
+                    wmma::load_matrix_sync(v_frag, V_fp16_local + k * CL_WMMA_N * HD + di * CL_WMMA_N, HD);
+
+                    wmma::mma_sync(o_frag, p_frag, v_frag, o_frag);
+                }
+
+                wmma::store_matrix_sync(O_acc + ri * CL_WMMA_M * HD + di * CL_WMMA_N, o_frag, HD,
+                                        wmma::mem_row_major);
+            }
+        }
+        __syncthreads();
+
+        // ---- Block 0: prefetch K[j+1] (FP16) → K_fp16_local
+        if (q_local == 0 && (j + 1) < num_kv_tiles) {
+            const int kv_start_next = (j + 1) * Bkv;
+            for (int vi = tid; vi < kv_total_vec8; vi += CL_BLOCK_THREADS) {
+                int i = vi * 8;
+                int r = i / HD;
+                int d = i % HD;
+                float4* dst = reinterpret_cast<float4*>(&K_fp16_local[i]);
+                if (kv_start_next + r < seq_kv) {
+                    const float4* src = reinterpret_cast<const float4*>(
+                        &K_ptr[(int64_t)(kv_start_next + r) * kv_row_stride + d]);
+                    *dst = *src;
+                } else {
+                    *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+                }
+            }
+        }
+        cluster.sync();
+    }
+
+    // ---- Write final output (vec4 = 4 FP32 → 4 FP16 per iter)
+    const int total_vec4 = (Bq * HD) / 4;
+    for (int vi = tid; vi < total_vec4; vi += CL_BLOCK_THREADS) {
+        int i = vi * 4;
+        int r = i / HD;
+        if (q_start + r >= seq_q)
+            continue;
+        float4 v = reinterpret_cast<const float4*>(O_acc)[vi];
+        half2 lo = __float22half2_rn(make_float2(v.x, v.y));
+        half2 hi = __float22half2_rn(make_float2(v.z, v.w));
+        uint2 packed;
+        packed.x = *reinterpret_cast<const uint32_t*>(&lo);
+        packed.y = *reinterpret_cast<const uint32_t*>(&hi);
+        *reinterpret_cast<uint2*>(&O_ptr[(int64_t)r * q_row_stride + (i % HD)]) = packed;
+    }
+}
+
+int select_cluster_fp8_Bq(int HD, int max_smem) {
+    // Match the FP16 cluster: Bq=64 only in PR 2.2; tile-tuning deferred to 2.3.
+    if (cluster_fp8_smem_bytes(64, CL_Bkv, HD) <= (size_t)max_smem) return 64;
+    return 0;
+}
+
+#define LAUNCH_FP8_CLUSTER(BQ, HD)                                                                          \
+    do {                                                                                                    \
+        auto kfunc = fmha_sm120_fp8_cluster_kernel<BQ, HD>;                                                 \
+        cudaError_t attr_err = cudaFuncSetAttribute(                                                        \
+            kfunc, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem));                    \
+        if (attr_err != cudaSuccess) {                                                                      \
+            IMP_LOG_WARN("FMHA FP8 cluster: cudaFuncSetAttribute failed Bq=%d HD=%d smem=%zu: %s", BQ, HD,  \
+                         smem, cudaGetErrorString(attr_err));                                               \
+            return false;                                                                                   \
+        }                                                                                                   \
+        cudaFuncSetAttribute(kfunc, cudaFuncAttributePreferredSharedMemoryCarveout,                         \
+                             cudaSharedmemCarveoutMaxShared);                                               \
+        cudaLaunchAttribute attrs[2];                                                                       \
+        cudaLaunchConfig_t config = cluster::build_cluster_config(                                          \
+            grid, block, smem, stream, attrs, /*cluster_x=*/static_cast<unsigned int>(n_q_per_kv));         \
+        cudaError_t launch_err = cudaLaunchKernelEx(                                                        \
+            &config, kfunc, reinterpret_cast<const half*>(Q.data),                                          \
+            reinterpret_cast<const half*>(K.data), reinterpret_cast<const half*>(V.data),                   \
+            reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv, n_heads, n_kv_heads, n_q_per_kv,    \
+            scale, causal, sliding_window, softcap);                                                        \
+        if (launch_err != cudaSuccess) {                                                                    \
+            IMP_LOG_WARN("FMHA FP8 cluster: cudaLaunchKernelEx failed Bq=%d HD=%d: %s", BQ, HD,             \
+                         cudaGetErrorString(launch_err));                                                   \
+            return false;                                                                                   \
+        }                                                                                                   \
+    } while (0)
+
 }  // namespace
 
 // Entry point — host launcher consulted by fmha_sm120_prefill before falling
@@ -547,6 +994,79 @@ bool try_fmha_sm120_cluster_prefill(const Tensor& Q, const Tensor& K, const Tens
     return false;
 }
 
+// Sibling of try_fmha_sm120_cluster_prefill for the FP8 score-compute
+// variant — consulted by fmha_sm120_fp8_prefill before the legacy
+// per-head FP8 kernel. Same gate, same opt-out flag, same Bq=64 policy.
+bool try_fmha_sm120_fp8_cluster_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
+                                        float scale, bool causal, int sliding_window, float softcap,
+                                        cudaStream_t stream) {
+    if (RuntimeConfig::current().attention.no_fmha_cluster)
+        return false;
+    if (Q.qtype != QType::F16)
+        return false;
+
+    const int batch_size = static_cast<int>(Q.shape[0]);
+    const int seq_q = static_cast<int>(Q.shape[1]);
+    const int n_heads = static_cast<int>(Q.shape[2]);
+    const int head_dim = static_cast<int>(Q.shape[3]);
+    const int seq_kv = static_cast<int>(K.shape[1]);
+    const int n_kv_heads = static_cast<int>(K.shape[2]);
+
+    if (n_kv_heads == 0 || n_heads % n_kv_heads != 0)
+        return false;
+    const int n_q_per_kv = n_heads / n_kv_heads;
+    if (n_q_per_kv != 2 && n_q_per_kv != 4 && n_q_per_kv != 8)
+        return false;
+    if (!cluster::valid_cluster_dim(static_cast<unsigned int>(n_q_per_kv)))
+        return false;
+
+    if (seq_q == 0 || seq_kv == 0)
+        return false;
+    if (head_dim % 32 != 0)
+        return false;  // FP8 MMA m16n8k32 requires HD % 32 == 0
+    if (head_dim != 64 && head_dim != 96 && head_dim != 128 && head_dim != 256)
+        return false;
+    if (head_dim == 96)
+        return false;  // 96 % 32 != 0 — FP8 MMA can't dispatch
+
+    if (seq_kv < CL_Bkv * 8)
+        return false;
+
+    int device = 0;
+    cudaGetDevice(&device);
+    int max_smem = 0;
+    cudaDeviceGetAttribute(&max_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
+
+    const int Bq = select_cluster_fp8_Bq(head_dim, max_smem);
+    if (Bq == 0) {
+        IMP_LOG_DEBUG("FMHA FP8 cluster: smem budget too small (HD=%d, max=%d)", head_dim, max_smem);
+        return false;
+    }
+    const int Bkv = CL_Bkv;
+    const size_t smem = cluster_fp8_smem_bytes(Bq, Bkv, head_dim);
+
+    const int num_q_tiles = (seq_q + Bq - 1) / Bq;
+    dim3 grid(num_q_tiles * n_q_per_kv, batch_size * n_kv_heads);
+    dim3 block(CL_WARP_SIZE, CL_NUM_WARPS);
+
+    IMP_LOG_DEBUG(
+        "FMHA FP8 cluster: B=%d Sq=%d Skv=%d nh=%d nkv=%d nq/kv=%d hd=%d Bq=%d Bkv=%d smem=%zu causal=%d "
+        "sw=%d softcap=%.1f",
+        batch_size, seq_q, seq_kv, n_heads, n_kv_heads, n_q_per_kv, head_dim, Bq, Bkv, smem, causal,
+        sliding_window, softcap);
+
+    (void)Bq;
+    switch (head_dim) {
+        case 64: LAUNCH_FP8_CLUSTER(64, 64); return true;
+        case 128: LAUNCH_FP8_CLUSTER(64, 128); return true;
+        case 256: LAUNCH_FP8_CLUSTER(64, 256); return true;
+        default: break;
+    }
+
+    return false;
+}
+
 #undef LAUNCH_CLUSTER
+#undef LAUNCH_FP8_CLUSTER
 
 }  // namespace imp

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include "compute/attention_fmha_sm120.h"
 #include "core/tensor.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <vector>
@@ -174,6 +175,119 @@ TEST_F(FmhaFP8Test, HD256) { run_test(1, 32, 32, 4, 4, 256, true); }
 // throughout — catches the S_tile smem overlap bug that the HD256 test
 // (Sq=Skv=32, zero-padded V) masked by having the reference also near zero.
 TEST_F(FmhaFP8Test, Qwen35LikeHD256_GQA41_SeqMultiTile) { run_test(1, 128, 128, 16, 4, 256, true); }
+
+// --- FP8 cluster path coverage (M5 Slice 2.2) -----------------------------
+//
+// The FP8 cluster kernel fires when:
+//   - n_q_per_kv ∈ {2,4,8}
+//   - head_dim ∈ {64,128,256}  (HD=96 dropped — FP8 m16n8k32 requires
+//                                HD % 32 == 0)
+//   - seq_kv ≥ 8 * CL_Bkv = 512
+//
+// run_test enforces a 5 % rel tolerance against the CPU reference; the
+// cluster kernel inherits the legacy FP8 quantization noise.
+
+TEST_F(FmhaFP8Test, ClusterPathGQA2Hd128) { run_test(1, 64, 512, 4, 2, 128, true); }
+TEST_F(FmhaFP8Test, ClusterPathGQA4Hd128) { run_test(1, 64, 512, 8, 2, 128, true); }
+TEST_F(FmhaFP8Test, ClusterPathGQA8Hd128) { run_test(1, 64, 512, 16, 2, 128, true); }
+TEST_F(FmhaFP8Test, ClusterPathHd64) { run_test(1, 64, 512, 8, 2, 64, true); }
+TEST_F(FmhaFP8Test, ClusterPathHd256) { run_test(1, 64, 512, 4, 2, 256, true); }
+TEST_F(FmhaFP8Test, ClusterPathLongPrompt) { run_test(1, 128, 1024, 8, 2, 128, true); }
+TEST_F(FmhaFP8Test, ClusterPathSlidingWindow) { run_test(1, 128, 1024, 4, 2, 128, true, /*sw=*/256); }
+TEST_F(FmhaFP8Test, ClusterPathSoftcap) { run_test(1, 128, 1024, 4, 2, 128, true, 0, /*softcap=*/50.0f); }
+TEST_F(FmhaFP8Test, ClusterPathBypassedForShortKv) {
+    // seq_kv < 512 → cluster gate rejects, legacy FP8 kernel runs.
+    run_test(1, 64, 256, 8, 2, 128, true);
+}
+
+// Direct cluster-vs-legacy bit-equivalence proof for the FP8 path. Mirrors
+// FmhaSm120Test.ClusterMatchesLegacy. Confirms the DSMEM staging + FP16→FP8
+// per-block conversion preserves the legacy FP8 kernel's bit-pattern.
+TEST_F(FmhaFP8Test, ClusterMatchesLegacy) {
+    int sm_major = 0, sm_minor = 0;
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaDeviceGetAttribute(&sm_major, cudaDevAttrComputeCapabilityMajor, device);
+    cudaDeviceGetAttribute(&sm_minor, cudaDevAttrComputeCapabilityMinor, device);
+    if (sm_major * 10 + sm_minor < 120) GTEST_SKIP() << "Requires sm_120+";
+
+    const int B = 1, Sq = 64, Skv = 1024, NH = 8, NKV = 2, HD = 128;
+    const float scale = 1.0f / std::sqrt(static_cast<float>(HD));
+
+    size_t q_elems = B * Sq * NH * HD;
+    size_t kv_elems = B * Skv * NKV * HD;
+
+    std::vector<half> Q_h(q_elems), K_h(kv_elems), V_h(kv_elems);
+    for (size_t i = 0; i < q_elems; i++)
+        Q_h[i] = __float2half(0.02f * static_cast<float>((i * 7 + 3) % 13 - 6));
+    for (size_t i = 0; i < kv_elems; i++) {
+        K_h[i] = __float2half(0.02f * static_cast<float>((i * 11 + 5) % 13 - 6));
+        V_h[i] = __float2half(0.02f * static_cast<float>((i * 13 + 7) % 13 - 6));
+    }
+
+    void *d_q, *d_k, *d_v, *d_o_cluster, *d_o_legacy;
+    size_t q_bytes = q_elems * sizeof(half), kv_bytes = kv_elems * sizeof(half);
+    cudaMalloc(&d_q, q_bytes);
+    cudaMalloc(&d_k, kv_bytes);
+    cudaMalloc(&d_v, kv_bytes);
+    cudaMalloc(&d_o_cluster, q_bytes);
+    cudaMalloc(&d_o_legacy, q_bytes);
+    cudaMemcpy(d_q, Q_h.data(), q_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_k, K_h.data(), kv_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v, V_h.data(), kv_bytes, cudaMemcpyHostToDevice);
+
+    int64_t q_shape[] = {B, Sq, NH, HD};
+    int64_t kv_shape[] = {B, Skv, NKV, HD};
+    Tensor Qt(d_q, QType::F16, 4, q_shape, true);
+    Tensor Kt(d_k, QType::F16, 4, kv_shape, true);
+    Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
+
+    {
+        RuntimeConfig cfg = RuntimeConfig::current();
+        cfg.attention.no_fmha_cluster = false;
+        RuntimeConfig::install(cfg);
+        cudaMemset(d_o_cluster, 0, q_bytes);
+        Tensor Oc(d_o_cluster, QType::F16, 4, q_shape, true);
+        ASSERT_TRUE(fmha_sm120_fp8_prefill(Qt, Kt, Vt, Oc, scale, true, 0, 0.0f, stream_));
+        cudaStreamSynchronize(stream_);
+    }
+    {
+        RuntimeConfig cfg = RuntimeConfig::current();
+        cfg.attention.no_fmha_cluster = true;
+        RuntimeConfig::install(cfg);
+        cudaMemset(d_o_legacy, 0, q_bytes);
+        Tensor Ol(d_o_legacy, QType::F16, 4, q_shape, true);
+        ASSERT_TRUE(fmha_sm120_fp8_prefill(Qt, Kt, Vt, Ol, scale, true, 0, 0.0f, stream_));
+        cudaStreamSynchronize(stream_);
+    }
+    {
+        RuntimeConfig cfg = RuntimeConfig::current();
+        cfg.attention.no_fmha_cluster = false;
+        RuntimeConfig::install(cfg);
+    }
+
+    std::vector<half> Oc(q_elems), Ol(q_elems);
+    cudaMemcpy(Oc.data(), d_o_cluster, q_bytes, cudaMemcpyDeviceToHost);
+    cudaMemcpy(Ol.data(), d_o_legacy, q_bytes, cudaMemcpyDeviceToHost);
+
+    float max_abs_diff = 0.0f, max_rel_diff = 0.0f;
+    for (size_t i = 0; i < q_elems; i++) {
+        float a = __half2float(Oc[i]);
+        float b = __half2float(Ol[i]);
+        float ad = std::abs(a - b);
+        float rd = ad / std::max(1.0f, std::abs(b));
+        max_abs_diff = std::max(max_abs_diff, ad);
+        max_rel_diff = std::max(max_rel_diff, rd);
+    }
+    fprintf(stderr, "FP8 ClusterMatchesLegacy: max_abs=%g max_rel=%g\n", max_abs_diff, max_rel_diff);
+    EXPECT_LT(max_abs_diff, 1e-2f) << "FP8 cluster vs legacy max abs diff " << max_abs_diff;
+
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_o_cluster);
+    cudaFree(d_o_legacy);
+}
 
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## Summary

Re-opening the FP8 cluster work after PR #201 merged into the now-deleted stack base `perf/m5-fmha-cluster-fp16-slice2` instead of `main`. The FP8 commit (`53b1993` originally, rebased onto `9e6e10c` as `0df29cf`) was therefore lost from main.

This PR ports the SM120 FP8 FMHA prefill kernel to the cluster shape established in #200. QK^T stays on the FP8 E4M3 m16n8k32 inline-PTX MMA; PV stays FP16 WMMA. Each block converts its DSMEM-staged FP16 K to FP8 once per KV tile — same per-block conversion cost as the legacy FP8 kernel, but global K bandwidth drops to `1/n_q_per_kv×` on GQA configs.

Wired through `fmha_sm120_fp8_prefill` with the same `attention.no_fmha_cluster` opt-out + same eligibility gate as the FP16 cluster, plus the FP8-specific `HD % 32 == 0` requirement (drops HD=96 — those configs fall through to the legacy kernel).

## Why DSMEM still carries FP16 K

Symmetric with #200's staging design. Each block independently converts the FP16 staging copy → FP8 in its own `K_fp8_local` slot before Phase 1 MMA, so the cluster.sync barrier semantics carry over unchanged from the FP16 variant. The FP8 PTX MMA reads `K_fp8_local` (plain shared memory) so the CUDA 13.2 cicc DSMEM-WMMA crash from #200 doesn't apply here either.

Smem layout per block at `Bq=64`:
- HD=64: ~50 KiB · HD=128: ~96 KiB · HD=256: ~177 KiB — all fit in the 228 KiB optin limit.

## Test plan

- [x] Rebased clean onto current `main` (#200's content)
- [x] `make build` green (Docker, CUDA 13.2, sm_120a)
- [x] All 10 FP8 cluster tests in `FmhaFP8Test.ClusterPath*` + `ClusterMatchesLegacy` pass
- [x] `ClusterMatchesLegacy` bit-identity vs legacy FP8 kernel (`max_abs=0`)
- [ ] Maintainer A/B on Qwen3-Coder-30B-NVFP4 / Qwen3.6-35B-NVFP4 / Gemma-4-26B-NVFP4 pp512 + pp2048 under `attention.fp8_prefill=on`

## Carve-outs preserved from #200

- DSMEM→local staging copy before WMMA (cicc 13.2 workaround)
- `Bq=64` only across all HDs (Bq=128 / HD=64 carve-out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)