### PR TITLE
chore(moe): drop dead expert_swiglu_base + tok_experts_dev locals

### DIFF
--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -539,8 +539,6 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                             char* gathered_base    = static_cast<char*>(moe_.gathered.data);
                             char* expert_gate_base = static_cast<char*>(moe_.expert_gate.data);
                             char* expert_up_base   = static_cast<char*>(moe_.expert_up.data);
-                            char* expert_swiglu_base =
-                                static_cast<char*>(moe_.expert_swiglu.data);
                             char* expert_down_base = static_cast<char*>(moe_.expert_down.data);
 
                             // SFA buffer prep — shared by both gate/up quant
@@ -688,8 +686,6 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                                      da_cache.d_down_SFB_ptrs,
                                                      da_cache.d_down_alpha,
                                                      expert_down_base, eff, d);
-                                (void)expert_swiglu_base;  // legacy fallback path still
-                                                            // uses moe_.expert_swiglu.data
                             }
                             if (ok) {
                                 device_args_done = true;
@@ -2152,9 +2148,6 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
     cudaStreamSynchronize(stream);
 
     for (int t = 0; t < n; t++) {
-        const int32_t* tok_experts_dev = static_cast<const int32_t*>(routing.expert_indices.data) +
-                                         static_cast<int64_t>(t) * top_k;
-        (void)tok_experts_dev;  // device pointer kept around for clarity; reads come from host array
         const float* tok_weights = static_cast<const float*>(routing.expert_weights.data) +
                                    static_cast<int64_t>(t) * top_k;
 


### PR DESCRIPTION
## Summary

Silence two nvcc `#550-D "set but never used"` warnings on the MoE prefill path. Both are leftovers from recent landings where the corresponding code paths were rewritten but the helper locals stayed alive behind `(void)x` no-op sinks (GCC silences those, nvcc doesn't).

- `src/graph/executor_forward_moe.cu:542` — `expert_swiglu_base` in the **device-args block** became dead with **M1 (#194)**: the fused SwiGLU+act-quant kernel writes directly into `expert_up_base` / the down activation buffer, so the swiglu scratch pointer was only kept alive by `(void)expert_swiglu_base;`.
- `src/graph/executor_forward_moe.cu:2151` — `tok_experts_dev` in the Gemma-4 ggml prefill loop became dead with **M2 (#195)**: routing reads now come from a pre-fetched host array (`h_all_experts`), the per-token device pointer was only kept alive by `(void)tok_experts_dev;`.

The other six `expert_swiglu_base` declarations in this file (legacy fallback, slow path, fused decode, Gemma-4 paths) keep their own live uses and are untouched.

Pure dead-code removal — no behaviour change, no perf delta expected.

## Test plan

- [x] Pre-push hook ran `make verify-fast` green
- [x] `grep expert_swiglu_base src/graph/executor_forward_moe.cu` confirms remaining scopes all have real downstream uses
- [ ] CI build (CUDA 13.2) green — warnings gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)