### PR TITLE
chore: nvcc dead-variable sweep — 4 more stale (void) sinks

### DIFF
--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -288,7 +288,6 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
         // for m_local / l_local so EVERY lane sees the same scalar (the
         // sQ_w fill below has lanes 16..31 also reading weights[col], so
         // they need consistent l_inv).
-        float* dots_smem_p = reinterpret_cast<float*>(sK_w) + 16 * 16 / 2;  // alias unused half region
         // Use the front of sFV_w for dots/weights — sFV_w is per-warp (1024B
         // floats = 256 entries) and only used after this for V WMMA store.
         float* dots_smem = sFV_w;
@@ -324,7 +323,6 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
         for (int off = 16; off > 0; off >>= 1) {
             l_local += __shfl_xor_sync(0xffffffff, l_local, off);
         }
-        (void)dots_smem_p;  // alias not used; keep dots in sFV_w for clarity
 
         float l_new = exp_diff * l_w + l_local;
         // Normalized rescale: (exp_diff * l_w_old) / l_new — same role as

--- a/src/compute/gemm_grouped_nvfp4_smallM.cu
+++ b/src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -258,8 +258,6 @@ __global__ void smallM_kernel_v1(
     constexpr int SFA_TILE_BYTES = TILE_M * SFA_BYTES_ROW;  // 1 KiB
     constexpr int SFB_TILE_BYTES = TILE_N * SFB_BYTES_ROW;  // 1 KiB
     constexpr int TMA_BYTES_PER_STAGE = A_TILE_BYTES + B_TILE_BYTES;  // 16 KiB
-    constexpr int CPASYNC_BYTES_PER_STAGE = SFA_TILE_BYTES + SFB_TILE_BYTES;  // 2 KiB
-    (void)CPASYNC_BYTES_PER_STAGE;
 
     const int K_groups   = K / 16;
     const int n_base     = n_tile * TILE_N;
@@ -935,7 +933,6 @@ bool gemm_grouped_nvfp4_smallM(
             default:  launch_for(TM128{}, IC128{}, IC3{}); break;
         }
     }
-    (void)TILE_K_rt;
 
     cudaFreeAsync(d_A, stream);   cudaFreeAsync(d_SFA, stream);
     cudaFreeAsync(d_B, stream);   cudaFreeAsync(d_SFB, stream);

--- a/src/compute/moe_routing.cu
+++ b/src/compute/moe_routing.cu
@@ -724,12 +724,9 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingResult& res
 // ============================================================================
 
 void moe_gather(const Tensor& input, const MoeRoutingResult& routing, Tensor& gathered, cudaStream_t stream) {
-    const int n_tokens_orig = static_cast<int>(input.shape[0]);
     const int d_model = static_cast<int>(input.shape[1]);
     const int total_tokens = static_cast<int>(routing.sorted_token_ids.shape[0]);
     const int32_t* d_sorted = static_cast<const int32_t*>(routing.sorted_token_ids.data);
-
-    (void)n_tokens_orig;
 
     if (input.qtype == QType::F16) {
         const half* d_input = static_cast<const half*>(input.data);

--- a/src/graph/executor_ssm_gdn.cu
+++ b/src/graph/executor_ssm_gdn.cu
@@ -297,13 +297,11 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     if (fused_input) {
         // One GEMV produces [proj | gate | alpha | beta] contiguously in
         // gdn_fused_proj_buf_; the views below take offset slices.
-        size_t es_loc = dtype_size(compute_dtype_);
         int total_out = packed_conv_channels + packed_inner + 2 * packed_n_heads;
         int64_t fused_shape[2] = {1, total_out};
         Tensor fused_out(gdn_fused_proj_buf_.data, compute_dtype_, 2, fused_shape, true);
         gemm_dispatch(no, ly.gdn_input_packed, fused_out, ctx);
         proj = Tensor(gdn_fused_proj_buf_.data, compute_dtype_, 2, proj_shape, true);
-        (void)es_loc;
     } else {
         // Original path: ssm_proj_buf_ is [max_tokens, ssm_in_dim] but we only
         // need [n, conv_channels].


### PR DESCRIPTION
## Summary

Companion to #205. Sweeps four more dead `(void)var;` no-op sinks that survived the M1/M2 refactors. Pure dead-code removal, no behaviour change.

## Changes (4 dead variables, 10 lines deleted)

| File:line | Variable | Origin |
|---|---|---|
| \`src/graph/executor_ssm_gdn.cu:300\` | \`es_loc\` | Stale local in \`fused_input\` branch (sibling branch has its own live decl) |
| \`src/compute/moe_routing.cu:727\` | \`n_tokens_orig\` in \`moe_gather\` | Launcher only reads \`d_model\` / \`total_tokens\` |
| \`src/compute/gemm_grouped_nvfp4_smallM.cu:261\` | \`CPASYNC_BYTES_PER_STAGE\` constexpr | cp.async path computes arrive-bytes inline |
| \`src/compute/gemm_grouped_nvfp4_smallM.cu:938\` | \`(void)TILE_K_rt;\` trailing sink | Variable used live above; only the sink was stale |
| \`src/compute/attention_paged_nvfp4_tc.cu:291\` | \`dots_smem_p\` alias | Kernel uses \`sFV_w\` instead |

These don't currently emit \`#550-D\` on CUDA 13.2.1 (nvcc treats their \`(void)\` sinks differently from the cases in #205), but they're genuinely dead from earlier refactors. Removing now eliminates a future-warning surface as toolchains evolve, and removes 10 lines of misleading "kept around for X" comments.

## Deliberately NOT fixed (load-bearing \`(void)x;\`)

Audited every remaining \`(void)var;\` in the tree. All remaining sinks are intentional:

- Kernel API params reserved for in-flight features (e.g. \`n_sinks\` across 5 attention launchers — streaming attention not yet wired)
- C++ function/template params intentionally unused (\`model_path\` in handlers, \`experts_on_host\` in workspace, \`floor\` in storage_planner, \`IsKv\` template in mtp_forward gated by \`if (false)\`)
- Structured-binding placeholders (\`for (auto& [k,v] : ...)\` where only \`k\` or only \`v\` is needed)
- \`#else\` arch-fallback silencing (\`(void)d,a,b,sfa,sfb\` when \`__CUDA_ARCH__ < 1200\`)

## Test plan

- [x] \`make verify-fast\` green (pre-push hook)
- [x] No \`#550-D\` warnings added or removed (these vars don't emit on current toolchain)
- [x] No behaviour change — pure dead-code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)