### PR TITLE
refactor(graph): R5 Slice 2 — FP8 kernel via GemmKernel registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ set(IMP_GRAPH_SOURCES
     src/graph/executor.cu
     src/graph/executor_kernels.cu
     src/graph/gemm_kernel_registry.cu
+    src/graph/gemm_kernel_fp8.cu
     src/graph/executor_workspace.cu
     src/graph/executor_workspace_buffers.cu
     src/graph/executor_kv_write.cu

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -2366,10 +2366,36 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
     const auto* ct4 = (wc->cutlass_nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_nvfp4;
     const auto* mx4 = (wc->cutlass_mxfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_mxfp4;
 
-    // R5 Slice 1: when gemm.use_kernel_registry is enabled, try the new
-    // dispatch table first. Only the FP16 tier is wired in Slice 1; other
-    // tiers fall through to the legacy gemm_dispatch_impl below.
+    // R5 Slice 1+2: when gemm.use_kernel_registry is enabled, try the new
+    // dispatch table first. Slices 1 (FP16) and 2 (FP8 prefill) are wired;
+    // other tiers fall through to the legacy gemm_dispatch_impl below.
+    //
+    // Tier order mirrors gemm_dispatch_impl precedence: FP8 is tried before
+    // FP16 because the legacy path picks FP8 when M>1 + the weight is in the
+    // FP8 cache, even if an FP16 cache entry also exists.
     if (RuntimeConfig::current().gemm.use_kernel_registry) {
+        const int M = static_cast<int>(input.shape[0]);
+        // FP8 prefill: M>1 only, requires FP8 cache hit + activation scratch.
+        // Matches the guard in gemm_dispatch_impl (M>1 branch).
+        if (fp8 != nullptr && M > 1 && qs->fp8_act != nullptr && qs->d_act_scale != nullptr) {
+            auto it = fp8->find(weight.data);
+            if (it != fp8->end()) {
+                GemmKernelArgs args{};
+                args.input = &input;
+                args.output = &output;
+                args.stream = ctx.stream;
+                args.beta = ctx.beta;
+                args.weight_payload = &it->second;
+                args.fp8_act_buf = qs->fp8_act;
+                args.d_act_scale = qs->d_act_scale;
+                args.d_fp8_block_maxes = qs->d_fp8_block_maxes;
+                args.d_fp8_absmax = qs->d_fp8_absmax;
+                args.fp8_max_grid = qs->fp8_max_grid;
+                GemmStrategy strat{StorageTier::FP8, QType::F16, /*m_is_one=*/false};
+                if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                    return;
+            }
+        }
         // The FP16 path is structurally simple — direct cuBLAS via the
         // fp16 weight cache OR the raw weight when it's already FP16/BF16.
         // Match the legacy preconditions: prefer the cache, then raw weight.
@@ -2379,7 +2405,6 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             args.output = &output;
             args.stream = ctx.stream;
             args.weight_payload = &it->second;
-            const int M = static_cast<int>(input.shape[0]);
             GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
             if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;
@@ -2390,7 +2415,6 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             args.output = &output;
             args.stream = ctx.stream;
             args.weight_payload = &weight;
-            const int M = static_cast<int>(input.shape[0]);
             GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
             if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;

--- a/src/graph/gemm_kernel_fp8.cu
+++ b/src/graph/gemm_kernel_fp8.cu
@@ -1,0 +1,72 @@
+#include "graph/gemm_kernel_registry.h"
+
+#include "compute/gemm.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "graph/executor.h"  // FP8CacheEntry
+#include "quant/fp8_quant.h"
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// FP8 tier — R5 Slice 2.
+//
+// Adapter that wraps the existing FP8 prefill path from gemm_dispatch_impl
+// (executor_kernels.cu, M>1 branch): quantize FP16 activations to FP8_E4M3
+// with per-tensor scale, then run a FP8xFP8 cuBLASLt GEMM via the cached
+// pre-quantized FP8 weight. Behavior is a verbatim wrap of the legacy call
+// site — no algorithmic change.
+//
+// Strategy: tier=FP8, weight_qtype=F16 (the source qtype the engine
+// observes for an FP8-cached weight; the FP8 conversion happened at load
+// time and lives inside FP8CacheEntry), m_is_one=false. M=1 / decode is
+// handled by GEMV / dp4a fast paths elsewhere — this adapter is prefill
+// (M>1) only, mirroring the legacy branch guard
+// (`fp8_cache != nullptr && input.shape[0] > 1`).
+//
+// Preconditions checked at the dispatch site (executor_kernels.cu): the
+// weight has an entry in `WeightCaches::fp8`, the FP8 activation scratch
+// (`fp8_act_buf`, `d_act_scale`, `d_fp8_block_maxes`, `d_fp8_absmax`) is
+// allocated, and M > 1. If any are missing the dispatch site must NOT
+// emit an FP8 strategy; the kernel returns PreconditionFail loud rather
+// than silently falling back.
+// ---------------------------------------------------------------------------
+static GemmDispatchResult fp8_gemm_kernel(const GemmKernelArgs& args) {
+    IMP_CHECK(args.input != nullptr, "fp8_gemm_kernel: input is null");
+    IMP_CHECK(args.output != nullptr, "fp8_gemm_kernel: output is null");
+    IMP_CHECK(args.weight_payload != nullptr, "fp8_gemm_kernel: weight_payload is null");
+
+    // FP8 prefill needs the activation quant scratch + the device-side scale.
+    // Without them we cannot run; the dispatch site is responsible for not
+    // emitting an FP8 strategy when these are unavailable. Refuse loud.
+    if (args.fp8_act_buf == nullptr || args.d_act_scale == nullptr)
+        return GemmDispatchResult::PreconditionFail;
+
+    const FP8CacheEntry& entry = *static_cast<const FP8CacheEntry*>(args.weight_payload);
+    const Tensor& input = *args.input;
+    Tensor& output = *args.output;
+
+    // Mirror executor_kernels.cu:2278-2282 verbatim — same activation
+    // quant kernel, same cuBLASLt call, same alpha/beta semantics.
+    Tensor fp8_act(args.fp8_act_buf, QType::FP8_E4M3, input.ndim, input.shape, /*on_device=*/true);
+    quantize_fp16_to_fp8_e4m3(input, fp8_act, args.d_act_scale, args.stream, args.d_fp8_block_maxes,
+                              args.d_fp8_absmax, args.fp8_max_grid);
+    gemm_cublaslt(fp8_act, entry.weight, output, /*alpha=*/1.0f, args.beta, args.d_act_scale, entry.d_scale,
+                  args.stream);
+    return GemmDispatchResult::Ok;
+}
+
+// Static registration. Slice 2 registers only the (M>1) prefill strategy
+// because the legacy FP8 branch only fires for M>1 (decode uses GEMV
+// fast paths, not this dispatch).
+namespace {
+struct FP8Registration {
+    FP8Registration() {
+        GemmKernelRegistry::instance().register_kernel(
+            GemmStrategy{StorageTier::FP8, QType::F16, /*m_is_one=*/false}, &fp8_gemm_kernel);
+    }
+};
+static FP8Registration s_fp8_registration;
+}  // namespace
+
+}  // namespace imp

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -1,6 +1,8 @@
 #include "graph/gemm_kernel_registry.h"
 #include "compute/gemm.h"
 #include "core/tensor.h"
+#include "graph/executor.h"  // FP8CacheEntry
+#include "quant/fp8_quant.h"
 
 #include <gtest/gtest.h>
 #include <cuda_runtime.h>
@@ -37,11 +39,176 @@ TEST_F(GemmKernelRegistryTest, Fp16KernelIsRegisteredAtStaticInit) {
 
 TEST_F(GemmKernelRegistryTest, UnregisteredStrategyReturnsNoMatch) {
     const auto& reg = GemmKernelRegistry::instance();
-    // CUTLASS_NVFP4 is not registered yet — Slice 1 has only FP16.
+    // CUTLASS_NVFP4 is not registered yet — Slices 1+2 only cover FP16 + FP8.
     GemmStrategy unregistered{StorageTier::CUTLASS_NVFP4, QType::F16, /*m_is_one=*/true};
     GemmKernelArgs args{};
     args.stream = stream_;
     EXPECT_EQ(reg.dispatch(unregistered, args), GemmDispatchResult::NoMatch);
+}
+
+// R5 Slice 2 — FP8 prefill kernel registered (M>1 only). With FP16 (2) +
+// FP8 prefill (1) we now expect at least 3 entries.
+TEST_F(GemmKernelRegistryTest, Fp8PrefillKernelIsRegisteredAtStaticInit) {
+    const auto& reg = GemmKernelRegistry::instance();
+    EXPECT_GE(reg.size(), 3u) << "FP16 (M==1/M>1) + FP8 (M>1) expected to be pre-registered";
+}
+
+// FP8 decode (M=1) strategy is intentionally NOT registered — decode uses
+// GEMV fast paths upstream, not this dispatch.
+TEST_F(GemmKernelRegistryTest, Fp8DecodeStrategyReturnsNoMatch) {
+    const auto& reg = GemmKernelRegistry::instance();
+    GemmStrategy decode{StorageTier::FP8, QType::F16, /*m_is_one=*/true};
+    GemmKernelArgs args{};
+    args.stream = stream_;
+    EXPECT_EQ(reg.dispatch(decode, args), GemmDispatchResult::NoMatch);
+}
+
+// FP8 kernel rejects loud when activation scratch is missing — refuses to
+// silently fall through to legacy.
+TEST_F(GemmKernelRegistryTest, Fp8KernelRejectsMissingScratch) {
+    constexpr int M = 4;
+    constexpr int N = 8;
+    constexpr int K = 16;
+
+    __half* d_input = nullptr;
+    int8_t* d_weight_fp8 = nullptr;
+    __half* d_out = nullptr;
+    float* d_w_scale = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_weight_fp8, sizeof(int8_t) * N * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+    cudaMalloc(&d_w_scale, sizeof(float));
+    cudaMemset(d_input, 0, sizeof(__half) * M * K);
+    cudaMemset(d_weight_fp8, 0, sizeof(int8_t) * N * K);
+    float h_w_scale = 1.0f;
+    cudaMemcpy(d_w_scale, &h_w_scale, sizeof(float), cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor out(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+    FP8CacheEntry entry{};
+    entry.weight = Tensor(d_weight_fp8, QType::FP8_E4M3, 2, w_shape, /*on_device=*/true);
+    entry.host_scale = 1.0f;
+    entry.d_scale = d_w_scale;
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out;
+    args.stream = stream_;
+    args.weight_payload = &entry;
+    // Deliberately leave fp8_act_buf / d_act_scale null — kernel must refuse.
+
+    GemmStrategy strat{StorageTier::FP8, QType::F16, /*m_is_one=*/false};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::PreconditionFail);
+
+    cudaFree(d_input);
+    cudaFree(d_weight_fp8);
+    cudaFree(d_out);
+    cudaFree(d_w_scale);
+}
+
+// End-to-end correctness: registry FP8 dispatch produces the same output as
+// calling quantize_fp16_to_fp8_e4m3 + gemm_cublaslt directly. Mirrors the
+// FP16 parity test pattern.
+TEST_F(GemmKernelRegistryTest, Fp8RegistryDispatchMatchesDirectPath) {
+    constexpr int M = 8;
+    constexpr int N = 16;
+    constexpr int K = 32;
+
+    std::vector<__half> h_input(M * K);
+    std::vector<__half> h_weight_fp16(N * K);
+    for (int i = 0; i < M * K; ++i) h_input[i] = __float2half((i % 5) * 0.0625f - 0.125f);
+    for (int i = 0; i < N * K; ++i) h_weight_fp16[i] = __float2half((i % 7) * 0.0625f - 0.1875f);
+
+    __half *d_input = nullptr, *d_weight_fp16 = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_weight_fp16, sizeof(__half) * N * K);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_weight_fp16, h_weight_fp16.data(), sizeof(__half) * N * K, cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight_fp16(d_weight_fp16, QType::F16, 2, w_shape, /*on_device=*/true);
+
+    // Pre-quantize weight to FP8 once (matches the load-time flow that fills
+    // WeightCaches::fp8). Two copies so the direct + registry paths each get
+    // their own — the FP8 weight buffer is read-only post-quant, so sharing
+    // would also work, but separate buffers keep the two paths isolated.
+    void *d_weight_fp8 = nullptr, *d_weight_fp8_b = nullptr;
+    cudaMalloc(&d_weight_fp8, sizeof(int8_t) * N * K);
+    cudaMalloc(&d_weight_fp8_b, sizeof(int8_t) * N * K);
+    float* d_w_scale = nullptr;
+    cudaMalloc(&d_w_scale, sizeof(float));
+    Tensor weight_fp8_a(d_weight_fp8, QType::FP8_E4M3, 2, w_shape, /*on_device=*/true);
+    quantize_fp16_to_fp8_e4m3(weight_fp16, weight_fp8_a, d_w_scale, stream_);
+    cudaMemcpyAsync(d_weight_fp8_b, d_weight_fp8, sizeof(int8_t) * N * K, cudaMemcpyDeviceToDevice, stream_);
+
+    // FP8 activation scratch — shared shape with the input.
+    void* d_fp8_act = nullptr;
+    float *d_act_scale = nullptr, *d_block_maxes = nullptr, *d_absmax = nullptr;
+    cudaMalloc(&d_fp8_act, sizeof(int8_t) * M * K);
+    cudaMalloc(&d_act_scale, sizeof(float));
+    cudaMalloc(&d_block_maxes, sizeof(float) * 256);
+    cudaMalloc(&d_absmax, sizeof(float));
+
+    // Path 1: direct (mirror executor_kernels.cu legacy branch verbatim).
+    __half* d_out_direct = nullptr;
+    cudaMalloc(&d_out_direct, sizeof(__half) * M * N);
+    Tensor out_direct(d_out_direct, QType::F16, 2, out_shape, /*on_device=*/true);
+    Tensor fp8_act_direct(d_fp8_act, QType::FP8_E4M3, 2, in_shape, /*on_device=*/true);
+    quantize_fp16_to_fp8_e4m3(input, fp8_act_direct, d_act_scale, stream_, d_block_maxes, d_absmax, 256);
+    gemm_cublaslt(fp8_act_direct, weight_fp8_a, out_direct, 1.0f, 0.0f, d_act_scale, d_w_scale, stream_);
+
+    // Path 2: registry dispatch through the FP8 kernel adapter.
+    __half* d_out_registry = nullptr;
+    cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
+    Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
+    FP8CacheEntry entry{};
+    entry.weight = Tensor(d_weight_fp8_b, QType::FP8_E4M3, 2, w_shape, /*on_device=*/true);
+    entry.host_scale = 1.0f;
+    entry.d_scale = d_w_scale;
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out_registry;
+    args.stream = stream_;
+    args.beta = 0.0f;
+    args.weight_payload = &entry;
+    args.fp8_act_buf = d_fp8_act;
+    args.d_act_scale = d_act_scale;
+    args.d_fp8_block_maxes = d_block_maxes;
+    args.d_fp8_absmax = d_absmax;
+    args.fp8_max_grid = 256;
+    GemmStrategy strat{StorageTier::FP8, QType::F16, /*m_is_one=*/false};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+
+    cudaStreamSynchronize(stream_);
+
+    std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);
+    cudaMemcpy(h_out_direct.data(), d_out_direct, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_out_registry.data(), d_out_registry, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+
+    // Both paths run the identical quant+cuBLASLt sequence → bit-identical.
+    for (int i = 0; i < M * N; ++i) {
+        EXPECT_EQ(__half_as_ushort(h_out_direct[i]), __half_as_ushort(h_out_registry[i]))
+            << "Mismatch at i=" << i << " (direct=" << __half2float(h_out_direct[i])
+            << " registry=" << __half2float(h_out_registry[i]) << ")";
+    }
+
+    cudaFree(d_input);
+    cudaFree(d_weight_fp16);
+    cudaFree(d_weight_fp8);
+    cudaFree(d_weight_fp8_b);
+    cudaFree(d_w_scale);
+    cudaFree(d_fp8_act);
+    cudaFree(d_act_scale);
+    cudaFree(d_block_maxes);
+    cudaFree(d_absmax);
+    cudaFree(d_out_direct);
+    cudaFree(d_out_registry);
 }
 
 // End-to-end correctness: register-then-dispatch produces the same output


### PR DESCRIPTION
## Summary

R5 Slice 2 — migrates the FP8 GEMM tier to the new \`GemmKernel\` registry interface introduced by Slice 1 (#197). Same feature-flag opt-in pattern (\`RuntimeConfig.gemm.use_kernel_registry\`, default OFF) — when the flag is off, behaviour is bit-identical to today; when on, FP8 + FP16 both dispatch via the registry, other tiers still fall through to legacy \`gemm_dispatch_impl\`.

## Files

- **\`src/graph/gemm_kernel_fp8.cu\`** (new, 70 lines) — FP8 strategy handler. Thin adapter; delegates verbatim to the existing compute calls (\`quantize_fp16_to_fp8_e4m3\` → \`gemm_cublaslt\`).
- **\`src/graph/executor_kernels.cu\`** — \`gemm_dispatch\` dispatch site: tries FP8 strategy first (M>1 + FP8 cache hit + scratch present), then FP16 strategies, then falls through to legacy. FP8-before-FP16 order mirrors legacy precedence.
- **\`CMakeLists.txt\`** — adds the new TU to \`IMP_GRAPH_SOURCES\`.
- **\`tests/test_gemm_kernel_registry.cu\`** — 4 new FP8 tests (described in test plan).

## Architecture notes

Slice 1's \`GemmKernelArgs\` already carries every FP8-specific field (\`fp8_act_buf\`, \`d_act_scale\`, \`d_fp8_block_maxes\`, \`d_fp8_absmax\`, \`fp8_max_grid\`, plus \`beta\`); no interface change was needed. The strategy key (\`{StorageTier::FP8, QType::F16, m_is_one=false}\`) registers only the M>1 GEMM path — FP8 GEMV (M=1) doesn't exist in the current codebase.

## Test plan

- [x] \`make build\` PASS
- [x] \`make verify-fast\` PASS (perf gate + smoke prompts SKIPPED — no baseline models in \`./models/\`, but the fast gtest filter PASSED)
- [x] \`test-compute --gtest_filter='*Gemm*:*FP8*:*Fp8*'\`: 28/28 PASS, including the 4 new FP8 registry tests:
  - \`Fp8PrefillKernelIsRegisteredAtStaticInit\` — registry count check
  - \`Fp8DecodeStrategyReturnsNoMatch\` — M=1 deliberately not registered
  - \`Fp8KernelRejectsMissingScratch\` — loud \`PreconditionFail\` when activation scratch absent
  - \`Fp8RegistryDispatchMatchesDirectPath\` — bit-identical output vs direct compute call

🤖 Generated with [Claude Code](https://claude.com/claude-code)