### PR TITLE
refactor(graph): R5 Slice 6 — MXFP4 kernel via GemmKernel registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ set(IMP_GRAPH_SOURCES
     src/graph/gemm_kernel_nvfp4_gemv.cu
     src/graph/gemm_kernel_nvfp4_gemm.cu
     src/graph/gemm_kernel_cutlass_nvfp4.cu
+    src/graph/gemm_kernel_mxfp4.cu
     src/graph/executor_workspace.cu
     src/graph/executor_workspace_buffers.cu
     src/graph/executor_kv_write.cu

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -2366,22 +2366,50 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
     const auto* ct4 = (wc->cutlass_nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_nvfp4;
     const auto* mx4 = (wc->cutlass_mxfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_mxfp4;
 
-    // R5 Slice 1+2+3+4+5: when gemm.use_kernel_registry is enabled, try the
+    // R5 Slice 1+2+3+4+5+6: when gemm.use_kernel_registry is enabled, try the
     // new dispatch table first. Slices 1 (FP16), 2 (FP8 prefill), 3 (NVFP4
-    // decode GEMV), 4 (NVFP4 prefill GEMM dequant) and 5 (CUTLASS_NVFP4
-    // prefill GEMM, preferred native FP4 path) are wired; remaining tiers
-    // (MXFP4 — Slice 6, dp4a/q8 — Slice 7) fall through to the legacy
-    // gemm_dispatch_impl below.
+    // decode GEMV), 4 (NVFP4 prefill GEMM dequant), 5 (CUTLASS_NVFP4 prefill
+    // GEMM, preferred native FP4 path) and 6 (MXFP4 native GGUF — GEMV +
+    // dequant→cuBLAS GEMM) are wired; remaining tiers (dp4a/q8 — Slice 7)
+    // fall through to the legacy gemm_dispatch_impl below.
     //
-    // Tier order mirrors gemm_dispatch_impl precedence: FP8 is tried before
-    // FP16 because the legacy path picks FP8 when M>1 + the weight is in the
-    // FP8 cache, even if an FP16 cache entry also exists. NVFP4 sits between
-    // FP8 and FP16 — the legacy dispatch evaluates NVFP4 before falling
-    // through to dp4a/fp16 cache paths, and NVFP4 weights are stored either
-    // as Tensor sidecars (qtype=NVFP4 directly on the weight) or in the
-    // separate nv4 cache; both must be checked.
+    // Tier order mirrors gemm_dispatch_impl precedence: MXFP4 GGUF is the
+    // top-priority branch in legacy (executor_kernels.cu:2085-2113) and is
+    // tried first here too. FP8 is tried before FP16 because the legacy path
+    // picks FP8 when M>1 + the weight is in the FP8 cache, even if an FP16
+    // cache entry also exists. NVFP4 sits between FP8 and FP16 — the legacy
+    // dispatch evaluates NVFP4 before falling through to dp4a/fp16 cache
+    // paths, and NVFP4 weights are stored either as Tensor sidecars
+    // (qtype=NVFP4 directly on the weight) or in the separate nv4 cache;
+    // both must be checked.
     if (RuntimeConfig::current().gemm.use_kernel_registry) {
         const int M = static_cast<int>(input.shape[0]);
+        // MXFP4 native GGUF (top priority — matches legacy precedence at
+        // gemm_dispatch_impl:2085). Cache hit + linear_scales gate apply
+        // identically. The kernel adapter further gates on linear_scales !=
+        // null and returns PreconditionFail on miss so we fall through. The
+        // dual-cache CUTLASS MXFP4 branch (legacy line 2149-2174) is NOT
+        // migrated here — it lives inside the NVFP4 path with a QW7 probe;
+        // see src/graph/gemm_kernel_mxfp4.cu header.
+        if (mx4 != nullptr && input.qtype == QType::F16) {
+            auto mx_it = mx4->find(weight.data);
+            if (mx_it != mx4->end() && mx_it->second.linear_scales != nullptr) {
+                GemmKernelArgs args{};
+                args.input = &input;
+                args.output = &output;
+                args.stream = ctx.stream;
+                args.beta = ctx.beta;
+                args.weight_payload = &mx_it->second;
+                args.dequant_scratch = qs->dequant;  // only consumed by M>1 path
+                GemmStrategy strat{StorageTier::MXFP4, QType::F16, /*m_is_one=*/(M == 1)};
+                auto rc = GemmKernelRegistry::instance().dispatch(strat, args);
+                if (rc == GemmDispatchResult::Ok)
+                    return;
+                // PreconditionFail (missing dequant scratch for M>1) — fall
+                // through to legacy, mirroring the legacy `else if (dequant_
+                // scratch != nullptr)` skip.
+            }
+        }
         // FP8 prefill: M>1 only, requires FP8 cache hit + activation scratch.
         // Matches the guard in gemm_dispatch_impl (M>1 branch).
         if (fp8 != nullptr && M > 1 && qs->fp8_act != nullptr && qs->d_act_scale != nullptr) {

--- a/src/graph/gemm_kernel_mxfp4.cu
+++ b/src/graph/gemm_kernel_mxfp4.cu
@@ -1,0 +1,114 @@
+#include "graph/gemm_kernel_registry.h"
+
+#include "compute/gemm.h"                       // gemm() FP16 cuBLAS wrapper
+#include "compute/gemm_cutlass_mxfp4_sm120.h"  // CutlassMxFP4Weight, dequant_mxfp4_to_fp16
+#include "compute/hadamard.h"                   // hadamard_block_size_valid, hadamard_transform_fp16
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "quant/mxfp4_gemm.h"                   // gemv_mxfp4_kpar
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// MXFP4 tiers — R5 Slice 6.
+//
+// Migrate the legacy MXFP4 GGUF dispatch (executor_kernels.cu:2085-2113) to
+// the GemmKernel registry. Two distinct backends mirror the Slice 3/4 split
+// for NVFP4 — GEMV for M==1 decode and dequant→cuBLAS for M>1 prefill — so
+// we register two strategies under StorageTier::MXFP4:
+//
+//   {MXFP4, F16, m_is_one=true}  → gemv_mxfp4_kpar (with optional Hadamard
+//                                  online rotation when hadamard_bs > 0).
+//   {MXFP4, F16, m_is_one=false} → dequant_mxfp4_to_fp16 → cuBLAS gemm.
+//
+// The third candidate — the dual-cache MXFP4 CUTLASS branch at
+// executor_kernels.cu:2149-2174 — is NOT migrated here. That branch lives
+// *inside* the NVFP4 path, requires the same weight.data to be present in
+// both `cutlass_nvfp4` and `cutlass_mxfp4` caches, and carries a `s_logged`
+// QW7 instrumentation probe documenting that production firings are still
+// under investigation. Migrating it would require a multi-tier strategy key
+// (NVFP4 cache hit + MXFP4 cache hit) that doesn't fit the (tier, qtype,
+// m_is_one) trio, and it stays on legacy until that branch is either
+// retired or earns a first-class strategy slot.
+//
+// Both kernels gate on `linear_scales != nullptr` — same precondition as
+// the legacy dispatch site (executor_kernels.cu:2087). When the gate fails
+// we return PreconditionFail so the dispatch site falls through to the
+// legacy switch.
+// ---------------------------------------------------------------------------
+
+static GemmDispatchResult mxfp4_gemv_kernel(const GemmKernelArgs& args) {
+    IMP_CHECK(args.input != nullptr, "mxfp4_gemv_kernel: input is null");
+    IMP_CHECK(args.output != nullptr, "mxfp4_gemv_kernel: output is null");
+    IMP_CHECK(args.weight_payload != nullptr, "mxfp4_gemv_kernel: weight_payload is null");
+    IMP_CHECK(args.input->qtype == QType::F16, "mxfp4_gemv_kernel: input qtype must be F16");
+
+    const CutlassMxFP4Weight& W = *static_cast<const CutlassMxFP4Weight*>(args.weight_payload);
+    if (W.linear_scales == nullptr) {
+        // Legacy: native MXFP4 GEMV requires linear_scales (sequential UE8M0
+        // layout). If absent the dispatch site must fall back to legacy.
+        return GemmDispatchResult::PreconditionFail;
+    }
+
+    // Mirror executor_kernels.cu:2088-2100 verbatim. Apply Hadamard online
+    // rotation in-place on the FP16 input when hadamard_bs is set, then run
+    // the kpar GEMV. `input.data` is a const half* but the legacy code does
+    // an in-place rewrite — we preserve that semantic via a const_cast.
+    const int K = static_cast<int>(W.K);
+    if (W.hadamard_bs > 0 && hadamard_block_size_valid(W.hadamard_bs)) {
+        hadamard_transform_fp16(reinterpret_cast<const half*>(args.input->data),
+                                reinterpret_cast<half*>(const_cast<void*>(args.input->data)),
+                                /*M=*/1, K, W.hadamard_bs, args.stream);
+    }
+    gemv_mxfp4_kpar(W, reinterpret_cast<const half*>(args.input->data),
+                    reinterpret_cast<half*>(args.output->data), static_cast<int>(W.N),
+                    K, args.stream);
+    return GemmDispatchResult::Ok;
+}
+
+static GemmDispatchResult mxfp4_gemm_kernel(const GemmKernelArgs& args) {
+    IMP_CHECK(args.input != nullptr, "mxfp4_gemm_kernel: input is null");
+    IMP_CHECK(args.output != nullptr, "mxfp4_gemm_kernel: output is null");
+    IMP_CHECK(args.weight_payload != nullptr, "mxfp4_gemm_kernel: weight_payload is null");
+    IMP_CHECK(args.input->qtype == QType::F16, "mxfp4_gemm_kernel: input qtype must be F16");
+    IMP_CHECK(args.input->shape[0] > 1, "mxfp4_gemm_kernel: M must be > 1 (use GEMV strategy for M==1)");
+
+    const CutlassMxFP4Weight& W = *static_cast<const CutlassMxFP4Weight*>(args.weight_payload);
+    if (W.linear_scales == nullptr) {
+        return GemmDispatchResult::PreconditionFail;
+    }
+    if (args.dequant_scratch == nullptr) {
+        // Legacy prefill path (executor_kernels.cu:2101) requires the FP16
+        // dequant scratch — without it the legacy switch silently skipped
+        // this branch. We surface the same fall-through via PreconditionFail.
+        return GemmDispatchResult::PreconditionFail;
+    }
+
+    // Mirror executor_kernels.cu:2102-2110: dequant MXFP4 → FP16 scratch,
+    // wrap as a borrowed Tensor, run cuBLAS FP16 GEMM with the caller's beta.
+    const int N = static_cast<int>(W.N);
+    const int K = static_cast<int>(W.K);
+    dequant_mxfp4_to_fp16(W.data, N, K, args.dequant_scratch, args.stream);
+    int64_t w_shape[2] = {N, K};
+    Tensor w_fp16(args.dequant_scratch, QType::F16, 2, w_shape, /*on_device=*/true);
+    gemm(*args.input, w_fp16, *args.output, /*alpha=*/1.0f, args.beta, args.stream);
+    return GemmDispatchResult::Ok;
+}
+
+// Static registration. Two strategies under StorageTier::MXFP4 — one for
+// each side of the m_is_one axis. The dual-cache CUTLASS MXFP4 branch
+// (executor_kernels.cu:2149-2174) stays on legacy (see file header).
+namespace {
+struct MxFP4Registration {
+    MxFP4Registration() {
+        auto& reg = GemmKernelRegistry::instance();
+        reg.register_kernel(GemmStrategy{StorageTier::MXFP4, QType::F16, /*m_is_one=*/true},
+                            &mxfp4_gemv_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::MXFP4, QType::F16, /*m_is_one=*/false},
+                            &mxfp4_gemm_kernel);
+    }
+};
+static MxFP4Registration s_mxfp4_registration;
+}  // namespace
+
+}  // namespace imp

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -1,9 +1,11 @@
 #include "graph/gemm_kernel_registry.h"
 #include "compute/gemm.h"
+#include "compute/gemm_cutlass_mxfp4_sm120.h"  // CutlassMxFP4Weight, convert_nvfp4_to_mxfp4_cutlass
 #include "compute/gemm_cutlass_sm120.h"  // CutlassNvFP4Weight, convert_nvfp4_to_cutlass, gemm_nvfp4_cutlass_sm120
 #include "core/tensor.h"
 #include "graph/executor.h"  // FP8CacheEntry
 #include "quant/fp8_quant.h"
+#include "quant/mxfp4_gemm.h"  // gemv_mxfp4_kpar
 #include "quant/nvfp4_gemm.h"
 #include "quant/nvfp4_quant.h"
 
@@ -42,9 +44,11 @@ TEST_F(GemmKernelRegistryTest, Fp16KernelIsRegisteredAtStaticInit) {
 
 TEST_F(GemmKernelRegistryTest, UnregisteredStrategyReturnsNoMatch) {
     const auto& reg = GemmKernelRegistry::instance();
-    // MXFP4 is not registered yet — Slices 1-5 cover FP16, FP8, NVFP4 GEMV+GEMM,
-    // CUTLASS_NVFP4 prefill GEMM. MXFP4 is Slice 6 territory.
-    GemmStrategy unregistered{StorageTier::MXFP4, QType::F16, /*m_is_one=*/true};
+    // Off-axis weight_qtype on an otherwise-registered tier (MXFP4 GEMV is
+    // registered under qtype=F16; BF16 must not resolve). Slices 1-6 now
+    // cover FP16, FP8, NVFP4 GEMV+GEMM, CUTLASS_NVFP4 prefill GEMM, MXFP4
+    // GEMV+GEMM. Q4_0/Q4_1 (dp4a/q8) is Slice 7 territory.
+    GemmStrategy unregistered{StorageTier::MXFP4, QType::BF16, /*m_is_one=*/true};
     GemmKernelArgs args{};
     args.stream = stream_;
     EXPECT_EQ(reg.dispatch(unregistered, args), GemmDispatchResult::NoMatch);
@@ -636,6 +640,191 @@ TEST_F(GemmKernelRegistryTest, CutlassNvfp4RegistryDispatchRunsToCompletion) {
     cudaFree(d_input);
     cudaFree(d_weight_fp16);
     cudaFree(d_out);
+}
+
+// R5 Slice 6 — MXFP4 native GGUF kernels registered. With FP16 (2) + FP8
+// prefill (1) + NVFP4 GEMV (1) + NVFP4 GEMM (1) + CUTLASS_NVFP4 GEMM (1) +
+// MXFP4 GEMV (1) + MXFP4 GEMM (1) we now expect at least 8 entries. The
+// dual-cache CUTLASS MXFP4 branch (legacy line 2149-2174) is intentionally
+// NOT migrated — see src/graph/gemm_kernel_mxfp4.cu header.
+TEST_F(GemmKernelRegistryTest, Mxfp4KernelsAreRegisteredAtStaticInit) {
+    const auto& reg = GemmKernelRegistry::instance();
+    EXPECT_GE(reg.size(), 8u)
+        << "FP16 (M==1/M>1) + FP8 (M>1) + NVFP4 GEMV (M==1) + NVFP4 GEMM (M>1) + "
+           "CUTLASS_NVFP4 GEMM (M>1) + MXFP4 GEMV (M==1) + MXFP4 GEMM (M>1) expected pre-registered";
+}
+
+// The MXFP4 adapters register only under (tier=MXFP4, qtype=F16). Off-axis
+// weight_qtype must NoMatch so the dispatch site falls back to legacy.
+TEST_F(GemmKernelRegistryTest, Mxfp4WrongQtypeReturnsNoMatch) {
+    const auto& reg = GemmKernelRegistry::instance();
+    GemmStrategy bf16_gemv{StorageTier::MXFP4, QType::BF16, /*m_is_one=*/true};
+    GemmStrategy bf16_gemm{StorageTier::MXFP4, QType::BF16, /*m_is_one=*/false};
+    GemmKernelArgs args{};
+    args.stream = stream_;
+    EXPECT_EQ(reg.dispatch(bf16_gemv, args), GemmDispatchResult::NoMatch);
+    EXPECT_EQ(reg.dispatch(bf16_gemm, args), GemmDispatchResult::NoMatch);
+}
+
+// The MXFP4 GEMM adapter requires the dequant scratch (legacy line 2101). A
+// null scratch returns PreconditionFail so the dispatch site can fall back
+// to legacy. Mirrors the FP8 missing-scratch test (Slice 2 pattern).
+TEST_F(GemmKernelRegistryTest, Mxfp4GemmRejectsMissingDequantScratch) {
+    constexpr int M = 4;
+    constexpr int N = 16;
+    constexpr int K = 64;
+
+    __half* d_input = nullptr;
+    __half* d_out = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor output(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    // Build a dummy CutlassMxFP4Weight with linear_scales != null so the
+    // gate at the top of the kernel passes, but leave dequant_scratch null.
+    // The kernel returns PreconditionFail before dereferencing weight bytes.
+    uint8_t dummy_scale = 0;
+    CutlassMxFP4Weight dummy{};
+    dummy.N = N;
+    dummy.K = K;
+    dummy.linear_scales = &dummy_scale;  // non-null is sufficient — never dereferenced
+    dummy.data = &dummy_scale;           // ditto
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &output;
+    args.stream = stream_;
+    args.weight_payload = &dummy;
+    // Intentionally leave dequant_scratch null.
+
+    GemmStrategy strat{StorageTier::MXFP4, QType::F16, /*m_is_one=*/false};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::PreconditionFail);
+
+    cudaFree(d_input);
+    cudaFree(d_out);
+}
+
+// Both adapters gate on linear_scales != null (legacy line 2087). When the
+// gate fails, both return PreconditionFail so the dispatch site falls back
+// to legacy. Use the GEMV slot because it has no other workspace requirement.
+TEST_F(GemmKernelRegistryTest, Mxfp4GemvRejectsMissingLinearScales) {
+    constexpr int M = 1;
+    constexpr int N = 16;
+    constexpr int K = 64;
+
+    __half* d_input = nullptr;
+    __half* d_out = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor output(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    // linear_scales is null by default in the value-initialized struct —
+    // mirrors the case where the loader did not populate linear scales for
+    // this weight (e.g. CUTLASS-only conversion).
+    CutlassMxFP4Weight dummy{};
+    dummy.N = N;
+    dummy.K = K;
+    // dummy.linear_scales stays null.
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &output;
+    args.stream = stream_;
+    args.weight_payload = &dummy;
+
+    GemmStrategy strat{StorageTier::MXFP4, QType::F16, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::PreconditionFail);
+
+    cudaFree(d_input);
+    cudaFree(d_out);
+}
+
+// End-to-end correctness: registry MXFP4 GEMV dispatch produces the same
+// output as calling gemv_mxfp4_kpar directly. Build the CutlassMxFP4Weight
+// via the NVFP4 → MXFP4 conversion path (same approach as
+// tests/test_weight_dispatch.cu), then compare bit-identical outputs.
+TEST_F(GemmKernelRegistryTest, Mxfp4GemvRegistryDispatchMatchesDirectPath) {
+    constexpr int M = 1;
+    constexpr int N = 16;
+    constexpr int K = 64;  // multiple of 32 (MXFP4 group size)
+
+    std::vector<__half> h_input(M * K);
+    std::vector<__half> h_weight_fp16(N * K);
+    for (int i = 0; i < M * K; ++i) h_input[i] = __float2half((i % 5) * 0.0625f - 0.125f);
+    for (int i = 0; i < N * K; ++i) h_weight_fp16[i] = __float2half((i % 7) * 0.0625f - 0.1875f);
+
+    __half *d_input = nullptr, *d_weight_fp16 = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_weight_fp16, sizeof(__half) * N * K);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_weight_fp16, h_weight_fp16.data(), sizeof(__half) * N * K, cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight_fp16(d_weight_fp16, QType::F16, 2, w_shape, /*on_device=*/true);
+
+    // Build the MXFP4 weight via FP16 → NVFP4 → MXFP4 conversion. The
+    // resulting CutlassMxFP4Weight has linear_scales populated (UE8M0 per 32)
+    // and hadamard_bs == 0 (no rotation), which is what gemv_mxfp4_kpar
+    // consumes. Both paths read the same struct so the GEMV is read-only.
+    NvFP4QuantResult nv4{};
+    quantize_fp16_to_nvfp4(weight_fp16, nv4, stream_);
+    CutlassMxFP4Weight mw{};
+    convert_nvfp4_to_mxfp4_cutlass(nv4, mw, stream_);
+    ASSERT_NE(mw.linear_scales, nullptr)
+        << "convert_nvfp4_to_mxfp4_cutlass did not populate linear_scales";
+    cudaStreamSynchronize(stream_);
+
+    // Path 1: direct gemv_mxfp4_kpar (mirrors executor_kernels.cu:2097-2099).
+    __half* d_out_direct = nullptr;
+    cudaMalloc(&d_out_direct, sizeof(__half) * M * N);
+    gemv_mxfp4_kpar(mw, reinterpret_cast<const half*>(d_input), reinterpret_cast<half*>(d_out_direct),
+                    static_cast<int>(mw.N), static_cast<int>(mw.K), stream_);
+
+    // Path 2: registry dispatch through the MXFP4 GEMV kernel adapter.
+    __half* d_out_registry = nullptr;
+    cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
+    Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out_registry;
+    args.stream = stream_;
+    args.beta = 0.0f;
+    args.weight_payload = &mw;
+    GemmStrategy strat{StorageTier::MXFP4, QType::F16, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+
+    cudaStreamSynchronize(stream_);
+
+    std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);
+    cudaMemcpy(h_out_direct.data(), d_out_direct, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_out_registry.data(), d_out_registry, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+
+    // Both paths invoke gemv_mxfp4_kpar with identical args → bit-identical.
+    // (Hadamard rotation is disabled here because mw.hadamard_bs == 0, so the
+    // input is not mutated.)
+    for (int i = 0; i < M * N; ++i) {
+        EXPECT_EQ(__half_as_ushort(h_out_direct[i]), __half_as_ushort(h_out_registry[i]))
+            << "Mismatch at i=" << i << " (direct=" << __half2float(h_out_direct[i])
+            << " registry=" << __half2float(h_out_registry[i]) << ")";
+    }
+
+    free_cutlass_mxfp4_weight(mw);
+    free_nvfp4_result(nv4);
+    cudaFree(d_input);
+    cudaFree(d_weight_fp16);
+    cudaFree(d_out_direct);
+    cudaFree(d_out_registry);
 }
 
 // Pin the GemmStrategy operator== contract — used by the linear-scan


### PR DESCRIPTION
## Summary

R5 Slice 6 — migrates the **MXFP4 dense path** to the \`GemmKernel\` registry. Two strategies registered (GEMV and GEMM dequant) to mirror the Slice 3+4 NVFP4 split. Feature-flag opt-in unchanged (default OFF).

## Files

- **\`src/graph/gemm_kernel_mxfp4.cu\`** (new, ~110 lines) — two strategy handlers:
  - GEMV via \`gemv_mxfp4_kpar\` (with in-place Hadamard rotation when \`hadamard_bs > 0\`)
  - GEMM via \`dequant_mxfp4_to_fp16\` + standard cuBLAS \`gemm()\`
- **\`src/graph/executor_kernels.cu\`** — MXFP4 branch added as FIRST registry path (mirrors legacy precedence at line 2085: MXFP4 cache hit takes precedence over NVFP4/FP8/FP16).
- **\`CMakeLists.txt\`** — adds the new TU.
- **\`tests/test_gemm_kernel_registry.cu\`** — 5 new MXFP4 tests + retargeted \`UnregisteredStrategyReturnsNoMatch\` (now points at a freshly-unregistered tier).

## Strategy-key decision: TWO entries

Registered \`{MXFP4, F16, m_is_one=true}\` (GEMV) and \`{MXFP4, F16, m_is_one=false}\` (GEMM) — they share zero runtime code:
- Different scale layouts: \`linear_scales\` row-major UE8M0 for GEMV vs raw GGUF split layout for dequant
- Different backends entirely
- Different workspace requirements: GEMV needs none; GEMM needs \`dequant_scratch\`

A single combined strategy with internal \`if (M==1)\` would re-duplicate the strategy-key axis the registry already exposes. Mirrors Slice 3+4.

## Architectural note — dual-cache QW7 probe deliberately left on legacy

The legacy GGUF MXFP4 dispatch site at \`executor_kernels.cu:2085-2113\` is NOT the only MXFP4 entry point. A **dual-cache CUTLASS MXFP4 branch** lives at lines 2149-2174 — nested inside the NVFP4 dispatch path, only fires when the same \`weight.data\` is in BOTH \`cutlass_nvfp4_cache\` AND \`cutlass_mxfp4_cache\`. It carries a \`s_logged.exchange(true)\` QW7 instrumentation probe (review/phase3_maint.md §5.1: "loader never does this … needs production trace").

Deliberately left on legacy for this slice: it doesn't fit the \`(tier, qtype, m_is_one)\` strategy trio (requires a dual-cache hit condition). Migrating it would either need a new axis on \`GemmStrategy\` (out of scope) or a contrived "owner tier" with an internal sub-check (defeats the registry's purpose). The new \`gemm_kernel_mxfp4.cu\` header documents this. **Slice 8 will resolve it** — either delete the QW7 branch (if instrumentation has confirmed it's dead by then) or promote it to a first-class strategy.

No \`GemmKernelArgs\` extensions needed; existing fields (\`dequant_scratch\`, \`mxfp4_act_sf\`, \`mxfp4_workspace\`) suffice.

## Test plan

- [x] \`make build\` PASS
- [x] \`make verify-fast\` PASS (host + pre-push hook)
- [x] 23/23 \`GemmKernelRegistryTest*:GemmStrategy*\` PASS (was 18/18 after Slice 5)
- [x] 146/146 \`test-compute\` PASS (was 141/141 after Slice 5; +5 new tests, 0 regressions)
- [x] Branch off origin/main; \`--base main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)