### PR TITLE
refactor(graph): R5 Slice 7 — GGUF dp4a/mmvq kernels via GemmKernel registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ set(IMP_GRAPH_SOURCES
     src/graph/gemm_kernel_nvfp4_gemm.cu
     src/graph/gemm_kernel_cutlass_nvfp4.cu
     src/graph/gemm_kernel_mxfp4.cu
+    src/graph/gemm_kernel_gguf.cu
     src/graph/executor_workspace.cu
     src/graph/executor_workspace_buffers.cu
     src/graph/executor_kv_write.cu

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -57,7 +57,11 @@ void prewarm_mmvq_scratch(int max_tokens, int max_K) {
                  need / 1024.0, max_tokens, max_K);
 }
 
-static void mmvq_scratch_get_or_grow(size_t need, void** out_buf, size_t* out_size) {
+// R5 Slice 7: the mmvq adapter in `gemm_kernel_gguf.cu` re-uses this single
+// global via a forward declaration there — internal linkage would force the
+// new TU to duplicate the scratch state. Kept namespace-local (no public
+// header declaration) to limit exposure.
+void mmvq_scratch_get_or_grow(size_t need, void** out_buf, size_t* out_size) {
     if (g_mmvq_scratch && g_mmvq_scratch_size >= need) {
         *out_buf = g_mmvq_scratch;
         *out_size = g_mmvq_scratch_size;
@@ -2366,12 +2370,14 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
     const auto* ct4 = (wc->cutlass_nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_nvfp4;
     const auto* mx4 = (wc->cutlass_mxfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_mxfp4;
 
-    // R5 Slice 1+2+3+4+5+6: when gemm.use_kernel_registry is enabled, try the
-    // new dispatch table first. Slices 1 (FP16), 2 (FP8 prefill), 3 (NVFP4
-    // decode GEMV), 4 (NVFP4 prefill GEMM dequant), 5 (CUTLASS_NVFP4 prefill
-    // GEMM, preferred native FP4 path) and 6 (MXFP4 native GGUF — GEMV +
-    // dequant→cuBLAS GEMM) are wired; remaining tiers (dp4a/q8 — Slice 7)
-    // fall through to the legacy gemm_dispatch_impl below.
+    // R5 Slice 1+2+3+4+5+6+7: when gemm.use_kernel_registry is enabled, try
+    // the new dispatch table first. Slices 1 (FP16), 2 (FP8 prefill), 3
+    // (NVFP4 decode GEMV), 4 (NVFP4 prefill GEMM dequant), 5 (CUTLASS_NVFP4
+    // prefill GEMM, preferred native FP4 path), 6 (MXFP4 native GGUF — GEMV +
+    // dequant→cuBLAS GEMM) and 7 (GGUF small-M mmvq + dp4a — 8 qtypes) are
+    // wired; the M>1 dequant+cuBLAS large-M fallback and Q4_1 quant_gemm_int4
+    // still fall through to the legacy gemm_dispatch_impl below (slice 8
+    // retires the legacy switch).
     //
     // Tier order mirrors gemm_dispatch_impl precedence: MXFP4 GGUF is the
     // top-priority branch in legacy (executor_kernels.cu:2085-2113) and is
@@ -2548,6 +2554,35 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
             if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;
+        }
+        // Slice 7 — GGUF small-M (mmvq / dp4a) dispatch. Only fires for M==1
+        // with FP16 input and a non-FP32 output, mirroring the legacy mmvq +
+        // dp4a gates at gemm_dispatch_impl:2216-2222. Per-qtype strategies
+        // (Option 2 scope decision — see gemm_kernel_gguf.cu header) and the
+        // handler internally selects mmvq vs dp4a based on the same
+        // RuntimeConfig fields the legacy switch reads. `prefer_fp16_cache`
+        // remains a dispatch-site gate because it depends on `fp16` cache
+        // membership + stride, which isn't part of GemmKernelArgs.
+        const bool fp32_output = (output.qtype == QType::F32);
+        const bool prefer_fp16_cache =
+            (fp16 != nullptr && fp16->count(weight.data) > 0 && input.stride[0] != weight.shape[1]);
+        if (M == 1 && input.qtype == QType::F16 && !fp32_output && !prefer_fp16_cache) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.beta = ctx.beta;
+            args.weight_payload = &weight;
+            args.q8_1_buf = qs->q8_1_buf;
+            args.d8_buf = qs->d8_buf;
+            GemmStrategy strat{StorageTier::FP16, qtype, /*m_is_one=*/true};
+            auto rc = GemmKernelRegistry::instance().dispatch(strat, args);
+            if (rc == GemmDispatchResult::Ok)
+                return;
+            // NoMatch (qtype not in slice 7 set) or PreconditionFail (neither
+            // mmvq nor dp4a backend matched) — fall through to legacy. Same
+            // semantics as the legacy `else if` chain continuing past the
+            // mmvq/dp4a branches.
         }
         // Fall through: registry returned NoMatch for this strategy — use legacy.
     }

--- a/src/graph/gemm_kernel_gguf.cu
+++ b/src/graph/gemm_kernel_gguf.cu
@@ -1,0 +1,234 @@
+#include "graph/gemm_kernel_registry.h"
+
+#include "compute/gemm.h"        // quantize_fp16_to_q8_1, block_q8_1
+#include "compute/ggml_mmvq.h"   // ggml_mmvq_q4k / q5k / q5_1 / q8_0
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "graph/executor_kernels.h"  // is_dp4a_qtype, dispatch_dp4a_gemv, block_q8_1
+#include "runtime/config.h"
+
+#include <cuda_fp16.h>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// GGUF small-M tier — R5 Slice 7.
+//
+// Migrates the legacy mmvq + dp4a small-M GGUF branches (gemm_dispatch_impl
+// at executor_kernels.cu:2216-2251) to the GemmKernel registry. The legacy
+// dispatch evaluates two parallel gates at M==1:
+//
+//   use_mmvq = gemma4.force_mmvq && qtype ∈ {Q4_K, Q5_K, Q5_1, Q8_0}
+//              && weight.shape[1] % 32 == 0 && !no_mmvq && !no_mmvq_q8_0(Q8_0)
+//              && !prefer_fp16_cache && input.qtype == F16 && !fp32_output
+//
+//   use_dp4a = !no_dp4a_gemv && qtype ∈ {Q6_K, Q8_0, Q4_0, Q4_K, Q5_K, Q2_K, Q3_K}
+//              && q8_1_buf && d8_buf && !prefer_fp16_cache && input.qtype == F16
+//              && !fp32_output && input.shape[0] == 1
+//
+// `use_mmvq` wins when both are eligible (legacy if/else if order). The two
+// backends overlap on Q4_K / Q5_K / Q8_0; the dispatch site emits a single
+// (FP16, <qtype>, m_is_one=true) strategy key per qtype and the registered
+// handler internally re-evaluates `force_mmvq`/`no_mmvq`/etc. and picks the
+// backend — same conditions, same precedence as legacy. PreconditionFail
+// when neither backend can run (e.g. dp4a scratch missing, mmvq disabled),
+// surfacing the same fall-through to legacy that the legacy `else if` chain
+// produces today.
+//
+// Scope decision — Option 2 trimmed (per-qtype, M==1 only), with internal
+// backend selection inside each handler.
+//
+// Why this shape:
+//   - Option 1 (one strategy + giant switch) buries the qtype axis inside
+//     the kernel handler — defeats the registry's "qtype key resolves to
+//     handler" contract.
+//   - Option 3 (one strategy per backend with internal qtype switch)
+//     collides on strategy keys because mmvq and dp4a overlap on three
+//     qtypes — no clean axis to disambiguate the two backends without
+//     overloading m_is_one or extending the StorageTier / GemmStrategy
+//     types (constrained by Slice 7 charter).
+//   - Option 2 (one strategy per qtype × m_is_one) maps cleanly onto the
+//     registry: the dispatch site emits exactly the qtype the weight has,
+//     the registry resolves to that qtype's handler, and the handler picks
+//     the backend based on the SAME RuntimeConfig fields the legacy switch
+//     reads. The "which backend wins" decision is local to the handler —
+//     mirroring how legacy makes it local to the dispatch impl. The cross-
+//     axis maintainability win still holds because each handler is small
+//     (~30 lines) and adding a new qtype is a single new registration.
+//
+// Strategy key set (8 entries, M==1 only):
+//   {FP16, Q4_K, true}, {FP16, Q5_K, true}, {FP16, Q5_1, true},
+//   {FP16, Q8_0, true}, {FP16, Q6_K, true}, {FP16, Q4_0, true},
+//   {FP16, Q2_K, true}, {FP16, Q3_K, true}
+//
+// StorageTier::FP16 = the INPUT tier (activations are FP16). GGUF weights
+// live raw in their qtype without a dedicated StorageTier — using FP16 as
+// the "input tier" matches Slice 1-6 semantics (where the tier name often
+// reflects what the engine observes for the weight, not its packed format).
+//
+// Out of scope (stays on legacy for now):
+//   - Q4_1 quant_gemm_int4 (also a small-M path but neither mmvq nor dp4a).
+//   - M>1 dequant+cuBLAS fallback (the "large-M path" in the slice 7 prompt).
+//   - Fused Q6_K/Q8_0 GEMV (the `else if` fallback below dp4a in legacy).
+//   - prefer_fp16_cache decision (stays on dispatch site — strictly upstream).
+//   - FP32-output paths (write directly to half*, so legacy stays in charge).
+// All of these continue through `gemm_dispatch_impl` when the registry
+// returns NoMatch / PreconditionFail. Slice 8 retires the legacy switch.
+// ---------------------------------------------------------------------------
+
+// Forward declarations — single-global mmvq scratch lives in
+// executor_kernels.cu. Calling it via prototype keeps the invariant
+// without widening the public header surface in this slice.
+void mmvq_scratch_get_or_grow(size_t need, void** out_buf, size_t* out_size);
+
+// ---------------------------------------------------------------------------
+// Backend helpers — small, qtype-parameterised. Both backends are M==1 only
+// (legacy gate at executor_kernels.cu:2221).
+// ---------------------------------------------------------------------------
+
+// mmvq backend: Q8_1-quantize activations into the file-scope mmvq scratch,
+// then run the ggml-compatible GEMV. Mirrors legacy lines 2230-2245.
+template <void (*Launcher)(const void*, const half*, half*, int, int, int, void*, size_t, cudaStream_t)>
+static void run_mmvq_backend(const GemmKernelArgs& args, const Tensor& weight) {
+    const int M = static_cast<int>(args.input->shape[0]);
+    const int N = static_cast<int>(weight.shape[0]);
+    const int K = static_cast<int>(weight.shape[1]);
+    size_t q8_need = static_cast<size_t>(M) * ((K + 31) / 32) * 36;
+    void* s_mmvq_scratch = nullptr;
+    size_t s_mmvq_scratch_size = 0;
+    mmvq_scratch_get_or_grow(q8_need, &s_mmvq_scratch, &s_mmvq_scratch_size);
+    Launcher(weight.data, static_cast<const half*>(args.input->data),
+             static_cast<half*>(args.output->data), M, N, K, s_mmvq_scratch, s_mmvq_scratch_size,
+             args.stream);
+}
+
+// dp4a backend: caller-provided q8_1_buf + d8_buf (sized by engine init via
+// QuantScratch). Mirrors legacy lines 2246-2251 verbatim.
+static void run_dp4a_backend(const GemmKernelArgs& args, const Tensor& weight, QType qtype) {
+    const int N = static_cast<int>(weight.shape[0]);
+    const int K = static_cast<int>(weight.shape[1]);
+    quantize_fp16_to_q8_1(static_cast<const half*>(args.input->data),
+                          static_cast<block_q8_1*>(args.q8_1_buf), args.d8_buf, K, args.stream);
+    dispatch_dp4a_gemv(qtype, weight.data, static_cast<const block_q8_1*>(args.q8_1_buf), args.d8_buf,
+                       static_cast<half*>(args.output->data), N, K, args.stream);
+}
+
+// Per-qtype dispatcher — internally picks mmvq vs dp4a based on RuntimeConfig
+// + workspace availability. `mmvq_eligible` flags qtypes mmvq supports; the
+// dp4a check uses is_dp4a_qtype(). When neither backend matches, returns
+// PreconditionFail so the dispatch site falls back to the legacy switch.
+template <void (*MmvqLauncher)(const void*, const half*, half*, int, int, int, void*, size_t, cudaStream_t)>
+static GemmDispatchResult run_gguf_smallm(const GemmKernelArgs& args, QType qtype, bool mmvq_eligible) {
+    IMP_CHECK(args.input != nullptr, "gguf_smallm: input is null");
+    IMP_CHECK(args.output != nullptr, "gguf_smallm: output is null");
+    IMP_CHECK(args.weight_payload != nullptr, "gguf_smallm: weight_payload is null");
+    const Tensor& weight = *static_cast<const Tensor*>(args.weight_payload);
+    IMP_CHECK(weight.qtype == qtype, "gguf_smallm: weight qtype mismatch");
+
+    // The dispatch site already filtered on `input.qtype==F16`, `M==1`, and
+    // `output.qtype != F32`. The kernel re-checks the runtime-config gates
+    // that legacy evaluates at the call site:
+    const auto& rcfg = RuntimeConfig::current();
+    const int K = static_cast<int>(weight.shape[1]);
+
+    // mmvq has stricter eligibility (legacy line 2216-2220): force_mmvq set,
+    // qtype mmvq supports, K%32==0, no_mmvq off, no_mmvq_q8_0 off for Q8_0.
+    const bool no_mmvq_q8_0 = rcfg.gemm.no_mmvq_q8_0;
+    const bool no_mmvq_all = rcfg.gemm.no_mmvq;
+    const bool use_mmvq = rcfg.gemma4.force_mmvq && mmvq_eligible && (K % 32 == 0) && !no_mmvq_all &&
+                          !(no_mmvq_q8_0 && qtype == QType::Q8_0);
+
+    // dp4a eligibility (legacy line 2221-2222): scratch present + is_dp4a_qtype.
+    const bool no_dp4a_gemv = rcfg.gemm.no_dp4a_gemv;
+    const bool use_dp4a = !no_dp4a_gemv && args.q8_1_buf != nullptr && args.d8_buf != nullptr &&
+                          is_dp4a_qtype(qtype);
+
+    if (use_mmvq) {
+        run_mmvq_backend<MmvqLauncher>(args, weight);
+        return GemmDispatchResult::Ok;
+    }
+    if (use_dp4a) {
+        run_dp4a_backend(args, weight, qtype);
+        return GemmDispatchResult::Ok;
+    }
+    // Neither backend matches — fall back to legacy (e.g. fused Q6_K/Q8_0
+    // GEMV at executor_kernels.cu:2263-2272, dequant+cuBLAS, etc.).
+    return GemmDispatchResult::PreconditionFail;
+}
+
+// A no-op mmvq launcher used by qtypes mmvq doesn't support (Q6_K, Q4_0,
+// Q2_K, Q3_K). The template parameter must compile but is never invoked at
+// runtime because `mmvq_eligible=false` for these qtypes.
+static void no_op_mmvq_launcher(const void*, const half*, half*, int, int, int, void*, size_t,
+                                cudaStream_t) {
+    // Intentionally empty — dispatched only if mmvq_eligible=true for the
+    // qtype, which is false for the qtypes that bind to this launcher.
+}
+
+// ---------------------------------------------------------------------------
+// Per-qtype handler functions (8 total, one per supported qtype).
+// ---------------------------------------------------------------------------
+
+static GemmDispatchResult gguf_q4k_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&ggml_mmvq_q4k>(args, QType::Q4_K, /*mmvq_eligible=*/true);
+}
+
+static GemmDispatchResult gguf_q5k_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&ggml_mmvq_q5k>(args, QType::Q5_K, /*mmvq_eligible=*/true);
+}
+
+static GemmDispatchResult gguf_q5_1_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&ggml_mmvq_q5_1>(args, QType::Q5_1, /*mmvq_eligible=*/true);
+}
+
+static GemmDispatchResult gguf_q8_0_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&ggml_mmvq_q8_0>(args, QType::Q8_0, /*mmvq_eligible=*/true);
+}
+
+// dp4a-only qtypes (no mmvq backend).
+static GemmDispatchResult gguf_q6k_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q6_K, /*mmvq_eligible=*/false);
+}
+
+static GemmDispatchResult gguf_q4_0_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q4_0, /*mmvq_eligible=*/false);
+}
+
+static GemmDispatchResult gguf_q2k_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q2_K, /*mmvq_eligible=*/false);
+}
+
+static GemmDispatchResult gguf_q3k_kernel(const GemmKernelArgs& args) {
+    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q3_K, /*mmvq_eligible=*/false);
+}
+
+namespace {
+struct GgufRegistration {
+    GgufRegistration() {
+        auto& reg = GemmKernelRegistry::instance();
+        // Eight strategies — every small-M GGUF qtype reachable via mmvq or
+        // dp4a. All under (StorageTier::FP16, <qtype>, m_is_one=true). The
+        // qtype axis is the discriminator; the handler internally picks the
+        // backend.
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q4_K, /*m_is_one=*/true},
+                            &gguf_q4k_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q5_K, /*m_is_one=*/true},
+                            &gguf_q5k_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q5_1, /*m_is_one=*/true},
+                            &gguf_q5_1_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q8_0, /*m_is_one=*/true},
+                            &gguf_q8_0_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q6_K, /*m_is_one=*/true},
+                            &gguf_q6k_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q4_0, /*m_is_one=*/true},
+                            &gguf_q4_0_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q2_K, /*m_is_one=*/true},
+                            &gguf_q2k_kernel);
+        reg.register_kernel(GemmStrategy{StorageTier::FP16, QType::Q3_K, /*m_is_one=*/true},
+                            &gguf_q3k_kernel);
+    }
+};
+static GgufRegistration s_gguf_registration;
+}  // namespace
+
+}  // namespace imp

--- a/src/graph/gemm_kernel_registry.h
+++ b/src/graph/gemm_kernel_registry.h
@@ -88,6 +88,18 @@ struct GemmKernelArgs {
     float* d_fp8_block_maxes = nullptr;
     float* d_fp8_absmax = nullptr;
     int fp8_max_grid = 0;
+
+    // dp4a / Q8_1 activation quantization scratch (slice 7 — GGUF dp4a tier).
+    // Same role as fp8_act_buf + d_act_scale above: a per-call activation
+    // scratch pre-sized by engine init (QuantScratch::q8_1_buf / d8_buf).
+    // The dp4a kernels quantize the FP16 activation into `q8_1_buf` then run
+    // dispatch_dp4a_gemv with the block scales in `d8_buf`. nullptr means the
+    // caller did not supply scratch and the kernel must PreconditionFail so
+    // the dispatch site can fall back to legacy. Typed as void* / float* to
+    // mirror the legacy gemm_dispatch_impl signature; the kernel reinterpret-
+    // casts to block_q8_1*.
+    void* q8_1_buf = nullptr;
+    float* d8_buf = nullptr;
 };
 
 // Result of a dispatch attempt.
@@ -139,7 +151,11 @@ private:
         GemmStrategy strategy;
         GemmKernelFn fn;
     };
-    Entry entries_[16] = {};
+    // Capacity sized for Slice 7: 8 entries through Slice 6 + 11 new GGUF
+    // strategies (4 mmvq qtypes + 7 dp4a qtypes) = 19; bumped to 32 for
+    // headroom (next slices may register additional GGUF qtype/backend
+    // combinations or the remaining Q4_1 / IQ4 paths).
+    Entry entries_[32] = {};
     std::size_t count_ = 0;
 };
 

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -4,16 +4,19 @@
 #include "compute/gemm_cutlass_sm120.h"  // CutlassNvFP4Weight, convert_nvfp4_to_cutlass, gemm_nvfp4_cutlass_sm120
 #include "core/tensor.h"
 #include "graph/executor.h"  // FP8CacheEntry
+#include "graph/executor_kernels.h"  // is_dp4a_qtype, dispatch_dp4a_gemv
 #include "quant/fp8_quant.h"
 #include "quant/mxfp4_gemm.h"  // gemv_mxfp4_kpar
 #include "quant/nvfp4_gemm.h"
 #include "quant/nvfp4_quant.h"
+#include "runtime/config.h"
 
 #include <gtest/gtest.h>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <vector>
 #include <cmath>
+#include <cstring>
 
 using namespace imp;
 
@@ -825,6 +828,282 @@ TEST_F(GemmKernelRegistryTest, Mxfp4GemvRegistryDispatchMatchesDirectPath) {
     cudaFree(d_weight_fp16);
     cudaFree(d_out_direct);
     cudaFree(d_out_registry);
+}
+
+// R5 Slice 7 — GGUF small-M (mmvq + dp4a) kernels registered. 8 qtypes
+// covered (Q4_K, Q5_K, Q5_1, Q8_0, Q6_K, Q4_0, Q2_K, Q3_K) — one strategy
+// per qtype, all under (StorageTier::FP16, <qtype>, m_is_one=true). With
+// Slices 1-6 contributing 8 entries, Slice 7 brings the total to 16.
+TEST_F(GemmKernelRegistryTest, GgufSmallmKernelsAreRegisteredAtStaticInit) {
+    const auto& reg = GemmKernelRegistry::instance();
+    EXPECT_GE(reg.size(), 16u)
+        << "Slices 1-6 (8 entries) + Slice 7 GGUF small-M (8 qtypes) expected pre-registered";
+}
+
+// Off-axis m_is_one (M>1 prefill) must NoMatch — Slice 7 only registers the
+// M==1 decode side. The dispatch site shouldn't accidentally pick up GGUF
+// strategies on the prefill path.
+TEST_F(GemmKernelRegistryTest, GgufWrongMIsOneReturnsNoMatch) {
+    const auto& reg = GemmKernelRegistry::instance();
+    GemmStrategy m_gt_one{StorageTier::FP16, QType::Q4_K, /*m_is_one=*/false};
+    GemmKernelArgs args{};
+    args.stream = stream_;
+    EXPECT_EQ(reg.dispatch(m_gt_one, args), GemmDispatchResult::NoMatch);
+}
+
+// An unsupported qtype (Q4_1 stays on legacy quant_gemm_int4, IQ4_NL/XS not
+// in slice 7) must NoMatch so the dispatch site falls back.
+TEST_F(GemmKernelRegistryTest, GgufUnsupportedQtypeReturnsNoMatch) {
+    const auto& reg = GemmKernelRegistry::instance();
+    GemmStrategy q4_1{StorageTier::FP16, QType::Q4_1, /*m_is_one=*/true};
+    GemmKernelArgs args{};
+    args.stream = stream_;
+    EXPECT_EQ(reg.dispatch(q4_1, args), GemmDispatchResult::NoMatch);
+}
+
+// When neither backend can run (mmvq disabled via force_mmvq=false AND dp4a
+// scratch missing), the handler returns PreconditionFail so the dispatch
+// site falls back to legacy. Q6_K is dp4a-only (no mmvq backend) — with
+// q8_1_buf/d8_buf null and force_mmvq=false, neither path matches.
+TEST_F(GemmKernelRegistryTest, GgufQ6kRejectsMissingDp4aScratch) {
+    constexpr int M = 1;
+    constexpr int N = 16;
+    constexpr int K = 256;  // Q6_K block = 256 elements
+
+    __half* d_input = nullptr;
+    __half* d_out = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+    cudaMemset(d_input, 0, sizeof(__half) * M * K);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor output(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+    // Dummy weight — never dereferenced because the handler returns
+    // PreconditionFail before touching the bytes.
+    Tensor weight(reinterpret_cast<void*>(static_cast<uintptr_t>(0xDEAD)), QType::Q6_K, 2, w_shape,
+                  /*on_device=*/true);
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &output;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    // q8_1_buf / d8_buf intentionally null — dp4a backend can't run.
+
+    GemmStrategy strat{StorageTier::FP16, QType::Q6_K, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::PreconditionFail);
+
+    cudaFree(d_input);
+    cudaFree(d_out);
+}
+
+// dp4a backend smoke: provide q8_1_buf + d8_buf, build a real Q8_0 weight,
+// and verify the registry dispatch produces the same output as calling
+// quantize_fp16_to_q8_1 + dispatch_dp4a_gemv directly (the legacy code path
+// at executor_kernels.cu:2249-2251). Q8_0 is the simplest qtype to set up:
+// the block layout is `block_q8_0 { half d; int8_t qs[32]; }` = 34 bytes,
+// and we can quantize an FP16 tensor on the host.
+TEST_F(GemmKernelRegistryTest, GgufQ8_0Dp4aRegistryDispatchMatchesDirectPath) {
+    constexpr int M = 1;
+    constexpr int N = 32;
+    constexpr int K = 128;  // multiple of 32 (Q8_0 block size)
+    constexpr int blocks_per_row = K / 32;
+
+    // Build a deterministic FP16 weight + activation.
+    std::vector<__half> h_weight_fp16(N * K);
+    std::vector<__half> h_input(M * K);
+    for (int i = 0; i < N * K; ++i) h_weight_fp16[i] = __float2half((i % 7) * 0.0625f - 0.1875f);
+    for (int i = 0; i < M * K; ++i) h_input[i] = __float2half((i % 5) * 0.0625f - 0.125f);
+
+    // Host-quantize the FP16 weight to Q8_0 layout: per 32-element block,
+    // store FP16 scale `d` (= max(|x|)/127), then 32 int8 quantized values.
+    constexpr int kQ8_0_BlockBytes = 2 + 32;  // half + 32 * int8
+    std::vector<uint8_t> h_weight_q8_0(static_cast<size_t>(N) * blocks_per_row * kQ8_0_BlockBytes);
+    for (int row = 0; row < N; ++row) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            float absmax = 0.0f;
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                absmax = std::max(absmax, std::fabs(v));
+            }
+            float d = absmax / 127.0f;
+            float inv_d = (d > 0.0f) ? 1.0f / d : 0.0f;
+            uint8_t* blk = h_weight_q8_0.data() +
+                           (static_cast<size_t>(row) * blocks_per_row + b) * kQ8_0_BlockBytes;
+            __half d_h = __float2half(d);
+            std::memcpy(blk, &d_h, sizeof(__half));
+            int8_t* qs = reinterpret_cast<int8_t*>(blk + 2);
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                int q = static_cast<int>(std::lrintf(v * inv_d));
+                qs[j] = static_cast<int8_t>(std::max(-127, std::min(127, q)));
+            }
+        }
+    }
+
+    // Upload weight + input.
+    void* d_weight = nullptr;
+    __half* d_input = nullptr;
+    cudaMalloc(&d_weight, h_weight_q8_0.size());
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMemcpy(d_weight, h_weight_q8_0.data(), h_weight_q8_0.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+
+    // dp4a scratch: q8_1_buf is `block_q8_1[K/32]` (36 bytes/block), d8_buf
+    // is `float[K/32]`.
+    void* d_q8_1 = nullptr;
+    float* d_d8 = nullptr;
+    cudaMalloc(&d_q8_1, sizeof(block_q8_1) * blocks_per_row);
+    cudaMalloc(&d_d8, sizeof(float) * blocks_per_row);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(d_weight, QType::Q8_0, 2, w_shape, /*on_device=*/true);
+
+    // Path 1: direct legacy invocation (mirrors gemm_dispatch_impl:2249-2251).
+    __half* d_out_direct = nullptr;
+    cudaMalloc(&d_out_direct, sizeof(__half) * M * N);
+    quantize_fp16_to_q8_1(static_cast<const half*>(d_input), static_cast<block_q8_1*>(d_q8_1), d_d8, K,
+                          stream_);
+    dispatch_dp4a_gemv(QType::Q8_0, d_weight, static_cast<const block_q8_1*>(d_q8_1), d_d8,
+                       reinterpret_cast<half*>(d_out_direct), N, K, stream_);
+
+    // Path 2: registry dispatch through the GGUF Q8_0 kernel adapter. We
+    // must temporarily disable force_mmvq so the handler picks the dp4a
+    // backend (legacy precedence: mmvq wins when both eligible).
+    auto& mut_cfg = const_cast<RuntimeConfig&>(RuntimeConfig::current());
+    const bool prev_force_mmvq = mut_cfg.gemma4.force_mmvq;
+    mut_cfg.gemma4.force_mmvq = false;
+
+    __half* d_out_registry = nullptr;
+    cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
+    Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out_registry;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    args.q8_1_buf = d_q8_1;
+    args.d8_buf = d_d8;
+    GemmStrategy strat{StorageTier::FP16, QType::Q8_0, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+
+    mut_cfg.gemma4.force_mmvq = prev_force_mmvq;
+    cudaStreamSynchronize(stream_);
+
+    std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);
+    cudaMemcpy(h_out_direct.data(), d_out_direct, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_out_registry.data(), d_out_registry, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+
+    // Both paths run the identical quantize + dp4a sequence → bit-identical.
+    for (int i = 0; i < M * N; ++i) {
+        EXPECT_EQ(__half_as_ushort(h_out_direct[i]), __half_as_ushort(h_out_registry[i]))
+            << "Mismatch at i=" << i << " (direct=" << __half2float(h_out_direct[i])
+            << " registry=" << __half2float(h_out_registry[i]) << ")";
+    }
+
+    cudaFree(d_weight);
+    cudaFree(d_input);
+    cudaFree(d_q8_1);
+    cudaFree(d_d8);
+    cudaFree(d_out_direct);
+    cudaFree(d_out_registry);
+}
+
+// mmvq backend smoke: provide weight + scratch + force_mmvq=true, verify
+// the registry handler picks mmvq (not dp4a) and produces a non-zero
+// output. We don't do bit-identical parity here because the mmvq scratch
+// is single-global and re-used between paths, which mucks with synchronous
+// invocation expectations; the dp4a parity test above is enough to pin
+// the args plumbing. This test only checks "Ok + non-zero output".
+TEST_F(GemmKernelRegistryTest, GgufQ8_0MmvqRegistryDispatchProducesNonZero) {
+    constexpr int M = 1;
+    constexpr int N = 32;
+    constexpr int K = 128;  // multiple of 32
+    constexpr int blocks_per_row = K / 32;
+
+    std::vector<__half> h_weight_fp16(N * K);
+    std::vector<__half> h_input(M * K);
+    for (int i = 0; i < N * K; ++i) h_weight_fp16[i] = __float2half((i % 7) * 0.0625f - 0.1875f);
+    for (int i = 0; i < M * K; ++i) h_input[i] = __float2half((i % 5) * 0.0625f - 0.125f);
+
+    constexpr int kQ8_0_BlockBytes = 34;
+    std::vector<uint8_t> h_weight_q8_0(static_cast<size_t>(N) * blocks_per_row * kQ8_0_BlockBytes);
+    for (int row = 0; row < N; ++row) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            float absmax = 0.0f;
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                absmax = std::max(absmax, std::fabs(v));
+            }
+            float d = absmax / 127.0f;
+            float inv_d = (d > 0.0f) ? 1.0f / d : 0.0f;
+            uint8_t* blk = h_weight_q8_0.data() +
+                           (static_cast<size_t>(row) * blocks_per_row + b) * kQ8_0_BlockBytes;
+            __half d_h = __float2half(d);
+            std::memcpy(blk, &d_h, sizeof(__half));
+            int8_t* qs = reinterpret_cast<int8_t*>(blk + 2);
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                int q = static_cast<int>(std::lrintf(v * inv_d));
+                qs[j] = static_cast<int8_t>(std::max(-127, std::min(127, q)));
+            }
+        }
+    }
+
+    void* d_weight = nullptr;
+    __half* d_input = nullptr;
+    cudaMalloc(&d_weight, h_weight_q8_0.size());
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMemcpy(d_weight, h_weight_q8_0.data(), h_weight_q8_0.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(d_weight, QType::Q8_0, 2, w_shape, /*on_device=*/true);
+
+    // Enable force_mmvq so the handler picks mmvq (precedence over dp4a).
+    auto& mut_cfg = const_cast<RuntimeConfig&>(RuntimeConfig::current());
+    const bool prev_force_mmvq = mut_cfg.gemma4.force_mmvq;
+    mut_cfg.gemma4.force_mmvq = true;
+
+    __half* d_out = nullptr;
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+    cudaMemsetAsync(d_out, 0, sizeof(__half) * M * N, stream_);
+    Tensor output(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &output;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    // q8_1_buf / d8_buf intentionally NOT supplied — mmvq has its own
+    // file-scope scratch and should win the gate.
+
+    GemmStrategy strat{StorageTier::FP16, QType::Q8_0, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+
+    mut_cfg.gemma4.force_mmvq = prev_force_mmvq;
+    cudaStreamSynchronize(stream_);
+
+    std::vector<__half> h_out(M * N);
+    cudaMemcpy(h_out.data(), d_out, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    int nonzero_count = 0;
+    for (int i = 0; i < M * N; ++i) {
+        if (__half_as_ushort(h_out[i]) != 0) ++nonzero_count;
+    }
+    EXPECT_GT(nonzero_count, 0) << "mmvq Q8_0 registry dispatch wrote all-zero output";
+
+    cudaFree(d_weight);
+    cudaFree(d_input);
+    cudaFree(d_out);
 }
 
 // Pin the GemmStrategy operator== contract — used by the linear-scan


### PR DESCRIPTION
## Summary

R5 Slice 7 — migrates the **GGUF dp4a/mmvq tier (M==1 GEMV decode path)** to the \`GemmKernel\` registry. Largest remaining scope: 8 supported GGUF qtypes registered as per-qtype strategies. Feature-flag opt-in unchanged.

## Files (5 changed, +573 / -8)

- **\`src/graph/gemm_kernel_gguf.cu\`** (new, 234 lines) — 8 per-qtype handlers + templated runners + registration block.
- **\`src/graph/gemm_kernel_registry.h\`** (+18 / -3) — extended \`GemmKernelArgs\` with \`q8_1_buf\` (void*) + \`d8_buf\` (float*) for dp4a's per-call activation scratch; bumped entries capacity 16 → 32 to fit new strategies + headroom.
- **\`src/graph/executor_kernels.cu\`** (+44 / -5) — removed \`static\` qualifier from \`mmvq_scratch_get_or_grow\` so the new TU can share via forward declaration (preserves single-global invariant); added Slice 7 GGUF dispatch site; updated the multi-slice banner comment.
- **\`CMakeLists.txt\`** (+1) — adds the new TU.
- **\`tests/test_gemm_kernel_registry.cu\`** (+279) — 6 new tests (registration count, off-axis NoMatch, unsupported-qtype NoMatch, missing-scratch PreconditionFail, bit-identical dp4a parity, mmvq non-zero smoke).

## Scope decision: Option 2 (per-qtype), trimmed to M==1

**8 strategies registered**, all \`{StorageTier::FP16, <qtype>, m_is_one=true}\`:
- Q2_K, Q3_K, Q4_K, Q5_K, Q6_K (K-quants)
- Q4_0, Q5_1 (legacy quants — only those actually reachable)
- Q8_0

Each handler internally picks mmvq vs dp4a based on the same \`RuntimeConfig\` fields the legacy switch reads (\`gemma4.force_mmvq\`, \`gemm.no_mmvq\`, \`gemm.no_dp4a_gemv\`, \`is_dp4a_qtype\`, K%32 gate).

**Why Option 2 over Option 3 (per-backend)**: Three qtypes (Q4_K / Q5_K / Q8_0) are reachable via BOTH mmvq and dp4a in legacy, and there was no clean strategy-key axis to disambiguate without overloading \`m_is_one\` (already means GEMV-vs-GEMM) or extending \`StorageTier\`/\`GemmStrategy\` (charter-excluded). Option 1 (monolithic) buries the qtype axis. Option 2 keeps the registry's "qtype-key resolves to handler" contract clean; each handler is one-line delegation to a templated runner; backend selection is local to the handler, mirroring how legacy makes it local to the dispatch impl.

**M>1 not in this slice**: The legacy GGUF M>1 path is dequant → standard FP16 cuBLAS GEMM via the FP16 tier (already covered by Slice 1). No new strategies needed for M>1.

## Architectural deviation: \`GemmKernelArgs\` extension

Added \`q8_1_buf\` (void*) + \`d8_buf\` (float*) — two new fields. **Justification documented in the header field comment**: dp4a's per-call activation scratch is structurally identical to FP8's \`fp8_act_buf\` + \`d_act_scale\` already in the struct — same role (per-call scratch sized by engine init in \`QuantScratch\`), same precedent. The alternative (encoding into existing fields or per-handler workspace lookup) would be uglier than the addition. No \`StorageTier\` extension. Capacity 16 → 32 bump uses static array storage — zero allocation cost.

## Test plan

- [x] \`make build\` PASS
- [x] \`make verify-fast\` PASS (host + pre-push hook)
- [x] 29/29 \`GemmKernelRegistryTest*:GemmStrategy*\` PASS (was 23/23 after Slice 6; +6 new)
- [x] 152/152 \`test-compute\` PASS (was 146/146 after Slice 6; no regressions)
- [x] Branch off origin/main; \`--base main\`

## Next: Slice 8

Final cleanup — replace legacy \`gemm_dispatch_impl\` calls with registry, delete the legacy switch, flip \`gemm.use_kernel_registry\` default ON. Plus resolve the dual-cache CUTLASS MXFP4 QW7 probe deferred from Slice 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)