### PR TITLE
refactor(graph): R5 Slice 8 — flip registry default ON (legacy retained as fallback)

### DIFF
--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -133,12 +133,16 @@ struct RuntimeConfig {
         bool no_dp4a_lm = false;
         bool no_mmvq = false;
         bool no_mmvq_q8_0 = false;
-        // R5 (review/phase5_synthesis.md §5): opt into the new GemmKernel
-        // registry. Slice 1 has only the FP16 tier wired; remaining tiers
-        // (FP8, NVFP4, CUTLASS_NVFP4, MXFP4) still go through the legacy
-        // gemm_dispatch_impl regardless of this flag. Default OFF until
-        // every tier is migrated.
-        bool use_kernel_registry = false;
+        // R5 (review/phase5_synthesis.md §5): the GemmKernel registry handles
+        // the migrated tiers (FP16, FP8 prefill, NVFP4 GEMV+GEMM, CUTLASS_NVFP4,
+        // MXFP4 GEMV+GEMM, GGUF small-M mmvq/dp4a for 8 qtypes). Slice 8 flips
+        // the default ON — production now reaches the registry first and falls
+        // through to the legacy `gemm_dispatch_impl` for the remaining uncovered
+        // cases (QW7 dual-cache MXFP4 probe, Q4_1 quant_gemm_int4, fused
+        // Q6_K/Q8_0 GEMV fallback when mmvq/dp4a skip, M>1 dequant+cuBLAS
+        // large-M fallback, FP8 cache-miss fallback). Setting this OFF still
+        // works as an escape hatch — every dispatch goes straight to legacy.
+        bool use_kernel_registry = true;
     } gemm;
 
     struct Gemma4 {


### PR DESCRIPTION
## Summary

R5 Slice 8 — **flips \`gemm.use_kernel_registry\` default to \`true\`**. The \`GemmKernel\` registry becomes the primary dispatch path; the legacy \`gemm_dispatch_impl\` switch is **retained as fallback** because the coverage audit revealed Slices 1-7 charters did not cover every legacy branch. **8 minor branches** still need migration before the legacy switch can be deleted — captured here as deferred work.

## Coverage audit (Part A)

| Legacy branch | Tier | qtype | M | Registered? | Slice |
|---|---|---|---|---|---|
| MXFP4 cache, M==1 | MXFP4 | F16 | 1 | yes | 6 |
| MXFP4 cache, M>1 | MXFP4 | F16 | >1 | yes | 6 |
| QW7 dual-cache CUTLASS MXFP4 probe | (special) | F16 | >1 | NO (probe) | — |
| CUTLASS_NVFP4 prefill | CUTLASS_NVFP4 | F16 | >1 | yes | 5 |
| NVFP4 decode GEMV | NVFP4 | F16 | 1 | yes | 3 |
| NVFP4 dequant GEMM fallback | NVFP4 | F16 | >1 | yes | 4 |
| FP8 prefill cache hit | FP8 | F16 | >1 | yes | 2 |
| **FP8 cache miss → dequant fallback** | — | various | >1 | **NO** | — |
| **FP8 cache miss → FP16 fallback** | — | F16/BF16 | >1 | **partial** | 1 |
| mmvq M==1 (5 qtypes) | FP16 | Q4_K..Q8_0 | 1 | yes | 7 |
| dp4a M==1 (8 qtypes) | FP16 | Q2_K..Q8_0 | 1 | yes | 7 |
| **Q4_1 + fp16_cache hit** | — | Q4_1 | * | **NO** | — |
| **Q4_1 quant_gemm_int4** | — | Q4_1 | * | **NO** | — |
| **Fused gemv_q6k M==1 fallback** | — | Q6_K | 1 | **NO** | — |
| **Fused gemv_q8_0 M==1 fallback** | — | Q8_0 | 1 | **NO** | — |
| **fp16_cache hit for non-F16 weight** | — | various | * | **NO** | — |
| **Raw quant + dequant_scratch large-M** | — | various | >1 | **NO** | — |
| Plain FP16/BF16 GEMM | FP16 | F16/BF16 | * | yes | 1 |

**Registry handles** all 6 tier-major paths (FP16, FP8 cache hit, NVFP4 GEMV+GEMM, CUTLASS_NVFP4, MXFP4) plus 13 GGUF qtypes at M==1. **Legacy still owns** 8 branches that are mostly fallback / fused / cache-miss edges.

## Changes

- **\`src/runtime/config.h\`** — \`Gemm::use_kernel_registry\` default: \`false\` → \`true\`. The flag is retained as an escape hatch (users can opt out via \`--set gemm.use_kernel_registry=false\` or \`imp.conf\`).
- No code deletion. \`gemm_dispatch_impl\` stays as registry-fallback for the 8 uncovered branches.

## Deferred — Slice 8.1+

Each uncovered branch wants its own follow-up PR (likely small, mechanical). Roughly priority-ordered:

1. **Slice 8.1**: FP8 cache miss fallbacks (dequant + FP16). Affects every FP8-enabled model not in the cache, so high-impact.
2. **Slice 8.2**: Fused gemv fallbacks (Q6_K, Q8_0). Common qtypes — Qwen3-Coder Q6_K hits this.
3. **Slice 8.3**: Q4_1 paths (rare qtype; low priority).
4. **Slice 8.4**: \`fp16_cache\` for non-F16 weights (the convert-and-cache-as-FP16 flow).
5. **Slice 8.5**: Raw-quant large-M dequant→cuBLAS path (covers anything Slices 1-7 missed).
6. **Slice 8.6 (or final delete)**: Retire QW7 dual-cache probe (depends on whether production trace ever fires it) + delete \`gemm_dispatch_impl\`.
7. **Cleanup**: Hoist \`mmvq_scratch_get_or_grow\` to a header (Slice 7 noted; pairs with final delete).

## Architectural notes

- The \`gemm_dispatch_impl\` function is INVISIBLE under the default registry path EXCEPT for the 8 unmigrated branches. For models that only exercise the 6 covered tiers (the common case), the legacy switch is dead-code-at-runtime. It still compiles and links; that's intentional (escape hatch + fallback for the deferred branches).
- The QW7 dual-cache probe (\`executor_kernels.cu:2149-2174\`, deferred from Slice 6 #213) is reachable: \`convert_nvfp4_to_mxfp4_cutlass\` at \`executor_pre_dequant.cu:1431\` populates \`wcache_.cutlass_mxfp4\` from NVFP4 entries. No production trace observed yet, but the probe is retained until that's confirmed dead.

## Test plan

- [x] \`make build\` PASS
- [x] \`make verify-fast\` PASS (host + pre-push hook). This is the **first run with registry as the default path** — green.
- [x] 29/29 \`GemmKernelRegistryTest*:GemmStrategy*\` PASS
- [x] 152/152 \`test-compute\` PASS
- [x] 37/37 \`imp-tests-unit\` PASS
- [x] Branch off origin/main; \`--base main\`
- [x] Pre-existing test failures at HEAD (\`EngineIntegrationTest.MoEInitSucceeds\` NVFP4 da_cache assert, \`FmhaSm120Test.ClusterPathNonAligned\`, several \`StubModelTest\`/\`EndToEndModelTest\` aborts) confirmed to exist on \`origin/main\` already — NOT introduced by this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)