### PR TITLE
refactor(graph): R5 Slice 8.2 — fused gemv Q6_K/Q8_0 fallback via GemmKernel registry

### DIFF
--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -2555,14 +2555,19 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;
         }
-        // Slice 7 — GGUF small-M (mmvq / dp4a) dispatch. Only fires for M==1
-        // with FP16 input and a non-FP32 output, mirroring the legacy mmvq +
-        // dp4a gates at gemm_dispatch_impl:2216-2222. Per-qtype strategies
-        // (Option 2 scope decision — see gemm_kernel_gguf.cu header) and the
-        // handler internally selects mmvq vs dp4a based on the same
-        // RuntimeConfig fields the legacy switch reads. `prefer_fp16_cache`
-        // remains a dispatch-site gate because it depends on `fp16` cache
-        // membership + stride, which isn't part of GemmKernelArgs.
+        // Slice 7 + Slice 8.2 — GGUF small-M (mmvq / dp4a / fused-gemv)
+        // dispatch. Only fires for M==1 with FP16 input and a non-FP32
+        // output, mirroring the legacy mmvq + dp4a gates at
+        // gemm_dispatch_impl:2216-2222 and the fused-gemv fallback at lines
+        // 2267-2276. Per-qtype strategies (Option 2 scope decision — see
+        // gemm_kernel_gguf.cu header) and the handler internally selects
+        // mmvq vs dp4a vs fused-gemv based on the same RuntimeConfig fields
+        // and workspace sentinels the legacy switch reads.
+        // `prefer_fp16_cache` remains a dispatch-site gate because it
+        // depends on `fp16` cache membership + stride, which isn't part of
+        // GemmKernelArgs. `dequant_scratch` is passed as an engine-ready
+        // sentinel for Slice 8.2's fused-gemv branch (the legacy gate at
+        // line 2267/2272 checks the same pointer).
         const bool fp32_output = (output.qtype == QType::F32);
         const bool prefer_fp16_cache =
             (fp16 != nullptr && fp16->count(weight.data) > 0 && input.stride[0] != weight.shape[1]);
@@ -2575,14 +2580,15 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             args.weight_payload = &weight;
             args.q8_1_buf = qs->q8_1_buf;
             args.d8_buf = qs->d8_buf;
+            args.dequant_scratch = qs->dequant;  // Slice 8.2 fused-gemv readiness sentinel
             GemmStrategy strat{StorageTier::FP16, qtype, /*m_is_one=*/true};
             auto rc = GemmKernelRegistry::instance().dispatch(strat, args);
             if (rc == GemmDispatchResult::Ok)
                 return;
-            // NoMatch (qtype not in slice 7 set) or PreconditionFail (neither
-            // mmvq nor dp4a backend matched) — fall through to legacy. Same
-            // semantics as the legacy `else if` chain continuing past the
-            // mmvq/dp4a branches.
+            // NoMatch (qtype not in slice 7/8.2 set) or PreconditionFail (no
+            // backend matched — neither mmvq nor dp4a nor fused-gemv) —
+            // fall through to legacy. Same semantics as the legacy `else if`
+            // chain continuing past the mmvq/dp4a/fused-gemv branches.
         }
         // Fall through: registry returned NoMatch for this strategy — use legacy.
     }

--- a/src/graph/gemm_kernel_gguf.cu
+++ b/src/graph/gemm_kernel_gguf.cu
@@ -12,11 +12,19 @@
 namespace imp {
 
 // ---------------------------------------------------------------------------
-// GGUF small-M tier — R5 Slice 7.
+// GGUF small-M tier — R5 Slice 7 + Slice 8.2.
 //
-// Migrates the legacy mmvq + dp4a small-M GGUF branches (gemm_dispatch_impl
-// at executor_kernels.cu:2216-2251) to the GemmKernel registry. The legacy
-// dispatch evaluates two parallel gates at M==1:
+// Slice 7 migrated the legacy mmvq + dp4a small-M GGUF branches
+// (gemm_dispatch_impl at executor_kernels.cu:2216-2251). Slice 8.2 extends
+// the Q6_K and Q8_0 handlers with a *third* internal branch: the fused-
+// gemv fallback that legacy reaches at gemm_dispatch_impl:2267-2276 when
+// both mmvq and dp4a are out (force_mmvq=false + no dp4a scratch / dp4a
+// disabled). That branch calls `gemv_q6k` / `gemv_q8_0` from compute/gemm —
+// the "dequant-and-dot in one pass" kernel — and only requires that the
+// engine is initialised (dequant_scratch != nullptr as a readiness sentinel,
+// even though the fused kernel itself doesn't consume the scratch).
+//
+// The legacy dispatch evaluates two parallel gates at M==1:
 //
 //   use_mmvq = gemma4.force_mmvq && qtype ∈ {Q4_K, Q5_K, Q5_1, Q8_0}
 //              && weight.shape[1] % 32 == 0 && !no_mmvq && !no_mmvq_q8_0(Q8_0)
@@ -30,13 +38,23 @@ namespace imp {
 // backends overlap on Q4_K / Q5_K / Q8_0; the dispatch site emits a single
 // (FP16, <qtype>, m_is_one=true) strategy key per qtype and the registered
 // handler internally re-evaluates `force_mmvq`/`no_mmvq`/etc. and picks the
-// backend — same conditions, same precedence as legacy. PreconditionFail
-// when neither backend can run (e.g. dp4a scratch missing, mmvq disabled),
-// surfacing the same fall-through to legacy that the legacy `else if` chain
-// produces today.
+// backend — same conditions, same precedence as legacy.
+//
+// Slice 8.2: when neither mmvq nor dp4a can run AND the qtype has a fused
+// gemv kernel (Q6_K or Q8_0) AND `dequant_scratch != nullptr` (engine-ready
+// sentinel matching legacy line 2267/2272), the handler invokes the fused
+// gemv kernel directly. For the other qtypes the third branch is absent and
+// the handler still returns PreconditionFail so the dispatch site falls
+// through to the legacy switch (which handles dequant+cuBLAS fallbacks for
+// Q4_K / Q5_K / etc.).
 //
 // Scope decision — Option 2 trimmed (per-qtype, M==1 only), with internal
-// backend selection inside each handler.
+// backend selection inside each handler. Slice 8.2 keeps the same shape:
+// it extends the existing Q6_K / Q8_0 handlers with a third branch instead
+// of adding new strategies, because the strategy key {FP16, Q6_K, M==1} (and
+// the Q8_0 analog) already routes to one handler — having THAT handler do
+// all three branches matches what the legacy switch did. New strategies
+// would multiply entries without changing the dispatch axis.
 //
 // Why this shape:
 //   - Option 1 (one strategy + giant switch) buries the qtype axis inside
@@ -69,7 +87,6 @@ namespace imp {
 // Out of scope (stays on legacy for now):
 //   - Q4_1 quant_gemm_int4 (also a small-M path but neither mmvq nor dp4a).
 //   - M>1 dequant+cuBLAS fallback (the "large-M path" in the slice 7 prompt).
-//   - Fused Q6_K/Q8_0 GEMV (the `else if` fallback below dp4a in legacy).
 //   - prefer_fp16_cache decision (stays on dispatch site — strictly upstream).
 //   - FP32-output paths (write directly to half*, so legacy stays in charge).
 // All of these continue through `gemm_dispatch_impl` when the registry
@@ -113,12 +130,31 @@ static void run_dp4a_backend(const GemmKernelArgs& args, const Tensor& weight, Q
                        static_cast<half*>(args.output->data), N, K, args.stream);
 }
 
-// Per-qtype dispatcher — internally picks mmvq vs dp4a based on RuntimeConfig
-// + workspace availability. `mmvq_eligible` flags qtypes mmvq supports; the
-// dp4a check uses is_dp4a_qtype(). When neither backend matches, returns
-// PreconditionFail so the dispatch site falls back to the legacy switch.
-template <void (*MmvqLauncher)(const void*, const half*, half*, int, int, int, void*, size_t, cudaStream_t)>
-static GemmDispatchResult run_gguf_smallm(const GemmKernelArgs& args, QType qtype, bool mmvq_eligible) {
+// Fused-gemv backend (Slice 8.2): runs the dequant-and-dot kernel
+// (`gemv_q6k` / `gemv_q8_0` from compute/gemm.cu). Signature matches both
+// kernels: (W, x, y, N, K, stream). The kernel performs the dequantization
+// inside the GEMV — no scratch buffer is read or written. Mirrors legacy
+// lines 2269-2271 (Q6_K) / 2274-2276 (Q8_0).
+template <void (*Launcher)(const void*, const half*, half*, int, int, cudaStream_t)>
+static void run_fused_gemv_backend(const GemmKernelArgs& args, const Tensor& weight) {
+    const int N = static_cast<int>(weight.shape[0]);
+    const int K = static_cast<int>(weight.shape[1]);
+    Launcher(weight.data, static_cast<const half*>(args.input->data),
+             static_cast<half*>(args.output->data), N, K, args.stream);
+}
+
+// Per-qtype dispatcher — internally picks mmvq → dp4a → fused gemv based on
+// RuntimeConfig + workspace availability. `mmvq_eligible` flags qtypes mmvq
+// supports; the dp4a check uses is_dp4a_qtype(). `FusedGemvLauncher` is set
+// to a real fused kernel only for Q6_K (`gemv_q6k`) and Q8_0 (`gemv_q8_0`)
+// per Slice 8.2; other qtypes bind to `no_op_fused_gemv_launcher` and the
+// third branch is skipped at compile time. When no branch matches, returns
+// PreconditionFail so the dispatch site falls back to the legacy switch
+// (which handles the remaining cases like dequant+cuBLAS for Q4_K / Q5_K).
+template <void (*MmvqLauncher)(const void*, const half*, half*, int, int, int, void*, size_t, cudaStream_t),
+          void (*FusedGemvLauncher)(const void*, const half*, half*, int, int, cudaStream_t)>
+static GemmDispatchResult run_gguf_smallm(const GemmKernelArgs& args, QType qtype, bool mmvq_eligible,
+                                          bool fused_gemv_eligible) {
     IMP_CHECK(args.input != nullptr, "gguf_smallm: input is null");
     IMP_CHECK(args.output != nullptr, "gguf_smallm: output is null");
     IMP_CHECK(args.weight_payload != nullptr, "gguf_smallm: weight_payload is null");
@@ -143,6 +179,12 @@ static GemmDispatchResult run_gguf_smallm(const GemmKernelArgs& args, QType qtyp
     const bool use_dp4a = !no_dp4a_gemv && args.q8_1_buf != nullptr && args.d8_buf != nullptr &&
                           is_dp4a_qtype(qtype);
 
+    // Fused-gemv fallback (Slice 8.2 — legacy lines 2267-2276): only Q6_K and
+    // Q8_0 have a fused-dequant-and-dot kernel. `dequant_scratch != nullptr`
+    // matches the legacy gate at lines 2267 / 2272 (engine-ready sentinel —
+    // the fused kernel itself doesn't read the scratch).
+    const bool use_fused_gemv = fused_gemv_eligible && args.dequant_scratch != nullptr;
+
     if (use_mmvq) {
         run_mmvq_backend<MmvqLauncher>(args, weight);
         return GemmDispatchResult::Ok;
@@ -151,8 +193,13 @@ static GemmDispatchResult run_gguf_smallm(const GemmKernelArgs& args, QType qtyp
         run_dp4a_backend(args, weight, qtype);
         return GemmDispatchResult::Ok;
     }
-    // Neither backend matches — fall back to legacy (e.g. fused Q6_K/Q8_0
-    // GEMV at executor_kernels.cu:2263-2272, dequant+cuBLAS, etc.).
+    if (use_fused_gemv) {
+        run_fused_gemv_backend<FusedGemvLauncher>(args, weight);
+        return GemmDispatchResult::Ok;
+    }
+    // No backend matches — fall back to legacy (e.g. dequant+cuBLAS for
+    // qtypes without a fused-gemv kernel, or Q6_K/Q8_0 when the engine
+    // hasn't allocated the dequant_scratch sentinel).
     return GemmDispatchResult::PreconditionFail;
 }
 
@@ -165,41 +212,58 @@ static void no_op_mmvq_launcher(const void*, const half*, half*, int, int, int, 
     // qtype, which is false for the qtypes that bind to this launcher.
 }
 
+// Same idea for the fused-gemv slot: only Q6_K / Q8_0 bind to real kernels
+// in Slice 8.2; the other six qtypes bind to this no-op (the third branch
+// is guarded by `fused_gemv_eligible=false`, never invoked at runtime).
+static void no_op_fused_gemv_launcher(const void*, const half*, half*, int, int, cudaStream_t) {
+    // Intentionally empty — see no_op_mmvq_launcher.
+}
+
 // ---------------------------------------------------------------------------
 // Per-qtype handler functions (8 total, one per supported qtype).
 // ---------------------------------------------------------------------------
 
 static GemmDispatchResult gguf_q4k_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&ggml_mmvq_q4k>(args, QType::Q4_K, /*mmvq_eligible=*/true);
+    return run_gguf_smallm<&ggml_mmvq_q4k, &no_op_fused_gemv_launcher>(
+        args, QType::Q4_K, /*mmvq_eligible=*/true, /*fused_gemv_eligible=*/false);
 }
 
 static GemmDispatchResult gguf_q5k_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&ggml_mmvq_q5k>(args, QType::Q5_K, /*mmvq_eligible=*/true);
+    return run_gguf_smallm<&ggml_mmvq_q5k, &no_op_fused_gemv_launcher>(
+        args, QType::Q5_K, /*mmvq_eligible=*/true, /*fused_gemv_eligible=*/false);
 }
 
 static GemmDispatchResult gguf_q5_1_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&ggml_mmvq_q5_1>(args, QType::Q5_1, /*mmvq_eligible=*/true);
+    return run_gguf_smallm<&ggml_mmvq_q5_1, &no_op_fused_gemv_launcher>(
+        args, QType::Q5_1, /*mmvq_eligible=*/true, /*fused_gemv_eligible=*/false);
 }
 
+// Slice 8.2: Q8_0 gains a fused-gemv fallback (`gemv_q8_0` in compute/gemm.cu).
 static GemmDispatchResult gguf_q8_0_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&ggml_mmvq_q8_0>(args, QType::Q8_0, /*mmvq_eligible=*/true);
+    return run_gguf_smallm<&ggml_mmvq_q8_0, &gemv_q8_0>(
+        args, QType::Q8_0, /*mmvq_eligible=*/true, /*fused_gemv_eligible=*/true);
 }
 
 // dp4a-only qtypes (no mmvq backend).
+// Slice 8.2: Q6_K gains a fused-gemv fallback (`gemv_q6k`).
 static GemmDispatchResult gguf_q6k_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q6_K, /*mmvq_eligible=*/false);
+    return run_gguf_smallm<&no_op_mmvq_launcher, &gemv_q6k>(
+        args, QType::Q6_K, /*mmvq_eligible=*/false, /*fused_gemv_eligible=*/true);
 }
 
 static GemmDispatchResult gguf_q4_0_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q4_0, /*mmvq_eligible=*/false);
+    return run_gguf_smallm<&no_op_mmvq_launcher, &no_op_fused_gemv_launcher>(
+        args, QType::Q4_0, /*mmvq_eligible=*/false, /*fused_gemv_eligible=*/false);
 }
 
 static GemmDispatchResult gguf_q2k_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q2_K, /*mmvq_eligible=*/false);
+    return run_gguf_smallm<&no_op_mmvq_launcher, &no_op_fused_gemv_launcher>(
+        args, QType::Q2_K, /*mmvq_eligible=*/false, /*fused_gemv_eligible=*/false);
 }
 
 static GemmDispatchResult gguf_q3k_kernel(const GemmKernelArgs& args) {
-    return run_gguf_smallm<&no_op_mmvq_launcher>(args, QType::Q3_K, /*mmvq_eligible=*/false);
+    return run_gguf_smallm<&no_op_mmvq_launcher, &no_op_fused_gemv_launcher>(
+        args, QType::Q3_K, /*mmvq_eligible=*/false, /*fused_gemv_eligible=*/false);
 }
 
 namespace {

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -1106,6 +1106,229 @@ TEST_F(GemmKernelRegistryTest, GgufQ8_0MmvqRegistryDispatchProducesNonZero) {
     cudaFree(d_out);
 }
 
+// ---------------------------------------------------------------------------
+// R5 Slice 8.2 — fused gemv Q6_K/Q8_0 fallback (3rd branch inside the
+// existing Slice 7 handlers).
+//
+// When mmvq is disabled AND dp4a scratch is unavailable, Q6_K and Q8_0 now
+// route to the fused-dequant-and-dot kernel (`gemv_q6k` / `gemv_q8_0`) via
+// the same {FP16, <qtype>, m_is_one=true} strategy key Slice 7 registered.
+// `dequant_scratch != nullptr` is the engine-ready sentinel matching legacy
+// gemm_dispatch_impl:2267 / :2272 (the fused kernel itself does not consume
+// the scratch).
+// ---------------------------------------------------------------------------
+
+// Q8_0 fused-gemv parity: with force_mmvq=false and dp4a scratch absent, the
+// handler MUST take the fused-gemv branch and produce bit-identical output
+// to calling gemv_q8_0 directly (the legacy code path at executor_kernels.cu
+// :2275-2276).
+TEST_F(GemmKernelRegistryTest, GgufQ8_0FusedGemvFallbackMatchesDirectPath) {
+    constexpr int M = 1;
+    constexpr int N = 32;
+    constexpr int K = 128;
+
+    // Host-quantize an FP16 weight to Q8_0 layout. Per 32-element block:
+    // FP16 scale `d = max(|x|)/127`, then 32 int8 quantized values.
+    const int blocks_per_row = K / 32;
+    std::vector<__half> h_weight_fp16(N * K);
+    std::vector<__half> h_input(M * K);
+    for (int i = 0; i < N * K; ++i)
+        h_weight_fp16[i] = __float2half((i % 7) * 0.0625f - 0.1875f);
+    for (int i = 0; i < M * K; ++i)
+        h_input[i] = __float2half((i % 5) * 0.0625f - 0.125f);
+
+    std::vector<uint8_t> h_weight_q8_0(static_cast<size_t>(N) * blocks_per_row * 34);
+    for (int row = 0; row < N; ++row) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            float absmax = 0.0f;
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                absmax = std::max(absmax, std::fabs(v));
+            }
+            float d = absmax / 127.0f;
+            float inv_d = (d > 0.0f) ? 1.0f / d : 0.0f;
+            uint8_t* blk = h_weight_q8_0.data() +
+                           (static_cast<size_t>(row) * blocks_per_row + b) * 34;
+            __half d_h = __float2half(d);
+            std::memcpy(blk, &d_h, sizeof(__half));
+            int8_t* qs = reinterpret_cast<int8_t*>(blk + 2);
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                int q = static_cast<int>(std::lrintf(v * inv_d));
+                qs[j] = static_cast<int8_t>(std::max(-127, std::min(127, q)));
+            }
+        }
+    }
+
+    void* d_weight = nullptr;
+    __half* d_input = nullptr;
+    cudaMalloc(&d_weight, h_weight_q8_0.size());
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMemcpy(d_weight, h_weight_q8_0.data(), h_weight_q8_0.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(d_weight, QType::Q8_0, 2, w_shape, /*on_device=*/true);
+
+    // Path 1: direct gemv_q8_0 invocation (mirrors legacy line 2275).
+    __half* d_out_direct = nullptr;
+    cudaMalloc(&d_out_direct, sizeof(__half) * M * N);
+    gemv_q8_0(d_weight, static_cast<const half*>(d_input), reinterpret_cast<half*>(d_out_direct), N, K,
+              stream_);
+
+    // Path 2: registry dispatch with mmvq disabled, dp4a scratch null,
+    // dequant_scratch non-null. Force the handler into the third branch.
+    auto& mut_cfg = const_cast<RuntimeConfig&>(RuntimeConfig::current());
+    const bool prev_force_mmvq = mut_cfg.gemma4.force_mmvq;
+    mut_cfg.gemma4.force_mmvq = false;
+
+    __half* d_out_registry = nullptr;
+    cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
+    Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    // Engine-ready sentinel — the kernel does not dereference this pointer,
+    // it only checks for nullptr (matching legacy line 2272's gate).
+    uint8_t dummy_scratch_sentinel = 0;
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out_registry;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    // q8_1_buf / d8_buf intentionally null — dp4a branch must not fire.
+    args.dequant_scratch = &dummy_scratch_sentinel;
+
+    GemmStrategy strat{StorageTier::FP16, QType::Q8_0, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+
+    mut_cfg.gemma4.force_mmvq = prev_force_mmvq;
+    cudaStreamSynchronize(stream_);
+
+    std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);
+    cudaMemcpy(h_out_direct.data(), d_out_direct, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_out_registry.data(), d_out_registry, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+
+    // Both paths run the identical gemv_q8_0 kernel → bit-identical.
+    for (int i = 0; i < M * N; ++i) {
+        EXPECT_EQ(__half_as_ushort(h_out_direct[i]), __half_as_ushort(h_out_registry[i]))
+            << "Mismatch at i=" << i;
+    }
+
+    cudaFree(d_weight);
+    cudaFree(d_input);
+    cudaFree(d_out_direct);
+    cudaFree(d_out_registry);
+}
+
+// Q6_K fused-gemv parity: same shape as the Q8_0 test, but Q6_K has a more
+// complex block layout (256 elements / block, 16 sub-blocks with 6-bit
+// quants). We can't trivially host-quantize Q6_K, so this test focuses on
+// dispatch-correctness only: build a zeroed Q6_K weight, run both paths,
+// and check that registry result matches direct path. With zero weight,
+// both paths produce zero output → bit-identical "noop" check that the
+// handler actually invoked the right branch (an mmvq/dp4a path would also
+// produce zero, so we additionally instrument with a non-null
+// dequant_scratch and zero scratch, then verify Ok was returned).
+TEST_F(GemmKernelRegistryTest, GgufQ6kFusedGemvFallbackReturnsOk) {
+    constexpr int M = 1;
+    constexpr int N = 16;
+    constexpr int K = 256;  // one Q6_K block
+
+    // Q6_K block layout (256 elements / 210 bytes): for this dispatch test
+    // we just need a non-null device buffer of the correct size; we don't
+    // verify numerical output.
+    const size_t block_bytes = 210;
+    void* d_weight = nullptr;
+    __half* d_input = nullptr;
+    __half* d_out = nullptr;
+    cudaMalloc(&d_weight, static_cast<size_t>(N) * block_bytes);
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+    cudaMemset(d_weight, 0, static_cast<size_t>(N) * block_bytes);
+    cudaMemset(d_input, 0, sizeof(__half) * M * K);
+    cudaMemset(d_out, 0, sizeof(__half) * M * N);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(d_weight, QType::Q6_K, 2, w_shape, /*on_device=*/true);
+    Tensor output(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    // Force the fused-gemv branch: no mmvq backend for Q6_K + dp4a scratch null
+    // + dequant_scratch non-null.
+    uint8_t dummy_scratch_sentinel = 0;
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &output;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    args.dequant_scratch = &dummy_scratch_sentinel;
+
+    // Clear any sticky CUDA error from earlier tests in this binary; we
+    // want this check to reflect only the gemv_q6k launch.
+    cudaGetLastError();
+
+    GemmStrategy strat{StorageTier::FP16, QType::Q6_K, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+    cudaStreamSynchronize(stream_);
+
+    // With a zeroed weight and zeroed input, the dequant-and-dot path
+    // produces zero output. Confirm the kernel ran (no kernel-launch error
+    // and output is all zero / valid FP16).
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess) << "gemv_q6k launch failed";
+    std::vector<__half> h_out(M * N);
+    cudaMemcpy(h_out.data(), d_out, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    for (int i = 0; i < M * N; ++i) {
+        EXPECT_EQ(__half_as_ushort(h_out[i]), __half_as_ushort(__float2half(0.0f)))
+            << "Expected zero output for zero weight × zero input, got "
+            << __half2float(h_out[i]) << " at i=" << i;
+    }
+
+    cudaFree(d_weight);
+    cudaFree(d_input);
+    cudaFree(d_out);
+}
+
+// Negative case: without `dequant_scratch` AND without dp4a scratch AND with
+// mmvq disabled, Q6_K must return PreconditionFail (no branch fires). This
+// pins the engine-ready sentinel gate added in Slice 8.2.
+TEST_F(GemmKernelRegistryTest, GgufQ6kFusedGemvRequiresDequantScratchSentinel) {
+    constexpr int M = 1;
+    constexpr int N = 16;
+    constexpr int K = 256;
+
+    __half* d_input = nullptr;
+    __half* d_out = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+    cudaMemset(d_input, 0, sizeof(__half) * M * K);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(reinterpret_cast<void*>(static_cast<uintptr_t>(0xDEAD)), QType::Q6_K, 2, w_shape,
+                  /*on_device=*/true);
+    Tensor output(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &output;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    // q8_1_buf / d8_buf / dequant_scratch all null — no branch can fire.
+
+    GemmStrategy strat{StorageTier::FP16, QType::Q6_K, /*m_is_one=*/true};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::PreconditionFail);
+
+    cudaFree(d_input);
+    cudaFree(d_out);
+}
+
 // Pin the GemmStrategy operator== contract — used by the linear-scan
 // lookup in dispatch().
 TEST(GemmStrategy, EqualityIsByValue) {


### PR DESCRIPTION
## Summary

R5 Slice 8.2 — second follow-up from Slice 8's coverage audit (#215). Migrates the **fused gemv fallback paths** for Q6_K and Q8_0 (the M==1 path that fires when both mmvq and dp4a backends are unavailable/disabled) into the GemmKernel registry.

## Option chosen — A (extend Slice 7 handlers in-place)

The strategy key \`{FP16, Q6_K, M==1}\` already routes to one handler in \`gemm_kernel_gguf.cu\`. Making THAT handler do **all three** internal branches (mmvq → dp4a → fused gemv) matches the legacy \`else if\` chain exactly and keeps the registry's "one strategy per qtype" contract.

Option B (separate fallback strategy) would multiply entries along an axis the registry doesn't expose — the three discriminators (StorageTier, QType, m_is_one) are already exhausted.

## Files

- **\`src/graph/gemm_kernel_gguf.cu\`** (+78/-29) — extended \`run_gguf_smallm\` to take a second template launcher + eligibility flag; added \`run_fused_gemv_backend\` and \`no_op_fused_gemv_launcher\`; Q6_K and Q8_0 handlers now bind \`gemv_q6k\` / \`gemv_q8_0\` as the fused launcher.
- **\`src/graph/executor_kernels.cu\`** (+19/-11) — dispatch site at the Slice 7 GGUF strategy now passes \`args.dequant_scratch = qs->dequant\` as the readiness sentinel (mirrors legacy gate behavior).
- **\`tests/test_gemm_kernel_registry.cu\`** (+223) — 3 new tests:
  - \`GgufQ8_0FusedGemvFallbackMatchesDirectPath\` — bit-identical parity vs direct \`gemv_q8_0\`
  - \`GgufQ6kFusedGemvFallbackReturnsOk\` — Q6_K Ok + zero-noop sanity
  - \`GgufQ6kFusedGemvRequiresDequantScratchSentinel\` — PreconditionFail when sentinel null

## Architecture notes

- Fused-gemv signature \`(const void* W, const half* x, half* y, int M, int K, cudaStream_t)\` differs from the mmvq launcher (8 params) but fits cleanly as a second function-pointer template parameter on \`run_gguf_smallm\`.
- Legacy's \`dequant_scratch != nullptr\` gate was an engine-ready sentinel (the fused kernel itself reads nothing from the buffer), so the registry handler checks \`args.dequant_scratch != nullptr\` to match.
- No \`GemmKernelArgs\` extension; \`dequant_scratch\` was already present and consumed by Slice 6 (MXFP4) and Slice 8.1 (FP8 cache miss).

## Coverage progress: 1 of 6 deferred Slice 8 branches closed

- **CLOSED**: "Fused gemv fallbacks for Q6_K, Q8_0"
- Remaining: 8.1 (FP8 cache miss — PR #217 in CI), 8.3 (Q4_1 paths), 8.4 (fp16_cache for non-F16 weights), 8.5 (raw-quant large-M), 8.6 (final delete + QW7 + mmvq_scratch hoist)

## Merge note

Built off origin/main at \`9520223\` (before Slice 8.1 #217 lands). Mechanical conflict expected on \`executor_kernels.cu\` and \`test_gemm_kernel_registry.cu\` if #217 merges first — rebase + retest will be a 5-min job.

## Test plan

- [x] \`make build\` PASS
- [x] \`make verify-fast\` PASS (pre-push hook)
- [x] 32/32 \`GemmKernelRegistryTest*:GemmStrategy*\` PASS (was 29/29 after Slice 8; +3 new)
- [x] 155/155 \`test-compute\` PASS (was 152/152; 0 regressions)
- [x] Branch off origin/main; \`--base main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)