### PR TITLE
refactor(graph): R5 Slice 8.4+8.5 — generic-dequant catch-all (8.4 was no-op)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ set(IMP_GRAPH_SOURCES
     src/graph/gemm_kernel_cutlass_nvfp4.cu
     src/graph/gemm_kernel_mxfp4.cu
     src/graph/gemm_kernel_gguf.cu
+    src/graph/gemm_kernel_generic_dequant.cu
     src/graph/executor_workspace.cu
     src/graph/executor_workspace_buffers.cu
     src/graph/executor_kv_write.cu

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -2599,6 +2599,27 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             // fall through to legacy. Same semantics as the legacy `else if`
             // chain continuing past the mmvq/dp4a/fused-gemv branches.
         }
+        // Slice 8.5 — qtype-agnostic generic-dequant catch-all (M>1 prefill).
+        // Mirrors the legacy fallback at gemm_dispatch_impl:2313-2319: when no
+        // tier-specific dispatcher matched and the weight qtype is dequantable
+        // via `dequant_gpu`, dequant the raw bytes into the FP16 scratch and
+        // run cuBLAS. Strategy key (FP16, NONE, m_is_one=false) is qtype-
+        // agnostic — the handler reads weight.qtype off the Tensor and
+        // switches via `dequant_gpu_supported`. PreconditionFail (missing
+        // scratch or unsupported qtype) drops through to legacy, which has a
+        // final raw `gemm()` arm for the FP16/BF16 case at line 2322.
+        if (M > 1 && input.qtype == QType::F16) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.beta = ctx.beta;
+            args.weight_payload = &weight;
+            args.dequant_scratch = qs->dequant;
+            GemmStrategy strat{StorageTier::FP16, QType::NONE, /*m_is_one=*/false};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        }
         // Fall through: registry returned NoMatch for this strategy — use legacy.
     }
 

--- a/src/graph/gemm_kernel_generic_dequant.cu
+++ b/src/graph/gemm_kernel_generic_dequant.cu
@@ -1,0 +1,90 @@
+#include "graph/gemm_kernel_registry.h"
+
+#include "compute/gemm.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "quant/dequant_gpu.h"
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// Generic dequant→cuBLAS catch-all — R5 Slice 8.5.
+//
+// Migrates the qtype-agnostic large-M fallback at the bottom of the legacy
+// gemm_dispatch_impl chain (executor_kernels.cu:2313-2319):
+//
+//   } else if (dequant_scratch != nullptr && dequant_gpu_supported(qtype)) {
+//       int rows = static_cast<int>(weight.shape[0]);
+//       int cols = static_cast<int>(weight.shape[1]);
+//       dequant_gpu(weight.data, dequant_scratch, qtype, rows, cols, stream);
+//       Tensor w_fp16(dequant_scratch, QType::F16, weight.ndim, weight.shape, true);
+//       gemm(input, w_fp16, output, 1.0f, beta, stream);
+//   }
+//
+// This branch is the qtype-agnostic generic dequant→FP16→cuBLAS GEMM path.
+// It fires after every tier-specific dispatcher (MXFP4 / NVFP4 / CUTLASS /
+// FP8 cache / FP16 cache / GGUF small-M) has either NoMatched or
+// PreconditionFailed and the weight qtype is dequantable. The handler
+// performs the same `dequant_gpu` + `gemm` sequence as the legacy branch —
+// bit-identical behavior.
+//
+// Strategy key: (FP16, NONE, m_is_one=false). The FP16 tier is reused
+// because the GEMM step itself runs on FP16 inputs (the dequant target);
+// the qtype-agnostic NONE key mirrors the Slice 8.1 FP8 cache-miss
+// adapter — the handler reads `weight.qtype` off the Tensor and switches
+// internally via `dequant_gpu_supported` + `dequant_gpu`. Registering one
+// strategy per dequant-eligible qtype (Q4_K / Q5_K / Q6_K / Q8_0 / ...)
+// would multiply entries without changing dispatch behavior. The dispatch
+// site emits NONE explicitly to signal "fallback: dequant any supported
+// qtype to FP16 then cuBLAS".
+//
+// Preconditions checked here:
+//   - input != nullptr, output != nullptr, weight_payload != nullptr
+//   - dequant_scratch != nullptr
+//   - dequant_gpu_supported(weight.qtype)
+// On any precondition fail the kernel returns PreconditionFail so the
+// dispatch site falls through to legacy `gemm_dispatch_impl` (which has
+// a final raw `gemm()` arm at line 2322 for the FP16/BF16-no-dequant
+// case).
+// ---------------------------------------------------------------------------
+static GemmDispatchResult generic_dequant_kernel(const GemmKernelArgs& args) {
+    IMP_CHECK(args.input != nullptr, "generic_dequant_kernel: input is null");
+    IMP_CHECK(args.output != nullptr, "generic_dequant_kernel: output is null");
+    IMP_CHECK(args.weight_payload != nullptr,
+              "generic_dequant_kernel: weight_payload is null");
+
+    if (args.dequant_scratch == nullptr)
+        return GemmDispatchResult::PreconditionFail;
+
+    const Tensor& weight = *static_cast<const Tensor*>(args.weight_payload);
+    if (!dequant_gpu_supported(weight.qtype))
+        return GemmDispatchResult::PreconditionFail;
+
+    // Mirror executor_kernels.cu:2315-2319 verbatim — dequant the raw quant
+    // bytes into the FP16 scratch, then wrap a Tensor view and call cuBLAS.
+    const int rows = static_cast<int>(weight.shape[0]);
+    const int cols = static_cast<int>(weight.shape[1]);
+    dequant_gpu(weight.data, args.dequant_scratch, weight.qtype, rows, cols, args.stream);
+    Tensor w_fp16(args.dequant_scratch, QType::F16, weight.ndim, weight.shape, /*on_device=*/true);
+    gemm(*args.input, w_fp16, *args.output, /*alpha=*/1.0f, args.beta, args.stream);
+    return GemmDispatchResult::Ok;
+}
+
+// Static registration. Slice 8.5 adds one (FP16, NONE, m_is_one=false)
+// entry — the qtype-agnostic generic-dequant catch-all. M==1 GEMV-style
+// catch-all is unnecessary because the M==1 path is already covered by
+// the per-qtype Slice 7 GGUF strategies and the FP16-cache path; the
+// catch-all is needed only for M>1 prefill where dequant→cuBLAS is the
+// last resort.
+namespace {
+struct GenericDequantRegistration {
+    GenericDequantRegistration() {
+        GemmKernelRegistry::instance().register_kernel(
+            GemmStrategy{StorageTier::FP16, QType::NONE, /*m_is_one=*/false},
+            &generic_dequant_kernel);
+    }
+};
+static GenericDequantRegistration s_generic_dequant_registration;
+}  // namespace
+
+}  // namespace imp

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -1535,6 +1535,205 @@ TEST_F(GemmKernelRegistryTest, GgufQ6kFusedGemvRequiresDequantScratchSentinel) {
     cudaFree(d_out);
 }
 
+// R5 Slice 8.5 — qtype-agnostic generic-dequant catch-all registered
+// under (tier=FP16, qtype=NONE, m_is_one=false). Slices 1-6 contribute 8
+// entries, Slice 7 adds 8 GGUF small-M qtypes, Slice 8.1 adds 1 FP8
+// cache-miss adapter, Slice 8.5 adds 1 generic-dequant catch-all → 18.
+TEST_F(GemmKernelRegistryTest, GenericDequantCatchAllIsRegisteredAtStaticInit) {
+    const auto& reg = GemmKernelRegistry::instance();
+    EXPECT_GE(reg.size(), 18u)
+        << "Slices 1-6 (8 entries) + Slice 7 GGUF small-M (8 qtypes) + Slice 8.1 FP8 "
+           "cache-miss dequant fallback (1 entry) + Slice 8.5 generic-dequant catch-all "
+           "(1 entry) expected pre-registered";
+}
+
+// The generic-dequant handler refuses loud when the dequant scratch is
+// missing. The dispatch site provides `qs->dequant`; without it the kernel
+// cannot stage the FP16 weight and must PreconditionFail so the caller
+// falls through to legacy `gemm_dispatch_impl`.
+TEST_F(GemmKernelRegistryTest, GenericDequantRejectsMissingScratch) {
+    constexpr int M = 4;
+    constexpr int N = 8;
+    constexpr int K = 128;  // multiple of 32 for Q8_0 blocks
+
+    __half* d_input = nullptr;
+    __half* d_out = nullptr;
+    void* d_weight_q8_0 = nullptr;
+    constexpr int kQ8_0_BlockBytes = 34;
+    const size_t weight_bytes = static_cast<size_t>(N) * (K / 32) * kQ8_0_BlockBytes;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+    cudaMalloc(&d_weight_q8_0, weight_bytes);
+    cudaMemset(d_input, 0, sizeof(__half) * M * K);
+    cudaMemset(d_weight_q8_0, 0, weight_bytes);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(d_weight_q8_0, QType::Q8_0, 2, w_shape, /*on_device=*/true);
+    Tensor out(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    // dequant_scratch deliberately nullptr — the handler must refuse.
+
+    GemmStrategy strat{StorageTier::FP16, QType::NONE, /*m_is_one=*/false};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::PreconditionFail);
+
+    cudaFree(d_input);
+    cudaFree(d_out);
+    cudaFree(d_weight_q8_0);
+}
+
+// Off-axis qtype (a qtype that `dequant_gpu_supported` rejects, e.g. raw
+// F16/BF16 which are not block-quantized) must surface as PreconditionFail
+// — the dispatch site falls back to legacy `gemm_dispatch_impl`, which has
+// a final raw `gemm()` arm for the FP16/BF16-no-dequant case.
+TEST_F(GemmKernelRegistryTest, GenericDequantRejectsUnsupportedQtype) {
+    constexpr int M = 4;
+    constexpr int N = 8;
+    constexpr int K = 16;
+
+    __half* d_input = nullptr;
+    __half* d_weight = nullptr;
+    __half* d_out = nullptr;
+    void* d_scratch = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_weight, sizeof(__half) * N * K);
+    cudaMalloc(&d_out, sizeof(__half) * M * N);
+    cudaMalloc(&d_scratch, sizeof(__half) * N * K);
+    cudaMemset(d_input, 0, sizeof(__half) * M * K);
+    cudaMemset(d_weight, 0, sizeof(__half) * N * K);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    // F16 weight — dequant_gpu_supported(F16) is false, so the handler
+    // must refuse rather than dequant a non-block-quant tensor.
+    Tensor weight(d_weight, QType::F16, 2, w_shape, /*on_device=*/true);
+    Tensor out(d_out, QType::F16, 2, out_shape, /*on_device=*/true);
+
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out;
+    args.stream = stream_;
+    args.weight_payload = &weight;
+    args.dequant_scratch = d_scratch;  // provided; the qtype check fails.
+
+    GemmStrategy strat{StorageTier::FP16, QType::NONE, /*m_is_one=*/false};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::PreconditionFail);
+
+    cudaFree(d_input);
+    cudaFree(d_weight);
+    cudaFree(d_out);
+    cudaFree(d_scratch);
+}
+
+// End-to-end parity: registry generic-dequant dispatch produces the same
+// output as the legacy `dequant_gpu → gemm` sequence for a Q8_0 weight.
+// Mirrors the Slice 8.1 FP8 cache-miss parity test — both adapters share
+// the same dequant_gpu + cuBLAS gemm sequence; only the strategy key and
+// the outer registration differ.
+TEST_F(GemmKernelRegistryTest, GenericDequantMatchesDirectPath) {
+    constexpr int M = 8;
+    constexpr int N = 16;
+    constexpr int K = 128;  // multiple of 32 for Q8_0
+    constexpr int blocks_per_row = K / 32;
+    constexpr int kQ8_0_BlockBytes = 34;
+
+    std::vector<__half> h_input(M * K);
+    std::vector<__half> h_weight_fp16(N * K);
+    for (int i = 0; i < M * K; ++i) h_input[i] = __float2half((i % 5) * 0.0625f - 0.125f);
+    for (int i = 0; i < N * K; ++i) h_weight_fp16[i] = __float2half((i % 7) * 0.0625f - 0.1875f);
+
+    std::vector<uint8_t> h_weight_q8_0(static_cast<size_t>(N) * blocks_per_row * kQ8_0_BlockBytes);
+    for (int row = 0; row < N; ++row) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            float absmax = 0.0f;
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                absmax = std::max(absmax, std::fabs(v));
+            }
+            float d = absmax / 127.0f;
+            float inv_d = (d > 0.0f) ? 1.0f / d : 0.0f;
+            uint8_t* blk = h_weight_q8_0.data() +
+                           (static_cast<size_t>(row) * blocks_per_row + b) * kQ8_0_BlockBytes;
+            __half d_h = __float2half(d);
+            std::memcpy(blk, &d_h, sizeof(__half));
+            int8_t* qs = reinterpret_cast<int8_t*>(blk + 2);
+            for (int j = 0; j < 32; ++j) {
+                float v = __half2float(h_weight_fp16[row * K + b * 32 + j]);
+                int q = static_cast<int>(std::lrintf(v * inv_d));
+                qs[j] = static_cast<int8_t>(std::max(-127, std::min(127, q)));
+            }
+        }
+    }
+
+    __half* d_input = nullptr;
+    void* d_weight = nullptr;
+    void* d_scratch_direct = nullptr;
+    void* d_scratch_registry = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_weight, h_weight_q8_0.size());
+    cudaMalloc(&d_scratch_direct, sizeof(__half) * N * K);
+    cudaMalloc(&d_scratch_registry, sizeof(__half) * N * K);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_weight, h_weight_q8_0.data(), h_weight_q8_0.size(), cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight(d_weight, QType::Q8_0, 2, w_shape, /*on_device=*/true);
+
+    // Path 1: direct (mirror executor_kernels.cu legacy generic catch-all).
+    __half* d_out_direct = nullptr;
+    cudaMalloc(&d_out_direct, sizeof(__half) * M * N);
+    Tensor out_direct(d_out_direct, QType::F16, 2, out_shape, /*on_device=*/true);
+    dequant_gpu(weight.data, d_scratch_direct, weight.qtype, N, K, stream_);
+    Tensor w_fp16_direct(d_scratch_direct, QType::F16, 2, w_shape, /*on_device=*/true);
+    gemm(input, w_fp16_direct, out_direct, /*alpha=*/1.0f, /*beta=*/0.0f, stream_);
+
+    // Path 2: registry dispatch through the generic-dequant adapter.
+    __half* d_out_registry = nullptr;
+    cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
+    Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
+    GemmKernelArgs args{};
+    args.input = &input;
+    args.output = &out_registry;
+    args.stream = stream_;
+    args.beta = 0.0f;
+    args.weight_payload = &weight;
+    args.dequant_scratch = d_scratch_registry;
+    GemmStrategy strat{StorageTier::FP16, QType::NONE, /*m_is_one=*/false};
+    EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
+
+    cudaStreamSynchronize(stream_);
+
+    std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);
+    cudaMemcpy(h_out_direct.data(), d_out_direct, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_out_registry.data(), d_out_registry, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+
+    // Both paths run an identical `dequant_gpu` + `gemm` sequence → bit-identical.
+    for (int i = 0; i < M * N; ++i) {
+        EXPECT_EQ(__half_as_ushort(h_out_direct[i]), __half_as_ushort(h_out_registry[i]))
+            << "Mismatch at i=" << i << " (direct=" << __half2float(h_out_direct[i])
+            << " registry=" << __half2float(h_out_registry[i]) << ")";
+    }
+
+    cudaFree(d_input);
+    cudaFree(d_weight);
+    cudaFree(d_scratch_direct);
+    cudaFree(d_scratch_registry);
+    cudaFree(d_out_direct);
+    cudaFree(d_out_registry);
+}
+
 // Pin the GemmStrategy operator== contract — used by the linear-scan
 // lookup in dispatch().
 TEST(GemmStrategy, EqualityIsByValue) {


### PR DESCRIPTION
## Summary

Two follow-ups from the Slice 8 coverage audit (#215). Combined PR because they're closely related (both handle fall-through generic paths).

- **Slice 8.4 (fp16_cache for non-F16 weights)**: structurally a no-op. Slice 1's dispatch site at \`executor_kernels.cu:2560\` (\`wc->fp16.find(weight.data)\`) already covers this. The map key is the raw \`weight.data\` pointer, qtype-agnostic — a pre-dequantized FP16 cache entry under any source qtype (Q4_K, Q5_K, Q8_0, etc.) hits the FP16 strategy directly. Legacy line 2302 (\`gemm(input, it->second, output, …)\`) is bit-identical to Slice 1's FP16 handler. Lifting \`fp16->find\` above qtype-specific branches would have **changed** legacy precedence (FP8 cache must fire first); current registry order correctly mirrors legacy. **No change needed.**
- **Slice 8.5 (raw-quant large-M dequant→cuBLAS catch-all)**: new strategy \`{FP16, NONE, m_is_one=false}\` that handles any qtype not covered by a specific tier, when M>1, via \`dequant_gpu\` + \`gemm()\`. Mirrors Slice 8.1's qtype-agnostic pattern.

## Files

- **\`src/graph/gemm_kernel_generic_dequant.cu\`** (new, ~85 lines) — \`{FP16, NONE, m_is_one=false}\` handler. IMP_CHECK preconditions (input qtype F16, dequant_scratch present, dequant_gpu_supported(weight.qtype)), then \`dequant_gpu → gemm\`.
- **\`src/graph/executor_kernels.cu\`** — adds Slice 8.5 dispatch block after the GGUF small-M section.
- **\`CMakeLists.txt\`** — adds new TU.
- **\`tests/test_gemm_kernel_registry.cu\`** — 4 new tests:
  - \`GenericDequantCatchAllIsRegisteredAtStaticInit\`
  - \`GenericDequantRejectsMissingScratch\` (PreconditionFail when \`dequant_scratch == nullptr\`)
  - \`GenericDequantRejectsUnsupportedQtype\` (PreconditionFail when \`!dequant_gpu_supported(qtype)\`)
  - \`GenericDequantMatchesDirectPath\` (bit-identical vs direct \`dequant_gpu + gemm\`)

## Coverage progress: 2 of 5 remaining Slice 8 branches closed

| Slice | Branch | Status |
|---|---|---|
| 8.1 | FP8 cache miss fallback | shipped (#217) |
| 8.2 | Fused gemv Q6_K/Q8_0 fallback | open (#220) |
| 8.3 | Q4_1 paths (dead code) | open (#221) |
| **8.4** | **fp16_cache for non-F16 weights** | **no-op (Slice 1 already covers)** |
| **8.5** | **Raw-quant large-M dequant catch-all** | **shipped (this PR)** |
| 8.6 | Final delete + QW7 + mmvq_scratch hoist | pending |

Registry size: 17 → **18**.

## Test plan

- [x] \`make build\` PASS
- [x] \`make verify-fast\` PASS (pre-push hook)
- [x] Targeted \`*GenericDequant*\` 4/4 PASS
- [x] Branch off origin/main; \`--base main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)