### PR TITLE
refactor(graph): R5 Slice 8.6 — retire gemm_dispatch_impl + flag + QW7 migration + mmvq_scratch hoist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ set(IMP_GRAPH_SOURCES
     src/graph/gemm_kernel_mxfp4.cu
     src/graph/gemm_kernel_gguf.cu
     src/graph/gemm_kernel_generic_dequant.cu
+    src/graph/gemm_scratch.cu
     src/graph/executor_workspace.cu
     src/graph/executor_workspace_buffers.cu
     src/graph/executor_kv_write.cu

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,9 +92,9 @@ EAGLE-3, self-speculative, DFlash, PPM-based TurboDraft, and n-gram speculation 
 
 A Blackwell-style cluster-launch variant of the FMHA prefill kernel (DSMEM K-broadcast across a 2-CTA cluster, modelled after `paged_attention_cluster_kernel<HD>`) was implemented across three slices in May 2026: Slice 1 helper (#198), Slice 2 FP16 cluster kernel + dispatch (#200), Slice 2.2 FP8 variant (#202). End-to-end A/B across 4 NVFP4 MoE models (Qwen3.6-35B, Coder-30B, Gemma-4-26B, Qwen3-30B-Modelopt) on 2026-05-17 found the perf signal **noise-dominated**: ±20% same shape, opposite signs across re-runs of the same config; cuBLAS / thermal / scheduler variance drowned any cluster effect. Cluster output is **bit-identical to legacy** (`ClusterMatchesLegacy*` tests: max_abs = 0), so the kernel is sound; the maintainability cost (a parallel kernel + dispatch + dual test files) doesn't pay back. Default flipped OFF in #204 via `attention.no_fmha_cluster=true`; code retained as opt-in for future hardware where the signal might emerge. Memo: `m5_slice2_cluster_refuted_2026_05_17.md`.
 
-### GEMM dispatch unification (R5)
+### GEMM dispatch unification (R5) — DONE
 
-The 21-parameter `gemm_dispatch_impl` god-dispatcher has been replaced by a strategy-keyed `GemmKernel` registry. Slice 1 (PR #197) shipped the interface (`src/graph/gemm_kernel_registry.h`); Slices 2-7 migrated each tier behind a `gemm.use_kernel_registry` feature flag (default OFF for those slices); Slice 8 (#215) flipped the default to ON. The registry is now the **primary dispatch path** in production. The legacy `gemm_dispatch_impl` switch is retained as fallback for a handful of branches Slices 1-7 did not target — these are queued as Slice 8.1+.
+The 21-parameter `gemm_dispatch_impl` god-dispatcher has been **retired**. The strategy-keyed `GemmKernel` registry (`src/graph/gemm_kernel_registry.h`) is the unconditional dispatch path. Slice 8.6 (final) closed the cross-axis refactor by migrating the QW7 dual-cache CUTLASS MXFP4 probe into the CUTLASS_NVFP4 handler, deleting the legacy switch (~247 LOC), and hoisting `mmvq_scratch_get_or_grow` into its own TU (`src/graph/gemm_scratch.{h,cu}`).
 
 | Slice | Tier / scope | Status |
 |---|---|---|
@@ -106,19 +106,16 @@ The 21-parameter `gemm_dispatch_impl` god-dispatcher has been replaced by a stra
 | 6 | MXFP4 (GEMV + GEMM) | shipped (#213) |
 | 7 | GGUF dp4a/mmvq, M==1 (8 qtypes) | shipped (#214) |
 | 8 | Flip default ON + coverage audit | shipped (#215) |
+| 8.1 | FP8 cache-miss → dequant fallback | shipped (#217) |
+| 8.2 | Fused gemv fallback for Q6_K, Q8_0 | shipped (#220) |
+| 8.3 | Q4_1 dead-code purge | shipped (#221) |
+| 8.4 | `fp16_cache` for non-F16 weights (covered by Slice 1, no-op) | shipped (#225) |
+| 8.5 | Raw-quant large-M dequant→cuBLAS catch-all | shipped (#225) |
+| 8.6 | QW7 dual-cache CUTLASS MXFP4 migration + final `gemm_dispatch_impl` delete + `mmvq_scratch` TU hoist + flag retired | shipped |
 
-**Deferred follow-ups** (the 8 branches Slice 8's audit found uncovered — `gemm_dispatch_impl` still owns them on the registry's `NoMatch` fallback):
+QW7 decision: the dual-cache CUTLASS MXFP4 probe was **migrated, not deleted**. It only fires under explicit `--mxfp4-prefill` opt-in (off by default; documented in `docs/performance.md`), so production-trace evidence wasn't available; deleting would silently break the opt-in path. The probe now lives inside the CUTLASS_NVFP4 handler — when both `cutlass_nvfp4` and `cutlass_mxfp4` caches hit the same `weight.data`, the handler tries MXFP4 CUTLASS first and falls back to NVFP4 CUTLASS on `gemm_mxfp4_cutlass_sm120` failure. Same drop-through semantics as the legacy switch.
 
-| Slice | Branch |
-|---|---|
-| 8.1 | FP8 cache miss → dequant fallback (high-impact: every FP8 model not in cache) |
-| 8.2 | Fused gemv fallbacks for Q6_K, Q8_0 (Qwen3-Coder Q6_K hits this) |
-| 8.3 | Q4_1 paths (rare qtype) |
-| 8.4 | `fp16_cache` for non-F16 weights (convert-and-cache-as-FP16 flow) |
-| 8.5 | Raw-quant large-M dequant→cuBLAS (catch-all for anything Slices 1-7 missed) |
-| 8.6 | QW7 dual-cache CUTLASS MXFP4 probe (waiting on production trace to confirm dead) + final `gemm_dispatch_impl` delete + `mmvq_scratch_get_or_grow` header hoist |
-
-Each is a small mechanical migration. Coverage table from Slice 8 audit is in PR #215 description. Once 8.1-8.6 land, the legacy switch + the `gemm.use_kernel_registry` flag can be retired entirely.
+`gemm.use_kernel_registry` config field deleted (was an escape hatch during Slice 1-7 migration; redundant once the legacy path is gone).
 
 ### MoE prefill graph capture (M3 Phase 4)
 

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -20,79 +20,7 @@
 #include "compute/ptx92_utils.cuh"
 #include "compute/warp_reduce.cuh"  // kWarpSize
 
-#include <atomic>
-
 namespace imp {
-
-// ---------------------------------------------------------------------------
-// MMVQ (Q8_1-input GEMV) scratch — file-scope, sized once at workspace init
-// via prewarm_mmvq_scratch(). The hot-path mmvq_scratch_get_or_grow() reads
-// the cached size; the grow branch (cudaFree+cudaMalloc) is the cold-path
-// fallback and capture-unsafe — engine init MUST prewarm to model max dims.
-// ---------------------------------------------------------------------------
-namespace {
-void* g_mmvq_scratch = nullptr;
-size_t g_mmvq_scratch_size = 0;
-}  // namespace
-
-void prewarm_mmvq_scratch(int max_tokens, int max_K) {
-    if (max_tokens <= 0 || max_K <= 0)
-        return;
-    const size_t per_call = static_cast<size_t>(max_tokens) * ((max_K + 31) / 32) * 36;
-    const size_t need = per_call * 2;
-    if (g_mmvq_scratch && g_mmvq_scratch_size >= need)
-        return;
-    if (g_mmvq_scratch)
-        IMP_CUDA_CHECK_LOG(cudaFree(g_mmvq_scratch));
-    cudaError_t err = cudaMalloc(&g_mmvq_scratch, need);
-    if (err != cudaSuccess) {
-        IMP_LOG_ERROR("prewarm_mmvq_scratch: cudaMalloc(%zu) failed: %s",
-                      need, cudaGetErrorString(err));
-        g_mmvq_scratch = nullptr;
-        g_mmvq_scratch_size = 0;
-        return;
-    }
-    g_mmvq_scratch_size = need;
-    IMP_LOG_INFO("MMVQ scratch pre-warmed: %.2f KiB (max_tokens=%d, max_K=%d)",
-                 need / 1024.0, max_tokens, max_K);
-}
-
-// R5 Slice 7: the mmvq adapter in `gemm_kernel_gguf.cu` re-uses this single
-// global via a forward declaration there — internal linkage would force the
-// new TU to duplicate the scratch state. Kept namespace-local (no public
-// header declaration) to limit exposure.
-void mmvq_scratch_get_or_grow(size_t need, void** out_buf, size_t* out_size) {
-    if (g_mmvq_scratch && g_mmvq_scratch_size >= need) {
-        *out_buf = g_mmvq_scratch;
-        *out_size = g_mmvq_scratch_size;
-        return;
-    }
-    // Cold path: prewarm missed (or model dim changed mid-run). Re-grow.
-    // Capture-unsafe; emits one ERROR log so the missing prewarm is visible.
-    static std::atomic<bool> s_warned{false};
-    if (!s_warned.exchange(true)) {
-        IMP_LOG_ERROR(
-            "mmvq_scratch_get_or_grow: hot-path grow fired (need=%zu, have=%zu) — "
-            "engine init did not call prewarm_mmvq_scratch() with the model's "
-            "(max_tokens, max_K). cudaMalloc inside graph capture will fail.",
-            need, g_mmvq_scratch_size);
-    }
-    if (g_mmvq_scratch)
-        IMP_CUDA_CHECK_LOG(cudaFree(g_mmvq_scratch));
-    cudaError_t err = cudaMalloc(&g_mmvq_scratch, need * 2);
-    if (err != cudaSuccess) {
-        IMP_LOG_ERROR("mmvq_scratch_get_or_grow: cudaMalloc(%zu) failed: %s",
-                      need * 2, cudaGetErrorString(err));
-        g_mmvq_scratch = nullptr;
-        g_mmvq_scratch_size = 0;
-        *out_buf = nullptr;
-        *out_size = 0;
-        return;
-    }
-    g_mmvq_scratch_size = need * 2;
-    *out_buf = g_mmvq_scratch;
-    *out_size = g_mmvq_scratch_size;
-}
 
 // ---------------------------------------------------------------------------
 // Device helpers for paged KV cache block table lookup
@@ -2063,258 +1991,20 @@ Tensor slice_rows(const Tensor& buf, int n_tokens) {
     return buf.slice(0, n_tokens);
 }
 
-// File-scope helper: the original multi-path GEMM dispatcher. Kept as a private
-// body inside the translation unit; the public API is the GemmContext-based
-// overload below, which forwards into this helper.
-//
-// - Q8_0/Q6_K (with dequant_scratch): dequant into scratch, then cuBLAS gemm.
-// - NONE/FP16/BF16: standard cuBLAS gemm.
-// - dp4a MMVQ path (M=1 + q8_1_buf/d8_buf): pre-quantize input to Q8_1, dot
-//   products via native INT8 SIMD (~2x faster than FP16 dequant for Q6_K/Q8_0).
-static void gemm_dispatch_impl(
-    const Tensor& input, const Tensor& weight, const Tensor& scales, QType qtype, Tensor& output,
-    void* dequant_scratch, cudaStream_t stream, block_q8_1* q8_1_buf, float* d8_buf,
-    const std::unordered_map<const void*, Tensor>* fp16_cache,
-    const std::unordered_map<const void*, FP8CacheEntry>* fp8_cache, void* fp8_act_buf, float* d_act_scale,
-    float* d_fp8_block_maxes, float* d_fp8_absmax, int fp8_max_grid,
-    const std::unordered_map<const void*, NvFP4QuantResult>* nvfp4_cache,
-    const std::unordered_map<const void*, CutlassNvFP4Weight>* cutlass_nvfp4_cache, void* cutlass_act_data,
-    void* cutlass_act_sf, void* cutlass_workspace, size_t cutlass_workspace_size,
-    const std::unordered_map<const void*, CutlassMxFP4Weight>* mxfp4_cache, void* mxfp4_act_sf,
-    void* mxfp4_workspace, size_t mxfp4_workspace_size, float beta) {
-    // beta != 0 (residual-fused GEMM) is only supported on FP16/dequant/FP8 paths
-    // below; callers must ensure their preconditions route there.
-    // Native MXFP4 GGUF: GEMV for M=1, CUTLASS for M>1.
-    if (mxfp4_cache != nullptr && input.qtype == QType::F16) {
-        auto mx_it = mxfp4_cache->find(weight.data);
-        if (mx_it != mxfp4_cache->end() && mx_it->second.linear_scales) {
-            if (input.shape[0] == 1) {
-                // MXFP4 GEMV decode — apply Hadamard online rotation if needed
-                int hbs = mx_it->second.hadamard_bs;
-                if (hbs > 0 && hadamard_block_size_valid(hbs)) {
-                    int K = static_cast<int>(mx_it->second.K);
-                    hadamard_transform_fp16(reinterpret_cast<const half*>(input.data),
-                                            reinterpret_cast<half*>(input.data),  // in-place
-                                            1, K, hbs, stream);
-                }
-                gemv_mxfp4_kpar(mx_it->second, reinterpret_cast<const half*>(input.data),
-                                reinterpret_cast<half*>(output.data), static_cast<int>(mx_it->second.N),
-                                static_cast<int>(mx_it->second.K), stream);
-                return;
-            } else if (dequant_scratch != nullptr) {
-                // MXFP4 prefill (M>1): dequant to FP16 scratch → cuBLAS GEMM
-                int N = static_cast<int>(mx_it->second.N);
-                int K = static_cast<int>(mx_it->second.K);
-                size_t fp16_bytes = static_cast<size_t>(N) * K * sizeof(half);
-                dequant_mxfp4_to_fp16(mx_it->second.data, N, K, dequant_scratch, stream);
-                int64_t w_shape[2] = {N, K};
-                Tensor w_fp16(dequant_scratch, QType::F16, 2, w_shape, true);
-                gemm(input, w_fp16, output, 1.0f, beta, stream);
-                return;
-            }
-        }
-    }
-    // NVFP4 dispatch: Tensor sidecars (prequant load path, qtype=NVFP4 set
-    // directly on the weight) take precedence over the legacy nvfp4_cache
-    // (decode-cache path, FP16/Q*_K weights converted on-the-fly during init).
-    // Build NvFP4QuantResult on-the-fly when the sidecars are populated;
-    // otherwise fall through to the cache lookup.
-    NvFP4QuantResult nvfp4_tmp;
-    const NvFP4QuantResult* nvfp4_view = nullptr;
-    if (input.qtype == QType::F16 && weight.qtype == QType::NVFP4 && weight.scales != nullptr) {
-        nvfp4_tmp.packed_data = weight.data;
-        nvfp4_tmp.micro_scales = weight.scales;
-        nvfp4_tmp.tensor_scale = weight.tensor_scale;
-        nvfp4_tmp.N = weight.shape[0];
-        // shape[1] holds packed K/2 for FP4 → kernel needs logical K
-        nvfp4_tmp.K = weight.shape[1] * 2;
-        nvfp4_view = &nvfp4_tmp;
-    } else if (nvfp4_cache != nullptr && input.qtype == QType::F16) {
-        auto it = nvfp4_cache->find(weight.data);
-        if (it != nvfp4_cache->end())
-            nvfp4_view = &it->second;
-    }
-    if (nvfp4_view != nullptr) {
-        const NvFP4QuantResult& res = *nvfp4_view;
-        if (input.shape[0] == 1) {
-            gemv_nvfp4_kpar(res, reinterpret_cast<const half*>(input.data),
-                            reinterpret_cast<half*>(output.data), static_cast<int>(res.N),
-                            static_cast<int>(res.K), stream);
-        } else if (cutlass_nvfp4_cache != nullptr && cutlass_act_data != nullptr) {
-            // Native FP4 GEMM: try cuBLASLt first, then CUTLASS sm_120
-            auto ct_it = cutlass_nvfp4_cache->find(weight.data);
-            if (ct_it != cutlass_nvfp4_cache->end()) {
-                int M = static_cast<int>(input.shape[0]);
-                int K = static_cast<int>(input.shape[1]);
-                int N = static_cast<int>(res.N);
-                quantize_fp16_to_nvfp4_cutlass(input.data, cutlass_act_data, cutlass_act_sf, M, K, stream);
-
-                // MXFP4 CUTLASS branch (UE8M0 scales per 32 elements). Fires
-                // only when the SAME weight.data exists in BOTH cutlass_nvfp4
-                // and cutlass_mxfp4 caches — review/phase3_maint.md §5.1
-                // claimed the loader never does this. convert_nvfp4_to_mxfp4_cutlass
-                // (executor_pre_dequant.cu:1518) IS active though, so this
-                // path is plausible. Instrumented (log-once) to confirm
-                // before deletion in a follow-up. See review/phase5_synthesis.md
-                // §7 dead/dormant verdict — needs production trace.
-                if (mxfp4_cache != nullptr && mxfp4_act_sf != nullptr && K % 32 == 0) {
-                    auto mx_it = mxfp4_cache->find(weight.data);
-                    if (mx_it != mxfp4_cache->end()) {
-                        static std::atomic<bool> s_logged{false};
-                        if (!s_logged.exchange(true)) {
-                            IMP_LOG_INFO(
-                                "QW7-probe: dual-cache NVFP4+MXFP4 branch fired "
-                                "(weight=%p M=%d N=%d K=%d) — branch is NOT dead", weight.data, M, N, K);
-                        }
-                        quantize_fp16_to_mxfp4_cutlass(input.data, cutlass_act_data, mxfp4_act_sf, M, K,
-                                                       stream);
-                        bool ok = gemm_mxfp4_cutlass_sm120(cutlass_act_data, mxfp4_act_sf, mx_it->second,
-                                                           output.data, M, N, K, mxfp4_workspace,
-                                                           mxfp4_workspace_size, stream);
-                        if (ok)
-                            return;
-                    }
-                }
-
-                // CUTLASS sm_120 block-scaled NVFP4 kernel. (cuBLASLt NVFP4
-                // was an alternate path but NVIDIA ships no FP4 kernels for
-                // consumer Blackwell (sm_120); deleted in favor of CUTLASS.)
-                bool ok = gemm_nvfp4_cutlass_sm120(cutlass_act_data, cutlass_act_sf, ct_it->second,
-                                                   output.data, M, N, K, cutlass_workspace,
-                                                   cutlass_workspace_size, stream);
-                if (ok)
-                    return;
-            }
-        }
-        if (input.shape[0] > 1) {
-            gemm_nvfp4(res, input, output, stream);
-        }
-        return;
-    }
-    // Gemma 4: if FP16 cache has the weight, use it (dp4a dispatch has issues
-    // with non-standard strides from per-layer narrow tensors).
-    bool prefer_fp16_cache = (fp16_cache != nullptr && fp16_cache->count(weight.data) > 0 &&
-                              input.stride[0] != weight.shape[1]);  // non-contiguous input
-    if (RuntimeConfig::current().diagnostics.debug_gemm_dispatch) {
-        fprintf(stderr,
-                "[GEMM_DISP] w=%p qtype=%d M=%lld N=%lld K=%lld prefer_fp16=%d "
-                "in_fp16_cache=%d in_fp8_cache=%d dp4a_ok=%d has_dequant=%d\n",
-                weight.data, (int)qtype, (long long)input.shape[0], (long long)weight.shape[0],
-                (long long)weight.shape[1], (int)prefer_fp16_cache,
-                (fp16_cache && fp16_cache->count(weight.data) > 0),
-                (fp8_cache && fp8_cache->count(weight.data) > 0),
-                (int)(is_dp4a_qtype(qtype) && q8_1_buf && d8_buf), (int)(dequant_scratch != nullptr));
-    }
-    const bool no_dp4a_gemv = RuntimeConfig::current().gemm.no_dp4a_gemv;
-    // MMVQ: ggml-compatible quantized GEMM for llama.cpp numerical parity.
-    // Auto-enabled for Gemma-4 via engine.cpp setenv. Non-static to pick up
-    // env var set during engine init (after static init of other flags).
-    // IMP_NO_MMVQ_Q8_0 / IMP_NO_MMVQ: debug bypass for suspected Q8_0 MMVQ bug.
-    const bool no_mmvq_q8_0 = RuntimeConfig::current().gemm.no_mmvq_q8_0;
-    const bool no_mmvq_all = RuntimeConfig::current().gemm.no_mmvq;
-    // FP16-only fast paths (mmvq, dp4a, gemv_q6k, gemv_q8_0) write directly to
-    // half* — must skip when caller requested FP32 output, otherwise the FP16
-    // bytes get interpreted as FP32 and produce billions-magnitude garbage.
-    const bool fp32_output = (output.qtype == QType::F32);
-    bool use_mmvq = RuntimeConfig::current().gemma4.force_mmvq && !prefer_fp16_cache &&
-                    input.qtype == QType::F16 && !fp32_output &&
-                    (qtype == QType::Q4_K || qtype == QType::Q5_K || qtype == QType::Q5_1 ||
-                     qtype == QType::Q8_0) &&
-                    (weight.shape[1] % 32 == 0) && !(no_mmvq_q8_0 && qtype == QType::Q8_0) && !no_mmvq_all;
-    bool use_dp4a = !no_dp4a_gemv && !prefer_fp16_cache && input.shape[0] == 1 && input.qtype == QType::F16 &&
-                    !fp32_output && q8_1_buf != nullptr && d8_buf != nullptr && is_dp4a_qtype(qtype);
-
-    if (use_mmvq) {
-        int M = static_cast<int>(input.shape[0]);
-        int N = static_cast<int>(weight.shape[0]);
-        int K = static_cast<int>(weight.shape[1]);
-        // Pre-warm-or-grow scratch. After workspace init, the hot-path size
-        // check is always false (no alloc, no cudaMalloc inside graph capture).
-        size_t q8_need = static_cast<size_t>(M) * ((K + 31) / 32) * 36;
-        void* s_mmvq_scratch = nullptr;
-        size_t s_mmvq_scratch_size = 0;
-        mmvq_scratch_get_or_grow(q8_need, &s_mmvq_scratch, &s_mmvq_scratch_size);
-        if (qtype == QType::Q4_K)
-            ggml_mmvq_q4k(weight.data, static_cast<const half*>(input.data), static_cast<half*>(output.data),
-                          M, N, K, s_mmvq_scratch, s_mmvq_scratch_size, stream);
-        else if (qtype == QType::Q5_K)
-            ggml_mmvq_q5k(weight.data, static_cast<const half*>(input.data), static_cast<half*>(output.data),
-                          M, N, K, s_mmvq_scratch, s_mmvq_scratch_size, stream);
-        else if (qtype == QType::Q5_1)
-            ggml_mmvq_q5_1(weight.data, static_cast<const half*>(input.data), static_cast<half*>(output.data),
-                           M, N, K, s_mmvq_scratch, s_mmvq_scratch_size, stream);
-        else if (qtype == QType::Q8_0)
-            ggml_mmvq_q8_0(weight.data, static_cast<const half*>(input.data), static_cast<half*>(output.data),
-                           M, N, K, s_mmvq_scratch, s_mmvq_scratch_size, stream);
-    } else if (use_dp4a) {
-        int N = static_cast<int>(weight.shape[0]);
-        int K = static_cast<int>(weight.shape[1]);
-        quantize_fp16_to_q8_1(static_cast<const half*>(input.data), q8_1_buf, d8_buf, K, stream);
-        dispatch_dp4a_gemv(qtype, weight.data, q8_1_buf, d8_buf, static_cast<half*>(output.data), N, K,
-                           stream);
-    } else if (input.shape[0] == 1 && input.qtype == QType::F16 && dequant_scratch != nullptr &&
-               qtype == QType::Q6_K) {
-        // Fallback: Fused Q6_K GEMV (FP16 dequant path)
-        gemv_q6k(weight.data, static_cast<const half*>(input.data), static_cast<half*>(output.data),
-                 static_cast<int>(weight.shape[0]), static_cast<int>(weight.shape[1]), stream);
-    } else if (input.shape[0] == 1 && input.qtype == QType::F16 && dequant_scratch != nullptr &&
-               qtype == QType::Q8_0) {
-        // Fallback: Fused Q8_0 GEMV (FP16 dequant path)
-        gemv_q8_0(weight.data, static_cast<const half*>(input.data), static_cast<half*>(output.data),
-                  static_cast<int>(weight.shape[0]), static_cast<int>(weight.shape[1]), stream);
-    } else if (fp8_cache != nullptr && input.shape[0] > 1 && fp8_act_buf != nullptr &&
-               d_act_scale != nullptr) {
-        // FP8 cache: quantize activation → FP8, then FP8×FP8 cuBLASLt GEMM (2x throughput on sm_120)
-        auto it = fp8_cache->find(weight.data);
-        if (it != fp8_cache->end()) {
-            Tensor fp8_act(fp8_act_buf, QType::FP8_E4M3, input.ndim, input.shape, true);
-            quantize_fp16_to_fp8_e4m3(input, fp8_act, d_act_scale, stream, d_fp8_block_maxes, d_fp8_absmax,
-                                      fp8_max_grid);
-            gemm_cublaslt(fp8_act, it->second.weight, output, 1.0f, beta, d_act_scale, it->second.d_scale,
-                          stream);
-        } else if (dequant_scratch != nullptr && dequant_gpu_supported(qtype)) {
-            int rows = static_cast<int>(weight.shape[0]);
-            int cols = static_cast<int>(weight.shape[1]);
-            dequant_gpu(weight.data, dequant_scratch, qtype, rows, cols, stream);
-            Tensor w_fp16(dequant_scratch, QType::F16, weight.ndim, weight.shape, true);
-            gemm(input, w_fp16, output, 1.0f, beta, stream);
-        } else {
-            gemm(input, weight, output, 1.0f, beta, stream);
-        }
-    } else if (fp16_cache != nullptr && (dequant_gpu_supported(qtype) || qtype == QType::MXFP4)) {
-        // Pre-dequantized FP16 cache: zero per-GEMM dequant overhead
-        auto it = fp16_cache->find(weight.data);
-        if (RuntimeConfig::current().diagnostics.debug_gemm_dispatch)
-            fprintf(stderr, "[GEMM_DISP]   -> fp16_cache hit=%d\n", (int)(it != fp16_cache->end()));
-        if (it != fp16_cache->end()) {
-            gemm(input, it->second, output, 1.0f, beta, stream);
-        } else if (dequant_scratch != nullptr && qtype != QType::MXFP4) {
-            // Cache miss (shouldn't happen) — fall back to on-the-fly dequant
-            int rows = static_cast<int>(weight.shape[0]);
-            int cols = static_cast<int>(weight.shape[1]);
-            dequant_gpu(weight.data, dequant_scratch, qtype, rows, cols, stream);
-            Tensor w_fp16(dequant_scratch, QType::F16, weight.ndim, weight.shape, true);
-            gemm(input, w_fp16, output, 1.0f, beta, stream);
-        } else {
-            gemm(input, weight, output, 1.0f, beta, stream);
-        }
-    } else if (dequant_scratch != nullptr && dequant_gpu_supported(qtype)) {
-        // Raw quantized bytes on GPU — dequant into scratch, then GEMM
-        int rows = static_cast<int>(weight.shape[0]);
-        int cols = static_cast<int>(weight.shape[1]);
-        dequant_gpu(weight.data, dequant_scratch, qtype, rows, cols, stream);
-        Tensor w_fp16(dequant_scratch, QType::F16, weight.ndim, weight.shape, true);
-        gemm(input, w_fp16, output, 1.0f, beta, stream);
-    } else {
-        // Standard FP16/BF16 GEMM
-        gemm(input, weight, output, 1.0f, beta, stream);
-    }
-}
-
 // ---------------------------------------------------------------------------
-// GemmContext-based dispatch: reads the weight's qtype directly off the
-// tensor (no separate parameter needed) and delegates to the file-private
-// gemm_dispatch_impl helper.
+// gemm_dispatch — single entry point that walks the GemmKernel registry in
+// tier-priority order. R5 Slice 8.6 closes the cross-axis refactor: the
+// legacy 21-parameter `gemm_dispatch_impl` switch (~250 LOC) is retired and
+// the registry is now the unconditional path. Every tier registers its
+// adapter from its own .cu file at static-init time (see
+// gemm_kernel_*.cu); adding a new qtype/quantization tier is a one-file
+// change.
+//
+// Tier order (MXFP4 GGUF → FP8 → NVFP4 GEMV → CUTLASS_NVFP4 → NVFP4 GEMM →
+// FP16 cache/raw → small-M GGUF → generic-dequant catch-all) mirrors the
+// historical legacy precedence and is the same as Slice 8 documented; it is
+// observed-equivalent to the production behaviour from when Slice 8 flipped
+// the registry default ON.
 // ---------------------------------------------------------------------------
 void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, const GemmContext& ctx) {
     const auto* wc = ctx.wcache;
@@ -2358,257 +2048,48 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
     const auto* ct4 = (wc->cutlass_nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_nvfp4;
     const auto* mx4 = (wc->cutlass_mxfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_mxfp4;
 
-    // R5 Slice 1+2+3+4+5+6+7: when gemm.use_kernel_registry is enabled, try
-    // the new dispatch table first. Slices 1 (FP16), 2 (FP8 prefill), 3
-    // (NVFP4 decode GEMV), 4 (NVFP4 prefill GEMM dequant), 5 (CUTLASS_NVFP4
-    // prefill GEMM, preferred native FP4 path), 6 (MXFP4 native GGUF — GEMV +
-    // dequant→cuBLAS GEMM) and 7 (GGUF small-M mmvq + dp4a — 8 qtypes) are
-    // wired; the M>1 dequant+cuBLAS large-M fallback still falls through to
-    // the legacy gemm_dispatch_impl below (slice 8.5 retires it).
-    //
-    // Tier order mirrors gemm_dispatch_impl precedence: MXFP4 GGUF is the
-    // top-priority branch in legacy (executor_kernels.cu:2085-2113) and is
-    // tried first here too. FP8 is tried before FP16 because the legacy path
-    // picks FP8 when M>1 + the weight is in the FP8 cache, even if an FP16
-    // cache entry also exists. NVFP4 sits between FP8 and FP16 — the legacy
-    // dispatch evaluates NVFP4 before falling through to dp4a/fp16 cache
-    // paths, and NVFP4 weights are stored either as Tensor sidecars
-    // (qtype=NVFP4 directly on the weight) or in the separate nv4 cache;
-    // both must be checked.
-    if (RuntimeConfig::current().gemm.use_kernel_registry) {
-        const int M = static_cast<int>(input.shape[0]);
-        // MXFP4 native GGUF (top priority — matches legacy precedence at
-        // gemm_dispatch_impl:2085). Cache hit + linear_scales gate apply
-        // identically. The kernel adapter further gates on linear_scales !=
-        // null and returns PreconditionFail on miss so we fall through. The
-        // dual-cache CUTLASS MXFP4 branch (legacy line 2149-2174) is NOT
-        // migrated here — it lives inside the NVFP4 path with a QW7 probe;
-        // see src/graph/gemm_kernel_mxfp4.cu header.
-        if (mx4 != nullptr && input.qtype == QType::F16) {
-            auto mx_it = mx4->find(weight.data);
-            if (mx_it != mx4->end() && mx_it->second.linear_scales != nullptr) {
-                GemmKernelArgs args{};
-                args.input = &input;
-                args.output = &output;
-                args.stream = ctx.stream;
-                args.beta = ctx.beta;
-                args.weight_payload = &mx_it->second;
-                args.dequant_scratch = qs->dequant;  // only consumed by M>1 path
-                GemmStrategy strat{StorageTier::MXFP4, QType::F16, /*m_is_one=*/(M == 1)};
-                auto rc = GemmKernelRegistry::instance().dispatch(strat, args);
-                if (rc == GemmDispatchResult::Ok)
-                    return;
-                // PreconditionFail (missing dequant scratch for M>1) — fall
-                // through to legacy, mirroring the legacy `else if (dequant_
-                // scratch != nullptr)` skip.
-            }
-        }
-        // FP8 prefill: M>1 only, requires FP8 cache hit + activation scratch.
-        // Matches the guard in gemm_dispatch_impl (M>1 branch). Slice 8.1
-        // adds the cache-MISS dequant fallback under the same outer gate —
-        // when the FP8 path is "active" (cache present, scratch present, M>1)
-        // but the specific weight isn't in the cache, dequant the raw quant
-        // bytes to FP16 and run cuBLAS. The raw FP16/BF16 weight case (legacy
-        // line 2294) falls through to the FP16 strategy below; no extra
-        // dispatch is needed here for it.
-        if (fp8 != nullptr && M > 1 && qs->fp8_act != nullptr && qs->d_act_scale != nullptr) {
-            auto it = fp8->find(weight.data);
-            if (it != fp8->end()) {
-                GemmKernelArgs args{};
-                args.input = &input;
-                args.output = &output;
-                args.stream = ctx.stream;
-                args.beta = ctx.beta;
-                args.weight_payload = &it->second;
-                args.fp8_act_buf = qs->fp8_act;
-                args.d_act_scale = qs->d_act_scale;
-                args.d_fp8_block_maxes = qs->d_fp8_block_maxes;
-                args.d_fp8_absmax = qs->d_fp8_absmax;
-                args.fp8_max_grid = qs->fp8_max_grid;
-                GemmStrategy strat{StorageTier::FP8, QType::F16, /*m_is_one=*/false};
-                if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                    return;
-            } else {
-                // Cache miss — try dequant fallback (Slice 8.1). The handler
-                // checks `dequant_gpu_supported(weight.qtype)` + scratch
-                // availability and returns PreconditionFail otherwise. On
-                // fail we drop through to the FP16 strategy lookup below,
-                // which handles the raw-FP16/BF16-weight case.
-                GemmKernelArgs args{};
-                args.input = &input;
-                args.output = &output;
-                args.stream = ctx.stream;
-                args.beta = ctx.beta;
-                args.weight_payload = &weight;
-                args.dequant_scratch = qs->dequant;
-                GemmStrategy strat{StorageTier::FP8, QType::NONE, /*m_is_one=*/false};
-                if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                    return;
-            }
-        }
-        // NVFP4 decode GEMV (M==1). Build the NvFP4QuantResult view exactly
-        // like gemm_dispatch_impl:2114-2133 — prequant Tensor sidecars take
-        // precedence over the nv4 cache. The temp is heap-allocated here only
-        // when the view comes from sidecars; cache lookups return a pointer
-        // into the long-lived cache map. Slice 4 adds the M>1 NVFP4 GEMM
-        // strategy immediately below.
-        if (M == 1 && input.qtype == QType::F16) {
-            NvFP4QuantResult nvfp4_tmp;
-            const NvFP4QuantResult* nvfp4_view = nullptr;
-            if (weight.qtype == QType::NVFP4 && weight.scales != nullptr) {
-                nvfp4_tmp.packed_data = weight.data;
-                nvfp4_tmp.micro_scales = weight.scales;
-                nvfp4_tmp.tensor_scale = weight.tensor_scale;
-                nvfp4_tmp.N = weight.shape[0];
-                nvfp4_tmp.K = weight.shape[1] * 2;  // shape[1] is packed K/2
-                nvfp4_view = &nvfp4_tmp;
-            } else if (nv4 != nullptr) {
-                auto it = nv4->find(weight.data);
-                if (it != nv4->end())
-                    nvfp4_view = &it->second;
-            }
-            if (nvfp4_view != nullptr) {
-                GemmKernelArgs args{};
-                args.input = &input;
-                args.output = &output;
-                args.stream = ctx.stream;
-                args.beta = ctx.beta;
-                args.weight_payload = nvfp4_view;
-                GemmStrategy strat{StorageTier::NVFP4, QType::F16, /*m_is_one=*/true};
-                if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                    return;
-            }
-        }
-        // CUTLASS_NVFP4 prefill GEMM (M>1, native sm_120 block-scaled FP4 —
-        // the preferred path when eligible). Mirror gemm_dispatch_impl:2140-
-        // 2184: requires (ct4 cache + ct4 hit + cutlass_act_data scratch).
-        // When all three are present, the registry kernel quantizes the FP16
-        // activation and calls gemm_nvfp4_cutlass_sm120. If the CUTLASS call
-        // returns false (kernel can't handle dims) the kernel returns
-        // PreconditionFail and we fall through to Slice 4's dequant GEMM
-        // below — same drop-through semantics as the legacy `if (ok) return;`.
-        if (M > 1 && input.qtype == QType::F16 && ct4 != nullptr &&
-            qs->cutlass_act_data != nullptr) {
-            auto ct_it = ct4->find(weight.data);
-            if (ct_it != ct4->end()) {
-                GemmKernelArgs args{};
-                args.input = &input;
-                args.output = &output;
-                args.stream = ctx.stream;
-                args.beta = ctx.beta;
-                args.weight_payload = &ct_it->second;
-                args.cutlass_act_data = qs->cutlass_act_data;
-                args.cutlass_act_sf = qs->cutlass_act_sf;
-                args.cutlass_workspace = qs->cutlass_workspace;
-                args.cutlass_workspace_size = qs->cutlass_workspace_size;
-                GemmStrategy strat{StorageTier::CUTLASS_NVFP4, QType::F16, /*m_is_one=*/false};
-                if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                    return;
-                // PreconditionFail (missing workspace or CUTLASS returned
-                // false) — fall through to the dequant GEMM below.
-            }
-        }
-        // NVFP4 prefill GEMM (M>1, dequant→cuBLAS fallback). Mirror
-        // gemm_dispatch_impl:2186-2188. Slice 5 above already handled the
-        // CUTLASS-eligible case; this branch is the fallback when CUTLASS
-        // isn't available (no ct4 cache, no ct4 hit, missing scratch) or the
-        // CUTLASS run returned PreconditionFail. The earlier `!cutlass_path_
-        // eligible` guard is gone now that Slice 5 owns the preferred path.
-        if (M > 1 && input.qtype == QType::F16) {
-            NvFP4QuantResult nvfp4_tmp;
-            const NvFP4QuantResult* nvfp4_view = nullptr;
-            if (weight.qtype == QType::NVFP4 && weight.scales != nullptr) {
-                nvfp4_tmp.packed_data = weight.data;
-                nvfp4_tmp.micro_scales = weight.scales;
-                nvfp4_tmp.tensor_scale = weight.tensor_scale;
-                nvfp4_tmp.N = weight.shape[0];
-                nvfp4_tmp.K = weight.shape[1] * 2;  // shape[1] is packed K/2
-                nvfp4_view = &nvfp4_tmp;
-            } else if (nv4 != nullptr) {
-                auto it = nv4->find(weight.data);
-                if (it != nv4->end())
-                    nvfp4_view = &it->second;
-            }
-            if (nvfp4_view != nullptr) {
-                GemmKernelArgs args{};
-                args.input = &input;
-                args.output = &output;
-                args.stream = ctx.stream;
-                args.beta = ctx.beta;
-                args.weight_payload = nvfp4_view;
-                GemmStrategy strat{StorageTier::NVFP4, QType::F16, /*m_is_one=*/false};
-                if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                    return;
-            }
-        }
-        // The FP16 path is structurally simple — direct cuBLAS via the
-        // fp16 weight cache OR the raw weight when it's already FP16/BF16.
-        // Match the legacy preconditions: prefer the cache, then raw weight.
-        if (auto it = wc->fp16.find(weight.data); it != wc->fp16.end()) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.weight_payload = &it->second;
-            GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-        if ((qtype == QType::F16 || qtype == QType::BF16) && weight.qtype == QType::F16) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.weight_payload = &weight;
-            GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-        // Slice 7 + Slice 8.2 — GGUF small-M (mmvq / dp4a / fused-gemv)
-        // dispatch. Only fires for M==1 with FP16 input and a non-FP32
-        // output, mirroring the legacy mmvq + dp4a gates at
-        // gemm_dispatch_impl:2216-2222 and the fused-gemv fallback at lines
-        // 2267-2276. Per-qtype strategies (Option 2 scope decision — see
-        // gemm_kernel_gguf.cu header) and the handler internally selects
-        // mmvq vs dp4a vs fused-gemv based on the same RuntimeConfig fields
-        // and workspace sentinels the legacy switch reads.
-        // `prefer_fp16_cache` remains a dispatch-site gate because it
-        // depends on `fp16` cache membership + stride, which isn't part of
-        // GemmKernelArgs. `dequant_scratch` is passed as an engine-ready
-        // sentinel for Slice 8.2's fused-gemv branch (the legacy gate at
-        // line 2267/2272 checks the same pointer).
-        const bool fp32_output = (output.qtype == QType::F32);
-        const bool prefer_fp16_cache =
-            (fp16 != nullptr && fp16->count(weight.data) > 0 && input.stride[0] != weight.shape[1]);
-        if (M == 1 && input.qtype == QType::F16 && !fp32_output && !prefer_fp16_cache) {
+    const int M = static_cast<int>(input.shape[0]);
+
+    // MXFP4 native GGUF (top priority). The kernel adapter gates internally
+    // on `linear_scales != nullptr`; cache miss + dequant_scratch nullptr at
+    // M>1 returns PreconditionFail so we fall through to the rest of the
+    // table — same as the legacy `else if (dequant_scratch != nullptr)` skip.
+    if (mx4 != nullptr && input.qtype == QType::F16) {
+        auto mx_it = mx4->find(weight.data);
+        if (mx_it != mx4->end() && mx_it->second.linear_scales != nullptr) {
             GemmKernelArgs args{};
             args.input = &input;
             args.output = &output;
             args.stream = ctx.stream;
             args.beta = ctx.beta;
-            args.weight_payload = &weight;
-            args.q8_1_buf = qs->q8_1_buf;
-            args.d8_buf = qs->d8_buf;
-            args.dequant_scratch = qs->dequant;  // Slice 8.2 fused-gemv readiness sentinel
-            GemmStrategy strat{StorageTier::FP16, qtype, /*m_is_one=*/true};
-            auto rc = GemmKernelRegistry::instance().dispatch(strat, args);
-            if (rc == GemmDispatchResult::Ok)
+            args.weight_payload = &mx_it->second;
+            args.dequant_scratch = qs->dequant;  // only consumed by M>1 path
+            GemmStrategy strat{StorageTier::MXFP4, QType::F16, /*m_is_one=*/(M == 1)};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;
-            // NoMatch (qtype not in slice 7/8.2 set) or PreconditionFail (no
-            // backend matched — neither mmvq nor dp4a nor fused-gemv) —
-            // fall through to legacy. Same semantics as the legacy `else if`
-            // chain continuing past the mmvq/dp4a/fused-gemv branches.
         }
-        // Slice 8.5 — qtype-agnostic generic-dequant catch-all (M>1 prefill).
-        // Mirrors the legacy fallback at gemm_dispatch_impl:2313-2319: when no
-        // tier-specific dispatcher matched and the weight qtype is dequantable
-        // via `dequant_gpu`, dequant the raw bytes into the FP16 scratch and
-        // run cuBLAS. Strategy key (FP16, NONE, m_is_one=false) is qtype-
-        // agnostic — the handler reads weight.qtype off the Tensor and
-        // switches via `dequant_gpu_supported`. PreconditionFail (missing
-        // scratch or unsupported qtype) drops through to legacy, which has a
-        // final raw `gemm()` arm for the FP16/BF16 case at line 2322.
-        if (M > 1 && input.qtype == QType::F16) {
+    }
+    // FP8 prefill (M>1): cache hit → FP8xFP8 cuBLASLt; cache miss with
+    // dequant-supported qtype → dequant→FP16 cuBLAS (Slice 8.1). Raw FP16
+    // weights drop to the FP16 strategy below.
+    if (fp8 != nullptr && M > 1 && qs->fp8_act != nullptr && qs->d_act_scale != nullptr) {
+        auto it = fp8->find(weight.data);
+        if (it != fp8->end()) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.beta = ctx.beta;
+            args.weight_payload = &it->second;
+            args.fp8_act_buf = qs->fp8_act;
+            args.d_act_scale = qs->d_act_scale;
+            args.d_fp8_block_maxes = qs->d_fp8_block_maxes;
+            args.d_fp8_absmax = qs->d_fp8_absmax;
+            args.fp8_max_grid = qs->fp8_max_grid;
+            GemmStrategy strat{StorageTier::FP8, QType::F16, /*m_is_one=*/false};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        } else {
             GemmKernelArgs args{};
             args.input = &input;
             args.output = &output;
@@ -2616,19 +2097,167 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             args.beta = ctx.beta;
             args.weight_payload = &weight;
             args.dequant_scratch = qs->dequant;
-            GemmStrategy strat{StorageTier::FP16, QType::NONE, /*m_is_one=*/false};
+            GemmStrategy strat{StorageTier::FP8, QType::NONE, /*m_is_one=*/false};
             if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;
         }
-        // Fall through: registry returned NoMatch for this strategy — use legacy.
     }
-
-    gemm_dispatch_impl(input, weight, Tensor(), qtype, output, qs->dequant, ctx.stream,
-                       static_cast<block_q8_1*>(qs->q8_1_buf), qs->d8_buf, fp16, fp8, qs->fp8_act,
-                       qs->d_act_scale, qs->d_fp8_block_maxes, qs->d_fp8_absmax, qs->fp8_max_grid, nv4, ct4,
-                       qs->cutlass_act_data, qs->cutlass_act_sf, qs->cutlass_workspace,
-                       qs->cutlass_workspace_size, mx4, qs->mxfp4_act_sf, qs->mxfp4_workspace,
-                       qs->mxfp4_workspace_size, ctx.beta);
+    // NVFP4 decode GEMV (M==1). Prequant Tensor sidecars (qtype=NVFP4 on the
+    // weight) take precedence over the nv4 cache; the temp NvFP4QuantResult
+    // is constructed here when sidecars are present.
+    if (M == 1 && input.qtype == QType::F16) {
+        NvFP4QuantResult nvfp4_tmp;
+        const NvFP4QuantResult* nvfp4_view = nullptr;
+        if (weight.qtype == QType::NVFP4 && weight.scales != nullptr) {
+            nvfp4_tmp.packed_data = weight.data;
+            nvfp4_tmp.micro_scales = weight.scales;
+            nvfp4_tmp.tensor_scale = weight.tensor_scale;
+            nvfp4_tmp.N = weight.shape[0];
+            nvfp4_tmp.K = weight.shape[1] * 2;  // shape[1] is packed K/2
+            nvfp4_view = &nvfp4_tmp;
+        } else if (nv4 != nullptr) {
+            auto it = nv4->find(weight.data);
+            if (it != nv4->end())
+                nvfp4_view = &it->second;
+        }
+        if (nvfp4_view != nullptr) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.beta = ctx.beta;
+            args.weight_payload = nvfp4_view;
+            GemmStrategy strat{StorageTier::NVFP4, QType::F16, /*m_is_one=*/true};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        }
+    }
+    // CUTLASS_NVFP4 prefill GEMM (M>1, native sm_120 block-scaled FP4 —
+    // preferred path). Slice 8.6 — QW7 dual-cache MXFP4 hand-off. When
+    // `--mxfp4-prefill` is on, executor_pre_dequant.cu populates
+    // `cutlass_mxfp4` by iterating every NVFP4 entry: cache membership is a
+    // superset of cutlass_nvfp4. We forward the MXFP4 payload + scratch
+    // through `args.mxfp4_payload` so the handler can try the MXFP4 CUTLASS
+    // GEMM first and fall back to NVFP4 CUTLASS on failure (mirrors the
+    // retired legacy QW7 probe).
+    if (M > 1 && input.qtype == QType::F16 && ct4 != nullptr &&
+        qs->cutlass_act_data != nullptr) {
+        auto ct_it = ct4->find(weight.data);
+        if (ct_it != ct4->end()) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.beta = ctx.beta;
+            args.weight_payload = &ct_it->second;
+            args.cutlass_act_data = qs->cutlass_act_data;
+            args.cutlass_act_sf = qs->cutlass_act_sf;
+            args.cutlass_workspace = qs->cutlass_workspace;
+            args.cutlass_workspace_size = qs->cutlass_workspace_size;
+            if (mx4 != nullptr && qs->mxfp4_act_sf != nullptr) {
+                auto mx_it = mx4->find(weight.data);
+                if (mx_it != mx4->end()) {
+                    args.mxfp4_payload = &mx_it->second;
+                    args.mxfp4_act_sf = qs->mxfp4_act_sf;
+                    args.mxfp4_workspace = qs->mxfp4_workspace;
+                    args.mxfp4_workspace_size = qs->mxfp4_workspace_size;
+                }
+            }
+            GemmStrategy strat{StorageTier::CUTLASS_NVFP4, QType::F16, /*m_is_one=*/false};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        }
+    }
+    // NVFP4 prefill GEMM (M>1, dequant→cuBLAS fallback) — fires when the
+    // CUTLASS path is unavailable or returned PreconditionFail.
+    if (M > 1 && input.qtype == QType::F16) {
+        NvFP4QuantResult nvfp4_tmp;
+        const NvFP4QuantResult* nvfp4_view = nullptr;
+        if (weight.qtype == QType::NVFP4 && weight.scales != nullptr) {
+            nvfp4_tmp.packed_data = weight.data;
+            nvfp4_tmp.micro_scales = weight.scales;
+            nvfp4_tmp.tensor_scale = weight.tensor_scale;
+            nvfp4_tmp.N = weight.shape[0];
+            nvfp4_tmp.K = weight.shape[1] * 2;  // shape[1] is packed K/2
+            nvfp4_view = &nvfp4_tmp;
+        } else if (nv4 != nullptr) {
+            auto it = nv4->find(weight.data);
+            if (it != nv4->end())
+                nvfp4_view = &it->second;
+        }
+        if (nvfp4_view != nullptr) {
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.beta = ctx.beta;
+            args.weight_payload = nvfp4_view;
+            GemmStrategy strat{StorageTier::NVFP4, QType::F16, /*m_is_one=*/false};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        }
+    }
+    // FP16 cache hit OR raw FP16/BF16-source weight (BF16 source is always
+    // converted to F16 at upload; weight.qtype is F16 here).
+    if (auto it = wc->fp16.find(weight.data); it != wc->fp16.end()) {
+        GemmKernelArgs args{};
+        args.input = &input;
+        args.output = &output;
+        args.stream = ctx.stream;
+        args.weight_payload = &it->second;
+        GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
+        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+            return;
+    }
+    if ((qtype == QType::F16 || qtype == QType::BF16) && weight.qtype == QType::F16) {
+        GemmKernelArgs args{};
+        args.input = &input;
+        args.output = &output;
+        args.stream = ctx.stream;
+        args.weight_payload = &weight;
+        GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
+        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+            return;
+    }
+    // GGUF small-M (mmvq / dp4a / fused-gemv): M==1, FP16 input, non-FP32
+    // output. `prefer_fp16_cache` keeps the cache-vs-raw decision at the
+    // dispatch site because it depends on cache membership + stride — not
+    // expressible via GemmKernelArgs alone.
+    const bool fp32_output = (output.qtype == QType::F32);
+    const bool prefer_fp16_cache =
+        (fp16 != nullptr && fp16->count(weight.data) > 0 && input.stride[0] != weight.shape[1]);
+    if (M == 1 && input.qtype == QType::F16 && !fp32_output && !prefer_fp16_cache) {
+        GemmKernelArgs args{};
+        args.input = &input;
+        args.output = &output;
+        args.stream = ctx.stream;
+        args.beta = ctx.beta;
+        args.weight_payload = &weight;
+        args.q8_1_buf = qs->q8_1_buf;
+        args.d8_buf = qs->d8_buf;
+        args.dequant_scratch = qs->dequant;  // fused-gemv readiness sentinel
+        GemmStrategy strat{StorageTier::FP16, qtype, /*m_is_one=*/true};
+        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+            return;
+    }
+    // Qtype-agnostic generic-dequant catch-all (M>1 prefill). Handler reads
+    // weight.qtype off the Tensor and switches via `dequant_gpu_supported`.
+    if (M > 1 && input.qtype == QType::F16) {
+        GemmKernelArgs args{};
+        args.input = &input;
+        args.output = &output;
+        args.stream = ctx.stream;
+        args.beta = ctx.beta;
+        args.weight_payload = &weight;
+        args.dequant_scratch = qs->dequant;
+        GemmStrategy strat{StorageTier::FP16, QType::NONE, /*m_is_one=*/false};
+        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+            return;
+    }
+    // Final fallback: raw FP16/BF16 cuBLAS. Reached only when none of the
+    // tiers above match — typically a raw FP16/BF16 weight at a shape no
+    // cache covered. Matches the legacy `else { gemm(...); }` arm.
+    gemm(input, weight, output, 1.0f, 0.0f, ctx.stream);
 }
 
 }  // namespace imp

--- a/src/graph/executor_kernels.h
+++ b/src/graph/executor_kernels.h
@@ -300,13 +300,7 @@ Tensor slice_rows(const Tensor& buf, int n_tokens);
 struct GemmContext;  // forward decl — defined in gemm_context.h
 void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, const GemmContext& ctx);
 
-// ---------------------------------------------------------------------------
-// Pre-warm the MMVQ (Q8_1-input GEMV) scratch buffer so the first call into
-// the ggml_mmvq_q* path inside CUDA stream capture doesn't trigger a
-// cudaMalloc. Call once during workspace allocation with the largest
-// (max_tokens, max_K) the model can dispatch. Idempotent: a re-call with a
-// smaller size is a no-op; a re-call with a larger size grows the buffer.
-// ---------------------------------------------------------------------------
-void prewarm_mmvq_scratch(int max_tokens, int max_K);
+// MMVQ scratch buffer prewarm + hot-path getter live in gemm_scratch.h since
+// R5 Slice 8.6 (TU hoist).
 
 }  // namespace imp

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -5,6 +5,7 @@
 #include "graph/executor.h"
 #include "graph/executor_kernels.h"
 #include "graph/executor_helpers.h"
+#include "graph/gemm_scratch.h"  // prewarm_mmvq_scratch
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
 #include "compute/sampling.h"

--- a/src/graph/gemm_kernel_cutlass_nvfp4.cu
+++ b/src/graph/gemm_kernel_cutlass_nvfp4.cu
@@ -1,5 +1,6 @@
 #include "graph/gemm_kernel_registry.h"
 
+#include "compute/gemm_cutlass_mxfp4_sm120.h"  // CutlassMxFP4Weight, gemm_mxfp4_cutlass_sm120 (QW7 dual-cache path)
 #include "compute/gemm_cutlass_sm120.h"  // CutlassNvFP4Weight, gemm_nvfp4_cutlass_sm120, quantize_fp16_to_nvfp4_cutlass
 #include "core/logging.h"
 #include "core/tensor.h"
@@ -7,22 +8,31 @@
 namespace imp {
 
 // ---------------------------------------------------------------------------
-// CUTLASS_NVFP4 tier — R5 Slice 5.
+// CUTLASS_NVFP4 tier — R5 Slice 5 + Slice 8.6 (QW7 dual-cache integration).
 //
 // Adapter that wraps the existing CUTLASS sm_120 block-scaled NVFP4 GEMM
-// from gemm_dispatch_impl (executor_kernels.cu:2147-2183): quantize the FP16
-// activation into the pre-allocated CUTLASS NVFP4 scratch (`cutlass_act_data`
-// + `cutlass_act_sf`), then run `gemm_nvfp4_cutlass_sm120` against the
-// pre-converted CUTLASS weight payload. This is the *preferred* NVFP4 GEMM
-// path — used when the loader has populated `cutlass_nvfp4_cache` AND the
-// workspace pointers are present; otherwise Slice 4's dequant fallback
-// (gemm_nvfp4) takes over.
+// from the retired gemm_dispatch_impl: quantize the FP16 activation into the
+// pre-allocated CUTLASS NVFP4 scratch (`cutlass_act_data` + `cutlass_act_sf`),
+// then run `gemm_nvfp4_cutlass_sm120` against the pre-converted CUTLASS
+// weight payload. This is the *preferred* NVFP4 GEMM path — used when the
+// loader has populated `cutlass_nvfp4_cache` AND the workspace pointers are
+// present; otherwise Slice 4's dequant fallback (gemm_nvfp4) takes over.
 //
 // Strategy: tier=CUTLASS_NVFP4, weight_qtype=F16 (engine observes FP16 source
 // qtype for an NVFP4-cached weight; the CUTLASS conversion happened at load
 // time and lives in the CutlassNvFP4Weight), m_is_one=false. The (M==1)
 // decode case never reaches the CUTLASS path in legacy — it goes to the
 // faster gemv_nvfp4_kpar (Slice 3) — so we only register the prefill slot.
+//
+// QW7 dual-cache MXFP4 branch (Slice 8.6): when `--mxfp4-prefill` is enabled
+// the loader builds `cutlass_mxfp4` alongside `cutlass_nvfp4` (executor_pre_
+// dequant.cu:1419-1444 iterates every NVFP4 entry with K%32==0 and converts
+// the scales to UE8M0 MXFP4). When BOTH caches hit the same `weight.data`,
+// the legacy switch tried MXFP4 CUTLASS first and fell back to NVFP4 CUTLASS
+// on failure. Slice 8.6 migrates this into the same handler by forwarding
+// the optional `mxfp4_payload` + `mxfp4_act_sf` + `mxfp4_workspace` fields
+// from the dispatch site. nullptr `mxfp4_payload` = no dual-cache hit, skip
+// straight to the NVFP4 path.
 //
 // Preconditions checked here (and at the dispatch site for fast fail):
 // - input/output/weight_payload non-null
@@ -58,6 +68,30 @@ static GemmDispatchResult cutlass_nvfp4_gemm_kernel(const GemmKernelArgs& args) 
     const int M = static_cast<int>(args.input->shape[0]);
     const int K = static_cast<int>(args.input->shape[1]);
     const int N = static_cast<int>(payload.N);
+
+    // QW7 dual-cache MXFP4 branch (Slice 8.6 — was a probe in legacy lines
+    // 2149-2174). Fires only when (a) the dispatch site found a matching
+    // entry in `cutlass_mxfp4` for the same weight.data and (b) the MXFP4
+    // activation scratch is allocated and (c) K is a multiple of the UE8M0
+    // SfAtom group (32). We re-use the NVFP4 activation data buffer because
+    // the packed E2M1 layout is the same — only the scale factor layout
+    // differs (UE8M0 per 32 vs UE4M3 per 16 for NVFP4).
+    if (args.mxfp4_payload != nullptr && args.mxfp4_act_sf != nullptr && K % 32 == 0) {
+        const CutlassMxFP4Weight& mx_payload =
+            *static_cast<const CutlassMxFP4Weight*>(args.mxfp4_payload);
+        quantize_fp16_to_mxfp4_cutlass(args.input->data, args.cutlass_act_data, args.mxfp4_act_sf, M, K,
+                                       args.stream);
+        bool mx_ok = gemm_mxfp4_cutlass_sm120(args.cutlass_act_data, args.mxfp4_act_sf, mx_payload,
+                                              args.output->data, M, N, K, args.mxfp4_workspace,
+                                              args.mxfp4_workspace_size, args.stream);
+        if (mx_ok)
+            return GemmDispatchResult::Ok;
+        // MXFP4 CUTLASS rejected the dims — fall through to NVFP4 CUTLASS
+        // below. Mirrors the legacy `if (ok) return;` drop-through. The
+        // activation buffer is reusable because quantize_fp16_to_nvfp4_cutlass
+        // overwrites it (separate scale buffer too — cutlass_act_sf vs
+        // mxfp4_act_sf).
+    }
 
     // Mirror executor_kernels.cu:2147 + 2179-2181 verbatim — same activation
     // quantization step, same CUTLASS GEMM call, same arg order.

--- a/src/graph/gemm_kernel_gguf.cu
+++ b/src/graph/gemm_kernel_gguf.cu
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include "core/tensor.h"
 #include "graph/executor_kernels.h"  // is_dp4a_qtype, dispatch_dp4a_gemv, block_q8_1
+#include "graph/gemm_scratch.h"  // mmvq_scratch_get_or_grow (Slice 8.6 hoist)
 #include "runtime/config.h"
 
 #include <cuda_fp16.h>
@@ -93,10 +94,10 @@ namespace imp {
 // returns NoMatch / PreconditionFail. Slice 8 retires the legacy switch.
 // ---------------------------------------------------------------------------
 
-// Forward declarations — single-global mmvq scratch lives in
-// executor_kernels.cu. Calling it via prototype keeps the invariant
-// without widening the public header surface in this slice.
-void mmvq_scratch_get_or_grow(size_t need, void** out_buf, size_t* out_size);
+// `mmvq_scratch_get_or_grow` lives in graph/gemm_scratch.h since Slice 8.6
+// (TU hoist). Engine init MUST call `prewarm_mmvq_scratch` from
+// `executor_workspace_buffers.cu` with the model's largest dims before the
+// hot path fires — see gemm_scratch.h.
 
 // ---------------------------------------------------------------------------
 // Backend helpers — small, qtype-parameterised. Both backends are M==1 only

--- a/src/graph/gemm_kernel_registry.h
+++ b/src/graph/gemm_kernel_registry.h
@@ -83,6 +83,16 @@ struct GemmKernelArgs {
     void* mxfp4_act_sf = nullptr;
     void* mxfp4_workspace = nullptr;
     size_t mxfp4_workspace_size = 0;
+    // R5 Slice 8.6 — QW7 dual-cache CUTLASS MXFP4 hand-off. When the
+    // CUTLASS_NVFP4 strategy fires AND the same `weight.data` is also present
+    // in the `cutlass_mxfp4` cache (only happens when `--mxfp4-prefill` is on,
+    // because executor_pre_dequant.cu builds the mxfp4 cache by iterating
+    // every NVFP4 entry), the dispatch site forwards the MXFP4 payload here
+    // so the handler can try the MXFP4 CUTLASS GEMM before falling back to
+    // the NVFP4 CUTLASS GEMM. nullptr = no dual-cache hit, take the NVFP4
+    // path directly. See cutlass_nvfp4_gemm_kernel in
+    // gemm_kernel_cutlass_nvfp4.cu for the branching logic.
+    const void* mxfp4_payload = nullptr;
     void* fp8_act_buf = nullptr;
     float* d_act_scale = nullptr;
     float* d_fp8_block_maxes = nullptr;

--- a/src/graph/gemm_scratch.cu
+++ b/src/graph/gemm_scratch.cu
@@ -1,0 +1,81 @@
+#include "graph/gemm_scratch.h"
+
+#include "core/logging.h"
+
+#include <cuda_runtime.h>
+#include <atomic>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// MMVQ (Q8_1-input GEMV) scratch — file-scope, sized once at workspace init
+// via prewarm_mmvq_scratch(). The hot-path mmvq_scratch_get_or_grow() reads
+// the cached size; the grow branch (cudaFree+cudaMalloc) is the cold-path
+// fallback and capture-unsafe — engine init MUST prewarm to model max dims.
+//
+// R5 Slice 8.6: hoisted out of executor_kernels.cu now that the legacy
+// `gemm_dispatch_impl` switch is retired. Single-TU ownership keeps the
+// global state private to this unit and the public header declares only
+// the two entry points.
+// ---------------------------------------------------------------------------
+namespace {
+void* g_mmvq_scratch = nullptr;
+size_t g_mmvq_scratch_size = 0;
+}  // namespace
+
+void prewarm_mmvq_scratch(int max_tokens, int max_K) {
+    if (max_tokens <= 0 || max_K <= 0)
+        return;
+    const size_t per_call = static_cast<size_t>(max_tokens) * ((max_K + 31) / 32) * 36;
+    const size_t need = per_call * 2;
+    if (g_mmvq_scratch && g_mmvq_scratch_size >= need)
+        return;
+    if (g_mmvq_scratch)
+        IMP_CUDA_CHECK_LOG(cudaFree(g_mmvq_scratch));
+    cudaError_t err = cudaMalloc(&g_mmvq_scratch, need);
+    if (err != cudaSuccess) {
+        IMP_LOG_ERROR("prewarm_mmvq_scratch: cudaMalloc(%zu) failed: %s", need,
+                      cudaGetErrorString(err));
+        g_mmvq_scratch = nullptr;
+        g_mmvq_scratch_size = 0;
+        return;
+    }
+    g_mmvq_scratch_size = need;
+    IMP_LOG_INFO("MMVQ scratch pre-warmed: %.2f KiB (max_tokens=%d, max_K=%d)",
+                 need / 1024.0, max_tokens, max_K);
+}
+
+void mmvq_scratch_get_or_grow(std::size_t need, void** out_buf, std::size_t* out_size) {
+    if (g_mmvq_scratch && g_mmvq_scratch_size >= need) {
+        *out_buf = g_mmvq_scratch;
+        *out_size = g_mmvq_scratch_size;
+        return;
+    }
+    // Cold path: prewarm missed (or model dim changed mid-run). Re-grow.
+    // Capture-unsafe; emits one ERROR log so the missing prewarm is visible.
+    static std::atomic<bool> s_warned{false};
+    if (!s_warned.exchange(true)) {
+        IMP_LOG_ERROR(
+            "mmvq_scratch_get_or_grow: hot-path grow fired (need=%zu, have=%zu) — "
+            "engine init did not call prewarm_mmvq_scratch() with the model's "
+            "(max_tokens, max_K). cudaMalloc inside graph capture will fail.",
+            need, g_mmvq_scratch_size);
+    }
+    if (g_mmvq_scratch)
+        IMP_CUDA_CHECK_LOG(cudaFree(g_mmvq_scratch));
+    cudaError_t err = cudaMalloc(&g_mmvq_scratch, need * 2);
+    if (err != cudaSuccess) {
+        IMP_LOG_ERROR("mmvq_scratch_get_or_grow: cudaMalloc(%zu) failed: %s", need * 2,
+                      cudaGetErrorString(err));
+        g_mmvq_scratch = nullptr;
+        g_mmvq_scratch_size = 0;
+        *out_buf = nullptr;
+        *out_size = 0;
+        return;
+    }
+    g_mmvq_scratch_size = need * 2;
+    *out_buf = g_mmvq_scratch;
+    *out_size = g_mmvq_scratch_size;
+}
+
+}  // namespace imp

--- a/src/graph/gemm_scratch.h
+++ b/src/graph/gemm_scratch.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// MMVQ (Q8_1-input GEMV) scratch — single file-scope buffer shared between
+// the mmvq dispatch in `gemm_kernel_gguf.cu` and engine workspace init in
+// `executor_workspace_buffers.cu`. R5 Slice 8.6 hoisted these out of
+// `executor_kernels.cu` into their own TU now that the legacy
+// `gemm_dispatch_impl` switch is retired and the only remaining consumer of
+// `mmvq_scratch_get_or_grow` is the GGUF registry kernel.
+//
+// `prewarm_mmvq_scratch(max_tokens, max_K)` is called once at engine init
+// with the model's largest expected dims. Idempotent: re-call with a smaller
+// size is a no-op; re-call with a larger size grows the buffer. Without a
+// prewarm, the first hot-path call into `mmvq_scratch_get_or_grow` triggers
+// a `cudaMalloc` which is unsafe under CUDA graph capture — the cold path
+// emits one ERROR log so the missing prewarm is visible.
+
+#include <cstddef>
+
+namespace imp {
+
+void prewarm_mmvq_scratch(int max_tokens, int max_K);
+
+// Hot-path getter. Returns the cached buffer if `g_mmvq_scratch_size >= need`,
+// otherwise grows (capture-unsafe; emits a one-shot ERROR log).
+void mmvq_scratch_get_or_grow(std::size_t need, void** out_buf, std::size_t* out_size);
+
+}  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -196,8 +196,6 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.no_mmvq = parse_bool(val, cfg.gemm.no_mmvq);
     else if (eq("gemm.no_mmvq_q8_0"))
         cfg.gemm.no_mmvq_q8_0 = parse_bool(val, cfg.gemm.no_mmvq_q8_0);
-    else if (eq("gemm.use_kernel_registry"))
-        cfg.gemm.use_kernel_registry = parse_bool(val, cfg.gemm.use_kernel_registry);
 
     // [gemma4]
     else if (eq("gemma4.fp32_gemm_out"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -145,16 +145,6 @@ struct RuntimeConfig {
         bool no_dp4a_lm = false;
         bool no_mmvq = false;
         bool no_mmvq_q8_0 = false;
-        // R5 (review/phase5_synthesis.md §5): the GemmKernel registry handles
-        // the migrated tiers (FP16, FP8 prefill, NVFP4 GEMV+GEMM, CUTLASS_NVFP4,
-        // MXFP4 GEMV+GEMM, GGUF small-M mmvq/dp4a for 8 qtypes). Slice 8 flips
-        // the default ON — production now reaches the registry first and falls
-        // through to the legacy `gemm_dispatch_impl` for the remaining uncovered
-        // cases (QW7 dual-cache MXFP4 probe, Q4_1 quant_gemm_int4, fused
-        // Q6_K/Q8_0 GEMV fallback when mmvq/dp4a skip, M>1 dequant+cuBLAS
-        // large-M fallback, FP8 cache-miss fallback). Setting this OFF still
-        // works as an escape hatch — every dispatch goes straight to legacy.
-        bool use_kernel_registry = true;
     } gemm;
 
     struct Gemma4 {


### PR DESCRIPTION
## Summary

**The FINAL R5 slice.** Closes the GEMM dispatch unification refactor end-to-end. Deletes the legacy \`gemm_dispatch_impl\` switch, retires the \`gemm.use_kernel_registry\` flag (registry becomes the unconditional path), migrates the QW7 dual-cache CUTLASS MXFP4 probe into the registry, and hoists \`mmvq_scratch_get_or_grow\` into its own TU.

**−237 net LOC** across 12 files (+370 / −607). \`executor_kernels.cu\` alone: 2634 → 2263 (−371).

## Coverage audit — every legacy branch closed

| Legacy branch | Status | Closed by |
|---|---|---|
| MXFP4 GEMV/GEMM (M==1, M>1) | covered | Slice 6 (#213) |
| **QW7 dual-cache CUTLASS MXFP4** | **migrated** | **Slice 8.6 (this PR)** |
| NVFP4 GEMV (M==1) | covered | Slice 3 (#210) |
| CUTLASS_NVFP4 GEMM (M>1) | covered | Slice 5 (#212) |
| NVFP4 dequant GEMM fallback | covered | Slice 4 (#211) |
| MMVQ / dp4a M==1 (8 qtypes) | covered | Slice 7 (#214) |
| Q6_K / Q8_0 fused-gemv fallback | covered | Slice 8.2 (#220) |
| FP8 prefill cache hit | covered | Slice 2 (#209) |
| FP8 cache-miss dequant | covered | Slice 8.1 (#217) |
| Q4_1 paths (dead) | deleted | Slice 8.3 (#221) |
| FP16 cache / raw FP16 weight | covered | Slice 1 (#197) |
| \`fp16_cache\` for non-F16 weight | covered (no-op) | Slice 8.4 |
| Generic-dequant catch-all (M>1) | covered | Slice 8.5 (#225) |
| Final raw FP16/BF16 \`gemm()\` | inlined defensive net | Slice 8.6 (this PR) |

## QW7 decision: migrated (not deleted)

The probe fires only under explicit \`--mxfp4-prefill\` opt-in (off-by-default; documented in \`docs/performance.md:143\`). Deleting would silently break this user-facing knob. Migration cost: one optional field on \`GemmKernelArgs\` (\`mxfp4_payload\`) + ~30 lines inside \`cutlass_nvfp4_gemm_kernel\` — same drop-through pattern as the legacy probe, just relocated into the per-tier handler.

## Changes

- **\`gemm_dispatch_impl\` deleted** (−247 lines, the entire function).
- **\`gemm.use_kernel_registry\` config field + parser line deleted** from \`RuntimeConfig::Gemm\` in \`src/runtime/config.{h,cpp}\`.
- **\`if (RuntimeConfig::current().gemm.use_kernel_registry)\` early-out deleted** in \`gemm_dispatch\`; registry is now the unconditional path.
- **Legacy comment block at top of \`gemm_dispatch_impl\` deleted**.
- **\`mmvq_scratch_get_or_grow\` + \`prewarm_mmvq_scratch\` hoisted** into new TU \`src/graph/gemm_scratch.{h,cu}\`. Forward-decl shim in \`gemm_kernel_gguf.cu\` replaced with \`#include\`. Declaration removed from \`executor_kernels.h\`.
- **QW7 probe migrated**: \`cutlass_nvfp4_gemm_kernel\` now tries MXFP4 first when a dual-cache hit is present (via \`args.mxfp4_payload\`), falls back to NVFP4 CUTLASS on MXFP4 launch failure.

## Architectural notes

- **BF16 "raw-weight FP16 fallback" was a phantom branch.** \`weight_upload.cu:600,625\` converts BF16 → FP16 at upload time; \`weight.qtype\` is never BF16 on the GPU side. Slice 1's FP16 strategy covers what was incorrectly flagged as "still open" in the original Slice 8 audit (#215).
- **The final defensive \`gemm()\` net** at the end of \`gemm_dispatch\` is unreachable in practice (Slice 1 covers every realistic case) but kept for safety against pathological partial-cache configurations during init.

## Test plan

- [x] \`make build\` PASS
- [x] \`make verify-fast\` PASS
- [x] **39/39 \`GemmKernelRegistryTest.*\` PASS** (unchanged from Slice 8.5)
- [x] **163/163 \`test-compute\` PASS**
- [x] \`imp-tests-unit\`: 151 + 37 + 157 PASS
- [x] Smoke prompt: Gemma-3-12B Q4_K_M coherent output, no degeneration
- Pre-existing failures on parent \`b217769\` (\`EngineIntegrationTest.MoEInitSucceeds\`, \`WeightDispatchTest.NVFP4_GemmMatchesDirect\`) reproduced — not introduced by this slice.

## R5 IS DONE

First major roadmap item closed end-to-end: Slice 1 (PR #197) through Slice 8.6 (this PR). The strategy-keyed \`GemmKernel\` registry is the sole dispatch path; adding a new qtype/quantization tier is a single-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)