### PR TITLE
fix(graph): QW8 da_cache gate — skip host-resident + require built > 0

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -2441,6 +2441,7 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 
         int eligible_layers = 0;  // layers that have any MoE expert ptrs
         int built_layers = 0;
+        int host_resident_layers = 0;  // intentionally not built (force_host or budget offload)
         std::vector<int> failed_layers;
         for (int li = 0; li < n_layers; ++li) {
             const auto& L = model_->layer(li);
@@ -2451,6 +2452,23 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 // Pure dense layer in a hybrid model (e.g. attention-only layer
                 // alongside MoE layers). Not eligible for the da_cache; skip
                 // without counting against the must-populate gate.
+                continue;
+            }
+            // Host-resident layers (host-offload / force_host_experts) by
+            // design have no CUTLASS NVFP4 weight payload — the per-layer
+            // fallback dispatch is the intended path. Don't count these as
+            // QW8 build failures. Detect via either packed-tensor (GGUF Path A)
+            // or per-expert tensor (SafeTensors Path B) staying on host.
+            const bool packed_host = (L.expert_up_packed.data && !L.expert_up_packed.on_device);
+            bool per_expert_host = false;
+            if (!packed_host && !L.expert_w_up.empty()) {
+                // Any per-expert weight on host => layer is host-resident.
+                for (const auto& w : L.expert_w_up) {
+                    if (w.data && !w.on_device) { per_expert_host = true; break; }
+                }
+            }
+            if (packed_host || per_expert_host) {
+                ++host_resident_layers;
                 continue;
             }
             ++eligible_layers;
@@ -2480,7 +2498,13 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
         // mismatched expert layout or a budget that fell short of needed
         // device allocations — the right response is to fail loud at init
         // rather than ship the user a slow build.
-        if (eligible_layers > 0 && built_layers < eligible_layers) {
+        // Only abort on *partial* coverage of device-resident MoE layers
+        // (the genuine "silent 5× regression" case). If nothing built at
+        // all, this model isn't going through the NVFP4 MoE da_cache path
+        // at runtime — log INFO and continue (covers --no-nvfp4 on GGUF
+        // MoE, Q4_K_M / Q6_K MoE without prequant scales, and synthetic
+        // force_host_experts spikes).
+        if (eligible_layers > 0 && built_layers > 0 && built_layers < eligible_layers) {
             std::string failed_str;
             for (size_t i = 0; i < failed_layers.size() && i < 16; ++i) {
                 if (!failed_str.empty()) failed_str += ", ";
@@ -2505,6 +2529,12 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                 built_layers, eligible_layers, ne,
                 (built_layers * 3.0 * ne * (2 * sizeof(void*) + sizeof(float))) /
                     1024.0);
+        }
+        if (host_resident_layers > 0) {
+            IMP_LOG_INFO(
+                "NVFP4 da_cache: skipped %d host-resident MoE layer(s) "
+                "(per-layer fallback / H2D staging is the intended path).",
+                host_resident_layers);
         }
         }  // ne > 0
     }


### PR DESCRIPTION
## Summary

The QW8 NVFP4 MoE da_cache abort at `executor_pre_dequant.cu:2483` is too strict — it fires whenever `built_layers < eligible_layers`, which catches three legitimate "not using NVFP4 MoE da_cache" paths:

1. **`--no-nvfp4` on a GGUF MoE model**: planner schedules NVFP4 entries (`nvfp4=140` in plan-ideal) but the cache isn't built (`nvfp4_moe=0` in wcache actual) → `built=0`, `eligible=N` → abort.
2. **Q4_K_M / Q6_K MoE without prequant scales**: default config tries to populate the NVFP4 MoE cache but only some tensors fit budget (e.g. Qwen3.6-35B Q4_K_M: 32/120 tensors) → partial → abort.
3. **`moe.force_host_experts=N`**: forced host-resident layers can't provide CUTLASS NVFP4 payloads → `built < eligible` → abort.

None of these is the "silent 5× decode regression" QW8 was guarding against. That regression occurs only when NVFP4 MoE decode IS active but partial — e.g. a real load-time bug for some layers' CUTLASS payloads.

## Fix (two axes)

- **Skip host-resident layers** from `eligible_layers`. Detect via packed-tensor (`expert_up_packed.on_device == false`, GGUF Path A) or per-expert tensor (`expert_w_up[e].on_device == false`, SafeTensors Path B). Log an INFO with the skipped count.
- **Require `built_layers > 0 && built_layers < eligible_layers`** for the abort. If nothing built at all, the NVFP4 MoE da_cache path isn't active at runtime — no silent-regression risk.

The original "some built but not all" abort still fires unchanged on real partial-build failures (cudaMalloc OOM for per-layer ptr arrays, mismatched expert layouts, etc.).

## Why now

Surfaced by the MoE host-offload Phase 1 nsys spike on `docs/roadmap-final-state-2026-05-17`. The abort prevented the spike from running at all on three of three candidate configs (Qwen3.6-35B Q4_K_M default, Qwen3.6-35B Q4_K_M `--no-nvfp4`, Qwen3-Coder NVFP4 `force_host_experts=24`). Memo: `memory/moe_host_offload_phase1_findings_2026_05_17.md`.

## Test plan

- [x] `make verify-fast` — passes (gtest filter only on this host; perf/graph/smoke gates skip without baseline models)
- [x] Qwen3-Coder NVFP4 baseline (all-on-GPU, Graphs ON): 268.76 tok/s — NVFP4 MoE da_cache full coverage path unchanged
- [x] Qwen3.6-35B Q4_K_M `--no-nvfp4`: 210.28 tok/s — `built_layers=0` now logs INFO + continues (was: abort)
- [x] Qwen3.6-35B Q4_K_M `--no-nvfp4 --set moe.force_host_experts=20`: 28.57 tok/s — host-resident layers skipped + `built_layers=0` allowed (was: abort)
- [x] Qwen3-Coder NVFP4 `--set moe.force_host_experts=24`: previously triggered the synthetic-spike scenario for nsys; now loads (was: abort at init)
- [ ] CI gate on green build