### PR TITLE
feat(graph): MoE host-offload Phase 2 — device-side LRU mirror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,6 +488,7 @@ if(IMP_BUILD_TESTS)
     imp_add_test_module(test-moe-gdn SOURCES
         tests/test_moe.cu
         tests/test_moe_executor.cu
+        tests/test_expert_cache.cu
         tests/test_gdn.cu
         tests/test_ssm.cu
         tests/test_json_constrain.cu

--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -48,6 +48,13 @@ struct ExpertCacheKeyHash {
     }
 };
 
+// MoE projection enum — every layer has up to three: gate, up, down.
+// Used to index the per-layer × per-projection × per-expert device-side
+// lookup mirror (Phase 2 of the MoE host-offload + CUDA Graphs design,
+// see docs/plans/moe_host_offload_graphs_design_2026_05_17.md §3a).
+enum class ExpertProj { Gate = 0, Up = 1, Down = 2 };
+inline constexpr int kExpertProjCount = 3;
+
 struct ExpertLRUCache {
     // Each slot holds one expert's raw quantized bytes on GPU.
     // Slots are fixed-size (max_expert_raw bytes each).
@@ -55,6 +62,11 @@ struct ExpertLRUCache {
         void* gpu_ptr = nullptr;  // points into pool_
         ExpertCacheKey key = {};
         bool occupied = false;
+        // Mirror coords — set on get_or_load, used to invalidate the device
+        // lookup cell on eviction.
+        int layer = -1;
+        int proj = -1;   // ExpertProj
+        int expert = -1;
     };
 
     void* pool_ = nullptr;     // contiguous GPU allocation for all slots
@@ -73,16 +85,32 @@ struct ExpertLRUCache {
 
     VRAMAllocator* alloc_ = nullptr;
 
-    // Initialize: allocate n_slots * slot_size bytes on GPU.
+    // Device-side lookup mirror (Phase 2). Sized [n_layers × 3 × n_experts]
+    // int32 cells; cell value = slot_idx or -1 if not cached. Read pattern in
+    // Phase 3+: `d_lookup_[layer * 3 * n_experts_ + proj * n_experts_ + expert]`.
+    // Today (Phase 2) the mirror is write-only — kept in sync with the host
+    // LRU so Phase 3 can drop the kernel onto a known-good device-side table.
+    int* d_lookup_ = nullptr;
+    int n_layers_ = 0;
+    int n_experts_ = 0;
+    bool debug_parity_ = false;
+    mutable int64_t parity_checks_ok_ = 0;  // exposed for tests; bumped by const check_parity()
+
+    // Initialize: allocate n_slots * slot_size bytes on GPU + n_layers × 3 ×
+    // n_experts int32 cells for the device-side lookup mirror.
     // Returns false if GPU allocation fails (cache disabled).
-    bool init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc = nullptr);
+    bool init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc,
+              int n_layers, int n_experts, bool debug_parity = false);
 
     // Lookup or insert an expert. Returns GPU pointer to cached expert data.
     // If cache miss: copies from host, evicts LRU entry if needed.
     // src_host = host pointer to this expert's raw bytes.
-    void* get_or_load(ExpertCacheKey key, const void* src_host, size_t expert_bytes, cudaStream_t stream);
+    // `layer` + `proj` identify the mirror cell to update; the cache key
+    // remains (packed_ptr, expert_idx) so the host-side LRU is unchanged.
+    void* get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
+                      const void* src_host, size_t expert_bytes, cudaStream_t stream);
 
-    // Check if expert is cached (no insertion).
+    // Check if expert is cached (no insertion). Updates LRU recency.
     void* find(ExpertCacheKey key);
 
     void destroy();
@@ -91,6 +119,13 @@ struct ExpertLRUCache {
         int64_t total = hits_ + misses_;
         return total > 0 ? static_cast<float>(hits_) / total : 0.0f;
     }
+
+    // Phase 2 debug helper: copy the device lookup mirror back to host and
+    // assert every cell matches the host-side LRU state. Returns true on
+    // match. When `debug_parity_` is enabled, get_or_load() runs this after
+    // every cache mutation and bumps `parity_checks_ok_` on success / aborts
+    // (via IMP_LOG_FATAL) on mismatch. Tests can call it directly.
+    bool check_parity(cudaStream_t stream) const;
 };
 
 // VRAM budget for weight cache allocation (computed by Engine::plan_vram_budget).

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -1225,7 +1225,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                         // Uses slot 0 always -- safe because all ops are on the same stream, so the previous
                         // GEMM reading from slot 0 completes before the next dequant writes to it.
                         auto dequant_expert = [&](const Tensor& packed, QType qtype,
-                                                  int expert_idx) -> Tensor {
+                                                  int expert_idx, ExpertProj proj) -> Tensor {
                             int64_t rows = packed.shape[1];
                             int64_t cols = packed.shape[2];
                             size_t row_bytes = qtype_row_bytes(qtype, cols);
@@ -1260,8 +1260,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                 const char* host_ptr = static_cast<const char*>(packed.data) + offset;
                                 if (expert_cache_.n_slots_ > 0) {
                                     ExpertCacheKey ck{packed.data, expert_idx};
-                                    void* cached = expert_cache_.get_or_load(ck, host_ptr, expert_raw,
-                                                                             stream);
+                                    void* cached = expert_cache_.get_or_load(layer, proj, ck, host_ptr,
+                                                                             expert_raw, stream);
                                     src = static_cast<const char*>(cached);
                                 } else if (moe_.raw_staging_buf) {
                                     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(moe_.raw_staging_buf, host_ptr,
@@ -1292,7 +1292,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                         // eliminates separate dequant_gpu + cuBLAS gemm overhead.
                         auto expert_gemm = [&](const Tensor& a, Tensor& c, const Tensor& packed, QType qtype,
                                                const std::vector<Tensor>& fallback,
-                                               const std::vector<TensorID>& fallback_ids, int eidx) {
+                                               const std::vector<TensorID>& fallback_ids, int eidx,
+                                               ExpertProj proj) {
                             // NVFP4 MoE batch cache path (Nemotron-H non-gated, and any
                             // NVFP4 MoE model when batch_dequant_buf is too small to fire
                             // the NVFP4→FP16 batch path). After cache_moe_native_nvfp4
@@ -1417,7 +1418,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                     const char* host_ptr = static_cast<const char*>(packed.data) + offset;
                                     if (expert_cache_.n_slots_ > 0) {
                                         ExpertCacheKey ck{packed.data, eidx};
-                                        w = expert_cache_.get_or_load(ck, host_ptr, expert_raw, stream);
+                                        w = expert_cache_.get_or_load(layer, proj, ck, host_ptr,
+                                                                       expert_raw, stream);
                                     } else if (moe_.raw_staging_buf && expert_raw <= moe_.raw_staging_size) {
                                         cudaMemcpyAsync(moe_.raw_staging_buf, host_ptr, expert_raw,
                                                         cudaMemcpyHostToDevice, stream);
@@ -1434,7 +1436,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                             }
                             // Fallback: separate dequant + cuBLAS GEMM
                             {
-                                Tensor b = use_packed_dequant ? dequant_expert(packed, qtype, eidx)
+                                Tensor b = use_packed_dequant ? dequant_expert(packed, qtype, eidx, proj)
                                                               : fallback[eidx];
                                 if (!b.data)
                                     return;  // dequant_expert failed (OOB or buffer too small)
@@ -1504,7 +1506,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                                         const std::vector<Tensor>& fallback,
                                                         const std::vector<TensorID>& fallback_ids,
                                                         const char* a_base, char* c_base, int K_dim,
-                                                        int N_dim) {
+                                                        int N_dim, ExpertProj proj) {
                             int64_t rows = packed.shape[1];
                             int64_t cols = packed.shape[2];
                             size_t expert_fp16_sz = static_cast<size_t>(rows) * cols * sizeof(half);
@@ -1525,7 +1527,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                     int64_t c_shape[2] = {count64, static_cast<int64_t>(N_dim)};
                                     Tensor c_view(c_base + static_cast<size_t>(start) * N_dim * es,
                                                   compute_dtype_, 2, c_shape, true);
-                                    expert_gemm(a_view, c_view, packed, qtype, fallback, fallback_ids, e);
+                                    expert_gemm(a_view, c_view, packed, qtype, fallback, fallback_ids, e,
+                                                proj);
                                 }
                                 return;
                             }
@@ -1612,10 +1615,10 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                             if (!non_gated_experts)
                                 chunked_dequant_gemm(ly.expert_gate_packed, ly.expert_gate_packed.qtype,
                                                      ly.expert_w_gate, ly.expert_gate_ids, gathered_base,
-                                                     expert_gate_base, d, eff);
+                                                     expert_gate_base, d, eff, ExpertProj::Gate);
                             chunked_dequant_gemm(ly.expert_up_packed, ly.expert_up_packed.qtype,
                                                  ly.expert_w_up, ly.expert_up_ids, gathered_base,
-                                                 expert_up_base, d, eff);
+                                                 expert_up_base, d, eff, ExpertProj::Up);
 
                             apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data,
                                                     moe_.expert_swiglu.data, non_gated_experts, expanded, eff,
@@ -1626,7 +1629,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                                                            : expert_swiglu_base;
                                 chunked_dequant_gemm(ly.expert_down_packed, ly.expert_down_packed.qtype,
                                                      ly.expert_w_down, ly.expert_down_ids, dequant_down_act,
-                                                     expert_down_base, eff, d);
+                                                     expert_down_base, eff, d, ExpertProj::Down);
                             }
 
                         } else {
@@ -1649,7 +1652,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                                   compute_dtype_, 2, c_shape, true);
                                     expert_gemm(a_view, c_view, ly.expert_gate_packed,
                                                 ly.expert_gate_packed.qtype, ly.expert_w_gate,
-                                                ly.expert_gate_ids, e);
+                                                ly.expert_gate_ids, e, ExpertProj::Gate);
                                 }
 
                                 {
@@ -1658,7 +1661,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                                   compute_dtype_, 2, c_shape, true);
                                     expert_gemm(a_view, c_view, ly.expert_up_packed,
                                                 ly.expert_up_packed.qtype, ly.expert_w_up, ly.expert_up_ids,
-                                                e);
+                                                e, ExpertProj::Up);
                                 }
                             }
 
@@ -1685,7 +1688,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                                               compute_dtype_, 2, c_shape, true);
                                 expert_gemm(a_view, c_view, ly.expert_down_packed,
                                             ly.expert_down_packed.qtype, ly.expert_w_down, ly.expert_down_ids,
-                                            e);
+                                            e, ExpertProj::Down);
                             }
                         }
                     }

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -273,7 +273,10 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 size_t safety = 128 << 20;  // 128 MiB reserve
                 size_t budget = (free_mem > safety) ? free_mem - safety : 0;
                 budget = static_cast<size_t>(budget * 0.15);  // 15% of available
-                if (expert_cache_.init(max_expert_raw, budget, vram_alloc_)) {
+                const auto& mcfg = model_->config();
+                bool debug_parity = RuntimeConfig::current().moe.expert_cache_debug_parity;
+                if (expert_cache_.init(max_expert_raw, budget, vram_alloc_, mcfg.n_layers,
+                                       mcfg.n_experts, debug_parity)) {
                     IMP_LOG_INFO("Expert LRU cache: %d slots (%.2f MiB / %.2f MiB budget)",
                                  expert_cache_.n_slots_,
                                  expert_cache_.n_slots_ * max_expert_raw / (1024.0 * 1024.0),

--- a/src/graph/expert_cache.cu
+++ b/src/graph/expert_cache.cu
@@ -3,10 +3,13 @@
 #include "core/logging.h"
 #include <cuda_runtime.h>
 #include <algorithm>
+#include <cstring>
+#include <vector>
 
 namespace imp {
 
-bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc) {
+bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc,
+                          int n_layers, int n_experts, bool debug_parity) {
     if (max_expert_raw == 0 || budget_bytes == 0)
         return false;
 
@@ -44,8 +47,33 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
     hits_ = 0;
     misses_ = 0;
 
-    IMP_LOG_INFO("Expert LRU cache: %d slots x %.2f MiB = %.2f MiB GPU memory", n_slots_,
-                 slot_size_ / (1024.0 * 1024.0), total / (1024.0 * 1024.0));
+    // Phase 2: device-side lookup mirror. Size [n_layers × 3 × n_experts]
+    // int32. n_layers/n_experts can be 0 in tests that don't care about the
+    // mirror — in that case we skip the allocation entirely.
+    n_layers_ = std::max(0, n_layers);
+    n_experts_ = std::max(0, n_experts);
+    debug_parity_ = debug_parity;
+    parity_checks_ok_ = 0;
+    if (n_layers_ > 0 && n_experts_ > 0) {
+        size_t cells = static_cast<size_t>(n_layers_) * kExpertProjCount * n_experts_;
+        size_t bytes = cells * sizeof(int);
+        cudaError_t err = cudaMalloc(reinterpret_cast<void**>(&d_lookup_), bytes);
+        if (err != cudaSuccess || !d_lookup_) {
+            IMP_LOG_WARN(
+                "Expert LRU cache: device-side mirror alloc failed (%zu bytes, err=%s) — "
+                "disabling Phase 2 mirror, host-side LRU still functional.",
+                bytes, cudaGetErrorString(err));
+            d_lookup_ = nullptr;
+        } else {
+            // (int32_t)-1 = 0xFFFFFFFF — memset 0xFF gives -1 in every cell.
+            IMP_CUDA_CHECK_LOG(cudaMemset(d_lookup_, 0xFF, bytes));
+        }
+    }
+
+    IMP_LOG_INFO("Expert LRU cache: %d slots x %.2f MiB = %.2f MiB GPU memory%s%s", n_slots_,
+                 slot_size_ / (1024.0 * 1024.0), total / (1024.0 * 1024.0),
+                 d_lookup_ ? " (+ device mirror)" : "",
+                 debug_parity_ ? " [parity-check on]" : "");
     return true;
 }
 
@@ -63,12 +91,38 @@ void* ExpertLRUCache::find(ExpertCacheKey key) {
     return slots_[slot_idx].gpu_ptr;
 }
 
-void* ExpertLRUCache::get_or_load(ExpertCacheKey key, const void* src_host, size_t expert_bytes,
+namespace {
+
+// Write a single int32 cell to the device-side lookup mirror.
+// Async on the supplied stream — Phase 2 mirror is write-only, so ordering
+// against subsequent kernels is whatever the stream provides.
+inline void write_lookup_cell(int* d_lookup, int n_experts, int layer, int proj, int expert,
+                              int slot_idx, cudaStream_t stream) {
+    if (!d_lookup)
+        return;
+    if (layer < 0 || proj < 0 || expert < 0)
+        return;
+    size_t off = (static_cast<size_t>(layer) * kExpertProjCount + proj) * n_experts + expert;
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_lookup + off, &slot_idx, sizeof(int),
+                                       cudaMemcpyHostToDevice, stream));
+}
+
+}  // namespace
+
+void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
+                                  const void* src_host, size_t expert_bytes,
                                   cudaStream_t stream) {
-    // Check cache hit
+    const int proj_idx = static_cast<int>(proj);
+
+    // Check cache hit — find() handles LRU front-update. Hits don't change
+    // which slot holds (layer, proj, expert), so the device mirror cell
+    // remains correct.
     void* cached = find(key);
-    if (cached)
+    if (cached) {
+        if (debug_parity_)
+            check_parity(stream);
         return cached;
+    }
 
     misses_++;
 
@@ -91,6 +145,9 @@ void* ExpertLRUCache::get_or_load(ExpertCacheKey key, const void* src_host, size
         lru_order_.pop_back();
         // Remove old entry from lookup
         lookup_.erase(slots_[slot_idx].key);
+        // Invalidate the evicted slot's device mirror cell before reusing.
+        write_lookup_cell(d_lookup_, n_experts_, slots_[slot_idx].layer, slots_[slot_idx].proj,
+                          slots_[slot_idx].expert, -1, stream);
         slots_[slot_idx].occupied = false;
     }
 
@@ -98,13 +155,66 @@ void* ExpertLRUCache::get_or_load(ExpertCacheKey key, const void* src_host, size
     Slot& slot = slots_[slot_idx];
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot.gpu_ptr, src_host, expert_bytes, cudaMemcpyHostToDevice, stream));
 
-    // Register in LRU
+    // Register in LRU + device mirror
     slot.key = key;
     slot.occupied = true;
+    slot.layer = layer;
+    slot.proj = proj_idx;
+    slot.expert = key.expert_idx;
     lru_order_.push_front(slot_idx);
     lookup_[key] = {slot_idx, lru_order_.begin()};
+    write_lookup_cell(d_lookup_, n_experts_, layer, proj_idx, key.expert_idx, slot_idx, stream);
+
+    if (debug_parity_)
+        check_parity(stream);
 
     return slot.gpu_ptr;
+}
+
+bool ExpertLRUCache::check_parity(cudaStream_t stream) const {
+    if (!d_lookup_ || n_layers_ <= 0 || n_experts_ <= 0)
+        return true;
+    size_t cells = static_cast<size_t>(n_layers_) * kExpertProjCount * n_experts_;
+    std::vector<int> host(cells, -1);
+
+    // Re-derive the expected device-mirror state from the authoritative
+    // host-side slot table — this is what every "+1 every update" path
+    // should converge to.
+    for (const auto& slot : slots_) {
+        if (!slot.occupied)
+            continue;
+        if (slot.layer < 0 || slot.proj < 0 || slot.expert < 0)
+            continue;
+        if (slot.layer >= n_layers_ || slot.proj >= kExpertProjCount || slot.expert >= n_experts_)
+            continue;
+        size_t off = (static_cast<size_t>(slot.layer) * kExpertProjCount + slot.proj) *
+                         n_experts_ +
+                     slot.expert;
+        int slot_idx = static_cast<int>(&slot - slots_.data());
+        host[off] = slot_idx;
+    }
+
+    std::vector<int> dev(cells);
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev.data(), d_lookup_, cells * sizeof(int),
+                                       cudaMemcpyDeviceToHost, stream));
+    IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+
+    for (size_t i = 0; i < cells; ++i) {
+        if (host[i] != dev[i]) {
+            int layer = static_cast<int>(i / (kExpertProjCount * n_experts_));
+            int rest = static_cast<int>(i % (kExpertProjCount * n_experts_));
+            int proj = rest / n_experts_;
+            int expert = rest % n_experts_;
+            IMP_LOG_FATAL(
+                "ExpertLRUCache parity check failed at (layer=%d, proj=%d, expert=%d): "
+                "host=%d device=%d. The host-side LRU and device-side mirror have diverged — "
+                "Phase 2 invariant broken.",
+                layer, proj, expert, host[i], dev[i]);
+            return false;
+        }
+    }
+    parity_checks_ok_++;
+    return true;
 }
 
 void ExpertLRUCache::destroy() {
@@ -120,12 +230,20 @@ void ExpertLRUCache::destroy() {
             cudaFree(pool_);
         pool_ = nullptr;
     }
+    if (d_lookup_) {
+        cudaFree(d_lookup_);
+        d_lookup_ = nullptr;
+    }
     slots_.clear();
     lru_order_.clear();
     lookup_.clear();
     n_slots_ = 0;
+    n_layers_ = 0;
+    n_experts_ = 0;
     hits_ = 0;
     misses_ = 0;
+    parity_checks_ok_ = 0;
+    debug_parity_ = false;
 }
 
 }  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -154,6 +154,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.moe.force_fp16_sync = parse_bool(val, cfg.moe.force_fp16_sync);
     else if (eq("moe.no_expert_cache"))
         cfg.moe.no_expert_cache = parse_bool(val, cfg.moe.no_expert_cache);
+    else if (eq("moe.expert_cache_debug_parity"))
+        cfg.moe.expert_cache_debug_parity = parse_bool(val, cfg.moe.expert_cache_debug_parity);
     else if (eq("moe.zero_workspace"))
         cfg.moe.zero_workspace = parse_bool(val, cfg.moe.zero_workspace);
     else if (eq("moe.no_shared_mlp"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -110,6 +110,12 @@ struct RuntimeConfig {
         bool skip = false;
         bool force_fp16_sync = false;
         bool no_expert_cache = false;
+        // Phase 2 (MoE host-offload Graphs design): assert device-side mirror
+        // == host-side LRU state after every cache mutation. Off by default;
+        // turn on via `moe.expert_cache_debug_parity = true` in imp.conf for
+        // CI / regression diagnosis. Has a meaningful cost (D2H readback of
+        // ~120 KiB per cache update) — never enable in perf runs.
+        bool expert_cache_debug_parity = false;
         bool zero_workspace = false;
         bool no_shared_mlp = false;
         bool no_shexp_gate = false;

--- a/tests/test_expert_cache.cu
+++ b/tests/test_expert_cache.cu
@@ -1,0 +1,178 @@
+// Phase 2 (MoE host-offload + CUDA Graphs design): unit tests for the
+// ExpertLRUCache device-side mirror.
+//
+// The host-side LRU is untouched — these tests exercise the new device
+// `d_lookup_` table, asserting it stays in sync with the host slot table
+// across hits, misses, evictions, and eviction-then-re-insert cycles.
+// Parity is the Phase 2 invariant — Phase 3 will start consuming the
+// device table from dispatch kernels.
+
+#include <gtest/gtest.h>
+#include "graph/executor.h"
+#include <cuda_runtime.h>
+#include <cstring>
+#include <cstdint>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// Synthetic test fixture: build an ExpertLRUCache without any model, drive
+// it through (layer, proj, expert) keys, and check the device-side mirror
+// agrees with the host-side LRU state after every operation.
+class ExpertCachePhase2Test : public ::testing::Test {
+   protected:
+    static constexpr int kSlotBytes = 64;       // tiny — we don't care about contents
+    static constexpr int kBudgetBytes = 4 * kSlotBytes;  // 4 slots
+    static constexpr int kNLayers = 3;
+    static constexpr int kNExperts = 8;
+
+    void SetUp() override {
+        ASSERT_EQ(cudaSuccess, cudaStreamCreate(&stream_));
+        // Source bytes: we don't care what — just enough to memcpy from
+        // pinned host memory to a slot. Pinned because LRU uses cudaMemcpyAsync.
+        ASSERT_EQ(cudaSuccess, cudaHostAlloc(&src_, kSlotBytes, cudaHostAllocDefault));
+        std::memset(src_, 0xAB, kSlotBytes);
+        ASSERT_TRUE(cache_.init(kSlotBytes, kBudgetBytes, /*alloc=*/nullptr, kNLayers, kNExperts,
+                                /*debug_parity=*/true));
+        ASSERT_EQ(cache_.n_slots_, 4);
+        ASSERT_NE(cache_.d_lookup_, nullptr);
+    }
+
+    void TearDown() override {
+        cache_.destroy();
+        cudaFreeHost(src_);
+        cudaStreamDestroy(stream_);
+    }
+
+    // Reads the device-side mirror back to host and returns the slot_idx at
+    // (layer, proj, expert). -1 means "not cached".
+    int read_mirror_cell(int layer, int proj, int expert) {
+        size_t off = (static_cast<size_t>(layer) * kExpertProjCount + proj) * kNExperts + expert;
+        int slot_idx = 0;
+        cudaMemcpyAsync(&slot_idx, cache_.d_lookup_ + off, sizeof(int), cudaMemcpyDeviceToHost,
+                        stream_);
+        cudaStreamSynchronize(stream_);
+        return slot_idx;
+    }
+
+    ExpertLRUCache cache_;
+    void* src_ = nullptr;
+    cudaStream_t stream_ = nullptr;
+
+    // Synthetic ExpertCacheKey — packed_ptr just needs to differ per (layer, proj).
+    // Cast a small integer to const void* — never dereferenced.
+    static const void* fake_packed_ptr(int layer, int proj) {
+        uintptr_t v = (static_cast<uintptr_t>(layer + 1) << 4) | static_cast<uintptr_t>(proj + 1);
+        return reinterpret_cast<const void*>(v);
+    }
+
+    void* load(int layer, ExpertProj proj, int expert) {
+        ExpertCacheKey key{fake_packed_ptr(layer, static_cast<int>(proj)), expert};
+        return cache_.get_or_load(layer, proj, key, src_, kSlotBytes, stream_);
+    }
+};
+
+TEST_F(ExpertCachePhase2Test, InitZerosMirrorToMinusOne) {
+    // After init, every cell should read -1.
+    for (int l = 0; l < kNLayers; ++l)
+        for (int p = 0; p < kExpertProjCount; ++p)
+            for (int e = 0; e < kNExperts; ++e)
+                EXPECT_EQ(read_mirror_cell(l, p, e), -1) << "(l=" << l << ", p=" << p
+                                                         << ", e=" << e << ")";
+}
+
+TEST_F(ExpertCachePhase2Test, SingleInsertMirrorsToSlotZero) {
+    void* ptr = load(/*layer=*/1, ExpertProj::Up, /*expert=*/3);
+    EXPECT_NE(ptr, nullptr);
+    EXPECT_EQ(read_mirror_cell(1, static_cast<int>(ExpertProj::Up), 3), 0);
+    // All other cells stay -1.
+    EXPECT_EQ(read_mirror_cell(0, 0, 0), -1);
+    EXPECT_EQ(read_mirror_cell(2, 2, 7), -1);
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase2Test, ThreeInsertsPickUnoccupiedSlots) {
+    load(0, ExpertProj::Gate, 0);
+    load(0, ExpertProj::Up, 0);
+    load(0, ExpertProj::Down, 0);
+    EXPECT_EQ(read_mirror_cell(0, 0, 0), 0);
+    EXPECT_EQ(read_mirror_cell(0, 1, 0), 1);
+    EXPECT_EQ(read_mirror_cell(0, 2, 0), 2);
+    EXPECT_EQ(cache_.misses_, 3);
+    EXPECT_EQ(cache_.hits_, 0);
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase2Test, HitDoesNotMoveSlot) {
+    void* p0 = load(0, ExpertProj::Gate, 0);
+    void* p1 = load(0, ExpertProj::Gate, 0);  // hit on same key
+    EXPECT_EQ(p0, p1);
+    EXPECT_EQ(cache_.misses_, 1);
+    EXPECT_EQ(cache_.hits_, 1);
+    EXPECT_EQ(read_mirror_cell(0, 0, 0), 0);
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase2Test, EvictionInvalidatesOldCellWritesNew) {
+    // Fill all 4 slots, then trigger eviction on the 5th insert.
+    load(0, ExpertProj::Gate, 0);  // -> slot 0
+    load(0, ExpertProj::Up, 1);    // -> slot 1
+    load(1, ExpertProj::Down, 2);  // -> slot 2
+    load(2, ExpertProj::Gate, 3);  // -> slot 3
+    EXPECT_TRUE(cache_.check_parity(stream_));
+
+    // Slot 0 (layer=0, proj=Gate, expert=0) is now the LRU. The next miss
+    // evicts it; that cell should read -1 and the new (layer=2, proj=Up,
+    // expert=4) cell should read the freed slot index.
+    load(2, ExpertProj::Up, 4);
+    EXPECT_EQ(read_mirror_cell(0, 0, 0), -1);
+    EXPECT_EQ(read_mirror_cell(2, 1, 4), 0);  // reused slot 0
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase2Test, AccessMovesToFrontResistsEviction) {
+    // Insert 4 entries (slots 0..3).
+    load(0, ExpertProj::Gate, 0);
+    load(0, ExpertProj::Up, 1);
+    load(1, ExpertProj::Down, 2);
+    load(2, ExpertProj::Gate, 3);
+
+    // Touch slot 0 → it becomes most-recently-used. Next eviction should
+    // hit slot 1 (now LRU), not slot 0.
+    load(0, ExpertProj::Gate, 0);  // hit
+    load(2, ExpertProj::Up, 4);    // miss → evict slot 1
+
+    EXPECT_EQ(read_mirror_cell(0, 0, 0), 0);     // still resident
+    EXPECT_EQ(read_mirror_cell(0, 1, 1), -1);    // evicted
+    EXPECT_EQ(read_mirror_cell(2, 1, 4), 1);     // reused slot 1
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase2Test, ParityCheckCounterAdvances) {
+    // With debug_parity=true (set in SetUp), every get_or_load() runs
+    // check_parity() internally. After 4 inserts the counter should be ≥4.
+    int64_t before = cache_.parity_checks_ok_;
+    load(0, ExpertProj::Gate, 0);
+    load(0, ExpertProj::Up, 1);
+    load(1, ExpertProj::Down, 2);
+    load(2, ExpertProj::Gate, 3);
+    EXPECT_GE(cache_.parity_checks_ok_ - before, 4);
+}
+
+TEST_F(ExpertCachePhase2Test, MirrorDisabledWhenNoLayersOrExperts) {
+    // Re-init with n_layers=0 — mirror should not be allocated, but the
+    // host-side LRU should still function normally.
+    ExpertLRUCache c;
+    ASSERT_TRUE(c.init(kSlotBytes, kBudgetBytes, /*alloc=*/nullptr, /*n_layers=*/0,
+                       /*n_experts=*/kNExperts));
+    EXPECT_EQ(c.d_lookup_, nullptr);
+    ExpertCacheKey key{fake_packed_ptr(0, 0), 0};
+    void* p = c.get_or_load(0, ExpertProj::Gate, key, src_, kSlotBytes, stream_);
+    EXPECT_NE(p, nullptr);
+    EXPECT_TRUE(c.check_parity(stream_));  // trivially true when mirror is null
+    c.destroy();
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Summary

Phase 2 of the MoE host-offload + CUDA Graphs design memo (\`docs/plans/moe_host_offload_graphs_design_2026_05_17.md\` §5). Bookkeeping only — no perf change, foundation for Phases 3-5.

The host-side \`ExpertLRUCache\` continues to make every eviction decision. A new device-side int32 lookup table sized \`[n_layers × 3 × n_experts]\` mirrors the host state — every host-LRU insert writes the new slot index into the \`(layer, proj, expert)\` cell; every eviction writes \`-1\` to the displaced cell before the new one is recorded.

Surfaced by the [Phase 1 nsys spike](https://github.com/kekzl/imp/pull/232) which found PCIe is only ~14 % of the host-offload decode penalty — the remaining 18 ms/tok is host-side LRU bookkeeping + Graphs-disabled launch overhead. Phase 2 lays the mirror; Phase 3 partitions the pool per-layer; Phase 4 adds async prefetch; Phase 5 captures decode into a CUDA Graph.

## What ships

- \`graph/executor.h\`: \`ExpertProj\` enum (Gate / Up / Down), \`kExpertProjCount\`, \`Slot::{layer, proj, expert}\` for eviction-time mirror invalidation, new \`ExpertLRUCache\` fields (\`d_lookup_\`, \`n_layers_\`, \`n_experts_\`, \`debug_parity_\`, mutable \`parity_checks_ok_\`), new \`init()\` signature (\`n_layers\`, \`n_experts\`, \`debug_parity\`), new \`get_or_load()\` signature (\`layer\`, \`proj\` are now leading args). \`check_parity()\` helper for tests and the debug-parity mode.
- \`graph/expert_cache.cu\`: allocate mirror in \`init()\`, memset to \`0xFF\` (cell value \`-1\` = \"not cached\"), free in \`destroy()\`. \`write_lookup_cell()\` helper threads a single int through \`cudaMemcpyAsync\` on every slot occupancy change. \`check_parity()\` rebuilds the expected mirror from the authoritative host slot table and D2H-compares against the device buffer; emits \`IMP_LOG_FATAL\` on first mismatch.
- \`graph/executor_forward_moe.cu\`: thread \`(layer, ExpertProj)\` through \`dequant_expert\` + \`expert_gemm\` + \`chunked_dequant_gemm\` lambdas, and through the seven outer call sites in \`run_moe_ffn()\` so every \`get_or_load()\` now identifies (layer, projection, expert).
- \`graph/executor_workspace_buffers.cu\`: pass model \`n_layers\` + \`n_experts\` + \`moe.expert_cache_debug_parity\` to \`init()\`.
- \`runtime/config.{h,cpp}\`: new bool \`moe.expert_cache_debug_parity\` (off by default; meaningful D2H cost per cache mutation).
- \`tests/test_expert_cache.cu\`: 8 GTests exercising init zero-fill, single insert, three-projection slot allocation, hit-no-move, eviction invalidation, recency reordering, parity counter, and the mirror-disabled-when-no-shape edge case. Registered in the \`test-moe-gdn\` module.

## Test plan

- [x] \`test-moe-gdn ExpertCachePhase2Test.*\` — 8/8 pass (194 ms total)
- [x] \`imp-tests-unit\` — 34/34 pass (3 expected skips)
- [x] GPU tests minus pre-existing failures — 62 pass, 1 perf bench fail (\`TmaBlockScaleBench\`, unrelated)
- [x] **End-to-end host-offload** on Qwen3.6-35B-A3B Q4_K_M with \`moe.force_host_experts=10\` + \`moe.expert_cache_debug_parity=true\`: 2 reps × 64 decode tokens, **55k cache ops, zero parity divergences**
- [x] **No perf regression**: same setup without parity check — tg256 = 45.64 tok/s vs Phase 1 baseline 46.59 tok/s (within variance — mirror writes are 4-byte \`cudaMemcpyAsync\` per cache mutation, dominated by the existing H2D expert copy)
- [ ] CI gate on green build

Phase 2 is read-side-untouched: dispatch kernels still consume the host slot pointer returned by \`get_or_load()\`. Phase 3 (\`feat/moe-host-offload-phase2-phase3\` locally, will open as a follow-up PR once this lands) partitions the pool per-layer; Phase 5 will switch the dispatch kernels to read \`d_lookup_[(layer, proj, expert)]\` directly.