### PR TITLE
feat(graph): MoE host-offload Phase 3 — per-layer slot pool + host addrs table

### DIFF
--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -55,15 +55,25 @@ struct ExpertCacheKeyHash {
 enum class ExpertProj { Gate = 0, Up = 1, Down = 2 };
 inline constexpr int kExpertProjCount = 3;
 
+// Per-layer LRU state — Phase 3 partitions the global pool so layer L's
+// cache state can't be evicted by layer M's misses. Each layer has its own
+// recency list + key→slot map; slot indices are layer-relative.
+struct PerLayerLRU {
+    std::list<int> lru_order;  // slot indices WITHIN this layer (0..slots_per_layer-1)
+    using LRUIter = std::list<int>::iterator;
+    std::unordered_map<ExpertCacheKey, std::pair<int, LRUIter>, ExpertCacheKeyHash> lookup;
+};
+
 struct ExpertLRUCache {
-    // Each slot holds one expert's raw quantized bytes on GPU.
-    // Slots are fixed-size (max_expert_raw bytes each).
+    // Each slot holds one expert's raw quantized bytes on GPU. Slots are
+    // partitioned per-layer (Phase 3): `slots_[layer * slots_per_layer_ +
+    // slot_idx_within_layer]`. GPU pointer = `pool_ + flat_index * slot_size_`.
     struct Slot {
         void* gpu_ptr = nullptr;  // points into pool_
         ExpertCacheKey key = {};
         bool occupied = false;
         // Mirror coords — set on get_or_load, used to invalidate the device
-        // lookup cell on eviction.
+        // lookup cell on eviction. `layer` matches the flat-index layer.
         int layer = -1;
         int proj = -1;   // ExpertProj
         int expert = -1;
@@ -71,53 +81,77 @@ struct ExpertLRUCache {
 
     void* pool_ = nullptr;     // contiguous GPU allocation for all slots
     size_t slot_size_ = 0;     // bytes per slot (max expert raw size)
-    int n_slots_ = 0;          // number of slots
-    std::vector<Slot> slots_;  // slot metadata
+    int slots_per_layer_ = 0;  // S — uniform per-layer pool depth (Phase 3)
+    int n_slots_ = 0;          // = n_layers_ * slots_per_layer_ (total)
+    std::vector<Slot> slots_;  // flat array, layer-major (size = n_slots_)
 
-    // LRU tracking: front = most recently used, back = least recently used
-    std::list<int> lru_order_;  // slot indices in LRU order
-    // Map from cache key to (slot_index, lru_iterator)
-    using LRUIter = std::list<int>::iterator;
-    std::unordered_map<ExpertCacheKey, std::pair<int, LRUIter>, ExpertCacheKeyHash> lookup_;
+    // Per-layer LRU state (Phase 3). `per_layer_lru_[layer]` holds layer L's
+    // recency list + key→slot map. Slot indices are layer-relative (0..S-1).
+    std::vector<PerLayerLRU> per_layer_lru_;
+    using LRUIter = PerLayerLRU::LRUIter;
+
+    // Phase 3: pre-computed host source pointers for capture-safe memcpy.
+    // host_expert_addrs_[layer][proj * n_experts + expert] = packed.data +
+    // expert_idx * expert_raw. Populated lazily on first get_or_load per
+    // cell — the value is stable for the lifetime of the model load (packed
+    // tensors don't move on host). Phase 5 will use these as the fixed
+    // `src` argument of cudaGraphAddMemcpyNode so the graph can replay
+    // without recomputing host pointers each iteration.
+    std::vector<std::vector<const void*>> host_expert_addrs_;
 
     int64_t hits_ = 0;
     int64_t misses_ = 0;
 
     VRAMAllocator* alloc_ = nullptr;
 
-    // Device-side lookup mirror (Phase 2). Sized [n_layers × 3 × n_experts]
-    // int32 cells; cell value = slot_idx or -1 if not cached. Read pattern in
-    // Phase 3+: `d_lookup_[layer * 3 * n_experts_ + proj * n_experts_ + expert]`.
-    // Today (Phase 2) the mirror is write-only — kept in sync with the host
-    // LRU so Phase 3 can drop the kernel onto a known-good device-side table.
+    // Device-side lookup mirror (Phase 2 → Phase 3). Sized [n_layers × 3 ×
+    // n_experts] int32 cells; cell value = **layer-relative** slot_idx
+    // (0..slots_per_layer-1) or -1 if not cached. Read pattern (Phase 5 will
+    // do this from inside dispatch kernels):
+    //   slot = d_lookup_[layer * 3 * n_experts + proj * n_experts + expert];
+    //   if (slot >= 0) src = pool_ + (layer * slots_per_layer + slot) * slot_size;
     int* d_lookup_ = nullptr;
     int n_layers_ = 0;
     int n_experts_ = 0;
     bool debug_parity_ = false;
     mutable int64_t parity_checks_ok_ = 0;  // exposed for tests; bumped by const check_parity()
 
-    // Initialize: allocate n_slots * slot_size bytes on GPU + n_layers × 3 ×
-    // n_experts int32 cells for the device-side lookup mirror.
-    // Returns false if GPU allocation fails (cache disabled).
+    // Initialize: allocate the slot pool (partitioned per-layer) + the
+    // device mirror + the host source-pointer table. Returns false if GPU
+    // allocation fails (cache disabled).
     bool init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc,
               int n_layers, int n_experts, bool debug_parity = false);
 
     // Lookup or insert an expert. Returns GPU pointer to cached expert data.
-    // If cache miss: copies from host, evicts LRU entry if needed.
-    // src_host = host pointer to this expert's raw bytes.
-    // `layer` + `proj` identify the mirror cell to update; the cache key
-    // remains (packed_ptr, expert_idx) so the host-side LRU is unchanged.
+    // If cache miss: copies from host, evicts LRU entry within the layer's
+    // pool if needed.
+    // src_host = host pointer to this expert's raw bytes. The first call per
+    // (layer, proj, expert) records src_host into host_expert_addrs_;
+    // subsequent calls reuse the stored pointer (the cache key disambiguates).
     void* get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
                       const void* src_host, size_t expert_bytes, cudaStream_t stream);
 
-    // Check if expert is cached (no insertion). Updates LRU recency.
-    void* find(ExpertCacheKey key);
+    // Check if (layer, expert) is cached (no insertion). Updates LRU recency
+    // within the layer.
+    void* find(int layer, ExpertCacheKey key);
 
     void destroy();
 
     float hit_rate() const {
         int64_t total = hits_ + misses_;
         return total > 0 ? static_cast<float>(hits_) / total : 0.0f;
+    }
+
+    // Returns the device pointer for layer L, slot_idx_within_layer s, or
+    // nullptr if the slot is not occupied. Used by Phase 3 tests and as the
+    // future Phase 5 kernel-side resolve helper. Phase 5 will inline this
+    // logic into the dispatch kernels.
+    void* slot_ptr(int layer, int slot_idx_within_layer) const {
+        if (!pool_ || slot_idx_within_layer < 0 ||
+            slot_idx_within_layer >= slots_per_layer_)
+            return nullptr;
+        size_t flat = static_cast<size_t>(layer) * slots_per_layer_ + slot_idx_within_layer;
+        return static_cast<char*>(pool_) + flat * slot_size_;
     }
 
     // Phase 2 debug helper: copy the device lookup mirror back to host and

--- a/src/graph/expert_cache.cu
+++ b/src/graph/expert_cache.cu
@@ -15,12 +15,33 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
 
     alloc_ = alloc;
     slot_size_ = max_expert_raw;
-    n_slots_ = static_cast<int>(budget_bytes / slot_size_);
+
+    // Phase 3: partition the pool per-layer. When n_layers == 0 (tests that
+    // don't care about the per-layer split or callers that haven't migrated
+    // yet) fall back to a single virtual layer holding the whole pool, so
+    // get_or_load(layer=0, …) keeps working.
+    n_layers_ = (n_layers > 0) ? n_layers : 1;
+    n_experts_ = std::max(0, n_experts);
+    debug_parity_ = debug_parity;
+    parity_checks_ok_ = 0;
+
+    // slots_per_layer = floor(budget / (slot_size × n_layers)). We need ≥ 1
+    // slot per layer (else a single miss in any layer can't be cached) and
+    // ideally ≥ 2 total so an eviction-aware test isn't trivial.
+    size_t per_layer_budget = budget_bytes / static_cast<size_t>(n_layers_);
+    slots_per_layer_ = static_cast<int>(per_layer_budget / slot_size_);
+    if (slots_per_layer_ < 1) {
+        IMP_LOG_WARN(
+            "Expert LRU cache: budget too small for even 1 slot per layer "
+            "(need %zu bytes/slot × %d layers, budget %zu bytes)",
+            slot_size_, n_layers_, budget_bytes);
+        return false;
+    }
+    n_slots_ = n_layers_ * slots_per_layer_;
     if (n_slots_ < 2) {
         IMP_LOG_WARN(
-            "Expert LRU cache: budget too small for even 2 slots "
-            "(need %zu bytes/slot, budget %zu bytes)",
-            slot_size_, budget_bytes);
+            "Expert LRU cache: total slot count too small (%d slots from %d layers × %d per-layer)",
+            n_slots_, n_layers_, slots_per_layer_);
         return false;
     }
 
@@ -35,89 +56,122 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
     if (!pool_) {
         IMP_LOG_WARN("Expert LRU cache: allocation failed for %zu bytes (%d slots)", total, n_slots_);
         n_slots_ = 0;
+        slots_per_layer_ = 0;
         return false;
     }
 
     slots_.resize(n_slots_);
     for (int i = 0; i < n_slots_; i++) {
         slots_[i].gpu_ptr = static_cast<char*>(pool_) + static_cast<size_t>(i) * slot_size_;
+        slots_[i].layer = i / slots_per_layer_;
     }
 
-    lookup_.reserve(n_slots_ * 2);
+    per_layer_lru_.assign(n_layers_, PerLayerLRU{});
+    for (auto& plru : per_layer_lru_)
+        plru.lookup.reserve(slots_per_layer_ * 2);
+
     hits_ = 0;
     misses_ = 0;
 
-    // Phase 2: device-side lookup mirror. Size [n_layers × 3 × n_experts]
-    // int32. n_layers/n_experts can be 0 in tests that don't care about the
-    // mirror — in that case we skip the allocation entirely.
-    n_layers_ = std::max(0, n_layers);
-    n_experts_ = std::max(0, n_experts);
-    debug_parity_ = debug_parity;
-    parity_checks_ok_ = 0;
-    if (n_layers_ > 0 && n_experts_ > 0) {
+    // Device-side lookup mirror. Cell value is **layer-relative** slot_idx
+    // (0..slots_per_layer_-1) or -1. n_experts == 0 means caller does not
+    // want the mirror — skip the alloc entirely.
+    if (n_experts_ > 0) {
         size_t cells = static_cast<size_t>(n_layers_) * kExpertProjCount * n_experts_;
         size_t bytes = cells * sizeof(int);
         cudaError_t err = cudaMalloc(reinterpret_cast<void**>(&d_lookup_), bytes);
         if (err != cudaSuccess || !d_lookup_) {
             IMP_LOG_WARN(
                 "Expert LRU cache: device-side mirror alloc failed (%zu bytes, err=%s) — "
-                "disabling Phase 2 mirror, host-side LRU still functional.",
+                "disabling mirror, host-side LRU still functional.",
                 bytes, cudaGetErrorString(err));
             d_lookup_ = nullptr;
         } else {
             // (int32_t)-1 = 0xFFFFFFFF — memset 0xFF gives -1 in every cell.
             IMP_CUDA_CHECK_LOG(cudaMemset(d_lookup_, 0xFF, bytes));
         }
+
+        // Host source-pointer table: [layer][proj * n_experts + expert].
+        // Lazy-populated by get_or_load() — the value is stable for the
+        // model's lifetime once stamped.
+        host_expert_addrs_.assign(n_layers_,
+                                  std::vector<const void*>(static_cast<size_t>(kExpertProjCount) *
+                                                              n_experts_,
+                                                          nullptr));
     }
 
-    IMP_LOG_INFO("Expert LRU cache: %d slots x %.2f MiB = %.2f MiB GPU memory%s%s", n_slots_,
-                 slot_size_ / (1024.0 * 1024.0), total / (1024.0 * 1024.0),
-                 d_lookup_ ? " (+ device mirror)" : "",
+    IMP_LOG_INFO("Expert LRU cache: %d layers × %d slots × %.2f MiB = %.2f MiB GPU memory%s%s",
+                 n_layers_, slots_per_layer_, slot_size_ / (1024.0 * 1024.0),
+                 total / (1024.0 * 1024.0), d_lookup_ ? " (+ device mirror)" : "",
                  debug_parity_ ? " [parity-check on]" : "");
     return true;
 }
 
-void* ExpertLRUCache::find(ExpertCacheKey key) {
-    auto it = lookup_.find(key);
-    if (it == lookup_.end())
-        return nullptr;
-
-    // Move to front (most recently used)
-    auto& [slot_idx, lru_it] = it->second;
-    lru_order_.erase(lru_it);
-    lru_order_.push_front(slot_idx);
-    it->second.second = lru_order_.begin();
-    hits_++;
-    return slots_[slot_idx].gpu_ptr;
-}
-
 namespace {
 
+inline int flat_slot(int layer, int slot_in_layer, int slots_per_layer) {
+    return layer * slots_per_layer + slot_in_layer;
+}
+
 // Write a single int32 cell to the device-side lookup mirror.
-// Async on the supplied stream — Phase 2 mirror is write-only, so ordering
-// against subsequent kernels is whatever the stream provides.
+// Async on the supplied stream — Phase 3 mirror is write-only from the
+// engine's perspective; ordering against subsequent kernels is whatever
+// the stream provides.
 inline void write_lookup_cell(int* d_lookup, int n_experts, int layer, int proj, int expert,
-                              int slot_idx, cudaStream_t stream) {
+                              int slot_idx_in_layer, cudaStream_t stream) {
     if (!d_lookup)
         return;
     if (layer < 0 || proj < 0 || expert < 0)
         return;
     size_t off = (static_cast<size_t>(layer) * kExpertProjCount + proj) * n_experts + expert;
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_lookup + off, &slot_idx, sizeof(int),
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_lookup + off, &slot_idx_in_layer, sizeof(int),
                                        cudaMemcpyHostToDevice, stream));
 }
 
 }  // namespace
 
+void* ExpertLRUCache::find(int layer, ExpertCacheKey key) {
+    if (layer < 0 || layer >= n_layers_)
+        return nullptr;
+    auto& plru = per_layer_lru_[layer];
+    auto it = plru.lookup.find(key);
+    if (it == plru.lookup.end())
+        return nullptr;
+
+    // Move to front (most recently used) within this layer's recency list.
+    auto& [slot_in_layer, lru_it] = it->second;
+    plru.lru_order.erase(lru_it);
+    plru.lru_order.push_front(slot_in_layer);
+    it->second.second = plru.lru_order.begin();
+    hits_++;
+    return slots_[flat_slot(layer, slot_in_layer, slots_per_layer_)].gpu_ptr;
+}
+
 void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
                                   const void* src_host, size_t expert_bytes,
                                   cudaStream_t stream) {
     const int proj_idx = static_cast<int>(proj);
+    if (layer < 0 || layer >= n_layers_) {
+        IMP_LOG_ERROR("ExpertLRUCache::get_or_load: layer %d out of range [0, %d)", layer,
+                      n_layers_);
+        return nullptr;
+    }
+    auto& plru = per_layer_lru_[layer];
 
-    // Check cache hit — find() handles LRU front-update. Hits don't change
-    // which slot holds (layer, proj, expert), so the device mirror cell
-    // remains correct.
-    void* cached = find(key);
+    // Stamp the host source pointer for capture-safe memcpy (Phase 5).
+    // Skipped if either the mirror is disabled or n_experts == 0 (tests).
+    if (!host_expert_addrs_.empty() && n_experts_ > 0 && key.expert_idx >= 0 &&
+        key.expert_idx < n_experts_) {
+        auto& table = host_expert_addrs_[layer];
+        size_t off = static_cast<size_t>(proj_idx) * n_experts_ + key.expert_idx;
+        if (off < table.size())
+            table[off] = src_host;
+    }
+
+    // Check cache hit — find() handles per-layer LRU front-update. Hits
+    // don't change which slot holds (layer, proj, expert), so the device
+    // mirror cell remains correct.
+    void* cached = find(layer, key);
     if (cached) {
         if (debug_parity_)
             check_parity(stream);
@@ -126,44 +180,43 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
 
     misses_++;
 
-    // Find a slot: use an unoccupied one, or evict LRU
-    int slot_idx = -1;
-
-    if (static_cast<int>(lookup_.size()) < n_slots_) {
-        // Find first unoccupied slot
-        for (int i = 0; i < n_slots_; i++) {
-            if (!slots_[i].occupied) {
-                slot_idx = i;
+    // Find a slot WITHIN this layer's pool: use an unoccupied one, or evict
+    // the layer's LRU entry.
+    int slot_in_layer = -1;
+    if (static_cast<int>(plru.lookup.size()) < slots_per_layer_) {
+        for (int s = 0; s < slots_per_layer_; ++s) {
+            if (!slots_[flat_slot(layer, s, slots_per_layer_)].occupied) {
+                slot_in_layer = s;
                 break;
             }
         }
     }
-
-    if (slot_idx < 0) {
-        // Evict LRU (back of list)
-        slot_idx = lru_order_.back();
-        lru_order_.pop_back();
-        // Remove old entry from lookup
-        lookup_.erase(slots_[slot_idx].key);
+    if (slot_in_layer < 0) {
+        // Evict layer-LRU (back of this layer's list).
+        slot_in_layer = plru.lru_order.back();
+        plru.lru_order.pop_back();
+        const int flat = flat_slot(layer, slot_in_layer, slots_per_layer_);
+        plru.lookup.erase(slots_[flat].key);
         // Invalidate the evicted slot's device mirror cell before reusing.
-        write_lookup_cell(d_lookup_, n_experts_, slots_[slot_idx].layer, slots_[slot_idx].proj,
-                          slots_[slot_idx].expert, -1, stream);
-        slots_[slot_idx].occupied = false;
+        write_lookup_cell(d_lookup_, n_experts_, slots_[flat].layer, slots_[flat].proj,
+                          slots_[flat].expert, -1, stream);
+        slots_[flat].occupied = false;
     }
 
-    // Load expert from host to GPU slot
-    Slot& slot = slots_[slot_idx];
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot.gpu_ptr, src_host, expert_bytes, cudaMemcpyHostToDevice, stream));
+    const int flat = flat_slot(layer, slot_in_layer, slots_per_layer_);
+    Slot& slot = slots_[flat];
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot.gpu_ptr, src_host, expert_bytes, cudaMemcpyHostToDevice,
+                                       stream));
 
-    // Register in LRU + device mirror
     slot.key = key;
     slot.occupied = true;
     slot.layer = layer;
     slot.proj = proj_idx;
     slot.expert = key.expert_idx;
-    lru_order_.push_front(slot_idx);
-    lookup_[key] = {slot_idx, lru_order_.begin()};
-    write_lookup_cell(d_lookup_, n_experts_, layer, proj_idx, key.expert_idx, slot_idx, stream);
+    plru.lru_order.push_front(slot_in_layer);
+    plru.lookup[key] = {slot_in_layer, plru.lru_order.begin()};
+    write_lookup_cell(d_lookup_, n_experts_, layer, proj_idx, key.expert_idx, slot_in_layer,
+                      stream);
 
     if (debug_parity_)
         check_parity(stream);
@@ -179,19 +232,20 @@ bool ExpertLRUCache::check_parity(cudaStream_t stream) const {
 
     // Re-derive the expected device-mirror state from the authoritative
     // host-side slot table — this is what every "+1 every update" path
-    // should converge to.
-    for (const auto& slot : slots_) {
+    // should converge to. Cell value is layer-relative slot_idx.
+    for (size_t flat = 0; flat < slots_.size(); ++flat) {
+        const Slot& slot = slots_[flat];
         if (!slot.occupied)
             continue;
         if (slot.layer < 0 || slot.proj < 0 || slot.expert < 0)
             continue;
         if (slot.layer >= n_layers_ || slot.proj >= kExpertProjCount || slot.expert >= n_experts_)
             continue;
+        const int slot_in_layer = static_cast<int>(flat) - slot.layer * slots_per_layer_;
         size_t off = (static_cast<size_t>(slot.layer) * kExpertProjCount + slot.proj) *
                          n_experts_ +
                      slot.expert;
-        int slot_idx = static_cast<int>(&slot - slots_.data());
-        host[off] = slot_idx;
+        host[off] = slot_in_layer;
     }
 
     std::vector<int> dev(cells);
@@ -208,7 +262,7 @@ bool ExpertLRUCache::check_parity(cudaStream_t stream) const {
             IMP_LOG_FATAL(
                 "ExpertLRUCache parity check failed at (layer=%d, proj=%d, expert=%d): "
                 "host=%d device=%d. The host-side LRU and device-side mirror have diverged — "
-                "Phase 2 invariant broken.",
+                "Phase 3 invariant broken.",
                 layer, proj, expert, host[i], dev[i]);
             return false;
         }
@@ -235,9 +289,10 @@ void ExpertLRUCache::destroy() {
         d_lookup_ = nullptr;
     }
     slots_.clear();
-    lru_order_.clear();
-    lookup_.clear();
+    per_layer_lru_.clear();
+    host_expert_addrs_.clear();
     n_slots_ = 0;
+    slots_per_layer_ = 0;
     n_layers_ = 0;
     n_experts_ = 0;
     hits_ = 0;

--- a/tests/test_expert_cache.cu
+++ b/tests/test_expert_cache.cu
@@ -1,11 +1,15 @@
-// Phase 2 (MoE host-offload + CUDA Graphs design): unit tests for the
-// ExpertLRUCache device-side mirror.
+// Phase 2 + Phase 3 (MoE host-offload + CUDA Graphs design): unit tests for
+// the ExpertLRUCache device-side mirror + per-layer slot pool partitioning.
 //
-// The host-side LRU is untouched — these tests exercise the new device
-// `d_lookup_` table, asserting it stays in sync with the host slot table
-// across hits, misses, evictions, and eviction-then-re-insert cycles.
-// Parity is the Phase 2 invariant — Phase 3 will start consuming the
-// device table from dispatch kernels.
+// Phase 2 invariant: every host-LRU mutation is mirrored into a device-side
+// int32 table sized [n_layers × 3 × n_experts]. Cell value is the
+// layer-relative slot index (Phase 3 narrows this from the old global slot
+// index) or -1 if not cached.
+//
+// Phase 3 invariant: the slot pool is partitioned per-layer so layer L's
+// cache state cannot be evicted by layer M's misses. Each layer owns
+// `slots_per_layer_` slots inside the shared pool_, with independent LRU
+// recency + key→slot maps.
 
 #include <gtest/gtest.h>
 #include "graph/executor.h"
@@ -17,25 +21,26 @@
 namespace imp {
 namespace {
 
-// Synthetic test fixture: build an ExpertLRUCache without any model, drive
-// it through (layer, proj, expert) keys, and check the device-side mirror
-// agrees with the host-side LRU state after every operation.
-class ExpertCachePhase2Test : public ::testing::Test {
+class ExpertCachePhase3Test : public ::testing::Test {
    protected:
-    static constexpr int kSlotBytes = 64;       // tiny — we don't care about contents
-    static constexpr int kBudgetBytes = 4 * kSlotBytes;  // 4 slots
+    // Pick a tiny budget that yields exactly 2 slots per layer with 3
+    // layers — enough to test eviction within a layer (2 inserts then a
+    // 3rd in the same layer evicts the LRU) and per-layer isolation
+    // (filling layer 0 doesn't touch layer 1).
+    static constexpr int kSlotBytes = 64;
     static constexpr int kNLayers = 3;
+    static constexpr int kSlotsPerLayer = 2;
+    static constexpr int kBudgetBytes = kNLayers * kSlotsPerLayer * kSlotBytes;
     static constexpr int kNExperts = 8;
 
     void SetUp() override {
         ASSERT_EQ(cudaSuccess, cudaStreamCreate(&stream_));
-        // Source bytes: we don't care what — just enough to memcpy from
-        // pinned host memory to a slot. Pinned because LRU uses cudaMemcpyAsync.
         ASSERT_EQ(cudaSuccess, cudaHostAlloc(&src_, kSlotBytes, cudaHostAllocDefault));
         std::memset(src_, 0xAB, kSlotBytes);
         ASSERT_TRUE(cache_.init(kSlotBytes, kBudgetBytes, /*alloc=*/nullptr, kNLayers, kNExperts,
                                 /*debug_parity=*/true));
-        ASSERT_EQ(cache_.n_slots_, 4);
+        ASSERT_EQ(cache_.slots_per_layer_, kSlotsPerLayer);
+        ASSERT_EQ(cache_.n_slots_, kNLayers * kSlotsPerLayer);
         ASSERT_NE(cache_.d_lookup_, nullptr);
     }
 
@@ -45,8 +50,8 @@ class ExpertCachePhase2Test : public ::testing::Test {
         cudaStreamDestroy(stream_);
     }
 
-    // Reads the device-side mirror back to host and returns the slot_idx at
-    // (layer, proj, expert). -1 means "not cached".
+    // Returns the layer-relative slot_idx at the (layer, proj, expert) cell,
+    // or -1 if not cached.
     int read_mirror_cell(int layer, int proj, int expert) {
         size_t off = (static_cast<size_t>(layer) * kExpertProjCount + proj) * kNExperts + expert;
         int slot_idx = 0;
@@ -55,10 +60,6 @@ class ExpertCachePhase2Test : public ::testing::Test {
         cudaStreamSynchronize(stream_);
         return slot_idx;
     }
-
-    ExpertLRUCache cache_;
-    void* src_ = nullptr;
-    cudaStream_t stream_ = nullptr;
 
     // Synthetic ExpertCacheKey — packed_ptr just needs to differ per (layer, proj).
     // Cast a small integer to const void* — never dereferenced.
@@ -71,10 +72,13 @@ class ExpertCachePhase2Test : public ::testing::Test {
         ExpertCacheKey key{fake_packed_ptr(layer, static_cast<int>(proj)), expert};
         return cache_.get_or_load(layer, proj, key, src_, kSlotBytes, stream_);
     }
+
+    ExpertLRUCache cache_;
+    void* src_ = nullptr;
+    cudaStream_t stream_ = nullptr;
 };
 
-TEST_F(ExpertCachePhase2Test, InitZerosMirrorToMinusOne) {
-    // After init, every cell should read -1.
+TEST_F(ExpertCachePhase3Test, InitZerosMirrorToMinusOne) {
     for (int l = 0; l < kNLayers; ++l)
         for (int p = 0; p < kExpertProjCount; ++p)
             for (int e = 0; e < kNExperts; ++e)
@@ -82,29 +86,59 @@ TEST_F(ExpertCachePhase2Test, InitZerosMirrorToMinusOne) {
                                                          << ", e=" << e << ")";
 }
 
-TEST_F(ExpertCachePhase2Test, SingleInsertMirrorsToSlotZero) {
+TEST_F(ExpertCachePhase3Test, SingleInsertMirrorsToSlotZero) {
     void* ptr = load(/*layer=*/1, ExpertProj::Up, /*expert=*/3);
     EXPECT_NE(ptr, nullptr);
+    // First insert in layer 1 picks layer-relative slot 0.
     EXPECT_EQ(read_mirror_cell(1, static_cast<int>(ExpertProj::Up), 3), 0);
-    // All other cells stay -1.
+    // Other cells stay -1.
     EXPECT_EQ(read_mirror_cell(0, 0, 0), -1);
     EXPECT_EQ(read_mirror_cell(2, 2, 7), -1);
     EXPECT_TRUE(cache_.check_parity(stream_));
 }
 
-TEST_F(ExpertCachePhase2Test, ThreeInsertsPickUnoccupiedSlots) {
+TEST_F(ExpertCachePhase3Test, TwoInsertsPickUnoccupiedSlotsSameLayer) {
     load(0, ExpertProj::Gate, 0);
-    load(0, ExpertProj::Up, 0);
-    load(0, ExpertProj::Down, 0);
+    load(0, ExpertProj::Up, 1);
     EXPECT_EQ(read_mirror_cell(0, 0, 0), 0);
-    EXPECT_EQ(read_mirror_cell(0, 1, 0), 1);
-    EXPECT_EQ(read_mirror_cell(0, 2, 0), 2);
-    EXPECT_EQ(cache_.misses_, 3);
+    EXPECT_EQ(read_mirror_cell(0, 1, 1), 1);
+    EXPECT_EQ(cache_.misses_, 2);
     EXPECT_EQ(cache_.hits_, 0);
     EXPECT_TRUE(cache_.check_parity(stream_));
 }
 
-TEST_F(ExpertCachePhase2Test, HitDoesNotMoveSlot) {
+TEST_F(ExpertCachePhase3Test, ThirdInsertSameLayerEvictsLRU) {
+    load(0, ExpertProj::Gate, 0);    // -> slot 0 in layer 0
+    load(0, ExpertProj::Up, 1);      // -> slot 1 in layer 0
+    EXPECT_TRUE(cache_.check_parity(stream_));
+    // Layer 0 is now full (2/2 occupied). A third insert in layer 0 evicts
+    // slot 0 (the LRU): the Gate/0 cell goes to -1 and Down/2 takes slot 0.
+    load(0, ExpertProj::Down, 2);
+    EXPECT_EQ(read_mirror_cell(0, 0, 0), -1);
+    EXPECT_EQ(read_mirror_cell(0, 1, 1), 1);
+    EXPECT_EQ(read_mirror_cell(0, 2, 2), 0);
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase3Test, PerLayerIsolation) {
+    // Filling layer 0 must not affect layer 1's slots.
+    load(0, ExpertProj::Gate, 0);
+    load(0, ExpertProj::Up, 1);
+    load(0, ExpertProj::Down, 2);  // would evict layer 0's slot 0 (LRU)
+    // Layer 1 still untouched.
+    for (int p = 0; p < kExpertProjCount; ++p)
+        for (int e = 0; e < kNExperts; ++e)
+            EXPECT_EQ(read_mirror_cell(1, p, e), -1);
+    // Now insert into layer 1 — slot allocation starts fresh.
+    load(1, ExpertProj::Gate, 0);
+    EXPECT_EQ(read_mirror_cell(1, 0, 0), 0);
+    // Layer 0's state still intact.
+    EXPECT_EQ(read_mirror_cell(0, 1, 1), 1);
+    EXPECT_EQ(read_mirror_cell(0, 2, 2), 0);
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase3Test, HitDoesNotMoveSlot) {
     void* p0 = load(0, ExpertProj::Gate, 0);
     void* p1 = load(0, ExpertProj::Gate, 0);  // hit on same key
     EXPECT_EQ(p0, p1);
@@ -114,44 +148,19 @@ TEST_F(ExpertCachePhase2Test, HitDoesNotMoveSlot) {
     EXPECT_TRUE(cache_.check_parity(stream_));
 }
 
-TEST_F(ExpertCachePhase2Test, EvictionInvalidatesOldCellWritesNew) {
-    // Fill all 4 slots, then trigger eviction on the 5th insert.
-    load(0, ExpertProj::Gate, 0);  // -> slot 0
-    load(0, ExpertProj::Up, 1);    // -> slot 1
-    load(1, ExpertProj::Down, 2);  // -> slot 2
-    load(2, ExpertProj::Gate, 3);  // -> slot 3
-    EXPECT_TRUE(cache_.check_parity(stream_));
-
-    // Slot 0 (layer=0, proj=Gate, expert=0) is now the LRU. The next miss
-    // evicts it; that cell should read -1 and the new (layer=2, proj=Up,
-    // expert=4) cell should read the freed slot index.
-    load(2, ExpertProj::Up, 4);
-    EXPECT_EQ(read_mirror_cell(0, 0, 0), -1);
-    EXPECT_EQ(read_mirror_cell(2, 1, 4), 0);  // reused slot 0
+TEST_F(ExpertCachePhase3Test, AccessMovesToFrontResistsEviction) {
+    load(0, ExpertProj::Gate, 0);  // slot 0
+    load(0, ExpertProj::Up, 1);    // slot 1
+    load(0, ExpertProj::Gate, 0);  // hit → slot 0 becomes MRU
+    // Next miss in layer 0 should evict slot 1 (now LRU), not slot 0.
+    load(0, ExpertProj::Down, 2);
+    EXPECT_EQ(read_mirror_cell(0, 0, 0), 0);   // still resident
+    EXPECT_EQ(read_mirror_cell(0, 1, 1), -1);  // evicted
+    EXPECT_EQ(read_mirror_cell(0, 2, 2), 1);   // reused slot 1
     EXPECT_TRUE(cache_.check_parity(stream_));
 }
 
-TEST_F(ExpertCachePhase2Test, AccessMovesToFrontResistsEviction) {
-    // Insert 4 entries (slots 0..3).
-    load(0, ExpertProj::Gate, 0);
-    load(0, ExpertProj::Up, 1);
-    load(1, ExpertProj::Down, 2);
-    load(2, ExpertProj::Gate, 3);
-
-    // Touch slot 0 → it becomes most-recently-used. Next eviction should
-    // hit slot 1 (now LRU), not slot 0.
-    load(0, ExpertProj::Gate, 0);  // hit
-    load(2, ExpertProj::Up, 4);    // miss → evict slot 1
-
-    EXPECT_EQ(read_mirror_cell(0, 0, 0), 0);     // still resident
-    EXPECT_EQ(read_mirror_cell(0, 1, 1), -1);    // evicted
-    EXPECT_EQ(read_mirror_cell(2, 1, 4), 1);     // reused slot 1
-    EXPECT_TRUE(cache_.check_parity(stream_));
-}
-
-TEST_F(ExpertCachePhase2Test, ParityCheckCounterAdvances) {
-    // With debug_parity=true (set in SetUp), every get_or_load() runs
-    // check_parity() internally. After 4 inserts the counter should be ≥4.
+TEST_F(ExpertCachePhase3Test, ParityCheckCounterAdvances) {
     int64_t before = cache_.parity_checks_ok_;
     load(0, ExpertProj::Gate, 0);
     load(0, ExpertProj::Up, 1);
@@ -160,18 +169,41 @@ TEST_F(ExpertCachePhase2Test, ParityCheckCounterAdvances) {
     EXPECT_GE(cache_.parity_checks_ok_ - before, 4);
 }
 
-TEST_F(ExpertCachePhase2Test, MirrorDisabledWhenNoLayersOrExperts) {
-    // Re-init with n_layers=0 — mirror should not be allocated, but the
-    // host-side LRU should still function normally.
+TEST_F(ExpertCachePhase3Test, MirrorDisabledWhenNoExperts) {
+    // Re-init with n_experts=0 → mirror skipped, host LRU still works.
     ExpertLRUCache c;
-    ASSERT_TRUE(c.init(kSlotBytes, kBudgetBytes, /*alloc=*/nullptr, /*n_layers=*/0,
-                       /*n_experts=*/kNExperts));
+    ASSERT_TRUE(c.init(kSlotBytes, kBudgetBytes, /*alloc=*/nullptr, kNLayers,
+                       /*n_experts=*/0));
     EXPECT_EQ(c.d_lookup_, nullptr);
+    EXPECT_TRUE(c.host_expert_addrs_.empty());
     ExpertCacheKey key{fake_packed_ptr(0, 0), 0};
     void* p = c.get_or_load(0, ExpertProj::Gate, key, src_, kSlotBytes, stream_);
     EXPECT_NE(p, nullptr);
     EXPECT_TRUE(c.check_parity(stream_));  // trivially true when mirror is null
     c.destroy();
+}
+
+TEST_F(ExpertCachePhase3Test, HostExpertAddrsLazyPopulation) {
+    // Before any get_or_load: every cell of host_expert_addrs_ is nullptr.
+    ASSERT_EQ(static_cast<int>(cache_.host_expert_addrs_.size()), kNLayers);
+    for (const auto& row : cache_.host_expert_addrs_)
+        for (const void* p : row)
+            EXPECT_EQ(p, nullptr);
+
+    // First load stamps the cell.
+    load(1, ExpertProj::Up, 3);
+    size_t off = static_cast<size_t>(ExpertProj::Up) * kNExperts + 3;
+    EXPECT_EQ(cache_.host_expert_addrs_[1][off], src_);
+    // Same-layer different-cell is still unset.
+    size_t off_other = static_cast<size_t>(ExpertProj::Down) * kNExperts + 0;
+    EXPECT_EQ(cache_.host_expert_addrs_[1][off_other], nullptr);
+}
+
+TEST_F(ExpertCachePhase3Test, SlotPtrAgreesWithGpuPtr) {
+    void* p = load(2, ExpertProj::Up, 5);
+    int slot_in_layer = read_mirror_cell(2, static_cast<int>(ExpertProj::Up), 5);
+    ASSERT_GE(slot_in_layer, 0);
+    EXPECT_EQ(cache_.slot_ptr(2, slot_in_layer), p);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Phase 3 of the MoE host-offload + CUDA Graphs design memo (\`docs/plans/moe_host_offload_graphs_design_2026_05_17.md\` §5). Partitions the global slot pool per-layer, adds a lazy-built host source pointer table for capture-safe memcpy, and narrows the device mirror cell semantics to layer-relative slot indices.

Builds on Phase 2 (#233, merged) which laid the device-side mirror. Phase 4 (async prefetch L+1 from L) is the next slice and will recover the hit-rate regression noted below.

## What ships

- \`ExpertLRUCache::slots_per_layer_\` (new) — uniform per-layer pool depth. \`n_slots_\` = \`n_layers_ × slots_per_layer_\`. \`Slot[flat].layer\` encodes which sub-pool the slot belongs to.

- \`PerLayerLRU\` struct + \`per_layer_lru_[layer]\` vector — each layer has its own recency list + key→slot map. \`find()\` takes a layer arg now and only searches that layer's sub-pool. Layer L's evictions never touch layer M's slots — necessary for the Phase 4 prefetch L+1 from L pattern.

- \`host_expert_addrs_[layer][proj * n_experts + expert]\` — lazy-stamped host source pointer table. First \`get_or_load(layer, proj, key, src_host, …)\` records \`src_host\` into the cell; subsequent calls reuse it. Phase 5 will pass these as the fixed \`src\` argument of \`cudaGraphAddMemcpyNode\` so the captured graph can replay without recomputing host pointers per iteration.

- Device mirror cell value is now **layer-relative** slot index (\`0..slots_per_layer_-1\`) instead of the old global slot index. Read pattern documented in \`executor.h\`: \`slot = d_lookup_[layer * 3 * n_experts + proj * n_experts + expert]; src = pool_ + (layer * slots_per_layer + slot) * slot_size\`.

- \`ExpertLRUCache::slot_ptr(layer, slot_in_layer)\` — Phase 3 test helper + future Phase 5 kernel-side resolve template.

- \`tests/test_expert_cache.cu\` rewritten: 11 GTests covering init zero-fill, single insert into a chosen layer, two-inserts-pick-different-slots, third-insert-in-same-layer-evicts-LRU, **per-layer isolation** (loads in layer 0 don't affect layer 1's slots), hit-no-move, MRU-resists-eviction, parity counter, mirror-disabled-when-no-experts, \`host_expert_addrs\` lazy population, \`slot_ptr\`-agrees-with-\`gpu_ptr\`.

## Test plan

- [x] \`test-moe-gdn ExpertCachePhase3Test.*\` — 11/11 pass (205 ms total)
- [x] End-to-end host-offload on Qwen3.6-35B-A3B Q4_K_M with \`moe.force_host_experts=10\` + \`moe.expert_cache_debug_parity=true\`: **55k cache ops, zero parity divergences** across 2 reps × 64 decode tokens. Mirror semantics (layer-relative slot indices) match the host slot table after every mutation.
- [ ] CI gate on green build

## Perf note (known regression, addressed by Phase 4)

Without parity check, tg256 on the same model + \`force_host=10\` drops from Phase 2's 45.64 tok/s to Phase 3's 30.37 tok/s (**−33 %**). The LRU hit rate drops from 85.4 % to 63.1 % because the per-layer partition forces the same cache budget to be uniformly split across all 40 layers — including 30 non-MoE GDN/attn layers that never use their share. Total budget unchanged; effective per-MoE-layer capacity is ~4× smaller (32 slots/layer vs the old global pool which the 10 host-resident layers could freely fill from ~1300 global slots).

This regression is the cost of preparing for Phase 4 (async prefetch needs layer-isolated pools so prefetching L+1's experts can't evict L's hot data). Phase 4 hides PCIe behind compute so the lower hit rate stops mattering. A follow-up tweak — partitioning only among layers that actually have host-resident experts — would narrow the regression without changing the per-layer architecture, but it's out of scope here.

**In non-host-offload configs** (all experts on device, the default for every model in the imp baseline set), Phase 3 is a no-op: the cache isn't initialised, so no perf change.