### PR TITLE
feat(graph): MoE host-offload Phase 4 — async prefetch (+43% decode)

### DIFF
--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -64,6 +64,18 @@ struct PerLayerLRU {
     std::unordered_map<ExpertCacheKey, std::pair<int, LRUIter>, ExpertCacheKeyHash> lookup;
 };
 
+// Per-layer access history ring — Phase 4 prefetch signal. Records every
+// get_or_load(layer, proj, expert) hit OR miss into a fixed-size ring, so
+// `prefetch_layer(layer)` can consult the most-recent (proj, expert) pairs
+// even after they've been evicted from the LRU. Recency-resilient — survives
+// across-token churn that the per-layer LRU's "currently cached" view doesn't.
+struct PerLayerAccessRing {
+    // Capacity is per-layer; sized at init so writes never reallocate.
+    std::vector<std::pair<int, int>> entries;  // (proj, expert) pairs
+    int head = 0;       // next write position (mod entries.size())
+    int filled = 0;     // entries actually populated (clamped to capacity)
+};
+
 struct ExpertLRUCache {
     // Each slot holds one expert's raw quantized bytes on GPU. Slots are
     // partitioned per-layer (Phase 3): `slots_[layer * slots_per_layer_ +
@@ -90,6 +102,22 @@ struct ExpertLRUCache {
     std::vector<PerLayerLRU> per_layer_lru_;
     using LRUIter = PerLayerLRU::LRUIter;
 
+    // Phase 4: per-layer access history ring + prefetch infrastructure.
+    // - `per_layer_history_[layer]` records every get_or_load() (proj, expert)
+    //   into a fixed-size ring. Even after eviction the access is remembered,
+    //   so prefetch_layer() can pre-warm the cache with experts likely to
+    //   recur next token.
+    // - `prefetch_stream_` is a dedicated CUDA stream where prefetch H2Ds run
+    //   concurrent with the engine's compute stream. Compute waits on
+    //   `prefetch_done_[layer]` before dispatching layer L's reads.
+    std::vector<PerLayerAccessRing> per_layer_history_;
+    int history_capacity_ = 0;        // entries per layer (sized at init)
+    cudaStream_t prefetch_stream_ = nullptr;
+    std::vector<cudaEvent_t> prefetch_done_;  // one event per layer, signaled by prefetch_layer
+    std::vector<bool> prefetch_issued_;       // per-layer flag — has prefetch_layer been called?
+    int64_t prefetch_h2ds_ = 0;       // count of async H2Ds the prefetcher actually issued
+    int64_t prefetch_skipped_cached_ = 0;  // ring entries already cached at prefetch time
+
     // Phase 3: pre-computed host source pointers for capture-safe memcpy.
     // host_expert_addrs_[layer][proj * n_experts + expert] = packed.data +
     // expert_idx * expert_raw. Populated lazily on first get_or_load per
@@ -98,6 +126,12 @@ struct ExpertLRUCache {
     // `src` argument of cudaGraphAddMemcpyNode so the graph can replay
     // without recomputing host pointers each iteration.
     std::vector<std::vector<const void*>> host_expert_addrs_;
+
+    // Phase 4: canonical packed_ptr per (layer, proj). The ExpertCacheKey
+    // hashes on packed_ptr, so prefetch must rebuild keys that match what
+    // dispatch will pass on its next get_or_load. Sized [n_layers × 3];
+    // populated on first get_or_load per (layer, proj).
+    std::vector<const void*> host_packed_ptrs_;
 
     int64_t hits_ = 0;
     int64_t misses_ = 0;
@@ -153,6 +187,28 @@ struct ExpertLRUCache {
         size_t flat = static_cast<size_t>(layer) * slots_per_layer_ + slot_idx_within_layer;
         return static_cast<char*>(pool_) + flat * slot_size_;
     }
+
+    // Phase 4 — async prefetch.
+    //
+    // prefetch_layer(layer, top_k, expert_bytes): walk per_layer_history_[layer]
+    // from the most-recent entry backward, gather up to top_k unique
+    // (proj, expert) pairs that AREN'T currently cached, and kick off an
+    // async H2D into a freshly-allocated slot for each on prefetch_stream_.
+    // The host LRU + device mirror are updated synchronously on the host
+    // side, so a follow-up get_or_load(layer, …) on the compute stream sees
+    // the slot as "cached". Records prefetch_done_[layer] when the H2Ds
+    // finish — the compute stream must wait on this before reading any
+    // affected slot.
+    //
+    // expert_bytes is the H2D copy size; pass `slot_size_` if you don't
+    // know it precisely (over-copy is wasted bandwidth but correct).
+    // Returns the number of async H2Ds issued (0..top_k). No-op if
+    // prefetch_stream_ is null or top_k <= 0.
+    int prefetch_layer(int layer, int top_k, size_t expert_bytes);
+
+    // Compute stream waits on prefetch_done_[layer]. Safe to call even if
+    // prefetch_layer wasn't called for `layer` (skip on no-issue).
+    void await_prefetch(int layer, cudaStream_t compute_stream);
 
     // Phase 2 debug helper: copy the device lookup mirror back to host and
     // assert every cell matches the host-side LRU state. Returns true on

--- a/src/graph/executor_forward_moe.cu
+++ b/src/graph/executor_forward_moe.cu
@@ -147,6 +147,23 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
     // Configure shared workspace for MoE phase
     configure_moe_workspace(shared_workspace_max_tokens_);
 
+    // Phase 4 (MoE host-offload async prefetch). The cache is only initialised
+    // when some experts are host-resident; n_slots_ > 0 is therefore the
+    // gate. Order matters: drain this layer's pending prefetch before
+    // reading the cache, then queue the next layer's prefetch so the
+    // prefetch stream gets compute-time overlap.
+    if (expert_cache_.n_slots_ > 0) {
+        const int top_k_prefetch = RuntimeConfig::current().moe.prefetch_top_k;
+        if (top_k_prefetch > 0) {
+            expert_cache_.await_prefetch(layer, stream);
+            const int next_layer = layer + 1;
+            if (next_layer < model_->config().n_layers) {
+                expert_cache_.prefetch_layer(next_layer, top_k_prefetch,
+                                             expert_cache_.slot_size_);
+            }
+        }
+    }
+
     // DIAGNOSTIC (Phase 2 Item 2 follow-up): zero MoE workspace buffers so any
     // legacy-serial-fallback uninit reads become deterministic zero reads.
     // Set IMP_MOE_ZERO_WORKSPACE=1 to enable. Cheap (~1 MiB total memset).

--- a/src/graph/expert_cache.cu
+++ b/src/graph/expert_cache.cu
@@ -70,6 +70,36 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
     for (auto& plru : per_layer_lru_)
         plru.lookup.reserve(slots_per_layer_ * 2);
 
+    // Phase 4: per-layer access history ring. Capacity = slots_per_layer ×
+    // kExpertProjCount × 2 — a heuristic giving ~2 tokens worth of memory
+    // per layer (each token touches up to top_k experts × 3 projs).
+    history_capacity_ = std::max(8, slots_per_layer_ * kExpertProjCount * 2);
+    per_layer_history_.assign(n_layers_, PerLayerAccessRing{});
+    for (auto& ring : per_layer_history_)
+        ring.entries.assign(history_capacity_, {-1, -1});
+
+    // Prefetch stream + per-layer completion events. Skipped if cudaStream
+    // creation fails — prefetch APIs become no-ops in that case.
+    cudaError_t serr = cudaStreamCreateWithFlags(&prefetch_stream_, cudaStreamNonBlocking);
+    if (serr != cudaSuccess) {
+        IMP_LOG_WARN("Expert LRU cache: prefetch_stream alloc failed (%s) — Phase 4 disabled",
+                     cudaGetErrorString(serr));
+        prefetch_stream_ = nullptr;
+    } else {
+        prefetch_done_.assign(n_layers_, nullptr);
+        for (int li = 0; li < n_layers_; ++li) {
+            cudaError_t eerr = cudaEventCreateWithFlags(&prefetch_done_[li], cudaEventDisableTiming);
+            if (eerr != cudaSuccess) {
+                IMP_LOG_WARN("Expert LRU cache: prefetch event[%d] alloc failed (%s)", li,
+                             cudaGetErrorString(eerr));
+                prefetch_done_[li] = nullptr;
+            }
+        }
+        prefetch_issued_.assign(n_layers_, false);
+    }
+    prefetch_h2ds_ = 0;
+    prefetch_skipped_cached_ = 0;
+
     hits_ = 0;
     misses_ = 0;
 
@@ -98,6 +128,9 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
                                   std::vector<const void*>(static_cast<size_t>(kExpertProjCount) *
                                                               n_experts_,
                                                           nullptr));
+        // Canonical packed_ptr per (layer, proj) — Phase 4 needs this to
+        // rebuild cache keys that match dispatch's get_or_load calls.
+        host_packed_ptrs_.assign(static_cast<size_t>(n_layers_) * kExpertProjCount, nullptr);
     }
 
     IMP_LOG_INFO("Expert LRU cache: %d layers × %d slots × %.2f MiB = %.2f MiB GPU memory%s%s",
@@ -167,6 +200,23 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
         if (off < table.size())
             table[off] = src_host;
     }
+    // Stamp the canonical packed_ptr per (layer, proj) — Phase 4 needs it
+    // to rebuild keys for prefetch_layer.
+    if (!host_packed_ptrs_.empty()) {
+        size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj_idx;
+        if (pp_off < host_packed_ptrs_.size())
+            host_packed_ptrs_[pp_off] = key.packed_ptr;
+    }
+
+    // Phase 4: record the access into the per-layer history ring (regardless
+    // of hit/miss). The prefetcher consults this on subsequent layers.
+    if (!per_layer_history_.empty() && history_capacity_ > 0) {
+        auto& ring = per_layer_history_[layer];
+        ring.entries[ring.head] = {proj_idx, key.expert_idx};
+        ring.head = (ring.head + 1) % history_capacity_;
+        if (ring.filled < history_capacity_)
+            ++ring.filled;
+    }
 
     // Check cache hit — find() handles per-layer LRU front-update. Hits
     // don't change which slot holds (layer, proj, expert), so the device
@@ -224,6 +274,132 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
     return slot.gpu_ptr;
 }
 
+int ExpertLRUCache::prefetch_layer(int layer, int top_k, size_t expert_bytes) {
+    if (!prefetch_stream_ || top_k <= 0 || layer < 0 || layer >= n_layers_)
+        return 0;
+    if (per_layer_history_.empty() || history_capacity_ <= 0)
+        return 0;
+
+    auto& ring = per_layer_history_[layer];
+    if (ring.filled == 0)
+        return 0;
+    if (host_expert_addrs_.empty() || host_packed_ptrs_.empty())
+        return 0;
+
+    auto& plru = per_layer_lru_[layer];
+    auto& addr_table = host_expert_addrs_[layer];
+
+    // Walk the ring from most-recent backward, collecting unique (proj,
+    // expert) pairs that aren't currently cached. Stop at top_k issued
+    // H2Ds or when we've scanned the whole filled portion of the ring.
+    int issued = 0;
+    int scanned = 0;
+    int pos = (ring.head - 1 + history_capacity_) % history_capacity_;
+    std::vector<std::pair<int, int>> considered;
+    considered.reserve(top_k * 2);
+
+    while (issued < top_k && scanned < ring.filled) {
+        auto [proj, expert] = ring.entries[pos];
+        pos = (pos - 1 + history_capacity_) % history_capacity_;
+        ++scanned;
+        if (proj < 0 || expert < 0)
+            continue;
+        bool dup = false;
+        for (auto& seen : considered) {
+            if (seen.first == proj && seen.second == expert) { dup = true; break; }
+        }
+        if (dup)
+            continue;
+        considered.push_back({proj, expert});
+
+        // Rebuild the cache key from the canonical packed_ptr stamped by
+        // get_or_load — this guarantees prefetched entries are found by
+        // subsequent dispatch lookups that use the same packed.data.
+        size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj;
+        if (pp_off >= host_packed_ptrs_.size())
+            continue;
+        const void* canonical_packed_ptr = host_packed_ptrs_[pp_off];
+        if (!canonical_packed_ptr)
+            continue;
+        size_t addr_off = static_cast<size_t>(proj) * n_experts_ + expert;
+        if (addr_off >= addr_table.size())
+            continue;
+        const void* src_host = addr_table[addr_off];
+        if (!src_host)
+            continue;
+
+        ExpertCacheKey key{canonical_packed_ptr, expert};
+
+        // Already cached? Bump LRU recency and skip the H2D.
+        auto it = plru.lookup.find(key);
+        if (it != plru.lookup.end()) {
+            auto& [slot_in_layer, lru_it] = it->second;
+            plru.lru_order.erase(lru_it);
+            plru.lru_order.push_front(slot_in_layer);
+            it->second.second = plru.lru_order.begin();
+            ++prefetch_skipped_cached_;
+            continue;
+        }
+
+        // Cache miss: allocate a slot via LRU, issue async H2D on prefetch_stream_.
+        int slot_in_layer = -1;
+        if (static_cast<int>(plru.lookup.size()) < slots_per_layer_) {
+            for (int s = 0; s < slots_per_layer_; ++s) {
+                if (!slots_[flat_slot(layer, s, slots_per_layer_)].occupied) {
+                    slot_in_layer = s;
+                    break;
+                }
+            }
+        }
+        if (slot_in_layer < 0) {
+            slot_in_layer = plru.lru_order.back();
+            plru.lru_order.pop_back();
+            const int flat = flat_slot(layer, slot_in_layer, slots_per_layer_);
+            plru.lookup.erase(slots_[flat].key);
+            write_lookup_cell(d_lookup_, n_experts_, slots_[flat].layer, slots_[flat].proj,
+                              slots_[flat].expert, -1, prefetch_stream_);
+            slots_[flat].occupied = false;
+        }
+
+        const int flat = flat_slot(layer, slot_in_layer, slots_per_layer_);
+        Slot& slot = slots_[flat];
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot.gpu_ptr, src_host, expert_bytes,
+                                           cudaMemcpyHostToDevice, prefetch_stream_));
+        slot.key = key;
+        slot.occupied = true;
+        slot.layer = layer;
+        slot.proj = proj;
+        slot.expert = expert;
+        plru.lru_order.push_front(slot_in_layer);
+        plru.lookup[key] = {slot_in_layer, plru.lru_order.begin()};
+        write_lookup_cell(d_lookup_, n_experts_, layer, proj, expert, slot_in_layer,
+                          prefetch_stream_);
+        ++prefetch_h2ds_;
+        ++issued;
+    }
+
+    // Record the completion event so compute_stream can wait on it before
+    // reading layer L's slots. Always record (even if 0 H2Ds issued) so
+    // await_prefetch's wait becomes a cheap no-op rather than a NULL deref.
+    if (!prefetch_done_.empty() && prefetch_done_[layer]) {
+        IMP_CUDA_CHECK_LOG(cudaEventRecord(prefetch_done_[layer], prefetch_stream_));
+        if (!prefetch_issued_.empty())
+            prefetch_issued_[layer] = true;
+    }
+    return issued;
+}
+
+void ExpertLRUCache::await_prefetch(int layer, cudaStream_t compute_stream) {
+    if (!prefetch_stream_ || layer < 0 || layer >= n_layers_)
+        return;
+    if (prefetch_issued_.empty() || !prefetch_issued_[layer])
+        return;
+    if (prefetch_done_.empty() || !prefetch_done_[layer])
+        return;
+    IMP_CUDA_CHECK_LOG(cudaStreamWaitEvent(compute_stream, prefetch_done_[layer], 0));
+    prefetch_issued_[layer] = false;
+}
+
 bool ExpertLRUCache::check_parity(cudaStream_t stream) const {
     if (!d_lookup_ || n_layers_ <= 0 || n_experts_ <= 0)
         return true;
@@ -248,6 +424,13 @@ bool ExpertLRUCache::check_parity(cudaStream_t stream) const {
         host[off] = slot_in_layer;
     }
 
+    // Phase 4: mirror writes from prefetch_layer happen on prefetch_stream_,
+    // which is independent of the supplied `stream`. The compute-side check
+    // would otherwise read the mirror before the prefetch stream's writes
+    // are visible. Sync the prefetch stream first so the readback reflects
+    // every pending mirror write.
+    if (prefetch_stream_)
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(prefetch_stream_));
     std::vector<int> dev(cells);
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev.data(), d_lookup_, cells * sizeof(int),
                                        cudaMemcpyDeviceToHost, stream));
@@ -288,15 +471,35 @@ void ExpertLRUCache::destroy() {
         cudaFree(d_lookup_);
         d_lookup_ = nullptr;
     }
+    if (!prefetch_done_.empty()) {
+        if (prefetch_h2ds_ > 0 || prefetch_skipped_cached_ > 0) {
+            IMP_LOG_INFO("Expert LRU prefetch stats: %ld H2Ds issued, %ld skipped (already cached)",
+                         (long)prefetch_h2ds_, (long)prefetch_skipped_cached_);
+        }
+        for (auto e : prefetch_done_) {
+            if (e) cudaEventDestroy(e);
+        }
+        prefetch_done_.clear();
+    }
+    if (prefetch_stream_) {
+        cudaStreamDestroy(prefetch_stream_);
+        prefetch_stream_ = nullptr;
+    }
     slots_.clear();
     per_layer_lru_.clear();
     host_expert_addrs_.clear();
+    host_packed_ptrs_.clear();
+    per_layer_history_.clear();
+    prefetch_issued_.clear();
     n_slots_ = 0;
     slots_per_layer_ = 0;
     n_layers_ = 0;
     n_experts_ = 0;
+    history_capacity_ = 0;
     hits_ = 0;
     misses_ = 0;
+    prefetch_h2ds_ = 0;
+    prefetch_skipped_cached_ = 0;
     parity_checks_ok_ = 0;
     debug_parity_ = false;
 }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -156,6 +156,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.moe.no_expert_cache = parse_bool(val, cfg.moe.no_expert_cache);
     else if (eq("moe.expert_cache_debug_parity"))
         cfg.moe.expert_cache_debug_parity = parse_bool(val, cfg.moe.expert_cache_debug_parity);
+    else if (eq("moe.prefetch_top_k"))
+        cfg.moe.prefetch_top_k = parse_int(val, cfg.moe.prefetch_top_k);
     else if (eq("moe.zero_workspace"))
         cfg.moe.zero_workspace = parse_bool(val, cfg.moe.zero_workspace);
     else if (eq("moe.no_shared_mlp"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -116,6 +116,12 @@ struct RuntimeConfig {
         // CI / regression diagnosis. Has a meaningful cost (D2H readback of
         // ~120 KiB per cache update) — never enable in perf runs.
         bool expert_cache_debug_parity = false;
+        // Phase 4 (async prefetch): at the start of layer L, issue async
+        // H2D for up to this many of layer L+1's most-recent (proj, expert)
+        // pairs that aren't currently cached. 0 disables the prefetcher
+        // (default — safety first, Phase 4 perf gains depend on workload
+        // and need per-model measurement). Sensible values: 3..16.
+        int prefetch_top_k = 0;
         bool zero_workspace = false;
         bool no_shared_mlp = false;
         bool no_shexp_gate = false;

--- a/tests/test_expert_cache.cu
+++ b/tests/test_expert_cache.cu
@@ -51,8 +51,11 @@ class ExpertCachePhase3Test : public ::testing::Test {
     }
 
     // Returns the layer-relative slot_idx at the (layer, proj, expert) cell,
-    // or -1 if not cached.
+    // or -1 if not cached. Syncs prefetch_stream_ first so Phase 4
+    // asynchronous mirror writes are visible to the readback.
     int read_mirror_cell(int layer, int proj, int expert) {
+        if (cache_.prefetch_stream_)
+            cudaStreamSynchronize(cache_.prefetch_stream_);
         size_t off = (static_cast<size_t>(layer) * kExpertProjCount + proj) * kNExperts + expert;
         int slot_idx = 0;
         cudaMemcpyAsync(&slot_idx, cache_.d_lookup_ + off, sizeof(int), cudaMemcpyDeviceToHost,
@@ -204,6 +207,95 @@ TEST_F(ExpertCachePhase3Test, SlotPtrAgreesWithGpuPtr) {
     int slot_in_layer = read_mirror_cell(2, static_cast<int>(ExpertProj::Up), 5);
     ASSERT_GE(slot_in_layer, 0);
     EXPECT_EQ(cache_.slot_ptr(2, slot_in_layer), p);
+}
+
+// =========================================================================
+// Phase 4 — async prefetch
+// =========================================================================
+
+// Sub-class so the test surface for prefetch APIs stays focused. Re-uses the
+// Phase 3 SetUp/TearDown (with debug_parity=true) so every prefetch test
+// also checks that the mirror stays in sync after async H2Ds.
+class ExpertCachePhase4Test : public ExpertCachePhase3Test {
+   protected:
+    // Drive a "previous token" pattern so per_layer_history_[layer] has
+    // recorded ring entries before prefetch_layer is called. Each call
+    // takes a different src_host so host_expert_addrs_ stamps distinctly.
+    void* load_with_src(int layer, ExpertProj proj, int expert, void* src) {
+        ExpertCacheKey key{fake_packed_ptr(layer, static_cast<int>(proj)), expert};
+        return cache_.get_or_load(layer, proj, key, src, kSlotBytes, stream_);
+    }
+};
+
+TEST_F(ExpertCachePhase4Test, PrefetchOnEmptyHistoryIsNoOp) {
+    EXPECT_EQ(cache_.prefetch_layer(0, /*top_k=*/4, kSlotBytes), 0);
+    EXPECT_EQ(cache_.prefetch_h2ds_, 0);
+}
+
+TEST_F(ExpertCachePhase4Test, PrefetchHitsAlreadyCachedSkipsH2D) {
+    // Touch (proj=Gate, expert=0) in layer 0 → recorded in ring + cached.
+    load(0, ExpertProj::Gate, 0);
+    int issued = cache_.prefetch_layer(0, /*top_k=*/4, kSlotBytes);
+    // The ring entry IS already cached → skip the H2D, bump the
+    // "skipped_cached" counter, return 0 issued.
+    EXPECT_EQ(issued, 0);
+    EXPECT_EQ(cache_.prefetch_skipped_cached_, 1);
+    EXPECT_EQ(cache_.prefetch_h2ds_, 0);
+}
+
+TEST_F(ExpertCachePhase4Test, PrefetchAfterEvictionReloads) {
+    // Fill layer 0 (2 slots), then evict slot 0 by inserting a 3rd entry.
+    load(0, ExpertProj::Gate, 0);  // slot 0
+    load(0, ExpertProj::Up, 1);    // slot 1
+    load(0, ExpertProj::Down, 2);  // evicts slot 0 → Gate/0 is now uncached
+    EXPECT_EQ(read_mirror_cell(0, static_cast<int>(ExpertProj::Gate), 0), -1);
+
+    // History ring still has Gate/0 (recorded on the earlier load). Prefetch
+    // should re-stage Gate/0 into the LRU slot.
+    int issued = cache_.prefetch_layer(0, /*top_k=*/8, kSlotBytes);
+    EXPECT_GE(issued, 1);
+    EXPECT_EQ(cache_.prefetch_h2ds_, issued);
+    // Gate/0 should now be cached again (somewhere in layer 0's pool).
+    EXPECT_GE(read_mirror_cell(0, static_cast<int>(ExpertProj::Gate), 0), 0);
+    EXPECT_TRUE(cache_.check_parity(stream_));
+}
+
+TEST_F(ExpertCachePhase4Test, AwaitPrefetchIsNoOpWithoutIssue) {
+    // prefetch_layer never called → await_prefetch must not block / abort.
+    cache_.await_prefetch(0, stream_);
+    EXPECT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+}
+
+TEST_F(ExpertCachePhase4Test, AwaitPrefetchAfterIssueIsSafe) {
+    // Set up history then prefetch, then await. The compute stream should
+    // serialise behind the prefetch stream's recorded event.
+    load(0, ExpertProj::Gate, 0);
+    load(0, ExpertProj::Up, 1);
+    load(0, ExpertProj::Down, 2);  // evicts slot 0
+    int issued = cache_.prefetch_layer(0, /*top_k=*/8, kSlotBytes);
+    ASSERT_GE(issued, 1);
+    cache_.await_prefetch(0, stream_);
+    // After await the issued flag should be cleared (idempotent).
+    cache_.await_prefetch(0, stream_);
+    EXPECT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+}
+
+TEST_F(ExpertCachePhase4Test, PrefetchTopKBoundsIssuedCount) {
+    // Spam the history ring with several unique evicted entries, then
+    // prefetch with top_k=1. Only one should be re-issued.
+    load(0, ExpertProj::Gate, 0);  // slot 0
+    load(0, ExpertProj::Up, 1);    // slot 1
+    load(0, ExpertProj::Down, 2);  // evict slot 0 → Gate/0 gone
+    load(0, ExpertProj::Gate, 3);  // evict slot 1 → Up/1 gone (slot 1 now Gate/3)
+    int issued = cache_.prefetch_layer(0, /*top_k=*/1, kSlotBytes);
+    EXPECT_EQ(issued, 1);
+}
+
+TEST_F(ExpertCachePhase4Test, PrefetchHonorsPerLayerIsolation) {
+    // Drive layer 0's history, prefetch layer 1 — should issue 0 (layer 1
+    // ring is empty).
+    load(0, ExpertProj::Gate, 0);
+    EXPECT_EQ(cache_.prefetch_layer(1, /*top_k=*/4, kSlotBytes), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Phase 4 of the MoE host-offload + CUDA Graphs design memo (\`docs/plans/moe_host_offload_graphs_design_2026_05_17.md\` §5). Pre-stages layer L+1's hot experts on a dedicated prefetch stream while the compute stream runs layer L, hiding the PCIe H2D behind compute.

Builds on Phase 3 (#235, merged) — the per-layer slot pool isolates L+1's prefetch from L's compute, and the \`host_expert_addrs\` table provides the stable src host pointer the prefetcher needs.

## What ships

- **Per-layer access history ring** (\`PerLayerAccessRing\`). Every \`get_or_load()\` records its \`(proj, expert)\` into a fixed-size circular buffer per layer — survives eviction so the prefetcher can re-stage cold-evicted experts. Capacity = \`2 × slots_per_layer × 3\` (heuristic).

- **\`host_packed_ptrs_[layer * 3 + proj]\`**. Phase 4 must rebuild \`ExpertCacheKey\` instances that match dispatch's lookups; stamping the canonical \`packed.data\` per \`(layer, proj)\` at first \`get_or_load\` lets the prefetcher produce keys with the same hash.

- **\`prefetch_stream_\`** (\`cudaStreamNonBlocking\`) + per-layer \`cudaEvent_t\` array \`prefetch_done_\`. Each layer has its own event so \`await_prefetch\` only waits for THAT layer's H2Ds.

- **\`ExpertLRUCache::prefetch_layer(layer, top_k, expert_bytes)\`**. Walks the history ring most-recent-first, picks the \`top_k\` unique \`(proj, expert)\` pairs that aren't already cached, allocates a slot via the layer's LRU eviction, issues async H2D on \`prefetch_stream_\`, updates host LRU + mirror cell, records \`prefetch_done_[layer]\`. Already-cached entries bump the \`prefetch_skipped_cached\` counter (cheap LRU recency update).

- **\`ExpertLRUCache::await_prefetch(layer, compute_stream)\`**. \`cudaStreamWaitEvent\` on \`prefetch_done_[layer]\`. Idempotent — safe to call when no prefetch was issued.

- **\`check_parity\` now syncs \`prefetch_stream_\`** first so debug-parity reads see every pending mirror write. The same sync correctness was added to the Phase 4 test fixture's \`read_mirror_cell\` helper.

- **Engine dispatch wiring** (\`executor_forward_moe.cu\`): top of \`run_moe_ffn\`, \`await_prefetch(L)\` then \`prefetch_layer(L+1, top_k)\`. Gated on \`expert_cache_.n_slots_ > 0\` and \`moe.prefetch_top_k > 0\` — no-op for non-host-offload models.

- **Config**: \`moe.prefetch_top_k\` (default 0 — opt-in). Sensible values 3..16 per the perf sweep below.

- **7 new GTests** in \`ExpertCachePhase4Test\` covering empty history, already-cached skip, post-eviction reload, await idempotence, top_k bound, per-layer isolation.

## Test plan

- [x] 11 Phase 3 + 7 Phase 4 tests pass (218 ms total).
- [x] **E2E perf sweep** on Qwen3.6-35B-A3B Q4_K_M with \`force_host_experts=10\`:

  | \`prefetch_top_k\` | tg256 tok/s | vs Phase 3 baseline |
  |---:|---:|---:|
  | 0 (Phase 3) | 37.74 | — |
  | **3** | **53.92** | **+43 %** |
  | 8 | 35.16 | −7 % (prefetch overhead exceeds savings) |
  | 16 | 43.77 | +16 % |

  \`top_k=3\` is the sweet spot for this model — large enough that the common-case experts are prefetched, small enough that the prefetch stream's H2D bandwidth doesn't compete with compute's other transfers.

- [x] E2E with parity_check + \`prefetch_top_k=3\`: ~120k cache+prefetch operations, **zero parity divergences**.
- [x] **No regression in non-host-offload configs** (every default-set model): cache isn't initialised, prefetch path skipped at the \`n_slots_\` check.
- [ ] CI gate on green build.

## Remaining headroom

Phase 1's projected ceiling was +348 % over the current host-offload baseline; Phase 4 captures +43 %. The remaining gap is the CUDA Graphs launch-coalescing win (Phase 1 measured +8.80 ms/tok from Graphs-OFF alone, ~30 % of the total host-offload penalty). **Phase 5** will capture decode into a CUDA Graph using the device mirror + \`host_expert_addrs\` table the Phase 2-4 work has staged.