### PR TITLE
fix(graph): MoE prefetch — per-(layer, proj) byte size correctness

### DIFF
--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -133,6 +133,14 @@ struct ExpertLRUCache {
     // populated on first get_or_load per (layer, proj).
     std::vector<const void*> host_packed_ptrs_;
 
+    // Phase 5: per-(layer, proj) expert byte size. The prefetch path can't
+    // reuse the global slot_size_ (max across projs) because smaller
+    // projections — e.g. Qwen3.6 gate @ 144 MiB vs down @ 176 MiB — would
+    // overflow the pinned host region during cudaMemcpyAsync and fail with
+    // "invalid argument". Populated on first get_or_load per (layer, proj)
+    // when the caller passes the actual per-expert byte size.
+    std::vector<size_t> host_expert_bytes_;
+
     int64_t hits_ = 0;
     int64_t misses_ = 0;
 

--- a/src/graph/expert_cache.cu
+++ b/src/graph/expert_cache.cu
@@ -131,6 +131,10 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
         // Canonical packed_ptr per (layer, proj) — Phase 4 needs this to
         // rebuild cache keys that match dispatch's get_or_load calls.
         host_packed_ptrs_.assign(static_cast<size_t>(n_layers_) * kExpertProjCount, nullptr);
+        // Per-(layer, proj) expert byte size — Phase 5 prereq. Avoids
+        // overflowing pinned host regions when projections have different
+        // sizes (e.g. Qwen3.6 gate < down).
+        host_expert_bytes_.assign(static_cast<size_t>(n_layers_) * kExpertProjCount, 0);
     }
 
     IMP_LOG_INFO("Expert LRU cache: %d layers × %d slots × %.2f MiB = %.2f MiB GPU memory%s%s",
@@ -207,6 +211,13 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
         if (pp_off < host_packed_ptrs_.size())
             host_packed_ptrs_[pp_off] = key.packed_ptr;
     }
+    // Stamp the per-(layer, proj) expert byte size — prefetch must use this
+    // (not slot_size_) to avoid reading past the pinned host region.
+    if (!host_expert_bytes_.empty()) {
+        size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj_idx;
+        if (pp_off < host_expert_bytes_.size() && expert_bytes > 0)
+            host_expert_bytes_[pp_off] = expert_bytes;
+    }
 
     // Phase 4: record the access into the per-layer history ring (regardless
     // of hit/miss). The prefetcher consults this on subsequent layers.
@@ -274,7 +285,7 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
     return slot.gpu_ptr;
 }
 
-int ExpertLRUCache::prefetch_layer(int layer, int top_k, size_t expert_bytes) {
+int ExpertLRUCache::prefetch_layer(int layer, int top_k, size_t expert_bytes_fallback) {
     if (!prefetch_stream_ || top_k <= 0 || layer < 0 || layer >= n_layers_)
         return 0;
     if (per_layer_history_.empty() || history_capacity_ <= 0)
@@ -363,7 +374,16 @@ int ExpertLRUCache::prefetch_layer(int layer, int top_k, size_t expert_bytes) {
 
         const int flat = flat_slot(layer, slot_in_layer, slots_per_layer_);
         Slot& slot = slots_[flat];
-        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot.gpu_ptr, src_host, expert_bytes,
+        // Prefer the per-(layer, proj) byte size — using slot_size_ as the
+        // fallback overflows for smaller projections and produces a CUDA
+        // "invalid argument" on pinned-but-narrower host regions.
+        size_t copy_bytes = expert_bytes_fallback;
+        if (!host_expert_bytes_.empty()) {
+            size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj;
+            if (pp_off < host_expert_bytes_.size() && host_expert_bytes_[pp_off] > 0)
+                copy_bytes = host_expert_bytes_[pp_off];
+        }
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot.gpu_ptr, src_host, copy_bytes,
                                            cudaMemcpyHostToDevice, prefetch_stream_));
         slot.key = key;
         slot.occupied = true;
@@ -489,6 +509,7 @@ void ExpertLRUCache::destroy() {
     per_layer_lru_.clear();
     host_expert_addrs_.clear();
     host_packed_ptrs_.clear();
+    host_expert_bytes_.clear();
     per_layer_history_.clear();
     prefetch_issued_.clear();
     n_slots_ = 0;


### PR DESCRIPTION
## Summary

Phase 4 (#236) passes \`slot_size_\` — the max expert byte size across all projections — to \`prefetch_layer\`'s \`cudaMemcpyAsync\`. Smaller projections (e.g. Qwen3.6 gate @ 144 MiB vs down @ 176 MiB) overflow the WSL2-pinned host region of the smaller proj, and the async copy fails with \`invalid argument\` against \`prefetch_stream_\`. The error was being swallowed by the executor's \"Cleared stale error before forward\" path so the bug was silent in production, but the prefetch's nominal H2Ds-issued counter overstated how many bytes actually reached the GPU.

Surfaced while implementing Phase 5 (CUDA Graphs under host-offload): the broken prefetch errors polluted the capture stream's error state and made it impossible to diagnose Phase 5's separate cross-stream event blocker cleanly.

## Fix

- Add \`host_expert_bytes_[layer * 3 + proj]\` — populated on first \`get_or_load\` per (layer, proj) with the actual per-expert byte size that the caller passes.
- \`prefetch_layer\` prefers this table over \`slot_size_\`; the global \`slot_size_\` stays as a fallback only when the table cell hasn't been stamped yet (first prefetch ever, before any \`get_or_load\` on that layer/proj).

## Test plan

- [x] \`test-moe-gdn ExpertCachePhase3Test.* + ExpertCachePhase4Test.*\` — 18/18 pass (210 ms total).
- [x] **End-to-end** host-offload (Qwen3.6-35B-A3B Q4_K_M, \`force_host_experts=10\`, \`prefetch_top_k=3\`, 5 reps × 256 tg tokens): **zero \"invalid argument\" errors** during prefill or decode. Output text unchanged from the pre-fix run (the bug was silent — the fallback path on compute stream re-loaded the same experts the broken prefetch had recorded as cached).
- [ ] CI gate on green build.

## Perf — honest re-measurement

With the broken prefetch silently no-op'ing the failed H2Ds and re-using stale slot content, **the original Phase 4 PR reported +43 %** decode vs Phase 3 baseline. After this correctness fix, the real Phase 4 gain at \`prefetch_top_k=3\` is **+10 %** (30.80 → 33.78 tok/s on Qwen3.6-35B Q4_K_M force_host=10). The original measurement was an artifact of the slot data happening to already hold the right expert from prior loads — the broken prefetch was effectively a no-op that saved one real H2D per cache \"hit\".

Honest Phase 4 perf at \`prefetch_top_k=3\` is **+10 %**, not +43 %. The Phase 4 PR description's perf claim will be corrected in a roadmap follow-up.

Sweep on the fixed build:

| \`prefetch_top_k\` | tg256 tok/s | hit rate |
|---:|---:|---:|
| 0 (Phase 3 baseline) | 30.80 | 65.3 % |
| 1 | 29.13 | 50.1 % |
| **3** | **33.78** (+10 %) | 60.8 % |
| 8 | 25.14 | 50.1 % |