### PR TITLE
feat(tests): FP4 PV Phase 3a microbench — single-level catastrophic, MMA gain real

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ if(IMP_USE_CUTLASS)
         list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/mxf4nvf4_mma_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/mxf4nvf4_mma_variants_bench.cu)
+        list(APPEND IMP_COMPUTE_SOURCES tests/bench/fp4_pv_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_qkt_validate.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/tma_block_scale_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/fmha_v_load_bench.cu)
@@ -472,6 +473,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mxf4nvf4_probe.cu
         tests/test_mxf4nvf4_mma_bench.cu
         tests/test_mxf4nvf4_mma_variants_bench.cu
+        tests/test_fp4_pv_bench.cu
         tests/test_mxf4nvf4_qkt_validate.cu
         tests/test_tma_block_scale_bench.cu
         tests/test_fmha_v_load_bench.cu

--- a/tests/bench/fp4_pv_bench.cu
+++ b/tests/bench/fp4_pv_bench.cu
@@ -1,0 +1,328 @@
+// =============================================================================
+// fp4_pv_bench.cu — Phase 3a FP4 PV microbench
+// =============================================================================
+//
+// See bench/fp4_pv_bench.h for the design rationale (in short: discriminates
+// whether single-level FP4 quantisation of post-softmax probabilities
+// preserves enough numerical precision for the +13 % MMA-level upside to
+// translate into useful end-to-end attention quality — before committing
+// the multi-week Phase 3b/3c production work).
+// =============================================================================
+
+#include "bench/fp4_pv_bench.h"
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+namespace imp {
+
+// -----------------------------------------------------------------------------
+// FP4 + UE4M3 encode/decode (host-side reference)
+// -----------------------------------------------------------------------------
+//
+// E2M1 magnitudes (sign bit separate): {0, 0.5, 1, 1.5, 2, 3, 4, 6}
+// E4M3 unsigned: exponent 4 bits (bias 7), mantissa 3 bits → max=448, min>0=2^-9.
+//
+// Mirrors the software fallback in `src/compute/attention_fmha_mxfp4_sm120.cu`
+// (`pack_fp4_pair` and `float_to_fp8_e4m3`). The PTX HW path uses IEEE RNE;
+// our software path uses midpoint cascade — tiny divergence at boundaries
+// that is not material for the long-tail truncation question Phase 3a tests.
+
+static constexpr float kFp4Mag[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+
+static uint8_t quantise_fp4(float v) {
+    uint8_t sign = (v < 0.0f) ? 1u : 0u;
+    float a = std::fabs(v);
+    int mag = (a >= 0.25f) + (a >= 0.75f) + (a >= 1.25f) + (a >= 1.75f) +
+              (a >= 2.5f)  + (a >= 3.5f)  + (a >= 5.0f);
+    return static_cast<uint8_t>((sign << 3) | mag);
+}
+
+static float dequantise_fp4(uint8_t code) {
+    int sign = (code >> 3) & 1;
+    int mag = code & 7;
+    float m = kFp4Mag[mag];
+    return sign ? -m : m;
+}
+
+static uint8_t encode_ue4m3(float v) {
+    if (v <= 0.0f) return 0;
+    // Bias 7, 3 mantissa bits, no inf/NaN encoding (positive only).
+    int exp;
+    float frac = std::frexp(v, &exp);  // frac in [0.5, 1), v = frac * 2^exp
+    int biased = (exp - 1) + 7;        // shift to normalised [1, 2) representation
+    if (biased < 0) return 0;
+    if (biased > 15) biased = 15;
+    float normalised = std::ldexp(frac, 1);  // now in [1, 2)
+    int mantissa = static_cast<int>(std::round((normalised - 1.0f) * 8.0f));
+    if (mantissa >= 8) { mantissa = 0; biased++; if (biased > 15) biased = 15; }
+    return static_cast<uint8_t>((biased << 3) | mantissa);
+}
+
+static float decode_ue4m3(uint8_t bits) {
+    int exp = (bits >> 3) & 0xF;
+    int mantissa = bits & 7;
+    if (exp == 0) return 0.0f;  // simplification — actual subnormals not used here
+    return std::ldexp(1.0f + mantissa / 8.0f, exp - 7);
+}
+
+// -----------------------------------------------------------------------------
+// Per-16-element block-scale quantise + dequantise (matches PTX semantics)
+// -----------------------------------------------------------------------------
+
+static void quantise_row_fp4(const float* row, int K, std::vector<uint8_t>& codes_out,
+                             std::vector<uint8_t>& scales_out) {
+    const int n_groups = K / 16;
+    codes_out.assign(static_cast<size_t>(K), 0);
+    scales_out.assign(static_cast<size_t>(n_groups), 0);
+    for (int g = 0; g < n_groups; ++g) {
+        float absmax = 0.0f;
+        for (int i = 0; i < 16; ++i)
+            absmax = std::fmax(absmax, std::fabs(row[g * 16 + i]));
+        float raw = absmax / 6.0f;  // 6 = max FP4 magnitude
+        scales_out[g] = encode_ue4m3(raw);
+        float dq = decode_ue4m3(scales_out[g]);
+        float inv = (dq > 0.0f) ? (1.0f / dq) : 0.0f;
+        for (int i = 0; i < 16; ++i)
+            codes_out[g * 16 + i] = quantise_fp4(row[g * 16 + i] * inv);
+    }
+}
+
+static void dequantise_row_fp4(const std::vector<uint8_t>& codes,
+                               const std::vector<uint8_t>& scales, int K,
+                               std::vector<float>& out) {
+    const int n_groups = K / 16;
+    out.assign(static_cast<size_t>(K), 0.0f);
+    for (int g = 0; g < n_groups; ++g) {
+        float dq = decode_ue4m3(scales[g]);
+        for (int i = 0; i < 16; ++i)
+            out[g * 16 + i] = dequantise_fp4(codes[g * 16 + i]) * dq;
+    }
+}
+
+// Generate one synthetic post-softmax row.
+//
+// Pattern: softmax(N(0, 1) + spike_at_random) where spike strength is
+// drawn from U(3, 8). This produces 1-3 high-mass values (0.05..0.95) and
+// a long tail in [1e-4 .. 1e-1] — representative of real attention rows
+// (`fp4_pv_potential_2026_04_25.md` cites the same distribution shape).
+static void generate_postsoftmax_row(float* row, int K, std::mt19937& rng) {
+    std::normal_distribution<float> logit_dist(0.0f, 1.0f);
+    std::uniform_int_distribution<int> spike_idx(0, K - 1);
+    std::uniform_real_distribution<float> spike_str(3.0f, 8.0f);
+
+    std::vector<float> logits(static_cast<size_t>(K));
+    for (int i = 0; i < K; ++i)
+        logits[i] = logit_dist(rng);
+    logits[spike_idx(rng)] += spike_str(rng);
+
+    float maxl = *std::max_element(logits.begin(), logits.end());
+    double sum = 0.0;
+    for (int i = 0; i < K; ++i) {
+        logits[i] = std::exp(logits[i] - maxl);
+        sum += logits[i];
+    }
+    for (int i = 0; i < K; ++i)
+        row[i] = static_cast<float>(logits[i] / sum);
+}
+
+// -----------------------------------------------------------------------------
+// Phase 3a accuracy harness
+// -----------------------------------------------------------------------------
+
+Fp4PvAccuracyResult bench_fp4_pv_accuracy(int n_rows, int K, int head_dim,
+                                          unsigned seed) {
+    std::mt19937 rng(seed);
+    std::normal_distribution<float> v_dist(0.0f, 1.0f);
+
+    // V matrix [K × head_dim] — column-major (per-K-group quantisation runs
+    // down each output column independently, matching the PV MMA layout).
+    std::vector<float> V(static_cast<size_t>(K) * head_dim);
+    for (auto& x : V) x = v_dist(rng);
+
+    // Pre-quantise V columns (V is loaded once per attention block — quant
+    // cost amortises across many P rows).
+    std::vector<std::vector<uint8_t>> V_fp4(head_dim);
+    std::vector<std::vector<uint8_t>> V_scales(head_dim);
+    std::vector<std::vector<float>> V_lossy(head_dim);
+    for (int n = 0; n < head_dim; ++n) {
+        std::vector<float> col(static_cast<size_t>(K));
+        for (int k = 0; k < K; ++k)
+            col[k] = V[static_cast<size_t>(k) * head_dim + n];
+        quantise_row_fp4(col.data(), K, V_fp4[n], V_scales[n]);
+        dequantise_row_fp4(V_fp4[n], V_scales[n], K, V_lossy[n]);
+    }
+
+    std::vector<float> abs_errs;
+    std::vector<float> rel_errs;
+    abs_errs.reserve(static_cast<size_t>(n_rows) * head_dim);
+    rel_errs.reserve(static_cast<size_t>(n_rows) * head_dim);
+    int catastrophic = 0;
+
+    for (int r = 0; r < n_rows; ++r) {
+        std::vector<float> P(static_cast<size_t>(K));
+        generate_postsoftmax_row(P.data(), K, rng);
+
+        std::vector<uint8_t> P_fp4, P_scales;
+        quantise_row_fp4(P.data(), K, P_fp4, P_scales);
+        std::vector<float> P_lossy;
+        dequantise_row_fp4(P_fp4, P_scales, K, P_lossy);
+
+        for (int n = 0; n < head_dim; ++n) {
+            // FP32 reference: P (exact) @ V (exact)
+            double ref = 0.0;
+            for (int k = 0; k < K; ++k)
+                ref += static_cast<double>(P[k]) *
+                       static_cast<double>(V[static_cast<size_t>(k) * head_dim + n]);
+            // FP4 reconstruction: P_lossy @ V_lossy (same numerical result
+            // as the actual MMA modulo accumulator rounding mode).
+            double fp4 = 0.0;
+            for (int k = 0; k < K; ++k)
+                fp4 += static_cast<double>(P_lossy[k]) * static_cast<double>(V_lossy[n][k]);
+            float abs_e = static_cast<float>(std::fabs(fp4 - ref));
+            float rel_e = abs_e / static_cast<float>(std::fabs(ref) + 1e-9);
+            abs_errs.push_back(abs_e);
+            rel_errs.push_back(rel_e);
+            if (rel_e > 0.5f) ++catastrophic;
+        }
+    }
+
+    auto pct = [](std::vector<float>& v, double p) -> float {
+        size_t idx = std::min(v.size() - 1, static_cast<size_t>(v.size() * p));
+        std::nth_element(v.begin(), v.begin() + idx, v.end());
+        return v[idx];
+    };
+
+    Fp4PvAccuracyResult r{};
+    r.n_rows = n_rows;
+    r.K = K;
+    r.head_dim = head_dim;
+    r.abs_err_median = pct(abs_errs, 0.5);
+    r.abs_err_p99   = pct(abs_errs, 0.99);
+    r.abs_err_max   = pct(abs_errs, 0.999999);
+    r.rel_err_median = pct(rel_errs, 0.5);
+    r.rel_err_p90   = pct(rel_errs, 0.90);
+    r.rel_err_p99   = pct(rel_errs, 0.99);
+    r.rel_err_max   = pct(rel_errs, 0.999999);
+    r.frac_rel_err_above_50pct =
+        static_cast<float>(catastrophic) / static_cast<float>(rel_errs.size());
+    return r;
+}
+
+// -----------------------------------------------------------------------------
+// Phase 3a throughput harness (raw MMA loop, HMMA reference vs blockscale)
+// -----------------------------------------------------------------------------
+//
+// Same warps × iterations × tight-loop pattern as
+// `bench/mxf4nvf4_mma_bench.cu`. The HMMA reference is `mma.sync.m16n8k16`
+// FP16-in/FP32-out — the same instruction the WMMA m16n16k16 wrapper
+// decomposes into. Two MMA tiles for n=16 are skipped (single n=8 issue
+// is sufficient for relative throughput).
+
+__global__ void bench_hmma_m16n8k16_pv_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u;
+    uint32_t a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = threadIdx.x * 43u + 3u;
+    uint32_t a3 = threadIdx.x * 47u + 4u;
+    uint32_t b0 = threadIdx.x * 53u + 5u;
+    uint32_t b1 = threadIdx.x * 59u + 6u;
+    float d0 = 0.f, d1 = 0.f, d2 = 0.f, d3 = 0.f;
+#if __CUDA_ARCH__ >= 800
+#pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+            "{%0, %1, %2, %3},"
+            "{%4, %5, %6, %7},"
+            "{%8, %9},"
+            "{%10, %11, %12, %13};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+              "f"(d0), "f"(d1), "f"(d2), "f"(d3));
+    }
+#endif
+    if (threadIdx.x == 0 && blockIdx.x == 0) sink[0] = d0 + d1 + d2 + d3;
+}
+
+__global__ void bench_mxf4nvf4_m16n8k64_pv_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u;
+    uint32_t a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = threadIdx.x * 43u + 3u;
+    uint32_t a3 = threadIdx.x * 47u + 4u;
+    uint32_t b0 = threadIdx.x * 53u + 5u;
+    uint32_t b1 = threadIdx.x * 59u + 6u;
+    uint32_t sfa = 0x38383838u;  // UE4M3 ~ 1.0
+    uint32_t sfb = 0x38383838u;
+    float d0 = 0.f, d1 = 0.f, d2 = 0.f, d3 = 0.f;
+    constexpr uint16_t tidA = 0, bidA = 0, bidB = 0, tidB0 = 0;
+#if __CUDA_ARCH__ >= 1200
+#pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+        asm volatile(
+            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32."
+            "ue4m3 "
+            "{%0, %1, %2, %3},"
+            "{%4, %5, %6, %7},"
+            "{%8, %9},"
+            "{%10, %11, %12, %13},"
+            "{%14},"
+            "{%15, %16},"
+            "{%17},"
+            "{%18, %19};\n"
+            : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+              "r"(sfa), "h"(bidA), "h"(tidA), "r"(sfb), "h"(bidB), "h"(tidB0));
+    }
+#endif
+    if (threadIdx.x == 0 && blockIdx.x == 0) sink[0] = d0 + d1 + d2 + d3;
+}
+
+static float run_kernel_bench(void (*kernel)(int, float*), int warps, int iterations,
+                              cudaStream_t stream) {
+    float* d_sink = nullptr;
+    if (cudaMalloc(&d_sink, sizeof(float)) != cudaSuccess) return -1.0f;
+    kernel<<<warps, 32, 0, stream>>>(iterations / 10, d_sink);
+    cudaStreamSynchronize(stream);
+    cudaEvent_t a, b;
+    cudaEventCreate(&a);
+    cudaEventCreate(&b);
+    constexpr int NUM_REPS = 5;
+    float total = 0.0f;
+    for (int r = 0; r < NUM_REPS; ++r) {
+        cudaEventRecord(a, stream);
+        kernel<<<warps, 32, 0, stream>>>(iterations, d_sink);
+        cudaEventRecord(b, stream);
+        cudaEventSynchronize(b);
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, a, b);
+        total += ms;
+    }
+    cudaEventDestroy(a);
+    cudaEventDestroy(b);
+    cudaFree(d_sink);
+    return total / NUM_REPS;
+}
+
+Fp4PvThroughputResult bench_fp4_pv_throughput(int warps, int iterations,
+                                              cudaStream_t stream) {
+    Fp4PvThroughputResult r{};
+    r.hmma_ms = run_kernel_bench(bench_hmma_m16n8k16_pv_kernel, warps, iterations, stream);
+    r.blockscale_ms =
+        run_kernel_bench(bench_mxf4nvf4_m16n8k64_pv_kernel, warps, iterations, stream);
+    // Ops per MMA (FMA = 2 ops):
+    //   HMMA m16n8k16:        16*8*16*2 =  4096
+    //   blockscale m16n8k64:  16*8*64*2 = 16384
+    constexpr double kHmmaOps = 16.0 * 8.0 * 16.0 * 2.0;
+    constexpr double kBlockOps = 16.0 * 8.0 * 64.0 * 2.0;
+    const double total = static_cast<double>(warps) * iterations;
+    r.hmma_tops = (kHmmaOps * total) / (r.hmma_ms * 1e-3) / 1e12;
+    r.blockscale_tops = (kBlockOps * total) / (r.blockscale_ms * 1e-3) / 1e12;
+    r.speedup = r.blockscale_tops / r.hmma_tops;
+    return r;
+}
+
+}  // namespace imp

--- a/tests/bench/fp4_pv_bench.h
+++ b/tests/bench/fp4_pv_bench.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// =============================================================================
+// fp4_pv_bench.h — Phase 3a FP4 PV microbench
+// =============================================================================
+//
+// Discriminates "MMA-level gain is real on realistic post-softmax data" vs
+// "evaporates" before committing to the multi-week Phase 3b/3c production
+// integration. See `docs/plans/fp4_pv_phase3_design_2026_05_17.md` §3 + §4.
+//
+// Two questions answered:
+//
+//   1. ACCURACY — single-level FP4 quant of post-softmax probabilities.
+//      Generates N synthetic attention rows (softmax over Gaussian logits +
+//      spike), quantises each row to FP4 + UE4M3 per-16 scales, and
+//      compares the "FP4 P @ FP4 V" dot product against an FP32 reference.
+//      Reports relative-error percentiles. THIS IS THE KEY DATA POINT —
+//      if single-level FP4 PV has catastrophic relative error (>~50 %),
+//      Phase 3b's two-level accumulator is mandatory; if it's bounded
+//      (<5 %), Phase 3 could ship without the accumulator complexity.
+//
+//   2. THROUGHPUT — raw MMA-pipeline TOPS for mxf4nvf4 m16n8k64 vs the
+//      WMMA m16n16k16 PV reference. The existing mxf4nvf4_mma_bench
+//      compared mxf4nvf4 vs f8f6f4; this adds the missing HMMA reference
+//      that the PV path actually replaces.
+//
+// Both run on the GPU and emit results to stdout. The accuracy half does
+// the quantisation in software (host-side reconstruction matches what the
+// PTX `cvt.rn.satfinite.e2m1x2.f32` + `cvt.rn.satfinite.e4m3.f32` produce
+// modulo IEEE rounding at midpoints; the numerical signal of interest —
+// long-tail truncation in softmax distributions — is independent of the
+// rounding mode).
+// =============================================================================
+
+struct Fp4PvAccuracyResult {
+    int n_rows;
+    int K;          // P width / V height (must be a multiple of 16)
+    int head_dim;   // V width
+    // Relative error percentiles (vs FP32 reference). Cell value is
+    // |O_fp4 - O_ref| / (|O_ref| + 1e-9).
+    float rel_err_median;
+    float rel_err_p90;
+    float rel_err_p99;
+    float rel_err_max;
+    // Absolute error percentiles (same indices).
+    float abs_err_median;
+    float abs_err_p99;
+    float abs_err_max;
+    // Fraction of outputs with relative error > 0.5 (i.e. catastrophic
+    // tail truncation). High value confirms Phase 3b is mandatory.
+    float frac_rel_err_above_50pct;
+};
+
+struct Fp4PvThroughputResult {
+    float hmma_ms;          // wmma m16n16k16 PV reference, avg ms per rep
+    float blockscale_ms;    // mxf4nvf4.block_scale m16n8k64 PV, avg ms per rep
+    double hmma_tops;
+    double blockscale_tops;
+    double speedup;         // blockscale / hmma
+};
+
+// Generate synthetic post-softmax rows + quantise + measure relative error
+// vs FP32 reference dot product. Deterministic given `seed`.
+Fp4PvAccuracyResult bench_fp4_pv_accuracy(int n_rows, int K, int head_dim,
+                                          unsigned seed);
+
+// Raw-instruction throughput comparison: HMMA m16n16k16 (PV reference)
+// vs mxf4nvf4 m16n8k64. Same warps × iterations pattern as
+// mxf4nvf4_mma_bench so numbers compose with that existing surface.
+Fp4PvThroughputResult bench_fp4_pv_throughput(int warps, int iterations,
+                                              cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_fp4_pv_bench.cu
+++ b/tests/test_fp4_pv_bench.cu
@@ -1,0 +1,83 @@
+// Phase 3a FP4 PV microbench wrapper — see bench/fp4_pv_bench.h for context.
+//
+// Two GTests:
+//   - Fp4PvBenchTest.Accuracy: synthetic post-softmax accuracy, no gate
+//   - Fp4PvBenchTest.ThroughputBlockscaleBeatsHmma: raw MMA throughput,
+//     asserts the 2× theoretical speedup over HMMA m16n8k16 is at least
+//     ≥ 2.0× in practice (the "≥ 2.5× for Phase 3b proceed" gate in the
+//     design memo is informational here — printed but not enforced, so a
+//     marginal result still produces actionable data).
+
+#include <gtest/gtest.h>
+#include "bench/fp4_pv_bench.h"
+#include <cuda_runtime.h>
+#include <cstdio>
+
+namespace imp {
+namespace {
+
+TEST(Fp4PvBenchTest, Accuracy) {
+    // 2000 rows × 64 head_dim = 128k samples. K=64 = one mxf4nvf4 tile.
+    // Deterministic seed so the percentile numbers are reproducible.
+    constexpr int N_ROWS = 2000;
+    constexpr int K = 64;
+    constexpr int HEAD_DIM = 64;
+
+    Fp4PvAccuracyResult r = bench_fp4_pv_accuracy(N_ROWS, K, HEAD_DIM, /*seed=*/42);
+
+    std::printf("\n=== Phase 3a FP4 PV accuracy on synthetic post-softmax data ===\n");
+    std::printf("  rows=%d  K=%d  head_dim=%d  (single-level FP4, NO two-level accumulator)\n",
+                r.n_rows, r.K, r.head_dim);
+    std::printf("  Absolute error |O_fp4 - O_ref|:\n");
+    std::printf("    median  %12.4e\n", r.abs_err_median);
+    std::printf("    p99     %12.4e\n", r.abs_err_p99);
+    std::printf("    max     %12.4e\n", r.abs_err_max);
+    std::printf("  Relative error |O_fp4 - O_ref| / |O_ref|:\n");
+    std::printf("    median  %7.2f %%\n", r.rel_err_median * 100.0);
+    std::printf("    p90     %7.2f %%\n", r.rel_err_p90 * 100.0);
+    std::printf("    p99     %7.2f %%\n", r.rel_err_p99 * 100.0);
+    std::printf("    max     %7.2f %%\n", r.rel_err_max * 100.0);
+    std::printf("  Catastrophic outputs (rel err > 50%%):  %6.2f %% of %d\n",
+                r.frac_rel_err_above_50pct * 100.0, r.n_rows * r.head_dim);
+    std::printf("\n");
+    std::printf("Interpretation (Phase 3a design memo §5):\n");
+    std::printf("  - p99 < 5%%   → single-level FP4 PV is viable; skip Phase 3b accumulator.\n");
+    std::printf("  - p99 < 50%%  → Phase 3b two-level accumulator is the right next step.\n");
+    std::printf("  - p99 > 50%%  → Phase 3 is dead without the residual path.\n\n");
+
+    // No assertion — the bench's job is to PRODUCE the data, not to gate
+    // CI on a specific quality threshold.
+    EXPECT_GT(r.rel_err_median, 0.0f);
+    EXPECT_LE(r.rel_err_median, 1.0f);
+}
+
+TEST(Fp4PvBenchTest, ThroughputBlockscaleBeatsHmma) {
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+    constexpr int WARPS = 170;            // 1 per SM on RTX 5090
+    constexpr int ITERATIONS = 1 << 20;   // 1M MMAs per warp
+
+    Fp4PvThroughputResult r = bench_fp4_pv_throughput(WARPS, ITERATIONS, stream);
+    cudaStreamDestroy(stream);
+
+    std::printf("\n=== Phase 3a raw MMA throughput, PV reference ===\n");
+    std::printf("  hmma.m16n8k16 (FP16 PV)              %7.2f ms  %7.2f TOPS\n",
+                r.hmma_ms, r.hmma_tops);
+    std::printf("  mxf4nvf4.block_scale.m16n8k64 (FP4)  %7.2f ms  %7.2f TOPS\n",
+                r.blockscale_ms, r.blockscale_tops);
+    std::printf("  Speedup (blockscale / hmma):         %5.2fx\n", r.speedup);
+    std::printf("  Phase 3b gate (≥ 2.5×): %s\n\n",
+                r.speedup >= 2.5 ? "PASS" : "FAIL — re-examine before integrating");
+
+    EXPECT_GT(r.hmma_tops, 0.0);
+    EXPECT_GT(r.blockscale_tops, 0.0);
+    // The MMA-level ratio is the lower bound on Phase 3b's eventual e2e
+    // payoff. If it isn't even ≥ 2.0×, integration won't help.
+    EXPECT_GT(r.speedup, 2.0)
+        << "mxf4nvf4.m16n8k64 raw-MMA speedup over HMMA m16n8k16 is < 2.0× — "
+        << "Phase 3b integration cannot recover the +13 % e2e ceiling from this base.";
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Summary

Phase 3a of the FP4 PV attention design (\`docs/plans/fp4_pv_phase3_design_2026_05_17.md\` §3-4). Standalone microbench answering the open question: **is the MMA-level upside real on realistic post-softmax data**, before committing to multi-week Phase 3b/3c production work?

## What ships

- \`tests/bench/fp4_pv_bench.{h,cu}\` (~350 LoC)
  - Host-side FP4 + UE4M3 encode/decode mirroring the PTX HW path.
  - Synthetic post-softmax row generator: \`softmax(N(0, 1) + spike@U(3, 8))\` — produces the spike-plus-long-tail distribution real attention rows have.
  - **Accuracy harness**: quantise P + V per-16 UE4M3, dequantise, dot against FP32 reference. Reports relative-error percentiles + catastrophic-output rate.
  - **Throughput harness**: HMMA m16n8k16 (FP16 PV reference) vs \`mxf4nvf4.block_scale.m16n8k64\` raw-MMA loop (170 warps × 1M iters), reports TOPS + speedup ratio. Adds the missing HMMA reference that the existing \`mxf4nvf4_mma_bench\` (which compares vs f8f6f4) lacks.
- \`tests/test_fp4_pv_bench.cu\` — two GTests in the \`test-quant\` module (consistent with \`mxf4nvf4_mma_bench\` placement).

## Results (2000 rows × head_dim=64 × K=64, seed=42)

### Accuracy (single-level FP4, NO two-level accumulator)

| Metric | Value |
|---|---:|
| Median rel err | **15.41 %** |
| p90 rel err | 100.00 % |
| **p99 rel err** | **797.47 %** |
| Max rel err | 318,065 % |
| Outputs with rel err > 50 % | **21.35 %** of 128k |

### Throughput (170 warps × 1M iters on RTX 5090)

| Path | Wall ms | TOPS | Ratio |
|---|---:|---:|---:|
| HMMA m16n8k16 (FP16 PV reference) | 13.82 | 52.85 | 1.0× |
| mxf4nvf4 block_scale m16n8k64 | 11.58 | 252.30 | **4.77×** |

## Decision

Against the Phase 3a gates from the design memo:

- **Accuracy**: p99 = 797 % is **far above** the 50 % threshold. Single-level FP4 PV on post-softmax data is non-viable — the long-tail truncation that \`sageattention3_study_2026_04_24.md\` predicted is exactly what we measure. **Phase 3b two-level accumulator is mandatory.**
- **Throughput**: 4.77× speedup is **far above** the 2.5× gate. The MMA-level upside is real; the +13 % e2e ceiling from the design memo (Phase-1 MMA is ~15 % of FMHA wall time on HD=128) is the correct expectation.

### Recommended next slice

**Phase 3b** (2-3 days, ~150 LoC extension of this bench) adds the two-level accumulator and re-measures combined error + combined throughput. Gates Phase 3c integration on whether 2L brings p99 back under 5 % AND combined speedup stays ≥ 1.5×. Full findings + path forward in the new memory file \`memory/fp4_pv_phase3a_findings_2026_05_17.md\`.

## Test plan

- [x] Builds clean in the Docker image.
- [x] Both Fp4PvBenchTest tests pass (340 ms total).
- [x] Accuracy results reproducible (deterministic seed=42).
- [x] Throughput test asserts speedup > 2.0× (gates against catastrophic regression of the MMA pipeline).
- [ ] CI gate on green build.