### PR TITLE
feat(attention): MXFP4 FP16 cache pruning — skip MoE expert + LM head

### DIFF
--- a/src/graph/executor_pre_dequant.cu
+++ b/src/graph/executor_pre_dequant.cu
@@ -1521,11 +1521,55 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 
                 // Dequant MXFP4 → FP16 for decode (only when MXFP4 GEMV not available).
                 // Single bulk allocation to avoid CUDA heap fragmentation.
+                //
+                // Phase A2 (`docs/plans/qwen35_27b_mxfp4_host_dequant_design_2026_05_17.md`):
+                // when attention.mxfp4_fp16_cache_policy == "pruned", skip
+                // tensor slots that aren't read on the dispatch hot path —
+                // MoE expert_*_packed (consumed only by executor_forward_moe.cu's
+                // pre-cached FP16 path, which the MXFP4 batch-dequant route
+                // bypasses) and the LM head out_proj_ (routed through
+                // generic-dequant). For Qwen3.5-27B MXFP4 this shrinks
+                // the FP16 fallback from ~48 GiB to ~8-12 GiB and unblocks
+                // load on 32 GiB VRAM.
+                std::unordered_set<const void*> pruned_skip_ptrs;
+                const bool pruned_policy =
+                    (RuntimeConfig::current().attention.mxfp4_fp16_cache_policy == "pruned");
+                if (pruned_policy) {
+                    for (int li = 0; li < cfg.n_layers; ++li) {
+                        const auto& L = model_->layer(li);
+                        if (L.expert_gate_packed.data)
+                            pruned_skip_ptrs.insert(L.expert_gate_packed.data);
+                        if (L.expert_up_packed.data)
+                            pruned_skip_ptrs.insert(L.expert_up_packed.data);
+                        if (L.expert_down_packed.data)
+                            pruned_skip_ptrs.insert(L.expert_down_packed.data);
+                    }
+                    if (model_->output_proj().data)
+                        pruned_skip_ptrs.insert(model_->output_proj().data);
+                }
+                size_t pruned_skipped_bytes = 0;
+                int pruned_skipped_count = 0;
+
                 size_t fp16_total = 0;
                 if (!mxfp4_gemv_available) {
-                    for (auto& [p, m] : wcache_.cutlass_mxfp4)
-                        if (!wcache_.fp16.count(p))
-                            fp16_total += static_cast<size_t>(m.N) * m.K * sizeof(half);
+                    for (auto& [p, m] : wcache_.cutlass_mxfp4) {
+                        if (wcache_.fp16.count(p))
+                            continue;
+                        size_t b = static_cast<size_t>(m.N) * m.K * sizeof(half);
+                        if (pruned_policy && pruned_skip_ptrs.count(p)) {
+                            pruned_skipped_bytes += b;
+                            pruned_skipped_count++;
+                            continue;
+                        }
+                        fp16_total += b;
+                    }
+                    if (pruned_policy && pruned_skipped_count > 0) {
+                        IMP_LOG_INFO(
+                            "MXFP4 FP16 cache pruning: skipping %d MoE/LM-head tensors "
+                            "(%.2f GiB saved)",
+                            pruned_skipped_count,
+                            pruned_skipped_bytes / (1024.0 * 1024.0 * 1024.0));
+                    }
                 }
 
                 void* d_fp16_bulk = nullptr;
@@ -1585,6 +1629,10 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
                     size_t offset = 0;
                     for (auto& [ptr, mw] : wcache_.cutlass_mxfp4) {
                         if (wcache_.fp16.count(ptr))
+                            continue;
+                        // Honor the same pruning filter the fp16_total compute
+                        // pass used; otherwise the offset accounting drifts.
+                        if (pruned_policy && pruned_skip_ptrs.count(ptr))
                             continue;
                         size_t fp16_bytes = static_cast<size_t>(mw.N) * mw.K * sizeof(half);
                         void* d_fp16 = static_cast<char*>(d_fp16_bulk) + offset;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -124,6 +124,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.attention.mxfp4 = val;
     else if (eq("attention.mxfp4_fp16_fallback"))
         cfg.attention.mxfp4_fp16_fallback = parse_bool(val, cfg.attention.mxfp4_fp16_fallback);
+    else if (eq("attention.mxfp4_fp16_cache_policy"))
+        cfg.attention.mxfp4_fp16_cache_policy = val;
     else if (eq("attention.fmha_blockscale"))
         cfg.attention.fmha_blockscale = val;
     else if (eq("attention.naive"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -82,6 +82,18 @@ struct RuntimeConfig {
         std::string fmha_sm120 = "auto";
         std::string mxfp4 = "auto";
         bool mxfp4_fp16_fallback = false;
+        // MXFP4 → FP16 cache pruning policy. "legacy" (default) caches FP16
+        // for every MXFP4 tensor. "pruned" skips MoE expert_*_packed and
+        // LM head (out_proj_) — those slots are either not read on the
+        // dispatch hot path (MoE expert FP16 cache is only consumed by
+        // executor_forward_moe.cu's pre-cached FP16 fallback, which is
+        // bypassed by the more efficient batch-dequant path for MXFP4)
+        // or routed through generic-dequant (LM head). Pruning is the
+        // Phase A1+A2 path from
+        // docs/plans/qwen35_27b_mxfp4_host_dequant_design_2026_05_17.md —
+        // unlocks Qwen3.5-27B MXFP4 load on 32 GiB VRAM by shrinking the
+        // ~48 GiB FP16 fallback to ~8-12 GiB.
+        std::string mxfp4_fp16_cache_policy = "legacy";
         std::string fmha_blockscale = "auto";
         bool naive = false;
         bool no_cublas = false;


### PR DESCRIPTION
## Summary

Phase A1+A2 of \`docs/plans/qwen35_27b_mxfp4_host_dequant_design_2026_05_17.md\`. Adds \`attention.mxfp4_fp16_cache_policy\` config (default \`legacy\`). When set to \`pruned\`, the MXFP4 → FP16 decode-fallback cache skips two tensor classes:

- **MoE expert_*_packed** (gate/up/down). The FP16 fallback is only consumed by \`executor_forward_moe.cu\`'s "pre-cached FP16 path" fallback at line 1580; the MXFP4 batch-dequant route at line 1581 (the production hot path) reads raw MXFP4 + dequants per-batch. The FP16 cache for these slots is dead weight.
- **LM head** (\`model->output_proj()\`). Routed through generic-dequant at the executor's lm_head dispatch site, never reads from \`wcache_.fp16\` directly.

For **Qwen3.5-27B MXFP4** (GDN+MoE, 12 GiB raw + 48 GiB FP16 fallback under legacy policy) the pruned policy shrinks the FP16 fallback to ~8-12 GiB, bringing total VRAM into the ~30 GiB ballpark that fits on a 32 GiB RTX 5090.

## Verification (local fleet — no Qwen3.5-27B on disk currently)

**Qwen3.5-4B MXFP4** (dense; exercises the LM head prune but not the MoE expert prune):

| Policy | FP16 cache | Tensors replaced | pp64 | tg32 |
|---|---:|---:|---:|---:|
| legacy | 8020.00 MiB | 249 | 3302 tok/s | 143.96 tok/s |
| pruned | **6807.50 MiB** (−1.18 GiB) | 248 | **4593 tok/s** (+39 %) | **159.15 tok/s** (+11 %) |

No regression — actually mildly faster, presumably from reduced VRAM pressure freeing up cuBLAS workspace.

The Qwen3.5-4B test confirms the **LM head prune** works correctly (saved 1.18 GiB ≈ LM head size). The **MoE expert prune** path is wired but not exercised by a local model — Qwen3.5-27B MXFP4 isn't on disk, and the smaller MXFP4 fleet is dense (no MoE).

## Known caveat

Qwen3.5-27B has a **separate N=48 alpha/beta MXFP4 GEMV NaN bug** that will still block decode quality even after this PR lets it load. That's a separate scope per the design memo §1.1; this PR's value is removing the load-time blocker so the kernel bug becomes investigable.

## Test plan

- [x] Build clean
- [x] Legacy policy unchanged (default) — Qwen3.5-4B MXFP4 baseline matches pre-PR behavior
- [x] Pruned policy: cache shrinks by LM head, perf flat-to-better on dense MXFP4 model
- [x] No production-default change (\`legacy\` remains the default)
- [ ] CI gate on green build
- [ ] (out of scope, awaits model) Qwen3.5-27B MXFP4 end-to-end load under \`attention.mxfp4_fp16_cache_policy=pruned\`

## Followups

- Phase A3 per design memo: verify on Qwen3.5-27B once the model lands (or is downloaded — see #243 for why imp doesn't auto-fetch).
- Phase B (full host-dequant + storage planner) stays deferred unless Phase A turns out to be insufficient.