### PR TITLE
perf(nvfp4): SCALE_DTYPE template param on paged attention kernels (MXFP4-KV Slice 1)

### DIFF
--- a/src/compute/attention_paged_nvfp4.cu
+++ b/src/compute/attention_paged_nvfp4.cu
@@ -1,6 +1,7 @@
 #include "compute/attention_paged.h"
 #include "compute/attention_paged_common.cuh"
 #include "compute/attention.h"
+#include "quant/turboquant_fp4.cuh"
 #include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -35,6 +36,29 @@ __device__ __forceinline__ float ue4m3_decode(uint8_t bits) {
     return static_cast<float>(v);
 }
 
+// Scale dtype tag for the NVFP4 paged attention kernels. Default E4M3 is the
+// existing NVFP4 path; UE8M0 reserves the second template arm for the
+// upcoming MXFP4-KV variant (design memo `docs/plans/turboquant_fp8_gap_design_2026_05_17.md`
+// §5 Phase 3). This Slice 1 commit only adds the template parameter; the
+// UE8M0 branch is implemented in Slice 2.
+enum class ScaleDtype : int { E4M3 = 0, UE8M0 = 1 };
+
+// Decode one packed scale byte into a float, dispatching on SCALE_DTYPE at
+// compile time. E4M3 path uses the existing ue4m3_decode helper. UE8M0 path
+// uses tq_fp4_ue8m0_to_float from src/quant/turboquant_fp4.cuh.
+template <ScaleDtype S>
+__device__ __forceinline__ float decode_kv_scale(uint8_t bits);
+
+template <>
+__device__ __forceinline__ float decode_kv_scale<ScaleDtype::E4M3>(uint8_t bits) {
+    return ue4m3_decode(bits);
+}
+
+template <>
+__device__ __forceinline__ float decode_kv_scale<ScaleDtype::UE8M0>(uint8_t bits) {
+    return tq_fp4_ue8m0_to_float(bits);
+}
+
 // Decode one packed FP4 byte (low nibble = .x, high nibble = .y) → half2.
 // Single PTX `cvt.rn.f16x2.e2m1x2` (sm_120+, CUDA 13.2+). Replaces the prior
 // per-nibble 8-entry magnitude LUT + sign branch (~12 ops/byte → 1).
@@ -49,7 +73,7 @@ __device__ __forceinline__ half2 fp4_byte_to_half2(uint32_t byte_val) {
 // Non-Split-K NVFP4 decode kernel
 // ---------------------------------------------------------------------------
 
-template <int HEAD_DIM>
+template <int HEAD_DIM, ScaleDtype SCALE_DTYPE = ScaleDtype::E4M3>
 __global__ void paged_attention_decode_nvfp4_kernel(
     const half* __restrict__ Q,
     const uint8_t* __restrict__ K_cache,    // packed FP4 pairs
@@ -131,9 +155,9 @@ __global__ void paged_attention_decode_nvfp4_kernel(
             const uint8_t* V_tok = V_block + t * kv_slot_stride + kv_head * kv_head_bytes;
 
             // Per-lane scale (one group covers all ELEMS for this lane)
-            float k_scale = ue4m3_decode(
+            float k_scale = decode_kv_scale<SCALE_DTYPE>(
                 K_sc_block[t * sc_slot_stride + kv_head * sc_groups + lane_group]);
-            float v_scale = ue4m3_decode(
+            float v_scale = decode_kv_scale<SCALE_DTYPE>(
                 V_sc_block[t * sc_slot_stride + kv_head * sc_groups + lane_group]);
             const half2 k_scale_h2 = __float2half2_rn(k_scale);
             const half2 v_scale_h2 = __float2half2_rn(v_scale);
@@ -182,7 +206,7 @@ __global__ void paged_attention_decode_nvfp4_kernel(
 // Split-K NVFP4 decode kernel
 // ---------------------------------------------------------------------------
 
-template <int HEAD_DIM>
+template <int HEAD_DIM, ScaleDtype SCALE_DTYPE = ScaleDtype::E4M3>
 __global__ void paged_attention_splitk_nvfp4_kernel(
     const half* __restrict__ Q, const uint8_t* __restrict__ K_cache, const uint8_t* __restrict__ V_cache,
     const uint8_t* __restrict__ K_scales, const uint8_t* __restrict__ V_scales,
@@ -273,9 +297,9 @@ __global__ void paged_attention_splitk_nvfp4_kernel(
             const uint8_t* K_tok = K_block + t * kv_slot_stride + kv_head * kv_head_bytes;
             const uint8_t* V_tok = V_block + t * kv_slot_stride + kv_head * kv_head_bytes;
 
-            float k_scale = ue4m3_decode(
+            float k_scale = decode_kv_scale<SCALE_DTYPE>(
                 K_sc_block[t * sc_slot_stride + kv_head * sc_groups + lane_group]);
-            float v_scale = ue4m3_decode(
+            float v_scale = decode_kv_scale<SCALE_DTYPE>(
                 V_sc_block[t * sc_slot_stride + kv_head * sc_groups + lane_group]);
             const half2 k_scale_h2 = __float2half2_rn(k_scale);
             const half2 v_scale_h2 = __float2half2_rn(v_scale);


### PR DESCRIPTION
## Summary

**Slice 1 of Phase 3** of the TurboQuant–FP8 gap design memo (`docs/plans/turboquant_fp8_gap_design_2026_05_17.md` §5 Phase 3 step 2). Adds a `ScaleDtype` enum + `decode_kv_scale<SCALE_DTYPE>` helper and threads a `SCALE_DTYPE = ScaleDtype::E4M3` (default) template parameter through both NVFP4 paged-attention kernels (decode + splitk).

**Zero behavioral change.** The launchers don't dispatch on `SCALE_DTYPE` yet — only the default `E4M3` instantiation is produced, which is bit-identical to the pre-Slice kernel. The `UE8M0` specialization compiles via `tq_fp4_ue8m0_to_float` (reused from `src/quant/turboquant_fp4.cuh`) but is never instantiated by any current dispatch site.

## What this unlocks

Slice 2 (next PR) adds the MXFP4-KV launcher arm that instantiates `SCALE_DTYPE = ScaleDtype::UE8M0`. With this template-param scaffold in place, Slice 2 is a ~30-LOC dispatch-side change rather than a 400-LOC parallel kernel file (which the design memo §5 Phase 3 step 2 explicitly recommends against).

## Diff

1 file, 30 ins / 6 del:

- `src/compute/attention_paged_nvfp4.cu`
  - new `#include "quant/turboquant_fp4.cuh"` for `tq_fp4_ue8m0_to_float`
  - new `enum class ScaleDtype : int { E4M3 = 0, UE8M0 = 1 }`
  - new templated `decode_kv_scale<S>` helper with `E4M3` and `UE8M0` specializations
  - both kernels (`paged_attention_decode_nvfp4_kernel`, `paged_attention_splitk_nvfp4_kernel`) get `ScaleDtype SCALE_DTYPE = ScaleDtype::E4M3` as second template parameter
  - 4 call sites `ue4m3_decode(...)` → `decode_kv_scale<SCALE_DTYPE>(...)` (preserving the exact index expressions)
  - launchers unchanged

## Test plan

- [x] `make build` green
- [x] `make test-gpu`: all NVFP4 tests pass (KVCacheNVFP4Layout, KVCacheNVFP4HeadDimReject, KVCacheNVFP4PerLayer, Nvfp4Gemv/Gemm registry tests). Pre-existing TmaBlockScaleBench.FusedFasterThanSeparate flake unrelated.
- [x] `make verify-fast` green
- [x] Spot-checked diff: all four call sites preserve the exact index expression; only the function wrapper changes.

## Cross-references

- Phase 1 findings: `docs/superpowers/plans/2026-05-17-turboquant-phase1-findings.md` (PR #246)
- Phase 2 findings: `docs/superpowers/plans/2026-05-17-turboquant-phase2-findings.md` (PR #247)
- Design memo: `docs/plans/turboquant_fp8_gap_design_2026_05_17.md` §5 Phase 3
- Existing UE8M0 helper: `src/quant/turboquant_fp4.cuh::tq_fp4_ue8m0_to_float` (already used by `attention_paged_turboquant.cu`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)