### PR TITLE
feat(q4k-imma): Phase 2A — Q4_K to symmetric-s8 reorder kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/ssm.cu
     src/compute/gdn.cu
     src/compute/hadamard.cu
+    src/compute/mmq_q4k_imma_layout.cu
 )
 
 if(IMP_USE_CUTLASS)
@@ -442,6 +443,7 @@ if(IMP_BUILD_TESTS)
         tests/test_sampling.cu
         tests/test_executor_kernels.cu
         tests/test_hadamard.cu
+        tests/test_mmq_q4k_imma_layout.cu
     )
 
     imp_add_test_module(test-attention SOURCES

--- a/src/compute/mmq_q4k_imma_layout.cu
+++ b/src/compute/mmq_q4k_imma_layout.cu
@@ -1,0 +1,148 @@
+// =============================================================================
+// mmq_q4k_imma_layout.cu — Phase 2A reorder kernel
+// =============================================================================
+//
+// Companion to design memo docs/plans/q4k_imma_design_2026_05_17.md §3 ("Q4_K →
+// INT8 reordering") and findings memo 2026-05-18-q4k-imma-phase1-findings.md.
+//
+// Decodes one Q4_K super-block per CTA. For each sub-block j ∈ [0, 8):
+//
+//   sc[j]  — 6-bit sub-block scale  (from scales[12], unpacked via get_scale_min_k4)
+//   m[j]   — 6-bit sub-block min    (same)
+//   α[j]   = d_super * sc[j]
+//   β[j]   = 8 * d_super * sc[j] - dmin_super * m[j]
+//
+// And for each element q in sub-block j:
+//   q_sym  = q - 8         (∈ [-8, 7], fits cleanly in int8_t)
+//   fp16   = α[j] * q_sym + β[j]
+//
+// The (q - 8) shift absorbs the unsigned-to-signed quantization into the GEMM
+// epilogue. β couples to the activation row-sum via the standard
+// (q_sym + 8) * a  =  q_sym * a + 8 * a  identity.
+//
+// Layout reference:
+//   Q4_K block: [d:fp16, dmin:fp16, scales[12]:u6×16, qs[128]:nibbles].
+//   Sub-block j ∈ [0,8) → 32 elements stored as:
+//     j even (j=0,2,4,6): low nibbles of qs[(j/2)*32 + 0 .. +31]
+//     j odd  (j=1,3,5,7): high nibbles of qs[(j/2)*32 + 0 .. +31]
+//   (See ggml dequantize_row_q4_K — outer loop j∈{0,64,128,192} reads 32 bytes,
+//    inner loop produces 32 low nibbles then 32 high nibbles.)
+
+#include "compute/mmq_q4k_imma_layout.h"
+
+#include <cuda_fp16.h>
+#include <cstdint>
+
+namespace imp {
+
+namespace {
+
+constexpr int kBlockBytes = 144;
+constexpr int kQK4K = kQ4kSuperBlockSize;  // 256
+
+// 6-bit scale + 6-bit min unpacker, matching ggml/llama.cpp get_scale_min_k4.
+// q points at the 12-byte `scales` array; j ∈ [0, 8) selects the sub-block.
+__device__ __forceinline__ void get_scale_min_k4(int j, const uint8_t* q, uint8_t& d_out,
+                                                 uint8_t& m_out) {
+    if (j < 4) {
+        d_out = q[j] & 63u;
+        m_out = q[j + 4] & 63u;
+    } else {
+        d_out = (q[j + 4] & 0xFu) | ((q[j - 4] >> 6) << 4);
+        m_out = (q[j + 4] >> 4) | ((q[j - 0] >> 6) << 4);
+    }
+}
+
+__global__ void mmq_q4k_imma_reorder_kernel(const uint8_t* __restrict__ q4k_blocks, int N, int K,
+                                            int8_t* __restrict__ w_sym_s8,
+                                            __half* __restrict__ eff_alpha,
+                                            __half* __restrict__ eff_beta) {
+    const int row = blockIdx.y;
+    const int super_in_row = blockIdx.x;
+    const int blocks_per_row = K / kQK4K;
+
+    if (row >= N || super_in_row >= blocks_per_row) return;
+
+    const int super_idx = row * blocks_per_row + super_in_row;
+    const uint8_t* bp = q4k_blocks + static_cast<size_t>(super_idx) * kBlockBytes;
+
+    // Read super-block header: d (FP16) + dmin (FP16).
+    __half d_h, dmin_h;
+    {
+        uint16_t d_bits, dmin_bits;
+        d_bits = static_cast<uint16_t>(bp[0]) | (static_cast<uint16_t>(bp[1]) << 8);
+        dmin_bits = static_cast<uint16_t>(bp[2]) | (static_cast<uint16_t>(bp[3]) << 8);
+        d_h = __ushort_as_half(d_bits);
+        dmin_h = __ushort_as_half(dmin_bits);
+    }
+    const float d = __half2float(d_h);
+    const float dmin = __half2float(dmin_h);
+
+    const uint8_t* scales = bp + 4;
+    const uint8_t* qs = bp + 4 + 12;  // 128 bytes of nibble-packed Q4 quants
+
+    // Per-CTA shared scratch for α and β so all 8 sub-blocks are decoded once.
+    __shared__ float s_alpha[kQ4kSubBlocksPerSuper];
+    __shared__ float s_beta[kQ4kSubBlocksPerSuper];
+
+    const int tid = threadIdx.x;
+    if (tid < kQ4kSubBlocksPerSuper) {
+        uint8_t sc_u, m_u;
+        get_scale_min_k4(tid, scales, sc_u, m_u);
+        const float sc_f = static_cast<float>(sc_u);
+        const float m_f = static_cast<float>(m_u);
+        s_alpha[tid] = d * sc_f;
+        s_beta[tid] = 8.0f * d * sc_f - dmin * m_f;
+    }
+    __syncthreads();
+
+    // Write α, β to output tensors. One thread per sub-block is enough.
+    if (tid < kQ4kSubBlocksPerSuper) {
+        const int alpha_idx =
+            row * blocks_per_row * kQ4kSubBlocksPerSuper + super_in_row * kQ4kSubBlocksPerSuper + tid;
+        eff_alpha[alpha_idx] = __float2half(s_alpha[tid]);
+        eff_beta[alpha_idx] = __float2half(s_beta[tid]);
+    }
+
+    // Decode nibbles → symmetric s8. 256 elements per super-block ÷ 32 threads = 8 per thread.
+    // The Q4_K layout interleaves sub-blocks as (j even = low nibbles, j odd = high nibbles)
+    // over the 32-byte qs slabs of 64 elements each.
+    //
+    // For element k_in_super ∈ [0, 256):
+    //   group   = k_in_super / 64       (0..3)
+    //   in_grp  = k_in_super % 64       (0..63)
+    //   is_high = in_grp >= 32          (1 if high nibble, 0 if low)
+    //   byte_in_group = in_grp % 32     (0..31)
+    //   byte_in_qs   = group * 32 + byte_in_group
+    //   sub_block     = group * 2 + is_high
+    const int8_t* w_row = reinterpret_cast<const int8_t*>(w_sym_s8);
+    int8_t* w_super = const_cast<int8_t*>(w_row) +
+                      static_cast<size_t>(row) * static_cast<size_t>(K) +
+                      static_cast<size_t>(super_in_row) * kQK4K;
+#pragma unroll
+    for (int e = tid; e < kQK4K; e += 32) {
+        const int group = e >> 6;            // /64
+        const int in_grp = e & 63;           // %64
+        const int is_high = (in_grp >> 5);   // /32 ∈ {0,1}
+        const int byte_in_group = in_grp & 31;
+        const int byte_in_qs = group * 32 + byte_in_group;
+        const uint8_t packed = qs[byte_in_qs];
+        const int nibble = is_high ? (packed >> 4) : (packed & 0xF);
+        const int q_sym = nibble - 8;
+        w_super[e] = static_cast<int8_t>(q_sym);
+    }
+}
+
+}  // namespace
+
+void mmq_q4k_imma_reorder(const void* q4k_blocks, int N, int K, int8_t* w_sym_s8,
+                          __half* eff_alpha, __half* eff_beta, cudaStream_t stream) {
+    if (K % kQ4kSuperBlockSize != 0) return;
+    const int blocks_per_row = K / kQ4kSuperBlockSize;
+    dim3 grid(blocks_per_row, N, 1);
+    dim3 block(32, 1, 1);
+    mmq_q4k_imma_reorder_kernel<<<grid, block, 0, stream>>>(
+        static_cast<const uint8_t*>(q4k_blocks), N, K, w_sym_s8, eff_alpha, eff_beta);
+}
+
+}  // namespace imp

--- a/src/compute/mmq_q4k_imma_layout.h
+++ b/src/compute/mmq_q4k_imma_layout.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// Q4_K_M → symmetric-s8 reorder for the future INT8 IMMA direct-GEMM kernel.
+// Phase 2A of the design memo `docs/plans/q4k_imma_design_2026_05_17.md`.
+//
+// Splits each Q4_K weight super-block into three outputs:
+//
+//   w_sym_s8[N, K]      — int8 weight, symmetric (q_sym = q - 8 ∈ [-8, 7]).
+//                          K-major, contiguous; row r occupies bytes [r*K, (r+1)*K).
+//   eff_alpha[N, K/32]  — FP16 per-(row, sub-block) multiplicative factor
+//                          α[j] = d_super * sc[j].
+//   eff_beta[N, K/32]   — FP16 per-(row, sub-block) additive factor
+//                          β[j] = 8 * d_super * sc[j] - dmin_super * m[j].
+//                          The "8 *" term collapses the (q_sym + 8) shift into the
+//                          GEMM epilogue; β couples to the activation row-sum.
+//
+// Decode equivalence (per element):
+//   fp16_value = d_super * sc[j] * q
+//              - dmin_super * m[j]
+//              = α[j] * q_sym + β[j]
+//
+// `K` must be a multiple of `kSuperBlockSize = 256`. `N` is unconstrained.
+//
+// Launch: one CTA per super-block (N * K/256 CTAs), 32 threads per CTA.
+//
+// Phase 2B will add a layout permutation suited to `ldmatrix.x4` fragment loads.
+// Phase 2A keeps the s8 tensor in plain row-major K-major to make the unit test
+// trivial — the permutation only matters when the consuming tile kernel exists.
+
+constexpr int kQ4kSuperBlockSize = 256;
+constexpr int kQ4kSubBlocksPerSuper = 8;  // 8 sub-blocks × 32 elements = 256
+constexpr int kQ4kSubBlockSize = 32;
+
+void mmq_q4k_imma_reorder(const void* q4k_blocks, int N, int K, int8_t* w_sym_s8,
+                          __half* eff_alpha, __half* eff_beta, cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_mmq_q4k_imma_layout.cu
+++ b/tests/test_mmq_q4k_imma_layout.cu
@@ -1,0 +1,191 @@
+// Phase 2A correctness test for the Q4_K → symmetric-s8 reorder kernel.
+// Verifies that for every element of every row of every super-block,
+//   α[r, k/32] * w_sym_s8[r, k] + β[r, k/32]   ==   d * sc[j] * q - dmin * m[j]
+// — i.e. the IMMA epilogue identity α · q_sym + β reconstructs the same FP16
+// value as the ggml dequant.
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "compute/mmq_q4k_imma_layout.h"
+
+namespace imp {
+namespace {
+
+constexpr int kBlockBytes = 144;
+
+// 6-bit get_scale_min_k4, CPU version. Identical to the device-side helper.
+inline void get_scale_min_k4_cpu(int j, const uint8_t* q, uint8_t& d_out, uint8_t& m_out) {
+    if (j < 4) {
+        d_out = q[j] & 63u;
+        m_out = q[j + 4] & 63u;
+    } else {
+        d_out = (q[j + 4] & 0xFu) | ((q[j - 4] >> 6) << 4);
+        m_out = (q[j + 4] >> 4) | ((q[j - 0] >> 6) << 4);
+    }
+}
+
+// Build a random plausible Q4_K block: d/dmin sampled, scales[12] random, qs[128] random.
+void make_q4k_block(std::vector<uint8_t>& out, int blocks_per_row, int n_rows, unsigned seed) {
+    out.resize(static_cast<size_t>(blocks_per_row) * n_rows * kBlockBytes);
+    std::srand(seed);
+    for (size_t b = 0; b < out.size() / kBlockBytes; ++b) {
+        uint8_t* bp = out.data() + b * kBlockBytes;
+        // d ∈ [0.001, 0.05] is a reasonable Q4_K range for FP16 weights.
+        float d = 0.001f + 0.0005f * (std::rand() % 100);
+        float dmin = 0.0005f + 0.0001f * (std::rand() % 100);
+        __half d_h = __float2half(d), dmin_h = __float2half(dmin);
+        uint16_t d_bits = __half_as_ushort(d_h);
+        uint16_t dmin_bits = __half_as_ushort(dmin_h);
+        bp[0] = d_bits & 0xFF;
+        bp[1] = (d_bits >> 8) & 0xFF;
+        bp[2] = dmin_bits & 0xFF;
+        bp[3] = (dmin_bits >> 8) & 0xFF;
+        // scales[12]: random 6-bit values packed via the ggml format.
+        // Simplest: random bytes — the 6-bit-extraction helper masks them.
+        for (int i = 0; i < 12; ++i) bp[4 + i] = static_cast<uint8_t>(std::rand() & 0xFF);
+        for (int i = 0; i < 128; ++i) bp[16 + i] = static_cast<uint8_t>(std::rand() & 0xFF);
+    }
+}
+
+// CPU oracle: full Q4_K dequant. Returns one FP32 value per (row, k).
+void dequant_q4k_cpu(const std::vector<uint8_t>& blocks, int N, int K, std::vector<float>& out) {
+    const int blocks_per_row = K / kQ4kSuperBlockSize;
+    out.resize(static_cast<size_t>(N) * K);
+    for (int r = 0; r < N; ++r) {
+        for (int s = 0; s < blocks_per_row; ++s) {
+            const uint8_t* bp =
+                blocks.data() + static_cast<size_t>(r * blocks_per_row + s) * kBlockBytes;
+            uint16_t d_bits = static_cast<uint16_t>(bp[0]) | (static_cast<uint16_t>(bp[1]) << 8);
+            uint16_t dmin_bits = static_cast<uint16_t>(bp[2]) | (static_cast<uint16_t>(bp[3]) << 8);
+            float d = __half2float(__ushort_as_half(d_bits));
+            float dmin = __half2float(__ushort_as_half(dmin_bits));
+            const uint8_t* scales = bp + 4;
+            const uint8_t* qs = bp + 4 + 12;
+            for (int e = 0; e < kQ4kSuperBlockSize; ++e) {
+                const int group = e >> 6;
+                const int in_grp = e & 63;
+                const int is_high = (in_grp >> 5);
+                const int byte_in_group = in_grp & 31;
+                const int byte_in_qs = group * 32 + byte_in_group;
+                const int sub_block = group * 2 + is_high;
+                uint8_t sc_u, m_u;
+                get_scale_min_k4_cpu(sub_block, scales, sc_u, m_u);
+                int nibble = is_high ? (qs[byte_in_qs] >> 4) : (qs[byte_in_qs] & 0xF);
+                float val = d * static_cast<float>(sc_u) * static_cast<float>(nibble) -
+                            dmin * static_cast<float>(m_u);
+                out[static_cast<size_t>(r) * K + static_cast<size_t>(s * kQ4kSuperBlockSize + e)] =
+                    val;
+            }
+        }
+    }
+}
+
+void check_reorder(int N, int K, unsigned seed) {
+    SCOPED_TRACE(testing::Message() << "N=" << N << " K=" << K << " seed=" << seed);
+    ASSERT_EQ(K % kQ4kSuperBlockSize, 0);
+
+    const int blocks_per_row = K / kQ4kSuperBlockSize;
+    const int subs_per_row = blocks_per_row * kQ4kSubBlocksPerSuper;
+    const int total_subs = N * subs_per_row;
+
+    // Build input blocks.
+    std::vector<uint8_t> host_blocks;
+    make_q4k_block(host_blocks, blocks_per_row, N, seed);
+
+    // CPU oracle.
+    std::vector<float> ref_fp32;
+    dequant_q4k_cpu(host_blocks, N, K, ref_fp32);
+
+    // Upload + run kernel.
+    void* dev_blocks = nullptr;
+    cudaMalloc(&dev_blocks, host_blocks.size());
+    cudaMemcpy(dev_blocks, host_blocks.data(), host_blocks.size(), cudaMemcpyHostToDevice);
+
+    int8_t* dev_w = nullptr;
+    __half* dev_alpha = nullptr;
+    __half* dev_beta = nullptr;
+    cudaMalloc(&dev_w, static_cast<size_t>(N) * K);
+    cudaMalloc(&dev_alpha, static_cast<size_t>(total_subs) * sizeof(__half));
+    cudaMalloc(&dev_beta, static_cast<size_t>(total_subs) * sizeof(__half));
+
+    mmq_q4k_imma_reorder(dev_blocks, N, K, dev_w, dev_alpha, dev_beta, nullptr);
+    cudaDeviceSynchronize();
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    // Download outputs.
+    std::vector<int8_t> host_w(static_cast<size_t>(N) * K);
+    std::vector<__half> host_alpha(total_subs);
+    std::vector<__half> host_beta(total_subs);
+    cudaMemcpy(host_w.data(), dev_w, host_w.size(), cudaMemcpyDeviceToHost);
+    cudaMemcpy(host_alpha.data(), dev_alpha, host_alpha.size() * sizeof(__half),
+               cudaMemcpyDeviceToHost);
+    cudaMemcpy(host_beta.data(), dev_beta, host_beta.size() * sizeof(__half),
+               cudaMemcpyDeviceToHost);
+
+    // Verify: for every (r, k), α[r, k/32] * w_sym[r, k] + β[r, k/32] ≈ ref[r, k].
+    //
+    // Reconstruction goes through FP16 α and β. Per-element error budget is
+    // bounded by:
+    //   |recon - ref|  ≤  ulp(α)·|w| + ulp(β)
+    // Worst case (d=0.05, sc=63, w=±8, dmin=0.05, m=63): |α|≈3.15, |β|≈25,
+    // |α·w| ≤ 25, ulp at magnitude 25 ≈ 25·2^-10 ≈ 0.025 per term, summed
+    // worst case ~0.05. Cap at 0.1 to be safe (relative gates blow up near
+    // ref≈0 which is fine — we check abs there).
+    float max_abs_err = 0.0f;
+    int worst_r = 0, worst_k = 0;
+    for (int r = 0; r < N; ++r) {
+        for (int k = 0; k < K; ++k) {
+            const int sub_global_idx =
+                r * subs_per_row + (k / kQ4kSubBlockSize);
+            const float a = __half2float(host_alpha[sub_global_idx]);
+            const float b = __half2float(host_beta[sub_global_idx]);
+            const int w = static_cast<int>(host_w[static_cast<size_t>(r) * K + k]);
+            const float recon = a * static_cast<float>(w) + b;
+            const float ref = ref_fp32[static_cast<size_t>(r) * K + k];
+            const float ae = std::fabs(recon - ref);
+            if (ae > max_abs_err) {
+                max_abs_err = ae;
+                worst_r = r;
+                worst_k = k;
+            }
+            // s8 quant of nibble q-8 must round-trip exactly through int8_t.
+            ASSERT_GE(w, -8) << "w_sym out of range at (" << r << ", " << k << ")";
+            ASSERT_LE(w, 7) << "w_sym out of range at (" << r << ", " << k << ")";
+        }
+    }
+    EXPECT_LT(max_abs_err, 0.1f)
+        << "Reconstruction abs_err > 0.1 at (" << worst_r << ", " << worst_k << ") — "
+        << "likely a layout / dequant mismatch (FP16 ulp budget is ~0.05)";
+    std::fprintf(stderr, "[q4k-imma-reorder N=%d K=%d] max_abs_err=%.5f at (%d, %d)\n", N, K,
+                 max_abs_err, worst_r, worst_k);
+
+    cudaFree(dev_blocks);
+    cudaFree(dev_w);
+    cudaFree(dev_alpha);
+    cudaFree(dev_beta);
+}
+
+TEST(MmqQ4kImmaLayout, ReorderRoundTripSmall) {
+    check_reorder(/*N=*/4, /*K=*/256, /*seed=*/11);
+}
+
+TEST(MmqQ4kImmaLayout, ReorderRoundTripMultiSuper) {
+    check_reorder(/*N=*/4, /*K=*/1024, /*seed=*/41);  // 4 super-blocks per row
+}
+
+TEST(MmqQ4kImmaLayout, ReorderRoundTripFFNShape) {
+    // Qwen3-32B FFN dimensions: d_ff × d_model = 27648 × 5120.
+    // Use a slice to keep allocation small but exercise both dims.
+    check_reorder(/*N=*/128, /*K=*/2560, /*seed=*/97);  // 10 super-blocks per row
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## What

First slice of Phase 2 of the Q4_K_M direct-GEMM via INT8 IMMA project. A standalone load-time reorder kernel that splits each Q4_K super-block into three operand tensors that the future tile kernel (Phase 2B) will consume:

- \`w_sym_s8[N, K]\` — int8 weight, symmetric (\`q_sym = q - 8 ∈ [-8, 7]\`)
- \`eff_alpha[N, K/32]\` — FP16: \`α[j] = d_super * sc[j]\`
- \`eff_beta[N, K/32]\`  — FP16: \`β[j] = 8 * d_super * sc[j] - dmin_super * m[j]\`

Decode identity: \`α[j] * q_sym + β[j]  ≡  d * sc[j] * q - dmin * m[j]\` — matches \`ggml dequantize_row_q4_K\` exactly.

## Why

Phase 1 microbench (PR #254) confirmed sm_120a delivers ~931 TOPS for the target \`mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32\` opcode (3.82× FP16 HMMA TOPS, gate was ≥1.8×). The PROCEED decision spawned 4 Phase 2 slices per the design memo §6; this PR is the first.

Splitting the reorder out before the tile kernel keeps each slice independently bisectable, and lets the unit test compare against a CPU dequant oracle without the kernel-skeleton complexity.

## How

- One CTA per super-block, 32 threads per CTA. ~160 LoC kernel.
- Device-side \`get_scale_min_k4\` helper for the 6-bit sub-block scale/min extraction (matches the ggml/llama.cpp CPU version).
- Q4_K layout: 256 elements per super-block stored as 4 × 64-element groups. Each group: 32 bytes nibble-packed quants. Low nibbles of \`qs[0..31]\` → 32 elements with sub-block scale \`is\`, then high nibbles → 32 with \`is+1\`. Sub-block \`j ∈ [0, 8)\` maps to \`(group, is_high) = (j/2, j&1)\`.

For Phase 2A the s8 tensor is plain row-major K-major. The \`ldmatrix.x4\` / \`ldmatrix.x2\` permutation Phase 2B's tile kernel needs is a separate concern that will land alongside the consuming kernel.

## Tests

\`tests/test_mmq_q4k_imma_layout.cu\` (3 cases):

| Test | Shape | Max abs_err |
|---|---|---:|
| \`ReorderRoundTripSmall\`      | N=4, K=256              | 0.00658 |
| \`ReorderRoundTripMultiSuper\` | N=4, K=1024 (4 supers)  | 0.00988 |
| \`ReorderRoundTripFFNShape\`   | N=128, K=2560 (10 sup.) | 0.01551 |

All 3 pass. FP16 ulp budget for our scale range (d ∈ [0.001, 0.05], sc ∈ [0, 63], max α ≈ 3.15, max β ≈ 25) is ~0.05 per element. Test cap is 0.1.

## Bench

N/A — no production hot path touched. The new \`imp::mmq_q4k_imma_reorder\` symbol has no callers yet; Phase 2B and 2C will wire it in.

## Risk

Low. New code, no production callers, no decode hot path. Rollback = revert the PR.

What this PR is **not**:
- Phase 2B: tile kernel (cp.async + ldmatrix + scale apply) — next slice
- Phase 2C: production dispatch (\`gemm_dispatch_impl\` + \`WeightCaches::q4k_imma\`) — blocked on 2B
- Phase 3: E2E A/B sweep on Qwen3-32B Q4_K_M and Gemma-3-12B Q4_K_M — blocked on 2C