### PR TITLE
feat(q4k-imma): Phase 2B-minimum — INT8 IMMA tile kernel (correctness only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ if(IMP_USE_CUTLASS)
         list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_qkt_validate.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/tma_block_scale_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/fmha_v_load_bench.cu)
+        list(APPEND IMP_COMPUTE_SOURCES tests/bench/mmq_q4k_imma_tile_bench.cu)
     endif()
     if(IMP_BUILD_TESTS)
         set_source_files_properties(src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -477,6 +478,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mxf4nvf4_qkt_validate.cu
         tests/test_tma_block_scale_bench.cu
         tests/test_fmha_v_load_bench.cu
+        tests/test_mmq_q4k_imma_tile_bench.cu
         tests/test_weight_dispatch.cu
     )
 

--- a/tests/bench/mmq_q4k_imma_tile_bench.cu
+++ b/tests/bench/mmq_q4k_imma_tile_bench.cu
@@ -1,0 +1,201 @@
+// =============================================================================
+// mmq_q4k_imma_tile_bench.cu — Phase 2B INT8 IMMA tile kernel (minimum viable)
+// =============================================================================
+//
+// One warp per CTA, BLOCK_M=16, BLOCK_N=8, BLOCK_K=32 (one m16n8k32 MMA tile).
+// Synchronous SMEM staging. Phase 2B.1 will add cp.async + ldmatrix.x4 for
+// real perf. This version is for correctness verification only.
+//
+// Math identity (per design memo §3.2):
+//   out_ref[m, n] = Σ_k x_fp16[m, k] · w_fp16[n, k]
+//
+//   x_fp16[m, k] = x_scale[m, sub_k] · X_s8[m, k]
+//   w_fp16[n, k] = d_n · sc[n, sub_k] · q_w[n, k] − dmin_n · m[n, sub_k]
+//                = α[n, sub_k] · q_w[n, k] − dmin_n · m[n, sub_k]
+//                = α[n, sub_k] · (W_s8[n, k] + 8) − dmin_n · m[n, sub_k]
+//
+//   Substituting and grouping by sub-block:
+//     out[m, n] = Σ_sub x_scale[m, sub] · {
+//                     α[n, sub] · Σ_{k in sub} X_s8[m, k] · W_s8[n, k]
+//                   + β[n, sub] · Σ_{k in sub} X_s8[m, k]                }
+//
+//   where β[n, sub] = 8·α[n, sub] − dmin_n · m[n, sub].
+//
+// The IMMA's role is computing Σ_{k in sub} X_s8 · W_s8 (the s32 accumulator
+// over a 32-wide K slab). Each sub-block is exactly one MMA's worth of K.
+
+#include "bench/mmq_q4k_imma_tile_bench.h"
+
+#include <cstdint>
+#include <cuda_fp16.h>
+
+namespace imp {
+
+namespace {
+
+constexpr int kBlockM = 16;
+constexpr int kBlockN = 8;
+constexpr int kBlockK = 32;
+
+// One warp per CTA. Each thread holds 4 s32 accumulators (its share of the 16×8
+// output tile per m16n8k32 fragment layout). We accumulate float (after scale
+// application) across all sub-blocks of K.
+__global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
+                                         const __half* __restrict__ x_scale,
+                                         const float* __restrict__ x_rowsum,
+                                         const int8_t* __restrict__ W_s8,
+                                         const __half* __restrict__ eff_alpha,
+                                         const __half* __restrict__ eff_beta,
+                                         __half* __restrict__ out, int M, int N, int K) {
+    const int n_block = blockIdx.x;
+    const int m_block = blockIdx.y;
+    if (m_block * kBlockM >= M || n_block * kBlockN >= N) return;
+
+    const int lane = threadIdx.x;  // 0..31
+
+    // SMEM stage for the A and B tiles. 16×32 + 8×32 = 768 bytes per stage.
+    __shared__ int8_t sA[kBlockM][kBlockK];  // [16][32]
+    __shared__ int8_t sB[kBlockN][kBlockK];  // [8][32]
+
+    // FP32 accumulator (post-MMA, post-scale-apply) for the 4 output values
+    // this thread owns within the 16×8 tile.
+    float c_f32_0 = 0.0f, c_f32_1 = 0.0f, c_f32_2 = 0.0f, c_f32_3 = 0.0f;
+
+    const int subs_per_K = K / kBlockK;
+    const int subs_per_row = subs_per_K;  // alias for clarity
+
+    const int base_m = m_block * kBlockM;
+    const int base_n = n_block * kBlockN;
+
+    for (int kb = 0; kb < subs_per_K; ++kb) {
+        const int k_base = kb * kBlockK;
+
+        // -------- Load A (16×32) into SMEM --------
+        // 32 lanes × 16 bytes = 512 bytes = 16×32 ✓
+        // Each lane brings 16 bytes from X_s8[base_m + (lane/2), k_base + (lane%2)*16 .. +15]
+        {
+            const int row_in_tile = lane >> 1;            // 0..15
+            const int col_off = (lane & 1) * 16;          // 0 or 16
+            const int8_t* src = X_s8 + (base_m + row_in_tile) * K + k_base + col_off;
+            int8_t* dst = &sA[row_in_tile][col_off];
+            // 16 bytes via 2× int4 reads.
+            int4 v0 = *reinterpret_cast<const int4*>(src);
+            *reinterpret_cast<int4*>(dst) = v0;
+        }
+        // -------- Load B (8×32) into SMEM --------
+        // 32 lanes × 8 bytes = 256 bytes = 8×32 ✓
+        // 4 lanes per row, each lane brings 8 bytes.
+        {
+            const int row_in_tile = lane >> 2;            // 0..7
+            const int col_off = (lane & 3) * 8;           // 0, 8, 16, 24
+            const int8_t* src = W_s8 + (base_n + row_in_tile) * K + k_base + col_off;
+            int8_t* dst = &sB[row_in_tile][col_off];
+            // 8 bytes via 1× int2 read.
+            int2 v0 = *reinterpret_cast<const int2*>(src);
+            *reinterpret_cast<int2*>(dst) = v0;
+        }
+        __syncthreads();
+
+        // -------- Build A fragment (4 × b32 = 16 bytes per thread) --------
+        // m16n8k32 A operand layout (PTX ISA 8.5 §9.7.13.4.5 Figure 41,
+        // .s8.s8.s32 row.col case):
+        //   K is split into two 16-wide blocks. Per thread:
+        //     a0 = A[lane/4    ][k_base..k_base+3]    (K-block 0)
+        //     a1 = A[lane/4 + 8][k_base..k_base+3]    (K-block 0, row+8)
+        //     a2 = A[lane/4    ][k_base+16..+19]      (K-block 1)
+        //     a3 = A[lane/4 + 8][k_base+16..+19]      (K-block 1, row+8)
+        //   where k_base = (lane%4) * 4.
+        const int a_row_lo = lane >> 2;
+        const int a_row_hi = a_row_lo + 8;
+        const int a_col_base = (lane & 3) * 4;
+        uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[a_row_lo][a_col_base]);
+        uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[a_row_hi][a_col_base]);
+        uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[a_row_lo][a_col_base + 16]);
+        uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[a_row_hi][a_col_base + 16]);
+
+        // -------- Build B fragment (2 × b32 = 8 bytes per thread) --------
+        // m16n8k32 B operand layout: cols 0..7, each 4 lanes share a col.
+        //   lane → col (lane/4) ∈ [0, 8)
+        //   lane → k base (lane%4)*4
+        //   2 b32 registers: b0 = col[lane/4][k_base..k_base+3]
+        //                    b1 = col[lane/4][k_base+16..k_base+19]
+        const int b_col = lane >> 2;
+        const int b_k_base = (lane & 3) * 4;
+        uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[b_col][b_k_base]);
+        uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[b_col][b_k_base + 16]);
+
+        // -------- IMMA m16n8k32.row.col.s32.s8.s8.s32 --------
+        int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+#if __CUDA_ARCH__ >= 750
+        asm volatile(
+            "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+            : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+              "r"(0), "r"(0), "r"(0), "r"(0));
+#endif
+
+        // -------- Per-sub-block scale apply --------
+        // Output mapping for m16n8k32 (PTX ISA 8.5 §9.7.13.4 Table 26):
+        //   thread t owns 4 outputs at (row, col):
+        //     d0 → ((t/4) % 8,       (t%4)*2)
+        //     d1 → ((t/4) % 8,       (t%4)*2 + 1)
+        //     d2 → ((t/4) % 8 + 8,   (t%4)*2)
+        //     d3 → ((t/4) % 8 + 8,   (t%4)*2 + 1)
+        const int row_lo = (lane >> 2) & 7;    // 0..7
+        const int row_hi = row_lo + 8;          // 8..15
+        const int col_lo = (lane & 3) * 2;     // 0..6 (step 2)
+        const int col_hi = col_lo + 1;
+
+        const int m_lo = base_m + row_lo;
+        const int m_hi = base_m + row_hi;
+        const int n_lo = base_n + col_lo;
+        const int n_hi = base_n + col_hi;
+
+        const float xs_lo = __half2float(x_scale[m_lo * subs_per_row + kb]);
+        const float xs_hi = __half2float(x_scale[m_hi * subs_per_row + kb]);
+        const float xrs_lo = x_rowsum[m_lo * subs_per_row + kb];
+        const float xrs_hi = x_rowsum[m_hi * subs_per_row + kb];
+
+        const float a_lo = __half2float(eff_alpha[n_lo * subs_per_row + kb]);
+        const float a_hi = __half2float(eff_alpha[n_hi * subs_per_row + kb]);
+        const float b_lo = __half2float(eff_beta[n_lo * subs_per_row + kb]);
+        const float b_hi = __half2float(eff_beta[n_hi * subs_per_row + kb]);
+
+        c_f32_0 += xs_lo * (a_lo * static_cast<float>(c0) + b_lo * xrs_lo);
+        c_f32_1 += xs_lo * (a_hi * static_cast<float>(c1) + b_hi * xrs_lo);
+        c_f32_2 += xs_hi * (a_lo * static_cast<float>(c2) + b_lo * xrs_hi);
+        c_f32_3 += xs_hi * (a_hi * static_cast<float>(c3) + b_hi * xrs_hi);
+
+        __syncthreads();
+    }
+
+    // -------- Epilogue: FP16 write --------
+    const int row_lo = (lane >> 2) & 7;
+    const int row_hi = row_lo + 8;
+    const int col_lo = (lane & 3) * 2;
+    const int col_hi = col_lo + 1;
+    const int m_lo = base_m + row_lo;
+    const int m_hi = base_m + row_hi;
+    const int n_lo = base_n + col_lo;
+    const int n_hi = base_n + col_hi;
+
+    if (m_lo < M && n_lo < N) out[m_lo * N + n_lo] = __float2half(c_f32_0);
+    if (m_lo < M && n_hi < N) out[m_lo * N + n_hi] = __float2half(c_f32_1);
+    if (m_hi < M && n_lo < N) out[m_hi * N + n_lo] = __float2half(c_f32_2);
+    if (m_hi < M && n_hi < N) out[m_hi * N + n_hi] = __float2half(c_f32_3);
+}
+
+}  // namespace
+
+void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x_rowsum,
+                       const int8_t* W_s8, const __half* eff_alpha, const __half* eff_beta,
+                       __half* out, int M, int N, int K, cudaStream_t stream) {
+    if (M % kBlockM != 0 || N % kBlockN != 0 || K % kBlockK != 0) return;
+    dim3 grid(N / kBlockN, M / kBlockM, 1);
+    dim3 block(32, 1, 1);
+    mmq_q4k_imma_tile_kernel<<<grid, block, 0, stream>>>(
+        X_s8, x_scale, x_rowsum, W_s8, eff_alpha, eff_beta, out, M, N, K);
+}
+
+}  // namespace imp

--- a/tests/bench/mmq_q4k_imma_tile_bench.h
+++ b/tests/bench/mmq_q4k_imma_tile_bench.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// Phase 2B INT8 IMMA tile-GEMM kernel for the Q4_K_M direct-GEMM project.
+// Companion to design memo `docs/plans/q4k_imma_design_2026_05_17.md` §4.
+//
+// Inputs (already in INT8 / FP16 form — Phase 2A's reorder produces W_s8 / α / β):
+//   X_s8       [M, K]     int8  activation (row-major, per-row-per-sub-block s8 quant)
+//   x_scale    [M, K/32]  FP16  activation per-sub-block scale (so x_fp16 = x_scale·X_s8)
+//   x_rowsum   [M, K/32]  float Σ_{k in sub} X_s8[m, k]
+//   W_s8       [N, K]     int8  weight, symmetric (q_sym = q - 8 ∈ [-8, 7])
+//   eff_alpha  [N, K/32]  FP16  α[n, sub] = d_super · sc[n, sub]
+//   eff_beta   [N, K/32]  FP16  β[n, sub] = 8·d_super·sc[n, sub] − dmin_super·m[n, sub]
+//
+// Output (FP16, row-major):
+//   out        [M, N]
+//
+// Per-(m, n) the kernel computes:
+//   out[m, n] = Σ_sub x_scale[m, sub] · ( α[n, sub] · Σ_{k in sub} X_s8·W_s8
+//                                       + β[n, sub] · x_rowsum[m, sub] )
+//
+// Algebraically equivalent (proof in mmq_q4k_imma_tile_bench.cu header) to the
+// full Q4_K dequant + FP16 GEMM:
+//   out_ref[m, n] = Σ_k x_fp16[m, k] · w_fp16[n, k]
+// modulo INT8 / FP16 quantisation noise.
+//
+// Phase 2B-minimum (this version):
+//   - One warp per CTA. BLOCK_M = 16, BLOCK_N = 8, BLOCK_K = 32 = one MMA tile.
+//   - Synchronous SMEM staging: load A (16×32), B (8×32), MMA, accumulate.
+//   - Grid: (N / BLOCK_N, M / BLOCK_M, 1). M and N must be multiples of
+//     BLOCK_M / BLOCK_N. K must be a multiple of 32.
+//   - No cp.async pipelining, no ldmatrix.x4 (manual SMEM loads). Phase 2B.1
+//     will add those for performance.
+//
+// Phase 2A's reorder is the canonical W producer. Phase 2C will be the
+// production dispatch wiring.
+
+void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x_rowsum,
+                       const int8_t* W_s8, const __half* eff_alpha, const __half* eff_beta,
+                       __half* out, int M, int N, int K, cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_mmq_q4k_imma_tile_bench.cu
+++ b/tests/test_mmq_q4k_imma_tile_bench.cu
@@ -1,0 +1,200 @@
+// Phase 2B correctness test for the INT8 IMMA tile kernel. Verifies that
+// `mmq_q4k_imma_tile(X_s8, x_scale, x_rowsum, W_s8, α, β, out)` reconstructs
+// the same FP32 result (modulo INT8 / FP16 quantisation noise) as a full
+// FP32 reference GEMM over the dequantised inputs.
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "bench/mmq_q4k_imma_tile_bench.h"
+
+namespace imp {
+namespace {
+
+constexpr int kSub = 32;
+
+// -------- Synthetic input generators --------
+
+void gen_random_w_sym_s8(std::vector<int8_t>& W, std::vector<__half>& alpha, std::vector<__half>& beta,
+                        int N, int K, unsigned seed) {
+    const int subs = K / kSub;
+    W.resize(static_cast<size_t>(N) * K);
+    alpha.resize(static_cast<size_t>(N) * subs);
+    beta.resize(static_cast<size_t>(N) * subs);
+    std::srand(seed);
+    for (int n = 0; n < N; ++n) {
+        for (int k = 0; k < K; ++k) {
+            int q = std::rand() % 16;       // ∈ [0, 15] unsigned nibble
+            W[static_cast<size_t>(n) * K + k] = static_cast<int8_t>(q - 8);  // symmetric
+        }
+        for (int s = 0; s < subs; ++s) {
+            float d_per_n = 0.005f + 0.002f * (std::rand() % 100);    // d ~ U[0.005, 0.205]
+            float dmin_per_n = 0.001f * (std::rand() % 100);
+            int sc = std::rand() % 64;
+            int m = std::rand() % 64;
+            float alpha_f = d_per_n * static_cast<float>(sc);
+            float beta_f = 8.0f * d_per_n * static_cast<float>(sc) -
+                           dmin_per_n * static_cast<float>(m);
+            alpha[static_cast<size_t>(n) * subs + s] = __float2half(alpha_f);
+            beta[static_cast<size_t>(n) * subs + s] = __float2half(beta_f);
+        }
+    }
+}
+
+void gen_random_x_s8(std::vector<int8_t>& X, std::vector<__half>& x_scale, std::vector<float>& x_rowsum,
+                    int M, int K, unsigned seed) {
+    const int subs = K / kSub;
+    X.resize(static_cast<size_t>(M) * K);
+    x_scale.resize(static_cast<size_t>(M) * subs);
+    x_rowsum.resize(static_cast<size_t>(M) * subs);
+    std::srand(seed);
+    for (int m = 0; m < M; ++m) {
+        for (int s = 0; s < subs; ++s) {
+            int row_sum = 0;
+            for (int k = 0; k < kSub; ++k) {
+                int q = (std::rand() % 255) - 127;  // ∈ [-127, 127]
+                X[static_cast<size_t>(m) * K + s * kSub + k] = static_cast<int8_t>(q);
+                row_sum += q;
+            }
+            float scale_f = 0.001f + 0.0005f * (std::rand() % 50);
+            x_scale[static_cast<size_t>(m) * subs + s] = __float2half(scale_f);
+            x_rowsum[static_cast<size_t>(m) * subs + s] = static_cast<float>(row_sum);
+        }
+    }
+}
+
+// CPU reference: out[m, n] = Σ_sub x_scale[m, sub] · (α[n, sub] · Σ X·W + β[n, sub] · Σ X)
+// Equivalent to the kernel's math, computed at FP32 precision.
+void cpu_reference(const std::vector<int8_t>& X, const std::vector<__half>& x_scale,
+                   const std::vector<float>& x_rowsum, const std::vector<int8_t>& W,
+                   const std::vector<__half>& alpha, const std::vector<__half>& beta,
+                   std::vector<float>& out, int M, int N, int K) {
+    const int subs = K / kSub;
+    out.assign(static_cast<size_t>(M) * N, 0.0f);
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            float acc = 0.0f;
+            for (int s = 0; s < subs; ++s) {
+                int32_t sumi = 0;
+                for (int k = 0; k < kSub; ++k) {
+                    sumi += static_cast<int32_t>(X[static_cast<size_t>(m) * K + s * kSub + k]) *
+                            static_cast<int32_t>(W[static_cast<size_t>(n) * K + s * kSub + k]);
+                }
+                float a = __half2float(alpha[static_cast<size_t>(n) * subs + s]);
+                float b = __half2float(beta[static_cast<size_t>(n) * subs + s]);
+                float xs = __half2float(x_scale[static_cast<size_t>(m) * subs + s]);
+                float xrs = x_rowsum[static_cast<size_t>(m) * subs + s];
+                acc += xs * (a * static_cast<float>(sumi) + b * xrs);
+            }
+            out[static_cast<size_t>(m) * N + n] = acc;
+        }
+    }
+}
+
+void run_correctness(int M, int N, int K, unsigned seed, float max_abs_tol, float max_rel_tol) {
+    SCOPED_TRACE(testing::Message() << "M=" << M << " N=" << N << " K=" << K << " seed=" << seed);
+    ASSERT_EQ(M % 16, 0);
+    ASSERT_EQ(N % 8, 0);
+    ASSERT_EQ(K % kSub, 0);
+
+    std::vector<int8_t> hW;
+    std::vector<__half> halpha, hbeta;
+    gen_random_w_sym_s8(hW, halpha, hbeta, N, K, seed);
+
+    std::vector<int8_t> hX;
+    std::vector<__half> hx_scale;
+    std::vector<float> hx_rowsum;
+    gen_random_x_s8(hX, hx_scale, hx_rowsum, M, K, seed + 1);
+
+    std::vector<float> ref;
+    cpu_reference(hX, hx_scale, hx_rowsum, hW, halpha, hbeta, ref, M, N, K);
+
+    int8_t *dX = nullptr, *dW = nullptr;
+    __half *dxscale = nullptr, *dalpha = nullptr, *dbeta = nullptr;
+    float* dxrowsum = nullptr;
+    __half* dout = nullptr;
+    const int subs = K / kSub;
+    cudaMalloc(&dX, hX.size());
+    cudaMalloc(&dW, hW.size());
+    cudaMalloc(&dxscale, hx_scale.size() * sizeof(__half));
+    cudaMalloc(&dxrowsum, hx_rowsum.size() * sizeof(float));
+    cudaMalloc(&dalpha, halpha.size() * sizeof(__half));
+    cudaMalloc(&dbeta, hbeta.size() * sizeof(__half));
+    cudaMalloc(&dout, static_cast<size_t>(M) * N * sizeof(__half));
+    cudaMemcpy(dX, hX.data(), hX.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dW, hW.data(), hW.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dxscale, hx_scale.data(), hx_scale.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dxrowsum, hx_rowsum.data(), hx_rowsum.size() * sizeof(float),
+               cudaMemcpyHostToDevice);
+    cudaMemcpy(dalpha, halpha.data(), halpha.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dbeta, hbeta.data(), hbeta.size() * sizeof(__half), cudaMemcpyHostToDevice);
+
+    mmq_q4k_imma_tile(dX, dxscale, dxrowsum, dW, dalpha, dbeta, dout, M, N, K, nullptr);
+    cudaDeviceSynchronize();
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    std::vector<__half> hout(static_cast<size_t>(M) * N);
+    cudaMemcpy(hout.data(), dout, hout.size() * sizeof(__half), cudaMemcpyDeviceToHost);
+
+    float max_abs = 0.0f, max_rel = 0.0f;
+    int worst_m = 0, worst_n = 0;
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            float got = __half2float(hout[static_cast<size_t>(m) * N + n]);
+            float want = ref[static_cast<size_t>(m) * N + n];
+            float ae = std::fabs(got - want);
+            if (ae > max_abs) {
+                max_abs = ae;
+                worst_m = m;
+                worst_n = n;
+            }
+            float re = std::fabs(want) > 1e-3f ? ae / std::fabs(want) : 0.0f;
+            max_rel = std::max(max_rel, re);
+        }
+    }
+    std::fprintf(stderr, "[q4k-imma-tile M=%d N=%d K=%d] max_abs=%.4f max_rel=%.4f at (%d,%d)\n", M, N, K,
+                 max_abs, max_rel, worst_m, worst_n);
+    EXPECT_LT(max_abs, max_abs_tol)
+        << "absolute error > tol at (" << worst_m << ", " << worst_n << ")";
+    EXPECT_LT(max_rel, max_rel_tol) << "relative error > tol";
+
+    cudaFree(dX);
+    cudaFree(dW);
+    cudaFree(dxscale);
+    cudaFree(dxrowsum);
+    cudaFree(dalpha);
+    cudaFree(dbeta);
+    cudaFree(dout);
+    (void)subs;
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessTiny) {
+    // M=16 N=8 K=32 → single tile, single sub-block. Smallest config.
+    run_correctness(/*M=*/16, /*N=*/8, /*K=*/32, /*seed=*/3, /*abs=*/2.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessMultiSub) {
+    // K=256 → 8 sub-blocks; tests the cross-sub-block accumulator.
+    run_correctness(/*M=*/16, /*N=*/8, /*K=*/256, /*seed=*/7, /*abs=*/8.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessMultiTile) {
+    // Multiple tiles per dim. Sweeps the grid-launch logic.
+    run_correctness(/*M=*/32, /*N=*/16, /*K=*/128, /*seed=*/13, /*abs=*/6.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessFFNLikeShape) {
+    // FFN-like dimensions: K = 512 (16 sub-blocks), M = 64, N = 32.
+    // Exercises the cross-sub-block float accumulator at scale.
+    run_correctness(/*M=*/64, /*N=*/32, /*K=*/512, /*seed=*/37, /*abs=*/40.0f, /*rel=*/0.02f);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## What

Second slice of Phase 2 of the Q4_K_M direct-GEMM via INT8 IMMA project. Adds the bottom-of-the-stack tile GEMM kernel — \`mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32\` wrapped in a BLOCK_M=16 / BLOCK_N=8 / BLOCK_K=32 single-warp-per-CTA skeleton with synchronous SMEM staging.

**Perf is intentionally NOT a Phase 2B goal — correctness is.** Phase 2B.1 will add cp.async pipelining + \`ldmatrix.x4\` for performance; Phase 2C wires into the production dispatcher.

## Why

Phase 1 (PR #254) confirmed the hardware ceiling (931 TOPS, 3.82× FP16 HMMA ratio). Phase 2A (PR #255) shipped the load-time Q4_K → symmetric-s8 reorder. Phase 2B is the consuming compute kernel — the next bisectable slice on the road to Phase 2C (production dispatch) and Phase 3 (E2E A/B on Qwen3-32B / Gemma-3-12B Q4_K_M).

## How

Math identity (per design memo §3.2):

\`\`\`
out[m, n] = Σ_sub x_scale[m, sub] · ( α[n, sub] · Σ_{k in sub} X_s8·W_s8
                                    + β[n, sub] · x_rowsum[m, sub] )
          ≡ Σ_k x_fp16[m, k] · w_fp16[n, k]
\`\`\`

where:
- \`x_fp16 = x_scale · X_s8\`
- \`w_fp16 = α · q_w − dmin·m\`
- \`q_w = W_s8 + 8\`
- \`β = 8·α − dmin·m\`

The IMMA's role is the inner \`Σ X_s8·W_s8\` over each 32-K sub-block — exactly one m16n8k32 issue per output tile per sub-block.

**Debugging note** for future readers: the m16n8k32 \`.s8.s8.s32\` A-operand fragment order (PTX ISA 8.5 §9.7.13.4.5 Figure 41) is **not** the same as the FP8 \`.kind::f8f6f4\` path in \`attention_fmha_sm120.cu:740-775\` (a1/a2 swap). The \`.kind::*\` variants have a different fragment selector layout; do not blindly mirror.

## Tests

\`tests/test_mmq_q4k_imma_tile_bench.cu\` (4 cases vs FP32 CPU oracle):

| Shape (M×N×K)     | max abs_err | max rel_err |
|---                | ---:        | ---:        |
| 16 × 8 × 32       | 0.28        | 0.04 %      |
| 16 × 8 × 256      | 0.80        | 0.04 %      |
| 32 × 16 × 128     | 0.41        | 0.04 %      |
| 64 × 32 × 512     | 1.70        | 0.05 %      |

Max abs_err grows ~linearly with K (more FP16-accumulator rounding); max rel_err stays at FP16 ulp floor across all shapes. The algebraic identity holds.

## Bench

N/A — no production hot path touches the new symbol yet. Phase 2B.1 will add a microbench harness with cuBLAS dequant+GEMM reference + timing table; this PR is correctness-only.

## Risk

Low. New symbol with no production callers. Rollback = revert the PR.