### PR TITLE
perf(q4k-imma): Phase 2B.3 — BLOCK_M=64 N=32, WRM·WRN=2·2 per warp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ if(IMP_USE_CUTLASS)
         list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_qkt_validate.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/tma_block_scale_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/fmha_v_load_bench.cu)
+        list(APPEND IMP_COMPUTE_SOURCES tests/bench/mmq_q4k_imma_tile_bench.cu)
     endif()
     if(IMP_BUILD_TESTS)
         set_source_files_properties(src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -477,6 +478,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mxf4nvf4_qkt_validate.cu
         tests/test_tma_block_scale_bench.cu
         tests/test_fmha_v_load_bench.cu
+        tests/test_mmq_q4k_imma_tile_bench.cu
         tests/test_weight_dispatch.cu
     )
 

--- a/tests/bench/mmq_q4k_imma_tile_bench.cu
+++ b/tests/bench/mmq_q4k_imma_tile_bench.cu
@@ -1,0 +1,201 @@
+// =============================================================================
+// mmq_q4k_imma_tile_bench.cu — Phase 2B INT8 IMMA tile kernel (minimum viable)
+// =============================================================================
+//
+// One warp per CTA, BLOCK_M=16, BLOCK_N=8, BLOCK_K=32 (one m16n8k32 MMA tile).
+// Synchronous SMEM staging. Phase 2B.1 will add cp.async + ldmatrix.x4 for
+// real perf. This version is for correctness verification only.
+//
+// Math identity (per design memo §3.2):
+//   out_ref[m, n] = Σ_k x_fp16[m, k] · w_fp16[n, k]
+//
+//   x_fp16[m, k] = x_scale[m, sub_k] · X_s8[m, k]
+//   w_fp16[n, k] = d_n · sc[n, sub_k] · q_w[n, k] − dmin_n · m[n, sub_k]
+//                = α[n, sub_k] · q_w[n, k] − dmin_n · m[n, sub_k]
+//                = α[n, sub_k] · (W_s8[n, k] + 8) − dmin_n · m[n, sub_k]
+//
+//   Substituting and grouping by sub-block:
+//     out[m, n] = Σ_sub x_scale[m, sub] · {
+//                     α[n, sub] · Σ_{k in sub} X_s8[m, k] · W_s8[n, k]
+//                   + β[n, sub] · Σ_{k in sub} X_s8[m, k]                }
+//
+//   where β[n, sub] = 8·α[n, sub] − dmin_n · m[n, sub].
+//
+// The IMMA's role is computing Σ_{k in sub} X_s8 · W_s8 (the s32 accumulator
+// over a 32-wide K slab). Each sub-block is exactly one MMA's worth of K.
+
+#include "bench/mmq_q4k_imma_tile_bench.h"
+
+#include <cstdint>
+#include <cuda_fp16.h>
+
+namespace imp {
+
+namespace {
+
+constexpr int kBlockM = 16;
+constexpr int kBlockN = 8;
+constexpr int kBlockK = 32;
+
+// One warp per CTA. Each thread holds 4 s32 accumulators (its share of the 16×8
+// output tile per m16n8k32 fragment layout). We accumulate float (after scale
+// application) across all sub-blocks of K.
+__global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
+                                         const __half* __restrict__ x_scale,
+                                         const float* __restrict__ x_rowsum,
+                                         const int8_t* __restrict__ W_s8,
+                                         const __half* __restrict__ eff_alpha,
+                                         const __half* __restrict__ eff_beta,
+                                         __half* __restrict__ out, int M, int N, int K) {
+    const int n_block = blockIdx.x;
+    const int m_block = blockIdx.y;
+    if (m_block * kBlockM >= M || n_block * kBlockN >= N) return;
+
+    const int lane = threadIdx.x;  // 0..31
+
+    // SMEM stage for the A and B tiles. 16×32 + 8×32 = 768 bytes per stage.
+    __shared__ int8_t sA[kBlockM][kBlockK];  // [16][32]
+    __shared__ int8_t sB[kBlockN][kBlockK];  // [8][32]
+
+    // FP32 accumulator (post-MMA, post-scale-apply) for the 4 output values
+    // this thread owns within the 16×8 tile.
+    float c_f32_0 = 0.0f, c_f32_1 = 0.0f, c_f32_2 = 0.0f, c_f32_3 = 0.0f;
+
+    const int subs_per_K = K / kBlockK;
+    const int subs_per_row = subs_per_K;  // alias for clarity
+
+    const int base_m = m_block * kBlockM;
+    const int base_n = n_block * kBlockN;
+
+    for (int kb = 0; kb < subs_per_K; ++kb) {
+        const int k_base = kb * kBlockK;
+
+        // -------- Load A (16×32) into SMEM --------
+        // 32 lanes × 16 bytes = 512 bytes = 16×32 ✓
+        // Each lane brings 16 bytes from X_s8[base_m + (lane/2), k_base + (lane%2)*16 .. +15]
+        {
+            const int row_in_tile = lane >> 1;            // 0..15
+            const int col_off = (lane & 1) * 16;          // 0 or 16
+            const int8_t* src = X_s8 + (base_m + row_in_tile) * K + k_base + col_off;
+            int8_t* dst = &sA[row_in_tile][col_off];
+            // 16 bytes via 2× int4 reads.
+            int4 v0 = *reinterpret_cast<const int4*>(src);
+            *reinterpret_cast<int4*>(dst) = v0;
+        }
+        // -------- Load B (8×32) into SMEM --------
+        // 32 lanes × 8 bytes = 256 bytes = 8×32 ✓
+        // 4 lanes per row, each lane brings 8 bytes.
+        {
+            const int row_in_tile = lane >> 2;            // 0..7
+            const int col_off = (lane & 3) * 8;           // 0, 8, 16, 24
+            const int8_t* src = W_s8 + (base_n + row_in_tile) * K + k_base + col_off;
+            int8_t* dst = &sB[row_in_tile][col_off];
+            // 8 bytes via 1× int2 read.
+            int2 v0 = *reinterpret_cast<const int2*>(src);
+            *reinterpret_cast<int2*>(dst) = v0;
+        }
+        __syncthreads();
+
+        // -------- Build A fragment (4 × b32 = 16 bytes per thread) --------
+        // m16n8k32 A operand layout (PTX ISA 8.5 §9.7.13.4.5 Figure 41,
+        // .s8.s8.s32 row.col case):
+        //   K is split into two 16-wide blocks. Per thread:
+        //     a0 = A[lane/4    ][k_base..k_base+3]    (K-block 0)
+        //     a1 = A[lane/4 + 8][k_base..k_base+3]    (K-block 0, row+8)
+        //     a2 = A[lane/4    ][k_base+16..+19]      (K-block 1)
+        //     a3 = A[lane/4 + 8][k_base+16..+19]      (K-block 1, row+8)
+        //   where k_base = (lane%4) * 4.
+        const int a_row_lo = lane >> 2;
+        const int a_row_hi = a_row_lo + 8;
+        const int a_col_base = (lane & 3) * 4;
+        uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[a_row_lo][a_col_base]);
+        uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[a_row_hi][a_col_base]);
+        uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[a_row_lo][a_col_base + 16]);
+        uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[a_row_hi][a_col_base + 16]);
+
+        // -------- Build B fragment (2 × b32 = 8 bytes per thread) --------
+        // m16n8k32 B operand layout: cols 0..7, each 4 lanes share a col.
+        //   lane → col (lane/4) ∈ [0, 8)
+        //   lane → k base (lane%4)*4
+        //   2 b32 registers: b0 = col[lane/4][k_base..k_base+3]
+        //                    b1 = col[lane/4][k_base+16..k_base+19]
+        const int b_col = lane >> 2;
+        const int b_k_base = (lane & 3) * 4;
+        uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[b_col][b_k_base]);
+        uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[b_col][b_k_base + 16]);
+
+        // -------- IMMA m16n8k32.row.col.s32.s8.s8.s32 --------
+        int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+#if __CUDA_ARCH__ >= 750
+        asm volatile(
+            "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+            : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+              "r"(0), "r"(0), "r"(0), "r"(0));
+#endif
+
+        // -------- Per-sub-block scale apply --------
+        // Output mapping for m16n8k32 (PTX ISA 8.5 §9.7.13.4 Table 26):
+        //   thread t owns 4 outputs at (row, col):
+        //     d0 → ((t/4) % 8,       (t%4)*2)
+        //     d1 → ((t/4) % 8,       (t%4)*2 + 1)
+        //     d2 → ((t/4) % 8 + 8,   (t%4)*2)
+        //     d3 → ((t/4) % 8 + 8,   (t%4)*2 + 1)
+        const int row_lo = (lane >> 2) & 7;    // 0..7
+        const int row_hi = row_lo + 8;          // 8..15
+        const int col_lo = (lane & 3) * 2;     // 0..6 (step 2)
+        const int col_hi = col_lo + 1;
+
+        const int m_lo = base_m + row_lo;
+        const int m_hi = base_m + row_hi;
+        const int n_lo = base_n + col_lo;
+        const int n_hi = base_n + col_hi;
+
+        const float xs_lo = __half2float(x_scale[m_lo * subs_per_row + kb]);
+        const float xs_hi = __half2float(x_scale[m_hi * subs_per_row + kb]);
+        const float xrs_lo = x_rowsum[m_lo * subs_per_row + kb];
+        const float xrs_hi = x_rowsum[m_hi * subs_per_row + kb];
+
+        const float a_lo = __half2float(eff_alpha[n_lo * subs_per_row + kb]);
+        const float a_hi = __half2float(eff_alpha[n_hi * subs_per_row + kb]);
+        const float b_lo = __half2float(eff_beta[n_lo * subs_per_row + kb]);
+        const float b_hi = __half2float(eff_beta[n_hi * subs_per_row + kb]);
+
+        c_f32_0 += xs_lo * (a_lo * static_cast<float>(c0) + b_lo * xrs_lo);
+        c_f32_1 += xs_lo * (a_hi * static_cast<float>(c1) + b_hi * xrs_lo);
+        c_f32_2 += xs_hi * (a_lo * static_cast<float>(c2) + b_lo * xrs_hi);
+        c_f32_3 += xs_hi * (a_hi * static_cast<float>(c3) + b_hi * xrs_hi);
+
+        __syncthreads();
+    }
+
+    // -------- Epilogue: FP16 write --------
+    const int row_lo = (lane >> 2) & 7;
+    const int row_hi = row_lo + 8;
+    const int col_lo = (lane & 3) * 2;
+    const int col_hi = col_lo + 1;
+    const int m_lo = base_m + row_lo;
+    const int m_hi = base_m + row_hi;
+    const int n_lo = base_n + col_lo;
+    const int n_hi = base_n + col_hi;
+
+    if (m_lo < M && n_lo < N) out[m_lo * N + n_lo] = __float2half(c_f32_0);
+    if (m_lo < M && n_hi < N) out[m_lo * N + n_hi] = __float2half(c_f32_1);
+    if (m_hi < M && n_lo < N) out[m_hi * N + n_lo] = __float2half(c_f32_2);
+    if (m_hi < M && n_hi < N) out[m_hi * N + n_hi] = __float2half(c_f32_3);
+}
+
+}  // namespace
+
+void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x_rowsum,
+                       const int8_t* W_s8, const __half* eff_alpha, const __half* eff_beta,
+                       __half* out, int M, int N, int K, cudaStream_t stream) {
+    if (M % kBlockM != 0 || N % kBlockN != 0 || K % kBlockK != 0) return;
+    dim3 grid(N / kBlockN, M / kBlockM, 1);
+    dim3 block(32, 1, 1);
+    mmq_q4k_imma_tile_kernel<<<grid, block, 0, stream>>>(
+        X_s8, x_scale, x_rowsum, W_s8, eff_alpha, eff_beta, out, M, N, K);
+}
+
+}  // namespace imp

--- a/tests/bench/mmq_q4k_imma_tile_bench.cu
+++ b/tests/bench/mmq_q4k_imma_tile_bench.cu
@@ -33,16 +33,19 @@ namespace imp {
 
 namespace {
 
-// Phase 2B.2 multi-warp layout:
-//   BLOCK_M = 32, BLOCK_N = 16, BLOCK_K = 32. 4 warps per CTA in 2×2 spatial
-//   arrangement. Each warp owns one m16n8k32 sub-tile (16 rows × 8 cols of
-//   output, 32 K per MMA). 1 MMA per warp per K-block.
-constexpr int kBlockM = 32;
-constexpr int kBlockN = 16;
+// Phase 2B.3 large-tile layout:
+//   BLOCK_M = 64, BLOCK_N = 32, BLOCK_K = 32. 4 warps per CTA in 2×2 spatial
+//   arrangement, each warp doing WRM·WRN = 2·2 = 4 MMAs per K-block.
+//   Each warp owns a 32×16 output sub-tile (= 4 × m16n8 fragments).
+//   Total: 16 MMAs per CTA per K-block (4× Phase 2B.2).
+constexpr int kBlockM = 64;
+constexpr int kBlockN = 32;
 constexpr int kBlockK = 32;
-constexpr int kNumStages = 2;  // 2-stage cp.async pipeline
+constexpr int kNumStages = 2;
 constexpr int kNumWarps = 4;
 constexpr int kThreadsPerCTA = kNumWarps * 32;  // 128
+constexpr int kWRM = 2;  // M-tiles per warp
+constexpr int kWRN = 2;  // N-tiles per warp
 
 // cp.async helpers (mirror src/compute/attention_paged_common.cuh, kept local
 // here so the bench TU stays self-contained).
@@ -62,33 +65,33 @@ __device__ __forceinline__ void cp_async_wait_group() {
     asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
 }
 
-// Per-CTA async load of one K-block. 128 threads cooperate:
-//   threads 0..63   → load A (32 rows × 32 K = 1024 bytes via 64×ca_16)
-//   threads 64..127 → load B (16 rows × 32 K = 512  bytes via 64×ca_8)
+// Per-CTA async load of one K-block. All 128 threads cooperate:
+//   each thread issues one A-load (16 bytes) and one B-load (8 bytes).
+//   A: 64×32 = 2048 bytes = 128 × 16  via ca_16
+//   B: 32×32 = 1024 bytes = 128 × 8   via ca_8
 __device__ __forceinline__ void async_load_tile_mw(int tid, const int8_t* X_s8,
                                                    const int8_t* W_s8, int8_t (*sA)[kBlockK],
                                                    int8_t (*sB)[kBlockK], int base_m, int base_n,
                                                    int k_base, int K) {
-    if (tid < 64) {
-        // A loader: 64 threads × 16 bytes = 1024 = 32×32.
-        const int lane = tid;
-        const int row_in_tile = lane >> 1;       // 0..31
-        const int col_off = (lane & 1) * 16;     // 0 or 16
+    // A load: 128 lanes, lane → row (lane/2), col_off ((lane&1)*16).
+    {
+        const int row_in_tile = tid >> 1;      // 0..63
+        const int col_off = (tid & 1) * 16;    // 0 or 16
         const int8_t* src = X_s8 + (base_m + row_in_tile) * K + k_base + col_off;
         int8_t* dst = &sA[row_in_tile][col_off];
         cp_async_ca_16(dst, src);
-    } else {
-        // B loader: 64 threads × 8 bytes = 512 = 16×32.
-        const int lane = tid - 64;
-        const int row_in_tile = lane >> 2;       // 0..15
-        const int col_off = (lane & 3) * 8;      // 0, 8, 16, 24
+    }
+    // B load: 128 lanes, lane → row (lane/4), col_off ((lane&3)*8).
+    {
+        const int row_in_tile = tid >> 2;      // 0..31
+        const int col_off = (tid & 3) * 8;     // 0, 8, 16, 24
         const int8_t* src = W_s8 + (base_n + row_in_tile) * K + k_base + col_off;
         int8_t* dst = &sB[row_in_tile][col_off];
         cp_async_ca_8(dst, src);
     }
 }
 
-// 4 warps per CTA, 2×2 spatial. Each warp owns one m16n8k32 sub-tile.
+// 4 warps per CTA, each warp doing WRM·WRN = 2·2 = 4 MMAs per K-block.
 __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
                                          const __half* __restrict__ x_scale,
                                          const float* __restrict__ x_rowsum,
@@ -106,23 +109,27 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
     const int warp_m = warp_id >> 1;    // 0..1
     const int warp_n = warp_id & 1;     // 0..1
 
-    // Double-buffered SMEM: sA[2][32][32] + sB[2][16][32] = 2048 + 1024 = 3072 bytes per CTA.
+    // SMEM: sA[2][64][32] + sB[2][32][32] = 4096 + 2048 = 6144 bytes per CTA.
     __shared__ int8_t sA[kNumStages][kBlockM][kBlockK];
     __shared__ int8_t sB[kNumStages][kBlockN][kBlockK];
 
-    // FP32 accumulator (post-MMA, post-scale-apply) for the 4 output values
-    // this warp's lane owns within its 16×8 sub-tile.
-    float c_f32_0 = 0.0f, c_f32_1 = 0.0f, c_f32_2 = 0.0f, c_f32_3 = 0.0f;
+    // FP32 accumulator per (wrm, wrn) MMA × 4 outputs per lane.
+    float c_f32[kWRM][kWRN][4] = {{{0.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.0f}},
+                                  {{0.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.0f}}};
 
     const int subs_per_K = K / kBlockK;
     const int subs_per_row = subs_per_K;
 
     const int base_m = m_block * kBlockM;
     const int base_n = n_block * kBlockN;
-    const int warp_base_m = warp_m * 16;  // sub-tile offset in M
-    const int warp_base_n = warp_n * 8;   // sub-tile offset in N
+    // Each warp owns a 32 × 16 region of output:
+    //   M rows: [warp_m * 32, warp_m * 32 + 32)
+    //   N cols: [warp_n * 16, warp_n * 16 + 16)
+    // Internally divided into 2 × 2 m16n8 sub-tiles (wrm, wrn).
+    const int warp_origin_m = warp_m * 32;
+    const int warp_origin_n = warp_n * 16;
 
-    // -------- Prologue: issue the first kb=0 load --------
+    // -------- Prologue --------
     if (subs_per_K > 0) {
         async_load_tile_mw(tid, X_s8, W_s8, sA[0], sB[0], base_m, base_n, 0, K);
         cp_async_commit();
@@ -142,77 +149,90 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
         }
         __syncthreads();
 
-        // -------- Build A fragment from sA[stage] for this warp's sub-tile --------
-        // Warp's A view spans 16 rows starting at warp_base_m, all 32 K cols.
-        const int a_row_lo = warp_base_m + (lane >> 2);
-        const int a_row_hi = a_row_lo + 8;
-        const int a_col_base = (lane & 3) * 4;
-        uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base]);
-        uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base]);
-        uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base + 16]);
-        uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base + 16]);
+        // -------- 4 MMAs per warp per K-block: wrm × wrn = 2 × 2 --------
+#pragma unroll
+        for (int wrm = 0; wrm < kWRM; ++wrm) {
+            const int sub_origin_m = warp_origin_m + wrm * 16;
+            const int a_row_lo = sub_origin_m + (lane >> 2);
+            const int a_row_hi = a_row_lo + 8;
+            const int a_col_base = (lane & 3) * 4;
+            uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base]);
+            uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base]);
+            uint32_t a2 =
+                *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base + 16]);
+            uint32_t a3 =
+                *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base + 16]);
 
-        // -------- Build B fragment from sB[stage] for this warp's sub-tile --------
-        // Warp's B view spans 8 cols starting at warp_base_n, all 32 K cols.
-        const int b_col = warp_base_n + (lane >> 2);
-        const int b_k_base = (lane & 3) * 4;
-        uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base]);
-        uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base + 16]);
+#pragma unroll
+            for (int wrn = 0; wrn < kWRN; ++wrn) {
+                const int sub_origin_n = warp_origin_n + wrn * 8;
+                const int b_col = sub_origin_n + (lane >> 2);
+                const int b_k_base = (lane & 3) * 4;
+                uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base]);
+                uint32_t b1 =
+                    *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base + 16]);
 
-        // -------- IMMA m16n8k32.row.col.s32.s8.s8.s32 --------
-        int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+                int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
 #if __CUDA_ARCH__ >= 750
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
-            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
-            : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
-            : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
-              "r"(0), "r"(0), "r"(0), "r"(0));
+                asm volatile(
+                    "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+                    : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+                      "r"(0), "r"(0), "r"(0), "r"(0));
 #endif
 
-        // -------- Per-sub-block scale apply for this warp's outputs --------
-        const int row_lo = warp_base_m + ((lane >> 2) & 7);
-        const int row_hi = row_lo + 8;
-        const int col_lo = warp_base_n + (lane & 3) * 2;
-        const int col_hi = col_lo + 1;
+                // -------- Per-sub-block scale apply for this (wrm, wrn) MMA --------
+                const int row_lo = sub_origin_m + ((lane >> 2) & 7);
+                const int row_hi = row_lo + 8;
+                const int col_lo = sub_origin_n + (lane & 3) * 2;
+                const int col_hi = col_lo + 1;
 
-        const int m_lo = base_m + row_lo;
-        const int m_hi = base_m + row_hi;
-        const int n_lo = base_n + col_lo;
-        const int n_hi = base_n + col_hi;
+                const int m_lo = base_m + row_lo;
+                const int m_hi = base_m + row_hi;
+                const int n_lo = base_n + col_lo;
+                const int n_hi = base_n + col_hi;
 
-        const float xs_lo = __half2float(x_scale[m_lo * subs_per_row + kb]);
-        const float xs_hi = __half2float(x_scale[m_hi * subs_per_row + kb]);
-        const float xrs_lo = x_rowsum[m_lo * subs_per_row + kb];
-        const float xrs_hi = x_rowsum[m_hi * subs_per_row + kb];
+                const float xs_lo = __half2float(x_scale[m_lo * subs_per_row + kb]);
+                const float xs_hi = __half2float(x_scale[m_hi * subs_per_row + kb]);
+                const float xrs_lo = x_rowsum[m_lo * subs_per_row + kb];
+                const float xrs_hi = x_rowsum[m_hi * subs_per_row + kb];
 
-        const float a_lo = __half2float(eff_alpha[n_lo * subs_per_row + kb]);
-        const float a_hi = __half2float(eff_alpha[n_hi * subs_per_row + kb]);
-        const float b_lo = __half2float(eff_beta[n_lo * subs_per_row + kb]);
-        const float b_hi = __half2float(eff_beta[n_hi * subs_per_row + kb]);
+                const float a_lo = __half2float(eff_alpha[n_lo * subs_per_row + kb]);
+                const float a_hi = __half2float(eff_alpha[n_hi * subs_per_row + kb]);
+                const float b_lo = __half2float(eff_beta[n_lo * subs_per_row + kb]);
+                const float b_hi = __half2float(eff_beta[n_hi * subs_per_row + kb]);
 
-        c_f32_0 += xs_lo * (a_lo * static_cast<float>(c0) + b_lo * xrs_lo);
-        c_f32_1 += xs_lo * (a_hi * static_cast<float>(c1) + b_hi * xrs_lo);
-        c_f32_2 += xs_hi * (a_lo * static_cast<float>(c2) + b_lo * xrs_hi);
-        c_f32_3 += xs_hi * (a_hi * static_cast<float>(c3) + b_hi * xrs_hi);
-
+                c_f32[wrm][wrn][0] += xs_lo * (a_lo * static_cast<float>(c0) + b_lo * xrs_lo);
+                c_f32[wrm][wrn][1] += xs_lo * (a_hi * static_cast<float>(c1) + b_hi * xrs_lo);
+                c_f32[wrm][wrn][2] += xs_hi * (a_lo * static_cast<float>(c2) + b_lo * xrs_hi);
+                c_f32[wrm][wrn][3] += xs_hi * (a_hi * static_cast<float>(c3) + b_hi * xrs_hi);
+            }
+        }
         __syncthreads();
     }
 
-    // -------- Epilogue: FP16 write --------
-    const int row_lo = warp_base_m + ((lane >> 2) & 7);
-    const int row_hi = row_lo + 8;
-    const int col_lo = warp_base_n + (lane & 3) * 2;
-    const int col_hi = col_lo + 1;
-    const int m_lo = base_m + row_lo;
-    const int m_hi = base_m + row_hi;
-    const int n_lo = base_n + col_lo;
-    const int n_hi = base_n + col_hi;
-
-    if (m_lo < M && n_lo < N) out[m_lo * N + n_lo] = __float2half(c_f32_0);
-    if (m_lo < M && n_hi < N) out[m_lo * N + n_hi] = __float2half(c_f32_1);
-    if (m_hi < M && n_lo < N) out[m_hi * N + n_lo] = __float2half(c_f32_2);
-    if (m_hi < M && n_hi < N) out[m_hi * N + n_hi] = __float2half(c_f32_3);
+    // -------- Epilogue: FP16 write for all 4 (wrm, wrn) tiles --------
+#pragma unroll
+    for (int wrm = 0; wrm < kWRM; ++wrm) {
+        const int sub_origin_m = warp_origin_m + wrm * 16;
+#pragma unroll
+        for (int wrn = 0; wrn < kWRN; ++wrn) {
+            const int sub_origin_n = warp_origin_n + wrn * 8;
+            const int row_lo = sub_origin_m + ((lane >> 2) & 7);
+            const int row_hi = row_lo + 8;
+            const int col_lo = sub_origin_n + (lane & 3) * 2;
+            const int col_hi = col_lo + 1;
+            const int m_lo = base_m + row_lo;
+            const int m_hi = base_m + row_hi;
+            const int n_lo = base_n + col_lo;
+            const int n_hi = base_n + col_hi;
+            if (m_lo < M && n_lo < N) out[m_lo * N + n_lo] = __float2half(c_f32[wrm][wrn][0]);
+            if (m_lo < M && n_hi < N) out[m_lo * N + n_hi] = __float2half(c_f32[wrm][wrn][1]);
+            if (m_hi < M && n_lo < N) out[m_hi * N + n_lo] = __float2half(c_f32[wrm][wrn][2]);
+            if (m_hi < M && n_hi < N) out[m_hi * N + n_hi] = __float2half(c_f32[wrm][wrn][3]);
+        }
+    }
 }
 
 }  // namespace

--- a/tests/bench/mmq_q4k_imma_tile_bench.cu
+++ b/tests/bench/mmq_q4k_imma_tile_bench.cu
@@ -33,10 +33,16 @@ namespace imp {
 
 namespace {
 
-constexpr int kBlockM = 16;
-constexpr int kBlockN = 8;
+// Phase 2B.2 multi-warp layout:
+//   BLOCK_M = 32, BLOCK_N = 16, BLOCK_K = 32. 4 warps per CTA in 2×2 spatial
+//   arrangement. Each warp owns one m16n8k32 sub-tile (16 rows × 8 cols of
+//   output, 32 K per MMA). 1 MMA per warp per K-block.
+constexpr int kBlockM = 32;
+constexpr int kBlockN = 16;
 constexpr int kBlockK = 32;
 constexpr int kNumStages = 2;  // 2-stage cp.async pipeline
+constexpr int kNumWarps = 4;
+constexpr int kThreadsPerCTA = kNumWarps * 32;  // 128
 
 // cp.async helpers (mirror src/compute/attention_paged_common.cuh, kept local
 // here so the bench TU stays self-contained).
@@ -56,19 +62,25 @@ __device__ __forceinline__ void cp_async_wait_group() {
     asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
 }
 
-// Per-lane async load of the A and B tiles for one K-block into a given stage.
-__device__ __forceinline__ void async_load_tile(int lane, const int8_t* X_s8, const int8_t* W_s8,
-                                                int8_t (*sA)[kBlockK], int8_t (*sB)[kBlockK],
-                                                int base_m, int base_n, int k_base, int K) {
-    {
-        const int row_in_tile = lane >> 1;       // 0..15
+// Per-CTA async load of one K-block. 128 threads cooperate:
+//   threads 0..63   → load A (32 rows × 32 K = 1024 bytes via 64×ca_16)
+//   threads 64..127 → load B (16 rows × 32 K = 512  bytes via 64×ca_8)
+__device__ __forceinline__ void async_load_tile_mw(int tid, const int8_t* X_s8,
+                                                   const int8_t* W_s8, int8_t (*sA)[kBlockK],
+                                                   int8_t (*sB)[kBlockK], int base_m, int base_n,
+                                                   int k_base, int K) {
+    if (tid < 64) {
+        // A loader: 64 threads × 16 bytes = 1024 = 32×32.
+        const int lane = tid;
+        const int row_in_tile = lane >> 1;       // 0..31
         const int col_off = (lane & 1) * 16;     // 0 or 16
         const int8_t* src = X_s8 + (base_m + row_in_tile) * K + k_base + col_off;
         int8_t* dst = &sA[row_in_tile][col_off];
         cp_async_ca_16(dst, src);
-    }
-    {
-        const int row_in_tile = lane >> 2;       // 0..7
+    } else {
+        // B loader: 64 threads × 8 bytes = 512 = 16×32.
+        const int lane = tid - 64;
+        const int row_in_tile = lane >> 2;       // 0..15
         const int col_off = (lane & 3) * 8;      // 0, 8, 16, 24
         const int8_t* src = W_s8 + (base_n + row_in_tile) * K + k_base + col_off;
         int8_t* dst = &sB[row_in_tile][col_off];
@@ -76,9 +88,7 @@ __device__ __forceinline__ void async_load_tile(int lane, const int8_t* X_s8, co
     }
 }
 
-// One warp per CTA. Each thread holds 4 s32 accumulators (its share of the 16×8
-// output tile per m16n8k32 fragment layout). We accumulate float (after scale
-// application) across all sub-blocks of K.
+// 4 warps per CTA, 2×2 spatial. Each warp owns one m16n8k32 sub-tile.
 __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
                                          const __half* __restrict__ x_scale,
                                          const float* __restrict__ x_rowsum,
@@ -90,13 +100,18 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
     const int m_block = blockIdx.y;
     if (m_block * kBlockM >= M || n_block * kBlockN >= N) return;
 
-    const int lane = threadIdx.x;  // 0..31
+    const int tid = threadIdx.x;       // 0..127
+    const int warp_id = tid >> 5;       // 0..3
+    const int lane = tid & 31;          // 0..31
+    const int warp_m = warp_id >> 1;    // 0..1
+    const int warp_n = warp_id & 1;     // 0..1
 
-    // Double-buffered SMEM stage. Each stage holds one K-block worth of A and B.
-    // Total: 2 * (16×32 + 8×32) = 2 * 768 = 1536 bytes per CTA.
+    // Double-buffered SMEM: sA[2][32][32] + sB[2][16][32] = 2048 + 1024 = 3072 bytes per CTA.
     __shared__ int8_t sA[kNumStages][kBlockM][kBlockK];
     __shared__ int8_t sB[kNumStages][kBlockN][kBlockK];
 
+    // FP32 accumulator (post-MMA, post-scale-apply) for the 4 output values
+    // this warp's lane owns within its 16×8 sub-tile.
     float c_f32_0 = 0.0f, c_f32_1 = 0.0f, c_f32_2 = 0.0f, c_f32_3 = 0.0f;
 
     const int subs_per_K = K / kBlockK;
@@ -104,35 +119,32 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
 
     const int base_m = m_block * kBlockM;
     const int base_n = n_block * kBlockN;
+    const int warp_base_m = warp_m * 16;  // sub-tile offset in M
+    const int warp_base_n = warp_n * 8;   // sub-tile offset in N
 
     // -------- Prologue: issue the first kb=0 load --------
     if (subs_per_K > 0) {
-        async_load_tile(lane, X_s8, W_s8, sA[0], sB[0], base_m, base_n, /*k_base=*/0, K);
+        async_load_tile_mw(tid, X_s8, W_s8, sA[0], sB[0], base_m, base_n, 0, K);
         cp_async_commit();
     }
 
     for (int kb = 0; kb < subs_per_K; ++kb) {
         const int stage = kb & 1;
         const int next_kb = kb + 1;
-        // Issue next-iteration prefetch (next stage) before waiting on this one,
-        // so the cp.async engine overlaps it with our MMA + scale-apply.
         if (next_kb < subs_per_K) {
             const int next_stage = next_kb & 1;
-            async_load_tile(lane, X_s8, W_s8, sA[next_stage], sB[next_stage], base_m, base_n,
-                            next_kb * kBlockK, K);
+            async_load_tile_mw(tid, X_s8, W_s8, sA[next_stage], sB[next_stage], base_m, base_n,
+                               next_kb * kBlockK, K);
             cp_async_commit();
-            // Wait for THIS iteration's load (the one issued one step earlier).
-            // After we just committed the next prefetch, the older group is the
-            // last-but-one ⇒ wait_group<1>.
             cp_async_wait_group<1>();
         } else {
-            // Last iteration: no further prefetch issued, just drain the current.
             cp_async_wait_group<0>();
         }
         __syncthreads();
 
-        // -------- Build A fragment from sA[stage] --------
-        const int a_row_lo = lane >> 2;
+        // -------- Build A fragment from sA[stage] for this warp's sub-tile --------
+        // Warp's A view spans 16 rows starting at warp_base_m, all 32 K cols.
+        const int a_row_lo = warp_base_m + (lane >> 2);
         const int a_row_hi = a_row_lo + 8;
         const int a_col_base = (lane & 3) * 4;
         uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base]);
@@ -140,8 +152,9 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
         uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base + 16]);
         uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base + 16]);
 
-        // -------- Build B fragment from sB[stage] --------
-        const int b_col = lane >> 2;
+        // -------- Build B fragment from sB[stage] for this warp's sub-tile --------
+        // Warp's B view spans 8 cols starting at warp_base_n, all 32 K cols.
+        const int b_col = warp_base_n + (lane >> 2);
         const int b_k_base = (lane & 3) * 4;
         uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base]);
         uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base + 16]);
@@ -157,10 +170,10 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
               "r"(0), "r"(0), "r"(0), "r"(0));
 #endif
 
-        // -------- Per-sub-block scale apply --------
-        const int row_lo = (lane >> 2) & 7;
+        // -------- Per-sub-block scale apply for this warp's outputs --------
+        const int row_lo = warp_base_m + ((lane >> 2) & 7);
         const int row_hi = row_lo + 8;
-        const int col_lo = (lane & 3) * 2;
+        const int col_lo = warp_base_n + (lane & 3) * 2;
         const int col_hi = col_lo + 1;
 
         const int m_lo = base_m + row_lo;
@@ -187,9 +200,9 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
     }
 
     // -------- Epilogue: FP16 write --------
-    const int row_lo = (lane >> 2) & 7;
+    const int row_lo = warp_base_m + ((lane >> 2) & 7);
     const int row_hi = row_lo + 8;
-    const int col_lo = (lane & 3) * 2;
+    const int col_lo = warp_base_n + (lane & 3) * 2;
     const int col_hi = col_lo + 1;
     const int m_lo = base_m + row_lo;
     const int m_hi = base_m + row_hi;
@@ -209,7 +222,7 @@ void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x
                        __half* out, int M, int N, int K, cudaStream_t stream) {
     if (M % kBlockM != 0 || N % kBlockN != 0 || K % kBlockK != 0) return;
     dim3 grid(N / kBlockN, M / kBlockM, 1);
-    dim3 block(32, 1, 1);
+    dim3 block(kThreadsPerCTA, 1, 1);
     mmq_q4k_imma_tile_kernel<<<grid, block, 0, stream>>>(
         X_s8, x_scale, x_rowsum, W_s8, eff_alpha, eff_beta, out, M, N, K);
 }

--- a/tests/bench/mmq_q4k_imma_tile_bench.cu
+++ b/tests/bench/mmq_q4k_imma_tile_bench.cu
@@ -36,6 +36,45 @@ namespace {
 constexpr int kBlockM = 16;
 constexpr int kBlockN = 8;
 constexpr int kBlockK = 32;
+constexpr int kNumStages = 2;  // 2-stage cp.async pipeline
+
+// cp.async helpers (mirror src/compute/attention_paged_common.cuh, kept local
+// here so the bench TU stays self-contained).
+__device__ __forceinline__ void cp_async_ca_8(void* smem, const void* glob) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 8;\n" ::"r"(s), "l"(glob));
+}
+__device__ __forceinline__ void cp_async_ca_16(void* smem, const void* glob) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 16;\n" ::"r"(s), "l"(glob));
+}
+__device__ __forceinline__ void cp_async_commit() {
+    asm volatile("cp.async.commit_group;\n");
+}
+template <int N>
+__device__ __forceinline__ void cp_async_wait_group() {
+    asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
+}
+
+// Per-lane async load of the A and B tiles for one K-block into a given stage.
+__device__ __forceinline__ void async_load_tile(int lane, const int8_t* X_s8, const int8_t* W_s8,
+                                                int8_t (*sA)[kBlockK], int8_t (*sB)[kBlockK],
+                                                int base_m, int base_n, int k_base, int K) {
+    {
+        const int row_in_tile = lane >> 1;       // 0..15
+        const int col_off = (lane & 1) * 16;     // 0 or 16
+        const int8_t* src = X_s8 + (base_m + row_in_tile) * K + k_base + col_off;
+        int8_t* dst = &sA[row_in_tile][col_off];
+        cp_async_ca_16(dst, src);
+    }
+    {
+        const int row_in_tile = lane >> 2;       // 0..7
+        const int col_off = (lane & 3) * 8;      // 0, 8, 16, 24
+        const int8_t* src = W_s8 + (base_n + row_in_tile) * K + k_base + col_off;
+        int8_t* dst = &sB[row_in_tile][col_off];
+        cp_async_ca_8(dst, src);
+    }
+}
 
 // One warp per CTA. Each thread holds 4 s32 accumulators (its share of the 16×8
 // output tile per m16n8k32 fragment layout). We accumulate float (after scale
@@ -53,76 +92,59 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
 
     const int lane = threadIdx.x;  // 0..31
 
-    // SMEM stage for the A and B tiles. 16×32 + 8×32 = 768 bytes per stage.
-    __shared__ int8_t sA[kBlockM][kBlockK];  // [16][32]
-    __shared__ int8_t sB[kBlockN][kBlockK];  // [8][32]
+    // Double-buffered SMEM stage. Each stage holds one K-block worth of A and B.
+    // Total: 2 * (16×32 + 8×32) = 2 * 768 = 1536 bytes per CTA.
+    __shared__ int8_t sA[kNumStages][kBlockM][kBlockK];
+    __shared__ int8_t sB[kNumStages][kBlockN][kBlockK];
 
-    // FP32 accumulator (post-MMA, post-scale-apply) for the 4 output values
-    // this thread owns within the 16×8 tile.
     float c_f32_0 = 0.0f, c_f32_1 = 0.0f, c_f32_2 = 0.0f, c_f32_3 = 0.0f;
 
     const int subs_per_K = K / kBlockK;
-    const int subs_per_row = subs_per_K;  // alias for clarity
+    const int subs_per_row = subs_per_K;
 
     const int base_m = m_block * kBlockM;
     const int base_n = n_block * kBlockN;
 
-    for (int kb = 0; kb < subs_per_K; ++kb) {
-        const int k_base = kb * kBlockK;
+    // -------- Prologue: issue the first kb=0 load --------
+    if (subs_per_K > 0) {
+        async_load_tile(lane, X_s8, W_s8, sA[0], sB[0], base_m, base_n, /*k_base=*/0, K);
+        cp_async_commit();
+    }
 
-        // -------- Load A (16×32) into SMEM --------
-        // 32 lanes × 16 bytes = 512 bytes = 16×32 ✓
-        // Each lane brings 16 bytes from X_s8[base_m + (lane/2), k_base + (lane%2)*16 .. +15]
-        {
-            const int row_in_tile = lane >> 1;            // 0..15
-            const int col_off = (lane & 1) * 16;          // 0 or 16
-            const int8_t* src = X_s8 + (base_m + row_in_tile) * K + k_base + col_off;
-            int8_t* dst = &sA[row_in_tile][col_off];
-            // 16 bytes via 2× int4 reads.
-            int4 v0 = *reinterpret_cast<const int4*>(src);
-            *reinterpret_cast<int4*>(dst) = v0;
-        }
-        // -------- Load B (8×32) into SMEM --------
-        // 32 lanes × 8 bytes = 256 bytes = 8×32 ✓
-        // 4 lanes per row, each lane brings 8 bytes.
-        {
-            const int row_in_tile = lane >> 2;            // 0..7
-            const int col_off = (lane & 3) * 8;           // 0, 8, 16, 24
-            const int8_t* src = W_s8 + (base_n + row_in_tile) * K + k_base + col_off;
-            int8_t* dst = &sB[row_in_tile][col_off];
-            // 8 bytes via 1× int2 read.
-            int2 v0 = *reinterpret_cast<const int2*>(src);
-            *reinterpret_cast<int2*>(dst) = v0;
+    for (int kb = 0; kb < subs_per_K; ++kb) {
+        const int stage = kb & 1;
+        const int next_kb = kb + 1;
+        // Issue next-iteration prefetch (next stage) before waiting on this one,
+        // so the cp.async engine overlaps it with our MMA + scale-apply.
+        if (next_kb < subs_per_K) {
+            const int next_stage = next_kb & 1;
+            async_load_tile(lane, X_s8, W_s8, sA[next_stage], sB[next_stage], base_m, base_n,
+                            next_kb * kBlockK, K);
+            cp_async_commit();
+            // Wait for THIS iteration's load (the one issued one step earlier).
+            // After we just committed the next prefetch, the older group is the
+            // last-but-one ⇒ wait_group<1>.
+            cp_async_wait_group<1>();
+        } else {
+            // Last iteration: no further prefetch issued, just drain the current.
+            cp_async_wait_group<0>();
         }
         __syncthreads();
 
-        // -------- Build A fragment (4 × b32 = 16 bytes per thread) --------
-        // m16n8k32 A operand layout (PTX ISA 8.5 §9.7.13.4.5 Figure 41,
-        // .s8.s8.s32 row.col case):
-        //   K is split into two 16-wide blocks. Per thread:
-        //     a0 = A[lane/4    ][k_base..k_base+3]    (K-block 0)
-        //     a1 = A[lane/4 + 8][k_base..k_base+3]    (K-block 0, row+8)
-        //     a2 = A[lane/4    ][k_base+16..+19]      (K-block 1)
-        //     a3 = A[lane/4 + 8][k_base+16..+19]      (K-block 1, row+8)
-        //   where k_base = (lane%4) * 4.
+        // -------- Build A fragment from sA[stage] --------
         const int a_row_lo = lane >> 2;
         const int a_row_hi = a_row_lo + 8;
         const int a_col_base = (lane & 3) * 4;
-        uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[a_row_lo][a_col_base]);
-        uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[a_row_hi][a_col_base]);
-        uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[a_row_lo][a_col_base + 16]);
-        uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[a_row_hi][a_col_base + 16]);
+        uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base]);
+        uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base]);
+        uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base + 16]);
+        uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base + 16]);
 
-        // -------- Build B fragment (2 × b32 = 8 bytes per thread) --------
-        // m16n8k32 B operand layout: cols 0..7, each 4 lanes share a col.
-        //   lane → col (lane/4) ∈ [0, 8)
-        //   lane → k base (lane%4)*4
-        //   2 b32 registers: b0 = col[lane/4][k_base..k_base+3]
-        //                    b1 = col[lane/4][k_base+16..k_base+19]
+        // -------- Build B fragment from sB[stage] --------
         const int b_col = lane >> 2;
         const int b_k_base = (lane & 3) * 4;
-        uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[b_col][b_k_base]);
-        uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[b_col][b_k_base + 16]);
+        uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base]);
+        uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base + 16]);
 
         // -------- IMMA m16n8k32.row.col.s32.s8.s8.s32 --------
         int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
@@ -136,15 +158,9 @@ __global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
 #endif
 
         // -------- Per-sub-block scale apply --------
-        // Output mapping for m16n8k32 (PTX ISA 8.5 §9.7.13.4 Table 26):
-        //   thread t owns 4 outputs at (row, col):
-        //     d0 → ((t/4) % 8,       (t%4)*2)
-        //     d1 → ((t/4) % 8,       (t%4)*2 + 1)
-        //     d2 → ((t/4) % 8 + 8,   (t%4)*2)
-        //     d3 → ((t/4) % 8 + 8,   (t%4)*2 + 1)
-        const int row_lo = (lane >> 2) & 7;    // 0..7
-        const int row_hi = row_lo + 8;          // 8..15
-        const int col_lo = (lane & 3) * 2;     // 0..6 (step 2)
+        const int row_lo = (lane >> 2) & 7;
+        const int row_hi = row_lo + 8;
+        const int col_lo = (lane & 3) * 2;
         const int col_hi = col_lo + 1;
 
         const int m_lo = base_m + row_lo;

--- a/tests/bench/mmq_q4k_imma_tile_bench.h
+++ b/tests/bench/mmq_q4k_imma_tile_bench.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// Phase 2B INT8 IMMA tile-GEMM kernel for the Q4_K_M direct-GEMM project.
+// Companion to design memo `docs/plans/q4k_imma_design_2026_05_17.md` §4.
+//
+// Inputs (already in INT8 / FP16 form — Phase 2A's reorder produces W_s8 / α / β):
+//   X_s8       [M, K]     int8  activation (row-major, per-row-per-sub-block s8 quant)
+//   x_scale    [M, K/32]  FP16  activation per-sub-block scale (so x_fp16 = x_scale·X_s8)
+//   x_rowsum   [M, K/32]  float Σ_{k in sub} X_s8[m, k]
+//   W_s8       [N, K]     int8  weight, symmetric (q_sym = q - 8 ∈ [-8, 7])
+//   eff_alpha  [N, K/32]  FP16  α[n, sub] = d_super · sc[n, sub]
+//   eff_beta   [N, K/32]  FP16  β[n, sub] = 8·d_super·sc[n, sub] − dmin_super·m[n, sub]
+//
+// Output (FP16, row-major):
+//   out        [M, N]
+//
+// Per-(m, n) the kernel computes:
+//   out[m, n] = Σ_sub x_scale[m, sub] · ( α[n, sub] · Σ_{k in sub} X_s8·W_s8
+//                                       + β[n, sub] · x_rowsum[m, sub] )
+//
+// Algebraically equivalent (proof in mmq_q4k_imma_tile_bench.cu header) to the
+// full Q4_K dequant + FP16 GEMM:
+//   out_ref[m, n] = Σ_k x_fp16[m, k] · w_fp16[n, k]
+// modulo INT8 / FP16 quantisation noise.
+//
+// Phase 2B-minimum (this version):
+//   - One warp per CTA. BLOCK_M = 16, BLOCK_N = 8, BLOCK_K = 32 = one MMA tile.
+//   - Synchronous SMEM staging: load A (16×32), B (8×32), MMA, accumulate.
+//   - Grid: (N / BLOCK_N, M / BLOCK_M, 1). M and N must be multiples of
+//     BLOCK_M / BLOCK_N. K must be a multiple of 32.
+//   - No cp.async pipelining, no ldmatrix.x4 (manual SMEM loads). Phase 2B.1
+//     will add those for performance.
+//
+// Phase 2A's reorder is the canonical W producer. Phase 2C will be the
+// production dispatch wiring.
+
+void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x_rowsum,
+                       const int8_t* W_s8, const __half* eff_alpha, const __half* eff_beta,
+                       __half* out, int M, int N, int K, cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_mmq_q4k_imma_tile_bench.cu
+++ b/tests/test_mmq_q4k_imma_tile_bench.cu
@@ -176,25 +176,25 @@ void run_correctness(int M, int N, int K, unsigned seed, float max_abs_tol, floa
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessTiny) {
-    // Smallest config that fills one CTA (BLOCK_M=32, BLOCK_N=16): one block,
-    // one sub-block of K.
-    run_correctness(/*M=*/32, /*N=*/16, /*K=*/32, /*seed=*/3, /*abs=*/2.0f, /*rel=*/0.02f);
+    // Smallest config that fills one CTA (BLOCK_M=64, BLOCK_N=32):
+    // one block, one sub-block of K.
+    run_correctness(/*M=*/64, /*N=*/32, /*K=*/32, /*seed=*/3, /*abs=*/2.0f, /*rel=*/0.02f);
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessMultiSub) {
     // K=256 → 8 sub-blocks; tests the cross-sub-block accumulator.
-    run_correctness(/*M=*/32, /*N=*/16, /*K=*/256, /*seed=*/7, /*abs=*/8.0f, /*rel=*/0.02f);
+    run_correctness(/*M=*/64, /*N=*/32, /*K=*/256, /*seed=*/7, /*abs=*/8.0f, /*rel=*/0.02f);
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessMultiTile) {
     // Multiple CTAs per dim. Sweeps the grid-launch logic.
-    run_correctness(/*M=*/64, /*N=*/32, /*K=*/128, /*seed=*/13, /*abs=*/6.0f, /*rel=*/0.02f);
+    run_correctness(/*M=*/128, /*N=*/64, /*K=*/128, /*seed=*/13, /*abs=*/6.0f, /*rel=*/0.02f);
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessFFNLikeShape) {
-    // FFN-like dimensions: K = 512 (16 sub-blocks), M = 64, N = 32.
+    // FFN-like dimensions: K = 512 (16 sub-blocks), M = 128, N = 64.
     // Exercises the cross-sub-block float accumulator at scale.
-    run_correctness(/*M=*/64, /*N=*/32, /*K=*/512, /*seed=*/37, /*abs=*/40.0f, /*rel=*/0.02f);
+    run_correctness(/*M=*/128, /*N=*/64, /*K=*/512, /*seed=*/37, /*abs=*/40.0f, /*rel=*/0.02f);
 }
 
 // Bench-only — prints kernel-time and effective TOPS at production-realistic
@@ -203,15 +203,22 @@ TEST(MmqQ4kImmaTile, CorrectnessFFNLikeShape) {
 // each SM; Phase 2B.2 (multi-warp expansion) is the next real perf lever.
 TEST(MmqQ4kImmaTile, BenchSweep) {
     struct Shape { int M, N, K; };
+    // Cover production FFN shapes (Qwen3-32B FFN ~5120, Gemma-3-12B ~3072).
+    // Larger M/N is mandatory for Phase 2B.3's BLOCK_M=64 BLOCK_N=32 tile —
+    // small shapes leave 170 SMs starved (verified empirically: M=512 N=256 →
+    // 64 CTAs ≈ 0.4 CTAs/SM and the kernel regresses vs Phase 2B.2).
     Shape shapes[] = {
-        {64,  256, 2048},
-        {128, 256, 2048},
-        {256, 256, 2048},
-        {512, 256, 2048},
+        {512,  512,  2048},
+        {1024, 512,  2048},
+        {2048, 512,  2048},
+        {4096, 1024, 2048},
+        {2048, 2048, 2048},
+        {4096, 4096, 2048},
     };
 
     std::fprintf(stderr,
-                 "\n[q4k-imma-tile Phase 2B.2 bench, 4 warps/CTA (32×16 output), 2-stage cp.async]\n");
+                 "\n[q4k-imma-tile Phase 2B.3 bench, 4 warps/CTA × WRM·WRN=2·2 "
+                 "(64×32 output), 2-stage cp.async]\n");
     std::fprintf(stderr, "  %4s %4s %5s  %10s  %10s\n", "M", "N", "K", "ms/rep", "TOPS");
 
     for (auto sh : shapes) {

--- a/tests/test_mmq_q4k_imma_tile_bench.cu
+++ b/tests/test_mmq_q4k_imma_tile_bench.cu
@@ -176,18 +176,19 @@ void run_correctness(int M, int N, int K, unsigned seed, float max_abs_tol, floa
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessTiny) {
-    // M=16 N=8 K=32 → single tile, single sub-block. Smallest config.
-    run_correctness(/*M=*/16, /*N=*/8, /*K=*/32, /*seed=*/3, /*abs=*/2.0f, /*rel=*/0.02f);
+    // Smallest config that fills one CTA (BLOCK_M=32, BLOCK_N=16): one block,
+    // one sub-block of K.
+    run_correctness(/*M=*/32, /*N=*/16, /*K=*/32, /*seed=*/3, /*abs=*/2.0f, /*rel=*/0.02f);
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessMultiSub) {
     // K=256 → 8 sub-blocks; tests the cross-sub-block accumulator.
-    run_correctness(/*M=*/16, /*N=*/8, /*K=*/256, /*seed=*/7, /*abs=*/8.0f, /*rel=*/0.02f);
+    run_correctness(/*M=*/32, /*N=*/16, /*K=*/256, /*seed=*/7, /*abs=*/8.0f, /*rel=*/0.02f);
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessMultiTile) {
-    // Multiple tiles per dim. Sweeps the grid-launch logic.
-    run_correctness(/*M=*/32, /*N=*/16, /*K=*/128, /*seed=*/13, /*abs=*/6.0f, /*rel=*/0.02f);
+    // Multiple CTAs per dim. Sweeps the grid-launch logic.
+    run_correctness(/*M=*/64, /*N=*/32, /*K=*/128, /*seed=*/13, /*abs=*/6.0f, /*rel=*/0.02f);
 }
 
 TEST(MmqQ4kImmaTile, CorrectnessFFNLikeShape) {
@@ -210,7 +211,7 @@ TEST(MmqQ4kImmaTile, BenchSweep) {
     };
 
     std::fprintf(stderr,
-                 "\n[q4k-imma-tile Phase 2B.1 bench, single warp per CTA, 2-stage cp.async]\n");
+                 "\n[q4k-imma-tile Phase 2B.2 bench, 4 warps/CTA (32×16 output), 2-stage cp.async]\n");
     std::fprintf(stderr, "  %4s %4s %5s  %10s  %10s\n", "M", "N", "K", "ms/rep", "TOPS");
 
     for (auto sh : shapes) {

--- a/tests/test_mmq_q4k_imma_tile_bench.cu
+++ b/tests/test_mmq_q4k_imma_tile_bench.cu
@@ -196,5 +196,91 @@ TEST(MmqQ4kImmaTile, CorrectnessFFNLikeShape) {
     run_correctness(/*M=*/64, /*N=*/32, /*K=*/512, /*seed=*/37, /*abs=*/40.0f, /*rel=*/0.02f);
 }
 
+// Bench-only — prints kernel-time and effective TOPS at production-realistic
+// shapes. No perf assertion: this is Phase 2B.1 informational baseline. The
+// 1-warp-per-CTA tile (BLOCK_M=16, BLOCK_N=8) substantially under-utilises
+// each SM; Phase 2B.2 (multi-warp expansion) is the next real perf lever.
+TEST(MmqQ4kImmaTile, BenchSweep) {
+    struct Shape { int M, N, K; };
+    Shape shapes[] = {
+        {64,  256, 2048},
+        {128, 256, 2048},
+        {256, 256, 2048},
+        {512, 256, 2048},
+    };
+
+    std::fprintf(stderr,
+                 "\n[q4k-imma-tile Phase 2B.1 bench, single warp per CTA, 2-stage cp.async]\n");
+    std::fprintf(stderr, "  %4s %4s %5s  %10s  %10s\n", "M", "N", "K", "ms/rep", "TOPS");
+
+    for (auto sh : shapes) {
+        std::vector<int8_t> hW;
+        std::vector<__half> halpha, hbeta;
+        gen_random_w_sym_s8(hW, halpha, hbeta, sh.N, sh.K, 71);
+
+        std::vector<int8_t> hX;
+        std::vector<__half> hx_scale;
+        std::vector<float> hx_rowsum;
+        gen_random_x_s8(hX, hx_scale, hx_rowsum, sh.M, sh.K, 73);
+
+        int8_t *dX = nullptr, *dW = nullptr;
+        __half *dxscale = nullptr, *dalpha = nullptr, *dbeta = nullptr;
+        float* dxrowsum = nullptr;
+        __half* dout = nullptr;
+        cudaMalloc(&dX, hX.size());
+        cudaMalloc(&dW, hW.size());
+        cudaMalloc(&dxscale, hx_scale.size() * sizeof(__half));
+        cudaMalloc(&dxrowsum, hx_rowsum.size() * sizeof(float));
+        cudaMalloc(&dalpha, halpha.size() * sizeof(__half));
+        cudaMalloc(&dbeta, hbeta.size() * sizeof(__half));
+        cudaMalloc(&dout, static_cast<size_t>(sh.M) * sh.N * sizeof(__half));
+        cudaMemcpy(dX, hX.data(), hX.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(dW, hW.data(), hW.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(dxscale, hx_scale.data(), hx_scale.size() * sizeof(__half),
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(dxrowsum, hx_rowsum.data(), hx_rowsum.size() * sizeof(float),
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(dalpha, halpha.data(), halpha.size() * sizeof(__half), cudaMemcpyHostToDevice);
+        cudaMemcpy(dbeta, hbeta.data(), hbeta.size() * sizeof(__half), cudaMemcpyHostToDevice);
+
+        for (int w = 0; w < 3; ++w) {
+            mmq_q4k_imma_tile(dX, dxscale, dxrowsum, dW, dalpha, dbeta, dout, sh.M, sh.N, sh.K,
+                              nullptr);
+        }
+        cudaDeviceSynchronize();
+
+        cudaEvent_t start, stop;
+        cudaEventCreate(&start);
+        cudaEventCreate(&stop);
+
+        constexpr int kReps = 20;
+        float total_ms = 0.0f;
+        for (int r = 0; r < kReps; ++r) {
+            cudaEventRecord(start);
+            mmq_q4k_imma_tile(dX, dxscale, dxrowsum, dW, dalpha, dbeta, dout, sh.M, sh.N, sh.K,
+                              nullptr);
+            cudaEventRecord(stop);
+            cudaEventSynchronize(stop);
+            float ms = 0.0f;
+            cudaEventElapsedTime(&ms, start, stop);
+            total_ms += ms;
+        }
+        float ms_per_rep = total_ms / kReps;
+        double ops = 2.0 * sh.M * sh.N * sh.K;
+        double tops = ops / (ms_per_rep * 1e-3) / 1e12;
+        std::fprintf(stderr, "  %4d %4d %5d  %10.4f  %10.3f\n", sh.M, sh.N, sh.K, ms_per_rep, tops);
+
+        cudaEventDestroy(start);
+        cudaEventDestroy(stop);
+        cudaFree(dX);
+        cudaFree(dW);
+        cudaFree(dxscale);
+        cudaFree(dxrowsum);
+        cudaFree(dalpha);
+        cudaFree(dbeta);
+        cudaFree(dout);
+    }
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_mmq_q4k_imma_tile_bench.cu
+++ b/tests/test_mmq_q4k_imma_tile_bench.cu
@@ -1,0 +1,200 @@
+// Phase 2B correctness test for the INT8 IMMA tile kernel. Verifies that
+// `mmq_q4k_imma_tile(X_s8, x_scale, x_rowsum, W_s8, α, β, out)` reconstructs
+// the same FP32 result (modulo INT8 / FP16 quantisation noise) as a full
+// FP32 reference GEMM over the dequantised inputs.
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "bench/mmq_q4k_imma_tile_bench.h"
+
+namespace imp {
+namespace {
+
+constexpr int kSub = 32;
+
+// -------- Synthetic input generators --------
+
+void gen_random_w_sym_s8(std::vector<int8_t>& W, std::vector<__half>& alpha, std::vector<__half>& beta,
+                        int N, int K, unsigned seed) {
+    const int subs = K / kSub;
+    W.resize(static_cast<size_t>(N) * K);
+    alpha.resize(static_cast<size_t>(N) * subs);
+    beta.resize(static_cast<size_t>(N) * subs);
+    std::srand(seed);
+    for (int n = 0; n < N; ++n) {
+        for (int k = 0; k < K; ++k) {
+            int q = std::rand() % 16;       // ∈ [0, 15] unsigned nibble
+            W[static_cast<size_t>(n) * K + k] = static_cast<int8_t>(q - 8);  // symmetric
+        }
+        for (int s = 0; s < subs; ++s) {
+            float d_per_n = 0.005f + 0.002f * (std::rand() % 100);    // d ~ U[0.005, 0.205]
+            float dmin_per_n = 0.001f * (std::rand() % 100);
+            int sc = std::rand() % 64;
+            int m = std::rand() % 64;
+            float alpha_f = d_per_n * static_cast<float>(sc);
+            float beta_f = 8.0f * d_per_n * static_cast<float>(sc) -
+                           dmin_per_n * static_cast<float>(m);
+            alpha[static_cast<size_t>(n) * subs + s] = __float2half(alpha_f);
+            beta[static_cast<size_t>(n) * subs + s] = __float2half(beta_f);
+        }
+    }
+}
+
+void gen_random_x_s8(std::vector<int8_t>& X, std::vector<__half>& x_scale, std::vector<float>& x_rowsum,
+                    int M, int K, unsigned seed) {
+    const int subs = K / kSub;
+    X.resize(static_cast<size_t>(M) * K);
+    x_scale.resize(static_cast<size_t>(M) * subs);
+    x_rowsum.resize(static_cast<size_t>(M) * subs);
+    std::srand(seed);
+    for (int m = 0; m < M; ++m) {
+        for (int s = 0; s < subs; ++s) {
+            int row_sum = 0;
+            for (int k = 0; k < kSub; ++k) {
+                int q = (std::rand() % 255) - 127;  // ∈ [-127, 127]
+                X[static_cast<size_t>(m) * K + s * kSub + k] = static_cast<int8_t>(q);
+                row_sum += q;
+            }
+            float scale_f = 0.001f + 0.0005f * (std::rand() % 50);
+            x_scale[static_cast<size_t>(m) * subs + s] = __float2half(scale_f);
+            x_rowsum[static_cast<size_t>(m) * subs + s] = static_cast<float>(row_sum);
+        }
+    }
+}
+
+// CPU reference: out[m, n] = Σ_sub x_scale[m, sub] · (α[n, sub] · Σ X·W + β[n, sub] · Σ X)
+// Equivalent to the kernel's math, computed at FP32 precision.
+void cpu_reference(const std::vector<int8_t>& X, const std::vector<__half>& x_scale,
+                   const std::vector<float>& x_rowsum, const std::vector<int8_t>& W,
+                   const std::vector<__half>& alpha, const std::vector<__half>& beta,
+                   std::vector<float>& out, int M, int N, int K) {
+    const int subs = K / kSub;
+    out.assign(static_cast<size_t>(M) * N, 0.0f);
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            float acc = 0.0f;
+            for (int s = 0; s < subs; ++s) {
+                int32_t sumi = 0;
+                for (int k = 0; k < kSub; ++k) {
+                    sumi += static_cast<int32_t>(X[static_cast<size_t>(m) * K + s * kSub + k]) *
+                            static_cast<int32_t>(W[static_cast<size_t>(n) * K + s * kSub + k]);
+                }
+                float a = __half2float(alpha[static_cast<size_t>(n) * subs + s]);
+                float b = __half2float(beta[static_cast<size_t>(n) * subs + s]);
+                float xs = __half2float(x_scale[static_cast<size_t>(m) * subs + s]);
+                float xrs = x_rowsum[static_cast<size_t>(m) * subs + s];
+                acc += xs * (a * static_cast<float>(sumi) + b * xrs);
+            }
+            out[static_cast<size_t>(m) * N + n] = acc;
+        }
+    }
+}
+
+void run_correctness(int M, int N, int K, unsigned seed, float max_abs_tol, float max_rel_tol) {
+    SCOPED_TRACE(testing::Message() << "M=" << M << " N=" << N << " K=" << K << " seed=" << seed);
+    ASSERT_EQ(M % 16, 0);
+    ASSERT_EQ(N % 8, 0);
+    ASSERT_EQ(K % kSub, 0);
+
+    std::vector<int8_t> hW;
+    std::vector<__half> halpha, hbeta;
+    gen_random_w_sym_s8(hW, halpha, hbeta, N, K, seed);
+
+    std::vector<int8_t> hX;
+    std::vector<__half> hx_scale;
+    std::vector<float> hx_rowsum;
+    gen_random_x_s8(hX, hx_scale, hx_rowsum, M, K, seed + 1);
+
+    std::vector<float> ref;
+    cpu_reference(hX, hx_scale, hx_rowsum, hW, halpha, hbeta, ref, M, N, K);
+
+    int8_t *dX = nullptr, *dW = nullptr;
+    __half *dxscale = nullptr, *dalpha = nullptr, *dbeta = nullptr;
+    float* dxrowsum = nullptr;
+    __half* dout = nullptr;
+    const int subs = K / kSub;
+    cudaMalloc(&dX, hX.size());
+    cudaMalloc(&dW, hW.size());
+    cudaMalloc(&dxscale, hx_scale.size() * sizeof(__half));
+    cudaMalloc(&dxrowsum, hx_rowsum.size() * sizeof(float));
+    cudaMalloc(&dalpha, halpha.size() * sizeof(__half));
+    cudaMalloc(&dbeta, hbeta.size() * sizeof(__half));
+    cudaMalloc(&dout, static_cast<size_t>(M) * N * sizeof(__half));
+    cudaMemcpy(dX, hX.data(), hX.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dW, hW.data(), hW.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dxscale, hx_scale.data(), hx_scale.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dxrowsum, hx_rowsum.data(), hx_rowsum.size() * sizeof(float),
+               cudaMemcpyHostToDevice);
+    cudaMemcpy(dalpha, halpha.data(), halpha.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dbeta, hbeta.data(), hbeta.size() * sizeof(__half), cudaMemcpyHostToDevice);
+
+    mmq_q4k_imma_tile(dX, dxscale, dxrowsum, dW, dalpha, dbeta, dout, M, N, K, nullptr);
+    cudaDeviceSynchronize();
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    std::vector<__half> hout(static_cast<size_t>(M) * N);
+    cudaMemcpy(hout.data(), dout, hout.size() * sizeof(__half), cudaMemcpyDeviceToHost);
+
+    float max_abs = 0.0f, max_rel = 0.0f;
+    int worst_m = 0, worst_n = 0;
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            float got = __half2float(hout[static_cast<size_t>(m) * N + n]);
+            float want = ref[static_cast<size_t>(m) * N + n];
+            float ae = std::fabs(got - want);
+            if (ae > max_abs) {
+                max_abs = ae;
+                worst_m = m;
+                worst_n = n;
+            }
+            float re = std::fabs(want) > 1e-3f ? ae / std::fabs(want) : 0.0f;
+            max_rel = std::max(max_rel, re);
+        }
+    }
+    std::fprintf(stderr, "[q4k-imma-tile M=%d N=%d K=%d] max_abs=%.4f max_rel=%.4f at (%d,%d)\n", M, N, K,
+                 max_abs, max_rel, worst_m, worst_n);
+    EXPECT_LT(max_abs, max_abs_tol)
+        << "absolute error > tol at (" << worst_m << ", " << worst_n << ")";
+    EXPECT_LT(max_rel, max_rel_tol) << "relative error > tol";
+
+    cudaFree(dX);
+    cudaFree(dW);
+    cudaFree(dxscale);
+    cudaFree(dxrowsum);
+    cudaFree(dalpha);
+    cudaFree(dbeta);
+    cudaFree(dout);
+    (void)subs;
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessTiny) {
+    // M=16 N=8 K=32 → single tile, single sub-block. Smallest config.
+    run_correctness(/*M=*/16, /*N=*/8, /*K=*/32, /*seed=*/3, /*abs=*/2.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessMultiSub) {
+    // K=256 → 8 sub-blocks; tests the cross-sub-block accumulator.
+    run_correctness(/*M=*/16, /*N=*/8, /*K=*/256, /*seed=*/7, /*abs=*/8.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessMultiTile) {
+    // Multiple tiles per dim. Sweeps the grid-launch logic.
+    run_correctness(/*M=*/32, /*N=*/16, /*K=*/128, /*seed=*/13, /*abs=*/6.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessFFNLikeShape) {
+    // FFN-like dimensions: K = 512 (16 sub-blocks), M = 64, N = 32.
+    // Exercises the cross-sub-block float accumulator at scale.
+    run_correctness(/*M=*/64, /*N=*/32, /*K=*/512, /*seed=*/37, /*abs=*/40.0f, /*rel=*/0.02f);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## What

Expands the Phase 2B.2 multi-warp INT8 IMMA kernel to a larger output tile per CTA. Each warp now owns a 32×16 sub-tile (4 m16n8k32 fragments), iterated as a 2×2 grid of (wrm, wrn) MMAs per K-block. **16 MMAs per CTA per K-block, 4× Phase 2B.2's 4.**

## Why

Phase 2B.2 (PR #258) plateaued at ~19 TOPS due to limited MMAs-per-CTA. The CTA undersaturation analysis showed multi-warp alone insufficient; expanding output-per-CTA was the design memo's next step.

## How

| | Phase 2B.2 | Phase 2B.3 |
|---|---|---|
| BLOCK_M × BLOCK_N | 32 × 16 | **64 × 32** |
| Warps / CTA | 4 (2×2 spatial) | 4 (2×2 spatial) |
| MMAs per warp per K-block | 1 | **4** (WRM·WRN=2·2) |
| MMAs per CTA per K-block | 4 | **16** |
| SMEM per CTA | 3072 B | 6144 B |
| Load distribution | 64 A + 64 B (split) | All 128 do both (1 ca_16 + 1 ca_8 each) |

Same 2-stage cp.async pipeline carries over. Tests updated to BLOCK_M=64 N=32 multiples (the 32×16 sizes fall below the new divisibility guard).

## Tests

All 4 correctness tests PASS at FP16 ulp-floor accuracy:

| Test          | Shape           | max_abs |
|---            | ---             | ---:    |
| Tiny          | 64 × 32 × 32    | 0.37 |
| MultiSub      | 64 × 32 × 256   | 1.00 |
| MultiTile     | 128 × 64 × 128  | 0.96 |
| FFNLikeShape  | 128 × 64 × 512  | 1.70 |

Max rel_err ~0.05 % across all shapes — math identity holds.

## Bench

Production FFN-scale shapes (Qwen3-32B / Gemma-3-12B style), mean of 20 reps, K=2048:

| M    | N    | ms/rep | TOPS |
|---:  |---:  |   ---: | ---:|
| 512  | 512  | 0.058  | 18.7 |
| 1024 | 512  | 0.071  | 30.4 |
| 2048 | 512  | 0.139  | 31.0 |
| 4096 | 1024 | 0.438  | 39.3 |
| 2048 | 2048 | 0.421  | 40.8 |
| 4096 | 4096 | 1.715  | **40.1** |

Throughput **plateaus at ~40 TOPS** once CTA-count fills the 170 SMs. That's **2× Phase 2B.2's ~19 TOPS** and a meaningful step toward the cuBLAS FP16-TC ~244 TFLOPS competitive zone — but still only ~4 % of the 931 TOPS raw-MMA ceiling.

Note: at *small* shapes (M ≤ 512 N ≤ 256), Phase 2B.3 **regresses** vs 2B.2 because BLOCK_M=64 N=32 leaves SMs starved (<1 CTA per SM). Phase 2C dispatcher will need to pick 2B.2 vs 2B.3 by shape.

## What's left for Phase 2B.4

- **`ldmatrix.x4` / `x2`** (`.b16` mode) for SMEM→reg coalescing — closes the SMEM-bandwidth gap that's bottlenecking the cp.async-staged loop
- **3+ cp.async stages** for deeper latency hiding on long K
- Tile-autotuner picking 2B.2 vs 2B.3 based on M, N

## Risk

None. Standalone bench kernel, no production callers.

## Stacking note

This PR is intentionally stacked on \`topic/q4k-imma-phase2b2-multiwarp\` (PR #258). Both target \`main\` directly; merge order doesn't matter.