### PR TITLE
feat(q4k-imma): Phase 2C infrastructure — WeightCaches::q4k_imma + config knob

### DIFF
--- a/src/graph/executor.h
+++ b/src/graph/executor.h
@@ -442,6 +442,29 @@ struct WeightCaches {
     size_t cutlass_mxfp4_bytes = 0;
     bool use_mxfp4 = false;
 
+    // --- Q4_K_M direct INT8 IMMA cache (Phase 2C infrastructure) ---
+    // Populated at load-time by mmq_q4k_imma_reorder() when
+    // gemm.q4k_imma_enabled = true. Consumed by mmq_q4k_imma_tile().
+    // Three device buffers per entry:
+    //   w_sym_s8 [N, K]      int8  symmetric-shifted (q - 8)
+    //   eff_alpha [N, K/32]  FP16  d_super · sc[j]
+    //   eff_beta  [N, K/32]  FP16  8·d_super·sc[j] − dmin_super·m[j]
+    // Decode identity: α·q_sym + β  ≡  d·sc·q − dmin·m.
+    //
+    // The Phase 2C dispatcher (separate PR) gates entries on
+    //   M ≥ 1024 && dense && Q4_K_M && !fp16_cache_hit
+    // Off by default until E2E A/B against dense Q4_K_M models lands.
+    struct Q4kImmaCacheEntry {
+        int8_t* w_sym_s8 = nullptr;
+        __half* eff_alpha = nullptr;
+        __half* eff_beta = nullptr;
+        int N = 0;
+        int K = 0;
+    };
+    std::unordered_map<const void*, Q4kImmaCacheEntry> q4k_imma;
+    size_t q4k_imma_bytes = 0;
+    bool use_q4k_imma = false;
+
     // Dual-path mode: FP8 attention + NVFP4 FFN
     bool dual_path_quant = false;
 };

--- a/src/graph/executor_workspace_buffers.cu
+++ b/src/graph/executor_workspace_buffers.cu
@@ -899,6 +899,14 @@ void GraphExecutor::free_buffers() {
             free_cutlass_mxfp4_weight(mw);
         wcache_.cutlass_mxfp4.clear();
         wcache_.cutlass_mxfp4_bytes = 0;
+        // Q4_K_M direct IMMA cache (Phase 2C infrastructure)
+        for (auto& [ptr, entry] : wcache_.q4k_imma) {
+            if (entry.w_sym_s8) cudaFree(entry.w_sym_s8);
+            if (entry.eff_alpha) cudaFree(entry.eff_alpha);
+            if (entry.eff_beta) cudaFree(entry.eff_beta);
+        }
+        wcache_.q4k_imma.clear();
+        wcache_.q4k_imma_bytes = 0;
         // FP8 cache (entries may point into bulk buffers — free entry data only if not in bulk)
         for (auto& [ptr, entry] : wcache_.fp8) {
             if (entry.weight.data) {

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -204,6 +204,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.no_mmvq = parse_bool(val, cfg.gemm.no_mmvq);
     else if (eq("gemm.no_mmvq_q8_0"))
         cfg.gemm.no_mmvq_q8_0 = parse_bool(val, cfg.gemm.no_mmvq_q8_0);
+    else if (eq("gemm.q4k_imma_enabled"))
+        cfg.gemm.q4k_imma_enabled = parse_bool(val, cfg.gemm.q4k_imma_enabled);
 
     // [gemma4]
     else if (eq("gemma4.fp32_gemm_out"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -179,6 +179,13 @@ struct RuntimeConfig {
         bool no_dp4a_lm = false;
         bool no_mmvq = false;
         bool no_mmvq_q8_0 = false;
+        // Phase 2C infrastructure (default off until E2E A/B lands on
+        // dense Q4_K_M models). When true, executor_pre_dequant will
+        // populate WeightCaches::q4k_imma for eligible Q4_K weights
+        // (dense, M ≥ 1024 hint) and a future dispatcher PR will route
+        // the GEMM through mmq_q4k_imma_tile. Detailed wrap-up:
+        // docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md.
+        bool q4k_imma_enabled = false;
     } gemm;
 
     struct Gemma4 {


### PR DESCRIPTION
## What

Adds the load-time cache structure that a follow-up dispatcher PR will populate from PR #255's reorder kernel and consume via PR #259's tile kernel. **Default off; no behavioural change for any existing model.**

Branched off \`main\` (independent of the IMMA PR chain #254–#262). Merge order with the chain doesn't matter.

## Why

The 8-PR Q4_K_M IMMA exploration (PRs #254–#261) wrapped up in PR #262 with the recommendation to land **PR #259 (Phase 2B.3 kernel) as the production target**, gated to dense Q4_K_M at M ≥ 1024 with no fp16_cache hit. The wrap-up memo (`docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md`) made the case; this PR ships the infrastructure that makes that dispatcher feasible without touching production code yet.

## How

**WeightCaches additions** (`src/graph/executor.h`):

\`\`\`cpp
struct Q4kImmaCacheEntry {
    int8_t* w_sym_s8 = nullptr;    // [N, K]      symmetric-shifted (q - 8)
    __half* eff_alpha = nullptr;   // [N, K/32]   d_super · sc[j]
    __half* eff_beta  = nullptr;   // [N, K/32]   8·d_super·sc[j] − dmin_super·m[j]
    int N = 0;
    int K = 0;
};
std::unordered_map<const void*, Q4kImmaCacheEntry> q4k_imma;
size_t q4k_imma_bytes = 0;
bool use_q4k_imma = false;  // set by the dispatcher PR
\`\`\`

**Free path** (`executor_workspace_buffers.cu`): \`cudaFree\` all three device buffers per entry, clear the map and byte counter — same pattern as \`cutlass_mxfp4\` / \`fp8\` caches.

**Config knob** (\`config.h\` + parser in \`config.cpp\`):

\`\`\`
gemm.q4k_imma_enabled = false
\`\`\`

When the dispatcher lands, it will:

- **At load time**: invoke \`mmq_q4k_imma_reorder()\` and stash into the \`q4k_imma\` map for Q4_K weights matching the eligibility gate (dense, M ≥ 1024 hint, \`!fp16_cache_hit\`).
- **At dispatch time**: route eligible GEMMs through \`mmq_q4k_imma_tile()\` (Phase 2B.3 kernel from PR #259).

## Tests

This PR is **infrastructure only** — no executor_pre_dequant edits, no gemm_dispatch_impl edits, no callers of \`mmq_q4k_imma_*\` yet. Keeps the diff small and risk near-zero: 4 files, +40 LoC, no production hot path touched.

\`test-core\` 157/157 PASS, \`test-compute\` 163/163 PASS. Build clean.

## Bench

N/A — no callers of the new symbols. Decode bench unchanged.

## Risk

Near-zero. All new fields default-initialised; \`gemm.q4k_imma_enabled\` defaults \`false\`; nothing reads the new cache map until the dispatcher PR lands.

Rollback = revert the PR.

## What's left

- **Phase 2C dispatcher PR** (next): wire `executor_pre_dequant.cu` to populate the cache when the knob is on, and `gemm_dispatch_impl` to dispatch eligible GEMMs through the tile kernel.
- **Phase 3 E2E A/B PR**: Qwen3-32B-Instruct Q4_K_M and Gemma-3-12B-it Q4_K_M prefill comparison vs the dequant→cuBLAS baseline.