### PR TITLE
fix(api): imp_generate — reject empty token stream cleanly instead of aborting

### DIFF
--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -465,6 +465,20 @@ ImpError imp_generate(ImpContext ctx, const char* prompt, const ImpGenerateParam
 
         auto tokens = tokenize_prompt(ctx, prompt, params);
 
+        // Empty token stream would walk into executor_forward.cu:183's
+        // "n_tokens must be positive" guard and then trip a FATAL at
+        // tensor.cpp:91 via the slice() of an uninitialised logits tensor.
+        // Bail out cleanly here instead of crashing the engine.
+        if (tokens.empty()) {
+            IMP_LOG_WARN(
+                "imp_generate: prompt tokenised to 0 tokens (prompt='%.80s%s', "
+                "model may lack vocab coverage or chat-template guard rejected it)",
+                prompt, std::strlen(prompt) > 80 ? "…" : "");
+            if (output_len) *output_len = 0;
+            if (output_buf_size > 0) output_buf[0] = '\0';
+            return IMP_ERROR_INVALID_ARG;
+        }
+
         // Create request with all sampling params
         auto req = std::make_shared<imp::Request>();
         req->input_tokens = std::move(tokens);


### PR DESCRIPTION
## What

\`imp_generate(\"AB\", ...)\` on a stub model whose tokenizer can't cover the prompt would tokenize to 0 tokens, schedule a Request with \`n_tokens=0\`, and crash the engine via a FATAL chain:

\`\`\`
[ERROR] executor_forward.cu:183: n_tokens must be positive, got 0
[FATAL] tensor.cpp:91: Tensor::slice: ndim=0, expected > 0
Aborted (core dumped)
\`\`\`

This was killing \`make test-gpu\` halfway through \`StubModelTest.CreateContextAndInfer\` in \`test-e2e\`, even though that test's stated contract is *"may fail with tiny random weights; we just check no crash/abort"*.

## Why

\`forward_logits\` does check \`n <= 0\` and returns early — but it leaves the \`logits_out\` tensor uninitialized (\`ndim=0\`), and the caller then tries to \`slice()\` it, which trips the FATAL at \`tensor.cpp:91\`. Cleanest fix is to reject the empty-token request before it ever enters the engine.

## How

In \`imp_generate\`, after \`tokenize_prompt\`, return \`IMP_ERROR_INVALID_ARG\` when the resulting token stream is empty, with a one-line warn explaining why (model vocab coverage / chat-template guard). The engine never sees the n=0 request, so the FATAL chain doesn't fire.

\`\`\`cpp
if (tokens.empty()) {
    IMP_LOG_WARN("imp_generate: prompt tokenised to 0 tokens (...)");
    if (output_len) *output_len = 0;
    if (output_buf_size > 0) output_buf[0] = '\0';
    return IMP_ERROR_INVALID_ARG;
}
\`\`\`

## Tests

- \`test-e2e\`: was **aborting** at \`StubModelTest.CreateContextAndInfer\` (binary SIGABRT) → all 5 \`StubModelTest.*\` PASS, full suite runs **68/68 testable** cases (30 SKIPPED — model-dependent tests with no test model present).
- \`make test-gpu\` now completes the \`test-e2e\` module cleanly.

## Bench

N/A — defensive guard at the C-API boundary; never fires in normal production use.

## Risk

Near-zero. The new guard only fires when tokenization yields zero tokens, which is already a degenerate state that no real workload hits.

Branched off main, independent of any other in-flight PR.