### PR TITLE
perf(q4k-imma): Phase 2B production tile kernel (collapsed 6-PR stack → single PR)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ if(IMP_USE_CUTLASS)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/tma_block_scale_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/fmha_v_load_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/mmq_q4k_imma_bench.cu)
+        list(APPEND IMP_COMPUTE_SOURCES tests/bench/mmq_q4k_imma_tile_bench.cu)
     endif()
     if(IMP_BUILD_TESTS)
         set_source_files_properties(src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -481,6 +482,7 @@ if(IMP_BUILD_TESTS)
         tests/test_tma_block_scale_bench.cu
         tests/test_fmha_v_load_bench.cu
         tests/test_mmq_q4k_imma_bench.cu
+        tests/test_mmq_q4k_imma_tile_bench.cu
         tests/test_weight_dispatch.cu
     )
 

--- a/tests/bench/mmq_q4k_imma_tile_bench.cu
+++ b/tests/bench/mmq_q4k_imma_tile_bench.cu
@@ -1,0 +1,250 @@
+// =============================================================================
+// mmq_q4k_imma_tile_bench.cu — Phase 2B INT8 IMMA tile kernel (minimum viable)
+// =============================================================================
+//
+// One warp per CTA, BLOCK_M=16, BLOCK_N=8, BLOCK_K=32 (one m16n8k32 MMA tile).
+// Synchronous SMEM staging. Phase 2B.1 will add cp.async + ldmatrix.x4 for
+// real perf. This version is for correctness verification only.
+//
+// Math identity (per design memo §3.2):
+//   out_ref[m, n] = Σ_k x_fp16[m, k] · w_fp16[n, k]
+//
+//   x_fp16[m, k] = x_scale[m, sub_k] · X_s8[m, k]
+//   w_fp16[n, k] = d_n · sc[n, sub_k] · q_w[n, k] − dmin_n · m[n, sub_k]
+//                = α[n, sub_k] · q_w[n, k] − dmin_n · m[n, sub_k]
+//                = α[n, sub_k] · (W_s8[n, k] + 8) − dmin_n · m[n, sub_k]
+//
+//   Substituting and grouping by sub-block:
+//     out[m, n] = Σ_sub x_scale[m, sub] · {
+//                     α[n, sub] · Σ_{k in sub} X_s8[m, k] · W_s8[n, k]
+//                   + β[n, sub] · Σ_{k in sub} X_s8[m, k]                }
+//
+//   where β[n, sub] = 8·α[n, sub] − dmin_n · m[n, sub].
+//
+// The IMMA's role is computing Σ_{k in sub} X_s8 · W_s8 (the s32 accumulator
+// over a 32-wide K slab). Each sub-block is exactly one MMA's worth of K.
+
+#include "bench/mmq_q4k_imma_tile_bench.h"
+
+#include <cstdint>
+#include <cuda_fp16.h>
+
+namespace imp {
+
+namespace {
+
+// Phase 2B.3 large-tile layout:
+//   BLOCK_M = 64, BLOCK_N = 32, BLOCK_K = 32. 4 warps per CTA in 2×2 spatial
+//   arrangement, each warp doing WRM·WRN = 2·2 = 4 MMAs per K-block.
+//   Each warp owns a 32×16 output sub-tile (= 4 × m16n8 fragments).
+//   Total: 16 MMAs per CTA per K-block (4× Phase 2B.2).
+constexpr int kBlockM = 64;
+constexpr int kBlockN = 32;
+constexpr int kBlockK = 32;
+constexpr int kNumStages = 2;
+constexpr int kNumWarps = 4;
+constexpr int kThreadsPerCTA = kNumWarps * 32;  // 128
+constexpr int kWRM = 2;  // M-tiles per warp
+constexpr int kWRN = 2;  // N-tiles per warp
+
+// cp.async helpers (mirror src/compute/attention_paged_common.cuh, kept local
+// here so the bench TU stays self-contained).
+__device__ __forceinline__ void cp_async_ca_8(void* smem, const void* glob) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 8;\n" ::"r"(s), "l"(glob));
+}
+__device__ __forceinline__ void cp_async_ca_16(void* smem, const void* glob) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 16;\n" ::"r"(s), "l"(glob));
+}
+__device__ __forceinline__ void cp_async_commit() {
+    asm volatile("cp.async.commit_group;\n");
+}
+template <int N>
+__device__ __forceinline__ void cp_async_wait_group() {
+    asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
+}
+
+// Per-CTA async load of one K-block. All 128 threads cooperate:
+//   each thread issues one A-load (16 bytes) and one B-load (8 bytes).
+//   A: 64×32 = 2048 bytes = 128 × 16  via ca_16
+//   B: 32×32 = 1024 bytes = 128 × 8   via ca_8
+__device__ __forceinline__ void async_load_tile_mw(int tid, const int8_t* X_s8,
+                                                   const int8_t* W_s8, int8_t (*sA)[kBlockK],
+                                                   int8_t (*sB)[kBlockK], int base_m, int base_n,
+                                                   int k_base, int K) {
+    // A load: 128 lanes, lane → row (lane/2), col_off ((lane&1)*16).
+    {
+        const int row_in_tile = tid >> 1;      // 0..63
+        const int col_off = (tid & 1) * 16;    // 0 or 16
+        const int8_t* src = X_s8 + (base_m + row_in_tile) * K + k_base + col_off;
+        int8_t* dst = &sA[row_in_tile][col_off];
+        cp_async_ca_16(dst, src);
+    }
+    // B load: 128 lanes, lane → row (lane/4), col_off ((lane&3)*8).
+    {
+        const int row_in_tile = tid >> 2;      // 0..31
+        const int col_off = (tid & 3) * 8;     // 0, 8, 16, 24
+        const int8_t* src = W_s8 + (base_n + row_in_tile) * K + k_base + col_off;
+        int8_t* dst = &sB[row_in_tile][col_off];
+        cp_async_ca_8(dst, src);
+    }
+}
+
+// 4 warps per CTA, each warp doing WRM·WRN = 2·2 = 4 MMAs per K-block.
+__global__ void mmq_q4k_imma_tile_kernel(const int8_t* __restrict__ X_s8,
+                                         const __half* __restrict__ x_scale,
+                                         const float* __restrict__ x_rowsum,
+                                         const int8_t* __restrict__ W_s8,
+                                         const __half* __restrict__ eff_alpha,
+                                         const __half* __restrict__ eff_beta,
+                                         __half* __restrict__ out, int M, int N, int K) {
+    const int n_block = blockIdx.x;
+    const int m_block = blockIdx.y;
+    if (m_block * kBlockM >= M || n_block * kBlockN >= N) return;
+
+    const int tid = threadIdx.x;       // 0..127
+    const int warp_id = tid >> 5;       // 0..3
+    const int lane = tid & 31;          // 0..31
+    const int warp_m = warp_id >> 1;    // 0..1
+    const int warp_n = warp_id & 1;     // 0..1
+
+    // SMEM: sA[2][64][32] + sB[2][32][32] = 4096 + 2048 = 6144 bytes per CTA.
+    __shared__ int8_t sA[kNumStages][kBlockM][kBlockK];
+    __shared__ int8_t sB[kNumStages][kBlockN][kBlockK];
+
+    // FP32 accumulator per (wrm, wrn) MMA × 4 outputs per lane.
+    float c_f32[kWRM][kWRN][4] = {{{0.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.0f}},
+                                  {{0.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.0f}}};
+
+    const int subs_per_K = K / kBlockK;
+    const int subs_per_row = subs_per_K;
+
+    const int base_m = m_block * kBlockM;
+    const int base_n = n_block * kBlockN;
+    // Each warp owns a 32 × 16 region of output:
+    //   M rows: [warp_m * 32, warp_m * 32 + 32)
+    //   N cols: [warp_n * 16, warp_n * 16 + 16)
+    // Internally divided into 2 × 2 m16n8 sub-tiles (wrm, wrn).
+    const int warp_origin_m = warp_m * 32;
+    const int warp_origin_n = warp_n * 16;
+
+    // -------- Prologue --------
+    if (subs_per_K > 0) {
+        async_load_tile_mw(tid, X_s8, W_s8, sA[0], sB[0], base_m, base_n, 0, K);
+        cp_async_commit();
+    }
+
+    for (int kb = 0; kb < subs_per_K; ++kb) {
+        const int stage = kb & 1;
+        const int next_kb = kb + 1;
+        if (next_kb < subs_per_K) {
+            const int next_stage = next_kb & 1;
+            async_load_tile_mw(tid, X_s8, W_s8, sA[next_stage], sB[next_stage], base_m, base_n,
+                               next_kb * kBlockK, K);
+            cp_async_commit();
+            cp_async_wait_group<1>();
+        } else {
+            cp_async_wait_group<0>();
+        }
+        __syncthreads();
+
+        // -------- 4 MMAs per warp per K-block: wrm × wrn = 2 × 2 --------
+#pragma unroll
+        for (int wrm = 0; wrm < kWRM; ++wrm) {
+            const int sub_origin_m = warp_origin_m + wrm * 16;
+            const int a_row_lo = sub_origin_m + (lane >> 2);
+            const int a_row_hi = a_row_lo + 8;
+            const int a_col_base = (lane & 3) * 4;
+            uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base]);
+            uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base]);
+            uint32_t a2 =
+                *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_lo][a_col_base + 16]);
+            uint32_t a3 =
+                *reinterpret_cast<const uint32_t*>(&sA[stage][a_row_hi][a_col_base + 16]);
+
+#pragma unroll
+            for (int wrn = 0; wrn < kWRN; ++wrn) {
+                const int sub_origin_n = warp_origin_n + wrn * 8;
+                const int b_col = sub_origin_n + (lane >> 2);
+                const int b_k_base = (lane & 3) * 4;
+                uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base]);
+                uint32_t b1 =
+                    *reinterpret_cast<const uint32_t*>(&sB[stage][b_col][b_k_base + 16]);
+
+                int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+#if __CUDA_ARCH__ >= 750
+                asm volatile(
+                    "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+                    : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+                      "r"(0), "r"(0), "r"(0), "r"(0));
+#endif
+
+                // -------- Per-sub-block scale apply for this (wrm, wrn) MMA --------
+                const int row_lo = sub_origin_m + ((lane >> 2) & 7);
+                const int row_hi = row_lo + 8;
+                const int col_lo = sub_origin_n + (lane & 3) * 2;
+                const int col_hi = col_lo + 1;
+
+                const int m_lo = base_m + row_lo;
+                const int m_hi = base_m + row_hi;
+                const int n_lo = base_n + col_lo;
+                const int n_hi = base_n + col_hi;
+
+                const float xs_lo = __half2float(x_scale[m_lo * subs_per_row + kb]);
+                const float xs_hi = __half2float(x_scale[m_hi * subs_per_row + kb]);
+                const float xrs_lo = x_rowsum[m_lo * subs_per_row + kb];
+                const float xrs_hi = x_rowsum[m_hi * subs_per_row + kb];
+
+                const float a_lo = __half2float(eff_alpha[n_lo * subs_per_row + kb]);
+                const float a_hi = __half2float(eff_alpha[n_hi * subs_per_row + kb]);
+                const float b_lo = __half2float(eff_beta[n_lo * subs_per_row + kb]);
+                const float b_hi = __half2float(eff_beta[n_hi * subs_per_row + kb]);
+
+                c_f32[wrm][wrn][0] += xs_lo * (a_lo * static_cast<float>(c0) + b_lo * xrs_lo);
+                c_f32[wrm][wrn][1] += xs_lo * (a_hi * static_cast<float>(c1) + b_hi * xrs_lo);
+                c_f32[wrm][wrn][2] += xs_hi * (a_lo * static_cast<float>(c2) + b_lo * xrs_hi);
+                c_f32[wrm][wrn][3] += xs_hi * (a_hi * static_cast<float>(c3) + b_hi * xrs_hi);
+            }
+        }
+        __syncthreads();
+    }
+
+    // -------- Epilogue: FP16 write for all 4 (wrm, wrn) tiles --------
+#pragma unroll
+    for (int wrm = 0; wrm < kWRM; ++wrm) {
+        const int sub_origin_m = warp_origin_m + wrm * 16;
+#pragma unroll
+        for (int wrn = 0; wrn < kWRN; ++wrn) {
+            const int sub_origin_n = warp_origin_n + wrn * 8;
+            const int row_lo = sub_origin_m + ((lane >> 2) & 7);
+            const int row_hi = row_lo + 8;
+            const int col_lo = sub_origin_n + (lane & 3) * 2;
+            const int col_hi = col_lo + 1;
+            const int m_lo = base_m + row_lo;
+            const int m_hi = base_m + row_hi;
+            const int n_lo = base_n + col_lo;
+            const int n_hi = base_n + col_hi;
+            if (m_lo < M && n_lo < N) out[m_lo * N + n_lo] = __float2half(c_f32[wrm][wrn][0]);
+            if (m_lo < M && n_hi < N) out[m_lo * N + n_hi] = __float2half(c_f32[wrm][wrn][1]);
+            if (m_hi < M && n_lo < N) out[m_hi * N + n_lo] = __float2half(c_f32[wrm][wrn][2]);
+            if (m_hi < M && n_hi < N) out[m_hi * N + n_hi] = __float2half(c_f32[wrm][wrn][3]);
+        }
+    }
+}
+
+}  // namespace
+
+void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x_rowsum,
+                       const int8_t* W_s8, const __half* eff_alpha, const __half* eff_beta,
+                       __half* out, int M, int N, int K, cudaStream_t stream) {
+    if (M % kBlockM != 0 || N % kBlockN != 0 || K % kBlockK != 0) return;
+    dim3 grid(N / kBlockN, M / kBlockM, 1);
+    dim3 block(kThreadsPerCTA, 1, 1);
+    mmq_q4k_imma_tile_kernel<<<grid, block, 0, stream>>>(
+        X_s8, x_scale, x_rowsum, W_s8, eff_alpha, eff_beta, out, M, N, K);
+}
+
+}  // namespace imp

--- a/tests/bench/mmq_q4k_imma_tile_bench.h
+++ b/tests/bench/mmq_q4k_imma_tile_bench.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// Phase 2B INT8 IMMA tile-GEMM kernel for the Q4_K_M direct-GEMM project.
+// Companion to design memo `docs/plans/q4k_imma_design_2026_05_17.md` §4.
+//
+// Inputs (already in INT8 / FP16 form — Phase 2A's reorder produces W_s8 / α / β):
+//   X_s8       [M, K]     int8  activation (row-major, per-row-per-sub-block s8 quant)
+//   x_scale    [M, K/32]  FP16  activation per-sub-block scale (so x_fp16 = x_scale·X_s8)
+//   x_rowsum   [M, K/32]  float Σ_{k in sub} X_s8[m, k]
+//   W_s8       [N, K]     int8  weight, symmetric (q_sym = q - 8 ∈ [-8, 7])
+//   eff_alpha  [N, K/32]  FP16  α[n, sub] = d_super · sc[n, sub]
+//   eff_beta   [N, K/32]  FP16  β[n, sub] = 8·d_super·sc[n, sub] − dmin_super·m[n, sub]
+//
+// Output (FP16, row-major):
+//   out        [M, N]
+//
+// Per-(m, n) the kernel computes:
+//   out[m, n] = Σ_sub x_scale[m, sub] · ( α[n, sub] · Σ_{k in sub} X_s8·W_s8
+//                                       + β[n, sub] · x_rowsum[m, sub] )
+//
+// Algebraically equivalent (proof in mmq_q4k_imma_tile_bench.cu header) to the
+// full Q4_K dequant + FP16 GEMM:
+//   out_ref[m, n] = Σ_k x_fp16[m, k] · w_fp16[n, k]
+// modulo INT8 / FP16 quantisation noise.
+//
+// Phase 2B-minimum (this version):
+//   - One warp per CTA. BLOCK_M = 16, BLOCK_N = 8, BLOCK_K = 32 = one MMA tile.
+//   - Synchronous SMEM staging: load A (16×32), B (8×32), MMA, accumulate.
+//   - Grid: (N / BLOCK_N, M / BLOCK_M, 1). M and N must be multiples of
+//     BLOCK_M / BLOCK_N. K must be a multiple of 32.
+//   - No cp.async pipelining, no ldmatrix.x4 (manual SMEM loads). Phase 2B.1
+//     will add those for performance.
+//
+// Phase 2A's reorder is the canonical W producer. Phase 2C will be the
+// production dispatch wiring.
+
+void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x_rowsum,
+                       const int8_t* W_s8, const __half* eff_alpha, const __half* eff_beta,
+                       __half* out, int M, int N, int K, cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_mmq_q4k_imma_tile_bench.cu
+++ b/tests/test_mmq_q4k_imma_tile_bench.cu
@@ -1,0 +1,294 @@
+// Phase 2B correctness test for the INT8 IMMA tile kernel. Verifies that
+// `mmq_q4k_imma_tile(X_s8, x_scale, x_rowsum, W_s8, α, β, out)` reconstructs
+// the same FP32 result (modulo INT8 / FP16 quantisation noise) as a full
+// FP32 reference GEMM over the dequantised inputs.
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "bench/mmq_q4k_imma_tile_bench.h"
+
+namespace imp {
+namespace {
+
+constexpr int kSub = 32;
+
+// -------- Synthetic input generators --------
+
+void gen_random_w_sym_s8(std::vector<int8_t>& W, std::vector<__half>& alpha, std::vector<__half>& beta,
+                        int N, int K, unsigned seed) {
+    const int subs = K / kSub;
+    W.resize(static_cast<size_t>(N) * K);
+    alpha.resize(static_cast<size_t>(N) * subs);
+    beta.resize(static_cast<size_t>(N) * subs);
+    std::srand(seed);
+    for (int n = 0; n < N; ++n) {
+        for (int k = 0; k < K; ++k) {
+            int q = std::rand() % 16;       // ∈ [0, 15] unsigned nibble
+            W[static_cast<size_t>(n) * K + k] = static_cast<int8_t>(q - 8);  // symmetric
+        }
+        for (int s = 0; s < subs; ++s) {
+            float d_per_n = 0.005f + 0.002f * (std::rand() % 100);    // d ~ U[0.005, 0.205]
+            float dmin_per_n = 0.001f * (std::rand() % 100);
+            int sc = std::rand() % 64;
+            int m = std::rand() % 64;
+            float alpha_f = d_per_n * static_cast<float>(sc);
+            float beta_f = 8.0f * d_per_n * static_cast<float>(sc) -
+                           dmin_per_n * static_cast<float>(m);
+            alpha[static_cast<size_t>(n) * subs + s] = __float2half(alpha_f);
+            beta[static_cast<size_t>(n) * subs + s] = __float2half(beta_f);
+        }
+    }
+}
+
+void gen_random_x_s8(std::vector<int8_t>& X, std::vector<__half>& x_scale, std::vector<float>& x_rowsum,
+                    int M, int K, unsigned seed) {
+    const int subs = K / kSub;
+    X.resize(static_cast<size_t>(M) * K);
+    x_scale.resize(static_cast<size_t>(M) * subs);
+    x_rowsum.resize(static_cast<size_t>(M) * subs);
+    std::srand(seed);
+    for (int m = 0; m < M; ++m) {
+        for (int s = 0; s < subs; ++s) {
+            int row_sum = 0;
+            for (int k = 0; k < kSub; ++k) {
+                int q = (std::rand() % 255) - 127;  // ∈ [-127, 127]
+                X[static_cast<size_t>(m) * K + s * kSub + k] = static_cast<int8_t>(q);
+                row_sum += q;
+            }
+            float scale_f = 0.001f + 0.0005f * (std::rand() % 50);
+            x_scale[static_cast<size_t>(m) * subs + s] = __float2half(scale_f);
+            x_rowsum[static_cast<size_t>(m) * subs + s] = static_cast<float>(row_sum);
+        }
+    }
+}
+
+// CPU reference: out[m, n] = Σ_sub x_scale[m, sub] · (α[n, sub] · Σ X·W + β[n, sub] · Σ X)
+// Equivalent to the kernel's math, computed at FP32 precision.
+void cpu_reference(const std::vector<int8_t>& X, const std::vector<__half>& x_scale,
+                   const std::vector<float>& x_rowsum, const std::vector<int8_t>& W,
+                   const std::vector<__half>& alpha, const std::vector<__half>& beta,
+                   std::vector<float>& out, int M, int N, int K) {
+    const int subs = K / kSub;
+    out.assign(static_cast<size_t>(M) * N, 0.0f);
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            float acc = 0.0f;
+            for (int s = 0; s < subs; ++s) {
+                int32_t sumi = 0;
+                for (int k = 0; k < kSub; ++k) {
+                    sumi += static_cast<int32_t>(X[static_cast<size_t>(m) * K + s * kSub + k]) *
+                            static_cast<int32_t>(W[static_cast<size_t>(n) * K + s * kSub + k]);
+                }
+                float a = __half2float(alpha[static_cast<size_t>(n) * subs + s]);
+                float b = __half2float(beta[static_cast<size_t>(n) * subs + s]);
+                float xs = __half2float(x_scale[static_cast<size_t>(m) * subs + s]);
+                float xrs = x_rowsum[static_cast<size_t>(m) * subs + s];
+                acc += xs * (a * static_cast<float>(sumi) + b * xrs);
+            }
+            out[static_cast<size_t>(m) * N + n] = acc;
+        }
+    }
+}
+
+void run_correctness(int M, int N, int K, unsigned seed, float max_abs_tol, float max_rel_tol) {
+    SCOPED_TRACE(testing::Message() << "M=" << M << " N=" << N << " K=" << K << " seed=" << seed);
+    ASSERT_EQ(M % 16, 0);
+    ASSERT_EQ(N % 8, 0);
+    ASSERT_EQ(K % kSub, 0);
+
+    std::vector<int8_t> hW;
+    std::vector<__half> halpha, hbeta;
+    gen_random_w_sym_s8(hW, halpha, hbeta, N, K, seed);
+
+    std::vector<int8_t> hX;
+    std::vector<__half> hx_scale;
+    std::vector<float> hx_rowsum;
+    gen_random_x_s8(hX, hx_scale, hx_rowsum, M, K, seed + 1);
+
+    std::vector<float> ref;
+    cpu_reference(hX, hx_scale, hx_rowsum, hW, halpha, hbeta, ref, M, N, K);
+
+    int8_t *dX = nullptr, *dW = nullptr;
+    __half *dxscale = nullptr, *dalpha = nullptr, *dbeta = nullptr;
+    float* dxrowsum = nullptr;
+    __half* dout = nullptr;
+    const int subs = K / kSub;
+    cudaMalloc(&dX, hX.size());
+    cudaMalloc(&dW, hW.size());
+    cudaMalloc(&dxscale, hx_scale.size() * sizeof(__half));
+    cudaMalloc(&dxrowsum, hx_rowsum.size() * sizeof(float));
+    cudaMalloc(&dalpha, halpha.size() * sizeof(__half));
+    cudaMalloc(&dbeta, hbeta.size() * sizeof(__half));
+    cudaMalloc(&dout, static_cast<size_t>(M) * N * sizeof(__half));
+    cudaMemcpy(dX, hX.data(), hX.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dW, hW.data(), hW.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dxscale, hx_scale.data(), hx_scale.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dxrowsum, hx_rowsum.data(), hx_rowsum.size() * sizeof(float),
+               cudaMemcpyHostToDevice);
+    cudaMemcpy(dalpha, halpha.data(), halpha.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dbeta, hbeta.data(), hbeta.size() * sizeof(__half), cudaMemcpyHostToDevice);
+
+    mmq_q4k_imma_tile(dX, dxscale, dxrowsum, dW, dalpha, dbeta, dout, M, N, K, nullptr);
+    cudaDeviceSynchronize();
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    std::vector<__half> hout(static_cast<size_t>(M) * N);
+    cudaMemcpy(hout.data(), dout, hout.size() * sizeof(__half), cudaMemcpyDeviceToHost);
+
+    float max_abs = 0.0f, max_rel = 0.0f;
+    int worst_m = 0, worst_n = 0;
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            float got = __half2float(hout[static_cast<size_t>(m) * N + n]);
+            float want = ref[static_cast<size_t>(m) * N + n];
+            float ae = std::fabs(got - want);
+            if (ae > max_abs) {
+                max_abs = ae;
+                worst_m = m;
+                worst_n = n;
+            }
+            float re = std::fabs(want) > 1e-3f ? ae / std::fabs(want) : 0.0f;
+            max_rel = std::max(max_rel, re);
+        }
+    }
+    std::fprintf(stderr, "[q4k-imma-tile M=%d N=%d K=%d] max_abs=%.4f max_rel=%.4f at (%d,%d)\n", M, N, K,
+                 max_abs, max_rel, worst_m, worst_n);
+    EXPECT_LT(max_abs, max_abs_tol)
+        << "absolute error > tol at (" << worst_m << ", " << worst_n << ")";
+    EXPECT_LT(max_rel, max_rel_tol) << "relative error > tol";
+
+    cudaFree(dX);
+    cudaFree(dW);
+    cudaFree(dxscale);
+    cudaFree(dxrowsum);
+    cudaFree(dalpha);
+    cudaFree(dbeta);
+    cudaFree(dout);
+    (void)subs;
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessTiny) {
+    // Smallest config that fills one CTA (BLOCK_M=64, BLOCK_N=32):
+    // one block, one sub-block of K.
+    run_correctness(/*M=*/64, /*N=*/32, /*K=*/32, /*seed=*/3, /*abs=*/2.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessMultiSub) {
+    // K=256 → 8 sub-blocks; tests the cross-sub-block accumulator.
+    run_correctness(/*M=*/64, /*N=*/32, /*K=*/256, /*seed=*/7, /*abs=*/8.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessMultiTile) {
+    // Multiple CTAs per dim. Sweeps the grid-launch logic.
+    run_correctness(/*M=*/128, /*N=*/64, /*K=*/128, /*seed=*/13, /*abs=*/6.0f, /*rel=*/0.02f);
+}
+
+TEST(MmqQ4kImmaTile, CorrectnessFFNLikeShape) {
+    // FFN-like dimensions: K = 512 (16 sub-blocks), M = 128, N = 64.
+    // Exercises the cross-sub-block float accumulator at scale.
+    run_correctness(/*M=*/128, /*N=*/64, /*K=*/512, /*seed=*/37, /*abs=*/40.0f, /*rel=*/0.02f);
+}
+
+// Bench-only — prints kernel-time and effective TOPS at production-realistic
+// shapes. No perf assertion: this is Phase 2B.1 informational baseline. The
+// 1-warp-per-CTA tile (BLOCK_M=16, BLOCK_N=8) substantially under-utilises
+// each SM; Phase 2B.2 (multi-warp expansion) is the next real perf lever.
+TEST(MmqQ4kImmaTile, BenchSweep) {
+    struct Shape { int M, N, K; };
+    // Cover production FFN shapes (Qwen3-32B FFN ~5120, Gemma-3-12B ~3072).
+    // Larger M/N is mandatory for Phase 2B.3's BLOCK_M=64 BLOCK_N=32 tile —
+    // small shapes leave 170 SMs starved (verified empirically: M=512 N=256 →
+    // 64 CTAs ≈ 0.4 CTAs/SM and the kernel regresses vs Phase 2B.2).
+    Shape shapes[] = {
+        {512,  512,  2048},
+        {1024, 512,  2048},
+        {2048, 512,  2048},
+        {4096, 1024, 2048},
+        {2048, 2048, 2048},
+        {4096, 4096, 2048},
+    };
+
+    std::fprintf(stderr,
+                 "\n[q4k-imma-tile Phase 2B.3 bench, 4 warps/CTA × WRM·WRN=2·2 "
+                 "(64×32 output), 2-stage cp.async]\n");
+    std::fprintf(stderr, "  %4s %4s %5s  %10s  %10s\n", "M", "N", "K", "ms/rep", "TOPS");
+
+    for (auto sh : shapes) {
+        std::vector<int8_t> hW;
+        std::vector<__half> halpha, hbeta;
+        gen_random_w_sym_s8(hW, halpha, hbeta, sh.N, sh.K, 71);
+
+        std::vector<int8_t> hX;
+        std::vector<__half> hx_scale;
+        std::vector<float> hx_rowsum;
+        gen_random_x_s8(hX, hx_scale, hx_rowsum, sh.M, sh.K, 73);
+
+        int8_t *dX = nullptr, *dW = nullptr;
+        __half *dxscale = nullptr, *dalpha = nullptr, *dbeta = nullptr;
+        float* dxrowsum = nullptr;
+        __half* dout = nullptr;
+        cudaMalloc(&dX, hX.size());
+        cudaMalloc(&dW, hW.size());
+        cudaMalloc(&dxscale, hx_scale.size() * sizeof(__half));
+        cudaMalloc(&dxrowsum, hx_rowsum.size() * sizeof(float));
+        cudaMalloc(&dalpha, halpha.size() * sizeof(__half));
+        cudaMalloc(&dbeta, hbeta.size() * sizeof(__half));
+        cudaMalloc(&dout, static_cast<size_t>(sh.M) * sh.N * sizeof(__half));
+        cudaMemcpy(dX, hX.data(), hX.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(dW, hW.data(), hW.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(dxscale, hx_scale.data(), hx_scale.size() * sizeof(__half),
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(dxrowsum, hx_rowsum.data(), hx_rowsum.size() * sizeof(float),
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(dalpha, halpha.data(), halpha.size() * sizeof(__half), cudaMemcpyHostToDevice);
+        cudaMemcpy(dbeta, hbeta.data(), hbeta.size() * sizeof(__half), cudaMemcpyHostToDevice);
+
+        for (int w = 0; w < 3; ++w) {
+            mmq_q4k_imma_tile(dX, dxscale, dxrowsum, dW, dalpha, dbeta, dout, sh.M, sh.N, sh.K,
+                              nullptr);
+        }
+        cudaDeviceSynchronize();
+
+        cudaEvent_t start, stop;
+        cudaEventCreate(&start);
+        cudaEventCreate(&stop);
+
+        constexpr int kReps = 20;
+        float total_ms = 0.0f;
+        for (int r = 0; r < kReps; ++r) {
+            cudaEventRecord(start);
+            mmq_q4k_imma_tile(dX, dxscale, dxrowsum, dW, dalpha, dbeta, dout, sh.M, sh.N, sh.K,
+                              nullptr);
+            cudaEventRecord(stop);
+            cudaEventSynchronize(stop);
+            float ms = 0.0f;
+            cudaEventElapsedTime(&ms, start, stop);
+            total_ms += ms;
+        }
+        float ms_per_rep = total_ms / kReps;
+        double ops = 2.0 * sh.M * sh.N * sh.K;
+        double tops = ops / (ms_per_rep * 1e-3) / 1e12;
+        std::fprintf(stderr, "  %4d %4d %5d  %10.4f  %10.3f\n", sh.M, sh.N, sh.K, ms_per_rep, tops);
+
+        cudaEventDestroy(start);
+        cudaEventDestroy(stop);
+        cudaFree(dX);
+        cudaFree(dW);
+        cudaFree(dxscale);
+        cudaFree(dxrowsum);
+        cudaFree(dalpha);
+        cudaFree(dbeta);
+        cudaFree(dout);
+    }
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## What

Production-target INT8 IMMA tile-GEMM kernel for Q4_K_M direct-GEMM. **Consolidates the 6-PR exploration stack #256→#257→#258→#259→#260→#261 into one bisectable PR** with the architecture-ceiling configuration. The intermediate steps in the stack are superseded by this PR; their findings are preserved in the commit message and in \`docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md\` (PR #262 — still open).

## Final kernel configuration

- \`BLOCK_M = 64, BLOCK_N = 32, BLOCK_K = 32\` (one m16n8k32 MMA per sub-block)
- **4 warps per CTA** in 2×2 spatial arrangement
- Each warp owns **32×16 of output** via WRM·WRN=2·2 → 4 MMAs per warp per K-block → 16 MMAs per CTA per K-block
- **2-stage cp.async pipeline** (3-stage refuted at saturation, was PR #260)
- **Manual 4×uint32 / 2×uint32 SMEM loads** (\`ldmatrix\` refuted, was PR #261)
- PTX: \`mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32\`

Math identity (per design memo §3.2):

\`\`\`
out[m, n] = Σ_sub x_scale[m, sub] · (α[n, sub] · Σ X_s8·W_s8 + β[n, sub] · x_rowsum[m, sub])
          ≡ Σ_k x_fp16[m, k] · w_fp16[n, k]
\`\`\`

## Stack exploration consolidated here

| Phase | Kernel change | TOPS @ M=N=4096 | Verdict |
|---|---|---:|---|
| 2B   | baseline: 1 warp/CTA, sync loads | n/a (correctness) | baseline (was #256) |
| 2B.1 | + 2-stage cp.async | 15.9 (small M) | shipped (was #257) |
| 2B.2 | + 4 warps/CTA, BLOCK_M=32 N=16  | 19.3 | shipped (was #258) |
| **2B.3** | **+ WRM·WRN=2·2, BLOCK_M=64 N=32** | **40.1** | **shipped HERE** (was #259) |
| 2B.4 | + 3-stage cp.async | 38.5 | refuted (was #260) |
| 2B.5 | + ldmatrix.x4/x2 | 37.5 | refuted (was #261) |

The +108 % step from 2B.2 → 2B.3 was the only meaningful architectural lever. 2B.4 helps small M (+35 %) but regresses at saturation (−7 %); 2B.5 is bit-identical, neutral perf — proves SMEM bandwidth was **not** the binding constraint. Architecture ceiling ≈ **40 TOPS ≈ 4.3 % of the 931 TOPS raw MMA peak** (PR #254).

## Tests — 4/4 PASS

| Test | Shape | max_abs | max_rel |
|---|---|---:|---:|
| Tiny         | 64 × 32 × 32   | 0.37 | 0.05 % |
| MultiSub     | 64 × 32 × 256  | 1.00 | 0.05 % |
| MultiTile    | 128 × 64 × 128 | 0.96 | 0.05 % |
| FFNLikeShape | 128 × 64 × 512 | 1.70 | 0.05 % |

Max rel_err stays at FP16 ulp floor across all shapes — math identity holds.

## Bench — production FFN shapes (BenchSweep, K=2048, mean of 20 reps)

| M    | N    | ms/rep | TOPS |
|---:  | ---: | ---:   | ---: |
| 512  | 512  | 0.068  | 15.9 |
| 1024 | 512  | 0.076  | 28.4 |
| 2048 | 512  | 0.122  | 35.1 |
| 4096 | 1024 | 0.429  | 40.1 |
| 2048 | 2048 | 0.418  | 41.0 |
| 4096 | 4096 | 1.715  | **40.1** |

## Files

- NEW \`tests/bench/mmq_q4k_imma_tile_bench.{h,cu}\` — production tile kernel + host launcher
- NEW \`tests/test_mmq_q4k_imma_tile_bench.cu\` — 4 correctness + 1 bench sweep
- EDIT \`CMakeLists.txt\` — wire the new TU under \`IMP_BUILD_TESTS OR IMP_BUILD_BENCH\` + test into \`test-quant\`

## Production wire-up (NOT in this PR)

Phase 2C dispatcher consumes this kernel + Phase 2A's reorder (PR #255, already on main) + Phase 2C infrastructure (PR #263, already on main). Recommended gate (per the Phase 2B ceiling memo):

\`\`\`
M >= 1024 && dense && Q4_K && !fp16_cache_hit && gemm.q4k_imma_enabled
\`\`\`

No production code touched here — bench-only. Decode bench unchanged.

## Risk

None — bench-only, no production callers of the new symbol.

## Close-list (after merge)

- #256 superseded by this PR
- #257 superseded
- #258 superseded
- #259 superseded (this is its content + the stack summary)
- #260 refuted (3-stage), not landing
- #261 refuted (ldmatrix), not landing