### PR TITLE
feat(q4k-imma): Phase 2C slice 2 — production dispatch wire-up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,7 @@ set(IMP_GRAPH_SOURCES
     src/graph/gemm_kernel_mxfp4.cu
     src/graph/gemm_kernel_gguf.cu
     src/graph/gemm_kernel_generic_dequant.cu
+    src/graph/gemm_kernel_q4k_imma.cu
     src/graph/gemm_scratch.cu
     src/graph/executor_workspace.cu
     src/graph/executor_workspace_buffers.cu

--- a/src/graph/executor_kernels.cu
+++ b/src/graph/executor_kernels.cu
@@ -1656,6 +1656,23 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
                 return;
         }
     }
+    // Q4_K_M direct-GEMM via INT8 IMMA (Phase 2C). Opt-in via
+    // `gemm.q4k_imma_enabled` (default off); production-recommended for dense
+    // Q4_K_M weights at M ≥ 1024 where the kernel's ~40 TOPS plateau beats
+    // the dequant→cuBLAS fallback. Falls through to FP8 / generic dequant on
+    // any precondition failure inside the handler. See
+    // docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md.
+    if (qtype == QType::Q4_K && input.qtype == QType::F16 && M >= 1024 &&
+        ctx.beta == 0.0f && RuntimeConfig::current().gemm.q4k_imma_enabled) {
+        GemmKernelArgs args{};
+        args.input = &input;
+        args.output = &output;
+        args.stream = ctx.stream;
+        args.weight_payload = &weight;
+        GemmStrategy strat{StorageTier::FP16, QType::Q4_K, /*m_is_one=*/false};
+        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+            return;
+    }
     // FP8 prefill (M>1): cache hit → FP8xFP8 cuBLASLt; cache miss with
     // dequant-supported qtype → dequant→FP16 cuBLAS (Slice 8.1). Raw FP16
     // weights drop to the FP16 strategy below.

--- a/src/graph/gemm_kernel_q4k_imma.cu
+++ b/src/graph/gemm_kernel_q4k_imma.cu
@@ -1,0 +1,79 @@
+// =============================================================================
+// gemm_kernel_q4k_imma.cu — Phase 2C dispatch handler for Q4_K_M INT8 IMMA
+// =============================================================================
+//
+// Routes Q4_K_M dense GEMM (M ≥ 1024, dense, non-MoE) through the Phase 2B
+// production tile kernel via the mmq_q4k_imma_gemm high-level entry. Default
+// off; the dispatch site checks `gemm.q4k_imma_enabled` before emitting the
+// {FP16, Q4_K, m_is_one=false} strategy key this handler is registered for.
+//
+// Eligibility (re-checked here):
+//   - weight.qtype == Q4_K
+//   - input.qtype == FP16
+//   - M ≥ 64 AND M % 64 == 0   (BLOCK_M; the dispatch site gates on M ≥ 1024)
+//   - N ≥ 32 AND N % 32 == 0   (BLOCK_N)
+//   - K % 32 == 0               (BLOCK_K — one m16n8k32 MMA per sub-block)
+//
+// On any failure the handler returns PreconditionFail and the dispatch site
+// falls through to the generic dequant catch-all (Slice 8.5) which performs
+// dequant→FP16 cuBLAS — bit-identical to the pre-Phase-2C behaviour.
+//
+// Reference: docs/plans/q4k_imma_design_2026_05_17.md,
+// docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md.
+
+#include "graph/gemm_kernel_registry.h"
+
+#include "compute/mmq_q4k_imma_tile.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "model/model_config.h"
+
+#include <cuda_fp16.h>
+
+namespace imp {
+
+static GemmDispatchResult q4k_imma_kernel(const GemmKernelArgs& args) {
+    // Soft preconditions — null args (e.g. from a registry-coverage probe test)
+    // must return PreconditionFail rather than FATAL, so the registry-lookup
+    // tests can route arbitrary strategy keys without instantiating real
+    // tensors.
+    if (args.input == nullptr || args.output == nullptr || args.weight_payload == nullptr)
+        return GemmDispatchResult::PreconditionFail;
+
+    const Tensor& weight = *static_cast<const Tensor*>(args.weight_payload);
+    if (weight.qtype != QType::Q4_K) return GemmDispatchResult::PreconditionFail;
+    if (args.input->qtype != QType::F16) return GemmDispatchResult::PreconditionFail;
+    if (args.output->qtype != QType::F16) return GemmDispatchResult::PreconditionFail;
+    if (args.beta != 0.0f) return GemmDispatchResult::PreconditionFail;  // residual fuse: dequant path handles it
+
+    const int M = static_cast<int>(args.input->shape[0]);
+    const int K = static_cast<int>(args.input->shape[1]);
+    const int N = static_cast<int>(weight.shape[0]);
+
+    // Kernel grid constraints from mmq_q4k_imma_tile (BLOCK_M=64, BLOCK_N=32,
+    // BLOCK_K=32). M < 64 or non-aligned dims fall through to dequant.
+    if (M < 64 || N < 32 || K < 32) return GemmDispatchResult::PreconditionFail;
+    if (M % 64 != 0 || N % 32 != 0 || K % 32 != 0) return GemmDispatchResult::PreconditionFail;
+
+    const __half* X = static_cast<const __half*>(args.input->data);
+    __half* Y = static_cast<__half*>(args.output->data);
+
+    if (!mmq_q4k_imma_gemm(weight.data, X, Y, M, N, K, args.stream)) {
+        // Shape/cache failure inside the entry — fall back.
+        return GemmDispatchResult::PreconditionFail;
+    }
+    return GemmDispatchResult::Ok;
+}
+
+namespace {
+struct Q4kImmaRegistration {
+    Q4kImmaRegistration() {
+        GemmKernelRegistry::instance().register_kernel(
+            GemmStrategy{StorageTier::FP16, QType::Q4_K, /*m_is_one=*/false},
+            &q4k_imma_kernel);
+    }
+};
+static Q4kImmaRegistration s_q4k_imma_registration;
+}  // namespace
+
+}  // namespace imp

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -1047,14 +1047,19 @@ TEST_F(GemmKernelRegistryTest, GgufSmallmKernelsAreRegisteredAtStaticInit) {
 }
 
 // Off-axis m_is_one (M>1 prefill) must NoMatch — Slice 7 only registers the
-// M==1 decode side. The dispatch site shouldn't accidentally pick up GGUF
-// strategies on the prefill path.
-TEST_F(GemmKernelRegistryTest, GgufWrongMIsOneReturnsNoMatch) {
+// GGUF handlers register only the M==1 decode side. The Q4_K M>1 strategy
+// is now claimed by the Phase 2C Q4_K_M INT8 IMMA handler instead — but with
+// null args the handler returns PreconditionFail (soft-check), so dispatch
+// still returns a non-Ok result that the dispatch site can fall back on.
+// (Originally this test expected NoMatch — pre-Phase-2C — and the rename
+// reflects the new contract: the M>1 path is COVERED by a handler that
+// rejects malformed args, not absent.)
+TEST_F(GemmKernelRegistryTest, GgufWrongMIsOneReturnsPreconditionFail) {
     const auto& reg = GemmKernelRegistry::instance();
     GemmStrategy m_gt_one{StorageTier::FP16, QType::Q4_K, /*m_is_one=*/false};
     GemmKernelArgs args{};
     args.stream = stream_;
-    EXPECT_EQ(reg.dispatch(m_gt_one, args), GemmDispatchResult::NoMatch);
+    EXPECT_EQ(reg.dispatch(m_gt_one, args), GemmDispatchResult::PreconditionFail);
 }
 
 // An unsupported qtype (Q4_1 stays on legacy quant_gemm_int4, IQ4_NL/XS not


### PR DESCRIPTION
## What

Routes dense Q4_K_M GEMMs at M ≥ 1024 through the Phase 2B production tile kernel (\`mmq_q4k_imma_gemm\`, PR #268) when \`gemm.q4k_imma_enabled = true\`. **Default off; no behavioural change for any existing model.**

## Why

PR #268 shipped the standalone \`mmq_q4k_imma_gemm\` entry but it had no callers. This PR wires it into the production GEMM dispatch path so an opt-in Q4_K_M dense workload (e.g. Qwen3-32B-Instruct Q4_K_M, Gemma-3-12B-it Q4_K_M) can actually exercise the kernel at M ≥ 1024 prefill — the regime where the ~40 TOPS plateau beats the dequant→cuBLAS fallback.

## How

**New handler** \`src/graph/gemm_kernel_q4k_imma.cu\`:
- Registers strategy \`{FP16, Q4_K, m_is_one=false}\`
- Soft preconditions (null args → \`PreconditionFail\`) so registry-coverage tests pass arbitrary keys without instantiating real tensors
- Re-checks grid constraints: \`M ≥ 64 && M % 64 == 0\`, \`N ≥ 32 && N % 32 == 0\`, \`K % 32 == 0\`
- Casts \`weight_payload\` → \`const Tensor*\`, dispatches to \`mmq_q4k_imma_gemm\`

**Dispatch-site change** \`src/graph/executor_kernels.cu\`:
- Insert Q4_K IMMA branch between MXFP4 and FP8 prefill blocks
- Gate: \`qtype == Q4_K && input.qtype == F16 && M ≥ 1024 && beta == 0 && gemm.q4k_imma_enabled\`
- On precondition fail: fall through to FP8 / generic dequant — bit-identical to pre-Phase-2C behaviour

**Test update**:
- \`GgufWrongMIsOneReturnsNoMatch\` → \`GgufWrongMIsOneReturnsPreconditionFail\`. The strategy key \`{FP16, Q4_K, m_is_one=false}\` is now claimed by the new IMMA handler; with null args the handler returns \`PreconditionFail\` rather than \`NoMatch\`. Dispatch site's fall-through semantics unchanged.

## Tests

- \`test-compute\` **166/166 PASS**
- \`test-quant\` **133/133 PASS**
- All \`MmqQ4kImmaGemm.*\` e2e cases from PR #268 still pass — they cover the exact path the new dispatch handler routes to.

## Bench

N/A — knob is off by default; the new code path only fires when explicitly opted in via \`gemm.q4k_imma_enabled = true\`. Decode bench unchanged. Phase 3 E2E A/B is the natural follow-up (needs a Q4_K_M model that triggers M ≥ 1024 prefill).

## Risk

Near-zero. Knob default-off; new dispatch only fires under explicit opt-in. Rollback = revert the PR.

## What's NOT in this PR (= Phase 2C slice 3, cleanup)

- Population of \`WeightCaches::q4k_imma\` at weight upload time in \`executor_pre_dequant.cu\` (cache infrastructure shipped in PR #263 but not yet consumed). The current path uses \`mmq_q4k_imma_gemm\`'s internal static cache, which has process-lifetime semantics and doesn't share with the engine's allocator.
- Activation-quant scratch pre-allocation in \`executor_workspace_buffers.cu\` (still relies on internal scratch grown lazily inside \`mmq_q4k_imma_gemm\`).

Branched off main, independent of any other in-flight PR.