### PR TITLE
docs(q4k-imma): Phase 3 E2E A/B — DEFERRED, IMMA path 3.8× slower on Gemma-3-12B

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -140,16 +140,21 @@ A **direct tiled Q4_K_M GEMM kernel** (`src/compute/mmq_q4k.cu`, Phase A dp4a) w
 Closing the high-M gap requires porting the inner loop to a Tensor-Core MMA. Two paths exist on sm_120:
 
 1. **FP16 HMMA** (`mma.sync.m16n8k16.f16`) with on-the-fly Q4→FP16 dequant. **Attempted and retired**: shipped across 7 phases as `src/compute/mmq_q4k_v2.cu` on a feature branch, microbench reached **4.87× v1 dp4a** at M=512 (kernel-only). End-to-end on Qwen3.6-35B Q4_K_M was **-4% pp** in production because MoE keeps experts under the `MIN_M=64` v2 threshold, the FP16 weight cache (`wcache_.fp16`) hits skip v2 entirely, and Phase 1 dispatch overhead is paid per call. Retired in PR #193. Re-eval pending a dense Q4_K_M model that bypasses both the MoE-min-M and the fp16_cache hot path. Memo: `mmq_q4k_v2_phase2_shipped_2026_05_16.md`.
-2. **INT8 IMMA** (`mma.sync.m16n8k32.s32.s8.s8.s32`, ~838 TOPS) with Q4_K dequant→INT8 reordering. **Phase 1 microbench complete (2026-05-18, memo `docs/superpowers/plans/2026-05-18-q4k-imma-phase1-findings.md`): PROCEED.** Raw-MMA throughput at 1360 warps × 32 768 iterations:
-   - INT8 IMMA `s32.s8.s8.s32`: **931 TOPS** (matches/exceeds the ~838 TOPS advertised peak — sm_120a is *not* throttled like the SM100-only `tcgen05.*` family).
-   - FP16 HMMA `f32.f16.f16.f32` (k=16) baseline: 244 TFLOPS.
-   - **IMMA/HMMA ratio = 3.82×** — gate was ≥ 1.8× (theoretical 2.0×, exceeded by 2.1×). Mixed-sign `s32.u8.s8.s32` and unsigned `s32.u8.u8.s32` are throughput-equivalent (~890–933 TOPS); the symmetric-s8 strategy (§3.2 of design memo) stands on tooling-familiarity, not perf.
+2. **INT8 IMMA** (`mma.sync.m16n8k32.s32.s8.s8.s32`, ~838 TOPS) with Q4_K dequant→INT8 reordering — **explored across PRs #254–#269 and DEFERRED 2026-05-18.** Wrap-up memos: `docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md`, `docs/superpowers/plans/2026-05-18-q4k-imma-phase3-refuted.md`.
 
-   Phase 2 = full production tile kernel (cp.async pipeline + `ldmatrix.x4`/`x2` + Q4-symmetric-s8 reorder + per-sub-block scale-apply); 5–8 days per design memo §6. A realistic full kernel will reach 30–60 % of raw MMA throughput per the v2 HMMA Phase 2 experience, so the e2e payoff is bounded by that fraction times the 3.82× headroom × the fraction of weights actually in scope (dense Q4_K_M, M ≥ 32, not in `fp16_cache`).
+   - **Phase 1** (PR #254): raw MMA microbench confirmed **931 TOPS** on sm_120a (3.82× FP16 HMMA), no throttle.
+   - **Phase 2A** (PR #255): Q4_K → symmetric-s8 reorder kernel.
+   - **Phase 2B** (PR #267): production tile kernel — BLOCK_M=64 N=32 K=32, 4 warps/CTA with WRM·WRN=2·2, 2-stage cp.async. **Plateaus at ~40 TOPS** (4.3 % of raw MMA peak); 3-stage cp.async + ldmatrix.x4 refuted at saturation.
+   - **Phase 2C** (PRs #263 + #268 + #269): infrastructure (`WeightCaches::q4k_imma` + `gemm.q4k_imma_enabled` knob), high-level `mmq_q4k_imma_gemm` entry, production dispatch handler. Default off.
+   - **Phase 3** (this date, refutation memo): end-to-end A/B on **Gemma-3-12B-it Q4_K_M** at pp2048: IMMA **3.8× slower** (1697 vs 6418 tok/s) than the default dequant→cuBLAS path. Decode unchanged. Per-dispatch IMMA at 40 TOPS = 1.5 ms; cuBLAS dequant→FP16 + GEMM at 244 TFLOPS = 0.26 ms ⇒ ~6× per-call ratio, compounded across ~336 Q4_K dispatches per prefill.
 
-   Bench code: `tests/bench/mmq_q4k_imma_bench.{h,cu}` + `tests/test_mmq_q4k_imma_bench.cu`. **Design memo:** `docs/plans/q4k_imma_design_2026_05_17.md`.
+   **Decision: DEFERRED.** All artifacts retained (kernel + dispatch handler + knob) so future researchers can re-bench when one of these conditions appears:
+   - Larger FFN shapes (N ≥ 8192, K ≥ 4096) where the 40 TOPS plateau region widens
+   - Fundamental kernel restructure (persistent CTAs + stream-K, or CUTLASS template instantiation)
+   - A workload where dequant→cuBLAS isn't reachable (fp16_cache disabled + dequant_scratch unavailable — rare)
+   - Activation-quant cost fuseable into the prior layer's epilogue
 
-Memos: `mmq_q4k_phase_a_2026_05_15.md` (v1 dp4a sweep), `mmq_q4k_v2_hmma_design_2026_05_15.md` (v2 blueprint), `q4k_mmvq_crossover_2026_05_15.md` (original mmvq-vs-cuBLAS measurement), `docs/plans/q4k_imma_design_2026_05_17.md` (INT8 IMMA forward-looking design), `docs/superpowers/plans/2026-05-18-q4k-imma-phase1-findings.md` (Phase 1 microbench result).
+Memos: `mmq_q4k_phase_a_2026_05_15.md` (v1 dp4a sweep), `mmq_q4k_v2_hmma_design_2026_05_15.md` (v2 HMMA blueprint), `q4k_mmvq_crossover_2026_05_15.md` (original mmvq-vs-cuBLAS measurement), `docs/plans/q4k_imma_design_2026_05_17.md` (INT8 IMMA design), `docs/superpowers/plans/2026-05-18-q4k-imma-phase1-findings.md` (Phase 1 PROCEED), `docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md` (Phase 2B 40 TOPS ceiling), `docs/superpowers/plans/2026-05-18-q4k-imma-phase3-refuted.md` (Phase 3 e2e refuted).
 
 ### Speculative decoding — investigated and shelved
 

--- a/docs/superpowers/plans/2026-05-18-q4k-imma-phase3-refuted.md
+++ b/docs/superpowers/plans/2026-05-18-q4k-imma-phase3-refuted.md
@@ -1,0 +1,144 @@
+# Q4_K_M INT8 IMMA — Phase 3 E2E A/B: REFUTED on real model
+
+**Date**: 2026-05-18
+**Status**: Phase 3 end-to-end A/B on **Gemma-3-12B-it Q4_K_M** refutes the
+Phase 2C production deployment. IMMA path is **3.8× slower** than the
+default dequant→cuBLAS path at pp2048. Decode unchanged (knob doesn't fire
+at M=1). **Recommendation: keep the knob default-OFF, retain the kernel as
+research artifact, mark the Q4_K_M IMMA project DEFERRED.**
+**Wrap-up of Phase 2B (architecture ceiling)**: `2026-05-18-q4k-imma-phase2b-ceiling.md`.
+
+## Setup
+
+- Model: `gemma-3-12b-it-Q4_K_M.gguf` (6.8 GiB)
+- Hardware: RTX 5090 (sm_120a, GB202)
+- Build: PR #269 stack (Phase 1 + 2A + 2B + 2C entry + 2C dispatch wire-up)
+- Bench: `imp-cli --bench --bench-pp 2048 --bench-reps 10 --prefill-chunk-size 0
+  --max-tokens 64 --temperature 0`, 3 trials, median reported
+- Env: `CUBLAS_WORKSPACE_CONFIG=:4096:8` for cuBLAS determinism
+- IMMA opt-in: `--set gemm.q4k_imma_enabled=true` (default off otherwise)
+
+`--prefill-chunk-size 0` is critical — the default chunked prefill at
+`chunk_size = 512` would never let M reach the IMMA dispatch gate (M ≥ 1024).
+For the A/B we force the entire 2048-token prompt into a single forward pass
+so the IMMA path actually fires.
+
+## Results
+
+| Config | pp2048 (tok/s) | tg64 (tok/s) |
+| ---    | ---:           | ---:         |
+| OFF (dequant→cuBLAS, default) | **6418** | 116 |
+| ON (IMMA, opt-in)              | **1697** | 119 |
+| Δ                              | **−74 %** | ±2 % (noise) |
+
+Trial-by-trial:
+
+```
+OFF: 6319, 6418, 6414  (median 6418 tok/s, σ ≈ 1.5 %)
+ON:  1698, 1691, 1696  (median 1697 tok/s, σ ≈ 0.2 %)
+```
+
+Decode (tg64) is unaffected because the dispatch site only emits the IMMA
+strategy for M ≥ 1024; decode dispatches with M = 1 and go through the
+existing GGUF small-M handlers regardless of the knob state.
+
+## Why is IMMA empirically slower?
+
+The Phase 1 microbench (PR #254) measured raw MMA throughput at 931 TOPS —
+the *hardware ceiling*. The Phase 2B chain (PRs #256→#267) measured the
+hand-rolled tile kernel at **40 TOPS** in isolation on synthetic shapes
+(M=N=4096 K=2048). The Phase 2B wrap-up (`2026-05-18-q4k-imma-phase2b-ceiling.md`)
+explicitly flagged this as ~4.3 % of the raw ceiling and noted that closing
+the gap requires fundamentally different kernel architecture.
+
+What Phase 3 surfaces empirically:
+
+1. **cuBLAS FP16-TC is 6× faster than IMMA at this scale.** For one Q4_K_M
+   GEMM at (M=2048, N=3840, K=3840) — typical Gemma-3-12B FFN tile shape —
+   the cost breakdown is:
+     - dequant→FP16: ~14 µs (Q4_K 7 MB read + FP16 28 MB write, ≈ 1.7 TB/s HBM)
+     - cuBLAS FP16-TC GEMM: ~245 µs (60 GFLOPs at 244 TFLOPS measured)
+     - **Total dequant→cuBLAS: ~0.26 ms per dispatch**
+     - IMMA at 40 TOPS: 60 GOPS / 40 TOPS = **1.5 ms per dispatch**
+
+   The 6× per-dispatch ratio compounds across the ~48 layers × 7 Q4_K
+   weights per layer = ~336 dispatches per prefill, producing the observed
+   3.8× e2e slowdown.
+
+2. **Mixed shapes hurt more than the synthetic bench.** Gemma-3-12B's
+   layers include attention Q/K/V/O at N=K=3840 (favourable for IMMA — the
+   ~40 TOPS plateau region) but FFN gate/up at N=24576 K=3840 (much bigger
+   N, more CTAs but also more activation-quant work) and FFN down at
+   N=3840 K=24576 (LONG K, lots of inner-loop iterations). The mixed
+   profile averages out below the 40 TOPS plateau.
+
+3. **Per-call activation quantization is unamortised.** The IMMA path
+   pays `quantize_fp16_to_int8_subblock` once per `mmq_q4k_imma_gemm` call.
+   That's a separate kernel launch per dispatch — adds launch overhead
+   the dequant→cuBLAS path doesn't pay (it just calls cuBLAS with the
+   raw FP16 input).
+
+4. **Weight-cache cold start.** The first prefill pass per (process-load)
+   pays the Phase 2A reorder for ~336 weights serially. At ~10-20 µs per
+   reorder kernel that's 3-7 ms of one-shot warm-up — visible as a small
+   tax in the bench mean (10 reps amortise it).
+
+## Re-eval triggers — when to revisit
+
+The kernel stays in the codebase (PRs #267 #268 #269 retained). Re-eval
+becomes worthwhile only when one of these conditions holds:
+
+- A **dense Q4_K_M model with much larger FFN shapes** appears — N ≥ 8192
+  with K ≥ 4096 — where the 40 TOPS plateau region is wider and the
+  per-call overhead amortises across bigger work.
+- A **major kernel restructure** ships:
+    - persistent-CTA + stream-K scheduling
+    - CUTLASS template instantiation (defer past the v4.5 inspection done
+      in `cutlass_4_5_sm120_research_2026_05_10.md`)
+    - tcgen05.* / warp-group MMA (SM100-only, n/a for sm_120)
+- **A workload appears where cuBLAS dequant→FP16 isn't reachable**:
+    - fp16_cache disabled AND dequant_scratch unavailable (rare on imp's
+      current configuration; only happens under tight VRAM pressure)
+- **Activation-quant cost can be fused** into the prior layer's epilogue
+  (e.g. fuse silu·up_gate quantization into the FFN gate kernel that
+  produces the activation).
+
+## Decision
+
+| Action | Status |
+| --- | --- |
+| Keep `mmq_q4k_imma_tile`, `mmq_q4k_imma_reorder`, `mmq_q4k_imma_gemm` | ✅ in `src/compute/` |
+| Keep `WeightCaches::q4k_imma` + `gemm.q4k_imma_enabled` knob | ✅ default off |
+| Keep `gemm_kernel_q4k_imma.cu` dispatch handler | ✅ on registry, gated by knob |
+| Default-OFF documented in roadmap as **refuted at deployment** | ☑ this memo + roadmap update |
+| Phase 2C slice 3 (cleanup: WeightCaches populate at load time) | ❌ unnecessary — knob stays off |
+| Multi-week kernel restructure to close the cuBLAS gap | ❌ defer indefinitely |
+
+The Q4_K_M IMMA project is **DEFERRED**. The architecture-ceiling memo
+(`2026-05-18-q4k-imma-phase2b-ceiling.md`) predicted the kernel might
+"already be competitive with the dequant→cuBLAS path the FFN cache-miss
+workload would hit." Phase 3 refutes that prediction on the only available
+test model. The cuBLAS FP16-TC path is materially faster end-to-end.
+
+## Memos in this thread
+
+- Phase 1 finding: `2026-05-18-q4k-imma-phase1-findings.md` (931 TOPS gate)
+- Phase 2B ceiling wrap-up: `2026-05-18-q4k-imma-phase2b-ceiling.md` (40 TOPS plateau)
+- **Phase 3 refutation (this memo)**: dense Q4_K_M e2e refuted at 3.8× slowdown
+
+## PRs in the chain
+
+| PR | Status | Subject |
+| ---:| --- | --- |
+| #254 | merged | Phase 1 microbench (931 TOPS) |
+| #255 | merged | Phase 2A reorder kernel |
+| #263 | merged | Phase 2C infrastructure (cache struct + knob) |
+| #267 | merged | Phase 2B production tile kernel |
+| #268 | merged | Phase 2C dispatcher entry (`mmq_q4k_imma_gemm`) |
+| #269 | open   | Phase 2C slice 2 (registry handler + dispatch site gate) |
+| (this) | n/a | Phase 3 findings doc + roadmap update |
+
+Note: #269 remains useful to merge — the dispatch handler is the only way
+the knob actually does anything, even if production users won't flip it on.
+Future researchers re-evaluating the kernel will need the handler wired up
+to bench the path quickly.


### PR DESCRIPTION
## What

End-to-end A/B on **Gemma-3-12B-it Q4_K_M** at pp2048 refutes the Phase 2C production deployment. IMMA path is **3.8× slower** than the default dequant→cuBLAS path. Decision: **DEFERRED**, all artifacts retained.

## Why

The Phase 2B chain (PRs #256→#267) reached a ~40 TOPS plateau in microbench at M=N=4096 K=2048 (4.3 % of the 931 TOPS raw MMA peak). The Phase 2B ceiling memo (`2026-05-18-q4k-imma-phase2b-ceiling.md`) speculated that the kernel "might already be competitive with the dequant→cuBLAS path." Phase 3 is the empirical check on the only available test model. The speculation is refuted.

## Setup

- Model: `gemma-3-12b-it-Q4_K_M.gguf` (6.8 GiB)
- Hardware: RTX 5090 (sm_120a, GB202)
- Build: this branch (PR #269 wire-up + base IMMA stack)
- Bench: `imp-cli --bench --bench-pp 2048 --bench-reps 10 --prefill-chunk-size 0 --max-tokens 64 --temperature 0`, 3 trials × 10 reps each, median reported
- Env: `CUBLAS_WORKSPACE_CONFIG=:4096:8` for cuBLAS determinism
- IMMA opt-in: `--set gemm.q4k_imma_enabled=true`

\`--prefill-chunk-size 0\` is critical — the default chunked prefill at \`chunk_size = 512\` would never let M reach the IMMA dispatch gate (M ≥ 1024).

## Results

| Config | pp2048 (tok/s) | tg64 (tok/s) |
|---|---:|---:|
| OFF (dequant→cuBLAS, default) | **6418** | 116 |
| ON  (IMMA, opt-in)            | **1697** | 119 |
| Δ                             | **−74 %** | ±2 % (noise) |

Trial-by-trial OFF: 6319 / 6418 / 6414 (σ ≈ 1.5 %).
Trial-by-trial ON:  1698 / 1691 / 1696 (σ ≈ 0.2 %).

Decode (tg64) is unaffected because the dispatch gate is M ≥ 1024; decode runs at M=1.

## Why IMMA is empirically slower

Per-dispatch arithmetic for a Gemma-3-12B FFN tile shape (M=2048, N=K≈3840):

\`\`\`
IMMA at 40 TOPS               =  1.5 ms / dispatch
cuBLAS dequant + FP16 GEMM    =  0.26 ms (14 µs dequant + 245 µs at 244 TFLOPS)
⇒ ~6× per-call ratio
\`\`\`

Compounded across ~336 Q4_K dispatches per prefill (~48 layers × 7 weights/layer) ⇒ 3.8× e2e slowdown. Plus per-call activation-quant launch overhead (unamortised) and weight-cache cold start on first rep.

## Decision

**DEFERRED.** All artifacts retained for future researchers to re-bench when one of these conditions appears:
- Larger FFN shapes (N ≥ 8192, K ≥ 4096) widen the 40 TOPS plateau region
- A fundamental kernel restructure ships (persistent CTAs + stream-K, CUTLASS template instantiation, etc.)
- Activation-quant cost can be fused into the prior layer's epilogue
- A workload where dequant→cuBLAS isn't reachable appears (fp16_cache + dequant_scratch both unavailable)

## Files

- NEW \`docs/superpowers/plans/2026-05-18-q4k-imma-phase3-refuted.md\` — full findings memo with arithmetic, re-eval triggers, full PR chain
- EDIT \`docs/roadmap.md\` §\`pp=512 on large dense models\` — collapses the multi-phase entry into the final DEFERRED decision with all three phase memos cross-referenced

## Risk

None. Doc-only PR; no code touched. Independent of any in-flight PR; merge order doesn't matter.

## Recommended merge

The artifacts are useful as research baseline even with the refutation. The companion PR #269 (dispatch handler) should still merge — it's the only way the knob does anything when a future re-eval happens. The kernel stays in the codebase by way of #267 (already merged) and #268 (already merged).