### PR TITLE
docs(nvfp4-smoothquant): retire roadmap item — sub-case (b) confirmed on all NVFP4 checkpoints

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,11 +32,19 @@ Each excluded class is a separate larger work item.
 
 When a single prompt exceeds `max_seq_len`, the engine's pre-allocated device buffer `d_pf_block_tables_` (sized `max_seq_len / block_size`) overflowed during `cudaMemcpyAsync`. Fixed in PR #134: `d_pf_block_tables_` is now sized from `max_blocks` (the total KV cache pool count), so a single request's block_table can grow to the entire cache without overflowing.
 
-### NVFP4 SmoothQuant input_scale (Mistral-3.2 NVFP4)
+### ~~NVFP4 SmoothQuant input_scale (Mistral-3.2 NVFP4)~~ — RETIRED 2026-05-18
 
-Mistral-Small-3.2-NVFP4 was calibrated with SmoothQuant 0.9, which records a per-Linear `input_scale` in SafeTensors. imp loads `input_scale` into `nvfp4_scratch_` but does not consume it at inference. PR #78 worked around long-prompt drift by disabling the 600-token default system prompt.
+Phase 1 diagnostic (full findings: `docs/superpowers/plans/2026-05-18-nvfp4-smoothquant-phase1-findings.md`) closed this roadmap item on **all relevant NVFP4 checkpoints**, including the one the design memo gated on.
 
-Direct absorption of `input_scale` as a per-tensor scalar GEMM alpha modifier (in either direction) was tested 2026-05-07 on Gemma-4-NVFP4 and refuted: phase4 18/20 → 4/20 (full degeneration). A real fix likely needs the per-channel SmoothQuant scaling vector applied during activation quantization, not a scalar alpha modifier — testable only against Mistral-3.2-NVFP4 (not present in default model set). **Design memo:** `docs/plans/nvfp4_smoothquant_input_scale_design_2026_05_17.md` (defer + optional Phase 1 diagnostic; key finding: SmoothQuant is likely already fused into `input_layernorm.weight` at calibration time, in which case the engine has nothing to do).
+**Local corpus** — 6 NVFP4 models scanned via SafeTensors header + engine audit-log run. `input_scale` is **100 % scalar (numel=1)** on every Linear of every checkpoint; none of the 6 recipe.yamls ships a `SmoothQuantModifier` (all are pure `QuantizationModifier: scheme: NVFP4`). The per-Linear scalar is llm-compressor's `input_global_scale` activation-absmax anchor, not a SmoothQuant `1/s` carrier — engine's existing "intentionally NOT applied" stance at `executor_pre_dequant.cu:431` is the correct behavior. The 2026-05-07 DIVIDE/MULTIPLY refutation on Gemma-4-NVFP4 is now structurally explained (no SmoothQuant correction existed to apply, since no SmoothQuant was calibrated into the model).
+
+**Mistral-3.2-NVFP4** (the one SmoothQuant-calibrated checkpoint in scope) — resolved via HF range-fetch of the recipe.yaml + first 16 MB of each safetensors shard (no full 15 GB download required for the answer; full download running as artifact). The recipe.yaml carries an explicit `SmoothQuantModifier` with mappings `[q_proj, k_proj, v_proj] → input_layernorm` and `[gate_proj, up_proj] → post_attention_layernorm` — **exactly** the structure design memo §4 sub-case (b) predicted, with `diag(1/s)` migrated into the upstream RMSNorm weights at calibration time. The 280 on-disk `input_scale` tensors are all `(1,)` scalar (sub-cases (a)/(c) refuted on the SmoothQuant model too); the 80 `(5120,)` layernorm weights (40 layers × 2 norm types) are the SmoothQuant migration targets. imp already loads + applies those layernorm weights via the standard path — nothing engine-side to add.
+
+PR #78's `use_default_system_prompt=false` workaround for Mistral-3.2-NVFP4 long-context drift stays load-bearing, but its root cause is **not** missing SmoothQuant absorption — it's the NVFP4-activation-noise-grows-with-`||X||` issue tracked in `memory/nvfp4_long_context_regression_2026_04_28.md`. That fix is a separate, much larger workitem (dynamic NVFP4 activation quantization end-to-end + a real NVFP4×NVFP4→FP32 GEMM in the dense path) outside this roadmap entry's scope.
+
+**Phase 2-4** (Option-B `smooth_activations` pre-pass kernel + regression tests) **never needed** — no checkpoint in the foreseeable workload would trigger a non-null `s_inv` path. Diagnostic patch shipped to `src/model/weight_upload.cu` (per-Linear `scalar=N per_channel=M` split + `ndim/shape/numel` samples under `diagnostics.audit_nvfp4_scales=true`) as the lasting deliverable for any future SmoothQuant-calibrated NVFP4 checkpoint that might land.
+
+**Design memo:** `docs/plans/nvfp4_smoothquant_input_scale_design_2026_05_17.md` (predicted sub-case (b); confirmed empirically).
 
 ### Qwen3.5-27B MXFP4 fails at load
 

--- a/docs/superpowers/plans/2026-05-18-nvfp4-smoothquant-phase1-findings.md
+++ b/docs/superpowers/plans/2026-05-18-nvfp4-smoothquant-phase1-findings.md
@@ -1,0 +1,154 @@
+# NVFP4 SmoothQuant `input_scale` Phase 1 findings
+
+**Date:** 2026-05-18
+**Branch:** main (`weight_upload.cu` diagnostic edit only, no semantic change)
+**Scope:** Resolve the design memo §4 sub-case question (`input_scale` per-tensor scalar vs per-channel `[K]`) for every NVFP4 checkpoint imp can reach today, **including** `Mistral-Small-3.2-24B-Instruct-2506-NVFP4` (resolved via HF range-fetch of the safetensors headers + recipe.yaml, no full download required for the answer; full download running in parallel as a follow-up artifact).
+**Design memo:** `docs/plans/nvfp4_smoothquant_input_scale_design_2026_05_17.md` §5 Phase 1
+**Diagnostic patch:** `src/model/weight_upload.cu:1965-2079` — adds `is_scalar_count` / `is_per_channel_count` split + per-sample `ndim/shape/numel` logging to the `diagnostics.audit_nvfp4_scales=true` audit. Default-off; no perf or semantic change.
+
+## Measurements
+
+Two independent paths cross-check the same question.
+
+### Path 1 — SafeTensors header scan (Python, no engine load)
+
+`input_scale` / `input_global_scale` tensor shapes pulled directly from the SafeTensors shard headers across every local NVFP4 checkpoint. No engine, no GPU.
+
+| Model | input_scale tensor count | shape distribution |
+|---|---:|---|
+| `Qwen3-8B-NVFP4-cortecs`              |    252 | `(1,)` × 252 |
+| `Gemma-4-26B-A4B-it-NVFP4`            | 11 725 | `(1,)` × 11 725 |
+| `Qwen3.6-35B-A3B-NVFP4`               | 30 880 | `(1,)` × 30 880 |
+| `Qwen3-30B-A3B-NVFP4-Modelopt`        | 18 624 | `()`   × 18 624 (rank-0) |
+| `Nemotron-3-Nano-30B-A3B-NVFP4`       |  5 968 | `()`   × 5 968  (rank-0) |
+| `Huihui-Qwen3.6-35B-A3B-abliterated-NVFP4` | 31 030 | `(1,)` × 31 030 |
+
+**All 6 models, 100 % scalar.** rank-0 vs rank-1 is a llm-compressor-version cosmetic; `numel() == 1` either way.
+
+### Path 2 — Engine audit log (C++, full weight upload)
+
+`imp-cli --model Qwen3-8B-NVFP4-cortecs --set diagnostics.audit_nvfp4_scales=true --prompt Hi --max-tokens 1`:
+
+```
+NVFP4 audit: input_scale present in 252/252 Linears (scalar=252 per_channel=0),
+  stats — count=252 zeros=0 min=0.25 max=7776 mean=457.443
+  sample: L17.w_up.input_scale  ndim=1 shape=[1] numel=1 first=231
+  sample: L24.wq.input_scale    ndim=1 shape=[1] numel=1 first=44.25
+  sample: L23.wk.input_scale    ndim=1 shape=[1] numel=1 first=58.75
+  sample: L21.wo.input_scale    ndim=1 shape=[1] numel=1 first=516
+  sample: L2.wv.input_scale     ndim=1 shape=[1] numel=1 first=2320
+  sample: L20.w_down.input_scale ndim=1 shape=[1] numel=1 first=154
+  sample: L11.wo.input_scale    ndim=1 shape=[1] numel=1 first=1312
+  sample: L11.wk.input_scale    ndim=1 shape=[1] numel=1 first=312
+NVFP4 prequant: 252 Linears carry input_scale (intentionally NOT applied; set IMP_AUDIT_NVFP4_SCALES=1 for stats).
+```
+
+C++ audit matches the Python header scan exactly: 252 Linears, all scalar, all `ndim=1 shape=[1]`. Per-Linear values span 0.25 – 7 776 (≈30 000× dynamic range) — characteristic of llm-compressor's per-Linear activation absmax calibration (`input_global_scale`), not a per-channel SmoothQuant `1/s` vector.
+
+### Recipe corroboration
+
+Every local NVFP4 model's `recipe.yaml` ships **only** a `QuantizationModifier` — none ship a `SmoothQuantModifier`. SmoothQuant calibration was never applied to any of these checkpoints.
+
+```yaml
+# representative recipe.yaml (Qwen3-8B-NVFP4-cortecs)
+default_stage:
+  default_modifiers:
+    QuantizationModifier:
+      targets: [Linear]
+      ignore: [lm_head]
+      scheme: NVFP4
+```
+
+## Acceptance criteria evaluation
+
+Design memo §4 enumerates three sub-cases for `input_scale`:
+
+- **(a)** `input_scale` is already per-channel `[K]` on disk.
+- **(b)** `input_scale` is scalar; the per-channel `1/s` was fused into the upstream `input_layernorm.weight` at calibration time.
+- **(c)** `input_scale` is per-channel but stored at a non-obvious key the loader currently drops.
+
+For the local NVFP4 corpus:
+
+| Question | Answer |
+|---|---|
+| Per-channel `input_scale` on disk? | **No** — all 6 models, every Linear is `numel=1`. Sub-case (a) **refuted**. |
+| Hidden per-channel key dropped by loader? | **No** — header scan covers `*input_global_scale` *and* `*input_scale`; nothing else matches. Sub-case (c) **refuted**. |
+| SmoothQuant fused into `input_layernorm.weight`? | **N/A** — no SmoothQuantModifier ran during calibration. Sub-case (b) **vacuously true** (scalar shipped, no per-channel `s` exists in the first place). |
+
+**Verdict for local corpus: there is nothing for the engine to do.** The per-Linear scalar is llm-compressor's `input_global_scale` activation calibration anchor, and imp's dynamic input quantizer (`src/quant/nvfp4_quant.cu:421-462` `quantize_fp16_to_nvfp4`) recomputes per-micro-block absmax at inference — correctly ignoring the calibration-time scalar that would otherwise double-apply correction. The 2026-05-07 DIVIDE/MULTIPLY refutation on Gemma-4-NVFP4 (`memory/llm_compressor_input_scale_dead_end_2026_05_07.md`) is now structurally explained: the scalar carried no SmoothQuant information *because no SmoothQuant was ever calibrated into it*.
+
+## Decision
+
+**Local corpus: CLOSE.** No engine work required for any of the 6 NVFP4 models in scope today. The "intentionally NOT applied" stance at `executor_pre_dequant.cu:431` is the correct behavior. Diagnostic patch ships as the lasting deliverable (lets future debug sessions distinguish scalar from per-channel without a re-scan).
+
+**Mistral-3.2-NVFP4 — RESOLVED (sub-case b confirmed) 2026-05-18 via HF range-fetch.** Without downloading the full 15 GB SafeTensors, the recipe.yaml + the first 16 MB of each shard (just enough for the safetensors header JSON) gave a definitive answer.
+
+### recipe.yaml — `SmoothQuantModifier` mappings
+
+```yaml
+SmoothQuantModifier:
+  smoothing_strength: 0.9
+  mappings:
+  - !!python/tuple
+    - ['re:.*q_proj', 're:.*k_proj', 're:.*v_proj']
+    - re:.*input_layernorm
+  - !!python/tuple
+    - ['re:.*gate_proj', 're:.*up_proj']
+    - re:.*post_attention_layernorm
+  ignore: []
+```
+
+This is **exactly** the structure the design memo §4 sub-case (b) predicted: SmoothQuant migrates the per-channel `diag(1/s)` factor into the **upstream RMSNorm weights** (`input_layernorm.weight` for attention Linears, `post_attention_layernorm.weight` for FFN Linears) at calibration time.
+
+### Header scan — `input_scale` is 100 % scalar on Mistral-3.2-NVFP4 too
+
+```
+Mistral-3.2-NVFP4 input_scale: 280 tensors total
+shape distribution: {(1,): 280}
+  example shape=(1,): language_model.model.layers.0.mlp.down_proj.input_global_scale
+
+input_layernorm.weight + post_attention_layernorm.weight:
+  shape distribution: {(5120,): 80}
+```
+
+280 scalar `input_scale` tensors confirm sub-case (a) and (c) are refuted on the SmoothQuant model too. The 80 `(5120,)` layernorm weights (`hidden_size=5120 × 40 layers × 2 norm types`) are exactly the migration targets the recipe specifies — `diag(1/s)` lives there.
+
+### Post-download engine audit (full cross-check)
+
+After the 15 GB download completed, `imp-cli --model /models/Mistral-Small-3.2-24B-Instruct-2506-NVFP4 --set diagnostics.audit_nvfp4_scales=true --prompt Hi --max-tokens 1` confirms the header-scan result through the actual C++ loader path:
+
+```
+NVFP4 audit: input_scale present in 280/280 Linears (scalar=280 per_channel=0),
+  stats — count=280 zeros=0 min=12 max=8832 mean=2167.09
+  sample: L29.wv.input_scale     ndim=1 shape=[1] numel=1 first=3072
+  sample: L30.wo.input_scale     ndim=1 shape=[1] numel=1 first=692
+  sample: L29.wq.input_scale     ndim=1 shape=[1] numel=1 first=3072
+  sample: L30.w_up.input_scale   ndim=1 shape=[1] numel=1 first=3200
+  sample: L29.w_gate.input_scale ndim=1 shape=[1] numel=1 first=3136
+  ...
+NVFP4 prequant: 280 Linears carry input_scale (intentionally NOT applied; set IMP_AUDIT_NVFP4_SCALES=1 for stats).
+```
+
+Stats vs Qwen3-8B-NVFP4-cortecs (non-SmoothQuant): Mistral's per-Linear absmax range is `12 – 8832 (mean 2167)` vs Qwen3-8B's `0.25 – 7776 (mean 457)` — Mistral's higher mean and tighter floor are consistent with SmoothQuant deliberately widening per-Linear (output-channel) absmax in exchange for tighter per-input-channel ranges. The distributions are different but both are pure scalars; neither carries any information the engine could use beyond what the dynamic input quantizer already recomputes per micro-block at inference.
+
+### What this means for the engine
+
+Sub-case (b) — fully confirmed. There is nothing for the engine to add: SmoothQuant's per-channel `1/s` is already baked into the upstream RMSNorm weights, which imp already loads and applies via the standard layernorm path (`src/compute/norm_*.cu`). The per-Linear scalar `input_global_scale` on disk is just llm-compressor's post-smoothing NVFP4 activation calibration anchor, which imp's dynamic input quantizer correctly ignores by recomputing per-micro-block absmax at inference (same mechanism as for the 6 non-SmoothQuant local NVFP4 models).
+
+**The roadmap item "NVFP4 SmoothQuant input_scale" retires.**
+
+PR #78's long-context drift workaround (`use_default_system_prompt=false`) is still load-bearing for Mistral-3.2-NVFP4, but its root cause is **NOT** missing SmoothQuant absorption — it's the **NVFP4-activation-noise-grows-with-`||X||`** hypothesis tracked separately in `memory/nvfp4_long_context_regression_2026_04_28.md` §"Suggestive evidence". Fixing that is a much larger workitem (dynamic NVFP4 activation quantization end-to-end + a true NVFP4×NVFP4→FP32 GEMM in the dense path) with its own design memo home, not part of this roadmap entry.
+
+**Phase 2-4 (Option-B `smooth_activations` pre-pass kernel + regression tests) — RETIRED, never needed.** No checkpoint in the foreseeable workload triggers a non-null `s_inv` path; SmoothQuant-calibrated NVFP4 checkpoints all bake `1/s` into upstream RMSNorm at calibration time.
+
+## Diagnostic patch lasting value
+
+The `scalar=N per_channel=M` split + `ndim/shape/numel` per-sample log lives in `src/model/weight_upload.cu:1965-2079`, gated to `diagnostics.audit_nvfp4_scales=true` (default-off, env-compat `IMP_AUDIT_NVFP4_SCALES=1`). Re-runs on any future NVFP4 checkpoint immediately answer the per-channel question without re-reading SafeTensors headers. Cost: 8 extra audit-mode-only `INFO` log lines per model load; zero VRAM, zero perf delta on production runs.
+
+## Cross-references
+
+- Design memo: `docs/plans/nvfp4_smoothquant_input_scale_design_2026_05_17.md`
+- 2026-05-07 refutation memo: `memory/llm_compressor_input_scale_dead_end_2026_05_07.md`
+- Long-context bisection: `memory/nvfp4_long_context_regression_2026_04_28.md`
+- PR #78 (production workaround for Mistral-3.2-NVFP4): `memory/mistral_3_2_nvfp4_use_default_system_2026_04_28.md`
+- Roadmap entry: `docs/roadmap.md` "NVFP4 SmoothQuant input_scale (Mistral-3.2 NVFP4)"

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1961,7 +1961,15 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
         // Same stats for input_scale (FP32 scalar per Linear, optional).
         float is_min = 1e30f, is_max = -1e30f, is_sum = 0.0f;
         int is_count = 0, is_zero = 0, is_present = 0;
-        std::vector<std::pair<std::string, float>> is_samples;
+        int is_scalar_count = 0, is_per_channel_count = 0;
+        struct InputScaleSample {
+            std::string name;
+            int ndim;
+            int64_t shape[4];
+            size_t numel;
+            float first_val;
+        };
+        std::vector<InputScaleSample> is_samples;
         if (audit) {
             ws2_samples.reserve(8);
             is_samples.reserve(8);
@@ -2002,6 +2010,10 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
             if (audit && sc.input_scale.data && !sc.input_scale.on_device) {
                 is_present++;
                 size_t n = sc.input_scale.numel();
+                if (n <= 1)
+                    is_scalar_count++;
+                else
+                    is_per_channel_count++;
                 const float* p = static_cast<const float*>(sc.input_scale.data);
                 for (size_t i = 0; i < n; ++i) {
                     float v = p[i];
@@ -2015,7 +2027,14 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
                     is_count++;
                 }
                 if (is_samples.size() < 8) {
-                    is_samples.emplace_back(name, p[0]);
+                    InputScaleSample s;
+                    s.name = name;
+                    s.ndim = sc.input_scale.ndim;
+                    for (int d = 0; d < s.ndim && d < 4; ++d)
+                        s.shape[d] = sc.input_scale.shape[d];
+                    s.numel = n;
+                    s.first_val = p[0];
+                    is_samples.push_back(std::move(s));
                 }
             }
             upload_scale(sc.weight_scale);
@@ -2040,11 +2059,24 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
         if (audit) {
             if (is_count > 0) {
                 IMP_LOG_INFO(
-                    "NVFP4 audit: input_scale present in %d/%zu Linears, "
+                    "NVFP4 audit: input_scale present in %d/%zu Linears "
+                    "(scalar=%d per_channel=%d), "
                     "stats — count=%d zeros=%d min=%.6g max=%.6g mean=%.6g",
-                    is_present, nvfp4_scratch_.size(), is_count, is_zero, is_min, is_max, is_sum / is_count);
-                for (auto& [n, v] : is_samples) {
-                    IMP_LOG_INFO("  sample: %s.input_scale = %.6g", n.c_str(), v);
+                    is_present, nvfp4_scratch_.size(),
+                    is_scalar_count, is_per_channel_count,
+                    is_count, is_zero, is_min, is_max, is_sum / is_count);
+                for (auto& s : is_samples) {
+                    char shape_str[64];
+                    int off = 0;
+                    off += snprintf(shape_str + off, sizeof(shape_str) - off, "[");
+                    for (int d = 0; d < s.ndim; ++d) {
+                        off += snprintf(shape_str + off, sizeof(shape_str) - off,
+                                        "%s%lld", d > 0 ? "," : "", (long long)s.shape[d]);
+                    }
+                    snprintf(shape_str + off, sizeof(shape_str) - off, "]");
+                    IMP_LOG_INFO(
+                        "  sample: %s.input_scale ndim=%d shape=%s numel=%zu first=%.6g",
+                        s.name.c_str(), s.ndim, shape_str, s.numel, s.first_val);
                 }
             } else {
                 IMP_LOG_INFO(


### PR DESCRIPTION
## Summary
- **Phase 1 of the NVFP4 SmoothQuant `input_scale` design memo closed for every NVFP4 checkpoint imp can reach today** — 6 local non-SmoothQuant + Mistral-Small-3.2-24B-Instruct-2506-NVFP4 (the one SmoothQuant outlier).
- All checkpoints ship `input_scale` as scalar (`numel=1`); Mistral's `recipe.yaml` carries an explicit `SmoothQuantModifier` mapping `[q_proj,k_proj,v_proj] → input_layernorm` + `[gate_proj,up_proj] → post_attention_layernorm` with `smoothing_strength=0.9`. That's **exactly** sub-case (b) from the design memo — `diag(1/s)` is migrated into the upstream RMSNorm weights at calibration time, which imp already loads + applies. Engine has nothing to do; `"intentionally NOT applied"` stance at `executor_pre_dequant.cu:431` is correct.
- The 2026-05-07 DIVIDE/MULTIPLY scalar-alpha refutation on Gemma-4-NVFP4 is now structurally explained: no SmoothQuant correction existed to apply because no SmoothQuant was calibrated. PR #78's long-context-drift workaround for Mistral-3.2-NVFP4 stays load-bearing, but its root cause is the NVFP4-noise-vs-FP16-act issue (separate roadmap concern, `memory/nvfp4_long_context_regression_2026_04_28.md`), not missing SmoothQuant absorption.
- Diagnostic patch in `weight_upload.cu` ships as the lasting deliverable: per-Linear `scalar=N per_channel=M` split + `ndim/shape/numel` sample logging under `diagnostics.audit_nvfp4_scales=true` (default off, zero perf delta). Future NVFP4 checkpoints with non-scalar `input_scale` would surface immediately at load time.

## Empirical evidence (three independent paths)
| Path | Mistral-3.2-NVFP4 result |
|---|---|
| `recipe.yaml` (declarative)              | `SmoothQuantModifier` with `input_layernorm` + `post_attention_layernorm` mappings |
| SafeTensors header range-fetch (16 MB/shard, no full download needed for the answer) | 280 × `input_scale (1,)` scalar; 80 × layernorm `(5120,)` weights as migration targets |
| C++ engine audit on local file (post-download cross-check) | `input_scale present in 280/280 Linears (scalar=280 per_channel=0)`, stats `min=12 max=8832 mean=2167` |

Local non-SmoothQuant corpus (6 models) was independently confirmed at 100% scalar (matrix in the findings memo).

## Files
- `docs/roadmap.md` — entry retired, retains the decision rationale + evidence summary
- `docs/superpowers/plans/2026-05-18-nvfp4-smoothquant-phase1-findings.md` — full Phase 1 findings (header scan tables, recipe.yaml excerpts, engine audit transcripts, sub-case decision table)
- `src/model/weight_upload.cu` — diagnostic enhancement only, gated to `audit=true`

## Test plan
- [x] `make build` (Docker, imp:test) — clean build
- [x] `imp-cli --set diagnostics.audit_nvfp4_scales=true` on Qwen3-8B-NVFP4-cortecs — 252/252 scalar reported, samples show `ndim=1 shape=[1] numel=1`
- [x] Same audit on Mistral-Small-3.2-24B-Instruct-2506-NVFP4 — 280/280 scalar reported, matches HF header scan
- [x] `make verify-fast` via pre-push hook — fast gtest filter PASS (perf/smoke gates SKIP because baseline GGUF models not in `$REPO/models/`)
- [x] Default-off behavior: no perf or semantic delta on production runs (`audit=false` path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)