### PR TITLE
refactor(handlers): lift 762-LOC SSE body out of stream_chat_response_

### DIFF
--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1560,6 +1560,9 @@ static void nonstream_chat_response_(
 // must outlive the SSE response (httplib invokes the chunked provider after
 // this function returns; ctx is a stack-local in handle_chat_completions
 // which keeps the request frame alive until the response is fully sent).
+static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
+                             std::shared_ptr<ServerRequest> server_req);
+
 static void stream_chat_response_(
     httplib::Response& res,
     ServerState& state,
@@ -1570,666 +1573,617 @@ static void stream_chat_response_(
     res.set_header("Cache-Control", "no-cache");
     res.set_header("Connection", "keep-alive");
 
-    std::string comp_id = ctx.req_id;
-    int64_t created = unix_timestamp();
+    ctx.comp_id = ctx.req_id;
+    ctx.created = unix_timestamp();
 
     res.set_chunked_content_provider(
         "text/event-stream",
-        [&state, server_req, comp_id, created,
-         max_tokens = ctx.params.max_tokens,
-         n_prompt_tokens = ctx.snap.n_prompt_tokens,
-         t_start = ctx.t_start,
-         stop_sequences = ctx.params.stop_sequences,
-         max_stop_len = ctx.params.max_stop_len,
-         req_logprobs = ctx.params.req_logprobs,
-         include_usage = ctx.params.include_usage,
-         enable_thinking = ctx.snap.enable_thinking,
-         has_tools = ctx.params.has_tools,
-         tpl_family = ctx.snap.tpl_family,
-         think_budget = ctx.params.think_budget,
-         snap_tok = ctx.snap.tok,
-         snap_have_template = ctx.snap.have_template,
-         snap_model_name = ctx.snap.model_name,
-         snap_is_think_model = ctx.snap.is_think_model,
-         snap_think_start_id = ctx.snap.think_start_id,
-         snap_think_end_id = ctx.snap.think_end_id,
-         snap_channel_open_id = ctx.snap.channel_open_id,
-         snap_channel_close_id = ctx.snap.channel_close_id,
-         snap_channel_newline_id = ctx.snap.channel_newline_id,
-         snap_stop_token_ids = ctx.snap.stop_token_ids,
-         log_skip = ctx.log_skip,
-         t_log_start = ctx.t_log_start,
-         log_endpoint = ctx.log_endpoint,
-         log_client_ip = ctx.log_client_ip,
-         log_raw_body = ctx.log_raw_body](size_t /*offset*/, httplib::DataSink& sink) -> bool {
-            // Active request ref for logprobs access
-            auto active_req = server_req->request;
+        [stream_ctx = ctx, &state, server_req](size_t /*offset*/, httplib::DataSink& sink) mutable -> bool {
+            return run_chat_stream_(sink, stream_ctx, state, server_req);
+        });
+}
 
-            // Pre-build SSE envelope templates for fast content/reasoning emission
-            SSEChunkWriter sse_writer(comp_id, created, snap_model_name);
 
-            // Send initial chunk with role
-            json role_delta = {{"role", "assistant"}};
-            std::string chunk = sse_chunk(comp_id, created, snap_model_name, role_delta, nullptr);
-            sink.write(chunk.data(), chunk.size());
+// Streaming chat response loop body. Extracted from the
+// res.set_chunked_content_provider() lambda in stream_chat_response_ so
+// the 760-LOC body is no longer a god-function nested four levels deep.
+// httplib calls the lambda repeatedly until it returns false; the lambda
+// just dispatches to this function. ctx is captured by value into the
+// lambda (so it survives stream_chat_response_'s return); state is
+// captured by reference (lives in the long-lived ServerState).
+static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
+                             std::shared_ptr<ServerRequest> server_req) {
+    // Local aliases so the body reads unchanged from its previous
+    // capture-list-based form. These were 30+ individual lambda captures
+    // before this refactor.
+    const std::string& comp_id          = ctx.comp_id;
+    int64_t            created          = ctx.created;
+    int                max_tokens       = ctx.params.max_tokens;
+    int                n_prompt_tokens  = ctx.snap.n_prompt_tokens;
+    auto               t_start          = ctx.t_start;
+    const auto&        stop_sequences   = ctx.params.stop_sequences;
+    int                max_stop_len     = ctx.params.max_stop_len;
+    int                req_logprobs     = ctx.params.req_logprobs;
+    bool               include_usage    = ctx.params.include_usage;
+    bool               enable_thinking  = ctx.snap.enable_thinking;
+    bool               has_tools        = ctx.params.has_tools;
+    auto               tpl_family       = ctx.snap.tpl_family;
+    float              think_budget     = ctx.params.think_budget;
+    auto               snap_tok         = ctx.snap.tok;
+    bool               snap_have_template = ctx.snap.have_template;
+    const std::string& snap_model_name  = ctx.snap.model_name;
+    bool               snap_is_think_model      = ctx.snap.is_think_model;
+    int                snap_think_start_id      = ctx.snap.think_start_id;
+    int                snap_think_end_id        = ctx.snap.think_end_id;
+    int                snap_channel_open_id     = ctx.snap.channel_open_id;
+    int                snap_channel_close_id    = ctx.snap.channel_close_id;
+    int                snap_channel_newline_id  = ctx.snap.channel_newline_id;
+    const auto&        snap_stop_token_ids      = ctx.snap.stop_token_ids;
+    bool               log_skip         = ctx.log_skip;
+    auto               t_log_start      = ctx.t_log_start;
+    const std::string& log_endpoint     = ctx.log_endpoint;
+    const std::string& log_client_ip    = ctx.log_client_ip;
+    const std::string& log_raw_body     = ctx.log_raw_body;
 
-            int n_output_tokens = 0;
-            const char* finish = nullptr;
-            double ttft_ms = 0.0;  // Time to first token
+    // Active request ref for logprobs access
+    auto active_req = server_req->request;
 
-            // Buffer for incomplete UTF-8 sequences across token boundaries
-            std::string utf8_buf;
+    // Pre-build SSE envelope templates for fast content/reasoning emission
+    SSEChunkWriter sse_writer(comp_id, created, snap_model_name);
 
-            // Buffered output for stop sequence matching in streaming mode.
-            // We hold back text until we're sure it doesn't contain a stop match.
-            std::string pending_text;
-            bool text_stop_matched = false;
+    // Send initial chunk with role
+    json role_delta = {{"role", "assistant"}};
+    std::string chunk = sse_chunk(comp_id, created, snap_model_name, role_delta, nullptr);
+    sink.write(chunk.data(), chunk.size());
 
-            // Tool call detection state machine for streaming
-            enum class ToolPhase { CONTENT, TAG_SCANNING, TOOL_CALL_BODY };
-            ToolPhase tool_phase = ToolPhase::CONTENT;
-            std::string tool_tag_buf;    // buffer for partial tag match
-            std::string tool_body_buf;   // buffer for tool call body
-            std::string tool_close_tag;  // expected closing tag
-            std::string tool_fn_name;    // Llama3: extracted function name from open tag
-            std::vector<ParsedToolCall> stream_tool_calls;
-            bool tool_calls_emitted = false;
-            // The full accumulated output (only used when has_tools, for fallback)
-            std::string full_output;
+    int n_output_tokens = 0;
+    const char* finish = nullptr;
+    double ttft_ms = 0.0;  // Time to first token
 
-            // Reasoning content extraction (DeepSeek format)
-            enum class ThinkPhase { SCAN, REASONING, CONTENT };
-            bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
-                                  snap_is_think_model);
-            ThinkPhase think_phase;
-            if (enable_thinking) {
-                think_phase = ThinkPhase::REASONING;  // <think> in prefill -> start reasoning
-            } else if (use_reasoning && think_budget > 0.0f) {
-                think_phase = ThinkPhase::SCAN;  // model decides whether to think
-            } else {
-                think_phase = ThinkPhase::CONTENT;  // no reasoning extraction
+    // Buffer for incomplete UTF-8 sequences across token boundaries
+    std::string utf8_buf;
+
+    // Buffered output for stop sequence matching in streaming mode.
+    // We hold back text until we're sure it doesn't contain a stop match.
+    std::string pending_text;
+    bool text_stop_matched = false;
+
+    // Tool call detection state machine for streaming
+    enum class ToolPhase { CONTENT, TAG_SCANNING, TOOL_CALL_BODY };
+    ToolPhase tool_phase = ToolPhase::CONTENT;
+    std::string tool_tag_buf;    // buffer for partial tag match
+    std::string tool_body_buf;   // buffer for tool call body
+    std::string tool_close_tag;  // expected closing tag
+    std::string tool_fn_name;    // Llama3: extracted function name from open tag
+    std::vector<ParsedToolCall> stream_tool_calls;
+    bool tool_calls_emitted = false;
+    // The full accumulated output (only used when has_tools, for fallback)
+    std::string full_output;
+
+    // Reasoning content extraction (DeepSeek format)
+    enum class ThinkPhase { SCAN, REASONING, CONTENT };
+    bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
+                          snap_is_think_model);
+    ThinkPhase think_phase;
+    if (enable_thinking) {
+        think_phase = ThinkPhase::REASONING;  // <think> in prefill -> start reasoning
+    } else if (use_reasoning && think_budget > 0.0f) {
+        think_phase = ThinkPhase::SCAN;  // model decides whether to think
+    } else {
+        think_phase = ThinkPhase::CONTENT;  // no reasoning extraction
+    }
+    std::string reasoning_utf8_buf;
+    std::string think_scan_buf;
+    int think_scan_count = 0;
+    int n_reasoning_tokens = 0;
+    bool content_started = (think_phase == ThinkPhase::CONTENT);
+    int think_reentries = 0;
+    const int kMaxThinkReentries = 1;
+    const int kThinkScanLimit = 8;
+
+    // Gemma-4 channel filter state: when we see <|channel> or <channel|>,
+    // skip tokens until the next newline (the channel header).
+    bool channel_header_active = false;
+
+    // Helper: emit reasoning_content SSE chunk
+    auto emit_reasoning = [&](const std::string& text) -> bool {
+        if (text.empty())
+            return true;
+        return sse_writer.write_reasoning(text, sink);
+    };
+
+    // Helper: flush confirmed text up to a byte position
+    auto flush_text = [&](size_t up_to) {
+        if (up_to == 0)
+            return true;
+        bool ok = sse_writer.write_content(pending_text.data(), up_to, sink);
+        pending_text.erase(0, up_to);
+        return ok;
+    };
+
+    auto request_start = std::chrono::steady_clock::now();
+    for (;;) {
+        // Check client disconnect
+        if (!sink.is_writable()) {
+            server_req->cancel();
+            finish = "cancelled";
+            break;
+        }
+
+        // Check request timeout
+        if (state.request_timeout > 0) {
+            auto elapsed = std::chrono::steady_clock::now() - request_start;
+            if (elapsed > std::chrono::seconds(state.request_timeout)) {
+                server_req->cancel();
+                finish = "length";
+                break;
             }
-            std::string reasoning_utf8_buf;
-            std::string think_scan_buf;
-            int think_scan_count = 0;
-            int n_reasoning_tokens = 0;
-            bool content_started = (think_phase == ThinkPhase::CONTENT);
-            int think_reentries = 0;
-            const int kMaxThinkReentries = 1;
-            const int kThinkScanLimit = 8;
+        }
 
-            // Gemma-4 channel filter state: when we see <|channel> or <channel|>,
-            // skip tokens until the next newline (the channel header).
-            bool channel_header_active = false;
+        // Read next token from the batching engine (with timeout)
+        TokenEvent evt;
+        if (!server_req->pop_token(evt)) {
+            continue;  // timeout — loop back to check disconnect/timeout
+        }
 
-            // Helper: emit reasoning_content SSE chunk
-            auto emit_reasoning = [&](const std::string& text) -> bool {
-                if (text.empty())
-                    return true;
-                return sse_writer.write_reasoning(text, sink);
-            };
+        if (evt.token_id < 0) {
+            // Finish event with no token
+            finish = evt.finish_reason ? evt.finish_reason : "stop";
+            break;
+        }
 
-            // Helper: flush confirmed text up to a byte position
-            auto flush_text = [&](size_t up_to) {
-                if (up_to == 0)
-                    return true;
-                bool ok = sse_writer.write_content(pending_text.data(), up_to, sink);
-                pending_text.erase(0, up_to);
-                return ok;
-            };
+        int32_t token = evt.token_id;
 
-            auto request_start = std::chrono::steady_clock::now();
+        // Silently drop structural stop tokens that slipped through.
+        // The engine's think-block implicit-close (Engine::should_stop)
+        // passes ONE EOS-like token through to recover from empty
+        // thinking. That token must not appear as user-visible content
+        // (would render as "<|im_end|>" / "<|endoftext|>" in chat).
+        if (!evt.is_last) {
+            bool is_structural_stop = (token == snap_tok->eos_id());
+            if (!is_structural_stop && snap_have_template) {
+                for (int32_t stop_id : snap_stop_token_ids) {
+                    if (token == stop_id) {
+                        is_structural_stop = true;
+                        break;
+                    }
+                }
+            }
+            if (is_structural_stop)
+                continue;
+        }
+
+        // Check stop conditions (EOS/stop tokens already detected by engine)
+        if (evt.is_last) {
+            // The engine marked this as the last token.
+            // Don't emit EOS/stop tokens — they're structural, not content.
+            if (token == snap_tok->eos_id()) {
+                finish = evt.finish_reason ? evt.finish_reason : "stop";
+                break;
+            }
+            bool is_stop = false;
+            if (snap_have_template) {
+                for (int32_t stop_id : snap_stop_token_ids) {
+                    if (token == stop_id) {
+                        is_stop = true;
+                        break;
+                    }
+                }
+            }
+            if (is_stop) {
+                finish = evt.finish_reason ? evt.finish_reason : "stop";
+                break;
+            }
+            // Not a stop token — emit it, then finish after this iteration
+            finish = evt.finish_reason ? evt.finish_reason : "length";
+        }
+
+        n_output_tokens++;
+        if (n_output_tokens == 1) {
+            auto t_first = std::chrono::high_resolution_clock::now();
+            ttft_ms = std::chrono::duration<double, std::milli>(t_first - t_start).count();
+        }
+        std::string piece = snap_tok->decode_token(token);
+
+        // Gemma-4 channel filter: strip "<|channel>NAME\n" structural
+        // headers from the content stream. `<channel|>` is the
+        // channel-switch marker — strip the token but do NOT enter
+        // the scan-until-newline mode, because Q5_K_M sometimes
+        // emits the final answer directly after it with no newline
+        // (observed: "<|channel>thought\n<channel|>5 + 3 = 8").
+        if (snap_channel_open_id >= 0) {
+            if (channel_header_active) {
+                if (token == snap_channel_newline_id ||
+                    (!piece.empty() && piece.back() == '\n')) {
+                    channel_header_active = false;
+                }
+                continue;
+            }
+            if (token == snap_channel_open_id) {
+                channel_header_active = true;
+                continue;
+            }
+            if (token == snap_channel_close_id) {
+                // Drop just the marker; the next token is body.
+                continue;
+            }
+        }
+
+        // Reasoning content extraction (DeepSeek format)
+        if (think_phase == ThinkPhase::SCAN) {
+            if (token == snap_think_start_id) {
+                think_phase = ThinkPhase::REASONING;
+                n_reasoning_tokens++;
+                continue;
+            }
+            think_scan_buf += piece;
+            think_scan_count++;
+            if (think_scan_buf.find("<think>") != std::string::npos) {
+                think_phase = ThinkPhase::REASONING;
+                n_reasoning_tokens += think_scan_count;
+                auto pos = think_scan_buf.find("<think>");
+                std::string after = think_scan_buf.substr(pos + 7);
+                think_scan_buf.clear();
+                if (!after.empty())
+                    reasoning_utf8_buf += after;
+                continue;
+            }
+            if (think_scan_count == 1 && piece.empty()) {
+                think_phase = ThinkPhase::REASONING;
+                n_reasoning_tokens++;
+                continue;
+            }
+            if (think_scan_count >= kThinkScanLimit) {
+                think_phase = ThinkPhase::CONTENT;
+                piece = think_scan_buf;
+                think_scan_buf.clear();
+            } else {
+                continue;
+            }
+        }
+
+        if (think_phase == ThinkPhase::REASONING) {
+            n_reasoning_tokens++;
+            // No forced </think> injection — let the model decide when
+            // to stop thinking (like llama.cpp).  Forcing </think> via
+            // token replacement corrupts the KV cache: the model sees
+            // the original token, not </think>, so it keeps reasoning
+            // while imp treats subsequent tokens as content.
+            if (token == snap_think_end_id) {
+                if (!emit_reasoning(reasoning_utf8_buf))
+                    return false;
+                reasoning_utf8_buf.clear();
+                think_phase = ThinkPhase::CONTENT;
+                continue;
+            }
+            // Skip duplicate <think> tokens while already reasoning
+            if (token == snap_think_start_id)
+                continue;
+            reasoning_utf8_buf += piece;
+            // Strip <think> text that appears via multi-token encoding
             for (;;) {
-                // Check client disconnect
-                if (!sink.is_writable()) {
-                    server_req->cancel();
-                    finish = "cancelled";
+                auto tp = reasoning_utf8_buf.find("<think>");
+                if (tp == std::string::npos)
                     break;
+                reasoning_utf8_buf.erase(tp, 7);
+            }
+            auto end_pos = reasoning_utf8_buf.find("</think>");
+            if (end_pos != std::string::npos) {
+                std::string before = reasoning_utf8_buf.substr(0, end_pos);
+                if (!emit_reasoning(before))
+                    return false;
+                think_phase = ThinkPhase::CONTENT;
+                std::string after = reasoning_utf8_buf.substr(end_pos + 8);
+                reasoning_utf8_buf.clear();
+                auto start = after.find_first_not_of("\n\r\t ");
+                if (start != std::string::npos) {
+                    piece = after.substr(start);
+                } else {
+                    continue;
                 }
-
-                // Check request timeout
-                if (state.request_timeout > 0) {
-                    auto elapsed = std::chrono::steady_clock::now() - request_start;
-                    if (elapsed > std::chrono::seconds(state.request_timeout)) {
-                        server_req->cancel();
-                        finish = "length";
-                        break;
+            } else {
+                // Keep a tail overlap so "</think>" spanning multiple
+                // tokens can still be detected on the next iteration.
+                // "</think>" is 8 bytes; we need at most 7 bytes of
+                // overlap to catch any partial match at the boundary.
+                constexpr size_t kOverlap = 7;
+                size_t complete = utf8_complete_len(reasoning_utf8_buf);
+                if (complete > kOverlap) {
+                    size_t emit_end = complete - kOverlap;
+                    // Walk emit_end back to a UTF-8 codepoint boundary —
+                    // the 7-byte overlap is geared to literal "</think>"
+                    // bytes, not codepoints, so it can land inside a
+                    // multibyte char (German umlauts, CJK, emoji), which
+                    // emits the lead byte alone and turns the trailing
+                    // continuation byte into a U+FFFD on the next flush
+                    // — visible to the user as "f��r" instead of "für".
+                    while (emit_end > 0 &&
+                           (static_cast<unsigned char>(reasoning_utf8_buf[emit_end]) & 0xC0) ==
+                               0x80) {
+                        --emit_end;
                     }
-                }
-
-                // Read next token from the batching engine (with timeout)
-                TokenEvent evt;
-                if (!server_req->pop_token(evt)) {
-                    continue;  // timeout — loop back to check disconnect/timeout
-                }
-
-                if (evt.token_id < 0) {
-                    // Finish event with no token
-                    finish = evt.finish_reason ? evt.finish_reason : "stop";
-                    break;
-                }
-
-                int32_t token = evt.token_id;
-
-                // Silently drop structural stop tokens that slipped through.
-                // The engine's think-block implicit-close (Engine::should_stop)
-                // passes ONE EOS-like token through to recover from empty
-                // thinking. That token must not appear as user-visible content
-                // (would render as "<|im_end|>" / "<|endoftext|>" in chat).
-                if (!evt.is_last) {
-                    bool is_structural_stop = (token == snap_tok->eos_id());
-                    if (!is_structural_stop && snap_have_template) {
-                        for (int32_t stop_id : snap_stop_token_ids) {
-                            if (token == stop_id) {
-                                is_structural_stop = true;
-                                break;
-                            }
-                        }
-                    }
-                    if (is_structural_stop)
-                        continue;
-                }
-
-                // Check stop conditions (EOS/stop tokens already detected by engine)
-                if (evt.is_last) {
-                    // The engine marked this as the last token.
-                    // Don't emit EOS/stop tokens — they're structural, not content.
-                    if (token == snap_tok->eos_id()) {
-                        finish = evt.finish_reason ? evt.finish_reason : "stop";
-                        break;
-                    }
-                    bool is_stop = false;
-                    if (snap_have_template) {
-                        for (int32_t stop_id : snap_stop_token_ids) {
-                            if (token == stop_id) {
-                                is_stop = true;
-                                break;
-                            }
-                        }
-                    }
-                    if (is_stop) {
-                        finish = evt.finish_reason ? evt.finish_reason : "stop";
-                        break;
-                    }
-                    // Not a stop token — emit it, then finish after this iteration
-                    finish = evt.finish_reason ? evt.finish_reason : "length";
-                }
-
-                n_output_tokens++;
-                if (n_output_tokens == 1) {
-                    auto t_first = std::chrono::high_resolution_clock::now();
-                    ttft_ms = std::chrono::duration<double, std::milli>(t_first - t_start).count();
-                }
-                std::string piece = snap_tok->decode_token(token);
-
-                // Gemma-4 channel filter: strip "<|channel>NAME\n" structural
-                // headers from the content stream. `<channel|>` is the
-                // channel-switch marker — strip the token but do NOT enter
-                // the scan-until-newline mode, because Q5_K_M sometimes
-                // emits the final answer directly after it with no newline
-                // (observed: "<|channel>thought\n<channel|>5 + 3 = 8").
-                if (snap_channel_open_id >= 0) {
-                    if (channel_header_active) {
-                        if (token == snap_channel_newline_id ||
-                            (!piece.empty() && piece.back() == '\n')) {
-                            channel_header_active = false;
-                        }
-                        continue;
-                    }
-                    if (token == snap_channel_open_id) {
-                        channel_header_active = true;
-                        continue;
-                    }
-                    if (token == snap_channel_close_id) {
-                        // Drop just the marker; the next token is body.
-                        continue;
+                    if (emit_end > 0) {
+                        std::string to_emit = reasoning_utf8_buf.substr(0, emit_end);
+                        reasoning_utf8_buf = reasoning_utf8_buf.substr(emit_end);
+                        if (!emit_reasoning(to_emit))
+                            return false;
                     }
                 }
+                continue;
+            }
+        }
 
-                // Reasoning content extraction (DeepSeek format)
-                if (think_phase == ThinkPhase::SCAN) {
-                    if (token == snap_think_start_id) {
-                        think_phase = ThinkPhase::REASONING;
-                        n_reasoning_tokens++;
-                        continue;
-                    }
-                    think_scan_buf += piece;
-                    think_scan_count++;
-                    if (think_scan_buf.find("<think>") != std::string::npos) {
-                        think_phase = ThinkPhase::REASONING;
-                        n_reasoning_tokens += think_scan_count;
-                        auto pos = think_scan_buf.find("<think>");
-                        std::string after = think_scan_buf.substr(pos + 7);
-                        think_scan_buf.clear();
-                        if (!after.empty())
-                            reasoning_utf8_buf += after;
-                        continue;
-                    }
-                    if (think_scan_count == 1 && piece.empty()) {
-                        think_phase = ThinkPhase::REASONING;
-                        n_reasoning_tokens++;
-                        continue;
-                    }
-                    if (think_scan_count >= kThinkScanLimit) {
-                        think_phase = ThinkPhase::CONTENT;
-                        piece = think_scan_buf;
-                        think_scan_buf.clear();
-                    } else {
-                        continue;
-                    }
-                }
+        // Strip leading whitespace after </think> → CONTENT transition
+        // (matches extract_reasoning behavior in non-streaming path)
+        if (!content_started && think_phase == ThinkPhase::CONTENT) {
+            auto ns = piece.find_first_not_of("\n\r\t ");
+            if (ns == std::string::npos)
+                continue;  // all whitespace
+            piece = piece.substr(ns);
+            content_started = true;
+        }
 
-                if (think_phase == ThinkPhase::REASONING) {
+        // CONTENT phase: handle stray think tokens from confused models
+        if (use_reasoning) {
+            if (token == snap_think_start_id) {
+                if (think_reentries < kMaxThinkReentries) {
+                    think_phase = ThinkPhase::REASONING;
                     n_reasoning_tokens++;
-                    // No forced </think> injection — let the model decide when
-                    // to stop thinking (like llama.cpp).  Forcing </think> via
-                    // token replacement corrupts the KV cache: the model sees
-                    // the original token, not </think>, so it keeps reasoning
-                    // while imp treats subsequent tokens as content.
-                    if (token == snap_think_end_id) {
-                        if (!emit_reasoning(reasoning_utf8_buf))
-                            return false;
-                        reasoning_utf8_buf.clear();
-                        think_phase = ThinkPhase::CONTENT;
-                        continue;
-                    }
-                    // Skip duplicate <think> tokens while already reasoning
-                    if (token == snap_think_start_id)
-                        continue;
-                    reasoning_utf8_buf += piece;
-                    // Strip <think> text that appears via multi-token encoding
-                    for (;;) {
-                        auto tp = reasoning_utf8_buf.find("<think>");
-                        if (tp == std::string::npos)
-                            break;
-                        reasoning_utf8_buf.erase(tp, 7);
-                    }
-                    auto end_pos = reasoning_utf8_buf.find("</think>");
-                    if (end_pos != std::string::npos) {
-                        std::string before = reasoning_utf8_buf.substr(0, end_pos);
-                        if (!emit_reasoning(before))
-                            return false;
-                        think_phase = ThinkPhase::CONTENT;
-                        std::string after = reasoning_utf8_buf.substr(end_pos + 8);
-                        reasoning_utf8_buf.clear();
-                        auto start = after.find_first_not_of("\n\r\t ");
-                        if (start != std::string::npos) {
-                            piece = after.substr(start);
-                        } else {
-                            continue;
-                        }
+                    think_reentries++;
+                }
+                continue;  // always strip <think> from content
+            }
+            if (token == snap_think_end_id) {
+                n_reasoning_tokens++;
+                continue;
+            }
+            // Strip text-level think tags from content piece
+            for (;;) {
+                auto p = piece.find("<think>");
+                if (p != std::string::npos) {
+                    piece.erase(p, 7);
+                    continue;
+                }
+                p = piece.find("</think>");
+                if (p != std::string::npos) {
+                    piece.erase(p, 8);
+                    continue;
+                }
+                break;
+            }
+            if (piece.empty())
+                continue;
+        }
+
+        // CONTENT phase — with tool call tag detection
+        if (has_tools)
+            full_output += piece;
+
+        // Tool call state machine (only active when tools are present)
+        if (has_tools && tool_phase == ToolPhase::TOOL_CALL_BODY) {
+            tool_body_buf += piece;
+            // Check for close tag
+            auto close_pos = tool_body_buf.find(tool_close_tag);
+            if (close_pos != std::string::npos) {
+                std::string body = tool_body_buf.substr(0, close_pos);
+                auto bs = body.find_first_not_of("\n\r\t ");
+                auto be = body.find_last_not_of("\n\r\t ");
+                if (bs != std::string::npos && be != std::string::npos)
+                    body = body.substr(bs, be - bs + 1);
+
+                // Parse and emit tool call
+                try {
+                    json j = json::parse(body);
+                    ParsedToolCall tc;
+                    tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
+                    if (tpl_family == imp::ChatTemplateFamily::LLAMA3) {
+                        tc.name = tool_fn_name;
+                        tc.arguments = j.dump();
                     } else {
-                        // Keep a tail overlap so "</think>" spanning multiple
-                        // tokens can still be detected on the next iteration.
-                        // "</think>" is 8 bytes; we need at most 7 bytes of
-                        // overlap to catch any partial match at the boundary.
-                        constexpr size_t kOverlap = 7;
-                        size_t complete = utf8_complete_len(reasoning_utf8_buf);
-                        if (complete > kOverlap) {
-                            size_t emit_end = complete - kOverlap;
-                            // Walk emit_end back to a UTF-8 codepoint boundary —
-                            // the 7-byte overlap is geared to literal "</think>"
-                            // bytes, not codepoints, so it can land inside a
-                            // multibyte char (German umlauts, CJK, emoji), which
-                            // emits the lead byte alone and turns the trailing
-                            // continuation byte into a U+FFFD on the next flush
-                            // — visible to the user as "f��r" instead of "für".
-                            while (emit_end > 0 &&
-                                   (static_cast<unsigned char>(reasoning_utf8_buf[emit_end]) & 0xC0) ==
-                                       0x80) {
-                                --emit_end;
-                            }
-                            if (emit_end > 0) {
-                                std::string to_emit = reasoning_utf8_buf.substr(0, emit_end);
-                                reasoning_utf8_buf = reasoning_utf8_buf.substr(emit_end);
-                                if (!emit_reasoning(to_emit))
-                                    return false;
-                            }
-                        }
-                        continue;
-                    }
-                }
-
-                // Strip leading whitespace after </think> → CONTENT transition
-                // (matches extract_reasoning behavior in non-streaming path)
-                if (!content_started && think_phase == ThinkPhase::CONTENT) {
-                    auto ns = piece.find_first_not_of("\n\r\t ");
-                    if (ns == std::string::npos)
-                        continue;  // all whitespace
-                    piece = piece.substr(ns);
-                    content_started = true;
-                }
-
-                // CONTENT phase: handle stray think tokens from confused models
-                if (use_reasoning) {
-                    if (token == snap_think_start_id) {
-                        if (think_reentries < kMaxThinkReentries) {
-                            think_phase = ThinkPhase::REASONING;
-                            n_reasoning_tokens++;
-                            think_reentries++;
-                        }
-                        continue;  // always strip <think> from content
-                    }
-                    if (token == snap_think_end_id) {
-                        n_reasoning_tokens++;
-                        continue;
-                    }
-                    // Strip text-level think tags from content piece
-                    for (;;) {
-                        auto p = piece.find("<think>");
-                        if (p != std::string::npos) {
-                            piece.erase(p, 7);
-                            continue;
-                        }
-                        p = piece.find("</think>");
-                        if (p != std::string::npos) {
-                            piece.erase(p, 8);
-                            continue;
-                        }
-                        break;
-                    }
-                    if (piece.empty())
-                        continue;
-                }
-
-                // CONTENT phase — with tool call tag detection
-                if (has_tools)
-                    full_output += piece;
-
-                // Tool call state machine (only active when tools are present)
-                if (has_tools && tool_phase == ToolPhase::TOOL_CALL_BODY) {
-                    tool_body_buf += piece;
-                    // Check for close tag
-                    auto close_pos = tool_body_buf.find(tool_close_tag);
-                    if (close_pos != std::string::npos) {
-                        std::string body = tool_body_buf.substr(0, close_pos);
-                        auto bs = body.find_first_not_of("\n\r\t ");
-                        auto be = body.find_last_not_of("\n\r\t ");
-                        if (bs != std::string::npos && be != std::string::npos)
-                            body = body.substr(bs, be - bs + 1);
-
-                        // Parse and emit tool call
-                        try {
-                            json j = json::parse(body);
-                            ParsedToolCall tc;
-                            tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
-                            if (tpl_family == imp::ChatTemplateFamily::LLAMA3) {
-                                tc.name = tool_fn_name;
-                                tc.arguments = j.dump();
-                            } else {
-                                tc.name = j.value("name", "");
-                                if (j.contains("arguments")) {
-                                    tc.arguments = j["arguments"].dump();
-                                } else {
-                                    json args = j;
-                                    args.erase("name");
-                                    tc.arguments = args.dump();
-                                }
-                            }
-                            if (!tc.name.empty()) {
-                                int idx = static_cast<int>(stream_tool_calls.size());
-                                // Emit name chunk
-                                json name_delta = {
-                                    {"tool_calls",
-                                     json::array(
-                                         {{{"index", idx},
-                                           {"id", tc.id},
-                                           {"type", "function"},
-                                           {"function", {{"name", tc.name}, {"arguments", ""}}}}})}};
-                                std::string sse = sse_chunk(comp_id, created, snap_model_name, name_delta,
-                                                            nullptr);
-                                sink.write(sse.data(), sse.size());
-
-                                // Emit arguments chunk
-                                json args_delta = {
-                                    {"tool_calls",
-                                     json::array({{{"index", idx},
-                                                   {"function", {{"arguments", tc.arguments}}}}})}};
-                                sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
-                                sink.write(sse.data(), sse.size());
-
-                                stream_tool_calls.push_back(std::move(tc));
-                                tool_calls_emitted = true;
-                            }
-                        } catch (...) {
-                            // Malformed JSON — skip
-                        }
-
-                        // Check for more content after close tag
-                        std::string after = tool_body_buf.substr(close_pos + tool_close_tag.size());
-                        tool_body_buf.clear();
-                        tool_phase = ToolPhase::CONTENT;
-                        // If there's remaining text, it might contain more tool calls
-                        if (!after.empty()) {
-                            auto ws = after.find_first_not_of("\n\r\t ");
-                            if (ws != std::string::npos) {
-                                piece = after.substr(ws);
-                                // Fall through to CONTENT handling below
-                            } else {
-                                continue;
-                            }
+                        tc.name = j.value("name", "");
+                        if (j.contains("arguments")) {
+                            tc.arguments = j["arguments"].dump();
                         } else {
-                            continue;
+                            json args = j;
+                            args.erase("name");
+                            tc.arguments = args.dump();
                         }
+                    }
+                    if (!tc.name.empty()) {
+                        int idx = static_cast<int>(stream_tool_calls.size());
+                        // Emit name chunk
+                        json name_delta = {
+                            {"tool_calls",
+                             json::array(
+                                 {{{"index", idx},
+                                   {"id", tc.id},
+                                   {"type", "function"},
+                                   {"function", {{"name", tc.name}, {"arguments", ""}}}}})}};
+                        std::string sse = sse_chunk(comp_id, created, snap_model_name, name_delta,
+                                                    nullptr);
+                        sink.write(sse.data(), sse.size());
+
+                        // Emit arguments chunk
+                        json args_delta = {
+                            {"tool_calls",
+                             json::array({{{"index", idx},
+                                           {"function", {{"arguments", tc.arguments}}}}})}};
+                        sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
+                        sink.write(sse.data(), sse.size());
+
+                        stream_tool_calls.push_back(std::move(tc));
+                        tool_calls_emitted = true;
+                    }
+                } catch (...) {
+                    // Malformed JSON — skip
+                }
+
+                // Check for more content after close tag
+                std::string after = tool_body_buf.substr(close_pos + tool_close_tag.size());
+                tool_body_buf.clear();
+                tool_phase = ToolPhase::CONTENT;
+                // If there's remaining text, it might contain more tool calls
+                if (!after.empty()) {
+                    auto ws = after.find_first_not_of("\n\r\t ");
+                    if (ws != std::string::npos) {
+                        piece = after.substr(ws);
+                        // Fall through to CONTENT handling below
                     } else {
-                        continue;  // Still collecting body
-                    }
-                }
-
-                if (has_tools && tool_phase == ToolPhase::TAG_SCANNING) {
-                    tool_tag_buf += piece;
-                    // ChatML: check for <tool_call>
-                    if (tpl_family != imp::ChatTemplateFamily::LLAMA3) {
-                        if (tool_tag_buf.size() >= 11) {  // len("<tool_call>")
-                            if (tool_tag_buf.find("<tool_call>") != std::string::npos) {
-                                auto pos = tool_tag_buf.find("<tool_call>");
-                                // Flush content before the tag
-                                std::string before = tool_tag_buf.substr(0, pos);
-                                if (!before.empty()) {
-                                    json cd = {{"content", before}};
-                                    std::string sse = sse_chunk(comp_id, created, snap_model_name, cd,
-                                                                nullptr);
-                                    sink.write(sse.data(), sse.size());
-                                }
-                                tool_body_buf = tool_tag_buf.substr(pos + 11);
-                                tool_close_tag = "</tool_call>";
-                                tool_tag_buf.clear();
-                                tool_phase = ToolPhase::TOOL_CALL_BODY;
-                                continue;
-                            }
-                            // Check if it's definitely not a tool_call tag
-                            if (tool_tag_buf.find("<tool_call") == std::string::npos &&
-                                tool_tag_buf.find("<tool_c") == std::string::npos &&
-                                tool_tag_buf.find("<tool_") == std::string::npos &&
-                                tool_tag_buf.find("<tool") == std::string::npos &&
-                                tool_tag_buf.find("<too") == std::string::npos &&
-                                tool_tag_buf.find("<to") == std::string::npos &&
-                                tool_tag_buf.find("<t") == std::string::npos) {
-                                // Not a tool tag — flush as content
-                                piece = tool_tag_buf;
-                                tool_tag_buf.clear();
-                                tool_phase = ToolPhase::CONTENT;
-                                // Fall through to content emission
-                            } else {
-                                continue;  // Still scanning
-                            }
-                        } else {
-                            // Check partial match
-                            const char* tc_tag = "<tool_call>";
-                            bool could_match = true;
-                            for (size_t ci = 0; ci < tool_tag_buf.size() && ci < 11; ci++) {
-                                if (tool_tag_buf[ci] != tc_tag[ci]) {
-                                    could_match = false;
-                                    break;
-                                }
-                            }
-                            if (!could_match) {
-                                piece = tool_tag_buf;
-                                tool_tag_buf.clear();
-                                tool_phase = ToolPhase::CONTENT;
-                            } else {
-                                continue;  // Still matching prefix
-                            }
-                        }
-                    } else {
-                        // Llama3: check for <function=
-                        if (tool_tag_buf.size() >= 10) {  // len("<function=")
-                            auto fn_pos = tool_tag_buf.find("<function=");
-                            if (fn_pos != std::string::npos) {
-                                auto gt = tool_tag_buf.find('>', fn_pos + 10);
-                                if (gt != std::string::npos) {
-                                    std::string before = tool_tag_buf.substr(0, fn_pos);
-                                    if (!before.empty()) {
-                                        json cd = {{"content", before}};
-                                        std::string sse = sse_chunk(comp_id, created, snap_model_name, cd,
-                                                                    nullptr);
-                                        sink.write(sse.data(), sse.size());
-                                    }
-                                    tool_fn_name = tool_tag_buf.substr(fn_pos + 10, gt - (fn_pos + 10));
-                                    tool_body_buf = tool_tag_buf.substr(gt + 1);
-                                    tool_close_tag = "</function>";
-                                    tool_tag_buf.clear();
-                                    tool_phase = ToolPhase::TOOL_CALL_BODY;
-                                    continue;
-                                } else {
-                                    continue;  // Still scanning for >
-                                }
-                            }
-                            // Check prefix match
-                            const char* fn_tag = "<function=";
-                            bool could_match = true;
-                            for (size_t ci = 0; ci < tool_tag_buf.size() && ci < 10; ci++) {
-                                if (tool_tag_buf[ci] != fn_tag[ci]) {
-                                    could_match = false;
-                                    break;
-                                }
-                            }
-                            if (!could_match) {
-                                piece = tool_tag_buf;
-                                tool_tag_buf.clear();
-                                tool_phase = ToolPhase::CONTENT;
-                            } else {
-                                continue;
-                            }
-                        } else {
-                            const char* fn_tag = "<function=";
-                            bool could_match = true;
-                            for (size_t ci = 0; ci < tool_tag_buf.size() && ci < 10; ci++) {
-                                if (tool_tag_buf[ci] != fn_tag[ci]) {
-                                    could_match = false;
-                                    break;
-                                }
-                            }
-                            if (!could_match) {
-                                piece = tool_tag_buf;
-                                tool_tag_buf.clear();
-                                tool_phase = ToolPhase::CONTENT;
-                            } else {
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                // In CONTENT phase, check for start of tool call tag
-                if (has_tools && tool_phase == ToolPhase::CONTENT) {
-                    // Look for < that might start a tool call tag
-                    size_t lt_pos = piece.find('<');
-                    if (lt_pos != std::string::npos) {
-                        // Emit everything before the <
-                        if (lt_pos > 0) {
-                            std::string before = piece.substr(0, lt_pos);
-                            if (stop_sequences.empty()) {
-                                utf8_buf += before;
-                            } else {
-                                pending_text += before;
-                            }
-                        }
-                        // Start tag scanning with the < and everything after
-                        tool_tag_buf = piece.substr(lt_pos);
-                        tool_phase = ToolPhase::TAG_SCANNING;
-                        // Flush any buffered content before entering tag scan
-                        if (stop_sequences.empty() && !utf8_buf.empty()) {
-                            size_t complete = utf8_complete_len(utf8_buf);
-                            if (complete > 0) {
-                                if (!sse_writer.write_content(utf8_buf.data(), complete, sink))
-                                    return false;
-                                utf8_buf.erase(0, complete);
-                            }
-                        } else if (!stop_sequences.empty()) {
-                            bool stop_found = false;
-                            for (const auto& stop : stop_sequences) {
-                                auto pos = pending_text.find(stop);
-                                if (pos != std::string::npos) {
-                                    if (!flush_text(pos))
-                                        return false;
-                                    stop_found = true;
-                                    break;
-                                }
-                            }
-                            if (stop_found) {
-                                text_stop_matched = true;
-                                finish = "stop";
-                                break;
-                            }
-                            if (pending_text.size() > max_stop_len) {
-                                size_t safe = pending_text.size() - max_stop_len + 1;
-                                if (!flush_text(safe))
-                                    return false;
-                            }
-                        }
                         continue;
-                    }
-                }
-
-                // Normal content emission (no tool tag detected)
-                if (stop_sequences.empty()) {
-                    // No stop sequences: stream directly (with UTF-8 buffering)
-                    utf8_buf += piece;
-                    size_t complete = utf8_complete_len(utf8_buf);
-                    if (complete > 0) {
-                        if (req_logprobs && active_req) {
-                            // Logprobs path: fall back to sse_chunk (rare)
-                            std::string to_emit = utf8_buf.substr(0, complete);
-                            utf8_buf.erase(0, complete);
-                            json content_delta = {{"content", to_emit}};
-                            json lp_chunk = nullptr;
-                            size_t lp_idx = n_output_tokens - 1;
-                            if (lp_idx < active_req->output_logprobs.size()) {
-                                const auto& lp = active_req->output_logprobs[lp_idx];
-                                json top_arr = json::array();
-                                for (const auto& t : lp.top) {
-                                    top_arr.push_back({{"token", safe_token_json(t.text)},
-                                                       {"logprob", t.logprob},
-                                                       {"bytes", token_bytes_json(t.text)}});
-                                }
-                                lp_chunk = {
-                                    {"content", json::array({{{"token", safe_token_json(lp.text)},
-                                                              {"logprob", lp.logprob},
-                                                              {"bytes", token_bytes_json(lp.text)},
-                                                              {"top_logprobs", top_arr}}})}};
-                            }
-                            std::string chunk = sse_chunk(comp_id, created, snap_model_name,
-                                                          content_delta, nullptr, lp_chunk);
-                            if (!sink.write(chunk.data(), chunk.size()))
-                                return false;
-                        } else {
-                            // Fast path: pre-formatted template
-                            if (!sse_writer.write_content(utf8_buf.data(), complete, sink))
-                                return false;
-                            utf8_buf.erase(0, complete);
-                        }
                     }
                 } else {
-                    // Buffer text and check for stop matches
-                    pending_text += piece;
+                    continue;
+                }
+            } else {
+                continue;  // Still collecting body
+            }
+        }
 
-                    // Check for complete stop match
+        if (has_tools && tool_phase == ToolPhase::TAG_SCANNING) {
+            tool_tag_buf += piece;
+            // ChatML: check for <tool_call>
+            if (tpl_family != imp::ChatTemplateFamily::LLAMA3) {
+                if (tool_tag_buf.size() >= 11) {  // len("<tool_call>")
+                    if (tool_tag_buf.find("<tool_call>") != std::string::npos) {
+                        auto pos = tool_tag_buf.find("<tool_call>");
+                        // Flush content before the tag
+                        std::string before = tool_tag_buf.substr(0, pos);
+                        if (!before.empty()) {
+                            json cd = {{"content", before}};
+                            std::string sse = sse_chunk(comp_id, created, snap_model_name, cd,
+                                                        nullptr);
+                            sink.write(sse.data(), sse.size());
+                        }
+                        tool_body_buf = tool_tag_buf.substr(pos + 11);
+                        tool_close_tag = "</tool_call>";
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::TOOL_CALL_BODY;
+                        continue;
+                    }
+                    // Check if it's definitely not a tool_call tag
+                    if (tool_tag_buf.find("<tool_call") == std::string::npos &&
+                        tool_tag_buf.find("<tool_c") == std::string::npos &&
+                        tool_tag_buf.find("<tool_") == std::string::npos &&
+                        tool_tag_buf.find("<tool") == std::string::npos &&
+                        tool_tag_buf.find("<too") == std::string::npos &&
+                        tool_tag_buf.find("<to") == std::string::npos &&
+                        tool_tag_buf.find("<t") == std::string::npos) {
+                        // Not a tool tag — flush as content
+                        piece = tool_tag_buf;
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::CONTENT;
+                        // Fall through to content emission
+                    } else {
+                        continue;  // Still scanning
+                    }
+                } else {
+                    // Check partial match
+                    const char* tc_tag = "<tool_call>";
+                    bool could_match = true;
+                    for (size_t ci = 0; ci < tool_tag_buf.size() && ci < 11; ci++) {
+                        if (tool_tag_buf[ci] != tc_tag[ci]) {
+                            could_match = false;
+                            break;
+                        }
+                    }
+                    if (!could_match) {
+                        piece = tool_tag_buf;
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::CONTENT;
+                    } else {
+                        continue;  // Still matching prefix
+                    }
+                }
+            } else {
+                // Llama3: check for <function=
+                if (tool_tag_buf.size() >= 10) {  // len("<function=")
+                    auto fn_pos = tool_tag_buf.find("<function=");
+                    if (fn_pos != std::string::npos) {
+                        auto gt = tool_tag_buf.find('>', fn_pos + 10);
+                        if (gt != std::string::npos) {
+                            std::string before = tool_tag_buf.substr(0, fn_pos);
+                            if (!before.empty()) {
+                                json cd = {{"content", before}};
+                                std::string sse = sse_chunk(comp_id, created, snap_model_name, cd,
+                                                            nullptr);
+                                sink.write(sse.data(), sse.size());
+                            }
+                            tool_fn_name = tool_tag_buf.substr(fn_pos + 10, gt - (fn_pos + 10));
+                            tool_body_buf = tool_tag_buf.substr(gt + 1);
+                            tool_close_tag = "</function>";
+                            tool_tag_buf.clear();
+                            tool_phase = ToolPhase::TOOL_CALL_BODY;
+                            continue;
+                        } else {
+                            continue;  // Still scanning for >
+                        }
+                    }
+                    // Check prefix match
+                    const char* fn_tag = "<function=";
+                    bool could_match = true;
+                    for (size_t ci = 0; ci < tool_tag_buf.size() && ci < 10; ci++) {
+                        if (tool_tag_buf[ci] != fn_tag[ci]) {
+                            could_match = false;
+                            break;
+                        }
+                    }
+                    if (!could_match) {
+                        piece = tool_tag_buf;
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::CONTENT;
+                    } else {
+                        continue;
+                    }
+                } else {
+                    const char* fn_tag = "<function=";
+                    bool could_match = true;
+                    for (size_t ci = 0; ci < tool_tag_buf.size() && ci < 10; ci++) {
+                        if (tool_tag_buf[ci] != fn_tag[ci]) {
+                            could_match = false;
+                            break;
+                        }
+                    }
+                    if (!could_match) {
+                        piece = tool_tag_buf;
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::CONTENT;
+                    } else {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // In CONTENT phase, check for start of tool call tag
+        if (has_tools && tool_phase == ToolPhase::CONTENT) {
+            // Look for < that might start a tool call tag
+            size_t lt_pos = piece.find('<');
+            if (lt_pos != std::string::npos) {
+                // Emit everything before the <
+                if (lt_pos > 0) {
+                    std::string before = piece.substr(0, lt_pos);
+                    if (stop_sequences.empty()) {
+                        utf8_buf += before;
+                    } else {
+                        pending_text += before;
+                    }
+                }
+                // Start tag scanning with the < and everything after
+                tool_tag_buf = piece.substr(lt_pos);
+                tool_phase = ToolPhase::TAG_SCANNING;
+                // Flush any buffered content before entering tag scan
+                if (stop_sequences.empty() && !utf8_buf.empty()) {
+                    size_t complete = utf8_complete_len(utf8_buf);
+                    if (complete > 0) {
+                        if (!sse_writer.write_content(utf8_buf.data(), complete, sink))
+                            return false;
+                        utf8_buf.erase(0, complete);
+                    }
+                } else if (!stop_sequences.empty()) {
                     bool stop_found = false;
                     for (const auto& stop : stop_sequences) {
                         auto pos = pending_text.find(stop);
                         if (pos != std::string::npos) {
-                            // Flush text before the stop string
                             if (!flush_text(pos))
                                 return false;
                             stop_found = true;
@@ -2241,130 +2195,198 @@ static void stream_chat_response_(
                         finish = "stop";
                         break;
                     }
-
-                    // Flush text that can't be part of a partial stop match.
-                    // Keep only the last (max_stop_len - 1) chars as potential prefix.
                     if (pending_text.size() > max_stop_len) {
                         size_t safe = pending_text.size() - max_stop_len + 1;
                         if (!flush_text(safe))
                             return false;
                     }
                 }
+                continue;
+            }
+        }
 
-                // Break after processing the last non-EOS token from batching engine
-                if (finish)
+        // Normal content emission (no tool tag detected)
+        if (stop_sequences.empty()) {
+            // No stop sequences: stream directly (with UTF-8 buffering)
+            utf8_buf += piece;
+            size_t complete = utf8_complete_len(utf8_buf);
+            if (complete > 0) {
+                if (req_logprobs && active_req) {
+                    // Logprobs path: fall back to sse_chunk (rare)
+                    std::string to_emit = utf8_buf.substr(0, complete);
+                    utf8_buf.erase(0, complete);
+                    json content_delta = {{"content", to_emit}};
+                    json lp_chunk = nullptr;
+                    size_t lp_idx = n_output_tokens - 1;
+                    if (lp_idx < active_req->output_logprobs.size()) {
+                        const auto& lp = active_req->output_logprobs[lp_idx];
+                        json top_arr = json::array();
+                        for (const auto& t : lp.top) {
+                            top_arr.push_back({{"token", safe_token_json(t.text)},
+                                               {"logprob", t.logprob},
+                                               {"bytes", token_bytes_json(t.text)}});
+                        }
+                        lp_chunk = {
+                            {"content", json::array({{{"token", safe_token_json(lp.text)},
+                                                      {"logprob", lp.logprob},
+                                                      {"bytes", token_bytes_json(lp.text)},
+                                                      {"top_logprobs", top_arr}}})}};
+                    }
+                    std::string chunk = sse_chunk(comp_id, created, snap_model_name,
+                                                  content_delta, nullptr, lp_chunk);
+                    if (!sink.write(chunk.data(), chunk.size()))
+                        return false;
+                } else {
+                    // Fast path: pre-formatted template
+                    if (!sse_writer.write_content(utf8_buf.data(), complete, sink))
+                        return false;
+                    utf8_buf.erase(0, complete);
+                }
+            }
+        } else {
+            // Buffer text and check for stop matches
+            pending_text += piece;
+
+            // Check for complete stop match
+            bool stop_found = false;
+            for (const auto& stop : stop_sequences) {
+                auto pos = pending_text.find(stop);
+                if (pos != std::string::npos) {
+                    // Flush text before the stop string
+                    if (!flush_text(pos))
+                        return false;
+                    stop_found = true;
                     break;
-            }
-
-            // Flush scan buffer if we never left SCAN phase (model didn't think)
-            if (think_phase == ThinkPhase::SCAN && !think_scan_buf.empty()) {
-                utf8_buf += think_scan_buf;
-                think_scan_buf.clear();
-            }
-
-            // Flush remaining reasoning buffer (model ended while still thinking)
-            if (!reasoning_utf8_buf.empty()) {
-                emit_reasoning(reasoning_utf8_buf);
-                reasoning_utf8_buf.clear();
-            }
-
-            // If the model exhausted tokens while still reasoning and never
-            // produced content, emit a notice so the user sees something
-            // instead of a blank response. Only fire this when max_tokens
-            // was actually the cause (finish == "length") — a model that
-            // naturally hit EOS during thinking will already have its
-            // reasoning_content delivered, and the notice would be
-            // misleading ("increase max_tokens" doesn't help when the model
-            // chose to stop).
-            if (think_phase == ThinkPhase::REASONING && utf8_buf.empty() && pending_text.empty() &&
-                finish && std::strcmp(finish, "length") == 0) {
-                std::string notice = "[Reasoning truncated — increase max_tokens for a complete answer]";
-                sse_writer.write_content(notice, sink);
-            }
-
-            // Handle incomplete tool call at end (max_tokens hit while in tag)
-            if (tool_phase != ToolPhase::CONTENT && !tool_calls_emitted) {
-                // Partial tool call — emit as content, finish_reason stays "length"
-                std::string leftover;
-                if (!tool_tag_buf.empty())
-                    leftover += tool_tag_buf;
-                if (!tool_body_buf.empty())
-                    leftover += tool_body_buf;
-                if (!leftover.empty()) {
-                    utf8_buf += leftover;
                 }
             }
-
-            // Flush any remaining UTF-8 buffer (only if no tool calls were emitted)
-            if (!utf8_buf.empty() && !text_stop_matched && !tool_calls_emitted) {
-                sse_writer.write_content(utf8_buf, sink);
+            if (stop_found) {
+                text_stop_matched = true;
+                finish = "stop";
+                break;
             }
 
-            // Flush any remaining buffered text (skip if text-level stop was matched)
-            if (!pending_text.empty() && !text_stop_matched && !tool_calls_emitted) {
-                sse_writer.write_content(pending_text, sink);
+            // Flush text that can't be part of a partial stop match.
+            // Keep only the last (max_stop_len - 1) chars as potential prefix.
+            if (pending_text.size() > max_stop_len) {
+                size_t safe = pending_text.size() - max_stop_len + 1;
+                if (!flush_text(safe))
+                    return false;
             }
+        }
 
-            if (!finish) {
-                finish = tool_calls_emitted ? "tool_calls" : "length";
-            } else if (tool_calls_emitted && strcmp(finish, "stop") == 0) {
-                finish = "tool_calls";
-            }
+        // Break after processing the last non-EOS token from batching engine
+        if (finish)
+            break;
+    }
 
-            // Send final chunk with finish_reason
-            json empty_delta = json::object();
-            std::string final_chunk = sse_chunk(comp_id, created, snap_model_name, empty_delta, finish);
-            sink.write(final_chunk.data(), final_chunk.size());
+    // Flush scan buffer if we never left SCAN phase (model didn't think)
+    if (think_phase == ThinkPhase::SCAN && !think_scan_buf.empty()) {
+        utf8_buf += think_scan_buf;
+        think_scan_buf.clear();
+    }
 
-            // Send usage chunk if requested
-            if (include_usage) {
-                json usage = {{"prompt_tokens", n_prompt_tokens},
-                              {"completion_tokens", n_output_tokens},
-                              {"total_tokens", n_prompt_tokens + n_output_tokens}};
-                // Report prefix cache hit (OpenAI-compatible prompt_tokens_details)
-                if (active_req && active_req->cached_tokens > 0) {
-                    usage["prompt_tokens_details"] = {{"cached_tokens", active_req->cached_tokens}};
-                }
-                if (n_reasoning_tokens > 0) {
-                    usage["completion_tokens_details"] = {{"reasoning_tokens", n_reasoning_tokens}};
-                }
-                json usage_obj = {{"id", comp_id},
-                                  {"object", "chat.completion.chunk"},
-                                  {"created", created},
-                                  {"model", snap_model_name},
-                                  {"choices", json::array()},
-                                  {"usage", usage}};
-                std::string usage_chunk = "data: " + usage_obj.dump() + "\n\n";
-                sink.write(usage_chunk.data(), usage_chunk.size());
-            }
+    // Flush remaining reasoning buffer (model ended while still thinking)
+    if (!reasoning_utf8_buf.empty()) {
+        emit_reasoning(reasoning_utf8_buf);
+        reasoning_utf8_buf.clear();
+    }
 
-            // Send [DONE]
-            std::string done = "data: [DONE]\n\n";
-            sink.write(done.data(), done.size());
-            sink.done();
+    // If the model exhausted tokens while still reasoning and never
+    // produced content, emit a notice so the user sees something
+    // instead of a blank response. Only fire this when max_tokens
+    // was actually the cause (finish == "length") — a model that
+    // naturally hit EOS during thinking will already have its
+    // reasoning_content delivered, and the notice would be
+    // misleading ("increase max_tokens" doesn't help when the model
+    // chose to stop).
+    if (think_phase == ThinkPhase::REASONING && utf8_buf.empty() && pending_text.empty() &&
+        finish && std::strcmp(finish, "length") == 0) {
+        std::string notice = "[Reasoning truncated — increase max_tokens for a complete answer]";
+        sse_writer.write_content(notice, sink);
+    }
 
-            // Log request with TTFT and cache hit info
-            auto t_end = std::chrono::high_resolution_clock::now();
-            double ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-            int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
-            fprintf(stderr, "[%s] %d prompt + %d completion tokens, %.1f ms (ttft=%.1f ms, cached=%d)\n",
-                    comp_id.c_str(), n_prompt_tokens, n_output_tokens, ms, ttft_ms, cached);
-            state.metrics.requests_total++;
-            state.metrics.tokens_prompt_total += n_prompt_tokens;
-            state.metrics.tokens_completion_total += n_output_tokens;
-            state.metrics.tokens_cached_total += cached;
-            state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
-            state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+    // Handle incomplete tool call at end (max_tokens hit while in tag)
+    if (tool_phase != ToolPhase::CONTENT && !tool_calls_emitted) {
+        // Partial tool call — emit as content, finish_reason stays "length"
+        std::string leftover;
+        if (!tool_tag_buf.empty())
+            leftover += tool_tag_buf;
+        if (!tool_body_buf.empty())
+            leftover += tool_body_buf;
+        if (!leftover.empty()) {
+            utf8_buf += leftover;
+        }
+    }
 
-            // Streaming response content is not accumulated across SSE
-            // chunks, so the JSONL `response` field stays null. The
-            // request body, token counts, finish reason, and latency
-            // still reflect everything the client did.
-            log_request_jsonl(state, log_skip, t_log_start, comp_id, log_endpoint, log_client_ip,
-                              log_raw_body, ms, n_prompt_tokens, n_output_tokens, finish, json());
+    // Flush any remaining UTF-8 buffer (only if no tool calls were emitted)
+    if (!utf8_buf.empty() && !text_stop_matched && !tool_calls_emitted) {
+        sse_writer.write_content(utf8_buf, sink);
+    }
 
-            return true;
-        });
+    // Flush any remaining buffered text (skip if text-level stop was matched)
+    if (!pending_text.empty() && !text_stop_matched && !tool_calls_emitted) {
+        sse_writer.write_content(pending_text, sink);
+    }
+
+    if (!finish) {
+        finish = tool_calls_emitted ? "tool_calls" : "length";
+    } else if (tool_calls_emitted && strcmp(finish, "stop") == 0) {
+        finish = "tool_calls";
+    }
+
+    // Send final chunk with finish_reason
+    json empty_delta = json::object();
+    std::string final_chunk = sse_chunk(comp_id, created, snap_model_name, empty_delta, finish);
+    sink.write(final_chunk.data(), final_chunk.size());
+
+    // Send usage chunk if requested
+    if (include_usage) {
+        json usage = {{"prompt_tokens", n_prompt_tokens},
+                      {"completion_tokens", n_output_tokens},
+                      {"total_tokens", n_prompt_tokens + n_output_tokens}};
+        // Report prefix cache hit (OpenAI-compatible prompt_tokens_details)
+        if (active_req && active_req->cached_tokens > 0) {
+            usage["prompt_tokens_details"] = {{"cached_tokens", active_req->cached_tokens}};
+        }
+        if (n_reasoning_tokens > 0) {
+            usage["completion_tokens_details"] = {{"reasoning_tokens", n_reasoning_tokens}};
+        }
+        json usage_obj = {{"id", comp_id},
+                          {"object", "chat.completion.chunk"},
+                          {"created", created},
+                          {"model", snap_model_name},
+                          {"choices", json::array()},
+                          {"usage", usage}};
+        std::string usage_chunk = "data: " + usage_obj.dump() + "\n\n";
+        sink.write(usage_chunk.data(), usage_chunk.size());
+    }
+
+    // Send [DONE]
+    std::string done = "data: [DONE]\n\n";
+    sink.write(done.data(), done.size());
+    sink.done();
+
+    // Log request with TTFT and cache hit info
+    auto t_end = std::chrono::high_resolution_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+    int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
+    fprintf(stderr, "[%s] %d prompt + %d completion tokens, %.1f ms (ttft=%.1f ms, cached=%d)\n",
+            comp_id.c_str(), n_prompt_tokens, n_output_tokens, ms, ttft_ms, cached);
+    state.metrics.requests_total++;
+    state.metrics.tokens_prompt_total += n_prompt_tokens;
+    state.metrics.tokens_completion_total += n_output_tokens;
+    state.metrics.tokens_cached_total += cached;
+    state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
+    state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+
+    // Streaming response content is not accumulated across SSE
+    // chunks, so the JSONL `response` field stays null. The
+    // request body, token counts, finish reason, and latency
+    // still reflect everything the client did.
+    log_request_jsonl(state, log_skip, t_log_start, comp_id, log_endpoint, log_client_ip,
+                      log_raw_body, ms, n_prompt_tokens, n_output_tokens, finish, json());
+
+    return true;
 }
 
 void handle_chat_completions(const httplib::Request& req, httplib::Response& res, ServerState& state) {


### PR DESCRIPTION
## Summary
- Replace the 762-LOC lambda body inside `stream_chat_response_` with a free function `run_chat_stream_`.
- `stream_chat_response_` drops from **801 LOC → 20 LOC**; it is no longer a god-function — just a thin SSE-headers / context-stamp / lambda-dispatch shim.
- The 30+ individual lambda captures (each rebinding one `ChatRequestContext` field) collapse into a single `[stream_ctx = ctx, &state, server_req]` capture.
- Pure structural refactor: same SSE chunks, same per-token state machine, same finish/usage/[DONE]/JSONL logging at end.

## Before / after

**Before** (handlers.cpp:1563):
```cpp
static void stream_chat_response_(httplib::Response& res, ServerState& state,
                                  ChatRequestContext& ctx, std::shared_ptr<ServerRequest> server_req)
{
    res.set_header("Cache-Control", "no-cache");
    res.set_header("Connection", "keep-alive");
    std::string comp_id = ctx.req_id;
    int64_t created = unix_timestamp();
    res.set_chunked_content_provider(
        "text/event-stream",
        [&state, server_req, comp_id, created,
         max_tokens = ctx.params.max_tokens,
         n_prompt_tokens = ctx.snap.n_prompt_tokens,
         t_start = ctx.t_start,
         // … 27 more identical-shape captures …
         log_raw_body = ctx.log_raw_body](size_t, httplib::DataSink& sink) -> bool {
            // 762 lines of body
        });
}
```

**After** (handlers.cpp:1566):
```cpp
static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx,
                             ServerState& state, std::shared_ptr<ServerRequest> server_req);

static void stream_chat_response_(httplib::Response& res, ServerState& state,
                                  ChatRequestContext& ctx, std::shared_ptr<ServerRequest> server_req)
{
    res.set_header("Cache-Control", "no-cache");
    res.set_header("Connection", "keep-alive");
    ctx.comp_id = ctx.req_id;
    ctx.created = unix_timestamp();
    res.set_chunked_content_provider(
        "text/event-stream",
        [stream_ctx = ctx, &state, server_req](size_t, httplib::DataSink& sink) mutable -> bool {
            return run_chat_stream_(sink, stream_ctx, state, server_req);
        });
}
```

`run_chat_stream_` itself is still ~800 LOC and remains a candidate for further sub-extraction (initial setup ~80 LOC, finalization ~115 LOC, main token loop ~600 LOC) — left for a follow-up PR.

## Test plan
- [x] `make build` — green
- [x] `DegenerationTest.*` (5/5 on Qwen3-8B Q8_0) — all PASSED
- [x] End-to-end server SSE smoke (Gemma-4-26B-A4B NVFP4):
  - launch `imp-server`, POST `/v1/chat/completions` with `stream:true`
  - received initial role chunk → 8 content chunks (`"The"`, `" capital"`, `" of"`, `" France"`, `" is"`, `" **"`, `"Paris"`, `"**."`) → finish_reason="stop" → `[DONE]`
  - reconstructed output: `"The capital of France is **Paris**."`

**Conclusion: SSE wire format identical, no regression.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)