### PR TITLE
fix(tests): make MultiTurnConversation tolerant of thinking-model output

### DIFF
--- a/tests/test_e2e_models.cpp
+++ b/tests/test_e2e_models.cpp
@@ -74,9 +74,32 @@ TEST_F(PrimaryModelTest, GenerateCoherentOutput) {
     EXPECT_NE(text.find("Paris"), std::string::npos) << "Expected 'Paris' in output: " << text;
 }
 
+// Helper: drop <think>...</think> blocks so this test works against both
+// non-thinking baselines (Qwen3-4B-Instruct, Llama-3.2-3B) and thinking
+// models (Qwen3-8B, DeepSeek-R1-Distill). Open `<think>` with no close —
+// model exhausted the token budget mid-reasoning — drops everything from
+// `<think>` to end so the post-reasoning substring check fails clean.
+static std::string strip_think_blocks_for_test_(std::string s) {
+    while (true) {
+        size_t open = s.find("<think>");
+        if (open == std::string::npos)
+            break;
+        size_t close = s.find("</think>", open);
+        if (close == std::string::npos) {
+            s.erase(open);
+            break;
+        }
+        s.erase(open, close + 8 /*len("</think>")*/ - open);
+    }
+    return s;
+}
+
 TEST_F(PrimaryModelTest, MultiTurnConversation) {
     ImpGenerateParams params = imp_generate_params_default();
-    params.max_tokens = 32;
+    // Thinking models (Qwen3-8B, DeepSeek-R1) need headroom for the
+    // <think>…</think> block plus the answer. Non-thinking models finish
+    // long before reaching 256; the cap only matters for the worst case.
+    params.max_tokens = 256;
     params.temperature = 0.0f;
     params.apply_chat_template = 1;
 
@@ -97,8 +120,9 @@ TEST_F(PrimaryModelTest, MultiTurnConversation) {
               IMP_SUCCESS);
     EXPECT_GT(len2, 0u);
 
-    std::string text2(out2, len2);
-    EXPECT_NE(text2.find("4"), std::string::npos) << "Expected '4' in output: " << text2;
+    std::string text2 = strip_think_blocks_for_test_(std::string(out2, len2));
+    EXPECT_NE(text2.find("4"), std::string::npos)
+        << "Expected '4' in (think-stripped) output: " << text2;
 }
 
 TEST_F(PrimaryModelTest, TokenizeRoundtrip) {


### PR DESCRIPTION
## Summary
- `PrimaryModelTest.MultiTurnConversation` failed on thinking models (Qwen3-8B, DeepSeek-R1-Distill) because the test expected '4' to appear bare in the answer but the model first emits `<think>…</think>` reasoning. With the previous `max_tokens=32`, the model hit the budget mid-reasoning and never reached '4'.
- Pre-existing failure (reproduced on `main` during PR #279 verification), not a regression.

## Fix (3 lines that matter)
- `max_tokens` 32 → 256: gives thinking models room to complete the reasoning block + emit the answer. Non-thinking baselines (Qwen3-4B-Instruct, Llama-3.2-3B Q8_0) still finish in <10 tokens; the cap only matters for the worst case.
- `strip_think_blocks_for_test_(...)` static helper: removes `<think>…</think>` pairs before the substring check. Open-with-no-close (model hit budget mid-reasoning) drops everything from `<think>` onward so the check fails cleanly with a legible error message.

## Test plan
- [x] `make build` — green
- [x] On Qwen3-8B-Q8_0 (thinking model, previously failing):
      `IMP_TEST_MODEL=/models/Qwen3-8B-Q8_0.gguf ./imp-tests --gtest_filter='*MultiTurnConversation'`
      → `[ PASSED ] 1 test.` in 14.2 s

Non-thinking model verification deferred (no local baseline currently symlinked into `./models/`), but the helper is a no-op for outputs without `<think>` tags so behavior is unchanged for that class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)