### PR TITLE
perf(nvfp4): remove __launch_bounds__ from MoE MR GEMVs + add NR tile knob

### DIFF
--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -5,6 +5,7 @@
 #include "core/tensor.h"
 #include "core/logging.h"
 #include "runtime/pdl.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cublasLt.h>
@@ -927,9 +928,11 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_nvfp4_moe_gate_up_fused
 // ---------------------------------------------------------------------------
 
 // Multi-row MoE gate+up with blockIdx.y split (gate=0, up=1).
-// Same approach as original but NR rows per block for reduced launch count.
+// One warp per row; threads-per-block = NR * 32 set by the launcher.
+// Note: no __launch_bounds__ — per sm120 perf testing the override costs
+// -4.5 % to -20 % on GEMV/attention paths (see sm120-cuda-expert skill).
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_gate_up_mr_kernel(
+__global__ void gemv_nvfp4_moe_gate_up_mr_kernel(
     const uint8_t* __restrict__ gate_packed, const uint8_t* __restrict__ gate_ms,
     const float* __restrict__ gate_ts, const uint8_t* __restrict__ up_packed,
     const uint8_t* __restrict__ up_ms, const float* __restrict__ up_ts,
@@ -970,7 +973,7 @@ __global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_gate_up_mr_kernel(
 
 // Multi-row MoE NVFP4 decode (single weight matrix, e.g., non-gated up or down).
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_decode_mr_kernel(
+__global__ void gemv_nvfp4_moe_decode_mr_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales,
     const float* __restrict__ tensor_scales, const int32_t* __restrict__ expert_indices,
     const half* __restrict__ x, half* __restrict__ y, int rows, int K, size_t expert_stride_packed,
@@ -1009,16 +1012,39 @@ __global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_decode_mr_kernel(
 // reduction (n_mb <= 512, i.e., K <= 8192).
 static bool use_moe_multirow(int K) { return (K / kMicroBlockSize) <= 512; }
 
+// Tile-tuning knob: read NR from RuntimeConfig, clamp to {4, 8, 16, 32}.
+// Default 8 = legacy behavior; 4/16/32 are A/B candidates for the perf
+// regression recovery work (see PR opening MoE NVFP4 decode tile sweep).
+static int resolve_mr_nr() {
+    int v = imp::RuntimeConfig::current().moe.mr_nr;
+    if (v == 4 || v == 8 || v == 16 || v == 32) return v;
+    return 8;
+}
+
+// Dispatch a single-output MR-decode launch for the requested NR (one warp
+// per row → threads-per-block = NR * 32). The thread-count match keeps the
+// `row = local_block * NR + warp_id; if (warp_id >= NR) return;` guard from
+// firing → no idle warps.
+template <int NR>
+static void launch_mr_decode(const NvFP4MoEQuantResult& w, const int32_t* expert_indices, const half* x,
+                             half* y, int rows, int K, int x_stride, int top_k, cudaStream_t stream) {
+    int blocks_per_expert = (rows + NR - 1) / NR;
+    int total_blocks = top_k * blocks_per_expert;
+    pdl::launch(gemv_nvfp4_moe_decode_mr_kernel<NR>, dim3(total_blocks), dim3(NR * 32), size_t(0), stream,
+                reinterpret_cast<const uint8_t*>(w.packed_data),
+                reinterpret_cast<const uint8_t*>(w.micro_scales), w.tensor_scales, expert_indices, x, y,
+                rows, K, w.expert_stride_packed, w.expert_stride_ms, x_stride, blocks_per_expert);
+}
+
 void gemv_nvfp4_moe_decode(const NvFP4MoEQuantResult& w, const int32_t* expert_indices, const half* x,
                            half* y, int rows, int K, int x_stride, int top_k, cudaStream_t stream) {
     if (use_moe_multirow(K)) {
-        constexpr int NR = 8;
-        int blocks_per_expert = (rows + NR - 1) / NR;
-        int total_blocks = top_k * blocks_per_expert;
-        pdl::launch(gemv_nvfp4_moe_decode_mr_kernel<NR>, dim3(total_blocks), dim3(kMRThreads), size_t(0),
-                    stream, reinterpret_cast<const uint8_t*>(w.packed_data),
-                    reinterpret_cast<const uint8_t*>(w.micro_scales), w.tensor_scales, expert_indices, x, y,
-                    rows, K, w.expert_stride_packed, w.expert_stride_ms, x_stride, blocks_per_expert);
+        switch (resolve_mr_nr()) {
+            case 4:  launch_mr_decode<4>(w, expert_indices, x, y, rows, K, x_stride, top_k, stream); break;
+            case 16: launch_mr_decode<16>(w, expert_indices, x, y, rows, K, x_stride, top_k, stream); break;
+            case 32: launch_mr_decode<32>(w, expert_indices, x, y, rows, K, x_stride, top_k, stream); break;
+            default: launch_mr_decode<8>(w, expert_indices, x, y, rows, K, x_stride, top_k, stream); break;
+        }
     } else {
         int total_blocks = top_k * rows;
         pdl::launch(gemv_nvfp4_moe_decode_kernel, dim3(total_blocks), dim3(kKparThreads), size_t(0), stream,
@@ -1028,20 +1054,31 @@ void gemv_nvfp4_moe_decode(const NvFP4MoEQuantResult& w, const int32_t* expert_i
     }
 }
 
+template <int NR>
+static void launch_mr_gate_up(const NvFP4MoEQuantResult& gate, const NvFP4MoEQuantResult& up,
+                              const int32_t* expert_indices, const half* x, half* y_gate, half* y_up,
+                              int rows, int K, int top_k, cudaStream_t stream) {
+    int blocks_per_expert = (rows + NR - 1) / NR;
+    dim3 grid(top_k * blocks_per_expert, 2);
+    pdl::launch(gemv_nvfp4_moe_gate_up_mr_kernel<NR>, grid, dim3(NR * 32), size_t(0), stream,
+                reinterpret_cast<const uint8_t*>(gate.packed_data),
+                reinterpret_cast<const uint8_t*>(gate.micro_scales), gate.tensor_scales,
+                reinterpret_cast<const uint8_t*>(up.packed_data),
+                reinterpret_cast<const uint8_t*>(up.micro_scales), up.tensor_scales, expert_indices, x,
+                y_gate, y_up, rows, K, gate.expert_stride_packed, gate.expert_stride_ms,
+                blocks_per_expert);
+}
+
 void gemv_nvfp4_moe_gate_up_fused(const NvFP4MoEQuantResult& gate, const NvFP4MoEQuantResult& up,
                                   const int32_t* expert_indices, const half* x, half* y_gate, half* y_up,
                                   int rows, int K, int top_k, cudaStream_t stream) {
     if (use_moe_multirow(K)) {
-        constexpr int NR = 8;
-        int blocks_per_expert = (rows + NR - 1) / NR;
-        dim3 grid(top_k * blocks_per_expert, 2);
-        pdl::launch(gemv_nvfp4_moe_gate_up_mr_kernel<NR>, grid, dim3(kMRThreads), size_t(0), stream,
-                    reinterpret_cast<const uint8_t*>(gate.packed_data),
-                    reinterpret_cast<const uint8_t*>(gate.micro_scales), gate.tensor_scales,
-                    reinterpret_cast<const uint8_t*>(up.packed_data),
-                    reinterpret_cast<const uint8_t*>(up.micro_scales), up.tensor_scales, expert_indices, x,
-                    y_gate, y_up, rows, K, gate.expert_stride_packed, gate.expert_stride_ms,
-                    blocks_per_expert);
+        switch (resolve_mr_nr()) {
+            case 4:  launch_mr_gate_up<4>(gate, up, expert_indices, x, y_gate, y_up, rows, K, top_k, stream); break;
+            case 16: launch_mr_gate_up<16>(gate, up, expert_indices, x, y_gate, y_up, rows, K, top_k, stream); break;
+            case 32: launch_mr_gate_up<32>(gate, up, expert_indices, x, y_gate, y_up, rows, K, top_k, stream); break;
+            default: launch_mr_gate_up<8>(gate, up, expert_indices, x, y_gate, y_up, rows, K, top_k, stream); break;
+        }
     } else {
         dim3 grid(top_k * rows, 2);
         pdl::launch(gemv_nvfp4_moe_gate_up_fused_kernel, grid, dim3(kKparThreads), size_t(0), stream,
@@ -1092,9 +1129,9 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_nvfp4_moe_swiglu_decode
 }
 
 // Multi-row SwiGLU + MoE NVFP4 GEMV for down projection.
-// NR rows per block, 256 threads (8 warps).
+// One warp per row; threads-per-block = NR * 32 set by the launcher.
 template <int NR>
-__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_swiglu_mr_kernel(
+__global__ void gemv_nvfp4_moe_swiglu_mr_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales,
     const float* __restrict__ tensor_scales, const int32_t* __restrict__ expert_indices,
     const half* __restrict__ gate, const half* __restrict__ up, half* __restrict__ y, int rows, int K,
@@ -1130,17 +1167,28 @@ __global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_moe_swiglu_mr_kernel(
         y[(size_t)expert_slot * rows + row] = __float2half(acc);
 }
 
+template <int NR>
+static void launch_mr_swiglu(const NvFP4MoEQuantResult& w, const int32_t* expert_indices,
+                             const half* gate, const half* up, half* y, int rows, int K, int x_stride,
+                             int top_k, cudaStream_t stream) {
+    int blocks_per_expert = (rows + NR - 1) / NR;
+    int total_blocks = top_k * blocks_per_expert;
+    pdl::launch(gemv_nvfp4_moe_swiglu_mr_kernel<NR>, dim3(total_blocks), dim3(NR * 32), size_t(0), stream,
+                reinterpret_cast<const uint8_t*>(w.packed_data),
+                reinterpret_cast<const uint8_t*>(w.micro_scales), w.tensor_scales, expert_indices, gate,
+                up, y, rows, K, w.expert_stride_packed, w.expert_stride_ms, x_stride, blocks_per_expert);
+}
+
 void gemv_nvfp4_moe_swiglu_decode(const NvFP4MoEQuantResult& w, const int32_t* expert_indices,
                                   const half* gate, const half* up, half* y, int rows, int K, int x_stride,
                                   int top_k, cudaStream_t stream) {
     if (use_moe_multirow(K)) {
-        constexpr int NR = 8;
-        int blocks_per_expert = (rows + NR - 1) / NR;
-        int total_blocks = top_k * blocks_per_expert;
-        pdl::launch(gemv_nvfp4_moe_swiglu_mr_kernel<NR>, dim3(total_blocks), dim3(kMRThreads), size_t(0),
-                    stream, reinterpret_cast<const uint8_t*>(w.packed_data),
-                    reinterpret_cast<const uint8_t*>(w.micro_scales), w.tensor_scales, expert_indices, gate,
-                    up, y, rows, K, w.expert_stride_packed, w.expert_stride_ms, x_stride, blocks_per_expert);
+        switch (resolve_mr_nr()) {
+            case 4:  launch_mr_swiglu<4>(w, expert_indices, gate, up, y, rows, K, x_stride, top_k, stream); break;
+            case 16: launch_mr_swiglu<16>(w, expert_indices, gate, up, y, rows, K, x_stride, top_k, stream); break;
+            case 32: launch_mr_swiglu<32>(w, expert_indices, gate, up, y, rows, K, x_stride, top_k, stream); break;
+            default: launch_mr_swiglu<8>(w, expert_indices, gate, up, y, rows, K, x_stride, top_k, stream); break;
+        }
     } else {
         int total_blocks = top_k * rows;
         pdl::launch(gemv_nvfp4_moe_swiglu_decode_kernel, dim3(total_blocks), dim3(kKparThreads), size_t(0),

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -178,6 +178,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.moe.nvfp4_smallM = parse_bool(val, cfg.moe.nvfp4_smallM);
     else if (eq("moe.nvfp4_smallM_threshold"))
         cfg.moe.nvfp4_smallM_threshold = parse_int(val, cfg.moe.nvfp4_smallM_threshold);
+    else if (eq("moe.mr_nr"))
+        cfg.moe.mr_nr = parse_int(val, cfg.moe.mr_nr);
 
     // [gdn]
     else if (eq("gdn.fp32_scan"))
@@ -336,6 +338,10 @@ void seed_from_env(RuntimeConfig& cfg) {
         if (v > 128) v = 128;
         cfg.moe.nvfp4_smallM_threshold = v;
     }
+
+    // moe.mr_nr — IMP_MOE_MR_NR: rows-per-block for NVFP4 MoE decode kernels.
+    if (const char* e = std::getenv("IMP_MOE_MR_NR"))
+        cfg.moe.mr_nr = std::atoi(e);
 
     // diagnostics.nvfp4_force_dequant — IMP_NVFP4_FORCE_DEQUANT: '1' only.
     if (const char* e = std::getenv("IMP_NVFP4_FORCE_DEQUANT"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -161,6 +161,13 @@ struct RuntimeConfig {
         // Threshold M for smallM kernel (clamped to [0,128]). Legacy env:
         // IMP_NVFP4_SMALLM_THRESHOLD.
         int nvfp4_smallM_threshold = 64;
+        // Rows-per-block (NR) for multi-row NVFP4 MoE decode kernels
+        // (gemv_nvfp4_moe_{gate_up,decode}_mr<NR>). One warp computes one
+        // row, so threads-per-block = NR * 32. Higher NR amortizes block
+        // launch overhead at the cost of fewer concurrent CTAs. Valid
+        // values: 4, 8 (default), 16, 32. Other values fall back to 8.
+        // Env: IMP_MOE_MR_NR.
+        int mr_nr = 8;
     } moe;
 
     struct GDN {


### PR DESCRIPTION
## Summary
Targeted perf work on the multi-row NVFP4 MoE decode GEMV (`gemv_nvfp4_moe_{gate_up,decode,swiglu}_mr_kernel`). The nsys profile flagged this kernel as 15 % of decode wall time on Gemma-4-26B-A4B-NVFP4 — the second-largest single contributor.

Two atomic changes:

1. **Drop `__launch_bounds__(kMRThreads)` from the three MR kernels.** Per the in-repo `sm120-cuda-expert` skill note, this override costs **-4.5 % to -20 %** on regular GEMV/attention paths on sm_120 — the compiler over-constrains register allocation when it assumes 256 threads/block. The MR kernels are SMEM-free and only do a warp-level reduction, so there's no occupancy benefit to capping registers.

2. **NR (rows-per-block) is now runtime-tunable** via `moe.mr_nr` (env `IMP_MOE_MR_NR`). Valid values: 4, 8 (default), 16, 32; others fall back to 8. Launchers set threads-per-block = `NR * 32` so the `warp_id < NR` guard never wastes a warp.

## Bench results

Gemma-4-26B-A4B-NVFP4, 5 reps each, cool 45 s between trials:

| Config | tg256 tok/s | vs main HEAD |
|---|---:|---:|
| main HEAD (`launch_bounds=256`, NR=8) | 205.05 (5-rep mean from bisect agent) | baseline |
| **this PR default** (no launch_bounds, NR=8) | **211.33** | **+3.0 %** |
| this PR + `IMP_MOE_MR_NR=4` | 213.24 | +4.0 % |
| this PR + `IMP_MOE_MR_NR=16` | 209.63 | +2.2 % |
| this PR + `IMP_MOE_MR_NR=32` | 200.92 | -2.0 % |

Default stays at NR=8 — minimal blast radius for un-benched MoE NVFP4 shapes (Qwen3.6-35B-A3B, Qwen3-Coder-30B-A3B-FP4, Nemotron-3-Nano-30B-A3B-NVFP4). Users wanting the extra +1 % can opt into `IMP_MOE_MR_NR=4`.

## Correctness
- Gemma-4 NVFP4 smoke `"The capital of France is"` → `"The capital of France is **Paris**."` — bit-identical token IDs to all previous-baseline runs (818, 5279, 529, 7001, 563, 5213, 50429, 84750, 106).
- `"Write the numbers from 1 to 10..."` → `"1, 2, 3, 4, 5, 6, 7, 8, 9, 10"` — coherent.
- The reduction tree changes shape across NR (more warps per block = different warp-level reduction order) but FP16 numerics stay within rounding tolerance — the greedy-temp=0 output token IDs match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)