### PR TITLE
refactor(weight-upload): decompose upload_weight + upload_expert_weights

### DIFF
--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -241,367 +241,390 @@ static uint16_t float_to_fp16(float val) {
 // For F32: converts to FP16 on host, uploads. scales_out stays empty.
 // ---------------------------------------------------------------------------
 
-static bool upload_weight(Tensor& weight, QType qtype, QType compute_dtype, cudaStream_t stream,
-                          std::vector<void*>& gpu_allocs, bool raw_quant = true, float weight_offset = 0.0f) {
-    // weight_offset: added to each FP32 element BEFORE FP16 conversion. Only
-    // applied on BF16-source paths (qtype==BF16 or qtype==F32/NONE with
-    // weight.qtype==BF16). F32-source paths leave it unused — GGUF norms
-    // already carry the offset baked in by the converter; SafeTensors stores
-    // the delta `W` (where actual gamma = 1 + W) for Qwen3.5/3.6 block norms.
-    if (weight.data == nullptr || weight.on_device)
-        return true;
-    if (weight.ndim < 1)
-        return true;
 
-    int64_t n_elements = weight.numel();
-    if (n_elements == 0)
-        return true;
+// Per-qtype upload handler extracted from upload_weight: mxfp4 path.
+static bool upload_qtype_mxfp4_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    if (weight.ndim < 2)
+        return false;
+    int64_t N = weight.shape[0];
+    int64_t K = weight.shape[1];
+    int blocks_per_row = static_cast<int>((K + 31) / 32);
+    int total_blocks = static_cast<int>(N) * blocks_per_row;
+    size_t data_bytes = static_cast<size_t>(N) * blocks_per_row * 16;  // packed nibbles only
 
-    // ---- MXFP4 (native) ----
-    // GGUF block: [16 bytes E2M1 data | 1 byte UE8M0 scale] × N_blocks
-    // Split on CPU: upload only the 16-byte data portion to GPU.
-    // Saves ~6% VRAM (1 byte/block scale overhead eliminated from GPU buffer).
-    // Scales are extracted to a separate host buffer, uploaded in executor_workspace.
-    if (qtype == QType::MXFP4) {
-        if (weight.ndim < 2)
-            return false;
-        int64_t N = weight.shape[0];
-        int64_t K = weight.shape[1];
-        int blocks_per_row = static_cast<int>((K + 31) / 32);
-        int total_blocks = static_cast<int>(N) * blocks_per_row;
-        size_t data_bytes = static_cast<size_t>(N) * blocks_per_row * 16;  // packed nibbles only
-
-        // CPU-side split: [data_0..data_N | scale_0..scale_N] contiguous layout.
-        // Source block layout depends on the originating GGUF type:
-        //   legacy (type 31): [data (16) | scale (1)] per block
-        //   modern (type 39): [scale (1) | data (16)] per block (llama.cpp standard)
-        // weight.mxfp4_layout_v2 tracks the modern layout (set by gguf_loader).
-        size_t scale_bytes = static_cast<size_t>(total_blocks);  // 1 byte per block
-        size_t total_bytes = data_bytes + scale_bytes;
-        const uint8_t* src = static_cast<const uint8_t*>(weight.data);
-        std::vector<uint8_t> h_buf(total_bytes);
-        if (weight.mxfp4_layout_v2) {
-            for (int i = 0; i < total_blocks; i++) {
-                h_buf[data_bytes + i] = src[static_cast<size_t>(i) * 17];
-                memcpy(h_buf.data() + static_cast<size_t>(i) * 16, src + static_cast<size_t>(i) * 17 + 1, 16);
-            }
-        } else {
-            for (int i = 0; i < total_blocks; i++) {
-                memcpy(h_buf.data() + static_cast<size_t>(i) * 16, src + static_cast<size_t>(i) * 17, 16);
-                h_buf[data_bytes + i] = src[static_cast<size_t>(i) * 17 + 16];
-            }
+    // CPU-side split: [data_0..data_N | scale_0..scale_N] contiguous layout.
+    // Source block layout depends on the originating GGUF type:
+    //   legacy (type 31): [data (16) | scale (1)] per block
+    //   modern (type 39): [scale (1) | data (16)] per block (llama.cpp standard)
+    // weight.mxfp4_layout_v2 tracks the modern layout (set by gguf_loader).
+    size_t scale_bytes = static_cast<size_t>(total_blocks);  // 1 byte per block
+    size_t total_bytes = data_bytes + scale_bytes;
+    const uint8_t* src = static_cast<const uint8_t*>(weight.data);
+    std::vector<uint8_t> h_buf(total_bytes);
+    if (weight.mxfp4_layout_v2) {
+        for (int i = 0; i < total_blocks; i++) {
+            h_buf[data_bytes + i] = src[static_cast<size_t>(i) * 17];
+            memcpy(h_buf.data() + static_cast<size_t>(i) * 16, src + static_cast<size_t>(i) * 17 + 1, 16);
         }
+    } else {
+        for (int i = 0; i < total_blocks; i++) {
+            memcpy(h_buf.data() + static_cast<size_t>(i) * 16, src + static_cast<size_t>(i) * 17, 16);
+            h_buf[data_bytes + i] = src[static_cast<size_t>(i) * 17 + 16];
+        }
+    }
 
+    void* d_data = nullptr;
+    checked_cuda_malloc(&d_data, total_bytes);
+    if (!d_data)
+        return false;
+    h2d_copy(d_data, h_buf.data(), total_bytes, stream);
+    gpu_allocs.push_back(d_data);
+    int64_t new_shape[4] = {N, K, 0, 0};
+    weight = Tensor(d_data, qtype, 2, new_shape, true);
+    IMP_LOG_DEBUG("  MXFP4 upload: [%lld, %lld] %.2f MiB (data+scales split)", (long long)N, (long long)K,
+                  total_bytes / (1024.0 * 1024.0));
+    return true;
+}
+
+// Per-qtype upload handler extracted from upload_weight: q4_0 path.
+static bool upload_qtype_q4_0_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    if (weight.ndim < 2) {
+        IMP_LOG_WARN("Q4_0 weight has < 2 dims, skipping upload");
+        return false;
+    }
+
+    int64_t N = weight.shape[0];  // out_features (rows)
+    int64_t K = weight.shape[1];  // in_features (cols), logical
+
+    // Raw upload: keep quantized bytes on GPU for dp4a GEMV decode path.
+    // Prefill uses fp16_cache or on-the-fly dequant_gpu → cuBLAS GEMM.
+    if (raw_quant) {
+        size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
         void* d_data = nullptr;
-        checked_cuda_malloc(&d_data, total_bytes);
+        checked_cuda_malloc(&d_data, raw_bytes);
         if (!d_data)
             return false;
-        h2d_copy(d_data, h_buf.data(), total_bytes, stream);
+        h2d_copy(d_data, weight.data, raw_bytes, stream);
         gpu_allocs.push_back(d_data);
+
+        // Logical shape [N, K] — qtype tells executor data is raw quantized
         int64_t new_shape[4] = {N, K, 0, 0};
         weight = Tensor(d_data, qtype, 2, new_shape, true);
-        IMP_LOG_DEBUG("  MXFP4 upload: [%lld, %lld] %.2f MiB (data+scales split)", (long long)N, (long long)K,
-                      total_bytes / (1024.0 * 1024.0));
         return true;
     }
 
-    // ---- Q4_0 ----
-    if (qtype == QType::Q4_0) {
-        if (weight.ndim < 2) {
-            IMP_LOG_WARN("Q4_0 weight has < 2 dims, skipping upload");
-            return false;
+    // Split upload fallback: separate nibbles + scales for quant_gemm_int4.
+    int blocks_per_row = static_cast<int>(K) / 32;
+    int num_groups = blocks_per_row;
+    int half_K = static_cast<int>(K) / 2;
+
+    // GGML Q4_0 block format: 18 bytes per block (2 fp16 scale + 16 nibbles)
+    static constexpr size_t Q4_0_BLOCK_SIZE = 18;
+
+    size_t nibbles_bytes = static_cast<size_t>(N) * half_K;
+    size_t scales_count = static_cast<size_t>(N) * num_groups;
+
+    std::vector<uint8_t> h_nibbles(nibbles_bytes);
+    std::vector<uint16_t> h_scales(scales_count);  // raw FP16 bits
+
+    const uint8_t* raw = static_cast<const uint8_t*>(weight.data);
+
+    for (int64_t n = 0; n < N; ++n) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            const uint8_t* block_ptr = raw + (n * blocks_per_row + b) * Q4_0_BLOCK_SIZE;
+
+            // Scale: first 2 bytes (fp16)
+            uint16_t scale_bits;
+            std::memcpy(&scale_bits, block_ptr, 2);
+            h_scales[n * num_groups + b] = scale_bits;
+
+            // Nibbles: next 16 bytes (copied as-is)
+            std::memcpy(&h_nibbles[n * half_K + b * 16], block_ptr + 2, 16);
         }
-
-        int64_t N = weight.shape[0];  // out_features (rows)
-        int64_t K = weight.shape[1];  // in_features (cols), logical
-
-        // Raw upload: keep quantized bytes on GPU for dp4a GEMV decode path.
-        // Prefill uses fp16_cache or on-the-fly dequant_gpu → cuBLAS GEMM.
-        if (raw_quant) {
-            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
-            void* d_data = nullptr;
-            checked_cuda_malloc(&d_data, raw_bytes);
-            if (!d_data)
-                return false;
-            h2d_copy(d_data, weight.data, raw_bytes, stream);
-            gpu_allocs.push_back(d_data);
-
-            // Logical shape [N, K] — qtype tells executor data is raw quantized
-            int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, qtype, 2, new_shape, true);
-            return true;
-        }
-
-        // Split upload fallback: separate nibbles + scales for quant_gemm_int4.
-        int blocks_per_row = static_cast<int>(K) / 32;
-        int num_groups = blocks_per_row;
-        int half_K = static_cast<int>(K) / 2;
-
-        // GGML Q4_0 block format: 18 bytes per block (2 fp16 scale + 16 nibbles)
-        static constexpr size_t Q4_0_BLOCK_SIZE = 18;
-
-        size_t nibbles_bytes = static_cast<size_t>(N) * half_K;
-        size_t scales_count = static_cast<size_t>(N) * num_groups;
-
-        std::vector<uint8_t> h_nibbles(nibbles_bytes);
-        std::vector<uint16_t> h_scales(scales_count);  // raw FP16 bits
-
-        const uint8_t* raw = static_cast<const uint8_t*>(weight.data);
-
-        for (int64_t n = 0; n < N; ++n) {
-            for (int b = 0; b < blocks_per_row; ++b) {
-                const uint8_t* block_ptr = raw + (n * blocks_per_row + b) * Q4_0_BLOCK_SIZE;
-
-                // Scale: first 2 bytes (fp16)
-                uint16_t scale_bits;
-                std::memcpy(&scale_bits, block_ptr, 2);
-                h_scales[n * num_groups + b] = scale_bits;
-
-                // Nibbles: next 16 bytes (copied as-is)
-                std::memcpy(&h_nibbles[n * half_K + b * 16], block_ptr + 2, 16);
-            }
-        }
-
-        // Upload packed nibbles to GPU
-        void* d_nibbles = nullptr;
-        checked_cuda_malloc(&d_nibbles, nibbles_bytes);
-        if (!d_nibbles)
-            return false;
-        h2d_copy(d_nibbles, h_nibbles.data(), nibbles_bytes, stream);
-        gpu_allocs.push_back(d_nibbles);
-
-        // Upload scales to GPU
-        void* d_scales = nullptr;
-        size_t scales_bytes = scales_count * sizeof(uint16_t);
-        checked_cuda_malloc(&d_scales, scales_bytes);
-        if (!d_scales) {
-            IMP_CUDA_CHECK_LOG(cudaFree(d_nibbles));
-            return false;
-        }
-        h2d_copy(d_scales, h_scales.data(), scales_bytes, stream);
-        gpu_allocs.push_back(d_scales);
-
-        // Update weight tensor to point to packed nibbles on GPU; the
-        // FP16 scales buffer rides along as Tensor::scales (sidecar).
-        int64_t new_shape[4] = {N, static_cast<int64_t>(half_K), 0, 0};
-        weight = Tensor(d_nibbles, qtype, 2, new_shape, true);
-        weight.scales = d_scales;
-
-        return true;
     }
 
-    // ---- Q8_0 ----
-    if (qtype == QType::Q8_0) {
-        if (weight.ndim < 2) {
-            IMP_LOG_WARN("Q8_0 weight has < 2 dims, skipping upload");
-            return false;
-        }
+    // Upload packed nibbles to GPU
+    void* d_nibbles = nullptr;
+    checked_cuda_malloc(&d_nibbles, nibbles_bytes);
+    if (!d_nibbles)
+        return false;
+    h2d_copy(d_nibbles, h_nibbles.data(), nibbles_bytes, stream);
+    gpu_allocs.push_back(d_nibbles);
 
-        int64_t N = weight.shape[0];
-        int64_t K = weight.shape[1];
+    // Upload scales to GPU
+    void* d_scales = nullptr;
+    size_t scales_bytes = scales_count * sizeof(uint16_t);
+    checked_cuda_malloc(&d_scales, scales_bytes);
+    if (!d_scales) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_nibbles));
+        return false;
+    }
+    h2d_copy(d_scales, h_scales.data(), scales_bytes, stream);
+    gpu_allocs.push_back(d_scales);
 
-        // Raw upload: keep quantized bytes on GPU, dequant on-the-fly in executor
-        if (raw_quant) {
-            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
-            void* d_data = nullptr;
-            checked_cuda_malloc(&d_data, raw_bytes);
-            if (!d_data)
-                return false;
-            h2d_copy(d_data, weight.data, raw_bytes, stream);
-            gpu_allocs.push_back(d_data);
+    // Update weight tensor to point to packed nibbles on GPU; the
+    // FP16 scales buffer rides along as Tensor::scales (sidecar).
+    int64_t new_shape[4] = {N, static_cast<int64_t>(half_K), 0, 0};
+    weight = Tensor(d_nibbles, qtype, 2, new_shape, true);
+    weight.scales = d_scales;
 
-            // Logical shape [N, K] — qtype tells executor data is raw quantized
-            int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, qtype, 2, new_shape, true);
-            return true;
-        }
+    return true;
+}
 
-        // CPU dequant fallback: decode to FP16 on host, upload
-        int blocks_per_row = static_cast<int>(K) / 32;
-        static constexpr size_t Q8_0_BLOCK_SIZE = 34;  // 2 (fp16 scale) + 32 (int8 quants)
+// Per-qtype upload handler extracted from upload_weight: q8_0 path.
+static bool upload_qtype_q8_0_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    if (weight.ndim < 2) {
+        IMP_LOG_WARN("Q8_0 weight has < 2 dims, skipping upload");
+        return false;
+    }
 
-        size_t fp16_count = static_cast<size_t>(N * K);
-        std::vector<uint16_t> h_fp16(fp16_count);
+    int64_t N = weight.shape[0];
+    int64_t K = weight.shape[1];
 
-        const uint8_t* raw = static_cast<const uint8_t*>(weight.data);
-
-        for (int64_t n = 0; n < N; ++n) {
-            for (int b = 0; b < blocks_per_row; ++b) {
-                const uint8_t* block_ptr = raw + (n * blocks_per_row + b) * Q8_0_BLOCK_SIZE;
-
-                uint16_t scale_bits;
-                std::memcpy(&scale_bits, block_ptr, 2);
-                float scale_f = fp16_to_float(scale_bits);
-
-                const int8_t* quants = reinterpret_cast<const int8_t*>(block_ptr + 2);
-                for (int q = 0; q < 32; ++q) {
-                    float val = static_cast<float>(quants[q]) * scale_f;
-                    h_fp16[n * K + b * 32 + q] = float_to_fp16(val);
-                }
-            }
-        }
-
-        size_t bytes = fp16_count * sizeof(uint16_t);
+    // Raw upload: keep quantized bytes on GPU, dequant on-the-fly in executor
+    if (raw_quant) {
+        size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
         void* d_data = nullptr;
-        checked_cuda_malloc(&d_data, bytes);
+        checked_cuda_malloc(&d_data, raw_bytes);
         if (!d_data)
             return false;
-        h2d_copy(d_data, h_fp16.data(), bytes, stream);
+        h2d_copy(d_data, weight.data, raw_bytes, stream);
+        gpu_allocs.push_back(d_data);
+
+        // Logical shape [N, K] — qtype tells executor data is raw quantized
+        int64_t new_shape[4] = {N, K, 0, 0};
+        weight = Tensor(d_data, qtype, 2, new_shape, true);
+        return true;
+    }
+
+    // CPU dequant fallback: decode to FP16 on host, upload
+    int blocks_per_row = static_cast<int>(K) / 32;
+    static constexpr size_t Q8_0_BLOCK_SIZE = 34;  // 2 (fp16 scale) + 32 (int8 quants)
+
+    size_t fp16_count = static_cast<size_t>(N * K);
+    std::vector<uint16_t> h_fp16(fp16_count);
+
+    const uint8_t* raw = static_cast<const uint8_t*>(weight.data);
+
+    for (int64_t n = 0; n < N; ++n) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            const uint8_t* block_ptr = raw + (n * blocks_per_row + b) * Q8_0_BLOCK_SIZE;
+
+            uint16_t scale_bits;
+            std::memcpy(&scale_bits, block_ptr, 2);
+            float scale_f = fp16_to_float(scale_bits);
+
+            const int8_t* quants = reinterpret_cast<const int8_t*>(block_ptr + 2);
+            for (int q = 0; q < 32; ++q) {
+                float val = static_cast<float>(quants[q]) * scale_f;
+                h_fp16[n * K + b * 32 + q] = float_to_fp16(val);
+            }
+        }
+    }
+
+    size_t bytes = fp16_count * sizeof(uint16_t);
+    void* d_data = nullptr;
+    checked_cuda_malloc(&d_data, bytes);
+    if (!d_data)
+        return false;
+    h2d_copy(d_data, h_fp16.data(), bytes, stream);
+    gpu_allocs.push_back(d_data);
+
+    int64_t new_shape[4] = {N, K, 0, 0};
+    weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+    return true;
+}
+
+// Per-qtype upload handler extracted from upload_weight: q6_k path.
+static bool upload_qtype_q6_k_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    if (weight.ndim < 2) {
+        IMP_LOG_WARN("Q6_K weight has < 2 dims, skipping upload");
+        return false;
+    }
+
+    int64_t N = weight.shape[0];
+    int64_t K = weight.shape[1];
+
+    // Raw upload: keep quantized bytes on GPU, dequant on-the-fly in executor
+    if (raw_quant) {
+        size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
+        void* d_data = nullptr;
+        checked_cuda_malloc(&d_data, raw_bytes);
+        if (!d_data)
+            return false;
+        h2d_copy(d_data, weight.data, raw_bytes, stream);
         gpu_allocs.push_back(d_data);
 
         int64_t new_shape[4] = {N, K, 0, 0};
-        weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+        weight = Tensor(d_data, qtype, 2, new_shape, true);
         return true;
     }
 
-    // ---- Q6_K ----
-    if (qtype == QType::Q6_K) {
-        if (weight.ndim < 2) {
-            IMP_LOG_WARN("Q6_K weight has < 2 dims, skipping upload");
-            return false;
-        }
+    // CPU dequant fallback: decode to FP16 on host, upload
+    int blocks_per_row = static_cast<int>(K) / 256;
+    static constexpr size_t Q6_K_BLOCK_SIZE = 210;
 
-        int64_t N = weight.shape[0];
-        int64_t K = weight.shape[1];
+    size_t fp16_count = static_cast<size_t>(N * K);
+    std::vector<uint16_t> h_fp16(fp16_count);
 
-        // Raw upload: keep quantized bytes on GPU, dequant on-the-fly in executor
-        if (raw_quant) {
-            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
-            void* d_data = nullptr;
-            checked_cuda_malloc(&d_data, raw_bytes);
-            if (!d_data)
-                return false;
-            h2d_copy(d_data, weight.data, raw_bytes, stream);
-            gpu_allocs.push_back(d_data);
+    const uint8_t* raw = static_cast<const uint8_t*>(weight.data);
 
-            int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, qtype, 2, new_shape, true);
-            return true;
-        }
+    for (int64_t n = 0; n < N; ++n) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            const uint8_t* block_ptr = raw + (n * blocks_per_row + b) * Q6_K_BLOCK_SIZE;
 
-        // CPU dequant fallback: decode to FP16 on host, upload
-        int blocks_per_row = static_cast<int>(K) / 256;
-        static constexpr size_t Q6_K_BLOCK_SIZE = 210;
+            const uint8_t* ql = block_ptr;
+            const uint8_t* qh = block_ptr + 128;
+            const int8_t* scales = reinterpret_cast<const int8_t*>(block_ptr + 192);
+            uint16_t d_bits;
+            std::memcpy(&d_bits, block_ptr + 208, 2);
+            float d = fp16_to_float(d_bits);
 
-        size_t fp16_count = static_cast<size_t>(N * K);
-        std::vector<uint16_t> h_fp16(fp16_count);
+            for (int i = 0; i < 256; ++i) {
+                int group = i / 128;
+                int within = i % 128;
+                int quad = within / 32;
+                int l = within % 32;
 
-        const uint8_t* raw = static_cast<const uint8_t*>(weight.data);
+                int ql_idx = group * 64 + (quad & 1) * 32 + l;
+                int qh_idx = group * 32 + l;
 
-        for (int64_t n = 0; n < N; ++n) {
-            for (int b = 0; b < blocks_per_row; ++b) {
-                const uint8_t* block_ptr = raw + (n * blocks_per_row + b) * Q6_K_BLOCK_SIZE;
-
-                const uint8_t* ql = block_ptr;
-                const uint8_t* qh = block_ptr + 128;
-                const int8_t* scales = reinterpret_cast<const int8_t*>(block_ptr + 192);
-                uint16_t d_bits;
-                std::memcpy(&d_bits, block_ptr + 208, 2);
-                float d = fp16_to_float(d_bits);
-
-                for (int i = 0; i < 256; ++i) {
-                    int group = i / 128;
-                    int within = i % 128;
-                    int quad = within / 32;
-                    int l = within % 32;
-
-                    int ql_idx = group * 64 + (quad & 1) * 32 + l;
-                    int qh_idx = group * 32 + l;
-
-                    uint8_t ql_byte = ql[ql_idx];
-                    uint8_t low4 = (quad >= 2) ? ((ql_byte >> 4) & 0xF) : (ql_byte & 0xF);
-                    uint8_t high2 = (qh[qh_idx] >> (quad * 2)) & 0x3;
-                    int q6 = static_cast<int>((high2 << 4) | low4) - 32;
-                    float val = d * static_cast<float>(scales[i / 16]) * static_cast<float>(q6);
-                    h_fp16[n * K + b * 256 + i] = float_to_fp16(val);
-                }
+                uint8_t ql_byte = ql[ql_idx];
+                uint8_t low4 = (quad >= 2) ? ((ql_byte >> 4) & 0xF) : (ql_byte & 0xF);
+                uint8_t high2 = (qh[qh_idx] >> (quad * 2)) & 0x3;
+                int q6 = static_cast<int>((high2 << 4) | low4) - 32;
+                float val = d * static_cast<float>(scales[i / 16]) * static_cast<float>(q6);
+                h_fp16[n * K + b * 256 + i] = float_to_fp16(val);
             }
         }
+    }
 
-        size_t bytes = fp16_count * sizeof(uint16_t);
+    size_t bytes = fp16_count * sizeof(uint16_t);
+    void* d_data = nullptr;
+    checked_cuda_malloc(&d_data, bytes);
+    if (!d_data)
+        return false;
+    h2d_copy(d_data, h_fp16.data(), bytes, stream);
+    gpu_allocs.push_back(d_data);
+
+    int64_t new_shape[4] = {N, K, 0, 0};
+    weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+    return true;
+}
+
+// Per-qtype upload handler extracted from upload_weight: general_quant path.
+static bool upload_qtype_general_quant_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    int64_t N = weight.shape[0];
+    int64_t K = weight.shape[1];
+
+    if (raw_quant) {
+        // Upload raw quantized bytes — executor dequants on-the-fly
+        size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
         void* d_data = nullptr;
-        checked_cuda_malloc(&d_data, bytes);
+        checked_cuda_malloc(&d_data, raw_bytes);
         if (!d_data)
             return false;
-        h2d_copy(d_data, h_fp16.data(), bytes, stream);
+        cudaError_t cpy_err = h2d_copy(d_data, weight.data, raw_bytes, stream);
+        if (cpy_err != cudaSuccess) {
+            IMP_LOG_ERROR("h2d_copy failed for qtype=%u [%ldx%ld] %zu bytes: %s", (unsigned)qtype,
+                          (long)N, (long)K, raw_bytes, cudaGetErrorString(cpy_err));
+        }
         gpu_allocs.push_back(d_data);
-
+        IMP_LOG_DEBUG("Upload raw qtype=%u [%ldx%ld] %zu bytes -> GPU %p", (unsigned)qtype, (long)N,
+                      (long)K, raw_bytes, d_data);
         int64_t new_shape[4] = {N, K, 0, 0};
-        weight = Tensor(d_data, QType::F16, 2, new_shape, true);
+        weight = Tensor(d_data, qtype, 2, new_shape, true);
         return true;
-    }
+    } else {
+        // Dequant on GPU: upload raw → dequant to FP16 → free raw
+        size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
+        void* d_raw = nullptr;
+        checked_cuda_malloc(&d_raw, raw_bytes);
+        if (!d_raw)
+            return false;
+        h2d_copy(d_raw, weight.data, raw_bytes, stream);
 
-    // ---- General quantized types (Q5_0, Q5_1, Q4_K, etc.) ----
-    // Any type supported by dequant_gpu that wasn't handled above.
-    if (dequant_gpu_supported(qtype) && weight.ndim >= 2) {
-        int64_t N = weight.shape[0];
-        int64_t K = weight.shape[1];
-
-        if (raw_quant) {
-            // Upload raw quantized bytes — executor dequants on-the-fly
-            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
-            void* d_data = nullptr;
-            checked_cuda_malloc(&d_data, raw_bytes);
-            if (!d_data)
-                return false;
-            cudaError_t cpy_err = h2d_copy(d_data, weight.data, raw_bytes, stream);
-            if (cpy_err != cudaSuccess) {
-                IMP_LOG_ERROR("h2d_copy failed for qtype=%u [%ldx%ld] %zu bytes: %s", (unsigned)qtype,
-                              (long)N, (long)K, raw_bytes, cudaGetErrorString(cpy_err));
-            }
-            gpu_allocs.push_back(d_data);
-            IMP_LOG_DEBUG("Upload raw qtype=%u [%ldx%ld] %zu bytes -> GPU %p", (unsigned)qtype, (long)N,
-                          (long)K, raw_bytes, d_data);
-            int64_t new_shape[4] = {N, K, 0, 0};
-            weight = Tensor(d_data, qtype, 2, new_shape, true);
-            return true;
-        } else {
-            // Dequant on GPU: upload raw → dequant to FP16 → free raw
-            size_t raw_bytes = static_cast<size_t>(N) * qtype_row_bytes(qtype, K);
-            void* d_raw = nullptr;
-            checked_cuda_malloc(&d_raw, raw_bytes);
-            if (!d_raw)
-                return false;
-            h2d_copy(d_raw, weight.data, raw_bytes, stream);
-
-            size_t fp16_bytes = static_cast<size_t>(N) * K * sizeof(uint16_t);
-            void* d_fp16 = nullptr;
-            checked_cuda_malloc(&d_fp16, fp16_bytes);
-            if (!d_fp16) {
-                IMP_CUDA_CHECK_LOG(cudaFree(d_raw));
-                return false;
-            }
-
-            dequant_gpu(d_raw, d_fp16, qtype, static_cast<int>(N), static_cast<int>(K), stream);
-            IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+        size_t fp16_bytes = static_cast<size_t>(N) * K * sizeof(uint16_t);
+        void* d_fp16 = nullptr;
+        checked_cuda_malloc(&d_fp16, fp16_bytes);
+        if (!d_fp16) {
             IMP_CUDA_CHECK_LOG(cudaFree(d_raw));
-            gpu_allocs.push_back(d_fp16);
-
-            weight = Tensor(d_fp16, QType::F16, weight.ndim, weight.shape, true);
-            return true;
-        }
-    }
-
-    // ---- F16: direct upload ----
-    if (qtype == QType::F16) {
-        size_t bytes = weight.nbytes();
-        void* d_data = nullptr;
-        checked_cuda_malloc(&d_data, bytes);
-        if (!d_data)
             return false;
-        h2d_copy(d_data, weight.data, bytes, stream);
-        gpu_allocs.push_back(d_data);
+        }
 
-        weight.data = d_data;
-        weight.on_device = true;
+        dequant_gpu(d_raw, d_fp16, qtype, static_cast<int>(N), static_cast<int>(K), stream);
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+        IMP_CUDA_CHECK_LOG(cudaFree(d_raw));
+        gpu_allocs.push_back(d_fp16);
+
+        weight = Tensor(d_fp16, QType::F16, weight.ndim, weight.shape, true);
         return true;
     }
-    // ---- BF16 (GGUF): convert to FP16 on host, then upload ----
-    if (qtype == QType::BF16) {
+}
+
+// Per-qtype upload handler extracted from upload_weight: f16 path.
+static bool upload_qtype_f16_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    size_t bytes = weight.nbytes();
+    void* d_data = nullptr;
+    checked_cuda_malloc(&d_data, bytes);
+    if (!d_data)
+        return false;
+    h2d_copy(d_data, weight.data, bytes, stream);
+    gpu_allocs.push_back(d_data);
+
+    weight.data = d_data;
+    weight.on_device = true;
+    return true;
+}
+
+// Per-qtype upload handler extracted from upload_weight: bf16 path.
+static bool upload_qtype_bf16_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    int64_t n_elem = weight.numel();
+    const uint16_t* src = static_cast<const uint16_t*>(weight.data);
+    std::vector<uint16_t> h_fp16(static_cast<size_t>(n_elem));
+    for (int64_t i = 0; i < n_elem; ++i) {
+        uint32_t bits = static_cast<uint32_t>(src[i]) << 16;
+        float f;
+        std::memcpy(&f, &bits, sizeof(float));
+        f += weight_offset;
+        h_fp16[i] = float_to_fp16(f);
+    }
+    size_t bytes = static_cast<size_t>(n_elem) * sizeof(uint16_t);
+    void* d_data = nullptr;
+    checked_cuda_malloc(&d_data, bytes);
+    if (!d_data)
+        return false;
+    h2d_copy(d_data, h_fp16.data(), bytes, stream);
+    gpu_allocs.push_back(d_data);
+    weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
+    return true;
+}
+
+// Per-qtype upload handler extracted from upload_weight: f32 path.
+static bool upload_qtype_f32_(Tensor& weight, QType qtype, QType compute_dtype,
+                                 cudaStream_t stream, std::vector<void*>& gpu_allocs,
+                                 bool raw_quant, float weight_offset) {
+    // BF16 (SafeTensors non-quantized weights): convert to FP16
+    if (weight.qtype == QType::BF16) {
         int64_t n_elem = weight.numel();
         const uint16_t* src = static_cast<const uint16_t*>(weight.data);
         std::vector<uint16_t> h_fp16(static_cast<size_t>(n_elem));
         for (int64_t i = 0; i < n_elem; ++i) {
+            // BF16 → float: zero-fill lower mantissa bits
             uint32_t bits = static_cast<uint32_t>(src[i]) << 16;
             float f;
             std::memcpy(&f, &bits, sizeof(float));
@@ -618,78 +641,10 @@ static bool upload_weight(Tensor& weight, QType qtype, QType compute_dtype, cuda
         weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
         return true;
     }
-
-    // ---- F32: convert to FP16 on host, then upload ----
-    if (qtype == QType::F32 || qtype == QType::NONE) {
-        // BF16 (SafeTensors non-quantized weights): convert to FP16
-        if (weight.qtype == QType::BF16) {
-            int64_t n_elem = weight.numel();
-            const uint16_t* src = static_cast<const uint16_t*>(weight.data);
-            std::vector<uint16_t> h_fp16(static_cast<size_t>(n_elem));
-            for (int64_t i = 0; i < n_elem; ++i) {
-                // BF16 → float: zero-fill lower mantissa bits
-                uint32_t bits = static_cast<uint32_t>(src[i]) << 16;
-                float f;
-                std::memcpy(&f, &bits, sizeof(float));
-                f += weight_offset;
-                h_fp16[i] = float_to_fp16(f);
-            }
-            size_t bytes = static_cast<size_t>(n_elem) * sizeof(uint16_t);
-            void* d_data = nullptr;
-            checked_cuda_malloc(&d_data, bytes);
-            if (!d_data)
-                return false;
-            h2d_copy(d_data, h_fp16.data(), bytes, stream);
-            gpu_allocs.push_back(d_data);
-            weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
-            return true;
-        }
-        // NONE maps to F32 (both are enum value 0)
-        if (weight.qtype != QType::F32) {
-            // If it's not actually FP32 data (e.g. INT8/U8 packed FP4), direct upload
-            size_t bytes = weight.nbytes();
-            void* d_data = nullptr;
-            checked_cuda_malloc(&d_data, bytes);
-            if (!d_data)
-                return false;
-            h2d_copy(d_data, weight.data, bytes, stream);
-            gpu_allocs.push_back(d_data);
-            weight.data = d_data;
-            weight.on_device = true;
-            return true;
-        }
-
-        int64_t n_elem = weight.numel();
-        const float* src = static_cast<const float*>(weight.data);
-        std::vector<uint16_t> h_fp16(static_cast<size_t>(n_elem));
-
-        for (int64_t i = 0; i < n_elem; ++i) {
-            h_fp16[i] = float_to_fp16(src[i]);
-        }
-
-        size_t bytes = static_cast<size_t>(n_elem) * sizeof(uint16_t);
-        void* d_data = nullptr;
-        checked_cuda_malloc(&d_data, bytes);
-        if (!d_data)
-            return false;
-        h2d_copy(d_data, h_fp16.data(), bytes, stream);
-        gpu_allocs.push_back(d_data);
-
-        weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
-        return true;
-    }
-
-    // Fallback: raw direct upload of opaque bytes (preserves qtype). Used for
-    // NVFP4/MXFP4/FP4_E2M1/INT8/INT4 packed-byte payloads that the SafeTensors
-    // loader categorises as "raw bytes" — e.g. NVFP4 prequant `weight_packed`
-    // arrives with qtype=INT8 (U8 wire dtype) and is later promoted to
-    // qtype=NVFP4 by executor_pre_dequant.cu Phase 0.
-    {
+    // NONE maps to F32 (both are enum value 0)
+    if (weight.qtype != QType::F32) {
+        // If it's not actually FP32 data (e.g. INT8/U8 packed FP4), direct upload
         size_t bytes = weight.nbytes();
-        if (bytes == 0) {
-            IMP_LOG_WARN("Empty raw weight for qtype %u, skipping", static_cast<unsigned>(qtype));
-            return false;
-        }
         void* d_data = nullptr;
         checked_cuda_malloc(&d_data, bytes);
         if (!d_data)
@@ -700,6 +655,81 @@ static bool upload_weight(Tensor& weight, QType qtype, QType compute_dtype, cuda
         weight.on_device = true;
         return true;
     }
+
+    int64_t n_elem = weight.numel();
+    const float* src = static_cast<const float*>(weight.data);
+    std::vector<uint16_t> h_fp16(static_cast<size_t>(n_elem));
+
+    for (int64_t i = 0; i < n_elem; ++i) {
+        h_fp16[i] = float_to_fp16(src[i]);
+    }
+
+    size_t bytes = static_cast<size_t>(n_elem) * sizeof(uint16_t);
+    void* d_data = nullptr;
+    checked_cuda_malloc(&d_data, bytes);
+    if (!d_data)
+        return false;
+    h2d_copy(d_data, h_fp16.data(), bytes, stream);
+    gpu_allocs.push_back(d_data);
+
+    weight = Tensor(d_data, QType::F16, weight.ndim, weight.shape, true);
+    return true;
+}
+
+// Raw-byte fallback upload (NVFP4/MXFP4/FP4_E2M1/INT8/INT4 packed payloads)
+static bool upload_qtype_raw_fallback_(Tensor& weight, QType qtype, cudaStream_t stream,
+                                       std::vector<void*>& gpu_allocs) {
+    size_t bytes = weight.nbytes();
+    if (bytes == 0) {
+        IMP_LOG_WARN("Empty raw weight for qtype %u, skipping", static_cast<unsigned>(qtype));
+        return false;
+    }
+    void* d_data = nullptr;
+    checked_cuda_malloc(&d_data, bytes);
+    if (!d_data)
+        return false;
+    h2d_copy(d_data, weight.data, bytes, stream);
+    gpu_allocs.push_back(d_data);
+    weight.data = d_data;
+    weight.on_device = true;
+    return true;
+}
+
+static bool upload_weight(Tensor& weight, QType qtype, QType compute_dtype, cudaStream_t stream,
+                          std::vector<void*>& gpu_allocs, bool raw_quant = true, float weight_offset = 0.0f) {
+    // weight_offset: added to each FP32 element BEFORE FP16 conversion. Only
+    // applied on BF16-source paths (qtype==BF16 or qtype==F32/NONE with
+    // weight.qtype==BF16). F32-source paths leave it unused — GGUF norms
+    // already carry the offset baked in by the converter; SafeTensors stores
+    // the delta `W` (where actual gamma = 1 + W) for Qwen3.5/3.6 block norms.
+    if (weight.data == nullptr || weight.on_device)
+        return true;
+    if (weight.ndim < 1)
+        return true;
+
+    int64_t n_elements = weight.numel();
+    if (n_elements == 0)
+        return true;
+
+    if (qtype == QType::MXFP4)
+        return upload_qtype_mxfp4_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+    if (qtype == QType::Q4_0)
+        return upload_qtype_q4_0_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+    if (qtype == QType::Q8_0)
+        return upload_qtype_q8_0_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+    if (qtype == QType::Q6_K)
+        return upload_qtype_q6_k_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+    if (dequant_gpu_supported(qtype) && weight.ndim >= 2)
+        return upload_qtype_general_quant_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+    if (qtype == QType::F16)
+        return upload_qtype_f16_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+    if (qtype == QType::BF16)
+        return upload_qtype_bf16_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+    if (qtype == QType::F32 || qtype == QType::NONE)
+        return upload_qtype_f32_(weight, qtype, compute_dtype, stream, gpu_allocs, raw_quant, weight_offset);
+
+    // Fallback: raw direct upload of opaque bytes (preserves qtype).
+    return upload_qtype_raw_fallback_(weight, qtype, stream, gpu_allocs);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1421,11 +1421,13 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i, const UploadCtx
 // upload_expert_weights: MoE expert weight upload for all layers (Pass 2).
 // Handles packed 3D tensors and per-expert 2D tensors.
 // ---------------------------------------------------------------------------
-static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_layers,
-                                  size_t expert_reserve_bytes, const UploadCtx& ctx) {
-    // Compute per-layer expert weight costs
+// Phase 1 of upload_expert_weights: compute per-layer expert-tensor byte cost
+// for the packed 3-D tensors PLUS per-expert 2-D tensors (NVFP4 llm-compressor
+// format). Returns total_expert_bytes; fills layer_expert_bytes in place.
+static size_t compute_expert_layer_costs_(const std::vector<TransformerLayer>& layers, int n_layers,
+                                          std::vector<size_t>& layer_expert_bytes) {
     size_t total_expert_bytes = 0;
-    std::vector<size_t> layer_expert_bytes(n_layers, 0);
+    layer_expert_bytes.assign(n_layers, 0);
     for (int i = 0; i < n_layers; ++i) {
         const TransformerLayer& L = layers[i];
         auto add_packed = [&](const Tensor& p, QType qt) {
@@ -1454,127 +1456,127 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
         add_2d_expert(L.expert_w_up);
         add_2d_expert(L.expert_w_down);
     }
+    return total_expert_bytes;
+}
 
-    // Decide which expert layers to upload based on actual remaining VRAM
-    std::vector<bool> experts_upload_layer(n_layers, false);
-    if (total_expert_bytes > 0) {
-        size_t free_mem = 0, total_mem = 0;
-        cudaMemGetInfo(&free_mem, &total_mem);
+// Phase 2 of upload_expert_weights: pick which MoE layers' experts stay on
+// GPU vs go to host. Honors:
+//   - VRAM reserve passed by Engine (KV cache + workspaces + FP16 cache),
+//   - WSL2/WDDM driver overhead (auto-pick 10 % aggressive if all fit, else
+//     30 % conservative), explicit overhead_pct override (0..50),
+//   - moe.force_host_experts = N debug flag (last N MoE layers off-GPU).
+// Also re-arms the g_cached_free_mem / g_total_allocated / g_vram_reserve
+// trio so per-expert checked_cuda_malloc calls don't double-count the
+// reserve.
+static void decide_expert_layer_placement_(const std::vector<size_t>& layer_expert_bytes,
+                                           size_t total_expert_bytes, size_t expert_reserve_bytes,
+                                           int n_layers, std::vector<bool>& experts_upload_layer) {
+    if (total_expert_bytes == 0)
+        return;
 
-        // Reserve for KV cache + SSM state + activation workspace + FP16 cache.
-        // Engine passes the exact reserve based on computed workspace sizes.
-        // CUDA driver overhead on WSL2/WDDM: cudaMalloc alignment, page tables,
-        // and WDDM shared memory management consume ~30% beyond the requested size.
-        // Empirical on RTX 5090 WSL2: 22 GiB expert alloc leaves 0 MiB from 28.7 GiB free.
-        //
-        // Auto-pick default: use 10% (aggressive) if ALL experts would fit with
-        // that overhead, else 30% (conservative). This saves users from a
-        // silent 3× perf penalty on Qwen3-Coder-30B / Qwen3.6-35B-class MoE
-        // models where the conservative default unnecessarily offloads experts
-        // to host (measured: 77 → 237 tok/s with 10% vs 30% on Qwen3-Coder-30B
-        // Q6_K, RTX 5090 native Linux).
-        //
-        // IMP_EXPERT_OVERHEAD_PCT: explicit override (integer 0..50). Required
-        // on WSL2/WDDM where the 10% auto-aggressive path may OOM at alloc time.
-        // [moe] expert_overhead_pct: explicit override (0..50). Default 10
-        // requests aggressive auto-pick; values outside the range fall back
-        // to the conservative 30% reserve.
-        int overhead_pct = RuntimeConfig::current().moe.expert_overhead_pct;
-        if (overhead_pct < 0 || overhead_pct > 50) {
+    size_t free_mem = 0, total_mem = 0;
+    cudaMemGetInfo(&free_mem, &total_mem);
+
+    // Auto-pick default: use 10% (aggressive) if ALL experts would fit with
+    // that overhead, else 30% (conservative). This saves users from a
+    // silent 3× perf penalty on Qwen3-Coder-30B / Qwen3.6-35B-class MoE
+    // models where the conservative default unnecessarily offloads experts
+    // to host (measured: 77 → 237 tok/s with 10% vs 30% on Qwen3-Coder-30B
+    // Q6_K, RTX 5090 native Linux).
+    int overhead_pct = RuntimeConfig::current().moe.expert_overhead_pct;
+    if (overhead_pct < 0 || overhead_pct > 50) {
+        overhead_pct = 30;
+    } else if (overhead_pct == 10) {
+        size_t aggressive_overhead = static_cast<size_t>(free_mem * 10 / 100);
+        size_t aggressive_reserve = expert_reserve_bytes + aggressive_overhead;
+        size_t aggressive_budget = (free_mem > aggressive_reserve) ? (free_mem - aggressive_reserve) : 0;
+        if (aggressive_budget < total_expert_bytes) {
             overhead_pct = 30;
-        } else if (overhead_pct == 10) {
-            // Auto-pick: probe with aggressive 10%. If all experts fit, use it.
-            // Else fall back to conservative 30%.
-            size_t aggressive_overhead = static_cast<size_t>(free_mem * 10 / 100);
-            size_t aggressive_reserve = expert_reserve_bytes + aggressive_overhead;
-            size_t aggressive_budget = (free_mem > aggressive_reserve) ? (free_mem - aggressive_reserve) : 0;
-            if (aggressive_budget < total_expert_bytes) {
-                overhead_pct = 30;
-            } else {
-                IMP_LOG_INFO(
-                    "Expert offload: all experts fit with 10%% overhead "
-                    "(%.2f GiB experts, %.2f GiB free) — picking aggressive.",
-                    total_expert_bytes / (1024.0 * 1024.0 * 1024.0), free_mem / (1024.0 * 1024.0 * 1024.0));
-            }
-        }
-        size_t overhead = static_cast<size_t>(free_mem * overhead_pct / 100);
-        size_t total_reserve = expert_reserve_bytes + overhead;
-        size_t budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
-
-        // [moe] force_host_experts = N: debug flag forcing the last N MoE
-        // layers off-GPU regardless of budget. Use for reproducing host-
-        // resident path bugs on a smaller quant.
-        int force_host_n = RuntimeConfig::current().moe.force_host_experts;
-        if (force_host_n < 0)
-            force_host_n = 0;
-
-        if (budget >= total_expert_bytes && force_host_n == 0) {
-            // All experts fit
-            for (int i = 0; i < n_layers; ++i) {
-                if (layer_expert_bytes[i] > 0)
-                    experts_upload_layer[i] = true;
-            }
-            IMP_LOG_INFO(
-                "Expert weights: %.2f GiB -> uploading ALL to GPU "
-                "(%.2f GiB free, %.2f GiB reserve)",
-                total_expert_bytes / (1024.0 * 1024.0 * 1024.0), free_mem / (1024.0 * 1024.0 * 1024.0),
-                expert_reserve_bytes / (1024.0 * 1024.0 * 1024.0));
-        } else if (force_host_n > 0) {
-            // Debug: force last N MoE layers to host. Still respect budget for
-            // the ones we do upload.
-            std::vector<int> moe_layer_idxs;
-            for (int i = 0; i < n_layers; ++i)
-                if (layer_expert_bytes[i] > 0)
-                    moe_layer_idxs.push_back(i);
-            int skip_from = std::max(0, (int)moe_layer_idxs.size() - force_host_n);
-            size_t uploaded = 0;
-            int n_uploaded = 0;
-            for (int k = 0; k < skip_from; ++k) {
-                int i = moe_layer_idxs[k];
-                if (uploaded + layer_expert_bytes[i] <= budget) {
-                    experts_upload_layer[i] = true;
-                    uploaded += layer_expert_bytes[i];
-                    n_uploaded++;
-                }
-            }
-            IMP_LOG_INFO(
-                "Expert weights (IMP_FORCE_HOST_EXPERTS=%d): uploading %d/%zu MoE layers, %d forced to host",
-                force_host_n, n_uploaded, moe_layer_idxs.size(), force_host_n);
         } else {
-            // Partial upload: greedily upload layers until budget exhausted
-            size_t uploaded = 0;
-            int n_uploaded = 0, n_total_moe = 0;
-            for (int i = 0; i < n_layers; ++i) {
-                if (layer_expert_bytes[i] == 0)
-                    continue;
-                n_total_moe++;
-                if (uploaded + layer_expert_bytes[i] <= budget) {
-                    experts_upload_layer[i] = true;
-                    uploaded += layer_expert_bytes[i];
-                    n_uploaded++;
-                }
-            }
             IMP_LOG_INFO(
-                "Expert weights: %.2f GiB total, uploading %d/%d MoE layers "
-                "(%.2f GiB on GPU, %.2f GiB on host, %.2f GiB free, "
-                "%.2f GiB reserve)",
-                total_expert_bytes / (1024.0 * 1024.0 * 1024.0), n_uploaded, n_total_moe,
-                uploaded / (1024.0 * 1024.0 * 1024.0),
-                (total_expert_bytes - uploaded) / (1024.0 * 1024.0 * 1024.0),
-                free_mem / (1024.0 * 1024.0 * 1024.0), expert_reserve_bytes / (1024.0 * 1024.0 * 1024.0));
+                "Expert offload: all experts fit with 10%% overhead "
+                "(%.2f GiB experts, %.2f GiB free) — picking aggressive.",
+                total_expert_bytes / (1024.0 * 1024.0 * 1024.0), free_mem / (1024.0 * 1024.0 * 1024.0));
         }
-
-        // Re-arm the cached free-memory window so per-expert checked_cuda_malloc
-        // calls don't fall back to a sync cudaMemGetInfo on every tensor.
-        // The budget we just computed is what we plan to spend; reflect that
-        // as headroom in the cached counter.
-        g_cached_free_mem = free_mem;
-        g_total_allocated = 0;
-        // We've already accounted for expert_reserve_bytes + overhead in the
-        // budget decision above, so for checked_cuda_malloc we drop the
-        // per-call reserve to avoid double-counting.
-        g_vram_reserve = 0;
     }
+    size_t overhead = static_cast<size_t>(free_mem * overhead_pct / 100);
+    size_t total_reserve = expert_reserve_bytes + overhead;
+    size_t budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
+
+    int force_host_n = RuntimeConfig::current().moe.force_host_experts;
+    if (force_host_n < 0)
+        force_host_n = 0;
+
+    if (budget >= total_expert_bytes && force_host_n == 0) {
+        for (int i = 0; i < n_layers; ++i) {
+            if (layer_expert_bytes[i] > 0)
+                experts_upload_layer[i] = true;
+        }
+        IMP_LOG_INFO(
+            "Expert weights: %.2f GiB -> uploading ALL to GPU "
+            "(%.2f GiB free, %.2f GiB reserve)",
+            total_expert_bytes / (1024.0 * 1024.0 * 1024.0), free_mem / (1024.0 * 1024.0 * 1024.0),
+            expert_reserve_bytes / (1024.0 * 1024.0 * 1024.0));
+    } else if (force_host_n > 0) {
+        // Debug: force last N MoE layers to host. Still respect budget for
+        // the ones we do upload.
+        std::vector<int> moe_layer_idxs;
+        for (int i = 0; i < n_layers; ++i)
+            if (layer_expert_bytes[i] > 0)
+                moe_layer_idxs.push_back(i);
+        int skip_from = std::max(0, (int)moe_layer_idxs.size() - force_host_n);
+        size_t uploaded = 0;
+        int n_uploaded = 0;
+        for (int k = 0; k < skip_from; ++k) {
+            int i = moe_layer_idxs[k];
+            if (uploaded + layer_expert_bytes[i] <= budget) {
+                experts_upload_layer[i] = true;
+                uploaded += layer_expert_bytes[i];
+                n_uploaded++;
+            }
+        }
+        IMP_LOG_INFO(
+            "Expert weights (IMP_FORCE_HOST_EXPERTS=%d): uploading %d/%zu MoE layers, %d forced to host",
+            force_host_n, n_uploaded, moe_layer_idxs.size(), force_host_n);
+    } else {
+        // Partial upload: greedily upload layers until budget exhausted
+        size_t uploaded = 0;
+        int n_uploaded = 0, n_total_moe = 0;
+        for (int i = 0; i < n_layers; ++i) {
+            if (layer_expert_bytes[i] == 0)
+                continue;
+            n_total_moe++;
+            if (uploaded + layer_expert_bytes[i] <= budget) {
+                experts_upload_layer[i] = true;
+                uploaded += layer_expert_bytes[i];
+                n_uploaded++;
+            }
+        }
+        IMP_LOG_INFO(
+            "Expert weights: %.2f GiB total, uploading %d/%d MoE layers "
+            "(%.2f GiB on GPU, %.2f GiB on host, %.2f GiB free, "
+            "%.2f GiB reserve)",
+            total_expert_bytes / (1024.0 * 1024.0 * 1024.0), n_uploaded, n_total_moe,
+            uploaded / (1024.0 * 1024.0 * 1024.0),
+            (total_expert_bytes - uploaded) / (1024.0 * 1024.0 * 1024.0),
+            free_mem / (1024.0 * 1024.0 * 1024.0), expert_reserve_bytes / (1024.0 * 1024.0 * 1024.0));
+    }
+
+    // Re-arm the cached free-memory window so per-expert checked_cuda_malloc
+    // calls don't fall back to a sync cudaMemGetInfo on every tensor.
+    g_cached_free_mem = free_mem;
+    g_total_allocated = 0;
+    g_vram_reserve = 0;  // budget already accounted for above
+}
+
+static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_layers,
+                                  size_t expert_reserve_bytes, const UploadCtx& ctx) {
+    std::vector<size_t> layer_expert_bytes;
+    size_t total_expert_bytes = compute_expert_layer_costs_(layers, n_layers, layer_expert_bytes);
+
+    std::vector<bool> experts_upload_layer(n_layers, false);
+    decide_expert_layer_placement_(layer_expert_bytes, total_expert_bytes, expert_reserve_bytes, n_layers,
+                                   experts_upload_layer);
 
     // Upload expert weights for each layer
     for (int i = 0; i < n_layers; ++i) {


### PR DESCRIPTION
## Summary
Last god-function pair on the original list: `upload_weight` (459 LOC) + `upload_expert_weights` (439 LOC) in `src/model/weight_upload.cu`.

| Function | Before | After | Δ |
|---|---:|---:|---:|
| `upload_weight` | 459 | **36** | –92 % |
| `upload_expert_weights` | 439 | **294** | –33 % |

Pure structural — same per-qtype upload paths, same VRAM-budget arithmetic, same `gpu_allocs` push order. Branch order in `upload_weight` and the cost/placement decision in `upload_expert_weights` preserved bit-identical.

## What moved out

### From `upload_weight` (9 per-qtype helpers)
| Helper | Path | LOC |
|---|---|---:|
| `upload_qtype_mxfp4_` | GGUF native MXFP4 split [data | scale] upload | ~46 |
| `upload_qtype_q4_0_` | Q4_0 raw upload + split nibbles+scales fallback | ~85 |
| `upload_qtype_q8_0_` | Q8_0 raw upload + CPU dequant fallback | ~63 |
| `upload_qtype_q6_k_` | Q6_K raw upload + CPU dequant fallback | ~76 |
| `upload_qtype_general_quant_` | dequant_gpu-supported types (Q4_K, Q5_0/1, etc.) | ~50 |
| `upload_qtype_f16_` | direct upload | ~13 |
| `upload_qtype_bf16_` | GGUF BF16 → FP16 host convert | ~22 |
| `upload_qtype_f32_` | F32/NONE with weight_offset + BF16-source variant | ~58 |
| `upload_qtype_raw_fallback_` | opaque-byte fallback (NVFP4 prequant) | ~16 |

`upload_weight` is now a linear dispatcher: 8 `if (qtype == ...) return upload_qtype_X_(...);` plus fallback.

### From `upload_expert_weights` (2 phase helpers)
- `compute_expert_layer_costs_` — per-layer expert-tensor byte cost (packed 3-D + per-expert 2-D llm-compressor)
- `decide_expert_layer_placement_` — pick which MoE layers stay GPU vs host; auto-pick 10 % aggressive vs 30 % conservative overhead, `moe.force_host_experts` debug flag, `g_cached_free_mem` re-arm

The remaining 294 LOC is the per-layer upload loop with the `upload_packed_experts` lambda. That captures too much shared state for a clean extraction without a context struct — deferred.

## Test plan
- [x] `make build` — green
- [x] `DegenerationTest.*` (5/5 on Qwen3-8B Q8_0) — all PASSED
- [x] Gemma-4-26B-A4B Q4_K_M smoke (exercises `upload_qtype_general_quant_` + `compute_expert_layer_costs_` + `decide_expert_layer_placement_` + expert-upload loop): `"The capital of France is"` → `"...Paris."` coherent
- [x] Gemma-4-26B-A4B NVFP4 5-rep bench: tg256 = **211.91 tok/s** vs post-PR-#283 baseline 211.33 → Δ +0.3 % (within noise)

**Conclusion: no perf regression, refactor is bit-equivalent and perf-neutral.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)