### PR TITLE
chore(deps): bump cpp-httplib 0.42.0 → 0.45.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ endif()
 if(IMP_BUILD_SERVER)
     FetchContent_Declare(httplib
         GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-        GIT_TAG v0.42.0
+        GIT_TAG v0.45.0
         GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(httplib)


### PR DESCRIPTION
## Summary

- Bumps `cpp-httplib` 3 minor versions (v0.42.0 → v0.45.0, latest released 2026-05-15). Only affects `imp-server`.
- v0.43 removed deprecated APIs — none used here (we stick to the stable `Server`/`Get`/`Post`/`set_pre_routing_handler`/`Options`/`SSLClient`/`Client` surface).
- v0.44 stops auto-percent-decoding HTTP header values (RFC 9110 §5.5; closes a CRLF-injection class). Behaviorally fine for the OpenAI-API server — `Authorization`/`Content-Type`/etc. are never percent-encoded on the wire.
- v0.45 fixes keep-alive corruption on requests without a framed body, and an `X-Forwarded-For` empty-tokenization crash when `set_trusted_proxies()` is configured.

## Test plan

- [x] `make build` (Docker, CUDA 13.2.1) — green
- [x] Pre-push `make verify-fast` (~90s) — green
- [x] Live smoke against bumped binary with `Qwen3-8B-Q8_0`:
  - `GET /health` → `{"model_loaded":true,"queue_depth":0,"status":"ok"}`
  - `GET /v1/models` → JSON list
  - `OPTIONS /v1/chat/completions` (CORS preflight) → `204`
  - `POST /v1/chat/completions` (`max_tokens=8`, non-stream) → returns 8 tokens
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)