### PR TITLE
docs(arch): add architecture refactor roadmap spec + Phase 1 plan

### DIFF
--- a/docs/superpowers/plans/2026-05-20-architecture-refactor-phase-1-luegen-entfernen.md
+++ b/docs/superpowers/plans/2026-05-20-architecture-refactor-phase-1-luegen-entfernen.md
@@ -1,0 +1,690 @@
+# Architecture Refactor Phase 1 — "Lügen entfernen" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the dead `Graph` IR (~250 LOC), bring the architecture diagram from the side branch onto `main`, and write a canonical `docs/architecture.md` narrative — so what the repo claims structurally matches what the code does.
+
+**Architecture:** Three sequential cleanup tasks plus one optional rename. Each task is a single PR. No code-execution-logic changes; only deletions, file moves, doc creation, and a mechanical rename. The existing test suite (`make verify-fast`) is the regression net — there is no new test logic to write because we are removing dead code, not changing behavior.
+
+**Tech Stack:** C++20, CUDA 13.2, CMake, Docker build (`make build`), GTest suite (`make verify-fast` / `make verify`).
+
+---
+
+## Reference: Source spec
+
+`docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md` §3 Phase 1. This plan implements the three Phase 1 critical PRs plus the soft PR. Both spec and plan live on `main`.
+
+## Reference: Pre-flight evidence
+
+Establishes that `Graph`/`OpNode`/`OpType` is dead:
+
+```
+$ grep -rln 'OpType::\|imp::Graph\|imp::OpNode' src/ include/ tests/ tools/
+src/graph/op.cpp
+src/graph/op.h
+src/graph/graph.cpp
+src/graph/graph.h
+```
+
+All four occurrences are the dead-IR files referencing each other. No executor, kernel, test, or tool consumes the type. Diagram files (`docs/architecture.{dot,svg,png}`) exist on branch `docs/arch-diagram` at commit `163bcf7` and were never merged.
+
+---
+
+## Task 1: Delete the dead Graph IR
+
+**Files:**
+- Delete: `src/graph/op.h`
+- Delete: `src/graph/op.cpp`
+- Delete: `src/graph/graph.h`
+- Delete: `src/graph/graph.cpp`
+- Modify: `CMakeLists.txt:237-238` (remove the two source-list lines)
+
+- [ ] **Step 1: Verify deadness one more time (pre-condition)**
+
+Run:
+
+```bash
+grep -rln 'OpType::\|imp::Graph\b\|imp::OpNode' src/ include/ tests/ tools/
+```
+
+Expected output (exactly four lines, all in `src/graph/`):
+
+```
+src/graph/op.cpp
+src/graph/op.h
+src/graph/graph.cpp
+src/graph/graph.h
+```
+
+If any other file appears, **stop**. The IR has a live consumer and the deletion is no longer safe. Surface the new finding before continuing.
+
+- [ ] **Step 2: Verify no string-based dispatch (defense-in-depth)**
+
+Run:
+
+```bash
+grep -rn '"EMBEDDING"\|"RMSNORM"\|"ATTENTION_PREFILL"\|op_type_name' src/ include/ tests/ tools/
+```
+
+Expected output (one line, in the dead IR itself):
+
+```
+src/graph/op.h:33:const char* op_type_name(OpType type);
+```
+
+If any other file references `op_type_name` or stringified OpType values, **stop** and investigate.
+
+- [ ] **Step 3: Delete the four source files**
+
+Run:
+
+```bash
+git rm src/graph/op.h src/graph/op.cpp src/graph/graph.h src/graph/graph.cpp
+```
+
+- [ ] **Step 4: Update CMakeLists.txt**
+
+Edit `CMakeLists.txt`. Find these two lines (lines 237-238 at time of writing — confirm with `grep -n 'op.cpp\|graph.cpp' CMakeLists.txt`):
+
+```cmake
+    src/graph/op.cpp
+    src/graph/graph.cpp
+```
+
+Delete both lines.
+
+- [ ] **Step 5: Build to confirm no compile-time consumer was missed**
+
+Run:
+
+```bash
+make build
+```
+
+Expected: build completes successfully, no errors about missing `op.h` / `graph.h` / `Graph` / `OpNode` / `OpType` symbols. If a build error references those symbols, **stop**: the grep in Step 1 missed a consumer (e.g., a generated file or a macro-hidden include). Investigate before deleting.
+
+- [ ] **Step 6: Run the fast test suite**
+
+Run:
+
+```bash
+make verify-fast
+```
+
+Expected: all tests pass in ~90 seconds. Decode/prefill perf gate is advisory (per spec §5); deletion of unreachable code cannot affect runtime perf, so any reported drift is variance.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+refactor(graph): delete dead Graph/OpNode IR
+
+Graph, OpNode, OpType, and op_type_name had no live consumers — only
+the four IR source files referenced each other. Confirmed via:
+  grep -rln 'OpType::\|imp::Graph\|imp::OpNode' src/ include/ tests/ tools/
+returning only src/graph/op.{h,cpp} and src/graph/graph.{h,cpp}.
+
+Removes ~250 LOC of misleading scaffolding. The "graph executor" is and
+remains an imperative sequence of executor_*.cu calls; the directory
+name will be revisited in a follow-up rename.
+
+Phase 1 of docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Bring the architecture diagram from the side branch onto main
+
+**Files:**
+- Create: `docs/architecture.dot` (from branch `docs/arch-diagram` commit `163bcf7`)
+- Create: `docs/architecture.svg` (from same)
+- Create: `docs/architecture.png` (from same)
+- Modify: `README.md` (insert link in the Documentation table)
+- Modify: `CLAUDE.md` (add diagram to "Where to look" section)
+
+- [ ] **Step 1: Verify the source commit and files**
+
+Run:
+
+```bash
+git show --stat 163bcf7 | head -25
+git ls-tree 163bcf7 docs/ | grep architecture
+```
+
+Expected: commit `163bcf7` is "docs(arch): add E2E load + execution pipeline diagram" on branch `docs/arch-diagram`, and the tree contains `docs/architecture.dot`, `docs/architecture.png`, `docs/architecture.svg`.
+
+- [ ] **Step 2: Check out the three diagram files into main**
+
+Run:
+
+```bash
+git checkout 163bcf7 -- docs/architecture.dot docs/architecture.svg docs/architecture.png
+git status --short
+```
+
+Expected: three new files staged for add (`A  docs/architecture.dot`, `A  docs/architecture.svg`, `A  docs/architecture.png`).
+
+- [ ] **Step 3: Verify the SVG is renderable (sanity check)**
+
+Run:
+
+```bash
+head -5 docs/architecture.svg
+file docs/architecture.svg docs/architecture.png
+```
+
+Expected: SVG starts with `<?xml version="1.0"` or `<svg ...`, `file` reports SVG/XML and PNG image data respectively.
+
+- [ ] **Step 4: Add the diagram to the README documentation table**
+
+Edit `README.md`. Find this block (current `## Documentation` section, ~line 115-126):
+
+```markdown
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Usage & reference](docs/usage.md) | Build, server, CLI, C API |
+| [Supported models](docs/supported-models.md) | Tested model families with VRAM + tok/s |
+| [Quantization](docs/quantization.md) | GGUF Q*_K, NVFP4, MXFP4, FP8 KV — formats, pipelines, trade-offs |
+```
+
+Insert this new row as the **first** documentation row, directly above `Usage & reference`:
+
+```markdown
+| [Architecture diagram](docs/architecture.svg) ([source](docs/architecture.dot)) | End-to-end load + execution pipeline (load → engine init → prefill → decode) |
+```
+
+The full Documentation table after the edit:
+
+```markdown
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Architecture diagram](docs/architecture.svg) ([source](docs/architecture.dot)) | End-to-end load + execution pipeline (load → engine init → prefill → decode) |
+| [Usage & reference](docs/usage.md) | Build, server, CLI, C API |
+| [Supported models](docs/supported-models.md) | Tested model families with VRAM + tok/s |
+| [Quantization](docs/quantization.md) | GGUF Q*_K, NVFP4, MXFP4, FP8 KV — formats, pipelines, trade-offs |
+| [Performance](docs/performance.md) | Decode + prefill throughput, methodology |
+| [imp.conf reference](imp.conf.example) | All runtime configuration keys |
+| [sm_120a kernels](docs/sm120.md) | Kernel optimization notes |
+| [Roadmap](docs/roadmap.md) | Open bugs and in-flight performance work |
+| [Changelog](CHANGELOG.md) | Per-release notes |
+```
+
+- [ ] **Step 5: Add the diagram to CLAUDE.md "Where to look"**
+
+Edit `CLAUDE.md`. Find the "Where to look" section near the end. Add a new bullet as the **first** bullet under that section:
+
+```markdown
+- `docs/architecture.{svg,dot}` — canonical end-to-end pipeline diagram (load → init → prefill → decode + attention dispatcher)
+```
+
+- [ ] **Step 6: Re-rendering instructions**
+
+Add a small note to the bottom of `docs/architecture.md` if it already exists, otherwise defer to Task 3. For this task, just verify the re-render command works (only if Docker is available locally for the dot renderer):
+
+```bash
+docker run --rm -v "$(pwd)/docs:/d" nshine/dot dot -Tsvg /d/architecture.dot -o /tmp/architecture_rerender.svg
+diff -q docs/architecture.svg /tmp/architecture_rerender.svg && echo "byte-identical re-render" || echo "differs (acceptable — graphviz may produce non-determ ordering)"
+```
+
+This is a sanity check, not a gate. If `nshine/dot` is unavailable, skip — re-rendering is documented in the commit message of `163bcf7`.
+
+- [ ] **Step 7: Run the fast test suite**
+
+Run:
+
+```bash
+make verify-fast
+```
+
+Expected: green. Documentation-only PR; tests should not be affected.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add docs/architecture.dot docs/architecture.svg docs/architecture.png README.md CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(arch): merge architecture diagram from docs/arch-diagram to main
+
+Brings the end-to-end load + execution pipeline diagram (originally
+added in commit 163bcf7 on branch docs/arch-diagram) onto main. Adds
+README and CLAUDE.md links so the diagram is discoverable.
+
+Re-render: docker run --rm -v "$(pwd)/docs:/d" nshine/dot \
+  dot -Tsvg /d/architecture.dot -o /d/architecture.svg
+
+Phase 1 of docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Write `docs/architecture.md` as the canonical narrative companion
+
+**Files:**
+- Create: `docs/architecture.md`
+- Modify: `README.md` (update the "Architecture diagram" row to point at the markdown narrative, with the SVG linked from it)
+
+- [ ] **Step 1: Create `docs/architecture.md`**
+
+Write `docs/architecture.md` with this exact content:
+
+```markdown
+# imp — Architecture
+
+This document is the canonical narrative companion to [`architecture.svg`](architecture.svg).
+The SVG shows the structural overview; this file explains each phase in
+prose and points at the source files that implement it.
+
+If the code and this document disagree, the code wins — but a disagreement
+is a bug in this document and should be fixed.
+
+## At a glance
+
+imp runs LLM inference end-to-end in four phases:
+
+1. **Load** — read a GGUF file or a Hugging-Face SafeTensors directory into a
+   `Model` object with a `WeightMap`, a `Tokenizer`, and a `ModelConfig`.
+2. **Engine init** — resolve runtime config, upload weights to VRAM, build
+   the paged KV cache, allocate workspaces, capture CUDA graphs for decode.
+3. **Prefill** — run the prompt through the per-layer forward pass (chunked
+   if the architecture supports it), producing the first-token logits.
+4. **Decode** — replay the captured CUDA graph per token: attention → FFN →
+   LM head → penalties → sampler → stop check, looping until EOS or limit.
+
+See [`architecture.svg`](architecture.svg) for the full graph including
+the attention dispatcher, memory subsystem, and kernel subsystem.
+
+## Phase 1 — Load (one-time, `src/model/`)
+
+Entry: `imp_model_load(path) → ImpModel` (`include/imp/imp.h`, dispatched
+via `src/api/imp_api.cpp`).
+
+Format detection inspects the path: a `.gguf` file routes to
+`src/model/gguf_loader.cpp`; a directory containing `config.json` and
+`*.safetensors` routes to `src/model/safetensors_loader.cpp` with optional
+LLM-Compressor recipe handling in `src/model/llm_compressor_loader.cpp`.
+
+Both loaders produce:
+
+- A **WeightMap** (`src/model/weight_map.cpp`) — tensor name → role.
+- A **Tokenizer** (`src/model/tokenizer.cpp` + `chat_template.cpp` +
+  `jinja.cpp` + optional `sentencepiece_loader.cpp`).
+- A **ModelConfig** + **Model** object (`src/model/model.cpp`,
+  `src/model/model_arch.h`).
+
+## Phase 2 — Engine init (one-time, `src/runtime/engine.cpp`)
+
+Entry: `imp_context_create(model, ImpConfig) → ImpContext`.
+
+`Engine::init()` orchestrates the init pipeline. The major steps are
+distinct private methods on `Engine`:
+
+| Step | Method | Notes |
+|---|---|---|
+| Load runtime config | `RuntimeConfig::load()` | `imp.conf` + `--config` CLI + legacy env-var seeds (`src/runtime/config.cpp`) |
+| Resolve quant/KV/SSM dtypes | `init_resolve_*` group | `init_resolve_kv_dtype_policy_`, `init_resolve_ssm_dtype_`, `init_resolve_fp8_prefill_`, `init_resolve_quant_flags_` |
+| Compute max sequence length | `init_compute_max_seq_len_` | VRAM budget → max context (`src/runtime/vram_budget.cpp`) |
+| Upload weights | `init_weights` | `upload_weight` + `upload_expert_weights` in `src/model/weight_upload.cu`; pre-dequant in `src/graph/executor_pre_dequant.cu` |
+| Init KV cache | `init_kv_cache` | Paged blocks (block_size=16); dtype is FP16 / FP8 / INT8 / INT4 / NVFP4 / MXFP4 |
+| Allocate workspaces | `init_features` | MMVQ scratch, cuBLAS S-matrix (~1 GiB — see Known wounds), FP8 activation scratch, split-K attn scratch |
+| Warm up | `warmup()` | Captures CUDA graph for decode (`src/runtime/cuda_graph.cu`) |
+
+The Engine surface is currently a large class — splitting it into named
+subsystems is Phase 4 of the refactor roadmap.
+
+## Phase 3 — Prefill (per request, `Engine::step_prefill`)
+
+Entry: `imp_prefill_with_params(tokens, n) → status`.
+
+Per-chunk loop in `src/graph/executor_forward.cu` (or
+`executor_forward_moe.cu` for MoE architectures). Each layer runs:
+
+```
+RMSNorm → QKV GEMM + RoPE + KV-cache write → Attention → O proj →
+RMSNorm + residual → FFN (dense SwiGLU or MoE top-k grouped GEMM)
+```
+
+After the last layer of the last chunk: final RMSNorm + LM head → logits.
+
+### Attention dispatcher (the central choice)
+
+`executor_attention.cu` decides which attention kernel to call. The gate
+at `executor_attention.cu:847` checks:
+
+```
+if (force_cublas || !no_cublas) && attn_scores_buf_ && n ≤ cap
+    && (force_cublas || !sliding)
+```
+
+When true (the default for typical Qwen3 / Gemma-4 configs), prefill goes
+through `attention_cublas_prefill`: cuBLAS QK^T → ~1 GiB S-matrix buffer
+→ causal softmax → cuBLAS PV. When false, it falls through to
+`attention_prefill_dispatch` (`attention_dispatch.cu:30`), which selects
+among the per-dtype FMHA variants.
+
+Decode attention uses a separate switch on `cache_dtype` at
+`executor_attention.cu:996`, dispatching to one of the paged kernels
+(INT4 / NVFP4 ± TC / MXFP4-KV / INT8 / FP8 / FP16-paged).
+
+**Status:** the FMHA dispatch chain currently has more variants than are
+default-enabled. Phase 2 of the refactor roadmap archives the unused
+variants.
+
+## Phase 4 — Decode loop (per token, `Engine::step_decode_forward`)
+
+Entry: `imp_decode_step(params) → next_token` (or the streaming wrapper
+`imp_generate_streaming`).
+
+Per token:
+
+1. **Replay** the captured CUDA graph (`src/runtime/cuda_graph.cu`).
+   Graph capture is enabled for most architectures; non-Gemma-4 MoE
+   disables it because of host-side routing (see CLAUDE.md).
+2. **Paged attention decode** — kernel chosen by KV dtype.
+3. **FFN GEMV** — dp4a / mma.sync / NVFP4 variants in
+   `executor_ffn.cu`.
+4. **LM head GEMV** → logits.
+5. **Apply penalties** (repeat / freq / presence / DRY) — `request.cpp`.
+6. **Sampler** (temp / top-p / top-k / min-p / typical / mirostat) —
+   `request.cpp`.
+7. **Stop check** — EOS, max_tokens, stop strings.
+8. **(Optional) MTP spec-decode draft** — `src/runtime/mtp_forward.cu`.
+
+## Subsystems referenced across phases
+
+- **Memory** — `src/memory/vram_allocator.cu`, `src/memory/kv_cache.cu`,
+  `src/memory/kv_cache_manager.cpp`, `src/memory/layer_offload.cu`,
+  `src/runtime/vram_budget.cpp`, `src/runtime/storage_planner.cpp`. The
+  cross-cutting ownership here is intentionally being consolidated in
+  Phase 5 of the refactor roadmap.
+- **Kernels** — `src/compute/` (attention, GEMM, RMSNorm, RoPE, SwiGLU,
+  softmax, sampling) and `src/quant/` (dequant, FP8 quant, NVFP4 quant).
+- **Public C API** — `include/imp/{imp,types,error,config}.h`,
+  implemented in `src/api/imp_api.cpp`. ABI-stable per CONTRIBUTING.md.
+
+## Known structural wounds
+
+These are documented for honesty. See the refactor roadmap in
+[`superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md`](superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md)
+for the resolution plan.
+
+- **`Engine::init` is 700+ LOC of orchestration in one method.** Will be
+  split into named subsystems in Phase 4.
+- **The cuBLAS attention path allocates ~1 GiB of S-matrix workspace.**
+  Caps maximum context length. Phase 5 evaluates tiled streaming softmax
+  or FMHA-default-switch.
+- **`RuntimeConfig::current()` is a global singleton.** Phase 5
+  de-globalizes it to per-Engine.
+- **The directory `src/graph/` does not contain a graph IR** (the
+  `OpNode`/`Graph` types were deleted in Phase 1). Rename to `src/exec/`
+  is a Phase 1 soft PR, possibly slipping to Phase 5.
+
+## Re-rendering the diagram
+
+```bash
+docker run --rm -v "$(pwd)/docs:/d" nshine/dot \
+  dot -Tsvg /d/architecture.dot -o /d/architecture.svg
+docker run --rm -v "$(pwd)/docs:/d" nshine/dot \
+  dot -Tpng /d/architecture.dot -o /d/architecture.png
+```
+
+Edit `architecture.dot` first, then regenerate both raster forms.
+```
+
+- [ ] **Step 2: Update README to point at the markdown narrative**
+
+Edit `README.md`. Replace the row added in Task 2 Step 4. Find:
+
+```markdown
+| [Architecture diagram](docs/architecture.svg) ([source](docs/architecture.dot)) | End-to-end load + execution pipeline (load → engine init → prefill → decode) |
+```
+
+Replace with:
+
+```markdown
+| [Architecture](docs/architecture.md) ([diagram](docs/architecture.svg)) | End-to-end load + execution pipeline (load → engine init → prefill → decode) |
+```
+
+- [ ] **Step 3: Run the fast test suite**
+
+Run:
+
+```bash
+make verify-fast
+```
+
+Expected: green. Documentation-only PR.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add docs/architecture.md README.md
+git commit -m "$(cat <<'EOF'
+docs(arch): add narrative companion docs/architecture.md
+
+The SVG shows the structural overview; this markdown explains each phase
+in prose, points at the source files that implement it, and lists the
+known structural wounds with pointers to the refactor roadmap.
+
+Phase 1 of docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 (SOFT — may slip to a later phase or be dropped): Rename `src/graph/` → `src/exec/`
+
+**Why soft:** The Phase 1 critical PRs are complete after Task 3. This
+rename is mechanical but touches 85+ include lines and the CMakeLists.
+If you are short on time, defer; the directory is no longer lying about
+containing a Graph IR (deleted in Task 1).
+
+**Files:**
+- Rename: all files under `src/graph/` to `src/exec/`
+- Modify: every `#include "graph/..."` (85 occurrences across src/) → `#include "exec/..."`
+- Modify: `CMakeLists.txt` — `IMP_GRAPH_SOURCES` variable name + source paths
+
+- [ ] **Step 1: Pre-flight scan — confirm the rename surface**
+
+Run:
+
+```bash
+grep -rln '#include "graph/' src/ tools/ tests/ | wc -l
+grep -rn 'src/graph/' CMakeLists.txt | head
+grep -rn 'IMP_GRAPH_SOURCES\|graph/' CMakeLists.txt | head
+```
+
+Note the file count (should be ~85 — exact number may have shifted if
+unrelated PRs landed between tasks). If the count differs by more than
+±10, refresh this plan task.
+
+- [ ] **Step 2: Move all files**
+
+Run:
+
+```bash
+git mv src/graph src/exec
+git status --short | head
+```
+
+Expected: every file under `src/graph/` shows as renamed to
+`src/exec/`. CMakeLists is not yet updated; build will fail until
+Step 3.
+
+- [ ] **Step 3: Rewrite include paths in source**
+
+Run:
+
+```bash
+grep -rl '#include "graph/' src/ tools/ tests/ \
+  | xargs sed -i 's|#include "graph/|#include "exec/|g'
+grep -rn '#include "graph/' src/ tools/ tests/
+```
+
+Expected: second `grep` returns no matches.
+
+- [ ] **Step 4: Update CMakeLists.txt**
+
+Edit `CMakeLists.txt`. Find the `IMP_GRAPH_SOURCES` variable (around
+line ~236). Two changes:
+
+1. Rename the variable: `IMP_GRAPH_SOURCES` → `IMP_EXEC_SOURCES`.
+2. Rewrite each `src/graph/...` path to `src/exec/...`.
+
+Then find every reference to `IMP_GRAPH_SOURCES` elsewhere in
+`CMakeLists.txt` and rename it:
+
+```bash
+grep -n 'IMP_GRAPH_SOURCES' CMakeLists.txt
+```
+
+Replace each occurrence.
+
+- [ ] **Step 5: Pre-flight grep for any missed `graph/` reference**
+
+Run:
+
+```bash
+grep -rn 'src/graph/\|"graph/' src/ include/ tests/ tools/ CMakeLists.txt
+```
+
+Expected: empty output. Any remaining match is a missed reference and
+must be fixed before build.
+
+- [ ] **Step 6: Build**
+
+Run:
+
+```bash
+make build
+```
+
+Expected: build completes. If `fatal error: graph/...: No such file or
+directory` appears, return to Step 3.
+
+- [ ] **Step 7: Full test run**
+
+Run:
+
+```bash
+make verify-fast
+```
+
+Expected: green. The rename is a no-op for behavior; any failure is a
+plumbing bug from Steps 2-4.
+
+- [ ] **Step 8: Update CLAUDE.md "Where to look" and docs/architecture.md**
+
+`CLAUDE.md` "Where to look" lists `src/{api,compute,core,graph,memory,...}`.
+Change `graph` → `exec`.
+
+`docs/architecture.md` (created in Task 3) references `src/graph/` in
+multiple places — search and replace `src/graph/` → `src/exec/`.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+refactor: rename src/graph/ → src/exec/
+
+The Graph IR (OpNode, OpType, Graph) was deleted in an earlier Phase 1
+commit. The directory name "graph" was misleading — its contents are
+imperative GraphExecutor / GEMM-kernel-registry / workspace / scratch
+code, not a graph. Rename clarifies intent.
+
+Mechanical change: file moves + include-path rewrite (85 occurrences) +
+CMake variable rename (IMP_GRAPH_SOURCES → IMP_EXEC_SOURCES).
+make verify-fast green.
+
+Phase 1 (soft PR) of docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 1 closeout
+
+After Tasks 1-3 are merged (and Task 4 either merged or deferred):
+
+- [ ] **Step 1: Run the full verification suite at the phase boundary** (per spec §5)
+
+Run:
+
+```bash
+make verify
+```
+
+Expected: full GTest suite passes in ~5min.
+
+- [ ] **Step 2: Capture a perf snapshot** (advisory, per spec §5)
+
+Run:
+
+```bash
+scripts/gen_perf_baseline.sh
+git diff tests/perf_baseline.json
+```
+
+If the diff is within ~3% decode / ~5% prefill of pre-Phase-1 numbers,
+no action. If outside, document the surprise in the next Phase plan —
+since Phase 1 only deleted dead code and added docs, any non-zero perf
+delta is variance and should be noted.
+
+- [ ] **Step 3: Update MEMORY.md** (per spec §5)
+
+Add an entry under "Architecture" or "Workflow feedback" pointing to
+the completed Phase 1 work. Note that `src/graph/op.{h,cpp}` and
+`graph.{h,cpp}` no longer exist (in case any memo references them) and
+that `src/graph/` was renamed to `src/exec/` (if Task 4 landed).
+
+- [ ] **Step 4: Mark Phase 1 closed in the roadmap spec**
+
+Edit `docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md`.
+At the top of the Phase 1 section, add:
+
+```markdown
+**Status (2026-MM-DD):** Closed. PRs #<N1> (Graph IR delete), #<N2>
+(diagram merge), #<N3> (architecture.md narrative), [#<N4> (rename)].
+```
+
+- [ ] **Step 5: Commit the closeout**
+
+Run:
+
+```bash
+git add MEMORY.md docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+git commit -m "docs(arch): close Phase 1 (Lügen entfernen) of refactor roadmap
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Phase 2 ("Attention-Dispatcher entrümpeln") may now begin. A new
+implementation plan is required — invoke the writing-plans skill with
+the Phase 2 section of the spec as input.

--- a/docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
@@ -1,0 +1,208 @@
+# imp — Architecture Refactor Roadmap
+
+**Status:** Design / Spec
+**Date:** 2026-05-20
+**Author:** Raphael Friedmann (with Claude Opus 4.7)
+**Type:** Master roadmap. Each phase will get its own implementation plan via the `writing-plans` skill.
+
+---
+
+## 1. Motivation
+
+A ruthless review of the current architecture (vs. the canonical pipeline diagram on the `docs/arch-diagram` branch) surfaced ten structural problems. They cluster naturally into three risk tiers: dead/misleading structures, internal coupling, and architectural layering. This document captures the agreed phasing.
+
+The diagram itself admits several of the problems verbatim — "1 GiB S-matrix!" with an exclamation mark, "Attention Dispatcher (3 layers, 10 paths)", and the cuBLAS-vs-FMHA gate label "TRUE (typical Qwen3/Gemma-4)" that quietly disables ~5000 LOC of FMHA code in the default path. The roadmap below treats these as work items to resolve, not constants to preserve.
+
+## 2. Ground Rules
+
+- **Order:** risk-ascending. Phase 1 = pure cleanup with no perf surface. Phase 5 = invasive layer redrawing.
+- **Phase gate:** the **critical PRs** of phase N must be merged before the critical PRs of phase N+1 land. **Soft PRs** within a phase may slip into the next phase or be dropped entirely.
+- **Perf invariant:** no hard CI gate during refactor PRs. `tests/perf_baseline.json` keeps running, but the 3% decode / 5% prefill thresholds are advisory, not blocking, for refactor work. Author judges case-by-case; a regression demands a written reason, not an automatic veto.
+- **Correctness invariant:** `make verify-fast` must stay green on every PR. `make verify` must stay green at every phase boundary.
+- **Solo work:** the author is the only committer. No coordination overhead; the roadmap exists for self-discipline and future Claude sessions, not team alignment.
+- **No third-party dependencies added.** The CLAUDE.md rule stands. Refactors are within the existing dependency set.
+
+## 3. The Five Phases
+
+### Phase 1 — Lügen entfernen
+**Goal:** What the repo claims must be true.
+
+**Critical PRs**
+1. Delete the dead `Graph` IR.
+   - Files: `src/graph/op.h`, `src/graph/op.cpp`, `src/graph/graph.h`, `src/graph/graph.cpp` (~250 LOC).
+   - Evidence of deadness: `grep -rln 'OpType::' src/` returns only those four files. `Graph::to_dot()` is never called from a live execution path. No executor consumes `OpNode`.
+   - Verify: `make verify-fast` green after deletion.
+2. Merge the architecture diagram to `main`.
+   - Source: commit `163bcf7` on `docs/arch-diagram`. Brings `docs/architecture.dot`, `docs/architecture.svg`, `docs/architecture.png`.
+   - Link from `README.md` (top-level "Architecture" section) and from `CLAUDE.md`'s "Where to look" table.
+3. Write `docs/architecture.md` as the canonical narrative companion to the SVG. Describes the four phases (load → init → prefill → decode) in text, links to the section headers in source.
+
+**Soft PRs**
+- Rename `src/graph/` → `src/exec/`. Mechanical: include-path updates + CMake target renames. Cannot land until critical PR 1 is merged.
+- Move `Graph::to_dot()`-style debug visualization to a single `tools/imp-arch-dump` binary if there is appetite for runtime arch inspection. Otherwise drop.
+
+**Expected outcome:** ~300 LOC deleted, one canonical architecture artifact, one directory that no longer lies about its contents.
+
+---
+
+### Phase 2 — Attention-Dispatcher entrümpeln
+**Goal:** From "3 layers, 10 paths" to "Default cuBLAS / Sliding-Fallback / Decode-paged" plus one FMHA variant for non-cuBLAS cases.
+
+**Critical PRs**
+1. Archive `attention_fmha_sm120_cluster.cu` (1102 LOC). Refuted by author in memo `fmha_tma_lever_refuted_2026_05_14.md` — cp.async beats TMA bulk on SM120. Move source to `docs/archive/fmha_sm120_cluster/` with a resurrection memo describing the build flag that would re-enable it.
+2. Archive `attention_fmha_mxf4nvf4_sm120.cu`. Path was never default-on for any production NVFP4 model in current benchmarks. Same archive treatment.
+3. Archive `attention_naive.cu`. Only the Gemma-4 hd=512 fallback referenced it, and the chunked-prefill path (`gemma4_chunked_prefill_2026_05_15.md`) replaced that need.
+4. Simplify `executor_attention.cu:847` gate from the current 4-clause predicate to a 2-level switch:
+   - **Prefill:** default cuBLAS+softmax → FMHA fallback (one variant only) → sliding-window-special-case.
+   - **Decode:** keep the existing `switch(cache_dtype)` at `:996` but flatten the wrapper paths.
+   - Target: file goes from 1300 LOC to ≤700 LOC.
+
+**Soft PRs**
+- Write `docs/attention-dispatch.md` documenting the final matrix (dtype × prefill/decode × paged × sliding) and which kernel handles each cell.
+- Add a compile-only resurrection test per archived FMHA variant so future ports detect bitrot before runtime.
+- Move `attention_paged_common.cuh` includes into the per-dtype paged files (eliminate the umbrella header).
+
+**Out of scope here:** The "1 GiB S-matrix" wound. That belongs to Phase 5 because it requires a rewrite of the cuBLAS-attention prefill path, not just a deletion.
+
+**Expected outcome:** ≈5000 LOC of compiled-but-rarely-fired FMHA code leaves the hot path; build time drops; the dispatch logic becomes legible enough to fit in a doc page.
+
+---
+
+### Phase 3 — Pre-Dequant + Quant-Zoo aufräumen
+**Goal:** `executor_pre_dequant.cu` (2693 LOC) becomes a thin dispatcher over a format registry, with one source file per quant family.
+
+**Critical PRs**
+1. Define the registry surface in `src/graph/pre_dequant_registry.h`:
+   ```cpp
+   using DequantFn = void(*)(const WeightHandle&, void* dst, /* ... */);
+   void register_pre_dequant(QType src, QType dst, DequantFn fn);
+   DequantFn get_pre_dequant(QType src, QType dst);
+   ```
+2. Split `executor_pre_dequant.cu` by quant family:
+   - `pre_dequant_q8.cu` (Q8_0 → FP16, Q8_0 → FP8)
+   - `pre_dequant_q4k.cu` (Q4_K_M → FP16, Q4_K_M → INT8 via Phase 3 IMMA path)
+   - `pre_dequant_mxfp4.cu`
+   - `pre_dequant_nvfp4.cu`
+   - `pre_dequant_fp16_cache.cu` (the FP16-on-device cache promotion)
+3. Reduce remaining `executor_pre_dequant.cu` to ≤200 LOC — pure dispatcher + the registry seed.
+
+**Soft PRs**
+- Apply the same registry pattern to `src/graph/gemm_kernel_*.cu` (8 files: `cutlass_nvfp4`, `fp8`, `generic_dequant`, `gguf`, `mxfp4`, `nvfp4_gemm`, `nvfp4_gemv`, `q4k_imma`). Currently dispatched via `gemm_kernel_registry.cu` — confirm or refactor.
+- Reconcile the `src/quant/dequant_*.cu` files (in-place dequant for hot paths) with `src/graph/pre_dequant_*.cu` (one-shot dequant at init). Currently both exist; document or merge.
+
+**Expected outcome:** Adding a new quant format becomes one file plus one `register_pre_dequant` call. The 2693-LOC monolith is gone.
+
+---
+
+### Phase 4 — Engine.cpp zerteilen
+**Goal:** `src/runtime/engine.cpp` shrinks from 3112 LOC to ≤800 LOC. Each subsystem becomes a named owner with constructor injection.
+
+**Critical PRs** (one subsystem per PR, ordered by independence)
+1. **`InitResolver`** — owns `init_resolve_kv_dtype_policy_`, `init_resolve_ssm_dtype_`, `init_resolve_fp8_prefill_`, `init_resolve_quant_flags_`, `init_compute_max_seq_len_`, `init_apply_debug_raw_overrides_`. Pure function-style; takes `RuntimeConfig` + `Model` in, returns a resolved `EngineRuntime` struct.
+2. **`WeightUploadOrchestrator`** — owns `init_weights` (and indirectly calls `upload_weight` / `upload_expert_weights` from `model/weight_upload.cu`). Includes the FP8/NVFP4 pre-dequant trigger.
+3. **`KVCacheInitializer`** — owns `init_kv_cache` and the paged-block geometry decisions. Outputs a configured `KVCacheManager`.
+4. **`WorkspaceBuilder`** — owns `init_features` plus the three `executor_workspace_*.cu` files (they already exist as separate files; this PR ties the ownership together).
+5. **`Warmup`** — owns `warmup()` and the CUDA graph capture orchestration. Wraps `cuda_graph.cu`.
+6. **`Scheduler`** — owns `step`, `step_async_graph_resume`, `step_schedule`, `step_prefill`, `prefill_allocate_kv_blocks_`. The actual hot-loop driver.
+7. **`SamplingHelper` + `StopController`** — owns `fill_sampling_params`, `upload_penalties`, `should_stop`, `track_think_state`, `build_banned_token_list`. Separate PRs if they grow; combined here because they share state.
+8. **`Engine` becomes a façade** — owns construction wiring, exposes the same `Engine::*` public methods, delegates each one to the appropriate subsystem. Target: ≤800 LOC.
+
+**Soft PRs**
+- Move `src/runtime/mtp_forward.cu` → `src/compute/mtp_forward.cu`. It is a kernel file, not an orchestrator.
+- Move `src/runtime/vision_pipeline.{cpp,h}` → `src/vision/vision_pipeline.{cpp,h}`. Aligns with the other `vision_*` files.
+- Promote `MTPSubsystem` and `VisionSubsystem` from inline Engine members to named classes (currently they exist as embedded `vision_` member + `mtp_*_` fields). Same pattern as Scheduler.
+
+**Expected outcome:** Engine.cpp diff per future feature drops dramatically. New subsystems can be added by writing one file + wiring it in `Engine::init()`. Test boundaries become tractable.
+
+---
+
+### Phase 5 — Schichten und APIs (höchstes Risiko)
+**Goal:** Structural honesty. The fuzzy boundaries become sharp.
+
+**Critical PRs**
+1. **VRAM ownership consolidation.** Today: `src/memory/vram_allocator.cu`, `src/memory/device_allocator.cu`, `src/memory/pinned_allocator.cpp`, `src/runtime/vram_budget.cpp`, `src/runtime/storage_planner.cpp`. Consolidate into one `MemoryManager` (target location: `src/memory/memory_manager.{cu,h}`) that owns:
+   - Device VRAM pool (existing `vram_allocator` logic).
+   - Pinned host allocator.
+   - Budget tracking (free VRAM, planned reservations).
+   - Storage tier planning (which tensor lives on device, which on host).
+   - The other files either become thin internal helpers or are deleted.
+2. **`RuntimeConfig` de-globalization.** Today: `RuntimeConfig::current()` is a global singleton accessed from any `.cu`/`.cpp` file. Change:
+   - `RuntimeConfig` becomes per-`Engine`. Passed by const reference into every subsystem constructor (Phase 4 sets this up).
+   - `RuntimeConfig::current()` is kept only at the C-API boundary (`src/api/imp_api.cpp`) — translating C-side config into the per-Engine instance.
+   - The `gemma4` section moves to `ModelConfig::arch_overrides` (or a new `ModelOverrides` struct). Model-specific config belongs to the model, not to the runtime.
+3. **Public API consolidation.** Today: `imp_generate` / `imp_generate_streaming` are parallel implementations alongside `imp_prefill_with_params` + `imp_decode_step`. Change: `imp_generate*` becomes a thin wrapper that loops `imp_prefill_with_params` then `imp_decode_step` until stop. Single source of truth for each generation feature.
+
+**Soft PRs**
+- **Tiled streaming softmax for cuBLAS attention prefill.** The "1 GiB S-matrix" allocation in `init_features` (`executor_workspace_buffers.cu`). Two paths to consider:
+  - (a) Implement tiled softmax in the cuBLAS path — keep the cuBLAS QK^T and PV calls but stream S in tiles, freeing the ~1 GiB.
+  - (b) After Phase 2 simplification, evaluate switching the default to the single remaining FMHA variant if it's perf-competitive on the typical Qwen3/Gemma-4 configs that motivated the cuBLAS gate originally.
+  - Either path is multi-week and perf-sensitive; lands as soft because the structural Phase 5 critical PRs unblock the work, not gate-block on it.
+- Rename `src/graph/` → `src/exec/` if it didn't land as a Phase 1 soft PR.
+
+**Expected outcome:** Hidden singletons are gone. Adding a new model architecture means writing one `ModelOverrides` block, not adding a section to `RuntimeConfig`. The public API has one canonical entry point per operation.
+
+---
+
+## 4. Transition Logic
+
+A phase is **closed** when its critical PRs are merged to `main` and `make verify` is green. Soft PRs may stay open in branches or be dropped.
+
+Phase N+1's critical PRs may start work (branches, drafts) while Phase N's soft PRs are still pending, but no Phase N+1 critical PR is **merged** until Phase N is closed.
+
+Concurrent soft PRs across phases are allowed as long as the merge order respects the critical chain.
+
+## 5. Verification Strategy
+
+| Check | When | Tool |
+|---|---|---|
+| Build green | Every PR | `make build` |
+| Tests green | Every PR | `make verify-fast` (~90s) |
+| Full suite green | Every phase boundary | `make verify` (~5min) |
+| Perf snapshot | Every phase boundary, archived | `scripts/gen_perf_baseline.sh` (advisory) |
+| Architecture diagram still matches code | Phase 1 close, Phase 4 close, Phase 5 close | Manual review of `docs/architecture.{md,svg}` |
+| `MEMORY.md` updates | Per phase | When a memo's referenced file/symbol is moved, the memo gets a "moved to X in PR #Y" note rather than silent staleness |
+
+No CI gate is added by this refactor. The advisory perf snapshot is for the author's awareness; regressions documented in the PR body are acceptable if the author justifies them.
+
+## 6. Decomposition Rationale
+
+Why this specific phase order, given the original critique's ten points:
+
+| Critique point | Phase | Why here |
+|---|---|---|
+| 1. Dead `Graph` IR | 1 | Pure deletion, no risk, sets honesty baseline |
+| 3. Attention 10-path dispatcher | 2 | Largest dead-code mass; LOW risk because the dead paths are dead by gate flag, not by latent bug |
+| 8. `executor_pre_dequant.cu` 2693 LOC | 3 | Touches no public API; structural split with bounded blast radius |
+| 2. `engine.cpp` god class | 4 | Largest diff surface; benefits from Phase 1-3 cleanup landing first (less to split) |
+| 4. 1 GiB S-matrix | 5 (soft) | Perf-sensitive rewrite; needs Phase 2 dispatcher simplification as prerequisite |
+| 5. `RuntimeConfig` singleton + `gemma4` | 5 | Touches every subsystem; benefits from Phase 4's subsystem extraction |
+| 6. Public API two-door | 5 | Same; the consolidated wrapper depends on `Scheduler` from Phase 4 |
+| 7. VRAM owner unclear | 5 | Cross-cuts memory + runtime + graph; needs Phase 4 to define which subsystem holds the new `MemoryManager` |
+| 9. Hand-written jinja/tokenizer | — | Out of scope. CLAUDE.md "no new third-party deps" rule stands; replacing these is a separate decision |
+| 10. Diagram on side branch | 1 | One-shot merge |
+
+## 7. Open Decisions
+
+These are deliberately left for the per-phase plans:
+
+- **Phase 2:** Which single FMHA variant survives as the non-cuBLAS fallback? Decision deferred to Phase 2 plan — depends on a fresh A/B against the simplified dispatcher.
+- **Phase 4:** Whether `SamplingHelper` and `StopController` become two classes or one. Decision deferred until the extraction starts and the actual coupling is visible.
+- **Phase 5 soft:** Tiled softmax (option a) vs. FMHA-default-switch (option b) for the 1 GiB S-matrix. Decision deferred until Phase 2 closes and the surviving FMHA variant has fresh benchmarks.
+
+## 8. Non-Goals
+
+- Reducing or eliminating CUDA dependencies.
+- Adding third-party libraries (Jinja, tokenizers, allocators).
+- Cross-architecture portability (sm_80, sm_90, sm_100). The sm_120a-only rule stays.
+- Replacing CUTLASS or cuBLAS as the GEMM backends.
+- Changing the public C-API symbol table beyond Phase 5's consolidation.
+
+## 9. Per-Phase Plans
+
+Each phase below will, when work starts on it, get its own implementation plan via the `writing-plans` skill:
+
+- `docs/superpowers/specs/<date>-architecture-refactor-phase-1-plan.md`
+- `docs/superpowers/specs/<date>-architecture-refactor-phase-2-plan.md`
+- … and so on through Phase 5.
+
+This roadmap document is the parent. It is updated only when a phase's scope materially changes during execution (e.g., a planned soft PR escalates to critical, or a phase splits in two).


### PR DESCRIPTION
## Summary
- `docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md` — five-phase, risk-ascending refactor roadmap derived from the 2026-05-20 critique
- `docs/superpowers/plans/2026-05-20-architecture-refactor-phase-1-luegen-entfernen.md` — bite-sized implementation plan for Phase 1 (delete dead Graph IR, bring diagram to main, write architecture.md, optional rename)

## Why
The architecture critique surfaced ten structural problems. The roadmap groups them into five risk-ascending phases (cleanup → attention dispatcher → pre-dequant zoo → engine split → layering). Each phase will get its own writing-plans output. This PR lands the parent docs so subsequent refactor PRs can reference them.

## Notes
- Pure documentation PR. No code touched. No tests affected.
- Phase gates are "critical PRs hard, soft PRs may slip". Perf invariant is advisory, not blocking, for refactor work (per spec §2).

## Test plan
- [x] No code changes — \`make verify-fast\` not required
- [x] Pre-push hook skipped verify (\`no source changes\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)