### PR TITLE
docs(arch): link architecture diagram from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Full build options, test commands, and verify-gate setup: [`docs/usage.md`](docs
 
 | Document | Description |
 |---|---|
+| [Architecture diagram](docs/architecture.svg) ([source](docs/architecture.dot)) | End-to-end load + execution pipeline (load → engine init → prefill → decode) |
 | [Usage & reference](docs/usage.md) | Build, server, CLI, C API |
 | [Supported models](docs/supported-models.md) | Tested model families with VRAM + tok/s |
 | [Quantization](docs/quantization.md) | GGUF Q*_K, NVFP4, MXFP4, FP8 KV — formats, pipelines, trade-offs |


### PR DESCRIPTION
## Summary
- Add an Architecture-diagram row as the first row of the README Documentation table
- Surfaces the `docs/architecture.{svg,dot}` artifacts that landed in #286 so they are discoverable

## Why
PR #286 merged the diagram itself but did not link it from any discovery surface (README, docs index). New readers — and future Claude sessions — currently have no entry point to the diagram. This adds the obvious top-row link.

## Notes
- CLAUDE.md is gitignored in this repo (\`.gitignore:97\`, PR #100 "Public-release cleanup"). The corresponding "Where to look" bullet was added to the local CLAUDE.md but is not committed, in keeping with the published-vs-local-state policy from #100.
- Pure documentation PR.

Phase 1 of [\`docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md\`](../tree/main/docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md).

## Test plan
- [x] No code changes — \`make verify-fast\` not required
- [x] Pre-push hook skipped verify (\`no source changes\`)
- [x] Spec compliance reviewer ✅
- [x] Code quality reviewer ✅ Approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)