### PR TITLE
docs(arch): closeout follow-ups from Phase 1 final review

### DIFF
--- a/docs/plans/k8_cpu_offload_design_2026_05_17.md
+++ b/docs/plans/k8_cpu_offload_design_2026_05_17.md
@@ -428,7 +428,7 @@ investment.
   is a no-op.
 - Wire `KVBlockOffloadManager::ensure_block(block_id, compute_stream)`
   into the executor at the paged-attention dispatch site
-  (`src/graph/executor_attention.cu`).
+  (`src/exec/executor_attention.cu`).
 - Validate: zero perf change in `make verify-fast` baseline.
 
 **Deliverable:** the plumbing is in place. Future phases can flip the

--- a/docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
@@ -25,7 +25,7 @@ The diagram itself admits several of the problems verbatim — "1 GiB S-matrix!"
 ## 3. The Five Phases
 
 ### Phase 1 — Lügen entfernen
-**Status (2026-05-20):** Closed. Landed: #287 (delete dead Graph IR), #286 + #289 (architecture diagram + README link), #291 (narrative companion docs/architecture.md), #290 (soft PR — rename src/graph/ → src/exec/). One soft follow-up deferred: `docs/roadmap.md` still has 4 stale src/graph/ paths.
+**Status (2026-05-20):** Closed. Landed: #287 (delete dead Graph IR), #286 + #289 (architecture diagram + README link), #291 (narrative companion docs/architecture.md), #290 (soft PR — rename src/graph/ → src/exec/), #292 (closeout: roadmap.md path sweep + this status line). Deferred follow-ups: stale `src/graph/` paths in `docs/plans/*_2026_05_17.md` historical design memos and `review/phase3_maint.md` audit snapshot — these are point-in-time records.
 
 **Goal:** What the repo claims must be true.
 


### PR DESCRIPTION
## Summary
Three follow-up fixes from the final Phase 1 reviewer that landed too late for #292:

1. **Spec status line was self-contradicting** — said "deferred" while #292 simultaneously swept the same paths. Rewritten to list the sweep plus the genuinely deferred items (historical design memos in \`docs/plans/*_2026_05_17.md\` and the audit snapshot in \`review/phase3_maint.md\`).
2. **\`docs/plans/k8_cpu_offload_design_2026_05_17.md:431\`** is an in-flight design doc (not historical), so its single stale \`src/graph/\` path is now \`src/exec/\`.
3. **\`CLAUDE.md\` "Where to look"** updated locally to lead with the markdown narrative (gitignored per \`.gitignore:97\`, so not committed here — recorded in commit body for transparency).

## Why a separate PR
PR #292 (which closed Phase 1) merged at 07:57; the final-review pass produced these three items afterward. Splitting them off keeps #292's history clean.

## Test plan
- [x] No code changes — \`make verify-fast\` not required
- [x] Pre-push hook skipped verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)