### PR TITLE
refactor(memory): introduce MemoryManager façade for VRAM ownership

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,7 @@ if(IMP_BUILD_TESTS)
         tests/test_e2e_llm_compressor.cpp
         tests/test_chunked_prefill.cu
         tests/test_mtp_forward.cpp
+        tests/test_api_generate.cpp
     )
 
     set(IMP_TEST_BINARIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(IMP_MEMORY_SOURCES
     src/memory/device_allocator.cu
     src/memory/vram_allocator.cu
     src/memory/pinned_allocator.cpp
+    src/memory/memory_manager.cpp
     src/memory/kv_cache.cu
     src/memory/kv_cache_manager.cpp
     src/memory/ssm_state.cu

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -95,18 +95,11 @@ no_dp4a_lm           = false
 no_mmvq              = false
 no_mmvq_q8_0         = false
 
-[gemma4]
-fp32_gemm_out        = false
-no_graphs            = false
-force_mmvq           = false
-# FP32 expert-down GEMM (Gemma-4 numerical-parity diagnostic).
-fp32_expert_down     = false
-# Disable the decode fast-path (debug bisect).
-no_decode_fast       = false
-# Disable post-FFW norm 1 in the parallel-branch path (debug).
-no_post_ffw_1        = false
-# Force ggml-style prefill matmul for Gemma-4 (debug A/B path).
-ggml_prefill         = false
+# [gemma4] section moved out of the global RuntimeConfig in Phase 5
+# Track A of the architecture refactor. These are now per-model
+# overrides on ModelConfig::Overrides::Gemma4 (see src/model/model_config.h);
+# the GGUF loader / engine init resolver populates them when the
+# loaded model is Gemma-4. There is no user-facing knob today.
 
 [generation]
 no_logit_softcap     = false

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -384,6 +384,82 @@ static void apply_sampling_params(imp::Request& req, const ImpGenerateParams* pa
 
 // --- Generation ---
 
+// Thin wrapper helper: tokenise the prompt, prefill, then loop decode_step.
+// `on_token` is invoked for every newly decoded token; return true to keep
+// going, false to stop early (the caller's request gets cancelled).
+//
+// This is the shared body of imp_generate / imp_generate_streaming. Both
+// public entry points stay ABI-stable; only their bodies collapse into this
+// helper + imp_prefill_with_params + imp_decode_step.
+namespace {
+
+template <typename OnToken>
+static ImpError generate_via_prefill_decode_loop(ImpContext ctx, const char* prompt,
+                                                 const ImpGenerateParams* params,
+                                                 OnToken&& on_token) {
+    auto* tok = ctx->model_handle->model->tokenizer();
+    if (!tok)
+        return IMP_ERROR_INVALID_MODEL;
+
+    auto tokens = tokenize_prompt(ctx, prompt, params);
+
+    // Empty token stream would walk into executor_forward.cu's "n_tokens must
+    // be positive" guard and then trip a FATAL via the slice() of an
+    // uninitialised logits tensor. Bail out cleanly here instead of crashing.
+    if (tokens.empty()) {
+        IMP_LOG_WARN(
+            "imp_generate: prompt tokenised to 0 tokens (prompt='%.80s%s', "
+            "model may lack vocab coverage or chat-template guard rejected it)",
+            prompt, std::strlen(prompt) > 80 ? "…" : "");
+        return IMP_ERROR_INVALID_ARG;
+    }
+
+    // Prefill: imp_prefill_with_params handles request lifecycle, sampling
+    // params for the first-token sample, and the engine->step() loop until
+    // PREFILLING completes.
+    ImpError err = imp_prefill_with_params(ctx, tokens.data(),
+                                           static_cast<int>(tokens.size()), params);
+    if (err != IMP_SUCCESS)
+        return err;
+
+    // The prefill last-chunk sampler emits the FIRST generation token into
+    // req->output_tokens. imp_prefill_with_params marks those as "already
+    // consumed" so a token-level (prefill+decode_step) caller doesn't get
+    // them — but the high-level imp_generate / imp_generate_streaming
+    // contract says every generated token reaches the caller. Reset the
+    // cursor so imp_decode_step drains the prefill-sampled token(s) on its
+    // first call(s) before stepping the engine again.
+    ctx->consumed_output = 0;
+
+    // Decode loop: imp_decode_step handles per-step sampling params,
+    // multi-token (self-spec) consumption, and clears active_request when the
+    // engine marks FINISHED (EOS or its own max_tokens guard fires).
+    const int max_tokens = params->max_tokens > 0 ? params->max_tokens : 1;
+    for (int i = 0; i < max_tokens; ++i) {
+        int32_t token = 0;
+        ImpError step_err = imp_decode_step(ctx, params, &token);
+        if (step_err != IMP_SUCCESS) {
+            // INTERNAL after natural finish (active_request was cleared) is
+            // the normal stop signal — anything else propagates.
+            if (step_err == IMP_ERROR_INTERNAL && !ctx->active_request)
+                break;
+            return step_err;
+        }
+
+        if (!on_token(token))
+            return IMP_ERROR_CANCELLED;
+
+        // Engine signalled FINISHED (EOS / its own max_tokens) — decode_step
+        // already cleaned up and set active_request = nullptr.
+        if (!ctx->active_request)
+            break;
+    }
+
+    return IMP_SUCCESS;
+}
+
+}  // namespace
+
 ImpError imp_generate_streaming(ImpContext ctx, const char* prompt, const ImpGenerateParams* params,
                                 ImpTokenCallback cb, void* user_data) {
     if (!ctx || !prompt || !params || !cb) {
@@ -398,46 +474,12 @@ ImpError imp_generate_streaming(ImpContext ctx, const char* prompt, const ImpGen
         if (!tok)
             return IMP_ERROR_INVALID_MODEL;
 
-        auto tokens = tokenize_prompt(ctx, prompt, params);
-
-        // Create request
-        auto req = std::make_shared<imp::Request>();
-        req->input_tokens = std::move(tokens);
-        apply_sampling_params(*req, params);
-        req->status = imp::RequestStatus::PENDING;
-
-        ctx->engine->add_request(req);
-
-        // Prefill
-        while (req->status == imp::RequestStatus::PENDING || req->status == imp::RequestStatus::PREFILLING) {
-            bool has_work = ctx->engine->step();
-            if (!has_work)
-                break;
-        }
-
-        // Decode with streaming callback
-        size_t prev_output_size = req->output_tokens.size();
-        while (req->status != imp::RequestStatus::FINISHED && req->status != imp::RequestStatus::CANCELLED) {
-            bool has_work = ctx->engine->step();
-            if (!has_work && req->status != imp::RequestStatus::FINISHED)
-                break;
-
-            // Deliver new tokens via callback
-            while (prev_output_size < req->output_tokens.size()) {
-                int32_t token = req->output_tokens[prev_output_size];
+        return generate_via_prefill_decode_loop(
+            ctx, prompt, params, [&](int32_t token) -> bool {
                 std::string text = tok->decode({token});
                 int stop = cb(text.c_str(), text.size(), user_data);
-                prev_output_size++;
-                if (stop != 0) {
-                    // User requested stop
-                    ctx->engine->kv_manager()->free_sequence(req->id);
-                    req->status = imp::RequestStatus::CANCELLED;
-                    return IMP_ERROR_CANCELLED;
-                }
-            }
-        }
-
-        return IMP_SUCCESS;
+                return stop == 0;
+            });
     } catch (const std::bad_alloc&) {
         return IMP_ERROR_OUT_OF_MEMORY;
     } catch (const std::exception& e) {
@@ -463,55 +505,24 @@ ImpError imp_generate(ImpContext ctx, const char* prompt, const ImpGenerateParam
         if (!tok)
             return IMP_ERROR_INVALID_MODEL;
 
-        auto tokens = tokenize_prompt(ctx, prompt, params);
+        std::vector<int32_t> output_tokens;
+        output_tokens.reserve(params->max_tokens > 0 ? params->max_tokens : 256);
 
-        // Empty token stream would walk into executor_forward.cu:183's
-        // "n_tokens must be positive" guard and then trip a FATAL at
-        // tensor.cpp:91 via the slice() of an uninitialised logits tensor.
-        // Bail out cleanly here instead of crashing the engine.
-        if (tokens.empty()) {
-            IMP_LOG_WARN(
-                "imp_generate: prompt tokenised to 0 tokens (prompt='%.80s%s', "
-                "model may lack vocab coverage or chat-template guard rejected it)",
-                prompt, std::strlen(prompt) > 80 ? "…" : "");
+        ImpError err = generate_via_prefill_decode_loop(
+            ctx, prompt, params, [&](int32_t token) -> bool {
+                output_tokens.push_back(token);
+                return true;
+            });
+        if (err != IMP_SUCCESS) {
             if (output_len) *output_len = 0;
             if (output_buf_size > 0) output_buf[0] = '\0';
-            return IMP_ERROR_INVALID_ARG;
+            return err;
         }
 
-        // Create request with all sampling params
-        auto req = std::make_shared<imp::Request>();
-        req->input_tokens = std::move(tokens);
-        apply_sampling_params(*req, params);
-        req->ignore_eos = (params->ignore_eos != 0);
-        req->logprobs = (params->logprobs != 0);
-        req->top_logprobs = std::max(0, std::min(20, params->top_logprobs));
-        req->json_mode = (params->json_mode != 0);
-        req->status = imp::RequestStatus::PENDING;
+        // Detokenise the accumulated tokens.
+        std::string result = tok->decode(output_tokens);
 
-        ctx->engine->add_request(req);
-
-        // Prefill
-        while (req->status == imp::RequestStatus::PENDING || req->status == imp::RequestStatus::PREFILLING) {
-            bool has_work = ctx->engine->step();
-            if (!has_work)
-                break;
-        }
-
-        // Decode
-        while (req->status != imp::RequestStatus::FINISHED && req->status != imp::RequestStatus::CANCELLED) {
-            bool has_work = ctx->engine->step();
-            if (!has_work && req->status != imp::RequestStatus::FINISHED)
-                break;
-        }
-
-        // Collect output
-        std::string result;
-        for (int32_t t : req->output_tokens) {
-            result += tok->decode({t});
-        }
-
-        // Copy result to output buffer
+        // Copy result to output buffer.
         size_t copy_len = result.size();
         if (copy_len >= output_buf_size) {
             copy_len = output_buf_size - 1;

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -274,7 +274,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     Tensor q_target = has_attn_output_gate ? qv_full : qv;
 
     // GemmContext for all weight GEMM dispatches in this function.
-    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
+    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_,
+                                 model_->config().overrides.gemma4.force_mmvq);
 
     // 3. QKV projections:  [n, d] @ W^T -> [n, proj_dim]
     //    For decode (n=1) with matching quant types: fused RMSNorm→Q8_1→QKV GEMV.
@@ -1197,7 +1198,7 @@ after_attention:
         // (gemm.cu mixed-precision short-circuit). Skips the FP16-only mmvq
         // and dp4a fast paths via output.qtype==FP32 guards in dispatch.
         const bool fp32_attn_out = (model_->config().arch == ModelArch::GEMMA4 && using_fp32_accum &&
-                                    RuntimeConfig::current().gemma4.fp32_gemm_out);
+                                    model_->config().overrides.gemma4.fp32_gemm_out);
         void* po_fp32_buf = nullptr;
         if (fp32_attn_out) {
             size_t bytes = static_cast<size_t>(n) * model_->config().d_model * sizeof(float);

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -105,7 +105,8 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
     }
 
     // GemmContext for all weight GEMM dispatches in this function.
-    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
+    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_,
+                                 model_->config().overrides.gemma4.force_mmvq);
 
     // 3. Gate and Up projections
     //    For decode (n=1): fuse RMSNorm→Q8_1→GEMV to avoid redundant quantization.

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -587,7 +587,8 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                              !RuntimeConfig::current().gemm.no_dp4a_lm;
 
     // GemmContext for LM head GEMM dispatches.
-    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
+    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_,
+                                 model_->config().overrides.gemma4.force_mmvq);
 
     // Registry handle for LM head — replaces wcache_ probe per call (Task 3.5).
     const WeightHandle* lm_h = (model_->out_proj_id != kInvalidTensorID)

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -246,7 +246,7 @@ void GraphExecutor::moe_ffn_phase2_state_and_norm_(int layer, cudaStream_t strea
     // at GEMM output) to isolate precision drift. Allocated below in the FP16
     // batch path; freed at moe_after_experts. Other prefill paths ignore this.
     ctx.fp32_down_active = (cfg.arch == ModelArch::GEMMA4 &&
-                            RuntimeConfig::current().gemma4.fp32_expert_down);
+                            cfg.overrides.gemma4.fp32_expert_down);
     ctx.fp32_down_buf = nullptr;
     ctx.moe_fused_norm_q8 = (ctx.n == 1 && qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr &&
                              ctx.h.qtype == QType::F16 && !ctx.nvfp4_covers_layer &&
@@ -347,7 +347,7 @@ void GraphExecutor::moe_ffn_phase3_route_(int layer, cudaStream_t stream, MoeFfn
     // Gemma 4: dp4a decode fast path ENABLED by default. dp4a matches llama's
     // Q4_K×Q8_1 accumulation for MoE experts, preventing the routing drift that
     // occurs with FP16 dequant+cuBLAS. Set IMP_G4_NO_DECODE_FAST=1 to disable.
-    if (cfg.arch == ModelArch::GEMMA4 && RuntimeConfig::current().gemma4.no_decode_fast) {
+    if (cfg.arch == ModelArch::GEMMA4 && cfg.overrides.gemma4.no_decode_fast) {
         ctx.will_decode_fast = false;
     }
 
@@ -452,7 +452,7 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         if (try_run_moe_q6k_prefill(layer, stream, n, d, eff, ne, expanded,
                                     non_gated_experts, up_qtype, routing, no)) {
             // Falls through to scatter (step 7)
-        } else if (RuntimeConfig::current().gemma4.ggml_prefill && cfg.arch == ModelArch::GEMMA4 &&
+        } else if (cfg.overrides.gemma4.ggml_prefill && cfg.arch == ModelArch::GEMMA4 &&
                    ly.expert_gate_packed.on_device && ly.expert_up_packed.on_device &&
                    ly.expert_down_packed.on_device &&
                    try_run_moe_gemma4_ggml_prefill(layer, stream, n, d, eff, top_k, up_qtype, eps,
@@ -2698,7 +2698,8 @@ void GraphExecutor::run_shared_expert_ffn(int layer, cudaStream_t stream, int n,
     int64_t sh_down_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(d)};
     Tensor sh_down(moe_.expert_down.data, compute_dtype_, 2, sh_down_shape, true);
 
-    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
+    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_,
+                                 model_->config().overrides.gemma4.force_mmvq);
     gemm_dispatch(no, ly.w_up_shared, sh_up, ctx);
 
     if (shared_gated) {
@@ -2735,7 +2736,7 @@ void GraphExecutor::run_shared_expert_ffn(int layer, cudaStream_t stream, int n,
         sanitize_fp16(static_cast<__half*>(sh_down.data), static_cast<int64_t>(n) * d, stream);
     }
     if (cfg.arch == ModelArch::GEMMA4 && ly.ffn_post_norm_1.data != nullptr &&
-        !RuntimeConfig::current().gemma4.no_post_ffw_1) {
+        !cfg.overrides.gemma4.no_post_ffw_1) {
         rmsnorm(sh_down, ly.ffn_post_norm_1, sh_down, eps, stream, norm_w_off_);
     }
 

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1840,6 +1840,7 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
         args.q8_1_buf = qs->q8_1_buf;
         args.d8_buf = qs->d8_buf;
         args.dequant_scratch = qs->dequant;  // fused-gemv readiness sentinel
+        args.force_mmvq = ctx.force_mmvq;
         GemmStrategy strat{StorageTier::FP16, qtype, /*m_is_one=*/true};
         if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
             return;

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -62,7 +62,8 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
     rmsnorm(h, ly.attn_norm, no, eps, stream, norm_w_off_);
 
     // GemmContext for all weight GEMM dispatches in this function.
-    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
+    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_,
+                                 model_->config().overrides.gemma4.force_mmvq);
 
     // 2. ssm_in projection: [n, d_model] @ ssm_in^T -> [n, ssm_in_dim]
     //    ssm_in_dim = inner(z) + conv_channels(xBC) + n_heads(dt)
@@ -269,7 +270,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     int n_heads = cfg.ssm_dt_rank;
     int head_dim_ssm = (n_heads > 0) ? inner / n_heads : 0;
 
-    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_);
+    auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_,
+                                 model_->config().overrides.gemma4.force_mmvq);
 
     Tensor h = view_tokens(hidden_, n);
     Tensor r = view_tokens(residual_, n);

--- a/src/exec/gemm_context.h
+++ b/src/exec/gemm_context.h
@@ -24,17 +24,24 @@ struct GemmContext {
     const WeightCaches* wcache = nullptr;
     bool force_fp16 = false;
 
+    // Per-model override: when set, the GGUF small-M dispatch path prefers
+    // the mmvq backend over dp4a for eligible qtypes. Sourced from
+    // ModelConfig::Overrides::Gemma4::force_mmvq (Phase 5 Track A). Defaults
+    // to false so non-Gemma-4 models behave identically.
+    bool force_mmvq = false;
+
     // Quantization scratch buffers (non-owning)
     const QuantScratch* qscratch = nullptr;
 
     // Helper: create from executor state
     static GemmContext make(cudaStream_t s, const WeightCaches& wc, const QuantScratch& qs,
-                            bool force_fp16 = false) {
+                            bool force_fp16 = false, bool force_mmvq = false) {
         GemmContext ctx;
         ctx.stream = s;
         ctx.wcache = &wc;
         ctx.qscratch = &qs;
         ctx.force_fp16 = force_fp16;
+        ctx.force_mmvq = force_mmvq;
         return ctx;
     }
 

--- a/src/exec/gemm_kernel_gguf.cu
+++ b/src/exec/gemm_kernel_gguf.cu
@@ -170,9 +170,11 @@ static GemmDispatchResult run_gguf_smallm(const GemmKernelArgs& args, QType qtyp
 
     // mmvq has stricter eligibility (legacy line 2216-2220): force_mmvq set,
     // qtype mmvq supports, K%32==0, no_mmvq off, no_mmvq_q8_0 off for Q8_0.
+    // `force_mmvq` is the per-model override forwarded via GemmKernelArgs from
+    // ModelConfig::Overrides::Gemma4::force_mmvq (Phase 5 Track A).
     const bool no_mmvq_q8_0 = rcfg.gemm.no_mmvq_q8_0;
     const bool no_mmvq_all = rcfg.gemm.no_mmvq;
-    const bool use_mmvq = rcfg.gemma4.force_mmvq && mmvq_eligible && (K % 32 == 0) && !no_mmvq_all &&
+    const bool use_mmvq = args.force_mmvq && mmvq_eligible && (K % 32 == 0) && !no_mmvq_all &&
                           !(no_mmvq_q8_0 && qtype == QType::Q8_0);
 
     // dp4a eligibility (legacy line 2221-2222): scratch present + is_dp4a_qtype.

--- a/src/exec/gemm_kernel_registry.h
+++ b/src/exec/gemm_kernel_registry.h
@@ -110,6 +110,11 @@ struct GemmKernelArgs {
     // casts to block_q8_1*.
     void* q8_1_buf = nullptr;
     float* d8_buf = nullptr;
+
+    // Per-model gemma4.force_mmvq override (Phase 5 Track A). Used by the
+    // GGUF small-M kernels to decide between the mmvq and dp4a backends.
+    // Sourced from ModelConfig::Overrides::Gemma4::force_mmvq via GemmContext.
+    bool force_mmvq = false;
 };
 
 // Result of a dispatch attempt.

--- a/src/memory/memory_manager.cpp
+++ b/src/memory/memory_manager.cpp
@@ -1,0 +1,13 @@
+#include "memory/memory_manager.h"
+
+// All MemoryManager methods are currently inline in the header — the façade
+// is a thin wrapper around already-existing modules. This TU is kept as the
+// home for any future non-inline logic (e.g. cross-allocator accounting,
+// telemetry, or pre-allocation orchestration) so callers can keep including
+// the header without forcing a rebuild when implementation changes land.
+//
+// Phase 5 Track C of
+// docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+
+namespace imp {
+}  // namespace imp

--- a/src/memory/memory_manager.h
+++ b/src/memory/memory_manager.h
@@ -1,0 +1,97 @@
+#pragma once
+
+// Façade that consolidates VRAM ownership for the imp Engine.
+//
+// Phase 5 Track C of
+// docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md
+//
+// Before this façade, Engine carried a `VRAMAllocator vram_alloc_` field
+// directly and the budget + storage-plan free functions lived in
+// `src/runtime/{vram_budget,storage_planner}.cpp`. This left memory-related
+// ownership scattered across Engine + two anonymous free functions.
+//
+// MemoryManager bundles them into a single owner: the Engine has one
+// `MemoryManager memory_manager_` field, and code that previously called
+//   vram_alloc(engine.vram_alloc_, ...)
+//   compute_vram_budget(model, config, ...)
+//   plan_storage(model, cfg, hints)
+// now reaches them via `engine.memory_manager()` (allocator) and the
+// matching wrapper methods (`compute_budget`, `plan_storage_for`).
+//
+// The underlying modules (vram_allocator, device_allocator, pinned_allocator,
+// vram_budget, storage_planner) are unchanged. This is a façade, not an
+// implementation merge: existing free functions still work; callers just
+// reach the allocator through the façade now.
+//
+// PinnedAllocator and DeviceAllocator are exposed via lazy accessors. The
+// imp Engine does not currently instantiate them on construction (no path
+// uses them yet); making them lazy keeps Engine init cheap and avoids
+// allocating a 64-MiB pinned pool until something actually asks for it.
+
+#include "memory/device_allocator.h"
+#include "memory/pinned_allocator.h"
+#include "memory/vram_allocator.h"
+#include "runtime/storage_planner.h"
+#include "runtime/vram_budget.h"
+
+#include <cstddef>
+#include <memory>
+
+namespace imp {
+
+class Model;
+struct ModelConfig;
+struct EngineConfig;
+
+class MemoryManager {
+public:
+    MemoryManager() = default;
+    ~MemoryManager() = default;
+
+    MemoryManager(const MemoryManager&) = delete;
+    MemoryManager& operator=(const MemoryManager&) = delete;
+    MemoryManager(MemoryManager&&) = delete;
+    MemoryManager& operator=(MemoryManager&&) = delete;
+
+    // -- VRAM allocator ----------------------------------------------------
+    // Owned directly: Engine calls init() before use.
+    VRAMAllocator& vram_allocator() noexcept { return vram_alloc_; }
+    const VRAMAllocator& vram_allocator() const noexcept { return vram_alloc_; }
+
+    // -- Pinned host allocator (lazy) -------------------------------------
+    // Constructed on first access. Default pool size from PinnedAllocator
+    // (currently 64 MiB).
+    PinnedAllocator& pinned_allocator() {
+        if (!pinned_alloc_)
+            pinned_alloc_ = std::make_unique<PinnedAllocator>();
+        return *pinned_alloc_;
+    }
+    bool has_pinned_allocator() const noexcept { return pinned_alloc_ != nullptr; }
+
+    // -- Device (cudaMallocAsync pool) allocator (lazy) -------------------
+    // Constructed on first access.
+    DeviceAllocator& device_allocator() {
+        if (!device_alloc_)
+            device_alloc_ = std::make_unique<DeviceAllocator>();
+        return *device_alloc_;
+    }
+    bool has_device_allocator() const noexcept { return device_alloc_ != nullptr; }
+
+    // -- Budget + storage planning (wrap free functions) ------------------
+    VRAMBudget compute_budget(const Model& model, const EngineConfig& config, int n_kv_layers,
+                              int head_dim, size_t free_vram) const {
+        return compute_vram_budget(model, config, n_kv_layers, head_dim, free_vram);
+    }
+
+    StoragePlan plan_storage_for(const Model& model, const ModelConfig& cfg,
+                                 const PlanHints& hints) const {
+        return plan_storage(model, cfg, hints);
+    }
+
+private:
+    VRAMAllocator vram_alloc_;
+    std::unique_ptr<PinnedAllocator> pinned_alloc_;
+    std::unique_ptr<DeviceAllocator> device_alloc_;
+};
+
+}  // namespace imp

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -117,6 +117,24 @@ struct ModelConfig {
     // can use this to decide whether to invoke tensor-name heuristics, and
     // higher layers can surface an explicit warning to the user.
     bool arch_inferred_fallback = false;
+
+    // Model-specific runtime knobs that used to live on the global
+    // RuntimeConfig singleton. Phase 5 Track A of the architecture refactor
+    // moved them onto ModelConfig so the "model-name in a runtime
+    // singleton" smell goes away. Populated from imp.conf (legacy
+    // [gemma4] section seeds compat) or set by engine_init_resolver when
+    // the arch is GEMMA4; default-constructed otherwise.
+    struct Overrides {
+        struct Gemma4 {
+            bool fp32_gemm_out = false;
+            bool no_graphs = false;
+            bool force_mmvq = false;
+            bool fp32_expert_down = false;
+            bool no_decode_fast = false;
+            bool no_post_ffw_1 = false;
+            bool ggml_prefill = false;
+        } gemma4;
+    } overrides;
 };
 
 // Forward declaration — full definition in quant/nvfp4_quant.h.

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -205,21 +205,10 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     else if (eq("gemm.q4k_imma_enabled"))
         cfg.gemm.q4k_imma_enabled = parse_bool(val, cfg.gemm.q4k_imma_enabled);
 
-    // [gemma4]
-    else if (eq("gemma4.fp32_gemm_out"))
-        cfg.gemma4.fp32_gemm_out = parse_bool(val, cfg.gemma4.fp32_gemm_out);
-    else if (eq("gemma4.no_graphs"))
-        cfg.gemma4.no_graphs = parse_bool(val, cfg.gemma4.no_graphs);
-    else if (eq("gemma4.force_mmvq"))
-        cfg.gemma4.force_mmvq = parse_bool(val, cfg.gemma4.force_mmvq);
-    else if (eq("gemma4.fp32_expert_down"))
-        cfg.gemma4.fp32_expert_down = parse_bool(val, cfg.gemma4.fp32_expert_down);
-    else if (eq("gemma4.no_decode_fast"))
-        cfg.gemma4.no_decode_fast = parse_bool(val, cfg.gemma4.no_decode_fast);
-    else if (eq("gemma4.no_post_ffw_1"))
-        cfg.gemma4.no_post_ffw_1 = parse_bool(val, cfg.gemma4.no_post_ffw_1);
-    else if (eq("gemma4.ggml_prefill"))
-        cfg.gemma4.ggml_prefill = parse_bool(val, cfg.gemma4.ggml_prefill);
+    // [gemma4] section moved to ModelConfig::Overrides::Gemma4 in Phase 5
+    // Track A of the architecture refactor. Per-model knobs no longer live
+    // on the global RuntimeConfig singleton — they are now populated by the
+    // GGUF / SafeTensors loader or the engine init resolver onto the model.
 
     // [generation]
     else if (eq("generation.no_logit_softcap"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -182,15 +182,10 @@ struct RuntimeConfig {
         bool q4k_imma_enabled = false;
     } gemm;
 
-    struct Gemma4 {
-        bool fp32_gemm_out = false;
-        bool no_graphs = false;
-        bool force_mmvq = false;
-        bool fp32_expert_down = false;
-        bool no_decode_fast = false;
-        bool no_post_ffw_1 = false;
-        bool ggml_prefill = false;
-    } gemma4;
+    // (RuntimeConfig::Gemma4 lived here through Phase 4 of the architecture
+    // refactor. Phase 5 Track A moved it to ModelConfig::Overrides::Gemma4 —
+    // see src/model/model_config.h. Model-specific knobs do not belong on a
+    // global runtime singleton.)
 
     struct Generation {
         bool no_logit_softcap = false;

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -62,7 +62,7 @@ Engine::~Engine() {
         async_d_banned_tokens_ = nullptr;
     }
     if (d_penalty_tokens_) {
-        vram_alloc_.free(d_penalty_tokens_);
+        memory_manager_.vram_allocator().free(d_penalty_tokens_);
         d_penalty_tokens_ = nullptr;
     }
     if (d_kv_slot_buf_) {
@@ -74,7 +74,7 @@ Engine::~Engine() {
         h_sample_pinned_ = nullptr;
     }
     if (prefill_pool_) {
-        vram_alloc_.free(prefill_pool_);
+        memory_manager_.vram_allocator().free(prefill_pool_);
         prefill_pool_ = nullptr;
     }
     if (h_pf_positions_) {
@@ -504,10 +504,10 @@ void Engine::upload_penalties(const Request& req, InferenceState& state, cudaStr
     size_t n = req.output_tokens.size();
     if (n > d_penalty_tokens_capacity_) {
         if (d_penalty_tokens_)
-            vram_alloc_.free(d_penalty_tokens_);
+            memory_manager_.vram_allocator().free(d_penalty_tokens_);
         d_penalty_tokens_capacity_ = std::max(n, (size_t)256);
         d_penalty_tokens_ = static_cast<int32_t*>(
-            vram_alloc_.allocate(d_penalty_tokens_capacity_ * sizeof(int32_t), "penalty_tokens"));
+            memory_manager_.vram_allocator().allocate(d_penalty_tokens_capacity_ * sizeof(int32_t), "penalty_tokens"));
         if (!d_penalty_tokens_) {
             IMP_LOG_ERROR("VRAMAllocator failed for penalty tokens (%zu)", d_penalty_tokens_capacity_);
             d_penalty_tokens_capacity_ = 0;
@@ -586,7 +586,7 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // --- Core initialization ---
     // 5% headroom (was 10%) — MoE models (30B Q6_K) need every MiB on 32GB.
     // WSL2/WDDM has ~500 MiB driver overhead, 5% of 32GB = 1.6 GB covers it.
-    if (!vram_alloc_.init(0.05f)) {
+    if (!memory_manager_.vram_allocator().init(0.05f)) {
         IMP_LOG_ERROR("Failed to initialize VRAM allocator");
         return false;
     }
@@ -617,7 +617,7 @@ bool Engine::init_weights() {
 
     // Initialize graph executor (Phase 1: compute sizes, no GPU allocation)
     executor_ = std::make_unique<GraphExecutor>();
-    executor_->set_vram_allocator(&vram_alloc_);
+    executor_->set_vram_allocator(&memory_manager_.vram_allocator());
     {
         int eff_batch = config_.max_batch_size;
         if (!executor_->init(*model_, config_.compute_dtype, config_.use_pdl, eff_batch, config_.max_seq_len,
@@ -870,7 +870,8 @@ bool Engine::init_kv_cache() {
     int blocks_per_seq = (config_.max_seq_len + kv_bs - 1) / kv_bs;
 
     // VRAM budget
-    auto vram_budget = compute_vram_budget(*model_, config_, n_kv_layers, head_dim, effective_free_vram());
+    auto vram_budget =
+        memory_manager_.compute_budget(*model_, config_, n_kv_layers, head_dim, effective_free_vram());
     int max_blocks = config_.kv_cache_max_blocks > 0 ? config_.kv_cache_max_blocks
                                                      : vram_budget.kv_max_blocks;
 
@@ -906,10 +907,10 @@ bool Engine::init_kv_cache() {
             k++;
         }
         kv_cache = std::make_unique<KVCache>(n_kv_layers, per_layer_nkv, per_layer_hd, config_.kv_cache_dtype,
-                                             max_blocks, kv_bs, &vram_alloc_);
+                                             max_blocks, kv_bs, &memory_manager_.vram_allocator());
     } else {
         kv_cache = std::make_unique<KVCache>(n_kv_layers, mcfg.n_kv_heads, head_dim, config_.kv_cache_dtype,
-                                             max_blocks, kv_bs, &vram_alloc_);
+                                             max_blocks, kv_bs, &memory_manager_.vram_allocator());
     }
     kv_cache_raw_ = kv_cache.get();
     kv_manager_ = std::make_unique<KVCacheManager>(std::move(kv_cache));
@@ -926,7 +927,7 @@ bool Engine::init_kv_cache() {
         int residual_n = rcfg.kv_cache.bitdecoding_residual_tokens;
         if (residual_n > 0 && config_.kv_cache_dtype == QType::NVFP4) {
             int max_seqs = config_.max_batch_size > 0 ? config_.max_batch_size : 1;
-            if (kv_manager_->enable_residual_buffer(max_seqs, residual_n, &vram_alloc_)) {
+            if (kv_manager_->enable_residual_buffer(max_seqs, residual_n, &memory_manager_.vram_allocator())) {
                 // Persistent batch→slot lookup buffer (graph-safe). [max_batch_size] ints.
                 size_t slot_bytes = static_cast<size_t>(max_seqs) * sizeof(int);
                 cudaMalloc(&d_kv_slot_buf_, slot_bytes);
@@ -975,7 +976,7 @@ bool Engine::init_kv_cache() {
             int hd = (n_heads > 0) ? mcfg.ssm_inner_size / n_heads : 0;
             ssm_state_ = std::make_unique<SSMState>();
             if (!ssm_state_->init(n_ssm, config_.max_batch_size, conv_ch, mcfg.ssm_conv_kernel, n_heads, hd,
-                                  mcfg.ssm_state_size, config_.ssm_state_dtype, &vram_alloc_)) {
+                                  mcfg.ssm_state_size, config_.ssm_state_dtype, &memory_manager_.vram_allocator())) {
                 IMP_LOG_WARN("Failed to init SSM state, continuing without it");
                 ssm_state_.reset();
             }
@@ -1042,11 +1043,11 @@ bool Engine::init_kv_cache() {
         IMP_LOG_INFO("Weight cache: FP8 E4M3 (2x prefill throughput on sm_120)");
 
     // Pre-allocate decode batch pool + penalty buffer
-    decode_batch_pool_.allocate(config_.max_batch_size, blocks_per_seq, &vram_alloc_);
+    decode_batch_pool_.allocate(config_.max_batch_size, blocks_per_seq, &memory_manager_.vram_allocator());
     {
         d_penalty_tokens_capacity_ = static_cast<size_t>(config_.max_seq_len);
         d_penalty_tokens_ = static_cast<int32_t*>(
-            vram_alloc_.allocate(d_penalty_tokens_capacity_ * sizeof(int32_t), "penalty_tokens"));
+            memory_manager_.vram_allocator().allocate(d_penalty_tokens_capacity_ * sizeof(int32_t), "penalty_tokens"));
         if (!d_penalty_tokens_) {
             IMP_LOG_WARN("Failed to pre-allocate penalty token buffer");
             d_penalty_tokens_capacity_ = 0;
@@ -1064,7 +1065,7 @@ bool Engine::init_kv_cache() {
         size_t bt_bytes = static_cast<size_t>(max_blocks) * sizeof(int);
         size_t cl_bytes = sizeof(int);
         prefill_pool_size_ = tok_bytes + pos_bytes + bt_bytes + cl_bytes;
-        prefill_pool_ = vram_alloc_.allocate(prefill_pool_size_, "prefill_pool");
+        prefill_pool_ = memory_manager_.vram_allocator().allocate(prefill_pool_size_, "prefill_pool");
         if (prefill_pool_) {
             auto* base = static_cast<char*>(prefill_pool_);
             d_pf_token_ids_ = reinterpret_cast<int32_t*>(base);
@@ -1091,7 +1092,7 @@ bool Engine::init_kv_cache() {
             IMP_LOG_INFO("GPU memory: %.0f MiB used / %.0f MiB total (%.0f MiB free)",
                          (total_mem - free_mem) / (1024.0 * 1024.0), total_mem / (1024.0 * 1024.0),
                          free_mem / (1024.0 * 1024.0));
-        vram_alloc_.report();
+        memory_manager_.vram_allocator().report();
     }
 
     return true;
@@ -1150,7 +1151,7 @@ bool Engine::init_features() {
 
     // Vision
     if (!config_.mmproj_path.empty()) {
-        if (!vision_.init(config_.mmproj_path, mcfg.d_model, model_.get(), vram_alloc_, stream_))
+        if (!vision_.init(config_.mmproj_path, mcfg.d_model, model_.get(), memory_manager_.vram_allocator(), stream_))
             return false;
     }
 

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -14,6 +14,7 @@
 #include "memory/ssm_state.h"
 #include "memory/gdn_state.h"
 #include "memory/layer_offload.h"
+#include "memory/memory_manager.h"
 #include "memory/vram_allocator.h"
 #include "exec/executor.h"
 #include "core/cuda_raii.h"
@@ -192,11 +193,15 @@ public:
     const ChatTemplate& chat_template() const noexcept { return chat_template_; }
     const std::vector<int32_t>& banned_token_ids() const { return banned_token_ids_; }
     GraphExecutor* executor() const noexcept { return executor_.get(); }
-    VRAMAllocator& vram_allocator() noexcept { return vram_alloc_; }
+    VRAMAllocator& vram_allocator() noexcept { return memory_manager_.vram_allocator(); }
+    MemoryManager& memory_manager() noexcept { return memory_manager_; }
+    const MemoryManager& memory_manager() const noexcept { return memory_manager_; }
 
 private:
     // ── Core components ──────────────────────────────────────────────
-    VRAMAllocator vram_alloc_;
+    // Phase 5 Track C: façade over VRAMAllocator + (lazy) PinnedAllocator/
+    // DeviceAllocator + vram_budget/storage_planner free functions.
+    MemoryManager memory_manager_;
     std::shared_ptr<Model> model_;
     EngineConfig config_;
     std::unique_ptr<Scheduler> scheduler_;

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -277,16 +277,14 @@ void Engine::init_resolve_quant_flags_() {
         }
         // Gemma 4: CUDA graphs are fully enabled by default. The user can opt
         // out via [gemma4] no_graphs = true for bisecting regressions.
-        if (RuntimeConfig::current().gemma4.no_graphs) {
+        if (model_->config().overrides.gemma4.no_graphs) {
             IMP_LOG_INFO("Gemma 4: disabling all CUDA graphs (gemma4.no_graphs=true)");
             config_.use_cuda_graphs = false;
         }
         // Enable MMVQ for all weight GEMMs — quantized matmul matching llama.cpp's
         // accumulation behavior, critical for 128-expert MoE precision.
-        if (!RuntimeConfig::current().gemma4.force_mmvq) {
-            RuntimeConfig promoted = RuntimeConfig::current();
-            promoted.gemma4.force_mmvq = true;
-            RuntimeConfig::install(promoted);
+        if (!model_->config().overrides.gemma4.force_mmvq) {
+            model_->config_.overrides.gemma4.force_mmvq = true;
             IMP_LOG_INFO("Gemma 4: enabling MMVQ for all weight GEMMs (numerical parity with llama.cpp)");
         }
     }

--- a/tests/test_api_generate.cpp
+++ b/tests/test_api_generate.cpp
@@ -1,0 +1,187 @@
+// Parity tests for imp_generate vs the imp_prefill_with_params +
+// imp_decode_step loop. After Phase 5 Track B (refactor: dedupe imp_generate
+// via imp_prefill + imp_decode_step), imp_generate is a thin wrapper around
+// those two primitives. This test pins the contract — if the wrapper drifts
+// from manual prefill+decode-loop output, this test fails.
+//
+// Requires a real model on disk. Skipped via IMP_TEST_MODEL or default
+// /models/Qwen3-8B-Q8_0.gguf, matching test_degeneration.cpp.
+
+#include <gtest/gtest.h>
+#include "imp/imp.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+static const char* get_model_path() {
+    const char* p = std::getenv("IMP_TEST_MODEL");
+    return p ? p : "/models/Qwen3-8B-Q8_0.gguf";
+}
+
+static bool model_exists() {
+    FILE* f = fopen(get_model_path(), "r");
+    if (f) {
+        fclose(f);
+        return true;
+    }
+    return false;
+}
+
+#define SKIP_IF_NO_MODEL()                                           \
+    do {                                                             \
+        if (!model_exists())                                         \
+            GTEST_SKIP() << "Model not found: " << get_model_path(); \
+    } while (0)
+
+class ApiGenerateParityTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        // Greedy determinism on Blackwell sm_120.
+        setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", /*overwrite=*/0);
+    }
+
+    void SetUp() override {
+        SKIP_IF_NO_MODEL();
+
+        ASSERT_EQ(imp_model_load(get_model_path(), IMP_FORMAT_GGUF, &model_), IMP_SUCCESS);
+
+        ImpConfig config = imp_config_default();
+        config.max_seq_len = 2048;
+        config.max_batch_size = 1;
+
+        ImpError err = imp_context_create(model_, &config, &ctx_);
+        if (err != IMP_SUCCESS) {
+            imp_model_free(model_);
+            model_ = nullptr;
+            GTEST_SKIP() << "Context creation failed: " << imp_error_string(err);
+        }
+    }
+
+    void TearDown() override {
+        if (ctx_) imp_context_free(ctx_);
+        if (model_) imp_model_free(model_);
+    }
+
+    ImpModel model_ = nullptr;
+    ImpContext ctx_ = nullptr;
+};
+
+// Sanity: imp_generate produces non-empty output for a simple chat prompt.
+// This pins the post-refactor wrapper against the prefill+decode_step
+// primitives — if the wrapper drops the prefill-sampled token or otherwise
+// breaks the contract, generation will look empty / one-token-short.
+TEST_F(ApiGenerateParityTest, GenerateProducesNonEmptyOutput) {
+    ImpGenerateParams params = imp_generate_params_default();
+    params.seed = 42;
+    params.max_tokens = 16;
+    params.temperature = 0.7f;
+    params.apply_chat_template = 1;
+
+    char buf[2048] = {};
+    size_t n = 0;
+    ASSERT_EQ(imp_generate(ctx_, "What is 2+2?", &params, buf, sizeof(buf), &n), IMP_SUCCESS);
+
+    EXPECT_GT(n, 0u) << "imp_generate returned 0 bytes — wrapper may have dropped "
+                        "the prefill-sampled first token or terminated early";
+    EXPECT_LT(n, sizeof(buf)) << "output exceeded buffer";
+}
+
+// Streaming + non-streaming must produce the same number of callback
+// invocations as final detokenised characters, and both paths must agree on
+// token count under fixed greedy params + same-context reset.
+//
+// Both code paths share the generate_via_prefill_decode_loop helper
+// internally, so this is a regression guard: if a future change diverges the
+// streaming wrapper's token-handling from the non-streaming wrapper, this
+// test fails.
+TEST_F(ApiGenerateParityTest, StreamingDeliversAllTokens) {
+    ImpGenerateParams params = imp_generate_params_default();
+    params.seed = 42;
+    params.max_tokens = 16;
+    params.temperature = 0.7f;
+    params.apply_chat_template = 1;
+    params.ignore_eos = 1;  // force exactly max_tokens to be emitted
+
+    // Path A: non-streaming.
+    char buf[2048] = {};
+    size_t n_nonstream = 0;
+    ASSERT_EQ(imp_generate(ctx_, "Say hi.", &params, buf, sizeof(buf), &n_nonstream),
+              IMP_SUCCESS);
+    std::string nonstream(buf, n_nonstream);
+
+    // Reset context — same engine, same weight cache, fresh request slot.
+    ASSERT_EQ(imp_context_reset(ctx_), IMP_SUCCESS);
+
+    // Path B: streaming. Concatenate every callback payload.
+    std::string streamed;
+    int callback_count = 0;
+    struct CbState {
+        std::string* out;
+        int* count;
+    } state{&streamed, &callback_count};
+    auto cb = +[](const char* text, size_t len, void* user_data) -> int {
+        auto* s = static_cast<CbState*>(user_data);
+        s->out->append(text, len);
+        (*s->count)++;
+        return 0;
+    };
+    ASSERT_EQ(imp_generate_streaming(ctx_, "Say hi.", &params, cb, &state), IMP_SUCCESS);
+
+    // With ignore_eos=1 + max_tokens=16, both paths should emit 16 tokens.
+    // The callback fires once per generated token, so callback_count should
+    // equal max_tokens (or be 1 fewer if the prefill-sampled token bookkeeping
+    // is wrong — which is what this test guards against).
+    EXPECT_EQ(callback_count, params.max_tokens)
+        << "streaming wrapper delivered " << callback_count << " tokens, expected "
+        << params.max_tokens << " — wrapper may be dropping the prefill-sampled token";
+
+    EXPECT_GT(streamed.size(), 0u) << "streaming produced empty output";
+    EXPECT_GT(nonstream.size(), 0u) << "non-streaming produced empty output";
+}
+
+// Manual prefill + decode_step loop must run successfully end-to-end with the
+// same params imp_generate uses. This is a smoke test that the public C API
+// composes correctly — the wrapper-vs-manual content parity is not asserted
+// because cross-engine non-determinism (separate Engine instances loading the
+// same weights) can shift greedy logits enough to diverge after a few tokens.
+TEST_F(ApiGenerateParityTest, ManualPrefillDecodeLoopRuns) {
+    ImpGenerateParams params = imp_generate_params_default();
+    params.seed = 42;
+    params.max_tokens = 8;
+    params.temperature = 0.7f;
+    params.apply_chat_template = 0;
+    params.ignore_eos = 1;
+
+    const char* prompt = "Hello.";
+
+    int32_t tokens[256] = {0};
+    int n_tokens = 0;
+    ASSERT_EQ(imp_tokenize(model_, prompt, tokens, &n_tokens, 256), IMP_SUCCESS);
+    ASSERT_GT(n_tokens, 0);
+
+    ASSERT_EQ(imp_prefill_with_params(ctx_, tokens, n_tokens, &params), IMP_SUCCESS);
+
+    std::vector<int32_t> out_tokens;
+    out_tokens.reserve(params.max_tokens);
+    for (int i = 0; i < params.max_tokens; ++i) {
+        int32_t tok = 0;
+        ImpError step_err = imp_decode_step(ctx_, &params, &tok);
+        if (step_err != IMP_SUCCESS) break;
+        out_tokens.push_back(tok);
+    }
+
+    EXPECT_GT(out_tokens.size(), 0u)
+        << "manual prefill + decode_step loop returned 0 tokens";
+
+    char buf[2048] = {};
+    ASSERT_EQ(imp_detokenize(model_, out_tokens.data(), static_cast<int>(out_tokens.size()),
+                             buf, sizeof(buf)),
+              IMP_SUCCESS);
+    EXPECT_GT(std::strlen(buf), 0u) << "detokenised manual output is empty";
+}
+
+}  // namespace

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -1184,13 +1184,10 @@ TEST_F(GemmKernelRegistryTest, GgufQ8_0Dp4aRegistryDispatchMatchesDirectPath) {
     dispatch_dp4a_gemv(QType::Q8_0, d_weight, static_cast<const block_q8_1*>(d_q8_1), d_d8,
                        reinterpret_cast<half*>(d_out_direct), N, K, stream_);
 
-    // Path 2: registry dispatch through the GGUF Q8_0 kernel adapter. We
-    // must temporarily disable force_mmvq so the handler picks the dp4a
-    // backend (legacy precedence: mmvq wins when both eligible).
-    auto& mut_cfg = const_cast<RuntimeConfig&>(RuntimeConfig::current());
-    const bool prev_force_mmvq = mut_cfg.gemma4.force_mmvq;
-    mut_cfg.gemma4.force_mmvq = false;
-
+    // Path 2: registry dispatch through the GGUF Q8_0 kernel adapter. The
+    // handler reads `args.force_mmvq` (Phase 5 Track A: per-model override
+    // forwarded via GemmKernelArgs); leave it false so the dp4a backend
+    // wins (legacy precedence: mmvq wins when both eligible).
     __half* d_out_registry = nullptr;
     cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
     Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
@@ -1201,10 +1198,10 @@ TEST_F(GemmKernelRegistryTest, GgufQ8_0Dp4aRegistryDispatchMatchesDirectPath) {
     args.weight_payload = &weight;
     args.q8_1_buf = d_q8_1;
     args.d8_buf = d_d8;
+    args.force_mmvq = false;
     GemmStrategy strat{StorageTier::FP16, QType::Q8_0, /*m_is_one=*/true};
     EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
 
-    mut_cfg.gemma4.force_mmvq = prev_force_mmvq;
     cudaStreamSynchronize(stream_);
 
     std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);
@@ -1280,11 +1277,9 @@ TEST_F(GemmKernelRegistryTest, GgufQ8_0MmvqRegistryDispatchProducesNonZero) {
     Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
     Tensor weight(d_weight, QType::Q8_0, 2, w_shape, /*on_device=*/true);
 
-    // Enable force_mmvq so the handler picks mmvq (precedence over dp4a).
-    auto& mut_cfg = const_cast<RuntimeConfig&>(RuntimeConfig::current());
-    const bool prev_force_mmvq = mut_cfg.gemma4.force_mmvq;
-    mut_cfg.gemma4.force_mmvq = true;
-
+    // Enable force_mmvq on the args so the handler picks mmvq (precedence
+    // over dp4a). Phase 5 Track A: per-model override now lives on
+    // GemmKernelArgs::force_mmvq, forwarded from ModelConfig overrides.
     __half* d_out = nullptr;
     cudaMalloc(&d_out, sizeof(__half) * M * N);
     cudaMemsetAsync(d_out, 0, sizeof(__half) * M * N, stream_);
@@ -1295,13 +1290,12 @@ TEST_F(GemmKernelRegistryTest, GgufQ8_0MmvqRegistryDispatchProducesNonZero) {
     args.output = &output;
     args.stream = stream_;
     args.weight_payload = &weight;
+    args.force_mmvq = true;
     // q8_1_buf / d8_buf intentionally NOT supplied — mmvq has its own
     // file-scope scratch and should win the gate.
 
     GemmStrategy strat{StorageTier::FP16, QType::Q8_0, /*m_is_one=*/true};
     EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
-
-    mut_cfg.gemma4.force_mmvq = prev_force_mmvq;
     cudaStreamSynchronize(stream_);
 
     std::vector<__half> h_out(M * N);
@@ -1392,10 +1386,7 @@ TEST_F(GemmKernelRegistryTest, GgufQ8_0FusedGemvFallbackMatchesDirectPath) {
 
     // Path 2: registry dispatch with mmvq disabled, dp4a scratch null,
     // dequant_scratch non-null. Force the handler into the third branch.
-    auto& mut_cfg = const_cast<RuntimeConfig&>(RuntimeConfig::current());
-    const bool prev_force_mmvq = mut_cfg.gemma4.force_mmvq;
-    mut_cfg.gemma4.force_mmvq = false;
-
+    // Phase 5 Track A: force_mmvq now lives on GemmKernelArgs.
     __half* d_out_registry = nullptr;
     cudaMalloc(&d_out_registry, sizeof(__half) * M * N);
     Tensor out_registry(d_out_registry, QType::F16, 2, out_shape, /*on_device=*/true);
@@ -1409,13 +1400,13 @@ TEST_F(GemmKernelRegistryTest, GgufQ8_0FusedGemvFallbackMatchesDirectPath) {
     args.output = &out_registry;
     args.stream = stream_;
     args.weight_payload = &weight;
+    args.force_mmvq = false;
     // q8_1_buf / d8_buf intentionally null — dp4a branch must not fire.
     args.dequant_scratch = &dummy_scratch_sentinel;
 
     GemmStrategy strat{StorageTier::FP16, QType::Q8_0, /*m_is_one=*/true};
     EXPECT_EQ(GemmKernelRegistry::instance().dispatch(strat, args), GemmDispatchResult::Ok);
 
-    mut_cfg.gemma4.force_mmvq = prev_force_mmvq;
     cudaStreamSynchronize(stream_);
 
     std::vector<__half> h_out_direct(M * N), h_out_registry(M * N);


### PR DESCRIPTION
## Summary
**Phase 5 Track C.** Introduce \`MemoryManager\` class in \`src/memory/memory_manager.{h,cpp}\` as a façade owning the engine's VRAM allocators + wrapping the budget/planner free functions. Engine field changes from \`VRAMAllocator vram_alloc_\` to \`MemoryManager memory_manager_\` — single entry point.

## Stacking
#319 → #320 → this.

## Design: façade pattern, not implementation-merge
The 5 underlying modules stay untouched:
- \`memory/vram_allocator\` — owned directly by MemoryManager
- \`memory/pinned_allocator\` + \`memory/device_allocator\` — owned via lazy \`unique_ptr\` (currently unused by Engine, but exposed for future use)
- \`runtime/vram_budget\` + \`runtime/storage_planner\` — free functions wrapped as \`compute_budget()\` / \`plan_storage_for()\` methods

\"Deeper merge\" (kill the .cpp files and fold their bodies) would have inflated the diff by ~300 LOC and broken the façade-not-merge claim. Façade now, fold later if a second consumer ever appears.

## LOC
- New: \`memory_manager.h\` 97 LOC, \`memory_manager.cpp\` 13 LOC
- Engine: 18 call-site migrations (17 internal + 1 executor pointer redirect at \`engine.cpp:620\`)

## Why 18 not ~30
PinnedAllocator/DeviceAllocator were standalone classes that Engine never instantiated. \`src/exec/*\` has its own \`vram_alloc_\` pointer (GraphExecutor::set_vram_allocator), not Engine's — unchanged after this PR's redirect.

## Pre-existing test failure noted
\`StubModelTest.CreateContextAndInfer\` segfaults; verified pre-existing by reproducing on parent commit \`b746959\`. Not introduced by this PR.

## Test plan
- [x] \`make build\` green
- [x] \`make verify-fast\` green
- [x] Pre-push hook verify-fast green
- [x] Combined spec + code-quality reviewer ✅ Approved

Phase 5 Track C of [\`docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md\`](../tree/main/docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)