### PR TITLE
refactor(config): de-globalize RuntimeConfig in Engine + GraphExecutor (partial)

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -16,6 +16,7 @@
 #include "exec/moe_workspace.h"
 #include "exec/quant_scratch.h"
 #include "runtime/storage_planner.h"
+#include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <vector>
@@ -700,6 +701,16 @@ public:
     // Public view_tokens wrapper for external callers.
     Tensor view_hidden(int n_tokens) const { return view_tokens(hidden_, n_tokens); }
 
+    // Phase 5 Track D: per-Engine RuntimeConfig (replaces RuntimeConfig::current()
+    // singleton). Engine wires this via set_runtime_config() during init.
+    // When the executor is constructed outside an Engine (unit tests that
+    // create a bare GraphExecutor without an owning Engine), the pointer
+    // remains null and the accessor falls back to the process-wide singleton.
+    void set_runtime_config(const RuntimeConfig& cfg) noexcept { runtime_config_ = &cfg; }
+    const RuntimeConfig& runtime_config() const noexcept {
+        return runtime_config_ ? *runtime_config_ : RuntimeConfig::current();
+    }
+
 private:
     // Phases of pre_dequant_weights(), extracted for readability.
     // Cross-phase state: remaining_budget is reduced by each FP16/FP8/NVFP4
@@ -910,6 +921,11 @@ private:
 
     // --- Layer offload manager (non-owning, set by engine) ---
     LayerOffloadManager* offload_mgr_ = nullptr;
+
+    // --- Per-Engine RuntimeConfig (Phase 5 Track D, non-owning) ---
+    // Engine wires this via set_runtime_config() during Engine::init.
+    // Replaces RuntimeConfig::current() inside GraphExecutor::* methods.
+    const RuntimeConfig* runtime_config_ = nullptr;
 
     // --- Allocation and configuration methods ---
 

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -553,7 +553,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         int64_t gate_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(q_actual_dim)};
         attn_gate_buf = Tensor(ssm_z_buf_.data, compute_dtype_, 2, gate_shape, true);
 
-        const bool use_concat = RuntimeConfig::current().attention.gate_concat;
+        const bool use_concat = runtime_config().attention.gate_concat;
         if (use_concat) {
             // Feature-dim concat: Q = src[:, :q_actual_dim]; gate = src[:, q_actual_dim:]
             // One 2D copy each, width = q_actual_dim bytes per row.
@@ -599,7 +599,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         } else if (fused_rope_dim > hd || fused_rope_dim <= 0) {
             fused_rope_dim = hd;
         }
-        const bool no_qknorm_fused = RuntimeConfig::current().attention.no_qknorm_fused;
+        const bool no_qknorm_fused = runtime_config().attention.no_qknorm_fused;
         if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused) {
             // Fused: QK-norm + RoPE in one kernel launch (decode only, n=1).
             // Keeps norm intermediate values in FP32 shared memory.
@@ -814,8 +814,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         // Set IMP_NO_CUBLAS_ATTN=1 to force flash attention (for benchmarking).
         // Gemma 4: flash attention kernels don't support head_dim=512, so we MUST
         // use cuBLAS attention for all layers (it handles arbitrary head_dim).
-        const bool no_cublas_attn = RuntimeConfig::current().attention.no_cublas;
-        const bool use_naive_attn = RuntimeConfig::current().attention.naive;
+        const bool no_cublas_attn = runtime_config().attention.no_cublas;
+        const bool use_naive_attn = runtime_config().attention.naive;
         bool force_cublas_attn = per_layer_shapes;  // Gemma 4 dual head_dim
         // Gemma-4 SWA used to need the naive FP32 workaround because the FMHA
         // chain emitted garbage on hd=256 + sliding and the cuBLAS softmax had
@@ -831,7 +831,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         int cublas_cap = attn_scores_buf_ ? static_cast<int>(attn_scores_.shape[1]) : 0;
         bool gemma4_overflow_cublas = (cfg.arch == ModelArch::GEMMA4 && n > cublas_cap);
         bool use_naive_for_swa = (gemma4_overflow_cublas && n <= 8192 &&
-                                  !RuntimeConfig::current().attention.no_naive_swa);
+                                  !runtime_config().attention.no_naive_swa);
         if ((use_naive_attn && n <= 2048) || use_naive_for_swa) {
             // Naive reference attention: simple FP32, no optimization.
             if (layer == 0 && use_naive_for_swa && !use_naive_attn)
@@ -925,7 +925,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
 
         // DEBUG: force cuBLAS attention for decode to isolate paged attention bugs.
         // When enabled, uses the same materialized QK^T path as prefill.
-        const bool force_cublas_decode = RuntimeConfig::current().attention.force_cublas_decode;
+        const bool force_cublas_decode = runtime_config().attention.force_cublas_decode;
         if (force_cublas_decode && n == 1 && attn_scores_buf_) {
             // Reconstruct K/V from cache for this position
             KVCache* cache_dbg = state.kv_cache;
@@ -1009,7 +1009,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // BitDecoding TC dispatch opt-in: kv_cache.bitdecoding_qk (legacy
             // IMP_USE_BITDECODING_QK=1) routes to the WMMA-Q.K variant; default
             // keeps the scalar-FFMA path unchanged.
-            const bool use_bitdecoding_tc = imp::RuntimeConfig::current().kv_cache.bitdecoding_qk;
+            const bool use_bitdecoding_tc = runtime_config().kv_cache.bitdecoding_qk;
             if (use_bitdecoding_tc) {
                 // QW6 from review/phase5_synthesis.md §2.1: gate the entire
                 // residual-arg marshalling (8+ trailing args) behind a single

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -231,7 +231,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
         // Instrumentation-only: measure contextual FFN sparsity (decode only).
         // Reads go and uo, counts rows with |silu(gate)*up| under each of 5
         // thresholds. Cheap (~1 µs / layer) when on, no-op when off.
-        if (n == 1 && RuntimeConfig::current().ffn.sparsity_probe &&
+        if (n == 1 && runtime_config().ffn.sparsity_probe &&
             go.qtype == QType::F16 && uo.qtype == QType::F16) {
             const int K_ff = static_cast<int>(ly.w_gate.shape[0]);
             probe_ffn_silu_sparsity(layer, static_cast<const half*>(go.data),
@@ -338,7 +338,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
             // Phase 2 FFN sparsity: when threshold > 0 and Q8_0 down_proj, build
             // a per-Q8-block mask from gate*up and dispatch the masked GEMV.
             // Falls through to standard dispatch for other qtypes or when off.
-            const float sparsity_thr = RuntimeConfig::current().ffn.sparsity_threshold;
+            const float sparsity_thr = runtime_config().ffn.sparsity_threshold;
             if (sparsity_thr > 0.0f && ly.w_down.qtype == QType::Q8_0 &&
                 qscratch_.ffn_block_mask != nullptr &&
                 cfg.ffn_activation != FFNActivation::GEGLU) {

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -218,7 +218,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
     // ---- Optional per-component profiling (IMP_PROFILE=1) ----
     // Profiling disables CUDA graph capture (they are incompatible).
     // Use IMP_PROFILE=1 for diagnostic runs only.
-    const bool do_profile = RuntimeConfig::current().diagnostics.profile;
+    const bool do_profile = runtime_config().diagnostics.profile;
     static int profile_step_ = 0;
     static float acc_total = 0, acc_attn = 0, acc_ffn = 0, acc_lm = 0;
     bool profiling = do_profile;
@@ -336,7 +336,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 tmp[1], tmp[2], tmp[3]);
     }
     // Binary dump: write the full FP16 hidden state to file
-    if (!RuntimeConfig::current().diagnostics.dump_hidden_dir.empty()) {
+    if (!runtime_config().diagnostics.dump_hidden_dir.empty()) {
         std::vector<half> h_buf(n * cfg.d_model);
         cudaMemcpy(h_buf.data(), h.data, h_buf.size() * sizeof(half), cudaMemcpyDeviceToHost);
         char fname[256];
@@ -356,7 +356,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
     int max_layer = (state.exit_layer > 0) ? std::min(state.exit_layer, cfg.n_layers) : cfg.n_layers;
     // [diagnostics] exit_layer = N runs only N layers (-1 = full forward).
     {
-        const int s_exit = RuntimeConfig::current().diagnostics.exit_layer;
+        const int s_exit = runtime_config().diagnostics.exit_layer;
         if (s_exit > 0)
             max_layer = std::min(max_layer, s_exit);
     }
@@ -408,7 +408,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             cudaEventRecord(ev_attn[i], stream);
 
         // FFN: MoE, dense, or none (attention-only layers may have no FFN)
-        const bool skip_moe = RuntimeConfig::current().moe.skip;
+        const bool skip_moe = runtime_config().moe.skip;
         if (skip_moe) {
             // Debug: skip all FFN/MoE to isolate attention bugs
         } else if (layer_has_moe(i)) {
@@ -473,7 +473,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                     // Binary dump: full hidden state for selected layers.
                     // [diagnostics] dump_hidden_dir = "<path>"  → layers 0/5/15/29.
                     // [diagnostics] dump_hidden_dir = "all"     → every layer.
-                    const std::string& dh = RuntimeConfig::current().diagnostics.dump_hidden_dir;
+                    const std::string& dh = runtime_config().diagnostics.dump_hidden_dir;
                     if (!dh.empty()) {
                         const bool dump_all = (dh == "all");
                         bool sel = dump_all || (i == 0 || i == 5 || i == 15 || i == 29);
@@ -511,7 +511,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         // Only sync when the MoE path did NOT go through the FP32 accum kernel
         // (e.g. layer has no post_ffn_norm or residual was fused into decode path).
         if (fp32_accum_buf_ && cfg.arch == ModelArch::GEMMA4 &&
-            RuntimeConfig::current().moe.force_fp16_sync) {
+            runtime_config().moe.force_fp16_sync) {
             Tensor fp32_h = view_tokens(fp32_hidden_, n);
             int64_t total = static_cast<int64_t>(n) * cfg.d_model;
             int threads = 256;
@@ -584,7 +584,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
     // bandwidth vs cuBLAS FP16 path (reads quantized weights directly).
     const auto out_qtype = model_->out_proj_.qtype;
     const bool use_dp4a_lm = qscratch_.q8_1_buf && compute_dtype_ == QType::F16 && is_dp4a_qtype(out_qtype) &&
-                             !RuntimeConfig::current().gemm.no_dp4a_lm;
+                             !runtime_config().gemm.no_dp4a_lm;
 
     // GemmContext for LM head GEMM dispatches.
     auto ctx = GemmContext::make(stream, wcache_, qscratch_, cur_force_fp16_,
@@ -656,7 +656,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             // Dequant output_proj to FP16 temp buffer, cuBLAS FP16 GEMM into FP32 logits.
             // If this gives llama-matching top logit (~+2.07) then the dp4a path is buggy;
             // if it still gives +8.83 then the bug is in hidden state or output_norm.
-            if (RuntimeConfig::current().generation.lm_dequant_fp16) {
+            if (runtime_config().generation.lm_dequant_fp16) {
                 Tensor no_last = view_tokens(norm_out_, 1);
                 rmsnorm(h_last, model_->output_norm(), no_last, cfg.rms_norm_eps, stream, norm_w_off_);
                 int N = cfg.vocab_size;
@@ -807,7 +807,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
     }
 
     // ---- Final logit soft-capping (Gemma-2/3/4, cap=30) ----
-    const bool skip_softcap = RuntimeConfig::current().generation.no_logit_softcap;
+    const bool skip_softcap = runtime_config().generation.no_logit_softcap;
     if (cfg.final_logit_softcap > 0.0f && !skip_softcap) {
         int64_t n_logits = static_cast<int64_t>(logits_out.shape[0]) * cfg.vocab_size;
         int threads = 256;

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -153,7 +153,7 @@ void GraphExecutor::moe_ffn_phase1_setup_(int layer, cudaStream_t stream) {
     // reading the cache, then queue the next layer's prefetch so the
     // prefetch stream gets compute-time overlap.
     if (expert_cache_.n_slots_ > 0) {
-        const int top_k_prefetch = RuntimeConfig::current().moe.prefetch_top_k;
+        const int top_k_prefetch = runtime_config().moe.prefetch_top_k;
         if (top_k_prefetch > 0) {
             expert_cache_.await_prefetch(layer, stream);
             const int next_layer = layer + 1;
@@ -167,7 +167,7 @@ void GraphExecutor::moe_ffn_phase1_setup_(int layer, cudaStream_t stream) {
     // DIAGNOSTIC (Phase 2 Item 2 follow-up): zero MoE workspace buffers so any
     // legacy-serial-fallback uninit reads become deterministic zero reads.
     // Set IMP_MOE_ZERO_WORKSPACE=1 to enable. Cheap (~1 MiB total memset).
-    if (RuntimeConfig::current().moe.zero_workspace) {
+    if (runtime_config().moe.zero_workspace) {
         cudaMemsetAsync(moe_.expert_gate.data, 0, moe_.expert_gate.nbytes(), stream);
         cudaMemsetAsync(moe_.expert_up.data, 0, moe_.expert_up.nbytes(), stream);
         cudaMemsetAsync(moe_.expert_swiglu.data, 0, moe_.expert_swiglu.nbytes(), stream);
@@ -1313,7 +1313,7 @@ bool GraphExecutor::try_run_moe_cutlass3x_nvfp4_prefill_(int layer, cudaStream_t
     //   Decode n=1:    ~48 tok/s (vs legacy ~38)     — 25% win
     // After shared-quantize gate+up (2026-04-20), 3.x beats legacy at all n.
     // `IMP_NO_CUTLASS3X_MOE=1` forces legacy (for debugging).
-    static const bool force_off = RuntimeConfig::current().moe.no_cutlass3x;
+    static const bool force_off = runtime_config().moe.no_cutlass3x;
     if (force_off)
         return false;
     if (!cutlass_grouped_3x_nvfp4_available())
@@ -1360,7 +1360,7 @@ bool device_args_done = false;
     // NVFP4 (decode unchanged). Set moe.nvfp4_device_args=false
     // (legacy IMP_NVFP4_DEVICE_ARGS=0) to force the legacy
     // path for A/B or workarounds.
-    const bool da_enabled = imp::RuntimeConfig::current().moe.nvfp4_device_args;
+    const bool da_enabled = runtime_config().moe.nvfp4_device_args;
     const bool use_device_args =
         da_enabled &&
         moe_.d_M_per && moe_.d_M_per_count >= ne &&
@@ -1578,7 +1578,7 @@ char* expert_down_base = static_cast<char*>(moe_.expert_down.data);
 // ---------------------------------------------------------------------
 bool smallM_done = false;
 {
-    const auto& moe_cfg = imp::RuntimeConfig::current().moe;
+    const auto& moe_cfg = runtime_config().moe;
     const bool smallM_optin = moe_cfg.nvfp4_smallM;
     if (smallM_optin && imp::gemm_grouped_nvfp4_smallM_available()) {
         const int smallM_threshold = moe_cfg.nvfp4_smallM_threshold;
@@ -2412,7 +2412,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     // Higher expert counts (e.g. 128 in Qwen3-Coder) prefer separate
     // gemv_gate_fp32 (128 parallel blocks).
     constexpr int kMaxFusedExperts = 8;
-    const std::string& dl = RuntimeConfig::current().diagnostics.dump_logits_dir;
+    const std::string& dl = runtime_config().diagnostics.dump_logits_dir;
     bool dump_logits = !dl.empty() && (layer == 29 || dl == "all");
 
     if (fp32_gate_logits_ready) {
@@ -2466,7 +2466,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     }
 
     // Routing decision dump
-    if (const std::string& drv = RuntimeConfig::current().diagnostics.dump_routing_dir; !drv.empty()) {
+    if (const std::string& drv = runtime_config().diagnostics.dump_routing_dir; !drv.empty()) {
         bool dump_all = (drv == "all");
         if (layer == 0 || dump_all) {
             int last_tok = n - 1;
@@ -2629,7 +2629,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
         int eff_q8_blocks = eff / 32;
         if (!non_gated_experts) {
             if (cfg.ffn_activation == FFNActivation::GEGLU) {
-                if (layer == 0 && RuntimeConfig::current().diagnostics.debug_forward)
+                if (layer == 0 && runtime_config().diagnostics.debug_forward)
                     fprintf(stderr, "[DEBUG_MoE] Using GEGLU activation for MoE experts\n");
                 geglu_quantize_q8_1(gate_buf, up_buf, q8, qscratch_.d8_buf, top_k * eff, stream);
             } else {
@@ -2683,7 +2683,7 @@ void GraphExecutor::run_shared_expert_ffn(int layer, cudaStream_t stream, int n,
     const auto& ly = model_->layer(layer);
 
     // DIAGNOSTIC: moe.no_shared_mlp config flag (was IMP_NO_SHARED_MLP env).
-    static const bool s_no_shared_mlp = RuntimeConfig::current().moe.no_shared_mlp;
+    static const bool s_no_shared_mlp = runtime_config().moe.no_shared_mlp;
     if (ly.w_up_shared.data == nullptr || s_no_shared_mlp) return;
 
     int eff_shared = static_cast<int>(ly.w_up_shared.shape[0]);
@@ -2749,7 +2749,7 @@ void GraphExecutor::run_shared_expert_ffn(int layer, cudaStream_t stream, int n,
         debug_tensor_rows("L0_shared_post_norm1", sh_down, stream);
     }
     // Qwen3-Next / Qwen3.6: per-token sigmoid gate on shared-expert output.
-    static const bool skip_shexp_gate = RuntimeConfig::current().moe.no_shexp_gate;
+    static const bool skip_shexp_gate = runtime_config().moe.no_shexp_gate;
     if (!skip_shexp_gate && ly.shared_expert_gate_inp.data != nullptr &&
         ly.shared_expert_gate_inp.on_device && compute_dtype_ == QType::F16) {
         shared_expert_gate_scale(no.data, ly.shared_expert_gate_inp.data, sh_down.data, n, d, d, stream);

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -1689,7 +1689,7 @@ if (mx_native > 0) {
     // 14) cascade we have not yet root-caused. Tracking in
     // qwen35_27b_mxfp4_ima_2026_04_25.md. Until that's resolved,
     // honor the historical fallback path.
-    bool force_fallback = RuntimeConfig::current().attention.mxfp4_fp16_fallback;
+    bool force_fallback = runtime_config().attention.mxfp4_fp16_fallback;
     bool has_gdn = (cfg.ssm_inner_size > 0);
     bool mxfp4_gemv_available = !force_fallback && !has_gdn;
     for (auto& [p, m] : wcache_.cutlass_mxfp4)
@@ -1717,7 +1717,7 @@ if (mx_native > 0) {
     // load on 32 GiB VRAM.
     std::unordered_set<const void*> pruned_skip_ptrs;
     const bool pruned_policy =
-        (RuntimeConfig::current().attention.mxfp4_fp16_cache_policy == "pruned");
+        (runtime_config().attention.mxfp4_fp16_cache_policy == "pruned");
     if (pruned_policy) {
         for (int li = 0; li < cfg.n_layers; ++li) {
             const auto& L = model_->layer(li);
@@ -1929,7 +1929,7 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         constexpr size_t kReserveFloor = 256ULL * 1024 * 1024;
         size_t kMoeReserve = std::clamp(kv_reserve + kWorkspaceSafety, kReserveFloor, kReserveCap);
         {
-            const int v = imp::RuntimeConfig::current().moe.reserve_mib;
+            const int v = runtime_config().moe.reserve_mib;
             if (v >= 128 && v <= 4096)
                 kMoeReserve = static_cast<size_t>(v) * 1024ULL * 1024ULL;
         }

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -373,7 +373,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     // layout. Qwen 3.6 uses 16K/32V asymmetric heads and triggers this
     // mismatch. Gated by IMP_GDN_VHEAD_REORDER to avoid regressing symmetric
     // models or models whose converters already emit grouped layout.
-    const bool vhead_reorder = RuntimeConfig::current().gdn.vhead_reorder;
+    const bool vhead_reorder = runtime_config().gdn.vhead_reorder;
     if (vhead_reorder && n_groups != n_heads) {
         const int inner_v = n_heads * head_dim_ssm;  // V channels = 32 * 128 = 4096 for Qwen 3.6
         const int BC_size_vh = n_groups * ssize;     // Q/K per-group size = 16 * 128 = 2048
@@ -421,7 +421,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         gemm_dispatch(no, ly.gdn_gate, gate_out, ctx);
     }
 
-    const bool use_fp32_scan = RuntimeConfig::current().gdn.fp32_scan;
+    const bool use_fp32_scan = runtime_config().gdn.fp32_scan;
 
     if (h_st) {
         size_t es = dtype_size(compute_dtype_);
@@ -473,7 +473,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         // IMP_GDN_FP32_SCAN=1: keep scan output in FP32 through RMSNorm+Gate.
         //   FP16 subnormal truncation (~6e-5) breaks RMS for near-zero heads on
         //   models with sparse scan activations (Qwen 3.6 L1 head 0).
-        const bool use_ref = RuntimeConfig::current().gdn.ref_kernel;
+        const bool use_ref = runtime_config().gdn.ref_kernel;
         if (use_fp32_scan) {
             // Layout in conv_f32 tail:
             //   [n*conv_channels)                : conv_f32 (done)
@@ -543,8 +543,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     // scan above (FP32-input variant). Skip to avoid double-applying.
     // [gdn] norm_eps_override > 0 can override eps (diagnostic).
     float norm_eps = eps;
-    if (RuntimeConfig::current().gdn.norm_eps_override > 0.0f) {
-        norm_eps = RuntimeConfig::current().gdn.norm_eps_override;
+    if (runtime_config().gdn.norm_eps_override > 0.0f) {
+        norm_eps = runtime_config().gdn.norm_eps_override;
     }
     if (!use_fp32_scan) {
         gdn_rmsnorm_gated_silu(static_cast<half*>(y_buf.data), static_cast<const half*>(gate_out.data),
@@ -561,7 +561,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     // residual in FP32 before downcast. FP16 accumulation here drifts ~5% per
     // element vs llama.cpp; that small drift amplifies to sign flips in
     // downstream near-zero projections and breaks Qwen 3.6.
-    const bool use_fp32_out = RuntimeConfig::current().gdn.fp32_out;
+    const bool use_fp32_out = runtime_config().gdn.fp32_out;
     Tensor out_buf = view_tokens(ssm_out_buf_, n);
     if (use_fp32_out) {
         // Allocate FP32 scratch via cudaMallocAsync (small: n * d_model * 4 bytes)

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -279,7 +279,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                     break;
                 }
             }
-            if (has_host_experts && !RuntimeConfig::current().moe.no_expert_cache) {
+            if (has_host_experts && !runtime_config().moe.no_expert_cache) {
                 // Budget: proportional to free VRAM (15%) instead of flat cap.
                 // KV cache + weight caches (FP8/NVFP4) need the remaining VRAM,
                 // so expert cache must not over-commit.
@@ -289,7 +289,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 size_t budget = (free_mem > safety) ? free_mem - safety : 0;
                 budget = static_cast<size_t>(budget * 0.15);  // 15% of available
                 const auto& mcfg = model_->config();
-                bool debug_parity = RuntimeConfig::current().moe.expert_cache_debug_parity;
+                bool debug_parity = runtime_config().moe.expert_cache_debug_parity;
                 if (expert_cache_.init(max_expert_raw, budget, vram_alloc_, mcfg.n_layers,
                                        mcfg.n_experts, debug_parity)) {
                     IMP_LOG_INFO("Expert LRU cache: %d slots (%.2f MiB / %.2f MiB budget)",
@@ -709,7 +709,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                     }
                 }
                 if (cutlass_sm120_mxfp4_available() &&
-                    (has_mxfp4_weights || RuntimeConfig::current().attention.mxfp4 == "always")) {
+                    (has_mxfp4_weights || runtime_config().attention.mxfp4 == "always")) {
                     qscratch_.mxfp4_act_sf_size = cutlass_mxfp4_sf_size(max_tokens_, max_k);
                     qscratch_.mxfp4_workspace_size = gemm_mxfp4_cutlass_sm120_workspace(max_tokens_, max_n,
                                                                                         max_k);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -286,19 +286,21 @@ struct RuntimeConfig {
     // Pass empty path to use the search-path default.
     static RuntimeConfig load(const std::string& explicit_path, const std::vector<std::string>& overrides);
 
-    // ---- Process-wide singleton -----------------------------------------
+    // ---- Process-wide singleton (legacy, being retired) ------------------
     //
-    // Engine init calls install() once with the loaded RuntimeConfig.
-    // All ~80 former getenv("IMP_*") call sites read via current(), which
-    // returns a const reference to the installed config (or a default-
-    // constructed one if install() was never called).
+    // Tools (imp-cli, imp-server) call install() once with the loaded
+    // RuntimeConfig before constructing the Engine. Engine::init() snapshots
+    // it into a per-Engine field (Phase 5 Track D, 2026-05-20) and from that
+    // point Engine::* and GraphExecutor::* methods read the per-instance
+    // copy instead of the singleton.
     //
-    // This is intentionally a process-wide singleton because the runtime
-    // configuration is global state — there is no expectation of two
-    // engines with different runtime configs in the same process. If
-    // that ever changes, threading a const RuntimeConfig& through every
-    // executor call site is a mechanical refactor; the read-side API
-    // (current().runtime.no_pdl etc.) does not need to change.
+    // The singleton remains for the long tail of free functions in
+    // src/compute/, src/quant/, src/model/, src/runtime/ that don't carry
+    // an Engine* / GraphExecutor* context (e.g. PDL kernel-attr lookup,
+    // gemm dispatch helpers, weight_upload static helpers, chat_template
+    // debug paths, graph_diag inline helpers). A follow-up PR will
+    // thread `const RuntimeConfig&` through those modules and delete
+    // current() / install().
     static const RuntimeConfig& current();
     static void install(const RuntimeConfig& cfg);
 };

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -181,7 +181,7 @@ bool Engine::enable_mtp_spec_decode(int k) {
         ws->mrope_sec2 = 0;
     }
     // Diagnostic: generation.mtp_no_rope (legacy IMP_MTP_NO_ROPE=1) disables RoPE entirely.
-    if (RuntimeConfig::current().generation.mtp_no_rope) {
+    if (runtime_config_.generation.mtp_no_rope) {
         ws->rope_dim = 0;
     }
     // Runtime weight_offset matches what the main model's rmsnorm calls pass:
@@ -573,6 +573,14 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     model_ = std::move(model);
     config_ = config;
 
+    // Phase 5 Track D: snapshot the process-wide RuntimeConfig into the
+    // per-Engine field. main.cpp (imp-cli / imp-server) has already called
+    // RuntimeConfig::install(load(...)) by this point. After this assign,
+    // every Engine::* method reads runtime_config_ directly; engine_init_
+    // resolver_ helpers mutate this snapshot in place for arch-specific
+    // defaults.
+    runtime_config_ = RuntimeConfig::current();
+
     const auto& mcfg = model_->config();
 
     init_apply_debug_raw_overrides_();
@@ -603,7 +611,7 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         return false;
     if (!init_features())
         return false;
-    if (!RuntimeConfig::current().runtime.warmup) {
+    if (!runtime_config_.runtime.warmup) {
         IMP_LOG_INFO("Warmup SKIPPED (runtime.warmup=false)");
     } else {
         warmup();
@@ -618,6 +626,10 @@ bool Engine::init_weights() {
     // Initialize graph executor (Phase 1: compute sizes, no GPU allocation)
     executor_ = std::make_unique<GraphExecutor>();
     executor_->set_vram_allocator(&memory_manager_.vram_allocator());
+    // Phase 5 Track D: wire per-Engine RuntimeConfig before any executor init.
+    // GraphExecutor methods read this via runtime_config() instead of the
+    // RuntimeConfig::current() singleton.
+    executor_->set_runtime_config(runtime_config_);
     {
         int eff_batch = config_.max_batch_size;
         if (!executor_->init(*model_, config_.compute_dtype, config_.use_pdl, eff_batch, config_.max_seq_len,
@@ -799,7 +811,7 @@ bool Engine::init_weights() {
             // architectural caveat; Phase 5.1+ refactors dispatch kernels
             // to read the device mirror at runtime so the captured graph
             // adapts correctly.
-            if (RuntimeConfig::current().moe.allow_graphs_under_offload) {
+            if (runtime_config_.moe.allow_graphs_under_offload) {
                 IMP_LOG_WARN(
                     "CUDA graphs ENABLED under host-offload "
                     "(moe.allow_graphs_under_offload=true). EXPERIMENTAL: output "
@@ -818,7 +830,7 @@ bool Engine::init_weights() {
                 config_.use_cuda_graphs = false;
             }
         }
-        if (RuntimeConfig::current().runtime.cuda_graphs == "never" && config_.use_cuda_graphs) {
+        if (runtime_config_.runtime.cuda_graphs == "never" && config_.use_cuda_graphs) {
             IMP_LOG_INFO("Disabling CUDA graphs: runtime.cuda_graphs=never");
             config_.use_cuda_graphs = false;
         }
@@ -923,7 +935,7 @@ bool Engine::init_kv_cache() {
     // residual write/read kernels read the state at execution time. This
     // makes the whole path graph-capture-safe — graphs stay enabled.
     {
-        const auto& rcfg = RuntimeConfig::current();
+        const auto& rcfg = runtime_config_;
         int residual_n = rcfg.kv_cache.bitdecoding_residual_tokens;
         if (residual_n > 0 && config_.kv_cache_dtype == QType::NVFP4) {
             int max_seqs = config_.max_batch_size > 0 ? config_.max_batch_size : 1;
@@ -1179,7 +1191,7 @@ void Engine::build_banned_token_list() {
     // Diagnostic bypass: generation.no_ban (legacy IMP_NO_BAN=1) disables the
     // ban list. Used to bisect Mistral-Small-3.2-NVFP4 long-form repetition
     // (ban vs weight quality).
-    if (RuntimeConfig::current().generation.no_ban) {
+    if (runtime_config_.generation.no_ban) {
         banned_token_ids_.clear();
         IMP_LOG_WARN("generation.no_ban=true: skipping banned-token list (debug)");
         return;
@@ -1865,7 +1877,7 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         // = prefill_chunk_size). H2D upload happened above on pf_stream
         // *before* this wrapper — captured region is forward_logits only,
         // analogous to the decode graph pattern.
-        const bool prefill_graph_enabled = RuntimeConfig::current().runtime.prefill_graph;
+        const bool prefill_graph_enabled = runtime_config_.runtime.prefill_graph;
         const bool can_capture = prefill_graph_enabled && pf_pool_used && config_.use_cuda_graphs;
         if (can_capture) {
             const int block_count = static_cast<int>(block_table.size());
@@ -2308,7 +2320,7 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
     std::vector<int32_t> tokens;
     Tensor decode_logits_out;
 
-    const bool profiling = RuntimeConfig::current().diagnostics.profile;
+    const bool profiling = runtime_config_.diagnostics.profile;
     int graph_idx = gpu_batch.n_sequences - 1;
     if (config_.use_cuda_graphs && !profiling && gpu_batch.n_sequences > 0 && graph_idx < kMaxGraphPoolSize &&
         decode_batch_pool_.is_allocated()) {
@@ -2382,7 +2394,7 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             if (match) mtp_accuracy_.matches++;
             // Optional verbose log: prints (predicted, actual, match) with
             // decoded strings so accept patterns can be analyzed offline.
-            const bool s_pattern_log = RuntimeConfig::current().diagnostics.mtp_pattern_log;
+            const bool s_pattern_log = runtime_config_.diagnostics.mtp_pattern_log;
             if (s_pattern_log) {
                 Tokenizer* tok = model_->tokenizer();
                 std::string ps = tok ? tok->decode_token(mtp_pending_prediction_) : std::string();
@@ -2431,7 +2443,7 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             // Optional: apply the main model's output norm before passing
             // h_prev to MTP. Upstream vllm passes post-RMSNorm hidden states
             // in some MTP variants; gate by env so we can A/B.
-            const bool s_pre_norm_h = RuntimeConfig::current().diagnostics.mtp_prenorm_h;
+            const bool s_pre_norm_h = runtime_config_.diagnostics.mtp_prenorm_h;
             const void* h_for_mtp = h_view.data;
             // Scratch buffer for the normalized variant (allocated once).
             static void* s_h_normed = nullptr;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -9,6 +9,7 @@
 #include "runtime/cuda_graph.h"
 #include "runtime/vision_pipeline.h"
 #include "runtime/constraint_manager.h"
+#include "runtime/config.h"
 #include "memory/kv_cache.h"
 #include "memory/kv_cache_manager.h"
 #include "memory/ssm_state.h"
@@ -197,11 +198,24 @@ public:
     MemoryManager& memory_manager() noexcept { return memory_manager_; }
     const MemoryManager& memory_manager() const noexcept { return memory_manager_; }
 
+    // Phase 5 Track D: per-Engine RuntimeConfig (replaces RuntimeConfig::current()
+    // singleton). Engine::init snapshots the loaded config; engine_init_resolver
+    // mutates it in place for arch-specific defaults; GraphExecutor reads a
+    // non-owning pointer set via set_runtime_config().
+    const RuntimeConfig& runtime_config() const noexcept { return runtime_config_; }
+    RuntimeConfig& mutable_runtime_config() noexcept { return runtime_config_; }
+
 private:
     // ── Core components ──────────────────────────────────────────────
     // Phase 5 Track C: façade over VRAMAllocator + (lazy) PinnedAllocator/
     // DeviceAllocator + vram_budget/storage_planner free functions.
     MemoryManager memory_manager_;
+    // Phase 5 Track D: per-Engine runtime configuration (replaces the
+    // RuntimeConfig::current() process-wide singleton). Snapshot is
+    // initialized from RuntimeConfig::current() at the start of init() and
+    // then mutated in-place by engine_init_resolver helpers for arch-
+    // specific defaults (deterministic_gemm, prefill_graph, etc.).
+    RuntimeConfig runtime_config_;
     std::shared_ptr<Model> model_;
     EngineConfig config_;
     std::unique_ptr<Scheduler> scheduler_;

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -21,7 +21,7 @@ namespace imp {
 // (e.g. llama.cpp). Forces downstream paths off (FP8/NVFP4/warmup/graphs) and
 // cuBLAS to deterministic. Triggered via [runtime] debug_raw = true.
 void Engine::init_apply_debug_raw_overrides_() {
-    const bool debug_raw_ = RuntimeConfig::current().runtime.debug_raw;
+    const bool debug_raw_ = runtime_config_.runtime.debug_raw;
     if (!debug_raw_)
         return;
     IMP_LOG_INFO(
@@ -54,9 +54,9 @@ void Engine::init_apply_debug_raw_overrides_() {
 // are opt-in. See the inline rationale for the 2026-04-24 root-cause memo.
 void Engine::init_resolve_kv_dtype_policy_() {
     const auto& mcfg = model_->config();
-    const bool debug_raw_ = RuntimeConfig::current().runtime.debug_raw;
-    const bool force_kv_fp16 = (RuntimeConfig::current().kv_cache.dtype == "fp16");
-    const bool fp8_auto_legacy = RuntimeConfig::current().kv_cache.fp8_auto_legacy;
+    const bool debug_raw_ = runtime_config_.runtime.debug_raw;
+    const bool force_kv_fp16 = (runtime_config_.kv_cache.dtype == "fp16");
+    const bool fp8_auto_legacy = runtime_config_.kv_cache.fp8_auto_legacy;
     if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16) {
         config_.kv_cache_dtype = QType::FP8_E4M3;
         IMP_LOG_INFO("KV cache dtype: IMP_KV_FP8_AUTO=1 → FP8_E4M3 (legacy opt-out)");
@@ -77,11 +77,11 @@ void Engine::init_resolve_kv_dtype_policy_() {
     }
 
     if (config_.kv_cache_dtype == QType::FP8_E4M3 &&
-        !RuntimeConfig::current().kv_cache.allow_nondeterministic_fp8 &&
-        !RuntimeConfig::current().runtime.deterministic_gemm) {
-        RuntimeConfig promoted = RuntimeConfig::current();
-        promoted.runtime.deterministic_gemm = true;
-        RuntimeConfig::install(promoted);
+        !runtime_config_.kv_cache.allow_nondeterministic_fp8 &&
+        !runtime_config_.runtime.deterministic_gemm) {
+        // Phase 5 Track D: mutate the per-Engine RuntimeConfig in place
+        // (formerly an install() call into the global singleton).
+        runtime_config_.runtime.deterministic_gemm = true;
         setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", 0);
         IMP_LOG_INFO(
             "FP8 KV cache: forcing runtime.deterministic_gemm=true "
@@ -138,8 +138,8 @@ void Engine::init_resolve_ssm_dtype_() {
 // produce garbage decode with FP8 weight cache active — accumulated
 // dequant error through deep narrow-GQA stacks.
 void Engine::init_resolve_fp8_prefill_() {
-    const bool no_fp8_prefill = (RuntimeConfig::current().attention.fp8_prefill == "never");
-    if (!config_.use_fp8_prefill && !RuntimeConfig::current().runtime.debug_raw && !no_fp8_prefill) {
+    const bool no_fp8_prefill = (runtime_config_.attention.fp8_prefill == "never");
+    if (!config_.use_fp8_prefill && !runtime_config_.runtime.debug_raw && !no_fp8_prefill) {
         config_.use_fp8_prefill = true;
         IMP_LOG_INFO("FP8 prefill: auto → enabled");
     } else if (no_fp8_prefill) {
@@ -264,10 +264,10 @@ void Engine::init_resolve_quant_flags_() {
         // from cuBLAS algo autotuning / split-K atomics amplifies into wildly
         // different top-1 picks (coherent " Paris" vs garbage "\n"). Force
         // deterministic GEMM paths so generation is stable run-to-run.
-        if (!RuntimeConfig::current().runtime.deterministic_gemm) {
-            RuntimeConfig promoted = RuntimeConfig::current();
-            promoted.runtime.deterministic_gemm = true;
-            RuntimeConfig::install(promoted);
+        if (!runtime_config_.runtime.deterministic_gemm) {
+            // Phase 5 Track D: mutate the per-Engine RuntimeConfig in place
+            // (formerly an install() call into the global singleton).
+            runtime_config_.runtime.deterministic_gemm = true;
             IMP_LOG_INFO(
                 "Gemma 4: enabling runtime.deterministic_gemm (output_norm outliers amplify algo jitter)");
         }
@@ -296,7 +296,7 @@ void Engine::init_resolve_quant_flags_() {
 // via runtime.max_seq_len.
 void Engine::init_compute_max_seq_len_() {
     const auto& mcfg = model_->config();
-    if (int v = RuntimeConfig::current().runtime.max_seq_len; v > 0) {
+    if (int v = runtime_config_.runtime.max_seq_len; v > 0) {
         config_.max_seq_len = v;
         IMP_LOG_INFO("max_seq_len: runtime.max_seq_len=%d", v);
     }

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -82,6 +82,11 @@ void Engine::init_resolve_kv_dtype_policy_() {
         // Phase 5 Track D: mutate the per-Engine RuntimeConfig in place
         // (formerly an install() call into the global singleton).
         runtime_config_.runtime.deterministic_gemm = true;
+        // TRANSITIONAL (Phase 5 Track D): mirror to RuntimeConfig::current() so
+        // free-function readers (e.g. gemm.cu's algo-selection skip-benchmark
+        // branch) see the promotion. The full free-function migration is the
+        // Phase 5 Track D follow-up PR; remove this dual-write when it lands.
+        RuntimeConfig::install(runtime_config_);
         setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", 0);
         IMP_LOG_INFO(
             "FP8 KV cache: forcing runtime.deterministic_gemm=true "
@@ -268,6 +273,8 @@ void Engine::init_resolve_quant_flags_() {
             // Phase 5 Track D: mutate the per-Engine RuntimeConfig in place
             // (formerly an install() call into the global singleton).
             runtime_config_.runtime.deterministic_gemm = true;
+            // TRANSITIONAL (Phase 5 Track D): see comment in FP8-KV block above.
+            RuntimeConfig::install(runtime_config_);
             IMP_LOG_INFO(
                 "Gemma 4: enabling runtime.deterministic_gemm (output_norm outliers amplify algo jitter)");
         }


### PR DESCRIPTION
**Rebased from #322** onto current main (PR-stack cleanup; harness blocked force-push). Original content preserved below.

---

## Summary
**Phase 5 Track D — partial migration.** 61 of 94 \`RuntimeConfig::current()\` call sites migrated to per-Engine ownership. The singleton remains for the 33 free-function readers (compute/quant/model/etc) that need follow-up parameter threading.

## Migration done
- **Engine**: \`runtime_config_\` member + \`Engine::runtime_config()\` accessor (\`src/runtime/engine.h\`)
- **GraphExecutor**: non-owning \`const RuntimeConfig*\` + setter/getter with null-fallback to singleton for bare-constructed unit tests
- **All Engine::* methods migrated** — engine.cpp + engine_init_resolver.cpp
- **All GraphExecutor::* methods migrated** — executor_forward / forward_moe / attention / ssm_gdn / workspace_buffers / pre_dequant / ffn

## Remaining (33 calls, deferred to follow-up PR)
Free functions without Engine/Executor context: \`src/compute/\` (8), \`src/runtime/\` inline helpers (5), \`src/model/\` (8), \`src/quant/\` (1), \`src/vision/\` (1), \`src/exec/\` debug headers (5), CLI/server tools (5).

Each needs \`const RuntimeConfig&\` threaded as parameter through 1-4 levels of callsites.

## Transitional safety net
Resolver helpers preserve \`RuntimeConfig::install(runtime_config_)\` as a **temporary dual-write** for \`deterministic_gemm\` flips (FP8-KV + Gemma-4). Without this, \`compute/gemm.cu:364\`'s skip-benchmark branch wouldn't fire — silent prefill-timing variance regression.

Removed when the follow-up PR migrates the free-function readers.

## Stacking
#319 → #320 → #321 → this.

## Pre-existing test failure
\`StubModelTest.CreateContextAndInfer\` segfaults in \`make test-gpu\`; verified pre-existing on parent commit. Not introduced by this PR.

## Test plan
- [x] \`make build\` green
- [x] \`make verify-fast\` green
- [x] Pre-push hook verify-fast green
- [x] Combined spec + code-quality reviewer ✅ Approved with one fix (the dual-write transitional, applied as \`5747169\`)

Phase 5 Track D (partial) of [\`docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md\`](../tree/main/docs/superpowers/specs/2026-05-20-architecture-refactor-roadmap-design.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)