### PR TITLE
docs(arch): add attention-dispatch + quant-pipeline companion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Full build options, test commands, and verify-gate setup: [`docs/usage.md`](docs
 | Document | Description |
 |---|---|
 | [Architecture](docs/architecture.md) ([diagram](docs/architecture.svg)) | End-to-end load + execution pipeline (load → engine init → prefill → decode) |
+| [Attention dispatch](docs/attention-dispatch.md) | Per-(phase × dtype × layer) kernel selection matrix |
+| [Quant pipeline](docs/quant-pipeline.md) | Boundary between hot-path dequant (`src/quant/`) and init-time pre-dequant (`src/exec/pre_dequant_*.cu`) + GEMM kernel registry |
 | [Usage & reference](docs/usage.md) | Build, server, CLI, C API |
 | [Supported models](docs/supported-models.md) | Tested model families with VRAM + tok/s |
 | [Quantization](docs/quantization.md) | GGUF Q*_K, NVFP4, MXFP4, FP8 KV — formats, pipelines, trade-offs |

--- a/docs/attention-dispatch.md
+++ b/docs/attention-dispatch.md
@@ -1,0 +1,73 @@
+# Attention dispatch
+
+Companion doc to [`architecture.md`](architecture.md) — covers exactly which attention kernel runs for each (phase × dtype × layer) combination.
+
+If this doc and the code disagree, the code wins. Source of truth is `src/exec/executor_attention.cu` for the gate, `src/compute/attention_dispatch.cu` for the FMHA chain.
+
+## Prefill — two-branch gate
+
+Post-Phase-2 (PR #344), the prefill dispatch in `src/exec/executor_attention.cu` is a flat two-branch switch:
+
+```cpp
+const bool force_cublas_attn = per_layer_shapes;          // Gemma-4 hd=512
+const bool s_matrix_fits     = attn_scores_buf_ != nullptr &&
+                               n <= attn_scores_.shape[1];
+const bool non_gemma4_sliding = !force_cublas_attn && sliding_active;
+
+if (s_matrix_fits && !non_gemma4_sliding) {
+    attention_cublas_prefill(...);
+} else {
+    attention_prefill_dispatch(...);   // FMHA fallback
+}
+```
+
+| Condition | Path | Why |
+|---|---|---|
+| S-matrix fits **and** (not non-Gemma-4 sliding) | `attention_cublas_prefill` | Default for typical Qwen3 / Gemma-4 configs. cuBLAS QK^T → materialized [nh, n, n] FP16 S-matrix (capped at ~1 GiB) → causal+sliding softmax → cuBLAS PV. |
+| S-matrix doesn't fit (long context past cap) | FMHA fallback chain | Tiled O(n) memory; no materialized S. |
+| `non_gemma4_sliding` (non-Gemma-4 model with sliding window) | FMHA fallback chain | cuBLAS's sliding-mask path is Gemma-4-optimized; FMHA is faster for other archs. |
+| `force_cublas_attn` (Gemma-4 hd=512 global layers) | `attention_cublas_prefill` always | FMHA OOMs the 100 KiB smem cap at hd=512. cuBLAS handles arbitrary head_dim. |
+
+### FMHA fallback chain (`src/compute/attention_dispatch.cu`)
+
+Tried in order, first hit wins. After Phase 2 archival the chain is:
+
+1. **`fmha_sm120_mxfp4_prefill`** — when `attention.mxfp4` enabled and the kernel accepts the head_dim
+2. **`fmha_sm120_fp8_prefill`** — when `attention.fp8_fmha != "never"` (default auto)
+3. **`fmha_sm120_prefill`** — FP16, the surviving non-cluster variant
+4. **`flash_attention_blackwell`** — WMMA 128×64 tiles as the last resort
+
+The previously-archived variants (`attention_fmha_sm120_cluster.cu`, `attention_fmha_mxf4nvf4_sm120.cu`, `attention_naive.cu`) live in `docs/archive/` with resurrection memos.
+
+### Chunked prefill carve-out (default for most archs)
+
+Per-arch default `prefill_chunk_size = 512` for full-attention models (Qwen3, Llama, Mistral), hybrid GDN+MoE / Mamba2+MoE (Qwen3.5/3.6, Nemotron-H), and Gemma-4. Past chunks' K/V are read from the paged cache via `paged_kv_gather_*` and concatenated with the current chunk; the result then hits the dispatch gate above with `q_offset`-aware causal masking. See `src/exec/executor_attention.cu` chunked-prefill branch, `Engine::resolve_prefill_chunk_size_()`, and the "Chunked prefill scope" entry in `docs/roadmap.md`.
+
+## Decode — switch on cache_dtype
+
+The decode dispatch (further down in `executor_attention.cu`) is a single `switch` on the KV cache dtype:
+
+| `cache_dtype` | Kernel | Notes |
+|---|---|---|
+| FP16 | `paged_attention_decode_fp16` | Default. WMMA 16×16 tiles. |
+| FP8 (E4M3) | `paged_attention_decode_fp8` | Per-token activation quant; bit-identical to FP16 within ~0.5% perplexity. |
+| INT8 | `paged_attention_decode_int8` | Per-head INT8 scale; rarely chosen. |
+| INT4 | `paged_attention_decode_int4` | Symmetric 4-bit + per-head FP16 scale. Long-context quality regression vs FP16. |
+| NVFP4 | `paged_attention_decode_nvfp4` or `_nvfp4_tc` | TC variant for SM120 mma.sync; falls back to non-TC for unsupported shapes. |
+| MXFP4 KV | `paged_attention_decode_mxfp4_kv` | MXFP4-quantized K/V with UE8M0 block-scale (Phase 3 of TurboQuant/MXFP4-KV slice; see `mxfp4_kv_slice3_findings_2026_05_17`). |
+
+### BitDecoding residual cache
+
+When `kv_cache.bitdecoding_qk` is true AND `kv_cache.dtype = nvfp4`, the newest `kv_cache.bitdecoding_residual_tokens` tokens are kept in a residual FP16 buffer and combined with the quantized older blocks at attention time. Used by NVFP4-decode for higher fidelity on the recent context. See `src/compute/attention_paged_nvfp4_tc.cu`.
+
+## Sliding-window mask
+
+cuBLAS path uses `attention_cublas_prefill`'s `sliding_window` parameter (Gemma-4 SWA layers). FMHA path uses `fmha_sm120_prefill`'s `sliding_window` argument (every FMHA variant accepts it). Naive FP32 SWA path is archived (`docs/archive/attention_naive/`).
+
+## Soft-cap (logit cap)
+
+cuBLAS path passes `cfg.attn_logit_softcap` through `attention_cublas_prefill`. FMHA path threads `softcap` through every kernel. Soft-cap is a Gemma-3/Gemma-4 feature; other archs default to 0 (off).
+
+## Known wounds
+
+- **1 GiB cuBLAS S-matrix workspace** (`executor_workspace_buffers.cu`). Caps maximum context length. Phase 5 Track E (tiled streaming softmax) deferred as ~10-15-day perf-sensitive work. Reopens when a regression specifically attributes to the workspace cap.

--- a/docs/quant-pipeline.md
+++ b/docs/quant-pipeline.md
@@ -1,0 +1,66 @@
+# Quant / dequant pipeline
+
+Companion doc to [`architecture.md`](architecture.md) — explains the two parallel layers that handle quantized weights and the boundary between them.
+
+## Two layers, one direction
+
+| Layer | Where | When | What |
+|---|---|---|---|
+| **Hot-path dequant** | `src/quant/dequant_*.cu` | Per-forward-pass, per-token | In-place dequant for kernels that take FP16/FP8 inputs and need to materialize from a Q*_K block on demand. Tiny scratch buffers, no persistent state. |
+| **Init-time pre-dequant** | `src/exec/pre_dequant_phase*.cu` | Once at `Engine::init` | Multi-phase orchestration that decides which weights live in which device tier (FP16 cache, FP8 cache, NVFP4 decode cache, MXFP4 standalone) and runs the actual format conversions. |
+
+Both layers ultimately call kernels from `src/quant/` (`dequant_q4k_to_fp16`, `quantize_fp16_nvfp4_cutlass`, `calibrate_quantize_fp8_async`, etc.). The difference is **lifetime**: hot-path dequant is per-call ephemeral; pre-dequant produces device tensors that live as long as the engine.
+
+## Files
+
+### `src/quant/` — kernels + hot-path orchestration
+- `dequant_fp16.cu` — generic Q*_K → FP16 row-block kernels
+- `dequant_int8.cu` — INT8 quant/dequant
+- `dequant_gptq.cu` — GPTQ-specific paths
+- `dequant_gpu.cu` — small device-side dequant helpers
+- `fp8_quant.cu`, `fp8_utils.cu`, `fp8_utils.cuh` — FP8 (E4M3) quant/dequant + calibration
+- `nvfp4_quant.cu`, `nvfp4_gemm.cu` — NVFP4 quant + GEMM
+- `mxfp4_gemm.cu` — MXFP4 dense GEMV/GEMM
+- `quant_gemm.cu`, `quant_gemm.h`, `quant_types.h` — shared types + dispatch shims
+- `turboquant_fp4.cuh` — UE8M0/FP4 helpers (kept for MXFP4-KV after TurboQuant was retired, see `turboquant_retired_2026_05_17.md`)
+
+### `src/exec/pre_dequant_*.cu` — init-time pipeline (Phase 3 of refactor)
+Pure orchestration; calls `src/quant/` kernels for the actual format work.
+
+- `executor_pre_dequant.cu` — 76 LOC orchestrator that calls each phase in order
+- `pre_dequant_internal.h` — 6 shared helpers (`borrow_payload_from_wcache`, `for_each_dense_weight`, etc.)
+- `pre_dequant_phase0_nvfp4_loader.cu` — Phase 0 + 0b: NVFP4 sidecar promotion + CUTLASS-NVFP4 registration
+- `pre_dequant_phase1_fp16_cache.cu` — Phase 1: GGUF Q*_K → FP16 device cache (used by Q4_K_M, Q5_K_M, Q6_K, Q8_0, ...)
+- `pre_dequant_phase2_fp8_cache.cu` — Phase 2: FP16 → FP8 device tensors for the `fp8_prefill` path
+- `pre_dequant_phase3_nvfp4_decode.cu` — Phase 3: NVFP4 decode-cache quantization (the bulk, 10 helpers)
+- `pre_dequant_phase3c_mxfp4.cu` — Phase 3c: standalone MXFP4 (separate from NVFP4 pipeline)
+- `pre_dequant_phase4_tensor_registry.cu` — Phase 4: WeightMap → role/tier registration
+
+## GEMM dispatch — the registry pattern
+
+`src/exec/gemm_kernel_registry.{cu,h}` is the registry first introduced in the R5 refactor and now the unconditional dispatch path. The previous 21-parameter `gemm_dispatch_impl` god-dispatcher was retired.
+
+Adding a new quant tier is a single-file change: implement the kernel in `src/exec/gemm_kernel_<format>.cu`, call `register_gemm_kernel(strategy_key, fn_ptr)` from a static initializer or registration helper, and the dispatcher picks it up. Existing tiers:
+
+- `gemm_kernel_cutlass_nvfp4.cu` — CUTLASS NVFP4 (default for NVFP4 prefill)
+- `gemm_kernel_nvfp4_gemm.cu`, `gemm_kernel_nvfp4_gemv.cu` — non-CUTLASS NVFP4 fallbacks
+- `gemm_kernel_fp8.cu` — FP8 paths
+- `gemm_kernel_mxfp4.cu` — MXFP4 dense
+- `gemm_kernel_gguf.cu` — GGUF Q*_K small-M path (dp4a + mmvq)
+- `gemm_kernel_q4k_imma.cu` — Q4_K_M INT8 IMMA experimental path
+- `gemm_kernel_generic_dequant.cu` — fallback for unhandled quants (dequant → cuBLAS)
+
+## Boundary rules
+
+When adding a new quant format:
+
+- If the format needs **per-call decode** during forward pass: add the kernel to `src/quant/` and a dispatch entry to `src/exec/gemm_kernel_<format>.cu`.
+- If the format needs **per-engine setup** (allocating tiered device tensors, computing a quant cache at load time): add a new `src/exec/pre_dequant_phase<N>_<name>.cu` file and one call from `executor_pre_dequant.cu`.
+- The boundary stays clean as long as `src/quant/` stays kernels-and-helpers and `src/exec/pre_dequant_*.cu` stays orchestration.
+
+## Where the two layers meet at runtime
+
+1. `Engine::init_weights` → `executor_pre_dequant.cu::pre_dequant_weights()` runs all phases sequentially, producing device tensors in the right tiers.
+2. Per-forward-pass: `gemm_kernel_registry` dispatches to the right `gemm_kernel_<format>.cu`, which reads the pre-dequant tier or calls `src/quant/dequant_*.cu` for an on-demand decode.
+
+Both paths share kernels in `src/quant/`. The split between `src/quant/` and `src/exec/pre_dequant_*.cu` is **when the work happens**, not what work it is.


### PR DESCRIPTION
## Summary
Closes 3 of the deferred soft PRs from the architecture refactor roadmap with two new doc files (no code changes).

## New docs
- \`docs/attention-dispatch.md\` — per-(phase × dtype × layer) kernel selection. Documents the post-Phase-2 two-branch prefill gate, the surviving FMHA chain, the decode switch on cache_dtype, sliding-window + soft-cap handling.
- \`docs/quant-pipeline.md\` — boundary between hot-path \`src/quant/\` and init-time \`src/exec/pre_dequant_*.cu\`. Documents the GEMM kernel registry pattern (\`src/exec/gemm_kernel_registry.{cu,h}\`) as the canonical \"add a new format\" entry point.

## Resolves these soft PRs
- Phase 2: \`docs/attention-dispatch.md\` documenting the final matrix ✅
- Phase 3: \`gemm_kernel_*.cu\` registry alignment confirm (registry already exists; doc explains the pattern) ✅
- Phase 3: \`dequant_*.cu\` reconciliation doc ✅

## Skipped (not in this PR)
- Phase 2 soft: drop \`attention_paged_common.cuh\` (446 LOC, 12 includers — too invasive for soft tier)
- Phase 2 soft: compile-only resurrection check (low value vs CMake effort)
- Phase 4 soft: promote subsystems to named classes (explicit future work per spec deviation note)

## Test plan
- [x] No code changes — \`make verify-fast\` not required
- [x] Pre-push hook skipped verify (\`no source changes\`)
- [x] README documentation table updated with both new doc links

🤖 Generated with [Claude Code](https://claude.com/claude-code)