### PR TITLE
fix(attention): disable Track E — multi-model degeneration (URGENT)

### DIFF
--- a/src/compute/attention_tiled_streaming.cu
+++ b/src/compute/attention_tiled_streaming.cu
@@ -591,6 +591,18 @@ bool attention_tiled_streaming_prefill(const Tensor& Q, const Tensor& K,
                                        bool causal, int sliding_window,
                                        float softcap, int q_offset,
                                        cudaStream_t stream) {
+    // DISABLED — multi-model smoke test (2026-05-21) revealed degeneration
+    // on Gemma-4 (Q8_0, Q4_K_M, NVFP4), Qwen3-8B-NVFP4, and a CUDA-error
+    // crash on Qwen3.5-4B (GDN+attention hybrid). Only Qwen3-8B-Q8_0 and
+    // Qwen3.6-35B-NVFP4 produce coherent output. Root cause unknown —
+    // the PV-repack fix in #353 resolved one bug class, but more remain.
+    //
+    // Suspects: hd=256 path (Gemma SWA), GDN attention shape contract,
+    // KV layout differences across architectures.
+    //
+    // Track E stays in tree for investigation but every call falls back
+    // to cuBLAS / FMHA via the existing dispatcher branches.
+    return false;
     if (Q.qtype != QType::F16 || K.qtype != QType::F16 || V.qtype != QType::F16)
         return false;
     if (Q.ndim != 4) return false;


### PR DESCRIPTION
## Critical hotfix

Multi-model smoke test (Q1: "What is 17 + 25?") reveals Track E is broken on 4 of 6 production models, not just one as previously thought:

| Model | Output | Status |
|---|---|---|
| Qwen3-8B Q8_0 | "Okay, I need to figure out..." | ✅ |
| Qwen3.6-35B NVFP4 | "The user is asking for the sum..." | ✅ |
| Qwen3-8B NVFP4 | "1. 1. 1. 1." infinite | ❌ DEGENERATE |
| Gemma-4-26B Q8_0 | "층-다스-층-다스-..." Korean garbage | ❌ DEGENERATE |
| Gemma-4-26B Q4_K_M | "the-land-land-land-..." | ❌ DEGENERATE |
| Gemma-4-26B NVFP4 | `<eos><eos>` immediate EOS | ❌ DEGENERATE |

PR #353 fixed ONE bug class (the m16n8k16 PV-repack interleaving). More remain.

## Verification of disable

With the disable in place (this PR):

| Model | Output |
|---|---|
| Qwen3-8B NVFP4 | "Okay, let's see." ✅ |
| Gemma-4-26B Q8_0 | "17 + 25 = 42`<turn|>`" ✅ |

## Suspects for remaining bugs

- **hd=256 path** (Gemma-4 SWA layers) uses Br=32 Bkv=32 — different register/smem layout than hd=128, may have its own indexing bugs the magnitude=1.0 test fill still misses
- **GDN+attention hybrid** (Qwen3.5/3.6) passes attention K/V with different shapes that Track E may misinterpret
- **NVFP4-weight models** produce attention activations with different distribution; some numerical path may saturate

## Why the tests didn't catch this

The \`TrackE_Correctness\` tests at \`fill_fp16_deterministic\` magnitude=1.0 all PASS (max_abs = 0.000244). The synthetic uniform fill, even at "realistic" magnitude, doesn't capture the multi-head non-uniform attention patterns of real models on real prompts.

**Required followup before re-enabling Track E:**
1. Replace test fill with a Gaussian or sample-from-real-model-checkpoint distribution
2. Add an automated smoke-prompt gate that runs through 6+ production models, not just the Qwen3-8B-Q8_0 verify-fast pin
3. Root-cause each of the 4 broken models (Gemma-4 ×3 + Qwen3-8B-NVFP4)

## Test plan

- [x] Build clean
- [x] Smoke test all 7 models — Track-E-broken paths now work via cuBLAS fallback
- [x] verify-fast pre-push hook green
- [x] Pre-existing Qwen3.5-4B cudaFree illegal-memory-access (unrelated to Track E) noted but not addressed by this PR

## Related

- #350 base Track E (merged with bugs)
- #351 4+4 warp-spec (merged, unrelated to correctness)
- #352 first disable hotfix (merged then superseded by #353)
- #353 PV repack fix (merged — fixed one bug class, more remain)
- **This PR** — re-disable until comprehensive fix lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)