### PR TITLE
fix(attention): disable Track E v2 — 50%+ perf regression vs cuBLAS

### DIFF
--- a/src/compute/attention_tiled_streaming.cu
+++ b/src/compute/attention_tiled_streaming.cu
@@ -364,6 +364,18 @@ bool attention_tiled_streaming_prefill(const Tensor& Q, const Tensor& K,
                                        bool causal, int sliding_window,
                                        float softcap, int q_offset,
                                        cudaStream_t stream) {
+    // Track E v2 is numerically correct but ~50% slower than cuBLAS at long
+    // context (scalar FP32 PV vs cuBLAS tensor-core PV). Production-disabled
+    // until a WMMA-PV variant matches correctness without losing perf.
+    //
+    // A/B on Qwen3-8B Q8_0:
+    //   pp512:  v2 = 10295 tok/s  vs cuBLAS = 12225 (-15.8%)
+    //   pp4096: v2 =  4906 tok/s  vs cuBLAS =  9905 (-50.5%)
+    //   pp8192: v2 =  3095 tok/s  vs cuBLAS =  8199 (-62.2%)
+    //
+    // Kernel stays in tree for the next optimisation pass (WMMA PV with
+    // FP32 accumulator + careful P handling).
+    return false;
     if (Q.qtype != QType::F16 || K.qtype != QType::F16 || V.qtype != QType::F16)
         return false;
     if (Q.ndim != 4)


### PR DESCRIPTION
## Urgent perf hotfix

PR #356 shipped Track E v2 as the default prefill path. It's **correct on all 6 production models** (the original goal) but **catastrophically slower than cuBLAS**:

| seq | Track E v2 | cuBLAS | Δ |
|---|---:|---:|---:|
| 512 | 10295 tok/s | 12225 | **-15.8%** |
| 4096 | 4906 tok/s | 9905 | **-50.5%** |
| 8192 | 3095 tok/s | 8199 | **-62.2%** |

A/B measured on identical `imp:test` image, Qwen3-8B Q8_0, 3 reps each. Production has been running with this regression since #356 merged ~1h ago.

## Root cause

v2's PV phase uses a scalar FP32 loop (V loaded FP16, upcast to FP32 inline, O accumulates FP32). This sidesteps the FP16 P-fragment numerical issue that bit v1 — but throws away tensor cores for PV.

cuBLAS uses tensor cores for both QKᵀ and PV. v2 uses tensor cores only for QKᵀ. The asymmetric loss of TC throughput on PV is the bottleneck.

## What this PR does

Adds an unconditional `return false;` at the launcher entry. Dispatcher falls back to cuBLAS / FMHA as before #350. Comment in the code documents the perf numbers + the path to a future re-enable.

## What stays

- Track E v2 kernel code stays in tree (700 LOC at `src/compute/attention_tiled_streaming.cu`)
- Layout probe from PR #355 stays as the regression gate
- Public header unchanged
- Dispatcher unchanged (Track E preferred → falls to cuBLAS via false return)

## Next optimisation pass

Replace v2's scalar FP32 PV with **WMMA m16n8k16 PV using FP32-accumulated P repack**. The key insight: P doesn't need to be stored to smem at all — keep it in registers in FP32, pack to FP16 just before each mma call. v1 stored P to smem then re-loaded as FP16 fragments (corrupting precision). v2 went scalar to avoid that. A third design: in-register FP32 P, pack-and-mma per WMMA tile.

Worth a focused 1-day experiment with the layout probe as a regression gate.

## Verification

- [x] Build clean
- [x] cuBLAS prefill perf restored (pp4096 = 9558 tok/s with disable, matches cuBLAS-only A/B baseline 9905)
- [x] verify-fast pre-push hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)