### PR TITLE
fix(diag): wire RuntimeConfig to GraphExecutor — diagnostics.profile actually fires

### DIFF
--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -24,6 +24,7 @@ bool Engine::init_weights() {
     // Initialize graph executor (Phase 1: compute sizes, no GPU allocation)
     executor_ = std::make_unique<GraphExecutor>();
     executor_->set_vram_allocator(&memory_manager_.vram_allocator());
+    executor_->set_runtime_config(runtime_config_);
     {
         int eff_batch = config_.max_batch_size;
         if (!executor_->init(*model_, config_.compute_dtype, config_.use_pdl, eff_batch, config_.max_seq_len,


### PR DESCRIPTION
## Summary
- The Phase-5 refactor (Track D singleton retirement) declared `GraphExecutor::set_runtime_config(const RuntimeConfig&)` but no production code ever called it. `runtime_config_` stayed null on every Engine instance and `runtime_config()` returned the static default.
- All `diagnostics.*` flags (`profile`, `log_gemm_algo`, `audit_nvfp4_scales`, `nvfp4_force_dequant`, …) plus the handful of `moe.*` overrides read via `runtime_config()` silently no-op'd.
- Found while enabling per-component decode profiling on Qwen3-14B Q6_K (see PR #362 follow-up) — `PROFILE avg over …` line at `executor_forward.cu:867` never fired regardless of `--config` setting.

## Fix
One line in `Engine::init_weights`, right after the executor is constructed:

```diff
  executor_->set_vram_allocator(&memory_manager_.vram_allocator());
+ executor_->set_runtime_config(runtime_config_);
```

`runtime_config_` is assigned at `engine.cpp:377` (`take_pending_runtime_config()`) and is a stable member of Engine — outlives the executor — so the stored reference is valid for the engine's lifetime.

## After
`--config imp.conf` with `[diagnostics] profile = true` correctly produces:

```
PROFILE avg over 159 steps: total=15.65ms  attn=5.82ms (37%)  ffn/moe=9.03ms (58%)  lm_head=0.76ms (5%)
```

## Test plan
- [x] `make test-unit` — 37/37 PASS
- [x] `make test-gpu` — 68/101 PASS, 33 skipped (no models), 0 fail
- [x] Bench with `--config /tmp/profile.conf --no-cuda-graphs` on Qwen3-14B Q6_K — PROFILE lines fire as expected.
- [x] Default bench unchanged — runtime_config snapshot is read-only in hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)