### PR TITLE
perf(vram_budget): compute FP8 budget after KV clamp — Mode 1 hits 150 tok/s on Qwen3-14B Q6_K

### DIFF
--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -170,15 +170,8 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
                                        : needed_blocks;
             if (config.use_nvfp4_decode != 2)
                 budget.kv_max_blocks = std::max(budget.kv_max_blocks, needed_blocks);
-
-            // FP8 prefill: use remaining VRAM after NVFP4 decode + KV cache.
-            // Cap FP8 to what we actually need (nvfp4_elems = raw weight bytes).
-            size_t kv_actual = static_cast<size_t>(budget.kv_max_blocks) * per_block_total;
-            size_t nvfp4_actual = nvfp4_estimate + cutlass_sf_estimate;
-            size_t remaining_for_fp8 = (available > kv_actual + nvfp4_actual)
-                                           ? (available - kv_actual - nvfp4_actual)
-                                           : 0;
-            budget.fp8_cache_bytes = std::min(nvfp4_elems, remaining_for_fp8);
+            // FP8 budget is computed below — after the kv_max_blocks clamp /
+            // min_kv_blocks enforcement — so it reflects the FINAL KV size.
             budget.nvfp4_second_pass = (config.use_nvfp4_decode == 2);
             break;
         }
@@ -222,6 +215,22 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
                      min_kv_blocks, min_kv_tok);
         budget.kv_max_blocks = min_kv_blocks;
         budget.kv_cache_bytes = static_cast<size_t>(min_kv_blocks) * per_block_total;
+    }
+
+    // FP8 prefill: use remaining VRAM after NVFP4 decode + the *final* KV size.
+    // Computing this earlier (against the unclamped kv_max_blocks) silently
+    // zeroed FP8 in mode 1 because the 0.8 kv_fraction filled the budget on
+    // paper, even though `target_blocks` clamped the actual KV allocation
+    // back down. The post-clamp computation lets mode 1 (additive) populate
+    // both caches when VRAM allows — Qwen3-14B Q6_K mode 1 default flags
+    // previously cached fp8=0 tensors and paid ~28 % prefill for it.
+    if (budget.strategy == VRAMBudget::FP8_PREFILL_NVFP4_DECODE) {
+        size_t kv_actual = static_cast<size_t>(budget.kv_max_blocks) * per_block_total;
+        size_t nvfp4_actual = nvfp4_estimate + cutlass_sf_estimate;
+        size_t remaining_for_fp8 = (available > kv_actual + nvfp4_actual)
+                                       ? (available - kv_actual - nvfp4_actual)
+                                       : 0;
+        budget.fp8_cache_bytes = std::min(nvfp4_elems, remaining_for_fp8);
     }
 
     const char* strat_name = (budget.strategy == VRAMBudget::FP8_PREFILL_NVFP4_DECODE)


### PR DESCRIPTION
## Summary
- `compute_vram_budget` computed the FP8 prefill cache budget from the **unclamped** `kv_max_blocks`. For mode 2 this was harmless (`kv_fraction=0.1`); for mode 1 (`--decode-nvfp4`, `kv_fraction=0.8`) it consumed all of `available` on paper and silently zeroed the FP8 cache.
- Result: every model that hit the `FP8_PREFILL_NVFP4_DECODE` strategy and was launched with explicit `--decode-nvfp4` paid -28 % prefill for zero FP8 prefill cache (pure dequant-on-the-fly fallback).
- Fix moves the FP8 budget calc past the `target_blocks` clamp and the `min_kv_blocks` enforcement so it uses the **final** KV size.

## Measurements (Qwen3-14B Q6_K, ctx=2048, `--decode-nvfp4`, 3 trials each)
| | pp2048 | tg128 | FP8 tensors |
|--|--|--|--|
| mode 2 default | 5583 | 145.0 | 208 |
| mode 1 PRE fix | 4040 | 150.0 | **0** |
| mode 1 POST fix | **5080** | **151.0** | **180** |
| Δ vs default | -9 % | **+4.1 %** | |

Mode 1 + this fix now beats the default on the GOAL.md north-star (Qwen3-14B Q6_K decode @ ctx=2048) by +4 %, **hitting the 150 tok/s milestone**, while keeping prefill within 10 % of mode 2 (vs the -28 % hit before).

## Mode 2 default — untouched
The bug only zeroed FP8 in mode 1. Verified mode 2 unchanged:
- Qwen3-8B  Q8_0 default: pp 11648 / tg 265.4 (unchanged within noise)
- Qwen3-14B Q6_K default: pp 5583  / tg 145.3 (unchanged)

Auto-resolve policy (`use_nvfp4_decode = -1 → 2`) is unchanged. Users who pass `--decode-nvfp4` for the decode win now don't pay the -28 % prefill tax.

## Test plan
- [x] `make test-unit` — 37/37 PASS
- [x] Qwen3-14B Q6_K mode 1 bench × 3 — 151 tok/s ± 0.1 %
- [x] Qwen3-14B Q6_K mode 2 bench × 3 — 145 tok/s ± 0.4 % (unchanged)
- [x] Qwen3-8B Q8_0 default — within 5%/3% CI thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)