### PR TITLE
docs(GOAL): north-star 121.4 → 145.6 default / 151 with --decode-nvfp4

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -126,6 +126,7 @@ A release is shippable when, on RTX 5090:
 
 This number goes up over time. It never goes down. If a refactor makes it go down, the refactor is wrong, no matter how clean the code looks.
 
-Current: 121.4 tok/s (+25.5% vs llama.cpp c830f99, May 2026).
-Next milestone: 150 tok/s.
+Current: **145.6 tok/s** default flags, **151 tok/s** with `--decode-nvfp4` (May 22 2026, post PR #362 + #364 — the 150 milestone is reached, default is one PR away).
+Previous: 121.4 tok/s (May 2026, +25.5% vs llama.cpp c830f99).
+Next milestone: 150 tok/s ✓ hit with `--decode-nvfp4` on 2026-05-22 (PR #364). Promote to default once the prefill cost (-9 % vs mode 2) is shown not to break the dense-prefill llama.cpp bar.
 Stretch: 200 tok/s with TurboDraft on.


### PR DESCRIPTION
## Summary
Updates the canonical north-star number after the May-22 decode push:

| | tg128 @ ctx=2048 | Δ vs old |
|--|--|--|
| Default flags (mode 2)   | **145.6 tok/s** | +20 % |
| `--decode-nvfp4` (mode 1) | **151.0 tok/s** | +24 % |
| Old (May 2026)            | 121.4 tok/s     | — |

The **150 milestone is hit** with explicit `--decode-nvfp4`. The default still resolves to mode 2 because GOAL.md ranks prefill #2 and mode 1's -9 % prefill is unevaluated against the "must match or beat llama.cpp on dense" bar — promoting to default is a follow-up.

## PR chain
- #362 — Phase-3 NVFP4 mode-2 in-loop safety right-sizing (default decode +16.5 %)
- #364 — vram_budget: compute FP8 budget after KV clamp (mode 1 prefill +25 % → 151 tok/s)

## Test plan
- [x] Docs only — no code changes; CI expected green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)