### PR TITLE
docs(GOAL): correct MoE-prefill gap to vLLM — 1.14-1.32× single-seq, not 20×

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -63,7 +63,7 @@ Concrete technical commitments — these are means, not ends, but progress on th
 - **MXFP4 FMHA** (already novel — first such impl) must stay ahead and expand to more shapes. The +6.7–7.9% over FP8 FMHA on Qwen3 is the baseline, not the ceiling.
 - **CUTLASS Hopper FMHA path on sm_120** for prefill — keep up with CUTLASS releases.
 - **WMMA 8-warp decode kernel** is the decode workhorse on sm_120. Tune for every hero model's head dim.
-- **Grouped GEMM dequant for MoE prefill** — the single biggest known gap. Fix this and Qwen3-Coder prefill returns to parity or better. Currently 1258 vs 25513 tok/s vs vLLM. Top engineering priority.
+- **Grouped GEMM dequant for MoE prefill** — closing the residual gap to vLLM single-seq. Qwen3-Coder-30B-A3B-NVFP4 pp512: imp ~14–16 k tok/s (cuBLAS-algo-variance band per the 2026-05-10 31-commit dive), vLLM 0.20.2 single-seq 18.5 k tok/s (**1.14–1.32× gap**). vLLM's 25.5 k multi-seq is continuous-batching mode, not a fair single-seq comparison — imp is batch=1 by design. Engineering priority remains high but the gap is multi-week (CUTLASS sm120 `MoEProblemShape` scheduler upstream, custom kernel work, or gather+quant fusion patterns), not a single-PR win.
 
 ### Memory
 - **Paged KV cache** (block 16) with LRU, prefix caching — keep and extend.


### PR DESCRIPTION
## Summary
The previous "Currently 1258 vs 25513 tok/s vs vLLM" line was both numerically stale and methodologically mixed:

- **"1258"** appears to predate the 2026-05-10 31-commit MoE-prefill dive that landed `769effe` (GrpGemm cache) + `41fb8fc` (gate+up fusion opt-in). Post-session warm 3-rep median was ~16,269 tok/s. Re-bench on current main (3 trials, Qwen3-Coder-30B-A3B-NVFP4 pp512): **14,065 / 14,434 / 13,653** — within the documented cuBLAS-algo-variance band (7-17 k cross-container median).
- **"25513"** was vLLM 0.20.2 **continuous-batching multi-seq** mode. imp is batch=1 by design ("What imp is NOT"). The single-seq comparison is vLLM 18,500.

## Real gap
| | pp512 (tok/s) | source |
|--|--|--|
| imp current | 14,000 – 16,000 | 2026-05-22 bench, variance band |
| vLLM 0.20.2 single-seq | 18,500 | 2026-05-10 audit |
| **Ratio** | **1.14× – 1.32×** | |
| vLLM 0.20.2 multi-seq | 25,513 | (continuous batching — not comparable) |

## Why the gap is still multi-week
- CUTLASS sm120 `MoEProblemShape` scheduler — waiting on upstream
- Custom NVFP4 grouped kernel — smallM experiment showed par at large M_e, -50 % at small M_e
- Gather + quant fusion — ~+3.5 % per target

## Test plan
- [x] Docs-only. CI green expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)