### PR TITLE
perf(nvfp4-decode): mode 1 is the new auto-default for dense Q*_K — Qwen3-14B Q6_K hits 150 tok/s by default

### DIFF
--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -167,7 +167,24 @@ void Engine::init_resolve_quant_flags_() {
             n_gdn_auto++;
 
     if (config_.use_nvfp4_decode < 0) {
-        if (n_gdn_auto > 0) {
+        const auto wq_qtype = model_->layer(0).wq.qtype;
+        const bool nvfp4_beneficial_qtype = (wq_qtype == QType::Q8_0 || wq_qtype == QType::Q8_K ||
+                                              wq_qtype == QType::Q6_K || wq_qtype == QType::Q5_K);
+        const bool is_moe = (mcfg.n_experts > 0);
+        const bool is_gdn = (n_gdn_auto > 0);
+
+        if (nvfp4_beneficial_qtype && !is_moe && !is_gdn) {
+            // Dense Q*_K (6-8 bit GGUF) on sm_120: mode 1 (additive — both FP8
+            // prefill and NVFP4 decode caches populated) measures +4% decode
+            // over mode 2 on Qwen3-14B Q6_K @ ctx=2048 (151 vs 145.6 tok/s,
+            // PR #364), at -9% prefill (5080 vs 5540). GOAL.md ranks decode #1
+            // for the north-star, so dense Q*_K defaults to mode 1.
+            // MoE / GDN / native-NVFP4 / sub-8-bit models stay on mode 2 —
+            // either the mode-1 advantage is absent (NVFP4 prequant) or it
+            // regresses (host-offloaded MoE measured -8% on Gemma-4 Q8_0).
+            config_.use_nvfp4_decode = 1;
+            IMP_LOG_INFO("NVFP4 decode: auto → mode 1 (dense Q*_K — decode-first)");
+        } else if (is_gdn) {
             // GDN models with large d_model: enable NVFP4 for attention + FFN weights,
             // but SSM/GDN projections (ssm_in/ssm_out) will be excluded in
             // pre_dequant_weights to preserve recurrent state precision.
@@ -177,8 +194,9 @@ void Engine::init_resolve_quant_flags_() {
                 "ssm_in/ssm_out excluded for precision)",
                 n_gdn_auto);
         } else {
+            const char* why = is_moe ? "MoE" : "non-Q*_K-6-8bit";
             config_.use_nvfp4_decode = 2;
-            IMP_LOG_INFO("NVFP4 decode: auto → mode 2");
+            IMP_LOG_INFO("NVFP4 decode: auto → mode 2 (%s)", why);
         }
     }
 


### PR DESCRIPTION
## Summary
Closes the policy gap from PR #364: mode 1 (additive) beats mode 2 on the GOAL.md north-star and hits the 150 tok/s milestone by default — but only for the model class where it's actually a win.

## Decision rule
```
IF  wq.qtype ∈ {Q8_0, Q8_K, Q6_K, Q5_K} AND n_experts == 0 AND n_gdn == 0
    → mode 1  (relies on PR #364's post-clamp FP8 budget fix; both caches populated)
ELIF n_gdn > 0
    → mode 2  (recurrent precision)
ELSE
    → mode 2  (MoE, native NVFP4 / MXFP4, sub-8-bit)
```

## Measurements (post-flip, default flags, 3 trials each)
| Model | pp (tok/s) | tg128 (tok/s) | mode |
|--|--|--|--|
| Qwen3-14B Q6_K @ ctx=2048 | 5046 (-9 % vs prior) | **150.1** (+3.1 %) | 1 |
| Qwen3-8B  Q8_0 pp512 | 11622 | 263.3 | 1 (neutral) |
| Gemma-4-26B-A4B Q8_0 pp2048 | 1453 | 19.4 | **2** (MoE — protected) |

Qwen3-14B Q6_K **default config** now hits the GOAL.md "next milestone: 150" line.

## Risk
- Prefill -9 % on dense Q*_K. Acceptable per GOAL.md decode-first ranking; absolute 5046 tok/s is well above any plausible llama.cpp baseline. Users can opt back via `--decode-nvfp4-only`.
- DeepSeek-R1-Distill-Qwen-14B Q6_K's FP8-prefill garbage hazard is independent of this change.
- GDN models stay on mode 2.

## Test plan
- [x] `make test-unit` — 37/37 PASS
- [x] `make test-gpu` — 68/101 PASS (33 skipped no models), 0 fail · attention 78/79 PASS
- [x] Coherence on Qwen3-14B Q6_K (default flags) — generation clean
- [x] Verified `NVFP4 decode: auto → mode 1 (dense Q*_K — decode-first)` log line fires for Qwen3-14B Q6_K, mode 2 retained for Gemma-4-26B-A4B Q8_0 (MoE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)