### PR TITLE
docs(GOAL): north-star 145.6 → 150.1 default — 150 milestone hit by default (PR #367)

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -126,7 +126,7 @@ A release is shippable when, on RTX 5090:
 
 This number goes up over time. It never goes down. If a refactor makes it go down, the refactor is wrong, no matter how clean the code looks.
 
-Current: **145.6 tok/s** default flags, **151 tok/s** with `--decode-nvfp4` (May 22 2026, post PR #362 + #364 — the 150 milestone is reached, default is one PR away).
+Current: **150.1 tok/s default flags** (May 22 2026, post PRs #362 + #364 + #367 — auto-resolve picks mode 1 for dense Q*_K models). The 150 milestone is hit by default.
 Previous: 121.4 tok/s (May 2026, +25.5% vs llama.cpp c830f99).
-Next milestone: 150 tok/s ✓ hit with `--decode-nvfp4` on 2026-05-22 (PR #364). Promote to default once the prefill cost (-9 % vs mode 2) is shown not to break the dense-prefill llama.cpp bar.
-Stretch: 200 tok/s with TurboDraft on.
+Next milestone: **175 tok/s** — needs architectural work (decode kernel tuning per the 35 % attention / 60 % FFN profile split, FP8 prefill cache coverage for the remaining ~100 layer-tensors that fall back to CUTLASS NVFP4 prefill, or LM_HEAD quantization unlock).
+Stretch: 200 tok/s with TurboDraft or draft-model spec-decode on (both blocked: TurboDraft broken on pretrained, no MTP head shipped for Qwen3-14B, draft-model integration is multi-week).


### PR DESCRIPTION
## Summary
After PR #367 (mode 1 as auto-default for dense Q*_K), Qwen3-14B Q6_K decode at default flags is now **150.1 tok/s** (was 145.6). The 150 milestone is the new floor — no flag needed.

Updates the GOAL.md north-star numbers:
- "Current" bumps to 150.1
- Next milestone moves to **175 tok/s**
- Stretch (200) annotated with current blockers (TurboDraft broken, no Qwen3-14B MTP head, draft-model integration multi-week)

## Test plan
Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)