### PR TITLE
ci(perf-baseline): cold-median methodology + Makefile target + refreshed Q8_0 numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_IMG ?= imp:test
 DOCKER_RUN = docker run --rm --gpus all -v $(PWD)/models:/models $(DOCKER_IMG)
 BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 
-.PHONY: build test-unit test-gpu test-fast test-all test-perf test-golden bench check-gpu verify verify-fast verify-chunked install-hooks format format-check
+.PHONY: build test-unit test-gpu test-fast test-all test-perf test-golden bench check-gpu verify verify-fast verify-chunked gen-perf-baseline install-hooks format format-check
 
 # Check that no other process is using the GPU (games, other inference, etc.)
 check-gpu:
@@ -93,6 +93,24 @@ verify-chunked:
 	@IMP_VERIFY_BASELINE=tests/perf_baseline_chunked.json \
 	 IMP_VERIFY_CHUNK_SIZE=512 \
 	 scripts/verify.sh fast
+
+# Regenerate tests/perf_baseline.json with the cold-median methodology (5 trials,
+# 15s cooldown between, median of each metric). Resists cuBLAS-algo-state drift —
+# see memory/bench_sustained_load_cublas_algo_drift_2026_05_23.md.
+# Defaults to Qwen3-8B Q8_0; pass MODEL=… to override.
+#
+# Mounts the resolved model directory (defaults to ~/models so symlinks work)
+# AND the repo root (so the script can write back to tests/perf_baseline.json).
+# `-u` matches the host UID so the write succeeds.
+MODEL ?= /models/Qwen3-8B-Q8_0.gguf
+MODELS_DIR ?= $(HOME)/models
+gen-perf-baseline: build
+	@docker run --rm --gpus all \
+		-v $(MODELS_DIR):/models \
+		-v $(PWD):/src -w /src \
+		-u $(shell id -u):$(shell id -g) \
+		-e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+		--entrypoint bash $(DOCKER_IMG) scripts/gen_perf_baseline.sh "$(MODEL)"
 
 # install the pre-push hook that runs verify-fast when source files change
 install-hooks:

--- a/scripts/gen_perf_baseline.sh
+++ b/scripts/gen_perf_baseline.sh
@@ -1,27 +1,85 @@
 #!/bin/bash
 # Generate performance baseline JSON for regression testing.
-# Usage: ./scripts/gen_perf_baseline.sh [model_path]
-# Default: /models/Qwen3-8B-Q8_0.gguf
+#
+# Methodology: N independent cli invocations (default 5) per metric, with a
+# short cooldown between, then take the **median**. Resists cuBLAS-algo-state
+# drift over long sessions — see
+# memory/bench_sustained_load_cublas_algo_drift_2026_05_23.md for the failure
+# mode this guards against (multi-hour bench session can drift decode -10 %
+# even with no code change). The old script used a single invocation; CI was
+# then sensitive to whatever cuBLAS state happened to be cached at that moment.
+#
+# Usage (always inside the imp:test container — uses bare `imp-cli`):
+#   docker run --rm --gpus all \
+#     -v /home/kekz/models:/models \
+#     -v $PWD:/src -w /src \
+#     -u $(id -u):$(id -g) \
+#     -e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+#     --entrypoint bash imp:test scripts/gen_perf_baseline.sh
+#
+# The `-u $(id -u):$(id -g)` is required so the container can write the new
+# tests/perf_baseline.json back to the host bind mount. Without it the script
+# completes the benches but fails at the final `cat > $OUTPUT` step.
+#
+# Optional positional args:
+#   $1  model path (default /models/Qwen3-8B-Q8_0.gguf)
+#   $2  number of trials (default 5)
+#
 set -euo pipefail
 
 MODEL="${1:-/models/Qwen3-8B-Q8_0.gguf}"
+N_TRIALS="${2:-5}"
 REPS=5
 OUTPUT="tests/perf_baseline.json"
 CLI="imp-cli"
+COOLDOWN_SEC=15
 
 echo "Generating performance baseline..."
 echo "Model: $MODEL"
-echo "Reps: $REPS"
+echo "Trials: $N_TRIALS × $REPS reps, $COOLDOWN_SEC s cooldown between trials"
 
-# Collect metrics — extract the tok/s value inside parens, not the avg-ms field.
-# Bench line format: `pp   512 tokens  avg    33.95 ms  (15083.10 tok/s)  [5 reps]`
-# Same parser shape as scripts/verify.sh — keep them in sync.
+# Extract the tok/s value inside parens. Bench line format:
+#   `pp   512 tokens  avg    33.95 ms  (15083.10 tok/s)  [5 reps]`
 extract_tps() {
     grep -oP "$1"'\s+\d+\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' | head -1
 }
-pp128=$($CLI --model "$MODEL" --bench --bench-pp 128 --bench-reps "$REPS" --max-tokens 128 --temperature 0 2>&1 | extract_tps "^pp")
-pp512=$($CLI --model "$MODEL" --bench --bench-pp 512 --bench-reps "$REPS" --max-tokens 128 --temperature 0 2>&1 | extract_tps "^pp")
-tg128=$($CLI --model "$MODEL" --bench --bench-pp 128 --bench-reps "$REPS" --max-tokens 128 --temperature 0 2>&1 | extract_tps "^tg")
+
+# Median of stdin (one number per line). Sort + pick middle.
+median() {
+    sort -g | awk '{a[NR]=$1} END {if (NR%2) print a[(NR+1)/2]; else printf "%.4f\n", (a[NR/2]+a[NR/2+1])/2}'
+}
+
+# Run one full trial: pp128 + pp512 + tg128 measurements. Each is its own
+# `imp-cli --bench` invocation so cuBLAS algo selection resets between.
+run_trial() {
+    local pp_size="$1"
+    local prefix="$2"  # "pp" or "tg"
+    $CLI --model "$MODEL" --bench --bench-pp "$pp_size" --bench-reps "$REPS" \
+        --max-tokens 128 --temperature 0 2>&1 | extract_tps "^$prefix"
+}
+
+pp128_samples=$(mktemp)
+pp512_samples=$(mktemp)
+tg128_samples=$(mktemp)
+trap 'rm -f "$pp128_samples" "$pp512_samples" "$tg128_samples"' EXIT
+
+for trial in $(seq 1 "$N_TRIALS"); do
+    echo "  trial $trial/$N_TRIALS..."
+    run_trial 128 pp >> "$pp128_samples"
+    run_trial 512 pp >> "$pp512_samples"
+    run_trial 128 tg >> "$tg128_samples"
+    if [ "$trial" -lt "$N_TRIALS" ]; then
+        sleep "$COOLDOWN_SEC"
+    fi
+done
+
+pp128=$(median < "$pp128_samples")
+pp512=$(median < "$pp512_samples")
+tg128=$(median < "$tg128_samples")
+
+echo "  pp128 samples: $(paste -sd, "$pp128_samples")  → median $pp128"
+echo "  pp512 samples: $(paste -sd, "$pp512_samples")  → median $pp512"
+echo "  tg128 samples: $(paste -sd, "$tg128_samples")  → median $tg128"
 
 # Get GPU info. Try nvcc first, then fall back to nvidia-smi cuda_version
 # (the runtime image has no nvcc, only the devel image does).
@@ -31,7 +89,7 @@ CUDA=$(nvcc --version 2>/dev/null | grep "release" | sed 's/.*release //' | sed 
        || echo "unknown")
 VRAM_TOTAL=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -1 || echo "0")
 
-# Get model VRAM from benchmark output
+# Get model VRAM from benchmark output (independent quick run).
 vram_line=$($CLI --model "$MODEL" --bench --bench-pp 128 --bench-reps 1 --max-tokens 1 --temperature 0 2>&1 | grep "GPU memory after weight upload" | tail -1)
 vram_weights=$(echo "$vram_line" | grep -oP 'weights ~\K[0-9]+' || echo "0")
 
@@ -44,7 +102,9 @@ cat > "$OUTPUT" << EOF
   "cuda": "$CUDA",
   "vram_total_mb": $VRAM_TOTAL,
   "timestamp": "$TIMESTAMP",
+  "methodology": "median of $N_TRIALS trials × $REPS reps, ${COOLDOWN_SEC}s cooldown between trials (cuBLAS algo drift resistant)",
   "reps": $REPS,
+  "n_trials": $N_TRIALS,
   "metrics": {
     "prefill_tps": {
       "pp128": $pp128,

--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -3,15 +3,17 @@
   "gpu": "NVIDIA GeForce RTX 5090",
   "cuda": "13.2",
   "vram_total_mb": 32607,
-  "timestamp": "2026-05-22T19:39:02Z",
+  "timestamp": "2026-05-23T00:49:22Z",
+  "methodology": "median of 5 trials × 5 reps, 15s cooldown between trials (cuBLAS algo drift resistant)",
   "reps": 5,
+  "n_trials": 5,
   "metrics": {
     "prefill_tps": {
-      "pp128": 4392.36,
-      "pp512": 11581.18
+      "pp128": 4482.03,
+      "pp512": 12111.02
     },
     "decode_tps": {
-      "tg128": 270.51
+      "tg128": 284.53
     },
     "memory_mb": {
       "model_weights": 8608


### PR DESCRIPTION
## Summary

- `scripts/gen_perf_baseline.sh` upgraded from single-shot to **median of N trials with cooldown** (default 5 trials × 5 reps, 15 s cooldown between trials; each metric medianed independently). JSON now records methodology + n_trials.
- New `make gen-perf-baseline` target that wraps the docker invocation correctly (`-u $(id -u):$(id -g)`, resolved `MODELS_DIR`). Pass `MODEL=...` to override.
- `tests/perf_baseline.json` regenerated on RTX 5090 + CUDA 13.2 using the new methodology — same perf, lower variance:

      pp128: 4392.36 → 4482.03  (+2.0 %)
      pp512: 11581.18 → 12111.02 (+4.6 %)
      tg128: 270.51 → 284.53    (+5.2 %)

The numbers move because single-shot captured whatever cuBLAS-algo-cache state happened to be live at that moment; cold-median is the steady-state.

## Test plan

- [x] `make gen-perf-baseline` produces a JSON with the new `methodology` + `n_trials` fields
- [x] CI perf-gate (3 % decode / 5 % prefill) still passes against the refreshed baseline
- [x] No source changes — pre-push hook skipped verify (CI-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)