### PR TITLE
docs(GOAL): north-star 150.1 → 157.71 tok/s (cold-median methodology)

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -126,7 +126,9 @@ A release is shippable when, on RTX 5090:
 
 This number goes up over time. It never goes down. If a refactor makes it go down, the refactor is wrong, no matter how clean the code looks.
 
-Current: **150.1 tok/s default flags** (May 22 2026, post PRs #362 + #364 + #367 — auto-resolve picks mode 1 for dense Q*_K models). The 150 milestone is hit by default.
-Previous: 121.4 tok/s (May 2026, +25.5% vs llama.cpp c830f99).
+Measurement methodology (always cold-median, never single-shot): 5 independent `imp-cli --bench` invocations × 5 reps × 15 s cooldown between trials, take the median. Resists cuBLAS-algo-state drift over long sessions (`memory/bench_sustained_load_cublas_algo_drift_2026_05_23.md`).
+
+Current: **157.71 tok/s default flags** (May 23 2026, cold-median methodology — 5 trials × 5 reps × 15 s cooldown, σ = 0.16 tok/s across samples; same code as the May 22 measurement, just less cuBLAS-algo-cache-state noise). The 150 milestone is hit by default with margin.
+Previous: 150.1 tok/s (May 22 2026, single-shot, post PRs #362 + #364 + #367). 121.4 tok/s (May 2026, +25.5% vs llama.cpp c830f99).
 Next milestone: **175 tok/s** — needs architectural work (decode kernel tuning per the 35 % attention / 60 % FFN profile split, FP8 prefill cache coverage for the remaining ~100 layer-tensors that fall back to CUTLASS NVFP4 prefill, or LM_HEAD quantization unlock).
 Stretch: 200 tok/s with TurboDraft or draft-model spec-decode on (both blocked: TurboDraft broken on pretrained, no MTP head shipped for Qwen3-14B, draft-model integration is multi-week).


### PR DESCRIPTION
## Summary

The May 22 single-shot claim of **150.1 tok/s** for Qwen3-14B Q6_K @ ctx=2048 (GOAL.md north-star) caught a worse cuBLAS-algo-cache state than the steady state. Re-measured today under the cold-median methodology shipped in #376:

| Metric | Samples | Median |
|---|---|---|
| pp512               | 5948, 5946, 5972, 5962, 5956 | **5956** |
| pp2048              | 5267, 5253, 5253, 5276, 5266 | **5266** |
| tg128 (default)     | 165.72, 165.69, 165.54, 165.95, 165.83 | **165.72** |
| **tg128 @ ctx=2048 (north-star)** | 157.43, 157.54, 157.86, 157.71, 157.74 | **157.71** |

σ on the north-star metric is **0.16 tok/s** (~0.1 % of median) — the methodology delivers exactly what the cuBLAS-drift memo predicted: tight, reproducible numbers.

Code unchanged between May 22 and May 23 — the 7.6 tok/s gap (150.1 → 157.71, +5.1 %) is single-shot variance, not a real perf change.

## Test plan

- [x] GOAL.md north-star number updated from 150.1 to 157.71
- [x] Methodology note added inline so future updates use cold-median
- [x] Pre-push hook skipped verify (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)