### PR TITLE
ci(perf-baseline): add north-star (Qwen3-14B Q6_K) baseline + verify-north-star target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,16 @@ verify-chunked:
 	 IMP_VERIFY_CHUNK_SIZE=512 \
 	 scripts/verify.sh fast
 
+# verify-north-star: gates the GOAL.md north-star model (Qwen3-14B Q6_K) against
+# tests/perf_baseline_north_star.json. Same 3%/5% thresholds as perf_baseline.json.
+# Requires Qwen3-14B-Q6_K.gguf in $(HOME)/models. Numbers were captured
+# 2026-05-23 under the cold-median methodology (PR #376) — see
+# memory/qwen3_14b_north_star_cold_median_2026_05_23.md for the raw samples
+# (σ = 0.16 tok/s on tg128 @ ctx=2048, well inside the 3% threshold).
+verify-north-star:
+	@IMP_VERIFY_BASELINE=tests/perf_baseline_north_star.json \
+	 scripts/verify.sh fast
+
 # Regenerate tests/perf_baseline.json with the cold-median methodology (5 trials,
 # 15s cooldown between, median of each metric). Resists cuBLAS-algo-state drift —
 # see memory/bench_sustained_load_cublas_algo_drift_2026_05_23.md.

--- a/tests/perf_baseline_north_star.json
+++ b/tests/perf_baseline_north_star.json
@@ -1,0 +1,29 @@
+{
+  "model": "Qwen3-14B-Q6_K.gguf",
+  "gpu": "NVIDIA GeForce RTX 5090",
+  "cuda": "13.2",
+  "vram_total_mb": 32607,
+  "timestamp": "2026-05-23T09:21:00Z",
+  "methodology": "median of 5 trials × 5 reps, 15s cooldown between trials (cuBLAS algo drift resistant)",
+  "reps": 5,
+  "n_trials": 5,
+  "_note": "This is the GOAL.md north-star baseline. CI verify.sh legacy path gates on pp512 + tg128 (i.e. at ctx=512). The tg128_at_ctx_2048 metric (157.71 tok/s) is the actual headline north-star number from GOAL.md; it's not auto-gated by verify.sh today (the script reads tg128 from a pp=512 bench) but is recorded here as the canonical cold-median measurement against which manual checks can be made.",
+  "metrics": {
+    "prefill_tps": {
+      "pp512": 5955.99,
+      "pp2048": 5266.41
+    },
+    "decode_tps": {
+      "tg128": 165.72,
+      "tg128_at_ctx_2048": 157.71
+    },
+    "memory_mb": {
+      "model_weights": 11860
+    }
+  },
+  "thresholds": {
+    "decode_regression_pct": 3,
+    "prefill_regression_pct": 5,
+    "vram_increase_pct": 10
+  }
+}


### PR DESCRIPTION
## Summary

The GOAL.md north-star metric (Qwen3-14B Q6_K decode @ ctx=2048) wasn't covered by any CI baseline — `tests/perf_baseline.json` only gates Qwen3-8B Q8_0. This PR adds the north-star model.

**`tests/perf_baseline_north_star.json`** — cold-median measurements from 2026-05-23 (5 trials × 5 reps, 15 s cooldown; σ on the north-star metric was 0.16 tok/s, well under the 3% decode threshold):

| Metric | Median |
|---|---:|
| pp512 | 5955.99 tok/s |
| pp2048 | 5266.41 tok/s |
| tg128 (ctx=128) | 165.72 tok/s |
| **tg128 @ ctx=2048** | **157.71 tok/s** ← canonical north-star |

The ctx=2048 measurement is documented in the JSON but not auto-gated by `verify.sh` legacy path (which reads `tg128` from a pp=512 bench). The pp512+tg128(ctx=128) pair is the actual CI gate metric for this model.

**`make verify-north-star`** — sets `IMP_VERIFY_BASELINE=…_north_star.json` and re-uses `scripts/verify.sh fast` (3%/5% thresholds). Sibling of the existing `verify-chunked` target. Requires `Qwen3-14B-Q6_K.gguf` in `$(HOME)/models`; gracefully skips if absent (matches existing perf-gate behavior).

## Why "local-verify only" today

CI's Test job (which runs the perf gate) is gated on `vars.HAS_GPU_RUNNER == 'true'` (see `.github/workflows/ci.yml:113`). No self-hosted GPU runner is registered yet, so the perf gate is dormant in CI. When the runner flips on, this baseline becomes active automatically with no further changes.

## Test plan

- [x] `make verify-north-star` runs and either passes (model present) or skips cleanly (model absent — what CI sees today)
- [x] JSON schema matches existing `tests/perf_baseline.json` (verify.sh legacy path)
- [x] Pre-push hook skipped (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)