### PR TITLE
test+stub(gdn): gdn_scan_chunkwise_f32 scaffolding for Phase 1b SSD kernel

### DIFF
--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -334,6 +334,49 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
     }
 }
 
+// EXPERIMENTAL — Phase 1b scaffolding for chunkwise SSD scan.
+// Current implementation: chunk-iterating sequential wrapper around
+// `gdn_scan_fused_f32`. Functionally identical to the monolithic call (the
+// kernel handles the H state in/out cleanly across multiple invocations,
+// validated by tests/test_gdn.cu::ChunkBoundaryHandoff). Phase 1b.1 replaces
+// the per-chunk call with a parallel-within-chunk SSD matmul kernel.
+//
+// The chunk_size parameter is currently informational (default 64 = Mamba2
+// paper's typical SSD block size). When the SSD kernel ships, it will tile
+// the within-chunk math at this block size.
+//
+// Reference for delta-rule parallel scan: Yang et al. 2024, "Parallel Linear
+// Attention With The Delta Rule" (the standard Mamba2 SSD assumes scalar
+// decay and doesn't cover GDN's rank-1 (I - β k k^T) multiplicative update).
+//
+// Phase 0 verdict (ncu): docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
+//   Memory 5.47 % peak / Compute 5.47 % peak / Achieved Occ 8.33 % → PROCEED.
+void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                            const float* A_log, const float* dt_bias, float* h_state, half* y,
+                            int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                            cudaStream_t stream, int chunk_size, int grouped_layout) {
+    // Effective chunk size: clamp to [1, n_tokens] so a single-token decode
+    // path falls through cleanly to one call with the same args.
+    if (chunk_size <= 0)
+        chunk_size = 64;
+    if (chunk_size > n_tokens)
+        chunk_size = n_tokens;
+
+    const int inner = n_heads * head_dim_ssm;
+    int t = 0;
+    while (t < n_tokens) {
+        const int this_chunk = (t + chunk_size <= n_tokens) ? chunk_size : (n_tokens - t);
+        // h_state mutates in-place across chunks — kernel reads it as the
+        // entry state and writes the chunk-end state back. No additional
+        // host-side sync needed; the chunks are issued on the same stream.
+        gdn_scan_fused_f32(conv_f32 + static_cast<size_t>(t) * conv_channels, conv_channels,
+                           alpha + t * n_heads, beta + t * n_heads, A_log, dt_bias, h_state,
+                           y + static_cast<size_t>(t) * inner, this_chunk, n_heads, head_dim_ssm,
+                           state_size, n_groups, stream, grouped_layout);
+        t += this_chunk;
+    }
+}
+
 // FP32-output variant — writes scan result as FP32 for downstream
 // FP32-input RMSNorm+Gate (avoids FP16 subnormal-truncation at ~6e-5).
 void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -19,6 +19,27 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
                         int n_heads, int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
                         int grouped_layout = 0);
 
+// EXPERIMENTAL — Phase 1b scaffolding for chunkwise SSD scan.
+// Same signature as `gdn_scan_fused_f32`. Will eventually implement the
+// parallel-within-chunk Mamba2 SSD algorithm (cf. Yang et al. 2024 "Parallel
+// Linear Attention With The Delta Rule" for the delta-rule adaptation; the
+// standard Mamba2 SSD assumes scalar decay and doesn't cover GDN's rank-1
+// `(I - β k k^T)` multiplicative update).
+//
+// Currently implemented as a chunk-iterating sequential wrapper around
+// `gdn_scan_fused_f32` — the FUNCTIONAL behavior is identical to the
+// monolithic call, validated by `tests/test_gdn.cu::ChunkBoundaryHandoff`.
+// Phase 1b.1 replaces the within-chunk sequential scan with the SSD matmul
+// algorithm; this scaffolding establishes the API + regression-gate plumbing.
+//
+// Design doc: docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
+// Phase 0 verdict: docs/plans/gdn_chunkwise_scan_design_2026_05_23.md →
+// PROCEED (latency-bound, 5.47 % mem + 5.47 % compute at peak).
+void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                            const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
+                            int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                            cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0);
+
 // Fused RMSNormGated + SiLU: y = rmsnorm(y) * silu(gate)
 // Processes all tokens × heads in one launch.
 void gdn_rmsnorm_gated_silu(half* y, const half* gate, const half* weight, float eps, int n_tokens,

--- a/tests/test_gdn.cu
+++ b/tests/test_gdn.cu
@@ -455,16 +455,57 @@ TEST(GDNScanTest, ChunkBoundaryHandoff) {
     EXPECT_LT(max_diff_chunk2, 1e-3f);
     EXPECT_LT(max_diff_state, 1e-5f);
 
+    // === Run C: gdn_scan_chunkwise_f32 — the Phase 1b scaffolding ===
+    // Currently a chunk-iterating sequential wrapper. Once Phase 1b.1 lands
+    // the real SSD matmul kernel, this same test catches any deviation.
+    float* d_state_cw;
+    half* d_y_cw;
+    cudaMalloc(&d_state_cw, state_floats * sizeof(float));
+    cudaMalloc(&d_y_cw, n_tok * inner * sizeof(half));
+    cudaMemset(d_state_cw, 0, state_floats * sizeof(float));
+    gdn_scan_chunkwise_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state_cw, d_y_cw, n_tok,
+                           n_heads, head_dim, state_size, n_groups, nullptr,
+                           /*chunk_size=*/chunk, /*grouped_layout=*/0);
+    cudaDeviceSynchronize();
+
+    std::vector<half> y_cw(n_tok * inner);
+    std::vector<float> state_cw_host(state_floats);
+    cudaMemcpy(y_cw.data(), d_y_cw, n_tok * inner * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(state_cw_host.data(), d_state_cw, state_floats * sizeof(float), cudaMemcpyDeviceToHost);
+
+    float max_diff_cw_y = 0;
+    for (int i = 0; i < n_tok * inner; i++) {
+        float d = std::abs(__half2float(y_full[i]) - __half2float(y_cw[i]));
+        if (d > max_diff_cw_y)
+            max_diff_cw_y = d;
+    }
+    float max_diff_cw_state = 0;
+    for (int i = 0; i < state_floats; i++) {
+        float d = std::abs(state_full[i] - state_cw_host[i]);
+        if (d > max_diff_cw_state)
+            max_diff_cw_state = d;
+    }
+    std::printf("  ChunkBoundaryHandoff: max_diff Y_chunkwise = %.6e\n", max_diff_cw_y);
+    std::printf("  ChunkBoundaryHandoff: max_diff state_chunkwise = %.6e\n", max_diff_cw_state);
+    // Same tolerance budgets as Run B (chunkwise scaffold is a chunk-iterating
+    // wrapper around gdn_scan_fused_f32, so for now this should also be bit-
+    // exact 0.0; once Phase 1b.1 ships the SSD matmul kernel, FMA-order
+    // differences may push the FP16 output toward the 1e-3 budget).
+    EXPECT_LT(max_diff_cw_y, 1e-3f);
+    EXPECT_LT(max_diff_cw_state, 1e-5f);
+
     cudaFree(d_conv);
     cudaFree(d_A);
     cudaFree(d_dt);
     cudaFree(d_state_full);
     cudaFree(d_state_mid);
+    cudaFree(d_state_cw);
     cudaFree(d_alpha);
     cudaFree(d_beta);
     cudaFree(d_y_full);
     cudaFree(d_y_chunk1);
     cudaFree(d_y_chunk2);
+    cudaFree(d_y_cw);
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

Phase 1b scaffolding for \`docs/plans/gdn_chunkwise_scan_design_2026_05_23.md\`. Adds the \`gdn_scan_chunkwise_f32\` host function and extends \`ChunkBoundaryHandoff\` to validate it.

**Currently a chunk-iterating sequential wrapper** around \`gdn_scan_fused_f32\` — functionally identical to the monolithic call. The existing kernel handles cross-chunk state handoff correctly (proved by #385), so iterating it across chunks produces bit-exact identical output.

**Phase 1b.1** (multi-week algorithmic work) replaces the per-chunk \`gdn_scan_fused_f32\` call with a parallel-within-chunk Mamba2 SSD matmul kernel. The scaffolding establishes:

1. **API surface** — \`chunk_size\` parameter (default 64 = Mamba2 paper's SSD block size), dispatch path ready
2. **Test surface** — Run C in \`ChunkBoundaryHandoff\`. Validates the wrapper produces identical Y and final H state. Bit-exact today; when 1b.1 lands, FMA-order changes may push \`Y_chunkwise\` toward the 1e-3 FP16 budget
3. **Reference pointer** for delta-rule parallel scan: Yang et al. 2024 "Parallel Linear Attention With The Delta Rule"

**Test results** on the sequential-wrapper implementation:

| Check | max_diff |
|---|---:|
| Y_chunk1 (existing) | 0.000000e+00 |
| Y_chunk2 (existing) | 0.000000e+00 |
| state (existing) | 0.000000e+00 |
| **Y_chunkwise (new)** | **0.000000e+00** |
| **state_chunkwise (new)** | **0.000000e+00** |

## Pipeline state

- ✅ Phase 0: ncu PROCEED verdict (latency-bound, 5.47% mem + 5.47% compute)
- ✅ Phase 1a (#385): regression gate test
- ✅ Phase 1b scaffolding (this PR)
- ⏳ Phase 1b.1: actual SSD matmul kernel implementation (multi-week)
- ⏳ Phase 2-4: production dispatch, NIAH validation, ship

## Why scaffolding now, kernel later

The delta-rule recurrence \`H[t] = g (I - β k k^T) H[t-1] + β k v^T\` has a rank-1 multiplicative update per token. The standard Mamba2 SSD algorithm assumes scalar decay and doesn't directly apply. The Yang 2024 paper covers the delta-rule case via WY-representation tricks for the matrix product chain — that's the multi-week implementation work that this PR sets up the test + dispatch surface for.

## Test plan

- [x] \`GDNScanTest.ChunkBoundaryHandoff\` passes with all 5 sub-checks at \`max_diff = 0.0\`
- [x] No regression in other GDN tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)