### PR TITLE
feat(gdn): Phase 1b.1 — standalone chunkwise SSD scan prototype

### DIFF
--- a/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
+++ b/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
@@ -95,13 +95,26 @@ Both memory AND compute at 5.47 % is the **latency-bound signature** — the ker
 
 **Result**: bit-exact pass (`max_diff Y_chunkwise = 0.0`, `max_diff state_chunkwise = 0.0`). API surface ready for Phase 1b.1 to drop in the real SSD kernel.
 
-### Phase 1b.1 — Standalone CUDA SSD prototype (3-5 days) ⏳ PENDING
+### Phase 1b.1 — Standalone CUDA SSD prototype ✅ DONE 2026-05-23
 
-- [ ] Standalone CUDA prototype of the chunkwise SSD algorithm at chunk_size=64
-- [ ] Pure FP32 first (no NVFP4/FP8 quantisation), correctness reference
-- [ ] Bit-near-equivalent (within tolerance budget set by Phase 1a) output vs `gdn_scan_fused_kernel` at chunk_size=64 boundary
-- [ ] Microbench: compare per-token throughput on the standalone kernel
-- [ ] **Reference**: Yang et al. 2024 "Parallel Linear Attention With The Delta Rule" — the standard Mamba2 SSD assumes scalar decay and doesn't cover GDN's rank-1 `(I - β k k^T)` multiplicative update. The Yang paper covers the delta-rule via WY-representation tricks for the matrix product chain.
+- [x] Standalone CUDA prototype of the chunkwise SSD algorithm at chunk_size=64
+- [x] Pure FP32 first (no NVFP4/FP8 quantisation), correctness reference
+- [x] Bit-near-equivalent (within tolerance budget set by Phase 1a) output vs `gdn_scan_fused_kernel` at chunk_size=64 boundary
+- [x] Microbench: compare per-token throughput on the standalone kernel
+- [x] **Reference**: Yang et al. 2024 "Parallel Linear Attention With The Delta Rule" — the standard Mamba2 SSD assumes scalar decay and doesn't cover GDN's rank-1 `(I - β k k^T)` multiplicative update. The Yang paper covers the delta-rule via WY-representation tricks for the matrix product chain.
+
+**Result**: New kernel `gdn_scan_chunkwise_kernel<HD, SS, CHUNK>` in `src/compute/gdn.cu` instantiated for HD=SS=128, CHUNK=64 (Qwen 3.5 / 3.6 GDN shape) and HD=SS=64, CHUNK=64. Dispatched from `gdn_scan_chunkwise_f32` when `chunk_size == 64` and `n_tokens >= 64`; falls through to the chunk-iterating wrapper otherwise. The structural change vs `gdn_scan_fused_kernel`: all CHUNK tokens' raw K, Q are loaded into shared memory upfront (Phase 1), L2-normalised in shared memory (Phase 2), then consumed by the sequential delta-rule sweep (Phase 3). The chunk-cached layout is the prerequisite for Phase 2's WY-rep parallel matmul.
+
+**Numerics**: bit-exact (`max_diff_y = 0.0`, `max_diff_state = 0.0`) vs the monolithic `gdn_scan_fused_f32` on the new test `GDNScanTest.ChunkwiseProtoMatchesFused` (n_tok=128 across 2 chunks of 64, HD=SS=128). Well inside the FP16 1e-3 / FP32 1e-5 budgets set by Phase 1a.
+
+**Microbench (n_tok=4096, n_heads=32, HD=SS=128, n_groups=16, RTX 5090 sm_120, 20 reps, gated on `IMP_GDN_MICROBENCH=1`)**:
+- `gdn_scan_fused_f32` (sequential):      6.602 ms / 4096 tok = **1.612 µs/token**
+- `gdn_scan_chunkwise_f32` (Phase 1b.1):  5.601 ms / 4096 tok = **1.367 µs/token**
+- Ratio: **0.848× wall** = **+15.2 % throughput** on the GDN scan kernel alone.
+
+The +15 % win is structural and comes for free with Phase 1b.1 — caching K, Q in shared memory eliminates redundant per-token global-memory loads of K (SS=128 floats) and Q (SS=128 floats) for every token of the chunk. Phase 2's WY-rep parallel matmul replaces the still-sequential delta-rule sweep on top of this; the design doc's +20-30 % prefill wall target is the combined ceiling.
+
+Code: `gdn_scan_chunkwise_kernel<HD, SS, CHUNK>` in `src/compute/gdn.cu` (under "Phase 1b.1 — Standalone chunkwise SSD scan prototype"); dispatch in `gdn_scan_chunkwise_f32`; tests `ChunkwiseProtoMatchesFused` + `ChunkwiseProtoMicrobench` in `tests/test_gdn.cu`.
 
 ### Phase 2 — Production kernel integration (5-7 days) ⏳ PENDING
 

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -183,6 +183,182 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_fused_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// Phase 1b.1 — Standalone chunkwise SSD scan prototype.
+//
+// Structural prototype for the Mamba2 SSD (Structured State-space Duality)
+// algorithm adapted for the GDN delta rule. Same numerical math as
+// `gdn_scan_fused_kernel`, but reorganised into per-chunk passes that cache
+// all CHUNK tokens' normalised K and Q in shared memory upfront, then sweep
+// the within-chunk delta-rule update.
+//
+// Phase 2 will replace the sequential within-chunk loop with the WY-rep
+// parallel matmul update (Yang et al. 2024, "Parallel Linear Attention With
+// The Delta Rule"). The chunk-cached K, Q layout established here is the
+// prerequisite — both Q · K^T (chunk-internal masked-attention) and the
+// cumulative decay propagation need all CHUNK tokens' K, Q resident at once.
+//
+// Per-block shared memory:
+//   s_k[CHUNK * SS]  — normalised K, all tokens in chunk
+//   s_q[CHUNK * SS]  — normalised Q, all tokens in chunk
+//   s_reduce[HD]     — block-reduction scratch (reused per L2 norm)
+//
+// At HD=SS=128, CHUNK=64 this is 2 * 64 * 128 * 4 + 128 * 4 = 65 KiB,
+// requiring the dynamic shared-memory opt-in (cudaFuncAttributeMaxDynamicShared
+// MemorySize). Host launcher sets it once.
+//
+// Grid:  (n_heads)              — one block per head
+// Block: (HD)                   — typically 128 threads
+// ---------------------------------------------------------------------------
+template <int HD, int SS, int CHUNK>
+__global__ void __launch_bounds__(HD, 1) gdn_scan_chunkwise_kernel(
+    const float* __restrict__ conv_f32,  // [n_tokens, conv_channels] FP32
+    const half* __restrict__ alpha_all,  // [n_tokens, n_heads] FP16
+    const half* __restrict__ beta_all,   // [n_tokens, n_heads] FP16
+    const float* __restrict__ A_log,     // [n_heads] FP32
+    const float* __restrict__ dt_bias,   // [n_heads] FP32
+    float* __restrict__ h_state,         // [n_heads, SS, HD] FP32
+    half* __restrict__ y_out,            // [n_tokens, n_heads * HD] FP16
+    int n_tokens, int n_heads, int n_groups, int conv_channels, int grouped_layout) {
+    const int h = blockIdx.x;
+    if (h >= n_heads)
+        return;
+    const int d = threadIdx.x;
+
+    const int g = grouped_layout ? (h / (n_heads / n_groups)) : (h % n_groups);
+    const int inner = n_heads * HD;
+    const int BC_size = n_groups * SS;
+    const float scale = rsqrtf(static_cast<float>(HD));
+
+    const float A_h = A_log[h];
+    const float dtb_h = dt_bias[h];
+
+    // State in registers (one column per thread).
+    float H_reg[SS];
+    {
+        const float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
+#pragma unroll
+        for (int s = 0; s < SS; s++)
+            H_reg[s] = H_col[s * HD];
+    }
+
+    extern __shared__ float smem[];
+    float* s_k = smem;                               // [CHUNK * SS]
+    float* s_q = smem + CHUNK * SS;                  // [CHUNK * SS]
+    float* s_reduce = smem + 2 * CHUNK * SS;         // [HD]
+
+    int t_chunk_start = 0;
+    while (t_chunk_start < n_tokens) {
+        const int L = (t_chunk_start + CHUNK <= n_tokens) ? CHUNK : (n_tokens - t_chunk_start);
+
+        // -------------------------------------------------------------------
+        // Phase 1: Load this chunk's K, Q (raw) into shared memory.
+        // Each thread d stores one element per token, looping over tokens.
+        // -------------------------------------------------------------------
+        if (d < SS) {
+            for (int t_local = 0; t_local < L; t_local++) {
+                const int t_global = t_chunk_start + t_local;
+                const float* row = conv_f32 + static_cast<size_t>(t_global) * conv_channels;
+                s_q[t_local * SS + d] = row[g * SS + d];
+                s_k[t_local * SS + d] = row[BC_size + g * SS + d];
+            }
+        }
+        __syncthreads();
+
+        // -------------------------------------------------------------------
+        // Phase 2: L2-normalise K, Q for each token in the chunk.
+        // Per-token reduction (sequential across tokens, parallel across SS).
+        // Uses the SAME formula as gdn_scan_fused_kernel (rsqrt of max(sum_sq,
+        // 1e-12)) for bit-equivalent numerics.
+        // -------------------------------------------------------------------
+        for (int t_local = 0; t_local < L; t_local++) {
+            float* k_row = s_k + t_local * SS;
+            float* q_row = s_q + t_local * SS;
+
+            float k_sq = 0.0f, q_sq = 0.0f;
+            for (int i = d; i < SS; i += HD) {
+                k_sq += k_row[i] * k_row[i];
+                q_sq += q_row[i] * q_row[i];
+            }
+            s_reduce[d] = k_sq;
+            __syncthreads();
+            for (int stride = HD / 2; stride > 0; stride >>= 1) {
+                if (d < stride)
+                    s_reduce[d] += s_reduce[d + stride];
+                __syncthreads();
+            }
+            float k_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
+
+            s_reduce[d] = q_sq;
+            __syncthreads();
+            for (int stride = HD / 2; stride > 0; stride >>= 1) {
+                if (d < stride)
+                    s_reduce[d] += s_reduce[d + stride];
+                __syncthreads();
+            }
+            float q_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
+
+            if (d < SS) {
+                k_row[d] *= k_inv;
+                q_row[d] *= q_inv;
+            }
+            __syncthreads();
+        }
+
+        // -------------------------------------------------------------------
+        // Phase 3: Sequential per-token delta-rule update within chunk.
+        // Reads K̃, Q̃ from shared memory; same math as gdn_scan_fused_kernel.
+        // Phase 2 of the design doc replaces this loop with the WY-rep
+        // parallel matmul update.
+        // -------------------------------------------------------------------
+        for (int t_local = 0; t_local < L; t_local++) {
+            const int t_global = t_chunk_start + t_local;
+            const float* row = conv_f32 + static_cast<size_t>(t_global) * conv_channels;
+            const float* V_base = row + 2 * BC_size;
+            const float v_d = V_base[h * HD + d];
+
+            const float* k_row = s_k + t_local * SS;
+            const float* q_row = s_q + t_local * SS;
+
+            float alpha_h = __half2float(alpha_all[t_global * n_heads + h]);
+            float dt_val = alpha_h + dtb_h;
+            dt_val = (dt_val > 20.0f) ? dt_val : logf(1.0f + expf(dt_val));
+            const float g_t = expf(fmaxf(A_h * dt_val, -20.0f));
+
+            float beta_h = __half2float(beta_all[t_global * n_heads + h]);
+            beta_h = 1.0f / (1.0f + expf(-fmaxf(fminf(beta_h, 20.0f), -20.0f)));
+
+            float kv_d = 0.0f;
+#pragma unroll
+            for (int s = 0; s < SS; s++)
+                kv_d += H_reg[s] * k_row[s];
+
+            const float delta_d = (v_d - g_t * kv_d) * beta_h;
+
+            float y_partial = 0.0f;
+#pragma unroll
+            for (int s = 0; s < SS; s++) {
+                const float h_new = g_t * H_reg[s] + k_row[s] * delta_d;
+                H_reg[s] = h_new;
+                y_partial += h_new * q_row[s];
+            }
+
+            y_out[t_global * inner + h * HD + d] = __float2half(y_partial * scale);
+        }
+
+        t_chunk_start += L;
+        __syncthreads();  // Before re-using s_k / s_q for the next chunk.
+    }
+
+    // Write final state back to global memory.
+    {
+        float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
+#pragma unroll
+        for (int s = 0; s < SS; s++)
+            H_col[s * HD] = H_reg[s];
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Fused RMSNormGated + SiLU kernel.
 // Computes: y[t,h,:] = rmsnorm(y[t,h,:], weight) * silu(gate[t,h,:])
 //
@@ -334,20 +510,21 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
     }
 }
 
-// EXPERIMENTAL — Phase 1b scaffolding for chunkwise SSD scan.
-// Current implementation: chunk-iterating sequential wrapper around
-// `gdn_scan_fused_f32`. Functionally identical to the monolithic call (the
-// kernel handles the H state in/out cleanly across multiple invocations,
-// validated by tests/test_gdn.cu::ChunkBoundaryHandoff). Phase 1b.1 replaces
-// the per-chunk call with a parallel-within-chunk SSD matmul kernel.
+// Phase 1b.1 — Standalone chunkwise SSD scan host launcher.
 //
-// The chunk_size parameter is currently informational (default 64 = Mamba2
-// paper's typical SSD block size). When the SSD kernel ships, it will tile
-// the within-chunk math at this block size.
+// Dispatches to `gdn_scan_chunkwise_kernel<HD, SS, CHUNK>` for the supported
+// (HD, SS, CHUNK) combinations and falls back to a chunk-iterating wrapper
+// around `gdn_scan_fused_f32` otherwise. The chunkwise kernel produces output
+// bit-near-equivalent to `gdn_scan_fused_kernel` (FP16 1e-3, FP32 state 1e-5
+// tolerances per Phase 1a), validated by ChunkBoundaryHandoff +
+// ChunkwiseProtoMatchesFused tests.
 //
-// Reference for delta-rule parallel scan: Yang et al. 2024, "Parallel Linear
-// Attention With The Delta Rule" (the standard Mamba2 SSD assumes scalar
-// decay and doesn't cover GDN's rank-1 (I - β k k^T) multiplicative update).
+// Phase 2 will replace the within-chunk sequential delta-rule loop in
+// `gdn_scan_chunkwise_kernel` with the WY-rep parallel matmul update (Yang
+// et al. 2024, "Parallel Linear Attention With The Delta Rule"). Until then
+// the prototype is structural-only and gives no perf win over the sequential
+// fused kernel; it establishes the chunked shared-memory layout that the
+// SSD matmul will need.
 //
 // Phase 0 verdict (ncu): docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
 //   Memory 5.47 % peak / Compute 5.47 % peak / Achieved Occ 8.33 % → PROCEED.
@@ -355,20 +532,48 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
                             const float* A_log, const float* dt_bias, float* h_state, half* y,
                             int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
                             cudaStream_t stream, int chunk_size, int grouped_layout) {
-    // Effective chunk size: clamp to [1, n_tokens] so a single-token decode
-    // path falls through cleanly to one call with the same args.
     if (chunk_size <= 0)
         chunk_size = 64;
     if (chunk_size > n_tokens)
         chunk_size = n_tokens;
 
+    // Direct chunkwise kernel dispatch for the supported (HD, SS, CHUNK) shapes.
+    // Phase 1b.1 covers chunk_size==64 + HD==SS in {128, 64}, the production
+    // GDN shapes (Qwen 3.5 / 3.6). Other sizes fall through to the wrapper.
+    if (chunk_size == 64 && n_tokens >= 64) {
+        if (head_dim_ssm == 128 && state_size == 128) {
+            constexpr int HD = 128, SS = 128, CHUNK = 64;
+            const size_t smem = (2 * CHUNK * SS + HD) * sizeof(float);
+            static bool attr_set = false;
+            if (!attr_set) {
+                cudaFuncSetAttribute(reinterpret_cast<const void*>(&gdn_scan_chunkwise_kernel<HD, SS, CHUNK>),
+                                     cudaFuncAttributeMaxDynamicSharedMemorySize, 96 * 1024);
+                attr_set = true;
+            }
+            gdn_scan_chunkwise_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
+                conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
+                grouped_layout);
+            return;
+        }
+        if (head_dim_ssm == 64 && state_size == 64) {
+            constexpr int HD = 64, SS = 64, CHUNK = 64;
+            const size_t smem = (2 * CHUNK * SS + HD) * sizeof(float);
+            // 2 * 64 * 64 * 4 + 64 * 4 = 32 KiB + 256 B — within default static cap.
+            gdn_scan_chunkwise_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
+                conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
+                grouped_layout);
+            return;
+        }
+    }
+
+    // Fallback: chunk-iterating wrapper around the sequential fused kernel.
+    // Used for non-default chunk sizes, unsupported HD/SS combos, and the
+    // tail-chunk path where n_tokens < chunk_size. h_state mutates in-place
+    // across the per-chunk calls; same-stream submission keeps ordering.
     const int inner = n_heads * head_dim_ssm;
     int t = 0;
     while (t < n_tokens) {
         const int this_chunk = (t + chunk_size <= n_tokens) ? chunk_size : (n_tokens - t);
-        // h_state mutates in-place across chunks — kernel reads it as the
-        // entry state and writes the chunk-end state back. No additional
-        // host-side sync needed; the chunks are issued on the same stream.
         gdn_scan_fused_f32(conv_f32 + static_cast<size_t>(t) * conv_channels, conv_channels,
                            alpha + t * n_heads, beta + t * n_heads, A_log, dt_bias, h_state,
                            y + static_cast<size_t>(t) * inner, this_chunk, n_heads, head_dim_ssm,

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -209,7 +209,7 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_fused_kernel(
 // Grid:  (n_heads)              — one block per head
 // Block: (HD)                   — typically 128 threads
 // ---------------------------------------------------------------------------
-template <int HD, int SS, int CHUNK>
+template <int HD, int SS, int CHUNK, typename YOut>
 __global__ void __launch_bounds__(HD, 1) gdn_scan_chunkwise_kernel(
     const float* __restrict__ conv_f32,  // [n_tokens, conv_channels] FP32
     const half* __restrict__ alpha_all,  // [n_tokens, n_heads] FP16
@@ -217,7 +217,7 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_chunkwise_kernel(
     const float* __restrict__ A_log,     // [n_heads] FP32
     const float* __restrict__ dt_bias,   // [n_heads] FP32
     float* __restrict__ h_state,         // [n_heads, SS, HD] FP32
-    half* __restrict__ y_out,            // [n_tokens, n_heads * HD] FP16
+    YOut* __restrict__ y_out,            // [n_tokens, n_heads * HD] FP16 or FP32
     int n_tokens, int n_heads, int n_groups, int conv_channels, int grouped_layout) {
     const int h = blockIdx.x;
     if (h >= n_heads)
@@ -342,7 +342,12 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_chunkwise_kernel(
                 y_partial += h_new * q_row[s];
             }
 
-            y_out[t_global * inner + h * HD + d] = __float2half(y_partial * scale);
+            const float out_val = y_partial * scale;
+            if constexpr (std::is_same_v<YOut, float>) {
+                y_out[t_global * inner + h * HD + d] = out_val;
+            } else {
+                y_out[t_global * inner + h * HD + d] = __float2half(out_val);
+            }
         }
 
         t_chunk_start += L;
@@ -528,10 +533,16 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
 //
 // Phase 0 verdict (ncu): docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
 //   Memory 5.47 % peak / Compute 5.47 % peak / Achieved Occ 8.33 % → PROCEED.
-void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
-                            const float* A_log, const float* dt_bias, float* h_state, half* y,
-                            int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            cudaStream_t stream, int chunk_size, int grouped_layout) {
+// Templated dispatcher used by both gdn_scan_chunkwise_f32 (YOut=half) and
+// gdn_scan_chunkwise_fp32out (YOut=float). Keeps the kernel-template + smem
+// + opt-in logic in one place — the two host launchers only differ in the
+// y_out element type and the fallback they use for unsupported shapes.
+template <typename YOut, typename FusedFallback>
+static void gdn_scan_chunkwise_dispatch(const float* conv_f32, int conv_channels, const half* alpha,
+                                        const half* beta, const float* A_log, const float* dt_bias,
+                                        float* h_state, YOut* y, int n_tokens, int n_heads, int head_dim_ssm,
+                                        int state_size, int n_groups, cudaStream_t stream, int chunk_size,
+                                        int grouped_layout, FusedFallback fused) {
     if (chunk_size <= 0)
         chunk_size = 64;
     if (chunk_size > n_tokens)
@@ -546,11 +557,12 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
             const size_t smem = (2 * CHUNK * SS + HD) * sizeof(float);
             static bool attr_set = false;
             if (!attr_set) {
-                cudaFuncSetAttribute(reinterpret_cast<const void*>(&gdn_scan_chunkwise_kernel<HD, SS, CHUNK>),
-                                     cudaFuncAttributeMaxDynamicSharedMemorySize, 96 * 1024);
+                cudaFuncSetAttribute(
+                    reinterpret_cast<const void*>(&gdn_scan_chunkwise_kernel<HD, SS, CHUNK, YOut>),
+                    cudaFuncAttributeMaxDynamicSharedMemorySize, 96 * 1024);
                 attr_set = true;
             }
-            gdn_scan_chunkwise_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
+            gdn_scan_chunkwise_kernel<HD, SS, CHUNK, YOut><<<n_heads, HD, smem, stream>>>(
                 conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
                 grouped_layout);
             return;
@@ -559,7 +571,7 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
             constexpr int HD = 64, SS = 64, CHUNK = 64;
             const size_t smem = (2 * CHUNK * SS + HD) * sizeof(float);
             // 2 * 64 * 64 * 4 + 64 * 4 = 32 KiB + 256 B — within default static cap.
-            gdn_scan_chunkwise_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
+            gdn_scan_chunkwise_kernel<HD, SS, CHUNK, YOut><<<n_heads, HD, smem, stream>>>(
                 conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
                 grouped_layout);
             return;
@@ -574,12 +586,44 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
     int t = 0;
     while (t < n_tokens) {
         const int this_chunk = (t + chunk_size <= n_tokens) ? chunk_size : (n_tokens - t);
-        gdn_scan_fused_f32(conv_f32 + static_cast<size_t>(t) * conv_channels, conv_channels,
-                           alpha + t * n_heads, beta + t * n_heads, A_log, dt_bias, h_state,
-                           y + static_cast<size_t>(t) * inner, this_chunk, n_heads, head_dim_ssm,
-                           state_size, n_groups, stream, grouped_layout);
+        fused(conv_f32 + static_cast<size_t>(t) * conv_channels, alpha + t * n_heads, beta + t * n_heads,
+              h_state, y + static_cast<size_t>(t) * inner, this_chunk);
         t += this_chunk;
     }
+}
+
+void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                            const float* A_log, const float* dt_bias, float* h_state, half* y,
+                            int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                            cudaStream_t stream, int chunk_size, int grouped_layout) {
+    gdn_scan_chunkwise_dispatch<half>(
+        conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, head_dim_ssm,
+        state_size, n_groups, stream, chunk_size, grouped_layout,
+        [&](const float* row_conv, const half* row_alpha, const half* row_beta, float* h_state_, half* y_,
+            int n_tok_chunk) {
+            gdn_scan_fused_f32(row_conv, conv_channels, row_alpha, row_beta, A_log, dt_bias, h_state_, y_,
+                               n_tok_chunk, n_heads, head_dim_ssm, state_size, n_groups, stream,
+                               grouped_layout);
+        });
+}
+
+// FP32-output chunkwise launcher. Mirrors `gdn_scan_chunkwise_f32` for the
+// `gdn.fp32_scan` path where the scan output must stay FP32 all the way
+// through RMSNorm+Gate+SiLU (Qwen 3.6 L0 sign-flip root cause; see comment
+// at executor_ssm_gdn.cu:483-486).
+void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                                const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
+                                int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                                cudaStream_t stream, int chunk_size, int grouped_layout) {
+    gdn_scan_chunkwise_dispatch<float>(
+        conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens, n_heads, head_dim_ssm,
+        state_size, n_groups, stream, chunk_size, grouped_layout,
+        [&](const float* row_conv, const half* row_alpha, const half* row_beta, float* h_state_, float* y_,
+            int n_tok_chunk) {
+            gdn_scan_fused_fp32out(row_conv, conv_channels, row_alpha, row_beta, A_log, dt_bias, h_state_, y_,
+                                   n_tok_chunk, n_heads, head_dim_ssm, state_size, n_groups, stream,
+                                   grouped_layout);
+        });
 }
 
 // FP32-output variant — writes scan result as FP32 for downstream

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -40,6 +40,14 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
                             int n_heads, int head_dim_ssm, int state_size, int n_groups,
                             cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0);
 
+// FP32-output chunkwise variant — matches `gdn_scan_fused_fp32out`'s contract.
+// Same chunked shared-memory layout as `gdn_scan_chunkwise_f32`, output kept
+// in FP32 for the gdn.fp32_scan path (RMSNorm+Gate+SiLU pipeline).
+void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                                const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
+                                int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                                cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0);
+
 // Fused RMSNormGated + SiLU: y = rmsnorm(y) * silu(gate)
 // Processes all tokens × heads in one launch.
 void gdn_rmsnorm_gated_silu(half* y, const half* gate, const half* weight, float eps, int n_tokens,

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -474,6 +474,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         //   FP16 subnormal truncation (~6e-5) breaks RMS for near-zero heads on
         //   models with sparse scan activations (Qwen 3.6 L1 head 0).
         const bool use_ref = runtime_config().gdn.ref_kernel;
+        const bool use_chunkwise = runtime_config().gdn.chunkwise_scan && !use_ref;
         if (use_fp32_scan) {
             // Layout in conv_f32 tail:
             //   [n*conv_channels)                : conv_f32 (done)
@@ -485,11 +486,22 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
             float* y_fp32 = conv_f32 + static_cast<size_t>(n) * conv_channels;
             float* y_fp32_postnorm = y_fp32 + static_cast<size_t>(n) * n_heads * head_dim_ssm;
             const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
-            gdn_scan_fused_fp32out(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
-                                   static_cast<const half*>(beta_proj_out.data),
-                                   static_cast<const float*>(ly.ssm_a.data),
-                                   static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
-                                   y_fp32, n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl);
+            if (use_chunkwise) {
+                gdn_scan_chunkwise_fp32out(conv_f32, conv_channels,
+                                           static_cast<const half*>(alpha_proj_out.data),
+                                           static_cast<const half*>(beta_proj_out.data),
+                                           static_cast<const float*>(ly.ssm_a.data),
+                                           static_cast<const float*>(ly.ssm_dt_b.data),
+                                           static_cast<float*>(h_st), y_fp32, n, n_heads, head_dim_ssm, ssize,
+                                           n_groups, stream, /*chunk_size=*/64, gl);
+            } else {
+                gdn_scan_fused_fp32out(conv_f32, conv_channels,
+                                       static_cast<const half*>(alpha_proj_out.data),
+                                       static_cast<const half*>(beta_proj_out.data),
+                                       static_cast<const float*>(ly.ssm_a.data),
+                                       static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
+                                       y_fp32, n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl);
+            }
             // FP32-in, FP32-out RMSNorm+Gate+SiLU: preserves precision for the
             // ssm_out matmul. The FP32→FP16 copy below is REQUIRED, not optional
             // — the !use_fp32_out path of ssm_out reads y_buf as FP16 input. The
@@ -517,12 +529,22 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                    stream, gl);
         } else {
             const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
-            gdn_scan_fused_f32(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
-                               static_cast<const half*>(beta_proj_out.data),
-                               static_cast<const float*>(ly.ssm_a.data),
-                               static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
-                               static_cast<half*>(y_buf.data), n, n_heads, head_dim_ssm, ssize, n_groups,
-                               stream, gl);
+            if (use_chunkwise) {
+                gdn_scan_chunkwise_f32(conv_f32, conv_channels,
+                                       static_cast<const half*>(alpha_proj_out.data),
+                                       static_cast<const half*>(beta_proj_out.data),
+                                       static_cast<const float*>(ly.ssm_a.data),
+                                       static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
+                                       static_cast<half*>(y_buf.data), n, n_heads, head_dim_ssm, ssize,
+                                       n_groups, stream, /*chunk_size=*/64, gl);
+            } else {
+                gdn_scan_fused_f32(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
+                                   static_cast<const half*>(beta_proj_out.data),
+                                   static_cast<const float*>(ly.ssm_a.data),
+                                   static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
+                                   static_cast<half*>(y_buf.data), n, n_heads, head_dim_ssm, ssize, n_groups,
+                                   stream, gl);
+            }
         }
     }
 

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -184,6 +184,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gdn.ref_kernel = parse_bool(val, cfg.gdn.ref_kernel);
     else if (eq("gdn.vhead_reorder"))
         cfg.gdn.vhead_reorder = parse_bool(val, cfg.gdn.vhead_reorder);
+    else if (eq("gdn.chunkwise_scan"))
+        cfg.gdn.chunkwise_scan = parse_bool(val, cfg.gdn.chunkwise_scan);
 
     // [gemm]
     else if (eq("gemm.no_dp4a"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -160,6 +160,17 @@ struct RuntimeConfig {
         float norm_eps_override = 0.0f;  // 0 = use model default
         bool ref_kernel = false;
         bool vhead_reorder = false;
+        // Phase 1b.1 of the GDN chunkwise SSD scan refactor
+        // (docs/plans/gdn_chunkwise_scan_design_2026_05_23.md). When true,
+        // the executor dispatches GDN scan through
+        // `gdn_scan_chunkwise_{f32,fp32out}` (chunk-cached K/Q in shared
+        // memory) instead of the per-token-loop `gdn_scan_fused_{f32,fp32out}`.
+        // Bit-near-equivalent output (FP16 1e-3 / FP32 1e-5 tolerances per
+        // Phase 1a); microbench shows +15.2 % on the GDN scan kernel alone
+        // at n_tok=4096. Off by default until Phase 2's WY-rep parallel
+        // matmul lands on top — the structural prereq is shipped, the
+        // algorithmic SSD win is Phase 2.
+        bool chunkwise_scan = false;
         // Override gated-DeltaNet weight layout. Legacy env: IMP_GDN_LAYOUT.
         std::string layout_override;
     } gdn;

--- a/tests/test_gdn.cu
+++ b/tests/test_gdn.cu
@@ -509,6 +509,226 @@ TEST(GDNScanTest, ChunkBoundaryHandoff) {
 }
 
 // =========================================================================
+// Test 3c: Chunkwise SSD prototype matches sequential fused scan
+// -------------------------------------------------------------------------
+// Phase 1b.1 of the chunkwise SSD scan refactor (docs/plans/gdn_chunkwise_
+// scan_design_2026_05_23.md). Exercises the chunked-shared-memory kernel
+// path inside gdn_scan_chunkwise_f32 (chunk_size=64), which is structurally
+// distinct from the existing per-token sequential kernel.
+//
+// Phase 1b's wrapper path (chunk_size != 64) is covered by ChunkBoundary
+// Handoff above. This test specifically validates the new
+// gdn_scan_chunkwise_kernel<128, 128, 64> at the production GDN shape
+// (Qwen 3.5 / 3.6: HD=SS=128). Tolerance budgets from Phase 1a:
+//   - FP16 y:   1e-3 max-abs-diff
+//   - FP32 H state: 1e-5 max-abs-diff
+// =========================================================================
+
+TEST(GDNScanTest, ChunkwiseProtoMatchesFused) {
+    constexpr int n_heads = 4, head_dim = 128, state_size = 128, n_groups = 4;
+    constexpr int inner = n_heads * head_dim, BC_size = n_groups * state_size;
+    constexpr int conv_channels = 2 * BC_size + inner;
+    constexpr int n_tok = 128;  // 2 chunks of 64 — exercises chunk-loop + boundary
+    constexpr int chunk_size = 64;
+
+    srand(7);
+    std::vector<float> conv_f32(n_tok * conv_channels);
+    std::vector<float> all_alpha(n_tok * n_heads), all_beta(n_tok * n_heads);
+    std::vector<float> h_A_log(n_heads, -0.5f), h_dt_bias(n_heads, 0.5f);
+    for (auto& v : conv_f32)
+        v = (rand() % 200 - 100) / 100.0f;
+    for (auto& v : all_alpha)
+        v = (rand() % 200 - 100) / 100.0f;
+    for (auto& v : all_beta)
+        v = (rand() % 200 - 100) / 100.0f;
+
+    std::vector<half> h_alpha_h(n_tok * n_heads), h_beta_h(n_tok * n_heads);
+    for (int i = 0; i < n_tok * n_heads; i++) {
+        h_alpha_h[i] = __float2half(all_alpha[i]);
+        h_beta_h[i] = __float2half(all_beta[i]);
+    }
+
+    const int state_floats = n_heads * state_size * head_dim;
+    float *d_conv, *d_A, *d_dt, *d_state_ref, *d_state_cw;
+    half *d_alpha, *d_beta, *d_y_ref, *d_y_cw;
+    cudaMalloc(&d_conv, n_tok * conv_channels * sizeof(float));
+    cudaMalloc(&d_A, n_heads * sizeof(float));
+    cudaMalloc(&d_dt, n_heads * sizeof(float));
+    cudaMalloc(&d_state_ref, state_floats * sizeof(float));
+    cudaMalloc(&d_state_cw, state_floats * sizeof(float));
+    cudaMalloc(&d_alpha, n_tok * n_heads * sizeof(half));
+    cudaMalloc(&d_beta, n_tok * n_heads * sizeof(half));
+    cudaMalloc(&d_y_ref, n_tok * inner * sizeof(half));
+    cudaMalloc(&d_y_cw, n_tok * inner * sizeof(half));
+
+    cudaMemcpy(d_conv, conv_f32.data(), n_tok * conv_channels * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_A, h_A_log.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_dt, h_dt_bias.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha, h_alpha_h.data(), n_tok * n_heads * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_beta, h_beta_h.data(), n_tok * n_heads * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_state_ref, 0, state_floats * sizeof(float));
+    cudaMemset(d_state_cw, 0, state_floats * sizeof(float));
+
+    // Reference: monolithic sequential fused scan.
+    gdn_scan_fused_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state_ref, d_y_ref, n_tok,
+                       n_heads, head_dim, state_size, n_groups, nullptr);
+    // Prototype: chunkwise SSD kernel (chunk_size=64 hits the new kernel path).
+    gdn_scan_chunkwise_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state_cw, d_y_cw, n_tok,
+                           n_heads, head_dim, state_size, n_groups, nullptr,
+                           /*chunk_size=*/chunk_size, /*grouped_layout=*/0);
+    cudaDeviceSynchronize();
+
+    std::vector<half> y_ref(n_tok * inner), y_cw(n_tok * inner);
+    std::vector<float> state_ref(state_floats), state_cw(state_floats);
+    cudaMemcpy(y_ref.data(), d_y_ref, n_tok * inner * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(y_cw.data(), d_y_cw, n_tok * inner * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(state_ref.data(), d_state_ref, state_floats * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(state_cw.data(), d_state_cw, state_floats * sizeof(float), cudaMemcpyDeviceToHost);
+
+    float max_diff_y = 0;
+    for (int i = 0; i < n_tok * inner; i++) {
+        float d = std::abs(__half2float(y_ref[i]) - __half2float(y_cw[i]));
+        if (d > max_diff_y)
+            max_diff_y = d;
+    }
+    float max_diff_state = 0;
+    for (int i = 0; i < state_floats; i++) {
+        float d = std::abs(state_ref[i] - state_cw[i]);
+        if (d > max_diff_state)
+            max_diff_state = d;
+    }
+
+    std::printf("\n  ChunkwiseProto: max_diff Y = %.6e\n", max_diff_y);
+    std::printf("  ChunkwiseProto: max_diff state = %.6e\n", max_diff_state);
+
+    // Phase 1a tolerance budgets.
+    EXPECT_LT(max_diff_y, 1e-3f);
+    EXPECT_LT(max_diff_state, 1e-5f);
+
+    cudaFree(d_conv);
+    cudaFree(d_A);
+    cudaFree(d_dt);
+    cudaFree(d_state_ref);
+    cudaFree(d_state_cw);
+    cudaFree(d_alpha);
+    cudaFree(d_beta);
+    cudaFree(d_y_ref);
+    cudaFree(d_y_cw);
+}
+
+// =========================================================================
+// Test 3d: Chunkwise prototype microbench (Phase 1b.1).
+// -------------------------------------------------------------------------
+// Times the chunkwise SSD prototype vs the sequential fused scan at the
+// Qwen 3.6 prefill shape (n_tokens=4096, n_heads=32, HD=SS=128, n_groups=16).
+// Gated behind IMP_GDN_MICROBENCH=1 because it's a perf probe, not a
+// correctness gate — only useful when explicitly comparing the two kernels.
+// =========================================================================
+
+TEST(GDNScanTest, ChunkwiseProtoMicrobench) {
+    if (!std::getenv("IMP_GDN_MICROBENCH")) {
+        GTEST_SKIP() << "Set IMP_GDN_MICROBENCH=1 to run the chunkwise perf probe";
+    }
+    constexpr int n_heads = 32, head_dim = 128, state_size = 128, n_groups = 16;
+    constexpr int inner = n_heads * head_dim, BC_size = n_groups * state_size;
+    constexpr int conv_channels = 2 * BC_size + inner;
+    constexpr int n_tok = 4096;
+    constexpr int chunk_size = 64;
+
+    srand(11);
+    std::vector<float> conv_f32(static_cast<size_t>(n_tok) * conv_channels);
+    std::vector<float> all_alpha(n_tok * n_heads), all_beta(n_tok * n_heads);
+    std::vector<float> h_A_log(n_heads, -0.5f), h_dt_bias(n_heads, 0.5f);
+    for (auto& v : conv_f32)
+        v = (rand() % 200 - 100) / 100.0f;
+    for (auto& v : all_alpha)
+        v = (rand() % 200 - 100) / 100.0f;
+    for (auto& v : all_beta)
+        v = (rand() % 200 - 100) / 100.0f;
+
+    std::vector<half> h_alpha_h(n_tok * n_heads), h_beta_h(n_tok * n_heads);
+    for (int i = 0; i < n_tok * n_heads; i++) {
+        h_alpha_h[i] = __float2half(all_alpha[i]);
+        h_beta_h[i] = __float2half(all_beta[i]);
+    }
+
+    const int state_floats = n_heads * state_size * head_dim;
+    float *d_conv, *d_A, *d_dt, *d_state;
+    half *d_alpha, *d_beta, *d_y;
+    cudaMalloc(&d_conv, static_cast<size_t>(n_tok) * conv_channels * sizeof(float));
+    cudaMalloc(&d_A, n_heads * sizeof(float));
+    cudaMalloc(&d_dt, n_heads * sizeof(float));
+    cudaMalloc(&d_state, state_floats * sizeof(float));
+    cudaMalloc(&d_alpha, n_tok * n_heads * sizeof(half));
+    cudaMalloc(&d_beta, n_tok * n_heads * sizeof(half));
+    cudaMalloc(&d_y, n_tok * inner * sizeof(half));
+
+    cudaMemcpy(d_conv, conv_f32.data(), static_cast<size_t>(n_tok) * conv_channels * sizeof(float),
+               cudaMemcpyHostToDevice);
+    cudaMemcpy(d_A, h_A_log.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_dt, h_dt_bias.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha, h_alpha_h.data(), n_tok * n_heads * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_beta, h_beta_h.data(), n_tok * n_heads * sizeof(half), cudaMemcpyHostToDevice);
+
+    cudaEvent_t e0, e1;
+    cudaEventCreate(&e0);
+    cudaEventCreate(&e1);
+
+    auto bench = [&](auto fn, const char* label, int reps = 20, int warmup = 3) {
+        for (int r = 0; r < warmup; r++) {
+            cudaMemset(d_state, 0, state_floats * sizeof(float));
+            fn();
+        }
+        cudaDeviceSynchronize();
+        float total_ms = 0;
+        for (int r = 0; r < reps; r++) {
+            cudaMemset(d_state, 0, state_floats * sizeof(float));
+            cudaDeviceSynchronize();
+            cudaEventRecord(e0);
+            fn();
+            cudaEventRecord(e1);
+            cudaEventSynchronize(e1);
+            float ms = 0;
+            cudaEventElapsedTime(&ms, e0, e1);
+            total_ms += ms;
+        }
+        float avg_ms = total_ms / reps;
+        float us_per_tok = avg_ms * 1000.0f / n_tok;
+        std::printf("  %s: %.3f ms avg over %d tokens = %.3f us/token (%d reps)\n", label, avg_ms, n_tok,
+                    us_per_tok, reps);
+        return avg_ms;
+    };
+
+    float ms_fused = bench(
+        [&]() {
+            gdn_scan_fused_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state, d_y, n_tok,
+                               n_heads, head_dim, state_size, n_groups, nullptr);
+        },
+        "gdn_scan_fused_f32 (sequential)");
+
+    float ms_chunkwise = bench(
+        [&]() {
+            gdn_scan_chunkwise_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state, d_y, n_tok,
+                                   n_heads, head_dim, state_size, n_groups, nullptr,
+                                   /*chunk_size=*/chunk_size, /*grouped_layout=*/0);
+        },
+        "gdn_scan_chunkwise_f32 (Phase 1b.1 proto)");
+
+    std::printf("  Ratio chunkwise/fused = %.3fx (prototype is structural, no SSD math yet)\n",
+                ms_chunkwise / ms_fused);
+
+    cudaEventDestroy(e0);
+    cudaEventDestroy(e1);
+    cudaFree(d_conv);
+    cudaFree(d_A);
+    cudaFree(d_dt);
+    cudaFree(d_state);
+    cudaFree(d_alpha);
+    cudaFree(d_beta);
+    cudaFree(d_y);
+}
+
+// =========================================================================
 // Test 4: Zero state + one token produces non-zero output
 // =========================================================================
 


### PR DESCRIPTION
## Summary

Closes Phase 1b.1 of `docs/plans/gdn_chunkwise_scan_design_2026_05_23.md` — the structural Mamba2 SSD chunkwise scan prototype adapted for the GDN delta rule.

- New `gdn_scan_chunkwise_kernel<HD, SS, CHUNK>` in `src/compute/gdn.cu`. Per-chunk: load all CHUNK tokens' K, Q into shared memory (Phase 1), L2-normalise in shared memory (Phase 2), then run the sequential delta-rule sweep reading from cache (Phase 3). State stays in registers across chunks.
- Dispatched from `gdn_scan_chunkwise_f32` when `chunk_size == 64` and `n_tokens >= 64`; falls through to the chunk-iterating wrapper otherwise. Instantiated for `HD=SS=128` (Qwen 3.5 / 3.6) and `HD=SS=64`. The 128/128 variant opts into 65 KiB dynamic shared memory via `cudaFuncSetAttribute`.
- New test `GDNScanTest.ChunkwiseProtoMatchesFused` (n_tok=128 across 2 chunks of 64): bit-exact (`max_diff_y = 0.0`, `max_diff_state = 0.0`) vs the monolithic `gdn_scan_fused_f32`. Well inside the FP16 1e-3 / FP32 1e-5 budgets set by Phase 1a.
- New microbench `GDNScanTest.ChunkwiseProtoMicrobench` (gated on `IMP_GDN_MICROBENCH=1`): **0.848× wall** (+15.2 % throughput) at n_tok=4096, n_heads=32, HD=SS=128, n_groups=16. The free +15 % comes from chunk-cached K, Q eliminating redundant per-token global-memory loads — Phase 2's WY-rep parallel matmul builds on top of this toward the design doc's +20-30 % ceiling.

Also marks Phase 0 / 1a / 1b scaffolding DONE in the plan doc (the scaffolding code landed via #385 / #386 but the doc status update was on a branch that never merged).

## Microbench raw

```
gdn_scan_fused_f32 (sequential):                 6.602 ms / 4096 tok = 1.612 us/tok
gdn_scan_chunkwise_f32 (Phase 1b.1 proto):       5.601 ms / 4096 tok = 1.367 us/tok
Ratio chunkwise/fused = 0.848x
```

(20 reps, RTX 5090 sm_120, in-container build via `imp:builder`.)

## Test plan

- [x] `test-moe-gdn --gtest_filter='GDNScanTest.*'` — 7 passed (1 skipped microbench)
- [x] `ChunkBoundaryHandoff` still bit-exact (`max_diff = 0.0` × 5)
- [x] `ChunkwiseProtoMatchesFused` bit-exact (`max_diff = 0.0` × 2)
- [x] `verify-fast` pre-push gate passed (verify fast: OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)