### PR TITLE
docs(plans): status banners for refuted/deferred Phase 0 spikes

### DIFF
--- a/docs/plans/gdn_scan_splitk_design_2026_05_23.md
+++ b/docs/plans/gdn_scan_splitk_design_2026_05_23.md
@@ -1,5 +1,7 @@
 # GDN Scan Split-K Refactor — Design Doc
-*2026-05-23 · multi-day design doc · not yet implemented*
+*2026-05-23 · multi-day design doc*
+
+**Status (2026-05-23): REFUTED at Phase 0.** `ncu --set full` confirmed Memory 17.57 %, Compute 3.95 %, Achieved Occupancy 7.85 % (vs theoretical 16.67 %) — the kernel is latency-bound, not HBM-bound. But the sync-overhead math kills the lever: 4× `cg::grid_group::sync()` × 30 layers = 600–1200 µs added vs ~90 µs realistic win = **~10× net negative**. DO NOT PROCEED to Phase 1. Refutation memo: `memory/gdn_scan_splitk_phase0_refuted_2026_05_23.md`. Algorithmic angle taken instead: chunkwise SSD scan (see `gdn_chunkwise_scan_design_2026_05_23.md`) — Phase 0 PROCEED, +15.2 % wall already achieved at Phase 1b.1, multi-phase ship plan active.
 
 ## Mission
 

--- a/docs/plans/kernel_fusion_rmsnorm_into_gemv_design_2026_05_23.md
+++ b/docs/plans/kernel_fusion_rmsnorm_into_gemv_design_2026_05_23.md
@@ -1,5 +1,11 @@
 # Kernel Fusion — rmsnorm into NVFP4 GEMV Hot Path
-*2026-05-23 · multi-day design doc · not yet implemented*
+*2026-05-23 · multi-day design doc*
+
+**Status (2026-05-23): REFUTED at Phase 0 (both paths).**
+- **Path A** (1-day dispatch swap to reuse existing `residual_add_rmsnorm`) — REFUTED: not a 1-day swap, actually a 3–5 day refactor across function contracts. The fused kernel writes `hidden += residual; out = rmsnorm(hidden)` but the current dataflow has `po` (post-output) and `r` (residual) flowing into SEPARATE downstream buffers. Memo: `memory/kernel_fusion_path_a_phase0_refuted_2026_05_23.md`.
+- **Path B** (fuse rmsnorm INTO the NVFP4 GEMV) — REFUTED: microbench at production hot-path M values shows the fused kernel WINS -40 to -51 % at small M but REGRESSES +23 % at M=6144 (Qwen3.6 attn QKV). Redundant rmsnorm work at hot path = +112 % overhead vs the 5 % design-doc gate (refuted by 22×). Memo: `memory/kernel_fusion_path_b_phase0_refuted_hot_path_2026_05_23.md`.
+
+Don't reopen unless one of the "Re-evaluation triggers" below fires.
 
 ## Mission
 

--- a/docs/plans/moe_prefill_cudagraph_via_cutlass_moe_scheduler_2026_05_23.md
+++ b/docs/plans/moe_prefill_cudagraph_via_cutlass_moe_scheduler_2026_05_23.md
@@ -1,5 +1,7 @@
 # MoE Prefill via CUTLASS `MoEProblemShape` — CUDA Graph Capture Plan
-*2026-05-23 · multi-week design doc · not yet implemented*
+*2026-05-23 · multi-week design doc*
+
+**Status (2026-05-23): DEFERRED — original motivation mostly closed via other levers.** The release-blocker metric (Qwen3-Coder-30B-A3B-NVFP4 MoE prefill gap to vLLM 0.20.2 single-seq) narrowed from 1.14–1.32× to **1.056×** via #374 + sustained-pp ramp work — see `memory/qwen3_coder_moe_prefill_gap_closed_2026_05_23.md`. The remaining ~5–6 % gap is what this plan would target; the lever is still valid but the urgency dropped. Also still blocked upstream on CUTLASS sm_120 `MoEProblemShape` scheduler (`IsMoEScheduler = false` at `cutlass/gemm/kernel/sm100_gemm_mixed_tma_cpasync_warpspecialized.hpp:92`). Re-open when (a) CUTLASS 4.5+ ships the sm_120 MoE scheduler OR (b) a workload re-opens a meaningful (> 8 %) MoE prefill gap.
 
 ## Mission
 

--- a/docs/plans/nvfp4_gemv_tuning_2026_05_23.md
+++ b/docs/plans/nvfp4_gemv_tuning_2026_05_23.md
@@ -1,5 +1,7 @@
 # NVFP4 Decode GEMV Tuning — Toward the 175 tok/s Milestone
-*2026-05-23 · multi-week design doc · not yet implemented*
+*2026-05-23 · multi-week design doc*
+
+**Status (2026-05-23): REFUTED — 175 milestone via NVFP4-GEMV kernel tuning is dead.** All four hypotheses (H1 SMEM staging, H2 scale-batch4, H3 register pressure, H4 software prefetch) were tested and refuted. ncu showed top-3 GEMVs at **64–73 % HBM peak**, not the 43 % analytical estimate that motivated the plan. H2 implementation caused a −41 % decode regression (157.71 → 92.28 tok/s) because the stride change blew the L1 cache. H4 (prefetch) and H1 (SMEM stage) showed flat zero wall delta — nvcc had already scheduled loads optimally. Memos: `memory/qwen3_14b_full_profile_2026_05_23.md`, `memory/h4_gemv_prefetch_refuted_2026_05_23.md`, `memory/h2_gemv_scale_batch4_refuted_2026_05_23.md`. To unlock the 175 milestone the gain has to come from **outside the per-GEMV kernel** (fusion of latency-bound minor kernels, model-level NVFP4 expansion to LM head — also refuted, see `lm_head_only_nvfp4_qwen3_6_refuted_2026_05_23.md`).
 
 ## Mission
 


### PR DESCRIPTION
## Summary

Four plans in `docs/plans/` had stale "*not yet implemented*" subtitles even though Phase 0 spikes captured in `~/.claude/.../memory/` already refuted or deferred them. This PR adds a one-paragraph **Status** banner at the top of each so a future session can triage at a glance instead of re-reading the whole doc + cross-referring with memory.

- **gdn_scan_splitk**: REFUTED Phase 0 — sync overhead ~10x net negative. Algorithmic angle taken via `gdn_chunkwise_scan` instead (+15.2 % already at Phase 1b.1, #388).
- **kernel_fusion_rmsnorm_into_gemv**: REFUTED Phase 0 both paths — Path A 3–5 day refactor not 1-day swap; Path B +112 % redundant work vs 5 % design gate, regression at hot M=6144.
- **nvfp4_gemv_tuning**: REFUTED — all four hypotheses (H1–H4) tested and refuted; ncu showed top-3 GEMVs at 64–73 % HBM peak (not 43 % analytical estimate); 175 milestone via this lever dead.
- **moe_prefill_cudagraph_via_cutlass_moe_scheduler**: DEFERRED — original vLLM-gap motivation closed to 1.056x via other levers; remaining ~5–6 % upside not worth multi-week effort; still blocked upstream on CUTLASS sm_120 MoE scheduler.

All four banners cross-link to the canonical refutation memos so the evidence is one click away. No code changes.

## Test plan

- [x] docs-only diff — no build/test impact
- [x] pre-push hook: "no source changes, skipping verify"

🤖 Generated with [Claude Code](https://claude.com/claude-code)