### PR TITLE
feat(gdn): Phase 2a — WY-rep parallel delta-rule scan (correctness reference)

### DIFF
--- a/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
+++ b/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
@@ -116,13 +116,117 @@ The +15 % win is structural and comes for free with Phase 1b.1 — caching K, Q 
 
 Code: `gdn_scan_chunkwise_kernel<HD, SS, CHUNK>` in `src/compute/gdn.cu` (under "Phase 1b.1 — Standalone chunkwise SSD scan prototype"); dispatch in `gdn_scan_chunkwise_f32`; tests `ChunkwiseProtoMatchesFused` + `ChunkwiseProtoMicrobench` in `tests/test_gdn.cu`.
 
-### Phase 2 — Production kernel integration (5-7 days) ⏳ PENDING
+### Phase 2 — Production kernel integration (5-7 days) ⏳ IN PROGRESS
 
-- [ ] Add `gdn_scan_chunkwise_kernel<HD, SS, CHUNK_SIZE, YOut>` in `src/compute/gdn.cu`
-- [ ] Use CUTLASS / cute tile descriptors for the chunk-internal lower-triangular MMA
-- [ ] FP32 accumulation for cross-chunk state propagation (precision preservation)
-- [ ] Dispatch from `gdn_scan_fused_f32_*` host launchers when `n_tokens >= CHUNK_SIZE` (decode falls through to existing sequential path)
-- [ ] Gate behind `gdn.chunkwise_scan = false` config flag (off by default until validated)
+- [x] Add `gdn_scan_chunkwise_kernel<HD, SS, CHUNK, YOut>` in `src/compute/gdn.cu` (PR #388 templated on YOut)
+- [ ] Use CUTLASS / cute tile descriptors for the chunk-internal lower-triangular MMA → **Phase 2b** (Tensor Core acceleration; multi-week)
+- [x] FP32 accumulation for cross-chunk state propagation (precision preservation) — done in 1b.1
+- [x] Dispatch from `gdn_scan_fused_f32_*` host launchers when `n_tokens >= CHUNK_SIZE` (decode falls through to existing sequential path) — done in PR #388 (auto-merged #390)
+- [x] Gate behind `gdn.chunkwise_scan = false` config flag (off by default until validated) — done in PR #388
+
+The dispatch + flag plumbing landed; the remaining piece is the **algorithmic core**: replacing the sequential delta-rule sweep with the WY-rep parallel scan. Split into 2a (correctness reference, naive shared-memory matmul) and 2b (Tensor Core MMA via CUTLASS / cute).
+
+#### Phase 2a — WY-rep delta-rule math worked out ✅ DONE 2026-05-24
+
+**Result**: New kernel `gdn_scan_chunkwise_wy_kernel<HD, SS, CHUNK=32>` in `src/compute/gdn.cu` implements the full WY-representation parallel delta-rule scan (Yang et al. 2024 adapted for GDN). Algorithm:
+
+1. **Setup** — per-token g_t, β_t, log-cumulative-decay log_D[t+1]; L2-normalised K̃, Q̃ cached in shared memory
+2. **Gram matrices KH, QH (matmul vs in-register H_0)** — thread d computes its own column of K̃·H_0 and Q̃·H_0
+3. **Gram matrices KK, QK (chunk-internal)** — lower-triangular Gram matrices; threads cooperate across L²=1024 entries
+4. **Forward triangular solve for u_t** — sequential over t∈[0,L), parallel over HD output dim (thread d owns column d of U)
+5. **Y computation** — y_t = scale · (D[0..t+1]·QH[t,:] + Σ_{j≤t} D[j+1..t+1]·QK[t,j]·u_j)
+6. **H_L update** — H_L = D[0..L]·H_0 + Σ_t D[t+1..L]·k̃_t·u_t^T
+
+CHUNK=32 (not 64 as design doc target) because the s_kh + s_qh + s_u buffers (3·CHUNK·HD floats each) push smem to ~89 KiB at CHUNK=32 — already near the sm_120 `sharedMemPerBlockOptin` cap of 99 KiB. CHUNK=64 would need ~157 KiB; either FP16 storage for K̃/Q̃ (precision audit) or smarter buffer reuse (recompute QH on the fly) is the path to CHUNK=64.
+
+**Numerics on `GDNScanTest.ChunkwiseWyMatchesFused` (n_tok=64, 2 chunks of 32, HD=SS=128)**:
+- max_diff Y = **3.8e-6** (FP16 quantisation floor; effectively bit-exact)
+- max_diff H state = **6e-8** (FP32 reordering noise)
+
+Well inside Phase 1a's FP16 1e-3 / FP32 1e-5 budgets. The chunk-internal log-space cumulative decay + the matmul reformulation don't introduce material precision error vs the sequential register-cached delta-rule loop.
+
+**Microbench (n_tok=4096, n_heads=32, HD=SS=128, n_groups=16, RTX 5090 sm_120, 20 reps)**:
+- gdn_scan_fused_f32 (sequential):       6.661 ms = **1.626 µs/token**
+- gdn_scan_chunkwise_f32 (Phase 1b.1):   5.686 ms = **1.388 µs/token** (0.854× wall, +17 % throughput)
+- gdn_scan_chunkwise_wy_f32 (Phase 2a):  14.771 ms = **3.606 µs/token** (2.218× wall, **-55 % throughput**)
+
+The 2.2× slowdown is expected and documents the gap that Phase 2b's Tensor Core MMA closes. Phase 2a does roughly 3× the FLOPs of the sequential kernel (chunk-internal KK matmul + forward solve + Y matmul) and runs them as scalar dot products in shared memory — without TC acceleration, those FLOPs cost more wall-clock than the sequential register-cached loop saves on dependency-breaking parallelism. The Tensor Core path turns those matmuls into ~16× faster MMA tile ops, which is where the design doc's +20-30 % wall lives.
+
+Phase 2a is shipped as **correctness reference + algorithmic scaffold only** — not wired into the production dispatch (would regress perf). The test `ChunkwiseWyMatchesFused` is the regression gate for any Phase 2b TC-MMA replacement.
+
+Code: `gdn_scan_chunkwise_wy_kernel<HD, SS, CHUNK>` in `src/compute/gdn.cu`; host launcher `gdn_scan_chunkwise_wy_f32` (HD=SS=128 + CHUNK=32 path; other shapes fall back to sequential); tests `ChunkwiseWyMatchesFused` + extended `ChunkwiseProtoMicrobench` in `tests/test_gdn.cu`.
+
+##### Original Phase 2a algorithmic derivation (kept for reference)
+
+Reference: Yang et al. 2024, *"Parallel Linear Attention With The Delta Rule"*. The math below is the imp-specific derivation; the kernel implementation is the multi-day part.
+
+**Per-token recurrence (current sequential kernel):**
+```
+H_{t+1} = g_t (I - β_t k̃_t k̃_t^T) H_t + β_t k̃_t v_t^T   ∈ R^{SS×HD}
+y_t     = q̃_t^T H_{t+1} · scale                          ∈ R^HD
+```
+where `k̃ = k / ‖k‖`, `q̃ = q / ‖q‖`.
+
+**Linearization via WY representation.** Define `u_t = β_t (v_t - g_t k̃_t^T H_t)` ∈ R^HD. Then `H_{t+1} = g_t H_t + k̃_t u_t^T`, and unrolling gives:
+```
+H_T  = D[0..T] H_0 + Σ_{t<T} D[t+1..T] k̃_t u_t^T          (cumulative state)
+y_t  = scale · (D[0..t+1] q̃_t^T H_0 + Σ_{j≤t} D[j+1..t+1] (q̃_t · k̃_j) u_j^T)
+```
+where `D[a..b] = Π_{i=a..b-1} g_i` is the cumulative decay product.
+
+`u_t` depends on `H_t` which depends recursively on prior `u_j`'s. Substituting:
+```
+k̃_t^T H_t = D[0..t] k̃_t^T H_0 + Σ_{j<t} D[j+1..t] (k̃_t · k̃_j) u_j^T
+```
+gives the **forward triangular solve**:
+```
+u_t = c_t - Σ_{j<t} T[t,j] u_j
+```
+where
+```
+c_t    = β_t v_t - β_t g_t D[0..t] (k̃_t^T H_0)             ∈ R^HD
+T[t,j] = β_t g_t D[j+1..t] (k̃_t · k̃_j)                    ∈ R     (j < t, strict lower-tri)
+```
+
+**Per-chunk algorithm (L tokens, given H_0):**
+
+1. **Setup (parallel over t):** compute `g_t, β_t`; L2-normalise `k̃_t, q̃_t`; cumulative decay `D[0..t]`.
+2. **Gram matrices (parallel matmul):**
+   - `KK = K̃ K̃^T ∈ R^{L×L}` (chunk-internal Gram)
+   - `QK = Q̃ K̃^T ∈ R^{L×L}` (chunk-internal masked attention)
+   - `KH = K̃ H_0 ∈ R^{L×HD}` (K̃ times entry state — produces the `c_t` bias)
+   - `QH = Q̃ H_0 ∈ R^{L×HD}` (Q̃ times entry state — produces the y-bias term)
+3. **Build T and c (parallel over t, j):**
+   - `T[t,j] = β_t g_t D[j+1..t] · KK[t,j]` for `j < t`
+   - `c_t = β_t v_t - β_t g_t D[0..t] · KH[t,:]`
+4. **Forward triangular solve (sequential over t, parallel over HD output dim):**
+   - `u_0 = c_0`
+   - `u_t = c_t - Σ_{j<t} T[t,j] u_j` for `t = 1..L-1` (each iteration: one row of L×HD matrix)
+5. **Compute Y (parallel over t):** `y_t = scale · (D[0..t+1] QH[t,:] + Σ_{j≤t} D[j+1..t+1] · QK[t,j] · u_j)`
+6. **Compute H_L (parallel matmul):** `H_L = D[0..L] H_0 + Σ_t D[t+1..L] k̃_t u_t^T` — a rank-L update to scaled H_0.
+
+**Where the parallelism lives:** steps 2, 3, 5, 6 are all matrix-matrix multiplies amenable to Tensor Core MMA (Phase 2b). Step 4 is the irreducibly sequential dependency — but it's `L = 64` sequential scalar steps on a vector of HD=128 elements, not `L × SS` sequential ops as in the existing kernel. The serial dependency length collapses from ~123k (4096 tokens × 30 layers) to ~64 per chunk.
+
+**Shared memory budget at L=64, HD=SS=128 (FP32):**
+- s_k[L·SS] = 32 KiB, s_q[L·SS] = 32 KiB, s_u[L·HD] = 32 KiB
+- s_KK[L·L] = 16 KiB (could fold into matmul-on-fly)
+- s_misc (g, β, D, reduce) ≈ 1 KiB
+
+Total ~113 KiB exceeds the 100 KiB sm_120 per-block cap → need to either drop CHUNK to 32 (~57 KiB, fits with opt-in) or store K̃/Q̃ as FP16 (halves to ~57 KiB; precision impact needs audit). Prototype uses CHUNK=32 + FP32 throughout.
+
+**Numerical precision concerns:**
+- FP32 accumulation throughout (matches current sequential kernel).
+- `D[0..L]` can underflow for large L if `g_t < 1` consistently. Mitigate by carrying `log_D` instead of `D` and exponentiating at use; small constant cost.
+- The triangular solve accumulates rounding errors over L steps. For L=32-64 this is well within the FP16-output tolerance (1e-3 from Phase 1a).
+
+#### Phase 2b — Tensor Core MMA via CUTLASS / cute (multi-week) ⏳ PENDING
+
+Once Phase 2a's WY-rep is correct, replace the naive shared-memory matmuls in steps 2, 5, 6 with CUTLASS / cute MMA tile dispatches. Operand layouts to derive:
+- `K̃ K̃^T` (L×SS × SS×L → L×L): standard A·A^T, FP16 input → FP32 accum on `mma.m16n8k16`.
+- `K̃ H_0` (L×SS × SS×HD → L×HD): FP16 input → FP32 accum.
+- Q̃ K̃^T similar; the masked variant needs the decay-scaled mask applied post-MMA (free if fused with the next matmul).
+
+sm_120 Tensor Core throughput is 838 TFLOPS FP16-accum (no tcgen05/wgmma). The L=64 inner matmuls fit naturally on `mma.m16n8k16` tiles — the chunk-internal computation is structurally identical to a small attention block.
 
 ### Phase 3 — Numerical validation across context lengths (2-3 days) ⏳ PENDING
 

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -364,6 +364,247 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_chunkwise_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// Phase 2a — WY-representation parallel delta-rule scan prototype.
+//
+// Numerically equivalent to gdn_scan_fused_kernel but factors the
+// chunk-internal sequential dependency into a forward triangular solve +
+// matrix-matrix products. Reference: Yang et al. 2024, "Parallel Linear
+// Attention With The Delta Rule"; imp-specific derivation in
+// docs/plans/gdn_chunkwise_scan_design_2026_05_23.md §"Phase 2a".
+//
+// Algorithm per chunk of L tokens:
+//   1. Cache K̃, Q̃ in shared memory (post L2 norm)
+//   2. Compute Gram matrices KK, QK, KH, QH (matmuls vs the in-register H_0)
+//   3. Build the L×L triangular coefficient matrix T and bias vectors c_t
+//   4. Forward solve u_t = c_t - Σ_{j<t} T[t,j] u_j (sequential over t,
+//      parallel over HD output dim — thread d owns column d of U)
+//   5. Compute y_t = scale · (D[0..t+1] QH[t,:] + Σ_{j≤t} D[j+1..t+1] · QK[t,j] · u_j)
+//   6. Update H_L = D[0..L] H_0 + Σ_t D[t+1..L] k̃_t u_t^T
+//
+// Cumulative decay D[a..b] = Π_{i=a..b-1} g_i carried in log-space to dodge
+// underflow over L=32 tokens with possibly tiny g (sequential kernel caps
+// g_t at e^-20).
+//
+// CHUNK=32 (not 64) to fit the L^2 + L×HD scratch buffers within the 100 KiB
+// sm_120 per-block opt-in cap. At HD=SS=128, CHUNK=32 → ~92 KiB dynamic smem.
+//
+// Phase 2b will swap the explicit per-thread shared-memory matmul loops for
+// CUTLASS / cute MMA tile dispatches. The numerical structure here mirrors
+// what the Tensor Core path needs, so 2b is a localized replacement.
+// ---------------------------------------------------------------------------
+template <int HD, int SS, int CHUNK>
+__global__ void __launch_bounds__(HD, 1) gdn_scan_chunkwise_wy_kernel(
+    const float* __restrict__ conv_f32, const half* __restrict__ alpha_all,
+    const half* __restrict__ beta_all, const float* __restrict__ A_log,
+    const float* __restrict__ dt_bias, float* __restrict__ h_state, half* __restrict__ y_out,
+    int n_tokens, int n_heads, int n_groups, int conv_channels, int grouped_layout) {
+    const int h = blockIdx.x;
+    if (h >= n_heads)
+        return;
+    const int d = threadIdx.x;
+
+    const int g_idx = grouped_layout ? (h / (n_heads / n_groups)) : (h % n_groups);
+    const int inner = n_heads * HD;
+    const int BC_size = n_groups * SS;
+    const float scale = rsqrtf(static_cast<float>(HD));
+    const float A_h = A_log[h];
+    const float dtb_h = dt_bias[h];
+
+    // State in registers (one column per thread).
+    float H_reg[SS];
+    {
+        const float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
+#pragma unroll
+        for (int s = 0; s < SS; s++)
+            H_reg[s] = H_col[s * HD];
+    }
+
+    // Shared memory layout (sized for CHUNK, SS, HD; opt-in dynamic smem).
+    extern __shared__ float smem[];
+    float* s_k = smem;                          // [CHUNK * SS]    normalized K
+    float* s_q = s_k + CHUNK * SS;              // [CHUNK * SS]    normalized Q
+    float* s_u = s_q + CHUNK * SS;              // [CHUNK * HD]    triangular-solve output
+    float* s_kh = s_u + CHUNK * HD;             // [CHUNK * HD]    K̃ H_0
+    float* s_qh = s_kh + CHUNK * HD;            // [CHUNK * HD]    Q̃ H_0
+    float* s_kk = s_qh + CHUNK * HD;            // [CHUNK * CHUNK] K̃ K̃^T (lower-tri only used)
+    float* s_qk = s_kk + CHUNK * CHUNK;         // [CHUNK * CHUNK] Q̃ K̃^T (lower-tri only used)
+    float* s_g = s_qk + CHUNK * CHUNK;          // [CHUNK]         per-token decay
+    float* s_beta = s_g + CHUNK;                // [CHUNK]         per-token learning rate
+    float* s_logD = s_beta + CHUNK;             // [CHUNK + 1]     cumulative log decay
+    float* s_reduce = s_logD + CHUNK + 1;       // [HD]            block-reduction scratch
+
+    int t_chunk_start = 0;
+    while (t_chunk_start < n_tokens) {
+        const int L = (t_chunk_start + CHUNK <= n_tokens) ? CHUNK : (n_tokens - t_chunk_start);
+
+        // ---------------- STEP 1: load + normalize K, Q ----------------
+        if (d < SS) {
+            for (int t_loc = 0; t_loc < L; t_loc++) {
+                const int t = t_chunk_start + t_loc;
+                const float* row = conv_f32 + static_cast<size_t>(t) * conv_channels;
+                s_q[t_loc * SS + d] = row[g_idx * SS + d];
+                s_k[t_loc * SS + d] = row[BC_size + g_idx * SS + d];
+            }
+        }
+        __syncthreads();
+
+        for (int t_loc = 0; t_loc < L; t_loc++) {
+            float k_sq = 0.0f, q_sq = 0.0f;
+            for (int i = d; i < SS; i += HD) {
+                k_sq += s_k[t_loc * SS + i] * s_k[t_loc * SS + i];
+                q_sq += s_q[t_loc * SS + i] * s_q[t_loc * SS + i];
+            }
+            s_reduce[d] = k_sq;
+            __syncthreads();
+            for (int stride = HD / 2; stride > 0; stride >>= 1) {
+                if (d < stride)
+                    s_reduce[d] += s_reduce[d + stride];
+                __syncthreads();
+            }
+            const float k_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
+
+            s_reduce[d] = q_sq;
+            __syncthreads();
+            for (int stride = HD / 2; stride > 0; stride >>= 1) {
+                if (d < stride)
+                    s_reduce[d] += s_reduce[d + stride];
+                __syncthreads();
+            }
+            const float q_inv = rsqrtf(fmaxf(s_reduce[0], 1e-12f));
+
+            if (d < SS) {
+                s_k[t_loc * SS + d] *= k_inv;
+                s_q[t_loc * SS + d] *= q_inv;
+            }
+            __syncthreads();
+        }
+
+        // ---------------- STEP 2a: per-token g_t, β_t, log_D[0..t+1] ----------------
+        // Thread 0 owns the sequential dependency (small, L=32 iterations).
+        if (d == 0) {
+            float log_D = 0.0f;
+            s_logD[0] = 0.0f;
+            for (int t_loc = 0; t_loc < L; t_loc++) {
+                const int t = t_chunk_start + t_loc;
+                float alpha_h = __half2float(alpha_all[t * n_heads + h]);
+                float dt_val = alpha_h + dtb_h;
+                dt_val = (dt_val > 20.0f) ? dt_val : logf(1.0f + expf(dt_val));
+                float lg_t = fmaxf(A_h * dt_val, -20.0f);  // log(g_t)
+                s_g[t_loc] = expf(lg_t);
+                log_D += lg_t;
+                s_logD[t_loc + 1] = log_D;
+                float beta_h = __half2float(beta_all[t * n_heads + h]);
+                s_beta[t_loc] = 1.0f / (1.0f + expf(-fmaxf(fminf(beta_h, 20.0f), -20.0f)));
+            }
+        }
+        __syncthreads();
+
+        // ---------------- STEP 2b: KH = K̃ H_0, QH = Q̃ H_0 ----------------
+        // Thread d computes column d of KH and QH (H_0 column d is in this thread's H_reg).
+        for (int t_loc = 0; t_loc < L; t_loc++) {
+            float kh = 0.0f, qh = 0.0f;
+#pragma unroll
+            for (int s = 0; s < SS; s++) {
+                kh += s_k[t_loc * SS + s] * H_reg[s];
+                qh += s_q[t_loc * SS + s] * H_reg[s];
+            }
+            s_kh[t_loc * HD + d] = kh;
+            s_qh[t_loc * HD + d] = qh;
+        }
+        // No sync needed yet — STEP 3 reads from s_kh/s_qh after a sync at end of STEP 2c.
+
+        // ---------------- STEP 2c: KK and QK Gram matrices ----------------
+        // Lower-triangular only (j ≤ i). HD=128 threads cooperate on L*L pairs.
+        for (int idx = d; idx < L * L; idx += HD) {
+            const int i = idx / L;
+            const int j = idx % L;
+            if (j > i) {
+                s_kk[idx] = 0.0f;
+                s_qk[idx] = 0.0f;
+                continue;
+            }
+            float kk = 0.0f, qk = 0.0f;
+#pragma unroll
+            for (int s = 0; s < SS; s++) {
+                const float k_is = s_k[i * SS + s];
+                const float k_js = s_k[j * SS + s];
+                const float q_is = s_q[i * SS + s];
+                kk += k_is * k_js;
+                qk += q_is * k_js;
+            }
+            s_kk[idx] = kk;
+            s_qk[idx] = qk;
+        }
+        __syncthreads();  // STEP 3 reads s_kh, s_kk; STEP 4 reads s_u; STEP 5 reads s_qh, s_qk.
+
+        // ---------------- STEP 3+4: triangular solve for u_t ----------------
+        // Sequential over t (intra-chunk), parallel over HD output dim (one per thread).
+        // u_t[d] = c_t[d] - Σ_{j<t} T[t,j] u_j[d]
+        // with c_t[d] = β_t v_t[d] - β_t g_t D[0..t] KH[t,d]
+        // and  T[t,j] = β_t g_t D[j+1..t] KK[t,j]
+        for (int t_loc = 0; t_loc < L; t_loc++) {
+            const int t = t_chunk_start + t_loc;
+            const float* row = conv_f32 + static_cast<size_t>(t) * conv_channels;
+            const float v_d = row[2 * BC_size + h * HD + d];
+
+            const float g_t = s_g[t_loc];
+            const float beta_t = s_beta[t_loc];
+            const float logD_0t = s_logD[t_loc];
+            const float D_0t = expf(logD_0t);
+
+            float u_t = beta_t * v_d - beta_t * g_t * D_0t * s_kh[t_loc * HD + d];
+            for (int j = 0; j < t_loc; j++) {
+                const float logD_j1t = s_logD[t_loc] - s_logD[j + 1];
+                const float coef = beta_t * g_t * expf(logD_j1t) * s_kk[t_loc * L + j];
+                u_t -= coef * s_u[j * HD + d];
+            }
+            s_u[t_loc * HD + d] = u_t;
+            __syncthreads();
+        }
+
+        // ---------------- STEP 5: Y[t] for all chunk tokens ----------------
+        // y_t[d] = scale · (D[0..t+1] QH[t,d] + Σ_{j≤t} D[j+1..t+1] QK[t,j] u_j[d])
+        for (int t_loc = 0; t_loc < L; t_loc++) {
+            const int t = t_chunk_start + t_loc;
+            const float logD_0t1 = s_logD[t_loc + 1];
+
+            float y = expf(logD_0t1) * s_qh[t_loc * HD + d];
+            for (int j = 0; j <= t_loc; j++) {
+                const float logD_j1t1 = s_logD[t_loc + 1] - s_logD[j + 1];
+                y += expf(logD_j1t1) * s_qk[t_loc * L + j] * s_u[j * HD + d];
+            }
+            y_out[static_cast<size_t>(t) * inner + h * HD + d] = __float2half(y * scale);
+        }
+
+        // ---------------- STEP 6: H_L = D[0..L] H_0 + Σ_t D[t+1..L] k̃_t u_t^T ----------------
+        // Thread d updates column d of H. For each state row s: H_reg[s] *= D[0..L] then add Σ_t D[t+1..L] k̃_t[s] u_t[d].
+        {
+            const float D_0L = expf(s_logD[L]);
+#pragma unroll
+            for (int s = 0; s < SS; s++) {
+                float add = 0.0f;
+                for (int t_loc = 0; t_loc < L; t_loc++) {
+                    const float logD_t1L = s_logD[L] - s_logD[t_loc + 1];
+                    add += expf(logD_t1L) * s_k[t_loc * SS + s] * s_u[t_loc * HD + d];
+                }
+                H_reg[s] = D_0L * H_reg[s] + add;
+            }
+        }
+
+        t_chunk_start += L;
+        __syncthreads();  // Before reusing s_k / s_q / etc. for the next chunk.
+    }
+
+    // Write final state back to global memory.
+    {
+        float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
+#pragma unroll
+        for (int s = 0; s < SS; s++)
+            H_col[s * HD] = H_reg[s];
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Fused RMSNormGated + SiLU kernel.
 // Computes: y[t,h,:] = rmsnorm(y[t,h,:], weight) * silu(gate[t,h,:])
 //
@@ -624,6 +865,48 @@ void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const 
                                    n_tok_chunk, n_heads, head_dim_ssm, state_size, n_groups, stream,
                                    grouped_layout);
         });
+}
+
+// Phase 2a WY-rep host launcher. Currently HD=SS=128 + CHUNK=32 only; other
+// shapes fall back to `gdn_scan_fused_f32`. Output is FP16 only — Phase 2a
+// is a correctness reference; the FP32-out and Phase 2b TC-MMA variants come
+// later.
+void gdn_scan_chunkwise_wy_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                               const float* A_log, const float* dt_bias, float* h_state, half* y,
+                               int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                               cudaStream_t stream, int grouped_layout) {
+    if (head_dim_ssm == 128 && state_size == 128 && n_tokens >= 1) {
+        constexpr int HD = 128, SS = 128, CHUNK = 32;
+        // Shared-memory budget for the WY kernel:
+        //   s_k + s_q       = 2 * CHUNK * SS         = 32 KiB
+        //   s_u + s_kh + s_qh = 3 * CHUNK * HD       = 48 KiB
+        //   s_kk + s_qk     = 2 * CHUNK * CHUNK      =  8 KiB
+        //   s_g + s_beta + s_logD + s_reduce        ≈  1 KiB
+        // Total ~89 KiB → needs the dynamic-shared opt-in.
+        const size_t smem =
+            (2 * CHUNK * SS + 3 * CHUNK * HD + 2 * CHUNK * CHUNK + 2 * CHUNK + (CHUNK + 1) + HD) *
+            sizeof(float);
+        static bool attr_set = false;
+        if (!attr_set) {
+            // sm_120 caps `cudaFuncAttributeMaxDynamicSharedMemorySize` at 99 KiB
+            // (sharedMemPerBlockOptin = 101376 B). Setting above that returns
+            // cudaErrorInvalidValue and the kernel falls back to the 48 KiB
+            // default → kernel launch fails with "invalid argument" since the
+            // request (~89 KiB) exceeds the default. Use 96 KiB (matches the
+            // existing reference kernel's opt-in).
+            cudaFuncSetAttribute(
+                reinterpret_cast<const void*>(&gdn_scan_chunkwise_wy_kernel<HD, SS, CHUNK>),
+                cudaFuncAttributeMaxDynamicSharedMemorySize, 96 * 1024);
+            attr_set = true;
+        }
+        gdn_scan_chunkwise_wy_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
+            conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
+            grouped_layout);
+        return;
+    }
+    // Unsupported shape — fall back to the sequential kernel for safety.
+    gdn_scan_fused_f32(conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads,
+                       head_dim_ssm, state_size, n_groups, stream, grouped_layout);
 }
 
 // FP32-output variant — writes scan result as FP32 for downstream

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -48,6 +48,21 @@ void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const 
                                 int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
                                 cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0);
 
+// Phase 2a — WY-representation parallel delta-rule scan prototype.
+// Numerically equivalent to the sequential delta rule but factors the
+// chunk-internal dependency into a forward triangular solve + matrix-matrix
+// products (steps 2/3/5/6 of the algorithm in
+// docs/plans/gdn_chunkwise_scan_design_2026_05_23.md §"Phase 2a"). Naive
+// shared-memory matmuls; Tensor Core MMA is Phase 2b.
+//
+// Currently instantiated for HD=SS=128, CHUNK=32 (chunk_size=32 dispatch);
+// other shapes fall back to gdn_scan_fused_f32 to avoid silent precision
+// loss before validation lands.
+void gdn_scan_chunkwise_wy_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                               const float* A_log, const float* dt_bias, float* h_state, half* y,
+                               int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                               cudaStream_t stream, int grouped_layout = 0);
+
 // Fused RMSNormGated + SiLU: y = rmsnorm(y) * silu(gate)
 // Processes all tokens × heads in one launch.
 void gdn_rmsnorm_gated_silu(half* y, const half* gate, const half* weight, float eps, int n_tokens,

--- a/tests/test_gdn.cu
+++ b/tests/test_gdn.cu
@@ -617,6 +617,108 @@ TEST(GDNScanTest, ChunkwiseProtoMatchesFused) {
 }
 
 // =========================================================================
+// Test 3e: Phase 2a WY-rep prototype matches sequential
+// -------------------------------------------------------------------------
+// Validates the new `gdn_scan_chunkwise_wy_f32` kernel — factorises the
+// chunk-internal sequential dependency into a forward triangular solve +
+// matrix-matrix products (WY representation, Yang et al. 2024). Same math
+// as the sequential kernel but reorganised; expected to be numerically
+// close (FMA-order may differ → ~5e-3 FP16 tolerance, ~1e-2 FP32 state).
+// =========================================================================
+
+TEST(GDNScanTest, ChunkwiseWyMatchesFused) {
+    constexpr int n_heads = 4, head_dim = 128, state_size = 128, n_groups = 4;
+    constexpr int inner = n_heads * head_dim, BC_size = n_groups * state_size;
+    constexpr int conv_channels = 2 * BC_size + inner;
+    constexpr int n_tok = 64;  // 2 WY chunks of 32 — exercises chunk loop + state propagation
+
+    srand(17);
+    std::vector<float> conv_f32(n_tok * conv_channels);
+    std::vector<float> all_alpha(n_tok * n_heads), all_beta(n_tok * n_heads);
+    std::vector<float> h_A_log(n_heads, -0.5f), h_dt_bias(n_heads, 0.5f);
+    for (auto& v : conv_f32)
+        v = (rand() % 200 - 100) / 100.0f;
+    for (auto& v : all_alpha)
+        v = (rand() % 200 - 100) / 100.0f;
+    for (auto& v : all_beta)
+        v = (rand() % 200 - 100) / 100.0f;
+
+    std::vector<half> h_alpha_h(n_tok * n_heads), h_beta_h(n_tok * n_heads);
+    for (int i = 0; i < n_tok * n_heads; i++) {
+        h_alpha_h[i] = __float2half(all_alpha[i]);
+        h_beta_h[i] = __float2half(all_beta[i]);
+    }
+
+    const int state_floats = n_heads * state_size * head_dim;
+    float *d_conv, *d_A, *d_dt, *d_state_ref, *d_state_wy;
+    half *d_alpha, *d_beta, *d_y_ref, *d_y_wy;
+    cudaMalloc(&d_conv, n_tok * conv_channels * sizeof(float));
+    cudaMalloc(&d_A, n_heads * sizeof(float));
+    cudaMalloc(&d_dt, n_heads * sizeof(float));
+    cudaMalloc(&d_state_ref, state_floats * sizeof(float));
+    cudaMalloc(&d_state_wy, state_floats * sizeof(float));
+    cudaMalloc(&d_alpha, n_tok * n_heads * sizeof(half));
+    cudaMalloc(&d_beta, n_tok * n_heads * sizeof(half));
+    cudaMalloc(&d_y_ref, n_tok * inner * sizeof(half));
+    cudaMalloc(&d_y_wy, n_tok * inner * sizeof(half));
+
+    cudaMemcpy(d_conv, conv_f32.data(), n_tok * conv_channels * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_A, h_A_log.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_dt, h_dt_bias.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha, h_alpha_h.data(), n_tok * n_heads * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_beta, h_beta_h.data(), n_tok * n_heads * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_state_ref, 0, state_floats * sizeof(float));
+    cudaMemset(d_state_wy, 0, state_floats * sizeof(float));
+
+    gdn_scan_fused_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state_ref, d_y_ref, n_tok,
+                       n_heads, head_dim, state_size, n_groups, nullptr);
+    gdn_scan_chunkwise_wy_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state_wy, d_y_wy, n_tok,
+                              n_heads, head_dim, state_size, n_groups, nullptr, /*grouped_layout=*/0);
+    cudaDeviceSynchronize();
+
+    std::vector<half> y_ref(n_tok * inner), y_wy(n_tok * inner);
+    std::vector<float> state_ref(state_floats), state_wy(state_floats);
+    cudaMemcpy(y_ref.data(), d_y_ref, n_tok * inner * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(y_wy.data(), d_y_wy, n_tok * inner * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(state_ref.data(), d_state_ref, state_floats * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(state_wy.data(), d_state_wy, state_floats * sizeof(float), cudaMemcpyDeviceToHost);
+
+    float max_diff_y = 0;
+    for (int i = 0; i < n_tok * inner; i++) {
+        float diff = std::abs(__half2float(y_ref[i]) - __half2float(y_wy[i]));
+        if (diff > max_diff_y)
+            max_diff_y = diff;
+    }
+    float max_diff_state = 0;
+    for (int i = 0; i < state_floats; i++) {
+        float diff = std::abs(state_ref[i] - state_wy[i]);
+        if (diff > max_diff_state)
+            max_diff_state = diff;
+    }
+
+    std::printf("\n  ChunkwiseWy: max_diff Y = %.6e\n", max_diff_y);
+    std::printf("  ChunkwiseWy: max_diff state = %.6e\n", max_diff_state);
+
+    // The WY reformulation differs from the sequential FMA order, but the
+    // chunk-internal matmuls + log-space cumulative decay land within FP32
+    // reordering noise: ~4e-6 max-abs on Y (FP16 quantisation floor),
+    // ~6e-8 max-abs on FP32 state at 2 chunks of 32 tokens. These are well
+    // inside Phase 1a's FP16 1e-3 / FP32 1e-5 budgets.
+    EXPECT_LT(max_diff_y, 1e-3f);
+    EXPECT_LT(max_diff_state, 1e-5f);
+
+    cudaFree(d_conv);
+    cudaFree(d_A);
+    cudaFree(d_dt);
+    cudaFree(d_state_ref);
+    cudaFree(d_state_wy);
+    cudaFree(d_alpha);
+    cudaFree(d_beta);
+    cudaFree(d_y_ref);
+    cudaFree(d_y_wy);
+}
+
+// =========================================================================
 // Test 3d: Chunkwise prototype microbench (Phase 1b.1).
 // -------------------------------------------------------------------------
 // Times the chunkwise SSD prototype vs the sequential fused scan at the
@@ -714,8 +816,17 @@ TEST(GDNScanTest, ChunkwiseProtoMicrobench) {
         },
         "gdn_scan_chunkwise_f32 (Phase 1b.1 proto)");
 
-    std::printf("  Ratio chunkwise/fused = %.3fx (prototype is structural, no SSD math yet)\n",
-                ms_chunkwise / ms_fused);
+    float ms_wy = bench(
+        [&]() {
+            gdn_scan_chunkwise_wy_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state, d_y, n_tok,
+                                      n_heads, head_dim, state_size, n_groups, nullptr,
+                                      /*grouped_layout=*/0);
+        },
+        "gdn_scan_chunkwise_wy_f32 (Phase 2a WY-rep)");
+
+    std::printf("  Ratio Phase1b.1/fused = %.3fx\n", ms_chunkwise / ms_fused);
+    std::printf("  Ratio Phase2a-WY/fused = %.3fx (naive shared-mem matmul; Phase 2b adds Tensor Cores)\n",
+                ms_wy / ms_fused);
 
     cudaEventDestroy(e0);
     cudaEventDestroy(e1);


### PR DESCRIPTION
## Summary

Implements the full Yang et al. 2024 WY-representation parallel scan for the GDN delta rule. Factorises the within-chunk sequential dependency into a forward triangular solve + chunk-internal matrix-matrix products. Produces output **bit-near-exact** vs the sequential reference (3.8e-6 Y, 6e-8 state at n_tok=64). The 2.2× slowdown is the expected gap that Phase 2b's Tensor Core MMA closes.

Closes Phase 2a of `docs/plans/gdn_chunkwise_scan_design_2026_05_23.md`. Phase 2b (CUTLASS / cute Tensor Core MMA) and Phase 3/4 (validation + ship decision) remain open.

## Algorithm (per chunk of L tokens, given entry state H_0)

1. L2-normalise K, Q; precompute g_t, β_t, log-cumulative-decay
2. Build KH = K̃·H_0, QH = Q̃·H_0 (in-register H_0, one column per thread)
3. Build lower-triangular KK = K̃ K̃^T, QK = Q̃ K̃^T
4. Forward solve `u_t = c_t - Σ_{j<t} T[t,j] u_j` (sequential over t, parallel over HD; thread d owns column d of U)
5. `y_t = scale · (D[0..t+1] QH[t,:] + Σ_{j≤t} D[j+1..t+1] QK[t,j] u_j)`
6. `H_L = D[0..L] H_0 + Σ_t D[t+1..L] k̃_t u_t^T`

The math derivation lives in the plan doc.

## Numerics

`GDNScanTest.ChunkwiseWyMatchesFused` (n_tok=64 = 2 chunks of 32, HD=SS=128):

|Metric | Value | Phase 1a budget |
|---|---|---|
|max_diff Y    | 3.8e-6 | 1e-3 |
|max_diff state | 6e-8   | 1e-5 |

Both well inside budget — effectively bit-exact at the FP16 / FP32 quantisation floors.

## Microbench (n_tok=4096, n_heads=32, HD=SS=128, n_groups=16, RTX 5090)

|Kernel | us/token | vs sequential |
|---|---|---|
|gdn_scan_fused_f32 (sequential)     | 1.626 | 1.000× |
|gdn_scan_chunkwise_f32 (Phase 1b.1) | 1.388 | 0.854× (+17 %) |
|gdn_scan_chunkwise_wy_f32 (Phase 2a) | 3.606 | 2.218× (**-55 %**) |

The 2.2× slowdown is the cost of running chunk-internal matmuls as scalar dot products in shared memory. Phase 2b replaces those with `mma.m16n8k16` Tensor Core tile dispatches via CUTLASS / cute — that's where the design doc's +20-30 % prefill wall ceiling lives.

Phase 2a is shipped as **correctness reference + algorithmic scaffold only**. The kernel is reachable via `gdn_scan_chunkwise_wy_f32` but NOT wired into the production dispatch (would regress perf). The new test is the regression gate for the Phase 2b TC replacement.

## Implementation gotcha (worth flagging)

sm_120 `cudaFuncAttributeMaxDynamicSharedMemorySize` is capped at `sharedMemPerBlockOptin = 99 KiB` (101376 B). Setting above that **silently fails** with `cudaErrorInvalidValue` and leaves the default 48 KiB cap — the next launch then fails with "invalid argument" for any kernel needing > 48 KiB smem. Use 96 KiB (matches the existing reference kernel).

## Test plan

- [x] `test-moe-gdn --gtest_filter='GDNScanTest.*'` — 8 passed (1 skipped microbench)
- [x] `ChunkwiseWyMatchesFused` — max_diff_y 3.8e-6, max_diff_state 6e-8
- [x] `ChunkwiseProtoMicrobench` (under IMP_GDN_MICROBENCH=1) — confirms 2.2× slowdown as expected
- [x] verify-fast pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)