### PR TITLE
feat(gdn): flip gdn.chunkwise_scan = true as the default

### DIFF
--- a/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
+++ b/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
@@ -338,9 +338,16 @@ NIAH ctx={16K, 32K} testing was descoped — imp doesn't ship a NIAH harness and
 
 All deltas are within the cuBLAS algo-cache variance band documented in MEMORY.md. **The +16.8 % kernel microbench win from Phase 1b.1 does not translate to a measurable end-to-end wall improvement on Qwen3.6** at the production prefill / decode sizes. Root cause: the GDN scan is ~37 % of *prefill kernel time* on this model, but only a fraction of total wall (the dominant costs are NVFP4/FP16 GEMMs in the dense layers + MoE grouped GEMM in the MoE layers + dispatch overhead, none of which the chunkwise change touches).
 
-**Ship verdict**: keep flag off-default. The chunkwise infrastructure stays in tree as the foundation for Phase 2c (TC-MMA on the H_L update) which is the only remaining algorithmic lever that could deliver the +20-30 % prefill wall the original plan targeted. Flag is opt-in for research / Phase 2c+ development.
+**Initial ship verdict (2026-05-24)**: keep flag off-default. Reasoning: no measurable wall win on the hero MoE model, so the safer choice was to keep behavior unchanged until Phase 2c TC-MMA delivered an end-to-end win.
 
-**What would change the verdict**: Phase 2c TC-MMA on H_L brings Phase 2b below sequential by a wide enough margin (≥ +10 % wall) that the existing dispatch flips can benefit. That work is the next thread, and is multi-day kernel + validation effort.
+**Updated ship verdict (2026-05-24, after Phase 2c benched)**: **flip default to `gdn.chunkwise_scan = true`**. Reasoning revised:
+- Phase 2c exhaustive bench (this doc above) showed the TC-MMA path cannot beat Phase 1b.1 on sm_120 — there's no future Phase 2c win to wait for.
+- Phase 4 A/B is wall-neutral (±0.5 % on Qwen3.6) — flipping on is NOT a regression.
+- The +16.7 % kernel-microbench win is real and may surface on workloads where the GDN scan is a larger share of total wall (longer contexts, pure-GDN models like Qwen3.5-4B-GDN / Qwen3.5-9B-GDN when bench data lands, batched serving where the scan is closer to the critical path).
+- Coherence smoke at multiple contexts shows no degeneration (output bit-identical to flag-off under temperature=0, consistent with the unit-test bit-exactness on the Phase 1b.1 kernel).
+- Cost of "no" is leaving a free 17 % kernel-throughput improvement permanently behind a feature flag.
+
+Opt out via `--set gdn.chunkwise_scan=false` if a future model regresses; the dispatch fall-through path is unchanged.
 
 ## Risks
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -160,17 +160,26 @@ struct RuntimeConfig {
         float norm_eps_override = 0.0f;  // 0 = use model default
         bool ref_kernel = false;
         bool vhead_reorder = false;
-        // Phase 1b.1 of the GDN chunkwise SSD scan refactor
+        // GDN chunkwise SSD scan refactor — Phase 1b.1 structural prototype
         // (docs/plans/gdn_chunkwise_scan_design_2026_05_23.md). When true,
         // the executor dispatches GDN scan through
         // `gdn_scan_chunkwise_{f32,fp32out}` (chunk-cached K/Q in shared
         // memory) instead of the per-token-loop `gdn_scan_fused_{f32,fp32out}`.
         // Bit-near-equivalent output (FP16 1e-3 / FP32 1e-5 tolerances per
-        // Phase 1a); microbench shows +15.2 % on the GDN scan kernel alone
-        // at n_tok=4096. Off by default until Phase 2's WY-rep parallel
-        // matmul lands on top — the structural prereq is shipped, the
-        // algorithmic SSD win is Phase 2.
-        bool chunkwise_scan = false;
+        // Phase 1a); microbench shows +16.7 % on the GDN scan kernel alone
+        // at n_tok=4096 (1.567 → 1.343 µs/tok on RTX 5090). Phase 4
+        // cold-median A/B on Qwen3.6-35B-A3B Q4_K_M showed the end-to-end
+        // wall delta is within the cuBLAS variance band (±0.5 % across
+        // pp512 / pp2048 / tg128), so flipping the default on is wall-neutral
+        // for the hero MoE model and unlocks the kernel-level win for
+        // workloads where the GDN scan is a larger share of wall (longer
+        // contexts, pure-GDN models like Qwen3.5-4B-GDN / Qwen3.5-9B-GDN
+        // when bench data becomes available). Opt out via
+        // `--set gdn.chunkwise_scan=false` if a model regresses.
+        // After the Phase 2 ladder (2a / 2b / 2c, all shipped) was
+        // exhaustively benched, Phase 1b.1 remains the fastest chunkwise
+        // path on sm_120 — the WY-rep + TC-MMA variants all stay behind it.
+        bool chunkwise_scan = true;
         // Override gated-DeltaNet weight layout. Legacy env: IMP_GDN_LAYOUT.
         std::string layout_override;
     } gdn;


### PR DESCRIPTION
## Summary

Flips `RuntimeConfig::GDN::chunkwise_scan` from `false` to `true` as the default. Executor now dispatches the GDN scan through the Phase 1b.1 chunk-cached path by default; opt out via `--set gdn.chunkwise_scan=false`.

## Why

1. **Phase 2c benched (PR #393) — there's no future TC-MMA win to wait for.** The WY-rep + TC-MMA family CANNOT beat Phase 1b.1's simpler structural approach at GDN's production shape on sm_120. Phase 1b.1 is the best chunkwise path we have, period.

2. **Phase 4 cold-median A/B on Qwen3.6-35B-A3B-UD-Q4_K_M was wall-neutral**:

   |Config            | pp512    | pp2048   | tg128@2K |
   |---|---|---|---|
   |chunkwise=false   | 3175.15  | 3209.36  | 238.98 |
   |chunkwise=true    | 3169.59  | 3205.76  | 238.15 |
   |Δ                 | -0.18 %  | -0.11 %  | -0.35 % |

   All within the cuBLAS variance band. Flipping on is NOT a regression on the hero MoE model.

3. **The +16.7 % kernel-microbench win is real** (1.567 → 1.343 us/tok on the GDN scan kernel at n_tok=4096, n_heads=32, HD=SS=128). It may surface on workloads where the GDN scan is a larger share of total wall — longer contexts, pure-GDN models like Qwen3.5-4B-GDN / Qwen3.5-9B-GDN when bench data lands, batched serving where the scan is closer to the critical path.

4. **Coherence preserved**. Output is bit-identical to flag-off under temperature=0 (consistent with the unit-test bit-exactness on the Phase 1b.1 kernel: `ChunkBoundaryHandoff` max_diff = 0.0, `ChunkwiseProtoMatchesFused` max_diff = 0.0).

5. **The cost of "no" is leaving a free 17 % kernel-throughput improvement permanently behind a feature flag.** Now that Phase 2c proves nothing better is coming on sm_120, there's no good reason to keep waiting.

## Test plan

- [x] `test-moe-gdn --gtest_filter='GDNScanTest.*'` — 10/10 pass (1 microbench skipped by default)
- [x] Coherence smoke on Qwen3.6-35B-A3B with no explicit `--set` (picks up new default): coherent output, pp=120 tok/s, tg=216 tok/s
- [x] `verify-fast` pre-push gate passed
- [x] Updated Phase 4 section of the plan doc with the revised ship verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)