### PR TITLE
fix(mxfp4): cudaFree cascade on shutdown + tied-embed MXFP4 garbage output

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -403,6 +403,15 @@ struct WeightCaches {
     std::unordered_map<const void*, Tensor> fp16;
     size_t fp16_bytes = 0;
 
+    // Bulk allocation used by the MXFP4 → FP16 decode fallback. When set,
+    // every Tensor::data in `fp16` is a SUB-pointer (offset) into this single
+    // cudaMalloc'd buffer — cudaFree on the sub-pointers returns
+    // "invalid argument". On shutdown, range-check each fp16 entry against
+    // this region (analogous to fp8_migrated_data) and skip the per-tensor
+    // cudaFree; the bulk pointer is freed once via raw cudaFree.
+    void* fp16_bulk_data = nullptr;
+    size_t fp16_bulk_data_size = 0;
+
     // Fused KV: [wk; wv] per layer for strided batched prefill GEMM.
     std::unordered_map<int, Tensor> fused_kv;
     // Fused gate+up: [w_gate; w_up] per layer.

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -889,11 +889,28 @@ void GraphExecutor::free_buffers() {
             if (tensor.data)
                 vram_free(vram_alloc_, tensor.data);
         wcache_.fused_gate_up.clear();
-        // FP16 cache
-        for (auto& [ptr, tensor] : wcache_.fp16)
-            vram_free(vram_alloc_, tensor.data);
+        // FP16 cache — entries from the MXFP4 → FP16 decode fallback are
+        // sub-pointers into wcache_.fp16_bulk_data (single bulk cudaMalloc);
+        // skip the per-tensor cudaFree for those, free the bulk once below.
+        for (auto& [ptr, tensor] : wcache_.fp16) {
+            if (!tensor.data)
+                continue;
+            bool in_bulk = wcache_.fp16_bulk_data &&
+                           reinterpret_cast<uintptr_t>(tensor.data) >=
+                               reinterpret_cast<uintptr_t>(wcache_.fp16_bulk_data) &&
+                           reinterpret_cast<uintptr_t>(tensor.data) <
+                               reinterpret_cast<uintptr_t>(wcache_.fp16_bulk_data) +
+                                   wcache_.fp16_bulk_data_size;
+            if (!in_bulk)
+                vram_free(vram_alloc_, tensor.data);
+        }
         wcache_.fp16.clear();
         wcache_.fp16_bytes = 0;
+        if (wcache_.fp16_bulk_data) {
+            IMP_CUDA_CHECK_LOG(cudaFree(wcache_.fp16_bulk_data));
+            wcache_.fp16_bulk_data = nullptr;
+            wcache_.fp16_bulk_data_size = 0;
+        }
         // NVFP4 decode cache
         for (auto& [ptr, result] : wcache_.nvfp4)
             free_nvfp4_result(result);

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -942,6 +942,12 @@ if (mx_native > 0) {
             IMP_LOG_ERROR("MXFP4 FP16 bulk alloc failed: %s (%.1f MiB)", cudaGetErrorString(ae),
                           fp16_total / (1024.0 * 1024.0));
             d_fp16_bulk = nullptr;
+        } else {
+            // Track the bulk for shutdown cleanup. Each fp16 Tensor written
+            // below points to a sub-range of this allocation, so we cannot
+            // cudaFree the sub-pointers — only the bulk base.
+            wcache_.fp16_bulk_data = d_fp16_bulk;
+            wcache_.fp16_bulk_data_size = fp16_total;
         }
     }
 
@@ -1009,6 +1015,15 @@ if (mx_native > 0) {
         }
         replace_weight(const_cast<Model*>(model_)->out_proj_,
                        const_cast<Model*>(model_)->out_proj_.qtype);
+        // Tok-embed table — when weight tying is on (Qwen3.5-4B / others), it
+        // shares the same GPU storage as out_proj_, so its data pointer is
+        // already a key in wcache_.fp16. Without this replace, the embedding
+        // lookup reads the raw MXFP4 bytes as FP16 → garbage hidden state from
+        // token 0 → garbage logits → token-0 spam output. Also harmless when
+        // the embedding is FP16 (the lookup misses, qtype guard is satisfied
+        // anyway).
+        replace_weight(const_cast<Model*>(model_)->tok_emb_,
+                       const_cast<Model*>(model_)->tok_emb_.qtype);
         IMP_LOG_INFO("MXFP4 → FP16: replaced %d weight tensor pointers",
                      (int)wcache_.fp16.size());
     }

--- a/src/exec/pre_dequant_phase3c_mxfp4.cu
+++ b/src/exec/pre_dequant_phase3c_mxfp4.cu
@@ -87,6 +87,11 @@ void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
                 void* d_fp16_bulk = nullptr;
                 IMP_CUDA_CHECK_LOG(cudaMalloc(&d_fp16_bulk, fp16_total));
                 if (d_fp16_bulk) {
+                    // Track bulk for shutdown cleanup (same pattern as Phase 3).
+                    // Phase 3 and Phase 3c are mutually exclusive in practice
+                    // (gated on `nvfp4_decode_mode`), so only one writes here.
+                    wcache_.fp16_bulk_data = d_fp16_bulk;
+                    wcache_.fp16_bulk_data_size = fp16_total;
                     size_t offset = 0;
                     for (auto& sw : small_weights) {
                         size_t bytes = static_cast<size_t>(sw.N) * sw.K * sizeof(half);


### PR DESCRIPTION
## Summary

Fixes two related bugs that surface together on Qwen3.5-4B-mxfp4 (and any MXFP4 GGUF with weight tying):

### 1. cudaFree cascade on shutdown (~250 "invalid argument" errors)

The MXFP4 → FP16 dequant fallback (Phase 3 NVFP4-decode path and Phase 3c standalone-MXFP4 path) issues ONE bulk `cudaMalloc` for the entire FP16 fallback cache, then stores ~249 sub-pointers (offsets into the bulk) as `Tensor.data` in `wcache_.fp16`. The cleanup loop in `executor_workspace_buffers.cu::free_buffers` iterates `wcache_.fp16` and calls `cudaFree` on each `Tensor.data` — but `cudaFree` on a sub-pointer returns `cudaErrorInvalidValue`. Result: the first cudaFree succeeds (frees the entire bulk), the remaining ~248 fail with the cascade.

**Fix** mirrors the existing FP8 pattern: add `fp16_bulk_data` / `fp16_bulk_data_size` tracking fields to `WeightCaches`, store the bulk pointer from both Phase 3 and Phase 3c allocators, and range-check each `fp16` entry against the bulk region in the cleanup loop — skip the per-tensor `vram_free` for in-bulk pointers and free the bulk once.

### 2. Tied-embedding MXFP4 garbage output (token-0 spam)

When the MXFP4 source GGUF uses weight tying (output proj shares storage with token embedding), the dequant `replace_weight` loop only updates `model_->out_proj_`. The token embedding `tok_emb_` still points at the raw MXFP4 storage. The `embedding_lookup` kernel reads those bytes as half values → garbage hidden state from token 0 → garbage logits → argmax always picks token 0 → `! ! ! !` spam.

Confirmed root cause on Qwen3.5-4B-mxfp4:
```
token_embd.weight: type=MXFP4_v2 shape=(248320, 2560)
+ weight tying: output projection shares token embedding
```

**Fix**: extend the `replace_weight` loop to also cover `tok_emb_`. Because weight tying makes `tok_emb_.data == out_proj_.data`, the same `wcache_.fp16` entry (keyed by the shared pointer) is reused — no new allocation needed.

## Before / after on Qwen3.5-4B-mxfp4

| Before | After |
|---|---|
| `! ! ! !` (token 0 spam) | varied tokens generated |
| cudaFree cascade on exit (~250 errors) | clean shutdown |

Output coherence is still imperfect (model emits random multilingual tokens, not coherent English). That's a separate, deeper MXFP4-specific quality issue — likely in the same family as the `Qwen3.5-27B MXFP4 IMA` open issue in MEMORY.md (which has its own design memo at `docs/plans/qwen35_27b_mxfp4_host_dequant_design_2026_05_17.md`). This PR is the narrow fix for the two bugs called out above.

## Test plan

- [x] Qwen3.5-4B-mxfp4: no more cudaFree cascade, no more token-0 spam
- [x] Qwen3-8B-Q8_0: regression check — coherent output, normal perf (235 tok/s tg)
- [x] Qwen3.6-35B-A3B-UD-Q4_K_M: regression check — coherent output, normal perf (202 tok/s tg)
- [x] `test-moe-gdn --gtest_filter='GDNScanTest.*'`: 10/10 pass (1 microbench skipped)
- [x] verify-fast pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)