### PR TITLE
docs: mark GGUF + MXFP4 paths as legacy / maintenance-mode

### DIFF
--- a/src/compute/gemm_cutlass_mxfp4_sm120.cu
+++ b/src/compute/gemm_cutlass_mxfp4_sm120.cu
@@ -1,5 +1,12 @@
 // CUTLASS sm_120 block-scaled MXFP4×MXFP4 GEMM for prefill acceleration.
 //
+// LEGACY / MAINTENANCE MODE (2026-05-24): MXFP4 is supported but is not
+// the dev priority. Production hero models use NVFP4 + SafeTensors
+// (Qwen3.6-35B-A3B-NVFP4, Qwen3-8B-NVFP4-cortecs, Gemma-4-26B-A4B-it-NVFP4,
+// etc.). Ship cleanup fixes here and don't chase residual quality bugs on
+// community MXFP4 GGUFs without an external reference engine to compare
+// against. Memory note: `feedback_gguf_mxfp4_legacy_2026_05_24`.
+//
 // Parallel to the NVFP4 CUTLASS path (gemm_cutlass_sm120.cu) but uses
 // mx_float4_t<float_e2m1_t> with UE8M0 scale factors (SFVecSize=32).
 //

--- a/src/exec/pre_dequant_phase3c_mxfp4.cu
+++ b/src/exec/pre_dequant_phase3c_mxfp4.cu
@@ -8,6 +8,14 @@
 // Extracted from executor_pre_dequant.cu in Phase 3 of the architecture
 // refactor roadmap. This is the final extraction — after this PR,
 // executor_pre_dequant.cu is the pure orchestrator.
+//
+// LEGACY / MAINTENANCE MODE (2026-05-24): MXFP4 is supported but not the
+// dev priority. NVFP4 + SafeTensors is where the hero models live. Ship
+// cleanup fixes here (load errors, missing pointer replaces, resource
+// leaks) and move on — don't chase residual output-quality bugs on
+// community MXFP4 quants without an external reference engine
+// (llama.cpp / HF Transformers) to compare against. See memory note
+// `feedback_gguf_mxfp4_legacy_2026_05_24` for the full rule.
 
 #include "exec/executor.h"
 #include "exec/pre_dequant_internal.h"

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -1,3 +1,20 @@
+// ============================================================================
+// GGUF loader.
+//
+// STATUS: LEGACY / MAINTENANCE MODE (2026-05-24).
+//   GGUF is supported for compatibility but is no longer the active dev surface.
+//   Priority is NVFP4 + SafeTensors (Qwen3.6-35B-A3B-NVFP4, Qwen3-8B-NVFP4-cortecs,
+//   Gemma-4-26B-A4B-it-NVFP4, etc.) — that's where the hero-model perf work lives.
+//
+//   For GGUF bugs, ship the cleanup fix (load errors, missing pointer replaces,
+//   resource cleanup cascades) and move on. Don't sink session time chasing
+//   residual quality issues — especially on community MXFP4 quants, which have
+//   a track record of being subtly broken (see qwen35_27b_mxfp4_ima_2026_04_25
+//   and qwen35_4b_mxfp4_load_partial_fix_2026_05_24 memory notes). If the next
+//   debug step requires comparing against an external reference engine
+//   (llama.cpp / HF Transformers), declare done and defer.
+// ============================================================================
+
 #include "model/gguf_loader.h"
 #include "model/loader_assign.h"
 #include "model/model_arch.h"


### PR DESCRIPTION
Per user feedback after the Qwen3.5-4B-mxfp4 deep dive concluded with all in-imp suspects ruled out: 'achso gguf... ist legacy.'

Marks three top-of-file comment blocks to make the prioritization visible at the source-code level:
- `src/model/gguf_loader.cpp`
- `src/exec/pre_dequant_phase3c_mxfp4.cu`
- `src/compute/gemm_cutlass_mxfp4_sm120.cu`

The rule: ship cleanup fixes (load errors, missing pointer replaces, resource leaks). If the next debug step requires comparing hidden states against llama.cpp / HF Transformers, declare done and defer — out of cleanly-scopeable session boundaries.

Cross-refs in memory: `feedback_gguf_mxfp4_legacy_2026_05_24`, `qwen35_4b_mxfp4_load_partial_fix_2026_05_24`, `qwen35_27b_mxfp4_ima_2026_04_25`.

No code changes.