### PR TITLE
fix: enable VRAM reclamation (7.3 GiB) + WDDM cuBLAS workaround

### DIFF
--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -466,7 +466,7 @@ void GraphExecutor::pre_dequant_phase4b_drop_redundant_sources_(
     // cudaFreeAsync + cudaMemPoolTrimTo (avoids the WDDM release that
     // corrupts cuBLAS). Requires refactoring weight_upload.cu to use
     // async allocation. Alternatively, file NVIDIA bug + wait for fix.
-    constexpr bool actually_free = false;
+    constexpr bool actually_free = true;
 
     auto* mut_model = const_cast<Model*>(model_);
     size_t marked_bytes = 0;
@@ -544,6 +544,16 @@ void GraphExecutor::pre_dequant_phase4b_drop_redundant_sources_(
             skipped_shared_count, skipped_shared_bytes / (1024.0 * 1024.0));
         if (actually_free) {
             cudaDeviceSynchronize();
+            // WSL2/CUDA 13.2/sm_120 workaround: mass cudaFree causes WDDM to
+            // release physical GPU pages, corrupting cuBLAS internal state.
+            // Allocating + freeing a refill block of the same size forces the
+            // driver to re-commit pages, restoring cuBLAS to a working state.
+            void* refill = nullptr;
+            if (cudaMalloc(&refill, marked_bytes) == cudaSuccess) {
+                cudaFree(refill);
+                IMP_LOG_INFO("Phase-4b: WDDM page refill %.2f MiB (cuBLAS workaround)",
+                             marked_bytes / (1024.0 * 1024.0));
+            }
             gemm_reset();
             IMP_LOG_INFO("Phase-4b: cuBLAS handles + algo cache reset after VRAM reclamation");
         }


### PR DESCRIPTION
## Summary
- **Flip `actually_free = true`**: 201 redundant GGUF source weights freed after overlay caches (NVFP4/FP8) are built
- **7.3 GiB VRAM reclaimed** on Qwen3-14B Q6_K (10.2 GiB free vs ~3 GiB before)
- **WDDM page refill workaround**: transient `cudaMalloc`+`cudaFree` of the freed size forces the WSL2 driver to re-commit physical pages, fixing cuBLAS status-14

The cuBLAS-14 root cause (mass `cudaFree` on WSL2/CUDA 13.2/sm_120 corrupts cuBLAS context) was identified in PR #399. This PR applies the 2-line workaround that makes it safe to actually free the memory.

## Test plan
- [x] 401 GTests pass, 0 failures
- [x] Qwen3-14B Q6_K: tg128=137 tok/s, no cuBLAS errors, 10.2 GiB free VRAM
- [x] Qwen3-8B Q8_0: tg128=230 tok/s, 5.2 GiB freed, no regression
- [x] Pre-push verify-fast passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)