### PR TITLE
docs: architecture.md + imp.conf.example updates

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ distinct private methods on `Engine`:
 | Load runtime config | `RuntimeConfig::load()` | `imp.conf` + `--config` CLI + legacy env-var seeds (`src/runtime/config.cpp`) |
 | Resolve quant/KV/SSM dtypes | `init_resolve_*` group | `init_resolve_kv_dtype_policy_`, `init_resolve_ssm_dtype_`, `init_resolve_fp8_prefill_`, `init_resolve_quant_flags_` |
 | Compute max sequence length | `init_compute_max_seq_len_` | VRAM budget → max context (`src/runtime/vram_budget.cpp`) |
-| Upload weights | `init_weights` | `upload_weight` + `upload_expert_weights` in `src/model/weight_upload.cu`; pre-dequant orchestrated by `src/exec/executor_pre_dequant.cu` (76 LOC dispatcher, calls 7 per-phase TUs: `pre_dequant_phase0_nvfp4_loader.cu`, `phase1_fp16_cache.cu`, `phase2_fp8_cache.cu`, `phase3_nvfp4_decode.cu`, `phase3c_mxfp4.cu`, `phase4_tensor_registry.cu`) |
+| Upload weights | `init_weights` | `upload_weight` + `upload_expert_weights` in `src/model/weight_upload.cu`; pre-dequant orchestrated by `src/exec/executor_pre_dequant.cu` (calls per-phase TUs: `phase0_nvfp4_loader.cu`, `phase1_fp16_cache.cu`, `phase2_fp8_cache.cu`, `phase3_nvfp4_decode.cu`, `phase3c_mxfp4.cu`, `phase4_tensor_registry.cu`, `phase4b` drop-source + VRAM reclamation, `phase4c` second-pass FP8 using reclaimed VRAM) |
 | Init KV cache | `init_kv_cache` | Paged blocks (block_size=16); dtype is FP16 / FP8 / INT8 / INT4 / NVFP4 / MXFP4 |
 | Allocate workspaces | `init_features` | MMVQ scratch, cuBLAS S-matrix (~1 GiB — see Known wounds), FP8 activation scratch, split-K attn scratch |
 | Warm up | `warmup()` | Captures CUDA graph for decode (`src/runtime/cuda_graph.cu`) |

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -91,6 +91,10 @@ no_dp4a_gemv         = false
 no_dp4a_lm           = false
 no_mmvq              = false
 no_mmvq_q8_0         = false
+# Extend NVFP4 decode cache to Q4_K/Q3_K/Q2_K models (default: only Q8/Q6/Q5).
+# Trades VRAM for decode throughput on sub-8-bit models.
+# Gemma-3-12B Q4_K_M: 77 → 141 tok/s (+82%).
+nvfp4_decode_all     = false
 
 # [gemma4] section moved out of the global RuntimeConfig in Phase 5
 # Track A of the architecture refactor. These are now per-model


### PR DESCRIPTION
## Summary
- `docs/architecture.md`: document Phase 4b (drop-source + VRAM reclamation) and Phase 4c (second-pass FP8) in the pre-dequant pipeline description
- `imp.conf.example`: add `gemm.nvfp4_decode_all` config option with description and performance impact note (Gemma-3-12B Q4_K_M: +82% decode)

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)