### PR TITLE
refactor(phase5): delete legacy gemm_dispatch switch, migrate FP16 M=1 tier

### DIFF
--- a/docs/superpowers/specs/2026-05-25-legacy-switch-cleanup.md
+++ b/docs/superpowers/specs/2026-05-25-legacy-switch-cleanup.md
@@ -1,53 +1,50 @@
 # Legacy gemm_dispatch Switch Cleanup
 
-**Status**: planned (next session)
-**Estimated effort**: 2-3h
+**Status**: done
+**Estimated effort**: 2-3h (actual: ~1h)
 **Prereqs**: PR #399 (dispatch migration), PR #400 (M=1 gemv_dispatch) — both merged
 
 ## Goal
 
 Trim the 290-LOC `gemm_dispatch(Tensor, Tensor, Tensor, GemmContext)` in
-`src/exec/executor_kernels.cu` to a ~50 LOC fallback that only handles:
+`src/exec/executor_kernels.cu` to a ~66 LOC static fallback that only handles:
 
 1. `kInvalidTensorID` — unregistered weights (budget-exhausted, no overlay)
-2. Generic dequant catch-all for M>1 prefill on uncached weights
+2. `beta != 0` residual-add for M=1 on registered weights
+3. Generic dequant catch-all for M>1 prefill on uncached weights
 
-## What's dead
+## Plan correction
 
-After PR #399 + #400, `gemm_via_handle_()` routes all 29 call sites:
+The original plan assumed the legacy switch was only reached for
+`kInvalidTensorID`, but `StorageTier::FP16` handles at M=1 also fell through
+the `default: break` in `gemm_via_handle_`'s switch. Deleting the FP16 cache,
+FP16 raw, and dp4a branches without migrating FP16 tier would have broken
+GGUF decode for models without NVFP4 decode cache (Q8_0, Q4_K_M, etc.).
 
-- **M>1**: WeightHandle dispatch (`weight_dispatch.cu`) for all tiers
-- **M=1 NVFP4/FP8/MXFP4**: `gemv_dispatch` (WeightHandle)
-- **M=1 CUTLASS_NVFP4**: secondary `wcache_.nvfp4` probe → kpar GEMV
-- **M=1 FP16 + dp4a source**: `GemmKernelRegistry` dp4a handler
-- **M=1 FP16 native**: `gemv_dispatch` → cuBLAS GEMV
+Fix: added `case StorageTier::FP16:` to `gemm_via_handle_`'s M=1 switch that
+routes GGUF block-quant sources through the dp4a/mmvq registry handler (same
+5-10x decode advantage over cuBLAS on the FP16 overlay) and native FP16 weights
+through `gemv_dispatch`. This made all legacy branches truly dead.
 
-The legacy switch is only reached from `gemm_via_handle_`'s fallback for
-`kInvalidTensorID`. The following code paths in the switch are dead:
+## What was deleted
 
-- MXFP4 native GGUF (line ~1642) — handled by `gemm_via_handle_` M>1
-- Q4_K IMMA (line ~1667) — handled by M>1 WeightHandle
-- FP8 prefill (line ~1681) — handled by M>1 WeightHandle
-- NVFP4 decode GEMV M=1 (line ~1714) — handled by `gemv_dispatch`
-- CUTLASS NVFP4 prefill M>1 (line ~1749) — handled by M>1 WeightHandle
-- NVFP4 prefill M>1 (line ~1779) — handled by M>1 WeightHandle
-- FP16 cache M>1 (line ~1806) — handled by M>1 WeightHandle
-- FP16 raw (line ~1829) — handled by M>1 WeightHandle
-- GGUF small-M dp4a (line ~1839) — handled by `gemm_via_handle_` FP16 M=1
-- Coverage-gap guard (line ~1887) — `gemm_via_handle_` routes dropped weights
+All 10 tier-specific branches (MXFP4, Q4K_IMMA, FP8, NVFP4 M=1, CUTLASS M>1,
+NVFP4 M>1, FP16 cache, FP16 raw, dp4a small-M, coverage-gap guard) plus
+5 cache pointer variables (fp16, fp8, nv4, ct4, mx4).
 
 ## What stays
 
-- Generic dequant catch-all (line ~1869): `dequant_gpu` + cuBLAS for
-  uncached weights at M>1. This is the safety net for budget-exhausted models.
-- Final raw FP16 fallback (line ~1898): `gemm(input, weight, ...)` for
-  natively FP16/BF16 uncached weights.
+- Beta != 0 section: FP16 cache lookup or dequant->cuBLAS for residual-add
+- Generic dequant catch-all (M>1 prefill for uncached weights)
+- Dropped-weight coverage-gap warning
+- Raw FP16/BF16 cuBLAS final fallback
+- Function renamed to `gemm_dispatch_uncached_fallback` (static, declaration
+  removed from executor_kernels.h)
 
-## Steps
+## Changes
 
-1. Delete the dead branches (MXFP4, Q4K_IMMA, FP8, NVFP4 M=1, CUTLASS,
-   FP16 cache, dp4a small-M, coverage-gap guard)
-2. Keep generic-dequant + raw-FP16 fallback (~50 LOC)
-3. Rename function to `gemm_dispatch_uncached_fallback_` or similar
-4. Update `gemm_via_handle_` to call the renamed function
-5. Build + 401 tests + smoke bench
+- `src/exec/executor_kernels.cu`: `gemm_dispatch` 290 LOC -> 66 LOC static
+  `gemm_dispatch_uncached_fallback`. `gemm_via_handle_` gained FP16 tier
+  routing with dp4a/mmvq for GGUF sources + gemv_dispatch for native FP16.
+- `src/exec/executor_kernels.h`: removed `gemm_dispatch` declaration (now
+  file-local)

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -990,10 +990,8 @@ private:
     // 5.1.3.d transitional: route M>1 prefill through WeightHandle dispatch
     // (tier-aware, no raw-data deref), M=1 decode through legacy dispatch
     // (dp4a on original quant is fastest). Caller passes both the TensorID
-    // and the original Tensor as fallback.
-    void gemm_via_handle_(TensorID id, const Tensor& weight_fallback,
-                          const Tensor& input, Tensor& output,
-                          const GemmContext& ctx);
+    void gemm_via_handle_(TensorID id, const Tensor& input,
+                          Tensor& output, const GemmContext& ctx);
     // MoE forward-pass phase helpers. The per-call locals live in the
     // MoeFfnContext struct declared just above the GraphExecutor class.
     void moe_ffn_phase1_setup_(int layer, cudaStream_t stream);

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -452,14 +452,14 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 }
                 if (n > 1 && fused_kv && !per_layer_shapes) {
                     // Q: still separate (different output dim with GQA)
-                    gemm_via_handle_(ly.wq_id, ly.wq, no, q_target, ctx);
+                    gemm_via_handle_(ly.wq_id, no, q_target, ctx);
                     // K+V: one batched cuBLAS call
                     gemm_kv_batched(no, *fused_kv, kk, vv, stream);
                 } else {
-                    gemm_via_handle_(ly.wq_id, ly.wq, no, q_target, ctx);
-                    gemm_via_handle_(ly.wk_id, ly.wk, no, kk, ctx);
+                    gemm_via_handle_(ly.wq_id, no, q_target, ctx);
+                    gemm_via_handle_(ly.wk_id, no, kk, ctx);
                     if (ly.wv.data != nullptr) {
-                        gemm_via_handle_(ly.wv_id, ly.wv, no, vv, ctx);
+                        gemm_via_handle_(ly.wv_id, no, vv, ctx);
                     }
                     // else: K=V sharing path — vv populated below from kk.
                 }
@@ -1146,12 +1146,12 @@ after_attention:
     } else if (will_fuse_o_beta1 && wo_tier == StorageTier::FP16) {
         // Fused: hidden = attn_out @ wo^T + hidden (cuBLAS beta=1).
         // Safe: hidden is only READ (never written) between attn_norm and here.
-        gemm_via_handle_(ly.wo_id, ly.wo, ao, h, ctx.with_beta(1.0f));
+        gemm_via_handle_(ly.wo_id, ao, h, ctx.with_beta(1.0f));
     } else if ((will_fuse_o_beta1 || will_fuse_o_dequant_beta1) && qscratch_.dequant != nullptr &&
                dequant_gpu_supported(ly.wo.qtype) &&
                !per_layer_shapes) {  // Gemma 4: workspace stride mismatch with narrow ao
         // Dequant beta=1: dequant weights on-the-fly, then FP16 GEMM + residual
-        gemm_via_handle_(ly.wo_id, ly.wo, ao, h, ctx.with_beta(1.0f));
+        gemm_via_handle_(ly.wo_id, ao, h, ctx.with_beta(1.0f));
     } else {
         // Fallback: separate O-projection + optional post-norm + residual add.
         // Diagnostic: when IMP_GEMMA4_FP32_GEMM_OUT is set on Gemma-4, after the
@@ -1173,9 +1173,9 @@ after_attention:
             IMP_CUDA_CHECK_LOG(cudaMallocAsync(&po_fp32_buf, bytes, stream));
             int64_t shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(model_->config().d_model)};
             Tensor po_fp32(po_fp32_buf, QType::F32, 2, shape, true);
-            gemm_via_handle_(ly.wo_id, ly.wo, ao, po_fp32, ctx);
+            gemm_via_handle_(ly.wo_id, ao, po_fp32, ctx);
         } else {
-            gemm_via_handle_(ly.wo_id, ly.wo, ao, po, ctx);
+            gemm_via_handle_(ly.wo_id, ao, po, ctx);
         }
         if (debug_attn_steps) {
             debug_tensor_stats_all("L0_ao_pre_wo", view_tokens(ao, n), stream);

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -234,8 +234,8 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                     // Batched gate+up: single cuBLAS call for both projections
                     gemm_pair_batched(no, *fused_gu, go, uo, stream);
                 } else {
-                    gemm_via_handle_(ly.w_gate_id, ly.w_gate, no, go, ctx);
-                    gemm_via_handle_(ly.w_up_id, ly.w_up, no, uo, ctx);
+                    gemm_via_handle_(ly.w_gate_id, no, go, ctx);
+                    gemm_via_handle_(ly.w_up_id, no, uo, ctx);
                 }
             }
         }
@@ -435,13 +435,13 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                               stream);
             } else if (will_fuse_down_beta1 && wd_tier == StorageTier::FP16) {
                 // Fused: hidden = swiglu_out @ w_down^T + hidden (cuBLAS beta=1).
-                gemm_via_handle_(ly.w_down_id, ly.w_down, so, h, ctx.with_beta(1.0f));
+                gemm_via_handle_(ly.w_down_id, so, h, ctx.with_beta(1.0f));
             } else if ((will_fuse_down_beta1 || will_fuse_down_dequant_beta1) &&
                        qscratch_.dequant != nullptr && dequant_gpu_supported(ly.w_down.qtype)) {
                 // Dequant into scratch, then beta=1.0 GEMM directly into hidden (which holds residual)
-                gemm_via_handle_(ly.w_down_id, ly.w_down, so, h, ctx.with_beta(1.0f));
+                gemm_via_handle_(ly.w_down_id, so, h, ctx.with_beta(1.0f));
             } else {
-                gemm_via_handle_(ly.w_down_id, ly.w_down, so, fo, ctx);
+                gemm_via_handle_(ly.w_down_id, so, fo, ctx);
                 if (has_post_ffn_norm && using_fp32_accum) {
                     // Post-FFN norm → FP32 accumulation (no D2D copy needed)
                     Tensor fp32_h = view_tokens(fp32_hidden_, n);

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -694,7 +694,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             debug_tensor_stats("W_output_norm", model_->output_norm(), stream);
             rmsnorm(h_last, model_->output_norm(), no_last, cfg.rms_norm_eps, stream, norm_w_off_);
             debug_tensor_stats("after_final_rmsnorm", no_last, stream);
-            gemm_via_handle_(model_->out_proj_id, model_->output_proj(), no_last, lg, ctx);
+            gemm_via_handle_(model_->out_proj_id, no_last, lg, ctx);
         }
         logits_out = lg;
         debug_top_logits(lg, stream);
@@ -776,7 +776,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             if (lm_tier == StorageTier::FP16) {
                 Tensor no_final = view_tokens(norm_out_, n);
                 rmsnorm(h_final, model_->output_norm(), no_final, cfg.rms_norm_eps, stream, norm_w_off_);
-                gemm_via_handle_(model_->out_proj_id, model_->output_proj(), no_final, lg, ctx);
+                gemm_via_handle_(model_->out_proj_id, no_final, lg, ctx);
                 goto lm_head_done;
             }
             auto* q8 = static_cast<block_q8_1*>(qscratch_.q8_1_buf);
@@ -813,7 +813,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 gemm_cublaslt(fp8_no, fp8_lm_w, lg, 1.0f, 0.0f, qscratch_.d_act_scale,
                               lm_h->payload.fp8.d_scale, stream);
             } else {
-                gemm_via_handle_(model_->out_proj_id, model_->output_proj(), no_final, lg, ctx);
+                gemm_via_handle_(model_->out_proj_id, no_final, lg, ctx);
             }
         }
     lm_head_done:

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -2784,11 +2784,11 @@ void GraphExecutor::run_shared_expert_ffn(int layer, cudaStream_t stream, int n,
 
     auto ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config(), cur_force_fp16_,
                                  model_->config().overrides.gemma4.force_mmvq);
-    gemm_via_handle_(ly.w_up_shared_id, ly.w_up_shared, no, sh_up, ctx);
+    gemm_via_handle_(ly.w_up_shared_id, no, sh_up, ctx);
 
     if (shared_gated) {
         Tensor sh_gate(moe_.expert_gate.data, compute_dtype_, 2, sh_shape, true);
-        gemm_via_handle_(ly.w_gate_shared_id, ly.w_gate_shared, no, sh_gate, ctx);
+        gemm_via_handle_(ly.w_gate_shared_id, no, sh_gate, ctx);
         if (cfg.ffn_activation == FFNActivation::GEGLU)
             geglu(sh_gate, sh_up, sh_swiglu, stream);
         else
@@ -2807,7 +2807,7 @@ void GraphExecutor::run_shared_expert_ffn(int layer, cudaStream_t stream, int n,
     Tensor& sh_act = shared_gated ? sh_swiglu : sh_up;
     if (layer == 0)
         debug_tensor_stats_all("L0_sh_act_preDown", sh_act, stream);
-    gemm_via_handle_(ly.w_down_shared_id, ly.w_down_shared, sh_act, sh_down, ctx);
+    gemm_via_handle_(ly.w_down_shared_id, sh_act, sh_down, ctx);
 
     if (layer == 0) {
         debug_tensor_stats_all("L0_sh_down_raw", sh_down, stream);

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1581,21 +1581,12 @@ Tensor slice_rows(const Tensor& buf, int n_tokens) {
 }
 
 // ---------------------------------------------------------------------------
-// gemm_dispatch — single entry point that walks the GemmKernel registry in
-// tier-priority order. R5 Slice 8.6 closes the cross-axis refactor: the
-// legacy 21-parameter `gemm_dispatch_impl` switch (~250 LOC) is retired and
-// the registry is now the unconditional path. Every tier registers its
-// adapter from its own .cu file at static-init time (see
-// gemm_kernel_*.cu); adding a new qtype/quantization tier is a one-file
-// change.
-//
-// Tier order (MXFP4 GGUF → FP8 → NVFP4 GEMV → CUTLASS_NVFP4 → NVFP4 GEMM →
-// FP16 cache/raw → small-M GGUF → generic-dequant catch-all) mirrors the
-// historical legacy precedence and is the same as Slice 8 documented; it is
-// observed-equivalent to the production behaviour from when Slice 8 flipped
-// the registry default ON.
 // ---------------------------------------------------------------------------
-void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, const GemmContext& ctx) {
+// Uncached fallback: safety net for weights without a WeightHandle
+// (kInvalidTensorID, budget-exhausted) and for M=1 beta!=0 residual-add.
+// ---------------------------------------------------------------------------
+static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& weight,
+                                            Tensor& output, const GemmContext& ctx) {
     const auto* wc = ctx.wcache;
     const auto* qs = ctx.qscratch;
     if (!wc || !qs)
@@ -1603,16 +1594,12 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
 
     const QType qtype = weight.qtype;
 
-    // Residual-add fuse (beta != 0): only FP16 weight cache or dequantable-to-FP16
-    // is supported. GEMV and block-scaled quant paths don't honor beta — callers
-    // for those cases must continue to use their explicit fast paths.
     if (ctx.beta != 0.0f) {
         auto it = wc->fp16.find(weight.data);
         if (it != wc->fp16.end()) {
             gemm(input, it->second, output, 1.0f, ctx.beta, ctx.stream);
             return;
         }
-        // dequant_gpu derefs weight.data raw — skip if dropped (5.1.4.b).
         if (qs->dequant != nullptr && dequant_gpu_supported(qtype) && !weight.dropped_source) {
             int rows = static_cast<int>(weight.shape[0]);
             int cols = static_cast<int>(weight.shape[1]);
@@ -1621,252 +1608,19 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
             gemm(input, w_fp16, output, 1.0f, ctx.beta, ctx.stream);
             return;
         }
-        if (weight.qtype == QType::F16 || weight.qtype == QType::BF16) {
+        if (qtype == QType::F16 || qtype == QType::BF16) {
             gemm(input, weight, output, 1.0f, ctx.beta, ctx.stream);
             return;
         }
         IMP_LOG_ERROR(
-            "gemm_dispatch: beta=%.3f requested but no FP16 path available "
-            "for qtype=%d",
+            "gemm_dispatch_uncached_fallback: beta=%.3f but no FP16 path for qtype=%d",
             ctx.beta, (int)qtype);
         return;
     }
 
-    const auto* fp16 = &wc->fp16;
-    const auto* fp8 = (wc->use_fp8 && !ctx.force_fp16) ? &wc->fp8 : nullptr;
-    const auto* nv4 = (wc->nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->nvfp4;
-    const auto* ct4 = (wc->cutlass_nvfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_nvfp4;
-    const auto* mx4 = (wc->cutlass_mxfp4.empty() || ctx.force_fp16) ? nullptr : &wc->cutlass_mxfp4;
-
     const int M = static_cast<int>(input.shape[0]);
 
-    // MXFP4 native GGUF (top priority). The kernel adapter gates internally
-    // on `linear_scales != nullptr`; cache miss + dequant_scratch nullptr at
-    // M>1 returns PreconditionFail so we fall through to the rest of the
-    // table — same as the legacy `else if (dequant_scratch != nullptr)` skip.
-    if (mx4 != nullptr && input.qtype == QType::F16) {
-        auto mx_it = mx4->find(weight.data);
-        if (mx_it != mx4->end() && mx_it->second.linear_scales != nullptr) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.beta = ctx.beta;
-            args.weight_payload = &mx_it->second;
-            args.dequant_scratch = qs->dequant;  // only consumed by M>1 path
-            GemmStrategy strat{StorageTier::MXFP4, QType::F16, /*m_is_one=*/(M == 1)};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-    }
-    // Q4_K_M direct-GEMM via INT8 IMMA (Phase 2C). Opt-in via
-    // `gemm.q4k_imma_enabled` (default off); production-recommended for dense
-    // Q4_K_M weights at M ≥ 1024 where the kernel's ~40 TOPS plateau beats
-    // the dequant→cuBLAS fallback. Falls through to FP8 / generic dequant on
-    // any precondition failure inside the handler. See
-    // docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md.
-    if (qtype == QType::Q4_K && input.qtype == QType::F16 && M >= 1024 &&
-        ctx.beta == 0.0f && ctx.q4k_imma_enabled) {
-        GemmKernelArgs args{};
-        args.input = &input;
-        args.output = &output;
-        args.stream = ctx.stream;
-        args.weight_payload = &weight;
-        GemmStrategy strat{StorageTier::FP16, QType::Q4_K, /*m_is_one=*/false};
-        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-            return;
-    }
-    // FP8 prefill (M>1): cache hit → FP8xFP8 cuBLASLt; cache miss with
-    // dequant-supported qtype → dequant→FP16 cuBLAS (Slice 8.1). Raw FP16
-    // weights drop to the FP16 strategy below.
-    if (fp8 != nullptr && M > 1 && qs->fp8_act != nullptr && qs->d_act_scale != nullptr) {
-        auto it = fp8->find(weight.data);
-        if (it != fp8->end()) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.beta = ctx.beta;
-            args.weight_payload = &it->second;
-            args.fp8_act_buf = qs->fp8_act;
-            args.d_act_scale = qs->d_act_scale;
-            args.d_fp8_block_maxes = qs->d_fp8_block_maxes;
-            args.d_fp8_absmax = qs->d_fp8_absmax;
-            args.fp8_max_grid = qs->fp8_max_grid;
-            GemmStrategy strat{StorageTier::FP8, QType::F16, /*m_is_one=*/false};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        } else {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.beta = ctx.beta;
-            args.weight_payload = &weight;
-            args.dequant_scratch = qs->dequant;
-            GemmStrategy strat{StorageTier::FP8, QType::NONE, /*m_is_one=*/false};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-    }
-    // NVFP4 decode GEMV (M==1). Prequant Tensor sidecars (qtype=NVFP4 on the
-    // weight) take precedence over the nv4 cache; the temp NvFP4QuantResult
-    // is constructed here when sidecars are present.
-    if (M == 1 && input.qtype == QType::F16) {
-        NvFP4QuantResult nvfp4_tmp;
-        const NvFP4QuantResult* nvfp4_view = nullptr;
-        if (weight.qtype == QType::NVFP4 && weight.scales != nullptr) {
-            nvfp4_tmp.packed_data = weight.data;
-            nvfp4_tmp.micro_scales = weight.scales;
-            nvfp4_tmp.tensor_scale = weight.tensor_scale;
-            nvfp4_tmp.N = weight.shape[0];
-            nvfp4_tmp.K = weight.shape[1] * 2;  // shape[1] is packed K/2
-            nvfp4_view = &nvfp4_tmp;
-        } else if (nv4 != nullptr) {
-            auto it = nv4->find(weight.data);
-            if (it != nv4->end())
-                nvfp4_view = &it->second;
-        }
-        if (nvfp4_view != nullptr) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.beta = ctx.beta;
-            args.weight_payload = nvfp4_view;
-            GemmStrategy strat{StorageTier::NVFP4, QType::F16, /*m_is_one=*/true};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-    }
-    // CUTLASS_NVFP4 prefill GEMM (M>1, native sm_120 block-scaled FP4 —
-    // preferred path). Slice 8.6 — QW7 dual-cache MXFP4 hand-off. When
-    // `--mxfp4-prefill` is on, executor_pre_dequant.cu populates
-    // `cutlass_mxfp4` by iterating every NVFP4 entry: cache membership is a
-    // superset of cutlass_nvfp4. We forward the MXFP4 payload + scratch
-    // through `args.mxfp4_payload` so the handler can try the MXFP4 CUTLASS
-    // GEMM first and fall back to NVFP4 CUTLASS on failure (mirrors the
-    // retired legacy QW7 probe).
-    if (M > 1 && input.qtype == QType::F16 && ct4 != nullptr &&
-        qs->cutlass_act_data != nullptr) {
-        auto ct_it = ct4->find(weight.data);
-        if (ct_it != ct4->end()) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.beta = ctx.beta;
-            args.weight_payload = &ct_it->second;
-            args.cutlass_act_data = qs->cutlass_act_data;
-            args.cutlass_act_sf = qs->cutlass_act_sf;
-            args.cutlass_workspace = qs->cutlass_workspace;
-            args.cutlass_workspace_size = qs->cutlass_workspace_size;
-            if (mx4 != nullptr && qs->mxfp4_act_sf != nullptr) {
-                auto mx_it = mx4->find(weight.data);
-                if (mx_it != mx4->end()) {
-                    args.mxfp4_payload = &mx_it->second;
-                    args.mxfp4_act_sf = qs->mxfp4_act_sf;
-                    args.mxfp4_workspace = qs->mxfp4_workspace;
-                    args.mxfp4_workspace_size = qs->mxfp4_workspace_size;
-                }
-            }
-            GemmStrategy strat{StorageTier::CUTLASS_NVFP4, QType::F16, /*m_is_one=*/false};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-    }
-    // NVFP4 prefill GEMM (M>1, dequant→cuBLAS fallback) — fires when the
-    // CUTLASS path is unavailable or returned PreconditionFail.
-    if (M > 1 && input.qtype == QType::F16) {
-        NvFP4QuantResult nvfp4_tmp;
-        const NvFP4QuantResult* nvfp4_view = nullptr;
-        if (weight.qtype == QType::NVFP4 && weight.scales != nullptr) {
-            nvfp4_tmp.packed_data = weight.data;
-            nvfp4_tmp.micro_scales = weight.scales;
-            nvfp4_tmp.tensor_scale = weight.tensor_scale;
-            nvfp4_tmp.N = weight.shape[0];
-            nvfp4_tmp.K = weight.shape[1] * 2;  // shape[1] is packed K/2
-            nvfp4_view = &nvfp4_tmp;
-        } else if (nv4 != nullptr) {
-            auto it = nv4->find(weight.data);
-            if (it != nv4->end())
-                nvfp4_view = &it->second;
-        }
-        if (nvfp4_view != nullptr) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.beta = ctx.beta;
-            args.weight_payload = nvfp4_view;
-            GemmStrategy strat{StorageTier::NVFP4, QType::F16, /*m_is_one=*/false};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-    }
-    // FP16 cache hit — only fire for M > 1 prefill OR for natively-F16
-    // weights (where the cache IS the source storage). At M = 1 decode with
-    // a quantized source (Q4_K, Q8_0, Q6_K cached as FP16), the small-M
-    // dp4a/mmvq path on the ORIGINAL quantized weight is far faster than
-    // cuBLAS gemv on the FP16 overlay (5-10x lower per-call HBM read).
-    // Pre-5.1.2: Phase 1 skipped Q4_K → fp16 cache miss → fall through to
-    // dp4a (FAST). Post-5.1.2: Phase 1 caches Q4_K → fp16 hit → this branch
-    // forced cuBLAS gemv on the FP16 overlay (SLOW, −36% tg128 regression).
-    // Gating on M>1 OR native-F16 restores the M=1 dp4a fast path.
-    // Phase 5 PR #1 Commit 5.1.3.c — closes the decode regression from 5.1.2.
-    const bool native_f16_weight = (weight.qtype == QType::F16 || weight.qtype == QType::BF16);
-    if (M > 1 || native_f16_weight) {
-        if (auto it = wc->fp16.find(weight.data); it != wc->fp16.end()) {
-            GemmKernelArgs args{};
-            args.input = &input;
-            args.output = &output;
-            args.stream = ctx.stream;
-            args.weight_payload = &it->second;
-            GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
-            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-                return;
-        }
-    }
-    if ((qtype == QType::F16 || qtype == QType::BF16) && weight.qtype == QType::F16) {
-        GemmKernelArgs args{};
-        args.input = &input;
-        args.output = &output;
-        args.stream = ctx.stream;
-        args.weight_payload = &weight;
-        GemmStrategy strat{StorageTier::FP16, QType::F16, M == 1};
-        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-            return;
-    }
-    // GGUF small-M (mmvq / dp4a / fused-gemv): M==1, FP16 input, non-FP32
-    // output. `prefer_fp16_cache` keeps the cache-vs-raw decision at the
-    // dispatch site because it depends on cache membership + stride — not
-    // expressible via GemmKernelArgs alone.
-    const bool fp32_output = (output.qtype == QType::F32);
-    const bool prefer_fp16_cache =
-        (fp16 != nullptr && fp16->count(weight.data) > 0 && input.stride[0] != weight.shape[1]);
-    // 5.1.4.b: small-M GGUF (dp4a/mmvq) derefs weight.data — skip if dropped.
-    if (M == 1 && input.qtype == QType::F16 && !fp32_output && !prefer_fp16_cache &&
-        !weight.dropped_source) {
-        GemmKernelArgs args{};
-        args.input = &input;
-        args.output = &output;
-        args.stream = ctx.stream;
-        args.beta = ctx.beta;
-        args.weight_payload = &weight;
-        args.q8_1_buf = qs->q8_1_buf;
-        args.d8_buf = qs->d8_buf;
-        args.dequant_scratch = qs->dequant;  // fused-gemv readiness sentinel
-        args.force_mmvq = ctx.force_mmvq;
-        args.no_mmvq = ctx.gemm_no_mmvq;
-        args.no_mmvq_q8_0 = ctx.gemm_no_mmvq_q8_0;
-        args.no_dp4a_gemv = ctx.gemm_no_dp4a_gemv;
-        GemmStrategy strat{StorageTier::FP16, qtype, /*m_is_one=*/true};
-        if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
-            return;
-    }
-    // Qtype-agnostic generic-dequant catch-all (M>1 prefill). Handler reads
-    // weight.qtype off the Tensor and switches via `dequant_gpu_supported`.
-    // 5.1.4.b: skip if dropped — overlay should have fired above.
+    // Generic dequant catch-all (M>1 prefill for uncached weights)
     if (M > 1 && input.qtype == QType::F16 && !weight.dropped_source) {
         GemmKernelArgs args{};
         args.input = &input;
@@ -1879,37 +1633,33 @@ void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, co
         if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
             return;
     }
-    // Final fallback: raw FP16/BF16 cuBLAS. Reached only when none of the
-    // tiers above match — typically a raw FP16/BF16 weight at a shape no
-    // cache covered. Matches the legacy `else { gemm(...); }` arm.
-    // 5.1.4.b safety probe: dropped weights MUST have been dispatched via
-    // overlay above. If we get here with a dropped weight, that's a coverage
-    // gap — surface it loud (once per process).
+
     if (weight.dropped_source) {
         static bool warned = false;
         if (!warned) {
             warned = true;
             IMP_LOG_WARN(
-                "gemm_dispatch: dropped weight reached final fallback! "
-                "M=%d qtype=%d kind=%s — overlay coverage gap, fix dispatch.",
+                "gemm_dispatch_uncached_fallback: dropped weight at final fallback! "
+                "M=%d qtype=%d kind=%s — overlay coverage gap.",
                 M, static_cast<int>(qtype), tensor_kind_name(weight.kind));
         }
-        return;  // bisect mode: don't crash; just no-op (output will be wrong, surfaces in bench)
+        return;
     }
     gemm(input, weight, output, 1.0f, 0.0f, ctx.stream);
 }
 
 // ---------------------------------------------------------------------------
-// 5.1.3.d transitional dispatch: WeightHandle for M>1 prefill, legacy for
-// M=1 decode. Lets call sites migrate incrementally — once all M=1 paths
-// are in weight_dispatch (dp4a, CUTLASS_NVFP4 M=1 stub), the fallback
-// branch and this function collapse to a direct weight_dispatch call.
+// gemm_via_handle_ — WeightHandle dispatch for all registered weights.
+// M>1 prefill routes through weight_dispatch (gemm_dispatch overload).
+// M=1 decode routes through gemv_dispatch or tier-specific handlers.
+// Uncached fallback (kInvalidTensorID, beta!=0) goes to the static
+// gemm_dispatch_uncached_fallback above.
 // ---------------------------------------------------------------------------
 void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& weight_fallback,
                                      const Tensor& input, Tensor& output,
                                      const GemmContext& ctx) {
     if (id == kInvalidTensorID) {
-        gemm_dispatch(input, weight_fallback, output, ctx);
+        gemm_dispatch_uncached_fallback(input, weight_fallback, output, ctx);
         return;
     }
     const auto& h = registry_.handle(id);
@@ -1933,14 +1683,44 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& weight_fallback,
                 }
                 break;
             }
+            case StorageTier::FP16: {
+                // GGUF block-quant source: dp4a/mmvq on original data is
+                // 5-10x faster than cuBLAS GEMV on the FP16 overlay.
+                if (h.source_qtype != QType::NONE && h.source_qtype != QType::F16 &&
+                    h.source_qtype != QType::BF16 && !weight_fallback.dropped_source &&
+                    output.qtype != QType::F32 &&
+                    input.stride[0] == weight_fallback.shape[1]) {
+                    const auto* qs = ctx.qscratch;
+                    if (qs) {
+                        GemmKernelArgs args{};
+                        args.input = &input;
+                        args.output = &output;
+                        args.stream = ctx.stream;
+                        args.weight_payload = &weight_fallback;
+                        args.q8_1_buf = qs->q8_1_buf;
+                        args.d8_buf = qs->d8_buf;
+                        args.dequant_scratch = qs->dequant;
+                        args.force_mmvq = ctx.force_mmvq;
+                        args.no_mmvq = ctx.gemm_no_mmvq;
+                        args.no_mmvq_q8_0 = ctx.gemm_no_mmvq_q8_0;
+                        args.no_dp4a_gemv = ctx.gemm_no_dp4a_gemv;
+                        GemmStrategy strat{StorageTier::FP16, h.source_qtype, true};
+                        if (GemmKernelRegistry::instance().dispatch(strat, args) ==
+                            GemmDispatchResult::Ok)
+                            return;
+                    }
+                }
+                imp::gemv_dispatch(h, input, output, ctx.stream);
+                return;
+            }
             default:
                 break;
         }
-        gemm_dispatch(input, weight_fallback, output, ctx);
+        gemm_dispatch_uncached_fallback(input, weight_fallback, output, ctx);
         return;
     }
     if (M == 1) {
-        gemm_dispatch(input, weight_fallback, output, ctx);
+        gemm_dispatch_uncached_fallback(input, weight_fallback, output, ctx);
         return;
     }
     imp::gemm_dispatch(nullptr, h, input, output, 1.0f, ctx.beta,

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1650,19 +1650,21 @@ static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& w
 
 // ---------------------------------------------------------------------------
 // gemm_via_handle_ — WeightHandle dispatch for all registered weights.
-// M>1 prefill routes through weight_dispatch (gemm_dispatch overload).
-// M=1 decode routes through gemv_dispatch or tier-specific handlers.
-// Uncached fallback (kInvalidTensorID, beta!=0) goes to the static
-// gemm_dispatch_uncached_fallback above.
+// M>1 routes through weight_dispatch. M=1 beta=0 routes through gemv_dispatch
+// or tier-specific handlers. M=1 beta!=0 routes through weight_dispatch
+// (cuBLAS GEMM with beta). Undefined tier (budget-exhausted) reconstructs
+// the weight Tensor from the handle and uses the uncached dequant fallback.
 // ---------------------------------------------------------------------------
-void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& weight_fallback,
-                                     const Tensor& input, Tensor& output,
-                                     const GemmContext& ctx) {
-    if (id == kInvalidTensorID) {
-        gemm_dispatch_uncached_fallback(input, weight_fallback, output, ctx);
+void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
+                                     Tensor& output, const GemmContext& ctx) {
+    const auto& h = registry_.handle(id);
+
+    if (h.primary_tier == StorageTier::Undefined) {
+        Tensor weight(const_cast<void*>(h.source_data), h.source_qtype, 2, h.shape, true);
+        gemm_dispatch_uncached_fallback(input, weight, output, ctx);
         return;
     }
-    const auto& h = registry_.handle(id);
+
     int M = static_cast<int>(input.shape[0]);
     if (M == 1 && ctx.beta == 0.0f) {
         switch (h.primary_tier) {
@@ -1672,7 +1674,7 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& weight_fallback,
                 imp::gemv_dispatch(h, input, output, ctx.stream);
                 return;
             case StorageTier::CUTLASS_NVFP4: {
-                auto it = wcache_.nvfp4.find(weight_fallback.data);
+                auto it = wcache_.nvfp4.find(h.source_data);
                 if (it != wcache_.nvfp4.end()) {
                     gemv_nvfp4_kpar(it->second,
                                     reinterpret_cast<const half*>(input.data),
@@ -1684,19 +1686,18 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& weight_fallback,
                 break;
             }
             case StorageTier::FP16: {
-                // GGUF block-quant source: dp4a/mmvq on original data is
-                // 5-10x faster than cuBLAS GEMV on the FP16 overlay.
                 if (h.source_qtype != QType::NONE && h.source_qtype != QType::F16 &&
-                    h.source_qtype != QType::BF16 && !weight_fallback.dropped_source &&
+                    h.source_qtype != QType::BF16 && h.source_data != nullptr &&
                     output.qtype != QType::F32 &&
-                    input.stride[0] == weight_fallback.shape[1]) {
+                    input.stride[0] == h.shape[1]) {
                     const auto* qs = ctx.qscratch;
                     if (qs) {
+                        Tensor src(const_cast<void*>(h.source_data), h.source_qtype, 2, h.shape, true);
                         GemmKernelArgs args{};
                         args.input = &input;
                         args.output = &output;
                         args.stream = ctx.stream;
-                        args.weight_payload = &weight_fallback;
+                        args.weight_payload = &src;
                         args.q8_1_buf = qs->q8_1_buf;
                         args.d8_buf = qs->d8_buf;
                         args.dequant_scratch = qs->dequant;
@@ -1716,12 +1717,6 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& weight_fallback,
             default:
                 break;
         }
-        gemm_dispatch_uncached_fallback(input, weight_fallback, output, ctx);
-        return;
-    }
-    if (M == 1) {
-        gemm_dispatch_uncached_fallback(input, weight_fallback, output, ctx);
-        return;
     }
     imp::gemm_dispatch(nullptr, h, input, output, 1.0f, ctx.beta,
                        shared_workspace_, shared_workspace_size_, ctx.stream);

--- a/src/exec/executor_kernels.h
+++ b/src/exec/executor_kernels.h
@@ -255,11 +255,10 @@ void rmsnorm_add_residual(const Tensor& input, const Tensor& weight, const Tenso
 
 Tensor slice_rows(const Tensor& buf, int n_tokens);
 
-// GemmContext-based dispatch. The qtype parameter was dropped — the weight
-// tensor's own .qtype field carries the type. Callers no longer need to
-// pass a separate *_qtype mirror.
-struct GemmContext;  // forward decl — defined in gemm_context.h
-void gemm_dispatch(const Tensor& input, const Tensor& weight, Tensor& output, const GemmContext& ctx);
+// GemmContext forward decl — defined in gemm_context.h.
+// The legacy gemm_dispatch free function is now a file-local uncached
+// fallback (gemm_dispatch_uncached_fallback in executor_kernels.cu).
+struct GemmContext;
 
 // MMVQ scratch buffer prewarm + hot-path getter live in gemm_scratch.h since
 // R5 Slice 8.6 (TU hoist).

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -68,7 +68,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
     // 2. ssm_in projection: [n, d_model] @ ssm_in^T -> [n, ssm_in_dim]
     //    ssm_in_dim = inner(z) + conv_channels(xBC) + n_heads(dt)
     Tensor proj = view_tokens(ssm_proj_buf_, n);
-    gemm_via_handle_(ly.ssm_in_id, ly.ssm_in, no, proj, ctx);
+    gemm_via_handle_(ly.ssm_in_id, no, proj, ctx);
 
     // 3. Split projection output [n, total_dim] into z, xBC, dt by column slices.
     //    proj layout: each row has [z(inner) | xBC(conv_channels) | dt(n_heads)].
@@ -241,7 +241,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
 
     // 10. ssm_out projection: [n, inner] @ ssm_out^T -> [n, d_model]
     Tensor out_buf = view_tokens(ssm_out_buf_, n);
-    gemm_via_handle_(ly.ssm_out_id, ly.ssm_out, y_buf, out_buf, ctx);
+    gemm_via_handle_(ly.ssm_out_id, y_buf, out_buf, ctx);
 
     // 11. Residual add: hidden = output + residual
     elementwise_add(out_buf, r, stream);
@@ -302,13 +302,13 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         int total_out = packed_conv_channels + packed_inner + 2 * packed_n_heads;
         int64_t fused_shape[2] = {1, total_out};
         Tensor fused_out(gdn_fused_proj_buf_.data, compute_dtype_, 2, fused_shape, true);
-        gemm_via_handle_(ly.gdn_input_packed_id, ly.gdn_input_packed, no, fused_out, ctx);
+        gemm_via_handle_(ly.gdn_input_packed_id, no, fused_out, ctx);
         proj = Tensor(gdn_fused_proj_buf_.data, compute_dtype_, 2, proj_shape, true);
     } else {
         // Original path: ssm_proj_buf_ is [max_tokens, ssm_in_dim] but we only
         // need [n, conv_channels].
         proj = Tensor(ssm_proj_buf_.data, compute_dtype_, 2, proj_shape, true);
-        gemm_via_handle_(ly.ssm_in_id, ly.ssm_in, no, proj, ctx);
+        gemm_via_handle_(ly.ssm_in_id, no, proj, ctx);
     }
     dump_tensor_npy("gdn_ssm_in_out", proj, stream, layer, cur_decode_step_);
 
@@ -418,7 +418,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         gate_out = Tensor(gate_ptr, compute_dtype_, 2, gate_shape, true);
     } else {
         gate_out = Tensor(ssm_z_buf_.data, compute_dtype_, 2, gate_shape, true);
-        gemm_via_handle_(ly.gdn_gate_id, ly.gdn_gate, no, gate_out, ctx);
+        gemm_via_handle_(ly.gdn_gate_id, no, gate_out, ctx);
     }
 
     const bool use_fp32_scan = runtime_config().gdn.fp32_scan;
@@ -448,15 +448,15 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                 alpha_proj_out = Tensor(ssm_dt_buf_.data, compute_dtype_, 2, ab_shape, true);
                 beta_proj_out = Tensor(static_cast<char*>(ssm_dt_buf_.data) + n_heads * es, compute_dtype_,
                                        2, ab_shape, true);
-                gemm_via_handle_(ly.gdn_alpha_beta_packed_id, ly.gdn_alpha_beta_packed, no, ab_packed_out, ctx);
+                gemm_via_handle_(ly.gdn_alpha_beta_packed_id, no, ab_packed_out, ctx);
             } else {
                 // 4-call fallback: ssm_dt_buf_ for alpha, +offset for beta.
                 alpha_proj_out = Tensor(ssm_dt_buf_.data, compute_dtype_, 2, ab_shape, true);
                 char* beta_ptr = static_cast<char*>(ssm_dt_buf_.data) +
                                  ((static_cast<size_t>(n) * n_heads * es + 255) & ~size_t(255));
                 beta_proj_out = Tensor(beta_ptr, compute_dtype_, 2, ab_shape, true);
-                gemm_via_handle_(ly.gdn_alpha_id, ly.gdn_alpha, no, alpha_proj_out, ctx);
-                gemm_via_handle_(ly.gdn_beta_id, ly.gdn_beta, no, beta_proj_out, ctx);
+                gemm_via_handle_(ly.gdn_alpha_id, no, alpha_proj_out, ctx);
+                gemm_via_handle_(ly.gdn_beta_id, no, beta_proj_out, ctx);
             }
             // Per-element dump: pre-softplus alpha and pre-sigmoid beta projections.
             // Compare to llama's `alpha-{layer}` and `beta-{layer}`.
@@ -598,7 +598,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         // cuBLAS FP32-input × FP16-cached-weight path silently produces zeros on
         // sm_120 with CUBLAS_COMPUTE_32F (tested 2026-04-21). Stay on FP16 y_buf
         // input; precision benefit from FP32 scan is limited to the rmsnorm stage.
-        gemm_via_handle_(ly.ssm_out_id, ly.ssm_out, y_buf, fp32_out_t, ctx);
+        gemm_via_handle_(ly.ssm_out_id, y_buf, fp32_out_t, ctx);
 
         // FP16 residual → FP32 + add + FP16 writeback to h in one kernel.
         int64_t total = static_cast<int64_t>(n) * cfg.d_model;
@@ -609,7 +609,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                                                static_cast<__half*>(h.data), total);
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(fp32_out, stream));
     } else {
-        gemm_via_handle_(ly.ssm_out_id, ly.ssm_out, y_buf, out_buf, ctx);
+        gemm_via_handle_(ly.ssm_out_id, y_buf, out_buf, ctx);
         // Per-element dump: linear_attn_out post-ssm_out GEMM, pre-residual.
         // Compare to llama's `linear_attn_out-{layer}` from eval-callback.
         dump_tensor_npy("gdn_linear_attn_out", out_buf, stream, layer, cur_decode_step_);

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -35,8 +35,6 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
         if (!t.data)
             return kInvalidTensorID;
         StorageTier tier = infer_tier_from_wcache(wcache_, t.data);
-        if (tier == StorageTier::Undefined)
-            return kInvalidTensorID;
         TensorID id = registry_.reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
         auto& h = registry_.handle(id);
         h.primary_tier = tier;


### PR DESCRIPTION
## Summary
- **Commit 1**: Trim `gemm_dispatch` from 290 LOC to 66 LOC static `gemm_dispatch_uncached_fallback`. Add `case StorageTier::FP16` to `gemm_via_handle_`'s M=1 switch (dp4a for GGUF sources, gemv_dispatch for native FP16). Delete 10 dead tier branches + 5 cache pointer variables. Net -224 LOC.
- **Commit 2**: Drop `weight_fallback` Tensor parameter from `gemm_via_handle_` and all 29 call sites. Register weights with `Undefined` tier when budget-exhausted (instead of returning `kInvalidTensorID`). CUTLASS_NVFP4 kpar and FP16 dp4a now use handle fields (`source_data`, `source_qtype`, `shape`). M=1 beta!=0 routes through weight_dispatch. Net -9 LOC across 8 files.

## Plan correction
Original spec assumed the legacy switch was only reached for `kInvalidTensorID`. `StorageTier::FP16` handles at M=1 also fell through `default: break`. Migrated FP16 tier into the switch before deleting.

## Test plan
- [x] `make build` — clean (both commits)
- [x] `make test-gpu` — 73+77+151+170+161+34 pass, 33 skipped (model-dependent)
- [x] `make verify-fast` — OK
- [x] Pre-push hook — OK (both pushes)
- [ ] E2E smoke bench (Qwen3-8B Q8_0, Gemma-3 Q4_K_M) — needs model files

🤖 Generated with [Claude Code](https://claude.com/claude-code)