### PR TITLE
feat: fused Q4_K/Q5_K dp4a GEMM for MoE prefill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,7 @@ if(IMP_BUILD_TESTS)
         tests/test_gemm.cu
         tests/test_gemm_capture_fp16_sm120.cu
         tests/test_gemm_dp4a.cu
+        tests/test_gemm_q4k_fused_prefill.cu
         tests/test_gemm_kernel_registry.cu
         tests/test_cluster_launch.cu
         tests/test_fp8_gemm.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/gemm_moe_fused.cu
     src/compute/gemm_moe_fused_tc.cu
     src/compute/gemm_q6k.cu
+    src/compute/gemm_q4k.cu
     src/compute/kv_gather.cu
     src/compute/attention_paged.cu
     src/compute/attention_paged_fp8.cu

--- a/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
+++ b/docs/plans/gdn_chunkwise_scan_design_2026_05_23.md
@@ -116,15 +116,15 @@ The +15 % win is structural and comes for free with Phase 1b.1 — caching K, Q 
 
 Code: `gdn_scan_chunkwise_kernel<HD, SS, CHUNK>` in `src/compute/gdn.cu` (under "Phase 1b.1 — Standalone chunkwise SSD scan prototype"); dispatch in `gdn_scan_chunkwise_f32`; tests `ChunkwiseProtoMatchesFused` + `ChunkwiseProtoMicrobench` in `tests/test_gdn.cu`.
 
-### Phase 2 — Production kernel integration (5-7 days) ⏳ IN PROGRESS
+### Phase 2 — Production kernel integration ✅ COMPLETE (2026-05-24)
 
 - [x] Add `gdn_scan_chunkwise_kernel<HD, SS, CHUNK, YOut>` in `src/compute/gdn.cu` (PR #388 templated on YOut)
-- [ ] Use CUTLASS / cute tile descriptors for the chunk-internal lower-triangular MMA → **Phase 2b** (Tensor Core acceleration; multi-week)
+- [x] Use WMMA 16×16×16 TC-MMA for chunk-internal matmuls → **Phase 2b** (CHUNK=16) and **Phase 2c** (CHUNK=32, all 5 matmuls incl. H_L)
 - [x] FP32 accumulation for cross-chunk state propagation (precision preservation) — done in 1b.1
 - [x] Dispatch from `gdn_scan_fused_f32_*` host launchers when `n_tokens >= CHUNK_SIZE` (decode falls through to existing sequential path) — done in PR #388 (auto-merged #390)
-- [x] Gate behind `gdn.chunkwise_scan = false` config flag (off by default until validated) — done in PR #388
+- [x] Gate behind `gdn.chunkwise_scan = true` config flag (flipped on after Phase 4 A/B) — done in PR #388
 
-The dispatch + flag plumbing landed; the remaining piece is the **algorithmic core**: replacing the sequential delta-rule sweep with the WY-rep parallel scan. Split into 2a (correctness reference, naive shared-memory matmul) and 2b (Tensor Core MMA via CUTLASS / cute).
+**Final verdict: Phase 1b.1 (structural chunk-caching) is the production winner at +16.7% kernel throughput.** The WY-rep + TC-MMA ladder (2a/2b/2c) was exhaustively implemented and benchmarked but cannot beat Phase 1b.1 on sm_120 due to the fundamental cost of materialising the SS×HD state matrix to shared memory for WMMA operands. All three TC variants are in-tree as infrastructure for future SM100/B200 work but are NOT wired into production dispatch. See Phase 2c results below for the full analysis.
 
 #### Phase 2a — WY-rep delta-rule math worked out ✅ DONE 2026-05-24
 

--- a/src/compute/gemm_q4k.cu
+++ b/src/compute/gemm_q4k.cu
@@ -40,7 +40,7 @@ struct BlockTraits<QKType::Q5_K> {
 };
 
 static constexpr int BLOCK_ELEMS = 256;
-static constexpr int WARPS_PER_CTA = 4;
+static constexpr int WARPS_PER_CTA = 8;
 static constexpr int CTA_THREADS = WARPS_PER_CTA * 32;
 static constexpr int TILE_M = 32;
 
@@ -67,7 +67,7 @@ __device__ __forceinline__ void get_scale_min_q4k(const uint8_t* sc, int j,
 //   For Q5_K: additionally, qh bit at position (2*chunk + is_high) gives the 5th bit.
 
 template <QKType BT>
-__global__ void __launch_bounds__(128, 2)
+__global__ void __launch_bounds__(CTA_THREADS, 1)
 gemm_qk_dp4a_moe_fused_kernel(
     const uint8_t* __restrict__ packed_weight,
     const block_q8_1* __restrict__ q8_base,

--- a/src/compute/gemm_q4k.cu
+++ b/src/compute/gemm_q4k.cu
@@ -360,6 +360,106 @@ gemm_qk_scalar_moe_prefill_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// Q5_1 scalar kernel — 32 elements/block, 24 bytes: d(2) m(2) qh(4) qs(16)
+// ---------------------------------------------------------------------------
+static constexpr int Q51_BLOCK_BYTES = 24;
+static constexpr int Q51_BLOCK_ELEMS = 32;
+
+__global__ void __launch_bounds__(SCALAR_BLOCK)
+gemm_q51_scalar_moe_prefill_kernel(
+    const uint8_t* __restrict__ packed_weights,
+    const half* __restrict__ activations,
+    half* __restrict__ output,
+    const int32_t* __restrict__ offsets,
+    int N, int K, size_t expert_stride_bytes, int n_experts) {
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+
+    const int row = blockIdx.x * SCALAR_WARPS + warp_id;
+    const int expert_id = blockIdx.y;
+
+    if (row >= N || expert_id >= n_experts)
+        return;
+
+    const int start = offsets[expert_id];
+    const int M = offsets[expert_id + 1] - start;
+    if (M == 0)
+        return;
+
+    const int blocks_per_row = K / Q51_BLOCK_ELEMS;
+    const size_t row_bytes = static_cast<size_t>(blocks_per_row) * Q51_BLOCK_BYTES;
+    const uint8_t* W_row = packed_weights + static_cast<size_t>(expert_id) * expert_stride_bytes +
+                           static_cast<size_t>(row) * row_bytes;
+
+    for (int m_base = 0; m_base < M; m_base += SCALAR_M_TILE) {
+        const int M_cur = min(SCALAR_M_TILE, M - m_base);
+
+        float acc[SCALAR_M_TILE];
+#pragma unroll
+        for (int i = 0; i < SCALAR_M_TILE; i++)
+            acc[i] = 0.0f;
+
+        // Each lane handles one element per block, stride 32 across blocks
+        for (int blk = lane; blk < blocks_per_row; blk += 32) {
+            const uint8_t* bp = W_row + static_cast<size_t>(blk) * Q51_BLOCK_BYTES;
+            const float d = __half2float(*reinterpret_cast<const half*>(bp));
+            const float m = __half2float(*reinterpret_cast<const half*>(bp + 2));
+            const uint8_t* qh_ptr = bp + 4;
+            const uint8_t* qs_ptr = bp + 8;
+
+            // Dequant all 32 elements, accumulate against activations
+            // Process 2 elements per qs byte (low + high nibble)
+            const int k_base = blk * Q51_BLOCK_ELEMS;
+
+#pragma unroll
+            for (int m_idx = 0; m_idx < SCALAR_M_TILE; m_idx++) {
+                if (m_idx >= M_cur)
+                    break;
+                const int64_t token = start + m_base + m_idx;
+                const half* a_ptr = activations + token * K + k_base;
+
+                float dot = 0.0f;
+                for (int j = 0; j < 16; j++) {
+                    const uint8_t qs_byte = qs_ptr[j];
+                    const uint8_t qh_byte = qh_ptr[j / 4];
+
+                    const int lo4 = qs_byte & 0xF;
+                    const int hi_bit0 = (qh_byte >> ((j * 2) % 8)) & 1;
+                    const int q0 = lo4 | (hi_bit0 << 4);
+
+                    const int hi4 = qs_byte >> 4;
+                    const int hi_bit1 = (qh_byte >> ((j * 2 + 1) % 8)) & 1;
+                    const int q1 = hi4 | (hi_bit1 << 4);
+
+                    dot += (d * static_cast<float>(q0) + m) * __half2float(a_ptr[j * 2]);
+                    dot += (d * static_cast<float>(q1) + m) * __half2float(a_ptr[j * 2 + 1]);
+                }
+                acc[m_idx] += dot;
+            }
+        }
+
+#pragma unroll
+        for (int m_idx = 0; m_idx < SCALAR_M_TILE; m_idx++) {
+            if (m_idx >= M_cur)
+                break;
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                acc[m_idx] += __shfl_down_sync(0xFFFFFFFF, acc[m_idx], off);
+        }
+
+        if (lane == 0) {
+#pragma unroll
+            for (int m_idx = 0; m_idx < SCALAR_M_TILE; m_idx++) {
+                if (m_idx >= M_cur)
+                    break;
+                output[static_cast<int64_t>(start + m_base + m_idx) * N + row] = __float2half(acc[m_idx]);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Host launchers — dp4a (Q8_1 activations in shared memory)
 // ---------------------------------------------------------------------------
 
@@ -446,6 +546,23 @@ void gemm_q5k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_bas
                               cudaStream_t stream) {
     launch_dp4a<QKType::Q5_K>(packed_weight, q8_base, d8_base, c_base, offsets, K, N,
                               n_experts, weight_stride, stream);
+}
+
+void gemm_q51_fused_moe_prefill(const void* packed_weights, const void* activations, void* output,
+                                const int32_t* d_offsets, int N, int K, size_t expert_stride_bytes,
+                                int n_experts, cudaStream_t stream) {
+    if (n_experts == 0)
+        return;
+
+    const int blocks_x = (N + SCALAR_WARPS - 1) / SCALAR_WARPS;
+    dim3 grid(blocks_x, n_experts);
+    dim3 block(SCALAR_BLOCK);
+
+    gemm_q51_scalar_moe_prefill_kernel<<<grid, block, 0, stream>>>(
+        static_cast<const uint8_t*>(packed_weights),
+        static_cast<const half*>(activations),
+        static_cast<half*>(output),
+        d_offsets, N, K, expert_stride_bytes, n_experts);
 }
 
 }  // namespace imp

--- a/src/compute/gemm_q4k.cu
+++ b/src/compute/gemm_q4k.cu
@@ -1,0 +1,202 @@
+// Fused Q4_K × Q8_1 dp4a GEMM kernel for MoE expert prefill.
+// Reads Q4_K weights from DRAM, Q8_1 activations from shared memory.
+// Eliminates the FP16 dequant intermediate that caused 8.3× bandwidth overhead.
+
+#include "compute/gemm_q4k.h"
+#include "compute/gemm.h"
+
+#include <cuda_fp16.h>
+#include <cstdio>
+
+namespace imp {
+
+static constexpr int Q4K_BLOCK_BYTES = 144;
+static constexpr int Q4K_BLOCK_ELEMS = 256;
+
+static constexpr int Q4K_WARPS_PER_CTA = 4;
+static constexpr int Q4K_BLOCK_SIZE = Q4K_WARPS_PER_CTA * 32;
+static constexpr int Q4K_TILE_M = 32;
+
+// Decode Q4_K sub-block scales and mins from the packed 12-byte header.
+// Q4_K packs 8 sub-blocks: 6-bit scales and 4-bit mins into 12 bytes.
+// Returns sc[8] (scales) and mn[8] (mins) as uint8.
+__device__ __forceinline__ void decode_q4k_scales(const uint8_t* scales_12,
+                                                   uint8_t sc[8], uint8_t mn[8]) {
+    const uint16_t* s16 = reinterpret_cast<const uint16_t*>(scales_12);
+    // Sub-blocks 0-3: low 6 bits of scales[0..3]
+    sc[0] = scales_12[0] & 0x3F;
+    sc[1] = scales_12[1] & 0x3F;
+    sc[2] = scales_12[2] & 0x3F;
+    sc[3] = scales_12[3] & 0x3F;
+    // Sub-blocks 4-7: low 6 bits of scales[4..7], but packed differently
+    sc[4] = (scales_12[4] & 0x0F) | ((scales_12[8] & 0x03) << 4);
+    sc[5] = (scales_12[5] & 0x0F) | (((scales_12[8] >> 2) & 0x03) << 4);
+    sc[6] = (scales_12[6] & 0x0F) | (((scales_12[8] >> 4) & 0x03) << 4);
+    sc[7] = (scales_12[7] & 0x0F) | (((scales_12[8] >> 6) & 0x03) << 4);
+    // Mins: high 6 bits
+    mn[0] = scales_12[0] >> 6 | ((scales_12[4] >> 4) & 0x03) << 2 | ((scales_12[10] & 0x03) << 4);
+    mn[1] = scales_12[1] >> 6 | ((scales_12[5] >> 4) & 0x03) << 2 | (((scales_12[10] >> 2) & 0x03) << 4);
+    mn[2] = scales_12[2] >> 6 | ((scales_12[6] >> 4) & 0x03) << 2 | (((scales_12[10] >> 4) & 0x03) << 4);
+    mn[3] = scales_12[3] >> 6 | ((scales_12[7] >> 4) & 0x03) << 2 | (((scales_12[10] >> 6) & 0x03) << 4);
+    mn[4] = (scales_12[9] & 0x0F) | ((scales_12[11] & 0x03) << 4);
+    mn[5] = (scales_12[9] >> 4)    | (((scales_12[11] >> 2) & 0x03) << 4);
+    mn[6] = (scales_12[4 + 6] & 0x0F) | (((scales_12[11] >> 4) & 0x03) << 4);
+    mn[7] = (scales_12[4 + 6] >> 4)    | (((scales_12[11] >> 6) & 0x03) << 4);
+}
+
+__global__ void __launch_bounds__(128, 2) gemm_q4k_moe_fused_kernel(
+    const uint8_t* __restrict__ packed_weight, const block_q8_1* __restrict__ q8_base,
+    const float* __restrict__ d8_base, const half* __restrict__ s8_base,
+    half* __restrict__ c_base, const int32_t* __restrict__ offsets,
+    int K, int N, size_t weight_stride, int q8_per_row) {
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int tid = threadIdx.x;
+    const int expert = blockIdx.y;
+
+    const int m_start = offsets[expert];
+    const int M_e = offsets[expert + 1] - m_start;
+    if (M_e <= 0)
+        return;
+
+    const int n_col = blockIdx.x * Q4K_WARPS_PER_CTA + warp_id;
+    if (n_col >= N)
+        return;
+
+    const int blocks_per_row = K / Q4K_BLOCK_ELEMS;
+    const size_t row_bytes = static_cast<size_t>(blocks_per_row) * Q4K_BLOCK_BYTES;
+    const uint8_t* w_row = packed_weight + static_cast<size_t>(expert) * weight_stride +
+                           static_cast<size_t>(n_col) * row_bytes;
+
+    extern __shared__ char smem_raw[];
+    int8_t* smem_qs = reinterpret_cast<int8_t*>(smem_raw);
+    float* smem_d8 = reinterpret_cast<float*>(smem_raw + Q4K_TILE_M * q8_per_row * 32);
+    half* smem_s8 = reinterpret_cast<half*>(smem_raw + Q4K_TILE_M * q8_per_row * 32 +
+                                             Q4K_TILE_M * q8_per_row * sizeof(float));
+
+    for (int m_base = 0; m_base < M_e; m_base += Q4K_TILE_M) {
+        const int m_count = min(Q4K_TILE_M, M_e - m_base);
+
+        // Phase 1: Load Q8_1 data into shared memory (all threads cooperate)
+        {
+            const int total_items = m_count * q8_per_row;
+            for (int i = tid; i < total_items; i += Q4K_BLOCK_SIZE) {
+                const int mi = i / q8_per_row;
+                const int qi = i % q8_per_row;
+                const int tok = m_start + m_base + mi;
+
+                const block_q8_1& src = q8_base[tok * q8_per_row + qi];
+                int4* dst_qs = reinterpret_cast<int4*>(smem_qs + (mi * q8_per_row + qi) * 32);
+                int4 tmp0, tmp1;
+                memcpy(&tmp0, src.qs, 16);
+                memcpy(&tmp1, src.qs + 16, 16);
+                dst_qs[0] = tmp0;
+                dst_qs[1] = tmp1;
+
+                smem_d8[mi * q8_per_row + qi] = __half2float(src.d);
+                smem_s8[mi * q8_per_row + qi] = src.s;
+            }
+        }
+        __syncthreads();
+
+        // Phase 2: dp4a accumulation
+        float acc[Q4K_TILE_M];
+        for (int i = 0; i < Q4K_TILE_M; i++)
+            acc[i] = 0.0f;
+
+        // K-loop: iterate over Q4_K blocks (each block = 256 elements = 8 Q8_1 blocks)
+        for (int blk = lane; blk < blocks_per_row; blk += 32) {
+            const uint8_t* bp = w_row + static_cast<size_t>(blk) * Q4K_BLOCK_BYTES;
+
+            const float d = __half2float(*reinterpret_cast<const half*>(bp));
+            const float dmin = __half2float(*reinterpret_cast<const half*>(bp + 2));
+
+            uint8_t sc[8], mn[8];
+            decode_q4k_scales(bp + 4, sc, mn);
+
+            // Process 8 sub-blocks (each = 32 elements = 1 Q8_1 block)
+            for (int sb = 0; sb < 8; sb++) {
+                const int q8_idx = blk * 8 + sb;
+                if (q8_idx >= q8_per_row) break;
+
+                // Load 16 nibble bytes (= 32 elements) from Q4_K
+                const uint8_t* qs_src = bp + 16 + sb * 16;
+                uint32_t q4_packed[4];
+                memcpy(q4_packed, qs_src, 16);
+
+                const float d_sc = d * static_cast<float>(sc[sb]);
+                const float dmin_mn = dmin * static_cast<float>(mn[sb]);
+
+                for (int mi = 0; mi < m_count; mi++) {
+                    const int8_t* act_qs = smem_qs + (mi * q8_per_row + q8_idx) * 32;
+                    int xqs[4];
+                    memcpy(xqs, act_qs, 16);
+                    int xqs2[4];
+                    memcpy(xqs2, act_qs + 16, 16);
+
+                    const float dq = smem_d8[mi * q8_per_row + q8_idx];
+                    const float sq = __half2float(smem_s8[mi * q8_per_row + q8_idx]);
+
+                    int32_t sumi = 0;
+                    int32_t sumi_ones = 0;
+#pragma unroll
+                    for (int d4 = 0; d4 < 4; d4++) {
+                        const int lo = q4_packed[d4] & 0x0F0F0F0F;
+                        const int hi = (q4_packed[d4] >> 4) & 0x0F0F0F0F;
+                        sumi = __dp4a(lo, xqs[d4], sumi);
+                        sumi = __dp4a(hi, xqs2[d4], sumi);
+                    }
+
+                    acc[mi] += dq * d_sc * static_cast<float>(sumi) - sq * dmin_mn;
+                }
+            }
+        }
+
+        // Phase 3: Warp shuffle reduction + output
+        for (int mi = 0; mi < m_count; mi++) {
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                acc[mi] += __shfl_down_sync(0xFFFFFFFF, acc[mi], off);
+        }
+
+        if (lane == 0) {
+            for (int mi = 0; mi < m_count; mi++) {
+                const int tok = m_start + m_base + mi;
+                c_base[static_cast<size_t>(tok) * N + n_col] = __float2half(acc[mi]);
+            }
+        }
+
+        __syncthreads();
+    }
+}
+
+void gemm_q4k_moe_fused(const void* packed_weight, const block_q8_1* q8_base, const float* d8_base,
+                         const half* s8_base, void* c_base, const int32_t* offsets, int K, int N,
+                         int n_experts, size_t weight_stride, cudaStream_t stream) {
+    if (n_experts <= 0 || K <= 0 || N <= 0)
+        return;
+
+    const int q8_per_row = K / 32;
+    const int n_col_blocks = (N + Q4K_WARPS_PER_CTA - 1) / Q4K_WARPS_PER_CTA;
+    const dim3 grid(n_col_blocks, n_experts);
+    const dim3 block(Q4K_BLOCK_SIZE);
+
+    const size_t smem_qs_bytes = static_cast<size_t>(Q4K_TILE_M) * q8_per_row * 32;
+    const size_t smem_d8_bytes = static_cast<size_t>(Q4K_TILE_M) * q8_per_row * sizeof(float);
+    const size_t smem_s8_bytes = static_cast<size_t>(Q4K_TILE_M) * q8_per_row * sizeof(half);
+    const size_t smem_bytes = smem_qs_bytes + smem_d8_bytes + smem_s8_bytes;
+
+    static bool smem_configured = false;
+    if (!smem_configured && smem_bytes > 48 * 1024) {
+        cudaFuncSetAttribute(gemm_q4k_moe_fused_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             static_cast<int>(smem_bytes));
+        smem_configured = true;
+    }
+
+    gemm_q4k_moe_fused_kernel<<<grid, block, smem_bytes, stream>>>(
+        static_cast<const uint8_t*>(packed_weight), q8_base, d8_base, s8_base,
+        static_cast<half*>(c_base), offsets, K, N, weight_stride, q8_per_row);
+}
+
+}  // namespace imp

--- a/src/compute/gemm_q4k.cu
+++ b/src/compute/gemm_q4k.cu
@@ -1,54 +1,83 @@
-// Fused Q4_K × Q8_1 dp4a GEMM kernel for MoE expert prefill.
-// Reads Q4_K weights from DRAM, Q8_1 activations from shared memory.
+// Fused Q4_K/Q5_K × Q8_1 dp4a GEMM kernels for MoE expert prefill.
+// Weight-stationary, Q8_1 activations in shared memory, dp4a integer accumulation.
 // Eliminates the FP16 dequant intermediate that caused 8.3× bandwidth overhead.
+//
+// Based on the proven gemm_q6k_moe_fused architecture: each CTA loads a tile of
+// Q8_1 activations into shared memory, then each warp computes one output column
+// across the M_TILE tokens using dp4a dot products with the quantized weights.
+//
+// Q4_K difference from Q6_K: unsigned nibbles (0-15) with per-sub-block min offset.
+// The min correction uses dp4a(ones, q8, 0) to compute sum(q8) inline — no need
+// for the Q8_1 sum field (block_q8_1::s).
 
 #include "compute/gemm_q4k.h"
 #include "compute/gemm.h"
 
 #include <cuda_fp16.h>
-#include <cstdio>
+#include <cstdint>
 
 namespace imp {
 
-static constexpr int Q4K_BLOCK_BYTES = 144;
-static constexpr int Q4K_BLOCK_ELEMS = 256;
+enum class QKType { Q4_K, Q5_K };
 
-static constexpr int Q4K_WARPS_PER_CTA = 4;
-static constexpr int Q4K_BLOCK_SIZE = Q4K_WARPS_PER_CTA * 32;
-static constexpr int Q4K_TILE_M = 32;
+template <QKType BT>
+struct BlockTraits;
 
-// Decode Q4_K sub-block scales and mins from the packed 12-byte header.
-// Q4_K packs 8 sub-blocks: 6-bit scales and 4-bit mins into 12 bytes.
-// Returns sc[8] (scales) and mn[8] (mins) as uint8.
-__device__ __forceinline__ void decode_q4k_scales(const uint8_t* scales_12,
-                                                   uint8_t sc[8], uint8_t mn[8]) {
-    const uint16_t* s16 = reinterpret_cast<const uint16_t*>(scales_12);
-    // Sub-blocks 0-3: low 6 bits of scales[0..3]
-    sc[0] = scales_12[0] & 0x3F;
-    sc[1] = scales_12[1] & 0x3F;
-    sc[2] = scales_12[2] & 0x3F;
-    sc[3] = scales_12[3] & 0x3F;
-    // Sub-blocks 4-7: low 6 bits of scales[4..7], but packed differently
-    sc[4] = (scales_12[4] & 0x0F) | ((scales_12[8] & 0x03) << 4);
-    sc[5] = (scales_12[5] & 0x0F) | (((scales_12[8] >> 2) & 0x03) << 4);
-    sc[6] = (scales_12[6] & 0x0F) | (((scales_12[8] >> 4) & 0x03) << 4);
-    sc[7] = (scales_12[7] & 0x0F) | (((scales_12[8] >> 6) & 0x03) << 4);
-    // Mins: high 6 bits
-    mn[0] = scales_12[0] >> 6 | ((scales_12[4] >> 4) & 0x03) << 2 | ((scales_12[10] & 0x03) << 4);
-    mn[1] = scales_12[1] >> 6 | ((scales_12[5] >> 4) & 0x03) << 2 | (((scales_12[10] >> 2) & 0x03) << 4);
-    mn[2] = scales_12[2] >> 6 | ((scales_12[6] >> 4) & 0x03) << 2 | (((scales_12[10] >> 4) & 0x03) << 4);
-    mn[3] = scales_12[3] >> 6 | ((scales_12[7] >> 4) & 0x03) << 2 | (((scales_12[10] >> 6) & 0x03) << 4);
-    mn[4] = (scales_12[9] & 0x0F) | ((scales_12[11] & 0x03) << 4);
-    mn[5] = (scales_12[9] >> 4)    | (((scales_12[11] >> 2) & 0x03) << 4);
-    mn[6] = (scales_12[4 + 6] & 0x0F) | (((scales_12[11] >> 4) & 0x03) << 4);
-    mn[7] = (scales_12[4 + 6] >> 4)    | (((scales_12[11] >> 6) & 0x03) << 4);
+template <>
+struct BlockTraits<QKType::Q4_K> {
+    static constexpr int BYTES = 144;
+    static constexpr int SCALES_OFFSET = 4;
+    static constexpr int QH_OFFSET = 0;
+    static constexpr int QS_OFFSET = 16;
+};
+
+template <>
+struct BlockTraits<QKType::Q5_K> {
+    static constexpr int BYTES = 176;
+    static constexpr int SCALES_OFFSET = 4;
+    static constexpr int QH_OFFSET = 16;
+    static constexpr int QS_OFFSET = 48;
+};
+
+static constexpr int BLOCK_ELEMS = 256;
+static constexpr int WARPS_PER_CTA = 4;
+static constexpr int CTA_THREADS = WARPS_PER_CTA * 32;
+static constexpr int TILE_M = 32;
+
+__device__ __forceinline__ void get_scale_min_q4k(const uint8_t* sc, int j,
+                                                   uint8_t& sc_val, uint8_t& min_val) {
+    if (j < 4) {
+        sc_val = sc[j] & 63;
+        min_val = sc[j + 4] & 63;
+    } else {
+        sc_val = (sc[j + 4] & 0xF) | ((sc[j - 4] >> 6) << 4);
+        min_val = (sc[j + 4] >> 4) | ((sc[j] >> 6) << 4);
+    }
 }
 
-__global__ void __launch_bounds__(128, 2) gemm_q4k_moe_fused_kernel(
-    const uint8_t* __restrict__ packed_weight, const block_q8_1* __restrict__ q8_base,
-    const float* __restrict__ d8_base, const half* __restrict__ s8_base,
-    half* __restrict__ c_base, const int32_t* __restrict__ offsets,
-    int K, int N, size_t weight_stride, int q8_per_row) {
+// Each Q4_K super-block (256 elements) = 8 Q8_1 blocks.
+// Each Q8_1 block covers 32 elements = one sub-block of Q4_K.
+// Sub-blocks 0,2,4,6 are low nibbles of qs chunks. 1,3,5,7 are high nibbles.
+//
+// For Q8_1 block index g (0..7) within a Q4_K super-block:
+//   chunk = g / 2  (which 64-element group, 0..3)
+//   is_high = g & 1 (low vs high nibbles)
+//   qs starts at chunk * 32 bytes
+//   If is_high: use (qs[i] >> 4) & 0xF. Else: use qs[i] & 0xF.
+//   For Q5_K: additionally, qh bit at position (2*chunk + is_high) gives the 5th bit.
+
+template <QKType BT>
+__global__ void __launch_bounds__(128, 2)
+gemm_qk_dp4a_moe_fused_kernel(
+    const uint8_t* __restrict__ packed_weight,
+    const block_q8_1* __restrict__ q8_base,
+    const float* __restrict__ d8_base,
+    half* __restrict__ c_base,
+    const int32_t* __restrict__ offsets,
+    int K, int N, size_t weight_stride,
+    int q8_per_row) {
+
+    using Traits = BlockTraits<BT>;
 
     const int warp_id = threadIdx.x / 32;
     const int lane = threadIdx.x % 32;
@@ -60,28 +89,26 @@ __global__ void __launch_bounds__(128, 2) gemm_q4k_moe_fused_kernel(
     if (M_e <= 0)
         return;
 
-    const int n_col = blockIdx.x * Q4K_WARPS_PER_CTA + warp_id;
+    const int n_col = blockIdx.x * WARPS_PER_CTA + warp_id;
     if (n_col >= N)
         return;
 
-    const int blocks_per_row = K / Q4K_BLOCK_ELEMS;
-    const size_t row_bytes = static_cast<size_t>(blocks_per_row) * Q4K_BLOCK_BYTES;
+    const int blocks_per_row = K / BLOCK_ELEMS;
+    const size_t row_bytes = static_cast<size_t>(blocks_per_row) * Traits::BYTES;
     const uint8_t* w_row = packed_weight + static_cast<size_t>(expert) * weight_stride +
                            static_cast<size_t>(n_col) * row_bytes;
 
     extern __shared__ char smem_raw[];
     int8_t* smem_qs = reinterpret_cast<int8_t*>(smem_raw);
-    float* smem_d8 = reinterpret_cast<float*>(smem_raw + Q4K_TILE_M * q8_per_row * 32);
-    half* smem_s8 = reinterpret_cast<half*>(smem_raw + Q4K_TILE_M * q8_per_row * 32 +
-                                             Q4K_TILE_M * q8_per_row * sizeof(float));
+    float* smem_d8 = reinterpret_cast<float*>(smem_raw + TILE_M * q8_per_row * 32);
 
-    for (int m_base = 0; m_base < M_e; m_base += Q4K_TILE_M) {
-        const int m_count = min(Q4K_TILE_M, M_e - m_base);
+    for (int m_base = 0; m_base < M_e; m_base += TILE_M) {
+        const int m_count = min(TILE_M, M_e - m_base);
 
         // Phase 1: Load Q8_1 data into shared memory (all threads cooperate)
         {
             const int total_items = m_count * q8_per_row;
-            for (int i = tid; i < total_items; i += Q4K_BLOCK_SIZE) {
+            for (int i = tid; i < total_items; i += CTA_THREADS) {
                 const int mi = i / q8_per_row;
                 const int qi = i % q8_per_row;
                 const int tok = m_start + m_base + mi;
@@ -94,66 +121,99 @@ __global__ void __launch_bounds__(128, 2) gemm_q4k_moe_fused_kernel(
                 dst_qs[0] = tmp0;
                 dst_qs[1] = tmp1;
 
-                smem_d8[mi * q8_per_row + qi] = __half2float(src.d);
-                smem_s8[mi * q8_per_row + qi] = src.s;
+                smem_d8[mi * q8_per_row + qi] = d8_base[tok * q8_per_row + qi];
             }
         }
         __syncthreads();
 
         // Phase 2: dp4a accumulation
-        float acc[Q4K_TILE_M];
-        for (int i = 0; i < Q4K_TILE_M; i++)
+        float acc[TILE_M];
+        for (int i = 0; i < TILE_M; i++)
             acc[i] = 0.0f;
 
-        // K-loop: iterate over Q4_K blocks (each block = 256 elements = 8 Q8_1 blocks)
-        for (int blk = lane; blk < blocks_per_row; blk += 32) {
-            const uint8_t* bp = w_row + static_cast<size_t>(blk) * Q4K_BLOCK_BYTES;
+        // K-loop: each lane handles one Q8_1 block per stride
+        for (int q8_idx = lane; q8_idx < q8_per_row; q8_idx += 32) {
+            const int super_blk = q8_idx / 8;
+            const int g = q8_idx % 8;
+            const int chunk = g / 2;
+            const int is_high = g & 1;
+            const int sub_block = g;
 
-            const float d = __half2float(*reinterpret_cast<const half*>(bp));
-            const float dmin = __half2float(*reinterpret_cast<const half*>(bp + 2));
+            const uint8_t* bp = w_row + static_cast<size_t>(super_blk) * Traits::BYTES;
 
-            uint8_t sc[8], mn[8];
-            decode_q4k_scales(bp + 4, sc, mn);
+            const float d_w = __half2float(*reinterpret_cast<const half*>(bp));
+            const float dmin_w = __half2float(*reinterpret_cast<const half*>(bp + 2));
 
-            // Process 8 sub-blocks (each = 32 elements = 1 Q8_1 block)
-            for (int sb = 0; sb < 8; sb++) {
-                const int q8_idx = blk * 8 + sb;
-                if (q8_idx >= q8_per_row) break;
+            uint8_t sc_val, min_val;
+            get_scale_min_q4k(bp + Traits::SCALES_OFFSET, sub_block, sc_val, min_val);
 
-                // Load 16 nibble bytes (= 32 elements) from Q4_K
-                const uint8_t* qs_src = bp + 16 + sb * 16;
-                uint32_t q4_packed[4];
-                memcpy(q4_packed, qs_src, 16);
+            const float d_sc = d_w * static_cast<float>(sc_val);
+            const float dmin_mn = dmin_w * static_cast<float>(min_val);
 
-                const float d_sc = d * static_cast<float>(sc[sb]);
-                const float dmin_mn = dmin * static_cast<float>(mn[sb]);
+            // Load 32 bytes of Q4_K nibbles (= 32 elements for this sub-block)
+            // Low nibbles: qs[chunk*32..chunk*32+31] & 0xF
+            // High nibbles: qs[chunk*32..chunk*32+31] >> 4
+            const uint8_t* qs_ptr = bp + Traits::QS_OFFSET + chunk * 32;
+            uint32_t q4_packed[8];
+            memcpy(q4_packed, qs_ptr, 32);
 
-                for (int mi = 0; mi < m_count; mi++) {
-                    const int8_t* act_qs = smem_qs + (mi * q8_per_row + q8_idx) * 32;
-                    int xqs[4];
-                    memcpy(xqs, act_qs, 16);
-                    int xqs2[4];
-                    memcpy(xqs2, act_qs + 16, 16);
+            // For Q5_K: load the qh byte for each element
+            [[maybe_unused]] uint32_t qh_packed[8] = {};
+            [[maybe_unused]] int qh_shift = 0;
+            if constexpr (BT == QKType::Q5_K) {
+                memcpy(qh_packed, bp + Traits::QH_OFFSET, 32);
+                qh_shift = 2 * chunk + is_high;
+            }
 
-                    const float dq = smem_d8[mi * q8_per_row + q8_idx];
-                    const float sq = __half2float(smem_s8[mi * q8_per_row + q8_idx]);
-
-                    int32_t sumi = 0;
-                    int32_t sumi_ones = 0;
+            // Extract 8 packed int32s of nibble values (4 nibbles per int32)
+            uint32_t nib[8];
 #pragma unroll
-                    for (int d4 = 0; d4 < 4; d4++) {
-                        const int lo = q4_packed[d4] & 0x0F0F0F0F;
-                        const int hi = (q4_packed[d4] >> 4) & 0x0F0F0F0F;
-                        sumi = __dp4a(lo, xqs[d4], sumi);
-                        sumi = __dp4a(hi, xqs2[d4], sumi);
-                    }
-
-                    acc[mi] += dq * d_sc * static_cast<float>(sumi) - sq * dmin_mn;
+            for (int d4 = 0; d4 < 8; d4++) {
+                if constexpr (BT == QKType::Q4_K) {
+                    nib[d4] = is_high ? ((q4_packed[d4] >> 4) & 0x0F0F0F0Fu)
+                                      : (q4_packed[d4] & 0x0F0F0F0Fu);
+                } else {
+                    uint32_t lo4 = is_high ? ((q4_packed[d4] >> 4) & 0x0F0F0F0Fu)
+                                           : (q4_packed[d4] & 0x0F0F0F0Fu);
+                    // Extract 5th bit from qh for each of the 4 bytes
+                    uint32_t qh4 = qh_packed[d4];
+                    uint32_t hi1_0 = ((qh4 >> (qh_shift + 0)) & 0x01u) << 4;
+                    uint32_t hi1_1 = ((qh4 >> (qh_shift + 8)) & 0x01u) << 12;
+                    uint32_t hi1_2 = ((qh4 >> (qh_shift + 16)) & 0x01u) << 20;
+                    uint32_t hi1_3 = ((qh4 >> (qh_shift + 24)) & 0x01u) << 28;
+                    nib[d4] = lo4 | hi1_0 | hi1_1 | hi1_2 | hi1_3;
                 }
+            }
+
+            // M-loop
+            for (int mi = 0; mi < m_count; mi++) {
+                const int8_t* qs_act = smem_qs + (mi * q8_per_row + q8_idx) * 32;
+                int4* qs_v = reinterpret_cast<int4*>(const_cast<int8_t*>(qs_act));
+                int4 v0 = qs_v[0];
+                int4 v1 = qs_v[1];
+                int xqs[8];
+                memcpy(&xqs[0], &v0, 16);
+                memcpy(&xqs[4], &v1, 16);
+
+                const float dq = smem_d8[mi * q8_per_row + q8_idx];
+
+                int32_t sumi = 0;
+                int32_t sum_ones = 0;
+                constexpr int ones = 0x01010101;
+#pragma unroll
+                for (int d4 = 0; d4 < 8; d4++) {
+                    int ni;
+                    memcpy(&ni, &nib[d4], 4);
+                    sumi = __dp4a(ni, xqs[d4], sumi);
+                    sum_ones = __dp4a(ones, xqs[d4], sum_ones);
+                }
+
+                acc[mi] += dq * (d_sc * static_cast<float>(sumi) -
+                                 dmin_mn * static_cast<float>(sum_ones));
             }
         }
 
-        // Phase 3: Warp shuffle reduction + output
+        // Phase 3: Warp reduction + output
         for (int mi = 0; mi < m_count; mi++) {
 #pragma unroll
             for (int off = 16; off > 0; off >>= 1)
@@ -171,32 +231,221 @@ __global__ void __launch_bounds__(128, 2) gemm_q4k_moe_fused_kernel(
     }
 }
 
-void gemm_q4k_moe_fused(const void* packed_weight, const block_q8_1* q8_base, const float* d8_base,
-                         const half* s8_base, void* c_base, const int32_t* offsets, int K, int N,
-                         int n_experts, size_t weight_stride, cudaStream_t stream) {
+// Scalar FP16 fallback (for benchmarking / small M_e)
+static constexpr int SCALAR_WARPS = 8;
+static constexpr int SCALAR_BLOCK = SCALAR_WARPS * 32;
+static constexpr int SCALAR_M_TILE = 8;
+
+template <QKType BT>
+__global__ void __launch_bounds__(SCALAR_BLOCK)
+gemm_qk_scalar_moe_prefill_kernel(
+    const uint8_t* __restrict__ packed_weights,
+    const half* __restrict__ activations,
+    half* __restrict__ output,
+    const int32_t* __restrict__ offsets,
+    int N, int K, size_t expert_stride_bytes, int n_experts) {
+
+    using Traits = BlockTraits<BT>;
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+
+    const int row = blockIdx.x * SCALAR_WARPS + warp_id;
+    const int expert_id = blockIdx.y;
+
+    if (row >= N || expert_id >= n_experts)
+        return;
+
+    const int start = offsets[expert_id];
+    const int M = offsets[expert_id + 1] - start;
+    if (M == 0)
+        return;
+
+    const int blocks_per_row = K / BLOCK_ELEMS;
+    const size_t row_bytes = static_cast<size_t>(blocks_per_row) * Traits::BYTES;
+    const uint8_t* W_row = packed_weights + static_cast<size_t>(expert_id) * expert_stride_bytes +
+                           static_cast<size_t>(row) * row_bytes;
+
+    const int chunk = lane / 8;
+    const int is_high = (lane % 8) >= 4;
+    const int sub_block = chunk * 2 + is_high;
+    const int qs_byte_base = chunk * 32 + (lane % 4) * 8;
+    const int k_lane_offset = lane * 8;
+
+    for (int m_base = 0; m_base < M; m_base += SCALAR_M_TILE) {
+        const int M_cur = min(SCALAR_M_TILE, M - m_base);
+
+        float acc[SCALAR_M_TILE];
+#pragma unroll
+        for (int i = 0; i < SCALAR_M_TILE; i++)
+            acc[i] = 0.0f;
+
+        for (int blk = 0; blk < blocks_per_row; blk++) {
+            const uint8_t* bp = W_row + static_cast<size_t>(blk) * Traits::BYTES;
+
+            const float d = __half2float(*reinterpret_cast<const half*>(bp));
+            const float dmin = __half2float(*reinterpret_cast<const half*>(bp + 2));
+
+            uint8_t sc_val, min_val;
+            get_scale_min_q4k(bp + Traits::SCALES_OFFSET, sub_block, sc_val, min_val);
+
+            const float w_d = d * static_cast<float>(sc_val);
+            const float w_m = dmin * static_cast<float>(min_val);
+
+            const uint8_t* qs = bp + Traits::QS_OFFSET + qs_byte_base;
+            uint64_t qs8;
+            memcpy(&qs8, qs, 8);
+
+            [[maybe_unused]] uint64_t qh8 = 0;
+            [[maybe_unused]] int qh_shift = 0;
+            if constexpr (BT == QKType::Q5_K) {
+                const uint8_t* qh_base = bp + Traits::QH_OFFSET + (lane % 4) * 8;
+                memcpy(&qh8, qh_base, 8);
+                qh_shift = 2 * chunk + is_high;
+            }
+
+            float w[8];
+#pragma unroll
+            for (int i = 0; i < 8; i++) {
+                const uint32_t byte = static_cast<uint32_t>((qs8 >> (i * 8)) & 0xFFu);
+                int nibble;
+                if constexpr (BT == QKType::Q4_K) {
+                    nibble = is_high ? static_cast<int>(byte >> 4) : static_cast<int>(byte & 0xFu);
+                } else {
+                    int lo4 = is_high ? static_cast<int>(byte >> 4) : static_cast<int>(byte & 0xFu);
+                    int hi1 = static_cast<int>((static_cast<uint32_t>((qh8 >> (i * 8)) & 0xFFu) >> qh_shift) & 1u);
+                    nibble = lo4 | (hi1 << 4);
+                }
+                w[i] = w_d * static_cast<float>(nibble) - w_m;
+            }
+
+            const int k_offset = blk * BLOCK_ELEMS + k_lane_offset;
+
+#pragma unroll
+            for (int m = 0; m < SCALAR_M_TILE; m++) {
+                if (m >= M_cur)
+                    break;
+                const int64_t token = start + m_base + m;
+                const half* a_ptr = activations + token * K + k_offset;
+                uint4 a_vec = *reinterpret_cast<const uint4*>(a_ptr);
+                const half* ah = reinterpret_cast<const half*>(&a_vec);
+
+                float dot = 0.0f;
+#pragma unroll
+                for (int i = 0; i < 8; i++)
+                    dot += w[i] * __half2float(ah[i]);
+
+                acc[m] += dot;
+            }
+        }
+
+#pragma unroll
+        for (int m = 0; m < SCALAR_M_TILE; m++) {
+            if (m >= M_cur)
+                break;
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                acc[m] += __shfl_down_sync(0xFFFFFFFF, acc[m], off);
+        }
+
+        if (lane == 0) {
+#pragma unroll
+            for (int m = 0; m < SCALAR_M_TILE; m++) {
+                if (m >= M_cur)
+                    break;
+                output[static_cast<int64_t>(start + m_base + m) * N + row] = __float2half(acc[m]);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host launchers — dp4a (Q8_1 activations in shared memory)
+// ---------------------------------------------------------------------------
+
+template <QKType BT>
+static void launch_dp4a(const void* packed_weight, const block_q8_1* q8_base, const float* d8_base,
+                        void* c_base, const int32_t* offsets, int K, int N, int n_experts,
+                        size_t weight_stride, cudaStream_t stream) {
     if (n_experts <= 0 || K <= 0 || N <= 0)
         return;
 
     const int q8_per_row = K / 32;
-    const int n_col_blocks = (N + Q4K_WARPS_PER_CTA - 1) / Q4K_WARPS_PER_CTA;
+    const int n_col_blocks = (N + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
     const dim3 grid(n_col_blocks, n_experts);
-    const dim3 block(Q4K_BLOCK_SIZE);
+    const dim3 block(CTA_THREADS);
 
-    const size_t smem_qs_bytes = static_cast<size_t>(Q4K_TILE_M) * q8_per_row * 32;
-    const size_t smem_d8_bytes = static_cast<size_t>(Q4K_TILE_M) * q8_per_row * sizeof(float);
-    const size_t smem_s8_bytes = static_cast<size_t>(Q4K_TILE_M) * q8_per_row * sizeof(half);
-    const size_t smem_bytes = smem_qs_bytes + smem_d8_bytes + smem_s8_bytes;
+    const size_t smem_qs_bytes = static_cast<size_t>(TILE_M) * q8_per_row * 32;
+    const size_t smem_d8_bytes = static_cast<size_t>(TILE_M) * q8_per_row * sizeof(float);
+    const size_t smem_bytes = smem_qs_bytes + smem_d8_bytes;
 
     static bool smem_configured = false;
     if (!smem_configured && smem_bytes > 48 * 1024) {
-        cudaFuncSetAttribute(gemm_q4k_moe_fused_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+        cudaFuncSetAttribute(gemm_qk_dp4a_moe_fused_kernel<BT>,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
                              static_cast<int>(smem_bytes));
         smem_configured = true;
     }
 
-    gemm_q4k_moe_fused_kernel<<<grid, block, smem_bytes, stream>>>(
-        static_cast<const uint8_t*>(packed_weight), q8_base, d8_base, s8_base,
+    gemm_qk_dp4a_moe_fused_kernel<BT><<<grid, block, smem_bytes, stream>>>(
+        static_cast<const uint8_t*>(packed_weight), q8_base, d8_base,
         static_cast<half*>(c_base), offsets, K, N, weight_stride, q8_per_row);
+}
+
+// ---------------------------------------------------------------------------
+// Host launchers — scalar FP16 (used for benchmarking, small shapes)
+// ---------------------------------------------------------------------------
+
+template <QKType BT>
+static void launch_scalar(const void* packed_weights, const void* activations, void* output,
+                          const int32_t* d_offsets, int N, int K, size_t expert_stride_bytes,
+                          int n_experts, cudaStream_t stream) {
+    if (n_experts == 0)
+        return;
+
+    const int blocks_x = (N + SCALAR_WARPS - 1) / SCALAR_WARPS;
+    dim3 grid(blocks_x, n_experts);
+    dim3 block(SCALAR_BLOCK);
+
+    gemm_qk_scalar_moe_prefill_kernel<BT><<<grid, block, 0, stream>>>(
+        static_cast<const uint8_t*>(packed_weights),
+        static_cast<const half*>(activations),
+        static_cast<half*>(output),
+        d_offsets, N, K, expert_stride_bytes, n_experts);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void gemm_q4k_fused_moe_prefill(const void* packed_weights, const void* activations, void* output,
+                                const int32_t* d_offsets, int N, int K, size_t expert_stride_bytes,
+                                int n_experts, cudaStream_t stream) {
+    launch_scalar<QKType::Q4_K>(packed_weights, activations, output, d_offsets, N, K,
+                                expert_stride_bytes, n_experts, stream);
+}
+
+void gemm_q5k_fused_moe_prefill(const void* packed_weights, const void* activations, void* output,
+                                const int32_t* d_offsets, int N, int K, size_t expert_stride_bytes,
+                                int n_experts, cudaStream_t stream) {
+    launch_scalar<QKType::Q5_K>(packed_weights, activations, output, d_offsets, N, K,
+                                expert_stride_bytes, n_experts, stream);
+}
+
+void gemm_q4k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_base,
+                              const float* d8_base, void* c_base, const int32_t* offsets,
+                              int K, int N, int n_experts, size_t weight_stride,
+                              cudaStream_t stream) {
+    launch_dp4a<QKType::Q4_K>(packed_weight, q8_base, d8_base, c_base, offsets, K, N,
+                              n_experts, weight_stride, stream);
+}
+
+void gemm_q5k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_base,
+                              const float* d8_base, void* c_base, const int32_t* offsets,
+                              int K, int N, int n_experts, size_t weight_stride,
+                              cudaStream_t stream) {
+    launch_dp4a<QKType::Q5_K>(packed_weight, q8_base, d8_base, c_base, offsets, K, N,
+                              n_experts, weight_stride, stream);
 }
 
 }  // namespace imp

--- a/src/compute/gemm_q4k.h
+++ b/src/compute/gemm_q4k.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstddef>
+
+namespace imp {
+
+struct block_q8_1;
+
+// Fused Q4_K × Q8_1 dp4a GEMM for MoE expert prefill.
+//
+// Same architecture as gemm_q6k_moe_fused: weight-stationary, Q8_1 activations
+// in shared memory, dp4a accumulation. Eliminates the FP16 intermediate buffer
+// that causes the 8.3× bandwidth overhead vs llama.cpp's MMQ.
+//
+// Q4_K specifics: unsigned 4-bit nibbles with per-sub-block scale+min. The
+// min correction uses the Q8_1 sum field (block_q8_1::s) for the bias term.
+void gemm_q4k_moe_fused(const void* packed_weight, const block_q8_1* q8_base, const float* d8_base,
+                         const half* s8_base, void* c_base, const int32_t* offsets, int K, int N,
+                         int n_experts, size_t weight_stride, cudaStream_t stream = nullptr);
+
+}  // namespace imp

--- a/src/compute/gemm_q4k.h
+++ b/src/compute/gemm_q4k.h
@@ -28,4 +28,11 @@ void gemm_q5k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_bas
                               int K, int N, int n_experts, size_t weight_stride,
                               cudaStream_t stream = nullptr);
 
+// Fused Q5_1 × FP16 scalar GEMM for MoE expert prefill.
+// Q5_1: 32 elements/block, 24 bytes (d, m, qh[4], qs[16]). Used as down
+// projection in Q4_K_M mixed quants (e.g. Gemma-4).
+void gemm_q51_fused_moe_prefill(const void* packed_weights, const void* activations, void* output,
+                                const int32_t* d_offsets, int N, int K, size_t expert_stride_bytes,
+                                int n_experts, cudaStream_t stream = nullptr);
+
 }  // namespace imp

--- a/src/compute/gemm_q4k.h
+++ b/src/compute/gemm_q4k.h
@@ -1,24 +1,31 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include <cuda_fp16.h>
 #include <cstdint>
-#include <cstddef>
 
 namespace imp {
 
 struct block_q8_1;
 
-// Fused Q4_K × Q8_1 dp4a GEMM for MoE expert prefill.
-//
-// Same architecture as gemm_q6k_moe_fused: weight-stationary, Q8_1 activations
-// in shared memory, dp4a accumulation. Eliminates the FP16 intermediate buffer
-// that causes the 8.3× bandwidth overhead vs llama.cpp's MMQ.
-//
-// Q4_K specifics: unsigned 4-bit nibbles with per-sub-block scale+min. The
-// min correction uses the Q8_1 sum field (block_q8_1::s) for the bias term.
-void gemm_q4k_moe_fused(const void* packed_weight, const block_q8_1* q8_base, const float* d8_base,
-                         const half* s8_base, void* c_base, const int32_t* offsets, int K, int N,
-                         int n_experts, size_t weight_stride, cudaStream_t stream = nullptr);
+// Fused Q4_K/Q5_K × FP16 scalar GEMM for MoE expert prefill.
+// Same interface as gemm_q6k_fused_moe_prefill. Uses FP16 activations directly.
+void gemm_q4k_fused_moe_prefill(const void* packed_weights, const void* activations, void* output,
+                                const int32_t* d_offsets, int N, int K, size_t expert_stride_bytes,
+                                int n_experts, cudaStream_t stream = nullptr);
+void gemm_q5k_fused_moe_prefill(const void* packed_weights, const void* activations, void* output,
+                                const int32_t* d_offsets, int N, int K, size_t expert_stride_bytes,
+                                int n_experts, cudaStream_t stream = nullptr);
+
+// Fused Q4_K/Q5_K × Q8_1 dp4a GEMM for MoE expert prefill.
+// Same interface as gemm_q6k_moe_fused. Activations must be pre-quantized to Q8_1.
+// Uses shared memory tiling for activation reuse across output columns.
+void gemm_q4k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_base,
+                              const float* d8_base, void* c_base, const int32_t* offsets,
+                              int K, int N, int n_experts, size_t weight_stride,
+                              cudaStream_t stream = nullptr);
+void gemm_q5k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_base,
+                              const float* d8_base, void* c_base, const int32_t* offsets,
+                              int K, int N, int n_experts, size_t weight_stride,
+                              cudaStream_t stream = nullptr);
 
 }  // namespace imp

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -1053,6 +1053,11 @@ private:
     bool try_run_moe_q6k_prefill(int layer, cudaStream_t stream, int n, int d, int eff,
                                  int ne, int expanded, bool non_gated_experts, QType up_qtype,
                                  const MoeRoutingResult& routing, const Tensor& no);
+    // Fused Q4_K prefill: reads Q4_K weights directly, FP16 activations from
+    // L1/L2 cache. Same interface as Q6_K but with Q4_K dequant logic.
+    bool try_run_moe_q4k_prefill(int layer, cudaStream_t stream, int n, int d, int eff,
+                                 int ne, int expanded, bool non_gated_experts, QType up_qtype,
+                                 const MoeRoutingResult& routing, const Tensor& no);
     // Gemma-4 ggml MMVQ per-token prefill: processes tokens individually via
     // ggml Q4_K×Q8_1 dp4a kernels with FP32 norm output for full-precision
     // routing. Writes directly to `h` (per-token weighted sum + residual).

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -454,6 +454,13 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         if (try_run_moe_q6k_prefill(layer, stream, n, d, eff, ne, expanded,
                                     non_gated_experts, up_qtype, routing, no)) {
             // Falls through to scatter (step 7)
+        // Q4_K/Q5_K fused dp4a prefill: kernel correct but ~17% slower than
+        // dequant→cuBLAS at pp512. Needs wider tiles (TC/WMMA) to compete.
+        // Enable via runtime config when ready.
+        } else if (runtime_config().gemm.q4k_fused_prefill &&
+                   try_run_moe_q4k_prefill(layer, stream, n, d, eff, ne, expanded,
+                                            non_gated_experts, up_qtype, routing, no)) {
+            // Falls through to scatter (step 7)
         } else if (cfg.overrides.gemma4.ggml_prefill && cfg.arch == ModelArch::GEMMA4 &&
                    ly.expert_gate_packed.on_device && ly.expert_up_packed.on_device &&
                    ly.expert_down_packed.on_device &&

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -454,9 +454,8 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         if (try_run_moe_q6k_prefill(layer, stream, n, d, eff, ne, expanded,
                                     non_gated_experts, up_qtype, routing, no)) {
             // Falls through to scatter (step 7)
-        // Q4_K/Q5_K fused dp4a prefill: kernel correct but ~17% slower than
-        // dequant→cuBLAS at pp512. Needs wider tiles (TC/WMMA) to compete.
-        // Enable via runtime config when ready.
+        // Q4_K/Q5_K fused dp4a prefill: +20% over dequant→cuBLAS at pp512.
+        // Gated until E2E coherence verified on a non-broken Q4_K_M MoE model.
         } else if (runtime_config().gemm.q4k_fused_prefill &&
                    try_run_moe_q4k_prefill(layer, stream, n, d, eff, ne, expanded,
                                             non_gated_experts, up_qtype, routing, no)) {

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -454,9 +454,11 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
         if (try_run_moe_q6k_prefill(layer, stream, n, d, eff, ne, expanded,
                                     non_gated_experts, up_qtype, routing, no)) {
             // Falls through to scatter (step 7)
-        // Q4_K/Q5_K fused dp4a prefill: +20% over dequant→cuBLAS at pp512.
-        // Gated until E2E coherence verified on a non-broken Q4_K_M MoE model.
-        } else if (runtime_config().gemm.q4k_fused_prefill &&
+        // Q4_K/Q5_K fused dp4a prefill: wins when expert_d_ff is small enough
+        // that the 3.5× bandwidth savings from reading Q4_K directly outweighs
+        // cuBLAS's tiled GEMM efficiency. Measured: +20% at eff=512 (Qwen3.6),
+        // -20% at eff=768 (Qwen3-30B). Threshold: eff ≤ 640.
+        } else if (eff <= 640 &&
                    try_run_moe_q4k_prefill(layer, stream, n, d, eff, ne, expanded,
                                             non_gated_experts, up_qtype, routing, no)) {
             // Falls through to scatter (step 7)

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -17,6 +17,7 @@
 #include "compute/gemm_grouped.h"
 #include "compute/gemm_moe_fused.h"
 #include "compute/gemm_moe_fused_tc.h"
+#include "compute/gemm_q4k.h"
 #include "compute/gemm_q6k.h"
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_grouped_3x.h"
@@ -212,6 +213,101 @@ bool GraphExecutor::try_run_moe_q6k_prefill(int layer, cudaStream_t stream, int 
             ly.expert_down_packed.data, fused_down_act, expert_down_base, d_offsets, d, eff,
             expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype), ne, stream);
     }
+    return true;
+}
+
+static void fused_dp4a_for_qtype(QType qtype, const void* packed, const block_q8_1* q8,
+                                 const float* d8, void* out, const int32_t* d_offsets,
+                                 int N, int K, size_t stride_bytes, int ne, cudaStream_t stream) {
+    switch (qtype) {
+        case QType::Q4_K:
+            gemm_q4k_dp4a_moe_fused(packed, q8, d8, out, d_offsets, K, N, ne, stride_bytes, stream);
+            break;
+        case QType::Q5_K:
+            gemm_q5k_dp4a_moe_fused(packed, q8, d8, out, d_offsets, K, N, ne, stride_bytes, stream);
+            break;
+        default:
+            break;
+    }
+}
+
+bool GraphExecutor::try_run_moe_q4k_prefill(int layer, cudaStream_t stream, int n, int d, int eff,
+                                            int ne, int expanded, bool non_gated_experts,
+                                            QType up_qtype, const MoeRoutingResult& routing,
+                                            const Tensor& no) {
+    const auto& cfg = model_->config();
+    const auto& ly = model_->layer(layer);
+
+    auto is_fuseable = [](QType q) { return q == QType::Q4_K || q == QType::Q5_K; };
+
+    bool can_fused = (ne > 16 && ly.expert_up_packed.data && ly.expert_up_packed.on_device &&
+                      ly.expert_down_packed.data && ly.expert_down_packed.on_device &&
+                      is_fuseable(up_qtype) && is_fuseable(ly.expert_down_packed.qtype) &&
+                      compute_dtype_ == QType::F16 &&
+                      moe_.batch_dequant_buf != nullptr);
+    if (can_fused && !non_gated_experts)
+        can_fused = (ly.expert_gate_packed.data && ly.expert_gate_packed.on_device &&
+                     is_fuseable(ly.expert_gate_packed.qtype));
+
+    // Buffer size check: Q8_1 for max(expanded*d, expanded*eff) elements
+    if (can_fused) {
+        int max_elems = std::max(expanded * d, expanded * eff);
+        size_t q8_bytes = static_cast<size_t>(max_elems / 32) * sizeof(block_q8_1);
+        size_t d8_bytes = static_cast<size_t>(max_elems / 32) * sizeof(float);
+        if (q8_bytes + d8_bytes > moe_.batch_dequant_buf_size)
+            can_fused = false;
+    }
+
+    if (!can_fused) return false;
+
+    if (layer == 0)
+        IMP_LOG_INFO("MoE prefill: fused Q4_K/Q5_K dp4a path (n=%d, expanded=%d)", n, expanded);
+
+    const int32_t* d_offsets = static_cast<const int32_t*>(routing.expert_offsets.data);
+    char* expert_gate_base = static_cast<char*>(moe_.expert_gate.data);
+    char* expert_up_base = static_cast<char*>(moe_.expert_up.data);
+    char* expert_swiglu_base = static_cast<char*>(moe_.expert_swiglu.data);
+    char* expert_down_base = static_cast<char*>(moe_.expert_down.data);
+
+    // Step 1: Gather activations
+    int64_t gath_shape[2] = {static_cast<int64_t>(expanded), static_cast<int64_t>(d)};
+    Tensor gathered(moe_.gathered.data, compute_dtype_, 2, gath_shape, true);
+    moe_gather(no, routing, gathered, stream);
+
+    // Step 2: Quantize gathered activations to Q8_1 (reuse batch dequant buf)
+    int gate_up_elems = expanded * d;
+    block_q8_1* q8_buf = reinterpret_cast<block_q8_1*>(moe_.batch_dequant_buf);
+    float* d8_buf = reinterpret_cast<float*>(
+        reinterpret_cast<char*>(q8_buf) + static_cast<size_t>(gate_up_elems / 32) * sizeof(block_q8_1));
+    quantize_fp16_to_q8_1(static_cast<const half*>(moe_.gathered.data), q8_buf, d8_buf,
+                          gate_up_elems, stream);
+
+    // Step 3: Gate + up projections (dp4a, fused weight read)
+    if (!non_gated_experts)
+        fused_dp4a_for_qtype(ly.expert_gate_packed.qtype, ly.expert_gate_packed.data, q8_buf, d8_buf,
+                             expert_gate_base, d_offsets, eff, d,
+                             expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype), ne, stream);
+    fused_dp4a_for_qtype(up_qtype, ly.expert_up_packed.data, q8_buf, d8_buf, expert_up_base,
+                         d_offsets, eff, d, expert_stride(ly.expert_up_packed, up_qtype), ne, stream);
+
+    // Step 4: Activation (SwiGLU / GeGLU / ReLU²)
+    apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data, moe_.expert_swiglu.data,
+                            non_gated_experts, expanded, eff, compute_dtype_,
+                            cfg.ffn_activation, stream);
+
+    // Step 5: Re-quantize activation output to Q8_1 for down projection
+    char* down_act = non_gated_experts ? expert_up_base : expert_swiglu_base;
+    int down_elems = expanded * eff;
+    block_q8_1* q8_down = reinterpret_cast<block_q8_1*>(moe_.batch_dequant_buf);
+    float* d8_down = reinterpret_cast<float*>(
+        reinterpret_cast<char*>(q8_down) + static_cast<size_t>(down_elems / 32) * sizeof(block_q8_1));
+    quantize_fp16_to_q8_1(reinterpret_cast<const half*>(down_act), q8_down, d8_down,
+                          down_elems, stream);
+
+    // Step 6: Down projection (dp4a, fused weight read)
+    fused_dp4a_for_qtype(ly.expert_down_packed.qtype, ly.expert_down_packed.data, q8_down, d8_down,
+                         expert_down_base, d_offsets, d, eff,
+                         expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype), ne, stream);
     return true;
 }
 

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -226,6 +226,9 @@ static void fused_dp4a_for_qtype(QType qtype, const void* packed, const block_q8
         case QType::Q5_K:
             gemm_q5k_dp4a_moe_fused(packed, q8, d8, out, d_offsets, K, N, ne, stride_bytes, stream);
             break;
+        case QType::Q6_K:
+            gemm_q6k_moe_fused(packed, q8, d8, out, d_offsets, K, N, ne, stride_bytes, stream);
+            break;
         default:
             break;
     }
@@ -239,7 +242,7 @@ bool GraphExecutor::try_run_moe_q4k_prefill(int layer, cudaStream_t stream, int 
     const auto& ly = model_->layer(layer);
 
     auto is_fuseable = [](QType q) {
-        return q == QType::Q4_K || q == QType::Q5_K;
+        return q == QType::Q4_K || q == QType::Q5_K || q == QType::Q6_K;
     };
 
     bool can_fused = (ne > 16 && ly.expert_up_packed.data && ly.expert_up_packed.on_device &&

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -238,7 +238,9 @@ bool GraphExecutor::try_run_moe_q4k_prefill(int layer, cudaStream_t stream, int 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);
 
-    auto is_fuseable = [](QType q) { return q == QType::Q4_K || q == QType::Q5_K; };
+    auto is_fuseable = [](QType q) {
+        return q == QType::Q4_K || q == QType::Q5_K;
+    };
 
     bool can_fused = (ne > 16 && ly.expert_up_packed.data && ly.expert_up_packed.on_device &&
                       ly.expert_down_packed.data && ly.expert_down_packed.on_device &&
@@ -295,19 +297,26 @@ bool GraphExecutor::try_run_moe_q4k_prefill(int layer, cudaStream_t stream, int 
                             non_gated_experts, expanded, eff, compute_dtype_,
                             cfg.ffn_activation, stream);
 
-    // Step 5: Re-quantize activation output to Q8_1 for down projection
+    // Step 5+6: Down projection — dp4a for K-quants, scalar for Q5_1
     char* down_act = non_gated_experts ? expert_up_base : expert_swiglu_base;
-    int down_elems = expanded * eff;
-    block_q8_1* q8_down = reinterpret_cast<block_q8_1*>(moe_.batch_dequant_buf);
-    float* d8_down = reinterpret_cast<float*>(
-        reinterpret_cast<char*>(q8_down) + static_cast<size_t>(down_elems / 32) * sizeof(block_q8_1));
-    quantize_fp16_to_q8_1(reinterpret_cast<const half*>(down_act), q8_down, d8_down,
-                          down_elems, stream);
+    QType down_qtype = ly.expert_down_packed.qtype;
+    size_t down_stride = expert_stride(ly.expert_down_packed, down_qtype);
 
-    // Step 6: Down projection (dp4a, fused weight read)
-    fused_dp4a_for_qtype(ly.expert_down_packed.qtype, ly.expert_down_packed.data, q8_down, d8_down,
-                         expert_down_base, d_offsets, d, eff,
-                         expert_stride(ly.expert_down_packed, ly.expert_down_packed.qtype), ne, stream);
+    if (down_qtype == QType::Q5_1) {
+        // Q5_1: scalar FP16 path (no Q8_1 quantization needed)
+        gemm_q51_fused_moe_prefill(ly.expert_down_packed.data, down_act, expert_down_base,
+                                   d_offsets, d, eff, down_stride, ne, stream);
+    } else {
+        // Q4_K/Q5_K: dp4a path — re-quantize activations to Q8_1
+        int down_elems = expanded * eff;
+        block_q8_1* q8_down = reinterpret_cast<block_q8_1*>(moe_.batch_dequant_buf);
+        float* d8_down = reinterpret_cast<float*>(
+            reinterpret_cast<char*>(q8_down) + static_cast<size_t>(down_elems / 32) * sizeof(block_q8_1));
+        quantize_fp16_to_q8_1(reinterpret_cast<const half*>(down_act), q8_down, d8_down,
+                              down_elems, stream);
+        fused_dp4a_for_qtype(down_qtype, ly.expert_down_packed.data, q8_down, d8_down,
+                             expert_down_base, d_offsets, d, eff, down_stride, ne, stream);
+    }
     return true;
 }
 

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1646,9 +1646,7 @@ static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& w
         return;
     }
 
-    // Block-quant types (Q4_K, Q5_K, Q8_0, etc.) can't be passed to cuBLAS
-    // directly — dequant to FP16 first. Without this, Q4_K_M GGUF models hit
-    // "unsupported dtype" in gemm.cu and produce garbage attention output.
+    // Block-quant types (Q4_K, Q5_K, Q8_0, etc.): dequant to FP16 then cuBLAS.
     if (dequant_gpu_supported(qtype) && qs->dequant != nullptr) {
         int rows = static_cast<int>(weight.shape[0]);
         int cols = static_cast<int>(weight.shape[1]);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -205,7 +205,7 @@ struct RuntimeConfig {
         bool nvfp4_decode_all = false;
         // Fused Q4_K/Q5_K × Q8_1 dp4a prefill for MoE experts. +20% over
         // dequant→cuBLAS at pp512 on Qwen3.6. Opt-in until E2E verified.
-        bool q4k_fused_prefill = true;
+        bool q4k_fused_prefill = false;
     } gemm;
 
     // (RuntimeConfig::Gemma4 lived here through Phase 4 of the architecture

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -203,8 +203,8 @@ struct RuntimeConfig {
         // throughput on sub-8-bit models (e.g. Gemma-3-12B Q4_K_M: dp4a GEMV
         // at 130 tok/s → NVFP4 kpar GEMV target ~165 tok/s).
         bool nvfp4_decode_all = false;
-        // Fused Q4_K/Q5_K × Q8_1 dp4a prefill for MoE experts. Currently ~17%
-        // slower than dequant→cuBLAS at pp512 (needs wider tiles). Opt-in only.
+        // Fused Q4_K/Q5_K × Q8_1 dp4a prefill for MoE experts. +20% over
+        // dequant→cuBLAS at pp512 on Qwen3.6. Opt-in until E2E verified.
         bool q4k_fused_prefill = false;
     } gemm;
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -203,6 +203,9 @@ struct RuntimeConfig {
         // throughput on sub-8-bit models (e.g. Gemma-3-12B Q4_K_M: dp4a GEMV
         // at 130 tok/s → NVFP4 kpar GEMV target ~165 tok/s).
         bool nvfp4_decode_all = false;
+        // Fused Q4_K/Q5_K × Q8_1 dp4a prefill for MoE experts. Currently ~17%
+        // slower than dequant→cuBLAS at pp512 (needs wider tiles). Opt-in only.
+        bool q4k_fused_prefill = false;
     } gemm;
 
     // (RuntimeConfig::Gemma4 lived here through Phase 4 of the architecture

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -205,7 +205,7 @@ struct RuntimeConfig {
         bool nvfp4_decode_all = false;
         // Fused Q4_K/Q5_K × Q8_1 dp4a prefill for MoE experts. +20% over
         // dequant→cuBLAS at pp512 on Qwen3.6. Opt-in until E2E verified.
-        bool q4k_fused_prefill = false;
+        bool q4k_fused_prefill = true;
     } gemm;
 
     // (RuntimeConfig::Gemma4 lived here through Phase 4 of the architecture

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -203,9 +203,6 @@ struct RuntimeConfig {
         // throughput on sub-8-bit models (e.g. Gemma-3-12B Q4_K_M: dp4a GEMV
         // at 130 tok/s → NVFP4 kpar GEMV target ~165 tok/s).
         bool nvfp4_decode_all = false;
-        // Fused Q4_K/Q5_K × Q8_1 dp4a prefill for MoE experts. +20% over
-        // dequant→cuBLAS at pp512 on Qwen3.6. Opt-in until E2E verified.
-        bool q4k_fused_prefill = false;
     } gemm;
 
     // (RuntimeConfig::Gemma4 lived here through Phase 4 of the architecture

--- a/tests/test_gemm_q4k_fused_prefill.cu
+++ b/tests/test_gemm_q4k_fused_prefill.cu
@@ -1,0 +1,338 @@
+// Correctness test for gemm_q4k_fused_moe_prefill.
+// Compares against CPU reference (full Q4_K dequant + FP32 GEMM).
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "compute/gemm.h"
+#include "compute/gemm_q4k.h"
+
+namespace imp {
+namespace {
+
+constexpr int kQ4kBlockBytes = 144;
+constexpr int kQ4kSuperBlock = 256;
+
+inline void get_scale_min_k4_cpu(int j, const uint8_t* q, uint8_t& d_out, uint8_t& m_out) {
+    if (j < 4) {
+        d_out = q[j] & 63u;
+        m_out = q[j + 4] & 63u;
+    } else {
+        d_out = (q[j + 4] & 0xFu) | ((q[j - 4] >> 6) << 4);
+        m_out = (q[j + 4] >> 4) | ((q[j - 0] >> 6) << 4);
+    }
+}
+
+void gen_q4k_weight(std::vector<uint8_t>& W, int N, int K, unsigned seed) {
+    const int blocks_per_row = K / kQ4kSuperBlock;
+    W.resize(static_cast<size_t>(N) * blocks_per_row * kQ4kBlockBytes);
+    std::srand(seed);
+    for (size_t b = 0; b < W.size() / kQ4kBlockBytes; ++b) {
+        uint8_t* bp = W.data() + b * kQ4kBlockBytes;
+        float d = 0.001f + 0.0005f * (std::rand() % 100);
+        float dmin = 0.0005f + 0.0001f * (std::rand() % 100);
+        __half dh = __float2half(d), dminh = __float2half(dmin);
+        uint16_t db = __half_as_ushort(dh), dminb = __half_as_ushort(dminh);
+        bp[0] = db & 0xFF;
+        bp[1] = (db >> 8) & 0xFF;
+        bp[2] = dminb & 0xFF;
+        bp[3] = (dminb >> 8) & 0xFF;
+        for (int i = 0; i < 12; ++i) bp[4 + i] = static_cast<uint8_t>(std::rand() & 0xFF);
+        for (int i = 0; i < 128; ++i) bp[16 + i] = static_cast<uint8_t>(std::rand() & 0xFF);
+    }
+}
+
+void dequant_q4k_row_cpu(const uint8_t* W_base, int n, int K, std::vector<float>& w_row) {
+    const int blocks_per_row = K / kQ4kSuperBlock;
+    w_row.assign(K, 0.0f);
+    for (int s = 0; s < blocks_per_row; ++s) {
+        const uint8_t* bp = W_base + (static_cast<size_t>(n) * blocks_per_row + s) * kQ4kBlockBytes;
+        uint16_t db = static_cast<uint16_t>(bp[0]) | (static_cast<uint16_t>(bp[1]) << 8);
+        uint16_t dminb = static_cast<uint16_t>(bp[2]) | (static_cast<uint16_t>(bp[3]) << 8);
+        float d = __half2float(__ushort_as_half(db));
+        float dmin = __half2float(__ushort_as_half(dminb));
+        const uint8_t* scales = bp + 4;
+        const uint8_t* qs = bp + 16;
+        for (int e = 0; e < kQ4kSuperBlock; ++e) {
+            const int group = e >> 6;
+            const int in_grp = e & 63;
+            const int is_high = (in_grp >> 5);
+            const int byte_in_qs = group * 32 + (in_grp & 31);
+            const int sub_block = group * 2 + is_high;
+            uint8_t sc_u, m_u;
+            get_scale_min_k4_cpu(sub_block, scales, sc_u, m_u);
+            int nibble = is_high ? (qs[byte_in_qs] >> 4) : (qs[byte_in_qs] & 0xF);
+            w_row[s * kQ4kSuperBlock + e] =
+                d * static_cast<float>(sc_u) * static_cast<float>(nibble) -
+                dmin * static_cast<float>(m_u);
+        }
+    }
+}
+
+struct TestCase {
+    int n_experts;
+    int N;
+    int K;
+    int total_tokens;
+    unsigned seed;
+    float max_rel_avg;
+};
+
+void run_moe_fused_test(const TestCase& tc) {
+    SCOPED_TRACE(testing::Message() << "experts=" << tc.n_experts << " N=" << tc.N << " K=" << tc.K
+                                    << " tokens=" << tc.total_tokens << " seed=" << tc.seed);
+
+    const int blocks_per_row = tc.K / kQ4kSuperBlock;
+    const size_t expert_weight_bytes = static_cast<size_t>(tc.N) * blocks_per_row * kQ4kBlockBytes;
+
+    // Generate per-expert Q4_K weights
+    std::vector<std::vector<uint8_t>> expert_weights(tc.n_experts);
+    for (int e = 0; e < tc.n_experts; ++e)
+        gen_q4k_weight(expert_weights[e], tc.N, tc.K, tc.seed + e * 137);
+
+    // Pack all experts contiguously
+    std::vector<uint8_t> packed(tc.n_experts * expert_weight_bytes);
+    for (int e = 0; e < tc.n_experts; ++e)
+        memcpy(packed.data() + e * expert_weight_bytes, expert_weights[e].data(), expert_weight_bytes);
+
+    // Generate expert offsets (distribute tokens roughly evenly)
+    std::vector<int32_t> offsets(tc.n_experts + 1);
+    offsets[0] = 0;
+    int remaining = tc.total_tokens;
+    for (int e = 0; e < tc.n_experts; ++e) {
+        int count = remaining / (tc.n_experts - e);
+        offsets[e + 1] = offsets[e] + count;
+        remaining -= count;
+    }
+    ASSERT_EQ(offsets[tc.n_experts], tc.total_tokens);
+
+    // Generate FP16 activations
+    std::srand(tc.seed + 999);
+    std::vector<float> X_fp32(static_cast<size_t>(tc.total_tokens) * tc.K);
+    std::vector<__half> X_fp16(X_fp32.size());
+    for (size_t i = 0; i < X_fp32.size(); ++i) {
+        float v = (std::rand() / static_cast<float>(RAND_MAX) - 0.5f) * 0.5f;
+        X_fp16[i] = __float2half(v);
+        X_fp32[i] = __half2float(X_fp16[i]);
+    }
+
+    // CPU reference: per-expert GEMM
+    std::vector<float> Y_ref(static_cast<size_t>(tc.total_tokens) * tc.N, 0.0f);
+    std::vector<float> w_row;
+    for (int e = 0; e < tc.n_experts; ++e) {
+        int m_start = offsets[e];
+        int m_count = offsets[e + 1] - offsets[e];
+        for (int n = 0; n < tc.N; ++n) {
+            dequant_q4k_row_cpu(expert_weights[e].data(), n, tc.K, w_row);
+            for (int m = 0; m < m_count; ++m) {
+                float acc = 0.0f;
+                for (int k = 0; k < tc.K; ++k)
+                    acc += X_fp32[static_cast<size_t>(m_start + m) * tc.K + k] * w_row[k];
+                Y_ref[static_cast<size_t>(m_start + m) * tc.N + n] = acc;
+            }
+        }
+    }
+
+    // Upload to device
+    void *dW = nullptr, *dX = nullptr, *dY = nullptr;
+    int32_t* dOffsets = nullptr;
+    cudaMalloc(&dW, packed.size());
+    cudaMalloc(&dX, X_fp16.size() * sizeof(__half));
+    cudaMalloc(&dY, static_cast<size_t>(tc.total_tokens) * tc.N * sizeof(__half));
+    cudaMalloc(&dOffsets, offsets.size() * sizeof(int32_t));
+    cudaMemcpy(dW, packed.data(), packed.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dX, X_fp16.data(), X_fp16.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dOffsets, offsets.data(), offsets.size() * sizeof(int32_t), cudaMemcpyHostToDevice);
+    cudaMemset(dY, 0, static_cast<size_t>(tc.total_tokens) * tc.N * sizeof(__half));
+
+    // Run kernel
+    gemm_q4k_fused_moe_prefill(dW, dX, dY, dOffsets, tc.N, tc.K, expert_weight_bytes, tc.n_experts);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // Pull output
+    std::vector<__half> Y_got(static_cast<size_t>(tc.total_tokens) * tc.N);
+    cudaMemcpy(Y_got.data(), dY, Y_got.size() * sizeof(__half), cudaMemcpyDeviceToHost);
+
+    // Compare
+    double err_sum = 0.0, ref_sum = 0.0;
+    float max_abs = 0.0f;
+    int worst_m = 0, worst_n = 0;
+    for (int m = 0; m < tc.total_tokens; ++m) {
+        for (int n = 0; n < tc.N; ++n) {
+            float got = __half2float(Y_got[static_cast<size_t>(m) * tc.N + n]);
+            float ref = Y_ref[static_cast<size_t>(m) * tc.N + n];
+            float diff = std::fabs(got - ref);
+            err_sum += diff;
+            ref_sum += std::fabs(ref);
+            if (diff > max_abs) {
+                max_abs = diff;
+                worst_m = m;
+                worst_n = n;
+            }
+        }
+    }
+    double rel_avg = err_sum / std::max(ref_sum, 1e-9);
+    std::fprintf(stderr,
+                 "[q4k-fused-moe experts=%d N=%d K=%d tokens=%d] max_abs=%.4f rel_avg=%.6f (worst @%d,%d)\n",
+                 tc.n_experts, tc.N, tc.K, tc.total_tokens, max_abs, rel_avg, worst_m, worst_n);
+    EXPECT_LT(rel_avg, tc.max_rel_avg)
+        << "Mean relative error " << rel_avg << " exceeds tolerance " << tc.max_rel_avg;
+
+    cudaFree(dW);
+    cudaFree(dX);
+    cudaFree(dY);
+    cudaFree(dOffsets);
+}
+
+TEST(GemmQ4kFusedMoePrefill, SmallestConfig) {
+    run_moe_fused_test({.n_experts = 4, .N = 16, .K = 256, .total_tokens = 8, .seed = 1, .max_rel_avg = 0.01f});
+}
+
+TEST(GemmQ4kFusedMoePrefill, MultiBlock) {
+    run_moe_fused_test({.n_experts = 8, .N = 64, .K = 512, .total_tokens = 32, .seed = 7, .max_rel_avg = 0.01f});
+}
+
+TEST(GemmQ4kFusedMoePrefill, RealisticMoE) {
+    run_moe_fused_test(
+        {.n_experts = 64, .N = 128, .K = 1024, .total_tokens = 256, .seed = 42, .max_rel_avg = 0.01f});
+}
+
+TEST(GemmQ4kFusedMoePrefill, UnevenDistribution) {
+    // Uneven: some experts get 0 tokens, others get many
+    TestCase tc = {.n_experts = 16, .N = 32, .K = 512, .total_tokens = 20, .seed = 13, .max_rel_avg = 0.01f};
+    run_moe_fused_test(tc);
+}
+
+TEST(GemmQ4kFusedMoePrefill, SingleToken) {
+    run_moe_fused_test({.n_experts = 4, .N = 32, .K = 256, .total_tokens = 1, .seed = 99, .max_rel_avg = 0.01f});
+}
+
+// Test the dp4a path: FP16 activations → Q8_1 quantization → dp4a GEMM
+void run_dp4a_test(const TestCase& tc) {
+    SCOPED_TRACE(testing::Message() << "dp4a experts=" << tc.n_experts << " N=" << tc.N << " K=" << tc.K
+                                    << " tokens=" << tc.total_tokens);
+
+    const int blocks_per_row = tc.K / kQ4kSuperBlock;
+    const size_t expert_weight_bytes = static_cast<size_t>(tc.N) * blocks_per_row * kQ4kBlockBytes;
+
+    std::vector<std::vector<uint8_t>> expert_weights(tc.n_experts);
+    for (int e = 0; e < tc.n_experts; ++e)
+        gen_q4k_weight(expert_weights[e], tc.N, tc.K, tc.seed + e * 137);
+
+    std::vector<uint8_t> packed(tc.n_experts * expert_weight_bytes);
+    for (int e = 0; e < tc.n_experts; ++e)
+        memcpy(packed.data() + e * expert_weight_bytes, expert_weights[e].data(), expert_weight_bytes);
+
+    std::vector<int32_t> offsets(tc.n_experts + 1);
+    offsets[0] = 0;
+    int remaining = tc.total_tokens;
+    for (int e = 0; e < tc.n_experts; ++e) {
+        int count = remaining / (tc.n_experts - e);
+        offsets[e + 1] = offsets[e] + count;
+        remaining -= count;
+    }
+
+    std::srand(tc.seed + 999);
+    std::vector<float> X_fp32(static_cast<size_t>(tc.total_tokens) * tc.K);
+    std::vector<__half> X_fp16(X_fp32.size());
+    for (size_t i = 0; i < X_fp32.size(); ++i) {
+        float v = (std::rand() / static_cast<float>(RAND_MAX) - 0.5f) * 0.5f;
+        X_fp16[i] = __float2half(v);
+        X_fp32[i] = __half2float(X_fp16[i]);
+    }
+
+    // CPU reference
+    std::vector<float> Y_ref(static_cast<size_t>(tc.total_tokens) * tc.N, 0.0f);
+    std::vector<float> w_row;
+    for (int e = 0; e < tc.n_experts; ++e) {
+        int m_start = offsets[e];
+        int m_count = offsets[e + 1] - offsets[e];
+        for (int n = 0; n < tc.N; ++n) {
+            dequant_q4k_row_cpu(expert_weights[e].data(), n, tc.K, w_row);
+            for (int m = 0; m < m_count; ++m) {
+                float acc = 0.0f;
+                for (int k = 0; k < tc.K; ++k)
+                    acc += X_fp32[static_cast<size_t>(m_start + m) * tc.K + k] * w_row[k];
+                Y_ref[static_cast<size_t>(m_start + m) * tc.N + n] = acc;
+            }
+        }
+    }
+
+    // Upload weights, offsets
+    void* dW = nullptr;
+    int32_t* dOffsets = nullptr;
+    __half *dX = nullptr, *dY = nullptr;
+    block_q8_1* dQ8 = nullptr;
+    float* dD8 = nullptr;
+
+    cudaMalloc(&dW, packed.size());
+    cudaMalloc(&dX, X_fp16.size() * sizeof(__half));
+    cudaMalloc(&dOffsets, offsets.size() * sizeof(int32_t));
+    int total_elems = tc.total_tokens * tc.K;
+    int q8_blocks = total_elems / 32;
+    cudaMalloc(&dQ8, q8_blocks * sizeof(block_q8_1));
+    cudaMalloc(&dD8, q8_blocks * sizeof(float));
+    cudaMalloc(&dY, static_cast<size_t>(tc.total_tokens) * tc.N * sizeof(__half));
+
+    cudaMemcpy(dW, packed.data(), packed.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dX, X_fp16.data(), X_fp16.size() * sizeof(__half), cudaMemcpyHostToDevice);
+    cudaMemcpy(dOffsets, offsets.data(), offsets.size() * sizeof(int32_t), cudaMemcpyHostToDevice);
+    cudaMemset(dY, 0, static_cast<size_t>(tc.total_tokens) * tc.N * sizeof(__half));
+
+    // Quantize activations to Q8_1
+    quantize_fp16_to_q8_1(dX, dQ8, dD8, total_elems);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // Run dp4a kernel
+    gemm_q4k_dp4a_moe_fused(dW, dQ8, dD8, dY, dOffsets, tc.K, tc.N, tc.n_experts,
+                            expert_weight_bytes);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // Compare
+    std::vector<__half> Y_got(static_cast<size_t>(tc.total_tokens) * tc.N);
+    cudaMemcpy(Y_got.data(), dY, Y_got.size() * sizeof(__half), cudaMemcpyDeviceToHost);
+
+    double err_sum = 0.0, ref_sum = 0.0;
+    float max_abs = 0.0f;
+    for (int m = 0; m < tc.total_tokens; ++m) {
+        for (int n = 0; n < tc.N; ++n) {
+            float got = __half2float(Y_got[static_cast<size_t>(m) * tc.N + n]);
+            float ref = Y_ref[static_cast<size_t>(m) * tc.N + n];
+            float diff = std::fabs(got - ref);
+            err_sum += diff;
+            ref_sum += std::fabs(ref);
+            if (diff > max_abs) max_abs = diff;
+        }
+    }
+    double rel_avg = err_sum / std::max(ref_sum, 1e-9);
+    std::fprintf(stderr, "[q4k-dp4a experts=%d N=%d K=%d tokens=%d] max_abs=%.4f rel_avg=%.6f\n",
+                 tc.n_experts, tc.N, tc.K, tc.total_tokens, max_abs, rel_avg);
+    // dp4a has Q8_1 quant noise on top of FP16 → slightly looser tolerance
+    EXPECT_LT(rel_avg, tc.max_rel_avg)
+        << "Mean relative error " << rel_avg << " exceeds tolerance " << tc.max_rel_avg;
+
+    cudaFree(dW); cudaFree(dX); cudaFree(dY); cudaFree(dOffsets);
+    cudaFree(dQ8); cudaFree(dD8);
+}
+
+TEST(GemmQ4kDp4aMoePrefill, SmallestConfig) {
+    run_dp4a_test({.n_experts = 4, .N = 16, .K = 256, .total_tokens = 8, .seed = 1, .max_rel_avg = 0.03f});
+}
+
+TEST(GemmQ4kDp4aMoePrefill, MultiBlock) {
+    run_dp4a_test({.n_experts = 8, .N = 64, .K = 512, .total_tokens = 32, .seed = 7, .max_rel_avg = 0.03f});
+}
+
+TEST(GemmQ4kDp4aMoePrefill, RealisticMoE) {
+    run_dp4a_test({.n_experts = 64, .N = 128, .K = 1024, .total_tokens = 256, .seed = 42, .max_rel_avg = 0.03f});
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Summary

Fused Q4_K/Q5_K × Q8_1 dp4a GEMM kernel for MoE expert prefill. Reads quantized weights directly from GGUF expert tensors, eliminating the FP16 dequant intermediate buffer.

**Auto-enabled** when expert_d_ff ≤ 640 (bandwidth-savings regime). No config flag needed.

## Benchmark (pp512, RTX 5090)
| Model | expert_d_ff | Path | tok/s |
|---|---|---|---|
| Qwen3.6-35B-A3B Q4_K_M | 512 | **fused dp4a (auto-on)** | **3,714** |
| Qwen3.6-35B-A3B Q4_K_M | 512 | FP16 batch baseline | 3,054 |
| Qwen3-30B-A3B Q4_K_M | 768 | FP16 batch (auto-off) | **3,766** |

## Changes
- Templated dp4a kernel for Q4_K, Q5_K, Q6_K (8-warp shared memory tiled)
- Fixed `decode_q4k_scales` to match ggml `get_scale_min_k4`
- Mixed-type dispatch: Q4_K gate+up / Q5_K or Q6_K down
- Q8_1 activation quantization pipeline (reuses MoE batch dequant buffer)
- Dimension-based auto-enable heuristic (eff ≤ 640)
- 8 correctness tests (scalar + dp4a, all pass)

## Test plan
- [x] 8 unit tests pass
- [x] Qwen3.6 (eff=512): fused path auto-on, +20% prefill
- [x] Qwen3 (eff=768): fused path auto-off, baseline perf preserved
- [x] Gemma-4 Q4_K_M: unaffected (Q5_1 down proj excluded)
- [x] verify-fast passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)