### PR TITLE
fix: restore NVFP4 decode — tg128 121→226 tok/s (+87%)

### DIFF
--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1674,6 +1674,7 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
                 imp::gemv_dispatch(h, input, output, ctx.stream);
                 return;
             case StorageTier::CUTLASS_NVFP4: {
+                // Try NVFP4 decode cache (GGUF models dequanted to NVFP4).
                 auto it = wcache_.nvfp4.find(h.source_data);
                 if (it != wcache_.nvfp4.end()) {
                     gemv_nvfp4_kpar(it->second,
@@ -1681,6 +1682,23 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
                                     reinterpret_cast<half*>(output.data),
                                     static_cast<int>(it->second.N),
                                     static_cast<int>(it->second.K), ctx.stream);
+                    return;
+                }
+                // Native NVFP4 SafeTensors: construct NvFP4QuantResult from
+                // the handle's source fields (CUTLASS payload only has SfAtom
+                // layout, gemv_nvfp4_kpar needs per-16 FP8 micro_scales).
+                if (h.source_data && h.source_scales) {
+                    NvFP4QuantResult nv;
+                    nv.packed_data = const_cast<void*>(h.source_data);
+                    nv.micro_scales = h.source_scales;
+                    nv.tensor_scale = h.source_tensor_scale;
+                    nv.N = h.shape[0];
+                    nv.K = h.shape[1] * 2;
+                    gemv_nvfp4_kpar(nv,
+                                    reinterpret_cast<const half*>(input.data),
+                                    reinterpret_cast<half*>(output.data),
+                                    static_cast<int>(nv.N),
+                                    static_cast<int>(nv.K), ctx.stream);
                     return;
                 }
                 break;

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -44,6 +44,8 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
         // Always borrowed — never freed by registry.
         h.source_data = t.data;
         h.source_qtype = t.qtype;
+        h.source_scales = t.scales;
+        h.source_tensor_scale = t.tensor_scale;
         borrow_payload_from_wcache(h, wcache_, t.data);
         return id;
     };

--- a/src/exec/weight_handle.h
+++ b/src/exec/weight_handle.h
@@ -32,6 +32,8 @@ struct WeightHandle {
     // Phase 5 PR #1 Commit 5.1.3.a — used by the upcoming weight_dispatch shim.
     const void* source_data = nullptr;
     QType source_qtype = QType::NONE;
+    void* source_scales = nullptr;
+    float source_tensor_scale = 1.0f;
 
     union {
         struct {


### PR DESCRIPTION
PR #404 broke native NVFP4 decode by looking up empty wcache_.nvfp4 instead of using source scales. Fix: store source_scales in WeightHandle, construct NvFP4QuantResult for gemv_nvfp4_kpar.