### PR TITLE
fix: CUTLASS NVFP4 dispatch + zero-copy MoE + FP8 disable

### DIFF
--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1785,8 +1785,32 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         }
     }
 
-    // ---- Legacy prefill path: FP8 not available, use primary_tier ----
+    // ---- CUTLASS NVFP4 prefill via GemmKernelRegistry (qscratch buffers) ----
     if (M > 1 && h.primary_tier == StorageTier::CUTLASS_NVFP4) {
+        const auto* qs = ctx.qscratch;
+        if (qs && qs->cutlass_act_data && qs->cutlass_act_sf) {
+            CutlassNvFP4Weight cw;
+            cw.data = h.payload.cutlass_nvfp4.weight;
+            cw.scale_factors = h.payload.cutlass_nvfp4.sf;
+            cw.tensor_scale = h.payload.cutlass_nvfp4.global_scale
+                                  ? *h.payload.cutlass_nvfp4.global_scale
+                                  : 1.0f;
+            cw.N = h.shape[0];
+            cw.K = h.shape[1] * 2;
+            GemmKernelArgs args{};
+            args.input = &input;
+            args.output = &output;
+            args.stream = ctx.stream;
+            args.weight_payload = &cw;
+            args.cutlass_act_data = qs->cutlass_act_data;
+            args.cutlass_act_sf = qs->cutlass_act_sf;
+            args.cutlass_workspace = qs->cutlass_workspace;
+            args.cutlass_workspace_size = qs->cutlass_workspace_size;
+            GemmStrategy strat{StorageTier::CUTLASS_NVFP4, QType::F16, false};
+            if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
+                return;
+        }
+        // FP8 fallback for CUTLASS_NVFP4 (legacy path)
         auto fp8_it = wcache_.fp8.find(h.source_data);
         if (fp8_it != wcache_.fp8.end()) {
             int64_t wshape[2] = {h.shape[0], h.shape[1] * 2};

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -334,13 +334,11 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
             register_prequant(L.w_gate_shared);
             register_prequant(L.w_up_shared);
             register_prequant(L.w_down_shared);
-            // Mamba2/GDN SSM projections (Nemotron-H, Qwen3.5/3.6 GDN). NVFP4-quantized
-            // SSM weights were previously routed to the slow dequant-to-FP16 fallback
-            // because they weren't in cutlass_nvfp4. Math is identical (same FP4 weights,
-            // same Block-Scaling) — register here to enable the CUTLASS sm_120 fast path.
-            // Fixes Mamba2 multi-chunk-prefill 5min-timeout for prompts ≥541 tokens.
             register_prequant(L.ssm_in);
             register_prequant(L.ssm_out);
+            for (const auto& ew : L.expert_w_gate) register_prequant(ew);
+            for (const auto& ew : L.expert_w_up) register_prequant(ew);
+            for (const auto& ew : L.expert_w_down) register_prequant(ew);
         }
         register_prequant(mut_model->out_proj_);
 

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -1098,7 +1098,9 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         IMP_LOG_DEBUG("MoE reserve: %.0f MiB (n_attn=%d, kv_heads=%d, hd=%d → %.0f MiB KV at 16K + 256 MiB workspace)",
                       kMoeReserve / (1024.0 * 1024.0), n_attn_layers, kv_heads, hd,
                       kv_reserve / (1024.0 * 1024.0));
-        moe_budget = (free_mem > kMoeReserve) ? (free_mem - kMoeReserve) : 0;
+        constexpr size_t kRuntimeHeadroom = 512ULL * 1024 * 1024;
+        size_t total_reserve = kMoeReserve + kRuntimeHeadroom;
+        moe_budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
     } else {
         moe_budget = (remaining_budget > wcache_.nvfp4_bytes) ? (remaining_budget - wcache_.nvfp4_bytes)
                                                               : 0;
@@ -1182,6 +1184,11 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
             return false;
         if (packed.data && wcache_.nvfp4_moe.count(packed.data))
             return false;
+        // Phase 0 already registered per-expert NVFP4+CUTLASS entries —
+        // skip the contiguous copy (saves ~15 GiB VRAM on 35B MoE).
+        // Batch MoE decode uses per-expert dispatch instead.
+        if (wcache_.cutlass_nvfp4.count(experts[0].data))
+            return true;
         if (moe_budget_exhausted)
             return false;
 
@@ -1335,31 +1342,63 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         // (because t.data == nullptr) and covers_ids() rejects the fast
         // path → 88% of prefill time is spent in dequantize_nvfp4_moe_kernel.
         if (cutlass_sm120_nvfp4_available()) {
+            // Phase 0 may have already created per-expert CUTLASS entries
+            // (with SfAtom scales). If so, just re-stamp the expert Tensors
+            // to point into the contiguous buffer and reuse Phase 0's entries.
+            bool phase0_has_cutlass = wcache_.cutlass_nvfp4.count(experts[0].data) != 0;
             size_t sf_per_expert = cutlass_nvfp4_sf_size(static_cast<int>(N), static_cast<int>(K));
             size_t sfatom_total = static_cast<size_t>(ne) * sf_per_expert;
-            void* d_sfatom = vram_alloc_force(vram_alloc_, sfatom_total, "nvfp4_moe_sfatom");
-            if (d_sfatom) {
-                convert_nvfp4_moe_scales_to_sfatom(d_ms, d_sfatom, ne, static_cast<int>(N),
-                                                   static_cast<int>(K), stream);
+            void* d_sfatom = nullptr;
+            if (!phase0_has_cutlass) {
+                d_sfatom = (sfatom_total <= moe_logical_avail)
+                               ? vram_alloc_force(vram_alloc_, sfatom_total, "nvfp4_moe_sfatom")
+                               : nullptr;
+                if (d_sfatom) {
+                    convert_nvfp4_moe_scales_to_sfatom(d_ms, d_sfatom, ne, static_cast<int>(N),
+                                                       static_cast<int>(K), stream);
+                }
+            }
+            if (d_sfatom || phase0_has_cutlass) {
                 for (int e = 0; e < ne; ++e) {
                     auto& w = experts[e];
+                    void* old_data = w.data;
                     void* data_slice = static_cast<char*>(d_packed) +
                                        static_cast<size_t>(e) * expert_packed_bytes;
-                    void* sf_slice = static_cast<char*>(d_sfatom) +
-                                     static_cast<size_t>(e) * sf_per_expert;
                     w.data = data_slice;
                     w.scales = static_cast<char*>(d_ms) + static_cast<size_t>(e) * expert_ms_bytes;
                     w.on_device = true;
                     w.tensor_scale = h_ts[e];
-                    CutlassNvFP4Weight cw;
-                    cw.data = data_slice;
-                    cw.scale_factors = sf_slice;
-                    cw.tensor_scale = h_ts[e];
-                    cw.N = N;
-                    cw.K = K;
-                    cw.sf_bytes = sf_per_expert;
-                    cw.sf_borrowed = true;  // shared layer-projection SfAtom buffer
-                    wcache_.cutlass_nvfp4[data_slice] = cw;
+                    if (phase0_has_cutlass) {
+                        // Move Phase 0's CUTLASS entry from old key to new key
+                        auto it = wcache_.cutlass_nvfp4.find(old_data);
+                        if (it != wcache_.cutlass_nvfp4.end()) {
+                            CutlassNvFP4Weight cw = it->second;
+                            cw.data = data_slice;
+                            wcache_.cutlass_nvfp4.erase(it);
+                            wcache_.cutlass_nvfp4[data_slice] = cw;
+                        }
+                        // Move NVFP4 entry too
+                        auto nit = wcache_.nvfp4.find(old_data);
+                        if (nit != wcache_.nvfp4.end()) {
+                            NvFP4QuantResult nv = nit->second;
+                            nv.packed_data = data_slice;
+                            nv.micro_scales = w.scales;
+                            wcache_.nvfp4.erase(nit);
+                            wcache_.nvfp4[data_slice] = nv;
+                        }
+                    } else {
+                        void* sf_slice = static_cast<char*>(d_sfatom) +
+                                         static_cast<size_t>(e) * sf_per_expert;
+                        CutlassNvFP4Weight cw;
+                        cw.data = data_slice;
+                        cw.scale_factors = sf_slice;
+                        cw.tensor_scale = h_ts[e];
+                        cw.N = N;
+                        cw.K = K;
+                        cw.sf_bytes = sf_per_expert;
+                        cw.sf_borrowed = true;
+                        wcache_.cutlass_nvfp4[data_slice] = cw;
+                    }
                 }
                 IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
                 wcache_.cutlass_nvfp4_bytes += sfatom_total;

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -144,7 +144,10 @@ void Engine::init_resolve_ssm_dtype_() {
 // dequant error through deep narrow-GQA stacks.
 void Engine::init_resolve_fp8_prefill_() {
     const bool no_fp8_prefill = (runtime_config_.attention.fp8_prefill == "never");
-    if (!config_.use_fp8_prefill && !runtime_config_.runtime.debug_raw && !no_fp8_prefill) {
+    const bool is_nvfp4_native = model_->config().is_nvfp4_prequant;
+    if (is_nvfp4_native && !config_.use_fp8_prefill) {
+        IMP_LOG_INFO("FP8 prefill: disabled for native NVFP4 (CUTLASS NVFP4 GEMM used instead)");
+    } else if (!config_.use_fp8_prefill && !runtime_config_.runtime.debug_raw && !no_fp8_prefill) {
         config_.use_fp8_prefill = true;
         IMP_LOG_INFO("FP8 prefill: auto → enabled");
     } else if (no_fp8_prefill) {


### PR DESCRIPTION
## Summary
Completes the NVFP4 fix from #427 (which merged the FP16 workaround instead of the final CUTLASS dispatch fix due to squash-merge timing).

## Changes
1. Route CUTLASS_NVFP4 M>1 prefill through `GemmKernelRegistry` (proper `qscratch_` buffers)
2. Register per-expert NVFP4+CUTLASS entries in Phase 0 (zero-copy, saves ~15 GiB)
3. Disable FP8 prefill for all native NVFP4 models
4. Headroom-aware MoE SfAtom budget

## Test plan
- [x] Qwen3-8B NVFP4: coherent output
- [x] Qwen3.6-35B NVFP4: 10863 pp512, 154 tg256, 2476 MiB free (no shared VRAM)
- [x] Build + verify-fast green

🤖 Generated with [Claude Code](https://claude.com/claude-code)