### PR TITLE
feat: Phi-4 fused projection support (qkv_proj, gate_up_proj)

### DIFF
--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -82,13 +82,20 @@ void GraphExecutor::pre_dequant_phase0_promote_nvfp4_sidecars_(
         // (transposed weight_scale). Both routes are 2D at promote time
         // (per-expert weights have been split by weight_upload.cu).
         if (w.ndim == 2 && sc.weight_scale.ndim == 2) {
-            std::string shape_err;
-            if (!nvfp4_validate_packed_scale_shapes(w.shape[0], w.shape[1],
-                                                   sc.weight_scale.shape[0], sc.weight_scale.shape[1],
-                                                   &shape_err)) {
-                n_wrong_scale_dtype++;
-                IMP_LOG_WARN("NVFP4 prequant: %s — %s. Skipping promotion.", key, shape_err.c_str());
-                return false;
+            // For fused projection splits (qkv_proj → wq/wk/wv), the scale
+            // tensor covers the full fused weight (e.g., 7680 rows) while the
+            // sub-projection has fewer rows (e.g., 1280). Accept if the scale
+            // is a superset that covers the sub-projection's row range.
+            bool is_fused_sub = (sc.weight_scale.shape[0] > w.shape[0]);
+            if (!is_fused_sub) {
+                std::string shape_err;
+                if (!nvfp4_validate_packed_scale_shapes(w.shape[0], w.shape[1],
+                                                       sc.weight_scale.shape[0], sc.weight_scale.shape[1],
+                                                       &shape_err)) {
+                    n_wrong_scale_dtype++;
+                    IMP_LOG_WARN("NVFP4 prequant: %s — %s. Skipping promotion.", key, shape_err.c_str());
+                    return false;
+                }
             }
         }
         float h_scale = 1.0f;
@@ -220,6 +227,55 @@ void GraphExecutor::pre_dequant_phase0_promote_nvfp4_sidecars_(
         if (promote(sc, *w, key.c_str()))
             prequant_count++;
     }
+    // Fused projection scale split: weight_map split qkv_proj/gate_up_proj
+    // data pointers, but scales were routed as fused tensors to ALL sub-
+    // projections. Now that promote() set .scales = fused GPU pointer,
+    // fix the sub-projection scales to point at the correct row offsets.
+    {
+        const auto& mc = cfg;
+        int hd = mc.head_dim > 0 ? mc.head_dim : (mc.d_model / mc.n_heads);
+        int q_rows = mc.n_heads * hd;
+        int kv_rows = mc.n_kv_heads * hd;
+        int n_qkv_split = 0, n_gateup_split = 0;
+        for (int i = 0; i < mc.n_layers; i++) {
+            auto& L = mut_model->layers_[i];
+            // Fused QKV: wq got scales from promote, wk/wv need split from wq's scales
+            if (L.wq.qtype == QType::NVFP4 && L.wk.data && L.wv.data &&
+                L.wk.qtype != QType::NVFP4 && L.wq.scales &&
+                L.wq.shape[0] == q_rows && L.wk.shape[0] == kv_rows) {
+                int64_t K_packed = L.wq.shape[1];
+                size_t scale_row_bytes = static_cast<size_t>(K_packed / 8);
+                L.wk.qtype = QType::NVFP4;
+                L.wk.tensor_scale = L.wq.tensor_scale;
+                L.wk.scales = static_cast<char*>(L.wq.scales) +
+                              static_cast<size_t>(q_rows) * scale_row_bytes;
+                L.wv.qtype = QType::NVFP4;
+                L.wv.tensor_scale = L.wq.tensor_scale;
+                L.wv.scales = static_cast<char*>(L.wq.scales) +
+                              static_cast<size_t>(q_rows + kv_rows) * scale_row_bytes;
+                n_qkv_split++;
+            }
+            // gate_up split: w_gate.scales is fused base, w_up needs offset
+            // Fused gate_up: w_gate got scales from promote, w_up has no scales
+            // (weight_scale routed to w_gate only). Copy qtype + tensor_scale
+            // from w_gate and offset the scales pointer.
+            if (L.w_gate.qtype == QType::NVFP4 && L.w_up.data &&
+                L.w_up.qtype != QType::NVFP4 && L.w_gate.scales) {
+                int64_t K_packed = L.w_gate.shape[1];
+                int64_t half_rows = L.w_gate.shape[0];
+                size_t scale_row_bytes = static_cast<size_t>(K_packed / 8);
+                L.w_up.qtype = QType::NVFP4;
+                L.w_up.tensor_scale = L.w_gate.tensor_scale;
+                L.w_up.scales = static_cast<char*>(L.w_gate.scales) +
+                                static_cast<size_t>(half_rows) * scale_row_bytes;
+                n_gateup_split++;
+            }
+        }
+        if (n_qkv_split > 0 || n_gateup_split > 0)
+            IMP_LOG_INFO("Fused projection scale split: %d QKV + %d gate_up layers",
+                         n_qkv_split, n_gateup_split);
+    }
+
     // Drop the scratch — its data pointers (weight_scale, weight_scale_2,
     // input_scale) are now device pointers borrowed by the main tensors,
     // and the host-side metadata isn't needed anymore.

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -462,6 +462,32 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
             } else if (proj == "o_proj") {
                 layer.wo = t;
                 matched = true;
+            } else if (proj == "qkv_proj") {
+                // Fused QKV (Phi-4): [Q+K+V, K_packed] → split into wq, wk, wv.
+                const auto& mc = model.config_;
+                int hd = mc.head_dim > 0 ? mc.head_dim : (mc.d_model / mc.n_heads);
+                int q_rows = mc.n_heads * hd;
+                int kv_rows = mc.n_kv_heads * hd;
+                int64_t cols = t.shape[1];
+                size_t row_bytes = t.nbytes() / static_cast<size_t>(t.shape[0]);
+                if (t.shape[0] == q_rows + 2 * kv_rows) {
+                    layer.wq = t;
+                    layer.wq.shape[0] = q_rows;
+                    layer.wk = t;
+                    layer.wk.data = static_cast<char*>(t.data) + static_cast<size_t>(q_rows) * row_bytes;
+                    layer.wk.shape[0] = kv_rows;
+                    layer.wv = t;
+                    layer.wv.data = static_cast<char*>(t.data) + static_cast<size_t>(q_rows + kv_rows) * row_bytes;
+                    layer.wv.shape[0] = kv_rows;
+                    if (t.scales) {
+                        int64_t scale_cols = t.shape[1] / 8;
+                        size_t scale_row_bytes = static_cast<size_t>(scale_cols);
+                        layer.wk.scales = static_cast<char*>(t.scales) + static_cast<size_t>(q_rows) * scale_row_bytes;
+                        layer.wv.scales = static_cast<char*>(t.scales) + static_cast<size_t>(q_rows + kv_rows) * scale_row_bytes;
+                    }
+                    matched = true;
+                    IMP_LOG_DEBUG("  qkv_proj split: Q[%d] K[%d] V[%d]", q_rows, kv_rows, kv_rows);
+                }
             }
         }
 
@@ -579,6 +605,23 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
             } else if (proj == "down_proj") {
                 layer.w_down = t;
                 matched = true;
+            } else if (proj == "gate_up_proj") {
+                // Fused gate+up (Phi-4): [2*d_ff, K_packed] → split into w_gate, w_up.
+                int64_t half_rows = t.shape[0] / 2;
+                int64_t cols = t.shape[1];
+                size_t row_bytes = t.nbytes() / static_cast<size_t>(t.shape[0]);
+                layer.w_gate = t;
+                layer.w_gate.shape[0] = half_rows;
+                layer.w_up = t;
+                layer.w_up.data = static_cast<char*>(t.data) + static_cast<size_t>(half_rows) * row_bytes;
+                layer.w_up.shape[0] = half_rows;
+                if (t.scales) {
+                    int64_t scale_cols = cols / 8;
+                    size_t scale_row_bytes = static_cast<size_t>(scale_cols);
+                    layer.w_up.scales = static_cast<char*>(t.scales) + static_cast<size_t>(half_rows) * scale_row_bytes;
+                }
+                matched = true;
+                IMP_LOG_DEBUG("  gate_up_proj split: gate[%lld] up[%lld]", (long long)half_rows, (long long)half_rows);
             }
         }
 
@@ -600,6 +643,18 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
                 slot = "wv";
             else if (proj == "o_proj")
                 slot = "wo";
+            else if (proj == "qkv_proj") {
+                // Route weight_scale to wq only (Phase 0 splits to wk/wv).
+                // Scalars (weight_scale_2, input_scale) go to all three.
+                if (kind == "weight_scale") {
+                    route_nvfp4_scale(model, layer_key_prefix + "wq", kind, t);
+                } else {
+                    route_nvfp4_scale(model, layer_key_prefix + "wq", kind, t);
+                    route_nvfp4_scale(model, layer_key_prefix + "wk", kind, t);
+                    route_nvfp4_scale(model, layer_key_prefix + "wv", kind, t);
+                }
+                matched = true;
+            }
             if (slot) {
                 route_nvfp4_scale(model, layer_key_prefix + slot, kind, t);
                 matched = true;
@@ -617,6 +672,17 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
                 slot = "w_up";
             else if (proj == "down_proj")
                 slot = "w_down";
+            else if (proj == "gate_up_proj") {
+                // Route weight_scale to w_gate only (Phase 0 splits to w_up).
+                // Scalars (weight_scale_2, input_scale) go to both.
+                if (kind == "weight_scale") {
+                    route_nvfp4_scale(model, layer_key_prefix + "w_gate", kind, t);
+                } else {
+                    route_nvfp4_scale(model, layer_key_prefix + "w_gate", kind, t);
+                    route_nvfp4_scale(model, layer_key_prefix + "w_up", kind, t);
+                }
+                matched = true;
+            }
             if (slot) {
                 route_nvfp4_scale(model, layer_key_prefix + slot, kind, t);
                 matched = true;


### PR DESCRIPTION
## Summary
Add support for Phi-4-style fused projections.
- qkv_proj split into wq/wk/wv, gate_up_proj split into w_gate/w_up (zero-copy)
- Phase 0 scale split for sub-projections after promote

## Test plan
- [x] Phi-4 coherent output, 40 QKV + 40 gate_up splits, verify-fast green