### PR TITLE
fix: dequant fallback for block-quant attention weights in prefill

### DIFF
--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -394,8 +394,9 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             char buf[64];
             snprintf(buf, sizeof(buf), "[step=%d] after_layer%02d_%s", decode_step, i,
                      layer_has_gdn(i)         ? "gdn"
+                     : layer_has_ssm(i)       ? "ssm"
                      : layer_has_attention(i) ? "attn"
-                                              : "ssm");
+                                              : "none");
             debug_tensor_stats_all(buf, view_tokens(h, n), stream);
             const bool dump_this_layer = debug_forward_enabled();
             if (dump_this_layer) {

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1645,6 +1645,19 @@ static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& w
         }
         return;
     }
+
+    // Block-quant types (Q4_K, Q5_K, Q8_0, etc.) can't be passed to cuBLAS
+    // directly — dequant to FP16 first. Without this, Q4_K_M GGUF models hit
+    // "unsupported dtype" in gemm.cu and produce garbage attention output.
+    if (dequant_gpu_supported(qtype) && qs->dequant != nullptr) {
+        int rows = static_cast<int>(weight.shape[0]);
+        int cols = static_cast<int>(weight.shape[1]);
+        dequant_gpu(weight.data, qs->dequant, qtype, rows, cols, ctx.stream);
+        Tensor w_fp16(qs->dequant, QType::F16, weight.ndim, weight.shape, true);
+        gemm(input, w_fp16, output, 1.0f, 0.0f, ctx.stream);
+        return;
+    }
+
     gemm(input, weight, output, 1.0f, 0.0f, ctx.stream);
 }
 


### PR DESCRIPTION
## Summary
- Block-quant types (Q4_K, Q5_K, Q8_0, etc.) were passed directly to cuBLAS when the weight had no FP16/FP8 cache, producing "unsupported dtype N" errors and garbage output
- Added dequant→FP16→cuBLAS fallback in `gemm_dispatch_uncached_fallback` for the beta=0 path (the beta≠0 path already had this)
- Fixes all Q4_K_M GGUF models where attention projections are Q4_K/Q6_K and FP8 prefill cache is auto-disabled

## Test plan
- [x] Qwen3-30B-A3B Q4_K_M: no more "unsupported dtype" errors, coherent output
- [x] verify-fast passes
- [x] No impact on models that already have FP16/FP8 weight caches (those paths are checked first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)