### PR TITLE
fix: remove D2H sync from FP8 decode GEMV (graph capture safe)

### DIFF
--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1702,16 +1702,10 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
             case StorageTier::FP8: {
                 auto fp8_it = wcache_.fp8.find(h.source_data);
                 if (fp8_it != wcache_.fp8.end()) {
-                    float host_scale = 1.0f;
-                    if (fp8_it->second.d_scale) {
-                        cudaMemcpyAsync(&host_scale, fp8_it->second.d_scale,
-                                        sizeof(float), cudaMemcpyDeviceToHost, ctx.stream);
-                        cudaStreamSynchronize(ctx.stream);
-                    }
                     int64_t wshape[2] = {h.shape[0],
                         (h.primary_tier == StorageTier::CUTLASS_NVFP4) ? h.shape[1] * 2 : h.shape[1]};
                     Tensor fp8_w(fp8_it->second.weight.data, QType::FP8_E4M3, 2, wshape, true);
-                    gemv_fp8(fp8_w, input, output, host_scale, ctx.stream);
+                    gemv_fp8(fp8_w, input, output, fp8_it->second.host_scale, ctx.stream);
                     return;
                 }
                 break;

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -212,7 +212,10 @@ void Engine::init_resolve_quant_flags_() {
         }
     }
 
-    // FP8 prefill auto-disable for sub-8-bit models
+    // FP8 prefill auto-disable for sub-8-bit models: Q4_K→FP8 loses ~1 bit
+    // per weight element; with 48 attention layers this compounds into
+    // degenerate output (verified on Qwen3-30B Q4_K_M). The dequant fallback
+    // (PR #431) handles these models by dequanting Q4_K→FP16 on each forward.
     if (config_.use_fp8_prefill) {
         auto qtype = model_->layer(0).wq.qtype;
         bool sub_8bit = (qtype == QType::Q4_0 || qtype == QType::Q4_K || qtype == QType::Q5_0 ||
@@ -220,7 +223,7 @@ void Engine::init_resolve_quant_flags_() {
                          qtype == QType::Q4_1 || qtype == QType::Q5_1);
         if (sub_8bit) {
             config_.use_fp8_prefill = 0;
-            IMP_LOG_INFO("FP8 prefill cache: auto-disabled (sub-8-bit weights)");
+            IMP_LOG_INFO("FP8 prefill cache: auto-disabled (sub-8-bit weights → dequant fallback)");
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove `cudaMemcpyAsync` D2H + `cudaStreamSynchronize` in the FP8 decode GEMV path — use pre-cached `FP8CacheEntry::host_scale` instead. The D2H broke CUDA graph capture.
- Document why FP8 is auto-disabled for sub-8-bit GGUF (Q4_K_M): Q4_K→FP8 loses ~1 bit/element, compounds across 48 attention layers into degenerate output (verified on Qwen3-30B Q4_K_M)
- Sub-8-bit models use the dequant fallback from PR #431

## Test plan
- [x] Qwen3-30B Q4_K_M: coherent output ("2+2=4"), no unsupported dtype errors, CUDA graphs work
- [x] Gemma-4 Q4_K_M: still works correctly (unaffected — uses different cache paths)
- [x] verify-fast passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)