### PR TITLE
fix: widen FP16 cache to cover all attention weights on sub-8-bit models

### DIFF
--- a/src/exec/pre_dequant_phase1_fp16_cache.cu
+++ b/src/exec/pre_dequant_phase1_fp16_cache.cu
@@ -53,6 +53,13 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
     };
 
     // --- Phase 1: FP16 weight cache + fused KV + fused gate+up ---
+    // When FP8 is disabled (sub-8-bit models), the planner's FP8 tier entries
+    // have no fallback — Q6_K/Q8_0 weights that would normally get FP8 prefill
+    // cache land in the dequant-on-every-forward fallback. Widen the FP16 gate
+    // to cover those weights too: any dequantable attention/FFN weight that
+    // doesn't already have an overlay gets FP16 cached.
+    const bool fp8_unavailable = !wcache_.use_fp8;
+
     auto cache_weight = [&](const Tensor& w, QType qtype, TensorKind kind) {
         if (!w.data || !dequant_gpu_supported(qtype))
             return;
@@ -60,7 +67,7 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
             return;  // already cached
         if (budget_exhausted)
             return;
-        if (!plan_routes_to_fp16(kind, qtype))
+        if (!fp8_unavailable && !plan_routes_to_fp16(kind, qtype))
             return;  // Phase 3 (NVFP4) or native FP4 owns this weight
 
         int rows = static_cast<int>(w.shape[0]);


### PR DESCRIPTION
## Summary
When FP8 is auto-disabled for sub-8-bit GGUF models, Q6_K/Q8_0 attention weights had no prefill cache (planner routed them to FP8, but FP8 was off). Now Phase 1 caches all dequantable weights as FP16 when FP8 is unavailable.

Qwen3-30B Q4_K_M: 96 → 192 FP16 cached tensors (+384 MiB VRAM), decode +2%, prefill stable.

## Test plan
- [x] Qwen3-30B Q4_K_M: coherent output, no dequant fallback for attention
- [x] Gemma-4 NVFP4: unaffected (fp8_unavailable=false)
- [x] verify-fast passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)