### PR TITLE
feat: dp4a dense prefill for Q4_K/Q5_K GGUF at small M

### DIFF
--- a/src/compute/gemm_q4k.cu
+++ b/src/compute/gemm_q4k.cu
@@ -1,4 +1,4 @@
-// Fused Q4_K/Q5_K × Q8_1 dp4a GEMM kernels for MoE expert prefill.
+// Fused Q4_K/Q5_K × Q8_1 dp4a GEMM kernels for MoE expert prefill AND dense prefill.
 // Weight-stationary, Q8_1 activations in shared memory, dp4a integer accumulation.
 // Eliminates the FP16 dequant intermediate that caused 8.3× bandwidth overhead.
 //
@@ -361,7 +361,195 @@ gemm_qk_scalar_moe_prefill_kernel(
 
 
 // ---------------------------------------------------------------------------
-// Host launchers — dp4a (Q8_1 activations in shared memory)
+// Dense (non-MoE) dp4a kernel: no expert offsets, grid over (N, 1).
+// sm_120 caps shared memory at 99 KiB (101,376 B), so TILE_M is smaller
+// than the MoE kernel to fit the Q8_1 tile within that budget.
+// ---------------------------------------------------------------------------
+
+static constexpr int DENSE_TILE_M = 16;
+
+template <QKType BT>
+__global__ void __launch_bounds__(CTA_THREADS, 1)
+gemm_qk_dp4a_dense_kernel(
+    const uint8_t* __restrict__ packed_weight,
+    const block_q8_1* __restrict__ q8_base,
+    const float* __restrict__ d8_base,
+    half* __restrict__ output,
+    int M, int K, int N,
+    int q8_per_row) {
+
+    using Traits = BlockTraits<BT>;
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int tid = threadIdx.x;
+
+    const int n_col = blockIdx.x * WARPS_PER_CTA + warp_id;
+    if (n_col >= N)
+        return;
+
+    const int blocks_per_row = K / BLOCK_ELEMS;
+    const size_t row_bytes = static_cast<size_t>(blocks_per_row) * Traits::BYTES;
+    const uint8_t* w_row = packed_weight + static_cast<size_t>(n_col) * row_bytes;
+
+    extern __shared__ char smem_raw[];
+    int8_t* smem_qs = reinterpret_cast<int8_t*>(smem_raw);
+    float* smem_d8 = reinterpret_cast<float*>(smem_raw + DENSE_TILE_M * q8_per_row * 32);
+
+    for (int m_base = 0; m_base < M; m_base += DENSE_TILE_M) {
+        const int m_count = min(DENSE_TILE_M, M - m_base);
+
+        {
+            const int total_items = m_count * q8_per_row;
+            for (int i = tid; i < total_items; i += CTA_THREADS) {
+                const int mi = i / q8_per_row;
+                const int qi = i % q8_per_row;
+                const int tok = m_base + mi;
+
+                const block_q8_1& src = q8_base[tok * q8_per_row + qi];
+                int4* dst_qs = reinterpret_cast<int4*>(smem_qs + (mi * q8_per_row + qi) * 32);
+                int4 tmp0, tmp1;
+                memcpy(&tmp0, src.qs, 16);
+                memcpy(&tmp1, src.qs + 16, 16);
+                dst_qs[0] = tmp0;
+                dst_qs[1] = tmp1;
+
+                smem_d8[mi * q8_per_row + qi] = d8_base[tok * q8_per_row + qi];
+            }
+        }
+        __syncthreads();
+
+        float acc[DENSE_TILE_M];
+        for (int i = 0; i < DENSE_TILE_M; i++)
+            acc[i] = 0.0f;
+
+        for (int q8_idx = lane; q8_idx < q8_per_row; q8_idx += 32) {
+            const int super_blk = q8_idx / 8;
+            const int g = q8_idx % 8;
+            const int chunk = g / 2;
+            const int is_high = g & 1;
+            const int sub_block = g;
+
+            const uint8_t* bp = w_row + static_cast<size_t>(super_blk) * Traits::BYTES;
+
+            const float d_w = __half2float(*reinterpret_cast<const half*>(bp));
+            const float dmin_w = __half2float(*reinterpret_cast<const half*>(bp + 2));
+
+            uint8_t sc_val, min_val;
+            get_scale_min_q4k(bp + Traits::SCALES_OFFSET, sub_block, sc_val, min_val);
+
+            const float d_sc = d_w * static_cast<float>(sc_val);
+            const float dmin_mn = dmin_w * static_cast<float>(min_val);
+
+            const uint8_t* qs_ptr = bp + Traits::QS_OFFSET + chunk * 32;
+            uint32_t q4_packed[8];
+            memcpy(q4_packed, qs_ptr, 32);
+
+            [[maybe_unused]] uint32_t qh_packed[8] = {};
+            [[maybe_unused]] int qh_shift = 0;
+            if constexpr (BT == QKType::Q5_K) {
+                memcpy(qh_packed, bp + Traits::QH_OFFSET, 32);
+                qh_shift = 2 * chunk + is_high;
+            }
+
+            uint32_t nib[8];
+#pragma unroll
+            for (int d4 = 0; d4 < 8; d4++) {
+                if constexpr (BT == QKType::Q4_K) {
+                    nib[d4] = is_high ? ((q4_packed[d4] >> 4) & 0x0F0F0F0Fu)
+                                      : (q4_packed[d4] & 0x0F0F0F0Fu);
+                } else {
+                    uint32_t lo4 = is_high ? ((q4_packed[d4] >> 4) & 0x0F0F0F0Fu)
+                                           : (q4_packed[d4] & 0x0F0F0F0Fu);
+                    uint32_t qh4 = qh_packed[d4];
+                    uint32_t hi1_0 = ((qh4 >> (qh_shift + 0)) & 0x01u) << 4;
+                    uint32_t hi1_1 = ((qh4 >> (qh_shift + 8)) & 0x01u) << 12;
+                    uint32_t hi1_2 = ((qh4 >> (qh_shift + 16)) & 0x01u) << 20;
+                    uint32_t hi1_3 = ((qh4 >> (qh_shift + 24)) & 0x01u) << 28;
+                    nib[d4] = lo4 | hi1_0 | hi1_1 | hi1_2 | hi1_3;
+                }
+            }
+
+            for (int mi = 0; mi < m_count; mi++) {
+                const int8_t* qs_act = smem_qs + (mi * q8_per_row + q8_idx) * 32;
+                int4* qs_v = reinterpret_cast<int4*>(const_cast<int8_t*>(qs_act));
+                int4 v0 = qs_v[0];
+                int4 v1 = qs_v[1];
+                int xqs[8];
+                memcpy(&xqs[0], &v0, 16);
+                memcpy(&xqs[4], &v1, 16);
+
+                const float dq = smem_d8[mi * q8_per_row + q8_idx];
+
+                int32_t sumi = 0;
+                int32_t sum_ones = 0;
+                constexpr int ones = 0x01010101;
+#pragma unroll
+                for (int d4 = 0; d4 < 8; d4++) {
+                    int ni;
+                    memcpy(&ni, &nib[d4], 4);
+                    sumi = __dp4a(ni, xqs[d4], sumi);
+                    sum_ones = __dp4a(ones, xqs[d4], sum_ones);
+                }
+
+                acc[mi] += dq * (d_sc * static_cast<float>(sumi) -
+                                 dmin_mn * static_cast<float>(sum_ones));
+            }
+        }
+
+        for (int mi = 0; mi < m_count; mi++) {
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                acc[mi] += __shfl_down_sync(0xFFFFFFFF, acc[mi], off);
+        }
+
+        if (lane == 0) {
+            for (int mi = 0; mi < m_count; mi++) {
+                output[static_cast<size_t>(m_base + mi) * N + n_col] = __float2half(acc[mi]);
+            }
+        }
+
+        __syncthreads();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host launchers — dense dp4a
+// ---------------------------------------------------------------------------
+
+template <QKType BT>
+static void launch_dense_dp4a(const void* packed_weight, const block_q8_1* q8_base,
+                               const float* d8_base, half* output,
+                               int M, int N, int K, cudaStream_t stream) {
+    if (M <= 0 || K <= 0 || N <= 0)
+        return;
+
+    const int q8_per_row = K / 32;
+    const int n_col_blocks = (N + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+    const dim3 grid(n_col_blocks);
+    const dim3 block(CTA_THREADS);
+
+    const size_t smem_qs_bytes = static_cast<size_t>(DENSE_TILE_M) * q8_per_row * 32;
+    const size_t smem_d8_bytes = static_cast<size_t>(DENSE_TILE_M) * q8_per_row * sizeof(float);
+    const size_t smem_bytes = smem_qs_bytes + smem_d8_bytes;
+
+    static size_t smem_max_configured = 0;
+    if (smem_bytes > smem_max_configured) {
+        if (smem_bytes > 48 * 1024) {
+            cudaFuncSetAttribute(gemm_qk_dp4a_dense_kernel<BT>,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                 static_cast<int>(smem_bytes));
+        }
+        smem_max_configured = smem_bytes;
+    }
+
+    gemm_qk_dp4a_dense_kernel<BT><<<grid, block, smem_bytes, stream>>>(
+        static_cast<const uint8_t*>(packed_weight), q8_base, d8_base,
+        output, M, K, N, q8_per_row);
+}
+
+// ---------------------------------------------------------------------------
+// Host launchers — MoE dp4a (Q8_1 activations in shared memory)
 // ---------------------------------------------------------------------------
 
 template <QKType BT>
@@ -447,6 +635,22 @@ void gemm_q5k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_bas
                               cudaStream_t stream) {
     launch_dp4a<QKType::Q5_K>(packed_weight, q8_base, d8_base, c_base, offsets, K, N,
                               n_experts, weight_stride, stream);
+}
+
+void gemm_q4k_dp4a_dense(const void* packed_q4k, const half* activations, half* output,
+                          void* q8_scratch, float* d8_scratch,
+                          int M, int N, int K, cudaStream_t stream) {
+    auto* q8 = reinterpret_cast<block_q8_1*>(q8_scratch);
+    quantize_fp16_to_q8_1(activations, q8, d8_scratch, M * K, stream);
+    launch_dense_dp4a<QKType::Q4_K>(packed_q4k, q8, d8_scratch, output, M, N, K, stream);
+}
+
+void gemm_q5k_dp4a_dense(const void* packed_q5k, const half* activations, half* output,
+                          void* q8_scratch, float* d8_scratch,
+                          int M, int N, int K, cudaStream_t stream) {
+    auto* q8 = reinterpret_cast<block_q8_1*>(q8_scratch);
+    quantize_fp16_to_q8_1(activations, q8, d8_scratch, M * K, stream);
+    launch_dense_dp4a<QKType::Q5_K>(packed_q5k, q8, d8_scratch, output, M, N, K, stream);
 }
 
 }  // namespace imp

--- a/src/compute/gemm_q4k.h
+++ b/src/compute/gemm_q4k.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <cuda_fp16.h>
 #include <cstdint>
 
 namespace imp {
@@ -28,5 +29,18 @@ void gemm_q5k_dp4a_moe_fused(const void* packed_weight, const block_q8_1* q8_bas
                               int K, int N, int n_experts, size_t weight_stride,
                               cudaStream_t stream = nullptr);
 
+
+// Dense Q4_K/Q5_K × Q8_1 dp4a GEMM for non-MoE prefill.
+// Quantizes FP16 activations [M, K] to Q8_1, then computes directly from
+// Q4_K/Q5_K blocks via dp4a — avoids the FP16 weight cache intermediate
+// (0.55 B/elem vs 2.0 B/elem, 2.5× bandwidth reduction).
+// q8_scratch: [M * ceil(K/32)] block_q8_1, d8_scratch: [M * ceil(K/32)] float.
+// beta must be 0 (no residual accumulation).
+void gemm_q4k_dp4a_dense(const void* packed_q4k, const half* activations, half* output,
+                          void* q8_scratch, float* d8_scratch,
+                          int M, int N, int K, cudaStream_t stream = nullptr);
+void gemm_q5k_dp4a_dense(const void* packed_q5k, const half* activations, half* output,
+                          void* q8_scratch, float* d8_scratch,
+                          int M, int N, int K, cudaStream_t stream = nullptr);
 
 }  // namespace imp

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -7,6 +7,7 @@
 #include "core/logging.h"
 #include "runtime/config.h"
 #include "compute/gemm.h"
+#include "compute/gemm_q4k.h"
 #include "compute/gemm_q6k.h"
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
@@ -1769,6 +1770,43 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         StorageTier prefill = h.prefill_tier;
         if (prefill == StorageTier::Undefined)
             prefill = h.primary_tier;
+
+        // dp4a dense: compute directly from Q4_K/Q5_K blocks (0.55 B/elem)
+        // instead of the FP16 cache (2.0 B/elem). Weight-stationary with
+        // TILE_M=16 → re-reads weight ceil(M/16) times. Only wins at small
+        // M where the GEMM is memory-bound (M ≤ 64). At M=512, cuBLAS FP16
+        // with tensor cores + single weight read is faster.
+        // sm_120 caps smem at 99 KiB — K up to ~4400 fits.
+        if (prefill == StorageTier::FP16 && ctx.beta == 0.0f && M <= 64) {
+            const auto* qs = ctx.qscratch;
+            if (qs && qs->q8_1_prefill_buf && qs->d8_prefill_buf) {
+                int N = static_cast<int>(h.shape[0]);
+                int K = static_cast<int>(h.shape[1]);
+                constexpr size_t kSmemLimit = 101376;
+                size_t smem_needed = static_cast<size_t>(16) * (K / 32) * 36;
+                size_t needed_q8 = static_cast<size_t>(M) * ((K + 31) / 32) * sizeof(block_q8_1);
+                size_t needed_d8 = static_cast<size_t>(M) * ((K + 31) / 32) * sizeof(float);
+                if (smem_needed <= kSmemLimit &&
+                    needed_q8 <= qs->q8_1_prefill_bytes && needed_d8 <= qs->d8_prefill_bytes) {
+                    if (h.source_qtype == QType::Q4_K) {
+                        gemm_q4k_dp4a_dense(h.source_data,
+                                            reinterpret_cast<const half*>(input.data),
+                                            reinterpret_cast<half*>(output.data),
+                                            qs->q8_1_prefill_buf, qs->d8_prefill_buf,
+                                            M, N, K, ctx.stream);
+                        return;
+                    }
+                    if (h.source_qtype == QType::Q5_K) {
+                        gemm_q5k_dp4a_dense(h.source_data,
+                                            reinterpret_cast<const half*>(input.data),
+                                            reinterpret_cast<half*>(output.data),
+                                            qs->q8_1_prefill_buf, qs->d8_prefill_buf,
+                                            M, N, K, ctx.stream);
+                        return;
+                    }
+                }
+            }
+        }
 
         if (prefill == StorageTier::FP16) {
             auto fp16_it = wcache_.fp16.find(h.source_data);

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -148,6 +148,46 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         if (max_k > 0 && max_tokens_ > 0) {
             prewarm_mmvq_scratch(max_tokens_, max_k);
         }
+
+        // dp4a prefill scratch: enables direct Q4_K/Q5_K → dp4a GEMM for M>1
+        // without the FP16 weight cache intermediate. Only allocated when the
+        // model has sub-5-bit dense weights that benefit (Q4_K, Q5_K).
+        if (max_blocks > 0 && max_tokens_ > 1) {
+            bool has_sub5bit_dense = false;
+            for (int i = 0; i < cfg.n_layers && !has_sub5bit_dense; i++) {
+                const auto& L = model_->layer(i);
+                for (const auto* w : {&L.w_gate, &L.w_up, &L.w_down, &L.w_gate_shared,
+                                      &L.w_up_shared, &L.w_down_shared,
+                                      &L.wq, &L.wk, &L.wv, &L.wo}) {
+                    if (w->data && (w->qtype == QType::Q4_K || w->qtype == QType::Q5_K)) {
+                        has_sub5bit_dense = true;
+                        break;
+                    }
+                }
+            }
+            if (has_sub5bit_dense) {
+                // dp4a dense prefill only activates at M ≤ 64 (weight-stationary
+                // TILE_M=16 re-reads weight ceil(M/16) times — only wins at small M).
+                constexpr int kDp4aDenseMaxM = 64;
+                int dp4a_m = std::min(max_tokens_, kDp4aDenseMaxM);
+                int prefill_max_blocks = dp4a_m * (max_k / 32);
+                size_t q8_sz = static_cast<size_t>(prefill_max_blocks) * sizeof(block_q8_1);
+                size_t d8_sz = static_cast<size_t>(prefill_max_blocks) * sizeof(float);
+                cudaError_t e1 = cudaMalloc(&qscratch_.q8_1_prefill_buf, q8_sz);
+                cudaError_t e2 = cudaMalloc(reinterpret_cast<void**>(&qscratch_.d8_prefill_buf), d8_sz);
+                if (e1 != cudaSuccess || e2 != cudaSuccess) {
+                    IMP_LOG_WARN("dp4a prefill scratch alloc failed (%.1f MiB), FP16 cache fallback",
+                                 (q8_sz + d8_sz) / (1024.0 * 1024.0));
+                    if (qscratch_.q8_1_prefill_buf) { cudaFree(qscratch_.q8_1_prefill_buf); qscratch_.q8_1_prefill_buf = nullptr; }
+                    if (qscratch_.d8_prefill_buf) { cudaFree(qscratch_.d8_prefill_buf); qscratch_.d8_prefill_buf = nullptr; }
+                } else {
+                    qscratch_.q8_1_prefill_bytes = q8_sz;
+                    qscratch_.d8_prefill_bytes = d8_sz;
+                    IMP_LOG_INFO("dp4a prefill scratch: %.1f KiB (max_m=%d, max_k=%d)",
+                                 (q8_sz + d8_sz) / 1024.0, dp4a_m, max_k);
+                }
+            }
+        }
     }
 
     // Split-K paged attention scratch buffer.

--- a/src/exec/quant_scratch.cu
+++ b/src/exec/quant_scratch.cu
@@ -56,6 +56,17 @@ void QuantScratch::free(VRAMAllocator* alloc) {
     }
     q8_1_max_blocks = 0;
 
+    if (q8_1_prefill_buf) {
+        IMP_CUDA_CHECK_LOG(cudaFree(q8_1_prefill_buf));
+        q8_1_prefill_buf = nullptr;
+    }
+    if (d8_prefill_buf) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d8_prefill_buf));
+        d8_prefill_buf = nullptr;
+    }
+    q8_1_prefill_bytes = 0;
+    d8_prefill_bytes = 0;
+
     if (ffn_block_mask) {
         IMP_CUDA_CHECK_LOG(cudaFree(ffn_block_mask));
         ffn_block_mask = nullptr;

--- a/src/exec/quant_scratch.h
+++ b/src/exec/quant_scratch.h
@@ -42,10 +42,18 @@ struct QuantScratch {
     void* mxfp4_workspace = nullptr;
     size_t mxfp4_workspace_size = 0;
 
-    // --- dp4a (MMVQ) scratch for quantized input vector ---
+    // --- dp4a (MMVQ) scratch for quantized input vector (M=1 decode) ---
     void* q8_1_buf = nullptr;  // block_q8_1 array
     float* d8_buf = nullptr;   // float scale array
     int q8_1_max_blocks = 0;   // max K/32
+
+    // --- dp4a prefill scratch for M>1 dense GEMM (Q4_K/Q5_K) ---
+    // Sized for max_tokens * max_k/32 blocks. Eliminates the FP16 weight
+    // cache intermediate: reads Q4_K directly (0.55 B/elem vs 2.0 B/elem).
+    void* q8_1_prefill_buf = nullptr;
+    float* d8_prefill_buf = nullptr;
+    size_t q8_1_prefill_bytes = 0;
+    size_t d8_prefill_bytes = 0;
 
     // --- FFN sparsity mask (Phase 2): 1 bit per Q8 block, packed uint32. ---
     // Sized (q8_1_max_blocks + 31) / 32 uint32s. Tiny (~tens of bytes).


### PR DESCRIPTION
## Summary
- Extends MoE dp4a GEMM to dense Q4_K/Q5_K prefill — computes directly from quantized blocks (0.55 B/elem vs 2.0 B/elem FP16 cache)
- Gated to M ≤ 64: weight-stationary TILE_M=16 re-reads weights at large M, making cuBLAS faster for pp512+
- sm_120 shared memory cap (99 KiB) constrains TILE_M and max K (~4400)

## Test plan
- [x] `make verify-fast` passes
- [x] Qwen3-30B-A3B Q4_K_M: correct output with dp4a active at M=15
- [x] Qwen3-8B Q8_0 baseline: tg128=274 tok/s (no regression)
- [x] Gemma-3-12B Q4_K_M pp512: no CUDA errors, no regression
- [ ] CI build gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)