### PR TITLE
docs: fix stale sm_120f refs + update model baselines

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -6,7 +6,7 @@ All numbers come from one machine, one run series. Reproducing them on a differe
 
 | | |
 |---|---|
-| Hardware | Single NVIDIA RTX 5090, 32 GB GDDR7, Blackwell `sm_120f`, custom water loop |
+| Hardware | Single NVIDIA RTX 5090, 32 GB GDDR7, Blackwell `sm_120a`, custom water loop |
 | Toolchain | CUDA 13.2.1, CUTLASS v4.4.2, GCC 13, RelWithDebInfo or Release Docker build |
 | imp config | NVFP4 decode cache + FP8 prefill (non-GDN) / FP16 prefill (GDN), CUDA Graphs on (where the model supports it) |
 | llama.cpp | `b8445+`, flash attention on, full offload (`-ngl 99`) |
@@ -147,7 +147,7 @@ Memo: `memory/kv_dtype_tradeoffs_2026_04_24.md`.
 | Spec | Value |
 |------|-------|
 | GPU (this benchmark) | NVIDIA GeForce RTX 5090 |
-| Other supported GPUs (same `sm_120f`) | RTX PRO 5000 Blackwell (48 GB), RTX PRO 6000 Blackwell (96 GB) |
+| Other supported GPUs (same `sm_120a`) | RTX PRO 5000 Blackwell (48 GB), RTX PRO 6000 Blackwell (96 GB) |
 | Architecture | Blackwell (GB202), sm_120 |
 | VRAM | 32 GB GDDR7, 512-bit, 1792 GB/s (RTX 5090) |
 | SMs | 170 |

--- a/docs/sm120.md
+++ b/docs/sm120.md
@@ -1,6 +1,6 @@
 # sm_120 kernel notes
 
-Notes on what was optimized for `sm_120f` (RTX 5090, GB202 Blackwell consumer), what didn't move the needle, and what's still open. Engineering reference, not a feature list.
+Notes on what was optimized for `sm_120a` (RTX 5090, GB202 Blackwell consumer), what didn't move the needle, and what's still open. Engineering reference, not a feature list.
 
 ## Hardware
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -10,12 +10,14 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 |---|---|---:|---:|---|
 | Qwen3-4B | Q8_0 | 4.0 GB | 236 | GGUF |
 | Qwen3-4B | MXFP4 | 2.8 GB | 124 | GGUF |
-| Qwen3-8B | Q8_0 | 8.2 GB | **274** | GGUF |
-| Qwen3-14B | Q6_K | 12 GB | **165** | GGUF (north-star, see GOAL.md) |
+| Qwen3-8B | Q8_0 | 8.2 GB | **260** | GGUF |
+| Qwen3-8B | NVFP4 | 5.0 GB | **238** | SafeTensors (cortecs) |
+| Qwen3-14B | Q6_K | 12 GB | **158** | GGUF (north-star, see GOAL.md) |
+| Qwen3-14B | NVFP4 | 10 GB | 105 | SafeTensors (nvidia) |
 | Qwen3-32B | Q4_K_M | 19 GB | — | GGUF |
+| Phi-4-reasoning-plus | NVFP4 | 9.0 GB | 115 | SafeTensors (nvidia), fused projections |
 | Llama-3.2-3B | Q8_0 | 3.2 GB | 306 | GGUF |
 | Mistral-Small-3.1-24B | Q6_K | 19 GB | — | GGUF |
-| Mistral-Small-3.2-24B | NVFP4 | 13 GB | 101 | SafeTensors (Modelopt) |
 | DeepSeek-R1-Distill-Qwen-7B | Q8_0 | 7.6 GB | — | GGUF |
 | DeepSeek-R1-Distill-Qwen-14B | Q6_K | 12 GB | — | GGUF |
 
@@ -36,13 +38,14 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 |---|---|---:|---:|---|
 | Qwen3-Coder-30B-A3B | Q6_K | 24 GB | 236 | GGUF |
 | Qwen3-Coder-30B-A3B | NVFP4 | 16 GB | 270 | SafeTensors (Modelopt) |
-| Qwen3.6-35B-A3B | Q4_K_M | 22 GB | 243 | GGUF, set `IMP_EXPERT_OVERHEAD_PCT=10` |
-| Qwen3.6-35B-A3B | NVFP4 | 18 GB | 227 | SafeTensors (Modelopt) |
+| Qwen3-30B-A3B | NVFP4 | 16 GB | 158 | SafeTensors (Modelopt) |
+| Qwen3.6-35B-A3B | Q4_K_M | 22 GB | 243 | GGUF |
+| Qwen3.6-35B-A3B | NVFP4 | 18 GB | 154 | SafeTensors (Modelopt) |
 | Gemma-4-26B-A4B-it | Q4_K_M | 14 GB | 187 | GGUF |
 | Gemma-4-26B-A4B-it | Q5_K_M | 17 GB | 65 | GGUF, recommended for code-gen |
-| Gemma-4-26B-A4B-it | NVFP4 | 14 GB | 205 | SafeTensors (Modelopt) |
-| Nemotron-3-Nano-30B-A3B | Q6_K | 32 GB | — | GGUF, Mamba2 + attention + MoE |
-| Nemotron-3-Nano-30B-A3B | NVFP4 | 18 GB | 325 | SafeTensors (Modelopt), Mamba2 + attention + MoE |
+| Gemma-4-26B-A4B-it | NVFP4 | 14 GB | 163 | SafeTensors (Modelopt) |
+| Nemotron-3-Nano-30B-A3B | NVFP4 | 18 GB | 47 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited |
+| Nemotron-Labs-3-Elastic-30B-A3B | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
 
 ## Vision
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@ Build instructions, CLI/server usage, configuration, C API, project structure.
 
 ## Requirements
 
-- **NVIDIA Blackwell GB202** (sm_120f) — RTX 5090, RTX PRO 5000 Blackwell, or RTX PRO 6000 Blackwell. Same binary, same kernels; the workstation cards just have more VRAM (48 / 96 GB) for bigger MoE models without expert offload.
+- **NVIDIA Blackwell GB202** (sm_120a) — RTX 5090, RTX PRO 5000 Blackwell, or RTX PRO 6000 Blackwell. Same binary, same kernels; the workstation cards just have more VRAM (48 / 96 GB) for bigger MoE models without expert offload.
 - **CUDA Toolkit 13.2+** — `cudart`, `cuda_driver`, `cublas`, `cublasLt`
 - **CMake 3.25+**
 - **C++20 compiler** (GCC 11+, Clang 14+)
@@ -38,11 +38,11 @@ make verify          # full pre-merge gate (~5 min)
 | `IMP_BUILD_BENCH` | ON | imp-bench |
 | `IMP_BUILD_SERVER` | ON | imp-server |
 | `IMP_SANITIZERS` | OFF | ASAN + UBSAN (host C++ code only) |
-| `CMAKE_CUDA_ARCHITECTURES` | hard-pinned `sm_120f` | RTX 5090 only |
+| `CMAKE_CUDA_ARCHITECTURES` | hard-pinned `sm_120a` | RTX 5090 / RTX PRO 6000 |
 
-`sm_120f` is set via raw `--generate-code=arch=compute_120f,code=sm_120` in
-`CMakeLists.txt` (CMake < 3.31 workaround for the family-feature target).
-Don't override `CMAKE_CUDA_ARCHITECTURES`.
+`sm_120a` SASS + `compute_120f` PTX fallback are set via raw `--generate-code`
+in `CMakeLists.txt` (CMake < 3.31 workaround). Don't override
+`CMAKE_CUDA_ARCHITECTURES`.
 
 ## Configuration — `imp.conf`
 
@@ -271,7 +271,7 @@ imp/
 │   ├── memory/           KV cache (paged), SSM state, device/pinned allocators
 │   ├── model/            Model loading (GGUF + SafeTensors), tokenizer, weight upload
 │   ├── quant/            FP8, NVFP4, INT4/INT8 dequant, quantised GEMM
-│   ├── graph/            GraphExecutor (hardcoded transformer forward pass)
+│   ├── exec/             GraphExecutor (hardcoded transformer forward pass)
 │   ├── runtime/          Engine, Scheduler, CUDA Graphs, PDL, Green Contexts,
 │   │                     RuntimeConfig (imp.conf parser)
 │   ├── vision/           SigLIP encoder, image preprocessing, mmproj loader
@@ -315,9 +315,9 @@ from both Model Optimizer and llm-compressor.
 6. **Sample** — temperature, top-p/k, min-p, typical-p, repetition / DRY /
    Mirostat from FP32 logits.
 
-### Attention dispatch (sm_120f only)
+### Attention dispatch (sm_120a only)
 
-Runtime dispatch with no architecture checks (the build is sm_120f-only).
+Runtime dispatch with no architecture checks (the build is sm_120a-only).
 
 | Phase | Path |
 |---|---|


### PR DESCRIPTION
## Summary
- Replace `sm_120f` → `sm_120a` across 3 doc files (primary target since PR #105)
- Fix `src/graph/` → `src/exec/` in usage.md project tree (Phase 1 rename)
- Correct tg256 numbers that were actually tg128 values in supported-models.md
- Add 5 missing NVFP4 models, remove 2 stale entries

## Test plan
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)