### PR TITLE
fix: route dense Gemma-4 MLP weights to standard slots

### DIFF
--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -279,6 +279,7 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
     int skipped = 0;
 
     const bool is_gemma4 = (arch_ == ModelArch::GEMMA4);
+    const bool is_gemma4_moe = is_gemma4 && (model.config_.n_experts > 0);
     const bool is_qwen36_moe = (arch_ == ModelArch::QWEN36_MOE);
     const bool is_nemotron_h = (arch_ == ModelArch::NEMOTRON_H_MOE);
     // Multimodal "ForConditionalGeneration" wrappers (Gemma-4-VL, Qwen3.6-VL)
@@ -507,10 +508,11 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
             matched = true;
         }
 
-        // -- Gemma 4: mlp.{gate,up,down}_proj.weight is the SHARED EXPERT,
+        // -- Gemma 4 MoE: mlp.{gate,up,down}_proj.weight is the SHARED EXPERT,
         //    NOT dense MLP. Route to w_*_shared instead. Must come before
-        //    the generic dense-MLP branch below.
-        if (!matched && is_gemma4 && parts.size() >= 6 && parts[3] == "mlp" && parts[5] == "weight") {
+        //    the generic dense-MLP branch below. Dense Gemma-4 (31B) falls
+        //    through to the standard w_gate/w_up/w_down path.
+        if (!matched && is_gemma4_moe && parts.size() >= 6 && parts[3] == "mlp" && parts[5] == "weight") {
             const std::string& proj = parts[4];
             if (proj == "gate_proj") {
                 layer.w_gate_shared = t;


### PR DESCRIPTION
## Summary
- The shared-expert routing for `mlp.{gate,up,down}_proj.weight` was gated on `is_gemma4` alone, which broke dense Gemma-4 (31B) — MLP weights were misrouted to `w_*_shared` leaving `w_gate`/`w_up`/`w_down` empty
- Added `is_gemma4_moe` flag (`is_gemma4 && n_experts > 0`) so only MoE variants (26B-A4B) use the shared expert path; dense models fall through to the generic MLP branch

## Test plan
- [x] Gemma-4-26B-A4B-it-NVFP4 (MoE) loads and generates correctly ("Capital of France?" → "Paris")
- [x] Gemma-4-31B-IT-NVFP4 (dense) weight mapping correct: `experts=0`, 1372 tensors assigned (OOM at 32 GB is expected — 31B dense is ~30 GB weights)
- [x] Unit tests pass (37/37)
- [x] `make verify-fast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)