### PR TITLE
chore: bump cpp-httplib v0.45.0 → v0.46.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ endif()
 if(IMP_BUILD_SERVER)
     FetchContent_Declare(httplib
         GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-        GIT_TAG v0.45.0
+        GIT_TAG v0.46.0
         GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(httplib)

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN { sed -i 's|archive.ubuntu.com|de.archive.ubuntu.com|g; s|security.ubuntu.co
 # Tags must mirror the FetchContent_Declare entries in CMakeLists.txt.
 RUN git clone --depth=1 --branch v1.17.0 https://github.com/google/googletest.git /deps/googletest \
  && git clone --depth=1 --branch v4.5.1  https://github.com/NVIDIA/cutlass.git    /deps/cutlass    \
- && git clone --depth=1 --branch v0.42.0 https://github.com/yhirose/cpp-httplib.git /deps/httplib  \
+ && git clone --depth=1 --branch v0.46.0 https://github.com/yhirose/cpp-httplib.git /deps/httplib  \
  && git clone --depth=1 --branch v3.12.0 https://github.com/nlohmann/json.git     /deps/json
 
 WORKDIR /src


### PR DESCRIPTION
Routine dep bump. 0 FAIL, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)