### PR TITLE
feat: Phase 3 auto-StreamingLLM for long agent sessions

### DIFF
--- a/include/imp/config.h
+++ b/include/imp/config.h
@@ -83,6 +83,7 @@ typedef struct {
     // middle KV blocks for long generations. Currently active only for the FP16
     // GQA decode path; other quantized variants ignore these settings.
     int streaming_kv_enabled;    // 0 = off (default), 1 = on
+    int streaming_kv_auto;       // 1 = auto-enable when KV cache >90% full (default)
     int streaming_kv_n_sinks;    // # of initial tokens to always keep (default 4)
     int streaming_kv_window;     // sliding window size (0 = use ModelConfig::sliding_window)
     int streaming_kv_threshold;  // ctx_len at which streaming activates

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -74,6 +74,7 @@ ImpConfig imp_config_default(void) {
     config.mmproj_path = NULL;                // no vision model
     config.turboquant_sketch_multiplier = 2;  // sketch_dim = 2 * head_dim
     config.streaming_kv_enabled = 0;          // off by default (opt-in)
+    config.streaming_kv_auto = 1;             // auto-enable when KV cache >90% full
     config.streaming_kv_n_sinks = 4;          // StreamingLLM paper default
     config.streaming_kv_window = 0;           // 0 = derive from ModelConfig::sliding_window
     config.streaming_kv_threshold = 0;        // 0 = auto
@@ -294,6 +295,7 @@ ImpError imp_context_create(ImpModel model, const ImpConfig* config, ImpContext*
         if (config->mmproj_path)
             ecfg.mmproj_path = config->mmproj_path;
         ecfg.streaming_kv_enabled = (config->streaming_kv_enabled != 0);
+        ecfg.streaming_kv_auto = (config->streaming_kv_auto != 0);
         ecfg.streaming_kv_n_sinks = config->streaming_kv_n_sinks;
         ecfg.streaming_kv_window = config->streaming_kv_window;
         ecfg.streaming_kv_threshold = config->streaming_kv_threshold;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -94,6 +94,7 @@ struct EngineConfig {
     // Currently active only on the FP16 GQA decode path; quantized variants
     // ignore these settings.
     bool streaming_kv_enabled = false;
+    bool streaming_kv_auto = true;   // auto-enable StreamingLLM when KV cache >90% full
     int streaming_kv_n_sinks = 4;    // # initial tokens to always attend
     int streaming_kv_window = 0;     // 0 = derive from ModelConfig::sliding_window
     int streaming_kv_threshold = 0;  // 0 = auto: n_sinks + window + 2*kKVBlockSize

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -755,6 +755,33 @@ void Engine::step_decode(cudaStream_t dec_stream) {
             }
         }
 
+        // Auto-activate StreamingLLM when KV cache is nearly exhausted.
+        // Only fires once (guards on !streaming_kv_enabled) and only for FP16
+        // KV — quantized variants don't support sentinel-block skipping yet.
+        if (!config_.streaming_kv_enabled && config_.streaming_kv_auto) {
+            auto st = kv_manager_->stats();
+            if (st.total_blocks > 0 && st.free_blocks < st.total_blocks / 10) {
+                if (kv_cache_raw_ && kv_cache_raw_->qtype() == QType::F16) {
+                    config_.streaming_kv_enabled = true;
+                    int n_sinks = (config_.streaming_kv_n_sinks > 0) ? config_.streaming_kv_n_sinks : 4;
+                    int win = (config_.streaming_kv_window > 0) ? config_.streaming_kv_window
+                                                                : model_->config().sliding_window;
+                    if (win <= 0) win = 4096;
+                    config_.streaming_kv_window = win;
+                    executor_->set_streaming_kv(n_sinks, win);
+                    IMP_LOG_WARN(
+                        "KV cache >90%% full (%d/%d blocks free) — auto-enabling "
+                        "StreamingLLM (sinks=%d, window=%d)",
+                        st.free_blocks, st.total_blocks, n_sinks, win);
+                    if (config_.use_cuda_graphs) {
+                        IMP_LOG_WARN(
+                            "Disabling CUDA Graphs (block table mutates with StreamingLLM).");
+                        config_.use_cuda_graphs = false;
+                    }
+                }
+            }
+        }
+
         // StreamingLLM smart KV cache: once context exceeds the threshold,
         // free middle blocks while keeping sinks + window. The decode kernel
         // skips the freed (-1 sentinel) slots via its own n_sinks logic.

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -72,6 +72,7 @@ void print_usage(const char* prog) {
             "                        for long-prompt workloads where prefill dominates wallclock.\n"
             "  --prefix-caching      Reuse KV cache blocks for shared token prefixes\n"
             "  --streaming-kv        Enable StreamingLLM smart KV cache (attention sinks + window)\n"
+            "  --no-streaming-kv-auto  Disable auto-StreamingLLM when KV cache >90%% full\n"
             "  --stream-sinks <n>    Number of attention-sink tokens to always keep (default: 4)\n"
             "  --stream-window <n>   Sliding-window size (default: model's sliding_window)\n"
             "  --mxfp4-prefill       Use CUTLASS MXFP4 GEMM for prefill (sm_120, requires NVFP4)\n"
@@ -200,6 +201,8 @@ CliArgs parse_args(int argc, char** argv) {
             args.prefix_caching = true;
         } else if (std::strcmp(arg, "--streaming-kv") == 0) {
             args.streaming_kv = true;
+        } else if (std::strcmp(arg, "--no-streaming-kv-auto") == 0) {
+            args.no_streaming_kv_auto = true;
         } else if (std::strcmp(arg, "--stream-sinks") == 0 && i + 1 < argc) {
             args.streaming_sinks = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--stream-window") == 0 && i + 1 < argc) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -62,6 +62,7 @@ struct CliArgs {
     bool dual_path_quant = false;        // --dual-path-quant: FP8 attention + NVFP4 FFN
     bool prefix_caching = false;         // --prefix-caching: reuse KV blocks for shared prefixes
     bool streaming_kv = false;           // --streaming-kv: StreamingLLM smart KV cache (sinks + window)
+    bool no_streaming_kv_auto = false;   // --no-streaming-kv-auto: disable auto-StreamingLLM on KV pressure
     int streaming_sinks = 4;             // --stream-sinks: # of sink tokens to keep
     int streaming_window = 0;            // --stream-window: window size (0 = use ModelConfig::sliding_window)
     std::vector<std::string> stop_sequences;  // --stop: text-level stop strings

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -147,6 +147,8 @@ int main(int argc, char** argv) {
         config.streaming_kv_n_sinks = args.streaming_sinks;
         config.streaming_kv_window = args.streaming_window;
     }
+    if (args.no_streaming_kv_auto)
+        config.streaming_kv_auto = 0;
     config.use_nvfp4_decode = args.decode_nvfp4;
     if (!args.mmproj_path.empty())
         config.mmproj_path = args.mmproj_path.c_str();


### PR DESCRIPTION
## Summary

Auto-enables StreamingLLM when KV cache pressure exceeds 90% during decode. This prevents request cancellation on long-running agent sessions by gracefully degrading to a sink+window attention pattern.

**What happens:**
1. Agent generates tokens until KV cache is 90% full
2. imp auto-activates StreamingLLM (logs a WARN)
3. Middle KV blocks are freed (sink=4 + window=4096 tokens retained)
4. Decode continues indefinitely — kernel skips freed blocks via `-1` sentinel
5. Quality degrades for tokens referencing very old context (acceptable for agents)

**Changes:**
- `engine_scheduler.cpp`: auto-activation check in `step_decode()`, fires once per session
- `engine.h` + `config.h`: `streaming_kv_auto` flag (default ON)
- CLI: `--no-streaming-kv-auto` opt-out
- Disables CUDA Graphs on activation (block table mutation invalidates captures)

**What this enables:**
- Effectively "infinite" context for agent workloads
- No OOM on 50k+ token sessions
- Combined with Phase 1 (32k+ FMHA) and NVFP4 KV: agents can run hundreds of turns

**Default ON** for both CLI and server. Opt-out via `--no-streaming-kv-auto` or `streaming_kv_auto = false` in imp.conf.

## Test plan
- [x] Build passes (make build + verify-fast)
- [ ] Manual: generate 32k+ tokens, verify auto-activation log fires and decode continues
- [ ] Verify decode quality acceptable (sink=4 + window=4096 covers recent context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)