### PR TITLE
perf: Sawtooth wavefront reordering in FMHA prefill

### DIFF
--- a/src/compute/attention_blackwell.cu
+++ b/src/compute/attention_blackwell.cu
@@ -148,10 +148,12 @@ __global__ void flash_attention_blackwell_kernel(const half* __restrict__ Q, con
     const int o_total_tiles = o_row_tiles * o_col_tiles;
     const int pv_chunks = BW_Bc / WMMA_K;  // 4
 
-    // ---- prefetch first K tile into buf[0] ----
+    // ---- prefetch first K tile into buf[0] (Sawtooth: start from opposite end if reversed) ----
+    const bool sawtooth_reverse = (blockIdx.x % 2 == 1);
+    const int first_j = sawtooth_reverse ? (num_kv_tiles - 1) : first_kv_tile;
     int cur_buf = 0;
     if (first_kv_tile < num_kv_tiles) {
-        const int kv_start = first_kv_tile * BW_Bc;
+        const int kv_start = first_j * BW_Bc;
         const int total = BW_Bc * head_dim;
         for (int i = tid; i < total; i += BW_BLOCK_THREADS) {
             int r = i / head_dim;
@@ -166,9 +168,11 @@ __global__ void flash_attention_blackwell_kernel(const half* __restrict__ Q, con
     __syncthreads();
 
     // ================================================================
-    // Main loop over KV tiles
+    // Main loop over KV tiles (Sawtooth: alternate scan direction per Q tile for L2 locality)
     // ================================================================
-    for (int j = first_kv_tile; j < num_kv_tiles; j++) {
+    const int n_kv_iters = num_kv_tiles - first_kv_tile;
+    for (int iter = 0; iter < n_kv_iters; iter++) {
+        const int j = sawtooth_reverse ? (num_kv_tiles - 1 - iter) : (first_kv_tile + iter);
         const int kv_start = j * BW_Bc;
 
         // K[j] is in KV_bufs[cur_buf], ready.
@@ -324,10 +328,12 @@ __global__ void flash_attention_blackwell_kernel(const half* __restrict__ Q, con
         }
         __syncthreads();
 
-        // ---- Prefetch K[j+1] into KV_bufs[1-cur_buf] ----
+        // ---- Prefetch next K tile into KV_bufs[1-cur_buf] (Sawtooth-aware) ----
         int next_buf = 1 - cur_buf;
-        if (j + 1 < num_kv_tiles) {
-            const int next_kv_start = (j + 1) * BW_Bc;
+        const int next_j = sawtooth_reverse ? (j - 1) : (j + 1);
+        const bool has_next = sawtooth_reverse ? (next_j >= first_kv_tile) : (next_j < num_kv_tiles);
+        if (has_next) {
+            const int next_kv_start = next_j * BW_Bc;
             const int total = BW_Bc * head_dim;
             for (int i = tid; i < total; i += BW_BLOCK_THREADS) {
                 int r = i / head_dim;

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -164,9 +164,12 @@ __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 2) fmha_sm120_kernel(
     const int pv_chunks = Bkv / SM120_WMMA_K;
 
     // ================================================================
-    // Main loop over KV tiles
+    // Main loop over KV tiles (Sawtooth: alternate scan direction per Q tile for L2 locality)
     // ================================================================
-    for (int j = first_kv_tile; j < num_kv_tiles; j++) {
+    const bool sawtooth_reverse = (blockIdx.x % 2 == 1);
+    const int n_kv_iters = num_kv_tiles - first_kv_tile;
+    for (int iter = 0; iter < n_kv_iters; iter++) {
+        const int j = sawtooth_reverse ? (num_kv_tiles - 1 - iter) : (first_kv_tile + iter);
         const int kv_start = j * Bkv;
 
         // ---- Load K tile (vectorized float4 = 8 halves per iter) ----


### PR DESCRIPTION
## Summary

Implements Sawtooth Wavefront Reordering (arxiv:2601.16032) in both FMHA prefill kernels. Even-indexed Q tiles scan KV forward, odd-indexed scan backward. Adjacent Q tiles on the same SM share L2-resident KV data at the scan boundary.

**Changes:**
- `attention_fmha_sm120.cu`: Loop direction toggle via `blockIdx.x % 2`
- `attention_blackwell.cu`: Same + adapted double-buffer prefetch for reverse direction

**Correctness:** Online softmax is commutative — scan order doesn't affect output. All 20 FmhaSm120Test pass unchanged.

**Expected gain:** +5-15% prefill at context >= 32k (RTX 5090 has 96 MiB L2; paper reports +60% on 24 MiB L2 GB10). Need A/B with pp8192+ to measure.

## Test plan
- [x] All 20 FmhaSm120Test pass (includes 7 q_offset chunked tests)
- [x] Build passes (make build + verify-fast)
- [ ] A/B benchmark at pp4096/pp8192 to measure actual gain

🤖 Generated with [Claude Code](https://claude.com/claude-code)