### PR TITLE
fix(gemma3): remove double norm offset that corrupted all output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes since v0.6. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Critical fixes
+
+- **Gemma-3 garbage output** — `apply_arch_defaults` set `norm_weight_offset = 1.0`
+  for `GEMMA3`, but the llama.cpp GGUF converter already bakes the `+1` into every
+  `*norm.weight` (verified: `blk.0.attn_norm.weight` min ≈ 0.99 == learned ≈ 0 + 1;
+  same convention noted for Qwen3.5/Gemma-4 in `gguf_loader.cpp`). The extra offset
+  double-counted across all four sandwich norms × 48 layers, producing incoherent
+  token salad on every prompt. Fix: GEMMA3 now uses offset 0 (matching GEMMA4 and
+  Qwen3.5). Verified coherent on `gemma-3-12b-it-Q4_K_M` ("The capital of France is
+  Paris."), decode speed unchanged.
+
+### Performance
+
+- **Gemma-3 chunked prefill** — enabled for `GEMMA3` (was gated off as "no test
+  model"). Gemma-3 has uniform head_dim/kv_heads and reuses the same per-layer
+  cuBLAS sliding-window dispatch as Gemma-4. Verified: byte-identical greedy output
+  vs single-shot prefill on a 577-token prompt split into 3 chunks across SWA
+  boundaries.
+
+### Fixed
+
+- **`imp-bench` build break** — `bench_attention.cu` called `attention_prefill_dispatch`
+  without the `RuntimeConfig` argument added to its signature. Restored the build and
+  extended the prefill-attention sweep to 32k tokens.
+
 ## [0.9.1] - 2026-05-27
 
 ### Critical fixes

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -224,11 +224,11 @@ void apply_arch_defaults(ModelConfig& cfg) {
     // Gemma-3/4 computes embed_scale from d_model
     if (cfg.arch == ModelArch::GEMMA3 || cfg.arch == ModelArch::GEMMA4)
         cfg.embed_scale = std::sqrt(static_cast<float>(cfg.d_model));
-    // Gemma-3 stores norm weights as (w - 1) so add 1.0 back at runtime.
-    // Gemma 4 stores them as actual values (verified against llama.cpp build_norm,
-    // which never adds an offset). q_norm values around 1.0234 ARE the actual scale.
-    if (cfg.arch == ModelArch::GEMMA3)
-        cfg.norm_weight_offset = 1.0f;
+    // Gemma norm weights store (1 + learned) directly: the GGUF converter bakes
+    // the +1 into every *norm.weight (see gguf_loader.cpp "already baked"), so the
+    // runtime must use the weight as-is (offset 0), same as Gemma-4 and Qwen3.5.
+    // Verified on gemma-3-12b-it-Q4_K_M: attn_norm min≈0.99 (== learned≈0 + 1), not
+    // centered at 0. Applying a +1 offset here double-counts → garbage output.
     if (e.ffn_activation >= 0)
         cfg.ffn_activation = static_cast<FFNActivation>(e.ffn_activation);
     if (e.norm_placement >= 0)

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -188,7 +188,9 @@ bool Engine::supports_chunked_prefill_() const {
     //   - cuBLAS softmax sliding_window param (PR feat(attn): sliding_window),
     //   - per-layer dispatch through the rectangular cuBLAS prefill path
     //     (every layer call uses its own nh/nkv/hd from layer-local vars).
-    if (cfg.arch == ModelArch::GEMMA3) return false;       // SWA, no test model
+    // GEMMA3 (SWA, uniform head_dim/kv_heads, sliding_window_pattern) reuses the
+    // same per-layer cuBLAS sliding_window dispatch as GEMMA4 and passes the
+    // uniformity gates below; verified coherent on gemma-3-12b-it-Q4_K_M.
     if (cfg.arch == ModelArch::LLAMA4) return false;       // MoE + SWA, untested
     // Per-layer attention shape uniformity gate. Hybrid archs (QWEN35*, QWEN36_MOE,
     // NEMOTRON_H_MOE) populate n_kv_heads_per_layer with zeros for non-attention

--- a/tools/imp-bench/bench_attention.cu
+++ b/tools/imp-bench/bench_attention.cu
@@ -2,6 +2,7 @@
 #include "compute/attention_tc.h"
 #include "compute/attention_paged.h"
 #include "core/tensor.h"
+#include "runtime/config.h"
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -71,7 +72,8 @@ static float bench_kernel(const AttentionConfig& cfg, int seq_len, bool use_cutl
     auto run_kernel = [&]() {
         if (use_cutlass) {
             // Use runtime dispatch (tries MXFP4 -> FP8 -> FP16 FMHA -> Blackwell WMMA)
-            attention_prefill_dispatch(Q, K, V, O, scale, true, 0, 0.0f, stream);
+            static const RuntimeConfig rcfg{};
+            attention_prefill_dispatch(Q, K, V, O, scale, true, 0, 0.0f, stream, rcfg);
             return;
         }
         flash_attention_blackwell(Q, K, V, O, scale, true, 0, 0.0f, stream);
@@ -126,7 +128,7 @@ void bench_attention() {
         {"Qwen3-Coder-30B", 32, 4, 128}, {"DS-R1-14B", 40, 8, 128},        {"Llama-3-70B", 64, 8, 128},
     };
 
-    std::vector<int> seq_lens = {512, 1024, 2048, 4096, 8192};
+    std::vector<int> seq_lens = {512, 1024, 2048, 4096, 8192, 16384, 32768};
 
     for (const auto& cfg : configs) {
         printf("%-24s  nh=%2d nkv=%2d hd=%3d (GQA %dx)\n", cfg.name, cfg.n_heads, cfg.n_kv_heads,


### PR DESCRIPTION
## Summary

Gemma-3 (a hero model) produced **incoherent token salad on every prompt** — discovered while auditing the roadmap. Root-caused and fixed.

- **Root cause:** `apply_arch_defaults` set `norm_weight_offset = 1.0` for `GEMMA3`, but the llama.cpp GGUF converter already bakes the `+1` into every `*norm.weight`. Verified empirically: `blk.0.attn_norm.weight` has min ≈ 0.99 (== learned ≈ 0 + 1), and `gguf_loader.cpp` already documents this convention for Qwen3.5/Gemma-4. The extra runtime offset double-counted across all four sandwich norms × 48 layers, computing `rmsnorm(x)·(2+learned)` instead of `·(1+learned)`. Fix: GEMMA3 uses offset 0, matching GEMMA4 and Qwen3.5.
- **Bonus 1 — Gemma-3 chunked prefill:** enabled (was gated off as "no test model"). Gemma-3 has uniform head_dim/kv_heads and reuses Gemma-4's per-layer cuBLAS sliding-window dispatch.
- **Bonus 2 — imp-bench build:** fixed a stale `attention_prefill_dispatch` signature (missing `RuntimeConfig`) and extended the prefill-attention sweep to 32k.

All three changes are strictly `arch == GEMMA3` / bench-only — no cross-model impact.

## Verification

- `gemma-3-12b-it-Q4_K_M`: garbage → `"The capital of France is Paris."` + coherent 90-token paragraph; stderr clean; decode 98.7 tok/s (unchanged — zero-cost config fix).
- Chunked prefill: byte-identical greedy output vs single-shot on a 577-token prompt split into 3 chunks across SWA boundaries.
- Qwen3-8B-Q8_0: still coherent (regression check; changes are GEMMA3-gated).

## Test plan

- [ ] `gemma-3-12b-it-Q4_K_M` generates coherent output (manual + DegenerationTest with the model)
- [ ] Chunked prefill greedy-parity holds (`--prefill-chunk-size 256` vs `0`)
- [ ] No regression on non-Gemma models (CI perf gate + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)