### PR TITLE
docs(q4k-mmq): fold forge experiment evidence into the spec

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ The goal is making imp the fastest local engine for AI agent workloads on consum
 
 ## Open performance work
 
-- **Q4_K_M prefill gap** (-38% vs llama.cpp) -- needs a custom in-SMEM Q4_K MMQ kernel with FP16 HMMA. Design spec: [`specs/2026-05-28-q4k-mmq-kernel-design.md`](superpowers/specs/2026-05-28-q4k-mmq-kernel-design.md). Prior INT8 IMMA and FP16 HMMA v2 approaches were both refuted. Estimated 2-3 weeks.
+- **Q4_K_M prefill gap** (-38% vs llama.cpp) -- the in-SMEM Q4_K MMQ + FP16 HMMA approach is now **evidence-refuted**: the `feat/q4k-mmq-hmma` forge experiment built exactly this kernel and ncu-proved it's decode-throughput-bound, *tying* (not beating) cuBLAS — and the gap is vs llama.cpp beating cuBLAS, so closing it needs to beat cuBLAS (decode-tax-blocked) or pay 2× weight VRAM via pre-shuffle (rejected). The biggest gaps are also MoE-expert (small-M) which a dense tile kernel doesn't touch. See the "Evidence from the forge experiment" section in [`specs/2026-05-28-q4k-mmq-kernel-design.md`](superpowers/specs/2026-05-28-q4k-mmq-kernel-design.md). Practical resolution: recommend NVFP4 SafeTensors for fast Q4_K-class prefill.
 
 - **Sawtooth Wavefront Reordering** (PR #456) -- alternate KV scan direction per Q tile for L2 locality. Implemented in both FMHA kernels. Expected +5-15% prefill at 32k+ context.
 

--- a/docs/superpowers/specs/2026-05-28-q4k-mmq-kernel-design.md
+++ b/docs/superpowers/specs/2026-05-28-q4k-mmq-kernel-design.md
@@ -2,7 +2,11 @@
 
 **Goal:** Close the -38% Q4_K_M prefill gap vs llama.cpp with a custom tiled GEMM kernel that works directly on Q4_K packed weights without dequant-to-FP16.
 
-**Status:** Design spec. Implementation estimated at 2-3 weeks.
+**Status:** Design spec. Implementation estimated at 2-3 weeks. **⚠️ See
+"Evidence from the forge experiment" below before starting — this exact approach
+was already built and ncu-characterized on branch `feat/q4k-mmq-hmma`, and it
+ties (does not beat) cuBLAS. Closing the −38 % gap requires *beating* cuBLAS,
+which the in-kernel decode tax blocks. Read the evidence first.**
 
 ---
 
@@ -93,6 +97,54 @@ For M < 32, the existing dp4a GEMV path (PR #436) is already faster than cuBLAS.
 - **Target:** within 20% of llama.cpp at pp512 (currently -38%)
 - **Theoretical ceiling:** 838 TFLOPS FP16-TC. At Q4_K 4.5 bits/elem, the kernel is compute-bound above M=64 (arithmetic intensity > 100 FLOPs/byte)
 - **Realistic:** 200-400 TFLOPS effective (shared memory decode overhead, scale apply, tile boundaries)
+
+## Evidence from the forge experiment (2026-05-28, branch `feat/q4k-mmq-hmma`)
+
+**This approach was already implemented and ncu-characterized.** The `forge/`
+mini-framework on branch `feat/q4k-mmq-hmma` is exactly the kernel this spec
+proposes: raw `mma.sync.m16n8k16` (FP16 HMMA) + `ldmatrix`, decoding Q4_K/Q6_K
+nibbles **in-register (dreg)** straight into MMA fragments — no fp16_cache, no
+pre-materialized FP16 buffer, single launch, plus a live per-shape autotuner. The
+three v2 failure modes this spec lists (MIN_M gate, fp16_cache hits, dispatch
+overhead) were all eliminated. It still does not close the gap. Findings:
+
+- **It ties cuBLAS, and the gap is vs llama.cpp *beating* cuBLAS.** Forge's Q4_K
+  reaches ~0.92× the FP16-WMMA reference and **ties cuBLAS at dense model level**
+  on gemma-3-12b and gemma-4-31B. But the −38 % is measured against llama.cpp,
+  whose MMQ beats cuBLAS — so a tie with cuBLAS is still ~−38 %. **Closing the gap
+  requires beating cuBLAS's hand-tuned FP16 GEMM, not matching it.**
+- **The kernel is decode-throughput-bound, not bandwidth- or compute-bound.** ncu
+  on the pure GEMM (M=512, no dequant in either side): forge/cuBLAS = ffn_gateup
+  0.81×, attn_out 0.52×, ffn_down 0.45×. ffn_down: DRAM 5.9 % (NOT bandwidth-bound),
+  SM 46–58 %, occupancy 11.8 % (SMEM-limited), top stalls `short_scoreboard` +
+  `mio_throttle` — i.e. **LSU/MIO read-transaction throughput on the nibble-unpack
+  SMEM reads.** This is forge's structural tax; cuBLAS reads pre-dequant FP16 (zero
+  decode) and never pays it.
+- **The three kernel-tuning axes all missed the bottleneck.** Split-K (model-neutral,
+  it's MIO-bound not SM-count-bound), occupancy/BN=64 (+0.5 %), uint16 reads (+0.8 %),
+  and the int4→fp16 bit-trick (Marlin/AWQ; neutral — the decode arithmetic is *off*
+  the critical path, so removing I2F doesn't help) were all refuted. The microbench
+  trap (BM=128 wins back-to-back, regresses single-shot in-model) bit twice.
+- **The only lever that moved it costs 2× weight VRAM.** A pre-shuffled (Marlin-style)
+  layout that pre-permutes decoded values into MMA-fragment order → coalesced reads:
+  Q6_K pp512 −11.5 % → −7.8 %, pp4096 → −2.9 %, some shapes beat the WMMA reference.
+  But it needs a 2nd persistent repacked weight copy (~1.37× weight VRAM). **Reverted —
+  the user will not double weight VRAM.** An on-the-fly in-kernel permute (no extra
+  copy) is ~5× slower (loses the decode↔MMA overlap). No contained no-doubling path.
+- **The −38 % is MoE-dominated, and this dense kernel doesn't address it.** The
+  largest gaps are Gemma-4 / Qwen3.6 Q4_K_M, where the weight is the **MoE-expert
+  grouped GEMM at small M-per-expert** (~32–64). Forge is structurally a large-M
+  kernel (flat decode cost regardless of row count → `ForgeQ6kBench.SmallMCrossover`
+  refuted the small-M niche), is not wired into the MoE path, and a TILE_M=64 dense
+  kernel leaves the dominant term untouched. The earlier INT8 IMMA prototype that
+  *did* target small-M plateaued at 40 TOPS (4.3 % of peak).
+
+**Recommendation:** do not spend the 2-3 weeks re-deriving this. The HMMA-decode
+MMQ is evidence-refuted for closing the gap; the remaining paths are (a) beat
+cuBLAS's GEMM (refuted-class multi-week), (b) accept 2× weight VRAM via pre-shuffle
+(rejected), or (c) accept the gap and recommend NVFP4 SafeTensors for fast Q4_K-class
+prefill. Full data + the reusable findings live in the forge branch and in
+`memory/forge_kernel_framework_2026_05_28.md`.
 
 ## Files
 


### PR DESCRIPTION
## Summary

Records the evidence that the in-SMEM Q4_K decode + FP16 HMMA approach (the roadmap's #1 open perf item) is **already refuted** by the `feat/q4k-mmq-hmma` forge experiment, so the 2-3 week implementation isn't re-derived.

- The forge branch *is* exactly this kernel (in-register Q4_K/Q6_K decode → `mma.sync.m16n8k16`, single launch, no fp16_cache — all three v2 failure modes eliminated).
- ncu: decode-throughput-bound (`short_scoreboard` + `mio_throttle` on the nibble-unpack SMEM reads; DRAM 5.9%, occupancy 11.8%). Pure-GEMM vs cuBLAS at M=512: 0.45–0.81×. It **ties** cuBLAS at best.
- The −38% gap is vs **llama.cpp beating cuBLAS**, so a tie with cuBLAS is still −38%. Closing it needs to *beat* cuBLAS (refuted-class) or pay 2× weight VRAM via pre-shuffle (rejected).
- The largest gaps are MoE-expert (small-M) Q4_K_M — a dense TILE_M=64 kernel doesn't touch that regime.

Adds an "Evidence from the forge experiment" section to the spec + a refutation caveat + NVFP4-SafeTensors resolution to the roadmap. Docs only.

## Test plan

- [ ] N/A — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)