### PR TITLE
fix: route boundary prefill chunk to cuBLAS (+30% NVFP4 pp2048) + server request-edge hardening

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -47,6 +47,10 @@ fp8_auto_legacy             = false
 fp8_prefill          = "auto"
 fp8_fmha             = "auto"
 fmha_sm120           = "auto"
+# Prefill chunk length (tokens) at/above which attention routes to FMHA
+# (tiled, O(n) memory) instead of the materialized cuBLAS S-matrix path.
+# -1 = auto (derived from the cuBLAS S-matrix VRAM cap).
+fmha_prefill_threshold = -1
 mxfp4                = "auto"
 mxfp4_fp16_fallback  = false
 force_cublas_decode  = false

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -257,12 +257,17 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
     }
 
     // Auto-derive fmha_prefill_threshold from S-matrix capacity.
-    // Sequences longer than attn_seq route to FMHA (no materialized S-matrix).
+    // Route to FMHA only when the materialized S-matrix does NOT fit, i.e.
+    // n > cap. The dispatch uses `prefer_fmha = (n >= threshold)`, so the
+    // threshold must be cap+1 — otherwise the largest prefill chunk (n == cap),
+    // for which the S-matrix fits exactly, mis-routes to FMHA. Measured: cuBLAS
+    // is ~30% faster than FMHA at n == cap for dense NVFP4 (Qwen3-8B pp2048:
+    // 28.3k vs 21.6k tok/s), so the boundary belongs to cuBLAS.
     if (runtime_config().attention.fmha_prefill_threshold == -1) {
-        int auto_threshold = attn_scores_cap() > 0 ? attn_scores_cap() : 1;
+        int auto_threshold = attn_scores_cap() > 0 ? attn_scores_cap() + 1 : 1;
         const_cast<RuntimeConfig::Attention&>(runtime_config().attention).fmha_prefill_threshold =
             auto_threshold;
-        IMP_LOG_INFO("auto fmha_prefill_threshold = %d (S-matrix cap)", auto_threshold);
+        IMP_LOG_INFO("auto fmha_prefill_threshold = %d (S-matrix cap + 1)", auto_threshold);
     }
 
     // MoE dequant and staging buffers

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -122,6 +122,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.attention.fp8_fmha = val;
     else if (eq("attention.fmha_sm120"))
         cfg.attention.fmha_sm120 = val;
+    else if (eq("attention.fmha_prefill_threshold"))
+        cfg.attention.fmha_prefill_threshold = parse_int(val, cfg.attention.fmha_prefill_threshold);
     else if (eq("attention.mxfp4"))
         cfg.attention.mxfp4 = val;
     else if (eq("attention.mxfp4_fp16_fallback"))

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -646,6 +646,17 @@ static bool parse_chat_request_params(
         res.set_content(err.dump(), "application/json");
         return false;
     }
+    // Bound the conversation length: each message is tokenized + template-expanded
+    // on the host, so an unbounded array is a CPU/memory DoS within the body cap.
+    constexpr size_t kMaxMessages = 10000;
+    if (messages.size() > kMaxMessages) {
+        res.status = 400;
+        json err = {{"error",
+                     {{"message", "messages array exceeds maximum of 10000 entries"},
+                      {"type", "invalid_request_error"}}}};
+        res.set_content(err.dump(), "application/json");
+        return false;
+    }
 
     ctx.params.temperature = body.value("temperature", 0.7f);
     ctx.params.top_p_explicit = body.contains("top_p");
@@ -3108,6 +3119,17 @@ void handle_detokenize(const httplib::Request& req, httplib::Response& res, Serv
     if (!snap_model) {
         res.status = 503;
         json err = {{"error", {{"message", "No model loaded"}, {"type", "server_error"}}}};
+        res.set_content(err.dump(), "application/json");
+        return;
+    }
+
+    // Bound the array before allocating buf = tokens.size()*32 + 256: a ~100 MiB
+    // JSON array of small ints would otherwise force a multi-GB host allocation.
+    if (body["tokens"].size() > 1000000) {
+        res.status = 400;
+        json err = {{"error",
+                     {{"message", "tokens array exceeds maximum of 1000000 entries"},
+                      {"type", "invalid_request_error"}}}};
         res.set_content(err.dump(), "application/json");
         return;
     }

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -132,7 +132,15 @@ int main(int argc, char** argv) {
         if (!state.api_key.empty()) {
             std::string auth = req.get_header_value("Authorization");
             std::string expected = "Bearer " + state.api_key;
-            if (auth != expected) {
+            // Constant-time comparison: std::string::operator!= short-circuits on
+            // the first differing byte, which leaks the key prefix via response
+            // timing. Accumulate over the full expected length instead.
+            unsigned char diff = static_cast<unsigned char>(auth.size() != expected.size());
+            for (size_t i = 0; i < expected.size(); ++i) {
+                unsigned char ac = (i < auth.size()) ? static_cast<unsigned char>(auth[i]) : 0;
+                diff |= ac ^ static_cast<unsigned char>(expected[i]);
+            }
+            if (diff != 0) {
                 res.status = 401;
                 json err = {{"error", {{"message", "Invalid API key"}, {"type", "invalid_request_error"}}}};
                 res.set_content(err.dump(), "application/json");


### PR DESCRIPTION
Two independent, verified fixes from a codebase audit. No file overlap with #461.

## 1. Attention prefill routing (`0685e25`)

The auto `fmha_prefill_threshold` was set to the cuBLAS S-matrix capacity (e.g. 2048 for a 32-head model). Dispatch uses `prefer_fmha = (n >= threshold)`, so a prefill chunk of exactly `n == cap` — where the materialized S-matrix fits *exactly* — wrongly routed to the slower FMHA path. Since the cap equals the max prefill chunk size for these models, the largest, most expensive chunk always mis-routed.

Fix: derive the auto threshold as `cap + 1` so cuBLAS is used whenever the S-matrix fits (`n <= cap`) and FMHA only when it genuinely doesn't (`n > cap`).

**Measured (RTX 5090, `CUBLAS_WORKSPACE_CONFIG=:4096:8`, 8 reps):**
| Model | pp2048 before | after | Δ |
|---|---|---|---|
| Qwen3-8B-NVFP4 dense | 21,630 | 28,142 | **+30.1%** |
| Qwen3-Coder-30B-A3B-FP4 | 15,027 | 17,636 | **+17.4%** |

Decode unchanged; all `DegenerationTest.*` pass; long-context output coherent. A/B confirms cuBLAS beats FMHA at pp2048 by +38% (28,274 vs 20,443) — also refutes the open "re-evaluate FMHA for NVFP4 at long context" lever.

Also wires `attention.fmha_prefill_threshold` into the config parser (it was a RuntimeConfig field with no parse path → unsettable/un-benchmarkable) and documents it in `imp.conf.example`.

## 2. Server request-edge hardening (`d231055`)

No GPU hot-path impact:
1. **API key**: `auth != expected` short-circuits on the first differing byte (timing side-channel) → constant-time comparison over the full expected length.
2. **`/v1/chat/completions`**: `messages` had no upper bound (host-side tokenize/template DoS within the 100 MiB body cap) → cap 10000.
3. **`/detokenize`**: allocated `tokens.size()*32+256` unbounded (a ~100 MiB int array → multi-GB host alloc) → cap 1e6.

Verified against a running server: valid key 200, wrong/missing key 401, oversized detokenize/messages 400, valid small requests 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)