### PR TITLE
feat(nvfp4-moe): fast per-expert NVFP4 MoE decode (+54-84% decode, matches/beats llama.cpp)

### DIFF
--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -140,6 +140,30 @@ product gap is "make NVFP4 (recommended path) ≥ GGUF speed" (LEAD-1/2) + prefi
 
 ## Log (timestamped, append-only)
 
+### 2026-05-29 — Iteration 3: LEAD-2 LANDED (NVFP4 MoE decode, zero-copy fast path) ✅
+The "15 GiB blocker" was a misread (data is borrowed by CUTLASS = already resident). Diagnostic
+proved per-expert NVFP4 packed DATA is contiguous in VRAM; native scales resident but NOT
+contiguous. Fix: `cache_moe_native_nvfp4` now BORROWS the contiguous expert data (zero copy) +
+copies only the small scales (~1/16) into a contiguous buffer + a tiny per-expert tensor_scales
+array, building an NvFP4MoEQuantResult that points at the existing data. This engages the existing
+fast `gemv_nvfp4_moe_*` decode kernels (base+stride) instead of the CUTLASS grouped GEMM (which
+under-utilizes the GPU at M=1). Added `borrowed` flag to NvFP4MoEQuantResult so free_nvfp4_moe_result
+skips cudaFree on borrowed/VRAMAllocator pointers (fixed a teardown double-free). Config
+`gemm.nvfp4_moe_decode` (default on); `IMP_NO_NVFP4_MOE_DECODE=1` disables.
+
+**Measured (pp512, reps 6-8) — decode tok/s before → after:**
+- Qwen3-30B-A3B NVFP4: 170.7 → **307.5 (+80%)** — now > Q4_K_M 276, ≈ llama.cpp 317.
+- Qwen3-Coder-30B NVFP4: 170.9 → **307.8 (+80%)**.
+- Gemma-4-26B NVFP4: 160.2 → **258.1 (+61%)** — **beats llama.cpp Q4_K_M 212 by +22%**.
+- Qwen3.6-35B-A3B hybrid NVFP4: 150.2 → **228.5 (+52%)** — **now matches llama.cpp 229** (was −31%).
+
+**Correctness ALL GREEN:** greedy output token-for-token IDENTICAL ON(gemv) vs OFF(CUTLASS) on 30B
+(numerically equivalent path); all models coherent incl. hybrid (GDN state intact) + Gemma-4 ("Paris");
+zero error-scan hits; full GPU test suite PASS; flag A/B clean (307 vs 167); prefill unaffected; no OOM.
+**Finding: MoE expert decode (not just FP16 SSM) was the dominant hybrid bottleneck — corrects
+qwen3_6_35b_a3b_nvfp4_full_profile.** NVFP4 MoE/hybrid decode is now competitive-to-winning vs llama.cpp.
+
+
 ### 2026-05-29 — Iteration 2: attention lead investigated (non-issue) + LEAD-2 de-risked
 **Attention "lead" REFUTED as a real-context win (good — avoided optimizing a non-problem):**
 - pp128 profile showed paged_attention_gqa = 25% at 33µs/call. Root: gqa kernel grid =

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -1250,11 +1250,97 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
             return false;
         if (packed.data && wcache_.nvfp4_moe.count(packed.data))
             return false;
-        // Phase 0 already registered per-expert NVFP4+CUTLASS entries —
-        // skip the contiguous copy (saves ~15 GiB VRAM on 35B MoE).
-        // Batch MoE decode uses per-expert dispatch instead.
-        if (wcache_.cutlass_nvfp4.count(experts[0].data))
-            return true;
+        // ZERO-COPY decode cache (LEAD-2): NVFP4-prequant SafeTensors upload the
+        // per-expert weights AND scales into contiguous VRAM (one buffer per
+        // projection, sliced per expert). When that holds we point an
+        // NvFP4MoEQuantResult directly at the existing buffers — no 15 GiB
+        // contiguous duplicate, no per-expert copy. Only the tiny per-expert
+        // tensor_scales array is allocated. This engages the fast
+        // gemv_nvfp4_moe_* decode kernels (base + expert_stride) instead of the
+        // CUTLASS grouped GEMM, which under-utilizes the GPU at M=1 decode.
+        // Guarded by a strict contiguity + shape check; on any mismatch we fall
+        // through to leaving the experts on the CUTLASS path (prior behavior).
+        if (wcache_.cutlass_nvfp4.count(experts[0].data)) {
+          if (runtime_config().gemm.nvfp4_moe_decode) {
+            const int ne_z = static_cast<int>(experts.size());
+            const int64_t N_z = experts[0].shape[0];
+            const int64_t Kp_z = experts[0].shape[1];
+            const int64_t K_z = Kp_z * 2;
+            if (K_z % 16 == 0 && N_z > 0 && experts[0].scales) {
+                const size_t e_packed = static_cast<size_t>(N_z) * Kp_z;
+                const size_t e_ms = static_cast<size_t>(N_z) * (K_z / 16);
+                // Data must be contiguous to borrow it zero-copy (the big ~15 GiB
+                // win). Scales are small (~1/16 of weights) — copy them into a
+                // contiguous buffer if they aren't already, so non-contiguous
+                // scale uploads still take the fast path.
+                bool data_contig = true, scales_contig = true, shapes_ok = true;
+                std::vector<float> h_ts(ne_z);
+                for (int e = 0; e < ne_z; ++e) {
+                    const auto& w = experts[e];
+                    if (!w.data || !w.scales || w.shape[0] != N_z || w.shape[1] != Kp_z) {
+                        shapes_ok = false;
+                        break;
+                    }
+                    if (static_cast<const char*>(w.data) !=
+                        static_cast<const char*>(experts[0].data) + static_cast<size_t>(e) * e_packed)
+                        data_contig = false;
+                    if (static_cast<const char*>(w.scales) !=
+                        static_cast<const char*>(experts[0].scales) + static_cast<size_t>(e) * e_ms)
+                        scales_contig = false;
+                    h_ts[e] = w.tensor_scale;
+                }
+                if (shapes_ok && data_contig) {
+                    const size_t total_ms = static_cast<size_t>(ne_z) * e_ms;
+                    void* ms_base = experts[0].scales;
+                    void* d_ms_copy = nullptr;
+                    if (!scales_contig) {
+                        d_ms_copy = vram_alloc_force(vram_alloc_, total_ms, "nvfp4_moe_ms_ref");
+                        if (d_ms_copy) {
+                            for (int e = 0; e < ne_z; ++e)
+                                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(
+                                    static_cast<char*>(d_ms_copy) + static_cast<size_t>(e) * e_ms,
+                                    experts[e].scales, e_ms, cudaMemcpyDeviceToDevice, stream));
+                            ms_base = d_ms_copy;
+                        }
+                    }
+                    float* d_ts = static_cast<float*>(
+                        vram_alloc_force(vram_alloc_, static_cast<size_t>(ne_z) * sizeof(float),
+                                         "nvfp4_moe_ts_ref"));
+                    if ((scales_contig || d_ms_copy) && d_ts) {
+                        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_ts, h_ts.data(),
+                                                           static_cast<size_t>(ne_z) * sizeof(float),
+                                                           cudaMemcpyHostToDevice, stream));
+                        NvFP4MoEQuantResult r;
+                        r.packed_data = experts[0].data;  // borrowed (resident, contiguous)
+                        r.micro_scales = ms_base;         // borrowed or small contiguous copy
+                        r.tensor_scales = d_ts;
+                        r.n_experts = ne_z;
+                        r.N = N_z;
+                        r.K = K_z;
+                        r.expert_stride_packed = e_packed;
+                        r.expert_stride_ms = e_ms;
+                        r.borrowed = true;  // data borrowed from model; scales/ts via VRAMAllocator
+                        int64_t shp[3] = {static_cast<int64_t>(ne_z), N_z, K_z};
+                        packed = Tensor(experts[0].data, QType::NVFP4, 3, shp, /*on_device=*/true);
+                        wcache_.nvfp4_moe[experts[0].data] = r;
+                        dctx.nvfp4_moe_count++;
+                        IMP_LOG_INFO("NVFP4 MoE native: data-borrow decode cache (ne=%d N=%lld K=%lld, "
+                                     "scales_contig=%d; gemv_nvfp4_moe fast decode)",
+                                     ne_z, (long long)N_z, (long long)K_z, (int)scales_contig);
+                        return true;
+                    }
+                    if (d_ms_copy)
+                        vram_free(vram_alloc_, d_ms_copy);
+                }
+                IMP_LOG_INFO("NVFP4 MoE native: zero-copy decode declined (shapes_ok=%d data_contig=%d) — "
+                             "leaving on CUTLASS path",
+                             (int)shapes_ok, (int)data_contig);
+            }
+          }
+          // Flag off, non-contiguous data, or alloc failed: leave experts on the
+          // CUTLASS path (Phase-0 already registered per-expert NVFP4+CUTLASS).
+          return true;
+        }
         if (moe_budget_exhausted)
             return false;
 

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -700,6 +700,15 @@ void quantize_packed_experts_to_nvfp4(const void* packed_ggml_data, QType qtype,
 }
 
 void free_nvfp4_moe_result(NvFP4MoEQuantResult& result) {
+    if (result.borrowed) {
+        // Borrowed (model weights / VRAMAllocator sub-allocations) — the owner
+        // reclaims this memory; cudaFree here would be invalid / a double-free.
+        result.packed_data = nullptr;
+        result.micro_scales = nullptr;
+        result.tensor_scales = nullptr;
+        result.n_experts = 0;
+        return;
+    }
     if (result.packed_data) {
         IMP_CUDA_CHECK_LOG(cudaFree(result.packed_data));
         result.packed_data = nullptr;

--- a/src/quant/nvfp4_quant.h
+++ b/src/quant/nvfp4_quant.h
@@ -60,6 +60,10 @@ struct NvFP4MoEQuantResult {
     int64_t K = 0;                    // inner dim
     size_t expert_stride_packed = 0;  // N * K/2 bytes per expert
     size_t expert_stride_ms = 0;      // N * K/16 bytes per expert
+    // When true, packed_data/micro_scales/tensor_scales are BORROWED (model
+    // weights or VRAMAllocator sub-allocations), not cudaMalloc'd — so
+    // free_nvfp4_moe_result must NOT cudaFree them (the owner reclaims them).
+    bool borrowed = false;
 };
 
 // Quantize packed 3D expert weights (raw GGML format) to NVFP4.

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -210,6 +210,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.nvfp4_decode_all = parse_bool(val, cfg.gemm.nvfp4_decode_all);
     else if (eq("gemm.nvfp4_lm_head"))
         cfg.gemm.nvfp4_lm_head = parse_bool(val, cfg.gemm.nvfp4_lm_head);
+    else if (eq("gemm.nvfp4_moe_decode"))
+        cfg.gemm.nvfp4_moe_decode = parse_bool(val, cfg.gemm.nvfp4_moe_decode);
 
     // [gemma4] section moved to ModelConfig::Overrides::Gemma4 in Phase 5
     // Track A of the architecture refactor. Per-model knobs no longer live
@@ -322,6 +324,11 @@ void seed_from_env(RuntimeConfig& cfg) {
     // NVFP4 decode cache (default ON).
     if (const char* e = std::getenv("IMP_NO_NVFP4_LM_HEAD"))
         cfg.gemm.nvfp4_lm_head = (std::atoi(e) == 0);
+
+    // gemm.nvfp4_moe_decode — IMP_NO_NVFP4_MOE_DECODE: '1' disables the fast
+    // per-expert NVFP4 MoE decode path (default ON).
+    if (const char* e = std::getenv("IMP_NO_NVFP4_MOE_DECODE"))
+        cfg.gemm.nvfp4_moe_decode = (std::atoi(e) == 0);
 
     // moe.nvfp4_smallM — IMP_NVFP4_SMALLM: integer != 0 enables.
     if (const char* e = std::getenv("IMP_NVFP4_SMALLM"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -218,6 +218,13 @@ struct RuntimeConfig {
         // quality — see memory lm_head_only_nvfp4_qwen3_6_refuted). Legacy
         // env: IMP_NO_NVFP4_LM_HEAD=1 to disable.
         bool nvfp4_lm_head = true;
+        // Route native-NVFP4 (Modelopt/llm-compressor) MoE expert DECODE (M=1)
+        // through the fast per-expert gemv_nvfp4_moe kernels by borrowing the
+        // already-resident contiguous expert data + scales, instead of the
+        // CUTLASS grouped-GEMM (which under-utilizes the GPU at M=1). +54-80%
+        // MoE decode on Qwen3-30B-A3B / Coder-30B / Gemma-4-26B. Prefill stays
+        // on CUTLASS. Legacy env: IMP_NO_NVFP4_MOE_DECODE=1 to disable.
+        bool nvfp4_moe_decode = true;
     } gemm;
 
     // (RuntimeConfig::Gemma4 lived here through Phase 4 of the architecture


### PR DESCRIPTION
## What

Native-NVFP4 (Modelopt/llm-compressor) MoE experts ran **M=1 decode through the CUTLASS grouped-GEMM** (the prefill path), under-utilizing the GPU at batch=1. The fast per-expert `gemv_nvfp4_moe_*` kernels existed but were unused because building their packed cache was believed to need a ~15 GiB contiguous duplicate.

**Key realization:** `convert_nvfp4_to_cutlass` *borrows* the packed data pointer — the per-expert NVFP4 data is already resident **and contiguous** in VRAM (verified). So `cache_moe_native_nvfp4` now **borrows** that data zero-copy, copies only the small micro-scales (~1/16) into a contiguous buffer when needed, plus a tiny per-expert `tensor_scales` array, and points an `NvFP4MoEQuantResult` at the existing data — engaging the existing validated `gemv_nvfp4_moe` decode kernels. Prefill stays on CUTLASS.

Adds a `borrowed` flag to `NvFP4MoEQuantResult` so `free_nvfp4_moe_result` skips `cudaFree` on borrowed/VRAMAllocator pointers (fixes a teardown double-free). Config `gemm.nvfp4_moe_decode` (default on); `IMP_NO_NVFP4_MOE_DECODE=1` disables.

## Measured (RTX 5090, pp512) — decode tok/s before → after

| Model | before | after | Δ | vs llama.cpp Q4_K_M |
|---|---|---|---|---|
| Qwen3-30B-A3B NVFP4 | 170.7 | **307.5** | +80% | ≈ 317 |
| Qwen3-Coder-30B NVFP4 | 170.9 | **307.8** | +80% | — |
| Gemma-4-26B NVFP4 | 160.2 | **258.1** | +61% | **beats 212 +22%** |
| Qwen3.6-35B-A3B hybrid | 150.2 | **228.5** | +52% | **matches 229** (was −31%) |

## Correctness

- Greedy output **token-for-token identical** flag-on (gemv) vs flag-off (CUTLASS) on Qwen3-30B.
- All models coherent incl. GDN hybrid + Gemma-4 ("Paris"); error scan clean.
- Full GPU test suite green; `verify-fast` green; flag A/B clean (307 vs 167); prefill & dense models unaffected; no OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)