### PR TITLE
docs(journal): iter4 findings — prefill scoped, Gemma-3 works, q4k_imma no-win

### DIFF
--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -8,36 +8,32 @@
 ## RESUME HERE (always current)
 
 **Session:** 2026-05-29. Work lands via PRs off main (branch then `gh pr create --base main`).
-**Phase:** Optimization loop, iteration 1 complete. LEAD-1 MERGED to main (#465, commit d009bbd).
-**Build:** main green w/ LEAD-1. Full scoreboard + measured llama.cpp head-to-head (below).
+**Phase:** Optimization loop, iterations 1-3 complete. LEAD-1 (#465) + LEAD-2 (#469) MERGED to main.
+**Build:** main green (commit 33b39d0) w/ both wins. Full scoreboard + measured llama.cpp (below).
 **On resume:** re-read this journal + `competitive_ground_truth_2026_05_29` memory. Rebuild
 `make build`. Re-run `scripts/scoreboard.sh` if trusting absolute numbers. Then pick from NEXT.
+NOTE: force-push + `git reset --hard` are BLOCKED in this env — land via fresh branch + merge,
+not rebase+force. Profile MoE decode at **pp512** not pp128 (split-K only engages at ctx≥512).
 
-**LANDED this session (MERGED to main):**
-- **LEAD-1 (#465, d009bbd): NVFP4 decode cache for FP16/BF16 lm_head.** Broad decode win across
-  non-hybrid NVFP4 fleet: Qwen3-8B +16%, Qwen3-14B +12.6%, Phi-4 +8.3%, Gemma-4-26B +11.3%,
-  Qwen3-30B-A3B +2.9%. Hybrid Qwen3.6-35B correctly excluded (unchanged). NVFP4 dense decode
-  now BEATS GGUF same-model and crushes llama.cpp. All correctness gates green; CI build green.
+**LANDED this session (both MERGED to main, CI green):**
+- **LEAD-1 (#465): NVFP4 decode cache for FP16/BF16 lm_head.** Dense NVFP4 decode +8-16%
+  (Qwen3-8B 240→277, Qwen3-14B 148→166, Phi-4 +8%). Beats GGUF same-model; crushes llama.cpp.
+- **LEAD-2 (#469): fast per-expert NVFP4 MoE decode (zero-copy data borrow).** +52-84% MoE/hybrid:
+  Qwen3-30B-A3B 171→307, Coder-30B 171→308, Gemma-4-26B 160→258 (beats llama +22%),
+  Qwen3.6-35B hybrid 150→228 (matches llama 229; was −31%). Greedy token-identical to CUTLASS.
+- **Net: imp NVFP4 decode is now best-or-tied vs llama.cpp on EVERY measured dense+MoE+hybrid model.**
 
-**NEXT (priority order):**
-1. **LEAD-2: NVFP4 MoE decode — PROFILED + ROOT-CAUSED, PARKED (hard).** Qwen3-30B-A3B NVFP4 175
-   vs imp-Q4_K_M 276 vs llama.cpp 317. nsys (eager): CUTLASS grouped GEMM 35.4% + paged-attn GQA
-   25.2% + ~15% fragmented scale-staging (convert_scales_sfatom, build_grouped_3x_staging,
-   compute_sfa_offsets, bzero_sfa_active, build_sfa_bases). Native-NVFP4 M=1 expert decode runs
-   the PREFILL grouped-GEMM path. ROOT CAUSE: `cache_moe_native_nvfp4` (pre_dequant_phase3) early-
-   returns when experts are in cutlass_nvfp4 — a DELIBERATE VRAM tradeoff (a duplicate standard-
-   packed NVFP4 expert cache for the fast gemv_nvfp4_moe_* path = ~15 GiB on 35B, won't fit on
-   32 GB alongside the CUTLASS cache). `can_decode_fast` accepts NVFP4 but needs expert_*_packed
-   (null for native NVFP4). FIX OPTIONS (all multi-hour, risky): (a) gemv that reads CUTLASS-
-   swizzled NVFP4 layout in-place (zero extra VRAM, ideal, hard); (b) precompute static per-step
-   scale-staging once at load (reclaims ~3-10%, medium); (c) free CUTLASS expert cache + use packed
-   for both decode AND prefill (but prefill wants grouped GEMM). Circle back after easier wins.
-   NOTE competitor reality: for Qwen3-30B-A3B the user's fastest imp option is Q4_K_M (276), which
-   still loses to llama.cpp Q4_K_M (317). NVFP4 MoE (175) is uncontested by NVFP4 rivals (vLLM
-   broken on sm_120) but slower than its own Q4_K_M.
-2. MoE/hybrid GGUF decode loss to llama.cpp (Qwen3.6-35B 158 vs 229).
-3. GGUF prefill 1.3-2.4× behind llama.cpp (hard: custom MMQ kernel).
-4. Stand up vLLM NVFP4 to confirm imp's NVFP4 prefill/decode lead is real.
+**NEXT (priority order) — remaining gaps are harder (kernel-level):**
+1. **GGUF prefill 1.3-2.4× behind llama.cpp** (Qwen3-8B Q8_0 7971 vs 14068; Gemma/MoE Q4_K_M ~2.4×).
+   dequant→cuBLAS vs llama MMQ. Biggest consistent gap. Needs a custom quantized-matmul (MMQ)
+   prefill kernel — multi-day. NOTE: NVFP4 prefill (imp 16-24k) already crushes llama GGUF, so this
+   only matters for users on GGUF. Forge raw-HMMA Q4_K/Q6_K branch exists (feat/q4k-mmq-hmma).
+2. **MoE/hybrid GGUF decode** (Qwen3-30B Q4_K_M 276 vs llama 317; −13%). dp4a path; profile at pp512.
+3. **Stand up vLLM NVFP4** on this machine to confirm imp's NVFP4 prefill/decode lead is real
+   (research says vLLM MoE-NVFP4 broken on sm_120, dense-NVFP4 works — measure it).
+4. **Spec-decode / EAGLE / MTP** (1.5-4× batch=1) — biggest ceiling, multi-week, parked at 196 tok/s.
+5. **Completeness pass** (mission §6): Gemma-3-12B Q4_K_M degeneration (bogus bench), server
+   continuous-batching stability, OOM/malformed-input handling, both API dialects under load.
 
 **GPU at start:** RTX 5090, 29°C idle. Host nsys works (recipe in memory nsys-host-to-container;
 use `--no-cuda-graphs` imp flag + `--trace=cuda`, --user root, /tmp/nsys_out chmod 777).

--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -136,6 +136,28 @@ product gap is "make NVFP4 (recommended path) ≥ GGUF speed" (LEAD-1/2) + prefi
 
 ## Log (timestamped, append-only)
 
+### 2026-05-29 — Iteration 4: GGUF prefill profiled; vLLM bringup dispatched
+- **GGUF prefill profile (Qwen3-8B Q8_0 pp512, eager):** CUTLASS f16 GEMM 40.5% + 64x256/64x64
+  variants ~17% (≈58% GEMM total) + **dequant_q8_0_kernel 30.3%** (Q8_0→FP16 before the GEMM).
+  llama.cpp MMQ matmuls on quantized data directly → skips the 30% dequant AND halves weight
+  bandwidth. Structural gap = need a direct quantized-matmul (MMQ) prefill kernel. Prior imp MMQ
+  attempts (mmq_q4k_v2) gave −4% e2e for DECODE; PREFILL (M=512) is the untried regime where INT8
+  IMMA / CUTLASS mixed-input could win — but it's multi-day. DEPRIORITIZED: NVFP4 prefill (imp
+  16-24k) already crushes llama GGUF and is the recommended path; GGUF prefill only affects
+  GGUF-only users. Documented for a future dedicated MMQ-prefill effort.
+- Dispatched bg agent to stand up **vLLM NVFP4** (dense Qwen3-8B/14B + MoE 30B) for the one
+  NVFP4-capable competitor comparison — defines whether imp's NVFP4 prefill lead is real.
+- **Gemma-3-12B Q4_K_M degeneration memory is STALE — model works** ("Paris. It's also its
+  largest city and a global center for art, fashion, gastronomy, and culture", 126 tok/s). Bogus
+  scoreboard tg=1588 was a transient artifact. True: tg128=126, pp512=4181. But imp LOSES it to
+  llama.cpp (decode 126 vs 142 −11%, prefill 4181 vs 8850). Profile: all-Q4_K, decode is dp4a FFN
+  GEMVs (53%, bandwidth-bound ~roofline) + Q4_K lm_head dp4a. `nvfp4_decode_all` REFUTED here —
+  Q4_K is already 4.5 bits, NVFP4 gives 0 bandwidth win ("no eligible weights, all ≤4.5 bits").
+  So Gemma-3-12B decode gap = dp4a-kernel efficiency vs llama MMQ-decode (large vocab + sliding
+  window) — hard, model-specific, no clean win. Same class as Qwen3-30B Q4_K_M decode (276 vs 317).
+- **Decode front status: WON on NVFP4 (recommended path) across the fleet. Remaining decode losses
+  are GGUF-Q4_K-only (dp4a vs MMQ) and modest. Remaining clear gap = GGUF prefill (MMQ, multi-day).**
+
 ### 2026-05-29 — Iteration 3: LEAD-2 LANDED (NVFP4 MoE decode, zero-copy fast path) ✅
 The "15 GiB blocker" was a misread (data is borrowed by CUTLASS = already resident). Diagnostic
 proved per-expert NVFP4 packed DATA is contiguous in VRAM; native scales resident but NOT

--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -279,3 +279,18 @@ NEXT: re-sweep NVFP4 dense models to capture the win; then LEAD-2 (NVFP4 MoE dec
   reps=8, CUBLAS_WORKSPACE_CONFIG=:4096:8 → `docs/scoreboard.tsv`.
 - Launched sweep (bg) + llama.cpp-on-sm120 build/bench agent (bg, builds CUDA 12.8 image).
 - Early results: Qwen3-8B Q8_0 pp512=7970/tg128=274 · Qwen3-8B-NVFP4 pp512=21581/tg128=239.
+
+### 2026-05-29 — Iteration 4b: GGUF prefill via IMMA scoped — architecturally capped
+- The existing INT8 IMMA Q4_K MMQ kernel (`gemm.q4k_imma_enabled`, default off) ONLY engages at
+  **M≥1024** (dense, %64). At pp512 it never fires (my first A/B showed no change — M=512).
+- At **pp2048** it DOES fire: Gemma-3-12B 4983 → **5375 (+7.9%)** prefill. Real but modest; coherent.
+  Variance-sensitive (cuBLAS prefill ±2.6×) — NOT shipped without rigorous cooldown/multi-trial/
+  multi-model validation (defer until GPU free; vLLM agent holds it).
+- **Phase-2B ceiling doc** (docs/archive/.../2026-05-18-q4k-imma-phase2b-ceiling.md): IMMA caps at
+  **40 TOPS = 4.3% of 931 TOPS peak** — scale-apply (FP16→FP32 + FMA between MMAs) serializes and
+  under-issues the tensor cores. Reaches ~dequant→cuBLAS parity only; beating llama MMQ (which
+  defers/batches scale-apply) needs a FUNDAMENTALLY different kernel. So GGUF prefill = genuine
+  multi-day kernel research, not a quick win.
+- **CONCLUSION this session: decode WON on NVFP4 (shipped #465+#469). All remaining gaps are
+  hard/research (GGUF prefill MMQ architecturally capped; GGUF Q4_K decode dp4a-bound) or pending
+  (vLLM NVFP4 prefill comparison, GPU-occupied). Next concrete action gated on vLLM result.**


### PR DESCRIPTION
Investigation journal (no code): GGUF prefill profiled (30% dequant + 58% FP16 GEMM → needs direct MMQ); Gemma-3-12B Q4_K_M works (stale degeneration memory corrected) but loses to llama on dp4a efficiency; existing q4k_imma INT8 MMQ kernel confirmed not-yet-winning (Phase 2B+ ceiling). Decode front won on NVFP4; GGUF prefill MMQ is the remaining multi-day frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)