### PR TITLE
docs(journal): iter5 — vLLM measured, NVFP4 decode WON vs llama+vLLM, prefill is next frontier

### DIFF
--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -309,3 +309,23 @@ vLLM 0.21.0 (FlashInfer-CUTLASS NVFP4, sm_120 verified) batch=1, measured this s
   the dense attention prefill path.** (Caveat: re-measure imp with cooldown/multi-trial — cuBLAS/CUTLASS
   prefill ±2.6× — but the gap is consistent + large.)
 - Decode mission goal essentially MET on NVFP4 (recommended path). Frontier now = NVFP4 prefill.
+
+### 2026-05-29 — Iteration 5b: NVFP4 prefill gap localized → attention, not GEMM
+Qwen3-14B NVFP4 prefill profile (pp2048, eager): CUTLASS NVFP4 GEMM 39% (compute, competitive w/
+vLLM) + **attention ~37%** (fmha_sm120_fp8 20% @0.71ms + causal_softmax_inplace 8% + attn GEMMs 9%).
+So the vLLM NVFP4-prefill lead is mostly the ATTENTION path: imp uses FP8-FMHA + materialized-S
+softmax (at the fmha_prefill_threshold=2049 boundary) vs vLLM's fused FlashInfer. Routing A/B (pp2048):
+- force-FMHA (threshold=1): 12806 (WORSE — re-confirms FMHA-rewrite-refuted).
+- chunked 256/512: ~16100 vs default 15104 (+6.6%) / vs single-chunk 14179 (+14%). MODEST, NOISY
+  (within cuBLAS ±2.6% band); does NOT close the vLLM −34% gap. Default already chunks (not worst-case).
+- CONCLUSION: NVFP4 prefill gap = fused-attention-prefill kernel (FlashInfer-class), a multi-day
+  kernel effort prior FMHA work found hard. Chunk-tuning is a borderline lead, not shipped (needs
+  rigorous multi-trial + risks per-arch-default regressions on other models/contexts).
+
+## SESSION SUMMARY (2026-05-29) — primary mission metric MET
+**Batch=1 DECODE (GOAL.md primary metric) on the recommended NVFP4 path is now BEST-IN-CLASS vs
+both llama.cpp AND vLLM on every measured dense/MoE/hybrid model** — via two shipped+merged wins:
+LEAD-1 (#465, lm_head NVFP4, +8-16% dense) and LEAD-2 (#469, MoE decode, +52-84%; flipped the 30B
+MoE from −29% vs vLLM to +51%). Remaining gaps (all secondary-metric / hard kernel research, for
+future sessions): NVFP4 prefill vs vLLM (−14-40%, fused-attention kernel), GGUF prefill vs llama
+(MMQ, architecturally capped), GGUF Q4_K decode (dp4a, minor), spec-decode (multi-week).

--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -294,3 +294,18 @@ NEXT: re-sweep NVFP4 dense models to capture the win; then LEAD-2 (NVFP4 MoE dec
 - **CONCLUSION this session: decode WON on NVFP4 (shipped #465+#469). All remaining gaps are
   hard/research (GGUF prefill MMQ architecturally capped; GGUF Q4_K decode dp4a-bound) or pending
   (vLLM NVFP4 prefill comparison, GPU-occupied). Next concrete action gated on vLLM result.**
+
+### 2026-05-29 — Iteration 5: vLLM measured → NVFP4 PREFILL is the next real gap
+vLLM 0.21.0 (FlashInfer-CUTLASS NVFP4, sm_120 verified) batch=1, measured this session:
+- **DECODE: imp NVFP4 BEATS vLLM on all (with LEAD-1/2 shipped):** Qwen3-8B 277 vs 142 (+95%),
+  Qwen3-14B 166 vs 97 (+71%), **Qwen3-30B-A3B MoE 307 vs 203 (+51%)**. LEAD-2 FLIPPED the MoE
+  (vLLM beat imp 203 vs 158 PRE-fix). imp NVFP4 decode = best-in-class vs llama.cpp AND vLLM. ✅
+- **CORRECTION: vLLM MoE-NVFP4 is NOT broken on sm_120** (vLLM 0.21.0 uses FLASHINFER_CUTLASS MoE,
+  not Marlin — the prior research/memory "broken on sm_120" is STALE). imp still beats it on decode.
+- **PREFILL: imp NVFP4 LOSES to vLLM** (imp pp2048 vs vLLM ~2267-tok prompt):
+  Qwen3-8B 26780 vs 35080 (−24%), **Qwen3-14B 14581 vs 24440 (−40%)**, Qwen3-30B 25800 vs 29450 (−12%).
+  imp Qwen3-14B pp512=17961 but pp2048=14581 (DROPS) → attention quadratic cost dominates long prefill;
+  vLLM's FlashInfer prefill attention likely the edge. **THIS is the next target: NVFP4 prefill, esp.
+  the dense attention prefill path.** (Caveat: re-measure imp with cooldown/multi-trial — cuBLAS/CUTLASS
+  prefill ±2.6× — but the gap is consistent + large.)
+- Decode mission goal essentially MET on NVFP4 (recommended path). Frontier now = NVFP4 prefill.


### PR DESCRIPTION
Recovers the iter5/5b journal entries (the prior journal PR auto-merged before these pushes landed).

- **vLLM 0.21.0 measured on this 5090:** imp NVFP4 decode beats vLLM on all (Qwen3-8B +95%, 14B +71%, **30B MoE +51%** — LEAD-2 flipped it from −29%). Corrects stale 'vLLM MoE-NVFP4 broken' assumption (0.21.0 uses FlashInfer-CUTLASS MoE).
- **imp NVFP4 decode = best-in-class vs both llama.cpp AND vLLM** across dense/MoE/hybrid — primary mission metric met.
- NVFP4 prefill loses to vLLM −14-40%; profiled to the attention-prefill kernel (not the GEMM). Documented as the next frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)