### PR TITLE
feat(attn): raise cuBLAS-attention S-matrix cap to 384 MiB (+21% NVFP4 prefill, 40-head models)

### DIFF
--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -222,7 +222,8 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         // 256 MiB: cuBLAS handles short sequences (up to ~1448 attn_seq for
         // 32-head models). Longer sequences auto-route to FMHA via the
         // fmha_prefill_threshold. Reduced from 1024 to free ~768 MiB for KV.
-        constexpr size_t kMaxAttnScoresMiB = 256;
+        int cfg_mib = runtime_config().attention.attn_scores_mib;
+        size_t kMaxAttnScoresMiB = (cfg_mib > 0) ? static_cast<size_t>(cfg_mib) : 256;
         size_t max_s_sz = kMaxAttnScoresMiB << 20;
         // max seq = sqrt(budget / (n_heads * sizeof(half)))
         int attn_seq = max_tokens_;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -124,6 +124,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.attention.fmha_sm120 = val;
     else if (eq("attention.fmha_prefill_threshold"))
         cfg.attention.fmha_prefill_threshold = parse_int(val, cfg.attention.fmha_prefill_threshold);
+    else if (eq("attention.attn_scores_mib"))
+        cfg.attention.attn_scores_mib = parse_int(val, cfg.attention.attn_scores_mib);
     else if (eq("attention.mxfp4"))
         cfg.attention.mxfp4 = val;
     else if (eq("attention.mxfp4_fp16_fallback"))
@@ -329,6 +331,12 @@ void seed_from_env(RuntimeConfig& cfg) {
     // per-expert NVFP4 MoE decode path (default ON).
     if (const char* e = std::getenv("IMP_NO_NVFP4_MOE_DECODE"))
         cfg.gemm.nvfp4_moe_decode = (std::atoi(e) == 0);
+
+    // attention.attn_scores_mib — IMP_ATTN_SCORES_MIB: cuBLAS attention S-matrix cap.
+    if (const char* e = std::getenv("IMP_ATTN_SCORES_MIB")) {
+        int v = std::atoi(e);
+        if (v > 0) cfg.attention.attn_scores_mib = v;
+    }
 
     // moe.nvfp4_smallM — IMP_NVFP4_SMALLM: integer != 0 enables.
     if (const char* e = std::getenv("IMP_NVFP4_SMALLM"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -100,6 +100,18 @@ struct RuntimeConfig {
         bool no_qknorm_fused = false;
         bool splitk_pipe = true;
         bool gate_concat = false;
+        // Max VRAM (MiB) for the materialized cuBLAS-attention S-matrix. Caps the
+        // prefill context length that uses the fast cuBLAS attention path before
+        // falling back to FMHA (auto fmha_prefill_threshold = S-matrix cap + 1).
+        // 256 MiB caps ~32-head models at seq 2048 but high-head-count models
+        // (e.g. Qwen3-14B, 40 heads → ~1824) drop to the slower FMHA at 2048.
+        // Larger = longer prefill on the fast path, at the cost of KV headroom.
+        // Legacy env: IMP_ATTN_SCORES_MIB. Auto-shrinks if the alloc fails.
+        // 384 keeps the fast cuBLAS attention path up to seq 2048 for up to
+        // 48-head models (e.g. Qwen3-14B, 40 heads: +21% pp2048 vs the old 256
+        // cap which dropped it to FMHA at ~1824). Only allocates what the
+        // model's max_tokens×heads needs (capped here); +128 MiB vs 256 at most.
+        int attn_scores_mib = 384;
     } attention;
 
     struct MoE {


### PR DESCRIPTION
## What

The materialized cuBLAS attention prefill path (faster than FMHA at the boundary — the code comment cites ~+30% for dense NVFP4) is gated by the S-matrix buffer, hard-capped at **256 MiB**. That caps the cuBLAS seq length per head count: 32-head models reach 2048, but **40-head models (Qwen3-14B) only ~1824**, so a 2048-token prefill drops to the slower FMHA kernel.

nsys (Qwen3-14B NVFP4 pp2048) showed attention ~37% of prefill, dominated by `fmha_sm120_fp8` + softmax because the S-matrix doesn't fit at 256 MiB. Raising the cap to **384 MiB** lets the 40-head S-matrix fit at seq 2240 → the 2048 prefill uses the fast cuBLAS path.

The cap is now a config knob (`attention.attn_scores_mib`, default 384; env `IMP_ATTN_SCORES_MIB`). The buffer still sizes to `min(needed_for_max_tokens, cap)`, so it only grows when heads×max_tokens warrants it (+128 MiB vs 256 at most), and the existing alloc-failure path still falls back to FMHA.

## Measured (RTX 5090)

| Model | pp2048 before | after | Δ |
|---|---|---|---|
| Qwen3-14B NVFP4 | 14402 | **17517** | **+21.6%** (vLLM gap −40% → −29%) |
| Qwen3-8B NVFP4 | 25910 | 26416 | unchanged (already cuBLAS at 2048) |

## Correctness / safety

- cuBLAS attention is the **validated default path** (FP32 S-matrix; the same one 8B uses) → no quality change, it's a routing/sizing fix. 14B output coherent.
- Q8_0 perf gate unchanged (pp512 7840, tg128 273.7 — within noise).
- Qwen3.6-35B (biggest) loads fine; S-matrix sizes to need (128 MiB), no OOM.
- Full GPU test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)