### PR TITLE
Opt-in NVFP4 lm_head for GDN/hybrid models (+11.4% Qwen3.6-35B decode)

### DIFF
--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -129,11 +129,14 @@ void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cud
     // GDN/SSM-hybrid models: the LM head is quality-load-bearing for the
     // recurrent state; NVFP4 there degrades coherence (memory
     // lm_head_only_nvfp4_qwen3_6_refuted). Detect via any GDN/SSM layer.
-    for (int i = 0; i < cfg.n_layers; i++) {
-        const auto& L = model_->layer(i);
-        if (L.ssm_in.data || L.ssm_out.data || L.gdn_gate.data) {
-            IMP_LOG_INFO("NVFP4 LM head: skipped (GDN/SSM-hybrid model)");
-            return;
+    // Opt-in override (gemm.nvfp4_lm_head_gdn) to re-measure the tradeoff.
+    if (!runtime_config().gemm.nvfp4_lm_head_gdn) {
+        for (int i = 0; i < cfg.n_layers; i++) {
+            const auto& L = model_->layer(i);
+            if (L.ssm_in.data || L.ssm_out.data || L.gdn_gate.data) {
+                IMP_LOG_INFO("NVFP4 LM head: skipped (GDN/SSM-hybrid model)");
+                return;
+            }
         }
     }
 

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -214,6 +214,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.nvfp4_decode_all = parse_bool(val, cfg.gemm.nvfp4_decode_all);
     else if (eq("gemm.nvfp4_lm_head"))
         cfg.gemm.nvfp4_lm_head = parse_bool(val, cfg.gemm.nvfp4_lm_head);
+    else if (eq("gemm.nvfp4_lm_head_gdn"))
+        cfg.gemm.nvfp4_lm_head_gdn = parse_bool(val, cfg.gemm.nvfp4_lm_head_gdn);
     else if (eq("gemm.nvfp4_moe_decode"))
         cfg.gemm.nvfp4_moe_decode = parse_bool(val, cfg.gemm.nvfp4_moe_decode);
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -239,6 +239,15 @@ struct RuntimeConfig {
         // quality — see memory lm_head_only_nvfp4_qwen3_6_refuted). Legacy
         // env: IMP_NO_NVFP4_LM_HEAD=1 to disable.
         bool nvfp4_lm_head = true;
+        // Allow NVFP4 LM head even on GDN/SSM-hybrid models (normally excluded —
+        // an older NVFP4 method degraded recurrent-state coherence, memory
+        // lm_head_only_nvfp4_qwen3_6_refuted). Re-measured 2026-05-29 with the
+        // current quantize-FP16→NVFP4 path: Qwen3.6-35B stays coherent (math /
+        // primes / explanations match FP16) AND decode is +11.4% (219.6→244.7
+        // tok/s) — the 248k-vocab lm_head is ~14% of decode. Kept opt-in
+        // (default false) pending exhaustive (perplexity / long multi-turn)
+        // quality eval before any default flip on hybrids.
+        bool nvfp4_lm_head_gdn = false;
         // Route native-NVFP4 (Modelopt/llm-compressor) MoE expert DECODE (M=1)
         // through the fast per-expert gemv_nvfp4_moe kernels by borrowing the
         // already-resident contiguous expert data + scales, instead of the

--- a/tools/analysis/lmhead_nvfp4_qwen36_ab.sh
+++ b/tools/analysis/lmhead_nvfp4_qwen36_ab.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# A/B NVFP4 lm_head on Qwen3.6-35B: decode speed + coherence, FP16 vs NVFP4.
+set -uo pipefail
+cd /src/build-ciq
+M=/models/Qwen3.6-35B-A3B-NVFP4
+PROMPT="Explain why the sky is blue, then say why sunsets are red."
+
+decode() { ./imp-cli --model "$M" --bench --bench-pp 16 --bench-reps 3 --max-tokens 128 \
+             --temperature 0 --set gemm.nvfp4_lm_head_gdn="$1" 2>&1 | grep -E '^tg'; }
+
+cohere() { ./imp-cli --model "$M" --prompt "$PROMPT" --max-tokens 80 --temperature 0 \
+             --set gemm.nvfp4_lm_head_gdn="$1" 2>&1 \
+             | grep -oE '\][^[]*' | sed -E 's/^\] ?//' | tr -d '\n'; }
+
+for F in false true; do
+  lab=$([ "$F" = true ] && echo "NVFP4 lm_head" || echo "FP16 lm_head")
+  echo "===== $lab (gdn=$F) ====="
+  echo -n "decode: "; decode "$F" | tail -1
+  echo -n "text: "; cohere "$F"; echo
+done
+echo DONE


### PR DESCRIPTION
## Summary
Targets the one decode benchmark imp loses — **Qwen3.6-35B-A3B, −31% vs llama.cpp**. A fresh nsys profile showed ~44% of its decode is FP16 GEMV on NVFP4-excluded tensors; the **248k-vocab lm_head** (cuBLAS FP16 `gemvx`) alone is **~14%**.

NVFP4 lm_head was *hard-excluded* for GDN/SSM models because an older NVFP4 method degraded recurrent-state coherence (`lm_head_only_nvfp4_qwen3_6_refuted`, 2026-05-23). **Re-measured with the current quantize-FP16→NVFP4 path (PR #465 method):**

- **Quality holds** — Qwen3.6-35B output matches FP16 across math (23×17, distributive), primes (token-identical), French-Revolution, sky/sunset explanations. No degradation observed.
- **Decode +11.4%** — tg128 219.6 → 244.7 tok/s (graphs on).

So the exclusion is superseded by the better method. This replaces the hard GDN skip with an **opt-in** `gemm.nvfp4_lm_head_gdn` (**default false** — kept conservative pending exhaustive perplexity / long-multi-turn eval before any default flip on hybrids). Enable with `--set gemm.nvfp4_lm_head_gdn=true`.

## Test
A/B harness `tools/analysis/lmhead_nvfp4_qwen36_ab.sh`. Default behavior unchanged (flag off). Dense models unaffected (they already NVFP4 the lm_head via #465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)