### PR TITLE
feat(gemm): default-on NVFP4 lm_head for GDN/hybrid models (+11.4% decode)

### DIFF
--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -246,9 +246,12 @@ struct RuntimeConfig {
         // on Qwen3.6-35B: decode +11.4% (219.6→244.7 tok/s; the 248k-vocab
         // lm_head is ~14% of decode) at a small but REAL quality cost —
         // perplexity 15.90 (FP16) → 16.25 (NVFP4), +2.2% (FP16 PPL is stable
-        // run-to-run, so it's signal not noise). Kept opt-in (default false):
-        // a deliberate speed/quality tradeoff to opt into, not a forced default.
-        bool nvfp4_lm_head_gdn = false;
+        // run-to-run, so it's signal not noise). Default ON: the +11.4% decode
+        // gain serves the primary mission metric (best batch=1 tok/s on the
+        // 5090) and the +2.2% PPL cost is small; set false to keep the FP16
+        // lm_head for maximum coherence. Env IMP_NO_NVFP4_LM_HEAD=1 still kills
+        // the NVFP4 lm_head entirely (dense + GDN) via gemm.nvfp4_lm_head.
+        bool nvfp4_lm_head_gdn = true;
         // Route native-NVFP4 (Modelopt/llm-compressor) MoE expert DECODE (M=1)
         // through the fast per-expert gemv_nvfp4_moe kernels by borrowing the
         // already-resident contiguous expert data + scales, instead of the


### PR DESCRIPTION
## What

Flips `gemm.nvfp4_lm_head_gdn` from `false` → `true`. On GDN/SSM-hybrid models (Qwen3.6-35B-A3B and family) the native-precision (FP16/BF16) lm_head is now quantized to NVFP4 by default instead of staying FP16.

## Why

The lm_head is ~14% of decode on the 248k-vocab Qwen3.6 family. Quantizing it to NVFP4 is the largest remaining bandwidth win on the GDN decode hot path.

**Tradeoff (measured 2026-05-29, PRs #479/#481):**
- Decode **+11.4%** (tg128 219.6 → 244.7 tok/s)
- Perplexity **+2.2%** (15.90 → 16.25; FP16 PPL is run-to-run stable, so signal not noise)

This serves the primary mission metric (best batch=1 decode tok/s on the 5090). The +2.2% PPL cost is small and real; set `gemm.nvfp4_lm_head_gdn=false` to keep the FP16 lm_head for maximum coherence. `IMP_NO_NVFP4_LM_HEAD=1` still kills the NVFP4 lm_head entirely (dense + GDN).

## Blast radius

Only GDN/SSM-hybrid NVFP4 models with an FP16/BF16 lm_head. Dense and pure-MoE models already took the NVFP4 lm_head path, so their behavior is unchanged. Not in `perf_baseline.json` (which uses dense Qwen3-8B-Q8_0), so the CI perf gate is unaffected.

## Verification

- `make verify-fast`: OK (fast gtest filter PASS)
- Coherence on **Qwen3.6-35B-A3B-NVFP4** (the affected GDN+MoE hybrid): path active (`NVFP4 LM head: quantized FP16 [248320 x 2048] → NVFP4 (272.8 MiB)`), output coherent (clean Rayleigh-scattering explanation, ≥64 tokens, no repetition), stderr clean (no CUDA error / NaN / silent fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)