### PR TITLE
ci: build with CUDA 13.3 toolchain (drop 13.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,14 @@ on:
 
 jobs:
   build:
-    name: Build (CUDA 13.2)
+    name: Build (CUDA 13.3)
     runs-on: ubuntu-24.04
 
     container:
+      # Base image only — it provides the NVIDIA CUDA apt repo. There is no 13.3
+      # devel image on Docker Hub yet, so (like the Dockerfile) the first step
+      # installs cuda-toolkit-13-3 on top and that is what nvcc actually uses.
+      # The build does NOT compile with the base image's 13.2.1 toolkit.
       image: nvidia/cuda:13.2.1-devel-ubuntu24.04
 
     env:
@@ -24,10 +28,27 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install dependencies
+      - name: Install CUDA 13.3 toolkit + build deps
+        # No 13.3 devel image on Docker Hub yet, so — exactly like the Dockerfile —
+        # start from the 13.2.1 base (which provides the NVIDIA CUDA apt repo) and
+        # install cuda-toolkit-13-3 on top, making it the default toolchain. CUDA
+        # 13.2 is no longer a supported toolchain for imp; the verify step below
+        # fails the build if nvcc is anything other than 13.3.
         run: |
           apt-get update
+          apt-get install -y --no-install-recommends --allow-change-held-packages \
+            cuda-toolkit-13-3
+          ln -sfn /usr/local/cuda-13.3 /usr/local/cuda
           apt-get install -y cmake g++ git python3 ccache
+          echo "/usr/local/cuda-13.3/bin" >> "$GITHUB_PATH"
+          echo "CUDA_HOME=/usr/local/cuda-13.3" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64" >> "$GITHUB_ENV"
+
+      - name: Verify nvcc is 13.3
+        run: |
+          nvcc --version
+          nvcc --version | grep -q "release 13.3" \
+            || { echo "::error::nvcc is not CUDA 13.3 — 13.2 is not a supported toolchain"; exit 1; }
 
       # ccache caches per-TU compile output by content hash. On a header
       # change that invalidates many TUs (typical refactor), ccache hits
@@ -37,10 +58,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.ccache
-          key: ${{ runner.os }}-cuda13.2.1-ccache-${{ github.sha }}
+          key: ${{ runner.os }}-cuda13.3-ccache-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cuda13.2.1-ccache-
-            ${{ runner.os }}-cuda13.2-ccache-
+            ${{ runner.os }}-cuda13.3-ccache-
 
       - name: Reset ccache stats
         run: |
@@ -56,12 +76,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: imp-build-${{ runner.os }}-cuda13.2.1-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-${{ hashFiles('tests/**') }}
+          key: imp-build-${{ runner.os }}-cuda13.3-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-${{ hashFiles('tests/**') }}
           restore-keys: |
-            imp-build-${{ runner.os }}-cuda13.2.1-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-
-            imp-build-${{ runner.os }}-cuda13.2.1-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-
-            imp-build-${{ runner.os }}-cuda13.2.1-
-            imp-build-${{ runner.os }}-cuda13.2-
+            imp-build-${{ runner.os }}-cuda13.3-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-
+            imp-build-${{ runner.os }}-cuda13.3-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-
+            imp-build-${{ runner.os }}-cuda13.3-
 
       - name: Configure
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
         # making it the default toolchain. The verify step below fails the build
         # if nvcc is not the pinned version, so an older base toolkit can't leak in.
         run: |
-          pkg="cuda-toolkit-${CUDA_VERSION//./-}"   # 13.3 -> cuda-toolkit-13-3
+          # POSIX sh (the step runs under sh, not bash): turn 13.3 into 13-3 via tr.
+          pkg="cuda-toolkit-$(echo "$CUDA_VERSION" | tr . -)"   # -> cuda-toolkit-13-3
           cuda_home="/usr/local/cuda-${CUDA_VERSION}"
           apt-get update
           apt-get install -y --no-install-recommends --allow-change-held-packages "$pkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,22 @@ on:
 
 jobs:
   build:
-    name: Build (CUDA 13.3)
+    name: Build
     runs-on: ubuntu-24.04
 
     container:
-      # Base image only — it provides the NVIDIA CUDA apt repo. There is no 13.3
-      # devel image on Docker Hub yet, so (like the Dockerfile) the first step
-      # installs cuda-toolkit-13-3 on top and that is what nvcc actually uses.
-      # The build does NOT compile with the base image's 13.2.1 toolkit.
+      # Base image only — it provides the NVIDIA CUDA apt repo. There is no devel
+      # image for the pinned toolkit version on Docker Hub yet, so (like the
+      # Dockerfile) the first step installs cuda-toolkit-$CUDA_VERSION on top and
+      # that is what nvcc actually uses. The build does NOT compile with the base
+      # image's bundled toolkit.
       image: nvidia/cuda:13.2.1-devel-ubuntu24.04
 
     env:
+      # Single source of truth for the CUDA toolchain. Bump this one line to move
+      # CI to a new toolkit; the apt package, paths, verify and cache keys below
+      # all derive from it.
+      CUDA_VERSION: "13.3"
       CCACHE_DIR: /github/home/.ccache
       CCACHE_MAXSIZE: 8G
       CCACHE_COMPILERCHECK: content
@@ -28,27 +33,28 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install CUDA 13.3 toolkit + build deps
-        # No 13.3 devel image on Docker Hub yet, so — exactly like the Dockerfile —
-        # start from the 13.2.1 base (which provides the NVIDIA CUDA apt repo) and
-        # install cuda-toolkit-13-3 on top, making it the default toolchain. CUDA
-        # 13.2 is no longer a supported toolchain for imp; the verify step below
-        # fails the build if nvcc is anything other than 13.3.
+      - name: Install CUDA toolkit + build deps
+        # No devel image for the pinned toolkit on Docker Hub yet, so — exactly
+        # like the Dockerfile — start from the base image (which only provides the
+        # NVIDIA CUDA apt repo) and install cuda-toolkit-$CUDA_VERSION on top,
+        # making it the default toolchain. The verify step below fails the build
+        # if nvcc is not the pinned version, so an older base toolkit can't leak in.
         run: |
+          pkg="cuda-toolkit-${CUDA_VERSION//./-}"   # 13.3 -> cuda-toolkit-13-3
+          cuda_home="/usr/local/cuda-${CUDA_VERSION}"
           apt-get update
-          apt-get install -y --no-install-recommends --allow-change-held-packages \
-            cuda-toolkit-13-3
-          ln -sfn /usr/local/cuda-13.3 /usr/local/cuda
+          apt-get install -y --no-install-recommends --allow-change-held-packages "$pkg"
+          ln -sfn "$cuda_home" /usr/local/cuda
           apt-get install -y cmake g++ git python3 ccache
-          echo "/usr/local/cuda-13.3/bin" >> "$GITHUB_PATH"
-          echo "CUDA_HOME=/usr/local/cuda-13.3" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64" >> "$GITHUB_ENV"
+          echo "$cuda_home/bin" >> "$GITHUB_PATH"
+          echo "CUDA_HOME=$cuda_home" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$cuda_home/lib64" >> "$GITHUB_ENV"
 
-      - name: Verify nvcc is 13.3
+      - name: Verify nvcc version
         run: |
           nvcc --version
-          nvcc --version | grep -q "release 13.3" \
-            || { echo "::error::nvcc is not CUDA 13.3 — 13.2 is not a supported toolchain"; exit 1; }
+          nvcc --version | grep -q "release ${CUDA_VERSION}" \
+            || { echo "::error::nvcc is not CUDA ${CUDA_VERSION} (the pinned toolchain)"; exit 1; }
 
       # ccache caches per-TU compile output by content hash. On a header
       # change that invalidates many TUs (typical refactor), ccache hits
@@ -58,9 +64,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.ccache
-          key: ${{ runner.os }}-cuda13.3-ccache-${{ github.sha }}
+          key: ${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-ccache-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cuda13.3-ccache-
+            ${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-ccache-
 
       - name: Reset ccache stats
         run: |
@@ -76,11 +82,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: imp-build-${{ runner.os }}-cuda13.3-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-${{ hashFiles('tests/**') }}
+          key: imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-${{ hashFiles('tests/**') }}
           restore-keys: |
-            imp-build-${{ runner.os }}-cuda13.3-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-
-            imp-build-${{ runner.os }}-cuda13.3-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-
-            imp-build-${{ runner.os }}-cuda13.3-
+            imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-
+            imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-
+            imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-
 
       - name: Configure
         run: |


### PR DESCRIPTION
## Problem

The CI \`build\` job ran the base image's **CUDA 13.2.1** nvcc, while the Dockerfile and the local/host toolchains are all **13.3** (switched 2026-05-29). CI was compiling sm_120a SASS with a different ptxas than every other build path — and the job was even labelled "Build (CUDA 13.2)".

## Fix

Mirror the Dockerfile exactly: keep the \`nvidia/cuda:13.2.1-devel\` base image (only as the NVIDIA CUDA apt-repo provider — there is no 13.3 devel image on Docker Hub yet) and install \`cuda-toolkit-13-3\` on top, pinning it via \`PATH\`/\`CUDA_HOME\`/\`LD_LIBRARY_PATH\`.

- New **"Verify nvcc is 13.3"** step hard-fails the build if nvcc isn't 13.3 → 13.2 can't silently return.
- Job renamed \`Build (CUDA 13.2)\` → \`Build (CUDA 13.3)\`.
- ccache + build-cache keys bumped \`13.2.1\`→\`13.3\`; stale 13.2 restore-key fallbacks dropped (a 13.2 ccache is wrong-toolchain content under \`COMPILERCHECK=content\` anyway).

YAML validated (parses cleanly). Trade-off: installing the 13.3 toolkit adds ~1-2 min per run vs a prebuilt layer; acceptable for toolchain correctness, and ccache still covers the compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)