### PR TITLE
feat(gemm): opt-in NVFP4 for recipe-excluded hybrid projections (+53% GGUF, +3.8% Nemotron)

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -768,6 +768,11 @@ private:
     // source (GGUF path handles it via collect_candidates) or when the model is
     // GDN/SSM-hybrid. See RuntimeConfig::Gemm::nvfp4_lm_head.
     void nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cudaStream_t stream);
+    // Quantize the recipe-excluded BF16/FP16 attention q/k/v/o projections of a
+    // native-NVFP4 hybrid into wcache_.nvfp4 so M=1 decode uses the fast NVFP4
+    // GEMV. Opt-in via gemm.nvfp4_attn_proj. No-op unless the flag is set.
+    // (The GDN in/out analog was measured to regress decode and was dropped.)
+    void nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg, cudaStream_t stream);
     void nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4DecodeContext& dctx);
     void nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaStream_t stream,
                                       Nvfp4DecodeContext& dctx);

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -14,6 +14,7 @@
 #include "compute/gemm_cutlass_sm120.h"
 #include "core/logging.h"
 #include "quant/nvfp4_quant.h"
+#include "runtime/config.h"
 
 #include <cuda_runtime.h>
 #include <cstdlib>
@@ -353,6 +354,16 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
     if (cutlass_sm120_nvfp4_available()) {
         int ct_count = 0;
         size_t ct_total = 0;
+        // NOTE on the GDN/SSM quality lock and gemm.nvfp4_ssm_proj:
+        // For NATIVE-NVFP4 checkpoints the in_proj/out_proj (ssm_in/ssm_out)
+        // weights only EXIST as NVFP4 bytes — there is no FP16 copy and
+        // dequant_gpu has no NVFP4 path, so they MUST be registered here or
+        // decode produces garbage (the uncached fallback would run cuBLAS on
+        // raw NVFP4 bytes). They are therefore ALREADY in the NVFP4 decode
+        // cache and already use the fast gemv_nvfp4_kpar path — the "FP16 SSM
+        // tax" does not apply to native-NVFP4 hybrids. The gemm.nvfp4_ssm_proj
+        // opt-in is meaningful only for GGUF-quant hybrids (Qwen3.6-35B Q4_K_M),
+        // gated in pre_dequant_phase3's collect_candidates. Always register.
         auto register_prequant = [&](const Tensor& w) {
             if (w.qtype != QType::NVFP4 || !w.data || !w.scales)
                 return;
@@ -403,6 +414,18 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
             wcache_.cutlass_nvfp4_bytes += ct_total;
             IMP_LOG_INFO("CUTLASS sm_120 NVFP4 cache (prequant): %d tensors, %.2f MiB", ct_count,
                          ct_total / (1024.0 * 1024.0));
+        }
+        {
+            int n_ssm = 0;
+            for (int i = 0; i < cfg.n_layers; i++) {
+                const auto& L = mut_model->layer(i);
+                if (L.ssm_in.data) n_ssm++;
+                if (L.ssm_out.data) n_ssm++;
+            }
+            if (n_ssm > 0)
+                IMP_LOG_INFO("GDN/SSM (native NVFP4): %d recurrent projections IN NVFP4 decode cache "
+                             "(no FP16 source exists; fast gemv_nvfp4_kpar at decode)",
+                             n_ssm);
         }
     }
 }

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -194,6 +194,86 @@ void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cud
                  rows, cols, nvfp4_mib);
 }
 
+// Quantize the recipe-excluded BF16/FP16 GDN + attention projections of a
+// native-NVFP4 hybrid model into NVFP4 decode-cache entries. Mirrors
+// nvfp4_decode_cache_fp16_lm_head_ exactly (same quantize call, same wcache
+// insertion, same guards: weight on device, qtype F16/BF16, ndim 2, cols%16==0,
+// not already cached) — phase 4 then auto-routes M=1 decode through gemv_nvfp4
+// because the weight lands in wcache_.nvfp4 (decode_tier → NVFP4). Prefill is
+// untouched: the unfused originals stay BF16 and the prefill tier still uses the
+// full-precision GEMM path. Opt-in via gemm.nvfp4_attn_proj → the recipe-excluded
+// BF16 attention q/k/v/o (stateless within a step, low quality risk).
+//
+// The analogous lever for the BF16 GDN/Mamba in_proj/out_proj was built and
+// measured to REGRESS decode (−9% Nemotron, −20% Qwen3.6) — the tuned FP16 GEMV
+// (70-81% HBM) beats the NVFP4 GEMV for the wide GDN-output shapes — so it was
+// removed; keeping those projections FP16 is correct for speed, not just quality.
+void GraphExecutor::nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg,
+                                                         cudaStream_t stream) {
+    const bool do_attn = runtime_config().gemm.nvfp4_attn_proj;
+    if (!do_attn)
+        return;
+
+    float* d_absmax_buf = nullptr;
+    float* d_tscale_buf = nullptr;
+    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_absmax_buf, sizeof(float)));
+    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_tscale_buf, sizeof(float)));
+
+    int n_attn = 0;
+    size_t bytes_attn = 0;
+
+    // Quantize one native-precision (F16/BF16) device weight into wcache_.nvfp4.
+    // Returns the NVFP4 byte cost on success, 0 if skipped. Same guard set as the
+    // LM-head path; idempotent (skips weights already cached).
+    auto quantize_one = [&](const Tensor& w) -> size_t {
+        if (!w.data || !w.on_device)
+            return 0;
+        if (w.qtype != QType::F16 && w.qtype != QType::BF16)
+            return 0;  // already NVFP4/quantized, or a non-2-byte source
+        if (w.ndim != 2)
+            return 0;
+        const int rows = static_cast<int>(w.shape[0]);
+        const int cols = static_cast<int>(w.shape[1]);
+        if (cols % 16 != 0)
+            return 0;
+        if (wcache_.nvfp4.count(w.data))
+            return 0;  // already cached (e.g. re-entry)
+
+        Tensor fp16_view(w.data, QType::F16, 2, w.shape, /*on_device=*/true);
+        NvFP4QuantResult result;
+        quantize_fp16_to_nvfp4_async(fp16_view, result, d_absmax_buf, d_tscale_buf, stream);
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+
+        float h_tscale = 1.0f;
+        IMP_CUDA_CHECK_LOG(cudaMemcpy(&h_tscale, d_tscale_buf, sizeof(float), cudaMemcpyDeviceToHost));
+        result.tensor_scale = h_tscale;
+        result.N = rows;
+        result.K = cols;
+        wcache_.nvfp4[w.data] = result;
+        return static_cast<size_t>(rows) * cols / 2 + static_cast<size_t>(rows) * cols / 16;
+    };
+
+    for (int i = 0; i < cfg.n_layers; i++) {
+        const auto& L = model_->layer(i);
+        for (const Tensor* w : {&L.wq, &L.wk, &L.wv, &L.wo}) {
+            size_t b = quantize_one(*w);
+            if (b) {
+                n_attn++;
+                bytes_attn += b;
+            }
+        }
+    }
+
+    IMP_CUDA_CHECK_LOG(cudaFree(d_absmax_buf));
+    IMP_CUDA_CHECK_LOG(cudaFree(d_tscale_buf));
+
+    if (n_attn > 0)
+        IMP_LOG_INFO("NVFP4 attn proj: quantized %d BF16 q/k/v/o weights -> NVFP4 (%.1f MiB), decode GEMV fast path",
+                     n_attn, bytes_attn / (1024.0 * 1024.0));
+    else
+        IMP_LOG_INFO("NVFP4 attn proj: no eligible BF16 q/k/v/o (flag on but model has none)");
+}
+
 void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
     const ModelConfig& cfg, const VRAMBudget& budget,
     size_t& remaining_budget, cudaStream_t stream) {
@@ -258,6 +338,12 @@ void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
     // FP16 GEMV over vocab×d_model (~0.78 ms/token, ~19% of decode on Qwen3-8B).
     // Run after dense quantize so the entry is committed before CUTLASS convert.
     nvfp4_decode_cache_fp16_lm_head_(cfg, stream);
+
+    // Native-NVFP4 hybrids store some attention projections BF16 (recipe
+    // exclusion). Opt-in (gemm.nvfp4_attn_proj) quantizes the q/k/v/o into the
+    // same NVFP4 decode cache. Run after the LM head, before CUTLASS convert so
+    // these entries get the same block-scaled treatment.
+    nvfp4_decode_cache_fp16_projections_(cfg, stream);
 
     if (!wcache_.nvfp4.empty() && cutlass_sm120_nvfp4_available()) {
         nvfp4_decode_convert_cutlass_(remaining_budget, stream);

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -58,7 +58,11 @@ void GraphExecutor::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
     // GDN/SSM models: exclude ssm_in/ssm_out projections from NVFP4.
     // These feed the recurrent scan which accumulates quantization error
     // in state H across tokens. 4-bit degrades quality on 9B+ models.
-    {
+    // Opt-in gemm.nvfp4_ssm_proj keeps them IN the cache to measure the
+    // speed/quality tradeoff (mirrors nvfp4_lm_head_gdn). This gate covers the
+    // GGUF-source hybrids (Qwen3.6-35B-A3B Q4_K_M); native-NVFP4 SSM weights
+    // are handled identically by the phase0b register gate.
+    if (!runtime_config().gemm.nvfp4_ssm_proj) {
         int n_ssm_excluded = 0;
         for (int i = 0; i < cfg.n_layers; i++) {
             const auto& L = model_->layer(i);
@@ -73,13 +77,18 @@ void GraphExecutor::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
         }
         if (n_ssm_excluded > 0)
             IMP_LOG_INFO("GDN/SSM: excluding %d recurrent projections from NVFP4 cache", n_ssm_excluded);
+    } else {
+        IMP_LOG_INFO("GDN/SSM: nvfp4_ssm_proj ON — recurrent projections eligible for NVFP4 cache");
     }
 
     const bool decode_all = runtime_config().gemm.nvfp4_decode_all;
-    auto collect_weight_nvfp4 = [&](const Tensor& w, QType qtype) {
+    // force_beneficial bypasses the nvfp4_beneficial(qtype) gate — used by the
+    // opt-in SSM path so a Q4_K/Q5_K recurrent projection (normally only
+    // eligible under nvfp4_decode_all) can be cached on its own merit.
+    auto collect_weight_nvfp4 = [&](const Tensor& w, QType qtype, bool force_beneficial) {
         if (!w.data)
             return;
-        if (!nvfp4_beneficial(qtype, decode_all))
+        if (!force_beneficial && !nvfp4_beneficial(qtype, decode_all))
             return;
         if (wcache_.nvfp4.count(w.data))
             return;
@@ -98,10 +107,28 @@ void GraphExecutor::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
     };
 
     // LM head first: largest single weight (vocab × d_model), biggest bandwidth win.
-    collect_weight_nvfp4(model_->output_proj(), model_->out_proj_.qtype);
+    collect_weight_nvfp4(model_->output_proj(), model_->out_proj_.qtype, false);
 
     // Dense attention + FFN: every tensor benefits every decode step.
-    for_each_dense_weight(*model_, cfg, collect_weight_nvfp4);
+    for_each_dense_weight(*model_, cfg, [&](const Tensor& w, QType qtype) {
+        collect_weight_nvfp4(w, qtype, false);
+    });
+
+    // GGUF-source GDN/SSM recurrent projections (opt-in). For native-NVFP4
+    // hybrids the SSM weights are already cached in phase0b (no FP16/quant
+    // source), so this loop is a no-op there; it only fires for quantized-
+    // source hybrids (e.g. Qwen3.6-35B-A3B Q4_K_M), where it forces the Q4_K
+    // recurrent projections into the NVFP4 decode cache to remove the FP16
+    // dequant→cuBLAS SSM tax. Quality risk is highest here (recurrent scan).
+    if (runtime_config().gemm.nvfp4_ssm_proj) {
+        for (int i = 0; i < cfg.n_layers; i++) {
+            const auto& L = model_->layer(i);
+            if (L.ssm_in.data)
+                collect_weight_nvfp4(L.ssm_in, L.ssm_in.qtype, true);
+            if (L.ssm_out.data)
+                collect_weight_nvfp4(L.ssm_out, L.ssm_out.qtype, true);
+        }
+    }
 }
 
 void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cudaStream_t stream) {

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -216,6 +216,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.nvfp4_lm_head = parse_bool(val, cfg.gemm.nvfp4_lm_head);
     else if (eq("gemm.nvfp4_lm_head_gdn"))
         cfg.gemm.nvfp4_lm_head_gdn = parse_bool(val, cfg.gemm.nvfp4_lm_head_gdn);
+    else if (eq("gemm.nvfp4_ssm_proj"))
+        cfg.gemm.nvfp4_ssm_proj = parse_bool(val, cfg.gemm.nvfp4_ssm_proj);
     else if (eq("gemm.nvfp4_moe_decode"))
         cfg.gemm.nvfp4_moe_decode = parse_bool(val, cfg.gemm.nvfp4_moe_decode);
 

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -218,6 +218,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.nvfp4_lm_head_gdn = parse_bool(val, cfg.gemm.nvfp4_lm_head_gdn);
     else if (eq("gemm.nvfp4_ssm_proj"))
         cfg.gemm.nvfp4_ssm_proj = parse_bool(val, cfg.gemm.nvfp4_ssm_proj);
+    else if (eq("gemm.nvfp4_attn_proj"))
+        cfg.gemm.nvfp4_attn_proj = parse_bool(val, cfg.gemm.nvfp4_attn_proj);
     else if (eq("gemm.nvfp4_moe_decode"))
         cfg.gemm.nvfp4_moe_decode = parse_bool(val, cfg.gemm.nvfp4_moe_decode);
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -257,13 +257,32 @@ struct RuntimeConfig {
         // cache by default: they feed the GDN/SSM recurrent scan, which
         // accumulates quantization error in the state H across tokens, so 4-bit
         // was thought to degrade quality on 9B+ models. At decode they therefore
-        // run as FP16/dequant GEMVs (gemv_fp16_kernel) — a measured ~16.8% of
-        // Nemotron decode (~1.78 GB/token vs ~490 MB in NVFP4). This opt-in
-        // (mirroring nvfp4_lm_head_gdn) re-tests the speed/quality tradeoff:
-        // quantizing the SSM projections to NVFP4 plausibly buys +15-25% decode
-        // IF perplexity holds. Default false (quality-locked); set true to
-        // measure / ship if the PPL cost is small.
+        // GGUF hybrid models (e.g. Qwen3.6-35B-A3B Q4_K_M): the GDN/SSM
+        // in_proj/out_proj are excluded from the NVFP4 decode cache (Q4_K source
+        // is not nvfp4_beneficial), so decode runs them via Q4_K→FP16→cuBLAS — a
+        // memory-bound tax. This opt-in forces them into the NVFP4 decode cache.
+        // MEASURED (2026-05-30): Qwen3.6-35B Q4_K_M **+53% decode** (161→248
+        // tok/s), perplexity flat (−0.01%), coherent — reverses the documented
+        // −31% GGUF-hybrid-decode loss vs llama.cpp. No-op on native-NVFP4 models
+        // (their SSM projections are already NVFP4-cached). Default false.
         bool nvfp4_ssm_proj = false;
+        // Native-NVFP4 hybrid models store SOME projections BF16 because the
+        // Modelopt/llm-compressor recipe excluded them from NVFP4. At decode these
+        // run as FP16 GEMVs (gemv_fp16_kernel). This opt-in quantizes the
+        // recipe-excluded BF16 **attention q/k/v/o** to an NVFP4 decode-cache
+        // entry at init (direct quantize_fp16_to_nvfp4_async, mirroring
+        // nvfp4_lm_head_gdn). q/k/v/o are stateless within a step → low quality
+        // risk. MEASURED (2026-05-30): Nemotron-3-Nano-30B **+3.8% decode**,
+        // perplexity-neutral (within noise). No-op on models whose attention is
+        // already NVFP4 (e.g. Qwen3.6-35B). Default false.
+        //
+        // NOTE: the analogous lever for the BF16 GDN/Mamba in_proj/out_proj was
+        // built and MEASURED to REGRESS decode −9% (Nemotron) to −20% (Qwen3.6) —
+        // the tuned FP16 GEMV (70-81% HBM) beats the NVFP4 GEMV for the wide
+        // GDN-output shapes, so the bandwidth saving never materializes. Keeping
+        // those projections FP16 is correct for SPEED (not just quality); no flag
+        // is provided for them. (See docs/MTP/SafeTensors profiling notes.)
+        bool nvfp4_attn_proj = false;
         // Route native-NVFP4 (Modelopt/llm-compressor) MoE expert DECODE (M=1)
         // through the fast per-expert gemv_nvfp4_moe kernels by borrowing the
         // already-resident contiguous expert data + scales, instead of the

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -252,6 +252,18 @@ struct RuntimeConfig {
         // lm_head for maximum coherence. Env IMP_NO_NVFP4_LM_HEAD=1 still kills
         // the NVFP4 lm_head entirely (dense + GDN) via gemm.nvfp4_lm_head.
         bool nvfp4_lm_head_gdn = true;
+        // Hybrid GDN/SSM models (Nemotron-3-Nano-30B, Qwen3.6-35B-A3B) keep the
+        // recurrent in_proj/out_proj (ssm_in/ssm_out) OUT of the NVFP4 decode
+        // cache by default: they feed the GDN/SSM recurrent scan, which
+        // accumulates quantization error in the state H across tokens, so 4-bit
+        // was thought to degrade quality on 9B+ models. At decode they therefore
+        // run as FP16/dequant GEMVs (gemv_fp16_kernel) — a measured ~16.8% of
+        // Nemotron decode (~1.78 GB/token vs ~490 MB in NVFP4). This opt-in
+        // (mirroring nvfp4_lm_head_gdn) re-tests the speed/quality tradeoff:
+        // quantizing the SSM projections to NVFP4 plausibly buys +15-25% decode
+        // IF perplexity holds. Default false (quality-locked); set true to
+        // measure / ship if the PPL cost is small.
+        bool nvfp4_ssm_proj = false;
         // Route native-NVFP4 (Modelopt/llm-compressor) MoE expert DECODE (M=1)
         // through the fast per-expert gemv_nvfp4_moe kernels by borrowing the
         // already-resident contiguous expert data + scales, instead of the

--- a/tools/analysis/nvfp4_proj_ab.sh
+++ b/tools/analysis/nvfp4_proj_ab.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# A/B the recipe-excluded BF16 GDN/attn projection NVFP4 lever on native-NVFP4
+# hybrids. 4 configs: off / attn-only / gdn-only / both.
+# Decode tg256 (10-rep), perplexity (teacher-forced), + coherence sample.
+set -uo pipefail
+
+IMG=imp:test
+MODELS=/home/kekz/models
+CORPUS=/work/tools/analysis/ppl_corpus.txt
+REPO=/home/kekz/github.com/kekzl/imp
+PROMPT="Explain why the sky is blue, then say why sunsets are red."
+
+run() {  # $1=model $2=attn $3=gdn  -> extra args
+  docker run --rm --gpus all -e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+    -v "$MODELS":/models -v "$REPO":/work "$IMG" "$@"
+}
+
+decode() { # model attn gdn
+  run "$1" imp-cli --model "/models/$(basename $1)" --bench --bench-pp 16 \
+      --bench-reps 10 --max-tokens 256 --temperature 0 \
+      --set gemm.nvfp4_attn_proj="$2" --set gemm.nvfp4_gdn_proj="$3" 2>&1 \
+    | grep -E '^tg|NVFP4 attn proj|NVFP4 GDN proj|gemv_fp16'
+}
+
+ppl() { # model attn gdn
+  run "$1" imp-cli --model "/models/$(basename $1)" --perplexity "$CORPUS" \
+      --temperature 0 \
+      --set gemm.nvfp4_attn_proj="$2" --set gemm.nvfp4_gdn_proj="$3" 2>&1 \
+    | grep -E '^perplexity'
+}
+
+cohere() { # model attn gdn
+  run "$1" imp-cli --model "/models/$(basename $1)" --prompt "$PROMPT" \
+      --max-tokens 80 --temperature 0 \
+      --set gemm.nvfp4_attn_proj="$2" --set gemm.nvfp4_gdn_proj="$3" 2>&1 \
+    | grep -oE '\][^[]*' | sed -E 's/^\] ?//' | tr -d '\n'
+}
+
+MODEL="$1"   # full path
+echo "######## MODEL: $(basename $MODEL) ########"
+# config: label attn gdn
+for cfg in "off:false:false" "attn:true:false" "gdn:false:true" "both:true:true"; do
+  lab=${cfg%%:*}; rest=${cfg#*:}; A=${rest%%:*}; G=${rest#*:}
+  echo "===== cfg=$lab (attn=$A gdn=$G) ====="
+  echo "--- decode ---"; decode "$MODEL" "$A" "$G" | tail -3
+  echo "--- ppl ---";    ppl    "$MODEL" "$A" "$G"
+  echo "--- text ---";   cohere "$MODEL" "$A" "$G"; echo
+  echo "[cooldown 90s]"; sleep 90
+done
+echo "DONE $(basename $MODEL)"


### PR DESCRIPTION
Two opt-in NVFP4 decode levers for GDN/SSM-hybrid models, both default-off, found via a fresh bench+profile sweep of the hybrid path.

## `gemm.nvfp4_ssm_proj` — GGUF hybrids, **+53% decode**
On GGUF hybrids (e.g. **Qwen3.6-35B-A3B Q4_K_M**), the GDN/SSM in_proj/out_proj are excluded from the NVFP4 decode cache (Q4_K source isn't `nvfp4_beneficial`), so decode runs them via Q4_K→FP16→cuBLAS — a memory-bound tax. This flag forces them into the NVFP4 decode cache.
- **Measured:** Qwen3.6-35B Q4_K_M decode **161 → 248 tok/s (+53.4%)**, perplexity flat (−0.01%), coherent.
- **Strategic:** reverses the documented −31% GGUF-hybrid-decode loss vs llama.cpp (~194 tok/s) into a win.
- No-op on native-NVFP4 models (their SSM projections are already NVFP4-cached).

## `gemm.nvfp4_attn_proj` — native-NVFP4 hybrids w/ BF16 attention, **+3.8%**
Native-NVFP4 hybrids store some projections BF16 (Modelopt/llm-compressor recipe exclusion) → FP16 GEMVs at decode. This flag quantizes the recipe-excluded BF16 **attention q/k/v/o** to an NVFP4 decode-cache entry at init (the lm_head playbook, #479). q/k/v/o are stateless within a step → low quality risk.
- **Measured (Nemotron-3-Nano-30B-A3B-NVFP4):** decode **130.8 → 135.7 tok/s (+3.8%)**, perplexity-neutral (within the model's run-to-run noise), coherent.
- No-op on models whose attention is already NVFP4 (Qwen3.6-35B).

## What was tried and rejected (negative result)
The analogous lever for the BF16 **GDN/Mamba in_proj/out_proj** was built and measured to **REGRESS** decode (−9% Nemotron, −20% Qwen3.6). The tuned FP16 GEMV (70-81% HBM) beats the NVFP4 GEMV for the wide GDN-output shapes, so the bandwidth saving never materializes. **Dropped** — keeping those projections FP16 is correct for *speed*, not just quality.

## Notes
- Both flags default-off (opt-in, like `nvfp4_lm_head_gdn`). Prefill is untouched (full-precision GEMM tier). `perf_baseline.json` not refreshed (no default-path change).
- A/B harness: `tools/analysis/nvfp4_proj_ab.sh`.
- Coherence verified on both Qwen3.6 GGUF (flag on) and Nemotron (attn on); no degeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)