### PR TITLE
fix(nvfp4): don't cudaFree borrowed decode-cache entries on teardown (clean exit)

### DIFF
--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -361,6 +361,7 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
             NvFP4QuantResult tmp;
             tmp.packed_data = w.data;
             tmp.micro_scales = w.scales;
+            tmp.owned = false;  // borrows resident model weight storage — don't cudaFree on teardown
             tmp.tensor_scale = w.tensor_scale;
             tmp.N = w.shape[0];
             tmp.K = w.shape[1] * 2;  // packed K/2 → logical K

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -1538,6 +1538,7 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
                             NvFP4QuantResult nv = nit->second;
                             nv.packed_data = data_slice;
                             nv.micro_scales = w.scales;
+                            nv.owned = false;  // borrows resident model storage — don't cudaFree on teardown
                             wcache_.nvfp4.erase(nit);
                             wcache_.nvfp4[data_slice] = nv;
                         }

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -595,14 +595,17 @@ void dequantize_nvfp4_moe_to_fp16(const NvFP4MoEQuantResult& result, void* outpu
 }
 
 void free_nvfp4_result(NvFP4QuantResult& result) {
-    if (result.packed_data) {
-        IMP_CUDA_CHECK_LOG(cudaFree(result.packed_data));
-        result.packed_data = nullptr;
+    // Borrowed results (data-borrow decode cache) point packed_data/micro_scales
+    // at resident model weights owned elsewhere — cudaFree'ing those is an
+    // invalid-argument error. Only free storage this result allocated.
+    if (result.owned) {
+        if (result.packed_data)
+            IMP_CUDA_CHECK_LOG(cudaFree(result.packed_data));
+        if (result.micro_scales)
+            IMP_CUDA_CHECK_LOG(cudaFree(result.micro_scales));
     }
-    if (result.micro_scales) {
-        IMP_CUDA_CHECK_LOG(cudaFree(result.micro_scales));
-        result.micro_scales = nullptr;
-    }
+    result.packed_data = nullptr;
+    result.micro_scales = nullptr;
     result.tensor_scale = 1.0f;
     result.N = 0;
     result.K = 0;

--- a/src/quant/nvfp4_quant.h
+++ b/src/quant/nvfp4_quant.h
@@ -21,6 +21,11 @@ struct NvFP4QuantResult {
     float tensor_scale = 1.0f;     // global tensor scale
     int64_t N = 0;
     int64_t K = 0;
+    // True when packed_data/micro_scales were allocated by this result (the
+    // quantize_* paths) and must be cudaFree'd on teardown. False when they
+    // BORROW resident model weight storage (the data-borrow decode cache) —
+    // cudaFree on a borrowed pointer fails with "invalid argument".
+    bool owned = true;
 };
 
 // Quantize FP16 tensor to NVFP4 with two-level scaling.


### PR DESCRIPTION
## Problem
On engine teardown, every native-NVFP4 model spammed **35+ `cudaFree(result.micro_scales) — invalid argument` ERROR lines**. The data-borrow NVFP4 decode cache (phase0 native-NVFP4 registration + the phase3 contiguous-slice re-key) stores `wcache_.nvfp4` entries whose `packed_data`/`micro_scales` **borrow resident model weight storage**; `free_nvfp4_result` then `cudaFree`'d those model-owned pointers.

It was cosmetic (the work is done — bench prints pp/tg before teardown), but it:
- spammed the log on every exit, and
- **masked real errors** — it was misread as a "Phi-4 fails to load" failure during a bench sweep. (Phi-4-reasoning-plus-NVFP4 actually loads + benchmarks fine: pp≈1100, tg≈161 tok/s.)

## Fix
Add `bool owned = true` to `NvFP4QuantResult`. `free_nvfp4_result` only `cudaFree`s when `owned`; the two borrow sites (`pre_dequant_phase0_nvfp4_loader.cu`, `pre_dequant_phase3_nvfp4_decode.cu`) set `owned = false`. The quantize_* paths (lm_head, attn, MoE) keep the default `owned = true` and are still freed.

## Verified
| model | cudaFree errors before | after | bench |
|---|---|---|---|
| Phi-4-reasoning-plus-NVFP4 | 35+ | **0** | pp 1098 / tg 161 ✓ |
| Qwen3.6-35B-A3B-NVFP4 | 35+ | **0** | pp 575 / tg 215 ✓ |

Pure teardown-path change (runs at exit, after all inference) — forward/coherence unaffected. No double-free, no leak (borrowed pointers are freed with the model weights elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)