### PR TITLE
fix(prefill): auto-disable prefill-graph when NVFP4 dequant workspace is uncapturable (fixes Qwen3.6 pp>=4096 crash)

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -888,6 +888,18 @@ private:
     void* nvfp4_dequant_ws_buf_ = nullptr;
     size_t nvfp4_dequant_ws_size_ = 0;
 
+    // Set when allocate_nvfp4_dequant_workspace() could NOT pre-allocate the
+    // M>1 dequant scratch (largest NVFP4 weight exceeds the cap, or alloc
+    // failed). The fallback then lazy-cudaMallocs, which is illegal inside
+    // CUDA graph capture (cublasLt status 14 → cascading capture failure).
+    // The scheduler reads this to skip prefill-graph capture (run eager).
+    bool nvfp4_dequant_uncapturable_ = false;
+
+public:
+    bool nvfp4_dequant_uncapturable() const { return nvfp4_dequant_uncapturable_; }
+
+private:
+
     // Weight caches (FP16, FP8, NVFP4, CUTLASS NVFP4/MXFP4, fused KV/gate+up)
     WeightCaches wcache_;
 

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -870,15 +870,18 @@ bool GraphExecutor::allocate_nvfp4_dequant_workspace() {
     if (max_bytes > kCap) {
         IMP_LOG_WARN(
             "gemm_nvfp4 dequant workspace: largest NVFP4 weight is %.2f MiB > %.0f MiB cap, "
-            "skipping pre-alloc. M>1 fallback during graph capture will fail-loud.",
+            "skipping pre-alloc — prefill graph capture disabled (M>1 fallback runs eager).",
             max_bytes / (1024.0 * 1024.0), kCap / (1024.0 * 1024.0));
+        nvfp4_dequant_uncapturable_ = true;  // scheduler will skip prefill-graph capture
         return false;
     }
 
     nvfp4_dequant_ws_buf_ = vram_alloc(vram_alloc_, max_bytes, "nvfp4_dequant");
     if (!nvfp4_dequant_ws_buf_) {
-        IMP_LOG_WARN("gemm_nvfp4 dequant workspace: alloc failed (%zu bytes)", max_bytes);
+        IMP_LOG_WARN("gemm_nvfp4 dequant workspace: alloc failed (%zu bytes) — prefill graph "
+                     "capture disabled (M>1 fallback runs eager).", max_bytes);
         nvfp4_dequant_ws_size_ = 0;
+        nvfp4_dequant_uncapturable_ = true;
         return false;
     }
     nvfp4_dequant_ws_size_ = max_bytes;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -566,7 +566,12 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         // *before* this wrapper — captured region is forward_logits only,
         // analogous to the decode graph pattern.
         const bool prefill_graph_enabled = runtime_config_.runtime.prefill_graph;
-        const bool can_capture = prefill_graph_enabled && pf_pool_used && config_.use_cuda_graphs;
+        // The M>1 NVFP4 dequant fallback lazy-cudaMallocs when its workspace
+        // couldn't be pre-allocated (largest weight > cap) — illegal under CUDA
+        // graph capture (cublasLt status 14 → cascading "previous error during
+        // capture"). Run prefill eager for those models (Qwen3.6-35B pp>=4096).
+        const bool can_capture = prefill_graph_enabled && pf_pool_used &&
+                                 config_.use_cuda_graphs && !executor_->nvfp4_dequant_uncapturable();
         if (can_capture) {
             const int block_count = static_cast<int>(block_table.size());
             if (chunk_len != last_prefill_chunk_len_ || block_count != last_prefill_block_count_) {


### PR DESCRIPTION
## Problem
**Qwen3.6-35B-A3B-NVFP4 crashes at prefill length >= 4096.** At long context VRAM is tight (`StoragePlanner: plan failed`), so the `gemm_nvfp4` M>1 dequant workspace for the largest NVFP4 weight (970 MiB) exceeds the 512 MiB pre-alloc cap and is skipped. The fallback then lazy-`cudaMalloc`s — **illegal inside CUDA graph capture**. The captured prefill GEMM hits `cublasLtMatmul status 14` → "Output buffer is garbage" → cascading `cudaMemcpyAsync ... failed due to a previous error during capture` across the MoE/SSM/attention executors. pp512 is fine.

## Root cause (confirmed)
With `--set runtime.prefill_graph=false` (eager prefill), pp4096 runs fine — cuBLAS allocates its workspace dynamically, which is only forbidden *during capture*. The engine already detects the uncapturable condition (it logs "M>1 fallback during graph capture will fail-loud") — it just needs to **skip prefill-graph capture** rather than fail.

## Fix
`allocate_nvfp4_dequant_workspace()` sets a new `nvfp4_dequant_uncapturable_` flag when it can't pre-allocate the dequant scratch (largest weight > cap, or alloc failed). The scheduler gates prefill-graph capture on `!executor_->nvfp4_dequant_uncapturable()`, running prefill **eager** for those models. The decode graph (separate) is unaffected.

## Verified (Qwen3.6-35B-A3B-NVFP4)
| | before | after |
|---|---|---|
| **pp4096** | **crash** (status 14 cascade) | **4274 tok/s** ✓ |
| pp512 | 11179 | 11145 (unchanged) |
| tg256/decode | 245 | 245 (unchanged) |
| coherence | — | coherent ✓ |

Trade-off: prefill-graph is disabled entirely for models with a >512 MiB NVFP4 weight (set at init from the largest weight). That's a marginal cost — prefill-graph's benefit is variance-dominated (per its own default-on A/B), and the alternative is a crash at long context. Correctness > marginal prefill speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)