### PR TITLE
feat(vision): Gemma-4 (gemma4v) vision + orientation-aware projector

### DIFF
--- a/docs/vision_gemma4v_spec.md
+++ b/docs/vision_gemma4v_spec.md
@@ -1,0 +1,59 @@
+# Gemma-4 vision (gemma4v) encoder — implementation spec
+
+Reverse-engineered from llama.cpp master (`tools/mtmd/models/gemma4v.cpp`, `clip.cpp`,
+`mtmd-image.cpp`). imp implements the gemma3 SigLIP path; gemma4v is a structurally
+different encoder. This doc is the reference for porting it.
+
+## GGUF facts (ggml-org/gemma-4-26B-A4B-it-GGUF mmproj)
+- `clip.vision.projector_type = gemma4v`, projection_dim=2816, hidden=1152,
+  block_count=27, head_count=16 (d_head=72), ffn=4304, eps=1e-6.
+- image_size=224, patch_size=16, image_mean=[0,0,0], image_std=[1,1,1].
+- Tensors: `mm.input_projection.weight` ne=[1152,2816] **[in,out] standard orient**,
+  `v.patch_embd.weight` [16,16,3,1152] (NO bias), `v.position_embd.weight` ne=[1152,10240,2]
+  (two axial tables: [:,:,0]=x/col, [:,:,1]=y/row), `v.std_bias` [1152], `v.std_scale` [1152].
+- ABSENT vs gemma3: no `mm.soft_emb_norm`, no `v.post_ln`, no `v.patch_embd.bias`.
+- n_merge = 3 (pool kernel), align = patch_size*n_merge = 48.
+
+## Forward pass (exact)
+```
+# preprocess (host): variable aspect ratio, single image, no tiling
+align=48; min_pixels=252*48²=580608; max_pixels=280*48²=645120
+(w_bar,h_bar)=calc_size_preserved_ratio(W,H,align,min,max)  # both multiples of 48
+img = bilinear_resize(orig,w_bar,h_bar); img/=255 (RGB)     # mean0/std1
+n_px=w_bar/16; n_py=h_bar/16  (multiples of 3); n_patches=n_px*n_py
+
+# graph
+inp_raw = inp_raw*2 - 1                                       # → [-1,1]
+inp = conv2d(patch_embd 16x16 s16, inp_raw) → [1152, n_patches]   # NO bias
+pos_x[i]=i%n_px; pos_y[i]=i/n_px
+inp += get_rows(pos_embd[:,:,0], pos_x) + get_rows(pos_embd[:,:,1], pos_y)
+kq_scale=1.0; rope_theta=100
+for il in 0..26:                          # RMSNorm blocks (NOT LayerNorm)
+    h = rms_norm(x)*ln1_w
+    Q=h·q_w+q_b; K=h·k_w+k_b; V=h·v_w+v_b      # 16 heads, d_head=72
+    Q = concat(rope_neox(Q[:36],pos_x,θ100), rope_neox(Q[36:],pos_y,θ100))   # axial 2D RoPE
+    K = concat(rope_neox(K[:36],pos_x,θ100), rope_neox(K[36:],pos_y,θ100))
+    V = rms_norm(V)                            # gemma4v-only V-norm, no weight
+    A = softmax(KᵀQ * kq_scale=1.0)·V          # no mask (bidirectional)
+    x = x + (A·o_w+o_b)
+    h2 = rms_norm(x)*ln2_w
+    x = x + ffn_gelu_tanh(h2)                  # up/gate/down + biases
+# NO post_ln
+# pooler
+g = avg_pool2d([n_px,n_py,1152], k=3, stride=3) → [1152, (n_px/3)*(n_py/3)]
+g = g * sqrt(1152)
+g = (g - std_bias) * std_scale                 # per-channel affine
+# embedder
+g = rms_norm(g)                                # no weight
+out = mm_input_proj_w · g                      # [1152→2816], plain mul_mat, no bias
+# → [2816, n_tokens], n_tokens≈252..280
+```
+
+## Risks / ambiguities (verify on hardware)
+1. **kq_scale=1.0** — relies on HF checkpoint pre-scaling Q. If wrong, logits off ~8.5×.
+2. d_head=72 (1152/16), RoPE half-dim=36.
+3. ffn_op = gelu_pytorch_tanh (gemma) — confirm.
+4. `Gemma4ClippableLinear` clamp only if per-weight min/max scalars present (this GGUF: none → plain).
+5. Token count is DYNAMIC (252–280), not a fixed mm_tokens_per_image.
+
+Source: llama.cpp master `tools/mtmd/models/gemma4v.cpp` + `clip.cpp`.

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -232,11 +232,19 @@ bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer, c
             stop_token_ids_.push_back(end_of_turn_id_);
             stop_token_ids_.push_back(static_cast<int32_t>(tokenizer.eos_id()));
 
-            // Vision tokens (optional — only present in Gemma-3 multimodal)
+            // Vision tokens (optional — Gemma-3 and Gemma-4 multimodal).
             // Resolved from vocabulary; stays -1 if not found (disables vision).
+            // Gemma-3: <start_of_image>/<image_soft_token>/<end_of_image>.
+            // Gemma-4: <|image>/<|image|>/<image|> (begin / repeated soft / end).
             boi_id_ = tokenizer.find_token("<start_of_image>");
+            if (boi_id_ < 0)
+                boi_id_ = tokenizer.find_token("<|image>");
             eoi_id_ = tokenizer.find_token("<end_of_image>");
+            if (eoi_id_ < 0)
+                eoi_id_ = tokenizer.find_token("<image|>");
             img_soft_token_id_ = tokenizer.find_token("<image_soft_token>");
+            if (img_soft_token_id_ < 0)
+                img_soft_token_id_ = tokenizer.find_token("<|image|>");
             break;
         }
         case ChatTemplateFamily::DEEPSEEK_R1: {

--- a/src/vision/vision_encoder.cu
+++ b/src/vision/vision_encoder.cu
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <cfloat>
 #include <cmath>
+#include <vector>
 
 namespace imp {
 
@@ -31,8 +32,12 @@ static void vision_gemm(const half* A, const half* B, half* C, int M, int N, int
     auto handle = get_vision_cublas_handle();
     cublasSetStream(handle, stream);
 
-    half h_alpha = __float2half(alpha);
-    half h_beta = __float2half(beta);
+    // FP32 accumulation (FP16 in/out): the FFN down-projection sums thousands of
+    // terms; FP16 accumulation overflows for high-magnitude tokens (→ inf, then
+    // RMSNorm turns inf×0 into NaN). FP32 compute keeps the encoder numerically
+    // robust. alpha/beta must be float for COMPUTE_32F.
+    float f_alpha = alpha;
+    float f_beta = beta;
 
     // cuBLAS uses column-major, so we compute C^T = B @ A^T
     // C^T [N, M] = B [N, K] @ A^T [K, M]
@@ -40,10 +45,10 @@ static void vision_gemm(const half* A, const half* B, half* C, int M, int N, int
                  CUBLAS_OP_T,                 // A^T
                  CUBLAS_OP_N,                 // B
                  N, M, K,                     // m, n, k in col-major terms
-                 &h_alpha, B, CUDA_R_16F, K,  // B [N, K] col-major stride = K
+                 &f_alpha, B, CUDA_R_16F, K,  // B [N, K] col-major stride = K
                  A, CUDA_R_16F, K,            // A [M, K] col-major stride = K
-                 &h_beta, C, CUDA_R_16F, N,   // C [M, N] col-major stride = N
-                 CUBLAS_COMPUTE_16F, CUBLAS_GEMM_DEFAULT);
+                 &f_beta, C, CUDA_R_16F, N,   // C [M, N] col-major stride = N
+                 CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
 }
 
 // ---- Helper: Batched strided GEMM for attention ----
@@ -252,6 +257,122 @@ __global__ void avg_pool_spatial_kernel(const half* __restrict__ in,  // [grid_h
     }
 }
 
+// RMSNorm over contiguous rows of width D, optional weight (null = no weight).
+// Used by gemma4v for per-head q/k/v norm (D=head_dim, n_rows=np*nh) and the
+// weightless pre-projection norm (D=hidden, n_rows=n_tokens).
+__global__ void vision_rmsnorm_opt_kernel(const half* __restrict__ x, const half* __restrict__ weight,
+                                          half* __restrict__ out, int D, float eps) {
+    int row = blockIdx.x;
+    int tid = threadIdx.x;
+    const half* x_row = x + static_cast<int64_t>(row) * D;
+    half* o_row = out + static_cast<int64_t>(row) * D;
+
+    __shared__ float s_buf[32];
+    float ss = 0.0f;
+    for (int i = tid; i < D; i += blockDim.x) {
+        float v = __half2float(x_row[i]);
+        ss += v * v;
+    }
+    float inv_rms = rsqrtf(block_reduce_sum(ss, s_buf) / D + eps);
+
+    for (int i = tid; i < D; i += blockDim.x) {
+        float v = __half2float(x_row[i]) * inv_rms;
+        if (weight)
+            v *= __half2float(weight[i]);
+        o_row[i] = __float2half(v);
+    }
+}
+
+// 2D axial NEOX RoPE for gemma4v vision attention. qk: [np, nh, head_dim].
+// The head_dim is split in half: first half rotated by the patch column (pos_x),
+// second half by the patch row (pos_y); each half is NEOX (pairs i, i+half/2).
+__global__ void vision_rope2d_neox_kernel(half* __restrict__ qk, const int* __restrict__ pos_x,
+                                          const int* __restrict__ pos_y, int np, int nh, int head_dim,
+                                          float base) {
+    int half_dim = head_dim / 2;       // dims rotated per axis
+    int pairs = half_dim / 2;          // rotation pairs per axis
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = np * nh * pairs;
+    if (idx >= total)
+        return;
+    int j = idx % pairs;          // 0..pairs-1
+    int hp = idx / pairs;         // patch*nh + head
+    int p = hp / nh;
+    half* vec = qk + static_cast<int64_t>(hp) * head_dim;
+
+    float inv = powf(base, -2.0f * j / half_dim);
+    // first half: column position
+    {
+        float ang = pos_x[p] * inv;
+        float c = cosf(ang), s = sinf(ang);
+        float a = __half2float(vec[j]);
+        float b = __half2float(vec[j + pairs]);
+        vec[j] = __float2half(a * c - b * s);
+        vec[j + pairs] = __float2half(a * s + b * c);
+    }
+    // second half: row position
+    {
+        int o = half_dim;
+        float ang = pos_y[p] * inv;
+        float c = cosf(ang), s = sinf(ang);
+        float a = __half2float(vec[o + j]);
+        float b = __half2float(vec[o + j + pairs]);
+        vec[o + j] = __float2half(a * c - b * s);
+        vec[o + j + pairs] = __float2half(a * s + b * c);
+    }
+}
+
+// Add the two axial learned position tables (x=col, y=row) to the patch grid.
+// tbl is v.position_embd laid out [2, pos_size, D]: x-table at offset 0, y-table
+// at offset pos_size*D.
+__global__ void axial_pos_add_kernel(half* __restrict__ x, const half* __restrict__ tbl,
+                                     const int* __restrict__ pos_x, const int* __restrict__ pos_y, int np,
+                                     int D, int pos_size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= np * D)
+        return;
+    int p = idx / D;
+    int d = idx % D;
+    float ex = __half2float(tbl[static_cast<int64_t>(pos_x[p]) * D + d]);
+    float ey = __half2float(tbl[(static_cast<int64_t>(pos_size) + pos_y[p]) * D + d]);
+    x[idx] = __float2half(__half2float(x[idx]) + ex + ey);
+}
+
+// gemma4v projector tail fused in FP32: out = rmsnorm((x*scale_factor - std_bias) * std_scale).
+// Gemma vision activations are large (absmax ~3000); the ×√D scale would overflow
+// FP16 (→ inf → NaN) if materialized, so the whole tail runs in FP32 registers and
+// only the RMS-normalized (small) result is written back as FP16.
+__global__ void gemma4v_tail_norm_kernel(const half* __restrict__ x, const half* __restrict__ std_bias,
+                                         const half* __restrict__ std_scale, half* __restrict__ out, int D,
+                                         float scale_factor, float eps) {
+    int row = blockIdx.x;
+    int tid = threadIdx.x;
+    const half* x_row = x + static_cast<int64_t>(row) * D;
+    half* o_row = out + static_cast<int64_t>(row) * D;
+    extern __shared__ float sv[];  // [D] FP32 scratch
+    __shared__ float s_buf[32];
+    float ss = 0.0f;
+    for (int i = tid; i < D; i += blockDim.x) {
+        float v = __half2float(x_row[i]) * scale_factor;
+        if (std_bias && std_scale)
+            v = (v - __half2float(std_bias[i])) * __half2float(std_scale[i]);
+        sv[i] = v;
+        ss += v * v;
+    }
+    float inv = rsqrtf(block_reduce_sum(ss, s_buf) / D + eps);
+    for (int i = tid; i < D; i += blockDim.x)
+        o_row[i] = __float2half(sv[i] * inv);
+}
+
+// Element-wise multiply: out = a * b (GeGLU gate combine).
+__global__ void mul_tensors_kernel(const half* __restrict__ a, const half* __restrict__ b,
+                                   half* __restrict__ out, int N) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N)
+        return;
+    out[idx] = __float2half(__half2float(a[idx]) * __half2float(b[idx]));
+}
+
 // Replace vision token embeddings in the hidden state
 __global__ void replace_vision_embeddings_kernel(
     half* __restrict__ hidden,              // [n_tokens, d_model]
@@ -337,6 +458,15 @@ void VisionEncoder::free_buffers() {
     safe_free(d_attn_scores_);
     safe_free(d_ffn_);
     safe_free(d_pooled_);
+    safe_free(d_gate_);
+    if (d_pos_x_) {
+        cudaFree(d_pos_x_);
+        d_pos_x_ = nullptr;
+    }
+    if (d_pos_y_) {
+        cudaFree(d_pos_y_);
+        d_pos_y_ = nullptr;
+    }
 }
 
 bool VisionEncoder::init(const VisionModel& model, int lm_d_model, cudaStream_t stream,
@@ -368,6 +498,26 @@ bool VisionEncoder::init(const VisionModel& model, int lm_d_model, cudaStream_t 
         IMP_LOG_ERROR("Vision encoder: workspace allocation failed");
         free_buffers();
         return false;
+    }
+
+    // gemma4v needs a separate GeGLU gate buffer and precomputed axial position
+    // indices (column = patch % grid, row = patch / grid).
+    if (cfg.is_gemma4v) {
+        int grid = cfg.image_size / cfg.patch_size;
+        if (!alloc(d_gate_, np * ff) ||
+            cudaMalloc(&d_pos_x_, np * sizeof(int)) != cudaSuccess ||
+            cudaMalloc(&d_pos_y_, np * sizeof(int)) != cudaSuccess) {
+            IMP_LOG_ERROR("Vision encoder: gemma4v workspace allocation failed");
+            free_buffers();
+            return false;
+        }
+        std::vector<int> hx(np), hy(np);
+        for (int i = 0; i < np; i++) {
+            hx[i] = i % grid;
+            hy[i] = i / grid;
+        }
+        cudaMemcpy(d_pos_x_, hx.data(), np * sizeof(int), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_pos_y_, hy.data(), np * sizeof(int), cudaMemcpyHostToDevice);
     }
 
     size_t total_mb = (np * pd + np * hd * 4 +
@@ -412,6 +562,9 @@ bool VisionEncoder::encode(const half* d_pixels, half* d_output, cudaStream_t st
 }
 
 bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream_t stream) {
+    if (model_->config.is_gemma4v)
+        return encode_impl_gemma4v(d_pixels, d_output, stream);
+
     const auto& cfg = model_->config;
     int np = cfg.num_patches;
     int hd = cfg.hidden_size;
@@ -648,6 +801,151 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
         vision_rmsnorm_kernel<<<n_pooled, 256, 0, stream>>>(
             d_output, static_cast<const half*>(model_->mm_post_norm_w.data), d_output, lm_d_model_, eps);
     }
+
+    return true;
+}
+
+// ======================================================================
+//  gemma4v encoder — RMSNorm blocks, per-head q/k/v norm, 2D axial NEOX
+//  RoPE, sandwich post-norms, GeGLU FFN, scale-1 attention, avg-pool(3)
+//  + ×√D + std-affine + pre-proj RMSNorm + linear projector.
+//  See docs/vision_gemma4v_spec.md.
+// ======================================================================
+bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cudaStream_t stream) {
+    const auto& cfg = model_->config;
+    int np = cfg.num_patches;
+    int hd = cfg.hidden_size;
+    int ff = cfg.intermediate_size;
+    int nh = cfg.num_heads;
+    int head_dim = cfg.head_dim;
+    int ps = cfg.patch_size;
+    int img = cfg.image_size;
+    int grid = img / ps;
+    int patch_dim = ps * ps * 3;
+    float eps = 1e-6f;
+    float rope_base = cfg.rope_theta;
+
+    // ---- Patch embed (no bias) ----
+    extract_patches_kernel<<<np, 256, 0, stream>>>(d_pixels, d_patches_, img, img, ps, grid, grid, patch_dim);
+    vision_gemm(d_patches_, static_cast<const half*>(model_->patch_embd_w.data), d_hidden_, np, hd, patch_dim,
+                1.0f, 0.0f, stream);
+
+    // ---- Axial learned position embeddings (x=col, y=row tables) ----
+    {
+        int pos_size = static_cast<int>(model_->position_embd.shape[1]);  // 10240
+        int total = np * hd;
+        axial_pos_add_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
+            d_hidden_, static_cast<const half*>(model_->position_embd.data), d_pos_x_, d_pos_y_, np, hd,
+            pos_size);
+    }
+
+    // ---- 27 transformer layers ----
+    for (int layer = 0; layer < cfg.num_layers; layer++) {
+        const auto& lw = model_->layers[layer];
+        int rows = np * nh;
+
+        // pre-attention RMSNorm (full-width, weighted)
+        vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
+            d_hidden_, static_cast<const half*>(lw.ln1_w.data), d_residual_, hd, eps);
+
+        // Q, K, V projections (no bias)
+        vision_gemm(d_residual_, static_cast<const half*>(lw.wq.data), d_q_, np, hd, hd, 1.0f, 0.0f, stream);
+        vision_gemm(d_residual_, static_cast<const half*>(lw.wk.data), d_k_, np, hd, hd, 1.0f, 0.0f, stream);
+        vision_gemm(d_residual_, static_cast<const half*>(lw.wv.data), d_v_, np, hd, hd, 1.0f, 0.0f, stream);
+
+        // per-head q/k RMSNorm (weighted [head_dim]) → 2D RoPE; per-head v RMSNorm (weightless)
+        vision_rmsnorm_opt_kernel<<<rows, 64, 0, stream>>>(
+            d_q_, static_cast<const half*>(lw.q_norm.data), d_q_, head_dim, eps);
+        vision_rmsnorm_opt_kernel<<<rows, 64, 0, stream>>>(
+            d_k_, static_cast<const half*>(lw.k_norm.data), d_k_, head_dim, eps);
+        {
+            int pairs = (head_dim / 2) / 2;
+            int total = np * nh * pairs;
+            int blocks = (total + 127) / 128;
+            vision_rope2d_neox_kernel<<<blocks, 128, 0, stream>>>(d_q_, d_pos_x_, d_pos_y_, np, nh, head_dim,
+                                                                  rope_base);
+            vision_rope2d_neox_kernel<<<blocks, 128, 0, stream>>>(d_k_, d_pos_x_, d_pos_y_, np, nh, head_dim,
+                                                                  rope_base);
+        }
+        vision_rmsnorm_opt_kernel<<<rows, 64, 0, stream>>>(d_v_, nullptr, d_v_, head_dim, eps);
+
+        // attention: scores = Q @ K^T, kq_scale = 1.0 (q/k-norm controls magnitude)
+        {
+            auto handle = get_vision_cublas_handle();
+            cublasSetStream(handle, stream);
+            float f_alpha = 1.0f;  // kq_scale = 1.0; FP32 accumulate to avoid FP16 overflow
+            float f_beta = 0.0f;
+            cublasGemmStridedBatchedEx(handle, CUBLAS_OP_T, CUBLAS_OP_N, np, np, head_dim, &f_alpha, d_k_,
+                                       CUDA_R_16F, nh * head_dim, head_dim, d_q_, CUDA_R_16F, nh * head_dim,
+                                       head_dim, &f_beta, d_attn_scores_, CUDA_R_16F, np,
+                                       static_cast<long long>(np) * np, nh, CUBLAS_COMPUTE_32F,
+                                       CUBLAS_GEMM_DEFAULT);
+        }
+        softmax_2d_kernel<<<nh * np, 256, 0, stream>>>(d_attn_scores_, np);
+        {
+            auto handle = get_vision_cublas_handle();
+            cublasSetStream(handle, stream);
+            float f_one = 1.0f;
+            float f_zero = 0.0f;
+            cublasGemmStridedBatchedEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, head_dim, np, np, &f_one, d_v_,
+                                       CUDA_R_16F, nh * head_dim, head_dim, d_attn_scores_, CUDA_R_16F, np,
+                                       static_cast<long long>(np) * np, &f_zero, d_attn_out_, CUDA_R_16F,
+                                       nh * head_dim, head_dim, nh, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+        }
+
+        // output projection (no bias) → d_residual_
+        vision_gemm(d_attn_out_, static_cast<const half*>(lw.wo.data), d_residual_, np, hd, hd, 1.0f, 0.0f,
+                    stream);
+        // sandwich: post-attention RMSNorm BEFORE residual add
+        vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
+            d_residual_, static_cast<const half*>(lw.attn_post_norm.data), d_residual_, hd, eps);
+        {
+            int total = np * hd;
+            add_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_hidden_, d_residual_, d_hidden_,
+                                                                        total);
+        }
+
+        // pre-FFN RMSNorm → GeGLU(up, gate) → down
+        vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
+            d_hidden_, static_cast<const half*>(lw.ln2_w.data), d_residual_, hd, eps);
+        vision_gemm(d_residual_, static_cast<const half*>(lw.ffn_up_w.data), d_ffn_, np, ff, hd, 1.0f, 0.0f,
+                    stream);
+        vision_gemm(d_residual_, static_cast<const half*>(lw.ffn_gate_w.data), d_gate_, np, ff, hd, 1.0f, 0.0f,
+                    stream);
+        {
+            int total = np * ff;
+            gelu_tanh_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_gate_, total);
+            mul_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_gate_, d_ffn_, d_ffn_, total);
+        }
+        vision_gemm(d_ffn_, static_cast<const half*>(lw.ffn_down_w.data), d_residual_, np, hd, ff, 1.0f, 0.0f,
+                    stream);
+        // sandwich: post-FFN RMSNorm BEFORE residual add
+        vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
+            d_residual_, static_cast<const half*>(lw.ffn_post_norm.data), d_residual_, hd, eps);
+        {
+            int total = np * hd;
+            add_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_hidden_, d_residual_, d_hidden_,
+                                                                        total);
+        }
+    }
+
+    // ---- Pooler: avg-pool(n_merge) ----
+    int pool = cfg.n_merge;
+    int out_h = grid / pool, out_w = grid / pool;
+    int n_pooled = out_h * out_w;
+    avg_pool_spatial_kernel<<<n_pooled, 256, 0, stream>>>(d_hidden_, d_pooled_, grid, grid, hd, pool, out_h,
+                                                          out_w);
+
+    // ---- Fused FP32 tail: ×√hd → (x-std_bias)*std_scale → pre-projection RMSNorm.
+    // Gemma vision activations reach ~3000; ×√hd would overflow FP16 if stored, so
+    // the whole tail runs in FP32 and only the RMS-normalized result is written. ----
+    gemma4v_tail_norm_kernel<<<n_pooled, 256, hd * sizeof(float), stream>>>(
+        d_pooled_, static_cast<const half*>(model_->std_bias.data),
+        static_cast<const half*>(model_->std_scale.data), d_pooled_, hd, sqrtf(static_cast<float>(hd)), eps);
+
+    // ---- Linear projection ----
+    vision_gemm(d_pooled_, static_cast<const half*>(model_->mm_proj_w.data), d_output, n_pooled, lm_d_model_,
+                hd, 1.0f, 0.0f, stream);
 
     return true;
 }

--- a/src/vision/vision_encoder.h
+++ b/src/vision/vision_encoder.h
@@ -38,6 +38,9 @@ private:
     half* d_attn_scores_ = nullptr;  // [num_heads, num_patches, num_patches]
     half* d_ffn_ = nullptr;          // [num_patches, intermediate_size]
     half* d_pooled_ = nullptr;       // [num_image_tokens, hidden_size]
+    half* d_gate_ = nullptr;         // [num_patches, intermediate_size] (gemma4v GeGLU gate)
+    int* d_pos_x_ = nullptr;         // [num_patches] axial column index (gemma4v)
+    int* d_pos_y_ = nullptr;         // [num_patches] axial row index (gemma4v)
 
     // CUDA graph for the full encoder forward. Topology is fixed once model
     // and workspace sizes are known; only the input/output pointers change
@@ -48,6 +51,7 @@ private:
     half* graph_d_output_ = nullptr;
 
     bool encode_impl(const half* d_pixels, half* d_output, cudaStream_t stream);
+    bool encode_impl_gemma4v(const half* d_pixels, half* d_output, cudaStream_t stream);
 
     void free_buffers();
 };

--- a/src/vision/vision_loader.cpp
+++ b/src/vision/vision_loader.cpp
@@ -449,6 +449,39 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
         cfg.image_size, cfg.patch_size, cfg.hidden_size, cfg.num_heads, cfg.num_layers, cfg.num_patches,
         cfg.num_image_tokens);
 
+    // Detect projector type. gemma4v is a structurally different encoder
+    // (RMSNorm blocks, per-head q/k/v norm, 2D axial NEOX RoPE, sandwich
+    // post-norms, GeGLU FFN, scale-1 attention) — configure it here; the encoder
+    // branches on cfg.is_gemma4v. See docs/vision_gemma4v_spec.md.
+    {
+        std::string projector;
+        auto it = metadata.find("clip.projector_type");
+        if (it == metadata.end())
+            it = metadata.find("clip.vision.projector_type");
+        if (it != metadata.end())
+            projector = it->second.str_val;
+        if (projector == "gemma4v") {
+            cfg.is_gemma4v = true;
+            cfg.n_merge = 3;
+            cfg.rope_theta = 100.0f;
+            // Use a budget-valid square (768² = 589824 px, within gemma4v's
+            // 252..280 token band at 48px alignment) so the existing square
+            // preprocessing yields a 48x48 patch grid → 16x16 = 256 tokens.
+            cfg.image_size = 768;
+            int side = cfg.image_size / cfg.patch_size;  // 48
+            cfg.num_patches = side * side;
+            int merged = side / cfg.n_merge;  // 16
+            cfg.num_image_tokens = merged * merged;
+            // gemma4v wants pixels in [-1,1] = 2*(px/255)-1; fold into mean/std=0.5.
+            for (int c = 0; c < 3; c++) {
+                cfg.image_mean[c] = 0.5f;
+                cfg.image_std[c] = 0.5f;
+            }
+            IMP_LOG_INFO("Vision: gemma4v encoder (768px, grid=%d, n_merge=3, tokens=%d, rope_theta=100)",
+                         side, cfg.num_image_tokens);
+        }
+    }
+
     // 7. Allocate layers
     model->layers.resize(cfg.num_layers);
 
@@ -467,18 +500,36 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
         for (uint32_t d = 0; d < info.n_dims; d++)
             shape[d] = info.dims[info.n_dims - 1 - d];
 
-        // Gemma-3 multimodal projector (clip.projector_type = gemma3): stored as
-        // [ne0=out, ne1=in], the transpose of vision_gemm's [N=out, K=in] contract.
-        // Upload transposed and record [out, in] so mm_proj_w drives lm_d_model.
+        // Multimodal projector (mm.input_projection.weight): vision_gemm wants
+        // B=[N=out, K=in] (contiguous along in=hidden). Orientation differs by
+        // export: Gemma-3 stores [ne0=out, ne1=in] (transpose needed), while the
+        // LLaVA-style convention stores [ne0=in, ne1=out] (already correct).
+        // Pick by which dim equals the SigLIP hidden size, then record [out, in]
+        // so mm_proj_w drives lm_d_model.
         if (info.name == "mm.input_projection.weight" && info.n_dims == 2) {
-            int64_t out_dim = info.dims[0];  // ne0 = LLM d_model
-            int64_t in_dim = info.dims[1];   // ne1 = SigLIP hidden
+            int64_t ne0 = info.dims[0];
+            int64_t ne1 = info.dims[1];
             void* dp = nullptr;
-            if (!upload_tensor_fp16_transposed(tensor_data, info.type, in_dim, out_dim, &dp,
-                                               model->gpu_allocs)) {
-                IMP_LOG_ERROR("Vision: failed to upload mm.input_projection.weight");
-                munmap(mmap_base, file_size);
-                return nullptr;
+            int64_t out_dim, in_dim;
+            if (ne1 == cfg.hidden_size) {
+                // ne0=out, ne1=in (gemma3): transpose into [out, in].
+                out_dim = ne0;
+                in_dim = ne1;
+                if (!upload_tensor_fp16_transposed(tensor_data, info.type, in_dim, out_dim, &dp,
+                                                   model->gpu_allocs)) {
+                    IMP_LOG_ERROR("Vision: failed to upload mm.input_projection.weight (transposed)");
+                    munmap(mmap_base, file_size);
+                    return nullptr;
+                }
+            } else {
+                // ne0=in=hidden (LLaVA convention): raw layout already matches.
+                out_dim = ne1;
+                in_dim = ne0;
+                if (!upload_tensor_fp16(tensor_data, info.type, ne0 * ne1, &dp, model->gpu_allocs)) {
+                    IMP_LOG_ERROR("Vision: failed to upload mm.input_projection.weight");
+                    munmap(mmap_base, file_size);
+                    return nullptr;
+                }
             }
             int64_t pshape[4] = {out_dim, in_dim, 1, 1};
             model->mm_proj_w = Tensor(dp, QType::F16, 2, pshape, true);
@@ -536,6 +587,14 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
             model->mm_post_norm_w = t;
             assigned++;
         }
+        // gemma4v projector-tail affine
+        else if (name == "v.std_scale") {
+            model->std_scale = t;
+            assigned++;
+        } else if (name == "v.std_bias") {
+            model->std_bias = t;
+            assigned++;
+        }
         // Layer weights: "v.blk.{i}.{field}"
         else if (name.substr(0, 6) == "v.blk.") {
             // Parse layer index
@@ -586,6 +645,17 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
                 layer.ffn_down_w = t;
             else if (field == "ffn_down.bias")
                 layer.ffn_down_b = t;
+            // gemma4v-only block tensors
+            else if (field == "attn_q_norm.weight")
+                layer.q_norm = t;
+            else if (field == "attn_k_norm.weight")
+                layer.k_norm = t;
+            else if (field == "attn_post_norm.weight")
+                layer.attn_post_norm = t;
+            else if (field == "ffn_post_norm.weight")
+                layer.ffn_post_norm = t;
+            else if (field == "ffn_gate.weight")
+                layer.ffn_gate_w = t;
             else {
                 IMP_LOG_DEBUG("Vision: unrecognized layer tensor: %s", name.c_str());
                 continue;

--- a/src/vision/vision_model.h
+++ b/src/vision/vision_model.h
@@ -15,18 +15,27 @@ struct VisionConfig {
     int head_dim = 72;           // hidden_size / num_heads
     int num_patches = 4096;      // (image_size / patch_size)^2
     int num_image_tokens = 256;  // after avg pooling
+    int n_merge = 4;             // spatial avg-pool kernel (gemma3=4, gemma4v=3)
     float image_mean[3] = {0.5f, 0.5f, 0.5f};
     float image_std[3] = {0.5f, 0.5f, 0.5f};
+    // gemma4v: a structurally different encoder (RMSNorm blocks, per-head q/k/v
+    // norm, 2D axial NEOX RoPE, sandwich post-norms, GeGLU FFN, scale-1 attn).
+    bool is_gemma4v = false;
+    float rope_theta = 0.0f;  // gemma4v vision RoPE base (100.0)
 };
 
 struct VisionLayerWeights {
-    Tensor ln1_w, ln1_b;            // pre-attention LayerNorm
+    Tensor ln1_w, ln1_b;            // pre-attention LayerNorm / RMSNorm
     Tensor wq, wk, wv;              // [hidden, hidden]
     Tensor bq, bk, bv;              // [hidden] biases
     Tensor wo, bo;                  // attention output projection + bias
-    Tensor ln2_w, ln2_b;            // pre-FFN LayerNorm
+    Tensor ln2_w, ln2_b;            // pre-FFN LayerNorm / RMSNorm
     Tensor ffn_up_w, ffn_up_b;      // [intermediate, hidden]
     Tensor ffn_down_w, ffn_down_b;  // [hidden, intermediate]
+    // gemma4v-only
+    Tensor q_norm, k_norm;                 // per-head RMSNorm weights [head_dim]
+    Tensor attn_post_norm, ffn_post_norm;  // sandwich post-norms [hidden]
+    Tensor ffn_gate_w;                     // GeGLU gate [intermediate, hidden]
 };
 
 struct VisionModel {
@@ -47,6 +56,9 @@ struct VisionModel {
     Tensor mm_proj_w;       // [d_model, hidden_size]
     Tensor mm_proj_b;       // [d_model]
     Tensor mm_post_norm_w;  // RMSNorm after projection
+
+    // gemma4v projector tail: per-channel affine before the pre-projection RMSNorm
+    Tensor std_scale, std_bias;  // [hidden_size]
 
     // Transformer layers
     std::vector<VisionLayerWeights> layers;

--- a/src/vision/vision_pipeline.cpp
+++ b/src/vision/vision_pipeline.cpp
@@ -3,6 +3,9 @@
 #include "vision/image_processor.h"
 #include "model/model.h"
 
+#include <cmath>
+#include <vector>
+
 namespace imp {
 
 VisionPipeline::~VisionPipeline() {
@@ -60,16 +63,22 @@ bool VisionPipeline::init(const std::string& mmproj_path, int lm_d_model, Model*
     Tokenizer* tok = text_model->tokenizer();
     if (tok) {
         const auto& mcfg = text_model->config();
+        // Gemma-3: <image_soft_token> / <start_of_image> / <end_of_image>.
+        // Gemma-4: <|image|> (repeated soft) / <|image> (begin) / <image|> (end).
         soft_token_id_ = tok->find_token("<image_soft_token>");
-        if (soft_token_id_ < 0) {
-            if (mcfg.vocab_size > 262144) {
-                soft_token_id_ = 262144;
-            }
+        if (soft_token_id_ < 0)
+            soft_token_id_ = tok->find_token("<|image|>");
+        if (soft_token_id_ < 0 && mcfg.vocab_size > 262144) {
+            soft_token_id_ = 262144;
         }
         boi_id_ = tok->find_token("<start_of_image>");
+        if (boi_id_ < 0)
+            boi_id_ = tok->find_token("<|image>");
         if (boi_id_ < 0 && mcfg.vocab_size > 255999)
             boi_id_ = 255999;
         eoi_id_ = tok->find_token("<end_of_image>");
+        if (eoi_id_ < 0)
+            eoi_id_ = tok->find_token("<image|>");
         if (eoi_id_ < 0 && mcfg.vocab_size > 256000)
             eoi_id_ = 256000;
         IMP_LOG_INFO("Vision tokens: soft=%d, boi=%d, eoi=%d", soft_token_id_, boi_id_, eoi_id_);


### PR DESCRIPTION
Follow-up to #489 (Gemma-3 mmproj projector fix). #489's auto-merge fired before these commits landed, so they're re-targeted here off main.

## 1. Orientation-aware projector transpose
#489 transposed `mm.input_projection` **unconditionally** (correct for Gemma-3's `[out,in]` GGUF layout). This makes it transpose **only when `ne1==hidden`**, so standard `[in,out]` projectors (Gemma-4, LLaVA) load without corruption.

## 2. Full Gemma-4 vision (`projector_type=gemma4v`)
A structurally different encoder from Gemma-3's SigLIP — implemented as a separate `encode_impl_gemma4v` path:

- **RMSNorm** blocks (not LayerNorm), **per-head q/k/v RMSNorm**, **2D axial NEOX RoPE** (θ=100, head_dim split by pos_x/pos_y), Gemma **sandwich post-norms** (`attn_post_norm`/`ffn_post_norm` before residual), **GeGLU** FFN, **scale-1** attention (q/k-norm controls magnitude).
- Axial learned position tables, avg-pool(n_merge=3) → ×√D → `(x−std_bias)·std_scale` → pre-projection RMSNorm → linear projector.
- 768px square preprocessing → 48×48 grid → 256 image tokens; input normalized to [-1,1].
- New kernels: per-head/weightless RMSNorm, 2D NEOX RoPE, axial pos add, GeGLU multiply, and a **fused FP32 projector tail**.
- Loader parses gemma4v block tensors (`attn_q/k_norm`, `attn/ffn_post_norm`, `ffn_gate`) + `v.std_scale`/`v.std_bias`.
- Injection: resolve Gemma-4 image tokens (`<|image>` begin / `<|image|>` repeated soft / `<image|>` end) in `chat_template` + `vision_pipeline`.

### Key bug (systematic-debugging)
Output was `<pad>` — the encoder produced exactly **7 fully-NaN tokens**. Found via per-stage NaN instrumentation: Gemma vision activations reach **absmax ~3000**, and the **×√D pooler scale overflows FP16** (2926×34 ≈ 99000 > 65504 → inf), then RMSNorm does `inf×0 = NaN`. The 27 layers survive FP16; only the tail overflows. **Fix = fused FP32 projector tail** (`gemma4v_tail_norm_kernel`): the large ×√D intermediate stays in FP32 registers, only the RMS-normalized result is written FP16. NaN 19712 → 0. (FP16 GEMM accumulation was ruled out — FP32 GEMM alone left the 7 NaN unchanged.)

## Verification
`gemma-4-26B-A4B-it Q4_K_M` + mmproj, greedy:
- cat → *"brown and black tabby cat"*
- pizza → *"tomato sauce, melted cheese, basil"*

Gemma-3 regression-clean (still describes images correctly). `make verify-fast` OK. Spec: `docs/vision_gemma4v_spec.md`.

Note: gemma-4-26B Q8_0 OOMs on 32 GB with vision overhead — use Q4_K_M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)