### PR TITLE
feat(server,agent): agent-readiness batch — streaming, tools, metrics, determinism, constraints, limits

### DIFF
--- a/docs/audit/performance_agent_readiness_2026_05_31.md
+++ b/docs/audit/performance_agent_readiness_2026_05_31.md
@@ -214,7 +214,41 @@ ist Prefill-GEMM/Attention-Effizienz, nicht der Routing-/Dequant-Pfad.
 8 Code-Tasks (T1,3,4,5,6,7,8,9) implementiert + **Docker-Build grün** (CUDA 13.3), Unit 37/37, GPU-Tests
 73 passed/0 failed. Decode-Moat-Check: neues Binary tg256=253.0 vs build-ciq 256.9 (−1.5 %, im Rauschen) —
 **decode-neutral** ✓. Determinismus-Flag (T4) verifiziert: `runtime.deterministic=true` liefert bit-identische
-Tokens über Läufe (Qwen3-Coder, temp=0). Output kohärent, keine Degeneration.
+Tokens über Läufe (Qwen3-Coder, temp=0). Output kohärent, keine Degeneration. Commit `09335dd3`.
+
+Live-Server-Smoke-Tests (neues Binary, Qwen3-8B-NVFP4):
+
+| Task | Ergebnis |
+|---|---|
+| T1 /v1/messages Streaming | ✓ echte inkrementelle SSE (message_start→content_block_delta…) |
+| T3 Tool-Calling | ✓ `{"city":"Berlin"}`, finish_reason=tool_calls; Arg-Validierung aktiv |
+| T5 Metrics | ✓ `imp_request_duration_seconds`/`imp_ttft_seconds`-Histogramme |
+| T9 Input-Limit | ✓ langer Prompt → HTTP 400 "Prompt exceeds max input tokens (189 > 50)"; kurzer → 200 |
+| T7 Constrained | json_object ✓, json_schema-Struktur ✓; **`pattern`-Regex-Masking deaktiviert** (NFA über-maskierte → `!!!!`; geparst aber nicht erzwungen) |
+| T8 thinking-Blocks | Mapping implementiert; feuert nur bei separiertem `reasoning_content` (`--reasoning-format`) — Default-Smoke nicht bestätigt |
+| T6 Tool-Deltas | implementiert; Streaming bestätigt |
+
+Offene Follow-ups: T7 NFA-Over-Masking fixen + GrammarConstrainer in `executor.cu` verdrahten; T8 mit reasoning-format bestätigen.
+
+### T10 (ncu-Roofline der Top-Prefill-Kernels) — gemessen [P]
+ncu (Host `/opt/nvidia/nsight-compute/2026.2.0/ncu`), Qwen3-Coder-NVFP4, graphs off, je 6 Mid-Network-Instanzen:
+
+| Kernel | DRAM% (1792 GB/s) | SM% | Occupancy | Klassifikation |
+|---|---|---|---|---|
+| NVFP4 grouped GEMM (MoE-Expert, mxf4nvf4 FP4-TC, Tile 128³, grid=170) | **59 %** | **34 %** | **24 %** | latency/wave-quantization-bound — **kein Roofline, Compute-Headroom** |
+| FA2 (`fmha_sm120_fa2_kernel<128>`, FP16, grid=128) | 3.4 % | 36 % | 16.8 % | latency/occupancy-bound — kein Roofline |
+
+`smsp__...tensor_op_mma`-Counter sind auf sm_120 nicht exponiert; FP4-/FP16-TC-Nutzung via Kernel-Symbol bestätigt.
+
+### T12 (Small-M grouped-GEMM-Tuning) — Befund + Empfehlung [P]
+Die ncu-Daten bestätigen: der grouped GEMM ist **NICHT compute- oder bandbreiten-limitiert**, sondern
+**single-wave + small-M-per-Expert** (2009 Tokens / 128 Experten → winziges M_e) bei nur 24 % Occupancy.
+Lebende Hebel: (a) persistent/stream-K-Grid statt 170-Block-Single-Wave, (b) besseres Token-Packing zur
+Anhebung von M_e, (c) occupancy-erhöhende Tile-Wahl. **Aber:** deckt sich mit `nvfp4_moe_prefill_landscape`
+("hand-rolled NVFP4 grouped = par bei großem M_e, **−50-55 % bei small M_e**") und mit T11 (vLLMs batched
+Prefill-GEMMs gewinnen). Substanzieller, zoo-weit zu validierender CUTLASS-/Kernel-Aufwand → **kein
+Session-Scope-Merge**; konkreter nächster Schritt: CUTLASS-Sm120-grouped-Scheduler auf persistent/stream-K
+umstellen und M_e-Packing messen, gegen das Decode-Gate absichern.
 
 ## Offene Fragen / fehlende Messungen
 

--- a/docs/audit/performance_agent_readiness_2026_05_31.md
+++ b/docs/audit/performance_agent_readiness_2026_05_31.md
@@ -1,0 +1,228 @@
+# imp — Audit: Performance & Agent-Readiness (2026-05-31)
+
+Read-only Audit. Keine Code-Änderung. Belege: **[M]** = frisch gemessen (diese Session),
+**[P]** = profilbelegt (nsys diese Session oder dokumentiertes ncu/nsys), **[C]** = Code-Stelle, **[H]** = Hypothese.
+
+Mess-Setup: Host RTX 5090 (sm_120), CUDA 13.3, Binary `build-ciq/imp-cli` (29.05., CompileIQ-ACF-Build —
+absolute Zahlen ±ein paar %, die qualitativen Schlüsse sind robust). `CUBLAS_WORKSPACE_CONFIG=:4096:8`.
+
+---
+
+## Executive Summary
+
+1. **Die zentrale Audit-Prämisse ist veraltet.** "MoE-Prefill ~1258 tok/s, 20× hinter vLLM" stimmt nicht mehr.
+   Frisch gemessen liefert Qwen3-Coder-30B-A3B-NVFP4 **16.5–18.2k tok/s Prefill** (pp512–pp4096). Der "1258"-Wert
+   stammt aus `archive/vllm_comparison_2026_05_10.md` (pp512, **vor** dem CUTLASS-3.x-grouped-GEMM-Umbau, alter
+   `NVFP4→FP16-dequant + cuBLAS-grouped`-Pfad). Dieser wurde mit ~42× abgelöst; der **reale Rest-Gap zu vLLM ist
+   ~1.15–1.42×**, nicht 20×. Das größte einzelne Prefill-Optimierungsziel aus dem Briefing existiert so nicht mehr.
+2. **Der echte NVFP4-Prefill-Hebel ist die Attention, nicht der grouped GEMM.** Der MoE-Expert-GEMM läuft fused
+   (Dequant in der MMA) und ist nahe Roofline. Der adressierbare Rest ist der teil-materialisierte Attention-Pfad
+   (FA2 greift nur teilweise).
+3. **Agent-Backend ist überraschend reif.** Serving (continuous batching, prefix-cache, paged-KV, cancellation,
+   rate-limit, Prometheus) ist weitgehend produktionsreif. Constrained Output **funktioniert** (entgegen erster
+   Vermutung — `apply_mask` ist im Sampling verdrahtet). Echte Lücken: synthetisches `/v1/messages`-Streaming,
+   kein Per-Request-Spec-Decode, Determinismus-Vorbehalt bei MoE, kein Prompt-Caching-Header.
+
+---
+
+# Teil A — Performance
+
+## A.0 Verifikation der Prämisse (frische Messung)
+
+Qwen3-Coder-30B-A3B-Instruct-FP4, 3 reps, Default-Pfad (`executor_forward_moe_cutlass.cu:112` device-args):
+
+| Metrik | pp512 | pp2048 | pp4096 | decode tg256 |
+|---|---|---|---|---|
+| tok/s **[M]** | 16.535 | 17.206 | 18.229 | 290–295 |
+
+- Fallback-Pfad `IMP_NVFP4_DEVICE_ARGS=0` (host-args CUTLASS 3.x): pp2048 = **12.815 tok/s [M]** — auch das ist
+  nicht 1258. Der echte ~77-tok/s-Wert ist der *legacy serielle* Pfad, längst tot (`executor_forward_moe_cutlass.cu:306`:
+  "Prefill n=120: ~2750 vs legacy ~77 — 35× win").
+- Decode-Moat bestätigt: tg256 ≈ 290 tok/s mit Graphs (höher als die im Briefing genannten 200). **[M]**
+- vLLM-Vergleichszahl 25.513 ist die einzige nicht selbst-verifizierte Größe; selbst gegen sie ist imp ~0.65–0.72×.
+
+## A.1 Prefill-Kernel-Breakdown (nsys, prefill-isoliert, Graphs off)
+
+Profil: ~2800-Token-Prompt + `--max-tokens 1` (isoliert Prefill). **Wichtiger Fallstrick zuerst:**
+
+- `convert_scales_sfatom_kernel` erscheint mit **21.7 %** — aber mit **identisch 37.249 Instanzen / ~47 ms in
+  *beiden* Läufen** (1 vs. 256 Decode-Steps). Das ist **einmalige Cache-Bau-Arbeit beim Modell-Laden**, kein
+  Per-Prefill-Kostenpunkt. Im Server (einmal laden) amortisiert → **nicht jagen** (deckt sich mit
+  `docs/decode-gap-analysis-2026-05-29.md:14`). **[P]**
+
+Bereinigter Per-Prefill-Mix (NVFP4 MoE):
+
+| Kernel | Anteil | Klasse | Beleg |
+|---|---|---|---|
+| CUTLASS NVFP4 grouped GEMM (`GroupProblemShape`) | ~19 % | Expert-FFN, ~Roofline | [P] nsys |
+| `fmha_sm120_fa2_kernel<128>` | ~13 % | FA2-Attention (greift partiell) | [P] nsys |
+| `causal_softmax_fp32_to_fp16` + nvjet-cuBLAS-MMAs | ~18 % | **materialisierte Attention (Nicht-FA2)** | [P] nsys |
+| MoE quant/scatter/permute/gating/scale | je ~1 % | Routing-Overhead, klein | [P] nsys |
+
+**Befund:** FA2 (`fmha_sm120_fa2_kernel`) *und* der alte materialisierte Pfad (`causal_softmax_fp32_to_fp16` + cuBLAS
+QK^T/PV) laufen gleichzeitig → Attention ist nur teilweise auf FA2. Das deckt sich mit der dokumentierten
+NVFP4-pp2048-Analyse: "CUTLASS NVFP4 GEMM 39 % (competitive w/ vLLM) + Attention ~37 %"
+(`docs/MISSION_JOURNAL.md:314`) und dem Roofline-Detail "FFN-Shapes ~100 % FP4-Roofline, Attention-Shapes ~34 %"
+(`docs/plans/nvfp4_pp2048_analysis_2026_05_25.md:35`).
+
+## A.2 Dequant fused vs. separater Pass — Hypothese aus dem Briefing geklärt
+
+- **NVFP4-MoE-Prefill: Dequant ist FUSED** in die block-scaled MMA (`mma.sync ...kind::mxf4nvf4.block_scale...m16n8k64`,
+  `src/compute/gemm_grouped_nvfp4_smallM.cu:81`; Pfad `executor_forward_moe_cutlass.cu:32-295`). Kein separater
+  FP16-Pass. Die Briefing-Arbeitshypothese ("grouped-GEMM Dequant-Pfad als Ursache") trifft auf NVFP4 **nicht** zu. **[C]**
+- **GGUF-Q4_K-MoE-Prefill: Dequant IST ein separater Pass** (`dequant_gpu()` → FP16 → `gemm_moe_batched()`,
+  4.55 B/elem vs. llama.cpp MMQ 0.55 B/elem = 8.3× Bandbreiten-Overhead, `docs/plans/q4k_prefill_analysis_2026_05_25.md:20-31`).
+  Das ist der reale "separate dequant"-Schmerz — aber bei GGUF, das laut Projekt-Policy *Legacy* ist (NVFP4 ist Priorität).
+- Fallback `try_run_moe_nvfp4_dequant_batch_prefill_` (`executor_forward_moe_batch.cu:54`) macht separaten Dequant
+  (Variable `slow_down_act`, Z.116) — feuert nur, wenn die device-args-Vorbedingungen fehlen. **[C]**
+
+## A.3 CUDA-13.2/13.3-Features — Einbaubarkeit
+
+| Feature | Anwendbar? | Wo / Effekt | Beleg |
+|---|---|---|---|
+| `cublasLtMatmulGrouped` NVFP4 device-shapes | **Nein** | 0 grouped-Algos auf sm_120 bis cuBLAS 13.4 (nur CC 10.x/11.0) | `docs/sm120.md:86`, `archive/cublas_13_4_sm120_no_movement_2026_05_09.md` [C] |
+| `cub::DeviceTopK` (Expert-Routing/Sampling) | **Prüfen [H]** | Aktuell `topk_gating_kernel` (1 Block/Token) — im Prefill nur ~1 %, im Decode/Sampling evtl. mehr. Kein vorheriger Test dokumentiert. | nsys [P] |
+| Grouped GEMM + CUDA Graphs | teilweise blockiert | CUTLASS `MoEProblemShape` trägt `IsMoEScheduler=false`-Stub für sm120; Capture-Hang unter `CaptureModeGlobal` | `archive/moe_prefill_graph_capture_analysis_2026_05_10.md`, `prefill_graph_blockers_2026_05_14.md` [C] |
+| CUDA 13.2→13.3 Instruktionen | kein Gewinn | 0 von 247 sm_120a-Instruktionen geflippt | `docs/MISSION_JOURNAL.md:413` [C] |
+
+## A.4 CUDA Graphs / Scheduling — Prämisse "nur Decode" widerlegt
+
+- **Prefill IST graphifiziert** (default `runtime.prefill_graph=true`). Effekt frisch messbar: pp2048 17.206 (Graph)
+  vs. 14.787 (Graph off) = **~+16 % [M]**. Die Briefing-Frage "werden Graphs nur im Decode genutzt?" → nein.
+- Offen: Graphs für Nicht-Fast-Path-MoE-Decode (GGUF) bleiben blockiert (D2H-Expert-Routing, `docs/sm120.md:79`).
+
+## A.5 Priorisierte Befundtabelle (Teil A)
+
+| # | Befund | Beleg | Erwarteter Speedup | Aufwand | Decode-Risiko | Adressiert MoE-Prefill-Lücke? |
+|---|---|---|---|---|---|---|
+| A1 | **FA2-Abdeckung im Prefill erhöhen** — materialisierter `causal_softmax`+cuBLAS-QK^T/PV-Pfad läuft parallel zu FA2; vollständige FA2-Umstellung über mehr Seq-Längen/Head-Dims | [P] nsys (~18 % Nicht-FA2-Attention) + [C] `attention.fmha_*` | pp +10–20 % (long-ctx) | M | mittel (Attention ändert sich; FA2 ist parity-getestet) | Ja (Haupt-Hebel NVFP4) |
+| A2 | **GGUF-Q4_K-MoE-Prefill: in-SMEM-MMQ statt dequant→cuBLAS** | [C] 8.3× BW-Overhead, doku-belegt | pp +30–50 % GGUF | XL (2–3 Wo) | niedrig | nur GGUF (Legacy-Prio) |
+| A3 | **Kleine-M grouped-GEMM-Effizienz** — Attention-Shapes ~34 % Roofline bei small-M; Tile/Scheduler-Tuning | [P] doku-Roofline | pp +5–10 % | L | mittel | teilweise |
+| A4 | `convert_scales_sfatom` als Init **nicht** als Prefill-Kosten behandeln (Anti-Befund) | [P] identische Instanzzahl | 0 (Klarstellung) | — | — | nein |
+| A5 | `cub::DeviceTopK` für Routing/Sampling evaluieren | [H] | gering (Routing ~1 % Prefill) | S (Messung) | niedrig | nein |
+| A6 | Grouped-GEMM-CUDA-Graph-Capture entblocken (`IsMoEScheduler`) | [C] | pp +10–15 % | XL | mittel | teilweise |
+
+> **Markiert als MoE-Prefill-Lücke:** A1 ist der mit Abstand beste Hebel — die Lücke ist *Attention*, nicht der
+> grouped GEMM. Der grouped GEMM ist bereits nahe Roofline und fused.
+
+---
+
+# Teil B — Agent-Betrieb
+
+Status pro Achse. **Korrektur vorab:** Der erste Sub-Audit meldete Constrained Output als "toten Code"
+(`apply_mask` nie aufgerufen). **Das ist falsch** — selbst verifiziert: `apply_mask()` wird im Sampling an
+`src/exec/executor.cu:122/124, 220/222, 360/362` aufgerufen (drei Sampling-Pfade), FSM-Fortschritt via
+`constraint_manager.cpp:167`. Constrained Output ist funktional.
+
+| # | Achse | Status | Code-Beleg | Agent-Impact | Aufwand |
+|---|---|---|---|---|---|
+| 1 | **Structured/Constrained Output** | **funktioniert (Core)** | FSM `json_constrain.cu`/`schema_constrain.cu`; Maske im Sampling `executor.cu:122-362`; Server `handlers.cpp:731` (`response_format`) | kritisch | — |
+| 1b | … Regex/`pattern` + GBNF-Grammar | **fehlt** | kein `pattern`-Parsing in `json_schema.h`; kein GBNF-Compiler | wichtig | M |
+| 1c | … Masking-Overhead | unbelegt | kein Benchmark/Kommentar | nice | S (messen) |
+| 2 | **Tool Calling** (Definition, tool_choice auto/required/named, Dialekte) | **teilweise→vollständig** | `tool_call.cpp:6-150`, `chat_template.cpp:1093`; Vektor-Return `tool_call.cpp:142` (Mehrfach-Parsing vorhanden) | kritisch | — |
+| 2b | … Streaming von Tool-Call-Deltas | **fehlt** | Streaming-Pfad segmentiert Tool-Args nicht | wichtig | M |
+| 2c | … Argument-Validierung gegen input_schema | **fehlt** | lenientes `json::parse`, keine Schema-Prüfung | wichtig (Halluzination) | M (FSM aus 1 wiederverwenden) |
+| 3 | **Anthropic `/v1/messages`** (Blocks, tool_use/result, stop_reason, multi-block) | **vollständig** | `anthropic.cpp:19-394`, Handler `handlers.cpp:3449` | kritisch | — |
+| 3b | … **Streaming** | **synthetisch** | `handlers.cpp:3572` "Phase 2 synthetic" — volle Generierung dann SSE-Replay → TTFT = volle Latenz | **kritisch für Agents** | M |
+| 3c | … `thinking`-Blocks | **fehlt** | `anthropic.cpp:102` — reasoning verworfen | wichtig | S |
+| 3d | … prompt-caching-Header (`cache_control`) | **fehlt** | kein Parsing/Tracking | wichtig | M |
+| — | OpenAI `/v1/chat/completions`-Streaming | **echt** | `pop_token`-Loop `handlers.cpp:1371/1759/2762/2932` | — | — |
+| 4 | **Prefix/Prompt-Caching über Turns** | **vollständig** | content-addressed `kv_cache_manager.h:70-283`, Scheduler-Reuse `scheduler.cpp:70`, LRU-Eviction, Metrik `imp_tokens_cached_total` | kritisch | — |
+| 5 | **KV-Cache lange Loops** | **vollständig** | paged block_size=16 `kv_cache.h:12`; StreamingLLM `kv_cache_manager.h:124`; FP8/INT8/NVFP4-KV | wichtig | — |
+| 6 | **Reliability** (cancel/timeout/OOM) | **vollständig** | cancel `batching_engine.cpp:93`; timeout `handlers.cpp:1360`; OOM-try/catch `batching_engine.cpp:108`; KV-exhaustion early-cancel `scheduler.cpp:48` | kritisch | — |
+| 7 | **Concurrency/Scheduling** | **vollständig (in-flight batching)** | continuous batching `scheduler.cpp:17-126`, SJF gegen HoL `scheduler.cpp:27`; single-worker (kein Thread-Parallelismus) | kritisch | — |
+| 7b | … p50/p99-Latenz | **teilweise** | nur Single-Gauges `handlers.h:61` (kein Histogramm) | wichtig | S |
+| 7b' | … Aggregat-Durchsatz skaliert kaum mit N | [doku] | ~130 tok/s flat (`server_batching_throughput_ceiling`) | wichtig (Single-User-5090: evtl. Non-Goal) | L |
+| 8 | **Speculative Decoding (MTP)** | **teilweise — nicht im Serving** | Head+Forward da (`mtp_forward.cu`), Engine-API `engine.h:142`; **kein Per-Request-Flag**, Draft-Verify-Loop nicht im Decode verdrahtet | wichtig | L (zudem K=1-Acceptance ~25-30 %, [[mtp_diagnosis]]) |
+| 9 | **Determinismus** | **teilweise / Vorbehalt** | greedy argmax deterministisch `sampling.cu:41`; **MoE-Routing + top-k via atomics → nicht reproduzierbar** (`moe_routing.cu`); Qwen3.6-35B doku-belegt non-det @temp0 | wichtig (Eval/Test) | M |
+| 10 | **Observability** | **vollständig (bis auf Histogramm)** | Prometheus `/metrics` `handlers.cpp:3154`; logprobs `request.h:72`; queue_depth; per-Request JSONL | wichtig | — |
+| 11 | **Session/State** | **stateless** (Prefix-Pin als Ersatz) | `handlers.cpp:2426`; `pin_prefix` `kv_cache_manager.h:99`; kein Session-Store | nice | M |
+| 12 | **Multi-Model-Serving** | **fehlt/teilweise** | 1 Modell/Instanz; Reload-POST deferred `handlers.cpp:267` | wichtig (Tool-Router-Modell) | L |
+| 13 | **Container-Manager/Sandbox** | **fehlt komplett** | keine exec/sandbox/docker-socket-Infrastruktur; "tools" = nur Output-Formatierung | kritisch f. autonome Tool-Exec | XL |
+| 14 | **Security/Limits** | **vollständig** | API-Key konstant-Zeit `main.cpp:138`; per-IP rate-limit `handlers.h:108`; payload-cap 100 MiB `main.cpp:76`; max-concurrent 429 `main.cpp:113`; timeout 300s | wichtig | — |
+| 14b | … Input-Token-Längen-Limit | **fehlt** | keine Token-Count-Validierung vor Prefill | nice | S |
+
+---
+
+# Schlussteil
+
+## Top-5-Maßnahmen (Impact/Aufwand)
+
+1. **`/v1/messages` echtes Token-Streaming** (B-3b). Synthetisches Streaming bedeutet TTFT = volle Generierung —
+   für interaktive Agent-Loops gegen den Anthropic-Endpoint ein harter Nachteil. OpenAI-Pfad streamt bereits echt,
+   das Muster ist also vorhanden. *Aufwand M, Impact kritisch.*
+2. **FA2-Abdeckung im Prefill vervollständigen** (A1). Der einzige große, decode-neutrale Prefill-Hebel; Attention,
+   nicht grouped GEMM, ist die Rest-Lücke zu vLLM. FA2 ist parity-getestet. *Aufwand M, Impact hoch.*
+3. **Tool-Argument-Validierung gegen `input_schema`** (B-2c) — die vorhandene Schema-FSM (B-1) auf Tool-Call-Bodies
+   anwenden. Verhindert halluzinierte/kaputte Tool-Argumente, der häufigste Agent-Loop-Bruch. *Aufwand M (Reuse).*
+4. **Determinismus-Schalter** (B-9): optionaler atomic-freier Routing-/Top-k-Pfad für `temperature=0`, für
+   reproduzierbare Agent-Evals. *Aufwand M, Impact wichtig (Testbarkeit).*
+5. **p50/p99-Latenz-Histogramm + prompt-caching-Header** (B-7b, B-3d): günstige Observability/Kosten-Sichtbarkeit
+   für Multi-Agent-Last. *Aufwand S–M.*
+
+> Container-Manager/Sandbox (B-13) ist der größte fehlende Baustein für *autonome* Tool-Ausführung, aber XL und
+> eine eigene Produktentscheidung — bewusst nicht in Top-5.
+
+## Decode-Schutz (Regressions-Guards vor jeder Prefill-Optimierung)
+
+- **Gate vor jedem Merge:** `make verify-fast` gegen `tests/perf_baseline.json` (3 % Decode / 5 % Prefill).
+- **A/B nur über Decode** (`tg256`), isoliert + 60–120 s GPU-Cooldown, 10 reps, `CUBLAS_WORKSPACE_CONFIG=:4096:8`.
+  Prefill-pp variiert bis 2.6× über Container-Restarts — niemals als alleiniges Signal.
+- **Graphs ON *und* OFF** messen (Graph-Replay kann silent Fallback verstecken — `check-degeneration`-Skill).
+- **Kohärenz-Check** nach Forward-/Attention-/Routing-Änderungen (kein Repetition-Loop/Token-Stuck).
+- Baseline-Modelle für die Decode-Wand: Qwen3.6-35B-A3B-NVFP4 (Moat), Qwen3-14B-NVFP4 (dense), Qwen3-Coder-30B (MoE).
+
+## Implementierungs-Befunde (2026-05-31, Tasklist-Abarbeitung)
+
+### T2 (FA2-Abdeckung) — gemessen, kein sicherer globaler Flip [M]
+FA2 wird in `executor_attention.cu:811-817` (chunked) und `:849` (non-chunked) per
+`attention.fmha_prefill_threshold` gegated (Auto-Default = S-Matrix-VRAM-Cap+1,
+`executor_workspace_buffers.cu:267`). `causal_softmax_fp32_to_fp16` kommt aus `attention_cublas.cu`
+(materialisierter Pfad unter dem Threshold). pp512 A/B default vs FA2-always (`fmha_prefill_threshold=1`),
+decode durchweg neutral (FA2 berührt Decode nicht):
+
+| Modell | default | FA2-always | Δ |
+|---|---|---|---|
+| Qwen3-30B-A3B | 13737 | 18154 | +32% |
+| Qwen3-Coder-30B | 15742 | 17465 | +11% |
+| Qwen3.6-35B-A3B | 10469 | 10575 | +1% |
+| Qwen3-14B (dense) | 18178 | 15321 | −16% |
+| Gemma-4-26B (MoE) | 22297 | 16732 | −25% |
+
+→ Crossover ist modellabhängig; **kein decode-neutraler globaler Default-Flip möglich** (Gemma-4/dense
+regredieren → Perf-Gate). Sicherer Win heute: per-Modell `attention.fmha_prefill_threshold=1` für
+Qwen3-30B/Coder. Echte Lösung = gemessene per-(arch,seqlen)-Crossover-Heuristik (Folge-Arbeit, zoo-weit
+zu validieren). pp≥2048 nutzt FA2 bereits (Default ≈ FA2-always).
+
+### T11 (vLLM-Gegenmessung) — gemessen [M], korrigiert die Doku-Annahme
+vLLM 0.21.0 (`vllm/vllm-openai`), Qwen3-Coder-30B-A3B-NVFP4, echter FlashInfer/CUTLASS-NVFP4-Pfad
+(NICHT Marlin: `FlashInferCutlassNvFp4LinearKernel` + `FLASHINFER_CUTLASS` MoE), prefix-caching aus,
+`--max-concurrency 1`, `--random-output-len 1`, best-of-3 (WSL2-bimodal → kühlerer Modus):
+
+| Prompt-Len | vLLM prefill tok/s | imp prefill tok/s | vLLM-Vorsprung |
+|---:|---:|---:|---:|
+| 512  | ~21.200 | 16.500 | 1.28× |
+| 2048 | ~33.300 | 17.200 | 1.94× |
+| 4096 | ~29.200 | 18.200 | 1.60× |
+
+→ Die "20×"-Prämisse ist endgültig widerlegt, **aber der reale Prefill-Gap (1.3–1.9× zugunsten vLLM) ist
+GRÖSSER als die in den Memos genannten 1.15–1.42×.** vLLM gewinnt Prefill auf jeder Länge über batched
+Prefill-GEMMs; Decode wurde nicht gemessen (imp-Decode-Moat unberührt). Konsistent mit A1/A.5: der Hebel
+ist Prefill-GEMM/Attention-Effizienz, nicht der Routing-/Dequant-Pfad.
+
+### Build-/Verifikations-Status (Tasklist-Batch, Branch `feat/agent-readiness-batch`)
+8 Code-Tasks (T1,3,4,5,6,7,8,9) implementiert + **Docker-Build grün** (CUDA 13.3), Unit 37/37, GPU-Tests
+73 passed/0 failed. Decode-Moat-Check: neues Binary tg256=253.0 vs build-ciq 256.9 (−1.5 %, im Rauschen) —
+**decode-neutral** ✓. Determinismus-Flag (T4) verifiziert: `runtime.deterministic=true` liefert bit-identische
+Tokens über Läufe (Qwen3-Coder, temp=0). Output kohärent, keine Degeneration.
+
+## Offene Fragen / fehlende Messungen
+
+1. **vLLM-Gegenmessung auf dieser Box** für Qwen3-Coder-NVFP4 (pp2048/pp4096), apples-to-apples — die 25.513
+   ist die einzige nicht selbst-verifizierte Zahl; der reale Rest-Gap (~1.4×?) sollte frisch bestätigt werden.
+2. **ncu fehlt auf dem Host** (`ncu: command not found`) — für Roofline/Occupancy/Stall der Top-Prefill-Kernels
+   (FA2, grouped GEMM) muss ncu via Container gemountet werden (Recipe in [[decode_frontier_reconfirmed]]).
+3. **FA2-Threshold:** FA2 feuerte bereits bei ~2800 Tokens, aber `causal_softmax` lief parallel — warum die
+   Aufteilung? (Head-Dim ≠ 128? Chunk-Grenzen?) Klärt den genauen Umfang von A1.
+4. **`cub::DeviceTopK`** im Sampling/Routing: lohnt nur, wenn `topk_gating`/Sampling im Decode messbar Zeit kostet — ncu nötig.
+5. **MTP im Serving:** lohnt der Draft-Verify-Loop bei ~25–30 % Acceptance überhaupt? (Doku sagt: bei NVFP4 nein.)

--- a/src/compute/constrain_common.h
+++ b/src/compute/constrain_common.h
@@ -179,4 +179,19 @@ __global__ inline void constrain_mask_allow_kernel(float* __restrict__ logits,
     }
 }
 
+// ---------------------------------------------------------------------------
+// Grammar mask kernel: pure per-token allow mask (no category gating).
+// Used by GrammarConstrainer where the NFA-derived allow list is the full
+// constraint. Tokens with token_allow[idx]==0 are masked to -FLT_MAX.
+// ---------------------------------------------------------------------------
+
+__global__ inline void grammar_mask_kernel(float* __restrict__ logits,
+                                           const uint8_t* __restrict__ token_allow, int vocab_size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= vocab_size)
+        return;
+    if (token_allow[idx] == 0)
+        logits[idx] = -FLT_MAX;
+}
+
 }  // namespace imp

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -338,4 +338,92 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
                                                           vocab_size);
 }
 
+// ============================================================================
+// GrammarConstrainer implementation (Part B)
+// ============================================================================
+
+GrammarConstrainer::~GrammarConstrainer() {
+    if (d_token_allow_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_token_allow_));
+        d_token_allow_ = nullptr;
+    }
+}
+
+bool GrammarConstrainer::init(const Tokenizer& tok, std::shared_ptr<RegexNfa> grammar) {
+    if (!grammar || !grammar->compiled()) {
+        IMP_LOG_ERROR("GrammarConstrainer: null/uncompiled grammar");
+        return false;
+    }
+    grammar_ = std::move(grammar);
+    vocab_size_ = tok.vocab_size();
+    token_texts_.resize(vocab_size_);
+    token_allow_.resize(vocab_size_, 1);
+    for (int i = 0; i < vocab_size_; i++)
+        token_texts_[i] = tok.decode_token(static_cast<int32_t>(i));
+
+    cudaError_t err = cudaMalloc(&d_token_allow_, vocab_size_ * sizeof(uint8_t));
+    if (err != cudaSuccess) {
+        IMP_LOG_ERROR("GrammarConstrainer: failed to allocate allow buffer: %s", cudaGetErrorString(err));
+        return false;
+    }
+
+    reset();
+    initialized_ = true;
+    IMP_LOG_INFO("GrammarConstrainer initialized (%d tokens)", vocab_size_);
+    return true;
+}
+
+void GrammarConstrainer::reset() {
+    if (grammar_)
+        active_states_ = grammar_->start_set();
+}
+
+bool GrammarConstrainer::accepts_now() const {
+    return grammar_ && grammar_->accepts(active_states_);
+}
+
+void GrammarConstrainer::compute_token_allow_mask() {
+    for (int i = 0; i < vocab_size_; i++) {
+        const std::string& text = token_texts_[i];
+        if (text.empty()) {
+            token_allow_[i] = 0;
+            continue;
+        }
+        // A token is allowed iff feeding all its bytes keeps the NFA alive.
+        std::vector<int> st = active_states_;
+        bool alive = true;
+        for (char c : text) {
+            st = grammar_->step(st, static_cast<unsigned char>(c));
+            if (st.empty()) {
+                alive = false;
+                break;
+            }
+        }
+        token_allow_[i] = alive ? 1 : 0;
+    }
+}
+
+void GrammarConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t stream) {
+    if (!initialized_ || !grammar_)
+        return;
+
+    compute_token_allow_mask();
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, token_allow_.data(), vocab_size_ * sizeof(uint8_t),
+                                       cudaMemcpyHostToDevice, stream));
+
+    int threads = 256;
+    int blocks = (vocab_size + threads - 1) / threads;
+    // No category gating for grammar; the per-token allow mask (built from the
+    // NFA) carries the full constraint.
+    grammar_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_allow_, vocab_size);
+}
+
+void GrammarConstrainer::update(int32_t token) {
+    if (!initialized_ || token < 0 || token >= vocab_size_)
+        return;
+    const std::string& text = token_texts_[token];
+    for (char c : text)
+        active_states_ = grammar_->step(active_states_, static_cast<unsigned char>(c));
+}
+
 }  // namespace imp

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "compute/preamble_gate.h"
+#include "compute/json_schema.h"  // RegexNfa (for GrammarConstrainer)
 #include "model/tokenizer.h"
 #include <cuda_runtime.h>
 #include <vector>
 #include <cstdint>
 #include <string>
+#include <memory>
 
 namespace imp {
 
@@ -128,6 +130,47 @@ private:
 
     // Advance FSM by one character
     void advance_char(char c);
+};
+
+// ---------------------------------------------------------------------------
+// GrammarConstrainer (Part B, non-recursive GBNF subset) — drives a compiled
+// RegexNfa as a token-mask FSM. Allows a candidate token only if its bytes
+// keep the grammar NFA alive; EOS is allowed once the NFA is in an accepting
+// state. Uses the per-token allow-mask kernel from constrain_common.h.
+//
+// Wiring into the executor/sampling path is left to the owning agent (this
+// class mirrors SchemaConstrainer's apply_mask/update/reset surface so it can
+// drop in identically). compile_gbnf_grammar() lives in json_schema.h.
+// ---------------------------------------------------------------------------
+class GrammarConstrainer {
+public:
+    GrammarConstrainer() = default;
+    ~GrammarConstrainer();
+
+    // Classify tokens and attach a compiled grammar NFA. Returns false if the
+    // NFA is null/uncompiled.
+    bool init(const Tokenizer& tok, std::shared_ptr<RegexNfa> grammar);
+
+    void apply_mask(float* d_logits, int vocab_size, cudaStream_t stream);
+    void update(int32_t token);
+    void reset();
+    bool is_initialized() const { return initialized_; }
+
+    // True once the grammar NFA is in an accepting state (generation may stop).
+    bool accepts_now() const;
+
+private:
+    bool initialized_ = false;
+    int vocab_size_ = 0;
+
+    std::shared_ptr<RegexNfa> grammar_;
+    std::vector<int> active_states_;  // current NFA state set
+
+    std::vector<std::string> token_texts_;
+    std::vector<uint8_t> token_allow_;
+    uint8_t* d_token_allow_ = nullptr;
+
+    void compute_token_allow_mask();
 };
 
 }  // namespace imp

--- a/src/compute/json_schema.cpp
+++ b/src/compute/json_schema.cpp
@@ -2,6 +2,11 @@
 #include "core/logging.h"
 #include <cstring>
 #include <cctype>
+#include <cstdlib>
+#include <algorithm>
+#include <map>
+#include <set>
+#include <sstream>
 
 namespace imp {
 
@@ -97,6 +102,25 @@ private:
         if (peek() == '"')
             pos_++;
         return s;
+    }
+
+    // Parse a (possibly negative) integer literal. Returns false if none.
+    bool parse_int(long& out) {
+        skip_ws();
+        size_t start = pos_;
+        if (peek() == '-')
+            pos_++;
+        bool any = false;
+        while (!eof() && peek() >= '0' && peek() <= '9') {
+            pos_++;
+            any = true;
+        }
+        if (!any) {
+            pos_ = start;
+            return false;
+        }
+        out = std::strtol(data_ + start, nullptr, 10);
+        return true;
     }
 
     bool parse_bool() {
@@ -260,6 +284,16 @@ private:
                 }
                 if (!has_type)
                     node->type = SchemaType::OBJECT;
+            } else if (key == "pattern") {
+                node->pattern = parse_string();
+            } else if (key == "minLength") {
+                long v = 0;
+                if (parse_int(v))
+                    node->min_length = static_cast<int>(v);
+            } else if (key == "maxLength") {
+                long v = 0;
+                if (parse_int(v))
+                    node->max_length = static_cast<int>(v);
             } else if (key == "required") {
                 node->required = parse_string_array();
             } else if (key == "additionalProperties") {
@@ -324,6 +358,28 @@ private:
     }
 };
 
+// Recursively compile any `pattern` fields into NFAs. Unsupported patterns
+// leave pattern_nfa null (enforcement is then skipped for that node).
+static void compile_patterns(SchemaNode* node) {
+    if (!node)
+        return;
+    if (!node->pattern.empty() && !node->pattern_nfa) {
+        auto nfa = std::make_shared<RegexNfa>();
+        if (nfa->compile(node->pattern)) {
+            node->pattern_nfa = std::move(nfa);
+        } else {
+            IMP_LOG_WARN("JSON schema: unsupported regex pattern '%s' — pattern not enforced",
+                         node->pattern.c_str());
+        }
+    }
+    for (auto& [name, prop] : node->properties)
+        compile_patterns(prop.get());
+    if (node->items)
+        compile_patterns(node->items.get());
+    for (auto& sub : node->any_of)
+        compile_patterns(sub.get());
+}
+
 std::unique_ptr<SchemaNode> parse_json_schema(const std::string& json) {
     SchemaParser parser(json.c_str(), json.size());
     auto root = parser.parse();
@@ -331,6 +387,7 @@ std::unique_ptr<SchemaNode> parse_json_schema(const std::string& json) {
         IMP_LOG_ERROR("Failed to parse JSON schema");
         return nullptr;
     }
+    compile_patterns(root.get());
     return root;
 }
 
@@ -340,6 +397,10 @@ std::unique_ptr<SchemaNode> SchemaNode::clone() const {
     c->additional_properties = additional_properties;
     c->required = required;
     c->enum_values = enum_values;
+    c->pattern = pattern;
+    c->min_length = min_length;
+    c->max_length = max_length;
+    c->pattern_nfa = pattern_nfa;  // shared; compiled NFA is immutable
     for (auto& [name, prop] : properties)
         c->properties.emplace_back(name, prop->clone());
     if (items)
@@ -347,6 +408,804 @@ std::unique_ptr<SchemaNode> SchemaNode::clone() const {
     for (auto& sub : any_of)
         c->any_of.push_back(sub->clone());
     return c;
+}
+
+// ===========================================================================
+// RegexNfa — Thompson-construction NFA over bytes for the supported subset.
+// All host-side; never compiled into device code.
+// ===========================================================================
+
+int RegexNfa::new_state() {
+    states_.emplace_back();
+    return static_cast<int>(states_.size()) - 1;
+}
+
+void RegexNfa::add_epsilon(int from, int to) {
+    NfaEdge e;
+    e.to = to;
+    e.is_epsilon = true;
+    states_[from].edges.push_back(std::move(e));
+}
+
+void RegexNfa::add_edge(int from, int to, const std::vector<uint8_t>& cls) {
+    NfaEdge e;
+    e.to = to;
+    e.is_epsilon = false;
+    e.char_class = cls;
+    states_[from].edges.push_back(std::move(e));
+}
+
+bool RegexNfa::make_shorthand(char esc, std::vector<uint8_t>& cls) {
+    cls.assign(256, 0);
+    auto set_digit = [&](bool neg) {
+        for (int c = 0; c < 256; c++) {
+            bool d = (c >= '0' && c <= '9');
+            cls[c] = (d != neg) ? 1 : 0;
+        }
+    };
+    auto set_word = [&](bool neg) {
+        for (int c = 0; c < 256; c++) {
+            bool w = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+            cls[c] = (w != neg) ? 1 : 0;
+        }
+    };
+    auto set_space = [&](bool neg) {
+        for (int c = 0; c < 256; c++) {
+            bool s = (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v');
+            cls[c] = (s != neg) ? 1 : 0;
+        }
+    };
+    switch (esc) {
+        case 'd':
+            set_digit(false);
+            return true;
+        case 'D':
+            set_digit(true);
+            return true;
+        case 'w':
+            set_word(false);
+            return true;
+        case 'W':
+            set_word(true);
+            return true;
+        case 's':
+            set_space(false);
+            return true;
+        case 'S':
+            set_space(true);
+            return true;
+        default:
+            return false;
+    }
+}
+
+// atom := '(' alt ')' | '[' class ']' | '.' | escape | literal
+bool RegexNfa::parse_atom(Frag& out) {
+    if (pos_ >= src_->size()) {
+        error_ = true;
+        return false;
+    }
+    char c = (*src_)[pos_];
+
+    if (c == '(') {
+        pos_++;  // consume '('
+        if (!parse_alt(out))
+            return false;
+        if (pos_ >= src_->size() || (*src_)[pos_] != ')') {
+            error_ = true;
+            return false;
+        }
+        pos_++;  // consume ')'
+        return true;
+    }
+
+    if (c == '[') {
+        return parse_class(out);
+    }
+
+    if (c == ')' || c == '|') {
+        // empty atom — caller handles
+        error_ = true;
+        return false;
+    }
+
+    std::vector<uint8_t> cls(256, 0);
+
+    if (c == '.') {
+        pos_++;
+        for (int i = 0; i < 256; i++)
+            cls[i] = (i == '\n') ? 0 : 1;  // any except newline
+    } else if (c == '\\') {
+        pos_++;
+        if (pos_ >= src_->size()) {
+            error_ = true;
+            return false;
+        }
+        char esc = (*src_)[pos_++];
+        std::vector<uint8_t> sc;
+        if (make_shorthand(esc, sc)) {
+            cls = sc;
+        } else {
+            // escaped literal (\. \\ \+ \{ etc.) — also map common control escapes
+            unsigned char lit;
+            switch (esc) {
+                case 'n':
+                    lit = '\n';
+                    break;
+                case 't':
+                    lit = '\t';
+                    break;
+                case 'r':
+                    lit = '\r';
+                    break;
+                case 'f':
+                    lit = '\f';
+                    break;
+                case 'v':
+                    lit = '\v';
+                    break;
+                default:
+                    lit = static_cast<unsigned char>(esc);
+                    break;
+            }
+            cls[lit] = 1;
+        }
+    } else if (c == '^' || c == '$') {
+        // Anchors: JSON-Schema pattern matching is treated as whole-string here
+        // (token masking cannot enforce sub-string matches), so a leading ^ /
+        // trailing $ are no-ops. Emit an epsilon fragment.
+        pos_++;
+        int s = new_state();
+        int a = new_state();
+        add_epsilon(s, a);
+        out.start = s;
+        out.accept = a;
+        return true;
+    } else {
+        // literal byte
+        pos_++;
+        cls[static_cast<unsigned char>(c)] = 1;
+    }
+
+    int s = new_state();
+    int a = new_state();
+    add_edge(s, a, cls);
+    out.start = s;
+    out.accept = a;
+    return true;
+}
+
+// class := '[' '^'? ( range | shorthand | char )+ ']'
+bool RegexNfa::parse_class(Frag& out) {
+    pos_++;  // consume '['
+    bool negate = false;
+    if (pos_ < src_->size() && (*src_)[pos_] == '^') {
+        negate = true;
+        pos_++;
+    }
+    std::vector<uint8_t> cls(256, 0);
+    bool any = false;
+
+    while (pos_ < src_->size() && (*src_)[pos_] != ']') {
+        char c = (*src_)[pos_];
+        if (c == '\\') {
+            pos_++;
+            if (pos_ >= src_->size()) {
+                error_ = true;
+                return false;
+            }
+            char esc = (*src_)[pos_++];
+            std::vector<uint8_t> sc;
+            if (make_shorthand(esc, sc)) {
+                for (int i = 0; i < 256; i++)
+                    if (sc[i])
+                        cls[i] = 1;
+                any = true;
+                continue;
+            }
+            unsigned char lit;
+            switch (esc) {
+                case 'n':
+                    lit = '\n';
+                    break;
+                case 't':
+                    lit = '\t';
+                    break;
+                case 'r':
+                    lit = '\r';
+                    break;
+                default:
+                    lit = static_cast<unsigned char>(esc);
+                    break;
+            }
+            cls[lit] = 1;
+            any = true;
+            continue;
+        }
+        // range a-z ?
+        if (pos_ + 2 < src_->size() && (*src_)[pos_ + 1] == '-' && (*src_)[pos_ + 2] != ']') {
+            unsigned char lo = static_cast<unsigned char>(c);
+            unsigned char hi = static_cast<unsigned char>((*src_)[pos_ + 2]);
+            pos_ += 3;
+            if (lo > hi) {
+                error_ = true;
+                return false;
+            }
+            for (int i = lo; i <= hi; i++)
+                cls[i] = 1;
+            any = true;
+        } else {
+            cls[static_cast<unsigned char>(c)] = 1;
+            pos_++;
+            any = true;
+        }
+    }
+
+    if (pos_ >= src_->size() || (*src_)[pos_] != ']' || !any) {
+        error_ = true;
+        return false;
+    }
+    pos_++;  // consume ']'
+
+    if (negate) {
+        for (int i = 0; i < 256; i++)
+            cls[i] = cls[i] ? 0 : 1;
+    }
+
+    int s = new_state();
+    int a = new_state();
+    add_edge(s, a, cls);
+    out.start = s;
+    out.accept = a;
+    return true;
+}
+
+// repeat := atom ('*' | '+' | '?' | '{n}' | '{n,}' | '{n,m}')?
+bool RegexNfa::parse_repeat(Frag& out) {
+    // Snapshot the atom's source start here so {n,m} can re-parse the exact
+    // source span of *this* atom (parse_atom may advance pos_ arbitrarily for
+    // groups / classes).
+    size_t atom_begin = pos_;
+    Frag atom;
+    if (!parse_atom(atom))
+        return false;
+
+    if (pos_ >= src_->size())
+        return (out = atom, true);
+
+    char q = (*src_)[pos_];
+
+    if (q == '*' || q == '+' || q == '?') {
+        pos_++;
+        int s = new_state();
+        int a = new_state();
+        if (q == '*') {
+            add_epsilon(s, atom.start);
+            add_epsilon(s, a);
+            add_epsilon(atom.accept, atom.start);
+            add_epsilon(atom.accept, a);
+        } else if (q == '+') {
+            add_epsilon(s, atom.start);
+            add_epsilon(atom.accept, atom.start);
+            add_epsilon(atom.accept, a);
+        } else {  // '?'
+            add_epsilon(s, atom.start);
+            add_epsilon(s, a);
+            add_epsilon(atom.accept, a);
+        }
+        out.start = s;
+        out.accept = a;
+        return true;
+    }
+
+    if (q == '{') {
+        // {n} {n,} {n,m}
+        size_t save = pos_;
+        pos_++;  // consume '{'
+        long n = 0, m = -1;
+        auto scan_int = [&](long& out_val) -> bool {
+            long v = 0;
+            bool any = false;
+            while (pos_ < src_->size() && (*src_)[pos_] >= '0' && (*src_)[pos_] <= '9') {
+                v = v * 10 + ((*src_)[pos_] - '0');
+                pos_++;
+                any = true;
+            }
+            if (any)
+                out_val = v;
+            return any;
+        };
+        bool has_n = scan_int(n);
+        bool comma = false;
+        if (pos_ < src_->size() && (*src_)[pos_] == ',') {
+            comma = true;
+            pos_++;
+            long mm = 0;
+            if (scan_int(mm))
+                m = mm;  // {n,m}; else {n,} -> m stays -1 (unbounded)
+        }
+        if (!has_n || pos_ >= src_->size() || (*src_)[pos_] != '}') {
+            // Not a valid quantifier — treat '{' as literal: rewind.
+            pos_ = save;
+            return (out = atom, true);
+        }
+        pos_++;  // consume '}'
+        if (!comma)
+            m = n;  // {n}
+
+        // Build: n mandatory copies, then either unbounded (*) or (m-n) optional.
+        int s = new_state();
+        int cur = s;
+        // We need fresh copies of the atom sub-pattern. Re-parse its exact
+        // source span [atom_begin, save) for each additional copy. `save` is
+        // the position right after the atom (the '{').
+        std::string atom_src = src_->substr(atom_begin, save - atom_begin);
+
+        auto clone_atom = [&](Frag& f) -> bool {
+            const std::string* prev_src = src_;
+            size_t prev_pos = pos_;
+            bool prev_err = error_;
+            // Parse the captured atom text in isolation.
+            std::string local = atom_src;
+            src_ = &local;
+            pos_ = 0;
+            error_ = false;
+            bool ok = parse_repeat(f);  // atom may itself be a repeat-free atom
+            // restore
+            src_ = prev_src;
+            pos_ = prev_pos;
+            error_ = prev_err;
+            return ok && !error_;
+        };
+
+        // first mandatory copy is the already-built `atom`
+        long built = 0;
+        if (n >= 1) {
+            add_epsilon(cur, atom.start);
+            cur = atom.accept;
+            built = 1;
+        } else {
+            // n == 0: atom is optional/unbounded from the start
+        }
+
+        for (long i = built; i < n; i++) {
+            Frag f;
+            if (!clone_atom(f))
+                return false;
+            add_epsilon(cur, f.start);
+            cur = f.accept;
+        }
+
+        int a = new_state();
+        if (m < 0) {
+            // {n,} -> after n mandatory, a Kleene star of the atom
+            Frag f;
+            if (!clone_atom(f))
+                return false;
+            int ls = new_state();
+            add_epsilon(cur, ls);
+            add_epsilon(ls, f.start);
+            add_epsilon(ls, a);
+            add_epsilon(f.accept, f.start);
+            add_epsilon(f.accept, a);
+        } else {
+            // {n,m} -> (m-n) optional copies
+            for (long i = n; i < m; i++) {
+                Frag f;
+                if (!clone_atom(f))
+                    return false;
+                add_epsilon(cur, f.start);
+                add_epsilon(cur, a);  // optional: skip the rest
+                cur = f.accept;
+            }
+            add_epsilon(cur, a);
+        }
+        out.start = s;
+        out.accept = a;
+        return true;
+    }
+
+    out = atom;
+    return true;
+}
+
+// concat := repeat*
+bool RegexNfa::parse_concat(Frag& out) {
+    int s = new_state();
+    int cur = s;
+    bool any = false;
+    while (pos_ < src_->size() && (*src_)[pos_] != '|' && (*src_)[pos_] != ')') {
+        Frag f;
+        if (!parse_repeat(f))
+            return false;
+        add_epsilon(cur, f.start);
+        cur = f.accept;
+        any = true;
+    }
+    if (!any) {
+        // empty concatenation matches empty string
+        int a = new_state();
+        add_epsilon(s, a);
+        out.start = s;
+        out.accept = a;
+        return true;
+    }
+    out.start = s;
+    out.accept = cur;
+    return true;
+}
+
+// alt := concat ('|' concat)*
+bool RegexNfa::parse_alt(Frag& out) {
+    Frag first;
+    if (!parse_concat(first))
+        return false;
+    if (pos_ >= src_->size() || (*src_)[pos_] != '|') {
+        out = first;
+        return true;
+    }
+    int s = new_state();
+    int a = new_state();
+    add_epsilon(s, first.start);
+    add_epsilon(first.accept, a);
+    while (pos_ < src_->size() && (*src_)[pos_] == '|') {
+        pos_++;  // consume '|'
+        Frag next;
+        if (!parse_concat(next))
+            return false;
+        add_epsilon(s, next.start);
+        add_epsilon(next.accept, a);
+    }
+    out.start = s;
+    out.accept = a;
+    return true;
+}
+
+bool RegexNfa::compile(const std::string& pattern) {
+    states_.clear();
+    compiled_ = false;
+    error_ = false;
+    src_ = &pattern;
+    pos_ = 0;
+
+    Frag root;
+    if (!parse_alt(root)) {
+        src_ = nullptr;
+        return false;
+    }
+    // Must have consumed the whole pattern.
+    if (pos_ != pattern.size() || error_) {
+        src_ = nullptr;
+        return false;
+    }
+    src_ = nullptr;
+
+    start_ = root.start;
+    accept_ = root.accept;
+    states_[accept_].accepting = true;
+    compiled_ = true;
+    return true;
+}
+
+void RegexNfa::epsilon_closure(std::vector<int>& set) const {
+    std::vector<int> stack(set.begin(), set.end());
+    std::vector<uint8_t> in(states_.size(), 0);
+    for (int s : set)
+        in[s] = 1;
+    while (!stack.empty()) {
+        int s = stack.back();
+        stack.pop_back();
+        for (const auto& e : states_[s].edges) {
+            if (e.is_epsilon && !in[e.to]) {
+                in[e.to] = 1;
+                set.push_back(e.to);
+                stack.push_back(e.to);
+            }
+        }
+    }
+    std::sort(set.begin(), set.end());
+}
+
+std::vector<int> RegexNfa::start_set() const {
+    std::vector<int> set;
+    if (!compiled_)
+        return set;
+    set.push_back(start_);
+    epsilon_closure(set);
+    return set;
+}
+
+std::vector<int> RegexNfa::step(const std::vector<int>& states, unsigned char c) const {
+    std::vector<int> next;
+    if (!compiled_)
+        return next;
+    std::vector<uint8_t> in(states_.size(), 0);
+    for (int s : states) {
+        for (const auto& e : states_[s].edges) {
+            if (!e.is_epsilon && e.char_class[c] && !in[e.to]) {
+                in[e.to] = 1;
+                next.push_back(e.to);
+            }
+        }
+    }
+    epsilon_closure(next);
+    return next;
+}
+
+bool RegexNfa::accepts(const std::vector<int>& states) const {
+    for (int s : states)
+        if (states_[s].accepting)
+            return true;
+    return false;
+}
+
+// ===========================================================================
+// GBNF grammar -> regex-string translation (Part B, non-recursive subset).
+//
+// Strategy: parse rules into raw RHS strings, then translate the root rule's
+// RHS into an anchored regex string by inlining rule references (detecting
+// recursion). The result is fed to RegexNfa::compile, reusing the whole
+// pattern engine. This is intentionally limited to the non-recursive fragment
+// (see header). True recursion needs a pushdown/Earley machine.
+//
+// TODO(part-b): replace the NFA backend with a proper recursive grammar
+// engine (e.g. an LL/Earley state stack like llama.cpp's grammar parser) to
+// support recursive rules and {n,m} counts. Until then recursion is rejected.
+// ===========================================================================
+
+namespace {
+
+// Translate one GBNF RHS expression into a regex string, inlining references.
+// `rules` maps rule name -> RHS text. `active` tracks the inlining chain to
+// detect recursion. Returns false (sets *err) on unsupported / recursive input.
+bool gbnf_expr_to_regex(const std::string& expr, const std::map<std::string, std::string>& rules,
+                        std::set<std::string>& active, std::string& out, std::string* err);
+
+// Translate a single rule by name (with recursion detection).
+bool gbnf_rule_to_regex(const std::string& name, const std::map<std::string, std::string>& rules,
+                        std::set<std::string>& active, std::string& out, std::string* err) {
+    if (active.count(name)) {
+        *err = "recursive rule '" + name + "' is not supported by the NFA backend";
+        return false;
+    }
+    auto it = rules.find(name);
+    if (it == rules.end()) {
+        *err = "undefined rule '" + name + "'";
+        return false;
+    }
+    active.insert(name);
+    std::string sub;
+    bool ok = gbnf_expr_to_regex(it->second, rules, active, sub, err);
+    active.erase(name);
+    if (!ok)
+        return false;
+    out = "(" + sub + ")";
+    return true;
+}
+
+void append_escaped_literal_char(char c, std::string& out) {
+    // Escape regex metacharacters so a GBNF literal is matched verbatim.
+    if (std::strchr(".^$*+?()[]{}|\\", c))
+        out += '\\';
+    out += c;
+}
+
+bool gbnf_expr_to_regex(const std::string& expr, const std::map<std::string, std::string>& rules,
+                        std::set<std::string>& active, std::string& out, std::string* err) {
+    size_t i = 0;
+    const size_t n = expr.size();
+    out.clear();
+
+    auto skip_ws = [&]() {
+        while (i < n && (expr[i] == ' ' || expr[i] == '\t'))
+            i++;
+    };
+
+    while (i < n) {
+        char c = expr[i];
+        if (c == ' ' || c == '\t') {
+            i++;
+            continue;  // concatenation = adjacency in regex
+        }
+        if (c == '|') {
+            out += '|';
+            i++;
+            continue;
+        }
+        if (c == '(') {
+            // find matching ')'
+            int depth = 1;
+            size_t start = ++i;
+            while (i < n && depth > 0) {
+                if (expr[i] == '(')
+                    depth++;
+                else if (expr[i] == ')')
+                    depth--;
+                if (depth == 0)
+                    break;
+                i++;
+            }
+            if (depth != 0) {
+                *err = "unbalanced '(' in grammar";
+                return false;
+            }
+            std::string inner = expr.substr(start, i - start);
+            i++;  // consume ')'
+            std::string sub;
+            if (!gbnf_expr_to_regex(inner, rules, active, sub, err))
+                return false;
+            out += "(" + sub + ")";
+            // optional trailing quantifier
+            if (i < n && (expr[i] == '*' || expr[i] == '+' || expr[i] == '?'))
+                out += expr[i++];
+            continue;
+        }
+        if (c == '"') {
+            // literal string
+            i++;
+            std::string lit;
+            while (i < n && expr[i] != '"') {
+                if (expr[i] == '\\' && i + 1 < n) {
+                    i++;
+                    char e = expr[i++];
+                    switch (e) {
+                        case 'n':
+                            lit += '\n';
+                            break;
+                        case 't':
+                            lit += '\t';
+                            break;
+                        case 'r':
+                            lit += '\r';
+                            break;
+                        case '"':
+                            lit += '"';
+                            break;
+                        case '\\':
+                            lit += '\\';
+                            break;
+                        default:
+                            lit += e;
+                            break;
+                    }
+                } else {
+                    lit += expr[i++];
+                }
+            }
+            if (i >= n) {
+                *err = "unterminated string literal in grammar";
+                return false;
+            }
+            i++;  // consume closing quote
+            std::string esc;
+            for (char lc : lit)
+                append_escaped_literal_char(lc, esc);
+            out += "(" + esc + ")";
+            if (i < n && (expr[i] == '*' || expr[i] == '+' || expr[i] == '?'))
+                out += expr[i++];
+            continue;
+        }
+        if (c == '[') {
+            // char class — pass through verbatim to RegexNfa (it shares syntax)
+            size_t start = i++;
+            while (i < n && expr[i] != ']') {
+                if (expr[i] == '\\')
+                    i++;  // skip escaped char
+                i++;
+            }
+            if (i >= n) {
+                *err = "unterminated character class in grammar";
+                return false;
+            }
+            i++;  // consume ']'
+            out += expr.substr(start, i - start);
+            if (i < n && (expr[i] == '*' || expr[i] == '+' || expr[i] == '?'))
+                out += expr[i++];
+            continue;
+        }
+        if (std::isalpha(static_cast<unsigned char>(c)) || c == '_' || c == '-') {
+            // rule reference
+            size_t start = i;
+            while (i < n && (std::isalnum(static_cast<unsigned char>(expr[i])) || expr[i] == '_' ||
+                             expr[i] == '-'))
+                i++;
+            std::string name = expr.substr(start, i - start);
+            std::string sub;
+            if (!gbnf_rule_to_regex(name, rules, active, sub, err))
+                return false;
+            out += sub;
+            if (i < n && (expr[i] == '*' || expr[i] == '+' || expr[i] == '?'))
+                out += expr[i++];
+            continue;
+        }
+        if (c == '{') {
+            *err = "{n,m} repetition in grammar is not supported";
+            return false;
+        }
+        // Unknown / unsupported token.
+        *err = std::string("unsupported grammar token '") + c + "'";
+        return false;
+    }
+    (void)skip_ws;
+    return true;
+}
+
+}  // namespace
+
+std::shared_ptr<RegexNfa> compile_gbnf_grammar(const std::string& gbnf) {
+    // 1) Tokenize into rule definitions: `name ::= rhs` (one logical rule per
+    //    `name ::=`; RHS may span the rest of the line). Comments start with #.
+    std::map<std::string, std::string> rules;
+    std::istringstream in(gbnf);
+    std::string line;
+    std::string cur_name;
+    std::string cur_rhs;
+    auto flush = [&]() {
+        if (!cur_name.empty())
+            rules[cur_name] = cur_rhs;
+        cur_name.clear();
+        cur_rhs.clear();
+    };
+    while (std::getline(in, line)) {
+        // strip comments
+        size_t hash = line.find('#');
+        if (hash != std::string::npos)
+            line = line.substr(0, hash);
+        // does this line start a new rule? look for "::="
+        size_t assign = line.find("::=");
+        // detect a leading "name ::=" pattern
+        size_t name_end = std::string::npos;
+        if (assign != std::string::npos) {
+            std::string lhs = line.substr(0, assign);
+            // trim
+            size_t b = lhs.find_first_not_of(" \t");
+            size_t e = lhs.find_last_not_of(" \t");
+            if (b != std::string::npos) {
+                std::string nm = lhs.substr(b, e - b + 1);
+                bool valid = !nm.empty();
+                for (char ch : nm)
+                    if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_' || ch == '-'))
+                        valid = false;
+                if (valid)
+                    name_end = assign;
+            }
+        }
+        if (name_end != std::string::npos) {
+            flush();
+            std::string lhs = line.substr(0, name_end);
+            size_t b = lhs.find_first_not_of(" \t");
+            size_t e = lhs.find_last_not_of(" \t");
+            cur_name = lhs.substr(b, e - b + 1);
+            cur_rhs = line.substr(name_end + 3);
+        } else {
+            // continuation line
+            cur_rhs += " " + line;
+        }
+    }
+    flush();
+
+    if (rules.find("root") == rules.end()) {
+        IMP_LOG_ERROR("GBNF: no 'root' rule found");
+        return nullptr;
+    }
+
+    // 2) Translate root rule into a regex string (inlining non-recursive refs).
+    std::set<std::string> active;
+    std::string regex;
+    std::string err;
+    if (!gbnf_rule_to_regex("root", rules, active, regex, &err)) {
+        IMP_LOG_ERROR("GBNF: %s", err.c_str());
+        return nullptr;
+    }
+
+    // 3) Compile via the shared RegexNfa engine.
+    auto nfa = std::make_shared<RegexNfa>();
+    if (!nfa->compile(regex)) {
+        IMP_LOG_ERROR("GBNF: translated grammar regex failed to compile: %s", regex.c_str());
+        return nullptr;
+    }
+    IMP_LOG_INFO("GBNF: compiled grammar (%zu rules) into NFA", rules.size());
+    return nfa;
 }
 
 }  // namespace imp

--- a/src/compute/json_schema.h
+++ b/src/compute/json_schema.h
@@ -3,8 +3,99 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 namespace imp {
+
+// ---------------------------------------------------------------------------
+// Regex -> NFA (host-side) for JSON-Schema "pattern" token-level constraining.
+//
+// Supported subset (documented; this is NOT a full regex engine):
+//   - literal characters
+//   - .            any char except newline
+//   - \d \D \w \W \s \S   digit / word / whitespace classes (and negations)
+//   - \\ \. \* ... backslash-escaped metacharacters (literal)
+//   - [...] [^...] character classes with a-z style ranges and the \d/\w/\s
+//                  shorthands inside the class
+//   - * + ?        greedy quantifiers (matching is set-based, so greediness
+//                  is irrelevant for prefix-liveness)
+//   - {n} {n,} {n,m}  bounded repetition
+//   - ( ... )      grouping
+//   - a|b          alternation
+//   - ^ $          anchors. Because JSON-Schema "pattern" is an *unanchored*
+//                  search by spec, a leading ^ / trailing $ are accepted but
+//                  treated as no-ops here; we always anchor the whole string
+//                  (token-level masking can only enforce a fully-matching
+//                  string). Mid-pattern ^/$ are not supported.
+//
+// NOT supported: backreferences, lookaround, named groups, non-greedy ?,
+// unicode property escapes, \b word boundaries. compile() returns false for
+// patterns it cannot represent; callers should then skip pattern enforcement.
+// ---------------------------------------------------------------------------
+
+// A single NFA transition: an edge that consumes one input char if `is_epsilon`
+// is false (matching when char_class[ch]==true), or a free epsilon move.
+struct NfaEdge {
+    int to = -1;
+    bool is_epsilon = true;
+    // 256-entry membership table for the byte that this edge accepts.
+    std::vector<uint8_t> char_class;  // size 256 when !is_epsilon
+};
+
+struct NfaState {
+    std::vector<NfaEdge> edges;
+    bool accepting = false;
+};
+
+class RegexNfa {
+public:
+    // Compile `pattern` into a Thompson NFA. Returns false on unsupported
+    // syntax (caller should treat as "no pattern constraint").
+    bool compile(const std::string& pattern);
+
+    bool compiled() const { return compiled_; }
+
+    // Epsilon-closure of the start state.
+    std::vector<int> start_set() const;
+
+    // Step the active state set with one input byte; returns the new set
+    // (may be empty -> the prefix is now dead).
+    std::vector<int> step(const std::vector<int>& states, unsigned char c) const;
+
+    // True if any state in `states` is accepting.
+    bool accepts(const std::vector<int>& states) const;
+
+    bool empty_set_dead(const std::vector<int>& states) const { return states.empty(); }
+
+private:
+    std::vector<NfaState> states_;
+    int start_ = -1;
+    int accept_ = -1;
+    bool compiled_ = false;
+
+    // Parser scratch
+    const std::string* src_ = nullptr;
+    size_t pos_ = 0;
+    bool error_ = false;
+
+    int new_state();
+    void add_epsilon(int from, int to);
+    void add_edge(int from, int to, const std::vector<uint8_t>& cls);
+    void epsilon_closure(std::vector<int>& set) const;
+
+    // Recursive-descent Thompson construction. Each returns a (start, accept)
+    // fragment pair via out params; returns false on error.
+    struct Frag {
+        int start;
+        int accept;
+    };
+    bool parse_alt(Frag& out);
+    bool parse_concat(Frag& out);
+    bool parse_repeat(Frag& out);
+    bool parse_atom(Frag& out);
+    bool parse_class(Frag& out);  // [...]
+    bool make_shorthand(char esc, std::vector<uint8_t>& cls);  // \d \w \s ...
+};
 
 enum class SchemaType {
     STRING,
@@ -35,6 +126,14 @@ struct SchemaNode {
     // ANY_OF
     std::vector<std::unique_ptr<SchemaNode>> any_of;
 
+    // STRING constraints (JSON Schema "pattern" / "minLength" / "maxLength").
+    std::string pattern;       // raw regex source; empty = no pattern
+    int min_length = -1;       // -1 = unset
+    int max_length = -1;       // -1 = unset
+    // Compiled NFA for `pattern`, lazily built at schema-load time. Shared via
+    // shared_ptr so clone() doesn't recompile. Null if no/unsupported pattern.
+    std::shared_ptr<RegexNfa> pattern_nfa;
+
     // Deep copy
     std::unique_ptr<SchemaNode> clone() const;
 };
@@ -42,5 +141,35 @@ struct SchemaNode {
 // Parse a JSON Schema string into a SchemaNode tree.
 // Returns nullptr on parse failure.
 std::unique_ptr<SchemaNode> parse_json_schema(const std::string& json);
+
+// ---------------------------------------------------------------------------
+// GBNF-style grammar loader (Part B — PARTIAL / non-recursive subset).
+//
+// Compiles a llama.cpp-flavoured GBNF grammar into a single byte-level NFA
+// (the same RegexNfa engine used for "pattern"), so the existing token-mask
+// FSM machinery applies unchanged. Because an NFA cannot represent unbounded
+// recursion, the supported subset is the *non-recursive* fragment:
+//
+//   Supported:
+//     root ::= <expr>                rule definition (root rule must be "root")
+//     "literal"                      double-quoted literal strings
+//     [a-z0-9_] / [^...]             character classes (RegexNfa [...] subset)
+//     seq                            space-separated concatenation
+//     a | b                          alternation
+//     x* x+ x?                       repetition
+//     ( ... )                        grouping
+//     rulename                       reference to another (non-recursive) rule
+//     # comment                      line comments
+//
+//   NOT supported (rejected with a clear error; see TODO in .cpp):
+//     - recursive / mutually-recursive rules (e.g. JSON value ::= object ...)
+//     - {n,m} repetition counts
+//     - char-class escapes beyond what RegexNfa's [...] handles
+//
+// compile_gbnf_grammar() returns a compiled RegexNfa on success, or nullptr
+// (with a logged error naming the unsupported construct) on failure. Callers
+// should fall back to unconstrained generation when it returns nullptr.
+// ---------------------------------------------------------------------------
+std::shared_ptr<RegexNfa> compile_gbnf_grammar(const std::string& gbnf);
 
 }  // namespace imp

--- a/src/compute/moe_routing.cu
+++ b/src/compute/moe_routing.cu
@@ -1,6 +1,7 @@
 #include "compute/moe_routing.h"
 #include "compute/warp_reduce.cuh"
 #include "core/logging.h"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cfloat>
@@ -520,6 +521,37 @@ __global__ void moe_scatter_kernel_impl(const T* __restrict__ expert_output,
     }
 }
 
+// Deterministic scatter-add: one block per OUTPUT token. Each block scans the
+// sorted rows in ascending row order and accumulates (in FP32 registers, fixed
+// order) every row that belongs to its token, then writes once. Avoids the FP
+// atomicAdd of moe_scatter_kernel_impl whose accumulation order is
+// scheduling-dependent (non-reproducible). Opt-in only (deterministic mode);
+// the default path keeps the faster atomic scatter.
+template <typename T>
+__global__ void moe_scatter_deterministic_kernel_impl(const T* __restrict__ expert_output,
+                                                      const int32_t* __restrict__ sorted_token_ids,
+                                                      const int32_t* __restrict__ sorted_flat_idx,
+                                                      const float* __restrict__ expert_weights,
+                                                      float* __restrict__ output, int total_rows,
+                                                      int n_tokens, int d_model) {
+    const int token = blockIdx.x;
+    if (token >= n_tokens)
+        return;
+
+    for (int col = threadIdx.x; col < d_model; col += blockDim.x) {
+        float sum = 0.0f;
+        // Scan rows in fixed ascending order; accumulate the ones mapping to
+        // this token. Deterministic regardless of routing/scheduling.
+        for (int row = 0; row < total_rows; ++row) {
+            if (sorted_token_ids[row] != token)
+                continue;
+            float weight = expert_weights[sorted_flat_idx[row]];
+            sum += weight * to_float(expert_output[static_cast<int64_t>(row) * d_model + col]);
+        }
+        output[static_cast<int64_t>(token) * d_model + col] = sum;
+    }
+}
+
 // ============================================================================
 // Fused count + scan + scatter kernel (single launch)
 //
@@ -578,6 +610,77 @@ __global__ void __launch_bounds__(256) moe_fused_permute_kernel(const int32_t* _
         sorted_flat_idx[dest] = idx;
         if (token_to_expanded)
             token_to_expanded[idx] = dest;
+    }
+}
+
+// ============================================================================
+// Deterministic fused count + scan + scatter kernel (opt-in).
+//
+// Same outputs as moe_fused_permute_kernel, but the per-expert bucket slot a
+// token lands in is a pure function of (expert, flat_idx) — independent of
+// warp scheduling. The default kernel uses atomicAdd on s_write_pos, so the
+// order of tokens within an expert bucket varies run-to-run; that ordering
+// feeds the gather/grouped-GEMM and (for the atomic scatter path) the FP
+// accumulation order, breaking reproducibility.
+//
+// Strategy: thread 0 does the scan (as before), then walks flat_idx in
+// ascending order, appending each assignment to its expert bucket. Because
+// flat_idx is visited in a fixed sequential order, slot assignment is stable.
+// n_experts and total are small for decode/short prefill, so the single-thread
+// scatter is acceptable for an opt-in reproducibility mode (default path is
+// untouched).
+// ============================================================================
+
+__global__ void __launch_bounds__(256) moe_fused_permute_deterministic_kernel(
+    const int32_t* __restrict__ expert_indices, int n_tokens, int top_k, int n_experts,
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ sorted_flat_idx,
+    int32_t* __restrict__ expert_offsets, int32_t* __restrict__ token_to_expanded) {
+    extern __shared__ int32_t smem[];
+    int32_t* s_counts = smem;
+    int32_t* s_write_pos = smem + n_experts;
+
+    const int tid = threadIdx.x;
+    const int total = n_tokens * top_k;
+
+    // Phase 1: Zero counts
+    for (int i = tid; i < n_experts; i += blockDim.x)
+        s_counts[i] = 0;
+    __syncthreads();
+
+    // Phase 2: Count tokens per expert (atomics in shared memory — counts are
+    // order-independent, so this stays parallel).
+    for (int i = tid; i < total; i += blockDim.x) {
+        int expert = expert_indices[i];
+        atomicAdd(&s_counts[expert], 1);
+    }
+    __syncthreads();
+
+    // Phase 3: Exclusive scan + initialize write positions (thread 0).
+    if (tid == 0) {
+        int32_t running = 0;
+        for (int i = 0; i < n_experts; i++) {
+            expert_offsets[i] = running;
+            s_write_pos[i] = 0;
+            running += s_counts[i];
+        }
+        expert_offsets[n_experts] = running;
+    }
+    __syncthreads();
+
+    // Phase 4: Deterministic scatter — single thread walks flat_idx in order
+    // so a token's slot within its expert bucket is fixed regardless of warp
+    // scheduling.
+    if (tid == 0) {
+        for (int idx = 0; idx < total; idx++) {
+            int token = idx / top_k;
+            int expert = expert_indices[idx];
+            int pos = s_write_pos[expert]++;
+            int dest = expert_offsets[expert] + pos;
+            sorted_token_ids[dest] = token;
+            sorted_flat_idx[dest] = idx;
+            if (token_to_expanded)
+                token_to_expanded[idx] = dest;
+        }
     }
 }
 
@@ -705,10 +808,16 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingResult& res
 
     // ---- Fused count + scan + scatter (single kernel) ----
     size_t smem_permute = static_cast<size_t>(n_experts) * 2 * sizeof(int32_t);
-    moe_fused_permute_kernel<<<1, BLOCK_SIZE, smem_permute, stream>>>(d_expert_indices, n_tokens, top_k,
-                                                                      n_experts, d_sorted_token_ids,
-                                                                      d_sorted_flat_idx, d_expert_offsets,
-                                                                      nullptr);
+    if (process_diag_deterministic_gemm()) {
+        moe_fused_permute_deterministic_kernel<<<1, BLOCK_SIZE, smem_permute, stream>>>(
+            d_expert_indices, n_tokens, top_k, n_experts, d_sorted_token_ids, d_sorted_flat_idx,
+            d_expert_offsets, nullptr);
+    } else {
+        moe_fused_permute_kernel<<<1, BLOCK_SIZE, smem_permute, stream>>>(d_expert_indices, n_tokens, top_k,
+                                                                          n_experts, d_sorted_token_ids,
+                                                                          d_sorted_flat_idx, d_expert_offsets,
+                                                                          nullptr);
+    }
 
     // ---- Fill result struct ----
     result.expert_indices = make_tensor_2d(d_expert_indices, QType::INT32, n_tokens, top_k, true);
@@ -763,6 +872,26 @@ void moe_scatter(const Tensor& expert_output, const MoeRoutingResult& routing, T
 
     // Output is always FP32 for the scatter-add (atomicAdd on float)
     float* d_output = static_cast<float*>(output.data);
+
+    if (process_diag_deterministic_gemm()) {
+        // Deterministic mode: one block per output token, fixed-order FP32
+        // accumulation over its rows. Writes output directly (no atomics, no
+        // pre-zero needed). total_tokens here is the number of expanded rows.
+        if (expert_output.qtype == QType::F16) {
+            const half* d_expert_out = static_cast<const half*>(expert_output.data);
+            moe_scatter_deterministic_kernel_impl<<<n_tokens, BLOCK_SIZE, 0, stream>>>(
+                d_expert_out, d_sorted_token_ids, d_sorted_flat_idx, d_expert_weights, d_output, total_tokens,
+                n_tokens, d_model);
+        } else {
+            const float* d_expert_out = static_cast<const float*>(expert_output.data);
+            moe_scatter_deterministic_kernel_impl<<<n_tokens, BLOCK_SIZE, 0, stream>>>(
+                d_expert_out, d_sorted_token_ids, d_sorted_flat_idx, d_expert_weights, d_output, total_tokens,
+                n_tokens, d_model);
+        }
+        return;
+    }
+
+    // Zero the output first (scatter-add accumulates into it)
     zero_float_kernel<<<grid_z, BLOCK_SIZE, 0, stream>>>(d_output, total_out_elems);
 
     if (expert_output.qtype == QType::F16) {
@@ -873,10 +1002,17 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingBuffers& bu
         int32_t* d_sorted_flat_idx = d_sorted_token_ids + total_assignments;
         size_t smem_bytes = static_cast<size_t>(n_experts) * 2 * sizeof(int32_t);
 
-        moe_fused_permute_kernel<<<1, BLOCK_SIZE, smem_bytes, stream>>>(d_expert_indices, n_tokens, top_k,
-                                                                        n_experts, d_sorted_token_ids,
-                                                                        d_sorted_flat_idx, d_expert_offsets,
-                                                                        buffers.token_to_expanded);
+        if (process_diag_deterministic_gemm()) {
+            moe_fused_permute_deterministic_kernel<<<1, BLOCK_SIZE, smem_bytes, stream>>>(
+                d_expert_indices, n_tokens, top_k, n_experts, d_sorted_token_ids, d_sorted_flat_idx,
+                d_expert_offsets, buffers.token_to_expanded);
+        } else {
+            moe_fused_permute_kernel<<<1, BLOCK_SIZE, smem_bytes, stream>>>(d_expert_indices, n_tokens, top_k,
+                                                                            n_experts, d_sorted_token_ids,
+                                                                            d_sorted_flat_idx,
+                                                                            d_expert_offsets,
+                                                                            buffers.token_to_expanded);
+        }
     }
 
     // Fill result struct (no ownership -- memory belongs to buffers)

--- a/src/compute/sampling.cu
+++ b/src/compute/sampling.cu
@@ -1,6 +1,7 @@
 #include "compute/sampling.h"
 #include "compute/warp_reduce.cuh"
 #include "core/logging.h"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cub/cub.cuh>
@@ -669,6 +670,36 @@ __global__ void softmax_sum_device_max_kernel(const float* __restrict__ logits, 
     }
 }
 
+// Deterministic single-block variant of softmax_sum_device_max_kernel.
+// A single block strides the whole vocab and reduces via a fixed-order
+// shared-memory tree, writing the sum directly. This removes the cross-block
+// FP atomicAdd of the multi-block path whose accumulation order varies
+// run-to-run. Opt-in (deterministic mode) only.
+__global__ void softmax_sum_device_max_single_block_kernel(const float* __restrict__ logits, int vocab_size,
+                                                          float inv_temperature,
+                                                          const float* __restrict__ d_max,
+                                                          float* __restrict__ d_sum) {
+    __shared__ float s_sum[BLOCK_SIZE / WARP_SIZE];
+
+    float global_max = *d_max;
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < vocab_size; i += blockDim.x) {
+        local_sum += expf((logits[i] - global_max) * inv_temperature);
+    }
+    local_sum = warp_reduce_sum(local_sum);
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    if (lane_id == 0)
+        s_sum[warp_id] = local_sum;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        float sm = 0.0f;
+        for (int w = 0; w < BLOCK_SIZE / WARP_SIZE; w++)
+            sm += s_sum[w];
+        d_sum[0] = sm;
+    }
+}
+
 // Kernel: top-p filter + sample from the first k sorted candidates
 __global__ void topp_sample_from_sorted_kernel(const float* __restrict__ sorted_probs,
                                                const int32_t* __restrict__ sorted_indices, int top_k,
@@ -813,13 +844,24 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
 
     int stats_blocks = std::min((vocab_size + BLOCK_SIZE - 1) / BLOCK_SIZE, 128);
 
-    // Phase 1: global max (result in d_max_sum[0])
+    const bool deterministic = process_diag_deterministic_gemm();
+
+    // Phase 1: global max (result in d_max_sum[0]). atomicMax on the int-bitcast
+    // of the max is order-independent and exact, so it is already deterministic.
     softmax_max_kernel<<<stats_blocks, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size, sc.d_max_sum);
 
-    // Phase 2: sum of exp — reads max from device memory (no D2H sync)
-    softmax_sum_device_max_kernel<<<stats_blocks, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size,
-                                                                           inv_temperature, sc.d_max_sum,
-                                                                           sc.d_max_sum + 1);
+    // Phase 2: sum of exp — reads max from device memory (no D2H sync).
+    // The default multi-block kernel sums via cross-block FP atomicAdd, whose
+    // accumulation order varies run-to-run. In deterministic mode use a single
+    // block with a fixed-order tree reduction instead.
+    if (deterministic) {
+        softmax_sum_device_max_single_block_kernel<<<1, BLOCK_SIZE, 0, stream>>>(
+            d_logits, vocab_size, inv_temperature, sc.d_max_sum, sc.d_max_sum + 1);
+    } else {
+        softmax_sum_device_max_kernel<<<stats_blocks, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size,
+                                                                               inv_temperature, sc.d_max_sum,
+                                                                               sc.d_max_sum + 1);
+    }
 
     // Step 2: Compute probabilities reading max/sum from device memory (no D2H sync)
     int pair_blocks = (vocab_size + BLOCK_SIZE - 1) / BLOCK_SIZE;
@@ -829,6 +871,20 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
 
     // Step 3: extract top_k via DeviceTopK (unsorted), then sort just those k.
     // Much faster than a full radix sort over the whole vocab when k << vocab.
+    //
+    // TODO(determinism): even in deterministic mode the candidate SET and the
+    // subsequent descending radix sort by probability are reproducible (the
+    // FP sum above is now fixed-order, and the probs are a pure function of the
+    // logits), so the sampled token is reproducible for distinct
+    // probabilities. The one residual gap is exact ties: DeviceTopK is invoked
+    // with determinism::not_guaranteed and SortPairsDescending on equal keys is
+    // not guaranteed stable on the int32 value, so two tokens with bit-identical
+    // probability could swap order between runs. For a fully tie-stable top-k
+    // here, fold the vocab index into the sort key (e.g. sort by (prob, -index))
+    // or request cub determinism::guaranteed when this stochastic path needs
+    // bit-exact reproducibility under ties. The single-block path
+    // (top_k <= MAX_TOP_K) already tie-breaks by index and is fully
+    // deterministic; this CUB path only runs for top_k > MAX_TOP_K (128).
     {
         size_t tk_bytes = sc.temp_bytes;
         cub::DeviceTopK::MaxPairs(sc.d_temp, tk_bytes, sc.d_keys_in, sc.d_keys_out, sc.d_vals_in,
@@ -1368,6 +1424,12 @@ __global__ void apply_typical_p_kernel(float* __restrict__ logits, int vocab_siz
         float dev = fabsf(surprise - H);
         int bucket = min(static_cast<int>(dev * bucket_scale), TYPICAL_NBUCKETS - 1);
         float p = expf(logits[i] - gmax) / sum_exp;
+        // TODO(determinism): this shared-memory FP atomicAdd accumulates bucket
+        // mass in scheduling-dependent order, so the cumulative cutoff bucket
+        // can flip when typical_p lands near a bucket boundary. typical_p is a
+        // sampling FILTER (not the greedy / top-k core covered by the
+        // deterministic flag); make this an ordered per-bucket reduction if
+        // typical_p ever needs bit-exact reproducibility.
         atomicAdd(&s_buckets[bucket], p);
     }
     __syncthreads();

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -108,6 +108,47 @@ bool SchemaConstrainer::is_valid_enum_prefix(const std::vector<std::string>& val
     return false;
 }
 
+bool SchemaConstrainer::token_keeps_pattern_alive(const SchemaFrame& f, const std::string& content,
+                                                  std::vector<int>& out_states, int& out_len) const {
+    out_states = f.regex_states;
+    out_len = f.string_len;
+
+    // NOTE: regex/pattern token-masking via the Thompson NFA currently over-masks
+    // (forbids all candidate tokens -> degenerate "!!!!" output), so it is disabled
+    // pending an NFA fix. `pattern` is still parsed (json_schema.cpp) and length
+    // bounds below are enforced; only the regex narrowing is skipped.
+    bool has_nfa = false;
+    int max_len = f.node ? f.node->max_length : -1;
+
+    for (char ch : content) {
+        // Reject control chars / quote / backslash inside a constrained string.
+        unsigned char uc = static_cast<unsigned char>(ch);
+        if (uc < 32 || ch == '"' || ch == '\\')
+            return false;
+        if (max_len >= 0 && out_len + 1 > max_len)
+            return false;
+        if (has_nfa) {
+            out_states = f.node->pattern_nfa->step(out_states, uc);
+            if (out_states.empty())
+                return false;  // prefix died -> no string can complete
+        }
+        out_len++;
+    }
+    return true;
+}
+
+bool SchemaConstrainer::can_close_string(const SchemaFrame& f, const std::vector<int>& states,
+                                         int len) const {
+    bool has_nfa = false;  // regex NFA enforcement disabled (see token_keeps_pattern_alive)
+    if (has_nfa && !f.node->pattern_nfa->accepts(states))
+        return false;
+    if (f.node && f.node->min_length >= 0 && len < f.node->min_length)
+        return false;
+    if (f.node && f.node->max_length >= 0 && len > f.node->max_length)
+        return false;
+    return true;
+}
+
 // ---------------------------------------------------------------------------
 // Compute category mask from schema FSM state
 // ---------------------------------------------------------------------------
@@ -234,6 +275,11 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
         case SchemaPhase::STRING_VALUE:
             return CAT_STRING_CHAR | CAT_QUOTE;
 
+        case SchemaPhase::STRING_PATTERN:
+            // token_allow enforces the regex / length; category just gates to
+            // string content + closing quote.
+            return CAT_STRING_CHAR | CAT_QUOTE;
+
         case SchemaPhase::STRING_ESCAPE:
             return 0xFFFF;  // any char valid after backslash
 
@@ -336,6 +382,37 @@ void SchemaConstrainer::compute_token_allow_mask() {
                 token_allow_[i] = is_valid_enum_prefix(f.node->enum_values, extended) ? 1 : 0;
             }
         }
+    } else if (f.phase == SchemaPhase::STRING_PATTERN && f.node) {
+        // Constrain tokens so the emitted string matches the regex / length.
+        need_token_allow_ = true;
+        for (int i = 0; i < vocab_size_; i++) {
+            const auto& text = token_texts_[i];
+            if (text.empty()) {
+                token_allow_[i] = 0;
+                continue;
+            }
+
+            size_t qpos = text.find('"');
+            if (qpos == std::string::npos) {
+                // Pure content token: must keep the regex prefix alive.
+                std::vector<int> st;
+                int len = 0;
+                token_allow_[i] = token_keeps_pattern_alive(f, text, st, len) ? 1 : 0;
+            } else {
+                // Token closes the string at qpos. Require: the content before
+                // the quote keeps the pattern alive, the close is legal, and
+                // nothing follows the quote (can't emit past string end here).
+                if (qpos + 1 != text.size()) {
+                    token_allow_[i] = 0;
+                    continue;
+                }
+                std::string content = text.substr(0, qpos);
+                std::vector<int> st;
+                int len = 0;
+                bool alive = token_keeps_pattern_alive(f, content, st, len);
+                token_allow_[i] = (alive && can_close_string(f, st, len)) ? 1 : 0;
+            }
+        }
     } else if (f.phase == SchemaPhase::OBJECT_OPEN && f.node) {
         // When we need to open with a quote for key, also constrain which
         // quote tokens start valid keys (for multi-char tokens like `"name`)
@@ -430,7 +507,19 @@ void SchemaConstrainer::advance_char(char c) {
                     break;
                 case SchemaType::STRING:
                     if (c == '"') {
-                        f.phase = SchemaPhase::STRING_VALUE;
+                        // Use the pattern-constrained string phase when the
+                        // schema specifies a (compiled) pattern or a length bound.
+                        if ((f.node->pattern_nfa && f.node->pattern_nfa->compiled()) ||
+                            f.node->min_length >= 0 || f.node->max_length >= 0) {
+                            f.phase = SchemaPhase::STRING_PATTERN;
+                            f.string_len = 0;
+                            if (f.node->pattern_nfa && f.node->pattern_nfa->compiled())
+                                f.regex_states = f.node->pattern_nfa->start_set();
+                            else
+                                f.regex_states.clear();
+                        } else {
+                            f.phase = SchemaPhase::STRING_VALUE;
+                        }
                         return;
                     }
                     break;
@@ -643,6 +732,30 @@ void SchemaConstrainer::advance_char(char c) {
                 return;
             }
             return;  // accumulate string content
+        }
+
+        case SchemaPhase::STRING_PATTERN: {
+            if (c == '"') {
+                // String value complete (mask guarantees closing was legal).
+                stack_.pop_back();
+                if (!stack_.empty()) {
+                    auto& parent = top();
+                    if (parent.phase == SchemaPhase::OBJECT_COLON)
+                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
+                    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
+                             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
+                        parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
+                }
+                return;
+            }
+            // NOTE: escapes are not interpreted for regex purposes — the
+            // supported pattern subset operates on raw emitted bytes. A token
+            // mask already forbids backslashes unless the pattern allows them.
+            if (f.node && f.node->pattern_nfa && f.node->pattern_nfa->compiled()) {
+                f.regex_states = f.node->pattern_nfa->step(f.regex_states, static_cast<unsigned char>(c));
+            }
+            f.string_len++;
+            return;
         }
 
         case SchemaPhase::STRING_ESCAPE: {

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -29,6 +29,7 @@ enum class SchemaPhase : uint8_t {
     ARRAY_OPEN,          // After [, expecting first item or ]
     ARRAY_AFTER_ITEM,    // After item, expecting , or ]
     STRING_VALUE,        // Inside a free string value
+    STRING_PATTERN,      // Inside a string value constrained by a regex pattern
     STRING_ESCAPE,       // After \ inside string
     NUMBER_VALUE,        // Inside a number
     LITERAL_VALUE,       // Generating true/false/null
@@ -47,6 +48,12 @@ struct SchemaFrame {
 
     // Enum tracking
     std::string enum_buffer;  // accumulated enum value characters
+
+    // String pattern / length tracking (for JSON-Schema "pattern"/min/maxLength).
+    // Active NFA state set for the regex over chars emitted so far in the
+    // current string value; refreshed as characters are consumed.
+    std::vector<int> regex_states;
+    int string_len = 0;  // number of content chars emitted in the current string
 
     // Literal tracking
     std::string literal_target;  // "true", "false", "null"
@@ -141,6 +148,18 @@ private:
 
     // Check if prefix matches any enum value
     bool is_valid_enum_prefix(const std::vector<std::string>& values, const std::string& prefix) const;
+
+    // Pattern/length helpers. Returns true if appending `text` (the content
+    // chars of a candidate token, excluding a trailing closing quote) keeps the
+    // regex prefix alive and does not exceed maxLength. `out_states` receives
+    // the resulting NFA state set. For a token that closes the string (contains
+    // the closing quote), pass only the content before the quote and use
+    // can_close_string to validate the closing quote separately.
+    bool token_keeps_pattern_alive(const SchemaFrame& f, const std::string& content,
+                                   std::vector<int>& out_states, int& out_len) const;
+    // True if the current string can legally close: regex accepts and length
+    // constraints satisfied.
+    bool can_close_string(const SchemaFrame& f, const std::vector<int>& states, int len) const;
 };
 
 }  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -84,7 +84,15 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [runtime]
     if (eq("runtime.deterministic_gemm"))
         cfg.runtime.deterministic_gemm = parse_bool(val, cfg.runtime.deterministic_gemm);
-    else if (eq("runtime.cuda_graphs"))
+    else if (eq("runtime.deterministic")) {
+        cfg.runtime.deterministic = parse_bool(val, cfg.runtime.deterministic);
+        // Full determinism implies deterministic GEMM algo selection — the
+        // compute kernels gate routing/sampling determinism on the same
+        // process_diag_deterministic_gemm() snapshot, so this one switch
+        // covers GEMM + MoE routing + top-k sampling.
+        if (cfg.runtime.deterministic)
+            cfg.runtime.deterministic_gemm = true;
+    } else if (eq("runtime.cuda_graphs"))
         cfg.runtime.cuda_graphs = val;
     else if (eq("runtime.warmup"))
         cfg.runtime.warmup = parse_bool(val, cfg.runtime.warmup);
@@ -318,6 +326,14 @@ std::string home_dir() {
 // fields before [imp.conf] file overrides. Semantics preserved exactly
 // per original call-site checks (see review/phase3_maint.md §9.1).
 void seed_from_env(RuntimeConfig& cfg) {
+    // runtime.deterministic — IMP_DETERMINISTIC: '1'/'true' enables full
+    // reproducibility (also implies deterministic_gemm).
+    if (const char* e = std::getenv("IMP_DETERMINISTIC")) {
+        cfg.runtime.deterministic = parse_bool(e, cfg.runtime.deterministic);
+        if (cfg.runtime.deterministic)
+            cfg.runtime.deterministic_gemm = true;
+    }
+
     // moe.reserve_mib — IMP_MOE_RESERVE_MIB: integer MiB.
     if (const char* e = std::getenv("IMP_MOE_RESERVE_MIB"))
         cfg.moe.reserve_mib = parse_int(e, cfg.moe.reserve_mib);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -24,6 +24,19 @@ namespace imp {
 struct RuntimeConfig {
     struct Runtime {
         bool deterministic_gemm = false;
+        // Opt-in full reproducibility mode for temperature=0 agent evals.
+        // When true, run-to-run non-determinism in MoE token routing
+        // (atomic expert-bucket scatter ordering) and top-k sampling
+        // (atomicMax/atomicAdd softmax-stat races) is eliminated by
+        // selecting deterministic kernel variants. It ALSO implies
+        // deterministic_gemm (timing-based cuBLAS algo selection is itself
+        // a non-determinism source), so a single switch covers GEMM +
+        // routing + sampling. Costs a little throughput (serial / ordered
+        // reductions), so it is strictly OFF by default — the default code
+        // path runs the exact same kernels as before with zero overhead.
+        // Legacy env: IMP_DETERMINISTIC=1. See audit B-9
+        // (docs/audit/performance_agent_readiness_2026_05_31.md).
+        bool deterministic = false;
         std::string cuda_graphs = "auto";  // "auto" | "always" | "never"
         bool warmup = false;               // opt-in for prod rollout; off in dev/CI
         int max_seq_len = 0;               // 0 = use model default

--- a/tools/imp-server/anthropic.cpp
+++ b/tools/imp-server/anthropic.cpp
@@ -98,9 +98,19 @@ void push_assistant_turn(json& out, const json& anth_msg) {
                      {"arguments", input.dump()},
                  }},
             });
+        } else if (type == "thinking") {
+            // Map Anthropic thinking blocks back onto OpenAI's
+            // reasoning_content so a prior assistant turn's chain of
+            // thought round-trips through the OpenAI code path.
+            std::string th = block.value("thinking", "");
+            if (!th.empty()) {
+                if (oai_msg.contains("reasoning_content"))
+                    oai_msg["reasoning_content"] =
+                        oai_msg["reasoning_content"].get<std::string>() + "\n" + th;
+                else
+                    oai_msg["reasoning_content"] = th;
+            }
         }
-        // thinking blocks: drop for OpenAI (no equivalent, imp side
-        // exposes them through reasoning_content independently).
     }
     oai_msg["content"] = text_accum.empty() ? json(nullptr) : json(text_accum);
     if (!tool_calls.empty())
@@ -342,8 +352,15 @@ json openai_to_anthropic_response(const json& oai, const std::string& anth_model
     }
     const json& msg = choice.contains("message") ? choice["message"] : json::object();
 
-    // Build content[] blocks. Text first, then tool_use entries.
+    // Build content[] blocks. Thinking first (Anthropic emits the thinking
+    // block before the visible answer), then text, then tool_use entries.
     json content = json::array();
+    if (msg.contains("reasoning_content") && msg["reasoning_content"].is_string()) {
+        std::string thinking = msg["reasoning_content"].get<std::string>();
+        if (!thinking.empty()) {
+            content.push_back({{"type", "thinking"}, {"thinking", thinking}});
+        }
+    }
     if (msg.contains("content") && msg["content"].is_string()) {
         std::string text = msg["content"].get<std::string>();
         if (!text.empty()) {
@@ -398,8 +415,21 @@ json openai_to_anthropic_response(const json& oai, const std::string& anth_model
         {"output_tokens", 0},
     };
     if (oai.contains("usage") && oai["usage"].is_object()) {
-        usage_out["input_tokens"] = oai["usage"].value("prompt_tokens", 0);
-        usage_out["output_tokens"] = oai["usage"].value("completion_tokens", 0);
+        const auto& u = oai["usage"];
+        int prompt_tokens = u.value("prompt_tokens", 0);
+        usage_out["output_tokens"] = u.value("completion_tokens", 0);
+        // Anthropic splits the prompt token count: tokens served from the
+        // prefix cache are reported separately (cache_read_input_tokens) and
+        // excluded from input_tokens. imp surfaces the prefix-cache hit count
+        // via OpenAI's prompt_tokens_details.cached_tokens — pass it through.
+        int cached = 0;
+        if (u.contains("prompt_tokens_details") && u["prompt_tokens_details"].is_object())
+            cached = u["prompt_tokens_details"].value("cached_tokens", 0);
+        if (cached > prompt_tokens)
+            cached = prompt_tokens;
+        usage_out["input_tokens"] = prompt_tokens - cached;
+        usage_out["cache_read_input_tokens"] = cached;
+        usage_out["cache_creation_input_tokens"] = 0;
     }
 
     // Use the OpenAI id if present; otherwise synthesize one.

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -38,6 +38,7 @@ void print_server_usage(const char* prog) {
             "  --max-concurrent <n>  Max simultaneous requests (default: 64, 0=unlimited)\n"
             "  --request-timeout <s> Per-request timeout in seconds (default: 300, 0=unlimited)\n"
             "  --rate-limit <n>      Max requests/minute per IP (default: 0=unlimited)\n"
+            "  --max-input-tokens <n> Reject prompts longer than n tokens with HTTP 400 (0=unlimited)\n"
             "  --log-requests <path> Append per-request JSONL with prompt + response content\n"
             "  --help                Show this help message\n",
             prog);
@@ -122,6 +123,8 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.request_timeout = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--rate-limit") == 0 && i + 1 < argc) {
             args.rate_limit = std::atoi(argv[++i]);
+        } else if (std::strcmp(arg, "--max-input-tokens") == 0 && i + 1 < argc) {
+            args.max_input_tokens = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--prefix-cache") == 0 && i + 1 < argc) {
             args.prefix_cache_path = argv[++i];
         } else if (std::strcmp(arg, "--log-requests") == 0 && i + 1 < argc) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -42,6 +42,7 @@ struct ServerArgs {
     int max_concurrent = 64;        // --max-concurrent: max simultaneous requests (0=unlimited)
     int request_timeout = 300;      // --request-timeout: per-request timeout in seconds (0=unlimited)
     int rate_limit = 0;             // --rate-limit: max requests per minute per IP (0=unlimited)
+    int max_input_tokens = 0;       // --max-input-tokens: reject prompts longer than this (0=unlimited)
     std::string prefix_cache_path;  // --prefix-cache: path to persist prefix cache
     std::string log_requests_path;  // --log-requests: append JSONL of every chat/messages request
 };

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1107,6 +1107,24 @@ static bool snapshot_state_and_tokenize_(
 
     ctx.snap.n_prompt_tokens = static_cast<int>(ctx.snap.tokens.size());
 
+    // Server-side input-token limit (--max-input-tokens). Reject before
+    // prefill so an oversized prompt never reaches the engine.
+    if (state.max_input_tokens > 0 && ctx.snap.n_prompt_tokens > state.max_input_tokens) {
+        if (ctx.snap.has_vision_request) {
+            std::lock_guard<std::timed_mutex> lock(state.mtx);
+            if (state.batching)
+                state.batching->start(state.ctx);
+        }
+        res.status = 400;
+        json error = {{"error",
+                       {{"message", "Prompt exceeds max input tokens (" +
+                                        std::to_string(ctx.snap.n_prompt_tokens) + " > " +
+                                        std::to_string(state.max_input_tokens) + ")"},
+                        {"type", "invalid_request_error"}}}};
+        res.set_content(error.dump(), "application/json");
+        return false;
+    }
+
     // Validate prompt length against context window
     if (ctx.snap.n_prompt_tokens >= ctx.snap.max_seq_len) {
         if (ctx.snap.has_vision_request) {
@@ -1518,6 +1536,7 @@ static void nonstream_chat_response_(
         // family-specific close marker as a stop token). The parser is
         // tolerant of trailing garbage after the closing marker.
         std::vector<ParsedToolCall> tool_calls;
+        std::string tool_validation_error;
         if (ctx.params.has_tools) {
             auto [pre_content, parsed_calls] = parse_tool_calls(ctx.snap.tpl_family, content,
                                                                 state.next_tool_call_id);
@@ -1525,6 +1544,17 @@ static void nonstream_chat_response_(
                 tool_calls = std::move(parsed_calls);
                 content = pre_content;
                 finish = "tool_calls";
+                // Validate parsed arguments against each tool's input schema.
+                // A failure means the model hallucinated/garbled the call —
+                // surface it rather than silently shipping bad arguments.
+                for (auto& tc : tool_calls) {
+                    validate_tool_call(tc, ctx.params.tools);
+                    if (!tc.valid) {
+                        if (!tool_validation_error.empty())
+                            tool_validation_error += "; ";
+                        tool_validation_error += tc.name + ": " + tc.error;
+                    }
+                }
             }
         }
 
@@ -1534,9 +1564,12 @@ static void nonstream_chat_response_(
             msg["content"] = content.empty() ? json(nullptr) : json(content);
             json tc_array = json::array();
             for (const auto& tc : tool_calls) {
-                tc_array.push_back({{"id", tc.id},
-                                    {"type", "function"},
-                                    {"function", {{"name", tc.name}, {"arguments", tc.arguments}}}});
+                json tc_json = {{"id", tc.id},
+                                {"type", "function"},
+                                {"function", {{"name", tc.name}, {"arguments", tc.arguments}}}};
+                if (!tc.valid)
+                    tc_json["invalid_arguments"] = tc.error;
+                tc_array.push_back(std::move(tc_json));
             }
             msg["tool_calls"] = tc_array;
         } else {
@@ -1544,6 +1577,9 @@ static void nonstream_chat_response_(
         }
         if (!reasoning_content.empty()) {
             msg["reasoning_content"] = reasoning_content;
+        }
+        if (!tool_validation_error.empty()) {
+            msg["tool_call_validation_error"] = tool_validation_error;
         }
 
         json choice = {{"index", ci}, {"message", msg}, {"finish_reason", finish}};
@@ -1567,6 +1603,7 @@ static void nonstream_chat_response_(
     state.metrics.tokens_prompt_total += ctx.snap.n_prompt_tokens;
     state.metrics.tokens_completion_total += total_output_tokens;
     state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
+    state.metrics.request_duration.observe(ms / 1000.0);
 
     json usage = {{"prompt_tokens", ctx.snap.n_prompt_tokens},
                   {"completion_tokens", total_output_tokens},
@@ -2037,13 +2074,29 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
                                                     nullptr);
                         sink.write(sse.data(), sse.size());
 
-                        // Emit arguments chunk
-                        json args_delta = {
-                            {"tool_calls",
-                             json::array({{{"index", idx},
-                                           {"function", {{"arguments", tc.arguments}}}}})}};
-                        sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
-                        sink.write(sse.data(), sse.size());
+                        // Emit arguments incrementally as partial-JSON deltas
+                        // (Task 6) so OpenAI streaming clients see the tool
+                        // arguments grow rather than land in one block.
+                        constexpr size_t kArgChunk = 48;
+                        const std::string& full_args = tc.arguments;
+                        if (full_args.empty()) {
+                            json args_delta = {
+                                {"tool_calls",
+                                 json::array({{{"index", idx},
+                                               {"function", {{"arguments", ""}}}}})}};
+                            sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
+                            sink.write(sse.data(), sse.size());
+                        }
+                        for (size_t aoff = 0; aoff < full_args.size(); aoff += kArgChunk) {
+                            size_t an = std::min(kArgChunk, full_args.size() - aoff);
+                            json args_delta = {
+                                {"tool_calls",
+                                 json::array(
+                                     {{{"index", idx},
+                                       {"function", {{"arguments", full_args.substr(aoff, an)}}}}})}};
+                            sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
+                            sink.write(sse.data(), sse.size());
+                        }
 
                         stream_tool_calls.push_back(std::move(tc));
                         tool_calls_emitted = true;
@@ -2412,6 +2465,9 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
     state.metrics.tokens_cached_total += cached;
     state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
     state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+    state.metrics.request_duration.observe(ms / 1000.0);
+    if (n_output_tokens > 0)
+        state.metrics.ttft.observe(ttft_ms / 1000.0);
 
     // Streaming response content is not accumulated across SSE
     // chunks, so the JSONL `response` field stays null. The
@@ -2636,6 +2692,17 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
     // Tokenize raw prompt (no chat template)
     std::vector<int32_t> tokens = snap_tok->encode(prompt);
     int n_prompt_tokens = static_cast<int>(tokens.size());
+
+    // Server-side input-token limit (--max-input-tokens). Reject pre-prefill.
+    if (state.max_input_tokens > 0 && n_prompt_tokens > state.max_input_tokens) {
+        res.status = 400;
+        json error = {{"error",
+                       {{"message", "Prompt exceeds max input tokens (" + std::to_string(n_prompt_tokens) +
+                                        " > " + std::to_string(state.max_input_tokens) + ")"},
+                        {"type", "invalid_request_error"}}}};
+        res.set_content(error.dump(), "application/json");
+        return;
+    }
 
     if (n_prompt_tokens >= snap_max_seq_len) {
         res.status = 400;
@@ -3186,6 +3253,45 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
     out += "# HELP imp_last_ttft_ms Time to first token of last request in milliseconds\n";
     out += "# TYPE imp_last_ttft_ms gauge\n";
     out += "imp_last_ttft_ms " + std::to_string(m.last_ttft_ms.load()) + "\n";
+
+    // Latency histograms (Prometheus histogram: cumulative _bucket{le=...},
+    // plus _sum and _count). Buckets are in seconds.
+    auto emit_histogram = [&out](const char* name, const char* help, const LatencyHistogram& h) {
+        out += "# HELP ";
+        out += name;
+        out += ' ';
+        out += help;
+        out += "\n# TYPE ";
+        out += name;
+        out += " histogram\n";
+        for (int i = 0; i < LatencyHistogram::kNumBuckets; ++i) {
+            char le[32];
+            std::snprintf(le, sizeof(le), "%g", LatencyHistogram::kBounds[i]);
+            out += name;
+            out += "_bucket{le=\"";
+            out += le;
+            out += "\"} ";
+            out += std::to_string(h.buckets[i].load());
+            out += "\n";
+        }
+        out += name;
+        out += "_bucket{le=\"+Inf\"} ";
+        out += std::to_string(h.count.load());
+        out += "\n";
+        char sum[48];
+        std::snprintf(sum, sizeof(sum), "%g", h.sum_us.load() / 1e6);
+        out += name;
+        out += "_sum ";
+        out += sum;
+        out += "\n";
+        out += name;
+        out += "_count ";
+        out += std::to_string(h.count.load());
+        out += "\n";
+    };
+    emit_histogram("imp_request_duration_seconds", "Request end-to-end latency in seconds",
+                   m.request_duration);
+    emit_histogram("imp_ttft_seconds", "Time to first token in seconds", m.ttft);
     out += "# HELP imp_model_loaded Whether a model is currently loaded\n";
     out += "# TYPE imp_model_loaded gauge\n";
     bool loaded;
@@ -3435,16 +3541,702 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
 }
 
 // ===========================================================================
-// Anthropic /v1/messages — Phase 1: non-streaming shim
+// Anthropic /v1/messages — native SSE streaming
 // ===========================================================================
 //
-// The generation path is identical to /v1/chat/completions. We only need
-// to transform the JSON envelope on the way in (Anthropic → OpenAI) and on
-// the way out (OpenAI → Anthropic), then delegate to handle_chat_completions.
-//
-// Streaming is intentionally rejected here; Phase 2 will add a parallel
-// handler that emits native Anthropic SSE events.
+// Non-streaming reuses the OpenAI code path (Anthropic→OpenAI body in,
+// OpenAI→Anthropic response out). Streaming drives the same real per-token
+// batching-engine loop the OpenAI streaming path uses (pop_token), but emits
+// native Anthropic SSE events incrementally so TTFT == real first-token
+// latency rather than full-generation latency.
 // ---------------------------------------------------------------------------
+
+namespace {
+
+// Anthropic SSE event writer. Emits "event: <name>\ndata: <json>\n\n".
+struct AnthropicSSE {
+    httplib::DataSink& sink;
+    bool emit(const char* event_name, const json& payload) {
+        std::string buf = "event: ";
+        buf += event_name;
+        buf += "\ndata: ";
+        buf += payload.dump();
+        buf += "\n\n";
+        return sink.write(buf.data(), buf.size());
+    }
+};
+
+// Tracks which content block (if any) is currently open in the stream so we
+// can close it before opening one of a different kind. Anthropic requires a
+// content_block_start before deltas and a content_block_stop after.
+enum class AnthBlock { NONE, THINKING, TEXT, TOOL_USE };
+
+// Drives the real token loop and emits native Anthropic SSE events. Mirrors
+// the token-handling of run_chat_stream_ (reasoning extraction, channel
+// filter, tool-call tag state machine) but maps it onto Anthropic blocks:
+//   reasoning -> thinking block (thinking_delta)
+//   content   -> text block (text_delta)
+//   tool call -> tool_use block (input_json_delta, chunked)
+static bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
+                                  std::shared_ptr<ServerRequest> server_req,
+                                  const std::string& anth_model, const std::string& msg_id) {
+    AnthropicSSE out{sink};
+
+    const auto& stop_sequences = ctx.params.stop_sequences;
+    size_t max_stop_len = static_cast<size_t>(ctx.params.max_stop_len);
+    bool enable_thinking = ctx.snap.enable_thinking;
+    bool has_tools = ctx.params.has_tools;
+    auto tpl_family = ctx.snap.tpl_family;
+    float think_budget = ctx.params.think_budget;
+    auto snap_tok = ctx.snap.tok;
+    bool snap_have_template = ctx.snap.have_template;
+    bool snap_is_think_model = ctx.snap.is_think_model;
+    int snap_think_start_id = ctx.snap.think_start_id;
+    int snap_think_end_id = ctx.snap.think_end_id;
+    int snap_channel_open_id = ctx.snap.channel_open_id;
+    int snap_channel_close_id = ctx.snap.channel_close_id;
+    int snap_channel_newline_id = ctx.snap.channel_newline_id;
+    const auto& snap_stop_token_ids = ctx.snap.stop_token_ids;
+    auto active_req = server_req->request;
+    auto t_start = ctx.t_start;
+    int n_prompt_tokens = ctx.snap.n_prompt_tokens;
+
+    // ---- message_start ----------------------------------------------------
+    {
+        json msg = {
+            {"id", msg_id},
+            {"type", "message"},
+            {"role", "assistant"},
+            {"content", json::array()},
+            {"model", anth_model},
+            {"stop_reason", nullptr},
+            {"stop_sequence", nullptr},
+            {"usage", {{"input_tokens", n_prompt_tokens}, {"output_tokens", 0}}},
+        };
+        if (!out.emit("message_start", json{{"type", "message_start"}, {"message", std::move(msg)}}))
+            return false;
+    }
+
+    int block_index = -1;
+    AnthBlock open_block = AnthBlock::NONE;
+
+    auto stop_block = [&]() -> bool {
+        if (open_block == AnthBlock::NONE)
+            return true;
+        bool ok = out.emit("content_block_stop",
+                           json{{"type", "content_block_stop"}, {"index", block_index}});
+        open_block = AnthBlock::NONE;
+        return ok;
+    };
+    auto start_text_block = [&]() -> bool {
+        if (open_block == AnthBlock::TEXT)
+            return true;
+        if (!stop_block())
+            return false;
+        ++block_index;
+        open_block = AnthBlock::TEXT;
+        return out.emit("content_block_start",
+                        json{{"type", "content_block_start"},
+                             {"index", block_index},
+                             {"content_block", {{"type", "text"}, {"text", ""}}}});
+    };
+    auto start_thinking_block = [&]() -> bool {
+        if (open_block == AnthBlock::THINKING)
+            return true;
+        if (!stop_block())
+            return false;
+        ++block_index;
+        open_block = AnthBlock::THINKING;
+        return out.emit("content_block_start",
+                        json{{"type", "content_block_start"},
+                             {"index", block_index},
+                             {"content_block", {{"type", "thinking"}, {"thinking", ""}}}});
+    };
+    auto emit_text = [&](const std::string& text) -> bool {
+        if (text.empty())
+            return true;
+        if (!start_text_block())
+            return false;
+        return out.emit("content_block_delta",
+                        json{{"type", "content_block_delta"},
+                             {"index", block_index},
+                             {"delta", {{"type", "text_delta"}, {"text", text}}}});
+    };
+    auto emit_thinking = [&](const std::string& text) -> bool {
+        if (text.empty())
+            return true;
+        if (!start_thinking_block())
+            return false;
+        return out.emit("content_block_delta",
+                        json{{"type", "content_block_delta"},
+                             {"index", block_index},
+                             {"delta", {{"type", "thinking_delta"}, {"thinking", text}}}});
+    };
+    // Open a tool_use block and stream its arguments as chunked
+    // input_json_delta events (Task 6: incremental arg deltas).
+    auto emit_tool_use = [&](const ParsedToolCall& tc) -> bool {
+        if (!stop_block())
+            return false;
+        ++block_index;
+        open_block = AnthBlock::TOOL_USE;
+        namespace anth = imp_server::anthropic;
+        if (!out.emit("content_block_start",
+                      json{{"type", "content_block_start"},
+                           {"index", block_index},
+                           {"content_block",
+                            {{"type", "tool_use"},
+                             {"id", anth::tool_call_id_to_anthropic(tc.id)},
+                             {"name", tc.name},
+                             {"input", json::object()}}}}))
+            return false;
+        const std::string& args = tc.arguments;
+        constexpr size_t kChunk = 48;
+        for (size_t off = 0; off < args.size(); off += kChunk) {
+            size_t n = std::min(kChunk, args.size() - off);
+            if (!out.emit("content_block_delta",
+                          json{{"type", "content_block_delta"},
+                               {"index", block_index},
+                               {"delta",
+                                {{"type", "input_json_delta"},
+                                 {"partial_json", args.substr(off, n)}}}}))
+                return false;
+        }
+        return stop_block();
+    };
+
+    int n_output_tokens = 0;
+    int n_reasoning_tokens = 0;
+    const char* finish = nullptr;
+    double ttft_ms = 0.0;
+
+    std::string utf8_buf;        // confirmed-UTF8 content buffer
+    std::string pending_text;    // stop-sequence holdback
+    bool text_stop_matched = false;
+
+    // Tool call detection state machine (same shape as run_chat_stream_).
+    enum class ToolPhase { CONTENT, TAG_SCANNING, TOOL_CALL_BODY };
+    ToolPhase tool_phase = ToolPhase::CONTENT;
+    std::string tool_tag_buf, tool_body_buf, tool_close_tag, tool_fn_name;
+    std::vector<ParsedToolCall> stream_tool_calls;
+    bool tool_calls_emitted = false;
+
+    // Reasoning extraction (DeepSeek <think>).
+    enum class ThinkPhase { SCAN, REASONING, CONTENT };
+    bool use_reasoning = (state.default_args.reasoning_format == "deepseek" && snap_is_think_model);
+    ThinkPhase think_phase;
+    if (enable_thinking)
+        think_phase = ThinkPhase::REASONING;
+    else if (use_reasoning && think_budget > 0.0f)
+        think_phase = ThinkPhase::SCAN;
+    else
+        think_phase = ThinkPhase::CONTENT;
+    std::string reasoning_utf8_buf, think_scan_buf;
+    int think_scan_count = 0;
+    bool content_started = (think_phase == ThinkPhase::CONTENT);
+    int think_reentries = 0;
+    const int kMaxThinkReentries = 1;
+    const int kThinkScanLimit = 8;
+    bool channel_header_active = false;
+
+    auto flush_text = [&](size_t up_to) -> bool {
+        if (up_to == 0)
+            return true;
+        bool ok = emit_text(pending_text.substr(0, up_to));
+        pending_text.erase(0, up_to);
+        return ok;
+    };
+
+    auto request_start = std::chrono::steady_clock::now();
+    for (;;) {
+        if (!sink.is_writable()) {
+            server_req->cancel();
+            finish = "cancelled";
+            break;
+        }
+        if (state.request_timeout > 0) {
+            auto elapsed = std::chrono::steady_clock::now() - request_start;
+            if (elapsed > std::chrono::seconds(state.request_timeout)) {
+                server_req->cancel();
+                finish = "length";
+                break;
+            }
+        }
+
+        TokenEvent evt;
+        if (!server_req->pop_token(evt))
+            continue;
+
+        if (evt.token_id < 0) {
+            finish = evt.finish_reason ? evt.finish_reason : "stop";
+            break;
+        }
+        int32_t token = evt.token_id;
+
+        if (!evt.is_last) {
+            bool is_structural_stop = (token == snap_tok->eos_id());
+            if (!is_structural_stop && snap_have_template) {
+                for (int32_t stop_id : snap_stop_token_ids)
+                    if (token == stop_id) {
+                        is_structural_stop = true;
+                        break;
+                    }
+            }
+            if (is_structural_stop)
+                continue;
+        }
+        if (evt.is_last) {
+            if (token == snap_tok->eos_id()) {
+                finish = evt.finish_reason ? evt.finish_reason : "stop";
+                break;
+            }
+            bool is_stop = false;
+            if (snap_have_template) {
+                for (int32_t stop_id : snap_stop_token_ids)
+                    if (token == stop_id) {
+                        is_stop = true;
+                        break;
+                    }
+            }
+            if (is_stop) {
+                finish = evt.finish_reason ? evt.finish_reason : "stop";
+                break;
+            }
+            finish = evt.finish_reason ? evt.finish_reason : "length";
+        }
+
+        n_output_tokens++;
+        if (n_output_tokens == 1)
+            ttft_ms = std::chrono::duration<double, std::milli>(
+                          std::chrono::high_resolution_clock::now() - t_start)
+                          .count();
+        std::string piece = snap_tok->decode_token(token);
+
+        // Gemma-4 channel filter.
+        if (snap_channel_open_id >= 0) {
+            if (channel_header_active) {
+                if (token == snap_channel_newline_id || (!piece.empty() && piece.back() == '\n'))
+                    channel_header_active = false;
+                continue;
+            }
+            if (token == snap_channel_open_id) {
+                channel_header_active = true;
+                continue;
+            }
+            if (token == snap_channel_close_id)
+                continue;
+        }
+
+        // Reasoning extraction.
+        if (think_phase == ThinkPhase::SCAN) {
+            if (token == snap_think_start_id) {
+                think_phase = ThinkPhase::REASONING;
+                n_reasoning_tokens++;
+                continue;
+            }
+            think_scan_buf += piece;
+            think_scan_count++;
+            if (think_scan_buf.find("<think>") != std::string::npos) {
+                think_phase = ThinkPhase::REASONING;
+                n_reasoning_tokens += think_scan_count;
+                auto pos = think_scan_buf.find("<think>");
+                std::string after = think_scan_buf.substr(pos + 7);
+                think_scan_buf.clear();
+                if (!after.empty())
+                    reasoning_utf8_buf += after;
+                continue;
+            }
+            if (think_scan_count == 1 && piece.empty()) {
+                think_phase = ThinkPhase::REASONING;
+                n_reasoning_tokens++;
+                continue;
+            }
+            if (think_scan_count >= kThinkScanLimit) {
+                think_phase = ThinkPhase::CONTENT;
+                piece = think_scan_buf;
+                think_scan_buf.clear();
+            } else {
+                continue;
+            }
+        }
+
+        if (think_phase == ThinkPhase::REASONING) {
+            n_reasoning_tokens++;
+            if (token == snap_think_end_id) {
+                size_t complete = utf8_complete_len(reasoning_utf8_buf);
+                if (!emit_thinking(reasoning_utf8_buf.substr(0, complete)))
+                    return false;
+                reasoning_utf8_buf.clear();
+                think_phase = ThinkPhase::CONTENT;
+                continue;
+            }
+            if (token == snap_think_start_id)
+                continue;
+            reasoning_utf8_buf += piece;
+            for (;;) {
+                auto tp = reasoning_utf8_buf.find("<think>");
+                if (tp == std::string::npos)
+                    break;
+                reasoning_utf8_buf.erase(tp, 7);
+            }
+            auto end_pos = reasoning_utf8_buf.find("</think>");
+            if (end_pos != std::string::npos) {
+                if (!emit_thinking(reasoning_utf8_buf.substr(0, end_pos)))
+                    return false;
+                think_phase = ThinkPhase::CONTENT;
+                std::string after = reasoning_utf8_buf.substr(end_pos + 8);
+                reasoning_utf8_buf.clear();
+                auto start = after.find_first_not_of("\n\r\t ");
+                if (start != std::string::npos)
+                    piece = after.substr(start);
+                else
+                    continue;
+            } else {
+                constexpr size_t kOverlap = 7;
+                size_t complete = utf8_complete_len(reasoning_utf8_buf);
+                if (complete > kOverlap) {
+                    size_t emit_end = complete - kOverlap;
+                    while (emit_end > 0 &&
+                           (static_cast<unsigned char>(reasoning_utf8_buf[emit_end]) & 0xC0) == 0x80)
+                        --emit_end;
+                    if (emit_end > 0) {
+                        std::string to_emit = reasoning_utf8_buf.substr(0, emit_end);
+                        reasoning_utf8_buf = reasoning_utf8_buf.substr(emit_end);
+                        if (!emit_thinking(to_emit))
+                            return false;
+                    }
+                }
+                continue;
+            }
+        }
+
+        if (!content_started && think_phase == ThinkPhase::CONTENT) {
+            auto ns = piece.find_first_not_of("\n\r\t ");
+            if (ns == std::string::npos)
+                continue;
+            piece = piece.substr(ns);
+            content_started = true;
+        }
+
+        if (use_reasoning) {
+            if (token == snap_think_start_id) {
+                if (think_reentries < kMaxThinkReentries) {
+                    think_phase = ThinkPhase::REASONING;
+                    n_reasoning_tokens++;
+                    think_reentries++;
+                }
+                continue;
+            }
+            if (token == snap_think_end_id) {
+                n_reasoning_tokens++;
+                continue;
+            }
+            for (;;) {
+                auto p = piece.find("<think>");
+                if (p != std::string::npos) {
+                    piece.erase(p, 7);
+                    continue;
+                }
+                p = piece.find("</think>");
+                if (p != std::string::npos) {
+                    piece.erase(p, 8);
+                    continue;
+                }
+                break;
+            }
+            if (piece.empty())
+                continue;
+        }
+
+        // Tool call body accumulation.
+        if (has_tools && tool_phase == ToolPhase::TOOL_CALL_BODY) {
+            tool_body_buf += piece;
+            auto close_pos = tool_body_buf.find(tool_close_tag);
+            if (close_pos != std::string::npos) {
+                std::string body = tool_body_buf.substr(0, close_pos);
+                auto bs = body.find_first_not_of("\n\r\t ");
+                auto be = body.find_last_not_of("\n\r\t ");
+                if (bs != std::string::npos && be != std::string::npos)
+                    body = body.substr(bs, be - bs + 1);
+                try {
+                    json j = json::parse(body);
+                    ParsedToolCall tc;
+                    tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
+                    if (tpl_family == imp::ChatTemplateFamily::LLAMA3) {
+                        tc.name = tool_fn_name;
+                        tc.arguments = j.dump();
+                    } else {
+                        tc.name = j.value("name", "");
+                        if (j.contains("arguments"))
+                            tc.arguments = j["arguments"].dump();
+                        else {
+                            json args = j;
+                            args.erase("name");
+                            tc.arguments = args.dump();
+                        }
+                    }
+                    if (!tc.name.empty()) {
+                        validate_tool_call(tc, ctx.params.tools);
+                        if (!tc.valid) {
+                            fprintf(stderr, "[%s] tool-call arg validation failed: %s: %s\n",
+                                    msg_id.c_str(), tc.name.c_str(), tc.error.c_str());
+                        }
+                        if (!emit_tool_use(tc))
+                            return false;
+                        stream_tool_calls.push_back(std::move(tc));
+                        tool_calls_emitted = true;
+                    }
+                } catch (...) {
+                }
+                std::string after = tool_body_buf.substr(close_pos + tool_close_tag.size());
+                tool_body_buf.clear();
+                tool_phase = ToolPhase::CONTENT;
+                if (!after.empty()) {
+                    auto ws = after.find_first_not_of("\n\r\t ");
+                    if (ws != std::string::npos)
+                        piece = after.substr(ws);
+                    else
+                        continue;
+                } else {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
+
+        if (has_tools && tool_phase == ToolPhase::TAG_SCANNING) {
+            tool_tag_buf += piece;
+            if (tpl_family != imp::ChatTemplateFamily::LLAMA3) {
+                if (tool_tag_buf.size() >= 11) {
+                    auto pos = tool_tag_buf.find("<tool_call>");
+                    if (pos != std::string::npos) {
+                        std::string before = tool_tag_buf.substr(0, pos);
+                        if (!before.empty() && !emit_text(before))
+                            return false;
+                        tool_body_buf = tool_tag_buf.substr(pos + 11);
+                        tool_close_tag = "</tool_call>";
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::TOOL_CALL_BODY;
+                        continue;
+                    }
+                    const char* tc_tag = "<tool_call>";
+                    bool could_match = true;
+                    for (size_t k = 0; k < tool_tag_buf.size() && k < 11; k++)
+                        if (tool_tag_buf[k] != tc_tag[k]) {
+                            could_match = false;
+                            break;
+                        }
+                    if (!could_match) {
+                        piece = tool_tag_buf;
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::CONTENT;
+                    } else {
+                        continue;
+                    }
+                } else {
+                    const char* tc_tag = "<tool_call>";
+                    bool could_match = true;
+                    for (size_t k = 0; k < tool_tag_buf.size() && k < 11; k++)
+                        if (tool_tag_buf[k] != tc_tag[k]) {
+                            could_match = false;
+                            break;
+                        }
+                    if (!could_match) {
+                        piece = tool_tag_buf;
+                        tool_tag_buf.clear();
+                        tool_phase = ToolPhase::CONTENT;
+                    } else {
+                        continue;
+                    }
+                }
+            } else {
+                if (tool_tag_buf.size() >= 10) {
+                    auto fn_pos = tool_tag_buf.find("<function=");
+                    if (fn_pos != std::string::npos) {
+                        auto gt = tool_tag_buf.find('>', fn_pos + 10);
+                        if (gt != std::string::npos) {
+                            std::string before = tool_tag_buf.substr(0, fn_pos);
+                            if (!before.empty() && !emit_text(before))
+                                return false;
+                            tool_fn_name = tool_tag_buf.substr(fn_pos + 10, gt - (fn_pos + 10));
+                            tool_body_buf = tool_tag_buf.substr(gt + 1);
+                            tool_close_tag = "</function>";
+                            tool_tag_buf.clear();
+                            tool_phase = ToolPhase::TOOL_CALL_BODY;
+                            continue;
+                        } else {
+                            continue;
+                        }
+                    }
+                }
+                const char* fn_tag = "<function=";
+                bool could_match = true;
+                for (size_t k = 0; k < tool_tag_buf.size() && k < 10; k++)
+                    if (tool_tag_buf[k] != fn_tag[k]) {
+                        could_match = false;
+                        break;
+                    }
+                if (!could_match) {
+                    piece = tool_tag_buf;
+                    tool_tag_buf.clear();
+                    tool_phase = ToolPhase::CONTENT;
+                } else {
+                    continue;
+                }
+            }
+        }
+
+        if (has_tools && tool_phase == ToolPhase::CONTENT) {
+            size_t lt_pos = piece.find('<');
+            if (lt_pos != std::string::npos) {
+                if (lt_pos > 0) {
+                    std::string before = piece.substr(0, lt_pos);
+                    if (stop_sequences.empty())
+                        utf8_buf += before;
+                    else
+                        pending_text += before;
+                }
+                tool_tag_buf = piece.substr(lt_pos);
+                tool_phase = ToolPhase::TAG_SCANNING;
+                if (stop_sequences.empty() && !utf8_buf.empty()) {
+                    size_t complete = utf8_complete_len(utf8_buf);
+                    if (complete > 0) {
+                        if (!emit_text(utf8_buf.substr(0, complete)))
+                            return false;
+                        utf8_buf.erase(0, complete);
+                    }
+                } else if (!stop_sequences.empty()) {
+                    bool stop_found = false;
+                    for (const auto& stop : stop_sequences) {
+                        auto pos = pending_text.find(stop);
+                        if (pos != std::string::npos) {
+                            if (!flush_text(pos))
+                                return false;
+                            stop_found = true;
+                            break;
+                        }
+                    }
+                    if (stop_found) {
+                        text_stop_matched = true;
+                        finish = "stop";
+                        break;
+                    }
+                    if (pending_text.size() > max_stop_len) {
+                        size_t safe = pending_text.size() - max_stop_len + 1;
+                        if (!flush_text(safe))
+                            return false;
+                    }
+                }
+                continue;
+            }
+        }
+
+        // Normal content emission.
+        if (stop_sequences.empty()) {
+            utf8_buf += piece;
+            size_t complete = utf8_complete_len(utf8_buf);
+            if (complete > 0) {
+                if (!emit_text(utf8_buf.substr(0, complete)))
+                    return false;
+                utf8_buf.erase(0, complete);
+            }
+        } else {
+            pending_text += piece;
+            bool stop_found = false;
+            for (const auto& stop : stop_sequences) {
+                auto pos = pending_text.find(stop);
+                if (pos != std::string::npos) {
+                    if (!flush_text(pos))
+                        return false;
+                    stop_found = true;
+                    break;
+                }
+            }
+            if (stop_found) {
+                text_stop_matched = true;
+                finish = "stop";
+                break;
+            }
+            if (pending_text.size() > max_stop_len) {
+                size_t safe = pending_text.size() - max_stop_len + 1;
+                if (!flush_text(safe))
+                    return false;
+            }
+        }
+
+        if (finish)
+            break;
+    }
+
+    // Flush trailing buffers.
+    if (think_phase == ThinkPhase::SCAN && !think_scan_buf.empty()) {
+        utf8_buf += think_scan_buf;
+        think_scan_buf.clear();
+    }
+    if (!reasoning_utf8_buf.empty()) {
+        emit_thinking(reasoning_utf8_buf);
+        reasoning_utf8_buf.clear();
+    }
+    if (tool_phase != ToolPhase::CONTENT && !tool_calls_emitted) {
+        std::string leftover = tool_tag_buf + tool_body_buf;
+        if (!leftover.empty())
+            utf8_buf += leftover;
+    }
+    if (!utf8_buf.empty() && !text_stop_matched && !tool_calls_emitted)
+        emit_text(utf8_buf);
+    if (!pending_text.empty() && !text_stop_matched && !tool_calls_emitted)
+        emit_text(pending_text);
+
+    // Close any block still open.
+    stop_block();
+
+    if (!finish)
+        finish = tool_calls_emitted ? "tool_calls" : "length";
+    else if (tool_calls_emitted && strcmp(finish, "stop") == 0)
+        finish = "tool_calls";
+
+    // Map finish_reason -> Anthropic stop_reason.
+    std::string stop_reason;
+    if (strcmp(finish, "stop") == 0)
+        stop_reason = "end_turn";
+    else if (strcmp(finish, "length") == 0)
+        stop_reason = "max_tokens";
+    else if (strcmp(finish, "tool_calls") == 0)
+        stop_reason = "tool_use";
+    else if (strcmp(finish, "cancelled") == 0)
+        stop_reason = "end_turn";
+    else
+        stop_reason = finish;
+
+    // ---- message_delta + message_stop ------------------------------------
+    out.emit("message_delta",
+             json{{"type", "message_delta"},
+                  {"delta", {{"stop_reason", stop_reason}, {"stop_sequence", nullptr}}},
+                  {"usage", {{"output_tokens", n_output_tokens}}}});
+    out.emit("message_stop", json{{"type", "message_stop"}});
+    sink.done();
+
+    // Metrics + log.
+    auto t_end = std::chrono::high_resolution_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+    int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
+    state.metrics.requests_total++;
+    state.metrics.tokens_prompt_total += n_prompt_tokens;
+    state.metrics.tokens_completion_total += n_output_tokens;
+    state.metrics.tokens_cached_total += cached;
+    state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
+    state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+    state.metrics.request_duration.observe(ms / 1000.0);
+    if (n_output_tokens > 0)
+        state.metrics.ttft.observe(ttft_ms / 1000.0);
+    log_request_jsonl(state, ctx.log_skip, ctx.t_log_start, msg_id, ctx.log_endpoint, ctx.log_client_ip,
+                      ctx.log_raw_body, ms, n_prompt_tokens, n_output_tokens, finish, json());
+    fprintf(stderr, "[%s] messages stream: %d prompt + %d completion tokens, %.1f ms (ttft=%.1f ms)\n",
+            msg_id.c_str(), n_prompt_tokens, n_output_tokens, ms, ttft_ms);
+    return true;
+}
+
+}  // namespace
 
 void handle_messages(const httplib::Request& req, httplib::Response& res, ServerState& state) {
     namespace anth = imp_server::anthropic;
@@ -3498,11 +4290,129 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
         return;
     }
 
-    // Shim: reuse the OpenAI handler with a cloned request carrying the
-    // transformed body. httplib::Request is a plain struct, safe to copy.
-    // Force stream=false on the inner OpenAI call — we re-serialize the
-    // response as native Anthropic SSE events below (Phase 2 "synthetic
-    // streaming"). Full event-by-event streaming is tracked as Phase 3.
+    // ---- Real streaming path -------------------------------------------
+    // For stream=true we drive the same per-token batching-engine loop the
+    // OpenAI streaming path uses and emit native Anthropic SSE events as
+    // tokens arrive — TTFT is real first-token latency, not full-gen latency.
+    if (want_stream) {
+        // Build the chat request context from the transformed OpenAI body.
+        httplib::Request shim_req = req;
+        json shim_body = oai_body;
+        shim_body["stream"] = true;
+        shim_req.body = shim_body.dump();
+        shim_req.headers.erase("Content-Length");
+        shim_req.headers.erase("content-length");
+
+        ChatRequestContext ctx;
+        g_in_anthropic_shim = true;  // suppress inner request-log (we log here)
+        bool ok = parse_chat_request_params(shim_req, res, state, ctx) &&
+                  snapshot_state_and_tokenize_(res, state, ctx);
+        g_in_anthropic_shim = false;
+        if (!ok) {
+            // parse/snapshot set an OpenAI-shaped error on res; re-wrap as
+            // an Anthropic error envelope.
+            json parsed;
+            try {
+                parsed = json::parse(res.body);
+            } catch (...) {
+                parsed = {{"error", {{"message", res.body}, {"type", "invalid_request_error"}}}};
+            }
+            json out = {{"type", "error"},
+                        {"error", parsed.value("error",
+                                               json{{"type", "invalid_request_error"}, {"message", "bad request"}})}};
+            res.set_content(out.dump(), "application/json");
+            return;
+        }
+
+        // Restore Anthropic logging context (parse_chat_request_params set
+        // these from the shim request; we log the outer Anthropic request).
+        ctx.log_skip = false;
+        ctx.log_endpoint = log_endpoint;
+        ctx.log_client_ip = log_client_ip;
+        ctx.log_raw_body = log_raw_body;
+        ctx.t_log_start = t_log_start;
+
+        // Vision streaming is unsupported (state is per-engine, not per-req).
+        // snapshot_state_and_tokenize_ stops the batching engine for exclusive
+        // vision access — restart it before bailing out.
+        if (ctx.snap.has_vision_request) {
+            {
+                std::lock_guard<std::timed_mutex> lock(state.mtx);
+                if (state.batching)
+                    state.batching->start(state.ctx);
+            }
+            res.status = 400;
+            json err = {{"type", "error"},
+                        {"error",
+                         {{"type", "invalid_request_error"},
+                          {"message", "Streaming is not supported for vision/image requests"}}}};
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+
+        auto imp_req = std::make_shared<imp::Request>();
+        imp_req->input_tokens = ctx.snap.tokens;
+        imp_req->max_tokens = ctx.params.max_tokens;
+        imp_req->temperature = ctx.params.temperature;
+        imp_req->top_p = ctx.params.top_p;
+        imp_req->top_k = ctx.params.top_k;
+        imp_req->seed = ctx.params.seed;
+        imp_req->min_p = ctx.params.min_p;
+        imp_req->typical_p = ctx.params.typical_p;
+        imp_req->repetition_penalty = ctx.params.repetition_penalty;
+        imp_req->frequency_penalty = ctx.params.frequency_penalty;
+        imp_req->presence_penalty = ctx.params.presence_penalty;
+        imp_req->repeat_last_n = ctx.params.repeat_last_n;
+        imp_req->dry_multiplier = ctx.params.dry_multiplier;
+        imp_req->dry_base = ctx.params.dry_base;
+        imp_req->dry_allowed_length = ctx.params.dry_allowed_length;
+        imp_req->dry_penalty_last_n = ctx.params.dry_penalty_last_n;
+        imp_req->mirostat = ctx.params.mirostat;
+        imp_req->mirostat_tau = ctx.params.mirostat_tau;
+        imp_req->mirostat_eta = ctx.params.mirostat_eta;
+        imp_req->logprobs = ctx.params.req_logprobs;
+        imp_req->top_logprobs = ctx.params.top_logprobs;
+        imp_req->json_mode = ctx.params.json_mode;
+        imp_req->json_schema = ctx.params.json_schema_str;
+        imp_req->has_tools = ctx.params.has_tools;
+        imp_req->tpl_family = ctx.snap.tpl_family;
+        imp_req->logit_bias = ctx.params.logit_bias;
+        imp_req->think_budget = ctx.params.think_budget;
+        imp_req->status = imp::RequestStatus::PENDING;
+
+        auto server_req = std::make_shared<ServerRequest>();
+        server_req->request = imp_req;
+        {
+            std::lock_guard<std::timed_mutex> lock(state.mtx);
+            if (!state.batching || !state.batching->is_running()) {
+                res.status = 503;
+                json err = {{"type", "error"},
+                            {"error",
+                             {{"type", "server_error"}, {"message", "Inference engine not ready. Please retry."}}}};
+                res.set_content(err.dump(), "application/json");
+                return;
+            }
+            state.batching->submit(server_req);
+        }
+
+        std::string msg_id = anth::make_message_id(static_cast<uint64_t>(state.next_id.fetch_add(1)));
+        ctx.t_start = std::chrono::high_resolution_clock::now();
+
+        res.status = 200;
+        res.set_header("Cache-Control", "no-cache");
+        res.set_header("Connection", "keep-alive");
+        res.set_chunked_content_provider(
+            "text/event-stream",
+            [stream_ctx = std::move(ctx), &state, server_req, anth_model, msg_id](
+                size_t /*offset*/, httplib::DataSink& sink) mutable -> bool {
+                return run_anthropic_stream_(sink, stream_ctx, state, server_req, anth_model, msg_id);
+            });
+        return;
+    }
+
+    // ---- Non-streaming path: reuse the OpenAI handler via a shim --------
+    // httplib::Request is a plain struct, safe to copy. Force stream=false on
+    // the inner OpenAI call — we re-serialize the response as Anthropic JSON.
     httplib::Request shim_req = req;
     json shim_body = oai_body;
     shim_body["stream"] = false;
@@ -3563,174 +4473,8 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
                           stop_reason.empty() ? nullptr : stop_reason.c_str(), anth_response);
     }
 
-    if (!want_stream) {
-        res.status = 200;
-        res.set_content(anth_response.dump(), "application/json");
-        return;
-    }
-
-    // ---- Phase 2 synthetic streaming -----------------------------------
-    // The full response is already computed above; we replay it as a
-    // well-formed Anthropic SSE stream so clients that set `stream: true`
-    // get the events they expect. TTFT is the full-generation latency for
-    // now — Phase 3 will plumb this through a real event-loop emitter.
+    // Non-streaming requests are fully assembled above (the want_stream path
+    // returned earlier with a native incremental SSE stream).
     res.status = 200;
-    res.set_header("Cache-Control", "no-cache");
-    res.set_header("Connection", "keep-alive");
-
-    // Capture everything needed by value (lambda outlives this function).
-    auto stream_data = std::make_shared<json>(std::move(anth_response));
-    res.set_chunked_content_provider(
-        "text/event-stream", [stream_data](size_t /*offset*/, httplib::DataSink& sink) -> bool {
-            auto emit = [&](const char* event_name, const json& payload) -> bool {
-                std::string buf = "event: ";
-                buf += event_name;
-                buf += "\ndata: ";
-                buf += payload.dump();
-                buf += "\n\n";
-                return sink.write(buf.data(), buf.size());
-            };
-
-            const json& anth = *stream_data;
-
-            // 1) message_start — mirrors the assembled message envelope but
-            //    with empty content[] and output_tokens=0 (per Anthropic spec).
-            {
-                json msg_start_msg = anth;  // copy
-                msg_start_msg["content"] = json::array();
-                msg_start_msg["stop_reason"] = nullptr;
-                if (msg_start_msg.contains("usage")) {
-                    msg_start_msg["usage"]["output_tokens"] = 0;
-                }
-                json ev = {
-                    {"type", "message_start"},
-                    {"message", std::move(msg_start_msg)},
-                };
-                if (!emit("message_start", ev)) {
-                    sink.done();
-                    return true;
-                }
-            }
-
-            // 2) Content blocks — one pair of content_block_start/stop per
-            //    block, with deltas in between. Text blocks are split into
-            //    modest chunks so progressive-UI clients render nicely; tool
-            //    input is sent as a single input_json_delta.
-            int block_index = 0;
-            if (anth.contains("content") && anth["content"].is_array()) {
-                for (const auto& block : anth["content"]) {
-                    std::string type = block.value("type", "");
-
-                    if (type == "text") {
-                        json cb = {
-                            {"type", "content_block_start"},
-                            {"index", block_index},
-                            {"content_block", {{"type", "text"}, {"text", ""}}},
-                        };
-                        if (!emit("content_block_start", cb)) {
-                            sink.done();
-                            return true;
-                        }
-
-                        const std::string text = block.value("text", "");
-                        // Split into ~32-char deltas — arbitrary but gives
-                        // progressive-rendering UIs something to do.
-                        constexpr size_t kChunk = 32;
-                        for (size_t off = 0; off < text.size(); off += kChunk) {
-                            size_t n = std::min(kChunk, text.size() - off);
-                            json d = {
-                                {"type", "content_block_delta"},
-                                {"index", block_index},
-                                {"delta",
-                                 {
-                                     {"type", "text_delta"},
-                                     {"text", text.substr(off, n)},
-                                 }},
-                            };
-                            if (!emit("content_block_delta", d)) {
-                                sink.done();
-                                return true;
-                            }
-                        }
-                    } else if (type == "tool_use") {
-                        json cb_start = {
-                            {"type", "content_block_start"},
-                            {"index", block_index},
-                            {"content_block",
-                             {
-                                 {"type", "tool_use"},
-                                 {"id", block.value("id", "")},
-                                 {"name", block.value("name", "")},
-                                 {"input", json::object()},
-                             }},
-                        };
-                        if (!emit("content_block_start", cb_start)) {
-                            sink.done();
-                            return true;
-                        }
-
-                        // Emit the full input JSON as a single input_json_delta.
-                        std::string partial = block.value("input", json::object()).dump();
-                        json d = {
-                            {"type", "content_block_delta"},
-                            {"index", block_index},
-                            {"delta",
-                             {
-                                 {"type", "input_json_delta"},
-                                 {"partial_json", std::move(partial)},
-                             }},
-                        };
-                        if (!emit("content_block_delta", d)) {
-                            sink.done();
-                            return true;
-                        }
-                    } else {
-                        // Unknown block type — start+stop with no deltas.
-                        json cb = {
-                            {"type", "content_block_start"},
-                            {"index", block_index},
-                            {"content_block", block},
-                        };
-                        if (!emit("content_block_start", cb)) {
-                            sink.done();
-                            return true;
-                        }
-                    }
-
-                    json cb_stop = {
-                        {"type", "content_block_stop"},
-                        {"index", block_index},
-                    };
-                    if (!emit("content_block_stop", cb_stop)) {
-                        sink.done();
-                        return true;
-                    }
-                    ++block_index;
-                }
-            }
-
-            // 3) message_delta — final stop_reason + per-spec output_tokens.
-            {
-                json delta = {{"stop_reason", anth.value("stop_reason", "end_turn")},
-                              {"stop_sequence", anth.value("stop_sequence", json(nullptr))}};
-                int output_tokens = 0;
-                if (anth.contains("usage")) {
-                    output_tokens = anth["usage"].value("output_tokens", 0);
-                }
-                json ev = {
-                    {"type", "message_delta"},
-                    {"delta", std::move(delta)},
-                    {"usage", {{"output_tokens", output_tokens}}},
-                };
-                if (!emit("message_delta", ev)) {
-                    sink.done();
-                    return true;
-                }
-            }
-
-            // 4) message_stop — terminator.
-            emit("message_stop", json{{"type", "message_stop"}});
-            sink.done();
-            return true;
-        });
+    res.set_content(anth_response.dump(), "application/json");
 }

--- a/tools/imp-server/handlers.h
+++ b/tools/imp-server/handlers.h
@@ -51,6 +51,32 @@ struct RequestLogger {
     }
 };
 
+// Prometheus-style latency histogram (cumulative buckets, in seconds).
+// Lock-free: each observation bumps the matching cumulative buckets + sum +
+// count. Bucket upper bounds are shared by request-duration and TTFT; both
+// are sub-second-to-minutes scale so the same ladder fits.
+struct LatencyHistogram {
+    // le upper bounds in seconds; the implicit +Inf bucket is `count`.
+    static constexpr int kNumBuckets = 11;
+    static constexpr double kBounds[kNumBuckets] = {0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
+                                                    0.5,   1.0,  2.5,   5.0,  10.0};
+    std::atomic<int64_t> buckets[kNumBuckets] = {};
+    std::atomic<int64_t> count{0};
+    // Sum of observed seconds, stored as micros to keep an integer atomic.
+    std::atomic<int64_t> sum_us{0};
+
+    void observe(double seconds) {
+        if (seconds < 0)
+            seconds = 0;
+        for (int i = 0; i < kNumBuckets; ++i) {
+            if (seconds <= kBounds[i])
+                buckets[i].fetch_add(1, std::memory_order_relaxed);
+        }
+        count.fetch_add(1, std::memory_order_relaxed);
+        sum_us.fetch_add(static_cast<int64_t>(seconds * 1e6), std::memory_order_relaxed);
+    }
+};
+
 // Server-wide metrics (atomics for lock-free reads from /metrics endpoint)
 struct ServerMetrics {
     std::atomic<int64_t> requests_total{0};
@@ -61,6 +87,8 @@ struct ServerMetrics {
     std::atomic<int64_t> last_request_duration_ms{0};
     std::atomic<int64_t> last_ttft_ms{0};  // Time to first token (ms)
     std::atomic<int64_t> model_loads_total{0};
+    LatencyHistogram request_duration;  // end-to-end request latency
+    LatencyHistogram ttft;              // time to first token
     std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
 };
 
@@ -103,7 +131,8 @@ struct ServerState {
     // Server limits
     int max_concurrent = 64;
     int request_timeout = 300;
-    int rate_limit = 0;  // requests per minute per IP (0=unlimited)
+    int rate_limit = 0;        // requests per minute per IP (0=unlimited)
+    int max_input_tokens = 0;  // reject prompts longer than this many tokens (0=disabled)
 
     // Rate limiter state: IP → list of request timestamps
     std::mutex rate_mutex;
@@ -151,8 +180,9 @@ void handle_health(const httplib::Request& req, httplib::Response& res, ServerSt
 void handle_models(const httplib::Request& req, httplib::Response& res, ServerState& state);
 void handle_chat_completions(const httplib::Request& req, httplib::Response& res, ServerState& state);
 void handle_completions(const httplib::Request& req, httplib::Response& res, ServerState& state);
-// Anthropic-compatible Messages API. For non-streaming requests this is a
-// thin shim over handle_chat_completions; streaming reserved for Phase 2.
+// Anthropic-compatible Messages API. Non-streaming requests are a thin shim
+// over handle_chat_completions; streaming requests drive the real per-token
+// batching-engine loop and emit native Anthropic SSE events incrementally.
 void handle_messages(const httplib::Request& req, httplib::Response& res, ServerState& state);
 void handle_tokenize(const httplib::Request& req, httplib::Response& res, ServerState& state);
 void handle_detokenize(const httplib::Request& req, httplib::Response& res, ServerState& state);

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -9,6 +9,8 @@
 
 #include <csignal>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 
 using json = nlohmann::json;
@@ -80,6 +82,10 @@ int main(int argc, char** argv) {
     state.max_concurrent = args.max_concurrent;
     state.request_timeout = args.request_timeout;
     state.rate_limit = args.rate_limit;
+
+    // --max-input-tokens <n>: reject prompts whose tokenized length exceeds
+    // <n> with HTTP 400 before prefill (0 = disabled).
+    state.max_input_tokens = args.max_input_tokens;
     if (!args.log_requests_path.empty()) {
         if (state.request_logger.open(args.log_requests_path)) {
             printf("Request logging: appending JSONL to %s\n", args.log_requests_path.c_str());
@@ -170,8 +176,8 @@ int main(int argc, char** argv) {
         handle_completions(req, res, state);
     });
 
-    // Anthropic-compatible Messages API. Non-streaming only in Phase 1;
-    // streaming requests are rejected with 501 until Phase 2 ships.
+    // Anthropic-compatible Messages API. Supports both non-streaming and
+    // native incremental SSE streaming (real per-token, not synthetic replay).
     svr.Post("/v1/messages", [&state](const httplib::Request& req, httplib::Response& res) {
         handle_messages(req, res, state);
     });
@@ -211,6 +217,8 @@ int main(int argc, char** argv) {
         printf("Request timeout: %ds\n", state.request_timeout);
     if (state.rate_limit > 0)
         printf("Rate limit: %d req/min per IP\n", state.rate_limit);
+    if (state.max_input_tokens > 0)
+        printf("Max input tokens: %d\n", state.max_input_tokens);
 
     printf("Server listening on http://%s:%d\n", args.host.c_str(), args.port);
     printf("Endpoints:\n");
@@ -218,7 +226,7 @@ int main(int argc, char** argv) {
     printf("  GET    /v1/models\n");
     printf("  POST   /v1/chat/completions\n");
     printf("  POST   /v1/completions\n");
-    printf("  POST   /v1/messages          Anthropic-compatible (non-streaming)\n");
+    printf("  POST   /v1/messages          Anthropic-compatible (streaming + non-streaming)\n");
     printf("  POST   /v1/embeddings\n");
     printf("  POST   /tokenize\n");
     printf("  POST   /detokenize\n");

--- a/tools/imp-server/tool_call.cpp
+++ b/tools/imp-server/tool_call.cpp
@@ -626,6 +626,98 @@ std::string reconstruct_tool_call_output(imp::ChatTemplateFamily family, const j
     return result;
 }
 
+// ---------------------------------------------------------------------------
+// Tool-call argument validation (self-contained; no engine constraint code).
+// ---------------------------------------------------------------------------
+
+// Does a parsed JSON value match a JSON-schema "type" string? Only the
+// top-level scalar/container kinds are checked — enough to catch the common
+// hallucination failure modes (string where a number is required, missing
+// object, etc.) without reimplementing a full validator.
+static bool json_type_matches(const json& v, const std::string& type) {
+    if (type == "string")
+        return v.is_string();
+    if (type == "integer")
+        return v.is_number_integer() || v.is_number_unsigned();
+    if (type == "number")
+        return v.is_number();
+    if (type == "boolean")
+        return v.is_boolean();
+    if (type == "object")
+        return v.is_object();
+    if (type == "array")
+        return v.is_array();
+    if (type == "null")
+        return v.is_null();
+    return true;  // unknown/compound type ("any", union via array) — accept
+}
+
+// Locate the tool definition for `name` and return its `parameters` schema.
+// Returns an empty object if not found.
+static json find_tool_schema(const json& tools, const std::string& name) {
+    if (!tools.is_array())
+        return json::object();
+    for (const auto& t : tools) {
+        if (!t.is_object())
+            continue;
+        // OpenAI shape: {"type":"function","function":{"name","parameters"}}
+        if (t.contains("function") && t["function"].is_object()) {
+            const auto& fn = t["function"];
+            if (fn.value("name", "") == name)
+                return fn.value("parameters", json::object());
+        }
+        // Bare shape: {"name","parameters"}
+        if (t.value("name", "") == name)
+            return t.value("parameters", json::object());
+    }
+    return json::object();
+}
+
+void validate_tool_call(ParsedToolCall& tc, const json& tools) {
+    json schema = find_tool_schema(tools, tc.name);
+    if (!schema.is_object() || schema.empty())
+        return;  // no schema to validate against — leave as-is
+
+    json args = json::parse(tc.arguments, nullptr, false);
+    if (args.is_discarded() || !args.is_object()) {
+        tc.valid = false;
+        tc.error = "arguments are not a valid JSON object";
+        return;
+    }
+
+    // Required properties must be present.
+    if (schema.contains("required") && schema["required"].is_array()) {
+        for (const auto& r : schema["required"]) {
+            if (!r.is_string())
+                continue;
+            const std::string key = r.get<std::string>();
+            if (!args.contains(key)) {
+                tc.valid = false;
+                tc.error = "missing required argument \"" + key + "\"";
+                return;
+            }
+        }
+    }
+
+    // Top-level property types (best-effort).
+    if (schema.contains("properties") && schema["properties"].is_object()) {
+        const auto& props = schema["properties"];
+        for (auto it = args.begin(); it != args.end(); ++it) {
+            if (!props.contains(it.key()))
+                continue;  // additional property — don't reject
+            const auto& pschema = props[it.key()];
+            if (pschema.is_object() && pschema.contains("type") && pschema["type"].is_string()) {
+                if (!json_type_matches(it.value(), pschema["type"].get<std::string>())) {
+                    tc.valid = false;
+                    tc.error = "argument \"" + it.key() + "\" has wrong type (expected " +
+                               pschema["type"].get<std::string>() + ")";
+                    return;
+                }
+            }
+        }
+    }
+}
+
 std::string format_tool_response(imp::ChatTemplateFamily family, const json& msg) {
     // Tool responses arrive either as a plain string (OpenAI canonical) or as
     // a structured JSON object/array (some clients pass through tool output

--- a/tools/imp-server/tool_call.h
+++ b/tools/imp-server/tool_call.h
@@ -12,10 +12,21 @@
 using json = nlohmann::json;
 
 struct ParsedToolCall {
-    std::string id;         // "call_imp_0", "call_imp_1", ...
-    std::string name;       // Function name
-    std::string arguments;  // JSON string
+    std::string id;            // "call_imp_0", "call_imp_1", ...
+    std::string name;          // Function name
+    std::string arguments;     // JSON string
+    bool valid = true;         // false if arguments failed schema validation
+    std::string error;         // human-readable reason when !valid
 };
+
+// Validate a tool call's parsed arguments against the matching tool's JSON
+// schema (the OpenAI `tools[].function.parameters` object). Checks that the
+// arguments parse as a JSON object, that all `required` properties are
+// present, and that present top-level properties roughly match their declared
+// `type`. On failure sets tc.valid=false and tc.error. Self-contained: does
+// not depend on the engine-side constraint/FSM code. A no-op (leaves the call
+// valid) when the tool or its schema can't be located.
+void validate_tool_call(ParsedToolCall& tc, const json& tools);
 
 std::string build_tool_prompt(imp::ChatTemplateFamily family, const json& tools, const json& tool_choice);
 


### PR DESCRIPTION
## Agent-readiness batch (from the 2026-05-31 audit tasklist)

Implements the tractable agent-backend gaps from `docs/audit/performance_agent_readiness_2026_05_31.md`. Built via 3 parallel sub-agents (server / constraints / CUDA-determinism), centrally verified.

### Shipped & verified
| Feature | Notes |
|---|---|
| **Real `/v1/messages` streaming** | replaces the synthetic full-then-replay path; native incremental SSE (`message_start`→`content_block_delta`→…). Verified live. |
| **Tool-arg validation** | validates parsed tool args against `input_schema` (required + top-level types). Verified (`{"city":"Berlin"}`). |
| **Tool-call delta streaming** | OpenAI `arguments` deltas + Anthropic `input_json_delta`. |
| **Determinism switch** | opt-in `runtime.deterministic` → deterministic MoE routing + top-k. **Default path byte-identical** (host-side kernel-variant branch). Verified: bit-identical tokens at temp=0. |
| **Latency histograms + cache_control** | Prometheus `imp_request_duration_seconds` / `imp_ttft_seconds`; Anthropic `cache_read/creation_input_tokens` accounting. |
| **`--max-input-tokens`** | rejects oversized prompts with HTTP 400 before prefill. Verified (`189 > 50` → 400). |

### Partial (documented follow-ups)
- **JSON-schema `pattern`**: parsing shipped (NFA + `minLength`/`maxLength`); **regex token-masking is disabled** — the NFA over-masked (forbade all tokens → degenerate `!!!!`). `json_object` and schema-structure constraints are unaffected. Follow-up: fix the NFA `step`/`start_set`, then re-enable.
- **GBNF**: non-recursive subset + `GrammarConstrainer` scaffold; not yet wired into `executor.cu`.
- **`thinking` blocks**: `reasoning_content`→Anthropic `thinking` mapping shipped; only fires when reasoning is separated (`--reasoning-format`), not confirmed in the default smoke test.

### Verification
- Docker build green (CUDA 13.3); unit 37/37; GPU tests 73 passed / 0 failed.
- **Decode moat neutral**: tg256 253.0 (new) vs 256.9 (pre-change), within noise — no hot-path regression (determinism variants are opt-in).
- Live-server smoke tests pass for streaming / tools / metrics / input-limit.

### Not in this PR (audit findings, no code)
FA2 prefill crossover is model-dependent (no safe global flip), vLLM prefill gap re-measured at 1.3–1.9×, ncu roofline of grouped-GEMM/FA2, small-M tuning recommendation — all in the audit doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
