### PR TITLE
fix(nvfp4): Phi-4 fused-projection scale split + chat generation-prompt

### DIFF
--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -125,6 +125,36 @@ ChatTemplateFamily ChatTemplate::parse_family(const std::string& name) {
     return ChatTemplateFamily::RAW;
 }
 
+// imp's minimal Jinja2 engine has no {% generation %}/{% endgeneration %} block
+// tags — a HuggingFace chat-template extension that marks the assistant-response
+// span for training-time loss masking (render-neutral). Phi-4-reasoning places
+// them inside the assistant branch; the unknown opening tag derails block nesting
+// so the trailing {% if add_generation_prompt %} is dropped → the assistant
+// generation prompt is never appended → the model emits role markers as text.
+// Strip the (render-neutral) tags before parsing.
+static std::string strip_generation_tags(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    size_t i = 0;
+    while (i < s.size()) {
+        if (s[i] == '{' && i + 1 < s.size() && s[i + 1] == '%') {
+            size_t close = s.find("%}", i + 2);
+            if (close != std::string::npos) {
+                std::string inner = s.substr(i + 2, close - (i + 2));
+                size_t a = inner.find_first_not_of(" \t\r\n-");
+                size_t b = inner.find_last_not_of(" \t\r\n-");
+                std::string kw = (a == std::string::npos) ? std::string() : inner.substr(a, b - a + 1);
+                if (kw == "generation" || kw == "endgeneration") {
+                    i = close + 2;  // drop the whole tag, render its inner body as-is
+                    continue;
+                }
+            }
+        }
+        out.push_back(s[i++]);
+    }
+    return out;
+}
+
 bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer, const std::string& jinja_str) {
     family_ = family;
     stop_token_ids_.clear();
@@ -132,8 +162,9 @@ bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer, c
 
     // Try Jinja2 rendering if template string provided
     if (!jinja_str.empty()) {
+        std::string cleaned = strip_generation_tags(jinja_str);
         auto tpl = std::make_shared<jinja::Template>();
-        if (tpl->parse(jinja_str)) {
+        if (tpl->parse(cleaned)) {
             jinja_tpl_ = std::move(tpl);
             use_jinja_ = true;
             build_control_token_map(tokenizer);

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -645,10 +645,27 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
             else if (proj == "o_proj")
                 slot = "wo";
             else if (proj == "qkv_proj") {
-                // Route weight_scale to wq only (Phase 0 splits to wk/wv).
-                // Scalars (weight_scale_2, input_scale) go to all three.
+                // Scalars (weight_scale_2, input_scale) are per-tensor → route to all
+                // three. weight_scale is per-group [Q+K+V, K/16]; slice it by output-row
+                // range so wk/wv each receive their own per-group scale and get promoted
+                // to NVFP4. (Previously the full fused scale went to wq only → wk/wv had
+                // no weight_scale in the scratch map → Phase 0 skipped promoting them →
+                // garbage K/V projections → degenerate output.)
                 if (kind == "weight_scale") {
-                    route_nvfp4_scale(model, layer_key_prefix + "wq", kind, t);
+                    const auto& mc = model.config_;
+                    int hd = mc.head_dim > 0 ? mc.head_dim : (mc.d_model / mc.n_heads);
+                    int q_rows = mc.n_heads * hd;
+                    int kv_rows = mc.n_kv_heads * hd;
+                    size_t srow = static_cast<size_t>(t.shape[1]);  // UE4M3: 1 byte/group
+                    Tensor sq = t, sk = t, sv = t;
+                    sq.shape[0] = q_rows;
+                    sk.shape[0] = kv_rows;
+                    sk.data = static_cast<char*>(t.data) + static_cast<size_t>(q_rows) * srow;
+                    sv.shape[0] = kv_rows;
+                    sv.data = static_cast<char*>(t.data) + static_cast<size_t>(q_rows + kv_rows) * srow;
+                    route_nvfp4_scale(model, layer_key_prefix + "wq", kind, sq);
+                    route_nvfp4_scale(model, layer_key_prefix + "wk", kind, sk);
+                    route_nvfp4_scale(model, layer_key_prefix + "wv", kind, sv);
                 } else {
                     route_nvfp4_scale(model, layer_key_prefix + "wq", kind, t);
                     route_nvfp4_scale(model, layer_key_prefix + "wk", kind, t);
@@ -674,10 +691,18 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
             else if (proj == "down_proj")
                 slot = "w_down";
             else if (proj == "gate_up_proj") {
-                // Route weight_scale to w_gate only (Phase 0 splits to w_up).
-                // Scalars (weight_scale_2, input_scale) go to both.
+                // weight_scale [2*ff, K/16] → slice into gate/up halves so w_up gets
+                // its own per-group scale and is promoted (was routed to w_gate only →
+                // w_up unpromoted → garbage up-projection). Scalars go to both.
                 if (kind == "weight_scale") {
-                    route_nvfp4_scale(model, layer_key_prefix + "w_gate", kind, t);
+                    int64_t half = t.shape[0] / 2;
+                    size_t srow = static_cast<size_t>(t.shape[1]);
+                    Tensor sg = t, su = t;
+                    sg.shape[0] = half;
+                    su.shape[0] = half;
+                    su.data = static_cast<char*>(t.data) + static_cast<size_t>(half) * srow;
+                    route_nvfp4_scale(model, layer_key_prefix + "w_gate", kind, sg);
+                    route_nvfp4_scale(model, layer_key_prefix + "w_up", kind, su);
                 } else {
                     route_nvfp4_scale(model, layer_key_prefix + "w_gate", kind, t);
                     route_nvfp4_scale(model, layer_key_prefix + "w_up", kind, t);


### PR DESCRIPTION
## Fix Phi-4-NVFP4 (Phi3ForCausalLM): fused-projection scale split + chat generation prompt

Phi-4-reasoning-plus-NVFP4 was listed as broken (degenerate, prompt-blind output). Root-caused two independent bugs.

### Bug 1 — fused qkv/gate_up `weight_scale` never split to sub-projections (`53767eaf`)
Phi-3/Phi-4 fuse q/k/v into `qkv_proj` and gate/up into `gate_up_proj` with a **single** per-group `weight_scale` (`[Q+K+V, K/16]` / `[2·ff, K/16]`). The loader routed that scale only to the primary slot (`wq` / `w_gate`), so the split targets **wk, wv, w_up** had no `weight_scale` in `nvfp4_scratch_` → Phase 0 skipped promoting them to NVFP4 → garbage K/V and up-projection.

**Fix:** slice the fused `weight_scale` by output-row range and route each slice to its slot.

**Evidence:**
- Promoted NVFP4 weights **160 → 280** (was 4/layer, now the full 7/layer × 40).
- Slice geometry verified against checkpoint shapes (`weight_scale` `[7680, 320]` / `[35840, 320]`).
- **Completion-mode output now correct + prompt-sensitive**: `2+2`→`4`, `largest city in Germany`→`Berlin`, `one, two, three, four,`→`five, six, seven…`.
- Only affects fused-projection models (Phi-3/Phi-4); separate-q/k/v models (Qwen3 etc.) unaffected (regression-checked: Qwen3-8B still coherent).

### Bug 2 — `{% generation %}` tags broke `add_generation_prompt` (`3c649650`)
Phi-4's chat template wraps the assistant span in `{% generation %}…{% endgeneration %}` (a HF loss-mask marker, render-neutral). imp's minimal Jinja2 engine doesn't know the tag; the unknown opener derailed block nesting so the trailing `{% if add_generation_prompt %}{{ '<|im_start|>assistant<|im_sep|>' }}{% endif %}` was dropped → no generation prompt → model emitted role markers as text.

**Fix:** strip the render-neutral `{% generation %}`/`{% endgeneration %}` tags before parsing.

**Evidence:** rendered chat prompt now correctly ends with `<|im_start|>assistant<|im_sep|>` (previously ended at `<|im_end|>`).

### Honest residual (not blocking)
With both fixes the model **loads correctly, is promoted fully, and is coherent + prompt-sensitive in completion mode**, and the chat prompt is now structurally correct. However, Phi-4-reasoning-plus **chat-mode** output on trivial prompts (e.g. "15+27") is still meta-heavy/poor under its mandatory reasoning system prompt — this appears inherent to the reasoning model (designed for long `<think>` on hard problems) and/or a deeper decoding nuance, independent of the two bugs fixed here. Completion-mode correctness proves the weights/load path are fixed.

Build green (CUDA 13.3). No GPU CI runner — validation above is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
