### PR TITLE
fix(constraints): preamble gate enforces immediately when thinking already closed (/no_think)

### DIFF
--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -82,8 +82,8 @@ public:
     // models with </think>); close_token<0 + max_tokens>0 enables budget-only
     // mode (markdown-fence preambles). Both modes also exit on the first
     // `{` / `[` seen. Pass close_token=-1 with max_tokens<=0 to fully disable.
-    void set_preamble(int32_t close_token, int max_tokens = 8192) {
-        preamble_.configure(close_token, max_tokens);
+    void set_preamble(int32_t close_token, int max_tokens = 8192, bool thinking_open = true) {
+        preamble_.configure(close_token, max_tokens, thinking_open);
     }
 
     // Tool-aware preamble: when configured, the gate stays "no-mask" through
@@ -94,12 +94,13 @@ public:
                                  std::vector<int32_t> open_tokens,
                                  std::vector<int32_t> close_tokens,
                                  std::string open_prefix,
-                                 std::string close_suffix) {
+                                 std::string close_suffix,
+                                 bool thinking_open = true) {
         preamble_.configure_with_tools(close_token, max_tokens,
                                        std::move(open_tokens),
                                        std::move(close_tokens),
                                        std::move(open_prefix),
-                                       std::move(close_suffix));
+                                       std::move(close_suffix), thinking_open);
     }
 
 private:

--- a/src/compute/preamble_gate.h
+++ b/src/compute/preamble_gate.h
@@ -43,12 +43,12 @@ namespace imp {
 class PreambleGate {
 public:
     // Existing two-arg overload — preserved for non-tool callers.
-    void configure(int32_t close_token, int max_tokens) {
+    void configure(int32_t close_token, int max_tokens, bool thinking_open = true) {
         configure_with_tools(close_token, max_tokens,
                              /*open_tokens=*/{},
                              /*close_tokens=*/{},
                              /*open_prefix=*/"",
-                             /*close_suffix=*/"");
+                             /*close_suffix=*/"", thinking_open);
     }
 
     // Tool-aware configure. open_tokens/close_tokens are token IDs of
@@ -62,19 +62,31 @@ public:
                               std::vector<int32_t> open_tokens,
                               std::vector<int32_t> close_tokens,
                               std::string open_prefix,
-                              std::string close_suffix) {
+                              std::string close_suffix,
+                              bool thinking_open = true) {
         max_tokens_ = max_tokens > 0 ? max_tokens : 0;
         close_token_ = close_token;
         open_tokens_ = std::move(open_tokens);
         close_tokens_ = std::move(close_tokens);
         open_prefix_ = std::move(open_prefix);
         close_suffix_ = std::move(close_suffix);
+        thinking_open_ = thinking_open;
         configured_ = (close_token >= 0) || (max_tokens_ > 0);
         reset();
     }
 
     void reset() {
-        state_ = configured_ ? State::ACTIVE : State::OFF;
+        // Reasoning models gate on </think>. But if generation begins with the
+        // thinking block ALREADY closed (e.g. /no_think — the template emits an
+        // empty <think></think> in the prompt, so no </think> is ever generated),
+        // there is nothing to absorb: waiting for a close token that never comes
+        // would let the model ramble unconstrained until the budget. Start OFF so
+        // the structural mask enforces immediately. Tool-aware mode keeps ACTIVE
+        // (tool openers may still appear post-think) and budget-only mode is
+        // unaffected (close_token_ < 0).
+        const bool reasoning_already_closed =
+            (close_token_ >= 0) && !thinking_open_ && !tool_detection_active();
+        state_ = (configured_ && !reasoning_already_closed) ? State::ACTIVE : State::OFF;
         seen_ = 0;
         char_buf_.clear();
     }
@@ -211,6 +223,7 @@ private:
     }
 
     bool configured_ = false;
+    bool thinking_open_ = true;  // false = thinking already closed at gen start (e.g. /no_think)
     State state_ = State::OFF;
     int32_t close_token_ = -1;
     int max_tokens_ = 0;

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -84,8 +84,8 @@ public:
 
     // See JsonConstrainer::set_preamble for semantics — close-token mode for
     // reasoning models (</think>) or budget-only mode for markdown fences.
-    void set_preamble(int32_t close_token, int max_tokens = 8192) {
-        preamble_.configure(close_token, max_tokens);
+    void set_preamble(int32_t close_token, int max_tokens = 8192, bool thinking_open = true) {
+        preamble_.configure(close_token, max_tokens, thinking_open);
     }
 
     // Tool-aware preamble: when configured, the gate stays "no-mask" through
@@ -96,12 +96,13 @@ public:
                                  std::vector<int32_t> open_tokens,
                                  std::vector<int32_t> close_tokens,
                                  std::string open_prefix,
-                                 std::string close_suffix) {
+                                 std::string close_suffix,
+                                 bool thinking_open = true) {
         preamble_.configure_with_tools(close_token, max_tokens,
                                        std::move(open_tokens),
                                        std::move(close_tokens),
                                        std::move(open_prefix),
-                                       std::move(close_suffix));
+                                       std::move(close_suffix), thinking_open);
     }
 
 private:

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -78,7 +78,7 @@ ToolDialect resolve_tool_dialect(Tokenizer* tokenizer, ChatTemplateFamily family
 }  // namespace
 
 void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, Tokenizer* tokenizer,
-                                bool has_tools, ChatTemplateFamily tpl_family) {
+                                bool has_tools, ChatTemplateFamily tpl_family, bool thinking_open) {
     active_json_ = false;
     active_schema_ = false;
 
@@ -115,9 +115,9 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
         if (has_tools) {
             constrainer->set_preamble_with_tools(think_close, preamble_budget,
                                                  dialect.open_tokens, dialect.close_tokens,
-                                                 dialect.open_prefix, dialect.close_suffix);
+                                                 dialect.open_prefix, dialect.close_suffix, thinking_open);
         } else {
-            constrainer->set_preamble(think_close, preamble_budget);
+            constrainer->set_preamble(think_close, preamble_budget, thinking_open);
         }
     };
 

--- a/src/runtime/constraint_manager.h
+++ b/src/runtime/constraint_manager.h
@@ -29,7 +29,8 @@ public:
     //   for (only consulted when has_tools is true)
     void prepare(bool json_mode, const std::string& json_schema, Tokenizer* tokenizer,
                  bool has_tools = false,
-                 ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML);
+                 ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML,
+                 bool thinking_open = true);
 
     // Get current constrainer pointers (nullptr if not active).
     JsonConstrainer* json_constrainer() const noexcept {

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -532,8 +532,12 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     fill_sampling_params(*req, state);
 
     // Constraints via ConstraintManager
+    // thinking_open = req->in_think_block: if the prompt already closed the
+    // <think> block (e.g. /no_think emits an empty <think></think> in the
+    // prompt), no </think> is ever generated — the preamble gate must enforce
+    // immediately instead of absorbing prose until the budget.
     constraints_.prepare(req->json_mode, req->json_schema, model_->tokenizer(), req->has_tools,
-                         req->tpl_family);
+                         req->tpl_family, /*thinking_open=*/req->in_think_block);
     state.json_constrainer = constraints_.json_constrainer();
     state.schema_constrainer = constraints_.schema_constrainer();
 

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -509,5 +509,33 @@ TEST(PreambleGateTest, ToolModeReasoningBudgetResetsAfterThinkClose) {
     EXPECT_FALSE(g.active());
 }
 
+TEST(PreambleGateTest, ThinkingAlreadyClosedStartsEnforcing) {
+    // Reasoning model, but the prompt already closed <think> (e.g. /no_think):
+    // there is no </think> to wait for, so the gate must enforce immediately.
+    PreambleGate g;
+    g.configure(TOK_THINK_CLOSE, 8192, /*thinking_open=*/false);
+    EXPECT_FALSE(g.active()) << "thinking already closed -> mask enforced from token 0";
+    EXPECT_FALSE(g.absorb(TOK_TEXT, "Okay")) << "must not absorb a free-form preamble";
+}
+
+TEST(PreambleGateTest, ThinkingOpenStillAbsorbsUntilClose) {
+    // Normal reasoning request (thinking open) is unchanged: absorb until </think>.
+    PreambleGate g;
+    g.configure(TOK_THINK_CLOSE, 8192, /*thinking_open=*/true);
+    EXPECT_TRUE(g.active());
+    EXPECT_TRUE(g.absorb(TOK_TEXT, "reasoning..."));
+    EXPECT_TRUE(g.active());
+    EXPECT_TRUE(g.absorb(TOK_THINK_CLOSE, "</think>"));
+    EXPECT_FALSE(g.active());
+}
+
+TEST(PreambleGateTest, BudgetOnlyModeUnaffectedByThinkingFlag) {
+    // Non-reasoning model (close_token < 0) keeps the small budget window even
+    // when thinking_open=false (the flag only matters in close-token mode).
+    PreambleGate g;
+    g.configure(/*close_token=*/-1, /*max_tokens=*/8, /*thinking_open=*/false);
+    EXPECT_TRUE(g.active());
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## The bug
The preamble gate keeps the mask OFF (pass-through) while a reasoning model emits its `<think>...</think>` preamble, exiting on `</think>`. But with **/no_think** the chat template puts an *empty* `<think></think>` in the **prompt** — so no `</think>` is ever generated. The gate stayed in pass-through and the model produced free-form prose up to the 8192-token budget, so **`json_object` / `json_schema` constraints never engaged at all** (observed: the model answered in prose, ignoring the schema).

## The fix
Plumb the request's `in_think_block` through `prepare()` → `set_preamble` → `PreambleGate::configure` as `thinking_open`. When a reasoning model (`close_token >= 0`) begins with thinking **already closed** (and no tool detection), the gate starts `OFF` so the structural mask enforces from token 0.

- Normal reasoning (thinking open): unchanged — absorbs until `</think>`.
- Non-reasoning budget mode (`close_token < 0`): unchanged.
- Tool-aware mode: unchanged (stays ACTIVE for post-think tool openers).

New unit tests: `PreambleGateTest.{ThinkingAlreadyClosedStartsEnforcing, ThinkingOpenStillAbsorbsUntilClose, BudgetOnlyModeUnaffectedByThinkingFlag}`. Build green; constraint path only (decode hot path untouched).

## ⚠️ Surfaces a separate, deeper bug (next to fix)
Making the constraint actually engage for /no_think reasoning requests reveals a **pre-existing schema-FSM bug**: with the real subword vocab, `OBJECT_KEY` property-name masking over-restricts — the model emits a wrong key then degenerates (`{\n  "Why!!!!`). This is the **schema FSM**, not the regex NFA (proven correct in #497). So json_schema still does not produce correct end-to-end output; that FSM fix is the immediate follow-up. (`json_object` is also degenerate end-to-end with the real vocab.) This PR is a correct, necessary prerequisite, not the full end-to-end fix for constrained output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)