### PR TITLE
fix(constraints): per-token FSM simulation for schema-constrained JSON

### DIFF
--- a/src/compute/json_schema.cpp
+++ b/src/compute/json_schema.cpp
@@ -354,6 +354,14 @@ private:
         }
         expect('}');
 
+        // Enum takes precedence over a co-declared "type". Key order in the
+        // object is not significant in JSON, and clients commonly emit
+        // {"type":"string","enum":[...]} — a later "type":"string" must NOT
+        // demote the node back to a free string (the constrainer would then
+        // accept any value). Resolve this order-independently.
+        if (!node->enum_values.empty())
+            node->type = SchemaType::ENUM;
+
         return node;
     }
 };

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -29,6 +29,7 @@ bool SchemaConstrainer::init(const Tokenizer& tok, std::unique_ptr<SchemaNode> s
         return false;
 
     vocab_size_ = tok.vocab_size();
+    eos_tokens_ = tok.eos_ids();
 
     // Classify all tokens (same logic as JsonConstrainer)
     token_categories_.resize(vocab_size_, 0);
@@ -156,7 +157,11 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
     const auto& f = top();
     switch (f.phase) {
         case SchemaPhase::VALUE_START: {
-            uint16_t mask = CAT_WHITESPACE;
+            // No insignificant whitespace: a reasoning model whose top token is
+            // a newline would otherwise stall forever (whitespace is always
+            // re-allowed, never forcing structural progress). Compact JSON only
+            // — whitespace *inside* string values is CAT_STRING_CHAR, untouched.
+            uint16_t mask = 0;
             if (!f.node)
                 return mask | CAT_VALUE_START;
             switch (f.node->type) {
@@ -193,7 +198,7 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
         }
 
         case SchemaPhase::OBJECT_OPEN: {
-            uint16_t mask = CAT_WHITESPACE | CAT_QUOTE;  // " for key
+            uint16_t mask = CAT_QUOTE;  // " for key (compact JSON, no whitespace)
             // Allow } only if all required keys are emitted
             bool all_required = true;
             if (f.node) {
@@ -213,13 +218,13 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
             return CAT_STRING_CHAR | CAT_QUOTE;  // token_allow handles key constraining
 
         case SchemaPhase::OBJECT_AFTER_KEY:
-            return CAT_COLON | CAT_WHITESPACE;
+            return CAT_COLON;
 
         case SchemaPhase::OBJECT_COLON:
-            return CAT_COLON | CAT_WHITESPACE;
+            return CAT_COLON;
 
         case SchemaPhase::OBJECT_AFTER_VALUE: {
-            uint16_t mask = CAT_WHITESPACE | CAT_COMMA;
+            uint16_t mask = CAT_COMMA;
             bool all_required = true;
             if (f.node) {
                 for (auto& req : f.node->required) {
@@ -235,7 +240,7 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
         }
 
         case SchemaPhase::ARRAY_OPEN: {
-            uint16_t mask = CAT_WHITESPACE | CAT_CLOSE_BRACKET;
+            uint16_t mask = CAT_CLOSE_BRACKET;
             // Allow value start for first item
             if (f.node && f.node->items) {
                 switch (f.node->items->type) {
@@ -266,7 +271,7 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
         }
 
         case SchemaPhase::ARRAY_AFTER_ITEM:
-            return CAT_WHITESPACE | CAT_COMMA | CAT_CLOSE_BRACKET;
+            return CAT_COMMA | CAT_CLOSE_BRACKET;
 
         case SchemaPhase::STRING_VALUE:
             return CAT_STRING_CHAR | CAT_QUOTE;
@@ -280,7 +285,7 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
             return 0xFFFF;  // any char valid after backslash
 
         case SchemaPhase::NUMBER_VALUE:
-            return CAT_NUMBER_CONT | CAT_WHITESPACE | CAT_COMMA | CAT_CLOSE_BRACE | CAT_CLOSE_BRACKET;
+            return CAT_NUMBER_CONT | CAT_COMMA | CAT_CLOSE_BRACE | CAT_CLOSE_BRACKET;
 
         case SchemaPhase::LITERAL_VALUE:
             return CAT_LITERAL_CONT;
@@ -303,155 +308,19 @@ void SchemaConstrainer::compute_token_allow_mask() {
 
     if (stack_.empty())
         return;
-    const auto& f = top();
 
-    if (f.phase == SchemaPhase::OBJECT_KEY && f.node) {
-        // Constrain tokens to valid property name prefixes/completions
-        need_token_allow_ = true;
-        const auto& prefix = f.key_buffer;
-
-        for (int i = 0; i < vocab_size_; i++) {
-            const auto& text = token_texts_[i];
-            if (text.empty()) {
-                token_allow_[i] = 0;
-                continue;
-            }
-
-            // Check if this token could be part of a valid key
-            std::string extended = prefix + text;
-            bool valid = false;
-
-            // Check if token is the closing quote
-            if (text == "\"") {
-                // Allow quote only if current prefix is a complete valid key
-                for (auto& [name, _] : f.node->properties) {
-                    if (!f.emitted_keys.count(name) && name == prefix) {
-                        valid = true;
-                        break;
-                    }
-                }
-            } else {
-                // Check if extended prefix matches any remaining property name
-                // Handle tokens that contain the closing quote (e.g. `name"`)
-                bool has_quote = text.find('"') != std::string::npos;
-                if (has_quote) {
-                    // Token contains quote — check if text before quote is a complete key
-                    size_t qpos = text.find('"');
-                    std::string key_part = prefix + text.substr(0, qpos);
-                    for (auto& [name, _] : f.node->properties) {
-                        if (!f.emitted_keys.count(name) && name == key_part) {
-                            valid = true;
-                            break;
-                        }
-                    }
-                } else {
-                    valid = is_valid_key_prefix(f.node, extended, f.emitted_keys);
-                }
-            }
-
-            token_allow_[i] = valid ? 1 : 0;
-        }
-    } else if (f.phase == SchemaPhase::ENUM_VALUE && f.node) {
-        // Constrain tokens to valid enum value prefixes
-        need_token_allow_ = true;
-        const auto& prefix = f.enum_buffer;
-
-        for (int i = 0; i < vocab_size_; i++) {
-            const auto& text = token_texts_[i];
-            if (text.empty()) {
-                token_allow_[i] = 0;
-                continue;
-            }
-
-            if (text == "\"") {
-                // Allow closing quote only if prefix is a complete enum value
-                bool complete = false;
-                for (auto& v : f.node->enum_values) {
-                    if (v == prefix) {
-                        complete = true;
-                        break;
-                    }
-                }
-                token_allow_[i] = complete ? 1 : 0;
-            } else {
-                std::string extended = prefix + text;
-                token_allow_[i] = is_valid_enum_prefix(f.node->enum_values, extended) ? 1 : 0;
-            }
-        }
-    } else if (f.phase == SchemaPhase::STRING_PATTERN && f.node) {
-        // Constrain tokens so the emitted string matches the regex / length.
-        need_token_allow_ = true;
-        for (int i = 0; i < vocab_size_; i++) {
-            const auto& text = token_texts_[i];
-            if (text.empty()) {
-                token_allow_[i] = 0;
-                continue;
-            }
-
-            size_t qpos = text.find('"');
-            if (qpos == std::string::npos) {
-                // Pure content token: must keep the regex prefix alive.
-                std::vector<int> st;
-                int len = 0;
-                token_allow_[i] = token_keeps_pattern_alive(f, text, st, len) ? 1 : 0;
-            } else {
-                // Token closes the string at qpos. Require: the content before
-                // the quote keeps the pattern alive, the close is legal, and
-                // nothing follows the quote (can't emit past string end here).
-                if (qpos + 1 != text.size()) {
-                    token_allow_[i] = 0;
-                    continue;
-                }
-                std::string content = text.substr(0, qpos);
-                std::vector<int> st;
-                int len = 0;
-                bool alive = token_keeps_pattern_alive(f, content, st, len);
-                token_allow_[i] = (alive && can_close_string(f, st, len)) ? 1 : 0;
-            }
-        }
-    } else if (f.phase == SchemaPhase::OBJECT_OPEN && f.node) {
-        // Multi-char tokens beginning with the opening quote (e.g. `"code`,
-        // `"id"`) open the key string AND emit key chars in a single step,
-        // bypassing the OBJECT_KEY prefix narrowing above. Constrain them here:
-        // the chars after the opening `"` must form a valid key prefix (or, if
-        // the token also carries the closing quote, a complete unemitted key).
-        // Without this, a quote-prefixed non-key token (`"Why`) slips through
-        // on its CAT_QUOTE bit alone and the FSM gets stuck mid-key → "!!!!".
-        //
-        // Non-quote tokens (whitespace, `}`) are gated by the category mask; we
-        // leave them allowed (=1) so the kernel's category-AND-allow is a no-op.
-        need_token_allow_ = true;
-        for (int i = 0; i < vocab_size_; i++) {
-            const auto& text = token_texts_[i];
-            if (text.empty() || text[0] != '"') {
-                token_allow_[i] = 1;
-                continue;
-            }
-            const std::string rest = text.substr(1);
-            bool valid = false;
-            if (rest.empty()) {
-                // Bare opening quote — always a legal key start.
-                valid = true;
-            } else {
-                size_t qpos = rest.find('"');
-                if (qpos == std::string::npos) {
-                    // Quote + partial key chars: must stay a valid key prefix.
-                    valid = is_valid_key_prefix(f.node, rest, f.emitted_keys);
-                } else if (qpos + 1 == rest.size()) {
-                    // Quote + complete key + closing quote (e.g. `"id"`).
-                    std::string key_part = rest.substr(0, qpos);
-                    for (auto& [name, _] : f.node->properties) {
-                        if (!f.emitted_keys.count(name) && name == key_part) {
-                            valid = true;
-                            break;
-                        }
-                    }
-                }
-                // A closing quote with trailing chars (`"id":`) is left masked;
-                // the model can take the bare-quote path instead.
-            }
-            token_allow_[i] = valid ? 1 : 0;
-        }
+    // Full per-token legality: a candidate token is allowed only if simulating
+    // its entire text from the current FSM state stays legal at every char.
+    // This is what the first-char category mask cannot do — it catches
+    // multi-char tokens that span phase transitions (`{}` closing an object
+    // with unmet required keys, `":"` as a bogus enum value, `"Why` opening a
+    // non-existent key, `0.98` for an integer). The category mask still runs
+    // alongside (it governs EOS / whitespace / structural first-char), so a
+    // token must pass BOTH. token_legal() handles empty (EOS/special) tokens by
+    // deferring to the category mask.
+    need_token_allow_ = true;
+    for (int i = 0; i < vocab_size_; i++) {
+        token_allow_[i] = token_legal(token_texts_[i]) ? 1 : 0;
     }
 }
 
@@ -460,11 +329,32 @@ void SchemaConstrainer::compute_token_allow_mask() {
 // ---------------------------------------------------------------------------
 
 void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t stream) {
-    if (!initialized_ || stack_.empty())
+    if (!initialized_)
         return;
 
     if (preamble_.active())
         return;
+
+    // Root value complete (stack drained): force EOS so generation stops cleanly
+    // instead of trailing free text after the closing brace/bracket. Mask
+    // everything except the EOS token(s) via the allow path (category = all).
+    if (stack_.empty()) {
+        if (eos_tokens_.empty())
+            return;  // no EOS to force — leave the model unconstrained
+        std::fill(token_allow_.begin(), token_allow_.end(), (uint8_t)0);
+        for (int32_t e : eos_tokens_)
+            if (e >= 0 && e < vocab_size_)
+                token_allow_[e] = 1;
+        uint16_t all_cats = 0xFFFF;
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_allowed_mask_, &all_cats, sizeof(uint16_t),
+                                           cudaMemcpyHostToDevice, stream));
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, token_allow_.data(),
+                                           vocab_size_ * sizeof(uint8_t), cudaMemcpyHostToDevice, stream));
+        int t = 256, b = (vocab_size + t - 1) / t;
+        constrain_mask_allow_kernel<<<b, t, 0, stream>>>(d_logits, d_token_categories_, d_token_allow_,
+                                                         d_allowed_mask_, vocab_size, /*use_allow=*/true);
+        return;
+    }
 
     // Compute masks
     uint16_t cat_mask = compute_category_mask();
@@ -503,7 +393,8 @@ void SchemaConstrainer::update(int32_t token) {
         return;
     SchemaPhase before = top().phase;
     for (char c : text) {
-        advance_char(c);
+        if (!sim_advance(stack_, c))
+            break;  // illegal char (mask should have prevented this) — stop early
     }
     if (!stack_.empty()) {
         IMP_LOG_DEBUG("SchemaConstrainer::update token=%d [%s] phase %d->%d stack=%zu", token, text.c_str(),
@@ -511,38 +402,73 @@ void SchemaConstrainer::update(int32_t token) {
     }
 }
 
-void SchemaConstrainer::advance_char(char c) {
-    if (stack_.empty())
+// After a value frame pops, advance the parent frame's phase. Shared by the
+// transition simulator below.
+static void sim_fixup_parent(std::vector<SchemaFrame>& stk) {
+    if (stk.empty())
         return;
+    SchemaFrame& parent = stk.back();
+    if (parent.phase == SchemaPhase::OBJECT_COLON)
+        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
+    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
+             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
+        parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
+}
 
-    auto& f = top();
+// ---------------------------------------------------------------------------
+// Transition simulator — the single source of truth for the schema grammar.
+// Drives the real update path (on stack_) and per-token mask legality (on a
+// cloned stack). Returns false on any illegal transition, so a multi-char
+// token that spans phase transitions (`{}`, `":"`, `"Why`, integer `0.98`,
+// trailing comma) is rejected as a whole rather than slipping past the
+// first-char category mask.
+// ---------------------------------------------------------------------------
+bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const {
+    if (stk.empty())
+        return false;  // trailing content after the root value completed
+
+    SchemaFrame& f = stk.back();
+    auto push_value = [&](const SchemaNode* node) {
+        SchemaFrame nf;
+        nf.node = node;
+        nf.phase = SchemaPhase::VALUE_START;
+        stk.push_back(std::move(nf));
+    };
+    auto required_satisfied = [](const SchemaFrame& fr) {
+        if (!fr.node)
+            return true;
+        for (auto& req : fr.node->required)
+            if (!fr.emitted_keys.count(req))
+                return false;
+        return true;
+    };
+    auto has_unemitted_property = [](const SchemaFrame& fr) {
+        if (!fr.node)
+            return true;  // unknown object — can't tell, allow another key
+        for (auto& [name, _] : fr.node->properties)
+            if (!fr.emitted_keys.count(name))
+                return true;
+        return false;
+    };
+    const bool space = std::isspace(static_cast<unsigned char>(c)) != 0;
 
     switch (f.phase) {
         case SchemaPhase::VALUE_START: {
-            if (std::isspace(static_cast<unsigned char>(c)))
-                return;
+            if (space)
+                return true;
             if (!f.node) {
-                stack_.pop_back();
-                return;
+                stk.pop_back();  // unconstrained value — accept opaquely
+                return true;
             }
-
             switch (f.node->type) {
                 case SchemaType::OBJECT:
-                    if (c == '{') {
-                        f.phase = SchemaPhase::OBJECT_OPEN;
-                        return;
-                    }
-                    break;
+                    if (c == '{') { f.phase = SchemaPhase::OBJECT_OPEN; return true; }
+                    return false;
                 case SchemaType::ARRAY:
-                    if (c == '[') {
-                        f.phase = SchemaPhase::ARRAY_OPEN;
-                        return;
-                    }
-                    break;
+                    if (c == '[') { f.phase = SchemaPhase::ARRAY_OPEN; return true; }
+                    return false;
                 case SchemaType::STRING:
                     if (c == '"') {
-                        // Use the pattern-constrained string phase when the
-                        // schema specifies a (compiled) pattern or a length bound.
                         if ((f.node->pattern_nfa && f.node->pattern_nfa->compiled()) ||
                             f.node->min_length >= 0 || f.node->max_length >= 0) {
                             f.phase = SchemaPhase::STRING_PATTERN;
@@ -554,306 +480,275 @@ void SchemaConstrainer::advance_char(char c) {
                         } else {
                             f.phase = SchemaPhase::STRING_VALUE;
                         }
-                        return;
+                        return true;
                     }
-                    break;
+                    return false;
                 case SchemaType::NUMBER:
                 case SchemaType::INTEGER:
                     if (c == '-' || (c >= '0' && c <= '9')) {
                         f.phase = SchemaPhase::NUMBER_VALUE;
-                        return;
+                        f.string_len = (c >= '0' && c <= '9') ? 1 : 0;  // digit count
+                        f.num_leading_zero = (c == '0');  // "0..." forbids more int digits
+                        return true;
                     }
-                    break;
+                    return false;
                 case SchemaType::BOOLEAN:
-                    if (c == 't') {
-                        f.phase = SchemaPhase::LITERAL_VALUE;
-                        f.literal_target = "true";
-                        f.literal_pos = 1;
-                        return;
-                    }
-                    if (c == 'f') {
-                        f.phase = SchemaPhase::LITERAL_VALUE;
-                        f.literal_target = "false";
-                        f.literal_pos = 1;
-                        return;
-                    }
-                    break;
+                    if (c == 't') { f.phase = SchemaPhase::LITERAL_VALUE; f.literal_target = "true"; f.literal_pos = 1; return true; }
+                    if (c == 'f') { f.phase = SchemaPhase::LITERAL_VALUE; f.literal_target = "false"; f.literal_pos = 1; return true; }
+                    return false;
                 case SchemaType::NULL_TYPE:
-                    if (c == 'n') {
-                        f.phase = SchemaPhase::LITERAL_VALUE;
-                        f.literal_target = "null";
-                        f.literal_pos = 1;
-                        return;
-                    }
-                    break;
+                    if (c == 'n') { f.phase = SchemaPhase::LITERAL_VALUE; f.literal_target = "null"; f.literal_pos = 1; return true; }
+                    return false;
                 case SchemaType::ENUM:
-                    if (c == '"') {
-                        f.phase = SchemaPhase::ENUM_VALUE;
-                        f.enum_buffer.clear();
-                        return;
-                    }
-                    break;
+                    if (c == '"') { f.phase = SchemaPhase::ENUM_VALUE; f.enum_buffer.clear(); return true; }
+                    return false;
                 case SchemaType::ANY_OF:
-                    // For anyOf, we can't easily constrain — treat as unconstrained value
+                    // anyOf is hard to constrain precisely — accept as free string.
                     f.phase = SchemaPhase::STRING_VALUE;
-                    return;
+                    return true;
                 default:
-                    break;
+                    return false;
             }
-            break;
         }
 
         case SchemaPhase::OBJECT_OPEN: {
-            if (std::isspace(static_cast<unsigned char>(c)))
-                return;
+            if (space)
+                return true;
             if (c == '}') {
-                stack_.pop_back();  // object complete
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-                             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
-                        parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
-                }
-                return;
+                // After a comma a key is mandatory — closing here is a trailing
+                // comma. Otherwise close only once required keys are present.
+                if (f.after_comma || !required_satisfied(f))
+                    return false;
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
             if (c == '"') {
                 f.phase = SchemaPhase::OBJECT_KEY;
                 f.key_buffer.clear();
-                return;
+                f.after_comma = false;
+                return true;
             }
-            break;
+            return false;
         }
 
         case SchemaPhase::OBJECT_KEY: {
             if (c == '"') {
-                // Key complete
+                // Close the key only if it is a complete, not-yet-emitted property.
+                bool complete = false;
+                if (f.node) {
+                    for (auto& [name, _] : f.node->properties) {
+                        if (!f.emitted_keys.count(name) && name == f.key_buffer) { complete = true; break; }
+                    }
+                }
+                if (!complete)
+                    return false;
                 f.current_key = f.key_buffer;
                 f.emitted_keys.insert(f.current_key);
                 f.phase = SchemaPhase::OBJECT_AFTER_KEY;
-                return;
+                return true;
             }
             if (c == '\\')
-                return;  // escape in key (rare but valid)
+                return true;  // key escape (rare)
+            if (!f.node || !is_valid_key_prefix(f.node, f.key_buffer + c, f.emitted_keys))
+                return false;
             f.key_buffer += c;
-            return;
+            return true;
         }
 
         case SchemaPhase::OBJECT_AFTER_KEY: {
-            if (std::isspace(static_cast<unsigned char>(c)))
-                return;
+            if (space)
+                return true;
             if (c == ':') {
                 f.phase = SchemaPhase::OBJECT_COLON;
-                // Push value frame for this property
-                const SchemaNode* prop_schema = find_property(f.node, f.current_key);
-                if (prop_schema) {
-                    push_value_frame(prop_schema);
-                } else {
-                    // Unknown property — allow any value (permissive)
-                    push_value_frame(nullptr);
-                }
-                return;
+                const SchemaNode* prop = f.node ? find_property(f.node, f.current_key) : nullptr;
+                push_value(prop);
+                return true;
             }
-            break;
+            return false;
         }
 
         case SchemaPhase::OBJECT_COLON: {
-            // Value was pushed as a sub-frame — this phase is re-entered
-            // when the value completes and the sub-frame is popped.
-            if (std::isspace(static_cast<unsigned char>(c)))
-                return;
-            // Should not reach here in normal flow (value frame handles it)
-            // but handle comma/brace for robustness
+            // The value is normally handled by the pushed sub-frame; this branch
+            // only fires for robustness if a comma/brace reaches the colon frame.
+            if (space)
+                return true;
             if (c == ',') {
-                f.phase = SchemaPhase::OBJECT_OPEN;  // next key
-                return;
+                if (!has_unemitted_property(f))
+                    return false;  // no more keys possible — comma would dangle
+                f.phase = SchemaPhase::OBJECT_OPEN;
+                f.after_comma = true;
+                return true;
             }
             if (c == '}') {
-                stack_.pop_back();
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                }
-                return;
+                if (!required_satisfied(f))
+                    return false;
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
-            break;
+            return false;
         }
 
         case SchemaPhase::OBJECT_AFTER_VALUE: {
-            if (std::isspace(static_cast<unsigned char>(c)))
-                return;
+            if (space)
+                return true;
             if (c == ',') {
-                f.phase = SchemaPhase::OBJECT_OPEN;  // back to expecting key
-                return;
+                if (!has_unemitted_property(f))
+                    return false;  // every property emitted — comma would dangle
+                f.phase = SchemaPhase::OBJECT_OPEN;
+                f.after_comma = true;
+                return true;
             }
             if (c == '}') {
-                stack_.pop_back();
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-                             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
-                        parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
-                }
-                return;
+                if (!required_satisfied(f))
+                    return false;
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
-            break;
+            return false;
         }
 
         case SchemaPhase::ARRAY_OPEN: {
-            if (std::isspace(static_cast<unsigned char>(c)))
-                return;
+            if (space)
+                return true;
             if (c == ']') {
-                stack_.pop_back();
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                }
-                return;
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
-            // Start first item — push item schema frame
             if (f.node && f.node->items) {
-                push_value_frame(f.node->items.get());
-                // Re-process this char in the new frame
-                advance_char(c);
+                push_value(f.node->items.get());
+                return sim_advance(stk, c);  // process first-item char in new frame
             }
-            return;
+            return true;  // array without an items schema — accept opaquely
         }
 
         case SchemaPhase::ARRAY_AFTER_ITEM: {
-            if (std::isspace(static_cast<unsigned char>(c)))
-                return;
+            if (space)
+                return true;
             if (c == ',') {
-                f.item_count++;
-                // Push next item frame
-                if (f.node && f.node->items) {
-                    push_value_frame(f.node->items.get());
-                }
-                return;
+                if (f.node && f.node->items)
+                    push_value(f.node->items.get());
+                return true;
             }
             if (c == ']') {
-                stack_.pop_back();
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                }
-                return;
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
-            break;
+            return false;
         }
 
         case SchemaPhase::STRING_VALUE: {
-            if (c == '\\') {
-                f.phase = SchemaPhase::STRING_ESCAPE;
-                return;
-            }
+            if (c == '\\') { f.phase = SchemaPhase::STRING_ESCAPE; return true; }
             if (c == '"') {
-                // String value complete
-                stack_.pop_back();
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-                             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
-                        parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
-                }
-                return;
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
-            return;  // accumulate string content
+            return true;  // any content char
         }
 
         case SchemaPhase::STRING_PATTERN: {
             if (c == '"') {
-                // String value complete (mask guarantees closing was legal).
-                stack_.pop_back();
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-                             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
-                        parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
-                }
-                return;
+                if (!can_close_string(f, f.regex_states, f.string_len))
+                    return false;
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
-            // NOTE: escapes are not interpreted for regex purposes — the
-            // supported pattern subset operates on raw emitted bytes. A token
-            // mask already forbids backslashes unless the pattern allows them.
+            if (f.node && f.node->max_length >= 0 && f.string_len + 1 > f.node->max_length)
+                return false;
             if (f.node && f.node->pattern_nfa && f.node->pattern_nfa->compiled()) {
-                f.regex_states = f.node->pattern_nfa->step(f.regex_states, static_cast<unsigned char>(c));
+                std::vector<int> next =
+                    f.node->pattern_nfa->step(f.regex_states, static_cast<unsigned char>(c));
+                if (next.empty())
+                    return false;  // pattern prefix died
+                f.regex_states = std::move(next);
             }
             f.string_len++;
-            return;
+            return true;
         }
 
         case SchemaPhase::STRING_ESCAPE: {
             f.phase = SchemaPhase::STRING_VALUE;
-            return;
+            return true;
         }
 
         case SchemaPhase::NUMBER_VALUE: {
-            if ((c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-')
-                return;  // continue number
-            // Number ended — pop and re-process char in parent
-            stack_.pop_back();
-            if (!stack_.empty()) {
-                auto& parent = top();
-                if (parent.phase == SchemaPhase::OBJECT_COLON)
-                    parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-                         parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
-                    parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
-                advance_char(c);
+            const bool is_int = f.node && f.node->type == SchemaType::INTEGER;
+            if (c >= '0' && c <= '9') {
+                if (f.string_len == 0) {  // first digit (came after a leading '-')
+                    f.num_leading_zero = (c == '0');
+                    f.string_len = 1;
+                    return true;
+                }
+                if (f.num_leading_zero)
+                    return false;  // JSON forbids leading zeros: `0` then digit
+                f.string_len++;
+                return true;
             }
-            return;
+            if (!is_int && (c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-')) {
+                f.num_leading_zero = false;  // fractional/exponent part — int rule done
+                return true;
+            }
+            // Any other char ends the number — legal only if >=1 digit was seen.
+            if (f.string_len == 0)
+                return false;
+            stk.pop_back();
+            sim_fixup_parent(stk);
+            return sim_advance(stk, c);  // reprocess the terminator in the parent
         }
 
         case SchemaPhase::LITERAL_VALUE: {
-            if (f.literal_pos < static_cast<int>(f.literal_target.size())) {
-                f.literal_pos++;
-                if (f.literal_pos >= static_cast<int>(f.literal_target.size())) {
-                    // Literal complete
-                    stack_.pop_back();
-                    if (!stack_.empty()) {
-                        auto& parent = top();
-                        if (parent.phase == SchemaPhase::OBJECT_COLON)
-                            parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                        else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-                                 parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
-                            parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
-                    }
-                }
+            if (f.literal_pos >= static_cast<int>(f.literal_target.size()))
+                return false;
+            if (c != f.literal_target[f.literal_pos])
+                return false;  // wrong char for true/false/null
+            f.literal_pos++;
+            if (f.literal_pos >= static_cast<int>(f.literal_target.size())) {
+                stk.pop_back();
+                sim_fixup_parent(stk);
             }
-            return;
+            return true;
         }
 
         case SchemaPhase::ENUM_VALUE: {
             if (c == '"') {
-                // Enum value complete
-                stack_.pop_back();
-                if (!stack_.empty()) {
-                    auto& parent = top();
-                    if (parent.phase == SchemaPhase::OBJECT_COLON)
-                        parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-                    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-                             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
-                        parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
+                bool exact = false;
+                if (f.node) {
+                    for (auto& v : f.node->enum_values)
+                        if (v == f.enum_buffer) { exact = true; break; }
                 }
-                return;
+                if (!exact)
+                    return false;  // close only on an exact enum value
+                stk.pop_back();
+                sim_fixup_parent(stk);
+                return true;
             }
+            if (!f.node || !is_valid_enum_prefix(f.node->enum_values, f.enum_buffer + c))
+                return false;
             f.enum_buffer += c;
-            return;
+            return true;
         }
 
         case SchemaPhase::DONE:
-            return;
+            return false;
     }
+    return false;
+}
+
+bool SchemaConstrainer::token_legal(const std::string& text) const {
+    if (text.empty())
+        return true;  // EOS / special tokens — governed by the category mask
+    std::vector<SchemaFrame> sim = stack_;  // deep copy of the frame stack
+    for (char c : text) {
+        if (!sim_advance(sim, c))
+            return false;
+    }
+    return true;
 }
 
 }  // namespace imp

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -410,10 +410,48 @@ void SchemaConstrainer::compute_token_allow_mask() {
             }
         }
     } else if (f.phase == SchemaPhase::OBJECT_OPEN && f.node) {
-        // When we need to open with a quote for key, also constrain which
-        // quote tokens start valid keys (for multi-char tokens like `"name`)
-        // Only activate if there are tokens that start with quote + key prefix
-        // For single " token, category mask handles it. No need for token_allow.
+        // Multi-char tokens beginning with the opening quote (e.g. `"code`,
+        // `"id"`) open the key string AND emit key chars in a single step,
+        // bypassing the OBJECT_KEY prefix narrowing above. Constrain them here:
+        // the chars after the opening `"` must form a valid key prefix (or, if
+        // the token also carries the closing quote, a complete unemitted key).
+        // Without this, a quote-prefixed non-key token (`"Why`) slips through
+        // on its CAT_QUOTE bit alone and the FSM gets stuck mid-key → "!!!!".
+        //
+        // Non-quote tokens (whitespace, `}`) are gated by the category mask; we
+        // leave them allowed (=1) so the kernel's category-AND-allow is a no-op.
+        need_token_allow_ = true;
+        for (int i = 0; i < vocab_size_; i++) {
+            const auto& text = token_texts_[i];
+            if (text.empty() || text[0] != '"') {
+                token_allow_[i] = 1;
+                continue;
+            }
+            const std::string rest = text.substr(1);
+            bool valid = false;
+            if (rest.empty()) {
+                // Bare opening quote — always a legal key start.
+                valid = true;
+            } else {
+                size_t qpos = rest.find('"');
+                if (qpos == std::string::npos) {
+                    // Quote + partial key chars: must stay a valid key prefix.
+                    valid = is_valid_key_prefix(f.node, rest, f.emitted_keys);
+                } else if (qpos + 1 == rest.size()) {
+                    // Quote + complete key + closing quote (e.g. `"id"`).
+                    std::string key_part = rest.substr(0, qpos);
+                    for (auto& [name, _] : f.node->properties) {
+                        if (!f.emitted_keys.count(name) && name == key_part) {
+                            valid = true;
+                            break;
+                        }
+                    }
+                }
+                // A closing quote with trailing chars (`"id":`) is left masked;
+                // the model can take the bare-quote path instead.
+            }
+            token_allow_[i] = valid ? 1 : 0;
+        }
     }
 }
 

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -61,6 +61,16 @@ struct SchemaFrame {
 
     // Array item count
     int item_count = 0;
+
+    // True right after a ',' inside an object: a key is now mandatory, so the
+    // object may not close (`}`) until another key/value is emitted — prevents
+    // trailing commas (`{"a":1,}`).
+    bool after_comma = false;
+
+    // True while the current number's integer part is the single digit '0'
+    // (JSON forbids leading zeros: `0` is fine, `09` is not). Cleared once a
+    // '.'/'e' is seen. Guards integer/number degeneration like `0999...`.
+    bool num_leading_zero = false;
 };
 
 class SchemaConstrainer {
@@ -125,6 +135,10 @@ private:
     // Schema FSM state
     std::vector<SchemaFrame> stack_;
 
+    // EOS token ids — forced (everything else masked) once the root value is
+    // complete, so generation stops cleanly instead of trailing free text.
+    std::vector<int32_t> eos_tokens_;
+
     // Preamble pass-through (reasoning models emit <think>...</think> first)
     PreambleGate preamble_;
 
@@ -137,7 +151,17 @@ private:
     uint16_t compute_category_mask() const;
     void compute_token_allow_mask();
 
-    void advance_char(char c);
+    // Single-char transition over a frame stack. Returns false when c is not a
+    // legal transition for the current phase. Drives both the real update path
+    // (on stack_) and per-token mask simulation (on a cloned stack), so there
+    // is one source of truth for the schema grammar.
+    bool sim_advance(std::vector<SchemaFrame>& stk, char c) const;
+
+    // True iff emitting the whole token keeps the schema satisfiable: every
+    // char is a legal transition and nothing trails past the root close. This
+    // catches multi-char tokens that span phase transitions (`{}`, `":"`,
+    // `"Why`, integer `0.98`) which the first-char category mask misses.
+    bool token_legal(const std::string& text) const;
 
     // Find property schema by key name
     const SchemaNode* find_property(const SchemaNode* obj, const std::string& key) const;

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -610,5 +610,47 @@ TEST(SchemaConstrainTest, PatternEnforcementMasksCorrectly) {
     EXPECT_FALSE(allowed(10)) << "'abc' (lowercase) must be masked by the pattern";
 }
 
+// At OBJECT_OPEN, a multi-char token that begins with the opening quote
+// (`"code`, `"Why`) opens the key string AND fills key chars in one step.
+// Such tokens must be narrowed to valid key prefixes — otherwise a non-key
+// token (`"Why`) slips through on its CAT_QUOTE bit and the FSM gets stuck
+// mid-key, degenerating into "!!!!". No model / preamble gate involved.
+TEST(SchemaConstrainTest, ObjectOpenQuotePrefixedKeyMasked) {
+    SKIP_IF_NO_CUDA();
+
+    //          0        1      2       3    4    5     6        7       8     9
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "}", "\"", "\"code", "\"Why", ":", "code"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"code":{"type":"string"}},"required":["code"]})");
+    ASSERT_TRUE(schema != nullptr);
+
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+
+    sc.update(3);  // "{"  → OBJECT_OPEN
+
+    const int vocab = static_cast<int>(toks.size());
+    std::vector<float> h(vocab, 1.0f);
+    float* d = nullptr;
+    cudaMalloc(&d, vocab * sizeof(float));
+    cudaMemcpy(d, h.data(), vocab * sizeof(float), cudaMemcpyHostToDevice);
+    sc.apply_mask(d, vocab, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, vocab * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+
+    auto allowed = [&](int i) { return h[i] > -1e30f; };
+
+    EXPECT_TRUE(allowed(5)) << "bare opening quote must be allowed";
+    EXPECT_TRUE(allowed(6)) << "'\"code' (quote + valid complete key) must be allowed";
+    EXPECT_FALSE(allowed(7)) << "'\"Why' (quote + invalid key) must be masked — the OBJECT_OPEN hole";
+    EXPECT_FALSE(allowed(9)) << "'code' without opening quote must be masked at OBJECT_OPEN (category)";
+    EXPECT_FALSE(allowed(4)) << "'}' must be masked: required key 'code' not yet emitted";
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -652,5 +652,142 @@ TEST(SchemaConstrainTest, ObjectOpenQuotePrefixedKeyMasked) {
     EXPECT_FALSE(allowed(4)) << "'}' must be masked: required key 'code' not yet emitted";
 }
 
+// Key order in a JSON object is not significant: {"type":"string","enum":[...]}
+// and the alphabetically-reordered {"enum":[...],"type":"string"} (what a
+// request round-trip through a JSON library produces) must both parse to ENUM.
+// A later "type":"string" must not demote the node back to a free string.
+TEST(SchemaConstrainTest, EnumPrecedenceIsOrderIndependent) {
+    auto a = parse_json_schema(R"({"type":"string","enum":["en","de","fr"]})");
+    ASSERT_TRUE(a != nullptr);
+    EXPECT_EQ(a->type, SchemaType::ENUM) << "type-then-enum must be ENUM";
+
+    auto b = parse_json_schema(R"({"enum":["en","de","fr"],"type":"string"})");
+    ASSERT_TRUE(b != nullptr);
+    EXPECT_EQ(b->type, SchemaType::ENUM) << "enum-then-type must still be ENUM";
+    EXPECT_EQ(b->enum_values.size(), 3u);
+}
+
+// Run apply_mask over a vocab of `n` tokens and return which token ids survive.
+static std::vector<bool> schema_allowed(SchemaConstrainer& sc, int n) {
+    std::vector<float> h(n, 1.0f);
+    float* d = nullptr;
+    cudaMalloc(&d, n * sizeof(float));
+    cudaMemcpy(d, h.data(), n * sizeof(float), cudaMemcpyHostToDevice);
+    sc.apply_mask(d, n, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, n * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+    std::vector<bool> out(n);
+    for (int i = 0; i < n; i++)
+        out[i] = h[i] > -1e30f;
+    return out;
+}
+
+// A combined token like `{}` opens AND closes an object in one step; it must be
+// rejected while required keys are unmet (the first-char category mask only
+// sees CAT_OPEN_BRACE and would let it through → empty object, schema violated).
+TEST(SchemaConstrainTest, PrematureObjectCloseRejected) {
+    SKIP_IF_NO_CUDA();
+    //                                 0       1      2      3    4    5     6     7
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "}", "{}", "\"", "code"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"code":{"type":"string"}},"required":["code"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    // Fresh root: phase VALUE_START expecting the object to open.
+    auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(a[3]) << "'{' must open the object";
+    EXPECT_FALSE(a[4]) << "bare '}' masked by category (not a value start)";
+    EXPECT_FALSE(a[5]) << "'{}' combined token must be rejected — required 'code' unmet";
+}
+
+// After the last property's value, a comma would dangle (no key can follow) —
+// it must be masked, leaving only the closing brace. Prevents `{"a":"x",}`.
+TEST(SchemaConstrainTest, TrailingCommaRejected) {
+    SKIP_IF_NO_CUDA();
+    //                                 0       1      2      3    4    5    6    7    8    9
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "a", "x", ":", "}", ","};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"a":{"type":"string"}},"required":["a"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    for (int t : {3, 4, 5, 4, 7, 4, 6, 4})  // { "a" : "x"  -> OBJECT_AFTER_VALUE
+        sc.update(t);
+    auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(a[8]) << "'}' must close the object after the only property";
+    EXPECT_FALSE(a[9]) << "',' must be masked — no further property can follow";
+}
+
+// JSON forbids leading zeros: after a single '0' the integer part is done, so
+// another digit is illegal (also bounds `0999...` degeneration).
+TEST(SchemaConstrainTest, IntegerLeadingZeroRejected) {
+    SKIP_IF_NO_CUDA();
+    //                                 0       1      2      3    4    5    6    7    8    9
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "n", ":", "0", "5", "}"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"n":{"type":"integer"}},"required":["n"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    for (int t : {3, 4, 5, 4, 6, 7})  // { "n" : 0  -> NUMBER_VALUE (leading zero)
+        sc.update(t);
+    auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_FALSE(a[8]) << "digit after a leading '0' must be masked";
+    EXPECT_TRUE(a[9]) << "'}' must be allowed to close the number/object";
+}
+
+// A combined value token must be validated against an enum/integer constraint,
+// not just its opening quote/digit category.
+TEST(SchemaConstrainTest, EnumAndIntegerComboTokensValidated) {
+    SKIP_IF_NO_CUDA();
+    //          0       1     2      3   4    5            6    7      8       9      10     11    12     13
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "sentiment", ":", "\"en\"", "\":\"", "\"x", "5", "5.", "5.0", "}"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+
+    // --- enum property ---
+    {
+        auto schema = parse_json_schema(
+            R"({"type":"object","properties":{"sentiment":{"type":"string","enum":["en","de","fr"]}},"required":["sentiment"]})");
+        ASSERT_TRUE(schema != nullptr);
+        SchemaConstrainer sc;
+        ASSERT_TRUE(sc.init(tok, std::move(schema)));
+        for (int t : {3, 4, 5, 4, 6})  // { " sentiment " :  -> value frame (enum)
+            sc.update(t);
+        auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+        EXPECT_TRUE(a[7]) << "'\"en\"' (exact enum value in one token) must be allowed";
+        EXPECT_TRUE(a[4]) << "bare opening '\"' must be allowed";
+        EXPECT_FALSE(a[8]) << "'\":\"' (quote+colon+quote, not an enum value) must be masked";
+        EXPECT_FALSE(a[9]) << "'\"x' (invalid enum prefix) must be masked";
+    }
+
+    // --- integer property: reject float-shaped combined tokens ---
+    {
+        auto schema = parse_json_schema(
+            R"({"type":"object","properties":{"sentiment":{"type":"integer"}},"required":["sentiment"]})");
+        ASSERT_TRUE(schema != nullptr);
+        SchemaConstrainer sc;
+        ASSERT_TRUE(sc.init(tok, std::move(schema)));
+        for (int t : {3, 4, 5, 4, 6})  // { " sentiment " :  -> value frame (integer)
+            sc.update(t);
+        auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+        EXPECT_TRUE(a[10]) << "'5' must be allowed for an integer";
+        EXPECT_FALSE(a[11]) << "'5.' must be masked for an integer";
+        EXPECT_FALSE(a[12]) << "'5.0' must be masked for an integer";
+    }
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## Problem

The schema constrainer (`response_format: json_schema`) masked logits by each token's **first-character category** plus a few per-phase prefix checks. Multi-char tokens that span a phase transition slipped through on their first char alone, so `json_schema` produced **invalid JSON end-to-end**:

| token | bug |
|-------|-----|
| `"Why` | quote+letters opened a key with a non-existent property → FSM stuck mid-key → degenerated into `!!!!` |
| `{}` | opened **and** closed an object with required keys still unmet (empty object) |
| `":"` | opened+filled+closed an `enum` value with a bogus string (`:`) |
| `0.98` | a float for an `integer` field |
| `,}` / `0999…` | trailing comma; integer runaway / leading zeros |

Additionally a model whose top token was a newline stalled forever in leading whitespace before ever emitting `{`, and `enum` parsed as a free string when `"type":"string"` followed `"enum"` in key order (which a JSON round-trip produces by alphabetical reordering).

## Fix

Replace the first-char heuristics with a single **validating transition simulator** (`sim_advance`): a candidate token is allowed only if replaying its entire text from the current FSM state stays legal at every character. It drives **both** the real update path and the per-token mask, so there is one source of truth for the grammar (the old `advance_char` is removed). The category mask still runs alongside to govern EOS/whitespace.

Same pass, all required for valid end-to-end output:
- **enum precedence** is order-independent (`enum` wins over a co-declared `"type"`).
- **compact JSON** — structural whitespace no longer allowed → no pre-`{` stall.
- **trailing commas, JSON leading-zeros, float-for-integer** rejected.
- **force EOS** once the root value completes → clean stop, no trailing prose.

## Tests

Deterministic unit tests with a synthetic subword vocab for each case: key over-masking, enum exact-match, integer/float, premature close, trailing comma, leading zero, order-independent enum parsing. Full GPU suite green (0 failures).

## End-to-end (Qwen3-8B-NVFP4, `json_schema`)

| schema | before | after |
|--------|--------|-------|
| free string | whitespace stall / `"Why!!!!` | `{"code":"…","explanation":"…"}` ✓ |
| enum+integer | `{"language":":en",…0999` | `{"language":"en","sentiment":"positive","confidence":0}` ✓ |
| array | — | `{"primes":[]}` ✓ |

All `finish=stop`, valid + schema-correct.

> Note: full end-to-end enforcement behind reasoning models (`/no_think`) also needs the preamble-gate fix (#498) to engage the gate; this PR's correctness is independent and unit-proven. The two compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)