### PR TITLE
fix(engine): unique recurrent-state slots per sequence (SSM/GDN concurrency)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -336,6 +336,7 @@ void Engine::finish_request(std::shared_ptr<Request>& req) {
         kv_manager_->register_block_hashes(req->id, req->input_tokens);
     }
     kv_manager_->free_sequence(req->id);
+    release_recurrent_slot_(req->id);
     constraints_.reset();
 }
 

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -20,6 +20,8 @@
 #include "exec/executor.h"
 #include "core/cuda_raii.h"
 #include <memory>
+#include <vector>
+#include <unordered_map>
 #include <string>
 #include <cuda_runtime.h>
 
@@ -276,6 +278,16 @@ private:
     // ── Model-specific state ─────────────────────────────────────────
     std::unique_ptr<SSMState> ssm_state_;
     std::unique_ptr<GDNState> gdn_state_;
+
+    // Recurrent (SSM/GDN) state-slot allocator. One slot per concurrent
+    // sequence (capacity == config.max_batch_size). Slots MUST be unique among
+    // live sequences — the recurrent state IS the sequence's memory, so a shared
+    // slot leaks one request's context into another. The previous
+    // `req.id % capacity` scheme aliased slots whenever two live request ids
+    // differed by a multiple of capacity; allocate a distinct free slot instead.
+    std::vector<int> free_recurrent_slots_;           // available slot ids
+    std::unordered_map<int, int> recurrent_slot_of_;  // req.id -> slot
+    bool recurrent_slots_initialized_ = false;
     bool has_pure_ssm_layers_ = false;  // true if model has Mamba2 SSM layers (not GDN)
     std::unique_ptr<LayerOffloadManager> offload_mgr_;
     bool experts_on_host_ = false;
@@ -435,6 +447,8 @@ private:
     void upload_penalties(const Request& req, InferenceState& state, cudaStream_t stream);
     void fill_sampling_params(const Request& req, InferenceState& state) const;
     void fill_recurrent_state(const Request& req, InferenceState& state, bool reset, cudaStream_t stream);
+    int acquire_recurrent_slot_(int req_id);   // distinct free slot for a new sequence
+    void release_recurrent_slot_(int req_id);  // idempotent; returns slot to the pool
     void finish_request(std::shared_ptr<Request>& req);
 
     // ── step() sub-phases ─────────────────────────────────────────────

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -214,19 +214,70 @@ void Engine::upload_penalties(const Request& req, InferenceState& state, cudaStr
     state.n_penalty_tokens = static_cast<int>(n);
 }
 
+// Recurrent state-slot allocator. One slot per concurrent sequence; slots must
+// be UNIQUE among live sequences (the recurrent state is the sequence memory).
+// The free list is sized lazily from the state capacity (== max_batch_size).
+int Engine::acquire_recurrent_slot_(int req_id) {
+    const int cap = ssm_state_ ? ssm_state_->max_sequences()
+                               : (gdn_state_ ? gdn_state_->max_sequences() : 0);
+    if (cap <= 0)
+        return 0;
+    auto it = recurrent_slot_of_.find(req_id);
+    if (it != recurrent_slot_of_.end())
+        return it->second;  // already holds a slot (multi-chunk prefill)
+    if (!recurrent_slots_initialized_) {
+        free_recurrent_slots_.clear();
+        for (int s = cap - 1; s >= 0; --s)
+            free_recurrent_slots_.push_back(s);
+        recurrent_slots_initialized_ = true;
+    }
+    int slot;
+    if (!free_recurrent_slots_.empty()) {
+        slot = free_recurrent_slots_.back();
+        free_recurrent_slots_.pop_back();
+    } else {
+        // Should not happen: the scheduler caps concurrency at capacity. Fall
+        // back to the legacy aliasing scheme rather than crash.
+        slot = req_id % cap;
+        IMP_LOG_WARN("recurrent slot pool exhausted (cap=%d) — falling back to id%%cap for req %d", cap,
+                     req_id);
+    }
+    recurrent_slot_of_[req_id] = slot;
+    return slot;
+}
+
+void Engine::release_recurrent_slot_(int req_id) {
+    auto it = recurrent_slot_of_.find(req_id);
+    if (it == recurrent_slot_of_.end())
+        return;  // idempotent: request never acquired a slot (dense model / pre-prefill cancel)
+    free_recurrent_slots_.push_back(it->second);
+    recurrent_slot_of_.erase(it);
+}
+
 void Engine::fill_recurrent_state(const Request& req, InferenceState& state, bool reset,
                                   cudaStream_t stream) {
+    if (!ssm_state_ && !gdn_state_)
+        return;
+    int slot;
+    if (reset) {
+        slot = acquire_recurrent_slot_(req.id);  // fresh slot for a new sequence
+    } else {
+        auto it = recurrent_slot_of_.find(req.id);
+        // Decode / later prefill chunks reuse the slot acquired at offset==0.
+        const int cap = ssm_state_ ? ssm_state_->max_sequences() : gdn_state_->max_sequences();
+        slot = (it != recurrent_slot_of_.end()) ? it->second : (cap > 0 ? req.id % cap : 0);
+    }
     if (ssm_state_) {
         state.ssm_state = ssm_state_.get();
-        state.ssm_seq_id = req.id % ssm_state_->max_sequences();
+        state.ssm_seq_id = slot;
         if (reset)
-            ssm_state_->reset_sequence(state.ssm_seq_id, stream);
+            ssm_state_->reset_sequence(slot, stream);
     }
     if (gdn_state_) {
         state.gdn_state = gdn_state_.get();
-        state.gdn_seq_id = req.id % gdn_state_->max_sequences();
+        state.gdn_seq_id = slot;
         if (reset)
-            gdn_state_->reset_sequence(state.gdn_seq_id, stream);
+            gdn_state_->reset_sequence(slot, stream);
     }
 }
 


### PR DESCRIPTION
## Problem

SSM/GDN recurrent state has one slot per concurrent sequence (capacity = `max_batch_size`), but the slot was chosen as `req.id % capacity` (`engine_sampling_stop.cpp`). Request ids are monotonic, so two **live** requests whose ids differ by a multiple of capacity alias the **same** recurrent slot.

The recurrent state *is* a sequence's memory, so a shared slot leaks one request's context into another — the model can answer a different concurrent request's prompt. The per-prefill `reset_sequence()` only saves the sequential case; concurrent hybrid sequences still collide.

## Fix

Replace the modulo scheme with a real free-list slot allocator (mirrors per-sequence KV-block allocation):
- each new sequence **acquires a distinct free slot** at its first prefill (`offset==0`),
- reuses it across decode / later prefill chunks,
- **releases** it on finish.

Pool is sized lazily from the state capacity. On the (scheduler-prevented) exhaustion case it falls back to the old modulo scheme with a warning rather than crashing. `release_recurrent_slot_` is idempotent (safe for dense models / pre-prefill cancels).

**Sequential single-request behaviour is unchanged by construction** (first request gets slot 0 + reset, exactly as before), so existing coherence is preserved; the fix only affects concurrent recurrent-model decoding.

## Context / honesty

Found by code analysis while hunting a sporadic **context-carryover** report (known issue #495/#496). This is the concrete slot-aliasing root cause for **hybrid (SSM/GDN) models** under concurrency. I could **not** reproduce dense-model single-turn carryover (110 sequential requests, default config) and verified the engine prompt path is healthy (tokenization round-trips; `"capital of France" → "Paris"` coherent), so this PR targets the one identified latent state-sharing path rather than claiming to fix every carryover symptom.

## Validation

- Build clean (CUDA 13.3).
- Full GPU GTest suite green, 0 failures.
- Behaviour identical to prior code for sequential use (coherence preserved by construction); divergence only under concurrent recurrent-model batching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)