### PR TITLE
fix(engine): release recurrent slot on API teardown (SSM/GDN slot leak from #500)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -291,9 +291,23 @@ cudaStream_t Engine::decode_stream() const {
 }
 
 void Engine::reset_ssm_state(int seq_id) {
+    // Public teardown entry point (API re-prefill / context reset / server
+    // cancellation). Reset the sequence's ACTUAL allocated recurrent slot, then
+    // return it to the free list — otherwise the slot leaks (these paths bypass
+    // finish_request) and the pool exhausts, forcing every later request onto
+    // the legacy id%cap aliasing fallback.
+    auto it = recurrent_slot_of_.find(seq_id);
     if (ssm_state_) {
-        ssm_state_->reset_sequence(seq_id % ssm_state_->max_sequences(), stream_);
+        const int cap = ssm_state_->max_sequences();
+        int slot = (it != recurrent_slot_of_.end()) ? it->second : (cap > 0 ? seq_id % cap : 0);
+        ssm_state_->reset_sequence(slot, stream_);
     }
+    if (gdn_state_) {
+        const int cap = gdn_state_->max_sequences();
+        int slot = (it != recurrent_slot_of_.end()) ? it->second : (cap > 0 ? seq_id % cap : 0);
+        gdn_state_->reset_sequence(slot, stream_);
+    }
+    release_recurrent_slot_(seq_id);
 }
 
 void Engine::reset_batch_pool_cache() { decode_batch_pool_.reset_upload_cache(); }


### PR DESCRIPTION
## Root cause

PR #500 introduced a free-list allocator for SSM/GDN recurrent-state slots, but
wired the slot release (`release_recurrent_slot_`) **only** into the scheduler's
`Engine::finish_request`. The API-driven request lifecycle never goes through
`finish_request`:

- `imp_prefill_with_params` (re-prefill teardown of the previous active request)
- `imp_context_reset`
- server cancellation / error paths in `batching_engine.cpp`

…all tear a sequence down via `kv_manager_->free_sequence(id)` + `reset_ssm_state(id)`,
so the recurrent slot was **never returned to the free list**.

### Consequence
Every bench rep / CLI generation / single-turn request acquires a fresh slot that
leaks. The pool exhausts after the first request, so every later request falls back
to the legacy `id % cap` aliasing scheme (the exact scheme #500 set out to remove),
spamming:

```
[WARN] recurrent slot pool exhausted (cap=1) — falling back to id%cap for req 2..N
```

- **Benign at `cap == 1`** (`id % 1 == 0` coincides with the only slot) — e.g.
  Qwen3.6-35B-A3B-NVFP4, whose >20 GB weights force `max_batch_size = 1`. Decode
  still works (~219 tok/s), it just warns.
- **Broken for any hybrid model with `cap > 1`**: a later request's `acquire_recurrent_slot_`
  returns a fresh free-list slot `N`, but `reset_ssm_state` reset slot `id % cap != N`
  → the request decodes from an **unreset / stale recurrent slot** = corrupt state.
  This is the latent state-corruption path consistent with the reported `tg128 = 0.00`
  scoreboard observation.

> Note on the reported `tg128 = 0.00`: it did **not** reproduce on a clean rebuild of
> current HEAD (Qwen3.6-35B-A3B-NVFP4 decodes coherently at ~186–219 tok/s, answers
> "Paris"). But the slot leak is a real, reproducible bug (the warnings prove the
> free-list never refills), and is the only correctness defect in #500's lifecycle —
> so it's fixed regardless.

## Fix

Fold slot release into `reset_ssm_state` — the single public "reset this sequence's
recurrent state" entry point that **all** teardown paths already call. It now:

1. resets the sequence's **actual allocated slot** (looked up from `recurrent_slot_of_`),
   not `id % cap`;
2. also resets **GDN** state (the old code only reset SSM);
3. releases the slot (`release_recurrent_slot_` is idempotent, so dense models that
   never acquired a slot, and the warmup double-reset, are no-ops).

No call-site changes, no new public API. 15 lines, one file.

## Validation (RTX 5090, rebuilt `imp:test`)

| model | family | tg128 tok/s | warnings | coherent |
|---|---|---|---|---|
| Qwen3.6-35B-A3B-NVFP4 | hybrid | ~219 (was warning-spamming) | none | "Paris" ✓ |
| Nemotron-3-Nano-30B-A3B-NVFP4 | hybrid | ~118 | none | "Paris" ✓ |
| Qwen3-8B-NVFP4-cortecs | dense | ~264 | none (unaffected) | ✓ |

- `GDNModelTest.GenerateCoherentOutput` + `GDNModelTest.MultiTurnGDNState` **PASS**
  on GGUF Qwen3.6 — `MultiTurnGDNState` exercises exactly the `turn1 → imp_context_reset → turn2`
  path this fix touches.
- `make verify-fast` gtest filter **PASS**; engine / SSM / GDN GPU tests **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)