### PR TITLE
docs: mark Phi-4-reasoning-plus NVFP4 as known-broken (FFN explosion)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -15,11 +15,12 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 | [Qwen3-14B](https://huggingface.co/unsloth/Qwen3-14B-GGUF) | Q6_K | 12 GB | **158** | GGUF |
 | [Qwen3-14B](https://huggingface.co/nvidia/Qwen3-14B-NVFP4) | NVFP4 | 10 GB | 105 | SafeTensors (nvidia) |
 | [Qwen3-32B](https://huggingface.co/unsloth/Qwen3-32B-GGUF) | Q4_K_M | 19 GB | — | GGUF |
-| [Phi-4-reasoning-plus](https://huggingface.co/nvidia/Phi-4-reasoning-plus-NVFP4) | NVFP4 | 9.0 GB | 115 | SafeTensors (nvidia), fused projections |
 | [Llama-3.2-3B-Instruct](https://huggingface.co/unsloth/Llama-3.2-3B-Instruct-GGUF) | Q8_0 | 3.2 GB | 306 | GGUF |
 | [Mistral-Small-3.1-24B](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF) | Q6_K | 19 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-7B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF) | Q8_0 | 7.6 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-14B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF) | Q6_K | 12 GB | — | GGUF |
+
+> **Known issue — Phi-4-reasoning-plus NVFP4 (Phi3ForCausalLM, fused projections):** loads and benches at full speed (pp512 ≈ 21k tok/s, tg ≈ 157 tok/s) but produces incoherent, prompt-blind output (e.g. `2 plus 2 equals` → `0.5, 0.`, repetition loops). Not the `k_scale`/`v_scale` load error or the `nvfp4_quant.cu:603 cudaFree` crash (both fixed in #494/#487). The fused `qkv_proj`/`gate_up_proj` `weight_scale` split from #494 promotes all 7 weights/layer and the per-row weights dequantize bit-correctly, but the **early-layer FFN output explodes** (hidden-state L2 ≈ 6 → 110 at layer-1 FFN, runaway) — a forward-compute bug specific to fused-projection (Phi-3/Phi-4) models. Qwen3-style separate-q/k/v NVFP4 models are unaffected.
 
 ## Hybrid (Gated DeltaNet + attention)
 


### PR DESCRIPTION
## Summary

Verification of two previously-documented NVFP4 bugs on current `main` (`d524c7ee`). Findings, evidence-based:

- **Bug B — Qwen3.6-35B-A3B-NVFP4 pp4096 graph-capture crash: RESOLVED on HEAD** by #491. `--bench-pp 4096 --bench-reps 5` completes cleanly (exit 0, no crash); log confirms `gemm_nvfp4 dequant workspace … > 512 MiB cap … prefill graph capture disabled (M>1 fallback runs eager)`. pp4096 ≈ 3129 tok/s, tg ≈ 124 tok/s; decode coherent (France→Paris). No code change needed.

- **Bug A — Phi-4-reasoning-plus-NVFP4: STILL BROKEN on HEAD (different failure than documented).** The original symptoms (`k_scale`/`v_scale` load error, `nvfp4_quant.cu:603 cudaFree`) are gone (fixed by #494/#487), and #494's fused-projection `weight_scale` split is present (280 weights promoted, all dequantize bit-correctly — verified via GPU dump). **But the model still produces incoherent, prompt-blind output** (`2 plus 2 equals` → `0.5, 0.`; `The capital of France is` → degenerate loop; chat-template reasoning never escapes a `I'll produce final answer.` loop). Bisected to an **early-layer FFN explosion**: hidden-state L2 ≈ 6 → 110 at layer-1 FFN, runaway to ~1040, drowning the token signal. Attention is healthy; the defect is in FFN compute and is specific to fused-projection (Phi-3/Phi-4) models — Qwen3 separate-q/k/v NVFP4 works on the same build.

This PR is **docs-only**: removes Phi-4-reasoning-plus from the "known-working" table in `docs/supported-models.md` and documents the open FFN-explosion issue. No speculative code fix shipped — root cause not yet isolated to a single confident fix.

## Test plan
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)