### PR TITLE
fix(nvfp4): NeoX RoPE for SafeTensors Llama-family models (Phi-4 prompt-blind)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -15,12 +15,11 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 | [Qwen3-14B](https://huggingface.co/unsloth/Qwen3-14B-GGUF) | Q6_K | 12 GB | **158** | GGUF |
 | [Qwen3-14B](https://huggingface.co/nvidia/Qwen3-14B-NVFP4) | NVFP4 | 10 GB | 105 | SafeTensors (nvidia) |
 | [Qwen3-32B](https://huggingface.co/unsloth/Qwen3-32B-GGUF) | Q4_K_M | 19 GB | — | GGUF |
+| [Phi-4-reasoning-plus](https://huggingface.co/nvidia/Phi-4-reasoning-plus-NVFP4) | NVFP4 | 9.0 GB | 157 | SafeTensors (nvidia), fused projections |
 | [Llama-3.2-3B-Instruct](https://huggingface.co/unsloth/Llama-3.2-3B-Instruct-GGUF) | Q8_0 | 3.2 GB | 306 | GGUF |
 | [Mistral-Small-3.1-24B](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF) | Q6_K | 19 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-7B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF) | Q8_0 | 7.6 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-14B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF) | Q6_K | 12 GB | — | GGUF |
-
-> **Known issue — Phi-4-reasoning-plus NVFP4 (Phi3ForCausalLM, fused projections):** loads and benches at full speed (pp512 ≈ 21k tok/s, tg ≈ 157 tok/s) but produces incoherent, prompt-blind output (e.g. `2 plus 2 equals` → `0.5, 0.`, repetition loops). Not the `k_scale`/`v_scale` load error or the `nvfp4_quant.cu:603 cudaFree` crash (both fixed in #494/#487). The fused `qkv_proj`/`gate_up_proj` `weight_scale` split from #494 promotes all 7 weights/layer and the per-row weights dequantize bit-correctly, but the **early-layer FFN output explodes** (hidden-state L2 ≈ 6 → 110 at layer-1 FFN, runaway) — a forward-compute bug specific to fused-projection (Phi-3/Phi-4) models. Qwen3-style separate-q/k/v NVFP4 models are unaffected.
 
 ## Hybrid (Gated DeltaNet + attention)
 

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1036,6 +1036,20 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
     // 4. Apply arch-specific defaults
     apply_arch_defaults(cfg);
 
+    // SafeTensors store Q/K in HuggingFace-native layout, which uses NeoX-style
+    // (rotate-half) RoPE: pairs (i, i+rope_dim/2). The arch table defaults
+    // LLAMA/MISTRAL/MIXTRAL/LLAMA4 to interleaved RoPE (rope_neox=0) because the
+    // GGUF converter pre-permutes Q/K so interleaved reproduces NeoX. That
+    // permutation is NOT applied to SafeTensors weights, so the interleaved
+    // default scrambles positional encoding (e.g. Phi-3/Phi-4 -> coherent but
+    // prompt-blind output with preserved magnitudes). Force NeoX for the
+    // SafeTensors path so HF-native Q/K rotate correctly. Arches that already
+    // keep the default (rope_neox=true: QWEN3/GEMMA/...) are unaffected.
+    if (cfg.arch == ModelArch::LLAMA || cfg.arch == ModelArch::MISTRAL ||
+        cfg.arch == ModelArch::MIXTRAL || cfg.arch == ModelArch::LLAMA4) {
+        cfg.rope_neox = true;
+    }
+
     IMP_LOG_INFO("Architecture: %s", model_arch_name(cfg.arch));
     IMP_LOG_INFO("Config: layers=%d d_model=%d d_ff=%d heads=%d kv_heads=%d vocab=%d ctx=%d", cfg.n_layers,
                  cfg.d_model, cfg.d_ff, cfg.n_heads, cfg.n_kv_heads, cfg.vocab_size, cfg.max_seq_len);


### PR DESCRIPTION
## Problem

Phi-4-reasoning-plus-NVFP4 (`Phi3ForCausalLM`) loaded and benched at full speed but produced **coherent-but-prompt-blind** output at greedy decode:
- `The capital of France is` → degenerate loop (ignored the prompt)
- `2 plus 2 equals` → `0.5, 0.`

The #494/#487 fixes (fused-projection `weight_scale` split, borrowed-cache `cudaFree`) were correct and necessary but did not address this. The known-issue note (#502) hypothesised an early-layer FFN explosion — that localization was a **misread**: per-layer hidden-state L2 grows monotonically and matches a healthy Qwen3-8B-NVFP4 (which reaches even higher L2 yet stays coherent). Magnitudes were never the problem.

## Root cause

SafeTensors store Q/K in **HuggingFace-native layout**, which uses **NeoX-style (rotate-half)** RoPE — pairs `(i, i+rope_dim/2)`. imp's arch-defaults table sets `rope_neox=0` (**interleaved**, pairs `(2i, 2i+1)`) for `LLAMA`/`MISTRAL`/`MIXTRAL`/`LLAMA4`, because the GGUF converter **pre-permutes** Q/K so interleaved RoPE reproduces NeoX. That permutation is **not** applied to SafeTensors weights, so the interleaved default scrambled the per-position rotation.

RoPE is norm-preserving, so this corrupted *which* token is attended to without changing hidden-state magnitudes → coherent grammar, blind to prompt content. `Phi3ForCausalLM → ModelArch::LLAMA` (`rope_neox=0`) hit this; Qwen3 (`ModelArch::QWEN3`, table value `-1` = keep `rope_neox=true` default) did not — which is exactly why Qwen3 NVFP4 worked and Phi-4 didn't.

Decisive evidence (instrumented, then reverted): `[ROPE_DBG] L0 ... neox=0 ...` for Phi-4 vs the `rope_neox=true` default for the working Qwen3 path.

## Fix

In `load_safetensors`, after `apply_arch_defaults`, force `cfg.rope_neox = true` for the GGUF-permuted arch families (`LLAMA`/`MISTRAL`/`MIXTRAL`/`LLAMA4`). 14 lines, isolated to the SafeTensors loader; the GGUF path and non-Llama arches (Qwen3/Gemma keep their `rope_neox=true` default) are untouched.

## Validation (RTX 5090, sm_120a)

- **Phi-4-reasoning-plus-NVFP4** (fixed): `Q: What is the capital of France? A:` → `The capital of France is Paris.`; `The sky appears blue because of` → `the scattering of sunlight by the Earth atmosphere.` (was a prompt-blind loop).
- **Qwen3-8B-NVFP4-cortecs** (same SafeTensors path, QWEN3 arch): no regression — `Paris`, coherent.
- stderr clean (no fallback / NaN / Inf). `make verify-fast` → OK.

Restores Phi-4-reasoning-plus to the supported-models table (removes the #502 known-issue note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)