### PR TITLE
fix(loader): load MTP head only when spec-decode requested (frees ~1.57 GiB VRAM)

### DIFF
--- a/include/imp/imp.h
+++ b/include/imp/imp.h
@@ -33,6 +33,15 @@ typedef struct ImpContext_T* ImpContext;
 
 ImpError imp_model_load(const char* path, ImpModelFormat format, ImpModel* out_model);
 
+// Like imp_model_load, but lets the caller opt into loading the MTP
+// (multi-token-prediction) head sidecar for SafeTensors models that ship one
+// (DeepSeek-V3 family, e.g. Qwen3.6). The head is ~1.57 GiB BF16 of VRAM and is
+// only useful when MTP spec-decode is subsequently enabled via
+// imp_enable_mtp_spec_decode. imp_model_load() is equivalent to passing
+// load_mtp_head=0. Has no effect for GGUF or models without an MTP sidecar.
+ImpError imp_model_load_ex(const char* path, ImpModelFormat format, int load_mtp_head,
+                           ImpModel* out_model);
+
 void imp_model_free(ImpModel model);
 
 // Query model metadata

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -174,7 +174,8 @@ static imp::QType map_dtype(ImpDType dt) {
 
 // --- Model Loading ---
 
-ImpError imp_model_load(const char* path, ImpModelFormat format, ImpModel* out_model) {
+ImpError imp_model_load_ex(const char* path, ImpModelFormat format, int load_mtp_head,
+                           ImpModel* out_model) {
     if (!path || !out_model) {
         return IMP_ERROR_INVALID_ARG;
     }
@@ -188,7 +189,7 @@ ImpError imp_model_load(const char* path, ImpModelFormat format, ImpModel* out_m
                 model = imp::load_gguf(path);
                 break;
             case IMP_FORMAT_SAFETENSORS:
-                model = imp::load_safetensors(path);
+                model = imp::load_safetensors(path, load_mtp_head != 0);
                 break;
             default:
                 return IMP_ERROR_INVALID_ARG;
@@ -214,6 +215,12 @@ ImpError imp_model_load(const char* path, ImpModelFormat format, ImpModel* out_m
     } catch (...) {
         return IMP_ERROR_INTERNAL;
     }
+}
+
+ImpError imp_model_load(const char* path, ImpModelFormat format, ImpModel* out_model) {
+    // Default load path: do NOT load the MTP head (saves ~1.57 GiB VRAM on
+    // Qwen3.6). Callers that want spec-decode use imp_model_load_ex(.., 1, ..).
+    return imp_model_load_ex(path, format, /*load_mtp_head=*/0, out_model);
 }
 
 void imp_model_free(ImpModel model) { delete model; }

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -851,7 +851,7 @@ static bool load_sharded(const std::string& model_dir, std::unordered_map<std::s
 
 // ---- Main SafeTensors loader ----
 
-std::unique_ptr<Model> load_safetensors(const std::string& path) {
+std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_head) {
     namespace fs = std::filesystem;
 
     std::string model_dir;
@@ -924,10 +924,14 @@ std::unique_ptr<Model> load_safetensors(const std::string& path) {
     // continues to skip the `mtp.` prefix; this sidecar load builds a separate
     // host tensor_map keyed by raw `mtp.*` names and dispatches to MtpHead fields.
     // Mmap is retained via Model::split_mmaps_ so Tensor pointers stay valid.
+    //
+    // Gated on load_mtp_head: the head is ~1.57 GiB BF16 (Qwen3.6) of dead VRAM
+    // unless the caller actually enables MTP spec-decode. Default-off skips it
+    // entirely so the model behaves as if no sidecar existed.
     std::optional<imp::MtpHead> mtp_local;
     std::unordered_map<std::string, Tensor> mtp_tensor_map;
     ShardInfo mtp_shard{};
-    if (!model_dir.empty()) {
+    if (load_mtp_head && !model_dir.empty()) {
         std::string mtp_path = model_dir + "/model_mtp.safetensors";
         std::error_code ec;
         auto sz = fs::file_size(mtp_path, ec);

--- a/src/model/safetensors_loader.h
+++ b/src/model/safetensors_loader.h
@@ -12,7 +12,14 @@ namespace imp {
 // path can be:
 //   - A single .safetensors file
 //   - A directory containing .safetensors files (+ config.json, etc.)
-std::unique_ptr<Model> load_safetensors(const std::string& path);
+//
+// load_mtp_head: when true, a `model_mtp.safetensors` sidecar (DeepSeek-V3
+// family, e.g. Qwen3.6) is parsed and retained (~1.57 GiB BF16 on Qwen3.6,
+// later uploaded to VRAM). Default false: the sidecar is skipped entirely, so
+// the model behaves as if it had no MTP head (spec-decode unavailable). Only
+// callers that actually intend to enable MTP spec-decode should pass true —
+// the head is wasted VRAM otherwise (server + normal CLI never use it).
+std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_head = false);
 
 // ---- Test-visible validation helpers ----
 //

--- a/tests/test_mtp_forward.cpp
+++ b/tests/test_mtp_forward.cpp
@@ -44,7 +44,7 @@ TEST(MtpForwardTest, DraftStepProducesValidToken) {
     }
 
     // Load model + upload weights with MTP enabled.
-    auto model = imp::load_safetensors(kQwen36ModelDir);
+    auto model = imp::load_safetensors(kQwen36ModelDir, /*load_mtp_head=*/true);
     ASSERT_NE(model, nullptr);
     ASSERT_TRUE(model->mtp_.has_value());
 

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -70,7 +70,10 @@ int main(int argc, char** argv) {
     auto t_init_start = std::chrono::high_resolution_clock::now();
 
     ImpModel model = nullptr;
-    ImpError err = imp_model_load(resolved_model.c_str(), format, &model);
+    // Only load the MTP head sidecar (~1.57 GiB BF16 on Qwen3.6) when the user
+    // actually requested MTP spec-decode. Otherwise it is dead VRAM.
+    ImpError err = imp_model_load_ex(resolved_model.c_str(), format,
+                                     /*load_mtp_head=*/args.mtp_spec_decode_k > 0, &model);
     if (err != IMP_SUCCESS) {
         fprintf(stderr, "Error loading model: %s\n", imp_error_string(err));
         return 1;


### PR DESCRIPTION
## Problem

For Qwen3.6-35B-A3B-NVFP4 (and any DeepSeek-V3-family model with a `model_mtp.safetensors` sidecar), the SafeTensors loader **always** loaded the MTP head — **~1.57 GiB BF16 uploaded to GPU** — gated only on the file existing.

But MTP speculative decoding is enabled **only** post-load via `imp_enable_mtp_spec_decode(ctx, k)`, triggered only by `imp-cli --mtp-spec-decode K`. **imp-server has no such flag at all** → the head was permanent dead VRAM on every server run (on a 32 GB card with Qwen3.6 loaded there were only ~248 MiB free). MTP on NVFP4 is also a known no-win, so it was wasted VRAM in the overwhelmingly common case.

## Fix

Gate the sidecar load behind a new `load_mtp_head` flag, **default off**:

- `load_safetensors(path, bool load_mtp_head = false)` — when false, the sidecar is skipped entirely (model behaves exactly as if it had no MTP head; spec-decode simply unavailable, and `imp_enable_mtp_spec_decode` already errors gracefully).
- New C API `imp_model_load_ex(path, format, load_mtp_head, out_model)`; `imp_model_load` delegates with `load_mtp_head=0`. **Server + all existing 3-arg callers are unaffected** (default = don't load).
- `imp-cli` passes `args.mtp_spec_decode_k > 0`, so `--mtp-spec-decode K` still loads the head and enables spec-decode.

## Evidence (Qwen3.6-35B-A3B-NVFP4)

**Default path** (`imp-cli --model ... --prompt "The capital of France is" --max-tokens 16 --temperature 0`):
- No `MTP head loaded` line in the log.
- `GPU memory after weight upload: 6514 MiB free / 32606 MiB total (weights ~23560 MiB)`
- Output coherent → `Paris`.

**Spec-decode path** (`--mtp-spec-decode 2`):
- `MTP head loaded: .../model_mtp.safetensors (1.57 GiB, 19 tensors, BF16)`
- `GPU memory after weight upload: 4970 MiB free ... (weights ~25104 MiB)`
- `MTP spec-decode enabled (k=2, ...)`, output coherent → `Paris`.

**VRAM saved: 1544 MiB (~1.5 GiB)** — both weight footprint (25104→23560) and free-after-upload (4970→6514) move by exactly the MTP head size.

- `MtpForwardTest.DraftStepProducesValidToken` PASSES (uses `load_safetensors(dir, /*load_mtp_head=*/true)`).
- Non-MTP `Qwen3-8B-NVFP4-cortecs` loads + generates coherently (unaffected — no sidecar).
- `make verify-fast`: OK (gtest filter green; perf/smoke skipped — GGUF baseline models not present in this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)