### PR TITLE
fix(server): model-reload SIGSEGV + VRAM retention; strict OpenAI model semantics (no auto-swap)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -537,6 +537,7 @@ if(IMP_BUILD_TESTS)
         tests/test_chunked_prefill.cu
         tests/test_mtp_forward.cpp
         tests/test_api_generate.cpp
+        tests/test_engine_relaunch.cpp
     )
 
     set(IMP_TEST_BINARIES

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -194,8 +194,11 @@ Endpoints: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`,
 non-streaming), `/tokenize`, `/detokenize`, `/health`. Tool/function
 calling, streaming usage stats, logprobs, and API-key auth
 (`--api-key`) supported.
-`/v1/models` lists available GGUF and SafeTensors models in the models
-directory.
+`/v1/models` lists the model the server is serving (OpenAI semantics: the
+server exposes exactly what it can serve). Requests must name that model —
+any other `model` value gets `404 model_not_found`; inference requests never
+trigger a model load/swap. To switch models, restart the server with a
+different `--model`.
 
 Server-only flags (not on `imp-cli`):
 
@@ -209,15 +212,18 @@ Server-only flags (not on `imp-cli`):
 | `--think-budget <f>` | Fraction of `max_tokens` reserved for reasoning (default 0.5, 0 = disabled) |
 
 ```bash
+# The model id is the served model's name (= /v1/models data[0].id)
+MODEL=$(curl -s http://localhost:8080/v1/models | jq -r '.data[0].id')
+
 # OpenAI chat completion
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"messages":[{"role":"user","content":"Hello!"}],"max_tokens":64}'
+  -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],\"max_tokens\":64}"
 
 # Streaming
 curl -N http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"messages":[{"role":"user","content":"Hello!"}],"stream":true}'
+  -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],\"stream\":true}"
 ```
 
 Works with the OpenAI Python SDK:
@@ -225,8 +231,9 @@ Works with the OpenAI Python SDK:
 ```python
 from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8080/v1", api_key="none")
+model = client.models.list().data[0].id
 for chunk in client.chat.completions.create(
-    model="imp", messages=[{"role": "user", "content": "Hi"}],
+    model=model, messages=[{"role": "user", "content": "Hi"}],
     stream=True, max_tokens=64
 ):
     print(chunk.choices[0].delta.content or "", end="", flush=True)

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -15,6 +15,34 @@
 #include <new>
 #include <exception>
 
+#include <cuda_runtime.h>
+
+namespace {
+
+// Return retained default-mempool blocks to the driver after a teardown.
+//
+// Engine init raises the default cudaMallocAsync pool's release threshold to
+// UINT64_MAX so freed blocks are kept for re-use. Model weights are allocated
+// from that pool (weight_upload.cu checked_cuda_malloc), so freeing a model
+// parks ~weights-sized memory in the pool instead of returning it. The next
+// model load can't see it: cudaMemGetInfo-based sizing (engine_init_resolver,
+// the upload oversubscription gate) and plain-cudaMalloc paths only observe
+// driver-free memory. Symptom: server auto-swap found ~1.5 GB free on a 32 GB
+// card and failed with "Failed to upload token embedding".
+void trim_default_mempool() {
+    // Retire pending async frees before trimming, otherwise their blocks are
+    // still referenced and survive the trim.
+    cudaDeviceSynchronize();
+    int dev = 0;
+    cudaMemPool_t pool = nullptr;
+    if (cudaGetDevice(&dev) == cudaSuccess &&
+        cudaDeviceGetDefaultMemPool(&pool, dev) == cudaSuccess && pool != nullptr) {
+        cudaMemPoolTrimTo(pool, 0);
+    }
+}
+
+}  // namespace
+
 // --- Error string ---
 
 const char* imp_error_string(ImpError err) {
@@ -223,7 +251,12 @@ ImpError imp_model_load(const char* path, ImpModelFormat format, ImpModel* out_m
     return imp_model_load_ex(path, format, /*load_mtp_head=*/0, out_model);
 }
 
-void imp_model_free(ImpModel model) { delete model; }
+void imp_model_free(ImpModel model) {
+    if (!model)
+        return;
+    delete model;
+    trim_default_mempool();
+}
 
 ImpModelArch imp_model_arch(ImpModel model) {
     if (!model || !model->model) {
@@ -337,7 +370,12 @@ ImpError imp_context_create(ImpModel model, const ImpConfig* config, ImpContext*
     }
 }
 
-void imp_context_free(ImpContext ctx) { delete ctx; }
+void imp_context_free(ImpContext ctx) {
+    if (!ctx)
+        return;
+    delete ctx;
+    trim_default_mempool();
+}
 
 // --- Helper: tokenize a prompt using chat template or raw encoding ---
 

--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -46,6 +46,13 @@ void attention_cublas_prewarm() {
     // calls inside captured streams find everything ready and don't
     // trigger any cudaMalloc (illegal under capture).
     cublasHandle_t h = get_attn_cublas_handle();
+    // The handle is process-global and outlives engines. Its last
+    // cublasSetStream() may reference a stream the previous engine destroyed
+    // (server model auto-swap) — issuing the dummy GEMM there segfaults inside
+    // cuBLAS algo selection (cuStreamGetGreenCtx on the dangling stream).
+    // Rebind to the default stream; real callers set their own stream before
+    // every use.
+    cublasSetStream(h, nullptr);
     ensure_attn_ptr_arrays(/*n_heads=*/256);
 
     constexpr int kM = 8, kN = 8, kK = 8;

--- a/tests/test_engine_relaunch.cpp
+++ b/tests/test_engine_relaunch.cpp
@@ -1,0 +1,117 @@
+// Regression tests for engine relaunch — the imp-server model auto-swap path.
+//
+// Two production bugs (server [auto-swap] Qwen3.6-35B → Gemma-4-31B, 2026-06):
+//
+//  1. SIGSEGV on engine re-init after inference: the process-global
+//     attention-cuBLAS handle kept the destroyed engine's stream bound
+//     (cublasSetStream in the batched-attention path). The next engine's
+//     attention_cublas_prewarm() issued its dummy GemmBatchedEx on that
+//     dangling stream → cuBLAS algo heuristics → cuStreamGetGreenCtx →
+//     segfault inside libcuda. The server died with no error output
+//     (exit 139); docker restart-policy masked it as connection drops.
+//
+//  2. VRAM starvation on swap: weights are allocated via cudaMallocAsync from
+//     the device default mempool, whose release threshold Engine init raises
+//     to UINT64_MAX. Freeing model+context parked ~weights-sized memory in
+//     the pool instead of returning it to the driver — the next model load
+//     (plain-cudaMalloc paths, cudaMemGetInfo-based sizing and the upload
+//     oversubscription gate) saw ~1.5 GB free on a 32 GB card and failed
+//     ("Failed to upload token embedding").
+//
+// Requires a real model on disk: IMP_TEST_MODEL or the default
+// /models/Qwen3-8B-Q8_0.gguf, matching test_api_generate.cpp.
+
+#include <gtest/gtest.h>
+#include "imp/imp.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+static const char* get_model_path() {
+    const char* p = std::getenv("IMP_TEST_MODEL");
+    return p ? p : "/models/Qwen3-8B-Q8_0.gguf";
+}
+
+static bool model_exists() {
+    FILE* f = fopen(get_model_path(), "r");
+    if (f) {
+        fclose(f);
+        return true;
+    }
+    return false;
+}
+
+#define SKIP_IF_NO_MODEL()                                           \
+    do {                                                             \
+        if (!model_exists())                                         \
+            GTEST_SKIP() << "Model not found: " << get_model_path(); \
+    } while (0)
+
+static size_t device_free_mib() {
+    size_t free_b = 0, total_b = 0;
+    if (cudaMemGetInfo(&free_b, &total_b) != cudaSuccess)
+        return 0;
+    return free_b >> 20;
+}
+
+// One full lifecycle: load → create context → generate (binds the global
+// attention-cuBLAS handle to this engine's stream) → free everything.
+static void run_one_cycle(const char* path) {
+    ImpModel model = nullptr;
+    ASSERT_EQ(imp_model_load(path, IMP_FORMAT_GGUF, &model), IMP_SUCCESS);
+
+    ImpConfig config = imp_config_default();
+    config.max_seq_len = 1024;
+    config.max_batch_size = 1;
+
+    ImpContext ctx = nullptr;
+    ImpError err = imp_context_create(model, &config, &ctx);
+    if (err != IMP_SUCCESS) {
+        imp_model_free(model);
+        FAIL() << "Context creation failed: " << imp_error_string(err);
+    }
+
+    ImpGenerateParams params = imp_generate_params_default();
+    params.seed = 42;
+    params.max_tokens = 8;
+    params.temperature = 0.7f;
+    params.apply_chat_template = 1;
+
+    char buf[1024] = {};
+    size_t n = 0;
+    EXPECT_EQ(imp_generate(ctx, "Say hi.", &params, buf, sizeof(buf), &n), IMP_SUCCESS);
+    EXPECT_GT(n, 0u);
+
+    imp_context_free(ctx);
+    imp_model_free(model);
+}
+
+}  // namespace
+
+TEST(EngineRelaunchTest, ReloadAfterInferenceReleasesVramAndDoesNotCrash) {
+    SKIP_IF_NO_MODEL();
+
+    size_t free_before = device_free_mib();
+    ASSERT_GT(free_before, 0u);
+
+    run_one_cycle(get_model_path());
+    if (::testing::Test::HasFatalFailure())
+        return;
+
+    // Teardown must hand the weights back to the driver, not park them in the
+    // default mempool: the next load sizes itself via cudaMemGetInfo and
+    // uploads through plain-cudaMalloc-visible memory. Allow ~2 GiB slack for
+    // persistent CUDA/cuBLAS context overhead from the first cycle.
+    size_t free_between = device_free_mib();
+    EXPECT_GT(free_between + 2048, free_before)
+        << "teardown retained " << (free_before - free_between)
+        << " MiB — default mempool not trimmed back to the driver";
+
+    // Re-init after inference: before the prewarm stream-rebind fix this
+    // segfaulted (dangling stream on the global attention-cuBLAS handle).
+    run_one_cycle(get_model_path());
+}

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -172,24 +172,18 @@ void handle_models(const httplib::Request& /*req*/, httplib::Response& res, Serv
     json data = json::array();
 
     // Snapshot state fields under lock
-    std::string models_dir;
     bool loaded;
     std::string model_name;
     {
         std::lock_guard<std::timed_mutex> lock(state.mtx);
-        models_dir = state.models_dir;
         loaded = state.model_loaded();
         model_name = state.model_name;
     }
 
-    // Scan models directory for all available models (GGUF + SafeTensors)
-    auto available = scan_model_files(models_dir);
-    if (!available.empty()) {
-        for (const auto& [name, path] : available) {
-            data.push_back({{"id", name}, {"object", "model"}, {"owned_by", "imp"}, {"path", path}});
-        }
-    } else if (loaded) {
-        // Fallback: only show loaded model if no models_dir configured
+    // OpenAI semantics: expose only what this server can actually serve —
+    // the loaded model. Listing the whole models directory invited clients
+    // to request models the server then had to swap in mid-flight.
+    if (loaded) {
         data.push_back({{"id", model_name}, {"object", "model"}, {"owned_by", "imp"}});
     }
 
@@ -219,10 +213,18 @@ std::string find_model_path(const ServerState& state, const std::string& name) {
     return "";
 }
 
-// Auto-swap model if a different one is requested and available as GGUF.
-// Returns true if the model is now loaded (either already loaded or swapped).
-// Returns false if the model couldn't be found or loaded (caller should 404).
-// Must be called with state.mtx held.
+// Serve only the loaded model (OpenAI semantics): requesting any other model
+// name gets 404 model_not_found. Inference requests never trigger a model
+// swap — the old auto-swap tore down the engine mid-stream, cancelling every
+// in-flight request (and the whole process if the new model didn't fit).
+// Switching models is an operator action: restart with a different --model.
+//
+// The one lifecycle action that remains on this path: if the server was
+// started without a model, the first request's model is resolved from the
+// models directory and loaded.
+//
+// Returns true if the requested model is loaded. Must be called with
+// state.mtx held.
 bool ensure_model_loaded(ServerState& state, const std::string& requested_model, httplib::Response& res) {
     if (!state.model_loaded()) {
         // No model loaded — try to load the requested one
@@ -236,7 +238,7 @@ bool ensure_model_loaded(ServerState& state, const std::string& requested_model,
             res.set_content(err.dump(), "application/json");
             return false;
         }
-        printf("[auto-swap] Loading %s...\n", requested_model.c_str());
+        printf("[auto-load] Loading %s...\n", requested_model.c_str());
         fflush(stdout);
         std::string error = load_model_into_state(state, path, json::object());
         if (!error.empty()) {
@@ -245,7 +247,7 @@ bool ensure_model_loaded(ServerState& state, const std::string& requested_model,
             res.set_content(err.dump(), "application/json");
             return false;
         }
-        printf("[auto-swap] %s loaded successfully\n", requested_model.c_str());
+        printf("[auto-load] %s loaded successfully\n", requested_model.c_str());
         fflush(stdout);
         return true;
     }
@@ -254,31 +256,15 @@ bool ensure_model_loaded(ServerState& state, const std::string& requested_model,
         return true;  // Already loaded
     }
 
-    // Different model requested — try to swap
-    std::string path = find_model_path(state, requested_model);
-    if (path.empty()) {
-        // Model not found in models dir — serve with current model anyway
-        // (matches llama.cpp behavior for unknown model names)
-        return true;
-    }
-
-    printf("[auto-swap] Swapping %s → %s...\n", state.model_name.c_str(), requested_model.c_str());
-    fflush(stdout);
-    std::string error = load_model_into_state(state, path, json::object());
-    if (!error.empty()) {
-        // Swap failed — try to keep serving with whatever is loaded
-        printf("[auto-swap] Swap failed: %s\n", error.c_str());
-        fflush(stdout);
-        if (state.model_loaded())
-            return true;  // Old model still works
-        res.status = 500;
-        json err = {{"error", {{"message", "Model swap failed: " + error}, {"type", "server_error"}}}};
-        res.set_content(err.dump(), "application/json");
-        return false;
-    }
-    printf("[auto-swap] %s loaded successfully\n", requested_model.c_str());
-    fflush(stdout);
-    return true;
+    res.status = 404;
+    json err = {{"error",
+                 {{"message", "The model '" + requested_model + "' does not exist; this server is serving '" +
+                                  state.model_name + "'"},
+                  {"type", "invalid_request_error"},
+                  {"param", "model"},
+                  {"code", "model_not_found"}}}};
+    res.set_content(err.dump(), "application/json");
+    return false;
 }
 
 // Build ImpConfig from default args + optional JSON overrides.
@@ -414,8 +400,8 @@ std::string load_model_into_state(ServerState& state, const std::string& path, c
 
     // Create context (engine auto-detects config from model metadata).
     // Re-stash the runtime config so Engine::init's take_pending_runtime_config()
-    // picks it up. The server may swap models at runtime; each swap rebuilds the
-    // Engine and consumes the pending slot.
+    // picks it up. The server may load a model at runtime (auto-load on first
+    // request); each load rebuilds the Engine and consumes the pending slot.
     imp::set_pending_runtime_config(state.runtime_config);
     ImpConfig config = build_config(state.default_args, state.runtime_config, path, config_overrides,
                                     state.model);

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -32,9 +32,10 @@ int main(int argc, char** argv) {
 
     // Load imp.conf (if present) + apply --set overrides, then stash for
     // Engine::init to pick up (Phase 5 Track D follow-up: replaces the
-    // RuntimeConfig::install() process-wide singleton). The server may
-    // reload models at runtime via /v1/models POST; load_model_into_state
-    // re-stashes the same config snapshot before each Engine construction.
+    // RuntimeConfig::install() process-wide singleton). The server may load
+    // a model at runtime (auto-load on first request when started without
+    // --model); load_model_into_state re-stashes the same config snapshot
+    // before each Engine construction.
     state.runtime_config = imp::RuntimeConfig::load(args.config_path, args.config_overrides);
     imp::process_diag_install(state.runtime_config);
     imp::set_pending_runtime_config(state.runtime_config);


### PR DESCRIPTION
Rebased replacement for #506 (conflict with #505, force-push restricted).

## Problem

Requesting a different model on the server (`[auto-swap]`) killed the process: SIGSEGV (exit 139) with no error output, docker restart-policy relaunched it — clients saw connection drops. Even when it didn't crash, swaps failed with "Failed to upload token embedding" although the new model fit easily.

## Root causes (reproduced under gdb)

1. **Dangling cuBLAS stream → SIGSEGV.** The process-global attention-cuBLAS handle keeps the stream of the destroyed engine. The next engine's `attention_cublas_prewarm()` runs its dummy GemmBatchedEx on that stream → `cuStreamGetGreenCtx` segfaults in libcuda. Only triggers after ≥1 inference (the handle is stream-bound lazily) — which is why cold swap tests never caught it.
   ```
   #2  cuStreamGetGreenCtx
   #6  cublasLtHSHMatmulAlgoGetHeuristicForStream
   #14 imp::attention_cublas_prewarm()
   #15 imp::Engine::init(...)
   ```
2. **Default mempool retention → reload starvation.** Weights are allocated via `cudaMallocAsync` from the default pool (release threshold UINT64_MAX). Freeing model+context parked **~28 GB** in the pool; `cudaMemGetInfo`-based sizing and the upload oversubscription gate then saw 1.5 GB free on a 32 GB card. Fix: `cudaMemPoolTrimTo(pool, 0)` in `imp_context_free`/`imp_model_free`.

## API change (breaking, intentional)

Auto-swap removed — inference requests never touch model lifecycle (the old behavior cancelled every in-flight request on swap):
- `/v1/models` exposes **only the loaded model** (was: full models_dir listing)
- requesting another model → **404 `model_not_found`** (OpenAI error shape); the silent llama.cpp-style serve-with-current fallback is gone
- auto-load only when no model is loaded; switching models = restart with another `--model`

## Verification

- New `EngineRelaunchTest`: load → generate → free → **assert VRAM returned** → reload → generate. Segfaulted/failed before, green now.
- Live server matrix: `/v1/models` single entry · correct model 200 · foreign model 404 · **concurrent stream + foreign-model request: stream completes (`stop` + `[DONE]`), server alive, RestartCount=0**
- `make verify-fast` OK (no hot-path changes; decode/prefill untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)