### PR TITLE
fix(server): unclosed think must not spill into content; degen_suite hardening

### DIFF
--- a/tools/analysis/degen_suite.py
+++ b/tools/analysis/degen_suite.py
@@ -450,7 +450,14 @@ def main():
     suite = Suite(srv, args.quick, args.skip_deterministic)
 
     t0 = time.time()
-    suite.probe_reasoning()
+    try:
+        suite.probe_reasoning()
+    except urllib.error.HTTPError as e:
+        body = e.read()[:300].decode("utf-8", "replace")
+        print(f"Reasoning probe failed: HTTP {e.code}: {body}", file=sys.stderr)
+        print("Server is up but cannot serve chat requests — check model state "
+              "and docker logs.", file=sys.stderr)
+        return 2
     for cat in selected:
         print(f"\n== {cat} ==")
         try:

--- a/tools/analysis/degen_suite.py
+++ b/tools/analysis/degen_suite.py
@@ -49,6 +49,10 @@ SPECIAL_MARKERS = [
     "<|channel>", "<channel|>", "<start_of_turn>", "<end_of_turn>",
     "[INST]", "[/INST]", "<<SYS>>", "<|user|>", "<|assistant|>",
     "<think>", "</think>",
+    # NUL byte: byte-level-BPE models can emit the 0x00 byte token —
+    # observed live on Qwen3.6-NVFP4 (alternating token/NUL right after
+    # server start). Never valid in text output.
+    "\x00",
 ]
 
 # Meta-reasoning openers: if a *reasoning* model puts these at the start of
@@ -205,11 +209,19 @@ class Suite:
         print(f"  [\033[33mSKIP\033[0m] {name} — {why}")
 
     def probe_reasoning(self):
-        """One short probe: does this model emit reasoning_content?"""
-        r = self.srv.chat_stream(
-            [{"role": "user", "content": "What is 2+2? Answer with the number only."}],
-            max_tokens=200,
-        )
+        """Probe: does this model emit reasoning_content?
+
+        Two attempts (stream + non-stream) — reasoning models are not
+        deterministic about WHEN they think (Qwen3.6 sometimes answers a
+        trivial question with zero reasoning tokens), so a single probe
+        misclassifies and downstream categories then use too-small budgets.
+        """
+        q = [{"role": "user", "content":
+              "Is 17 a prime number? Explain briefly, then answer yes or no."}]
+        r = self.srv.chat_stream(q, max_tokens=400)
+        if not r["reasoning"]:
+            r2 = self.srv.chat(q, max_tokens=400, seed=7)
+            r["reasoning"] = r["reasoning"] or r2["reasoning"]
         self.is_reasoning = bool(r["reasoning"])
         print(f"Model emits reasoning_content: {self.is_reasoning}")
         return r
@@ -311,7 +323,7 @@ class Suite:
 
     # -- adherence (prompt-blindness / gross hallucination) ------------------
     def cat_adherence(self):
-        n = 600 if self.is_reasoning else 80
+        n = 1000 if self.is_reasoning else 80
         tasks = [
             ("echo literal", "Reply with exactly this string and nothing else: BANANA42", "BANANA42"),
             ("arithmetic", "What is 17 + 25? Reply with the number only.", "42"),
@@ -341,7 +353,7 @@ class Suite:
             + filler_unit * reps
             + "\n\nWhat was the code I asked you to remember? Reply with the code only."
         )
-        n = 600 if self.is_reasoning else 60
+        n = 1000 if self.is_reasoning else 60
         try:
             r = self.srv.chat([{"role": "user", "content": prompt}], max_tokens=n)
         except urllib.error.HTTPError as e:
@@ -353,7 +365,7 @@ class Suite:
 
     # -- multi-turn state ----------------------------------------------------
     def cat_multi_turn(self):
-        n = 600 if self.is_reasoning else 100
+        n = 1000 if self.is_reasoning else 100
         msgs = [{"role": "user", "content": "My lucky number is 271. Just acknowledge briefly."}]
         r1 = self.srv.chat(msgs, max_tokens=n)
         msgs.append({"role": "assistant", "content": r1["content"] or "Noted."})
@@ -373,7 +385,7 @@ class Suite:
     # -- stream protocol -----------------------------------------------------
     def cat_stream(self):
         q = [{"role": "user", "content": "List the numbers from 1 to 10, comma separated."}]
-        n = 700 if self.is_reasoning else 120
+        n = 1000 if self.is_reasoning else 120
         s = self.srv.chat_stream(q, max_tokens=n)
         self.record("stream", "SSE terminates with [DONE]", s["done"])
         self.record("stream", "finish_reason chunk present",

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1471,9 +1471,23 @@ static void nonstream_chat_response_(
         // Extract reasoning content (DeepSeek format) or strip think blocks
         std::string reasoning_content;
         if (ctx.snap.is_think_model && state.default_args.reasoning_format == "deepseek") {
-            auto [reasoning, cleaned] = extract_reasoning(content);
-            reasoning_content = reasoning;
-            content = cleaned;
+            // Generation that started inside an injected <think> prefix
+            // (chat-template or server-appended; see prompt_tail_contains
+            // above) carries no opener in its output. If it also never
+            // reached </think> — budget exhausted mid-think, or the model
+            // stopped while reasoning — the WHOLE text is reasoning.
+            // extract_reasoning() can't tell that from text alone and would
+            // spill it into user-visible content (the streaming path gets
+            // this right via its in-think state machine).
+            if (ctx.snap.enable_thinking && content.find("</think>") == std::string::npos &&
+                content.find("<think>") == std::string::npos) {
+                reasoning_content = std::move(content);
+                content.clear();
+            } else {
+                auto [reasoning, cleaned] = extract_reasoning(content);
+                reasoning_content = reasoning;
+                content = cleaned;
+            }
         } else if (ctx.snap.is_think_model && state.default_args.reasoning_format != "none") {
             strip_think_block(content);
         }


### PR DESCRIPTION
## Think-leak fix (the 'Qwen3.6 leaks its reasoning' complaint)

Chat templates for Qwen3/3.5/3.6/R1 inject `<think>` into the **prompt**, so generation starts mid-thinking with no opener in the output. When the output also never reaches `</think>` (budget exhausted or verbose reasoning), `extract_reasoning()` found neither tag and returned the **whole buffer as user-visible content** — non-stream responses began with `Thinking Process: ...`. The streaming path (token-state machine) labelled the same output `reasoning_content` correctly.

Fix: in the non-stream finalize, `thinking active && no </think> in output` ⇒ whole text is `reasoning_content`, content stays empty — matching stream semantics. `/v1/messages` non-stream inherits the fix.

## Validation (degen_suite vs live Qwen3.6-35B-NVFP4)

think-leak category: **6 FAIL → 0 FAIL** (all 7 checks green, incl. truncated-think spill and `enable_thinking=false`). Clean separation confirmed on raw responses:
`content: "4"` / `reasoning_content: "The user is asking..."`.

Remaining suite FAILs (2) are flaky model behavior (answer emitted inside think + EOS — intermittent at temp=0), tracked separately.

## degen_suite hardening

- NUL-byte detection in SPECIAL_MARKERS — live-observed `0x00` byte-token emission on Qwen3.6 right after server start (separate issue)
- reasoning probe: 2 attempts (stream + non-stream) — single probe misclassified non-deterministic thinkers
- reasoning budgets → 1000 tokens; HTTP errors in probe exit cleanly (code 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)