### PR TITLE
fix(attention+server): revert FA2-everywhere routing (9/12 models prompt-blind); fix SSE NUL-terminator leak

### DIFF
--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -807,15 +807,22 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             Tensor k_full_t(k_full, QType::F16, 2, kv_full_shape, /*on_device=*/true);
             Tensor v_full_t(v_full, QType::F16, 2, kv_full_shape, /*on_device=*/true);
 
-            // Chunked prefill: choose FMHA or cuBLAS
+            // Chunked prefill: choose FMHA or cuBLAS.
+            //
+            // REVERTED (#493 routed ALL hd=128 prefill into FA2 "regardless of
+            // the threshold" for +7-25% pp512): both fp8-quantizing FMHA
+            // kernels (FA2 and the fp8 FMHA) carry per-layer e4m3 score noise
+            // that compounds across layers into prompt-blind/degenerate output
+            // — every hd=128 model failed the degen suite at short prompts
+            // (Qwen3-8B answered "What is 17 + 25?" with "2 5 2 5 2 5...").
+            // The FP16 cuBLAS path is the accuracy reference; FMHA stays
+            // gated behind the S-matrix-capacity threshold where it has
+            // history in production. fp8-attention quality above the
+            // threshold is tracked separately (see issue #511).
             const int fmha_threshold = runtime_config().attention.fmha_prefill_threshold;
-            // FA2 (register-resident, hd=128, seq-adaptive Bq) beats the materialized
-            // cuBLAS path at every measured context length → prefer it for hd=128
-            // regardless of the S-matrix-capacity threshold (non-128 / Gemma-4 stay cuBLAS).
-            const bool fa2_capable = (hd == 128) && (runtime_config().attention.fmha_fa2 == "on");
             const bool chunked_use_fmha =
                 !per_layer_shapes &&  // Gemma-4 hd=512 stays cuBLAS
-                (fa2_capable || (fmha_threshold > 0 && ctx_len >= fmha_threshold));
+                (fmha_threshold > 0 && ctx_len >= fmha_threshold);
 
             if (chunked_use_fmha) {
                 // FMHA: no S-matrix needed, O(n) memory. Reshape to 4D for dispatch.
@@ -849,10 +856,10 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         const bool s_matrix_fits = attn_scores_buf_ != nullptr &&
                                    n <= static_cast<int>(attn_scores_.shape[1]);
         const bool non_gemma4_sliding = !force_cublas_attn && sliding_active;
-        // Prefer FA2 for hd=128 regardless of threshold (see chunked path above).
-        const bool fa2_capable = (hd == 128) && (runtime_config().attention.fmha_fa2 == "on");
+        // FMHA only above the S-matrix threshold — see the chunked path above
+        // for why the #493 prefer-FA2-at-every-length override was reverted.
         const bool prefer_fmha = !force_cublas_attn &&
-                                 (fa2_capable || n >= runtime_config().attention.fmha_prefill_threshold);
+                                 (n >= runtime_config().attention.fmha_prefill_threshold);
 
         if (s_matrix_fits && !non_gemma4_sliding && !prefer_fmha) {
             attention_cublas_prefill(qv, kk, vv, ao, attn_scores_, nh, nkv, hd, scale,

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -184,16 +184,16 @@ TEST_F(FmhaFP8Test, Qwen35LikeHD256_GQA41_SeqMultiTile) { run_test(1, 128, 128, 
 class FmhaFA2Test : public FmhaFP8Test {
 protected:
     void run_fa2(int B, int Sq, int Skv, int NH, int NKV, int HD, bool causal, int sw = 0,
-                 float softcap = 0.0f) {
+                 float softcap = 0.0f, float amplitude = 1.0f) {
         float scale = 1.0f / std::sqrt(static_cast<float>(HD));
         size_t q_elems = B * Sq * NH * HD;
         size_t kv_elems = B * Skv * NKV * HD;
 
         std::vector<float> Q_f(q_elems), K_f(kv_elems), V_f(kv_elems);
         for (size_t i = 0; i < q_elems; i++)
-            Q_f[i] = 0.02f * static_cast<float>((i * 7 + 3) % 13 - 6);
+            Q_f[i] = amplitude * 0.02f * static_cast<float>((i * 7 + 3) % 13 - 6);
         for (size_t i = 0; i < kv_elems; i++) {
-            K_f[i] = 0.02f * static_cast<float>((i * 11 + 5) % 13 - 6);
+            K_f[i] = amplitude * 0.02f * static_cast<float>((i * 11 + 5) % 13 - 6);
             V_f[i] = 0.02f * static_cast<float>((i * 13 + 7) % 13 - 6);
         }
 
@@ -259,6 +259,30 @@ protected:
 };
 
 TEST_F(FmhaFA2Test, CausalHD128) { run_fa2(1, 64, 64, 4, 4, 128, true); }
+
+// Engine-realistic SHORT prefill shapes. Since the executor prefers FA2 for
+// hd=128 at every length (executor_attention.cu fa2_capable), short chat
+// prompts hit this kernel too — production corruption (prompt-blind models,
+// degenerate output) appeared exactly there. Qwen3-8B GQA is 32 Q / 8 KV.
+TEST_F(FmhaFA2Test, CausalShortSeq24_GQA32_8) { run_fa2(1, 24, 24, 32, 8, 128, true); }
+TEST_F(FmhaFA2Test, CausalSeq32_GQA32_8) { run_fa2(1, 32, 32, 32, 8, 128, true); }
+TEST_F(FmhaFA2Test, CausalShortSeq24) { run_fa2(1, 24, 24, 4, 4, 128, true); }
+TEST_F(FmhaFA2Test, CausalOddSeq136_GQA32_8) { run_fa2(1, 136, 136, 32, 8, 128, true); }
+TEST_F(FmhaFA2Test, CausalOddSeq51) { run_fa2(1, 51, 51, 4, 4, 128, true); }
+
+// Realistic Q/K magnitudes. QK-normed models (Qwen3 family) produce Q/K values
+// far beyond the ±0.12 of the synthetic fill above; the FA2 kernel converts
+// Q and K to FP8 e4m3 WITHOUT a scale factor, so large inputs lose precision
+// or saturate (e4m3 max ±448) — production symptom: prompt-blind models on
+// every hd=128 architecture while the FP16 cuBLAS path stays correct.
+// amplitude=80 → |Q|,|K| up to ~9.6, QK dots up to ~118 pre-scale (still
+// within e4m3 range per element, but only ~2 mantissa bits at that scale).
+TEST_F(FmhaFA2Test, RealisticMagnitude_Seq24) {
+    run_fa2(1, 24, 24, 32, 8, 128, true, 0, 0.0f, /*amplitude=*/80.0f);
+}
+TEST_F(FmhaFA2Test, RealisticMagnitude_Seq64) {
+    run_fa2(1, 64, 64, 4, 4, 128, true, 0, 0.0f, /*amplitude=*/80.0f);
+}
 TEST_F(FmhaFA2Test, NonCausalHD128) { run_fa2(1, 32, 64, 4, 4, 128, false); }
 TEST_F(FmhaFA2Test, GQA_HD128) { run_fa2(1, 64, 64, 8, 2, 128, true); }
 TEST_F(FmhaFA2Test, CausalMultiTile_HD128) { run_fa2(1, 128, 128, 4, 4, 128, true); }

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1673,7 +1673,15 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
     int                n_prompt_tokens  = ctx.snap.n_prompt_tokens;
     auto               t_start          = ctx.t_start;
     const auto&        stop_sequences   = ctx.params.stop_sequences;
-    size_t             max_stop_len     = static_cast<size_t>(ctx.params.max_stop_len);
+    // Derive max_stop_len from the FINAL stop list, not ctx.params.max_stop_len:
+    // the snapshot phase may inject server-side stops ("\nHuman" turn guard for
+    // think models) AFTER request parsing computed max_stop_len. A stale 0 made
+    // the partial-match holdback `size - max_stop_len + 1` flush one byte PAST
+    // pending_text's end — emitting the std::string NUL terminator into every
+    // SSE content delta ("4 ") and disabling cross-token stop matching.
+    size_t             max_stop_len     = 0;
+    for (const auto& s : stop_sequences)
+        max_stop_len = std::max(max_stop_len, s.size());
     int                req_logprobs     = ctx.params.req_logprobs;
     bool               include_usage    = ctx.params.include_usage;
     bool               enable_thinking  = ctx.snap.enable_thinking;
@@ -1765,6 +1773,7 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
 
     // Helper: flush confirmed text up to a byte position
     auto flush_text = [&](size_t up_to) {
+        up_to = std::min(up_to, pending_text.size());  // never read past the buffer
         if (up_to == 0)
             return true;
         bool ok = sse_writer.write_content(pending_text.data(), up_to, sink);
@@ -3583,7 +3592,11 @@ static bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& c
     AnthropicSSE out{sink};
 
     const auto& stop_sequences = ctx.params.stop_sequences;
-    size_t max_stop_len = static_cast<size_t>(ctx.params.max_stop_len);
+    // Derive from the FINAL stop list (server-injected stops update it late) —
+    // see the matching comment in the chat streaming path.
+    size_t max_stop_len = 0;
+    for (const auto& s : stop_sequences)
+        max_stop_len = std::max(max_stop_len, s.size());
     bool enable_thinking = ctx.snap.enable_thinking;
     bool has_tools = ctx.params.has_tools;
     auto tpl_family = ctx.snap.tpl_family;


### PR DESCRIPTION
Two production bugs found by the degen-suite zoo sweep (12 models), both root-caused with in-engine instrumentation.

## 1. FA2-everywhere routing made 9/12 zoo models prompt-blind (regression, PR #493)

#493 routed **all** hd=128 prefill into the FA2 kernel (was: only ≥ `fmha_prefill_threshold` ≈ 2497). Sweep result: every hd=128 model (Qwen3 dense+MoE, Phi-4, Nemotron×2 — NVFP4 **and** GGUF) prompt-blind/degenerate at short prompts; Gemma (hd≠128 → FA2 declines) and Qwen3.6 clean:

```
Qwen3-8B-Q8:  'What is 17 + 25?' → '    2     5     5     5 ...'
Qwen3-14B:    answers '390+50' — a question never asked
gemma-3-12b:  every answer = 'A'
```

**Root cause (measured):** diffuse e4m3 quantization noise from the unscaled Q/K→fp8 conversion. In-engine A/B vs FP16 reference on identical tensors: layer 1 = 1.7% elements >5% off, layer 8 = 42% (compounds). q-row 0 — softmax over one element, quantization-immune — is exact. Both fp8 kernels (FA2, fp8-FMHA) affected; #478's 'output-identical' validation compared the two fp8 kernels against each other. Kernel unit tests pass because per-call noise sits below the 5% oracle threshold — the failure is cumulative over 36 layers.

**Fix:** revert to threshold gating (the pre-#493, perf-baseline-measured state). fp8-attention accuracy above the threshold → #511. Adds engine-realistic FA2 kernel tests (seq 24/32/51/136, GQA 32/8, realistic magnitudes) as coverage.

## 2. NUL terminator in every SSE content delta (issue #510 root-caused)

`{"content":"4\u0000"}` on every chat-stream delta for think models: the `\nHuman` turn guard (#442) is injected **after** parsing computed `max_stop_len` → streams ran with `max_stop_len=0` → holdback `size-0+1` flushed one byte past `pending_text` = std::string's NUL terminator. Bonus: the #442 guard could never match across token boundaries (zero holdback). Only the OpenAI chat stream affected (other paths clamp via substr).

**Fix:** derive `max_stop_len` from the final stop list at both use sites + clamp `flush_text`.

## Verification

| | vorher | nachher |
|---|---|---|
| Qwen3-8B-Q8 suite | 7 FAIL (garbage, NULs) | **1 FAIL** (benign: thinks past budget, coherent) |
| Qwen3-14B-NVFP4 suite | 6 FAIL | **2 FAIL** (budget + long-ctx quality) |
| NUL count in stream | 22-32/response | **0** |
| stream == non-stream @temp0 | FAIL | **PASS** |
| `imp-cli` 17+25 | '2 5 2 5...' | coherent reasoning |

FmhaFA2Test 13/13, perf baseline (pp512 = cuBLAS conditions) restored to its measurement state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)