### PR TITLE
fix(engine+server): Nemotron NoPE attention, think-budget chain, JSON termination, gemma-4-31B dense decode

### DIFF
--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -35,6 +35,17 @@ bool JsonConstrainer::init(const Tokenizer& tok) {
         token_categories_[i] = classify_token(text);
     }
 
+    // EOS gets a dedicated category: classify_token sees the rendered text
+    // ("<|im_end|>" → STRING_CHAR), so in the DONE state (whitespace-only
+    // mask) EOS was blocked and a completed JSON could never terminate —
+    // every json_mode request ran to max_tokens and finished with "length".
+    // CAT_EOS is allowed ONLY in DONE — allowing it everywhere lets a
+    // json-reluctant model emit EOS as its very first token (0 completions).
+    for (int32_t eid : tok.eos_ids()) {
+        if (eid >= 0 && eid < vocab_size_)
+            token_categories_[eid] = CAT_EOS;  // reachable only where the mask says so
+    }
+
     // Upload to device
     cudaError_t err = cudaMalloc(&d_token_categories_, vocab_size_ * sizeof(uint16_t));
     if (err != cudaSuccess) {
@@ -66,11 +77,15 @@ void JsonConstrainer::reset() {
     current_state_ = JsonState::START;
     partial_literal_.clear();
     target_literal_.clear();
+    ws_run_ = 0;
     preamble_.reset();
 }
 
 uint16_t JsonConstrainer::compute_allowed_mask() const {
-    uint16_t mask = CAT_WHITESPACE;  // whitespace is always allowed
+    // Whitespace is legal between any JSON tokens, but cap the run length —
+    // see advance_char. (EOS has its own CAT_EOS bit, allowed in DONE only.)
+    constexpr int kMaxWsRun = 64;
+    uint16_t mask = (ws_run_ < kMaxWsRun) ? CAT_WHITESPACE : 0;
 
     switch (current_state_) {
         case JsonState::START:
@@ -133,7 +148,11 @@ uint16_t JsonConstrainer::compute_allowed_mask() const {
             break;
 
         case JsonState::DONE:
-            // Parsing complete — only allow EOS / whitespace
+            // Parsing complete — only EOS (and capped whitespace). CAT_EOS
+            // must stay allowed even when the WS-run cap zeroes whitespace,
+            // otherwise every token is -inf and greedy argmax degenerates to
+            // token id 0 ('!' on byte-level BPE vocabs).
+            mask |= CAT_EOS;
             break;
 
         default:
@@ -146,11 +165,17 @@ uint16_t JsonConstrainer::compute_allowed_mask() const {
 }
 
 void JsonConstrainer::advance_char(char c) {
-    // Skip whitespace in non-string states
+    // Skip whitespace in non-string states — but count the run. JSON allows
+    // unlimited inter-token whitespace, and a model that doesn't want to emit
+    // JSON exploits that as an escape hatch (greedy decode emits newlines
+    // until max_tokens). compute_allowed_mask() drops CAT_WHITESPACE once the
+    // run exceeds the cap, forcing a structural token (or EOS) instead.
     if (current_state_ != JsonState::IN_STRING && current_state_ != JsonState::IN_STRING_ESCAPE &&
         (c == ' ' || c == '\t' || c == '\n' || c == '\r')) {
+        ws_run_++;
         return;
     }
+    ws_run_ = 0;
 
     switch (current_state_) {
         case JsonState::START:

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -46,6 +46,7 @@ enum JsonTokenCat : uint16_t {
     CAT_WHITESPACE = 1 << 12,    // space, tab, newline
     CAT_LITERAL_CONT = 1 << 13,  // continuation of a partial literal (r, u, e, a, l, s)
     CAT_NUMBER_CONT = 1 << 14,   // 0-9, ., e, E, +, - (continuation of number)
+    CAT_EOS = 1 << 15,           // EOS token ids — allowed only in the DONE state
 };
 
 // Mask for tokens that can start a JSON value
@@ -117,6 +118,9 @@ private:
     // FSM state
     std::vector<JsonState> state_stack_;
     JsonState current_state_ = JsonState::START;
+    // Consecutive whitespace chars in non-string states (escape-hatch cap,
+    // see advance_char/compute_allowed_mask).
+    int ws_run_ = 0;
     std::string partial_literal_;  // for tracking partial "true"/"false"/"null"
     std::string target_literal_;   // full expected literal
 

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -600,7 +600,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         bool has_qk_norm = (ly.attn_q_norm.data != nullptr && ly.attn_k_norm.data != nullptr);
         // Determine if we can fuse K-RoPE into KV cache write
         bool can_fuse_rope_kv = (!state.is_prefill && n == 1 && qv.qtype == QType::F16 && state.kv_cache &&
-                                 state.kv_cache->qtype() == QType::F16);
+                                 state.kv_cache->qtype() == QType::F16 && !cfg.rope_attn_disabled);
         // Per-layer rope_dim. Gemma 4: both SWA and global layers rotate the
         // full head_dim. Global layers' freq_factors (loaded into
         // longrope_freqs above) zero out most pairs to realize the
@@ -612,7 +612,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             fused_rope_dim = hd;
         }
         const bool no_qknorm_fused = runtime_config().attention.no_qknorm_fused;
-        if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused) {
+        if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused &&
+            !cfg.rope_attn_disabled) {
             // Fused: QK-norm + RoPE in one kernel launch (decode only, n=1).
             // Keeps norm intermediate values in FP32 shared memory.
             qknorm_rope_fused(static_cast<half*>(qv.data), static_cast<half*>(kk.data),
@@ -673,9 +674,14 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             } else if (layer_rope_dim > hd || layer_rope_dim <= 0) {
                 layer_rope_dim = hd;  // safety clamp
             }
-            rope_forward(q4r_t, k4r_t, state.positions, hd, layer_rope_theta, layer_rope_freq_scale,
-                         layer_rope_dim, cfg.rope_neox, cfg.yarn_ext_factor, cfg.yarn_attn_factor,
-                         cfg.yarn_ext_factor > 0.0f ? yarn_corr_dims_ : nullptr, stream, longrope_freqs);
+            // NoPE attention (Nemotron-H): position lives in the Mamba layers,
+            // rotating Q/K here scrambles positional binding (bag-of-words
+            // prompts). QK-norm above still applies; only the rotation is skipped.
+            if (!cfg.rope_attn_disabled) {
+                rope_forward(q4r_t, k4r_t, state.positions, hd, layer_rope_theta, layer_rope_freq_scale,
+                             layer_rope_dim, cfg.rope_neox, cfg.yarn_ext_factor, cfg.yarn_attn_factor,
+                             cfg.yarn_ext_factor > 0.0f ? yarn_corr_dims_ : nullptr, stream, longrope_freqs);
+            }
         }
     }
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -237,6 +237,17 @@ void apply_arch_defaults(ModelConfig& cfg) {
         cfg.moe_sigmoid_gating = true;
     if (e.expert_weights_norm)
         cfg.expert_weights_norm = true;
+
+    // Nemotron-H family attention is NoPE: the Mamba layers carry position,
+    // the attention layers are trained WITHOUT rotary embeddings. The HF
+    // config still ships rope_theta=10000 / partial_rotary_factor=1.0 (class
+    // defaults), and applying RoPE scrambles positional binding — the model
+    // reads prompts as a bag of words ("17 + 25" → "25 + 17"/"15 + 7";
+    // "ALPHA BRAVO CHARLIE" → hallucinated different prompt). Verified by
+    // disabling rotation (rope_theta=1e12 config patch): prompt reading
+    // becomes exact.
+    if (cfg.arch == ModelArch::NEMOTRON_H_MOE)
+        cfg.rope_attn_disabled = true;
 }
 
 }  // namespace imp

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -46,6 +46,9 @@ struct ModelConfig {
     bool gdn_grouped_head_layout = false;
     int rope_dim = 0;       // 0 = full head_dim, 84 = partial
     bool rope_neox = true;  // true = NeoX/split (i, i+d/2), false = interleaved (2i, 2i+1)
+    // NoPE attention (Nemotron-H family): attention layers use NO rotary
+    // embedding — position is carried by the recurrent (Mamba) layers.
+    bool rope_attn_disabled = false;
 
     // YaRN / Dynamic NTK RoPE scaling
     float yarn_ext_factor = 0.0f;   // 0 = linear/none, 1.0 = YaRN blending

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -253,6 +253,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [server]
     else if (eq("server.prefix_cache"))
         cfg.server.prefix_cache = parse_bool(val, cfg.server.prefix_cache);
+    else if (eq("server.green_contexts"))
+        cfg.server.green_contexts = parse_bool(val, cfg.server.green_contexts);
 
     // [bench]
     else if (eq("bench.generate"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -324,6 +324,10 @@ struct RuntimeConfig {
 
     struct Server {
         bool prefix_cache = false;
+        // Green Contexts / prefill-decode overlap streams in the server engine.
+        // [server] green_contexts = false to disable (diagnostic: suspected
+        // memSyncDomain race on sm_120 fallback streams — gemma-3-12b IMA).
+        bool green_contexts = true;
     } server;
 
     struct Bench {

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -84,13 +84,17 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
 
     const int32_t think_close = detect_think_close(tokenizer);
 
-    // Reasoning models always get the large think-close budget. Otherwise:
+    // The large think-close budget applies only when THIS REQUEST is actually
+    // reasoning (thinking_open). Keying it off tokenizer capability alone gave
+    // every request on a think-capable tokenizer an 8192-token unmasked
+    // preamble — a non-thinking json_mode request never emits </think>, so the
+    // grammar never engaged and the output was unconstrained garbage.
     //   - has_tools: 64-token slack so short verbal preambles ("Sure! ")
     //     don't squeeze out the tool-tag opener.
     //   - no tools: 8-token slack for markdown fences, matches today's
     //     non-reasoning default.
     int preamble_budget;
-    if (think_close >= 0) {
+    if (thinking_open && think_close >= 0) {
         preamble_budget = 8192;
     } else if (has_tools) {
         preamble_budget = 64;

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -300,6 +300,21 @@ void Engine::init_resolve_quant_flags_() {
             // on Q4_K_M + UD-Q4_K_M: tg256 184 → 204 tok/s (+11%), pp512
             // 1795 → 2347 tok/s (+30%). Coherent on chat prompts; the
             // pre-existing Q4_K_M code-gen drift (see roadmap) is orthogonal.
+            //
+            // DENSE Gemma-4 (31B, no experts) from GGUF: the mode-2 prequant
+            // conversion corrupts the decode weights — NaN logits from decode
+            // step 2, greedy argmax lands on <pad> (token 0) and generation
+            // stops after the first (prefill-sampled, correct) token. Mode 1
+            // and the FP16 cache are verified clean on the same model, so
+            // cap dense GGUF Gemma-4 at mode 1 until the mode-2 conversion
+            // bug is found (issue #516). The MoE 26B-A4B (degen-suite green)
+            // keeps mode 2.
+            if (config_.use_nvfp4_decode == 2 && model_->config().n_experts == 0 &&
+                !model_->config().is_nvfp4_prequant) {
+                config_.use_nvfp4_decode = 1;
+                IMP_LOG_INFO("Gemma 4 dense (GGUF): NVFP4 decode capped at mode 1 "
+                             "(mode-2 prequant conversion produces NaN decode — #516)");
+            }
             IMP_LOG_INFO("Gemma 4: NVFP4 decode cache enabled (use_nvfp4_decode=%d, prequant=%d)",
                          config_.use_nvfp4_decode,
                          (int)model_->config().is_nvfp4_prequant);

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -272,6 +272,22 @@ void Engine::init_resolve_quant_flags_() {
         IMP_LOG_INFO("GDN model: disabling FP8 prefill (recurrent state needs FP16 precision)");
         config_.use_fp8_prefill = 0;
     }
+    // DENSE Gemma (3 and 4) from GGUF: the mode-2 NVFP4 prequant conversion
+    // is broken for these shapes. Two manifestations, same lever:
+    //   - gemma-4-31B: NaN logits from decode step 2, greedy argmax lands on
+    //     <pad> (NaN beats the -inf ban mask) → 1-token answers (#516).
+    //   - gemma-3-12b: server-only IMA race in the step-decode path
+    //     truncating every chat response after the first token; vanishes
+    //     with the NVFP4 decode cache off or at mode 1 (#514).
+    // Mode 1 (additive, few tensors) and the FP16 cache are verified clean
+    // on both models; the MoE 26B-A4B (degen-suite green) keeps mode 2.
+    if (config_.use_nvfp4_decode == 2 && !model_->config().is_nvfp4_prequant &&
+        model_->config().n_experts == 0 &&
+        (model_->config().arch == ModelArch::GEMMA3 || model_->config().arch == ModelArch::GEMMA4)) {
+        config_.use_nvfp4_decode = 1;
+        IMP_LOG_INFO("Dense Gemma (GGUF): NVFP4 decode capped at mode 1 "
+                     "(mode-2 prequant conversion broken for dense Gemma — #514/#516)");
+    }
     if (model_->config().arch == ModelArch::GEMMA4) {
         // CUDA graphs: enabled for Gemma-4 decode. The MoE decode fast path is fully
         // device-side (dp4a GEMV, no D2H memcpy), so graph capture works.
@@ -300,21 +316,6 @@ void Engine::init_resolve_quant_flags_() {
             // on Q4_K_M + UD-Q4_K_M: tg256 184 → 204 tok/s (+11%), pp512
             // 1795 → 2347 tok/s (+30%). Coherent on chat prompts; the
             // pre-existing Q4_K_M code-gen drift (see roadmap) is orthogonal.
-            //
-            // DENSE Gemma-4 (31B, no experts) from GGUF: the mode-2 prequant
-            // conversion corrupts the decode weights — NaN logits from decode
-            // step 2, greedy argmax lands on <pad> (token 0) and generation
-            // stops after the first (prefill-sampled, correct) token. Mode 1
-            // and the FP16 cache are verified clean on the same model, so
-            // cap dense GGUF Gemma-4 at mode 1 until the mode-2 conversion
-            // bug is found (issue #516). The MoE 26B-A4B (degen-suite green)
-            // keeps mode 2.
-            if (config_.use_nvfp4_decode == 2 && model_->config().n_experts == 0 &&
-                !model_->config().is_nvfp4_prequant) {
-                config_.use_nvfp4_decode = 1;
-                IMP_LOG_INFO("Gemma 4 dense (GGUF): NVFP4 decode capped at mode 1 "
-                             "(mode-2 prequant conversion produces NaN decode — #516)");
-            }
             IMP_LOG_INFO("Gemma 4: NVFP4 decode cache enabled (use_nvfp4_decode=%d, prequant=%d)",
                          config_.use_nvfp4_decode,
                          (int)model_->config().is_nvfp4_prequant);

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -18,6 +18,7 @@
 #include "runtime/batch.h"
 #include "model/chat_template.h"
 #include "core/logging.h"
+#include <cstdlib>
 
 #include <algorithm>
 #include <string>
@@ -174,7 +175,10 @@ void Engine::fill_sampling_params(const Request& req, InferenceState& state) con
     if (req.think_budget > 0.0f && think_end_id_ >= 0 && !req.output_tokens.empty()) {
         int think_limit = static_cast<int>(req.max_tokens * req.think_budget);
         int n_reasoning = 0;
-        bool currently_thinking = false;
+        // Injected <think> prefixes live in the PROMPT — the output then has
+        // no opener, so the recount must start in-think or the budget never
+        // fires (model thinks until max_tokens, content stays empty).
+        bool currently_thinking = req.started_in_think;
         for (int32_t t : req.output_tokens) {
             if (t == think_start_id_)
                 currently_thinking = true;

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -79,8 +79,15 @@ bool Engine::init_features() {
             int32_t ts = ptok->find_token("<think>");
             int32_t te = ptok->find_token("</think>");
             int vocab = ptok->vocab_size();
+            // Accept CONTROL *and* USER_DEFINED token types: Qwen3 GGUFs tag
+            // <think>/</think> as USER_DEFINED (type 4), and requiring CONTROL
+            // left think_end_id_ at -1 — the think-budget enforcement
+            // (force </think> via logit manipulation) could then never fire,
+            // so models thought until max_tokens (empty content under
+            // json_mode/short budgets). Nemotron's "<think>" at ID 12 is type
+            // NORMAL text and stays excluded.
             bool is_special = (ts >= 0) &&
-                              (ptok->has_token_types() ? ptok->is_control_token(ts) : ts > vocab * 99 / 100);
+                              (ptok->has_token_types() ? ptok->is_special_token(ts) : ts > vocab * 99 / 100);
             if (is_special) {
                 think_start_id_ = ts;
                 think_end_id_ = te;

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -52,6 +52,10 @@ struct Request {
     float mirostat_mu = 0.0f;         // Running variable (persists across tokens, init = 2*tau)
     bool ignore_eos = false;          // Don't stop on EOS (benchmark mode)
     bool in_think_block = false;      // Currently inside <think>...</think> (suppress stop tokens)
+    // Generation began inside an injected <think> prefix (the opener lives in
+    // the PROMPT, not the output) — seeds the think-budget recount loop and
+    // the CUDA-graph decode config so the budget engages from token 0.
+    bool started_in_think = false;
     // Sliding-window decoded-text buffer for multi-token </think> detection.
     // Required for tokenizers that ship <think>/</think> as added_tokens with
     // special=False (Qwen3.6, Qwen3-Coder NVFP4 SafeTensors): the model emits

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -36,7 +36,9 @@ struct ServerArgs {
     std::string api_key;                        // --api-key: require Bearer token auth
     std::string reasoning_format = "deepseek";  // --reasoning-format: deepseek or none
     float think_budget =
-        1.0f;  // --think-budget: fraction of max_tokens for reasoning (1.0=unlimited, 0=disabled)
+        0.5f;  // --think-budget: fraction of max_tokens for reasoning (1.0=unlimited, 0=disabled).
+               // 0.5 matches docs/usage.md and guarantees answer headroom — at 1.0 a
+               // rambling reasoning model eats max_tokens and returns empty content.
     int min_kv_tokens = 0;  // --min-kv-tokens: minimum KV cache capacity (0=auto)
     // Server limits
     int max_concurrent = 64;        // --max-concurrent: max simultaneous requests (0=unlimited)

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1342,6 +1342,13 @@ static void nonstream_chat_response_(
         req->tpl_family = ctx.snap.tpl_family;
         req->logit_bias = ctx.params.logit_bias;
         req->think_budget = ctx.params.think_budget;
+        // Generation starts INSIDE the think block when the prompt carries the
+        // <think> prefix (template-injected or server-appended). Without this
+        // the engine's think-budget enforcement never sees an opener in the
+        // output, counts zero reasoning tokens, and lets the model think until
+        // max_tokens (content empty, finish=length).
+        req->started_in_think = ctx.snap.enable_thinking;
+        req->in_think_block = ctx.snap.enable_thinking;
         req->status = imp::RequestStatus::PENDING;
         return req;
     };
@@ -2550,6 +2557,13 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
         req->tpl_family = ctx.snap.tpl_family;
         req->logit_bias = ctx.params.logit_bias;
         req->think_budget = ctx.params.think_budget;
+        // Generation starts INSIDE the think block when the prompt carries the
+        // <think> prefix (template-injected or server-appended). Without this
+        // the engine's think-budget enforcement never sees an opener in the
+        // output, counts zero reasoning tokens, and lets the model think until
+        // max_tokens (content empty, finish=length).
+        req->started_in_think = ctx.snap.enable_thinking;
+        req->in_think_block = ctx.snap.enable_thinking;
         req->status = imp::RequestStatus::PENDING;
         return req;
     };

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -36,7 +36,8 @@ struct ChatRequestParams {
     int n_completions = 1, top_logprobs = 0;
     bool stream = false, json_mode = false, req_logprobs = false, include_usage = false;
     bool top_p_explicit = false, top_k_explicit = false, rep_pen_explicit = false;
-    bool enable_thinking_requested = false;  // true iff body contained "enable_thinking": true
+    bool enable_thinking_requested = false;  // value of "enable_thinking" if present
+    bool enable_thinking_set = false;        // true iff body contained "enable_thinking"
     // Stop sequences
     std::vector<std::string> stop_sequences;
     size_t max_stop_len = 0;
@@ -356,7 +357,7 @@ ImpConfig build_config(const ServerArgs& args, const imp::RuntimeConfig& runtime
     config.use_prefix_caching = runtime_cfg.server.prefix_cache ? 1 : 0;
 
     // Green Contexts: SM partitioning for concurrent prefill/decode (CUDA 13.1+)
-    config.enable_green_contexts = 1;
+    config.enable_green_contexts = runtime_cfg.server.green_contexts ? 1 : 0;
     if (!args.prefix_cache_path.empty()) {
         snprintf(config.prefix_cache_path, sizeof(config.prefix_cache_path), "%s",
                  args.prefix_cache_path.c_str());
@@ -869,6 +870,7 @@ static bool parse_chat_request_params(
 
     // Parse enable_thinking (only meaningful for think models; checked in orchestrator)
     ctx.params.enable_thinking_requested = body.value("enable_thinking", false);
+    ctx.params.enable_thinking_set = body.contains("enable_thinking") && body["enable_thinking"].is_boolean();
 
     return true;
 }
@@ -969,12 +971,21 @@ static bool snapshot_state_and_tokenize_(
         }
     }
 
-    // Thinking mode: only enable when explicitly requested via "enable_thinking": true.
-    // The model is free to generate <think> on its own if it wants to reason —
-    // forcing <think> into the prompt breaks structured output (JSON) because the
-    // model enters reasoning mode instead of generating the requested format.
+    // Thinking mode default: ON for think models in plain chat. These models
+    // are trained with the <think> prefix; serving them without it produces
+    // bare reasoning that cannot be separated and leaks into user-visible
+    // content ("Okay, let's see. The user is asking..." as the answer — the
+    // recurring think-leak bug class). Exceptions, where entering reasoning
+    // mode breaks the requested output format: structured output (json_mode)
+    // and tool calls keep the old default OFF. An explicit "enable_thinking"
+    // in the request always wins in both directions.
+    const bool thinking_default =
+        ctx.snap.is_think_model && !ctx.params.json_mode && !ctx.params.has_tools;
+    const bool want_thinking = ctx.params.enable_thinking_set
+                                   ? ctx.params.enable_thinking_requested
+                                   : thinking_default;
     ctx.snap.enable_thinking = ctx.snap.is_think_model && ctx.snap.think_start_id >= 0 &&
-                               ctx.params.enable_thinking_requested;
+                               want_thinking;
     ctx.snap.suppress_thinking = ctx.snap.is_think_model && !ctx.snap.enable_thinking && ctx.params.think_budget <= 0.0f;
 
     // If thinking IS enabled, remove the provisional <think> stop token.
@@ -1073,7 +1084,11 @@ static bool snapshot_state_and_tokenize_(
         }
         return tail_text.find(needle) != std::string::npos;
     };
-    if (ctx.snap.is_think_model && ctx.snap.think_start_id >= 0 && !ctx.snap.enable_thinking) {
+    // No special-token requirement here: Nemotron-style models think at TEXT
+    // level ("<think>" renders as plain text pieces, "</think>" closes it) —
+    // when their chat template injects the prefix, the output is reasoning
+    // from token 0 and must flow into reasoning_content, not content.
+    if (!ctx.snap.enable_thinking) {
         if (prompt_tail_contains("<think>", 8)) {
             ctx.snap.enable_thinking = true;
         }
@@ -1468,9 +1483,13 @@ static void nonstream_chat_response_(
         total_output_tokens += n_output_tokens;
         std::string content = !ctx.params.stop_sequences.empty() ? output_text : ctx.snap.tok->decode(output_ids);
 
-        // Extract reasoning content (DeepSeek format) or strip think blocks
+        // Extract reasoning content (DeepSeek format) or strip think blocks.
+        // enable_thinking also covers text-level thinkers (Nemotron) whose
+        // template injects "<think>" as plain text — is_think_model is false
+        // but the output is reasoning until the literal "</think>".
         std::string reasoning_content;
-        if (ctx.snap.is_think_model && state.default_args.reasoning_format == "deepseek") {
+        if ((ctx.snap.is_think_model || ctx.snap.enable_thinking) &&
+            state.default_args.reasoning_format == "deepseek") {
             // Generation that started inside an injected <think> prefix
             // (chat-template or server-appended; see prompt_tail_contains
             // above) carries no opener in its output. If it also never
@@ -1739,10 +1758,13 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
     // The full accumulated output (only used when has_tools, for fallback)
     std::string full_output;
 
-    // Reasoning content extraction (DeepSeek format)
+    // Reasoning content extraction (DeepSeek format). enable_thinking also
+    // covers text-level thinkers (Nemotron: template-injected "<think>" as
+    // plain text, no special token — is_think_model is false but the output
+    // starts mid-reasoning and exits via the literal "</think>").
     enum class ThinkPhase { SCAN, REASONING, CONTENT };
     bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
-                          snap_is_think_model);
+                          (snap_is_think_model || enable_thinking));
     ThinkPhase think_phase;
     if (enable_thinking) {
         think_phase = ThinkPhase::REASONING;  // <think> in prefill -> start reasoning
@@ -3733,9 +3755,11 @@ static bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& c
     std::vector<ParsedToolCall> stream_tool_calls;
     bool tool_calls_emitted = false;
 
-    // Reasoning extraction (DeepSeek <think>).
+    // Reasoning extraction (DeepSeek <think>). enable_thinking also covers
+    // text-level thinkers (Nemotron) — see the chat streaming path.
     enum class ThinkPhase { SCAN, REASONING, CONTENT };
-    bool use_reasoning = (state.default_args.reasoning_format == "deepseek" && snap_is_think_model);
+    bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
+                          (snap_is_think_model || enable_thinking));
     ThinkPhase think_phase;
     if (enable_thinking)
         think_phase = ThinkPhase::REASONING;


### PR DESCRIPTION
Working through the remaining degen-suite findings (goal: fix alle findings). Four root-caused fix clusters:

## 1. Nemotron NoPE attention (#515) — the big one

Nemotron-H attention is trained **without rotary embeddings** (Mamba layers carry position); the HF config's `rope_theta=10000`/`partial_rotary_factor=1.0` are class defaults. imp applied RoPE anyway → positional binding scrambled → the model read prompts as a **bag of words** ('17 + 25' → '25 + 17'/'15 + 7'; 'ALPHA BRAVO CHARLIE' → hallucinated a completely different prompt). Hypothesis verified by disabling rotation via config patch (`rope_theta=1e12`): prompt reading became exact.

Fix: `ModelConfig::rope_attn_disabled`, set per-arch in `apply_arch_defaults` (covers GGUF+SafeTensors); executor keeps QK-norm, skips rotation, bypasses fused-rope kernels.

**Nemotron-3-Nano: degen suite 8 FAIL → 27 checks / 0 FAIL.** Nemotron was positionally blind in imp since its integration.

## 2. Think-budget chain (3 stacked bugs)

(a) budget recount required a `<think>` opener in the **output** — injected prefixes live in the prompt → never fired (new `Request::started_in_think`); (b) engine think-id cache required CONTROL token type, Qwen3 GGUFs use USER_DEFINED → `think_end_id_=-1`, force-close impossible; (c) server default 1.0 (unlimited) vs documented 0.5 → rambling models returned empty content at finish=length.

## 3. JSON mode termination + gating (#517)

(a) EOS classified by rendered text → blocked in DONE → completed JSON could **never terminate** (always finish=length); new `CAT_EOS`, DONE-only (everywhere-EOS lets reluctant models stop at 0 tokens — tested). (b) preamble budget keyed off tokenizer capability → every request on a think-capable tokenizer got 8192 unmasked tokens, grammar never engaged → `'[].' + whitespace` spam; now requires request-level `thinking_open`. (c) JSON whitespace escape hatch capped at 64 chars.

**json_schema on GGUF Qwen3-8B: `{"age":30,"name":"Bob"}`, 12 tokens, finish=stop** (was: garbage to max_tokens).

## 4. gemma-4-31B dense GGUF (#516)

NOT an unimplemented arch: the **mode-2 NVFP4 prequant conversion** corrupts dense Gemma-4 decode weights → NaN logits from step 2 → argmax lands on `<pad>` (NaN beats the -inf ban mask) → stop after the first (correct!) token. Dense GGUF capped at mode 1 — verified full `BANANA42`; MoE 26B-A4B keeps mode 2. Conversion bug itself stays open in #516.

## Verification

| Modell | vorher | nachher |
|---|---|---|
| Nemotron-3-Nano | 8 FAIL, prompt-blind | **0 FAIL**, liest exakt |
| Qwen3-8B json_schema | Müll bis max_tokens | exaktes JSON, 12 toks |
| gemma-4-31B Q4_K_M | 1 Token + stop | vollständige Antworten |
| Qwen3-8B Suite | — | 2 Grenzfälle (Budget-Stottern, WS-Diff) — Tuning, kein Regress |

`verify-fast: OK`. Offen bleiben: #514 (gemma-3-12b step-path race), #516 mode-2 conversion, #511 fp8-FMHA ≥threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)