### PR TITLE
chore: native CUDA 13.3 Docker images (builder + runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,13 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      # Base image only — it provides the NVIDIA CUDA apt repo. There is no devel
-      # image for the pinned toolkit version on Docker Hub yet, so (like the
-      # Dockerfile) the first step installs cuda-toolkit-$CUDA_VERSION on top and
-      # that is what nvcc actually uses. The build does NOT compile with the base
-      # image's bundled toolkit.
-      image: nvidia/cuda:13.2.1-devel-ubuntu24.04
+      # Native CUDA devel image: nvcc $CUDA_VERSION is on PATH at /usr/local/cuda
+      # out of the box (matches the Dockerfile builder). No apt toolkit install.
+      image: nvidia/cuda:13.3.0-devel-ubuntu24.04
 
     env:
-      # Single source of truth for the CUDA toolchain. Bump this one line to move
-      # CI to a new toolkit; the apt package, paths, verify and cache keys below
-      # all derive from it.
+      # CUDA toolchain version — used by the verify step and cache keys. Kept in
+      # sync with the container image tag above (bump both to move CI).
       CUDA_VERSION: "13.3"
       CCACHE_DIR: /github/home/.ccache
       CCACHE_MAXSIZE: 8G
@@ -33,29 +29,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install CUDA toolkit + build deps
-        # No devel image for the pinned toolkit on Docker Hub yet, so — exactly
-        # like the Dockerfile — start from the base image (which only provides the
-        # NVIDIA CUDA apt repo) and install cuda-toolkit-$CUDA_VERSION on top,
-        # making it the default toolchain. The verify step below fails the build
-        # if nvcc is not the pinned version, so an older base toolkit can't leak in.
+      - name: Install build deps
+        # The native CUDA devel image already provides nvcc on PATH at
+        # /usr/local/cuda; only the non-CUDA build tooling needs installing.
         run: |
-          # POSIX sh (the step runs under sh, not bash): turn 13.3 into 13-3 via tr.
-          pkg="cuda-toolkit-$(echo "$CUDA_VERSION" | tr . -)"   # -> cuda-toolkit-13-3
-          cuda_home="/usr/local/cuda-${CUDA_VERSION}"
           apt-get update
-          apt-get install -y --no-install-recommends --allow-change-held-packages "$pkg"
-          ln -sfn "$cuda_home" /usr/local/cuda
-          apt-get install -y cmake g++ git python3 ccache
-          echo "$cuda_home/bin" >> "$GITHUB_PATH"
-          echo "CUDA_HOME=$cuda_home" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$cuda_home/lib64" >> "$GITHUB_ENV"
+          apt-get install -y --no-install-recommends cmake g++ git python3 ccache
 
       - name: Verify nvcc version
         run: |
           nvcc --version
           nvcc --version | grep -q "release ${CUDA_VERSION}" \
-            || { echo "::error::nvcc is not CUDA ${CUDA_VERSION} (the pinned toolchain)"; exit 1; }
+            || { echo "::error::nvcc is not CUDA ${CUDA_VERSION} (the image toolchain)"; exit 1; }
 
       # ccache caches per-TU compile output by content hash. On a header
       # change that invalidates many TUs (typical refactor), ccache hits

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,18 @@
 # =============================================================================
 # Stage 1: Build imp from source
 # =============================================================================
-# Base provides the NVIDIA CUDA apt repo; we install the CUDA 13.3 toolkit on
-# top (no 13.3 devel image on Docker Hub yet) and make it the default. The host
-# driver (UMD 13.3) supports it. sm_120 gains the 13.3 ptxas/PTX-ISA-9.3
-# codegen; no new tensor-core HW (still mma.sync, no tcgen05/wgmma).
-FROM nvidia/cuda:13.2.1-devel-ubuntu24.04 AS builder
+# Native CUDA 13.3 devel image: nvcc 13.3 (V13.3.33) is on PATH at
+# /usr/local/cuda (-> /usr/local/cuda-13.3) out of the box — no apt toolkit
+# install needed. The host driver (UMD 13.3) supports it. sm_120 gains the 13.3
+# ptxas/PTX-ISA-9.3 codegen; no new tensor-core HW (still mma.sync, no
+# tcgen05/wgmma).
+FROM nvidia/cuda:13.3.0-devel-ubuntu24.04 AS builder
 
 ARG CMAKE_BUILD_TYPE=Release
 
 RUN { sed -i 's|archive.ubuntu.com|de.archive.ubuntu.com|g; s|security.ubuntu.com|de.archive.ubuntu.com|g' \
           /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true; } \
     && apt-get update \
-    && apt-get install -y --no-install-recommends --allow-change-held-packages \
-        cuda-toolkit-13-3 \
-    && ln -sfn /usr/local/cuda-13.3 /usr/local/cuda \
     && apt-get install -y --no-install-recommends \
         g++ git ninja-build ca-certificates python3 wget \
     && wget -qO /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v4.3.1/cmake-4.3.1-linux-x86_64.sh \
@@ -24,10 +22,8 @@ RUN { sed -i 's|archive.ubuntu.com|de.archive.ubuntu.com|g; s|security.ubuntu.co
     && rm /tmp/cmake.sh \
     && rm -rf /var/lib/apt/lists/*
 
-# Pin CUDA 13.3 as the toolchain for nvcc/cmake (override the base image's 13.2 paths).
-ENV CUDA_HOME=/usr/local/cuda-13.3
-ENV PATH=/usr/local/cuda-13.3/bin:${PATH}
-ENV LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64:${LD_LIBRARY_PATH}
+# Hint CMake's find_package(CUDAToolkit) at the toolkit (nvcc is already on PATH).
+ENV CUDA_HOME=/usr/local/cuda
 
 # Pre-clone third-party deps into their own layer. Only invalidated when the
 # pinned tags below change — code-only edits keep this layer cached, saving
@@ -72,20 +68,15 @@ RUN cmake -B build -G Ninja \
 # =============================================================================
 # Stage 2: Minimal runtime image
 # =============================================================================
-FROM nvidia/cuda:13.2.1-runtime-ubuntu24.04
+# Native CUDA 13.3 runtime image already ships the matching cudart + cuBLAS
+# (and transitive deps like libnvjitlink) at /usr/local/cuda; only the small
+# entrypoint/healthcheck helpers need adding.
+FROM nvidia/cuda:13.3.0-runtime-ubuntu24.04
 
-# Install CUDA 13.3 runtime libs to match the 13.3-built binaries (cudart +
-# cuBLAS). apt resolves the transitive deps (libnvjitlink, etc.).
-RUN apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages \
-        cuda-cudart-13-3 \
-        libcublas-13-3 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         jq \
-    && ln -sfn /usr/local/cuda-13.3 /usr/local/cuda \
     && rm -rf /var/lib/apt/lists/*
-
-ENV PATH=/usr/local/cuda-13.3/bin:${PATH}
-ENV LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64:${LD_LIBRARY_PATH}
 
 # Copy built binaries
 COPY --from=builder /tmp/imp-server /usr/local/bin/imp-server


### PR DESCRIPTION
Die nativen 13.3-Images existieren jetzt auf Docker Hub — der apt-Nachinstallations-Workaround (cuda-toolkit-13-3 in den 13.2.1-Builder, ~1-2 GB Download bei jedem Cache-Miss der ersten Layer) entfällt komplett.

- `FROM nvidia/cuda:13.3.0-devel-ubuntu24.04` (Builder) / `13.3.0-runtime-ubuntu24.04` (Runtime)
- Entfernt: cuda-toolkit-13-3-apt-Install, /usr/local/cuda-Symlink-Hack, PATH/LD_LIBRARY_PATH-13.3-Exports, cuda-cudart/libcublas-Nachinstallation im Runtime-Image
- CI: Container-Image auf 13.3.0-devel, Toolkit-Install-Step → nur noch Build-Deps; `CUDA_VERSION`-Env + Cache-Keys unverändert konsistent; **Job-Name bleibt exakt 'Build'** (Ruleset-Check)
- Kein `--mount=type=cache` (Projektregel)
- Verifiziert: voller Build (293 TUs, sm_120a, nvcc V13.3.33) sauber durch; imp-cli läuft im Endimage

🤖 Generated with [Claude Code](https://claude.com/claude-code)