### PR TITLE
fix(constrain): whole-token JSON validation, empty-allow EOS guards, free-form schema routing — closes #517

### DIFF
--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -17,6 +17,10 @@ JsonConstrainer::~JsonConstrainer() {
         IMP_CUDA_CHECK_LOG(cudaFree(d_token_categories_));
         d_token_categories_ = nullptr;
     }
+    if (d_token_allow_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_token_allow_));
+        d_token_allow_ = nullptr;
+    }
     if (d_allowed_mask_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_allowed_mask_));
         d_allowed_mask_ = nullptr;
@@ -41,7 +45,8 @@ bool JsonConstrainer::init(const Tokenizer& tok) {
     // every json_mode request ran to max_tokens and finished with "length".
     // CAT_EOS is allowed ONLY in DONE — allowing it everywhere lets a
     // json-reluctant model emit EOS as its very first token (0 completions).
-    for (int32_t eid : tok.eos_ids()) {
+    eos_ids_ = tok.eos_ids();
+    for (int32_t eid : eos_ids_) {
         if (eid >= 0 && eid < vocab_size_)
             token_categories_[eid] = CAT_EOS;  // reachable only where the mask says so
     }
@@ -84,12 +89,15 @@ void JsonConstrainer::reset() {
 uint16_t JsonConstrainer::compute_allowed_mask() const {
     // Whitespace is legal between any JSON tokens, but cap the run length —
     // see advance_char. (EOS has its own CAT_EOS bit, allowed in DONE only.)
-    constexpr int kMaxWsRun = 64;
+    constexpr int kMaxWsRun = 32;
     uint16_t mask = (ws_run_ < kMaxWsRun) ? CAT_WHITESPACE : 0;
 
     switch (current_state_) {
         case JsonState::START:
-            // Must start with { or [
+            // Must start with { or [. (Forcing object-only at the root was
+            // tried and reverted: a json-reluctant model then fights the
+            // mask with whitespace floods instead of emitting a minimal
+            // valid document.)
             mask |= CAT_OPEN_BRACE | CAT_OPEN_BRACKET;
             break;
 
@@ -164,16 +172,22 @@ uint16_t JsonConstrainer::compute_allowed_mask() const {
     return mask;
 }
 
-void JsonConstrainer::advance_char(char c) {
+bool JsonConstrainer::advance_char(char c) {
     // Skip whitespace in non-string states — but count the run. JSON allows
     // unlimited inter-token whitespace, and a model that doesn't want to emit
     // JSON exploits that as an escape hatch (greedy decode emits newlines
     // until max_tokens). compute_allowed_mask() drops CAT_WHITESPACE once the
     // run exceeds the cap, forcing a structural token (or EOS) instead.
+    //
+    // Returns true when the char is a legal continuation in the current FSM
+    // state. update() ignores the result (tolerant, as before); the
+    // whole-token simulation in apply_mask() uses it to reject tokens whose
+    // FIRST char passes the category mask but whose tail violates the
+    // grammar (e.g. the single token "[]." — '.' after a completed value).
     if (current_state_ != JsonState::IN_STRING && current_state_ != JsonState::IN_STRING_ESCAPE &&
         (c == ' ' || c == '\t' || c == '\n' || c == '\r')) {
         ws_run_++;
-        return;
+        return true;
     }
     ws_run_ = 0;
 
@@ -185,6 +199,8 @@ void JsonConstrainer::advance_char(char c) {
             } else if (c == '[') {
                 state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::ARRAY_START;
+            } else {
+                return false;
             }
             break;
 
@@ -196,12 +212,16 @@ void JsonConstrainer::advance_char(char c) {
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
                 current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
+            } else {
+                return false;
             }
             break;
 
         case JsonState::AFTER_KEY:
             if (c == ':') {
                 current_state_ = JsonState::AFTER_COLON;
+            } else {
+                return false;
             }
             break;
 
@@ -230,6 +250,8 @@ void JsonConstrainer::advance_char(char c) {
                 current_state_ = JsonState::IN_LITERAL;
             } else if ((c >= '0' && c <= '9') || c == '-') {
                 current_state_ = JsonState::IN_NUMBER;
+            } else {
+                return false;
             }
             break;
 
@@ -241,6 +263,8 @@ void JsonConstrainer::advance_char(char c) {
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
                 current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
+            } else {
+                return false;
             }
             break;
 
@@ -272,6 +296,8 @@ void JsonConstrainer::advance_char(char c) {
                 current_state_ = JsonState::IN_LITERAL;
             } else if ((c >= '0' && c <= '9') || c == '-') {
                 current_state_ = JsonState::IN_NUMBER;
+            } else {
+                return false;
             }
             break;
 
@@ -282,6 +308,8 @@ void JsonConstrainer::advance_char(char c) {
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
                 current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
+            } else {
+                return false;
             }
             break;
 
@@ -312,12 +340,16 @@ void JsonConstrainer::advance_char(char c) {
                 current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
-                advance_char(c);  // re-process
-                return;
+                return advance_char(c);  // re-process in parent context
             }
             break;
 
         case JsonState::IN_LITERAL:
+            // Strict: the char must be the literal's next expected char
+            // ("tru"+'x' was silently accepted before).
+            if (partial_literal_.size() >= target_literal_.size() ||
+                c != target_literal_[partial_literal_.size()])
+                return false;
             partial_literal_ += c;
             if (partial_literal_.size() >= target_literal_.size()) {
                 // Literal complete — transition to parent
@@ -328,8 +360,37 @@ void JsonConstrainer::advance_char(char c) {
             break;
 
         case JsonState::DONE:
-            break;
+            // Any non-whitespace after a complete document is invalid.
+            return false;
     }
+    return true;
+}
+
+bool JsonConstrainer::sim_token_valid(const std::string& text) {
+    // Snapshot → strict-advance over the whole token text → restore.
+    // advance_char is the single grammar source of truth (no parallel FSM).
+    const JsonState st = current_state_;
+    const size_t depth = state_stack_.size();
+    const std::string plit = partial_literal_;
+    const std::string tlit = target_literal_;
+    const int ws = ws_run_;
+    std::vector<JsonState> stack_copy = state_stack_;
+
+    bool ok = true;
+    for (char c : text) {
+        if (!advance_char(c)) {
+            ok = false;
+            break;
+        }
+    }
+
+    current_state_ = st;
+    state_stack_ = std::move(stack_copy);
+    (void)depth;
+    partial_literal_ = plit;
+    target_literal_ = tlit;
+    ws_run_ = ws;
+    return ok;
 }
 
 void JsonConstrainer::update(int32_t token) {
@@ -352,15 +413,65 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
 
     uint16_t mask = compute_allowed_mask();
 
-    // Upload mask to device
-    IMP_CUDA_CHECK_LOG(
-        cudaMemcpyAsync(d_allowed_mask_, &mask, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
+    // Whole-token validation: the category bitmask only inspects a token's
+    // FIRST character class, so multi-char tokens could smuggle grammar
+    // violations past it (the single token "[]." closes the document and
+    // appends an illegal '.'). Simulate every category-passing candidate
+    // through the FSM (advance_char strict mode) and build a per-token
+    // allow list. Hot-path shortcut: inside strings, tokens without '"'
+    // or '\\' can never change FSM state — skip the simulation.
+    if (token_allow_.size() != static_cast<size_t>(vocab_size))
+        token_allow_.assign(vocab_size, 0);
+    const bool in_string =
+        current_state_ == JsonState::IN_STRING || current_state_ == JsonState::IN_STRING_ESCAPE;
+    size_t n_allowed = 0;
+    for (int i = 0; i < vocab_size; i++) {
+        uint8_t allow = 0;
+        if ((token_categories_[i] & mask) != 0) {
+            const std::string& text = token_texts_[i];
+            if (token_categories_[i] == CAT_EOS) {
+                allow = 1;  // EOS already gated by the mask (DONE state only)
+            } else if (in_string && text.find('"') == std::string::npos &&
+                       text.find('\\') == std::string::npos) {
+                allow = 1;
+            } else {
+                allow = sim_token_valid(text) ? 1 : 0;
+            }
+        }
+        token_allow_[i] = allow;
+        n_allowed += allow;
+    }
 
-    // Launch masking kernel
+    // Empty-allow guard: if NOTHING passes (over-tight schema/state combo),
+    // every logit would be -FLT_MAX and greedy argmax degenerates to token
+    // id 0 — the "!!!!!" spam. Force a clean finish instead by allowing EOS.
+    if (n_allowed == 0) {
+        for (int32_t eid : eos_ids_) {
+            if (eid >= 0 && eid < vocab_size)
+                token_allow_[eid] = 1;
+        }
+        IMP_LOG_WARN("JsonConstrainer: no token satisfies the grammar in state %d — allowing EOS",
+                     static_cast<int>(current_state_));
+    }
+
+    if (!d_token_allow_) {
+        if (cudaMalloc(&d_token_allow_, vocab_size) != cudaSuccess) {
+            d_token_allow_ = nullptr;
+            return;
+        }
+    }
+    IMP_CUDA_CHECK_LOG(
+        cudaMemcpyAsync(d_token_allow_, token_allow_.data(), vocab_size, cudaMemcpyHostToDevice, stream));
+
+    uint16_t any_mask = 0xFFFF;  // per-token allow already encodes the category mask
+    IMP_CUDA_CHECK_LOG(
+        cudaMemcpyAsync(d_allowed_mask_, &any_mask, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
+
     int threads = 256;
     int blocks = (vocab_size + threads - 1) / threads;
-    constrain_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_categories_, d_allowed_mask_,
-                                                          vocab_size);
+    constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_categories_,
+                                                                d_token_allow_, d_allowed_mask_, vocab_size,
+                                                                /*use_token_allow=*/true);
 }
 
 // ============================================================================

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -126,6 +126,10 @@ private:
 
     // Device buffer for allowed mask (1 uint16_t, stable address)
     uint16_t* d_allowed_mask_ = nullptr;
+    // Per-token whole-token-validated allow list (host + device)
+    std::vector<uint8_t> token_allow_;
+    uint8_t* d_token_allow_ = nullptr;
+    std::vector<int32_t> eos_ids_;
 
     // Preamble pass-through (reasoning models emit <think>...</think> first)
     PreambleGate preamble_;
@@ -133,8 +137,12 @@ private:
     // Compute allowed category mask from current FSM state
     uint16_t compute_allowed_mask() const;
 
+    // Whole-token strict validation: snapshot the FSM, advance over the
+    // token text, restore. True iff every char is a legal continuation.
+    bool sim_token_valid(const std::string& text);
+
     // Advance FSM by one character
-    void advance_char(char c);
+    bool advance_char(char c);
 };
 
 // ---------------------------------------------------------------------------

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -360,6 +360,28 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
     uint16_t cat_mask = compute_category_mask();
     compute_token_allow_mask();
 
+    // Empty-allow guard: an over-tight schema/state combination (e.g.
+    // {"type":"object"} without properties — the key phase knows no legal
+    // key) can reject every token. All logits then go to -FLT_MAX and greedy
+    // argmax degenerates to token id 0 ("!!!!" spam on byte-level BPE
+    // vocabs). Force a clean EOS finish instead.
+    if (need_token_allow_) {
+        size_t n_allowed = 0;
+        for (int i = 0; i < vocab_size_ && n_allowed == 0; i++) {
+            if (token_allow_[i] && (token_categories_[i] & cat_mask) != 0)
+                n_allowed++;
+        }
+        if (n_allowed == 0) {
+            std::fill(token_allow_.begin(), token_allow_.end(), (uint8_t)0);
+            for (int32_t e : eos_tokens_)
+                if (e >= 0 && e < vocab_size_)
+                    token_allow_[e] = 1;
+            cat_mask = 0xFFFF;
+            IMP_LOG_WARN("SchemaConstrainer: no token satisfies the schema in phase %d — allowing EOS",
+                         static_cast<int>(top().phase));
+        }
+    }
+
     IMP_LOG_DEBUG("SchemaConstrainer::apply_mask phase=%d cat_mask=0x%04x need_allow=%d stack=%zu",
                   static_cast<int>(top().phase), cat_mask, need_token_allow_, stack_.size());
 

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -91,15 +91,17 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
     // grammar never engaged and the output was unconstrained garbage.
     //   - has_tools: 64-token slack so short verbal preambles ("Sure! ")
     //     don't squeeze out the tool-tag opener.
-    //   - no tools: 8-token slack for markdown fences, matches today's
-    //     non-reasoning default.
+    //   - no tools: 0 — the old 8-token "markdown fence" slack let the model
+    //     open ```json fences that then leaked into content around otherwise
+    //     perfect JSON. With the mask active from token 1 the model starts
+    //     at '{' directly (whitespace is still legal in the START state).
     int preamble_budget;
     if (thinking_open && think_close >= 0) {
         preamble_budget = 8192;
     } else if (has_tools) {
         preamble_budget = 64;
     } else {
-        preamble_budget = 8;
+        preamble_budget = 0;
     }
 
     ToolDialect dialect;
@@ -125,7 +127,23 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
         }
     };
 
-    if (!json_schema.empty()) {
+    // Free-form object schema ({"type":"object"} without properties/enum):
+    // the schema FSM knows no legal key, rejects every token in the key
+    // phase, and the empty-allow guard force-finishes right after "{".
+    // Semantically this IS json_object — route to the any-JSON constrainer,
+    // which is whole-token validated.
+    bool use_schema = !json_schema.empty();
+    if (use_schema) {
+        auto probe = parse_json_schema(json_schema);
+        if (probe && probe->type == SchemaType::OBJECT && probe->properties.empty() &&
+            probe->enum_values.empty()) {
+            IMP_LOG_INFO("ConstraintManager: free-form object schema → any-JSON constrainer");
+            use_schema = false;
+            json_mode = true;
+        }
+    }
+
+    if (use_schema) {
         if (schema_constrainer_ && schema_constrainer_->is_initialized() &&
             json_schema == cached_schema_string_) {
             configure_gate(schema_constrainer_.get());

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -726,7 +726,20 @@ static bool parse_chat_request_params(
                 body["response_format"]["json_schema"].is_object()) {
                 auto& js = body["response_format"]["json_schema"];
                 if (js.contains("schema") && js["schema"].is_object()) {
-                    ctx.params.json_schema_str = js["schema"].dump();
+                    const auto& sch = js["schema"];
+                    // Free-form object schema ({"type":"object"} without
+                    // properties/enum) carries no structure the schema
+                    // constrainer could enforce — its key phase would reject
+                    // every token. Semantically this is json_object: leave
+                    // json_schema_str empty so the whole request (scheduler
+                    // included) takes the any-JSON constrainer path.
+                    const bool free_form = sch.value("type", "") == "object" &&
+                                           (!sch.contains("properties") ||
+                                            sch["properties"].empty()) &&
+                                           !sch.contains("enum");
+                    if (!free_form) {
+                        ctx.params.json_schema_str = sch.dump();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Schließt #517 vollständig. Der `'!!!!'`-Spam und der `'[].'`-Schmuggel sind tot.

## Fixes

1. **Whole-Token-Validierung** im JsonConstrainer: Kategorie-Maske prüfte nur das erste Zeichen — Multi-Char-Tokens schmuggelten Grammatik-Verstöße (`'[].'`). `advance_char` liefert jetzt strikte Validität (auch `'tru'+'x'` wird abgelehnt), apply_mask simuliert jeden Kategorie-Kandidaten durch die FSM (Snapshot/Restore — eine Grammatik-Wahrheitsquelle, #499-Muster) mit In-String-Fastpath.
2. **Empty-Allow→EOS-Guards** (Json + Schema): über-enge Zustände maskierten ALLES → alle Logits -FLT_MAX → Greedy-Argmax degeneriert zu Token-ID 0 (`'!'` auf Byte-BPE-Vocabs). Beide Constrainer erkennen die leere Allow-Menge und erzwingen sauberes EOS.
3. **Free-Form-Schemas** (`{"type":"object"}` ohne properties): Server klassifiziert sie beim Parsen als json_object (scheduler-konsistent — vorher lief der Decode komplett unmaskiert, daher Markdown-Fences um perfektes JSON).
4. **Plain-JSON-Preamble 8→0**: die Fence-Slack leakte ``\`\`\`json`-Fences in den Content. (Object-only-Root probiert und revertiert: unwillige Modelle bekämpfen die Maske mit Whitespace-Fluten; `{|[` + 32-Char-WS-Cap terminiert sauber.)

## Verifikation (Qwen3-8B-Q8, greedy)

| Fall | vorher | nachher |
|---|---|---|
| json_object | `'[].'`+WS-Spam bis length | **valid JSON, finish=stop** |
| freies Schema | `'{\n\n\n"!!!!…'` bis length | **valid JSON, finish=stop** |
| konkretes Schema | ✓ | ✓ `{"age":30,"name":"Bob"}` (keine Regression) |
| Constrainer-GTests | — | 19/19 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)