### PR TITLE
perf(attention): FP16-QK FA2 for short prefill — replace materialized cuBLAS path (+25-35% pp512)

### DIFF
--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -404,8 +404,7 @@ static size_t compute_smem_sm120(int Bq, int Bkv, int head_dim) {
 // =============================================================================
 
 bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
-                        bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                        int q_offset) {
+                        bool causal, int sliding_window, float softcap, cudaStream_t stream, int q_offset) {
     if (Q.qtype != QType::F16)
         return false;
 
@@ -472,25 +471,22 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
         batch_size, seq_q, seq_kv, n_heads, n_kv_heads, head_dim, Bq, Bkv, smem, causal, sliding_window,
         softcap);
 
-#define LAUNCH_FMHA_SM120(BQ, HD)                                                                         \
-    do {                                                                                                  \
-        cudaError_t attr_err = cudaFuncSetAttribute(fmha_sm120_kernel<BQ, HD>,                            \
-                                                    cudaFuncAttributeMaxDynamicSharedMemorySize,          \
-                                                    static_cast<int>(smem));                              \
-        if (attr_err != cudaSuccess) {                                                                    \
-            IMP_LOG_WARN("FMHA sm120: cudaFuncSetAttribute failed for Bq=%d HD=%d smem=%zu: %s", BQ, HD,  \
-                         smem, cudaGetErrorString(attr_err));                                             \
-            return false;                                                                                 \
-        }                                                                                                 \
-        cudaFuncSetAttribute(fmha_sm120_kernel<BQ, HD>, cudaFuncAttributePreferredSharedMemoryCarveout,   \
-                             cudaSharedmemCarveoutMaxShared);                                             \
-        fmha_sm120_kernel<BQ, HD>                                                                         \
-            <<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),                        \
-                                            reinterpret_cast<const half*>(K.data),                        \
-                                            reinterpret_cast<const half*>(V.data),                        \
-                                            reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv,   \
-                                            n_heads, n_kv_heads, scale, causal, sliding_window, softcap,  \
-                                            q_offset);                                                    \
+#define LAUNCH_FMHA_SM120(BQ, HD)                                                                        \
+    do {                                                                                                 \
+        cudaError_t attr_err = cudaFuncSetAttribute(fmha_sm120_kernel<BQ, HD>,                           \
+                                                    cudaFuncAttributeMaxDynamicSharedMemorySize,         \
+                                                    static_cast<int>(smem));                             \
+        if (attr_err != cudaSuccess) {                                                                   \
+            IMP_LOG_WARN("FMHA sm120: cudaFuncSetAttribute failed for Bq=%d HD=%d smem=%zu: %s", BQ, HD, \
+                         smem, cudaGetErrorString(attr_err));                                            \
+            return false;                                                                                \
+        }                                                                                                \
+        cudaFuncSetAttribute(fmha_sm120_kernel<BQ, HD>, cudaFuncAttributePreferredSharedMemoryCarveout,  \
+                             cudaSharedmemCarveoutMaxShared);                                            \
+        fmha_sm120_kernel<BQ, HD><<<grid, block, smem, stream>>>(                                        \
+            reinterpret_cast<const half*>(Q.data), reinterpret_cast<const half*>(K.data),                \
+            reinterpret_cast<const half*>(V.data), reinterpret_cast<half*>(O.data), batch_size, seq_q,   \
+            seq_kv, n_heads, n_kv_heads, scale, causal, sliding_window, softcap, q_offset);              \
     } while (0)
 
     if (Bq == 128) {
@@ -992,13 +988,10 @@ bool fmha_sm120_fp8_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
             return false;                                                                                   \
         cudaFuncSetAttribute(fmha_sm120_fp8_kernel<BQ, HD>, cudaFuncAttributePreferredSharedMemoryCarveout, \
                              cudaSharedmemCarveoutMaxShared);                                               \
-        fmha_sm120_fp8_kernel<BQ, HD>                                                                       \
-            <<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),                          \
-                                            reinterpret_cast<const half*>(K.data),                          \
-                                            reinterpret_cast<const half*>(V.data),                          \
-                                            reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv,     \
-                                            n_heads, n_kv_heads, scale, causal, sliding_window, softcap,    \
-                                            q_offset);                                                      \
+        fmha_sm120_fp8_kernel<BQ, HD><<<grid, block, smem, stream>>>(                                       \
+            reinterpret_cast<const half*>(Q.data), reinterpret_cast<const half*>(K.data),                   \
+            reinterpret_cast<const half*>(V.data), reinterpret_cast<half*>(O.data), batch_size, seq_q,      \
+            seq_kv, n_heads, n_kv_heads, scale, causal, sliding_window, softcap, q_offset);                 \
     } while (0)
 
     if (Bq == 128) {
@@ -1114,20 +1107,20 @@ __device__ __forceinline__ float quad_sum(float v) {
 //   K/V (halfs):   +8  → stride 136 (16 B, preserves cp.async 16-B alignment) →
 //                  cuts the wide cvt/V smem reads from ~8-way down to ~2-way.
 // The pad columns are never written or read; they only shift row addresses.
-constexpr int FA2_Q_PAD = 16;   // extra bytes per Q_fp8 row
-constexpr int FA2_KV_PAD = 8;   // extra halfs per K/V row (16 B, cp.async-aligned)
+constexpr int FA2_Q_PAD = 16;  // extra bytes per Q_fp8 row
+constexpr int FA2_KV_PAD = 8;  // extra halfs per K/V row (16 B, cp.async-aligned)
 
 // Out-of-range rows: K left stale (masked out in the score step), V zero-filled
 // (P=0 for those cols, but 0*NaN=NaN would poison O, so V must be finite).
 template <int HD>
 __device__ __forceinline__ void prefetch_kv_tile(half* K_dst, half* V_dst, const half* K_ptr,
-                                                  const half* V_ptr, int kv_start, int seq_kv,
-                                                  int64_t kv_row_stride, int tid, int nthreads) {
+                                                 const half* V_ptr, int kv_start, int seq_kv,
+                                                 int64_t kv_row_stride, int tid, int nthreads) {
     constexpr int Bkv = 64;
-    constexpr int VEC = 8;                       // 8 halfs = 16 B per cp.async
-    constexpr int vecs_per_row = HD / VEC;       // 16
+    constexpr int VEC = 8;                  // 8 halfs = 16 B per cp.async
+    constexpr int vecs_per_row = HD / VEC;  // 16
     constexpr int total_vecs = Bkv * vecs_per_row;
-    constexpr int KVS = HD + FA2_KV_PAD;         // padded smem row stride (halfs)
+    constexpr int KVS = HD + FA2_KV_PAD;  // padded smem row stride (halfs)
     for (int vi = tid; vi < total_vecs; vi += nthreads) {
         int r = vi / vecs_per_row;
         int c = (vi % vecs_per_row) * VEC;
@@ -1142,7 +1135,15 @@ __device__ __forceinline__ void prefetch_kv_tile(half* K_dst, half* V_dst, const
     }
 }
 
-template <int Bq, int HD>
+// FP16QK=false: Q staged in smem as e4m3, K converted f16->fp8 inline, QK via
+// mma.m16n8k32.e4m3 (2x score throughput; quality validated ONLY at long
+// context — e4m3 score noise compounds across layers at short seq, #511/#512).
+// FP16QK=true: Q staged as f16, K read from f16 smem directly, QK via
+// mma.m16n8k16.f16 — half the score throughput, full fp16 accuracy. This is
+// the short-sequence variant that replaces the materialized cuBLAS+softmax
+// path below fmha_prefill_threshold without the e4m3 quality risk.
+// Softmax, masking and PV are shared — one grammar of truth for the math.
+template <int Bq, int HD, bool FP16QK = false>
 __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __restrict__ K,
                                       const half* __restrict__ V, half* __restrict__ O, int batch_size,
                                       int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale,
@@ -1165,13 +1166,13 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
     const int head_idx = batch_head % n_heads;
     const int kv_head = head_idx / (n_heads / n_kv_heads);
 
-    const int lane = threadIdx.x;       // 0..31
-    const int warp_id = threadIdx.y;    // 0..7  → this warp's row tile
+    const int lane = threadIdx.x;     // 0..31
+    const int warp_id = threadIdx.y;  // 0..7  → this warp's row tile
     const int tid = lane + warp_id * 32;
     const int q_start = tile_q * Bq;
     const int row_lo = warp_id * 16 + lane / 4;  // local row within Bq for d0/d1
-    const int rl = lane / 4;                      // row in 16-tile (lo)
-    const int cl = (lane % 4) * 2;                // col base in 8/16-tile
+    const int rl = lane / 4;                     // row in 16-tile (lo)
+    const int cl = (lane % 4) * 2;               // col base in 8/16-tile
 
     const int64_t q_row_stride = (int64_t)n_heads * head_dim;
     const int64_t kv_row_stride = (int64_t)n_kv_heads * head_dim;
@@ -1183,16 +1184,33 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
                   (int64_t)head_idx * head_dim;
 
     // Padded smem row strides (see FA2_Q_PAD / FA2_KV_PAD — bank-conflict relief).
-    constexpr int QSTRIDE = head_dim + FA2_Q_PAD;   // Q_fp8 row stride in BYTES
-    constexpr int KVSTRIDE = head_dim + FA2_KV_PAD;  // K/V row stride in HALFS
+    // FP16QK stores Q as halfs: stride unit is HALFS and the row size doubles
+    // in bytes (2*(HD+pad)); fp8 mode keeps the byte-stride layout.
+    constexpr int QSTRIDE = head_dim + (FP16QK ? FA2_KV_PAD : FA2_Q_PAD);  // halfs (fp16) / bytes (fp8)
+    constexpr int KVSTRIDE = head_dim + FA2_KV_PAD;                        // K/V row stride in HALFS
+    constexpr size_t Q_SMEM_BYTES = (size_t)Bq * QSTRIDE * (FP16QK ? sizeof(half) : sizeof(uint8_t));
 
     extern __shared__ char smem[];
-    uint8_t* Q_fp8 = reinterpret_cast<uint8_t*>(smem);
-    half* K_buf = reinterpret_cast<half*>(Q_fp8 + Bq * QSTRIDE);  // [2][Bkv*KVSTRIDE] f16
-    half* V_buf = K_buf + 2 * Bkv * KVSTRIDE;                     // [2][Bkv*KVSTRIDE] f16
+    uint8_t* Q_fp8 = reinterpret_cast<uint8_t*>(smem);           // fp8 mode view
+    half* Q_h16 = reinterpret_cast<half*>(smem);                 // fp16 mode view
+    half* K_buf = reinterpret_cast<half*>(smem + Q_SMEM_BYTES);  // [2][Bkv*KVSTRIDE] f16
+    half* V_buf = K_buf + 2 * Bkv * KVSTRIDE;                    // [2][Bkv*KVSTRIDE] f16
 
-    // ---- load Q → fp8 once (4 halves → 4 e4m3 per thread) ----
-    {
+    // ---- load Q once: fp8 mode converts 4 halves → 4 e4m3; fp16 mode copies ----
+    if constexpr (FP16QK) {
+        const int total_vec4 = (Bq * head_dim) / 4;
+        for (int vi = tid; vi < total_vec4; vi += NTHREADS) {
+            int i = vi * 4;
+            int r = i / head_dim;
+            int d = i % head_dim;  // multiple of 4 → uint2-aligned into the padded row
+            uint2* dst = reinterpret_cast<uint2*>(Q_h16 + r * QSTRIDE + d);
+            if (q_start + r >= seq_q) {
+                *dst = make_uint2(0, 0);
+            } else {
+                *dst = *reinterpret_cast<const uint2*>(&Q_ptr[(int64_t)r * q_row_stride + d]);
+            }
+        }
+    } else {
         const int total_vec4 = (Bq * head_dim) / 4;
         for (int vi = tid; vi < total_vec4; vi += NTHREADS) {
             int i = vi * 4;
@@ -1231,8 +1249,8 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
         // prefetch tile j+1 into the alternate slot, overlapping this tile's compute
         if (j + 1 < num_kv_tiles) {
             const int nslot = slot ^ 1;
-            prefetch_kv_tile<head_dim>(K_buf + nslot * Bkv * KVSTRIDE, V_buf + nslot * Bkv * KVSTRIDE,
-                                       K_ptr, V_ptr, (j + 1) * Bkv, seq_kv, kv_row_stride, tid, NTHREADS);
+            prefetch_kv_tile<head_dim>(K_buf + nslot * Bkv * KVSTRIDE, V_buf + nslot * Bkv * KVSTRIDE, K_ptr,
+                                       V_ptr, (j + 1) * Bkv, seq_kv, kv_row_stride, tid, NTHREADS);
             cp_async_commit();
             cp_async_wait_group<1>();  // this tile (slot) landed; tile j+1 still in flight
         } else {
@@ -1243,29 +1261,57 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
         const half* K_cur = K_buf + slot * Bkv * KVSTRIDE;
         const half* V_cur = V_buf + slot * Bkv * KVSTRIDE;
 
-        // ---- QK: S[n] = Q(warp rows) @ K[n-tile]^T, fp8 m16n8k32 (K cvt f16→fp8 inline) ----
+        // ---- QK: S[n] = Q(warp rows) @ K[n-tile]^T ----
+        // fp8 mode: m16n8k32.e4m3 (K cvt f16→fp8 inline). fp16 mode: m16n8k16.f16.
         float S[N_S][4];
 #pragma unroll
         for (int n = 0; n < N_S; n++) {
             float d0 = 0.f, d1 = 0.f, d2 = 0.f, d3 = 0.f;
+            if constexpr (FP16QK) {
 #pragma unroll
-            for (int k = 0; k < KC; k++) {
-                const uint8_t* qb = Q_fp8 + warp_id * 16 * QSTRIDE + k * 32;
-                uint32_t a0 = *reinterpret_cast<const uint32_t*>(qb + rl * QSTRIDE + cl * 2);
-                uint32_t a1 = *reinterpret_cast<const uint32_t*>(qb + rl * QSTRIDE + cl * 2 + 16);
-                uint32_t a2 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl * 2);
-                uint32_t a3 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl * 2 + 16);
-                const half* kb = K_cur + n * 8 * KVSTRIDE + k * 32;
-                uint32_t b0 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2);
-                uint32_t b1 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2 + 16);
+                for (int k = 0; k < HD / 16; k++) {
+                    // m16n8k16 A (row-major f16): a0=(rl,cl) a1=(rl+8,cl)
+                    // a2=(rl,cl+8) a3=(rl+8,cl+8) — same reg order the
+                    // validated PV mma below uses (ra1 = S[..][2,3] = row+8).
+                    const half* qb = Q_h16 + warp_id * 16 * QSTRIDE + k * 16;
+                    uint32_t a0 = *reinterpret_cast<const uint32_t*>(qb + rl * QSTRIDE + cl);
+                    uint32_t a1 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl);
+                    uint32_t a2 = *reinterpret_cast<const uint32_t*>(qb + rl * QSTRIDE + cl + 8);
+                    uint32_t a3 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl + 8);
+                    // B (col-major f16): thread holds K-row (= score col) rl,
+                    // k-elems {cl,cl+1} (b0) and {cl+8,cl+9} (b1).
+                    const half* kb = K_cur + (n * 8 + rl) * KVSTRIDE + k * 16;
+                    uint32_t b0 = *reinterpret_cast<const uint32_t*>(kb + cl);
+                    uint32_t b1 = *reinterpret_cast<const uint32_t*>(kb + cl + 8);
 #if __CUDA_ARCH__ >= 1200
-                asm volatile(
-                    "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
-                    "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
-                    : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
-                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0), "f"(d1), "f"(d2),
-                      "f"(d3));
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+                        "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
+                        : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0), "f"(d1), "f"(d2),
+                          "f"(d3));
 #endif
+                }
+            } else {
+#pragma unroll
+                for (int k = 0; k < KC; k++) {
+                    const uint8_t* qb = Q_fp8 + warp_id * 16 * QSTRIDE + k * 32;
+                    uint32_t a0 = *reinterpret_cast<const uint32_t*>(qb + rl * QSTRIDE + cl * 2);
+                    uint32_t a1 = *reinterpret_cast<const uint32_t*>(qb + rl * QSTRIDE + cl * 2 + 16);
+                    uint32_t a2 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl * 2);
+                    uint32_t a3 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl * 2 + 16);
+                    const half* kb = K_cur + n * 8 * KVSTRIDE + k * 32;
+                    uint32_t b0 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2);
+                    uint32_t b1 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2 + 16);
+#if __CUDA_ARCH__ >= 1200
+                    asm volatile(
+                        "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+                        "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
+                        : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0), "f"(d1), "f"(d2),
+                          "f"(d3));
+#endif
+                }
             }
             S[n][0] = d0;
             S[n][1] = d1;
@@ -1354,8 +1400,9 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
 #pragma unroll
             for (int hn = 0; hn < N_O; hn++) {
                 int ncol = hn * 8 + rl;  // HD col
-                uint32_t rb0 = pack2_hh(V_cur[(kr0) * KVSTRIDE + ncol], V_cur[(kr0 + 1) * KVSTRIDE + ncol]);
-                uint32_t rb1 = pack2_hh(V_cur[(kr0 + 8) * KVSTRIDE + ncol], V_cur[(kr0 + 9) * KVSTRIDE + ncol]);
+                uint32_t rb0 = pack2_hh(V_cur[(kr0)*KVSTRIDE + ncol], V_cur[(kr0 + 1) * KVSTRIDE + ncol]);
+                uint32_t rb1 = pack2_hh(V_cur[(kr0 + 8) * KVSTRIDE + ncol],
+                                        V_cur[(kr0 + 9) * KVSTRIDE + ncol]);
                 float o0 = O_frag[hn][0], o1 = O_frag[hn][1], o2 = O_frag[hn][2], o3 = O_frag[hn][3];
 #if __CUDA_ARCH__ >= 1200
                 asm volatile(
@@ -1377,7 +1424,7 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
     // ---- normalize by row sum and write O ----
     float invA = (lA > 0.f) ? (1.0f / lA) : 0.f;
     float invB = (lB > 0.f) ? (1.0f / lB) : 0.f;
-    int rowA = warp_id * 16 + rl;       // local row (O_ptr already at q_start)
+    int rowA = warp_id * 16 + rl;  // local row (O_ptr already at q_start)
     int rowB = rowA + 8;
 #pragma unroll
     for (int hn = 0; hn < N_O; hn++) {
@@ -1393,18 +1440,20 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
     }
 }
 
-static size_t compute_smem_fa2(int Bq, int head_dim) {
+static size_t compute_smem_fa2(int Bq, int head_dim, bool fp16_qk) {
     constexpr int Bkv = 64;
-    const size_t qstride = head_dim + FA2_Q_PAD;    // bytes (bank-conflict pad)
     const size_t kvstride = head_dim + FA2_KV_PAD;  // halfs (bank-conflict pad)
-    return (size_t)Bq * qstride * sizeof(uint8_t)        // Q_fp8 (padded)
-           + (size_t)2 * Bkv * kvstride * sizeof(half)    // K_buf[2] f16 (double-buffer, padded)
-           + (size_t)2 * Bkv * kvstride * sizeof(half);   // V_buf[2] f16 (double-buffer, padded)
+    // Q tile: fp8 mode stages e4m3 bytes (FA2_Q_PAD), fp16 mode stages halfs
+    // (FA2_KV_PAD, same stride math as the kernel's QSTRIDE).
+    const size_t q_bytes = fp16_qk ? (size_t)Bq * (head_dim + FA2_KV_PAD) * sizeof(half)
+                                   : (size_t)Bq * (head_dim + FA2_Q_PAD) * sizeof(uint8_t);
+    return q_bytes + (size_t)2 * Bkv * kvstride * sizeof(half)  // K_buf[2] f16 (double-buffer, padded)
+           + (size_t)2 * Bkv * kvstride * sizeof(half);         // V_buf[2] f16 (double-buffer, padded)
 }
 
 bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
-                            bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                            int q_offset) {
+                            bool causal, int sliding_window, float softcap, cudaStream_t stream, int q_offset,
+                            bool fp16_qk) {
     if (Q.qtype != QType::F16)
         return false;
     const int batch_size = static_cast<int>(Q.shape[0]);
@@ -1434,10 +1483,13 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
     // the q-tiles (2× CTAs) to fill the GPU. Large context already fills with Bq=128 (more
     // latency-hiding per CTA via 8 warps), so keep 128 there.
     const long blocks_128 = (long)((seq_q + 127) / 128) * batch_size * n_heads;
-    const bool use_bq64 = blocks_128 < (long)sm_count;
+    // fp16 QK doubles the Q tile: Bq=128 (~102 KB) blows the sm_120 smem
+    // opt-in, Bq=64 (~85 KB) fits — and fp16 mode only runs below the prefill
+    // threshold anyway, where Bq=64 is the occupancy winner.
+    const bool use_bq64 = fp16_qk || blocks_128 < (long)sm_count;
     const int Bq = use_bq64 ? 64 : 128;
 
-    const size_t smem = compute_smem_fa2(Bq, head_dim);
+    const size_t smem = compute_smem_fa2(Bq, head_dim, fp16_qk);
     if (smem > (size_t)max_smem)
         return false;
 
@@ -1445,17 +1497,19 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
     dim3 grid(num_q_tiles, batch_size * n_heads);
     dim3 block(SM120_WARP_SIZE, Bq / 16);  // warps = Bq/16
 
-    auto kern = use_bq64 ? fmha_sm120_fa2_kernel<64, 128> : fmha_sm120_fa2_kernel<128, 128>;
-    cudaError_t aerr =
-        cudaFuncSetAttribute(kern, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem));
+    auto kern = fp16_qk ? fmha_sm120_fa2_kernel<64, 128, true>
+                        : (use_bq64 ? fmha_sm120_fa2_kernel<64, 128> : fmha_sm120_fa2_kernel<128, 128>);
+    cudaError_t aerr = cudaFuncSetAttribute(kern, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                            static_cast<int>(smem));
     if (aerr != cudaSuccess)
         return false;
 
     static bool logged_once = false;
     if (!logged_once) {
         logged_once = true;
-        IMP_LOG_INFO("FMHA FA2 register-resident kernel ACTIVE (hd=128, Bq=%d, smem=%zu B, seq_q=%d seq_kv=%d)",
-                     Bq, smem, seq_q, seq_kv);
+        IMP_LOG_INFO(
+            "FMHA FA2 register-resident kernel ACTIVE (hd=128, Bq=%d, qk=%s, smem=%zu B, seq_q=%d seq_kv=%d)",
+            Bq, fp16_qk ? "f16" : "e4m3", smem, seq_q, seq_kv);
     }
     kern<<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),
                                         reinterpret_cast<const half*>(K.data),

--- a/src/compute/attention_fmha_sm120.h
+++ b/src/compute/attention_fmha_sm120.h
@@ -40,8 +40,14 @@ bool fmha_sm120_fp8_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
 // runs its online softmax independently (no cross-warp reduction).
 // Target: long-context prefill where the smem-materializing fp8 kernel is
 // barrier-bound (ncu: 14.5% compute, 75.7% L1/TEX). Head dims: 128 (first).
+//
+// fp16_qk=true switches QK^T to mma.m16n8k16.f16 (Q staged as f16 in smem,
+// K read from f16 smem directly): half the score throughput, but NO e4m3
+// score noise — safe below fmha_prefill_threshold where the fp8 variants
+// compound per-layer noise into prompt-blind output (#511/#512). Bq=64 only
+// (f16 Q tile at Bq=128 exceeds the sm_120 smem opt-in).
 bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                             bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                            int q_offset = 0);
+                            int q_offset = 0, bool fp16_qk = false);
 
 }  // namespace imp

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -17,6 +17,7 @@
 #include "compute/activation.h"
 #include "compute/attention.h"
 #include "compute/attention_cublas.h"
+#include "compute/attention_fmha_sm120.h"
 #include "compute/attention_paged.h"
 #include "compute/kv_gather.h"
 #include "compute/moe_routing.h"
@@ -50,6 +51,29 @@ namespace imp {
 // ---------------------------------------------------------------------------
 
 // is_dp4a_qtype() and dispatch_dp4a_gemv() are defined in executor_kernels.h
+
+// FP16-QK FA2 for SHORT prefill (seq below fmha_prefill_threshold): replaces
+// the materialized cuBLAS+softmax path with the register-resident FA2 kernel
+// in f16-QK mode. Same numerical class as the cuBLAS reference (f16 inputs,
+// f32 accumulate) — the short-seq e4m3 quality cliff (#511/#512) does not
+// apply, and no [n × ctx] S-matrix is materialized. Declined configs
+// (hd!=128, non-F16) return false → caller stays on cuBLAS; the fp8 FMHA
+// family is intentionally NOT a fallback here.
+static bool try_fa2_fp16qk_prefill(const RuntimeConfig& rcfg, const Tensor& q, const Tensor& k,
+                                   const Tensor& v, Tensor& o, int n, int kv_len, int nh, int nkv, int hd,
+                                   float scale, int sliding_window, float softcap, int q_offset,
+                                   cudaStream_t stream) {
+    if (rcfg.attention.fa2_fp16qk == "never" || hd != 128)
+        return false;
+    int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
+    int64_t kv4s[4] = {1, (int64_t)kv_len, (int64_t)nkv, (int64_t)hd};
+    Tensor q4 = q.reshape(4, q4s);
+    Tensor k4 = k.reshape(4, kv4s);
+    Tensor v4 = v.reshape(4, kv4s);
+    Tensor o4 = o.reshape(4, q4s);
+    return fmha_sm120_fa2_prefill(q4, k4, v4, o4, scale, /*causal=*/true, sliding_window, softcap, stream,
+                                  q_offset, /*fp16_qk=*/true);
+}
 
 // Fused QKV GEMV dispatch by quant type (all share identical signatures).
 static void dispatch_gemv_qkv_fused(QType qtype, const void* W_q, const void* W_k, const void* W_v,
@@ -311,11 +335,11 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         const bool nv_k_secondary = (nv_k_it != wcache_.nvfp4.end());
         const bool nv_v_secondary = (nv_v_it != wcache_.nvfp4.end());
         const bool wq_is_nvfp4 = (mxfp4_hwq && mxfp4_hwq->primary_tier == StorageTier::NVFP4) ||
-                                  nv_q_secondary;
+                                 nv_q_secondary;
         const bool wk_is_nvfp4 = (mxfp4_hwk && mxfp4_hwk->primary_tier == StorageTier::NVFP4) ||
-                                  nv_k_secondary;
+                                 nv_k_secondary;
         const bool wv_is_nvfp4 = (mxfp4_hwv && mxfp4_hwv->primary_tier == StorageTier::NVFP4) ||
-                                  nv_v_secondary;
+                                 nv_v_secondary;
         bool nvfp4_qkv = (!has_attn_output_gate && n == 1 && wq_is_nvfp4 && wk_is_nvfp4 && wv_is_nvfp4);
         // Gemma-4: disable fused QKV when FP32 accum is active — the fused kernel
         // reads FP16 h instead of fp32_hidden_, losing precision through 128-expert routing.
@@ -612,8 +636,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             fused_rope_dim = hd;
         }
         const bool no_qknorm_fused = runtime_config().attention.no_qknorm_fused;
-        if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused &&
-            !cfg.rope_attn_disabled) {
+        if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused && !cfg.rope_attn_disabled) {
             // Fused: QK-norm + RoPE in one kernel launch (decode only, n=1).
             // Keeps norm intermediate values in FP32 shared memory.
             qknorm_rope_fused(static_cast<half*>(qv.data), static_cast<half*>(kk.data),
@@ -714,9 +737,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             QType kvt = cache->qtype();
             // Defense-in-depth: engine resolves out-of-scope models to chunk_size=0,
             // so this code only runs for FP16 / FP8 / NVFP4 / MXFP4_KV KV.
-            const bool kvt_ok = (kvt == QType::F16 || kvt == QType::FP8_E4M3 ||
-                                  kvt == QType::NVFP4 || kvt == QType::MXFP4_KV ||
-                                  kvt == QType::INT4);
+            const bool kvt_ok = (kvt == QType::F16 || kvt == QType::FP8_E4M3 || kvt == QType::NVFP4 ||
+                                 kvt == QType::MXFP4_KV || kvt == QType::INT4);
             // sliding_active and attn_shapes_vary are now both supported:
             //   - cuBLAS softmax accepts a sliding_window argument (PR feat(attn): sw),
             //   - the rectangular cuBLAS path dispatches per-layer with nh/nkv/hd.
@@ -743,13 +765,13 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // guard the FP16 footprint here.
             int s_cap = attn_scores_buf_ ? static_cast<int>(attn_scores_.shape[1]) : 0;
             int64_t fp16_elems_needed = static_cast<int64_t>(n) * ctx_len;
-            int64_t fp16_elems_avail  = static_cast<int64_t>(s_cap) * s_cap;
+            int64_t fp16_elems_avail = static_cast<int64_t>(s_cap) * s_cap;
             if (s_cap == 0 || fp16_elems_needed > fp16_elems_avail || n > s_cap) {
                 IMP_LOG_ERROR(
                     "chunked_prefill: attn_scores_ capacity %d×%d=%lld too small for "
                     "n=%d × ctx_len=%d = %lld at L%d — engine should have prevented this",
-                    s_cap, s_cap, (long long)fp16_elems_avail, n, ctx_len,
-                    (long long)fp16_elems_needed, layer);
+                    s_cap, s_cap, (long long)fp16_elems_avail, n, ctx_len, (long long)fp16_elems_needed,
+                    layer);
                 std::abort();
             }
             size_t full_bytes = (size_t)ctx_len * nkv * hd * sizeof(half);
@@ -767,40 +789,37 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                      state.block_tables, q_offset, kv_bs, nkv, hd, stream);
             } else if (kvt == QType::FP8_E4M3) {
                 float kv_scale = (!kv_scales_.empty() && kv_layer < (int)kv_scales_.size())
-                                     ? kv_scales_[kv_layer] : 1.0f;
-                paged_kv_gather_fp8_to_fp16(
-                    k_full, static_cast<const __nv_fp8_e4m3*>(cache->k_ptr(kv_layer, 0)),
-                    state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
-                paged_kv_gather_fp8_to_fp16(
-                    v_full, static_cast<const __nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)),
-                    state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
+                                     ? kv_scales_[kv_layer]
+                                     : 1.0f;
+                paged_kv_gather_fp8_to_fp16(k_full,
+                                            static_cast<const __nv_fp8_e4m3*>(cache->k_ptr(kv_layer, 0)),
+                                            state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_fp8_to_fp16(v_full,
+                                            static_cast<const __nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)),
+                                            state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
             } else if (kvt == QType::NVFP4) {
-                paged_kv_gather_nvfp4_to_fp16(
-                    k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
-                    static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
-                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
-                paged_kv_gather_nvfp4_to_fp16(
-                    v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
-                    static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_nvfp4_to_fp16(k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
+                                              static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
+                                              state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_nvfp4_to_fp16(v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
+                                              static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
+                                              state.block_tables, q_offset, kv_bs, nkv, hd, stream);
             } else if (kvt == QType::MXFP4_KV) {
-                paged_kv_gather_mxfp4_kv_to_fp16(
-                    k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
-                    static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
-                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
-                paged_kv_gather_mxfp4_kv_to_fp16(
-                    v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
-                    static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_mxfp4_kv_to_fp16(k_full,
+                                                 static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
+                                                 static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
+                                                 state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_mxfp4_kv_to_fp16(v_full,
+                                                 static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
+                                                 static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
+                                                 state.block_tables, q_offset, kv_bs, nkv, hd, stream);
             } else {  // INT4 — symmetric 4-bit with per-head FP16 scale
-                paged_kv_gather_int4_to_fp16(
-                    k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
-                    static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
-                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
-                paged_kv_gather_int4_to_fp16(
-                    v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
-                    static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
-                    state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_int4_to_fp16(k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
+                                             static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
+                                             state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                paged_kv_gather_int4_to_fp16(v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
+                                             static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
+                                             state.block_tables, q_offset, kv_bs, nkv, hd, stream);
             }
 
             // Append current chunk's K/V at offset q_offset.
@@ -826,22 +845,25 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // history in production. fp8-attention quality above the
             // threshold is tracked separately (see issue #511).
             const int fmha_threshold = runtime_config().attention.fmha_prefill_threshold;
-            const bool chunked_use_fmha =
-                !per_layer_shapes &&  // Gemma-4 hd=512 stays cuBLAS
-                (fmha_threshold > 0 && ctx_len >= fmha_threshold);
+            const bool chunked_use_fmha = !per_layer_shapes &&  // Gemma-4 hd=512 stays cuBLAS
+                                          (fmha_threshold > 0 && ctx_len >= fmha_threshold);
 
             if (chunked_use_fmha) {
                 // FMHA: no S-matrix needed, O(n) memory. Reshape to 4D for dispatch.
-                int64_t q4s[4]  = {1, (int64_t)n,       (int64_t)nh,  (int64_t)hd};
+                int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
                 int64_t kv4s[4] = {1, (int64_t)ctx_len, (int64_t)nkv, (int64_t)hd};
-                int64_t o4s[4]  = {1, (int64_t)n,       (int64_t)nh,  (int64_t)hd};
-                Tensor q4  = qv.reshape(4, q4s);
-                Tensor k4  = k_full_t.reshape(4, kv4s);
-                Tensor v4  = v_full_t.reshape(4, kv4s);
-                Tensor o4  = ao.reshape(4, o4s);
-                attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true,
-                                           layer_sliding_window, cfg.attn_logit_softcap,
-                                           stream, runtime_config(), q_offset);
+                int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
+                Tensor q4 = qv.reshape(4, q4s);
+                Tensor k4 = k_full_t.reshape(4, kv4s);
+                Tensor v4 = v_full_t.reshape(4, kv4s);
+                Tensor o4 = ao.reshape(4, o4s);
+                attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
+                                           cfg.attn_logit_softcap, stream, runtime_config(), q_offset);
+            } else if (!per_layer_shapes &&
+                       try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
+                                              nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
+                                              q_offset, stream)) {
+                // short chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
             } else {
                 // cuBLAS: needs S-matrix for [n × ctx_len]
                 attention_cublas_prefill(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv, hd, scale,
@@ -868,14 +890,23 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                  (n >= runtime_config().attention.fmha_prefill_threshold);
 
         if (s_matrix_fits && !non_gemma4_sliding && !prefer_fmha) {
-            attention_cublas_prefill(qv, kk, vv, ao, attn_scores_, nh, nkv, hd, scale,
-                                     /*causal=*/true, cfg.attn_logit_softcap,
-                                     /*q_offset=*/0, stream, layer_sliding_window);
+            // Below the FMHA threshold: prefer the FP16-QK FA2 kernel over the
+            // materialized cuBLAS path (same f16/f32 numerics, O(n) memory).
+            if (!force_cublas_attn &&
+                try_fa2_fp16qk_prefill(runtime_config(), qv, kk, vv, ao, n, n, nh, nkv, hd, scale,
+                                       layer_sliding_window, cfg.attn_logit_softcap, /*q_offset=*/0,
+                                       stream)) {
+                // handled by FA2 f16
+            } else {
+                attention_cublas_prefill(qv, kk, vv, ao, attn_scores_, nh, nkv, hd, scale,
+                                         /*causal=*/true, cfg.attn_logit_softcap,
+                                         /*q_offset=*/0, stream, layer_sliding_window);
+            }
         } else {
             // FMHA fallback: tiled O(n) memory chain.
-            int64_t q4s[4]  = {1, (int64_t)n,   (int64_t)nh,  (int64_t)hd};
-            int64_t kv4s[4] = {1, (int64_t)n,   (int64_t)nkv, (int64_t)hd};
-            int64_t o4s[4]  = {1, (int64_t)n,   (int64_t)nh,  (int64_t)hd};
+            int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
+            int64_t kv4s[4] = {1, (int64_t)n, (int64_t)nkv, (int64_t)hd};
+            int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
             Tensor q4 = qv.reshape(4, q4s);
             Tensor k4 = kk.reshape(4, kv4s);
             Tensor v4 = vv.reshape(4, kv4s);
@@ -1017,15 +1048,13 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 // null-check. Default path (residual_on=false) uses the
                 // function's default arguments — no explicit nullptr/0 marshalling
                 // at the call site, no dead per-layer state lookups.
-                const bool residual_on = state.kv_manager != nullptr &&
-                                         state.kv_manager->residual_enabled();
+                const bool residual_on = state.kv_manager != nullptr && state.kv_manager->residual_enabled();
                 const uint8_t* k_scales = static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0));
                 const uint8_t* v_scales = static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0));
                 if (!residual_on) {
-                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales,
-                                                    state.block_tables, state.context_lens, kv_bs, scale,
-                                                    state.max_context_len, layer_sliding_window,
-                                                    cfg.attn_logit_softcap, stream,
+                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, state.block_tables,
+                                                    state.context_lens, kv_bs, scale, state.max_context_len,
+                                                    layer_sliding_window, cfg.attn_logit_softcap, stream,
                                                     state.max_blocks_per_seq);
                 } else {
                     // Phase 3b residual read. Two activation paths:
@@ -1061,16 +1090,13 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                         res_count = rs.fill_count;
                         res_widx = rs.write_idx;
                     }
-                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales,
-                                                    state.block_tables, state.context_lens, kv_bs, scale,
-                                                    state.max_context_len, layer_sliding_window,
-                                                    cfg.attn_logit_softcap, stream,
-                                                    state.max_blocks_per_seq, 0,
-                                                    k_res, v_res, res_count, res_n, res_widx,
-                                                    k_res_base, v_res_base, res_seq_stride_elems,
-                                                    state.d_residual_seq_slots,
-                                                    state.d_residual_counts,
-                                                    state.d_residual_write_idxes,
+                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, state.block_tables,
+                                                    state.context_lens, kv_bs, scale, state.max_context_len,
+                                                    layer_sliding_window, cfg.attn_logit_softcap, stream,
+                                                    state.max_blocks_per_seq, 0, k_res, v_res, res_count,
+                                                    res_n, res_widx, k_res_base, v_res_base,
+                                                    res_seq_stride_elems, state.d_residual_seq_slots,
+                                                    state.d_residual_counts, state.d_residual_write_idxes,
                                                     state.kv_manager->d_residual_fc_ptr(),
                                                     state.kv_manager->d_residual_widx_ptr());
                 }
@@ -1087,11 +1113,11 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // BitDecoding TC path not supported for MXFP4_KV in Slice 2 — always scalar.
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_mxfp4_kv(q4, k_c, v_c, o4,
-                                             static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
-                                             static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                                             state.block_tables, state.context_lens, kv_bs, scale,
-                                             state.max_context_len, layer_sliding_window,
-                                             cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
+                                            static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
+                                            static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
+                                            state.block_tables, state.context_lens, kv_bs, scale,
+                                            state.max_context_len, layer_sliding_window,
+                                            cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
         } else if (cache_dtype == QType::INT8) {
             // INT8 dp4a paged attention with per-head scales (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -132,6 +132,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.attention.fmha_sm120 = val;
     else if (eq("attention.fmha_fa2"))
         cfg.attention.fmha_fa2 = val;
+    else if (eq("attention.fa2_fp16qk"))
+        cfg.attention.fa2_fp16qk = val;
     else if (eq("attention.fmha_prefill_threshold"))
         cfg.attention.fmha_prefill_threshold = parse_int(val, cfg.attention.fmha_prefill_threshold);
     else if (eq("attention.attn_scores_mib"))
@@ -361,7 +363,8 @@ void seed_from_env(RuntimeConfig& cfg) {
     // attention.attn_scores_mib — IMP_ATTN_SCORES_MIB: cuBLAS attention S-matrix cap.
     if (const char* e = std::getenv("IMP_ATTN_SCORES_MIB")) {
         int v = std::atoi(e);
-        if (v > 0) cfg.attention.attn_scores_mib = v;
+        if (v > 0)
+            cfg.attention.attn_scores_mib = v;
     }
 
     // attention.fmha_fa2 — IMP_FMHA_FA2: '1' enables the register-resident FA2
@@ -376,8 +379,10 @@ void seed_from_env(RuntimeConfig& cfg) {
     // moe.nvfp4_smallM_threshold — IMP_NVFP4_SMALLM_THRESHOLD: clamped int.
     if (const char* e = std::getenv("IMP_NVFP4_SMALLM_THRESHOLD")) {
         int v = std::atoi(e);
-        if (v < 0) v = 0;
-        if (v > 128) v = 128;
+        if (v < 0)
+            v = 0;
+        if (v > 128)
+            v = 128;
         cfg.moe.nvfp4_smallM_threshold = v;
     }
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -104,6 +104,15 @@ struct RuntimeConfig {
         // hd!=128 (Gemma), non-F16, or insufficient smem, so it's safe by
         // default. "never" forces the legacy FP8 FMHA. Legacy env: IMP_FMHA_FA2.
         std::string fmha_fa2 = "on";
+        // FP16-QK FA2 for SHORT prefill (seq < fmha_prefill_threshold, hd=128):
+        // replaces the materialized cuBLAS+softmax path with the register-
+        // resident FA2 kernel running QK^T in f16 (mma.m16n8k16) instead of
+        // e4m3 — same numerical class as the cuBLAS reference (f16 inputs,
+        // f32 accumulate), so the short-seq e4m3 quality cliff (#511/#512)
+        // does not apply. O(n) memory: no S-matrix alloc. Declined configs
+        // (hd!=128, dual-head-dim Gemma-4) fall back to cuBLAS, never to the
+        // fp8 FMHA family. "never" restores the materialized cuBLAS path.
+        std::string fa2_fp16qk = "on";
         std::string mxfp4 = "auto";
         bool mxfp4_fp16_fallback = false;
         // MXFP4 → FP16 cache pruning policy. "legacy" (default) caches FP16

--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -1,20 +1,20 @@
 {
   "model": "Qwen3-8B-Q8_0.gguf",
   "gpu": "NVIDIA GeForce RTX 5090",
-  "cuda": "13.3",
+  "cuda": "unknown",
   "vram_total_mb": 32607,
-  "timestamp": "2026-05-29T15:12:50Z",
+  "timestamp": "2026-06-04T12:04:04Z",
   "methodology": "median of 5 trials × 5 reps, 15s cooldown between trials (cuBLAS algo drift resistant)",
   "reps": 5,
   "n_trials": 5,
   "metrics": {
     "prefill_tps": {
-      "pp128": 3647.36,
-      "pp512": 8259.59,
-      "pp4096": 8300.55
+      "pp128": 3197.38,
+      "pp512": 7153.42,
+      "pp4096": 8751.49
     },
     "decode_tps": {
-      "tg128": 258.87
+      "tg128": 238.63
     },
     "memory_mb": {
       "model_weights": 8320

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -72,11 +72,16 @@ protected:
         size_t kv_elems = B * Skv * NKV * HD;
 
         std::vector<float> Q_f(q_elems), K_f(kv_elems), V_f(kv_elems);
+        // NOTE: the int cast before the -6 is load-bearing. `(i*7+3)%13 - 6`
+        // with size_t i underflows unsigned whenever %13 < 6, producing
+        // ±3.7e17 (→ ±inf as half) at ~46% of positions. The e4m3 satfinite
+        // convert masked that in the fp8 kernel, and the NaN-poisoned CPU
+        // reference made std::max() drop every comparison → vacuous pass.
         for (size_t i = 0; i < q_elems; i++)
-            Q_f[i] = 0.02f * static_cast<float>((i * 7 + 3) % 13 - 6);
+            Q_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 7 + 3) % 13) - 6);
         for (size_t i = 0; i < kv_elems; i++) {
-            K_f[i] = 0.02f * static_cast<float>((i * 11 + 5) % 13 - 6);
-            V_f[i] = 0.02f * static_cast<float>((i * 13 + 7) % 13 - 6);
+            K_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 11 + 5) % 13) - 6);
+            V_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 13 + 7) % 13) - 6);
         }
 
         std::vector<float> O_ref(q_elems, 0.0f);
@@ -128,10 +133,14 @@ protected:
 
         // FP8 QK^T has lower precision than FP16 — use relaxed tolerance
         float max_err = 0.0f;
-        int nan_count = 0;
+        int nan_count = 0, ref_nan_count = 0;
         for (size_t i = 0; i < q_elems; i++) {
             float got = __half2float(O_h[i]);
             float ref = O_ref[i];
+            if (!std::isfinite(ref)) {
+                ref_nan_count++;  // poisoned reference would silently skip comparisons
+                continue;
+            }
             if (std::isnan(got)) {
                 nan_count++;
                 continue;
@@ -140,6 +149,7 @@ protected:
             float denom = std::max(1.0f, std::abs(ref));
             max_err = std::max(max_err, err / denom);
         }
+        EXPECT_EQ(ref_nan_count, 0) << "CPU reference is NaN/inf — test data is broken";
         EXPECT_EQ(nan_count, 0) << "NaN values in FP8 FMHA output";
         // FP8 E4M3 has ~0.1% precision loss in scores, allow 5% relative error
         EXPECT_LT(max_err, 0.05f) << "Max relative error too high: " << max_err;
@@ -184,17 +194,18 @@ TEST_F(FmhaFP8Test, Qwen35LikeHD256_GQA41_SeqMultiTile) { run_test(1, 128, 128, 
 class FmhaFA2Test : public FmhaFP8Test {
 protected:
     void run_fa2(int B, int Sq, int Skv, int NH, int NKV, int HD, bool causal, int sw = 0,
-                 float softcap = 0.0f, float amplitude = 1.0f) {
+                 float softcap = 0.0f, float amplitude = 1.0f, bool fp16_qk = false) {
         float scale = 1.0f / std::sqrt(static_cast<float>(HD));
         size_t q_elems = B * Sq * NH * HD;
         size_t kv_elems = B * Skv * NKV * HD;
 
         std::vector<float> Q_f(q_elems), K_f(kv_elems), V_f(kv_elems);
+        // int cast before -6 is load-bearing — see run_test above.
         for (size_t i = 0; i < q_elems; i++)
-            Q_f[i] = amplitude * 0.02f * static_cast<float>((i * 7 + 3) % 13 - 6);
+            Q_f[i] = amplitude * 0.02f * static_cast<float>(static_cast<int>((i * 7 + 3) % 13) - 6);
         for (size_t i = 0; i < kv_elems; i++) {
-            K_f[i] = amplitude * 0.02f * static_cast<float>((i * 11 + 5) % 13 - 6);
-            V_f[i] = 0.02f * static_cast<float>((i * 13 + 7) % 13 - 6);
+            K_f[i] = amplitude * 0.02f * static_cast<float>(static_cast<int>((i * 11 + 5) % 13) - 6);
+            V_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 13 + 7) % 13) - 6);
         }
 
         std::vector<float> O_ref(q_elems, 0.0f);
@@ -227,7 +238,8 @@ protected:
         Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
         Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
-        bool ok = fmha_sm120_fa2_prefill(Qt, Kt, Vt, Ot, scale, causal, sw, softcap, stream_);
+        bool ok = fmha_sm120_fa2_prefill(Qt, Kt, Vt, Ot, scale, causal, sw, softcap, stream_,
+                                         /*q_offset=*/0, fp16_qk);
         ASSERT_TRUE(ok) << "fmha_sm120_fa2_prefill returned false (config must be supported)";
         cudaStreamSynchronize(stream_);
         cudaError_t err = cudaGetLastError();
@@ -237,10 +249,14 @@ protected:
         cudaMemcpy(O_h.data(), d_o, q_bytes, cudaMemcpyDeviceToHost);
 
         float max_err = 0.0f;
-        int nan_count = 0;
+        int nan_count = 0, ref_nan_count = 0;
         for (size_t i = 0; i < q_elems; i++) {
             float got = __half2float(O_h[i]);
             float ref = O_ref[i];
+            if (!std::isfinite(ref)) {
+                ref_nan_count++;  // poisoned reference would silently skip comparisons
+                continue;
+            }
             if (std::isnan(got)) {
                 nan_count++;
                 continue;
@@ -253,8 +269,14 @@ protected:
         cudaFree(d_k);
         cudaFree(d_v);
         cudaFree(d_o);
+        EXPECT_EQ(ref_nan_count, 0) << "CPU reference is NaN/inf — test data is broken";
         EXPECT_EQ(nan_count, 0) << "NaN values in FA2 FMHA output";
-        EXPECT_LT(max_err, 0.05f) << "Max relative error too high: " << max_err;
+        // fp16 QK has no e4m3 score quantization — hold it to a 1% bound
+        // (inputs are half-rounded vs the float reference; ~2^-11 per element
+        // over a 128-dot + f16 P/V rounding in PV). fp8 QK keeps the
+        // historical 5%.
+        const float tol = fp16_qk ? 0.01f : 0.05f;
+        EXPECT_LT(max_err, tol) << "Max relative error too high: " << max_err;
     }
 };
 
@@ -289,6 +311,34 @@ TEST_F(FmhaFA2Test, CausalMultiTile_HD128) { run_fa2(1, 128, 128, 4, 4, 128, tru
 TEST_F(FmhaFA2Test, LongCtx_HD128) { run_fa2(1, 256, 256, 8, 2, 128, true); }
 TEST_F(FmhaFA2Test, SlidingWindow_HD128) { run_fa2(1, 128, 128, 4, 4, 128, true, 64); }
 TEST_F(FmhaFA2Test, Softcap_HD128) { run_fa2(1, 64, 64, 4, 4, 128, true, 0, 50.0f); }
+
+// ---------------------------------------------------------------------------
+// FP16-QK variant (mma.m16n8k16.f16): the short-prefill replacement for the
+// materialized cuBLAS path. No e4m3 quantization anywhere in QK → verified
+// at 1% tolerance (5x tighter than the fp8 tests). The realistic-magnitude
+// cases are the exact regime where the fp8 QK loses mantissa bits (#511) —
+// fp16 must hold the tight bound there too.
+// ---------------------------------------------------------------------------
+TEST_F(FmhaFA2Test, FP16QK_CausalShortSeq24_GQA32_8) {
+    run_fa2(1, 24, 24, 32, 8, 128, true, 0, 0.0f, 1.0f, /*fp16_qk=*/true);
+}
+TEST_F(FmhaFA2Test, FP16QK_CausalSeq64) { run_fa2(1, 64, 64, 4, 4, 128, true, 0, 0.0f, 1.0f, true); }
+TEST_F(FmhaFA2Test, FP16QK_CausalOddSeq51) { run_fa2(1, 51, 51, 4, 4, 128, true, 0, 0.0f, 1.0f, true); }
+TEST_F(FmhaFA2Test, FP16QK_CausalOddSeq136_GQA32_8) {
+    run_fa2(1, 136, 136, 32, 8, 128, true, 0, 0.0f, 1.0f, true);
+}
+TEST_F(FmhaFA2Test, FP16QK_RealisticMagnitude_Seq24) {
+    run_fa2(1, 24, 24, 32, 8, 128, true, 0, 0.0f, /*amplitude=*/80.0f, true);
+}
+TEST_F(FmhaFA2Test, FP16QK_RealisticMagnitude_Seq64) {
+    run_fa2(1, 64, 64, 4, 4, 128, true, 0, 0.0f, /*amplitude=*/80.0f, true);
+}
+TEST_F(FmhaFA2Test, FP16QK_NonCausal) { run_fa2(1, 32, 64, 4, 4, 128, false, 0, 0.0f, 1.0f, true); }
+TEST_F(FmhaFA2Test, FP16QK_GQA) { run_fa2(1, 64, 64, 8, 2, 128, true, 0, 0.0f, 1.0f, true); }
+TEST_F(FmhaFA2Test, FP16QK_MultiTile) { run_fa2(1, 128, 128, 4, 4, 128, true, 0, 0.0f, 1.0f, true); }
+TEST_F(FmhaFA2Test, FP16QK_LongCtx) { run_fa2(1, 256, 256, 8, 2, 128, true, 0, 0.0f, 1.0f, true); }
+TEST_F(FmhaFA2Test, FP16QK_SlidingWindow) { run_fa2(1, 128, 128, 4, 4, 128, true, 64, 0.0f, 1.0f, true); }
+TEST_F(FmhaFA2Test, FP16QK_Softcap) { run_fa2(1, 64, 64, 4, 4, 128, true, 0, 50.0f, 1.0f, true); }
 
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## Was

Unterhalb `fmha_prefill_threshold` (hd=128) lief Prefill-Attention über den materialisierten cuBLAS+Softmax-Pfad — der fp8-FA2 war dort quality-banned (#511/#512: e4m3-Score-Rauschen kumuliert über Layer → prompt-blind bei kurzen Prompts). Dieser PR fügt dem register-residenten FA2-Kernel eine **FP16-QK-Template-Variante** hinzu (`mma.m16n8k16.f16`, Q als f16 in smem): gleiche Numerik-Klasse wie die cuBLAS-Referenz (f16-Inputs, f32-Akkumulation) — Softmax/Masking/PV mit dem fp8-Pfad geteilt. Bq=64 only (f16-Q-Tile @Bq=128 sprengt das sm_120-smem-Opt-in; ~85 KB passt).

**Routing:** Executor versucht FP16-FA2 in beiden Kurz-Prefill-cuBLAS-Zweigen (chunked + non-chunked). Abgelehnte Configs (hd≠128, Gemma-4 dual-head-dim) fallen auf cuBLAS zurück — **nie** auf die fp8-FMHA-Familie. Oberhalb des Thresholds bleibt der quality-validierte fp8-FA2. Knob: `attention.fa2_fp16qk` (default on, `never` = alter Zustand).

## Messungen

Same-Process-Knob-A/B (10 reps × 3 Trials, `CUBLAS_WORKSPACE_CONFIG=:4096:8`):

| Modell | Metrik | never (cuBLAS) | on (FP16-FA2) | Δ |
|---|---|---|---|---|
| Qwen3-8B-NVFP4 | pp512 | ~21.2k | ~28.6k | **+25-35%** |
| Qwen3-8B-NVFP4 | pp2048 | ~18.4k | ~22.0k | **+19%** |
| Qwen3-8B-NVFP4 | tg256 | 237-244 | 237-276 | neutral |
| Qwen3-8B-Q8_0 | pp512 | 6.9-7.2k | 7.2-7.3k | +2-3% |
| Qwen3-8B-Q8_0 | tg256 | 235 | 235 | neutral |

Qualität: degen_suite **27/0** auf Qwen3-8B-NVFP4 (Log bestätigt `qk=f16` aktiv ab seq_q=27), GGUF-Kurz-Prompt kohärent, volle GPU-Suite grün.

## Test-Findings (TEST_AUDIT-Klasse, im Vorbeigehen gefunden)

Die neuen FP16QK-Tests (12 Varianten, **1% Toleranz** statt 5%) schlugen initial mit 100% NaN fehl — Root-Cause war **der Test, nicht der Kernel**:

- **`size_t`-Underflow im Datengenerator**: `(i*7+3) % 13 - 6` mit `size_t i` underflowt unsigned bei %13<6 → ±3.7e17 → **±inf als half an ~46% der Positionen**. Der e4m3-satfinite-Convert des fp8-Kernels maskierte das (inf→448); der f16-Pfad propagiert ehrlich → `inf−inf=NaN`.
- **NaN-schluckender Komparator**: Die CPU-Referenz wird mit denselben Garbage-Floats NaN, und `std::max(old, NaN)` lässt jeden Vergleich fallen → `max_err=0` → **die fp8/FA2-Suiten waren größtenteils vakuos** (erklärt retroaktiv, warum #493 trotz grüner Tests prompt-blind war). Komparator failt jetzt laut bei nicht-finiter Referenz.
- FP16-A-Fragment-Reihenfolge gegen isolierten mma-Harness validiert (a1=row+8, a2=col+8; vertauschte Ordnung → max_err 0.186 vs 8e-5).

## perf_baseline.json

Refreshed (isoliert, prod gestoppt). **Achtung:** Q8_0 pp512/tg128 driften −13%/−8% vs. Baseline 2026-05-29 — **unabhängig von diesem PR** (identisch reproduziert auf main@#523 und mit `fa2_fp16qk=never`). Wird separat als Issue getrackt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)