### PR TITLE
test(audit): E2E greedy regression locks, llama.cpp-verified (Phase 2.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,7 @@ if(IMP_BUILD_TESTS)
         tests/test_engine_integration.cu
         tests/test_e2e.cpp
         tests/test_e2e_models.cpp
+        tests/test_e2e_greedy_lock.cpp
         tests/test_continuous_batching.cpp
         tests/test_degeneration.cpp
         tests/test_weight_registry_preservation.cpp

--- a/tests/refs/e2e_greedy_locks.h
+++ b/tests/refs/e2e_greedy_locks.h
@@ -1,0 +1,74 @@
+// E2E greedy locks — frozen full-stack token sequences (TEST_AUDIT risk #3).
+// Consumed by tests/test_e2e_greedy_lock.cpp. See that file's header for the
+// lock lifecycle (generate with IMP_LOCK_PRINT=1 → verify EXTERNALLY →
+// commit). Every entry documents its verification in the comment above it:
+//   "verified: llama.cpp <image> <date>" — same raw prompt, greedy, the
+//     external engine produced a semantically equivalent continuation
+//     (token-identical across engines is not expected or required).
+//   "verified: internal <date>" — no external engine loads this format
+//     (NVFP4 SafeTensors); human-reviewed for coherent prompt-grounded
+//     output + degen_suite green on the same build.
+#pragma once
+
+#include <cstdint>
+
+namespace imp_refs {
+
+struct GreedyLock {
+    const char* model_basename;  // matched against basename(IMP_TEST_MODEL)
+    const char* prompt;          // raw completion prompt (no chat template)
+    int n_tokens;                // locked sequence length (may be < requested on EOS)
+    int32_t tokens[48];          // the frozen greedy sequence
+};
+
+inline constexpr GreedyLock kGreedyLocks[] = {
+    // verified: llama.cpp ghcr.io/ggml-org/llama.cpp:server-cuda 2026-06-04.
+    // Cross-engine note: llama.cpp greedy continues " Paris. The capital of
+    // Italy is Rome..."; imp continues ". What is the capital of Germany?
+    // ... Berlin ... Italy ... Rome..." — both coherent capital-Q&A with
+    // correct facts; the engines diverge at the FIRST token (greedy
+    // amplifies sub-ulp logit differences into different-but-valid
+    // trajectories). Locked sequence is imp's own — the lock is a
+    // regression net, not a cross-engine equality claim.
+    {"Qwen3-8B-Q8_0.gguf",
+     "The capital of France is",
+     31,
+     {13,    3555, 374, 279, 6722, 315, 9856, 30,  576, 6722,  315,   9856, 374, 19846, 13,   3555,
+      374,   279,  6722, 315, 15344, 30, 576, 6722, 315, 15344, 374, 21718, 13, 3555, 374}},
+    // verified: llama.cpp server-cuda 2026-06-04 — both engines answer " 42"
+    // (imp: "42\n\nOkay, let me try to figure out what 17 plus 25 is...";
+    // llama.cpp: " 42\n\nQ: What is 17 + 25?\nA: 42..."). Arithmetic
+    // grounding agrees; this is the prompt-blindness detector (#512-class
+    // bugs scrambled exactly this prompt shape).
+    {"Qwen3-8B-Q8_0.gguf",
+     "Q: What is 17 + 25?\nA:",
+     31,
+     {19,  17,    271, 32313, 11,  1077, 752, 1430, 311, 7071,  700, 1128, 220, 16, 22, 5519,
+      220, 17, 20, 374, 13, 88190, 11, 358, 6099, 429, 7842, 5109, 3363, 34171, 862}},
+    // verified: internal 2026-06-04 — no external engine loads NVFP4
+    // SafeTensors. Coherent capital-Q&A with correct facts (Berlin/Rome/
+    // Madrid/Lisbon); degen_suite 27/0 on this model+build the same day.
+    // This entry locks the SafeTensors loader + RoPE path (the #503
+    // RoPE-NeoX class shipped prompt-blind output exactly here).
+    {"Qwen3-8B-NVFP4-cortecs",
+     "The capital of France is",
+     31,
+     {13,  576, 6722, 315, 9856, 374, 19846, 13,  576, 6722, 315, 15344, 374, 21718, 13, 576,
+      6722, 315, 17689, 374, 24081, 13, 576, 6722, 315, 33311, 374, 80701, 13, 576, 6722}},
+    // verified: internal 2026-06-04 — "17+25=42": arithmetically correct,
+    // prompt-grounded (the prompt-blindness detector for the NVFP4 path).
+    {"Qwen3-8B-NVFP4-cortecs",
+     "Q: What is 17 + 25?\nA:",
+     31,
+     {16, 22, 10, 17, 20, 28, 19, 17, 271, 48, 25, 3555, 374, 220, 16, 22,
+      488, 220, 17, 20, 5267, 32, 25, 220, 16, 22, 10, 17, 20, 28, 19}},
+    // NOT locked (both Qwen3-8B-Q8_0 and -NVFP4-cortecs): "The three
+    // primary colors are red, blue, and" — imp's greedy output is
+    // NON-DETERMINISTIC across fresh contexts at temp=0 on a DENSE model
+    // (caught by this test's determinism probe at lock-generation time,
+    // 2026-06-04; likely an exact logit tie broken by a non-deterministic
+    // argmax reduction). A lock would flake; the probe turns any future
+    // spread of this behavior into a loud failure.
+};
+
+}  // namespace imp_refs

--- a/tests/test_e2e_greedy_lock.cpp
+++ b/tests/test_e2e_greedy_lock.cpp
@@ -1,0 +1,188 @@
+// E2E greedy regression locks — TEST_AUDIT.md risk #3 (Phase 2.4).
+//
+// The single highest-leverage test class in the audit: a fixed prompt run
+// greedy (temp=0, top_k=1) through the FULL stack (tokenize → prefill →
+// decode loop, CUDA graphs ON = the production path) must reproduce a
+// frozen token sequence exactly. Locks would have caught: Nemotron NoPE
+// (positionally blind since integration), Phi-4 RoPE-NeoX (#503), the FA2
+// short-prefill regression (#512), and the gemma mode-2 NaN collapse
+// (#514/#516) — all of which shipped while per-kernel parity suites were
+// green.
+//
+// Lock lifecycle (tests/refs/e2e_greedy_locks.h):
+//   1. Generate candidates: IMP_LOCK_PRINT=1 prints ready-to-paste lock
+//      entries for the loaded model.
+//   2. Verify EXTERNALLY before committing: GGUF locks are checked against
+//      llama.cpp greedy output on the same raw prompt (semantic agreement —
+//      bit-identical tokens across engines is not expected; coherent,
+//      prompt-grounded continuation is). SafeTensors/NVFP4 models have no
+//      external engine that loads them; their locks are verified by human
+//      review + degen_suite and marked "internal" in the table.
+//   3. Commit the entry. From then on ANY token drift fails loudly.
+//
+// A lock failure means: forward pass / tokenizer / sampler behavior changed.
+// That is sometimes intentional (kernel rework with quality-neutral PPL) —
+// regenerate via step 1+2 and say so in the PR; it is never noise: this test
+// also asserts determinism (two fresh-context runs must match), so a flaky
+// lock is itself a finding (atomics in the forward pass of a dense model).
+
+#include <gtest/gtest.h>
+#include "imp/imp.h"
+#include "refs/e2e_greedy_locks.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+const char* model_path() { return std::getenv("IMP_TEST_MODEL"); }
+
+std::string basename_of(const std::string& p) {
+    size_t s = p.find_last_of('/');
+    std::string b = (s == std::string::npos) ? p : p.substr(s + 1);
+    if (!b.empty() && b.back() == '/')
+        b.pop_back();
+    return b;
+}
+
+bool is_safetensors_dir(const std::string& p) {
+    // crude but sufficient: GGUF models are files ending in .gguf
+    return p.size() < 5 || p.substr(p.size() - 5) != ".gguf";
+}
+
+class GreedyLockTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const char* path = model_path();
+        if (!path)
+            GTEST_SKIP() << "Set IMP_TEST_MODEL to run greedy locks";
+        path_ = path;
+
+        ImpModelFormat fmt = is_safetensors_dir(path_) ? IMP_FORMAT_SAFETENSORS : IMP_FORMAT_GGUF;
+        ASSERT_EQ(imp_model_load(path, fmt, &model_), IMP_SUCCESS);
+
+        ImpConfig cfg = imp_config_default();
+        cfg.max_seq_len = 512;
+        cfg.max_batch_size = 1;
+        cfg.enable_cuda_graphs = 1;  // locks freeze the PRODUCTION path
+        ASSERT_EQ(imp_context_create(model_, &cfg, &ctx_), IMP_SUCCESS);
+    }
+
+    void TearDown() override {
+        if (ctx_)
+            imp_context_free(ctx_);
+        if (model_)
+            imp_model_free(model_);
+    }
+
+    // Greedy generation via the token-level API (prefill + decode loop).
+    std::vector<int32_t> generate_greedy(const char* prompt, int n_gen) {
+        ImpGenerateParams params = imp_generate_params_default();
+        params.temperature = 0.0f;
+        params.top_k = 1;
+        params.top_p = 1.0f;
+        params.seed = 42;  // greedy ignores it; pinned for determinism anyway
+        params.max_tokens = n_gen;
+
+        std::vector<int32_t> prompt_tokens(512);
+        int n_prompt = 0;
+        EXPECT_EQ(imp_tokenize(model_, prompt, prompt_tokens.data(), &n_prompt, 512), IMP_SUCCESS);
+        prompt_tokens.resize(n_prompt);
+
+        EXPECT_EQ(imp_context_reset(ctx_), IMP_SUCCESS);
+        EXPECT_EQ(imp_prefill_with_params(ctx_, prompt_tokens.data(), n_prompt, &params), IMP_SUCCESS);
+
+        std::vector<int32_t> out;
+        for (int i = 0; i < n_gen; i++) {
+            int32_t tok = -1;
+            if (imp_decode_step(ctx_, &params, &tok) != IMP_SUCCESS || tok < 0)
+                break;
+            out.push_back(tok);
+        }
+        return out;
+    }
+
+    std::string detok(const std::vector<int32_t>& toks) {
+        std::string buf(4096, '\0');
+        if (imp_detokenize(model_, toks.data(), (int)toks.size(), buf.data(), buf.size()) != IMP_SUCCESS)
+            return "<detokenize failed>";
+        buf.resize(strlen(buf.c_str()));
+        return buf;
+    }
+
+    std::string path_;
+    ImpModel model_ = nullptr;
+    ImpContext ctx_ = nullptr;
+};
+
+// Candidate prompts for NEW locks (IMP_LOCK_PRINT=1). Raw completion
+// prompts, no chat template: template churn must not invalidate locks.
+// One factual cloze, one arithmetic (the prompt-blindness detector — Nemotron
+// NoPE and the FA2 regression scrambled exactly this), one multi-sentence.
+constexpr const char* kCandidatePrompts[] = {
+    "The capital of France is",
+    "Q: What is 17 + 25?\nA:",
+    "The three primary colors are red, blue, and",
+};
+constexpr int kLockLen = 32;
+
+TEST_F(GreedyLockTest, FrozenSequences) {
+    const std::string base = basename_of(path_);
+    const bool print_mode = std::getenv("IMP_LOCK_PRINT") != nullptr;
+
+    if (print_mode) {
+        for (const char* prompt : kCandidatePrompts) {
+            std::vector<int32_t> run1 = generate_greedy(prompt, kLockLen);
+            std::vector<int32_t> run2 = generate_greedy(prompt, kLockLen);
+            ASSERT_EQ(run1, run2) << "NON-DETERMINISTIC at lock-generation time — do not lock";
+            std::string esc;  // escape \n for the C literal
+            for (char c : std::string(prompt))
+                esc += (c == '\n') ? std::string("\\n") : std::string(1, c);
+            printf("    // verified: <FILL: llama.cpp <image> <date> / internal <date>>\n");
+            printf("    {\"%s\",\n     \"%s\",\n     %d,\n     {", base.c_str(), esc.c_str(),
+                   (int)run1.size());
+            for (size_t i = 0; i < run1.size(); i++)
+                printf("%s%d", i ? ", " : "", run1[i]);
+            printf("}},\n    // text: %s\n", detok(run1).c_str());
+        }
+        GTEST_SKIP() << "IMP_LOCK_PRINT mode: candidates printed, nothing asserted";
+    }
+
+    int n_locks = 0;
+    for (const auto& lock : imp_refs::kGreedyLocks) {
+        if (base != lock.model_basename)
+            continue;
+        n_locks++;
+        SCOPED_TRACE(std::string(lock.model_basename) + " :: " + lock.prompt);
+
+        // ALWAYS request kLockLen (same as lock generation): the engine
+        // yields requested-1 tokens (prefill samples token 1, the graph loop
+        // plans max_tokens-1 decode steps), so requesting lock.n_tokens
+        // would generate one token short of the lock.
+        std::vector<int32_t> run1 = generate_greedy(lock.prompt, kLockLen);
+
+        // Determinism probe: a dense model MUST reproduce itself exactly on a
+        // fresh context. A flaky lock is a forward-pass-atomics finding, not
+        // test noise.
+        std::vector<int32_t> run2 = generate_greedy(lock.prompt, kLockLen);
+        ASSERT_EQ(run1, run2) << "NON-DETERMINISTIC greedy output (fresh contexts, temp=0):\n"
+                              << "  run1: " << detok(run1) << "\n  run2: " << detok(run2);
+
+        std::vector<int32_t> want(lock.tokens, lock.tokens + lock.n_tokens);
+        // The model may stop early (EOS) — the lock stores exactly what the
+        // engine produced at lock time, so lengths must match too.
+        EXPECT_EQ(run1, want) << "GREEDY LOCK BROKEN for " << base << "\n  prompt: " << lock.prompt
+                              << "\n  locked: " << detok(want) << "\n  now:    " << detok(run1)
+                              << "\nIf this change is intentional (quality-neutral kernel rework), "
+                                 "regenerate with IMP_LOCK_PRINT=1, re-verify externally "
+                                 "(tests/refs/e2e_greedy_locks.h header comment), and say so in the PR.";
+    }
+
+    if (n_locks == 0)
+        GTEST_SKIP() << "no greedy locks recorded for model '" << base
+                     << "' — generate with IMP_LOCK_PRINT=1 and add to tests/refs/e2e_greedy_locks.h";
+}
+
+}  // namespace


### PR DESCRIPTION
## Was (TEST_AUDIT Phase 2.4 — Risk #3, der höchste Hebel)

Frozen Full-Stack-Greedy-Token-Sequenzen (tokenize → `imp_prefill_with_params` → `imp_decode_step`-Loop, **CUDA-Graphs ON** = Produktionspfad), exakt asserted. Diese Lock-Klasse hätte gefangen: Nemotron-NoPE, Phi-4-RoPE-NeoX (#503), FA2-Kurz-Prefill-Regression (#512), gemma-Mode-2-Kollaps (#514/#516).

**Lifecycle** (im Test + Golden dokumentiert): `IMP_LOCK_PRINT=1` druckt Kandidaten → **externe Verifikation vor dem Commit** (GGUF: llama.cpp `server-cuda` greedy auf demselben Raw-Prompt, semantische Übereinstimmung; NVFP4-SafeTensors: kein externes Engine-Oracle möglich → Human-Review + degen_suite, als `internal` markiert) → Eintrag einfrieren. Jede künftige Token-Drift failt laut mit Diff + Anleitung.

**Gelockt:** Qwen3-8B-Q8_0 (GGUF-Pfad) + Qwen3-8B-NVFP4-cortecs (SafeTensors/RoPE-Pfad — die #503-Klasse), je 2 Prompts (Faktum-Cloze + Arithmetik = Prompt-Blindness-Detektor). Beide Modelle validiert grün.

## Eingebaute Determinismus-Probe — mit Sofort-Fund

Jeder Lock läuft 2× auf frischen Contexts und muss exakt matchen, BEVOR gegen das Golden verglichen wird (flaky Lock = Forward-Pass-Befund, nicht Testrauschen). Die Probe schlug direkt an: **"The three primary colors are red, blue, and" ist auf BEIDEN dense Qwen3-8B-Builds non-deterministisch bei temp=0** (exakter Logit-Tie + non-deterministische Argmax-Reduktion). Im Golden dokumentiert, Prompt ungelockt — bisher war Non-Determinismus bei temp=0 nur für Qwen3.6-35B (GDN/MoE) bekannt; dense war unerwartet.

## Cross-Engine-Beobachtung (dokumentiert, kein Blocker)

llama.cpp setzt "The capital of France is" mit " Paris..." fort, imp mit ". What is the capital of Germany? ...Berlin...Rome..." — beide kohärent und faktisch korrekt; greedy verstärkt sub-ulp-Logit-Differenzen am ersten Token in unterschiedliche-aber-valide Trajektorien. Bei "17+25" antworten beide Engines "42". Locks frieren imps eigene Trajektorie ein (Regressionsnetz, kein Cross-Engine-Gleichheitsanspruch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)