### PR TITLE
test(audit): GGUF fault injection + tokenizer robustness, 5 loader hardening fixes (Phase 2.6, risk #10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,7 @@ if(IMP_BUILD_TESTS)
         tests/test_tensor_kind_coverage.cpp
         tests/test_kv_cache.cpp
         tests/test_gguf_loader.cpp
+        tests/test_gguf_fault_injection.cpp
         tests/test_llm_compressor_loader.cpp
         tests/test_hf_config_loader.cpp
         tests/test_safetensors_loader.cpp
@@ -447,6 +448,7 @@ if(IMP_BUILD_TESTS)
 
     imp_add_test_module(test-text SOURCES
         tests/test_tokenizer.cpp
+        tests/test_tokenizer_robustness.cpp
         tests/test_tokenizer_compat.cpp
         tests/test_chat_template.cpp
         tests/test_jinja.cpp

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -308,8 +308,12 @@ public:
     size_t remaining() const { return size_ - pos_; }
     const uint8_t* ptr() const { return data_ + pos_; }
     bool failed() const { return failed_; }
+    void fail() { failed_ = true; }
 
-    bool check(size_t n) const { return pos_ + n <= size_; }
+    // Bounds check for an n-byte read at the current cursor. Guards against
+    // pos_ + n overflowing on attacker-controlled u64 lengths (a wrapped sum
+    // would otherwise compare <= size_ and admit an out-of-bounds read).
+    bool check(size_t n) const { return n <= size_ - pos_; }
 
     void skip(size_t n) {
         if (!check(n)) {
@@ -356,8 +360,14 @@ public:
 
     std::string read_string() {
         uint64_t len = read_u64();
-        if (!check(len))
+        // A length that runs past EOF (incl. an absurd 2^60-style value) is a
+        // hard parse error, not a recoverable empty string: returning "" here
+        // would leave the cursor desynced and let the caller keep parsing
+        // garbage. Flag failure so the surrounding loop stops.
+        if (failed_ || len > remaining()) {
+            failed_ = true;
             return "";
+        }
         std::string s(reinterpret_cast<const char*>(data_ + pos_), static_cast<size_t>(len));
         pos_ += static_cast<size_t>(len);
         return s;
@@ -457,9 +467,11 @@ static GGUFValue read_gguf_value(BinaryReader& r, GGUFValueType type) {
                     r, count, v.int_array,
                     [](BinaryReader& br) { return static_cast<int32_t>(br.read_u8()); }, 1);
             } else {
-                // Skip unknown array element types
-                for (uint64_t i = 0; i < count && !r.failed(); i++)
-                    read_gguf_value(r, arr_type);
+                // Unknown/unsupported array element type. read_gguf_value()'s
+                // switch has no default, so it would consume zero bytes per
+                // element — a `count` of 2^60 would then spin ~forever without
+                // ever tripping the EOF guard. Treat it as a parse error.
+                r.fail();
             }
             break;
         }
@@ -828,6 +840,44 @@ static void parse_tensor_infos(BinaryReader& reader, uint64_t tensor_count,
     }
 }
 
+// ---- Tensor on-disk byte span ----
+
+// Total bytes a tensor occupies in the file, with saturating arithmetic so a
+// crafted dim product (e.g. ne[0]*ne[1] overflowing int64) can never wrap to a
+// small value that then passes the bounds check. Returns SIZE_MAX on overflow,
+// which makes the caller reject the tensor.
+static size_t gguf_tensor_byte_size(const GGUFTensorInfo& info) {
+    uint64_t n_elements = 1;
+    for (uint32_t d = 0; d < info.n_dims && d < 4; d++) {
+        int64_t dim = info.dims[d];
+        if (dim < 0)
+            return SIZE_MAX;  // negative/huge dim — reject
+        uint64_t ud = static_cast<uint64_t>(dim);
+        if (ud != 0 && n_elements > UINT64_MAX / ud)
+            return SIZE_MAX;  // multiply would overflow
+        n_elements *= ud;
+    }
+    int bs = gguf_blck_size(info.type);
+    size_t ts = gguf_type_size(info.type);
+    if (bs <= 0 || ts == 0)
+        return SIZE_MAX;  // unknown / unsupported quant type
+    uint64_t n_blocks = (n_elements + static_cast<uint64_t>(bs) - 1) / static_cast<uint64_t>(bs);
+    if (n_blocks != 0 && ts > UINT64_MAX / n_blocks)
+        return SIZE_MAX;
+    return static_cast<size_t>(n_blocks * ts);
+}
+
+// True iff the tensor's [offset, offset+size) window lies fully inside its
+// shard's data region (data_limit bytes from data_base).
+static bool gguf_tensor_in_bounds(const GGUFTensorInfo& info) {
+    size_t size = gguf_tensor_byte_size(info);
+    if (size == SIZE_MAX)
+        return false;
+    if (info.offset > info.data_limit)
+        return false;
+    return size <= info.data_limit - info.offset;
+}
+
 // ---- Main GGUF loader ----
 
 std::unique_ptr<Model> load_gguf(const std::string& path) {
@@ -894,7 +944,11 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
 
     // 3. Parse metadata key-value pairs
     std::unordered_map<std::string, GGUFValue> metadata;
-    metadata.reserve(static_cast<size_t>(kv_count));
+    // Clamp the reserve to what the file could physically hold (each KV pair is
+    // at least a 8-byte string-length prefix + 4-byte type tag = 12 bytes).
+    // Without this, a corrupt kv_count=2^60 would reserve petabytes and OOM
+    // before a single read ever fails.
+    metadata.reserve(std::min<uint64_t>(kv_count, reader.remaining() / 12));
 
     for (uint64_t i = 0; i < kv_count && !reader.failed(); i++) {
         std::string key = reader.read_string();
@@ -911,7 +965,10 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
 
     // 4. Parse tensor info entries
     std::vector<GGUFTensorInfo> tensor_infos;
-    tensor_infos.reserve(static_cast<size_t>(tensor_count));
+    // Clamp like the metadata reserve above: a tensor-info entry is at least
+    // name-len(8) + n_dims(4) + type(4) + offset(8) = 24 bytes, so a corrupt
+    // tensor_count cannot drive an unbounded allocation.
+    tensor_infos.reserve(std::min<uint64_t>(tensor_count, reader.remaining() / 24));
     parse_tensor_infos(reader, tensor_count, tensor_infos);
 
     if (reader.failed()) {
@@ -934,9 +991,13 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
 
     IMP_LOG_DEBUG("Tensor data starts at offset %zu (alignment=%zu)", tensor_data_start, alignment);
 
-    // Set data_base for primary shard tensors
+    // Set data_base for primary shard tensors. data_limit = bytes of mapped
+    // file available past the tensor-data section, used to bounds-check each
+    // tensor's [offset, offset+size) window before we hand out a raw pointer.
+    size_t primary_data_avail = (tensor_data_start <= file_size) ? file_size - tensor_data_start : 0;
     for (auto& info : tensor_infos) {
         info.data_base = data + tensor_data_start;
+        info.data_limit = primary_data_avail;
     }
 
     // 5b. Handle split GGUF files (multiple shards)
@@ -1024,8 +1085,10 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
 
                 // Set data_base for this shard's tensors
                 size_t shard_tensor_start = tensor_infos.size() - static_cast<size_t>(stensor_count);
+                size_t shard_data_avail = (shard_data_start <= shard_size) ? shard_size - shard_data_start : 0;
                 for (size_t ti = shard_tensor_start; ti < tensor_infos.size(); ti++) {
                     tensor_infos[ti].data_base = sdata + shard_data_start;
+                    tensor_infos[ti].data_limit = shard_data_avail;
                 }
 
                 IMP_LOG_INFO("  Shard %d: %lu tensors, %.1f MiB", shard, (unsigned long)stensor_count,
@@ -1357,6 +1420,20 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
     int assigned = 0, skipped = 0;
 
     for (const auto& info : tensor_infos) {
+        // Reject tensors whose [offset, offset+size) window escapes the mapped
+        // file before we ever form a pointer into it. A corrupt offset or a
+        // dim product that overflows would otherwise yield a wild pointer that
+        // weight_upload later reads — an out-of-bounds read / crash on a
+        // malformed file. Skipping leaves the slot null; downstream load fails
+        // cleanly (missing-weight path) instead of faulting.
+        if (!gguf_tensor_in_bounds(info)) {
+            IMP_LOG_ERROR(
+                "GGUF tensor '%s' out of bounds (offset=%lu, limit=%zu) — skipping; file is corrupt",
+                info.name.c_str(), (unsigned long)info.offset, info.data_limit);
+            skipped++;
+            continue;
+        }
+
         // Compute pointer into mmap'd data (supports split GGUF via per-tensor data_base)
         auto* tensor_data = const_cast<void*>(static_cast<const void*>(info.data_base + info.offset));
 

--- a/src/model/gguf_loader.h
+++ b/src/model/gguf_loader.h
@@ -89,6 +89,7 @@ struct GGUFTensorInfo {
     GgufWireType type;
     uint64_t offset;                     // relative to start of tensor data section
     const uint8_t* data_base = nullptr;  // shard data base pointer (for split GGUF)
+    size_t data_limit = 0;               // bytes available from data_base (for bounds checks)
 };
 
 // Load a model from a GGUF file.

--- a/tests/test_gguf_fault_injection.cpp
+++ b/tests/test_gguf_fault_injection.cpp
@@ -1,0 +1,446 @@
+// GGUF loader fault-injection tests — TEST_AUDIT.md Phase 2, risk #10.
+//
+// Charter (risk #10): "header fault injection → clean error". The contract
+// under test is NOT that a malformed file loads correctly — it is that the
+// loader NEVER crashes, hangs, or allocates unbounded memory on adversarial
+// input. Internal errors may throw or return nullptr (both are "clean"); UB,
+// OOM, and infinite loops are the failures we hunt.
+//
+// Method: build a minimal VALID GGUF v3 byte buffer in-memory (one F32 tensor,
+// minimal llama metadata) that load_gguf() accepts, then inject ONE targeted
+// corruption per test and assert the loader rejects it gracefully. Each case
+// states, by hand, why the expected outcome is what it is. We compare against
+// the real loader, not a mock (audit §4).
+//
+// Several of these tests are REGRESSION tests for real weaknesses found while
+// writing them (length/count overflow, unknown-array-type spin, unbounded
+// reserve, unchecked tensor offsets). See the commit message / report.
+
+#include <gtest/gtest.h>
+#include "model/gguf_loader.h"
+#include "model/model.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+namespace imp {
+namespace {
+
+// ---- Minimal GGUF byte-buffer builder ----
+//
+// Produces a valid single-tensor GGUF v3 file. Field offsets of interest are
+// recorded so a test can patch exactly one value without rebuilding the rest.
+
+struct GgufBytes {
+    std::vector<uint8_t> buf;
+
+    // Recorded byte offsets into buf (set during build()).
+    size_t off_magic = 0;
+    size_t off_version = 0;
+    size_t off_tensor_count = 0;
+    size_t off_kv_count = 0;
+    size_t off_tensor_name_len = 0;   // u64 length prefix of the tensor's name
+    size_t off_tensor_dim0 = 0;       // u64 ne[0] of the tensor
+    size_t off_tensor_type = 0;       // u32 ggml type of the tensor
+    size_t off_tensor_data_offset = 0;  // u64 data-section-relative offset
+};
+
+class Writer {
+public:
+    explicit Writer(std::vector<uint8_t>& b) : b_(b) {}
+    size_t pos() const { return b_.size(); }
+    void u32(uint32_t v) { raw(&v, 4); }
+    void i32(int32_t v) { raw(&v, 4); }
+    void u64(uint64_t v) { raw(&v, 8); }
+    void f32(float v) { raw(&v, 4); }
+    void str(const std::string& s) {
+        u64(s.size());
+        raw(s.data(), s.size());
+    }
+    void raw(const void* p, size_t n) {
+        size_t at = b_.size();
+        b_.resize(at + n);
+        std::memcpy(b_.data() + at, p, n);
+    }
+    void pad_to(size_t align) {
+        while (b_.size() % align)
+            b_.push_back(0);
+    }
+
+private:
+    std::vector<uint8_t>& b_;
+};
+
+// GGUF metadata value types (subset)
+constexpr uint32_t T_UINT32 = 4;
+constexpr uint32_t T_STRING = 8;
+// GGML tensor type
+constexpr uint32_t GGML_F32 = 0;
+
+// One F32 tensor [4 x 4] = 16 elements = 64 bytes. Metadata is the minimum a
+// llama-family load needs to not get fully rejected on missing arch.
+GgufBytes build_valid_gguf() {
+    GgufBytes g;
+    Writer w(g.buf);
+
+    // --- header ---
+    g.off_magic = w.pos();
+    w.u32(GGUF_MAGIC);
+    g.off_version = w.pos();
+    w.u32(3);
+    g.off_tensor_count = w.pos();
+    w.u64(1);  // one tensor
+    g.off_kv_count = w.pos();
+    w.u64(2);  // two KV pairs
+
+    // --- metadata KV pairs ---
+    // general.architecture = "llama"
+    w.str("general.architecture");
+    w.u32(T_STRING);
+    w.str("llama");
+    // llama.block_count = 0  (no layers — keeps the model trivially small)
+    w.str("llama.block_count");
+    w.u32(T_UINT32);
+    w.u32(0);
+
+    // --- tensor info ---
+    g.off_tensor_name_len = w.pos();
+    w.str("token_embd.weight");
+    w.u32(2);  // n_dims
+    g.off_tensor_dim0 = w.pos();
+    w.u64(4);  // ne[0]
+    w.u64(4);  // ne[1]
+    g.off_tensor_type = w.pos();
+    w.u32(GGML_F32);
+    g.off_tensor_data_offset = w.pos();
+    w.u64(0);  // data offset (relative to aligned tensor-data start)
+
+    // --- align + tensor data (16 floats) ---
+    w.pad_to(GGUF_DEFAULT_ALIGNMENT);
+    for (int i = 0; i < 16; i++)
+        w.f32(0.01f * static_cast<float>(i));
+
+    return g;
+}
+
+std::string write_temp(const std::vector<uint8_t>& data) {
+    char path[] = "/tmp/imp_fault_XXXXXX.gguf";
+    int fd = mkstemps(path, 5);
+    if (fd < 0)
+        return "";
+    ssize_t n = write(fd, data.data(), data.size());
+    (void)n;
+    close(fd);
+    return std::string(path);
+}
+
+// Run load_gguf on a buffer and return whether it crashed-free. Wraps the
+// throw→nullptr ambiguity: a clean error is EITHER nullptr OR a thrown
+// exception we catch here. The only failure is a crash/hang (which GTest would
+// surface as a SIGSEGV/timeout, not a returned value).
+bool load_is_clean(const std::vector<uint8_t>& data) {
+    std::string path = write_temp(data);
+    if (path.empty())
+        return false;
+    bool clean = true;
+    try {
+        auto model = load_gguf(path);
+        // nullptr or a model are both "clean" — we only assert no crash. A
+        // model returned from a corrupt-but-survivable file is acceptable as
+        // long as it didn't fault building it.
+        (void)model;
+    } catch (...) {
+        // Throwing is the documented internal-error channel (translated to
+        // ImpError at the API boundary). Catching here proves we unwound
+        // rather than faulted.
+        clean = true;
+    }
+    unlink(path.c_str());
+    return clean;
+}
+
+// Load a buffer and return the model (may be nullptr). Used by the bounds
+// tests to assert the OBSERVABLE consequence of the fix: a tensor whose data
+// window escapes the file is SKIPPED, so token_embedding().data stays null —
+// the unfixed loader instead assigns a wild pointer (non-null). This is the
+// non-tautological discriminator between fixed and unfixed.
+std::unique_ptr<Model> load_buf(const std::vector<uint8_t>& data) {
+    std::string path = write_temp(data);
+    if (path.empty())
+        return nullptr;
+    std::unique_ptr<Model> m;
+    try {
+        m = load_gguf(path);
+    } catch (...) {
+        m = nullptr;
+    }
+    unlink(path.c_str());
+    return m;
+}
+
+void patch_u64(std::vector<uint8_t>& buf, size_t off, uint64_t v) {
+    std::memcpy(buf.data() + off, &v, 8);
+}
+void patch_u32(std::vector<uint8_t>& buf, size_t off, uint32_t v) {
+    std::memcpy(buf.data() + off, &v, 4);
+}
+
+// ---- Sanity: the baseline buffer actually loads ----
+
+TEST(GgufFaultInjection, ValidBaselineLoads) {
+    // If this fails, every corruption test below is vacuous (the input was
+    // never valid to begin with). This is the anti-tautology anchor.
+    GgufBytes g = build_valid_gguf();
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    auto model = load_gguf(path);
+    EXPECT_NE(model, nullptr) << "baseline GGUF must load, else corruption tests are meaningless";
+    unlink(path.c_str());
+}
+
+// ---- Magic / version ----
+
+TEST(GgufFaultInjection, BadMagic) {
+    // Wrong magic → load_gguf checks magic first and bails. Expect nullptr:
+    // there is no recovery from a non-GGUF file.
+    GgufBytes g = build_valid_gguf();
+    patch_u32(g.buf, g.off_magic, 0xDEADBEEF);
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    EXPECT_EQ(load_gguf(path), nullptr);
+    unlink(path.c_str());
+}
+
+TEST(GgufFaultInjection, BadVersion) {
+    // Only v2/v3 supported. v1 and v999 must be rejected (nullptr), never
+    // parsed with v3 field layout assumptions.
+    for (uint32_t ver : {0u, 1u, 4u, 999u, 0xFFFFFFFFu}) {
+        GgufBytes g = build_valid_gguf();
+        patch_u32(g.buf, g.off_version, ver);
+        std::string path = write_temp(g.buf);
+        ASSERT_FALSE(path.empty());
+        EXPECT_EQ(load_gguf(path), nullptr) << "version " << ver << " must be rejected";
+        unlink(path.c_str());
+    }
+}
+
+// ---- Truncation ----
+
+TEST(GgufFaultInjection, TruncatedHeader) {
+    // File cut to 8 bytes (magic+version present, counts missing). The u64
+    // reads for tensor_count/kv_count must fail the EOF check → nullptr.
+    GgufBytes g = build_valid_gguf();
+    g.buf.resize(8);
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    EXPECT_EQ(load_gguf(path), nullptr);
+    unlink(path.c_str());
+}
+
+TEST(GgufFaultInjection, TruncatedMidMetadata) {
+    // Cut the file in the middle of the metadata section (after the header but
+    // before the second KV pair completes). read_string / read_u32 must hit
+    // EOF and the metadata loop must terminate with reader.failed() → nullptr.
+    GgufBytes g = build_valid_gguf();
+    // off_tensor_name_len marks the end of metadata; cut a few bytes before it.
+    ASSERT_GT(g.off_tensor_name_len, 4u);
+    g.buf.resize(g.off_tensor_name_len - 4);
+    EXPECT_TRUE(load_is_clean(g.buf));
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    EXPECT_EQ(load_gguf(path), nullptr);
+    unlink(path.c_str());
+}
+
+TEST(GgufFaultInjection, TruncatedMidTensorData) {
+    // Header + metadata + tensor-info intact, but the tensor's data bytes are
+    // cut short. The tensor claims 64 bytes; we leave only 8. The bounds check
+    // must reject the tensor (offset+size escapes the mapped region) instead
+    // of handing weight_upload a pointer that reads off the end of the file.
+    GgufBytes g = build_valid_gguf();
+    // Keep everything up to ~16 bytes into the data section, drop the rest.
+    size_t keep = g.off_tensor_data_offset + 8 + 16;  // through offset field + a little data
+    if (keep < g.buf.size())
+        g.buf.resize(keep);
+    EXPECT_TRUE(load_is_clean(g.buf));
+}
+
+// ---- Absurd counts (must not allocate-to-OOM) ----
+
+TEST(GgufFaultInjection, HugeKvCount) {
+    // kv_count = 2^60 with a tiny file. Pre-fix, metadata.reserve(2^60) would
+    // attempt to allocate petabytes → bad_alloc / OOM-kill before any read.
+    // Post-fix the reserve is clamped to remaining()/12 and the first KV read
+    // fails on EOF → clean nullptr.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_kv_count, (uint64_t{1} << 60));
+    EXPECT_TRUE(load_is_clean(g.buf));
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    EXPECT_EQ(load_gguf(path), nullptr);
+    unlink(path.c_str());
+}
+
+TEST(GgufFaultInjection, HugeTensorCount) {
+    // tensor_count = 2^60. Same class as HugeKvCount but for the tensor-info
+    // reserve. Must not OOM; must fail cleanly.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_count, (uint64_t{1} << 60));
+    EXPECT_TRUE(load_is_clean(g.buf));
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    EXPECT_EQ(load_gguf(path), nullptr);
+    unlink(path.c_str());
+}
+
+TEST(GgufFaultInjection, MaxU64TensorCount) {
+    // tensor_count = UINT64_MAX. Stresses the reserve clamp and the parse loop
+    // bound simultaneously; the loop must stop on the first failed read.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_count, UINT64_MAX);
+    EXPECT_TRUE(load_is_clean(g.buf));
+}
+
+// ---- String length past EOF / overflow ----
+
+TEST(GgufFaultInjection, StringLengthPastEof) {
+    // The tensor-name length prefix is set to a value larger than the file.
+    // read_string's bounds check must reject it (set failed_) rather than
+    // construct a std::string spanning past the mmap.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_name_len, 1'000'000'000ULL);
+    EXPECT_TRUE(load_is_clean(g.buf));
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    EXPECT_EQ(load_gguf(path), nullptr);
+    unlink(path.c_str());
+}
+
+TEST(GgufFaultInjection, StringLengthOverflow) {
+    // Length = UINT64_MAX. Pre-fix, `pos_ + len <= size_` wrapped around and
+    // admitted the read → a ~2^64-byte std::string construction → crash. The
+    // overflow-safe check (`len <= remaining()`) must reject it.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_name_len, UINT64_MAX);
+    EXPECT_TRUE(load_is_clean(g.buf));
+}
+
+// ---- Unknown array element type (infinite-loop guard) ----
+
+TEST(GgufFaultInjection, UnknownArrayElementTypeHugeCount) {
+    // Build a file whose single KV value is an ARRAY whose element type is an
+    // unknown/unsupported enum (99) with count = 2^60. read_gguf_value's switch
+    // has no default → it consumes 0 bytes per element. Pre-fix the loop would
+    // spin 2^60 times (~forever). Post-fix the unknown element type fails the
+    // reader immediately. We assert it returns within a generous time bound.
+    constexpr uint32_t T_ARRAY = 9;
+    GgufBytes g;
+    Writer w(g.buf);
+    w.u32(GGUF_MAGIC);
+    w.u32(3);
+    w.u64(0);  // tensor_count
+    w.u64(1);  // kv_count
+    // one KV: key="bad", value = ARRAY<unknown=99>[2^60]
+    w.str("bad");
+    w.u32(T_ARRAY);
+    w.u32(99);                    // element type — not a real GGUFValueType
+    w.u64(uint64_t{1} << 60);     // count
+
+    auto start = std::chrono::steady_clock::now();
+    std::string path = write_temp(g.buf);
+    ASSERT_FALSE(path.empty());
+    auto model = load_gguf(path);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    unlink(path.c_str());
+    (void)model;
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), 5)
+        << "unknown array element type with huge count must not spin";
+}
+
+// ---- Tensor offset / dim corruption ----
+
+TEST(GgufFaultInjection, TensorOffsetPastEof) {
+    // Set token_embd.weight's data offset far beyond the file. data_base+offset
+    // would point past the mmap. The bounds check must SKIP the tensor — the
+    // unfixed loader instead hands weight_upload a wild pointer (an OOB read /
+    // GPU fault on a real model). Observable here: the embedding stays unset.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_data_offset, 1'000'000'000ULL);
+    auto m = load_buf(g.buf);
+    ASSERT_NE(m, nullptr);
+    EXPECT_EQ(m->token_embedding().data, nullptr) << "out-of-bounds tensor must be skipped, not assigned";
+}
+
+TEST(GgufFaultInjection, TensorOffsetMaxU64) {
+    // Offset = UINT64_MAX: data_base + offset overflows the pointer. The bounds
+    // check (offset > data_limit) rejects it before the addition is ever used.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_data_offset, UINT64_MAX);
+    auto m = load_buf(g.buf);
+    ASSERT_NE(m, nullptr);
+    EXPECT_EQ(m->token_embedding().data, nullptr);
+}
+
+TEST(GgufFaultInjection, TensorDimOverflow) {
+    // ne[0] = 2^40 and ne[1] = 2^40 → element count overflows int64 and the
+    // byte size overflows size_t. The saturating size computation must return
+    // SIZE_MAX and the tensor must be rejected (not wrap to a small "valid"
+    // size that then passes the bounds check and yields a wild pointer).
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_dim0, uint64_t{1} << 40);
+    patch_u64(g.buf, g.off_tensor_dim0 + 8, uint64_t{1} << 40);
+    auto m = load_buf(g.buf);
+    ASSERT_NE(m, nullptr);
+    EXPECT_EQ(m->token_embedding().data, nullptr) << "overflowing-size tensor must be skipped";
+}
+
+TEST(GgufFaultInjection, TensorDimNegative) {
+    // A dim with the high bit set reads back as a negative int64. The size
+    // computation must treat it as invalid (reject), not compute a bogus span.
+    GgufBytes g = build_valid_gguf();
+    patch_u64(g.buf, g.off_tensor_dim0, uint64_t{0x8000000000000000ULL});
+    auto m = load_buf(g.buf);
+    ASSERT_NE(m, nullptr);
+    EXPECT_EQ(m->token_embedding().data, nullptr);
+}
+
+TEST(GgufFaultInjection, NonexistentTensorType) {
+    // ggml type id = 9999 (no such quant). gguf_blck_size/gguf_type_size return
+    // 0 for unknown types → byte-size computation returns SIZE_MAX → tensor
+    // rejected (also guards against a divide-by-zero on block size 0).
+    GgufBytes g = build_valid_gguf();
+    patch_u32(g.buf, g.off_tensor_type, 9999);
+    auto m = load_buf(g.buf);
+    ASSERT_NE(m, nullptr);
+    EXPECT_EQ(m->token_embedding().data, nullptr) << "unknown-type tensor must be skipped";
+}
+
+// ---- Alignment abuse ----
+
+TEST(GgufFaultInjection, ZeroAlignmentMetadata) {
+    // general.alignment = 0 would make `pos_ % 0` a divide-by-zero in the
+    // reader's align(). The loader guards alignment==0 → falls back to the
+    // default. We inject it by appending a KV; simplest is to rebuild with an
+    // alignment KV. Here we assert the guard via a from-scratch buffer.
+    constexpr uint32_t T_U32 = 4;
+    GgufBytes g;
+    Writer w(g.buf);
+    w.u32(GGUF_MAGIC);
+    w.u32(3);
+    w.u64(0);  // tensor_count
+    w.u64(2);  // kv_count
+    w.str("general.architecture");
+    w.u32(T_STRING);
+    w.str("llama");
+    w.str("general.alignment");
+    w.u32(T_U32);
+    w.u32(0);  // zero alignment — must not crash the align() modulo
+    EXPECT_TRUE(load_is_clean(g.buf));
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_tokenizer_robustness.cpp
+++ b/tests/test_tokenizer_robustness.cpp
@@ -1,0 +1,322 @@
+// Tokenizer robustness / round-trip tests — TEST_AUDIT.md Phase 2, risk #10.
+//
+// The #510 class (NUL string terminators leaking into SSE deltas) lived in the
+// special-token / byte rendering paths. These tests pin the contract that
+// matters there: for a byte-level (GPT2) tokenizer, encode∘decode is the
+// IDENTITY on arbitrary byte content — including embedded NUL, lone surrogate
+// bytes (invalid UTF-8), 2/3/4-byte UTF-8, emoji + ZWJ, and long runs — and
+// that boundary token ids (negative, 0, vocab_size, vocab_size-1) decode to ""
+// without faulting.
+//
+// Why GPT2 for the identity assertions: byte-level BPE has a total byte→token
+// mapping (every one of 256 bytes is a token), so the round-trip is exact by
+// construction. SPM with a tiny synthetic vocab only round-trips via byte
+// fallback and applies documented normalization (▁→space), so for SPM we assert
+// the WEAKER, documented contract (no crash + non-empty decode), matching the
+// existing suite's stance. Special-token-as-text behavior is asserted as the
+// actual contract (CONTROL pre-split), not a wished-for one.
+
+#include "model/tokenizer.h"
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// ---- Full byte-level GPT2 fixture (256 byte tokens, no merges) ----
+//
+// With every byte mapped to its own token and no merge rules, encode produces
+// one token per byte and decode reverses it exactly. This makes the round-trip
+// the cleanest possible identity oracle for "any bytes in → same bytes out".
+
+static std::string codepoint_to_utf8(uint32_t cp) {
+    std::string s;
+    if (cp < 0x80) {
+        s += static_cast<char>(cp);
+    } else if (cp < 0x800) {
+        s += static_cast<char>(0xC0 | (cp >> 6));
+        s += static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp < 0x10000) {
+        s += static_cast<char>(0xE0 | (cp >> 12));
+        s += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+        s += static_cast<char>(0x80 | (cp & 0x3F));
+    }
+    return s;
+}
+
+// GPT2 byte→codepoint table (must match tokenizer.cpp's byte_to_gpt2 mapping).
+static const uint32_t BYTE_TO_CP[256] = {
+    256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275,
+    276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 33,  34,  35,  36,  37,  38,  39,
+    40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+    60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
+    80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
+    100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+    120, 121, 122, 123, 124, 125, 126, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301,
+    302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321,
+    322, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 323, 174, 175, 176, 177, 178, 179,
+    180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,
+    200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
+    220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+    240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255,
+};
+
+static Tokenizer make_byte_gpt2_tokenizer() {
+    std::vector<std::string> tokens;
+    std::vector<float> scores;
+    tokens.push_back("<unk>");
+    scores.push_back(0.0f);
+    tokens.push_back("<s>");
+    scores.push_back(0.0f);
+    tokens.push_back("</s>");
+    scores.push_back(0.0f);
+    // ids 3..258: one token per byte value
+    for (int b = 0; b < 256; b++) {
+        tokens.push_back(codepoint_to_utf8(BYTE_TO_CP[b]));
+        scores.push_back(0.0f);
+    }
+    Tokenizer tok;
+    tok.load_vocab(tokens, scores, /*bos_id=*/1, /*eos_id=*/2);
+    tok.set_type("gpt2");
+    tok.set_add_bos(false);
+    tok.load_merges({});  // no merges → exactly one token per byte
+    return tok;
+}
+
+// Encode then decode; assert byte-exact identity.
+static void expect_roundtrip(const Tokenizer& tok, const std::string& s, const char* what) {
+    auto ids = tok.encode(s);
+    std::string back = tok.decode(ids);
+    EXPECT_EQ(back, s) << "round-trip mismatch for: " << what;
+}
+
+// ---- Byte-exact round-trip identity (GPT2 byte-level) ----
+
+TEST(TokenizerRobustness, RoundtripASCII) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    expect_roundtrip(tok, "Hello, World! 0123456789", "ascii");
+}
+
+TEST(TokenizerRobustness, RoundtripUtf8TwoByte) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    // German umlauts + sharp s: ä ö ü ß — all 2-byte UTF-8.
+    expect_roundtrip(tok, "Gr\xc3\xbc\xc3\x9fe \xc3\xa4\xc3\xb6\xc3\xbc", "utf8 2-byte");
+}
+
+TEST(TokenizerRobustness, RoundtripUtf8ThreeByte) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    // CJK "你好世界" — each char 3-byte UTF-8.
+    expect_roundtrip(tok, "\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c", "utf8 3-byte");
+}
+
+TEST(TokenizerRobustness, RoundtripUtf8FourByteEmoji) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    // 🌍 (U+1F30D) — 4-byte UTF-8.
+    expect_roundtrip(tok, "earth \xf0\x9f\x8c\x8d done", "utf8 4-byte emoji");
+}
+
+TEST(TokenizerRobustness, RoundtripEmojiZWJSequence) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    // 👩‍💻 = woman (U+1F469) + ZWJ (U+200D) + laptop (U+1F4BB). The ZWJ
+    // (E2 80 8D) is the exact kind of invisible joiner that special-token
+    // rendering paths mishandle. Byte-level must reproduce every byte.
+    expect_roundtrip(tok, "\xf0\x9f\x91\xa9\xe2\x80\x8d\xf0\x9f\x92\xbb", "emoji ZWJ sequence");
+}
+
+TEST(TokenizerRobustness, RoundtripEmbeddedNUL) {
+    // THE #510 class: a NUL byte in the middle of the text. std::string holds
+    // it fine; the tokenizer must encode it as the byte-0 token and decode it
+    // back — not truncate at the NUL nor leak a stray terminator.
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    std::string s("a\0b", 3);  // explicit length: "a", NUL, "b"
+    ASSERT_EQ(s.size(), 3u);
+    auto ids = tok.encode(s);
+    std::string back = tok.decode(ids);
+    ASSERT_EQ(back.size(), 3u) << "NUL byte was dropped or string truncated";
+    EXPECT_EQ(back, s);
+    EXPECT_EQ(back[1], '\0');
+}
+
+TEST(TokenizerRobustness, RoundtripAllNULRun) {
+    // A run of pure NUL bytes — stresses the "empty-looking but non-empty"
+    // edge where C-string logic would see length 0.
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    std::string s(8, '\0');
+    auto ids = tok.encode(s);
+    std::string back = tok.decode(ids);
+    EXPECT_EQ(back, s);
+    EXPECT_EQ(back.size(), 8u);
+}
+
+TEST(TokenizerRobustness, RoundtripLoneSurrogateBytes) {
+    // Invalid UTF-8: bytes 0xED 0xA0 0x80 are the encoding of a lone high
+    // surrogate (U+D800), which is NOT valid UTF-8. A byte-level tokenizer has
+    // no notion of validity — it must pass the raw bytes through unchanged and
+    // not crash on the malformed sequence. Defined behavior = identity.
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    std::string s("x\xed\xa0\x80y", 5);
+    auto ids = tok.encode(s);
+    std::string back = tok.decode(ids);
+    EXPECT_EQ(back, s);
+}
+
+TEST(TokenizerRobustness, RoundtripAllSingleBytes) {
+    // Every one of the 256 byte values, individually, round-trips to itself.
+    // This is the exhaustive form of the NUL test and the strongest possible
+    // identity assertion for the byte path.
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    for (int b = 0; b < 256; b++) {
+        std::string s(1, static_cast<char>(b));
+        auto ids = tok.encode(s);
+        std::string back = tok.decode(ids);
+        EXPECT_EQ(back, s) << "byte 0x" << std::hex << b << " did not round-trip";
+    }
+}
+
+TEST(TokenizerRobustness, RoundtripLongWhitespaceRun) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    // Long run of spaces + tabs + newlines. Whitespace handling in the
+    // pre-tokenizer is a common place to lose or duplicate bytes.
+    std::string s;
+    for (int i = 0; i < 200; i++)
+        s += " \t\n";
+    expect_roundtrip(tok, s, "long whitespace run");
+}
+
+TEST(TokenizerRobustness, RoundtripVeryLongToken) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    // A 5000-byte run of a single non-space byte (one "word"): exercises the
+    // BPE inner loop's allocation/linked-list path at scale without merges.
+    std::string s(5000, 'Z');
+    expect_roundtrip(tok, s, "very long single token");
+}
+
+// ---- Boundary token-id decode (must never fault) ----
+
+TEST(TokenizerRobustness, DecodeBoundaryIdsNoCrash) {
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    const int vs = tok.vocab_size();
+    ASSERT_GT(vs, 0);
+    // Out-of-range ids must decode to "" (the documented guard), never index
+    // out of bounds. -1, vocab_size, and a far-out id are all invalid.
+    EXPECT_EQ(tok.decode_token(-1), "");
+    EXPECT_EQ(tok.decode_token(vs), "");
+    EXPECT_EQ(tok.decode_token(vs + 1000), "");
+    EXPECT_EQ(tok.decode_token(INT32_MIN), "");
+    EXPECT_EQ(tok.decode_token(INT32_MAX), "");
+    // Valid boundary ids must decode without faulting (content unimportant).
+    (void)tok.decode_token(0);
+    (void)tok.decode_token(vs - 1);
+}
+
+TEST(TokenizerRobustness, DecodeMixedValidInvalidIds) {
+    // A decode of a sequence containing out-of-range ids must skip them (each
+    // contributes "") and still emit the valid ones — no crash, no desync.
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    int a = tok.find_token(codepoint_to_utf8(BYTE_TO_CP['A']));
+    int b = tok.find_token(codepoint_to_utf8(BYTE_TO_CP['B']));
+    ASSERT_GE(a, 0);
+    ASSERT_GE(b, 0);
+    std::vector<int32_t> ids = {a, -5, b, tok.vocab_size() + 7, a};
+    std::string back = tok.decode(ids);
+    EXPECT_EQ(back, "ABA");
+}
+
+// ---- Special-token strings as TEXT input (contract pinning) ----
+//
+// These pin the ACTUAL behavior (audit §4: characterize, don't wish). The
+// contract differs by whether token_types_ marks a literal as CONTROL.
+
+TEST(TokenizerRobustness, LiteralMarkerWithoutControlIsPlainText) {
+    // No token_types loaded → special_pieces_ is empty → no pre-split. A
+    // literal "<think>" typed by a user is encoded as ordinary bytes and
+    // round-trips as text. CONTRACT: without CONTROL metadata, markers are
+    // NOT promoted to control tokens.
+    Tokenizer tok = make_byte_gpt2_tokenizer();
+    EXPECT_FALSE(tok.has_token_types());
+    std::string s = "say <think> literally";
+    auto ids = tok.encode(s);
+    std::string back = tok.decode(ids);
+    EXPECT_EQ(back, s);
+}
+
+TEST(TokenizerRobustness, LiteralMarkerWithControlIsPreSplit) {
+    // When "<think>" exists in the vocab AND is tagged CONTROL, the encoder
+    // pre-splits on it and emits its single control-token id for the literal
+    // substring. CONTRACT: this IS the documented behavior — a user who types
+    // the literal marker gets the control token. (Whether that is desirable is
+    // a policy question above the tokenizer; we pin the mechanism.)
+    std::vector<std::string> tokens;
+    std::vector<float> scores;
+    tokens.push_back("<unk>");
+    scores.push_back(0.0f);
+    tokens.push_back("<s>");
+    scores.push_back(0.0f);
+    tokens.push_back("</s>");
+    scores.push_back(0.0f);
+    for (int b = 0; b < 256; b++) {
+        tokens.push_back(codepoint_to_utf8(BYTE_TO_CP[b]));
+        scores.push_back(0.0f);
+    }
+    int think_id = static_cast<int>(tokens.size());
+    tokens.push_back("<think>");
+    scores.push_back(0.0f);
+
+    Tokenizer tok;
+    tok.load_vocab(tokens, scores, /*bos_id=*/1, /*eos_id=*/2);
+    tok.set_type("gpt2");
+    tok.set_add_bos(false);
+    tok.load_merges({});
+    // Mark <think> as CONTROL (type 3) — this builds special_pieces_.
+    std::vector<int32_t> types(tokens.size(), 1);
+    types[think_id] = 3;
+    tok.load_token_types(types);
+
+    auto ids = tok.encode("a<think>b");
+    // Expect: byte 'a', the single <think> control token, byte 'b'.
+    bool saw_think = false;
+    for (int32_t id : ids)
+        if (id == think_id)
+            saw_think = true;
+    EXPECT_TRUE(saw_think) << "CONTROL-tagged literal marker must encode as its control token";
+    // And decoding that control token renders the literal text back (the #510
+    // rendering surface): no stray NUL, exactly "<think>".
+    EXPECT_EQ(tok.decode_token(think_id), "<think>");
+}
+
+// ---- SPM weaker contract (documented normalization, no crash) ----
+
+TEST(TokenizerRobustness, SpmByteFallbackNoCrashOnArbitraryBytes) {
+    // SPM with a byte-fallback vocab: arbitrary bytes (incl. NUL and invalid
+    // UTF-8) must encode without crashing. We assert the documented weaker
+    // contract: round-trip reproduces the original bytes via byte fallback
+    // (SPM applies ▁→space normalization only to the space marker, absent here
+    // because add_space_prefix is off and the input has no ▁).
+    std::vector<std::string> tokens = {"<unk>", "<s>", "</s>"};
+    std::vector<float> scores = {0.0f, 0.0f, 0.0f};
+    int byte_base = static_cast<int>(tokens.size());
+    for (int b = 0; b < 256; b++) {
+        char buf[8];
+        std::snprintf(buf, sizeof(buf), "<0x%02X>", b);
+        tokens.push_back(buf);
+        scores.push_back(-10.0f);
+    }
+    (void)byte_base;
+    Tokenizer tok;
+    tok.load_vocab(tokens, scores, 1, 2);
+    tok.set_type("spm");
+    tok.set_add_bos(false);
+    tok.set_add_space_prefix(false);
+
+    std::string s("\x01\x02\xff\x00\x7f", 5);
+    auto ids = tok.encode(s);
+    ASSERT_FALSE(ids.empty());
+    std::string back = tok.decode(ids);
+    EXPECT_EQ(back, s) << "SPM byte fallback must reconstruct raw bytes";
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Was (TEST_AUDIT Phase 2.6 — Risk #10)

34 CPU-Tests (18 GGUF-Fault-Injection in test-core, 16 Tokenizer-Robustheit in test-text) gegen den ECHTEN Loader/Tokenizer — plus **5 reale Loader-Härtungs-Fixes**, die die Tests gegen den ungefixten Stand beweisbar fangen (Anti-Tautologie-Nachweis: Tests liefen gegen HEAD-ohne-Fix und schlugen an).

## Real gefundene Defekte (alle in `src/model/gguf_loader.cpp` gefixt)
1. **`bad_alloc`-Crash**: `reserve(kv_count)` / `reserve(tensor_count)` mit angreifer-kontrolliertem u64 (2^60) → unbegrenzte Allokation. Fix: Clamp auf `remaining()/min-entry-size`.
2. **Endlos-Hang**: unbekannter Array-Elementtyp konsumiert 0 Bytes/Element, Schleife läuft bis count≈2^60 (bei 15s SIGKILL abgebrochen). Fix: sofortiger Parse-Fehler.
3. **`check(n)` Integer-Overflow**: `pos_+n <= size_` wickelte bei ~2^64-Längen um → OOB-Reads zugelassen. Fix: overflow-sicher `n <= size_-pos_`.
4. **`read_string()` Cursor-Desync**: Länge über EOF gab still `""` zurück, Parser lief desynct weiter. Fix: `failed_`-Flag.
5. **Tensor-Offsets/Dims nie gegen file_size validiert**: korrupter Offset oder `ne[0]*ne[1]`-Overflow → wilder Pointer in `weight_upload`. Fix: saturierende `gguf_tensor_byte_size` + `data_limit` pro Tensor (inkl. Shards); OOB-Tensoren werden übersprungen.

## Tokenizer-Kontrakte gepinnt
Byte-Level-GPT2 = encode∘decode-Identität für alle 256 Bytes inkl. **NUL** (#510-Klasse), ZWJ, lone Surrogates, 2/3/4-Byte-UTF-8. Special-Marker als Text: ohne CONTROL-Typ bleibt `<think>` Klartext, mit CONTROL-Tag sauber gesplittet+dekodiert (kein Stray-NUL). Rand-IDs (−1, 0, vocab_size, INT32_MIN/MAX) → `""`, kein Crash.

Volle CPU-Unit-Suite nach den Fixes: null Failures, keine Regression. Nicht abdeckbar (begründet im Test): echter OOB-Fault in `weight_upload` (braucht GPU+Modell — Tests asserten das beobachtbare Skip), Split-GGUF-Shard-Fault-Injection (bräuchte reale Shard-Dateien).

🤖 Generated with [Claude Code](https://claude.com/claude-code)