### PR TITLE
test(audit): prefix-cache equivalence — unit green, E2E divergence proven (Phase 2.6, risk #7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ if(IMP_BUILD_TESTS)
         tests/test_kv_cache_write.cu
         tests/test_kv_gather.cu
         tests/test_green_ctx.cu
+        tests/test_prefix_cache_equiv.cpp
     )
 
     imp_add_test_module(test-moe-gdn SOURCES
@@ -550,6 +551,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mtp_forward.cpp
         tests/test_api_generate.cpp
         tests/test_engine_relaunch.cpp
+        tests/test_prefix_cache_e2e.cpp
     )
 
     set(IMP_TEST_BINARIES

--- a/tests/test_prefix_cache_e2e.cpp
+++ b/tests/test_prefix_cache_e2e.cpp
@@ -1,0 +1,192 @@
+// Prefix-cache E2E equivalence — TEST_AUDIT.md risk #7 (Phase 2.6).
+//
+// The unit tests (tests/test_prefix_cache_equiv.cpp) prove the KVCacheManager
+// hands back the same physical block with intact KV bytes. This file closes
+// the loop end-to-end through the REAL engine + a REAL model: with prefix
+// caching ON, a fresh-prefill generation and a prefix-cache-HIT generation of
+// the same greedy request must produce the SAME tokens. That equivalence is
+// the property that ships the feature; risk #7 calls the test "the enabler".
+//
+// Engine seam (verified in src/api/imp_api.cpp + src/runtime/engine*.cpp):
+//   The prefix cache is only populated when a request FINISHES naturally
+//   (engine step() → finish_request() → register_block_hashes() + cache the
+//   blocks). The manual token-level path (imp_prefill_with_params +
+//   imp_decode_step) never registers hashes, AND imp_context_reset()
+//   deliberately evicts ALL cached blocks. So the cache engages ONLY across
+//   two consecutive imp_generate() calls on the SAME context with NO reset
+//   between them: call 1 finishes and caches its prefix; call 2 hits it.
+//   We therefore drive imp_generate twice and rely on greedy determinism.
+//
+// Skipped without IMP_TEST_MODEL (no GPU model in CI).
+
+#include <gtest/gtest.h>
+#include "imp/imp.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+const char* model_path() { return std::getenv("IMP_TEST_MODEL"); }
+
+bool is_safetensors_dir(const std::string& p) {
+    return p.size() < 5 || p.substr(p.size() - 5) != ".gguf";
+}
+
+class PrefixCacheE2ETest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const char* path = model_path();
+        if (!path)
+            GTEST_SKIP() << "Set IMP_TEST_MODEL to run prefix-cache E2E equivalence";
+        path_ = path;
+        fmt_ = is_safetensors_dir(path_) ? IMP_FORMAT_SAFETENSORS : IMP_FORMAT_GGUF;
+        ASSERT_EQ(imp_model_load(path, fmt_, &model_), IMP_SUCCESS);
+    }
+
+    void TearDown() override {
+        if (ctx_) imp_context_free(ctx_);
+        if (model_) imp_model_free(model_);
+    }
+
+    // Create a context with prefix caching on/off. Single batch; CUDA graphs ON
+    // (production path) so the equivalence is asserted on the real decode loop.
+    void MakeContext(bool prefix_cache) {
+        ImpConfig cfg = imp_config_default();
+        cfg.max_seq_len = 1024;
+        cfg.max_batch_size = 1;
+        cfg.enable_cuda_graphs = 1;
+        cfg.use_prefix_caching = prefix_cache ? 1 : 0;
+        ASSERT_EQ(imp_context_create(model_, &cfg, &ctx_), IMP_SUCCESS);
+    }
+
+    // Greedy generation through imp_generate (the path that reaches
+    // finish_request → registers prefix hashes). Returns produced text.
+    std::string gen(const char* prompt, int max_tokens) {
+        ImpGenerateParams p = imp_generate_params_default();
+        p.temperature = 0.0f;
+        p.top_k = 1;
+        p.top_p = 1.0f;
+        p.seed = 42;
+        p.max_tokens = max_tokens;
+        p.ignore_eos = 0;  // allow natural finish so the prefix is registered+cached
+
+        std::string out(8192, '\0');
+        size_t out_len = 0;
+        EXPECT_EQ(imp_generate(ctx_, prompt, &p, out.data(), out.size(), &out_len), IMP_SUCCESS);
+        out.resize(out_len);
+        return out;
+    }
+
+    std::string path_;
+    ImpModelFormat fmt_ = IMP_FORMAT_GGUF;
+    ImpModel model_ = nullptr;
+    ImpContext ctx_ = nullptr;
+};
+
+// A long, multi-block prompt so prefix caching has ≥2 full blocks to reuse.
+// Raw completion prompt (no chat template) — template churn is irrelevant here.
+constexpr const char* kPrompt =
+    "The history of computing begins long before electronic machines. Ancient "
+    "civilizations used counting tools, and over centuries mathematicians built "
+    "mechanical aids. In the twentieth century, the first programmable computers "
+    "appeared. Summarize the key idea in one sentence:";
+
+constexpr int kGen = 24;
+
+// 0. CONTROL: with caching OFF, two consecutive greedy imp_generate calls on
+//    the same context must already be identical. If THIS fails, back-to-back
+//    divergence is a cross-request engine property (sampler state, KV reuse,
+//    allocator layout ...) and tests 1-3 cannot attribute anything to the
+//    prefix cache. Discriminates "cache corrupts KV" from "second request
+//    differs regardless".
+TEST_F(PrefixCacheE2ETest, ControlNoCacheBackToBackIsDeterministic) {
+    MakeContext(/*prefix_cache=*/false);
+
+    std::string first = gen(kPrompt, kGen);
+    std::string second = gen(kPrompt, kGen);
+
+    ASSERT_FALSE(first.empty()) << "model produced no output";
+    EXPECT_EQ(first, second)
+        << "back-to-back greedy requests diverge WITHOUT prefix caching —\n"
+           "cross-request nondeterminism in the engine itself; the prefix-cache\n"
+           "equivalence tests below cannot run until this holds:\n  run1: "
+        << first << "\n  run2: " << second;
+}
+
+// =============================================================================
+// Tests 1-3 are DISABLED: they FAIL against the current engine — the
+// prefix-cache hit DIVERGES from the fresh prefill under greedy decoding
+// (verified 2026-06-04, Qwen3-8B-Q8_0, CUDA graphs ON; diverges ~15 tokens
+// in: "...computing starting from ancient times up to the" vs "...computing.
+// Let me start by recalling the"). The control test above passes, so the
+// divergence is attributable to the cache path, and the unit tests prove the
+// manager returns the right blocks with intact bytes — the corruption is in
+// the engine integration of a cache hit (partial-block resume / position
+// bookkeeping are the prime suspects). Tracked in issue #536; flip DISABLED_ off when fixing — these tests ARE the
+// feature's ship gate (TEST_AUDIT risk #7: "the test IS the enabler").
+// =============================================================================
+// 1. Fresh-prefill vs prefix-cache-HIT must be token-identical.
+//    Same context, prefix caching ON, NO reset between calls: call 1 prefills
+//    fresh and caches its prefix on finish; call 2 hits the cached prefix.
+//    Greedy ⇒ the two outputs must be byte-identical. A mismatch is exactly the
+//    silent-determinism failure that keeps the feature off-by-default.
+TEST_F(PrefixCacheE2ETest, DISABLED_FreshVsPrefixHitTokenEqual) {
+    MakeContext(/*prefix_cache=*/true);
+
+    std::string first = gen(kPrompt, kGen);   // fresh prefill, caches prefix on finish
+    std::string second = gen(kPrompt, kGen);  // hits the cached prefix
+
+    ASSERT_FALSE(first.empty()) << "model produced no output";
+    EXPECT_EQ(first, second)
+        << "PREFIX-CACHE HIT DIVERGED FROM FRESH PREFILL (greedy):\n  fresh: " << first
+        << "\n  hit:   " << second
+        << "\nThis is the determinism failure risk #7 names — the cached KV does "
+           "not reproduce the fresh forward pass.";
+}
+
+// 2. Cross-context equivalence: prefix-cache-ON output == prefix-cache-OFF
+//    output for the same greedy request. This pins the cache path to the
+//    canonical fresh-prefill result, not merely to "self-consistent".
+TEST_F(PrefixCacheE2ETest, DISABLED_PrefixCacheMatchesNoCacheBaseline) {
+    // Baseline: caching OFF.
+    MakeContext(/*prefix_cache=*/false);
+    std::string baseline = gen(kPrompt, kGen);
+    imp_context_free(ctx_);
+    ctx_ = nullptr;
+
+    // Caching ON, warm the cache, then the hit run.
+    MakeContext(/*prefix_cache=*/true);
+    (void)gen(kPrompt, kGen);             // warm: caches the prefix
+    std::string cached = gen(kPrompt, kGen);  // prefix-cache hit
+
+    ASSERT_FALSE(baseline.empty());
+    EXPECT_EQ(baseline, cached)
+        << "prefix-cache output diverged from the no-cache baseline (greedy):\n"
+        << "  no-cache: " << baseline << "\n  cached:   " << cached;
+}
+
+// 3. Shared prefix, different suffix: a cache hit on the common prefix must not
+//    corrupt the continuation. We warm the cache with kPrompt, then issue a
+//    request that shares the long kPrompt prefix but appends a distinct suffix.
+//    The result must be (a) non-empty/coherent and (b) reproducible 2× — proving
+//    the partial prefix hit feeds a correct, deterministic continuation.
+TEST_F(PrefixCacheE2ETest, DISABLED_SharedPrefixDifferentSuffixStable) {
+    MakeContext(/*prefix_cache=*/true);
+    (void)gen(kPrompt, kGen);  // warm: cache kPrompt's blocks
+
+    const std::string suffixed =
+        std::string(kPrompt) + " Also list two early mechanical devices:";
+
+    std::string a = gen(suffixed.c_str(), kGen);  // partial prefix hit + new suffix
+    std::string b = gen(suffixed.c_str(), kGen);  // full prefix hit (a registered it)
+
+    ASSERT_FALSE(a.empty()) << "shared-prefix+new-suffix produced no output";
+    EXPECT_EQ(a, b)
+        << "continuation after a partial-prefix cache hit is non-deterministic:\n"
+        << "  run a: " << a << "\n  run b: " << b;
+}
+
+}  // namespace

--- a/tests/test_prefix_cache_equiv.cpp
+++ b/tests/test_prefix_cache_equiv.cpp
@@ -1,0 +1,338 @@
+// Prefix-cache equivalence — TEST_AUDIT.md risk #7 (Phase 2.6).
+//
+// "Prefix cache ships off-by-default BECAUSE its determinism is unvalidated —
+//  the test IS the enabler."
+//
+// The existing KVCacheManager suite (tests/test_kv_cache.cpp) already covers
+// the BLOCK-ID BOOKKEEPING of prefix caching (reuse counts, partial match,
+// cached-block eviction, pool integrity). What it does NOT cover — and what
+// Risk #7 actually names — is the part that makes the feature *correct*:
+//
+//   (a) KV-DATA equivalence: a "reused" block must hand back the SAME physical
+//       block carrying the SAME KV bytes that were computed for the prefix.
+//       A correct reuse *count* with stale/wrong KV bytes is exactly the
+//       silent-correctness failure that keeps the feature off-by-default.
+//   (b) eviction+refill stability: once a cached prefix is EVICTED, re-allocating
+//       the identical prefix must come back as NEW (0 reuse) — never a false
+//       hit on a recycled/stale block (hash-collision / stale-block guard).
+//   (c) ref-count keep-alive: a block shared by two live sequences must survive
+//       one of them being freed, with its KV bytes intact (no use-after-free).
+//
+// These assert against the REAL KVCacheManager wrapping a REAL KVCache pool;
+// the content checks use a fp32-independent oracle — bytes we wrote ourselves
+// into device memory, read back via cudaMemcpy. The pool is zero-initialized
+// on construction, so a stale/wrong-block hit reads zeros, not our pattern:
+// the content assert cannot pass tautologically.
+//
+// block_size = kKVBlockSize = 16 throughout; expectations are derived from the
+// documented hashing semantics (FNV-1a parent-chained per full block; partial
+// blocks are NOT cacheable) and stated per case.
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+
+#include "memory/kv_cache.h"
+#include "memory/kv_cache_manager.h"
+#include "core/tensor.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+namespace imp {
+namespace {
+
+static bool HasCudaDevice() {
+    int count = 0;
+    cudaError_t err = cudaGetDeviceCount(&count);
+    return err == cudaSuccess && count > 0;
+}
+
+#define SKIP_IF_NO_CUDA()                               \
+    do {                                                \
+        if (!HasCudaDevice()) {                         \
+            GTEST_SKIP() << "No CUDA device available"; \
+        }                                               \
+    } while (0)
+
+// Real manager over a real (small) KV pool. F16 so k_ptr/v_ptr are plain
+// contiguous device memory we can byte-copy in and out.
+static std::unique_ptr<KVCacheManager> MakeManager(int max_blocks, int n_layers = 2,
+                                                   int n_kv_heads = 2, int head_dim = 32) {
+    auto cache = std::make_unique<KVCache>(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks);
+    return std::make_unique<KVCacheManager>(std::move(cache));
+}
+
+// Fill block `block_id`'s K and V regions (all layers) with a deterministic
+// per-(layer, block) byte pattern. Returns nothing; pairs with ReadBlock.
+static void WriteBlockPattern(KVCache* c, int block_id, uint8_t seed) {
+    const size_t bb = c->block_bytes();
+    std::vector<uint8_t> host(bb);
+    for (int l = 0; l < c->n_layers(); ++l) {
+        for (size_t i = 0; i < bb; ++i)
+            host[i] = static_cast<uint8_t>(seed + l * 7 + (i & 0x3F));
+        ASSERT_EQ(cudaMemcpy(c->k_ptr(l, block_id), host.data(), bb, cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        for (size_t i = 0; i < bb; ++i)
+            host[i] = static_cast<uint8_t>(seed + 100 + l * 7 + (i & 0x3F));
+        ASSERT_EQ(cudaMemcpy(c->v_ptr(l, block_id), host.data(), bb, cudaMemcpyHostToDevice),
+                  cudaSuccess);
+    }
+}
+
+// Read block `block_id`'s K (k_or_v=0) or V (k_or_v=1) for one layer into host.
+static std::vector<uint8_t> ReadBlock(KVCache* c, int block_id, int layer, int k_or_v) {
+    const size_t bb = c->block_bytes();
+    std::vector<uint8_t> host(bb);
+    void* src = (k_or_v == 0) ? c->k_ptr(layer, block_id) : c->v_ptr(layer, block_id);
+    EXPECT_EQ(cudaMemcpy(host.data(), src, bb, cudaMemcpyDeviceToHost), cudaSuccess);
+    return host;
+}
+
+// The expected pattern bytes for a given (layer, k_or_v, seed) — recomputed
+// independently of any device read.
+static std::vector<uint8_t> ExpectedPattern(size_t bb, int layer, int k_or_v, uint8_t seed) {
+    std::vector<uint8_t> e(bb);
+    int base = (k_or_v == 0) ? 0 : 100;
+    for (size_t i = 0; i < bb; ++i)
+        e[i] = static_cast<uint8_t>(seed + base + layer * 7 + (i & 0x3F));
+    return e;
+}
+
+// ── (1) Full-prefix reuse count ───────────────────────────────────────────
+// Two sequences with IDENTICAL ≥2-block prefixes. After seq A is registered +
+// freed (cached), seq B's allocate_blocks_with_prefix must report exactly the
+// number of FULL blocks as reused. Derivation: each full block's FNV-1a hash
+// chains through its parent; identical tokens ⇒ identical chain ⇒ every full
+// block matches. 48 tokens / 16 = 3 full blocks ⇒ 3 reused.
+TEST(PrefixEquivTest, FullPrefixReuseCount) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+
+    std::vector<int32_t> tokens(48);
+    std::iota(tokens.begin(), tokens.end(), 1000);
+
+    int reused_a = mgr->allocate_blocks_with_prefix(0, tokens);
+    ASSERT_EQ(reused_a, 0) << "first sequence cannot reuse — cache is empty";
+    mgr->register_block_hashes(0, tokens);
+    mgr->free_sequence(0);
+    ASSERT_EQ(mgr->num_cached_blocks(), 3);
+
+    int reused_b = mgr->allocate_blocks_with_prefix(1, tokens);
+    EXPECT_EQ(reused_b, 3) << "identical 3-full-block prefix must reuse all 3";
+    mgr->free_sequence(1);
+}
+
+// ── (2) Exactly-one-block shared prefix ───────────────────────────────────
+// Share the first block (16 identical tokens), differ in the second. The
+// parent-chained hash breaks at block 2, so exactly ONE block reuses.
+TEST(PrefixEquivTest, PartialOneBlockShared) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+
+    std::vector<int32_t> a(32);
+    std::iota(a.begin(), a.end(), 0);
+    mgr->allocate_blocks_with_prefix(0, a);
+    mgr->register_block_hashes(0, a);
+    mgr->free_sequence(0);
+    ASSERT_EQ(mgr->num_cached_blocks(), 2);
+
+    std::vector<int32_t> b(32);
+    std::iota(b.begin(), b.begin() + 16, 0);     // same first block
+    std::iota(b.begin() + 16, b.end(), 5000);    // different second block
+    int reused = mgr->allocate_blocks_with_prefix(1, b);
+    EXPECT_EQ(reused, 1) << "only the first block's hash matches; chain breaks after";
+    mgr->free_sequence(1);
+}
+
+// ── (3) No common prefix → 0 reuse ────────────────────────────────────────
+// Disjoint tokens from the very first block ⇒ no hash matches ⇒ 0 reuse.
+TEST(PrefixEquivTest, NoCommonPrefixZeroReuse) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+
+    std::vector<int32_t> a(48);
+    std::iota(a.begin(), a.end(), 0);
+    mgr->allocate_blocks_with_prefix(0, a);
+    mgr->register_block_hashes(0, a);
+    mgr->free_sequence(0);
+
+    std::vector<int32_t> b(48);
+    std::iota(b.begin(), b.end(), 900000);  // completely different from block 0 on
+    int reused = mgr->allocate_blocks_with_prefix(1, b);
+    EXPECT_EQ(reused, 0);
+    mgr->free_sequence(1);
+}
+
+// ── (4) KV-DATA equivalence: reused block carries the same bytes ──────────
+// The heart of risk #7. Reuse is only correct if the reused physical block
+// holds the KV data computed for that prefix. We:
+//   1. allocate the prefix for seq A,
+//   2. write a known byte pattern into A's blocks' K/V device memory
+//      (standing in for "prefill computed these KV"),
+//   3. register + free A (blocks cached, ref=1, data retained),
+//   4. reuse the prefix for seq B,
+//   5. read B's reused blocks back and assert byte-identical to what A wrote.
+// The pool was zero-initialized, so a stale/wrong-block hit would read zeros:
+// passing requires the SAME physical block with intact KV bytes.
+TEST(PrefixEquivTest, ReusedBlockKVContentPreserved) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+    KVCache* c = mgr->kv_cache();
+    const size_t bb = c->block_bytes();
+
+    std::vector<int32_t> tokens(32);  // 2 full blocks
+    std::iota(tokens.begin(), tokens.end(), 7);
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens), 0);
+
+    const std::vector<int> blocks_a = mgr->block_table(0);  // copy: A is about to be freed
+    ASSERT_EQ(blocks_a.size(), 2u);
+    WriteBlockPattern(c, blocks_a[0], /*seed=*/0x11);
+    WriteBlockPattern(c, blocks_a[1], /*seed=*/0x22);
+
+    mgr->register_block_hashes(0, tokens);
+    mgr->free_sequence(0);
+
+    int reused = mgr->allocate_blocks_with_prefix(1, tokens);
+    ASSERT_EQ(reused, 2);
+    const std::vector<int>& blocks_b = mgr->block_table(1);
+    ASSERT_EQ(blocks_b.size(), 2u);
+
+    // Same physical blocks (content-addressed reuse hands back the cached ids).
+    EXPECT_EQ(blocks_b[0], blocks_a[0]);
+    EXPECT_EQ(blocks_b[1], blocks_a[1]);
+
+    // And the KV BYTES survived the free→cache→reuse round-trip, every layer.
+    const uint8_t seeds[2] = {0x11, 0x22};
+    for (int bi = 0; bi < 2; ++bi) {
+        for (int l = 0; l < c->n_layers(); ++l) {
+            EXPECT_EQ(ReadBlock(c, blocks_b[bi], l, /*K*/ 0),
+                      ExpectedPattern(bb, l, 0, seeds[bi]))
+                << "reused block " << bi << " layer " << l << " K bytes corrupted";
+            EXPECT_EQ(ReadBlock(c, blocks_b[bi], l, /*V*/ 1),
+                      ExpectedPattern(bb, l, 1, seeds[bi]))
+                << "reused block " << bi << " layer " << l << " V bytes corrupted";
+        }
+    }
+    mgr->free_sequence(1);
+}
+
+// ── (5) ref-count keep-alive: freeing A must not corrupt B's shared block ──
+// A and B both hold the shared prefix CONCURRENTLY (B reuses A's registered
+// blocks; ref_count goes to 2). Freeing A must leave the shared block alive
+// (ref_count back to 1, NOT returned to the pool) with KV bytes intact — the
+// use-after-free / premature-free guard.
+TEST(PrefixEquivTest, RefCountKeepsSharedBlockAliveForB) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+    KVCache* c = mgr->kv_cache();
+    const size_t bb = c->block_bytes();
+
+    std::vector<int32_t> tokens(32);
+    std::iota(tokens.begin(), tokens.end(), 50);
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens), 0);
+    const std::vector<int> blocks_a = mgr->block_table(0);
+    ASSERT_EQ(blocks_a.size(), 2u);
+    WriteBlockPattern(c, blocks_a[0], 0x33);
+    WriteBlockPattern(c, blocks_a[1], 0x44);
+    mgr->register_block_hashes(0, tokens);
+
+    // B reuses A's blocks WHILE A is still alive → ref_count == 2 (shared).
+    int reused = mgr->allocate_blocks_with_prefix(1, tokens);
+    ASSERT_EQ(reused, 2);
+    const std::vector<int> blocks_b = mgr->block_table(1);
+    ASSERT_EQ(blocks_b[0], blocks_a[0]);
+    EXPECT_EQ(c->ref_count(blocks_a[0]), 2) << "block shared by A and B must be ref-counted twice";
+
+    int free_before = mgr->num_free_blocks();
+    mgr->free_sequence(0);  // A goes away
+
+    // The shared blocks must NOT have returned to the pool (B still holds them).
+    EXPECT_EQ(mgr->num_free_blocks(), free_before)
+        << "shared blocks returned to pool while B still references them";
+    EXPECT_GE(c->ref_count(blocks_b[0]), 1);
+    EXPECT_GE(c->ref_count(blocks_b[1]), 1);
+
+    // B's KV bytes are still the ones A wrote — no use-after-free overwrite.
+    const uint8_t seeds[2] = {0x33, 0x44};
+    for (int bi = 0; bi < 2; ++bi)
+        for (int l = 0; l < c->n_layers(); ++l)
+            EXPECT_EQ(ReadBlock(c, blocks_b[bi], l, 0), ExpectedPattern(bb, l, 0, seeds[bi]))
+                << "B's shared block corrupted after A freed (use-after-free)";
+
+    mgr->free_sequence(1);
+}
+
+// ── (6) eviction+refill: an evicted prefix must re-allocate as NEW ────────
+// Cache a prefix, free it (cached, ref=1), then force the cached blocks out of
+// the pool via NEW unrelated sequences that need the space. Re-allocating the
+// ORIGINAL prefix must then report 0 reuse — its hash entries were removed on
+// eviction, so it must not falsely hit a recycled/stale block. This is the
+// hash-collision / stale-block guard that risk #7 names as the determinism
+// blocker.
+TEST(PrefixEquivTest, EvictionThenRefillIsNewNotStaleHit) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(4);  // tiny pool: 4 blocks total
+    mgr->set_prefix_caching_enabled(true);
+
+    // Cache a 2-block prefix, then free → 2 cached blocks, 2 free.
+    std::vector<int32_t> p(32);
+    std::iota(p.begin(), p.end(), 0);
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, p), 0);
+    mgr->register_block_hashes(0, p);
+    mgr->free_sequence(0);
+    ASSERT_EQ(mgr->num_cached_blocks(), 2);
+
+    // A 4-block sequence needs the whole pool → the 2 cached prefix blocks must
+    // be evicted (reclaimed) to satisfy it. Different tokens ⇒ 0 reuse here.
+    std::vector<int32_t> big(64);
+    std::iota(big.begin(), big.end(), 300000);
+    int reused_big = mgr->allocate_blocks_with_prefix(1, big);
+    ASSERT_EQ(reused_big, 0);
+    ASSERT_EQ(static_cast<int>(mgr->block_table(1).size()), 4);
+    EXPECT_EQ(mgr->num_cached_blocks(), 0) << "cached prefix must have been evicted to fit seq 1";
+    mgr->register_block_hashes(1, big);  // register the new occupant
+    mgr->free_sequence(1);
+
+    // Now re-request the ORIGINAL prefix. Its hash entries were dropped on
+    // eviction → must come back as NEW (0 reuse), never a stale hit on a block
+    // that now belongs to a different token sequence.
+    int reused_again = mgr->allocate_blocks_with_prefix(2, p);
+    EXPECT_EQ(reused_again, 0)
+        << "evicted prefix falsely re-hit a recycled block — STALE-BLOCK BUG";
+    mgr->free_sequence(2);
+}
+
+// ── (7) non-block-aligned prefix length ───────────────────────────────────
+// 40 tokens at block_size 16 = 2 full blocks + 1 partial (8 tokens). Only full
+// blocks are cacheable, so re-requesting the identical 40 tokens reuses exactly
+// the 2 full blocks; the partial tail is always re-allocated fresh.
+TEST(PrefixEquivTest, NonAlignedPrefixReusesFullBlocksOnly) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+
+    std::vector<int32_t> tokens(40);
+    std::iota(tokens.begin(), tokens.end(), 11);
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens), 0);
+    ASSERT_EQ(static_cast<int>(mgr->block_table(0).size()), 3);  // 2 full + 1 partial
+    mgr->register_block_hashes(0, tokens);
+    mgr->free_sequence(0);
+    // Only the 2 full blocks are cacheable; the partial tail is freed to pool.
+    EXPECT_EQ(mgr->num_cached_blocks(), 2);
+
+    int reused = mgr->allocate_blocks_with_prefix(1, tokens);
+    EXPECT_EQ(reused, 2) << "2 full blocks reused; partial tail re-allocated fresh";
+    EXPECT_EQ(static_cast<int>(mgr->block_table(1).size()), 3);
+    mgr->free_sequence(1);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Was (TEST_AUDIT Phase 2.6 — Risk #7, der letzte offene Top-10-Risk)

Das Audit nannte diesen Test "the enabler" — er sollte beweisen, dass der off-by-default Prefix-Cache deterministisch ist. **Er beweist das Gegenteil: Issue #536.**

### Geliefert
- **`tests/test_prefix_cache_equiv.cpp` (7 Unit-Tests, GRÜN):** echter KVCacheManager — Reuse-Zählung (voll/partiell/null), KV-Bytes auf reused Blocks intakt, ref_count-Lebensdauer, Eviction+Refill = frische Allokation (kein Stale-Hit), nicht-alignte Prefixe reusen nur volle Blöcke.
- **`tests/test_prefix_cache_e2e.cpp`:** 
  - **Kontrolltest (GRÜN):** back-to-back greedy OHNE Cache ist byte-identisch → Divergenz ist dem Cache-Pfad zuordenbar.
  - **3 Äquivalenztests als `DISABLED_`** — sie failen ehrlich: der Prefix-Cache-HIT divergiert nach ~15 Tokens vom frischen Prefill (Qwen3-8B-Q8_0, CUDA Graphs ON, greedy). Beim Fix von #536 `DISABLED_` entfernen — die Tests sind das Ship-Gate des Features.

### Schuldzuweisung (sauber eingegrenzt)
Manager-Ebene grün + Kontrolle grün ⇒ die Korruption sitzt in der **Engine-Integration des Cache-Hits** (Partial-Block-Resume / Positions-Buchhaltung als Hauptverdächtige) — Details in #536.

Damit ist das Top-10-Risiko-Programm des Audits vollständig: #1–#8, #10 geliefert, #9 begründet zurückgestellt (#533).

🤖 Generated with [Claude Code](https://claude.com/claude-code)