### PR TITLE
fix(decode): content-compare block-table upload cache — prefix-cache equivalence restored (fixes #536)

### DIFF
--- a/src/runtime/batch.cpp
+++ b/src/runtime/batch.cpp
@@ -160,8 +160,7 @@ void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllo
 
     max_batch_size_ = max_batch_size;
     max_blocks_per_seq_ = max_blocks_per_seq;
-    last_upload_n_blocks_ = -1;
-    last_upload_first_block_ = -1;
+    last_upload_block_tables_.clear();
 
     // Compute sizes with 256-byte alignment per sub-buffer
     auto align256 = [](size_t x) -> size_t { return (x + 255) & ~size_t(255); };
@@ -233,23 +232,19 @@ GPUBatch GPUBatchPool::upload_into_pool(const Batch& batch, cudaStream_t stream)
     }
 
     if (batch.max_blocks_per_seq > 0 && !batch.block_tables.empty()) {
-        // For single-seq decode, skip block_table re-upload when block count and
-        // first block ID are unchanged. Within a request, existing block IDs are
-        // stable (only new blocks appended). Between requests, the first block ID
-        // changes (different physical page), forcing a re-upload.
-        int n_blocks = batch.actual_blocks_per_seq > 0
-                           ? batch.actual_blocks_per_seq
-                           : static_cast<int>(batch.block_tables.size()) / batch.n_sequences;
-        int first_block = batch.block_tables[0];
-        if (batch.n_sequences == 1 && n_blocks == last_upload_n_blocks_ &&
-            first_block == last_upload_first_block_) {
+        // For single-seq decode, skip the block_table re-upload only when the
+        // CONTENT matches the last upload exactly. Size/first-block proxies are
+        // NOT sufficient — see last_upload_block_tables_ in batch.h (#536).
+        if (batch.n_sequences == 1 && batch.block_tables == last_upload_block_tables_) {
             // Skip — block_table content is identical to last upload
         } else {
             IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_block_tables_, batch.block_tables.data(),
                                                batch.n_sequences * batch.max_blocks_per_seq * sizeof(int),
                                                cudaMemcpyHostToDevice, stream));
-            last_upload_n_blocks_ = (batch.n_sequences == 1) ? n_blocks : -1;
-            last_upload_first_block_ = (batch.n_sequences == 1) ? first_block : -1;
+            if (batch.n_sequences == 1)
+                last_upload_block_tables_ = batch.block_tables;
+            else
+                last_upload_block_tables_.clear();
         }
     }
 
@@ -271,8 +266,7 @@ void GPUBatchPool::free_pool() {
     d_block_tables_ = nullptr;
     d_context_lens_ = nullptr;
     d_sample_result_ = nullptr;
-    last_upload_n_blocks_ = -1;
-    last_upload_first_block_ = -1;
+    last_upload_block_tables_.clear();
 }
 
 }  // namespace imp

--- a/src/runtime/batch.h
+++ b/src/runtime/batch.h
@@ -64,10 +64,7 @@ public:
 
     bool is_allocated() const { return pool_ != nullptr; }
     int max_blocks_per_seq() const { return max_blocks_per_seq_; }
-    void reset_upload_cache() {
-        last_upload_n_blocks_ = -1;
-        last_upload_first_block_ = -1;
-    }
+    void reset_upload_cache() { last_upload_block_tables_.clear(); }
 
     // Pre-allocated single int32 result buffer for sampling kernels
     int32_t* d_sample_result() const { return d_sample_result_; }
@@ -88,12 +85,18 @@ private:
     int max_batch_size_ = 0;
     int max_blocks_per_seq_ = 0;
 
-    // Track block_table changes for single-seq decode: skip re-upload when unchanged.
-    // We track both block count and first block ID — the count only changes when a new
-    // KV block is allocated, and the first block ID changes between requests (different
-    // physical pages), preventing cross-request stale reads.
-    int last_upload_n_blocks_ = -1;
-    int last_upload_first_block_ = -1;
+    // Track block_table changes for single-seq decode: skip re-upload when the
+    // CONTENT is unchanged. The previous proxy (block count + first block ID)
+    // broke under prefix caching: a prefix-HIT request starts with the SAME
+    // reused first block and can have the same count as the previous request
+    // while differing in the middle (e.g. [0,1,4,3,2] after reuse+eviction vs
+    // [0,1,2,3,4]) — the skip then left the decode running on the previous
+    // request's table, writing KV into the wrong physical blocks (issue #536:
+    // greedy prefix-hit diverged from fresh prefill; the same silent-stale
+    // class was misdiagnosed as "FP rounding from different physical
+    // addresses" when prefix caching was first turned off). A host-side
+    // vector compare of <=max_blocks ints costs nanoseconds per decode step.
+    std::vector<int> last_upload_block_tables_;
 };
 
 class BatchBuilder {

--- a/tests/test_prefix_cache_e2e.cpp
+++ b/tests/test_prefix_cache_e2e.cpp
@@ -117,23 +117,24 @@ TEST_F(PrefixCacheE2ETest, ControlNoCacheBackToBackIsDeterministic) {
 }
 
 // =============================================================================
-// Tests 1-3 are DISABLED: they FAIL against the current engine — the
-// prefix-cache hit DIVERGES from the fresh prefill under greedy decoding
-// (verified 2026-06-04, Qwen3-8B-Q8_0, CUDA graphs ON; diverges ~15 tokens
-// in: "...computing starting from ancient times up to the" vs "...computing.
-// Let me start by recalling the"). The control test above passes, so the
-// divergence is attributable to the cache path, and the unit tests prove the
-// manager returns the right blocks with intact bytes — the corruption is in
-// the engine integration of a cache hit (partial-block resume / position
-// bookkeeping are the prime suspects). Tracked in issue #536; flip DISABLED_ off when fixing — these tests ARE the
-// feature's ship gate (TEST_AUDIT risk #7: "the test IS the enabler").
+// History: tests 1-3 initially FAILED (issue #536) — the prefix-cache HIT
+// diverged from the fresh prefill under greedy decoding. Root cause was NOT
+// the cache or FP rounding: GPUBatchPool::upload_into_pool skipped the
+// block-table re-upload based on a (count + first-block-ID) proxy, which a
+// prefix hit defeats (same first reused block, same count, different middle
+// after reuse+eviction, e.g. [0,1,4,3,2]) — the first eager decode step then
+// ran on the PREVIOUS request's table, writing the new token's KV into the
+// wrong physical block while the async graph read garbage at the self-token
+// position. Fixed by content-comparing the table (batch.cpp). These tests
+// are the feature's ship gate (TEST_AUDIT risk #7: "the test IS the
+// enabler") — they must stay green for prefix caching to be enabled.
 // =============================================================================
 // 1. Fresh-prefill vs prefix-cache-HIT must be token-identical.
 //    Same context, prefix caching ON, NO reset between calls: call 1 prefills
 //    fresh and caches its prefix on finish; call 2 hits the cached prefix.
 //    Greedy ⇒ the two outputs must be byte-identical. A mismatch is exactly the
 //    silent-determinism failure that keeps the feature off-by-default.
-TEST_F(PrefixCacheE2ETest, DISABLED_FreshVsPrefixHitTokenEqual) {
+TEST_F(PrefixCacheE2ETest, FreshVsPrefixHitTokenEqual) {
     MakeContext(/*prefix_cache=*/true);
 
     std::string first = gen(kPrompt, kGen);   // fresh prefill, caches prefix on finish
@@ -150,7 +151,7 @@ TEST_F(PrefixCacheE2ETest, DISABLED_FreshVsPrefixHitTokenEqual) {
 // 2. Cross-context equivalence: prefix-cache-ON output == prefix-cache-OFF
 //    output for the same greedy request. This pins the cache path to the
 //    canonical fresh-prefill result, not merely to "self-consistent".
-TEST_F(PrefixCacheE2ETest, DISABLED_PrefixCacheMatchesNoCacheBaseline) {
+TEST_F(PrefixCacheE2ETest, PrefixCacheMatchesNoCacheBaseline) {
     // Baseline: caching OFF.
     MakeContext(/*prefix_cache=*/false);
     std::string baseline = gen(kPrompt, kGen);
@@ -173,7 +174,7 @@ TEST_F(PrefixCacheE2ETest, DISABLED_PrefixCacheMatchesNoCacheBaseline) {
 //    request that shares the long kPrompt prefix but appends a distinct suffix.
 //    The result must be (a) non-empty/coherent and (b) reproducible 2× — proving
 //    the partial prefix hit feeds a correct, deterministic continuation.
-TEST_F(PrefixCacheE2ETest, DISABLED_SharedPrefixDifferentSuffixStable) {
+TEST_F(PrefixCacheE2ETest, SharedPrefixDifferentSuffixStable) {
     MakeContext(/*prefix_cache=*/true);
     (void)gen(kPrompt, kGen);  // warm: cache kPrompt's blocks
 


### PR DESCRIPTION
## Root Cause (war weder der Cache noch FP-Rundung)

`GPUBatchPool::upload_into_pool` überspringt den Block-Table-Re-Upload im Single-Seq-Decode, wenn **(Blockanzahl, erste Block-ID)** zum letzten Upload passen. Ein Prefix-HIT schlägt genau diesen Proxy: Der neue Request beginnt mit demselben reused ersten Block und kann dieselbe Anzahl haben, unterscheidet sich aber in der Mitte (gemessen nach Reuse+LRU-Eviction: `[0,1,4,3,2]` vs. `[0,1,2,3,4]`). Der erste eager Decode-Step lief dann auf der **stalen Tabelle des Vorgänger-Requests**: das Token-1-KV landete im falschen physischen Block, während der (eigene, korrekte) AsyncGraph am Self-Token Müll las → Hidden-Drift → greedy kippte ~Token 7.

## Forensik (Qwen3-8B-Q8_0, Graphs ON)
1. **Flip-Rate über 6 Prompts:** Prefix-Hit 3/6 vs. chunked-Resume 0/6 bei identischer Resume-Geometrie ⇒ systematisch, kein FP-Rauschen.
2. **Prompt-KV nach Hit-Prefill bit-identisch zu fresh** (Layer 0 UND 35) ⇒ Resume-Mathematik sauber. Die historische Diagnose beim Default-Off-Commit ("cached blocks get different physical KV addresses, causing FP rounding differences") war eine Fehlattribution **dieses** Bugs.
3. **Sentinel-Beweis:** Step-1-KV-Write zerstörte den Sentinel im Block der ALTEN Tabelle; der Zielblock der neuen Tabelle behielt seinen Sentinel 1024/1024 ⇒ der Write lief auf dem stalen Upload.

## Fix
Inhaltsvergleich der vollen Host-Tabelle gegen die zuletzt hochgeladene Kopie (`vector==`, ≤max_blocks ints ⇒ Nanosekunden pro Decode-Step); Re-Upload bei jeder Inhaltsänderung. `n_sequences>1` lädt weiterhin bedingungslos.

## Validierung
- **Die 3 `DISABLED_`-Äquivalenztests aus #537 (das Ship-Gate des Features) sind aktiviert und GRÜN** — inkl. Fresh≡Hit-Token-Gleichheit, No-Cache-Baseline-Gleichheit, Shared-Prefix/Different-Suffix-Stabilität
- Kontrolltest + 7 Manager-Unit-Tests + test-kv 41/41 + Greedy-Locks grün
- Decode-Perf neutral (tg256 = 240 tok/s Qwen3-8B-NVFP4)

Damit ist der Weg frei, `server.prefix_cache` default zu aktivieren (separate Entscheidung) und `cache_control` (#522) anzubinden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)