### PR TITLE
fix(attention): in-place float→half S/P-tile compaction raced across rows in smem WMMA prefill kernels

### DIFF
--- a/src/compute/attention_blackwell.cu
+++ b/src/compute/attention_blackwell.cu
@@ -271,18 +271,25 @@ __global__ void flash_attention_blackwell_kernel(const half* __restrict__ Q, con
                 }
             }
 
-            // Step 6: Convert SP_float → SP_half with 1/l_new baked in
+            // Step 6: Convert SP_float → SP_half with 1/l_new baked in.
+            // SP_half aliases SP_float COMPACTLY: half row r lives in the
+            // bytes of float row r/2, so in-place stores clobber float scores
+            // other threads have not read yet (deterministic even intra-warp;
+            // padding rows skip Steps 1-5 and race ahead zero-filling valid
+            // rows' scores — issue #528). Stage this thread's halves in
+            // registers, barrier, then store.
+            constexpr int CPT = BW_Bc / TPR;  // columns per thread
             float spv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
-            if (row_valid) {
-                for (int c = sm_lane; c < BW_Bc; c += TPR) {
-                    SP_half[r * BW_Bc + c] = __float2half(SP_float[r * BW_Bc + c] * spv);
-                }
-            } else if (r < Br) {
-                // Zero out invalid rows for clean WMMA input
-                for (int c = sm_lane; c < BW_Bc; c += TPR) {
-                    SP_half[r * BW_Bc + c] = __float2half(0.0f);
-                }
+            half hbuf[CPT];
+#pragma unroll
+            for (int i = 0; i < CPT; i++) {
+                int c = sm_lane + i * TPR;
+                hbuf[i] = __float2half(row_valid ? SP_float[r * BW_Bc + c] * spv : 0.0f);
             }
+            __syncthreads();  // all float reads of SP_float complete before any half write
+#pragma unroll
+            for (int i = 0; i < CPT; i++)
+                SP_half[r * BW_Bc + sm_lane + i * TPR] = hbuf[i];
         }
         __syncthreads();
 

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -826,15 +826,23 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                 }
             }
 
-            // Step 6: Normalize + float→half for P
+            // Step 6: Normalize + float→half for P.
+            // In-place float→half compaction: stage in registers + barrier
+            // (SP_half row r aliases the bytes of float row r/2 — unsynced
+            // stores clobber float scores other threads have not read yet,
+            // issue #528; see attention_fmha_sm120.cu).
+            constexpr int CPT = Bkv / TPR;
             float spv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
-            if (row_valid) {
-                for (int c = sm_lane; c < Bkv; c += TPR)
-                    SP_half[r * Bkv + c] = __float2half(S_tile[r * Bkv + c] * spv);
-            } else if (r < Bq) {
-                for (int c = sm_lane; c < Bkv; c += TPR)
-                    SP_half[r * Bkv + c] = __float2half(0.0f);
+            half hbuf[CPT];
+#pragma unroll
+            for (int i = 0; i < CPT; i++) {
+                int c = sm_lane + i * TPR;
+                hbuf[i] = __float2half(row_valid ? S_tile[r * Bkv + c] * spv : 0.0f);
             }
+            __syncthreads();  // all float reads of S_tile complete before any half write
+#pragma unroll
+            for (int i = 0; i < CPT; i++)
+                SP_half[r * Bkv + sm_lane + i * TPR] = hbuf[i];
         }
 
         // Wait for V prefetch to complete, then sync all SMEM writes (P + V)

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -297,17 +297,26 @@ __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 2) fmha_sm120_kernel(
                 }
             }
 
-            // Step 6: Fused softmax normalize + float->half conversion
+            // Step 6: Fused softmax normalize + float->half conversion.
+            // SP_half aliases S_tile COMPACTLY: half row r lives in the bytes
+            // of float row r/2, so in-place stores clobber float scores other
+            // threads have not read yet (row 2r+1's halves land in row r's
+            // cols >= Bkv/2 — deterministic even intra-warp — and padding
+            // rows skip Steps 1-5 and race ahead zero-filling valid rows'
+            // scores, worst at short seq_q; issue #528). Stage this thread's
+            // halves in registers, barrier, then store.
+            constexpr int CPT = Bkv / TPR;  // columns per thread
             float spv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
-            if (row_valid) {
-                for (int c = sm_lane; c < Bkv; c += TPR) {
-                    SP_half[r * Bkv + c] = __float2half(S_tile[r * Bkv + c] * spv);
-                }
-            } else if (r < Bq) {
-                for (int c = sm_lane; c < Bkv; c += TPR) {
-                    SP_half[r * Bkv + c] = __float2half(0.0f);
-                }
+            half hbuf[CPT];
+#pragma unroll
+            for (int i = 0; i < CPT; i++) {
+                int c = sm_lane + i * TPR;
+                hbuf[i] = __float2half(row_valid ? S_tile[r * Bkv + c] * spv : 0.0f);
             }
+            __syncthreads();  // all float reads of S_tile complete before any half write
+#pragma unroll
+            for (int i = 0; i < CPT; i++)
+                SP_half[r * Bkv + sm_lane + i * TPR] = hbuf[i];
         }
         __syncthreads();
 
@@ -842,14 +851,21 @@ __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 1) fmha_sm120_fp8_kernel(
                     O_acc[r * head_dim + d] *= rescale;
             }
 
+            // In-place float→half compaction: stage in registers + barrier
+            // (SP_half row r aliases the bytes of float row r/2 — issue #528,
+            // see the f16 kernel above).
+            constexpr int CPT = Bkv / TPR;
             float spv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
-            if (row_valid) {
-                for (int c = sm_lane; c < Bkv; c += TPR)
-                    SP_half[r * Bkv + c] = __float2half(S_tile[r * Bkv + c] * spv);
-            } else if (r < Bq) {
-                for (int c = sm_lane; c < Bkv; c += TPR)
-                    SP_half[r * Bkv + c] = __float2half(0.0f);
+            half hbuf[CPT];
+#pragma unroll
+            for (int i = 0; i < CPT; i++) {
+                int c = sm_lane + i * TPR;
+                hbuf[i] = __float2half(row_valid ? S_tile[r * Bkv + c] * spv : 0.0f);
             }
+            __syncthreads();  // all float reads of S_tile complete before any half write
+#pragma unroll
+            for (int i = 0; i < CPT; i++)
+                SP_half[r * Bkv + sm_lane + i * TPR] = hbuf[i];
         }
         __syncthreads();
 

--- a/tests/refs/README.md
+++ b/tests/refs/README.md
@@ -18,9 +18,12 @@ ground truth). Rules (TEST_AUDIT.md §4):
      #512 mechanism). These paths are CHARACTERIZED (envelope assert +
      printed stats), never blessed at 5e-2; E2E token-level locks carry the
      real quality gate.
-   - WMMA attention (fmha_sm120, flash_attention_blackwell): measured
-     0.15-0.86 rel on mild realistic data despite f32 accumulators — under
-     investigation (cross-path divergence issue); characterized like fp8.
+   - WMMA attention (fmha_sm120, flash_attention_blackwell): **≤ 1e-2 rel**
+     vs fp64, same class as the f32 chain (f16 QK with f32 accumulators +
+     f32 softmax + f16 P). The 0.15-0.86 rel measured at the suite's birth
+     was the #528 in-place float→half S/P-tile compaction race (half row r
+     aliases the bytes of float row r/2); post-fix both paths measure ~4e-4
+     on all configs and are held strict.
    - NVFP4: **≤ 1e-1 rel** single-op, plus E2E locks.
    - fp64-vs-fp64 generator cross-checks (numpy vs C++ double loops):
      **≤ 1e-9 rel** — summation-order ulps only; anything larger means the

--- a/tests/test_attention_crosspath.cu
+++ b/tests/test_attention_crosspath.cu
@@ -143,14 +143,14 @@ protected:
     void SetUp() override { cudaStreamCreate(&stream_); }
     void TearDown() override { cudaStreamDestroy(stream_); }
 
-    // Strictness model (measured 2026-06-04, see tests/refs/README.md):
-    // only the f32-score-chain paths (cuBLAS FP32-S, FA2-f16) reproduce the
-    // fp64 reference at 1e-2 on realistic uncorrelated data — they are held
-    // strict in BOTH tiers, plus pairwise agreement. The fp8-QK paths
-    // (score-quantization noise, worst at short rows where no averaging
-    // happens — the #512 mechanism) and the WMMA paths (fmha_sm120,
-    // blackwell: up to 0.86 rel on MILD data despite f32 accumulators —
-    // under investigation, tracked in the cross-path divergence issue) are
+    // Strictness model (see tests/refs/README.md):
+    // the f32-score-chain paths (cuBLAS FP32-S, FA2-f16) and — since the
+    // #528 fix (in-place float→half S/P-tile compaction raced across rows;
+    // post-fix ~4e-4 max_rel) — the WMMA paths (fmha_sm120, blackwell)
+    // reproduce the fp64 reference at 1e-2 on realistic uncorrelated data.
+    // All four are held strict in BOTH tiers; the f32 pair additionally has
+    // pairwise agreement. The fp8-QK paths (score-quantization noise, worst
+    // at short rows where no averaging happens — the #512 mechanism) are
     // CHARACTERIZED: stats printed, only gross breakage (NaN, envelope
     // exceeded) fails. mild=true selects the tighter envelope.
     void run_config(int cfg_idx, const char* name, int Sq, int Skv, int NH, int NKV, int HD, bool causal,
@@ -279,12 +279,17 @@ protected:
         // f32-score-chain paths: exact-ish QK accumulation + f32 softmax —
         // these track the fp64 reference even on sharp data.
         auto f32_chain = [](const PathResult& r) { return r.name == "cublas" || r.name == "fa2_f16"; };
+        // f16-class strict: f16 QK with f32 accumulators + f32 softmax + f16 P.
+        // Held to 1e-2 vs fp64 since the #528 race fix (measured ~4e-4).
+        auto f16_strict = [&](const PathResult& r) {
+            return f32_chain(r) || r.name == "fmha_sm120_f16" || r.name == "blackwell";
+        };
 
         // ---- each path vs the verified fp64 reference ----
         for (auto& r : results) {
             if (!r.ran)
                 continue;
-            const bool strict = f32_chain(r);
+            const bool strict = f16_strict(r);
             const float tol = strict ? 1e-2f : (mild ? 1.5f : 4.0f);
             ErrStats e = err_stats(r.O, ref, strict ? tol : 1e-2f);
             EXPECT_EQ(e.nan_count, 0) << r.name << ": NaN in output";
@@ -339,10 +344,15 @@ protected:
 // all numbers = max_rel vs fp64 ref, denom max(1,|ref|)):
 //   mild (amp=2, score sigma ~0.6):  fp8-QK 0.58-0.71 (worst at SHORT rows —
 //     e4m3 score noise with no averaging, the #512 mechanism), WMMA paths
-//     0.15-0.86 DESPITE f32 accumulators (worst at short rows; under
-//     investigation — cross-path divergence issue). f32-chain: < 1e-2.
+//     0.15-0.86 DESPITE f32 accumulators (worst at short rows). f32-chain:
+//     < 1e-2.
 //   sharp (amp=8, near-one-hot softmax): fp8 ~2.3 (76% of elements past
 //     5e-2), WMMA ~1.0-1.2. f32-chain still < 1e-2.
+// RESOLVED 2026-06-05 (#528): the WMMA divergence was the in-place
+// float→half S/P-tile compaction clobbering neighbor rows' float scores
+// (half row r aliases the bytes of float row r/2; padding rows raced ahead
+// zero-filling valid rows — hence worst at short seq). Post-fix the WMMA
+// paths measure ~4e-4 on all four configs and are held strict at 1e-2.
 // Production survives the characterized paths because real activations are
 // correlated and long-context averaging dilutes per-row flips (#511) — but
 // SHORT prefill must stay on the f32 chain (#512, #525), and the old %13

--- a/tests/test_attention_fmha_sm120.cu
+++ b/tests/test_attention_fmha_sm120.cu
@@ -90,11 +90,17 @@ protected:
         size_t kv_elems = B * Skv * NKV * HD;
 
         std::vector<float> Q_f(q_elems), K_f(kv_elems), V_f(kv_elems);
+        // NOTE: the int cast before the -6 is load-bearing (#525/#528). With
+        // size_t i, `(i*7+3)%13 - 6` underflows unsigned whenever %13 < 6 —
+        // ~46% of fills became ±inf, the reference went NaN and the NaN-
+        // dropping comparator passed vacuously. Also: the old V multiplier 13
+        // made V CONSTANT (i*13 % 13 == 0), so P@V was insensitive to the
+        // attention weights entirely; 17 (coprime to 13) restores coverage.
         for (size_t i = 0; i < q_elems; i++)
-            Q_f[i] = 0.02f * static_cast<float>((i * 7 + 3) % 13 - 6);
+            Q_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 7 + 3) % 13) - 6);
         for (size_t i = 0; i < kv_elems; i++) {
-            K_f[i] = 0.02f * static_cast<float>((i * 11 + 5) % 13 - 6);
-            V_f[i] = 0.02f * static_cast<float>((i * 13 + 7) % 13 - 6);
+            K_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 11 + 5) % 13) - 6);
+            V_f[i] = 0.2f * static_cast<float>(static_cast<int>((i * 17 + 7) % 13) - 6);
         }
 
         // CPU reference
@@ -147,12 +153,21 @@ protected:
         cudaMemcpy(O_h.data(), d_o, q_bytes, cudaMemcpyDeviceToHost);
 
         float max_err = 0.0f;
+        int non_finite = 0;
         for (size_t i = 0; i < q_elems; i++) {
             float got = __half2float(O_h[i]);
             float ref = O_ref[i];
-            float denom = std::max(std::abs(ref), 1e-6f);
+            if (!std::isfinite(got) || !std::isfinite(ref)) {
+                non_finite++;  // NaN would silently fall out of std::max below
+                continue;
+            }
+            // denom max(1,|ref|) as in test_attention_crosspath.cu: outputs
+            // are O(1)-bounded weighted averages of V; an |ref|-relative error
+            // with a 1e-6 floor explodes at sign crossings of correct kernels.
+            float denom = std::max(std::abs(ref), 1.0f);
             max_err = std::max(max_err, std::abs(got - ref) / denom);
         }
+        EXPECT_EQ(non_finite, 0) << "non-finite output/reference elements";
 
         EXPECT_LT(max_err, tol) << "Max relative error " << max_err << " exceeds threshold " << tol
                                 << " (B=" << B << " Sq=" << Sq << " Skv=" << Skv << " NH=" << NH
@@ -259,19 +274,12 @@ TEST_F(FmhaSm120Test, DispatchSelectsSm120FMHA) {
     run_test(1, 64, 64, 4, 4, 128, true, 0, 0.0f);
 }
 
-TEST_F(FmhaSm120Test, DISABLED_DispatchManual) {
-    // INVESTIGATION 2026-05-14: when called via this manual path, the kernel
-    // produces NaN output even with the IDENTICAL data pattern as run_test()
-    // which works for the same shape (B=1, S=64, NH=4, HD=128, causal). Both
-    // paths route through fmha_sm120_prefill → fmha_sm120_kernel with the
-    // same arguments. Diff is the surrounding setup; likely a CUDA stream /
-    // initialization state issue specific to invoking the kernel from a
-    // top-level TEST_F body rather than the run_test() helper. Reproduced
-    // via gtest_also_run_disabled_tests; debug prints show Q=correct, kernel
-    // returns true, no CUDA error, but O[0..7]=NaN. The kernel works fine
-    // when called via run_test() — see e.g. DispatchSelectsSm120FMHA which
-    // exercises this exact shape and passes.
-    // Leaving DISABLED until someone reproduces under nsys/compute-sanitizer.
+TEST_F(FmhaSm120Test, DispatchManual) {
+    // RESOLVED 2026-06-05 (#528): the 2026-05-14 "NaN mystery" (this manual
+    // path produced NaN while run_test() 'worked' on the same shape) was the
+    // size_t underflow in the %13 fills — ~46% of inputs were ±inf, so NaN
+    // output was CORRECT; run_test() only looked green because its comparator
+    // silently dropped NaNs via std::max. With the int cast both paths agree.
     const int B = 1, S = 64, NH = 4, HD = 128;
     size_t bytes = B * S * NH * HD * sizeof(half);
 
@@ -283,11 +291,11 @@ TEST_F(FmhaSm120Test, DISABLED_DispatchManual) {
 
     std::vector<half> h_q(B * S * NH * HD), h_k(B * S * NH * HD), h_v(B * S * NH * HD);
     for (size_t i = 0; i < h_q.size(); i++) {
-        h_q[i] = __float2half(0.02f * static_cast<float>(((i * 7 + 3) % 13) - 6));
+        h_q[i] = __float2half(0.02f * static_cast<float>(static_cast<int>((i * 7 + 3) % 13) - 6));
     }
     for (size_t i = 0; i < h_k.size(); i++) {
-        h_k[i] = __float2half(0.02f * static_cast<float>(((i * 11 + 5) % 13) - 6));
-        h_v[i] = __float2half(0.02f * static_cast<float>(((i * 13 + 7) % 13) - 6));
+        h_k[i] = __float2half(0.02f * static_cast<float>(static_cast<int>((i * 11 + 5) % 13) - 6));
+        h_v[i] = __float2half(0.2f * static_cast<float>(static_cast<int>((i * 17 + 7) % 13) - 6));
     }
     cudaMemcpy(d_q, h_q.data(), bytes, cudaMemcpyHostToDevice);
     cudaMemcpy(d_k, h_k.data(), bytes, cudaMemcpyHostToDevice);
@@ -320,12 +328,15 @@ TEST_F(FmhaSm120Test, DISABLED_DispatchManual) {
     // Check output has finite, non-zero values
     std::vector<half> h_o(B * S * NH * HD);
     cudaMemcpy(h_o.data(), d_o, bytes, cudaMemcpyDeviceToHost);
-    int finite_nonzero = 0;
+    int finite_nonzero = 0, nan_count = 0;
     for (auto& v : h_o) {
         float fv = __half2float(v);
         if (std::isfinite(fv) && fv != 0.0f)
             finite_nonzero++;
+        if (std::isnan(fv))
+            nan_count++;
     }
+    EXPECT_EQ(nan_count, 0) << "NaN in output with finite inputs";
     // Debug: check Q input is non-zero too
     std::vector<half> h_q_check(B * S * NH * HD);
     cudaMemcpy(h_q_check.data(), d_q, bytes, cudaMemcpyDeviceToHost);

--- a/tests/test_attention_tc.cu
+++ b/tests/test_attention_tc.cu
@@ -52,10 +52,12 @@ TEST_F(AttentionTCTest, SmallPrefill) {
     cudaMalloc(&d_v, kv_bytes);
     cudaMalloc(&d_o, qo_bytes);
 
-    // Initialize Q,K,V with small values that won't cause overflow
+    // Initialize Q,K,V with small values that won't cause overflow.
+    // int cast is load-bearing: `(i % 7) - 3` with size_t i underflows
+    // unsigned whenever %7 < 3 → ±inf fills (#525/#528).
     std::vector<half> h_qkv(B * S * NH * HD);
     for (size_t i = 0; i < h_qkv.size(); i++) {
-        h_qkv[i] = __float2half(0.02f * static_cast<float>((i % 7) - 3));
+        h_qkv[i] = __float2half(0.02f * static_cast<float>(static_cast<int>(i % 7) - 3));
     }
     cudaMemcpy(d_q, h_qkv.data(), qo_bytes, cudaMemcpyHostToDevice);
     cudaMemcpy(d_k, h_qkv.data(), kv_bytes, cudaMemcpyHostToDevice);
@@ -212,11 +214,16 @@ protected:
         size_t kv_elems = B * Skv * NKV * HD;
 
         std::vector<float> Q_f(q_elems), K_f(kv_elems), V_f(kv_elems);
+        // NOTE: the int cast before the -6 is load-bearing (#525/#528). With
+        // size_t i the subtraction underflows unsigned → ±inf fills → NaN
+        // reference → vacuous pass. The old V multiplier 13 made V CONSTANT
+        // (i*13 % 13 == 0), hiding any attention-weight error from P@V; 17
+        // (coprime to 13) restores coverage.
         for (size_t i = 0; i < q_elems; i++)
-            Q_f[i] = 0.02f * static_cast<float>((i * 7 + 3) % 13 - 6);
+            Q_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 7 + 3) % 13) - 6);
         for (size_t i = 0; i < kv_elems; i++) {
-            K_f[i] = 0.02f * static_cast<float>((i * 11 + 5) % 13 - 6);
-            V_f[i] = 0.02f * static_cast<float>((i * 13 + 7) % 13 - 6);
+            K_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 11 + 5) % 13) - 6);
+            V_f[i] = 0.2f * static_cast<float>(static_cast<int>((i * 17 + 7) % 13) - 6);
         }
 
         // CPU reference
@@ -264,14 +271,21 @@ protected:
         cudaMemcpy(O_h.data(), d_o, q_bytes, cudaMemcpyDeviceToHost);
 
         float max_err = 0.0f;
+        int non_finite = 0;
         for (size_t i = 0; i < q_elems; i++) {
             float got = __half2float(O_h[i]);
             float ref = O_ref[i];
-            float err_val = std::abs(got - ref);
-            // Relative tolerance for larger values
-            float denom = std::max(std::abs(ref), 1e-6f);
-            max_err = std::max(max_err, err_val / denom);
+            if (!std::isfinite(got) || !std::isfinite(ref)) {
+                non_finite++;  // NaN would silently fall out of std::max below
+                continue;
+            }
+            // denom max(1,|ref|) as in test_attention_crosspath.cu: outputs
+            // are O(1)-bounded weighted averages of V; an |ref|-relative error
+            // with a 1e-6 floor explodes at sign crossings of correct kernels.
+            float denom = std::max(std::abs(ref), 1.0f);
+            max_err = std::max(max_err, std::abs(got - ref) / denom);
         }
+        EXPECT_EQ(non_finite, 0) << "non-finite output/reference elements";
 
         // FP16 WMMA with online softmax: allow 1e-2 relative tolerance
         EXPECT_LT(max_err, 1e-2f) << "Max relative error " << max_err << " exceeds threshold 1e-2"
@@ -338,11 +352,12 @@ TEST_F(AttentionBlackwellTest, SlidingWindow) {
     size_t kv_elems = B * Skv * NKV * HD;
 
     std::vector<float> Q_f(q_elems), K_f(kv_elems), V_f(kv_elems);
+    // int cast + V multiplier 17: see run_test() above (#525/#528).
     for (size_t i = 0; i < q_elems; i++)
-        Q_f[i] = 0.02f * static_cast<float>((i * 7 + 3) % 13 - 6);
+        Q_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 7 + 3) % 13) - 6);
     for (size_t i = 0; i < kv_elems; i++) {
-        K_f[i] = 0.02f * static_cast<float>((i * 11 + 5) % 13 - 6);
-        V_f[i] = 0.02f * static_cast<float>((i * 13 + 7) % 13 - 6);
+        K_f[i] = 0.02f * static_cast<float>(static_cast<int>((i * 11 + 5) % 13) - 6);
+        V_f[i] = 0.2f * static_cast<float>(static_cast<int>((i * 17 + 7) % 13) - 6);
     }
 
     // CPU reference with sliding window mask
@@ -424,12 +439,18 @@ TEST_F(AttentionBlackwellTest, SlidingWindow) {
     cudaMemcpy(O_h.data(), d_o, q_bytes, cudaMemcpyDeviceToHost);
 
     float max_err = 0.0f;
+    int non_finite = 0;
     for (size_t i = 0; i < q_elems; i++) {
         float got = __half2float(O_h[i]);
         float ref = O_ref[i];
-        float denom = std::max(std::abs(ref), 1e-6f);
+        if (!std::isfinite(got) || !std::isfinite(ref)) {
+            non_finite++;  // NaN would silently fall out of std::max below
+            continue;
+        }
+        float denom = std::max(std::abs(ref), 1.0f);
         max_err = std::max(max_err, std::abs(got - ref) / denom);
     }
+    EXPECT_EQ(non_finite, 0) << "non-finite output/reference elements";
     EXPECT_LT(max_err, 1e-2f) << "Sliding window max relative error " << max_err;
 
     cudaFree(d_q);


### PR DESCRIPTION
Fixes #528 (WMMA attention paths diverge up to 0.85 rel from fp64 on realistic data).

## Root cause

The smem-materializing prefill kernels (`fmha_sm120_kernel` f16 + fp8, `flash_attention_blackwell_kernel`, `fmha_sm120_mxfp4_kernel`) convert the float S tile to the compact half P matrix **in place**: half row `r` occupies the **bytes of float row `r/2`**. The Step-6 stores therefore clobber float scores other threads have not read yet:

- **Deterministic even intra-warp:** row `2r+1`'s half stores land in row `r`'s float cols `>= Bkv/2`, which row `r`'s thread only reads in later loop iterations of the same lockstep loop.
- **Padding rows race ahead:** invalid rows skip softmax Steps 1–5 entirely (`row_valid` guards) and immediately zero-fill — into *valid* rows' float scores. This is why **short sequences were worst** (mild_short 0.85/0.70).

This explains every observation in #528: row-wise wrong attention *weights*, short rows worst, both WMMA paths affected, f32 accumulators ruled out.

## Fix

Stage this thread's normalized halves in registers, **one `__syncthreads()`**, then store. Applied to all four kernels with the pattern (mxfp4 included — same copy of the code).

## Evidence (controlled experiment)

Fix applied to `fmha_sm120_kernel` **only**, blackwell as control arm:

| path | mild_long | mild_short | mild_sw | sharp |
|---|---|---|---|---|
| fmha_sm120 before | 0.42 | **0.85** | 0.32 | 1.21 |
| fmha_sm120 after | **0.0004** | **0.0004** | **0.0004** | **0.0007** |
| blackwell (control, unfixed) | 0.157 | 0.702 | 0.265 | 1.023 (unchanged) |

After fixing all kernels, `fmha_fp8`'s envelope matches `fa2_e4m3` exactly (race component gone; residual = pure e4m3 score quantization).

## Also in this PR (issue TODOs 2+3)

- **Cross-path test**: `fmha_sm120_f16` + `blackwell` raised from *characterized* to **strict 1e-2** vs the fp64 reference.
- **`test_attention_fmha_sm120.cu` / `test_attention_tc.cu`**: the `%13` fills had the #525 size_t underflow (~46% ±inf → NaN reference → NaN-dropping `std::max` comparator → vacuous pass). Bonus finding: `V` used multiplier 13 ≡ 0 (mod 13) → **V was a constant**, so `P@V` was blind to attention-weight errors even with finite data. int cast + multiplier 17 + NaN-fest comparators.
- **`FmhaSm120Test.DISABLED_DispatchManual` re-enabled**: the 2026-05-14 "NaN mystery" was the underflow — ±inf inputs ⇒ NaN output was *correct*; passes now.

## Verification

- `test-attention`: 119 tests green (incl. strict cross-path + honest fills).
- Full `make test-gpu` + `make verify-fast`: green.
- E2E coherence (Qwen3-8B Q8_0, single-chunk 3.8k-token prefill, greedy, per dispatch variant): `fmha_sm120` and `blackwell` answer the needle question correctly with clean stop; fp8 variant behaves identically to the untouched FA2 default; stderr clean on all four (no NaN/fallback/capture messages).

## Perf

Production hot shape (hd=128) runs the register-resident FA2 kernel — **untouched**. The fixed kernels gain one barrier + a small register buffer per KV tile; the fp8 smem kernel is default-auto for hd≠128, the others are fallback-chain only. Perf baseline (Qwen3-8B, FA2 + paged decode) unaffected by construction; probe decode tg ≈ 219–229 tok/s at ctx 3.8k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)