### PR TITLE
chore(perf): refresh Q8_0 baseline — #526 drift was a depressed-host artifact, not a regression

### DIFF
--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -3,18 +3,18 @@
   "gpu": "NVIDIA GeForce RTX 5090",
   "cuda": "unknown",
   "vram_total_mb": 32607,
-  "timestamp": "2026-06-04T12:04:04Z",
+  "timestamp": "2026-06-04T22:52:45Z",
   "methodology": "median of 5 trials × 5 reps, 15s cooldown between trials (cuBLAS algo drift resistant)",
   "reps": 5,
   "n_trials": 5,
   "metrics": {
     "prefill_tps": {
-      "pp128": 3197.38,
-      "pp512": 7153.42,
-      "pp4096": 8751.49
+      "pp128": 3602.66,
+      "pp512": 8221.54,
+      "pp4096": 9781.29
     },
     "decode_tps": {
-      "tg128": 238.63
+      "tg128": 268.42
     },
     "memory_mb": {
       "model_weights": 8320


### PR DESCRIPTION
## Befund (closes #526)

**Keine Code-Regression.** Diskriminierungs-Experiment am 2026-06-05 (isoliert, Clock-Warmup, 10 reps × 3 Trials, `CUBLAS_WORKSPACE_CONFIG=:4096:8`):

| Build | 06-04 (Issue) | 06-05 (heute) |
|---|---|---|
| main@`8eb5ba6f` (#523) — exakt der Issue-Build | tg 234 | **tg 276 / 279 / 278** |
| HEAD (`931a2f19`) | — | tg 270 / 278 / 278 |

Derselbe Build, ~15% Unterschied zwischen den Tagen ⇒ die 06-04-Messung war host-seitig gedrückt (alle drei damals gemessenen Builds uniform betroffen). Ein Bisect über #485–#524 ist damit obsolet — im Verdachtsbereich gibt es auch keinen einzigen Commit, der den Q8_0-dense-Decode-CLI-Pfad heiß berührt.

## Konsequenz: Baseline-Korrektur

Der 06-04-Refresh (#525) hatte die gedrückten Zahlen in `tests/perf_baseline.json` festgeschrieben → Decode-Gate ~17% zu lax. Kanonisch neu generiert via `scripts/gen_perf_baseline.sh` (median of 5 trials × 5 reps):

| Metrik | alt (06-04) | neu (06-05) |
|---|---|---|
| tg128 | 238.63 | **268.42** (Samples: 279/256/264/279/268) |
| pp128 | 3197 | 3603 |
| pp512 | 7153 | 8222 |
| pp4096 | 8751 | 9781 |

## Erkenntnisse / Vorsorge

- **Decode ist innerhalb einer Session stabil, kann aber tagesweise 8–15% low lesen** (identischer Code: 276 am 05-28, 259 am 05-29, 238 am 06-04, 278 am 06-05). Die historische Deutung „276 war favorable conditions“ war falsch herum — ~278 ist der gesunde Wert.
- Gesunde Last-Referenz (für künftige Drift-Forensik, Clocks WÄHREND des Benchs samplen): ~2850 MHz SM / 13801 MHz mem / ~500 W bei util 100%.
- Lokal: CLAUDE.md-Benchmarking-Gotcha ergänzt (gitignored), GPU-Stats-Logger-Retention 30 min → 7 Tage erhöht — der nächste Drift-Fall ist retroaktiv diagnostizierbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
