### PR TITLE
fix(determinism): [runtime] deterministic wirkt jetzt via C API + bit-stabile Perplexity; E2E-Beweis auf GDN-Hybrid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,7 @@ if(IMP_BUILD_TESTS)
         tests/test_api_generate.cpp
         tests/test_engine_relaunch.cpp
         tests/test_prefix_cache_e2e.cpp
+        tests/test_determinism_e2e.cpp
     )
 
     set(IMP_TEST_BINARIES

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -15,6 +15,11 @@
 [runtime]
 # Force deterministic GEMM (cuBLASLt no_reduce_split). Slower but reproducible.
 deterministic_gemm   = false
+# Full reproducibility mode for temp=0 evals: deterministic MoE routing /
+# expert-scatter and top-k sampling kernels, implies deterministic_gemm.
+# Greedy output becomes bit-identical across runs/contexts (DetEvalE2ETest).
+# Legacy env: IMP_DETERMINISTIC=1. Costs a little throughput; off by default.
+deterministic        = false
 # CUDA Graph capture: "auto" picks per-model based on architecture support;
 # "always" forces capture (fails for MoE with D2H routing); "never" disables.
 cuda_graphs          = "auto"

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -773,8 +773,12 @@ ImpError imp_perplexity(ImpContext ctx, const int32_t* tokens, int n_tokens, dou
         if (e != IMP_SUCCESS)
             return e;
         double ppl = ctx->engine->executor()->perplexity_nll(tokens, n_tokens);
-        // Release the prefill request's KV.
-        ctx->active_request = nullptr;
+        // Release the prefill request's KV + recurrent slot. NOTE: do NOT
+        // null active_request first — imp_context_reset only cleans up
+        // (free_sequence / reset_ssm_state / slot release) when it still
+        // sees the request; nulling early leaked the KV sequence AND the
+        // SSM/GDN slot on every imp_perplexity call, so repeated scoring
+        // on hybrid models drifted (stale recurrent state, slot pool decay).
         imp_context_reset(ctx);
         if (ppl < 0.0)
             return IMP_ERROR_INTERNAL;

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -26,12 +26,14 @@
 
 namespace imp {
 
-// One block per row. Online max + logsumexp over the vocab, then accumulate
-// -logprob(target) into a global double accumulator. Skips the final corpus
-// position (no next token to predict).
+// One block per row. Online max + logsumexp over the vocab, then write
+// -logprob(target) to the per-position slot. Skips the final corpus position
+// (no next token to predict). Per-position writes (host sums in fixed index
+// order) instead of a global atomicAdd keep the NLL bit-reproducible —
+// cross-block atomic accumulation order varies run-to-run.
 __global__ void perplexity_nll_kernel(const float* __restrict__ logits,  // [csz, V]
                                        const int32_t* __restrict__ tokens, int chunk_start, int n,
-                                       int V, double* __restrict__ nll_accum) {
+                                       int V, double* __restrict__ nll_per_pos) {
     int row = blockIdx.x;                 // local row in this chunk
     int global_pos = chunk_start + row;   // position in the corpus
     if (global_pos >= n - 1)
@@ -75,7 +77,7 @@ __global__ void perplexity_nll_kernel(const float* __restrict__ logits,  // [csz
     if (tid == 0) {
         double lse = log(redd[0]) + static_cast<double>(mx);
         double logprob = static_cast<double>(lg[target]) - lse;
-        atomicAdd(nll_accum, -logprob);
+        nll_per_pos[global_pos] = -logprob;
     }
 }
 
@@ -94,10 +96,10 @@ double GraphExecutor::perplexity_nll(const int32_t* tokens, int n, cudaStream_t 
     int32_t* d_tokens = nullptr;
     double* d_nll = nullptr;
     IMP_CUDA_CHECK_LOG(cudaMalloc(&d_tokens, static_cast<size_t>(n) * sizeof(int32_t)));
-    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_nll, sizeof(double)));
+    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_nll, static_cast<size_t>(n) * sizeof(double)));
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_tokens, tokens, static_cast<size_t>(n) * sizeof(int32_t),
                                        cudaMemcpyHostToDevice, stream));
-    IMP_CUDA_CHECK_LOG(cudaMemsetAsync(d_nll, 0, sizeof(double), stream));
+    IMP_CUDA_CHECK_LOG(cudaMemsetAsync(d_nll, 0, static_cast<size_t>(n) * sizeof(double), stream));
 
     GemmContext ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config());
 
@@ -148,11 +150,16 @@ double GraphExecutor::perplexity_nll(const int32_t* tokens, int n, cudaStream_t 
                                                         n, V, d_nll);
     }
 
-    double h_nll = 0.0;
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(&h_nll, d_nll, sizeof(double), cudaMemcpyDeviceToHost, stream));
+    // Fixed-order host reduction over per-position NLLs (bit-reproducible).
+    std::vector<double> h_nll_pos(static_cast<size_t>(n), 0.0);
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_nll_pos.data(), d_nll, static_cast<size_t>(n) * sizeof(double),
+                                       cudaMemcpyDeviceToHost, stream));
     IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
     cudaFree(d_tokens);
     cudaFree(d_nll);
+    double h_nll = 0.0;
+    for (int i = 0; i < n - 1; ++i)
+        h_nll += h_nll_pos[i];
 
     double ppl = std::exp(h_nll / static_cast<double>(n - 1));
     IMP_LOG_INFO("perplexity_nll: n=%d  mean_nll=%.4f  PPL=%.4f", n, h_nll / (n - 1), ppl);

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1,6 +1,7 @@
 #include "runtime/engine.h"
 #include "runtime/engine_internal.h"
 #include "runtime/config.h"
+#include "runtime/process_diag.h"
 #include "runtime/vram_budget.h"
 #include "runtime/batch.h"
 #include "compute/mtp_forward.h"
@@ -399,6 +400,15 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // resolver_ helpers mutate this snapshot in place for arch-specific
     // defaults.
     runtime_config_ = take_pending_runtime_config();
+
+    // The deterministic kernel gate lives in process_diag (compute kernels
+    // read process_diag_deterministic_gemm()), but process_diag_install()
+    // only runs in tool mains. Promote the gate here so library/test
+    // embeddings (C API without a tool main) honor [runtime] deterministic /
+    // IMP_DETERMINISTIC too. True-promotion only — arch resolvers and tool
+    // installs may already have set it.
+    if (runtime_config_.runtime.deterministic || runtime_config_.runtime.deterministic_gemm)
+        process_diag_set_deterministic_gemm(true);
 
     init_apply_debug_raw_overrides_();
     init_resolve_kv_dtype_policy_();

--- a/tests/test_determinism_e2e.cpp
+++ b/tests/test_determinism_e2e.cpp
@@ -1,0 +1,216 @@
+// E2E proof for [runtime] deterministic — issue #522 item 3.
+//
+// The deterministic kernel variants (MoE permute/scatter, top-k softmax sum,
+// cuBLASLt algo pinning) shipped with the audit-B9 work, gated on
+// process_diag_deterministic_gemm(), but nothing ever ASSERTED the resulting
+// guarantee. This test is that proof, against the model family where the
+// nondeterminism is documented (MoE/hybrid — Qwen3.6-35B is the known
+// temp=0 flipper; see memory/audit B-9):
+//
+//   deterministic=true  ⇒  greedy output and teacher-forced perplexity are
+//   byte-/bit-identical for repeated requests on one context (server eval
+//   steady state) and across fresh processes (CLI eval runs; verified
+//   manually, 2× identical on Qwen3.6-35B).
+//
+// KNOWN LIMIT (the DISABLED_ tests below are the gate): across FRESH
+// CONTEXTS in ONE process, output on the GDN-hybrid is only *usually*
+// identical — observed flaky for both greedy decode and perplexity on
+// Qwen3.6-35B (same binary alternated green/red run-to-run; PPL deltas up
+// to a few percent, i.e. state-sized, not rounding-sized). The varying
+// input is per-context engine state (VRAM layout, CUDA-graph capture, slot
+// assignment); not yet pinned down. Eval workloads don't hit this (server =
+// one context; CLI = one process). Historical note: SAME-context perplexity
+// drift had a separate root cause — imp_perplexity nulled active_request
+// before imp_context_reset, leaking the KV sequence + SSM/GDN slot per call
+// (fixed in imp_api.cpp alongside this test).
+//
+// Gated on IMP_TEST_MOE_MODEL (point it at an MoE/hybrid model dir or .gguf;
+// dense models pass trivially since they skip the routed-expert kernels).
+// The deterministic flag reaches the engine via the legacy IMP_DETERMINISTIC
+// env seed: library users without a tool-main RuntimeConfig::load() get
+// env-seeded defaults from take_pending_runtime_config() at engine init.
+
+#include <gtest/gtest.h>
+
+#include "imp/imp.h"
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+const char* model_path() { return std::getenv("IMP_TEST_MOE_MODEL"); }
+
+bool is_safetensors_dir(const std::string& p) {
+    return p.size() < 5 || p.substr(p.size() - 5) != ".gguf";
+}
+
+class DetEvalE2ETest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const char* path = model_path();
+        if (!path)
+            GTEST_SKIP() << "Set IMP_TEST_MOE_MODEL to run deterministic-mode E2E";
+        // Must be set BEFORE imp_context_create: engine init pulls the
+        // env-seeded RuntimeConfig via take_pending_runtime_config().
+        setenv("IMP_DETERMINISTIC", "1", 1);
+        path_ = path;
+        fmt_ = is_safetensors_dir(path_) ? IMP_FORMAT_SAFETENSORS : IMP_FORMAT_GGUF;
+        ASSERT_EQ(imp_model_load(path, fmt_, &model_), IMP_SUCCESS);
+    }
+
+    void TearDown() override {
+        if (ctx_)
+            imp_context_free(ctx_);
+        if (model_)
+            imp_model_free(model_);
+        unsetenv("IMP_DETERMINISTIC");
+    }
+
+    void MakeContext(bool cuda_graphs = true) {
+        ImpConfig cfg = imp_config_default();
+        cfg.max_seq_len = 1024;
+        cfg.max_batch_size = 1;
+        cfg.enable_cuda_graphs = cuda_graphs ? 1 : 0;
+        ASSERT_EQ(imp_context_create(model_, &cfg, &ctx_), IMP_SUCCESS);
+    }
+
+    void FreeContext() {
+        imp_context_free(ctx_);
+        ctx_ = nullptr;
+    }
+
+    std::string gen(const char* prompt, int max_tokens) {
+        ImpGenerateParams p = imp_generate_params_default();
+        p.temperature = 0.0f;
+        p.top_k = 1;
+        p.top_p = 1.0f;
+        p.seed = 42;
+        p.max_tokens = max_tokens;
+        p.ignore_eos = 0;
+
+        std::string out(16384, '\0');
+        size_t out_len = 0;
+        EXPECT_EQ(imp_generate(ctx_, prompt, &p, out.data(), out.size(), &out_len), IMP_SUCCESS);
+        out.resize(out_len);
+        return out;
+    }
+
+    std::string path_;
+    ImpModelFormat fmt_ = IMP_FORMAT_GGUF;
+    ImpModel model_ = nullptr;
+    ImpContext ctx_ = nullptr;
+};
+
+// Prompts chosen to push through enough routed-expert decode steps that an
+// atomics-order flip would have many chances to surface (the documented
+// Qwen3.6-35B flips appeared within ~100 tokens).
+constexpr const char* kPrompts[] = {
+    "Explain why the sky is blue, then explain why sunsets are red.",
+    "List the first ten prime numbers and briefly say why each is prime.",
+    "Write a short story about a lighthouse keeper who finds a message in a bottle.",
+};
+
+constexpr int kGen = 96;
+
+// 0. DIAGNOSTIC SPLIT: same-context repeats with CUDA graphs OFF. The first
+//    request on a context runs partially eager while the conditional graph
+//    captures; later requests replay the graph — a different kernel mix for
+//    the same step. Graphs-off isolates the underlying kernels from that mix.
+TEST_F(DetEvalE2ETest, GreedyReproducibleSameContextGraphsOff) {
+    MakeContext(/*cuda_graphs=*/false);
+    for (const char* prompt : kPrompts) {
+        std::string first = gen(prompt, kGen);
+        std::string second = gen(prompt, kGen);
+
+        ASSERT_FALSE(first.empty()) << "model produced no output for: " << prompt;
+        EXPECT_EQ(first, second) << "deterministic=1 greedy diverged back-to-back with graphs "
+                                    "OFF for prompt:\n  "
+                                 << prompt << "\n  run1: " << first << "\n  run2: " << second;
+    }
+    FreeContext();
+}
+
+// 1. Greedy output must be byte-identical for repeated requests on ONE
+//    context — the serving/eval steady state (server process, many requests).
+TEST_F(DetEvalE2ETest, GreedyReproducibleSameContext) {
+    MakeContext();
+    for (const char* prompt : kPrompts) {
+        std::string first = gen(prompt, kGen);
+        std::string second = gen(prompt, kGen);
+
+        ASSERT_FALSE(first.empty()) << "model produced no output for: " << prompt;
+        EXPECT_EQ(first, second) << "deterministic=1 greedy output diverged back-to-back on "
+                                    "one context for prompt:\n  "
+                                 << prompt << "\n  run1: " << first << "\n  run2: " << second;
+    }
+    FreeContext();
+}
+
+// 2. KNOWN LIMIT (see header): cross-context greedy in one process is flaky
+//    — DISABLED_ is the gate; enable when the layout-sensitive source is
+//    pinned and fixed.
+TEST_F(DetEvalE2ETest, DISABLED_GreedyReproducibleAcrossFreshContexts) {
+    for (const char* prompt : kPrompts) {
+        MakeContext();
+        std::string first = gen(prompt, kGen);
+        FreeContext();
+
+        MakeContext();
+        std::string second = gen(prompt, kGen);
+        FreeContext();
+
+        ASSERT_FALSE(first.empty()) << "model produced no output for: " << prompt;
+        EXPECT_EQ(first, second) << "deterministic=1 greedy output diverged across fresh "
+                                    "contexts for prompt:\n  "
+                                 << prompt << "\n  run1: " << first << "\n  run2: " << second;
+    }
+}
+
+// 3. Teacher-forced perplexity must be bit-identical for repeated scoring on
+//    one context — the eval number itself is the artifact agent evals
+//    compare. (Guards the per-position NLL reduction: the old cross-block
+//    double atomicAdd accumulated in scheduling-dependent order.)
+TEST_F(DetEvalE2ETest, PerplexityBitIdenticalSameContext) {
+    // Token IDs are model-agnostic small IDs; content doesn't matter for
+    // reproducibility, only that the same sequence is scored twice.
+    std::vector<int32_t> tokens;
+    for (int i = 0; i < 256; ++i)
+        tokens.push_back(1000 + (i * 37) % 4000);
+
+    MakeContext();
+    double ppl1 = 0.0;
+    ASSERT_EQ(imp_perplexity(ctx_, tokens.data(), static_cast<int>(tokens.size()), &ppl1), IMP_SUCCESS);
+    double ppl2 = 0.0;
+    ASSERT_EQ(imp_perplexity(ctx_, tokens.data(), static_cast<int>(tokens.size()), &ppl2), IMP_SUCCESS);
+    FreeContext();
+
+    EXPECT_GT(ppl1, 0.0);
+    // Bit-identical, not approximately equal — that is the deliverable.
+    EXPECT_EQ(ppl1, ppl2) << "perplexity differs back-to-back under deterministic=1: " << ppl1
+                          << " vs " << ppl2;
+}
+
+// 4. KNOWN LIMIT companion (see header): cross-context perplexity in one
+//    process — flaky on the GDN-hybrid like the greedy variant.
+TEST_F(DetEvalE2ETest, DISABLED_PerplexityBitIdenticalAcrossFreshContexts) {
+    std::vector<int32_t> tokens;
+    for (int i = 0; i < 256; ++i)
+        tokens.push_back(1000 + (i * 37) % 4000);
+
+    MakeContext();
+    double ppl1 = 0.0;
+    ASSERT_EQ(imp_perplexity(ctx_, tokens.data(), static_cast<int>(tokens.size()), &ppl1), IMP_SUCCESS);
+    FreeContext();
+
+    MakeContext();
+    double ppl2 = 0.0;
+    ASSERT_EQ(imp_perplexity(ctx_, tokens.data(), static_cast<int>(tokens.size()), &ppl2), IMP_SUCCESS);
+    FreeContext();
+
+    EXPECT_EQ(ppl1, ppl2) << "perplexity differs across fresh contexts under deterministic=1: "
+                          << ppl1 << " vs " << ppl2;
+}
+
+}  // namespace


### PR DESCRIPTION
## #522 Item 3: `[runtime] deterministic` komplettiert + bewiesen

Die deterministischen Kernel-Varianten (MoE permute/scatter, top-k softmax-sum, cuBLASLt-Algo-Pinning) existierten seit Audit B-9 — aber **nichts hat die Garantie je geprüft**, und der neue Beweis-Test fand sofort drei echte Defekte:

### Fixes

1. **Gate im Library-Pfad tot** — `process_diag_install()` läuft nur in Tool-mains; über die C-API hatte `[runtime] deterministic` / `IMP_DETERMINISTIC` **null Wirkung** (Kernel-Gate blieb false). `Engine::init` promotet das Gate jetzt selbst aus seiner RuntimeConfig.
2. **`imp_perplexity` leakte pro Aufruf** — `active_request = nullptr` *vor* `imp_context_reset` → der Reset räumte nichts auf: KV-Sequenz **und** SSM/GDN-Slot leakten bei jedem Aufruf; wiederholtes Scoring auf Hybrid-Modellen driftete (stale Recurrent-State, Slot-Pool-Verfall).
3. **PPL-NLL-Reduktion nondeterministisch** — cross-block `atomicAdd(double)` in Scheduling-Reihenfolge → jetzt per-Position-Writes + Host-Summe in fester Indexreihenfolge (bit-reproduzierbar, perf-neutral).

### Beweis: `DetEvalE2ETest` (gated auf `IMP_TEST_MOE_MODEL`, gefahren auf Qwen3.6-35B-A3B — dem dokumentierten temp=0-Flipper)

3× stabil grün:
- Greedy byte-identisch back-to-back auf einem Kontext (Graphs ON **und** OFF)
- Perplexity bit-identisch back-to-back auf einem Kontext
- Fresh-Process-Greedy manuell verifiziert (CLI 2× identisch, MD5-gleich)

### Dokumentierte Grenze (DISABLED_-Gates im Test + Header-Doku)

Über **frische Kontexte im selben Prozess** flippt der GDN-Hybrid weiterhin gelegentlich (PPL-Deltas in Prozent-Größe = State, nicht Rundung; gleiche Binary alternierte grün/rot). Quelle ist per-Kontext-Engine-State (VRAM-Layout/Graph-Capture/Slot-Zuordnung), noch nicht gepinnt. **Eval-Workloads trifft das nicht** (Server = ein Kontext, CLI = ein Prozess). Die zwei DISABLED_-Tests sind das Aktivierungs-Gate, falls jemand die Quelle fixt.

### Verifikation

- DetEvalE2ETest 3/3 Läufe × 3 Tests grün; bewusst falsifiziert: ohne Gate-Fix waren alle rot
- verify-fast grün (tg128 274.9 = +2.4 %, pp512 +2.3 %)
- test-core/test-kv unverändert grün

Item 2 (per-request spec-decode) wird separat im Issue als won't-do begründet; Item 4 (LoRA) bleibt offen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
