### PR TITLE
test(chunked-prefill): dedicated IMP_TEST_MODEL_QWEN4B env — stop generic suite model from hijacking 4B-calibrated expectations

### DIFF
--- a/tests/.env.test
+++ b/tests/.env.test
@@ -2,8 +2,18 @@
 # Set these to run full end-to-end tests with real models.
 # Tests are skipped if the model file doesn't exist.
 
-# Primary test model: small, fast, exercises standard attention + FFN
+# Primary test model: the model under test for model-agnostic E2E gates
+# (prefix cache, greedy locks, engine relaunch, API generate, ...).
 IMP_TEST_MODEL=/models/Qwen3-4B-Instruct-2507-Q8_0.gguf
+
+# Chunked-prefill equality suite: calibrated for Qwen3-4B specifically
+# (chunk=0 vs chunk>0 cross attention-kernel paths on other models, where
+# greedy ties may flip). Separate from IMP_TEST_MODEL so suite runs with a
+# different model under test don't hijack these expectations.
+IMP_TEST_MODEL_QWEN4B=/models/Qwen3-4B-Instruct-2507-Q8_0.gguf
 
 # Secondary test model: GDN hybrid architecture (Qwen3.5 Gated DeltaNet)
 IMP_TEST_MODEL_GDN=/models/Qwen3.5-4B-Q8_0.gguf
+
+# Deterministic-mode E2E proof (DetEvalE2ETest): MoE/hybrid model
+IMP_TEST_MOE_MODEL=/models/Qwen3.6-35B-A3B-NVFP4

--- a/tests/test_chunked_prefill.cu
+++ b/tests/test_chunked_prefill.cu
@@ -89,10 +89,15 @@ static std::string generate_greedy(const char* model_path, const std::string& pr
 class ChunkedPrefillTest : public ::testing::Test {
 protected:
     // Model paths: env var override → /models absolute path (Docker bind-mount).
-    // IMP_TEST_MODEL=path overrides Qwen3-4B path.
+    // IMP_TEST_MODEL_QWEN4B=path overrides the Qwen3-4B path. Deliberately NOT
+    // the generic IMP_TEST_MODEL: suite runs set that to whatever model is
+    // under test (e.g. Qwen3-8B for the prefix-cache/greedy-lock gates), and
+    // these chunk-equality expectations are calibrated for Qwen3-4B — on other
+    // models chunk=0 vs chunk>0 cross the attention-kernel threshold into
+    // DIFFERENT kernel paths, where greedy logit ties may legitimately flip.
     // IMP_TEST_MODEL_LLAMA=path overrides Llama-3B path.
     static const char* qwen3_4b_path() {
-        const char* p = std::getenv("IMP_TEST_MODEL");
+        const char* p = std::getenv("IMP_TEST_MODEL_QWEN4B");
         if (p) return p;
         return "/models/Qwen3-4B-Instruct-2507-Q8_0.gguf";
     }


### PR DESCRIPTION
Suite runs set IMP_TEST_MODEL to the model under test (e.g. Qwen3-8B for
the prefix-cache / greedy-lock / determinism gates). ChunkedPrefillTest
reused that same env as an override for its Qwen3-4B path, so a full
imp-tests run with a different model forced the chunk-equality tests onto
a model they are not calibrated for — chunk=0 vs chunk>0 cross the
attention-kernel threshold into different kernel paths there, where greedy
logit ties may legitimately flip, producing 3 spurious FAILs.

Now reads IMP_TEST_MODEL_QWEN4B (documented in tests/.env.test, which also
gains the missing IMP_TEST_MOE_MODEL entry). Full imp-tests with
IMP_TEST_MODEL=Qwen3-8B + IMP_TEST_MOE_MODEL=Qwen3.6-35B: 0 FAILED across
all 8 modules.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
