### PR TITLE
docs(usage): Google Test pin is v1.17.0, not v1.14.0

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ Build instructions, CLI/server usage, configuration, C API, project structure.
 - **CMake 3.25+**
 - **C++20 compiler** (GCC 11+, Clang 14+)
 
-CUTLASS v4.5.1 and Google Test v1.14.0 are fetched automatically via
+CUTLASS v4.5.1 and Google Test v1.17.0 are fetched automatically via
 `FetchContent`. `stb_image` and `stb_image_resize2` are vendored in
 `third_party/stb/`.
 


### PR DESCRIPTION
One-line follow-up to #544: `docs/usage.md` claimed GTest v1.14.0; `CMakeLists.txt:64` and `Dockerfile:32` both pin **v1.17.0** (which is also the latest upstream release). Found during the post-#544 upstream-update sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)