### PR TITLE
chore(deps): bump cpp-httplib v0.46.0 → v0.46.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ endif()
 if(IMP_BUILD_SERVER)
     FetchContent_Declare(httplib
         GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-        GIT_TAG v0.46.0
+        GIT_TAG v0.46.1
         GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(httplib)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV CUDA_HOME=/usr/local/cuda
 # Tags must mirror the FetchContent_Declare entries in CMakeLists.txt.
 RUN git clone --depth=1 --branch v1.17.0 https://github.com/google/googletest.git /deps/googletest \
  && git clone --depth=1 --branch v4.5.1  https://github.com/NVIDIA/cutlass.git    /deps/cutlass    \
- && git clone --depth=1 --branch v0.46.0 https://github.com/yhirose/cpp-httplib.git /deps/httplib  \
+ && git clone --depth=1 --branch v0.46.1 https://github.com/yhirose/cpp-httplib.git /deps/httplib  \
  && git clone --depth=1 --branch v3.12.0 https://github.com/nlohmann/json.git     /deps/json
 
 WORKDIR /src


### PR DESCRIPTION
Closes out the upstream-update sweep: httplib was the only pin with a newer release. All other pins (CUTLASS v4.5.1, GTest v1.17.0, nlohmann/json v3.12.0, `nvidia/cuda:13.3.0` base) are already latest upstream.

v0.46.1 is a patch release (client-side TLS `Expect: 100-continue` fix + Windows warning fixes) — neither path affects imp's plain-HTTP Linux server use; this is hygiene to stay current. Both pin sites updated (CMakeLists FetchContent + Dockerfile deps clone).

## Validation
- Rebuilt `imp:test` from the bumped Dockerfile (clone-layer cache invalidated by the changed `RUN` line → provably built against v0.46.1)
- Full GPU suite on the rebuilt image: **1108 tests, 0 FAILED** (IMP_TEST_MODEL=Qwen3-8B-Q8_0, IMP_TEST_MOE_MODEL=Qwen3.6-35B-A3B-NVFP4)
- Live `imp-server` smoke: `/health` ok, `/v1/chat/completions` non-stream + SSE streaming clean (no NUL bytes in deltas, well-formed chunks)
- `verify-fast` via pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)