### PR TITLE
fix(prefill): fa2_fp16qk wrong attention on chunk continuation + chunk-aware imp_perplexity; NLL-based chunked gates (#548)

### DIFF
--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -765,14 +765,20 @@ ImpError imp_perplexity(ImpContext ctx, const int32_t* tokens, int n_tokens, dou
     }
     *out_ppl = -1.0;
     try {
-        // Fresh context so hidden_ holds exactly this corpus after prefill.
+        // Fresh context so the prefill covers exactly this corpus.
         imp_context_reset(ctx);
-        // Single-chunk prefill (caller must configure prefill_chunk_size=0 / corpus
-        // <= chunk size) so the persistent hidden_ retains all n positions.
+        // Chunked-prefill-aware: the engine accumulates per-position NLL
+        // after every chunk it forwards. (The executor's hidden_ only
+        // retains the most recent chunk, so the historical post-hoc
+        // executor()->perplexity_nll() silently scored stale positions
+        // whenever the resolved prefill chunk size was smaller than the
+        // corpus — which is the C-API DEFAULT: prefill_chunk_size=-1
+        // resolves to 512 on dense archs.)
+        if (!ctx->engine->begin_perplexity_capture(tokens, n_tokens))
+            return IMP_ERROR_INTERNAL;
         ImpError e = imp_prefill(ctx, tokens, n_tokens);
-        if (e != IMP_SUCCESS)
-            return e;
-        double ppl = ctx->engine->executor()->perplexity_nll(tokens, n_tokens);
+        double ppl = -1.0;
+        const bool reduced = ctx->engine->end_perplexity_capture(&ppl);  // always frees buffers
         // Release the prefill request's KV + recurrent slot. NOTE: do NOT
         // null active_request first — imp_context_reset only cleans up
         // (free_sequence / reset_ssm_state / slot release) when it still
@@ -780,7 +786,9 @@ ImpError imp_perplexity(ImpContext ctx, const int32_t* tokens, int n_tokens, dou
         // SSM/GDN slot on every imp_perplexity call, so repeated scoring
         // on hybrid models drifted (stale recurrent state, slot pool decay).
         imp_context_reset(ctx);
-        if (ppl < 0.0)
+        if (e != IMP_SUCCESS)
+            return e;
+        if (!reduced || ppl < 0.0)
             return IMP_ERROR_INTERNAL;
         *out_ppl = ppl;
         return IMP_SUCCESS;

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -605,11 +605,25 @@ public:
     // logits_out will be a view into the internal logits buffer.
     void forward_logits(const InferenceState& state, Tensor& logits_out, cudaStream_t stream = nullptr);
 
-    // Teacher-forced perplexity over tokens[0..n-1]. Call AFTER a prefill of the
-    // same tokens (uses the persistent-workspace hidden_, which holds all-position
-    // final hidden after forward_logits). Applies the tier-aware LM head to every
-    // position in chunks and returns exp(mean NLL of next tokens). Bench/eval only.
+    // Teacher-forced perplexity over tokens[0..n-1]. Call AFTER a SINGLE-CHUNK
+    // prefill of the same tokens (uses the persistent-workspace hidden_, which
+    // holds all-position final hidden after forward_logits). Applies the
+    // tier-aware LM head to every position in chunks and returns exp(mean NLL
+    // of next tokens). Bench/eval only. For chunked prefill use the
+    // Engine::begin/end_perplexity_capture flow, which accumulates via
+    // perplexity_nll_partial after every chunk's forward.
     double perplexity_nll(const int32_t* tokens, int n, cudaStream_t stream = nullptr);
+
+    // Per-chunk NLL accumulation (chunked-prefill-aware imp_perplexity).
+    // Applies the tier-aware LM head to hidden_[0..chunk_len-1] — the chunk
+    // that prefill just forwarded, absolute corpus positions chunk_start..
+    // chunk_start+chunk_len-1 — and writes -log p(next token) into
+    // d_nll[global_pos]. d_tokens / d_nll are device buffers of length
+    // n_total owned by the caller (Engine ppl capture). Enqueues on `stream`
+    // only; the caller reduces after a sync. Overwrites the logits_
+    // workspace — call only after all reads of the chunk's logits are done.
+    void perplexity_nll_partial(const int32_t* d_tokens, int n_total, int chunk_start,
+                                int chunk_len, double* d_nll, cudaStream_t stream);
 
     // Sample tokens from pre-computed logits (for use after CUDA graph execution).
     std::vector<int32_t> sample_from_logits(const Tensor& logits, const InferenceState& state,

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -57,13 +57,23 @@ namespace imp {
 // in f16-QK mode. Same numerical class as the cuBLAS reference (f16 inputs,
 // f32 accumulate) — the short-seq e4m3 quality cliff (#511/#512) does not
 // apply, and no [n × ctx] S-matrix is materialized. Declined configs
-// (hd!=128, non-F16) return false → caller stays on cuBLAS; the fp8 FMHA
-// family is intentionally NOT a fallback here.
+// (hd!=128, non-F16, chunk continuation) return false → caller stays on
+// cuBLAS; the fp8 FMHA family is intentionally NOT a fallback here.
 static bool try_fa2_fp16qk_prefill(const RuntimeConfig& rcfg, const Tensor& q, const Tensor& k,
                                    const Tensor& v, Tensor& o, int n, int kv_len, int nh, int nkv, int hd,
                                    float scale, int sliding_window, float softcap, int q_offset,
                                    cudaStream_t stream) {
     if (rcfg.attention.fa2_fp16qk == "never" || hd != 128)
+        return false;
+    // Chunk CONTINUATION (q_offset > 0, queries attend gathered past KV) is
+    // declined: the f16-QK kernel produces wrong attention there on the
+    // Llama family (teacher-forced NLL 0.29 → 7.13 on Llama-3.2-3B at
+    // chunk=64; greedy output token-identical to single-shot once routed to
+    // cuBLAS instead). Qwen3 was bit-exact through the same path, so this is
+    // a conservative blanket decline until the kernel's q_offset handling is
+    // root-caused (issue #548) — first chunks (q_offset == 0, the original #525 use case)
+    // keep the fast path.
+    if (q_offset > 0)
         return false;
     int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
     int64_t kv4s[4] = {1, (int64_t)kv_len, (int64_t)nkv, (int64_t)hd};

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -1,11 +1,17 @@
 // Teacher-forced perplexity over a token sequence.
 //
-// Assumes the caller has just run a prefill of `tokens[0..n-1]` so the
-// persistent-workspace `hidden_` holds the final-layer hidden state for ALL n
-// positions (forward_logits leaves it intact — it only slices the last token
-// for the production LM head). We then apply the (tier-aware) LM head to every
-// position in chunks of <= max_logit_tokens_ (logits_ is batch-sized) and
-// accumulate the negative log-likelihood of each actual next token.
+// Two entry points:
+//  - perplexity_nll(tokens, n): assumes a SINGLE-CHUNK prefill of
+//    `tokens[0..n-1]` just ran, so the persistent-workspace `hidden_` holds
+//    the final-layer hidden state for ALL n positions (forward_logits leaves
+//    it intact — it only slices the last token for the production LM head).
+//  - perplexity_nll_partial(...): per-chunk accumulation for CHUNKED prefill
+//    (hidden_ only retains the most recent chunk). Driven by the engine's
+//    step_prefill_one via begin/end_perplexity_capture — that flow backs
+//    imp_perplexity, whose default config resolves to chunked prefill.
+// Both apply the (tier-aware) LM head to every position in batches of
+// <= max_logit_tokens_ (logits_ is batch-sized) and accumulate the negative
+// log-likelihood of each actual next token.
 //
 // PPL = exp( (1/(n-1)) * sum_{i=0}^{n-2} -log softmax(logits_i)[tokens_{i+1}] ).
 //
@@ -81,25 +87,14 @@ __global__ void perplexity_nll_kernel(const float* __restrict__ logits,  // [csz
     }
 }
 
-double GraphExecutor::perplexity_nll(const int32_t* tokens, int n, cudaStream_t stream) {
-    if (!initialized_ || n < 2) {
-        IMP_LOG_ERROR("perplexity_nll: not initialized or n < 2 (n=%d)", n);
-        return -1.0;
+void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total, int chunk_start,
+                                           int chunk_len, double* d_nll, cudaStream_t stream) {
+    if (!initialized_ || chunk_len <= 0 || n_total < 2 || !d_tokens || !d_nll) {
+        return;
     }
     const auto& cfg = model_->config();
     const int V = cfg.vocab_size;
     const int mb = max_logit_tokens_ > 0 ? max_logit_tokens_ : 1;
-
-    // Ensure the (single-chunk) prefill that populated hidden_ is complete.
-    IMP_CUDA_CHECK_LOG(cudaDeviceSynchronize());
-
-    int32_t* d_tokens = nullptr;
-    double* d_nll = nullptr;
-    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_tokens, static_cast<size_t>(n) * sizeof(int32_t)));
-    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_nll, static_cast<size_t>(n) * sizeof(double)));
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_tokens, tokens, static_cast<size_t>(n) * sizeof(int32_t),
-                                       cudaMemcpyHostToDevice, stream));
-    IMP_CUDA_CHECK_LOG(cudaMemsetAsync(d_nll, 0, static_cast<size_t>(n) * sizeof(double), stream));
 
     GemmContext ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config());
 
@@ -127,9 +122,9 @@ double GraphExecutor::perplexity_nll(const int32_t* tokens, int n, cudaStream_t 
         }
     }
 
-    Tensor hidden_all = view_tokens(hidden_, n);
-    for (int c = 0; c < n; c += mb) {
-        int csz = (n - c < mb) ? (n - c) : mb;
+    Tensor hidden_all = view_tokens(hidden_, chunk_len);
+    for (int c = 0; c < chunk_len; c += mb) {
+        int csz = (chunk_len - c < mb) ? (chunk_len - c) : mb;
         Tensor hc = hidden_all.slice(c, c + csz);          // [csz, d]
         Tensor lg = view_tokens(logits_, csz);             // [csz, V]
         if (lm_is_nvfp4) {
@@ -146,9 +141,29 @@ double GraphExecutor::perplexity_nll(const int32_t* tokens, int n, cudaStream_t 
             rmsnorm(hc, model_->output_norm(), noc, cfg.rms_norm_eps, stream, norm_w_off_);
             gemm_via_handle_(model_->out_proj_id, noc, lg, ctx);
         }
-        perplexity_nll_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), d_tokens, c,
-                                                        n, V, d_nll);
+        perplexity_nll_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), d_tokens,
+                                                        chunk_start + c, n_total, V, d_nll);
     }
+}
+
+double GraphExecutor::perplexity_nll(const int32_t* tokens, int n, cudaStream_t stream) {
+    if (!initialized_ || n < 2) {
+        IMP_LOG_ERROR("perplexity_nll: not initialized or n < 2 (n=%d)", n);
+        return -1.0;
+    }
+
+    // Ensure the (single-chunk) prefill that populated hidden_ is complete.
+    IMP_CUDA_CHECK_LOG(cudaDeviceSynchronize());
+
+    int32_t* d_tokens = nullptr;
+    double* d_nll = nullptr;
+    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_tokens, static_cast<size_t>(n) * sizeof(int32_t)));
+    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_nll, static_cast<size_t>(n) * sizeof(double)));
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_tokens, tokens, static_cast<size_t>(n) * sizeof(int32_t),
+                                       cudaMemcpyHostToDevice, stream));
+    IMP_CUDA_CHECK_LOG(cudaMemsetAsync(d_nll, 0, static_cast<size_t>(n) * sizeof(double), stream));
+
+    perplexity_nll_partial(d_tokens, n, /*chunk_start=*/0, /*chunk_len=*/n, d_nll, stream);
 
     // Fixed-order host reduction over per-position NLLs (bit-reproducible).
     std::vector<double> h_nll_pos(static_cast<size_t>(n), 0.0);

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -134,6 +134,18 @@ public:
     // stale block table pointers when KV blocks are reused)
     void reset_batch_pool_cache();
 
+    // Chunked-prefill-aware teacher-forced perplexity (imp_perplexity).
+    // begin: upload the target tokens + zero a per-position NLL buffer.
+    // While active, step_prefill_one accumulates -log p(next token) for every
+    // chunk it forwards (the executor's hidden_ only retains the most recent
+    // chunk, so a post-hoc executor()->perplexity_nll() reads stale positions
+    // whenever the resolved prefill chunk size is smaller than the corpus).
+    // Prefix-cache block reuse is bypassed while active so every position is
+    // actually forwarded. end: fixed-order host reduction (bit-reproducible),
+    // returns exp(mean NLL) in *out_ppl and always frees the buffers.
+    [[nodiscard]] bool begin_perplexity_capture(const int32_t* tokens, int n);
+    [[nodiscard]] bool end_perplexity_capture(double* out_ppl);
+
     // Vision: set image for next generation. Returns false if no mmproj loaded.
     [[nodiscard]] bool set_image(const std::string& path);
     [[nodiscard]] bool set_image_from_memory(const uint8_t* data, size_t len);
@@ -277,6 +289,16 @@ private:
     int32_t* async_d_banned_tokens_ = nullptr;
     std::vector<int32_t> async_pending_tokens_;
     int async_pending_cursor_ = 0;
+
+    // Teacher-forced perplexity capture (begin/end_perplexity_capture).
+    // Device buffers of length n; step_prefill_one writes per-position NLL
+    // for every forwarded chunk while active.
+    struct PplCapture {
+        bool active = false;
+        int n = 0;
+        int32_t* d_tokens = nullptr;
+        double* d_nll = nullptr;
+    } ppl_capture_;
 
     // ── Model-specific state ─────────────────────────────────────────
     std::unique_ptr<SSMState> ssm_state_;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -29,6 +29,7 @@
 #include "compute/layernorm.h"
 #include "core/logging.h"
 
+#include <cmath>
 #include <cstring>
 #include <algorithm>
 #include <vector>
@@ -248,6 +249,59 @@ int Engine::resolve_prefill_chunk_size_() const {
 }
 
 // =====================================================================
+// begin/end_perplexity_capture — chunked-prefill-aware teacher forcing
+// (imp_perplexity). See engine.h for the contract.
+// =====================================================================
+
+bool Engine::begin_perplexity_capture(const int32_t* tokens, int n) {
+    if (ppl_capture_.active || !tokens || n < 2 || !executor_) {
+        return false;
+    }
+    if (cudaMalloc(&ppl_capture_.d_tokens, static_cast<size_t>(n) * sizeof(int32_t)) != cudaSuccess) {
+        ppl_capture_.d_tokens = nullptr;
+        return false;
+    }
+    if (cudaMalloc(&ppl_capture_.d_nll, static_cast<size_t>(n) * sizeof(double)) != cudaSuccess) {
+        cudaFree(ppl_capture_.d_tokens);
+        ppl_capture_.d_tokens = nullptr;
+        ppl_capture_.d_nll = nullptr;
+        return false;
+    }
+    IMP_CUDA_CHECK_LOG(cudaMemcpy(ppl_capture_.d_tokens, tokens,
+                                  static_cast<size_t>(n) * sizeof(int32_t), cudaMemcpyHostToDevice));
+    IMP_CUDA_CHECK_LOG(cudaMemset(ppl_capture_.d_nll, 0, static_cast<size_t>(n) * sizeof(double)));
+    ppl_capture_.n = n;
+    ppl_capture_.active = true;
+    return true;
+}
+
+bool Engine::end_perplexity_capture(double* out_ppl) {
+    if (!ppl_capture_.active) {
+        return false;
+    }
+    const int n = ppl_capture_.n;
+    IMP_CUDA_CHECK_LOG(cudaDeviceSynchronize());
+
+    // Fixed-order host reduction over per-position NLLs (bit-reproducible —
+    // same contract as GraphExecutor::perplexity_nll).
+    std::vector<double> h_nll_pos(static_cast<size_t>(n), 0.0);
+    IMP_CUDA_CHECK_LOG(cudaMemcpy(h_nll_pos.data(), ppl_capture_.d_nll,
+                                  static_cast<size_t>(n) * sizeof(double), cudaMemcpyDeviceToHost));
+    cudaFree(ppl_capture_.d_tokens);
+    cudaFree(ppl_capture_.d_nll);
+    ppl_capture_ = PplCapture{};
+
+    double h_nll = 0.0;
+    for (int i = 0; i < n - 1; ++i)
+        h_nll += h_nll_pos[i];
+    double ppl = std::exp(h_nll / static_cast<double>(n - 1));
+    IMP_LOG_INFO("perplexity_nll: n=%d  mean_nll=%.4f  PPL=%.4f", n, h_nll / (n - 1), ppl);
+    if (out_ppl)
+        *out_ppl = ppl;
+    return true;
+}
+
+// =====================================================================
 // step_prefill — process all prefill requests
 // =====================================================================
 
@@ -295,7 +349,10 @@ bool Engine::prefill_allocate_kv_blocks_(std::shared_ptr<Request>& req, int kv_b
     int prefix_reused = 0;
     int existing = static_cast<int>(kv_manager_->block_table(req->id).size());
 
-    if (kv_manager_->prefix_caching_enabled() && existing == 0 && offset == 0) {
+    // Perplexity capture must forward EVERY position — a prefix-cache hit
+    // skips the reused prefix's forward, leaving those NLL slots at 0.
+    if (kv_manager_->prefix_caching_enabled() && existing == 0 && offset == 0 &&
+        !ppl_capture_.active) {
         int total_blocks_needed = (total_input + kv_bs - 1) / kv_bs;
         prefix_reused = kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens);
         if (prefix_reused < 0) {
@@ -594,6 +651,14 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
             executor_->forward_logits(state, logits_out, pf_stream);
         }
 
+        // Teacher-forced NLL for this chunk's positions (imp_perplexity).
+        // Runs eagerly after the (possibly graph-replayed) forward; hidden_
+        // holds exactly this chunk and nothing reads logits_ afterwards.
+        if (ppl_capture_.active) {
+            executor_->perplexity_nll_partial(ppl_capture_.d_tokens, ppl_capture_.n, offset,
+                                              chunk_len, ppl_capture_.d_nll, pf_stream);
+        }
+
         if (!pf_pool_used) {
             free_prefill_buffers(d_token_ids, d_positions, d_block_tables, d_context_lens, pf_stream);
         }
@@ -682,6 +747,16 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
             req->output_logprobs.push_back(build_logprob_info(executor_->h_logits_pinned(), vocab_size,
                                                               next_token, req->top_logprobs,
                                                               model_->tokenizer()));
+        }
+
+        // Teacher-forced NLL for the LAST chunk's positions (imp_perplexity).
+        // After sampling + logprob extraction: the partial pass overwrites the
+        // logits_ workspace, so it must run once nothing reads this chunk's
+        // logits anymore. hidden_ still holds the chunk (forward_logits only
+        // slices the last token for the production LM head).
+        if (ppl_capture_.active) {
+            executor_->perplexity_nll_partial(ppl_capture_.d_tokens, ppl_capture_.n, offset,
+                                              chunk_len, ppl_capture_.d_nll, pf_stream);
         }
 
         req->output_tokens.push_back(next_token);

--- a/tests/.env.test
+++ b/tests/.env.test
@@ -6,10 +6,11 @@
 # (prefix cache, greedy locks, engine relaunch, API generate, ...).
 IMP_TEST_MODEL=/models/Qwen3-4B-Instruct-2507-Q8_0.gguf
 
-# Chunked-prefill equality suite: calibrated for Qwen3-4B specifically
-# (chunk=0 vs chunk>0 cross attention-kernel paths on other models, where
-# greedy ties may flip). Separate from IMP_TEST_MODEL so suite runs with a
-# different model under test don't hijack these expectations.
+# Chunked-prefill equivalence suite (teacher-forced PPL chunk=0 vs chunk>0;
+# greedy byte-equality was retired 2026-06-06 — cross-kernel-path ULP noise
+# flips greedy argmax depending on the exact quant file). Separate from
+# IMP_TEST_MODEL so suite runs with a different model under test don't
+# hijack these probes.
 IMP_TEST_MODEL_QWEN4B=/models/Qwen3-4B-Instruct-2507-Q8_0.gguf
 
 # Secondary test model: GDN hybrid architecture (Qwen3.5 Gated DeltaNet)

--- a/tests/test_chunked_prefill.cu
+++ b/tests/test_chunked_prefill.cu
@@ -1,9 +1,18 @@
 // E2E logits-equality battery for chunked prefill.
 //
-// Verifies that chunked prefill (prefill_chunk_size > 0) produces
-// token-for-token identical greedy output compared to single-chunk prefill
-// (prefill_chunk_size = 0) for FP16 KV, and at least 6/8 matching tokens
-// for FP8 KV (small noise from FP8 dequant is expected).
+// Verifies that chunked prefill (prefill_chunk_size > 0) is logit-equivalent
+// to single-chunk prefill (prefill_chunk_size = 0) via teacher-forced
+// perplexity over the probe prompt (imp_perplexity applies the LM head to
+// every position — any positional/KV-corruption bug in the chunked path
+// shifts the mean NLL massively).
+//
+// Greedy TEXT byte-equality (the original form of these tests) is
+// deliberately NOT asserted anymore: chunk=0 vs chunk>0 legitimately route
+// through different attention kernels (cuBLAS S-matrix vs FA2, threshold-
+// dependent per chunk), whose few-ULP logit differences flip greedy argmax
+// on near-tied prompts. That made the suite a function of the exact quant
+// file it was calibrated on (#543) — re-downloaded quants of the SAME model
+// broke it while teacher-forced PPL was bit-identical to 0.15% relative.
 //
 // Tests skip cleanly when model files are absent — no crash, GTest reports SKIP.
 //
@@ -82,6 +91,74 @@ static std::string generate_greedy(const char* model_path, const std::string& pr
     return std::string(output, output_len);
 }
 
+// Teacher-forced perplexity of `prompt` at a given prefill_chunk_size.
+// Returns -1.0 on any API failure.
+static double ppl_for_chunk(const char* model_path, const std::string& prompt,
+                            int chunk_size, bool use_fp8_kv = false) {
+    ImpModel model = nullptr;
+    if (imp_model_load(model_path, IMP_FORMAT_GGUF, &model) != IMP_SUCCESS || !model)
+        return -1.0;
+
+    std::vector<int32_t> tokens(4096);
+    int n_tokens = 0;
+    if (imp_tokenize(model, prompt.c_str(), tokens.data(), &n_tokens,
+                     static_cast<int>(tokens.size())) != IMP_SUCCESS ||
+        n_tokens < 2) {
+        imp_model_free(model);
+        return -1.0;
+    }
+
+    ImpConfig cfg = imp_config_default();
+    cfg.max_seq_len = 4096;
+    cfg.max_batch_size = 1;
+    cfg.enable_cuda_graphs = 0;
+    cfg.prefill_chunk_size = chunk_size;
+    if (use_fp8_kv)
+        cfg.kv_cache_dtype = IMP_DTYPE_FP8_E4M3;
+
+    ImpContext ctx = nullptr;
+    if (imp_context_create(model, &cfg, &ctx) != IMP_SUCCESS || !ctx) {
+        imp_model_free(model);
+        return -1.0;
+    }
+
+    double ppl = -1.0;
+    ImpError err = imp_perplexity(ctx, tokens.data(), n_tokens, &ppl);
+
+    imp_context_free(ctx);
+    imp_model_free(model);
+
+    return (err == IMP_SUCCESS) ? ppl : -1.0;
+}
+
+// Count whitespace-separated unique words (degeneration-loop detector).
+static int count_unique_words(const std::string& text) {
+    std::set<std::string> unique_words;
+    std::string word;
+    for (char c : text) {
+        if (c == ' ' || c == '\n' || c == '\t') {
+            if (!word.empty()) {
+                unique_words.insert(word);
+                word.clear();
+            }
+        } else {
+            word += c;
+        }
+    }
+    if (!word.empty())
+        unique_words.insert(word);
+    return static_cast<int>(unique_words.size());
+}
+
+// Chunk-invariance tolerances on teacher-forced PPL, relative to chunk=0.
+// Measured cross-kernel-path noise (2026-06-06, Qwen3-8B + Llama-3.2-3B,
+// 3.3-3.4k-token forcing): |dPPL| <= 0.15% relative. A positional or
+// KV-corruption bug in the chunked path shifts PPL by >= 50%. 1% keeps a
+// 6x noise margin while catching real bugs with > 50x margin.
+static constexpr double kFp16RelTol = 0.01;
+// FP8-KV adds dequant noise on the chunk-continuation KV reads.
+static constexpr double kFp8RelTol = 0.03;
+
 // ---------------------------------------------------------------------------
 // Test class
 // ---------------------------------------------------------------------------
@@ -130,6 +207,26 @@ protected:
         }
         return p;
     }
+
+    // Probe prompt for the NLL-equivalence tests: ~1.4k tokens, deliberately
+    // BELOW the attn_scores s_cap clamp (~1984 @ max_seq_len 4096) so that
+    // chunk=0 is a genuinely single-shot reference forward. Measured
+    // 2026-06-06 (post fa2_fp16qk continuation-decline): Qwen3-4B is
+    // BIT-IDENTICAL across chunk={64,128,512,1024}; Llama-3.2-3B is within
+    // 0.01% (continuation chunks route through cuBLAS, first chunk through
+    // FA2-f16qk). Above ~2.5k context the late chunks route through the
+    // fp8/e4m3 FMHA family and drift up to ~25% NLL — that open issue is
+    // tracked by the DISABLED_ long-context test below.
+    static std::string probe_prompt() {
+        std::string p = "Summarize the following list:\n";
+        for (int i = 0; i < 54; i++) {
+            p += "Item " + std::to_string(i) + ": ";
+            for (int w = 0; w < 10; w++)
+                p += "word" + std::to_string(w) + " ";
+            p += "\n";
+        }
+        return p;
+    }
 };
 
 // ---------------------------------------------------------------------------
@@ -144,33 +241,23 @@ TEST_F(ChunkedPrefillTest, Qwen3_4B_Q8_0_FP16_KV_LogitsEqual) {
     if (!model_exists(path))
         GTEST_SKIP() << "model not present: " << path;
 
-    const std::string prompt = long_prompt();
-    const int n = 8;  // decode tokens to compare
+    const std::string prompt = probe_prompt();
 
-    std::string single      = generate_greedy(path, prompt, /*chunk=*/0,    n);
-    std::string chunked512  = generate_greedy(path, prompt, /*chunk=*/512,  n);
-    std::string chunked128  = generate_greedy(path, prompt, /*chunk=*/128,  n);
-    std::string chunked64   = generate_greedy(path, prompt, /*chunk=*/64,   n);
-    std::string chunked1024 = generate_greedy(path, prompt, /*chunk=*/1024, n);
+    const double base = ppl_for_chunk(path, prompt, /*chunk=*/0);
+    ASSERT_GT(base, 0.0) << "single-chunk perplexity failed";
 
-    ASSERT_FALSE(single.empty())      << "single-chunk run produced no output";
-    ASSERT_FALSE(chunked512.empty())  << "chunk=512 run produced no output";
-    ASSERT_FALSE(chunked128.empty())  << "chunk=128 run produced no output";
-    ASSERT_FALSE(chunked64.empty())   << "chunk=64 run produced no output";
-    ASSERT_FALSE(chunked1024.empty()) << "chunk=1024 run produced no output";
-
-    // Greedy generation with FP16 KV must be byte-identical across chunk sizes.
-    EXPECT_EQ(single, chunked512)  << "chunk=512 diverges from single-chunk";
-    EXPECT_EQ(single, chunked128)  << "chunk=128 diverges from single-chunk";
-    EXPECT_EQ(single, chunked64)   << "chunk=64 diverges from single-chunk";
-    EXPECT_EQ(single, chunked1024) << "chunk=1024 diverges from single-chunk";
+    for (int chunk : {64, 128, 512, 1024}) {
+        const double ppl = ppl_for_chunk(path, prompt, chunk);
+        ASSERT_GT(ppl, 0.0) << "chunk=" << chunk << " perplexity failed";
+        EXPECT_NEAR(ppl, base, base * kFp16RelTol)
+            << "chunk=" << chunk
+            << " teacher-forced PPL diverges from single-chunk prefill";
+    }
 }
 
 // ---------------------------------------------------------------------------
-// Test 2: FP8 KV — allow some character-level difference (FP8 dequant noise)
-//
-// FP8 KV introduces small rounding noise. The text must be non-empty and
-// at least 75% similar (edit-distance proxy: common-prefix length >= 3/4 total).
+// Test 2: FP8 KV — chunk continuation reads FP8-quantized KV of previous
+// chunks; allow the extra dequant noise on top of the FP16 tolerance.
 // ---------------------------------------------------------------------------
 
 TEST_F(ChunkedPrefillTest, Qwen3_4B_Q8_0_FP8_KV_LogitsEqual) {
@@ -178,29 +265,16 @@ TEST_F(ChunkedPrefillTest, Qwen3_4B_Q8_0_FP8_KV_LogitsEqual) {
     if (!model_exists(path))
         GTEST_SKIP() << "model not present: " << path;
 
-    const std::string prompt = long_prompt();
-    const int n = 8;
+    const std::string prompt = probe_prompt();
 
-    std::string single  = generate_greedy(path, prompt, 0,   n, /*fp8=*/true);
-    std::string chunked = generate_greedy(path, prompt, 512, n, /*fp8=*/true);
+    const double base = ppl_for_chunk(path, prompt, /*chunk=*/0, /*fp8=*/true);
+    ASSERT_GT(base, 0.0) << "single-chunk FP8 perplexity failed";
 
-    ASSERT_FALSE(single.empty())  << "single-chunk FP8 run produced no output";
-    ASSERT_FALSE(chunked.empty()) << "chunk=512 FP8 run produced no output";
+    const double chunked = ppl_for_chunk(path, prompt, /*chunk=*/512, /*fp8=*/true);
+    ASSERT_GT(chunked, 0.0) << "chunk=512 FP8 perplexity failed";
 
-    // FP8 KV noise: count matching characters from the start.
-    // Require at least 6/8 of the shorter string to match character-for-character.
-    int match = 0;
-    int compare_len = static_cast<int>(std::min(single.size(), chunked.size()));
-    for (int i = 0; i < compare_len; i++)
-        if (single[i] == chunked[i])
-            match++;
-        else
-            break;  // first divergence point
-
-    int required = (compare_len * 6) / 8;
-    EXPECT_GE(match, required) << "FP8 KV: only " << match << " of " << compare_len
-                               << " chars matched from prefix (single='" << single
-                               << "' vs chunked='" << chunked << "')";
+    EXPECT_NEAR(chunked, base, base * kFp8RelTol)
+        << "chunk=512 FP8-KV teacher-forced PPL diverges from single-chunk prefill";
 }
 
 // ---------------------------------------------------------------------------
@@ -212,18 +286,52 @@ TEST_F(ChunkedPrefillTest, Llama_3_2_3B_Chunk_64_LogitsEqual) {
     if (!model_exists(path))
         GTEST_SKIP() << "model not present: " << path;
 
-    const std::string prompt = long_prompt();
-    const int n = 8;
+    const std::string prompt = probe_prompt();
 
-    std::string single  = generate_greedy(path, prompt, 0,  n);
-    std::string chunked = generate_greedy(path, prompt, 64, n);  // non-block-aligned (block=16)
+    const double base = ppl_for_chunk(path, prompt, /*chunk=*/0);
+    ASSERT_GT(base, 0.0) << "single-chunk perplexity failed";
 
-    ASSERT_FALSE(single.empty())  << "single-chunk run produced no output";
-    ASSERT_FALSE(chunked.empty()) << "chunk=64 run produced no output";
+    const double chunked = ppl_for_chunk(path, prompt, /*chunk=*/64);
+    ASSERT_GT(chunked, 0.0) << "chunk=64 perplexity failed";
 
-    EXPECT_EQ(single, chunked) << "chunk=64 (non-block-aligned) diverges from single-chunk"
-                               << "\n  single:  '" << single << "'"
-                               << "\n  chunked: '" << chunked << "'";
+    EXPECT_NEAR(chunked, base, base * kFp16RelTol)
+        << "chunk=64 (small odd chunk count) teacher-forced PPL diverges "
+           "from single-chunk prefill";
+}
+
+// ---------------------------------------------------------------------------
+// Test 3b (DISABLED — issue #548): LONG-context chunk invariance.
+//
+// Once a chunk's ctx_len crosses fmha_prefill_threshold (~2.5-2.9k), the
+// chunked path routes through the fp8/e4m3 FMHA family
+// (attention_prefill_dispatch) whose accumulated e4m3 score noise drifts the
+// teacher-forced NLL by up to ~25% vs the reference (measured 2026-06-06,
+// 120-item long_prompt ~3.1k tokens, Llama-3.2-3B, post fa2_fp16qk
+// continuation-decline):
+//   chunk=0(→s_cap-clamped ~1984+rest) nll 0.80
+//   chunk=64  nll 0.61   chunk=512 nll 0.97
+// (Before the fa2_fp16qk continuation-decline this read nll 8.08 —
+// catastrophic — at chunk=64; that part is fixed.) Same quality class as
+// issue #511 (fp8-FMHA above threshold unvalidated); tracked in #548.
+// Enable when the long-context chunk path is numerically reconciled.
+// ---------------------------------------------------------------------------
+
+TEST_F(ChunkedPrefillTest, DISABLED_LongContext_Chunk_Invariance) {
+    const char* path = llama_3b_path();
+    if (!model_exists(path))
+        GTEST_SKIP() << "model not present: " << path;
+
+    const std::string prompt = long_prompt();  // ~3.1k tokens, crosses the kernel threshold
+
+    const double base = ppl_for_chunk(path, prompt, /*chunk=*/0);
+    ASSERT_GT(base, 0.0) << "reference perplexity failed";
+
+    for (int chunk : {64, 512}) {
+        const double ppl = ppl_for_chunk(path, prompt, chunk);
+        ASSERT_GT(ppl, 0.0) << "chunk=" << chunk << " perplexity failed";
+        EXPECT_NEAR(ppl, base, base * kFp16RelTol)
+            << "chunk=" << chunk << " long-context teacher-forced PPL diverges";
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -258,29 +366,25 @@ TEST_F(ChunkedPrefillTest, Qwen3_4B_GenerationCoherent) {
     if (!model_exists(path))
         GTEST_SKIP() << "model not present: " << path;
 
+    // Baseline first: greedy continuation quality on the synthetic list
+    // prompt is a property of the model FILE, not of chunking — some quants
+    // of the same model collapse to repetition even with chunk=0 (observed
+    // 2026-06-06 with a re-downloaded Qwen3-4B-Instruct-2507 Q8_0). Only
+    // judge the chunked run against a baseline that is itself coherent.
+    std::string single = generate_greedy(path, long_prompt(), 0, 32);
+    ASSERT_FALSE(single.empty()) << "single-chunk run produced no output";
+    if (count_unique_words(single) < 4)
+        GTEST_SKIP() << "model file degenerates on the probe prompt even "
+                        "unchunked — coherence probe not applicable: '"
+                     << single << "'";
+
     std::string out = generate_greedy(path, long_prompt(), 512, 32);
     ASSERT_FALSE(out.empty()) << "chunk=512 run produced no output";
 
-    // Count distinct words in the output.
-    // A degeneration loop (e.g. "word word word ...") produces only 1-2 unique words.
-    std::set<std::string> unique_words;
-    std::string word;
-    for (char c : out) {
-        if (c == ' ' || c == '\n' || c == '\t') {
-            if (!word.empty()) {
-                unique_words.insert(word);
-                word.clear();
-            }
-        } else {
-            word += c;
-        }
-    }
-    if (!word.empty())
-        unique_words.insert(word);
-
-    EXPECT_GE(static_cast<int>(unique_words.size()), 4)
-        << "generation collapsed to repetition: only " << unique_words.size()
-        << " unique words in output: '" << out << "'";
+    // A degeneration loop (e.g. "word word word ...") produces 1-2 unique words.
+    EXPECT_GE(count_unique_words(out), 4)
+        << "generation collapsed to repetition under chunked prefill while "
+           "single-chunk was coherent: '" << out << "'";
 }
 
 }  // namespace imp_test


### PR DESCRIPTION
Born from reactivating the chunked-prefill coverage (models re-downloaded after deletion). The old greedy byte-equality tests turned out to be calibrated to the exact deleted quant files — and rebuilding them on an honest foundation surfaced two real bugs.

## Bug 1 (user-facing, default path): fa2_fp16qk chunk-continuation garbage on Llama family

The #525 FP16-QK FA2 short-prefill kernel produces **wrong attention for chunk-continuation calls** (q_offset > 0, gathered past KV) on Llama-family models: teacher-forced NLL **0.29 → 7.13** (Llama-3.2-3B, chunk=64), greedy output degenerates to prompt echo. Chunked prefill is the **default (512) for dense archs** → every Llama GGUF prompt > 512 tokens was affected. Qwen3 through the same kernel is bit-exact.

**Fix (conservative):** continuations decline to the materialized cuBLAS path — verified **token-identical** to single-shot afterwards. First chunks (q_offset == 0, the original #525 use case, incl. the pp512 headline win) keep the fast path. Kernel-level root cause → #548.

## Bug 2 (API): imp_perplexity silently scored stale positions under chunked prefill

`hidden_` only retains the most recent chunk; the post-hoc `executor()->perplexity_nll()` read all n positions anyway. Triggered by the **C-API default** (`prefill_chunk_size=-1` → 512 dense) and by any corpus > attn_scores s_cap (~2k tokens) via the internal clamp — **including `imp-cli --perplexity`** (PPL 727 instead of 9.45 on a 3.1k-token corpus). Reproduces the exact garbage arithmetic: NLL ≈ (valid_last_chunk·real + rest·ln(V))/n.

**Fix:** engine-level capture (`begin/end_perplexity_capture` + `perplexity_nll_partial`) accumulates per-position NLL after every chunk's forward; prefix-cache reuse bypassed while active; bit-reproducible fixed-order reduction retained.

## Tests: greedy byte-equality → teacher-forced NLL equivalence

Byte-equality flips with the exact quant file (greedy ties at cross-kernel ULP noise — the #543 calibration trap). The suite now gates the actual invariant:

| Gate | Result |
|---|---|
| Qwen3-4B FP16 KV, chunk={64,128,512,1024} vs 0 | **bit-identical** (PPL 1.0669 ×5) |
| Qwen3-4B FP8 KV, chunk=512 vs 0 | 1.0670 vs 1.0669 |
| Llama-3.2-3B chunk=64 vs 0 | 1.3332 vs 1.3331 (0.008%) |
| Long-context (ctx ≥ fmha threshold) | drifts ≤ ~25% through the e4m3 FMHA family → `DISABLED_` test + #548 |

Coherence probe now guards against model-file degeneration (the re-downloaded unsloth 4B collapses on the synthetic prompt even unchunked — that's a file property, not a chunking property).

## Validation

- Full suite **1112 tests, 0 FAILED** (Qwen3-8B + Qwen3.6-35B-MoE), incl. the DetEval PPL **bit-stability** gates on the new capture path
- `verify-fast` via pre-push hook (perf gate measures at `--prefill-chunk-size 0` → unaffected; pp512 chunked = single chunk keeps the #525 fast path)
- A/B proof: `--set attention.fa2_fp16qk=never` makes chunk=64 token-identical to chunk=0 on Llama (before the fix)

Closes nothing; tracks #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)