### PR TITLE
docs: GOAL.md ground-truth realignment (#550, #549) + determinism known-limits doc (#554)

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -13,7 +13,7 @@ Single-user, single-GPU, latency-first. Not a competitor to vLLM/SGLang on throu
 Ranked, non-negotiable order:
 
 1. **Decode throughput (tok/s) at batch=1** on RTX 5090 — primary metric. Must lead llama.cpp, vLLM, SGLang, ExLlamaV3, MLC-LLM on every supported architecture and quant combination we ship.
-2. **Prefill throughput (tok/s) at batch=1** on RTX 5090 — must match or beat llama.cpp on dense; must close the MoE gap to vLLM (Qwen3-Coder NVFP4 pp512 was 1.14-1.32× behind vLLM 0.20.2 single-seq as of 2026-05-10; closed to **1.056× as of 2026-05-23** post-#374 skip-gather, see *What "best on 5090" requires* below).
+2. **Prefill throughput (tok/s) at batch=1** on RTX 5090 — must match or beat llama.cpp on dense **NVFP4/SafeTensors** (GGUF prefill is best-effort, ceiling is architectural — see release bar 3); must close the MoE gap to vLLM (re-measured ~1.4× single-seq 2026-05-31; remaining levers: prefill attention + grouped-GEMM occupancy scheduler #558).
 3. **Time-to-first-token (TTFT)** at realistic prompt lengths (512, 2048, 8192, 32k) — must be competitive with vLLM despite our batch=1 focus.
 4. **VRAM efficiency** — must fit larger models than competitors at equivalent quality (NVFP4, FP8 KV, paged cache). 32 GB on a 5090 should serve everything up to ~70B dense at usable quality.
 5. **Quality** — perplexity and downstream eval parity with llama.cpp at the same quant. No silent quality regressions for speed.
@@ -35,22 +35,34 @@ Everything else is best-effort via cuBLAS + scalar Flash Attention 2 fallback. N
 
 ## Target models (hero set)
 
-These models must be **best-in-class on 5090**. No exceptions, no excuses:
+These models must be **best-in-class on 5090**. No exceptions, no excuses.
+Hero status requires staged local weights, a green degeneration battery, and
+decode numbers in `BENCHMARKS.md` (realigned 2026-06-06, issues #549/#550 —
+heroes that had never produced a local number moved to the extended set
+below; gpt-oss-20b is the one tracked not-yet-supported hero):
 
 | Model | Quant | Why |
 |---|---|---|
-| Qwen3-4B / 8B | Q8_0, NVFP4 | Daily driver dense, fast iteration |
-| Qwen3-14B | Q6_K, NVFP4 | Sweet spot for 5090 |
-| Qwen3-Coder-30B-A3B | Q6_K, NVFP4 | Hero MoE — the prefill gap closes here |
-| DeepSeek-R1-Distill-7B/14B | Q8_0, Q6_K | Reasoning baseline |
-| Gemma-3 27B (text + vision) | Q4_K_M, NVFP4 | Multimodal hero |
-| Gemma-4 26B-A4B | NVFP4 | MoE follow-up (integration active) |
-| Phi-4 14B | Q6_K | Dense alt |
-| Mixtral 8x7B | Q4_K_M | MoE classic |
+| Qwen3-4B / 8B | Q8_0 (8B also NVFP4) | Daily driver dense, fast iteration |
+| Qwen3-14B | Q6_K, NVFP4 | Sweet spot for 5090 — the north-star model |
+| Qwen3-Coder-30B-A3B | NVFP4 | Hero MoE |
+| Qwen3.6-35B-A3B | NVFP4 | Hybrid (GDN + MoE) daily driver, MTP head |
+| Gemma-4 26B-A4B (text + vision) | NVFP4 | Multimodal + MoE hero |
 | Nemotron-H | NVFP4 | Hybrid (Mamba2 + Attn + MoE) flagship |
-| gpt-oss-20b | MXFP4 | First-class MXFP4 path |
+| gpt-oss-20b | MXFP4 (SafeTensors) | First-class MXFP4 path — **tracked gap, not yet supported (#547)** |
 
 If a hero model regresses against any competitor on the primary metric, that is a release blocker.
+
+**Extended set** — supported architectures, validated opportunistically, NOT
+release-blocking (promotion back to hero requires staged weights + battery +
+benchmark numbers):
+
+| Model | State (2026-06-06) |
+|---|---|
+| DeepSeek-R1-Distill-7B/14B | Never benched locally. Arch is Qwen2/Llama (covered); the DEEPSEEK arch path itself uses standard MHA → real MLA checkpoints (V2/V3/R1) are unsupported. |
+| Gemma-3 27B | 12B Q4_K_M + 4B-VL validated locally; 27B never staged. |
+| Phi-4 14B | NVFP4 (reasoning-plus) validated locally; GGUF Q6_K never staged. |
+| Mixtral 8x7B | Arch in the enum, chat-template test only; never staged. |
 
 ---
 
@@ -69,17 +81,19 @@ Concrete technical commitments — these are means, not ends, but progress on th
   - **tg128 @ ctx=512 = 273.24 tok/s** (σ 0.09 — rock solid)
   - **tg128 @ ctx=2048 = 268.46 tok/s** (σ 0.10)
 
-  Compared to vLLM 0.20.2 single-seq pp512 = 18,500 tok/s: **gap = 1.056× (5.6 %)**, was 1.14-1.32× pre-#374. The MoE-prefill skip-gather (#374) + downstream improvements moved us from 14,562 → 17,521 pp512 (+20.3 %). pp2048 actually exceeds vLLM's single-seq pp512 baseline. vLLM's 25.5 k multi-seq is continuous-batching mode, not a fair single-seq comparison — imp is batch=1 by design. **Remaining 5.6 % gap is within cuBLAS-algo-variance band on pp512.** Engineering priority drops here — the MoEProblemShape upstream / custom kernel work path documented in `docs/plans/moe_prefill_cudagraph_via_cutlass_moe_scheduler_2026_05_23.md` is no longer a release blocker.
+  Compared to vLLM 0.20.2 single-seq pp512 = 18,500 tok/s: **gap = 1.056× (5.6 %)**, was 1.14-1.32× pre-#374. The MoE-prefill skip-gather (#374) + downstream improvements moved us from 14,562 → 17,521 pp512 (+20.3 %). pp2048 actually exceeds vLLM's single-seq pp512 baseline. vLLM's 25.5 k multi-seq is continuous-batching mode, not a fair single-seq comparison — imp is batch=1 by design.
+
+  *Update 2026-05-31/06-06:* the fresh audit re-measured the real single-seq gap at **~1.4×** (the 1.056× snapshot above sat inside the 2.6× cuBLAS-restart variance band). The grouped-GEMM compute itself is near roofline (the "20× grouped-GEMM gap" premise is refuted); the remaining halves of the gap are **prefill attention** (FA2 partial) and the **grouped-GEMM launch/occupancy** (single wave at ~24% occupancy, latency-bound at small per-expert M — persistent/stream-K scheduler, tracked in #558).
 
 ### Memory
 - **Paged KV cache** (block 16) with LRU, prefix caching — keep and extend.
 - **FP8 / INT8 / NVFP4 KV cache** — NVFP4 decode cache is already shipping; expand to prefill where quality allows.
-- **TurboQuant integration** — KV-cache compression as a first-class feature once stable. The 5090's 32 GB is the bottleneck; squeezing KV is how we serve bigger models than the competition.
+- ~~TurboQuant integration~~ — **retired 2026-05-17** (dead-ends archive); the CLI flags survive only as deprecated aliases. KV squeezing beyond the shipped FP8/INT8/NVFP4 cache options is not a tracked commitment.
 
 ### Latency
 - **CUDA Graphs everywhere on decode** — already done, never regress.
 - **PDL (Programmatic Dependent Launch)** — keep aggressive.
-- **TurboDraft (L2-resident speculative decoder)** — ship it. PPM-based, tree drafting. This is the multiplier that puts imp uncatchable on decode for the hero models.
+- ~~TurboDraft (L2-resident speculative decoder)~~ — **dead end at current precision** (MTP diagnosis 2026-05-30, authoritative): the implementation is correct (PyTorch-reference parity), but the real K=1 acceptance of ~25-30% on the NVFP4 head is below draft overhead — no net win. Spec-decode returns to the table only with a higher-precision MTP head or a trained draft model (multi-week, not committed).
 - **No host syncs on the decode hot path.** Ever. CI gates this.
 
 ### Surface
@@ -116,10 +130,10 @@ Defining this is as important as defining the mission. These are explicit non-go
 
 A release is shippable when, on RTX 5090:
 
-1. All hero models pass correctness tests (perplexity within 0.5% of llama.cpp reference at the same quant).
+1. All hero models pass correctness tests: perplexity within 0.5% of llama.cpp reference at the same quant **with documented owner-approved speed/quality trades excluded** — currently `gemm.nvfp4_lm_head_gdn` default-ON (#483): +2.2% PPL for +11.4% decode on GDN hybrids; each such trade must be opt-out via config and listed here.
 2. Decode tok/s leads llama.cpp by ≥5% on every hero model.
-3. Prefill tok/s ≥ llama.cpp on every dense hero model.
-4. Prefill tok/s ≥ 50% of vLLM on every MoE hero model (interim — closes to ≥90% by year end).
+3. Prefill tok/s ≥ llama.cpp on every dense **NVFP4/SafeTensors** hero. GGUF prefill is explicitly best-effort: the Q4K-MMQ experiment (2026-05-28) showed imp's GGUF prefill ceiling is architectural (ties cuBLAS at ~4.3% of peak; llama.cpp's MMQ leads 1.3-2.4×) — the old "≥ llama.cpp on every dense GGUF hero" bar was permanently violated as written and is dropped (realignment 2026-06-06, #550).
+4. Prefill tok/s ≥ 70% of vLLM single-seq on every MoE hero (measured ~1.4× gap 2026-05-31; the remaining levers are prefill attention and the grouped-GEMM launch/occupancy scheduler, #558).
 5. No host syncs on the decode hot path (CI-enforced).
 6. OpenAI API compliance suite green.
 7. README benchmarks updated, commit hash of competitors recorded.
@@ -136,5 +150,5 @@ Measurement methodology (always cold-median, never single-shot): 5 independent `
 
 Current: **157.71 tok/s default flags** (May 23 2026, cold-median methodology — 5 trials × 5 reps × 15 s cooldown, σ = 0.16 tok/s across samples; same code as the May 22 measurement, just less cuBLAS-algo-cache-state noise). The 150 milestone is hit by default with margin.
 Previous: 150.1 tok/s (May 22 2026, single-shot, post PRs #362 + #364 + #367). 121.4 tok/s (May 2026, +25.5% vs llama.cpp c830f99).
-Next milestone: **175 tok/s** — needs architectural work (decode kernel tuning per the 35 % attention / 60 % FFN profile split, FP8 prefill cache coverage for the remaining ~100 layer-tensors that fall back to CUTLASS NVFP4 prefill, or LM_HEAD quantization unlock).
-Stretch: 200 tok/s with TurboDraft or draft-model spec-decode on (both blocked: TurboDraft broken on pretrained, no MTP head shipped for Qwen3-14B, draft-model integration is multi-week).
+Next milestone: **175 tok/s** — requires multi-week kernel-fusion work, not tuning. The roofline sweep (2026-05-30) showed decode is 87% NVFP4 GEMVs running at 66-70% HBM with a 4-bit-dequant co-limit (L1TEX 91%); occupancy raises and KPAR/MR rerouting are measured dead ends, and the LM_HEAD quantization unlock already shipped (#479/#483). The previously listed "FP8 prefill cache coverage" lever **does not exist on this hardware** — FP8 prefill is cuBLAS `NOT_SUPPORTED` on sm_120 (realignment 2026-06-06, #550).
+Stretch: 200 tok/s would need speculative decoding, which is currently a measured dead end (MTP diagnosis 2026-05-30: ~25-30% acceptance below draft overhead; no MTP head for Qwen3-14B; draft-model integration is multi-week, not committed).

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ This is a running experiment in how far AI-generated systems code scales. The [a
 | [Quantization](docs/quantization.md) | GGUF, NVFP4, MXFP4, FP8 KV — formats and trade-offs |
 | [Attention dispatch](docs/attention-dispatch.md) | Per-(phase x dtype x layer) kernel selection |
 | [sm_120a kernels](docs/sm120.md) | Kernel optimization notes |
+| [Determinism](docs/determinism.md) | Reproducibility guarantees + known limits |
 | [imp.conf reference](imp.conf.example) | All runtime configuration keys |
 | [Roadmap](docs/roadmap.md) | Open issues and in-flight work |
 | [Changelog](CHANGELOG.md) | Per-release notes |

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -1,0 +1,83 @@
+# Determinism
+
+What imp guarantees about run-to-run reproducibility, what `[runtime]
+deterministic` adds, and the documented limits (tracked in issue #554).
+
+## Shipped guarantees
+
+`[runtime] deterministic = true` (legacy env `IMP_DETERMINISTIC=1`) is the
+opt-in full-reproducibility mode for temperature=0 evals. It eliminates the
+known run-to-run non-determinism sources by selecting deterministic kernel
+variants:
+
+- **MoE token routing** — atomic expert-bucket scatter ordering.
+- **Top-k sampling** — atomicMax/atomicAdd softmax-stat races (single-block
+  path, `top_k <= 128`).
+- **GEMM** — implies `deterministic_gemm` (cuBLASLt `no_reduce_split`;
+  timing-based algo selection is itself a non-determinism source).
+
+With it ON, the gated guarantees (`DetEvalE2ETest`, PR #542) are:
+
+- **Greedy output bit-identical** across runs in the *same context* and
+  across *fresh processes* (incl. GDN/hybrid models such as Qwen3.6-35B).
+- **Perplexity NLL bit-stable** (`imp_perplexity` / `imp-cli --perplexity`)
+  — the teacher-forced harness is the determinism-proof A/B instrument.
+
+The mode is applied engine-side (effective through the C API and server, not
+just the CLI tools). Costs a little throughput; strictly OFF by default —
+the default path runs the exact same kernels as before with zero overhead.
+
+## Known limits
+
+These are the documented boundaries of the guarantee. They are deliberate
+(perf or upstream-API constraints), tracked in issue #554, and live here so
+they are not only discoverable as code comments.
+
+### 1. Dense greedy logit ties
+
+Exactly-tied logits can resolve to different argmax tokens across kernel
+paths and runs — the FP values are bit-identical, but tie-breaking is not
+specified across paths. Greedy-token A/B comparisons on tie-heavy prompts
+(synthetic lists, repetitive corpora) are therefore **invalid as a
+correctness signal**; use teacher-forced NLL instead (this is why
+`ChunkedPrefillTest` moved from byte-equality to NLL gates in PR #553).
+
+### 2. CUB top-k is not tie-stable for `top_k > 128`
+
+`src/compute/sampling.cu` (`DeviceTopK::MaxPairs`): the CUB path runs with
+`determinism::not_guaranteed`, and the descending radix sort is not
+guaranteed stable on the token index for bit-identical probabilities — two
+tied tokens can swap order between runs. The single-block path
+(`top_k <= 128`) tie-breaks by index and is fully deterministic. Fix path if
+ever needed: fold the vocab index into the sort key (`(prob, -index)`) or
+request `determinism::guaranteed`.
+
+### 3. `typical_p` shared-memory FP atomicAdd
+
+`src/compute/sampling.cu` (bucket histogram): per-bucket probability mass is
+accumulated via shared-memory FP `atomicAdd`, whose ordering is
+scheduling-dependent. Under deterministic mode this remains a documented
+exception — `typical_p` is not part of the temp=0 eval surface.
+
+### 4. GDN cross-context-in-process
+
+`tests/test_determinism_e2e.cpp`:
+`DISABLED_GreedyReproducibleAcrossFreshContexts` /
+`DISABLED_PerplexityBitIdenticalAcrossFreshContexts` — on GDN/hybrid models,
+creating a *new context inside the same process* may not reproduce
+bit-identically (VRAM-layout-sensitive recurrent-state slots). Same-context
+and fresh-process reproducibility ARE guaranteed (see above). For
+reproducible eval sweeps over multiple contexts: one process per context.
+
+## Recipe: reproducible evals
+
+```ini
+# imp.conf
+[runtime]
+deterministic = true
+```
+
+- Compare **teacher-forced NLL** (`imp-cli --perplexity`), not greedy bytes.
+- temperature=0 / greedy only on prompts without logit ties, `top_k <= 128`.
+- GDN models: fresh process per context.
+- `imp-cli` logs to stdout — strip log lines before hashing output.

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -18,6 +18,8 @@ deterministic_gemm   = false
 # Full reproducibility mode for temp=0 evals: deterministic MoE routing /
 # expert-scatter and top-k sampling kernels, implies deterministic_gemm.
 # Greedy output becomes bit-identical across runs/contexts (DetEvalE2ETest).
+# Guarantees + known limits (ties, top_k>128, typical_p, GDN cross-context):
+# docs/determinism.md.
 # Legacy env: IMP_DETERMINISTIC=1. Costs a little throughput; off by default.
 deterministic        = false
 # CUDA Graph capture: "auto" picks per-model based on architecture support;


### PR DESCRIPTION
One batched docs PR closing three audit-tracker issues.

## #550 — GOAL.md realignment (B1–B5)
- **B1 TurboDraft**: "ship it" → dead end at current precision (authoritative MTP diagnosis 2026-05-30: correct implementation, ~25-30% K=1 acceptance below draft overhead).
- **B2 TurboQuant**: marked retired (2026-05-17, dead-ends archive; flags are deprecated aliases).
- **B3 FP8 prefill lever**: removed from the 175-tok/s milestone — FP8 prefill is cuBLAS NOT_SUPPORTED on sm_120; replaced with the measured roofline reality (dequant co-limit, kernel-fusion scale of work).
- **B4 release bar 3**: rescoped to dense NVFP4/SafeTensors heroes; GGUF prefill documented as best-effort with the architectural ceiling evidence (Q4K-MMQ experiment ties cuBLAS).
- **B5 release bar 1**: PPL bar now excludes documented owner-approved trades (`gemm.nvfp4_lm_head_gdn` default-ON, +2.2% PPL / +11.4% decode, #483) and requires config opt-out + listing.
- Consistency: "definition of best" #2 and the grouped-GEMM section updated to the re-measured ~1.4× vLLM gap (premise audit 2026-05-31) with #558 as the tracked lever.

## #549 — hero-set coverage
Heroes that never produced a local number (DeepSeek-R1-Distill, Gemma-3 27B, Phi-4 Q6_K, Mixtral 8x7B) are explicitly moved to a non-blocking **extended set** with per-model state, per the issue's own resolution option. Qwen3.6-35B-A3B (validated, MTP head, daily driver) promoted to hero. gpt-oss-20b stays hero as the tracked gap (#547).

## #554 — determinism known-limits
New `docs/determinism.md`: shipped `[runtime] deterministic` guarantees (#542) plus the four documented boundaries (dense greedy logit ties, CUB top-k>128 tie order, typical_p shared-mem atomicAdd, GDN cross-context-in-process) with file pointers and the reproducible-eval recipe. Linked from README docs table and imp.conf.example.

Docs-only — no code paths touched.

Closes #550. Closes #549. Closes #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
