### PR TITLE
feat(gguf): IQ4_NL / IQ4_XS i-quant support (#556)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ VRAM, decode tok/s, and per-model notes: [`docs/supported-models.md`](docs/suppo
 
 | | |
 |---|---|
-| **Quantization** | GGUF Q4_K_M/Q5_K_M/Q6_K/Q8_0, SafeTensors NVFP4 (prequant), MXFP4. NVFP4 KV cache (`--kv-nvfp4`) for 4× context compression at decode parity. |
+| **Quantization** | GGUF Q4_K_M/Q5_K_M/Q6_K/Q8_0 + IQ4_NL/IQ4_XS, SafeTensors NVFP4 (prequant), MXFP4. NVFP4 KV cache (`--kv-nvfp4`) for 4× context compression at decode parity. |
 | **Attention** | Prefill: FP16 cuBLAS below the auto `fmha_prefill_threshold` (the largest chunk whose S-matrix fits, ~2.5k tokens), then the FMHA family above it — an `mma.sync` `m16n8k32` FP8-E4M3 score kernel and a register-resident FlashAttention-2 kernel (head_dim 128). Decode: paged attention (block_size 16) switching on KV dtype (FP16/FP8/INT8/INT4/NVFP4/MXFP4). Auto-dispatch per phase × dtype × layer — see [`docs/attention-dispatch.md`](docs/attention-dispatch.md). |
 | **Architectures** | Dense transformers, Mixture-of-Experts (top-k grouped GEMM), Gated DeltaNet (fused recurrent scan), Mamba2 (SSM), SigLIP/Gemma-4v vision encoders. |
 | **`sm_120a` kernels** | NVFP4 block-scaled `mma.sync mxf4nvf4` GEMM/GEMV (CUTLASS v4.5.1), FP8 `f8f6f4` attention scores, FA2 block-scaling, packed `cvt.e2m1`/`cvt.e4m3x2` dequant, PDL, Green Contexts. **No** `tcgen05`/TMEM/`wgmma`/TMA-WS — those are datacenter Blackwell only. |

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -13,6 +13,7 @@ For per-model picks see [`supported-models.md`](supported-models.md). For benchm
 | Q5_K_M | 5.5 | GGUF | dp4a GEMV decode + cuBLAS prefill |
 | Q4_K_M | 4.5 | GGUF | dp4a GEMV decode + cuBLAS prefill |
 | Q4_0 | 4.5 | GGUF | dp4a GEMV decode + cuBLAS prefill |
+| IQ4_NL / IQ4_XS | 4.5 / 4.25 | GGUF | dequant→FP16 cache decode + dequant→cuBLAS prefill (no dp4a/MMVQ kernels) |
 | FP8 E4M3 | 8.0 | runtime | KV cache (opt-in), prefill weight cache |
 | INT8 | 8.0 | runtime | KV cache (opt-in) |
 | INT4 | 4.0 | runtime | KV cache (long-ctx, opt-in) |
@@ -107,5 +108,6 @@ Quick guidance, not a benchmark:
 - **Q8_0** is the cleanest baseline. Use it when output quality matters and VRAM allows.
 - **Q4_K_M** is the most VRAM-efficient GGUF. Sufficient for most chat; can degenerate on long code-gen on Gemma-4 — use Q5_K_M or Q8_0 there.
 - **Q6_K** sits in between. Good MoE pick on Qwen3-Coder-30B (234 tok/s).
+- **IQ4_NL / IQ4_XS** (i-quants) load and run since #556 via the dequant path (FP16-cache decode like Q4_K, dequant→cuBLAS prefill). Supported for community-quant compatibility — at equal VRAM prefer Q4_K_M, which has dedicated dp4a/MMVQ kernels. The IQ1/IQ2/IQ3 families remain unsupported.
 - **NVFP4** (SafeTensors prequant) gives the highest decode throughput on prequant-aware models — Qwen3-Coder-30B at 272 tok/s, Qwen3.6-35B at 217 tok/s, Gemma-4-26B at 213 tok/s. Requires AWQ/SmoothQuant calibration; only Modelopt is fully tested.
 - **MXFP4** is GGUF-native FP4. Smallest footprint (Qwen3-4B at 2.8 GB), but quality lags Q4_K_M without MR-GPTQ calibration.

--- a/src/core/qtype.cpp
+++ b/src/core/qtype.cpp
@@ -53,6 +53,10 @@ size_t qtype_row_bytes(QType q, int64_t cols) {
             return static_cast<size_t>(cols / 256) * 176;
         case QType::Q8_K:
             return static_cast<size_t>(cols / 256) * 292;
+        case QType::IQ4_NL:
+            return static_cast<size_t>(cols / 32) * 18;
+        case QType::IQ4_XS:
+            return static_cast<size_t>(cols / 256) * 136;
         case QType::F16:
         case QType::BF16:
             return static_cast<size_t>(cols) * 2;
@@ -106,6 +110,10 @@ const char* qtype_name(QType q) {
             return "Q6_K";
         case QType::Q8_K:
             return "Q8_K";
+        case QType::IQ4_NL:
+            return "IQ4_NL";
+        case QType::IQ4_XS:
+            return "IQ4_XS";
         case QType::BF16:
             return "BF16";
         case QType::MXFP4:

--- a/src/core/qtype.h
+++ b/src/core/qtype.h
@@ -27,6 +27,8 @@ enum class QType : uint16_t {
     Q5_K = 13,
     Q6_K = 14,
     Q8_K = 15,
+    IQ4_NL = 20,
+    IQ4_XS = 23,
     BF16 = 30,
     MXFP4 = 31,
 
@@ -45,11 +47,12 @@ enum class QType : uint16_t {
     // for ABI compatibility but map to MXFP4_KV at the imp_api.cpp boundary.
 };
 
-// True for block-quantised disk formats (Q*_K, Q*_0, Q*_1, MXFP4, NVFP4).
+// True for block-quantised disk formats (Q*_K, Q*_0, Q*_1, IQ4_*, MXFP4, NVFP4).
 // These types require a Sidecar scales tensor for reconstruction.
 constexpr bool is_block_quant(QType q) {
     auto v = static_cast<uint16_t>(q);
-    return (v >= 2 && v <= 15) || q == QType::MXFP4 || q == QType::NVFP4;
+    return (v >= 2 && v <= 15) || q == QType::IQ4_NL || q == QType::IQ4_XS || q == QType::MXFP4 ||
+           q == QType::NVFP4;
 }
 
 // True for compute-side dtypes that map directly to a hardware FP/INT type.
@@ -91,6 +94,8 @@ static_assert(static_cast<uint16_t>(QType::Q4_0) == 2, "QType::Q4_0 wire value")
 static_assert(static_cast<uint16_t>(QType::Q4_K) == 12, "QType::Q4_K wire value");
 static_assert(static_cast<uint16_t>(QType::Q6_K) == 14, "QType::Q6_K wire value");
 static_assert(static_cast<uint16_t>(QType::Q8_0) == 8, "QType::Q8_0 wire value");
+static_assert(static_cast<uint16_t>(QType::IQ4_NL) == 20, "QType::IQ4_NL wire value");
+static_assert(static_cast<uint16_t>(QType::IQ4_XS) == 23, "QType::IQ4_XS wire value");
 static_assert(static_cast<uint16_t>(QType::BF16) == 30, "QType::BF16 wire value");
 static_assert(static_cast<uint16_t>(QType::MXFP4) == 31, "QType::MXFP4 wire value");
 

--- a/src/exec/pre_dequant_internal.h
+++ b/src/exec/pre_dequant_internal.h
@@ -106,6 +106,13 @@ inline bool nvfp4_beneficial(QType qt, bool decode_all = false) {
         case QType::Q3_K:
         case QType::Q2_K:
             return decode_all;
+        case QType::IQ4_NL:
+        case QType::IQ4_XS:
+            // i-quants have no dp4a/MMVQ decode kernels — without the NVFP4
+            // decode cache they fall to dequant->cuBLAS GEMV (uncapturable
+            // under graph capture, ~2x slower). Similar bit-width to Q4_K,
+            // but here the conversion is the only fast decode path.
+            return true;
         default:
             return false;
     }

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -224,8 +224,12 @@ QType gguf_type_to_qtype(GgufWireType type) {
             return QType::INT8;
         case GgufWireType::I32:
             return QType::INT32;
+        case GgufWireType::IQ4_NL:
+            return QType::IQ4_NL;
+        case GgufWireType::IQ4_XS:
+            return QType::IQ4_XS;
         default:
-            // IQ4_NL/IQ4_XS/etc. — no native QType yet; mark unsupported.
+            // IQ1/IQ2/IQ3 i-quants — no native QType yet; mark unsupported.
             return QType::NONE;
     }
 }

--- a/src/model/tensor_kind_table.cu
+++ b/src/model/tensor_kind_table.cu
@@ -104,7 +104,11 @@ KindCapabilities effective_capabilities(TensorKind k, QType source_qtype) {
     // quality risk. Mirror the runtime `nvfp4_beneficial(qtype)` policy.
     const bool nvfp4_overlay_ok =
         (source_qtype == QType::Q8_0 || source_qtype == QType::Q8_K ||
-         source_qtype == QType::Q6_K || source_qtype == QType::Q5_K);
+         source_qtype == QType::Q6_K || source_qtype == QType::Q5_K ||
+         // i-quants: no dp4a/MMVQ kernels — the NVFP4 decode cache is the
+         // only fast decode path, so the overlay is allowed despite the
+         // similar bit-width (mirror nvfp4_beneficial).
+         source_qtype == QType::IQ4_NL || source_qtype == QType::IQ4_XS);
 
     if (!nvfp4_overlay_ok) {
         cap.supported = cap.supported & ~mask(StorageTier::NVFP4) &

--- a/src/quant/dequant_gpu.cu
+++ b/src/quant/dequant_gpu.cu
@@ -21,6 +21,8 @@ bool dequant_gpu_supported(QType qtype) {
         case QType::Q4_K:
         case QType::Q5_K:
         case QType::Q8_K:
+        case QType::IQ4_NL:
+        case QType::IQ4_XS:
             return true;
         default:
             return false;
@@ -696,6 +698,100 @@ __global__ void dequant_q3k_kernel(const uint8_t* __restrict__ src, half* __rest
 }
 
 // ---------------------------------------------------------------------------
+// IQ4_NL GPU dequantization kernel
+//
+// Block format (18 bytes per 32 elements):
+//   d[2]   : fp16 scale
+//   qs[16] : packed 4-bit codebook indices (2 per byte)
+//
+// Non-linear 4-bit: the index selects from a fixed signed codebook
+// (kvalues_iq4nl, ggml-common.h). Element layout matches Q4_0: element e
+// (0..15) is the low nibble of qs[e]; element e+16 is the high nibble.
+// Dequantization: val = d * codebook[nibble].
+// ---------------------------------------------------------------------------
+
+__device__ __constant__ int8_t kvalues_iq4nl_gpu[16] = {-127, -104, -83, -65, -49, -35, -22, -10,
+                                                        1,    13,   25,  38,  53,  69,  89,  113};
+
+__global__ void dequant_iq4_nl_kernel(const uint8_t* __restrict__ src, half* __restrict__ dst, int rows,
+                                      int cols) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    int64_t total = static_cast<int64_t>(rows) * cols;
+    if (idx >= total)
+        return;
+
+    int row = static_cast<int>(idx / cols);
+    int col = static_cast<int>(idx % cols);
+    int blk = col / 32;
+    int i = col % 32;
+    int blocks_per_row = cols / 32;
+
+    const uint8_t* block_ptr = src + static_cast<int64_t>(row * blocks_per_row + blk) * 18;
+    half d_val = *reinterpret_cast<const half*>(block_ptr);
+    const uint8_t* qs = block_ptr + 2;
+
+    int byte_idx = i & 15;
+    uint8_t packed = qs[byte_idx];
+    int nibble = (i < 16) ? (packed & 0xF) : ((packed >> 4) & 0xF);
+
+    float val = __half2float(d_val) * static_cast<float>(kvalues_iq4nl_gpu[nibble]);
+    dst[idx] = __float2half(val);
+}
+
+// ---------------------------------------------------------------------------
+// IQ4_XS GPU dequantization kernel
+//
+// Super-block format (136 bytes per 256 elements):
+//   d[2]        : fp16 super-block scale
+//   scales_h[2] : uint16, upper 2 bits of the 8 sub-block scales (2 bits each)
+//   scales_l[4] : lower 4 bits of the 8 sub-block scales (2 per byte)
+//   qs[128]     : packed 4-bit codebook indices (2 per byte)
+//
+// 8 sub-blocks of 32 elements, each with a 6-bit scale ls (bias 32) and the
+// same non-linear codebook as IQ4_NL. Within a sub-block the nibble layout
+// matches IQ4_NL: 16 bytes, element j low nibble, element j+16 high nibble
+// (ggml dequantize_row_iq4_xs). Dequantization:
+//   ls  = (scales_l nibble) | ((scales_h >> 2*sub) & 3) << 4
+//   val = d * (ls - 32) * codebook[nibble]
+// ---------------------------------------------------------------------------
+
+__global__ void dequant_iq4_xs_kernel(const uint8_t* __restrict__ src, half* __restrict__ dst, int rows,
+                                      int cols) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    int64_t total = static_cast<int64_t>(rows) * cols;
+    if (idx >= total)
+        return;
+
+    int row = static_cast<int>(idx / cols);
+    int col = static_cast<int>(idx % cols);
+    int blk = col / 256;
+    int i = col % 256;
+    int blocks_per_row = cols / 256;
+
+    const uint8_t* block_ptr = src + static_cast<int64_t>(row * blocks_per_row + blk) * 136;
+    half d_val = *reinterpret_cast<const half*>(block_ptr);
+    uint16_t scales_h;
+    memcpy(&scales_h, block_ptr + 2, 2);
+    const uint8_t* scales_l = block_ptr + 4;  // 4 bytes, 8 nibbles
+    const uint8_t* qs = block_ptr + 8;        // 128 bytes
+
+    int sub = i / 32;     // sub-block 0..7
+    int within = i & 31;  // 0..31 within the sub-block
+
+    int ls_low = (scales_l[sub / 2] >> (4 * (sub & 1))) & 0xF;
+    int ls_high = (scales_h >> (2 * sub)) & 3;
+    int ls = ls_low | (ls_high << 4);
+
+    int byte_idx = sub * 16 + (within & 15);
+    uint8_t packed = qs[byte_idx];
+    int nibble = (within < 16) ? (packed & 0xF) : ((packed >> 4) & 0xF);
+
+    float val = __half2float(d_val) * static_cast<float>(ls - 32) *
+                static_cast<float>(kvalues_iq4nl_gpu[nibble]);
+    dst[idx] = __float2half(val);
+}
+
+// ---------------------------------------------------------------------------
 // Q6_K → FP8 E4M3 dequantization kernel
 //
 // Same Q6_K block decoding as dequant_q6k_v2_kernel, but writes FP8 E4M3
@@ -792,6 +888,8 @@ void dequant_gpu(const void* src, void* dst, QType qtype, int rows, int cols, cu
             DEQUANT_CASE(Q4_K, dequant_q4k_kernel)
             DEQUANT_CASE(Q5_K, dequant_q5k_kernel)
             DEQUANT_CASE(Q8_K, dequant_q8k_kernel)
+            DEQUANT_CASE(IQ4_NL, dequant_iq4_nl_kernel)
+            DEQUANT_CASE(IQ4_XS, dequant_iq4_xs_kernel)
 
         default:
             IMP_LOG_ERROR("dequant_gpu: unsupported qtype %u", static_cast<unsigned>(qtype));

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -186,8 +186,13 @@ void Engine::init_resolve_quant_flags_() {
 
     if (config_.use_nvfp4_decode < 0) {
         const auto wq_qtype = model_->layer(0).wq.qtype;
+        // IQ4_NL/IQ4_XS count as beneficial unconditionally: i-quants have no
+        // dp4a/MMVQ decode kernels, so the NVFP4 decode cache is their only
+        // fast (and graph-capturable) decode path.
+        const bool is_iq4 = (wq_qtype == QType::IQ4_NL || wq_qtype == QType::IQ4_XS);
         const bool nvfp4_beneficial_qtype = (wq_qtype == QType::Q8_0 || wq_qtype == QType::Q8_K ||
                                               wq_qtype == QType::Q6_K || wq_qtype == QType::Q5_K ||
+                                              is_iq4 ||
                                               (config_.nvfp4_decode_all &&
                                                (wq_qtype == QType::Q4_K || wq_qtype == QType::Q3_K ||
                                                 wq_qtype == QType::Q2_K)));
@@ -195,7 +200,7 @@ void Engine::init_resolve_quant_flags_() {
         const bool is_gdn = (n_gdn_auto > 0);
 
         const bool sub8bit_qtype = (wq_qtype == QType::Q4_K || wq_qtype == QType::Q3_K ||
-                                     wq_qtype == QType::Q2_K);
+                                     wq_qtype == QType::Q2_K || is_iq4);
         if (nvfp4_beneficial_qtype && !is_moe && !is_gdn && !sub8bit_qtype) {
             // Dense Q*_K (6-8 bit GGUF) on sm_120: mode 1 (additive — high-
             // precision prefill cache (FP8 1 B/elem, or FP16 2 B/elem when FP8 is

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -117,6 +117,11 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
             case Q3_K:
             case Q2_K:
                 return decode_all;
+            case IQ4_NL:
+            case IQ4_XS:
+                // No dp4a/MMVQ kernels for i-quants — NVFP4 decode cache is
+                // the only fast decode path (mirror pre_dequant_internal.h).
+                return true;
             default:
                 return false;
         }

--- a/tests/test_gguf_dequant_ref.cu
+++ b/tests/test_gguf_dequant_ref.cu
@@ -166,6 +166,46 @@ void ref_dequant_q4_k(const uint8_t* blk, double* out) {
     }
 }
 
+// IQ4_NL: 18 bytes / 32 elems. [ d:f16 | qs:u8[16] ]. Non-linear 4-bit: the
+// nibble indexes a fixed signed codebook (ggml-common.h kvalues_iq4nl).
+// Element j (0..15) = low nibble of qs[j]; element j+16 = high nibble
+// (ggml dequantize_row_iq4_nl). val = d * codebook[nibble].
+static const int8_t kRefIq4nlValues[16] = {-127, -104, -83, -65, -49, -35, -22, -10,
+                                           1,    13,   25,  38,  53,  69,  89,  113};
+void ref_dequant_iq4_nl(const uint8_t* blk, double* out) {
+    half d;
+    std::memcpy(&d, blk, 2);
+    const uint8_t* qs = blk + 2;
+    double dd = f16_to_f64(d);
+    for (int j = 0; j < 16; ++j) {
+        out[j] = dd * static_cast<double>(kRefIq4nlValues[qs[j] & 0xF]);
+        out[j + 16] = dd * static_cast<double>(kRefIq4nlValues[(qs[j] >> 4) & 0xF]);
+    }
+}
+
+// IQ4_XS: 136 bytes / 256 elems. [ d:f16 | scales_h:u16 | scales_l:u8[4] |
+// qs:u8[128] ]. 8 sub-blocks of 32, 6-bit scale per sub-block:
+//   ls = (scales_l[ib/2] >> 4*(ib%2)) & 0xF | ((scales_h >> 2*ib) & 3) << 4
+// Same codebook + nibble layout as IQ4_NL within each 16-byte sub-block
+// (ggml dequantize_row_iq4_xs). val = d * (ls - 32) * codebook[nibble].
+void ref_dequant_iq4_xs(const uint8_t* blk, double* out) {
+    half d;
+    std::memcpy(&d, blk, 2);
+    uint16_t scales_h;
+    std::memcpy(&scales_h, blk + 2, 2);
+    const uint8_t* scales_l = blk + 4;
+    const uint8_t* qs = blk + 8;
+    double dd = f16_to_f64(d);
+    for (int ib = 0; ib < 8; ++ib) {
+        int ls = ((scales_l[ib / 2] >> (4 * (ib % 2))) & 0xF) | (((scales_h >> (2 * ib)) & 3) << 4);
+        double dl = dd * static_cast<double>(ls - 32);
+        for (int j = 0; j < 16; ++j) {
+            out[ib * 32 + j] = dl * static_cast<double>(kRefIq4nlValues[qs[ib * 16 + j] & 0xF]);
+            out[ib * 32 + j + 16] = dl * static_cast<double>(kRefIq4nlValues[(qs[ib * 16 + j] >> 4) & 0xF]);
+        }
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Synthetic block builders — raw bytes via LCG, scale halfs chosen separately.
 // scale_mode: 0 = "normal" random-ish scales; 1 = d=0 (degenerate);
@@ -239,6 +279,36 @@ void build_q4_k(std::vector<uint8_t>& buf, int N, int K, Lcg& g, ScaleMode mode)
         }
 }
 
+void build_iq4_nl(std::vector<uint8_t>& buf, int N, int K, Lcg& g, ScaleMode mode) {
+    int bpr = K / 32;
+    buf.resize((size_t)N * bpr * 18);
+    for (int r = 0; r < N; ++r)
+        for (int b = 0; b < bpr; ++b) {
+            uint8_t* bp = buf.data() + ((size_t)r * bpr + b) * 18;
+            half d = pick_d(g, mode);
+            std::memcpy(bp, &d, 2);
+            for (int i = 0; i < 16; ++i)
+                bp[2 + i] = g.byte();  // codebook indices, full nibble range
+        }
+}
+
+void build_iq4_xs(std::vector<uint8_t>& buf, int N, int K, Lcg& g, ScaleMode mode) {
+    int bpr = K / 256;
+    buf.resize((size_t)N * bpr * 136);
+    for (int r = 0; r < N; ++r)
+        for (int b = 0; b < bpr; ++b) {
+            uint8_t* bp = buf.data() + ((size_t)r * bpr + b) * 136;
+            half d = pick_d(g, mode);
+            std::memcpy(bp, &d, 2);
+            // scales_h + scales_l: all-1-bits hits every 6-bit scale = 63
+            // (max |ls-32| = 31) under MAXMAG, else LCG.
+            for (int i = 0; i < 6; ++i)
+                bp[2 + i] = (mode == MAXMAG) ? 0xFF : g.byte();
+            for (int i = 0; i < 128; ++i)
+                bp[8 + i] = g.byte();
+        }
+}
+
 // -----------------------------------------------------------------------------
 // GPU helpers
 // -----------------------------------------------------------------------------
@@ -282,6 +352,16 @@ void ref_dequant_all(const std::vector<uint8_t>& buf, int N, int K, QType qt,
         for (int r = 0; r < N; ++r)
             for (int b = 0; b < bpr; ++b)
                 ref_dequant_q6_k(buf.data() + ((size_t)r * bpr + b) * 210, &out[(size_t)r * K + b * 256]);
+    } else if (qt == QType::IQ4_NL) {
+        int bpr = K / 32;
+        for (int r = 0; r < N; ++r)
+            for (int b = 0; b < bpr; ++b)
+                ref_dequant_iq4_nl(buf.data() + ((size_t)r * bpr + b) * 18, &out[(size_t)r * K + b * 32]);
+    } else if (qt == QType::IQ4_XS) {
+        int bpr = K / 256;
+        for (int r = 0; r < N; ++r)
+            for (int b = 0; b < bpr; ++b)
+                ref_dequant_iq4_xs(buf.data() + ((size_t)r * bpr + b) * 136, &out[(size_t)r * K + b * 256]);
     } else {  // Q4_K
         int bpr = K / 256;
         for (int r = 0; r < N; ++r)
@@ -300,6 +380,10 @@ void check_dequant(const char* name, QType qt, int N, int K, ScaleMode mode, dou
         build_q8_0(buf, N, K, g, mode);
     else if (qt == QType::Q6_K)
         build_q6_k(buf, N, K, g, mode);
+    else if (qt == QType::IQ4_NL)
+        build_iq4_nl(buf, N, K, g, mode);
+    else if (qt == QType::IQ4_XS)
+        build_iq4_xs(buf, N, K, g, mode);
     else
         build_q4_k(buf, N, K, g, mode);
 
@@ -444,6 +528,20 @@ TEST(GgufRef, Q4_K_Dequant) {
     check_dequant("Q4_K", QType::Q4_K, 16, 256, ZERO_D, 1e-3);
     check_dequant("Q4_K", QType::Q4_K, 16, 256, MAXMAG, 1e-3);
     check_dequant("Q4_K", QType::Q4_K, 8, 256, NAN_D, 1e-3);
+}
+
+TEST(GgufRef, IQ4_NL_Dequant) {
+    check_dequant("IQ4_NL", QType::IQ4_NL, 37, 512, NORMAL, 1e-3);
+    check_dequant("IQ4_NL", QType::IQ4_NL, 16, 256, ZERO_D, 1e-3);
+    check_dequant("IQ4_NL", QType::IQ4_NL, 16, 256, MAXMAG, 1e-3);
+    check_dequant("IQ4_NL", QType::IQ4_NL, 8, 256, NAN_D, 1e-3);
+}
+
+TEST(GgufRef, IQ4_XS_Dequant) {
+    check_dequant("IQ4_XS", QType::IQ4_XS, 33, 512, NORMAL, 1e-3);
+    check_dequant("IQ4_XS", QType::IQ4_XS, 16, 256, ZERO_D, 1e-3);
+    check_dequant("IQ4_XS", QType::IQ4_XS, 16, 256, MAXMAG, 1e-3);
+    check_dequant("IQ4_XS", QType::IQ4_XS, 8, 256, NAN_D, 1e-3);
 }
 
 // =============================================================================


### PR DESCRIPTION
Implements GGUF i-quant support (IQ4_NL + IQ4_XS), closing the "common community quants fail to load" gap. Decision per issue: **implement** (incl. the NVFP4 decode-cache conversion suggested there), not document-as-out-of-scope.

## What

- `QType::IQ4_NL` (20) / `QType::IQ4_XS` (23) with wire-stable values, row-bytes, names, loader mapping — i-quant GGUFs now load.
- **GPU dequant kernels** for both formats (fixed non-linear `kvalues_iq4nl` codebook; block layouts per ggml `dequantize_row_iq4_nl/_xs`), registered in `dequant_gpu` → prefill runs via the generic dequant→cuBLAS path, FP16 cache, etc.
- **NVFP4 decode cache enabled for i-quants** (`nvfp4_beneficial`, resolver auto→mode 2, `tensor_kind_table` overlay, `vram_budget`). Rationale: i-quants have **no dp4a/MMVQ kernels**, so without the cache decode falls to dequant→cuBLAS GEMV — which fails under CUDA-graph capture (cublasLt status 14 inside capture) and runs ~59 tok/s eager. With the cache, decode graphs capture cleanly. This mirrors the established `nvfp4_decode_all` sub-8-bit design (Gemma-3-12B Q4_K_M 77→141 tok/s), here unconditional because no faster alternative exists.
- **Class-A fp64 reference tests**: `GgufRef.IQ4_NL_Dequant` / `IQ4_XS_Dequant` with byte-level LCG block builders + independent fp64 reference (same audit-Phase-2 pattern as Q8_0/Q6_K/Q4_K), incl. d=0 / max-magnitude / NaN-scale edge modes. **Bit-exact (max_rel = 0.0).**
- Docs: `quantization.md` format table + pick guidance, README quant row. IQ1/IQ2/IQ3 families remain explicitly unsupported.

## Validation (RTX 5090, fresh downloads)

| Check | Result |
|---|---|
| Qwen3-4B-Instruct-2507-**IQ4_NL** E2E | coherent, decode **321 tok/s**, graphs captured |
| Llama-3.2-3B-Instruct-**IQ4_XS** E2E | coherent (incl. correct Eiffel-Tower facts), 292 tok/s |
| Greedy graphs vs `--no-cuda-graphs` | Qwen identical; Llama identical through ~30 tokens then non-degenerate drift (documented dense-greedy logit-tie class) |
| `DegenerationTest.*` on IQ4_NL | 5/5 PASS |
| PPL (ppl_corpus, IQ4_NL vs Q8_0 same model) | 7.516 vs 7.140 (+5.3% — normal 4-bit envelope) |
| `verify-fast` (tests + perf gate + graphs gate + smoke) | all PASS; baseline deltas +1.8% tg / +2.0% pp (no regression) |
| stderr grep (CUDA error/capture failed/NaN) | clean |

Closes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
