### PR TITLE
feat(json_schema): $ref/$defs support incl. recursive schemas (#555)

### DIFF
--- a/src/compute/json_schema.cpp
+++ b/src/compute/json_schema.cpp
@@ -26,6 +26,14 @@ public:
         return node;
     }
 
+    // Definitions encountered anywhere in the document ($defs/definitions).
+    // parse_json_schema() attaches them to the root node after parsing.
+    std::vector<std::pair<std::string, std::unique_ptr<SchemaNode>>> collected_defs_;
+    // Set when an unsupported $ref form is seen — the whole parse must fail
+    // (constraining with a silently-dropped $ref would enforce a WRONG grammar).
+    bool ref_error_ = false;
+    bool ref_error() const { return ref_error_; }
+
 private:
     const char* data_;
     size_t len_;
@@ -320,6 +328,48 @@ private:
                     expect(']');
                 }
                 node->type = SchemaType::ENUM;
+            } else if (key == "$ref") {
+                std::string ref = parse_string();
+                std::string name;
+                if (ref == "#") {
+                    name = "#";
+                } else if (ref.rfind("#/$defs/", 0) == 0) {
+                    name = ref.substr(8);
+                } else if (ref.rfind("#/definitions/", 0) == 0) {
+                    name = ref.substr(14);
+                }
+                if (name.empty() || name.find('/') != std::string::npos) {
+                    // External refs / deep JSON pointers — unsupported; fail the
+                    // parse so the caller declines constrained decoding.
+                    IMP_LOG_WARN("JSON schema: unsupported $ref '%s'", ref.c_str());
+                    ref_error_ = true;
+                } else {
+                    node->type = SchemaType::REF;
+                    node->ref_name = name;
+                    has_type = true;
+                }
+            } else if (key == "$defs" || key == "definitions") {
+                skip_ws();
+                if (expect('{')) {
+                    skip_ws();
+                    while (!eof() && peek() != '}') {
+                        std::string def_name = parse_string();
+                        skip_ws();
+                        if (!expect(':'))
+                            break;
+                        auto def_schema = parse_schema_object();
+                        if (def_schema)
+                            collected_defs_.emplace_back(std::move(def_name), std::move(def_schema));
+                        skip_ws();
+                        if (peek() == ',') {
+                            pos_++;
+                            skip_ws();
+                            continue;
+                        }
+                        break;
+                    }
+                    expect('}');
+                }
             } else if (key == "anyOf" || key == "oneOf") {
                 skip_ws();
                 if (expect('[')) {
@@ -359,7 +409,7 @@ private:
         // {"type":"string","enum":[...]} — a later "type":"string" must NOT
         // demote the node back to a free string (the constrainer would then
         // accept any value). Resolve this order-independently.
-        if (!node->enum_values.empty())
+        if (!node->enum_values.empty() && node->type != SchemaType::REF)
             node->type = SchemaType::ENUM;
 
         return node;
@@ -386,6 +436,55 @@ static void compile_patterns(SchemaNode* node) {
         compile_patterns(node->items.get());
     for (auto& sub : node->any_of)
         compile_patterns(sub.get());
+    for (auto& [name, def] : node->defs)
+        compile_patterns(def.get());
+}
+
+// Resolve a REF chain against the root defs table. Defensive guard against
+// pure ref->ref cycles; validate_refs() rejects those at parse time.
+const SchemaNode* resolve_schema_ref(const SchemaNode* root, const SchemaNode* node) {
+    int guard = 0;
+    while (node && node->type == SchemaType::REF) {
+        if (++guard > 64 || !root)
+            return nullptr;
+        if (node->ref_name == "#") {
+            node = root;
+            continue;
+        }
+        const SchemaNode* found = nullptr;
+        for (auto& [name, def] : root->defs) {
+            if (name == node->ref_name) {
+                found = def.get();
+                break;
+            }
+        }
+        node = found;
+    }
+    return node;
+}
+
+// Validate every $ref in the tree: the target must exist and a chain of pure
+// refs must terminate in a non-REF node. Returns false (with a log) on the
+// first unresolvable ref so the caller declines constrained decoding.
+static bool validate_refs(const SchemaNode* root, const SchemaNode* node) {
+    if (!node)
+        return true;
+    if (node->type == SchemaType::REF && resolve_schema_ref(root, node) == nullptr) {
+        IMP_LOG_WARN("JSON schema: unresolvable $ref '%s'", node->ref_name.c_str());
+        return false;
+    }
+    for (auto& [name, prop] : node->properties)
+        if (!validate_refs(root, prop.get()))
+            return false;
+    if (node->items && !validate_refs(root, node->items.get()))
+        return false;
+    for (auto& sub : node->any_of)
+        if (!validate_refs(root, sub.get()))
+            return false;
+    for (auto& [name, def] : node->defs)
+        if (!validate_refs(root, def.get()))
+            return false;
+    return true;
 }
 
 std::unique_ptr<SchemaNode> parse_json_schema(const std::string& json) {
@@ -393,6 +492,18 @@ std::unique_ptr<SchemaNode> parse_json_schema(const std::string& json) {
     auto root = parser.parse();
     if (!root) {
         IMP_LOG_ERROR("Failed to parse JSON schema");
+        return nullptr;
+    }
+    if (parser.ref_error()) {
+        IMP_LOG_ERROR("Failed to parse JSON schema: unsupported $ref form");
+        return nullptr;
+    }
+    // Attach definitions collected anywhere in the document to the root —
+    // resolve_schema_ref() searches only the root table.
+    for (auto& [name, def] : parser.collected_defs_)
+        root->defs.emplace_back(std::move(name), std::move(def));
+    if (!validate_refs(root.get(), root.get())) {
+        IMP_LOG_ERROR("Failed to parse JSON schema: unresolvable $ref");
         return nullptr;
     }
     compile_patterns(root.get());
@@ -409,6 +520,9 @@ std::unique_ptr<SchemaNode> SchemaNode::clone() const {
     c->min_length = min_length;
     c->max_length = max_length;
     c->pattern_nfa = pattern_nfa;  // shared; compiled NFA is immutable
+    c->ref_name = ref_name;
+    for (auto& [name, def] : defs)
+        c->defs.emplace_back(name, def->clone());
     for (auto& [name, prop] : properties)
         c->properties.emplace_back(name, prop->clone());
     if (items)

--- a/src/compute/json_schema.h
+++ b/src/compute/json_schema.h
@@ -107,6 +107,7 @@ enum class SchemaType {
     ARRAY,
     ENUM,
     ANY_OF,
+    REF,  // $ref to a $defs/definitions entry (or "#" = schema root)
 };
 
 struct SchemaNode {
@@ -126,6 +127,16 @@ struct SchemaNode {
     // ANY_OF
     std::vector<std::unique_ptr<SchemaNode>> any_of;
 
+    // REF: name of the referenced definition ("#" = schema root). Resolution
+    // happens against the ROOT node's `defs` table at constrain time, so
+    // recursive and mutually-recursive schemas are representable without
+    // ownership cycles (frames hold non-owning resolved pointers).
+    std::string ref_name;
+
+    // Definitions table ($defs / definitions). Collected from anywhere in the
+    // schema document and attached to the ROOT node by parse_json_schema().
+    std::vector<std::pair<std::string, std::unique_ptr<SchemaNode>>> defs;
+
     // STRING constraints (JSON Schema "pattern" / "minLength" / "maxLength").
     std::string pattern;       // raw regex source; empty = no pattern
     int min_length = -1;       // -1 = unset
@@ -138,9 +149,19 @@ struct SchemaNode {
     std::unique_ptr<SchemaNode> clone() const;
 };
 
-// Parse a JSON Schema string into a SchemaNode tree.
-// Returns nullptr on parse failure.
+// Parse a JSON Schema string into a SchemaNode tree. Supports $defs /
+// definitions + "$ref": "#/$defs/<name>" | "#/definitions/<name>" | "#",
+// including recursive and mutually-recursive definitions (agent frameworks —
+// pydantic, zod — emit $defs+$ref for every nested model).
+// Returns nullptr on parse failure or when a $ref cannot be resolved (callers
+// then decline constrained decoding rather than enforcing a wrong grammar).
 std::unique_ptr<SchemaNode> parse_json_schema(const std::string& json);
+
+// Resolve a (possibly REF) node against the root's defs table. Returns the
+// node itself when it is not a REF; nullptr on a missing target or a pure
+// ref->ref cycle (parse_json_schema validates both, so runtime hits are
+// defensive only).
+const SchemaNode* resolve_schema_ref(const SchemaNode* root, const SchemaNode* node);
 
 // ---------------------------------------------------------------------------
 // GBNF-style grammar loader (Part B — PARTIAL / non-recursive subset).

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -10,6 +10,12 @@
 
 namespace imp {
 
+// Max simulated frame-stack depth. Each '{'/'[' nesting level holds ~2 frames
+// (container frame + value frame), so 192 frames ~= 96 nesting levels. Only
+// reachable via recursive $ref schemas; hitting the cap forces closure (still
+// schema-valid — any finite nesting satisfies a recursive schema).
+static constexpr size_t kMaxSchemaStackDepth = 192;
+
 // ---------------------------------------------------------------------------
 // Initialization
 // ---------------------------------------------------------------------------
@@ -72,7 +78,9 @@ void SchemaConstrainer::reset() {
 
 void SchemaConstrainer::push_value_frame(const SchemaNode* node) {
     SchemaFrame frame;
-    frame.node = node;
+    // Frames always hold RESOLVED nodes: $ref indirection ends here, so the
+    // phase machine below never sees SchemaType::REF.
+    frame.node = resolve_schema_ref(schema_.get(), node);
     frame.phase = SchemaPhase::VALUE_START;
     stack_.push_back(std::move(frame));
 }
@@ -84,7 +92,7 @@ void SchemaConstrainer::push_value_frame(const SchemaNode* node) {
 const SchemaNode* SchemaConstrainer::find_property(const SchemaNode* obj, const std::string& key) const {
     for (auto& [name, schema] : obj->properties) {
         if (name == key)
-            return schema.get();
+            return resolve_schema_ref(schema_.get(), schema.get());
     }
     return nullptr;
 }
@@ -241,9 +249,11 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
 
         case SchemaPhase::ARRAY_OPEN: {
             uint16_t mask = CAT_CLOSE_BRACKET;
-            // Allow value start for first item
-            if (f.node && f.node->items) {
-                switch (f.node->items->type) {
+            // Allow value start for first item ($ref items resolve first)
+            const SchemaNode* items =
+                f.node ? resolve_schema_ref(schema_.get(), f.node->items.get()) : nullptr;
+            if (items) {
+                switch (items->type) {
                     case SchemaType::STRING:
                         mask |= CAT_QUOTE;
                         break;
@@ -452,7 +462,7 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
     SchemaFrame& f = stk.back();
     auto push_value = [&](const SchemaNode* node) {
         SchemaFrame nf;
-        nf.node = node;
+        nf.node = resolve_schema_ref(schema_.get(), node);
         nf.phase = SchemaPhase::VALUE_START;
         stk.push_back(std::move(nf));
     };
@@ -484,10 +494,23 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
             }
             switch (f.node->type) {
                 case SchemaType::OBJECT:
-                    if (c == '{') { f.phase = SchemaPhase::OBJECT_OPEN; return true; }
+                    // Depth cap: recursive $ref schemas allow unbounded nesting;
+                    // refuse to open deeper than ~96 levels (any finite nesting
+                    // still satisfies the schema, so this only forces closure).
+                    if (c == '{') {
+                        if (stk.size() >= kMaxSchemaStackDepth)
+                            return false;
+                        f.phase = SchemaPhase::OBJECT_OPEN;
+                        return true;
+                    }
                     return false;
                 case SchemaType::ARRAY:
-                    if (c == '[') { f.phase = SchemaPhase::ARRAY_OPEN; return true; }
+                    if (c == '[') {
+                        if (stk.size() >= kMaxSchemaStackDepth)
+                            return false;
+                        f.phase = SchemaPhase::ARRAY_OPEN;
+                        return true;
+                    }
                     return false;
                 case SchemaType::STRING:
                     if (c == '"') {

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -135,8 +135,9 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
     bool use_schema = !json_schema.empty();
     if (use_schema) {
         auto probe = parse_json_schema(json_schema);
-        if (probe && probe->type == SchemaType::OBJECT && probe->properties.empty() &&
-            probe->enum_values.empty()) {
+        const SchemaNode* probe_res = probe ? resolve_schema_ref(probe.get(), probe.get()) : nullptr;
+        if (probe_res && probe_res->type == SchemaType::OBJECT && probe_res->properties.empty() &&
+            probe_res->enum_values.empty()) {
             IMP_LOG_INFO("ConstraintManager: free-form object schema → any-JSON constrainer");
             use_schema = false;
             json_mode = true;

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -817,5 +817,133 @@ TEST(SchemaConstrainTest, EnumAndIntegerComboTokensValidated) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// $ref / $defs (issue #555) — pydantic/zod emit $defs+$ref for EVERY nested
+// model, so this is the agent-framework path, not an exotic corner.
+// ---------------------------------------------------------------------------
+
+// Parse-level: $defs collected, $ref resolves, unsupported/unresolvable refs
+// fail the parse (decline constrained decoding instead of enforcing a wrong
+// grammar). No CUDA needed.
+TEST(SchemaConstrainTest, RefDefsParseAndResolve) {
+    // pydantic-style nested model
+    auto a = parse_json_schema(
+        R"({"type":"object","properties":{"inner":{"$ref":"#/$defs/Inner"}},)"
+        R"("required":["inner"],"$defs":{"Inner":{"type":"object",)"
+        R"("properties":{"x":{"type":"integer"}},"required":["x"]}}})");
+    ASSERT_TRUE(a != nullptr);
+    ASSERT_EQ(a->properties.size(), 1u);
+    const SchemaNode* inner_ref = a->properties[0].second.get();
+    EXPECT_EQ(inner_ref->type, SchemaType::REF);
+    const SchemaNode* inner = resolve_schema_ref(a.get(), inner_ref);
+    ASSERT_TRUE(inner != nullptr);
+    EXPECT_EQ(inner->type, SchemaType::OBJECT);
+    ASSERT_EQ(inner->properties.size(), 1u);
+    EXPECT_EQ(inner->properties[0].first, "x");
+
+    // "definitions" spelling + clone preserves refs/defs
+    auto b = parse_json_schema(
+        R"({"definitions":{"S":{"type":"string"}},"type":"object",)"
+        R"("properties":{"s":{"$ref":"#/definitions/S"}}})");
+    ASSERT_TRUE(b != nullptr);
+    auto b2 = b->clone();
+    const SchemaNode* s_res = resolve_schema_ref(b2.get(), b2->properties[0].second.get());
+    ASSERT_TRUE(s_res != nullptr);
+    EXPECT_EQ(s_res->type, SchemaType::STRING);
+
+    // root self-ref "#"
+    auto c = parse_json_schema(
+        R"({"type":"object","properties":{"next":{"$ref":"#"}},"required":[]})");
+    ASSERT_TRUE(c != nullptr);
+    EXPECT_EQ(resolve_schema_ref(c.get(), c->properties[0].second.get()), c.get());
+
+    // unresolvable name → parse fails
+    EXPECT_EQ(parse_json_schema(
+                  R"({"type":"object","properties":{"a":{"$ref":"#/$defs/Missing"}}})"),
+              nullptr);
+    // external / deep-pointer refs → parse fails
+    EXPECT_EQ(parse_json_schema(
+                  R"({"properties":{"a":{"$ref":"https://example.com/s.json"}}})"),
+              nullptr);
+    EXPECT_EQ(parse_json_schema(
+                  R"({"properties":{"a":{"$ref":"#/properties/b"}}})"),
+              nullptr);
+    // pure ref->ref cycle → parse fails (no structure to terminate resolution)
+    EXPECT_EQ(parse_json_schema(
+                  R"({"$ref":"#/$defs/A","$defs":{"A":{"$ref":"#/$defs/B"},)"
+                  R"("B":{"$ref":"#/$defs/A"}}})"),
+              nullptr);
+}
+
+// Enforcement through a $ref: the referenced object's keys/required are
+// enforced exactly as an inline schema would be.
+TEST(SchemaConstrainTest, RefNestedModelEnforced) {
+    SKIP_IF_NO_CUDA();
+    //                                 0       1      2      3    4    5        6    7    8    9
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "inner", ":", "x", "5", "}"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"inner":{"$ref":"#/$defs/Inner"}},)"
+        R"("required":["inner"],"$defs":{"Inner":{"type":"object",)"
+        R"("properties":{"x":{"type":"integer"}},"required":["x"]}}})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    for (int t : {3, 4, 5, 4, 6})  // { "inner" :  → value frame is the REF target
+        sc.update(t);
+    {
+        auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+        EXPECT_TRUE(a[3]) << "'{' must open the $ref'd inner object";
+        EXPECT_FALSE(a[8]) << "bare digit masked — inner value is an object, not a number";
+    }
+    for (int t : {3, 4, 7, 4, 6})  // { "x" :  → inner integer value
+        sc.update(t);
+    {
+        auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+        EXPECT_TRUE(a[8]) << "'5' must be allowed for Inner.x (integer)";
+        EXPECT_FALSE(a[9]) << "'}' masked — required Inner.x not yet emitted";
+    }
+}
+
+// True recursion: a tree node whose children are arrays of itself. The frame
+// stack must follow $ref depth arbitrarily (here 2 levels) — the gap the old
+// NFA backend could not represent.
+TEST(SchemaConstrainTest, RecursiveSchemaEnforced) {
+    SKIP_IF_NO_CUDA();
+    //                                 0       1      2      3    4    5    6    7    8    9    10   11
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "v", ":", "1", ",", "kids", "[", "]"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"$ref":"#/$defs/Node","$defs":{"Node":{"type":"object",)"
+        R"("properties":{"v":{"type":"integer"},"kids":{"type":"array",)"
+        R"("items":{"$ref":"#/$defs/Node"}}},"required":["v"]}}})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+
+    // { "v" : 1 , "kids" : [
+    for (int t : {3, 4, 5, 4, 6, 7, 8, 4, 9, 4, 6, 10})
+        sc.update(t);
+    {
+        auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+        EXPECT_TRUE(a[3]) << "'{' must start a recursive child Node inside kids[]";
+        EXPECT_TRUE(a[11]) << "']' must be allowed (empty kids)";
+        EXPECT_FALSE(a[7]) << "bare digit masked — items are Node objects";
+    }
+    // open child: { "v" : 1 — the recursive frame enforces Node's grammar at
+    // depth 2: a second "kids" key (','+key) must be offered, digits must not.
+    for (int t : {3, 4, 5, 4, 6, 7})
+        sc.update(t);
+    {
+        auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+        EXPECT_TRUE(a[8]) << "',' after child's v — 'kids' is still emittable at depth 2";
+        EXPECT_FALSE(a[4]) << "bare quote masked mid-number at depth 2";
+    }
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
Closes the `TODO(part-b)` milestone for the **json_schema** path: recursive schemas now work end-to-end. Agent frameworks (pydantic, zod) emit `$defs`+`$ref` for *every* nested model — until now any such schema failed to parse and constrained decoding was declined.

## Design

The key insight: the per-token FSM simulator (#499) is already **stack-based** (`std::vector<SchemaFrame>`) — it was always capable of unbounded recursion. The actual gaps were (a) the parser had no `$ref`/`$defs` at all, and (b) `SchemaNode` ownership (`unique_ptr` children) cannot represent cycles. So instead of replacing the NFA with a pushdown engine:

- `SchemaType::REF` nodes carry a definition *name*; `$defs`/`definitions` are collected anywhere in the document and attached to the root.
- `resolve_schema_ref(root, node)` resolves `#`, `#/$defs/<n>`, `#/definitions/<n>` chains; the constrainer resolves at **frame-push time**, so the phase machine never sees a REF and recursion costs nothing on the hot path.
- `parse_json_schema` validates all refs up front — unsupported forms (external URLs, deep pointers), missing targets, and pure ref→ref cycles **fail the parse**, so callers decline constrained decoding rather than enforce a wrong grammar (same safety contract as before).
- Depth cap at ~96 nesting levels: recursive schemas otherwise allow unbounded frame growth; the cap only forces closure, which is still schema-valid.

The GBNF `grammar` parameter keeps its documented non-recursive subset (a true pushdown for GBNF remains future work); the json_schema constrained-decoding milestone from the issue is what ships here.

## Tests

- `SchemaConstrainTest.RefDefsParseAndResolve` — $defs/definitions parsing, resolution, clone-preservation, root self-ref `#`, and the three decline classes (missing target, external/deep ref, pure ref cycle).
- `SchemaConstrainTest.RefNestedModelEnforced` — masks through a `$ref`'d nested object (required-key + integer-type enforcement at depth 2).
- `SchemaConstrainTest.RecursiveSchemaEnforced` — self-referential tree schema; enforcement verified inside `kids[]` at recursion depth 2.
- Full `SchemaConstrainTest/JsonConstrainTest/RegexNfaTest` suites: 23/23 PASS.

## E2E (Qwen3-4B Q8_0, imp-server)

pydantic-style extraction schema with `$defs.Address`:
```json
{"name": "Anna Schmidt", "age": 34, "address": {"street": "Hauptstr. 5", "zip": "10115", "city": "Berlin"}}
```
recursive Node-tree schema (`$ref: #/$defs/Node` at root and in `items`):
```json
{"children": [{"name": "src", "children": [{"name": "main.c", "children": []}, {"name": "util.c", "children": []}]}], "name": "root"}
```
both exact, valid, schema-conform at temperature 0.

Note: degen_suite adherence failures on Qwen3-4B-Instruct-2507 (answers landing in `reasoning_content`) are **pre-existing on main** (verified by A/B with a clean main build) — tracked separately, unrelated to this PR.

Closes #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
