### PR TITLE
fix(server): thinking default requires template evidence — Instruct-2507 answers no longer trapped in reasoning_content

### DIFF
--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -159,6 +159,7 @@ bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer, c
     family_ = family;
     stop_token_ids_.clear();
     use_jinja_ = false;
+    mentions_thinking_ = false;  // resolved below once the Jinja engine is up
 
     // Try Jinja2 rendering if template string provided
     if (!jinja_str.empty()) {
@@ -169,6 +170,19 @@ bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer, c
             use_jinja_ = true;
             build_control_token_map(tokenizer);
             IMP_LOG_INFO("Chat template: using Jinja2 engine");
+            // Think evidence (drives the server-side thinking DEFAULT):
+            //  a) the template exposes the `enable_thinking` switch
+            //     (Qwen3 hybrid, Qwen3.6, Nemotron), or
+            //  b) a fresh-conversation render emits "<think>" (Phi-4
+            //     reasoning system prompt, DeepSeek-R1 generation prefix).
+            // A raw substring match is NOT enough: Qwen3-*-Instruct-2507
+            // mentions <think> only in branches that re-render PAST
+            // assistant turns — for a fresh turn nothing thinks, and
+            // defaulting it to thinking traps the whole answer in
+            // reasoning_content.
+            mentions_thinking_ = jinja_str.find("enable_thinking") != std::string::npos;
+            if (!mentions_thinking_ && jinja_str.find("<think>") != std::string::npos)
+                mentions_thinking_ = probe_render_mentions_think(tokenizer);
         } else {
             IMP_LOG_WARN("Jinja2 parse failed (%s), falling back to hardcoded template",
                          tpl->error().c_str());
@@ -1115,6 +1129,22 @@ std::vector<int32_t> ChatTemplate::apply_jinja(const Tokenizer& tok, const std::
     auto_detect_stop_tokens(ctx);
 
     return result;
+}
+
+// Render a minimal fresh conversation and report whether the generation
+// prompt itself contains "<think>" — i.e. the template (not the model)
+// enters reasoning mode on a new turn. See init() for why this exists.
+bool ChatTemplate::probe_render_mentions_think(const Tokenizer& tok) const {
+    if (!jinja_tpl_)
+        return false;
+    jinja::Context ctx;
+    std::vector<ChatMessage> probe{{"user", "hi"}};
+    ctx["messages"] = jinja::Value(build_jinja_messages(probe, /*suppress_thinking=*/false));
+    ctx["add_generation_prompt"] = jinja::Value(true);
+    ctx["bos_token"] = (bos_id_ >= 0) ? jinja::Value(tok.token_text(bos_id_)) : jinja::Value(std::string(""));
+    ctx["eos_token"] = jinja::Value(tok.token_text(tok.eos_id()));
+    std::string rendered = jinja_tpl_->render(ctx);
+    return rendered.find("<think>") != std::string::npos;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/model/chat_template.h
+++ b/src/model/chat_template.h
@@ -72,6 +72,17 @@ public:
 
     const std::vector<int32_t>& stop_token_ids() const { return stop_token_ids_; }
     ChatTemplateFamily family() const { return family_; }
+    // True when the raw Jinja template references reasoning ("<think>" or
+    // "enable_thinking"). Used to decide the server-side thinking DEFAULT:
+    // vocab-level <think> tokens alone are NOT evidence of a think-trained
+    // model (Qwen3-*-Instruct-2507 ships the Qwen3 vocab incl. <think>
+    // specials but is not think-trained and its template never opens a
+    // think block — defaulting it to thinking traps the whole answer in
+    // reasoning_content).
+    bool mentions_thinking() const { return mentions_thinking_; }
+    // True when a raw Jinja template is driving rendering (mentions_thinking
+    // is only meaningful evidence in that case).
+    bool has_jinja() const { return use_jinja_; }
     bool is_raw() const { return family_ == ChatTemplateFamily::RAW; }
     bool supports_tools() const;
     const std::string& default_system_message() const { return default_system_message_; }
@@ -128,8 +139,10 @@ private:
     // Jinja2 engine (set during init if template string provided)
     std::shared_ptr<jinja::Template> jinja_tpl_;
     bool use_jinja_ = false;
+    bool mentions_thinking_ = false;
 
     // Jinja2-based apply: render template, split on control tokens, encode
+    bool probe_render_mentions_think(const Tokenizer& tok) const;
     std::vector<int32_t> apply_jinja(const Tokenizer& tok, const std::vector<ChatMessage>& msgs,
                                      bool add_generation_prompt = true, bool suppress_thinking = false) const;
 

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1014,8 +1014,20 @@ static bool snapshot_state_and_tokenize_(
     // mode breaks the requested output format: structured output (json_mode)
     // and tool calls keep the old default OFF. An explicit "enable_thinking"
     // in the request always wins in both directions.
-    const bool thinking_default =
-        ctx.snap.is_think_model && !ctx.params.json_mode && !ctx.params.has_tools;
+    // Template evidence guard: vocab-level <think> specials alone are not
+    // proof of a think-trained model — Qwen3-*-Instruct-2507 ships the Qwen3
+    // vocab (incl. <think>) but never opens a think block; defaulting it to
+    // thinking traps the entire answer in reasoning_content (content "").
+    // Default ON only when the chat template itself references thinking.
+    // Models without a Jinja template keep the previous default (no evidence
+    // either way); an explicit "enable_thinking" still wins in both cases.
+    // Only a present-but-silent Jinja template counts as evidence AGAINST
+    // thinking; hardcoded families / templateless runs keep the old default.
+    const bool template_think_evidence = !ctx.snap.have_template ||
+                                         !ctx.snap.chat_tpl.has_jinja() ||
+                                         ctx.snap.chat_tpl.mentions_thinking();
+    const bool thinking_default = ctx.snap.is_think_model && template_think_evidence &&
+                                  !ctx.params.json_mode && !ctx.params.has_tools;
     const bool want_thinking = ctx.params.enable_thinking_set
                                    ? ctx.params.enable_thinking_requested
                                    : thinking_default;


### PR DESCRIPTION
Drive-by find from the #555 E2E validation: **every plain-chat answer from Qwen3-4B-Instruct-2507 landed in `reasoning_content` with `content: ""`** (degen_suite adherence 4/4 FAIL, verified pre-existing on a clean main build).

## Root cause

`is_think_model` is detected purely from the vocab (`<think>`/`</think>` exist as special tokens). The 2507-Instruct family ships the Qwen3 vocab — including those specials — but is **not think-trained**, and its chat template mentions `<think>` only in branches that re-render *past* assistant turns. With #513's thinking-default-ON the server injected `<think>\n` into the prompt, the model (never trained to close) answered inside the think block and EOS'd → the whole answer was classified as reasoning.

## Fix

The thinking **default** now additionally requires template evidence:

- the Jinja template references `enable_thinking` (Qwen3 hybrid, Qwen3-14B, Qwen3.6, Nemotron all have it — checked against the local zoo), **or**
- a fresh-conversation probe render emits `<think>` (Phi-4-reasoning's system prompt, DeepSeek-R1's generation prefix).

A raw substring match cannot discriminate — the 2507 template *contains* `<think>` but never renders it for a new turn, hence the probe render. Hardcoded-family/templateless runs keep the previous default (no evidence either way), and an explicit `enable_thinking` in the request still wins in both directions. `is_think_model` itself is unchanged (it also drives the phantom-turn stop-token guards, which remain correct for 2507).

## Validation

| Check | Before | After |
|---|---|---|
| 2507 plain chat | `content:""`, answer in reasoning | `content:"BANANA42"`, `reasoning:null` |
| degen_suite adherence (2507) | 4/4 FAIL | 4/4 PASS |
| Qwen3-8B think default | thinks | still thinks (reasoning_content populated, clean content) |
| verify-fast | — | tests PASS, decode +0.09% vs baseline (isolated re-run; a first back-to-back read of −3.17% was the documented batching artifact), pp512 WARN = cuBLAS restart variance, pp4096 +4.87% PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
