### PR TITLE
fix(gemma): remove dense-Gemma NVFP4 mode-2 cap + repair teacher-forced eval path (#552)

### DIFF
--- a/include/imp/imp.h
+++ b/include/imp/imp.h
@@ -50,6 +50,11 @@ int imp_model_n_layers(ImpModel model);
 int imp_model_d_model(ImpModel model);
 int imp_model_vocab_size(ImpModel model);
 int imp_model_max_seq_len(ImpModel model);
+/* BOS token id when the model's tokenizer prepends one (add_bos), else -1.
+ * Teacher-forced eval (perplexity) must prepend it for BOS-dependent
+ * families (Gemma, Llama) or the NLL measures an out-of-distribution
+ * sequence. */
+int32_t imp_model_bos_token(ImpModel model);
 
 // --- Context / Runtime ---
 

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -287,6 +287,14 @@ int imp_model_vocab_size(ImpModel model) {
     return model->model->config().vocab_size;
 }
 
+int32_t imp_model_bos_token(ImpModel model) {
+    if (!model || !model->model || !model->model->tokenizer()) {
+        return -1;
+    }
+    const auto* tok = model->model->tokenizer();
+    return tok->add_bos() ? tok->bos_id() : -1;
+}
+
 int imp_model_max_seq_len(ImpModel model) {
     if (!model || !model->model) {
         return 0;

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -1,4 +1,5 @@
 #include "exec/executor.h"
+#include "exec/executor_gemv_helpers.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
 #include "exec/executor_debug.h"
@@ -52,33 +53,6 @@ namespace imp {
 // Shared helpers: executor_helpers.h (get_kv_layer, vram_alloc, etc.)
 // Layer methods: executor_attention.cu, executor_ffn.cu, executor_ssm_gdn.cu
 
-// LM head dp4a GEMV dispatch: y = W @ x (FP32 output for logits).
-static void dispatch_gemv_fp32(QType qtype, const void* W, const block_q8_1* q8_1, const float* d8, float* y,
-                               int M, int K, cudaStream_t stream) {
-    switch (qtype) {
-        case QType::Q6_K:
-            gemv_q6k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
-            break;
-        case QType::Q4_0:
-            gemv_q4_0_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
-            break;
-        case QType::Q4_K:
-            gemv_q4_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
-            break;
-        case QType::Q5_K:
-            gemv_q5_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
-            break;
-        case QType::Q2_K:
-            gemv_q2_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
-            break;
-        case QType::Q3_K:
-            gemv_q3_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
-            break;
-        default:
-            gemv_q8_0_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
-            break;
-    }
-}
 
 // Gemma 4: per-layer output scale. Multiplies all elements of `data` by the
 // scalar half stored at `scale_ptr` (device memory). Used at end of each layer

--- a/src/exec/executor_gemv_helpers.h
+++ b/src/exec/executor_gemv_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "compute/gemm.h"
 #include "compute/gemm_q6k.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -31,6 +32,37 @@ static void dispatch_gemv_residual(QType qtype, const void* W, const block_q8_1*
             break;
         default:
             gemv_q8_0_q8_1_residual(W, q8_1, d8, y, residual, M, K, stream);
+            break;
+    }
+}
+
+// LM head dp4a GEMV dispatch: y = W @ x with FP32 output (logits).
+// Shared by executor_forward.cu (production forward_logits) and
+// executor_perplexity.cu (teacher-forced eval) — the eval path MUST use the
+// same kernels as production or PPL stops measuring what serving does.
+static void dispatch_gemv_fp32(QType qtype, const void* W, const block_q8_1* q8_1, const float* d8,
+                               float* y, int M, int K, cudaStream_t stream) {
+    switch (qtype) {
+        case QType::Q6_K:
+            gemv_q6k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
+            break;
+        case QType::Q4_0:
+            gemv_q4_0_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
+            break;
+        case QType::Q4_K:
+            gemv_q4_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
+            break;
+        case QType::Q5_K:
+            gemv_q5_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
+            break;
+        case QType::Q2_K:
+            gemv_q2_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
+            break;
+        case QType::Q3_K:
+            gemv_q3_k_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
+            break;
+        default:
+            gemv_q8_0_q8_1_fp32(W, q8_1, d8, y, M, K, stream);
             break;
     }
 }

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -19,6 +19,8 @@
 // gemm_via_handle_ (tier-aware: NVFP4 / FP8 / FP16 / GGUF all handled).
 
 #include "exec/executor.h"
+#include "exec/executor_gemv_helpers.h"
+#include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
 #include "compute/layernorm.h"
 #include "core/logging.h"
@@ -108,6 +110,15 @@ void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total,
     const bool lm_nvfp4_secondary = (lm_nvfp4_it != wcache_.nvfp4.end());
     const bool lm_has_fp8 = (wcache_.fp8.count(model_->output_proj().data) != 0);
     const bool lm_is_nvfp4 = !lm_has_fp8 && ((lm_tier == StorageTier::NVFP4) || lm_nvfp4_secondary);
+    // Raw-GGUF-quant LM head (tied-embedding Gemma Q4_K etc.): mirror the
+    // production use_dp4a_lm arm. Routing these through gemm_via_handle_ at
+    // M=1 hits the GGUF GEMV handlers with an FP16 (un-quantized) input and
+    // produced an illegal memory access on gemma-3-12b — which poisoned the
+    // context and surfaced as the absurd PPL=1.0000 (zeroed NLL buffer).
+    const auto out_qtype = model_->out_proj_.qtype;
+    const bool use_dp4a_lm = qscratch_.q8_1_buf && compute_dtype_ == QType::F16 &&
+                             is_dp4a_qtype(out_qtype) && !runtime_config().gemm.no_dp4a_lm &&
+                             lm_tier != StorageTier::MXFP4 && !lm_has_fp8;
     NvFP4QuantResult nvfp4_lm_r{};
     if (lm_is_nvfp4) {
         if (lm_nvfp4_secondary) {
@@ -136,10 +147,35 @@ void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total,
                 gemv_nvfp4_kpar_fp32(nvfp4_lm_r, static_cast<const half*>(no_row.data),
                                      static_cast<float*>(lg_row.data), cfg.vocab_size, cfg.d_model, stream);
             }
+        } else if (use_dp4a_lm) {
+            // Per-row: fused RMSNorm→Q8_1 quantize + dp4a GEMV (the q8_1
+            // scratch holds exactly one row — same as production decode).
+            auto* q8 = static_cast<block_q8_1*>(qscratch_.q8_1_buf);
+            for (int r = 0; r < csz; ++r) {
+                Tensor h_row = hc.slice(r, r + 1);
+                Tensor lg_row = lg.slice(r, r + 1);
+                rmsnorm_quantize_q8_1(static_cast<const half*>(h_row.data),
+                                      static_cast<const half*>(model_->output_norm().data), q8,
+                                      qscratch_.d8_buf, nullptr, cfg.d_model, cfg.rms_norm_eps, stream,
+                                      norm_w_off_);
+                dispatch_gemv_fp32(out_qtype, model_->output_proj().data, q8, qscratch_.d8_buf,
+                                   static_cast<float*>(lg_row.data), cfg.vocab_size, cfg.d_model, stream);
+            }
         } else {
             Tensor noc = view_tokens(norm_out_, csz);      // [csz, d]
             rmsnorm(hc, model_->output_norm(), noc, cfg.rms_norm_eps, stream, norm_w_off_);
             gemm_via_handle_(model_->out_proj_id, noc, lg, ctx);
+        }
+        // Final logit softcap (Gemma-2/3/4): production forward_logits applies
+        // it before sampling — without it the eval NLL measures a different
+        // model than the one being served.
+        if (cfg.final_logit_softcap > 0.0f && !runtime_config().generation.no_logit_softcap) {
+            int64_t total = static_cast<int64_t>(csz) * V;
+            int threads = 256;
+            int blocks = static_cast<int>((total + threads - 1) / threads);
+            logit_softcap_fp32_kernel<<<blocks, threads, 0, stream>>>(
+                static_cast<float*>(lg.data), cfg.final_logit_softcap,
+                1.0f / cfg.final_logit_softcap, total);
         }
         perplexity_nll_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), d_tokens,
                                                         chunk_start + c, n_total, V, d_nll);

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -277,22 +277,16 @@ void Engine::init_resolve_quant_flags_() {
         IMP_LOG_INFO("GDN model: disabling FP8 prefill (recurrent state needs FP16 precision)");
         config_.use_fp8_prefill = 0;
     }
-    // DENSE Gemma (3 and 4) from GGUF: the mode-2 NVFP4 prequant conversion
-    // is broken for these shapes. Two manifestations, same lever:
-    //   - gemma-4-31B: NaN logits from decode step 2, greedy argmax lands on
-    //     <pad> (NaN beats the -inf ban mask) → 1-token answers (#516).
-    //   - gemma-3-12b: server-only IMA race in the step-decode path
-    //     truncating every chat response after the first token; vanishes
-    //     with the NVFP4 decode cache off or at mode 1 (#514).
-    // Mode 1 (additive, few tensors) and the FP16 cache are verified clean
-    // on both models; the MoE 26B-A4B (degen-suite green) keeps mode 2.
-    if (config_.use_nvfp4_decode == 2 && !model_->config().is_nvfp4_prequant &&
-        model_->config().n_experts == 0 &&
-        (model_->config().arch == ModelArch::GEMMA3 || model_->config().arch == ModelArch::GEMMA4)) {
-        config_.use_nvfp4_decode = 1;
-        IMP_LOG_INFO("Dense Gemma (GGUF): NVFP4 decode capped at mode 1 "
-                     "(mode-2 prequant conversion broken for dense Gemma — #514/#516)");
-    }
+    // DENSE Gemma (3 and 4) from GGUF: the mode-2 NVFP4 conversion used to be
+    // broken here (#514 server-only IMA truncation on gemma-3-12b, #516 NaN
+    // logits from step 2 on gemma-4-31B) and was capped to mode 1 as a
+    // mitigation. Re-validated 2026-06-06 (#552): both manifestations are
+    // gone on current main (fixed by the intervening decode-path work, most
+    // likely the #539 in-place compaction race fix) — gemma-3-12b mode 2 is
+    // degen-suite clean CLI+server, gemma-4-31B mode 2 answers coherently
+    // (55 tok/s vs 21.7 at mode 1) with multi-turn green. The cap is removed;
+    // dense Gemma follows the same sub-8-bit mode-2 auto-pick as every other
+    // arch (still gated behind gemm.nvfp4_decode_all for Q4_K-class sources).
     if (model_->config().arch == ModelArch::GEMMA4) {
         // CUDA graphs: enabled for Gemma-4 decode. The MoE decode fast path is fully
         // device-side (dp4a GEMV, no D2H memcpy), so graph capture works.

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -195,6 +195,14 @@ int main(int argc, char** argv) {
             return 1;
         }
         ppl_tokens.resize(n_tok);
+        // BOS-dependent families (Gemma especially) need the BOS prepended or
+        // the teacher-forced NLL measures an out-of-distribution sequence
+        // (gemma-3-12b read PPL ~100 instead of ~10 without it).
+        int32_t bos = imp_model_bos_token(model);
+        if (bos >= 0 && ppl_tokens[0] != bos) {
+            ppl_tokens.insert(ppl_tokens.begin(), bos);
+            n_tok++;
+        }
         config.prefill_chunk_size = 0;  // single-chunk: keep all-position hidden
         config.max_batch_size = 1;
         config.max_seq_len = n_tok + 16;


### PR DESCRIPTION
Re-validates and closes both halves of #552, and repairs the teacher-forced eval instrument that the validation required.

## 1. `attention_k_eq_v` (gemma-4-31B): already implemented, verified working

The 31B GGUF has no `attn_v.weight` on full-attention layers (HF `attention_k_eq_v: true`, `num_global_key_value_heads: 4`, `global_head_dim: 512`). imp's K→V alias + scale-free `v_norm` (executor_attention.cu) match the HF reference semantics (`value_states = k_proj` output, v_norm without RoPE). **Empirically: 31B Q4_K_M answers coherently on main** ("The capital of France is Paris.", correct 3-capital list), server battery repetition/adherence/multi-turn **12/12 PASS**. The issue's "unimplemented" claim was stale.

## 2. Mode-2 NVFP4 conversion: no longer broken → cap removed

Both historical manifestations were re-driven with the cap disabled:

| Probe | #514/#516 symptom | Now |
|---|---|---|
| gemma-3-12b mode 2, CLI | (CLI was ok) | coherent, 107 tok/s |
| gemma-3-12b mode 2, **server** | IMA, every response truncated after 1 token | clean answers, 16/16 battery PASS |
| gemma-4-31B mode 2 | NaN logits from step 2 → `<pad>` | coherent, **55 tok/s vs 21.7 at mode 1 (+155%)**, 12/12 battery |

Fixed upstream by the intervening decode-path work (most plausibly the #539 in-place compaction race fix). The mode-1 cap is removed; dense Gemma follows the standard sub-8-bit mode-2 auto-pick (still gated behind `gemm.nvfp4_decode_all`). **Quality gate: gemma-3-12b PPL mode 2 = 5.3024 vs default 5.3512 — parity.**

## 3. Eval-instrument repairs (found building that quality gate)

The PPL harness was silently broken for Gemma:

- **IMA → PPL=1.0000**: `perplexity_nll_partial` routed raw-GGUF-quant LM heads (tied-embedding Gemma Q4_K) through `gemm_via_handle_` at M=1 → illegal memory access → poisoned context → zeroed NLL buffer → `mean_nll=0.0000`. Now mirrors the production `use_dp4a_lm` arm (fused RMSNorm→Q8_1 + dp4a GEMV); `dispatch_gemv_fp32` moved to `executor_gemv_helpers.h` and shared so eval and serving cannot drift.
- **Missing softcap**: `final_logit_softcap` (Gemma-2/3/4) is applied by production `forward_logits` but was never applied in the eval path.
- **Missing BOS**: `imp-cli --perplexity` never prepended BOS; Gemma is catastrophically BOS-dependent (gemma-3-12b: PPL ~100 → **5.35** with BOS). New additive C-API getter `imp_model_bos_token()`; the CLI prepends only when the tokenizer requests it (no-op where encode already emits BOS).

**No-regression proof**: Qwen3-14B 6.055 / Llama-3.2 7.191 / Qwen3-30B-MoE 6.614 — bit-identical to pre-change values. verify-fast: tests PASS, decode +1.7%, prefill +2.6%/+4.5%, graphs gate + smoke PASS.

Known remainder (separate issue, newly *visible* thanks to the working instrument, generation unaffected): gemma-4 family reads elevated teacher-forced PPL (31B ≈ 39.8, 26B-A4B ≈ 7450) while greedy/battery output is coherent — multi-position hidden-state or eval-side arch gap, filed separately.

Closes #552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
