### PR TITLE
fix(prefill): pinned-staging reuse race corrupted chunked continuations — kernel exonerated, long-ctx e4m3 reroute (#548)

### DIFF
--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -73,8 +73,15 @@ static bool try_fa2_fp16qk_prefill(const RuntimeConfig& rcfg, const Tensor& q, c
     // a conservative blanket decline until the kernel's q_offset handling is
     // root-caused (issue #548) — first chunks (q_offset == 0, the original #525 use case)
     // keep the fast path.
-    if (q_offset > 0)
-        return false;
+    // Chunk continuations (q_offset > 0) were declined here as a #553
+    // mitigation for catastrophic NLL on the Llama family. Root cause
+    // (#548) was NOT this kernel: the pinned prefill staging
+    // (h_pf_token_ids_/h_pf_positions_) was rewritten by the host while
+    // earlier chunks' H2D copies were still queued — the fully-async FA2
+    // path let the host run far enough ahead to hit it, the cuBLAS path's
+    // implicit syncs hid it. Fixed via pf_staging_evt_ in
+    // engine_scheduler.cpp; kernel-level q_offset parity is locked by
+    // FmhaFA2Test.FP16QK_Chunked_*.
     int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
     int64_t kv4s[4] = {1, (int64_t)kv_len, (int64_t)nkv, (int64_t)hd};
     Tensor q4 = q.reshape(4, q4s);
@@ -858,7 +865,20 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             const bool chunked_use_fmha = !per_layer_shapes &&  // Gemma-4 hd=512 stays cuBLAS
                                           (fmha_threshold > 0 && ctx_len >= fmha_threshold);
 
-            if (chunked_use_fmha) {
+            // Chunked attention routing (#548): prefer the FP16-QK FA2 kernel
+            // at EVERY ctx_len, not only below the threshold. It is O(n)
+            // memory (no S-matrix) like the fp8 family but carries no e4m3
+            // score noise — the long-context chunked path through the
+            // e4m3 FMHA family drifted teacher-forced NLL by up to ~25%
+            // (ChunkedPrefillTest.LongContext_Chunk_Invariance is the gate).
+            // The fp8 family stays as fallback for configs f16-QK declines
+            // (hd != 128, fa2_fp16qk=never), and cuBLAS below the threshold.
+            if (!per_layer_shapes &&
+                try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
+                                       nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
+                                       q_offset, stream)) {
+                // chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
+            } else if (chunked_use_fmha) {
                 // FMHA: no S-matrix needed, O(n) memory. Reshape to 4D for dispatch.
                 int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
                 int64_t kv4s[4] = {1, (int64_t)ctx_len, (int64_t)nkv, (int64_t)hd};
@@ -869,11 +889,6 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 Tensor o4 = ao.reshape(4, o4s);
                 attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
                                            cfg.attn_logit_softcap, stream, runtime_config(), q_offset);
-            } else if (!per_layer_shapes &&
-                       try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
-                                              nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
-                                              q_offset, stream)) {
-                // short chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
             } else {
                 // cuBLAS: needs S-matrix for [n × ctx_len]
                 attention_cublas_prefill(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv, hd, scale,

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -86,6 +86,10 @@ Engine::~Engine() {
         IMP_CUDA_CHECK_LOG(cudaFreeHost(h_pf_token_ids_));
         h_pf_token_ids_ = nullptr;
     }
+    if (pf_staging_evt_) {
+        IMP_CUDA_CHECK_LOG(cudaEventDestroy(pf_staging_evt_));
+        pf_staging_evt_ = nullptr;
+    }
     // MTP spec-decode workspace cleanup
     if (mtp_ws_storage_) {
         auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -332,6 +332,13 @@ private:
     int* d_pf_context_lens_ = nullptr;
     int* h_pf_positions_ = nullptr;      // pinned host staging
     int32_t* h_pf_token_ids_ = nullptr;  // pinned host staging
+    // Guards reuse of the pinned staging above: records after the H2D copies
+    // are enqueued; the next chunk host-waits on it before REWRITING the
+    // pinned source. Without this the host runs many fully-async chunks
+    // ahead (no implicit syncs on the FA2 path) and overwrites the staging
+    // while earlier copies are still queued -> chunk c uploads chunk c+N's
+    // tokens/positions (#548: catastrophic chunked-prefill NLL on Llama).
+    cudaEvent_t pf_staging_evt_ = nullptr;
 
     // ── Penalty token buffer ─────────────────────────────────────────
     int32_t* d_penalty_tokens_ = nullptr;

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -272,6 +272,8 @@ bool Engine::init_kv_cache() {
         if (cudaHostAlloc(&h_pf_token_ids_, config_.max_seq_len * sizeof(int32_t), cudaHostAllocDefault) !=
             cudaSuccess)
             h_pf_token_ids_ = nullptr;
+        if (cudaEventCreateWithFlags(&pf_staging_evt_, cudaEventDisableTiming) != cudaSuccess)
+            pf_staging_evt_ = nullptr;
     }
 
     // Report memory

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -465,7 +465,18 @@ bool Engine::prefill_upload_metadata_(std::shared_ptr<Request>& req,
         }
     }
 
-    // Use pinned staging buffers when available (avoids internal pageable->pinned copy)
+    // Use pinned staging buffers when available (avoids internal pageable->pinned copy).
+    // PINNED sources are truly asynchronous: the H2D reads the buffer when the
+    // copy EXECUTES (in stream order, behind all prior chunks' kernels), not
+    // when it is enqueued. Before rewriting the staging for this chunk, wait
+    // until the previous chunk's copies have actually run — otherwise a host
+    // that runs several fully-async chunks ahead (FA2 attention path, no
+    // implicit syncs) uploads chunk c+N's tokens/positions for chunk c
+    // (#548: catastrophic chunked-prefill NLL, timing/arch-dependent).
+    // Pageable sources below (block_table, ctx_len) are safe by CUDA
+    // semantics (captured before cudaMemcpyAsync returns).
+    if (pf_staging_evt_ && (h_pf_token_ids_ || h_pf_positions_) && chunk_len <= config_.max_seq_len)
+        IMP_CUDA_CHECK_LOG(cudaEventSynchronize(pf_staging_evt_));
     if (h_pf_token_ids_ && chunk_len <= config_.max_seq_len) {
         memcpy(h_pf_token_ids_, req->input_tokens.data() + offset, chunk_len * sizeof(int32_t));
         check(cudaMemcpyAsync(d_token_ids, h_pf_token_ids_, chunk_len * sizeof(int32_t),
@@ -491,6 +502,9 @@ bool Engine::prefill_upload_metadata_(std::shared_ptr<Request>& req,
                               pf_stream),
               "memcpy positions");
     }
+
+    if (pf_staging_evt_ && (h_pf_token_ids_ || h_pf_positions_) && chunk_len <= config_.max_seq_len)
+        IMP_CUDA_CHECK_LOG(cudaEventRecord(pf_staging_evt_, pf_stream));
 
     check(cudaMemcpyAsync(d_block_tables, block_table.data(), block_table.size() * sizeof(int),
                           cudaMemcpyHostToDevice, pf_stream),

--- a/tests/test_chunked_prefill.cu
+++ b/tests/test_chunked_prefill.cu
@@ -300,23 +300,20 @@ TEST_F(ChunkedPrefillTest, Llama_3_2_3B_Chunk_64_LogitsEqual) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 3b (DISABLED — issue #548): LONG-context chunk invariance.
+// Test 3b (#548 gate — ENABLED): LONG-context chunk invariance.
 //
-// Once a chunk's ctx_len crosses fmha_prefill_threshold (~2.5-2.9k), the
-// chunked path routes through the fp8/e4m3 FMHA family
-// (attention_prefill_dispatch) whose accumulated e4m3 score noise drifts the
-// teacher-forced NLL by up to ~25% vs the reference (measured 2026-06-06,
-// 120-item long_prompt ~3.1k tokens, Llama-3.2-3B, post fa2_fp16qk
-// continuation-decline):
-//   chunk=0(→s_cap-clamped ~1984+rest) nll 0.80
-//   chunk=64  nll 0.61   chunk=512 nll 0.97
-// (Before the fa2_fp16qk continuation-decline this read nll 8.08 —
-// catastrophic — at chunk=64; that part is fixed.) Same quality class as
-// issue #511 (fp8-FMHA above threshold unvalidated); tracked in #548.
-// Enable when the long-context chunk path is numerically reconciled.
+// History: chunked continuations above fmha_prefill_threshold used to route
+// through the fp8/e4m3 FMHA family, drifting teacher-forced NLL up to ~25%;
+// below the threshold the f16-QK fast path produced CATASTROPHIC NLL on the
+// Llama family (0.29 -> 7.13). Root cause of the latter was never the
+// kernel: the pinned prefill staging (h_pf_token_ids_/h_pf_positions_) was
+// rewritten by the host while earlier chunks' H2D copies were still queued
+// (#548, fixed via pf_staging_evt_). With the race fixed, chunked
+// continuations now route through the FP16-QK FA2 kernel at every ctx_len
+// (no e4m3 score noise, no S-matrix), and this gate holds.
 // ---------------------------------------------------------------------------
 
-TEST_F(ChunkedPrefillTest, DISABLED_LongContext_Chunk_Invariance) {
+TEST_F(ChunkedPrefillTest, LongContext_Chunk_Invariance) {
     const char* path = llama_3b_path();
     if (!model_exists(path))
         GTEST_SKIP() << "model not present: " << path;

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -21,7 +21,8 @@ protected:
     // CPU reference attention (same as FP16 test)
     static void ref_attention(const std::vector<float>& Q_f, const std::vector<float>& K_f,
                               const std::vector<float>& V_f, std::vector<float>& O_f, int B, int Sq, int Skv,
-                              int NH, int NKV, int HD, float scale, bool causal, int sw, float softcap) {
+                              int NH, int NKV, int HD, float scale, bool causal, int sw, float softcap,
+                              int q_offset = 0) {
         int gqa = NH / NKV;
         for (int b = 0; b < B; b++) {
             for (int h = 0; h < NH; h++) {
@@ -39,9 +40,9 @@ protected:
                         dot *= scale;
                         if (softcap > 0)
                             dot = softcap * std::tanh(dot / softcap);
-                        if (causal && sk > sq)
+                        if (causal && sk > (q_offset + sq))
                             dot = -1e30f;
-                        if (sw > 0 && (sq - sk) >= sw)
+                        if (sw > 0 && ((q_offset + sq) - sk) >= sw)
                             dot = -1e30f;
                         scores[sk] = dot;
                         max_s = std::max(max_s, dot);
@@ -194,7 +195,7 @@ TEST_F(FmhaFP8Test, Qwen35LikeHD256_GQA41_SeqMultiTile) { run_test(1, 128, 128, 
 class FmhaFA2Test : public FmhaFP8Test {
 protected:
     void run_fa2(int B, int Sq, int Skv, int NH, int NKV, int HD, bool causal, int sw = 0,
-                 float softcap = 0.0f, float amplitude = 1.0f, bool fp16_qk = false) {
+                 float softcap = 0.0f, float amplitude = 1.0f, bool fp16_qk = false, int q_offset = 0) {
         float scale = 1.0f / std::sqrt(static_cast<float>(HD));
         size_t q_elems = B * Sq * NH * HD;
         size_t kv_elems = B * Skv * NKV * HD;
@@ -209,7 +210,7 @@ protected:
         }
 
         std::vector<float> O_ref(q_elems, 0.0f);
-        ref_attention(Q_f, K_f, V_f, O_ref, B, Sq, Skv, NH, NKV, HD, scale, causal, sw, softcap);
+        ref_attention(Q_f, K_f, V_f, O_ref, B, Sq, Skv, NH, NKV, HD, scale, causal, sw, softcap, q_offset);
 
         std::vector<half> Q_h(q_elems), K_h(kv_elems), V_h(kv_elems);
         for (size_t i = 0; i < q_elems; i++)
@@ -239,7 +240,7 @@ protected:
         Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
         bool ok = fmha_sm120_fa2_prefill(Qt, Kt, Vt, Ot, scale, causal, sw, softcap, stream_,
-                                         /*q_offset=*/0, fp16_qk);
+                                         q_offset, fp16_qk);
         ASSERT_TRUE(ok) << "fmha_sm120_fa2_prefill returned false (config must be supported)";
         cudaStreamSynchronize(stream_);
         cudaError_t err = cudaGetLastError();
@@ -339,6 +340,37 @@ TEST_F(FmhaFA2Test, FP16QK_MultiTile) { run_fa2(1, 128, 128, 4, 4, 128, true, 0,
 TEST_F(FmhaFA2Test, FP16QK_LongCtx) { run_fa2(1, 256, 256, 8, 2, 128, true, 0, 0.0f, 1.0f, true); }
 TEST_F(FmhaFA2Test, FP16QK_SlidingWindow) { run_fa2(1, 128, 128, 4, 4, 128, true, 64, 0.0f, 1.0f, true); }
 TEST_F(FmhaFA2Test, FP16QK_Softcap) { run_fa2(1, 64, 64, 4, 4, 128, true, 0, 50.0f, 1.0f, true); }
+
+// --- Chunk continuation (q_offset > 0) — issue #548 ---
+// PR #553 measured wrong attention on Llama-3.2-3B chunk continuations
+// (teacher-forced NLL 0.29 → 7.13 at chunk=64) while Qwen3-4B was bit-exact
+// through the same kernel, and declined the fast path as a mitigation. These
+// cases reproduce the failing production shapes at the kernel level:
+// Llama-3.2-3B is GQA 24Q/8KV (ratio 3) vs Qwen3's 32/8 (ratio 4), prompts
+// end on arbitrary (non-tile-multiple) KV lengths, and offsets are not
+// Bq/Bkv multiples. seq_kv = q_offset + Sq exactly as the chunked gather
+// produces it.
+TEST_F(FmhaFA2Test, FP16QK_Chunked_GQA4) {
+    run_fa2(1, 64, 512, 32, 8, 128, true, 0, 0.0f, 1.0f, true, /*q_offset=*/448);
+}
+TEST_F(FmhaFA2Test, FP16QK_Chunked_GQA3_LlamaShape) {
+    run_fa2(1, 64, 512, 24, 8, 128, true, 0, 0.0f, 1.0f, true, /*q_offset=*/448);
+}
+TEST_F(FmhaFA2Test, FP16QK_Chunked_GQA3_OddKv) {
+    // partial last KV tile (seq_kv % 64 != 0) + odd chunk length
+    run_fa2(1, 51, 371, 24, 8, 128, true, 0, 0.0f, 1.0f, true, /*q_offset=*/320);
+}
+TEST_F(FmhaFA2Test, FP16QK_Chunked_OffsetNotTileMultiple) {
+    run_fa2(1, 64, 292, 24, 8, 128, true, 0, 0.0f, 1.0f, true, /*q_offset=*/228);
+}
+TEST_F(FmhaFA2Test, FP16QK_Chunked_LongCtx) {
+    // continuation chunk far past the threshold-class context (3k)
+    run_fa2(1, 128, 3200, 24, 8, 128, true, 0, 0.0f, 1.0f, true, /*q_offset=*/3072);
+}
+TEST_F(FmhaFA2Test, FP8_Chunked_GQA3) {
+    // e4m3 path with the same continuation geometry (looser 5% tol)
+    run_fa2(1, 64, 512, 24, 8, 128, true, 0, 0.0f, 1.0f, false, /*q_offset=*/448);
+}
 
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
Closes both halves of #548 by root-causing the "catastrophic fa2_fp16qk continuation bug" — which was never a kernel bug at all.

## Root cause: pinned-staging reuse race (host-ahead)

`prefill_upload_metadata_` rewrites the **pinned** staging buffers (`h_pf_token_ids_` / `h_pf_positions_`) per chunk and enqueues async H2D copies from them. Pinned-source copies read the buffer **when they execute** (in stream order, behind all prior chunks' kernels) — not at enqueue. On the fully-async FA2 attention path the host runs many chunks ahead and rewrites the staging while earlier copies are still queued → **chunk c uploads chunk c+N's tokens and RoPE positions**. The cuBLAS path's implicit syncs kept the host ~1 chunk ahead and hid the race.

That explains every confusing #553 observation at once: "wrong attention on Llama continuations" (corrupted positions/tokens), "Qwen bit-exact" (timing luck), "cuBLAS routing fixes it" (implicit syncs), "exact discriminator unknown" (there was none — it's a race).

## Proof chain

1. **Kernel exonerated**: 6 new `FmhaFA2Test.FP16QK_Chunked_*`/`FP8_Chunked_*` parity cases against the fp64-style CPU oracle — GQA ratio 3 (Llama-3.2 24Q/8KV) and 4, odd KV lengths, non-tile-multiple offsets, 3.2k ctx. All pass on the *unfixed* kernel.
2. **Engine repro**: with the #553 decline lifted, `Llama_3_2_3B_Chunk_64_LogitsEqual` reads NLL **7.13 vs 0.29** — catastrophic, current.
3. **Race signature**: a host `cudaStreamSynchronize` alone (no recomputation) makes the same run read NLL 0.2875 == single-shot.

## Fix + reroute

- `pf_staging_evt_` records after the pinned-sourced H2D copies; the next chunk host-waits on it before rewriting the staging (waits only for the *copies*, the kernel pipeline stays async). Pageable sources (`block_table`, `ctx_len`) were always safe (captured at call time).
- The #553 `q_offset > 0` decline is removed; **chunked continuations route through FP16-QK FA2 at every ctx_len** (O(n) memory, no e4m3 score noise), fp8 family as fallback. This closes the second #548 half — the long-context e4m3 NLL drift (~25%).
- `ChunkedPrefillTest.LongContext_Chunk_Invariance` is **enabled** and green.

## Validation

| Gate | Result |
|---|---|
| ChunkedPrefillTest (incl. enabled long-ctx invariance + previously catastrophic Llama chunk=64) | 6/6 PASS, NLL bit-equal to single-shot |
| FmhaFA2Test + FmhaSm120Test | 53/53 PASS |
| verify-chunked decode gates (Llama-3.2-3B / Qwen3-4B / Qwen3-8B, chunk=512) | all PASS |
| graphs gate + smoke | PASS |
| verify-fast decode | read −5.5%, **but a main-build A/B under identical conditions read −8.1%** → depressed host state (foreign `tb-dev` container holds the GPU at ~10% background util, idle mem-clock samples at 405 MHz), not a code regression — the documented #526 host-state class |

Closes #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
