### PR TITLE
fix(attention): SWA prefill routed through broken WMMA chain — Gemma long-context generation + eval were wrong (#566)

### DIFF
--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -536,6 +536,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         debug_tensor_stats("L0_step1_after_qkv_k", kk, stream);
     }
 
+
     // Per-layer RoPE theta and sliding window (Gemma-3: alternating local/global layers)
     float layer_rope_theta = cfg.rope_theta;
     float layer_rope_freq_scale = cfg.rope_freq_scale;
@@ -737,8 +738,6 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     float scale = (cfg.arch == ModelArch::GEMMA4) ? 1.0f : (1.0f / std::sqrt(static_cast<float>(hd)));
 
     if (state.is_prefill) {
-        bool sliding_active = (layer_sliding_window > 0 && n > layer_sliding_window);
-
         // Chunked prefill: when prefill_offset > 0, queries from this chunk must
         // attend to past chunks K/V already in the paged cache. Gather past
         // [0, prefill_offset) KV → contiguous, append current chunk, then run
@@ -908,13 +907,21 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         const bool force_cublas_attn = per_layer_shapes;  // Gemma 4 dual head_dim
         const bool s_matrix_fits = attn_scores_buf_ != nullptr &&
                                    n <= static_cast<int>(attn_scores_.shape[1]);
-        const bool non_gemma4_sliding = !force_cublas_attn && sliding_active;
         // FMHA only above the S-matrix threshold — see the chunked path above
         // for why the #493 prefer-FA2-at-every-length override was reverted.
         const bool prefer_fmha = !force_cublas_attn &&
                                  (n >= runtime_config().attention.fmha_prefill_threshold);
 
-        if (s_matrix_fits && !non_gemma4_sliding && !prefer_fmha) {
+        // NOTE (#566): sliding-window prefill used to be routed AWAY from the
+        // cuBLAS path here (`non_gemma4_sliding`) into the WMMA fallback
+        // chain — a relic from before attention_cublas_prefill grew its
+        // sliding_window softmax mask. The WMMA chain's hd=256 + window
+        // combination computes catastrophically wrong attention (gemma-3-12b
+        // at n>1024: teacher-forced PPL 42 vs llama.cpp 1.0; long-prompt
+        // recall answered '77' instead of '477'). The cuBLAS masked softmax
+        // is the correctness reference and handles the window — keep SWA
+        // prefill here whenever the S-matrix fits.
+        if (s_matrix_fits && !prefer_fmha) {
             // Below the FMHA threshold: prefer the FP16-QK FA2 kernel over the
             // materialized cuBLAS path (same f16/f32 numerics, O(n) memory).
             if (!force_cublas_attn &&

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -291,6 +291,14 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
     cudaFree(ppl_capture_.d_nll);
     ppl_capture_ = PplCapture{};
 
+    if (getenv("IMP_PPL_DUMP") != nullptr) {
+        fprintf(stderr, "[PPL-DUMP] per-pos nll:");
+        for (int i = 0; i < n - 1; ++i) {
+            if (i < 16 || i % 16 == 0 || i > n - 6)
+                fprintf(stderr, " [%d]=%.3f", i, h_nll_pos[i]);
+        }
+        fprintf(stderr, "\n");
+    }
     double h_nll = 0.0;
     for (int i = 0; i < n - 1; ++i)
         h_nll += h_nll_pos[i];


### PR DESCRIPTION
Root-causes the actionable half of #566: **imp's sliding-window prefill was routed into the WMMA fallback chain, which computes catastrophically wrong attention** — a real production bug affecting Gemma generation at long prompts, not just the eval.

## Forensics chain

1. With the eval instrument fixed (#565), gemma-3-12b (healthy short-context, PPL 5.35) read **PPL 42-44 at >1024 tokens** where llama.cpp reads **1.0012** on the identical file (c=2048 control, repeated corpus).
2. Same positions (256-960), same prefix: mean NLL **0.000** at total length 971 vs **~4.9** at total length 1553 → a length-triggered routing change, not clipped-position behavior. The trigger: `sliding_active = n > window` (gemma window = 1024).
3. Forcing window masks off: PPL 43.6 → 1.73 → the route, not the model.
4. **Production impact**: a 1290-word recall prompt — imp answered `77`, llama.cpp `477` (correct).

## Root cause & fix

`non_gemma4_sliding` routed SWA prefill away from the cuBLAS S-matrix path into the WMMA fallback chain — a relic from before `attention_cublas_prefill` grew its sliding-window softmax mask. The WMMA chain's hd=256+window combination is broken (its no-window flavor is also degraded: PPL 10.5). The cuBLAS masked softmax (whose mask lambdas are shared with the proven chunked rectangular path) is the correctness reference — SWA prefill now stays there whenever the S-matrix fits.

## After

| Probe | Before | After |
|---|---|---|
| gemma-3-12b PPL @1553 tok | 43.59 | **1.2491** (beats the 1.73 full-attention control — true SWA distribution) |
| Long-prompt recall | `77` | **`477`** (chunked and default paths) |
| ChunkedPrefillTest | — | 6/6 PASS |
| FmhaFA2Test + FmhaSm120Test | — | 53/53 PASS |
| verify-fast | — | all gates PASS (decode −1.85%) |

Also ships the env-gated `IMP_PPL_DUMP` per-position NLL diagnostic that localized this.

## What remains in #566 (issue updated)

- The **gemma-4-26B-A4B "PPL 7450"** turned out to be substantially **model-intrinsic**: llama.cpp reads PPL 23-31 on the same file at BOTH Q4_K_M and Q8_0 on near-trivially-repetitive text where 12b reads 1.01 — the instruct-tuned MoE teacher-forces terribly on raw text. imp's gemma-4 readings are in that family ballpark (31B: 39.8).
- Remnant: single-shot **unchunked** prefill beyond the S-matrix cap (~2k) with an active window still reaches the WMMA chain (only reachable via CLI `--perplexity`'s forced chunk=0; server/C-API default to chunked prefill → correct rectangular cuBLAS).

Refs #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
