### PR TITLE
feat(gpt-oss): gpt-oss-20b support — MXFP4 experts, sinks, Harmony, YaRN/splitk/FP16-range fixes (#547)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ set(IMP_EXEC_SOURCES
     src/exec/executor_perplexity.cu
     src/exec/executor_lora.cu
     src/lora/lora_adapter.cpp
+    src/quant/gpt_oss_mxfp4_convert.cu
     src/exec/executor_ffn.cu
     src/exec/executor_ssm_gdn.cu
     src/exec/executor_forward_moe.cu

--- a/include/imp/types.h
+++ b/include/imp/types.h
@@ -37,6 +37,7 @@ typedef enum {
     IMP_ARCH_QWEN35_MOE = 11,
     IMP_ARCH_GEMMA4 = 12,
     IMP_ARCH_QWEN36_MOE = 13,
+    IMP_ARCH_GPT_OSS = 14,
 } ImpModelArch;
 
 typedef enum {

--- a/src/compute/activation.cu
+++ b/src/compute/activation.cu
@@ -138,6 +138,54 @@ __global__ void geglu_fp32_vec4_kernel(const float* __restrict__ gate, const flo
 }
 
 // --------------------------------------------------------------------------
+// gpt-oss clamped GLU kernels (issue #547):
+//   gate_c = min(gate, 7);  up_c = clamp(up, -7, 7)
+//   out = (up_c + 1) * gate_c * sigmoid(1.702 * gate_c)
+// --------------------------------------------------------------------------
+__device__ __forceinline__ float gpt_oss_glu_elem(float g, float u) {
+    constexpr float kLimit = 7.0f;
+    constexpr float kAlpha = 1.702f;
+    g = fminf(g, kLimit);
+    u = fminf(fmaxf(u, -kLimit), kLimit);
+    float glu = g / (1.0f + __expf(-kAlpha * g));
+    return (u + 1.0f) * glu;
+}
+
+__global__ void gpt_oss_glu_fp16_kernel(const __half* __restrict__ gate, const __half* __restrict__ up,
+                                        __half* __restrict__ out, int64_t n) {
+    const int64_t idx = (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) * 2;
+    if (idx + 1 < n) {
+        float2 gf = __half22float2(*reinterpret_cast<const __half2*>(gate + idx));
+        float2 uf = __half22float2(*reinterpret_cast<const __half2*>(up + idx));
+        *reinterpret_cast<__half2*>(out + idx) = __float22half2_rn(
+            make_float2(gpt_oss_glu_elem(gf.x, uf.x), gpt_oss_glu_elem(gf.y, uf.y)));
+    } else if (idx < n) {
+        out[idx] = __float2half(gpt_oss_glu_elem(__half2float(gate[idx]), __half2float(up[idx])));
+    }
+}
+
+__global__ void gpt_oss_glu_fp32_kernel(const float* __restrict__ gate, const float* __restrict__ up,
+                                        float* __restrict__ out, int64_t n) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx < n)
+        out[idx] = gpt_oss_glu_elem(gate[idx], up[idx]);
+}
+
+__global__ void gpt_oss_glu_fp32_vec4_kernel(const float* __restrict__ gate, const float* __restrict__ up,
+                                             float* __restrict__ out, int64_t n) {
+    const int64_t idx = (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) * 4;
+    if (idx + 3 < n) {
+        float4 g4 = reinterpret_cast<const float4*>(gate)[idx / 4];
+        float4 u4 = reinterpret_cast<const float4*>(up)[idx / 4];
+        float4 o4;
+#pragma unroll
+        for (int i = 0; i < 4; i++)
+            (&o4.x)[i] = gpt_oss_glu_elem((&g4.x)[i], (&u4.x)[i]);
+        reinterpret_cast<float4*>(out)[idx / 4] = o4;
+    }
+}
+
+// --------------------------------------------------------------------------
 // GELU FP32 vectorized kernel
 // gelu(x) = x * 0.5 * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
 // --------------------------------------------------------------------------
@@ -272,6 +320,17 @@ void geglu(const Tensor& gate, const Tensor& up, Tensor& out, cudaStream_t strea
         return;
     dispatch_gated_activation(gate, up, out, n, geglu_fp32_vec4_kernel, geglu_fp32_kernel, geglu_fp16_kernel,
                               true, stream);
+}
+
+// --------------------------------------------------------------------------
+// Host dispatch: gpt_oss_glu
+// --------------------------------------------------------------------------
+void gpt_oss_glu(const Tensor& gate, const Tensor& up, Tensor& out, cudaStream_t stream) {
+    const int64_t n = gate.numel();
+    if (n == 0)
+        return;
+    dispatch_gated_activation(gate, up, out, n, gpt_oss_glu_fp32_vec4_kernel, gpt_oss_glu_fp32_kernel,
+                              gpt_oss_glu_fp16_kernel, true, stream);
 }
 
 // --------------------------------------------------------------------------

--- a/src/compute/activation.h
+++ b/src/compute/activation.h
@@ -11,6 +11,11 @@ void swiglu(const Tensor& gate, const Tensor& up, Tensor& out, cudaStream_t stre
 // Fused GeGLU: out = gelu_tanh(gate) * up  (Gemma-3)
 void geglu(const Tensor& gate, const Tensor& up, Tensor& out, cudaStream_t stream = nullptr);
 
+// gpt-oss clamped GLU (issue #547), HF GptOssExperts semantics:
+//   gate_c = min(gate, 7);  up_c = clamp(up, -7, 7)
+//   out = (up_c + 1) * gate_c * sigmoid(1.702 * gate_c)
+void gpt_oss_glu(const Tensor& gate, const Tensor& up, Tensor& out, cudaStream_t stream = nullptr);
+
 void gelu(const Tensor& x, Tensor& out, cudaStream_t stream = nullptr);
 
 // Qwen3-Next / Qwen3.6 shared-expert sigmoid gate:

--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -99,7 +99,8 @@ void attention_cublas_prewarm() {
 __global__ void causal_softmax_fp32_to_fp16_kernel(const float* __restrict__ S_in,
                                                     half* __restrict__ S_out, int q_len,
                                                     int kv_len, int q_offset, bool causal,
-                                                    int sliding_window) {
+                                                    int sliding_window,
+                                                    const half* __restrict__ sinks) {
     int row = blockIdx.x, head = blockIdx.y, tid = threadIdx.x;
     int warp_id = tid / 32, lane_id = tid % 32;
     int n_warps = (blockDim.x + 31) / 32;
@@ -133,6 +134,12 @@ __global__ void causal_softmax_fp32_to_fp16_kernel(const float* __restrict__ S_i
     __syncthreads();
     max_val = s_max[0];
 
+    // gpt-oss sink (#547): virtual extra column — joins max + denominator,
+    // dropped from the output (probabilities sum to < 1).
+    float sink_val = sinks ? __half2float(sinks[head]) : -FLT_MAX;
+    if (sinks)
+        max_val = fmaxf(max_val, sink_val);
+
     float sum_val = 0.0f;
     for (int j = tid; j < kv_len; j += blockDim.x)
         sum_val += masked(j) ? 0.0f : expf(row_in[j] - max_val);
@@ -150,7 +157,8 @@ __global__ void causal_softmax_fp32_to_fp16_kernel(const float* __restrict__ S_i
         s_sum[0] = v;
     }
     __syncthreads();
-    float inv_sum = (s_sum[0] > 0.0f) ? (1.0f / s_sum[0]) : 0.0f;
+    float denom = s_sum[0] + (sinks ? expf(sink_val - max_val) : 0.0f);
+    float inv_sum = (denom > 0.0f) ? (1.0f / denom) : 0.0f;
 
     for (int j = tid; j < kv_len; j += blockDim.x) {
         float v = masked(j) ? 0.0f : expf(row_in[j] - max_val) * inv_sum;
@@ -229,7 +237,8 @@ __global__ void causal_softmax_fp32_inplace_kernel(float* __restrict__ S, int q_
 // Warp-level reductions for max and sum using __shfl_xor_sync.
 // ---------------------------------------------------------------------------
 __global__ void causal_softmax_inplace_kernel(half* __restrict__ S, int q_len, int kv_len,
-                                               int q_offset, bool causal, int sliding_window) {
+                                               int q_offset, bool causal, int sliding_window,
+                                               const half* __restrict__ sinks) {
     // Each block processes one row: blockIdx.x = row, blockIdx.y = head
     int row = blockIdx.x;
     int head = blockIdx.y;
@@ -279,6 +288,12 @@ __global__ void causal_softmax_inplace_kernel(half* __restrict__ S, int q_len, i
     __syncthreads();
     max_val = s_max[0];
 
+    // gpt-oss sink (#547): virtual extra column — joins max + denominator,
+    // dropped from the output (probabilities sum to < 1).
+    float sink_val = sinks ? __half2float(sinks[head]) : -FLT_MAX;
+    if (sinks)
+        max_val = fmaxf(max_val, sink_val);
+
     // Step 2: Compute exp and sum
     float sum_val = 0.0f;
     for (int j = tid; j < kv_len; j += blockDim.x) {
@@ -309,7 +324,8 @@ __global__ void causal_softmax_inplace_kernel(half* __restrict__ S, int q_len, i
         s_sum[0] = v;
     }
     __syncthreads();
-    float inv_sum = (s_sum[0] > 0.0f) ? (1.0f / s_sum[0]) : 0.0f;
+    float denom = s_sum[0] + (sinks ? expf(sink_val - max_val) : 0.0f);
+    float inv_sum = (denom > 0.0f) ? (1.0f / denom) : 0.0f;
 
     // Step 3: Normalize and write back
     for (int j = tid; j < kv_len; j += blockDim.x) {
@@ -403,7 +419,9 @@ static inline void launch_build_attn_ptrs(void** d_ptrs, int n_heads, const void
 // ---------------------------------------------------------------------------
 void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, Tensor& S,
                               int n_heads, int n_kv_heads, int head_dim, float scale, bool causal,
-                              float softcap, int q_offset, cudaStream_t stream, int sliding_window) {
+                              float softcap, int q_offset, cudaStream_t stream, int sliding_window,
+                              const void* sinks) {
+    const half* sinks_h = static_cast<const half*>(sinks);
     int q_len = static_cast<int>(Q.shape[0]);
     int kv_len = static_cast<int>(K.shape[0]);
     if (q_len == 0)
@@ -481,10 +499,10 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                 // probabilities to S_base directly. Replaces softmax_fp32_inplace
                 // + fp32_to_fp16_kernel pair (saves one full pass over the tensor).
                 causal_softmax_fp32_to_fp16_kernel<<<grid, threads, 0, stream>>>(
-                    S_f32, S_base, q_len, kv_len, q_offset, causal, sliding_window);
+                    S_f32, S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
             } else {
                 causal_softmax_inplace_kernel<<<grid, threads, 0, stream>>>(
-                    S_base, q_len, kv_len, q_offset, causal, sliding_window);
+                    S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
             }
         }
 
@@ -533,10 +551,10 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
             if (use_fp32_s) {
                 // Fused FP32 softmax + downcast (see MHA path above).
                 causal_softmax_fp32_to_fp16_kernel<<<grid, threads, 0, stream>>>(
-                    S_f32, S_base, q_len, kv_len, q_offset, causal, sliding_window);
+                    S_f32, S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
             } else {
                 causal_softmax_inplace_kernel<<<grid, threads, 0, stream>>>(
-                    S_base, q_len, kv_len, q_offset, causal, sliding_window);
+                    S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
             }
         }
 

--- a/src/compute/attention_cublas.h
+++ b/src/compute/attention_cublas.h
@@ -19,10 +19,14 @@ namespace imp {
 //
 // sliding_window > 0 additionally masks K[j] where (abs_pos - j) >= sliding_window,
 // i.e. the visible K window is [abs_pos - sliding_window + 1, abs_pos]. Defaults to 0 (off).
+//
+// sinks (gpt-oss, #547): per-head learned sink logits [n_heads] FP16. Each acts
+// as a virtual extra softmax column: the denominator gains exp(sink - max) and
+// the column is dropped after softmax (probabilities sum to < 1). nullptr = off.
 void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, Tensor& S,
                               int n_heads, int n_kv_heads, int head_dim, float scale, bool causal,
                               float softcap = 0.0f, int q_offset = 0, cudaStream_t stream = nullptr,
-                              int sliding_window = 0);
+                              int sliding_window = 0, const void* sinks = nullptr);
 
 // Force-create the static cuBLAS handle. Safe to call multiple times.
 // Engine init calls this so the first attention_cublas_prefill invocation

--- a/src/compute/attention_paged.cu
+++ b/src/compute/attention_paged.cu
@@ -930,8 +930,12 @@ __global__ void paged_attention_splitk_pipeline_kernel(
                     cp_async_ca_16(&k_buf0[lane_offset + chunk], &K_tok[lane_offset + chunk]);
                 }
             }
-            if constexpr (ELEMS < 8) {
+            if constexpr (ELEMS == 4) {
                 cp_async_ca_8(&k_buf0[lane_offset], &K_tok[lane_offset]);
+            } else if constexpr (ELEMS < 8) {
+                // ELEMS==2 (head_dim=64): per-lane offset is only 4-byte
+                // aligned — 8-byte cp.async faults (cudaErrorMisalignedAddress).
+                cp_async_ca_4(&k_buf0[lane_offset], &K_tok[lane_offset]);
             }
             cp_async_commit();
         }
@@ -955,9 +959,12 @@ __global__ void paged_attention_splitk_pipeline_kernel(
                     cp_async_ca_16(&k_bufs[1 - cur][lane_offset + chunk], &K_next[lane_offset + chunk]);
                 }
             }
-            if constexpr (ELEMS < 8) {
+            if constexpr (ELEMS == 4) {
                 cp_async_ca_8(&v_buf[lane_offset], &V_tok[lane_offset]);
                 cp_async_ca_8(&k_bufs[1 - cur][lane_offset], &K_next[lane_offset]);
+            } else if constexpr (ELEMS < 8) {
+                cp_async_ca_4(&v_buf[lane_offset], &V_tok[lane_offset]);
+                cp_async_ca_4(&k_bufs[1 - cur][lane_offset], &K_next[lane_offset]);
             }
             cp_async_commit();
 

--- a/src/compute/attention_paged.cu
+++ b/src/compute/attention_paged.cu
@@ -93,7 +93,7 @@ __global__ void __launch_bounds__(1024) paged_attention_gqa_kernel(
     half* __restrict__ O, const int* __restrict__ block_tables, const int* __restrict__ context_lens,
     int batch_size, int n_heads, int n_kv_heads, int head_dim, int block_size, float scale,
     int max_context_len, int max_num_blocks, int n_q_per_kv, int warps_per_q, int sliding_window, int n_sinks,
-    float softcap) {
+    float softcap, const half* __restrict__ attn_sinks) {
     const int batch_idx = blockIdx.x;
     const int kv_head = blockIdx.y;
 
@@ -261,11 +261,17 @@ __global__ void __launch_bounds__(1024) paged_attention_gqa_kernel(
         for (int w = 0; w < warps_per_q; w++) {
             global_max = fmaxf(global_max, red_max[base_w + w]);
         }
+        // gpt-oss learned sink (#547): virtual extra softmax column — joins
+        // max + denominator, dropped from the numerator.
+        if (attn_sinks)
+            global_max = fmaxf(global_max, __half2float(attn_sinks[head_idx]));
 
         float global_l = 0.0f;
         for (int w = 0; w < warps_per_q; w++) {
             global_l += expf(red_max[base_w + w] - global_max) * red_l[base_w + w];
         }
+        if (attn_sinks)
+            global_l += expf(__half2float(attn_sinks[head_idx]) - global_max);
 
         for (int i = 0; i < elems_per_thread; i++) {
             int d = lane_id + i * WARP_SIZE;
@@ -1012,7 +1018,7 @@ __global__ void paged_attention_splitk_pipeline_kernel(
 __global__ void paged_attention_reduce_kernel(
     const float* __restrict__ partial_out,  // [batch, n_heads, num_splits, (2+head_dim)]
     half* __restrict__ O,                   // [batch, 1, n_heads, head_dim]
-    int n_heads, int head_dim, int num_splits) {
+    int n_heads, int head_dim, int num_splits, const half* __restrict__ attn_sinks) {
     const int batch_idx = blockIdx.x;
     const int head_idx = blockIdx.y;
     const int tid = threadIdx.x;
@@ -1031,6 +1037,10 @@ __global__ void paged_attention_reduce_kernel(
             float m = base[s * partial_stride];
             gmax = fmaxf(gmax, m);
         }
+        // gpt-oss learned sink (#547): virtual extra softmax column — joins
+        // the global max and the denominator, dropped from the numerator.
+        if (attn_sinks)
+            gmax = fmaxf(gmax, __half2float(attn_sinks[head_idx]));
         s_global_max = gmax;
 
         // Step 2: Compute global denominator
@@ -1040,6 +1050,8 @@ __global__ void paged_attention_reduce_kernel(
             float l = base[s * partial_stride + 1];
             gl += expf(m - gmax) * l;
         }
+        if (attn_sinks)
+            gl += expf(__half2float(attn_sinks[head_idx]) - gmax);
         s_global_l = gl;
     }
     __syncthreads();
@@ -1088,7 +1100,8 @@ void paged_attention_launch_reduce(float* partial, half* O, int batch_size, int 
                                    int num_splits, cudaStream_t stream) {
     dim3 grid(batch_size, n_heads);
     dim3 block(128);
-    paged_attention_reduce_kernel<<<grid, block, 0, stream>>>(partial, O, n_heads, head_dim, num_splits);
+    paged_attention_reduce_kernel<<<grid, block, 0, stream>>>(partial, O, n_heads, head_dim, num_splits,
+                                                              /*attn_sinks=*/nullptr);
 }
 
 // ---------------------------------------------------------------------------
@@ -1115,7 +1128,8 @@ __global__ void paged_attention_cluster_kernel(const half* __restrict__ Q, const
                                                const int* __restrict__ context_lens, int batch_size,
                                                int n_heads, int n_kv_heads, int block_size, float scale,
                                                int max_context_len, int max_num_blocks, int n_q_per_kv,
-                                               int sliding_window, int n_sinks, float softcap) {
+                                               int sliding_window, int n_sinks, float softcap,
+                                               const half* __restrict__ attn_sinks) {
     namespace cg = cooperative_groups;
     auto cluster = cg::this_cluster();
     const int q_local = cluster.block_rank();       // which Q-head in this KV group [0, n_q_per_kv)
@@ -1280,7 +1294,7 @@ __global__ void paged_attention_cluster_kernel(const half* __restrict__ Q, const
 
     // ---- Cross-warp reduction within this block ----
     crosswarp_reduce_and_write<HEAD_DIM>(warp_max, m_w, l_w, o_reg, warp_id, lane_id, lane_offset, O,
-                                         batch_idx, n_heads, head_idx);
+                                         batch_idx, n_heads, head_idx, attn_sinks);
 }
 
 // ---------------------------------------------------------------------------
@@ -1289,7 +1303,8 @@ __global__ void paged_attention_cluster_kernel(const half* __restrict__ Q, const
 void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor& V_cache, Tensor& O,
                             const int* block_tables, const int* context_lens, int block_size, float scale,
                             int max_context_len, int sliding_window, float softcap, cudaStream_t stream,
-                            int max_blocks_per_seq, int n_sinks) {
+                            int max_blocks_per_seq, int n_sinks, const void* attn_sinks) {
+    const half* sinks_h = static_cast<const half*>(attn_sinks);
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int n_heads = static_cast<int>(Q.shape[2]);
     const int head_dim = static_cast<int>(Q.shape[3]);
@@ -1437,7 +1452,7 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
         dim3 block2(128);
 
         paged_attention_reduce_kernel<<<grid2, block2, 0, stream>>>(partial, reinterpret_cast<half*>(O.data),
-                                                                    n_heads, head_dim, num_splits);
+                                                                    n_heads, head_dim, num_splits, sinks_h);
     } else if (n_q_per_kv > 1) {
         // GQA path: try cluster kernel first, then fall back to cooperative GQA
         bool used_cluster = false;
@@ -1471,7 +1486,8 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
                        reinterpret_cast<const half*>(K_cache.data),                                        \
                        reinterpret_cast<const half*>(V_cache.data), reinterpret_cast<half*>(O.data),       \
                        block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale,     \
-                       max_context_len, max_num_blocks, n_q_per_kv, sliding_window, n_sinks, softcap)
+                       max_context_len, max_num_blocks, n_q_per_kv, sliding_window, n_sinks, softcap,      \
+                       sinks_h)
 
             switch (head_dim) {
                 case 64:
@@ -1531,13 +1547,21 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
                 reinterpret_cast<const half*>(Q.data), reinterpret_cast<const half*>(K_cache.data),
                 reinterpret_cast<const half*>(V_cache.data), reinterpret_cast<half*>(O.data), block_tables,
                 context_lens, batch_size, n_heads, n_kv_heads, head_dim, block_size, scale, max_context_len,
-                max_num_blocks, n_q_per_kv, warps_per_q, sliding_window, n_sinks, softcap);
+                max_num_blocks, n_q_per_kv, warps_per_q, sliding_window, n_sinks, softcap, sinks_h);
         } else if (!used_cluster) {
             // MHA fallback for n_q_per_kv > MAX_Q_PER_KV without cluster
             goto mha_fallback;
         }
     } else {
     mha_fallback:
+        if (sinks_h) {
+            static bool warned_sinks_mha = false;
+            if (!warned_sinks_mha) {
+                warned_sinks_mha = true;
+                IMP_LOG_WARN("paged_attention_decode: MHA fallback ignores learned attention sinks "
+                             "(gpt-oss) — output will be wrong for this config");
+            }
+        }
         // MHA fallback: simple per-head kernel (templated + vectorized)
         dim3 grid(batch_size, n_heads);
         dim3 block(BLOCK_THREADS);

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -15,10 +15,14 @@ namespace imp {
 //          Requires sliding_window > 0 and ctx_len > n_sinks + sliding_window to
 //          activate; otherwise behaves as plain sliding-window / full attention.
 // softcap: 0 = disabled, >0 = apply tanh(score/cap)*cap (Gemma-2/3)
+// attn_sinks (gpt-oss, #547): per-head learned sink logits [n_heads] FP16 —
+//          virtual extra softmax column (denominator += exp(sink - max),
+//          column dropped). Unrelated to the positional n_sinks above.
 void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor& V_cache, Tensor& O,
                             const int* block_tables, const int* context_lens, int block_size, float scale,
                             int max_context_len, int sliding_window = 0, float softcap = 0.0f,
-                            cudaStream_t stream = nullptr, int max_blocks_per_seq = 0, int n_sinks = 0);
+                            cudaStream_t stream = nullptr, int max_blocks_per_seq = 0, int n_sinks = 0,
+                            const void* attn_sinks = nullptr);
 
 // Set split-K scratch buffer for paged attention. Must be called before
 // paged_attention_decode if split-K is desired. The scratch buffer holds

--- a/src/compute/attention_paged_common.cuh
+++ b/src/compute/attention_paged_common.cuh
@@ -13,6 +13,15 @@ static constexpr int BLOCK_THREADS = 256;
 static constexpr int NUM_WARPS = BLOCK_THREADS / WARP_SIZE;  // 8
 
 // cp.async helpers for pipelined Split-K attention
+// 4-byte async copy (2 halves): the only size legal for ELEMS=2 lanes
+// (head_dim=64 → per-lane offset is 4-byte aligned; an 8-byte cp.async from
+// odd lanes raises cudaErrorMisalignedAddress — found via gpt-oss #547,
+// the first hd=64 model through this path).
+__device__ __forceinline__ void cp_async_ca_4(void* smem, const void* glob) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 4;\n" ::"r"(s), "l"(glob));
+}
+
 __device__ __forceinline__ void cp_async_ca_8(void* smem, const void* glob) {
     uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
     asm volatile("cp.async.ca.shared.global [%0], [%1], 8;\n" ::"r"(s), "l"(glob));

--- a/src/compute/attention_paged_common.cuh
+++ b/src/compute/attention_paged_common.cuh
@@ -344,12 +344,16 @@ __device__ __forceinline__ void apply_score_masks(float* S_tile, int Br, int Bc,
 // Requires shared memory: float[NUM_WARPS + NUM_WARPS + NUM_WARPS * HEAD_DIM].
 // Only the first warp (warp_id==0) writes to global memory.
 // ---------------------------------------------------------------------------
+// attn_sinks (gpt-oss, #547): per-head learned sink logit — virtual extra
+// softmax column: joins the global max and adds exp(sink - max) to the
+// denominator; dropped from the numerator. nullptr = off.
 template <int HEAD_DIM>
 __device__ __forceinline__ void crosswarp_reduce_and_write(
     float* smem_base,      // shared memory region (warp_max | warp_l | warp_o)
     float m_w, float l_w,  // per-warp softmax state
     const float* o_reg,    // per-thread O accumulator [ELEMS]
-    int warp_id, int lane_id, int lane_offset, half* O, int batch_idx, int n_heads, int head_idx) {
+    int warp_id, int lane_id, int lane_offset, half* O, int batch_idx, int n_heads, int head_idx,
+    const half* attn_sinks = nullptr) {
     constexpr int ELEMS = HEAD_DIM / WARP_SIZE;
     float* warp_max = smem_base;
     float* warp_l = warp_max + NUM_WARPS;
@@ -368,10 +372,14 @@ __device__ __forceinline__ void crosswarp_reduce_and_write(
         float global_max = -FLT_MAX;
         for (int w = 0; w < NUM_WARPS; w++)
             global_max = fmaxf(global_max, warp_max[w]);
+        if (attn_sinks)
+            global_max = fmaxf(global_max, __half2float(attn_sinks[head_idx]));
 
         float global_l = 0.0f;
         for (int w = 0; w < NUM_WARPS; w++)
             global_l += expf(warp_max[w] - global_max) * warp_l[w];
+        if (attn_sinks)
+            global_l += expf(__half2float(attn_sinks[head_idx]) - global_max);
 
 #pragma unroll
         for (int i = 0; i < ELEMS; i++) {

--- a/src/compute/moe_routing.cu
+++ b/src/compute/moe_routing.cu
@@ -365,6 +365,80 @@ __global__ void gemv_gate_topk_fused_kernel(const half* __restrict__ W_gate,  //
 }
 
 // ============================================================================
+// gpt-oss bias kernels (issue #547)
+// ============================================================================
+
+__global__ void moe_add_logit_bias_kernel(float* __restrict__ logits, const half* __restrict__ bias,
+                                          int64_t total, int ne) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx < total)
+        logits[idx] += __half2float(bias[idx % ne]);
+}
+
+__global__ void moe_add_expert_bias_indexed_kernel(half* __restrict__ buf, const half* __restrict__ bias,
+                                                   const int32_t* __restrict__ expert_indices,
+                                                   int64_t total, int dim) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx < total) {
+        int row = static_cast<int>(idx / dim);
+        int e = expert_indices[row];
+        buf[idx] = __hadd(buf[idx], bias[static_cast<int64_t>(e) * dim + idx % dim]);
+    }
+}
+
+__global__ void moe_add_expert_bias_sorted_kernel(half* __restrict__ buf, const half* __restrict__ bias,
+                                                  const int32_t* __restrict__ expert_offsets, int ne,
+                                                  int64_t total, int dim) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total)
+        return;
+    int row = static_cast<int>(idx / dim);
+    // Binary search: expert e with offsets[e] <= row < offsets[e+1]. ne is
+    // small (32 for gpt-oss-20b) — 5 iterations, all from L2/__ldg.
+    int lo = 0, hi = ne - 1;
+    while (lo < hi) {
+        int mid = (lo + hi + 1) >> 1;
+        if (__ldg(&expert_offsets[mid]) <= row)
+            lo = mid;
+        else
+            hi = mid - 1;
+    }
+    buf[idx] = __hadd(buf[idx], bias[static_cast<int64_t>(lo) * dim + idx % dim]);
+}
+
+void moe_add_logit_bias(float* logits_f32, const void* bias_fp16, int n, int ne, cudaStream_t stream) {
+    int64_t total = static_cast<int64_t>(n) * ne;
+    if (total == 0)
+        return;
+    int threads = 256;
+    int blocks = static_cast<int>((total + threads - 1) / threads);
+    moe_add_logit_bias_kernel<<<blocks, threads, 0, stream>>>(
+        logits_f32, static_cast<const half*>(bias_fp16), total, ne);
+}
+
+void moe_add_expert_bias_indexed(void* buf_fp16, const void* bias_fp16, const int32_t* expert_indices,
+                                 int n_rows, int dim, cudaStream_t stream) {
+    int64_t total = static_cast<int64_t>(n_rows) * dim;
+    if (total == 0)
+        return;
+    int threads = 256;
+    int blocks = static_cast<int>((total + threads - 1) / threads);
+    moe_add_expert_bias_indexed_kernel<<<blocks, threads, 0, stream>>>(
+        static_cast<half*>(buf_fp16), static_cast<const half*>(bias_fp16), expert_indices, total, dim);
+}
+
+void moe_add_expert_bias_sorted(void* buf_fp16, const void* bias_fp16, const int32_t* expert_offsets,
+                                int ne, int n_rows, int dim, cudaStream_t stream) {
+    int64_t total = static_cast<int64_t>(n_rows) * dim;
+    if (total == 0)
+        return;
+    int threads = 256;
+    int blocks = static_cast<int>((total + threads - 1) / threads);
+    moe_add_expert_bias_sorted_kernel<<<blocks, threads, 0, stream>>>(
+        static_cast<half*>(buf_fp16), static_cast<const half*>(bias_fp16), expert_offsets, ne, total, dim);
+}
+
+// ============================================================================
 // Kernel 2: Count tokens per expert
 //
 // Each token contributes top_k entries.  We atomically increment per-expert

--- a/src/compute/moe_routing.h
+++ b/src/compute/moe_routing.h
@@ -51,6 +51,21 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingBuffers& bu
                      bool normalize_weights = true, const void* score_bias = nullptr,
                      bool skip_sorting = false);
 
+// gpt-oss router bias (issue #547): true linear bias on the gate LOGITS, added
+// BEFORE softmax/top-k (affects selection AND weights). Distinct from the
+// DeepSeek-style `score_bias` above, which biases SELECTION only.
+// logits_f32: [n, ne] FP32 (mutated). bias: [ne] FP16 on device.
+void moe_add_logit_bias(float* logits_f32, const void* bias_fp16, int n, int ne,
+                        cudaStream_t stream = nullptr);
+
+// gpt-oss per-expert output biases (issue #547).
+// indexed: row r belongs to expert expert_indices[r] (decode [top_k, dim] layout).
+void moe_add_expert_bias_indexed(void* buf_fp16, const void* bias_fp16, const int32_t* expert_indices,
+                                 int n_rows, int dim, cudaStream_t stream = nullptr);
+// sorted: rows grouped by expert per expert_offsets[ne+1] (prefill expanded layout).
+void moe_add_expert_bias_sorted(void* buf_fp16, const void* bias_fp16, const int32_t* expert_offsets,
+                                int ne, int n_rows, int dim, cudaStream_t stream = nullptr);
+
 void moe_gather(const Tensor& input, const MoeRoutingResult& routing, Tensor& gathered,
                 cudaStream_t stream = nullptr);
 

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -809,6 +809,7 @@ private:
     void nvfp4_decode_mxfp4_fp16_fallback_(const ModelConfig& cfg, cudaStream_t stream);
     void nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg, size_t& remaining_budget,
                                          cudaStream_t stream, Nvfp4DecodeContext& dctx);
+    void gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx);
     void pre_dequant_phase3c_standalone_mxfp4_(const ModelConfig& cfg, cudaStream_t stream);
     void pre_dequant_phase4_tensor_registry_(const ModelConfig& cfg, cudaStream_t stream);
     // Phase 5 PR #1 Commit 5.1.4.b: mark Tensor.dropped_source for weights

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -664,9 +664,15 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     bool rope_k_deferred = false;  // true when K-RoPE will be fused into KV write
     {
         bool has_qk_norm = (ly.attn_q_norm.data != nullptr && ly.attn_k_norm.data != nullptr);
-        // Determine if we can fuse K-RoPE into KV cache write
+        // Determine if we can fuse K-RoPE into KV cache write.
+        // YaRN models (#547, gpt-oss): the fused kernels
+        // (rope_q_only_fp16_kernel / write_kv_cache_rope_fused_kernel) only
+        // know theta + 1/scale — no ramp blending, no attn_factor. Prefill
+        // K would be YaRN-correct but every decode-written K plain-RoPE →
+        // degeneration from token 2. Keep YaRN on the separate full path.
         bool can_fuse_rope_kv = (!state.is_prefill && n == 1 && qv.qtype == QType::F16 && state.kv_cache &&
-                                 state.kv_cache->qtype() == QType::F16 && !cfg.rope_attn_disabled);
+                                 state.kv_cache->qtype() == QType::F16 && !cfg.rope_attn_disabled &&
+                                 cfg.yarn_ext_factor <= 0.0f);
         // Per-layer rope_dim. Gemma 4: both SWA and global layers rotate the
         // full head_dim. Global layers' freq_factors (loaded into
         // longrope_freqs above) zero out most pairs to realize the
@@ -1059,15 +1065,19 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             int64_t v_shape[2] = {ctx_len, nkv * hd};
             Tensor k_cont(k_flat, QType::F16, 2, k_shape, true);
             Tensor v_cont(v_flat, QType::F16, 2, v_shape, true);
-            // Use n=1 cuBLAS attention with causal=false (all context visible).
-            // Track E is tried first; it will decline causal=false and fall through to cuBLAS.
+            // n=1 cuBLAS attention. causal=true + q_offset=ctx_len-1 makes the
+            // single query row see the full context AND keeps the sliding-window
+            // mask correct (the old causal=false/q_offset=0 form broke SWA
+            // layers: abs_row=0 never triggered the window). Sinks pass through
+            // so this debug arm stays a faithful reference for gpt-oss (#547).
             {
                 int64_t s_shape[3] = {(int64_t)nh, 1, (int64_t)ctx_len};
                 half* s_buf = nullptr;
-                cudaMalloc(&s_buf, nh * ctx_len * sizeof(half));
+                cudaMalloc(&s_buf, (size_t)nh * ctx_len * sizeof(half));
                 Tensor s_view(s_buf, QType::F16, 3, s_shape, true);
-                attention_cublas_prefill(qv, k_cont, v_cont, ao, s_view, nh, nkv, hd, scale, /*causal=*/false,
-                                         cfg.attn_logit_softcap, /*q_offset=*/0, stream);
+                attention_cublas_prefill(qv, k_cont, v_cont, ao, s_view, nh, nkv, hd, scale, /*causal=*/true,
+                                         cfg.attn_logit_softcap, /*q_offset=*/ctx_len - 1, stream,
+                                         layer_sliding_window, attn_sinks);
                 cudaFree(s_buf);
             }
             cudaFree(k_flat);

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -573,6 +573,13 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // Global layer: full attention, model rope_theta, with freq scaling
             layer_sliding_window = 0;
         }
+    } else if (cfg.arch == ModelArch::GPT_OSS && !cfg.swa_layers.empty()) {
+        // gpt-oss (#547): even layers sliding_attention (window 128), odd
+        // layers full attention. Same RoPE (YaRN) on both layer types —
+        // only the window toggles.
+        bool is_swa = (layer < (int)cfg.swa_layers.size() && cfg.swa_layers[layer]);
+        if (!is_swa)
+            layer_sliding_window = 0;
     } else if (cfg.sliding_window_pattern > 0) {
         bool is_global = (layer % cfg.sliding_window_pattern) == (cfg.sliding_window_pattern - 1);
         if (is_global) {
@@ -754,6 +761,12 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     //                 Q-norm and K-norm absorb the per-element scaling).
     float scale = (cfg.arch == ModelArch::GEMMA4) ? 1.0f : (1.0f / std::sqrt(static_cast<float>(hd)));
 
+    // gpt-oss learned attention sinks (#547): per-head logits acting as a
+    // virtual extra softmax column. Only the cuBLAS prefill softmax and the
+    // FP16 paged decode kernels understand them — prefill routing below
+    // forces the cuBLAS path whenever sinks are present.
+    const void* attn_sinks = (cfg.arch == ModelArch::GPT_OSS) ? ly.attn_sinks.data : nullptr;
+
     if (state.is_prefill) {
         // Chunked prefill: when prefill_offset > 0, queries from this chunk must
         // attend to past chunks K/V already in the paged cache. Gather past
@@ -889,12 +902,12 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // (ChunkedPrefillTest.LongContext_Chunk_Invariance is the gate).
             // The fp8 family stays as fallback for configs f16-QK declines
             // (hd != 128, fa2_fp16qk=never), and cuBLAS below the threshold.
-            if (!per_layer_shapes &&
+            if (!per_layer_shapes && !attn_sinks &&
                 try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
                                        nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
                                        q_offset, stream)) {
                 // chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
-            } else if (chunked_use_fmha) {
+            } else if (chunked_use_fmha && !attn_sinks) {
                 // FMHA: no S-matrix needed, O(n) memory. Reshape to 4D for dispatch.
                 int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
                 int64_t kv4s[4] = {1, (int64_t)ctx_len, (int64_t)nkv, (int64_t)hd};
@@ -909,7 +922,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                 // cuBLAS: needs S-matrix for [n × ctx_len]
                 attention_cublas_prefill(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv, hd, scale,
                                          /*causal=*/true, cfg.attn_logit_softcap, q_offset, stream,
-                                         layer_sliding_window);
+                                         layer_sliding_window, attn_sinks);
             }
 
             cudaFreeAsync(k_full, stream);
@@ -921,7 +934,8 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         }
 
         // Prefill dispatch (post-Phase-2 + Phase-5 Track D):
-        const bool force_cublas_attn = per_layer_shapes;  // Gemma 4 dual head_dim
+        // attn_sinks: only the cuBLAS softmax understands learned sinks.
+        const bool force_cublas_attn = per_layer_shapes || attn_sinks != nullptr;
         const bool s_matrix_fits = attn_scores_buf_ != nullptr &&
                                    n <= static_cast<int>(attn_scores_.shape[1]);
         // FMHA only above the S-matrix threshold — see the chunked path above
@@ -949,9 +963,18 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             } else {
                 attention_cublas_prefill(qv, kk, vv, ao, attn_scores_, nh, nkv, hd, scale,
                                          /*causal=*/true, cfg.attn_logit_softcap,
-                                         /*q_offset=*/0, stream, layer_sliding_window);
+                                         /*q_offset=*/0, stream, layer_sliding_window, attn_sinks);
             }
         } else {
+            if (attn_sinks) {
+                static bool warned_sinks_fmha = false;
+                if (!warned_sinks_fmha) {
+                    warned_sinks_fmha = true;
+                    IMP_LOG_WARN("attention sinks: S-matrix too small (n=%d) — FMHA fallback IGNORES "
+                                 "sinks; output will be wrong. Lower the prefill chunk size.",
+                                 n);
+                }
+            }
             // FMHA fallback: tiled O(n) memory chain.
             int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
             int64_t kv4s[4] = {1, (int64_t)n, (int64_t)nkv, (int64_t)hd};
@@ -1189,7 +1212,16 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode(q4, k_c, v_c, o4, state.block_tables, state.context_lens, kv_bs, scale,
                                    state.max_context_len, layer_sliding_window, cfg.attn_logit_softcap,
-                                   stream, state.max_blocks_per_seq, layer_n_sinks);
+                                   stream, state.max_blocks_per_seq, layer_n_sinks, attn_sinks);
+        }
+        if (attn_sinks && cache_dtype != QType::F16) {
+            static bool warned_sinks_kv = false;
+            if (!warned_sinks_kv) {
+                warned_sinks_kv = true;
+                IMP_LOG_WARN("attention sinks: only the FP16 paged decode kernels apply sinks — "
+                             "kv_cache.dtype=%d ignores them; use fp16 KV for this model.",
+                             (int)cache_dtype);
+            }
         }
 
         // Clear L2 persistence hint (weights loaded next need L2 space)
@@ -1372,6 +1404,13 @@ after_attention:
         if (po_fp32_buf) {
             cudaFreeAsync(po_fp32_buf, stream);
         }
+    }
+
+    // gpt-oss o_proj bias (#547): h holds residual + Wo·ao from whichever arm
+    // ran — broadcast-add the bias per token here, after all fused variants.
+    if (ly.o_bias.data != nullptr) {
+        Tensor hv = view_tokens(h, n);
+        add_bias(hv, ly.o_bias, stream);
     }
 
     // LoRA delta on o_proj: h already holds residual + Wo·ao from whichever

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -772,10 +772,6 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     // FP16 paged decode kernels understand them — prefill routing below
     // forces the cuBLAS path whenever sinks are present.
     const void* attn_sinks = (cfg.arch == ModelArch::GPT_OSS) ? ly.attn_sinks.data : nullptr;
-    // TEMP diagnostic toggle (#547 bring-up): A/B sinks off.
-    static const bool s_no_sinks = getenv("GPTOSS_NO_SINKS") != nullptr;
-    if (s_no_sinks)
-        attn_sinks = nullptr;
 
     if (state.is_prefill) {
         // Chunked prefill: when prefill_offset > 0, queries from this chunk must

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -772,6 +772,10 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     // FP16 paged decode kernels understand them — prefill routing below
     // forces the cuBLAS path whenever sinks are present.
     const void* attn_sinks = (cfg.arch == ModelArch::GPT_OSS) ? ly.attn_sinks.data : nullptr;
+    // TEMP diagnostic toggle (#547 bring-up): A/B sinks off.
+    static const bool s_no_sinks = getenv("GPTOSS_NO_SINKS") != nullptr;
+    if (s_no_sinks)
+        attn_sinks = nullptr;
 
     if (state.is_prefill) {
         // Chunked prefill: when prefill_offset > 0, queries from this chunk must

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -109,10 +109,8 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
 
     // gpt-oss (#547): per-expert biases on gate/up outputs BEFORE activation.
     // Rows are expert-sorted (expanded layout) — expert via expert_offsets.
-    static const bool s_no_ebias = getenv("GPTOSS_NO_EBIAS") != nullptr;   // TEMP #547 A/B
-    static const bool s_swiglu = getenv("GPTOSS_SWIGLU") != nullptr;       // TEMP #547 A/B
     const int32_t* d_offsets = static_cast<const int32_t*>(ctx.routing.expert_offsets.data);
-    if (cfg.arch == ModelArch::GPT_OSS && !s_no_ebias) {
+    if (cfg.arch == ModelArch::GPT_OSS) {
         moe_add_expert_bias_sorted(expert_gate_base, ly.expert_gate_bias.data, d_offsets, ctx.ne,
                                    ctx.expanded, ctx.eff, stream);
         moe_add_expert_bias_sorted(expert_up_base, ly.expert_up_bias.data, d_offsets, ctx.ne,
@@ -122,13 +120,13 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
     // Activation
     apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data, moe_.expert_swiglu.data,
                             ctx.non_gated_experts, ctx.expanded, ctx.eff, compute_dtype_,
-                            s_swiglu ? FFNActivation::SWIGLU : cfg.ffn_activation, stream);
+                            cfg.ffn_activation, stream);
 
     // Down projection
     char* slow_down_act = ctx.non_gated_experts ? expert_up_base : expert_swiglu_base;
     nvfp4_batch_dequant_gemm(*ly.nvfp4_moe_down_ptr, slow_down_act, expert_down_base, ctx.eff, ctx.d);
 
-    if (cfg.arch == ModelArch::GPT_OSS && !s_no_ebias)
+    if (cfg.arch == ModelArch::GPT_OSS)
         moe_add_expert_bias_sorted(expert_down_base, ly.expert_down_bias.data, d_offsets, ctx.ne,
                                    ctx.expanded, ctx.d, stream);
 
@@ -648,8 +646,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
         // added before softmax/top-k it shifts selection AND the renormalized
         // top-k weights (= HF's topk(logits+b) → softmax-over-selected).
         // Distinct from DeepSeek's selection-only score_bias (router_bias_ptr).
-        static const bool s_no_rbias = getenv("GPTOSS_NO_RBIAS") != nullptr;  // TEMP #547 A/B
-        if (cfg.arch == ModelArch::GPT_OSS && ly.router_bias.data != nullptr && !s_no_rbias)
+        if (cfg.arch == ModelArch::GPT_OSS && ly.router_bias.data != nullptr)
             moe_add_logit_bias(static_cast<float*>(logits_f32.data), ly.router_bias.data, n, ne, stream);
         if (moe_.routing_buffers.pool) {
             moe_topk_gating(logits_f32, top_k, moe_.routing_buffers, routing, stream, use_sigmoid,

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -107,6 +107,16 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
     // Up projection
     nvfp4_batch_dequant_gemm(*ly.nvfp4_moe_up_ptr, gathered_base, expert_up_base, ctx.d, ctx.eff);
 
+    // gpt-oss (#547): per-expert biases on gate/up outputs BEFORE activation.
+    // Rows are expert-sorted (expanded layout) — expert via expert_offsets.
+    const int32_t* d_offsets = static_cast<const int32_t*>(ctx.routing.expert_offsets.data);
+    if (cfg.arch == ModelArch::GPT_OSS) {
+        moe_add_expert_bias_sorted(expert_gate_base, ly.expert_gate_bias.data, d_offsets, ctx.ne,
+                                   ctx.expanded, ctx.eff, stream);
+        moe_add_expert_bias_sorted(expert_up_base, ly.expert_up_bias.data, d_offsets, ctx.ne,
+                                   ctx.expanded, ctx.eff, stream);
+    }
+
     // Activation
     apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data, moe_.expert_swiglu.data,
                             ctx.non_gated_experts, ctx.expanded, ctx.eff, compute_dtype_,
@@ -115,6 +125,10 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
     // Down projection
     char* slow_down_act = ctx.non_gated_experts ? expert_up_base : expert_swiglu_base;
     nvfp4_batch_dequant_gemm(*ly.nvfp4_moe_down_ptr, slow_down_act, expert_down_base, ctx.eff, ctx.d);
+
+    if (cfg.arch == ModelArch::GPT_OSS)
+        moe_add_expert_bias_sorted(expert_down_base, ly.expert_down_bias.data, d_offsets, ctx.ne,
+                                   ctx.expanded, ctx.d, stream);
 
     return true;
 }
@@ -628,6 +642,12 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     const auto& ly = model_->layer(layer);
 
     auto run_topk = [&](const Tensor& logits_f32) {
+        // gpt-oss (#547): router bias is a true LINEAR bias on the logits —
+        // added before softmax/top-k it shifts selection AND the renormalized
+        // top-k weights (= HF's topk(logits+b) → softmax-over-selected).
+        // Distinct from DeepSeek's selection-only score_bias (router_bias_ptr).
+        if (cfg.arch == ModelArch::GPT_OSS && ly.router_bias.data != nullptr)
+            moe_add_logit_bias(static_cast<float*>(logits_f32.data), ly.router_bias.data, n, ne, stream);
         if (moe_.routing_buffers.pool) {
             moe_topk_gating(logits_f32, top_k, moe_.routing_buffers, routing, stream, use_sigmoid,
                             norm_weights, router_bias_ptr, /*skip_sorting=*/will_decode_fast);
@@ -766,7 +786,23 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
         use_nvfp4_moe = (ly.nvfp4_moe_gate_ptr != nullptr);
 
     if (use_nvfp4_moe) {
-        if (!non_gated_experts) {
+        if (cfg.arch == ModelArch::GPT_OSS) {
+            // gpt-oss (#547): per-expert biases on gate/up/down outputs + the
+            // clamped GLU. The fused swiglu-down GEMV computes plain SwiGLU
+            // inline — bypassed here in favor of explicit bias→GLU→down→bias.
+            gemv_nvfp4_moe_gate_up_fused(*ly.nvfp4_moe_gate_ptr, *ly.nvfp4_moe_up_ptr, expert_indices,
+                                         norm_ptr, gate_buf, up_buf, eff, d, top_k, stream);
+            moe_add_expert_bias_indexed(gate_buf, ly.expert_gate_bias.data, expert_indices, top_k, eff,
+                                        stream);
+            moe_add_expert_bias_indexed(up_buf, ly.expert_up_bias.data, expert_indices, top_k, eff,
+                                        stream);
+            apply_expert_activation(gate_buf, up_buf, act_buf, /*non_gated=*/false, top_k, eff,
+                                    compute_dtype_, FFNActivation::GPT_OSS_GLU, stream);
+            gemv_nvfp4_moe_decode(*ly.nvfp4_moe_down_ptr, expert_indices, act_buf, down_buf, d, eff,
+                                  /*x_stride=*/eff, top_k, stream);
+            moe_add_expert_bias_indexed(down_buf, ly.expert_down_bias.data, expert_indices, top_k, d,
+                                        stream);
+        } else if (!non_gated_experts) {
             gemv_nvfp4_moe_gate_up_fused(*ly.nvfp4_moe_gate_ptr, *ly.nvfp4_moe_up_ptr, expert_indices,
                                          norm_ptr, gate_buf, up_buf, eff, d, top_k, stream);
             gemv_nvfp4_moe_swiglu_decode(*ly.nvfp4_moe_down_ptr, expert_indices, gate_buf, up_buf,

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -109,8 +109,10 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
 
     // gpt-oss (#547): per-expert biases on gate/up outputs BEFORE activation.
     // Rows are expert-sorted (expanded layout) — expert via expert_offsets.
+    static const bool s_no_ebias = getenv("GPTOSS_NO_EBIAS") != nullptr;   // TEMP #547 A/B
+    static const bool s_swiglu = getenv("GPTOSS_SWIGLU") != nullptr;       // TEMP #547 A/B
     const int32_t* d_offsets = static_cast<const int32_t*>(ctx.routing.expert_offsets.data);
-    if (cfg.arch == ModelArch::GPT_OSS) {
+    if (cfg.arch == ModelArch::GPT_OSS && !s_no_ebias) {
         moe_add_expert_bias_sorted(expert_gate_base, ly.expert_gate_bias.data, d_offsets, ctx.ne,
                                    ctx.expanded, ctx.eff, stream);
         moe_add_expert_bias_sorted(expert_up_base, ly.expert_up_bias.data, d_offsets, ctx.ne,
@@ -120,13 +122,13 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
     // Activation
     apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data, moe_.expert_swiglu.data,
                             ctx.non_gated_experts, ctx.expanded, ctx.eff, compute_dtype_,
-                            cfg.ffn_activation, stream);
+                            s_swiglu ? FFNActivation::SWIGLU : cfg.ffn_activation, stream);
 
     // Down projection
     char* slow_down_act = ctx.non_gated_experts ? expert_up_base : expert_swiglu_base;
     nvfp4_batch_dequant_gemm(*ly.nvfp4_moe_down_ptr, slow_down_act, expert_down_base, ctx.eff, ctx.d);
 
-    if (cfg.arch == ModelArch::GPT_OSS)
+    if (cfg.arch == ModelArch::GPT_OSS && !s_no_ebias)
         moe_add_expert_bias_sorted(expert_down_base, ly.expert_down_bias.data, d_offsets, ctx.ne,
                                    ctx.expanded, ctx.d, stream);
 
@@ -646,7 +648,8 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
         // added before softmax/top-k it shifts selection AND the renormalized
         // top-k weights (= HF's topk(logits+b) → softmax-over-selected).
         // Distinct from DeepSeek's selection-only score_bias (router_bias_ptr).
-        if (cfg.arch == ModelArch::GPT_OSS && ly.router_bias.data != nullptr)
+        static const bool s_no_rbias = getenv("GPTOSS_NO_RBIAS") != nullptr;  // TEMP #547 A/B
+        if (cfg.arch == ModelArch::GPT_OSS && ly.router_bias.data != nullptr && !s_no_rbias)
             moe_add_logit_bias(static_cast<float*>(logits_f32.data), ly.router_bias.data, n, ne, stream);
         if (moe_.routing_buffers.pool) {
             moe_topk_gating(logits_f32, top_k, moe_.routing_buffers, routing, stream, use_sigmoid,

--- a/src/exec/executor_forward_moe_internal.h
+++ b/src/exec/executor_forward_moe_internal.h
@@ -35,6 +35,8 @@ inline void apply_expert_activation(void* gate_data, void* up_data, void* swiglu
         Tensor a(swiglu_data, compute_dtype, 2, act_shape, true);
         if (act_type == FFNActivation::GEGLU)
             geglu(g, u, a, stream);
+        else if (act_type == FFNActivation::GPT_OSS_GLU)
+            gpt_oss_glu(g, u, a, stream);
         else
             swiglu(g, u, a, stream);
     }

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -1271,9 +1271,12 @@ void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
                   gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
                                                    static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
                                                    gu_K, /*offset=*/1, /*stride=*/2, u) &&
+                  // down: extra 2^-4 — residual-stream rescale (see arch
+                  // registry comment in model.cpp; bias scaled in the loader).
                   gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(dn_b.data),
                                                    static_cast<const uint8_t*>(dn_s.data), ne, dn_rows,
-                                                   dn_K, /*offset=*/0, /*stride=*/1, d);
+                                                   dn_K, /*offset=*/0, /*stride=*/1, d,
+                                                   /*extra_scale=*/0.0625f);
         if (!ok) {
             IMP_LOG_ERROR("gpt-oss L%d: MXFP4→NVFP4 expert conversion failed (VRAM?)", i);
             return;

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -15,6 +15,7 @@
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
 #include "quant/dequant_gpu.h"
+#include "quant/gpt_oss_mxfp4_convert.h"
 #include "quant/fp8_quant.h"
 #include "quant/nvfp4_quant.h"
 #include "quant/nvfp4_gemm.h"
@@ -355,6 +356,8 @@ void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
         nvfp4_decode_mxfp4_fp16_fallback_(cfg, stream);
     }
 
+    if (cfg.arch == ModelArch::GPT_OSS)
+        gpt_oss_convert_moe_experts_(cfg, dctx);
     nvfp4_decode_cache_moe_experts_(cfg, remaining_budget, stream, dctx);
 }
 
@@ -1230,6 +1233,73 @@ if (mx_native > 0) {
 //    per projection.
 //  - cache_moe_expert_nvfp4: GGUF / re-quant path, expert_*_packed is the
 //    3-D contiguous tensor.
+// ---------------------------------------------------------------------------
+// gpt-oss (#547): convert the HF-MXFP4 pre-packed experts (host-mmap'd
+// blocks/scales) into the native NVFP4 MoE cache. e2m1 nibbles are
+// bit-identical (linear pair order); ue8m0 scales expand 1→2 e4m3
+// micro-scales under a per-expert tensor scale. gate_up rows arrive
+// interleaved (g0,u0,g1,…) and are de-interleaved into separate gate/up
+// results, so the whole proven NVFP4-MoE machinery (CUTLASS grouped prefill,
+// gemv_nvfp4_moe decode, CUDA graphs) applies unchanged. Placeholder packed
+// tensors keyed on the converted device pointers let Phase 4 wire
+// nvfp4_moe_{gate,up,down}_ptr exactly like the Modelopt path.
+// ---------------------------------------------------------------------------
+void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx) {
+    int converted = 0;
+    for (int i = 0; i < cfg.n_layers; ++i) {
+        TransformerLayer& L = const_cast<Model*>(model_)->layer(i);
+        const Tensor& gu_b = L.expert_gate_up_packed_blocks;
+        const Tensor& gu_s = L.expert_gate_up_packed_scales;
+        const Tensor& dn_b = L.expert_down_packed_blocks;
+        const Tensor& dn_s = L.expert_down_packed_scales;
+        if (!gu_b.data || !gu_s.data || !dn_b.data || !dn_s.data)
+            continue;
+        if (gu_b.on_device || dn_b.on_device) {
+            IMP_LOG_ERROR("gpt-oss L%d: packed expert tensors unexpectedly on device — skipping", i);
+            continue;
+        }
+        const int ne = static_cast<int>(gu_b.shape[0]);
+        const int64_t gu_rows = gu_b.shape[1];           // 2*d_ff, interleaved
+        const int64_t gu_K = gu_b.shape[2] * 32;         // K from block count
+        const int64_t dn_rows = dn_b.shape[1];           // d_model
+        const int64_t dn_K = dn_b.shape[2] * 32;         // d_ff
+
+        NvFP4MoEQuantResult g{}, u{}, d{};
+        bool ok = gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
+                                                   static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
+                                                   gu_K, /*offset=*/0, /*stride=*/2, g) &&
+                  gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
+                                                   static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
+                                                   gu_K, /*offset=*/1, /*stride=*/2, u) &&
+                  gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(dn_b.data),
+                                                   static_cast<const uint8_t*>(dn_s.data), ne, dn_rows,
+                                                   dn_K, /*offset=*/0, /*stride=*/1, d);
+        if (!ok) {
+            IMP_LOG_ERROR("gpt-oss L%d: MXFP4→NVFP4 expert conversion failed (VRAM?)", i);
+            return;
+        }
+
+        auto install = [&](NvFP4MoEQuantResult& r, Tensor& packed_slot) {
+            int64_t shp[3] = {r.n_experts, r.N, r.K};
+            packed_slot = Tensor(r.packed_data, QType::NVFP4, 3, shp, /*on_device=*/true);
+            wcache_.nvfp4_moe[r.packed_data] = r;
+            auto* m = const_cast<Model*>(model_);
+            m->gpu_allocations_.push_back(r.packed_data);
+            m->gpu_allocations_.push_back(r.micro_scales);
+            m->gpu_allocations_.push_back(r.tensor_scales);
+        };
+        install(g, L.expert_gate_packed);
+        install(u, L.expert_up_packed);
+        install(d, L.expert_down_packed);
+        dctx.nvfp4_moe_count += 3;
+        converted++;
+    }
+    if (converted)
+        IMP_LOG_INFO("gpt-oss: converted MXFP4→NVFP4 experts for %d layers "
+                     "(ne=%d, gate/up de-interleaved)",
+                     converted, cfg.n_experts);
+}
+
 void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
                                                     size_t& remaining_budget,
                                                     cudaStream_t stream,

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -27,6 +27,8 @@ const char* chat_template_family_name(ChatTemplateFamily family) {
             return "deepseek_r1";
         case ChatTemplateFamily::PHI:
             return "phi";
+        case ChatTemplateFamily::HARMONY:
+            return "harmony";
     }
     return "unknown";
 }
@@ -61,6 +63,10 @@ ChatTemplateFamily ChatTemplate::detect_family(const std::string& jinja2_str) {
                         "User"
                         "\xef\xbd\x9c") != std::string::npos)
         return ChatTemplateFamily::DEEPSEEK_R1;
+    // Harmony (gpt-oss): <|channel|> is unique to the format. Must be checked
+    // BEFORE Phi — the Harmony template also contains the literal <|end|>.
+    if (jinja2_str.find("<|channel|>") != std::string::npos)
+        return ChatTemplateFamily::HARMONY;
     // Phi: <|end|> is literal in the Jinja2 template (role tags are dynamic)
     if (jinja2_str.find("<|end|>") != std::string::npos)
         return ChatTemplateFamily::PHI;
@@ -96,6 +102,8 @@ ChatTemplateFamily ChatTemplate::default_family_for_arch(ModelArch arch) {
             return ChatTemplateFamily::GEMMA;
         case ModelArch::LLAMA4:
             return ChatTemplateFamily::LLAMA3;
+        case ModelArch::GPT_OSS:
+            return ChatTemplateFamily::HARMONY;
         default:
             return ChatTemplateFamily::RAW;
     }
@@ -122,6 +130,8 @@ ChatTemplateFamily ChatTemplate::parse_family(const std::string& name) {
         return ChatTemplateFamily::DEEPSEEK_R1;
     if (name == "phi")
         return ChatTemplateFamily::PHI;
+    if (name == "harmony")
+        return ChatTemplateFamily::HARMONY;
     return ChatTemplateFamily::RAW;
 }
 
@@ -330,6 +340,32 @@ bool ChatTemplate::init(ChatTemplateFamily family, const Tokenizer& tokenizer, c
             stop_token_ids_.push_back(phi_end_id_);
             break;
         }
+        case ChatTemplateFamily::HARMONY: {
+            hm_start_id_ = tokenizer.find_token("<|start|>");
+            hm_end_id_ = tokenizer.find_token("<|end|>");
+            hm_message_id_ = tokenizer.find_token("<|message|>");
+            hm_channel_id_ = tokenizer.find_token("<|channel|>");
+            hm_return_id_ = tokenizer.find_token("<|return|>");
+            hm_call_id_ = tokenizer.find_token("<|call|>");
+            if (hm_start_id_ < 0 || hm_end_id_ < 0 || hm_message_id_ < 0 || hm_channel_id_ < 0 ||
+                hm_return_id_ < 0) {
+                IMP_LOG_WARN(
+                    "Harmony template: missing tokens "
+                    "(start=%d, end=%d, message=%d, channel=%d, return=%d), falling back to raw",
+                    hm_start_id_, hm_end_id_, hm_message_id_, hm_channel_id_, hm_return_id_);
+                family_ = ChatTemplateFamily::RAW;
+                return false;
+            }
+            // The final-channel answer ends with <|return|>; tool calls end
+            // with <|call|>. <|end|> is deliberately NOT a stop token — it
+            // separates the analysis message from the final message inside
+            // one assistant turn (stopping there would truncate after the
+            // reasoning block).
+            stop_token_ids_.push_back(hm_return_id_);
+            if (hm_call_id_ >= 0)
+                stop_token_ids_.push_back(hm_call_id_);
+            break;
+        }
         default:
             break;
     }
@@ -412,6 +448,8 @@ std::vector<int32_t> ChatTemplate::apply(const Tokenizer& tok, const std::vector
             return apply_deepseek_r1(tok, eff_msgs);
         case ChatTemplateFamily::PHI:
             return apply_phi(tok, eff_msgs);
+        case ChatTemplateFamily::HARMONY:
+            return apply_harmony(tok, eff_msgs);
         default:
             break;
     }
@@ -730,6 +768,71 @@ std::vector<int32_t> ChatTemplate::apply_phi(const Tokenizer& tok,
             }
             fprintf(stderr, "|");
         }
+        fprintf(stderr, "\n");
+    }
+
+    return tokens;
+}
+
+// Harmony (gpt-oss): <|start|>role<|message|>content<|end|> blocks.
+// System turn carries the channel declaration the model was trained on;
+// a user-provided "system" message maps to the developer role per the
+// Harmony spec. Assistant history is rendered as the final channel.
+std::vector<int32_t> ChatTemplate::apply_harmony(const Tokenizer& tok,
+                                                 const std::vector<ChatMessage>& msgs) const {
+    std::vector<int32_t> tokens;
+
+    auto push_text = [&](const std::string& text) {
+        auto ids = tok.encode(text);
+        tokens.insert(tokens.end(), ids.begin(), ids.end());
+    };
+    auto open_role = [&](const char* role) {
+        tokens.push_back(hm_start_id_);
+        push_text(role);
+    };
+
+    // Fixed system turn (Harmony spec): identity + reasoning level + the
+    // channel contract. The model relies on this to route analysis vs final.
+    open_role("system");
+    tokens.push_back(hm_message_id_);
+    push_text(
+        "You are ChatGPT, a large language model trained by OpenAI.\n"
+        "Knowledge cutoff: 2024-06\n\n"
+        "Reasoning: medium\n\n"
+        "# Valid channels: analysis, commentary, final. "
+        "Channel must be included for every message.");
+    tokens.push_back(hm_end_id_);
+
+    for (const auto& msg : msgs) {
+        if (msg.role == "system") {
+            // User-supplied instructions → developer role (Harmony spec).
+            open_role("developer");
+            tokens.push_back(hm_message_id_);
+            push_text("# Instructions\n\n" + msg.content);
+            tokens.push_back(hm_end_id_);
+        } else if (msg.role == "assistant") {
+            open_role("assistant");
+            tokens.push_back(hm_channel_id_);
+            push_text("final");
+            tokens.push_back(hm_message_id_);
+            push_text(msg.content);
+            tokens.push_back(hm_end_id_);
+        } else {  // user (and any unknown role)
+            open_role(msg.role == "user" ? "user" : msg.role.c_str());
+            tokens.push_back(hm_message_id_);
+            push_text(msg.content);
+            tokens.push_back(hm_end_id_);
+        }
+    }
+
+    // Generation prompt: the model emits "<|channel|>analysis<|message|>..."
+    // itself, then "<|start|>assistant<|channel|>final<|message|>...<|return|>".
+    open_role("assistant");
+
+    if (imp::process_diag_debug_template()) {
+        fprintf(stderr, "[DEBUG_TPL] harmony %zu tokens:", tokens.size());
+        for (size_t i = 0; i < tokens.size(); i++)
+            fprintf(stderr, " %d", tokens[i]);
         fprintf(stderr, "\n");
     }
 

--- a/src/model/chat_template.h
+++ b/src/model/chat_template.h
@@ -20,6 +20,7 @@ enum class ChatTemplateFamily {
     GEMMA,        // <start_of_turn>user\n...<end_of_turn>\n<start_of_turn>model\n
     DEEPSEEK_R1,  // <｜User｜>...<｜Assistant｜>...<｜end▁of▁sentence｜>
     PHI,          // <|user|>...<|end|>...<|assistant|>
+    HARMONY,      // gpt-oss: <|start|>role<|message|>...<|end|>, channels, <|return|> stop
 };
 
 const char* chat_template_family_name(ChatTemplateFamily family);
@@ -131,6 +132,14 @@ private:
     int32_t phi_assistant_id_ = -1;  // <|assistant|>
     int32_t phi_end_id_ = -1;        // <|end|>
 
+    // Harmony tokens (gpt-oss)
+    int32_t hm_start_id_ = -1;    // <|start|>
+    int32_t hm_end_id_ = -1;      // <|end|>     (message separator — NOT a stop token)
+    int32_t hm_message_id_ = -1;  // <|message|>
+    int32_t hm_channel_id_ = -1;  // <|channel|>
+    int32_t hm_return_id_ = -1;   // <|return|>  (stop)
+    int32_t hm_call_id_ = -1;     // <|call|>    (stop, tool call)
+
     // Vision tokens (Gemma-3)
     int32_t boi_id_ = -1;             // <start_of_image>
     int32_t eoi_id_ = -1;             // <end_of_image>
@@ -172,6 +181,7 @@ private:
     std::vector<int32_t> apply_gemma(const Tokenizer& tok, const std::vector<ChatMessage>& msgs) const;
     std::vector<int32_t> apply_deepseek_r1(const Tokenizer& tok, const std::vector<ChatMessage>& msgs) const;
     std::vector<int32_t> apply_phi(const Tokenizer& tok, const std::vector<ChatMessage>& msgs) const;
+    std::vector<int32_t> apply_harmony(const Tokenizer& tok, const std::vector<ChatMessage>& msgs) const;
 };
 
 }  // namespace imp

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -38,6 +38,7 @@ ModelArch HFConfigLoader::map_architecture(const std::string& hf_arch) {
         {"Gemma3ForConditionalGeneration", ModelArch::GEMMA3},
         {"Gemma4ForCausalLM", ModelArch::GEMMA4},
         {"Gemma4ForConditionalGeneration", ModelArch::GEMMA4},
+        {"GptOssForCausalLM", ModelArch::GPT_OSS},
         {"DeepseekV2ForCausalLM", ModelArch::DEEPSEEK},
         {"DeepseekV3ForCausalLM", ModelArch::DEEPSEEK},
         {"Llama4ForCausalLM", ModelArch::LLAMA4},
@@ -489,6 +490,22 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
                      "scale=%.2f norm_topk=%d",
                      cfg.n_experts, cfg.n_experts_active, cfg.n_experts_shared,
                      cfg.expert_shared_d_ff, cfg.expert_weights_scale, (int) cfg.expert_weights_norm);
+    }
+
+    // gpt-oss: alternating attention — layer_types[] marks "sliding_attention"
+    // (window 128) on even layers, "full_attention" on odd. Uniform head_dim
+    // (64); the per-head sink logits + per-expert biases are tensor-level
+    // (weight_map.cpp). Router = topk-then-softmax (resolved in the MoE path).
+    if (cfg.arch == ModelArch::GPT_OSS) {
+        const JValue* lt = jobj_find(eff, "layer_types");
+        if (lt && lt->type == JType::ARRAY) {
+            cfg.swa_layers.clear();
+            cfg.swa_layers.reserve(lt->arr.size());
+            for (const auto& v : lt->arr)
+                cfg.swa_layers.push_back(v.str_val == "sliding_attention" ? 1 : 0);
+        }
+        if (cfg.sliding_window <= 0)
+            cfg.sliding_window = 128;
     }
 
     // Gemma 4: per-layer geometry. layer_types[] tells SWA vs global, and

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -314,6 +314,11 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
     if (!jobj_get_int(eff, "moe_intermediate_size", cfg.expert_d_ff)) {
         jobj_get_int(eff, "expert_intermediate_size", cfg.expert_d_ff);
     }
+    // gpt-oss: no separate MoE intermediate key — intermediate_size IS the
+    // per-expert FFN width (2880); there is no dense FFN at all.
+    if (cfg.expert_d_ff == 0 && cfg.n_experts > 0 && cfg.arch == ModelArch::GPT_OSS) {
+        cfg.expert_d_ff = cfg.d_ff;
+    }
 
     // Qwen3.5/3.6 GDN: linear-attention layer config. The HF config exposes
     // these as `linear_*` fields; we map them onto the existing ssm_*

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -195,10 +195,15 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
         float factor = 1.0f;
         jobj_get_float(*rope_scaling, "factor", factor);
 
+        // imp convention (matches the GGUF loader / rope_forward): rope_freq_scale
+        // stores the FACTOR (>1, e.g. 32); the kernel applies 1/factor itself.
+        // Storing 1/factor here double-inverted YaRN for gpt-oss (#547):
+        // interpolated dims rotated factor^2=1024x too fast and the mscale
+        // compensation flipped to 0.653 instead of 1.347.
         if (rope_type == "linear") {
-            cfg.rope_freq_scale = 1.0f / factor;
+            cfg.rope_freq_scale = factor;
         } else if (rope_type == "yarn") {
-            cfg.rope_freq_scale = 1.0f / factor;
+            cfg.rope_freq_scale = factor;
             jobj_get_float(*rope_scaling, "attn_factor", cfg.yarn_attn_factor);
             jobj_get_float(*rope_scaling, "beta_fast", cfg.yarn_beta_fast);
             jobj_get_float(*rope_scaling, "beta_slow", cfg.yarn_beta_slow);

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -136,7 +136,12 @@ static constexpr ArchEntry kArchRegistry[] = {
     // ewnorm=true: gpt-oss routes softmax-after-topk — selection on biased
     // logits + renormalized top-k softmax is exactly imp's norm_weights path
     // once the router bias is added to the logits (compute_moe_routing).
-    {ModelArch::GPT_OSS, "gpt_oss", kApiGptOss, 1, 0, 3 /*GPT_OSS_GLU*/, -1, false, true, 1.0f, 1.0f, 0},
+    // embed_scale=2^-4: residual-stream rescale — gpt-oss's massive BF16
+    // activations overflow the FP16 hidden state (±inf by L23). All other
+    // h-contributors (Wo, o_bias, expert down + bias) are scaled to match
+    // at load; RMSNorm scale-invariance makes the model output exact.
+    {ModelArch::GPT_OSS, "gpt_oss", kApiGptOss, 1, 0.0625f, 3 /*GPT_OSS_GLU*/, -1, false, true, 1.0f, 1.0f,
+     0},
     {ModelArch::GEMMA3, "gemma3", kApiGemma3, -1, 0, 1, 1, false, false, 0.6f, 0.95f, 0},
     {ModelArch::GEMMA4, "gemma4", kApiGemma4, -1, 0, 1, 1, false, true, 0.6f, 0.9f, 20},
     {ModelArch::LLAMA4, "llama4", kApiLlama4, 0, 0, -1, -1, false, false, 0.6f, 0.95f, 0},

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -116,6 +116,7 @@ enum {
     kApiQwen35Moe = 11,
     kApiGemma4 = 12,
     kApiQwen36Moe = 13,
+    kApiGptOss = 14,
 };
 
 static constexpr ArchEntry kArchRegistry[] = {
@@ -132,6 +133,7 @@ static constexpr ArchEntry kArchRegistry[] = {
     {ModelArch::QWEN35, "qwen35", kApiQwen35, -1, 0, -1, -1, false, false, 0.6f, 0.95f, 20},
     {ModelArch::QWEN35_MOE, "qwen35moe", kApiQwen35Moe, -1, 0, -1, -1, false, true, 0.6f, 0.95f, 20},
     {ModelArch::QWEN36_MOE, "qwen36moe", kApiQwen36Moe, -1, 0, -1, -1, false, true, 0.6f, 0.95f, 20},
+    {ModelArch::GPT_OSS, "gpt_oss", kApiGptOss, 1, 0, 3 /*GPT_OSS_GLU*/, -1, false, false, 1.0f, 1.0f, 0},
     {ModelArch::GEMMA3, "gemma3", kApiGemma3, -1, 0, 1, 1, false, false, 0.6f, 0.95f, 0},
     {ModelArch::GEMMA4, "gemma4", kApiGemma4, -1, 0, 1, 1, false, true, 0.6f, 0.9f, 20},
     {ModelArch::LLAMA4, "llama4", kApiLlama4, 0, 0, -1, -1, false, false, 0.6f, 0.95f, 0},
@@ -172,6 +174,8 @@ ModelArch parse_model_arch(const std::string& s) {
         {"qwen36moe", ModelArch::QWEN36_MOE},
         {"qwen3.6_moe", ModelArch::QWEN36_MOE},
         {"qwen3.6moe", ModelArch::QWEN36_MOE},
+        {"gpt_oss", ModelArch::GPT_OSS},
+        {"gpt-oss", ModelArch::GPT_OSS},
         {"gemma3", ModelArch::GEMMA3},
         {"gemma", ModelArch::GEMMA3},
         {"gemma2", ModelArch::GEMMA3},

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -133,7 +133,10 @@ static constexpr ArchEntry kArchRegistry[] = {
     {ModelArch::QWEN35, "qwen35", kApiQwen35, -1, 0, -1, -1, false, false, 0.6f, 0.95f, 20},
     {ModelArch::QWEN35_MOE, "qwen35moe", kApiQwen35Moe, -1, 0, -1, -1, false, true, 0.6f, 0.95f, 20},
     {ModelArch::QWEN36_MOE, "qwen36moe", kApiQwen36Moe, -1, 0, -1, -1, false, true, 0.6f, 0.95f, 20},
-    {ModelArch::GPT_OSS, "gpt_oss", kApiGptOss, 1, 0, 3 /*GPT_OSS_GLU*/, -1, false, false, 1.0f, 1.0f, 0},
+    // ewnorm=true: gpt-oss routes softmax-after-topk — selection on biased
+    // logits + renormalized top-k softmax is exactly imp's norm_weights path
+    // once the router bias is added to the logits (compute_moe_routing).
+    {ModelArch::GPT_OSS, "gpt_oss", kApiGptOss, 1, 0, 3 /*GPT_OSS_GLU*/, -1, false, true, 1.0f, 1.0f, 0},
     {ModelArch::GEMMA3, "gemma3", kApiGemma3, -1, 0, 1, 1, false, false, 0.6f, 0.95f, 0},
     {ModelArch::GEMMA4, "gemma4", kApiGemma4, -1, 0, 1, 1, false, true, 0.6f, 0.9f, 20},
     {ModelArch::LLAMA4, "llama4", kApiLlama4, 0, 0, -1, -1, false, false, 0.6f, 0.95f, 0},

--- a/src/model/model_arch.h
+++ b/src/model/model_arch.h
@@ -15,6 +15,7 @@ enum class ModelArch {
     QWEN35,
     QWEN35_MOE,
     QWEN36_MOE,
+    GPT_OSS,
     GEMMA3,
     GEMMA4,
     LLAMA4,

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -171,9 +171,15 @@ struct TransformerLayer {
     Tensor o_bias;                         // Output-projection bias (gpt-oss)
     Tensor attn_sinks;                     // Per-head sink logits [n_heads] (gpt-oss)
     Tensor router_bias;                    // Router logits bias [n_experts] (gpt-oss)
-    Tensor expert_gate_bias;               // Per-expert gate bias [ne, d_ff] (gpt-oss)
-    Tensor expert_up_bias;                 // Per-expert up bias [ne, d_ff] (gpt-oss)
+    Tensor expert_gate_bias;               // Per-expert gate bias [ne, d_ff] (gpt-oss, de-interleaved)
+    Tensor expert_up_bias;                 // Per-expert up bias [ne, d_ff] (gpt-oss, de-interleaved)
     Tensor expert_down_bias;               // Per-expert down bias [ne, d_model] (gpt-oss)
+    // gpt-oss raw checkpoint slots (HF MXFP4 layout, consumed at upload):
+    Tensor expert_gate_up_packed_blocks;   // U8 [ne, 2*d_ff, K/32, 16] e2m1, rows interleaved g0,u0,g1,...
+    Tensor expert_gate_up_packed_scales;   // U8 [ne, 2*d_ff, K/32] ue8m0
+    Tensor expert_gate_up_bias_fused;      // BF16 [ne, 2*d_ff] interleaved
+    Tensor expert_down_packed_blocks;      // U8 [ne, d_model, d_ff/32, 16]
+    Tensor expert_down_packed_scales;      // U8 [ne, d_model, d_ff/32]
     Tensor attn_q_norm, attn_k_norm;       // QK-norm (Qwen3-style per-head RMSNorm)
     Tensor post_attn_norm, post_ffn_norm;  // Post-layer norms (Gemma-3)
     // Gemma 4 extras

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -8,7 +8,9 @@
 namespace imp {
 
 // FFN activation function type
-enum class FFNActivation { SWIGLU, GEGLU, RELU_SQR };
+// GPT_OSS_GLU (gpt-oss): gate/up clamped to ±limit (gate only from above),
+// glu = gate·sigmoid(1.702·gate), out = (up + 1)·glu — plus per-expert biases.
+enum class FFNActivation { SWIGLU, GEGLU, RELU_SQR, GPT_OSS_GLU };
 
 // Norm placement relative to residual connection
 enum class NormPlacement { PRE_NORM, POST_NORM };
@@ -166,6 +168,12 @@ struct NvFP4PreQuantWeight {
 struct TransformerLayer {
     Tensor wq, wk, wv, wo, attn_norm;
     Tensor q_bias, k_bias, v_bias;         // Attention biases (Qwen2)
+    Tensor o_bias;                         // Output-projection bias (gpt-oss)
+    Tensor attn_sinks;                     // Per-head sink logits [n_heads] (gpt-oss)
+    Tensor router_bias;                    // Router logits bias [n_experts] (gpt-oss)
+    Tensor expert_gate_bias;               // Per-expert gate bias [ne, d_ff] (gpt-oss)
+    Tensor expert_up_bias;                 // Per-expert up bias [ne, d_ff] (gpt-oss)
+    Tensor expert_down_bias;               // Per-expert down bias [ne, d_model] (gpt-oss)
     Tensor attn_q_norm, attn_k_norm;       // QK-norm (Qwen3-style per-head RMSNorm)
     Tensor post_attn_norm, post_ffn_norm;  // Post-layer norms (Gemma-3)
     // Gemma 4 extras

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1343,6 +1343,46 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             "Inference may be incoherent.");
     }
 
+    // gpt-oss post-load pass (#547): de-interleave the fused gate_up expert
+    // bias (g0,u0,g1,u1,... along the column dim) into separate gate/up bias
+    // tensors so the standard per-projection bias plumbing applies. The
+    // packed MXFP4 expert weights stay host-mmap'd; the MXFP4→NVFP4
+    // conversion happens at executor pre-dequant (needs the executor's
+    // wcache). Host copies live in host_owned_buffers_ (freed in ~Model).
+    if (cfg.arch == ModelArch::GPT_OSS) {
+        for (auto& layer : model->layers_) {
+            const Tensor& fused = layer.expert_gate_up_bias_fused;
+            if (!fused.data || fused.ndim != 2)
+                continue;
+            const int64_t ne = fused.shape[0];
+            const int64_t two_ff = fused.shape[1];
+            const int64_t ff = two_ff / 2;
+            const uint16_t* src = static_cast<const uint16_t*>(fused.data);  // BF16
+            auto* g = static_cast<uint16_t*>(std::malloc(sizeof(uint16_t) * ne * ff));
+            auto* u = static_cast<uint16_t*>(std::malloc(sizeof(uint16_t) * ne * ff));
+            if (!g || !u) {
+                std::free(g);
+                std::free(u);
+                IMP_LOG_ERROR("gpt-oss: bias de-interleave alloc failed");
+                return nullptr;
+            }
+            for (int64_t e = 0; e < ne; e++) {
+                const uint16_t* row = src + e * two_ff;
+                for (int64_t i = 0; i < ff; i++) {
+                    g[e * ff + i] = row[2 * i];
+                    u[e * ff + i] = row[2 * i + 1];
+                }
+            }
+            model->host_owned_buffers_.push_back(g);
+            model->host_owned_buffers_.push_back(u);
+            int64_t bshape[4] = {ne, ff, 0, 0};
+            layer.expert_gate_bias = Tensor(g, QType::BF16, 2, bshape, /*on_device=*/false);
+            layer.expert_up_bias = Tensor(u, QType::BF16, 2, bshape, /*on_device=*/false);
+        }
+        IMP_LOG_INFO("gpt-oss: expert gate_up biases de-interleaved for %zu layers",
+                     model->layers_.size());
+    }
+
     IMP_LOG_INFO("SafeTensors model loaded successfully from %s", path.c_str());
     return model;
 }

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1381,6 +1381,53 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         }
         IMP_LOG_INFO("gpt-oss: expert gate_up biases de-interleaved for %zu layers",
                      model->layers_.size());
+
+        // Residual-stream 2^-4 rescale (#547): gpt-oss's massive BF16
+        // activations overflow the FP16 hidden state (hidden L2 jumps ~12x at
+        // L6 and reaches ±inf by L23 → NaN logits + garbage decode). Scaling
+        // every contributor to h by 2^-4 is exact for the model output: FP16
+        // scaling is an exponent shift (lossless), RMSNorm is scale-invariant,
+        // and lm_head reads only normed values. Contributors:
+        //   - embeddings: cfg.embed_scale = 2^-4 (arch registry)
+        //   - Wo + o_bias + expert down bias: scaled here (host BF16)
+        //   - expert down weights: tensor_scales inside the MXFP4→NVFP4
+        //     converter (pre_dequant_phase3_nvfp4_decode.cu)
+        auto scale_bf16_pow2 = [&](Tensor& t, int neg_exp) -> bool {
+            if (!t.data || t.on_device)
+                return true;
+            if (t.qtype != QType::BF16) {
+                IMP_LOG_ERROR("gpt-oss rescale: expected BF16, got qtype %d", (int)t.qtype);
+                return false;
+            }
+            int64_t n = t.numel();
+            auto* dst = static_cast<uint16_t*>(std::malloc(sizeof(uint16_t) * n));
+            if (!dst)
+                return false;
+            const uint16_t* src = static_cast<const uint16_t*>(t.data);
+            for (int64_t i = 0; i < n; i++) {
+                uint16_t v = src[i];
+                int exp = (v >> 7) & 0xFF;
+                if (exp == 0xFF || exp == 0)
+                    dst[i] = v;  // inf/nan/zero/subnormal: keep as-is
+                else if (exp <= neg_exp)
+                    dst[i] = static_cast<uint16_t>(v & 0x8000);  // underflow → signed zero
+                else
+                    dst[i] = static_cast<uint16_t>(v - (neg_exp << 7));
+            }
+            model->host_owned_buffers_.push_back(dst);
+            t.data = dst;
+            return true;
+        };
+        bool rescale_ok = true;
+        for (auto& layer : model->layers_) {
+            rescale_ok = rescale_ok && scale_bf16_pow2(layer.wo, 4) &&
+                         scale_bf16_pow2(layer.o_bias, 4) && scale_bf16_pow2(layer.expert_down_bias, 4);
+        }
+        if (!rescale_ok) {
+            IMP_LOG_ERROR("gpt-oss: residual-stream rescale failed");
+            return nullptr;
+        }
+        IMP_LOG_INFO("gpt-oss: residual stream rescaled by 2^-4 (FP16 range headroom)");
     }
 
     IMP_LOG_INFO("SafeTensors model loaded successfully from %s", path.c_str());

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -187,7 +187,7 @@ std::string WeightMap::map_name(const std::string& name) const {
                 return prefix + "w_down_shared";
         }
 
-        // Attention biases: self_attn.{q,k,v}_proj.bias
+        // Attention biases: self_attn.{q,k,v,o}_proj.bias
         if (parts.size() >= 6 && parts[3] == "self_attn" && parts[5] == "bias") {
             if (parts[4] == "q_proj")
                 return prefix + "q_bias";
@@ -195,6 +195,27 @@ std::string WeightMap::map_name(const std::string& name) const {
                 return prefix + "k_bias";
             if (parts[4] == "v_proj")
                 return prefix + "v_bias";
+            if (parts[4] == "o_proj")
+                return prefix + "o_bias";
+        }
+
+        // gpt-oss attention sinks: self_attn.sinks [n_heads]
+        if (parts.size() >= 5 && parts[3] == "self_attn" && parts[4] == "sinks") {
+            return prefix + "attn_sinks";
+        }
+
+        // gpt-oss MoE router: mlp.router.{weight,bias}
+        if (parts.size() >= 6 && parts[3] == "mlp" && parts[4] == "router") {
+            if (parts[5] == "weight")
+                return prefix + "moe_gate";
+            if (parts[5] == "bias")
+                return prefix + "moe_router_bias";
+        }
+
+        // gpt-oss pre-packed MXFP4 experts:
+        //   mlp.experts.{gate_up,down}_proj_{blocks,scales,bias}
+        if (parts.size() >= 6 && parts[3] == "mlp" && parts[4] == "experts") {
+            return prefix + "experts." + parts[5];
         }
 
         // QK-Norm: self_attn.{q,k}_norm.weight
@@ -914,6 +935,51 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
                 matched = true;
             } else if (proj == "v_proj") {
                 layer.v_bias = t;
+                matched = true;
+            } else if (proj == "o_proj") {
+                layer.o_bias = t;
+                matched = true;
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // gpt-oss: attention sinks, router (weight+bias), pre-packed MXFP4
+        // experts. Blocks/scales land in the *_packed slots verbatim; the
+        // upload stage converts them to the NVFP4 expert cache (e2m1 nibbles
+        // are bit-identical, ue8m0 scales convert to e4m3 + tensor scale).
+        // -----------------------------------------------------------------
+        if (!matched && parts.size() >= 5 && parts[3] == "self_attn" && parts[4] == "sinks") {
+            layer.attn_sinks = t;
+            matched = true;
+        }
+        if (!matched && parts.size() >= 6 && parts[3] == "mlp" && parts[4] == "router") {
+            if (parts[5] == "weight") {
+                layer.moe_gate = t;
+                matched = true;
+            } else if (parts[5] == "bias") {
+                layer.router_bias = t;
+                matched = true;
+            }
+        }
+        if (!matched && parts.size() >= 6 && parts[3] == "mlp" && parts[4] == "experts") {
+            const std::string& field = parts[5];
+            if (field == "gate_up_proj_blocks") {
+                layer.expert_gate_up_packed_blocks = t;
+                matched = true;
+            } else if (field == "gate_up_proj_scales") {
+                layer.expert_gate_up_packed_scales = t;
+                matched = true;
+            } else if (field == "gate_up_proj_bias") {
+                layer.expert_gate_up_bias_fused = t;
+                matched = true;
+            } else if (field == "down_proj_blocks") {
+                layer.expert_down_packed_blocks = t;
+                matched = true;
+            } else if (field == "down_proj_scales") {
+                layer.expert_down_packed_scales = t;
+                matched = true;
+            } else if (field == "down_proj_bias") {
+                layer.expert_down_bias = t;
                 matched = true;
             }
         }

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1121,7 +1121,8 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i, const Upl
     }
 
     // Attention biases (Qwen2-style Q/K/V biases, F32)
-    for (auto* bias : {&L.q_bias, &L.k_bias, &L.v_bias}) {
+    for (auto* bias : {&L.q_bias, &L.k_bias, &L.v_bias, &L.o_bias, &L.attn_sinks, &L.router_bias,
+                       &L.expert_gate_bias, &L.expert_up_bias, &L.expert_down_bias}) {
         if (bias->data && !bias->on_device) {
             if (!upload_unquantized_weight(*bias, QType::NONE, ctx.compute_dtype, ctx.stream,
                                            ctx.gpu_allocs)) {

--- a/src/quant/gpt_oss_mxfp4_convert.cu
+++ b/src/quant/gpt_oss_mxfp4_convert.cu
@@ -12,7 +12,7 @@ namespace imp {
 
 bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_scales, int ne,
                                       int64_t n_rows_total, int64_t K, int row_offset, int row_stride,
-                                      NvFP4MoEQuantResult& out) {
+                                      NvFP4MoEQuantResult& out, float extra_scale) {
     const int64_t N = n_rows_total / row_stride;  // rows per expert in the output
     const int64_t kb32 = K / 32;                  // MXFP4 blocks per row
     const int64_t row_bytes = K / 2;              // packed nibbles per row
@@ -36,7 +36,7 @@ bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_
                 max_u = std::max(max_u, static_cast<int>(sr[b]));
         }
         const int ts_exp = max_u - 127 - 8;
-        tscales[e] = std::ldexp(1.0f, ts_exp);
+        tscales[e] = std::ldexp(1.0f, ts_exp) * extra_scale;
 
         // Pass 2: nibbles copy + scale expansion.
         const uint8_t* eb_base = h_blocks + static_cast<size_t>(e) * n_rows_total * row_bytes;

--- a/src/quant/gpt_oss_mxfp4_convert.cu
+++ b/src/quant/gpt_oss_mxfp4_convert.cu
@@ -1,0 +1,109 @@
+#include "quant/gpt_oss_mxfp4_convert.h"
+#include "core/logging.h"
+
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+namespace imp {
+
+bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_scales, int ne,
+                                      int64_t n_rows_total, int64_t K, int row_offset, int row_stride,
+                                      NvFP4MoEQuantResult& out) {
+    const int64_t N = n_rows_total / row_stride;  // rows per expert in the output
+    const int64_t kb32 = K / 32;                  // MXFP4 blocks per row
+    const int64_t row_bytes = K / 2;              // packed nibbles per row
+    const int64_t ms_per_row = K / 16;            // NVFP4 micro-scales per row
+
+    std::vector<uint8_t> packed(static_cast<size_t>(ne) * N * row_bytes);
+    std::vector<uint8_t> mscales(static_cast<size_t>(ne) * N * ms_per_row);
+    std::vector<float> tscales(ne, 1.0f);
+
+    int clamped_lo = 0, clamped_hi = 0;
+    for (int e = 0; e < ne; e++) {
+        // Pass 1: per-expert max ue8m0 exponent → tensor scale.
+        // tensor_scale = 2^(max_u - 127 - 8): the largest block scale maps to
+        // e4m3 value 2^8 = 256 (≤ 448), leaving e4m3's ~18 octaves of range
+        // downwards (min subnormal 2^-9 → covers blocks within 2^17 of max).
+        int max_u = 0;
+        const uint8_t* es_base = h_scales + static_cast<size_t>(e) * n_rows_total * kb32;
+        for (int64_t r = 0; r < N; r++) {
+            const uint8_t* sr = es_base + static_cast<size_t>(row_offset + r * row_stride) * kb32;
+            for (int64_t b = 0; b < kb32; b++)
+                max_u = std::max(max_u, static_cast<int>(sr[b]));
+        }
+        const int ts_exp = max_u - 127 - 8;
+        tscales[e] = std::ldexp(1.0f, ts_exp);
+
+        // Pass 2: nibbles copy + scale expansion.
+        const uint8_t* eb_base = h_blocks + static_cast<size_t>(e) * n_rows_total * row_bytes;
+        uint8_t* op = packed.data() + static_cast<size_t>(e) * N * row_bytes;
+        uint8_t* om = mscales.data() + static_cast<size_t>(e) * N * ms_per_row;
+        for (int64_t r = 0; r < N; r++) {
+            const int64_t src_row = row_offset + r * row_stride;
+            std::memcpy(op + r * row_bytes, eb_base + static_cast<size_t>(src_row) * row_bytes,
+                        static_cast<size_t>(row_bytes));
+            const uint8_t* sr = es_base + static_cast<size_t>(src_row) * kb32;
+            uint8_t* mr = om + r * ms_per_row;
+            for (int64_t b = 0; b < kb32; b++) {
+                // block scale (absolute) = 2^(u-127); stored e4m3 = scale / ts
+                float rel = std::ldexp(1.0f, static_cast<int>(sr[b]) - 127 - ts_exp);
+                if (rel > 448.0f) {
+                    rel = 448.0f;
+                    clamped_hi++;
+                } else if (rel > 0.0f && rel < 0.001953125f) {  // < 2^-9 (e4m3 min subnormal)
+                    rel = 0.001953125f;
+                    clamped_lo++;
+                }
+                __nv_fp8_e4m3 f8 = __nv_fp8_e4m3(rel);
+                uint8_t byte;
+                std::memcpy(&byte, &f8, 1);
+                mr[2 * b] = byte;
+                mr[2 * b + 1] = byte;  // one 32-block scale covers two 16-blocks
+            }
+        }
+    }
+    if (clamped_lo || clamped_hi)
+        IMP_LOG_WARN("gpt-oss MXFP4→NVFP4: %d block scales clamped low, %d high (range loss)", clamped_lo,
+                     clamped_hi);
+
+    // Device upload.
+    void* d_packed = nullptr;
+    void* d_ms = nullptr;
+    float* d_ts = nullptr;
+    if (cudaMalloc(&d_packed, packed.size()) != cudaSuccess)
+        return false;
+    if (cudaMalloc(&d_ms, mscales.size()) != cudaSuccess) {
+        cudaFree(d_packed);
+        return false;
+    }
+    if (cudaMalloc(&d_ts, sizeof(float) * ne) != cudaSuccess) {
+        cudaFree(d_packed);
+        cudaFree(d_ms);
+        return false;
+    }
+    if (cudaMemcpy(d_packed, packed.data(), packed.size(), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_ms, mscales.data(), mscales.size(), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_ts, tscales.data(), sizeof(float) * ne, cudaMemcpyHostToDevice) != cudaSuccess) {
+        cudaFree(d_packed);
+        cudaFree(d_ms);
+        cudaFree(d_ts);
+        return false;
+    }
+
+    out.packed_data = d_packed;
+    out.micro_scales = d_ms;
+    out.tensor_scales = d_ts;
+    out.n_experts = ne;
+    out.N = N;
+    out.K = K;
+    out.expert_stride_packed = static_cast<size_t>(N) * row_bytes;
+    out.expert_stride_ms = static_cast<size_t>(N) * ms_per_row;
+    out.borrowed = false;
+    return true;
+}
+
+}  // namespace imp

--- a/src/quant/gpt_oss_mxfp4_convert.h
+++ b/src/quant/gpt_oss_mxfp4_convert.h
@@ -25,9 +25,11 @@ namespace imp {
 // ue8m0 scales (host memory) into a device NvFP4MoEQuantResult.
 // row_stride/row_offset select interleaved sub-matrices:
 //   gate: offset 0, stride 2;  up: offset 1, stride 2;  down: offset 0, stride 1.
-// Returns false on allocation failure.
+// extra_scale folds a constant into the per-expert tensor scale — used for the
+// gpt-oss residual-stream 2^-4 rescale on the down projection (see the arch
+// registry comment in model.cpp). Returns false on allocation failure.
 bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_scales, int ne,
                                       int64_t n_rows_total, int64_t K, int row_offset, int row_stride,
-                                      NvFP4MoEQuantResult& out);
+                                      NvFP4MoEQuantResult& out, float extra_scale = 1.0f);
 
 }  // namespace imp

--- a/src/quant/gpt_oss_mxfp4_convert.h
+++ b/src/quant/gpt_oss_mxfp4_convert.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// gpt-oss checkpoint conversion (issue #547): HF-MXFP4 packed experts →
+// imp's native NVFP4 MoE cache (NvFP4MoEQuantResult).
+//
+// Why this works losslessly on the nibbles: both formats store e2m1 4-bit
+// values in linear pair order (element 2i = low nibble of byte i — verified
+// against transformers' integrations/mxfp4.py unpack and imp's split-layout
+// dequant). Only the SCALES differ: MXFP4 = ue8m0 per 32 elements,
+// NVFP4 = e4m3 per 16 elements + one FP32 tensor scale per expert. Each
+// ue8m0 scale expands to two identical e4m3 micro-scales; the per-expert
+// tensor scale normalizes the ue8m0 range into e4m3's dynamic range
+// (clamped + logged on the rare out-of-range block).
+//
+// gate_up arrives row-INTERLEAVED (g0,u0,g1,u1,… along N — HF slices the
+// output ::2/1::2); the converter de-interleaves into separate gate and up
+// results so imp's standard MoE machinery applies unchanged.
+
+#include "quant/nvfp4_quant.h"
+#include <cstdint>
+
+namespace imp {
+
+// Convert one packed projection [ne, N, K/32, 16] blocks + [ne, N, K/32]
+// ue8m0 scales (host memory) into a device NvFP4MoEQuantResult.
+// row_stride/row_offset select interleaved sub-matrices:
+//   gate: offset 0, stride 2;  up: offset 1, stride 2;  down: offset 0, stride 1.
+// Returns false on allocation failure.
+bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_scales, int ne,
+                                      int64_t n_rows_total, int64_t K, int row_offset, int row_stride,
+                                      NvFP4MoEQuantResult& out);
+
+}  // namespace imp

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -146,8 +146,14 @@ void Engine::build_banned_token_list() {
     }
     for (int32_t sid : chat_template_.stop_token_ids()) keep_ids.push_back(sid);
     if (tok) {
+        // Harmony (gpt-oss, #547): the model is TRAINED to emit its own
+        // structure tokens (<|channel|>analysis<|message|>...<|end|>
+        // <|start|>assistant<|channel|>final<|message|>...). Banning them
+        // traps generation in an endless analysis channel.
         for (const char* name : {"<think>", "</think>", "<|think|>", "<|/think|>",
-                                  "<|channel>", "<channel|>"}) {
+                                  "<|channel>", "<channel|>",
+                                  "<|channel|>", "<|message|>", "<|start|>", "<|end|>",
+                                  "<|constrain|>"}) {
             int32_t tid = tok->find_token(name);
             if (tid >= 0) keep_ids.push_back(tid);
         }

--- a/tests/test_paged_attention.cu
+++ b/tests/test_paged_attention.cu
@@ -670,6 +670,136 @@ TEST(PagedAttentionTest, GQALongContext) {
 }
 
 // =========================================================================
+// gpt-oss decode shape (#547): split-K + hd=64 + GQA 8:1 (+ learned sinks).
+// The split-K branch only activates when scratch is set — none of the older
+// tests set it, so the hd=64 split-K path was never covered (gpt-oss is the
+// first hd=64 model; the rest of the zoo is hd>=128).
+// =========================================================================
+
+void run_gptoss_shape_splitk_case(bool with_sinks) {
+    constexpr int batch = 1, n_heads = 64, n_kv_heads = 8, head_dim = 64;
+    constexpr int seq_len = 256;  // 16 blocks >= 8 → split-K heuristics fire
+    constexpr int num_blocks = (seq_len + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    constexpr int max_blocks = num_blocks;
+    const float scale = 1.0f / sqrtf(static_cast<float>(head_dim));
+
+    std::vector<float> h_Q(n_heads * head_dim);
+    for (size_t i = 0; i < h_Q.size(); i++)
+        h_Q[i] = sinf(static_cast<float>(i) * 0.013f);
+    std::vector<float> h_K(seq_len * n_kv_heads * head_dim);
+    std::vector<float> h_V(seq_len * n_kv_heads * head_dim);
+    for (size_t i = 0; i < h_K.size(); i++) {
+        h_K[i] = cosf(static_cast<float>(i) * 0.007f);
+        h_V[i] = sinf(static_cast<float>(i) * 0.011f + 0.5f);
+    }
+    std::vector<float> h_sinks(n_heads);
+    for (int h = 0; h < n_heads; h++)
+        h_sinks[h] = -1.0f + 0.05f * static_cast<float>(h);  // mix of weak/strong sinks
+
+    // CPU reference: softmax over [scores, sink]; sink column dropped.
+    std::vector<float> h_O(n_heads * head_dim, 0.0f);
+    for (int qh = 0; qh < n_heads; qh++) {
+        int kvh = qh / (n_heads / n_kv_heads);
+        std::vector<float> scores(seq_len);
+        float m = with_sinks ? h_sinks[qh] : -FLT_MAX;
+        for (int s = 0; s < seq_len; s++) {
+            float dot = 0.0f;
+            for (int d = 0; d < head_dim; d++)
+                dot += h_Q[qh * head_dim + d] * h_K[(s * n_kv_heads + kvh) * head_dim + d];
+            scores[s] = dot * scale;
+            m = std::max(m, scores[s]);
+        }
+        float denom = with_sinks ? expf(h_sinks[qh] - m) : 0.0f;
+        for (int s = 0; s < seq_len; s++)
+            denom += expf(scores[s] - m);
+        for (int d = 0; d < head_dim; d++) {
+            float acc = 0.0f;
+            for (int s = 0; s < seq_len; s++)
+                acc += expf(scores[s] - m) / denom * h_V[(s * n_kv_heads + kvh) * head_dim + d];
+            h_O[qh * head_dim + d] = acc;
+        }
+    }
+
+    std::vector<int> bt(num_blocks);
+    std::iota(bt.begin(), bt.end(), 0);
+    int total_cache_elems = num_blocks * BLOCK_SIZE * n_kv_heads * head_dim;
+    std::vector<float> h_K_cache(total_cache_elems, 0.0f);
+    std::vector<float> h_V_cache(total_cache_elems, 0.0f);
+    // Direct layout copy: cache[blk][slot][kvh][d] = K[s][kvh][d]
+    for (int s = 0; s < seq_len; s++) {
+        int blk = s / BLOCK_SIZE, slot = s % BLOCK_SIZE;
+        for (int h = 0; h < n_kv_heads; h++)
+            for (int d = 0; d < head_dim; d++) {
+                int dst = ((blk * BLOCK_SIZE + slot) * n_kv_heads + h) * head_dim + d;
+                int src = (s * n_kv_heads + h) * head_dim + d;
+                h_K_cache[dst] = h_K[src];
+                h_V_cache[dst] = h_V[src];
+            }
+    }
+
+    Tensor d_Q = make_gpu_tensor_fp16(h_Q.data(), {batch, 1, n_heads, head_dim});
+    Tensor d_K = make_gpu_tensor_fp16(h_K_cache.data(), {num_blocks, BLOCK_SIZE, n_kv_heads, head_dim});
+    Tensor d_V = make_gpu_tensor_fp16(h_V_cache.data(), {num_blocks, BLOCK_SIZE, n_kv_heads, head_dim});
+    Tensor d_O = alloc_gpu_tensor_fp16({batch, 1, n_heads, head_dim});
+
+    int* d_bt = nullptr;
+    int* d_ctx = nullptr;
+    cudaMalloc(&d_bt, max_blocks * sizeof(int));
+    cudaMalloc(&d_ctx, sizeof(int));
+    cudaMemcpy(d_bt, bt.data(), max_blocks * sizeof(int), cudaMemcpyHostToDevice);
+    int ctx = seq_len;
+    cudaMemcpy(d_ctx, &ctx, sizeof(int), cudaMemcpyHostToDevice);
+
+    // Force split-K: provide scratch (64 blocks < 2*SMs on any modern GPU).
+    constexpr int kMaxSplits = 64;
+    size_t scratch_size = static_cast<size_t>(batch) * n_heads * kMaxSplits * (2 + head_dim) * sizeof(float);
+    void* d_scratch = nullptr;
+    cudaMalloc(&d_scratch, scratch_size);
+    paged_attention_set_splitk_scratch(d_scratch, scratch_size);
+
+    half* d_sinks = nullptr;
+    if (with_sinks) {
+        std::vector<half> hs(n_heads);
+        for (int h = 0; h < n_heads; h++)
+            hs[h] = __float2half(h_sinks[h]);
+        cudaMalloc(&d_sinks, n_heads * sizeof(half));
+        cudaMemcpy(d_sinks, hs.data(), n_heads * sizeof(half), cudaMemcpyHostToDevice);
+    }
+
+    paged_attention_decode(d_Q, d_K, d_V, d_O, d_bt, d_ctx, BLOCK_SIZE, scale, seq_len,
+                           /*sliding_window=*/0, /*softcap=*/0.0f, /*stream=*/nullptr,
+                           /*max_blocks_per_seq=*/max_blocks, /*n_sinks=*/0, d_sinks);
+    cudaDeviceSynchronize();
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    auto result = read_gpu_fp16(d_O);
+    double max_err = 0.0;
+    for (int qh = 0; qh < n_heads; qh++) {
+        for (int d = 0; d < head_dim; d++) {
+            int idx = qh * head_dim + d;
+            max_err = std::max(max_err, static_cast<double>(std::abs(result[idx] - h_O[idx])));
+            EXPECT_NEAR(result[idx], h_O[idx], 0.05f)
+                << "split-K hd64 mismatch at Q-head " << qh << " dim " << d
+                << " (with_sinks=" << with_sinks << ")";
+        }
+    }
+
+    paged_attention_set_splitk_scratch(nullptr, 0);
+    cudaFree(d_scratch);
+    if (d_sinks)
+        cudaFree(d_sinks);
+    free_gpu(d_Q);
+    free_gpu(d_K);
+    free_gpu(d_V);
+    free_gpu(d_O);
+    cudaFree(d_bt);
+    cudaFree(d_ctx);
+}
+
+TEST(PagedAttentionTest, GQA_SplitK_HD64) { run_gptoss_shape_splitk_case(/*with_sinks=*/false); }
+TEST(PagedAttentionTest, GQA_SplitK_HD64_Sinks) { run_gptoss_shape_splitk_case(/*with_sinks=*/true); }
+
+// =========================================================================
 // GQA with HD=256: exercises split-K and cluster paths for Gemma-3 config
 // =========================================================================
 


### PR DESCRIPTION
Implements gpt-oss-20b (SafeTensors MXFP4) support — issue #547.

## Architecture (GPT_OSS, arch id 14)
- HF config mapping (GptOssForCausalLM): YaRN(32x), per-layer SWA-128 (even layers), 64q/8kv heads @ hd=64, 32-expert top-4 MoE, attention sinks, q/k/v/o biases, untied lm_head.
- Weight map: `self_attn.sinks`, `mlp.router.{weight,bias}`, packed MXFP4 expert `gate_up/down_proj_{blocks,scales,bias}`, o_bias. 459/459 tensors assigned; fused gate_up bias de-interleaved at load.

## MXFP4 -> NVFP4 expert conversion (`src/quant/gpt_oss_mxfp4_convert.cu`)
Nibbles are bit-identical (both e2m1 linear pair order); only scales convert: 1 ue8m0 -> 2 e4m3 micro-scales + per-expert FP32 tensor scale `2^(max_u-127-8)` (exact powers of two, zero loss; clamps logged, none fire on the 20b checkpoint). gate_up rows are interleaved (g0,u0,g1,...) and de-interleaved during conversion. Both MoE paths consume the result: batch-prefill dequant GEMM + decode GEMVs.

## Forward specifics
- **Router**: true linear bias on the logits (`moe_add_logit_bias`) *before* top-k — affects selection AND weights (deliberately distinct from DeepSeek's selection-only `score_bias`); registry `expert_weights_norm=true` makes imp's renormalized top-k softmax exactly HF's topk->softmax.
- **Clamped GLU** (`gpt_oss_glu`): `gate<=7`, `up in [-7,7]`, `(up+1) * gate * sigmoid(1.702*gate)`.
- **Per-expert biases**: indexed kernel (decode, via expert_indices) + sorted kernel (prefill, binary search over expert_offsets).
- **Attention sinks**: virtual extra softmax column (denominator += `exp(sink-max)`, column dropped) in the cuBLAS prefill softmax kernels and the paged decode kernels (GQA, cluster via `crosswarp_reduce_and_write`, split-K reduce). Prefill routing forces cuBLAS when sinks are present.
- **o_bias** after Wo+residual (same seam as the LoRA O hook).

## Bugs found & fixed (all latent, gpt-oss was the first model to hit them)
1. **HF `rope_freq_scale` convention inverted** (`hf_config_loader`): imp stores the FACTOR (GGUF convention, kernel applies 1/factor); the HF loader stored 1/factor -> YaRN interpolated dims rotated factor^2=1024x too fast, mscale 0.653 instead of 1.347. This was the dominant quality bug: PPL 104 -> 7.7 (HF BF16 reference: 6.71 on the same corpus).
2. **FP16 residual overflow**: gpt-oss's massive activations reach |h| > 65504 by L23 (hidden L2 trace matches HF: ~42k jump at L7) -> inf/NaN logits. Fix: exact 2^-4 residual rescale (embeddings via `embed_scale`, Wo/o_bias/down_bias host-scaled, expert-down via converter tensor_scales). FP16 power-of-two scaling is an exponent shift (lossless); RMSNorm scale-invariance keeps the model output mathematically identical — verified by unchanged PPL, minus the inf/NaN class.
3. **Split-K paged attention hd=64 misaligned cp.async**: `cp_async_ca_8` from `lane_offset = lane*2 halves` (4-byte aligned) raises `cudaErrorMisalignedAddress` for ELEMS==2. New `cp_async_ca_4` + ELEMS-gated selection. Whole zoo is hd>=128, so this never fired before. New unit tests `PagedAttentionTest.GQA_SplitK_HD64{,_Sinks}` (split-K was previously never activated in tests — no scratch).
4. **Fused rope-KV decode path ignores YaRN**: `rope_q_only_fp16_kernel`/`write_kv_cache_rope_fused_kernel` know only theta+scale -> decode-written K was plain-RoPE while prefill K was YaRN-correct -> degeneration from token 2. YaRN models now take the separate full-rope path.
5. **`swa_layers` was honored only for GEMMA4** -> gpt-oss would have gotten SWA-128 on all 24 layers instead of even ones.
6. **`force_cublas_decode` debug arm broke SWA** (causal=false/q_offset=0 never triggers the window mask) — now causal=true @ q_offset=ctx-1 + sinks pass-through, keeping it a faithful reference.

## Harmony chat template
New `HARMONY` family ( `<|start|>role<|message|>...<|end|>`, system turn with channel contract, user `system` -> developer role, assistant history as final channel). Detected via `<|channel|>` before the Phi `<|end|>` check. Stops: `<|return|>` + `<|call|>` — `<|end|>` deliberately NOT a stop (separates analysis from final). The banned-token list now keeps the Harmony structure tokens (the model is trained to emit them; banning trapped generation in an endless analysis channel). imp's mini-Jinja renders the shipped `chat_template.jinja` correctly as well.

## Validation
- Teacher-forced PPL 7.67 vs HF transformers BF16-dequant CPU reference 6.71 (same corpus, same tokens; engine-class delta).
- Greedy + sampled chat produce clean Harmony output: `<|channel|>analysis<|message|>...<|end|><|start|>assistant<|channel|>final<|message|>The capital of France is **Paris**.`
- 220-token decode crosses the SWA-128 boundary coherently, graphs ON == OFF behavior.
- Regression: Qwen3-8B Q8 tg 275 tok/s (baseline 268), pp 8437; "17+25 -> 42"; gemma-3-12b SWA "Paris" — all clean. `verify-fast` gtest filter PASS.

## Follow-up (tracked in #547)
Server-side Harmony channel split (analysis -> `reasoning_content`, final -> `content`) — the existing think-machinery is `<think>`-token based; gpt-oss needs the `<|end|>`-separator variant + header stripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
