### PR TITLE
docs: gpt-oss-20b in supported models + benchmarks (tg256=345)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -46,6 +46,13 @@ prequant (Model Optimizer / llm-compressor exports), command pattern
 | Qwen3.6-35B-A3B | 35B (3B) | 245 |
 | Gemma-4-26B-A4B | 26B (4B) | 259 |
 | Nemotron-3-Nano-30B | 30B (3B) | 126 |
+| gpt-oss-20b¹ | 21B (3.6B) | 345 |
+
+¹ 2026-06-06, commit `85189b15` (PR #572): SafeTensors MXFP4 source, experts
+converted to the NVFP4 decode cache at load (bit-exact nibbles, power-of-two
+scales). Prefill runs the NVFP4→FP16 batch-dequant path + cuBLAS attention
+(attention sinks) — pp512 ≈ 1.9k tok/s, structurally below the CUTLASS
+grouped-GEMM models.
 
 On `sm_120`, native-NVFP4 decode is effectively uncontested (vLLM gates its
 NVFP4 path on `tcgen05`/falls back to Marlin on the 5090; llama.cpp has no

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ CLI reference, server flags, config, and C API: [`docs/usage.md`](docs/usage.md)
 | Gemma-4 | 26B-A4B MoE, 31B dense | Q4_K_M, Q5_K_M, Q8_0, NVFP4 |
 | Gemma-3 | text + vision (SigLIP) | GGUF |
 | Phi-4-reasoning-plus | dense, fused projections | NVFP4 |
+| gpt-oss-20b | MoE (32 experts, top-4), Harmony | SafeTensors MXFP4 (native) |
 | Nemotron-H | Mamba2 + Attention + MoE | NVFP4, GGUF |
 | Llama / Mistral / DeepSeek | dense + MoE | GGUF (Q*_K, Q8_0) |
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -46,6 +46,7 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 163 | SafeTensors (Modelopt) |
 | [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 47 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited |
 | [Nemotron-Labs-3-Elastic-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4) | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
+| [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 1.9k tok/s (batch-dequant + cuBLAS-attention path). |
 
 ## Vision
 


### PR DESCRIPTION
Adds gpt-oss-20b (PR #572) to README family table, BENCHMARKS.md NVFP4 decode table, and docs/supported-models.md.

Measured 2026-06-06 on merged main (`85189b15`), `imp-cli --bench`, CUBLAS_WORKSPACE_CONFIG=:4096:8:
- **tg256 = 345 tok/s** — fastest model in the zoo (21B total / 3.6B active, NVFP4 expert decode cache)
- pp512 ≈ 1.9k tok/s (structural: NVFP4→FP16 batch-dequant prefill + forced cuBLAS attention for sinks — noted in the docs)
- Peak VRAM ~15 GB weights (+KV/workspaces)

Per-model notes: Harmony channel split, temperature-1.0 recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
