### PR TITLE
perf(gpt-oss): CUTLASS grouped-GEMM prefill — pp512 1.9k → 16-19k tok/s (~10x)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -48,11 +48,11 @@ prequant (Model Optimizer / llm-compressor exports), command pattern
 | Nemotron-3-Nano-30B | 30B (3B) | 126 |
 | gpt-oss-20b¹ | 21B (3.6B) | 345 |
 
-¹ 2026-06-06, commit `85189b15` (PR #572): SafeTensors MXFP4 source, experts
-converted to the NVFP4 decode cache at load (bit-exact nibbles, power-of-two
-scales). Prefill runs the NVFP4→FP16 batch-dequant path + cuBLAS attention
-(attention sinks) — pp512 ≈ 1.9k tok/s, structurally below the CUTLASS
-grouped-GEMM models.
+¹ 2026-06-06 (PRs #572/#574): SafeTensors MXFP4 source, experts converted to
+NVFP4 at load (bit-exact nibbles, power-of-two scales) and registered for the
+CUTLASS grouped-GEMM prefill — pp512 ≈ 16-19k tok/s. Attention stays on the
+cuBLAS path (attention sinks). Decode measured 310-345 depending on host state
+(documented day-to-day variance).
 
 On `sm_120`, native-NVFP4 decode is effectively uncontested (vLLM gates its
 NVFP4 path on `tcgen05`/falls back to Marlin on the 5090; llama.cpp has no

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -46,7 +46,7 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 163 | SafeTensors (Modelopt) |
 | [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 47 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited |
 | [Nemotron-Labs-3-Elastic-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4) | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
-| [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 1.9k tok/s (batch-dequant + cuBLAS-attention path). |
+| [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
 
 ## Vision
 

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -348,6 +348,10 @@ bool GraphExecutor::moe_cutlass3x_will_use_device_args_(int layer,
                                                         const MoeFfnContext& ctx) const {
     if (runtime_config().moe.no_cutlass3x)
         return false;
+    // gpt-oss: device-args path is arch-gated off (no GLU/bias hooks in the
+    // fused act+quantize kernel) — keep the mirror in sync.
+    if (model_->config().arch == ModelArch::GPT_OSS)
+        return false;
     if (!cutlass_grouped_3x_nvfp4_available())
         return false;
     if (!moe_.cutlass3x_packed || !moe_.cutlass3x_sf)

--- a/src/exec/executor_forward_moe_cutlass.cu
+++ b/src/exec/executor_forward_moe_cutlass.cu
@@ -95,8 +95,11 @@ bool device_args_done = false;
     // (legacy IMP_NVFP4_DEVICE_ARGS=0) to force the legacy
     // path for A/B or workarounds.
     const bool da_enabled = runtime_config().moe.nvfp4_device_args;
+    // gpt-oss (#547): the fused act+quantize kernel knows SwiGLU/GeGLU/ReLU2
+    // only and has no per-expert bias hooks — the legacy host-args path below
+    // runs apply_expert_activation (GPT_OSS_GLU-aware) with bias seams.
     const bool use_device_args =
-        da_enabled &&
+        da_enabled && cfg.arch != ModelArch::GPT_OSS &&
         moe_.d_M_per && moe_.d_M_per_count >= ne &&
         moe_.d_sfa_offsets && moe_.d_B_ptrs_cache &&
         moe_.d_SFB_ptrs_cache && moe_.d_alpha_full &&
@@ -345,7 +348,7 @@ char* expert_down_base = static_cast<char*>(moe_.expert_down.data);
 bool smallM_done = false;
 {
     const auto& moe_cfg = runtime_config().moe;
-    const bool smallM_optin = moe_cfg.nvfp4_smallM;
+    const bool smallM_optin = moe_cfg.nvfp4_smallM && cfg.arch != ModelArch::GPT_OSS;
     if (smallM_optin && imp::gemm_grouped_nvfp4_smallM_available()) {
         const int smallM_threshold = moe_cfg.nvfp4_smallM_threshold;
         int max_M = 0;
@@ -739,6 +742,18 @@ if (quantize_once(gathered_base, d, sfa_offs, sfa_bases)) {
     grouped_gemm(ly.expert_up_ids, expert_up_base, d, eff, sfa_offs);
 }
 
+// gpt-oss (#547): per-expert biases on gate/up BEFORE activation (rows are
+// expert-sorted — same seam as the dequant batch path).
+const int32_t* gpt_oss_offsets =
+    (cfg.arch == ModelArch::GPT_OSS) ? static_cast<const int32_t*>(routing.expert_offsets.data)
+                                     : nullptr;
+if (gpt_oss_offsets) {
+    moe_add_expert_bias_sorted(expert_gate_base, ly.expert_gate_bias.data, gpt_oss_offsets, ne,
+                               expanded, eff, stream);
+    moe_add_expert_bias_sorted(expert_up_base, ly.expert_up_bias.data, gpt_oss_offsets, ne,
+                               expanded, eff, stream);
+}
+
 apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data,
                         moe_.expert_swiglu.data, non_gated_experts, expanded, eff,
                         compute_dtype_, cfg.ffn_activation, stream);
@@ -750,6 +765,9 @@ apply_expert_activation(moe_.expert_gate.data, moe_.expert_up.data,
 char* down_act = non_gated_experts ? expert_up_base : expert_swiglu_base;
 if (quantize_once(down_act, eff, sfa_offs, sfa_bases)) {
     grouped_gemm(ly.expert_down_ids, expert_down_base, eff, d, sfa_offs);
+    if (gpt_oss_offsets)
+        moe_add_expert_bias_sorted(expert_down_base, ly.expert_down_bias.data, gpt_oss_offsets, ne,
+                                   expanded, d, stream);
 }
 }  // !smallM_done
 }  // !device_args_done

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -1265,18 +1265,19 @@ void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
         const int64_t dn_K = dn_b.shape[2] * 32;         // d_ff
 
         NvFP4MoEQuantResult g{}, u{}, d{};
+        std::vector<float> g_ts, u_ts, d_ts;
         bool ok = gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
                                                    static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
-                                                   gu_K, /*offset=*/0, /*stride=*/2, g) &&
+                                                   gu_K, /*offset=*/0, /*stride=*/2, g, 1.0f, &g_ts) &&
                   gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
                                                    static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
-                                                   gu_K, /*offset=*/1, /*stride=*/2, u) &&
+                                                   gu_K, /*offset=*/1, /*stride=*/2, u, 1.0f, &u_ts) &&
                   // down: extra 2^-4 — residual-stream rescale (see arch
                   // registry comment in model.cpp; bias scaled in the loader).
                   gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(dn_b.data),
                                                    static_cast<const uint8_t*>(dn_s.data), ne, dn_rows,
                                                    dn_K, /*offset=*/0, /*stride=*/1, d,
-                                                   /*extra_scale=*/0.0625f);
+                                                   /*extra_scale=*/0.0625f, &d_ts);
         if (!ok) {
             IMP_LOG_ERROR("gpt-oss L%d: MXFP4→NVFP4 expert conversion failed (VRAM?)", i);
             return;
@@ -1294,6 +1295,72 @@ void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
         install(g, L.expert_gate_packed);
         install(u, L.expert_up_packed);
         install(d, L.expert_down_packed);
+
+        // Per-expert CUTLASS_NVFP4 registration (#547 prefill): without it,
+        // covers_ids() rejects the CUTLASS 3.x grouped path and prefill runs
+        // the dequant->FP16->cuBLAS batch fallback (~38 GB of FP16 dequant
+        // writes per forward — pp512 ~1.9k vs ~15k+ tok/s). Mirrors
+        // cache_moe_native_nvfp4's re-stamp block: shared SfAtom buffer per
+        // projection + per-expert Tensor slices into the contiguous result so
+        // Phase 4's register_tensor() sees CUTLASS-tier wcache entries.
+        auto register_cutlass = [&](NvFP4MoEQuantResult& r, std::vector<Tensor>& experts,
+                                    const std::vector<float>& h_ts) -> bool {
+            if (!cutlass_sm120_nvfp4_available())
+                return false;
+            const size_t sf_per_expert =
+                cutlass_nvfp4_sf_size(static_cast<int>(r.N), static_cast<int>(r.K));
+            const size_t sfatom_total = static_cast<size_t>(ne) * sf_per_expert;
+            void* d_sfatom = vram_alloc_force(vram_alloc_, sfatom_total, "gptoss_moe_sfatom");
+            if (!d_sfatom) {
+                IMP_LOG_WARN("gpt-oss L%d: SfAtom alloc failed (%.1f MiB) — prefill stays on the "
+                             "dequant fallback",
+                             i, sfatom_total / (1024.0 * 1024.0));
+                return false;
+            }
+            convert_nvfp4_moe_scales_to_sfatom(r.micro_scales, d_sfatom, ne, static_cast<int>(r.N),
+                                               static_cast<int>(r.K), /*stream=*/nullptr);
+            IMP_CUDA_CHECK_LOG(cudaDeviceSynchronize());
+            const_cast<Model*>(model_)->gpu_allocations_.push_back(d_sfatom);
+            experts.assign(ne, Tensor{});
+            for (int e = 0; e < ne; ++e) {
+                void* data_slice =
+                    static_cast<char*>(r.packed_data) + static_cast<size_t>(e) * r.expert_stride_packed;
+                void* ms_slice =
+                    static_cast<char*>(r.micro_scales) + static_cast<size_t>(e) * r.expert_stride_ms;
+                int64_t eshape[2] = {r.N, r.K / 2};  // packed-byte convention (K/2)
+                Tensor w(data_slice, QType::NVFP4, 2, eshape, /*on_device=*/true);
+                w.scales = ms_slice;
+                w.tensor_scale = h_ts[e];
+                experts[e] = w;
+
+                NvFP4QuantResult nv;
+                nv.packed_data = data_slice;
+                nv.micro_scales = ms_slice;
+                nv.owned = false;  // slices into the contiguous conversion result
+                nv.tensor_scale = h_ts[e];
+                nv.N = r.N;
+                nv.K = r.K;
+                wcache_.nvfp4[data_slice] = nv;
+
+                CutlassNvFP4Weight cw;
+                cw.data = data_slice;
+                cw.scale_factors = static_cast<char*>(d_sfatom) + static_cast<size_t>(e) * sf_per_expert;
+                cw.tensor_scale = h_ts[e];
+                cw.N = r.N;
+                cw.K = r.K;
+                cw.sf_bytes = sf_per_expert;
+                cw.sf_borrowed = true;
+                wcache_.cutlass_nvfp4[data_slice] = cw;
+            }
+            wcache_.cutlass_nvfp4_bytes += sfatom_total;
+            return true;
+        };
+        bool ct_ok = register_cutlass(g, L.expert_w_gate, g_ts) &&
+                     register_cutlass(u, L.expert_w_up, u_ts) &&
+                     register_cutlass(d, L.expert_w_down, d_ts);
+        if (i == 0)
+            IMP_LOG_INFO("gpt-oss: CUTLASS grouped prefill %s", ct_ok ? "registered" : "UNAVAILABLE");
+
         dctx.nvfp4_moe_count += 3;
         converted++;
     }

--- a/src/quant/gpt_oss_mxfp4_convert.cu
+++ b/src/quant/gpt_oss_mxfp4_convert.cu
@@ -12,7 +12,8 @@ namespace imp {
 
 bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_scales, int ne,
                                       int64_t n_rows_total, int64_t K, int row_offset, int row_stride,
-                                      NvFP4MoEQuantResult& out, float extra_scale) {
+                                      NvFP4MoEQuantResult& out, float extra_scale,
+                                      std::vector<float>* h_tscales_out) {
     const int64_t N = n_rows_total / row_stride;  // rows per expert in the output
     const int64_t kb32 = K / 32;                  // MXFP4 blocks per row
     const int64_t row_bytes = K / 2;              // packed nibbles per row
@@ -103,6 +104,8 @@ bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_
     out.expert_stride_packed = static_cast<size_t>(N) * row_bytes;
     out.expert_stride_ms = static_cast<size_t>(N) * ms_per_row;
     out.borrowed = false;
+    if (h_tscales_out)
+        *h_tscales_out = tscales;
     return true;
 }
 

--- a/src/quant/gpt_oss_mxfp4_convert.h
+++ b/src/quant/gpt_oss_mxfp4_convert.h
@@ -18,6 +18,7 @@
 
 #include "quant/nvfp4_quant.h"
 #include <cstdint>
+#include <vector>
 
 namespace imp {
 
@@ -28,8 +29,11 @@ namespace imp {
 // extra_scale folds a constant into the per-expert tensor scale — used for the
 // gpt-oss residual-stream 2^-4 rescale on the down projection (see the arch
 // registry comment in model.cpp). Returns false on allocation failure.
+// h_tscales_out (optional): host copy of the per-expert FP32 tensor scales
+// (incl. extra_scale) — needed for the per-expert CUTLASS weight registration.
 bool gpt_oss_convert_experts_to_nvfp4(const uint8_t* h_blocks, const uint8_t* h_scales, int ne,
                                       int64_t n_rows_total, int64_t K, int row_offset, int row_stride,
-                                      NvFP4MoEQuantResult& out, float extra_scale = 1.0f);
+                                      NvFP4MoEQuantResult& out, float extra_scale = 1.0f,
+                                      std::vector<float>* h_tscales_out = nullptr);
 
 }  // namespace imp


### PR DESCRIPTION
The gpt-oss MoE prefill ran the NVFP4→FP16 batch-dequant fallback (all 32 experts fully dequantized to FP16 three times per forward ≈ 38 GB of writes) because the converted experts had no CUTLASS-tier registry handles — `covers_ids()` rejected the grouped path.

## Changes
- **Per-expert CUTLASS_NVFP4 registration** in the gpt-oss converter phase (mirrors `cache_moe_native_nvfp4`'s re-stamp block): shared per-projection SfAtom buffer via `convert_nvfp4_moe_scales_to_sfatom`, per-expert Tensor slices into the contiguous conversion result, `wcache_.nvfp4` + `wcache_.cutlass_nvfp4` entries → Phase 4 registers `expert_*_ids` with CUTLASS tier and the grouped path fires.
- **Arch gates**: device-args fast path + smallM are disabled for GPT_OSS (their fused act+quantize kernel knows SwiGLU/GeGLU/ReLU² only and has no per-expert bias hooks). gpt-oss runs the legacy host-args CUTLASS 3.x path, which uses `apply_expert_activation` (GPT_OSS_GLU-aware). Mirror predicate `moe_cutlass3x_will_use_device_args_` kept in sync.
- **Bias seams** in the legacy path: `moe_add_expert_bias_sorted` on gate/up before activation + on down output — identical seams to the batch path.
- Converter gains an optional host copy of the per-expert tensor scales (needed for the CUTLASS weight registration; includes the 2^-4 down rescale).

## Measured (RTX 5090, CUBLAS_WORKSPACE_CONFIG=:4096:8)
| | before | after |
|---|---:|---:|
| pp512 | 1 902 tok/s | **15 800–19 000 tok/s** |
| tg256 (alternating cooled A/B) | 310.5 / 309.4 | **315.1 / 315.6** |

Decode is unchanged-to-slightly-better (same `nvfp4_moe_*_ptr` GEMV path). Quality: teacher-forced PPL 7.99 vs 7.67 on the dequant path (HF reference 6.71) — the usual NVFP4 activation-quant trade-off shared by all prequant NVFP4 models; chat output verified clean (Harmony analysis/final intact).

Regression: Qwen3-30B-A3B-NVFP4 still takes the device-args path (log verified), pp 12.9k, coherent output. All non-GPT_OSS models are untouched (every change is arch-gated or a nullptr no-op).

Docs updated (BENCHMARKS.md footnote, supported-models prefill note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
