### PR TITLE
test(R2)+ci(R3): CPU routing-decision tables + mock API contract suite in CI (#577, #578)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,33 @@ jobs:
             build/test-e2e
             build/libimp.a
 
+  # CPU-only API contract check (R3 / P2.6). The Python mock suite in tests/api/
+  # exercises the HTTP schema, SSE envelope, error bodies and lifecycle against
+  # the in-process mock_server.py — no GPU, no model, no CUDA toolchain. It was
+  # the cheapest CI-able coverage in the test audit but ran only manually
+  # (run_mock_tests.sh). Separate ubuntu job so it stays independent of the slow
+  # CUDA Build job; "not perf and not tools" deselects the real-model markers.
+  # NOTE: do NOT rename the `build` job's `name: Build` — a branch ruleset
+  # requires that exact check name.
+  mock-api:
+    name: Mock API contract
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test deps
+        run: pip install -r tests/api/requirements.txt
+
+      - name: Run mock API suite
+        env:
+          IMP_USE_MOCK: "1"
+        run: python -m pytest tests/api -m "not perf and not tools" --tb=short -q
+
   test:
     name: Test
     needs: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,7 @@ if(IMP_BUILD_TESTS)
         tests/test_safetensors_loader.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
+        tests/test_routing_decision.cpp
         tests/test_think_stop_logic.cpp
         tests/test_stream_pipeline.cpp
         tests/test_vision_preprocess.cpp

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -28,7 +28,7 @@ int get_device_sm_version() {
 
 // NOTE: the path-selection ORDER + config gates below are mirrored as a pure
 // host function `select_attn_prefill_path` in attention_dispatch_decision.h and
-// pinned by test_attention_dispatch_table.cpp (R2 / P1.4). The kernels are
+// pinned by test_routing_decision.cpp (R2 / P1.4). The kernels are
 // called lazily here (each launches on accept, falls through on decline), so
 // this can't simply delegate to the pure function — but any reorder or gate
 // change MUST be reflected in that header or the unit test will diverge.

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -26,6 +26,12 @@ int get_device_sm_version() {
     return cached_sm_version;
 }
 
+// NOTE: the path-selection ORDER + config gates below are mirrored as a pure
+// host function `select_attn_prefill_path` in attention_dispatch_decision.h and
+// pinned by test_attention_dispatch_table.cpp (R2 / P1.4). The kernels are
+// called lazily here (each launches on accept, falls through on decline), so
+// this can't simply delegate to the pure function — but any reorder or gate
+// change MUST be reflected in that header or the unit test will diverge.
 void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                                 bool causal, int sliding_window, float softcap, cudaStream_t stream,
                                 const RuntimeConfig& rcfg, int q_offset) {

--- a/src/compute/attention_dispatch_decision.h
+++ b/src/compute/attention_dispatch_decision.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "runtime/config.h"
+
+// Pure host-side model of the attention-prefill dispatch ordering in
+// attention_dispatch.cu. Extracted so the routing table (which kernel serves a
+// given config + head_dim) is covered by a cheap CPU unit test — the #493
+// regression was exactly an unintended routing shift, and the 06-04 test audit
+// flagged this as "cheap, catches path moves" (R2 / P1.4).
+//
+// The .cu dispatch interleaves three things:
+//   1. config gates    (rcfg.attention.fmha_fa2 == "on", fp8_fmha != "never", …)
+//   2. kernel support   (the kernel returns false for hd!=128, insufficient
+//                        smem, non-F16, etc. and the dispatch falls through)
+//   3. the actual kernel launch
+//
+// Only (1)+(2) decide *which* path runs; (3) is the device work. This header
+// models (1)+(2) as a pure function: the caller supplies, per kernel, whether
+// that kernel would *accept* the (Q,K,V,O) config (the boolean the real
+// `fmha_..._prefill(...)` return value collapses to). The function then
+// reproduces the exact short-circuit order of attention_dispatch.cu.
+//
+// Keeping this in lock-step with attention_dispatch.cu is the point: any reorder
+// or gate change shows up as a diff in test_attention_dispatch_table.cpp.
+
+namespace imp {
+
+enum class AttnPrefillPath {
+    MXFP4,        // fmha_sm120_mxfp4_prefill
+    FA2,          // fmha_sm120_fa2_prefill (register-resident)
+    FP8,          // fmha_sm120_fp8_prefill
+    FMHA_SM120,   // fmha_sm120_prefill (WMMA)
+    BLACKWELL,    // flash_attention_blackwell (final fallback)
+};
+
+// Per-kernel "would this kernel accept the config" flags, mirroring the bool
+// each `fmha_..._prefill(...)` collapses to in the .cu (mxfp4 also has an outer
+// availability gate). Defaults reflect the common hd=128 F16 case where the
+// specialized kernels accept.
+struct AttnKernelSupport {
+    bool mxfp4_available = false;   // attention_mxfp4_available()
+    bool mxfp4_accepts = false;     // fmha_sm120_mxfp4_prefill(...) succeeded
+    bool fa2_accepts = false;       // fmha_sm120_fa2_prefill(...) succeeded
+    bool fp8_accepts = false;       // fmha_sm120_fp8_prefill(...) succeeded
+    bool fmha_sm120_accepts = false;// fmha_sm120_prefill(...) succeeded
+};
+
+// Reproduces attention_prefill_dispatch()'s path selection (config gates +
+// fall-through on kernel decline). Returns the path that would actually run.
+inline AttnPrefillPath select_attn_prefill_path(const RuntimeConfig& rcfg,
+                                                const AttnKernelSupport& sup) {
+    // 1. MXFP4 Flash Attention (opt-in, outer availability + per-config accept).
+    if (sup.mxfp4_available && sup.mxfp4_accepts)
+        return AttnPrefillPath::MXFP4;
+
+    // 2. Register-resident FA2 — only when [attention] fmha_fa2 == "on".
+    if (rcfg.attention.fmha_fa2 == "on" && sup.fa2_accepts)
+        return AttnPrefillPath::FA2;
+
+    // 3. Native FP8 FMHA — ON unless fp8_fmha == "never".
+    if (rcfg.attention.fp8_fmha != "never" && sup.fp8_accepts)
+        return AttnPrefillPath::FP8;
+
+    // 4. Native FP16 WMMA FMHA — ON unless fmha_sm120 == "never".
+    if (rcfg.attention.fmha_sm120 != "never" && sup.fmha_sm120_accepts)
+        return AttnPrefillPath::FMHA_SM120;
+
+    // 5. Final fallback: WMMA 128x64 Blackwell flash attention (always runs).
+    return AttnPrefillPath::BLACKWELL;
+}
+
+}  // namespace imp

--- a/src/compute/attention_dispatch_decision.h
+++ b/src/compute/attention_dispatch_decision.h
@@ -21,7 +21,7 @@
 // reproduces the exact short-circuit order of attention_dispatch.cu.
 //
 // Keeping this in lock-step with attention_dispatch.cu is the point: any reorder
-// or gate change shows up as a diff in test_attention_dispatch_table.cpp.
+// or gate change shows up as a diff in test_routing_decision.cpp.
 
 namespace imp {
 

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -346,7 +346,7 @@ void GraphExecutor::moe_ffn_phase3_route_(int layer, cudaStream_t stream, MoeFfn
 // lazily, so output stays correct (at most one wasted decision).
 // The path-selection ORDER + arch/config gates are mirrored as a pure function
 // `select_moe_prefill_path` in moe_prefill_decision.h, pinned by
-// test_moe_prefill_decision.cpp (R2 / P1.4).
+// test_routing_decision.cpp (R2 / P1.4).
 bool GraphExecutor::moe_cutlass3x_will_use_device_args_(int layer,
                                                         const MoeFfnContext& ctx) const {
     if (runtime_config().moe.no_cutlass3x)

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -344,6 +344,9 @@ void GraphExecutor::moe_ffn_phase3_route_(int layer, cudaStream_t stream, MoeFfn
 // two predicates in sync — if device-args' actual gate flips false at runtime
 // while this returns true, the legacy fallback inside the function gathers
 // lazily, so output stays correct (at most one wasted decision).
+// The path-selection ORDER + arch/config gates are mirrored as a pure function
+// `select_moe_prefill_path` in moe_prefill_decision.h, pinned by
+// test_moe_prefill_decision.cpp (R2 / P1.4).
 bool GraphExecutor::moe_cutlass3x_will_use_device_args_(int layer,
                                                         const MoeFfnContext& ctx) const {
     if (runtime_config().moe.no_cutlass3x)

--- a/src/exec/moe_prefill_decision.h
+++ b/src/exec/moe_prefill_decision.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "model/model_arch.h"
+#include "runtime/config.h"
+
+// Pure host-side model of the MoE-prefill GEMM path selection in
+// executor_forward_moe_cutlass.cu (and its precondition mirror
+// moe_cutlass3x_will_use_device_args_ in executor_forward_moe.cu). Extracted so
+// the grouped-GEMM-vs-fallback routing — added in PR #574 (#547, gpt-oss
+// CUTLASS grouped prefill) — is covered by a cheap CPU unit test instead of
+// E2E-only (R2 / P1.4).
+//
+// The .cu interleaves config gates + arch gates + workspace-readiness probes +
+// the actual dispatch. Only the gates pick *which* path runs; this header
+// models them as a pure function. The caller supplies, per tier, whether the
+// device workspace for that tier is populated (the boolean the long
+// `moe_.d_M_per && moe_.cutlass3x_packed && …` conjunction collapses to).
+
+namespace imp {
+
+enum class MoePrefillPath {
+    DEVICE_ARGS,   // CUTLASS 3.x NVFP4 device-args full path (fast)
+    SMALL_M,       // gemm_grouped_nvfp4_smallM (small token counts)
+    GROUPED,       // host-args CUTLASS 3.x grouped GEMM (+ gpt-oss bias seams)
+    LEGACY,        // per-expert legacy fallback (gather + serial GEMM)
+};
+
+// Workspace-readiness flags, mirroring the device-pointer / packed-tensor
+// conjunctions in the .cu. When false, that tier's preconditions are not met
+// and selection falls through to the next tier.
+struct MoePrefillWorkspace {
+    // try_run_moe_cutlass3x_nvfp4_prefill_ returns false at entry (→ whole-
+    // function LEGACY) unless the CUTLASS 3.x grouped path is available AND the
+    // packed/scale workspace + per-expert NVFP4 tier coverage are all present.
+    // This single flag collapses cutlass_grouped_3x_nvfp4_available() +
+    // cutlass3x_packed/sf + covers_ids() — all checked BEFORE the device-args
+    // block, so it gates device-args too.
+    bool grouped_available = false;
+    bool device_args_ready = false;  // cutlass3x device-args buffers all populated
+    bool smallM_available = false;   // gemm_grouped_nvfp4_smallM_available()
+    bool smallM_under_threshold = false;  // max active M <= nvfp4_smallM_threshold
+    bool grouped_ready = false;      // host-args grouped path can run this layer
+};
+
+// Reproduces the path selection in try_run_moe_cutlass3x_nvfp4_prefill_.
+// gpt-oss (#574/#547) is arch-gated OFF the device-args and smallM tiers (the
+// fused act+quantize kernel has no GLU-clamp / per-expert-bias hooks) — it
+// takes the GROUPED tier, which applies the bias seams + GPT_OSS_GLU activation.
+inline MoePrefillPath select_moe_prefill_path(ModelArch arch, const RuntimeConfig& rcfg,
+                                              const MoePrefillWorkspace& ws) {
+    const bool is_gpt_oss = (arch == ModelArch::GPT_OSS);
+
+    // Function-entry gate: moe.no_cutlass3x or an unavailable/uncovered CUTLASS
+    // 3.x grouped path makes the whole try_run_... return false → per-expert
+    // LEGACY fallback. Checked BEFORE device-args, so it gates every CUTLASS
+    // tier including device-args.
+    if (rcfg.moe.no_cutlass3x || !ws.grouped_available)
+        return MoePrefillPath::LEGACY;
+
+    // Tier 1: device-args fast path. Gated by moe.nvfp4_device_args, off for
+    // gpt-oss, requires the full device-args workspace.
+    if (rcfg.moe.nvfp4_device_args && !is_gpt_oss && ws.device_args_ready)
+        return MoePrefillPath::DEVICE_ARGS;
+
+    // Tier 2: smallM path. Opt-in (moe.nvfp4_smallM), off for gpt-oss, only
+    // when the kernel is available and the active token count is under the
+    // smallM threshold.
+    if (rcfg.moe.nvfp4_smallM && !is_gpt_oss && ws.smallM_available && ws.smallM_under_threshold)
+        return MoePrefillPath::SMALL_M;
+
+    // Tier 3: host-args grouped GEMM (gpt-oss adds per-expert bias seams).
+    if (ws.grouped_ready)
+        return MoePrefillPath::GROUPED;
+
+    // Tier 4: per-expert legacy fallback.
+    return MoePrefillPath::LEGACY;
+}
+
+}  // namespace imp

--- a/tests/test_routing_decision.cpp
+++ b/tests/test_routing_decision.cpp
@@ -1,0 +1,205 @@
+// CPU unit tests for the host-side routing decisions extracted from the
+// attention-prefill dispatch (attention_dispatch.cu) and the MoE-prefill GEMM
+// dispatch (executor_forward_moe_cutlass.cu). R2 / P1.4 — the #493 regression
+// was a routing change covered only by E2E; the grouped-GEMM-vs-fallback path
+// (#574) was likewise E2E-only. These pin the tables as a cheap CPU diff.
+
+#include "compute/attention_dispatch_decision.h"
+#include "exec/moe_prefill_decision.h"
+
+#include <gtest/gtest.h>
+
+using namespace imp;
+
+// --------------------------------------------------------------------------
+// Attention prefill dispatch table
+// --------------------------------------------------------------------------
+
+namespace {
+
+// Default config: fmha_fa2="on", fp8_fmha="auto", fmha_sm120="auto".
+RuntimeConfig default_cfg() { return RuntimeConfig{}; }
+
+// Typical hd=128 F16 prefill: every specialized kernel would accept.
+AttnKernelSupport all_accept() {
+    AttnKernelSupport s;
+    s.mxfp4_available = false;  // mxfp4 is opt-in, off by default
+    s.mxfp4_accepts = true;
+    s.fa2_accepts = true;
+    s.fp8_accepts = true;
+    s.fmha_sm120_accepts = true;
+    return s;
+}
+
+}  // namespace
+
+TEST(AttnDispatchTable, DefaultConfigPicksFA2) {
+    // fmha_fa2="on" (default) and FA2 accepts hd=128 → FA2 wins over FP8.
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), all_accept()), AttnPrefillPath::FA2);
+}
+
+TEST(AttnDispatchTable, Mxfp4WinsWhenAvailableAndAccepts) {
+    auto cfg = default_cfg();
+    auto sup = all_accept();
+    sup.mxfp4_available = true;
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::MXFP4);
+}
+
+TEST(AttnDispatchTable, Mxfp4AvailableButDeclinesFallsToFA2) {
+    auto cfg = default_cfg();
+    auto sup = all_accept();
+    sup.mxfp4_available = true;
+    sup.mxfp4_accepts = false;  // e.g. head_dim < 32
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FA2);
+}
+
+TEST(AttnDispatchTable, FA2NeverFallsToFP8) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::FP8);
+}
+
+TEST(AttnDispatchTable, FA2OnButDeclinesFallsToFP8) {
+    // hd != 128 (e.g. Gemma): FA2 declines even with fmha_fa2="on".
+    auto cfg = default_cfg();
+    auto sup = all_accept();
+    sup.fa2_accepts = false;
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FP8);
+}
+
+TEST(AttnDispatchTable, FP8NeverWithFA2NeverFallsToFMHA) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    cfg.attention.fp8_fmha = "never";
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::FMHA_SM120);
+}
+
+TEST(AttnDispatchTable, FP8DeclinesFallsToFMHA) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    auto sup = all_accept();
+    sup.fp8_accepts = false;
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FMHA_SM120);
+}
+
+TEST(AttnDispatchTable, AllSpecializedDisabledFallsToBlackwell) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    cfg.attention.fp8_fmha = "never";
+    cfg.attention.fmha_sm120 = "never";
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::BLACKWELL);
+}
+
+TEST(AttnDispatchTable, AllSpecializedDeclineFallsToBlackwell) {
+    // Unsupported config for every specialized kernel → final WMMA fallback.
+    auto cfg = default_cfg();
+    AttnKernelSupport sup;  // all false
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::BLACKWELL);
+}
+
+TEST(AttnDispatchTable, FMHASm120AutoIsNotNever) {
+    // "auto" (default) must not be treated as "never" for the WMMA tier.
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    cfg.attention.fp8_fmha = "never";
+    auto sup = all_accept();
+    EXPECT_EQ(cfg.attention.fmha_sm120, "auto");
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FMHA_SM120);
+}
+
+// --------------------------------------------------------------------------
+// MoE prefill GEMM dispatch table
+// --------------------------------------------------------------------------
+
+namespace {
+
+// Workspace with every tier's preconditions satisfied — the path is then
+// decided purely by the config + arch gates.
+MoePrefillWorkspace all_ready() {
+    MoePrefillWorkspace ws;
+    ws.device_args_ready = true;
+    ws.grouped_available = true;
+    ws.smallM_available = true;
+    ws.smallM_under_threshold = true;
+    ws.grouped_ready = true;
+    return ws;
+}
+
+}  // namespace
+
+TEST(MoePrefillTable, DefaultPicksDeviceArgs) {
+    // nvfp4_device_args=true (default), non-gpt-oss, workspace ready.
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, default_cfg(), all_ready()),
+              MoePrefillPath::DEVICE_ARGS);
+}
+
+TEST(MoePrefillTable, GptOssSkipsDeviceArgsTakesGrouped) {
+    // gpt-oss is arch-gated off device-args AND smallM → host-args grouped
+    // (with bias seams), even when smallM would otherwise apply.
+    auto ws = all_ready();
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_smallM = true;  // would route others to smallM
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::GPT_OSS, cfg, ws), MoePrefillPath::GROUPED);
+}
+
+TEST(MoePrefillTable, DeviceArgsDisabledFallsToGrouped) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_device_args = false;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()),
+              MoePrefillPath::GROUPED);
+}
+
+TEST(MoePrefillTable, DeviceArgsWorkspaceNotReadyFallsToGrouped) {
+    auto ws = all_ready();
+    ws.device_args_ready = false;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, default_cfg(), ws),
+              MoePrefillPath::GROUPED);
+}
+
+TEST(MoePrefillTable, SmallMWhenOptedInAndUnderThreshold) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_device_args = false;  // so device-args doesn't win first
+    cfg.moe.nvfp4_smallM = true;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()),
+              MoePrefillPath::SMALL_M);
+}
+
+TEST(MoePrefillTable, SmallMOverThresholdFallsToGrouped) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_device_args = false;
+    cfg.moe.nvfp4_smallM = true;
+    auto ws = all_ready();
+    ws.smallM_under_threshold = false;  // too many tokens
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, ws), MoePrefillPath::GROUPED);
+}
+
+TEST(MoePrefillTable, NoCutlass3xFallsToLegacy) {
+    auto cfg = default_cfg();
+    cfg.moe.no_cutlass3x = true;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()),
+              MoePrefillPath::LEGACY);
+}
+
+TEST(MoePrefillTable, GroupedUnavailableFallsToLegacy) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_device_args = false;
+    auto ws = all_ready();
+    ws.grouped_available = false;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, ws), MoePrefillPath::LEGACY);
+}
+
+TEST(MoePrefillTable, GroupedNotReadyFallsToLegacy) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_device_args = false;
+    auto ws = all_ready();
+    ws.grouped_ready = false;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, ws), MoePrefillPath::LEGACY);
+}
+
+TEST(MoePrefillTable, GptOssNoCutlass3xFallsToLegacy) {
+    // Even gpt-oss drops to legacy when the grouped kernel is unavailable.
+    auto cfg = default_cfg();
+    cfg.moe.no_cutlass3x = true;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::GPT_OSS, cfg, all_ready()),
+              MoePrefillPath::LEGACY);
+}


### PR DESCRIPTION
Implements plan items **R2** and **R3** from \`tests/TEST_AUDIT.md\` (PR #575).

## R2 — Routing-Unit-Tests (closes #577)
- New pure-host oracle headers mirroring the dispatch decisions:
  - \`src/compute/attention_dispatch_decision.h\` — attention prefill path selection (MXFP4 → FA2 → FP8 → FMHA_SM120 → Blackwell), incl. \`fmha_fa2\`/\`fp8_fmha\`/\`fmha_sm120\` config gates.
  - \`src/exec/moe_prefill_decision.h\` — MoE prefill tier selection (DEVICE_ARGS → SMALL_M → GROUPED → LEGACY), incl. \`no_cutlass3x\` function-entry gate and the gpt-oss arch gate from #574.
- \`tests/test_routing_decision.cpp\` — 20 table-driven CPU tests in the unit lane (CI-capable, no GPU). An unintended routing shift (#493 class) now fails a cheap named-enum assert.
- Dispatch \`.cu\` files gained only cross-reference comments — **no behavior change** (verified by spec review against the real dispatch order).
- Development already caught one real ordering subtlety: \`no_cutlass3x\` gates the whole CUTLASS path before device-args; the oracle mirrors that.

## R3 — Python-Mock-Contract-Suite in CI (closes #578)
- New independent \`mock-api\` job (ubuntu-24.04, Python 3.12): \`pytest tests/api -m "not perf and not tools"\` with \`IMP_USE_MOCK=1\` against the in-process \`mock_server.py\` — HTTP-Schema/SSE/Errors/Lifecycle contract checks, no GPU/model needed.
- \`Build\` job untouched (ruleset-required check name).

## Verification
- \`make build\` + \`make test-unit\`: 277+167+37 passed (incl. the 20 new routing tests).
- Mock suite in python:3.12-slim with the exact CI invocation: 66 passed, 9 deselected.
- Two-stage review (spec + quality): compliant/approved; stale comment filenames fixed in follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)