### PR TITLE
test(R4): harden perf gate — baseline-key fix, host-drift-aware decode gate, schema_version (#579)

### DIFF
--- a/scripts/gen_perf_baseline.sh
+++ b/scripts/gen_perf_baseline.sh
@@ -107,6 +107,7 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 cat > "$OUTPUT" << EOF
 {
+  "schema_version": "legacy-v1",
   "model": "$(basename "$MODEL")",
   "gpu": "$GPU",
   "cuda": "$CUDA",

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -91,7 +91,8 @@ warn()    { echo "${YLW}WARN${RST} $*"; }
 #     400 W floor so a healthy ~500 W run never trips it.
 #   - The SM clock ramps ~1s at bench start (cold-start artifact, audit §5), so
 #     we drop the first 2 samples before aggregating to avoid a false depressed
-#     classification from the ramp.
+#     classification from the ramp. A run with only 1-2 samples can't drop the
+#     ramp, so it's treated as no-data (gate fails open: plain FAIL).
 # Fail-open: if nvidia-smi is missing or errors, the sampler no-ops and the gate
 # behaves exactly as before (no degradation logic kicks in).
 GPU_DRIFT_MEM_FLOOR=13801   # mem clock (MHz) at/above which the host is healthy
@@ -129,7 +130,11 @@ gpu_sample_stop() {
     read -r MEM_MED PWR_MAX N < <(awk -F, '
         { gsub(/ /,""); n++; sm[n]=$1+0; mem[n]=$2+0; pwr[n]=$3+0 }
         END {
-            start = (n > 2) ? 3 : 1; cnt = 0; pmax = 0;
+            # n<=2 is too short to drop the ~1s cold-ramp samples: classify as
+            # no-data (N=0) so the gate fails open (plain FAIL on regression),
+            # never letting cold-ramp low-mem samples force a depressed WARN.
+            if (n <= 2) { print 0, 0, 0; exit }
+            start = 3; cnt = 0; pmax = 0;
             for (i = start; i <= n; i++) { m[++cnt] = mem[i]; if (pwr[i] > pmax) pmax = pwr[i]; }
             if (cnt == 0) { print 0, 0, 0; exit }
             # median of m[1..cnt]

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -123,7 +123,7 @@ gpu_sample_stop() {
     GPU_DRIFT_DEPRESSED=0
     GPU_DRIFT_DESC=""
     [ -n "$_SAMPLE_PID" ] && kill "$_SAMPLE_PID" >/dev/null 2>&1
-    wait "$_SAMPLE_PID" 2>/dev/null
+    [ -n "$_SAMPLE_PID" ] && wait "$_SAMPLE_PID" 2>/dev/null
     [ -n "$_SAMPLE_FILE" ] && [ -s "$_SAMPLE_FILE" ] || { _cleanup_sample; return 0; }
     # Drop the first 2 samples (clock-ramp cold-start), then aggregate:
     # median mem clock + max power over the steady portion of the run.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -74,6 +74,92 @@ section() { echo; echo "${YLW}== $* ==${RST}"; }
 pass()    { echo "${GRN}PASS${RST} $*"; }
 fail()    { echo "${RED}FAIL${RST} $*"; FAIL=$((FAIL+1)); }
 skip()    { echo "${YLW}SKIP${RST} $*"; }
+warn()    { echo "${YLW}WARN${RST} $*"; }
+
+# --- Host-drift guard (#526) -------------------------------------------------
+# This WSL2 box has day-level "depressed host" states where decode reads 8-15%
+# low DESPITE full methodology (memory: q8_drift_host_artifact_2026_06_05). The
+# culprit is host/driver state, not code — but the perf gate cannot tell the two
+# apart from a single bench number. So we sample GPU clocks/power DURING the
+# decode bench and, if a regression coincides with the depressed-host signature,
+# we degrade FAIL→WARN (clearly labeled) instead of crying false-positive.
+#
+# Healthy under-load signature: ~2850 MHz SM / 13801 MHz mem / ~500 W.
+# Depressed         => mem-clock median < 13801 MHz, OR power max < 400 W.
+#   - mem-clock is the cleanest tell (GDDR7 either P0-clocks or it doesn't).
+#   - power uses MAX over the run (a robust upper bound) with a conservative
+#     400 W floor so a healthy ~500 W run never trips it.
+#   - The SM clock ramps ~1s at bench start (cold-start artifact, audit §5), so
+#     we drop the first 2 samples before aggregating to avoid a false depressed
+#     classification from the ramp.
+# Fail-open: if nvidia-smi is missing or errors, the sampler no-ops and the gate
+# behaves exactly as before (no degradation logic kicks in).
+GPU_DRIFT_MEM_FLOOR=13801   # mem clock (MHz) at/above which the host is healthy
+GPU_DRIFT_POWER_FLOOR=400   # power (W) max below which the host is depressed
+_SAMPLE_FILE=""
+_SAMPLE_PID=""
+
+# Start a background sampler writing "sm,mem,power" CSV rows every 1s.
+# No-op (leaves _SAMPLE_PID empty) if nvidia-smi can't be queried.
+gpu_sample_start() {
+    _SAMPLE_FILE=""; _SAMPLE_PID=""
+    command -v nvidia-smi >/dev/null 2>&1 || return 0
+    nvidia-smi --query-gpu=clocks.sm,clocks.mem,power.draw \
+        --format=csv,noheader,nounits >/dev/null 2>&1 || return 0
+    _SAMPLE_FILE=$(mktemp)
+    ( while true; do
+        nvidia-smi --query-gpu=clocks.sm,clocks.mem,power.draw \
+            --format=csv,noheader,nounits 2>/dev/null | head -1
+        sleep 1
+      done ) >>"$_SAMPLE_FILE" 2>/dev/null &
+    _SAMPLE_PID=$!
+}
+
+# Stop the sampler and classify the run. Sets globals:
+#   GPU_DRIFT_DEPRESSED = 0|1
+#   GPU_DRIFT_DESC      = human-readable "mem=… power=…" summary ("" if no data)
+gpu_sample_stop() {
+    GPU_DRIFT_DEPRESSED=0
+    GPU_DRIFT_DESC=""
+    [ -n "$_SAMPLE_PID" ] && kill "$_SAMPLE_PID" >/dev/null 2>&1
+    wait "$_SAMPLE_PID" 2>/dev/null
+    [ -n "$_SAMPLE_FILE" ] && [ -s "$_SAMPLE_FILE" ] || { _cleanup_sample; return 0; }
+    # Drop the first 2 samples (clock-ramp cold-start), then aggregate:
+    # median mem clock + max power over the steady portion of the run.
+    read -r MEM_MED PWR_MAX N < <(awk -F, '
+        { gsub(/ /,""); n++; sm[n]=$1+0; mem[n]=$2+0; pwr[n]=$3+0 }
+        END {
+            start = (n > 2) ? 3 : 1; cnt = 0; pmax = 0;
+            for (i = start; i <= n; i++) { m[++cnt] = mem[i]; if (pwr[i] > pmax) pmax = pwr[i]; }
+            if (cnt == 0) { print 0, 0, 0; exit }
+            # median of m[1..cnt]
+            for (a = 1; a <= cnt; a++) for (b = a+1; b <= cnt; b++) if (m[b] < m[a]) { t=m[a]; m[a]=m[b]; m[b]=t }
+            med = (cnt % 2) ? m[(cnt+1)/2] : (m[cnt/2] + m[cnt/2+1]) / 2;
+            printf "%.0f %.0f %d\n", med, pmax, cnt;
+        }' "$_SAMPLE_FILE")
+    _cleanup_sample
+    [ "${N:-0}" -gt 0 ] || return 0
+    GPU_DRIFT_DESC="mem=${MEM_MED}MHz(med) power=${PWR_MAX}W(max) n=${N}"
+    if [ "$MEM_MED" -lt "$GPU_DRIFT_MEM_FLOOR" ] || [ "$PWR_MAX" -lt "$GPU_DRIFT_POWER_FLOOR" ]; then
+        GPU_DRIFT_DEPRESSED=1
+    fi
+}
+
+_cleanup_sample() {
+    [ -n "$_SAMPLE_FILE" ] && rm -f "$_SAMPLE_FILE"
+    _SAMPLE_FILE=""; _SAMPLE_PID=""
+}
+
+# Report a decode regression, degrading FAIL→WARN under the depressed-host
+# signature (#526). $1 = context label for the message.
+decode_regression() {
+    local ctx="$1"
+    if [ "${GPU_DRIFT_DEPRESSED:-0}" = "1" ]; then
+        warn "$ctx: depressed-host signature ($GPU_DRIFT_DESC) — decode delta not attributable to code, FAIL degraded to WARN (#526)"
+    else
+        fail "$ctx"
+    fi
+}
 
 # Docker-only host (host has neither cmake nor a build/ directory): run
 # the canonical Docker build, then exit early — the test / perf / smoke
@@ -145,12 +231,14 @@ elif [ ! -x "$BIN" ]; then
 elif ! command -v jq >/dev/null 2>&1; then
     skip "jq not installed (needed to parse $BASELINE)"
 else
-    # Detect baseline schema version.
-    # v1 (perf_baseline_chunked.json): has top-level "models" map + "regression_thresholds".
-    # legacy (perf_baseline.json): single model under "metrics.decode_tps".
+    # Detect baseline schema version (R4/#579: all three baselines now carry a
+    # common "schema_version" string — "legacy-v1" | "multi-model-v1"). Fall back
+    # to the historical numeric ".version" (multi-model == 1) for forward-tolerance
+    # if an older/regenerated file still lacks schema_version.
+    BL_SCHEMA=$(jq -r '.schema_version // empty' "$BASELINE")
     BL_VERSION=$(jq -r '.version // 0' "$BASELINE")
 
-    if [ "$BL_VERSION" = "1" ]; then
+    if [ "$BL_SCHEMA" = "multi-model-v1" ] || [ "$BL_VERSION" = "1" ]; then
         # ---- Multi-model v1 schema ----
         DEC_THR=$(jq -r '.regression_thresholds.decode_pct' "$BASELINE")
         PRE_THR=$(jq -r '.regression_thresholds.prefill_pct' "$BASELINE")
@@ -169,8 +257,10 @@ else
             fi
             ANY_MEASURED=1
             ERR=$(mktemp)
+            gpu_sample_start
             "$BIN" --model "$MODEL_PATH" --bench --bench-pp 512 --bench-reps $REPS \
                   --prefill-chunk-size "$BENCH_CHUNK" --max-tokens 256 --temperature 0 >/dev/null 2>"$ERR"
+            gpu_sample_stop
             PP=$(grep -oP '^pp\s+512\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' "$ERR" | head -1)
             TG=$(grep -oP '^tg\s+256\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' "$ERR" | head -1)
             if [ -z "$PP" ] || [ -z "$TG" ]; then
@@ -184,8 +274,9 @@ else
                 PRE_REG=$(awk -v d="$PRE_DELTA" -v t="$PRE_THR" 'BEGIN{print (-d > t) ? 1 : 0}')
                 printf "  %-42s  tg256=%7.2f (base %7.2f, %+.1f%%)  pp512=%7.1f (base %7.1f, %+.1f%%)\n" \
                     "$BL_MODEL" "$TG" "$BL_TG" "$DEC_DELTA" "$PP" "$BL_PP" "$PRE_DELTA"
+                [ -n "${GPU_DRIFT_DESC:-}" ] && echo "    GPU during bench: $GPU_DRIFT_DESC"
                 if [ "$DEC_REG" = "1" ]; then
-                    fail "$BL_MODEL: decode regression > ${DEC_THR}%"
+                    decode_regression "$BL_MODEL: decode regression > ${DEC_THR}%"
                 else
                     pass "$BL_MODEL: decode within ${DEC_THR}% threshold"
                 fi
@@ -213,8 +304,10 @@ else
             ERR=$(mktemp)
             # --prefill-chunk-size 0 forces single-chunk prefill so the baseline
             # remains apples-to-apples with the pre-chunked-prefill measurements.
+            gpu_sample_start
             "$BIN" --model "$MODEL_PATH" --bench --bench-pp 512 --bench-reps $REPS \
                   --prefill-chunk-size "${CHUNK_SIZE}" --max-tokens 128 --temperature 0 >/dev/null 2>"$ERR"
+            gpu_sample_stop
             # Bench lines (stderr) have variable spacing inside parens for short numbers:
             #   "pp   512 tokens  avg    38.47 ms  (13310.12 tok/s)  [3 reps]"
             #   "tg   128 tokens  avg   861.50 ms  ( 148.58 tok/s)  [3 reps]"
@@ -232,9 +325,10 @@ else
 
                 printf "  decode  tg128 = %7.2f tok/s  (baseline %7.2f, delta %+s%%)\n" "$TG" "$BL_TG" "$DEC_DELTA"
                 printf "  prefill pp512 = %7.2f tok/s  (baseline %7.2f, delta %+s%%)\n" "$PP" "$BL_PP" "$PRE_DELTA"
+                [ -n "${GPU_DRIFT_DESC:-}" ] && echo "  GPU during bench: $GPU_DRIFT_DESC"
 
                 if [ "$DEC_REG" = "1" ]; then
-                    fail "decode regression > ${DEC_THR}%  (if expected: ./scripts/gen_perf_baseline.sh $MODEL_PATH)"
+                    decode_regression "decode regression > ${DEC_THR}%  (if expected: ./scripts/gen_perf_baseline.sh $MODEL_PATH)"
                 else
                     pass "decode within ${DEC_THR}% threshold"
                 fi

--- a/tests/api/test_perf_regression.py
+++ b/tests/api/test_perf_regression.py
@@ -1,13 +1,25 @@
 """
 Performance regression gate.
 
-Measures TTFT and decode throughput against stored baselines. Fails if
-performance regresses beyond thresholds.
+Measures TTFT and decode throughput against the stored verify.sh baseline.
+Fails if performance regresses beyond thresholds.
 
-What it tests:   TTFT p95 regression, decode tok/s regression.
+What it tests:   TTFT p95 regression (optional, additive key), decode tok/s
+                 regression vs the canonical baseline.
 What it does NOT test: Absolute performance, model quality.
 External state:  Running imp-server with real model + GPU.
                  Baseline file: tests/perf_baseline.json
+
+The baseline file is the canonical verify.sh schema (legacy single-model):
+    {"metrics": {"decode_tps": {"tg128": ...}, "prefill_tps": {"pp512": ...}},
+     "thresholds": {"decode_regression_pct": 3, ...}, "schema_version": ...}
+This suite gates decode throughput against metrics.decode_tps.tg128 and reads
+its threshold from thresholds.decode_regression_pct so it shares ONE source of
+truth with scripts/verify.sh (the audit found the old ["throughput"]/["ttft"]
+keys never existed in the baseline, so the gate silently no-op'd — #579).
+
+TTFT has no key in the verify.sh schema; it is an optional additive
+"ttft" block this suite owns. When absent the TTFT test skips gracefully.
 
 Run with:  pytest test_perf_regression.py -m perf
 Update baselines:  pytest test_perf_regression.py --update-baseline
@@ -15,7 +27,6 @@ Update baselines:  pytest test_perf_regression.py --update-baseline
 
 import json
 import os
-import statistics
 import time
 
 import httpx
@@ -25,9 +36,10 @@ import conftest
 
 BASELINE_PATH = os.path.join(os.path.dirname(__file__), "..", "perf_baseline.json")
 
-# Thresholds
-TTFT_REGRESSION_PCT = 5    # p95 TTFT must not exceed baseline by more than 5%
-THROUGHPUT_REGRESSION_PCT = 3  # p50 tok/s must not regress by more than 3%
+# Fallback thresholds when the baseline omits a thresholds block. The baseline's
+# thresholds.{decode,prefill}_regression_pct take precedence (shared with verify.sh).
+TTFT_REGRESSION_PCT = 5         # p95 TTFT must not exceed baseline by more than 5%
+THROUGHPUT_REGRESSION_PCT = 3   # decode tok/s must not regress by more than this
 
 
 def load_baseline() -> dict:
@@ -35,6 +47,18 @@ def load_baseline() -> dict:
         with open(BASELINE_PATH) as f:
             return json.load(f)
     return {}
+
+
+def baseline_decode_tps(baseline: dict):
+    """Canonical decode-throughput baseline (verify.sh schema). None if absent."""
+    return baseline.get("metrics", {}).get("decode_tps", {}).get("tg128")
+
+
+def baseline_decode_threshold_pct(baseline: dict) -> float:
+    """Decode regression threshold from the baseline, else the module default."""
+    return baseline.get("thresholds", {}).get(
+        "decode_regression_pct", THROUGHPUT_REGRESSION_PCT
+    )
 
 
 def save_baseline(data: dict):
@@ -136,7 +160,13 @@ class TestThroughputRegression:
     RUNS = 10
 
     def test_decode_throughput(self, client, model, request):
-        """Decode tok/s p50 must not regress vs baseline by more than 3%."""
+        """Decode tok/s p50 must not regress vs the canonical verify.sh baseline.
+
+        Gates against metrics.decode_tps.tg128 with thresholds.decode_regression_pct
+        (the same keys scripts/verify.sh reads) so the gate has a single source of
+        truth. --update-baseline rewrites that key in place, preserving the rest of
+        the verify.sh schema.
+        """
         update = request.config.getoption("--update-baseline", default=False)
         baseline = load_baseline()
 
@@ -159,18 +189,22 @@ class TestThroughputRegression:
         print(f"\n  Decode throughput p50: {p50:.1f} tok/s")
 
         if update:
-            baseline["throughput"] = {"decode_tps_p50": p50}
+            baseline.setdefault("metrics", {}).setdefault("decode_tps", {})["tg128"] = p50
             save_baseline(baseline)
             return
 
-        if "throughput" not in baseline:
-            pytest.skip("No throughput baseline. Run with --update-baseline first.")
+        base = baseline_decode_tps(baseline)
+        if base is None:
+            pytest.skip(
+                "No decode baseline (metrics.decode_tps.tg128) found. "
+                "Run scripts/gen_perf_baseline.sh or --update-baseline first."
+            )
 
-        base_p50 = baseline["throughput"]["decode_tps_p50"]
-        threshold = base_p50 * (1 - THROUGHPUT_REGRESSION_PCT / 100.0)
+        thr_pct = baseline_decode_threshold_pct(baseline)
+        threshold = base * (1 - thr_pct / 100.0)
         assert p50 >= threshold, (
             f"Decode throughput p50={p50:.1f} tok/s below baseline "
-            f"{base_p50:.1f} tok/s by >{THROUGHPUT_REGRESSION_PCT}% "
+            f"{base:.1f} tok/s by >{thr_pct}% "
             f"(threshold={threshold:.1f} tok/s)"
         )
 

--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "legacy-v1",
   "model": "Qwen3-8B-Q8_0.gguf",
   "gpu": "NVIDIA GeForce RTX 5090",
   "cuda": "unknown",

--- a/tests/perf_baseline_chunked.json
+++ b/tests/perf_baseline_chunked.json
@@ -1,5 +1,6 @@
 {
   "comment": "Chunked-prefill perf baseline (chunk=512). Looser gates than perf_baseline.json (5% decode / 8% prefill) to account for gather + rect-attn overhead per chunk. Measured 2026-05-08 on RTX 5090, CUDA 13.2, 5 reps each with --prefill-chunk-size 512.",
+  "schema_version": "multi-model-v1",
   "version": 1,
   "gpu": "NVIDIA GeForce RTX 5090",
   "cuda": "13.2.78",

--- a/tests/perf_baseline_north_star.json
+++ b/tests/perf_baseline_north_star.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "legacy-v1",
   "model": "Qwen3-14B-Q6_K.gguf",
   "gpu": "NVIDIA GeForce RTX 5090",
   "cuda": "13.2",


### PR DESCRIPTION
Implements plan item **R4** from \`tests/TEST_AUDIT.md\` (PR #575). Closes #579.

## 1. \`test_perf_regression.py\` baseline-key bug (P1.5)
The suite gated against \`["ttft"]\`/\`["throughput"]\` keys that never existed in \`tests/perf_baseline.json\` → silent no-op on the first real run. Now reads the verify.sh schema (\`metrics.decode_tps.tg128\`, \`thresholds.decode_regression_pct\`) — single source of truth. Skips gracefully when keys absent; \`--update-baseline\` rewrites in place; \`perf\` marker untouched, mock CI lane unaffected (66 passed, 9 deselected).

## 2. Host-drift-aware decode gate (P2.8, #526 class)
\`verify.sh\` now samples \`nvidia-smi --query-gpu=clocks.sm,clocks.mem,power.draw\` (1s) DURING both decode-bench paths. Depressed-host signature (mem median < 13801 MHz or power max < 400 W, thresholds documented inline per #526) degrades a decode regression FAIL→WARN with a labeled, actionable message — instead of a false-positive regression on host-depressed days.
- Cold-start clock-ramp handled: first 2 samples dropped; ≤2 samples = no-data.
- **Fail-open everywhere:** no nvidia-smi / query error / no data → gate behaves exactly as before (plain FAIL). The degradation can only relax, never tighten, and never masks a regression on a healthy host.
- Verified live on the 5090 via \`make verify-fast\`: \`decode tg128 = 269.73 (baseline 268.42, +0.49%)\`, \`GPU during bench: mem=13801MHz(med) power=523W(max)\` → healthy → real PASS. Degradation matrix unit-tested (healthy+regression→FAIL, depressed+regression→WARN, no-data→FAIL).

## 3. Baseline \`schema_version\`
All three baseline files now carry a common \`schema_version\` (\`legacy-v1\` ×2, \`multi-model-v1\`); verify.sh detects via the field with numeric \`.version\` fallback; \`gen_perf_baseline.sh\` emits it. Additive — CI inline gate and all jq consumers unaffected.

## Verification
- \`bash -n\` clean; \`make verify-fast\` end-to-end PASS on RTX 5090; mock pytest lane clean.
- Two-stage review: spec review found one gap (≤2-sample cold-ramp window could misclassify as depressed) — fixed to no-data fail-open and re-verified; quality review approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)