### PR TITLE
docs: GHCR-Quickstart + OCI-Image-Labels für die Container-Package-Page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,14 @@ RUN cmake -B build -G Ninja \
 # entrypoint/healthcheck helpers need adding.
 FROM nvidia/cuda:13.3.0-runtime-ubuntu24.04
 
+# OCI image metadata — GHCR renders org.opencontainers.image.description on the
+# package page (https://github.com/kekzl/imp/pkgs/container/imp). Hardcoded here
+# (not only via docker/metadata-action) so local builds carry it too.
+LABEL org.opencontainers.image.title="imp" \
+      org.opencontainers.image.description="LLM inference engine in C++/CUDA for NVIDIA Blackwell sm_120 (RTX 5090/5080/5070 Ti, RTX PRO 6000). Native NVFP4 + GGUF, OpenAI/Anthropic-compatible server. Written entirely by Claude Code." \
+      org.opencontainers.image.source="https://github.com/kekzl/imp" \
+      org.opencontainers.image.licenses="MIT"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         jq \

--- a/README.md
+++ b/README.md
@@ -71,23 +71,31 @@ command: **[BENCHMARKS.md](BENCHMARKS.md)**. Methodology details:
 
 ## Quickstart
 
-Everything runs in Docker — no local CUDA toolkit needed.
+Everything runs in Docker — no local CUDA toolkit needed. Prebuilt images are on
+[GHCR](https://github.com/kekzl/imp/pkgs/container/imp) (built per release for
+x86-64 + sm_120a):
 
 ```bash
-git clone https://github.com/kekzl/imp.git && cd imp
-
 # Drop a GGUF or SafeTensors model into ./models/
 mkdir -p models
 
-# Build and run the server
-docker compose build imp-server
+# Run the server from the prebuilt image
 docker run --gpus all -v ./models:/models -p 8080:8080 \
-  imp:latest --model /models/your-model.gguf
+  ghcr.io/kekzl/imp:latest --model /models/your-model.gguf
 
 # Hit the OpenAI-compatible endpoint
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"messages":[{"role":"user","content":"Hello!"}],"max_tokens":64}'
+```
+
+Or build from source (tracks `main` instead of the latest release):
+
+```bash
+git clone https://github.com/kekzl/imp.git && cd imp
+docker compose build imp-server
+docker run --gpus all -v ./models:/models -p 8080:8080 \
+  imp:latest --model /models/your-model.gguf
 ```
 
 CLI reference, server flags, config, and C API: [`docs/usage.md`](docs/usage.md).


### PR DESCRIPTION
- **README-Quickstart**: nutzt jetzt zuerst das fertige Image \`ghcr.io/kekzl/imp:latest\` ([Package](https://github.com/kekzl/imp/pkgs/container/imp)) — kein Clone/Build mehr nötig; Build-from-source bleibt als Alternative (trackt \`main\`).
- **Dockerfile**: OCI-Labels im Runtime-Stage (\`org.opencontainers.image.description/source/title/licenses\`) — GHCR rendert die Description auf der Package-Page. Hardcoded statt nur via docker/metadata-action, damit auch lokale Builds sie tragen. Verifiziert: \`make build\` grün, Labels via \`docker image inspect\` bestätigt.

Hinweis: Die Description erscheint auf der Package-Page erst mit dem nächsten Image-Push (nächstes Release oder manueller \`release-docker\`-Workflow-Run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)