### PR TITLE
docs(skills): audit + refresh agent skills, add 4 workflow skills

### DIFF
--- a/.claude/skills/AUDIT_skills_2026_06_07.md
+++ b/.claude/skills/AUDIT_skills_2026_06_07.md
@@ -1,0 +1,74 @@
+# Skill Audit — 2026-06-07
+
+Audit, fix, and extension of the agent skills in `.claude/skills/`. Goal: an agent
+working on imp triggers the right skill for each recurring workflow and the skill
+content matches the current repo state (no stale facts, no dead references).
+
+## Phase 1 — Audit of existing skills
+
+| Skill | Purpose | Trigger quality | Problems found | Action |
+|---|---|---|---|---|
+| benchmark-cuda | Kernel/engine benchmarking, ncu/nsys, roofline | Good keywords; no negative cases | ① "thermal throttling skews A/B" red flag — this GPU is water-cooled and never throttles; the real artifacts (idle-downclock ~1 s ramp reading LOW, cross-day host drift 8–15% #526, back-to-back sweeps 6–10% low) were absent. ② Warmup "≥3 iterations" doesn't cover the 1 s clock ramp. ③ Bench methodology (`CUBLAS_WORKSPACE_CONFIG=:4096:8`, 10 reps, 3+ trials, one model/process) missing. ④ No Docker/WSL2 context although the host has no CUDA toolkit; nsys WSL2 flags and ncu mount recipe missing. ⑤ Claimed baseline metric `tg256`; `tests/perf_baseline.json` gates on `tg128`. ⑥ No publish-numbers guidance (BENCHMARKS.md/README/baseline-refresh rules). | **fix** (done) |
+| check-degeneration | Output-coherence battery after hot-path changes | Very good (symptoms + "after enabling X") | Current (2026-06-04); all paths/test names/flags verified correct. Missing: re-downloaded quant caveat (06-06 Qwen3-4B/Llama-3.2-3B are different files; greedy tie-prompts diverge → NLL not byte-equality), and the docker-run pattern for the server behind `degen_suite.py`. | **fix** (minor, done) |
+| sm120-cuda-expert | Writing/optimizing sm_120a kernels | Good | ① "FP8 prefill cache +40–60%" listed as a working technique — FP8 prefill is default-DISABLED on sm_120 (`engine_init_resolver.cpp:156`, cuBLAS `NOT_SUPPORTED` at non-aligned M). ② `attention_mxf4nvf4_probe.cu` referenced under `src/compute/` — actual location `tests/bench/`. ③ known-issues referenced `executor_moe.cu` — doesn't exist (`executor_forward_moe*.cu`/`expert_cache.cu`). ④ "AsyncGraphLoop … max_steps=255" — class is `CudaGraphConditionalRunner`, max_steps is sized per request. ⑤ Dead-end "CUTLASS TC GEMM at M=1, retry on 4.5+" — pin is v4.5.1 since PR #546; retry condition met, not re-probed. ⑥ Missing shipped levers: FA2 stack (default-on, fp16qk, bank-conflict padding, cp.async dbuf), NVFP4 lm_head, `nvfp4_ssm_proj`; missing 2026-05-30 roofline finding (occupancy raise = refuted lever on decode GEMV) nuancing "Law 2: Occupancy is king". | **fix** (done) |
+
+No merge/split/deprecate cases — the three skills are correctly delineated (measure / write / validate-output) and cross-reference each other.
+
+Side finding (docs, not skills): `GOAL.md:29` still lists H100/H200 (sm_90a) as maintained target hardware and `GOAL.md:76` a "CUTLASS Hopper FMHA path", which contradicts CLAUDE.md/README ("sm_120a only, no Hopper"). Not touched here — flagging for a docs pass.
+
+## Phase 2 — Gap analysis
+
+| Missing skill | Justification | Priority | Outcome |
+|---|---|---|---|
+| building-and-testing | Every session builds/tests; high-cost tribal knowledge: no host toolkit, root-owned `build/`, no `--mount=type=cache`, models symlinks, dep pins in two places, CI has no GPU runner (local-only GPU validation), ruleset check named `Build`, determinism/PPL caveats | P1 | **created** |
+| server-api | ~15% of commits are server work; endpoints (OpenAI+Anthropic), real SSE streaming (older audit docs say "synthetic" — obsolete since `main.cpp:192`), json_schema/`sim_advance`, cache_control prefix pinning, strict #507 model semantics, validation tooling | P1 | **created** |
+| add-model-arch | Recurring (gpt-oss #572, Nemotron, Gemma-4, vision): integration checklist + wrong-output diagnostic fingerprints (RoPE NeoX, NoPE, YaRN inversion, swa_layers, h_state FP32) | P2 | **created** |
+| quant-formats | Reference for loaders/dequant work: GGUF vs NVFP4 worlds, StorageTier dispatch contract, decode cache, KV dtypes; thin pointer to `docs/quantization.md`/`quant-pipeline.md` | P3 | **created** |
+| release/bench docs | Real staleness risk but would collide with benchmark-cuda triggers | — | **folded into benchmark-cuda** ("Publishing numbers") |
+| profiling/roofline | Already covered by benchmark-cuda | — | fix only |
+
+## Phase 3 — Changes made
+
+- `benchmark-cuda/SKILL.md`: rewritten (see Phase 1 row). New sections: STOP (5 measurement artifacts of this box), Methodology, ncu/nsys WSL2+Docker recipes, compute-sanitizer-not-on-WSL2, Publishing numbers. Description gains negative cases.
+- `sm120-cuda-expert/SKILL.md`: FP8-prefill row replaced by explicit disabled-note; FA2/NVFP4-lever rows added; Law 1/2 corrected (graph-runner class name; occupancy ceiling caveat). `references/known-issues.md`: CUTLASS-4.5 retry row updated, `executor_moe.cu` ref fixed, 3 negative results added (FP8 prefill, GDN in/out NVFP4, occupancy raise/KPAR→MR). `references/ptx-patterns.md`: 13.3 re-verification note, probe path fixed.
+- `check-degeneration/SKILL.md`: server docker-run example; quant-file caveat block (re-downloads, NLL-vs-byte-equality, Qwen3.6 non-determinism).
+- New: `building-and-testing/`, `server-api/`, `add-model-arch/`, `quant-formats/` (each a single SKILL.md).
+- New: `README.md` (index + boundary map), this report.
+
+All factual claims in new/changed content were verified against the working tree
+(Makefile, CMakeLists, `src/runtime/config.h`, `engine_init_resolver.cpp`,
+`storage_tier.h`, `model_arch.h`, `tools/imp-server/args.{h,cpp}`,
+`tools/imp-server/main.cpp:192`, `tests/perf_baseline*.json`, scripts/, tests/api/).
+One error caught in self-review: `sim_advance` lives in `schema_constrain.{h,cu}`,
+not `json_schema.h` — fixed before commit.
+
+## Phase 4 — Trigger-test matrix
+
+Assessment: does the description fire on the positive prompts and stay silent on the negative ones? (✓ = description covers it verbatim or by clear synonym.)
+
+| Skill | Should fire (examples) | Must NOT fire | Verdict |
+|---|---|---|---|
+| benchmark-cuda | "is this decode regression real?" · "profile the GEMV with ncu" · "refresh the perf baseline" | "make the kernel faster" (→ sm120) · "does the model still output sane text" (→ check-degeneration) | ✓ — both negatives named in description |
+| sm120-cuda-expert | "write an NVFP4 GEMV variant" · "kernel emits HMMA instead of mxf4nvf4" · "smem layout for hd=128" | "how fast is it" (→ benchmark-cuda) · "which quant format is this" (→ quant-formats) | ✓ — pairing note covers measurement; quant-formats negative covered from the other side |
+| check-degeneration | "after the KV change, does Qwen still answer coherently?" · "output is ' own own own'" | "server returns 404" (→ server-api) · "tests fail to build" (→ building-and-testing) | ✓ |
+| building-and-testing | "run the GPU tests" · "CI is blocked" · "bump GTest" · "build dir is root-owned, can't delete" | "bench the model" (→ benchmark-cuda) · "think-leak in responses" (→ server-api/check-degeneration) | ✓ — both negatives named |
+| server-api | "add a field to /v1/messages" · "tool calling returns malformed JSON" · "cache_control doesn't report cache_read tokens" | "imp-cli prints garbage" (→ add-model-arch/check-degeneration) · "kernel slow" | ✓ — CLI-only negative named |
+| add-model-arch | "add support for Qwen4" · "model loads but is prompt-blind" · "digits come out scrambled" | "Q8_0 block layout question" (→ quant-formats) · "decode tok/s low" (→ benchmark/sm120) | ✓ — both negatives named |
+| quant-formats | "how does NVFP4 two-level scaling work here?" · "weight lands on slow gemm_nvfp4 path" · "which KV dtype saves most VRAM" | "write a faster dequant kernel" (→ sm120) · "is Q6_K decode at roofline" (→ benchmark-cuda) | ✓ — both negatives named |
+
+Cross-check: no two descriptions claim the same trigger words for different intents;
+overlapping nouns ("perf baseline" in benchmark-cuda vs "verify-fast" in
+building-and-testing) are disambiguated by intent verbs (measure/refresh vs run/gate).
+No dead references (all cited paths smoke-checked, see Phase 3).
+
+Smoke tests: command surfaces verified against source rather than executed end-to-end
+(GPU jobs are long-running): Makefile targets exist as cited; `imp-server` flags match
+`args.cpp`; `degen_suite.py` flags/categories match source; ncu host install present
+at `/opt/nvidia/nsight-compute/2026.2.0/`; nsys on host PATH.
+
+## Residual trigger risks
+
+1. **"slow" without context** can plausibly route to benchmark-cuda or sm120-cuda-expert — acceptable: the skills cross-reference each other in line 1, so either entry point converges.
+2. **degen_suite.py is server-level** but owned by check-degeneration; server-api links to it. A prompt like "run the API battery" may fire server-api first — its Validation section routes to the same tool, so no wrong outcome.
+3. **quant-formats vs add-model-arch** on "NVFP4 model produces garbage": both could fire; add-model-arch's fingerprint table routes quant-layout cases onward. Watch in practice.
+4. GOAL.md's stale Hopper lines (see Phase 1 side finding) could mislead an agent reading GOAL.md directly — skills now consistently say sm_120a-only, but the doc itself should be fixed in a separate docs PR.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,21 @@
+# imp Agent Skills — Index
+
+Project-scoped skills for agentic work on imp (`.claude/skills/*/SKILL.md`). Each
+description states when to fire AND when not to — keep that property when editing.
+
+| Skill | Covers | Pairs with |
+|---|---|---|
+| [building-and-testing](building-and-testing/SKILL.md) | Docker build, test suite, verify gates, CI reality (no GPU runner), determinism/PPL caveats, PR conventions | benchmark-cuda (perf), check-degeneration (quality) |
+| [benchmark-cuda](benchmark-cuda/SKILL.md) | Benchmarking & profiling (cudaEvent/ncu/nsys/roofline), measurement artifacts on this box (clock ramp, host drift), baseline refresh + publishing numbers | sm120-cuda-expert |
+| [sm120-cuda-expert](sm120-cuda-expert/SKILL.md) | Writing/optimizing CUDA kernels for sm_120a; PTX templates + dead-ends ledgers in `references/` | benchmark-cuda, check-degeneration |
+| [check-degeneration](check-degeneration/SKILL.md) | Output-coherence battery after hot-path changes (degen_suite, GTest battery, graphs parity) | — |
+| [server-api](server-api/SKILL.md) | imp-server endpoints (OpenAI + Anthropic), streaming, json_schema, tool calling, cache_control, validation tools | check-degeneration |
+| [add-model-arch](add-model-arch/SKILL.md) | New-architecture integration checklist + wrong-output diagnostic fingerprints | quant-formats, check-degeneration |
+| [quant-formats](quant-formats/SKILL.md) | GGUF/NVFP4/FP8 formats, StorageTier dispatch contract, decode cache, KV dtypes | sm120-cuda-expert |
+
+Boundaries (to avoid trigger collisions):
+
+- *Measure* perf → benchmark-cuda · *write* the kernel → sm120-cuda-expert · *is the output still sane* → check-degeneration.
+- *Build/test mechanics & CI* → building-and-testing · *model output via HTTP* → server-api · *model loads but is wrong* → add-model-arch · *bytes/scales/tiers* → quant-formats.
+
+Audit history: [AUDIT_skills_2026_06_07.md](AUDIT_skills_2026_06_07.md).

--- a/.claude/skills/add-model-arch/SKILL.md
+++ b/.claude/skills/add-model-arch/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: add-model-arch
+description: Use when adding support for a new model architecture to imp, porting a model family, or debugging a model that loads but produces wrong output — "add support for <model>", "new arch", loader detection, chat template, RoPE variant, "outputs garbage", "prompt-blind", "digits scrambled", "NaN logits". Do NOT use for kernel performance (sm120-cuda-expert) or quant-format questions (quant-formats).
+---
+
+# Adding a Model Architecture — imp
+
+## Integration checklist (gpt-oss PR #572 is the reference example)
+
+1. **Enum + registry**: add to `ModelArch` in `src/model/model_arch.h`; wire `parse_model_arch` (GGUF `general.architecture`, `gguf_loader.cpp:1114`) and/or HF detection (`hf_config_loader.cpp:76` — `architectures` array, `model_type` fallback), `model_arch_name`, `apply_arch_defaults`, sampling defaults in `src/model/model_arch.cpp`.
+2. **Loader**: tensor-name mapping in `src/model/tensor_kind_matcher.cpp` / `weight_map.cpp`; SafeTensors path in `safetensors_loader.cpp` (NVFP4 prequant via `llm_compressor_loader.cpp` if applicable).
+3. **Arch config**: RoPE variant (NeoX vs GPT-J pair layout! see traps), YaRN/`rope_freq_scale`, SWA layer pattern, attention quirks (NoPE, sinks, softcap), norm placement, MoE router type — in `model_config.h` + `apply_arch_defaults`.
+4. **Chat template**: `src/model/chat_template.cpp` (+ `jinja.cpp` if templated); think/reasoning channel handling if applicable.
+5. **Kernels** only if genuinely new ops (sinks, new gating) — check `src/exec/` + `src/compute/` for an existing path first.
+6. **Verify** (in order): loads → coherent greedy output (run `check-degeneration` battery) → **perplexity vs HF reference** (`imp-cli --perplexity`; expect within ~10-20% of HF, e.g. gpt-oss 7.67 vs HF 6.71) → decode/prefill sanity (`benchmark-cuda`).
+7. **Docs**: row in `docs/supported-models.md` (+ BENCHMARKS.md if hero-class); perf baseline entry if it becomes a gated model.
+
+## Diagnostic fingerprints (wrong-output triage)
+
+| Symptom | Root-cause class | Historical case |
+|---|---|---|
+| Fluent text but ignores the prompt ("prompt-blind") | **RoPE pair layout** — HF SafeTensors need `rope_neox=true`; GGUF pre-permutes Q/K | whole SafeTensors Llama/Mistral family, PR #503 |
+| Words fine, digits/numbers scrambled | Position encoding bug (NoPE layer treated as RoPE, or vice versa) | Nemotron-H `rope_attn_disabled`, PR #518 |
+| Argmax always token 0 | NaN logits upstream (residual overflow, bad scale) | gpt-oss FP16 residual overflow |
+| Coherent until ~1k ctx, then garbage | YaRN/`rope_freq_scale` inverted or fused-rope path missing YaRN | gpt-oss: inverted scale = 1024× error, PR #572 |
+| Long-context wrong only with chunked prefill | continuation-chunk path | PR #553 |
+| Wrong language / valid-but-wrong tokens | weight upload / dequant layout, not the arch code | |
+| CLI fine, server broken | not an arch bug — see `server-api` skill |
+
+## Known traps (each cost a debugging session)
+
+- **`rope_neox`**: GGUF converters pre-permute Q/K; HF SafeTensors do NOT. Llama-family SafeTensors without `rope_neox=true` = prompt-blind.
+- **SWA layer masks**: the `swa_layers` pattern was Gemma-only hardcoded once — verify per-layer attention type for any interleaved-SWA arch.
+- **Fused-rope-KV vs YaRN**: the fused rope+KV-write kernel must apply the same YaRN scaling as the standalone path.
+- **Banned-token list vs channel tokens**: arch-specific control tokens (Harmony channels) must not land on the banned list.
+- **Per-layer rope_freqs** (Gemma-4): non-SWA layers need their own freqs, `n_rot=hd`.
+- **h_state precision** (GDN/hybrid): FP32 gate required — FP16 NaNs at depth.
+- **`attention_k_eq_v`** (gemma-4-31B-style) is NOT implemented — such archs need real work, not config.
+- Model too big? 32 GB VRAM: ~29 GiB weights is the practical ceiling (gemma-4-31B NVFP4 never fits).
+
+## After it works
+
+Re-run `make verify-fast`, add the model to local model notes, and consider a `DegenerationTest`-compatible probe prompt. New archs with think-channels: validate via `tools/analysis/degen_suite.py` against a running server (think-leak category).

--- a/.claude/skills/benchmark-cuda/SKILL.md
+++ b/.claude/skills/benchmark-cuda/SKILL.md
@@ -1,40 +1,40 @@
 ---
 name: benchmark-cuda
-description: Use when benchmarking, profiling, or A/B-testing CUDA kernels in the imp inference engine on RTX 5090 (sm_120). Triggers on "benchmark kernel", "profile cuda", "ncu", "nsys", "kernel timing", "occupancy", "bandwidth bound", "compute bound", "roofline", "perf baseline", "kernel feels slow", "is this regression real".
+description: Use when benchmarking, profiling, or A/B-testing CUDA kernels or end-to-end perf in the imp inference engine on RTX 5090 (sm_120), including refreshing tests/perf_baseline.json or publishing numbers to BENCHMARKS.md/README. Triggers on "benchmark kernel", "profile cuda", "ncu", "nsys", "kernel timing", "occupancy", "bandwidth bound", "compute bound", "roofline", "perf baseline", "is this regression real", "decode dropped". Do NOT use for writing/optimizing kernel code (sm120-cuda-expert) or output-quality checks (check-degeneration).
 ---
 
 # CUDA Kernel Benchmarking — imp / sm_120 / RTX 5090
 
 Pair with `sm120-cuda-expert` for optimization decisions.
 
-## STOP — read first
+## STOP — what is a real signal on this box
 
-**Decode (`tg256`) is the only reliable A/B signal.** `pp512` varies up to **2.6× across container restarts** because cuBLAS picks different algorithms each cold start. Never gate on prefill-only numbers; always show decode delta too. The CI gate (`tests/perf_baseline.json`) reflects this: 3% decode threshold, 5% prefill threshold.
+1. **Decode is the only reliable A/B signal.** Prefill (`pp512`) varies up to **2.6× across container restarts** (cuBLAS algo re-selection each cold start). Never gate on prefill-only numbers. Metric keys: `tests/perf_baseline.json` gates on **`tg128`**; ad-hoc bench runs usually report `tg256` — compare like with like.
+2. **The GPU is water-cooled and never throttles** (idles ~30 °C). Do NOT insert temperature cooldowns. The 15 s cooldown in `gen_perf_baseline.sh` resets **cuBLAS algo-selection state** under sustained load, not temperature.
+3. **Idle downclock is the dominant cold-start artifact.** Clocks take ~1 s to ramp under load — the first second reads artificially LOW (produced a spurious −42% that re-measured +20% clean). Always precede timed reps with a **discarded warmup run >1 s**; imp's built-in `Warmup...` is too short.
+4. **Decode can read 8–15% low for a whole day** (host/driver state, WSL2 — issue #526). Sample clocks DURING the bench: `nvidia-smi --query-gpu=clocks.sm,clocks.mem,power.draw --format=csv -l 1`. Healthy load ≈ **2850 MHz SM / 13801 MHz mem / ~500 W**. Lower mem clock or power = depressed host day → do NOT trust cross-day deltas or refresh baselines that day.
+5. **Back-to-back sweeps read 6–10% low** vs isolated runs. One model per process, isolated, before trusting cross-model deltas.
 
-## Theoretical peaks (RTX 5090)
+## Methodology (every A/B)
 
-| Metric | Peak |
-|--------|------|
-| HBM bandwidth | 1,792 GB/s |
-| FP16 TC | 838 TFLOPS |
-| FP8 TC | 1,677 TFLOPS |
-| FP4 TC | 3,354 TOPS |
-| L2 cache | 96 MB |
+`CUBLAS_WORKSPACE_CONFIG=:4096:8` · 10 reps · 3+ trials · one model per process · `make check-gpu` first (no concurrent GPU consumers) · warm clocks >1 s before timing.
 
-Below 60% bandwidth (memory-bound) or 50% compute (compute-bound) → investigate.
+The host has **no CUDA toolkit** — all binaries run inside Docker (`imp:test`, models mounted from `/home/kekz/models`, NOT the repo's `models/` symlinks).
 
 ## Pick the right tool
 
 | Goal | Tool | Notes |
 |------|------|-------|
-| End-to-end engine perf | `make bench` → `tools/imp-bench/` | runs across baseline models, reports tg/pp |
-| Per-config sweep with MBU/MFU/TTFT/TBT | `bench/bench.py` | CSV output, optional llama.cpp compare |
-| Refresh perf baseline | `scripts/gen_perf_baseline.sh` | run after intentional perf changes; writes `tests/perf_baseline.json` |
-| Regression gate | `make verify-fast` | reads `tests/perf_baseline.json`, 3%/5% thresholds |
+| End-to-end engine perf | `make bench` | `imp-cli --bench --bench-pp 512 --bench-reps 5` sweep across baseline models |
+| Single model quick check | `make test-perf` | Qwen3-8B Q8_0 only |
+| Per-config sweep MBU/MFU/TTFT/TBT | `bench/bench.py` | CSV output, optional llama.cpp compare |
+| Refresh perf baseline | `make gen-perf-baseline [MODEL=/models/…]` | cold-median: 5 trials × 15 s cooldown; writes `tests/perf_baseline.json` |
+| Regression gate | `make verify-fast` | 3% decode / 5% prefill thresholds |
+| North-star gate (Qwen3-14B Q6_K) | `make verify-north-star` | vs `tests/perf_baseline_north_star.json` |
 | Single kernel — wall-clock A/B | `cudaEvent` in launcher | see Step 1 |
-| Single kernel — metrics, occupancy, stalls | `ncu` | see Step 2 |
-| Multi-kernel timeline / launch overhead / graph behavior | `nsys` | see Step 3 |
-| Compare imp vs llama.cpp | `bench/profile.sh` | apples-to-apples on same models |
+| Single kernel — metrics, stalls | `ncu` | see Step 2 |
+| Timeline / launch overhead / graphs | `nsys` | see Step 3 |
+| Compare imp vs llama.cpp | `bench/profile.sh` | same models, apples-to-apples |
 
 ## Step 1: cudaEvent in-code (quick A/B)
 
@@ -42,7 +42,7 @@ Below 60% bandwidth (memory-bound) or 50% compute (compute-bound) → investigat
 cudaEvent_t start, stop;
 cudaEventCreate(&start); cudaEventCreate(&stop);
 
-// Warmup — always >=3 iterations (first launch has JIT/cache penalty)
+// Warmup — >=3 iterations AND >1s total busy time (clock ramp, see STOP #3)
 for (int i = 0; i < 3; i++) kernel<<<...>>>(...);
 cudaDeviceSynchronize();
 
@@ -56,17 +56,20 @@ cudaEventElapsedTime(&ms, start, stop);
 float avg_us = (ms / N_ITER) * 1000.0f;
 ```
 
-Rules: warmup ≥3, N_ITER ≥100 for kernels <100µs, lock clocks (`sudo nvidia-smi -lgc 2400,2400`; reset `-rgc`), kill concurrent GPU consumers.
+Rules: N_ITER ≥100 for kernels <100 µs, check stddev not just mean, kill concurrent GPU consumers, sample clocks during the run (STOP #4).
 
 ## Step 2: Nsight Compute (ncu) — per-kernel metrics
 
-Use the helper to get a consistent metric set:
+ncu is NOT in the runtime image. Use the **host** install mounted into the container, and call the real binary (not the cuda symlink wrapper):
 
 ```bash
-./.claude/skills/benchmark-cuda/ncu-basic.sh "my_kernel.*" ./build/imp-bench
+docker run --rm --gpus all -v /home/kekz/models:/models \
+  -v /opt/nvidia/nsight-compute/2026.2.0:/ncu -v /tmp/out:/out --user root \
+  imp:test /ncu/ncu --kernel-name "regex:my_kernel.*" --launch-skip 3 --launch-count 10 \
+  -o /out/profile ./build/imp-bench …   # chmod 777 /tmp/out first
 ```
 
-Or invoke directly with the canonical metric list — see `ncu-basic.sh` for the full set. Key metrics to read:
+Canonical metric set: `./.claude/skills/benchmark-cuda/ncu-basic.sh "<kernel-regex>" <binary> [args]`. Key metrics:
 
 | Metric | Meaning | Target |
 |--------|---------|--------|
@@ -77,48 +80,59 @@ Or invoke directly with the canonical metric list — see `ncu-basic.sh` for the
 | `l1tex__t_sector_hit_rate` | L1 hit rate | >90% for cached |
 | `stall_*` | Where warps stall | lowest = bottleneck |
 
-Always `--launch-skip 3 --launch-count N` to skip warmup. Compile with `-lineinfo` for source-correlated stalls (`--set detailed --import-source yes`).
+Always `--launch-skip 3 --launch-count N`. Compile with `-lineinfo` for source-correlated stalls (`--set detailed --import-source yes`).
 
 ## Step 3: Nsight Systems (nsys) — timeline
 
 When you suspect: launch overhead, H2D/D2H stalls, stream serialization, CUDA Graph behavior.
 
+**WSL2 needs sampling disabled** or nsys hangs/errors:
+
 ```bash
-nsys profile --stats=true -t cuda,nvtx,osrt \
-    --cuda-memory-usage=true -o timeline \
-    --force-overwrite=true ./build/imp-bench
+nsys profile --sample=none --cpuctxsw=none --backtrace=none -t cuda,nvtx \
+    --stats=true --cuda-memory-usage=true -o timeline --force-overwrite=true \
+    ./build/imp-bench …
 nsys stats timeline.nsys-rep
 ```
 
-**`nsys` needs `--no-cuda-graphs`** when measuring per-kernel times — graph replay hides individual kernel timings.
+**CUDA Graphs hide captured kernels** — profile with imp's `--no-cuda-graphs` flag to see the true decode kernel mix.
 
-Red flags: gaps between launches >10µs (CPU-bound) · H2D/D2H during compute without overlap · CUDA Graph not collapsing launches (graph disabled or stream-captured wrong).
+Red flags: gaps between launches >10 µs (CPU-bound) · H2D/D2H during compute without overlap · graph not collapsing launches (silent fallback — see `check-degeneration`).
+
+**compute-sanitizer does NOT work on WSL2** (WDDM exposes no debugger interface). `make sanitize` is documented for native-Linux hosts only.
 
 ## Step 4: Roofline (one-liner)
 
-`AI = total_flops / total_bytes_moved` (matmul FLOPs = `2·M·N·K`; bytes from `dram__bytes.sum` in ncu). Ridge points: FP16=468, FP8=936, FP4=1873 FLOP/byte. AI < ridge → memory-bound; AI > ridge → compute-bound.
+`AI = total_flops / total_bytes_moved` (matmul FLOPs = `2·M·N·K`; bytes from `dram__bytes.sum` in ncu). Peaks: HBM 1,792 GB/s · FP16 838 TFLOPS · FP8 1,677 · FP4 3,354 TOPS · L2 96 MB. Ridge points: FP16=468, FP8=936, FP4=1873 FLOP/byte. AI < ridge → memory-bound.
 
 ## Report template
 
 ```
 Kernel: <name>, config: <block=X, grid=Y, smem=Z>
-  Wall:        <us> µs (N=<iters>, warmup=3)
+  Wall:        <us> µs (N=<iters>, warmup >1s)
   DRAM:        <pct>% of 1792 GB/s
   SM:          <pct>% of peak
   Occup:       <pct>%
   TC util:     <pct>%
+  Clocks live: <MHz SM>/<MHz mem>/<W>   (healthy: 2850/13801/~500)
   Bound by:    <memory|compute|latency|stalls>  reason: <top stall>
-  vs baseline: <±X%>
+  vs baseline: <±X%> on tg (decode)
 ```
+
+## Publishing numbers (keep docs from going stale)
+
+- **`tests/perf_baseline.json`** is the canonical CI gate. Refresh ONLY when a change *intentionally* moves perf: `make gen-perf-baseline`, on a healthy-host day (STOP #4), and say so in the PR.
+- **`BENCHMARKS.md`** is SHA-anchored (method, date, commit, command, tok/s). Update it — and the README numbers — in the same commit as the perf change. `scripts/check-release.sh` gates release-touching PRs.
+- `bash scripts/scoreboard.sh` tallies hero-model status vs llama.cpp.
 
 ## Red flags — STOP and re-run
 
-- Reporting `pp512` delta without `tg256` delta → variance is up to 2.6×, you're seeing noise
-- Skipping warmup → first launch 2–10× worse (JIT + cold caches)
-- Profiling with clocks unlocked → thermal throttling skews A/B
+- Reporting `pp512` delta without a decode delta → 2.6× restart variance, you're seeing noise
+- Trusting a cold single-shot number → first ~1 s runs at idle clocks (NOT heat — this box never throttles)
+- Cross-day decode delta without sampling clocks during the bench → host drift is 8–15%
+- Refreshing the baseline on a depressed-host day → bakes a low bar in
 - Including `cudaMalloc/Free` in timing → allocate once outside the loop
-- Trusting `ncu` wall-clock → ncu serializes/replays kernels; use `nsys` or `cudaEvent` for real time
-- `ncu` without `-lineinfo` → no source correlation
-- Comparing against wrong peak → FP16 ≠ FP8 ≠ FP4 TOPS; pick the kernel's dtype
-- Small `N_ITER` on noisy kernels → run ≥100, check stddev not just mean
-- A/B without graphs both ON and OFF → graph replay can hide silent fallback (see `check-degeneration` skill)
+- Trusting `ncu` wall-clock → ncu serializes/replays; use `nsys` or `cudaEvent` for real time
+- Comparing against wrong peak → FP16 ≠ FP8 ≠ FP4; pick the kernel's dtype
+- A/B without graphs both ON and OFF → graph replay can hide silent fallback (see `check-degeneration`)
+- Back-to-back multi-model sweep deltas → isolate per process, one model each

--- a/.claude/skills/building-and-testing/SKILL.md
+++ b/.claude/skills/building-and-testing/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: building-and-testing
+description: Use when building imp, running its test suite, checking CI status, or debugging build/test failures — "make build", "run the tests", "test-gpu", "verify-fast", GTEST_FILTER, Docker/CUDA toolchain, dependency bumps, "CI is red/blocked", determinism or perplexity checks. Do NOT use for benchmarking/profiling (benchmark-cuda) or output-quality batteries (check-degeneration).
+---
+
+# Build & Test — imp
+
+## Hard rules (violations cost hours)
+
+1. **The host has NO CUDA toolkit by design.** All build/run/test happens inside Docker (`make build` → image `imp:test`, CUDA 13.3, nvcc V13.3.33). Never apt-install toolchains on the host.
+2. **`build/` is root-owned** (created by the container). Remove via throwaway container, never `sudo` on the host: `docker run --rm -v $PWD:/src -w /src ubuntu rm -rf build`.
+3. **Never use `--mount=type=cache`** in the Dockerfile — it silently invalidates test results.
+4. **`models/` in the repo is a symlink farm** to `/home/kekz/models`. Most Makefile targets mount `$(PWD)/models`, which works because Docker resolves on access — but for custom `docker run`, mount `/home/kekz/models:/models` directly so symlink targets resolve.
+5. **Dependency pins live in TWO places**: `CMakeLists.txt` FetchContent AND the Dockerfile deps-clone. Bump BOTH (current: CUTLASS v4.5.1, GTest v1.17.0, nlohmann/json v3.12.0, httplib v0.46.1).
+6. **CI has no GPU runner.** The `Test` job and perf gate are SKIPPED in CI — GPU correctness/perf validation is LOCAL-ONLY (`make verify-fast` before push; `make install-hooks` installs the pre-push hook). The required GitHub check is named exactly `Build`; renaming the CI job without updating ruleset "Require CI" (id 14716423) leaves PRs stuck at `mergeState=BLOCKED`.
+
+## Command table
+
+| Task | Command | Time |
+|---|---|---|
+| Build Docker image (tests on) | `make build` | varies |
+| CPU/host unit tests | `make test-unit` | <5 s |
+| Full GPU suite | `make test-gpu` | ~4–5 min (`test-attention` alone ~241 s) |
+| E2E model tests (real models) | `make test-e2e` | needs Qwen3-4B + Qwen3.5-4B + Gemma-4 GGUFs |
+| Vision goldens | `make test-vision` | `IMP_VISION_GOLDEN_DUMP=1` to regenerate |
+| Pre-push gate | `make verify-fast` | ~90 s; build + filtered tests + perf gate + smoke |
+| Full pre-merge gate | `make verify` | ~5 min |
+| Chunked-prefill gate | `make verify-chunked` | vs `perf_baseline_chunked.json`, 5%/8% |
+| North-star gate | `make verify-north-star` | Qwen3-14B Q6_K vs its own baseline |
+| clang-format (in container) | `make format` / `make format-check` | repo is NOT fully format-clean — never format whole files you didn't touch |
+| API mock contract suite | `pytest tests/api/` (see `tests/api/run_mock_tests.sh`) | no GPU needed |
+
+Filtered run with explicit model:
+
+```bash
+docker run --rm --gpus all -v /home/kekz/models:/models \
+  -e IMP_TEST_MODEL=/models/Qwen3-8B-Q8_0.gguf \
+  imp:test imp-tests --gtest_filter="DegenerationTest.*"
+```
+
+Test binaries in the image: `imp-tests` (full GPU), `imp-tests-unit` (CPU), plus split binaries `test-core test-text test-compute test-attention test-quant test-kv test-moe-gdn test-e2e test-gdn`.
+
+## Determinism & quality caveats
+
+- `--set runtime.deterministic=true` gives full temp=0 reproducibility (covers MoE routing atomics + top-k sampling races + implies `deterministic_gemm`). Default OFF — costs throughput. The engine promotes it process-wide since PR #542.
+- 3 `DISABLED_` tests mark known determinism boundaries (cross-context GDN, FMHA smem) — do not "fix" them by re-enabling.
+- Qwen3.6-35B is non-deterministic at temp=0 even with full methodology — never assert exact output for it.
+- Perplexity: `imp-cli --perplexity <textfile>` (teacher-forced, chunk-aware since PR #553 — PPL absolutes from before 2026-06-06 on corpora >2k tokens were wrong; same-corpus A/B deltas remain valid).
+- `imp-cli` logs to **stdout** — strip log lines before hashing output.
+- `make sanitize` (compute-sanitizer) does NOT work on WSL2 (WDDM, no debugger interface) — native-Linux hosts only.
+
+## When the build fails
+
+- nvcc/arch errors: target is raw gencode `compute_120a/sm_120a` + optional `compute_120f` PTX fallback (`CMakeLists.txt` ~line 31). Don't "fix" by switching to generic `sm_120`/`compute_120` — see `sm120-cuda-expert`.
+- FetchContent mismatch vs Docker deps-clone → see hard rule 5.
+- Out-of-space: Docker images are large; prune old `imp:*` images first.
+
+## PR / merge conventions
+
+Branch off `main`, `gh pr create --base main`, never stack PRs. Batch related fixes into one PR. CI green (`Build`) + auto-merge; GPU validation stays your job locally. If a change intentionally moves perf, refresh `tests/perf_baseline.json` (see `benchmark-cuda` skill → Publishing numbers) and say so in the PR.

--- a/.claude/skills/check-degeneration/SKILL.md
+++ b/.claude/skills/check-degeneration/SKILL.md
@@ -39,7 +39,10 @@ where the recurring production failures live (reasoning/think separation,
 channel stripping, stop handling, truncated-think spill, prompt-blindness):
 
 ```bash
-# server must be running (any model); stdlib-only, runs on the host
+# server must be running, e.g.:
+#   docker run --rm --gpus all -p 8080:8080 -v /home/kekz/models:/models imp:test \
+#     imp-server --host 0.0.0.0 --model /models/<MODEL>
+# the suite itself is stdlib-only and runs on the host:
 python3 tools/analysis/degen_suite.py --url http://localhost:8080
 # Qwen3.6 is non-deterministic at temp=0 — skip the equality check:
 python3 tools/analysis/degen_suite.py --skip-deterministic
@@ -117,6 +120,8 @@ Any match = **fail**, even if output passed the heuristic. Cross-check measured 
 | Llama-3.2-3B | "The capital of France is" | `Paris` |
 
 Pick the first model from this table whose family matches your change. Stable prompts give stable regressions — do not invent new probes.
+
+**Quant-file caveat (2026-06-06):** the local Qwen3-4B (unsloth) and Llama-3.2-3B (bartowski) GGUFs are re-downloads — *different quant files* than the originals. Greedy behavior on logit-tie prompts differs (the unsloth 4B degenerates on synthetic list prompts even unchunked — that's model-intrinsic, NOT an engine bug). For byte-level A/B prefer NLL/perplexity comparison over exact-output equality (the ChunkedPrefill tests switched to NLL for this reason, PR #553). Qwen3.6-35B is non-deterministic even at temp=0 — greedy-token A/B is INVALID there; use perplexity or `degen_suite.py --skip-deterministic`.
 
 ## Red flags — STOP and re-run
 

--- a/.claude/skills/quant-formats/SKILL.md
+++ b/.claude/skills/quant-formats/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: quant-formats
+description: Use when working on imp's quantization formats, loaders, or dequant paths — GGUF Q4_0…Q8_0/Q*_K/IQ4/MXFP4, NVFP4 two-level scaling, FP8 E4M3, StorageTier, decode cache, KV-cache dtypes, "which quant should I use", scale-factor layout, dequant kernel wiring. Do NOT use for writing/optimizing GEMM/GEMV kernels (sm120-cuda-expert) or measuring quant perf (benchmark-cuda).
+---
+
+# Quantization Formats & Pipelines — imp
+
+**Sources of truth: `docs/quantization.md` (formats, choosing a quant) and `docs/quant-pipeline.md` (files, GEMM-dispatch registry, boundary rules).** This skill carries only the agent-facing gotchas — read those docs for the full picture.
+
+## The two worlds
+
+| | GGUF | SafeTensors NVFP4 (prequant) |
+|---|---|---|
+| Formats | Q8_0, Q6_K, Q5_K_M, Q4_K_M, Q4_0, IQ4_NL/XS, MXFP4 | NVFP4: per-tensor AWQ scale (FP32) + per-16 FP8-E4M3 micro-scales |
+| Decode | dp4a GEMV per qtype; **plus NVFP4 decode cache built at init** (bandwidth win) | native NVFP4 GEMV (prmt LUT) |
+| Prefill | cuBLAS on dequanted source (full precision) | CUTLASS NVFP4 GEMM (sm_120 TC) |
+| Priority | legacy/maintenance — esp. community MXFP4 quality bugs: don't sink time | **the strategic path** |
+
+- GGUF→NVFP4 decode cache: weights converted at init; `nvfp4_beneficial` weights skip the FP16 cache. Opt-in extensions: `gemm.nvfp4_ssm_proj` (+53% GGUF hybrid), `gemm.nvfp4_attn_proj`.
+- gpt-oss: native MXFP4 experts are converted to NVFP4 at load.
+
+## StorageTier is the dispatch contract (`src/core/storage_tier.h`)
+
+`Undefined` (FATAL if dispatched) · `FP32` · `FP16` · `FP8` (E4M3 + per-tensor scale) · `NVFP4` (two-level micro-scale, decode-GEMV path) · `CUTLASS_NVFP4` (block-scaled, CUTLASS sm_120 grouped-GEMM **fast path**) · `MXFP4` (CUTLASS FMHA path).
+
+**`NVFP4` ≠ `CUTLASS_NVFP4`**: a weight stuck on plain `NVFP4` falls through to the slow `gemm_nvfp4` dequant→cuBLAS fallback. For the fast path the scale factors need the CUTLASS SfAtom layout (set up in `src/exec/pre_dequant_*.cu`, Phase 3b). `convert_scales_sfatom` is a load-time artifact — not a runtime perf lever.
+
+## MoE specifics
+
+Per-expert NVFP4 tensors are copied into one contiguous `[ne, N, K_packed]` buffer per layer/projection at load (`cache_moe_native_nvfp4`) — this is what makes CUDA-Graph capture possible. Without it: per-step FP16 dequant + cuBLAS, 5–17× slower, no graphs.
+
+## KV cache dtypes
+
+`kv_cache.dtype = fp16 | fp8 | int8 | int4 | nvfp4` (CLI: `--kv-fp8` etc.). FP8 KV has a nondeterminism opt-in (`allow_nondeterministic_fp8`). Quant-KV accuracy envelopes are frozen in tests (TEST_AUDIT).
+
+## Gotchas
+
+- **Q8_0 blocks are 34 bytes, NOT 4-aligned** — `memcpy()`, never `reinterpret_cast`.
+- **FP8 prefill is disabled on sm_120** (cuBLAS `NOT_SUPPORTED` at non-aligned M) — don't build on it.
+- **MXFP4 GGUF default stays `legacy`** (`attention.mxfp4_fp16_cache_policy`); Qwen3.5-27B/4B MXFP4 has an open IMA/incoherence bug family — known, parked.
+- **Dequant correctness is golden-locked**: GGUF dequant is bit-exact vs spec; f16-class cross-path tolerance is strict 1e-2 (measured ~4e-4). If your change moves these, it's a bug, not noise.
+- Quantizing new checkpoints happens OUTSIDE imp (NVIDIA ModelOpt / llm-compressor); imp only loads. Bad community quants exist — a degenerate model can be the file, not the engine (verify with llama.cpp control where possible).
+- NVFP4 lm_head quantization (`gemm.nvfp4_lm_head`, `_gdn` default ON) trades +2.2% PPL for +8–16% decode — owner-accepted; don't "fix" the PPL delta by reverting silently.

--- a/.claude/skills/server-api/SKILL.md
+++ b/.claude/skills/server-api/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: server-api
+description: Use when working on or testing imp-server and its HTTP APIs — OpenAI/Anthropic endpoints, /v1/chat/completions, /v1/messages, SSE streaming, tool calling, json_schema/constrained decoding, thinking/reasoning_content, cache_control/prefix cache, model loading semantics, "server returns 404/garbage", API compliance. Do NOT use for CLI-only inference (imp-cli), kernel work (sm120-cuda-expert), or pure output-quality checks (check-degeneration).
+---
+
+# Server & API — imp-server
+
+Source: `tools/imp-server/` (`main.cpp` routes, `handlers.cpp` OpenAI dialect, `anthropic.cpp` Anthropic dialect, `batching_engine.cpp` scheduler).
+
+## Start the server
+
+```bash
+docker run --rm --gpus all -p 8080:8080 -v /home/kekz/models:/models imp:test \
+  imp-server --host 0.0.0.0 --model /models/<MODEL> [--set server.prefix_cache=true]
+```
+
+Key flags (`imp-server --help` for all): `--port` (8080) · `--chat-template auto|chatml|llama3|nemotron|gemma` · `--lora NAME=PATH` (repeatable, select per request via `"lora"`) · `--kv-fp8|--kv-int8|--kv-int4|--kv-nvfp4` · `--think-budget <frac>` (default 0.5 of max_tokens) · `--api-key` · `--max-concurrent` (64) · `--log-requests <jsonl>` · `--mmproj` (vision) · `--set section.key=value` for any `RuntimeConfig` override.
+
+## Endpoints
+
+| Route | Dialect | Notes |
+|---|---|---|
+| `POST /v1/chat/completions` | OpenAI | SSE streaming, tools, json_schema |
+| `POST /v1/completions` | OpenAI legacy | raw text |
+| `POST /v1/messages` | **Anthropic** | thinking, tool use, `cache_control`, **real per-token SSE** (`main.cpp:192` — old "synthetic replay" info is obsolete) |
+| `GET /v1/models` | both | **strict semantics since PR #507**: only the loaded model is listed; a foreign `model` field → 404 `model_not_found`; switching models = restart (auto-swap was removed after a reload SIGSEGV) |
+| `POST /tokenize`, `/detokenize` | imp | |
+| `GET /health`, `/metrics` | imp | healthcheck / Prometheus |
+
+## Semantics that bite
+
+- **Thinking**: default-ON for think-capable models in plain chat (json/tools requests excluded). Reasoning is split into `reasoning_content` vs `content` (`--reasoning-format deepseek`); gpt-oss uses Harmony channels (analysis/final) mapped the same way. Think-budget guarantees answer headroom — `started_in_think` edge cases were a 3-bug chain (PR #518), be careful there.
+- **Constrained decoding** (`response_format: json_schema`): the per-token FSM simulator `sim_advance` is the SINGLE grammar source (`src/compute/schema_constrain.{h,cu}`; schema parsing in `src/compute/json_schema.h`; chain PRs #497–#499). Supports `$ref`/`$defs`. Termination is exact-JSON (CAT_EOS only at DONE, whitespace cap) — the server returns exactly the JSON object.
+- **`cache_control` / prefix cache**: Anthropic `cache_control` pins prompt-KV blocks (budget `server.prefix_pin_budget_pct` = 25% FIFO) and reports `cache_read_input_tokens`/`cache_creation_input_tokens`. `server.prefix_cache` is default ON since the #536/#538 stale-block-table fix; `PrefixCacheE2ETest` is the ship gate.
+- **Config keys** (`src/runtime/config.h` → `struct Server`): `prefix_cache`, `prefix_pin_budget_pct`, `green_contexts`.
+- **Stop handling**: server stops on turn markers at high temperature (PR #442) — don't remove that guard.
+
+## Validation (run before claiming server work done)
+
+```bash
+# 1. Degeneration/think-leak/adherence battery against the running server
+python3 tools/analysis/degen_suite.py --url http://localhost:8080   # --skip-deterministic for Qwen3.6
+
+# 2. API contract suite (mock server, no GPU)
+pytest tests/api/        # or tests/api/run_mock_tests.sh
+
+# 3. SafeTensors model-level validation battery
+python3 scripts/validate_safetensors.py --help
+```
+
+## Diagnostic fingerprints
+
+| Symptom | Likely cause |
+|---|---|
+| CLI output fine, server output broken | `step()` path or NVFP4 cache divergence — not the model |
+| Think text leaking into `content` | template-injected `<think>` without `</think>` (non-stream spill) — degen_suite catches this |
+| Empty `content`, long reasoning | think-budget eaten (`--think-budget 1.0` footgun) |
+| SIGSEGV on model reload | prewarm on dangling cuBLAS stream — reload is intentionally unsupported, restart instead |
+| 404 `model_not_found` | strict #507 semantics, not a bug — request must name the loaded model |
+
+After any server-side inference change, run the `check-degeneration` skill battery (section 0 targets exactly this layer).

--- a/.claude/skills/sm120-cuda-expert/SKILL.md
+++ b/.claude/skills/sm120-cuda-expert/SKILL.md
@@ -23,9 +23,9 @@ Optimal-kernel reference for RTX 5090 (GB202, **sm_120a** — consumer Blackwell
 
 ## The three laws
 
-1. **Decode at batch=1 is launch-overhead-bound first, memory-bound second.** With ~80–120 launches per layer, per-launch µs costs dominate once GEMM is fast. Order of operations: (a) make per-launch GEMM fast (CUTLASS sm_120 NVFP4 fast-path, not slow `gemm_nvfp4` dequant→cuBLAS fallback); (b) capture decode in CUDA Graph (`AsyncGraphLoop`); (c) only then chase memory traffic. A faster kernel alone shows little tok/s gain — but it *enables* graph capture to win because launches no longer hide behind GEMM. Always re-bench graphs ON after a hot-path patch.
+1. **Decode at batch=1 is launch-overhead-bound first, memory-bound second.** With ~80–120 launches per layer, per-launch µs costs dominate once GEMM is fast. Order of operations: (a) make per-launch GEMM fast (CUTLASS sm_120 NVFP4 fast-path, not slow `gemm_nvfp4` dequant→cuBLAS fallback); (b) capture decode in CUDA Graph (the async graph decode loop — `CudaGraphConditionalRunner` in `src/runtime/cuda_graph.h`, launched by `engine_graph_decode.cpp`); (c) only then chase memory traffic. A faster kernel alone shows little tok/s gain — but it *enables* graph capture to win because launches no longer hide behind GEMM. Always re-bench graphs ON after a hot-path patch.
 
-2. **Occupancy is king.** Keep registers ≤48/thread for 100% occupancy. **Don't add `__launch_bounds__`** on regular GEMV/attention paths — overrides cost -4.5% to -20%. Two known correct exceptions: HD=128 GDN kernel needs `(HD,1)` to avoid a miscompile; FMHA `(256,1)` is correct on SMEM-limited kernels (~69 KB → 1 block/SM anyway, allows max register allocation).
+2. **Occupancy is king — for getting kernels to the roofline, not past it.** Keep registers ≤48/thread for 100% occupancy. **Don't add `__launch_bounds__`** on regular GEMV/attention paths — overrides cost -4.5% to -20%. Two known correct exceptions: HD=128 GDN kernel needs `(HD,1)` to avoid a miscompile; FMHA `(256,1)` is correct on SMEM-limited kernels (~69 KB → 1 block/SM anyway, allows max register allocation). Caveat: the mature NVFP4 decode path already sits at its ceiling — full nsys+ncu sweep (2026-05-30, Qwen3-14B NVFP4) showed decode = 87% NVFP4 GEMVs at 66–70% HBM with the plateau co-limited by 4-bit dequant (L1TEX 91%); **raising occupancy further and KPAR→MR rerouting are refuted levers there** — don't re-pursue.
 
 3. **Quantization type determines kernel strategy.** Q8_0 (simple dequant) → bandwidth-bound → row-parallel + smem-cached activations. Q6_K (complex dequant) → compute-influenced → K-parallel + warp-level work division. NVFP4 prequant → must hit `StorageTier::CUTLASS_NVFP4` (SfAtom layout) for the sm_120a fast path; plain `StorageTier::NVFP4` falls through to slow `gemm_nvfp4`. No universal "best" GEMV.
 
@@ -33,14 +33,21 @@ Optimal-kernel reference for RTX 5090 (GB202, **sm_120a** — consumer Blackwell
 
 | Technique | Gain | Detail |
 |-----------|------|--------|
-| **CUDA Graph decode + AsyncGraphLoop** | **+95–376% decode** | Conditional graph w/ PDL, `max_steps=255`. Biggest gain on small-GEMM models. Requires CUTLASS NVFP4 fast-path active first. |
-| CUTLASS sm_120a NVFP4 weight cache | enables graph win | `StorageTier::CUTLASS_NVFP4`. Verify via init log; `StorageTier::NVFP4` = slowpath. |
+| **CUDA Graph decode (conditional graph + PDL)** | **+95–376% decode** | `CudaGraphConditionalRunner`; `max_steps` sized per request. Biggest gain on small-GEMM models. Requires CUTLASS NVFP4 fast-path active first. |
+| CUTLASS sm_120a NVFP4 weight cache | enables graph win | `StorageTier::CUTLASS_NVFP4` (`src/core/storage_tier.h`); plain `StorageTier::NVFP4` = slowpath. |
 | `mma.sync.kind::mxf4nvf4.block_scale` | 2.6× raw MMA over f8f6f4 | k=64 vs k=32; HW applies UE4M3 scale inside MMA. Needs `compute_120a` (see Compile flags). |
-| FP8 prefill cache | +40–60% prefill | FP8×FP8 cuBLAS = 2× TC throughput |
+| FA2 register-resident prefill (`attention.fmha_fa2`, default on) | +13–19% long-ctx NVFP4 prefill | S/P/O in registers, 1 barrier/KV tile; declines safely for hd≠128. |
+| FP16-QK FA2 for short prefill (`attention.fa2_fp16qk`, default on) | +25–35% pp512 NVFP4 | QK^T in f16 mma — avoids the short-seq e4m3 quality cliff (#511/#512); declined configs fall back to cuBLAS. |
+| FA2 smem row-stride padding | 1.54× FA2 kernel, +27% pp16384 | head_dim=128 stride aliased all 32 banks (PR #484). Post-fix FA2 is LSU-bound ≈ ceiling. |
+| FA2 cp.async K/V double-buffer | −11.6% FA2 kernel long-ctx | prefetch tile j+1 while j computes |
+| NVFP4 lm_head (`gemm.nvfp4_lm_head`, `…_gdn` default ON) | +8–16% dense, +11.4% Qwen3.6 decode | BF16 lm_head quantized to NVFP4 at load; costs +2.2% PPL (owner-accepted). |
+| GGUF `gemm.nvfp4_ssm_proj` (opt-in) | +53% GGUF-hybrid decode | reverses the −31% GGUF Qwen3.6 loss vs llama.cpp; `nvfp4_attn_proj` +3.8% Nemotron. **NVFP4 on GDN in/out projections REGRESSES −9 to −20% — dead end.** |
 | NVFP4 prmt register LUT | +4.7–16% | `prmt.b32` replaces SMEM LUT |
 | Inline Q8_1 in O-projection | +5–10% | Eliminates 1 launch + 1 DRAM round-trip |
 | `__ldcs` on KV cache reads | +2–4% decode | Bypass L1, evict-first L2. **KV only, NOT weights.** |
 | 8-warp Blackwell attention | better SM util | 256 threads vs Hopper's 128 |
+
+**FP8 prefill is DISABLED on sm_120** (`attention.fp8_prefill` auto → off; cuBLAS FP8 returns `NOT_SUPPORTED` at non-aligned M on consumer Blackwell — `src/runtime/engine_init_resolver.cpp:156`). The historical "+40–60% prefill" FP8×FP8 cuBLAS path does not apply here; prefill levers are the FA2 family above.
 
 PTX templates for all of these → `references/ptx-patterns.md`.
 

--- a/.claude/skills/sm120-cuda-expert/references/known-issues.md
+++ b/.claude/skills/sm120-cuda-expert/references/known-issues.md
@@ -25,7 +25,7 @@ For small edits (parameter tweak, kernel-signature change, fusing two existing k
 | Dead end | Blocked by | Retry on |
 |----------|-----------|----------|
 | cuBLASLt grouped layout sm_120 | Zero algorithms for consumer Blackwell | New cuBLAS release (check algorithm count) |
-| CUTLASS TC GEMM at M=1 | Activation quant + TMA overhead | CUTLASS 4.5+ |
+| CUTLASS TC GEMM at M=1 | Activation quant + TMA overhead | ~~CUTLASS 4.5+~~ pin is v4.5.1 since PR #546 (2026-06-06) — retry condition met but NOT re-probed yet. Note: the 2026-05-30 decode roofline sweep found decode GEMV at 66–70% HBM with a 4-bit-dequant co-limit, so the upside is bounded. |
 | `cp.async.bulk` with `.ignore_oob` | Requires TMA descriptor rewrite | ~~CUDA 13.3+~~ still ❌ on 13.3 — TMA not on sm_120; next major |
 | `st.async .b128` to global | PTX 9.2 only targets `shared::cluster` | ~~New PTX ISA~~ still ❌ on PTX ISA 9.3 (13.3) |
 | CUTLASS NVFP4 sm_120 graph-determinism | Universally non-deterministic for `cudaGraphExecUpdate` re-capture (verified 2026-05-05) | Future CUTLASS NVFP4 deterministic mode |
@@ -57,7 +57,7 @@ These bugs were diagnosed at high cost. The current kernels assume the fix is in
 | **Qwen3.5 Q8 α/β qtype consistency** | Pre-dequanted Q8→FP16 without updating qtype → dispatcher mis-interprets bytes → state collapse | `upload_weight` path — keep qtype tag in sync with stored bytes. |
 | **Qwen 3.6 h_state FP32 gate + PyTorch L2 norm** | NaN at L38 in GDN | h_state must be FP32, not FP16/BF16. |
 | **Gemma-4 per-layer `rope_freqs` for non-SWA layers, `n_rot=hd`** | L13/L14 drift 11–15% (was) → <2% (fixed) | Pass per-layer rope_freqs through. |
-| **MoE expert-offload auto-probe at 10% before falling back to 30%** | Qwen3-Coder-30B Q6_K decode 234 → 77 tok/s | `executor_moe.cu` — keep the 10% probe. |
+| **MoE expert-offload auto-probe at 10% before falling back to 30%** | Qwen3-Coder-30B Q6_K decode 234 → 77 tok/s | MoE offload path (`src/exec/executor_forward_moe*.cu` / `expert_cache.cu`, config `moe.expert_overhead_pct=10`) — keep the 10% probe. |
 | **L2 access-policy window `num_bytes` clamp to `cudaDevAttrMaxAccessPolicyWindowSize`** | Silent CUDA error / IMA on 5090 (128 MiB max) | `set_l2_streaming` / `set_l2_persist_kv` in `runtime/`. |
 | **NVFP4 dequant graph-safe fallback (PR #121)** | `cudaMallocAsync` inside captured graph crash | `set_nvfp4_dequant_workspace()` + capture-guard in `ensure_dequant_buffer`. |
 
@@ -78,6 +78,9 @@ These bugs were diagnosed at high cost. The current kernels assume the fix is in
 ## Negative results (don't repeat)
 
 - **Generic `compute_120` PTX fallback.** Lacks FP8 MMA + block-scale. Always pin `compute_120a/sm_120a`.
+- **FP8×FP8 cuBLAS prefill on sm_120.** Disabled by default since 2026-05-28: cuBLAS FP8 returns `NOT_SUPPORTED` at non-aligned M on consumer Blackwell (`engine_init_resolver.cpp:156`, config `attention.fp8_prefill`). Prefill levers are the FA2 family instead.
+- **NVFP4 on GDN in/out projections.** REGRESSES −9 to −20% on wide GDN shapes — FP16 wins there. (`gemm.nvfp4_ssm_proj` for GGUF hybrids and `gemm.nvfp4_attn_proj` are the shipped, measured exceptions.)
+- **Occupancy raise / KPAR→MR reroute on the NVFP4 decode GEMV path.** Refuted by the 2026-05-30 nsys+ncu roofline sweep — decode plateau is a 4-bit-dequant co-limit (L1TEX 91%), not occupancy.
 - **Async `wgmma` / `tcgen05` / TMEM on consumer Blackwell.** Not available — SM100 (B200) exclusives. sm_120 peak path is register `mma.sync`. (Note: the *synchronous* `nvcuda::wmma` API *does* compile on sm_120 but lowers to **HMMA** — it is not async wgmma and not the peak path; it costs extra smem traffic and a smem round-trip vs hand-written `mma.sync` with register-resident fragments.)
 - **Materializing the attention score tile (S/P) in shared memory.** A FA-style kernel that writes S to smem, runs softmax over smem, then reads P back for the PV MMA becomes **barrier- / L1-TEX-bound** (tensor cores idle, compute util in the teens) — the smem round-trip + `__syncthreads` dominate, not the MMAs. True FA2 keeps row max/sum and the S/P fragments **register-resident** and fuses softmax into the QK→PV handoff. Don't trust a kernel header that *claims* register-based softmax — verify against the code (some in-tree kernels are mislabeled).
 - **`__noinline__` on device inner-loop helpers.** Spills to Local Memory (DRAM). Use `__forceinline__`.

--- a/.claude/skills/sm120-cuda-expert/references/ptx-patterns.md
+++ b/.claude/skills/sm120-cuda-expert/references/ptx-patterns.md
@@ -1,6 +1,6 @@
 # sm_120a PTX Inline Assembly Patterns
 
-Heavy reference for the `sm120-cuda-expert` skill. Templates verified on RTX 5090 / GB202 under CUDA 13.2.1, `compute_120a / sm_120a`.
+Heavy reference for the `sm120-cuda-expert` skill. Templates verified on RTX 5090 / GB202 under CUDA 13.2.1, `compute_120a / sm_120a` — re-verified unchanged on CUDA 13.3 (PTX ISA 9.3: 0 of 247 instructions flipped, see known-issues.md).
 
 Guard all sm_120 code: `#if __CUDA_ARCH__ >= 1200`.
 
@@ -32,7 +32,7 @@ asm volatile(
 **Requires `compute_120a`** (NOT `compute_120` / `compute_120f` — `block_scale` modifier and TMA-WS-grouped-GEMM are gated on the `a` arch suffix).
 
 References in repo:
-- `src/compute/attention_mxf4nvf4_probe.cu` — canned-input probe
+- `tests/bench/attention_mxf4nvf4_probe.cu` — canned-input probe
 - `src/compute/attention_fmha_mxf4nvf4_sm120.h` — FMHA upgrade target
 
 ---


### PR DESCRIPTION
Full audit of the project agent skills (`.claude/skills/`) against the current repo state, plus four new skills for recurring workflows. Report with phase tables and trigger-test matrix: `.claude/skills/AUDIT_skills_2026_06_07.md`.

## Fixed (stale facts, verified against the tree)

- **benchmark-cuda** (rewrite): replaced the wrong "thermal throttling" red flag with the real measurement artifacts of this box (idle-downclock ~1 s ramp, cross-day host drift 8–15% #526 incl. healthy-clock signature, back-to-back sweeps reading low); added the bench methodology (`CUBLAS_WORKSPACE_CONFIG`, 10 reps, 3+ trials, one model/process), WSL2/Docker ncu+nsys recipes (host has no CUDA toolkit), `tg128` vs `tg256` baseline-key clarification, and a "Publishing numbers" section (baseline refresh rules, BENCHMARKS.md/README, scoreboard/check-release).
- **sm120-cuda-expert**: FP8 prefill is default-disabled on sm_120 (`engine_init_resolver.cpp:156`) — removed it as a "working technique" and added the actual prefill levers (FA2 default-on, fp16qk, bank-conflict padding, cp.async dbuf) plus NVFP4 lm_head/ssm_proj rows; corrected `AsyncGraphLoop`→`CudaGraphConditionalRunner` (max_steps is dynamic), probe-file path (`tests/bench/`), `executor_moe.cu`→`executor_forward_moe*.cu`; nuanced "Occupancy is king" with the 2026-05-30 decode-roofline finding; flagged the CUTLASS-4.5 retry condition as met (pin is v4.5.1).
- **check-degeneration** (minor): re-downloaded-quant caveat (NLL over byte-equality, Qwen3.6 temp=0 non-determinism) + server docker-run example.

## New skills

- **building-and-testing** — Docker build/test mechanics, root-owned `build/`, models-symlink mount, dep pins in two places, CI-has-no-GPU-runner reality, determinism/PPL caveats, PR conventions. (Named with gerund because `.gitignore`'s `build-*/` would ignore `build-and-test/`.)
- **server-api** — endpoints (OpenAI + Anthropic), real per-token SSE (obsoletes the old "synthetic /v1/messages" note), json_schema/`sim_advance`, cache_control prefix pinning, strict #507 model semantics, validation tooling, diagnostic fingerprints.
- **add-model-arch** — integration checklist (gpt-oss #572 as reference) + wrong-output triage table (RoPE NeoX, NoPE, YaRN inversion, …).
- **quant-formats** — GGUF vs NVFP4 worlds, StorageTier dispatch contract, decode cache, KV dtypes; thin pointer to `docs/quantization.md`.

Plus `.claude/skills/README.md` as index with trigger-boundary map.

## Side finding (not touched here)

`GOAL.md:29/76` still references H100/H200 (sm_90a) and a "CUTLASS Hopper FMHA path", contradicting CLAUDE.md/README's sm_120a-only stance — left for a docs pass.

Docs-only change; no source touched, pre-push verify skipped accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)