### PR TITLE
docs: refresh stale facts across living .md files

### DIFF
--- a/.github/workflows/roofline.yml
+++ b/.github/workflows/roofline.yml
@@ -1,0 +1,64 @@
+# Roofline regression gate + plot artifacts.
+#
+# CI has no GPU runner — measurement (`roofline measure`) is LOCAL-only.
+# This workflow re-parses the committed history (raw CSV exports), runs the
+# regression gate against the pinned baseline (tools/roofline/history/BASELINE)
+# and publishes roofline.png / roofline_trend.png as artifacts.
+#
+# Baseline pinning happens locally after a merge to main:
+#   make roofline-pin     # roofline measure (3 restarts) + pin run_id + commit
+name: Roofline
+
+on:
+  pull_request:
+    paths:
+      - "tools/roofline/**"
+  push:
+    branches: [main]
+    paths:
+      - "tools/roofline/**"
+
+jobs:
+  roofline-check:
+    name: Roofline regress + plots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install plot deps
+        run: pip install matplotlib==3.9.2
+
+      - name: Regression gate vs pinned baseline
+        run: |
+          cd tools/roofline
+          if [ ! -f history/BASELINE ]; then
+            echo "no pinned baseline (history/BASELINE missing) — skipping gate"
+            exit 0
+          fi
+          if [ ! -s history/index.jsonl ]; then
+            echo "no runs in history — skipping gate"
+            exit 0
+          fi
+          python3 roofline.py regress --baseline "$(cat history/BASELINE)" --run latest --threshold 5
+
+      - name: Render plots from history
+        run: |
+          cd tools/roofline
+          if [ ! -s history/index.jsonl ]; then
+            echo "no runs in history — skipping plots"
+            exit 0
+          fi
+          mkdir -p plots
+          python3 rl_plot.py --mode roofline --run latest --out plots/roofline.png
+          python3 rl_plot.py --mode trend --run latest --out plots/roofline_trend.png
+
+      - name: Upload plot artifacts
+        if: hashFiles('tools/roofline/plots/*.png') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: roofline-plots
+          path: tools/roofline/plots/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ _audit/
 CLAUDE.md
 .claude/*
 !.claude/skills/
+tools/roofline/history/raw/**/*.ncu-rep
+tools/roofline/history/raw/**/*.nsys-rep
+tools/roofline/history/raw/**/*.sqlite
+tools/roofline/plots/
+tools/roofline/__pycache__/

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -22,7 +22,7 @@ prefill regression gate); refresh it via `scripts/gen_perf_baseline.sh`.
 
 | Date | Commit | CUDA | Model | Quant | Metric | tok/s | Command |
 |---|---|---|---|---|---|---:|---|
-| 2026-05-29 | `perf_baseline.json` | 13.3 | Qwen3-8B | Q8_0 | tg128 | 258.9 | `imp-cli --model Qwen3-8B-Q8_0.gguf --bench --bench-tg 128` |
+| 2026-06-05 | `perf_baseline.json` (#540) | 13.3 | Qwen3-8B | Q8_0 | tg128 | 268.4 | `imp-cli --model Qwen3-8B-Q8_0.gguf --bench --bench-tg 128` |
 | 2026-05-29 | `perf_baseline.json` | 13.3 | Qwen3-14B | Q6_K | tg128 @ctx2048 | 157.7 | `imp-cli --model Qwen3-14B-Q6_K.gguf --bench --bench-tg 128 --ctx 2048` |
 | 2026-05-30 | `bebafd5` | 13.3 | Gemma-4-26B-A4B | Q4_K_M | tg128 | 259 | `imp-cli --model gemma-4-26B-A4B-it-UD-Q4_K_M.gguf --bench --bench-tg 128` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 - CUDA teardown errors in Model destructor (#439)
 - Q5_K forward pass test NaN from cross-test cuBLAS state contamination (#445)
 
-## Unreleased
+### Earlier unversioned work (pre-0.9.1; was a stray second "Unreleased" section)
 
 - **Gemma-4 FP8 prefill carve-out removed** — the 2026-05-09 measurement
   showing -5..-19% prefill on Gemma-4 vs FP16 has substantially closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Useful build options:
 ## Test
 
 ```bash
-make test-gpu          # Full CUDA suite (~30s)
+make test-gpu          # Full CUDA suite (~4-5 min; test-attention alone ~241s)
 make test-unit         # CPU-only filter (~5s)
 make verify-fast       # Build + filtered tests + perf gate + smoke prompt (~90s)
 make verify            # Full pre-merge gate (~5min)

--- a/GOAL.md
+++ b/GOAL.md
@@ -26,10 +26,9 @@ Anything below this bar is a bug.
 
 1. **RTX 5090** (sm_120, GB202, 32 GB GDDR7) — the hero target. Every optimization decision is made for this chip first.
 2. **RTX PRO 6000 Blackwell** (sm_120, 96 GB) — same arch, more VRAM. Free win if 5090 is fast.
-3. **H100 / H200** (sm_90a) — Hopper path stays alive but is not the hero. Maintained, not optimized aggressively.
-4. **Consumer Blackwell siblings** (5080, 5070 Ti, etc.) — same sm_120, should work, lower priority for tuning.
+3. **Consumer Blackwell siblings** (5080, 5070 Ti, etc.) — same sm_120, covered by the `compute_120f` PTX fallback in the fatbin, lower priority for tuning.
 
-Everything else is best-effort via cuBLAS + scalar Flash Attention 2 fallback. Not a goal.
+Everything else is **unsupported by design**. There is no Hopper (sm_90a), Ada, Ampere, or datacenter-Blackwell (sm_100) path in the tree — the engine is built against `sm_120a` exclusively (see README "Consumer Blackwell only"). Not a goal.
 
 ---
 
@@ -39,7 +38,8 @@ These models must be **best-in-class on 5090**. No exceptions, no excuses.
 Hero status requires staged local weights, a green degeneration battery, and
 decode numbers in `BENCHMARKS.md` (realigned 2026-06-06, issues #549/#550 —
 heroes that had never produced a local number moved to the extended set
-below; gpt-oss-20b is the one tracked not-yet-supported hero):
+below; gpt-oss-20b closed the last hero gap on 2026-06-06, #547 / PRs
+#572–#574):
 
 | Model | Quant | Why |
 |---|---|---|
@@ -49,7 +49,7 @@ below; gpt-oss-20b is the one tracked not-yet-supported hero):
 | Qwen3.6-35B-A3B | NVFP4 | Hybrid (GDN + MoE) daily driver, MTP head |
 | Gemma-4 26B-A4B (text + vision) | NVFP4 | Multimodal + MoE hero |
 | Nemotron-H | NVFP4 | Hybrid (Mamba2 + Attn + MoE) flagship |
-| gpt-oss-20b | MXFP4 (SafeTensors) | First-class MXFP4 path — **tracked gap, not yet supported (#547)** |
+| gpt-oss-20b | MXFP4 (SafeTensors) | First-class MXFP4 path — **supported since 2026-06-06** (#547, PRs #572–#574): experts converted to NVFP4 at load, Harmony channels, tg ≈ 315–345, pp512 ≈ 16–19k |
 
 If a hero model regresses against any competitor on the primary metric, that is a release blocker.
 
@@ -73,8 +73,8 @@ Concrete technical commitments — these are means, not ends, but progress on th
 ### Compute path
 - **NVFP4 must remain the default fast path** on sm_120. FP16/BF16 paths exist for correctness, never as the recommended config. The Blackwell consumer FP16/BF16 throughput nerf is a hardware fact; NVFP4 is the way out and we lean into it harder than anyone.
 - **MXFP4 FMHA** (already novel — first such impl) must stay ahead and expand to more shapes. The +6.7–7.9% over FP8 FMHA on Qwen3 is the baseline, not the ceiling.
-- **CUTLASS Hopper FMHA path on sm_120** for prefill — keep up with CUTLASS releases.
-- **WMMA 8-warp decode kernel** is the decode workhorse on sm_120. Tune for every hero model's head dim.
+- **FA2 prefill family** (register-resident FA2 default-on, FP16-QK FA2 for short prefill, FP8 FMHA fallback) is the prefill attention path on sm_120 — FP8×FP8 cuBLAS prefill is `NOT_SUPPORTED` on this chip, so FA2 carries the commitment. Keep it ahead and expand shapes (hd≠128 declines today).
+- **Paged decode attention** (FP16/FP8/INT8/INT4/NVFP4 KV) + the CUDA-graph decode loop is the decode workhorse on sm_120. Tune for every hero model's head dim.
 - **Grouped GEMM dequant for MoE prefill** — gap to vLLM single-seq has substantially closed. Qwen3-Coder-30B-A3B-NVFP4 (cold-median 5×5 trials, 15 s cooldown, 2026-05-23):
   - **pp512 = 17,521 tok/s** (σ wide: 16k-19k spread across trials — cuBLAS-algo-state still drifts at this kernel size despite cold-median methodology)
   - **pp2048 = 18,573 tok/s** (σ tight: 18.3k-18.9k = 3 % spread — exceeds vLLM 0.20.2's pp512 single-seq number)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER_IMG ?= imp:test
 DOCKER_RUN = docker run --rm --gpus all -v $(PWD)/models:/models $(DOCKER_IMG)
 BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 
-.PHONY: build test-unit test-gpu test-fast test-all test-vision test-perf test-golden bench check-gpu verify verify-fast verify-chunked gen-perf-baseline install-hooks format format-check sanitize
+.PHONY: build test-unit test-gpu test-fast test-all test-vision test-perf test-golden bench check-gpu verify verify-fast verify-chunked gen-perf-baseline install-hooks format format-check sanitize roofline-measure roofline-pin roofline-regress
 
 # Check that no other process is using the GPU (games, other inference, etc.)
 check-gpu:
@@ -140,6 +140,22 @@ gen-perf-baseline: build
 		-u $(shell id -u):$(shell id -g) \
 		-e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
 		--entrypoint bash $(DOCKER_IMG) scripts/gen_perf_baseline.sh "$(MODEL)"
+
+# Roofline pipeline (tools/roofline/): GPU measurement is local-only (CI has no
+# GPU runner). `roofline-pin` runs the full sweep, pins the run as regression
+# baseline (history/BASELINE) and leaves history ready to commit.
+roofline-measure: check-gpu
+	@tools/roofline/roofline measure
+
+roofline-pin: check-gpu
+	@RUN_ID=$$(tools/roofline/roofline measure | tail -1) && \
+		echo "$$RUN_ID" > tools/roofline/history/BASELINE && \
+		echo "pinned roofline baseline: $$RUN_ID (commit tools/roofline/history/)"
+
+roofline-regress:
+	@if [ -f tools/roofline/history/BASELINE ]; then \
+		tools/roofline/roofline regress --baseline "$$(cat tools/roofline/history/BASELINE)" --run latest --threshold 5; \
+	else echo "no pinned baseline — run 'make roofline-pin' first"; fi
 
 # install the pre-push hook that runs verify-fast when source files change
 install-hooks:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Single RTX 5090, greedy, CUDA 13.3, CUDA Graphs on. Headline numbers
 (decode, the reliable A/B signal — see [BENCHMARKS.md](BENCHMARKS.md) for
 dated, commit-anchored measurements with exact commands):
 
-- **GGUF dense decode:** Qwen3-8B Q8_0 at **~258 tok/s** (CI-gated baseline) —
+- **GGUF dense decode:** Qwen3-8B Q8_0 at **~268 tok/s** (CI-gated baseline) —
   **+37–72% over llama.cpp** with full offload and flash attention.
 - **NVFP4 SafeTensors decode:** 30B-class MoE at **~245–307 tok/s**
   (Qwen3-30B/Coder-30B 307, Qwen3.6-35B 245, Gemma-4-26B 259) — effectively

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -10,10 +10,10 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 |---|---|---:|---:|---|
 | [Qwen3-4B](https://huggingface.co/unsloth/Qwen3-4B-GGUF) | Q8_0 | 4.0 GB | 236 | GGUF |
 | Qwen3-4B | MXFP4 | 2.8 GB | 124 | GGUF (imp-converted) |
-| [Qwen3-8B](https://huggingface.co/unsloth/Qwen3-8B-GGUF) | Q8_0 | 8.2 GB | **260** | GGUF |
-| [Qwen3-8B](https://huggingface.co/cortecs/Qwen3-8B-NVFP4) | NVFP4 | 5.0 GB | **238** | SafeTensors (cortecs) |
+| [Qwen3-8B](https://huggingface.co/unsloth/Qwen3-8B-GGUF) | Q8_0 | 8.2 GB | **268** (tg128, CI baseline #540) | GGUF |
+| [Qwen3-8B](https://huggingface.co/cortecs/Qwen3-8B-NVFP4) | NVFP4 | 5.0 GB | **277** | SafeTensors (cortecs) |
 | [Qwen3-14B](https://huggingface.co/unsloth/Qwen3-14B-GGUF) | Q6_K | 12 GB | **158** | GGUF |
-| [Qwen3-14B](https://huggingface.co/nvidia/Qwen3-14B-NVFP4) | NVFP4 | 10 GB | 105 | SafeTensors (nvidia) |
+| [Qwen3-14B](https://huggingface.co/nvidia/Qwen3-14B-NVFP4) | NVFP4 | 10 GB | 168 | SafeTensors (nvidia) |
 | [Qwen3-32B](https://huggingface.co/unsloth/Qwen3-32B-GGUF) | Q4_K_M | 19 GB | — | GGUF |
 | [Phi-4-reasoning-plus](https://huggingface.co/nvidia/Phi-4-reasoning-plus-NVFP4) | NVFP4 | 9.0 GB | 157 | SafeTensors (nvidia), fused projections |
 | [Llama-3.2-3B-Instruct](https://huggingface.co/unsloth/Llama-3.2-3B-Instruct-GGUF) | Q8_0 | 3.2 GB | 306 | GGUF |
@@ -37,25 +37,26 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | Model | Quant | VRAM | Decode `tg256` | Format |
 |---|---|---:|---:|---|
 | [Qwen3-Coder-30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | Q6_K | 24 GB | 236 | GGUF |
-| [Qwen3-Coder-30B-A3B](https://huggingface.co/NVFP4/Qwen3-Coder-30B-A3B-Instruct-FP4) | NVFP4 | 16 GB | 270 | SafeTensors (Modelopt) |
-| [Qwen3-30B-A3B](https://huggingface.co/nvidia/Qwen3-30B-A3B-NVFP4) | NVFP4 | 16 GB | 158 | SafeTensors (Modelopt) |
+| [Qwen3-Coder-30B-A3B](https://huggingface.co/NVFP4/Qwen3-Coder-30B-A3B-Instruct-FP4) | NVFP4 | 16 GB | 307 | SafeTensors (Modelopt) |
+| [Qwen3-30B-A3B](https://huggingface.co/nvidia/Qwen3-30B-A3B-NVFP4) | NVFP4 | 16 GB | 307 | SafeTensors (Modelopt) |
 | [Qwen3.6-35B-A3B](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) | Q4_K_M | 22 GB | 243 | GGUF |
-| [Qwen3.6-35B-A3B](https://huggingface.co/mmangkad/Qwen3.6-35B-A3B-NVFP4) | NVFP4 | 18 GB | 154 | SafeTensors (Modelopt) |
-| [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 187 | GGUF |
+| [Qwen3.6-35B-A3B](https://huggingface.co/mmangkad/Qwen3.6-35B-A3B-NVFP4) | NVFP4 | 18 GB | 245 | SafeTensors (Modelopt) |
+| [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 259 (tg128) | GGUF |
 | [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q5_K_M | 17 GB | 65 | GGUF, recommended for code-gen |
-| [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 163 | SafeTensors (Modelopt) |
-| [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 47 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited |
+| [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 259 | SafeTensors (Modelopt) |
+| [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 126 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited (FP16 GDN/attn-projection tax) |
 | [Nemotron-Labs-3-Elastic-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4) | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
 | [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
 
 ## Vision
 
-Gemma-3 is the only multimodal family currently supported. The vision encoder weights ship as a separate `mmproj.gguf` file:
+Gemma-3 and Gemma-4 are the multimodal families currently supported. The vision encoder weights ship as a separate `mmproj.gguf` file:
 
 | Model | Quant | VRAM | Decode `tg256` | Notes |
 |---|---|---:|---:|---|
 | [Gemma-3-12B-it](https://huggingface.co/bartowski/google_gemma-3-12b-it-GGUF) | Q8_0 | 12 GB | 129 | text + vision (includes mmproj) |
 | [Gemma-3-27B-it](https://huggingface.co/unsloth/gemma-3-27b-it-GGUF) | Q4_K_M | 16 GB | — | largest Gemma-3 |
+| [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 259 (tg128) | text + vision via the gemma4v encoder (separate BF16 mmproj) — see [`vision_gemma4v_spec.md`](vision_gemma4v_spec.md) |
 
 Run with both flags:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@ Build instructions, CLI/server usage, configuration, C API, project structure.
 ## Requirements
 
 - **NVIDIA Blackwell GB202** (sm_120a) — RTX 5090, RTX PRO 5000 Blackwell, or RTX PRO 6000 Blackwell. Same binary, same kernels; the workstation cards just have more VRAM (48 / 96 GB) for bigger MoE models without expert offload.
-- **CUDA Toolkit 13.2+** — `cudart`, `cuda_driver`, `cublas`, `cublasLt`
+- **CUDA Toolkit 13.3** (13.2 minimum enforced by CMake; 13.3 is the canonical toolchain Docker and CI build with) — `cudart`, `cuda_driver`, `cublas`, `cublasLt`
 - **CMake 3.25+**
 - **C++20 compiler** (GCC 11+, Clang 14+)
 

--- a/tools/roofline/Dockerfile.plot
+++ b/tools/roofline/Dockerfile.plot
@@ -1,0 +1,4 @@
+# Plot container for the roofline pipeline (host stays clean — no matplotlib
+# on the host). Built on demand by `roofline plot`.
+FROM python:3.12-slim
+RUN pip install --no-cache-dir matplotlib==3.9.2

--- a/tools/roofline/README.md
+++ b/tools/roofline/README.md
@@ -1,0 +1,68 @@
+# tools/roofline — reproduzierbare Roofline- & Coverage-Pipeline
+
+Misst Roofline-Nähe (%-Roofline, AI, achieved FLOPS/BW) und Kernel-Coverage
+(Legacy-Fallback-Anteile) der imp-Hot-Path-Kernels auf der RTX 5090 (sm_120a),
+mit append-only Historie pro Commit.
+
+## Quickstart
+
+```bash
+tools/roofline/roofline measure                 # voller Sweep, 3 Restarts (~Stunden, GPU exklusiv)
+tools/roofline/roofline measure --models q8-dense --shapes tg256 --restarts 1   # Smoke
+tools/roofline/roofline plot --latest           # roofline.png + roofline_trend.png
+tools/roofline/roofline plot --compare RUN_A RUN_B
+tools/roofline/roofline report --run latest -o audit/roofline_$(date +%Y_%m_%d).md
+tools/roofline/roofline regress --baseline <run_id|sha> --threshold 5
+tools/roofline/roofline issues --run latest     # dry-run; --create legt GitHub-Issues an
+tools/roofline/roofline ab --knob fa2           # unprofiled A/B (FA2 on vs never)
+```
+
+## Architektur
+
+- **Messung** (`measure`): pro Zelle (Modell × Shape × Restart) zwei Pässe in
+  frischen Docker-Containern (= Restart-Varianz by construction):
+  1. **nsys** (volle Timeline): Kernel-Zeitanteile, cuBLAS-API-Attribution
+     (batched GEMM ⇒ Legacy-Attention QK^T/PV), Phasen-Split (init/prefill/
+     decode) und Kalibrierung des ncu `--launch-skip` (Steady-State-Fenster).
+  2. **ncu** (gepinntes Counter-Set, `--clock-control base`): pro Launch
+     Zeit, `dram__bytes`, Tensor-Pipe-FLOP-Counter, SM/DRAM-%, Occupancy.
+- **Historie** (`history/`): append-only.
+  - `runs/<run_id>.json` — geparster Run (committed). `run_id = <shortSHA>[-dirty]_<timestamp>`.
+  - `index.jsonl` — eine Zeile pro Run für Trend-Queries (committed).
+  - `raw/<run_id>/*.ncu_raw.csv.gz` + `*.nsys_extract.json` — Roh-Exporte,
+    Re-Parse ohne Re-Measure (committed).
+  - `raw/<run_id>/*.ncu-rep|*.nsys-rep|*.sqlite` — binäre Originale,
+    **nur lokal** (gitignored; Release-Check verbietet sie im Repo).
+- **Plots** (`plot`): matplotlib im Container `imp-roofline-plot`
+  (Dockerfile.plot, Host bleibt clean) — rendert ausschließlich aus History.
+- **Report** (`report`): Markdown mit Modul-1-Tabelle, Modul-2-Coverage-Matrix
+  und priorisierter Lever-Liste; jede Zahl referenziert den Run (commit+ts).
+- **Gate** (`regress`): exit≠0, wenn eine Kernel-Klasse (Zeitanteil ≥0.5%)
+  im Median > Schwelle unter die Baseline fällt UND die Restart-Spannen
+  disjunkt sind (sonst Varianz, kein Fail).
+
+## Determinismus / Methodik
+
+- Counter-Set, Shapes, Peaks und Klassifikations-Regexes liegen versioniert in
+  `config.json` (`config_version` — Läufe nur innerhalb gleicher Version vergleichen).
+- ncu lockt Clocks auf Base (`--clock-control base`); Compute-Peaks werden auf
+  den **gemessenen** SM-Takt normiert (`gpc__cycles_elapsed.avg.per_second`),
+  Ridge-Points auf Boost-Takt (2.407 GHz) — beides in config.json.
+- AI = FLOPs / `dram__bytes.sum` (gemessener DRAM-Traffic, nicht geschätzt).
+- **FLOP counting**: Tensor-Core-FLOPs aus `sm__ops_path_tensor_src_*`-Countern
+  (Kalibrierung gegen bekannte GEMM-Shapes, siehe Report-Methodik). Non-TC:
+  SASS-Thread-Instruktionen (ffma=2 FLOP; hfma als gepackt HFMA2=4 FLOP
+  gezählt — obere Schranke, im Report als solche markiert).
+- Profil-Läufe nutzen `--no-cuda-graphs` (Graph-Replay versteckt Kernel,
+  Kernel-Mix ist identisch — siehe docs/MISSION_JOURNAL/memory).
+- Prefill-Zellen messen `--bench-reps 3 --max-tokens 1`; Decode-Zellen
+  `--bench-pp 64 --max-tokens 256`. pp-Restart-Varianz (bekannt bis 2.6×)
+  wird als min/med/max ausgewiesen, nie weggemittelt.
+
+## CI
+
+GPU-Messung ist LOKAL (CI hat keinen GPU-Runner). Der Workflow
+`.github/workflows/roofline.yml` prüft auf jedem PR nur Parser/Mathe gegen die
+eingecheckte History (re-parse) und rendert Plots als Artefakt. Baseline-Pinning:
+nach Merge auf main lokal `roofline measure` + Commit der History; `regress`
+läuft im pre-push-Hook, wenn eine Baseline gepinnt ist (`history/BASELINE`).

--- a/tools/roofline/config.json
+++ b/tools/roofline/config.json
@@ -1,0 +1,147 @@
+{
+  "config_version": 1,
+  "comment": "Pinned roofline measurement config. Changing counters/shapes bumps config_version — runs are only comparable within the same version.",
+
+  "gpu": {
+    "name": "NVIDIA GeForce RTX 5090 (GB202, sm_120a)",
+    "sm_count": 170,
+    "dram_peak_gbs": 1792.0,
+    "nominal_boost_ghz": 2.407,
+    "flop_per_cycle": {
+      "comment": "GPU-wide dense math ops per SM-clock cycle. peak_flops(dtype) = flop_per_cycle * measured_sm_clock_hz. Calibrated so tc_fp16*2.407GHz = 838 TFLOPS, tc_fp8 = 1677, tc_fp4 = 3354 (datasheet peaks).",
+      "tc_fp16": 348160,
+      "tc_bf16": 348160,
+      "tc_fp8": 696320,
+      "tc_fp4": 1392640,
+      "tc_int8": 696320,
+      "cuda_fp32": 43520,
+      "cuda_fp16": 87040
+    }
+  },
+
+  "ncu": {
+    "binary": "/opt/nvidia/nsight-compute/2026.2.0/ncu",
+    "clock_control": "base",
+    "launch_count": 120,
+    "skip_fraction": 0.45,
+    "replay_mode": "kernel",
+    "metrics": [
+      "gpu__time_duration.sum",
+      "sm__throughput.avg.pct_of_peak_sustained_elapsed",
+      "gpu__dram_throughput.avg.pct_of_peak_sustained_elapsed",
+      "dram__bytes.sum",
+      "gpc__cycles_elapsed.avg.per_second",
+      "sm__warps_active.avg.pct_of_peak_sustained_active",
+      "l1tex__throughput.avg.pct_of_peak_sustained_elapsed",
+      "l1tex__t_sector_hit_rate.pct",
+      "sm__ops_path_tensor_src_fp4_dst_fp32.sum",
+      "sm__ops_path_tensor_src_fp4_fp6_dst_fp16.sum",
+      "sm__ops_path_tensor_src_fp4_fp6_dst_fp32.sum",
+      "sm__ops_path_tensor_src_fp8_dst_fp16.sum",
+      "sm__ops_path_tensor_src_fp8_dst_fp32.sum",
+      "sm__ops_path_tensor_src_fp16_dst_fp16.sum",
+      "sm__ops_path_tensor_src_fp16_dst_fp32.sum",
+      "sm__ops_path_tensor_src_bf16_dst_fp32.sum",
+      "sm__ops_path_tensor_src_int8.sum",
+      "sm__sass_thread_inst_executed_op_ffma_pred_on.sum",
+      "sm__sass_thread_inst_executed_op_fadd_pred_on.sum",
+      "sm__sass_thread_inst_executed_op_fmul_pred_on.sum",
+      "sm__sass_thread_inst_executed_op_hfma_pred_on.sum",
+      "sm__sass_thread_inst_executed_op_hadd_pred_on.sum",
+      "sm__sass_thread_inst_executed_op_hmul_pred_on.sum"
+    ]
+  },
+
+  "nsys": {
+    "binary": "/opt/nvidia/nsight-systems/2026.1.3/target-linux-x64/nsys",
+    "trace": "cuda,nvtx,osrt,cublas"
+  },
+
+  "docker": {
+    "image": "imp:test",
+    "models_mount": "/home/kekz/models",
+    "imp_cli": "/usr/local/bin/imp-cli",
+    "env": { "CUBLAS_WORKSPACE_CONFIG": ":4096:8" }
+  },
+
+  "models": {
+    "q8-dense": {
+      "path": "/models/Qwen3-8B-Q8_0.gguf",
+      "family": "gguf-q8", "arch": "dense",
+      "comment": "dense GGUF: cuBLAS FP16 prefill + NVFP4/Q8 decode cache"
+    },
+    "nvfp4-dense": {
+      "path": "/models/Qwen3-14B-NVFP4",
+      "family": "nvfp4", "arch": "dense",
+      "comment": "north-star dense NVFP4 SafeTensors: CUTLASS NVFP4 GEMM + FA2"
+    },
+    "nvfp4-moe": {
+      "path": "/models/Qwen3-30B-A3B-NVFP4-Modelopt",
+      "family": "nvfp4", "arch": "moe",
+      "comment": "MoE NVFP4: CUTLASS grouped GEMM + MoE GEMV decode"
+    },
+    "q4k-moe": {
+      "path": "/models/Qwen3-30B-A3B-Q4_K_M/Qwen3-30B-A3B-Q4_K_M.gguf",
+      "family": "gguf-q4k", "arch": "moe",
+      "comment": "legacy GGUF Q4_K: source dequant prefill + fused MoE"
+    },
+    "q4k-dense-hd256": {
+      "path": "/models/gemma-3-12b-it-Q4_K_M.gguf",
+      "family": "gguf-q4k", "arch": "dense",
+      "shapes": ["pp512", "pp2048", "tg256"],
+      "comment": "hd=256: FA2/fa2_fp16qk decline (hd!=128) -> exercises the legacy materialized cuBLAS attention path below fmha_prefill_threshold + gemv_gguf decode (no NVFP4 fast-path)"
+    }
+  },
+
+  "shapes": {
+    "pp512":  { "phase": "prefill", "bench_pp": 512,  "bench_reps": 3, "max_tokens": 1 },
+    "pp2048": { "phase": "prefill", "bench_pp": 2048, "bench_reps": 3, "max_tokens": 1 },
+    "pp4096": { "phase": "prefill", "bench_pp": 4096, "bench_reps": 3, "max_tokens": 1 },
+    "tg256":  { "phase": "decode",  "bench_pp": 64,   "bench_reps": 1, "max_tokens": 256 }
+  },
+
+  "capture_regex": {
+    "prefill": "fmha|flash_attention|causal_softmax|softcap|gemm|gemv|cutlass|nvjet|nvf4|xmma|quantize_fp16|dequant|rmsnorm|rope|qknorm",
+    "decode": "gemv|nvjet|paged_attention|rmsnorm|rope|qknorm|write_kv|argmax|topk|softmax|apply_|residual"
+  },
+
+  "kernel_classes": [
+    { "name": "attn_fa2",            "group": "attention", "regex": "fmha_sm120_fa2_kernel" },
+    { "name": "attn_fmha_fp8",       "group": "attention", "regex": "fmha_sm120_fp8_kernel" },
+    { "name": "attn_fmha_mxfp4",     "group": "attention", "regex": "fmha_sm120_mxfp4_kernel" },
+    { "name": "attn_fmha_wmma",      "group": "attention", "regex": "fmha_sm120_kernel" },
+    { "name": "attn_wmma_fallback",  "group": "attention", "regex": "flash_attention_blackwell_kernel|flash_attention_prefill_tc_kernel" },
+    { "name": "attn_legacy_softmax", "group": "attention_legacy", "regex": "causal_softmax|softcap_fp16_kernel|build_attn_ptr_arrays" },
+    { "name": "attn_decode_paged",   "group": "attention", "regex": "paged_attention_" },
+    { "name": "gemm_grouped_nvfp4",  "group": "gemm", "regex": "GemmUniversal.*Grp|grouped_3x_staging|device_kernel.*Group" },
+    { "name": "gemm_cutlass_nvfp4",  "group": "gemm", "regex": "cutlass.*(nv_float4|float_e2m1|f4|ue4m3)|cutlass3x_sm120" },
+    { "name": "gemm_cublas",         "group": "gemm", "regex": "nvjet|ampere_|turing_|volta_|sm80_|sm86_|sm89_|sm90_|sm100_|sm120_|xmma|cublas|cutlass::Kernel|cutlass3x" },
+    { "name": "gemm_moe_fused_gguf", "group": "gemm", "regex": "gemm_q6k_fused_moe|gemm_q6k_moe_fused|gemm_q4k|mmq_q4k" },
+    { "name": "gemv_nvfp4",          "group": "gemv", "regex": "gemv_nvfp4_" },
+    { "name": "gemv_mxfp4",          "group": "gemv", "regex": "gemv_mxfp4_" },
+    { "name": "gemv_gguf",           "group": "gemv", "regex": "gemv_q8_0|gemv_q6k|gemv_q4|gemv_q5|gemv_q2|gemv_q3" },
+    { "name": "gemv_fp",             "group": "gemv", "regex": "gemv_fp16|gemv_fp32|gemv_bf16|gemv_fp8" },
+    { "name": "quant_cvt_nvfp4",     "group": "dequant", "regex": "quantize_fp16_nvfp4|fused_act_quantize|convert_scales_sfatom|quantize_fp16_mxfp4|build_mxfp4_scales" },
+    { "name": "dequant_nvfp4",       "group": "dequant", "regex": "dequantize_nvfp4|nvfp4_dequant" },
+    { "name": "dequant_gguf",        "group": "dequant", "regex": "dequant_q[0-9]|dequant_iq4|dequant_mxfp4|dequantize_fp8" },
+    { "name": "rmsnorm",             "group": "norm", "regex": "rmsnorm|add_rmsnorm|group_rmsnorm" },
+    { "name": "rope",                "group": "rope", "regex": "rope_forward|qknorm_rope|write_kv_cache_rope|rope_q_only|mrope" },
+    { "name": "sampling",            "group": "sampling", "regex": "argmax|topk_topp|topp_sample|softmax_to_pairs|softmax_max|softmax_sum|apply_penalties|apply_min_p|apply_typical|apply_dry|mirostat|force_single_token" },
+    { "name": "kv_write",            "group": "misc", "regex": "write_kv_cache" },
+    { "name": "elementwise",         "group": "misc", "regex": "silu|swiglu|geglu|gelu|residual_add|add_residual|fp32_to_fp16|fp16_to_fp32|embed|copy_|cast_" }
+  ],
+
+  "roofline": {
+    "comment": "ridge_flop_per_byte computed as peak_flops(dtype)@boost / dram_peak; %-roofline uses measured SM clock for the compute peak.",
+    "memory_bound_pct_target": 70.0,
+    "compute_bound_pct_target": 50.0
+  },
+
+  "regress": { "default_threshold_pct": 5.0, "metric": "pct_roofline", "min_time_share_pct": 0.5 },
+
+  "issues": {
+    "min_lever_pct_estimate": 3.0,
+    "labels": ["audit"],
+    "title_prefix": "[roofline-audit]"
+  }
+}

--- a/tools/roofline/rl_classify.py
+++ b/tools/roofline/rl_classify.py
@@ -1,0 +1,124 @@
+"""Kernel classification + roofline math (AI, achieved FLOPS/BW, %-roofline). stdlib only."""
+import re
+
+# tensor ops-path counter -> dtype peak key
+TC_OPS_METRICS = {
+    "sm__ops_path_tensor_src_fp4_dst_fp32.sum": "tc_fp4",
+    "sm__ops_path_tensor_src_fp4_fp6_dst_fp16.sum": "tc_fp4",
+    "sm__ops_path_tensor_src_fp4_fp6_dst_fp32.sum": "tc_fp4",
+    "sm__ops_path_tensor_src_fp8_dst_fp16.sum": "tc_fp8",
+    "sm__ops_path_tensor_src_fp8_dst_fp32.sum": "tc_fp8",
+    "sm__ops_path_tensor_src_fp16_dst_fp16.sum": "tc_fp16",
+    "sm__ops_path_tensor_src_fp16_dst_fp32.sum": "tc_fp16",
+    "sm__ops_path_tensor_src_bf16_dst_fp32.sum": "tc_bf16",
+    "sm__ops_path_tensor_src_int8.sum": "tc_int8",
+}
+# SASS thread-inst counters -> (flops per inst, dtype key). HFMA2/packed-half executes
+# 2 FMAs per thread-inst; we count hfma as packed (x4 flops) — calibrated against
+# known-shape GEMV, see tools/roofline/README.md "FLOP counting".
+SASS_FLOPS = {
+    "sm__sass_thread_inst_executed_op_ffma_pred_on.sum": (2.0, "cuda_fp32"),
+    "sm__sass_thread_inst_executed_op_fadd_pred_on.sum": (1.0, "cuda_fp32"),
+    "sm__sass_thread_inst_executed_op_fmul_pred_on.sum": (1.0, "cuda_fp32"),
+    "sm__sass_thread_inst_executed_op_hfma_pred_on.sum": (4.0, "cuda_fp16"),
+    "sm__sass_thread_inst_executed_op_hadd_pred_on.sum": (2.0, "cuda_fp16"),
+    "sm__sass_thread_inst_executed_op_hmul_pred_on.sum": (2.0, "cuda_fp16"),
+}
+
+
+def build_classifier(cfg):
+    rules = [(c["name"], c["group"], re.compile(c["regex"])) for c in cfg["kernel_classes"]]
+
+    def classify(kernel_name):
+        for name, group, rx in rules:
+            if rx.search(kernel_name):
+                return name, group
+        return "unclassified", "unclassified"
+
+    return classify
+
+
+def kernel_flops(metrics):
+    """Return (total_flops, dominant_dtype). TC ops counters count FLOPs directly
+    (1 op = 1 multiply or add); SASS half/float inst are converted per SASS_FLOPS."""
+    by_dtype = {}
+    for m, key in TC_OPS_METRICS.items():
+        v = metrics.get(m, 0.0) or 0.0
+        if v:
+            by_dtype[key] = by_dtype.get(key, 0.0) + v
+    for m, (factor, key) in SASS_FLOPS.items():
+        v = metrics.get(m, 0.0) or 0.0
+        if v:
+            by_dtype[key] = by_dtype.get(key, 0.0) + v * factor
+    total = sum(by_dtype.values())
+    dominant = max(by_dtype, key=by_dtype.get) if by_dtype else "cuda_fp32"
+    return total, dominant
+
+
+def roofline_point(metrics, gpu_cfg):
+    """Per-launch (or aggregated) metrics dict -> roofline record."""
+    t_s = metrics.get("gpu__time_duration.sum", 0.0)  # SI (seconds) post-parser
+    t_ns = t_s * 1e9
+    dram_bytes = metrics.get("dram__bytes.sum", 0.0)
+    sm_hz = metrics.get("gpc__cycles_elapsed.avg.per_second", 0.0)
+    flops, dtype = kernel_flops(metrics)
+
+    ai = (flops / dram_bytes) if dram_bytes > 0 else 0.0
+    achieved_flops = flops / t_s if t_s > 0 else 0.0
+    achieved_bw = dram_bytes / t_s if t_s > 0 else 0.0
+
+    fpc = gpu_cfg["flop_per_cycle"][dtype]
+    peak_flops_at_clock = fpc * sm_hz                       # at the measured (locked) clock
+    peak_flops_boost = fpc * gpu_cfg["nominal_boost_ghz"] * 1e9
+    peak_bw = gpu_cfg["dram_peak_gbs"] * 1e9
+    ridge = peak_flops_boost / peak_bw
+
+    bound = "memory" if ai < ridge else "compute"
+    if bound == "memory":
+        pct = 100.0 * achieved_bw / peak_bw
+    else:
+        pct = 100.0 * achieved_flops / peak_flops_at_clock if peak_flops_at_clock > 0 else 0.0
+
+    return {
+        "time_ns": t_ns,
+        "flops": flops,
+        "dram_bytes": dram_bytes,
+        "dtype": dtype,
+        "ai_flop_per_byte": ai,
+        "achieved_gflops": achieved_flops / 1e9,
+        "achieved_gbs": achieved_bw / 1e9,
+        "sm_clock_mhz": sm_hz / 1e6,
+        "ridge_flop_per_byte": ridge,
+        "bound_by": bound,
+        "pct_roofline": pct,
+        "sm_pct": metrics.get("sm__throughput.avg.pct_of_peak_sustained_elapsed", 0.0),
+        "dram_pct": metrics.get("gpu__dram_throughput.avg.pct_of_peak_sustained_elapsed", 0.0),
+        "occupancy_pct": metrics.get("sm__warps_active.avg.pct_of_peak_sustained_active", 0.0),
+        "l1tex_pct": metrics.get("l1tex__throughput.avg.pct_of_peak_sustained_elapsed", 0.0),
+        "l1_hit_pct": metrics.get("l1tex__t_sector_hit_rate.pct", 0.0),
+    }
+
+
+def aggregate_launches(launches, gpu_cfg):
+    """Sum counters over all captured launches of one kernel, then compute the
+    roofline point on the aggregate (time-weighted by construction). Percent/rate
+    metrics are time-weighted-averaged."""
+    if not launches:
+        return None
+    summed, weighted = {}, {}
+    total_t = sum(l.get("gpu__time_duration.sum", 0.0) for l in launches) or 1.0
+    for l in launches:
+        t = l.get("gpu__time_duration.sum", 0.0)
+        for k, v in l.items():
+            if v is None or not isinstance(v, (int, float)):
+                continue
+            if k.endswith(".sum"):
+                summed[k] = summed.get(k, 0.0) + v
+            else:
+                weighted[k] = weighted.get(k, 0.0) + v * t
+    agg = dict(summed)
+    for k, v in weighted.items():
+        agg[k] = v / total_t
+    rec = roofline_point(agg, gpu_cfg)
+    rec["n_launches"] = len(launches)
+    return rec

--- a/tools/roofline/rl_config.py
+++ b/tools/roofline/rl_config.py
@@ -1,0 +1,46 @@
+"""Config + run-metadata helpers for the roofline pipeline. stdlib only."""
+import json
+import os
+import subprocess
+import datetime
+
+TOOL_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(TOOL_DIR, "..", ".."))
+HISTORY_DIR = os.path.join(TOOL_DIR, "history")
+RUNS_DIR = os.path.join(HISTORY_DIR, "runs")
+RAW_DIR = os.path.join(HISTORY_DIR, "raw")
+INDEX_PATH = os.path.join(HISTORY_DIR, "index.jsonl")
+
+
+def load_config(path=None):
+    with open(path or os.path.join(TOOL_DIR, "config.json")) as f:
+        return json.load(f)
+
+
+def _run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw).stdout.strip()
+
+
+def git_meta():
+    sha = _run(["git", "-C", REPO_ROOT, "rev-parse", "--short", "HEAD"])
+    dirty = bool(_run(["git", "-C", REPO_ROOT, "status", "--porcelain",
+                       "--", "src", "include", "tools", "CMakeLists.txt"]))
+    return {"commit": sha, "dirty": dirty}
+
+
+def env_meta(cfg):
+    drv = _run(["nvidia-smi", "--query-gpu=driver_version,name", "--format=csv,noheader"])
+    driver, _, gpu_name = drv.partition(", ")
+    cuda = _run(["bash", "-c",
+                 "nvidia-smi -q | grep -m1 'CUDA Version' | awk -F': ' '{print $2}'"])
+    ncu_ver = _run([cfg["ncu"]["binary"], "--version"]).splitlines()[-1] if os.path.exists(cfg["ncu"]["binary"]) else "missing"
+    return {"driver": driver, "gpu": gpu_name, "cuda": cuda, "ncu": ncu_ver}
+
+
+def now_ts():
+    return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def new_run_id():
+    g = git_meta()
+    return "{}{}_{}".format(g["commit"], "-dirty" if g["dirty"] else "", now_ts())

--- a/tools/roofline/rl_history.py
+++ b/tools/roofline/rl_history.py
@@ -1,0 +1,59 @@
+"""Append-only run history: history/runs/<run_id>.json + index.jsonl. stdlib only."""
+import json
+import os
+
+from rl_config import RUNS_DIR, RAW_DIR, INDEX_PATH
+
+
+def write_run(run):
+    os.makedirs(RUNS_DIR, exist_ok=True)
+    path = os.path.join(RUNS_DIR, run["run_id"] + ".json")
+    if os.path.exists(path):
+        raise SystemExit(f"refusing to overwrite existing run {path} (append-only history)")
+    with open(path, "w") as f:
+        json.dump(run, f, indent=1, sort_keys=True)
+    summary = {
+        "run_id": run["run_id"],
+        "commit": run["meta"]["git"]["commit"],
+        "dirty": run["meta"]["git"]["dirty"],
+        "timestamp": run["meta"]["timestamp"],
+        "config_version": run["meta"]["config_version"],
+        "cells": sorted(run["cells"].keys()),
+        "note": run["meta"].get("note", ""),
+    }
+    with open(INDEX_PATH, "a") as f:
+        f.write(json.dumps(summary, sort_keys=True) + "\n")
+    return path
+
+
+def list_runs():
+    if not os.path.exists(INDEX_PATH):
+        return []
+    with open(INDEX_PATH) as f:
+        return [json.loads(l) for l in f if l.strip()]
+
+
+def resolve_run_id(ref):
+    """ref: 'latest', exact run_id, or commit-SHA prefix (newest match wins)."""
+    runs = list_runs()
+    if not runs:
+        raise SystemExit("no runs in history")
+    if ref in (None, "latest"):
+        return runs[-1]["run_id"]
+    matches = [r for r in runs if r["run_id"] == ref] or \
+              [r for r in runs if r["run_id"].startswith(ref) or r["commit"].startswith(ref)]
+    if not matches:
+        raise SystemExit(f"no run matching '{ref}' in history")
+    return matches[-1]["run_id"]
+
+
+def load_run(ref):
+    run_id = resolve_run_id(ref)
+    with open(os.path.join(RUNS_DIR, run_id + ".json")) as f:
+        return json.load(f)
+
+
+def raw_dir_for(run_id):
+    d = os.path.join(RAW_DIR, run_id)
+    os.makedirs(d, exist_ok=True)
+    return d

--- a/tools/roofline/rl_issues.py
+++ b/tools/roofline/rl_issues.py
@@ -1,0 +1,125 @@
+"""Deliverable 5: GitHub issues from audit findings (English), idempotent via
+audit-key marker. Dry-run by default; real creation only with --create. stdlib only."""
+import json
+import re
+import subprocess
+
+import rl_report
+import rl_table
+
+AUDIT_KEY_RX = re.compile(r"<!-- audit-key: (\S+) -->")
+
+
+def build_issues(run, cfg, ab_results=None):
+    gpu = cfg["gpu"]
+    rows = rl_table.time_share_within_cell(rl_table.build_rows(run, gpu))
+    cov = rl_report.coverage_matrix(run, cfg)
+    rows = rl_report.apply_nsys_time_shares(rows, cov)
+    lv = rl_report.levers(rows, cov, cfg["roofline"])
+    min_gain = cfg["issues"]["min_lever_pct_estimate"]
+    issues = []
+    for rank, l in enumerate([x for x in lv if x["est_gain_pct"] >= min_gain], 1):
+        prio = "P0" if rank <= 2 else ("P1" if rank <= 5 else "P2")
+        if l["kind"] == "legacy_attention_fallback":
+            key = f"roofline:legacy_attn:{l['cell'].replace('/', ':')}"
+            title = (f"Prefill attention coverage: {l['time_share_pct']:.0f}% of "
+                     f"{l['cell']} window on materialized causal_softmax+cuBLAS path")
+            label_kind = "coverage"
+        else:
+            key = f"roofline:{l['class']}:{l['cell'].replace('/', ':')}"
+            title = (f"{l['class']} at {l['pct_roofline_med']:.0f}% roofline "
+                     f"({l['bound_by']}-bound) on {l['cell']} — "
+                     f"{l['time_share_pct']:.0f}% of window time")
+            label_kind = "roofline"
+        body = render_body(l, run, key)
+        issues.append({"key": key, "title": title, "body": body,
+                       "labels": cfg["issues"]["labels"] + [label_kind, prio.lower()],
+                       "prio": prio})
+    return issues
+
+
+def render_body(l, run, key):
+    meta = run["meta"]
+    lines = [
+        f"<!-- audit-key: {key} -->",
+        "## Finding",
+    ]
+    if l["kind"] == "roofline_headroom":
+        lines += [
+            f"- Kernel class **{l['class']}** on **{l['cell']}** reaches "
+            f"**{l['pct_roofline_med']:.1f}%** of the applicable roofline "
+            f"({l['bound_by']}-bound, dtype `{l['dtype']}`); target is {l['target_pct']:.0f}%.",
+            f"- Measured time share of the profiled window: **{l['time_share_pct']:.1f}%**.",
+        ]
+    else:
+        lines += [
+            f"- **{l['time_share_pct']:.1f}%** (median over restarts) of the "
+            f"{l['cell']} prefill window still runs on the legacy materialized "
+            f"attention path (causal_softmax kernels + batched cuBLAS QK^T/PV).",
+        ]
+    lines += [
+        "",
+        "## Evidence",
+        f"- History run: `{run['run_id']}` (commit `{meta['git']['commit']}`"
+        f"{', dirty' if meta['git']['dirty'] else ''}, {meta['timestamp']})",
+        f"- Raw exports: `tools/roofline/history/raw/{run['run_id']}/`",
+        f"- Reproduce: `tools/roofline/roofline report --run {run['run_id']}`",
+        "",
+        "## Expected lever",
+        f"- **Estimate:** ~{l['est_gain_pct']:.1f}% of the affected window "
+        "(Amdahl: time share x roofline headroom). This is an estimate, not a measurement.",
+        "",
+        "## Acceptance criteria",
+    ]
+    if l["kind"] == "roofline_headroom":
+        lines += [f"- `{l['class']}` reaches > {l['target_pct']:.0f}% roofline on "
+                  f"{l['cell']} (verify: `roofline regress --baseline {run['run_id']}`).",]
+    else:
+        lines += ["- Legacy prefill attention path share < 5% on the affected cell "
+                  f"(verify: `roofline report --run <new>` coverage matrix vs `{run['run_id']}`).",]
+    return "\n".join(lines)
+
+
+def existing_audit_issues():
+    out = subprocess.run(
+        ["gh", "issue", "list", "--label", "audit", "--state", "all",
+         "--json", "number,title,body", "--limit", "200"],
+        capture_output=True, text=True)
+    if out.returncode != 0:
+        raise SystemExit(f"gh issue list failed: {out.stderr[-300:]}")
+    by_key = {}
+    for iss in json.loads(out.stdout or "[]"):
+        m = AUDIT_KEY_RX.search(iss.get("body") or "")
+        if m:
+            by_key[m.group(1)] = iss
+    return by_key
+
+
+def ensure_labels(labels):
+    for lb in labels:
+        subprocess.run(["gh", "label", "create", lb, "--force"],
+                       capture_output=True, text=True)
+
+
+def create_or_update(issues, dry_run=True):
+    existing = existing_audit_issues() if not dry_run else {}
+    results = []
+    for iss in issues:
+        if dry_run:
+            results.append(("DRY-RUN", iss["title"]))
+            continue
+        ensure_labels(iss["labels"])
+        if iss["key"] in existing:
+            num = str(existing[iss["key"]]["number"])
+            subprocess.run(["gh", "issue", "comment", num, "--body",
+                            "Updated by new audit run:\n\n" + iss["body"]],
+                           capture_output=True, text=True)
+            results.append(("updated #" + num, iss["title"]))
+        else:
+            out = subprocess.run(
+                ["gh", "issue", "create", "--title", iss["title"],
+                 "--body", iss["body"]]
+                + sum((["--label", lb] for lb in iss["labels"]), []),
+                capture_output=True, text=True)
+            results.append(("created " + out.stdout.strip(), iss["title"]))
+    return results

--- a/tools/roofline/rl_measure.py
+++ b/tools/roofline/rl_measure.py
@@ -1,0 +1,193 @@
+"""Measurement orchestration: per (model, shape, restart) run nsys (coverage +
+skip calibration) then ncu (pinned counters). Each docker run is a fresh
+container => restart variance is captured by construction. stdlib only."""
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+import rl_config
+import rl_ncu
+import rl_nsys
+from rl_classify import build_classifier, aggregate_launches
+
+BENCH_RX = re.compile(r"^(pp|tg)\s+(\d+) tokens\s+avg\s+([\d.]+) ms\s+\(([\d.]+) tok/s\)", re.M)
+
+
+def _log(msg):
+    print(f"[roofline] {msg}", flush=True)
+    sys.stdout.flush()
+
+
+def _run_cmd(cmd, timeout=1800):
+    t0 = time.time()
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    dt = time.time() - t0
+    return p, dt
+
+
+def bench_args(model_path, shape, no_graphs=True):
+    args = ["--model", model_path, "--bench",
+            "--bench-pp", str(shape["bench_pp"]),
+            "--bench-reps", str(shape["bench_reps"]),
+            "--max-tokens", str(shape["max_tokens"]),
+            "--temperature", "0", "--seed", "42"]
+    if no_graphs:
+        args.append("--no-cuda-graphs")
+    return args
+
+
+def parse_bench_tps(text):
+    out = {}
+    for kind, n, _ms, tps in BENCH_RX.findall(text):
+        out[f"{kind}{n}"] = float(tps)
+    return out
+
+
+def measure_cell(cfg, classify, raw_dir, model_key, shape_key, restart, dry_run=False):
+    model = cfg["models"][model_key]
+    shape = cfg["shapes"][shape_key]
+    base = f"{model_key}_{shape_key}_r{restart}"
+    cell = {"model": model_key, "shape": shape_key, "restart": restart}
+    args = bench_args(model["path"], shape)
+
+    # --- pass 1: nsys (fast, full timeline) ---
+    nsys_cmd = rl_nsys.docker_nsys_cmd(cfg, raw_dir, base, args)
+    if dry_run:
+        _log("DRY nsys: " + " ".join(nsys_cmd))
+        return cell
+    _log(f"{base}: nsys pass")
+    p, dt = _run_cmd(nsys_cmd)
+    if p.returncode != 0:
+        cell["error"] = f"nsys failed rc={p.returncode}: {p.stderr[-800:]}"
+        _log(cell["error"])
+        return cell
+    cell["bench_tps_under_nsys"] = parse_bench_tps(p.stdout + p.stderr)
+    cell["nsys_wall_s"] = round(dt, 1)
+
+    rep = os.path.join(raw_dir, base + ".nsys-rep")
+    sqlite_path = rl_nsys.export_sqlite(cfg["nsys"]["binary"], rep)
+    extract = rl_nsys.extract(sqlite_path, classify)
+    with open(os.path.join(raw_dir, base + ".nsys_extract.json"), "w") as f:
+        json.dump(extract, f, indent=1, sort_keys=True)
+    cell["nsys_extract_file"] = base + ".nsys_extract.json"
+
+    # --- pass 2: ncu with calibrated skip ---
+    capture_rx = cfg["capture_regex"][shape["phase"]]
+    n_init = rl_nsys.matched_init_launches(extract, capture_rx)
+    n_steady = rl_nsys.matched_launches_after_init(extract, capture_rx)
+    if n_steady == 0:
+        cell["error"] = "no kernels matched capture regex post-init"
+        return cell
+    launch_count = min(cfg["ncu"]["launch_count"], max(n_steady // 2, 1))
+    skip = n_init + int(n_steady * cfg["ncu"]["skip_fraction"])
+    if skip + launch_count > n_init + n_steady:
+        skip = max(n_init + n_steady - launch_count, 0)
+    cell["ncu_launch_skip"] = skip
+    cell["ncu_launch_count"] = launch_count
+
+    ncu_cmd = rl_ncu.docker_ncu_cmd(cfg, capture_rx, skip, launch_count, raw_dir, base, args)
+    _log(f"{base}: ncu pass (skip={skip} count={launch_count}, init={n_init}, steady={n_steady})")
+    p, dt = _run_cmd(ncu_cmd, timeout=3600)
+    rep_path = os.path.join(raw_dir, base + ".ncu-rep")
+    if p.returncode != 0 or not os.path.exists(rep_path):
+        cell["error"] = f"ncu failed rc={p.returncode}: {(p.stderr or p.stdout)[-800:]}"
+        _log(cell["error"])
+        return cell
+    cell["ncu_wall_s"] = round(dt, 1)
+
+    csv_gz = os.path.join(raw_dir, base + ".ncu_raw.csv.gz")
+    rl_ncu.export_csv(cfg["ncu"]["binary"], rep_path, csv_gz)
+    cell["ncu_csv_file"] = os.path.basename(csv_gz)
+
+    launches = rl_ncu.parse_csv_gz(csv_gz, cfg["ncu"]["metrics"])
+    cell["ncu_kernels"] = aggregate_by_kernel(cfg, classify, launches)
+    return cell
+
+
+def aggregate_by_kernel(cfg, classify, launches):
+    by_kernel = {}
+    for l in launches:
+        by_kernel.setdefault(l["kernel_name"], []).append(l)
+    out = {}
+    for name, ls in by_kernel.items():
+        kcls, group = classify(name)
+        rec = aggregate_launches(ls, cfg["gpu"])
+        rec["class"] = kcls
+        rec["group"] = group
+        out[name] = rec
+    return out
+
+
+def measure(cfg, restarts, model_keys, shape_keys, note="", dry_run=False):
+    classify = build_classifier(cfg)
+    run_id = rl_config.new_run_id()
+    import rl_history
+    raw_dir = rl_history.raw_dir_for(run_id)
+    meta = {
+        "git": rl_config.git_meta(),
+        "timestamp": rl_config.now_ts(),
+        "config_version": cfg["config_version"],
+        "ncu_metrics": cfg["ncu"]["metrics"],
+        "note": note,
+        "restarts": restarts,
+    }
+    if not dry_run:
+        meta["env"] = rl_config.env_meta(cfg)
+    run = {"run_id": run_id, "meta": meta, "cells": {}}
+    _log(f"run {run_id}: {len(model_keys)} models x {len(shape_keys)} shapes x {restarts} restarts")
+
+    for restart in range(restarts):
+        for mk in model_keys:
+            for sk in shape_keys:
+                allowed = cfg["models"][mk].get("shapes")
+                if allowed and sk not in allowed:
+                    continue
+                key = f"{mk}|{sk}"
+                cell = measure_cell(cfg, classify, raw_dir, mk, sk, restart, dry_run)
+                run["cells"].setdefault(key, []).append(cell)
+                # checkpoint after every cell so a crash loses nothing
+                if not dry_run:
+                    with open(os.path.join(raw_dir, "run_partial.json"), "w") as f:
+                        json.dump(run, f, indent=1, sort_keys=True)
+    if dry_run:
+        return None
+    import rl_history
+    path = rl_history.write_run(run)
+    _log(f"run written: {path}")
+    return run
+
+
+def ab_test(cfg, model_keys, shape_keys, knob, env_overrides, restarts=3):
+    """Plain (unprofiled) bench A/B: baseline env vs override env, paired per
+    restart so cuBLAS restart variance hits both arms equally."""
+    results = []
+    for restart in range(restarts):
+        for mk in model_keys:
+            for sk in shape_keys:
+                model, shape = cfg["models"][mk], cfg["shapes"][sk]
+                args = bench_args(model["path"], shape, no_graphs=False)
+                pair = {"model": mk, "shape": sk, "restart": restart, "knob": knob}
+                for arm, env in (("baseline", None), ("variant", env_overrides)):
+                    cmd = _plain_bench_cmd(cfg, args, env)
+                    _log(f"ab {knob} {mk}|{sk} r{restart} {arm}")
+                    p, _ = _run_cmd(cmd)
+                    pair[arm] = parse_bench_tps(p.stdout + p.stderr)
+                    if p.returncode != 0:
+                        pair[arm + "_error"] = (p.stderr or "")[-400:]
+                results.append(pair)
+    return results
+
+
+def _plain_bench_cmd(cfg, imp_cli_args, extra_env=None):
+    d = cfg["docker"]
+    env_flags = []
+    for k, v in {**d.get("env", {}), **(extra_env or {})}.items():
+        env_flags += ["-e", f"{k}={v}"]
+    return ["docker", "run", "--rm", "--gpus", "all",
+            "-u", f"{os.getuid()}:{os.getgid()}",
+            "-v", f"{d['models_mount']}:/models",
+            *env_flags,
+            "--entrypoint", d["imp_cli"], d["image"], *imp_cli_args]

--- a/tools/roofline/rl_ncu.py
+++ b/tools/roofline/rl_ncu.py
@@ -1,0 +1,98 @@
+"""ncu invocation + raw-CSV ingest. The parser reads ncu's own --csv --page raw
+export — no hand-entered numbers. stdlib only."""
+import csv
+import gzip
+import io
+import os
+import subprocess
+
+
+def export_csv(ncu_bin, ncu_rep_path, csv_gz_path):
+    """ncu-rep -> raw-page CSV (gzipped). Runs on the host ncu (no GPU needed)."""
+    out = subprocess.run(
+        [ncu_bin, "--import", ncu_rep_path, "--csv", "--page", "raw"],
+        capture_output=True, text=True)
+    if out.returncode != 0 or not out.stdout.strip():
+        raise RuntimeError(f"ncu import failed for {ncu_rep_path}: {out.stderr[-500:]}")
+    with gzip.open(csv_gz_path, "wt") as f:
+        f.write(out.stdout)
+    return csv_gz_path
+
+
+def _to_float(s):
+    if s is None or s == "":
+        return None
+    try:
+        return float(s.replace(",", ""))
+    except ValueError:
+        return None
+
+
+# ncu raw-page units -> SI factor (seconds, bytes, Hz; counts/percent stay).
+UNIT_SCALE = {
+    "": 1.0, "inst": 1.0, "%": 1.0, "cycle": 1.0, "sector": 1.0, "warp": 1.0,
+    "byte": 1.0, "Kbyte": 1e3, "Mbyte": 1e6, "Gbyte": 1e9, "Tbyte": 1e12,
+    "ns": 1e-9, "nsecond": 1e-9, "us": 1e-6, "usecond": 1e-6,
+    "ms": 1e-3, "msecond": 1e-3, "s": 1.0, "second": 1.0,
+    "hz": 1.0, "Hz": 1.0, "Khz": 1e3, "Mhz": 1e6, "Ghz": 1e9,
+}
+
+
+def parse_csv_gz(csv_gz_path, metric_names):
+    """Yield {kernel_name, block, grid, <metric>: float-in-SI} per launch.
+    Row 1 = column names, row 2 = per-column units (normalized via UNIT_SCALE)."""
+    with gzip.open(csv_gz_path, "rt") as f:
+        text = f.read()
+    rows = list(csv.reader(io.StringIO(text)))
+    if len(rows) < 3:
+        return []
+    header, units = rows[0], rows[1]
+    idx = {name: header.index(name) for name in header}
+    scale = {}
+    for m in metric_names:
+        if m in idx:
+            u = units[idx[m]]
+            if u not in UNIT_SCALE:
+                raise RuntimeError(f"unknown ncu unit '{u}' for {m} — extend UNIT_SCALE")
+            scale[m] = UNIT_SCALE[u]
+    launches = []
+    for row in rows[2:]:
+        if len(row) != len(header):
+            continue
+        rec = {"kernel_name": row[idx.get("Kernel Name", 0)]}
+        for opt in ("Block Size", "Grid Size"):
+            if opt in idx:
+                rec[opt.lower().replace(" ", "_")] = row[idx[opt]]
+        for m, sc in scale.items():
+            v = _to_float(row[idx[m]])
+            rec[m] = v * sc if v is not None else None
+        launches.append(rec)
+    return launches
+
+
+def docker_ncu_cmd(cfg, kernel_regex, launch_skip, launch_count, out_host_dir,
+                   out_base_name, imp_cli_args, extra_env=None):
+    d = cfg["docker"]
+    n = cfg["ncu"]
+    env_flags = []
+    for k, v in {**d.get("env", {}), **(extra_env or {})}.items():
+        env_flags += ["-e", f"{k}={v}"]
+    return [
+        "docker", "run", "--rm", "--gpus", "all", "--privileged",
+        "-u", f"{os.getuid()}:{os.getgid()}", "-w", "/tmp",
+        "-v", f"{d['models_mount']}:/models",
+        "-v", f"{out_host_dir}:/out",
+        "-v", "/opt/nvidia:/opt/nvidia:ro",
+        *env_flags,
+        "--entrypoint", n["binary"],
+        d["image"],
+        "--target-processes", "all",
+        "--kernel-name", f"regex:{kernel_regex}",
+        "--launch-skip", str(launch_skip),
+        "--launch-count", str(launch_count),
+        "--metrics", ",".join(n["metrics"]),
+        "--clock-control", n.get("clock_control", "base"),
+        "--force-overwrite",
+        "-o", f"/out/{out_base_name}",
+        d["imp_cli"], *imp_cli_args,
+    ]

--- a/tools/roofline/rl_nsys.py
+++ b/tools/roofline/rl_nsys.py
@@ -1,0 +1,149 @@
+"""nsys capture + sqlite extraction: kernel time shares, legacy-attention
+attribution (marker adjacency), phase split (init/prefill/decode), and ncu
+launch-skip calibration. stdlib only.
+
+Legacy-attention attribution: the materialized path launches
+build_attn_ptr_arrays -> cuBLAS QK^T -> causal_softmax -> cuBLAS PV, so a
+cuBLAS GEMM kernel launch-adjacent (+-1 in launch order) to one of those marker
+kernels belongs to attention; all other cuBLAS GEMMs are dense layer GEMMs.
+(The nsys cublas API trace produces no sqlite table in this setup, so
+correlation-id attribution is not available — validated empirically: the
+attributed count must be ~2x the causal_softmax count.)"""
+import os
+import re
+import sqlite3
+import subprocess
+
+PREFILL_ATTN_RX = re.compile(
+    r"fmha|flash_attention|causal_softmax|softcap_fp16|build_attn_ptr")
+MARKER_RX = re.compile(r"causal_softmax|softcap_fp16|build_attn_ptr")
+
+
+def docker_nsys_cmd(cfg, out_host_dir, out_base_name, imp_cli_args, extra_env=None):
+    d = cfg["docker"]
+    env_flags = []
+    for k, v in {**d.get("env", {}), **(extra_env or {})}.items():
+        env_flags += ["-e", f"{k}={v}"]
+    return [
+        "docker", "run", "--rm", "--gpus", "all",
+        "-u", f"{os.getuid()}:{os.getgid()}", "-w", "/tmp",
+        "-v", f"{d['models_mount']}:/models",
+        "-v", f"{out_host_dir}:/out",
+        "-v", "/opt/nvidia:/opt/nvidia:ro",
+        *env_flags,
+        "--entrypoint", cfg["nsys"]["binary"],
+        d["image"],
+        "profile",
+        f"--trace={cfg['nsys']['trace']}",
+        "--cuda-memory-usage=true",
+        "--force-overwrite=true",
+        "--stats=false",
+        "--sample=none", "--cpuctxsw=none", "--backtrace=none",
+        "-o", f"/out/{out_base_name}",
+        d["imp_cli"], *imp_cli_args,
+    ]
+
+
+def export_sqlite(nsys_bin, rep_path):
+    sqlite_path = rep_path.replace(".nsys-rep", ".sqlite")
+    out = subprocess.run(
+        [nsys_bin, "export", "--type", "sqlite", "--force-overwrite", "true",
+         "--output", sqlite_path, rep_path],
+        capture_output=True, text=True)
+    if out.returncode != 0 or not os.path.exists(sqlite_path):
+        raise RuntimeError(f"nsys export failed: {out.stderr[-500:]}")
+    return sqlite_path
+
+
+def _kernel_rows(con):
+    """[(start, end, name)] for all kernel executions, launch-ordered."""
+    cur = con.cursor()
+    cols = {r[1] for r in cur.execute("PRAGMA table_info(CUPTI_ACTIVITY_KIND_KERNEL)")}
+    name_col = "demangledName" if "demangledName" in cols else "shortName"
+    return cur.execute(
+        f"SELECT k.start, k.end, s.value "
+        f"FROM CUPTI_ACTIVITY_KIND_KERNEL k JOIN StringIds s ON k.{name_col} = s.id "
+        f"ORDER BY k.start").fetchall()
+
+
+def extract(sqlite_path, classify):
+    """Per-kernel time totals (class + legacy-attention attribution) and phase
+    split. Phases: init (before first prefill-attention kernel), prefill_window
+    (up to the END of the last prefill-attention kernel — for decode-shape runs
+    this covers warmup + pp-bench + the tg prefill), post_prefill (pure decode
+    for decode-shape runs). Returns a JSON-serializable dict."""
+    con = sqlite3.connect(sqlite_path)
+    kernels = _kernel_rows(con)
+    con.close()
+    if not kernels:
+        return {"error": "no kernels in trace"}
+
+    names = [k[2] for k in kernels]
+    classes = [classify(n) for n in names]
+    is_marker = [bool(MARKER_RX.search(n)) for n in names]
+    attn_starts = [s for (s, e, n) in kernels if PREFILL_ATTN_RX.search(n)]
+    first_attn = min(attn_starts) if attn_starts else kernels[0][0]
+    last_attn_end = max((e for (s, e, n) in kernels if PREFILL_ATTN_RX.search(n)),
+                        default=kernels[0][0])
+
+    per_kernel = {}
+    n_attn_gemm = 0
+    for i, (s, e, name) in enumerate(kernels):
+        kcls, group = classes[i]
+        if s < first_attn:
+            phase = "init"
+        elif s >= last_attn_end:
+            phase = "post_prefill"
+        else:
+            phase = "prefill_window"
+        rec = per_kernel.setdefault(name, {
+            "class": kcls, "group": group, "count": 0, "time_ns": 0,
+            "phase_time_ns": {}, "attn_gemm_time_ns": 0,
+            "attn_gemm_phase_time_ns": {}})
+        t = e - s
+        rec["count"] += 1
+        rec["time_ns"] += t
+        rec["phase_time_ns"][phase] = rec["phase_time_ns"].get(phase, 0) + t
+        if kcls == "gemm_cublas" and (
+                (i > 0 and is_marker[i - 1]) or
+                (i + 1 < len(kernels) and is_marker[i + 1])):
+            n_attn_gemm += 1
+            rec["attn_gemm_time_ns"] += t
+            rec["attn_gemm_phase_time_ns"][phase] = \
+                rec["attn_gemm_phase_time_ns"].get(phase, 0) + t
+
+    n_softmax = sum(1 for i, n in enumerate(names)
+                    if classes[i][0] == "attn_legacy_softmax" and "causal_softmax" in n)
+    return {
+        "n_kernels_total": len(kernels),
+        "first_attn_ts": first_attn,
+        "last_attn_end_ts": last_attn_end,
+        "n_attn_gemm_attributed": n_attn_gemm,
+        "n_causal_softmax": n_softmax,
+        "per_kernel": per_kernel,
+    }
+
+
+def matched_launches_after_init(extract_result, capture_rx):
+    """How many post-init kernel launches match the ncu capture regex —
+    used to derive --launch-skip so the ncu window sits in steady state."""
+    rx = re.compile(capture_rx)
+    total = 0
+    for name, rec in extract_result["per_kernel"].items():
+        if rx.search(name):
+            total += max(rec["count"] - _phase_count_estimate(rec, "init"), 0)
+    return total
+
+
+def _phase_count_estimate(rec, phase):
+    # counts are not tracked per phase; estimate via time share (init kernels are
+    # conversion bursts, close enough for skip calibration)
+    t_total = rec["time_ns"] or 1
+    return int(round(rec["count"] * (rec["phase_time_ns"].get(phase, 0) / t_total)))
+
+
+def matched_init_launches(extract_result, capture_rx):
+    rx = re.compile(capture_rx)
+    return sum(_phase_count_estimate(rec, "init")
+               for name, rec in extract_result["per_kernel"].items()
+               if rx.search(name))

--- a/tools/roofline/rl_plot.py
+++ b/tools/roofline/rl_plot.py
@@ -1,0 +1,169 @@
+"""Roofline plots (matplotlib). Runs inside the plot container (see
+Dockerfile.plot) — invoked by `roofline plot`, renders purely from history."""
+import argparse
+import math
+import sys
+
+import rl_config
+import rl_history
+import rl_table
+
+GROUP_COLOR = {
+    "attention": "tab:blue", "attention_legacy": "tab:red", "gemm": "tab:green",
+    "gemv": "tab:purple", "dequant": "tab:orange", "norm": "tab:brown",
+    "rope": "tab:pink", "sampling": "tab:gray", "misc": "tab:olive",
+    "unclassified": "black",
+}
+
+
+def _import_mpl():
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    return plt
+
+
+def _roofs(gpu):
+    peak_bw = gpu["dram_peak_gbs"]  # GB/s
+    roofs = []
+    for dtype, label in (("tc_fp4", "FP4 TC"), ("tc_fp8", "FP8 TC"), ("tc_fp16", "FP16 TC"),
+                         ("cuda_fp32", "FP32 CUDA")):
+        peak = gpu["flop_per_cycle"][dtype] * gpu["nominal_boost_ghz"]  # GFLOPS
+        roofs.append((dtype, label, peak, peak / peak_bw))
+    return peak_bw, roofs
+
+
+def plot_roofline(run, out_path, cfg, title_suffix=""):
+    plt = _import_mpl()
+    gpu = cfg["gpu"]
+    rows = rl_table.time_share_within_cell(rl_table.build_rows(run, gpu))
+    peak_bw, roofs = _roofs(gpu)
+
+    fig, ax = plt.subplots(figsize=(13, 9))
+    ai_axis = [2 ** e for e in range(-4, 13)]
+    for dtype, label, peak, ridge in roofs:
+        ys = [min(ai * peak_bw, peak) for ai in ai_axis]
+        ax.plot(ai_axis, ys, lw=1, alpha=0.6, color="gray")
+        ax.annotate(f"{label} {peak/1000:.0f} TFLOPS", xy=(ai_axis[-1], peak),
+                    fontsize=8, ha="right", va="bottom", color="gray")
+        ax.axvline(ridge, color="lightgray", ls=":", lw=0.7)
+
+    classes_seen = {}
+    for r in rows:
+        if r["time_share_pct"] < 1.0 or r["ai"] <= 0:
+            continue
+        color = GROUP_COLOR.get(_group_of(cfg, r["class"]), "black")
+        marker = "o" if r["bound_by"] == "memory" else "^"
+        size = 20 + 4 * r["time_share_pct"]
+        ax.scatter(r["ai"], r["achieved_gflops"], s=size, color=color, marker=marker,
+                   alpha=0.75, edgecolors="white", linewidths=0.5)
+        lbl = f"{r['class']} ({r['model']}/{r['shape']})"
+        ax.annotate(lbl, xy=(r["ai"], r["achieved_gflops"]), fontsize=5.5,
+                    xytext=(3, 3), textcoords="offset points")
+        classes_seen[r["class"]] = color
+
+    ax.set_xscale("log", base=2)
+    ax.set_yscale("log", base=10)
+    ax.set_xlabel("Arithmetic intensity [FLOP/byte], from measured dram__bytes")
+    ax.set_ylabel("Achieved [GFLOPS]")
+    ax.set_title(f"imp roofline — {gpu['name']}\nrun {run['run_id']}{title_suffix} "
+                 f"(o = memory-bound, ^ = compute-bound; size ~ time share)")
+    ax.grid(True, which="both", alpha=0.15)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=160)
+    print(f"wrote {out_path}")
+
+
+def plot_trend(runs, out_path, cfg, last_n=20):
+    plt = _import_mpl()
+    gpu = cfg["gpu"]
+    runs = runs[-last_n:]
+    series = {}   # (cell,class) -> [(idx, pct_med)]
+    labels = []
+    for i, run in enumerate(runs):
+        labels.append(run["run_id"][:18])
+        rows = rl_table.time_share_within_cell(rl_table.build_rows(run, gpu))
+        for r in rows:
+            if r["time_share_pct"] < 3.0:
+                continue
+            series.setdefault(f"{r['class']} {r['model']}/{r['shape']}", []).append(
+                (i, r["pct_roofline_med"]))
+    fig, ax = plt.subplots(figsize=(13, 7))
+    for name, pts in sorted(series.items()):
+        xs, ys = zip(*pts)
+        ax.plot(xs, ys, marker="o", ms=3, lw=1, label=name, alpha=0.8)
+    ax.set_xticks(range(len(labels)))
+    ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=6)
+    ax.set_ylabel("% roofline (median over restarts)")
+    ax.set_title("imp roofline trend — hot-path kernel classes (>3% cell time)")
+    ax.grid(True, alpha=0.2)
+    ax.legend(fontsize=5, ncol=2, loc="center left", bbox_to_anchor=(1.0, 0.5))
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=160)
+    print(f"wrote {out_path}")
+
+
+def plot_compare(run_a, run_b, out_path, cfg):
+    plt = _import_mpl()
+    gpu = cfg["gpu"]
+    peak_bw, roofs = _roofs(gpu)
+    fig, ax = plt.subplots(figsize=(13, 9))
+    ai_axis = [2 ** e for e in range(-4, 13)]
+    for dtype, label, peak, ridge in roofs:
+        ax.plot(ai_axis, [min(ai * peak_bw, peak) for ai in ai_axis],
+                lw=1, alpha=0.5, color="gray")
+
+    def keyed(run):
+        rows = rl_table.time_share_within_cell(rl_table.build_rows(run, gpu))
+        return {(r["model"], r["shape"], r["class"]): r for r in rows
+                if r["time_share_pct"] >= 1.0 and r["ai"] > 0}
+
+    ra, rb = keyed(run_a), keyed(run_b)
+    for key in sorted(set(ra) & set(rb)):
+        a, b = ra[key], rb[key]
+        color = GROUP_COLOR.get(_group_of(cfg, key[2]), "black")
+        ax.annotate("", xy=(b["ai"], b["achieved_gflops"]),
+                    xytext=(a["ai"], a["achieved_gflops"]),
+                    arrowprops=dict(arrowstyle="->", color=color, lw=1.2, alpha=0.8))
+        ax.scatter([a["ai"]], [a["achieved_gflops"]], s=18, color=color, alpha=0.4)
+        ax.scatter([b["ai"]], [b["achieved_gflops"]], s=26, color=color, alpha=0.9)
+        ax.annotate(f"{key[2]} ({key[0]}/{key[1]})", xy=(b["ai"], b["achieved_gflops"]),
+                    fontsize=5.5, xytext=(3, 3), textcoords="offset points")
+    ax.set_xscale("log", base=2)
+    ax.set_yscale("log", base=10)
+    ax.set_xlabel("Arithmetic intensity [FLOP/byte]")
+    ax.set_ylabel("Achieved [GFLOPS]")
+    ax.set_title(f"imp roofline compare\nA={run_a['run_id']} (faint) -> B={run_b['run_id']} (solid)")
+    ax.grid(True, which="both", alpha=0.15)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=160)
+    print(f"wrote {out_path}")
+
+
+def _group_of(cfg, class_name):
+    for c in cfg["kernel_classes"]:
+        if c["name"] == class_name:
+            return c["group"]
+    return "unclassified"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["roofline", "trend", "compare"], required=True)
+    ap.add_argument("--run", default="latest")
+    ap.add_argument("--run-b")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    cfg = rl_config.load_config()
+    if args.mode == "roofline":
+        plot_roofline(rl_history.load_run(args.run), args.out, cfg)
+    elif args.mode == "trend":
+        runs = [rl_history.load_run(r["run_id"]) for r in rl_history.list_runs()]
+        plot_trend(runs, args.out, cfg)
+    else:
+        plot_compare(rl_history.load_run(args.run), rl_history.load_run(args.run_b),
+                     args.out, cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/roofline/rl_regress.py
+++ b/tools/roofline/rl_regress.py
@@ -1,0 +1,32 @@
+"""Regression gate: compare a run against a pinned baseline run. Exit != 0 if a
+hot-path kernel class drops more than threshold below baseline. stdlib only."""
+import rl_table
+
+
+def compare(baseline_run, current_run, cfg, threshold_pct):
+    gpu = cfg["gpu"]
+    min_share = cfg["regress"]["min_time_share_pct"]
+    base = {(r["model"], r["shape"], r["class"]): r
+            for r in rl_table.time_share_within_cell(rl_table.build_rows(baseline_run, gpu))}
+    cur = {(r["model"], r["shape"], r["class"]): r
+           for r in rl_table.time_share_within_cell(rl_table.build_rows(current_run, gpu))}
+    failures, infos = [], []
+    for key in sorted(set(base) & set(cur)):
+        b, c = base[key], cur[key]
+        if b["time_share_pct"] < min_share:
+            continue
+        if b["pct_roofline_med"] <= 0:
+            continue
+        delta_rel = 100.0 * (c["pct_roofline_med"] - b["pct_roofline_med"]) / b["pct_roofline_med"]
+        line = (f"{key[2]} @ {key[0]}/{key[1]}: %roofline med "
+                f"{b['pct_roofline_med']:.1f} -> {c['pct_roofline_med']:.1f} ({delta_rel:+.1f}%)")
+        if delta_rel < -threshold_pct:
+            # restart-variance guard: only fail if the current MAX is also below
+            # the baseline MIN (i.e. no overlap of restart ranges)
+            if c["pct_roofline_max"] < b["pct_roofline_min"]:
+                failures.append(line + "  [ranges disjoint -> REGRESSION]")
+            else:
+                infos.append(line + "  [within restart variance, not gated]")
+        else:
+            infos.append(line)
+    return failures, infos

--- a/tools/roofline/rl_report.py
+++ b/tools/roofline/rl_report.py
@@ -1,0 +1,227 @@
+"""Markdown report: Modul-1 roofline table + Modul-2 coverage matrix + lever
+list. Renders purely from history (run JSON + nsys extracts). stdlib only."""
+import json
+import os
+import re
+import statistics
+
+import rl_history
+import rl_table
+
+BATCHED_RX = re.compile(r"[Bb]atched")
+
+
+def load_nsys_extracts(run):
+    """{cell_key: [extract_dict per restart]}"""
+    raw = os.path.join(rl_history.RAW_DIR, run["run_id"])
+    out = {}
+    for cell_key, restarts in run["cells"].items():
+        for c in restarts:
+            f = c.get("nsys_extract_file")
+            if not f:
+                continue
+            p = os.path.join(raw, f)
+            if os.path.exists(p):
+                with open(p) as fh:
+                    out.setdefault(cell_key, []).append(json.load(fh))
+    return out
+
+
+def coverage_for_extract(ex, phases):
+    """Per-class time shares within the given phases + attention-path split.
+    Legacy attention = causal_softmax/softcap/ptr-array kernels + the cuBLAS
+    GEMM kernels launch-adjacent to those markers (QK^T/PV) — see rl_nsys."""
+    per_class = {}
+    attn = {"legacy_softmax": 0, "legacy_cublas_qkpv": 0, "fa2": 0,
+            "fmha_fp8": 0, "fmha_wmma": 0, "wmma_fallback": 0, "decode_paged": 0}
+    total = 0
+    for name, rec in ex["per_kernel"].items():
+        t = sum(rec["phase_time_ns"].get(p, 0) for p in phases)
+        if t <= 0:
+            continue
+        total += t
+        per_class[rec["class"]] = per_class.get(rec["class"], 0) + t
+        attn_gemm = sum(rec.get("attn_gemm_phase_time_ns", {}).get(p, 0) for p in phases)
+        if rec["class"] == "attn_legacy_softmax":
+            attn["legacy_softmax"] += t
+        elif rec["class"] == "gemm_cublas" and attn_gemm:
+            attn["legacy_cublas_qkpv"] += attn_gemm
+        elif rec["class"] == "attn_fa2":
+            attn["fa2"] += t
+        elif rec["class"] == "attn_fmha_fp8":
+            attn["fmha_fp8"] += t
+        elif rec["class"] in ("attn_fmha_wmma", "attn_fmha_mxfp4"):
+            attn["fmha_wmma"] += t
+        elif rec["class"] == "attn_wmma_fallback":
+            attn["wmma_fallback"] += t
+        elif rec["class"] == "attn_decode_paged":
+            attn["decode_paged"] += t
+    legacy = attn["legacy_softmax"] + attn["legacy_cublas_qkpv"]
+    attn_total = sum(attn.values())
+    return {
+        "total_ns": total,
+        "class_share_pct": {k: 100.0 * v / total for k, v in sorted(per_class.items())},
+        "attn_ns": attn,
+        "legacy_attn_share_of_total_pct": 100.0 * legacy / total if total else 0.0,
+        "legacy_share_of_attention_pct": 100.0 * legacy / attn_total if attn_total else 0.0,
+        "attribution_sanity": {
+            "n_attn_gemm_attributed": ex.get("n_attn_gemm_attributed", 0),
+            "n_causal_softmax": ex.get("n_causal_softmax", 0),
+        },
+    }
+
+
+def coverage_matrix(run, cfg):
+    """{cell_key: {metric: [per-restart values]}} summarized min/med/max.
+    Prefill cells use the prefill_window phase; decode cells the post_prefill
+    phase (pure decode — see rl_nsys.extract docstring)."""
+    extracts = load_nsys_extracts(run)
+    out = {}
+    for cell_key, exs in sorted(extracts.items()):
+        shape_key = cell_key.split("|")[1]
+        phase = cfg["shapes"][shape_key]["phase"]
+        phases = ("prefill_window",) if phase == "prefill" else ("post_prefill",)
+        covs = [coverage_for_extract(e, phases) for e in exs if "per_kernel" in e]
+        if not covs:
+            continue
+        agg = {"n_restarts": len(covs)}
+        for metric in ("legacy_attn_share_of_total_pct", "legacy_share_of_attention_pct"):
+            vals = [c[metric] for c in covs]
+            agg[metric] = {"min": min(vals), "med": statistics.median(vals), "max": max(vals)}
+        # median-restart class shares
+        med_cov = sorted(covs, key=lambda c: c["legacy_attn_share_of_total_pct"])[len(covs) // 2]
+        agg["class_share_pct_med_restart"] = med_cov["class_share_pct"]
+        out[cell_key] = agg
+    return out
+
+
+def apply_nsys_time_shares(rows, cov):
+    """Replace the ncu-capture-window time share (oversampling bias) with the
+    true per-phase class share from the nsys timeline where available."""
+    for r in rows:
+        cell_key = f"{r['model']}|{r['shape']}"
+        share = cov.get(cell_key, {}).get("class_share_pct_med_restart", {}).get(r["class"])
+        if share is not None:
+            r["time_share_pct"] = share
+            r["time_share_source"] = "nsys"
+        else:
+            r["time_share_source"] = "ncu-window"
+    return rows
+
+
+def fmt_num(x, digits=1):
+    if x >= 1000:
+        return f"{x:,.0f}"
+    return f"{x:.{digits}f}"
+
+
+def module1_table(rows, min_share_pct=1.0):
+    hdr = ("| Kernel-Klasse | Modell/Shape | Zeitanteil % (nsys) | AI (FLOP/B) | erreicht "
+           "(med) | Peak | %-Roofline (min/med/max) | bound-by | dtype | SM% | Occ % |\n"
+           "|---|---|---|---|---|---|---|---|---|---|---|\n")
+    lines = []
+    for r in sorted(rows, key=lambda r: (r["model"], r["shape"], -r.get("time_share_pct", 0))):
+        if r.get("time_share_pct", 0) < min_share_pct:
+            continue
+        if r["bound_by"] == "memory":
+            ach = f"{fmt_num(r['achieved_med'])} GB/s"
+            peak = f"{fmt_num(r['peak_gbs'])} GB/s"
+        else:
+            ach = f"{fmt_num(r['achieved_med'])} GFLOPS"
+            peak = f"{fmt_num(r['peak_gflops_at_clock'])} GFLOPS @{r['sm_clock_mhz']:.0f}MHz"
+        share = f"{r['time_share_pct']:.1f}"
+        if r.get("time_share_source") == "ncu-window":
+            share += "*"
+        lines.append(
+            f"| {r['class']} | {r['model']}/{r['shape']} | {share} "
+            f"| {r['ai']:.2f} | {ach} | {peak} "
+            f"| {r['pct_roofline_min']:.1f} / {r['pct_roofline_med']:.1f} / {r['pct_roofline_max']:.1f} "
+            f"| {r['bound_by']} | {r['dtype']} | {r.get('sm_pct', 0):.0f} | {r['occupancy_pct']:.0f} |")
+    return hdr + "\n".join(lines) + "\n(*) = Zeitanteil aus ncu-Fenster (nsys-Share fehlt)\n"
+
+
+def module2_table(cov):
+    hdr = ("| Zelle | Legacy-Attn %-Anteil Fenster (min/med/max) | Legacy-Anteil an "
+           "Attention % (min/med/max) | Restarts |\n|---|---|---|---|\n")
+    lines = []
+    for cell, agg in cov.items():
+        a = agg["legacy_attn_share_of_total_pct"]
+        b = agg["legacy_share_of_attention_pct"]
+        lines.append(f"| {cell} | {a['min']:.1f} / {a['med']:.1f} / {a['max']:.1f} "
+                     f"| {b['min']:.1f} / {b['med']:.1f} / {b['max']:.1f} | {agg['n_restarts']} |")
+    return hdr + "\n".join(lines) + "\n"
+
+
+def levers(rows, cov, targets):
+    """Estimated levers, ranked: time_share x roofline headroom (Amdahl).
+    All gains are ESTIMATES derived from measured shares + measured %-roofline."""
+    out = []
+    for r in rows:
+        share = r.get("time_share_pct", 0)
+        if share < 2.0:
+            continue
+        target = targets["memory_bound_pct_target" if r["bound_by"] == "memory"
+                         else "compute_bound_pct_target"]
+        pct = r["pct_roofline_med"]
+        if pct >= target:
+            continue
+        # speedup of this class to target => saved fraction of window time
+        saved_pct = share * (1.0 - pct / target)
+        out.append({
+            "kind": "roofline_headroom",
+            "class": r["class"], "cell": f"{r['model']}/{r['shape']}",
+            "time_share_pct": share, "pct_roofline_med": pct, "target_pct": target,
+            "est_gain_pct": saved_pct,
+            "bound_by": r["bound_by"], "dtype": r["dtype"],
+        })
+    for cell, agg in cov.items():
+        med = agg["legacy_attn_share_of_total_pct"]["med"]
+        if med >= 2.0:
+            out.append({
+                "kind": "legacy_attention_fallback", "class": "attn_legacy_softmax+cublas",
+                "cell": cell, "time_share_pct": med,
+                "est_gain_pct": med * 0.5,
+                "note": "assumes FA2-class path is ~2x the materialized path (estimate)",
+            })
+    out.sort(key=lambda l: -l["est_gain_pct"])
+    return out
+
+
+def render(run, cfg, ab_results=None):
+    gpu = cfg["gpu"]
+    rows = rl_table.time_share_within_cell(rl_table.build_rows(run, gpu))
+    cov = coverage_matrix(run, cfg)
+    rows = apply_nsys_time_shares(rows, cov)
+    lv = levers(rows, cov, cfg["roofline"])
+    meta = run["meta"]
+    md = []
+    md.append(f"# imp Roofline-Audit — Run `{run['run_id']}`\n")
+    md.append(f"- Commit: `{meta['git']['commit']}`{' (dirty)' if meta['git']['dirty'] else ''}"
+              f" · Timestamp: {meta['timestamp']} · config_version: {meta['config_version']}")
+    env = meta.get("env", {})
+    md.append(f"- GPU: {env.get('gpu','?')} · Treiber: {env.get('driver','?')} · "
+              f"CUDA: {env.get('cuda','?')} · ncu: {env.get('ncu','?')}")
+    md.append(f"- Methodik: ncu `--clock-control base` (Clocks gelockt), Counter gepinnt "
+              f"(config_version {meta['config_version']}), {meta['restarts']} Container-Restarts, "
+              f"AI aus gemessenem `dram__bytes.sum`, FLOPs aus `sm__ops_path_tensor_*`/SASS-Counters. "
+              f"Roh-Exporte: `tools/roofline/history/raw/{run['run_id']}/`.\n")
+    md.append("## Modul 1 — Roofline pro Kernel-Klasse\n")
+    md.append("Zeitanteil = Klassen-Anteil an der nsys-Phasen-Timeline der Zelle "
+              "(prefill_window bzw. post_prefill=Decode). %-Roofline/AI aus dem "
+              "ncu-Steady-State-Fenster. Peak compute auf gemessenen (gelockten) "
+              "SM-Takt normiert; ridge auf Boost-Takt.\n")
+    md.append(module1_table(rows))
+    md.append("\n## Modul 2 — Coverage / Legacy-Fallback (aus nsys-Timeline)\n")
+    md.append(module2_table(cov))
+    if ab_results:
+        md.append("\n### A/B Fallback-Deltas (gemessen, unprofiled)\n")
+        md.append("```json\n" + json.dumps(ab_results, indent=1) + "\n```\n")
+    md.append("\n## Lever-Liste (priorisiert, **alle Gewinne = Schätzung** via Amdahl "
+              "aus gemessenem Zeitanteil × Roofline-Headroom)\n")
+    for i, l in enumerate(lv[:15], 1):
+        md.append(f"{i}. **{l['class']}** @ {l['cell']} — est. Fenster-Gewinn "
+                  f"~{l['est_gain_pct']:.1f}% (Zeitanteil {l['time_share_pct']:.1f}%, "
+                  f"{'%-Roofline med ' + format(l.get('pct_roofline_med', 0), '.1f') + ' vs Ziel ' + format(l.get('target_pct', 0), '.0f') if l['kind']=='roofline_headroom' else l.get('note','')})")
+    md.append("\n*(Jede Zahl rückverfolgbar: run_id = commit_timestamp; Roh-ncu-CSV + "
+              "nsys-Extract liegen append-only unter history/raw/<run_id>/.)*\n")
+    return "\n".join(md)

--- a/tools/roofline/rl_table.py
+++ b/tools/roofline/rl_table.py
@@ -1,0 +1,93 @@
+"""Build the Modul-1 roofline table rows from a run record. Shared by
+report/plot/regress/issues. stdlib only."""
+import statistics
+
+
+def _median(vals):
+    return statistics.median(vals) if vals else 0.0
+
+
+def class_aggregate(ncu_kernels, class_name, gpu_cfg):
+    """Aggregate all kernels of one class within one restart cell."""
+    members = {n: r for n, r in ncu_kernels.items() if r["class"] == class_name}
+    if not members:
+        return None
+    t = sum(r["time_ns"] for r in members.values())
+    fl = sum(r["flops"] for r in members.values())
+    by = sum(r["dram_bytes"] for r in members.values())
+    if t <= 0:
+        return None
+    # dominant dtype = dtype of the FLOP-heaviest member
+    dom = max(members.values(), key=lambda r: r["flops"])
+    dtype = dom["dtype"]
+    clk_hz = sum(r["sm_clock_mhz"] * 1e6 * r["time_ns"] for r in members.values()) / t
+
+    ai = fl / by if by > 0 else 0.0
+    ach_flops = fl / (t * 1e-9)
+    ach_bw = by / (t * 1e-9)
+    peak_bw = gpu_cfg["dram_peak_gbs"] * 1e9
+    fpc = gpu_cfg["flop_per_cycle"][dtype]
+    peak_flops_boost = fpc * gpu_cfg["nominal_boost_ghz"] * 1e9
+    peak_flops_clk = fpc * clk_hz
+    ridge = peak_flops_boost / peak_bw
+    bound = "memory" if ai < ridge else "compute"
+    pct = 100.0 * (ach_bw / peak_bw if bound == "memory"
+                   else (ach_flops / peak_flops_clk if peak_flops_clk else 0.0))
+    occ = sum(r["occupancy_pct"] * r["time_ns"] for r in members.values()) / t
+    sm_pct = sum(r["sm_pct"] * r["time_ns"] for r in members.values()) / t
+    return {
+        "sm_pct": sm_pct,
+        "class": class_name, "dtype": dtype, "time_ns": t,
+        "n_kernels": len(members),
+        "n_launches": sum(r.get("n_launches", 0) for r in members.values()),
+        "ai": ai, "achieved_gflops": ach_flops / 1e9, "achieved_gbs": ach_bw / 1e9,
+        "ridge": ridge, "bound_by": bound, "pct_roofline": pct,
+        "occupancy_pct": occ, "sm_clock_mhz": clk_hz / 1e6,
+        "peak_gflops_at_clock": peak_flops_clk / 1e9,
+        "peak_gbs": gpu_cfg["dram_peak_gbs"],
+    }
+
+
+def build_rows(run, gpu_cfg):
+    """-> list of rows: one per (cell, class) with min/med/max over restarts."""
+    rows = []
+    for cell_key, restarts in sorted(run["cells"].items()):
+        model, shape = cell_key.split("|")
+        valid = [c for c in restarts if "ncu_kernels" in c]
+        if not valid:
+            continue
+        classes = sorted({r["class"] for c in valid for r in c["ncu_kernels"].values()})
+        for cls in classes:
+            per_restart = [a for c in valid
+                           if (a := class_aggregate(c["ncu_kernels"], cls, gpu_cfg))]
+            if not per_restart:
+                continue
+            med = sorted(per_restart, key=lambda r: r["pct_roofline"])[len(per_restart) // 2]
+            row = dict(med)
+            row.update({
+                "model": model, "shape": shape, "n_restarts": len(per_restart),
+                "pct_roofline_min": min(r["pct_roofline"] for r in per_restart),
+                "pct_roofline_med": _median([r["pct_roofline"] for r in per_restart]),
+                "pct_roofline_max": max(r["pct_roofline"] for r in per_restart),
+                "achieved_min": min(_ach(r) for r in per_restart),
+                "achieved_med": _median([_ach(r) for r in per_restart]),
+                "achieved_max": max(_ach(r) for r in per_restart),
+            })
+            rows.append(row)
+    return rows
+
+
+def _ach(r):
+    return r["achieved_gbs"] if r["bound_by"] == "memory" else r["achieved_gflops"]
+
+
+def time_share_within_cell(rows):
+    """Annotate rows with % of captured-window time within their cell."""
+    by_cell = {}
+    for r in rows:
+        by_cell.setdefault((r["model"], r["shape"]), []).append(r)
+    for cell_rows in by_cell.values():
+        total = sum(r["time_ns"] for r in cell_rows) or 1
+        for r in cell_rows:
+            r["time_share_pct"] = 100.0 * r["time_ns"] / total
+    return rows

--- a/tools/roofline/roofline
+++ b/tools/roofline/roofline
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 "$(dirname "$(readlink -f "$0")")/roofline.py" "$@"

--- a/tools/roofline/roofline.py
+++ b/tools/roofline/roofline.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""roofline — reproducible roofline + kernel-coverage pipeline for imp.
+
+Subcommands:
+  measure   ncu+nsys sweep over the shape set (>=3 restarts), new history entry
+  ab        unprofiled A/B bench for a fallback knob (e.g. fa2)
+  plot      render roofline.png / trend / compare from history (no re-measure)
+  report    markdown report (Modul 1 + Modul 2 + levers) from history
+  regress   exit!=0 if a kernel class fell > threshold below a baseline run
+  issues    generate GitHub issues from findings (dry-run unless --create)
+  list      list history runs
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import rl_config
+import rl_history
+
+PLOT_IMAGE = "imp-roofline-plot"
+
+
+def cmd_measure(args):
+    cfg = rl_config.load_config(args.config)
+    import rl_measure
+    model_keys = args.models.split(",") if args.models else list(cfg["models"])
+    shape_keys = args.shapes.split(",") if args.shapes else list(cfg["shapes"])
+    for mk in model_keys:
+        if mk not in cfg["models"]:
+            raise SystemExit(f"unknown model key {mk}")
+    for sk in shape_keys:
+        if sk not in cfg["shapes"]:
+            raise SystemExit(f"unknown shape key {sk}")
+    run = rl_measure.measure(cfg, args.restarts, model_keys, shape_keys,
+                             note=args.note, dry_run=args.dry_run)
+    if run:
+        bad = [k for k, cells in run["cells"].items() if any("error" in c for c in cells)]
+        if bad:
+            print(f"WARNING: cells with errors: {bad}", file=sys.stderr)
+        print(run["run_id"])
+    return 0
+
+
+def cmd_ab(args):
+    cfg = rl_config.load_config(args.config)
+    import rl_measure
+    knobs = {
+        "fa2": {"IMP_FMHA_FA2": "0"},
+    }
+    if args.knob not in knobs:
+        raise SystemExit(f"unknown knob {args.knob}; have {list(knobs)}")
+    model_keys = args.models.split(",") if args.models else list(cfg["models"])
+    shape_keys = args.shapes.split(",") if args.shapes else ["pp512", "pp2048", "pp4096"]
+    res = rl_measure.ab_test(cfg, model_keys, shape_keys, args.knob,
+                             knobs[args.knob], restarts=args.restarts)
+    out = args.out or os.path.join(rl_config.HISTORY_DIR,
+                                   f"ab_{args.knob}_{rl_config.new_run_id()}.json")
+    with open(out, "w") as f:
+        json.dump({"knob": args.knob, "git": rl_config.git_meta(),
+                   "timestamp": rl_config.now_ts(), "results": res}, f, indent=1)
+    print(out)
+    return 0
+
+
+def _ensure_plot_image():
+    have = subprocess.run(["docker", "image", "inspect", PLOT_IMAGE],
+                          capture_output=True).returncode == 0
+    if not have:
+        subprocess.run(["docker", "build", "-t", PLOT_IMAGE, "-f",
+                        os.path.join(rl_config.TOOL_DIR, "Dockerfile.plot"),
+                        rl_config.TOOL_DIR], check=True)
+
+
+def cmd_plot(args):
+    _ensure_plot_image()
+    repo = rl_config.REPO_ROOT
+    out_dir = args.out_dir or os.path.join(rl_config.TOOL_DIR, "plots")
+    os.makedirs(out_dir, exist_ok=True)
+    rel_tool = os.path.relpath(rl_config.TOOL_DIR, repo)
+
+    def run_plot(mode, out_name, run_ref="latest", run_b=None):
+        cmd = ["docker", "run", "--rm", "-u", f"{os.getuid()}:{os.getgid()}",
+               "-e", "MPLCONFIGDIR=/tmp",
+               "-v", f"{repo}:/repo", "-w", f"/repo/{rel_tool}",
+               PLOT_IMAGE, "python3", "rl_plot.py", "--mode", mode,
+               "--run", run_ref, "--out",
+               os.path.join("/repo", os.path.relpath(out_dir, repo), out_name)]
+        if run_b:
+            cmd += ["--run-b", run_b]
+        subprocess.run(cmd, check=True)
+
+    if args.compare:
+        run_plot("compare", "roofline_compare.png", args.compare[0], args.compare[1])
+    else:
+        ref = args.commit or args.run or "latest"
+        run_plot("roofline", "roofline.png", ref)
+        run_plot("trend", "roofline_trend.png", ref)
+    print(f"plots in {out_dir}")
+    return 0
+
+
+def cmd_report(args):
+    cfg = rl_config.load_config(args.config)
+    import rl_report
+    run = rl_history.load_run(args.run)
+    ab = None
+    if args.ab_file and os.path.exists(args.ab_file):
+        with open(args.ab_file) as f:
+            ab = json.load(f)
+    md = rl_report.render(run, cfg, ab_results=ab)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(md)
+        print(args.out)
+    else:
+        print(md)
+    return 0
+
+
+def cmd_regress(args):
+    cfg = rl_config.load_config(args.config)
+    import rl_regress
+    base = rl_history.load_run(args.baseline)
+    cur = rl_history.load_run(args.run)
+    thr = args.threshold if args.threshold is not None else cfg["regress"]["default_threshold_pct"]
+    failures, infos = rl_regress.compare(base, cur, cfg, thr)
+    for l in infos:
+        print("  " + l)
+    if failures:
+        print(f"\nREGRESSIONS (> {thr}% below baseline {base['run_id']}):")
+        for l in failures:
+            print("  FAIL " + l)
+        return 1
+    print(f"\nOK: no kernel class > {thr}% below baseline {base['run_id']}")
+    return 0
+
+
+def cmd_issues(args):
+    cfg = rl_config.load_config(args.config)
+    import rl_issues
+    run = rl_history.load_run(args.run)
+    issues = rl_issues.build_issues(run, cfg)
+    if not issues:
+        print("no findings above issue threshold")
+        return 0
+    for st, title in rl_issues.create_or_update(issues, dry_run=not args.create):
+        print(f"[{st}] {title}")
+    if not args.create:
+        print(f"\n({len(issues)} issues planned — re-run with --create to create/update them)")
+    return 0
+
+
+def cmd_list(args):
+    for r in rl_history.list_runs():
+        print(f"{r['run_id']}  cells={len(r['cells'])}  note={r.get('note','')}")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="roofline", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", default=None)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    m = sub.add_parser("measure")
+    m.add_argument("--restarts", type=int, default=3)
+    m.add_argument("--models", help="comma-separated model keys (default: all)")
+    m.add_argument("--shapes", help="comma-separated shape keys (default: all)")
+    m.add_argument("--note", default="")
+    m.add_argument("--dry-run", action="store_true")
+    m.set_defaults(fn=cmd_measure)
+
+    a = sub.add_parser("ab")
+    a.add_argument("--knob", required=True)
+    a.add_argument("--models")
+    a.add_argument("--shapes")
+    a.add_argument("--restarts", type=int, default=3)
+    a.add_argument("--out")
+    a.set_defaults(fn=cmd_ab)
+
+    p = sub.add_parser("plot")
+    p.add_argument("--run")
+    p.add_argument("--commit")
+    p.add_argument("--latest", action="store_true")
+    p.add_argument("--compare", nargs=2, metavar=("RUN_A", "RUN_B"))
+    p.add_argument("--out-dir")
+    p.set_defaults(fn=cmd_plot)
+
+    r = sub.add_parser("report")
+    r.add_argument("--run", default="latest")
+    r.add_argument("--ab-file")
+    r.add_argument("-o", "--out")
+    r.set_defaults(fn=cmd_report)
+
+    g = sub.add_parser("regress")
+    g.add_argument("--baseline", required=True)
+    g.add_argument("--run", default="latest")
+    g.add_argument("--threshold", type=float, help="percent, e.g. 5")
+    g.set_defaults(fn=cmd_regress)
+
+    i = sub.add_parser("issues")
+    i.add_argument("--run", default="latest")
+    i.add_argument("--create", action="store_true")
+    i.set_defaults(fn=cmd_issues)
+
+    l = sub.add_parser("list")
+    l.set_defaults(fn=cmd_list)
+
+    args = ap.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Docs-truth pass over the living .md files (follow-up to the skills audit #591, which flagged GOAL.md). Dated snapshots/journals (`ptx-status-*`, `decode-gap-analysis`, `MISSION_JOURNAL`, `DISPATCH.md` log, `docs/archive/`, `TEST_AUDIT`) were intentionally left untouched as historical record.

## GOAL.md
- **Target hardware**: removed the `H100/H200 (sm_90a) — Hopper path stays alive` row and the cuBLAS/scalar-FA2 best-effort claim — there is no Hopper/Ada/Ampere/sm_100 path in the tree; replaced with the `compute_120f` PTX-fallback reality and an explicit "unsupported by design" statement (now consistent with README/CLAUDE.md).
- **Technical means**: `CUTLASS Hopper FMHA path on sm_120` → the actual FA2 prefill family (register-resident FA2 default-on, FP16-QK short-prefill, FP8 FMHA fallback; FP8×FP8 cuBLAS prefill is `NOT_SUPPORTED` on sm_120). `WMMA 8-warp decode kernel` → paged decode attention + CUDA-graph decode loop.
- **Hero set**: gpt-oss-20b was still listed as "tracked gap, not yet supported (#547)" — supported since 2026-06-06 (PRs #572–#574, tg ≈ 315–345, pp512 ≈ 16–19k).

## supported-models.md
- Decode columns were pre-re-bench (2026-05-26 era). Synced with the SHA-anchored BENCHMARKS.md values (2026-05-30, `bebafd5`): Qwen3-8B-cortecs 238→277, Qwen3-14B NVFP4 105→168, Qwen3-30B 158→307, Qwen3-Coder NVFP4 270→307, Qwen3.6-35B 154→245, Gemma-4 NVFP4 163→259, Nemotron 47→126; Qwen3-8B Q8 → 268 (tg128 CI baseline #540), Gemma-4 Q4_K_M → 259 (tg128).
- Vision section claimed "Gemma-3 is the only multimodal family" — Gemma-4 VL shipped in #489/#490; added the Gemma-4 row + spec link.

## Smaller fixes
- **README.md / BENCHMARKS.md**: Qwen3-8B Q8_0 baseline ~258 → ~268 (perf_baseline.json refresh 2026-06-05, #540).
- **CONTRIBUTING.md**: `make test-gpu (~30s)` → `~4–5 min` (the Makefile itself already flagged the 30s note as stale).
- **docs/usage.md**: CUDA Toolkit requirement now names 13.3 as canonical (13.2 CMake minimum).
- **CHANGELOG.md**: folded the stray second `## Unreleased` section (entries that shipped pre-0.9.1) into [0.9.1] as a labeled subsection — one `[Unreleased]` remains.

## Verified, intentionally NOT changed
- `/v1/embeddings` stays documented as an endpoint — live-tested against a freshly built `imp:test` (server + Qwen3-4B, returns real embedding vectors), refuting an audit finding that it was unimplemented.
- Phi-4-reasoning-plus stays listed as working (fixed by the RoPE-NeoX fix #503; an audit finding claiming it broken was stale).
- docs/performance.md, quantization.md, quant-pipeline.md, attention-dispatch.md, sm120.md, roadmap.md, determinism.md, architecture.md audited — current, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)