### PR TITLE
docs: English-only repo language — translate remaining German content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ Prefill numbers vary up to 2.6× across container restarts because of cuBLAS alg
 
 Other rules:
 
+- **English only.** All PRs (title + body), commit messages, code comments, docs, and `.md` files are written entirely in English. (Deliberate non-English *test data* — tokenizer Unicode fixtures, multilingual probes in `tools/analysis/degen_suite.py` — is exempt and should carry a comment saying so.)
 - `#pragma once` in headers (no include guards).
 - `.cu` for CUDA, `.cpp` for plain C++, `.h` for headers (CUDA or not).
 - File names are `snake_case`. Known intentional exception: the `smallM` fragment (`gemm_grouped_nvfp4_smallM.{h,cu}`) — it mirrors the user-facing config key `moe.nvfp4_smallM`, which can't change without breaking configs.

--- a/docs/audit/performance_agent_readiness_2026_05_31.md
+++ b/docs/audit/performance_agent_readiness_2026_05_31.md
@@ -1,187 +1,187 @@
 # imp — Audit: Performance & Agent-Readiness (2026-05-31)
 
-Read-only Audit. Keine Code-Änderung. Belege: **[M]** = frisch gemessen (diese Session),
-**[P]** = profilbelegt (nsys diese Session oder dokumentiertes ncu/nsys), **[C]** = Code-Stelle, **[H]** = Hypothese.
+Read-only audit. No code changes. Evidence: **[M]** = freshly measured (this session),
+**[P]** = profile-backed (nsys this session or documented ncu/nsys), **[C]** = code location, **[H]** = hypothesis.
 
-Mess-Setup: Host RTX 5090 (sm_120), CUDA 13.3, Binary `build-ciq/imp-cli` (29.05., CompileIQ-ACF-Build —
-absolute Zahlen ±ein paar %, die qualitativen Schlüsse sind robust). `CUBLAS_WORKSPACE_CONFIG=:4096:8`.
+Measurement setup: Host RTX 5090 (sm_120), CUDA 13.3, binary `build-ciq/imp-cli` (05-29, CompileIQ-ACF build —
+absolute numbers ±a few %, the qualitative conclusions are robust). `CUBLAS_WORKSPACE_CONFIG=:4096:8`.
 
 ---
 
 ## Executive Summary
 
-1. **Die zentrale Audit-Prämisse ist veraltet.** "MoE-Prefill ~1258 tok/s, 20× hinter vLLM" stimmt nicht mehr.
-   Frisch gemessen liefert Qwen3-Coder-30B-A3B-NVFP4 **16.5–18.2k tok/s Prefill** (pp512–pp4096). Der "1258"-Wert
-   stammt aus `archive/vllm_comparison_2026_05_10.md` (pp512, **vor** dem CUTLASS-3.x-grouped-GEMM-Umbau, alter
-   `NVFP4→FP16-dequant + cuBLAS-grouped`-Pfad). Dieser wurde mit ~42× abgelöst; der **reale Rest-Gap zu vLLM ist
-   ~1.15–1.42×**, nicht 20×. Das größte einzelne Prefill-Optimierungsziel aus dem Briefing existiert so nicht mehr.
-2. **Der echte NVFP4-Prefill-Hebel ist die Attention, nicht der grouped GEMM.** Der MoE-Expert-GEMM läuft fused
-   (Dequant in der MMA) und ist nahe Roofline. Der adressierbare Rest ist der teil-materialisierte Attention-Pfad
-   (FA2 greift nur teilweise).
-3. **Agent-Backend ist überraschend reif.** Serving (continuous batching, prefix-cache, paged-KV, cancellation,
-   rate-limit, Prometheus) ist weitgehend produktionsreif. Constrained Output **funktioniert** (entgegen erster
-   Vermutung — `apply_mask` ist im Sampling verdrahtet). Echte Lücken: synthetisches `/v1/messages`-Streaming,
-   kein Per-Request-Spec-Decode, Determinismus-Vorbehalt bei MoE, kein Prompt-Caching-Header.
+1. **The central audit premise is outdated.** "MoE prefill ~1258 tok/s, 20× behind vLLM" no longer holds.
+   Freshly measured, Qwen3-Coder-30B-A3B-NVFP4 delivers **16.5–18.2k tok/s prefill** (pp512–pp4096). The "1258" value
+   comes from `archive/vllm_comparison_2026_05_10.md` (pp512, **before** the CUTLASS 3.x grouped-GEMM rework, old
+   `NVFP4→FP16-dequant + cuBLAS-grouped` path). That path was superseded by ~42×; the **real remaining gap to vLLM is
+   ~1.15–1.42×**, not 20×. The single largest prefill optimization target from the briefing no longer exists as such.
+2. **The real NVFP4 prefill lever is attention, not the grouped GEMM.** The MoE expert GEMM runs fused
+   (dequant in the MMA) and is near roofline. The addressable remainder is the partially materialized attention path
+   (FA2 only applies partially).
+3. **The agent backend is surprisingly mature.** Serving (continuous batching, prefix-cache, paged-KV, cancellation,
+   rate-limit, Prometheus) is largely production-ready. Constrained output **works** (contrary to the initial
+   assumption — `apply_mask` is wired into sampling). Real gaps: synthetic `/v1/messages` streaming,
+   no per-request spec-decode, determinism caveat for MoE, no prompt-caching header.
 
 ---
 
-# Teil A — Performance
+# Part A — Performance
 
-## A.0 Verifikation der Prämisse (frische Messung)
+## A.0 Verification of the premise (fresh measurement)
 
-Qwen3-Coder-30B-A3B-Instruct-FP4, 3 reps, Default-Pfad (`executor_forward_moe_cutlass.cu:112` device-args):
+Qwen3-Coder-30B-A3B-Instruct-FP4, 3 reps, default path (`executor_forward_moe_cutlass.cu:112` device-args):
 
-| Metrik | pp512 | pp2048 | pp4096 | decode tg256 |
+| Metric | pp512 | pp2048 | pp4096 | decode tg256 |
 |---|---|---|---|---|
 | tok/s **[M]** | 16.535 | 17.206 | 18.229 | 290–295 |
 
-- Fallback-Pfad `IMP_NVFP4_DEVICE_ARGS=0` (host-args CUTLASS 3.x): pp2048 = **12.815 tok/s [M]** — auch das ist
-  nicht 1258. Der echte ~77-tok/s-Wert ist der *legacy serielle* Pfad, längst tot (`executor_forward_moe_cutlass.cu:306`:
+- Fallback path `IMP_NVFP4_DEVICE_ARGS=0` (host-args CUTLASS 3.x): pp2048 = **12.815 tok/s [M]** — that too is
+  not 1258. The actual ~77 tok/s value is the *legacy serial* path, long dead (`executor_forward_moe_cutlass.cu:306`:
   "Prefill n=120: ~2750 vs legacy ~77 — 35× win").
-- Decode-Moat bestätigt: tg256 ≈ 290 tok/s mit Graphs (höher als die im Briefing genannten 200). **[M]**
-- vLLM-Vergleichszahl 25.513 ist die einzige nicht selbst-verifizierte Größe; selbst gegen sie ist imp ~0.65–0.72×.
+- Decode moat confirmed: tg256 ≈ 290 tok/s with graphs (higher than the 200 cited in the briefing). **[M]**
+- vLLM comparison value 25.513 is the only non-self-verified figure; even against it imp is ~0.65–0.72×.
 
-## A.1 Prefill-Kernel-Breakdown (nsys, prefill-isoliert, Graphs off)
+## A.1 Prefill kernel breakdown (nsys, prefill-isolated, graphs off)
 
-Profil: ~2800-Token-Prompt + `--max-tokens 1` (isoliert Prefill). **Wichtiger Fallstrick zuerst:**
+Profile: ~2800-token prompt + `--max-tokens 1` (isolates prefill). **Important pitfall first:**
 
-- `convert_scales_sfatom_kernel` erscheint mit **21.7 %** — aber mit **identisch 37.249 Instanzen / ~47 ms in
-  *beiden* Läufen** (1 vs. 256 Decode-Steps). Das ist **einmalige Cache-Bau-Arbeit beim Modell-Laden**, kein
-  Per-Prefill-Kostenpunkt. Im Server (einmal laden) amortisiert → **nicht jagen** (deckt sich mit
+- `convert_scales_sfatom_kernel` appears at **21.7 %** — but with **identical 37.249 instances / ~47 ms in
+  *both* runs** (1 vs. 256 decode steps). This is **one-time cache-build work at model load**, not a
+  per-prefill cost. In the server (load once) it amortizes → **don't chase** (consistent with
   `docs/decode-gap-analysis-2026-05-29.md:14`). **[P]**
 
-Bereinigter Per-Prefill-Mix (NVFP4 MoE):
+Cleaned-up per-prefill mix (NVFP4 MoE):
 
-| Kernel | Anteil | Klasse | Beleg |
+| Kernel | Share | Class | Evidence |
 |---|---|---|---|
-| CUTLASS NVFP4 grouped GEMM (`GroupProblemShape`) | ~19 % | Expert-FFN, ~Roofline | [P] nsys |
-| `fmha_sm120_fa2_kernel<128>` | ~13 % | FA2-Attention (greift partiell) | [P] nsys |
-| `causal_softmax_fp32_to_fp16` + nvjet-cuBLAS-MMAs | ~18 % | **materialisierte Attention (Nicht-FA2)** — ⚠️ STALE (Stand vor #525 FP16-QK-FA2). Re-Messung 2026-06-07: **0.0 %** auf allen hd=128-Modellen pp512–4096; nur hd≠128 (gemma-3) bei 3.6–6.9 %. Siehe [`roofline_2026_06_07.md`](roofline_2026_06_07.md) | [P] nsys |
-| MoE quant/scatter/permute/gating/scale | je ~1 % | Routing-Overhead, klein | [P] nsys |
+| CUTLASS NVFP4 grouped GEMM (`GroupProblemShape`) | ~19 % | Expert-FFN, ~roofline | [P] nsys |
+| `fmha_sm120_fa2_kernel<128>` | ~13 % | FA2 attention (applies partially) | [P] nsys |
+| `causal_softmax_fp32_to_fp16` + nvjet-cuBLAS-MMAs | ~18 % | **materialized attention (non-FA2)** — ⚠️ STALE (state before #525 FP16-QK-FA2). Re-measured 2026-06-07: **0.0 %** on all hd=128 models pp512–4096; only hd≠128 (gemma-3) at 3.6–6.9 %. See [`roofline_2026_06_07.md`](roofline_2026_06_07.md) | [P] nsys |
+| MoE quant/scatter/permute/gating/scale | ~1 % each | routing overhead, small | [P] nsys |
 
-**Befund:** FA2 (`fmha_sm120_fa2_kernel`) *und* der alte materialisierte Pfad (`causal_softmax_fp32_to_fp16` + cuBLAS
-QK^T/PV) laufen gleichzeitig → Attention ist nur teilweise auf FA2. Das deckt sich mit der dokumentierten
-NVFP4-pp2048-Analyse: "CUTLASS NVFP4 GEMM 39 % (competitive w/ vLLM) + Attention ~37 %"
-(`docs/MISSION_JOURNAL.md:314`) und dem Roofline-Detail "FFN-Shapes ~100 % FP4-Roofline, Attention-Shapes ~34 %"
+**Finding:** FA2 (`fmha_sm120_fa2_kernel`) *and* the old materialized path (`causal_softmax_fp32_to_fp16` + cuBLAS
+QK^T/PV) run simultaneously → attention is only partially on FA2. This matches the documented
+NVFP4-pp2048 analysis: "CUTLASS NVFP4 GEMM 39 % (competitive w/ vLLM) + Attention ~37 %"
+(`docs/MISSION_JOURNAL.md:314`) and the roofline detail "FFN shapes ~100 % FP4 roofline, attention shapes ~34 %"
 (`docs/plans/nvfp4_pp2048_analysis_2026_05_25.md:35`).
 
-## A.2 Dequant fused vs. separater Pass — Hypothese aus dem Briefing geklärt
+## A.2 Dequant fused vs. separate pass — hypothesis from the briefing clarified
 
-- **NVFP4-MoE-Prefill: Dequant ist FUSED** in die block-scaled MMA (`mma.sync ...kind::mxf4nvf4.block_scale...m16n8k64`,
-  `src/compute/gemm_grouped_nvfp4_smallM.cu:81`; Pfad `executor_forward_moe_cutlass.cu:32-295`). Kein separater
-  FP16-Pass. Die Briefing-Arbeitshypothese ("grouped-GEMM Dequant-Pfad als Ursache") trifft auf NVFP4 **nicht** zu. **[C]**
-- **GGUF-Q4_K-MoE-Prefill: Dequant IST ein separater Pass** (`dequant_gpu()` → FP16 → `gemm_moe_batched()`,
-  4.55 B/elem vs. llama.cpp MMQ 0.55 B/elem = 8.3× Bandbreiten-Overhead, `docs/plans/q4k_prefill_analysis_2026_05_25.md:20-31`).
-  Das ist der reale "separate dequant"-Schmerz — aber bei GGUF, das laut Projekt-Policy *Legacy* ist (NVFP4 ist Priorität).
-- Fallback `try_run_moe_nvfp4_dequant_batch_prefill_` (`executor_forward_moe_batch.cu:54`) macht separaten Dequant
-  (Variable `slow_down_act`, Z.116) — feuert nur, wenn die device-args-Vorbedingungen fehlen. **[C]**
+- **NVFP4 MoE prefill: dequant is FUSED** into the block-scaled MMA (`mma.sync ...kind::mxf4nvf4.block_scale...m16n8k64`,
+  `src/compute/gemm_grouped_nvfp4_smallM.cu:81`; path `executor_forward_moe_cutlass.cu:32-295`). No separate
+  FP16 pass. The briefing's working hypothesis ("grouped-GEMM dequant path as the cause") does **not** apply to NVFP4. **[C]**
+- **GGUF Q4_K MoE prefill: dequant IS a separate pass** (`dequant_gpu()` → FP16 → `gemm_moe_batched()`,
+  4.55 B/elem vs. llama.cpp MMQ 0.55 B/elem = 8.3× bandwidth overhead, `docs/plans/q4k_prefill_analysis_2026_05_25.md:20-31`).
+  That is the real "separate dequant" pain — but in GGUF, which per project policy is *legacy* (NVFP4 is priority).
+- Fallback `try_run_moe_nvfp4_dequant_batch_prefill_` (`executor_forward_moe_batch.cu:54`) does a separate dequant
+  (variable `slow_down_act`, line 116) — fires only when the device-args preconditions are absent. **[C]**
 
-## A.3 CUDA-13.2/13.3-Features — Einbaubarkeit
+## A.3 CUDA 13.2/13.3 features — applicability
 
-| Feature | Anwendbar? | Wo / Effekt | Beleg |
+| Feature | Applicable? | Where / effect | Evidence |
 |---|---|---|---|
-| `cublasLtMatmulGrouped` NVFP4 device-shapes | **Nein** | 0 grouped-Algos auf sm_120 bis cuBLAS 13.4 (nur CC 10.x/11.0) | `docs/sm120.md:86`, `archive/cublas_13_4_sm120_no_movement_2026_05_09.md` [C] |
-| `cub::DeviceTopK` (Expert-Routing/Sampling) | **Prüfen [H]** | Aktuell `topk_gating_kernel` (1 Block/Token) — im Prefill nur ~1 %, im Decode/Sampling evtl. mehr. Kein vorheriger Test dokumentiert. | nsys [P] |
-| Grouped GEMM + CUDA Graphs | teilweise blockiert | CUTLASS `MoEProblemShape` trägt `IsMoEScheduler=false`-Stub für sm120; Capture-Hang unter `CaptureModeGlobal` | `archive/moe_prefill_graph_capture_analysis_2026_05_10.md`, `prefill_graph_blockers_2026_05_14.md` [C] |
-| CUDA 13.2→13.3 Instruktionen | kein Gewinn | 0 von 247 sm_120a-Instruktionen geflippt | `docs/MISSION_JOURNAL.md:413` [C] |
+| `cublasLtMatmulGrouped` NVFP4 device-shapes | **No** | 0 grouped algos on sm_120 up to cuBLAS 13.4 (only CC 10.x/11.0) | `docs/sm120.md:86`, `archive/cublas_13_4_sm120_no_movement_2026_05_09.md` [C] |
+| `cub::DeviceTopK` (expert routing/sampling) | **Check [H]** | Currently `topk_gating_kernel` (1 block/token) — only ~1 % in prefill, possibly more in decode/sampling. No prior test documented. | nsys [P] |
+| Grouped GEMM + CUDA Graphs | partially blocked | CUTLASS `MoEProblemShape` carries `IsMoEScheduler=false` stub for sm120; capture hang under `CaptureModeGlobal` | `archive/moe_prefill_graph_capture_analysis_2026_05_10.md`, `prefill_graph_blockers_2026_05_14.md` [C] |
+| CUDA 13.2→13.3 instructions | no gain | 0 of 247 sm_120a instructions flipped | `docs/MISSION_JOURNAL.md:413` [C] |
 
-## A.4 CUDA Graphs / Scheduling — Prämisse "nur Decode" widerlegt
+## A.4 CUDA Graphs / scheduling — premise "decode only" refuted
 
-- **Prefill IST graphifiziert** (default `runtime.prefill_graph=true`). Effekt frisch messbar: pp2048 17.206 (Graph)
-  vs. 14.787 (Graph off) = **~+16 % [M]**. Die Briefing-Frage "werden Graphs nur im Decode genutzt?" → nein.
-- Offen: Graphs für Nicht-Fast-Path-MoE-Decode (GGUF) bleiben blockiert (D2H-Expert-Routing, `docs/sm120.md:79`).
+- **Prefill IS graphified** (default `runtime.prefill_graph=true`). Effect freshly measurable: pp2048 17.206 (graph)
+  vs. 14.787 (graph off) = **~+16 % [M]**. The briefing question "are graphs used only in decode?" → no.
+- Open: graphs for non-fast-path MoE decode (GGUF) remain blocked (D2H expert routing, `docs/sm120.md:79`).
 
-## A.5 Priorisierte Befundtabelle (Teil A)
+## A.5 Prioritized findings table (Part A)
 
-| # | Befund | Beleg | Erwarteter Speedup | Aufwand | Decode-Risiko | Adressiert MoE-Prefill-Lücke? |
+| # | Finding | Evidence | Expected speedup | Effort | Decode risk | Addresses MoE-prefill gap? |
 |---|---|---|---|---|---|---|
-| A1 | **FA2-Abdeckung im Prefill erhöhen** — ✅ ERLEDIGT (#525 FP16-QK-FA2): Re-Messung 2026-06-07 = **0.0 % Legacy-Anteil auf hd=128**; Rest nur hd≠128 (gemma, 3.6–6.9 % Fenster = 92–99 % von dessen Attention). Siehe [`roofline_2026_06_07.md`](roofline_2026_06_07.md) | [P] nsys (~~18 %~~ → 0 %) | erledigt | — | — | Ja |
-| A2 | **GGUF-Q4_K-MoE-Prefill: in-SMEM-MMQ statt dequant→cuBLAS** | [C] 8.3× BW-Overhead, doku-belegt | pp +30–50 % GGUF | XL (2–3 Wo) | niedrig | nur GGUF (Legacy-Prio) |
-| A3 | **Kleine-M grouped-GEMM-Effizienz** — Attention-Shapes ~34 % Roofline bei small-M; Tile/Scheduler-Tuning | [P] doku-Roofline | pp +5–10 % | L | mittel | teilweise |
-| A4 | `convert_scales_sfatom` als Init **nicht** als Prefill-Kosten behandeln (Anti-Befund) | [P] identische Instanzzahl | 0 (Klarstellung) | — | — | nein |
-| A5 | `cub::DeviceTopK` für Routing/Sampling evaluieren | [H] | gering (Routing ~1 % Prefill) | S (Messung) | niedrig | nein |
-| A6 | Grouped-GEMM-CUDA-Graph-Capture entblocken (`IsMoEScheduler`) | [C] | pp +10–15 % | XL | mittel | teilweise |
+| A1 | **Increase FA2 coverage in prefill** — ✅ DONE (#525 FP16-QK-FA2): re-measured 2026-06-07 = **0.0 % legacy share on hd=128**; remainder only hd≠128 (gemma, 3.6–6.9 % window = 92–99 % of its attention). See [`roofline_2026_06_07.md`](roofline_2026_06_07.md) | [P] nsys (~~18 %~~ → 0 %) | done | — | — | Yes |
+| A2 | **GGUF Q4_K MoE prefill: in-SMEM MMQ instead of dequant→cuBLAS** | [C] 8.3× BW overhead, doc-backed | pp +30–50 % GGUF | XL (2–3 wk) | low | GGUF only (legacy prio) |
+| A3 | **Small-M grouped-GEMM efficiency** — attention shapes ~34 % roofline at small-M; tile/scheduler tuning | [P] doc roofline | pp +5–10 % | L | medium | partially |
+| A4 | Treat `convert_scales_sfatom` as init, **not** as prefill cost (anti-finding) | [P] identical instance count | 0 (clarification) | — | — | no |
+| A5 | Evaluate `cub::DeviceTopK` for routing/sampling | [H] | small (routing ~1 % prefill) | S (measurement) | low | no |
+| A6 | Unblock grouped-GEMM CUDA-graph capture (`IsMoEScheduler`) | [C] | pp +10–15 % | XL | medium | partially |
 
-> **Markiert als MoE-Prefill-Lücke:** A1 ist der mit Abstand beste Hebel — die Lücke ist *Attention*, nicht der
-> grouped GEMM. Der grouped GEMM ist bereits nahe Roofline und fused.
+> **Marked as MoE-prefill gap:** A1 is by far the best lever — the gap is *attention*, not the
+> grouped GEMM. The grouped GEMM is already near roofline and fused.
 
 ---
 
-# Teil B — Agent-Betrieb
+# Part B — Agent operation
 
-Status pro Achse. **Korrektur vorab:** Der erste Sub-Audit meldete Constrained Output als "toten Code"
-(`apply_mask` nie aufgerufen). **Das ist falsch** — selbst verifiziert: `apply_mask()` wird im Sampling an
-`src/exec/executor.cu:122/124, 220/222, 360/362` aufgerufen (drei Sampling-Pfade), FSM-Fortschritt via
-`constraint_manager.cpp:167`. Constrained Output ist funktional.
+Status per axis. **Correction up front:** the first sub-audit reported constrained output as "dead code"
+(`apply_mask` never called). **That is wrong** — self-verified: `apply_mask()` is called in sampling at
+`src/exec/executor.cu:122/124, 220/222, 360/362` (three sampling paths), FSM progress via
+`constraint_manager.cpp:167`. Constrained output is functional.
 
-| # | Achse | Status | Code-Beleg | Agent-Impact | Aufwand |
+| # | Axis | Status | Code evidence | Agent impact | Effort |
 |---|---|---|---|---|---|
-| 1 | **Structured/Constrained Output** | **funktioniert (Core)** | FSM `json_constrain.cu`/`schema_constrain.cu`; Maske im Sampling `executor.cu:122-362`; Server `handlers.cpp:731` (`response_format`) | kritisch | — |
-| 1b | … Regex/`pattern` + GBNF-Grammar | **fehlt** | kein `pattern`-Parsing in `json_schema.h`; kein GBNF-Compiler | wichtig | M |
-| 1c | … Masking-Overhead | unbelegt | kein Benchmark/Kommentar | nice | S (messen) |
-| 2 | **Tool Calling** (Definition, tool_choice auto/required/named, Dialekte) | **teilweise→vollständig** | `tool_call.cpp:6-150`, `chat_template.cpp:1093`; Vektor-Return `tool_call.cpp:142` (Mehrfach-Parsing vorhanden) | kritisch | — |
-| 2b | … Streaming von Tool-Call-Deltas | **fehlt** | Streaming-Pfad segmentiert Tool-Args nicht | wichtig | M |
-| 2c | … Argument-Validierung gegen input_schema | **fehlt** | lenientes `json::parse`, keine Schema-Prüfung | wichtig (Halluzination) | M (FSM aus 1 wiederverwenden) |
-| 3 | **Anthropic `/v1/messages`** (Blocks, tool_use/result, stop_reason, multi-block) | **vollständig** | `anthropic.cpp:19-394`, Handler `handlers.cpp:3449` | kritisch | — |
-| 3b | … **Streaming** | **synthetisch** | `handlers.cpp:3572` "Phase 2 synthetic" — volle Generierung dann SSE-Replay → TTFT = volle Latenz | **kritisch für Agents** | M |
-| 3c | … `thinking`-Blocks | **fehlt** | `anthropic.cpp:102` — reasoning verworfen | wichtig | S |
-| 3d | … prompt-caching-Header (`cache_control`) | **fehlt** | kein Parsing/Tracking | wichtig | M |
-| — | OpenAI `/v1/chat/completions`-Streaming | **echt** | `pop_token`-Loop `handlers.cpp:1371/1759/2762/2932` | — | — |
-| 4 | **Prefix/Prompt-Caching über Turns** | **vollständig** | content-addressed `kv_cache_manager.h:70-283`, Scheduler-Reuse `scheduler.cpp:70`, LRU-Eviction, Metrik `imp_tokens_cached_total` | kritisch | — |
-| 5 | **KV-Cache lange Loops** | **vollständig** | paged block_size=16 `kv_cache.h:12`; StreamingLLM `kv_cache_manager.h:124`; FP8/INT8/NVFP4-KV | wichtig | — |
-| 6 | **Reliability** (cancel/timeout/OOM) | **vollständig** | cancel `batching_engine.cpp:93`; timeout `handlers.cpp:1360`; OOM-try/catch `batching_engine.cpp:108`; KV-exhaustion early-cancel `scheduler.cpp:48` | kritisch | — |
-| 7 | **Concurrency/Scheduling** | **vollständig (in-flight batching)** | continuous batching `scheduler.cpp:17-126`, SJF gegen HoL `scheduler.cpp:27`; single-worker (kein Thread-Parallelismus) | kritisch | — |
-| 7b | … p50/p99-Latenz | **teilweise** | nur Single-Gauges `handlers.h:61` (kein Histogramm) | wichtig | S |
-| 7b' | … Aggregat-Durchsatz skaliert kaum mit N | [doku] | ~130 tok/s flat (`server_batching_throughput_ceiling`) | wichtig (Single-User-5090: evtl. Non-Goal) | L |
-| 8 | **Speculative Decoding (MTP)** | **teilweise — nicht im Serving** | Head+Forward da (`mtp_forward.cu`), Engine-API `engine.h:142`; **kein Per-Request-Flag**, Draft-Verify-Loop nicht im Decode verdrahtet | wichtig | L (zudem K=1-Acceptance ~25-30 %, [[mtp_diagnosis]]) |
-| 9 | **Determinismus** | **teilweise / Vorbehalt** | greedy argmax deterministisch `sampling.cu:41`; **MoE-Routing + top-k via atomics → nicht reproduzierbar** (`moe_routing.cu`); Qwen3.6-35B doku-belegt non-det @temp0 | wichtig (Eval/Test) | M |
-| 10 | **Observability** | **vollständig (bis auf Histogramm)** | Prometheus `/metrics` `handlers.cpp:3154`; logprobs `request.h:72`; queue_depth; per-Request JSONL | wichtig | — |
-| 11 | **Session/State** | **stateless** (Prefix-Pin als Ersatz) | `handlers.cpp:2426`; `pin_prefix` `kv_cache_manager.h:99`; kein Session-Store | nice | M |
-| 12 | **Multi-Model-Serving** | **fehlt/teilweise** | 1 Modell/Instanz; Reload-POST deferred `handlers.cpp:267` | wichtig (Tool-Router-Modell) | L |
-| 13 | **Container-Manager/Sandbox** | **fehlt komplett** | keine exec/sandbox/docker-socket-Infrastruktur; "tools" = nur Output-Formatierung | kritisch f. autonome Tool-Exec | XL |
-| 14 | **Security/Limits** | **vollständig** | API-Key konstant-Zeit `main.cpp:138`; per-IP rate-limit `handlers.h:108`; payload-cap 100 MiB `main.cpp:76`; max-concurrent 429 `main.cpp:113`; timeout 300s | wichtig | — |
-| 14b | … Input-Token-Längen-Limit | **fehlt** | keine Token-Count-Validierung vor Prefill | nice | S |
+| 1 | **Structured/Constrained Output** | **works (core)** | FSM `json_constrain.cu`/`schema_constrain.cu`; mask in sampling `executor.cu:122-362`; server `handlers.cpp:731` (`response_format`) | critical | — |
+| 1b | … regex/`pattern` + GBNF grammar | **missing** | no `pattern` parsing in `json_schema.h`; no GBNF compiler | important | M |
+| 1c | … masking overhead | unmeasured | no benchmark/comment | nice | S (measure) |
+| 2 | **Tool Calling** (definition, tool_choice auto/required/named, dialects) | **partial→complete** | `tool_call.cpp:6-150`, `chat_template.cpp:1093`; vector return `tool_call.cpp:142` (multi-parse present) | critical | — |
+| 2b | … streaming of tool-call deltas | **missing** | streaming path does not segment tool args | important | M |
+| 2c | … argument validation against input_schema | **missing** | lenient `json::parse`, no schema check | important (hallucination) | M (reuse FSM from 1) |
+| 3 | **Anthropic `/v1/messages`** (blocks, tool_use/result, stop_reason, multi-block) | **complete** | `anthropic.cpp:19-394`, handler `handlers.cpp:3449` | critical | — |
+| 3b | … **streaming** | **synthetic** | `handlers.cpp:3572` "Phase 2 synthetic" — full generation then SSE replay → TTFT = full latency | **critical for agents** | M |
+| 3c | … `thinking` blocks | **missing** | `anthropic.cpp:102` — reasoning discarded | important | S |
+| 3d | … prompt-caching header (`cache_control`) | **missing** | no parsing/tracking | important | M |
+| — | OpenAI `/v1/chat/completions` streaming | **real** | `pop_token` loop `handlers.cpp:1371/1759/2762/2932` | — | — |
+| 4 | **Prefix/Prompt caching across turns** | **complete** | content-addressed `kv_cache_manager.h:70-283`, scheduler reuse `scheduler.cpp:70`, LRU eviction, metric `imp_tokens_cached_total` | critical | — |
+| 5 | **KV cache long loops** | **complete** | paged block_size=16 `kv_cache.h:12`; StreamingLLM `kv_cache_manager.h:124`; FP8/INT8/NVFP4 KV | important | — |
+| 6 | **Reliability** (cancel/timeout/OOM) | **complete** | cancel `batching_engine.cpp:93`; timeout `handlers.cpp:1360`; OOM try/catch `batching_engine.cpp:108`; KV-exhaustion early-cancel `scheduler.cpp:48` | critical | — |
+| 7 | **Concurrency/Scheduling** | **complete (in-flight batching)** | continuous batching `scheduler.cpp:17-126`, SJF against HoL `scheduler.cpp:27`; single-worker (no thread parallelism) | critical | — |
+| 7b | … p50/p99 latency | **partial** | only single gauges `handlers.h:61` (no histogram) | important | S |
+| 7b' | … aggregate throughput barely scales with N | [doc] | ~130 tok/s flat (`server_batching_throughput_ceiling`) | important (single-user 5090: possibly non-goal) | L |
+| 8 | **Speculative Decoding (MTP)** | **partial — not in serving** | head+forward present (`mtp_forward.cu`), engine API `engine.h:142`; **no per-request flag**, draft-verify loop not wired into decode | important | L (also K=1 acceptance ~25-30 %, [[mtp_diagnosis]]) |
+| 9 | **Determinism** | **partial / caveat** | greedy argmax deterministic `sampling.cu:41`; **MoE routing + top-k via atomics → not reproducible** (`moe_routing.cu`); Qwen3.6-35B doc-confirmed non-det @temp0 | important (eval/test) | M |
+| 10 | **Observability** | **complete (except histogram)** | Prometheus `/metrics` `handlers.cpp:3154`; logprobs `request.h:72`; queue_depth; per-request JSONL | important | — |
+| 11 | **Session/State** | **stateless** (prefix-pin as substitute) | `handlers.cpp:2426`; `pin_prefix` `kv_cache_manager.h:99`; no session store | nice | M |
+| 12 | **Multi-model serving** | **missing/partial** | 1 model/instance; reload-POST deferred `handlers.cpp:267` | important (tool-router model) | L |
+| 13 | **Container manager/sandbox** | **completely missing** | no exec/sandbox/docker-socket infrastructure; "tools" = output formatting only | critical for autonomous tool exec | XL |
+| 14 | **Security/Limits** | **complete** | API key constant-time `main.cpp:138`; per-IP rate-limit `handlers.h:108`; payload cap 100 MiB `main.cpp:76`; max-concurrent 429 `main.cpp:113`; timeout 300s | important | — |
+| 14b | … input-token length limit | **missing** | no token-count validation before prefill | nice | S |
 
 ---
 
-# Schlussteil
+# Closing section
 
-## Top-5-Maßnahmen (Impact/Aufwand)
+## Top-5 actions (impact/effort)
 
-1. **`/v1/messages` echtes Token-Streaming** (B-3b). Synthetisches Streaming bedeutet TTFT = volle Generierung —
-   für interaktive Agent-Loops gegen den Anthropic-Endpoint ein harter Nachteil. OpenAI-Pfad streamt bereits echt,
-   das Muster ist also vorhanden. *Aufwand M, Impact kritisch.*
-2. **FA2-Abdeckung im Prefill vervollständigen** (A1). Der einzige große, decode-neutrale Prefill-Hebel; Attention,
-   nicht grouped GEMM, ist die Rest-Lücke zu vLLM. FA2 ist parity-getestet. *Aufwand M, Impact hoch.*
-3. **Tool-Argument-Validierung gegen `input_schema`** (B-2c) — die vorhandene Schema-FSM (B-1) auf Tool-Call-Bodies
-   anwenden. Verhindert halluzinierte/kaputte Tool-Argumente, der häufigste Agent-Loop-Bruch. *Aufwand M (Reuse).*
-4. **Determinismus-Schalter** (B-9): optionaler atomic-freier Routing-/Top-k-Pfad für `temperature=0`, für
-   reproduzierbare Agent-Evals. *Aufwand M, Impact wichtig (Testbarkeit).*
-5. **p50/p99-Latenz-Histogramm + prompt-caching-Header** (B-7b, B-3d): günstige Observability/Kosten-Sichtbarkeit
-   für Multi-Agent-Last. *Aufwand S–M.*
+1. **`/v1/messages` real token streaming** (B-3b). Synthetic streaming means TTFT = full generation —
+   a hard disadvantage for interactive agent loops against the Anthropic endpoint. The OpenAI path already streams for real,
+   so the pattern exists. *Effort M, impact critical.*
+2. **Complete FA2 coverage in prefill** (A1). The only large, decode-neutral prefill lever; attention,
+   not grouped GEMM, is the remaining gap to vLLM. FA2 is parity-tested. *Effort M, impact high.*
+3. **Tool-argument validation against `input_schema`** (B-2c) — apply the existing schema FSM (B-1) to tool-call bodies.
+   Prevents hallucinated/broken tool arguments, the most common agent-loop break. *Effort M (reuse).*
+4. **Determinism switch** (B-9): optional atomic-free routing/top-k path for `temperature=0`, for
+   reproducible agent evals. *Effort M, impact important (testability).*
+5. **p50/p99 latency histogram + prompt-caching header** (B-7b, B-3d): cheap observability/cost visibility
+   for multi-agent load. *Effort S–M.*
 
-> Container-Manager/Sandbox (B-13) ist der größte fehlende Baustein für *autonome* Tool-Ausführung, aber XL und
-> eine eigene Produktentscheidung — bewusst nicht in Top-5.
+> Container manager/sandbox (B-13) is the largest missing building block for *autonomous* tool execution, but XL and
+> a product decision of its own — deliberately not in the top-5.
 
-## Decode-Schutz (Regressions-Guards vor jeder Prefill-Optimierung)
+## Decode protection (regression guards before any prefill optimization)
 
-- **Gate vor jedem Merge:** `make verify-fast` gegen `tests/perf_baseline.json` (3 % Decode / 5 % Prefill).
-- **A/B nur über Decode** (`tg256`), isoliert + 60–120 s GPU-Cooldown, 10 reps, `CUBLAS_WORKSPACE_CONFIG=:4096:8`.
-  Prefill-pp variiert bis 2.6× über Container-Restarts — niemals als alleiniges Signal.
-- **Graphs ON *und* OFF** messen (Graph-Replay kann silent Fallback verstecken — `check-degeneration`-Skill).
-- **Kohärenz-Check** nach Forward-/Attention-/Routing-Änderungen (kein Repetition-Loop/Token-Stuck).
-- Baseline-Modelle für die Decode-Wand: Qwen3.6-35B-A3B-NVFP4 (Moat), Qwen3-14B-NVFP4 (dense), Qwen3-Coder-30B (MoE).
+- **Gate before every merge:** `make verify-fast` against `tests/perf_baseline.json` (3 % decode / 5 % prefill).
+- **A/B over decode only** (`tg256`), isolated + 60–120 s GPU cooldown, 10 reps, `CUBLAS_WORKSPACE_CONFIG=:4096:8`.
+  Prefill pp varies up to 2.6× across container restarts — never as the sole signal.
+- **Measure graphs ON *and* OFF** (graph replay can hide a silent fallback — `check-degeneration` skill).
+- **Coherence check** after forward/attention/routing changes (no repetition loop/token-stuck).
+- Baseline models for the decode wall: Qwen3.6-35B-A3B-NVFP4 (moat), Qwen3-14B-NVFP4 (dense), Qwen3-Coder-30B (MoE).
 
-## Implementierungs-Befunde (2026-05-31, Tasklist-Abarbeitung)
+## Implementation findings (2026-05-31, tasklist execution)
 
-### T2 (FA2-Abdeckung) — gemessen, kein sicherer globaler Flip [M]
-FA2 wird in `executor_attention.cu:811-817` (chunked) und `:849` (non-chunked) per
-`attention.fmha_prefill_threshold` gegated (Auto-Default = S-Matrix-VRAM-Cap+1,
-`executor_workspace_buffers.cu:267`). `causal_softmax_fp32_to_fp16` kommt aus `attention_cublas.cu`
-(materialisierter Pfad unter dem Threshold). pp512 A/B default vs FA2-always (`fmha_prefill_threshold=1`),
-decode durchweg neutral (FA2 berührt Decode nicht):
+### T2 (FA2 coverage) — measured, no safe global flip [M]
+FA2 is gated in `executor_attention.cu:811-817` (chunked) and `:849` (non-chunked) by
+`attention.fmha_prefill_threshold` (auto-default = S-matrix VRAM cap+1,
+`executor_workspace_buffers.cu:267`). `causal_softmax_fp32_to_fp16` comes from `attention_cublas.cu`
+(materialized path below the threshold). pp512 A/B default vs FA2-always (`fmha_prefill_threshold=1`),
+decode neutral throughout (FA2 does not touch decode):
 
-| Modell | default | FA2-always | Δ |
+| Model | default | FA2-always | Δ |
 |---|---|---|---|
 | Qwen3-30B-A3B | 13737 | 18154 | +32% |
 | Qwen3-Coder-30B | 15742 | 17465 | +11% |
@@ -189,74 +189,74 @@ decode durchweg neutral (FA2 berührt Decode nicht):
 | Qwen3-14B (dense) | 18178 | 15321 | −16% |
 | Gemma-4-26B (MoE) | 22297 | 16732 | −25% |
 
-→ Crossover ist modellabhängig; **kein decode-neutraler globaler Default-Flip möglich** (Gemma-4/dense
-regredieren → Perf-Gate). Sicherer Win heute: per-Modell `attention.fmha_prefill_threshold=1` für
-Qwen3-30B/Coder. Echte Lösung = gemessene per-(arch,seqlen)-Crossover-Heuristik (Folge-Arbeit, zoo-weit
-zu validieren). pp≥2048 nutzt FA2 bereits (Default ≈ FA2-always).
+→ Crossover is model-dependent; **no decode-neutral global default flip possible** (Gemma-4/dense
+regress → perf gate). Safe win today: per-model `attention.fmha_prefill_threshold=1` for
+Qwen3-30B/Coder. Real solution = measured per-(arch,seqlen) crossover heuristic (follow-up work, to be
+validated zoo-wide). pp≥2048 already uses FA2 (default ≈ FA2-always).
 
-### T11 (vLLM-Gegenmessung) — gemessen [M], korrigiert die Doku-Annahme
-vLLM 0.21.0 (`vllm/vllm-openai`), Qwen3-Coder-30B-A3B-NVFP4, echter FlashInfer/CUTLASS-NVFP4-Pfad
-(NICHT Marlin: `FlashInferCutlassNvFp4LinearKernel` + `FLASHINFER_CUTLASS` MoE), prefix-caching aus,
-`--max-concurrency 1`, `--random-output-len 1`, best-of-3 (WSL2-bimodal → kühlerer Modus):
+### T11 (vLLM cross-measurement) — measured [M], corrects the doc assumption
+vLLM 0.21.0 (`vllm/vllm-openai`), Qwen3-Coder-30B-A3B-NVFP4, real FlashInfer/CUTLASS-NVFP4 path
+(NOT Marlin: `FlashInferCutlassNvFp4LinearKernel` + `FLASHINFER_CUTLASS` MoE), prefix-caching off,
+`--max-concurrency 1`, `--random-output-len 1`, best-of-3 (WSL2 bimodal → cooler mode):
 
-| Prompt-Len | vLLM prefill tok/s | imp prefill tok/s | vLLM-Vorsprung |
+| Prompt len | vLLM prefill tok/s | imp prefill tok/s | vLLM lead |
 |---:|---:|---:|---:|
 | 512  | ~21.200 | 16.500 | 1.28× |
 | 2048 | ~33.300 | 17.200 | 1.94× |
 | 4096 | ~29.200 | 18.200 | 1.60× |
 
-→ Die "20×"-Prämisse ist endgültig widerlegt, **aber der reale Prefill-Gap (1.3–1.9× zugunsten vLLM) ist
-GRÖSSER als die in den Memos genannten 1.15–1.42×.** vLLM gewinnt Prefill auf jeder Länge über batched
-Prefill-GEMMs; Decode wurde nicht gemessen (imp-Decode-Moat unberührt). Konsistent mit A1/A.5: der Hebel
-ist Prefill-GEMM/Attention-Effizienz, nicht der Routing-/Dequant-Pfad.
+→ The "20×" premise is conclusively refuted, **but the real prefill gap (1.3–1.9× in vLLM's favor) is
+LARGER than the 1.15–1.42× cited in the memos.** vLLM wins prefill at every length via batched
+prefill GEMMs; decode was not measured (imp decode moat untouched). Consistent with A1/A.5: the lever
+is prefill-GEMM/attention efficiency, not the routing/dequant path.
 
-### Build-/Verifikations-Status (Tasklist-Batch, Branch `feat/agent-readiness-batch`)
-8 Code-Tasks (T1,3,4,5,6,7,8,9) implementiert + **Docker-Build grün** (CUDA 13.3), Unit 37/37, GPU-Tests
-73 passed/0 failed. Decode-Moat-Check: neues Binary tg256=253.0 vs build-ciq 256.9 (−1.5 %, im Rauschen) —
-**decode-neutral** ✓. Determinismus-Flag (T4) verifiziert: `runtime.deterministic=true` liefert bit-identische
-Tokens über Läufe (Qwen3-Coder, temp=0). Output kohärent, keine Degeneration. Commit `09335dd3`.
+### Build/verification status (tasklist batch, branch `feat/agent-readiness-batch`)
+8 code tasks (T1,3,4,5,6,7,8,9) implemented + **Docker build green** (CUDA 13.3), unit 37/37, GPU tests
+73 passed/0 failed. Decode-moat check: new binary tg256=253.0 vs build-ciq 256.9 (−1.5 %, within noise) —
+**decode-neutral** ✓. Determinism flag (T4) verified: `runtime.deterministic=true` produces bit-identical
+tokens across runs (Qwen3-Coder, temp=0). Output coherent, no degeneration. Commit `09335dd3`.
 
-Live-Server-Smoke-Tests (neues Binary, Qwen3-8B-NVFP4):
+Live-server smoke tests (new binary, Qwen3-8B-NVFP4):
 
-| Task | Ergebnis |
+| Task | Result |
 |---|---|
-| T1 /v1/messages Streaming | ✓ echte inkrementelle SSE (message_start→content_block_delta…) |
-| T3 Tool-Calling | ✓ `{"city":"Berlin"}`, finish_reason=tool_calls; Arg-Validierung aktiv |
-| T5 Metrics | ✓ `imp_request_duration_seconds`/`imp_ttft_seconds`-Histogramme |
-| T9 Input-Limit | ✓ langer Prompt → HTTP 400 "Prompt exceeds max input tokens (189 > 50)"; kurzer → 200 |
-| T7 Constrained | json_object ✓, json_schema-Struktur ✓; **`pattern`-Regex-Masking deaktiviert** (NFA über-maskierte → `!!!!`; geparst aber nicht erzwungen) |
-| T8 thinking-Blocks | Mapping implementiert; feuert nur bei separiertem `reasoning_content` (`--reasoning-format`) — Default-Smoke nicht bestätigt |
-| T6 Tool-Deltas | implementiert; Streaming bestätigt |
+| T1 /v1/messages streaming | ✓ real incremental SSE (message_start→content_block_delta…) |
+| T3 tool calling | ✓ `{"city":"Berlin"}`, finish_reason=tool_calls; arg validation active |
+| T5 metrics | ✓ `imp_request_duration_seconds`/`imp_ttft_seconds` histograms |
+| T9 input limit | ✓ long prompt → HTTP 400 "Prompt exceeds max input tokens (189 > 50)"; short → 200 |
+| T7 constrained | json_object ✓, json_schema structure ✓; **`pattern` regex masking disabled** (NFA over-masked → `!!!!`; parsed but not enforced) |
+| T8 thinking blocks | mapping implemented; fires only with separated `reasoning_content` (`--reasoning-format`) — default smoke not confirmed |
+| T6 tool deltas | implemented; streaming confirmed |
 
-Offene Follow-ups: T7 NFA-Over-Masking fixen + GrammarConstrainer in `executor.cu` verdrahten; T8 mit reasoning-format bestätigen.
+Open follow-ups: T7 fix NFA over-masking + wire GrammarConstrainer into `executor.cu`; T8 confirm with reasoning-format.
 
-### T10 (ncu-Roofline der Top-Prefill-Kernels) — gemessen [P]
-ncu (Host `/opt/nvidia/nsight-compute/2026.2.0/ncu`), Qwen3-Coder-NVFP4, graphs off, je 6 Mid-Network-Instanzen:
+### T10 (ncu roofline of the top prefill kernels) — measured [P]
+ncu (host `/opt/nvidia/nsight-compute/2026.2.0/ncu`), Qwen3-Coder-NVFP4, graphs off, 6 mid-network instances each:
 
-| Kernel | DRAM% (1792 GB/s) | SM% | Occupancy | Klassifikation |
+| Kernel | DRAM% (1792 GB/s) | SM% | Occupancy | Classification |
 |---|---|---|---|---|
-| NVFP4 grouped GEMM (MoE-Expert, mxf4nvf4 FP4-TC, Tile 128³, grid=170) | **59 %** | **34 %** | **24 %** | latency/wave-quantization-bound — **kein Roofline, Compute-Headroom** |
-| FA2 (`fmha_sm120_fa2_kernel<128>`, FP16, grid=128) | 3.4 % | 36 % | 16.8 % | latency/occupancy-bound — kein Roofline |
+| NVFP4 grouped GEMM (MoE expert, mxf4nvf4 FP4-TC, tile 128³, grid=170) | **59 %** | **34 %** | **24 %** | latency/wave-quantization-bound — **not roofline, compute headroom** |
+| FA2 (`fmha_sm120_fa2_kernel<128>`, FP16, grid=128) | 3.4 % | 36 % | 16.8 % | latency/occupancy-bound — not roofline |
 
-`smsp__...tensor_op_mma`-Counter sind auf sm_120 nicht exponiert; FP4-/FP16-TC-Nutzung via Kernel-Symbol bestätigt.
+`smsp__...tensor_op_mma` counters are not exposed on sm_120; FP4/FP16 TC usage confirmed via kernel symbol.
 
-### T12 (Small-M grouped-GEMM-Tuning) — Befund + Empfehlung [P]
-Die ncu-Daten bestätigen: der grouped GEMM ist **NICHT compute- oder bandbreiten-limitiert**, sondern
-**single-wave + small-M-per-Expert** (2009 Tokens / 128 Experten → winziges M_e) bei nur 24 % Occupancy.
-Lebende Hebel: (a) persistent/stream-K-Grid statt 170-Block-Single-Wave, (b) besseres Token-Packing zur
-Anhebung von M_e, (c) occupancy-erhöhende Tile-Wahl. **Aber:** deckt sich mit `nvfp4_moe_prefill_landscape`
-("hand-rolled NVFP4 grouped = par bei großem M_e, **−50-55 % bei small M_e**") und mit T11 (vLLMs batched
-Prefill-GEMMs gewinnen). Substanzieller, zoo-weit zu validierender CUTLASS-/Kernel-Aufwand → **kein
-Session-Scope-Merge**; konkreter nächster Schritt: CUTLASS-Sm120-grouped-Scheduler auf persistent/stream-K
-umstellen und M_e-Packing messen, gegen das Decode-Gate absichern.
+### T12 (small-M grouped-GEMM tuning) — finding + recommendation [P]
+The ncu data confirm: the grouped GEMM is **NOT compute- or bandwidth-limited**, but
+**single-wave + small-M-per-expert** (2009 tokens / 128 experts → tiny M_e) at only 24 % occupancy.
+Live levers: (a) persistent/stream-K grid instead of 170-block single-wave, (b) better token packing to
+raise M_e, (c) occupancy-raising tile choice. **But:** matches `nvfp4_moe_prefill_landscape`
+("hand-rolled NVFP4 grouped = par at large M_e, **−50-55 % at small M_e**") and T11 (vLLM's batched
+prefill GEMMs win). Substantial CUTLASS/kernel work to be validated zoo-wide → **not a
+session-scope merge**; concrete next step: switch the CUTLASS Sm120 grouped scheduler to persistent/stream-K
+and measure M_e packing, guarded against the decode gate.
 
-## Offene Fragen / fehlende Messungen
+## Open questions / missing measurements
 
-1. **vLLM-Gegenmessung auf dieser Box** für Qwen3-Coder-NVFP4 (pp2048/pp4096), apples-to-apples — die 25.513
-   ist die einzige nicht selbst-verifizierte Zahl; der reale Rest-Gap (~1.4×?) sollte frisch bestätigt werden.
-2. **ncu fehlt auf dem Host** (`ncu: command not found`) — für Roofline/Occupancy/Stall der Top-Prefill-Kernels
-   (FA2, grouped GEMM) muss ncu via Container gemountet werden (Recipe in [[decode_frontier_reconfirmed]]).
-3. **FA2-Threshold:** FA2 feuerte bereits bei ~2800 Tokens, aber `causal_softmax` lief parallel — warum die
-   Aufteilung? (Head-Dim ≠ 128? Chunk-Grenzen?) Klärt den genauen Umfang von A1.
-4. **`cub::DeviceTopK`** im Sampling/Routing: lohnt nur, wenn `topk_gating`/Sampling im Decode messbar Zeit kostet — ncu nötig.
-5. **MTP im Serving:** lohnt der Draft-Verify-Loop bei ~25–30 % Acceptance überhaupt? (Doku sagt: bei NVFP4 nein.)
+1. **vLLM cross-measurement on this box** for Qwen3-Coder-NVFP4 (pp2048/pp4096), apples-to-apples — 25.513
+   is the only non-self-verified number; the real remaining gap (~1.4×?) should be freshly confirmed.
+2. **ncu missing on the host** (`ncu: command not found`) — for roofline/occupancy/stall of the top prefill kernels
+   (FA2, grouped GEMM), ncu must be mounted via container (recipe in [[decode_frontier_reconfirmed]]).
+3. **FA2 threshold:** FA2 already fired at ~2800 tokens, but `causal_softmax` ran in parallel — why the
+   split? (head-dim ≠ 128? chunk boundaries?) Clarifies the exact scope of A1.
+4. **`cub::DeviceTopK`** in sampling/routing: worth it only if `topk_gating`/sampling costs measurable time in decode — ncu needed.
+5. **MTP in serving:** is the draft-verify loop worthwhile at all at ~25–30 % acceptance? (Doc says: for NVFP4, no.)

--- a/docs/audit/roofline_2026_06_07.md
+++ b/docs/audit/roofline_2026_06_07.md
@@ -1,35 +1,35 @@
 # imp Roofline-Audit — 2026-06-07
 
-**Run `e66cfa45-dirty_20260607_042900`** · 57 Zellen (5 Modelle × pp512/2048/4096 + tg256 × 3 Container-Restarts), **0 Fehlzellen**. Gemessen mit der neuen `tools/roofline/`-Pipeline (ncu-Counter + nsys-Timeline, append-only History) — **keine Zahl übernommen, alles dieser Run**. Reproduktion: `tools/roofline/roofline report --run e66cfa45-dirty_20260607_042900`.
+**Run `e66cfa45-dirty_20260607_042900`** · 57 cells (5 models × pp512/2048/4096 + tg256 × 3 container restarts), **0 missing cells**. Measured with the new `tools/roofline/` pipeline (ncu counters + nsys timeline, append-only history) — **no number carried over, everything from this run**. Reproduce: `tools/roofline/roofline report --run e66cfa45-dirty_20260607_042900`.
 
 ## Executive Summary
 
-1. **Die "~18 % materialisierte Attention" (Audit 2026-05-31) existiert nicht mehr.** Legacy-Pfad (cuBLAS QK^T → `causal_softmax` → cuBLAS PV) = **0.00 % Prefill-Zeit auf allen hd=128-Modellen** (Qwen3 Q8_0 / Q4_K_M-MoE / NVFP4 dense+MoE; alle Shapes, alle Restarts). FP16-QK-FA2 (#525) deckt Kurz-Prefill, FA2/FP8-FMHA den Long-Bereich. Restnutzer: **hd≠128** (gemma-3-12b, hd=256): 3.6–6.9 % der Prefill-Zeit = **92–99 % von dessen Attention-Zeit** (die ganze FA2-Familie verlangt hd=128). Attribution validiert: 673 attribuierte Attention-GEMMs ≈ 2 × 336 causal_softmax-Launches.
-2. **NVFP4-Dense-Prefill-GEMM (CUTLASS) = 50–61 % der Fensterzeit bei nur 22.4 % HBM-Roofline** (402 GB/s; AI≈1683 nahe FP4-Ridge 1872; L1-Hit 96 %, Occ 21 %). Grouped-GEMM (MoE-Experten) erreicht 41–52 % — der dense small-M-Pfad (M=512-Chunks) ist der größte quantifizierte Hebel (`moe.nvfp4_smallM`-Branch existiert als unverdrahtetes Opt-in).
-3. **FA2-Prefill-Attention: 5.6–8.3 % des FP16-TC-Peaks** bei bis zu 40 % Zeitanteil (pp4096 MoE), L1-Hit 3–25 %, Occ 8 % — konsistent mit der LSU-Bound-Analyse nach #484. A/B `fmha_fa2` on/off: ±2 % (FA2 vs FP8-FMHA perf-neutral) → der Hebel ist strukturell (Kernel-Familie), nicht Dispatch.
-4. **GGUF-Q4_K-MoE-Prefill: 63–65 % der Zeit im Source-Dequant** (`dequant_q4k`, 704 GB/s = 39 % BW) + 25–30 % cuBLAS — der NVFP4-Pfad zahlt für denselben Schritt nur 3–5 % (`quantize_fp16_nvfp4`, fused). GGUF-Q4_K-Decode läuft auf `gemv_dp4a_*` @ 42 % BW vs NVFP4-GEMV @ 59–73 %.
-5. **Decode bestätigt das HBM-Plateau:** NVFP4-dense `gemv_nvfp4` 87.5 % Zeitanteil @ 61.4 % HBM (bekanntes Dequant-Co-Limit); Q8-via-NVFP4-Cache 58.8 %; MoE-GEMV nur 30 % (Experten-Fragmentierung, kleine N je Experte).
+1. **The "~18 % materialized attention" (audit 2026-05-31) no longer exists.** Legacy path (cuBLAS QK^T → `causal_softmax` → cuBLAS PV) = **0.00 % prefill time on all hd=128 models** (Qwen3 Q8_0 / Q4_K_M-MoE / NVFP4 dense+MoE; all shapes, all restarts). FP16-QK-FA2 (#525) covers short prefill, FA2/FP8-FMHA the long range. Remaining user: **hd≠128** (gemma-3-12b, hd=256): 3.6–6.9 % of prefill time = **92–99 % of its attention time** (the entire FA2 family requires hd=128). Attribution validated: 673 attributed attention GEMMs ≈ 2 × 336 causal_softmax launches.
+2. **NVFP4 dense prefill GEMM (CUTLASS) = 50–61 % of window time at only 22.4 % HBM roofline** (402 GB/s; AI≈1683 near FP4 ridge 1872; L1 hit 96 %, occ 21 %). Grouped GEMM (MoE experts) reaches 41–52 % — the dense small-M path (M=512 chunks) is the largest quantified lever (`moe.nvfp4_smallM` branch exists as an unwired opt-in).
+3. **FA2 prefill attention: 5.6–8.3 % of FP16 TC peak** at up to 40 % time share (pp4096 MoE), L1 hit 3–25 %, occ 8 % — consistent with the LSU-bound analysis after #484. A/B `fmha_fa2` on/off: ±2 % (FA2 vs FP8-FMHA perf-neutral) → the lever is structural (kernel family), not dispatch.
+4. **GGUF Q4_K MoE prefill: 63–65 % of the time in source dequant** (`dequant_q4k`, 704 GB/s = 39 % BW) + 25–30 % cuBLAS — the NVFP4 path pays only 3–5 % for the same step (`quantize_fp16_nvfp4`, fused). GGUF Q4_K decode runs on `gemv_dp4a_*` @ 42 % BW vs NVFP4-GEMV @ 59–73 %.
+5. **Decode confirms the HBM plateau:** NVFP4-dense `gemv_nvfp4` 87.5 % time share @ 61.4 % HBM (known dequant co-limit); Q8-via-NVFP4-cache 58.8 %; MoE-GEMV only 30 % (expert fragmentation, small N per expert).
 
-### Top-3-Lever (alle Gewinne = Schätzung via Amdahl: Zeitanteil × Roofline-Headroom)
+### Top-3 levers (all gains = estimate via Amdahl: time share × roofline headroom)
 
-| # | Lever | Beleg (gemessen) | Erwartung (Schätzung) |
+| # | Lever | Evidence (measured) | Expectation (estimate) |
 |---|---|---|---|
-| 1 | **CUTLASS-NVFP4-GEMM small-M (dense Prefill)**: Tile/Scheduler für M=512-Chunks; `moe.nvfp4_smallM`-Branch evaluieren | 22.4 % Roofline bei 50–61 % Fensterzeit (alle 3 Shapes, σ über Restarts < 0.2 pp) | bis ~+35 % Prefill-Fenster dense NVFP4 |
-| 2 | **FA2-Kernel-Familie long-ctx**: strukturell (LSU-bound), nicht Tuning — Re-Evaluation des fp16qk-Kernels bei mittlerem ctx | 5.6–8.3 % FP16-Peak bei 21–40 % Fensterzeit; A/B on/off ±2 % | bis ~+25 % Fenster @ pp4096 MoE — nur falls LSU-Decke fällt |
-| 3 | **GGUF-Q4_K fused dequant+GEMM (Prefill)**: Materialisierung eliminieren (Q6K-fused-MoE-Pendant existiert) | 63–65 % Fensterzeit Source-Dequant @ 39 % BW | ~+25 % GGUF-MoE-Prefill (Legacy-Priorität) |
+| 1 | **CUTLASS-NVFP4-GEMM small-M (dense prefill)**: tile/scheduler for M=512 chunks; evaluate `moe.nvfp4_smallM` branch | 22.4 % roofline at 50–61 % window time (all 3 shapes, σ across restarts < 0.2 pp) | up to ~+35 % prefill window dense NVFP4 |
+| 2 | **FA2 kernel family long-ctx**: structural (LSU-bound), not tuning — re-evaluation of the fp16qk kernel at medium ctx | 5.6–8.3 % FP16 peak at 21–40 % window time; A/B on/off ±2 % | up to ~+25 % window @ pp4096 MoE — only if the LSU ceiling falls |
+| 3 | **GGUF Q4_K fused dequant+GEMM (prefill)**: eliminate materialization (Q6K-fused-MoE counterpart exists) | 63–65 % window time source dequant @ 39 % BW | ~+25 % GGUF MoE prefill (legacy priority) |
 
 ---
 
 
 - Commit: `e66cfa45` (dirty) · Timestamp: 20260607_042900 · config_version: 2
-- GPU: NVIDIA GeForce RTX 5090 · Treiber: 610.47 · CUDA: 13.3 [Deprecated; will be removed in CUDA 14.0. Use CUDA UMD Version instead] · ncu: Version 2026.2.0.0 (build 37790515) (public-release)
-- Methodik: ncu `--clock-control base` (Clocks gelockt), Counter gepinnt (config_version 2), 3 Container-Restarts, AI aus gemessenem `dram__bytes.sum`, FLOPs aus `sm__ops_path_tensor_*`/SASS-Counters. Roh-Exporte: `tools/roofline/history/raw/e66cfa45-dirty_20260607_042900/`.
+- GPU: NVIDIA GeForce RTX 5090 · Driver: 610.47 · CUDA: 13.3 [Deprecated; will be removed in CUDA 14.0. Use CUDA UMD Version instead] · ncu: Version 2026.2.0.0 (build 37790515) (public-release)
+- Methodology: ncu `--clock-control base` (clocks locked), counters pinned (config_version 2), 3 container restarts, AI from measured `dram__bytes.sum`, FLOPs from `sm__ops_path_tensor_*`/SASS counters. Raw exports: `tools/roofline/history/raw/e66cfa45-dirty_20260607_042900/`.
 
-## Modul 1 — Roofline pro Kernel-Klasse
+## Module 1 — Roofline per kernel class
 
-Zeitanteil = Klassen-Anteil an der nsys-Phasen-Timeline der Zelle (prefill_window bzw. post_prefill=Decode). %-Roofline/AI aus dem ncu-Steady-State-Fenster. Peak compute auf gemessenen (gelockten) SM-Takt normiert; ridge auf Boost-Takt.
+Time share = class share of the cell's nsys phase timeline (prefill_window resp. post_prefill=decode). %-roofline/AI from the ncu steady-state window. Peak compute normalized to the measured (locked) SM clock; ridge to boost clock.
 
-| Kernel-Klasse | Modell/Shape | Zeitanteil % (nsys) | AI (FLOP/B) | erreicht (med) | Peak | %-Roofline (min/med/max) | bound-by | dtype | L1-Hit% | Occ % |
+| Kernel class | Model/shape | Time share % (nsys) | AI (FLOP/B) | achieved (med) | Peak | %-roofline (min/med/max) | bound-by | dtype | L1-hit% | Occ % |
 |---|---|---|---|---|---|---|---|---|---|---|
 | gemm_cutlass_nvfp4 | nvfp4-dense/pp2048 | 57.6 | 1681.50 | 402.7 GB/s | 1,792 GB/s | 22.3 / 22.5 / 22.5 | memory | tc_fp4 | 96 | 21 |
 | attn_fa2 | nvfp4-dense/pp2048 | 20.8 | 522.31 | 39,390 GFLOPS | 696,588 GFLOPS @2001MHz | 5.6 / 5.7 / 5.7 | compute | tc_fp16 | 20 | 8 |
@@ -130,12 +130,12 @@ Zeitanteil = Klassen-Anteil an der nsys-Phasen-Timeline der Zelle (prefill_windo
 | rmsnorm | q8-dense/tg256 | 3.3 | 1.49 | 9.1 GB/s | 1,792 GB/s | 0.5 / 0.5 / 0.6 | memory | cuda_fp16 | 25 | 32 |
 | rope | q8-dense/tg256 | 2.3 | 4.44 | 6.7 GB/s | 1,792 GB/s | 0.3 / 0.4 / 0.4 | memory | cuda_fp32 | 52 | 8 |
 | kv_write | q8-dense/tg256 | 1.2 | 0.14 | 4.0 GB/s | 1,792 GB/s | 0.2 / 0.2 / 0.2 | memory | cuda_fp16 | 10 | 13 |
-(*) = Zeitanteil aus ncu-Fenster (nsys-Share fehlt)
+(*) = time share from ncu window (nsys share missing)
 
 
-## Modul 2 — Coverage / Legacy-Fallback (aus nsys-Timeline)
+## Module 2 — Coverage / legacy fallback (from nsys timeline)
 
-| Zelle | Legacy-Attn %-Anteil Fenster (min/med/max) | Legacy-Anteil an Attention % (min/med/max) | Restarts |
+| Cell | Legacy-attn %-share window (min/med/max) | Legacy share of attention % (min/med/max) | Restarts |
 |---|---|---|---|
 | nvfp4-dense|pp2048 | 0.0 / 0.0 / 0.0 | 0.0 / 0.0 / 0.0 | 3 |
 | nvfp4-dense|pp4096 | 0.0 / 0.0 / 0.0 | 0.0 / 0.0 / 0.0 | 3 |
@@ -158,9 +158,9 @@ Zeitanteil = Klassen-Anteil an der nsys-Phasen-Timeline der Zelle (prefill_windo
 | q8-dense|tg256 | 0.0 / 0.0 / 0.0 | 0.0 / 0.0 / 0.0 | 3 |
 
 
-### A/B Fallback-Deltas (gemessen, unprofiled)
+### A/B fallback deltas (measured, unprofiled)
 
-| Modell/Shape | fa2=on (tok/s je Restart) | fa2=never | Δ FA2-Gewinn je Paar |
+| Model/shape | fa2=on (tok/s per restart) | fa2=never | Δ FA2 gain per pair |
 |---|---|---|---|
 | nvfp4-dense/pp2048 | 18,193, 18,064 | 18,042, 17,712 | +0.8%, +1.9% |
 | nvfp4-dense/pp4096 | 15,565, 15,613 | 15,697, 15,356 | -0.8%, +1.6% |
@@ -169,63 +169,63 @@ Zeitanteil = Klassen-Anteil an der nsys-Phasen-Timeline der Zelle (prefill_windo
 | q8-dense/pp4096 | 7,528, 7,353 | 7,526, 7,471 | +0.0%, -1.6% |
 | q8-dense/pp512 | 8,490, 8,438 | 8,384, 8,423 | +1.3%, +0.2% |
 
-Quelle: `tools/roofline/history/ab_fa2_e66cfa45-dirty_20260607_093755.json` (unprofiled, gepaarte Container-Restarts, `IMP_FMHA_FA2=0` als Variant-Arm; `fa2_fp16qk` bleibt in beiden Armen aktiv). **Befund: FA2 register-resident vs FP8-FMHA-Fallback ist perf-neutral (±2 %; der +14.3 %-Ausreißer bei pp512 ist cuBLAS-Restart-Varianz — Paar 2 zeigt +1.9 %).**
+Source: `tools/roofline/history/ab_fa2_e66cfa45-dirty_20260607_093755.json` (unprofiled, paired container restarts, `IMP_FMHA_FA2=0` as variant arm; `fa2_fp16qk` stays active in both arms). **Finding: FA2 register-resident vs FP8-FMHA fallback is perf-neutral (±2 %; the +14.3 % outlier at pp512 is cuBLAS restart variance — pair 2 shows +1.9 %).**
 
 
-## Lever-Liste (priorisiert, **alle Gewinne = Schätzung** via Amdahl aus gemessenem Zeitanteil × Roofline-Headroom)
+## Lever list (prioritized, **all gains = estimate** via Amdahl from measured time share × roofline headroom)
 
-1. **gemm_cublas** @ q4k-dense-hd256/pp2048 — est. Fenster-Gewinn ~56.4% (Zeitanteil 77.1%, %-Roofline med 18.8 vs Ziel 70)
-2. **gemm_cublas** @ q8-dense/pp512 — est. Fenster-Gewinn ~46.3% (Zeitanteil 61.5%, %-Roofline med 17.3 vs Ziel 70)
-3. **gemm_cublas** @ q4k-dense-hd256/pp512 — est. Fenster-Gewinn ~45.3% (Zeitanteil 80.5%, %-Roofline med 21.9 vs Ziel 50)
-4. **gemm_cutlass_nvfp4** @ nvfp4-dense/pp512 — est. Fenster-Gewinn ~41.5% (Zeitanteil 61.1%, %-Roofline med 22.4 vs Ziel 70)
-5. **gemm_cutlass_nvfp4** @ nvfp4-dense/pp2048 — est. Fenster-Gewinn ~39.1% (Zeitanteil 57.6%, %-Roofline med 22.5 vs Ziel 70)
-6. **gemm_cutlass_nvfp4** @ nvfp4-dense/pp4096 — est. Fenster-Gewinn ~34.1% (Zeitanteil 50.1%, %-Roofline med 22.4 vs Ziel 70)
-7. **attn_fa2** @ nvfp4-moe/pp4096 — est. Fenster-Gewinn ~33.5% (Zeitanteil 40.0%, %-Roofline med 8.1 vs Ziel 50)
-8. **gemm_cublas** @ q8-dense/pp2048 — est. Fenster-Gewinn ~32.7% (Zeitanteil 57.2%, %-Roofline med 21.4 vs Ziel 50)
-9. **attn_decode_paged** @ nvfp4-moe/tg256 — est. Fenster-Gewinn ~31.7% (Zeitanteil 32.3%, %-Roofline med 1.4 vs Ziel 70)
-10. **gemm_cublas** @ q8-dense/pp4096 — est. Fenster-Gewinn ~30.6% (Zeitanteil 53.3%, %-Roofline med 21.3 vs Ziel 50)
-11. **attn_decode_paged** @ q4k-moe/tg256 — est. Fenster-Gewinn ~30.3% (Zeitanteil 30.9%, %-Roofline med 1.4 vs Ziel 70)
-12. **gemv_dp4a_gguf** @ q4k-dense-hd256/tg256 — est. Fenster-Gewinn ~28.9% (Zeitanteil 71.9%, %-Roofline med 41.9 vs Ziel 70)
-13. **dequant_gguf** @ q4k-moe/pp2048 — est. Fenster-Gewinn ~28.7% (Zeitanteil 65.3%, %-Roofline med 39.3 vs Ziel 70)
-14. **gemv_nvfp4** @ nvfp4-moe/tg256 — est. Fenster-Gewinn ~28.4% (Zeitanteil 49.9%, %-Roofline med 30.2 vs Ziel 70)
-15. **dequant_gguf** @ q4k-moe/pp512 — est. Fenster-Gewinn ~28.2% (Zeitanteil 64.3%, %-Roofline med 39.3 vs Ziel 70)
+1. **gemm_cublas** @ q4k-dense-hd256/pp2048 — est. window gain ~56.4% (time share 77.1%, %-roofline med 18.8 vs target 70)
+2. **gemm_cublas** @ q8-dense/pp512 — est. window gain ~46.3% (time share 61.5%, %-roofline med 17.3 vs target 70)
+3. **gemm_cublas** @ q4k-dense-hd256/pp512 — est. window gain ~45.3% (time share 80.5%, %-roofline med 21.9 vs target 50)
+4. **gemm_cutlass_nvfp4** @ nvfp4-dense/pp512 — est. window gain ~41.5% (time share 61.1%, %-roofline med 22.4 vs target 70)
+5. **gemm_cutlass_nvfp4** @ nvfp4-dense/pp2048 — est. window gain ~39.1% (time share 57.6%, %-roofline med 22.5 vs target 70)
+6. **gemm_cutlass_nvfp4** @ nvfp4-dense/pp4096 — est. window gain ~34.1% (time share 50.1%, %-roofline med 22.4 vs target 70)
+7. **attn_fa2** @ nvfp4-moe/pp4096 — est. window gain ~33.5% (time share 40.0%, %-roofline med 8.1 vs target 50)
+8. **gemm_cublas** @ q8-dense/pp2048 — est. window gain ~32.7% (time share 57.2%, %-roofline med 21.4 vs target 50)
+9. **attn_decode_paged** @ nvfp4-moe/tg256 — est. window gain ~31.7% (time share 32.3%, %-roofline med 1.4 vs target 70)
+10. **gemm_cublas** @ q8-dense/pp4096 — est. window gain ~30.6% (time share 53.3%, %-roofline med 21.3 vs target 50)
+11. **attn_decode_paged** @ q4k-moe/tg256 — est. window gain ~30.3% (time share 30.9%, %-roofline med 1.4 vs target 70)
+12. **gemv_dp4a_gguf** @ q4k-dense-hd256/tg256 — est. window gain ~28.9% (time share 71.9%, %-roofline med 41.9 vs target 70)
+13. **dequant_gguf** @ q4k-moe/pp2048 — est. window gain ~28.7% (time share 65.3%, %-roofline med 39.3 vs target 70)
+14. **gemv_nvfp4** @ nvfp4-moe/tg256 — est. window gain ~28.4% (time share 49.9%, %-roofline med 30.2 vs target 70)
+15. **dequant_gguf** @ q4k-moe/pp512 — est. window gain ~28.2% (time share 64.3%, %-roofline med 39.3 vs target 70)
 
-*(Jede Zahl rückverfolgbar: run_id = commit_timestamp; Roh-ncu-CSV + nsys-Extract liegen append-only unter history/raw/<run_id>/.)*
+*(Every number traceable: run_id = commit_timestamp; raw ncu CSV + nsys extract are append-only under history/raw/<run_id>/.)*
 
 ---
 
-## Dispatch-Bedingungen des Legacy-Pfads (Code-Stand dieses Audits)
+## Dispatch conditions of the legacy path (code state of this audit)
 
-`attention_cublas_prefill` (cuBLAS QK^T → materialisierte [nh,n,n]-S-Matrix → causal_softmax → cuBLAS PV) läuft nur noch wenn (Quellen: `src/exec/executor_attention.cu:942ff`, `:787ff`; `src/compute/attention_dispatch_decision.h`):
+`attention_cublas_prefill` (cuBLAS QK^T → materialized [nh,n,n] S-matrix → causal_softmax → cuBLAS PV) only runs when (sources: `src/exec/executor_attention.cu:942ff`, `:787ff`; `src/compute/attention_dispatch_decision.h`):
 
-1. **Nicht-chunked** (`q_offset==0`): S-Matrix passt (`attn_scores_mib`=384, auto-Threshold ≈ s_cap+1) **und** n < `fmha_prefill_threshold` **und** (`hd≠128` **oder** `fa2_fp16qk=="never"` **oder** attn_sinks/per-layer-shapes). Bei hd=128 greift vorher `fmha_sm120_fa2_kernel<…,FP16QK=1>` (#525).
-2. **Chunked Continuation** (`q_offset>0`): FA2-f16QK declined `q_offset>0` blanket (#548-Nachwirkung) **und** kumulative ctx < Threshold (sonst FMHA-Kette).
-3. Debug: `force_cublas_decode` (nur Decode).
+1. **Non-chunked** (`q_offset==0`): S-matrix fits (`attn_scores_mib`=384, auto-threshold ≈ s_cap+1) **and** n < `fmha_prefill_threshold` **and** (`hd≠128` **or** `fa2_fp16qk=="never"` **or** attn_sinks/per-layer-shapes). At hd=128 `fmha_sm120_fa2_kernel<…,FP16QK=1>` (#525) kicks in first.
+2. **Chunked continuation** (`q_offset>0`): FA2-f16QK declines `q_offset>0` blanket (#548 aftereffect) **and** cumulative ctx < threshold (otherwise FMHA chain).
+3. Debug: `force_cublas_decode` (decode only).
 
-Gemessen heißt das: hd=128 ⇒ 0 %, gemma-3 (hd=256) ⇒ 3.6 % (pp512) / 6.9 % (pp2048) Fensterzeit. Der Anteil **steigt** mit ctx (Continuation-Chunks unterhalb Threshold laufen ebenfalls cuBLAS).
+Measured, this means: hd=128 ⇒ 0 %, gemma-3 (hd=256) ⇒ 3.6 % (pp512) / 6.9 % (pp2048) window time. The share **rises** with ctx (continuation chunks below threshold also run cuBLAS).
 
-## Dequant-Coverage (Modul 2, Teil 2)
+## Dequant coverage (Module 2, part 2)
 
-| Pfad | Trigger | gemessener Anteil Prefill-Fenster | Δ vs optimiert |
+| Path | Trigger | measured share prefill window | Δ vs optimized |
 |---|---|---|---|
-| `dequant_q4k`→cuBLAS (materialisiert) | GGUF Q*_K Prefill (source dequant) | **63–65 %** (q4k-moe, alle Shapes) @ 39 % BW; 29.8 % (q8-dense); 9–14 % (gemma) | NVFP4-Pfad: 3–5 % (`quantize_fp16_nvfp4`, fused) — Differenz ≈ Fensteranteil − 5 % (Schätzung) |
-| `quantize_fp16_nvfp4` + CUTLASS-FP4-GEMM (fused) | NVFP4-Modelle Prefill | 3–5 % Quant-Overhead + GEMM near-/sub-roofline (s. Modul 1) | Referenzpfad |
-| `gemv_dp4a_*` (Q4_K INT-Decode) | GGUF Q4_K Decode (kein NVFP4-Cache) | 36–72 % Decode-Fenster @ 25–42 % BW | NVFP4-GEMV: 59–73 % BW — Δ ≈ +40–75 % Decode-GEMV-Durchsatz (Schätzung, kernel-level) |
+| `dequant_q4k`→cuBLAS (materialized) | GGUF Q*_K prefill (source dequant) | **63–65 %** (q4k-moe, all shapes) @ 39 % BW; 29.8 % (q8-dense); 9–14 % (gemma) | NVFP4 path: 3–5 % (`quantize_fp16_nvfp4`, fused) — difference ≈ window share − 5 % (estimate) |
+| `quantize_fp16_nvfp4` + CUTLASS-FP4-GEMM (fused) | NVFP4 models prefill | 3–5 % quant overhead + GEMM near-/sub-roofline (see Module 1) | Reference path |
+| `gemv_dp4a_*` (Q4_K INT decode) | GGUF Q4_K decode (no NVFP4 cache) | 36–72 % decode window @ 25–42 % BW | NVFP4-GEMV: 59–73 % BW — Δ ≈ +40–75 % decode-GEMV throughput (estimate, kernel-level) |
 
-## Methodik, Kalibrierung, Grenzen
+## Methodology, calibration, limits
 
-- **FLOPs:** TC via `sm__ops_path_tensor_src_*` (zählt FLOPs direkt). **Ausnahme FP4/sm_120:** `ops_path_…fp4*` zählt für den mxf4nvf4-`mma.sync`-Pfad NICHTS — FP4-FLOPs = `smsp__inst_executed_pipe_tensor.sum` × 16384 (m16n8k64). **Kalibriert exakt:** 5 570 560 Insts × 16384 = 9.13e10 ≡ 2·512·17408·5120 (Qwen3-14B-FFN-GEMM). Non-TC: SASS-Counter; `hfma` als gepackt HFMA2 = 4 FLOP/Inst gezählt (**obere Schranke**).
-- **Clocks:** ncu lockt SM auf ~2.0 GHz Base; Compute-%-Roofline ist auf den **gemessenen** Takt normiert (`gpc__cycles_elapsed`), Ridge auf Boost 2.407 GHz. Memory-Clock bleibt voll → BW-%-Werte sind produktionsnah.
-- **Zeitanteile** aus der nsys-Phasen-Timeline (prefill_window/post_prefill), nicht aus dem ncu-Fenster (Oversampling-Bias). Workloads mit `--max-seq-len`-Cap (ncu braucht VRAM-Headroom; Kernel-Verhalten im Messfenster unverändert).
-- **Bekannte Artefakte:** (a) `attn_decode_paged` @ tg256 liest ctx≈320-KV → 1.4–6.7 % BW ist ein **Workload-Artefakt** (latency-bound bei Mini-KV), kein Regressionssignal — der Lever-Eintrag dazu ist entsprechend NICHT als Issue übernommen. (b) FA2/CUTLASS-Klassen mit L1-Hit ≫ 90 % bzw. AI nahe Ridge sind cache-resident — die DRAM-Roofline unterschätzt deren effektive Auslastung; SM-/L1-Spalten mitlesen. (c) cuBLAS-Prefill-Restart-Varianz (bekannt bis 2.6×) erscheint als min/max-Spreizung der gemm_cublas-Zeilen und im A/B-Ausreißer.
-- **WSL2-ncu-Eigenheiten** (alle in `tools/roofline/config.json` dokumentiert): Multi-Pass-Kernel-Replay stirbt auf TMA-Kernels → Single-Pass-Metrikgruppen; SASS-Counter ohne Begleit-Counter; ncu-Kernel-Regex matcht ohne Namespace; **ein zweiter CUDA-Context (idle imp-server-Container) bricht Profiling auf ≥12B-Modellen** → `check_gpu_free()`-Guard in der Pipeline.
+- **FLOPs:** TC via `sm__ops_path_tensor_src_*` (counts FLOPs directly). **Exception FP4/sm_120:** `ops_path_…fp4*` counts NOTHING for the mxf4nvf4 `mma.sync` path — FP4 FLOPs = `smsp__inst_executed_pipe_tensor.sum` × 16384 (m16n8k64). **Calibrated exactly:** 5,570,560 insts × 16384 = 9.13e10 ≡ 2·512·17408·5120 (Qwen3-14B FFN GEMM). Non-TC: SASS counters; `hfma` counted as packed HFMA2 = 4 FLOP/inst (**upper bound**).
+- **Clocks:** ncu locks SM to ~2.0 GHz base; compute-%-roofline is normalized to the **measured** clock (`gpc__cycles_elapsed`), ridge to boost 2.407 GHz. Memory clock stays full → BW-% values are production-near.
+- **Time shares** from the nsys phase timeline (prefill_window/post_prefill), not from the ncu window (oversampling bias). Workloads with `--max-seq-len` cap (ncu needs VRAM headroom; kernel behavior in the measurement window unchanged).
+- **Known artifacts:** (a) `attn_decode_paged` @ tg256 reads ctx≈320 KV → 1.4–6.7 % BW is a **workload artifact** (latency-bound at mini-KV), not a regression signal — the corresponding lever entry is accordingly NOT adopted as an issue. (b) FA2/CUTLASS classes with L1 hit ≫ 90 % resp. AI near ridge are cache-resident — the DRAM roofline underestimates their effective utilization; read the SM/L1 columns alongside. (c) cuBLAS prefill restart variance (known up to 2.6×) appears as the min/max spread of the gemm_cublas rows and in the A/B outlier.
+- **WSL2 ncu quirks** (all documented in `tools/roofline/config.json`): multi-pass kernel replay dies on TMA kernels → single-pass metric groups; SASS counters without companion counters; ncu kernel regex matches without namespace; **a second CUDA context (idle imp-server container) breaks profiling on ≥12B models** → `check_gpu_free()` guard in the pipeline.
 
-## Doku-Abgleich (Deliverable 3) — Vorher/Nachher
+## Documentation reconciliation (Deliverable 3) — before/after
 
-| Stelle | Vorher | Nachher |
+| Location | Before | After |
 |---|---|---|
-| `docs/attention-dispatch.md` | "attention_cublas_prefill … Default for typical Qwen3 / Gemma-4 configs"; FMHA-Kette ohne FA2/fa2_fp16qk (Stand vor #478/#525) | Gate-Beschreibung auf #525-Stand (FA2-f16QK zuerst, cuBLAS nur hd≠128/Sinks/Continuation), FA2 in der Kette, Coverage-Messwerte verlinkt |
-| `docs/audit/performance_agent_readiness_2026_05_31.md` | "~18 % materialisierte Attention"; Lever A1 offen | Beide Stellen als STALE/ERLEDIGT annotiert mit Verweis auf dieses Audit (0.0 % auf hd=128) |
-| `README.md` / `BENCHMARKS.md` | tok/s-Headlines (frisch 2026-06-07 refresht) | **Kein Widerspruch:** unprofilierte A/B-Läufe dieses Audits (q8 pp512 ≈ 8.4k tok/s) decken sich mit den dokumentierten Werten — keine Änderung nötig |
+| `docs/attention-dispatch.md` | "attention_cublas_prefill … Default for typical Qwen3 / Gemma-4 configs"; FMHA chain without FA2/fa2_fp16qk (state before #478/#525) | Gate description at #525 state (FA2-f16QK first, cuBLAS only hd≠128/sinks/continuation), FA2 in the chain, coverage measurements linked |
+| `docs/audit/performance_agent_readiness_2026_05_31.md` | "~18 % materialized attention"; lever A1 open | Both locations annotated as STALE/DONE with reference to this audit (0.0 % on hd=128) |
+| `README.md` / `BENCHMARKS.md` | tok/s headlines (freshly refreshed 2026-06-07) | **No contradiction:** unprofiled A/B runs of this audit (q8 pp512 ≈ 8.4k tok/s) match the documented values — no change needed |
 
-*(Roh-Exporte: `tools/roofline/history/raw/e66cfa45-dirty_20260607_042900/` — `.ncu_raw.csv.gz` + `.nsys_extract.json` committed (Re-Parse ohne Re-Measure); binäre `.ncu-rep`/`.nsys-rep`/`.sqlite` nur lokal. Hinweis "dirty" im run_id: die Pipeline selbst war zum Messzeitpunkt untracked; der Messcode ist identisch mit dem in diesem PR committeten Stand.)*
+*(Raw exports: `tools/roofline/history/raw/e66cfa45-dirty_20260607_042900/` — `.ncu_raw.csv.gz` + `.nsys_extract.json` committed (re-parse without re-measure); binary `.ncu-rep`/`.nsys-rep`/`.sqlite` local only. Note "dirty" in the run_id: the pipeline itself was untracked at measurement time; the measurement code is identical to the state committed in this PR.)*

--- a/src/core/qtype.h
+++ b/src/core/qtype.h
@@ -32,7 +32,7 @@ enum class QType : uint16_t {
     BF16 = 30,
     MXFP4 = 31,
 
-    // Engine-internal (>= 64, kollidiert nie mit künftigen Wire-Werten)
+    // Engine-internal (>= 64, never collides with future wire values)
     NONE = 64,
     FP8_E4M3 = 65,
     FP8_E5M2 = 66,

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -331,7 +331,7 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
     //
     // Build the CUTLASS cache directly from the Tensor sidecars (data
     // pointer, scales, tensor_scale, shape) so the prefill dispatch
-    // at executor_kernels.cu:1975 zündet on the native FP4×FP4 path.
+    // at executor_kernels.cu:1975 fires on the native FP4×FP4 path.
     //
     // Historical EXCLUSION (added 2026-05-02, REMOVED 2026-05-14):
     // The llm-compressor NVFP4 format previously triggered a Skip-Guard

--- a/tests/TEST_AUDIT.md
+++ b/tests/TEST_AUDIT.md
@@ -1,267 +1,267 @@
-# Testsuite-Audit & Refactor-Plan — Re-Audit 2026-06-06
+# Test Suite Audit & Refactor Plan — Re-Audit 2026-06-06
 
-Commit-Basis: `7a94d81f` (post-#574) · Vorgänger: [`docs/TEST_AUDIT.md`](../docs/TEST_AUDIT.md)
-(2026-06-04, Phase-1-Gap-Analyse; deren Top-10-Programm wurde via PRs #527–#539
-umgesetzt). Dieses Dokument ist das **Delta-Re-Audit** nach PRs #538–#574
-(gpt-oss, LoRA, IQ4, chunked-NLL-Umbau, CUTLASS grouped GEMM, Issue-Sweep)
-plus die im 06-04-Audit nicht abgedeckten Dimensionen (Perf-Varianz,
-Stale/Dead, Laufzeit/Split).
+Commit base: `7a94d81f` (post-#574) · Predecessor: [`docs/TEST_AUDIT.md`](../docs/TEST_AUDIT.md)
+(2026-06-04, Phase-1 gap analysis; its top-10 program was implemented via PRs
+#527–#539). This document is the **delta re-audit** after PRs #538–#574
+(gpt-oss, LoRA, IQ4, chunked-NLL rework, CUTLASS grouped GEMM, issue sweep)
+plus the dimensions not covered by the 06-04 audit (perf variance,
+stale/dead, runtime/split).
 
-Hinweis Phase 0: `AGENTS.md` und `AUDIT.md` existieren im Repo nicht
-(Audit-Quellen waren CLAUDE.md, DISPATCH.md, docs/TEST_AUDIT.md, CMakeLists,
-Makefile, scripts/verify.sh, tests/refs/README.md). `DISPATCH.md` beschreibt
-den geschelvten cuTile-FA2-Track und betrifft die Suite nicht.
+Phase 0 note: `AGENTS.md` and `AUDIT.md` do not exist in the repo
+(audit sources were CLAUDE.md, DISPATCH.md, docs/TEST_AUDIT.md, CMakeLists,
+Makefile, scripts/verify.sh, tests/refs/README.md). `DISPATCH.md` describes
+the shelved cuTile-FA2 track and does not concern the suite.
 
-Klassifikation (wie 06-04): **A** = unabhängige Referenz (fp64/Format-Spez,
-committeter Generator, dokumentierte Toleranz) · **A−** = echte Referenz, aber
-benigne Daten / unbegründete oder nicht assertete Toleranz · **B** =
-tautologisch (imp-vs-imp, Round-trip) · **C** = Smoke/strukturell.
+Classification (as 06-04): **A** = independent reference (fp64/format spec,
+committed generator, documented tolerance) · **A−** = real reference, but
+benign data / unjustified or unasserted tolerance · **B** =
+tautological (imp-vs-imp, round-trip) · **C** = smoke/structural.
 
 ---
 
-## 1. Coverage-Matrix (Modul × Testtyp)
+## 1. Coverage Matrix (Module × Test Type)
 
-Stand nach #574. „CI" = läuft im GitHub-CI (kein GPU-Runner → nur unit);
-„lokal" = braucht GPU und/oder Modell.
+State after #574. "CI" = runs in GitHub CI (no GPU runner → unit only);
+"local" = needs GPU and/or model.
 
-| Modul | unit | integration | e2e | numeric-correctness | perf | ungetestet (wertvollste Lücken) |
+| Module | unit | integration | e2e | numeric-correctness | perf | untested (most valuable gaps) |
 |---|---|---|---|---|---|---|
-| core (tensor/config) | ✓ (strukturell) | — | — | — | — | reshape/slice-Numerik (unverändert seit 06-04) |
-| compute/attention | ✓ | ✓ | ✓ greedy-locks | **A**: crosspath fp64-Golden (6 Prefill-Pfade paarweise, `test_attention_crosspath.cu`); **A**: paged-Oracle als TYPED_TEST über 6 KV-Dtypes inkl. INT4/INT8 (`test_attention_paged_oracle.cu`, R8/#582) | bench-only | `attention_blackwell.cu` [Routing-Tabelle: **geschlossen #577** `test_routing_decision.cpp`; attention sinks (gpt-oss #572): **A geschlossen, #584** `test_gpt_oss_sinks_ref.cu`] |
-| compute/sonstige Kernel | ✓ | — | — | A (RoPE/RMSNorm/softmax/reduce vs CPU; **YaRN-Langseq fp64 #584** `test_gpt_oss_yarn_ref.cu`) | — | GPT_OSS_GLU-Aktivierung, Sampling-Numerik (nur „token in vocab") |
-| quant | ✓ | ✓ | ✓ | **A**: `test_gguf_dequant_ref.cu` (Q8_0/Q6_K/Q4_K/IQ4_NL/IQ4_XS als TYPED_TEST vs fp64-Format-Spez, Byte-LCG, no-NaN-Guard); **A**: `test_nvfp4_outlier_ref.cu` (adversariale Fixtures); **A**: `test_gpt_oss_mxfp4_convert_ref.cu` (R1.1/#576, bit-exakt); **A**: `test_cutlass_grouped_ref.cu` (R1.2/#576, fp64-CPU-Ref auf identischen Quant-Bits) | bench-only | — |
-| memory/KV | ✓ | ✓ | ✓ prefix-cache E2E (#538-Ship-Gate, 4/4 aktiv) | A (FP8-KV-Kalibrierung) | — | Eviction+Refill-Output-Stabilität, INT8/INT4/NVFP4-KV-Genauigkeitsbänder, vram-Allocator-Budget |
-| model/loader/tokenizer | ✓ inkl. fault-injection (#535-Familie) | ✓ | ✓ | A (Merges, Jinja; **Harmony-Render-Golden vs HF #584** `test_gpt_oss_harmony_golden.cpp`) | — | hf_hub |
-| exec | ✓ teilweise | ✓ | ✓ | **A** (grouped GEMM via `test_cutlass_grouped_ref.cu`, s. §2) | — | `executor_ffn.cu` isoliert, `executor_lora.cu`-Kernel (nur E2E via test_lora) [grouped-vs-fallback-Routing: **geschlossen #577** `test_routing_decision.cpp`] |
-| lora (neu #571) | — | — | ✓ `test_lora.cpp` (A−: zero-B/nonzero-B-Identität) | — | — | Kernel-Isolation, Multi-Adapter, Rank-Grenzfälle |
-| runtime | ✓ (think/stop, scheduler, json-FSM inkl. $ref/$defs #562) | ✓ | ✓ determinism-E2E (#542) | — | graphs-Gate in verify.sh | ConditionalRunner, Request-Lifecycle/Abort, Warmup-Token-Typ |
-| vision | ✓ CPU-Preprocessing (#564) | ✓ GPU-Encoder+Projector Frozen-Golden (R9/#583: SigLIP+gemma4v, committetes 64² PNG → Projector-Spots, f16-Klasse ≤1e-2 rel + NaN/Inf-Guard, mmproj standalone ohne LM) | manuell (gemma-3/4 VL) | — | — | Vision-RoPE/Norm-Einzelkernel isoliert (Golden lockt nur den Encoder-Output) |
-| api/server | ✓ SSE-Utils, anthropic-Transform, stream_pipeline (echte Quelldateien einkompiliert, nicht Mock!) | ✓ relaunch | ✓ | — | — | `handlers.cpp` selbst (nur dessen Utils getestet), Abort-Pfad |
-| api/HTTP (Python) | ✓ Mock (Contract/Errors/Lifecycle) | ✓ real (modellgebunden) | ✓ | — | TTFT/Decode-Gates (real-only) | rekursives json_schema auf API-Ebene; /v1/messages-Streaming-E2E |
+| core (tensor/config) | ✓ (structural) | — | — | — | — | reshape/slice numerics (unchanged since 06-04) |
+| compute/attention | ✓ | ✓ | ✓ greedy-locks | **A**: crosspath fp64-Golden (6 prefill paths pairwise, `test_attention_crosspath.cu`); **A**: paged-Oracle as TYPED_TEST over 6 KV-Dtypes incl. INT4/INT8 (`test_attention_paged_oracle.cu`, R8/#582) | bench-only | `attention_blackwell.cu` [routing table: **closed #577** `test_routing_decision.cpp`; attention sinks (gpt-oss #572): **A closed, #584** `test_gpt_oss_sinks_ref.cu`] |
+| compute/other kernels | ✓ | — | — | A (RoPE/RMSNorm/softmax/reduce vs CPU; **YaRN long-seq fp64 #584** `test_gpt_oss_yarn_ref.cu`) | — | GPT_OSS_GLU activation, sampling numerics (only "token in vocab") |
+| quant | ✓ | ✓ | ✓ | **A**: `test_gguf_dequant_ref.cu` (Q8_0/Q6_K/Q4_K/IQ4_NL/IQ4_XS as TYPED_TEST vs fp64 format spec, byte-LCG, no-NaN-Guard); **A**: `test_nvfp4_outlier_ref.cu` (adversarial fixtures); **A**: `test_gpt_oss_mxfp4_convert_ref.cu` (R1.1/#576, bit-exact); **A**: `test_cutlass_grouped_ref.cu` (R1.2/#576, fp64-CPU-Ref on identical quant bits) | bench-only | — |
+| memory/KV | ✓ | ✓ | ✓ prefix-cache E2E (#538 ship-gate, 4/4 active) | A (FP8-KV calibration) | — | eviction+refill output stability, INT8/INT4/NVFP4-KV accuracy bands, vram allocator budget |
+| model/loader/tokenizer | ✓ incl. fault-injection (#535 family) | ✓ | ✓ | A (merges, Jinja; **Harmony-render-Golden vs HF #584** `test_gpt_oss_harmony_golden.cpp`) | — | hf_hub |
+| exec | ✓ partial | ✓ | ✓ | **A** (grouped GEMM via `test_cutlass_grouped_ref.cu`, see §2) | — | `executor_ffn.cu` isolated, `executor_lora.cu` kernel (only E2E via test_lora) [grouped-vs-fallback routing: **closed #577** `test_routing_decision.cpp`] |
+| lora (new #571) | — | — | ✓ `test_lora.cpp` (A−: zero-B/nonzero-B identity) | — | — | kernel isolation, multi-adapter, rank edge cases |
+| runtime | ✓ (think/stop, scheduler, json-FSM incl. $ref/$defs #562) | ✓ | ✓ determinism-E2E (#542) | — | graphs-gate in verify.sh | ConditionalRunner, request-lifecycle/abort, warmup-token type |
+| vision | ✓ CPU preprocessing (#564) | ✓ GPU encoder+projector frozen-golden (R9/#583: SigLIP+gemma4v, committed 64² PNG → projector spots, f16-class ≤1e-2 rel + NaN/Inf-Guard, mmproj standalone without LM) | manual (gemma-3/4 VL) | — | — | vision RoPE/norm single kernels isolated (golden only locks the encoder output) |
+| api/server | ✓ SSE-utils, anthropic-transform, stream_pipeline (real source files compiled in, not mock!) | ✓ relaunch | ✓ | — | — | `handlers.cpp` itself (only its utils tested), abort path |
+| api/HTTP (Python) | ✓ mock (contract/errors/lifecycle) | ✓ real (model-bound) | ✓ | — | TTFT/decode gates (real-only) | recursive json_schema at API level; /v1/messages streaming E2E |
 
-Gegenüber 06-04: ~45 % direkt → spürbar besser in attention/quant/runtime/api
-(6 der 10 Risiken geschlossen, s. §6); vision-GPU jetzt per Frozen-Golden
-abgedeckt (R9/#583), exec-Isolation unverändert blind.
+Compared to 06-04: ~45% direct → noticeably better in attention/quant/runtime/api
+(6 of 10 risks closed, see §6); vision-GPU now covered via frozen-golden
+(R9/#583), exec isolation unchanged blind.
 
-## 2. Hot-Path-Kernels — Tiefe der Correctness-Tests
+## 2. Hot-Path Kernels — Depth of Correctness Tests
 
-| Kernel | Tests | Klasse | Befund |
+| Kernel | Tests | Class | Finding |
 |---|---|---|---|
-| NVFP4 quantize→dequant→GEMV | `test_nvfp4_outlier_ref.cu` + `tests/refs/gen_nvfp4_outlier_golden.py` | **A** | fp64-Referenz aus Formatdefinition (E2M1+UE4M3+1/512-Floor), 4 adversariale Verteilungen (Gemma-Kollaps-Klasse #514/#516), harter no-NaN/Inf-Guard. Vorbildlich. |
-| NVFP4 block-scaled MMA (mxf4nvf4) | `test_mxf4nvf4_qkt_validate.cu` | A− | E2M1-exakte Inputs → Referenz verlustfrei, aber benignes Datenregime; Präzisionskante nie exerziert. `_probe` = Smoke. |
-| NVFP4-GEMV-Loop | `test_nvfp4_gemv_kpar_loop.cu` | B | Bewusst dokumentiertes Negativ-Resultat (Repro mathematisch äquivalent); Regressions-Riegel, kein Correctness-Beweis. OK so. |
-| **CUTLASS grouped GEMM (pp512-10×-Pfad #574)** | `test_cutlass_grouped_3x_nvfp4.cu` + `test_cutlass_grouped_ref.cu` (R1.2/#576) | **A** | grouped-vs-per-expert (B, Staging) PLUS unabhängige fp64-CPU-Referenz auf den identischen Quant-Bits, die die GPU konsumiert (Quant-Fehler kancelt → f16-Akkumulationsklasse ≤1e-2, gemessen ~4.9e-4). Boundary-Verteilungen M=0/1/200, single-active-expert. |
-| FP8-E4M3-Encoder | `test_cutlass_nvfp4_alpha.cu` | A− | kanonische Bit-Grenzwerte exakt gepinnt (448/overflow/240-Cliff); Prefill-Teil Smoke. |
-| fp8 FMHA | `test_fmha_fp8.cu` | A− | CPU-Referenz korrekt, aber Toleranz bewusst NICHT assertet („characterized", README §2 — e4m3 auf kurzen Zeilen 0.58–0.71 rel, #512-Mechanismus). Qualitätsgate liegt per Policy bei den E2E-Locks. Füllung teils noch `%13`-Muster. |
-| FA2-Prefill (alle 6 Pfade inkl. cuBLAS-legacy) | `test_attention_crosspath.cu` + fp64-Golden | **A** | Paarweise f16-Klassen-Agreement 1e-2 (gemessen ~4e-4 post-#528), realistisches Heavy-Tail-Datenregime, bit-identische LCG-Fixtures Python↔C++. Der „Killer-Assert" aus Risiko #1 existiert. |
-| FA2 chunked continuation (#553/#568) | `test_attention_chunked.cu` + `test_chunked_prefill.cu` | A−/E2E | Kernel-Test + teacher-forced-NLL-Gates (seit #553 NLL statt Byte-Equality — korrekt wegen Re-Download-Quant-Drift). hd=256-Paritäts-Locks via #570. |
-| Paged decode F16 | `test_attention_paged_oracle.cu` | **A** | fp64-Ref aus Original-f16-K/V; kv_len=333 absichtlich nicht block-aligned. |
-| Paged decode FP8/INT8/INT4 | dito (Envelopes; seit R8/#582 als TYPED_TEST über alle 6 KV-Dtypes) | A− | Quant-Pfade „characterized" mit ASSERTETEN eingefrorenen Envelopes (Korrektur 06-07: INT4/INT8-Envelopes existierten schon seit PR #534 — der „keine"-Erstbefund war stale). Risiko #6 von 06-04 geschlossen. |
-| Paged NVFP4-TC | `test_attention_paged_nvfp4_tc*.cu` | C lokal | Launch+SASS-Guard; Numerik via Offline-Microbench + E2E (synthetische Daten NaN-en beide Pfade — dokumentiert). |
-| GGUF-Dequant inkl. IQ4 (#561) | `test_gguf_dequant_ref.cu` | **A** | s. §1. Edge-Cases (d=0, NaN-d, Max-Scale) drin. |
-| MMVQ/dp4a | `test_mmvq.cu`, `test_gemm_dp4a.cu` | B (Diagnose) | dp4a-vs-MMVQ ohne harten Threshold; die echte Referenz läuft über `test_gguf_dequant_ref.cu` (GEMV ≤2.5e-2 mit gemessenem Envelope). |
-| MoE-Routing | `test_moe.cu` | A− | CPU-top-k-Referenz, aber hartkodierte eindeutige Logits — keine Tie-Cases. Executor-Test = not-NaN. |
-| **gpt-oss MXFP4-Experten + sinks (#572)** | — | **C→A für Sinks/Harmony/YaRN (#584)** | Sinks: fp64-Softmax-Ref + Eviction-Geometrie (`test_gpt_oss_sinks_ref.cu`); Harmony: HF-Render-Golden exakt (`test_gpt_oss_harmony_golden.cpp`); YaRN-Langseq fp64 bis 131071 + Inversions-Sensitivität (`test_gpt_oss_yarn_ref.cu`). MXFP4-Konverter: **A geschlossen #576** (`test_gpt_oss_mxfp4_convert_ref.cu`, bit-exakt). |
-| GDN/SSM | `test_gdn.cu`, `test_ssm.cu` | A− | CPU-Delta-Rule-Scan-Referenz vorhanden; Toleranz nur implizit (EXPECT_NEAR), Daten synthetisch-benign. |
+| NVFP4 quantize→dequant→GEMV | `test_nvfp4_outlier_ref.cu` + `tests/refs/gen_nvfp4_outlier_golden.py` | **A** | fp64 reference from format definition (E2M1+UE4M3+1/512-floor), 4 adversarial distributions (Gemma collapse class #514/#516), hard no-NaN/Inf-Guard. Exemplary. |
+| NVFP4 block-scaled MMA (mxf4nvf4) | `test_mxf4nvf4_qkt_validate.cu` | A− | E2M1-exact inputs → reference lossless, but benign data regime; precision edge never exercised. `_probe` = smoke. |
+| NVFP4-GEMV-Loop | `test_nvfp4_gemv_kpar_loop.cu` | B | Deliberately documented negative result (repro mathematically equivalent); regression latch, not a correctness proof. OK as is. |
+| **CUTLASS grouped GEMM (pp512-10×-path #574)** | `test_cutlass_grouped_3x_nvfp4.cu` + `test_cutlass_grouped_ref.cu` (R1.2/#576) | **A** | grouped-vs-per-expert (B, staging) PLUS independent fp64-CPU reference on the identical quant bits the GPU consumes (quant error cancels → f16-accumulation class ≤1e-2, measured ~4.9e-4). Boundary distributions M=0/1/200, single-active-expert. |
+| FP8-E4M3 encoder | `test_cutlass_nvfp4_alpha.cu` | A− | canonical bit limits pinned exactly (448/overflow/240-cliff); prefill part smoke. |
+| fp8 FMHA | `test_fmha_fp8.cu` | A− | CPU reference correct, but tolerance deliberately NOT asserted ("characterized", README §2 — e4m3 on short rows 0.58–0.71 rel, #512 mechanism). Quality gate is by policy at the E2E locks. Fill partly still `%13` pattern. |
+| FA2 prefill (all 6 paths incl. cuBLAS-legacy) | `test_attention_crosspath.cu` + fp64-Golden | **A** | Pairwise f16-class agreement 1e-2 (measured ~4e-4 post-#528), realistic heavy-tail data regime, bit-identical LCG fixtures Python↔C++. The "killer assert" from risk #1 exists. |
+| FA2 chunked continuation (#553/#568) | `test_attention_chunked.cu` + `test_chunked_prefill.cu` | A−/E2E | Kernel test + teacher-forced-NLL gates (since #553 NLL instead of byte-equality — correct due to re-download quant drift). hd=256 parity locks via #570. |
+| Paged decode F16 | `test_attention_paged_oracle.cu` | **A** | fp64-Ref from original f16 K/V; kv_len=333 deliberately not block-aligned. |
+| Paged decode FP8/INT8/INT4 | ditto (envelopes; since R8/#582 as TYPED_TEST over all 6 KV-Dtypes) | A− | Quant paths "characterized" with ASSERTED frozen envelopes (correction 06-07: INT4/INT8 envelopes already existed since PR #534 — the "none" initial finding was stale). Risk #6 from 06-04 closed. |
+| Paged NVFP4-TC | `test_attention_paged_nvfp4_tc*.cu` | C local | Launch+SASS-Guard; numerics via offline microbench + E2E (synthetic data NaNs both paths — documented). |
+| GGUF dequant incl. IQ4 (#561) | `test_gguf_dequant_ref.cu` | **A** | see §1. Edge cases (d=0, NaN-d, max-scale) included. |
+| MMVQ/dp4a | `test_mmvq.cu`, `test_gemm_dp4a.cu` | B (diagnostic) | dp4a-vs-MMVQ without hard threshold; the real reference runs via `test_gguf_dequant_ref.cu` (GEMV ≤2.5e-2 with measured envelope). |
+| MoE routing | `test_moe.cu` | A− | CPU-top-k reference, but hardcoded unambiguous logits — no tie cases. Executor test = not-NaN. |
+| **gpt-oss MXFP4 experts + sinks (#572)** | — | **C→A for sinks/Harmony/YaRN (#584)** | Sinks: fp64-softmax-Ref + eviction geometry (`test_gpt_oss_sinks_ref.cu`); Harmony: HF-render-golden exact (`test_gpt_oss_harmony_golden.cpp`); YaRN long-seq fp64 up to 131071 + inversion sensitivity (`test_gpt_oss_yarn_ref.cu`). MXFP4 converter: **A closed #576** (`test_gpt_oss_mxfp4_convert_ref.cu`, bit-exact). |
+| GDN/SSM | `test_gdn.cu`, `test_ssm.cu` | A− | CPU delta-rule-scan reference present; tolerance only implicit (EXPECT_NEAR), data synthetic-benign. |
 
-Hinweis zum Audit-Prompt: „TMA warp-spec grouped GEMM" existiert auf sm_120
-nicht (kein TMA-WS/tcgen05); der grouped-GEMM-Pfad ist CUTLASS `mma.sync` —
-oben entsprechend bewertet.
+Note on the audit prompt: "TMA warp-spec grouped GEMM" does not exist on sm_120
+(no TMA-WS/tcgen05); the grouped-GEMM path is CUTLASS `mma.sync` —
+evaluated accordingly above.
 
-## 3. Quant-Correctness: Goldens & Toleranzen
+## 3. Quant Correctness: Goldens & Tolerances
 
-- **`tests/refs/` ist das funktionierende Schema** (Erbe Phase 2): committete
-  numpy-Generatoren, bit-exakte Regeneration, Toleranz-Policy mit Begründung
-  in `tests/refs/README.md` (f16-Klasse ≤1e-2 rel gemessen ~4e-4; fp8
-  characterized-not-blessed; NVFP4 ≤1e-1 + E2E-Locks; Generator-Crosscheck
-  ≤1e-9). Drei Konsumenten: crosspath, nvfp4_outlier, e2e_greedy_locks.
-- **Lücke (Stand 06-07 weitgehend geschlossen via #576/#584):** grouped GEMM
-  und gpt_oss_mxfp4_convert haben jetzt class-A-Referenzen nach der Policy;
-  YaRN/Harmony-Goldens committet. Verbleibend: mxf4nvf4-Validate (benigne
-  Daten); FP8-FMHA-Fixtures nutzen teils noch das `%13`-Füllmuster, das #525
-  vakuös machte.
-- GGUF-Dequant-Toleranzen sind dokumentiert UND begründet (Dequant ≤1e-3 =
-  reine f32-Rundung; GEMV ≤1e-2; dp4a/MMVQ 2.5e-2 mit Aktivierungs-Quant-
-  Rauschen, gemessener Envelope) — Soll-Zustand.
+- **`tests/refs/` is the working schema** (Phase 2 legacy): committed
+  numpy generators, bit-exact regeneration, tolerance policy with justification
+  in `tests/refs/README.md` (f16-class ≤1e-2 rel measured ~4e-4; fp8
+  characterized-not-blessed; NVFP4 ≤1e-1 + E2E-locks; generator crosscheck
+  ≤1e-9). Three consumers: crosspath, nvfp4_outlier, e2e_greedy_locks.
+- **Gap (as of 06-07 largely closed via #576/#584):** grouped GEMM
+  and gpt_oss_mxfp4_convert now have class-A references per the policy;
+  YaRN/Harmony goldens committed. Remaining: mxf4nvf4-validate (benign
+  data); FP8-FMHA fixtures still partly use the `%13` fill pattern that made
+  #525 vacuous.
+- GGUF dequant tolerances are documented AND justified (dequant ≤1e-3 =
+  pure f32 rounding; GEMV ≤1e-2; dp4a/MMVQ 2.5e-2 with activation-quant
+  noise, measured envelope) — target state.
 
-## 4. Determinismus
+## 4. Determinism
 
-- **DISABLED_-Inventar (3):** 2× `test_determinism_e2e.cpp`
-  (cross-context auf GDN-Hybrid — dokumentierte, berechtigte Grenze aus #542)
-  · 1× `test_attention_fmha_mxfp4.cu:141 DISABLED_BasicHD256` („requires
-  large shared memory; disabled pending smem optimization" — begründet, aber
-  ohne Issue-Ref).
-- **Exact-Equal-Asserts sind bewusst und korrekt eingesetzt:** Greedy-Locks
-  (`test_e2e_greedy_lock.cpp:170`) laufen 2× fresh-context, sodass ein
-  Atomics-Flip selbst der Befund ist; PPL-Bit-Identität ist das Deliverable
-  des deterministic mode (#542); prefix-cache fresh-vs-hit-Token-Equality ist
-  das Ship-Gate (#538). Chunked-Prefill nutzt seit #553 NLL-Toleranz statt
-  Byte-Equality (richtige Reaktion auf Logit-Tie-/Quant-Drift-Klasse).
-- **MoE-Atomics:** Qwen3.6-Nondeterminismus ist dokumentiert und über
-  `[runtime] deterministic` + DetEvalE2ETest abgedeckt; ein quantifizierender
-  „Atomics-Spread-Probe" (N=20, Spread-Bound) fehlt weiterhin (Honorable
-  Mention 06-04).
-- ~51 GTEST_SKIP-Pfade, alle legitim gemustert (Modell/HW/Build-Feature).
-  Keine Seed-Variation in irgendeinem Test (alles seed=42) — bei reinem
-  Greedy-Fokus akzeptabel, für Sampling-Numerik ein Loch (s. §1).
+- **DISABLED_ inventory (3):** 2× `test_determinism_e2e.cpp`
+  (cross-context on GDN-Hybrid — documented, justified limit from #542)
+  · 1× `test_attention_fmha_mxfp4.cu:141 DISABLED_BasicHD256` ("requires
+  large shared memory; disabled pending smem optimization" — justified, but
+  without issue ref).
+- **Exact-equal asserts are deliberately and correctly used:** greedy-locks
+  (`test_e2e_greedy_lock.cpp:170`) run 2× fresh-context, so that an
+  atomics flip is itself the finding; PPL bit-identity is the deliverable
+  of deterministic mode (#542); prefix-cache fresh-vs-hit token-equality is
+  the ship-gate (#538). Chunked prefill uses NLL tolerance since #553 instead of
+  byte-equality (correct response to the logit-tie/quant-drift class).
+- **MoE atomics:** Qwen3.6 nondeterminism is documented and covered via
+  `[runtime] deterministic` + DetEvalE2ETest; a quantifying
+  "atomics spread probe" (N=20, spread-bound) is still missing (honorable
+  mention 06-04).
+- ~51 GTEST_SKIP paths, all legitimately patterned (model/HW/build-feature).
+  No seed variation in any test (all seed=42) — acceptable with pure
+  greedy focus, a hole for sampling numerics (see §1).
 
-## 5. Perf-Tests vs. Messvarianz
+## 5. Perf Tests vs. Measurement Variance
 
-- `verify.sh`-Gate: Median aus Trials mit 15 s Cooldown, decode 3 % hart;
-  **prefill ist WARN-only** — bewusste und richtige Antwort auf die
-  2.6×-Container-Restart-Varianz von cuBLAS. Decode-Tagesdrift (8–15 %,
-  #526) wird NICHT erkannt: Das Gate vergleicht gegen die Baseline ohne
-  Clock-/Power-Plausibilisierung (`nvidia-smi`-Sampling WÄHREND des Benches,
-  healthy = ~2850 MHz SM / 13801 MHz mem / ~500 W) → an gedrückten Tagen
-  false-positive Regression möglich.
-- **Drei Baseline-Dateien, drei Schemata** (legacy implizit / v1 / north_star
-  ohne Versionsfeld); `perf_baseline_chunked.json` 29 Tage alt;
-  `north_star` wird von keinem Target außer `verify-north-star` gelesen.
-- `tests/api/test_perf_regression.py` gated TTFT-p95/Decode-p50 hart gegen
-  Keys `["ttft"]`/`["throughput"]` in `perf_baseline.json` — **die dort gar
-  nicht existieren** (verify.sh-Schema). Real-only-markiert, fällt im
-  Mock-Lauf raus, würde aber bei realem Lauf gegen fehlende Keys laufen →
-  prüfen/reparieren.
-- Alle 11 `*Bench*`-GTests (ctest -L perf) sind print-only-Diagnose ohne
-  Asserts — okay, solange das so dokumentiert ist; sie sollten nicht den
-  Eindruck eines Gates erwecken.
+- `verify.sh` gate: median of trials with 15 s cooldown, decode 3% hard;
+  **prefill is WARN-only** — deliberate and correct response to cuBLAS's
+  2.6× container-restart variance. Decode daily drift (8–15%,
+  #526) is NOT detected: the gate compares against the baseline without
+  clock/power plausibility check (`nvidia-smi` sampling DURING the bench,
+  healthy = ~2850 MHz SM / 13801 MHz mem / ~500 W) → on depressed days
+  false-positive regression possible.
+- **Three baseline files, three schemas** (legacy implicit / v1 / north_star
+  without version field); `perf_baseline_chunked.json` 29 days old;
+  `north_star` is read by no target except `verify-north-star`.
+- `tests/api/test_perf_regression.py` gates TTFT-p95/decode-p50 hard against
+  keys `["ttft"]`/`["throughput"]` in `perf_baseline.json` — **which do not
+  exist there at all** (verify.sh schema). Real-only-marked, drops out in the
+  mock run, but would run against missing keys in a real run →
+  check/repair.
+- All 11 `*Bench*` GTests (ctest -L perf) are print-only diagnostics without
+  asserts — fine, as long as that is documented; they should not create the
+  impression of a gate.
 
-## 6. Gaps vs. bekannte Prioritäten
+## 6. Gaps vs. Known Priorities
 
-| Priorität (Prompt) | Stand 06-06 |
+| Priority (prompt) | State 06-06 |
 |---|---|
-| FA2-Prefill-Coverage inkl. legacy cuBLAS-Pfad | **GESCHLOSSEN** — crosspath testet alle 6 Pfade paarweise (A-Klasse); chunked continuation via #553/#570 NLL-/Paritäts-Locks |
-| /v1/messages-Streaming real | **OFFEN auf E2E-Ebene.** Seit #564 sind Envelope/Reasoning-Split/anthropic-Transform unit-getestet (gegen die echten Server-Quelldateien, nicht Mock — gut). Echtes Streaming-Verhalten E2E weiterhin nur OpenAI-seitig; Anthropic-SSE-E2E fehlt. |
-| Tool-Arg-Schema-Validierung | Teilweise: Pass-through in `test_tools.py`; FSM-Ebene inkl. $ref/$defs in `test_json_constrain.cu` (#562). **API-Ebene rekursives Schema ungetestet.** |
-| Constrained output | Gut abgedeckt (whole-token-FSM #517/#519-Kette + #562). |
-| **Neu seit 06-04, ungetestet:** | executor_lora-Kernel. [gpt_oss_mxfp4_convert: **geschlossen #576** (bit-exakte fp64-Ref); grouped-vs-fallback-Routing: **geschlossen #577**; attention sinks, Harmony-Parität vs HF, YaRN-Langsequenz: **geschlossen #584**] |
-| Offene 06-04-Risiken: | #2 teilweise (mode-2-from-scratch weiter ohne externe Oracle), #6 **geschlossen** (INT4/INT8-paged-Envelopes existierten seit PR #534 — Erstbefund stale; seit R8/#582 TYPED_TEST über alle KV-Dtypes), #9 zurückgestellt (begründet — MTP dead end), #10 teilweise (fault injection ✓, Unicode-Roundtrip ✓ via fixtures+robustness; NUL-Klasse via SSE-Tests ✓). |
+| FA2-prefill coverage incl. legacy cuBLAS path | **CLOSED** — crosspath tests all 6 paths pairwise (A-class); chunked continuation via #553/#570 NLL/parity locks |
+| /v1/messages streaming real | **OPEN at E2E level.** Since #564, envelope/reasoning-split/anthropic-transform are unit-tested (against the real server source files, not mock — good). Real streaming behavior E2E still only OpenAI-side; Anthropic-SSE-E2E missing. |
+| Tool-arg schema validation | Partial: pass-through in `test_tools.py`; FSM level incl. $ref/$defs in `test_json_constrain.cu` (#562). **API-level recursive schema untested.** |
+| Constrained output | Well covered (whole-token-FSM #517/#519 chain + #562). |
+| **New since 06-04, untested:** | executor_lora kernel. [gpt_oss_mxfp4_convert: **closed #576** (bit-exact fp64-Ref); grouped-vs-fallback routing: **closed #577**; attention sinks, Harmony parity vs HF, YaRN long sequence: **closed #584**] |
+| Open 06-04 risks: | #2 partial (mode-2-from-scratch still without external oracle), #6 **closed** (INT4/INT8-paged envelopes existed since PR #534 — initial finding stale; since R8/#582 TYPED_TEST over all KV-Dtypes), #9 deferred (justified — MTP dead end), #10 partial (fault injection ✓, Unicode roundtrip ✓ via fixtures+robustness; NUL class via SSE tests ✓). |
 
 ## 7. Stale / Dead
 
-| Fund | Beleg | Bewertung |
+| Finding | Evidence | Assessment |
 |---|---|---|
-| `tests/golden/*.txt` (5 Dateien) | **null Konsumenten** (grep über tests/scripts/tools/CI); 2× Mistral-Small = gelöschtes Modell; Makefile `test-golden` verweist selbst auf pytest | **tot → löschen** (low-risk) |
-| `tests/api/test_outputs/` (21 committete .txt) | Lauf-Artefakte von `test_repetition_compare.sh` (schreibt dorthin), einmalig vor Monaten committet | **Artefakte → löschen + .gitignore** (low-risk) |
-| `tests/refs/gen_reference.py` | null Nutzung; Infrastruktur für künftige HF-Layer-Vergleiche | schlafend — behalten, im README als dormant markieren |
-| `tests/fixtures/` | **NICHT tot** (Agent-Erstbefund falsch): `scripts/validate_safetensors.py:628,892` konsumiert beide Dateien | behalten |
-| Stale-Kommentar „FMHA sm120 requires sm_90+ (WMMA fallback)" | `test_attention_fmha_sm120.cu:84` | irreführend auf sm_120a-only-Engine → fixen (low-risk) |
-| Kommentar „same fate as the SM100-only tcgen05 family" (`tests/bench/mmq_q4k_imma_bench.cu:30`) | Agent-Erstbefund „dead commentary" — geprüft: im Kontext korrekt (tcgen05 IST sm_100-only, genau deshalb fehlt es auf sm_120) | behalten |
-| `test_engine_chat.sh`, `test_server_concurrent.sh`, `tests/api/elchtest.sh` | von keinem Target/CI aufgerufen | manuelle Werkzeuge → im Kopf der Skripte als manuell dokumentieren, nicht löschen |
-| TurboQuant/BitDecoding/FP4-PV-Reste | sauber entfernt; nur Kommentar-Verweis in CMakeLists (dokumentarisch) | ✓ kein Handlungsbedarf |
-| Vermeintliche Duplikate (mmq_q4k×5, mxf4nvf4×3, attention_mxfp4×2) | geprüft: Pyramide unit→layout→bench bzw. paged-vs-FMHA | **keine Duplikate** |
-| `tests/bench/*.cu` in `IMP_COMPUTE_SOURCES` (CMakeLists ~196–207) | nur unter `IMP_BUILD_TESTS OR IMP_BUILD_BENCH`, kommentiert (P3/P5-Entscheid) | akzeptiert; kein Prod-Leak im Default-Release ohne Tests |
+| `tests/golden/*.txt` (5 files) | **zero consumers** (grep over tests/scripts/tools/CI); 2× Mistral-Small = deleted model; Makefile `test-golden` itself points to pytest | **dead → delete** (low-risk) |
+| `tests/api/test_outputs/` (21 committed .txt) | run artifacts of `test_repetition_compare.sh` (writes there), committed once months ago | **artifacts → delete + .gitignore** (low-risk) |
+| `tests/refs/gen_reference.py` | zero usage; infrastructure for future HF-layer comparisons | dormant — keep, mark as dormant in README |
+| `tests/fixtures/` | **NOT dead** (agent's initial finding wrong): `scripts/validate_safetensors.py:628,892` consumes both files | keep |
+| Stale comment "FMHA sm120 requires sm_90+ (WMMA fallback)" | `test_attention_fmha_sm120.cu:84` | misleading on sm_120a-only engine → fix (low-risk) |
+| Comment "same fate as the SM100-only tcgen05 family" (`tests/bench/mmq_q4k_imma_bench.cu:30`) | agent's initial finding "dead commentary" — checked: correct in context (tcgen05 IS sm_100-only, which is exactly why it is missing on sm_120) | keep |
+| `test_engine_chat.sh`, `test_server_concurrent.sh`, `tests/api/elchtest.sh` | called by no target/CI | manual tools → document as manual in the script header, do not delete |
+| TurboQuant/BitDecoding/FP4-PV remnants | cleanly removed; only comment reference in CMakeLists (documentary) | ✓ no action needed |
+| Apparent duplicates (mmq_q4k×5, mxf4nvf4×3, attention_mxfp4×2) | checked: pyramid unit→layout→bench resp. paged-vs-FMHA | **no duplicates** |
+| `tests/bench/*.cu` in `IMP_COMPUTE_SOURCES` (CMakeLists ~196–207) | only under `IMP_BUILD_TESTS OR IMP_BUILD_BENCH`, commented (P3/P5 decision) | accepted; no prod leak in the default release without tests |
 
-## 8. Laufzeit & Parallelisierbarkeit, GPU/Host-Trennung
+## 8. Runtime & Parallelizability, GPU/Host Separation
 
-- **Split ist auf Binary-Ebene sauber:** 8 Binaries, ctest-Labels
-  unit/gpu/perf; unit-Binaries sind reine .cpp ohne Device-Code (cuda_fp16.h
-  nur für Host-Konvertierung). CI (kein GPU-Runner) baut + skippt Test-Job;
-  ctest läuft ohne `-j` — für GPU-Tests korrekt (VRAM/Context-Konkurrenz),
-  für die unit-Label-Teilmenge wäre `-j` gefahrlos.
-- **Fragilität (GESCHLOSSEN #580, R5):** der unit/gpu-Split von `test-e2e`
-  hing an einem hartkodierten gtest_filter-String in CMakeLists
-  (`_unit_e2e_filter`) — Test-Umbenennung verschob Tests still ins falsche
-  Label. CPU- und GPU-Tests sind in `test_e2e.cpp`/`test_continuous_batching.cpp`
-  verschränkt (StubModelTest teilt eine Fixture über CPU- und GPU-Subtests),
-  also kein sauberes eigenes Binary ohne Fixture-Duplizierung → stattdessen
-  Filter behalten + Guard-Test `guard_e2e_lane_split`
-  (`scripts/check_e2e_lane_split.sh`), der per `--gtest_list_tests` prüft, dass
-  der Filter EXAKT die eingefrorene CPU-Menge auflöst (37 Tests) — eine
-  Umbenennung schlägt jetzt laut fehl statt still zu verschieben. Außerdem:
-  `gtest_discover_tests()` registrierte ALLE Tests nochmal einzeln neben den
-  Label-Aggregaten → `ctest` ohne Label führte alles doppelt aus (gemessen:
-  1215 ctest-Einträge); entfernt → jetzt 14 Einträge (3 unit + 1 Guard + 6 gpu
-  + 4 perf), jeder Test läuft genau einmal.
-- **Kein per-Test-Timeout in CMake** (nur CI-global 120 s); lange E2E-Tests
-  (Modell-Load + 128 Tokens) blockieren den sequentiellen Lauf.
-- **Gemessen (2026-06-06, RTX 5090, ohne Modelle):** Gesamtsuite 1.154 Tests;
-  7 von 8 Binaries zusammen < 11 s, aber **test-attention allein 241 s** —
-  die Makefile-Annahme „GPU tests < 30s" ist stale. Treiber sind die
-  paged-/crosspath-Oracle-Sweeps; ein `-L unit`-Lauf bleibt < 1 s. (Makefile-
-  Kommentar `test-gpu` korrigiert, #580; Stand 06-07 sind es ~1.202 Tests.)
-- **Python-API-Suite hängt an nichts:** `run_mock_tests.sh` (CPU-fähig,
-  Mock) wird weder von CI noch von verify.sh aufgerufen — die einzige
-  CPU-CI-fähige Contract-Suite läuft nur manuell.
-- Modell-Gating über `IMP_TEST_MODEL*`-Env-Vars, dezentral in den Testdateien
-  kopiert. **GESCHLOSSEN #581 (R6):** zentrale Registry `tests/test_models.h`
-  (header-only) hält die Env-Var-Namen (`imp_test::kEnv*`) + Accessoren
-  (`env_path`/`env_path_or`) an EINER Stelle; die ~14 Konsumenten ziehen den
-  Namen jetzt aus der Registry statt aus kopierten String-Literalen (die
-  GTEST_SKIP-Aufrufe bleiben am Call-Site, weil GTEST_SKIP aus der
-  *aufrufenden* Funktion zurückkehrt). Die hartkodierten
-  `/models/...`-Fallback-Pfade (degeneration/api_generate/relaunch/lora/chunked)
-  sind KEIN Defekt: sie matchen den Container-Mount `-v $(PWD)/models:/models`
-  aus dem Makefile und skippen sauber, wenn die Datei fehlt — bleiben daher als
-  call-site-sichtbare Literale erhalten. `test_mtp_forward.cpp` kodierte einen
-  Host-Pfad (`/home/kekz/models/...`), der im Container nie existierte → auf
-  `/models/...`-Container-Stil normalisiert (#581), skippt jetzt konsistent.
+- **Split is clean at the binary level:** 8 binaries, ctest labels
+  unit/gpu/perf; unit binaries are pure .cpp without device code (cuda_fp16.h
+  only for host conversion). CI (no GPU runner) builds + skips test job;
+  ctest runs without `-j` — correct for GPU tests (VRAM/context contention),
+  for the unit-label subset `-j` would be safe.
+- **Fragility (CLOSED #580, R5):** the unit/gpu split of `test-e2e`
+  hung on a hardcoded gtest_filter string in CMakeLists
+  (`_unit_e2e_filter`) — test renaming silently moved tests into the wrong
+  label. CPU and GPU tests are interleaved in `test_e2e.cpp`/`test_continuous_batching.cpp`
+  (StubModelTest shares a fixture across CPU and GPU subtests),
+  so no clean separate binary without fixture duplication → instead
+  keep filter + guard test `guard_e2e_lane_split`
+  (`scripts/check_e2e_lane_split.sh`), which checks via `--gtest_list_tests` that
+  the filter resolves EXACTLY to the frozen CPU set (37 tests) — a
+  rename now fails loudly instead of silently moving. In addition:
+  `gtest_discover_tests()` registered ALL tests again individually next to the
+  label aggregates → `ctest` without label ran everything twice (measured:
+  1215 ctest entries); removed → now 14 entries (3 unit + 1 guard + 6 gpu
+  + 4 perf), each test runs exactly once.
+- **No per-test timeout in CMake** (only CI-global 120 s); long E2E tests
+  (model load + 128 tokens) block the sequential run.
+- **Measured (2026-06-06, RTX 5090, without models):** total suite 1,154 tests;
+  7 of 8 binaries together < 11 s, but **test-attention alone 241 s** —
+  the Makefile assumption "GPU tests < 30s" is stale. Drivers are the
+  paged/crosspath oracle sweeps; a `-L unit` run stays < 1 s. (Makefile
+  comment `test-gpu` corrected, #580; as of 06-07 it is ~1,202 tests.)
+- **Python-API suite hangs on nothing:** `run_mock_tests.sh` (CPU-capable,
+  mock) is called by neither CI nor verify.sh — the only
+  CPU-CI-capable contract suite runs only manually.
+- Model gating via `IMP_TEST_MODEL*` env vars, copied decentrally across the test files.
+  **CLOSED #581 (R6):** central registry `tests/test_models.h`
+  (header-only) holds the env-var names (`imp_test::kEnv*`) + accessors
+  (`env_path`/`env_path_or`) in ONE place; the ~14 consumers now pull the
+  name from the registry instead of from copied string literals (the
+  GTEST_SKIP calls remain at the call site, because GTEST_SKIP returns from the
+  *calling* function). The hardcoded
+  `/models/...` fallback paths (degeneration/api_generate/relaunch/lora/chunked)
+  are NOT a defect: they match the container mount `-v $(PWD)/models:/models`
+  from the Makefile and skip cleanly when the file is missing — hence kept as
+  call-site-visible literals. `test_mtp_forward.cpp` encoded a
+  host path (`/home/kekz/models/...`) that never existed in the container → normalized to
+  `/models/...` container style (#581), now skips consistently.
 
 ---
 
-## Priorisierung (Impact × Aufwand)
+## Prioritization (Impact × Effort)
 
-**P1 — fängt echte Bugs, moderater Aufwand**
-1. `gpt_oss_mxfp4_convert.cu`-Referenztest (Format-Spez-fp64 wie
-   `test_gguf_dequant_ref.cu`; MXFP4-Nibble-Order war GERADE ein realer Bug
-   im Issue-Sweep #560-Familie!). Aufwand: S–M.
-2. CUTLASS-grouped-GEMM gegen unabhängige Referenz (per-expert-fp32-CPU oder
-   dense-cuBLAS-fp16-Pfad statt desselben Adapters). Der neue 10×-Prefill-
-   Pfad verdient mehr als B-Klasse. Aufwand: M.
-3. Paged-INT4/INT8-Oracle nach dem Muster von `test_attention_paged_oracle.cu`
-   (Methodik existiert, nur Dtypes ergänzen). Aufwand: S–M.
-4. `attention_dispatch`-Routing-Tabellen-Test ((hd,seq,dtype)→Pfad, reine
-   Host-Logik; #493 war genau diese Klasse). Aufwand: S.
-5. `test_perf_regression.py`-Baseline-Key-Mismatch klären (greift ins Leere
-   oder bricht beim ersten Real-Lauf). Aufwand: S.
+**P1 — catches real bugs, moderate effort**
+1. `gpt_oss_mxfp4_convert.cu` reference test (format-spec-fp64 like
+   `test_gguf_dequant_ref.cu`; MXFP4 nibble order was JUST a real bug
+   in the issue-sweep #560 family!). Effort: S–M.
+2. CUTLASS grouped GEMM against an independent reference (per-expert-fp32-CPU or
+   dense-cuBLAS-fp16 path instead of the same adapter). The new 10×-prefill
+   path deserves more than B-class. Effort: M.
+3. Paged-INT4/INT8 oracle following the pattern of `test_attention_paged_oracle.cu`
+   (methodology exists, just add dtypes). Effort: S–M.
+4. `attention_dispatch` routing-table test ((hd,seq,dtype)→path, pure
+   host logic; #493 was exactly this class). Effort: S.
+5. Clarify `test_perf_regression.py` baseline-key mismatch (hits nothing
+   or breaks on the first real run). Effort: S.
 
-**P2 — Velocity/Robustheit**
-6. Python-Mock-Suite in CI verdrahten (`pytest -m "not perf and not tools"`,
-   CPU-only — der einzige CI-fähige Contract-Check). Aufwand: S.
-7. ~~Attention-sinks-Unit (Sink-Logit-Shift vs CPU-Softmax-Referenz) +
-   Harmony-Template-Golden vs HF-Tokenizer-Output.~~ **DONE (P2.7, #584):**
-   `test_gpt_oss_sinks_ref.cu` (gpt-oss Sink-Logit vs fp64-Softmax-Referenz,
-   inkl. StreamingLLM-Slot-Eviction-Geometrie), `test_gpt_oss_harmony_golden.cpp`
-   (imp-Jinja-Render vs HF `apply_chat_template`-Golden, exakt), plus
-   `test_gpt_oss_yarn_ref.cu` (YaRN-Langsequenz-Parität bis pos 131071 vs fp64,
-   sensitiv auf die #547 rope_freq_scale-Inversion). Generatoren+Goldens in
+**P2 — Velocity/Robustness**
+6. Wire the Python mock suite into CI (`pytest -m "not perf and not tools"`,
+   CPU-only — the only CI-capable contract check). Effort: S.
+7. ~~Attention-sinks unit (sink-logit shift vs CPU-softmax reference) +
+   Harmony-template golden vs HF-tokenizer output.~~ **DONE (P2.7, #584):**
+   `test_gpt_oss_sinks_ref.cu` (gpt-oss sink-logit vs fp64-softmax reference,
+   incl. StreamingLLM slot-eviction geometry), `test_gpt_oss_harmony_golden.cpp`
+   (imp-Jinja-render vs HF `apply_chat_template` golden, exact), plus
+   `test_gpt_oss_yarn_ref.cu` (YaRN long-sequence parity up to pos 131071 vs fp64,
+   sensitive to the #547 rope_freq_scale inversion). Generators+goldens in
    `tests/refs/` (gen_harmony_golden.py, gen_yarn_rope_golden.py).
-8. Decode-Gate um Clock-/Power-Plausibilisierung ergänzen (#526-Klasse:
-   bei mem-clock < 13801 MHz WARN statt FAIL). Aufwand: S.
-9. ~~unit_e2e_filter aus Test-Namen-Kopplung lösen + doppelte
-   ctest-Registrierung bereinigen.~~ **DONE (R5, #580):** Filter behalten +
-   Guard-Test `guard_e2e_lane_split` (rename-fest via `--gtest_list_tests`-
-   Abgleich gegen die eingefrorene CPU-Menge); `gtest_discover_tests` entfernt
-   (1215→14 ctest-Einträge, kein Doppellauf mehr).
+8. Extend the decode gate with clock/power plausibility check (#526 class:
+   on mem-clock < 13801 MHz WARN instead of FAIL). Effort: S.
+9. ~~Decouple unit_e2e_filter from test-name coupling + clean up duplicate
+   ctest registration.~~ **DONE (R5, #580):** keep filter +
+   guard test `guard_e2e_lane_split` (rename-proof via `--gtest_list_tests`
+   comparison against the frozen CPU set); `gtest_discover_tests` removed
+   (1215→14 ctest entries, no more double run).
 
-**P3 — Hygiene (low-risk, sofort ausführbar)**
-10. `tests/golden/` löschen (tot), `tests/api/test_outputs/` löschen +
-    .gitignore, irreführende Skip-Message in `test_attention_fmha_sm120.cu`
-    fixen, Manual-Skripte als manuell markieren,
-    `tests/refs/gen_reference.py` als dormant markieren.
+**P3 — Hygiene (low-risk, immediately executable)**
+10. Delete `tests/golden/` (dead), delete `tests/api/test_outputs/` +
+    .gitignore, fix the misleading skip message in `test_attention_fmha_sm120.cu`,
+    mark manual scripts as manual,
+    mark `tests/refs/gen_reference.py` as dormant.
 
-**Nicht tun:** Spec-decode-Exactness (#9 von 06-04) bleibt zurückgestellt
-(MTP = bewiesener Dead End bei aktueller Präzision); Bench-Tests nicht in
-Gates verwandeln (Varianz); keine Seed-Sweeps für Greedy-Pfade.
+**Do not do:** Spec-decode exactness (#9 from 06-04) stays deferred
+(MTP = proven dead end at current precision); do not turn bench tests into
+gates (variance); no seed sweeps for greedy paths.
 
 ---
 
-## Phase 2 — Refactor-Plan (Vorschlag, pro Item Risiko/Aufwand)
+## Phase 2 — Refactor Plan (proposal, risk/effort per item)
 
-| # | Item | Risiko | Aufwand |
+| # | Item | Risk | Effort |
 |---|---|---|---|
-| R1 | **Referenz-First für neue Hot-Paths:** P1.1–P1.3 als ein Paket „class-A-Anker für #572/#574-Pfade" — Generatoren nach `tests/refs/`-Schema (committet, bit-exakt, Toleranz begründet) | niedrig (nur neue Tests) | M |
-| R2 | **Routing-/Host-Logik-Units:** P1.4 attention_dispatch + grouped-vs-fallback-Entscheid in `executor_forward` als CPU-Tests (kein GPU nötig → CI-Lane) | niedrig | S |
-| R3 | **CI-Lane Python-Mock** (P2.6): neuer CI-Step nach Build, `pytest tests/api -m "not perf and not tools"` gegen mock_server; läuft ohne GPU | niedrig (CI-only) | S |
-| R4 | **Perf-Gate härten** (P1.5 + P2.8): test_perf_regression-Keys reparieren oder Suite auf verify.sh-Schema umstellen; verify.sh sampelt clocks.mem/power während des Benches und degradiert FAIL→WARN bei depressed-host-Signatur; Baseline-Dateien bekommen einheitliches `schema_version`-Feld | mittel (Gate-Semantik ändert sich — Abstimmung, weil CI-Verhalten betroffen) | M |
-| R5 | **test-e2e-Split entkoppeln** (P2.9): Stub-Unit-Tests in eigenes Binary; Label-Aggregate behalten; gtest_discover_tests-Doppelregistrierung auf Label-Aggregate reduzieren — **ERLEDIGT (#580):** eigenes Binary verworfen (CPU/GPU-Tests teilen Fixtures, nicht trennbar ohne Duplizierung); stattdessen Filter behalten + Guard `guard_e2e_lane_split` (`scripts/check_e2e_lane_split.sh`, rename-fest), `gtest_discover_tests` entfernt (1215→14 ctest-Einträge, kein Doppellauf), Makefile-`<30s`-Kommentar gefixt | mittel (Runner-Umbau, Makefile/CI/verify.sh-Pfade anfassen) | M |
-| R6 | **Modell-Env-Registry:** ein `tests/test_models.h` (Header-only) mit den Env-Vars + Accessoren statt kopiertem Muster; mechanische Migration — **ERLEDIGT (#581):** `tests/test_models.h` (`imp_test::kEnv*` + `env_path`/`env_path_or`), ~14 Dateien migriert (Env-Namen aus Registry, SKIP bleibt am Call-Site, /models-Fallbacks erhalten), `test_mtp_forward` Host-Pfad → Container-Pfad normalisiert | niedrig (mechanisch, semantikerhaltend) | M (Fleißarbeit) |
-| R7 | **Hygiene-Batch** (P3.10) | minimal | S |
-| R8 | **Parametrisierung Quant×Arch** (Prompt-Wunsch): NICHT als große Matrix empfohlen — die Greedy-Lock-/NLL-E2E-Suite parametrisiert bereits über die real vorhandenen Modelle, und eine synthetische Arch-Matrix (LLaMA/Mistral/DeepSeek/…) ohne Gewichte testet nur Loader-Pfade, die `test_e2e_models`/Loader-Tests schon abdecken. Stattdessen: TYPED_TEST über KV-Dtypes im paged-Oracle (R1) und über Quant-Formate im Dequant-Ref — dort ist Parametrisierung billig und echt. | niedrig | S–M |
-| R9 | **Vision-GPU-Golden** (einziger komplett blinder GPU-Bereich): ein eingefrorenes SigLIP-Encoder-Golden (kleines committetes Bild → Projector-Output-Spots, Toleranz f16-Klasse) — **ERLEDIGT (#583)**: `tests/test_vision_golden.cu` + `tests/refs/vision_encoder_golden.h`, deckt SigLIP **und** gemma4v ab (committetes 64² PNG, mmproj standalone ohne LM), ≤1e-2 rel + 5e-3 abs + NaN/Inf-Guard, sauberer SKIP ohne Modell, `make test-vision` (Dump-Mode regeneriert) | niedrig | M |
+| R1 | **Reference-first for new hot paths:** P1.1–P1.3 as one package "class-A anchors for #572/#574 paths" — generators per `tests/refs/` schema (committed, bit-exact, tolerance justified) | low (only new tests) | M |
+| R2 | **Routing/host-logic units:** P1.4 attention_dispatch + grouped-vs-fallback decision in `executor_forward` as CPU tests (no GPU needed → CI lane) | low | S |
+| R3 | **CI-lane Python mock** (P2.6): new CI step after build, `pytest tests/api -m "not perf and not tools"` against mock_server; runs without GPU | low (CI-only) | S |
+| R4 | **Harden perf gate** (P1.5 + P2.8): repair test_perf_regression keys or switch suite to verify.sh schema; verify.sh samples clocks.mem/power during the bench and degrades FAIL→WARN on depressed-host signature; baseline files get a uniform `schema_version` field | medium (gate semantics change — coordination, because CI behavior is affected) | M |
+| R5 | **Decouple test-e2e split** (P2.9): stub unit tests in own binary; keep label aggregates; reduce gtest_discover_tests double registration to label aggregates — **DONE (#580):** own binary discarded (CPU/GPU tests share fixtures, not separable without duplication); instead keep filter + guard `guard_e2e_lane_split` (`scripts/check_e2e_lane_split.sh`, rename-proof), `gtest_discover_tests` removed (1215→14 ctest entries, no double run), Makefile `<30s` comment fixed | medium (runner rework, touch Makefile/CI/verify.sh paths) | M |
+| R6 | **Model env registry:** one `tests/test_models.h` (header-only) with the env vars + accessors instead of a copied pattern; mechanical migration — **DONE (#581):** `tests/test_models.h` (`imp_test::kEnv*` + `env_path`/`env_path_or`), ~14 files migrated (env names from registry, SKIP stays at call site, /models fallbacks preserved), `test_mtp_forward` host path → container path normalized | low (mechanical, semantics-preserving) | M (grind work) |
+| R7 | **Hygiene batch** (P3.10) | minimal | S |
+| R8 | **Parametrization Quant×Arch** (prompt wish): NOT recommended as a large matrix — the greedy-lock/NLL-E2E suite already parametrizes over the actually present models, and a synthetic arch matrix (LLaMA/Mistral/DeepSeek/…) without weights only tests loader paths that `test_e2e_models`/loader tests already cover. Instead: TYPED_TEST over KV-Dtypes in the paged-oracle (R1) and over quant formats in the dequant-ref — there parametrization is cheap and real. | low | S–M |
+| R9 | **Vision-GPU golden** (the only completely blind GPU area): a frozen SigLIP-encoder golden (small committed image → projector-output spots, tolerance f16-class) — **DONE (#583)**: `tests/test_vision_golden.cu` + `tests/refs/vision_encoder_golden.h`, covers SigLIP **and** gemma4v (committed 64² PNG, mmproj standalone without LM), ≤1e-2 rel + 5e-3 abs + NaN/Inf-Guard, clean SKIP without model, `make test-vision` (dump mode regenerates) | low | M |
 
-Empfohlene Reihenfolge: R7 (sofort) → R2+R3 (billig, CI-Wirkung) → R1 (Kern) →
-R4 → R6 → R5 → R9. R8 in R1 integrieren.
+Recommended order: R7 (immediately) → R2+R3 (cheap, CI impact) → R1 (core) →
+R4 → R6 → R5 → R9. Integrate R8 into R1.
 
-— Phase 1+2 Ende. Phase 3 nur nach Freigabe; als low-risk markiert und damit
-ausführbar ohne weitere Freigabe: **R7 (Hygiene-Batch)**.
+— End of Phase 1+2. Phase 3 only after approval; marked as low-risk and thus
+executable without further approval: **R7 (hygiene batch)**.

--- a/tests/api/elchtest.sh
+++ b/tests/api/elchtest.sh
@@ -26,8 +26,8 @@ req_status() { curl -s -o /dev/null -w '%{http_code}' --max-time "${2:-10}" "$UR
 health() { curl -s --max-time 5 http://localhost:8080"$1" 2>/dev/null; }
 
 echo "╔══════════════════════════════════════════════════════════════════╗"
-echo "║  ELCHTEST — imp-server Stabilitäts- & Korrektheitsprüfung      ║"
-echo "║  Modell: Qwen3-8B-Q8_0    GPU: RTX 5090                       ║"
+echo "║  ELCHTEST (moose test) — imp-server stability & correctness    ║"
+echo "║  Model: Qwen3-8B-Q8_0    GPU: RTX 5090                        ║"
 echo "╚══════════════════════════════════════════════════════════════════╝"
 echo ""
 
@@ -39,7 +39,7 @@ r=$(health "/health")
 t "GET /health → 200 + status ok" "endpoint" "$(echo "$r" | grep -q '"status":"ok"' && echo 1 || echo 0)"
 
 r=$(health "/v1/models")
-t "GET /v1/models → list mit data[]" "endpoint" "$(echo "$r" | grep -q '"object":"list"' && echo 1 || echo 0)"
+t "GET /v1/models → list with data[]" "endpoint" "$(echo "$r" | grep -q '"object":"list"' && echo 1 || echo 0)"
 
 r=$(health "/metrics")
 t "GET /metrics → Prometheus format" "endpoint" "$(echo "$r" | grep -q 'imp_requests_total' && echo 1 || echo 0)"
@@ -53,13 +53,13 @@ sc=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$URL" -H "Content-Type
 t "Malformed JSON → 400" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
 
 sc=$(req_status '{"model":"nonexistent.gguf","messages":[{"role":"user","content":"hi"}]}')
-t "Unbekanntes Modell → 404" "error" "$([ "$sc" = "404" ] && echo 1 || echo 0)"
+t "Unknown model → 404" "error" "$([ "$sc" = "404" ] && echo 1 || echo 0)"
 
 sc=$(req_status '{"model":"'$MODEL'","messages":"not array"}')
-t "messages kein Array → 400" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
+t "messages not an array → 400" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
 
 sc=$(req_status '{"model":"'$MODEL'","messages":[]}')
-t "Leeres messages[] → 400" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
+t "Empty messages[] → 400" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
 
 sc=$(req_status '{"model":"'$MODEL'","messages":[{"role":"user","content":"hi"}],"temperature":5}')
 t "temperature=5 → 400" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
@@ -68,46 +68,46 @@ sc=$(req_status '{"model":"'$MODEL'","messages":[{"role":"user","content":"hi"}]
 t "max_tokens=0 → 400" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
 
 sc=$(req_status '{"model":"'$MODEL'","messages":[{"role":"user","content":"hi"}],"n":3}')
-t "n=3 → 400 (nicht unterstützt)" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
+t "n=3 → 400 (not supported)" "error" "$([ "$sc" = "400" ] && echo 1 || echo 0)"
 
 r=$(health "/health")
-t "Server lebt nach 7 Fehler-Requests" "error" "$(echo "$r" | grep -q '"status":"ok"' && echo 1 || echo 0)"
+t "Server alive after 7 error requests" "error" "$(echo "$r" | grep -q '"status":"ok"' && echo 1 || echo 0)"
 
 # ═══════════════════════════════════════════════════════════
 echo ""
-echo "── 3. KORREKTHEIT ──"
+echo "── 3. CORRECTNESS ──"
 # ═══════════════════════════════════════════════════════════
 
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":"What is 2+2? Answer with just the number."}],"temperature":0,"max_tokens":30}' 30)
 c=$(echo "$r" | jq -r '.choices[0].message.content // ""')
-t "Greedy 2+2 → enthält '4'" "correct" "$(echo "$c" | grep -q '4' && echo 1 || echo 0)"
+t "Greedy 2+2 → contains '4'" "correct" "$(echo "$c" | grep -q '4' && echo 1 || echo 0)"
 
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":"Capital of France? One word."}],"temperature":0,"max_tokens":30}' 30)
 c=$(echo "$r" | jq -r '.choices[0].message.content // ""')
-t "Greedy Hauptstadt Frankreich → Paris" "correct" "$(echo "$c" | grep -qi 'paris' && echo 1 || echo 0)"
+t "Greedy capital of France → Paris" "correct" "$(echo "$c" | grep -qi 'paris' && echo 1 || echo 0)"
 
-# Determinismus
+# Determinism
 p='{"model":"'$MODEL'","messages":[{"role":"user","content":"Say hello"}],"temperature":0,"max_tokens":20,"seed":42}'
 c1=$(req "$p" 30 | jq -r '.choices[0].message.content // ""')
 c2=$(req "$p" 30 | jq -r '.choices[0].message.content // ""')
-t "Seed=42 temp=0 → deterministisch" "correct" "$([ "$c1" = "$c2" ] && echo 1 || echo 0)"
+t "Seed=42 temp=0 → deterministic" "correct" "$([ "$c1" = "$c2" ] && echo 1 || echo 0)"
 
 # JSON output
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"system","content":"Reply JSON: {\"answer\":\"...\"}"},{"role":"user","content":"Capital of Germany?"}],"temperature":0.7,"max_tokens":100}' 30)
 c=$(echo "$r" | jq -r '.choices[0].message.content // ""')
-t "JSON mode → valides JSON" "correct" "$(echo "$c" | jq . >/dev/null 2>&1 && echo 1 || echo 0)"
+t "JSON mode → valid JSON" "correct" "$(echo "$c" | jq . >/dev/null 2>&1 && echo 1 || echo 0)"
 
-# Usage korrekt
+# Usage correct
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":"hi"}],"max_tokens":5,"temperature":0}' 15)
 pt=$(echo "$r" | jq -r '.usage.prompt_tokens // 0')
 ct=$(echo "$r" | jq -r '.usage.completion_tokens // 0')
 tt=$(echo "$r" | jq -r '.usage.total_tokens // 0')
 t "Usage: total = prompt + completion" "correct" "$([ "$tt" -eq "$((pt + ct))" ] && echo 1 || echo 0)"
 
-# max_tokens respektiert
+# max_tokens respected
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":"Count 1 to 1000"}],"max_tokens":3,"temperature":0}' 15)
 ct=$(echo "$r" | jq -r '.usage.completion_tokens // 0')
-t "max_tokens=3 respektiert (≤5 tok)" "correct" "$([ "$ct" -le 5 ] && echo 1 || echo 0)"
+t "max_tokens=3 respected (≤5 tok)" "correct" "$([ "$ct" -le 5 ] && echo 1 || echo 0)"
 
 # ═══════════════════════════════════════════════════════════
 echo ""
@@ -115,9 +115,9 @@ echo "── 4. STREAMING ──"
 # ═══════════════════════════════════════════════════════════
 
 raw=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10,"temperature":0,"stream":true}' 15)
-t "Stream: enthält chat.completion.chunk" "stream" "$(echo "$raw" | grep -q 'chat.completion.chunk' && echo 1 || echo 0)"
+t "Stream: contains chat.completion.chunk" "stream" "$(echo "$raw" | grep -q 'chat.completion.chunk' && echo 1 || echo 0)"
 t "Stream: [DONE] sentinel" "stream" "$(echo "$raw" | grep -q 'data: \[DONE\]' && echo 1 || echo 0)"
-t "Stream: finish_reason vorhanden" "stream" "$(echo "$raw" | grep -q 'finish_reason' && echo 1 || echo 0)"
+t "Stream: finish_reason present" "stream" "$(echo "$raw" | grep -q 'finish_reason' && echo 1 || echo 0)"
 
 # Stream vs non-stream: assemble stream chunks via jq, compare trimmed
 p_base='{"model":"'$MODEL'","messages":[{"role":"user","content":"What is 1+1? Number only."}],"max_tokens":5,"temperature":0,"think_budget":0'
@@ -143,10 +143,10 @@ all_ok=1
 for i in $(seq 1 8); do
   if ! jq -e '.choices[0].message.content' /tmp/conc_$i.json >/dev/null 2>&1; then all_ok=0; fi
 done
-t "8 concurrent Requests → alle mit content" "concur" "$all_ok"
+t "8 concurrent requests → all with content" "concur" "$all_ok"
 
 r=$(health "/health")
-t "Server stabil nach 8-concurrent" "concur" "$(echo "$r" | grep -q '"status":"ok"' && echo 1 || echo 0)"
+t "Server stable after 8-concurrent" "concur" "$(echo "$r" | grep -q '"status":"ok"' && echo 1 || echo 0)"
 
 # ═══════════════════════════════════════════════════════════
 echo ""
@@ -170,14 +170,15 @@ echo "── 7. EDGE CASES ──"
 # ═══════════════════════════════════════════════════════════
 
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":""}],"max_tokens":5,"temperature":0}' 15)
-t "Leerer User-Content → kein Crash" "edge" "$(echo "$r" | jq -e '.choices[0]' >/dev/null 2>&1 && echo 1 || echo 0)"
+t "Empty user content → no crash" "edge" "$(echo "$r" | jq -e '.choices[0]' >/dev/null 2>&1 && echo 1 || echo 0)"
 
 longtext=$(printf 'word %.0s' $(seq 1 600))
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":"Summarize: '"$longtext"'"}],"max_tokens":20,"temperature":0}' 30)
-t "Langer Prompt (600 Wörter) → Antwort" "edge" "$(echo "$r" | jq -e '.choices[0].message.content' >/dev/null 2>&1 && echo 1 || echo 0)"
+t "Long prompt (600 words) → response" "edge" "$(echo "$r" | jq -e '.choices[0].message.content' >/dev/null 2>&1 && echo 1 || echo 0)"
 
+# Prompt intentionally German ("What does 🎉🚀💻 mean?") to exercise unicode/emoji + multilingual input
 r=$(req '{"model":"'$MODEL'","messages":[{"role":"user","content":"Was bedeutet 🎉🚀💻?"}],"max_tokens":30,"temperature":0}' 30)
-t "Unicode/Emoji im Prompt → kein Crash" "edge" "$(echo "$r" | jq -e '.choices[0]' >/dev/null 2>&1 && echo 1 || echo 0)"
+t "Unicode/emoji in prompt → no crash" "edge" "$(echo "$r" | jq -e '.choices[0]' >/dev/null 2>&1 && echo 1 || echo 0)"
 
 rapid_ok=1
 for i in $(seq 1 20); do
@@ -185,7 +186,7 @@ for i in $(seq 1 20); do
     -d '{"model":"'$MODEL'","messages":[{"role":"user","content":"'$i'"}],"max_tokens":1,"temperature":0}' 2>/dev/null)
   echo "$r" | jq -e '.choices[0]' >/dev/null 2>&1 || rapid_ok=0
 done
-t "20 rapid-fire Requests → alle OK" "edge" "$rapid_ok"
+t "20 rapid-fire requests → all OK" "edge" "$rapid_ok"
 
 timeout 1 curl -s "$URL" -H "Content-Type: application/json" \
   -d '{"model":"'$MODEL'","messages":[{"role":"user","content":"Count 1 to 1000"}],"max_tokens":500,"stream":true}' >/dev/null 2>&1 || true
@@ -217,12 +218,12 @@ t "Decode ≥200 tok/s (got ${tps})" "perf" "$([ $tps -ge 200 ] && echo 1 || ech
 # ═══════════════════════════════════════════════════════════
 echo ""
 echo "╔══════════════════════════════════════════════════════════════════╗"
-printf "║  ERGEBNIS: %d/%d PASS  (%d FAIL)                               ║\n" "$PASS" "$TOTAL" "$FAIL"
+printf "║  RESULT: %d/%d PASS  (%d FAIL)                                 ║\n" "$PASS" "$TOTAL" "$FAIL"
 echo "╠══════════════════════════════════════════════════════════════════╣"
 if [ $FAIL -eq 0 ]; then
-echo "║  ✓ ELCHTEST BESTANDEN                                          ║"
+echo "║  ✓ ELCHTEST PASSED                                             ║"
 else
-echo "║  ✗ ELCHTEST NICHT BESTANDEN                                    ║"
+echo "║  ✗ ELCHTEST FAILED                                             ║"
 printf "║  Failures:%-54s║\n" ""
 printf "$FAILS\n" | while read line; do [ -n "$line" ] && printf "║    %-60s║\n" "$line"; done
 fi

--- a/tests/test_attention_paged_oracle.cu
+++ b/tests/test_attention_paged_oracle.cu
@@ -573,8 +573,8 @@ struct PathNVFP4TC {
 };
 
 // ===========================================================================
-// TYPED_TEST over KV dtypes (R8 / audit Phase-2 R8: "TYPED_TEST über KV-Dtypes
-// im paged-Oracle"). One typed fixture, one body; each KV dtype is a policy
+// TYPED_TEST over KV dtypes (R8 / audit Phase-2 R8: "TYPED_TEST over KV dtypes
+// in the paged oracle"). One typed fixture, one body; each KV dtype is a policy
 // type. The two production decode shapes (GQA 32x8 and MHA 8x8 at hd=128) and
 // the kv_len sweep {16, 64, 333, 1024} run inside the body. 333 is deliberately
 // NOT block-aligned (partial-tail block); 16/64 are the short rows where quant

--- a/tools/roofline/README.md
+++ b/tools/roofline/README.md
@@ -1,68 +1,68 @@
-# tools/roofline — reproduzierbare Roofline- & Coverage-Pipeline
+# tools/roofline — reproducible roofline & coverage pipeline
 
-Misst Roofline-Nähe (%-Roofline, AI, achieved FLOPS/BW) und Kernel-Coverage
-(Legacy-Fallback-Anteile) der imp-Hot-Path-Kernels auf der RTX 5090 (sm_120a),
-mit append-only Historie pro Commit.
+Measures roofline proximity (%-roofline, AI, achieved FLOPS/BW) and kernel
+coverage (legacy-fallback shares) of the imp hot-path kernels on the RTX 5090
+(sm_120a), with append-only history per commit.
 
 ## Quickstart
 
 ```bash
-tools/roofline/roofline measure                 # voller Sweep, 3 Restarts (~Stunden, GPU exklusiv)
-tools/roofline/roofline measure --models q8-dense --shapes tg256 --restarts 1   # Smoke
+tools/roofline/roofline measure                 # full sweep, 3 restarts (~hours, GPU exclusive)
+tools/roofline/roofline measure --models q8-dense --shapes tg256 --restarts 1   # smoke
 tools/roofline/roofline plot --latest           # roofline.png + roofline_trend.png
 tools/roofline/roofline plot --compare RUN_A RUN_B
 tools/roofline/roofline report --run latest -o audit/roofline_$(date +%Y_%m_%d).md
 tools/roofline/roofline regress --baseline <run_id|sha> --threshold 5
-tools/roofline/roofline issues --run latest     # dry-run; --create legt GitHub-Issues an
+tools/roofline/roofline issues --run latest     # dry-run; --create files GitHub issues
 tools/roofline/roofline ab --knob fa2           # unprofiled A/B (FA2 on vs never)
 ```
 
-## Architektur
+## Architecture
 
-- **Messung** (`measure`): pro Zelle (Modell × Shape × Restart) zwei Pässe in
-  frischen Docker-Containern (= Restart-Varianz by construction):
-  1. **nsys** (volle Timeline): Kernel-Zeitanteile, cuBLAS-API-Attribution
-     (batched GEMM ⇒ Legacy-Attention QK^T/PV), Phasen-Split (init/prefill/
-     decode) und Kalibrierung des ncu `--launch-skip` (Steady-State-Fenster).
-  2. **ncu** (gepinntes Counter-Set, `--clock-control base`): pro Launch
-     Zeit, `dram__bytes`, Tensor-Pipe-FLOP-Counter, SM/DRAM-%, Occupancy.
-- **Historie** (`history/`): append-only.
-  - `runs/<run_id>.json` — geparster Run (committed). `run_id = <shortSHA>[-dirty]_<timestamp>`.
-  - `index.jsonl` — eine Zeile pro Run für Trend-Queries (committed).
-  - `raw/<run_id>/*.ncu_raw.csv.gz` + `*.nsys_extract.json` — Roh-Exporte,
-    Re-Parse ohne Re-Measure (committed).
-  - `raw/<run_id>/*.ncu-rep|*.nsys-rep|*.sqlite` — binäre Originale,
-    **nur lokal** (gitignored; Release-Check verbietet sie im Repo).
-- **Plots** (`plot`): matplotlib im Container `imp-roofline-plot`
-  (Dockerfile.plot, Host bleibt clean) — rendert ausschließlich aus History.
-- **Report** (`report`): Markdown mit Modul-1-Tabelle, Modul-2-Coverage-Matrix
-  und priorisierter Lever-Liste; jede Zahl referenziert den Run (commit+ts).
-- **Gate** (`regress`): exit≠0, wenn eine Kernel-Klasse (Zeitanteil ≥0.5%)
-  im Median > Schwelle unter die Baseline fällt UND die Restart-Spannen
-  disjunkt sind (sonst Varianz, kein Fail).
+- **Measurement** (`measure`): per cell (model × shape × restart), two passes in
+  fresh Docker containers (= restart variance by construction):
+  1. **nsys** (full timeline): kernel time shares, cuBLAS API attribution
+     (batched GEMM ⇒ legacy attention QK^T/PV), phase split (init/prefill/
+     decode), and calibration of the ncu `--launch-skip` (steady-state window).
+  2. **ncu** (pinned counter set, `--clock-control base`): per launch
+     time, `dram__bytes`, tensor-pipe FLOP counters, SM/DRAM %, occupancy.
+- **History** (`history/`): append-only.
+  - `runs/<run_id>.json` — parsed run (committed). `run_id = <shortSHA>[-dirty]_<timestamp>`.
+  - `index.jsonl` — one line per run for trend queries (committed).
+  - `raw/<run_id>/*.ncu_raw.csv.gz` + `*.nsys_extract.json` — raw exports,
+    re-parse without re-measure (committed).
+  - `raw/<run_id>/*.ncu-rep|*.nsys-rep|*.sqlite` — binary originals,
+    **local only** (gitignored; the release check forbids them in the repo).
+- **Plots** (`plot`): matplotlib in the `imp-roofline-plot` container
+  (Dockerfile.plot, host stays clean) — renders exclusively from history.
+- **Report** (`report`): Markdown with the Module-1 table, the Module-2 coverage
+  matrix and a prioritized lever list; every number references the run (commit+ts).
+- **Gate** (`regress`): exit≠0 when a kernel class (time share ≥0.5%) drops in
+  the median by more than the threshold below the baseline AND the restart
+  ranges are disjoint (otherwise variance, no fail).
 
-## Determinismus / Methodik
+## Determinism / methodology
 
-- Counter-Set, Shapes, Peaks und Klassifikations-Regexes liegen versioniert in
-  `config.json` (`config_version` — Läufe nur innerhalb gleicher Version vergleichen).
-- ncu lockt Clocks auf Base (`--clock-control base`); Compute-Peaks werden auf
-  den **gemessenen** SM-Takt normiert (`gpc__cycles_elapsed.avg.per_second`),
-  Ridge-Points auf Boost-Takt (2.407 GHz) — beides in config.json.
-- AI = FLOPs / `dram__bytes.sum` (gemessener DRAM-Traffic, nicht geschätzt).
-- **FLOP counting**: Tensor-Core-FLOPs aus `sm__ops_path_tensor_src_*`-Countern
-  (Kalibrierung gegen bekannte GEMM-Shapes, siehe Report-Methodik). Non-TC:
-  SASS-Thread-Instruktionen (ffma=2 FLOP; hfma als gepackt HFMA2=4 FLOP
-  gezählt — obere Schranke, im Report als solche markiert).
-- Profil-Läufe nutzen `--no-cuda-graphs` (Graph-Replay versteckt Kernel,
-  Kernel-Mix ist identisch — siehe docs/MISSION_JOURNAL/memory).
-- Prefill-Zellen messen `--bench-reps 3 --max-tokens 1`; Decode-Zellen
-  `--bench-pp 64 --max-tokens 256`. pp-Restart-Varianz (bekannt bis 2.6×)
-  wird als min/med/max ausgewiesen, nie weggemittelt.
+- The counter set, shapes, peaks and classification regexes are versioned in
+  `config.json` (`config_version` — only compare runs within the same version).
+- ncu locks clocks to base (`--clock-control base`); compute peaks are
+  normalized to the **measured** SM clock (`gpc__cycles_elapsed.avg.per_second`),
+  ridge points to the boost clock (2.407 GHz) — both in config.json.
+- AI = FLOPs / `dram__bytes.sum` (measured DRAM traffic, not estimated).
+- **FLOP counting**: tensor-core FLOPs from the `sm__ops_path_tensor_src_*`
+  counters (calibrated against known GEMM shapes, see report methodology). Non-TC:
+  SASS thread instructions (ffma=2 FLOP; hfma counted as packed HFMA2=4 FLOP
+  — an upper bound, flagged as such in the report).
+- Profile runs use `--no-cuda-graphs` (graph replay hides kernels, the kernel
+  mix is identical — see docs/MISSION_JOURNAL/memory).
+- Prefill cells measure `--bench-reps 3 --max-tokens 1`; decode cells
+  `--bench-pp 64 --max-tokens 256`. pp restart variance (known up to 2.6×) is
+  reported as min/med/max, never averaged away.
 
 ## CI
 
-GPU-Messung ist LOKAL (CI hat keinen GPU-Runner). Der Workflow
-`.github/workflows/roofline.yml` prüft auf jedem PR nur Parser/Mathe gegen die
-eingecheckte History (re-parse) und rendert Plots als Artefakt. Baseline-Pinning:
-nach Merge auf main lokal `roofline measure` + Commit der History; `regress`
-läuft im pre-push-Hook, wenn eine Baseline gepinnt ist (`history/BASELINE`).
+GPU measurement is LOCAL (CI has no GPU runner). The workflow
+`.github/workflows/roofline.yml` checks only parser/math against the checked-in
+history (re-parse) on each PR and renders plots as an artifact. Baseline pinning:
+after merge to main, run `roofline measure` locally + commit the history;
+`regress` runs in the pre-push hook when a baseline is pinned (`history/BASELINE`).

--- a/tools/roofline/rl_issues.py
+++ b/tools/roofline/rl_issues.py
@@ -12,8 +12,8 @@ AUDIT_KEY_RX = re.compile(r"<!-- audit-key: (\S+) -->")
 
 # Classes whose low %-roofline at the measured shapes is a workload artifact or
 # noise floor, not an actionable lever — kept out of issues (documented in the
-# audit report's "Bekannte Artefakte"): tiny-ctx decode attention, launch-bound
-# micro-kernels at tg256, routing overhead, unclassified leftovers.
+# audit report's "Known artifacts" section): tiny-ctx decode attention,
+# launch-bound micro-kernels at tg256, routing overhead, unclassified leftovers.
 SKIP_CLASSES = {"unclassified", "moe_routing", "kv_write", "kv_gather",
                 "elementwise", "sampling", "rope"}
 SKIP_CELL_CLASS = {("tg256", "attn_decode_paged"), ("tg256", "rmsnorm")}

--- a/tools/roofline/rl_report.py
+++ b/tools/roofline/rl_report.py
@@ -1,4 +1,4 @@
-"""Markdown report: Modul-1 roofline table + Modul-2 coverage matrix + lever
+"""Markdown report: Module-1 roofline table + Module-2 coverage matrix + lever
 list. Renders purely from history (run JSON + nsys extracts). stdlib only."""
 import json
 import os
@@ -116,8 +116,8 @@ def fmt_num(x, digits=1):
 
 
 def module1_table(rows, min_share_pct=1.0):
-    hdr = ("| Kernel-Klasse | Modell/Shape | Zeitanteil % (nsys) | AI (FLOP/B) | erreicht "
-           "(med) | Peak | %-Roofline (min/med/max) | bound-by | dtype | L1-Hit% | Occ % |\n"
+    hdr = ("| Kernel class | Model/Shape | Time share % (nsys) | AI (FLOP/B) | achieved "
+           "(med) | Peak | %-roofline (min/med/max) | bound-by | dtype | L1-hit% | Occ % |\n"
            "|---|---|---|---|---|---|---|---|---|---|---|\n")
     lines = []
     for r in sorted(rows, key=lambda r: (r["model"], r["shape"], -r.get("time_share_pct", 0))):
@@ -137,12 +137,12 @@ def module1_table(rows, min_share_pct=1.0):
             f"| {r['ai']:.2f} | {ach} | {peak} "
             f"| {r['pct_roofline_min']:.1f} / {r['pct_roofline_med']:.1f} / {r['pct_roofline_max']:.1f} "
             f"| {r['bound_by']} | {r['dtype']} | {r.get('l1_hit_pct', 0):.0f} | {r['occupancy_pct']:.0f} |")
-    return hdr + "\n".join(lines) + "\n(*) = Zeitanteil aus ncu-Fenster (nsys-Share fehlt)\n"
+    return hdr + "\n".join(lines) + "\n(*) = time share from the ncu window (nsys share missing)\n"
 
 
 def module2_table(cov):
-    hdr = ("| Zelle | Legacy-Attn %-Anteil Fenster (min/med/max) | Legacy-Anteil an "
-           "Attention % (min/med/max) | Restarts |\n|---|---|---|---|\n")
+    hdr = ("| Cell | Legacy-attn %-share of window (min/med/max) | Legacy share of "
+           "attention % (min/med/max) | Restarts |\n|---|---|---|---|\n")
     lines = []
     for cell, agg in cov.items():
         a = agg["legacy_attn_share_of_total_pct"]
@@ -195,33 +195,33 @@ def render(run, cfg, ab_results=None):
     lv = levers(rows, cov, cfg["roofline"])
     meta = run["meta"]
     md = []
-    md.append(f"# imp Roofline-Audit — Run `{run['run_id']}`\n")
+    md.append(f"# imp Roofline Audit — Run `{run['run_id']}`\n")
     md.append(f"- Commit: `{meta['git']['commit']}`{' (dirty)' if meta['git']['dirty'] else ''}"
               f" · Timestamp: {meta['timestamp']} · config_version: {meta['config_version']}")
     env = meta.get("env", {})
-    md.append(f"- GPU: {env.get('gpu','?')} · Treiber: {env.get('driver','?')} · "
+    md.append(f"- GPU: {env.get('gpu','?')} · Driver: {env.get('driver','?')} · "
               f"CUDA: {env.get('cuda','?')} · ncu: {env.get('ncu','?')}")
-    md.append(f"- Methodik: ncu `--clock-control base` (Clocks gelockt), Counter gepinnt "
-              f"(config_version {meta['config_version']}), {meta['restarts']} Container-Restarts, "
-              f"AI aus gemessenem `dram__bytes.sum`, FLOPs aus `sm__ops_path_tensor_*`/SASS-Counters. "
-              f"Roh-Exporte: `tools/roofline/history/raw/{run['run_id']}/`.\n")
-    md.append("## Modul 1 — Roofline pro Kernel-Klasse\n")
-    md.append("Zeitanteil = Klassen-Anteil an der nsys-Phasen-Timeline der Zelle "
-              "(prefill_window bzw. post_prefill=Decode). %-Roofline/AI aus dem "
-              "ncu-Steady-State-Fenster. Peak compute auf gemessenen (gelockten) "
-              "SM-Takt normiert; ridge auf Boost-Takt.\n")
+    md.append(f"- Methodology: ncu `--clock-control base` (clocks locked), pinned counters "
+              f"(config_version {meta['config_version']}), {meta['restarts']} container restarts, "
+              f"AI from measured `dram__bytes.sum`, FLOPs from `sm__ops_path_tensor_*`/SASS counters. "
+              f"Raw exports: `tools/roofline/history/raw/{run['run_id']}/`.\n")
+    md.append("## Module 1 — Roofline per kernel class\n")
+    md.append("Time share = class share of the cell's nsys phase timeline "
+              "(prefill_window resp. post_prefill=decode). %-roofline/AI from the "
+              "ncu steady-state window. Peak compute normalized to the measured (locked) "
+              "SM clock; ridge to the boost clock.\n")
     md.append(module1_table(rows))
-    md.append("\n## Modul 2 — Coverage / Legacy-Fallback (aus nsys-Timeline)\n")
+    md.append("\n## Module 2 — Coverage / legacy fallback (from the nsys timeline)\n")
     md.append(module2_table(cov))
     if ab_results:
-        md.append("\n### A/B Fallback-Deltas (gemessen, unprofiled)\n")
+        md.append("\n### A/B fallback deltas (measured, unprofiled)\n")
         md.append("```json\n" + json.dumps(ab_results, indent=1) + "\n```\n")
-    md.append("\n## Lever-Liste (priorisiert, **alle Gewinne = Schätzung** via Amdahl "
-              "aus gemessenem Zeitanteil × Roofline-Headroom)\n")
+    md.append("\n## Lever list (prioritized, **all gains = estimate** via Amdahl "
+              "from measured time share × roofline headroom)\n")
     for i, l in enumerate(lv[:15], 1):
-        md.append(f"{i}. **{l['class']}** @ {l['cell']} — est. Fenster-Gewinn "
-                  f"~{l['est_gain_pct']:.1f}% (Zeitanteil {l['time_share_pct']:.1f}%, "
-                  f"{'%-Roofline med ' + format(l.get('pct_roofline_med', 0), '.1f') + ' vs Ziel ' + format(l.get('target_pct', 0), '.0f') if l['kind']=='roofline_headroom' else l.get('note','')})")
-    md.append("\n*(Jede Zahl rückverfolgbar: run_id = commit_timestamp; Roh-ncu-CSV + "
-              "nsys-Extract liegen append-only unter history/raw/<run_id>/.)*\n")
+        md.append(f"{i}. **{l['class']}** @ {l['cell']} — est. window gain "
+                  f"~{l['est_gain_pct']:.1f}% (time share {l['time_share_pct']:.1f}%, "
+                  f"{'%-roofline med ' + format(l.get('pct_roofline_med', 0), '.1f') + ' vs target ' + format(l.get('target_pct', 0), '.0f') if l['kind']=='roofline_headroom' else l.get('note','')})")
+    md.append("\n*(Every number traceable: run_id = commit_timestamp; raw ncu CSV + "
+              "nsys extract are append-only under history/raw/<run_id>/.)*\n")
     return "\n".join(md)

--- a/tools/roofline/rl_table.py
+++ b/tools/roofline/rl_table.py
@@ -1,4 +1,4 @@
-"""Build the Modul-1 roofline table rows from a run record. Joins the per-cell
+"""Build the Module-1 roofline table rows from a run record. Joins the per-cell
 ncu metric groups (base/sass_*/tc_* for prefill, full for decode) at kernel-
 class level: each group is an independent single-pass capture of the SAME
 steady-state window (same --launch-skip/--launch-count), so per-group rates

--- a/tools/roofline/roofline.py
+++ b/tools/roofline/roofline.py
@@ -5,7 +5,7 @@ Subcommands:
   measure   ncu+nsys sweep over the shape set (>=3 restarts), new history entry
   ab        unprofiled A/B bench for a fallback knob (e.g. fa2)
   plot      render roofline.png / trend / compare from history (no re-measure)
-  report    markdown report (Modul 1 + Modul 2 + levers) from history
+  report    markdown report (Module 1 + Module 2 + levers) from history
   regress   exit!=0 if a kernel class fell > threshold below a baseline run
   issues    generate GitHub issues from findings (dry-run unless --create)
   list      list history runs


### PR DESCRIPTION
Establishes English as the repository language and translates all remaining German content in living files.

## Rule

New entry in CONTRIBUTING.md (Code style): all PRs (title + body), commit messages, code comments, docs, and `.md` files are written entirely in English. Deliberate non-English test data is exempt.

## Audit method

Two-pass scan over all tracked files: umlaut/ß grep (strong signal) + German-stopword grep. 24 files flagged, classified into: living content (translated), deliberate test data (kept), historical records (left as-is).

## Translated

- `tests/TEST_AUDIT.md` — test-suite audit (267 lines, mixed DE/EN)
- `docs/audit/performance_agent_readiness_2026_05_31.md` + `docs/audit/roofline_2026_06_07.md`
- `tools/roofline/README.md` + report generator strings (`rl_report.py`, `rl_table.py`, `rl_issues.py`, `roofline.py`) — generated reports now emit English headings; no JSON keys, logic, or regexes changed; headings verified unparsed by any code
- `tests/api/elchtest.sh` — banners/labels; assertions and payloads untouched (`bash -n` clean)
- 3 stray German source comments (`qtype.h`, `pre_dequant_phase0_nvfp4_loader.cu`, `test_attention_paged_oracle.cu`)

## Deliberately kept German

- `src/model/tokenizer.cpp` / `tests/test_tokenizer_robustness.cpp` — Unicode NFC tables and UTF-8 test fixtures
- `tools/analysis/degen_suite.py` — German think-leak detection patterns + multilingual probes

## Left as point-in-time records

`docs/archive/` (incl. `review-2026-05-16/`) and `docs/superpowers/` plans/specs — historical documents; rewriting them adds risk without value.

verify-fast: green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)