### PR TITLE
perf(dp4a): vectorize Q4_K/Q5_K GEMV weight loads (LDG.128) + Q5_K reference test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ if(IMP_USE_CUTLASS)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/attention_mxf4nvf4_probe.cu)
         list(APPEND IMP_COMPUTE_SOURCES src/compute/nvfp4_quant_ref.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/mxf4nvf4_mma_bench.cu)
+        list(APPEND IMP_COMPUTE_SOURCES tests/bench/mma_peak_saturated.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/mxf4nvf4_mma_variants_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES tests/bench/fp4_pv_bench.cu)
         list(APPEND IMP_COMPUTE_SOURCES src/compute/mxf4nvf4_qkt_validate.cu)
@@ -535,6 +536,7 @@ if(IMP_BUILD_TESTS)
         tests/test_quantize_fp16_nvfp4_moe_native.cu
         tests/test_mxf4nvf4_probe.cu
         tests/test_mxf4nvf4_mma_bench.cu
+        tests/test_mma_peak_saturated.cu
         tests/test_mxf4nvf4_mma_variants_bench.cu
         tests/test_fp4_pv_bench.cu
         tests/test_mxf4nvf4_qkt_validate.cu

--- a/docs/audit/roofline_2026_06_07.md
+++ b/docs/audit/roofline_2026_06_07.md
@@ -1,5 +1,18 @@
 # imp Roofline-Audit — 2026-06-07
 
+> **CALIBRATION CORRECTION (2026-06-07 evening, PR #606):** the %-roofline figures
+> below were normalized against datasheet peaks that sm_120a silicon cannot reach
+> via `mma.sync`. Measured saturated ceilings (`tests/bench/mma_peak_saturated.cu`):
+> FP4 block-scale = **½ datasheet** (2019 of 3354 TOPS), FP16/FP8 with f32
+> accumulate = **¼ rate** (253 of 838 / 496 of 1677). Re-parsing this run against
+> the corrected peaks (config_version 3): `gemm_cublas` 17–22 % → **83–88 %**
+> (q8/q4k-dense; the kernel was near its real ceiling — the lever is the compute
+> TYPE, shipped as opt-in `gemm.cublas_fp16_acc`, +17 % q8 pp512), `gemm_cutlass_nvfp4`
+> 22 % → **60 %** compute-bound (kv_proj wave-starvation fixed: small-N pingpong 2.1×),
+> `attn_fa2` 5.6–8.3 % → **19–33 %**. Lever-list estimates below are accordingly
+> overstated; the per-kernel time shares and raw data remain valid.
+> Re-parse: `tools/roofline/roofline report --run e66cfa45-dirty_20260607_042900`.
+
 **Run `e66cfa45-dirty_20260607_042900`** · 57 cells (5 models × pp512/2048/4096 + tg256 × 3 container restarts), **0 missing cells**. Measured with the new `tools/roofline/` pipeline (ncu counters + nsys timeline, append-only history) — **no number carried over, everything from this run**. Reproduce: `tools/roofline/roofline report --run e66cfa45-dirty_20260607_042900`.
 
 ## Executive Summary

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -175,6 +175,12 @@ nvfp4_attn_proj      = false
 # Route native-NVFP4 MoE expert decode (M=1) through per-expert GEMV
 # kernels instead of grouped CUTLASS (+54-80% MoE decode). Default ON.
 nvfp4_moe_decode     = true
+# FP16-accumulate cuBLAS prefill GEMMs (CUBLAS_COMPUTE_16F). GeForce sm_120
+# runs FP32-accumulate tensor cores at 1/4 rate, so 32F caps prefill at
+# ~225 TFLOPS; 16F doubles kernel throughput (Qwen3-8B Q8_0 pp512 +17%,
+# PPL flat). Gemma-3-12B measured +0.7% PPL — hence opt-in. Decode (M=1)
+# is unaffected.
+cublas_fp16_acc      = false
 
 # [gemma4] section moved out of the global RuntimeConfig in Phase 5
 # Track A of the architecture refactor. These are now per-model

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -325,7 +325,13 @@ static int gemm_algo_log_enabled() { return imp::process_diag_log_gemm_algo() ? 
 static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry, const void* A_data,
                                       const void* B_data, size_t C_bytes, float alpha, float beta,
                                       bool is_int_compute, cudaStream_t stream, int M = 0, int N = 0,
-                                      int K = 0) {
+                                      int K = 0, bool fp16_scale = false) {
+    // COMPUTE_16F descriptors take __half alpha/beta (scale type CUDA_R_16F).
+    const __half h_alpha = __float2half(alpha);
+    const __half h_zero = __float2half(0.0f);
+    const float f_zero = 0.0f;
+    const void* p_alpha = fp16_scale ? static_cast<const void*>(&h_alpha) : static_cast<const void*>(&alpha);
+    const void* p_zero = fp16_scale ? static_cast<const void*>(&h_zero) : static_cast<const void*>(&f_zero);
     cublasLtMatmulPreference_t pref = nullptr;
     CUBLASLT_CHECK(cublasLtMatmulPreferenceCreate(&pref));
     CUBLASLT_CHECK(cublasLtMatmulPreferenceSetAttribute(pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
@@ -400,10 +406,9 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
             algo_ok[i] = false;
             continue;
         }
-        float zero = 0.0f;
         for (int w = 0; w < kWarmupIters; w++) {
-            cublasStatus_t wst = cublasLtMatmul(lt, entry.opDesc, &alpha, B_data, entry.Bdesc, A_data,
-                                                 entry.Adesc, &zero, temp_c, entry.Cdesc, temp_c, entry.Cdesc,
+            cublasStatus_t wst = cublasLtMatmul(lt, entry.opDesc, p_alpha, B_data, entry.Bdesc, A_data,
+                                                 entry.Adesc, p_zero, temp_c, entry.Cdesc, temp_c, entry.Cdesc,
                                                  &results[i].algo, s_workspace, results[i].workspaceSize, stream);
             if (wst != CUBLAS_STATUS_SUCCESS) {
                 algo_ok[i] = false;
@@ -415,10 +420,9 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
     for (int i = 0; i < nresults; i++) {
         if (!algo_ok[i])
             continue;
-        float zero = 0.0f;
         cudaEventRecord(start, stream);
         for (int r = 0; r < kBenchmarkIters; r++)
-            cublasLtMatmul(lt, entry.opDesc, &alpha, B_data, entry.Bdesc, A_data, entry.Adesc, &zero, temp_c,
+            cublasLtMatmul(lt, entry.opDesc, p_alpha, B_data, entry.Bdesc, A_data, entry.Adesc, p_zero, temp_c,
                            entry.Cdesc, temp_c, entry.Cdesc, &results[i].algo, s_workspace,
                            results[i].workspaceSize, stream);
         cudaEventRecord(stop, stream);
@@ -558,6 +562,15 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C, f
     cudaDataType_t cuda_dtype_C = dtype_to_cuda(C.qtype);
     cublasComputeType_t compute_type = dtype_to_compute(A.qtype);
 
+    // FP16-accumulate prefill fast path (gemm.cublas_fp16_acc): GeForce
+    // sm_120 runs FP16 TC with FP32 accumulate at 1/4 rate; COMPUTE_16F
+    // restores full rate (~2x measured on prefill shapes). F16-only, M>1 —
+    // decode (M==1) routes through gemm_try_gemv before this and stays 32F.
+    const bool use_fp16_acc = process_diag_cublas_fp16_acc() && M > 1 && A.qtype == QType::F16 &&
+                              B.qtype == QType::F16 && C.qtype == QType::F16;
+    if (use_fp16_acc)
+        compute_type = CUBLAS_COMPUTE_16F;
+
     // Capture-safe path: cuBLASLt fails with CUBLAS_STATUS_INTERNAL_ERROR
     // (status 14) under stream capture on sm_120 — heuristic + workspace
     // allocation paths aren't graph-safe. Route FP16×FP16→FP16 GEMMs to the
@@ -606,14 +619,17 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C, f
         } else {
             GemmCacheEntry new_entry{};
             new_entry.desc_M = M;
-            cudaDataType_t scale_type = (compute_type == CUBLAS_COMPUTE_32I) ? CUDA_R_32I : CUDA_R_32F;
+            cudaDataType_t scale_type = (compute_type == CUBLAS_COMPUTE_32I)   ? CUDA_R_32I
+                                        : (compute_type == CUBLAS_COMPUTE_16F) ? CUDA_R_16F
+                                                                                : CUDA_R_32F;
 
             create_gemm_descriptors(new_entry, compute_type, scale_type, cuda_dtype_A, cuda_dtype_B,
                                     cuda_dtype_C, (int)K, (int)M, (int)N);
 
             size_t c_bytes = (size_t)M * N * dtype_size(C.qtype);
             benchmark_and_select_algo(lt, new_entry, A.data, B.data, c_bytes, alpha, beta,
-                                      (compute_type == CUBLAS_COMPUTE_32I), stream, (int)M, (int)N, (int)K);
+                                      (compute_type == CUBLAS_COMPUTE_32I), stream, (int)M, (int)N, (int)K,
+                                      use_fp16_acc);
 
             auto [inserted_it, _] = s_gemm_cache.emplace(cache_key, new_entry);
             entry = &inserted_it->second;
@@ -645,8 +661,15 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C, f
                          (int)N, CUBLAS_COMPUTE_32I, CUBLAS_GEMM_DEFAULT);
         }
     } else {
-        cublasStatus_t st = cublasLtMatmul(lt, entry->opDesc, &alpha, B.data, entry->Bdesc, A.data,
-                                           entry->Adesc, &beta, C.data, entry->Cdesc, C.data, entry->Cdesc,
+        // COMPUTE_16F descriptors take __half alpha/beta (scale type R_16F).
+        const __half h_alpha = __float2half(alpha);
+        const __half h_beta = __float2half(beta);
+        const void* p_alpha = use_fp16_acc ? static_cast<const void*>(&h_alpha)
+                                           : static_cast<const void*>(&alpha);
+        const void* p_beta = use_fp16_acc ? static_cast<const void*>(&h_beta)
+                                          : static_cast<const void*>(&beta);
+        cublasStatus_t st = cublasLtMatmul(lt, entry->opDesc, p_alpha, B.data, entry->Bdesc, A.data,
+                                           entry->Adesc, p_beta, C.data, entry->Cdesc, C.data, entry->Cdesc,
                                            entry->has_algo ? &entry->algo : nullptr, s_workspace,
                                            entry->workspace_size, stream);
         if (st != CUBLAS_STATUS_SUCCESS) {
@@ -656,8 +679,8 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C, f
                 std::lock_guard<std::mutex> lock(s_gemm_cache_mutex);
                 reselect_algo_for_entry(*entry);
             }
-            st = cublasLtMatmul(lt, entry->opDesc, &alpha, B.data, entry->Bdesc, A.data, entry->Adesc, &beta,
-                                C.data, entry->Cdesc, C.data, entry->Cdesc,
+            st = cublasLtMatmul(lt, entry->opDesc, p_alpha, B.data, entry->Bdesc, A.data, entry->Adesc,
+                                p_beta, C.data, entry->Cdesc, C.data, entry->Cdesc,
                                 entry->has_algo ? &entry->algo : nullptr, s_workspace, entry->workspace_size,
                                 stream);
             if (st != CUBLAS_STATUS_SUCCESS) {

--- a/src/compute/gemm_cutlass_sm120.cu
+++ b/src/compute/gemm_cutlass_sm120.cu
@@ -85,17 +85,52 @@ using GemmKernel = cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int
 
 using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
-using StrideA = typename Gemm::GemmKernel::StrideA;
-using StrideB = typename Gemm::GemmKernel::StrideB;
-using StrideC = typename Gemm::GemmKernel::StrideC;
-using StrideD = typename Gemm::GemmKernel::StrideD;
-using LayoutSFA = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFA;
-using LayoutSFB = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFB;
-using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+// Strides / SF layouts are derived per-variant inside the templated impl
+// below (typename GemmT::GemmKernel::StrideA etc.) — both variants share the
+// same SfAtom data layout, only the CTA tiling differs.
 
 // Verify SFVecSize matches our constant (kSFVecSize = 16)
 static_assert(Gemm::GemmKernel::CollectiveMainloop::TiledMma::Traits::SFVecSize == 16,
               "CUTLASS SFVecSize mismatch — expected 16 for nv_float4_t");
+
+// ---------------------------------------------------------------------------
+// Small-N variant: pingpong schedule + 128x64x128 tile.
+// The default cooperative 128x128 tile starves the GPU on small-N GEMMs
+// (kv_proj N=1024 at M=512: 32 CTAs on 170 SMs). Pingpong with a 64-wide
+// N-tile doubles the CTA count and overlaps two consumer warpgroups:
+// measured 2026-06-07 (standalone config sweep on Qwen3-14B shapes, #596)
+// 2.1x on 512x1024x5120 (27.0us -> 12.8us). It LOSES ~25% on large-N
+// shapes, hence the dispatch threshold below. The SfAtom scale layout is
+// tile-shape-independent (128-row x 4-group atoms from SFVecSize=16), so
+// both variants consume identical A/B scale buffers.
+// ---------------------------------------------------------------------------
+using ThreadBlockShapeSmallN = Shape<_128, _64, _128>;
+
+using CollectiveEpilogueSmallN = typename cutlass::epilogue::collective::CollectiveBuilder<
+    ArchTag, OperatorClass, ThreadBlockShapeSmallN, ClusterShape,
+    cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator, ElementAccumulator, ElementC,
+    LayoutCTag, AlignmentC, ElementD, LayoutDTag, AlignmentD,
+    cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+using CollectiveMainloopSmallN = typename cutlass::gemm::collective::CollectiveBuilder<
+    ArchTag, OperatorClass, ElementA, LayoutATag, AlignmentA, ElementB, LayoutBTag, AlignmentB,
+    ElementAccumulator, ThreadBlockShapeSmallN, ClusterShape,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+        sizeof(typename CollectiveEpilogueSmallN::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecializedPingpong>::CollectiveOp;
+
+using GemmKernelSmallN = cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>,
+                                                              CollectiveMainloopSmallN,
+                                                              CollectiveEpilogueSmallN, void>;
+using GemmSmallN = cutlass::gemm::device::GemmUniversalAdapter<GemmKernelSmallN>;
+
+static_assert(GemmSmallN::GemmKernel::CollectiveMainloop::TiledMma::Traits::SFVecSize == 16,
+              "CUTLASS SFVecSize mismatch (small-N variant)");
+
+// N at/below this routes to the small-N pingpong kernel. Measured: N=1024
+// is 2.1x faster, N=5120 is ~25% slower — the crossover lies between;
+// 2048 is the conservative cut.
+static constexpr int kSmallNThreshold = 2048;
 
 namespace imp {
 
@@ -611,27 +646,36 @@ void fused_act_quantize_fp16_to_nvfp4_cutlass_moe(const void* gate_fp16, const v
 static void* s_cutlass_workspace = nullptr;
 static size_t s_cutlass_workspace_size = 0;
 
-size_t gemm_nvfp4_cutlass_sm120_workspace(int M, int N, int K) {
-    auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, {M, K, 1});
-    auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, {N, K, 1});
-    auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, {M, N, 1});
-    auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, {M, N, 1});
+template <class GemmT>
+static size_t cutlass_workspace_for(int M, int N, int K) {
+    using GK = typename GemmT::GemmKernel;
+    auto stride_A = cutlass::make_cute_packed_stride(typename GK::StrideA{}, {M, K, 1});
+    auto stride_B = cutlass::make_cute_packed_stride(typename GK::StrideB{}, {N, K, 1});
+    auto stride_C = cutlass::make_cute_packed_stride(typename GK::StrideC{}, {M, N, 1});
+    auto stride_D = cutlass::make_cute_packed_stride(typename GK::StrideD{}, {M, N, 1});
 
-    auto layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(cute::make_shape(M, N, K, 1));
-    auto layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(cute::make_shape(M, N, K, 1));
+    using BlkCfg = typename GK::CollectiveMainloop::Sm1xxBlkScaledConfig;
+    auto layout_SFA = BlkCfg::tile_atom_to_shape_SFA(cute::make_shape(M, N, K, 1));
+    auto layout_SFB = BlkCfg::tile_atom_to_shape_SFB(cute::make_shape(M, N, K, 1));
 
-    typename Gemm::Arguments args{cutlass::gemm::GemmUniversalMode::kGemm,
-                                  {M, N, K, 1},
-                                  {nullptr, stride_A, nullptr, stride_B, nullptr, layout_SFA, nullptr,
-                                   layout_SFB},
-                                  {{1.0f, 0.0f}, nullptr, stride_C, nullptr, stride_D}};
+    typename GemmT::Arguments args{cutlass::gemm::GemmUniversalMode::kGemm,
+                                   {M, N, K, 1},
+                                   {nullptr, stride_A, nullptr, stride_B, nullptr, layout_SFA, nullptr,
+                                    layout_SFB},
+                                   {{1.0f, 0.0f}, nullptr, stride_C, nullptr, stride_D}};
 
-    return Gemm::get_workspace_size(args);
+    return GemmT::get_workspace_size(args);
 }
 
-bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const CutlassNvFP4Weight& b, void* d_fp16,
-                              int M, int N, int K, void* workspace, size_t workspace_size,
-                              cudaStream_t stream) {
+size_t gemm_nvfp4_cutlass_sm120_workspace(int M, int N, int K) {
+    return (N <= kSmallNThreshold) ? cutlass_workspace_for<GemmSmallN>(M, N, K)
+                                   : cutlass_workspace_for<Gemm>(M, N, K);
+}
+
+template <class GemmT>
+static bool gemm_nvfp4_cutlass_sm120_impl(const void* a_data, const void* a_sf, const CutlassNvFP4Weight& b,
+                                          void* d_fp16, int M, int N, int K, void* workspace,
+                                          size_t workspace_size, cudaStream_t stream) {
     // Flush any prior async errors — a sticky CUDA error will make
     // cuTensorMapEncodeTiled return 719 (LAUNCH_FAILED) instead of the real code.
     {
@@ -642,13 +686,15 @@ bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const Cutlas
         }
     }
 
-    auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, {M, K, 1});
-    auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, {N, K, 1});
-    auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, {M, N, 1});
-    auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, {M, N, 1});
+    using GK = typename GemmT::GemmKernel;
+    auto stride_A = cutlass::make_cute_packed_stride(typename GK::StrideA{}, {M, K, 1});
+    auto stride_B = cutlass::make_cute_packed_stride(typename GK::StrideB{}, {N, K, 1});
+    auto stride_C = cutlass::make_cute_packed_stride(typename GK::StrideC{}, {M, N, 1});
+    auto stride_D = cutlass::make_cute_packed_stride(typename GK::StrideD{}, {M, N, 1});
 
-    auto layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(cute::make_shape(M, N, K, 1));
-    auto layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(cute::make_shape(M, N, K, 1));
+    using BlkCfg = typename GK::CollectiveMainloop::Sm1xxBlkScaledConfig;
+    auto layout_SFA = BlkCfg::tile_atom_to_shape_SFA(cute::make_shape(M, N, K, 1));
+    auto layout_SFB = BlkCfg::tile_atom_to_shape_SFB(cute::make_shape(M, N, K, 1));
 
     auto* a_ptr = reinterpret_cast<const ElementA::DataType*>(a_data);
     auto* b_ptr = reinterpret_cast<const ElementB::DataType*>(b.data);
@@ -664,17 +710,17 @@ bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const Cutlas
     // D = tensor_scale * (A_fp4 * SFA * B_fp4 * micro_scale_only) = correct result.
     float alpha = b.tensor_scale;
 
-    typename Gemm::Arguments args{cutlass::gemm::GemmUniversalMode::kGemm,
-                                  {M, N, K, 1},
-                                  {a_ptr, stride_A, b_ptr, stride_B, sfa_ptr, layout_SFA, sfb_ptr,
-                                   layout_SFB},
-                                  {{alpha, 0.0f},
-                                   d_ptr,
-                                   stride_C,  // C = D buffer (beta=0, never read)
-                                   d_ptr,
-                                   stride_D}};
+    typename GemmT::Arguments args{cutlass::gemm::GemmUniversalMode::kGemm,
+                                   {M, N, K, 1},
+                                   {a_ptr, stride_A, b_ptr, stride_B, sfa_ptr, layout_SFA, sfb_ptr,
+                                    layout_SFB},
+                                   {{alpha, 0.0f},
+                                    d_ptr,
+                                    stride_C,  // C = D buffer (beta=0, never read)
+                                    d_ptr,
+                                    stride_D}};
 
-    Gemm gemm;
+    GemmT gemm;
     cutlass::Status st = gemm.can_implement(args);
     if (st != cutlass::Status::kSuccess) {
         IMP_LOG_WARN("CUTLASS sm120 NVFP4 GEMM: can_implement failed (%d) for M=%d N=%d K=%d", (int)st, M, N,
@@ -683,7 +729,7 @@ bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const Cutlas
     }
 
     // Ensure workspace
-    size_t needed = Gemm::get_workspace_size(args);
+    size_t needed = GemmT::get_workspace_size(args);
     void* ws = workspace;
     if (needed > workspace_size) {
         if (needed > s_cutlass_workspace_size) {
@@ -708,6 +754,16 @@ bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const Cutlas
     }
 
     return true;
+}
+
+bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const CutlassNvFP4Weight& b, void* d_fp16,
+                              int M, int N, int K, void* workspace, size_t workspace_size,
+                              cudaStream_t stream) {
+    if (N <= kSmallNThreshold)
+        return gemm_nvfp4_cutlass_sm120_impl<GemmSmallN>(a_data, a_sf, b, d_fp16, M, N, K, workspace,
+                                                         workspace_size, stream);
+    return gemm_nvfp4_cutlass_sm120_impl<Gemm>(a_data, a_sf, b, d_fp16, M, N, K, workspace, workspace_size,
+                                               stream);
 }
 
 bool cutlass_sm120_nvfp4_available() { return true; }

--- a/src/compute/gemv_dp4a_traits.cuh
+++ b/src/compute/gemv_dp4a_traits.cuh
@@ -68,14 +68,20 @@ __device__ __forceinline__ int unpack_nibbles_2(uint8_t b0, uint8_t b1) {
     return r;
 }
 
-__device__ __forceinline__ void get_scale_min_k4(const uint8_t* __restrict__ sc, int sub, uint8_t& sc_val,
-                                                 uint8_t& min_val) {
+// 6-bit scale/min unpacker matching ggml get_scale_min_k4, register variant
+// (#598): the 12 scale bytes arrive as three words (s0 = sc[0..3],
+// s1 = sc[4..7], s2 = sc[8..11]) from a single uint4 header load instead of
+// per-byte L1 traffic. Byte-pointer reference copies live in
+// mmq_q4k_imma_layout.cu / gemv_ggml_compat.cu.
+__device__ __forceinline__ void get_scale_min_k4_reg(uint32_t s0, uint32_t s1, uint32_t s2, int sub,
+                                                     uint8_t& sc_val, uint8_t& min_val) {
+    auto byte_of = [](uint32_t w, int i) -> uint32_t { return (w >> (8 * i)) & 0xFFu; };
     if (sub < 4) {
-        sc_val = sc[sub] & 63;
-        min_val = sc[sub + 4] & 63;
+        sc_val = byte_of(s0, sub) & 63;
+        min_val = byte_of(s1, sub) & 63;
     } else {
-        sc_val = (sc[sub + 4] & 0xF) | ((sc[sub - 4] >> 6) << 4);
-        min_val = (sc[sub + 4] >> 4) | ((sc[sub] >> 6) << 4);
+        sc_val = (byte_of(s2, sub - 4) & 0xF) | ((byte_of(s0, sub - 4) >> 6) << 4);
+        min_val = (byte_of(s2, sub - 4) >> 4) | ((byte_of(s1, sub - 4) >> 6) << 4);
     }
 }
 
@@ -91,18 +97,23 @@ __device__ __forceinline__ float q4k_dp4a_sub(const uint8_t* __restrict__ qs,  /
     const bool use_high = (sub & 1);
     const uint8_t* qs_base = qs + qs_byte_offset;
 
+    // Two LDG.128 instead of eight LDG.32 (#598): this kernel class is
+    // L1TEX-instruction-bound (L1 hit 98.7%, DRAM 42%), so load count is
+    // the limiter. Alignment is guaranteed: the 144-byte superblock is
+    // 16B-aligned (144 = 9*16, GGUF tensor alignment 32) and qs sits at
+    // +16 + 32*k within it.
+    const uint4 lo = *reinterpret_cast<const uint4*>(qs_base);
+    const uint4 hi = *reinterpret_cast<const uint4*>(qs_base + 16);
+    const uint32_t qsw[8] = {lo.x, lo.y, lo.z, lo.w, hi.x, hi.y, hi.z, hi.w};
+
     int32_t sumi = 0;
     int q8_sum_int = 0;
     const int ones = 0x01010101;
 
 #pragma unroll
     for (int j = 0; j < 8; j++) {
-        uint32_t qs4;
-        memcpy(&qs4, qs_base + j * 4, 4);
-        uint32_t nibbles = use_high ? ((qs4 >> 4) & 0x0F0F0F0Fu) : (qs4 & 0x0F0F0F0Fu);
-        int ni;
-        memcpy(&ni, &nibbles, 4);
-        sumi = __dp4a(ni, xi[j], sumi);
+        uint32_t nibbles = use_high ? ((qsw[j] >> 4) & 0x0F0F0F0Fu) : (qsw[j] & 0x0F0F0F0Fu);
+        sumi = __dp4a(static_cast<int>(nibbles), xi[j], sumi);
         q8_sum_int = __dp4a(xi[j], ones, q8_sum_int);
     }
 
@@ -128,6 +139,16 @@ __device__ __forceinline__ float q5k_dp4a_sub(
     const bool use_high = (sub & 1);
     const uint8_t* qs_base = qs + qs_byte_offset;
 
+    // Vectorized loads (#598, same rationale as q4k_dp4a_sub): qs sits at
+    // +48 + 32*k (16B-aligned), qh at +16 (16B-aligned, 32 bytes shared by
+    // all subs). 4x LDG.128 replaces 16x LDG.32 per call.
+    const uint4 qlo = *reinterpret_cast<const uint4*>(qs_base);
+    const uint4 qhi = *reinterpret_cast<const uint4*>(qs_base + 16);
+    const uint32_t qsw[8] = {qlo.x, qlo.y, qlo.z, qlo.w, qhi.x, qhi.y, qhi.z, qhi.w};
+    const uint4 h0 = *reinterpret_cast<const uint4*>(qh);
+    const uint4 h1 = *reinterpret_cast<const uint4*>(qh + 16);
+    const uint32_t qhw[8] = {h0.x, h0.y, h0.z, h0.w, h1.x, h1.y, h1.z, h1.w};
+
     int32_t sumi = 0;
     int32_t sumi_h = 0;  // 5th-bit correction
     int q8_sum_int = 0;
@@ -135,27 +156,18 @@ __device__ __forceinline__ float q5k_dp4a_sub(
 
 #pragma unroll
     for (int j = 0; j < 8; j++) {
-        uint32_t qs4;
-        memcpy(&qs4, qs_base + j * 4, 4);
-        uint32_t nibbles = use_high ? ((qs4 >> 4) & 0x0F0F0F0Fu) : (qs4 & 0x0F0F0F0Fu);
-        int ni;
-        memcpy(&ni, &nibbles, 4);
-        sumi = __dp4a(ni, xi[j], sumi);
+        uint32_t nibbles = use_high ? ((qsw[j] >> 4) & 0x0F0F0F0Fu) : (qsw[j] & 0x0F0F0F0Fu);
+        sumi = __dp4a(static_cast<int>(nibbles), xi[j], sumi);
         q8_sum_int = __dp4a(xi[j], ones, q8_sum_int);
 
-        // Four consecutive elements l = j*4, j*4+1, j*4+2, j*4+3.
-        // Each reads qh[l] and extracts bit `sub`. Place the resulting
-        // 0/1 into bit 4 (→ value 16) of each byte of the 4-byte packed
-        // int, matching how ni was built from nibbles 0..15.
-        uint8_t b0 = qh[j * 4 + 0];
-        uint8_t b1 = qh[j * 4 + 1];
-        uint8_t b2 = qh[j * 4 + 2];
-        uint8_t b3 = qh[j * 4 + 3];
-        uint32_t hbits = (((b0 >> sub) & 1u) << 4) | (((b1 >> sub) & 1u) << 12) | (((b2 >> sub) & 1u) << 20) |
-                         (((b3 >> sub) & 1u) << 28);
-        int hi;
-        memcpy(&hi, &hbits, 4);
-        sumi_h = __dp4a(hi, xi[j], sumi_h);
+        // Four consecutive elements l = j*4 .. j*4+3 live in word qhw[j]
+        // (byte l%4). Each extracts bit `sub` and places the 0/1 into bit 4
+        // (→ value 16) of the corresponding byte, matching how `nibbles`
+        // was built from nibbles 0..15.
+        const uint32_t w = qhw[j];
+        uint32_t hbits = ((((w >> 0) >> sub) & 1u) << 4) | ((((w >> 8) >> sub) & 1u) << 12) |
+                         ((((w >> 16) >> sub) & 1u) << 20) | ((((w >> 24) >> sub) & 1u) << 28);
+        sumi_h = __dp4a(static_cast<int>(hbits), xi[j], sumi_h);
     }
 
     return dq * (d_super * (float)sc_val * (float)(sumi + sumi_h) -
@@ -278,13 +290,17 @@ struct DequantTraits<DPQTag::Q4_K> {
 
     static __device__ __forceinline__ float dp4a_block(const uint8_t* bp, int sub, const int* xi, float dq,
                                                        float /*q8_sum*/) {
-        float d_super = __half2float(*reinterpret_cast<const half*>(bp));
-        float dmin_super = __half2float(*reinterpret_cast<const half*>(bp + 2));
-        const uint8_t* sc = bp + 4;
+        // One LDG.128 for the whole 16-byte header (d, dmin, 12 scale
+        // bytes) instead of 2x LD.16 + per-byte scale loads (#598). The
+        // superblock is 16B-aligned (144 = 9*16).
+        const uint4 hdr = *reinterpret_cast<const uint4*>(bp);
+        const half2 dd = *reinterpret_cast<const half2*>(&hdr.x);
+        float d_super = __half2float(__low2half(dd));
+        float dmin_super = __half2float(__high2half(dd));
         const uint8_t* qs = bp + 16;
 
         uint8_t sc_val, min_val;
-        get_scale_min_k4(sc, sub, sc_val, min_val);
+        get_scale_min_k4_reg(hdr.y, hdr.z, hdr.w, sub, sc_val, min_val);
 
         return q4k_dp4a_sub(qs, sub, d_super, dmin_super, sc_val, min_val, xi, dq);
     }
@@ -302,14 +318,16 @@ struct DequantTraits<DPQTag::Q5_K> {
 
     static __device__ __forceinline__ float dp4a_block(const uint8_t* bp, int sub, const int* xi, float dq,
                                                        float /*q8_sum*/) {
-        float d_super = __half2float(*reinterpret_cast<const half*>(bp));
-        float dmin_super = __half2float(*reinterpret_cast<const half*>(bp + 2));
-        const uint8_t* sc = bp + 4;
+        // Header via one LDG.128 (#598); 176-byte superblock is 16B-aligned.
+        const uint4 hdr = *reinterpret_cast<const uint4*>(bp);
+        const half2 dd = *reinterpret_cast<const half2*>(&hdr.x);
+        float d_super = __half2float(__low2half(dd));
+        float dmin_super = __half2float(__high2half(dd));
         const uint8_t* qh = bp + 16;
         const uint8_t* qs = bp + 48;
 
         uint8_t sc_val, min_val;
-        get_scale_min_k4(sc, sub, sc_val, min_val);
+        get_scale_min_k4_reg(hdr.y, hdr.z, hdr.w, sub, sc_val, min_val);
 
         return q5k_dp4a_sub(qs, qh, sub, d_super, dmin_super, sc_val, min_val, xi, dq);
     }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -224,6 +224,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.nvfp4_decode_all = parse_bool(val, cfg.gemm.nvfp4_decode_all);
     else if (eq("gemm.nvfp4_lm_head"))
         cfg.gemm.nvfp4_lm_head = parse_bool(val, cfg.gemm.nvfp4_lm_head);
+    else if (eq("gemm.cublas_fp16_acc"))
+        cfg.gemm.cublas_fp16_acc = parse_bool(val, cfg.gemm.cublas_fp16_acc);
     else if (eq("gemm.nvfp4_lm_head_gdn"))
         cfg.gemm.nvfp4_lm_head_gdn = parse_bool(val, cfg.gemm.nvfp4_lm_head_gdn);
     else if (eq("gemm.nvfp4_ssm_proj"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -261,6 +261,18 @@ struct RuntimeConfig {
         // quality — see memory lm_head_only_nvfp4_qwen3_6_refuted). Legacy
         // env: IMP_NO_NVFP4_LM_HEAD=1 to disable.
         bool nvfp4_lm_head = true;
+        // FP16-accumulate cuBLAS prefill GEMMs (CUBLAS_COMPUTE_16F instead of
+        // 32F). GeForce sm_120 runs FP16 tensor cores with FP32 accumulate at
+        // 1/4 rate (measured 2026-06-07: 253 vs 1956 TFLOPS saturated
+        // mma.sync); the cuBLAS 32F prefill GEMMs sit at ~225 TFLOPS — ~89% of
+        // that quarter-rate ceiling, so the kernel is fine, the compute type
+        // is the cap. 16F measured ~2x kernel throughput on all prefill
+        // shapes (e.g. 512x17408x5120: 226→422 TFLOPS, B streamed from DRAM).
+        // Risk: f16 accumulator overflow/precision over long-K dots — keep
+        // default off until a perplexity A/B blesses it. Applies only to
+        // F16xF16→F16 with M>1 (prefill); decode GEMV and mixed-precision
+        // paths are untouched.
+        bool cublas_fp16_acc = false;
         // Allow NVFP4 LM head even on GDN/SSM-hybrid models (normally excluded —
         // an older NVFP4 method degraded recurrent-state coherence, memory
         // lm_head_only_nvfp4_qwen3_6_refuted). Quantified 2026-05-29 with the

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -25,6 +25,7 @@ struct ProcessDiag {
 
     // GEMM (may be promoted in place by engine_init_resolver)
     bool deterministic_gemm = false;
+    bool cublas_fp16_acc = false;
 
     // Attention
     bool attention_splitk_pipe = true;
@@ -69,6 +70,7 @@ void process_diag_install(const RuntimeConfig& cfg) {
     d.graph_capture_mode = cfg.runtime.graph_capture_mode;
     d.prefill_graph_enabled = cfg.runtime.prefill_graph;
     d.deterministic_gemm = cfg.runtime.deterministic_gemm;
+    d.cublas_fp16_acc = cfg.gemm.cublas_fp16_acc;
     d.attention_splitk_pipe = cfg.attention.splitk_pipe;
     d.attention_mxfp4_mode = cfg.attention.mxfp4;
     d.ffn_sparsity_probe = cfg.ffn.sparsity_probe;
@@ -96,6 +98,7 @@ bool process_diag_no_vision_graph() { return slot().no_vision_graph; }
 const std::string& process_diag_graph_capture_mode() { return slot().graph_capture_mode; }
 bool process_diag_prefill_graph_enabled() { return slot().prefill_graph_enabled; }
 bool process_diag_deterministic_gemm() { return slot().deterministic_gemm; }
+bool process_diag_cublas_fp16_acc() { return slot().cublas_fp16_acc; }
 void process_diag_set_deterministic_gemm(bool v) { slot().deterministic_gemm = v; }
 bool process_diag_attention_splitk_pipe() { return slot().attention_splitk_pipe; }
 const std::string& process_diag_attention_mxfp4_mode() { return slot().attention_mxfp4_mode; }

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -48,6 +48,9 @@ bool process_diag_prefill_graph_enabled();
 // the cache in place (replaces the former RuntimeConfig::install dual-write).
 bool process_diag_deterministic_gemm();
 void process_diag_set_deterministic_gemm(bool v);
+// FP16-accumulate cuBLAS prefill GEMMs (gemm.cublas_fp16_acc) — read by the
+// free-function gemm() in compute/gemm.cu, which carries no RuntimeConfig.
+bool process_diag_cublas_fp16_acc();
 
 // Attention
 bool process_diag_attention_splitk_pipe();

--- a/tests/bench/mma_peak_saturated.cu
+++ b/tests/bench/mma_peak_saturated.cu
@@ -1,0 +1,210 @@
+// =============================================================================
+// mma_peak_saturated.cu -- Saturated tensor-core peak microbench (sm_120a)
+// =============================================================================
+//
+// Measures the TRUE achievable mma.sync throughput per dtype: 8 warps/SM
+// with 4 independent accumulator chains per warp (ILP hides the MMA
+// pipeline latency). The older mxf4nvf4_mma_bench runs 1 warp/SM with a
+// serial accumulator dependency — that measures issue LATENCY, not peak
+// (it reads ~273 TOPS where saturation reaches ~2019).
+//
+// Calibration results (2026-06-07, RTX 5090 @ ~2.85 GHz boost under load):
+//   FP4  mxf4nvf4 block_scale : ~2019 TOPS  (datasheet 3354 — mma.sync
+//                               delivers HALF; 4096 ops/SM/clk, not 8192)
+//   FP16 f16acc               : ~1956 TFLOPS (= datasheet 838 * 2.85/2.407 —
+//                               methodology check, full rate confirmed)
+//   FP16 f32acc               : ~253 TFLOPS  (1/4 rate on GeForce)
+//   FP8  e4m3 f32acc          : ~496 TOPS    (1/4 rate on GeForce)
+//
+// These numbers feed tools/roofline/config.json flop_per_cycle (issues
+// #595/#596): roofline %s against the 3354/838 datasheet values understate
+// kernel quality by 2-4x for f32-accumulate / FP4 kernels.
+// =============================================================================
+
+#include "bench/mma_peak_saturated.h"
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace imp {
+
+namespace {
+
+constexpr int kBlocks = 170;          // 1 block/SM on RTX 5090
+constexpr int kWarpsPerBlock = 8;     // saturates the 4 TC schedulers
+constexpr int kChains = 4;            // independent accumulators (ILP)
+constexpr int kIterations = 1 << 14;  // per-chain MMA issues
+
+__global__ void peak_mxf4nvf4_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u, a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = threadIdx.x * 43u + 3u, a3 = threadIdx.x * 47u + 4u;
+    uint32_t b0 = threadIdx.x * 53u + 5u, b1 = threadIdx.x * 59u + 6u;
+    uint32_t sfa = 0x38383838u, sfb = 0x38383838u;  // UE4M3 ~1.0
+    constexpr uint16_t zid = 0;
+
+    float d0[kChains], d1[kChains], d2[kChains], d3[kChains];
+#pragma unroll
+    for (int c = 0; c < kChains; ++c) d0[c] = d1[c] = d2[c] = d3[c] = 0.0f;
+
+#if __CUDA_ARCH__ >= 1200
+#pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+#pragma unroll
+        for (int c = 0; c < kChains; ++c) {
+            asm volatile(
+                "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1."
+                "e2m1.f32.ue4m3 "
+                "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
+                "{%14}, {%15, %16}, {%17}, {%18, %19};\n"
+                : "=f"(d0[c]), "=f"(d1[c]), "=f"(d2[c]), "=f"(d3[c])
+                : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0[c]), "f"(d1[c]),
+                  "f"(d2[c]), "f"(d3[c]), "r"(sfa), "h"(zid), "h"(zid), "r"(sfb), "h"(zid), "h"(zid));
+        }
+    }
+#endif
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        float s = 0.0f;
+#pragma unroll
+        for (int c = 0; c < kChains; ++c) s += d0[c] + d1[c] + d2[c] + d3[c];
+        sink[0] = s;
+    }
+}
+
+__global__ void peak_fp16_f16acc_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u, a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = threadIdx.x * 43u + 3u, a3 = threadIdx.x * 47u + 4u;
+    uint32_t b0 = threadIdx.x * 53u + 5u, b1 = threadIdx.x * 59u + 6u;
+
+    uint32_t d0[kChains], d1[kChains];
+#pragma unroll
+    for (int c = 0; c < kChains; ++c) d0[c] = d1[c] = 0u;
+
+#pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+#pragma unroll
+        for (int c = 0; c < kChains; ++c) {
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+                "{%0, %1}, {%2, %3, %4, %5}, {%6, %7}, {%8, %9};\n"
+                : "=r"(d0[c]), "=r"(d1[c])
+                : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "r"(d0[c]), "r"(d1[c]));
+        }
+    }
+    if (threadIdx.x == 0 && blockIdx.x == 0)
+        sink[0] = static_cast<float>(d0[0] + d1[0]);
+}
+
+__global__ void peak_fp16_f32acc_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u, a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = threadIdx.x * 43u + 3u, a3 = threadIdx.x * 47u + 4u;
+    uint32_t b0 = threadIdx.x * 53u + 5u, b1 = threadIdx.x * 59u + 6u;
+
+    float d0[kChains], d1[kChains], d2[kChains], d3[kChains];
+#pragma unroll
+    for (int c = 0; c < kChains; ++c) d0[c] = d1[c] = d2[c] = d3[c] = 0.0f;
+
+#pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+#pragma unroll
+        for (int c = 0; c < kChains; ++c) {
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+                "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(d0[c]), "=f"(d1[c]), "=f"(d2[c]), "=f"(d3[c])
+                : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0[c]), "f"(d1[c]),
+                  "f"(d2[c]), "f"(d3[c]));
+        }
+    }
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        float s = 0.0f;
+#pragma unroll
+        for (int c = 0; c < kChains; ++c) s += d0[c] + d1[c] + d2[c] + d3[c];
+        sink[0] = s;
+    }
+}
+
+__global__ void peak_fp8_f32acc_kernel(int iterations, float* sink) {
+    uint32_t a0 = threadIdx.x * 37u + 1u, a1 = threadIdx.x * 41u + 2u;
+    uint32_t a2 = threadIdx.x * 43u + 3u, a3 = threadIdx.x * 47u + 4u;
+    uint32_t b0 = threadIdx.x * 53u + 5u, b1 = threadIdx.x * 59u + 6u;
+
+    float d0[kChains], d1[kChains], d2[kChains], d3[kChains];
+#pragma unroll
+    for (int c = 0; c < kChains; ++c) d0[c] = d1[c] = d2[c] = d3[c] = 0.0f;
+
+#if __CUDA_ARCH__ >= 890
+#pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+#pragma unroll
+        for (int c = 0; c < kChains; ++c) {
+            asm volatile(
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+                "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(d0[c]), "=f"(d1[c]), "=f"(d2[c]), "=f"(d3[c])
+                : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0[c]), "f"(d1[c]),
+                  "f"(d2[c]), "f"(d3[c]));
+        }
+    }
+#endif
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        float s = 0.0f;
+#pragma unroll
+        for (int c = 0; c < kChains; ++c) s += d0[c] + d1[c] + d2[c] + d3[c];
+        sink[0] = s;
+    }
+}
+
+// Best-of-3 reps of one kernel; returns effective ops/s across all warps.
+double run_peak(void (*kernel)(int, float*), double ops_per_mma, cudaStream_t stream) {
+    float* d_sink = nullptr;
+    if (cudaMalloc(&d_sink, sizeof(float)) != cudaSuccess)
+        return 0.0;
+
+    dim3 block(32 * kWarpsPerBlock);
+    kernel<<<kBlocks, block, 0, stream>>>(kIterations / 8, d_sink);  // warmup
+    cudaStreamSynchronize(stream);
+
+    cudaEvent_t s, e;
+    cudaEventCreate(&s);
+    cudaEventCreate(&e);
+    double best = 0.0;
+    for (int r = 0; r < 3; ++r) {
+        cudaEventRecord(s, stream);
+        kernel<<<kBlocks, block, 0, stream>>>(kIterations, d_sink);
+        cudaEventRecord(e, stream);
+        cudaEventSynchronize(e);
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, s, e);
+        double total_mmas = static_cast<double>(kBlocks) * kWarpsPerBlock * kChains * kIterations;
+        double tops = total_mmas * ops_per_mma / (ms * 1e-3) / 1e12;
+        if (tops > best)
+            best = tops;
+    }
+    cudaEventDestroy(s);
+    cudaEventDestroy(e);
+    cudaFree(d_sink);
+    return best;
+}
+
+}  // namespace
+
+MmaPeakResult bench_mma_peak_saturated(cudaStream_t stream) {
+    // Clock-ramp warmup >1s: idle downclock is the dominant cold-start
+    // artifact on this box (see benchmark methodology).
+    {
+        float* d_sink = nullptr;
+        cudaMalloc(&d_sink, sizeof(float));
+        for (int i = 0; i < 10; ++i)
+            peak_mxf4nvf4_kernel<<<kBlocks, 32 * kWarpsPerBlock, 0, stream>>>(kIterations, d_sink);
+        cudaStreamSynchronize(stream);
+        cudaFree(d_sink);
+    }
+
+    MmaPeakResult r{};
+    r.fp4_blockscale_tops = run_peak(peak_mxf4nvf4_kernel, 16384.0, stream);   // 16*8*64*2
+    r.fp16_f16acc_tflops = run_peak(peak_fp16_f16acc_kernel, 4096.0, stream);  // 16*8*16*2
+    r.fp16_f32acc_tflops = run_peak(peak_fp16_f32acc_kernel, 4096.0, stream);
+    r.fp8_f32acc_tops = run_peak(peak_fp8_f32acc_kernel, 8192.0, stream);      // 16*8*32*2
+    return r;
+}
+
+}  // namespace imp

--- a/tests/bench/mma_peak_saturated.h
+++ b/tests/bench/mma_peak_saturated.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace imp {
+
+struct MmaPeakResult {
+    double fp4_blockscale_tops;  // mxf4nvf4.block_scale m16n8k64, f32 acc
+    double fp16_f16acc_tflops;   // m16n8k16 f16.f16.f16.f16
+    double fp16_f32acc_tflops;   // m16n8k16 f32.f16.f16.f32
+    double fp8_f32acc_tops;      // m16n8k32 f32.e4m3.e4m3.f32
+};
+
+// SATURATED tensor-core peak per dtype: 8 warps/SM x 4 independent
+// accumulator chains (vs. mxf4nvf4_mma_bench's 1 warp/SM serial chain,
+// which is latency-bound and reads ~7x low). This is the empirical
+// compute-roofline ceiling used to calibrate tools/roofline/config.json
+// (issues #595/#596): on GeForce sm_120, f32 accumulate runs at 1/4 the
+// f16-accumulate rate, and the FP4 block-scale path peaks at HALF the
+// 3354-TOPS datasheet number (~2019 TOPS measured at ~2.85 GHz boost).
+MmaPeakResult bench_mma_peak_saturated(cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_gguf_dequant_ref.cu
+++ b/tests/test_gguf_dequant_ref.cu
@@ -166,6 +166,33 @@ void ref_dequant_q4_k(const uint8_t* blk, double* out) {
     }
 }
 
+// Q5_K: 176 bytes / 256 elems. [ d:f16 | dmin:f16 | scales:u8[12] | qh:u8[32] |
+// qs:u8[128] ]. Same 6-bit (scale,min) packing as Q4_K. The 5th bit of
+// element i lives in qh[i % 32] at bit position sub = i/32 (ggml
+// dequantize_row_q5_K). val = d*scale*(q4 + 16*bit) - dmin*min.
+void ref_dequant_q5_k(const uint8_t* blk, double* out) {
+    half d, dmin;
+    std::memcpy(&d, blk, 2);
+    std::memcpy(&dmin, blk + 2, 2);
+    const uint8_t* sc = blk + 4;
+    const uint8_t* qh = blk + 16;
+    const uint8_t* qs = blk + 48;
+    double dd = f16_to_f64(d);
+    double dm = f16_to_f64(dmin);
+    for (int i = 0; i < 256; ++i) {
+        int sub = i / 32;
+        uint8_t scv, mnv;
+        ref_get_scale_min_k4(sub, sc, scv, mnv);
+        int qs_byte = (i / 64) * 32 + (i % 32);
+        int use_high = (i / 32) & 1;
+        uint8_t packed = qs[qs_byte];
+        int q4 = use_high ? ((packed >> 4) & 0xF) : (packed & 0xF);
+        int q5 = q4 + (((qh[i % 32] >> sub) & 1) << 4);
+        out[i] = dd * static_cast<double>(scv) * static_cast<double>(q5) -
+                 dm * static_cast<double>(mnv);
+    }
+}
+
 // IQ4_NL: 18 bytes / 32 elems. [ d:f16 | qs:u8[16] ]. Non-linear 4-bit: the
 // nibble indexes a fixed signed codebook (ggml-common.h kvalues_iq4nl).
 // Element j (0..15) = low nibble of qs[j]; element j+16 = high nibble
@@ -279,6 +306,30 @@ void build_q4_k(std::vector<uint8_t>& buf, int N, int K, Lcg& g, ScaleMode mode)
         }
 }
 
+void build_q5_k(std::vector<uint8_t>& buf, int N, int K, Lcg& g, ScaleMode mode) {
+    int bpr = K / 256;
+    buf.resize((size_t)N * bpr * 176);
+    for (int r = 0; r < N; ++r)
+        for (int b = 0; b < bpr; ++b) {
+            uint8_t* bp = buf.data() + ((size_t)r * bpr + b) * 176;
+            half d = pick_d(g, mode);
+            half dmin = (mode == MAXMAG) ? f16_from_bits(0x7BFF)
+                                         : __float2half(0.002f + 0.01f * std::fabs(g.unit()));
+            if (mode == ZERO_D)
+                dmin = __float2half(0.0f);
+            if (mode == NAN_D)
+                dmin = f16_from_bits(0x7E00);
+            std::memcpy(bp, &d, 2);
+            std::memcpy(bp + 2, &dmin, 2);
+            for (int i = 0; i < 12; ++i)
+                bp[4 + i] = (mode == MAXMAG) ? 0xFF : g.byte();  // 6-bit scale fields
+            for (int i = 0; i < 32; ++i)
+                bp[16 + i] = g.byte();  // qh: 5th bits, full range
+            for (int i = 0; i < 128; ++i)
+                bp[48 + i] = g.byte();  // 4-bit quant nibbles
+        }
+}
+
 void build_iq4_nl(std::vector<uint8_t>& buf, int N, int K, Lcg& g, ScaleMode mode) {
     int bpr = K / 32;
     buf.resize((size_t)N * bpr * 18);
@@ -362,6 +413,11 @@ void ref_dequant_all(const std::vector<uint8_t>& buf, int N, int K, QType qt,
         for (int r = 0; r < N; ++r)
             for (int b = 0; b < bpr; ++b)
                 ref_dequant_iq4_xs(buf.data() + ((size_t)r * bpr + b) * 136, &out[(size_t)r * K + b * 256]);
+    } else if (qt == QType::Q5_K) {
+        int bpr = K / 256;
+        for (int r = 0; r < N; ++r)
+            for (int b = 0; b < bpr; ++b)
+                ref_dequant_q5_k(buf.data() + ((size_t)r * bpr + b) * 176, &out[(size_t)r * K + b * 256]);
     } else {  // Q4_K
         int bpr = K / 256;
         for (int r = 0; r < N; ++r)
@@ -632,6 +688,8 @@ void run_dp4a_gemv(const char* name, QType qt, int N, int K,
         build_q8_0(buf, N, K, g, NORMAL);
     else if (qt == QType::Q6_K)
         build_q6_k(buf, N, K, g, NORMAL);
+    else if (qt == QType::Q5_K)
+        build_q5_k(buf, N, K, g, NORMAL);
     else
         build_q4_k(buf, N, K, g, NORMAL);
     void* dW = to_device(buf);
@@ -724,6 +782,7 @@ void run_mmvq_gemv(const char* name, QType qt, int N, int K,
 TEST(GgufRef, Q8_0_GemvDp4a) { run_dp4a_gemv("Q8_0", QType::Q8_0, 256, 1024, gemv_q8_0_q8_1); }
 TEST(GgufRef, Q6_K_GemvDp4a) { run_dp4a_gemv("Q6_K", QType::Q6_K, 256, 1024, gemv_q6k_q8_1); }
 TEST(GgufRef, Q4_K_GemvDp4a) { run_dp4a_gemv("Q4_K", QType::Q4_K, 256, 1024, gemv_q4_k_q8_1); }
+TEST(GgufRef, Q5_K_GemvDp4a) { run_dp4a_gemv("Q5_K", QType::Q5_K, 256, 1024, gemv_q5_k_q8_1); }
 
 TEST(GgufRef, Q8_0_GemvMmvq) { run_mmvq_gemv("Q8_0", QType::Q8_0, 256, 1024, ggml_mmvq_q8_0); }
 TEST(GgufRef, Q4_K_GemvMmvq) { run_mmvq_gemv("Q4_K", QType::Q4_K, 256, 1024, ggml_mmvq_q4k); }

--- a/tests/test_mma_peak_saturated.cu
+++ b/tests/test_mma_peak_saturated.cu
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include "bench/mma_peak_saturated.h"
+#include <cuda_runtime.h>
+#include <cstdio>
+
+namespace imp {
+namespace {
+
+// Saturated TC peak calibration (issues #595/#596). Logs the measured
+// ceilings and asserts the two structural facts the roofline calibration
+// (tools/roofline/config.json flop_per_cycle) depends on:
+//   1. f32 accumulate runs at a fraction (~1/4) of the f16-accumulate rate
+//      on GeForce sm_120 — if a driver/HW change ever lifts this, the
+//      *_f32acc peaks (and the gemm.cublas_fp16_acc tradeoff) must be
+//      re-evaluated.
+//   2. The FP4 block-scale path lands far closer to half the 3354-TOPS
+//      datasheet number than to the full one.
+// Thresholds are deliberately loose (clock/host variance); this is a
+// calibration tripwire, not a perf gate.
+TEST(MmaPeakSaturatedTest, CalibrationInvariants) {
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+    MmaPeakResult r = bench_mma_peak_saturated(stream);
+    cudaStreamDestroy(stream);
+
+    std::printf("\n=== Saturated mma.sync peaks (170 blocks x 8 warps x 4 chains) ===\n");
+    std::printf("  FP4  mxf4nvf4 block_scale : %8.1f TOPS   (datasheet 3354)\n", r.fp4_blockscale_tops);
+    std::printf("  FP16 f16acc               : %8.1f TFLOPS (datasheet 838 @2.407GHz)\n",
+                r.fp16_f16acc_tflops);
+    std::printf("  FP16 f32acc               : %8.1f TFLOPS\n", r.fp16_f32acc_tflops);
+    std::printf("  FP8  e4m3 f32acc          : %8.1f TOPS\n\n", r.fp8_f32acc_tops);
+
+    ASSERT_GT(r.fp4_blockscale_tops, 0.0);
+    ASSERT_GT(r.fp16_f16acc_tflops, 0.0);
+
+    // (1) f32acc is a small fraction of f16acc (measured ~7.7x apart).
+    EXPECT_GT(r.fp16_f16acc_tflops, r.fp16_f32acc_tflops * 3.0)
+        << "f32-accumulate penalty vanished — recalibrate tools/roofline/config.json "
+           "and re-evaluate gemm.cublas_fp16_acc";
+
+    // (2) FP4 peak is ~half datasheet (measured ~2019 of 3354 at boost).
+    EXPECT_LT(r.fp4_blockscale_tops, 2700.0)
+        << "FP4 mma.sync exceeds half-datasheet band — recalibrate tc_fp4";
+    EXPECT_GT(r.fp4_blockscale_tops, 1500.0) << "FP4 peak collapsed vs 2026-06-07 calibration (2019 TOPS)";
+}
+
+}  // namespace
+}  // namespace imp

--- a/tools/roofline/config.json
+++ b/tools/roofline/config.json
@@ -1,5 +1,5 @@
 {
-  "config_version": 2,
+  "config_version": 3,
   "comment": "Pinned roofline measurement config. Changing counters/shapes bumps config_version \u2014 runs are only comparable within the same version.",
   "gpu": {
     "name": "NVIDIA GeForce RTX 5090 (GB202, sm_120a)",
@@ -7,14 +7,17 @@
     "dram_peak_gbs": 1792.0,
     "nominal_boost_ghz": 2.407,
     "flop_per_cycle": {
-      "comment": "GPU-wide dense math ops per SM-clock cycle. peak_flops(dtype) = flop_per_cycle * measured_sm_clock_hz. Calibrated so tc_fp16*2.407GHz = 838 TFLOPS, tc_fp8 = 1677, tc_fp4 = 3354 (datasheet peaks).",
+      "comment": "GPU-wide dense math ops per SM-clock cycle. peak_flops(dtype) = flop_per_cycle * measured_sm_clock_hz. CALIBRATED EMPIRICALLY 2026-06-07 (saturated mma.sync microbench, issues #595/#596): tc_fp16 f16acc hits the 838-TFLOPS datasheet rate (170 SM x 2048 ops/clk), but (a) FP32 accumulate runs at 1/4 rate on GeForce (tc_*_f32acc keys; fp16 f32acc measured 253 TFLOPS @2.85GHz = 512 ops/SM/clk, fp8 f32acc 496 = 1024), and (b) the mxf4nvf4 block-scale FP4 path peaks at HALF the 3354-TOPS datasheet number (measured 2019 TOPS @2.85GHz = 4096 ops/SM/clk) - 3354 is not reachable via mma.sync on sm_120a. dst_fp32 ncu counters map to the *_f32acc keys in rl_classify.TC_OPS_METRICS.",
       "tc_fp16": 348160,
       "tc_bf16": 348160,
       "tc_fp8": 696320,
-      "tc_fp4": 1392640,
+      "tc_fp4": 696320,
       "tc_int8": 696320,
       "cuda_fp32": 43520,
-      "cuda_fp16": 87040
+      "cuda_fp16": 87040,
+      "tc_fp16_f32acc": 87040,
+      "tc_bf16_f32acc": 87040,
+      "tc_fp8_f32acc": 174080
     }
   },
   "ncu": {

--- a/tools/roofline/rl_classify.py
+++ b/tools/roofline/rl_classify.py
@@ -2,16 +2,20 @@
 math itself lives in rl_table (it joins multiple ncu metric groups). stdlib only."""
 import re
 
-# tensor ops-path counter -> dtype peak key
+# tensor ops-path counter -> dtype peak key.
+# dst_fp32 maps to a *_f32acc peak: GeForce sm_120 runs FP16/FP8 tensor cores
+# with FP32 accumulate at 1/4 of the f16-accumulate rate (measured 2026-06-07,
+# saturated mma.sync microbench: fp16 f16acc 1956 vs f32acc 253 TFLOPS,
+# fp8 f32acc 496 TOPS — see issue #595/#596 calibration).
 TC_OPS_METRICS = {
     "sm__ops_path_tensor_src_fp4_dst_fp32.sum": "tc_fp4",
     "sm__ops_path_tensor_src_fp4_fp6_dst_fp16.sum": "tc_fp4",
     "sm__ops_path_tensor_src_fp4_fp6_dst_fp32.sum": "tc_fp4",
     "sm__ops_path_tensor_src_fp8_dst_fp16.sum": "tc_fp8",
-    "sm__ops_path_tensor_src_fp8_dst_fp32.sum": "tc_fp8",
+    "sm__ops_path_tensor_src_fp8_dst_fp32.sum": "tc_fp8_f32acc",
     "sm__ops_path_tensor_src_fp16_dst_fp16.sum": "tc_fp16",
-    "sm__ops_path_tensor_src_fp16_dst_fp32.sum": "tc_fp16",
-    "sm__ops_path_tensor_src_bf16_dst_fp32.sum": "tc_bf16",
+    "sm__ops_path_tensor_src_fp16_dst_fp32.sum": "tc_fp16_f32acc",
+    "sm__ops_path_tensor_src_bf16_dst_fp32.sum": "tc_bf16_f32acc",
     "sm__ops_path_tensor_src_int8.sum": "tc_int8",
 }
 # SASS thread-inst counters -> (flops per inst, dtype key). HFMA2/packed-half


### PR DESCRIPTION
Addresses #598 (gemv_dp4a_gguf at 42% BW, 72%/44% decode window).

## Analysis

The dp4a K-par GEMV kernels are **L1TEX-instruction-bound**, not DRAM-bound (audit raw data: L1 hit 98.7%, DRAM 42%, occupancy ~51%). The weight side issued eight 4-byte loads per 32-byte qs slice plus per-byte scale loads — all on provably 16B-aligned addresses (Q4_K superblock 144 = 9×16, Q5_K 176 = 11×16, GGUF tensor alignment 32).

## Change

- `q4k_dp4a_sub`: qs slice → two LDG.128 (was 8× LDG.32)
- `q5k_dp4a_sub`: qs + the 32-byte qh → four LDG.128 with register byte-extracts (was 16× LDG.32 + 32 byte-loads)
- Q4_K/Q5_K `dp4a_block`: 16-byte header (d, dmin, scales) → one LDG.128; new `get_scale_min_k4_reg` unpacks from registers

## Measured

| | base | new |
|---|---:|---:|
| Qwen3-30B-A3B Q4_K_M tg256 (10 reps, time-adjacent) | 276.0 | **283.4 (+2.7%)** |
| PPL (4824 tok, 2 runs each) | 1.1183 / 1.1201 | 1.1210 / 1.1181 — same jitter band |

Numerics: `GgufRef` dp4a-vs-fp64 suite green (Q4_K max_rel 1.2e-2 in the q8_1-activation band). **New: Q5_K dp4a reference coverage** (`build_q5_k` + `ref_dequant_q5_k` + `Q5_K_GemvDp4a`) — Q5_K previously had no dp4a test at all.

## Structural ceiling (rest of #598)

Further vectorization is blocked by the **36-byte `block_q8_1` activation layout** (qs at offset 4 — never 16B-aligned, so the activation side stays 8× LDG.32 per block; fixing it means an SoA repack of the quantized-activation pipeline). Combined with the Q4_K superblock unpack cost this mirrors the refuted NVFP4-GEMV plateau (4-bit dequant co-limit). The big lever for Q4_K models remains the existing `gemm.nvfp4_decode_all` opt-in (documented +82% on Gemma-3-12B). Details in the issue close-out comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)