### PR TITLE
perf(gemm): cublas_fp16_acc default-on via per-arch auto — +26% dense GGUF prefill

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -177,10 +177,12 @@ nvfp4_attn_proj      = false
 nvfp4_moe_decode     = true
 # FP16-accumulate cuBLAS prefill GEMMs (CUBLAS_COMPUTE_16F). GeForce sm_120
 # runs FP32-accumulate tensor cores at 1/4 rate, so 32F caps prefill at
-# ~225 TFLOPS; 16F doubles kernel throughput (Qwen3-8B Q8_0 pp512 +17%,
-# PPL flat). Gemma-3-12B measured +0.7% PPL — hence opt-in. Decode (M=1)
-# is unaffected.
-cublas_fp16_acc      = false
+# ~225 TFLOPS; 16F roughly doubles GEMM throughput (Qwen3-8B Q8_0 pp512
+# +24.9% measured 2026-06-07, PPL flat, decode neutral). auto (default) =
+# ON per arch except Gemma-3/4 (+0.7% PPL measured) and gpt-oss
+# (f16-overflow sensitivity); on = force everywhere; off = always 32F.
+# Decode (M=1) is unaffected.
+cublas_fp16_acc      = auto
 
 # [gemma4] section moved out of the global RuntimeConfig in Phase 5
 # Track A of the architecture refactor. These are now per-model

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -224,8 +224,13 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.nvfp4_decode_all = parse_bool(val, cfg.gemm.nvfp4_decode_all);
     else if (eq("gemm.nvfp4_lm_head"))
         cfg.gemm.nvfp4_lm_head = parse_bool(val, cfg.gemm.nvfp4_lm_head);
-    else if (eq("gemm.cublas_fp16_acc"))
-        cfg.gemm.cublas_fp16_acc = parse_bool(val, cfg.gemm.cublas_fp16_acc);
+    else if (eq("gemm.cublas_fp16_acc")) {
+        // tri-state auto|on|off; legacy bool spellings stay valid
+        if (val == "auto" || val == "on" || val == "off")
+            cfg.gemm.cublas_fp16_acc = val;
+        else
+            cfg.gemm.cublas_fp16_acc = parse_bool(val, false) ? "on" : "off";
+    }
     else if (eq("gemm.nvfp4_lm_head_gdn"))
         cfg.gemm.nvfp4_lm_head_gdn = parse_bool(val, cfg.gemm.nvfp4_lm_head_gdn);
     else if (eq("gemm.nvfp4_ssm_proj"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -266,13 +266,17 @@ struct RuntimeConfig {
         // 1/4 rate (measured 2026-06-07: 253 vs 1956 TFLOPS saturated
         // mma.sync); the cuBLAS 32F prefill GEMMs sit at ~225 TFLOPS — ~89% of
         // that quarter-rate ceiling, so the kernel is fine, the compute type
-        // is the cap. 16F measured ~2x kernel throughput on all prefill
-        // shapes (e.g. 512x17408x5120: 226→422 TFLOPS, B streamed from DRAM).
-        // Risk: f16 accumulator overflow/precision over long-K dots — keep
-        // default off until a perplexity A/B blesses it. Applies only to
+        // is the cap. 16F measured +24.9% q8 pp512 model-level (2026-06-07,
+        // paired same-day restarts), decode neutral. "auto" (default) enables
+        // it per-arch at engine init: ON except GEMMA3/GEMMA4 (measured +0.7%
+        // PPL on gemma-3-12b) and GPT_OSS (known FP16-residual-overflow
+        // sensitivity — f16 accumulators are the same hazard class). "on"
+        // forces it everywhere, "off" restores 32F accumulate. Legacy bool
+        // values (true/false/1/0) parse as on/off. Applies only to
         // F16xF16→F16 with M>1 (prefill); decode GEMV and mixed-precision
-        // paths are untouched.
-        bool cublas_fp16_acc = false;
+        // paths are untouched. Standalone tools that skip engine init treat
+        // "auto" as off.
+        std::string cublas_fp16_acc = "auto";
         // Allow NVFP4 LM head even on GDN/SSM-hybrid models (normally excluded —
         // an older NVFP4 method degraded recurrent-state coherence, memory
         // lm_head_only_nvfp4_qwen3_6_refuted). Quantified 2026-05-29 with the

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -176,6 +176,22 @@ void Engine::init_resolve_fp8_prefill_() {
 void Engine::init_resolve_quant_flags_() {
     const auto& mcfg = model_->config();
     // --- Resolve auto-detection flags ---
+
+    // gemm.cublas_fp16_acc=auto → per-arch default. GeForce sm_120 quarters
+    // FP32-accumulate FP16 tensor-core rate (PR #606 calibration); 16F
+    // accumulate restores full rate (+24.9% q8 pp512 measured 2026-06-07,
+    // decode neutral, PPL flat on Qwen3-8B). Denied per measurement/risk:
+    // Gemma-3/4 (+0.7% PPL on gemma-3-12b) and gpt-oss (documented FP16
+    // residual-overflow sensitivity — f16 accumulators are the same hazard
+    // class). "on"/"off" bypass this and were applied at install time.
+    if (runtime_config_.gemm.cublas_fp16_acc == "auto") {
+        const bool deny = (mcfg.arch == ModelArch::GEMMA3 || mcfg.arch == ModelArch::GEMMA4 ||
+                           mcfg.arch == ModelArch::GPT_OSS);
+        process_diag_set_cublas_fp16_acc(!deny);
+        IMP_LOG_INFO("cuBLAS FP16-accumulate prefill: auto → %s (arch=%s)", deny ? "OFF" : "ON",
+                     model_arch_name(mcfg.arch));
+    }
+
     // NVFP4 decode mode
     int n_gdn_auto = 0;
     for (int i = 0; i < mcfg.n_layers; i++)

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -70,7 +70,10 @@ void process_diag_install(const RuntimeConfig& cfg) {
     d.graph_capture_mode = cfg.runtime.graph_capture_mode;
     d.prefill_graph_enabled = cfg.runtime.prefill_graph;
     d.deterministic_gemm = cfg.runtime.deterministic_gemm;
-    d.cublas_fp16_acc = cfg.gemm.cublas_fp16_acc;
+    // "auto" resolves per-arch at engine init (init_resolve_quant_flags_ →
+    // process_diag_set_cublas_fp16_acc); standalone tools without an engine
+    // treat auto as off.
+    d.cublas_fp16_acc = (cfg.gemm.cublas_fp16_acc == "on");
     d.attention_splitk_pipe = cfg.attention.splitk_pipe;
     d.attention_mxfp4_mode = cfg.attention.mxfp4;
     d.ffn_sparsity_probe = cfg.ffn.sparsity_probe;
@@ -99,6 +102,7 @@ const std::string& process_diag_graph_capture_mode() { return slot().graph_captu
 bool process_diag_prefill_graph_enabled() { return slot().prefill_graph_enabled; }
 bool process_diag_deterministic_gemm() { return slot().deterministic_gemm; }
 bool process_diag_cublas_fp16_acc() { return slot().cublas_fp16_acc; }
+void process_diag_set_cublas_fp16_acc(bool v) { slot().cublas_fp16_acc = v; }
 void process_diag_set_deterministic_gemm(bool v) { slot().deterministic_gemm = v; }
 bool process_diag_attention_splitk_pipe() { return slot().attention_splitk_pipe; }
 const std::string& process_diag_attention_mxfp4_mode() { return slot().attention_mxfp4_mode; }

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -50,7 +50,11 @@ bool process_diag_deterministic_gemm();
 void process_diag_set_deterministic_gemm(bool v);
 // FP16-accumulate cuBLAS prefill GEMMs (gemm.cublas_fp16_acc) — read by the
 // free-function gemm() in compute/gemm.cu, which carries no RuntimeConfig.
+// "auto" (default) is resolved per-arch by init_resolve_quant_flags_ via the
+// setter (ON except Gemma-3/4 and gpt-oss); install() maps auto → off so
+// engine-less tools keep 32F accumulate.
 bool process_diag_cublas_fp16_acc();
+void process_diag_set_cublas_fp16_acc(bool v);
 
 // Attention
 bool process_diag_attention_splitk_pipe();

--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -2,20 +2,20 @@
   "schema_version": "legacy-v1",
   "model": "Qwen3-8B-Q8_0.gguf",
   "gpu": "NVIDIA GeForce RTX 5090",
-  "cuda": "unknown",
+  "cuda": "13.3",
   "vram_total_mb": 32607,
-  "timestamp": "2026-06-04T22:52:45Z",
+  "timestamp": "2026-06-07T15:33:17Z",
   "methodology": "median of 5 trials × 5 reps, 15s cooldown between trials (cuBLAS algo drift resistant)",
   "reps": 5,
   "n_trials": 5,
   "metrics": {
     "prefill_tps": {
-      "pp128": 3602.66,
-      "pp512": 8221.54,
-      "pp4096": 9781.29
+      "pp128": 3858.32,
+      "pp512": 10649.22,
+      "pp4096": 13691.02
     },
     "decode_tps": {
-      "tg128": 268.42
+      "tg128": 284.82
     },
     "memory_mb": {
       "model_weights": 8320


### PR DESCRIPTION
## Summary

Executes lever #2 from the prefill gap analysis (#608): GeForce sm_120 quarters the FP32-accumulate FP16 TC rate (253 vs 1956 TFLOPS, #606 calibration). `gemm.cublas_fp16_acc` becomes **tri-state `auto|on|off`** (legacy bool spellings parse), default `auto` = ON per arch except **GEMMA3/GEMMA4** (+0.7 % PPL measured historically) and **GPT_OSS** (documented f16 residual-overflow sensitivity). Resolution happens at engine init (`init_resolve_quant_flags_`, log-verified); engine-less tools treat auto as off.

## Validation

**PPL (deterministic-GEMM arms — bit-stable on Qwen, reproducible to 4 decimals):**

| Model | off | auto (ON) | Δ |
|---|---:|---:|---|
| Qwen3-8B Q8_0 | 31.165 | 31.167 | +0.006 % (flat) |
| Qwen3-14B Q6_K | 30.413 | 30.361 | **−0.17 % (better)** |
| Qwen3-30B-A3B Q4_K_M | 31.699 | 31.576 | **−0.39 % (better)** |
| gemma-3-12b / gpt-oss-20b | — | auto→OFF (deny, log-verified) | n/a |

Caveat documented: gemma-3-12b and gpt-oss show ~1 % PPL run-noise between code-identical runs even under `deterministic_gemm` (gemma-3 = #514-class instability) — deny kept on historical evidence + conservatism.

**Bench (2 restarts, clocks sampled healthy 2790/13818/541 W):**

| Model | pp512 before | pp512 after | decode |
|---|---:|---:|---|
| Qwen3-8B Q8_0 | 8 401/8 422 | **10 593/10 634 (+26 %)** | 274.6 (neutral) |
| Qwen3-14B Q6_K | 5 278/5 247 | **6 617/6 586 (+25 %)** — now **above llama.cpp (6 522)** | 154.2 (neutral, off-arm identical; #610 investigated+closed as host variance) |
| Qwen3-30B-A3B Q4_K_M | 3 903/3 884 | 3 976/3 974 (+2 % — cuBLAS is only ~30 % of the MoE window; the dequant tax is #599/IMMA territory) | 283.6 (neutral) |

Gap vs llama.cpp (same-day head-to-head from #608): dense Q8 **1.63× → 1.29×**, dense Q6_K **1.24× → 0.99× (parity/win)**.

**`tests/perf_baseline.json` refreshed** (cold-median, 5 trials, healthy-host day, intentional perf move): pp512 10 649, pp4096 13 691, tg128 284.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)