### PR TITLE
perf(gemm): Q8_0 INT8 IMMA prefill GEMM — fused dequant on int8 tensor cores (opt-in)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/hadamard.cu
     src/compute/mmq_q4k_imma_layout.cu
     src/compute/mmq_q4k_imma_tile.cu
+    src/compute/mmq_q8_imma.cu
     src/compute/mmq_q4k_hmma.cu
 )
 
@@ -545,6 +546,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mmq_q4k_imma_bench.cu
         tests/test_mmq_q4k_imma_tile_bench.cu
         tests/test_mmq_q4k_imma_gemm.cu
+        tests/test_mmq_q8_imma.cu
         tests/test_mmq_q4k_hmma.cu
         tests/test_weight_dispatch.cu
     )

--- a/src/compute/mmq_q8_imma.cu
+++ b/src/compute/mmq_q8_imma.cu
@@ -1,0 +1,379 @@
+// =============================================================================
+// mmq_q8_imma.cu — Q8_0 INT8 IMMA prefill GEMM (sm_120a)
+// =============================================================================
+//
+// See mmq_q8_imma.h for the design rationale (phase-2B ceiling fixes: SMEM-
+// staged scales, 128×128×64 tiles, symmetric epilogue). Reuses the activation
+// quantizer from the Q4_K IMMA stack (quantize_fp16_to_int8_subblock).
+
+#include "compute/mmq_q8_imma.h"
+#include "core/logging.h"
+
+#include <cstring>
+#include <mutex>
+#include <unordered_map>
+
+namespace imp {
+
+namespace {
+
+constexpr int kBM = 128;
+constexpr int kBN = 128;
+constexpr int kBK = 64;  // 2 sub-blocks per K-step
+constexpr int kPad = 16;  // smem row pad (bytes): 80-B stride = conflict-free rl-lane access
+constexpr int kRow = kBK + kPad;
+constexpr int kStages = 2;
+constexpr int kWarpsM = 4;
+constexpr int kWarpsN = 2;
+constexpr int kThreads = kWarpsM * kWarpsN * 32;  // 256
+constexpr int kWarpTileM = kBM / kWarpsM;          // 32 → 2 m16 frags
+constexpr int kWarpTileN = kBN / kWarpsN;          // 64 → 8 n8 frags
+constexpr int kMF = kWarpTileM / 16;               // 2
+constexpr int kNF = kWarpTileN / 8;                // 8
+
+__device__ __forceinline__ void cp_async_cg_16(void* smem, const void* glob, bool valid) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    int src_size = valid ? 16 : 0;  // src-size 0 → zero-fill (OOB M-tail rows)
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;\n" ::"r"(s), "l"(glob),
+                 "r"(src_size));
+}
+__device__ __forceinline__ void cp_async_ca_4(void* smem, const void* glob, bool valid) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    int src_size = valid ? 4 : 0;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 4, %2;\n" ::"r"(s), "l"(glob),
+                 "r"(src_size));
+}
+__device__ __forceinline__ void cp_async_commit() {
+    asm volatile("cp.async.commit_group;\n");
+}
+template <int N>
+__device__ __forceinline__ void cp_async_wait_group() {
+    asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
+}
+
+// One K-step tile load, all 256 threads cooperating:
+//   A  [kBM][kBK] s8 = 8192 B → 32 B/thread (2 × cp16), M-tail rows zero-filled
+//   B  [kBN][kBK] s8 = 8192 B → 32 B/thread (2 × cp16)
+//   Ad [kBM][2] half = 512 B → first 128 threads, 4 B each (d-plane cols
+//      (kb0, kb0+1) are contiguous and 4-B aligned: kb0 is even)
+//   Bd [kBN][2] half = 512 B → next 128 threads
+__device__ __forceinline__ void load_kstep(int tid, const int8_t* __restrict__ A,
+                                           const int8_t* __restrict__ Ad_src,
+                                           const int8_t* __restrict__ B,
+                                           const int8_t* __restrict__ Bd_src,
+                                           int8_t (*sA)[kRow], int8_t (*sB)[kRow],
+                                           __half (*sAd)[2], __half (*sBd)[2], int base_m, int M,
+                                           int K, int subs, int k_base) {
+    {
+        // A: row = tid/2 in 0..127, col = (tid&1)*32 + {0,16}
+        const int row = tid >> 1;
+        const int col = (tid & 1) * 32;
+        const bool valid = (base_m + row) < M;
+        const int8_t* src = A + static_cast<size_t>(base_m + row) * K + k_base + col;
+        cp_async_cg_16(&sA[row][col], src, valid);
+        cp_async_cg_16(&sA[row][col + 16], src + 16, valid);
+    }
+    {
+        // B: weight rows are always full (N % kBN == 0 gate)
+        const int row = tid >> 1;
+        const int col = (tid & 1) * 32;
+        const int8_t* src = B + static_cast<size_t>(row) * K + k_base + col;  // B pre-offset to base_n
+        cp_async_cg_16(&sB[row][col], src, true);
+        cp_async_cg_16(&sB[row][col + 16], src + 16, true);
+    }
+    {
+        const int kb0 = k_base / 32;
+        if (tid < kBM) {
+            const bool valid = (base_m + tid) < M;
+            const __half* src = reinterpret_cast<const __half*>(Ad_src) +
+                                static_cast<size_t>(base_m + tid) * subs + kb0;
+            cp_async_ca_4(&sAd[tid][0], src, valid);
+        } else if (tid < kBM + kBN) {
+            const int row = tid - kBM;
+            const __half* src =
+                reinterpret_cast<const __half*>(Bd_src) + static_cast<size_t>(row) * subs + kb0;
+            cp_async_ca_4(&sBd[row][0], src, true);
+        }
+    }
+}
+
+// out[M,N] = (or +=, BETA1) per-block-scaled IMMA over [kBM,kBN] tiles.
+template <bool BETA1>
+__global__ void __launch_bounds__(kThreads)
+    mmq_q8_imma_kernel(const int8_t* __restrict__ X_s8, const __half* __restrict__ x_scale,
+                       const int8_t* __restrict__ W_s8, const __half* __restrict__ w_d,
+                       __half* __restrict__ out, int M, int N, int K) {
+    const int n_block = blockIdx.x;
+    const int m_block = blockIdx.y;
+    const int base_m = m_block * kBM;
+    const int base_n = n_block * kBN;
+    if (base_m >= M) return;
+
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+    const int warp_m = warp_id >> 1;  // 0..3
+    const int warp_n = warp_id & 1;   // 0..1
+    const int rl = lane >> 2;         // 0..7
+    const int cl = lane & 3;          // 0..3
+
+    __shared__ int8_t sA[kStages][kBM][kRow];
+    __shared__ int8_t sB[kStages][kBN][kRow];
+    __shared__ __half sAd[kStages][kBM][2];
+    __shared__ __half sBd[kStages][kBN][2];
+
+    float acc[kMF][kNF][4];
+#pragma unroll
+    for (int i = 0; i < kMF; ++i)
+#pragma unroll
+        for (int j = 0; j < kNF; ++j)
+            acc[i][j][0] = acc[i][j][1] = acc[i][j][2] = acc[i][j][3] = 0.0f;
+
+    const int subs = K / 32;
+    const int ksteps = K / kBK;
+    const int8_t* B_base = W_s8 + static_cast<size_t>(base_n) * K;
+    const int8_t* Bd_base = reinterpret_cast<const int8_t*>(w_d + static_cast<size_t>(base_n) * subs);
+    const int8_t* Ad_base = reinterpret_cast<const int8_t*>(x_scale);
+
+    load_kstep(tid, X_s8, Ad_base, B_base, Bd_base, sA[0], sB[0], sAd[0], sBd[0], base_m, M, K,
+               subs, 0);
+    cp_async_commit();
+
+    for (int ks = 0; ks < ksteps; ++ks) {
+        const int stage = ks & 1;
+        if (ks + 1 < ksteps) {
+            const int nstage = (ks + 1) & 1;
+            load_kstep(tid, X_s8, Ad_base, B_base, Bd_base, sA[nstage], sB[nstage], sAd[nstage],
+                       sBd[nstage], base_m, M, K, subs, (ks + 1) * kBK);
+            cp_async_commit();
+            cp_async_wait_group<1>();
+        } else {
+            cp_async_wait_group<0>();
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int kb = 0; kb < 2; ++kb) {  // 2 sub-blocks per K-step
+            const int kc = kb * 32;
+#pragma unroll
+            for (int mf = 0; mf < kMF; ++mf) {
+                const int arow_lo = warp_m * kWarpTileM + mf * 16 + rl;
+                const int arow_hi = arow_lo + 8;
+                const int acol = kc + cl * 4;
+                uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol]);
+                uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol]);
+                uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol + 16]);
+                uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol + 16]);
+                // d_a for this fragment's two rows, hoisted over all 8 n-frags
+                const float da_lo = __half2float(sAd[stage][arow_lo][kb]);
+                const float da_hi = __half2float(sAd[stage][arow_hi][kb]);
+
+#pragma unroll
+                for (int nf = 0; nf < kNF; ++nf) {
+                    const int bcol = warp_n * kWarpTileN + nf * 8 + rl;
+                    const int bk = kc + cl * 4;
+                    uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[stage][bcol][bk]);
+                    uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[stage][bcol][bk + 16]);
+
+                    int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+#if __CUDA_ARCH__ >= 800
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+                        : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "r"(0), "r"(0),
+                          "r"(0), "r"(0));
+#endif
+                    // c0,c1 = rows (rl) cols (cl*2, cl*2+1); c2,c3 = rows (rl+8)
+                    const int ncol_lo = warp_n * kWarpTileN + nf * 8 + cl * 2;
+                    const float dw_lo = __half2float(sBd[stage][ncol_lo][kb]);
+                    const float dw_hi = __half2float(sBd[stage][ncol_lo + 1][kb]);
+                    acc[mf][nf][0] += (da_lo * dw_lo) * static_cast<float>(c0);
+                    acc[mf][nf][1] += (da_lo * dw_hi) * static_cast<float>(c1);
+                    acc[mf][nf][2] += (da_hi * dw_lo) * static_cast<float>(c2);
+                    acc[mf][nf][3] += (da_hi * dw_hi) * static_cast<float>(c3);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    // Epilogue: FP16 store, M-tail predicated (N is a multiple of kBN).
+#pragma unroll
+    for (int mf = 0; mf < kMF; ++mf) {
+        const int row_lo = base_m + warp_m * kWarpTileM + mf * 16 + rl;
+        const int row_hi = row_lo + 8;
+#pragma unroll
+        for (int nf = 0; nf < kNF; ++nf) {
+            const int col = base_n + warp_n * kWarpTileN + nf * 8 + cl * 2;
+            if (row_lo < M) {
+                __half2* p = reinterpret_cast<__half2*>(&out[static_cast<size_t>(row_lo) * N + col]);
+                __half2 v = __floats2half2_rn(acc[mf][nf][0], acc[mf][nf][1]);
+                *p = BETA1 ? __hadd2(*p, v) : v;
+            }
+            if (row_hi < M) {
+                __half2* p = reinterpret_cast<__half2*>(&out[static_cast<size_t>(row_hi) * N + col]);
+                __half2 v = __floats2half2_rn(acc[mf][nf][2], acc[mf][nf][3]);
+                *p = BETA1 ? __hadd2(*p, v) : v;
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Q8_0 SoA split: raw 34-B blocks {half d; int8 qs[32]} (2-aligned! memcpy
+// only) → qs plane [N][K] s8 + d plane [N][K/32] half. One-time per weight.
+// -----------------------------------------------------------------------------
+__global__ void q8_split_kernel(const uint8_t* __restrict__ src, int8_t* __restrict__ qs_plane,
+                                __half* __restrict__ d_plane, int n_blocks_total, int subs) {
+    const int b = blockIdx.x * blockDim.x + threadIdx.x;
+    if (b >= n_blocks_total) return;
+    const uint8_t* blk = src + static_cast<size_t>(b) * 34;
+    __half d;
+    memcpy(&d, blk, 2);
+    d_plane[b] = d;
+    int8_t* dst = qs_plane + static_cast<size_t>(b) * 32;
+#pragma unroll
+    for (int i = 0; i < 32; ++i) dst[i] = static_cast<int8_t>(blk[2 + i]);
+    (void)subs;
+}
+
+// Faster activation quantizer than the shared 32-thread-block version
+// (quantize_fp16_to_int8_subblock): same math, but 8 warps per block with a
+// grid-stride loop over (m, sub) pairs — the shared kernel's 65k 32-thread
+// blocks cap SM occupancy and ran at ~150 GB/s (32.5 µs per 512×4096 GEMM,
+// nsys 2026-06-07); this version is plain-coalesced and occupancy-bound.
+__global__ void quantize_act_fast_kernel(const __half* __restrict__ X, int M, int K,
+                                         int8_t* __restrict__ xs8, __half* __restrict__ xscale) {
+    const int subs = K / 32;
+    const int total = M * subs;
+    const int lane = threadIdx.x & 31;
+    const int warp = (blockIdx.x * (blockDim.x >> 5)) + (threadIdx.x >> 5);
+    const int nwarps = gridDim.x * (blockDim.x >> 5);
+    for (int idx = warp; idx < total; idx += nwarps) {
+        const int m = idx / subs;
+        const int s = idx - m * subs;
+        const size_t off = static_cast<size_t>(m) * K + s * 32;
+        const float v = __half2float(X[off + lane]);
+        float amax = fabsf(v);
+#pragma unroll
+        for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFu, amax, o));
+        const float inv = (amax > 0.0f) ? (127.0f / amax) : 0.0f;
+        int q = __float2int_rn(v * inv);
+        q = max(-127, min(127, q));
+        xs8[off + lane] = static_cast<int8_t>(q);
+        if (lane == 0)
+            xscale[static_cast<size_t>(m) * subs + s] =
+                __float2half((amax > 0.0f) ? (amax / 127.0f) : 0.0f);
+    }
+}
+
+struct WeightPlanes {
+    int8_t* qs = nullptr;
+    __half* d = nullptr;
+    int N = 0;
+    int K = 0;
+};
+struct ActScratch {
+    int8_t* xs8 = nullptr;
+    __half* xscale = nullptr;
+    size_t cap_mk = 0;
+    size_t cap_msubs = 0;
+};
+
+std::mutex g_mtx;
+std::unordered_map<const void*, WeightPlanes> g_weights;
+ActScratch g_act;
+
+bool stream_capturing(cudaStream_t stream) {
+    cudaStreamCaptureStatus st = cudaStreamCaptureStatusNone;
+    return cudaStreamIsCapturing(stream, &st) == cudaSuccess &&
+           st == cudaStreamCaptureStatusActive;
+}
+
+bool ensure_weight(const void* src, int N, int K, cudaStream_t stream, bool capturing) {
+    auto it = g_weights.find(src);
+    if (it != g_weights.end() && it->second.N == N && it->second.K == K) return true;
+    if (capturing) return false;  // never allocate inside graph capture
+
+    WeightPlanes w;
+    w.N = N;
+    w.K = K;
+    if (cudaMalloc(&w.qs, static_cast<size_t>(N) * K) != cudaSuccess) return false;
+    if (cudaMalloc(&w.d, static_cast<size_t>(N) * (K / 32) * sizeof(__half)) != cudaSuccess) {
+        cudaFree(w.qs);
+        return false;
+    }
+    const int total = N * (K / 32);
+    q8_split_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
+        static_cast<const uint8_t*>(src), w.qs, w.d, total, K / 32);
+    g_weights[src] = w;
+    return true;
+}
+
+bool ensure_act(int M, int K, bool capturing) {
+    const size_t mk = static_cast<size_t>(M) * K;
+    const size_t msubs = static_cast<size_t>(M) * (K / 32);
+    if (g_act.xs8 && g_act.cap_mk >= mk && g_act.cap_msubs >= msubs) return true;
+    if (capturing) return false;
+    if (g_act.xs8) {
+        cudaFree(g_act.xs8);
+        cudaFree(g_act.xscale);
+        g_act = ActScratch{};
+    }
+    if (cudaMalloc(&g_act.xs8, mk) != cudaSuccess) return false;
+    if (cudaMalloc(&g_act.xscale, msubs * sizeof(__half)) != cudaSuccess) return false;
+    g_act.cap_mk = mk;
+    g_act.cap_msubs = msubs;
+    return true;
+}
+
+}  // namespace
+
+bool mmq_q8_imma_gemm(const void* w_q8_blocks, const __half* x_f16, __half* out_f16, int M, int N,
+                      int K, cudaStream_t stream, float beta) {
+    if (M < 64 || N % kBN != 0 || K % kBK != 0) return false;
+    if (beta != 0.0f && beta != 1.0f) return false;
+
+    std::lock_guard<std::mutex> lk(g_mtx);
+    const bool capturing = stream_capturing(stream);
+    if (!ensure_weight(w_q8_blocks, N, K, stream, capturing)) return false;
+    if (!ensure_act(M, K, capturing)) return false;
+
+    {
+        const int total_warps_needed = M * (K / 32);
+        const int blocks = min(2048, (total_warps_needed + 7) / 8);
+        quantize_act_fast_kernel<<<blocks, 256, 0, stream>>>(x_f16, M, K, g_act.xs8, g_act.xscale);
+    }
+
+    const auto& w = g_weights[w_q8_blocks];
+    dim3 grid(N / kBN, (M + kBM - 1) / kBM);
+    if (beta == 1.0f)
+        mmq_q8_imma_kernel<true><<<grid, kThreads, 0, stream>>>(g_act.xs8, g_act.xscale, w.qs, w.d,
+                                                                out_f16, M, N, K);
+    else
+        mmq_q8_imma_kernel<false><<<grid, kThreads, 0, stream>>>(g_act.xs8, g_act.xscale, w.qs,
+                                                                 w.d, out_f16, M, N, K);
+    static bool logged = false;
+    if (!logged) {
+        logged = true;
+        IMP_LOG_INFO("Q8_0 IMMA prefill ACTIVE (M=%d N=%d K=%d, tile 128x128x64, 8 warps)", M, N, K);
+    }
+    return true;
+}
+
+void mmq_q8_imma_release_all() {
+    std::lock_guard<std::mutex> lk(g_mtx);
+    for (auto& [_, w] : g_weights) {
+        cudaFree(w.qs);
+        cudaFree(w.d);
+    }
+    g_weights.clear();
+    if (g_act.xs8) {
+        cudaFree(g_act.xs8);
+        cudaFree(g_act.xscale);
+        g_act = ActScratch{};
+    }
+}
+
+}  // namespace imp

--- a/src/compute/mmq_q8_imma.h
+++ b/src/compute/mmq_q8_imma.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace imp {
+
+// Q8_0 INT8 IMMA prefill GEMM — fused dequant on int8 tensor cores.
+//
+// Sibling of the Q4_K IMMA stack (mmq_q4k_imma_tile.*), redesigned against
+// the 2026-05-18 phase-2B ceiling diagnosis (40 TOPS plateau). The three
+// structural fixes over that kernel:
+//   1. Per-sub-block scales are cp.async-staged in SMEM with the data tiles —
+//      the 2B kernel paid 8 GLOBAL loads per MMA for x_scale/α/β/rowsum.
+//   2. BLOCK 128×128×64, 8 warps, 32×64 warp tile → 128 MMAs per CTA per
+//      K-step with ONE __syncthreads pair (2B: 16 MMAs per 2 syncs).
+//   3. Q8_0 is symmetric (w = d·q): the epilogue is a pure
+//      (d_a·d_w)·s32 FMA — no β·rowsum correction term at all.
+//
+// Math:  out[m,n] = Σ_kb  d_a[m,kb] · d_w[n,kb] · Σ_{k∈kb} X_s8[m,k]·W_s8[n,k]
+// (kb = 32-wide sub-block = one m16n8k32 IMMA per fragment; measured
+// saturated s8.s8.s32 peak on this silicon: 968 TOPS — full rate.)
+//
+// Weight planes ([N][K] s8 + [N][K/32] half d) are split out of the raw GGUF
+// Q8_0 block stream once per weight pointer and cached. Activation s8 planes
+// are grow-only scratch. Both allocations are capture-guarded: a cache miss
+// during CUDA-graph capture declines (returns false) instead of allocating —
+// the warmup prefill populates the caches before capture.
+
+// Attempt out[M,N] (FP16, row-major) = x[M,K]·W^T (beta=0) or += (beta=1)
+// from the raw Q8_0 block stream (34-B blocks, [N][K/32]).
+// Declines (returns false, output untouched) when: M < 64, N % 128 != 0,
+// K % 64 != 0, beta ∉ {0,1}, capture-guarded cache miss, or allocation
+// failure.
+bool mmq_q8_imma_gemm(const void* w_q8_blocks, const __half* x_f16, __half* out_f16, int M, int N,
+                      int K, cudaStream_t stream, float beta = 0.0f);
+
+// Free cached weight planes + activation scratch (tests / teardown).
+void mmq_q8_imma_release_all();
+
+}  // namespace imp

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -18,6 +18,7 @@
 #include "quant/nvfp4_gemm.h"
 #include "quant/mxfp4_gemm.h"
 #include "compute/ggml_mmvq.h"
+#include "compute/mmq_q8_imma.h"
 #include "exec/gemm_kernel_q4k_hmma.h"
 #include "compute/hadamard.h"
 #include "runtime/pdl.h"
@@ -1855,6 +1856,21 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
     // path below as before.
     if (M > 1 && h.source_data != nullptr && dequant_gpu_supported(h.source_qtype) &&
         (h.primary_tier == StorageTier::CUTLASS_NVFP4 || h.primary_tier == StorageTier::NVFP4)) {
+        // Q8_0 INT8 IMMA fast path (gemm.q8_imma_enabled, default off): fused
+        // dequant on the int8 tensor cores instead of the materialize-to-FP16
+        // → cuBLAS round-trip (the dominant Q8_0 prefill tax, see
+        // docs/audit/prefill_gap_2026_06_07.md §4.1). Covers beta=0 and the
+        // beta=1 residual-add form; declines (shape / capture-guard) fall
+        // through to the dequant fallback below.
+        if (ctx.q8_imma_enabled && h.source_qtype == QType::Q8_0 && input.qtype == QType::F16 &&
+            output.qtype == QType::F16 && M >= 64 && input.stride[0] == h.shape[1] &&
+            output.stride[0] == h.shape[0]) {
+            if (mmq_q8_imma_gemm(h.source_data, reinterpret_cast<const __half*>(input.data),
+                                 reinterpret_cast<__half*>(output.data), M,
+                                 static_cast<int>(h.shape[0]), static_cast<int>(h.shape[1]),
+                                 ctx.stream, ctx.beta))
+                return;
+        }
         Tensor weight(const_cast<void*>(h.source_data), h.source_qtype, 2, h.shape, true);
         gemm_dispatch_uncached_fallback(input, weight, output, ctx);
         return;

--- a/src/exec/gemm_context.h
+++ b/src/exec/gemm_context.h
@@ -36,6 +36,7 @@ struct GemmContext {
     // Wired by the executor's GemmContext::make caller from runtime_config().
     bool q4k_imma_enabled = false;
     bool q4k_hmma_enabled = false;
+    bool q8_imma_enabled = false;
     bool gemm_no_mmvq = false;
     bool gemm_no_mmvq_q8_0 = false;
     bool gemm_no_dp4a_gemv = false;
@@ -58,6 +59,7 @@ struct GemmContext {
         ctx.force_mmvq = force_mmvq;
         ctx.q4k_imma_enabled = rcfg.gemm.q4k_imma_enabled;
         ctx.q4k_hmma_enabled = rcfg.gemm.q4k_hmma_enabled;
+        ctx.q8_imma_enabled = rcfg.gemm.q8_imma_enabled;
         ctx.gemm_no_mmvq = rcfg.gemm.no_mmvq;
         ctx.gemm_no_mmvq_q8_0 = rcfg.gemm.no_mmvq_q8_0;
         ctx.gemm_no_dp4a_gemv = rcfg.gemm.no_dp4a_gemv;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -220,6 +220,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.q4k_imma_enabled = parse_bool(val, cfg.gemm.q4k_imma_enabled);
     else if (eq("gemm.q4k_hmma_enabled"))
         cfg.gemm.q4k_hmma_enabled = parse_bool(val, cfg.gemm.q4k_hmma_enabled);
+    else if (eq("gemm.q8_imma_enabled"))
+        cfg.gemm.q8_imma_enabled = parse_bool(val, cfg.gemm.q8_imma_enabled);
     else if (eq("gemm.nvfp4_decode_all"))
         cfg.gemm.nvfp4_decode_all = parse_bool(val, cfg.gemm.nvfp4_decode_all);
     else if (eq("gemm.nvfp4_lm_head"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -246,6 +246,13 @@ struct RuntimeConfig {
         // m16n8k16 tile kernel. Phase 0 scaffold (default off). When enabled,
         // prefill (M >= 32) Q4_K weights bypass dequant-to-FP16 + cuBLAS.
         bool q4k_hmma_enabled = false;
+        // Q8_0 INT8 IMMA prefill GEMM (mmq_q8_imma.cu): fused dequant on the
+        // int8 tensor cores (s8.s8.s32 measured 968 TOPS — full rate, unlike
+        // the quartered f32-accumulate paths). Replaces the dequant-to-FP16 →
+        // cuBLAS round-trip for Q8_0 prefill (M ≥ 64). Redesigned against the
+        // Q4_K-IMMA phase-2B ceiling diagnosis (SMEM-staged scales, 128x128x64
+        // tiles, symmetric epilogue). Experimental: default off.
+        bool q8_imma_enabled = false;
         // Extend NVFP4 decode cache to ALL quantized types (Q4_K, Q3_K, etc.),
         // not just the default Q8_0/Q6_K/Q5_K set. Trades VRAM for decode
         // throughput on sub-8-bit models (e.g. Gemma-3-12B Q4_K_M: dp4a GEMV

--- a/tests/test_mmq_q8_imma.cu
+++ b/tests/test_mmq_q8_imma.cu
@@ -1,0 +1,202 @@
+// Reference-parity test for mmq_q8_imma_gemm — the Q8_0 INT8 IMMA prefill
+// GEMM. Two-level verification:
+//   1. EXACT-MODEL reference: the CPU reference reproduces the device math
+//      at the algorithm level (same activation quantize — per-32-block
+//      amax/127, rn-round, ±127 clamp — and the same per-block d_a·d_w·s32
+//      fixup in double). NOT bit-exact: the Release build compiles the
+//      device quantizer's 127/amax with --use_fast_math (div.approx.f32),
+//      so a near-tie activation element can quantize ±1 LSB differently
+//      from the CPU model — worth up to ~|xscale·dw·127| ≈ 1% of one
+//      output. Tolerance covers that plus fp32 accumulation order.
+//   2. UNQUANTIZED sanity: against the plain dequant GEMM (no activation
+//      quant) with a loose tolerance — bounds the activation-quant error
+//      the path introduces end-to-end.
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "compute/mmq_q8_imma.h"
+
+namespace imp {
+namespace {
+
+constexpr int kBlk = 32;
+constexpr int kBlockBytes = 34;  // half d + 32 s8
+
+void gen_q8_weight(std::vector<uint8_t>& W, int N, int K, unsigned seed) {
+    ASSERT_EQ(K % kBlk, 0);
+    const int bpr = K / kBlk;
+    W.resize(static_cast<size_t>(N) * bpr * kBlockBytes);
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<int> qd(-127, 127);
+    std::uniform_real_distribution<float> dd(0.001f, 0.05f);
+    for (size_t b = 0; b < W.size() / kBlockBytes; ++b) {
+        uint8_t* bp = W.data() + b * kBlockBytes;
+        __half d = __float2half(dd(rng));
+        std::memcpy(bp, &d, 2);
+        for (int i = 0; i < 32; ++i) bp[2 + i] = static_cast<uint8_t>(static_cast<int8_t>(qd(rng)));
+    }
+}
+
+// CPU model of the device activation quantizer (quantize_fp16_to_int8_subblock).
+void quant_act_cpu(const std::vector<__half>& x, int M, int K, std::vector<int8_t>& xs8,
+                   std::vector<float>& xscale) {
+    const int subs = K / kBlk;
+    xs8.assign(static_cast<size_t>(M) * K, 0);
+    xscale.assign(static_cast<size_t>(M) * subs, 0.0f);
+    for (int m = 0; m < M; ++m) {
+        for (int s = 0; s < subs; ++s) {
+            float amax = 0.0f;
+            for (int i = 0; i < kBlk; ++i)
+                amax = std::fmax(amax, std::fabs(__half2float(x[(size_t)m * K + s * kBlk + i])));
+            const float inv = (amax > 0.0f) ? 127.0f / amax : 0.0f;
+            const float scale = (amax > 0.0f) ? amax / 127.0f : 0.0f;
+            // device stores the scale as half — model that rounding
+            xscale[(size_t)m * subs + s] = __half2float(__float2half(scale));
+            for (int i = 0; i < kBlk; ++i) {
+                float v = __half2float(x[(size_t)m * K + s * kBlk + i]);
+                int q = static_cast<int>(std::nearbyint(v * inv));
+                q = std::max(-127, std::min(127, q));
+                xs8[(size_t)m * K + s * kBlk + i] = static_cast<int8_t>(q);
+            }
+        }
+    }
+}
+
+void run_case(int M, int N, int K, unsigned seed, float tol_exact, float tol_unquant) {
+    std::vector<uint8_t> W;
+    gen_q8_weight(W, N, K, seed);
+
+    std::vector<__half> x(static_cast<size_t>(M) * K);
+    std::mt19937 rng(seed * 7 + 1);
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+    for (auto& v : x) v = __float2half(nd(rng));
+
+    // device
+    uint8_t* d_w = nullptr;
+    __half *d_x = nullptr, *d_out = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_w, W.size()), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_x, x.size() * sizeof(__half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_out, static_cast<size_t>(M) * N * sizeof(__half)), cudaSuccess);
+    cudaMemcpy(d_w, W.data(), W.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, x.data(), x.size() * sizeof(__half), cudaMemcpyHostToDevice);
+
+    ASSERT_TRUE(mmq_q8_imma_gemm(d_w, d_x, d_out, M, N, K, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    std::vector<__half> out(static_cast<size_t>(M) * N);
+    cudaMemcpy(out.data(), d_out, out.size() * sizeof(__half), cudaMemcpyDeviceToHost);
+
+    // CPU references
+    std::vector<int8_t> xs8;
+    std::vector<float> xscale;
+    quant_act_cpu(x, M, K, xs8, xscale);
+    const int subs = K / kBlk;
+
+    // Exact-model check: per-output relative error (denominator floored at
+    // the output RMS so near-zero outputs don't divide by ~0). Unquantized
+    // check: NORMALIZED RMS error — activation-quant noise on individual
+    // small outputs has heavy tails (cancellation), the energy ratio is the
+    // meaningful end-to-end bound.
+    double err2_exact = 0.0, err2_unq = 0.0, ref2 = 0.0, max_rel_exact = 0.0;
+    std::vector<double> exact_buf, unq_buf, got_buf;
+    std::mt19937 pick(seed * 13 + 5);
+    const int rows_to_check = std::min(M, 16);
+    for (int rc = 0; rc < rows_to_check; ++rc) {
+        const int m = (rows_to_check == M) ? rc : static_cast<int>(pick() % M);
+        for (int n = 0; n < N; ++n) {
+            double acc_exact = 0.0, acc_unq = 0.0;
+            for (int s = 0; s < subs; ++s) {
+                const uint8_t* bp =
+                    W.data() + (static_cast<size_t>(n) * subs + s) * kBlockBytes;
+                __half dh;
+                std::memcpy(&dh, bp, 2);
+                const double dw = __half2float(dh);
+                const int8_t* wq = reinterpret_cast<const int8_t*>(bp + 2);
+                long isum = 0;
+                double unq = 0.0;
+                for (int i = 0; i < kBlk; ++i) {
+                    isum += static_cast<long>(xs8[(size_t)m * K + s * kBlk + i]) * wq[i];
+                    unq += static_cast<double>(__half2float(x[(size_t)m * K + s * kBlk + i])) *
+                           (dw * wq[i]);
+                }
+                acc_exact += static_cast<double>(xscale[(size_t)m * subs + s]) * dw *
+                             static_cast<double>(isum);
+                acc_unq += unq;
+            }
+            const double got = __half2float(out[(size_t)m * N + n]);
+            exact_buf.push_back(acc_exact);
+            unq_buf.push_back(acc_unq);
+            got_buf.push_back(got);
+            ref2 += acc_unq * acc_unq;
+        }
+    }
+    const double ref_rms = std::sqrt(ref2 / static_cast<double>(unq_buf.size()));
+    for (size_t i = 0; i < got_buf.size(); ++i) {
+        const double de = std::fabs(got_buf[i] - exact_buf[i]);
+        max_rel_exact = std::max(max_rel_exact, de / std::max(ref_rms, std::fabs(exact_buf[i])));
+        err2_exact += de * de;
+        const double du = got_buf[i] - unq_buf[i];
+        err2_unq += du * du;
+    }
+    const double nrmse_unq = std::sqrt(err2_unq / static_cast<double>(got_buf.size())) /
+                             std::max(ref_rms, 1e-30);
+    if (max_rel_exact >= tol_exact) {
+        // dump the worst output for diagnosis
+        size_t wi = 0;
+        double wv = 0.0;
+        for (size_t i = 0; i < got_buf.size(); ++i) {
+            const double r = std::fabs(got_buf[i] - exact_buf[i]) /
+                             std::max(ref_rms, std::fabs(exact_buf[i]));
+            if (r > wv) {
+                wv = r;
+                wi = i;
+            }
+        }
+        fprintf(stderr, "WORST idx=%zu (row-slot %zu, n=%zu): got=%f exact=%f unq=%f ref_rms=%f\n",
+                wi, wi / N, wi % N, got_buf[wi], exact_buf[wi], unq_buf[wi], ref_rms);
+    }
+    EXPECT_LT(max_rel_exact, tol_exact) << "M=" << M << " N=" << N << " K=" << K;
+    EXPECT_LT(nrmse_unq, tol_unquant) << "M=" << M << " N=" << N << " K=" << K
+                                      << " ref_rms=" << ref_rms;
+
+    cudaFree(d_w);
+    cudaFree(d_x);
+    cudaFree(d_out);
+    mmq_q8_imma_release_all();
+}
+
+TEST(MmqQ8Imma, Square128) { run_case(128, 128, 64, 42, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, PrefillChunkShape) { run_case(512, 128, 256, 43, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, QkvLikeShape) { run_case(512, 1024, 4096, 44, 15e-3f, 1e-2f); }
+TEST(MmqQ8Imma, MTail) { run_case(313, 256, 128, 45, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, MTailNoTail320) { run_case(320, 256, 128, 45, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, MTailSeed47) { run_case(313, 256, 128, 47, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, MTailBigK) { run_case(313, 256, 1024, 45, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, M64Min) { run_case(64, 128, 64, 46, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, DeclineShapes) {
+    // N not multiple of 128 / K not multiple of 64 / M < 64 → false
+    std::vector<uint8_t> W;
+    gen_q8_weight(W, 64, 64, 1);
+    uint8_t* d_w = nullptr;
+    __half *d_x = nullptr, *d_out = nullptr;
+    cudaMalloc(&d_w, W.size());
+    cudaMalloc(&d_x, 64 * 64 * sizeof(__half));
+    cudaMalloc(&d_out, 64 * 64 * sizeof(__half));
+    EXPECT_FALSE(mmq_q8_imma_gemm(d_w, d_x, d_out, 63, 128, 64, nullptr));   // M
+    EXPECT_FALSE(mmq_q8_imma_gemm(d_w, d_x, d_out, 64, 64, 64, nullptr));    // N
+    EXPECT_FALSE(mmq_q8_imma_gemm(d_w, d_x, d_out, 64, 128, 32, nullptr));   // K
+    cudaFree(d_w);
+    cudaFree(d_x);
+    cudaFree(d_out);
+    mmq_q8_imma_release_all();
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Summary

Phase 1 of the IMMA prefill track (#608 lever #1): a fused `s8.s8.s32` `mma.sync` prefill GEMM for Q8_0, replacing the dequant-to-FP16 → cuBLAS round-trip (the ~30 %-of-window Q8 prefill tax). **Q8_0 weights are native int8 — the unpack tax that capped the forge/Q4_K-IMMA experiments does not exist here.** Opt-in via `gemm.q8_imma_enabled` (default off).

## Measured (Qwen3-8B Q8_0, vs the new `cublas_fp16_acc` default-on baseline from #611)

| | baseline | IMMA | Δ |
|---|---:|---:|---|
| pp512 | 10 611 | **11 426 / 11 391** | **+7.4 %** |
| pp2048 | ~10 000 | **10 887** | **+10 %** |
| decode tg256 | 274.4 | 274.1 | neutral |
| PPL (teacher-forced, deterministic) | 31.1670 | **31.1547** | **−0.04 % — activation s8-quant is free at Q8 precision** |

Cumulative same-day gap vs llama.cpp (13.7k): 1.63× (morning) → 1.29× (#611) → **1.20×**.

## Kernel design — vs the 2026-05-18 Q4_K-IMMA phase-2B ceiling (40 TOPS)

- **Per-sub-block scales cp.async-staged in SMEM** — the 2B kernel paid 8 *global* loads per MMA for scales; that (not the FP fixup) was its real ceiling.
- 128×128×64 tiles, 8 warps: 256 MMAs per CTA per K-step between ONE `__syncthreads` pair (2B: 16 per 2).
- **+16 B SMEM row pad**: the 64-B row stride aliased banks — measured 28.3 M conflicts on 18.5 M loads → 0.
- Symmetric Q8_0 epilogue (pure `(d_a·d_w)·s32` FMA, no β·rowsum); β=0 **and** β=1 residual-add covered (first cut left 38 % of GEMMs on the dequant path).
- Weight SoA split (qs plane + d plane, same footprint as source) cached per pointer, **capture-guarded** (declines under graph capture; warmup populates).
- Activation quantizer: 8-warp grid-stride (shared 32-thread version ran 32.5 µs/GEMM → ~7 µs).
- INT8 ceiling measured this session: **968 TOPS saturated** (full rate — not f32acc-quartered).

## Refuted (documented in-code)

- **3-stage cp.async: −21 %** (stage-pointer arrays spill to local; matches the 2B.4 finding) — reverted.
- Fast-math `div.approx` causes ±1-LSB activation-quantize ties vs the CPU reference — test tolerance documents it.

## Verification

- 9/9 `MmqQ8Imma` reference-parity tests (exact-model CPU reference + NRMSE bound vs unquantized GEMM)
- PPL gate (above), long-context degeneration check coherent, decode neutral, graphs-ON throughout
- `make verify-fast` green (pre-push hook)

## Known headroom (Phase 2)

Kernel sits at ~240 effective TOPS of the 968 peak: 184 regs → 1 CTA/SM (barrier + long-scoreboard stalls), ldmatrix operand fetch untried here, BK=128. Q4_K/Q6_K unpack variants + MoE grouped (the 2.4–2.6× gap) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)