### PR TITLE
perf(gemm): Q4_K raw-read IMMA MoE prefill — 30B-MoE GGUF gap 2.4× → 1.05× (opt-in)

### DIFF
--- a/src/compute/mmq_q8_imma.cu
+++ b/src/compute/mmq_q8_imma.cu
@@ -14,7 +14,6 @@
 // to Q4_K's collapsed (q-8)+dmin terms, see mmq_q4k_imma_layout.h).
 
 #include "compute/mmq_q8_imma.h"
-#include "compute/mmq_q4k_imma_layout.h"
 #include "core/logging.h"
 
 #include <cstring>
@@ -257,6 +256,243 @@ __global__ void __launch_bounds__(kThreads)
 }
 
 // -----------------------------------------------------------------------------
+// Q4_K RAW-read kernel: reads the GGUF 144-B super-blocks directly — zero
+// extra weight VRAM (the plane-repack variant duplicated all expert weights
+// and hit the 32-GB wall on Qwen3-30B MoE: pp512 8x SLOWER under UVM
+// paging). One 64-wide K-step = exactly one 32-byte nibble group per B row
+// (sub-block pair = low/high nibbles of the same bytes), so the B-fragment
+// fetch is one u32 load + shift/mask/vsub4. The (α, β) scale pairs are
+// computed from the staged 16-B block headers in a cooperative pass after
+// the tile lands (α = d·sc6, β = 8·α − dmin·m6; algebra identical to the
+// mmq_q4k_imma_reorder form, see mmq_q4k_imma_layout.h).
+// -----------------------------------------------------------------------------
+
+__device__ __forceinline__ void q4k_scale_min(int j, const uint8_t* q, uint32_t& sc,
+                                              uint32_t& mn) {
+    if (j < 4) {
+        sc = q[j] & 63u;
+        mn = q[j + 4] & 63u;
+    } else {
+        sc = (q[j + 4] & 0xFu) | ((q[j - 4] >> 6) << 4);
+        mn = (q[j + 4] >> 4) | ((q[j - 0] >> 6) << 4);
+    }
+}
+
+constexpr int kQRow = 32 + 16;  // staged qs row: 32 B group + 16-B pad (bank stride 12 words)
+
+template <int BM>
+__device__ __forceinline__ void load_kstep_q4k(int tid, const int8_t* __restrict__ A,
+                                               const __half* __restrict__ Asc,
+                                               const float* __restrict__ Ars,
+                                               const uint8_t* __restrict__ Wq4k, int base_n,
+                                               int N, int sblk_count, int8_t (*sA)[kRow],
+                                               uint8_t (*sBq)[kQRow], uint8_t (*sBh)[16],
+                                               __half (*sAsc)[2], float (*sArs)[2], int base_m,
+                                               int M, int K, int subs, int k_base) {
+#pragma unroll
+    for (int i = tid; i < BM * 4; i += kThreads) {
+        const int row = i >> 2;
+        const int col = (i & 3) * 16;
+        const bool valid = (base_m + row) < M;
+        cp_async_cg_16(&sA[row][col],
+                       A + static_cast<size_t>(base_m + row) * K + k_base + col, valid);
+    }
+    const int ks = k_base / kBK;
+    const int sblk = ks >> 2;          // super-block index along K
+    const int grp = ks & 3;            // 32-byte nibble group within it
+#pragma unroll
+    for (int i = tid; i < kBN * 3; i += kThreads) {
+        const int row = i / 3;
+        const int part = i % 3;
+        const uint8_t* blk = Wq4k + (static_cast<size_t>(base_n + row) * sblk_count + sblk) * 144;
+        if (part == 0) {
+            cp_async_cg_16(&sBh[row][0], blk, true);  // d, dmin, 12-B scales
+        } else {
+            const int off = (part - 1) * 16;
+            cp_async_cg_16(&sBq[row][off], blk + 16 + grp * 32 + off, true);
+        }
+    }
+    const int kb0 = k_base / 32;
+#pragma unroll
+    for (int i = tid; i < BM; i += kThreads) {
+        const bool valid = (base_m + i) < M;
+        cp_async_ca_4(&sAsc[i][0], Asc + static_cast<size_t>(base_m + i) * subs + kb0, valid);
+        cp_async_ca_8(&sArs[i][0], Ars + static_cast<size_t>(base_m + i) * subs + kb0, valid);
+    }
+}
+
+template <int BM, bool BETA1>
+__global__ void __launch_bounds__(kThreads)
+    mmq_imma_q4k_raw_kernel(const int8_t* __restrict__ X_s8, const __half* __restrict__ x_scale,
+                            const float* __restrict__ x_rowsum, const uint8_t* __restrict__ Wq4k,
+                            __half* __restrict__ out, int M, int N, int K,
+                            const int32_t* __restrict__ expert_offsets, size_t w_stride_blocks) {
+    constexpr int kWM = (BM == 128) ? 4 : 2;
+    constexpr int kWN = (BM == 128) ? 2 : 4;
+    constexpr int kTileM = BM / kWM;
+    constexpr int kTileN = kBN / kWN;
+    constexpr int kMF = kTileM / 16;
+    constexpr int kNF = kTileN / 8;
+
+    int rows = M;
+    size_t row_off = 0;
+    const int e = blockIdx.z;
+    if (expert_offsets != nullptr) {
+        const int32_t o0 = __ldg(&expert_offsets[e]);
+        const int32_t o1 = __ldg(&expert_offsets[e + 1]);
+        row_off = static_cast<size_t>(o0);
+        rows = o1 - o0;
+    }
+    const int base_m = blockIdx.y * BM;
+    const int base_n = blockIdx.x * kBN;
+    if (base_m >= rows || rows == 0) return;
+
+    const int subs = K / 32;
+    const int sblk_count = K / 256;
+    const int8_t* A = X_s8 + row_off * K;
+    const __half* Asc = x_scale + row_off * subs;
+    const float* Ars = x_rowsum + row_off * subs;
+    const uint8_t* W = Wq4k + static_cast<size_t>(e) * w_stride_blocks * 144;
+    __half* C = out + row_off * N;
+
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+    const int warp_m = warp_id / kWN;
+    const int warp_n = warp_id % kWN;
+    const int rl = lane >> 2;
+    const int cl = lane & 3;
+
+    __shared__ int8_t sA[kStages][BM][kRow];
+    __shared__ uint8_t sBq[kStages][kBN][kQRow];
+    __shared__ uint8_t sBh[kStages][kBN][16];
+    __shared__ __half sAsc[kStages][BM][2];
+    __shared__ float sArs[kStages][BM][2];
+    __shared__ __half2 sBab[kStages][kBN][2];  // (α, β) per (col, kb)
+
+    float acc[kMF][kNF][4];
+#pragma unroll
+    for (int i = 0; i < kMF; ++i)
+#pragma unroll
+        for (int j = 0; j < kNF; ++j)
+            acc[i][j][0] = acc[i][j][1] = acc[i][j][2] = acc[i][j][3] = 0.0f;
+
+    const int ksteps = K / kBK;
+    load_kstep_q4k<BM>(tid, A, Asc, Ars, W, base_n, N, sblk_count, sA[0], sBq[0], sBh[0],
+                       sAsc[0], sArs[0], base_m, rows, K, subs, 0);
+    cp_async_commit();
+
+    for (int ks = 0; ks < ksteps; ++ks) {
+        const int stage = ks & 1;
+        if (ks + 1 < ksteps) {
+            const int nstage = (ks + 1) & 1;
+            load_kstep_q4k<BM>(tid, A, Asc, Ars, W, base_n, N, sblk_count, sA[nstage],
+                               sBq[nstage], sBh[nstage], sAsc[nstage], sArs[nstage], base_m, rows,
+                               K, subs, (ks + 1) * kBK);
+            cp_async_commit();
+            cp_async_wait_group<1>();
+        } else {
+            cp_async_wait_group<0>();
+        }
+        __syncthreads();
+
+        // header → (α, β) cooperative pass: one thread per (col, kb)
+        {
+            const int j0 = (2 * ks) & 7;  // sub-block within the super-block
+#pragma unroll
+            for (int i = tid; i < kBN * 2; i += kThreads) {
+                const int row = i >> 1;
+                const int kb = i & 1;
+                const uint8_t* h = &sBh[stage][row][0];
+                __half d_h, dmin_h;
+                memcpy(&d_h, h, 2);
+                memcpy(&dmin_h, h + 2, 2);
+                uint32_t sc, mn;
+                q4k_scale_min(j0 + kb, h + 4, sc, mn);
+                const float a = __half2float(d_h) * static_cast<float>(sc);
+                const float b =
+                    8.0f * a - __half2float(dmin_h) * static_cast<float>(mn);
+                sBab[stage][row][kb] = __floats2half2_rn(a, b);
+            }
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int kb = 0; kb < 2; ++kb) {
+            const int kc = kb * 32;
+            const uint32_t shift = kb * 4;
+#pragma unroll
+            for (int mf = 0; mf < kMF; ++mf) {
+                const int arow_lo = warp_m * kTileM + mf * 16 + rl;
+                const int arow_hi = arow_lo + 8;
+                const int acol = kc + cl * 4;
+                uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol]);
+                uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol]);
+                uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol + 16]);
+                uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol + 16]);
+                const float da_lo = __half2float(sAsc[stage][arow_lo][kb]);
+                const float da_hi = __half2float(sAsc[stage][arow_hi][kb]);
+                const float rs_lo = sArs[stage][arow_lo][kb];
+                const float rs_hi = sArs[stage][arow_hi][kb];
+
+#pragma unroll
+                for (int nf = 0; nf < kNF; ++nf) {
+                    const int bcol = warp_n * kTileN + nf * 8 + rl;
+                    const uint32_t raw0 =
+                        *reinterpret_cast<const uint32_t*>(&sBq[stage][bcol][cl * 4]);
+                    const uint32_t raw1 =
+                        *reinterpret_cast<const uint32_t*>(&sBq[stage][bcol][cl * 4 + 16]);
+                    const uint32_t b0 = __vsub4((raw0 >> shift) & 0x0F0F0F0Fu, 0x08080808u);
+                    const uint32_t b1 = __vsub4((raw1 >> shift) & 0x0F0F0F0Fu, 0x08080808u);
+
+                    int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+#if __CUDA_ARCH__ >= 800
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+                        : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "r"(0), "r"(0),
+                          "r"(0), "r"(0));
+#endif
+                    const int ncol_lo = warp_n * kTileN + nf * 8 + cl * 2;
+                    const __half2 ab_lo = sBab[stage][ncol_lo][kb];
+                    const __half2 ab_hi = sBab[stage][ncol_lo + 1][kb];
+                    const float al = __half2float(__low2half(ab_lo));
+                    const float bl = __half2float(__high2half(ab_lo));
+                    const float ah = __half2float(__low2half(ab_hi));
+                    const float bh = __half2float(__high2half(ab_hi));
+                    acc[mf][nf][0] += da_lo * fmaf(al, static_cast<float>(c0), bl * rs_lo);
+                    acc[mf][nf][1] += da_lo * fmaf(ah, static_cast<float>(c1), bh * rs_lo);
+                    acc[mf][nf][2] += da_hi * fmaf(al, static_cast<float>(c2), bl * rs_hi);
+                    acc[mf][nf][3] += da_hi * fmaf(ah, static_cast<float>(c3), bh * rs_hi);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+#pragma unroll
+    for (int mf = 0; mf < kMF; ++mf) {
+        const int row_lo = base_m + warp_m * kTileM + mf * 16 + rl;
+        const int row_hi = row_lo + 8;
+#pragma unroll
+        for (int nf = 0; nf < kNF; ++nf) {
+            const int col = base_n + warp_n * kTileN + nf * 8 + cl * 2;
+            if (row_lo < rows) {
+                __half2* p = reinterpret_cast<__half2*>(&C[static_cast<size_t>(row_lo) * N + col]);
+                __half2 v = __floats2half2_rn(acc[mf][nf][0], acc[mf][nf][1]);
+                *p = BETA1 ? __hadd2(*p, v) : v;
+            }
+            if (row_hi < rows) {
+                __half2* p = reinterpret_cast<__half2*>(&C[static_cast<size_t>(row_hi) * N + col]);
+                __half2 v = __floats2half2_rn(acc[mf][nf][2], acc[mf][nf][3]);
+                *p = BETA1 ? __hadd2(*p, v) : v;
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Q8_0 SoA split: raw 34-B blocks {half d; int8 qs[32]} (2-aligned! memcpy
 // only) → qs plane [N][K] s8 + interleaved (α=d, β=0) plane [N][K/32][2].
 // -----------------------------------------------------------------------------
@@ -272,17 +508,6 @@ __global__ void q8_split_kernel(const uint8_t* __restrict__ src, int8_t* __restr
     int8_t* dst = qs_plane + static_cast<size_t>(b) * 32;
 #pragma unroll
     for (int i = 0; i < 32; ++i) dst[i] = static_cast<int8_t>(blk[2 + i]);
-}
-
-// Interleave separate α / β planes ([N][subs] each, from mmq_q4k_imma_reorder)
-// into the kernel's [N][subs][2] layout.
-__global__ void interleave_ab_kernel(const __half* __restrict__ alpha,
-                                     const __half* __restrict__ beta,
-                                     __half* __restrict__ sc_plane, size_t total) {
-    const size_t i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (i >= total) return;
-    sc_plane[i * 2] = alpha[i];
-    sc_plane[i * 2 + 1] = beta[i];
 }
 
 // Activation quantizer: 8 warps per block, grid-stride over (m, sub) pairs
@@ -331,10 +556,6 @@ struct ActScratch {
     float* xrowsum = nullptr;
     size_t cap_mk = 0;
     size_t cap_msubs = 0;
-    // quantize memo: gate/up MoE GEMMs share one gathered batch
-    const void* last_ptr = nullptr;
-    int last_m = 0;
-    int last_k = 0;
 };
 
 std::mutex g_mtx;
@@ -347,7 +568,11 @@ bool stream_capturing(cudaStream_t stream) {
            st == cudaStreamCaptureStatusActive;
 }
 
-bool ensure_weight(const void* src, bool q4k, int N, int K, cudaStream_t stream, bool capturing) {
+bool ensure_weight(const void* src, int N, int K, cudaStream_t stream, bool capturing) {
+    // Q8_0 only: the SoA planes cost 1.06x the source — fine for dense Q8
+    // models, but Q4_K (esp. MoE experts) reads the raw blocks in-kernel
+    // instead (the plane variant duplicated all expert weights and hit the
+    // 32-GB VRAM wall on Qwen3-30B: pp512 8x SLOWER under UVM paging).
     auto it = g_weights.find(src);
     if (it != g_weights.end() && it->second.N == N && it->second.K == K) return true;
     if (capturing) return false;  // never allocate inside graph capture
@@ -361,30 +586,9 @@ bool ensure_weight(const void* src, bool q4k, int N, int K, cudaStream_t stream,
         cudaFree(w.qs);
         return false;
     }
-    if (!q4k) {
-        const int total = N * static_cast<int>(subs);
-        q8_split_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
-            static_cast<const uint8_t*>(src), w.qs, w.sc, total);
-    } else {
-        // reorder into temp α/β planes, then interleave (init-time only)
-        __half* tmp_a = nullptr;
-        __half* tmp_b = nullptr;
-        const size_t plane = static_cast<size_t>(N) * subs * sizeof(__half);
-        if (cudaMalloc(&tmp_a, plane) != cudaSuccess ||
-            cudaMalloc(&tmp_b, plane) != cudaSuccess) {
-            cudaFree(tmp_a);
-            cudaFree(w.qs);
-            cudaFree(w.sc);
-            return false;
-        }
-        mmq_q4k_imma_reorder(src, N, K, w.qs, tmp_a, tmp_b, stream);
-        const size_t total = static_cast<size_t>(N) * subs;
-        interleave_ab_kernel<<<static_cast<unsigned>((total + 255) / 256), 256, 0, stream>>>(
-            tmp_a, tmp_b, w.sc, total);
-        cudaStreamSynchronize(stream);  // init-time; temps freed right after
-        cudaFree(tmp_a);
-        cudaFree(tmp_b);
-    }
+    const int total = N * static_cast<int>(subs);
+    q8_split_kernel<<<(total + 255) / 256, 256, 0, stream>>>(static_cast<const uint8_t*>(src),
+                                                             w.qs, w.sc, total);
     g_weights[src] = w;
     return true;
 }
@@ -405,20 +609,18 @@ bool ensure_act(int M, int K, bool capturing) {
     if (cudaMalloc(&g_act.xrowsum, msubs * sizeof(float)) != cudaSuccess) return false;
     g_act.cap_mk = mk;
     g_act.cap_msubs = msubs;
-    g_act.last_ptr = nullptr;
     return true;
 }
 
 void quantize_act(const __half* x, int M, int K, cudaStream_t stream) {
-    if (g_act.last_ptr == x && g_act.last_m == M && g_act.last_k == K)
-        return;  // gate/up share one gathered batch — quantize once
+    // NO memoization: workspace buffers (moe gathered, layer activations) are
+    // REUSED across layers with the same pointer — a (ptr, M, K) memo served
+    // layer-1 activations to every later layer (PPL 31.6 → 441k, found
+    // 2026-06-07). The kernel costs ~7 µs; quantize unconditionally.
     const int total_warps = M * (K / 32);
     const int blocks = min(2048, (total_warps + 7) / 8);
     quantize_act_fast_kernel<<<blocks, 256, 0, stream>>>(x, M, K, g_act.xs8, g_act.xscale,
                                                          g_act.xrowsum);
-    g_act.last_ptr = x;
-    g_act.last_m = M;
-    g_act.last_k = K;
 }
 
 bool gemm_common(const void* w_blocks, bool q4k, const __half* x_f16, __half* out_f16, int M,
@@ -426,19 +628,39 @@ bool gemm_common(const void* w_blocks, bool q4k, const __half* x_f16, __half* ou
                  int h_max_rows, int expanded, int ne) {
     std::lock_guard<std::mutex> lk(g_mtx);
     const bool capturing = stream_capturing(stream);
-    if (!ensure_weight(w_blocks, q4k, ne * N, K, stream, capturing)) return false;
+    if (!q4k && !ensure_weight(w_blocks, ne * N, K, stream, capturing)) return false;
     const int act_rows = d_offsets ? expanded : M;
     if (!ensure_act(act_rows, K, capturing)) return false;
     quantize_act(x_f16, act_rows, K, stream);
 
-    const auto& w = g_weights[w_blocks];
-    const size_t w_stride = static_cast<size_t>(N) * K;
-    const size_t wsc_stride = static_cast<size_t>(N) * (K / 32) * 2;
     const int grid_m_rows = d_offsets ? h_max_rows : M;
     const bool small_m = d_offsets && h_max_rows < 96;
     const int bm = small_m ? 32 : 128;
     dim3 grid(N / kBN, (grid_m_rows + bm - 1) / bm, ne);
 
+    if (q4k) {
+        // raw-read kernel: zero extra weight VRAM
+        const uint8_t* w4 = static_cast<const uint8_t*>(w_blocks);
+        const size_t w_stride_blocks = static_cast<size_t>(N) * (K / 256);
+        if (small_m) {
+            mmq_imma_q4k_raw_kernel<32, false><<<grid, kThreads, 0, stream>>>(
+                g_act.xs8, g_act.xscale, g_act.xrowsum, w4, out_f16, M, N, K, d_offsets,
+                w_stride_blocks);
+        } else if (beta == 1.0f) {
+            mmq_imma_q4k_raw_kernel<128, true><<<grid, kThreads, 0, stream>>>(
+                g_act.xs8, g_act.xscale, g_act.xrowsum, w4, out_f16, M, N, K, d_offsets,
+                w_stride_blocks);
+        } else {
+            mmq_imma_q4k_raw_kernel<128, false><<<grid, kThreads, 0, stream>>>(
+                g_act.xs8, g_act.xscale, g_act.xrowsum, w4, out_f16, M, N, K, d_offsets,
+                w_stride_blocks);
+        }
+        return true;
+    }
+
+    const auto& w = g_weights[w_blocks];
+    const size_t w_stride = static_cast<size_t>(N) * K;
+    const size_t wsc_stride = static_cast<size_t>(N) * (K / 32) * 2;
     if (small_m) {
         mmq_imma_kernel<32, false><<<grid, kThreads, 0, stream>>>(
             g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K, d_offsets,

--- a/src/compute/mmq_q8_imma.cu
+++ b/src/compute/mmq_q8_imma.cu
@@ -1,12 +1,20 @@
 // =============================================================================
-// mmq_q8_imma.cu — Q8_0 INT8 IMMA prefill GEMM (sm_120a)
+// mmq_q8_imma.cu — INT8 IMMA prefill GEMM family (sm_120a)
 // =============================================================================
 //
-// See mmq_q8_imma.h for the design rationale (phase-2B ceiling fixes: SMEM-
-// staged scales, 128×128×64 tiles, symmetric epilogue). Reuses the activation
-// quantizer from the Q4_K IMMA stack (quantize_fp16_to_int8_subblock).
+// Fused-dequant prefill GEMMs on the int8 tensor cores for Q8_0 and Q4_K
+// (dense + MoE-grouped). See mmq_q8_imma.h for the contract and the design
+// notes vs the 2026-05-18 phase-2B ceiling (SMEM-staged scales, 128x128x64
+// tiles, +16-B row pad killing 28.3M bank conflicts, one syncthreads pair
+// per K-step; 3-stage cp.async REGRESSED -21% — do not re-add).
+//
+// Unified math (α/β form; Q8_0 repacks with α=d, β=0):
+//   out[m,n] = Σ_kb d_a[m,kb] · ( α[n,kb]·Σ_{k∈kb} a_s8·w_s8 + β[n,kb]·rs[m,kb] )
+// where rs is the int rowsum of the quantized activation sub-block (couples
+// to Q4_K's collapsed (q-8)+dmin terms, see mmq_q4k_imma_layout.h).
 
 #include "compute/mmq_q8_imma.h"
+#include "compute/mmq_q4k_imma_layout.h"
 #include "core/logging.h"
 
 #include <cstring>
@@ -17,24 +25,23 @@ namespace imp {
 
 namespace {
 
-constexpr int kBM = 128;
 constexpr int kBN = 128;
-constexpr int kBK = 64;  // 2 sub-blocks per K-step
+constexpr int kBK = 64;   // 2 sub-blocks per K-step
 constexpr int kPad = 16;  // smem row pad (bytes): 80-B stride = conflict-free rl-lane access
 constexpr int kRow = kBK + kPad;
 constexpr int kStages = 2;
-constexpr int kWarpsM = 4;
-constexpr int kWarpsN = 2;
-constexpr int kThreads = kWarpsM * kWarpsN * 32;  // 256
-constexpr int kWarpTileM = kBM / kWarpsM;          // 32 → 2 m16 frags
-constexpr int kWarpTileN = kBN / kWarpsN;          // 64 → 8 n8 frags
-constexpr int kMF = kWarpTileM / 16;               // 2
-constexpr int kNF = kWarpTileN / 8;                // 8
+constexpr int kThreads = 256;
 
 __device__ __forceinline__ void cp_async_cg_16(void* smem, const void* glob, bool valid) {
     uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
     int src_size = valid ? 16 : 0;  // src-size 0 → zero-fill (OOB M-tail rows)
     asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;\n" ::"r"(s), "l"(glob),
+                 "r"(src_size));
+}
+__device__ __forceinline__ void cp_async_ca_8(void* smem, const void* glob, bool valid) {
+    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
+    int src_size = valid ? 8 : 0;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 8, %2;\n" ::"r"(s), "l"(glob),
                  "r"(src_size));
 }
 __device__ __forceinline__ void cp_async_ca_4(void* smem, const void* glob, bool valid) {
@@ -51,76 +58,102 @@ __device__ __forceinline__ void cp_async_wait_group() {
     asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
 }
 
-// One K-step tile load, all 256 threads cooperating:
-//   A  [kBM][kBK] s8 = 8192 B → 32 B/thread (2 × cp16), M-tail rows zero-filled
-//   B  [kBN][kBK] s8 = 8192 B → 32 B/thread (2 × cp16)
-//   Ad [kBM][2] half = 512 B → first 128 threads, 4 B each (d-plane cols
-//      (kb0, kb0+1) are contiguous and 4-B aligned: kb0 is even)
-//   Bd [kBN][2] half = 512 B → next 128 threads
+// One K-step tile load, all 256 threads cooperating (loops are fully
+// unrolled compile-time for both BM variants):
+//   A   [BM][kBK]  s8     M-tail rows zero-filled
+//   B   [kBN][kBK] s8     weight rows always full (N % kBN == 0 gate)
+//   Asc [BM][2]    half   activation scale, d-plane cols (kb0, kb0+1)
+//   Ars [BM][2]    float  activation rowsum, same cols
+//   Bsc [kBN][2][2] half  weight (α, β) interleaved for both kb cols
+template <int BM>
 __device__ __forceinline__ void load_kstep(int tid, const int8_t* __restrict__ A,
-                                           const int8_t* __restrict__ Ad_src,
+                                           const __half* __restrict__ Asc,
+                                           const float* __restrict__ Ars,
                                            const int8_t* __restrict__ B,
-                                           const int8_t* __restrict__ Bd_src,
-                                           int8_t (*sA)[kRow], int8_t (*sB)[kRow],
-                                           __half (*sAd)[2], __half (*sBd)[2], int base_m, int M,
-                                           int K, int subs, int k_base) {
-    {
-        // A: row = tid/2 in 0..127, col = (tid&1)*32 + {0,16}
-        const int row = tid >> 1;
-        const int col = (tid & 1) * 32;
+                                           const __half* __restrict__ Bsc, int8_t (*sA)[kRow],
+                                           int8_t (*sB)[kRow], __half (*sAsc)[2],
+                                           float (*sArs)[2], __half (*sBsc)[2][2], int base_m,
+                                           int M, int K, int subs, int k_base) {
+#pragma unroll
+    for (int i = tid; i < BM * 4; i += kThreads) {
+        const int row = i >> 2;
+        const int col = (i & 3) * 16;
         const bool valid = (base_m + row) < M;
-        const int8_t* src = A + static_cast<size_t>(base_m + row) * K + k_base + col;
-        cp_async_cg_16(&sA[row][col], src, valid);
-        cp_async_cg_16(&sA[row][col + 16], src + 16, valid);
+        cp_async_cg_16(&sA[row][col],
+                       A + static_cast<size_t>(base_m + row) * K + k_base + col, valid);
     }
-    {
-        // B: weight rows are always full (N % kBN == 0 gate)
-        const int row = tid >> 1;
-        const int col = (tid & 1) * 32;
-        const int8_t* src = B + static_cast<size_t>(row) * K + k_base + col;  // B pre-offset to base_n
-        cp_async_cg_16(&sB[row][col], src, true);
-        cp_async_cg_16(&sB[row][col + 16], src + 16, true);
+#pragma unroll
+    for (int i = tid; i < kBN * 4; i += kThreads) {
+        const int row = i >> 2;
+        const int col = (i & 3) * 16;
+        cp_async_cg_16(&sB[row][col], B + static_cast<size_t>(row) * K + k_base + col, true);
     }
-    {
-        const int kb0 = k_base / 32;
-        if (tid < kBM) {
-            const bool valid = (base_m + tid) < M;
-            const __half* src = reinterpret_cast<const __half*>(Ad_src) +
-                                static_cast<size_t>(base_m + tid) * subs + kb0;
-            cp_async_ca_4(&sAd[tid][0], src, valid);
-        } else if (tid < kBM + kBN) {
-            const int row = tid - kBM;
-            const __half* src =
-                reinterpret_cast<const __half*>(Bd_src) + static_cast<size_t>(row) * subs + kb0;
-            cp_async_ca_4(&sBd[row][0], src, true);
-        }
+    const int kb0 = k_base / 32;
+#pragma unroll
+    for (int i = tid; i < BM; i += kThreads) {
+        const bool valid = (base_m + i) < M;
+        cp_async_ca_4(&sAsc[i][0], Asc + static_cast<size_t>(base_m + i) * subs + kb0, valid);
+        cp_async_ca_8(&sArs[i][0], Ars + static_cast<size_t>(base_m + i) * subs + kb0, valid);
+    }
+#pragma unroll
+    for (int i = tid; i < kBN; i += kThreads) {
+        cp_async_ca_8(&sBsc[i][0][0], Bsc + (static_cast<size_t>(i) * subs + kb0) * 2, true);
     }
 }
 
-// out[M,N] = (or +=, BETA1) per-block-scaled IMMA over [kBM,kBN] tiles.
-template <bool BETA1>
+// out = (or +=, BETA1) the α/β-scaled IMMA over [BM,kBN] tiles. Grouped MoE
+// form: gridDim.z = ne with device expert_offsets; dense passes offsets ==
+// nullptr (z extent 1).
+template <int BM, bool BETA1>
 __global__ void __launch_bounds__(kThreads)
-    mmq_q8_imma_kernel(const int8_t* __restrict__ X_s8, const __half* __restrict__ x_scale,
-                       const int8_t* __restrict__ W_s8, const __half* __restrict__ w_d,
-                       __half* __restrict__ out, int M, int N, int K) {
-    const int n_block = blockIdx.x;
-    const int m_block = blockIdx.y;
-    const int base_m = m_block * kBM;
-    const int base_n = n_block * kBN;
-    if (base_m >= M) return;
+    mmq_imma_kernel(const int8_t* __restrict__ X_s8, const __half* __restrict__ x_scale,
+                    const float* __restrict__ x_rowsum, const int8_t* __restrict__ W_s8,
+                    const __half* __restrict__ w_sc, __half* __restrict__ out, int M, int N,
+                    int K, const int32_t* __restrict__ expert_offsets, size_t w_stride,
+                    size_t wsc_stride) {
+    constexpr int kWM = (BM == 128) ? 4 : 2;  // warp grid
+    constexpr int kWN = (BM == 128) ? 2 : 4;
+    constexpr int kTileM = BM / kWM;       // 32 / 16
+    constexpr int kTileN = kBN / kWN;      // 64 / 32
+    constexpr int kMF = kTileM / 16;       // 2 / 1
+    constexpr int kNF = kTileN / 8;        // 8 / 4
+    static_assert(kWM * kWN * 32 == kThreads, "warp grid must fill the CTA");
+
+    int rows = M;
+    size_t row_off = 0;
+    const int e = blockIdx.z;
+    if (expert_offsets != nullptr) {
+        const int32_t o0 = __ldg(&expert_offsets[e]);
+        const int32_t o1 = __ldg(&expert_offsets[e + 1]);
+        row_off = static_cast<size_t>(o0);
+        rows = o1 - o0;
+    }
+    const int base_m = blockIdx.y * BM;
+    const int base_n = blockIdx.x * kBN;
+    if (base_m >= rows || rows == 0) return;
+
+    const int subs = K / 32;
+    const int8_t* A = X_s8 + row_off * K;
+    const __half* Asc = x_scale + row_off * subs;
+    const float* Ars = x_rowsum + row_off * subs;
+    const int8_t* B = W_s8 + static_cast<size_t>(e) * w_stride + static_cast<size_t>(base_n) * K;
+    const __half* Bsc = w_sc + static_cast<size_t>(e) * wsc_stride +
+                        static_cast<size_t>(base_n) * subs * 2;
+    __half* C = out + row_off * N;
 
     const int tid = threadIdx.x;
     const int warp_id = tid >> 5;
     const int lane = tid & 31;
-    const int warp_m = warp_id >> 1;  // 0..3
-    const int warp_n = warp_id & 1;   // 0..1
-    const int rl = lane >> 2;         // 0..7
-    const int cl = lane & 3;          // 0..3
+    const int warp_m = warp_id / kWN;
+    const int warp_n = warp_id % kWN;
+    const int rl = lane >> 2;  // 0..7
+    const int cl = lane & 3;   // 0..3
 
-    __shared__ int8_t sA[kStages][kBM][kRow];
+    __shared__ int8_t sA[kStages][BM][kRow];
     __shared__ int8_t sB[kStages][kBN][kRow];
-    __shared__ __half sAd[kStages][kBM][2];
-    __shared__ __half sBd[kStages][kBN][2];
+    __shared__ __half sAsc[kStages][BM][2];
+    __shared__ float sArs[kStages][BM][2];
+    __shared__ __half sBsc[kStages][kBN][2][2];
 
     float acc[kMF][kNF][4];
 #pragma unroll
@@ -129,22 +162,17 @@ __global__ void __launch_bounds__(kThreads)
         for (int j = 0; j < kNF; ++j)
             acc[i][j][0] = acc[i][j][1] = acc[i][j][2] = acc[i][j][3] = 0.0f;
 
-    const int subs = K / 32;
     const int ksteps = K / kBK;
-    const int8_t* B_base = W_s8 + static_cast<size_t>(base_n) * K;
-    const int8_t* Bd_base = reinterpret_cast<const int8_t*>(w_d + static_cast<size_t>(base_n) * subs);
-    const int8_t* Ad_base = reinterpret_cast<const int8_t*>(x_scale);
-
-    load_kstep(tid, X_s8, Ad_base, B_base, Bd_base, sA[0], sB[0], sAd[0], sBd[0], base_m, M, K,
-               subs, 0);
+    load_kstep<BM>(tid, A, Asc, Ars, B, Bsc, sA[0], sB[0], sAsc[0], sArs[0], sBsc[0], base_m,
+                   rows, K, subs, 0);
     cp_async_commit();
 
     for (int ks = 0; ks < ksteps; ++ks) {
         const int stage = ks & 1;
         if (ks + 1 < ksteps) {
             const int nstage = (ks + 1) & 1;
-            load_kstep(tid, X_s8, Ad_base, B_base, Bd_base, sA[nstage], sB[nstage], sAd[nstage],
-                       sBd[nstage], base_m, M, K, subs, (ks + 1) * kBK);
+            load_kstep<BM>(tid, A, Asc, Ars, B, Bsc, sA[nstage], sB[nstage], sAsc[nstage],
+                           sArs[nstage], sBsc[nstage], base_m, rows, K, subs, (ks + 1) * kBK);
             cp_async_commit();
             cp_async_wait_group<1>();
         } else {
@@ -153,24 +181,27 @@ __global__ void __launch_bounds__(kThreads)
         __syncthreads();
 
 #pragma unroll
-        for (int kb = 0; kb < 2; ++kb) {  // 2 sub-blocks per K-step
+        for (int kb = 0; kb < 2; ++kb) {
             const int kc = kb * 32;
 #pragma unroll
             for (int mf = 0; mf < kMF; ++mf) {
-                const int arow_lo = warp_m * kWarpTileM + mf * 16 + rl;
+                const int arow_lo = warp_m * kTileM + mf * 16 + rl;
                 const int arow_hi = arow_lo + 8;
                 const int acol = kc + cl * 4;
                 uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol]);
                 uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol]);
                 uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol + 16]);
                 uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol + 16]);
-                // d_a for this fragment's two rows, hoisted over all 8 n-frags
-                const float da_lo = __half2float(sAd[stage][arow_lo][kb]);
-                const float da_hi = __half2float(sAd[stage][arow_hi][kb]);
+                // activation scale + rowsum for the fragment's two rows,
+                // hoisted over all n-frags
+                const float da_lo = __half2float(sAsc[stage][arow_lo][kb]);
+                const float da_hi = __half2float(sAsc[stage][arow_hi][kb]);
+                const float rs_lo = sArs[stage][arow_lo][kb];
+                const float rs_hi = sArs[stage][arow_hi][kb];
 
 #pragma unroll
                 for (int nf = 0; nf < kNF; ++nf) {
-                    const int bcol = warp_n * kWarpTileN + nf * 8 + rl;
+                    const int bcol = warp_n * kTileN + nf * 8 + rl;
                     const int bk = kc + cl * 4;
                     uint32_t b0 = *reinterpret_cast<const uint32_t*>(&sB[stage][bcol][bk]);
                     uint32_t b1 = *reinterpret_cast<const uint32_t*>(&sB[stage][bcol][bk + 16]);
@@ -185,13 +216,18 @@ __global__ void __launch_bounds__(kThreads)
                           "r"(0), "r"(0));
 #endif
                     // c0,c1 = rows (rl) cols (cl*2, cl*2+1); c2,c3 = rows (rl+8)
-                    const int ncol_lo = warp_n * kWarpTileN + nf * 8 + cl * 2;
-                    const float dw_lo = __half2float(sBd[stage][ncol_lo][kb]);
-                    const float dw_hi = __half2float(sBd[stage][ncol_lo + 1][kb]);
-                    acc[mf][nf][0] += (da_lo * dw_lo) * static_cast<float>(c0);
-                    acc[mf][nf][1] += (da_lo * dw_hi) * static_cast<float>(c1);
-                    acc[mf][nf][2] += (da_hi * dw_lo) * static_cast<float>(c2);
-                    acc[mf][nf][3] += (da_hi * dw_hi) * static_cast<float>(c3);
+                    const int ncol_lo = warp_n * kTileN + nf * 8 + cl * 2;
+                    const __half2 ab_lo = *reinterpret_cast<const __half2*>(&sBsc[stage][ncol_lo][kb][0]);
+                    const __half2 ab_hi =
+                        *reinterpret_cast<const __half2*>(&sBsc[stage][ncol_lo + 1][kb][0]);
+                    const float al = __half2float(__low2half(ab_lo));
+                    const float bl = __half2float(__high2half(ab_lo));
+                    const float ah = __half2float(__low2half(ab_hi));
+                    const float bh = __half2float(__high2half(ab_hi));
+                    acc[mf][nf][0] += da_lo * fmaf(al, static_cast<float>(c0), bl * rs_lo);
+                    acc[mf][nf][1] += da_lo * fmaf(ah, static_cast<float>(c1), bh * rs_lo);
+                    acc[mf][nf][2] += da_hi * fmaf(al, static_cast<float>(c2), bl * rs_hi);
+                    acc[mf][nf][3] += da_hi * fmaf(ah, static_cast<float>(c3), bh * rs_hi);
                 }
             }
         }
@@ -201,18 +237,18 @@ __global__ void __launch_bounds__(kThreads)
     // Epilogue: FP16 store, M-tail predicated (N is a multiple of kBN).
 #pragma unroll
     for (int mf = 0; mf < kMF; ++mf) {
-        const int row_lo = base_m + warp_m * kWarpTileM + mf * 16 + rl;
+        const int row_lo = base_m + warp_m * kTileM + mf * 16 + rl;
         const int row_hi = row_lo + 8;
 #pragma unroll
         for (int nf = 0; nf < kNF; ++nf) {
-            const int col = base_n + warp_n * kWarpTileN + nf * 8 + cl * 2;
-            if (row_lo < M) {
-                __half2* p = reinterpret_cast<__half2*>(&out[static_cast<size_t>(row_lo) * N + col]);
+            const int col = base_n + warp_n * kTileN + nf * 8 + cl * 2;
+            if (row_lo < rows) {
+                __half2* p = reinterpret_cast<__half2*>(&C[static_cast<size_t>(row_lo) * N + col]);
                 __half2 v = __floats2half2_rn(acc[mf][nf][0], acc[mf][nf][1]);
                 *p = BETA1 ? __hadd2(*p, v) : v;
             }
-            if (row_hi < M) {
-                __half2* p = reinterpret_cast<__half2*>(&out[static_cast<size_t>(row_hi) * N + col]);
+            if (row_hi < rows) {
+                __half2* p = reinterpret_cast<__half2*>(&C[static_cast<size_t>(row_hi) * N + col]);
                 __half2 v = __floats2half2_rn(acc[mf][nf][2], acc[mf][nf][3]);
                 *p = BETA1 ? __hadd2(*p, v) : v;
             }
@@ -222,29 +258,39 @@ __global__ void __launch_bounds__(kThreads)
 
 // -----------------------------------------------------------------------------
 // Q8_0 SoA split: raw 34-B blocks {half d; int8 qs[32]} (2-aligned! memcpy
-// only) → qs plane [N][K] s8 + d plane [N][K/32] half. One-time per weight.
+// only) → qs plane [N][K] s8 + interleaved (α=d, β=0) plane [N][K/32][2].
 // -----------------------------------------------------------------------------
 __global__ void q8_split_kernel(const uint8_t* __restrict__ src, int8_t* __restrict__ qs_plane,
-                                __half* __restrict__ d_plane, int n_blocks_total, int subs) {
+                                __half* __restrict__ sc_plane, int n_blocks_total) {
     const int b = blockIdx.x * blockDim.x + threadIdx.x;
     if (b >= n_blocks_total) return;
     const uint8_t* blk = src + static_cast<size_t>(b) * 34;
     __half d;
     memcpy(&d, blk, 2);
-    d_plane[b] = d;
+    sc_plane[static_cast<size_t>(b) * 2] = d;
+    sc_plane[static_cast<size_t>(b) * 2 + 1] = __float2half(0.0f);
     int8_t* dst = qs_plane + static_cast<size_t>(b) * 32;
 #pragma unroll
     for (int i = 0; i < 32; ++i) dst[i] = static_cast<int8_t>(blk[2 + i]);
-    (void)subs;
 }
 
-// Faster activation quantizer than the shared 32-thread-block version
-// (quantize_fp16_to_int8_subblock): same math, but 8 warps per block with a
-// grid-stride loop over (m, sub) pairs — the shared kernel's 65k 32-thread
-// blocks cap SM occupancy and ran at ~150 GB/s (32.5 µs per 512×4096 GEMM,
-// nsys 2026-06-07); this version is plain-coalesced and occupancy-bound.
+// Interleave separate α / β planes ([N][subs] each, from mmq_q4k_imma_reorder)
+// into the kernel's [N][subs][2] layout.
+__global__ void interleave_ab_kernel(const __half* __restrict__ alpha,
+                                     const __half* __restrict__ beta,
+                                     __half* __restrict__ sc_plane, size_t total) {
+    const size_t i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= total) return;
+    sc_plane[i * 2] = alpha[i];
+    sc_plane[i * 2 + 1] = beta[i];
+}
+
+// Activation quantizer: 8 warps per block, grid-stride over (m, sub) pairs
+// (the shared 32-thread-block version ran at ~150 GB/s). Emits s8 + half
+// scale + float rowsum (the rowsum couples to the Q4_K β term; ~free here).
 __global__ void quantize_act_fast_kernel(const __half* __restrict__ X, int M, int K,
-                                         int8_t* __restrict__ xs8, __half* __restrict__ xscale) {
+                                         int8_t* __restrict__ xs8, __half* __restrict__ xscale,
+                                         float* __restrict__ xrowsum) {
     const int subs = K / 32;
     const int total = M * subs;
     const int lane = threadIdx.x & 31;
@@ -262,23 +308,33 @@ __global__ void quantize_act_fast_kernel(const __half* __restrict__ X, int M, in
         int q = __float2int_rn(v * inv);
         q = max(-127, min(127, q));
         xs8[off + lane] = static_cast<int8_t>(q);
-        if (lane == 0)
+        int sq = q;
+#pragma unroll
+        for (int o = 16; o > 0; o >>= 1) sq += __shfl_xor_sync(0xFFFFFFFFu, sq, o);
+        if (lane == 0) {
             xscale[static_cast<size_t>(m) * subs + s] =
                 __float2half((amax > 0.0f) ? (amax / 127.0f) : 0.0f);
+            xrowsum[static_cast<size_t>(m) * subs + s] = static_cast<float>(sq);
+        }
     }
 }
 
 struct WeightPlanes {
     int8_t* qs = nullptr;
-    __half* d = nullptr;
-    int N = 0;
+    __half* sc = nullptr;  // interleaved (α, β) [N][K/32][2]
+    int N = 0;             // total rows (ne × per-expert rows for MoE)
     int K = 0;
 };
 struct ActScratch {
     int8_t* xs8 = nullptr;
     __half* xscale = nullptr;
+    float* xrowsum = nullptr;
     size_t cap_mk = 0;
     size_t cap_msubs = 0;
+    // quantize memo: gate/up MoE GEMMs share one gathered batch
+    const void* last_ptr = nullptr;
+    int last_m = 0;
+    int last_k = 0;
 };
 
 std::mutex g_mtx;
@@ -291,7 +347,7 @@ bool stream_capturing(cudaStream_t stream) {
            st == cudaStreamCaptureStatusActive;
 }
 
-bool ensure_weight(const void* src, int N, int K, cudaStream_t stream, bool capturing) {
+bool ensure_weight(const void* src, bool q4k, int N, int K, cudaStream_t stream, bool capturing) {
     auto it = g_weights.find(src);
     if (it != g_weights.end() && it->second.N == N && it->second.K == K) return true;
     if (capturing) return false;  // never allocate inside graph capture
@@ -299,14 +355,36 @@ bool ensure_weight(const void* src, int N, int K, cudaStream_t stream, bool capt
     WeightPlanes w;
     w.N = N;
     w.K = K;
+    const size_t subs = static_cast<size_t>(K) / 32;
     if (cudaMalloc(&w.qs, static_cast<size_t>(N) * K) != cudaSuccess) return false;
-    if (cudaMalloc(&w.d, static_cast<size_t>(N) * (K / 32) * sizeof(__half)) != cudaSuccess) {
+    if (cudaMalloc(&w.sc, static_cast<size_t>(N) * subs * 2 * sizeof(__half)) != cudaSuccess) {
         cudaFree(w.qs);
         return false;
     }
-    const int total = N * (K / 32);
-    q8_split_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
-        static_cast<const uint8_t*>(src), w.qs, w.d, total, K / 32);
+    if (!q4k) {
+        const int total = N * static_cast<int>(subs);
+        q8_split_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
+            static_cast<const uint8_t*>(src), w.qs, w.sc, total);
+    } else {
+        // reorder into temp α/β planes, then interleave (init-time only)
+        __half* tmp_a = nullptr;
+        __half* tmp_b = nullptr;
+        const size_t plane = static_cast<size_t>(N) * subs * sizeof(__half);
+        if (cudaMalloc(&tmp_a, plane) != cudaSuccess ||
+            cudaMalloc(&tmp_b, plane) != cudaSuccess) {
+            cudaFree(tmp_a);
+            cudaFree(w.qs);
+            cudaFree(w.sc);
+            return false;
+        }
+        mmq_q4k_imma_reorder(src, N, K, w.qs, tmp_a, tmp_b, stream);
+        const size_t total = static_cast<size_t>(N) * subs;
+        interleave_ab_kernel<<<static_cast<unsigned>((total + 255) / 256), 256, 0, stream>>>(
+            tmp_a, tmp_b, w.sc, total);
+        cudaStreamSynchronize(stream);  // init-time; temps freed right after
+        cudaFree(tmp_a);
+        cudaFree(tmp_b);
+    }
     g_weights[src] = w;
     return true;
 }
@@ -319,12 +397,61 @@ bool ensure_act(int M, int K, bool capturing) {
     if (g_act.xs8) {
         cudaFree(g_act.xs8);
         cudaFree(g_act.xscale);
+        cudaFree(g_act.xrowsum);
         g_act = ActScratch{};
     }
     if (cudaMalloc(&g_act.xs8, mk) != cudaSuccess) return false;
     if (cudaMalloc(&g_act.xscale, msubs * sizeof(__half)) != cudaSuccess) return false;
+    if (cudaMalloc(&g_act.xrowsum, msubs * sizeof(float)) != cudaSuccess) return false;
     g_act.cap_mk = mk;
     g_act.cap_msubs = msubs;
+    g_act.last_ptr = nullptr;
+    return true;
+}
+
+void quantize_act(const __half* x, int M, int K, cudaStream_t stream) {
+    if (g_act.last_ptr == x && g_act.last_m == M && g_act.last_k == K)
+        return;  // gate/up share one gathered batch — quantize once
+    const int total_warps = M * (K / 32);
+    const int blocks = min(2048, (total_warps + 7) / 8);
+    quantize_act_fast_kernel<<<blocks, 256, 0, stream>>>(x, M, K, g_act.xs8, g_act.xscale,
+                                                         g_act.xrowsum);
+    g_act.last_ptr = x;
+    g_act.last_m = M;
+    g_act.last_k = K;
+}
+
+bool gemm_common(const void* w_blocks, bool q4k, const __half* x_f16, __half* out_f16, int M,
+                 int N, int K, cudaStream_t stream, float beta, const int32_t* d_offsets,
+                 int h_max_rows, int expanded, int ne) {
+    std::lock_guard<std::mutex> lk(g_mtx);
+    const bool capturing = stream_capturing(stream);
+    if (!ensure_weight(w_blocks, q4k, ne * N, K, stream, capturing)) return false;
+    const int act_rows = d_offsets ? expanded : M;
+    if (!ensure_act(act_rows, K, capturing)) return false;
+    quantize_act(x_f16, act_rows, K, stream);
+
+    const auto& w = g_weights[w_blocks];
+    const size_t w_stride = static_cast<size_t>(N) * K;
+    const size_t wsc_stride = static_cast<size_t>(N) * (K / 32) * 2;
+    const int grid_m_rows = d_offsets ? h_max_rows : M;
+    const bool small_m = d_offsets && h_max_rows < 96;
+    const int bm = small_m ? 32 : 128;
+    dim3 grid(N / kBN, (grid_m_rows + bm - 1) / bm, ne);
+
+    if (small_m) {
+        mmq_imma_kernel<32, false><<<grid, kThreads, 0, stream>>>(
+            g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K, d_offsets,
+            w_stride, wsc_stride);
+    } else if (beta == 1.0f) {
+        mmq_imma_kernel<128, true><<<grid, kThreads, 0, stream>>>(
+            g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K, d_offsets,
+            w_stride, wsc_stride);
+    } else {
+        mmq_imma_kernel<128, false><<<grid, kThreads, 0, stream>>>(
+            g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K, d_offsets,
+            w_stride, wsc_stride);
+    }
     return true;
 }
 
@@ -334,44 +461,45 @@ bool mmq_q8_imma_gemm(const void* w_q8_blocks, const __half* x_f16, __half* out_
                       int K, cudaStream_t stream, float beta) {
     if (M < 64 || N % kBN != 0 || K % kBK != 0) return false;
     if (beta != 0.0f && beta != 1.0f) return false;
+    return gemm_common(w_q8_blocks, false, x_f16, out_f16, M, N, K, stream, beta, nullptr, 0, 0,
+                       1);
+}
 
-    std::lock_guard<std::mutex> lk(g_mtx);
-    const bool capturing = stream_capturing(stream);
-    if (!ensure_weight(w_q8_blocks, N, K, stream, capturing)) return false;
-    if (!ensure_act(M, K, capturing)) return false;
+bool mmq_q4k_imma_gemm(const void* w_q4k_blocks, const __half* x_f16, __half* out_f16, int M,
+                       int N, int K, cudaStream_t stream, float beta) {
+    if (M < 64 || N % kBN != 0 || K % 256 != 0) return false;
+    if (beta != 0.0f && beta != 1.0f) return false;
+    return gemm_common(w_q4k_blocks, true, x_f16, out_f16, M, N, K, stream, beta, nullptr, 0, 0,
+                       1);
+}
 
-    {
-        const int total_warps_needed = M * (K / 32);
-        const int blocks = min(2048, (total_warps_needed + 7) / 8);
-        quantize_act_fast_kernel<<<blocks, 256, 0, stream>>>(x_f16, M, K, g_act.xs8, g_act.xscale);
-    }
-
-    const auto& w = g_weights[w_q8_blocks];
-    dim3 grid(N / kBN, (M + kBM - 1) / kBM);
-    if (beta == 1.0f)
-        mmq_q8_imma_kernel<true><<<grid, kThreads, 0, stream>>>(g_act.xs8, g_act.xscale, w.qs, w.d,
-                                                                out_f16, M, N, K);
-    else
-        mmq_q8_imma_kernel<false><<<grid, kThreads, 0, stream>>>(g_act.xs8, g_act.xscale, w.qs,
-                                                                 w.d, out_f16, M, N, K);
+bool mmq_imma_moe_gemm(const void* w_blocks, bool qtype_is_q4k, const __half* x_f16,
+                       __half* out_f16, const int32_t* d_offsets, int h_max_rows, int expanded,
+                       int ne, int N, int K, cudaStream_t stream) {
+    if (N % kBN != 0 || K % (qtype_is_q4k ? 256 : kBK) != 0) return false;
+    if (h_max_rows <= 0 || expanded <= 0 || ne <= 0) return false;
+    const bool ok = gemm_common(w_blocks, qtype_is_q4k, x_f16, out_f16, /*M=*/0, N, K, stream,
+                                0.0f, d_offsets, h_max_rows, expanded, ne);
     static bool logged = false;
-    if (!logged) {
+    if (ok && !logged) {
         logged = true;
-        IMP_LOG_INFO("Q8_0 IMMA prefill ACTIVE (M=%d N=%d K=%d, tile 128x128x64, 8 warps)", M, N, K);
+        IMP_LOG_INFO("MoE IMMA prefill ACTIVE (%s, ne=%d N=%d K=%d max_rows=%d)",
+                     qtype_is_q4k ? "Q4_K" : "Q8_0", ne, N, K, h_max_rows);
     }
-    return true;
+    return ok;
 }
 
 void mmq_q8_imma_release_all() {
     std::lock_guard<std::mutex> lk(g_mtx);
     for (auto& [_, w] : g_weights) {
         cudaFree(w.qs);
-        cudaFree(w.d);
+        cudaFree(w.sc);
     }
     g_weights.clear();
     if (g_act.xs8) {
         cudaFree(g_act.xs8);
         cudaFree(g_act.xscale);
+        cudaFree(g_act.xrowsum);
         g_act = ActScratch{};
     }
 }

--- a/src/compute/mmq_q8_imma.h
+++ b/src/compute/mmq_q8_imma.h
@@ -6,35 +6,45 @@
 
 namespace imp {
 
-// Q8_0 INT8 IMMA prefill GEMM — fused dequant on int8 tensor cores.
+// INT8 IMMA prefill GEMM family (sm_120a) — fused dequant on int8 tensor
+// cores (s8.s8.s32 mma.sync, measured 968 TOPS saturated — full rate).
 //
-// Sibling of the Q4_K IMMA stack (mmq_q4k_imma_tile.*), redesigned against
-// the 2026-05-18 phase-2B ceiling diagnosis (40 TOPS plateau). The three
-// structural fixes over that kernel:
-//   1. Per-sub-block scales are cp.async-staged in SMEM with the data tiles —
-//      the 2B kernel paid 8 GLOBAL loads per MMA for x_scale/α/β/rowsum.
-//   2. BLOCK 128×128×64, 8 warps, 32×64 warp tile → 128 MMAs per CTA per
-//      K-step with ONE __syncthreads pair (2B: 16 MMAs per 2 syncs).
-//   3. Q8_0 is symmetric (w = d·q): the epilogue is a pure
-//      (d_a·d_w)·s32 FMA — no β·rowsum correction term at all.
+// Weight forms:
+//   Q8_0 — native s8, SoA-split once per tensor (qs [N][K] + (α=d, β=0)
+//          interleaved scale plane [N][K/32][2]).
+//   Q4_K — reordered once via mmq_q4k_imma_reorder (symmetric s8 + per-sub
+//          α/β, see mmq_q4k_imma_layout.h), interleaved the same way.
 //
-// Math:  out[m,n] = Σ_kb  d_a[m,kb] · d_w[n,kb] · Σ_{k∈kb} X_s8[m,k]·W_s8[n,k]
-// (kb = 32-wide sub-block = one m16n8k32 IMMA per fragment; measured
-// saturated s8.s8.s32 peak on this silicon: 968 TOPS — full rate.)
+// Unified epilogue per 32-wide sub-block kb:
+//   out[m,n] += d_a[m,kb] · ( α[n,kb] · Σ s8·s8 + β[n,kb] · rowsum_a[m,kb] )
 //
-// Weight planes ([N][K] s8 + [N][K/32] half d) are split out of the raw GGUF
-// Q8_0 block stream once per weight pointer and cached. Activation s8 planes
-// are grow-only scratch. Both allocations are capture-guarded: a cache miss
-// during CUDA-graph capture declines (returns false) instead of allocating —
-// the warmup prefill populates the caches before capture.
+// Activations are s8-quantized per 32-block (half scale + float rowsum),
+// memoized per (pointer, M, K) so MoE gate/up GEMMs sharing one gathered
+// batch quantize once. All caches are capture-guarded: a miss during CUDA-
+// graph capture declines instead of allocating (warmup populates them).
 
-// Attempt out[M,N] (FP16, row-major) = x[M,K]·W^T (beta=0) or += (beta=1)
-// from the raw Q8_0 block stream (34-B blocks, [N][K/32]).
-// Declines (returns false, output untouched) when: M < 64, N % 128 != 0,
-// K % 64 != 0, beta ∉ {0,1}, capture-guarded cache miss, or allocation
-// failure.
+// Dense Q8_0: out[M,N] = x·W^T (beta=0) or += (beta=1).
+// Declines: M < 64, N % 128, K % 64, beta ∉ {0,1}, capture-guarded miss.
 bool mmq_q8_imma_gemm(const void* w_q8_blocks, const __half* x_f16, __half* out_f16, int M, int N,
                       int K, cudaStream_t stream, float beta = 0.0f);
+
+// Dense Q4_K (new stack — distinct from the legacy gemm.q4k_imma_enabled
+// 2026-05 kernel): same contract; K % 256 == 0 (Q4_K super-block).
+bool mmq_q4k_imma_gemm(const void* w_q4k_blocks, const __half* x_f16, __half* out_f16, int M,
+                       int N, int K, cudaStream_t stream, float beta = 0.0f);
+
+// MoE grouped prefill GEMM over ne experts in ONE launch (gridDim.z = ne).
+//   w_blocks     : packed expert weights [ne][N][K] (GGUF blocks, contiguous)
+//   x_f16        : gathered activations [expanded][K] (expert-contiguous)
+//   out_f16      : [expanded][N]
+//   d_offsets    : device int32 [ne+1] expert row offsets
+//   h_max_rows   : host-known max rows per expert (sizes grid.y; < 96 picks
+//                  the BM=32 small-M tile — pp512 top-8/128 routing averages
+//                  ~32 rows per expert)
+//   expanded     : total gathered rows (activation quantize span)
+bool mmq_imma_moe_gemm(const void* w_blocks, bool qtype_is_q4k, const __half* x_f16,
+                       __half* out_f16, const int32_t* d_offsets, int h_max_rows, int expanded,
+                       int ne, int N, int K, cudaStream_t stream);
 
 // Free cached weight planes + activation scratch (tests / teardown).
 void mmq_q8_imma_release_all();

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -2,6 +2,7 @@
 // Extracted from executor_forward_moe.cu for maintainability.
 
 #include "exec/executor.h"
+#include "compute/mmq_q8_imma.h"
 #include "exec/executor_forward_moe_internal.h"
 #include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
@@ -440,11 +441,30 @@ bool GraphExecutor::try_run_moe_fp16_batch_prefill(int layer, cudaStream_t strea
         }
     }
 
+    // MoE IMMA prefill (gemm.moe_imma_prefill): Q8_0/Q4_K expert tensors run
+    // the grouped INT8 IMMA kernel — fused dequant, one launch over all
+    // experts — instead of materializing every expert to FP16 (the 63-65%-of-
+    // window dequant tax, docs/audit/prefill_gap_2026_06_07.md §4.2). Other
+    // qtypes (Q6_K down_proj) and FP32-out fall through to the legacy path.
+    int max_rows_per_expert = 0;
+    for (int e = 0; e < ne; ++e)
+        max_rows_per_expert = std::max(max_rows_per_expert, h_offsets[e + 1] - h_offsets[e]);
+    const bool moe_imma = runtime_config().gemm.moe_imma_prefill;
+
     auto batch_dequant_gemm = [&](const Tensor& packed, QType qtype, const char* a_base,
                                   char* c_base, int K_dim, int N_dim,
                                   QType out_dtype = QType::F16) {
         int64_t rows = packed.shape[1];
         int64_t cols = packed.shape[2];
+        if (moe_imma && out_dtype == QType::F16 &&
+            (qtype == QType::Q8_0 || qtype == QType::Q4_K) && max_rows_per_expert > 0) {
+            if (mmq_imma_moe_gemm(packed.data, qtype == QType::Q4_K,
+                                  reinterpret_cast<const __half*>(a_base),
+                                  reinterpret_cast<__half*>(c_base),
+                                  static_cast<const int32_t*>(routing.expert_offsets.data),
+                                  max_rows_per_expert, expanded, ne, N_dim, K_dim, stream))
+                return;
+        }
         size_t expert_fp16_sz = static_cast<size_t>(rows) * cols * sizeof(half);
         dequant_gpu(static_cast<const uint8_t*>(packed.data), buf, qtype,
                     ne * static_cast<int>(rows), static_cast<int>(cols), stream);

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -1862,13 +1862,21 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         // docs/audit/prefill_gap_2026_06_07.md §4.1). Covers beta=0 and the
         // beta=1 residual-add form; declines (shape / capture-guard) fall
         // through to the dequant fallback below.
-        if (ctx.q8_imma_enabled && h.source_qtype == QType::Q8_0 && input.qtype == QType::F16 &&
-            output.qtype == QType::F16 && M >= 64 && input.stride[0] == h.shape[1] &&
-            output.stride[0] == h.shape[0]) {
+        const bool imma_eligible = input.qtype == QType::F16 && output.qtype == QType::F16 &&
+                                   M >= 64 && input.stride[0] == h.shape[1] &&
+                                   output.stride[0] == h.shape[0];
+        if (ctx.q8_imma_enabled && h.source_qtype == QType::Q8_0 && imma_eligible) {
             if (mmq_q8_imma_gemm(h.source_data, reinterpret_cast<const __half*>(input.data),
                                  reinterpret_cast<__half*>(output.data), M,
                                  static_cast<int>(h.shape[0]), static_cast<int>(h.shape[1]),
                                  ctx.stream, ctx.beta))
+                return;
+        }
+        if (ctx.q4k_imma_prefill && h.source_qtype == QType::Q4_K && imma_eligible) {
+            if (mmq_q4k_imma_gemm(h.source_data, reinterpret_cast<const __half*>(input.data),
+                                  reinterpret_cast<__half*>(output.data), M,
+                                  static_cast<int>(h.shape[0]), static_cast<int>(h.shape[1]),
+                                  ctx.stream, ctx.beta))
                 return;
         }
         Tensor weight(const_cast<void*>(h.source_data), h.source_qtype, 2, h.shape, true);

--- a/src/exec/gemm_context.h
+++ b/src/exec/gemm_context.h
@@ -37,6 +37,7 @@ struct GemmContext {
     bool q4k_imma_enabled = false;
     bool q4k_hmma_enabled = false;
     bool q8_imma_enabled = false;
+    bool q4k_imma_prefill = false;
     bool gemm_no_mmvq = false;
     bool gemm_no_mmvq_q8_0 = false;
     bool gemm_no_dp4a_gemv = false;
@@ -60,6 +61,7 @@ struct GemmContext {
         ctx.q4k_imma_enabled = rcfg.gemm.q4k_imma_enabled;
         ctx.q4k_hmma_enabled = rcfg.gemm.q4k_hmma_enabled;
         ctx.q8_imma_enabled = rcfg.gemm.q8_imma_enabled;
+        ctx.q4k_imma_prefill = rcfg.gemm.q4k_imma_prefill;
         ctx.gemm_no_mmvq = rcfg.gemm.no_mmvq;
         ctx.gemm_no_mmvq_q8_0 = rcfg.gemm.no_mmvq_q8_0;
         ctx.gemm_no_dp4a_gemv = rcfg.gemm.no_dp4a_gemv;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -222,6 +222,10 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.q4k_hmma_enabled = parse_bool(val, cfg.gemm.q4k_hmma_enabled);
     else if (eq("gemm.q8_imma_enabled"))
         cfg.gemm.q8_imma_enabled = parse_bool(val, cfg.gemm.q8_imma_enabled);
+    else if (eq("gemm.q4k_imma_prefill"))
+        cfg.gemm.q4k_imma_prefill = parse_bool(val, cfg.gemm.q4k_imma_prefill);
+    else if (eq("gemm.moe_imma_prefill"))
+        cfg.gemm.moe_imma_prefill = parse_bool(val, cfg.gemm.moe_imma_prefill);
     else if (eq("gemm.nvfp4_decode_all"))
         cfg.gemm.nvfp4_decode_all = parse_bool(val, cfg.gemm.nvfp4_decode_all);
     else if (eq("gemm.nvfp4_lm_head"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -253,6 +253,18 @@ struct RuntimeConfig {
         // Q4_K-IMMA phase-2B ceiling diagnosis (SMEM-staged scales, 128x128x64
         // tiles, symmetric epilogue). Experimental: default off.
         bool q8_imma_enabled = false;
+        // Q4_K dense prefill via the same (new-stack) IMMA kernel — distinct
+        // from the legacy gemm.q4k_imma_enabled (2026-05 64x32 kernel, 40
+        // TOPS plateau). Uses mmq_q4k_imma_reorder's symmetric-s8 + α/β form
+        // with the unified β·rowsum epilogue. Experimental: default off.
+        bool q4k_imma_prefill = false;
+        // MoE batch prefill via the grouped IMMA kernel (one launch over all
+        // experts, gridDim.z = expert, BM=32 small-M tile for the typical
+        // ~32-rows-per-expert routing at pp512). Covers Q8_0/Q4_K expert
+        // tensors; others (Q6_K down_proj) stay on dequant→cuBLAS. This is
+        // lever #1 for the 2.4-2.6x GGUF-MoE prefill gap
+        // (docs/audit/prefill_gap_2026_06_07.md §4.2). Default off.
+        bool moe_imma_prefill = false;
         // Extend NVFP4 decode cache to ALL quantized types (Q4_K, Q3_K, etc.),
         // not just the default Q8_0/Q6_K/Q5_K set. Trades VRAM for decode
         // throughput on sub-8-bit models (e.g. Gemma-3-12B Q4_K_M: dp4a GEMV

--- a/tests/test_mmq_q8_imma.cu
+++ b/tests/test_mmq_q8_imma.cu
@@ -180,6 +180,165 @@ TEST(MmqQ8Imma, MTailNoTail320) { run_case(320, 256, 128, 45, 15e-3f, 2e-2f); }
 TEST(MmqQ8Imma, MTailSeed47) { run_case(313, 256, 128, 47, 15e-3f, 2e-2f); }
 TEST(MmqQ8Imma, MTailBigK) { run_case(313, 256, 1024, 45, 15e-3f, 2e-2f); }
 TEST(MmqQ8Imma, M64Min) { run_case(64, 128, 64, 46, 15e-3f, 2e-2f); }
+// ---- Q4_K dense (new stack) — NRMSE vs full-dequant reference ----
+namespace q4k_helpers {
+constexpr int kSuper = 256;
+constexpr int kSuperBytes = 144;
+inline void get_scale_min_k4_cpu(int j, const uint8_t* q, uint8_t& d_out, uint8_t& m_out) {
+    if (j < 4) {
+        d_out = q[j] & 63u;
+        m_out = q[j + 4] & 63u;
+    } else {
+        d_out = (q[j + 4] & 0xFu) | ((q[j - 4] >> 6) << 4);
+        m_out = (q[j + 4] >> 4) | ((q[j - 0] >> 6) << 4);
+    }
+}
+inline void gen_q4k(std::vector<uint8_t>& W, int N, int K, unsigned seed) {
+    const int bpr = K / kSuper;
+    W.resize(static_cast<size_t>(N) * bpr * kSuperBytes);
+    std::mt19937 rng(seed);
+    for (size_t b = 0; b < W.size() / kSuperBytes; ++b) {
+        uint8_t* bp = W.data() + b * kSuperBytes;
+        __half dh = __float2half(0.001f + 0.0005f * (rng() % 100));
+        __half mh = __float2half(0.0005f + 0.0001f * (rng() % 100));
+        std::memcpy(bp, &dh, 2);
+        std::memcpy(bp + 2, &mh, 2);
+        for (int i = 0; i < 12; ++i) bp[4 + i] = static_cast<uint8_t>(rng() & 0xFF);
+        for (int i = 0; i < 128; ++i) bp[16 + i] = static_cast<uint8_t>(rng() & 0xFF);
+    }
+}
+inline void dequant_row(const std::vector<uint8_t>& W, int n, int K, std::vector<double>& row) {
+    const int bpr = K / kSuper;
+    row.assign(K, 0.0);
+    for (int sblk = 0; sblk < bpr; ++sblk) {
+        const uint8_t* bp = W.data() + (static_cast<size_t>(n) * bpr + sblk) * kSuperBytes;
+        __half dh, mh;
+        std::memcpy(&dh, bp, 2);
+        std::memcpy(&mh, bp + 2, 2);
+        const double d = __half2float(dh), dmin = __half2float(mh);
+        const uint8_t* scales = bp + 4;
+        const uint8_t* qs = bp + 16;
+        for (int e = 0; e < kSuper; ++e) {
+            const int group = e >> 6, in_grp = e & 63, hi = in_grp >> 5;
+            const int byte_q = group * 32 + (in_grp & 31);
+            const int sub = group * 2 + hi;
+            uint8_t sc, mn;
+            get_scale_min_k4_cpu(sub, scales, sc, mn);
+            const int nib = hi ? (qs[byte_q] >> 4) : (qs[byte_q] & 0xF);
+            row[sblk * kSuper + e] = d * sc * nib - dmin * mn;
+        }
+    }
+}
+}  // namespace q4k_helpers
+
+TEST(MmqQ8Imma, Q4KDenseNRMSE) {
+    using namespace q4k_helpers;
+    const int M = 128, N = 128, K = 512;
+    std::vector<uint8_t> W;
+    gen_q4k(W, N, K, 77);
+    std::vector<__half> x(static_cast<size_t>(M) * K);
+    std::mt19937 rng(78);
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+    for (auto& v : x) v = __float2half(nd(rng));
+
+    uint8_t* d_w; __half *d_x, *d_out;
+    ASSERT_EQ(cudaMalloc(&d_w, W.size()), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_x, x.size() * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_out, static_cast<size_t>(M) * N * 2), cudaSuccess);
+    cudaMemcpy(d_w, W.data(), W.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, x.data(), x.size() * 2, cudaMemcpyHostToDevice);
+    ASSERT_TRUE(mmq_q4k_imma_gemm(d_w, d_x, d_out, M, N, K, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    std::vector<__half> out(static_cast<size_t>(M) * N);
+    cudaMemcpy(out.data(), d_out, out.size() * 2, cudaMemcpyDeviceToHost);
+
+    double err2 = 0, ref2 = 0;
+    std::vector<double> wrow;
+    for (int n = 0; n < N; ++n) {
+        dequant_row(W, n, K, wrow);
+        for (int m = 0; m < M; m += 7) {
+            double ref = 0;
+            for (int k = 0; k < K; ++k)
+                ref += static_cast<double>(__half2float(x[(size_t)m * K + k])) * wrow[k];
+            const double got = __half2float(out[(size_t)m * N + n]);
+            err2 += (got - ref) * (got - ref);
+            ref2 += ref * ref;
+        }
+    }
+    const double nrmse = std::sqrt(err2 / std::max(ref2, 1e-30));
+    EXPECT_LT(nrmse, 2e-2) << "Q4K dense NRMSE";
+    cudaFree(d_w); cudaFree(d_x); cudaFree(d_out);
+    mmq_q8_imma_release_all();
+}
+
+// ---- MoE grouped (Q8_0, ne=4, ragged offsets incl. an empty expert) ----
+TEST(MmqQ8Imma, MoeGroupedQ8) {
+    const int ne = 4, N = 128, K = 256;
+    const int rows_per[ne] = {37, 0, 96, 19};  // ragged; expert 1 empty
+    int32_t h_off[ne + 1] = {0};
+    for (int e = 0; e < ne; ++e) h_off[e + 1] = h_off[e] + rows_per[e];
+    const int expanded = h_off[ne];
+
+    // packed experts: contiguous [ne][N][K/32] Q8_0 blocks
+    std::vector<uint8_t> W;
+    gen_q8_weight(W, ne * N, K, 91);
+    std::vector<__half> x(static_cast<size_t>(expanded) * K);
+    std::mt19937 rng(92);
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+    for (auto& v : x) v = __float2half(nd(rng));
+
+    uint8_t* d_w; __half *d_x, *d_out; int32_t* d_off;
+    ASSERT_EQ(cudaMalloc(&d_w, W.size()), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_x, x.size() * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_out, static_cast<size_t>(expanded) * N * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_off, sizeof(h_off)), cudaSuccess);
+    cudaMemcpy(d_w, W.data(), W.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, x.data(), x.size() * 2, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_off, h_off, sizeof(h_off), cudaMemcpyHostToDevice);
+
+    int max_rows = 0;
+    for (int e = 0; e < ne; ++e) max_rows = std::max(max_rows, rows_per[e]);
+    ASSERT_TRUE(mmq_imma_moe_gemm(d_w, false, d_x, d_out, d_off, max_rows, expanded, ne, N, K,
+                                  nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    std::vector<__half> out(static_cast<size_t>(expanded) * N);
+    cudaMemcpy(out.data(), d_out, out.size() * 2, cudaMemcpyDeviceToHost);
+
+    // reference: per-expert dense GEMM on dequantized Q8 weights (double),
+    // with CPU-modeled activation quantization (NRMSE bound covers it)
+    std::vector<int8_t> xs8;
+    std::vector<float> xscale;
+    quant_act_cpu(x, expanded, K, xs8, xscale);
+    const int subs = K / kBlk;
+    double err2 = 0, ref2 = 0;
+    for (int e = 0; e < ne; ++e) {
+        for (int r = h_off[e]; r < h_off[e + 1]; ++r) {
+            for (int n = 0; n < N; ++n) {
+                double accv = 0;
+                for (int s = 0; s < subs; ++s) {
+                    const uint8_t* bp = W.data() +
+                        ((static_cast<size_t>(e) * N + n) * subs + s) * kBlockBytes;
+                    __half dh;
+                    std::memcpy(&dh, bp, 2);
+                    const double dw = __half2float(dh);
+                    const int8_t* wq = reinterpret_cast<const int8_t*>(bp + 2);
+                    long isum = 0;
+                    for (int i = 0; i < kBlk; ++i)
+                        isum += static_cast<long>(xs8[(size_t)r * K + s * kBlk + i]) * wq[i];
+                    accv += static_cast<double>(xscale[(size_t)r * subs + s]) * dw * isum;
+                }
+                const double got = __half2float(out[(size_t)r * N + n]);
+                err2 += (got - accv) * (got - accv);
+                ref2 += accv * accv;
+            }
+        }
+    }
+    const double nrmse = std::sqrt(err2 / std::max(ref2, 1e-30));
+    EXPECT_LT(nrmse, 5e-3) << "MoE grouped vs exact model";
+    cudaFree(d_w); cudaFree(d_x); cudaFree(d_out); cudaFree(d_off);
+    mmq_q8_imma_release_all();
+}
+
 TEST(MmqQ8Imma, DeclineShapes) {
     // N not multiple of 128 / K not multiple of 64 / M < 64 → false
     std::vector<uint8_t> W;


### PR DESCRIPTION
## Summary

IMMA Phase 2 (prefill gap analysis #608, the **2.4–2.6× GGUF-MoE liability**): the kernel family from #612 now covers Q4_K via **in-kernel nibble unpack of the raw GGUF super-blocks** — zero extra weight VRAM — plus a **grouped MoE form** (one launch over all experts, gridDim.z = expert, BM=32 small-M tile for the ~32-rows-per-expert pp512 routing).

Two commits: the grouped/α-β foundation (plane-based, kept for Q8_0) and the raw-read kernel that makes it deployable.

## Measured (Qwen3-30B-A3B Q4_K_M, `gemm.moe_imma_prefill=true`, 10 reps, 2 restarts)

| | baseline | IMMA raw | Δ |
|---|---:|---:|---|
| pp512 | 3 968 | **8 900 / 8 597** | **+117–124 %** |
| pp2048 | 3 897 | **8 652** | **+122 %** |
| gap vs llama.cpp (same-day 9 288/9 313) | 2.40× | **1.04–1.08×** | — |
| decode tg256 | 282.8 | 283.9 | neutral |
| VRAM peak | — | **25.5 GB** | (plane variant: 32.1 GB saturated, 8× slower) |
| PPL (teacher-forced, deterministic) | 31.576 | **31.475** | −0.3 % (better) |

## Kernel

- One 64-wide K-step = exactly one 32-byte nibble group per B row (Q4_K sub-block pair = low/high nibbles of the same bytes) → B-fragment fetch is **one u32 smem load + shift/mask/`vsub4`**.
- 16-B block headers (d, dmin, 6-bit scales) cp.async-staged; (α, β) computed in a cooperative per-K-step pass (α = d·sc6, β = 8α − dmin·m6 — same algebra as `mmq_q4k_imma_reorder`).
- Dense Q4_K (`gemm.q4k_imma_prefill`) uses the same raw kernel.

## Bug found & fixed during validation

The activation-quantize **memo keyed on (ptr, M, K) was poisonous**: workspace buffers are reused across layers with the same pointer → every layer after the first computed on layer-1 activations. Unit tests passed (fresh pointers); the **teacher-forced PPL gate caught it** (31.6 → 441 k). Memo removed — the quantizer costs ~7 µs. Lesson encoded in-code: no pointer-keyed memoization over reused workspaces.

## Verification

- 11/11 `MmqQ8Imma` reference tests (raw kernel validated against the dequant reference; ragged MoE offsets incl. empty expert)
- PPL gate (above), decode neutral, VRAM headroom confirmed, `make verify-fast` green (pre-push hook)
- Flags default **off** (`gemm.moe_imma_prefill`, `gemm.q4k_imma_prefill`); default-flip after soak is a product decision

## Follow-ups

- Q6_K `down_proj` stays on dequant→cuBLAS — the remaining ~4–8 % to llama parity (needs per-16-scale handling)
- gemma-4 MoE routes through the separate `ggml_prefill` path — needs its own dispatch hook (its 2.5× gap is untouched by this PR)
- Kernel tuning headroom from #612 still applies (regs/occupancy, ldmatrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)