### PR TITLE
perf(gemm): Q5_1 raw-read IMMA — gemma-4-26B MoE prefill +111% cumulative (opt-in)

### DIFF
--- a/src/compute/mmq_q8_imma.cu
+++ b/src/compute/mmq_q8_imma.cu
@@ -789,6 +789,235 @@ constexpr size_t q6k_smem_bytes(int BM) {
 }
 
 // -----------------------------------------------------------------------------
+// Q5_1 RAW-read kernel (legacy 32-elem blocks, asymmetric).
+//
+// block_q5_1 = {half d; half m; u8 qh[4]; u8 qs[16]} = 24 B. One K-step =
+// two consecutive blocks = 48 contiguous bytes, and kb0 is always even so
+// the pair starts 16-B aligned (48·n) — NO repack needed, 3× cp.async-16
+// per row per K-step.
+//
+// w = d·q + m with q ∈ 0..31  →  q_sym = q − 16:  w = d·q_sym + (16d + m)
+// → exactly the kernel's α/β form (α = d, β = 16d + m), reusing the same
+// rowsum coupling as Q4_K. The 5th bit comes from qh: element j (0..15) =
+// qs[j]&0xF | bit(qh, j)<<4; element j+16 = qs[j]>>4 | bit(qh, j+16)<<4.
+// -----------------------------------------------------------------------------
+
+constexpr int kQ51Row = 48 + 16;  // staged pair row + pad
+
+// spread 4 consecutive bits of x into bit 4 of each byte lane
+__device__ __forceinline__ uint32_t q51_spread4(uint32_t bits) {
+    return (((bits & 1u) | ((bits & 2u) << 7) | ((bits & 4u) << 14) | ((bits & 8u) << 21)) << 4);
+}
+
+template <int BM>
+__device__ __forceinline__ void load_kstep_q51(int tid, const int8_t* __restrict__ A,
+                                               const __half* __restrict__ Asc,
+                                               const float* __restrict__ Ars,
+                                               const uint8_t* __restrict__ Wq51, int base_n,
+                                               int blk_count, int8_t (*sA)[kRow],
+                                               uint8_t (*sBq)[kQ51Row], __half (*sAsc)[2],
+                                               float (*sArs)[2], int base_m, int M, int K,
+                                               int subs, int k_base, int base_n_rows) {
+#pragma unroll
+    for (int i = tid; i < BM * 4; i += kThreads) {
+        const int row = i >> 2;
+        const int col = (i & 3) * 16;
+        const bool valid = (base_m + row) < M;
+        cp_async_cg_16(&sA[row][col],
+                       A + static_cast<size_t>(base_m + row) * K + k_base + col, valid);
+    }
+    const int kb0 = k_base / 32;
+#pragma unroll
+    for (int i = tid; i < kBN * 3; i += kThreads) {
+        const int row = i / 3;
+        const int part = i % 3;
+        const bool bvalid = (base_n_rows < 0) || (row < base_n_rows);
+        const uint8_t* blk =
+            Wq51 + (static_cast<size_t>(base_n + row) * blk_count + kb0) * 24 + part * 16;
+        cp_async_cg_16(&sBq[row][part * 16], blk, bvalid);
+    }
+#pragma unroll
+    for (int i = tid; i < BM; i += kThreads) {
+        const bool valid = (base_m + i) < M;
+        cp_async_ca_4(&sAsc[i][0], Asc + static_cast<size_t>(base_m + i) * subs + kb0, valid);
+        cp_async_ca_8(&sArs[i][0], Ars + static_cast<size_t>(base_m + i) * subs + kb0, valid);
+    }
+}
+
+template <int BM, bool BETA1>
+__global__ void __launch_bounds__(kThreads)
+    mmq_imma_q51_raw_kernel(const int8_t* __restrict__ X_s8, const __half* __restrict__ x_scale,
+                            const float* __restrict__ x_rowsum, const uint8_t* __restrict__ Wq51,
+                            __half* __restrict__ out, int M, int N, int K,
+                            const int32_t* __restrict__ expert_offsets, size_t w_stride_blocks) {
+    constexpr int kWM = (BM == 128) ? 4 : 2;
+    constexpr int kWN = (BM == 128) ? 2 : 4;
+    constexpr int kTileM = BM / kWM;
+    constexpr int kTileN = kBN / kWN;
+    constexpr int kMF = kTileM / 16;
+    constexpr int kNF = kTileN / 8;
+
+    int rows = M;
+    size_t row_off = 0;
+    const int e = blockIdx.z;
+    if (expert_offsets != nullptr) {
+        const int32_t o0 = __ldg(&expert_offsets[e]);
+        const int32_t o1 = __ldg(&expert_offsets[e + 1]);
+        row_off = static_cast<size_t>(o0);
+        rows = o1 - o0;
+    }
+    const int base_m = blockIdx.y * BM;
+    const int base_n = blockIdx.x * kBN;
+    if (base_m >= rows || rows == 0) return;
+    const int n_rem = (N - base_n >= kBN) ? -1 : (N - base_n);
+
+    const int subs = K / 32;
+    const int blk_count = subs;  // one block per 32
+    const int8_t* A = X_s8 + row_off * K;
+    const __half* Asc = x_scale + row_off * subs;
+    const float* Ars = x_rowsum + row_off * subs;
+    const uint8_t* W = Wq51 + static_cast<size_t>(e) * w_stride_blocks * 24;
+    __half* C = out + row_off * N;
+
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+    const int warp_m = warp_id / kWN;
+    const int warp_n = warp_id % kWN;
+    const int rl = lane >> 2;
+    const int cl = lane & 3;
+
+    __shared__ int8_t sA[kStages][BM][kRow];
+    __shared__ uint8_t sBq[kStages][kBN][kQ51Row];
+    __shared__ __half sAsc[kStages][BM][2];
+    __shared__ float sArs[kStages][BM][2];
+    __shared__ __half2 sBab[kStages][kBN][2];  // (α, β) per (col, kb)
+
+    float acc[kMF][kNF][4];
+#pragma unroll
+    for (int i = 0; i < kMF; ++i)
+#pragma unroll
+        for (int j2 = 0; j2 < kNF; ++j2)
+            acc[i][j2][0] = acc[i][j2][1] = acc[i][j2][2] = acc[i][j2][3] = 0.0f;
+
+    const int ksteps = K / kBK;
+    load_kstep_q51<BM>(tid, A, Asc, Ars, W, base_n, blk_count, sA[0], sBq[0], sAsc[0], sArs[0],
+                       base_m, rows, K, subs, 0, n_rem);
+    cp_async_commit();
+
+    for (int ks = 0; ks < ksteps; ++ks) {
+        const int stage = ks & 1;
+        if (ks + 1 < ksteps) {
+            const int nstage = (ks + 1) & 1;
+            load_kstep_q51<BM>(tid, A, Asc, Ars, W, base_n, blk_count, sA[nstage], sBq[nstage],
+                               sAsc[nstage], sArs[nstage], base_m, rows, K, subs, (ks + 1) * kBK,
+                               n_rem);
+            cp_async_commit();
+            cp_async_wait_group<1>();
+        } else {
+            cp_async_wait_group<0>();
+        }
+        __syncthreads();
+
+        // header → (α = d, β = 16d + m) cooperative pass
+        {
+#pragma unroll
+            for (int i = tid; i < kBN * 2; i += kThreads) {
+                const int row = i >> 1;
+                const int kb = i & 1;
+                const uint8_t* blk = &sBq[stage][row][kb * 24];
+                __half d_h, m_h;
+                memcpy(&d_h, blk, 2);
+                memcpy(&m_h, blk + 2, 2);
+                const float d = __half2float(d_h);
+                const float b = 16.0f * d + __half2float(m_h);
+                sBab[stage][row][kb] = __floats2half2_rn(d, b);
+            }
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int kb = 0; kb < 2; ++kb) {
+            const int kc = kb * 32;
+#pragma unroll
+            for (int mf = 0; mf < kMF; ++mf) {
+                const int arow_lo = warp_m * kTileM + mf * 16 + rl;
+                const int arow_hi = arow_lo + 8;
+                const int acol = kc + cl * 4;
+                uint32_t a0 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol]);
+                uint32_t a1 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol]);
+                uint32_t a2 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_lo][acol + 16]);
+                uint32_t a3 = *reinterpret_cast<const uint32_t*>(&sA[stage][arow_hi][acol + 16]);
+                const float da_lo = __half2float(sAsc[stage][arow_lo][kb]);
+                const float da_hi = __half2float(sAsc[stage][arow_hi][kb]);
+                const float rs_lo = sArs[stage][arow_lo][kb];
+                const float rs_hi = sArs[stage][arow_hi][kb];
+
+#pragma unroll
+                for (int nf = 0; nf < kNF; ++nf) {
+                    const int bcol = warp_n * kTileN + nf * 8 + rl;
+                    const uint8_t* blk = &sBq[stage][bcol][kb * 24];
+                    uint32_t qh;
+                    memcpy(&qh, blk + 4, 4);
+                    const uint32_t qs_u32 =
+                        *reinterpret_cast<const uint32_t*>(blk + 8 + cl * 4);
+                    // b0: elements cl*4..+3 (lows); b1: +16 (highs)
+                    const uint32_t b0 = __vsub4((qs_u32 & 0x0F0F0F0Fu) |
+                                                    q51_spread4((qh >> (cl * 4)) & 0xFu),
+                                                0x10101010u);
+                    const uint32_t b1 = __vsub4(((qs_u32 >> 4) & 0x0F0F0F0Fu) |
+                                                    q51_spread4((qh >> (16 + cl * 4)) & 0xFu),
+                                                0x10101010u);
+
+                    int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
+#if __CUDA_ARCH__ >= 800
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+                        : "=r"(c0), "=r"(c1), "=r"(c2), "=r"(c3)
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "r"(0), "r"(0),
+                          "r"(0), "r"(0));
+#endif
+                    const int ncol_lo = warp_n * kTileN + nf * 8 + cl * 2;
+                    const __half2 ab_lo = sBab[stage][ncol_lo][kb];
+                    const __half2 ab_hi = sBab[stage][ncol_lo + 1][kb];
+                    const float al = __half2float(__low2half(ab_lo));
+                    const float bl = __half2float(__high2half(ab_lo));
+                    const float ah = __half2float(__low2half(ab_hi));
+                    const float bh = __half2float(__high2half(ab_hi));
+                    acc[mf][nf][0] += da_lo * fmaf(al, static_cast<float>(c0), bl * rs_lo);
+                    acc[mf][nf][1] += da_lo * fmaf(ah, static_cast<float>(c1), bh * rs_lo);
+                    acc[mf][nf][2] += da_hi * fmaf(al, static_cast<float>(c2), bl * rs_hi);
+                    acc[mf][nf][3] += da_hi * fmaf(ah, static_cast<float>(c3), bh * rs_hi);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+#pragma unroll
+    for (int mf = 0; mf < kMF; ++mf) {
+        const int row_lo = base_m + warp_m * kTileM + mf * 16 + rl;
+        const int row_hi = row_lo + 8;
+#pragma unroll
+        for (int nf = 0; nf < kNF; ++nf) {
+            const int col = base_n + warp_n * kTileN + nf * 8 + cl * 2;
+            if (col + 1 >= N) continue;  // N-tail
+            if (row_lo < rows) {
+                __half2* p = reinterpret_cast<__half2*>(&C[static_cast<size_t>(row_lo) * N + col]);
+                __half2 v = __floats2half2_rn(acc[mf][nf][0], acc[mf][nf][1]);
+                *p = BETA1 ? __hadd2(*p, v) : v;
+            }
+            if (row_hi < rows) {
+                __half2* p = reinterpret_cast<__half2*>(&C[static_cast<size_t>(row_hi) * N + col]);
+                __half2 v = __floats2half2_rn(acc[mf][nf][2], acc[mf][nf][3]);
+                *p = BETA1 ? __hadd2(*p, v) : v;
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Q8_0 SoA split: raw 34-B blocks {half d; int8 qs[32]} (2-aligned! memcpy
 // only) → qs plane [N][K] s8 + interleaved (α=d, β=0) plane [N][K/32][2].
 // -----------------------------------------------------------------------------
@@ -948,6 +1177,7 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
     if (qkind == 2 &&
         !ensure_q6k(w_blocks, static_cast<size_t>(ne) * N * (K / 256), stream, capturing))
         return false;
+    // qkind 3 (Q5_1) reads raw blocks — nothing to prepare
     const int act_rows = d_offsets ? expanded : M;
     if (!ensure_act(act_rows, K, capturing)) return false;
     quantize_act(x_f16, act_rows, K, stream);
@@ -972,6 +1202,24 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
         } else {
             mmq_imma_q4k_raw_kernel<128, false><<<grid, kThreads, 0, stream>>>(
                 g_act.xs8, g_act.xscale, g_act.xrowsum, w4, out_f16, M, N, K, d_offsets,
+                w_stride_blocks);
+        }
+        return true;
+    }
+    if (qkind == 3) {
+        const uint8_t* w5 = static_cast<const uint8_t*>(w_blocks);
+        const size_t w_stride_blocks = static_cast<size_t>(N) * (K / 32);
+        if (small_m) {
+            mmq_imma_q51_raw_kernel<32, false><<<grid, kThreads, 0, stream>>>(
+                g_act.xs8, g_act.xscale, g_act.xrowsum, w5, out_f16, M, N, K, d_offsets,
+                w_stride_blocks);
+        } else if (beta == 1.0f) {
+            mmq_imma_q51_raw_kernel<128, true><<<grid, kThreads, 0, stream>>>(
+                g_act.xs8, g_act.xscale, g_act.xrowsum, w5, out_f16, M, N, K, d_offsets,
+                w_stride_blocks);
+        } else {
+            mmq_imma_q51_raw_kernel<128, false><<<grid, kThreads, 0, stream>>>(
+                g_act.xs8, g_act.xscale, g_act.xrowsum, w5, out_f16, M, N, K, d_offsets,
                 w_stride_blocks);
         }
         return true;
@@ -1056,7 +1304,8 @@ bool mmq_q6k_imma_gemm(const void* w_q6k_blocks, const __half* x_f16, __half* ou
 bool mmq_imma_moe_gemm(const void* w_blocks, int qkind, const __half* x_f16, __half* out_f16,
                        const int32_t* d_offsets, int h_max_rows, int expanded, int ne, int N,
                        int K, cudaStream_t stream) {
-    if (N % 2 != 0 || K % (qkind != 0 ? 256 : kBK) != 0) return false;
+    if (N % 2 != 0) return false;
+    if (K % ((qkind == 1 || qkind == 2) ? 256 : kBK) != 0) return false;
     if (h_max_rows <= 0 || expanded <= 0 || ne <= 0) return false;
     const bool ok = gemm_common(w_blocks, qkind, x_f16, out_f16, /*M=*/0, N, K, stream, 0.0f,
                                 d_offsets, h_max_rows, expanded, ne);
@@ -1064,7 +1313,9 @@ bool mmq_imma_moe_gemm(const void* w_blocks, int qkind, const __half* x_f16, __h
     if (ok && !logged) {
         logged = true;
         IMP_LOG_INFO("MoE IMMA prefill ACTIVE (%s, ne=%d N=%d K=%d max_rows=%d)",
-                     qkind == 1 ? "Q4_K" : (qkind == 2 ? "Q6_K" : "Q8_0"), ne, N, K, h_max_rows);
+                     qkind == 1 ? "Q4_K"
+                                : (qkind == 2 ? "Q6_K" : (qkind == 3 ? "Q5_1" : "Q8_0")),
+                     ne, N, K, h_max_rows);
     }
     return ok;
 }

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -457,9 +457,12 @@ bool GraphExecutor::try_run_moe_fp16_batch_prefill(int layer, cudaStream_t strea
         int64_t rows = packed.shape[1];
         int64_t cols = packed.shape[2];
         if (moe_imma && out_dtype == QType::F16 &&
-            (qtype == QType::Q8_0 || qtype == QType::Q4_K || qtype == QType::Q6_K) &&
+            (qtype == QType::Q8_0 || qtype == QType::Q4_K || qtype == QType::Q6_K ||
+             qtype == QType::Q5_1) &&
             max_rows_per_expert > 0) {
-            const int qkind = (qtype == QType::Q4_K) ? 1 : (qtype == QType::Q6_K ? 2 : 0);
+            const int qkind = (qtype == QType::Q4_K)
+                                  ? 1
+                                  : (qtype == QType::Q6_K ? 2 : (qtype == QType::Q5_1 ? 3 : 0));
             if (mmq_imma_moe_gemm(packed.data, qkind,
                                   reinterpret_cast<const __half*>(a_base),
                                   reinterpret_cast<__half*>(c_base),

--- a/tests/test_mmq_q8_imma.cu
+++ b/tests/test_mmq_q8_imma.cu
@@ -348,6 +348,81 @@ TEST(MmqQ8Imma, Q6KDenseNRMSE) {
     mmq_q8_imma_release_all();
 }
 
+// ---- Q5_1 MoE grouped — NRMSE vs dequant reference (asymmetric β-form) ----
+TEST(MmqQ8Imma, MoeGroupedQ51) {
+    const int ne = 2, N = 128, K = 256;
+    const int rows_per[ne] = {70, 41};
+    int32_t h_off[ne + 1] = {0};
+    for (int e = 0; e < ne; ++e) h_off[e + 1] = h_off[e] + rows_per[e];
+    const int expanded = h_off[ne];
+
+    // packed q5_1 experts: [ne][N][K/32] 24-B blocks
+    const int bpr = K / 32;
+    std::vector<uint8_t> W(static_cast<size_t>(ne) * N * bpr * 24);
+    std::mt19937 rng(401);
+    for (size_t b = 0; b < W.size() / 24; ++b) {
+        uint8_t* bp = W.data() + b * 24;
+        __half dh = __float2half(0.001f + 0.0005f * (rng() % 100));
+        __half mh = __float2half(-0.02f + 0.0004f * (rng() % 100));
+        std::memcpy(bp, &dh, 2);
+        std::memcpy(bp + 2, &mh, 2);
+        for (int i = 0; i < 20; ++i) bp[4 + i] = static_cast<uint8_t>(rng() & 0xFF);
+    }
+    std::vector<__half> x(static_cast<size_t>(expanded) * K);
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+    for (auto& v : x) v = __float2half(nd(rng));
+
+    uint8_t* d_w; __half *d_x, *d_out; int32_t* d_off;
+    ASSERT_EQ(cudaMalloc(&d_w, W.size()), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_x, x.size() * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_out, static_cast<size_t>(expanded) * N * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_off, sizeof(h_off)), cudaSuccess);
+    cudaMemcpy(d_w, W.data(), W.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, x.data(), x.size() * 2, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_off, h_off, sizeof(h_off), cudaMemcpyHostToDevice);
+    ASSERT_TRUE(mmq_imma_moe_gemm(d_w, /*qkind=*/3, d_x, d_out, d_off, 70, expanded, ne, N, K,
+                                  nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    std::vector<__half> out(static_cast<size_t>(expanded) * N);
+    cudaMemcpy(out.data(), d_out, out.size() * 2, cudaMemcpyDeviceToHost);
+
+    // dequant reference (unquantized activations; NRMSE bound)
+    auto q5 = [&](const uint8_t* bp, int i) -> int {
+        uint32_t qh;
+        std::memcpy(&qh, bp + 4, 4);
+        const uint8_t* qs = bp + 8;
+        if (i < 16) return (qs[i] & 0xF) | (((qh >> i) & 1u) << 4);
+        return (qs[i - 16] >> 4) | (((qh >> (i)) & 1u) << 4);
+    };
+    double err2 = 0, ref2 = 0;
+    for (int e = 0; e < ne; ++e) {
+        for (int r = h_off[e]; r < h_off[e + 1]; ++r) {
+            for (int n = 0; n < N; ++n) {
+                double ref = 0;
+                for (int s2 = 0; s2 < bpr; ++s2) {
+                    const uint8_t* bp =
+                        W.data() + ((static_cast<size_t>(e) * N + n) * bpr + s2) * 24;
+                    __half dh, mh;
+                    std::memcpy(&dh, bp, 2);
+                    std::memcpy(&mh, bp + 2, 2);
+                    const double d = __half2float(dh), mm = __half2float(mh);
+                    for (int i = 0; i < 32; ++i)
+                        ref += static_cast<double>(
+                                   __half2float(x[(size_t)r * K + s2 * 32 + i])) *
+                               (d * q5(bp, i) + mm);
+                }
+                const double got = __half2float(out[(size_t)r * N + n]);
+                err2 += (got - ref) * (got - ref);
+                ref2 += ref * ref;
+            }
+        }
+    }
+    const double nrmse = std::sqrt(err2 / std::max(ref2, 1e-30));
+    EXPECT_LT(nrmse, 2e-2) << "Q5_1 MoE NRMSE";
+    cudaFree(d_w); cudaFree(d_x); cudaFree(d_out); cudaFree(d_off);
+    mmq_q8_imma_release_all();
+}
+
 TEST(MmqQ8Imma, MoeGroupedQ8) {
     const int ne = 4, N = 128, K = 256;
     const int rows_per[ne] = {37, 0, 96, 19};  // ragged; expert 1 empty


### PR DESCRIPTION
## Summary

Q5_1 (gemma-4's `down_proj` expert quant, profiled in #615) joins the IMMA family — all three gemma-4 expert GEMMs now run fused on int8 tensor cores.

**No repack needed**: the 24-B legacy blocks pair per 64-wide K-step into 48 contiguous, 16-B-aligned bytes (kb0 is always even → offset 48·n). The asymmetry folds into the existing β-form exactly: w = d·q + m with q∈0..31 → α = d, β = 16d + m. The 5th bit spreads from `qh` into byte-lane bit 4.

## Measured (gemma-4-26B-A4B-it-UD-Q4_K_M, `gemm.moe_imma_prefill=true`)

| | value |
|---|---:|
| pp512 | 4 231 (baseline) → 6 686 (#615) → **8 946 (+111 % cumulative)** |
| gap vs llama.cpp (10 749) | 2.51× → **1.20×** |
| decode tg256 | 262.9 (neutral) |
| PPL (teacher-forced, deterministic) | 131.05 → **122.33 (better)** |
| tests | 14/14 (new `MoeGroupedQ51` vs dequant reference) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)