### PR TITLE
perf(dp4a): 16-B-aligned block_q8_1 (48-B stride) — removes the #598 activation-load ceiling

### DIFF
--- a/src/compute/gemm.h
+++ b/src/compute/gemm.h
@@ -56,12 +56,22 @@ void gemv_gate_fp32_fp32input(const half* W, const float* x, float* y, int M, in
 
 // Q8_1 block: 32 int8 quantized values + FP16 scale (d) + FP16 sum (s).
 // The sum field enables the dp4a bias subtraction trick.
-struct block_q8_1 {
+//
+// LAYOUT (since 2026-06-07, #598 follow-up): qs first + alignas(16) + pad to
+// a 48-B stride. The historical ggml-style 36-B layout put qs at offset 4 —
+// never 16-B aligned — which chained every dp4a GEMV activation read to
+// 8× LDG.32 per block (the measured structural ceiling of the kernel
+// family: 31-42% DRAM BW). With qs at offset 0 and 16-B block alignment the
+// existing 32-B memcpy loads compile to 2× LDG.128. Costs 12 pad bytes per
+// block in tiny scratch buffers. mmvq keeps its own ggml_block_q8_1 (the
+// imported ggml vec_dot kernels expect the original layout).
+struct alignas(16) block_q8_1 {
+    int8_t qs[32];  // quantized values (16-B aligned: offset 0, stride 48)
     half d;         // delta (scale): val = d * qs[i]
     half s;         // sum of qs[0..31] (unused for Q6_K path, used for Q4 variants)
-    int8_t qs[32];  // quantized values
+    int8_t pad[12];
 };
-static_assert(sizeof(block_q8_1) == 36, "block_q8_1 must be 36 bytes");
+static_assert(sizeof(block_q8_1) == 48, "block_q8_1: 48-B stride (16-B-aligned qs plane)");
 
 // Quantize FP16 input vector to Q8_1 blocks.
 // x: [K] FP16, q8_1_out: [K/32] block_q8_1, d8_out: [K/32] float (block scales for fast access).

--- a/tests/test_quant_integration.cu
+++ b/tests/test_quant_integration.cu
@@ -1925,7 +1925,7 @@ TEST(QuantIntegrationTest, Q5_KDp4aDenseGemm) {
 
     // Q8_1 scratch
     int q8_blocks = M * (K / 32);
-    void* d_q8 = nullptr; cudaMalloc(&d_q8, q8_blocks * 36);
+    void* d_q8 = nullptr; cudaMalloc(&d_q8, q8_blocks * sizeof(imp::block_q8_1));
     float* d_d8 = nullptr; cudaMalloc(&d_d8, q8_blocks * sizeof(float));
 
     gemm_q5k_dp4a_dense(d_w, d_act, d_out, d_q8, d_d8, M, N, K, nullptr);


### PR DESCRIPTION
## Summary

The #598 follow-up, collapsed from the assumed 'SoA repack (separate, larger project)' to a **single struct change**: `block_q8_1` reordered (qs first) + `alignas(16)` + pad to a 48-B stride. The historical 36-B ggml-style layout put `qs` at offset 4 — never 16-B aligned — chaining the kpar/dense dp4a GEMV activation reads to 8× LDG.32 per block (the documented structural ceiling of the family). **SASS now shows `LDG.E.128` on the kpar kernels.**

## Honest measurement

**Decode-neutral on the current zoo**: Qwen3-30B-A3B tg256 280–282 vs 283.7 baseline (noise), PPL bit-identical (31.6039). Root cause of the neutrality, now understood: the 30B-MoE decode runs the *moe-dp4a* variants whose 4-byte chunk loads were already thread-coalesced — the #598 ceiling applied to the kpar/dense family, which today's zoo rarely exercises for decode (dense K-quants ride the NVFP4 decode cache). Zero-cost hygiene that un-blocks the family for any future dense-K-quant dp4a workload; pp512 unaffected (10.1k on the 30B).

**Corrected diagnosis for the remaining 30B decode gap (283 vs llama 314)**: both engines run at only ~17–19 % of the weight-bandwidth ceiling (~1.6k tok/s) — the gap is launch/latency-bound expert fragmentation, not activation alignment. Follow-up diagnosis planned.

## Scope

- mmvq keeps its own `ggml_block_q8_1` (imported ggml vec_dot kernels expect the original layout)
- All sizing sites use `sizeof()` and adapt automatically; one test hardcoded 36 (fixed)
- 35/35 quant + 180/180 compute tests green; `make verify-fast` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)