### PR TITLE
VRAM cache rebuild: Stage 1 (one tier truth) + Stage 2 (RAII ownership)

### DIFF
--- a/docs/audit/vram_cache_structure_2026_06_07.md
+++ b/docs/audit/vram_cache_structure_2026_06_07.md
@@ -1,0 +1,135 @@
+# VRAM / weight-cache structure audit — 2026-06-07
+
+Scope: where model-weight VRAM goes, which copies coexist, and where the
+caching/budget architecture has lost structure. All findings verified against
+source AND real bench logs (Qwen3-8B Q8_0 GGUF, Qwen3-14B Q6_K GGUF on clean
+`main`). Diagnostic-only; no code changed.
+
+## TL;DR
+
+Per GGUF weight, up to **three** representations are resident at once:
+the original GGUF blocks (used by prefill), an NVFP4 decode cache (used by
+decode), and a CUTLASS scale-factor buffer (**used by nobody on GGUF**). On top
+of that, three independent systems decide tiers and budget, only the weakest of
+which actually drives allocation, and two cleanup passes that look load-bearing
+are dead no-ops. The owner's instinct ("null Struktur") is correct: the cache
+layer is mid-refactor and the migration stalled.
+
+Measured residency (clean main, real logs):
+
+| Model | GGUF source (prefill) | NVFP4 decode | CUTLASS SF | weight held ≈ |
+|-------|-----------------------|--------------|------------|---------------|
+| Qwen3-8B Q8_0  | ~8.0 GB | 4.06 GB | 0.45 GB (dead) | **1.55×** |
+| Qwen3-14B Q6_K | ~9.76 GB | 6.69 GB | 0.83 GB (dead) | **1.8×** |
+
+`GPU memory: 16396 MiB used` for an 8B-Q8 model that weighs 8.3 GB on disk.
+
+---
+
+## Gap G1 — three tier-decision systems, only the worst one rules
+
+There are three places that decide "which tier does weight X get", and they
+disagree by design:
+
+1. **`StoragePlanner`** (`src/runtime/storage_planner.cpp`) — fully implemented,
+   source-qtype-aware (`effective_capabilities(kind, source_qtype)`), has a
+   budget-pressure downgrade loop. **Completely unused.**
+   `src/runtime/vram_budget.cpp:174`: *"Heuristic still drives allocation;
+   planner output diagnostic only (5.1.5)."*
+2. **Heuristic** (`vram_budget.cpp:106-271`) — source-*blind*
+   (`nvfp4_beneficial(qtype)`, never consults `kind` or the capability table).
+   This is what actually sizes the caches.
+3. **Runtime `nvfp4_beneficial`** — a **second copy** of the same predicate at
+   `src/exec/pre_dequant_internal.h:98`, called per-tensor during the Phase 0-3
+   build to decide which weights physically get an NVFP4 slot. Identical logic to
+   the `vram_budget.cpp:108` lambda, different file → silent drift risk.
+
+Live divergence in the logs: planner projects **10055 MiB**, heuristic projects
+**7504 + 833 MiB**. Nobody reconciles the gap; the planner's answer is logged and
+thrown away. The planner has been "diagnostic only" since commit 5.1.5 and the
+flip to make it authoritative ("retire heuristic") was never started.
+
+## Gap G2 — Phase 4b "drop redundant GGUF source" is a dead no-op
+
+`pre_dequant_phase4b_drop_redundant_sources_` (`pre_dequant_phase4_tensor_registry.cu:463`)
+is wired into the pipeline with `actually_free = true`, and a sibling diagnostic
+prints *"7668 MiB of original GGUF could be freed … deferred to Commit 5.1.4.b."*
+
+But it frees **nothing**. The skip guard at lines 489-490:
+
+```cpp
+if (wcache_.cutlass_nvfp4.count(t.data) > 0 ||
+    wcache_.nvfp4.count(t.data) > 0) { /* skip */ }
+```
+
+`wcache_.nvfp4` is keyed on the **source pointer** `t.data`, so this is true for
+*every* NVFP4-overlay weight — i.e. exactly the weights `can_drop_source()` just
+flagged as droppable. Result: `marked_count = 0`, and the "Phase-4b freed N
+sources" log line never appears in any real run (confirmed: only the 4a
+diagnostic prints).
+
+Worse, the diagnostic's premise is now **false**: it claims the overlay "covers
+prefill + decode", but since the IMMA raw-read prefill work (#617), GGUF prefill
+reads the **original GGUF source** directly —
+`executor_kernels.cu:1868` → `mmq_q8_imma_gemm(h.source_data, …)`. The GGUF source
+is *not* redundant; prefill needs it. So the "7.6/9.8 GB could be freed" number is
+misleading, the free path can't fire, and both halves of the feature are dead.
+
+## Gap G3 — the CUTLASS scale-factor buffer is dead weight on GGUF
+
+For every GGUF weight, Phase 3b builds a `cutlass_nvfp4` entry (borrowed packed
+data + a freshly-allocated SfAtom scale buffer). Logs: `wcache actual:
+nvfp4=253 cutlass_nvfp4=253`.
+
+That CUTLASS SF buffer (0.45 GB Q8 / 0.83 GB Q6K) is **never read** for GGUF
+models, verified three independent ways:
+- The planner says it shouldn't exist: `plan-ideal tiers: … cutlass_nvfp4=0`.
+- GGUF weights get `primary_tier = NVFP4`, but the CUTLASS prefill path only fires
+  for `primary_tier == CUTLASS_NVFP4` (`executor_kernels.cu:1894`) — the native
+  SafeTensors-NVFP4 case.
+- Prefill goes through IMMA raw-read on the source; decode goes through the plain
+  `nvfp4` GEMV. Neither touches `cutlass_nvfp4`.
+
+This is pure waste on the GGUF path. (Note: this is *not* double-storage of the
+packed weights — `cutlass_nvfp4.data` borrows `nvfp4.packed_data`, only the scale
+factors are a second buffer. That part is clean.)
+
+## Gap G4 — GGUF source ⊕ NVFP4 coexistence is structural, not a leak
+
+The big 1.55–1.8× residency is the GGUF source (prefill, IMMA raw-read) plus the
+NVFP4 decode cache (decode, GEMV) living side by side. This is a *deliberate*
+prefill/decode split — two different representations for two different kernels —
+not a bug, and not trivially removable while both paths run in one process. It
+*is* the dominant VRAM cost and worth a design decision: is keeping a full FP-rep
+for prefill the right call now that IMMA raw-read decode-format kernels exist, or
+could decode and prefill share one representation?
+
+## Gap G5 — no cross-cache ownership/dedup; mode-asymmetric FP16 freeing
+
+- `VRAMAllocator` tracks tagged bytes for reporting but does no dedup across the
+  ~9 weight-cache maps (`fp16/fp8/nvfp4/nvfp4_moe/cutlass_nvfp4/cutlass_mxfp4/
+  q4k_imma/fused_kv/fused_gate_up`). Each map is independent; correctness of
+  "this weight lives in exactly one tier" rests entirely on the build-order
+  conventions in the Phase 1-3 lambdas, not on any invariant.
+- FP16-cache freeing is **mode-asymmetric**: Mode 0 frees each FP16 entry as it
+  seeds the NVFP4 build (`phase3…:449-457`); Mode 1 "additive" keeps them. *(Claim
+  surfaced by sub-agent; needs a targeted measurement on a model that actually
+  builds an FP16 cache before trusting the magnitude — Q8/Q6K early-return out of
+  FP16 so they don't exhibit it.)*
+
+---
+
+## Suggested cleanup order (cheap → structural)
+
+1. **G3 (cheap win):** stop building `cutlass_nvfp4` SF buffers for GGUF
+   (`primary_tier == NVFP4`) models. Frees 0.45–0.83 GB, zero behaviour change.
+   Verify no native-NVFP4 regression.
+2. **G2 (correctness/clarity):** either make Phase 4b actually free droppable
+   sources (re-key the skip guard off the *owned* packed pointer, not the source
+   key) **or** delete the dead pass + the misleading diagnostic. As-is it's
+   confusing dead code claiming a 7.6 GB win that can't happen.
+3. **G1 (de-dup the truth):** collapse the two `nvfp4_beneficial` copies to one
+   shared symbol; decide whether to finish the planner migration or delete the
+   planner. Two-and-a-half tier oracles is the root "null Struktur" smell.
+4. **G4 (design decision, biggest VRAM):** revisit the prefill/decode dual-rep now
+   that IMMA raw-read exists — owner call, not a mechanical fix.

--- a/docs/superpowers/specs/2026-06-07-vram-cache-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-07-vram-cache-architecture-design.md
@@ -1,0 +1,203 @@
+# VRAM / weight-cache architecture — clean rebuild (design)
+
+Date: 2026-06-07
+Status: approved skeleton → implementation planning
+Audit basis: `docs/audit/vram_cache_structure_2026_06_07.md`
+
+## Problem
+
+The weight-cache layer is mid-refactor and the migration stalled. Three
+independent systems decide a weight's storage tier and disagree by design; two
+cleanup passes that look load-bearing are dead no-ops; per GGUF weight up to
+three representations are resident. Measured on clean `main`:
+
+- Qwen3-8B Q8_0: GGUF source ~8.0 GB + NVFP4 decode 4.06 GB + CUTLASS SF 0.45 GB
+  (dead) → weight held ~1.55×. `GPU memory: 16396 MiB used` for an 8.3 GB model.
+- Qwen3-14B Q6_K: ~9.76 GB + 6.69 GB + 0.83 GB (dead) → ~1.8×.
+
+Audit gaps (see audit doc for file:line):
+- **G1** — three tier oracles: `StoragePlanner` (correct, source-aware, but
+  "diagnostic only (5.1.5)"), the `vram_budget.cpp` heuristic (source-blind,
+  actually allocates), and a *second* `nvfp4_beneficial` copy in
+  `pre_dequant_internal.h`. Planner projects 10055 MiB vs heuristic 7504+833 —
+  nobody reconciles.
+- **G2** — Phase 4b "drop redundant GGUF source" is a dead no-op: its skip guard
+  `wcache_.nvfp4.count(t.data) > 0` matches every NVFP4 weight (map keyed on the
+  source pointer) → `marked_count = 0`. Its sibling diagnostic claims "7.6 GB
+  could be freed, overlay covers prefill" — false since IMMA raw-read prefill
+  (#617) reads `h.source_data` directly.
+- **G3** — the CUTLASS SF buffer is dead weight on GGUF (0.45–0.83 GB): planner
+  says `cutlass_nvfp4=0`, GGUF weights are `primary_tier=NVFP4`, the CUTLASS
+  prefill path only fires for `primary_tier==CUTLASS_NVFP4`.
+- **G4** — GGUF source ⊕ NVFP4 coexistence (the big 1.55–1.8×) is a *deliberate*
+  prefill/decode split, both perf-justified (measured). Not a leak. Out of scope
+  for the strict-quality-neutral rebuild.
+- **G5** — no cross-cache ownership invariant; correctness rests on build-order
+  conventions + `borrowed`/`owned` bool flags across ~9 cache maps.
+
+### Evidence that calibrated scope
+
+- **native-NVFP4 (strategic models) is already lean**: `fp16=0`, prefill via
+  CUTLASS-NVFP4 TC, decode via NVFP4 GEMV, both from the same source. The 1.55–
+  1.8× doubling is a **GGUF-only** (legacy-path) phenomenon.
+- VRAM↔speed is **shape/kernel-dependent, measured both ways**: GDN projections
+  FP16→NVFP4 *regress* decode −9..−20% (kernel efficiency beats byte count);
+  `nvfp4_attn_proj` *gains* +3.8%; dropping the GGUF NVFP4 decode cache costs
+  −27% (Gemma 165→130). So the big GGUF posts are real Roofline trades, not
+  structural waste.
+
+## Goals & constraints
+
+- **Strictly quality-neutral**: output PPL/greedy must not change. All existing
+  arch carve-outs preserved, only encoded cleanly instead of scattered.
+- **Performance-gated**: every sub-PR within the 3% decode / 5% prefill gate.
+- **Staged**: each stage independently mergeable, benched, reversible.
+- VRAM is the scarce resource; recover it where free, never trade it for
+  measurable speed/quality loss.
+
+## Roadmap (staged)
+
+1. **Stage 1 — One overlay-tier truth (this spec).** `StoragePlanner` becomes
+   authoritative for the overlay-tier decision; heuristic + the duplicate
+   `nvfp4_beneficial` die; dead posts (G3, G2, the double CUTLASS build) fall out
+   as a consequence. Low risk, ~1 GB (G3 0.45–0.83 + double CUTLASS ~0.4) +
+   structural clarity.
+2. **Stage 2 — Arena ownership (RAII).** One stream-aware arena owner holds all
+   weight allocations; the ~9 cache maps become non-owning views; owning-vs-
+   borrowing moves into the type system. Kills the lifecycle-bug class (G5, the
+   model-swap leak). Its own spec; builds on Stage 1's reduced cache variety.
+3. **Stage 3 (optional) — Honest budget.** The planner's downgrade loop is used
+   for real (not diagnostic); the `reserve` fudge is replaced by plan bytes.
+   Closes G1 fully.
+
+Stages 2 and 3 are sketched here for context only and get their own specs.
+
+---
+
+## Stage 1 design
+
+### Scope
+
+Stage 1 consolidates the **overlay-tier decision** (which tensor gets an
+FP16/FP8/NVFP4/CUTLASS overlay cache). It does **not** touch: the native GGUF
+source blocks (`Model::gpu_allocations_`), the GGUF source ⊕ NVFP4 dual-rep
+(G4), physical allocation mechanics, or ownership/lifecycle (Stage 2). Only the
+decision is unified.
+
+The `StoragePlan` already scopes exactly this: per its header comment it
+describes "the overlay layer — tensors whose storage tier is a runtime decision",
+while native GGUF blocks "bypass the plan/registry entirely". We make the
+already-correct plan authoritative instead of diagnostic.
+
+### Architecture: one producer, many readers
+
+**Producer** — `plan_storage(model, cfg, hints)` runs once, early (before the
+pre-dequant phases), and the result is held on the executor for the model's
+lifetime (today it runs twice, both discarded as diagnostics).
+
+**Readers** (replace their own tier logic with a plan lookup):
+
+| Site | Today | Stage 1 |
+|------|-------|---------|
+| `vram_budget.cpp` sizing | `nvfp4_beneficial(qtype)` heuristic estimate | read `plan.projected_vram_bytes` + per-tier sums |
+| Phase 1 FP16 build | `plan_routes_to_fp16(kind, qtype)` local lambda | `plan.tier(id) == FP16` |
+| Phase 2 FP8 build | local FP8 routing | `plan.tier(id) == FP8` |
+| Phase 3 NVFP4 build | `nvfp4_beneficial(qtype, decode_all)` | `plan.tier(id) ∈ {NVFP4, CUTLASS_NVFP4}` |
+| Phase 3b CUTLASS build | iterate all `wcache_.nvfp4` | only entries `plan.tier(id) == CUTLASS_NVFP4` |
+| Phase 4b drop-source | broken `wcache.count` guard | `plan.tier(id)` says source is overlay-covered |
+
+A small plan-index helper (`tier_of(TensorID)` / `tier_of(const void* src)`)
+backs the lookups; `TensorID` already keys the registry.
+
+### Arch carve-outs as plan rules
+
+Today the arch-specific quality rules are scattered across
+`engine_init_resolver.cpp`, the phase lambdas, and `effective_capabilities`.
+Stage 1 gathers them into **one** post-plan pass `apply_arch_rules(plan, cfg,
+hints)` (chosen over expanding `effective_capabilities` so the clean kind×qtype
+capability table stays free of arch special-cases):
+
+- **gemma-3**: nvfp4_beneficial weights (Q6_K/Q8_0/Q5_K) require a companion FP16
+  entry so the NVFP4 decode cache is built FROM the FP16 copy, not from scratch
+  (from-scratch corrupts gemma-3 decode → `<pad>`/IMA). Encoded as: for
+  `arch==GEMMA3`, NVFP4-tier entries also get an FP16 backing flag. This requires
+  extending `StoragePlan::Entry` with a `bool fp16_companion` (or equivalent), so
+  Stage 1 touches the plan schema — Phase 1 reads it to keep the FP16 copy alive.
+- **GDN `ssm_in`/`ssm_out`**: FP16 floor by default (recurrent precision); NVFP4
+  only when `hints.nvfp4_ssm_proj`. (Wide-GDN NVFP4 measured to *regress* speed —
+  keeping FP16 is correct for speed, not just quality.)
+- **`nvfp4_attn_proj`, `nvfp4_lm_head`, `nvfp4_lm_head_gdn`**: opt-in hints that
+  promote specific recipe-excluded BF16 kinds to an NVFP4 entry.
+- **native-NVFP4 prefill**: stays CUTLASS-NVFP4 (no FP16 prefill copy — already
+  the runtime reality; the stale "all dense weights get FP16 prefill" comment in
+  `pre_dequant_phase4_tensor_registry.cu` is corrected).
+
+One function decides; all phases read. This is the structural insurance against
+the scattered-`if(arch==…)` bug class (the rejected 2026-06-07 FP16-gate diff,
+the #428×#434 regression).
+
+### VRAM by-catch (consequences, not separate features)
+
+- **G3**: the plan assigns `cutlass_nvfp4` only where `tier==CUTLASS_NVFP4`
+  (native-NVFP4). GGUF weights are `tier==NVFP4` → Phase 3b skips them → the
+  0.45–0.83 GB dead SF buffer is never built.
+- **double CUTLASS (native)**: the plan enumerates each tensor once; Phase 0
+  (prequant) and Phase 3 reconcile against the single plan instead of both
+  building → the ~0.4 GB overlap goes away. *(Exact overlap to be confirmed in
+  the implementation plan — flagged, not assumed.)*
+- **G2**: Phase 4b reads the plan to decide droppability honestly. Since IMMA
+  raw-read prefill needs the GGUF source, the honest answer for GGUF NVFP4-tier
+  weights is "not droppable" — so the misleading "7.6 GB could be freed"
+  diagnostic is removed and the dead free-path is either fixed to free genuinely-
+  redundant sources or deleted. (No GGUF VRAM recovered here — the value is
+  removing false code.)
+
+### Migration (incremental, each sub-PR gated)
+
+1. Hold the plan persistently on the executor; expose `tier_of()` lookups. No
+   behaviour change yet (plan still not read by builders) — pure plumbing.
+2. Convert **one phase at a time** to plan-query, each as its own PR, proving
+   parity (golden + perf + canaries) before the next.
+3. Convert `vram_budget.cpp` sizing to plan bytes last (it gates KV size, so it
+   moves once the per-phase builds are plan-driven and stable).
+4. Delete the heuristic `nvfp4_beneficial` lambda and the
+   `pre_dequant_internal.h` copy; the dead posts (G3, double CUTLASS) and the
+   Phase-4b diagnostic fall out in the same PRs that make their producers
+   plan-driven.
+
+Order rationale: plumbing first (zero risk), then per-phase (smallest provable
+steps), sizing last (highest blast radius).
+
+### Verification / canaries
+
+Every sub-PR must be green on all four:
+- **golden output** — bit-neutral greedy output (the strict-quality-neutral gate)
+- **perf gate** — 3% decode / 5% prefill vs `tests/perf_baseline.json`
+- **gemma-3-12b Q4_K_M coherence** — the crash canary (clean main: coherent;
+  rejected diff: `<pad>`/IMA). `check-degeneration` battery.
+- **Qwen3-14B Q6_K decode** — the north-star, the −15.5% canary from the rejected
+  diff. `verify-north-star`.
+
+These four are exactly the net that caught the rejected FP16-gate diff this
+morning; making them a per-PR gate is the point.
+
+### Out of scope (Stage 1)
+
+- GGUF source ⊕ NVFP4 dual-rep (G4) — real Roofline trade, strict-neutral keeps it.
+- Ownership/RAII (G5) — Stage 2.
+- Planner downgrade loop driving real allocation (G1 final) — Stage 3.
+- Any kernel or dispatch change. Stage 1 is allocation-decision only.
+
+### Risks
+
+- **Plan/runtime parity gaps**: the plan's per-(kind,qtype) tier must exactly
+  reproduce today's per-phase decisions for every model in the zoo, or output
+  changes. Mitigation: per-phase migration with golden parity; the plan already
+  runs as a diagnostic, so a pre-migration A/B of "plan tier vs actual wcache
+  tier" per model surfaces mismatches before any builder is switched.
+- **`kind` classification**: the planner uses field position (L.wq→WQ); any
+  tensor reaching a builder without a matching plan entry must fall back safely
+  (treat as "no overlay", today's uncached path) and log, never silently
+  mis-tier.
+- **MoE / hybrid coverage**: expert and shared-expert kinds, GDN exclusions
+  (`gdn_gate` intentionally not enumerated) must be preserved exactly.

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -941,6 +941,16 @@ private:
     // Mode flags mirrored from wcache_ for PlanHints (hints_ is the Phase 5 source of truth).
     PlanHints hints_;
 
+    // Stage 1 (one-tier-truth): the StoragePlanner output, held for the model's
+    // lifetime. Built once at the top of pre_dequant_weights(). The pre-dequant
+    // phases are being migrated to read their overlay-tier decision from here
+    // (plan_tier_of) instead of scattered nvfp4_beneficial/plan_routes_to_fp16
+    // checks. Empty until pre_dequant_weights runs.
+    StoragePlan storage_plan_;
+    // Planned overlay tier for a source pointer, or Undefined if the pointer is
+    // not in the plan (native GGUF blocks bypass the overlay layer).
+    StorageTier plan_tier_of(const void* src) const { return storage_plan_.tier_of(src); }
+
     // WeightRegistry: parallel handle store (Phase 2+ shim, populated alongside wcache_)
     WeightRegistry registry_;
 

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -950,6 +950,10 @@ private:
     // Planned overlay tier for a source pointer, or Undefined if the pointer is
     // not in the plan (native GGUF blocks bypass the overlay layer).
     StorageTier plan_tier_of(const void* src) const { return storage_plan_.tier_of(src); }
+    // Stage 1.2: fold the scattered arch-specific overlay rules (gemma-3 FP16
+    // backing, GDN ssm FP16 floor, native-NVFP4 prefill) into one pass over the
+    // freshly-built plan, so the plan matches what the legacy builders produce.
+    void apply_arch_rules_(StoragePlan& plan, const ModelConfig& cfg) const;
 
     // WeightRegistry: parallel handle store (Phase 2+ shim, populated alongside wcache_)
     WeightRegistry registry_;

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -37,23 +37,6 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     size_t total_reserve = min_reserve + budget.nvfp4_cache_bytes;
     size_t remaining_budget = (free_vram > total_reserve) ? (free_vram - total_reserve) : 0;
 
-    // Stage 1 (one-tier-truth): build the StoragePlan once and hold it for the
-    // model's lifetime. The pre-dequant phases are being migrated to read their
-    // overlay-tier decision from `storage_plan_` (plan_tier_of) instead of
-    // scattered nvfp4_beneficial/plan_routes_to_fp16 checks. A plan-vs-actual
-    // parity diagnostic runs in Phase 4 (after the caches are built) to surface
-    // any mismatch before a builder is switched. The plan does not drive
-    // allocation yet — this commit is pure plumbing (zero behaviour change).
-    hints_.vram_budget_bytes = remaining_budget;
-    storage_plan_ = plan_storage(*model_, cfg, hints_);
-    if (storage_plan_.failed) {
-        IMP_LOG_WARN("StoragePlanner: plan failed — %s", storage_plan_.failure_reason.c_str());
-    } else {
-        IMP_LOG_INFO("StoragePlanner: %zu entries, projected VRAM %.2f MiB",
-                     storage_plan_.entries.size(),
-                     storage_plan_.projected_vram_bytes / (1024.0 * 1024.0));
-    }
-
     // --- Phase 0: Promote NVFP4 pre-quantized weights to Tensor sidecars ---
     // (body extracted to pre_dequant_phase0_promote_nvfp4_sidecars_)
     pre_dequant_phase0_promote_nvfp4_sidecars_(cfg, stream);
@@ -61,6 +44,25 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     // --- Phase 0b: register prequant-promoted NVFP4 weights in CUTLASS cache ---
     // (body extracted to pre_dequant_phase0b_register_cutlass_nvfp4_)
     pre_dequant_phase0b_register_cutlass_nvfp4_(cfg, stream);
+
+    // Stage 1 (one-tier-truth): build the StoragePlan once and hold it for the
+    // model's lifetime. The pre-dequant phases are being migrated to read their
+    // overlay-tier decision from `storage_plan_` (plan_tier_of) instead of
+    // scattered nvfp4_beneficial/plan_routes_to_fp16 checks. Built AFTER Phase 0
+    // so prequant-NVFP4 weights already carry QType::NVFP4 (Phase 0 stamps it) —
+    // building earlier mis-tiered native-NVFP4 weights as FP16/FP8. A plan-vs-
+    // actual parity diagnostic runs in Phase 4 to surface any mismatch before a
+    // builder is switched. The plan does not drive allocation yet.
+    hints_.vram_budget_bytes = remaining_budget;
+    storage_plan_ = plan_storage(*model_, cfg, hints_);
+    apply_arch_rules_(storage_plan_, cfg);
+    if (storage_plan_.failed) {
+        IMP_LOG_WARN("StoragePlanner: plan failed — %s", storage_plan_.failure_reason.c_str());
+    } else {
+        IMP_LOG_INFO("StoragePlanner: %zu entries, projected VRAM %.2f MiB",
+                     storage_plan_.entries.size(),
+                     storage_plan_.projected_vram_bytes / (1024.0 * 1024.0));
+    }
 
     // --- Phase 1: FP16 weight cache + fused KV + fused gate+up (extracted) ---
     pre_dequant_phase1_fp16_cache_(cfg, budget, remaining_budget, stream);
@@ -80,6 +82,55 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 
     // --- Phase 4b: mark redundant sources as dropped (5.1.4.b — bisect mode) ---
     pre_dequant_phase4b_drop_redundant_sources_(cfg, stream);
+}
+
+// Fold the scattered arch-specific overlay rules into one pass over the plan so
+// the plan reproduces what the legacy builders do (the precondition for making
+// builders plan-driven without changing behaviour). Driven by the Phase-4
+// plan/actual parity diagnostic: a rule is added here only where parity shows
+// the plan and the legacy path disagree for a real (non-budget) reason.
+void GraphExecutor::apply_arch_rules_(StoragePlan& plan, const ModelConfig& cfg) const {
+    // FP8 prefill unavailable (sm_120 cuBLAS, and disabled for gemma/GDN): the
+    // FP8-floor kinds (WK/WV/QKV_FUSED) the plan picked from the kind table fall
+    // back to FP16 at build time. Encode that so the plan matches.
+    if (!wcache_.use_fp8) {
+        for (auto& e : plan.entries)
+            if (e.tier == StorageTier::FP8)
+                e.tier = StorageTier::FP16;
+    }
+
+    // LM head → NVFP4 when nvfp4_lm_head (default on): the kind table caps
+    // LM_HEAD at FP16, so the plan can't pick NVFP4 itself, but the legacy path
+    // quantizes the BF16/Q*_K lm_head to an NVFP4 decode cache (+8-16% decode,
+    // +2.2% PPL — owner-accepted). GDN/SSM-hybrid models keep the FP16 lm_head
+    // unless nvfp4_lm_head_gdn (mirrors nvfp4_decode_cache_fp16_lm_head_).
+    if (runtime_config().gemm.nvfp4_lm_head) {
+        bool is_gdn = false;
+        for (int i = 0; i < cfg.n_layers; i++) {
+            const auto& L = model_->layer(i);
+            if (L.ssm_in.data || L.ssm_out.data || L.gdn_gate.data) {
+                is_gdn = true;
+                break;
+            }
+        }
+        if (!is_gdn || runtime_config().gemm.nvfp4_lm_head_gdn) {
+            for (auto& e : plan.entries)
+                if (e.kind == TensorKind::LM_HEAD)
+                    e.tier = StorageTier::NVFP4;
+        }
+    }
+
+    // gemma-3: the NVFP4 decode cache must be built FROM an FP16 companion copy,
+    // not from scratch — from-scratch corrupts gemma-3 decode (first step emits
+    // token 0 / <pad>, then IMA). The legacy Phase 1 keeps these FP16-cached;
+    // encode that as an fp16_companion flag on every NVFP4-tier entry so the
+    // plan-driven Phase 1 (Stage 1.3) preserves the same backing copy.
+    if (cfg.arch == ModelArch::GEMMA3) {
+        for (auto& e : plan.entries) {
+            if (e.tier == StorageTier::NVFP4)
+                e.fp16_companion = true;
+        }
+    }
 }
 
 }  // namespace imp

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -37,20 +37,21 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     size_t total_reserve = min_reserve + budget.nvfp4_cache_bytes;
     size_t remaining_budget = (free_vram > total_reserve) ? (free_vram - total_reserve) : 0;
 
-    // Phase 4.2: run StoragePlanner for diagnostic purposes.
-    // The plan output is NOT used to drive allocation yet — the existing legacy code
-    // path still decides what to allocate. Log discrepancies between the plan and
-    // the legacy decisions so we can catch bugs before Phase 4.4+ flips to
-    // plan-driven allocation. Actual storage ownership flip happens in Phase 5.
-    {
-        hints_.vram_budget_bytes = remaining_budget;
-        StoragePlan diag_plan = plan_storage(*model_, cfg, hints_);
-        if (diag_plan.failed) {
-            IMP_LOG_WARN("StoragePlanner (diagnostic): plan failed — %s", diag_plan.failure_reason.c_str());
-        } else {
-            IMP_LOG_INFO("StoragePlanner (diagnostic): %zu entries, projected VRAM %.2f MiB",
-                         diag_plan.entries.size(), diag_plan.projected_vram_bytes / (1024.0 * 1024.0));
-        }
+    // Stage 1 (one-tier-truth): build the StoragePlan once and hold it for the
+    // model's lifetime. The pre-dequant phases are being migrated to read their
+    // overlay-tier decision from `storage_plan_` (plan_tier_of) instead of
+    // scattered nvfp4_beneficial/plan_routes_to_fp16 checks. A plan-vs-actual
+    // parity diagnostic runs in Phase 4 (after the caches are built) to surface
+    // any mismatch before a builder is switched. The plan does not drive
+    // allocation yet — this commit is pure plumbing (zero behaviour change).
+    hints_.vram_budget_bytes = remaining_budget;
+    storage_plan_ = plan_storage(*model_, cfg, hints_);
+    if (storage_plan_.failed) {
+        IMP_LOG_WARN("StoragePlanner: plan failed — %s", storage_plan_.failure_reason.c_str());
+    } else {
+        IMP_LOG_INFO("StoragePlanner: %zu entries, projected VRAM %.2f MiB",
+                     storage_plan_.entries.size(),
+                     storage_plan_.projected_vram_bytes / (1024.0 * 1024.0));
     }
 
     // --- Phase 0: Promote NVFP4 pre-quantized weights to Tensor sidecars ---

--- a/src/exec/pre_dequant_phase1_fp16_cache.cu
+++ b/src/exec/pre_dequant_phase1_fp16_cache.cu
@@ -22,7 +22,6 @@
 
 using imp::pre_dequant_internal::create_fused_weight_pair;
 using imp::pre_dequant_internal::deduct_budget;
-using imp::pre_dequant_internal::nvfp4_beneficial;
 
 namespace imp {
 
@@ -41,55 +40,28 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
         return;
     }
 
-    // Plan-driven per-weight gate: cache as FP16 iff the (source-qtype-aware)
-    // planner would route this kind+qtype to the FP16 tier. Sub-5-bit sources
-    // (Q4_K, Q4_0, etc.) land here. Q5_K/Q6_K/Q8_0/Q8_K → NVFP4 (Phase 3).
-    // Native FP4 → their own tier. Replaces the unconditional NVFP4-only
-    // early-exit + per-FFN nvfp4_decode_mode heuristic.
-    auto plan_routes_to_fp16 = [&](TensorKind kind, QType qtype) {
-        if (qtype == QType::F16 || qtype == QType::BF16 || qtype == QType::F32)
-            return false;  // already in compute dtype; no overlay needed
-        const auto cap = effective_capabilities(kind, qtype);
-        return cap.required_floor == StorageTier::FP16;
-    };
-
     // --- Phase 1: FP16 weight cache + fused KV + fused gate+up ---
-    // When FP8 is disabled (sub-8-bit models), the planner's FP8 tier entries
-    // have no fallback — Q6_K/Q8_0 weights that would normally get FP8 prefill
-    // cache land in the dequant-on-every-forward fallback. Widen the FP16 gate
-    // to cover those weights too: any dequantable attention/FFN weight that
-    // doesn't already have an overlay gets FP16 cached.
-    const bool fp8_unavailable = !wcache_.use_fp8;
-
+    // Plan-driven gate (Stage 1.3): FP16-cache a weight iff the StoragePlan
+    // routes its source to the FP16 tier, OR the plan flagged it as needing an
+    // FP16 companion. The plan (built in pre_dequant_weights + apply_arch_rules_)
+    // already folds in every rule this gate used to compute inline:
+    //   - Phase 3 owns nvfp4_beneficial weights (Q8_0/Q6_K/Q5_K) → tier NVFP4,
+    //     not FP16 (the #428×#434 starvation guard, now structural).
+    //   - FP8 unavailable → FP8-floor kinds fall back to FP16.
+    //   - gemma-3: NVFP4-tier weights get fp16_companion so the Phase-3 decode
+    //     cache is built FROM the FP16 copy, not from scratch (the <pad>/IMA
+    //     corruption guard) — without a scattered arch check here.
     auto cache_weight = [&](const Tensor& w, QType qtype, TensorKind kind) {
+        (void)kind;
         if (!w.data || !dequant_gpu_supported(qtype))
             return;
         if (wcache_.fp16.count(w.data))
             return;  // already cached
         if (budget_exhausted)
             return;
-        // Phase 3 (the NVFP4 decode cache) owns nvfp4_beneficial weights
-        // (Q8_0/Q6_K/Q5_K) whenever the decode cache is active. Never FP16-cache
-        // those here — not even when FP8 is unavailable. Doing so consumes the
-        // VRAM budget Phase 3 needs and starves the decode cache to ~2 of ~252
-        // tensors → decode falls back to heavy FP16 weights. That FP8-disable
-        // (PR #428) × FP16-widen (PR #434) interaction regressed Qwen3-8B Q8_0
-        // tg128 284→146 and Qwen3-14B Q6_K 157→93. These weights instead get a
-        // compact NVFP4 decode cache (0.5 B/elem, fast + coherent) and prefill
-        // via on-the-fly Q*_K→FP16 dequant (executor_kernels gemm_via_handle_) —
-        // far less VRAM than double-caching FP16+NVFP4, leaving headroom for KV.
-        // GEMMA3 exception: keep its nvfp4_beneficial weights FP16-cached so the
-        // Phase-3 NVFP4 decode cache is built FROM the FP16 copy, not from scratch
-        // (source Q*_K dequant). Skipping FP16 here forces the from-scratch NVFP4
-        // build, which corrupts Gemma-3 decode (first decode step emits token 0 /
-        // <pad> — verified: pre-#461 FP16-backed Gemma-3 is coherent, #461's skip
-        // regressed gemma-3-12b-it-Q4_K_M to "The"→<pad>). Qwen3 Q6_K/Q8_0 build
-        // NVFP4 from scratch fine, so this is GEMMA3-arch-specific.
-        if (wcache_.nvfp4_decode_mode > 0 && cfg.arch != ModelArch::GEMMA3 &&
-            nvfp4_beneficial(qtype, runtime_config().gemm.nvfp4_decode_all))
-            return;
-        if (!fp8_unavailable && !plan_routes_to_fp16(kind, qtype))
-            return;  // Phase 3 (NVFP4) or native FP4 owns this weight
+        const auto* e = storage_plan_.entry_of(w.data);
+        if (!e || (e->tier != StorageTier::FP16 && !e->fp16_companion))
+            return;  // plan routes this to NVFP4 / FP8 / native, or not in plan
 
         int rows = static_cast<int>(w.shape[0]);
         int cols = static_cast<int>(w.shape[1]);
@@ -124,8 +96,8 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
     // Priority order: attention weights first (critical for cuBLAS prefill),
     // then SSM, shared experts, and dense FFN.  This ensures hybrid models
     // like Nemotron (23 SSM + 6 attention layers) cache all attention weights
-    // before SSM weights exhaust the VRAM budget. Tier-decision is per-kind
-    // via plan_routes_to_fp16; per-tensor budget pressure still applies.
+    // before SSM weights exhaust the VRAM budget. Tier-decision is plan-driven
+    // (storage_plan_); per-tensor budget pressure still applies.
     for (int i = 0; i < cfg.n_layers; i++) {
         const auto& L = model_->layer(i);
         cache_weight(L.wq, L.wq.qtype, TensorKind::WQ);

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -825,9 +825,23 @@ void GraphExecutor::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
     int ct_count = 0;
     size_t ct_total = 0;
     bool ct_exhausted = false;
+    int ct_skipped_dead = 0;
     for (auto& [ptr, nvfp4] : wcache_.nvfp4) {
         if (ct_exhausted)
             break;
+        // G3 (Stage 1.4): skip the CUTLASS SF buffer for weights whose M>1
+        // prefill uses IMMA raw-read on the GGUF source — the CUTLASS GEMM path
+        // (executor_kernels gemm_via_handle_, primary_tier==CUTLASS_NVFP4) is
+        // never reached for them, so the SF buffer is dead VRAM (~0.45 GB on an
+        // 8B Q8_0 model). Today that is Q8_0 with q8_imma_enabled. CUTLASS stays
+        // for native-NVFP4 (prefill IS CUTLASS) and Q6_K/Q5_K (not IMMA-routed →
+        // CUTLASS is their prefill path). Decode is unaffected: decode_tier stays
+        // NVFP4 (the plain wcache_.nvfp4 GEMV), independent of the SF buffer.
+        const auto* pe = storage_plan_.entry_of(ptr);
+        if (pe && pe->source_qtype == QType::Q8_0 && runtime_config().gemm.q8_imma_enabled) {
+            ++ct_skipped_dead;
+            continue;
+        }
         // Estimate CUTLASS allocation (only scale factors — data is borrowed)
         size_t est = cutlass_nvfp4_sf_size(static_cast<int>(nvfp4.N), static_cast<int>(nvfp4.K));
         if (ct_total + est > ct_budget) {
@@ -850,8 +864,13 @@ void GraphExecutor::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
         wcache_.cutlass_nvfp4_bytes = ct_total;
         deduct_budget(remaining_budget, ct_total + wcache_.nvfp4_bytes);
-        IMP_LOG_INFO("CUTLASS sm_120 NVFP4 weight cache: %d tensors, %.2f MiB", ct_count,
-                     ct_total / (1024.0 * 1024.0));
+        IMP_LOG_INFO("CUTLASS sm_120 NVFP4 weight cache: %d tensors, %.2f MiB (skipped %d "
+                     "IMMA-prefill weights — dead SF buffer)",
+                     ct_count, ct_total / (1024.0 * 1024.0), ct_skipped_dead);
+    } else if (ct_skipped_dead > 0) {
+        IMP_LOG_INFO("CUTLASS sm_120 NVFP4 weight cache: 0 tensors (skipped %d IMMA-prefill "
+                     "weights — dead SF buffer)",
+                     ct_skipped_dead);
     }
 }
 

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -333,17 +333,19 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
             "(GGUF blocks + norms + scratch — bypass the overlay layer)",
             model_->gpu_allocations_.size());
 
-        // Phase 5 PR #1 Commit 5.1.4.a: log how many bytes of original GGUF
-        // are REDUNDANT — fully covered by the overlay tier such that the
-        // dispatch never reads `source_data`. Diagnostic-only here; actual
-        // freeing (5.1.4.b) requires dispatch-site safety guards.
-        //
-        // Qualifying tiers: NVFP4 / CUTLASS_NVFP4 / FP8 / MXFP4 (decode-fast
-        // kernels exist for the overlay). FP16-cached weights still need the
-        // original for dp4a decode (per 5.1.3.c) and are not counted.
+        // Decode-redundancy diagnostic: how many bytes of original GGUF the
+        // overlay tier (NVFP4 / CUTLASS_NVFP4 / FP8 / MXFP4) covers for DECODE.
+        // This is an UPPER BOUND, not freeable VRAM: M>1 prefill still reads the
+        // GGUF source for these weights — Q8_0/Q4_K via IMMA raw-read on the
+        // source, Q6_K/Q5_K via on-the-fly dequant or CUTLASS — so the source
+        // stays resident under the current strict-quality-neutral prefill paths.
+        // (The earlier "could be freed / deferred to 5.1.4.b" wording was wrong
+        // since IMMA raw-read prefill #617; Phase 4b correctly frees nothing for
+        // these, see its source-pointer guard.) FP16-cached weights keep the
+        // original for dp4a decode and are not counted.
         {
-            size_t droppable_count = 0;
-            size_t droppable_bytes = 0;
+            size_t decode_redundant_count = 0;
+            size_t decode_redundant_bytes = 0;
             for (TensorID id = 0; id < static_cast<TensorID>(registry_.size()); ++id) {
                 const auto& h = registry_.handle(id);
                 if (!h.can_drop_source())
@@ -351,14 +353,14 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
                 int64_t cols = h.shape[1] > 0 ? h.shape[1] : 1;
                 size_t row_bytes = qtype_row_bytes(h.source_qtype, cols);
                 size_t bytes = row_bytes * static_cast<size_t>(h.shape[0]);
-                droppable_bytes += bytes;
-                ++droppable_count;
+                decode_redundant_bytes += bytes;
+                ++decode_redundant_count;
             }
             IMP_LOG_INFO(
-                "Phase-4 drop-source diagnostic: %zu handles, %.2f MiB of original "
-                "GGUF could be freed (overlay tier covers prefill + decode). "
-                "Actual freeing deferred to Commit 5.1.4.b.",
-                droppable_count, droppable_bytes / (1024.0 * 1024.0));
+                "Phase-4 decode-redundancy: %zu handles, %.2f MiB of GGUF source is "
+                "decode-redundant (overlay covers decode) but kept resident for "
+                "M>1 prefill (upper bound, not freeable).",
+                decode_redundant_count, decode_redundant_bytes / (1024.0 * 1024.0));
         }
     }
 
@@ -517,13 +519,16 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
     }
 }
 
-// Phase 5 PR #1 Commit 5.1.4.b: mark `Tensor.dropped_source = true` for
-// every weight whose handle says can_drop_source(). BISECT MODE: does NOT
-// actually free the GPU allocation. The mark triggers safety guards in
-// dispatch — any path that derefs weight.data raw with a marked weight
-// logs a "coverage gap" warning. When all paths route via overlay
-// correctly (no warnings), the second phase of 5.1.4.b will flip the
-// `actually_free` flag below and reclaim the VRAM.
+// Free a GGUF source allocation only when NO path still reads it. The guard
+// below (try_mark) frees a source iff it's a base allocation AND not present in
+// wcache_.nvfp4 / wcache_.cutlass_nvfp4. For decode-cached weights the source
+// IS present in those maps (keyed on the source pointer), so they are correctly
+// SKIPPED — M>1 prefill reads the GGUF source (IMMA raw-read / dequant /
+// CUTLASS) under the strict-quality-neutral prefill paths. Net effect today:
+// near-zero sources freed, by design — the decode-redundancy diagnostic in
+// Phase 4 is an upper bound, not freeable VRAM. The mark also sets
+// Tensor.dropped_source so any raw-deref path that DID lose its source would
+// log a coverage-gap warning instead of reading freed memory.
 void GraphExecutor::pre_dequant_phase4b_drop_redundant_sources_(
     const ModelConfig& cfg, cudaStream_t stream) {
     constexpr bool actually_free = true;

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -182,7 +182,9 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
     // entirely, so the diff between plan and registry is informational, not
     // an error.
     {
-        StoragePlan ideal_plan = plan_storage(*model_, cfg, hints_);
+        // Stage 1: reuse the persistent plan built at the top of
+        // pre_dequant_weights() instead of re-running plan_storage a third time.
+        const StoragePlan& ideal_plan = storage_plan_;
         size_t plan_overlay = 0;
         size_t plan_fp16 = 0, plan_fp8 = 0, plan_nvfp4 = 0;
         size_t plan_cutlass_nvfp4 = 0, plan_mxfp4 = 0, plan_fp32 = 0;
@@ -258,6 +260,62 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
             wcache_.fp16.size(), wcache_.fp8.size(), wcache_.nvfp4.size(), wcache_.cutlass_nvfp4.size(),
             wcache_.cutlass_mxfp4.size(), wcache_.nvfp4_moe.size(), wcache_.fused_kv.size(),
             wcache_.fused_gate_up.size());
+
+        // Stage 1 plan-vs-actual parity diagnostic: for every plan entry whose
+        // tier is an overlay, compare the planned tier against the tier the
+        // legacy build path actually produced (inferred from which wcache map
+        // the source pointer landed in). A mismatch means switching this
+        // builder to plan-driven would change behaviour — it MUST be understood
+        // (expected budget-eviction, or a real arch-rule the plan doesn't yet
+        // encode) before that builder is migrated. Pure diagnostic; logs only.
+        // The planned tier here is the post-downgrade tier; budget eviction
+        // (planned overlay → actual native/uncached) is the common benign case.
+        {
+            // "Present in the planned tier's map?" — NOT first-hit. A GGUF weight
+            // legitimately appears in BOTH wcache_.nvfp4 (its tier) AND
+            // wcache_.cutlass_nvfp4 (the dead G3 SF buffer); first-hit would
+            // falsely flag it. We ask: did the legacy build put this source into
+            // the map the plan chose? If yes → matched (extra overlays are a
+            // separate G3 concern). If it landed in a DIFFERENT map → real
+            // mismatch (the plan and the legacy path disagree on tier). If it
+            // landed nowhere → evicted (budget / native fallback, benign).
+            auto present_in = [&](StorageTier t, const void* src) -> bool {
+                switch (t) {
+                    case StorageTier::FP16: return wcache_.fp16.count(src) > 0;
+                    case StorageTier::FP8: return wcache_.fp8.count(src) > 0;
+                    case StorageTier::NVFP4: return wcache_.nvfp4.count(src) > 0;
+                    case StorageTier::CUTLASS_NVFP4: return wcache_.cutlass_nvfp4.count(src) > 0;
+                    case StorageTier::MXFP4: return wcache_.cutlass_mxfp4.count(src) > 0;
+                    default: return false;
+                }
+            };
+            auto any_overlay = [&](const void* src) -> bool {
+                return wcache_.fp16.count(src) || wcache_.fp8.count(src) ||
+                       wcache_.nvfp4.count(src) || wcache_.cutlass_nvfp4.count(src) ||
+                       wcache_.cutlass_mxfp4.count(src);
+            };
+            int mismatch = 0, evicted = 0, matched = 0;
+            for (const auto& e : ideal_plan.entries) {
+                const bool plan_overlay_e =
+                    (e.tier == StorageTier::FP16 || e.tier == StorageTier::FP8 ||
+                     e.tier == StorageTier::NVFP4 || e.tier == StorageTier::CUTLASS_NVFP4 ||
+                     e.tier == StorageTier::MXFP4);
+                if (!plan_overlay_e)
+                    continue;
+                if (present_in(e.tier, e.source_data)) {
+                    ++matched;
+                } else if (any_overlay(e.source_data)) {
+                    ++mismatch;
+                    IMP_LOG_INFO("Phase-4 plan/actual MISMATCH: %s plan-tier=%d not in its map "
+                                 "(landed in a different overlay)",
+                                 tensor_kind_name(e.kind), static_cast<int>(e.tier));
+                } else {
+                    ++evicted;  // planned overlay but not cached (budget / native fallback)
+                }
+            }
+            IMP_LOG_INFO("Phase-4 plan/actual parity: matched=%d mismatch=%d evicted=%d",
+                         matched, mismatch, evicted);
+        }
         // Native layer counterpart to the overlay diagnostic: tensors uploaded
         // as their on-disk format and dispatched through qtype-specific kernels
         // (no tier choice, no cascade-bug class). gpu_allocations_ tracks every

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -304,11 +304,17 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
                     continue;
                 if (present_in(e.tier, e.source_data)) {
                     ++matched;
+                } else if (e.fp16_companion && present_in(StorageTier::FP16, e.source_data)) {
+                    // gemma-3 companion: planned NVFP4 + FP16 backing; when the
+                    // NVFP4 primary is budget-evicted only the FP16 companion
+                    // remains. Expected degraded state, not a tier disagreement.
+                    ++matched;
                 } else if (any_overlay(e.source_data)) {
                     ++mismatch;
-                    IMP_LOG_INFO("Phase-4 plan/actual MISMATCH: %s plan-tier=%d not in its map "
-                                 "(landed in a different overlay)",
-                                 tensor_kind_name(e.kind), static_cast<int>(e.tier));
+                    StorageTier actual = infer_tier_from_wcache(wcache_, e.source_data);
+                    IMP_LOG_INFO("Phase-4 plan/actual MISMATCH: %s plan-tier=%d actual-tier=%d",
+                                 tensor_kind_name(e.kind), static_cast<int>(e.tier),
+                                 static_cast<int>(actual));
                 } else {
                     ++evicted;  // planned overlay but not cached (budget / native fallback)
                 }

--- a/src/runtime/storage_planner.cpp
+++ b/src/runtime/storage_planner.cpp
@@ -106,7 +106,7 @@ void add_tensor(const Tensor& t, TensorKind kind, StoragePlan& plan, TensorID& n
     int64_t cols = (t.ndim > 1 ? t.shape[1] : 1);
     int64_t bytes = bytes_for_tier(rows, cols, tier);
 
-    plan.entries.push_back({next_id++, kind, t.qtype, tier, bytes, rows, cols});
+    plan.entries.push_back({next_id++, kind, t.qtype, tier, bytes, rows, cols, t.data, false});
     total += static_cast<size_t>(bytes);
 }
 
@@ -207,6 +207,30 @@ StoragePlan plan_storage(const Model& model, const ModelConfig& cfg, const PlanH
         plan.failure_reason = "vram budget insufficient even at required_floor tiers";
     }
     return plan;
+}
+
+void StoragePlan::build_index_() const {
+    by_src_.clear();
+    by_src_.reserve(entries.size());
+    for (const auto& e : entries) {
+        if (e.source_data)
+            by_src_[e.source_data] = &e;
+    }
+    index_built_ = true;
+}
+
+const StoragePlan::Entry* StoragePlan::entry_of(const void* src) const {
+    if (!src)
+        return nullptr;
+    if (!index_built_)
+        build_index_();
+    auto it = by_src_.find(src);
+    return it == by_src_.end() ? nullptr : it->second;
+}
+
+StorageTier StoragePlan::tier_of(const void* src) const {
+    const Entry* e = entry_of(src);
+    return e ? e->tier : StorageTier::Undefined;
 }
 
 }  // namespace imp

--- a/src/runtime/storage_planner.h
+++ b/src/runtime/storage_planner.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace imp {
@@ -30,11 +31,28 @@ struct StoragePlan {
         int64_t bytes;
         int64_t rows;
         int64_t cols;
+        const void* source_data = nullptr;  // GGUF/source pointer — the key the
+                                            // pre-dequant phases dispatch on.
+        // Stage 1: arch rule (gemma-3) requires the NVFP4 decode cache to be
+        // built FROM an FP16 companion copy, not from scratch. When true, an
+        // NVFP4-tier entry also keeps an FP16 cache entry alive.
+        bool fp16_companion = false;
     };
     std::vector<Entry> entries;
     size_t projected_vram_bytes = 0;
     bool failed = false;
     std::string failure_reason;
+
+    // O(1) lookup of the planned tier for a source pointer. Returns
+    // StorageTier::Undefined if the pointer is not in the plan (e.g. native
+    // GGUF blocks that bypass the overlay layer). Built lazily on first call.
+    StorageTier tier_of(const void* src) const;
+    const Entry* entry_of(const void* src) const;
+
+  private:
+    mutable std::unordered_map<const void*, const Entry*> by_src_;
+    mutable bool index_built_ = false;
+    void build_index_() const;
 };
 
 // Pure function — no GPU allocations, no side effects. Determines per-tensor


### PR DESCRIPTION
## Why

Audit of the weight-cache / VRAM layer (`docs/audit/vram_cache_structure_2026_06_07.md`, verified against code + real bench logs) found the cache layer mid-refactor with the migration stalled:

- **G1** — three diverging tier oracles: `StoragePlanner` (source-aware, correct, but "diagnostic only"), the source-blind `vram_budget.cpp` heuristic (actually allocates), and a *second* `nvfp4_beneficial` copy. Scattered `if(arch==…)` rules across `engine_init_resolver` + the phase builders — the exact class that caused the rejected FP16-gate diff this morning (north-star decode −15.5% + gemma-3 crash) and the historical #428×#434 regression.
- **G2** — Phase 4b's drop-source diagnostic claimed "7.6 GB could be freed (overlay covers prefill + decode)" — false since IMMA raw-read prefill (#617) reads the GGUF source directly.
- **G3** — dead CUTLASS scale-factor buffers on GGUF (Q8: 253 tensors / 451 MiB never read).

Design: `docs/superpowers/specs/2026-06-07-vram-cache-architecture-design.md`. Strictly quality-neutral, perf-gated, staged. This PR is **Stage 1** — make the plan authoritative for the overlay-tier decision, starting with the FP16 phase, fold the scattered arch rules into one pass, and drop the dead posts that fall out as a consequence.

## What

- **`StoragePlan` becomes the held source of truth** (1.1/1.2): built once after Phase 0 (so prequant-NVFP4 weights carry `QType::NVFP4`), with O(1) `tier_of(src)` lookups and a per-tensor plan/actual **parity diagnostic** that proved the migration map before any builder was switched.
- **`apply_arch_rules_`** (1.2): one pass folding the scattered overlay rules into the plan — FP8-unavailable → FP16 fallback, `nvfp4_lm_head` → LM_HEAD NVFP4 (GDN-gated), gemma-3 NVFP4-from-FP16 companion. One function decides; builders read.
- **Phase 1 FP16 cache reads the plan** (1.3a): three inline rules (`nvfp4_beneficial` early-return, the GEMMA3 exception, the FP8-widening) collapse to one plan query.
- **G3: skip dead CUTLASS SF** (1.4): Q8_0 + `q8_imma` weights do M>1 prefill via IMMA raw-read, so their CUTLASS SF buffer is never read — Phase 3b skips it (keyed off the plan's `source_qtype`). CUTLASS stays for native-NVFP4 and Q6_K/Q5_K (their actual prefill path).
- **G2: honest diagnostics** (1.5): renamed to "decode-redundancy … kept resident for M>1 prefill (upper bound, not freeable)"; Phase 4b comment corrected to match the code.

## Verification (GPU, healthy host: mem 13801, 5090)

| Model | Parity | Coherence | Decode (vs baseline) | Prefill |
|---|---|---|---|---|
| Qwen3-8B Q8_0 | mismatch=0 | ✓ | 265/267 (~262) | 12.1k (~12k) |
| native-NVFP4 (cortecs) | mismatch=0 | ✓ | — | — |
| Qwen3-14B Q6_K (north-star) | mismatch=0 | ✓ | 143 (~145) | 6.5k (~6.5k) |
| gemma-3-12b Q4_K_M | mismatch=1* | ✓ "Paris.<end>" | — | — |

\*the one remainder is `TOK_EMBED` (tied with lm_head→NVFP4), a benign 1-tensor diagnostic-only edge case.

- **G3 win:** Qwen3-8B Q8_0 `cutlass_nvfp4` 253 → 0 tensors (451 MiB freed), prefill/decode neutral (proves the SF was dead). Qwen3-14B Q6_K unaffected.
- No IMA/NaN/CUDA errors. **`make verify-fast`: OK** (gtest + perf gate + degeneration smoke).

## Out of scope (follow-up PRs, per the staged design)

- Phase 3 (NVFP4) plan-driven — needs a plan-schema extension (a single `tier` can't express "prefill via CUTLASS, decode via NVFP4" for native-NVFP4).
- Phase 2 (FP8, no-op on sm_120), `vram_budget` sizing on plan bytes, Stage 2 (RAII arena ownership), Stage 3 (honest budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)