### PR TITLE
chore(config): D4 dead-flag sweep — remove 3 never-read flags + land debt audit

### DIFF
--- a/docs/audit/structural_debt_2026_06_08.md
+++ b/docs/audit/structural_debt_2026_06_08.md
@@ -1,0 +1,154 @@
+# Structural debt audit — 2026-06-08
+
+Scope: codebase-wide structural debt beyond the VRAM-cache layer (which was
+rebuilt in PR #621, see `vram_cache_structure_2026_06_07.md`). Verified against
+the tree with grep/wc; counts are evidence, not estimates. Diagnostic only — no
+code changed. Ranked by pain × risk × how-well-bounded-the-fix-is.
+
+## TL;DR
+
+The VRAM cache was one instance of a recurring shape: **a decision recomputed in
+many places instead of decided once and read.** The same shape appears in three
+more places. The highest-value next target is the same move we just made for
+tiers — a single **ModelProfile** for architecture facts. The rest is a god-object
+split (big, risky) and a dead-code/flag sweep (cheap, do anytime).
+
+---
+
+## D1 — No central `ModelProfile` (highest priority)
+
+Architecture-derived facts are recomputed inline across the codebase instead of
+classified once into a struct the rest of the code reads. This is **the same class
+of bug** that the rejected FP16-gate diff hit and that caused #514/#516 (a
+scattered `if (arch==…)` one path forgets).
+
+**Evidence:**
+- **GDN/SSM-hybrid detection** — "loop the layers, check `gdn_gate.data`/
+  `ssm_in.data != nullptr`" is recomputed at ≥6 sites:
+  `engine_init_resolver.cpp:128`, `engine_kv_cache_init.cpp:155/174/210`,
+  `engine_weight_upload.cpp:142`, `vram_budget.cpp:60`. Each decides something
+  (SSM state dtype, FP8 disable, VRAM footprint, graph compatibility) off the
+  same fact, independently.
+- **Hot-path arch branching** — per-forward/per-layer `cfg.arch == ModelArch::*`:
+  `executor_forward_moe.cu` (15), `executor_attention.cu` (15),
+  `executor_forward_moe_batch.cu` (7). These pick FFN-norm variant, attn scale,
+  SWA routing, expert-offset layout *every layer* instead of from a pre-decided
+  enum (e.g. `AttentionVariant`, `FfnNormVariant`).
+- **RoPE / FP8-eligibility / CUDA-graph-eligibility** — each decided in one place
+  but then re-read from `model_config_` downstream instead of from a profile.
+
+**Nuance (not all arch-checks are debt):** `model.cpp` (72) and
+`hf_config_loader.cpp` (44) are *load-time classification* — the correct place,
+run once. The debt is the **hot-path re-derivation**, not the loader.
+
+**What exists vs what's missing:** `ModelConfig` (static metadata) + `EngineConfig`
+(decided runtime flags) + a global `process_diag` singleton (holds
+`cublas_fp16_acc` — bad pattern). **Missing:** a `ModelProfile` that computes the
+*derived* facts (is_gdn, is_moe, is_hybrid, attn_variant, ffn_norm_variant,
+rope_variant, fp8_eligible, graphs_eligible) once at init and is read everywhere.
+
+**Why it's the right next target:** real bug history (#514/#516), exactly the
+"scattered → one truth" move just proven on tiers, and well-bounded (one struct,
+filled once, call-sites migrated individually behind the existing canaries:
+coherence across dense/MoE/GGUF/gemma, verify-fast).
+
+---
+
+## D2 — `GraphExecutor` god-object
+
+`src/exec/executor.h` declares `GraphExecutor` with **53 methods + 69 data members
++ 10 supporting structs** in one ~1160-line header. It owns: weight caches, KV
+cache, MoE routing + expert LRU, attention, FFN, SSM, sampling, RoPE (3 variants),
+LoRA, workspace allocation, and the whole pre-dequant quantization pipeline.
+
+**Why it's hard to work with:** no component is testable in isolation (KV
+calibration needs the whole workspace + model); adding a quant strategy touches
+the executor core; the forward DAG hides behind `init()`/`forward()`/`*_workspace()`.
+
+**Why it's NOT first:** large blast radius, many PRs, needs its own design pass.
+Best done *after* D1 (a ModelProfile removes a chunk of the executor's arch
+branching, shrinking the split surface).
+
+---
+
+## D3 — Oversized files / god-functions
+
+| File | Lines | Issue |
+|------|-------|-------|
+| `pre_dequant_phase3_nvfp4_decode.cu` | 1906 | 5 sub-phases sharing `Nvfp4DecodeContext`; a **329-line lambda** (`cache_moe_native_nvfp4`, lines ~1528–1856) capturing 20+ vars |
+| `executor_kernels.cu` | 1932 | conflates dp4a GEMV dispatch + attention utils (RoPE, KV index) + sampling preprocessing |
+| `weight_upload.cu` | 2174 | qtype byte-pattern detection + GPU alloc + per-format decompress |
+
+**Not debt (don't touch):** `jinja.cpp` (2629) is a self-contained lexer→parser→
+evaluator, single responsibility; `gdn.cu` (2061) is domain-cohesive. Size alone
+isn't the smell — *conflated responsibilities* are.
+
+---
+
+## D4 — Flag sprawl + dead/half-migrated paths (cheap sweep, do anytime)
+
+`RuntimeConfig` has 100+ fields; `gemm` alone has 18. Confirmed leftovers:
+- **Dead/retired flags:** `diagnostics.tq_skip_qjl` (comment: "TurboQuant retired
+  2026-05-17"); `kv_cache.fp8_auto_legacy` (env-var compat shim).
+- **`gemm.q4k_imma_enabled`** — suspected dead *gate*: grep finds it only in
+  comments + the kernel file's own comment claiming "the dispatch site checks
+  it", but the actual prefill dispatch (`executor_kernels.cu:1875`) checks the
+  *separate* `q4k_imma_prefill`. **Verify before removing** (the ~1200 lines of
+  q4k_imma kernel infra are NOT all dead — `q4k_imma_prefill` is live; only the
+  `_enabled` gate looks orphaned).
+- **Two config systems** half-separated: `RuntimeConfig.gemm` (global) vs
+  `ModelConfig::Overrides::Gemma4` (per-model). config.h:352 itself notes
+  "model-specific knobs do not belong on a global runtime singleton" while Q4_K
+  flags remain global.
+- **Overlapping pairs:** `nvfp4_lm_head` + `nvfp4_lm_head_gdn`; the q4k_imma gate
+  pair above.
+
+Low risk, immediately visible, and shrinks the surface for D1/D2. Good filler
+between the bigger pieces.
+
+---
+
+## Recommended order
+
+1. **D1 ModelProfile** — highest pain×risk, well-bounded, same proven move.
+2. **D4 dead-code/flag sweep** — cheap, do opportunistically (even before/between).
+3. **D2 GraphExecutor split** — biggest structural win, highest risk; own design
+   round, after D1 thins its arch branching.
+4. **D3 god-functions** — extract the 329-line MoE lambda + split
+   executor_kernels by domain; can ride along with D1/D2 where they overlap.
+
+Each follows the same discipline as the VRAM rebuild: one decision moved to one
+place, call-sites migrated individually, gated by coherence (dense/MoE/GGUF/
+gemma-3) + `EngineRelaunchTest` + `verify-fast`, strictly behaviour-neutral.
+
+---
+
+## Progress
+
+- **D1 — DONE** (PR #622 init-path classification + PR #623 hot-path arch
+  identity). All 55 hot-path `cfg.arch == ModelArch::X` reads + the ≥6
+  GDN/SSM/MoE detection loops now read one `ModelProfile`. The scaffolded
+  `attn_variant`/eligibility fields were dropped, not wired: the real code keys
+  off arch identity + per-layer tensor presence.
+- **D4 — partial** (this PR): removed three confirmed-dead flags —
+  `gemm.no_dp4a` (split long ago into `no_dp4a_gemv`/`no_dp4a_lm`),
+  `gemm.q4k_imma_enabled` (the orphaned gate this audit flagged: parsed +
+  mirrored into `GemmContext` but never read in any dispatch), and
+  `diagnostics.debug_gemm_dispatch` (declared + parsed, never read). Misleading
+  comments referencing the removed flag fixed.
+
+### New findings (during the D4 sweep)
+
+- **Dead `WeightCaches::q4k_imma` cache** — the OLD Phase-2C Q4_K IMMA cache
+  (`Q4kImmaCacheEntry` map, `use_q4k_imma`, `mmq_q4k_imma_tile`/`_reorder`) is
+  only *declared + freed*, never populated (its load-time gate was the now-dead
+  `q4k_imma_enabled`). Removing the ~1200-line tile/reorder stack is a D3-class
+  change (kernel infra), deferred — left an INACTIVE note on the cache decl.
+- **Unbridged `server.*` / `paths.*` config keys** — `server.prefix_cache`,
+  `server.green_contexts`, `paths.mmproj` are parsed into `RuntimeConfig` but
+  never read; the live enablement flows through the C-API
+  (`use_prefix_caching` / `enable_green_contexts` / CLI `--mmproj`). This is the
+  D4 "two config systems half-separated" item — these keys are silently inert
+  from `imp.conf`. NOT removed in this sweep: they are user-facing surface that
+  looks like incomplete wiring, not internal dead code — needs a decision to
+  either bridge them or retire them (own change).

--- a/src/compute/mmq_q8_imma.h
+++ b/src/compute/mmq_q8_imma.h
@@ -28,8 +28,8 @@ namespace imp {
 bool mmq_q8_imma_gemm(const void* w_q8_blocks, const __half* x_f16, __half* out_f16, int M, int N,
                       int K, cudaStream_t stream, float beta = 0.0f);
 
-// Dense Q4_K (new stack — distinct from the legacy gemm.q4k_imma_enabled
-// 2026-05 kernel): same contract; K % 256 == 0 (Q4_K super-block).
+// Dense Q4_K (new stack — distinct from the retired 2026-05 64x32 q4k_imma
+// kernel): same contract; K % 256 == 0 (Q4_K super-block).
 bool mmq_q4k_imma_gemm(const void* w_q4k_blocks, const __half* x_f16, __half* out_f16, int M,
                        int N, int K, cudaStream_t stream, float beta = 0.0f);
 

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -457,8 +457,11 @@ struct WeightCaches {
     bool use_mxfp4 = false;
 
     // --- Q4_K_M direct INT8 IMMA cache (Phase 2C infrastructure) ---
-    // Populated at load-time by mmq_q4k_imma_reorder() when
-    // gemm.q4k_imma_enabled = true. Consumed by mmq_q4k_imma_tile().
+    // NOTE (2026-06-08): currently INACTIVE. The load-time gate (the former
+    // gemm.q4k_imma_enabled flag) was removed as dead — no path populates this
+    // map; it is only declared + freed. Was meant to be filled by
+    // mmq_q4k_imma_reorder() and consumed by mmq_q4k_imma_tile(). Kept pending a
+    // Phase-2C revival or a full removal of the q4k_imma_tile stack.
     // Three device buffers per entry:
     //   w_sym_s8 [N, K]      int8  symmetric-shifted (q - 8)
     //   eff_alpha [N, K/32]  FP16  d_super · sc[j]

--- a/src/exec/gemm_context.h
+++ b/src/exec/gemm_context.h
@@ -34,7 +34,6 @@ struct GemmContext {
     // Phase 5 Track D follow-up: per-Engine knobs; were read from
     // RuntimeConfig::current() in gemm_dispatch / gemm_kernel_gguf hot paths.
     // Wired by the executor's GemmContext::make caller from runtime_config().
-    bool q4k_imma_enabled = false;
     bool q4k_hmma_enabled = false;
     bool q8_imma_enabled = false;
     bool q4k_imma_prefill = false;
@@ -58,7 +57,6 @@ struct GemmContext {
         ctx.qscratch = &qs;
         ctx.force_fp16 = force_fp16;
         ctx.force_mmvq = force_mmvq;
-        ctx.q4k_imma_enabled = rcfg.gemm.q4k_imma_enabled;
         ctx.q4k_hmma_enabled = rcfg.gemm.q4k_hmma_enabled;
         ctx.q8_imma_enabled = rcfg.gemm.q8_imma_enabled;
         ctx.q4k_imma_prefill = rcfg.gemm.q4k_imma_prefill;

--- a/src/exec/gemm_kernel_q4k_imma.cu
+++ b/src/exec/gemm_kernel_q4k_imma.cu
@@ -3,9 +3,10 @@
 // =============================================================================
 //
 // Routes Q4_K_M dense GEMM (M ≥ 1024, dense, non-MoE) through the Phase 2B
-// production tile kernel via the mmq_q4k_imma_gemm high-level entry. Default
-// off; the dispatch site checks `gemm.q4k_imma_enabled` before emitting the
-// {FP16, Q4_K, m_is_one=false} strategy key this handler is registered for.
+// production tile kernel via the mmq_q4k_imma_gemm high-level entry. Registered
+// for the {FP16, Q4_K, m_is_one=false} strategy key. (The former
+// gemm.q4k_imma_enabled gate was removed as dead 2026-06-08; the live Q4_K IMMA
+// prefill flag is gemm.q4k_imma_prefill, checked at executor_kernels.cu.)
 //
 // Eligibility (re-checked here):
 //   - weight.qtype == Q4_K

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -206,8 +206,6 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gdn.chunkwise_scan = parse_bool(val, cfg.gdn.chunkwise_scan);
 
     // [gemm]
-    else if (eq("gemm.no_dp4a"))
-        cfg.gemm.no_dp4a = parse_bool(val, cfg.gemm.no_dp4a);
     else if (eq("gemm.no_dp4a_gemv"))
         cfg.gemm.no_dp4a_gemv = parse_bool(val, cfg.gemm.no_dp4a_gemv);
     else if (eq("gemm.no_dp4a_lm"))
@@ -216,8 +214,6 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         cfg.gemm.no_mmvq = parse_bool(val, cfg.gemm.no_mmvq);
     else if (eq("gemm.no_mmvq_q8_0"))
         cfg.gemm.no_mmvq_q8_0 = parse_bool(val, cfg.gemm.no_mmvq_q8_0);
-    else if (eq("gemm.q4k_imma_enabled"))
-        cfg.gemm.q4k_imma_enabled = parse_bool(val, cfg.gemm.q4k_imma_enabled);
     else if (eq("gemm.q4k_hmma_enabled"))
         cfg.gemm.q4k_hmma_enabled = parse_bool(val, cfg.gemm.q4k_hmma_enabled);
     else if (eq("gemm.q8_imma_enabled"))
@@ -284,8 +280,6 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [diagnostics]
     else if (eq("diagnostics.debug_forward"))
         cfg.diagnostics.debug_forward = parse_bool(val, cfg.diagnostics.debug_forward);
-    else if (eq("diagnostics.debug_gemm_dispatch"))
-        cfg.diagnostics.debug_gemm_dispatch = parse_bool(val, cfg.diagnostics.debug_gemm_dispatch);
     else if (eq("diagnostics.debug_template"))
         cfg.diagnostics.debug_template = parse_bool(val, cfg.diagnostics.debug_template);
     else if (eq("diagnostics.dump_hidden_dir"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -230,18 +230,10 @@ struct RuntimeConfig {
     } gdn;
 
     struct GEMM {
-        bool no_dp4a = false;
         bool no_dp4a_gemv = false;
         bool no_dp4a_lm = false;
         bool no_mmvq = false;
         bool no_mmvq_q8_0 = false;
-        // Phase 2C infrastructure (default off until E2E A/B lands on
-        // dense Q4_K_M models). When true, executor_pre_dequant will
-        // populate WeightCaches::q4k_imma for eligible Q4_K weights
-        // (dense, M ≥ 1024 hint) and a future dispatcher PR will route
-        // the GEMM through mmq_q4k_imma_tile. Detailed wrap-up:
-        // docs/superpowers/plans/2026-05-18-q4k-imma-phase2b-ceiling.md.
-        bool q4k_imma_enabled = false;
         // Q4_K x FP16 HMMA GEMM: in-SMEM nibble decode + FP16 tensor core
         // m16n8k16 tile kernel. Phase 0 scaffold (default off). When enabled,
         // prefill (M >= 32) Q4_K weights bypass dequant-to-FP16 + cuBLAS.
@@ -253,10 +245,10 @@ struct RuntimeConfig {
         // Q4_K-IMMA phase-2B ceiling diagnosis (SMEM-staged scales, 128x128x64
         // tiles, symmetric epilogue). Experimental: default off.
         bool q8_imma_enabled = true;
-        // Q4_K dense prefill via the same (new-stack) IMMA kernel — distinct
-        // from the legacy gemm.q4k_imma_enabled (2026-05 64x32 kernel, 40
-        // TOPS plateau). Uses mmq_q4k_imma_reorder's symmetric-s8 + α/β form
-        // with the unified β·rowsum epilogue. Experimental: default off.
+        // Q4_K dense prefill via the (new-stack) IMMA kernel: uses
+        // mmq_q4k_imma_reorder's symmetric-s8 + α/β form with the unified
+        // β·rowsum epilogue. Experimental: default off. (Distinct from the
+        // retired 2026-05 64x32 q4k_imma kernel that plateaued at 40 TOPS.)
         bool q4k_imma_prefill = false;
         // MoE batch prefill via the grouped IMMA kernel (one launch over all
         // experts, gridDim.z = expert, BM=32 small-M tile for the typical
@@ -414,7 +406,6 @@ struct RuntimeConfig {
 
     struct Diagnostics {
         bool debug_forward = false;
-        bool debug_gemm_dispatch = false;
         bool debug_template = false;
         std::string dump_hidden_dir;
         std::string dump_logits_dir;   // path or empty


### PR DESCRIPTION
## What

D4 from the structural-debt audit (the cheap dead-code/flag sweep). Removes three
config flags that are **parsed and plumbed but whose value is never read** in any
conditional, and lands the audit doc that motivated D1 (#622/#623) and this.

## Removed (all verified never-read)

| Flag | Why dead |
|---|---|
| `gemm.no_dp4a` | superseded by the specific `no_dp4a_gemv` / `no_dp4a_lm` (live); parent left orphaned |
| `gemm.q4k_imma_enabled` | the gate this audit flagged — parsed + mirrored into `GemmContext`, but no dispatch site reads it; the live flag is `gemm.q4k_imma_prefill` |
| `diagnostics.debug_gemm_dispatch` | declared + parsed, never read |

Misleading comments that claimed "the dispatch site checks `gemm.q4k_imma_enabled`"
are fixed (`executor.h`, `gemm_kernel_q4k_imma.cu`, `mmq_q8_imma.h`).

## Behaviour-neutral

All three default `false` and are never consulted → removal changes nothing.
Unknown keys already warn-and-ignore, so a stale `gemm.no_dp4a=true` in a user
`imp.conf` degrades gracefully (verified: `WARN: unknown key … ignoring`).

## Findings surfaced (documented, NOT acted on here)

- **Never-populated `WeightCaches::q4k_imma` cache** — the OLD Phase-2C Q4_K IMMA
  stack (`Q4kImmaCacheEntry`, `mmq_q4k_imma_tile`/`_reorder`) is only declared +
  freed, never filled. Removing the ~1200-line kernel stack is D3-class; deferred,
  left an `INACTIVE` note on the decl.
- **Unbridged `server.prefix_cache` / `server.green_contexts` / `paths.mmproj`** —
  parsed into `RuntimeConfig` but never read; live enablement flows through the
  C-API. The "two config systems" item — user-facing surface that needs a
  bridge-or-retire decision, not a blind delete.

## Verification

Build green · `make verify-fast` gtest filter green · Qwen3-8B coherence (Paris) ·
live-flag config parse still works · removed-key warn-and-ignore confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
