### PR TITLE
feat(profile): attn_variant — semantic enum for the attention SWA/NoPE dispatch (D1 Step B)

### DIFF
--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -184,6 +184,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
 
     const auto& cfg = model_->config();
     const auto& prof = model_->profile();
+    using AttnVariant = ModelProfile::AttnVariant;
     const auto& ly = model_->layer(layer);
     int n = state.n_tokens;
     int nh = cfg.n_heads;
@@ -563,7 +564,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     // (otherwise full attention covers the full context anyway). Resolved
     // again per-layer below in case Gemma-3 disables SWA on this layer.
     int layer_n_sinks = streaming_n_sinks_;
-    if (prof.is_gemma4 && !cfg.swa_layers.empty()) {
+    if (prof.attn_variant == AttnVariant::GEMMA4_SWA) {
         // Gemma 4: per-layer SWA pattern stored in cfg.swa_layers (1=SWA, 0=global).
         bool is_swa = (layer < (int)cfg.swa_layers.size() && cfg.swa_layers[layer]);
         if (is_swa) {
@@ -574,7 +575,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // Global layer: full attention, model rope_theta, with freq scaling
             layer_sliding_window = 0;
         }
-    } else if (prof.is_gpt_oss && !cfg.swa_layers.empty()) {
+    } else if (prof.attn_variant == AttnVariant::GPTOSS_SWA) {
         // gpt-oss (#547): even layers sliding_attention (window 128), odd
         // layers full attention. Same RoPE (YaRN) on both layer types —
         // only the window toggles.
@@ -611,7 +612,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     // (n_rot=hd, with most pairs effectively zeroed by 1e30 divisors). This
     // matches the proportional-rope schema (ccss000000000000) the converter
     // emits via partial_rotary_factor=0.25.
-    if (prof.is_gemma4 && !cfg.swa_layers.empty()) {
+    if (prof.attn_variant == AttnVariant::GEMMA4_SWA) {
         bool layer_is_swa = (layer < (int)cfg.swa_layers.size() && cfg.swa_layers[layer]);
         if (!layer_is_swa && ly.rope_freqs.data && ly.rope_freqs.on_device) {
             longrope_freqs = static_cast<const float*>(ly.rope_freqs.data);
@@ -672,7 +673,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         // K would be YaRN-correct but every decode-written K plain-RoPE →
         // degeneration from token 2. Keep YaRN on the separate full path.
         bool can_fuse_rope_kv = (!state.is_prefill && n == 1 && qv.qtype == QType::F16 && state.kv_cache &&
-                                 state.kv_cache->qtype() == QType::F16 && !cfg.rope_attn_disabled &&
+                                 state.kv_cache->qtype() == QType::F16 && prof.attn_variant != AttnVariant::NOPE &&
                                  cfg.yarn_ext_factor <= 0.0f);
         // Per-layer rope_dim. Gemma 4: both SWA and global layers rotate the
         // full head_dim. Global layers' freq_factors (loaded into
@@ -685,7 +686,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             fused_rope_dim = hd;
         }
         const bool no_qknorm_fused = runtime_config().attention.no_qknorm_fused;
-        if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused && !cfg.rope_attn_disabled) {
+        if (has_qk_norm && n == 1 && qv.qtype == QType::F16 && !no_qknorm_fused && prof.attn_variant != AttnVariant::NOPE) {
             // Fused: QK-norm + RoPE in one kernel launch (decode only, n=1).
             // Keeps norm intermediate values in FP32 shared memory.
             qknorm_rope_fused(static_cast<half*>(qv.data), static_cast<half*>(kk.data),
@@ -749,7 +750,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // NoPE attention (Nemotron-H): position lives in the Mamba layers,
             // rotating Q/K here scrambles positional binding (bag-of-words
             // prompts). QK-norm above still applies; only the rotation is skipped.
-            if (!cfg.rope_attn_disabled) {
+            if (prof.attn_variant != AttnVariant::NOPE) {
                 rope_forward(q4r_t, k4r_t, state.positions, hd, layer_rope_theta, layer_rope_freq_scale,
                              layer_rope_dim, cfg.rope_neox, cfg.yarn_ext_factor, cfg.yarn_attn_factor,
                              cfg.yarn_ext_factor > 0.0f ? yarn_corr_dims_ : nullptr, stream, longrope_freqs);

--- a/src/model/model_profile.cpp
+++ b/src/model/model_profile.cpp
@@ -40,6 +40,20 @@ ModelProfile derive_model_profile(const Model& model, const ModelConfig& cfg) {
     p.is_gpt_oss = cfg.arch == ModelArch::GPT_OSS;
     p.is_llama4 = cfg.arch == ModelArch::LLAMA4;
 
+    // Attention variant. NoPE wins (it is mutually exclusive with the SWA
+    // patterns — Nemotron-H has neither arch SWA nor RoPE). The SWA variants gate
+    // on a populated swa_layers, exactly as the old inline checks did, so a
+    // gemma-4 build with empty swa_layers stays STANDARD and falls through to the
+    // sliding_window_pattern path in run_attention.
+    if (cfg.rope_attn_disabled)
+        p.attn_variant = ModelProfile::AttnVariant::NOPE;
+    else if (p.is_gemma4 && !cfg.swa_layers.empty())
+        p.attn_variant = ModelProfile::AttnVariant::GEMMA4_SWA;
+    else if (p.is_gpt_oss && !cfg.swa_layers.empty())
+        p.attn_variant = ModelProfile::AttnVariant::GPTOSS_SWA;
+    else
+        p.attn_variant = ModelProfile::AttnVariant::STANDARD;
+
     return p;
 }
 

--- a/src/model/model_profile.h
+++ b/src/model/model_profile.h
@@ -35,6 +35,20 @@ struct ModelProfile {
     bool is_gemma4 = false;
     bool is_gpt_oss = false;
     bool is_llama4 = false;
+
+    // --- attention variant (drives the SWA / NoPE dispatch in run_attention) ---
+    // The attention path forks on how positions + sliding windows work. Encoding
+    // it as one variant (decided here from arch + swa_layers + rope_attn_disabled)
+    // replaces the per-call `is_gemma4 && !swa_layers.empty()` /
+    // `is_gpt_oss && !swa_layers.empty()` / `!rope_attn_disabled` re-derivation.
+    //   STANDARD    — RoPE, no per-arch SWA pattern (Gemma-3's
+    //                 sliding_window_pattern path is handled separately and is
+    //                 still STANDARD here).
+    //   GEMMA4_SWA  — Gemma-4 per-layer SWA mask in swa_layers (local rope_theta).
+    //   GPTOSS_SWA  — gpt-oss even=sliding/odd=full, same YaRN RoPE on both.
+    //   NOPE        — no positional encoding at all (Nemotron-H attention).
+    enum class AttnVariant { STANDARD, GEMMA4_SWA, GPTOSS_SWA, NOPE };
+    AttnVariant attn_variant = AttnVariant::STANDARD;
 };
 
 // Pure: no side effects, no allocation. Reads the model's layers + config once.

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -446,8 +446,15 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     model_->build_profile();
     {
         const auto& mp = model_->profile();
-        IMP_LOG_INFO("ModelProfile: moe=%d gdn=%d ssm=%d hybrid=%d dense=%d",
-                     mp.is_moe, mp.is_gdn, mp.is_ssm, mp.is_hybrid, mp.is_dense);
+        const char* av = "standard";
+        switch (mp.attn_variant) {
+            case ModelProfile::AttnVariant::GEMMA4_SWA: av = "gemma4_swa"; break;
+            case ModelProfile::AttnVariant::GPTOSS_SWA: av = "gptoss_swa"; break;
+            case ModelProfile::AttnVariant::NOPE: av = "nope"; break;
+            case ModelProfile::AttnVariant::STANDARD: av = "standard"; break;
+        }
+        IMP_LOG_INFO("ModelProfile: moe=%d gdn=%d ssm=%d hybrid=%d dense=%d attn=%s",
+                     mp.is_moe, mp.is_gdn, mp.is_ssm, mp.is_hybrid, mp.is_dense, av);
     }
 
     init_apply_debug_raw_overrides_();


### PR DESCRIPTION
## What

Completes the ModelProfile design's **Step B** literally. PR #623 routed the
attention arch checks through arch-identity booleans; this adds the semantic
`AttnVariant` enum the design called for, so the attention SWA/NoPE forking is
**one decided variant** rather than per-call re-derivation.

## Changes

- `ModelProfile::AttnVariant { STANDARD, GEMMA4_SWA, GPTOSS_SWA, NOPE }`, derived
  once in `derive_model_profile` from `arch + swa_layers + rope_attn_disabled`.
- `run_attention` reads `prof.attn_variant`:
  - `is_gemma4 && !swa_layers.empty()` (×2) → `== GEMMA4_SWA`
  - `is_gpt_oss && !swa_layers.empty()`      → `== GPTOSS_SWA`
  - `!rope_attn_disabled` (×3)               → `!= NOPE`
- Engine logs the variant in the `ModelProfile:` line.

## Behaviour-neutral by construction

- SWA variants gate on a populated `swa_layers` exactly as before → a gemma-4
  build with empty `swa_layers` stays `STANDARD` and falls through to the
  `sliding_window_pattern` path (Gemma-3's route).
- `NOPE ⟺ rope_attn_disabled`, so `!= NOPE` ≡ the old `!rope_attn_disabled`.
- The arch-id booleans (`is_gemma4` etc.) stay for the gemma-4 tensor-presence
  branches that are not a positional/SWA variant. `rope_attn_disabled` stays the
  source-of-truth bool for the fused-rope-KV kernels in other TUs.

## Verification

All four variants classified + coherent:

| Model | attn_variant | output |
|---|---|---|
| Gemma-4-26B-A4B NVFP4 | `gemma4_swa` | Paris |
| gpt-oss-20b | `gptoss_swa` | Paris |
| Nemotron-3-Nano-30B | `nope` | Paris |
| gemma-3-12b Q4_K_M | `standard` | Paris |

No CUDA error / fallback / NaN. `make verify-fast` gtest filter green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
