### PR TITLE
refactor(pre-dequant): extract the 325-line MoE-native lambda to a method (D3)

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -812,6 +812,17 @@ private:
     void nvfp4_decode_mxfp4_fp16_fallback_(const ModelConfig& cfg, cudaStream_t stream);
     void nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg, size_t& remaining_budget,
                                          cudaStream_t stream, Nvfp4DecodeContext& dctx);
+    // NVFP4-prequant SafeTensors MoE: build the contiguous per-projection decode
+    // cache for one layer's experts (gate/up/down). Borrows resident contiguous
+    // storage zero-copy when possible, else copies per-expert tensors into one
+    // buffer + frees the sources, and re-stamps per-expert CUTLASS_NVFP4 slices.
+    // Stamps `packed` so wcache lookups + the executor dispatch wire up. Returns
+    // true when the projection is handled (cached or left on the CUTLASS path).
+    // Extracted from the nvfp4_decode_cache_moe_experts_ body; the budget flags
+    // are threaded through so the per-layer accounting is shared across calls.
+    bool cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>& experts, cudaStream_t stream,
+                                 Nvfp4DecodeContext& dctx, bool& moe_budget_exhausted,
+                                 size_t& moe_logical_avail);
     void gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx);
     void pre_dequant_phase3c_standalone_mxfp4_(const ModelConfig& cfg, cudaStream_t stream);
     void pre_dequant_phase4_tensor_registry_(const ModelConfig& cfg, cudaStream_t stream);

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -1518,7 +1518,64 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
     // the duplicate (per-expert + contiguous) would peak at ~30 GiB which
     // doesn't fit in 32 GiB, and the legacy fallback can't fire for layers
     // where nvfp4_moe_*_ptr is non-null anyway.
-    auto cache_moe_native_nvfp4 = [&](Tensor& packed, std::vector<Tensor>& experts) -> bool {
+
+    for (int i = 0; i < cfg.n_layers; i++) {
+        // Need mutable access to expert_*_packed for cache_moe_native_nvfp4
+        // to stamp the contiguous buffer pointer. const_cast follows the
+        // existing pattern at e.g. lines 1517 / 1598 of weight_upload.cu.
+        auto& L = const_cast<Model*>(model_)->layer(i);
+
+        bool g = false, u = false, d = false;
+        if (cfg.is_nvfp4_prequant) {
+            g = cache_moe_native_nvfp4_(L.expert_gate_packed, L.expert_w_gate, stream, dctx, moe_budget_exhausted, moe_logical_avail);
+            u = cache_moe_native_nvfp4_(L.expert_up_packed, L.expert_w_up, stream, dctx, moe_budget_exhausted, moe_logical_avail);
+            d = cache_moe_native_nvfp4_(L.expert_down_packed, L.expert_w_down, stream, dctx, moe_budget_exhausted, moe_logical_avail);
+            // Non-gated MoE (e.g. Nemotron-H NemotronHForCausalLM): no gate
+            // projection exists, so g=0 is expected when up and down cached.
+            // Suppress the misleading warning in that case; expert_gemm's
+            // wcache_.nvfp4_moe lookup handles the missing-gate path.
+            bool non_gated = (L.expert_gate_packed.data == nullptr &&
+                              (L.expert_w_gate.empty() ||
+                               L.expert_w_gate[0].data == nullptr));
+            if ((g || u || d) && !(g && u && d) && !(non_gated && u && d)) {
+                IMP_LOG_WARN(
+                    "Layer %d: partial NVFP4 MoE native cache "
+                    "(g=%d u=%d d=%d) — fast path may not engage",
+                    i, (int)g, (int)u, (int)d);
+            }
+        }
+
+        // GGUF / re-quant path: only run when native didn't populate.
+        // For GGUF NVFP4-target models the source qtype is Q*_K/Q8_0 and
+        // packed.data is non-null; for prequant SafeTensors all three
+        // native calls succeeded above and these are no-ops because
+        // packed.data now points into wcache_.nvfp4_moe.
+        if (!g)
+            cache_moe_expert_nvfp4(L.expert_gate_packed, L.expert_gate_packed.qtype);
+        if (!u)
+            cache_moe_expert_nvfp4(L.expert_up_packed, L.expert_up_packed.qtype);
+        if (!d)
+            cache_moe_expert_nvfp4(L.expert_down_packed, L.expert_down_packed.qtype);
+    }
+
+    if (dctx.nvfp4_moe_count > 0) {
+        wcache_.nvfp4_moe_bytes = dctx.nvfp4_moe_total;
+        IMP_LOG_INFO("NVFP4 MoE cache: %d tensors, %.2f MiB", dctx.nvfp4_moe_count,
+                     dctx.nvfp4_moe_total / (1024.0 * 1024.0));
+    } else if (wcache_.nvfp4.empty()) {
+        IMP_LOG_INFO("NVFP4 decode: no eligible weights found (all ≤ 4.5 bits/elem)");
+    }
+}
+
+
+// Extracted from nvfp4_decode_cache_moe_experts_ (was a 325-line [&] lambda).
+// Builds the contiguous NVFP4 decode cache for one MoE projection's experts;
+// see the declaration in executor.h for the full contract. The budget flags
+// (moe_budget_exhausted / moe_logical_avail) are threaded in so the per-layer
+// accounting is shared across the gate/up/down calls.
+bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>& experts,
+                                            cudaStream_t stream, Nvfp4DecodeContext& dctx,
+                                            bool& moe_budget_exhausted, size_t& moe_logical_avail) {
         if (experts.empty() || !experts[0].data)
             return false;
         if (experts[0].qtype != QType::NVFP4 || experts[0].scales == nullptr)
@@ -1842,54 +1899,5 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         }
 
         return true;
-    };
-
-    for (int i = 0; i < cfg.n_layers; i++) {
-        // Need mutable access to expert_*_packed for cache_moe_native_nvfp4
-        // to stamp the contiguous buffer pointer. const_cast follows the
-        // existing pattern at e.g. lines 1517 / 1598 of weight_upload.cu.
-        auto& L = const_cast<Model*>(model_)->layer(i);
-
-        bool g = false, u = false, d = false;
-        if (cfg.is_nvfp4_prequant) {
-            g = cache_moe_native_nvfp4(L.expert_gate_packed, L.expert_w_gate);
-            u = cache_moe_native_nvfp4(L.expert_up_packed, L.expert_w_up);
-            d = cache_moe_native_nvfp4(L.expert_down_packed, L.expert_w_down);
-            // Non-gated MoE (e.g. Nemotron-H NemotronHForCausalLM): no gate
-            // projection exists, so g=0 is expected when up and down cached.
-            // Suppress the misleading warning in that case; expert_gemm's
-            // wcache_.nvfp4_moe lookup handles the missing-gate path.
-            bool non_gated = (L.expert_gate_packed.data == nullptr &&
-                              (L.expert_w_gate.empty() ||
-                               L.expert_w_gate[0].data == nullptr));
-            if ((g || u || d) && !(g && u && d) && !(non_gated && u && d)) {
-                IMP_LOG_WARN(
-                    "Layer %d: partial NVFP4 MoE native cache "
-                    "(g=%d u=%d d=%d) — fast path may not engage",
-                    i, (int)g, (int)u, (int)d);
-            }
-        }
-
-        // GGUF / re-quant path: only run when native didn't populate.
-        // For GGUF NVFP4-target models the source qtype is Q*_K/Q8_0 and
-        // packed.data is non-null; for prequant SafeTensors all three
-        // native calls succeeded above and these are no-ops because
-        // packed.data now points into wcache_.nvfp4_moe.
-        if (!g)
-            cache_moe_expert_nvfp4(L.expert_gate_packed, L.expert_gate_packed.qtype);
-        if (!u)
-            cache_moe_expert_nvfp4(L.expert_up_packed, L.expert_up_packed.qtype);
-        if (!d)
-            cache_moe_expert_nvfp4(L.expert_down_packed, L.expert_down_packed.qtype);
-    }
-
-    if (dctx.nvfp4_moe_count > 0) {
-        wcache_.nvfp4_moe_bytes = dctx.nvfp4_moe_total;
-        IMP_LOG_INFO("NVFP4 MoE cache: %d tensors, %.2f MiB", dctx.nvfp4_moe_count,
-                     dctx.nvfp4_moe_total / (1024.0 * 1024.0));
-    } else if (wcache_.nvfp4.empty()) {
-        IMP_LOG_INFO("NVFP4 decode: no eligible weights found (all ≤ 4.5 bits/elem)");
-    }
 }
-
 }  // namespace imp


### PR DESCRIPTION
## What

D3 from the structural-debt audit — break up the biggest god-function it
flagged: a **325-line `[&]` lambda** (`cache_moe_native_nvfp4`) buried inside
`nvfp4_decode_cache_moe_experts_`, capturing the whole enclosing scope.

Hoisted it to a named member with an explicit signature, so the four pieces of
state it actually used are visible instead of implicit `[&]` captures:

```cpp
bool GraphExecutor::cache_moe_native_nvfp4_(
    Tensor& packed, std::vector<Tensor>& experts, cudaStream_t stream,
    Nvfp4DecodeContext& dctx, bool& moe_budget_exhausted, size_t& moe_logical_avail);
```

The orchestrator shrinks from ~470 → 177 lines. The 3 gate/up/down call sites
pass the budget flags explicitly so the per-layer accounting stays shared.

## Pure code-motion

The method body is **byte-identical** to the old lambda body (323 lines,
verified by `diff`) — the captures simply became named parameters. I confirmed
captures by grep first: the lambda referenced only `dctx`, `moe_budget_exhausted`,
`moe_logical_avail`, `stream` from the enclosing scope (everything else is a
member via `this`).

## Verification

Behaviour-neutral on the NVFP4-prequant MoE models that hit this path:

| Model | data-borrow cache entries | decode | output |
|---|---|---|---|
| Qwen3-30B-A3B-NVFP4 | 144 | tg256 **289** warmed isolated (~307 baseline) | Paris |
| Nemotron-3-Nano-30B | 46 | 142 tok/s | Paris |
| Gemma-4-26B-A4B NVFP4 | 90 | — | Paris |

No legacy-fallback / heap-exhausted / premature-budget warnings (a broken
extraction would drop to the ~30 tok/s D2H-sync fallback). `make verify-fast`
gtest filter green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
