### PR TITLE
refactor(exec): extract QuantPipeline — first GraphExecutor component (D2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,7 @@ if(IMP_BUILD_TESTS)
         tests/test_e2e_greedy_lock.cpp
         tests/test_continuous_batching.cpp
         tests/test_degeneration.cpp
+        tests/test_quant_pipeline.cpp
         tests/test_weight_registry_preservation.cpp
         tests/test_e2e_llm_compressor.cpp
         tests/test_chunked_prefill.cu

--- a/docs/superpowers/plans/2026-06-08-quant-pipeline.md
+++ b/docs/superpowers/plans/2026-06-08-quant-pipeline.md
@@ -1,0 +1,351 @@
+# QuantPipeline Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the init-time weight-quantization pipeline (23 `pre_dequant_*` / `nvfp4_decode_*` methods + the build-only `StoragePlan`) out of the `GraphExecutor` god-object into a standalone `QuantPipeline` builder class.
+
+**Architecture:** `QuantPipeline` holds the build-only `StoragePlan` plus pointer members to the build inputs/outputs (model, allocator, runtime config, and the four long-lived caches that stay owned by `GraphExecutor`). `build()` sets those pointers and runs the existing phase pipeline, filling the caches by reference — so the forward hot path reads `wcache_`/`qscratch_`/`registry_` exactly as today (byte-identical, zero overhead). `GraphExecutor::pre_dequant_weights` becomes a one-line delegate, so the engine call site is untouched.
+
+**Tech Stack:** C++20 / CUDA, Docker build (`make build`), GTest (`imp-tests`), the 4-arch coherence canary.
+
+Spec: `docs/superpowers/specs/2026-06-08-quant-pipeline-design.md`. Branch: `feat/d2-quant-pipeline` (spec already committed).
+
+---
+
+## File structure
+
+- **Create** `src/exec/quant_pipeline.h` — the `QuantPipeline` class declaration (build-only state + pointer members + the 23 moved method declarations + `build()`).
+- **Modify** `src/exec/executor.h` — add `#include "exec/quant_pipeline.h"`, add member `QuantPipeline quant_pipeline_;`, remove the 23 moved method declarations + the `StoragePlan storage_plan_;` member, keep `pre_dequant_weights` (now a delegate).
+- **Modify** the 7 pre-dequant TUs — change `GraphExecutor::` → `QuantPipeline::` for the moved methods, change value-cache member access `.` → `->` (now pointers), keep `storage_plan_` as a value member of `QuantPipeline`:
+  `executor_pre_dequant.cu`, `pre_dequant_phase0_nvfp4_loader.cu`, `pre_dequant_phase1_fp16_cache.cu`, `pre_dequant_phase2_fp8_cache.cu`, `pre_dequant_phase3_nvfp4_decode.cu`, `pre_dequant_phase3c_mxfp4.cu`, `pre_dequant_phase4_tensor_registry.cu`.
+- **Modify** `CMakeLists.txt` — no new TU (the phase TUs already listed); only if a new test file is added.
+- **Create** `tests/test_quant_pipeline.cpp` — standalone `QuantPipelineTest` (Task 7).
+
+The build inputs/outputs threaded into `QuantPipeline` (from the spec's member-access analysis, plus `moe_` found in phase4):
+- inputs: `const Model* model_`, `VRAMAllocator* vram_alloc_`, `const RuntimeConfig* runtime_config_`, `const VRAMBudget* budget_`, `cudaStream_t stream_`
+- outputs (filled, owned by GraphExecutor): `WeightCaches* wcache_`, `QuantScratch* qscratch_`, `WeightRegistry* registry_`, `PlanHints* hints_`, `MoEWorkspace* moe_`
+- owned build-only: `StoragePlan storage_plan_`
+
+---
+
+### Task 1: Create the `QuantPipeline` header skeleton
+
+**Files:**
+- Create: `src/exec/quant_pipeline.h`
+- Reference (copy decls from): `src/exec/executor.h:787-825` (the `pre_dequant_*` / `nvfp4_decode_*` declarations) and `src/exec/executor.h:489-516` (`Nvfp4DecodeContext`).
+
+- [ ] **Step 1: Read the exact current declarations to copy**
+
+Run:
+```bash
+sed -n '786,825p' src/exec/executor.h
+grep -nE "GraphExecutor::(pre_dequant|nvfp4_decode|gpt_oss_convert|apply_arch_rules|cache_moe_native)" src/exec/*.cu | sed 's/.*GraphExecutor:://;s/(.*//' | sort -u
+```
+Expected: the 23 method names + their signatures. Copy the signatures verbatim for Step 2.
+
+- [ ] **Step 2: Write `quant_pipeline.h`**
+
+```cpp
+#pragma once
+
+#include "core/quant.h"          // QType, etc. (match executor.h's includes for these types)
+#include "exec/storage_planner.h" // StoragePlan, PlanHints
+#include "exec/weight_registry.h" // WeightRegistry
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace imp {
+
+class Model;
+class VRAMAllocator;
+struct RuntimeConfig;
+struct VRAMBudget;
+struct WeightCaches;
+struct QuantScratch;
+struct MoEWorkspace;
+
+// Init-time weight-quantization pipeline, extracted from GraphExecutor (D2).
+// Runs once via build(); fills the four long-lived caches (owned by the caller)
+// and owns only the build-only StoragePlan + decode context. See
+// docs/superpowers/specs/2026-06-08-quant-pipeline-design.md.
+class QuantPipeline {
+public:
+    void build(const Model& model, const RuntimeConfig& rcfg, VRAMAllocator& alloc,
+               const VRAMBudget& budget, cudaStream_t stream, WeightCaches& wcache,
+               QuantScratch& qscratch, WeightRegistry& registry, PlanHints& hints,
+               MoEWorkspace& moe);
+
+private:
+    // Build context (set at the top of build(); the phase methods read these
+    // exactly as they read the same-named GraphExecutor members today).
+    const Model* model_ = nullptr;
+    VRAMAllocator* vram_alloc_ = nullptr;
+    const RuntimeConfig* runtime_config_ = nullptr;
+    const VRAMBudget* budget_ = nullptr;
+    cudaStream_t stream_ = nullptr;
+    WeightCaches* wcache_ = nullptr;
+    QuantScratch* qscratch_ = nullptr;
+    WeightRegistry* registry_ = nullptr;
+    PlanHints* hints_ = nullptr;
+    MoEWorkspace* moe_ = nullptr;
+
+    // Owned build-only state.
+    StoragePlan storage_plan_;
+
+    // --- moved phase / helper declarations (paste verbatim from executor.h) ---
+    // void pre_dequant_weights(cudaStream_t stream, const VRAMBudget& budget);  // see note
+    // ... the other 22 declarations, with the SAME signatures ...
+};
+
+}  // namespace imp
+```
+
+Notes for Step 2:
+- Paste the 22 inner phase/helper declarations verbatim from `executor.h` (the `pre_dequant_phase*_`, `nvfp4_decode_*`, `gpt_oss_convert_moe_experts_`, `apply_arch_rules_`, `cache_moe_native_nvfp4_` decls).
+- The public entry inside QuantPipeline is `build()`. The current `pre_dequant_weights(stream, budget)` body becomes the **private** `run_(...)` of QuantPipeline OR `build()` simply contains that body. Simplest: rename the moved `pre_dequant_weights` body to `build()`'s body (the body already calls the phases). Keep the phase decls private.
+- Fix `#include`s by copying the exact ones `executor.h` uses for `StoragePlan`, `PlanHints`, `WeightRegistry`, `Nvfp4DecodeContext`. If `Nvfp4DecodeContext` / `MoeFfnContext` live in `executor.h`, move `Nvfp4DecodeContext` into `quant_pipeline.h` (it's "Per-call state for pre_dequant_phase3" — build-only) and have `executor.h` keep compiling (it no longer needs it).
+
+- [ ] **Step 3: Commit the skeleton (won't fully wire yet)**
+
+```bash
+git add src/exec/quant_pipeline.h
+git commit -m "feat(quant): QuantPipeline header skeleton (D2 component 1)"
+```
+
+---
+
+### Task 2: Move the phase method DEFINITIONS to `QuantPipeline`
+
+**Files:**
+- Modify: `src/exec/executor_pre_dequant.cu`, `pre_dequant_phase0_nvfp4_loader.cu`, `pre_dequant_phase1_fp16_cache.cu`, `pre_dequant_phase2_fp8_cache.cu`, `pre_dequant_phase3_nvfp4_decode.cu`, `pre_dequant_phase3c_mxfp4.cu`, `pre_dequant_phase4_tensor_registry.cu`
+
+- [ ] **Step 1: Back up the TUs**
+
+```bash
+mkdir -p /tmp/qp_bak && cp src/exec/executor_pre_dequant.cu src/exec/pre_dequant_phase*.cu /tmp/qp_bak/
+```
+
+- [ ] **Step 2: Add the include + reclass the method definitions**
+
+In each of the 7 TUs, add `#include "exec/quant_pipeline.h"` (after the existing `#include "exec/executor.h"`), then reclass the moved methods:
+
+```bash
+for f in src/exec/executor_pre_dequant.cu src/exec/pre_dequant_phase0_nvfp4_loader.cu \
+         src/exec/pre_dequant_phase1_fp16_cache.cu src/exec/pre_dequant_phase2_fp8_cache.cu \
+         src/exec/pre_dequant_phase3_nvfp4_decode.cu src/exec/pre_dequant_phase3c_mxfp4.cu \
+         src/exec/pre_dequant_phase4_tensor_registry.cu; do
+  grep -q 'exec/quant_pipeline.h' "$f" || sed -i '0,/#include "exec\/executor.h"/s//#include "exec\/executor.h"\n#include "exec\/quant_pipeline.h"/' "$f"
+  # reclass the moved methods (the 23 names) from GraphExecutor:: to QuantPipeline::
+  perl -0pi -e 's/\bGraphExecutor::(pre_dequant_weights|pre_dequant_phase\w+|nvfp4_decode_\w+|gpt_oss_convert_moe_experts_|apply_arch_rules_|cache_moe_native_nvfp4_)\b/QuantPipeline::$1/g' "$f"
+done
+```
+
+- [ ] **Step 3: Rename the `pre_dequant_weights` definition to `build` and give it the build() signature**
+
+In `executor_pre_dequant.cu`, change:
+```cpp
+void QuantPipeline::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& budget) {
+```
+to the `build()` signature, and stash the context pointers at the top:
+```cpp
+void QuantPipeline::build(const Model& model, const RuntimeConfig& rcfg, VRAMAllocator& alloc,
+                          const VRAMBudget& budget, cudaStream_t stream, WeightCaches& wcache,
+                          QuantScratch& qscratch, WeightRegistry& registry, PlanHints& hints,
+                          MoEWorkspace& moe) {
+    model_ = &model; runtime_config_ = &rcfg; vram_alloc_ = &alloc; budget_ = &budget;
+    stream_ = stream; wcache_ = &wcache; qscratch_ = &qscratch; registry_ = &registry;
+    hints_ = &hints; moe_ = &moe;
+    // ... the rest of the original pre_dequant_weights body unchanged ...
+```
+If the original body used the parameter names `stream` / `budget` directly, keep doing so (they're still params). The body's internal phase calls (`pre_dequant_phase1_fp16_cache_(...)` etc.) are member calls — unchanged.
+
+- [ ] **Step 4: Convert value-cache member access to pointer access**
+
+The four caches + `moe_` are now POINTER members; `storage_plan_` stays a value member (owned). Apply per TU:
+```bash
+for f in src/exec/executor_pre_dequant.cu src/exec/pre_dequant_phase*.cu; do
+  perl -0pi -e 's/\bwcache_\./wcache_->/g; s/\bqscratch_\./qscratch_->/g; s/\bregistry_\./registry_->/g; s/\bhints_\./hints_->/g; s/\bmoe_\./moe_->/g' "$f"
+  # address-of / by-value passes of the now-pointer caches:
+  perl -0pi -e 's/&wcache_\b/wcache_/g; s/&qscratch_\b/qscratch_/g; s/&registry_\b/registry_/g; s/&moe_\b/moe_/g' "$f"
+done
+```
+`model_->` / `vram_alloc_->` are unchanged (already pointers). `storage_plan_.` is unchanged (still a value member, now on QuantPipeline). Do NOT touch `storage_plan_`.
+
+- [ ] **Step 5: Commit the move (will not build until Task 3 wires GraphExecutor)**
+
+```bash
+git add src/exec/*.cu
+git commit -m "refactor(quant): reclass pre_dequant phase methods onto QuantPipeline"
+```
+
+---
+
+### Task 3: Wire `GraphExecutor` to own + delegate to `QuantPipeline`
+
+**Files:**
+- Modify: `src/exec/executor.h`
+
+- [ ] **Step 1: Include + member**
+
+In `executor.h`, add near the top includes: `#include "exec/quant_pipeline.h"`. In the private member section (near `WeightCaches wcache_;` at line ~953) add:
+```cpp
+    QuantPipeline quant_pipeline_;
+```
+
+- [ ] **Step 2: Remove the moved declarations + the build-only member**
+
+Delete from `executor.h`:
+- the 22 inner declarations (`pre_dequant_phase*_`, `nvfp4_decode_*`, `gpt_oss_convert_moe_experts_`, `apply_arch_rules_`, `cache_moe_native_nvfp4_`) — they now live on `QuantPipeline`.
+- the `StoragePlan storage_plan_;` member (line ~963) — now owned by `QuantPipeline`.
+- `Nvfp4DecodeContext` struct (lines ~489-516) if it was moved into `quant_pipeline.h` in Task 1.
+
+KEEP `void pre_dequant_weights(cudaStream_t stream, const VRAMBudget& budget);` declared on GraphExecutor (it becomes a delegate).
+
+- [ ] **Step 3: Make `pre_dequant_weights` a delegate**
+
+The original `GraphExecutor::pre_dequant_weights` body now lives in `QuantPipeline::build`. Add a NEW tiny `GraphExecutor::pre_dequant_weights` definition (put it in `executor_pre_dequant.cu`, replacing the now-renamed one):
+```cpp
+void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& budget) {
+    quant_pipeline_.build(*model_, *runtime_config_, *vram_alloc_, budget, stream,
+                          wcache_, qscratch_, registry_, hints_, moe_);
+}
+```
+(`wcache_`/`qscratch_`/`registry_`/`hints_`/`moe_` here are the GraphExecutor value members — passed by reference into `build`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/exec/executor.h src/exec/executor_pre_dequant.cu
+git commit -m "refactor(exec): GraphExecutor owns + delegates to QuantPipeline"
+```
+
+---
+
+### Task 4: Build and fix the compile errors
+
+- [ ] **Step 1: Build**
+
+Run: `make build 2>&1 | grep -iE "error:" | head -40`
+Expected initially: a short list of errors — most likely (a) a build method that read a GraphExecutor member NOT in the planned set (model_/alloc/rcfg/budget/stream/wcache/qscratch/registry/hints/moe/storage_plan), or (b) a missing include in `quant_pipeline.h`, or (c) a residual `wcache_.` / `&wcache_` the perl missed.
+
+- [ ] **Step 2: Resolve each error by category**
+
+- **Missing GraphExecutor member referenced in a moved method**: add it to the build context — a pointer member on `QuantPipeline` + a `build()` param + set it in Step-3-of-Task-2, and pass it from the delegate. Re-grep to confirm it's genuinely build-time (no hot-path writer).
+- **`Nvfp4DecodeContext` / type not found**: add the include or move the type into `quant_pipeline.h`.
+- **Residual value-access**: fix the specific `.`/`&` site by hand.
+
+Iterate `make build` until clean. Expected final: `make build` succeeds.
+
+- [ ] **Step 3: Commit the fixes**
+
+```bash
+git add -A && git commit -m "fix(quant): thread remaining build-context members + includes"
+```
+
+---
+
+### Task 5: Behaviour-neutral canary (the gate)
+
+- [ ] **Step 1: 4-arch coherence + native-MoE-cache count**
+
+```bash
+for M in "Qwen3-8B-Q8_0.gguf|dense" "Qwen3-30B-A3B-NVFP4-Modelopt|moe-native" \
+         "Nemotron-3-Nano-30B-A3B-NVFP4|hybrid" "gemma-3-12b-it-Q4_K_M.gguf|gemma3"; do
+  MODEL="${M%%|*}";
+  docker run --rm --gpus all -v /home/kekz/models:/models imp:test \
+    imp-cli --model "/models/$MODEL" --prompt "What is the capital of France? One word." \
+    --max-tokens 200 --temperature 0 --seed 42 >/tmp/qp.out 2>&1
+  echo "== $MODEL =="
+  grep -aoiE "paris" /tmp/qp.out | head -1
+  grep -acE "NVFP4 MoE native: data-borrow decode cache" /tmp/qp.out
+  grep -aiE "CUDA error|falling back|\bNaN\b|legacy.*fallback" /tmp/qp.out | head -1
+done
+```
+Expected: each model prints `Paris`, no `CUDA error/falling back/NaN`, and the MoE models print the SAME native-cache count as `main` (Qwen3-30B 144, Nemotron 46). If the count differs or a model degenerates, the extraction reordered something — bisect against the Task-2/3 commits.
+
+- [ ] **Step 2: `verify-fast`**
+
+Run: `IMP_VERIFY_SKIP_BUILD=1 make verify-fast 2>&1 | grep -E "PASS|FAIL|OK ==="`
+Expected: `PASS fast gtest filter`, `=== verify fast: OK ===`.
+
+- [ ] **Step 3: Commit (no-op if clean) / proceed**
+
+No code change here; this is the gate. If anything failed, fix and re-run before continuing.
+
+---
+
+### Task 6: Confirm the hot path is byte-identical
+
+- [ ] **Step 1: Diff the forward TUs vs main**
+
+Run: `git diff main -- src/exec/executor_attention.cu src/exec/executor_ffn.cu src/exec/executor_forward.cu src/exec/executor_forward_moe.cu src/exec/executor_gemm_dispatch.cu | wc -l`
+Expected: `0` — the hot-path TUs are untouched (they still read `wcache_`/`qscratch_`/`registry_` as GraphExecutor members). If non-zero, something leaked into the hot path; investigate before proceeding.
+
+---
+
+### Task 7: Add the standalone `QuantPipelineTest`
+
+**Files:**
+- Create: `tests/test_quant_pipeline.cpp`
+- Modify: `CMakeLists.txt` (add the test source to the GPU test bundle, next to the other `tests/test_*.cu`/`.cpp` entries)
+
+- [ ] **Step 1: Write the test**
+
+A minimal test that loads a small model, runs the pipeline via the public engine path, and asserts the caches got populated. Since `QuantPipeline::build` needs a loaded `Model` + allocator (GPU), the pragmatic first test drives it through the engine and asserts an observable post-build invariant:
+
+```cpp
+#include <gtest/gtest.h>
+#include "api/imp_c.h"   // or the engine header used by other GPU tests
+#include "test_models.h" // existing registry of local test model paths
+
+// QuantPipeline runs inside engine init; assert it produced a usable decode
+// cache by checking the model decodes coherently (the cache is what makes the
+// native NVFP4 / dequant decode path fire). This is the component's
+// post-condition observed end-to-end until a bare-model unit fixture exists.
+TEST(QuantPipelineTest, BuildPopulatesDecodeCachesAndDecodes) {
+    // Mirror the setup of tests/test_degeneration.cpp (same C API + default model).
+    // ... load default model, generate ~16 tokens greedy, assert non-degenerate ...
+}
+```
+
+Match the exact harness of `tests/test_degeneration.cpp` (same include set, model env var, generation helper). Keep the assertion simple: ≥10 coherent tokens, no repetition. (A true bare-`QuantPipeline` unit test needs a model fixture without the full engine; note it as a follow-up if the fixture doesn't exist yet — do not block this PR on it.)
+
+- [ ] **Step 2: Register + build + run**
+
+```bash
+# add tests/test_quant_pipeline.cpp to the test target list in CMakeLists.txt
+make build 2>&1 | tail -2
+docker run --rm --gpus all -v /home/kekz/models:/models imp:test imp-tests --gtest_filter="QuantPipelineTest.*" 2>&1 | tail -8
+```
+Expected: `[  PASSED  ] 1 test.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_quant_pipeline.cpp CMakeLists.txt
+git commit -m "test(quant): QuantPipeline build post-condition (decode coherence)"
+```
+
+---
+
+### Task 8: Push + PR
+
+- [ ] **Step 1: Push + open PR vs main**
+
+```bash
+git push -u origin feat/d2-quant-pipeline
+gh pr create --base main --head feat/d2-quant-pipeline \
+  --title "refactor(exec): extract QuantPipeline — first GraphExecutor component (D2)" \
+  --body "<summary: what moved, byte-identical hot path (Task 6 diff=0), 4-arch canary + native-MoE-cache count + verify-fast green; establishes the component pattern for the rest of D2>"
+```
+
+- [ ] **Step 2: Watch CI, merge when green** (Build required check; Test skips — GPU local-only; the canary in Task 5 is the behaviour gate run locally).
+
+---
+
+## Notes / gotchas (from prior D-work on this repo)
+
+- Build is Docker-only (`make build`); `build/` is root-owned. GPU canary runs need `-v /home/kekz/models:/models` (the repo `models/` are symlinks).
+- `pre_dequant_phase3_nvfp4_decode.cu` already holds the extracted `cache_moe_native_nvfp4_` method (from PR #627) — it reclasses to `QuantPipeline::cache_moe_native_nvfp4_` like the rest.
+- Line-surgery lesson: keep `/tmp/*.bak` copies before perl edits; never use `perl -0pi` with an embedded `do{<>}` (it empties the file) — the per-TU perl commands here are plain substitutions, which are safe.
+- Qwen3-30B-A3B-NVFP4 is MoE-routing nondeterministic at temp=0; judge it by the native-cache COUNT + coherence, not exact tokens.

--- a/docs/superpowers/specs/2026-06-08-quant-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-08-quant-pipeline-design.md
@@ -1,0 +1,148 @@
+# QuantPipeline — first component of the GraphExecutor split (D2)
+
+Date: 2026-06-08
+
+## Problem
+
+`GraphExecutor` (declared in `src/exec/executor.h`, ~1188-line header) is a
+god-object: ~53 methods + ~69 data members + 10 supporting structs in one class.
+D2 of the structural-debt audit (`docs/audit/structural_debt_2026_06_08.md`)
+calls for breaking it into testable components with clear interfaces.
+
+The `.cu` *implementations* are already domain-partitioned
+(`executor_attention.cu`, `executor_forward_moe*.cu`, `executor_pre_dequant.cu`,
+the `pre_dequant_phase*.cu` set, …). What is monolithic is the **class + header**:
+all members are visible to every TU (no encapsulation), no domain is testable in
+isolation, and any header edit recompiles the world.
+
+This spec covers the **first** extracted component — `QuantPipeline` — chosen as
+the proof-of-concept because it has the cleanest boundary and the lowest hot-path
+risk: it runs once at init and the forward path only *reads* the caches it builds.
+
+## Goal & constraints
+
+- Extract the init-time weight-quantization pipeline into a standalone
+  `QuantPipeline` class with a single `build()` entry point.
+- **Strictly behaviour-neutral.** The forward hot path must stay byte-identical
+  and zero-overhead — no new indirection in decode/prefill.
+- Gated like the prior refactors: coherence canary across dense / MoE / GGUF /
+  gemma + native-NVFP4, plus `make verify-fast`.
+- Establish the **pattern** (component class + `build()`-style interface + the
+  canary gates) that later components (MoeRunner, Workspace, AttentionRunner, …)
+  will follow. Those are out of scope here.
+
+## Architecture
+
+`QuantPipeline` is a **builder component**. `GraphExecutor` owns one
+(`QuantPipeline quant_pipeline_;`) and invokes it once during init (today's
+`pre_dequant_weights` call site in `init_kv_cache`). The 23 build methods become
+`QuantPipeline::` methods; the existing `pre_dequant_phase*.cu` / `executor_pre_dequant.cu`
+translation units stay as-is except for the class prefix change.
+
+The key principle that keeps the hot path zero-overhead: **the long-lived caches
+stay owned by `GraphExecutor`; `QuantPipeline` fills them by reference.**
+
+### State split
+
+Verified by member-access analysis of the pre-dequant TUs:
+
+| Member | Refs | Decision |
+|---|---|---|
+| `wcache_` (WeightCaches) | 207 | **stays on GraphExecutor**, filled by ref — hot path reads it everywhere |
+| `model_` | 64 | input — passed to `build()` |
+| `qscratch_` (QuantScratch) | 37 | **stays**, filled by ref — hot path reads it |
+| `vram_alloc_` | 29 | input — passed to `build()` |
+| `registry_` (WeightRegistry) | 14 | **stays**, filled by ref — hot path reads it |
+| `storage_plan_` (StoragePlan) | 11 | **moves into QuantPipeline** — build-only, no hot-path reader |
+| `hints_` (PlanHints) | 2 | **stays**, filled by ref (read by `executor_workspace.cu` sizing) |
+
+`QuantPipeline` owns only build-only transient state: `storage_plan_`, the
+`Nvfp4DecodeContext`, and any build scratch. Everything the forward path consumes
+remains a `GraphExecutor` member, read identically to today.
+
+### Methods that move (23)
+
+`pre_dequant_weights` (entry) + `apply_arch_rules_` + `pre_dequant_phase0_promote_nvfp4_sidecars_`
++ `pre_dequant_phase0b_register_cutlass_nvfp4_` + `pre_dequant_phase1_fp16_cache_`
++ `pre_dequant_phase2_fp8_cache_` + `pre_dequant_phase3_nvfp4_decode_`
++ `pre_dequant_phase3c_standalone_mxfp4_` + `pre_dequant_phase4_tensor_registry_`
++ `pre_dequant_phase4b_drop_redundant_sources_` + the 10 `nvfp4_decode_*` helpers
++ `gpt_oss_convert_moe_experts_` + `cache_moe_native_nvfp4_`.
+
+## Interface
+
+```cpp
+// src/exec/quant_pipeline.h
+class QuantPipeline {
+public:
+    // Runs the full init-time quantization pipeline once. Populates the four
+    // long-lived caches (owned by the caller) from the model's weights; owns the
+    // transient StoragePlan + decode context internally.
+    void build(const Model& model, const RuntimeConfig& rcfg, VRAMAllocator& alloc,
+               const VRAMBudget& budget, cudaStream_t stream,
+               WeightCaches& wcache, QuantScratch& qscratch,
+               WeightRegistry& registry, PlanHints& hints);
+
+private:
+    StoragePlan storage_plan_;
+    // + the 23 phase/helper methods (moved verbatim), now reading their inputs
+    //   from build() params / members instead of GraphExecutor members.
+};
+```
+
+`GraphExecutor::init_kv_cache` replaces its `pre_dequant_weights(stream, budget)`
+call with `quant_pipeline_.build(*model_, *runtime_config_, *vram_alloc_, budget,
+stream, wcache_, qscratch_, registry_, hints_)`.
+
+## Open detail (resolved during implementation)
+
+- The 2 `moe_` (MoEWorkspace) references inside the build methods: confirm whether
+  they are genuine members (then `moe_` joins the `build()` params) or locals.
+  Small; does not change the architecture.
+
+## Data flow
+
+Init: `GraphExecutor::init` → `init_kv_cache` → `quant_pipeline_.build(...)`
+→ phases run, filling `wcache_`/`qscratch_`/`registry_`/`hints_` → control returns,
+GraphExecutor proceeds. Forward: unchanged — reads `wcache_`/`qscratch_`/`registry_`
+directly.
+
+## Error handling
+
+Unchanged. The phases throw on internal errors (translated to `ImpError` at the
+API boundary per the project convention); `build()` propagates exceptions the same
+way the current `pre_dequant_weights` does. No status-return conversion.
+
+## Testing
+
+- **New**: a standalone `QuantPipelineTest` that constructs a `QuantPipeline`,
+  builds against a small loaded model with empty caches, and asserts the caches
+  are populated (entry counts / tiers) — the first component testable without the
+  full forward machinery. (If a bare-model fixture is impractical in unit scope,
+  fall back to asserting via the existing GPU e2e path; note it in the plan.)
+- **Canary (behaviour-neutral gate)**: coherence across Qwen3-8B Q8_0 (dense
+  GGUF), Qwen3-30B-A3B-NVFP4 (MoE native — exercises `cache_moe_native_nvfp4_`),
+  Nemotron-3-Nano-30B (Mamba2/MoE hybrid), gemma-3-12b (dense gemma). Each must
+  stay coherent (Paris-class probe) with no `CUDA error / falling back / NaN` and
+  no decode-speed drop (the native MoE cache must still fire — same count of
+  `NVFP4 MoE native: data-borrow decode cache` log lines).
+- `make verify-fast` gtest filter green.
+
+## Out of scope
+
+- Any other component (MoeRunner, Workspace, AttentionRunner, ExpertLRUCache,
+  …). This PR only proves the pattern with QuantPipeline.
+- Moving `wcache_`/`qscratch_`/`registry_` ownership off GraphExecutor (would add
+  hot-path indirection — explicitly rejected).
+- Splitting the supporting structs out of `executor.h` (a separate, smaller
+  cleanup; not required for this extraction).
+
+## Risks
+
+- **A build method reads a GraphExecutor member not in the planned set.** Caught
+  at compile time (the method moves to QuantPipeline and won't see the member);
+  resolve by threading it through `build()` params or as a QuantPipeline member if
+  build-only. The member-access analysis above bounds this to a short list.
+- **Subtle reordering of cache population.** Mitigation: methods move verbatim
+  (pure code-motion, like the D3 lambda extraction); the canary's native-MoE-cache
+  count + coherence catches any divergence.

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -15,6 +15,7 @@
 #include "exec/weight_handle.h"
 #include "exec/moe_workspace.h"
 #include "exec/quant_scratch.h"
+#include "exec/quant_pipeline.h"
 #include "runtime/storage_planner.h"
 #include "runtime/config.h"
 #include <cuda_runtime.h>
@@ -486,33 +487,8 @@ struct WeightCaches {
     bool dual_path_quant = false;
 };
 
-// Per-call state for GraphExecutor::pre_dequant_phase3_nvfp4_decode_().
-// Bundles the locals shared between sub-phase helpers — exclusion set,
-// candidate entries, mode string, MoE-cache accumulators.
-struct Nvfp4DecodeContext {
-    // One entry per weight that may receive NVFP4 quantization. Populated by
-    // the collect phase; consumed by the mode-1 / mode-2 / second-pass phases.
-    struct Entry {
-        const void* orig_ptr;
-        Tensor weight;
-        QType qtype;
-        bool from_scratch;
-    };
-
-    std::unordered_set<const void*> exclude_ptrs;
-    std::vector<Entry> entries;
-    const char* mode_str = "";          // "additive" or "only", set early
-    size_t moe_budget = 0;              // initialised before the MoE-cache phase
-    int    nvfp4_moe_count = 0;         // populated by the MoE-cache phase
-    size_t nvfp4_moe_total = 0;
-    // Shared VRAM safety reserve for mode 2 paths (dense incremental,
-    // CUTLASS NVFP4, MoE expert caching). Computed once at the top of
-    // pre_dequant_phase3_nvfp4_decode_() from the model's actual attention
-    // layout — replaces the previous `total_mem / 10` heuristic which
-    // reserved 3.2 GiB on a 32 GiB 5090 and starved the dense NVFP4 cache
-    // (20 of 281 tensors uncached on Qwen3-14B Q6_K → −20% decode tok/s).
-    size_t safety_reserve = 0;
-};
+// Nvfp4DecodeContext moved to exec/quant_pipeline.h (build-only; consumed by
+// the QuantPipeline phase-3 helpers).
 
 // Per-call state for GraphExecutor::run_moe_ffn(). Bundles the locals that
 // were previously captured by the monolithic body so each MoE phase helper
@@ -775,64 +751,10 @@ public:
     }
 
 private:
-    // Phases of pre_dequant_weights(), extracted for readability.
-    // Cross-phase state: remaining_budget is reduced by each FP16/FP8/NVFP4
-    // pass; cfg is const reference to model config.
-    void pre_dequant_phase0_promote_nvfp4_sidecars_(const ModelConfig& cfg, cudaStream_t stream);
-    void pre_dequant_phase0b_register_cutlass_nvfp4_(const ModelConfig& cfg, cudaStream_t stream);
-    void pre_dequant_phase1_fp16_cache_(const ModelConfig& cfg, const VRAMBudget& budget,
-                                        size_t& remaining_budget, cudaStream_t stream);
-    void pre_dequant_phase2_fp8_cache_(const ModelConfig& cfg, const VRAMBudget& budget,
-                                       size_t& remaining_budget, cudaStream_t stream);
-    void pre_dequant_phase3_nvfp4_decode_(const ModelConfig& cfg, const VRAMBudget& budget,
-                                          size_t& remaining_budget, cudaStream_t stream);
-    // Sub-phase helpers for pre_dequant_phase3_nvfp4_decode_. Each operates
-    // on a shared Nvfp4DecodeContext; the orchestrator above calls them in
-    // sequence, mirroring the legacy monolithic body.
-    void nvfp4_decode_collect_candidates_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx);
-    // Quantize a native-precision (FP16/BF16) LM head to an NVFP4 decode cache
-    // entry in wcache_.nvfp4. No-op when the LM head is already a quantized
-    // source (GGUF path handles it via collect_candidates) or when the model is
-    // GDN/SSM-hybrid. See RuntimeConfig::Gemm::nvfp4_lm_head.
-    void nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cudaStream_t stream);
-    // Quantize the recipe-excluded BF16/FP16 attention q/k/v/o projections of a
-    // native-NVFP4 hybrid into wcache_.nvfp4 so M=1 decode uses the fast NVFP4
-    // GEMV. Opt-in via gemm.nvfp4_attn_proj. No-op unless the flag is set.
-    // (The GDN in/out analog was measured to regress decode and was dropped.)
-    void nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg, cudaStream_t stream);
-    void nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4DecodeContext& dctx);
-    void nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaStream_t stream,
-                                      Nvfp4DecodeContext& dctx);
-    void nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_budget, cudaStream_t stream,
-                                                 Nvfp4DecodeContext& dctx);
-    void nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStream_t stream,
-                                   Nvfp4DecodeContext& dctx);
-    void nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cudaStream_t stream);
-    void nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cfg, cudaStream_t stream);
-    void nvfp4_decode_mxfp4_fp16_fallback_(const ModelConfig& cfg, cudaStream_t stream);
-    void nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg, size_t& remaining_budget,
-                                         cudaStream_t stream, Nvfp4DecodeContext& dctx);
-    // NVFP4-prequant SafeTensors MoE: build the contiguous per-projection decode
-    // cache for one layer's experts (gate/up/down). Borrows resident contiguous
-    // storage zero-copy when possible, else copies per-expert tensors into one
-    // buffer + frees the sources, and re-stamps per-expert CUTLASS_NVFP4 slices.
-    // Stamps `packed` so wcache lookups + the executor dispatch wire up. Returns
-    // true when the projection is handled (cached or left on the CUTLASS path).
-    // Extracted from the nvfp4_decode_cache_moe_experts_ body; the budget flags
-    // are threaded through so the per-layer accounting is shared across calls.
-    bool cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>& experts, cudaStream_t stream,
-                                 Nvfp4DecodeContext& dctx, bool& moe_budget_exhausted,
-                                 size_t& moe_logical_avail);
-    void gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx);
-    void pre_dequant_phase3c_standalone_mxfp4_(const ModelConfig& cfg, cudaStream_t stream);
-    void pre_dequant_phase4_tensor_registry_(const ModelConfig& cfg, cudaStream_t stream);
-    // Phase 5 PR #1 Commit 5.1.4.b: mark Tensor.dropped_source for weights
-    // whose handle says can_drop_source(). DOES NOT cudaFree (yet) — bisect
-    // mode: trigger the safety guards in dispatch to surface unguarded paths
-    // via "dropped-source reached final fallback" warnings without actually
-    // crashing on stale pointers. Actual freeing follows once coverage is
-    // verified clean.
-    void pre_dequant_phase4b_drop_redundant_sources_(const ModelConfig& cfg, cudaStream_t stream);
+    // The init-time weight-quantization pipeline (the 23 pre_dequant_*/
+    // nvfp4_decode_* methods + the build-only StoragePlan) was extracted to
+    // QuantPipeline (exec/quant_pipeline.h). GraphExecutor owns one
+    // (quant_pipeline_, below) and delegates pre_dequant_weights() to it.
 
     // StreamingLLM (sinks + window). 0 = disabled.
     int streaming_n_sinks_ = 0;
@@ -949,25 +871,19 @@ public:
     bool nvfp4_dequant_uncapturable() const { return nvfp4_dequant_uncapturable_; }
 
 private:
+    // Init-time weight-quantization pipeline (D2 extraction). Owns the build-only
+    // StoragePlan; fills the long-lived caches below by reference in build().
+    QuantPipeline quant_pipeline_;
+
     // Weight caches (FP16, FP8, NVFP4, CUTLASS NVFP4/MXFP4, fused KV/gate+up)
     WeightCaches wcache_;
 
     // Mode flags mirrored from wcache_ for PlanHints (hints_ is the Phase 5 source of truth).
     PlanHints hints_;
 
-    // Stage 1 (one-tier-truth): the StoragePlanner output, held for the model's
-    // lifetime. Built once at the top of pre_dequant_weights(). The pre-dequant
-    // phases are being migrated to read their overlay-tier decision from here
-    // (plan_tier_of) instead of scattered nvfp4_beneficial/plan_routes_to_fp16
-    // checks. Empty until pre_dequant_weights runs.
-    StoragePlan storage_plan_;
-    // Planned overlay tier for a source pointer, or Undefined if the pointer is
-    // not in the plan (native GGUF blocks bypass the overlay layer).
-    StorageTier plan_tier_of(const void* src) const { return storage_plan_.tier_of(src); }
-    // Stage 1.2: fold the scattered arch-specific overlay rules (gemma-3 FP16
-    // backing, GDN ssm FP16 floor, native-NVFP4 prefill) into one pass over the
-    // freshly-built plan, so the plan matches what the legacy builders produce.
-    void apply_arch_rules_(StoragePlan& plan, const ModelConfig& cfg) const;
+    // The build-only StoragePlan (storage_plan_), plan_tier_of(), and
+    // apply_arch_rules_() moved into QuantPipeline (exec/quant_pipeline.h) —
+    // they have no hot-path reader.
 
     // WeightRegistry: parallel handle store (Phase 2+ shim, populated alongside wcache_)
     WeightRegistry registry_;

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -22,7 +22,6 @@
 #include <cuda_fp16.h>
 #include <vector>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <list>
 

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -4,7 +4,8 @@
 //
 // Adding a new phase: write one new src/exec/pre_dequant_phase*.cu file,
 // add it to CMakeLists.txt IMP_EXEC_SOURCES, declare the method on
-// GraphExecutor in executor.h, and call it from pre_dequant_weights() below.
+// QuantPipeline in quant_pipeline.h, and call it from QuantPipeline::build()
+// below.
 
 #include "exec/executor.h"
 #include "exec/quant_pipeline.h"
@@ -31,9 +32,11 @@ void QuantPipeline::build(const Model& model, const RuntimeConfig& rcfg, VRAMAll
                           const VRAMBudget& budget, cudaStream_t stream, WeightCaches& wcache,
                           QuantScratch& qscratch, WeightRegistry& registry, PlanHints& hints,
                           MoEWorkspace& moe, int max_tokens) {
-    model_ = &model; runtime_config_ = &rcfg; vram_alloc_ = &alloc; budget_ = &budget;
-    stream_ = stream; wcache_ = &wcache; qscratch_ = &qscratch; registry_ = &registry;
+    model_ = &model; runtime_config_ = &rcfg; vram_alloc_ = &alloc;
+    wcache_ = &wcache; qscratch_ = &qscratch; registry_ = &registry;
     hints_ = &hints; moe_ = &moe; max_tokens_ = max_tokens;
+    // `budget` and `stream` are threaded explicitly through every phase call
+    // below (not stored as members).
     // Skip all weight caching for debugging numerical precision issues
 
     const auto& cfg = model_->config();

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -16,6 +16,17 @@
 
 namespace imp {
 
+// Delegate: the init-time quantization pipeline lives in QuantPipeline. The
+// engine call site (engine_kv_cache_init.cpp) is unchanged. The four long-lived
+// caches + moe_ stay owned by GraphExecutor and are filled by reference; the
+// forward hot path reads them exactly as before (byte-identical).
+void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& budget) {
+    if (!initialized_ || !model_)
+        return;
+    quant_pipeline_.build(*model_, runtime_config(), *vram_alloc_, budget, stream,
+                          wcache_, qscratch_, registry_, hints_, moe_, max_tokens_);
+}
+
 void QuantPipeline::build(const Model& model, const RuntimeConfig& rcfg, VRAMAllocator& alloc,
                           const VRAMBudget& budget, cudaStream_t stream, WeightCaches& wcache,
                           QuantScratch& qscratch, WeightRegistry& registry, PlanHints& hints,

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -7,6 +7,7 @@
 // GraphExecutor in executor.h, and call it from pre_dequant_weights() below.
 
 #include "exec/executor.h"
+#include "exec/quant_pipeline.h"
 #include "core/logging.h"
 #include "runtime/storage_planner.h"
 
@@ -15,9 +16,13 @@
 
 namespace imp {
 
-void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& budget) {
-    if (!initialized_ || !model_)
-        return;
+void QuantPipeline::build(const Model& model, const RuntimeConfig& rcfg, VRAMAllocator& alloc,
+                          const VRAMBudget& budget, cudaStream_t stream, WeightCaches& wcache,
+                          QuantScratch& qscratch, WeightRegistry& registry, PlanHints& hints,
+                          MoEWorkspace& moe, int max_tokens) {
+    model_ = &model; runtime_config_ = &rcfg; vram_alloc_ = &alloc; budget_ = &budget;
+    stream_ = stream; wcache_ = &wcache; qscratch_ = &qscratch; registry_ = &registry;
+    hints_ = &hints; moe_ = &moe; max_tokens_ = max_tokens;
     // Skip all weight caching for debugging numerical precision issues
 
     const auto& cfg = model_->config();
@@ -53,8 +58,8 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
     // building earlier mis-tiered native-NVFP4 weights as FP16/FP8. A plan-vs-
     // actual parity diagnostic runs in Phase 4 to surface any mismatch before a
     // builder is switched. The plan does not drive allocation yet.
-    hints_.vram_budget_bytes = remaining_budget;
-    storage_plan_ = plan_storage(*model_, cfg, hints_);
+    hints_->vram_budget_bytes = remaining_budget;
+    storage_plan_ = plan_storage(*model_, cfg, *hints_);
     apply_arch_rules_(storage_plan_, cfg);
     if (storage_plan_.failed) {
         IMP_LOG_WARN("StoragePlanner: plan failed — %s", storage_plan_.failure_reason.c_str());
@@ -89,11 +94,11 @@ void GraphExecutor::pre_dequant_weights(cudaStream_t stream, const VRAMBudget& b
 // builders plan-driven without changing behaviour). Driven by the Phase-4
 // plan/actual parity diagnostic: a rule is added here only where parity shows
 // the plan and the legacy path disagree for a real (non-budget) reason.
-void GraphExecutor::apply_arch_rules_(StoragePlan& plan, const ModelConfig& cfg) const {
+void QuantPipeline::apply_arch_rules_(StoragePlan& plan, const ModelConfig& cfg) const {
     // FP8 prefill unavailable (sm_120 cuBLAS, and disabled for gemma/GDN): the
     // FP8-floor kinds (WK/WV/QKV_FUSED) the plan picked from the kind table fall
     // back to FP16 at build time. Encode that so the plan matches.
-    if (!wcache_.use_fp8) {
+    if (!wcache_->use_fp8) {
         for (auto& e : plan.entries)
             if (e.tier == StorageTier::FP8)
                 e.tier = StorageTier::FP16;

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -10,6 +10,7 @@
 // refactor roadmap. See pre_dequant_internal.h for shared helpers.
 
 #include "exec/executor.h"
+#include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "compute/gemm_cutlass_sm120.h"
 #include "core/logging.h"
@@ -24,7 +25,7 @@
 
 namespace imp {
 
-void GraphExecutor::pre_dequant_phase0_promote_nvfp4_sidecars_(
+void QuantPipeline::pre_dequant_phase0_promote_nvfp4_sidecars_(
     const ModelConfig& cfg, cudaStream_t stream) {
     if (!cfg.is_nvfp4_prequant)
         return;
@@ -311,7 +312,7 @@ void GraphExecutor::pre_dequant_phase0_promote_nvfp4_sidecars_(
     }
 }
 
-void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
+void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
     const ModelConfig& cfg, cudaStream_t stream) {
     if (!cfg.is_nvfp4_prequant)
         return;
@@ -320,7 +321,7 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
     // --- Phase 0b: register prequant-promoted NVFP4 weights in CUTLASS cache ---
     //
     // Phase 0 set qtype=NVFP4 directly on the main weight Tensor sidecars
-    // but did NOT populate wcache_.nvfp4 (the legacy decode-cache map that
+    // but did NOT populate wcache_->nvfp4 (the legacy decode-cache map that
     // Phase 3b iterates to build the CUTLASS cache). Without this loop,
     // prefill (M>1) for prequant SafeTensors models falls through to
     // gemm_nvfp4 dequant→cuBLAS in executor_kernels.cu — slower AND
@@ -367,7 +368,7 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
         auto register_prequant = [&](const Tensor& w) {
             if (w.qtype != QType::NVFP4 || !w.data || !w.scales)
                 return;
-            if (wcache_.cutlass_nvfp4.count(w.data))
+            if (wcache_->cutlass_nvfp4.count(w.data))
                 return;
             NvFP4QuantResult tmp;
             tmp.packed_data = w.data;
@@ -380,12 +381,12 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
             // per-16 FP8 micro_scales, not SfAtom). Without this, decode falls
             // through to the CUTLASS_NVFP4 case which uses source_scales —
             // but that path produced zero output on some models.
-            wcache_.nvfp4[w.data] = tmp;
+            wcache_->nvfp4[w.data] = tmp;
 
             CutlassNvFP4Weight cw;
             convert_nvfp4_to_cutlass(tmp, cw, stream);
             if (cw.data) {
-                wcache_.cutlass_nvfp4[w.data] = cw;
+                wcache_->cutlass_nvfp4[w.data] = cw;
                 ct_total += cw.sf_bytes;
                 ct_count++;
             }
@@ -412,7 +413,7 @@ void GraphExecutor::pre_dequant_phase0b_register_cutlass_nvfp4_(
 
         if (ct_count > 0) {
             IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-            wcache_.cutlass_nvfp4_bytes += ct_total;
+            wcache_->cutlass_nvfp4_bytes += ct_total;
             IMP_LOG_INFO("CUTLASS sm_120 NVFP4 cache (prequant): %d tensors, %.2f MiB", ct_count,
                          ct_total / (1024.0 * 1024.0));
         }

--- a/src/exec/pre_dequant_phase1_fp16_cache.cu
+++ b/src/exec/pre_dequant_phase1_fp16_cache.cu
@@ -12,6 +12,7 @@
 // refactor roadmap. See pre_dequant_internal.h for shared helpers.
 
 #include "exec/executor.h"
+#include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "model/tensor_kind_table.h"
 #include "quant/dequant_gpu.h"
@@ -25,7 +26,7 @@ using imp::pre_dequant_internal::deduct_budget;
 
 namespace imp {
 
-void GraphExecutor::pre_dequant_phase1_fp16_cache_(
+void QuantPipeline::pre_dequant_phase1_fp16_cache_(
     const ModelConfig& cfg, const VRAMBudget& budget,
     size_t& remaining_budget, cudaStream_t stream) {
     (void)budget;  // strategy gate retired — plan-driven now
@@ -33,7 +34,7 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
     int cached_count = 0;
     bool budget_exhausted = false;
 
-    if (wcache_.use_fp8) {
+    if (wcache_->use_fp8) {
         IMP_LOG_INFO(
             "FP8 prefill: skipping FP16 cache (Phase 1), "
             "all dense weights → FP8 cache (Phase 2)");
@@ -55,7 +56,7 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
         (void)kind;
         if (!w.data || !dequant_gpu_supported(qtype))
             return;
-        if (wcache_.fp16.count(w.data))
+        if (wcache_->fp16.count(w.data))
             return;  // already cached
         if (budget_exhausted)
             return;
@@ -88,7 +89,7 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
         dequant_gpu(w.data, fp16_buf, qtype, rows, cols, stream);
 
         Tensor fp16_tensor(fp16_buf, QType::F16, w.ndim, w.shape, true);
-        wcache_.fp16[w.data] = fp16_tensor;
+        wcache_->fp16[w.data] = fp16_tensor;
         total_cache_bytes += fp16_bytes;
         cached_count++;
     };
@@ -123,8 +124,8 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
     for (int i = 0; i < cfg.n_layers; i++) {
         const auto& L = model_->layer(i);
         bool stop = false;
-        if (create_fused_weight_pair(L.wk, L.wv, wcache_.fp16, vram_alloc_, total_cache_bytes,
-                                     remaining_budget, stream, wcache_.fused_kv, i, stop))
+        if (create_fused_weight_pair(L.wk, L.wv, wcache_->fp16, vram_alloc_, total_cache_bytes,
+                                     remaining_budget, stream, wcache_->fused_kv, i, stop))
             fused_kv_count++;
         else if (stop)
             break;
@@ -140,8 +141,8 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
             (L.w_gate.shape[0] != L.w_up.shape[0] || L.w_gate.shape[1] != L.w_up.shape[1]))
             continue;
         bool stop = false;
-        if (create_fused_weight_pair(L.w_gate, L.w_up, wcache_.fp16, vram_alloc_, total_cache_bytes,
-                                     remaining_budget, stream, wcache_.fused_gate_up, i, stop))
+        if (create_fused_weight_pair(L.w_gate, L.w_up, wcache_->fp16, vram_alloc_, total_cache_bytes,
+                                     remaining_budget, stream, wcache_->fused_gate_up, i, stop))
             fused_gu_count++;
         else if (stop)
             break;
@@ -149,7 +150,7 @@ void GraphExecutor::pre_dequant_phase1_fp16_cache_(
 
     if (cached_count > 0) {
         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-        wcache_.fp16_bytes = total_cache_bytes;
+        wcache_->fp16_bytes = total_cache_bytes;
         IMP_LOG_INFO("FP16 weight cache: %d tensors, %.2f MiB (incl. %d fused KV, %d fused gate+up)",
                      cached_count, total_cache_bytes / (1024.0 * 1024.0), fused_kv_count, fused_gu_count);
     }

--- a/src/exec/pre_dequant_phase2_fp8_cache.cu
+++ b/src/exec/pre_dequant_phase2_fp8_cache.cu
@@ -11,6 +11,7 @@
 // refactor roadmap. See pre_dequant_internal.h for shared helpers.
 
 #include "exec/executor.h"
+#include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "quant/dequant_gpu.h"
 #include "quant/nvfp4_quant.h"
@@ -29,12 +30,12 @@ using imp::pre_dequant_internal::for_each_dense_weight;
 
 namespace imp {
 
-void GraphExecutor::pre_dequant_phase2_fp8_cache_(
+void QuantPipeline::pre_dequant_phase2_fp8_cache_(
     const ModelConfig& cfg, const VRAMBudget& budget,
     size_t& remaining_budget, cudaStream_t stream) {
     size_t fp8_budget = std::min(remaining_budget, budget.fp8_cache_bytes);
     size_t phase2_fp16_bytes = 0;
-    if (wcache_.use_fp8) {
+    if (wcache_->use_fp8) {
         // --- FP16 weight cache for native NVFP4 ---
         // FP8 quantization error (~0.5%/layer) compounds over 36 layers and
         // shifts argmax in 152K vocab. vLLM avoids this by dequanting NVFP4→FP16
@@ -45,7 +46,7 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
         size_t fp16_all_bytes = 0;
         {
             auto cache_weight_fp16 = [&](const Tensor& w) {
-                if (!w.data || wcache_.fp16.count(w.data))
+                if (!w.data || wcache_->fp16.count(w.data))
                     return;
                 QType qtype = w.qtype;
                 if (qtype != QType::NVFP4)
@@ -77,7 +78,7 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
 
                 int64_t fp16_shape[4] = {static_cast<int64_t>(rows), logical_K, 0, 0};
                 Tensor fp16_tensor(fp16_buf, QType::F16, 2, fp16_shape, true);
-                wcache_.fp16[w.data] = fp16_tensor;
+                wcache_->fp16[w.data] = fp16_tensor;
                 fp16_all_count++;
                 fp16_all_bytes += fp16_bytes;
             };
@@ -114,9 +115,9 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
                 return;
             if (!dequant_gpu_supported(qtype) && qtype != QType::NVFP4)
                 return;
-            if (wcache_.fp16.count(w.data))
+            if (wcache_->fp16.count(w.data))
                 return;
-            if (wcache_.fp8.count(w.data))
+            if (wcache_->fp8.count(w.data))
                 return;
             if (fp8_exhausted)
                 return;
@@ -143,7 +144,7 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
         // Same priority order — attention first, then SSM/FFN
         for_each_dense_weight(*model_, cfg, collect_weight_fp8);
 
-        if (!fp8_entries.empty() && qscratch_.dequant) {
+        if (!fp8_entries.empty() && qscratch_->dequant) {
             // Pre-allocate reusable calibration temp buffers
             int max_grid = 0;
             size_t total_fp8_bytes = 0;
@@ -185,16 +186,16 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
                     nv.tensor_scale = e.weight.tensor_scale;
                     nv.N = rows;
                     nv.K = cols * 2;
-                    dequantize_nvfp4_to_fp16(nv, qscratch_.dequant, stream);
+                    dequantize_nvfp4_to_fp16(nv, qscratch_->dequant, stream);
                 } else {
-                    dequant_gpu(e.weight.data, qscratch_.dequant, e.qtype, rows, cols, stream);
+                    dequant_gpu(e.weight.data, qscratch_->dequant, e.qtype, rows, cols, stream);
                 }
 
                 void* fp8_buf = d_fp8_bulk + fp8_offset;
                 fp8_offset += e.n_elems;
 
                 // Async calibrate + quantize (no host sync)
-                calibrate_and_quantize_fp8_async(qscratch_.dequant, fp8_buf, static_cast<int>(e.n_elems),
+                calibrate_and_quantize_fp8_async(qscratch_->dequant, fp8_buf, static_cast<int>(e.n_elems),
                                                  d_block_maxes, max_grid, d_absmax,
                                                  d_scales_all + static_cast<ptrdiff_t>(i), stream);
 
@@ -202,7 +203,7 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
                     (e.qtype == QType::NVFP4) ? e.weight.shape[1] * 2 : e.weight.shape[1],
                     e.weight.shape[2], e.weight.shape[3]};
                 Tensor fp8_t(fp8_buf, QType::FP8_E4M3, e.weight.ndim, fp8_shape, true);
-                wcache_.fp8[e.orig_ptr] = {fp8_t, 0.0f, d_scales_all + static_cast<ptrdiff_t>(i)};
+                wcache_->fp8[e.orig_ptr] = {fp8_t, 0.0f, d_scales_all + static_cast<ptrdiff_t>(i)};
                 actual_count++;
             }
 
@@ -213,8 +214,8 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
                 IMP_CUDA_CHECK_LOG(cudaMemcpy(h_scales.data(), d_scales_all, actual_count * sizeof(float),
                                               cudaMemcpyDeviceToHost));
                 for (int i = 0; i < actual_count; i++) {
-                    auto it = wcache_.fp8.find(fp8_entries[i].orig_ptr);
-                    if (it != wcache_.fp8.end()) {
+                    auto it = wcache_->fp8.find(fp8_entries[i].orig_ptr);
+                    if (it != wcache_->fp8.end()) {
                         it->second.host_scale = h_scales[i];
                     }
                 }
@@ -223,17 +224,17 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
             IMP_CUDA_CHECK_LOG(cudaFree(d_block_maxes));
             IMP_CUDA_CHECK_LOG(cudaFree(d_absmax));
             // Track bulk buffers for cleanup
-            wcache_.fp8_overflow_scales = d_scales_all;
-            wcache_.fp8_overflow_count = actual_count;
-            wcache_.fp8_overflow_data = d_fp8_bulk;
-            wcache_.fp8_overflow_data_size = total_fp8_bytes;
+            wcache_->fp8_overflow_scales = d_scales_all;
+            wcache_->fp8_overflow_count = actual_count;
+            wcache_->fp8_overflow_data = d_fp8_bulk;
+            wcache_->fp8_overflow_data_size = total_fp8_bytes;
             fp8_count = actual_count;
         }
 
         if (fp8_count > 0) {
-            wcache_.fp8_bytes = fp8_total;
+            wcache_->fp8_bytes = fp8_total;
             size_t fp16_equivalent = 0;
-            for (auto& [ptr, entry] : wcache_.fp8) {
+            for (auto& [ptr, entry] : wcache_->fp8) {
                 fp16_equivalent += entry.weight.numel() * sizeof(half);
             }
             IMP_LOG_INFO("FP8 weight cache: %d tensors, %.2f MiB (%.2f MiB saved vs FP16)", fp8_count,
@@ -243,7 +244,7 @@ void GraphExecutor::pre_dequant_phase2_fp8_cache_(
         }
     }
 
-    deduct_budget(remaining_budget, wcache_.fp8_bytes + phase2_fp16_bytes);
+    deduct_budget(remaining_budget, wcache_->fp8_bytes + phase2_fp16_bytes);
 }
 
 }  // namespace imp

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -11,6 +11,7 @@
 // See pre_dequant_internal.h for shared helpers.
 
 #include "exec/executor.h"
+#include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
@@ -37,10 +38,10 @@ using imp::pre_dequant_internal::deduct_budget;
 using imp::pre_dequant_internal::for_each_dense_weight;
 using imp::pre_dequant_internal::nvfp4_beneficial;
 
-void GraphExecutor::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
+void QuantPipeline::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
                                                      Nvfp4DecodeContext& dctx) {
     // Dual-path mode: attention weights stay at FP8 for quality.
-    if (wcache_.dual_path_quant) {
+    if (wcache_->dual_path_quant) {
         for (int i = 0; i < cfg.n_layers; i++) {
             const auto& L = model_->layer(i);
             if (L.wq.data)
@@ -91,7 +92,7 @@ void GraphExecutor::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
             return;
         if (!force_beneficial && !nvfp4_beneficial(qtype, decode_all))
             return;
-        if (wcache_.nvfp4.count(w.data))
+        if (wcache_->nvfp4.count(w.data))
             return;
         // Skip excluded weights (dual-path attention, GDN/SSM recurrent projections)
         if (dctx.exclude_ptrs.count(w.data))
@@ -101,8 +102,8 @@ void GraphExecutor::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
         if (cols % 16 != 0)
             return;
 
-        bool from_scratch = (wcache_.fp16.find(w.data) == wcache_.fp16.end());
-        if (from_scratch && (!dequant_gpu_supported(qtype) || !qscratch_.dequant))
+        bool from_scratch = (wcache_->fp16.find(w.data) == wcache_->fp16.end());
+        if (from_scratch && (!dequant_gpu_supported(qtype) || !qscratch_->dequant))
             return;
         dctx.entries.push_back({w.data, w, qtype, from_scratch});
     };
@@ -132,7 +133,7 @@ void GraphExecutor::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
     }
 }
 
-void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cudaStream_t stream) {
+void QuantPipeline::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cudaStream_t stream) {
     if (!runtime_config().gemm.nvfp4_lm_head)
         return;
 
@@ -151,7 +152,7 @@ void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cud
     if (cols % 16 != 0)
         return;
     // Already cached (e.g. tied embeddings already promoted, or re-entry).
-    if (wcache_.nvfp4.count(lm.data))
+    if (wcache_->nvfp4.count(lm.data))
         return;
 
     // GDN/SSM-hybrid models: the LM head is quality-load-bearing for the
@@ -183,7 +184,7 @@ void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cud
     result.tensor_scale = h_tscale;
     result.N = rows;
     result.K = cols;
-    wcache_.nvfp4[lm.data] = result;
+    wcache_->nvfp4[lm.data] = result;
 
     IMP_CUDA_CHECK_LOG(cudaFree(d_absmax_buf));
     IMP_CUDA_CHECK_LOG(cudaFree(d_tscale_buf));
@@ -200,7 +201,7 @@ void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cud
 // nvfp4_decode_cache_fp16_lm_head_ exactly (same quantize call, same wcache
 // insertion, same guards: weight on device, qtype F16/BF16, ndim 2, cols%16==0,
 // not already cached) — phase 4 then auto-routes M=1 decode through gemv_nvfp4
-// because the weight lands in wcache_.nvfp4 (decode_tier → NVFP4). Prefill is
+// because the weight lands in wcache_->nvfp4 (decode_tier → NVFP4). Prefill is
 // untouched: the unfused originals stay BF16 and the prefill tier still uses the
 // full-precision GEMM path. Opt-in via gemm.nvfp4_attn_proj → the recipe-excluded
 // BF16 attention q/k/v/o (stateless within a step, low quality risk).
@@ -209,7 +210,7 @@ void GraphExecutor::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cud
 // measured to REGRESS decode (−9% Nemotron, −20% Qwen3.6) — the tuned FP16 GEMV
 // (70-81% HBM) beats the NVFP4 GEMV for the wide GDN-output shapes — so it was
 // removed; keeping those projections FP16 is correct for speed, not just quality.
-void GraphExecutor::nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg,
+void QuantPipeline::nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg,
                                                          cudaStream_t stream) {
     const bool do_attn = runtime_config().gemm.nvfp4_attn_proj;
     if (!do_attn)
@@ -223,7 +224,7 @@ void GraphExecutor::nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg,
     int n_attn = 0;
     size_t bytes_attn = 0;
 
-    // Quantize one native-precision (F16/BF16) device weight into wcache_.nvfp4.
+    // Quantize one native-precision (F16/BF16) device weight into wcache_->nvfp4.
     // Returns the NVFP4 byte cost on success, 0 if skipped. Same guard set as the
     // LM-head path; idempotent (skips weights already cached).
     auto quantize_one = [&](const Tensor& w) -> size_t {
@@ -237,7 +238,7 @@ void GraphExecutor::nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg,
         const int cols = static_cast<int>(w.shape[1]);
         if (cols % 16 != 0)
             return 0;
-        if (wcache_.nvfp4.count(w.data))
+        if (wcache_->nvfp4.count(w.data))
             return 0;  // already cached (e.g. re-entry)
 
         Tensor fp16_view(w.data, QType::F16, 2, w.shape, /*on_device=*/true);
@@ -250,7 +251,7 @@ void GraphExecutor::nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg,
         result.tensor_scale = h_tscale;
         result.N = rows;
         result.K = cols;
-        wcache_.nvfp4[w.data] = result;
+        wcache_->nvfp4[w.data] = result;
         return static_cast<size_t>(rows) * cols / 2 + static_cast<size_t>(rows) * cols / 16;
     };
 
@@ -275,14 +276,14 @@ void GraphExecutor::nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg,
         IMP_LOG_INFO("NVFP4 attn proj: no eligible BF16 q/k/v/o (flag on but model has none)");
 }
 
-void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
+void QuantPipeline::pre_dequant_phase3_nvfp4_decode_(
     const ModelConfig& cfg, const VRAMBudget& budget,
     size_t& remaining_budget, cudaStream_t stream) {
-    if (wcache_.nvfp4_decode_mode <= 0)
+    if (wcache_->nvfp4_decode_mode <= 0)
         return;
 
     Nvfp4DecodeContext dctx;
-    dctx.mode_str = (wcache_.nvfp4_decode_mode == 1) ? "additive" : "only";
+    dctx.mode_str = (wcache_->nvfp4_decode_mode == 1) ? "additive" : "only";
 
     // Compute the shared mode-2 safety reserve once. Mode 1 keeps the upfront
     // 10% headroom (see vram_budget.cpp:50), so its budget arithmetic already
@@ -292,7 +293,7 @@ void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
     // 5090) that starved the dense NVFP4 cache. Replace with the same formula
     // the MoE expert path already uses: a KV-headroom estimate at 16 K tokens
     // plus a 256 MiB workspace cushion, clamped to [256 MiB, 1 GiB].
-    if (wcache_.nvfp4_decode_mode == 2) {
+    if (wcache_->nvfp4_decode_mode == 2) {
         int n_attn_layers = 0;
         for (int i = 0; i < cfg.n_layers; i++) {
             if (model_->layer(i).wq.data != nullptr &&
@@ -320,13 +321,13 @@ void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
     using NvFP4Entry = Nvfp4DecodeContext::Entry;
     std::vector<NvFP4Entry>& nvfp4_entries = dctx.entries;
 
-    if (wcache_.nvfp4_decode_mode == 2 && !nvfp4_entries.empty()) {
+    if (wcache_->nvfp4_decode_mode == 2 && !nvfp4_entries.empty()) {
         nvfp4_decode_quantize_mode2_(stream, dctx);
     } else if (!nvfp4_entries.empty()) {
         nvfp4_decode_quantize_mode1_(remaining_budget, stream, dctx);
     }
 
-    if (wcache_.nvfp4_decode_mode == 2 && !wcache_.fp16.empty()) {
+    if (wcache_->nvfp4_decode_mode == 2 && !wcache_->fp16.empty()) {
         nvfp4_decode_free_fp16_and_migrate_fp8_(remaining_budget, stream, dctx);
     }
 
@@ -346,13 +347,13 @@ void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
     // these entries get the same block-scaled treatment.
     nvfp4_decode_cache_fp16_projections_(cfg, stream);
 
-    if (!wcache_.nvfp4.empty() && cutlass_sm120_nvfp4_available()) {
+    if (!wcache_->nvfp4.empty() && cutlass_sm120_nvfp4_available()) {
         nvfp4_decode_convert_cutlass_(remaining_budget, stream);
     }
 
     nvfp4_decode_convert_mxfp4_and_native_(cfg, stream);
 
-    if (qscratch_.mxfp4_act_sf != nullptr && cutlass_sm120_mxfp4_available()) {
+    if (qscratch_->mxfp4_act_sf != nullptr && cutlass_sm120_mxfp4_available()) {
         nvfp4_decode_mxfp4_fp16_fallback_(cfg, stream);
     }
 
@@ -365,7 +366,7 @@ void GraphExecutor::pre_dequant_phase3_nvfp4_decode_(
 // first (each conversion nets VRAM since NVFP4 ≈ 28% of FP16), then the
 // from-scratch entries until VRAM is exhausted. Frees each source FP16
 // entry immediately after the corresponding NVFP4 result is committed.
-void GraphExecutor::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4DecodeContext& dctx) {
+void QuantPipeline::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4DecodeContext& dctx) {
     using NvFP4Entry = Nvfp4DecodeContext::Entry;
     auto& nvfp4_entries = dctx.entries;
 
@@ -413,8 +414,8 @@ void GraphExecutor::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4Decod
 
         if (e.from_scratch) {
             size_t need = static_cast<size_t>(rows) * cols * sizeof(half);
-            void* dq_buf = qscratch_.dequant;
-            if (need > qscratch_.dequant_size) {
+            void* dq_buf = qscratch_->dequant;
+            if (need > qscratch_->dequant_size) {
                 if (cudaMalloc(&tmp_buf, need) != cudaSuccess || !tmp_buf)
                     continue;
                 dq_buf = tmp_buf;
@@ -422,7 +423,7 @@ void GraphExecutor::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4Decod
             dequant_gpu(e.weight.data, dq_buf, e.qtype, rows, cols, stream);
             fp16_ptr = reinterpret_cast<const half*>(dq_buf);
         } else {
-            auto it = wcache_.fp16.find(e.orig_ptr);
+            auto it = wcache_->fp16.find(e.orig_ptr);
             fp16_ptr = reinterpret_cast<const half*>(it->second.data);
         }
 
@@ -438,7 +439,7 @@ void GraphExecutor::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4Decod
         IMP_CUDA_CHECK_LOG(
             cudaMemcpy(&h_tscale, d_tscale_buf, sizeof(float), cudaMemcpyDeviceToHost));
         result.tensor_scale = h_tscale;
-        wcache_.nvfp4[e.orig_ptr] = result;
+        wcache_->nvfp4[e.orig_ptr] = result;
         actual_bytes += nvfp4_bytes;
         actual_count++;
 
@@ -447,12 +448,12 @@ void GraphExecutor::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4Decod
 
         // Free FP16 cache entry to reclaim VRAM for next weight
         if (!e.from_scratch) {
-            auto it = wcache_.fp16.find(e.orig_ptr);
-            if (it != wcache_.fp16.end()) {
+            auto it = wcache_->fp16.find(e.orig_ptr);
+            if (it != wcache_->fp16.end()) {
                 size_t freed = it->second.nbytes();
                 vram_free(vram_alloc_, it->second.data);
-                wcache_.fp16.erase(it);
-                wcache_.fp16_bytes -= freed;
+                wcache_->fp16.erase(it);
+                wcache_->fp16_bytes -= freed;
                 actual_from_fp16++;
             }
         } else {
@@ -463,7 +464,7 @@ void GraphExecutor::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4Decod
     IMP_CUDA_CHECK_LOG(cudaFree(d_absmax_buf));
     IMP_CUDA_CHECK_LOG(cudaFree(d_tscale_buf));
 
-    wcache_.nvfp4_bytes = actual_bytes;
+    wcache_->nvfp4_bytes = actual_bytes;
     IMP_LOG_INFO(
         "NVFP4 decode cache: %d tensors, %.2f MiB "
         "(%d from FP16, %d from scratch, mode: %s)",
@@ -475,7 +476,7 @@ void GraphExecutor::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4Decod
 // remaining VRAM budget, quantize them via a single batched
 // quantize_fp16_to_nvfp4_async pass, then commit tensor_scales after one
 // stream sync.
-void GraphExecutor::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaStream_t stream,
+void QuantPipeline::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaStream_t stream,
                                                  Nvfp4DecodeContext& dctx) {
     using NvFP4Entry = Nvfp4DecodeContext::Entry;
     auto& nvfp4_entries = dctx.entries;
@@ -523,8 +524,8 @@ void GraphExecutor::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaS
 
         if (e.from_scratch) {
             size_t need = static_cast<size_t>(rows) * cols * sizeof(half);
-            void* dq_buf = qscratch_.dequant;
-            if (need > qscratch_.dequant_size) {
+            void* dq_buf = qscratch_->dequant;
+            if (need > qscratch_->dequant_size) {
                 void* tmp = nullptr;
                 if (cudaMalloc(&tmp, need) != cudaSuccess || !tmp)
                     continue;
@@ -534,7 +535,7 @@ void GraphExecutor::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaS
             dequant_gpu(e.weight.data, dq_buf, e.qtype, rows, cols, stream);
             fp16_ptr = reinterpret_cast<const half*>(dq_buf);
         } else {
-            auto it = wcache_.fp16.find(e.orig_ptr);
+            auto it = wcache_->fp16.find(e.orig_ptr);
             fp16_ptr = reinterpret_cast<const half*>(it->second.data);
         }
 
@@ -542,7 +543,7 @@ void GraphExecutor::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaS
 
         NvFP4QuantResult result;
         quantize_fp16_to_nvfp4_async(fp16_view, result, d_absmax_buf, d_tscales_all + i, stream);
-        wcache_.nvfp4[e.orig_ptr] = result;
+        wcache_->nvfp4[e.orig_ptr] = result;
     }
 
     IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
@@ -553,8 +554,8 @@ void GraphExecutor::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaS
     IMP_CUDA_CHECK_LOG(cudaMemcpy(h_tscales.data(), d_tscales_all, budgeted.size() * sizeof(float),
                                   cudaMemcpyDeviceToHost));
     for (size_t i = 0; i < budgeted.size(); i++) {
-        auto it = wcache_.nvfp4.find(budgeted[i].orig_ptr);
-        if (it != wcache_.nvfp4.end()) {
+        auto it = wcache_->nvfp4.find(budgeted[i].orig_ptr);
+        if (it != wcache_->nvfp4.end()) {
             it->second.tensor_scale = h_tscales[i];
         }
     }
@@ -562,7 +563,7 @@ void GraphExecutor::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaS
     IMP_CUDA_CHECK_LOG(cudaFree(d_absmax_buf));
     IMP_CUDA_CHECK_LOG(cudaFree(d_tscales_all));
 
-    wcache_.nvfp4_bytes = budget_used;
+    wcache_->nvfp4_bytes = budget_used;
     if (nvfp4_from_scratch > 0) {
         IMP_LOG_INFO(
             "NVFP4 decode cache: %d tensors, %.2f MiB (%d from FP16 cache, %d via dequant scratch, "
@@ -580,21 +581,21 @@ void GraphExecutor::nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaS
 // (calibrate + per-tensor scale), then free the FP16 cache except entries
 // that have no NVFP4/FP8 alternative (GDN ssm_in/ssm_out on hybrids).
 // Also frees the fused KV / gate-up prefill caches.
-void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_budget,
+void QuantPipeline::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_budget,
                                                             cudaStream_t stream,
                                                             Nvfp4DecodeContext& dctx) {
     (void)dctx;
     int migrated = 0;
     size_t migrated_bytes = 0;
-    if (wcache_.use_fp8) {
+    if (wcache_->use_fp8) {
         struct MigrateEntry {
             const void* orig_ptr;
             Tensor fp16_tensor;
             size_t n_elems;
         };
         std::vector<MigrateEntry> to_migrate;
-        for (auto& [orig_ptr, fp16_tensor] : wcache_.fp16) {
-            if (wcache_.fp8.count(orig_ptr))
+        for (auto& [orig_ptr, fp16_tensor] : wcache_->fp16) {
+            if (wcache_->fp8.count(orig_ptr))
                 continue;
             size_t n = static_cast<size_t>(fp16_tensor.shape[0]) * fp16_tensor.shape[1];
             to_migrate.push_back({orig_ptr, fp16_tensor, n});
@@ -639,13 +640,13 @@ void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
                                                  d_absmax, d_scales_all + i, stream);
 
                 Tensor fp8_t(fp8_buf, QType::FP8_E4M3, e.fp16_tensor.ndim, e.fp16_tensor.shape, true);
-                wcache_.fp8[e.orig_ptr] = {fp8_t, 0.0f, d_scales_all + static_cast<ptrdiff_t>(i)};
+                wcache_->fp8[e.orig_ptr] = {fp8_t, 0.0f, d_scales_all + static_cast<ptrdiff_t>(i)};
                 migrated++;
                 migrated_bytes += e.n_elems + sizeof(float);
             }
 
-            wcache_.fp8_migrated_data = d_fp8_bulk;
-            wcache_.fp8_migrated_data_size = total_fp8_bytes;
+            wcache_->fp8_migrated_data = d_fp8_bulk;
+            wcache_->fp8_migrated_data_size = total_fp8_bytes;
 
             if (migrated > 0) {
                 IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
@@ -654,8 +655,8 @@ void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
                                               cudaMemcpyDeviceToHost));
                 int idx = 0;
                 for (size_t i = 0; i < to_migrate.size() && idx < migrated; i++, idx++) {
-                    auto it = wcache_.fp8.find(to_migrate[i].orig_ptr);
-                    if (it != wcache_.fp8.end()) {
+                    auto it = wcache_->fp8.find(to_migrate[i].orig_ptr);
+                    if (it != wcache_->fp8.end()) {
                         it->second.host_scale = h_scales[idx];
                     }
                 }
@@ -663,8 +664,8 @@ void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
 
             IMP_CUDA_CHECK_LOG(cudaFree(d_block_maxes));
             IMP_CUDA_CHECK_LOG(cudaFree(d_absmax));
-            wcache_.fp8_migrated_scales = d_scales_all;
-            wcache_.fp8_migrated_count = migrated;
+            wcache_->fp8_migrated_scales = d_scales_all;
+            wcache_->fp8_migrated_count = migrated;
         }
     }
 
@@ -681,15 +682,15 @@ void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
     size_t kept_bytes = 0;
     int kept_count = 0;
     std::vector<const void*> to_erase;
-    for (auto& [ptr, tensor] : wcache_.fp16) {
-        const bool has_cutlass_nvfp4 = (wcache_.cutlass_nvfp4.find(ptr) != wcache_.cutlass_nvfp4.end());
+    for (auto& [ptr, tensor] : wcache_->fp16) {
+        const bool has_cutlass_nvfp4 = (wcache_->cutlass_nvfp4.find(ptr) != wcache_->cutlass_nvfp4.end());
         if (has_cutlass_nvfp4) {
             kept_bytes += static_cast<size_t>(tensor.shape[0]) * tensor.shape[1] * sizeof(half);
             kept_count++;
             continue;
         }
-        const bool has_nvfp4 = (wcache_.nvfp4.find(ptr) != wcache_.nvfp4.end());
-        const bool has_fp8 = (wcache_.fp8.find(ptr) != wcache_.fp8.end());
+        const bool has_nvfp4 = (wcache_->nvfp4.find(ptr) != wcache_->nvfp4.end());
+        const bool has_fp8 = (wcache_->fp8.find(ptr) != wcache_->fp8.end());
         if (has_nvfp4 || has_fp8) {
             vram_free(vram_alloc_, tensor.data);
             freed += static_cast<size_t>(tensor.shape[0]) * tensor.shape[1] * sizeof(half);
@@ -700,8 +701,8 @@ void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
         }
     }
     for (auto p : to_erase)
-        wcache_.fp16.erase(p);
-    wcache_.fp16_bytes = kept_bytes;
+        wcache_->fp16.erase(p);
+    wcache_->fp16_bytes = kept_bytes;
     if (kept_count > 0) {
         IMP_LOG_INFO(
             "NVFP4 only mode: preserved %d FP16 entries (%.2f MiB) "
@@ -710,19 +711,19 @@ void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
     }
 
     // Free fused caches (prefill uses individual FP8 weights)
-    for (auto& [idx, tensor] : wcache_.fused_kv) {
+    for (auto& [idx, tensor] : wcache_->fused_kv) {
         if (tensor.data)
             vram_free(vram_alloc_, tensor.data);
     }
-    wcache_.fused_kv.clear();
-    for (auto& [idx, tensor] : wcache_.fused_gate_up) {
+    wcache_->fused_kv.clear();
+    for (auto& [idx, tensor] : wcache_->fused_gate_up) {
         if (tensor.data)
             vram_free(vram_alloc_, tensor.data);
     }
-    wcache_.fused_gate_up.clear();
+    wcache_->fused_gate_up.clear();
 
     remaining_budget += freed;
-    wcache_.fp8_bytes += migrated_bytes;
+    wcache_->fp8_bytes += migrated_bytes;
     IMP_LOG_INFO(
         "NVFP4 only mode: freed FP16 cache (%.2f MiB), migrated %d weights to FP8 (%.2f MiB)",
         freed / (1024.0 * 1024.0), migrated, migrated_bytes / (1024.0 * 1024.0));
@@ -731,7 +732,7 @@ void GraphExecutor::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
 // NVFP4 second pass: after the FP16-free + FP8 migration phase frees VRAM,
 // re-attempt NVFP4 quantization for entries skipped earlier due to budget
 // pressure. Same per-tensor cudaMemGetInfo gate as mode 2.
-void GraphExecutor::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStream_t stream,
+void QuantPipeline::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStream_t stream,
                                               Nvfp4DecodeContext& dctx) {
     (void)budget;
     auto& nvfp4_entries = dctx.entries;
@@ -745,7 +746,7 @@ void GraphExecutor::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStre
     size_t second_bytes = 0;
 
     for (auto& e : nvfp4_entries) {
-        if (wcache_.nvfp4.count(e.orig_ptr))
+        if (wcache_->nvfp4.count(e.orig_ptr))
             continue;  // already cached
         int rows = static_cast<int>(e.weight.shape[0]);
         int cols = static_cast<int>(e.weight.shape[1]);
@@ -760,11 +761,11 @@ void GraphExecutor::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStre
 
         // Dequant from quantized weights via scratch buffer
         size_t need = static_cast<size_t>(rows) * cols * sizeof(half);
-        void* dq_buf = qscratch_.dequant;
+        void* dq_buf = qscratch_->dequant;
         void* tmp_buf = nullptr;
-        if (!dequant_gpu_supported(e.qtype) || !qscratch_.dequant)
+        if (!dequant_gpu_supported(e.qtype) || !qscratch_->dequant)
             continue;
-        if (need > qscratch_.dequant_size) {
+        if (need > qscratch_->dequant_size) {
             if (cudaMalloc(&tmp_buf, need) != cudaSuccess || !tmp_buf)
                 continue;
             dq_buf = tmp_buf;
@@ -780,7 +781,7 @@ void GraphExecutor::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStre
         IMP_CUDA_CHECK_LOG(
             cudaMemcpy(&h_tscale, d_tscale_buf2, sizeof(float), cudaMemcpyDeviceToHost));
         result.tensor_scale = h_tscale;
-        wcache_.nvfp4[e.orig_ptr] = result;
+        wcache_->nvfp4[e.orig_ptr] = result;
         second_bytes += nvfp4_bytes;
         second_count++;
 
@@ -792,7 +793,7 @@ void GraphExecutor::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStre
     IMP_CUDA_CHECK_LOG(cudaFree(d_tscale_buf2));
 
     if (second_count > 0) {
-        wcache_.nvfp4_bytes += second_bytes;
+        wcache_->nvfp4_bytes += second_bytes;
         IMP_LOG_INFO("NVFP4 second pass: %d additional tensors, %.2f MiB", second_count,
                      second_bytes / (1024.0 * 1024.0));
     }
@@ -802,10 +803,10 @@ void GraphExecutor::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStre
 // Must run after FP16-free; the CUTLASS cache approximately doubles NVFP4
 // VRAM (repacked data + SfAtom scales).  Budget-aware: stops if VRAM
 // budget runs out and emits an info line.
-void GraphExecutor::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cudaStream_t stream) {
+void QuantPipeline::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cudaStream_t stream) {
     // After incremental mode, remaining_budget is stale.  Use actual free VRAM.
     size_t ct_budget;
-    if (wcache_.nvfp4_decode_mode == 2) {
+    if (wcache_->nvfp4_decode_mode == 2) {
         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
         size_t free_mem = 0, total_mem = 0;
         IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
@@ -818,15 +819,15 @@ void GraphExecutor::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
         size_t kCtReserve = std::max(total_mem / 10, static_cast<size_t>(256ULL * 1024 * 1024));
         ct_budget = (free_mem > kCtReserve) ? (free_mem - kCtReserve) : 0;
     } else {
-        ct_budget = (remaining_budget > wcache_.nvfp4_bytes)
-                        ? (remaining_budget - wcache_.nvfp4_bytes)
+        ct_budget = (remaining_budget > wcache_->nvfp4_bytes)
+                        ? (remaining_budget - wcache_->nvfp4_bytes)
                         : 0;
     }
     int ct_count = 0;
     size_t ct_total = 0;
     bool ct_exhausted = false;
     int ct_skipped_dead = 0;
-    for (auto& [ptr, nvfp4] : wcache_.nvfp4) {
+    for (auto& [ptr, nvfp4] : wcache_->nvfp4) {
         if (ct_exhausted)
             break;
         // G3 (Stage 1.4): skip the CUTLASS SF buffer for weights whose M>1
@@ -836,7 +837,7 @@ void GraphExecutor::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
         // 8B Q8_0 model). Today that is Q8_0 with q8_imma_enabled. CUTLASS stays
         // for native-NVFP4 (prefill IS CUTLASS) and Q6_K/Q5_K (not IMMA-routed →
         // CUTLASS is their prefill path). Decode is unaffected: decode_tier stays
-        // NVFP4 (the plain wcache_.nvfp4 GEMV), independent of the SF buffer.
+        // NVFP4 (the plain wcache_->nvfp4 GEMV), independent of the SF buffer.
         const auto* pe = storage_plan_.entry_of(ptr);
         if (pe && pe->source_qtype == QType::Q8_0 && runtime_config().gemm.q8_imma_enabled) {
             ++ct_skipped_dead;
@@ -855,15 +856,15 @@ void GraphExecutor::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
         CutlassNvFP4Weight cw;
         convert_nvfp4_to_cutlass(nvfp4, cw, stream);
         if (cw.data) {
-            wcache_.cutlass_nvfp4[ptr] = cw;
+            wcache_->cutlass_nvfp4[ptr] = cw;
             ct_total += cw.sf_bytes;
             ct_count++;
         }
     }
     if (ct_count > 0) {
         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-        wcache_.cutlass_nvfp4_bytes = ct_total;
-        deduct_budget(remaining_budget, ct_total + wcache_.nvfp4_bytes);
+        wcache_->cutlass_nvfp4_bytes = ct_total;
+        deduct_budget(remaining_budget, ct_total + wcache_->nvfp4_bytes);
         IMP_LOG_INFO("CUTLASS sm_120 NVFP4 weight cache: %d tensors, %.2f MiB (skipped %d "
                      "IMMA-prefill weights — dead SF buffer)",
                      ct_count, ct_total / (1024.0 * 1024.0), ct_skipped_dead);
@@ -879,7 +880,7 @@ void GraphExecutor::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
 // GPU. Allocates the MXFP4 activation scratch once if any layer carries
 // MXFP4 weights, then runs an optional NVFP4->MXFP4 conversion pass for
 // models with `use_mxfp4`.
-void GraphExecutor::nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cfg, cudaStream_t stream) {
+void QuantPipeline::nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cfg, cudaStream_t stream) {
     // These bypass NVFP4 entirely — the GGUF data is unpacked into
     // separate E2M1 data + SfAtom UE8M0 scales on GPU.
     // For native MXFP4, allocate activation buffers if not already done.
@@ -900,7 +901,7 @@ void GraphExecutor::nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cf
         }
 
         // Allocate MXFP4 scratch if needed and not already allocated
-        if (has_mxfp4 && !qscratch_.mxfp4_act_sf) {
+        if (has_mxfp4 && !qscratch_->mxfp4_act_sf) {
             int max_k = 0, max_n = 0;
             for (int i = 0; i < cfg.n_layers; i++) {
                 const auto& L = model_->layer(i);
@@ -926,25 +927,25 @@ void GraphExecutor::nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cf
                 }
             }
             if (max_k > 0) {
-                qscratch_.mxfp4_act_sf_size = cutlass_mxfp4_sf_size(max_tokens_, max_k);
-                qscratch_.mxfp4_workspace_size = gemm_mxfp4_cutlass_sm120_workspace(max_tokens_,
+                qscratch_->mxfp4_act_sf_size = cutlass_mxfp4_sf_size(max_tokens_, max_k);
+                qscratch_->mxfp4_workspace_size = gemm_mxfp4_cutlass_sm120_workspace(max_tokens_,
                                                                                     max_n, max_k);
-                qscratch_.mxfp4_act_sf = vram_alloc(vram_alloc_, qscratch_.mxfp4_act_sf_size,
+                qscratch_->mxfp4_act_sf = vram_alloc(vram_alloc_, qscratch_->mxfp4_act_sf_size,
                                                     "mxfp4_act_sf");
-                qscratch_.mxfp4_workspace = (qscratch_.mxfp4_workspace_size > 0)
+                qscratch_->mxfp4_workspace = (qscratch_->mxfp4_workspace_size > 0)
                                                 ? vram_alloc(vram_alloc_,
-                                                             qscratch_.mxfp4_workspace_size,
+                                                             qscratch_->mxfp4_workspace_size,
                                                              "mxfp4_workspace")
                                                 : nullptr;
                 // Also need CUTLASS activation data buffer
-                if (!qscratch_.cutlass_act_data) {
-                    qscratch_.cutlass_act_data_size = static_cast<size_t>(max_tokens_) * (max_k / 2);
-                    qscratch_.cutlass_act_data = vram_alloc(vram_alloc_,
-                                                            qscratch_.cutlass_act_data_size,
+                if (!qscratch_->cutlass_act_data) {
+                    qscratch_->cutlass_act_data_size = static_cast<size_t>(max_tokens_) * (max_k / 2);
+                    qscratch_->cutlass_act_data = vram_alloc(vram_alloc_,
+                                                            qscratch_->cutlass_act_data_size,
                                                             "cutlass_act_data");
                 }
                 IMP_LOG_INFO("Native MXFP4: allocated activation scratch (sf=%.2f MiB)",
-                             qscratch_.mxfp4_act_sf_size / (1024.0 * 1024.0));
+                             qscratch_->mxfp4_act_sf_size / (1024.0 * 1024.0));
             }
         }
     }
@@ -953,24 +954,24 @@ void GraphExecutor::nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cf
     // Same packed FP4 data (borrowed), only allocates new scale factor buffers.
     // Note: Hadamard rotation requires MR-GPTQ pre-rotated weights (SafeTensors).
     // For GGUF models, we use direct scale conversion (no rotation).
-    if (wcache_.use_mxfp4 && qscratch_.mxfp4_act_sf != nullptr && cutlass_sm120_mxfp4_available()) {
+    if (wcache_->use_mxfp4 && qscratch_->mxfp4_act_sf != nullptr && cutlass_sm120_mxfp4_available()) {
         int mx_count = 0;
         size_t mx_total = 0;
-        for (auto& [ptr, nvfp4] : wcache_.nvfp4) {
+        for (auto& [ptr, nvfp4] : wcache_->nvfp4) {
             // Only convert weights where K is multiple of 32 (MXFP4 requirement)
             if (nvfp4.K % 32 != 0)
                 continue;
             CutlassMxFP4Weight mw;
             convert_nvfp4_to_mxfp4_cutlass(nvfp4, mw, stream);
             if (mw.data) {
-                wcache_.cutlass_mxfp4[ptr] = mw;
+                wcache_->cutlass_mxfp4[ptr] = mw;
                 mx_total += mw.sf_bytes;
                 mx_count++;
             }
         }
         if (mx_count > 0) {
             IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-            wcache_.cutlass_mxfp4_bytes = mx_total;
+            wcache_->cutlass_mxfp4_bytes = mx_total;
             IMP_LOG_INFO("CUTLASS sm_120 MXFP4 weight cache: %d tensors, %.2f MiB", mx_count,
                          mx_total / (1024.0 * 1024.0));
         }
@@ -981,7 +982,7 @@ void GraphExecutor::nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cf
 // directly in the CUTLASS cache, then for GDN / forced-fallback models
 // dequants them into a bulk FP16 buffer and rewrites model weight pointers
 // so the dispatch path sees FP16 instead of raw MXFP4 blocks.
-void GraphExecutor::nvfp4_decode_mxfp4_fp16_fallback_(const ModelConfig& cfg, cudaStream_t stream) {
+void QuantPipeline::nvfp4_decode_mxfp4_fp16_fallback_(const ModelConfig& cfg, cudaStream_t stream) {
 int mx_native = 0;
 size_t mx_native_bytes = 0;
 auto register_if_mxfp4 = [&](const Tensor& w, QType qt, bool is_attn = true) {
@@ -989,12 +990,12 @@ auto register_if_mxfp4 = [&](const Tensor& w, QType qt, bool is_attn = true) {
         return;
     if (w.ndim < 2 || w.shape[1] % 32 != 0)
         return;
-    if (wcache_.cutlass_mxfp4.count(w.data))
+    if (wcache_->cutlass_mxfp4.count(w.data))
         return;  // already registered
     CutlassMxFP4Weight mw;
     if (unpack_mxfp4_gguf(w.data, w.shape[0], w.shape[1], mw, stream)) {
         mw.hadamard_bs = is_attn ? cfg.mxfp4_hadamard_attn : cfg.mxfp4_hadamard_ffn;
-        wcache_.cutlass_mxfp4[w.data] = mw;
+        wcache_->cutlass_mxfp4[w.data] = mw;
         mx_native_bytes += mw.sf_bytes + static_cast<size_t>(w.shape[0]) * (w.shape[1] / 2);
         mx_native++;
     }
@@ -1018,8 +1019,8 @@ for (int i = 0; i < cfg.n_layers; i++) {
 register_if_mxfp4(model_->output_proj(), model_->out_proj_.qtype);
 if (mx_native > 0) {
     IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-    wcache_.cutlass_mxfp4_bytes += mx_native_bytes;
-    wcache_.use_mxfp4 = true;
+    wcache_->cutlass_mxfp4_bytes += mx_native_bytes;
+    wcache_->use_mxfp4 = true;
     IMP_LOG_INFO("Native MXFP4 GGUF: %d tensors, %.2f MiB (direct → CUTLASS)", mx_native,
                  mx_native_bytes / (1024.0 * 1024.0));
 
@@ -1043,7 +1044,7 @@ if (mx_native > 0) {
     bool force_fallback = runtime_config().attention.mxfp4_fp16_fallback;
     bool has_gdn = (cfg.ssm_inner_size > 0);
     bool mxfp4_gemv_available = !force_fallback && !has_gdn;
-    for (auto& [p, m] : wcache_.cutlass_mxfp4)
+    for (auto& [p, m] : wcache_->cutlass_mxfp4)
         if (!m.linear_scales) {
             mxfp4_gemv_available = false;
             break;
@@ -1087,8 +1088,8 @@ if (mx_native > 0) {
 
     size_t fp16_total = 0;
     if (!mxfp4_gemv_available) {
-        for (auto& [p, m] : wcache_.cutlass_mxfp4) {
-            if (wcache_.fp16.count(p))
+        for (auto& [p, m] : wcache_->cutlass_mxfp4) {
+            if (wcache_->fp16.count(p))
                 continue;
             size_t b = static_cast<size_t>(m.N) * m.K * sizeof(half);
             if (pruned_policy && pruned_skip_ptrs.count(p)) {
@@ -1140,7 +1141,7 @@ if (mx_native > 0) {
                 fp16_total / (1024.0 * 1024.0 * 1024.0),
                 kRuntimeHeadroom / (1024.0 * 1024.0 * 1024.0),
                 free_mem / (1024.0 * 1024.0 * 1024.0));
-            // Skip the alloc — wcache_.fp16 stays empty for these weights.
+            // Skip the alloc — wcache_->fp16 stays empty for these weights.
             // Downstream code will detect the missing entries and bail
             // with its own diagnostic instead of silently corrupting state.
             fp16_total = 0;
@@ -1161,15 +1162,15 @@ if (mx_native > 0) {
             // Track the bulk for shutdown cleanup. Each fp16 Tensor written
             // below points to a sub-range of this allocation, so we cannot
             // cudaFree the sub-pointers — only the bulk base.
-            wcache_.fp16_bulk_data = d_fp16_bulk;
-            wcache_.fp16_bulk_data_size = fp16_total;
+            wcache_->fp16_bulk_data = d_fp16_bulk;
+            wcache_->fp16_bulk_data_size = fp16_total;
         }
     }
 
     if (d_fp16_bulk) {
         size_t offset = 0;
-        for (auto& [ptr, mw] : wcache_.cutlass_mxfp4) {
-            if (wcache_.fp16.count(ptr))
+        for (auto& [ptr, mw] : wcache_->cutlass_mxfp4) {
+            if (wcache_->fp16.count(ptr))
                 continue;
             // Honor the same pruning filter the fp16_total compute
             // pass used; otherwise the offset accounting drifts.
@@ -1188,7 +1189,7 @@ if (mx_native > 0) {
             // correctly (data first, scales at offset N*K/2).
             dequant_mxfp4_to_fp16(ptr, mw.N, mw.K, d_fp16, stream);
             int64_t shape[2] = {mw.N, mw.K};
-            wcache_.fp16[ptr] = Tensor(d_fp16, QType::F16, 2, shape, true);
+            wcache_->fp16[ptr] = Tensor(d_fp16, QType::F16, 2, shape, true);
         }
     }  // end if (d_fp16_bulk)
 
@@ -1206,8 +1207,8 @@ if (mx_native > 0) {
         // This ensures ALL code paths (GEMV, direct gemm, etc.) see
         // valid FP16 data instead of raw MXFP4 blocks.
         auto replace_weight = [&](Tensor& w, QType& qt) {
-            auto it = wcache_.fp16.find(w.data);
-            if (it != wcache_.fp16.end() && qt == QType::MXFP4) {
+            auto it = wcache_->fp16.find(w.data);
+            if (it != wcache_->fp16.end() && qt == QType::MXFP4) {
                 w = it->second;
                 qt = QType::F16;
             }
@@ -1232,7 +1233,7 @@ if (mx_native > 0) {
                        const_cast<Model*>(model_)->out_proj_.qtype);
         // Tok-embed table — when weight tying is on (Qwen3.5-4B / others), it
         // shares the same GPU storage as out_proj_, so its data pointer is
-        // already a key in wcache_.fp16. Without this replace, the embedding
+        // already a key in wcache_->fp16. Without this replace, the embedding
         // lookup reads the raw MXFP4 bytes as FP16 → garbage hidden state from
         // token 0 → garbage logits → token-0 spam output. Also harmless when
         // the embedding is FP16 (the lookup misses, qtype guard is satisfied
@@ -1240,7 +1241,7 @@ if (mx_native > 0) {
         replace_weight(const_cast<Model*>(model_)->tok_emb_,
                        const_cast<Model*>(model_)->tok_emb_.qtype);
         IMP_LOG_INFO("MXFP4 → FP16: replaced %d weight tensor pointers",
-                     (int)wcache_.fp16.size());
+                     (int)wcache_->fp16.size());
     }
 }
 }
@@ -1263,7 +1264,7 @@ if (mx_native > 0) {
 // tensors keyed on the converted device pointers let Phase 4 wire
 // nvfp4_moe_{gate,up,down}_ptr exactly like the Modelopt path.
 // ---------------------------------------------------------------------------
-void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx) {
+void QuantPipeline::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx) {
     int converted = 0;
     for (int i = 0; i < cfg.n_layers; ++i) {
         TransformerLayer& L = const_cast<Model*>(model_)->layer(i);
@@ -1305,7 +1306,7 @@ void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
         auto install = [&](NvFP4MoEQuantResult& r, Tensor& packed_slot) {
             int64_t shp[3] = {r.n_experts, r.N, r.K};
             packed_slot = Tensor(r.packed_data, QType::NVFP4, 3, shp, /*on_device=*/true);
-            wcache_.nvfp4_moe[r.packed_data] = r;
+            wcache_->nvfp4_moe[r.packed_data] = r;
             auto* m = const_cast<Model*>(model_);
             m->gpu_allocations_.push_back(r.packed_data);
             m->gpu_allocations_.push_back(r.micro_scales);
@@ -1359,7 +1360,7 @@ void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
                 nv.tensor_scale = h_ts[e];
                 nv.N = r.N;
                 nv.K = r.K;
-                wcache_.nvfp4[data_slice] = nv;
+                wcache_->nvfp4[data_slice] = nv;
 
                 CutlassNvFP4Weight cw;
                 cw.data = data_slice;
@@ -1369,9 +1370,9 @@ void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
                 cw.K = r.K;
                 cw.sf_bytes = sf_per_expert;
                 cw.sf_borrowed = true;
-                wcache_.cutlass_nvfp4[data_slice] = cw;
+                wcache_->cutlass_nvfp4[data_slice] = cw;
             }
-            wcache_.cutlass_nvfp4_bytes += sfatom_total;
+            wcache_->cutlass_nvfp4_bytes += sfatom_total;
             return true;
         };
         bool ct_ok = register_cutlass(g, L.expert_w_gate, g_ts) &&
@@ -1389,14 +1390,14 @@ void GraphExecutor::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
                      converted, cfg.n_experts);
 }
 
-void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
+void QuantPipeline::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
                                                     size_t& remaining_budget,
                                                     cudaStream_t stream,
                                                     Nvfp4DecodeContext& dctx) {
     (void)remaining_budget;
     size_t moe_budget;
     // Cache MoE expert weights — done after FP16 free so mode 2 has full budget
-    if (wcache_.nvfp4_decode_mode == 2) {
+    if (wcache_->nvfp4_decode_mode == 2) {
         size_t free_mem = 0, total_mem = 0;
         IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
         // Reserve VRAM so the KV cache (sized after this in init_kv_cache)
@@ -1443,7 +1444,7 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         size_t total_reserve = kMoeReserve + kRuntimeHeadroom;
         moe_budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
     } else {
-        moe_budget = (remaining_budget > wcache_.nvfp4_bytes) ? (remaining_budget - wcache_.nvfp4_bytes)
+        moe_budget = (remaining_budget > wcache_->nvfp4_bytes) ? (remaining_budget - wcache_->nvfp4_bytes)
                                                               : 0;
     }
     bool moe_budget_exhausted = false;
@@ -1462,7 +1463,7 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
             return;
         if (!nvfp4_beneficial(qtype, decode_all_moe))
             return;
-        if (wcache_.nvfp4_moe.count(packed.data))
+        if (wcache_->nvfp4_moe.count(packed.data))
             return;
         if (moe_budget_exhausted)
             return;
@@ -1476,7 +1477,7 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         int cols = static_cast<int>(packed.shape[2]);
         if (cols % 16 != 0)
             return;
-        if (!dequant_gpu_supported(qtype) || !qscratch_.dequant)
+        if (!dequant_gpu_supported(qtype) || !qscratch_->dequant)
             return;
 
         size_t nvfp4_bytes = static_cast<size_t>(ne) * rows * cols / 2 +
@@ -1493,10 +1494,10 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         }
 
         NvFP4MoEQuantResult result;
-        quantize_packed_experts_to_nvfp4(packed.data, qtype, ne, rows, cols, qscratch_.dequant, result,
+        quantize_packed_experts_to_nvfp4(packed.data, qtype, ne, rows, cols, qscratch_->dequant, result,
                                          stream);
 
-        wcache_.nvfp4_moe[packed.data] = result;
+        wcache_->nvfp4_moe[packed.data] = result;
         dctx.nvfp4_moe_total += nvfp4_bytes;
         dctx.nvfp4_moe_count++;
     };
@@ -1533,7 +1534,7 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
             // Non-gated MoE (e.g. Nemotron-H NemotronHForCausalLM): no gate
             // projection exists, so g=0 is expected when up and down cached.
             // Suppress the misleading warning in that case; expert_gemm's
-            // wcache_.nvfp4_moe lookup handles the missing-gate path.
+            // wcache_->nvfp4_moe lookup handles the missing-gate path.
             bool non_gated = (L.expert_gate_packed.data == nullptr &&
                               (L.expert_w_gate.empty() ||
                                L.expert_w_gate[0].data == nullptr));
@@ -1549,7 +1550,7 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         // For GGUF NVFP4-target models the source qtype is Q*_K/Q8_0 and
         // packed.data is non-null; for prequant SafeTensors all three
         // native calls succeeded above and these are no-ops because
-        // packed.data now points into wcache_.nvfp4_moe.
+        // packed.data now points into wcache_->nvfp4_moe.
         if (!g)
             cache_moe_expert_nvfp4(L.expert_gate_packed, L.expert_gate_packed.qtype);
         if (!u)
@@ -1559,10 +1560,10 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
     }
 
     if (dctx.nvfp4_moe_count > 0) {
-        wcache_.nvfp4_moe_bytes = dctx.nvfp4_moe_total;
+        wcache_->nvfp4_moe_bytes = dctx.nvfp4_moe_total;
         IMP_LOG_INFO("NVFP4 MoE cache: %d tensors, %.2f MiB", dctx.nvfp4_moe_count,
                      dctx.nvfp4_moe_total / (1024.0 * 1024.0));
-    } else if (wcache_.nvfp4.empty()) {
+    } else if (wcache_->nvfp4.empty()) {
         IMP_LOG_INFO("NVFP4 decode: no eligible weights found (all ≤ 4.5 bits/elem)");
     }
 }
@@ -1573,14 +1574,14 @@ void GraphExecutor::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
 // see the declaration in executor.h for the full contract. The budget flags
 // (moe_budget_exhausted / moe_logical_avail) are threaded in so the per-layer
 // accounting is shared across the gate/up/down calls.
-bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>& experts,
+bool QuantPipeline::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>& experts,
                                             cudaStream_t stream, Nvfp4DecodeContext& dctx,
                                             bool& moe_budget_exhausted, size_t& moe_logical_avail) {
         if (experts.empty() || !experts[0].data)
             return false;
         if (experts[0].qtype != QType::NVFP4 || experts[0].scales == nullptr)
             return false;
-        if (packed.data && wcache_.nvfp4_moe.count(packed.data))
+        if (packed.data && wcache_->nvfp4_moe.count(packed.data))
             return false;
         // ZERO-COPY decode cache (LEAD-2): NVFP4-prequant SafeTensors upload the
         // per-expert weights AND scales into contiguous VRAM (one buffer per
@@ -1592,7 +1593,7 @@ bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
         // CUTLASS grouped GEMM, which under-utilizes the GPU at M=1 decode.
         // Guarded by a strict contiguity + shape check; on any mismatch we fall
         // through to leaving the experts on the CUTLASS path (prior behavior).
-        if (wcache_.cutlass_nvfp4.count(experts[0].data)) {
+        if (wcache_->cutlass_nvfp4.count(experts[0].data)) {
           if (runtime_config().gemm.nvfp4_moe_decode) {
             const int ne_z = static_cast<int>(experts.size());
             const int64_t N_z = experts[0].shape[0];
@@ -1654,7 +1655,7 @@ bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
                         r.borrowed = true;  // data borrowed from model; scales/ts via VRAMAllocator
                         int64_t shp[3] = {static_cast<int64_t>(ne_z), N_z, K_z};
                         packed = Tensor(experts[0].data, QType::NVFP4, 3, shp, /*on_device=*/true);
-                        wcache_.nvfp4_moe[experts[0].data] = r;
+                        wcache_->nvfp4_moe[experts[0].data] = r;
                         dctx.nvfp4_moe_count++;
                         IMP_LOG_INFO("NVFP4 MoE native: data-borrow decode cache (ne=%d N=%lld K=%lld, "
                                      "scales_contig=%d; gemv_nvfp4_moe fast decode)",
@@ -1771,14 +1772,14 @@ bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
         r.expert_stride_packed = expert_packed_bytes;
         r.expert_stride_ms = expert_ms_bytes;
 
-        // Stamp the packed Tensor so wcache_.nvfp4_moe key + consumer
+        // Stamp the packed Tensor so wcache_->nvfp4_moe key + consumer
         // wiring (expert_*_packed.data lookup) work uniformly with the
         // GGUF path. Logical K (NOT K/2) per cache_moe_expert_nvfp4
         // convention at shape[2].
         int64_t shape[3] = {static_cast<int64_t>(ne), N, K};
         packed = Tensor(d_packed, QType::NVFP4, 3, shape, /*on_device=*/true);
 
-        wcache_.nvfp4_moe[d_packed] = r;
+        wcache_->nvfp4_moe[d_packed] = r;
         dctx.nvfp4_moe_total += add_bytes;
         dctx.nvfp4_moe_count++;
 
@@ -1821,7 +1822,7 @@ bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
         // branch) can fire instead of dequant→FP16→cuBLAS. The cleanup loop
         // above nulled experts[e].data because the original per-expert
         // source allocs were freed; the executor needs valid slice pointers
-        // for register_tensor() and the per-expert wcache_.cutlass_nvfp4
+        // for register_tensor() and the per-expert wcache_->cutlass_nvfp4
         // lookup. Without this block, expert_*_ids[e] = kInvalidTensorID
         // (because t.data == nullptr) and covers_ids() rejects the fast
         // path → 88% of prefill time is spent in dequantize_nvfp4_moe_kernel.
@@ -1829,7 +1830,7 @@ bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
             // Phase 0 may have already created per-expert CUTLASS entries
             // (with SfAtom scales). If so, just re-stamp the expert Tensors
             // to point into the contiguous buffer and reuse Phase 0's entries.
-            bool phase0_has_cutlass = wcache_.cutlass_nvfp4.count(experts[0].data) != 0;
+            bool phase0_has_cutlass = wcache_->cutlass_nvfp4.count(experts[0].data) != 0;
             size_t sf_per_expert = cutlass_nvfp4_sf_size(static_cast<int>(N), static_cast<int>(K));
             size_t sfatom_total = static_cast<size_t>(ne) * sf_per_expert;
             void* d_sfatom = nullptr;
@@ -1854,22 +1855,22 @@ bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
                     w.tensor_scale = h_ts[e];
                     if (phase0_has_cutlass) {
                         // Move Phase 0's CUTLASS entry from old key to new key
-                        auto it = wcache_.cutlass_nvfp4.find(old_data);
-                        if (it != wcache_.cutlass_nvfp4.end()) {
+                        auto it = wcache_->cutlass_nvfp4.find(old_data);
+                        if (it != wcache_->cutlass_nvfp4.end()) {
                             CutlassNvFP4Weight cw = it->second;
                             cw.data = data_slice;
-                            wcache_.cutlass_nvfp4.erase(it);
-                            wcache_.cutlass_nvfp4[data_slice] = cw;
+                            wcache_->cutlass_nvfp4.erase(it);
+                            wcache_->cutlass_nvfp4[data_slice] = cw;
                         }
                         // Move NVFP4 entry too
-                        auto nit = wcache_.nvfp4.find(old_data);
-                        if (nit != wcache_.nvfp4.end()) {
+                        auto nit = wcache_->nvfp4.find(old_data);
+                        if (nit != wcache_->nvfp4.end()) {
                             NvFP4QuantResult nv = nit->second;
                             nv.packed_data = data_slice;
                             nv.micro_scales = w.scales;
                             nv.owned = false;  // borrows resident model storage — don't cudaFree on teardown
-                            wcache_.nvfp4.erase(nit);
-                            wcache_.nvfp4[data_slice] = nv;
+                            wcache_->nvfp4.erase(nit);
+                            wcache_->nvfp4[data_slice] = nv;
                         }
                     } else {
                         void* sf_slice = static_cast<char*>(d_sfatom) +
@@ -1882,11 +1883,11 @@ bool GraphExecutor::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
                         cw.K = K;
                         cw.sf_bytes = sf_per_expert;
                         cw.sf_borrowed = true;
-                        wcache_.cutlass_nvfp4[data_slice] = cw;
+                        wcache_->cutlass_nvfp4[data_slice] = cw;
                     }
                 }
                 IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-                wcache_.cutlass_nvfp4_bytes += sfatom_total;
+                wcache_->cutlass_nvfp4_bytes += sfatom_total;
                 moe_logical_avail = (moe_logical_avail > sfatom_total)
                                         ? (moe_logical_avail - sfatom_total)
                                         : 0;

--- a/src/exec/pre_dequant_phase3c_mxfp4.cu
+++ b/src/exec/pre_dequant_phase3c_mxfp4.cu
@@ -18,6 +18,7 @@
 // `feedback_gguf_mxfp4_legacy_2026_05_24` for the full rule.
 
 #include "exec/executor.h"
+#include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
 #include "core/logging.h"
@@ -30,9 +31,9 @@
 
 namespace imp {
 
-void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
+void QuantPipeline::pre_dequant_phase3c_standalone_mxfp4_(
     const ModelConfig& cfg, cudaStream_t stream) {
-    if (!(wcache_.nvfp4_decode_mode == 0 && wcache_.cutlass_mxfp4.empty() &&
+    if (!(wcache_->nvfp4_decode_mode == 0 && wcache_->cutlass_mxfp4.empty() &&
           cutlass_sm120_mxfp4_available()))
         return;
     // Check if any layer has MXFP4 weights
@@ -62,12 +63,12 @@ void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
             check(L.ssm_out);
             check(L.gdn_gate);
         }
-        if (max_k > 0 && !qscratch_.mxfp4_act_sf) {
-            qscratch_.mxfp4_act_sf_size = cutlass_mxfp4_sf_size(max_tokens_, max_k);
-            qscratch_.mxfp4_act_sf = vram_alloc(vram_alloc_, qscratch_.mxfp4_act_sf_size, "mxfp4_act_sf");
-            if (!qscratch_.cutlass_act_data) {
-                qscratch_.cutlass_act_data_size = static_cast<size_t>(max_tokens_) * (max_k / 2);
-                qscratch_.cutlass_act_data = vram_alloc(vram_alloc_, qscratch_.cutlass_act_data_size,
+        if (max_k > 0 && !qscratch_->mxfp4_act_sf) {
+            qscratch_->mxfp4_act_sf_size = cutlass_mxfp4_sf_size(max_tokens_, max_k);
+            qscratch_->mxfp4_act_sf = vram_alloc(vram_alloc_, qscratch_->mxfp4_act_sf_size, "mxfp4_act_sf");
+            if (!qscratch_->cutlass_act_data) {
+                qscratch_->cutlass_act_data_size = static_cast<size_t>(max_tokens_) * (max_k / 2);
+                qscratch_->cutlass_act_data = vram_alloc(vram_alloc_, qscratch_->cutlass_act_data_size,
                                                         "cutlass_act_data");
             }
         }
@@ -98,8 +99,8 @@ void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
                     // Track bulk for shutdown cleanup (same pattern as Phase 3).
                     // Phase 3 and Phase 3c are mutually exclusive in practice
                     // (gated on `nvfp4_decode_mode`), so only one writes here.
-                    wcache_.fp16_bulk_data = d_fp16_bulk;
-                    wcache_.fp16_bulk_data_size = fp16_total;
+                    wcache_->fp16_bulk_data = d_fp16_bulk;
+                    wcache_->fp16_bulk_data_size = fp16_total;
                     size_t offset = 0;
                     for (auto& sw : small_weights) {
                         size_t bytes = static_cast<size_t>(sw.N) * sw.K * sizeof(half);
@@ -107,7 +108,7 @@ void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
                         offset += bytes;
                         dequant_mxfp4_to_fp16(sw.ptr, sw.N, sw.K, d_fp16, stream);
                         int64_t shape[2] = {sw.N, sw.K};
-                        wcache_.fp16[sw.ptr] = Tensor(d_fp16, QType::F16, 2, shape, true);
+                        wcache_->fp16[sw.ptr] = Tensor(d_fp16, QType::F16, 2, shape, true);
                     }
                     IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
                     IMP_LOG_INFO("MXFP4 → FP16 (alpha/beta): %.2f MiB (%d tensors)",
@@ -115,8 +116,8 @@ void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
                     for (int i = 0; i < cfg.n_layers; i++) {
                         TransformerLayer& L = const_cast<Model*>(model_)->layer(i);
                         auto replace = [&](Tensor& w, QType& qt) {
-                            auto it = wcache_.fp16.find(w.data);
-                            if (it != wcache_.fp16.end() && qt == QType::MXFP4) {
+                            auto it = wcache_->fp16.find(w.data);
+                            if (it != wcache_->fp16.end() && qt == QType::MXFP4) {
                                 w = it->second;
                                 qt = QType::F16;
                             }
@@ -135,12 +136,12 @@ void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
                 return;
             if (w.ndim < 2 || w.shape[1] % 32 != 0)
                 return;
-            if (wcache_.cutlass_mxfp4.count(w.data))
+            if (wcache_->cutlass_mxfp4.count(w.data))
                 return;
             CutlassMxFP4Weight mw;
             if (unpack_mxfp4_gguf(w.data, w.shape[0], w.shape[1], mw, stream)) {
                 mw.hadamard_bs = is_attn ? cfg.mxfp4_hadamard_attn : cfg.mxfp4_hadamard_ffn;
-                wcache_.cutlass_mxfp4[w.data] = mw;
+                wcache_->cutlass_mxfp4[w.data] = mw;
                 mx_count++;
             }
         };
@@ -162,7 +163,7 @@ void GraphExecutor::pre_dequant_phase3c_standalone_mxfp4_(
         register_mx(model_->output_proj(), model_->out_proj_.qtype, true);
         if (mx_count > 0) {
             IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-            wcache_.use_mxfp4 = true;
+            wcache_->use_mxfp4 = true;
 
             // In-place unpack: raw blocks are compacted to [N, K/2] within the
             // SAME buffer. No separate data allocation, no free needed.

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -7,6 +7,7 @@
 // refactor roadmap. See pre_dequant_internal.h for shared helpers.
 
 #include "exec/executor.h"
+#include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "core/logging.h"
 #include "runtime/storage_planner.h"
@@ -22,11 +23,11 @@ using imp::pre_dequant_internal::infer_tier_from_wcache;
 
 namespace imp {
 
-void GraphExecutor::pre_dequant_phase4_tensor_registry_(
+void QuantPipeline::pre_dequant_phase4_tensor_registry_(
     const ModelConfig& cfg, cudaStream_t stream) {
     (void)stream;  // unused but kept for signature consistency
     // Build WeightRegistry from wcache_ contents (phase-2 shim).
-    registry_.clear();
+    registry_->clear();
     // Explicit kind overrides t.kind which is UNKNOWN after weight_upload.cu
     // creates fresh Tensor descriptors (TensorKind is not preserved through
     // the upload code paths). Phase 5 plan-driven allocation requires kind to
@@ -34,15 +35,15 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
     auto register_tensor = [&](const Tensor& t, TensorKind kind) -> TensorID {
         if (!t.data)
             return kInvalidTensorID;
-        StorageTier tier = infer_tier_from_wcache(wcache_, t.data);
-        TensorID id = registry_.reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
-        auto& h = registry_.handle(id);
+        StorageTier tier = infer_tier_from_wcache(*wcache_, t.data);
+        TensorID id = registry_->reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
+        auto& h = registry_->handle(id);
         h.primary_tier = tier;
         h.source_data = t.data;
         h.source_qtype = t.qtype;
         h.source_scales = t.scales;
         h.source_tensor_scale = t.tensor_scale;
-        borrow_payload_from_wcache(h, wcache_, t.data);
+        borrow_payload_from_wcache(h, *wcache_, t.data);
 
         // Dual-tier dispatch: pick the best tier per operation type.
         // Prefill (M>1): FP16 cuBLAS > FP8 cuBLAS > CUTLASS NVFP4 > source dequant
@@ -53,13 +54,13 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
         // Decode uses source NVFP4 data for GEMV (single-token, no compounding).
         h.prefill_tier = tier;
         h.decode_tier = tier;
-        if (tier == StorageTier::CUTLASS_NVFP4 && wcache_.fp16.count(t.data)) {
+        if (tier == StorageTier::CUTLASS_NVFP4 && wcache_->fp16.count(t.data)) {
             h.prefill_tier = StorageTier::FP16;
             // Decode: use source NVFP4 data for GEMV (not the FP16 cache)
-        } else if (tier == StorageTier::CUTLASS_NVFP4 && wcache_.fp8.count(t.data)) {
+        } else if (tier == StorageTier::CUTLASS_NVFP4 && wcache_->fp8.count(t.data)) {
             h.prefill_tier = StorageTier::FP8;
             h.decode_tier = StorageTier::FP8;
-        } else if (tier == StorageTier::CUTLASS_NVFP4 && wcache_.nvfp4.count(t.data)) {
+        } else if (tier == StorageTier::CUTLASS_NVFP4 && wcache_->nvfp4.count(t.data)) {
             h.decode_tier = StorageTier::NVFP4;
         }
         return id;
@@ -106,29 +107,29 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
 
         // Borrow nvfp4_moe pointers for packed 3D expert NVFP4 cache (Task 3.4)
         {
-            auto it = wcache_.nvfp4_moe.find(L.expert_gate_packed.data);
-            L.nvfp4_moe_gate_ptr = (it != wcache_.nvfp4_moe.end()) ? &it->second : nullptr;
+            auto it = wcache_->nvfp4_moe.find(L.expert_gate_packed.data);
+            L.nvfp4_moe_gate_ptr = (it != wcache_->nvfp4_moe.end()) ? &it->second : nullptr;
         }
         {
-            auto it = wcache_.nvfp4_moe.find(L.expert_up_packed.data);
-            L.nvfp4_moe_up_ptr = (it != wcache_.nvfp4_moe.end()) ? &it->second : nullptr;
+            auto it = wcache_->nvfp4_moe.find(L.expert_up_packed.data);
+            L.nvfp4_moe_up_ptr = (it != wcache_->nvfp4_moe.end()) ? &it->second : nullptr;
         }
         {
-            auto it = wcache_.nvfp4_moe.find(L.expert_down_packed.data);
-            L.nvfp4_moe_down_ptr = (it != wcache_.nvfp4_moe.end()) ? &it->second : nullptr;
+            auto it = wcache_->nvfp4_moe.find(L.expert_down_packed.data);
+            L.nvfp4_moe_down_ptr = (it != wcache_->nvfp4_moe.end()) ? &it->second : nullptr;
         }
         // Borrow fp16 pointers for packed expert tensors (Task 3.4)
         {
-            auto it = wcache_.fp16.find(L.expert_gate_packed.data);
-            L.fp16_packed_gate_cache = (it != wcache_.fp16.end()) ? &it->second : nullptr;
+            auto it = wcache_->fp16.find(L.expert_gate_packed.data);
+            L.fp16_packed_gate_cache = (it != wcache_->fp16.end()) ? &it->second : nullptr;
         }
         {
-            auto it = wcache_.fp16.find(L.expert_up_packed.data);
-            L.fp16_packed_up_cache = (it != wcache_.fp16.end()) ? &it->second : nullptr;
+            auto it = wcache_->fp16.find(L.expert_up_packed.data);
+            L.fp16_packed_up_cache = (it != wcache_->fp16.end()) ? &it->second : nullptr;
         }
         {
-            auto it = wcache_.fp16.find(L.expert_down_packed.data);
-            L.fp16_packed_down_cache = (it != wcache_.fp16.end()) ? &it->second : nullptr;
+            auto it = wcache_->fp16.find(L.expert_down_packed.data);
+            L.fp16_packed_down_cache = (it != wcache_->fp16.end()) ? &it->second : nullptr;
         }
     }
     // Register model-level (non-layer) tensors.
@@ -144,12 +145,12 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
     // the GPU pointer. `h.owned_bytes` is set to the allocation size so the
     // registry destructor (`free_owned_storage`) will free it. The wcache_
     // map entry is erased after transfer so that the workspace cleanup's
-    // wcache_.fused_kv loop becomes a no-op — no double-free.
+    // wcache_->fused_kv loop becomes a no-op — no double-free.
     auto register_fused = [&](TensorKind kind, const Tensor& t) -> TensorID {
         if (!t.data)
             return kInvalidTensorID;
-        TensorID id = registry_.reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
-        auto& h = registry_.handle(id);
+        TensorID id = registry_->reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
+        auto& h = registry_->handle(id);
         h.primary_tier = StorageTier::FP16;
         h.payload.fp16.data = static_cast<half*>(t.data);
         h.owned_bytes = static_cast<int64_t>(t.nbytes());
@@ -157,21 +158,21 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
     };
     for (int i = 0; i < cfg.n_layers; ++i) {
         auto& L = const_cast<Model*>(model_)->layer(i);
-        if (auto it = wcache_.fused_kv.find(i); it != wcache_.fused_kv.end()) {
+        if (auto it = wcache_->fused_kv.find(i); it != wcache_->fused_kv.end()) {
             L.fused_kv_id = register_fused(TensorKind::FUSED_KV, it->second);
         }
-        if (auto it = wcache_.fused_gate_up.find(i); it != wcache_.fused_gate_up.end()) {
+        if (auto it = wcache_->fused_gate_up.find(i); it != wcache_->fused_gate_up.end()) {
             L.fused_gate_up_id = register_fused(TensorKind::FUSED_GATE_UP, it->second);
         }
     }
-    // Transfer storage ownership: clear the wcache_.fused_kv / fused_gate_up
+    // Transfer storage ownership: clear the wcache_->fused_kv / fused_gate_up
     // maps so the legacy cleanup loops in executor_workspace_buffers.cu find
     // them empty. The underlying pointers live on in the registry handles
-    // and are freed by `registry_.free_owned_storage()` in workspace cleanup.
-    wcache_.fused_kv.clear();
-    wcache_.fused_gate_up.clear();
+    // and are freed by `registry_->free_owned_storage()` in workspace cleanup.
+    wcache_->fused_kv.clear();
+    wcache_->fused_gate_up.clear();
 
-    IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)", registry_.size());
+    IMP_LOG_INFO("WeightRegistry populated with %zu handles (phase-2 shim)", registry_->size());
 
     // Phase 4 (Option C) overlay diagnostic: report ideal vs actual overlay
     // population. The plan enumerates every quantize-able tensor at its
@@ -217,7 +218,7 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
                     break;
             }
         }
-        size_t registry_count = registry_.size();
+        size_t registry_count = registry_->size();
         IMP_LOG_INFO(
             "Phase-4 overlay: registry=%zu cached / plan-ideal=%zu "
             "(uncached %zu remain as native GGUF blocks)",
@@ -237,8 +238,8 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
                 if (overlay)
                     ++plan_per_kind[static_cast<int>(e.kind)];
             }
-            for (TensorID id = 0; id < static_cast<TensorID>(registry_.size()); ++id) {
-                ++registry_per_kind[static_cast<int>(registry_.handle(id).kind)];
+            for (TensorID id = 0; id < static_cast<TensorID>(registry_->size()); ++id) {
+                ++registry_per_kind[static_cast<int>(registry_->handle(id).kind)];
             }
             for (int k = 0; k < static_cast<int>(TensorKind::_COUNT); ++k) {
                 int diff = plan_per_kind[k] - registry_per_kind[k];
@@ -257,9 +258,9 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
             "Phase-4 wcache actual: fp16=%zu fp8=%zu nvfp4=%zu "
             "cutlass_nvfp4=%zu cutlass_mxfp4=%zu nvfp4_moe=%zu "
             "fused_kv=%zu fused_gate_up=%zu",
-            wcache_.fp16.size(), wcache_.fp8.size(), wcache_.nvfp4.size(), wcache_.cutlass_nvfp4.size(),
-            wcache_.cutlass_mxfp4.size(), wcache_.nvfp4_moe.size(), wcache_.fused_kv.size(),
-            wcache_.fused_gate_up.size());
+            wcache_->fp16.size(), wcache_->fp8.size(), wcache_->nvfp4.size(), wcache_->cutlass_nvfp4.size(),
+            wcache_->cutlass_mxfp4.size(), wcache_->nvfp4_moe.size(), wcache_->fused_kv.size(),
+            wcache_->fused_gate_up.size());
 
         // Stage 1 plan-vs-actual parity diagnostic: for every plan entry whose
         // tier is an overlay, compare the planned tier against the tier the
@@ -272,8 +273,8 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
         // (planned overlay → actual native/uncached) is the common benign case.
         {
             // "Present in the planned tier's map?" — NOT first-hit. A GGUF weight
-            // legitimately appears in BOTH wcache_.nvfp4 (its tier) AND
-            // wcache_.cutlass_nvfp4 (the dead G3 SF buffer); first-hit would
+            // legitimately appears in BOTH wcache_->nvfp4 (its tier) AND
+            // wcache_->cutlass_nvfp4 (the dead G3 SF buffer); first-hit would
             // falsely flag it. We ask: did the legacy build put this source into
             // the map the plan chose? If yes → matched (extra overlays are a
             // separate G3 concern). If it landed in a DIFFERENT map → real
@@ -281,18 +282,18 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
             // landed nowhere → evicted (budget / native fallback, benign).
             auto present_in = [&](StorageTier t, const void* src) -> bool {
                 switch (t) {
-                    case StorageTier::FP16: return wcache_.fp16.count(src) > 0;
-                    case StorageTier::FP8: return wcache_.fp8.count(src) > 0;
-                    case StorageTier::NVFP4: return wcache_.nvfp4.count(src) > 0;
-                    case StorageTier::CUTLASS_NVFP4: return wcache_.cutlass_nvfp4.count(src) > 0;
-                    case StorageTier::MXFP4: return wcache_.cutlass_mxfp4.count(src) > 0;
+                    case StorageTier::FP16: return wcache_->fp16.count(src) > 0;
+                    case StorageTier::FP8: return wcache_->fp8.count(src) > 0;
+                    case StorageTier::NVFP4: return wcache_->nvfp4.count(src) > 0;
+                    case StorageTier::CUTLASS_NVFP4: return wcache_->cutlass_nvfp4.count(src) > 0;
+                    case StorageTier::MXFP4: return wcache_->cutlass_mxfp4.count(src) > 0;
                     default: return false;
                 }
             };
             auto any_overlay = [&](const void* src) -> bool {
-                return wcache_.fp16.count(src) || wcache_.fp8.count(src) ||
-                       wcache_.nvfp4.count(src) || wcache_.cutlass_nvfp4.count(src) ||
-                       wcache_.cutlass_mxfp4.count(src);
+                return wcache_->fp16.count(src) || wcache_->fp8.count(src) ||
+                       wcache_->nvfp4.count(src) || wcache_->cutlass_nvfp4.count(src) ||
+                       wcache_->cutlass_mxfp4.count(src);
             };
             int mismatch = 0, evicted = 0, matched = 0;
             for (const auto& e : ideal_plan.entries) {
@@ -311,7 +312,7 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
                     ++matched;
                 } else if (any_overlay(e.source_data)) {
                     ++mismatch;
-                    StorageTier actual = infer_tier_from_wcache(wcache_, e.source_data);
+                    StorageTier actual = infer_tier_from_wcache(*wcache_, e.source_data);
                     IMP_LOG_INFO("Phase-4 plan/actual MISMATCH: %s plan-tier=%d actual-tier=%d",
                                  tensor_kind_name(e.kind), static_cast<int>(e.tier),
                                  static_cast<int>(actual));
@@ -346,8 +347,8 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
         {
             size_t decode_redundant_count = 0;
             size_t decode_redundant_bytes = 0;
-            for (TensorID id = 0; id < static_cast<TensorID>(registry_.size()); ++id) {
-                const auto& h = registry_.handle(id);
+            for (TensorID id = 0; id < static_cast<TensorID>(registry_->size()); ++id) {
+                const auto& h = registry_->handle(id);
                 if (!h.can_drop_source())
                     continue;
                 int64_t cols = h.shape[1] > 0 ? h.shape[1] : 1;
@@ -381,7 +382,7 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
         const int ne = cfg.n_experts;
         const int n_layers = cfg.n_layers;
         if (ne > 0) {
-        moe_.per_layer_da_cache.assign(n_layers, MoEWorkspace::PerLayerNvfp4DeviceArgsCache{});
+        moe_->per_layer_da_cache.assign(n_layers, MoEWorkspace::PerLayerNvfp4DeviceArgsCache{});
 
         std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
         std::vector<float>       h_alpha(ne);
@@ -395,7 +396,7 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
                 for (int e = 0; e < ne; ++e) {
                     if (ids[e] == kInvalidTensorID)
                         return false;
-                    const auto& h = registry_.handle(ids[e]);
+                    const auto& h = registry_->handle(ids[e]);
                     if (!h.payload.cutlass_nvfp4.weight ||
                         !h.payload.cutlass_nvfp4.sf)
                         return false;
@@ -424,7 +425,7 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
         std::vector<int> failed_layers;
         for (int li = 0; li < n_layers; ++li) {
             const auto& L = model_->layer(li);
-            auto& c = moe_.per_layer_da_cache[li];
+            auto& c = moe_->per_layer_da_cache[li];
             const bool moe_layer = !L.expert_up_ids.empty() || !L.expert_down_ids.empty() ||
                                    !L.expert_gate_ids.empty();
             if (!moe_layer) {
@@ -521,7 +522,7 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
 
 // Free a GGUF source allocation only when NO path still reads it. The guard
 // below (try_mark) frees a source iff it's a base allocation AND not present in
-// wcache_.nvfp4 / wcache_.cutlass_nvfp4. For decode-cached weights the source
+// wcache_->nvfp4 / wcache_->cutlass_nvfp4. For decode-cached weights the source
 // IS present in those maps (keyed on the source pointer), so they are correctly
 // SKIPPED — M>1 prefill reads the GGUF source (IMMA raw-read / dequant /
 // CUTLASS) under the strict-quality-neutral prefill paths. Net effect today:
@@ -529,7 +530,7 @@ void GraphExecutor::pre_dequant_phase4_tensor_registry_(
 // Phase 4 is an upper bound, not freeable VRAM. The mark also sets
 // Tensor.dropped_source so any raw-deref path that DID lose its source would
 // log a coverage-gap warning instead of reading freed memory.
-void GraphExecutor::pre_dequant_phase4b_drop_redundant_sources_(
+void QuantPipeline::pre_dequant_phase4b_drop_redundant_sources_(
     const ModelConfig& cfg, cudaStream_t stream) {
     constexpr bool actually_free = true;
 
@@ -542,7 +543,7 @@ void GraphExecutor::pre_dequant_phase4b_drop_redundant_sources_(
     auto try_mark = [&](Tensor& t, TensorID id) -> bool {
         if (id == kInvalidTensorID || !t.data || t.dropped_source)
             return false;
-        const auto& h = registry_.handle(id);
+        const auto& h = registry_->handle(id);
         if (!h.can_drop_source())
             return false;
         if (h.source_data != t.data)
@@ -555,8 +556,8 @@ void GraphExecutor::pre_dequant_phase4b_drop_redundant_sources_(
                 skipped_shared_bytes += bytes;
                 return false;
             }
-            if (wcache_.cutlass_nvfp4.count(t.data) > 0 ||
-                wcache_.nvfp4.count(t.data) > 0) {
+            if (wcache_->cutlass_nvfp4.count(t.data) > 0 ||
+                wcache_->nvfp4.count(t.data) > 0) {
                 ++skipped_shared_count;
                 skipped_shared_bytes += bytes;
                 return false;

--- a/src/exec/quant_pipeline.h
+++ b/src/exec/quant_pipeline.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "core/tensor.h"            // Tensor, QType (used by Nvfp4DecodeContext + signatures)
+#include "runtime/storage_planner.h" // StoragePlan, PlanHints, StorageTier
+#include "exec/weight_handle.h"      // WeightRegistry
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <vector>
+#include <unordered_set>
+
+namespace imp {
+
+class Model;
+class VRAMAllocator;
+struct ModelConfig;
+struct RuntimeConfig;
+struct VRAMBudget;     // defined in exec/executor.h
+struct WeightCaches;   // defined in exec/executor.h
+struct QuantScratch;
+struct MoEWorkspace;
+
+// Per-call state for QuantPipeline::pre_dequant_phase3_nvfp4_decode_().
+// Bundles the locals shared between sub-phase helpers — exclusion set,
+// candidate entries, mode string, MoE-cache accumulators.
+struct Nvfp4DecodeContext {
+    // One entry per weight that may receive NVFP4 quantization. Populated by
+    // the collect phase; consumed by the mode-1 / mode-2 / second-pass phases.
+    struct Entry {
+        const void* orig_ptr;
+        Tensor weight;
+        QType qtype;
+        bool from_scratch;
+    };
+
+    std::unordered_set<const void*> exclude_ptrs;
+    std::vector<Entry> entries;
+    const char* mode_str = "";          // "additive" or "only", set early
+    size_t moe_budget = 0;              // initialised before the MoE-cache phase
+    int    nvfp4_moe_count = 0;         // populated by the MoE-cache phase
+    size_t nvfp4_moe_total = 0;
+    // Shared VRAM safety reserve for mode 2 paths (dense incremental,
+    // CUTLASS NVFP4, MoE expert caching). Computed once at the top of
+    // pre_dequant_phase3_nvfp4_decode_() from the model's actual attention
+    // layout — replaces the previous `total_mem / 10` heuristic which
+    // reserved 3.2 GiB on a 32 GiB 5090 and starved the dense NVFP4 cache
+    // (20 of 281 tensors uncached on Qwen3-14B Q6_K → −20% decode tok/s).
+    size_t safety_reserve = 0;
+};
+
+// Init-time weight-quantization pipeline, extracted from GraphExecutor (D2).
+// Runs once via build(); fills the four long-lived caches (owned by the caller)
+// and owns only the build-only StoragePlan + decode context. The forward hot
+// path reads the caches unchanged (byte-identical). See
+// docs/superpowers/specs/2026-06-08-quant-pipeline-design.md.
+class QuantPipeline {
+public:
+    // Runs the full init-time quantization pipeline once. Populates the four
+    // long-lived caches (owned by the caller) from the model's weights; owns the
+    // transient StoragePlan + decode context internally.
+    void build(const Model& model, const RuntimeConfig& rcfg, VRAMAllocator& alloc,
+               const VRAMBudget& budget, cudaStream_t stream, WeightCaches& wcache,
+               QuantScratch& qscratch, WeightRegistry& registry, PlanHints& hints,
+               MoEWorkspace& moe);
+
+private:
+    // Build context (set at the top of build(); the phase methods read these
+    // exactly as they read the same-named GraphExecutor members today).
+    const Model* model_ = nullptr;
+    VRAMAllocator* vram_alloc_ = nullptr;
+    const RuntimeConfig* runtime_config_ = nullptr;
+    const VRAMBudget* budget_ = nullptr;
+    cudaStream_t stream_ = nullptr;
+    WeightCaches* wcache_ = nullptr;
+    QuantScratch* qscratch_ = nullptr;
+    WeightRegistry* registry_ = nullptr;
+    PlanHints* hints_ = nullptr;
+    MoEWorkspace* moe_ = nullptr;
+
+    // Owned build-only state.
+    StoragePlan storage_plan_;
+    // Planned overlay tier for a source pointer, or Undefined if the pointer is
+    // not in the plan (native GGUF blocks bypass the overlay layer).
+    StorageTier plan_tier_of(const void* src) const { return storage_plan_.tier_of(src); }
+
+    // --- moved phase / helper declarations (verbatim from executor.h) ---
+    // Stage 1.2: fold the scattered arch-specific overlay rules into one pass
+    // over the freshly-built plan, so the plan matches the legacy builders.
+    void apply_arch_rules_(StoragePlan& plan, const ModelConfig& cfg) const;
+
+    void pre_dequant_phase0_promote_nvfp4_sidecars_(const ModelConfig& cfg, cudaStream_t stream);
+    void pre_dequant_phase0b_register_cutlass_nvfp4_(const ModelConfig& cfg, cudaStream_t stream);
+    void pre_dequant_phase1_fp16_cache_(const ModelConfig& cfg, const VRAMBudget& budget,
+                                        size_t& remaining_budget, cudaStream_t stream);
+    void pre_dequant_phase2_fp8_cache_(const ModelConfig& cfg, const VRAMBudget& budget,
+                                       size_t& remaining_budget, cudaStream_t stream);
+    void pre_dequant_phase3_nvfp4_decode_(const ModelConfig& cfg, const VRAMBudget& budget,
+                                          size_t& remaining_budget, cudaStream_t stream);
+    // Sub-phase helpers for pre_dequant_phase3_nvfp4_decode_. Each operates
+    // on a shared Nvfp4DecodeContext; the orchestrator above calls them in
+    // sequence, mirroring the legacy monolithic body.
+    void nvfp4_decode_collect_candidates_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx);
+    void nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cudaStream_t stream);
+    void nvfp4_decode_cache_fp16_projections_(const ModelConfig& cfg, cudaStream_t stream);
+    void nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4DecodeContext& dctx);
+    void nvfp4_decode_quantize_mode1_(size_t& remaining_budget, cudaStream_t stream,
+                                      Nvfp4DecodeContext& dctx);
+    void nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_budget, cudaStream_t stream,
+                                                 Nvfp4DecodeContext& dctx);
+    void nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStream_t stream,
+                                   Nvfp4DecodeContext& dctx);
+    void nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cudaStream_t stream);
+    void nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cfg, cudaStream_t stream);
+    void nvfp4_decode_mxfp4_fp16_fallback_(const ModelConfig& cfg, cudaStream_t stream);
+    void nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg, size_t& remaining_budget,
+                                         cudaStream_t stream, Nvfp4DecodeContext& dctx);
+    bool cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>& experts, cudaStream_t stream,
+                                 Nvfp4DecodeContext& dctx, bool& moe_budget_exhausted,
+                                 size_t& moe_logical_avail);
+    void gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx);
+    void pre_dequant_phase3c_standalone_mxfp4_(const ModelConfig& cfg, cudaStream_t stream);
+    void pre_dequant_phase4_tensor_registry_(const ModelConfig& cfg, cudaStream_t stream);
+    void pre_dequant_phase4b_drop_redundant_sources_(const ModelConfig& cfg, cudaStream_t stream);
+};
+
+}  // namespace imp

--- a/src/exec/quant_pipeline.h
+++ b/src/exec/quant_pipeline.h
@@ -68,8 +68,6 @@ private:
     const Model* model_ = nullptr;
     VRAMAllocator* vram_alloc_ = nullptr;
     const RuntimeConfig* runtime_config_ = nullptr;
-    const VRAMBudget* budget_ = nullptr;
-    cudaStream_t stream_ = nullptr;
     WeightCaches* wcache_ = nullptr;
     QuantScratch* qscratch_ = nullptr;
     WeightRegistry* registry_ = nullptr;
@@ -80,6 +78,10 @@ private:
     // Accessor mirroring GraphExecutor::runtime_config() so the moved phase
     // methods read the config exactly as before. Set in build() from the
     // owning GraphExecutor's already-validated config.
+    // DELIBERATE DUPLICATION (behaviour-neutral verbatim move): keeps the ~12
+    // runtime_config() call sites in the moved phases byte-identical. When the
+    // next GraphExecutor component (MoeRunner/Workspace) needs a 3rd copy, hoist
+    // this to a shared free helper in runtime/config.h instead.
     const RuntimeConfig& runtime_config() const noexcept {
         static const RuntimeConfig kDefault;
         return runtime_config_ ? *runtime_config_ : kDefault;

--- a/src/exec/quant_pipeline.h
+++ b/src/exec/quant_pipeline.h
@@ -3,6 +3,7 @@
 #include "core/tensor.h"            // Tensor, QType (used by Nvfp4DecodeContext + signatures)
 #include "runtime/storage_planner.h" // StoragePlan, PlanHints, StorageTier
 #include "exec/weight_handle.h"      // WeightRegistry
+#include "runtime/config.h"          // RuntimeConfig (runtime_config() accessor)
 #include <cuda_runtime.h>
 #include <cstddef>
 #include <vector>
@@ -13,7 +14,6 @@ namespace imp {
 class Model;
 class VRAMAllocator;
 struct ModelConfig;
-struct RuntimeConfig;
 struct VRAMBudget;     // defined in exec/executor.h
 struct WeightCaches;   // defined in exec/executor.h
 struct QuantScratch;
@@ -60,7 +60,7 @@ public:
     void build(const Model& model, const RuntimeConfig& rcfg, VRAMAllocator& alloc,
                const VRAMBudget& budget, cudaStream_t stream, WeightCaches& wcache,
                QuantScratch& qscratch, WeightRegistry& registry, PlanHints& hints,
-               MoEWorkspace& moe);
+               MoEWorkspace& moe, int max_tokens);
 
 private:
     // Build context (set at the top of build(); the phase methods read these
@@ -75,6 +75,15 @@ private:
     WeightRegistry* registry_ = nullptr;
     PlanHints* hints_ = nullptr;
     MoEWorkspace* moe_ = nullptr;
+    int max_tokens_ = 0;   // workspace max token count (build-time scratch sizing)
+
+    // Accessor mirroring GraphExecutor::runtime_config() so the moved phase
+    // methods read the config exactly as before. Set in build() from the
+    // owning GraphExecutor's already-validated config.
+    const RuntimeConfig& runtime_config() const noexcept {
+        static const RuntimeConfig kDefault;
+        return runtime_config_ ? *runtime_config_ : kDefault;
+    }
 
     // Owned build-only state.
     StoragePlan storage_plan_;

--- a/tests/test_quant_pipeline.cpp
+++ b/tests/test_quant_pipeline.cpp
@@ -1,0 +1,141 @@
+// QuantPipeline build post-condition test (D2 extraction proof).
+//
+// QuantPipeline (src/exec/quant_pipeline.h) is the init-time weight-
+// quantization pipeline extracted out of GraphExecutor. Its build() runs
+// once during engine init and populates the long-lived decode caches
+// (FP16 / FP8 / NVFP4) that the forward hot path reads. The whole point of
+// the extraction is that this stage is now a separable, testable component.
+//
+// FALLBACK PATH (sanctioned by docs/superpowers/specs/2026-06-08-
+// quant-pipeline-design.md, "Testing"): we drive the pipeline through the
+// normal engine / C-API path and assert its observable post-condition — the
+// model decodes coherent, non-degenerate output — which only happens because
+// build() successfully populated the decode caches. A truly standalone unit
+// test (construct QuantPipeline directly, hand it a bare Model +
+// VRAMAllocator + empty caches, call build(), assert the caches filled) is
+// the preferred proof, but it is currently impractical: a bare imp::Model is
+// only reachable via the opaque ImpModel C-API handle, VRAMAllocator is owned
+// by the engine's MemoryManager and constructed inside engine->init(), and
+// the VRAMBudget that drives which phases run is computed during KV-cache
+// init. Standing all of that up in a test means reproducing ~half of engine
+// init.
+//
+// FOLLOW-UP: replace this with a true bare-QuantPipeline unit test once a
+// lightweight Model + VRAMAllocator fixture exists (no full engine init).
+//
+// Requires a real model and GPU. Run with:
+//   imp-tests --gtest_filter="QuantPipelineTest.*"
+
+#include <gtest/gtest.h>
+#include "imp/imp.h"
+#include "test_models.h"
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+static std::string model_path() {
+    return imp_test::env_path_or(imp_test::kEnvModel, "/models/Qwen3-8B-Q8_0.gguf");
+}
+
+static bool model_exists(const std::string& p) {
+    FILE* f = fopen(p.c_str(), "r");
+    if (f) {
+        fclose(f);
+        return true;
+    }
+    return false;
+}
+
+// Count "word-like" whitespace-separated tokens that contain at least one
+// alphanumeric character. A populated decode cache produces real words; a
+// pipeline that failed to fill its caches yields empty / garbage output.
+static int wordlike_token_count(const std::string& text) {
+    int count = 0;
+    bool in_word = false;
+    bool has_alnum = false;
+    for (char c : text) {
+        if (std::isspace(static_cast<unsigned char>(c))) {
+            if (in_word && has_alnum)
+                ++count;
+            in_word = false;
+            has_alnum = false;
+        } else {
+            in_word = true;
+            if (std::isalnum(static_cast<unsigned char>(c)))
+                has_alnum = true;
+        }
+    }
+    if (in_word && has_alnum)
+        ++count;
+    return count;
+}
+
+class QuantPipelineTest : public ::testing::Test {
+protected:
+    ImpModel model_ = nullptr;
+    ImpContext ctx_ = nullptr;
+
+    // Pin the cuBLAS workspace for greedy-deterministic behavior on sm_120.
+    static void SetUpTestSuite() {
+        setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", /*overwrite=*/0);
+    }
+
+    void SetUp() override {
+        const std::string path = model_path();
+        if (!model_exists(path))
+            GTEST_SKIP() << "Model not found: " << path;
+
+        // imp_model_load + imp_context_create run engine init, which calls
+        // QuantPipeline::build() (via GraphExecutor::pre_dequant_weights).
+        ASSERT_EQ(imp_model_load(path.c_str(), IMP_FORMAT_GGUF, &model_), IMP_SUCCESS);
+
+        ImpConfig config = imp_config_default();
+        config.max_seq_len = 2048;
+        config.max_batch_size = 1;
+
+        ImpError err = imp_context_create(model_, &config, &ctx_);
+        if (err != IMP_SUCCESS) {
+            imp_model_free(model_);
+            model_ = nullptr;
+            GTEST_SKIP() << "Context creation failed: " << imp_error_string(err);
+        }
+    }
+
+    void TearDown() override {
+        if (ctx_)
+            imp_context_free(ctx_);
+        if (model_)
+            imp_model_free(model_);
+    }
+};
+
+// build() post-condition: with the decode caches populated, greedy decode
+// produces coherent, non-degenerate output (>= 10 word-like tokens).
+TEST_F(QuantPipelineTest, BuildPopulatesDecodeCachesForCoherentDecode) {
+    ImpGenerateParams params = imp_generate_params_default();
+    params.max_tokens = 64;
+    params.temperature = 0.0f;  // greedy: exercises the decode caches build() filled
+    params.seed = 42;
+    params.apply_chat_template = 1;
+
+    char output[4096];
+    size_t output_len = 0;
+    ImpError err = imp_generate(ctx_, "List three primary colors.", &params, output,
+                                sizeof(output), &output_len);
+    ASSERT_EQ(err, IMP_SUCCESS) << "Decode failed: " << imp_error_string(err);
+
+    std::string out(output, output_len);
+    ASSERT_GT(out.size(), 0u) << "Empty decode output — decode caches likely unpopulated";
+
+    int words = wordlike_token_count(out);
+    EXPECT_GE(words, 10) << "Decode produced only " << words
+                         << " word-like tokens (expected >= 10); a coherent decode "
+                            "indicates QuantPipeline::build() populated the caches. "
+                            "Output: " << out.substr(0, 200);
+}
+
+}  // namespace


### PR DESCRIPTION
## What

**D2, component 1** — extract the init-time weight-quantization pipeline out of the `GraphExecutor` god-object into a standalone, testable `QuantPipeline` builder. First real component of the GraphExecutor split (D1 centralized arch facts via ModelProfile; D3 carved the MoE-native lambda + GEMM dispatch into their own TUs).

The 23 `pre_dequant_*` / `nvfp4_decode_*` methods + the build-only `StoragePlan` move onto `QuantPipeline`. The long-lived caches (`wcache_`/`qscratch_`/`registry_`/`hints_`/`moe_`) **stay owned by `GraphExecutor`**; `QuantPipeline` holds pointers to them, set at the top of `build()`, and fills them by reference — so the **forward hot path is byte-identical** (reads its own members, zero added indirection). `GraphExecutor::pre_dequant_weights` becomes a one-line delegate, so the engine call site is untouched.

`executor.h` sheds 113 lines; the pipeline internals (`Nvfp4DecodeContext`, the 22 phase methods) are no longer visible to every TU.

## Why this design

`QuantPipeline` is a builder, not an owner of the caches: keeping the caches on `GraphExecutor` is what makes the change zero-overhead and the hot path provably unchanged. It establishes the component + `build()`-interface + canary-gate pattern for the rest of D2 (MoeRunner, Workspace, …).

## Behaviour-neutral — verified

- **Hot-path diff = 0**: `git diff main` over `executor_attention/ffn/forward/forward_moe/gemm_dispatch.cu` is empty. The moved method bodies are verbatim (mechanical `GraphExecutor::`→`QuantPipeline::` + value-cache `.`→`->`).
- **4-arch coherence canary**: Qwen3-8B Q8_0 (dense), Qwen3-30B-A3B-NVFP4 (MoE native), Nemotron-3-Nano-30B (Mamba2/MoE hybrid), gemma-3-12b (dense gemma) — all coherent (Paris), no `CUDA error / falling back / NaN`. The MoE native-cache counts match `main` exactly (Qwen3-30B **144**, Nemotron **46**).
- `make verify-fast` gtest filter green.
- New `QuantPipelineTest` (the component's observable post-condition: with build() having populated the decode caches, greedy decode is coherent). A true bare-`QuantPipeline` unit test is documented as a follow-up — a bare `Model`/`VRAMAllocator` fixture doesn't exist yet (everything is behind the engine's C-API).

## Review

Spec-compliance + code-quality reviewed (two-stage): pure code-motion confirmed; dead context members + an orphaned include cleaned up; the `runtime_config()` accessor mirror flagged as deliberate behaviour-neutral duplication to hoist when a 3rd component copies it.

Spec: `docs/superpowers/specs/2026-06-08-quant-pipeline-design.md`. Plan: `docs/superpowers/plans/2026-06-08-quant-pipeline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
