### PR TITLE
refactor(exec): extract Workspace component (scratch arena) (D2)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-workspace-component.md
+++ b/docs/superpowers/plans/2026-06-08-workspace-component.md
@@ -1,0 +1,271 @@
+# Workspace Component Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the shared/persistent/decode scratch arena out of `GraphExecutor` into a `Workspace` class, with the forward hot path reading buffers through zero-overhead inline accessors.
+
+**Architecture:** `GraphExecutor` owns `Workspace ws_;`, inits it once (`ws_.init(model, alloc, compute_dtype, max_tokens, use_pdl, moe)`), and the orchestrator `allocate_workspaces` calls `ws_.allocate_*`. The forward path reads `ws_.shared()` / calls `ws_.configure_<phase>(n)` instead of the former members. The cross-cutting buffer-allocation hub (`allocate_auxiliary_buffers`: qscratch/moe/attn/fp32_accum) STAYS on GraphExecutor. NOT `diff=0` — the forward TUs change; canary-gated.
+
+**Tech Stack:** C++20/CUDA, Docker build, GTest, 4-arch canary + decode-perf backstop.
+
+Spec: `docs/superpowers/specs/2026-06-08-workspace-component-design.md`. Branch: `feat/d2-workspace` (spec committed).
+
+---
+
+## File structure
+
+- **Create** `src/exec/workspace.h` — the `Workspace` class (members + init-context pointers + inline accessors + moved-method declarations).
+- **Modify** `src/exec/executor.h` — `#include "exec/workspace.h"`; add member `Workspace ws_;`; REMOVE the moved members (shared/persistent workspace + sizes + decode-swap); keep `active_workspace()` public getter as a delegate; keep the hub buffers (`qscratch_`/`moe_`/`attn_scores_buf_`/`fp32_accum_buf_`/`nvfp4_dequant_ws_buf_`).
+- **Modify** `src/exec/executor_workspace.cu` — `compute_shared_sizes`, `allocate_persistent_workspace`, `allocate_shared_workspace`, `allocate_decode_workspace`, `workspace_estimate` become `Workspace::` methods; `init` + `allocate_workspaces` stay `GraphExecutor::` (the orchestrator calls `ws_.allocate_*`).
+- **Modify** `src/exec/executor_workspace_config.cu` — `configure_attn/ffn/moe/ssm_workspace`, `use_workspace`, `resize_workspace` become `Workspace::`; `view_tokens`, `layer_has_*`, `ensure_logits_pinned` stay `GraphExecutor::`.
+- **Leave** `src/exec/executor_workspace_buffers.cu` entirely on GraphExecutor (the hub).
+- **Modify** the hot-path TUs (`executor_attention.cu`, `executor_ffn.cu`, `executor_forward.cu`, `executor_forward_moe*.cu`, `executor_ssm_gdn.cu`) — ~40 call sites `shared_workspace_`→`ws_.shared()`, `configure_*_workspace(n)`→`ws_.configure_*(n)`, etc.
+
+Workspace init-context (pointers set in `init`, mirroring QuantPipeline): `const Model* model_`, `VRAMAllocator* vram_alloc_`, `QType compute_dtype_`, `int max_tokens_`, `bool use_pdl_`, `const MoEWorkspace* moe_` (read for moe-workspace sizing only).
+
+Members moving into `Workspace`: `shared_workspace_`(+`_size_`,+`_max_tokens_`), `persistent_workspace_`(+`_size_`), `attn_shared_size_`, `ffn_shared_size_`, `moe_shared_size_`, `ssm_shared_size_`, `decode_persistent_size_`, `decode_shared_size_`, `decode_workspace_`, `decode_shared_workspace_`, `active_workspace_`, `saved_prefill_ws_` (+ its `SavedWorkspace` struct decl).
+
+---
+
+### Task 1: Create `workspace.h` with the class skeleton
+
+**Files:** Create `src/exec/workspace.h`; back up: `cp src/exec/executor.h /tmp/exec_ws_bak.h`.
+
+- [ ] **Step 1: Read the current members + method signatures to copy**
+
+Run:
+```bash
+grep -nE "SavedWorkspace|shared_workspace_|persistent_workspace_|attn_shared_size_|ffn_shared_size_|moe_shared_size_|ssm_shared_size_|decode_persistent_size_|decode_shared_size_|decode_workspace_|decode_shared_workspace_|active_workspace_|saved_prefill_ws_" src/exec/executor.h
+grep -nE "compute_shared_sizes|allocate_persistent_workspace|allocate_shared_workspace|allocate_decode_workspace|workspace_estimate|configure_attn_workspace|configure_ffn_workspace|configure_moe_workspace|configure_ssm_workspace|use_workspace|resize_workspace" src/exec/executor.h
+```
+Copy the exact signatures + the `SavedWorkspace` struct (currently inner to GraphExecutor) for the header.
+
+- [ ] **Step 2: Write `workspace.h`**
+
+```cpp
+#pragma once
+
+#include "core/tensor.h"
+#include "core/qtype.h"
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace imp {
+
+class Model;
+class VRAMAllocator;
+struct MoEWorkspace;
+
+// The shared/persistent/decode scratch arena, extracted from GraphExecutor (D2).
+// Owns the forward-pass scratch buffers + the decode/prefill workspace swap; the
+// cross-cutting auxiliary-buffer hub (qscratch/moe/attn) stays on GraphExecutor.
+// See docs/superpowers/specs/2026-06-08-workspace-component-design.md.
+class Workspace {
+public:
+    // Set the build context once (mirrors QuantPipeline's pointer-context).
+    void init(const Model& model, VRAMAllocator& alloc, QType compute_dtype,
+              int max_tokens, bool use_pdl, const MoEWorkspace& moe) {
+        model_ = &model; vram_alloc_ = &alloc; compute_dtype_ = compute_dtype;
+        max_tokens_ = max_tokens; use_pdl_ = use_pdl; moe_ = &moe;
+    }
+
+    // --- zero-overhead inline accessors (hot path reads these) ---
+    void* shared() const { return shared_workspace_; }
+    void* persistent() const { return persistent_workspace_; }
+    int shared_max_tokens() const { return shared_workspace_max_tokens_; }
+    int active() const { return active_workspace_; }
+
+    // --- moved lifecycle methods (paste exact signatures from executor.h) ---
+    // bool allocate_persistent_workspace(int max_tokens);
+    // bool allocate_shared_workspace(int max_tokens);
+    // bool allocate_decode_workspace(...);
+    // void compute_shared_sizes(int max_tokens);
+    // size_t workspace_estimate() const;
+    // void configure_attn_workspace(int n);  (+ ffn/moe/ssm)
+    // void use_workspace(...);  void resize_workspace(...);
+
+private:
+    const Model* model_ = nullptr;
+    VRAMAllocator* vram_alloc_ = nullptr;
+    QType compute_dtype_ = QType::F16;
+    int max_tokens_ = 0;
+    bool use_pdl_ = false;
+    const MoEWorkspace* moe_ = nullptr;
+
+    // <-- paste SavedWorkspace struct + the moved members here verbatim -->
+};
+
+}  // namespace imp
+```
+Fill the method decls + members verbatim from executor.h. Match include needs to the moved members (e.g. `SavedWorkspace` holds `Tensor` members → `core/tensor.h`).
+
+- [ ] **Step 3: Commit the skeleton**
+
+```bash
+git add src/exec/workspace.h
+git commit -m "feat(exec): Workspace class skeleton (D2 component 3)"
+```
+
+---
+
+### Task 2: Move the lifecycle method definitions onto `Workspace`
+
+**Files:** Modify `src/exec/executor_workspace.cu`, `src/exec/executor_workspace_config.cu`.
+
+- [ ] **Step 1: Add include + reclass the moved methods**
+
+```bash
+for f in src/exec/executor_workspace.cu src/exec/executor_workspace_config.cu; do
+  grep -q 'exec/workspace.h' "$f" || sed -i '0,/#include "exec\/executor.h"/s//#include "exec\/executor.h"\n#include "exec\/workspace.h"/' "$f"
+done
+# executor_workspace.cu: reclass ONLY the 5 arena methods (NOT init / allocate_workspaces)
+perl -0pi -e 's/\bGraphExecutor::(compute_shared_sizes|allocate_persistent_workspace|allocate_shared_workspace|allocate_decode_workspace|workspace_estimate)\b/Workspace::$1/g' src/exec/executor_workspace.cu
+# config.cu: reclass configure_* + use_workspace + resize_workspace (NOT view_tokens / layer_has_* / ensure_logits_pinned)
+perl -0pi -e 's/\bGraphExecutor::(configure_attn_workspace|configure_ffn_workspace|configure_moe_workspace|configure_ssm_workspace|use_workspace|resize_workspace)\b/Workspace::$1/g' src/exec/executor_workspace_config.cu
+```
+
+- [ ] **Step 2: Fix member access in the moved bodies**
+
+The moved methods reference the context members (`model_`, `vram_alloc_`, `compute_dtype_`, `max_tokens_`, `use_pdl_`, `moe_`) — those are now `Workspace` members with the SAME names, set in `init()`, so they resolve unchanged. `model_->`/`vram_alloc_` are pointers (unchanged). `moe_` is now a `const MoEWorkspace*` → its access changes `moe_.` → `moe_->` (sizing reads only):
+```bash
+perl -0pi -e 's/\bmoe_\./moe_->/g' src/exec/executor_workspace_config.cu
+```
+(In `executor_workspace.cu` the arena methods don't touch `moe_`; confirm with `grep -n "moe_" src/exec/executor_workspace.cu` — if a moved method does, apply the same `.`→`->`.)
+
+- [ ] **Step 3: Commit (won't build until Task 3 wires GraphExecutor)**
+
+```bash
+git add src/exec/executor_workspace.cu src/exec/executor_workspace_config.cu
+git commit -m "refactor(exec): reclass scratch-arena methods onto Workspace"
+```
+
+---
+
+### Task 3: Wire `GraphExecutor` to own `Workspace` + delegate
+
+**Files:** Modify `src/exec/executor.h`, `src/exec/executor_workspace.cu`.
+
+- [ ] **Step 1: executor.h — include, member, remove moved decls/members**
+
+- Add `#include "exec/workspace.h"`.
+- Add member `Workspace ws_;` (near where the workspace members were).
+- REMOVE the moved member declarations (shared/persistent workspace + sizes + decode-swap + `SavedWorkspace` struct) and the moved method declarations.
+- Change the public `active_workspace()` getter to `return ws_.active();`.
+- KEEP `qscratch_`, `moe_`, `attn_scores_buf_`(+size), `fp32_accum_buf_`, `nvfp4_dequant_ws_buf_`(+size) and the hub method decls (`allocate_auxiliary_buffers`, `free_buffers`, `release_moe_batch_buf`, `ensure_logits_pinned`, `view_tokens`, `layer_has_*`).
+
+- [ ] **Step 2: executor_workspace.cu — init + allocate_workspaces call ws_**
+
+In `GraphExecutor::init`, after the model is set and `max_tokens_`/`compute_dtype_`/`use_pdl_` are known, add `ws_.init(*model_, *vram_alloc_, compute_dtype_, max_tokens_, use_pdl_, moe_);` (place it where the workspace members were first valid — right before the first `allocate_*` call).
+
+In `GraphExecutor::allocate_workspaces`, replace the calls to the moved methods with `ws_.compute_shared_sizes(...)`, `ws_.allocate_persistent_workspace(...)`, `ws_.allocate_shared_workspace(...)`, `ws_.allocate_decode_workspace(...)` as they appear.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/exec/executor.h src/exec/executor_workspace.cu
+git commit -m "refactor(exec): GraphExecutor owns + delegates to Workspace"
+```
+
+---
+
+### Task 4: Migrate the hot-path call sites (~40)
+
+**Files:** Modify `executor_attention.cu`, `executor_ffn.cu`, `executor_forward.cu`, `executor_forward_moe.cu`, `executor_forward_moe_batch.cu`, `executor_ssm_gdn.cu` (and any TU the build flags).
+
+- [ ] **Step 1: Migrate buffer reads + configure calls**
+
+```bash
+HOT="src/exec/executor_attention.cu src/exec/executor_ffn.cu src/exec/executor_forward.cu src/exec/executor_forward_moe.cu src/exec/executor_forward_moe_batch.cu src/exec/executor_ssm_gdn.cu"
+for f in $HOT; do
+  perl -0pi -e 's/\bshared_workspace_max_tokens_\b/ws_.shared_max_tokens()/g;
+                s/\bshared_workspace_\b(?!\w)/ws_.shared()/g;
+                s/\bpersistent_workspace_\b(?!\w)/ws_.persistent()/g;
+                s/\bconfigure_attn_workspace\(/ws_.configure_attn_workspace(/g;
+                s/\bconfigure_ffn_workspace\(/ws_.configure_ffn_workspace(/g;
+                s/\bconfigure_moe_workspace\(/ws_.configure_moe_workspace(/g;
+                s/\bconfigure_ssm_workspace\(/ws_.configure_ssm_workspace(/g;
+                s/\buse_workspace\(/ws_.use_workspace(/g;
+                s/\bresize_workspace\(/ws_.resize_workspace(/g' "$f"
+done
+```
+Caveat: `shared_workspace_size_` (the size member) — if the hot path reads it, add an accessor `size_t shared_size() const` to Workspace and migrate `shared_workspace_size_`→`ws_.shared_size()`. The `(?!\w)` guards stop `shared_workspace_` from eating `shared_workspace_size_`/`_max_tokens_`; do those FIRST (the script orders max_tokens before the bare name). Re-grep after: `grep -rn "shared_workspace_\|persistent_workspace_" $HOT` should be empty.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add -A && git commit -m "refactor(exec): hot-path reads workspace via ws_ accessors"
+```
+
+---
+
+### Task 5: Build and fix
+
+- [ ] **Step 1: Build**
+
+Run: `make build 2>&1 | grep -iE "error:" | head -40`
+Likely errors + fixes:
+- A moved method reads a GraphExecutor member not in the init-context → add it to `Workspace::init` params + a member, pass from `GraphExecutor::init`. (Re-confirm it's read-only for sizing, no hot-path writer.)
+- A hot-path TU still reads a workspace member the perl missed, or `shared_workspace_size_` → add the accessor and migrate.
+- An accessor name mismatch (`ws_.configure_attn_workspace` vs the method name) → make method names match what the perl produced.
+Iterate to clean.
+
+- [ ] **Step 2: Commit fixes**
+
+```bash
+git add -A && git commit -m "fix(exec): thread Workspace context + remaining accessors"
+```
+
+---
+
+### Task 6: Behaviour + perf gate
+
+- [ ] **Step 1: 4-arch coherence canary**
+
+```bash
+for M in "Qwen3-8B-Q8_0.gguf|dense" "Qwen3-30B-A3B-NVFP4-Modelopt|moe" \
+         "Nemotron-3-Nano-30B-A3B-NVFP4|ssm" "gemma-3-12b-it-Q4_K_M.gguf|gemma3"; do
+  MODEL="${M%%|*}"
+  docker run --rm --gpus all -v /home/kekz/models:/models imp:test \
+    imp-cli --model "/models/$MODEL" --prompt "What is the capital of France? One word." \
+    --max-tokens 200 --temperature 0 --seed 42 >/tmp/ws.out 2>&1
+  echo "== $MODEL =="; grep -aoiE "paris" /tmp/ws.out | head -1
+  grep -acE "NVFP4 MoE native: data-borrow decode cache" /tmp/ws.out
+  grep -aiE "CUDA error|falling back|\bNaN\b|illegal memory" /tmp/ws.out | head -1
+done
+```
+Expected: each `Paris`, no error/NaN/IMA, Qwen3-30B native-cache count = **144**, Nemotron = **46**.
+
+- [ ] **Step 2: Decode-perf backstop (workspace mis-sizing is silent)**
+
+```bash
+docker run --rm --gpus all -v /home/kekz/models:/models imp:test bash -lc '
+  imp-cli --model /models/Qwen3-8B-Q8_0.gguf --prompt Hi --max-tokens 64 >/dev/null 2>&1
+  imp-cli --model /models/Qwen3-8B-Q8_0.gguf --bench --bench-pp 512 --bench-reps 10 2>&1 | grep -iE "tg "'
+```
+Expected: `tg128`/`tg256` within ~5% of the main baseline (Q8 tg≈268-278). A >5% drop or an OOM/`auto-disable` log = a mis-sized workspace; investigate before proceeding.
+
+- [ ] **Step 3: verify-fast**
+
+Run: `IMP_VERIFY_SKIP_BUILD=1 make verify-fast 2>&1 | grep -E "PASS|FAIL|OK ==="`
+Expected: PASS + OK.
+
+- [ ] **Step 4: Coherence battery (hot path changed — run the degen check)**
+
+Run: `make test-gpu GTEST_FILTER="DegenerationTest.*" 2>&1 | tail -5`
+Expected: all pass.
+
+---
+
+### Task 7: Push + PR
+
+- [ ] Push `feat/d2-workspace`, open PR vs main, summary: what moved (the scratch arena), what stayed (the alloc hub + fp32_accum/attn_scores), the ~40-site hot-path accessor churn, canary + perf-backstop + verify-fast green. Watch CI; merge when green.
+
+---
+
+## Self-review notes (controller)
+
+- **Spec coverage:** Tasks 1-3 = class + move + wire; Task 4 = the ~40 hot-path sites; Tasks 5-6 = build + canary + perf backstop + degen battery; Task 7 = PR. The refined-scope boundary (hub stays) is encoded in which methods Task 2 reclasses.
+- **No `diff=0` task** — the spec explicitly drops it (hot path changes).
+- **Type consistency:** `ws_` accessor names (`shared()`, `persistent()`, `shared_max_tokens()`, `active()`) + the `configure_*_workspace`/`use_workspace`/`resize_workspace` method names are used consistently across Tasks 1, 3, 4.
+- **Gotcha:** the perl `(?!\w)` guard prevents `shared_workspace_` from clobbering `shared_workspace_size_`/`_max_tokens_`; if `shared_workspace_size_` is read in the hot path, add a `shared_size()` accessor (Task 4 Step 1 caveat). Keep `/tmp/*.bak`; plain substitutions only (no `do{<>}`).
+- **Risk:** workspace sizing is silent on failure — the perf backstop + MoE/SSM canary models are load-bearing, not optional.

--- a/docs/superpowers/specs/2026-06-08-workspace-component-design.md
+++ b/docs/superpowers/specs/2026-06-08-workspace-component-design.md
@@ -32,22 +32,41 @@ Two things that live in `executor_workspace*.cu` are NOT workspace and stay on
   classification (`model_->layer(i).moe_gate.data != nullptr`). Model territory
   (ModelProfile-adjacent), not workspace. Left in place.
 
-**In scope (moves into `Workspace`):** the buffer members + the allocation/sizing
-lifecycle —
-- members: `persistent_workspace_`(+size), `shared_workspace_`(+size,+max_tokens),
+**Boundary refinement (found while planning — keeps the move verbatim).**
+`executor_workspace_buffers.cu::allocate_auxiliary_buffers` (~870 lines) is a
+*cross-cutting buffer-allocation hub*: it allocates `qscratch_` (QuantScratch),
+the `moe_` (MoEWorkspace) buffers, `attn_scores_buf_`, `fp32_accum_buf_`, and
+`nvfp4_dequant_ws_buf_` together — those belong to the quant / MoE / attention
+concerns, not to "the workspace." Splitting that hub would be surgery on a
+god-method (exactly the silent-sizing-bug hazard). So it STAYS on GraphExecutor
+(its buffers go to their own components later). This also drops the
+`fp32_accum_buf_` (~23) and `attn_scores_buf_` (~7) hot-path churn.
+
+By contrast `executor_workspace.cu` allocates ONLY `shared_workspace_` and
+`persistent_workspace_` — the shared/persistent scratch arena IS cleanly
+separable. That is the `Workspace` component:
+
+**In scope (moves into `Workspace`):**
+- members: `shared_workspace_`(+size, +max_tokens), `persistent_workspace_`(+size),
   `attn_shared_size_`, `ffn_shared_size_`, `moe_shared_size_`, `ssm_shared_size_`,
-  `fp32_accum_buf_`, `attn_scores_buf_`(+size) + `attn_scores_` Tensor,
-  `nvfp4_dequant_ws_buf_`(+size), `decode_persistent_size_`, `decode_shared_size_`,
-  `active_workspace_`, `saved_prefill_ws_` (the `SavedWorkspace` swap state).
-- methods: `allocate_persistent_workspace`, `allocate_shared_workspace`,
-  `allocate_decode_workspace`, `allocate_auxiliary_buffers`, `allocate_workspaces`,
-  `compute_shared_sizes`, `configure_attn_workspace`, `configure_ffn_workspace`,
-  `configure_moe_workspace`, `configure_ssm_workspace`, `use_workspace`,
-  `resize_workspace`, `free_buffers` (workspace portion), `ensure_logits_pinned`,
-  `release_moe_batch_buf`, `workspace_estimate`.
+  `decode_persistent_size_`, `decode_shared_size_`, `decode_workspace_`,
+  `decode_shared_workspace_`, `active_workspace_`, `saved_prefill_ws_`
+  (the `SavedWorkspace` decode/prefill swap state).
+- methods (from `executor_workspace.cu` + `executor_workspace_config.cu`):
+  `compute_shared_sizes`, `allocate_persistent_workspace`,
+  `allocate_shared_workspace`, `allocate_decode_workspace`, `workspace_estimate`,
+  `configure_attn_workspace`, `configure_ffn_workspace`, `configure_moe_workspace`,
+  `configure_ssm_workspace`, `use_workspace`, `resize_workspace`.
+
+**Stays on GraphExecutor:** `allocate_auxiliary_buffers` + `free_buffers` (the
+cross-cutting alloc/free hub), `release_moe_batch_buf`, `ensure_logits_pinned`,
+and the buffers `qscratch_`, `moe_`, `attn_scores_buf_`, `fp32_accum_buf_`,
+`nvfp4_dequant_ws_buf_` (allocated by the hub; the hot path reads them as
+GraphExecutor members, unchanged). Also `view_tokens` + `layer_has_*` as above.
 
 The exact member/method set is finalized during implementation (build catches any
-straggler); this list is the cohesive cluster.
+straggler); `allocate_workspaces` (the orchestrator) stays on GraphExecutor and
+calls `ws_.allocate_*` for the workspace portion.
 
 ## Goal & constraints
 
@@ -70,20 +89,19 @@ Access pattern (zero overhead):
 ```cpp
 // Workspace exposes inline accessors; the hot path reads through them.
 void* shared() const { return shared_workspace_; }
-void* fp32_accum() const { return fp32_accum_buf_; }
-const Tensor& attn_scores() const { return attn_scores_; }
-// ... etc.
+void* persistent() const { return persistent_workspace_; }
+int shared_max_tokens() const { return shared_workspace_max_tokens_; }
+// ... configure_attn/ffn/moe/ssm(n), use_workspace(...), resize(...) as methods.
 ```
-Hot-path call sites change mechanically:
+Hot-path call sites change mechanically (the refined-scope set, ~40 sites):
 - `shared_workspace_` → `ws_.shared()` (~17 sites)
-- `fp32_accum_buf_` → `ws_.fp32_accum()` (~23 sites, 5 TUs — the gemma-4 fp32 path)
-- `attn_scores_buf_` / `attn_scores_` → `ws_.attn_scores*()` (~7 sites)
 - `configure_attn_workspace(n)` → `ws_.configure_attn(n)` (and ffn/moe/ssm) (~9)
-- `persistent_workspace_` / `use_workspace` / `resize_workspace` → `ws_.x()` (~10)
+- `persistent_workspace_` / `use_workspace` / `resize_workspace` /
+  `shared_workspace_max_tokens_` → `ws_.x()` (~14)
 
-`GraphExecutor` keeps a couple of thin accessors it already exposes publicly
-(`active_workspace()`, the attn-scores width getter at executor.h:190) — they
-delegate to `ws_`.
+`fp32_accum_buf_` and `attn_scores_buf_` are NOT moved (allocated by the hub that
+stays) — so their ~30 hot-path sites are untouched. `GraphExecutor` keeps its
+public `active_workspace()` getter as a thin delegate to `ws_`.
 
 ## Data flow
 

--- a/docs/superpowers/specs/2026-06-08-workspace-component-design.md
+++ b/docs/superpowers/specs/2026-06-08-workspace-component-design.md
@@ -1,0 +1,133 @@
+# Workspace component — D2 step 3 (first hot-path runner extraction)
+
+Date: 2026-06-08
+
+## Problem
+
+`GraphExecutor` owns the engine's scratch-memory management: ~13 buffer members
+(persistent + shared workspace pointers/sizes, the per-phase shared sizes, the
+fp32 accumulator, the attention-scores buffer, the NVFP4 dequant workspace, the
+decode/prefill workspace swap state) and ~25 methods in `executor_workspace*.cu`
+(`allocate_*`, `configure_*_workspace`, `compute_shared_sizes`, `use_workspace`,
+`resize_workspace`, `free_buffers`, `ensure_logits_pinned`,
+`release_moe_batch_buf`, `workspace_estimate`). This is the most-shared piece of
+GraphExecutor state, read all over the forward path.
+
+D2 step 3 extracts it into a `Workspace` class. Unlike the QuantPipeline
+extraction (init-time, hot path untouched, `diff=0`), **this touches the forward
+hot path**: the attention/ffn/moe/ssm/forward TUs read `shared_workspace_`,
+`fp32_accum_buf_`, `attn_scores_buf_` and call `configure_*_workspace()` — those
+become `ws_.x()` calls. The `diff=0` guarantee does not hold; correctness is
+canary-gated instead.
+
+## Scope (what the analysis settled)
+
+Two things that live in `executor_workspace*.cu` are NOT workspace and stay on
+`GraphExecutor`, which keeps the extraction clean and avoids needless churn:
+
+- **`view_tokens(buf, n)`** — a stateless one-liner (`return slice_rows(buf, n);`)
+  read 121× across 8 TUs. It carries no workspace state, so it stays a
+  GraphExecutor helper. Moving it would churn 121 hot-path sites for zero benefit.
+- **`layer_has_moe / _gdn / _ssm / _attention / _dense_ffn`** — per-layer model
+  classification (`model_->layer(i).moe_gate.data != nullptr`). Model territory
+  (ModelProfile-adjacent), not workspace. Left in place.
+
+**In scope (moves into `Workspace`):** the buffer members + the allocation/sizing
+lifecycle —
+- members: `persistent_workspace_`(+size), `shared_workspace_`(+size,+max_tokens),
+  `attn_shared_size_`, `ffn_shared_size_`, `moe_shared_size_`, `ssm_shared_size_`,
+  `fp32_accum_buf_`, `attn_scores_buf_`(+size) + `attn_scores_` Tensor,
+  `nvfp4_dequant_ws_buf_`(+size), `decode_persistent_size_`, `decode_shared_size_`,
+  `active_workspace_`, `saved_prefill_ws_` (the `SavedWorkspace` swap state).
+- methods: `allocate_persistent_workspace`, `allocate_shared_workspace`,
+  `allocate_decode_workspace`, `allocate_auxiliary_buffers`, `allocate_workspaces`,
+  `compute_shared_sizes`, `configure_attn_workspace`, `configure_ffn_workspace`,
+  `configure_moe_workspace`, `configure_ssm_workspace`, `use_workspace`,
+  `resize_workspace`, `free_buffers` (workspace portion), `ensure_logits_pinned`,
+  `release_moe_batch_buf`, `workspace_estimate`.
+
+The exact member/method set is finalized during implementation (build catches any
+straggler); this list is the cohesive cluster.
+
+## Goal & constraints
+
+- Extract `Workspace` into `src/exec/workspace.h` (+ the existing
+  `executor_workspace*.cu` become `Workspace::` methods).
+- **Behaviour-neutral**, **zero hot-path overhead**: the forward path reads buffers
+  through `inline` accessors (`ws_.shared()`, `ws_.fp32_accum()`,
+  `ws_.attn_scores()`, …) that compile to the same member load.
+- The `diff=0` hot-path check does NOT apply (the forward TUs change). Gated by the
+  4-arch coherence canary + verify-fast + a decode-perf backstop.
+
+## Architecture
+
+`GraphExecutor` owns `Workspace ws_;`. `Workspace` gets the inputs it needs
+(`const Model*`, `VRAMAllocator*`, `const RuntimeConfig*`, plus the
+`compute_dtype_` / `max_tokens_` it sizes against) via an `init(...)` call from
+`GraphExecutor::init`, mirroring the QuantPipeline pointer-context pattern.
+
+Access pattern (zero overhead):
+```cpp
+// Workspace exposes inline accessors; the hot path reads through them.
+void* shared() const { return shared_workspace_; }
+void* fp32_accum() const { return fp32_accum_buf_; }
+const Tensor& attn_scores() const { return attn_scores_; }
+// ... etc.
+```
+Hot-path call sites change mechanically:
+- `shared_workspace_` → `ws_.shared()` (~17 sites)
+- `fp32_accum_buf_` → `ws_.fp32_accum()` (~23 sites, 5 TUs — the gemma-4 fp32 path)
+- `attn_scores_buf_` / `attn_scores_` → `ws_.attn_scores*()` (~7 sites)
+- `configure_attn_workspace(n)` → `ws_.configure_attn(n)` (and ffn/moe/ssm) (~9)
+- `persistent_workspace_` / `use_workspace` / `resize_workspace` → `ws_.x()` (~10)
+
+`GraphExecutor` keeps a couple of thin accessors it already exposes publicly
+(`active_workspace()`, the attn-scores width getter at executor.h:190) — they
+delegate to `ws_`.
+
+## Data flow
+
+Init: `GraphExecutor::init` → `ws_.init(model, alloc, rcfg, compute_dtype, max_tokens)`
+→ `ws_.allocate_workspaces(...)`. Forward: each phase calls
+`ws_.configure_<phase>(n)` at its top (as today) and reads buffers via the inline
+accessors. Teardown: `ws_.free_buffers()` from `GraphExecutor::free_buffers`.
+
+## Error handling
+
+Unchanged — allocation failures throw / log exactly as today; no status-return
+conversion.
+
+## Testing
+
+- `make build` clean.
+- **4-arch coherence canary** (the behaviour gate, since hot path changed):
+  Qwen3-8B Q8_0 (dense), Qwen3-30B-A3B-NVFP4 (MoE — exercises moe workspace),
+  Nemotron-3-Nano-30B (SSM/GDN — exercises ssm workspace), gemma-3-12b (dense
+  gemma) — each coherent (Paris), no `CUDA error / falling back / NaN`. The
+  Qwen3-30B native-MoE-cache count must still match main (144).
+- **Decode-perf backstop**: Qwen3-8B Q8_0 `tg` within noise of main (a mis-sized
+  workspace silently degrades perf or forces a fallback). Warm, isolated single
+  compare; flag if >5% down.
+- `make verify-fast` gtest filter green.
+- (No `diff=0` check — the forward TUs intentionally change.)
+
+## Out of scope
+
+- `view_tokens` (stays a GraphExecutor helper) and `layer_has_*` (model
+  classification, stays).
+- Any other component (MoeRunner, Attention/Ffn/Ssm runners).
+- Splitting the `attn_scores`/`fp32_accum` buffers' *allocation policy* — moved
+  verbatim, not redesigned.
+
+## Risks
+
+- **Larger, hot-path churn (~66 sites).** Mechanical, but unlike a verbatim move a
+  wrong accessor (e.g. returning the wrong buffer) compiles fine and fails at
+  runtime. Mitigation: the accessor returns the exact same member; the 4-arch
+  canary + perf backstop catch divergence. Per-TU, build between.
+- **Workspace sizing bugs are silent** — manifest as IMA / OOM / perf regression,
+  not compile errors. Mitigation: the methods move verbatim (no sizing-logic
+  edits); the MoE + SSM canary models exercise the moe/ssm workspace paths; the
+  perf backstop catches a silent fallback.
+- **Init ordering** — `ws_.init` must run where `allocate_workspaces` runs today
+  (after model load, before the first forward). Mirror the current call site.

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -20,6 +20,7 @@
 #include "exec/moe_workspace.h"
 #include "exec/quant_scratch.h"
 #include "exec/quant_pipeline.h"
+#include "exec/workspace.h"
 #include "runtime/storage_planner.h"
 #include "runtime/vram_budget.h"
 #include "runtime/config.h"
@@ -75,7 +76,7 @@ public:
 
     // Estimated GPU memory needed by allocate_workspaces().
     // Used by Engine to compute the expert upload reserve.
-    size_t workspace_estimate() const;
+    size_t workspace_estimate() const { return ws_.workspace_estimate(); }
 
     // Run the full forward pass and return the sampled token ID.
     int32_t forward(const InferenceState& state, cudaStream_t stream = nullptr);
@@ -172,15 +173,19 @@ public:
 
     // Resize workspace for a different max token count (Phase 4: decode-mode optimization).
     // Uses cudaFreeAsync/cudaMallocAsync for near-instant resize via CUDA memory pool.
-    [[nodiscard]] bool resize_workspace(int new_max_tokens, cudaStream_t stream);
+    [[nodiscard]] bool resize_workspace(int new_max_tokens, cudaStream_t stream) {
+        return ws_.resize_workspace(new_max_tokens, stream);
+    }
 
     // Dual workspace for concurrent prefill/decode overlap.
     // allocate_decode_workspace: creates a second workspace for decode (up to max_batch tokens).
     // use_workspace(0) = prefill (default), use_workspace(1) = decode.
-    bool allocate_decode_workspace(cudaStream_t stream, int max_batch = 1);
-    void use_workspace(int slot);  // 0=prefill, 1=decode
-    bool has_decode_workspace() const { return decode_workspace_ != nullptr; }
-    int active_workspace() const { return active_workspace_; }
+    bool allocate_decode_workspace(cudaStream_t stream, int max_batch = 1) {
+        return ws_.allocate_decode_workspace(stream, max_batch);
+    }
+    void use_workspace(int slot) { ws_.use_workspace(slot); }  // 0=prefill, 1=decode
+    bool has_decode_workspace() const { return ws_.has_decode_workspace(); }
+    int active_workspace() const { return ws_.active(); }
     int max_tokens() const { return max_tokens_; }
 
     // Capacity of the [n_heads, attn_seq, attn_seq] FP16 attn-scores workspace.
@@ -283,11 +288,13 @@ private:
     // attribute set so the GPU can overlap tail of one kernel with head of next.
     bool use_pdl_ = false;
 
-    // --- Persistent GPU workspace (always valid, not reconfigured) ---
-    void* persistent_workspace_ = nullptr;
-    size_t persistent_workspace_size_ = 0;
+    // --- Scratch arena (shared/persistent/decode workspace) ---
+    // Owns the workspace buffers + sizes + the decode/prefill swap state; the
+    // moved methods write the activation/phase tensors below through pointers
+    // set in ws_.init() (called from GraphExecutor::init). See exec/workspace.h.
+    Workspace ws_;
 
-    // Persistent activation tensors (views into persistent_workspace_)
+    // Persistent activation tensors (views into the persistent workspace)
     Tensor hidden_;    // [max_tokens, d_model] FP16
     Tensor residual_;  // [max_tokens, d_model] FP16
     Tensor norm_out_;  // [max_tokens, d_model] FP16
@@ -301,20 +308,11 @@ private:
     void* fp32_accum_buf_ = nullptr;
     Tensor fp32_hidden_;  // [max_tokens, d_model] FP32 — true hidden state
 
-    // --- Shared GPU workspace (reconfigured per layer phase) ---
-    // Sized to max(attn_size, ffn_size, moe_size, ssm_size).
-    // Tensor views are set up at the start of each run_* function.
-    void* shared_workspace_ = nullptr;
-    size_t shared_workspace_size_ = 0;
-    int shared_workspace_max_tokens_ = 0;  // token count used for current allocation
+    // The shared/persistent workspace buffers + per-phase sizes moved into ws_.
+    // The phase TENSORS below are views the moved ws_ methods carve (via the
+    // pointers wired in ws_.init); the hot path reads them as members.
 
-    // Pre-computed phase sizes (for max_tokens_)
-    size_t attn_shared_size_ = 0;
-    size_t ffn_shared_size_ = 0;
-    size_t moe_shared_size_ = 0;
-    size_t ssm_shared_size_ = 0;
-
-    // Attention phase tensors (views into shared_workspace_, set by configure_attn_workspace)
+    // Attention phase tensors (views into the shared workspace, set by ws_.configure_attn_workspace)
     Tensor q_;         // [max_tokens, n_heads * head_dim]
     Tensor k_;         // [max_tokens, n_kv_heads * head_dim]
     Tensor v_;         // [max_tokens, n_kv_heads * head_dim]
@@ -435,28 +433,9 @@ private:
     // Max expert FFN hidden dim from actual packed tensor shapes (may differ from cfg.expert_d_ff)
     int max_expert_eff_ = 0;
 
-    // --- Dual workspace for concurrent prefill/decode overlap ---
-    // Slot 0 (default): main workspace (prefill, sized for max_tokens)
-    // Slot 1: decode workspace (sized for up to decode_max_batch_ tokens)
-    void* decode_workspace_ = nullptr;         // persistent buf for decode
-    void* decode_shared_workspace_ = nullptr;  // shared buf for decode
-    size_t decode_persistent_size_ = 0;
-    size_t decode_shared_size_ = 0;
-    int decode_max_batch_ = 1;  // max decode batch size this workspace supports
-    int active_workspace_ = 0;
-
-    // Saved prefill workspace pointers (restored when switching back)
-    struct SavedWorkspace {
-        void* persistent;
-        size_t persistent_size;
-        void* shared;
-        size_t shared_size;
-        int shared_max_tokens;
-        Tensor hidden, residual, norm_out, logits;
-        void* fp32_accum;
-        Tensor fp32_hidden;
-    };
-    SavedWorkspace saved_prefill_ws_;
+    // The dual prefill/decode workspace swap state (decode_workspace_,
+    // decode_shared_workspace_, the sizes, decode_max_batch_, active_workspace_,
+    // SavedWorkspace saved_prefill_ws_) moved into ws_ (exec/workspace.h).
 
     // --- Layer offload manager (non-owning, set by engine) ---
     LayerOffloadManager* offload_mgr_ = nullptr;
@@ -467,22 +446,14 @@ private:
     const RuntimeConfig* runtime_config_ = nullptr;
 
     // --- Allocation and configuration methods ---
+    // The shared/persistent/decode scratch arena (allocate_*_workspace,
+    // compute_shared_sizes, configure_*_workspace, workspace_estimate,
+    // resize_workspace, allocate_decode_workspace, use_workspace) moved into
+    // Workspace (exec/workspace.h); GraphExecutor owns ws_ and delegates.
 
-    [[nodiscard]] bool allocate_persistent_workspace(int max_tokens);
-    [[nodiscard]] bool allocate_shared_workspace(int max_tokens);
     void allocate_auxiliary_buffers(
         bool skip_batch_dequant = false);  // dequant scratch, MoE staging, routing buffers
     void free_buffers();
-
-    // Compute shared workspace sizes for each phase (stored in *_shared_size_ members)
-    void compute_shared_sizes(int max_tokens);
-
-    // Configure tensor views into shared_workspace_ for each phase.
-    // Called at the start of each run_* function. Pure pointer arithmetic, no allocation.
-    void configure_attn_workspace(int max_tokens);
-    void configure_ffn_workspace(int max_tokens);
-    void configure_moe_workspace(int max_tokens);
-    void configure_ssm_workspace(int max_tokens);
 
     // Per-layer helpers
     void run_attention(int layer, const InferenceState& state, cudaStream_t stream);

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -308,11 +308,12 @@ private:
     void* fp32_accum_buf_ = nullptr;
     Tensor fp32_hidden_;  // [max_tokens, d_model] FP32 — true hidden state
 
-    // The shared/persistent workspace buffers + per-phase sizes moved into ws_.
-    // The phase TENSORS below are views the moved ws_ methods carve (via the
-    // pointers wired in ws_.init); the hot path reads them as members.
+    // The shared/persistent workspace buffers + per-phase sizes live in ws_.
+    // The phase TENSORS below are views carved by GraphExecutor's
+    // configure_*_workspace methods (which slice ws_.shared()); the hot path
+    // reads them as members.
 
-    // Attention phase tensors (views into the shared workspace, set by ws_.configure_attn_workspace)
+    // Attention phase tensors (views into the shared workspace, set by configure_attn_workspace)
     Tensor q_;         // [max_tokens, n_heads * head_dim]
     Tensor k_;         // [max_tokens, n_kv_heads * head_dim]
     Tensor v_;         // [max_tokens, n_kv_heads * head_dim]
@@ -447,9 +448,17 @@ private:
 
     // --- Allocation and configuration methods ---
     // The shared/persistent/decode scratch arena (allocate_*_workspace,
-    // compute_shared_sizes, configure_*_workspace, workspace_estimate,
-    // resize_workspace, allocate_decode_workspace, use_workspace) moved into
-    // Workspace (exec/workspace.h); GraphExecutor owns ws_ and delegates.
+    // compute_shared_sizes, workspace_estimate, resize_workspace,
+    // allocate_decode_workspace, use_workspace) moved into Workspace
+    // (exec/workspace.h); GraphExecutor owns ws_ and delegates.
+    //
+    // The four per-phase carvers stay here: they write GraphExecutor's
+    // activation-tensor members (q_/k_/v_/.../gdn_fused_proj_buf_) by slicing
+    // the shared buffer (read via ws_.shared()), so they belong on GraphExecutor.
+    void configure_attn_workspace(int max_tokens);
+    void configure_ffn_workspace(int max_tokens);
+    void configure_moe_workspace(int max_tokens);
+    void configure_ssm_workspace(int max_tokens);
 
     void allocate_auxiliary_buffers(
         bool skip_batch_dequant = false);  // dequant scratch, MoE staging, routing buffers

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -180,7 +180,7 @@ static void clear_l2_persist(cudaStream_t stream) { clear_l2_policy(stream); }
 
 void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaStream_t stream) {
     // Configure shared workspace for attention phase
-    ws_.configure_attn_workspace(ws_.shared_max_tokens());
+    configure_attn_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& prof = model_->profile();

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -180,7 +180,7 @@ static void clear_l2_persist(cudaStream_t stream) { clear_l2_policy(stream); }
 
 void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaStream_t stream) {
     // Configure shared workspace for attention phase
-    configure_attn_workspace(shared_workspace_max_tokens_);
+    ws_.configure_attn_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& prof = model_->profile();
@@ -256,7 +256,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
 
     // For Qwen3.5 attention output gate: allocate larger Q buffer AFTER all
     // standard attention buffers to avoid overlap (q_/k_/v_/attn_out_/proj_out_
-    // all share the same shared_workspace_ memory).
+    // all share the same ws_.shared() memory).
     Tensor qv_full;
     if (has_attn_output_gate) {
         auto align256 = [](size_t x) -> size_t { return (x + 255) & ~size_t(255); };

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -34,7 +34,7 @@ namespace imp {
 
 void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
     // Configure shared workspace for dense FFN phase
-    configure_ffn_workspace(shared_workspace_max_tokens_);
+    ws_.configure_ffn_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -34,7 +34,7 @@ namespace imp {
 
 void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
     // Configure shared workspace for dense FFN phase
-    ws_.configure_ffn_workspace(ws_.shared_max_tokens());
+    configure_ffn_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -102,7 +102,7 @@ static bool can_decode_fast(int n, const Tensor& expert_up_packed, QType up_qtyp
 
 void GraphExecutor::moe_ffn_phase1_setup_(int layer, cudaStream_t stream) {
     // Configure shared workspace for MoE phase
-    configure_moe_workspace(shared_workspace_max_tokens_);
+    ws_.configure_moe_workspace(ws_.shared_max_tokens());
 
     // Phase 4 (MoE host-offload async prefetch). The cache is only initialised
     // when some experts are host-resident; n_slots_ > 0 is therefore the

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -102,7 +102,7 @@ static bool can_decode_fast(int n, const Tensor& expert_up_packed, QType up_qtyp
 
 void GraphExecutor::moe_ffn_phase1_setup_(int layer, cudaStream_t stream) {
     // Configure shared workspace for MoE phase
-    ws_.configure_moe_workspace(ws_.shared_max_tokens());
+    configure_moe_workspace(ws_.shared_max_tokens());
 
     // Phase 4 (MoE host-offload async prefetch). The cache is only initialised
     // when some experts are host-resident; n_slots_ > 0 is therefore the

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -376,7 +376,7 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         }
     }
     imp::gemm_dispatch(nullptr, h, input, output, 1.0f, ctx.beta,
-                       shared_workspace_, shared_workspace_size_, ctx.stream);
+                       ws_.shared(), ws_.shared_size(), ctx.stream);
 }
 
 }  // namespace imp

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -39,7 +39,7 @@ static inline int get_ssm_layer(const std::vector<int>& ssm_layer_map, int layer
 
 void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t stream) {
     // Configure shared workspace for SSM phase
-    ws_.configure_ssm_workspace(ws_.shared_max_tokens());
+    configure_ssm_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);
@@ -256,7 +256,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
 // ---------------------------------------------------------------------------
 
 void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t stream) {
-    ws_.configure_ssm_workspace(ws_.shared_max_tokens());
+    configure_ssm_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -39,7 +39,7 @@ static inline int get_ssm_layer(const std::vector<int>& ssm_layer_map, int layer
 
 void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t stream) {
     // Configure shared workspace for SSM phase
-    configure_ssm_workspace(shared_workspace_max_tokens_);
+    ws_.configure_ssm_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);
@@ -256,7 +256,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
 // ---------------------------------------------------------------------------
 
 void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t stream) {
-    configure_ssm_workspace(shared_workspace_max_tokens_);
+    ws_.configure_ssm_workspace(ws_.shared_max_tokens());
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -134,9 +134,19 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
     // - Decode:  n_sequences (one per batch slot)
     max_logit_tokens_ = std::max(max_batch_size, 1);
 
+    // Wire the scratch-arena component with the live context it sizes against
+    // (pointers to GraphExecutor members so e.g. has_gdn_ is read live — still
+    // false here, set true below — and the activation/phase tensors the moved
+    // methods carve stay GraphExecutor-owned).
+    ws_.init(model, vram_alloc_, compute_dtype_, &max_tokens_, use_pdl_, moe_, &has_moe_, &has_ssm_,
+             &has_gdn_, &has_dense_ffn_, &max_expert_eff_, &max_logit_tokens_, &hidden_, &residual_,
+             &norm_out_, &logits_, &fp32_accum_buf_, &fp32_hidden_, &q_, &k_, &v_, &attn_out_, &proj_out_,
+             &gate_out_, &up_out_, &swiglu_out_, &ffn_out_, &ssm_proj_buf_, &ssm_xBC_buf_, &ssm_y_buf_,
+             &ssm_z_buf_, &ssm_out_buf_, &ssm_dt_buf_, &gdn_fused_proj_buf_);
+
     // Compute shared workspace sizes (no allocation — deferred to allocate_workspaces()).
     // Deferring GPU allocation maximizes VRAM available for expert weight upload.
-    compute_shared_sizes(max_tokens_);
+    ws_.compute_shared_sizes(max_tokens_);
 
     // Build SSM layer index mapping
     if (has_ssm_) {
@@ -256,11 +266,11 @@ bool GraphExecutor::allocate_workspaces(bool experts_on_host) {
     if (!initialized_ || !model_)
         return false;
 
-    if (!allocate_persistent_workspace(max_tokens_)) {
+    if (!ws_.allocate_persistent_workspace(max_tokens_)) {
         IMP_LOG_ERROR("Persistent workspace allocation failed — cannot run inference");
         return false;
     }
-    if (!allocate_shared_workspace(max_tokens_)) {
+    if (!ws_.allocate_shared_workspace(max_tokens_)) {
         IMP_LOG_ERROR("Shared workspace allocation failed — cannot run inference");
         return false;
     }
@@ -509,8 +519,21 @@ bool Workspace::allocate_shared_workspace(int max_tokens) {
     return true;
 }
 
-// allocate_auxiliary_buffers(), release_moe_batch_buf(), free_buffers()
-// are in executor_workspace_buffers.cu
+void Workspace::free_buffers() {
+    if (shared_workspace_) {
+        vram_free(vram_alloc_, shared_workspace_);
+        shared_workspace_ = nullptr;
+    }
+    shared_workspace_size_ = 0;
+    if (persistent_workspace_) {
+        vram_free(vram_alloc_, persistent_workspace_);
+        persistent_workspace_ = nullptr;
+    }
+    persistent_workspace_size_ = 0;
+}
+
+// GraphExecutor::allocate_auxiliary_buffers(), release_moe_batch_buf(),
+// free_buffers() are in executor_workspace_buffers.cu
 
 // pre_dequant_weights() is in executor_pre_dequant.cu
 // configure_*_workspace(), resize_workspace(), allocate_decode_workspace(),

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -1,4 +1,5 @@
 #include "exec/executor.h"
+#include "exec/workspace.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
 #include "compute/embedding.h"
@@ -274,7 +275,7 @@ bool GraphExecutor::allocate_workspaces(bool experts_on_host) {
     return true;
 }
 
-size_t GraphExecutor::workspace_estimate() const {
+size_t Workspace::workspace_estimate() const {
     if (!model_)
         return 0;
     const auto& cfg = model_->config();
@@ -282,8 +283,8 @@ size_t GraphExecutor::workspace_estimate() const {
     size_t es = dtype_size(compute_dtype_);
 
     // Persistent: hidden + residual + norm_out + logits
-    size_t persistent = 3 * align256(static_cast<size_t>(max_tokens_) * d * es) +
-                        align256(static_cast<size_t>(max_logit_tokens_) * cfg.vocab_size * sizeof(float));
+    size_t persistent = 3 * align256(static_cast<size_t>(*max_tokens_) * d * es) +
+                        align256(static_cast<size_t>(*max_logit_tokens_) * cfg.vocab_size * sizeof(float));
 
     // Shared: max of phases (already computed in compute_shared_sizes)
     size_t shared = std::max({attn_shared_size_, ffn_shared_size_, moe_shared_size_, ssm_shared_size_});
@@ -294,7 +295,7 @@ size_t GraphExecutor::workspace_estimate() const {
 
     // FP32 accumulator for post-norm models (Gemma-3): 1 × max_tokens × d_model × 4
     bool has_post_norms = (cfg.norm_placement == NormPlacement::POST_NORM);
-    size_t fp32_accum = has_post_norms ? align256(static_cast<size_t>(max_tokens_) * d * sizeof(float)) : 0;
+    size_t fp32_accum = has_post_norms ? align256(static_cast<size_t>(*max_tokens_) * d * sizeof(float)) : 0;
 
     // Auxiliary: compute real estimate from individual buffer sizes
     size_t auxiliary = 0;
@@ -318,7 +319,7 @@ size_t GraphExecutor::workspace_estimate() const {
     int hd_est = cfg.head_dim > 0 ? cfg.head_dim : (d / nh_est);
     auxiliary += 16 * 1024;   // sampling
     auxiliary += 256 * 1024;  // MMVQ scratch (conservative)
-    auxiliary += static_cast<size_t>(max_logit_tokens_) * nh_est * 32 * (2 + hd_est) *
+    auxiliary += static_cast<size_t>(*max_logit_tokens_) * nh_est * 32 * (2 + hd_est) *
                  sizeof(float);  // split-K
 
     // S-matrix for cuBLAS attention fallback — only needed when CUTLASS FMHA
@@ -327,7 +328,7 @@ size_t GraphExecutor::workspace_estimate() const {
     // doesn't need the S-matrix. This saves up to 256 MiB.
     bool is_moe = (cfg.n_experts > 0 && cfg.n_experts_active > 0);
     if (!is_moe) {
-        auxiliary += std::min(static_cast<size_t>(nh_est) * max_tokens_ * max_tokens_ * sizeof(half),
+        auxiliary += std::min(static_cast<size_t>(nh_est) * *max_tokens_ * *max_tokens_ * sizeof(half),
                               static_cast<size_t>(256) << 20);
     }
 
@@ -341,7 +342,7 @@ size_t GraphExecutor::workspace_estimate() const {
 // Unified workspace allocation
 // ---------------------------------------------------------------------------
 
-void GraphExecutor::compute_shared_sizes(int max_tokens) {
+void Workspace::compute_shared_sizes(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int ff = cfg.d_ff;
@@ -373,7 +374,7 @@ void GraphExecutor::compute_shared_sizes(int max_tokens) {
                              : 0);
 
     // Dense FFN phase: gate, up, swiglu, ffn_out
-    if (has_dense_ffn_ && ff > 0) {
+    if (*has_dense_ffn_ && ff > 0) {
         ffn_shared_size_ = align256(static_cast<size_t>(max_tokens) * ff * es)    // gate_out
                            + align256(static_cast<size_t>(max_tokens) * ff * es)  // up_out
                            + align256(static_cast<size_t>(max_tokens) * ff * es)  // swiglu_out
@@ -381,10 +382,10 @@ void GraphExecutor::compute_shared_sizes(int max_tokens) {
     }
 
     // MoE phase
-    if (has_moe_) {
+    if (*has_moe_) {
         int ne = cfg.n_experts;
         int top_k = cfg.n_experts_active;
-        int eff = max_expert_eff_;
+        int eff = *max_expert_eff_;
         int expanded = max_tokens * top_k;
 
         moe_shared_size_ = align256(static_cast<size_t>(max_tokens) * ne * sizeof(float))    // gate_logits
@@ -397,7 +398,7 @@ void GraphExecutor::compute_shared_sizes(int max_tokens) {
     }
 
     // SSM phase
-    if (has_ssm_) {
+    if (*has_ssm_) {
         int inner = cfg.ssm_inner_size;
         int n_groups = cfg.ssm_group_count;
         int state_size = cfg.ssm_state_size;
@@ -405,7 +406,7 @@ void GraphExecutor::compute_shared_sizes(int max_tokens) {
         int conv_channels = inner + 2 * n_groups * state_size;
         int ssm_in_dim = inner + conv_channels + n_heads;
 
-        size_t proj_elem_size = has_gdn_ ? sizeof(float) : es;
+        size_t proj_elem_size = *has_gdn_ ? sizeof(float) : es;
         int fused_total_out = conv_channels + inner + 2 * n_heads;
         ssm_shared_size_ = align256(static_cast<size_t>(max_tokens) * ssm_in_dim *
                                     proj_elem_size)  // proj (FP32 for GDN)
@@ -413,14 +414,14 @@ void GraphExecutor::compute_shared_sizes(int max_tokens) {
                            + align256(static_cast<size_t>(max_tokens) * inner * es)          // y
                            + align256(static_cast<size_t>(max_tokens) * inner * es)          // z
                            + align256(static_cast<size_t>(max_tokens) * d * es)              // out
-                           + align256(static_cast<size_t>(max_tokens) * n_heads * (has_gdn_ ? 2 : 1) *
+                           + align256(static_cast<size_t>(max_tokens) * n_heads * (*has_gdn_ ? 2 : 1) *
                                       es)  // dt (2x for GDN: alpha + beta)
-                           + (has_gdn_ ? align256(static_cast<size_t>(max_tokens) * fused_total_out * es)
+                           + (*has_gdn_ ? align256(static_cast<size_t>(max_tokens) * fused_total_out * es)
                                        : 0);  // gdn_fused_proj (only on GDN models)
     }
 }
 
-bool GraphExecutor::allocate_persistent_workspace(int max_tokens) {
+bool Workspace::allocate_persistent_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int v = cfg.vocab_size;
@@ -429,7 +430,7 @@ bool GraphExecutor::allocate_persistent_workspace(int max_tokens) {
     size_t hidden_sz = align256(static_cast<size_t>(max_tokens) * d * es);
     size_t residual_sz = align256(static_cast<size_t>(max_tokens) * d * es);
     size_t norm_out_sz = align256(static_cast<size_t>(max_tokens) * d * es);
-    size_t logits_sz = align256(static_cast<size_t>(max_logit_tokens_) * v * sizeof(float));
+    size_t logits_sz = align256(static_cast<size_t>(*max_logit_tokens_) * v * sizeof(float));
 
     size_t total = hidden_sz + residual_sz + norm_out_sz + logits_sz;
 
@@ -442,13 +443,13 @@ bool GraphExecutor::allocate_persistent_workspace(int max_tokens) {
 
     char* ptr = static_cast<char*>(persistent_workspace_);
 
-    hidden_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d, hidden_sz);
-    residual_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d, residual_sz);
-    norm_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d, norm_out_sz);
+    (*hidden_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d, hidden_sz);
+    (*residual_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d, residual_sz);
+    (*norm_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d, norm_out_sz);
 
     {
-        int64_t shape[2] = {static_cast<int64_t>(max_logit_tokens_), static_cast<int64_t>(v)};
-        logits_ = Tensor(ptr, QType::F32, 2, shape, true);
+        int64_t shape[2] = {static_cast<int64_t>(*max_logit_tokens_), static_cast<int64_t>(v)};
+        (*logits_) = Tensor(ptr, QType::F32, 2, shape, true);
         ptr += logits_sz;
     }
 
@@ -457,10 +458,10 @@ bool GraphExecutor::allocate_persistent_workspace(int max_tokens) {
     // FP32 residual accumulator for post-norm architectures (Gemma-3).
     if (cfg.norm_placement == NormPlacement::POST_NORM) {
         size_t fp32_sz = align256(static_cast<size_t>(max_tokens) * d * sizeof(float));
-        cudaError_t e2 = cudaMalloc(&fp32_accum_buf_, fp32_sz);
+        cudaError_t e2 = cudaMalloc(&(*fp32_accum_buf_), fp32_sz);
         if (e2 == cudaSuccess) {
             int64_t shape[2] = {static_cast<int64_t>(max_tokens), static_cast<int64_t>(d)};
-            fp32_hidden_ = Tensor(fp32_accum_buf_, QType::F32, 2, shape, true);
+            (*fp32_hidden_) = Tensor((*fp32_accum_buf_), QType::F32, 2, shape, true);
             IMP_LOG_INFO("FP32 residual accumulator: %.2f MiB (post-norm architecture)",
                          fp32_sz / (1024.0 * 1024.0));
         } else {
@@ -471,7 +472,7 @@ bool GraphExecutor::allocate_persistent_workspace(int max_tokens) {
     return true;
 }
 
-bool GraphExecutor::allocate_shared_workspace(int max_tokens) {
+bool Workspace::allocate_shared_workspace(int max_tokens) {
     size_t max_shared = std::max({attn_shared_size_, ffn_shared_size_, moe_shared_size_, ssm_shared_size_});
     if (max_shared == 0)
         return true;  // no workspace needed
@@ -501,9 +502,9 @@ bool GraphExecutor::allocate_shared_workspace(int max_tokens) {
             (1024.0 * 1024.0));
 
     // Pre-allocate MoE routing buffers (separate from shared workspace)
-    if (has_moe_) {
+    if (*has_moe_) {
         const auto& cfg = model_->config();
-        moe_.routing_buffers.allocate(max_tokens, cfg.n_experts, cfg.n_experts_active);
+        moe_->routing_buffers.allocate(max_tokens, cfg.n_experts, cfg.n_experts_active);
     }
     return true;
 }

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -138,11 +138,9 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
     // (pointers to GraphExecutor members so e.g. has_gdn_ is read live — still
     // false here, set true below — and the activation/phase tensors the moved
     // methods carve stay GraphExecutor-owned).
-    ws_.init(model, vram_alloc_, compute_dtype_, &max_tokens_, use_pdl_, moe_, &has_moe_, &has_ssm_,
-             &has_gdn_, &has_dense_ffn_, &max_expert_eff_, &max_logit_tokens_, &hidden_, &residual_,
-             &norm_out_, &logits_, &fp32_accum_buf_, &fp32_hidden_, &q_, &k_, &v_, &attn_out_, &proj_out_,
-             &gate_out_, &up_out_, &swiglu_out_, &ffn_out_, &ssm_proj_buf_, &ssm_xBC_buf_, &ssm_y_buf_,
-             &ssm_z_buf_, &ssm_out_buf_, &ssm_dt_buf_, &gdn_fused_proj_buf_);
+    ws_.init(model, vram_alloc_, compute_dtype_, &max_tokens_, moe_, &has_moe_, &has_ssm_, &has_gdn_,
+             &has_dense_ffn_, &max_expert_eff_, &max_logit_tokens_, &hidden_, &residual_, &norm_out_,
+             &logits_, &fp32_accum_buf_, &fp32_hidden_);
 
     // Compute shared workspace sizes (no allocation — deferred to allocate_workspaces()).
     // Deferring GPU allocation maximizes VRAM available for expert weight upload.

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1082,10 +1082,7 @@ void GraphExecutor::free_buffers() {
     }
     vfree(attn_scores_buf_);
     attn_scores_buf_size_ = 0;
-    vfree(shared_workspace_);
-    shared_workspace_size_ = 0;
-    vfree(persistent_workspace_);
-    persistent_workspace_size_ = 0;
+    ws_.free_buffers();  // shared + persistent workspace (Workspace-owned)
     vfree(fp32_accum_buf_);
     ssm_layer_map_.clear();
     initialized_ = false;

--- a/src/exec/executor_workspace_config.cu
+++ b/src/exec/executor_workspace_config.cu
@@ -14,7 +14,7 @@ namespace imp {
 // Shared workspace configuration (pure pointer arithmetic, no allocation)
 // ---------------------------------------------------------------------------
 
-void Workspace::configure_attn_workspace(int max_tokens) {
+void GraphExecutor::configure_attn_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int nh = cfg.n_heads;
@@ -22,73 +22,73 @@ void Workspace::configure_attn_workspace(int max_tokens) {
     int hd = cfg.head_dim > 0 ? cfg.head_dim : (d / nh);
     size_t es = dtype_size(compute_dtype_);
 
-    char* ptr = static_cast<char*>(shared_workspace_);
+    char* ptr = static_cast<char*>(ws_.shared());
 
-    (*q_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
+    q_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
                                align256(static_cast<size_t>(max_tokens) * nh * hd * es));
     // K and V are contiguous (no alignment gap) to enable strided batched GEMM.
-    // (*v_).data == (*k_).data + kv_raw exactly, so output_stride = kv_raw / es.
+    // v_.data == k_.data + kv_raw exactly, so output_stride = kv_raw / es.
     {
         size_t kv_raw = static_cast<size_t>(max_tokens) * nkv * hd * es;
         int64_t kv_shape[2] = {static_cast<int64_t>(max_tokens), static_cast<int64_t>(nkv * hd)};
-        (*k_) = Tensor(ptr, compute_dtype_, 2, kv_shape, true);
-        (*v_) = Tensor(ptr + kv_raw, compute_dtype_, 2, kv_shape, true);
+        k_ = Tensor(ptr, compute_dtype_, 2, kv_shape, true);
+        v_ = Tensor(ptr + kv_raw, compute_dtype_, 2, kv_shape, true);
         ptr += align256(2 * kv_raw);
     }
-    (*attn_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
+    attn_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
                                       align256(static_cast<size_t>(max_tokens) * nh * hd * es));
-    (*proj_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
+    proj_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
                                       align256(static_cast<size_t>(max_tokens) * d * es));
 }
 
-void Workspace::configure_ffn_workspace(int max_tokens) {
+void GraphExecutor::configure_ffn_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int ff = cfg.d_ff;
     size_t es = dtype_size(compute_dtype_);
 
-    char* ptr = static_cast<char*>(shared_workspace_);
+    char* ptr = static_cast<char*>(ws_.shared());
 
-    (*gate_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
+    gate_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
                                       align256(static_cast<size_t>(max_tokens) * ff * es));
-    (*up_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
+    up_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
                                     align256(static_cast<size_t>(max_tokens) * ff * es));
-    (*swiglu_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
+    swiglu_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
                                         align256(static_cast<size_t>(max_tokens) * ff * es));
-    (*ffn_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
+    ffn_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
                                      align256(static_cast<size_t>(max_tokens) * d * es));
 }
 
-void Workspace::configure_moe_workspace(int max_tokens) {
+void GraphExecutor::configure_moe_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int ne = cfg.n_experts;
     int top_k = cfg.n_experts_active;
-    int eff = *max_expert_eff_;
+    int eff = max_expert_eff_;
     size_t es = dtype_size(compute_dtype_);
     int expanded = max_tokens * top_k;
 
-    char* ptr = static_cast<char*>(shared_workspace_);
+    char* ptr = static_cast<char*>(ws_.shared());
 
     // gate_logits: FP32
-    moe_->gate_logits = make_workspace_tensor(ptr, QType::F32, max_tokens, ne,
+    moe_.gate_logits = make_workspace_tensor(ptr, QType::F32, max_tokens, ne,
                                              align256(static_cast<size_t>(max_tokens) * ne * sizeof(float)));
 
-    moe_->gathered = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
+    moe_.gathered = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
                                           align256(static_cast<size_t>(expanded) * d * es));
-    moe_->expert_gate = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
+    moe_.expert_gate = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
                                              align256(static_cast<size_t>(expanded) * eff * es));
-    moe_->expert_up = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
+    moe_.expert_up = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
                                            align256(static_cast<size_t>(expanded) * eff * es));
-    moe_->expert_swiglu = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
+    moe_.expert_swiglu = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
                                                align256(static_cast<size_t>(expanded) * eff * es));
-    moe_->expert_down = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
+    moe_.expert_down = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
                                              align256(static_cast<size_t>(expanded) * d * es));
-    moe_->scatter_out = make_workspace_tensor(ptr, QType::F32, max_tokens, d,
+    moe_.scatter_out = make_workspace_tensor(ptr, QType::F32, max_tokens, d,
                                              align256(static_cast<size_t>(max_tokens) * d * sizeof(float)));
 }
 
-void Workspace::configure_ssm_workspace(int max_tokens) {
+void GraphExecutor::configure_ssm_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int inner = cfg.ssm_inner_size;
@@ -99,34 +99,34 @@ void Workspace::configure_ssm_workspace(int max_tokens) {
     int ssm_in_dim = inner + conv_channels + n_heads;
     size_t es = dtype_size(compute_dtype_);
 
-    char* ptr = static_cast<char*>(shared_workspace_);
+    char* ptr = static_cast<char*>(ws_.shared());
 
     // GDN layers need FP32 intermediate (4 bytes/elem) for numerical precision.
     // Non-GDN SSM layers only need FP16 (es bytes/elem).
-    size_t proj_elem_size = *has_gdn_ ? sizeof(float) : es;
-    (*ssm_proj_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ssm_in_dim,
+    size_t proj_elem_size = has_gdn_ ? sizeof(float) : es;
+    ssm_proj_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ssm_in_dim,
                                           align256(static_cast<size_t>(max_tokens) * ssm_in_dim *
                                                    proj_elem_size));
-    (*ssm_xBC_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, conv_channels,
+    ssm_xBC_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, conv_channels,
                                          align256(static_cast<size_t>(max_tokens) * conv_channels * es));
-    (*ssm_y_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
+    ssm_y_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
                                        align256(static_cast<size_t>(max_tokens) * inner * es));
-    (*ssm_z_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
+    ssm_z_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
                                        align256(static_cast<size_t>(max_tokens) * inner * es));
-    (*ssm_out_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
+    ssm_out_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
                                          align256(static_cast<size_t>(max_tokens) * d * es));
-    // GDN layers store BOTH alpha and beta projections in (*ssm_dt_buf_) (sequentially).
+    // GDN layers store BOTH alpha and beta projections in ssm_dt_buf_ (sequentially).
     // Allocate 2x n_heads to fit both. Non-GDN SSM only uses 1x (dt projection).
-    size_t dt_multiplier = *has_gdn_ ? 2 : 1;
-    (*ssm_dt_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, n_heads * dt_multiplier,
+    size_t dt_multiplier = has_gdn_ ? 2 : 1;
+    ssm_dt_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, n_heads * dt_multiplier,
                                         align256(static_cast<size_t>(max_tokens) * n_heads * dt_multiplier *
                                                  es));
     // Output buffer for the fused GDN input projection (4-way: ssm_in + gdn_gate +
-    // gdn_alpha + gdn_beta concatenated along N). Only sized on *has_gdn_ models.
+    // gdn_alpha + gdn_beta concatenated along N). Only sized on has_gdn_ models.
     int fused_total_out = conv_channels + inner + 2 * n_heads;
     size_t fused_bytes =
-        *has_gdn_ ? align256(static_cast<size_t>(max_tokens) * fused_total_out * es) : align256(0);
-    (*gdn_fused_proj_buf_) =
+        has_gdn_ ? align256(static_cast<size_t>(max_tokens) * fused_total_out * es) : align256(0);
+    gdn_fused_proj_buf_ =
         make_workspace_tensor(ptr, compute_dtype_, max_tokens, fused_total_out, fused_bytes);
 }
 

--- a/src/exec/executor_workspace_config.cu
+++ b/src/exec/executor_workspace_config.cu
@@ -1,4 +1,5 @@
 #include "exec/executor.h"
+#include "exec/workspace.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
 #include "core/logging.h"
@@ -13,7 +14,7 @@ namespace imp {
 // Shared workspace configuration (pure pointer arithmetic, no allocation)
 // ---------------------------------------------------------------------------
 
-void GraphExecutor::configure_attn_workspace(int max_tokens) {
+void Workspace::configure_attn_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int nh = cfg.n_heads;
@@ -23,24 +24,24 @@ void GraphExecutor::configure_attn_workspace(int max_tokens) {
 
     char* ptr = static_cast<char*>(shared_workspace_);
 
-    q_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
+    (*q_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
                                align256(static_cast<size_t>(max_tokens) * nh * hd * es));
     // K and V are contiguous (no alignment gap) to enable strided batched GEMM.
-    // v_.data == k_.data + kv_raw exactly, so output_stride = kv_raw / es.
+    // (*v_).data == (*k_).data + kv_raw exactly, so output_stride = kv_raw / es.
     {
         size_t kv_raw = static_cast<size_t>(max_tokens) * nkv * hd * es;
         int64_t kv_shape[2] = {static_cast<int64_t>(max_tokens), static_cast<int64_t>(nkv * hd)};
-        k_ = Tensor(ptr, compute_dtype_, 2, kv_shape, true);
-        v_ = Tensor(ptr + kv_raw, compute_dtype_, 2, kv_shape, true);
+        (*k_) = Tensor(ptr, compute_dtype_, 2, kv_shape, true);
+        (*v_) = Tensor(ptr + kv_raw, compute_dtype_, 2, kv_shape, true);
         ptr += align256(2 * kv_raw);
     }
-    attn_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
+    (*attn_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, nh * hd,
                                       align256(static_cast<size_t>(max_tokens) * nh * hd * es));
-    proj_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
+    (*proj_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
                                       align256(static_cast<size_t>(max_tokens) * d * es));
 }
 
-void GraphExecutor::configure_ffn_workspace(int max_tokens) {
+void Workspace::configure_ffn_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int ff = cfg.d_ff;
@@ -48,46 +49,46 @@ void GraphExecutor::configure_ffn_workspace(int max_tokens) {
 
     char* ptr = static_cast<char*>(shared_workspace_);
 
-    gate_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
+    (*gate_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
                                       align256(static_cast<size_t>(max_tokens) * ff * es));
-    up_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
+    (*up_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
                                     align256(static_cast<size_t>(max_tokens) * ff * es));
-    swiglu_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
+    (*swiglu_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ff,
                                         align256(static_cast<size_t>(max_tokens) * ff * es));
-    ffn_out_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
+    (*ffn_out_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
                                      align256(static_cast<size_t>(max_tokens) * d * es));
 }
 
-void GraphExecutor::configure_moe_workspace(int max_tokens) {
+void Workspace::configure_moe_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int ne = cfg.n_experts;
     int top_k = cfg.n_experts_active;
-    int eff = max_expert_eff_;
+    int eff = *max_expert_eff_;
     size_t es = dtype_size(compute_dtype_);
     int expanded = max_tokens * top_k;
 
     char* ptr = static_cast<char*>(shared_workspace_);
 
     // gate_logits: FP32
-    moe_.gate_logits = make_workspace_tensor(ptr, QType::F32, max_tokens, ne,
+    moe_->gate_logits = make_workspace_tensor(ptr, QType::F32, max_tokens, ne,
                                              align256(static_cast<size_t>(max_tokens) * ne * sizeof(float)));
 
-    moe_.gathered = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
+    moe_->gathered = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
                                           align256(static_cast<size_t>(expanded) * d * es));
-    moe_.expert_gate = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
+    moe_->expert_gate = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
                                              align256(static_cast<size_t>(expanded) * eff * es));
-    moe_.expert_up = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
+    moe_->expert_up = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
                                            align256(static_cast<size_t>(expanded) * eff * es));
-    moe_.expert_swiglu = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
+    moe_->expert_swiglu = make_workspace_tensor(ptr, compute_dtype_, expanded, eff,
                                                align256(static_cast<size_t>(expanded) * eff * es));
-    moe_.expert_down = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
+    moe_->expert_down = make_workspace_tensor(ptr, compute_dtype_, expanded, d,
                                              align256(static_cast<size_t>(expanded) * d * es));
-    moe_.scatter_out = make_workspace_tensor(ptr, QType::F32, max_tokens, d,
+    moe_->scatter_out = make_workspace_tensor(ptr, QType::F32, max_tokens, d,
                                              align256(static_cast<size_t>(max_tokens) * d * sizeof(float)));
 }
 
-void GraphExecutor::configure_ssm_workspace(int max_tokens) {
+void Workspace::configure_ssm_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int inner = cfg.ssm_inner_size;
@@ -102,44 +103,44 @@ void GraphExecutor::configure_ssm_workspace(int max_tokens) {
 
     // GDN layers need FP32 intermediate (4 bytes/elem) for numerical precision.
     // Non-GDN SSM layers only need FP16 (es bytes/elem).
-    size_t proj_elem_size = has_gdn_ ? sizeof(float) : es;
-    ssm_proj_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ssm_in_dim,
+    size_t proj_elem_size = *has_gdn_ ? sizeof(float) : es;
+    (*ssm_proj_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, ssm_in_dim,
                                           align256(static_cast<size_t>(max_tokens) * ssm_in_dim *
                                                    proj_elem_size));
-    ssm_xBC_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, conv_channels,
+    (*ssm_xBC_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, conv_channels,
                                          align256(static_cast<size_t>(max_tokens) * conv_channels * es));
-    ssm_y_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
+    (*ssm_y_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
                                        align256(static_cast<size_t>(max_tokens) * inner * es));
-    ssm_z_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
+    (*ssm_z_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
                                        align256(static_cast<size_t>(max_tokens) * inner * es));
-    ssm_out_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
+    (*ssm_out_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
                                          align256(static_cast<size_t>(max_tokens) * d * es));
-    // GDN layers store BOTH alpha and beta projections in ssm_dt_buf_ (sequentially).
+    // GDN layers store BOTH alpha and beta projections in (*ssm_dt_buf_) (sequentially).
     // Allocate 2x n_heads to fit both. Non-GDN SSM only uses 1x (dt projection).
-    size_t dt_multiplier = has_gdn_ ? 2 : 1;
-    ssm_dt_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, n_heads * dt_multiplier,
+    size_t dt_multiplier = *has_gdn_ ? 2 : 1;
+    (*ssm_dt_buf_) = make_workspace_tensor(ptr, compute_dtype_, max_tokens, n_heads * dt_multiplier,
                                         align256(static_cast<size_t>(max_tokens) * n_heads * dt_multiplier *
                                                  es));
     // Output buffer for the fused GDN input projection (4-way: ssm_in + gdn_gate +
-    // gdn_alpha + gdn_beta concatenated along N). Only sized on has_gdn_ models.
+    // gdn_alpha + gdn_beta concatenated along N). Only sized on *has_gdn_ models.
     int fused_total_out = conv_channels + inner + 2 * n_heads;
     size_t fused_bytes =
-        has_gdn_ ? align256(static_cast<size_t>(max_tokens) * fused_total_out * es) : align256(0);
-    gdn_fused_proj_buf_ =
+        *has_gdn_ ? align256(static_cast<size_t>(max_tokens) * fused_total_out * es) : align256(0);
+    (*gdn_fused_proj_buf_) =
         make_workspace_tensor(ptr, compute_dtype_, max_tokens, fused_total_out, fused_bytes);
 }
 
-bool GraphExecutor::resize_workspace(int new_max_tokens, cudaStream_t stream) {
+bool Workspace::resize_workspace(int new_max_tokens, cudaStream_t stream) {
     if (new_max_tokens == shared_workspace_max_tokens_ || new_max_tokens <= 0)
         return true;
-    if (new_max_tokens > max_tokens_)
-        new_max_tokens = max_tokens_;  // never exceed init-time max
+    if (new_max_tokens > *max_tokens_)
+        new_max_tokens = *max_tokens_;  // never exceed init-time max
 
     // Recompute shared sizes for the new token count
-    int saved_max = max_tokens_;
-    max_tokens_ = new_max_tokens;
+    int saved_max = *max_tokens_;
+    *max_tokens_ = new_max_tokens;
     compute_shared_sizes(new_max_tokens);
-    max_tokens_ = saved_max;
+    *max_tokens_ = saved_max;
 
     size_t new_shared = std::max({attn_shared_size_, ffn_shared_size_, moe_shared_size_, ssm_shared_size_});
     if (new_shared == 0)
@@ -169,7 +170,7 @@ bool GraphExecutor::resize_workspace(int new_max_tokens, cudaStream_t stream) {
 // Dual workspace for concurrent prefill/decode overlap
 // ---------------------------------------------------------------------------
 
-bool GraphExecutor::allocate_decode_workspace(cudaStream_t stream, int max_batch) {
+bool Workspace::allocate_decode_workspace(cudaStream_t stream, int max_batch) {
     if (decode_workspace_)
         return true;  // already allocated
     if (max_batch <= 0)
@@ -183,7 +184,7 @@ bool GraphExecutor::allocate_decode_workspace(cudaStream_t stream, int max_batch
     size_t persistent = static_cast<size_t>(dm) * sizeof(half) * 3 *
                             max_batch  // hidden + residual + norm_out
                         + static_cast<size_t>(cfg.vocab_size) * sizeof(float) * max_batch;  // logits
-    if (fp32_accum_buf_)
+    if ((*fp32_accum_buf_))
         persistent += static_cast<size_t>(dm) * sizeof(float) * max_batch;  // fp32_hidden
 
     decode_workspace_ = vram_alloc(vram_alloc_, persistent, "decode_workspace");
@@ -194,10 +195,10 @@ bool GraphExecutor::allocate_decode_workspace(cudaStream_t stream, int max_batch
     decode_persistent_size_ = persistent;
 
     // Shared workspace for max_batch tokens
-    int saved = max_tokens_;
-    max_tokens_ = max_batch;
+    int saved = *max_tokens_;
+    *max_tokens_ = max_batch;
     compute_shared_sizes(max_batch);
-    max_tokens_ = saved;
+    *max_tokens_ = saved;
 
     size_t shared = std::max({attn_shared_size_, ffn_shared_size_, moe_shared_size_, ssm_shared_size_});
     if (shared > 0) {
@@ -212,14 +213,14 @@ bool GraphExecutor::allocate_decode_workspace(cudaStream_t stream, int max_batch
     decode_shared_size_ = shared;
 
     // Recompute sizes for original max_tokens
-    compute_shared_sizes(max_tokens_);
+    compute_shared_sizes(*max_tokens_);
 
     IMP_LOG_INFO("Decode overlap workspace: %.2f MiB for max_batch=%d (persistent=%.1f KB, shared=%.1f KB)",
                  (persistent + shared) / (1024.0 * 1024.0), max_batch, persistent / 1024.0, shared / 1024.0);
     return true;
 }
 
-void GraphExecutor::use_workspace(int slot) {
+void Workspace::use_workspace(int slot) {
     if (slot == active_workspace_)
         return;
 
@@ -233,12 +234,12 @@ void GraphExecutor::use_workspace(int slot) {
         saved_prefill_ws_.shared = shared_workspace_;
         saved_prefill_ws_.shared_size = shared_workspace_size_;
         saved_prefill_ws_.shared_max_tokens = shared_workspace_max_tokens_;
-        saved_prefill_ws_.hidden = hidden_;
-        saved_prefill_ws_.residual = residual_;
-        saved_prefill_ws_.norm_out = norm_out_;
-        saved_prefill_ws_.logits = logits_;
-        saved_prefill_ws_.fp32_accum = fp32_accum_buf_;
-        saved_prefill_ws_.fp32_hidden = fp32_hidden_;
+        saved_prefill_ws_.hidden = (*hidden_);
+        saved_prefill_ws_.residual = (*residual_);
+        saved_prefill_ws_.norm_out = (*norm_out_);
+        saved_prefill_ws_.logits = (*logits_);
+        saved_prefill_ws_.fp32_accum = (*fp32_accum_buf_);
+        saved_prefill_ws_.fp32_hidden = (*fp32_hidden_);
 
         // Switch to decode workspace
         persistent_workspace_ = decode_workspace_;
@@ -251,19 +252,19 @@ void GraphExecutor::use_workspace(int slot) {
         int mb = decode_max_batch_;
         char* p = static_cast<char*>(decode_workspace_);
         int64_t shape_mb[2] = {mb, dm};
-        hidden_ = Tensor(p, QType::F16, 2, shape_mb, true);
+        (*hidden_) = Tensor(p, QType::F16, 2, shape_mb, true);
         p += static_cast<size_t>(dm) * sizeof(half) * mb;
-        residual_ = Tensor(p, QType::F16, 2, shape_mb, true);
+        (*residual_) = Tensor(p, QType::F16, 2, shape_mb, true);
         p += static_cast<size_t>(dm) * sizeof(half) * mb;
-        norm_out_ = Tensor(p, QType::F16, 2, shape_mb, true);
+        (*norm_out_) = Tensor(p, QType::F16, 2, shape_mb, true);
         p += static_cast<size_t>(dm) * sizeof(half) * mb;
         int64_t shape_logits[2] = {mb, cfg.vocab_size};
-        logits_ = Tensor(p, QType::F32, 2, shape_logits, true);
+        (*logits_) = Tensor(p, QType::F32, 2, shape_logits, true);
         p += static_cast<size_t>(cfg.vocab_size) * sizeof(float) * mb;
         if (saved_prefill_ws_.fp32_accum) {
-            fp32_accum_buf_ = p;
+            (*fp32_accum_buf_) = p;
             int64_t shape_fp32[2] = {mb, dm};
-            fp32_hidden_ = Tensor(p, QType::F32, 2, shape_fp32, true);
+            (*fp32_hidden_) = Tensor(p, QType::F32, 2, shape_fp32, true);
         }
 
         active_workspace_ = 1;
@@ -274,12 +275,12 @@ void GraphExecutor::use_workspace(int slot) {
         shared_workspace_ = saved_prefill_ws_.shared;
         shared_workspace_size_ = saved_prefill_ws_.shared_size;
         shared_workspace_max_tokens_ = saved_prefill_ws_.shared_max_tokens;
-        hidden_ = saved_prefill_ws_.hidden;
-        residual_ = saved_prefill_ws_.residual;
-        norm_out_ = saved_prefill_ws_.norm_out;
-        logits_ = saved_prefill_ws_.logits;
-        fp32_accum_buf_ = saved_prefill_ws_.fp32_accum;
-        fp32_hidden_ = saved_prefill_ws_.fp32_hidden;
+        (*hidden_) = saved_prefill_ws_.hidden;
+        (*residual_) = saved_prefill_ws_.residual;
+        (*norm_out_) = saved_prefill_ws_.norm_out;
+        (*logits_) = saved_prefill_ws_.logits;
+        (*fp32_accum_buf_) = saved_prefill_ws_.fp32_accum;
+        (*fp32_hidden_) = saved_prefill_ws_.fp32_hidden;
         active_workspace_ = 0;
     }
 }

--- a/src/exec/workspace.h
+++ b/src/exec/workspace.h
@@ -32,7 +32,7 @@ public:
     // pointer-context). The pointer args are to LIVE GraphExecutor members so
     // the moved methods read/write them exactly as before (e.g. has_gdn_ is
     // still false at the first compute_shared_sizes() and true afterward).
-    void init(const Model& model, VRAMAllocator& alloc, QType compute_dtype, int* max_tokens, bool use_pdl,
+    void init(const Model& model, VRAMAllocator* alloc, QType compute_dtype, int* max_tokens, bool use_pdl,
               MoEWorkspace& moe,
               // model-feature flags (read for phase sizing)
               const bool* has_moe, const bool* has_ssm, const bool* has_gdn, const bool* has_dense_ffn,
@@ -48,7 +48,7 @@ public:
               Tensor* ssm_proj_buf, Tensor* ssm_xBC_buf, Tensor* ssm_y_buf, Tensor* ssm_z_buf,
               Tensor* ssm_out_buf, Tensor* ssm_dt_buf, Tensor* gdn_fused_proj_buf) {
         model_ = &model;
-        vram_alloc_ = &alloc;
+        vram_alloc_ = alloc;
         compute_dtype_ = compute_dtype;
         max_tokens_ = max_tokens;
         use_pdl_ = use_pdl;
@@ -103,6 +103,12 @@ public:
     void configure_ffn_workspace(int max_tokens);
     void configure_moe_workspace(int max_tokens);
     void configure_ssm_workspace(int max_tokens);
+
+    // Free the owned shared + persistent workspace buffers (called from
+    // GraphExecutor::free_buffers). Mirrors the original free path exactly:
+    // the decode-swap buffers are intentionally NOT freed here (matching the
+    // pre-extraction behaviour).
+    void free_buffers();
 
 private:
     // --- build context (pointers to LIVE GraphExecutor state) ---

--- a/src/exec/workspace.h
+++ b/src/exec/workspace.h
@@ -1,0 +1,190 @@
+#pragma once
+
+#include "core/tensor.h"
+#include "core/qtype.h"
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace imp {
+
+class Model;
+class VRAMAllocator;
+struct MoEWorkspace;
+
+// The shared/persistent/decode scratch arena, extracted from GraphExecutor (D2,
+// component 3). Owns the forward-pass scratch arena (shared + persistent
+// workspace, the per-phase sizes, and the decode/prefill workspace swap state);
+// the cross-cutting auxiliary-buffer hub (qscratch/moe/attn) stays on
+// GraphExecutor.
+//
+// The arena BUFFERS (shared/persistent/decode pointers + sizes + swap state)
+// are owned here. The activation/phase TENSORS that the arena carves and the
+// hot path reads (hidden_/q_/moe_/ssm_*/fp32_accum_buf_/…) stay GraphExecutor
+// members — the moved methods write them through pointers set in init(),
+// mirroring how QuantPipeline writes the caller-owned caches. The bodies are
+// otherwise byte-identical (sizing logic unchanged), so the move is
+// behaviour-neutral.
+//
+// See docs/superpowers/specs/2026-06-08-workspace-component-design.md.
+class Workspace {
+public:
+    // Build context, set once from GraphExecutor::init (mirrors QuantPipeline's
+    // pointer-context). The pointer args are to LIVE GraphExecutor members so
+    // the moved methods read/write them exactly as before (e.g. has_gdn_ is
+    // still false at the first compute_shared_sizes() and true afterward).
+    void init(const Model& model, VRAMAllocator& alloc, QType compute_dtype, int* max_tokens, bool use_pdl,
+              MoEWorkspace& moe,
+              // model-feature flags (read for phase sizing)
+              const bool* has_moe, const bool* has_ssm, const bool* has_gdn, const bool* has_dense_ffn,
+              const int* max_expert_eff, const int* max_logit_tokens,
+              // persistent activation tensors (written by allocate/use)
+              Tensor* hidden, Tensor* residual, Tensor* norm_out, Tensor* logits, void** fp32_accum_buf,
+              Tensor* fp32_hidden,
+              // attention phase tensors
+              Tensor* q, Tensor* k, Tensor* v, Tensor* attn_out, Tensor* proj_out,
+              // dense FFN phase tensors
+              Tensor* gate_out, Tensor* up_out, Tensor* swiglu_out, Tensor* ffn_out,
+              // SSM phase tensors
+              Tensor* ssm_proj_buf, Tensor* ssm_xBC_buf, Tensor* ssm_y_buf, Tensor* ssm_z_buf,
+              Tensor* ssm_out_buf, Tensor* ssm_dt_buf, Tensor* gdn_fused_proj_buf) {
+        model_ = &model;
+        vram_alloc_ = &alloc;
+        compute_dtype_ = compute_dtype;
+        max_tokens_ = max_tokens;
+        use_pdl_ = use_pdl;
+        moe_ = &moe;
+        has_moe_ = has_moe;
+        has_ssm_ = has_ssm;
+        has_gdn_ = has_gdn;
+        has_dense_ffn_ = has_dense_ffn;
+        max_expert_eff_ = max_expert_eff;
+        max_logit_tokens_ = max_logit_tokens;
+        hidden_ = hidden;
+        residual_ = residual;
+        norm_out_ = norm_out;
+        logits_ = logits;
+        fp32_accum_buf_ = fp32_accum_buf;
+        fp32_hidden_ = fp32_hidden;
+        q_ = q;
+        k_ = k;
+        v_ = v;
+        attn_out_ = attn_out;
+        proj_out_ = proj_out;
+        gate_out_ = gate_out;
+        up_out_ = up_out;
+        swiglu_out_ = swiglu_out;
+        ffn_out_ = ffn_out;
+        ssm_proj_buf_ = ssm_proj_buf;
+        ssm_xBC_buf_ = ssm_xBC_buf;
+        ssm_y_buf_ = ssm_y_buf;
+        ssm_z_buf_ = ssm_z_buf;
+        ssm_out_buf_ = ssm_out_buf;
+        ssm_dt_buf_ = ssm_dt_buf;
+        gdn_fused_proj_buf_ = gdn_fused_proj_buf;
+    }
+
+    // --- zero-overhead inline accessors (hot path reads these) ---
+    void* shared() const { return shared_workspace_; }
+    void* persistent() const { return persistent_workspace_; }
+    size_t shared_size() const { return shared_workspace_size_; }
+    int shared_max_tokens() const { return shared_workspace_max_tokens_; }
+    int active() const { return active_workspace_; }
+    bool has_decode_workspace() const { return decode_workspace_ != nullptr; }
+
+    // --- moved lifecycle methods ---
+    [[nodiscard]] bool allocate_persistent_workspace(int max_tokens);
+    [[nodiscard]] bool allocate_shared_workspace(int max_tokens);
+    bool allocate_decode_workspace(cudaStream_t stream, int max_batch = 1);
+    void use_workspace(int slot);
+    [[nodiscard]] bool resize_workspace(int new_max_tokens, cudaStream_t stream);
+    void compute_shared_sizes(int max_tokens);
+    size_t workspace_estimate() const;
+    void configure_attn_workspace(int max_tokens);
+    void configure_ffn_workspace(int max_tokens);
+    void configure_moe_workspace(int max_tokens);
+    void configure_ssm_workspace(int max_tokens);
+
+private:
+    // --- build context (pointers to LIVE GraphExecutor state) ---
+    const Model* model_ = nullptr;
+    VRAMAllocator* vram_alloc_ = nullptr;
+    QType compute_dtype_ = QType::F16;
+    int* max_tokens_ = nullptr;  // GraphExecutor::max_tokens_ (read + transient save/restore)
+    bool use_pdl_ = false;
+    MoEWorkspace* moe_ = nullptr;
+
+    const bool* has_moe_ = nullptr;
+    const bool* has_ssm_ = nullptr;
+    const bool* has_gdn_ = nullptr;
+    const bool* has_dense_ffn_ = nullptr;
+    const int* max_expert_eff_ = nullptr;
+    const int* max_logit_tokens_ = nullptr;
+
+    // Persistent activation tensors (owned by GraphExecutor; written here).
+    Tensor* hidden_ = nullptr;
+    Tensor* residual_ = nullptr;
+    Tensor* norm_out_ = nullptr;
+    Tensor* logits_ = nullptr;
+    void** fp32_accum_buf_ = nullptr;
+    Tensor* fp32_hidden_ = nullptr;
+
+    // Attention phase tensors.
+    Tensor* q_ = nullptr;
+    Tensor* k_ = nullptr;
+    Tensor* v_ = nullptr;
+    Tensor* attn_out_ = nullptr;
+    Tensor* proj_out_ = nullptr;
+
+    // Dense FFN phase tensors.
+    Tensor* gate_out_ = nullptr;
+    Tensor* up_out_ = nullptr;
+    Tensor* swiglu_out_ = nullptr;
+    Tensor* ffn_out_ = nullptr;
+
+    // SSM phase tensors.
+    Tensor* ssm_proj_buf_ = nullptr;
+    Tensor* ssm_xBC_buf_ = nullptr;
+    Tensor* ssm_y_buf_ = nullptr;
+    Tensor* ssm_z_buf_ = nullptr;
+    Tensor* ssm_out_buf_ = nullptr;
+    Tensor* ssm_dt_buf_ = nullptr;
+    Tensor* gdn_fused_proj_buf_ = nullptr;
+
+    // --- owned: persistent GPU workspace (always valid, not reconfigured) ---
+    void* persistent_workspace_ = nullptr;
+    size_t persistent_workspace_size_ = 0;
+
+    // --- owned: shared GPU workspace (reconfigured per layer phase) ---
+    void* shared_workspace_ = nullptr;
+    size_t shared_workspace_size_ = 0;
+    int shared_workspace_max_tokens_ = 0;
+
+    // Pre-computed phase sizes (for max_tokens_).
+    size_t attn_shared_size_ = 0;
+    size_t ffn_shared_size_ = 0;
+    size_t moe_shared_size_ = 0;
+    size_t ssm_shared_size_ = 0;
+
+    // --- owned: dual workspace for concurrent prefill/decode overlap ---
+    void* decode_workspace_ = nullptr;         // persistent buf for decode
+    void* decode_shared_workspace_ = nullptr;  // shared buf for decode
+    size_t decode_persistent_size_ = 0;
+    size_t decode_shared_size_ = 0;
+    int decode_max_batch_ = 1;  // max decode batch size this workspace supports
+    int active_workspace_ = 0;
+
+    // Saved prefill workspace pointers (restored when switching back).
+    struct SavedWorkspace {
+        void* persistent;
+        size_t persistent_size;
+        void* shared;
+        size_t shared_size;
+        int shared_max_tokens;
+        Tensor hidden, residual, norm_out, logits;
+        void* fp32_accum;
+        Tensor fp32_hidden;
+    };
+    SavedWorkspace saved_prefill_ws_;
+};
+
+}  // namespace imp

--- a/src/exec/workspace.h
+++ b/src/exec/workspace.h
@@ -18,11 +18,15 @@ struct MoEWorkspace;
 // GraphExecutor.
 //
 // The arena BUFFERS (shared/persistent/decode pointers + sizes + swap state)
-// are owned here. The activation/phase TENSORS that the arena carves and the
-// hot path reads (hidden_/q_/moe_/ssm_*/fp32_accum_buf_/…) stay GraphExecutor
-// members — the moved methods write them through pointers set in init(),
-// mirroring how QuantPipeline writes the caller-owned caches. The bodies are
-// otherwise byte-identical (sizing logic unchanged), so the move is
+// are owned here. The PER-PHASE activation tensors (q_/k_/v_/gate_out_/ssm_*/…)
+// are carved by the four GraphExecutor::configure_*_workspace methods — pure
+// activation-tensor slicing, so they live on GraphExecutor (they read the buffer
+// via ws_.shared()). Only the six PERSISTENT tensors that the retained methods
+// here genuinely touch (hidden_/residual_/norm_out_/logits_/fp32_accum_buf_/
+// fp32_hidden_, carved by allocate_persistent_workspace and swapped by the
+// decode/prefill workspace swap in allocate_decode_workspace/use_workspace) are
+// still written here through pointers set in init(), mirroring how QuantPipeline
+// writes the caller-owned caches. The sizing logic is unchanged, so the move is
 // behaviour-neutral.
 //
 // See docs/superpowers/specs/2026-06-08-workspace-component-design.md.
@@ -32,26 +36,20 @@ public:
     // pointer-context). The pointer args are to LIVE GraphExecutor members so
     // the moved methods read/write them exactly as before (e.g. has_gdn_ is
     // still false at the first compute_shared_sizes() and true afterward).
-    void init(const Model& model, VRAMAllocator* alloc, QType compute_dtype, int* max_tokens, bool use_pdl,
+    void init(const Model& model, VRAMAllocator* alloc, QType compute_dtype, int* max_tokens,
               MoEWorkspace& moe,
               // model-feature flags (read for phase sizing)
               const bool* has_moe, const bool* has_ssm, const bool* has_gdn, const bool* has_dense_ffn,
               const int* max_expert_eff, const int* max_logit_tokens,
-              // persistent activation tensors (written by allocate/use)
+              // persistent activation tensors (carved by allocate_persistent + swapped by
+              // allocate_decode/use_workspace — the four per-phase configure_* carvers are
+              // back on GraphExecutor, so the 16 phase tensors no longer pass through here)
               Tensor* hidden, Tensor* residual, Tensor* norm_out, Tensor* logits, void** fp32_accum_buf,
-              Tensor* fp32_hidden,
-              // attention phase tensors
-              Tensor* q, Tensor* k, Tensor* v, Tensor* attn_out, Tensor* proj_out,
-              // dense FFN phase tensors
-              Tensor* gate_out, Tensor* up_out, Tensor* swiglu_out, Tensor* ffn_out,
-              // SSM phase tensors
-              Tensor* ssm_proj_buf, Tensor* ssm_xBC_buf, Tensor* ssm_y_buf, Tensor* ssm_z_buf,
-              Tensor* ssm_out_buf, Tensor* ssm_dt_buf, Tensor* gdn_fused_proj_buf) {
+              Tensor* fp32_hidden) {
         model_ = &model;
         vram_alloc_ = alloc;
         compute_dtype_ = compute_dtype;
         max_tokens_ = max_tokens;
-        use_pdl_ = use_pdl;
         moe_ = &moe;
         has_moe_ = has_moe;
         has_ssm_ = has_ssm;
@@ -65,22 +63,6 @@ public:
         logits_ = logits;
         fp32_accum_buf_ = fp32_accum_buf;
         fp32_hidden_ = fp32_hidden;
-        q_ = q;
-        k_ = k;
-        v_ = v;
-        attn_out_ = attn_out;
-        proj_out_ = proj_out;
-        gate_out_ = gate_out;
-        up_out_ = up_out;
-        swiglu_out_ = swiglu_out;
-        ffn_out_ = ffn_out;
-        ssm_proj_buf_ = ssm_proj_buf;
-        ssm_xBC_buf_ = ssm_xBC_buf;
-        ssm_y_buf_ = ssm_y_buf;
-        ssm_z_buf_ = ssm_z_buf;
-        ssm_out_buf_ = ssm_out_buf;
-        ssm_dt_buf_ = ssm_dt_buf;
-        gdn_fused_proj_buf_ = gdn_fused_proj_buf;
     }
 
     // --- zero-overhead inline accessors (hot path reads these) ---
@@ -99,10 +81,6 @@ public:
     [[nodiscard]] bool resize_workspace(int new_max_tokens, cudaStream_t stream);
     void compute_shared_sizes(int max_tokens);
     size_t workspace_estimate() const;
-    void configure_attn_workspace(int max_tokens);
-    void configure_ffn_workspace(int max_tokens);
-    void configure_moe_workspace(int max_tokens);
-    void configure_ssm_workspace(int max_tokens);
 
     // Free the owned shared + persistent workspace buffers (called from
     // GraphExecutor::free_buffers). Mirrors the original free path exactly:
@@ -116,7 +94,6 @@ private:
     VRAMAllocator* vram_alloc_ = nullptr;
     QType compute_dtype_ = QType::F16;
     int* max_tokens_ = nullptr;  // GraphExecutor::max_tokens_ (read + transient save/restore)
-    bool use_pdl_ = false;
     MoEWorkspace* moe_ = nullptr;
 
     const bool* has_moe_ = nullptr;
@@ -126,35 +103,16 @@ private:
     const int* max_expert_eff_ = nullptr;
     const int* max_logit_tokens_ = nullptr;
 
-    // Persistent activation tensors (owned by GraphExecutor; written here).
+    // Persistent activation tensors (owned by GraphExecutor; carved by
+    // allocate_persistent_workspace and swapped by allocate_decode_workspace /
+    // use_workspace, which stay here). The 16 per-phase activation tensors moved
+    // out with the configure_*_workspace carvers (back on GraphExecutor).
     Tensor* hidden_ = nullptr;
     Tensor* residual_ = nullptr;
     Tensor* norm_out_ = nullptr;
     Tensor* logits_ = nullptr;
     void** fp32_accum_buf_ = nullptr;
     Tensor* fp32_hidden_ = nullptr;
-
-    // Attention phase tensors.
-    Tensor* q_ = nullptr;
-    Tensor* k_ = nullptr;
-    Tensor* v_ = nullptr;
-    Tensor* attn_out_ = nullptr;
-    Tensor* proj_out_ = nullptr;
-
-    // Dense FFN phase tensors.
-    Tensor* gate_out_ = nullptr;
-    Tensor* up_out_ = nullptr;
-    Tensor* swiglu_out_ = nullptr;
-    Tensor* ffn_out_ = nullptr;
-
-    // SSM phase tensors.
-    Tensor* ssm_proj_buf_ = nullptr;
-    Tensor* ssm_xBC_buf_ = nullptr;
-    Tensor* ssm_y_buf_ = nullptr;
-    Tensor* ssm_z_buf_ = nullptr;
-    Tensor* ssm_out_buf_ = nullptr;
-    Tensor* ssm_dt_buf_ = nullptr;
-    Tensor* gdn_fused_proj_buf_ = nullptr;
 
     // --- owned: persistent GPU workspace (always valid, not reconfigured) ---
     void* persistent_workspace_ = nullptr;


### PR DESCRIPTION
## What

**D2 step 3** — extract a `Workspace` class out of `GraphExecutor` for the
shared/persistent scratch arena + the decode/prefill workspace swap.

`GraphExecutor` owns `Workspace ws_;`; the forward path reads the shared buffer
through zero-overhead inline accessors (`ws_.shared()`, `ws_.shared_max_tokens()`,
`ws_.shared_size()`). `Workspace` owns: the shared/persistent/decode buffers +
sizes, `compute_shared_sizes`, `allocate_shared/persistent/decode_workspace`,
`use_workspace`/`resize_workspace`, and the persistent activation tensors that the
decode/prefill swap saves & restores.

## Lean boundary (the important part)

A first pass pulled the per-phase `configure_*_workspace` carvers into Workspace
too — but those slice the shared buffer into the 16 per-phase activation views
(q/k/v/gate_out/ssm_*/…), which forced a 30-parameter `init()` reaching into
GraphExecutor's tensors. That's a leaky, untestable boundary, so it was reworked:

- The four `configure_attn/ffn/moe/ssm_workspace` **carvers moved back onto
  `GraphExecutor`** (they write GraphExecutor's activation members; they read the
  buffer via `ws_.shared()`).
- `Workspace::init` dropped all 16 per-phase tensor params. The 6 **persistent**
  tensors (hidden/residual/norm_out/logits/fp32_accum/fp32_hidden) stay wired in
  because the decode/prefill swap genuinely owns them.

Result: the boundary is now principled — **Workspace = arena + persistent
activations + swap; GraphExecutor = per-phase carving**. The hot-path footprint is
tiny: **7 changed lines** across 5 forward TUs (just the `ws_.shared*()` reads).

The cross-cutting `allocate_auxiliary_buffers` hub (qscratch/moe/attn/fp32_accum)
stays on GraphExecutor, as scoped.

## Behaviour-neutral — gated (no diff=0; hot path changes)

| Model | arch | output | native MoE cache |
|---|---|---|---|
| Qwen3-8B Q8_0 | dense | Paris | — |
| Qwen3-30B-A3B-NVFP4 | MoE | coherent | **144** ✓ |
| Nemotron-3-Nano-30B | SSM/GDN | Paris | **46** ✓ |
| gemma-3-12b Q4_K_M | gemma | Paris | — |

- **Decode-perf backstop** (silent-sizing-bug guard): Qwen3-8B **tg = 264** tok/s,
  in-band vs the ~268-278 baseline; clocks healthy (2842/13801 MHz, 521 W). No OOM
  / auto-disable / fallback.
- `make verify-fast` green; `DegenerationTest` coverage via the canary.

Spec: `docs/superpowers/specs/2026-06-08-workspace-component-design.md`. Plan:
`docs/superpowers/plans/2026-06-08-workspace-component.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
