### PR TITLE
chore(audit): structure audit 2026-06-09 + C6/C7 cheap-sweep

### DIFF
--- a/docs/audit/structural_debt_2026_06_09.md
+++ b/docs/audit/structural_debt_2026_06_09.md
@@ -1,0 +1,170 @@
+# Structural audit — 2026-06-09
+
+Scope: a fresh codebase-wide pass over the areas the 2026-06-08 audit
+(`structural_debt_2026_06_08.md`, D1–D4) did **not** cover. That audit focused on
+`src/exec/` and the `GraphExecutor` god-object; this one targets `src/compute/`
+(40,942 LOC — 40 % of the codebase, previously untouched), the loader family in
+`src/model/`, header/dependency hygiene, and the test suite. Counts are verified
+with grep/wc, not estimated. Diagnostic + an opening cheap-sweep PR.
+
+## TL;DR
+
+After D1–D4 and the D2/D3 PRs (#621–#631) the `exec/` layer is structurally
+healthy and — pleasantly — the **header/dependency layer is clean**: no module
+cycle, 100 % `#pragma once`, the public C-API boundary leaks nothing. The real
+untouched debt lives in **`src/compute/`** (god-files + heavy attention-variant
+duplication) and in **`weight_map.cpp`** (an 858-line matcher ladder). The two
+findings deferred on 2026-06-08 are still open.
+
+A note on method: several agent-reported "dead flags/files" were **false
+positives** caught by re-verifying with the right search scope (the exact trap
+documented on 2026-06-08). They are recorded under "Refuted" so they are not
+re-chased.
+
+---
+
+## C1 — `src/compute/` paged-attention duplication (highest new value)
+
+Six variants — `attention_paged{,_nvfp4,_nvfp4_tc,_int8,_fp8,_int4}.cu`
+(5,261 LOC together) — each reimplement the **same per-token online-softmax loop**
+(m/l/O accumulation, KV-tile load, score reduction, block range helpers). Only the
+dequant of K/V differs (~2,000 LOC of repeated core loop). The drift risk is real:
+a softmax/range fix has to be applied six times.
+
+**Fix:** an `attention_paged_core_loop.cuh` template parametrised by dequant
+traits — exactly the pattern `gemv_dp4a_traits.cuh` already uses for GEMV. High
+effort, own brainstorm→spec→plan cycle, each variant verified against its current
+output. Rank: high pain × high risk.
+
+## C2 — `src/compute/` god-files (conflated responsibilities)
+
+| File | LOC | Conflated concerns |
+|------|-----|--------------------|
+| `gdn.cu` | 2,061 | delta-rule scan + RMSNorm/gated-SiLU + V-head layout conversion |
+| `gemm.cu` | 1,806 | GEMM dispatch + 12 GEMV kernel variants + MoE gate/up-fused |
+| `sampling.cu` | 1,763 | 7 sampling algorithms + 3 penalty fns + logprob computation |
+| `json_schema.cpp` | 1,333 | JSON parser + schema tree + RegexNfa (Thompson) + GBNF transform |
+
+All are verbatim-extractable (D3-style, low risk): e.g. `gdn_scan.cu` /
+`gdn_activation.cu` / `gdn_layout.cu`; pull GEMVs out of `gemm.cu`; lift
+`regex_nfa.cpp` out of `json_schema.cpp`. Size alone is not the smell —
+*conflated* responsibilities are (`jinja.cpp` 2,629 and the FA2 kernels stay:
+single responsibility). Rank: medium pain × low risk.
+
+## C3 — `weight_map.cpp` 858-line matcher ladder
+
+`apply_weights()` (lines 312–1170) is 23 sequential `if (!matched && …)` string-
+matching blocks. Concrete duplication inside it:
+- GPTQ field assignment duplicated (self_attn vs mlp, ~58 LOC, lines 1079–1138).
+- NVFP4 fused-scale slicing duplicated (qkv vs gate_up, ~40 LOC, lines 668–730).
+- `moe_gate` assigned at 4 separate sites (Gemma-4 / Mixtral / DeepSeek / gpt-oss).
+
+**Fix:** a matcher-registry table (`{pattern, field-assignment}`) instead of a
+linear scan; extract the slicing/GPTQ helpers. Rank: medium pain × low risk.
+
+## C4 — Loader config-parse paths diverge (GGUF ↔ SafeTensors)
+
+GGUF parses arch-specific config **inline** (gemma4 SWA array, LongRoPE,
+`rope_local_theta`; `gguf_loader.cpp:1106–1400`); SafeTensors delegates to
+`hf_config_loader.cpp` + `apply_arch_defaults()`. The Gemma SWA setup has no
+SafeTensors equivalent — an arch change can land on one path only. This is the
+exact #514/#516 bug class D1's ModelProfile was meant to retire, surviving in the
+*loaders* rather than the hot path. **Fix:** move metadata-agnostic config logic
+into a shared post-load routine both loaders call after arch detection. Rank:
+medium pain × high risk.
+
+## C5 — Deferred 2026-06-08 findings, still open (re-verified)
+
+- **Dead `WeightCaches::q4k_imma` cache** — re-confirmed never populated (no
+  `use_q4k_imma = true`, no insertion into the map anywhere in `src/`); only
+  declared (`exec/weight_caches.h:99`) + freed. ~1,200 LOC of tile/reorder infra.
+  The *live* path is the separate `q4k_imma_prefill` stack. Removal is D3-class
+  kernel work.
+- **Unbridged config keys** — `server.prefix_cache`, `server.green_contexts`,
+  `server.prefix_pin_budget_pct`, `paths.mmproj` are parsed into `RuntimeConfig`
+  but **never read** (`grep cfg.server.` finds only the parse lines); the live
+  enablement flows through the C-API (`imp_api.cpp`). Silently inert from
+  `imp.conf`. Needs a bridge-or-retire decision (user-facing), not a blind delete.
+
+## C6 — Header micro-findings (the layer is otherwise clean)
+
+- `exec/inference_state.h` includes `compute/json_constrain.h` +
+  `schema_constrain.h` (~190 LOC each) but only stores `JsonConstrainer*` /
+  `SchemaConstrainer*` — forward-declarable. The includes ride transitively into
+  every `executor.h` consumer. **(Fixed in this PR — see Progress.)**
+- **Dependency inversion:** `compute/weight_dispatch.h` includes
+  `exec/weight_handle.h` — `compute` (lower layer) depending on `exec` (higher).
+  The only violation of the api→runtime→exec→compute DAG. Fix: split a
+  `weight_dispatch_types.h` interface so compute includes only the interface.
+
+## C7 — Test-fixture adoption gap
+
+`SKIP_IF_NO_CUDA()` is defined in **11 files** with three divergent bodies
+(`::imp::test::HasCudaDevice()`, a raw `cudaGetDevice` check, an unqualified
+`HasCudaDevice()`); `HasCudaDevice()` itself is re-defined in 6 files;
+`get_model_path()` in 3. A shared layer (`test_models.h`, `test_model_builder.h`)
+exists but only 17 of ~117 test files use it. **Fix:** a lightweight
+`tests/test_cuda_skip.h` owning the one `HasCudaDevice()` + macro (kept separate
+from the heavy `test_model_builder.h` so host-compiled `.cpp` tests don't pull in
+`cuda_fp16`/`half`). **(Fixed in this PR — see Progress.)**
+
+## C8 — Candidate dead kernels (verify launch-by-pointer before deleting)
+
+0 `<<<` launch sites found, each symbol confined to its own TU:
+`softmax_sum_kernel`, `softmax_to_pairs_kernel` (`sampling.cu` — note the *device*
+variant `softmax_to_pairs_device_kernel` **is** launched at line 868, so only the
+non-device pair looks dead); `zero_int32_kernel`, `exclusive_scan_kernel`,
+`count_tokens_per_expert_kernel` (`moe_routing.cu`, look like leftovers from an
+older routing implementation). Rule out `cudaLaunchKernel`-by-pointer before
+deletion. Rank: low pain × low risk.
+
+---
+
+## Refuted (do not re-chase)
+
+Re-verification with `tools/` included and a fresh tree caught these agent
+false positives — the same local-scope trap noted on 2026-06-08:
+
+- **`diagnostics.dump_tokens`, `generation.force_bos`, `bench.generate` are NOT
+  dead** — all read in `tools/imp-cli/main.cpp` (lines 638 / 631 / 812). The
+  search that flagged them omitted `tools/`.
+- **`tests/golden/` and `tests/api/test_outputs/` do not exist** (count 0) — the
+  "dead artifacts" finding was stale.
+- `generation.think_budget` (global field) is the one marginal residue: live use
+  is the *per-request* `req.think_budget` (`engine_graph_decode.cpp:87`); the
+  global config field appears unread → at most a bridge-or-retire, not a safe
+  delete.
+
+## Clean — no action
+
+Public API boundary (`include/imp/`, 0 internal leaks), module DAG acyclic,
+151/151 headers `#pragma once`, `CMakeLists.txt` structured per-module, `tools/`
+cohesive (no duplicated dequant/tokenizer logic), `executor.h` at 584 LOC post
+PRs #629–#631.
+
+---
+
+## Recommended order
+
+1. **Cheap, now:** test-fixture consolidation (C7) + header forward-decls (C6) —
+   verbatim, low risk. *(this PR)*
+2. **Medium, high value:** `compute/` god-file splits (C2) — D3-style verbatim,
+   each behind the coherence canaries.
+3. **Biggest:** paged-attention traits refactor (C1) — own brainstorm→spec→plan,
+   each variant verified against current output.
+4. **Decision, not code:** unbridged config keys (C5) — bridge or retire.
+
+---
+
+## Progress
+
+- **C6 — DONE (this PR):** `inference_state.h` forward-declares `JsonConstrainer`
+  / `SchemaConstrainer` instead of including their headers; `executor.cu` gains a
+  direct `#include "compute/schema_constrain.h"` (it dereferences
+  `schema_constrainer->apply_mask`). `engine_scheduler.cpp` only assigns/null-
+  checks the pointers → forward decl suffices.
+- **C7 — DONE (this PR):** new `tests/test_cuda_skip.h` owns
+  `imp::test::HasCudaDevice()` + `SKIP_IF_NO_CUDA()`; the 11 local macro
+  definitions and 6 local `HasCudaDevice()` re-definitions removed and replaced
+  with the include. `get_model_path()` dedup (3 files) left for a follow-up.
+</content>

--- a/src/exec/executor.cu
+++ b/src/exec/executor.cu
@@ -8,6 +8,7 @@
 #include "quant/quant_gemm.h"
 #include "quant/nvfp4_gemm.h"
 #include "compute/json_constrain.h"
+#include "compute/schema_constrain.h"
 #include "core/logging.h"
 
 #include <cuda_runtime.h>

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -4,14 +4,18 @@
 #include "memory/kv_cache.h"     // KVCache
 #include "memory/ssm_state.h"    // SSMState
 #include "memory/gdn_state.h"    // GDNState
-#include "compute/json_constrain.h"    // JsonConstrainer
-#include "compute/schema_constrain.h"  // SchemaConstrainer
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <utility>
 #include <vector>
 
 namespace imp {
+
+// Constrained-decoding hooks are referenced only by pointer here; their full
+// definitions live in compute/json_constrain.h / compute/schema_constrain.h and
+// are included by the TUs that dereference them (executor.cu).
+class JsonConstrainer;
+class SchemaConstrainer;
 
 // All the state needed for a single forward pass invocation.
 struct InferenceState {

--- a/tests/test_continuous_batching.cpp
+++ b/tests/test_continuous_batching.cpp
@@ -6,6 +6,7 @@
 #include "runtime/scheduler.h"
 #include "memory/kv_cache.h"
 #include "memory/kv_cache_manager.h"
+#include "test_cuda_skip.h"
 
 #include <cstdint>
 #include <memory>
@@ -13,22 +14,6 @@
 
 namespace imp {
 namespace {
-
-// ============================================================================
-// Helper: skip the entire test if no CUDA device is available.
-// ============================================================================
-static bool HasCudaDevice() {
-    int count = 0;
-    cudaError_t err = cudaGetDeviceCount(&count);
-    return err == cudaSuccess && count > 0;
-}
-
-#define SKIP_IF_NO_CUDA()                               \
-    do {                                                \
-        if (!HasCudaDevice()) {                         \
-            GTEST_SKIP() << "No CUDA device available"; \
-        }                                               \
-    } while (0)
 
 // ============================================================================
 // BatchBuilder Tests

--- a/tests/test_cuda_skip.h
+++ b/tests/test_cuda_skip.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// CUDA-presence gate shared across the test suite.
+//
+// Before this header, `HasCudaDevice()` was re-defined in 6 files and the
+// `SKIP_IF_NO_CUDA()` macro in 11 — with three divergent bodies (a fully
+// qualified call, a raw cudaGetDevice check, an unqualified call). This is the
+// single source of truth.
+//
+// Kept separate from test_model_builder.h on purpose: that header pulls in
+// model/model.h + cuda_fp16/half, which host-compiled .cpp tests should not be
+// forced to include just to gate on a CUDA device. This header needs only
+// <cuda_runtime.h>.
+
+#include <cuda_runtime.h>
+
+namespace imp {
+namespace test {
+
+inline bool HasCudaDevice() {
+    int count = 0;
+    cudaError_t err = cudaGetDeviceCount(&count);
+    return err == cudaSuccess && count > 0;
+}
+
+}  // namespace test
+}  // namespace imp
+
+#define SKIP_IF_NO_CUDA()                               \
+    do {                                                \
+        if (!::imp::test::HasCudaDevice()) {            \
+            GTEST_SKIP() << "No CUDA device available"; \
+        }                                               \
+    } while (0)

--- a/tests/test_fp8_kv_cache.cu
+++ b/tests/test_fp8_kv_cache.cu
@@ -10,22 +10,10 @@
 #include "core/tensor.h"
 #include "quant/fp8_quant.h"
 #include "compute/attention_paged.h"
+#include "test_cuda_skip.h"
 
 namespace imp {
 namespace {
-
-static bool HasCudaDevice() {
-    int count = 0;
-    cudaError_t err = cudaGetDeviceCount(&count);
-    return err == cudaSuccess && count > 0;
-}
-
-#define SKIP_IF_NO_CUDA()                               \
-    do {                                                \
-        if (!HasCudaDevice()) {                         \
-            GTEST_SKIP() << "No CUDA device available"; \
-        }                                               \
-    } while (0)
 
 // ============================================================================
 // Test 1: FP8 KV Cache construction — verify half-sized blocks

--- a/tests/test_green_ctx.cu
+++ b/tests/test_green_ctx.cu
@@ -7,24 +7,10 @@
 #include <vector>
 #include <atomic>
 
+#include "test_cuda_skip.h"
+
 namespace imp {
 namespace {
-
-// ============================================================================
-// Helper: skip if no CUDA device
-// ============================================================================
-static bool HasCudaDevice() {
-    int count = 0;
-    cudaError_t err = cudaGetDeviceCount(&count);
-    return err == cudaSuccess && count > 0;
-}
-
-#define SKIP_IF_NO_CUDA()                               \
-    do {                                                \
-        if (!HasCudaDevice()) {                         \
-            GTEST_SKIP() << "No CUDA device available"; \
-        }                                               \
-    } while (0)
 
 // Simple kernel for testing graph capture
 __global__ void add_one_kernel(float* data, int n) {

--- a/tests/test_hadamard.cu
+++ b/tests/test_hadamard.cu
@@ -7,6 +7,8 @@
 #include <vector>
 #include <numeric>
 
+#include "test_cuda_skip.h"
+
 namespace imp {
 namespace {
 
@@ -14,14 +16,6 @@ namespace {
     do {                                                                          \
         cudaError_t err = (call);                                                 \
         ASSERT_EQ(err, cudaSuccess) << "CUDA error: " << cudaGetErrorString(err); \
-    } while (0)
-
-#define SKIP_IF_NO_CUDA()                     \
-    do {                                      \
-        int dev_count = 0;                    \
-        cudaGetDeviceCount(&dev_count);       \
-        if (dev_count == 0)                   \
-            GTEST_SKIP() << "No CUDA device"; \
     } while (0)
 
 // CPU reference: Walsh-Hadamard transform (in-place, unnormalized).

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -10,12 +10,7 @@
 #include <string>
 #include <cfloat>
 
-#define SKIP_IF_NO_CUDA()                       \
-    do {                                        \
-        int dev;                                \
-        if (cudaGetDevice(&dev) != cudaSuccess) \
-            GTEST_SKIP();                       \
-    } while (0)
+#include "test_cuda_skip.h"
 
 namespace imp {
 namespace {

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -14,24 +14,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include "test_cuda_skip.h"
+
 namespace imp {
 namespace {
-
-// ============================================================================
-// Helper: skip the entire test if no CUDA device is available.
-// ============================================================================
-static bool HasCudaDevice() {
-    int count = 0;
-    cudaError_t err = cudaGetDeviceCount(&count);
-    return err == cudaSuccess && count > 0;
-}
-
-#define SKIP_IF_NO_CUDA()                               \
-    do {                                                \
-        if (!HasCudaDevice()) {                         \
-            GTEST_SKIP() << "No CUDA device available"; \
-        }                                               \
-    } while (0)
 
 // ============================================================================
 // DeviceAllocator tests

--- a/tests/test_model_builder.h
+++ b/tests/test_model_builder.h
@@ -5,6 +5,7 @@
 
 #include "model/model.h"
 #include "core/tensor.h"
+#include "test_cuda_skip.h"  // HasCudaDevice() + SKIP_IF_NO_CUDA()
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -18,19 +19,6 @@ namespace test {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-inline bool HasCudaDevice() {
-    int count = 0;
-    cudaError_t err = cudaGetDeviceCount(&count);
-    return err == cudaSuccess && count > 0;
-}
-
-#define SKIP_IF_NO_CUDA()                               \
-    do {                                                \
-        if (!::imp::test::HasCudaDevice()) {            \
-            GTEST_SKIP() << "No CUDA device available"; \
-        }                                               \
-    } while (0)
-
 inline Tensor make_random_weight(int64_t rows, int64_t cols, std::mt19937& rng, float scale = 0.02f) {
     std::normal_distribution<float> dist(0.0f, scale);
     int64_t n = rows * cols;

--- a/tests/test_prefix_cache_equiv.cpp
+++ b/tests/test_prefix_cache_equiv.cpp
@@ -41,21 +41,10 @@
 #include <numeric>
 #include <vector>
 
+#include "test_cuda_skip.h"
+
 namespace imp {
 namespace {
-
-static bool HasCudaDevice() {
-    int count = 0;
-    cudaError_t err = cudaGetDeviceCount(&count);
-    return err == cudaSuccess && count > 0;
-}
-
-#define SKIP_IF_NO_CUDA()                               \
-    do {                                                \
-        if (!HasCudaDevice()) {                         \
-            GTEST_SKIP() << "No CUDA device available"; \
-        }                                               \
-    } while (0)
 
 // Real manager over a real (small) KV pool. F16 so k_ptr/v_ptr are plain
 // contiguous device memory we can byte-copy in and out.

--- a/tests/test_quant_integration.cu
+++ b/tests/test_quant_integration.cu
@@ -17,25 +17,14 @@
 #include <random>
 #include <unordered_set>
 
+#include "test_cuda_skip.h"
+
 namespace imp {
 namespace {
 
 // ===========================================================================
 // Helpers
 // ===========================================================================
-
-static bool HasCudaDevice() {
-    int count = 0;
-    cudaError_t err = cudaGetDeviceCount(&count);
-    return err == cudaSuccess && count > 0;
-}
-
-#define SKIP_IF_NO_CUDA()                               \
-    do {                                                \
-        if (!HasCudaDevice()) {                         \
-            GTEST_SKIP() << "No CUDA device available"; \
-        }                                               \
-    } while (0)
 
 // Host-side FP16 conversion helpers (bitwise, no CUDA device intrinsics)
 static float fp16_to_float(uint16_t h) {

--- a/tests/test_softmax.cu
+++ b/tests/test_softmax.cu
@@ -8,12 +8,7 @@
 #include <cmath>
 #include <limits>
 
-#define SKIP_IF_NO_CUDA()                       \
-    do {                                        \
-        int dev;                                \
-        if (cudaGetDevice(&dev) != cudaSuccess) \
-            GTEST_SKIP();                       \
-    } while (0)
+#include "test_cuda_skip.h"
 
 namespace imp {
 namespace {

--- a/tests/test_ssm.cu
+++ b/tests/test_ssm.cu
@@ -7,12 +7,7 @@
 #include <vector>
 #include <cmath>
 
-#define SKIP_IF_NO_CUDA()                       \
-    do {                                        \
-        int dev;                                \
-        if (cudaGetDevice(&dev) != cudaSuccess) \
-            GTEST_SKIP();                       \
-    } while (0)
+#include "test_cuda_skip.h"
 
 namespace imp {
 namespace {


### PR DESCRIPTION
## Audit

Fresh codebase-wide structural pass over what the 2026-06-08 audit (D1–D4, focused on `src/exec/`) did **not** cover: `src/compute/` (40k LOC = 40% of the tree, previously untouched), the loader family, header/dependency hygiene, and the test suite. Full report: `docs/audit/structural_debt_2026_06_09.md`.

Highlights:
- **C1** paged-attention duplication — 6 variants reimplement the same online-softmax core loop (~2k LOC repeated); traits-template candidate.
- **C2** `compute/` god-files (`gdn.cu`, `gemm.cu`, `sampling.cu`, `json_schema.cpp`) — verbatim-splittable.
- **C3** `weight_map.cpp` 858-line matcher ladder + GPTQ/NVFP4 slicing dups.
- **C4** GGUF↔SafeTensors config-parse divergence (the #514/#516 bug class, in the loaders).
- **C5** the two 2026-06-08 deferred findings (dead `q4k_imma` cache; unbridged `server.*`/`paths.mmproj` keys) re-verified still open.
- **Header/dependency layer is clean** (no cycle, 100% `#pragma once`, public API leaks nothing).
- **Refuted:** several agent-reported "dead flags/files" were false positives (search omitted `tools/` / referenced an already-deleted tree) — recorded so they aren't re-chased.

## Cheap sweep applied (verbatim, behaviour-neutral)

**C6** — `exec/inference_state.h` forward-declares `JsonConstrainer`/`SchemaConstrainer` instead of including their ~190-line headers (which rode transitively into every `executor.h` consumer). `executor.cu` gains a direct `compute/schema_constrain.h` include; `engine_scheduler.cpp` only assigns/null-checks the pointers so the forward decl suffices.

**C7** — new lightweight `tests/test_cuda_skip.h` owns the single `HasCudaDevice()` + `SKIP_IF_NO_CUDA()`; removed **11 local macro definitions** (three divergent bodies) + **6 local `HasCudaDevice()`** re-definitions. Kept separate from the heavy `test_model_builder.h` so host-compiled `.cpp` tests don't pull in `cuda_fp16`/`half` just to gate on a device.

## Verification
- `make build` (CUDA 13.3) — green (full compile incl. all test TUs)
- `make test-unit` — 37/37 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)