### PR TITLE
refactor(compute): remove dead routing/sampling kernels (audit C8)

### DIFF
--- a/src/compute/moe_routing.cu
+++ b/src/compute/moe_routing.cu
@@ -439,62 +439,6 @@ void moe_add_expert_bias_sorted(void* buf_fp16, const void* bias_fp16, const int
 }
 
 // ============================================================================
-// Kernel 2: Count tokens per expert
-//
-// Each token contributes top_k entries.  We atomically increment per-expert
-// counts.  expert_counts has n_experts elements, initialized to zero.
-// ============================================================================
-
-__global__ void count_tokens_per_expert_kernel(const int32_t* __restrict__ expert_indices, int n_tokens,
-                                               int top_k, int32_t* __restrict__ expert_counts) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int total = n_tokens * top_k;
-    if (idx < total) {
-        int expert = expert_indices[idx];
-        atomicAdd(&expert_counts[expert], 1);
-    }
-}
-
-// ============================================================================
-// Kernel 3: Exclusive prefix sum (scan) on expert_counts to produce
-// expert_offsets.  Single block, single thread (n_experts is small).
-// ============================================================================
-
-__global__ void exclusive_scan_kernel(const int32_t* __restrict__ counts, int32_t* __restrict__ offsets,
-                                      int n_experts) {
-    if (threadIdx.x == 0) {
-        int32_t running = 0;
-        for (int i = 0; i < n_experts; ++i) {
-            offsets[i] = running;
-            running += counts[i];
-        }
-        offsets[n_experts] = running;  // total
-    }
-}
-
-// ============================================================================
-// Kernel 4: Scatter token IDs into sorted_token_ids based on expert assignment.
-//
-// For each (token, j) pair where expert_indices[token*top_k + j] == e,
-// place the token into the e-th bucket of sorted_token_ids.
-// We use atomicAdd on a write-position counter per expert.
-// ============================================================================
-
-__global__ void scatter_token_ids_kernel(const int32_t* __restrict__ expert_indices,
-                                         const int32_t* __restrict__ expert_offsets, int n_tokens, int top_k,
-                                         int32_t* __restrict__ sorted_token_ids,
-                                         int32_t* __restrict__ expert_write_pos) {  // [n_experts], init to 0
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int total = n_tokens * top_k;
-    if (idx < total) {
-        int token = idx / top_k;
-        int expert = expert_indices[idx];
-        int pos = atomicAdd(&expert_write_pos[expert], 1);
-        sorted_token_ids[expert_offsets[expert] + pos] = token;
-    }
-}
-
-// ============================================================================
 // Kernel 5: Gather -- reorder tokens by expert assignment
 //
 // For each position i in sorted_token_ids:
@@ -547,25 +491,6 @@ __global__ void moe_gather_kernel_impl(const T* __restrict__ input,
 //
 // We'll store this auxiliary array right after sorted_token_ids in memory.
 // ============================================================================
-
-// Extended scatter kernel that also writes flat indices.
-__global__ void scatter_token_ids_with_flat_idx_kernel(
-    const int32_t* __restrict__ expert_indices, const int32_t* __restrict__ expert_offsets, int n_tokens,
-    int top_k, int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ sorted_flat_idx,
-    int32_t* __restrict__ expert_write_pos, int32_t* __restrict__ token_to_expanded) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int total = n_tokens * top_k;
-    if (idx < total) {
-        int token = idx / top_k;
-        int expert = expert_indices[idx];
-        int pos = atomicAdd(&expert_write_pos[expert], 1);
-        int dest = expert_offsets[expert] + pos;
-        sorted_token_ids[dest] = token;
-        sorted_flat_idx[dest] = idx;  // flat index into expert_weights
-        if (token_to_expanded)
-            token_to_expanded[idx] = dest;  // inverse map
-    }
-}
 
 // Scatter-add kernel using the flat index to look up weights.
 // Reads from T* expert output (float or half), always accumulates into float* output.
@@ -761,12 +686,6 @@ __global__ void __launch_bounds__(256) moe_fused_permute_deterministic_kernel(
 // ============================================================================
 // Utility: zero-initialize device memory
 // ============================================================================
-
-__global__ void zero_int32_kernel(int32_t* data, int n) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < n)
-        data[idx] = 0;
-}
 
 __global__ void zero_float_kernel(float* data, int n) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;

--- a/src/compute/sampling.cu
+++ b/src/compute/sampling.cu
@@ -568,18 +568,6 @@ __global__ void topk_topp_sample_kernel(const float* __restrict__ logits, int vo
 // kernels). The single-block kernel above handles the graph-captured path.
 // ============================================================================
 
-// Kernel: compute softmax probabilities with temperature into key/value arrays
-__global__ void softmax_to_pairs_kernel(const float* __restrict__ logits, int vocab_size,
-                                        float inv_temperature, float global_max, float inv_sum,
-                                        float* __restrict__ d_keys, int32_t* __restrict__ d_values) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= vocab_size)
-        return;
-    float prob = expf((logits[idx] - global_max) * inv_temperature) * inv_sum;
-    d_keys[idx] = prob;
-    d_values[idx] = idx;
-}
-
 // Kernel: compute softmax probabilities reading max/sum from device memory.
 // d_max_sum[0] = global_max, d_max_sum[1] = sum. Avoids 2 D2H syncs.
 __global__ void softmax_to_pairs_device_kernel(const float* __restrict__ logits, int vocab_size,
@@ -618,29 +606,6 @@ __global__ void softmax_max_kernel(const float* __restrict__ logits, int vocab_s
             if (s_max[w] > mx)
                 mx = s_max[w];
         atomicMax(reinterpret_cast<int*>(d_max), __float_as_int(mx));
-    }
-}
-
-// Kernel: compute sum of exp(logits - max) (Phase 2, launched after max is known)
-__global__ void softmax_sum_kernel(const float* __restrict__ logits, int vocab_size, float inv_temperature,
-                                   float global_max, float* __restrict__ d_sum) {
-    __shared__ float s_sum[BLOCK_SIZE / WARP_SIZE];
-
-    float local_sum = 0.0f;
-    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < vocab_size; i += blockDim.x * gridDim.x) {
-        local_sum += expf((logits[i] - global_max) * inv_temperature);
-    }
-    local_sum = warp_reduce_sum(local_sum);
-    int warp_id = threadIdx.x / WARP_SIZE;
-    int lane_id = threadIdx.x % WARP_SIZE;
-    if (lane_id == 0)
-        s_sum[warp_id] = local_sum;
-    __syncthreads();
-    if (threadIdx.x == 0) {
-        float sm = 0.0f;
-        for (int w = 0; w < BLOCK_SIZE / WARP_SIZE; w++)
-            sm += s_sum[w];
-        atomicAdd(d_sum, sm);
     }
 }
 


### PR DESCRIPTION
Audit finding **C8** (`docs/audit/structural_debt_2026_06_09.md`): five `__global__` kernels with **zero launch sites** and no header declaration.

Verified dead — each symbol appeared only at its own definition line across `src/ tests/ tools/`, and removal links cleanly (a live launch would fail the link):

- **`moe_routing.cu`** — the legacy pre-fused MoE routing path (replaced by `moe_fused_permute_kernel`): `count_tokens_per_expert_kernel`, `exclusive_scan_kernel`, `scatter_token_ids_kernel`, `scatter_token_ids_with_flat_idx_kernel`, `zero_int32_kernel`. The live `moe_gather_kernel_impl` / `moe_scatter_kernel_impl` / `zero_float_kernel` sit interleaved and are untouched.
- **`sampling.cu`** — `softmax_to_pairs_kernel`, `softmax_sum_kernel`; their device-memory variants (`*_device_kernel` / `*_device_max_kernel`) are the live ones and stay.

116 LOC removed, no live path touched.

## Verification
- `make build` (CUDA 13.3) — green (clean link proves no launch site)
- `make test-unit` — 37/37 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)