### PR TITLE
fix(config): bridge inert imp.conf [server]/[paths] keys (audit C5)

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -215,17 +215,19 @@ mtp_no_rope          = false
 
 [server]
 # Prefix caching: reuse KV blocks for shared prompt prefixes (system
-# prompts, multi-turn history). Default ON since the #536/#538
-# stale-block-table fix; PrefixCacheE2ETest guards hit==fresh equality.
-# Auto-disabled for recurrent (SSM/GDN) models.
+# prompts, multi-turn history). Read by the engine and ORed into the live
+# config at init; PrefixCacheE2ETest guards hit==fresh equality.
+# Auto-disabled for recurrent (SSM/GDN) models. (Library/C-API embedders
+# that do not load imp.conf default to OFF.)
 prefix_cache         = true
 # Cap on KV blocks pinned by Anthropic cache_control / "cache_prompt"
 # requests, as percent of the KV pool. Oldest pins recycle FIFO. 0 = pin
 # requests are ignored.
 prefix_pin_budget_pct = 25
 # Green Contexts / prefill-decode overlap streams in the server engine.
-# false = disable (diagnostic).
-green_contexts       = true
+# Opt-in (off by default): suspected memSyncDomain race on sm_120 fallback
+# streams (gemma-3-12b IMA). Set true to enable.
+green_contexts       = false
 
 [bench]
 # imp-cli --bench: also run Engine::generate() loop for accurate timing.

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -359,16 +359,19 @@ struct RuntimeConfig {
     } generation;
 
     struct Server {
-        // Prefix caching: default ON since the #536/#538 stale-block-table fix
-        // (the historical "FP rounding" off-by-default rationale was a
-        // misattribution of that bug; PrefixCacheE2ETest is the ship gate).
-        bool prefix_cache = true;
+        // Prefix caching: reuse KV blocks for shared prompt prefixes. Defaults
+        // OFF here to match the EngineConfig default (off-by-default for
+        // library/C-API embedders); the server/CLI opt in via imp.conf
+        // ([server] prefix_cache = true, the value in imp.conf.example). The
+        // engine ORs this into EngineConfig.use_prefix_caching at init.
+        // PrefixCacheE2ETest is the ship gate; auto-disabled for SSM/GDN.
+        bool prefix_cache = false;
         // Cap on cache_control/cache_prompt-pinned blocks, % of the KV pool.
         int prefix_pin_budget_pct = 25;
         // Green Contexts / prefill-decode overlap streams in the server engine.
-        // [server] green_contexts = false to disable (diagnostic: suspected
-        // memSyncDomain race on sm_120 fallback streams — gemma-3-12b IMA).
-        bool green_contexts = true;
+        // OFF by default (suspected memSyncDomain race on sm_120 fallback
+        // streams — gemma-3-12b IMA); opt in via [server] green_contexts = true.
+        bool green_contexts = false;
     } server;
 
     struct Bench {

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -431,6 +431,23 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // defaults.
     runtime_config_ = take_pending_runtime_config();
 
+    // Bridge the documented imp.conf [server]/[paths] keys into the live
+    // EngineConfig. These keys are user-facing (imp.conf.example) but were
+    // parsed into RuntimeConfig and never read — the live path flowed only
+    // through the C-API/CLI, so setting them in imp.conf was silently inert
+    // (the wiring PR #541 intended for [server] prefix_cache regressed in a
+    // later refactor). imp.conf is the user's persistent preference; a CLI
+    // flag / C-API value can additionally ENABLE a knob (OR), so a library
+    // embedder's explicit choice is never clobbered. --mmproj (explicit
+    // one-shot) overrides imp.conf. RuntimeConfig defaults for these match the
+    // EngineConfig defaults (off), so no-imp.conf embedders are unaffected.
+    config_.use_prefix_caching = config_.use_prefix_caching || runtime_config_.server.prefix_cache;
+    config_.use_green_contexts = config_.use_green_contexts || runtime_config_.server.green_contexts;
+    if (config_.prefix_pin_budget_pct == 25)  // EngineConfig default untouched → take imp.conf
+        config_.prefix_pin_budget_pct = runtime_config_.server.prefix_pin_budget_pct;
+    if (config_.mmproj_path.empty())
+        config_.mmproj_path = runtime_config_.paths.mmproj;
+
     // The deterministic kernel gate lives in process_diag (compute kernels
     // read process_diag_deterministic_gemm()), but process_diag_install()
     // only runs in tool mains. Promote the gate here so library/test


### PR DESCRIPTION
Audit finding **C5** (`docs/audit/structural_debt_2026_06_09.md`): the keys `server.prefix_cache`, `server.green_contexts`, `server.prefix_pin_budget_pct`, `paths.mmproj` are documented in `imp.conf.example` but were parsed into `RuntimeConfig` and **never read** — the live path flowed only through the C-API/CLI, so setting them in `imp.conf` was silently inert. The wiring PR #541 intended for `[server] prefix_cache` had regressed in a later refactor.

## Fix
Bridge them into the live `EngineConfig` at engine init, right after the pending `RuntimeConfig` is taken (`engine.cpp`):

```cpp
config_.use_prefix_caching = config_.use_prefix_caching || runtime_config_.server.prefix_cache;
config_.use_green_contexts = config_.use_green_contexts || runtime_config_.server.green_contexts;
if (config_.prefix_pin_budget_pct == 25)  // EngineConfig default untouched -> take imp.conf
    config_.prefix_pin_budget_pct = runtime_config_.server.prefix_pin_budget_pct;
if (config_.mmproj_path.empty())
    config_.mmproj_path = runtime_config_.paths.mmproj;
```

**OR semantics** for the enable bools: `imp.conf` is the user's persistent preference, and a CLI flag / C-API value can additionally enable a knob — so a library embedder's explicit choice is never clobbered. `--mmproj` (explicit one-shot) overrides `imp.conf`.

## Behavior / no-regression
The `RuntimeConfig` defaults for these previously **claimed "default ON" in a comment but were never applied** (running default was off everywhere). Realigned them to the real `EngineConfig` defaults (off), so **no-imp.conf embedders are unaffected**. `imp.conf.example`:
- `prefix_cache = true` (kept — restores the intended server-on behavior; `PrefixCacheE2ETest` is the ship gate, auto-disabled for SSM/GDN).
- `green_contexts = false` (set to opt-in — suspected sm_120 memSyncDomain race, gemma-3-12b IMA).

## Verification
- Functional: `imp.conf prefix_cache=true` → engine logs `Prefix caching enabled (pin budget 512 blocks)`; `=false` → not enabled.
- `make build` (CUDA 13.3) + `make test-unit` (37/37) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)