### PR TITLE
chore(cleanup): audit follow-ups — dead q4k_imma cache, test + config nits

### DIFF
--- a/docs/audit/structural_debt_2026_06_09.md
+++ b/docs/audit/structural_debt_2026_06_09.md
@@ -75,11 +75,15 @@ medium pain × high risk.
 
 ## C5 — Deferred 2026-06-08 findings, still open (re-verified)
 
-- **Dead `WeightCaches::q4k_imma` cache** — re-confirmed never populated (no
-  `use_q4k_imma = true`, no insertion into the map anywhere in `src/`); only
-  declared (`exec/weight_caches.h:99`) + freed. ~1,200 LOC of tile/reorder infra.
-  The *live* path is the separate `q4k_imma_prefill` stack. Removal is D3-class
-  kernel work.
+- **Dead `WeightCaches::q4k_imma` cache — REMOVED (follow-up).** Re-confirmed
+  never populated (no `use_q4k_imma = true`, no insertion anywhere). **Correction
+  to the "~1,200 LOC tile/reorder stack" estimate:** the call-graph shows the
+  *live* `mmq_q4k_imma_gemm` (the `q4k_imma_prefill` path) calls
+  `mmq_q4k_imma_reorder` + `mmq_q4k_imma_tile` on-the-fly — those kernels are
+  **live, not dead**. The only dead code was the unused cache struct itself
+  (`Q4kImmaCacheEntry` map + `use_q4k_imma` + `q4k_imma_bytes`, ~30 LOC in
+  `weight_caches.h`) and its always-empty free loop in
+  `executor_workspace_buffers.cu`. Removed those; the kernels stay.
 - **Unbridged config keys** — `server.prefix_cache`, `server.green_contexts`,
   `server.prefix_pin_budget_pct`, `paths.mmproj` are parsed into `RuntimeConfig`
   but **never read** (`grep cfg.server.` finds only the parse lines); the live

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -157,8 +157,7 @@ no_mmvq_q8_0         = false
 # Trades VRAM for decode throughput on sub-8-bit models.
 # Gemma-3-12B Q4_K_M: 77 → 141 tok/s (+82%).
 nvfp4_decode_all     = false
-# Q4_K IMMA / HMMA tensor-core GEMM scaffolds (experimental, default off).
-q4k_imma_enabled     = false
+# Q4_K HMMA tensor-core GEMM scaffold (experimental, default off).
 q4k_hmma_enabled     = false
 # Quantize a native FP16/BF16 LM head to an NVFP4 decode cache (dense
 # models; ~+8-16% decode). Default ON.

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -993,14 +993,6 @@ void GraphExecutor::free_buffers() {
             free_cutlass_mxfp4_weight(mw);
         wcache_.cutlass_mxfp4.clear();
         wcache_.cutlass_mxfp4_bytes = 0;
-        // Q4_K_M direct IMMA cache (Phase 2C infrastructure)
-        for (auto& [ptr, entry] : wcache_.q4k_imma) {
-            if (entry.w_sym_s8) cudaFree(entry.w_sym_s8);
-            if (entry.eff_alpha) cudaFree(entry.eff_alpha);
-            if (entry.eff_beta) cudaFree(entry.eff_beta);
-        }
-        wcache_.q4k_imma.clear();
-        wcache_.q4k_imma_bytes = 0;
         // FP8 cache (entries may point into bulk buffers — free entry data only if not in bulk)
         for (auto& [ptr, entry] : wcache_.fp8) {
             if (entry.weight.data) {

--- a/src/exec/weight_caches.h
+++ b/src/exec/weight_caches.h
@@ -81,32 +81,6 @@ struct WeightCaches {
     size_t cutlass_mxfp4_bytes = 0;
     bool use_mxfp4 = false;
 
-    // --- Q4_K_M direct INT8 IMMA cache (Phase 2C infrastructure) ---
-    // NOTE (2026-06-08): currently INACTIVE. The load-time gate (the former
-    // gemm.q4k_imma_enabled flag) was removed as dead — no path populates this
-    // map; it is only declared + freed. Was meant to be filled by
-    // mmq_q4k_imma_reorder() and consumed by mmq_q4k_imma_tile(). Kept pending a
-    // Phase-2C revival or a full removal of the q4k_imma_tile stack.
-    // Three device buffers per entry:
-    //   w_sym_s8 [N, K]      int8  symmetric-shifted (q - 8)
-    //   eff_alpha [N, K/32]  FP16  d_super · sc[j]
-    //   eff_beta  [N, K/32]  FP16  8·d_super·sc[j] − dmin_super·m[j]
-    // Decode identity: α·q_sym + β  ≡  d·sc·q − dmin·m.
-    //
-    // The Phase 2C dispatcher (separate PR) gates entries on
-    //   M ≥ 1024 && dense && Q4_K_M && !fp16_cache_hit
-    // Off by default until E2E A/B against dense Q4_K_M models lands.
-    struct Q4kImmaCacheEntry {
-        int8_t* w_sym_s8 = nullptr;
-        __half* eff_alpha = nullptr;
-        __half* eff_beta = nullptr;
-        int N = 0;
-        int K = 0;
-    };
-    std::unordered_map<const void*, Q4kImmaCacheEntry> q4k_imma;
-    size_t q4k_imma_bytes = 0;
-    bool use_q4k_imma = false;
-
     // Dual-path mode: FP8 attention + NVFP4 FFN
     bool dual_path_quant = false;
 };

--- a/tests/test_api_generate.cpp
+++ b/tests/test_api_generate.cpp
@@ -19,8 +19,7 @@
 namespace {
 
 static const char* get_model_path() {
-    const char* p = std::getenv(imp_test::kEnvModel);
-    return p ? p : "/models/Qwen3-8B-Q8_0.gguf";
+    return imp_test::env_cstr_or(imp_test::kEnvModel, "/models/Qwen3-8B-Q8_0.gguf");
 }
 
 static bool model_exists() {

--- a/tests/test_degeneration.cpp
+++ b/tests/test_degeneration.cpp
@@ -20,8 +20,7 @@
 namespace {
 
 static const char* get_model_path() {
-    const char* p = std::getenv(imp_test::kEnvModel);
-    return p ? p : "/models/Qwen3-8B-Q8_0.gguf";
+    return imp_test::env_cstr_or(imp_test::kEnvModel, "/models/Qwen3-8B-Q8_0.gguf");
 }
 
 static bool model_exists() {

--- a/tests/test_engine_relaunch.cpp
+++ b/tests/test_engine_relaunch.cpp
@@ -33,8 +33,7 @@
 namespace {
 
 static const char* get_model_path() {
-    const char* p = std::getenv(imp_test::kEnvModel);
-    return p ? p : "/models/Qwen3-8B-Q8_0.gguf";
+    return imp_test::env_cstr_or(imp_test::kEnvModel, "/models/Qwen3-8B-Q8_0.gguf");
 }
 
 static bool model_exists() {

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -84,6 +84,16 @@ inline std::string env_path_or(const char* name, const char* fallback) {
     return v ? std::string(v) : std::string(fallback);
 }
 
+// const char* variant for the suites that pass the result straight to
+// fopen()/the C API. Both the getenv pointer and the literal `fallback` have
+// static lifetime, so the returned pointer is safe to hold. The `fallback`
+// stays at the call site (model<->test mapping visible); only the
+// getenv-or-default mechanic is shared.
+inline const char* env_cstr_or(const char* name, const char* fallback) {
+    const char* v = std::getenv(name);
+    return v ? v : fallback;
+}
+
 }  // namespace imp_test
 
 #endif  // IMP_TESTS_TEST_MODELS_H


### PR DESCRIPTION
The remaining small audit items.

### 1. Remove the dead `WeightCaches::q4k_imma` cache
Re-confirmed never populated (no `use_q4k_imma = true`, no insertion anywhere).

**Correction to the audit's "~1,200 LOC tile/reorder stack" estimate:** the call graph shows the **live** `mmq_q4k_imma_gemm` (the `q4k_imma_prefill` path) calls `mmq_q4k_imma_reorder` + `mmq_q4k_imma_tile` on the fly — those kernels are **live, not dead**. The only dead code was the never-populated cache struct (`Q4kImmaCacheEntry` map + `use_q4k_imma` + `q4k_imma_bytes`, ~30 LOC in `weight_caches.h`) and its always-empty free loop in `executor_workspace_buffers.cu`. Removed those; the kernels stay. Audit doc C5 corrected.

### 2. Drop stale `q4k_imma_enabled` from imp.conf.example
The `gemm.q4k_imma_enabled` flag was removed from the parser in #624, so an `imp.conf` carrying it would log "unknown key". `q4k_hmma_enabled` and `q4k_imma_prefill` are still parsed and stay.

### 3. Dedup `get_model_path()` (C7 follow-up)
Added `imp_test::env_cstr_or()` to `test_models.h`; the 3 suites (`test_api_generate`, `test_engine_relaunch`, `test_degeneration`) delegate to it. The getenv-or-default mechanic is shared; the model-path literal stays at the call site (the header's documented design — model↔test mapping stays visible).

## Verification
- `make build` (CUDA 13.3) + `make test-unit` (37/37) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)