### PR TITLE
skills: add codebase-audit + docs-sync

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -12,10 +12,13 @@ description states when to fire AND when not to — keep that property when edit
 | [server-api](server-api/SKILL.md) | imp-server endpoints (OpenAI + Anthropic), streaming, json_schema, tool calling, cache_control, validation tools | check-degeneration |
 | [add-model-arch](add-model-arch/SKILL.md) | New-architecture integration checklist + wrong-output diagnostic fingerprints | quant-formats, check-degeneration |
 | [quant-formats](quant-formats/SKILL.md) | GGUF/NVFP4/FP8 formats, StorageTier dispatch contract, decode cache, KV dtypes | sm120-cuda-expert |
+| [codebase-audit](codebase-audit/SKILL.md) | Structural-debt / dead-code / god-file / flag audits + the verification discipline that stops fan-out over-flagging; `docs/audit/` convention | building-and-testing, check-degeneration |
+| [docs-sync](docs-sync/SKILL.md) | Keeping architecture.md / README / GOAL.md / supported-models.md / imp.conf.example / CHANGELOG coherent after a change; English-only rule | benchmark-cuda (perf), codebase-audit |
 
 Boundaries (to avoid trigger collisions):
 
 - *Measure* perf → benchmark-cuda · *write* the kernel → sm120-cuda-expert · *is the output still sane* → check-degeneration.
 - *Build/test mechanics & CI* → building-and-testing · *model output via HTTP* → server-api · *model loads but is wrong* → add-model-arch · *bytes/scales/tiers* → quant-formats.
+- *Is this code dead / should we refactor* → codebase-audit · *keep the docs consistent with the code* → docs-sync. Perf-number measurement + `perf_baseline.json` refresh stay with benchmark-cuda (docs-sync only reconciles the surrounding prose).
 
 Audit history: [AUDIT_skills_2026_06_07.md](AUDIT_skills_2026_06_07.md).

--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: codebase-audit
+description: Use when auditing the imp codebase for structural debt, dead code, god-objects/files, duplication, flag sprawl, or deciding whether a cleanup is worth shipping — "structure audit", "tech debt", "is this still used", "dead code", "refactor for clarity", "should we split this file", "remove this flag". Do NOT use for build/test mechanics (building-and-testing), perf/kernel work (benchmark-cuda / sm120-cuda-expert), or output quality (check-degeneration).
+---
+
+# Codebase audit & structural debt — imp
+
+## The one hard rule
+
+**Never act on a raw finding. Verify every finding against the real code first.**
+Fan-out audits (Explore agents, grep sweeps) systematically **over-flag**. On the
+2026-06-09 pass, the big-ticket findings C1/C2/C4 were all REFUTED on inspection,
+and several "dead flags/files" were live. Treat a finding as a *candidate*, not a
+fact, until a targeted check confirms it. Most of an audit's value is in the
+verification, not the sweep.
+
+## Verification recipes (the load-bearing checks)
+
+| Claim | How to actually verify | Trap that fooled a past audit |
+|---|---|---|
+| "flag/symbol X is dead" | grep across **`src/ tests/ tools/`** — `tools/` IS in scope | `dump_tokens`/`force_bos`/`bench.generate` looked dead in `src/`, but are read in `tools/imp-cli/main.cpp` |
+| "config field never read" | grep the leaf field for a **value-read in a conditional**, excluding decl/parse/copy | a local var sharing the field name hides the read (`fp8_auto_legacy`) |
+| "kernel/function is dead" | trace the **call graph**, not just `<<<` sites — reachable from a live dispatch = live | `q4k_imma` *cache* was dead, but `mmq_q4k_imma_tile`/`_reorder` are LIVE via `q4k_imma_prefill → mmq_q4k_imma_gemm` (called on the fly). Only the ~30-LOC cache struct was dead, not the "~1200 LOC stack" |
+| "this file is a god-file, split it" | **split on conflation, not size**; check if the shared part is already factored | `gdn.cu`/`gemm.cu`/`sampling.cu`/`json_schema.cpp` are each one cohesive domain. The 6 `attention_paged*` variants already share `attention_paged_common.cuh` (online-softmax loop) — only dequant differs |
+| "rewrite this into a registry/template" | **no speculative abstraction** — need a concrete bug, not a smell | the `weight_map.cpp` `if (!matched)` ladder works and is readable; a mis-mapped tensor name = garbage output. Risk > cosmetic gain |
+| "imp.conf key is inert" | is it read in `src/` AND `tools/`? Is the live path the **C-API** instead? | `server.prefix_cache` etc. were parsed but unread — live enablement bridges at engine init (PR #636) |
+
+## Workflow
+
+1. **Fan out** — Explore agents / grep to surface candidates (breadth is fine here).
+2. **Verify each** with the recipe above. Demote refuted ones immediately.
+3. **Write it up** — `docs/audit/structural_debt_YYYY-MM-DD.md`. Counts are evidence,
+   not estimates. Keep a **"Refuted (do not re-chase)"** section so the next pass
+   doesn't re-flag the same false positives.
+4. **Ship cleanups** as small PRs (REQUIRED SUB-SKILL: building-and-testing) — branch
+   off `main`, never stack, Docker `make build` + `make test-unit`, prefer batching
+   related nits. Behavior-sensitive removals: also a coherence check (check-degeneration).
+
+## Priors — settled, do NOT re-flag
+
+From `docs/audit/structural_debt_2026-06-08.md` (D1–D4) + `..._2026-06-09.md`:
+- **exec/ god-object** (`GraphExecutor`) is intrinsically forward-pass-coupled; the
+  D2 runner-extraction track ENDED (cosmetic friend-backdoor only). Header split done
+  (1188→584 lines). Don't re-attempt runner classes.
+- **ModelProfile (D1)** centralized arch facts — don't reintroduce scattered `cfg.arch==`.
+- `gdn.cu` is domain-cohesive ("don't touch"); the compute/ files are not god-files.
+- The two-config-systems split (`RuntimeConfig` global vs `ModelConfig::Overrides`) is
+  known and deliberate; config keys use the typed-binder `B/I/F/S(...)` ladder (PR #626).
+
+## Red flags — you are about to over-flag
+
+- About to delete code because a sweep said "no references" → did you grep `tools/`?
+- About to split a file because it's big → is it *conflated* or just one large domain?
+- About to rewrite a working ladder/loader for elegance → where's the concrete bug?
+- Reporting LOC of "dead" kernels → did you trace the call graph, or just `<<<`?

--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: docs-sync
+description: Use when keeping imp's docs and config examples coherent after a change — updating architecture.md / README / GOAL.md / supported-models.md / imp.conf.example / CHANGELOG / MISSION_JOURNAL, or "is this doc stale", "document this change", "the example config is out of date", "the README says X but the code does Y". Do NOT use for structural code audits (codebase-audit), measuring perf or refreshing the perf baseline (benchmark-cuda), or the agent's private memory (MEMORY.md).
+---
+
+# Docs sync — imp
+
+## Hard rules
+
+1. **English only in the repo.** Every committed artifact — PRs, commits, code
+   comments, `.md` docs — is written entirely in English. (Chat replies to the user
+   stay German; this rule is for things that land in the repo / on GitHub.)
+2. **`imp.conf.example` MUST match the parser.** Every key in the example has to be
+   a real `B/I/F/S("...")` binder in `src/runtime/config.cpp`; a key the parser
+   dropped logs `imp.conf: unknown key` at load (e.g. stale `q4k_imma_enabled` after
+   PR #624). When you add/remove/rename a config field: update `config.h`,
+   `config.cpp`, AND `imp.conf.example` together, with the real default.
+3. **Numbers are commit-anchored.** `tests/perf_baseline.json` is the canonical gate
+   (CI: 3% decode / 5% prefill). `BENCHMARKS.md` rows are
+   `date | commit SHA | CUDA | model | quant | metric | value | exact command` —
+   "the commit SHA is the version". Never paste a tok/s number without the commit +
+   CUDA + reproducing command.
+4. **Verify before you claim.** Docs drift; grep the tree before citing a doc fact.
+   (Audit lore can be stale — e.g. the old "GOAL.md still lists H100/H200" flag was
+   already fixed; GOAL.md:31 now states sm_120a-exclusive.)
+
+## The doc set + what each owns
+
+| Doc | Owns | Touch it when |
+|---|---|---|
+| `docs/architecture.md` | Canonical narrative (the source of truth) | a refactor changes the high-level structure / data flow |
+| `README.md` | User-facing pitch + quickstart + headline numbers | supported models, build steps, or headline perf change |
+| `GOAL.md` | North-star target (Qwen3-14B Q6_K @ctx2048 → 175 tok/s) + hardware scope | the goal or hardware scope changes |
+| `BENCHMARKS.md` | Reproducible perf table (SHA-anchored) | you measured a number worth publishing |
+| `tests/perf_baseline*.json` | The CI perf gate (canonical) | a change intentionally moves perf — refresh via `scripts/gen_perf_baseline.sh` |
+| `docs/supported-models.md` | Supported architectures/models | a new arch/model lands or a quant is dropped |
+| `docs/MISSION_JOURNAL.md` · `docs/scoreboard.tsv` | Mission log · competitive scoreboard | a competitive/strategic result changes |
+| `CHANGELOG.md` | Notable changes | user-visible behavior changes |
+| `docs/audit/` | Audit reports (see codebase-audit) | an audit/cleanup pass |
+
+## When a change lands, sync the matching doc
+
+- **Perf moved** (intentionally) → refresh `perf_baseline.json` via
+  `scripts/gen_perf_baseline.sh`, add a `BENCHMARKS.md` row, and **say so in the PR**.
+  Re-bench properly first (REQUIRED SUB-SKILL: benchmark-cuda — clock ramp + host
+  drift make cold single shots lie).
+- **Config flag added/removed** → `imp.conf.example` + the `config.h`/`config.cpp` pair.
+- **New arch / model / quant** → `docs/supported-models.md` + README if headline.
+- **Structural refactor** → `docs/architecture.md` if the narrative no longer matches.
+
+## Common mistakes
+
+- Editing `BENCHMARKS.md` with a number from a cold/single-shot run (use benchmark-cuda).
+- Adding an `imp.conf.example` key without a parser binder (or vice versa) → silent drift.
+- Writing repo docs/comments in German (English-only rule).
+- "Fixing" a doc from memory without grepping — half the staleness reports are already fixed.
+- Confusing repo docs with the agent's private `MEMORY.md` (that's the auto-memory system, not a repo doc).


### PR DESCRIPTION
Two new project skills (`.claude/skills/`), house format: SKILL.md grounded in the working tree, README index + boundary map, trigger cross-check against the existing seven. Markdown only — no build impact.

### `codebase-audit`
Structural-debt / dead-code / god-file / flag audits, centered on the **verification discipline** that this session repeatedly proved necessary. The 2026-06-09 audit pass refuted its own big-ticket findings (C1/C2/C4) and several "dead" flags/kernels on inspection — the skill encodes the recipes so the next pass doesn't repeat the work:
- grep dead-symbol claims across `src/ tests/ tools/` (**`tools/` is in scope** — the trap that flagged `dump_tokens`/`force_bos` as dead);
- **trace the call graph** before declaring a kernel dead (the `q4k_imma` cache was dead, but its tile/reorder kernels are live via `q4k_imma_prefill`);
- **"split on conflation, not size"** (gdn/gemm/sampling are cohesive; the 6 attention variants already share `attention_paged_common.cuh`);
- **"no speculative abstraction"** (don't rewrite a working ladder/loader without a concrete bug);
- the `docs/audit/` convention + a **Refuted** section + settled priors so they aren't re-flagged.

### `docs-sync`
Keeping `architecture.md` / `README` / `GOAL.md` / `supported-models.md` / `imp.conf.example` / `CHANGELOG` coherent with the code: the English-only rule, the `imp.conf.example`↔parser sync (a dropped key logs "unknown key"), and verify-before-claiming (audit lore goes stale — e.g. the old GOAL.md H100 flag is already fixed). Perf-number measurement + `perf_baseline.json` refresh are **deferred to benchmark-cuda** (no trigger collision; the 06-07 audit had folded bench-docs there).

## Verification (house process)
- Every factual claim checked against the working tree (`tools/` reads, `q4k_imma` call graph, GOAL.md:31, `perf_baseline*.json` + `gen_perf_baseline.sh`, BENCHMARKS SHA-anchoring, `imp.conf.example`).
- Trigger cross-check: `codebase-audit` collides with no existing skill; `docs-sync`'s original "refresh the benchmarks" overlap with `benchmark-cuda` was removed (perf stays with benchmark-cuda). Both descriptions name their negative cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)