### PR TITLE
docs(config): drop orphaned imp.conf.example keys no_dp4a + debug_gemm_dispatch

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -148,7 +148,6 @@ layout_override      = ""
 [gemm]
 # dp4a = INT8 4-element packed multiply-accumulate. mmvq = matrix*vec
 # quantized GEMM. Disabling forces dequant->cuBLAS path (diagnostic).
-no_dp4a              = false
 no_dp4a_gemv         = false
 no_dp4a_lm           = false
 no_mmvq              = false
@@ -248,7 +247,6 @@ sparsity_threshold   = 0.0
 [diagnostics]
 # Verbose per-layer forward dumps. Heavy I/O — use only for bisecting bugs.
 debug_forward        = false
-debug_gemm_dispatch  = false
 # Print intermediate Jinja2 chat-template rendering steps.
 debug_template       = false
 # If non-empty, dump per-layer hidden states as .npy files to this directory.


### PR DESCRIPTION
## What

`/docs-sync` audit found two keys in `imp.conf.example` with **no parser binder** in `src/runtime/config.cpp` — both would log `imp.conf: unknown key` at load (docs-sync hard rule #2):

| Key | Status |
|---|---|
| `no_dp4a` | stale combined flag, long since split into the live `no_dp4a_gemv` / `no_dp4a_lm` (both still bound) |
| `debug_gemm_dispatch` | orphaned since the original config refactor (#72); not read anywhere in `src/`, `include/`, or `tools/` |

Removed both. The surrounding comments stay valid for the remaining live keys.

## Verification

Bidirectional `imp.conf.example` ↔ `config.cpp` binder diff is now **clean — 0 orphaned example keys**.

Checked false positives (left untouched):
- `q4k_imma_prefill` — the live prefill path (only the dead `q4k_imma_enabled` was already dropped in #639).
- `deterministic` — bound via the special-cased `dotted_key == "runtime.deterministic"` block, not a `B()` macro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)