### PR TITLE
perf(attn): f16-accumulate QK^T for FA2 prefill (opt-in) — +3-4% long-ctx (#597)

### DIFF
--- a/docs/audit/attn_fa2_f16acc_2026_06_09.md
+++ b/docs/audit/attn_fa2_f16acc_2026_06_09.md
@@ -1,0 +1,85 @@
+# `attn_fa2` roofline — fresh profile + f16-acc QK^T lever (issue #597)
+
+**Date:** 2026-06-09 · **Issue:** [#597](https://github.com/kekzl/imp/issues/597)
+(`attn_fa2`: 8 % roofline on `nvfp4-moe/pp4096`) · **Outcome:** shipped a measured
++3–4 % long-context prefill lever (opt-in `attention.fa2_f16acc`); the residual
+gap is a documented structural ceiling (the acceptance-criteria alternative).
+
+## Fresh profile changes the bottleneck model (post-#609)
+
+The issue's "8 %" was against the FP16 TC datasheet peak. Two corrections:
+
+1. **Recalibration (#606):** the QK^T HMMA accumulates in f32, which on GeForce
+   sm_120 runs at **¼ rate** (253 of 838 TFLOPS). Against the real f32-acc
+   ceiling the kernel sits at **~33 %**, not 8 %.
+2. **The kernel is no longer LSU-bound.** The owner's earlier "LSU-bound"
+   attribution predates PR #609 (ldmatrix operand fetch). A fresh ncu profile
+   of the live kernel (`fmha_sm120_fa2_kernel<128,128,FP16QK=1>`, the chunked
+   pp4096 path, 2026-06-09) shows:
+
+| Metric | Value | Reading |
+|---|---|---|
+| Tensor-pipe active | **52.8 %** | busiest unit (LSU only 12.2 %, ALU 8.5 %) |
+| SM throughput | 25.6 % | — |
+| Occupancy | 16.7 % | **smem-capped**: 69.6 KB/block → 1 CTA/SM (regs=175 also cap) |
+| waves/SM | **0.75** | grid=128 < 170 SMs — chunked-prefill underfill |
+| dominant stall | **wait = 2.03** | exec-latency exposure at ~1 warp/scheduler |
+
+So post-#609 the kernel is **tensor-pipe-leaning + latency/occupancy-bound**,
+not LSU-bound. The LSU bottleneck #609 targeted is gone (12 %). Profile raw:
+`tools/roofline` recipe, `--kernel-name regex:fmha_sm120_fa2 --launch-skip 20 --launch-count 4`.
+
+## The lever: f16-accumulate QK^T (shipped, opt-in)
+
+Since the tensor pipe is the busiest unit and runs f32-acc at ¼ rate, switching
+the **QK^T** score MMA to f16 accumulate (`mma.m16n8k16.f16.f16.f16.f16`) lifts
+it to the full-rate class. Scores are softmaxed immediately, so the reduced
+accumulate precision is low-risk; PV stays f32-acc (the online O sum needs the
+range). Accumulators also shrink from 4 f32 regs to 2 packed-half2.
+
+**Measured (Qwen3-14B-NVFP4, hd=128, isolated trials, healthy host):**
+
+| Cell | f32-acc (default) | f16-acc | Δ |
+|---|---|---|---|
+| pp4096 | 16374 tok/s | **17026** | **+4.0 %** |
+| pp2048 | 18647 | 19206 | +3.0 % |
+| pp512 | 21306 | 21557 | +1 % (noise) |
+| **perplexity** (201 tok) | 6.4044 | **6.4282** | **+0.37 %** |
+
+A/B in one build via `--set attention.fa2_f16acc=true|false`; off-path is
+byte-identical to the prior kernel (FmhaFA2Test 32/32 + cross-path 4/4 green).
+The +0.37 % PPL is 6× smaller than the already-accepted `nvfp4_lm_head` tradeoff
+(+2.2 %) for a comparable gain. Tool: `tools/analysis/fa2_f16acc_ab.sh`.
+
+**Shipped as opt-in** (`attention.fa2_f16acc`, default off, env `IMP_FA2_F16ACC`):
+it is a quality tradeoff on the prefill score path, and the FP16-QK path exists
+precisely to dodge the short-prefill e4m3 cliff (#511/#512) — so the default
+stays conservative pending broader quality validation (more corpora + the
+degen suite). Only the `fa2_fp16qk` path is affected; the fp8-QK path keeps f32
+accumulate (its f16-acc variant is a documented future extension).
+
+## Why >50 % roofline is not reached on the existing path
+
+Even with the QK pipe relieved, two structural limits remain:
+
+- **Occupancy is double-capped at 1 CTA/SM.** The KV cp.async double-buffer
+  alone is ~70 KB (2×Bkv×(hd+pad)×2B for K and V), and 2×70 KB > the 99 KB
+  opt-in smem — so registers aside, smem already forbids a 2nd CTA. Raising
+  occupancy needs the owner-noted **K single-buffer**, which competes head-on
+  with the −11.6 % cp.async-prefetch win (PR, FA2 double-buffer). Genuine
+  tradeoff, not free.
+- **Grid underfill (0.75 waves)** is intrinsic to chunked prefill: a 512-token
+  chunk × 32 heads / Bq=128 = 128 CTAs < 170 SMs. Dropping to Bq=64 doubles the
+  grid but **halves per-SM occupancy** (4 vs 8 warps, still 1 CTA/SM) → with the
+  wait-latency stall dominant, that trades the wrong way. The launcher already
+  picks Bq=128 here for max latency-hiding.
+
+The kernel therefore operates near the real ceiling of a latency/occupancy-bound
+attention kernel on this consumer-Blackwell smem budget. This issue remains the
+**NVFP4 long-context tracker**; the f16-acc lever is concrete progress on it.
+
+## Files
+
+- `src/compute/attention_fmha_sm120.cu` — `F16ACC` template path + launcher dispatch
+- `src/runtime/{config.h,config.cpp,process_diag.{h,cpp}}` — `attention.fa2_f16acc` flag
+- `imp.conf.example`, `tools/analysis/fa2_f16acc_ab.sh`

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -75,6 +75,11 @@ fmha_fa2             = "on"
 # replaces the materialized cuBLAS+softmax path (PR #525, +25-35% pp512
 # NVFP4). "never" restores the materialized cuBLAS path.
 fa2_fp16qk           = "on"
+# f16-accumulate QK^T in the fp16-qk FA2 kernel (#597). GeForce sm_120 runs
+# f16-src/f32-acc HMMA at 1/4 rate (#606); f16-acc lifts the score MMA to the
+# full-rate class: +3-4% pp2048/pp4096 NVFP4 prefill (Qwen3-14B) for +0.37% PPL.
+# Opt-in quality tradeoff (default false); only the fa2_fp16qk path is affected.
+fa2_f16acc           = false
 # Prefill chunk length (tokens) at/above which attention routes to FMHA
 # (tiled, O(n) memory) instead of the materialized cuBLAS S-matrix path.
 # -1 = auto (derived from the cuBLAS S-matrix VRAM cap).

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -33,6 +33,7 @@
 #include "compute/attention_fmha_sm120.h"
 #include "compute/attention_paged_common.cuh"
 #include "core/logging.h"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
@@ -1186,7 +1187,7 @@ __device__ __forceinline__ void prefetch_kv_tile(half* K_dst, half* V_dst, const
 // the short-sequence variant that replaces the materialized cuBLAS+softmax
 // path below fmha_prefill_threshold without the e4m3 quality risk.
 // Softmax, masking and PV are shared — one grammar of truth for the math.
-template <int Bq, int HD, bool FP16QK = false>
+template <int Bq, int HD, bool FP16QK = false, bool F16ACC = false>
 __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __restrict__ K,
                                       const half* __restrict__ V, half* __restrict__ O, int batch_size,
                                       int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale,
@@ -1328,8 +1329,6 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
             // for tile n+1. A comes from the hoisted loop-invariant a_frag.
 #pragma unroll
             for (int n = 0; n < N_S; n += 2) {
-                float dA[4] = {0.f, 0.f, 0.f, 0.f};
-                float dB[4] = {0.f, 0.f, 0.f, 0.f};
                 const int b_row = (n + (lane >> 4)) * 8 + (lane & 7);
                 const int b_khalf = ((lane >> 3) & 1) << 3;
                 const half* krow = K_cur + b_row * KVSTRIDE + b_khalf;
@@ -1338,36 +1337,91 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
                 // latency is otherwise exposed (short_scoreboard-bound).
                 uint32_t b0, b1, c0, c1;
                 ldsm_x4(b0, b1, c0, c1, krow);
+                if constexpr (F16ACC) {
+                    // f16-accumulate QK^T (#597, opt-in attention.fa2_f16acc).
+                    // GeForce sm_120 runs f16-src/f32-acc HMMA at 1/4 rate (253
+                    // of 838 TFLOPS, #606); f16-acc lifts the score MMA to the
+                    // full-rate class (+3-4% pp2048/pp4096 NVFP4, +0.37% PPL on
+                    // Qwen3-14B). Scores are softmaxed immediately so the
+                    // reduced accumulate precision is low-risk. Accumulators are
+                    // 2 packed-half2 registers (also halves the score reg foot-
+                    // print). PV stays f32-acc (online O sum needs the range).
+                    uint32_t dA[2] = {0u, 0u};
+                    uint32_t dB[2] = {0u, 0u};
 #pragma unroll
-                for (int k = 0; k < HD / 16; k++) {
-                    uint32_t nb0, nb1, nc0, nc1;
-                    if (k + 1 < HD / 16)
-                        ldsm_x4(nb0, nb1, nc0, nc1, krow + (k + 1) * 16);
+                    for (int k = 0; k < HD / 16; k++) {
+                        uint32_t nb0, nb1, nc0, nc1;
+                        if (k + 1 < HD / 16)
+                            ldsm_x4(nb0, nb1, nc0, nc1, krow + (k + 1) * 16);
 #if __CUDA_ARCH__ >= 1200
-                    asm volatile(
-                        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
-                        "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
-                        : "=f"(dA[0]), "=f"(dA[1]), "=f"(dA[2]), "=f"(dA[3])
-                        : "r"(a_frag[k][0]), "r"(a_frag[k][1]), "r"(a_frag[k][2]), "r"(a_frag[k][3]),
-                          "r"(b0), "r"(b1), "f"(dA[0]), "f"(dA[1]), "f"(dA[2]), "f"(dA[3]));
-                    asm volatile(
-                        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
-                        "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
-                        : "=f"(dB[0]), "=f"(dB[1]), "=f"(dB[2]), "=f"(dB[3])
-                        : "r"(a_frag[k][0]), "r"(a_frag[k][1]), "r"(a_frag[k][2]), "r"(a_frag[k][3]),
-                          "r"(c0), "r"(c1), "f"(dB[0]), "f"(dB[1]), "f"(dB[2]), "f"(dB[3]));
+                        asm volatile(
+                            "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+                            "{%0,%1},{%2,%3,%4,%5},{%6,%7},{%0,%1};\n"
+                            : "+r"(dA[0]), "+r"(dA[1])
+                            : "r"(a_frag[k][0]), "r"(a_frag[k][1]), "r"(a_frag[k][2]),
+                              "r"(a_frag[k][3]), "r"(b0), "r"(b1));
+                        asm volatile(
+                            "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+                            "{%0,%1},{%2,%3,%4,%5},{%6,%7},{%0,%1};\n"
+                            : "+r"(dB[0]), "+r"(dB[1])
+                            : "r"(a_frag[k][0]), "r"(a_frag[k][1]), "r"(a_frag[k][2]),
+                              "r"(a_frag[k][3]), "r"(c0), "r"(c1));
 #endif
-                    if (k + 1 < HD / 16) {
-                        b0 = nb0;
-                        b1 = nb1;
-                        c0 = nc0;
-                        c1 = nc1;
+                        if (k + 1 < HD / 16) {
+                            b0 = nb0;
+                            b1 = nb1;
+                            c0 = nc0;
+                            c1 = nc1;
+                        }
                     }
-                }
+                    const half2 a01 = *reinterpret_cast<const half2*>(&dA[0]);
+                    const half2 a23 = *reinterpret_cast<const half2*>(&dA[1]);
+                    const half2 b01 = *reinterpret_cast<const half2*>(&dB[0]);
+                    const half2 b23 = *reinterpret_cast<const half2*>(&dB[1]);
+                    S[n][0] = __low2float(a01);
+                    S[n][1] = __high2float(a01);
+                    S[n][2] = __low2float(a23);
+                    S[n][3] = __high2float(a23);
+                    S[n + 1][0] = __low2float(b01);
+                    S[n + 1][1] = __high2float(b01);
+                    S[n + 1][2] = __low2float(b23);
+                    S[n + 1][3] = __high2float(b23);
+                } else {
+                    float dA[4] = {0.f, 0.f, 0.f, 0.f};
+                    float dB[4] = {0.f, 0.f, 0.f, 0.f};
 #pragma unroll
-                for (int e = 0; e < 4; e++) {
-                    S[n][e] = dA[e];
-                    S[n + 1][e] = dB[e];
+                    for (int k = 0; k < HD / 16; k++) {
+                        uint32_t nb0, nb1, nc0, nc1;
+                        if (k + 1 < HD / 16)
+                            ldsm_x4(nb0, nb1, nc0, nc1, krow + (k + 1) * 16);
+#if __CUDA_ARCH__ >= 1200
+                        asm volatile(
+                            "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+                            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
+                            : "=f"(dA[0]), "=f"(dA[1]), "=f"(dA[2]), "=f"(dA[3])
+                            : "r"(a_frag[k][0]), "r"(a_frag[k][1]), "r"(a_frag[k][2]),
+                              "r"(a_frag[k][3]), "r"(b0), "r"(b1), "f"(dA[0]), "f"(dA[1]), "f"(dA[2]),
+                              "f"(dA[3]));
+                        asm volatile(
+                            "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+                            "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};\n"
+                            : "=f"(dB[0]), "=f"(dB[1]), "=f"(dB[2]), "=f"(dB[3])
+                            : "r"(a_frag[k][0]), "r"(a_frag[k][1]), "r"(a_frag[k][2]),
+                              "r"(a_frag[k][3]), "r"(c0), "r"(c1), "f"(dB[0]), "f"(dB[1]), "f"(dB[2]),
+                              "f"(dB[3]));
+#endif
+                        if (k + 1 < HD / 16) {
+                            b0 = nb0;
+                            b1 = nb1;
+                            c0 = nc0;
+                            c1 = nc1;
+                        }
+                    }
+#pragma unroll
+                    for (int e = 0; e < 4; e++) {
+                        S[n][e] = dA[e];
+                        S[n + 1][e] = dB[e];
+                    }
                 }
             }
         } else {
@@ -1608,9 +1662,14 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
     dim3 grid(num_q_tiles, batch_size * n_heads);
     dim3 block(SM120_WARP_SIZE, Bq / 16);  // warps = Bq/16
 
-    auto kern = fp16_qk
-                    ? (use_bq64 ? fmha_sm120_fa2_kernel<64, 128, true> : fmha_sm120_fa2_kernel<128, 128, true>)
-                    : (use_bq64 ? fmha_sm120_fa2_kernel<64, 128> : fmha_sm120_fa2_kernel<128, 128>);
+    // f16-acc QK^T (#597) only applies to the fp16_qk path (the fp8 path keeps
+    // its f32 accumulate). Opt-in: +3-4% pp2048/pp4096 NVFP4 for +0.37% PPL.
+    const bool f16acc = fp16_qk && imp::process_diag_fa2_f16acc();
+    auto kern = fp16_qk ? (f16acc ? (use_bq64 ? fmha_sm120_fa2_kernel<64, 128, true, true>
+                                              : fmha_sm120_fa2_kernel<128, 128, true, true>)
+                                   : (use_bq64 ? fmha_sm120_fa2_kernel<64, 128, true>
+                                               : fmha_sm120_fa2_kernel<128, 128, true>))
+                        : (use_bq64 ? fmha_sm120_fa2_kernel<64, 128> : fmha_sm120_fa2_kernel<128, 128>);
     cudaError_t aerr = cudaFuncSetAttribute(kern, cudaFuncAttributeMaxDynamicSharedMemorySize,
                                             static_cast<int>(smem));
     if (aerr != cudaSuccess)
@@ -1620,8 +1679,9 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
     if (!logged_once) {
         logged_once = true;
         IMP_LOG_INFO(
-            "FMHA FA2 register-resident kernel ACTIVE (hd=128, Bq=%d, qk=%s, smem=%zu B, seq_q=%d seq_kv=%d)",
-            Bq, fp16_qk ? "f16" : "e4m3", smem, seq_q, seq_kv);
+            "FMHA FA2 register-resident kernel ACTIVE (hd=128, Bq=%d, qk=%s, qk_acc=%s, smem=%zu B, "
+            "seq_q=%d seq_kv=%d)",
+            Bq, fp16_qk ? "f16" : "e4m3", f16acc ? "f16" : "f32", smem, seq_q, seq_kv);
     }
     kern<<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),
                                         reinterpret_cast<const half*>(K.data),

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -132,6 +132,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("attention.fmha_sm120", cfg.attention.fmha_sm120);
     S("attention.fmha_fa2", cfg.attention.fmha_fa2);
     S("attention.fa2_fp16qk", cfg.attention.fa2_fp16qk);
+    B("attention.fa2_f16acc", cfg.attention.fa2_f16acc);
     I("attention.fmha_prefill_threshold", cfg.attention.fmha_prefill_threshold);
     I("attention.attn_scores_mib", cfg.attention.attn_scores_mib);
     S("attention.mxfp4", cfg.attention.mxfp4);
@@ -303,6 +304,11 @@ void seed_from_env(RuntimeConfig& cfg) {
     // prefill kernel (A/B vs the legacy FP8 FMHA), '0' forces it off.
     if (const char* e = std::getenv("IMP_FMHA_FA2"))
         cfg.attention.fmha_fa2 = (std::atoi(e) != 0) ? "on" : "never";
+
+    // attention.fa2_f16acc — IMP_FA2_F16ACC: '1' enables f16-accumulate QK^T
+    // in the fp16-qk FA2 kernel (#597, +3-4% long-ctx prefill / +0.37% PPL).
+    if (const char* e = std::getenv("IMP_FA2_F16ACC"))
+        cfg.attention.fa2_f16acc = (std::atoi(e) != 0);
 
     // moe.nvfp4_smallM — IMP_NVFP4_SMALLM: integer != 0 enables.
     if (const char* e = std::getenv("IMP_NVFP4_SMALLM"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -113,6 +113,14 @@ struct RuntimeConfig {
         // (hd!=128, dual-head-dim Gemma-4) fall back to cuBLAS, never to the
         // fp8 FMHA family. "never" restores the materialized cuBLAS path.
         std::string fa2_fp16qk = "on";
+        // f16-accumulate QK^T in the FP16-QK FA2 kernel (#597). GeForce sm_120
+        // runs f16-src/f32-acc HMMA at 1/4 rate (#606); accumulating the score
+        // MMA in f16 lifts it to the full-rate class. Measured +3-4% pp2048/
+        // pp4096 NVFP4 prefill (Qwen3-14B) for +0.37% PPL — a quality tradeoff
+        // (scores are softmaxed immediately, so the reduced accumulate precision
+        // is low-risk). Opt-in (default off); only affects the fa2_fp16qk path,
+        // the fp8-QK path keeps f32 accumulate. Env: IMP_FA2_F16ACC.
+        bool fa2_f16acc = false;
         std::string mxfp4 = "auto";
         bool mxfp4_fp16_fallback = false;
         // MXFP4 → FP16 cache pruning policy. "legacy" (default) caches FP16

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -29,6 +29,7 @@ struct ProcessDiag {
 
     // Attention
     bool attention_splitk_pipe = true;
+    bool attention_fa2_f16acc = false;
     std::string attention_mxfp4_mode = "auto";
 
     // FFN
@@ -75,6 +76,7 @@ void process_diag_install(const RuntimeConfig& cfg) {
     // treat auto as off.
     d.cublas_fp16_acc = (cfg.gemm.cublas_fp16_acc == "on");
     d.attention_splitk_pipe = cfg.attention.splitk_pipe;
+    d.attention_fa2_f16acc = cfg.attention.fa2_f16acc;
     d.attention_mxfp4_mode = cfg.attention.mxfp4;
     d.ffn_sparsity_probe = cfg.ffn.sparsity_probe;
     d.moe_mr_nr = cfg.moe.mr_nr;
@@ -105,6 +107,7 @@ bool process_diag_cublas_fp16_acc() { return slot().cublas_fp16_acc; }
 void process_diag_set_cublas_fp16_acc(bool v) { slot().cublas_fp16_acc = v; }
 void process_diag_set_deterministic_gemm(bool v) { slot().deterministic_gemm = v; }
 bool process_diag_attention_splitk_pipe() { return slot().attention_splitk_pipe; }
+bool process_diag_fa2_f16acc() { return slot().attention_fa2_f16acc; }
 const std::string& process_diag_attention_mxfp4_mode() { return slot().attention_mxfp4_mode; }
 bool process_diag_ffn_sparsity_probe() { return slot().ffn_sparsity_probe; }
 int process_diag_moe_mr_nr() { return slot().moe_mr_nr; }

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -58,6 +58,7 @@ void process_diag_set_cublas_fp16_acc(bool v);
 
 // Attention
 bool process_diag_attention_splitk_pipe();
+bool process_diag_fa2_f16acc();  // f16-accumulate QK^T in the fp16-qk FA2 kernel (#597)
 // "auto" | "always" | "never" (default "auto"); attention_mxfp4_available()
 // only enables MXFP4 attention when mode == "always".
 const std::string& process_diag_attention_mxfp4_mode();

--- a/tools/analysis/fa2_f16acc_ab.sh
+++ b/tools/analysis/fa2_f16acc_ab.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Issue #597: A/B the f16-accumulate QK^T experiment for the FA2 prefill kernel.
+# Fresh ncu (2026-06-09) showed the FP16QK FA2 kernel is tensor-pipe-leaning
+# (52.8% pipe active, the busiest unit) running f32-acc QK^T at 1/4 rate on
+# GeForce sm_120, occupancy smem-capped at 16.7%. f16-acc lifts the score MMA
+# to the full-rate class. This measures prefill throughput + perplexity (quality
+# gate) — run once on the baseline image, once on the f16-acc image.
+set -uo pipefail
+IMG=imp:test
+MODELS=/home/kekz/models
+REPO=/home/kekz/github.com/kekzl/imp
+MODEL="${1:-/models/Qwen3-14B-NVFP4}"   # dense hd=128, exercises FP16QK FA2
+CORPUS=/work/tools/analysis/ppl_corpus.txt
+
+run() { docker run --rm --gpus all -e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+          -v "$MODELS":/models -v "$REPO":/work "$IMG" "$@"; }
+
+echo "######## FA2 f16-acc A/B: $(basename "$MODEL") ########"
+echo "[warmup, discarded]"
+run imp-cli --model "$MODEL" --bench --bench-pp 2048 --bench-reps 3 --max-tokens 1 \
+    --temperature 0 >/dev/null 2>&1
+
+for PP in 512 2048 4096; do
+  echo "===== pp$PP (3 isolated trials) ====="
+  for t in 1 2 3; do
+    echo -n "  trial$t: "
+    run imp-cli --model "$MODEL" --bench --bench-pp "$PP" --bench-reps 5 --max-tokens 1 \
+        --temperature 0 --seed 42 2>&1 | grep -E '^pp' | tr '\n' ' '; echo
+  done
+done
+echo "===== perplexity (quality gate, same corpus) ====="
+run imp-cli --model "$MODEL" --perplexity "$CORPUS" --temperature 0 2>&1 | grep -iE 'perplexity'
+echo "DONE"


### PR DESCRIPTION
## Issue #597 — `attn_fa2` 8% roofline on `nvfp4-moe/pp4096`

A fresh ncu profile (2026-06-09) of the live FP16-QK FA2 kernel changes the bottleneck model and yields a concrete, measured lever.

### Fresh profile (post-#609)
- **Recalibration (#606):** QK^T accumulates in f32, which runs at **¼ rate** on GeForce sm_120 → the "8%" is **~33%** vs the real ceiling.
- **No longer LSU-bound** (the owner's "LSU-bound" predates #609): LSU only **12%**; the **tensor pipe is the busiest unit (52.8%)**; occupancy **smem-capped at 16.7%** (69.6 KB/block → 1 CTA/SM); dominant stall is exec-latency `wait`; grid is **0.75 waves** (chunked-prefill underfill).

### Lever (shipped, opt-in)
Accumulate the QK^T score MMA in **f16** (`mma.m16n8k16.f16.f16.f16.f16`) → lifts the busiest pipe to the full-rate class. Scores are softmaxed immediately (low-risk); PV stays f32-acc.

| Cell | f32-acc (default) | f16-acc | Δ |
|---|---|---|---|
| pp4096 | 16374 | **17026** | **+4.0%** |
| pp2048 | 18647 | 19206 | +3.0% |
| **PPL** (201 tok) | 6.4044 | 6.4282 | **+0.37%** |

A/B in one build via `--set attention.fa2_f16acc=true|false`. The +0.37% PPL is 6× smaller than the accepted `nvfp4_lm_head` tradeoff (+2.2%).

### Safety
- **Opt-in** (`attention.fa2_f16acc`, default off, env `IMP_FA2_F16ACC`) — prefill-score quality tradeoff, default stays conservative pending broader validation (more corpora + degen suite).
- Off-path is **byte-identical** to the prior kernel (`F16ACC=false` template). **FmhaFA2Test 32/32 + cross-path 4/4 green.**
- Only the `fa2_fp16qk` path is touched; fp8-QK keeps f32-acc.
- Default config unchanged → `perf_baseline.json` unaffected (no refresh needed).

### Residual gap
>50% roofline is not reached on the existing path: occupancy is double-capped by the ~70 KB KV double-buffer (2×70 > 99 KB opt-in), and the 0.75-wave chunked underfill can't be fixed by Bq=64 (halves per-SM occupancy under a wait-latency-dominant kernel). Documented structural ceiling — see `docs/audit/attn_fa2_f16acc_2026_06_09.md`. Issue stays the NVFP4 long-context tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)