### PR TITLE
docs(audit): gemm_grouped_nvfp4 41% roofline = structural ceiling (#601)

### DIFF
--- a/docs/audit/gemm_grouped_nvfp4_ceiling_2026_06_09.md
+++ b/docs/audit/gemm_grouped_nvfp4_ceiling_2026_06_09.md
@@ -1,0 +1,88 @@
+# `gemm_grouped_nvfp4` MoE-prefill 41% roofline — structural-ceiling analysis (#601)
+
+**Date:** 2026-06-09 · **Resolves:** [#601](https://github.com/kekzl/imp/issues/601)
+(`gemm_grouped_nvfp4`: 41% roofline on `nvfp4-moe/pp2048`) · **Verdict:**
+documented structural ceiling (the acceptance-criteria alternative). The default
+path is already the best available; the one alternative kernel regresses.
+
+## The finding
+
+The CUTLASS 3.x NVFP4 block-scaled grouped GEMM (MoE expert FFN, prefill) reaches
+41.3% of the DRAM roofline on `nvfp4-moe/pp2048` (Qwen3-30B-A3B-NVFP4), 52% on
+pp512, 44% on pp4096 — at 30–48% of the prefill window.
+
+## Why — small per-expert M → 1-wave, 23%-occupancy grid
+
+Qwen3-30B-A3B: `top_k=8`, 128 experts, `moe_intermediate=768`, hidden=2048. At
+chunk=512 each expert sees only `512·8/128 ≈ 32` tokens. The grouped GEMM
+(N=768 gate/up resp. 2048 down, K=2048/768) therefore launches a small,
+shallow grid:
+
+| kernel (committed ncu, pp2048) | grid | occupancy |
+|---|---|---|
+| `cutlass::GemmUniversal<…BlockScaled…>` (gemm_grouped_nvfp4) | **170 CTAs** | **23%** |
+
+Grid = 170 = exactly the SM count → **one wave**, and the block-scaled CUTLASS
+collective (128×128×128 tile, `OpClassBlockScaledTensorOp`, StageCount auto-
+carveout) caps occupancy at 23%. A 1-wave, 23%-occupancy kernel cannot saturate
+HBM → 41% roofline. AI≈575 FLOP/B sits below the (recalibrated ½-rate) FP4
+ridge, so the classifier's "memory-bound" label is right, but the limiter is
+occupancy/wave-fill, not raw bandwidth demand.
+
+## The one alternative kernel regresses (fresh 3-arm A/B, 2026-06-09)
+
+imp ships a hand-rolled persistent **small-M grouped GEMM** (`moe.nvfp4_smallM`,
+default off) with M-aware tile selection (16/32/64/128) — exactly aimed at the
+M≈32 underfill. It lives in the non-device-args tier, so testing it means
+disabling the default device-args dispatch. Best-of-3 isolated trials,
+Qwen3-30B-A3B-NVFP4:
+
+| Arm | pp512 (best tok/s) | pp2048 (best tok/s) |
+|---|---|---|
+| **A — default (device-args CUTLASS grouped)** | **19051** | **17185** |
+| B — device-args off + smallM (thr=128) | 14180 | 13009 |
+| C — device-args off + host-args grouped | 13964 | 12963 |
+
+The default wins by **+25–32%**. The smallM kernel (B) is within noise of the
+plain host-args grouped (C) — its better M-tiling does **not** overcome the
+per-layer host dispatch overhead it is stuck behind. This independently
+reproduces the 2026-05-14 result baked into the code (device-args default-ON
+comment: "+11–39% pp512 vs the legacy host-args + smallM dispatch on
+Qwen3-Coder / Qwen3.6 / Qwen3-30B-Modelopt / Gemma-4"). Tool:
+`tools/analysis/moe_smallm_ab.sh`.
+
+**The device-args advantage is dispatch, not GEMM math:** both tiers run the same
+class of CUTLASS block-scaled grouped kernel; device-args wins by keeping the
+per-expert problem shapes device-resident (no D2H sync / host relaunch per
+layer). So the 23%-occupancy grouped kernel is what every path runs — and the
+M-aware smallM kernel does not beat it. The tile-M underfill is therefore **not**
+the dominant limiter; the occupancy/wave-fill structural limit of the sm_120
+block-scaled collective at these MoE shapes is.
+
+## Why >70% is not reachable on the existing path
+
+- The default device-args path is already the fastest available (+25–32% over
+  both alternatives), and it is the 41%-roofline kernel itself.
+- Raising occupancy past 23% would require retuning the CUTLASS block-scaled
+  collective (smaller tiles / more stages / cluster) for the small-M-per-expert
+  regime — but the hand-rolled M-aware kernel that does exactly that (smallM)
+  already fails to beat the 128-tile path, so the expected payoff is low and the
+  risk (a from-scratch device-args small-M collective) is high.
+- pp512 already reads 52% (higher than pp2048's 41%), i.e. the kernel is near
+  its achievable envelope for these shapes; the variation across pp512/2048/4096
+  (52/41/44%) is within restart/window-attribution noise.
+
+This is the batch-prefill counterpart of the batch-1 MoE wall (#600): MoE expert
+GEMMs are intrinsically small per expert, so the grouped GEMM runs shallow grids
+at low occupancy. Consistent with the authoritative finding that the NVFP4
+prefill lever is **attention** (FA2, #597), not the grouped GEMM (already
+fused, near its structural envelope) — see
+`memory/moe_prefill_20x_premise_refuted_2026_05_31`.
+
+## Conclusion
+
+41% roofline on `gemm_grouped_nvfp4` is a structural ceiling of small-M-per-expert
+MoE prefill on the sm_120 block-scaled CUTLASS collective. The default device-args
+path is already optimal among available implementations; `moe.nvfp4_smallM`
+regresses and stays default-off. No code change; this analysis is the documented
+resolution per the issue's acceptance criteria.

--- a/tools/analysis/moe_smallm_ab.sh
+++ b/tools/analysis/moe_smallm_ab.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Issue #601: A/B the NVFP4 MoE grouped-GEMM paths for prefill. gemm_grouped_nvfp4
+# reaches only 41-52% roofline on nvfp4-moe prefill (23% occupancy, 1-wave grid).
+# Three arms:
+#   A  default          — device-args CUTLASS 3.x grouped (Tier 1, default ON)
+#   B  da-off + smallM   — hand-rolled M-aware tile kernel (Tier 2, opt-in)
+#   C  da-off + grouped  — host-args CUTLASS grouped (Tier 3)
+# The smallM (B) and host-grouped (C) tiers both require device_args=false.
+# Result (2026-06-09, Qwen3-30B-A3B-NVFP4): default wins by ~25-32% — smallM
+# regresses (confirms the 2026-05-14 device-args +11-39% A/B). Default is the
+# best available path; 41% roofline is the small-M grouped structural ceiling.
+set -uo pipefail
+IMG=imp:test; MODELS=/home/kekz/models; REPO=/home/kekz/github.com/kekzl/imp
+MODEL="${1:-/models/Qwen3-30B-A3B-NVFP4-Modelopt}"
+CORPUS=/work/tools/analysis/ppl_corpus.txt
+R() { docker run --rm --gpus all -e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+        -v "$MODELS":/models -v "$REPO":/work "$IMG" imp-cli --model "$MODEL" "$@"; }
+
+echo "######## MoE grouped-GEMM A/B: $(basename "$MODEL") ########"
+echo "[warmup]"; R --bench --bench-pp 2048 --bench-reps 3 --max-tokens 1 --temperature 0 >/dev/null 2>&1
+
+arm() {  # $1=label  $2..=flags
+  local lab="$1"; shift
+  echo "-- $lab --"
+  for PP in 512 2048; do for t in 1 2 3; do
+    echo -n "  pp$PP t$t: "
+    R --bench --bench-pp $PP --bench-reps 5 --max-tokens 1 --temperature 0 --seed 42 "$@" 2>&1 \
+      | grep -E '^pp' | tr '\n' ' '; echo
+  done; done
+}
+arm "A default (device-args)"
+arm "B da-off + smallM" --set moe.nvfp4_device_args=false --set moe.nvfp4_smallM=true --set moe.nvfp4_smallM_threshold=128
+arm "C da-off + grouped" --set moe.nvfp4_device_args=false
+
+echo "===== perplexity (quality gate) ====="
+echo -n "  default: "; R --perplexity "$CORPUS" --temperature 0 2>&1 | grep -iE 'perplexity'
+echo -n "  smallM : "; R --perplexity "$CORPUS" --temperature 0 --set moe.nvfp4_device_args=false --set moe.nvfp4_smallM=true --set moe.nvfp4_smallM_threshold=128 2>&1 | grep -iE 'perplexity'
+echo "DONE"


### PR DESCRIPTION
## Issue #601 — `gemm_grouped_nvfp4` 41% roofline on `nvfp4-moe/pp2048`

Documented structural-ceiling analysis (the acceptance-criteria alternative to >70%), backed by committed ncu data + a fresh 3-arm A/B.

### Finding
The CUTLASS NVFP4 block-scaled grouped GEMM (MoE expert prefill) launches **grid=170 (= SM count → 1 wave) at 23% occupancy**; per-expert M ≈ 32 (512·8/128 at chunk=512). A 1-wave, 23%-occupancy block-scaled collective can't saturate HBM → 41% roofline.

### The one alternative kernel regresses
imp ships an opt-in hand-rolled small-M grouped GEMM (`moe.nvfp4_smallM`, M-aware 16/32/64/128 tiles) — exactly aimed at the M≈32 underfill. It requires `device_args=false`. Best-of-3 isolated trials, Qwen3-30B-A3B-NVFP4:

| Arm | pp512 | pp2048 |
|---|---|---|
| **A — default (device-args grouped)** | **19051** | **17185** |
| B — device-args off + smallM | 14180 | 13009 |
| C — device-args off + host-grouped | 13964 | 12963 |

Default wins **+25–32%**; smallM ≈ host-grouped (its M-tiling doesn't overcome the host-dispatch overhead it's stuck behind). This reproduces the 2026-05-14 result baked into the code (device-args default-ON: "+11–39% pp512 vs host-args + smallM"). The device-args advantage is **dispatch** (device-resident problem shapes, no per-layer D2H), not GEMM math — the 23%-occupancy kernel is what every tier runs.

### Verdict
41% is the small-M-per-expert structural ceiling; the default device-args path is already optimal among available implementations. **No code change**; `moe.nvfp4_smallM` stays default-off. The NVFP4 prefill lever remains **attention** (FA2, #597), not the grouped GEMM. See `docs/audit/gemm_grouped_nvfp4_ceiling_2026_06_09.md`; tool `tools/analysis/moe_smallm_ab.sh`.

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)