### PR TITLE
fix(loader): strip model.language_model.* prefix for Qwen3.5-VL (QWEN35)

### DIFF
--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -324,11 +324,11 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
     const bool is_gemma4_moe = is_gemma4 && (model.config_.n_experts > 0);
     const bool is_qwen36_moe = (arch_ == ModelArch::QWEN36_MOE);
     const bool is_nemotron_h = (arch_ == ModelArch::NEMOTRON_H_MOE);
-    // Multimodal "ForConditionalGeneration" wrappers (Gemma-4-VL, Qwen3.6-VL)
-    // share the same `model.language_model.*` / `model.vision_tower.*` layout.
-    // Text-only Qwen3.6 ships bare `model.*` keys, so the strip is a no-op
-    // there.
-    const bool needs_multimodal_strip = is_gemma4 || is_qwen36_moe;
+    // Multimodal "ForConditionalGeneration" wrappers (Gemma-4-VL, Qwen3.5-VL,
+    // Qwen3.6-VL) share the same `model.language_model.*` / `model.vision_tower.*`
+    // (resp. `model.visual.*`) layout plus an `mtp.*` head. Text-only variants
+    // ship bare `model.*` keys, so the strip is prefix-guarded and a no-op there.
+    const bool needs_multimodal_strip = is_gemma4 || is_qwen36_moe || (arch_ == ModelArch::QWEN35);
 
     for (auto& [orig_name, tensor] : tensors) {
         std::string name = orig_name;


### PR DESCRIPTION
### The bug
`Qwen3.5-4B` ships as `Qwen3_5ForConditionalGeneration` — a multimodal wrapper: the LLM lives under `model.language_model.*`, vision under `model.visual.*`, plus an `mtp.*` head. The `model.language_model.` prefix-strip in `weight_map.cpp` only fired for `GEMMA4` / `QWEN36_MOE`, so **QWEN35** kept the prefix → none of the 738 tensors matched the `model.layers.*` patterns → **`WeightMap: no tensors were assigned`** (hard load failure).

### The fix
Add `QWEN35` to `needs_multimodal_strip` (one condition). The strip is prefix-guarded, so text-only Qwen3.5 (bare `model.*`) is a **no-op** and unaffected.

After: assigns **426** LLM tensors (311 vision+mtp skipped), ties `out_proj`→embed (`tie_word_embeddings=true`), classified as GDN/SSM hybrid (`moe=0 gdn=1 ssm=1 hybrid=1`).

### Scope / honest status
This fixes the **reported load failure only**. The Qwen3.5 **dense-GDN forward still produces NaN logits** (teacher-forced PPL = nan; not fixed by `gdn.fp32_scan`/`fp32_out`) — a separate dense-GDN arch-bringup bug. The model **loads but is not yet coherent**; full Qwen3.5-VL support (dense-GDN forward + vision) is follow-up work. Shipping this because the prefix-strip is correct and general for the Qwen3.5-VL family, and it moves the model from hard-fail to a debuggable forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)