### PR TITLE
perf(decode): conditional-graph loop for NVFP4 think models (+45% think decode)

### DIFF
--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -841,6 +841,7 @@ bool Tokenizer::load(const std::string& path) {
     const JValue* added = jobj_find(root, "added_tokens");
     if (added && added->type == JType::ARRAY) {
         token_types_.resize(vocab_.size(), 1);  // default NORMAL=1
+        added_token_ids_.resize(vocab_.size(), false);
 
         for (const auto& tok : added->arr) {
             if (tok.type != JType::OBJECT)
@@ -863,9 +864,12 @@ bool Tokenizer::load(const std::string& path) {
                 scores_.resize(id + 1, 0.0f);
                 token_types_.resize(id + 1, 1);
             }
+            if (id >= static_cast<int>(added_token_ids_.size()))
+                added_token_ids_.resize(id + 1, false);
 
             vocab_[id] = content;
             token_to_id_[content] = id;
+            added_token_ids_[id] = true;
             if (is_special)
                 token_types_[id] = 3;  // CONTROL
 

--- a/src/model/tokenizer.h
+++ b/src/model/tokenizer.h
@@ -100,6 +100,15 @@ public:
         return id >= 0 && id < static_cast<int>(token_types_.size()) && token_types_[id] != 1;
     }
 
+    // True if `id` was declared in tokenizer.json's `added_tokens` array (an
+    // explicit added marker), regardless of its `special` flag. Distinguishes a
+    // deliberately-added marker like Qwen3's `</think>` (added, special=false)
+    // from a NORMAL BPE piece that happens to spell "<think>" (Nemotron ID 12,
+    // not added). Empty vector ⇒ no added-token metadata ⇒ always false.
+    bool is_added_token(int id) const {
+        return id >= 0 && id < static_cast<int>(added_token_ids_.size()) && added_token_ids_[id];
+    }
+
     // Defensive overlay: mark a token as CONTROL even when it wasn't tagged
     // by the source tokenizer. Used to cross-check special_tokens_map.json
     // against tokenizer.json's special-flag column for HF model directories.
@@ -153,6 +162,10 @@ private:
 
     // Per-token type from GGUF (NORMAL=1, CONTROL=3, etc.). Empty if not available.
     std::vector<int32_t> token_types_;
+
+    // Membership flag per id for tokenizer.json `added_tokens` (HF SafeTensors).
+    // Empty when the source carries no added_tokens array.
+    std::vector<bool> added_token_ids_;
 
     // Cached list of special-token strings (CONTROL type) sorted by length
     // descending. Used by encode_*() to pre-split input on these literals so

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -485,9 +485,10 @@ __global__ void post_decode_step_kernel(
     int* __restrict__ d_step_counter,        // [1] device-side step counter
     int max_steps, int eos_id, const int32_t* __restrict__ d_stop_ids, int n_stop_ids,
     // Think budget (all 0/-1 when disabled)
-    int think_budget_limit, int32_t think_start_id, int32_t think_end_id,
-    int* __restrict__ d_think_count,  // [1] reasoning token counter
-    int* __restrict__ d_in_think,     // [1] think block flag
+    int think_budget_limit, int32_t think_start_id, int32_t think_end_id, int think_grace_tokens,
+    int* __restrict__ d_think_count,      // [1] reasoning token counter
+    int* __restrict__ d_in_think,         // [1] think block flag
+    int* __restrict__ d_think_exit_step,  // [1] step </think> last closed (-1 = never)
     int ignore_eos,                   // 1 = don't stop on EOS/stop tokens
     // Penalty ring buffer: d_penalty_ring[prefix_len + step] = token
     int32_t* __restrict__ d_penalty_ring,  // may be null if no penalties
@@ -497,14 +498,20 @@ __global__ void post_decode_step_kernel(
     int step = *d_step_counter;
     int32_t token = *d_token_id;
 
-    // Track think state on device
-    if (think_budget_limit > 0) {
-        if (token == think_start_id)
+    // Track think state on device. Active whenever a </think> id is known
+    // (think_end_id >= 0), independent of the budget — it drives EOS/stop
+    // suppression inside the block and the post-</think> grace window. The
+    // reasoning-token counter only matters for the budget (budget_limit > 0).
+    const bool track_think = (think_end_id >= 0);
+    if (track_think) {
+        if (token == think_start_id) {
             *d_in_think = 1;
-        else if (token == think_end_id)
+        } else if (token == think_end_id) {
             *d_in_think = 0;
-        else if (*d_in_think)
+            *d_think_exit_step = step;  // open the post-think grace window
+        } else if (*d_in_think && think_budget_limit > 0) {
             (*d_think_count)++;
+        }
     }
 
     // Write token to ring buffer (visible to host via mapped memory)
@@ -534,11 +541,15 @@ __global__ void post_decode_step_kernel(
     *d_ring_step_counter = step + 1;
 
     // Check stop conditions.
-    // Suppress stop tokens (EOS, <|im_end|>) while inside <think> block —
-    // the model may emit them during reasoning, stopping prematurely.
-    bool in_think = (think_budget_limit > 0 && d_in_think && *d_in_think);
+    // Suppress stop tokens (EOS, <|im_end|>) while inside <think> block — the
+    // model may emit them during reasoning, stopping prematurely — and for a
+    // grace window after </think> closes (numerically-noisy NVFP4 quants can
+    // close an empty block in ~3 tokens then EOS to a 0-content completion).
+    bool in_think = (track_think && d_in_think && *d_in_think);
+    bool grace = (think_grace_tokens > 0 && d_think_exit_step && *d_think_exit_step >= 0 &&
+                  (step - *d_think_exit_step) < think_grace_tokens);
     bool should_stop = (step + 1 >= max_steps);
-    if (!in_think && !ignore_eos) {
+    if (!in_think && !grace && !ignore_eos) {
         if (token == eos_id)
             should_stop = true;
         for (int i = 0; i < n_stop_ids; i++) {
@@ -547,8 +558,10 @@ __global__ void post_decode_step_kernel(
         }
     }
 
-    // Think budget: break loop to return to CPU for force_token injection
-    if (in_think && *d_think_count >= think_budget_limit) {
+    // Think budget: break loop to return to CPU for force_token injection.
+    // Gated on budget_limit > 0 — without it, limit 0 would make every in-think
+    // step satisfy (count >= 0) and break the loop on the first reasoning token.
+    if (think_budget_limit > 0 && in_think && *d_think_count >= think_budget_limit) {
         should_stop = true;
     }
 
@@ -557,7 +570,7 @@ __global__ void post_decode_step_kernel(
             int stop_reason = 0;
             if (step + 1 >= max_steps)
                 stop_reason = 1;  // max_steps
-            else if (!in_think && !ignore_eos) {
+            else if (!in_think && !grace && !ignore_eos) {
                 if (token == eos_id)
                     stop_reason = 2;  // eos
                 for (int i = 0; i < n_stop_ids; i++) {
@@ -623,15 +636,21 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         }
     }
 
-    // Think budget counters (device-side)
-    if (config_.think_budget_limit > 0) {
+    // Think-state counters (device-side). Allocated whenever think tracking is
+    // active (a </think> id is known), not only for budgets — the in_think flag
+    // and exit-step drive EOS/stop suppression + the post-</think> grace window.
+    if (config_.think_end_id >= 0) {
         err = cudaMalloc(&d_think_count_, sizeof(int));
         if (err != cudaSuccess)
             goto fail;
         err = cudaMalloc(&d_in_think_, sizeof(int));
         if (err != cudaSuccess)
             goto fail;
+        err = cudaMalloc(&d_think_exit_step_, sizeof(int));
+        if (err != cudaSuccess)
+            goto fail;
         int zero = 0;
+        int neg_one = -1;
         int init_think = config_.initial_in_think ? 1 : 0;
         err = cudaMemcpyAsync(d_think_count_, &zero, sizeof(int), cudaMemcpyHostToDevice, stream);
         if (err != cudaSuccess) {
@@ -641,6 +660,11 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         err = cudaMemcpyAsync(d_in_think_, &init_think, sizeof(int), cudaMemcpyHostToDevice, stream);
         if (err != cudaSuccess) {
             IMP_LOG_ERROR("ConditionalRunner: in_think init failed: %s", cudaGetErrorString(err));
+            goto fail;
+        }
+        err = cudaMemcpyAsync(d_think_exit_step_, &neg_one, sizeof(int), cudaMemcpyHostToDevice, stream);
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("ConditionalRunner: think_exit_step init failed: %s", cudaGetErrorString(err));
             goto fail;
         }
     }
@@ -832,7 +856,8 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                                                      config_.max_steps, config_.eos_id, d_stop_ids_,
                                                      static_cast<int>(config_.stop_ids.size()),
                                                      config_.think_budget_limit, config_.think_start_id,
-                                                     config_.think_end_id, d_think_count_, d_in_think_,
+                                                     config_.think_end_id, config_.think_grace_tokens,
+                                                     d_think_count_, d_in_think_, d_think_exit_step_,
                                                      config_.ignore_eos ? 1 : 0, d_penalty_ring_,
                                                      penalty_prefix_len_, d_penalty_count_, handle_);
 
@@ -977,6 +1002,10 @@ void CudaGraphConditionalRunner::cleanup() {
     if (d_in_think_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_in_think_));
         d_in_think_ = nullptr;
+    }
+    if (d_think_exit_step_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_think_exit_step_));
+        d_think_exit_step_ = nullptr;
     }
     if (d_penalty_ring_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_penalty_ring_));

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -138,6 +138,12 @@ public:
         int32_t think_start_id = -1;    // <think> token ID
         int32_t think_end_id = -1;      // </think> token ID
         bool initial_in_think = false;  // true if already inside <think> block
+        // Post-</think> grace: suppress EOS/stop for this many tokens after the
+        // think block closes, matching think_logic::kMinAnswerAfterThink on the
+        // eager path. Guards against numerically-noisy NVFP4 quants that close an
+        // empty think block in ~3 tokens then EOS to a 0-content completion.
+        // 0 = no think tracking in the loop (set >0 whenever think_end_id >= 0).
+        int think_grace_tokens = 0;
         bool ignore_eos = false;        // don't stop on EOS/stop tokens (benchmark mode)
         // Penalty parameters (applied to logits before sampling each iteration)
         float repetition_penalty = 1.0f;
@@ -187,8 +193,9 @@ private:
     int32_t* d_stop_ids_ = nullptr;  // [n_stop_ids] stop token IDs on device
 
     // Think budget tracking (device-side)
-    int* d_think_count_ = nullptr;  // [1] reasoning token counter
-    int* d_in_think_ = nullptr;     // [1] currently inside <think> block
+    int* d_think_count_ = nullptr;      // [1] reasoning token counter
+    int* d_in_think_ = nullptr;         // [1] currently inside <think> block
+    int* d_think_exit_step_ = nullptr;  // [1] step at which </think> last closed (-1 = never)
 
     // Penalty token history: [prefix_len + max_steps] ring buffer for penalty computation.
     // prefix_len tokens are pre-populated from prior output; subsequent slots filled by

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -1,5 +1,6 @@
 #include "runtime/engine.h"
 #include "runtime/cuda_graph.h"
+#include "runtime/think_stop_logic.h"
 #include "memory/kv_cache.h"
 #include "model/chat_template.h"
 #include "compute/sampling.h"
@@ -83,12 +84,19 @@ CudaGraphConditionalRunner::Config Engine::build_graph_config(const Request& req
             gcfg.penalty_history = req.output_tokens;
         }
     }
-    // Think budget: device-side enforcement in post_decode_step_kernel
-    if (req.think_budget > 0.0f && think_end_id_ >= 0) {
-        gcfg.think_budget_limit = static_cast<int>(req.max_tokens * req.think_budget);
+    // Think tracking: device-side in post_decode_step_kernel. Enabled whenever a
+    // single-token </think> id is known (think_end_id_ >= 0), so the conditional
+    // loop runs for reasoning models instead of falling back to eager decode.
+    // Provides EOS/stop suppression while inside the block + a post-</think>
+    // grace window (matches the eager should_stop path). think_budget_limit stays
+    // opt-in (only when the request set a budget).
+    if (think_end_id_ >= 0) {
         gcfg.think_start_id = think_start_id_;
         gcfg.think_end_id = think_end_id_;
         gcfg.initial_in_think = req.in_think_block;
+        gcfg.think_grace_tokens = think_logic::kMinAnswerAfterThink;
+        if (req.think_budget > 0.0f)
+            gcfg.think_budget_limit = static_cast<int>(req.max_tokens * req.think_budget);
     }
     return gcfg;
 }

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -87,10 +87,10 @@ bool Engine::init_features() {
             // so models thought until max_tokens (empty content under
             // json_mode/short budgets). Nemotron's "<think>" at ID 12 is type
             // NORMAL text and stays excluded.
-            bool is_special = think_logic::accept_think_token(
+            bool accept = think_logic::accept_think_token(
                 ts, ptok->has_token_types(), ptok->has_token_types() && ptok->is_special_token(ts),
-                vocab);
-            if (is_special) {
+                ptok->is_added_token(ts), vocab);
+            if (accept) {
                 think_start_id_ = ts;
                 think_end_id_ = te;
             }

--- a/src/runtime/think_stop_logic.h
+++ b/src/runtime/think_stop_logic.h
@@ -29,11 +29,20 @@ namespace imp::think_logic {
 // "lives in the top 1% of the vocab id range" (added/special tokens cluster there).
 //
 // `start_id` < 0 means the literal "<think>" is absent -> never a think model.
-inline bool accept_think_token(int32_t start_id, bool has_token_types, bool is_special, int vocab_size) {
+//
+// `is_added` == the token was declared in tokenizer.json's added_tokens array.
+// Qwen3/Qwen3.x NVFP4 SafeTensors ship <think>/</think> as added tokens with
+// special=false (is_special=false), so the is_special gate alone left
+// think_end_id_ == -1 and forced those reasoning models onto the eager decode
+// path (no conditional-graph loop, −27..36% decode). An *added* marker is a
+// deliberate control marker even when special=false; only a NORMAL BPE piece
+// that merely spells "<think>" (Nemotron ID 12, not added) must stay rejected.
+inline bool accept_think_token(int32_t start_id, bool has_token_types, bool is_special, bool is_added,
+                               int vocab_size) {
     if (start_id < 0)
         return false;
     if (has_token_types)
-        return is_special;  // is_special == (token_type != NORMAL)
+        return is_special || is_added;  // special OR an explicit added marker
     return start_id > vocab_size * 99 / 100;
 }
 

--- a/tests/test_think_stop_logic.cpp
+++ b/tests/test_think_stop_logic.cpp
@@ -32,7 +32,7 @@ using namespace imp::think_logic;
 TEST(ThinkTokenAccept, ControlTypeAccepted) {
     // GGUF metadata path: <think> tagged CONTROL -> is_special=true -> accept.
     EXPECT_TRUE(accept_think_token(/*start_id=*/151648, /*has_token_types=*/true,
-                                   /*is_special=*/true, /*vocab=*/152064));
+                                   /*is_special=*/true, /*is_added=*/false, /*vocab=*/152064));
 }
 
 TEST(ThinkTokenAccept, UserDefinedTypeAccepted) {
@@ -40,21 +40,32 @@ TEST(ThinkTokenAccept, UserDefinedTypeAccepted) {
     // still true (4 != NORMAL). The old code required CONTROL and rejected this,
     // leaving think_end_id_ == -1 so the budget never fired. Must accept now.
     EXPECT_TRUE(accept_think_token(/*start_id=*/151648, /*has_token_types=*/true,
-                                   /*is_special=*/true, /*vocab=*/152064));
+                                   /*is_special=*/true, /*is_added=*/false, /*vocab=*/152064));
+}
+
+TEST(ThinkTokenAccept, AddedButNotSpecialAccepted) {
+    // THE Qwen3/Qwen3.x NVFP4 SafeTensors case: </think> is added_tokens id
+    // 151668 with special=false -> is_special=false but is_added=true. The old
+    // is_special-only gate rejected it (think_end_id_ == -1), forcing every
+    // think chat onto the eager decode path. An explicit added marker must be
+    // accepted so the conditional-graph loop runs.
+    EXPECT_TRUE(accept_think_token(/*start_id=*/151667, /*has_token_types=*/true,
+                                   /*is_special=*/false, /*is_added=*/true, /*vocab=*/151936));
 }
 
 TEST(ThinkTokenAccept, NormalTypeRejected) {
-    // Nemotron: "<think>" is plain text at ID 12, type NORMAL -> is_special=false.
-    // Must NOT be treated as a think marker (else every literal "<think>" in
-    // ordinary text would toggle reasoning mode).
+    // Nemotron: "<think>" is plain text at ID 12, type NORMAL, NOT in
+    // added_tokens -> is_special=false, is_added=false. Must NOT be treated as a
+    // think marker (else every literal "<think>" in ordinary text would toggle
+    // reasoning mode).
     EXPECT_FALSE(accept_think_token(/*start_id=*/12, /*has_token_types=*/true,
-                                    /*is_special=*/false, /*vocab=*/256000));
+                                    /*is_special=*/false, /*is_added=*/false, /*vocab=*/256000));
 }
 
 TEST(ThinkTokenAccept, AbsentTokenRejected) {
     // find_token("<think>") == -1: the model has no <think> token at all.
     EXPECT_FALSE(accept_think_token(/*start_id=*/-1, /*has_token_types=*/true,
-                                    /*is_special=*/false, /*vocab=*/152064));
+                                    /*is_special=*/false, /*is_added=*/false, /*vocab=*/152064));
 }
 
 TEST(ThinkTokenAccept, NoTypeTableHeuristicTopOfVocab) {
@@ -62,11 +73,11 @@ TEST(ThinkTokenAccept, NoTypeTableHeuristicTopOfVocab) {
     // 1% of the vocab range (added/special tokens cluster there).
     // vocab=1000 -> threshold = 1000*99/100 = 990; accept strictly above 990.
     EXPECT_TRUE(accept_think_token(/*start_id=*/995, /*has_token_types=*/false,
-                                   /*is_special=*/false, /*vocab=*/1000));
+                                   /*is_special=*/false, /*is_added=*/false, /*vocab=*/1000));
     EXPECT_FALSE(accept_think_token(/*start_id=*/990, /*has_token_types=*/false,
-                                    /*is_special=*/false, /*vocab=*/1000));
+                                    /*is_special=*/false, /*is_added=*/false, /*vocab=*/1000));
     EXPECT_FALSE(accept_think_token(/*start_id=*/5, /*has_token_types=*/false,
-                                    /*is_special=*/false, /*vocab=*/1000));
+                                    /*is_special=*/false, /*is_added=*/false, /*vocab=*/1000));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A decode-scheduling audit found that imp has two CUDA-graph decode mechanisms: a **conditional async loop** (whole multi-token loop on device, no per-token CPU↔GPU sync) and a **per-step graph pool**. A set of workloads is disqualified from the fast conditional loop and pays a measured **−27..36% decode** penalty from the per-token sync. One of them hits a hero workload directly: **NVFP4 SafeTensors think models** (Qwen3/3.5/3.6).

Root cause: these models ship `<think>`/`</think>` as `added_tokens` with `special=false`. `accept_think_token` gated on `is_special` only, so `think_end_id_` stayed `-1`, and `needs_eager_for_text_think` forced every think chat onto the eager path. Since the chat template injects `<think>\n` by default, **this is the default mode** for these heroes — so they decoded eager all the time.

## Fix (three parts)

1. **Tokenizer** tracks `added_tokens` membership (`is_added_token`). An *added* marker is a deliberate control marker even when `special=false`; a NORMAL BPE piece that merely spells `<think>` (not added — e.g. a true Nemotron text token) stays rejected. `accept_think_token` now accepts `is_special || is_added`.
2. **Conditional-graph kernel** (`post_decode_step_kernel`) tracks think state whenever a `</think>` id is known (not only under a budget), driving EOS/stop suppression inside the block plus a **device-side post-`</think>` grace window** (mirrors `think_logic::kMinAnswerAfterThink` on the eager path — guards the numerically-noisy NVFP4 empty-think→EOS 0-content failure). Budget force stays gated on `budget_limit > 0`.
3. **Scheduler** `needs_eager_for_text_think` now resolves false for these models. Models whose `</think>` truly has no single-token id keep the text-tail fallback.

## Measurement (RTX 5090, healthy host: 2850/13801/~516W)

Qwen3-8B-NVFP4 think chat: **177 → 257 tok/s (+45%)**.

## Validation

- `think_logic` unit tests **22/22** (incl. new added-but-not-special case)
- Qwen3-8B-NVFP4 `degen_suite` **33/33** (think-leak, reasoning-separation, truncated-think-no-spill, multi-turn, long-context, streaming, anthropic-thinking)
- Nemotron-3-Nano-NVFP4 `degen_suite` **16/16** (affected by the added-token change; not broken)
- Q8 GGUF `DegenerationTest` **5/5**, stderr clean (no silent graph fallback)
- graphs-vs-eager greedy parity **identical** (token selection unchanged; only stop timing moves)
- Q8 decode **272 tok/s** (within baseline) — kernel change is decode-neutral

🤖 Generated with [Claude Code](https://claude.com/claude-code)