### PR TITLE
fix+perf(constrain): SafeTensors json SIGBUS, control-char leak, schema fast path, pipelined constrained decode

### DIFF
--- a/src/compute/constrain_common.h
+++ b/src/compute/constrain_common.h
@@ -155,14 +155,24 @@ __global__ inline void constrain_mask_kernel(float* __restrict__ logits,
 // is true.
 // ---------------------------------------------------------------------------
 
+// `vocab_size` is the LOGITS width (model vocab); `n_classified` is the number
+// of tokens the constrainer classified (tokenizer vocab). SafeTensors models
+// pad the lm_head past the tokenizer vocab (Qwen3-8B-NVFP4: 151936 vs 151669);
+// those padding ids have no grammar classification and untrained weight rows,
+// so they are masked unconditionally — and the category/allow buffers are only
+// n_classified wide, so reading them at idx >= n_classified would be OOB.
 __global__ inline void constrain_mask_allow_kernel(float* __restrict__ logits,
                                                    const uint16_t* __restrict__ token_cats,
                                                    const uint8_t* __restrict__ token_allow,
                                                    const uint16_t* __restrict__ allowed_mask, int vocab_size,
-                                                   bool use_token_allow) {
+                                                   int n_classified, bool use_token_allow) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= vocab_size)
         return;
+    if (idx >= n_classified) {
+        logits[idx] = -FLT_MAX;
+        return;
+    }
 
     uint16_t mask = *allowed_mask;
     bool cat_ok = (token_cats[idx] & mask) != 0;
@@ -186,11 +196,12 @@ __global__ inline void constrain_mask_allow_kernel(float* __restrict__ logits,
 // ---------------------------------------------------------------------------
 
 __global__ inline void grammar_mask_kernel(float* __restrict__ logits,
-                                           const uint8_t* __restrict__ token_allow, int vocab_size) {
+                                           const uint8_t* __restrict__ token_allow, int vocab_size,
+                                           int n_classified) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= vocab_size)
         return;
-    if (token_allow[idx] == 0)
+    if (idx >= n_classified || token_allow[idx] == 0)
         logits[idx] = -FLT_MAX;
 }
 

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -324,12 +324,21 @@ bool JsonConstrainer::advance_char(char c) {
                 } else {
                     current_state_ = JsonState::DONE;
                 }
+            } else if (static_cast<unsigned char>(c) < 0x20) {
+                // JSON forbids raw control chars (U+0000–U+001F) inside
+                // strings — they must arrive escaped. Multi-char tokens whose
+                // first char passes the category mask (e.g. `"<newline>`)
+                // used to smuggle them through.
+                return false;
             }
             // Otherwise stay in IN_STRING
             break;
 
         case JsonState::IN_STRING_ESCAPE:
-            // Any char after \ — back to IN_STRING
+            // Back to IN_STRING — but `\` + raw control char is not a legal
+            // escape sequence (the escape char itself must be printable).
+            if (static_cast<unsigned char>(c) < 0x20)
+                return false;
             current_state_ = JsonState::IN_STRING;
             break;
 
@@ -425,7 +434,14 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
     const bool in_string =
         current_state_ == JsonState::IN_STRING || current_state_ == JsonState::IN_STRING_ESCAPE;
     size_t n_allowed = 0;
-    for (int i = 0; i < vocab_size; i++) {
+    // vocab_size is the LOGITS width (model vocab); token_categories_ /
+    // token_texts_ only cover the TOKENIZER vocab (vocab_size_). SafeTensors
+    // models pad the lm_head past the tokenizer vocab (Qwen3-8B-NVFP4: 151936
+    // vs 151669) — iterating to vocab_size read token_texts_ out of bounds
+    // (host SIGBUS, killed imp-server on the first json_mode request).
+    // Padding ids stay allow=0 and the kernel masks them via n_classified.
+    const int n_classified = std::min(vocab_size, vocab_size_);
+    for (int i = 0; i < n_classified; i++) {
         uint8_t allow = 0;
         if ((token_categories_[i] & mask) != 0) {
             const std::string& text = token_texts_[i];
@@ -471,7 +487,7 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
     int blocks = (vocab_size + threads - 1) / threads;
     constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_categories_,
                                                                 d_token_allow_, d_allowed_mask_, vocab_size,
-                                                                /*use_token_allow=*/true);
+                                                                n_classified, /*use_token_allow=*/true);
 }
 
 // ============================================================================
@@ -550,8 +566,10 @@ void GrammarConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_
     int threads = 256;
     int blocks = (vocab_size + threads - 1) / threads;
     // No category gating for grammar; the per-token allow mask (built from the
-    // NFA) carries the full constraint.
-    grammar_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_allow_, vocab_size);
+    // NFA) carries the full constraint. d_token_allow_ only covers the
+    // tokenizer vocab — padding logits past it are masked via n_classified.
+    grammar_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_allow_, vocab_size,
+                                                        /*n_classified=*/vocab_size_);
 }
 
 void GrammarConstrainer::update(int32_t token) {

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -362,7 +362,8 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
                                            vocab_size_ * sizeof(uint8_t), cudaMemcpyHostToDevice, stream));
         int t = 256, b = (vocab_size + t - 1) / t;
         constrain_mask_allow_kernel<<<b, t, 0, stream>>>(d_logits, d_token_categories_, d_token_allow_,
-                                                         d_allowed_mask_, vocab_size, /*use_allow=*/true);
+                                                         d_allowed_mask_, vocab_size,
+                                                         /*n_classified=*/vocab_size_, /*use_allow=*/true);
         return;
     }
 
@@ -407,8 +408,12 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
 
     int threads = 256;
     int blocks = (vocab_size + threads - 1) / threads;
+    // vocab_size is the LOGITS width (model vocab); the category/allow buffers
+    // only cover the tokenizer vocab — padding logits are masked via
+    // n_classified (SafeTensors lm_head padding, see json_constrain.cu).
     constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_categories_, d_token_allow_,
                                                                 d_allowed_mask_, vocab_size,
+                                                                /*n_classified=*/vocab_size_,
                                                                 need_token_allow_);
 }
 
@@ -693,6 +698,12 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                 sim_fixup_parent(stk);
                 return true;
             }
+            // JSON forbids raw control chars (U+0000–U+001F) inside strings —
+            // they must arrive escaped (\n, \uXXXX). Multi-char tokens whose
+            // first char passes the category mask (e.g. `"<newline>`) used to
+            // smuggle them through, producing unparseable output.
+            if (static_cast<unsigned char>(c) < 0x20)
+                return false;
             return true;  // any content char
         }
 
@@ -704,6 +715,8 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                 sim_fixup_parent(stk);
                 return true;
             }
+            if (static_cast<unsigned char>(c) < 0x20)
+                return false;  // raw control char — see STRING_VALUE
             if (f.node && f.node->max_length >= 0 && f.string_len + 1 > f.node->max_length)
                 return false;
             if (f.node && f.node->pattern_nfa && f.node->pattern_nfa->compiled()) {
@@ -718,6 +731,8 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
         }
 
         case SchemaPhase::STRING_ESCAPE: {
+            if (static_cast<unsigned char>(c) < 0x20)
+                return false;  // `\` + raw control char is not a legal escape
             f.phase = SchemaPhase::STRING_VALUE;
             return true;
         }

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -940,5 +940,143 @@ TEST(SchemaConstrainTest, RecursiveSchemaEnforced) {
     }
 }
 
+// ===========================================================================
+// Vocab-mismatch regression (SIGBUS 2026-06-09): SafeTensors models have
+// MORE logits than tokenizer entries (Qwen3-8B-NVFP4: lm_head vocab 151936
+// vs tokenizer.json 151669). apply_mask receives the LOGITS vocab size; the
+// constrainer classified only the TOKENIZER vocab. The host validation loop
+// then read token_texts_[i] out of bounds (SIGBUS — killed imp-server on the
+// first json_mode request), and the mask kernels read the category/allow
+// device buffers out of bounds. Contract under test: apply_mask with a
+// larger vocab_size must (a) not crash and (b) mask every logit in the
+// padding range [tokenizer_vocab, model_vocab) — padding ids are unknown to
+// the grammar and untrained in the model, so they must never be sampleable.
+// ===========================================================================
+
+// ===========================================================================
+// Raw-control-char regression (2026-06-10): JSON forbids unescaped U+0000–
+// U+001F inside strings, but both FSMs accepted "any content char" there.
+// Multi-char tokens whose FIRST char passes the category mask (`"<newline>`
+// opens a string and smuggles a raw newline in one step) produced output that
+// json.loads() rejects ("Invalid control character"). Observed live on
+// Qwen3-8B-NVFP4 json_schema generation.
+// ===========================================================================
+
+TEST(SchemaConstrainTest, RawControlCharInStringMasked) {
+    SKIP_IF_NO_CUDA();
+
+    //          0        1      2       3    4     5       6    7     8        9
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "code", ":", "}", "\"\n", "\"ok"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"code":{"type":"string"}},"required":["code"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+
+    // Walk to OBJECT_COLON: {  "code"  :   — next token opens the string value.
+    for (int t : {3, 4, 5, 4, 6})
+        sc.update(t);
+
+    auto a = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(a[9]) << "'\"ok' (quote + printable content) must be allowed";
+    EXPECT_FALSE(a[8]) << "'\"<newline>' must be masked — raw control char inside a string";
+}
+
+TEST(JsonConstrainTest, RawControlCharInStringMasked) {
+    SKIP_IF_NO_CUDA();
+
+    //          0        1      2       3    4     5      6
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "\"\n", "\"ok"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    JsonConstrainer jc;
+    ASSERT_TRUE(jc.init(tok));
+    jc.update(3);  // '{' → OBJECT_START, next token may open a key string
+
+    const int vocab = static_cast<int>(toks.size());
+    std::vector<float> h(vocab, 1.0f);
+    float* d = nullptr;
+    cudaMalloc(&d, vocab * sizeof(float));
+    cudaMemcpy(d, h.data(), vocab * sizeof(float), cudaMemcpyHostToDevice);
+    jc.apply_mask(d, vocab, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, vocab * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+
+    EXPECT_GT(h[6], -1e30f) << "'\"ok' (quote + printable key chars) must be allowed";
+    EXPECT_FLOAT_EQ(h[5], -FLT_MAX) << "'\"<newline>' must be masked — raw control char in string";
+}
+
+TEST(JsonConstrainTest, ModelVocabLargerThanTokenizerMasksPadding) {
+    SKIP_IF_NO_CUDA();
+
+    //          0        1      2       3    4     5    6
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "}", "0"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    JsonConstrainer jc;
+    ASSERT_TRUE(jc.init(tok));
+
+    const int tok_vocab = static_cast<int>(toks.size());
+    const int model_vocab = tok_vocab + 9;  // simulated lm_head padding rows
+
+    std::vector<float> h(model_vocab, 1.0f);
+    float* d = nullptr;
+    cudaMalloc(&d, model_vocab * sizeof(float));
+    cudaMemcpy(d, h.data(), model_vocab * sizeof(float), cudaMemcpyHostToDevice);
+    jc.apply_mask(d, model_vocab, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, model_vocab * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+
+    // '{' starts a JSON document — must stay alive.
+    EXPECT_GT(h[3], -1e30f) << "'{' must be allowed at document start";
+    // Every padding id (no tokenizer entry) must be masked.
+    for (int i = tok_vocab; i < model_vocab; i++) {
+        EXPECT_FLOAT_EQ(h[i], -FLT_MAX) << "padding id " << i << " leaked through the json mask";
+    }
+}
+
+TEST(SchemaConstrainTest, ModelVocabLargerThanTokenizerMasksPadding) {
+    SKIP_IF_NO_CUDA();
+
+    //          0        1      2       3    4     5       6    7
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "code", ":", "}"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"code":{"type":"string"}},"required":["code"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+
+    const int tok_vocab = static_cast<int>(toks.size());
+    const int model_vocab = tok_vocab + 9;
+
+    std::vector<float> h(model_vocab, 1.0f);
+    float* d = nullptr;
+    cudaMalloc(&d, model_vocab * sizeof(float));
+    cudaMemcpy(d, h.data(), model_vocab * sizeof(float), cudaMemcpyHostToDevice);
+    sc.apply_mask(d, model_vocab, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, model_vocab * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+
+    EXPECT_GT(h[3], -1e30f) << "'{' must be allowed at schema root";
+    for (int i = tok_vocab; i < model_vocab; i++) {
+        EXPECT_FLOAT_EQ(h[i], -FLT_MAX) << "padding id " << i << " leaked through the schema mask";
+    }
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
Four changes to JSON/schema constrained decoding, found and built while chasing constrained-decode throughput on Qwen3-8B-NVFP4. Together: the server no longer crashes, output is valid JSON, and json_schema decode goes from **102–130 to ~235 tok/s sustained** (plain decode: 270–278).

## Bug 1 — SIGBUS kills imp-server on the first json_mode/json_schema request (SafeTensors)

`apply_mask` receives the **logits** width (model vocab — 151936 on Qwen3-8B-NVFP4) while the constrainer classified only the **tokenizer** vocab (151669). GGUF models have no such gap, which is why only SafeTensors crashed.

gdb-confirmed crash site:
```
SIGBUS in imp::JsonConstrainer::sim_token_valid(std::string const&)
  ← JsonConstrainer::apply_mask ← GraphExecutor::forward ← step_prefill_one
```
**Fix:** clamp the host validation loop to the classified vocab and pass `n_classified` to the mask kernels, which now mask every padding id unconditionally — padding rows are untrained and unknown to the grammar, so they must never be sampleable.

## Bug 2 — raw control characters inside constrained JSON strings

Both FSMs accepted "any content char" in string states, so a multi-char token whose *first* char passes the category mask (e.g. `"<newline>`) smuggled raw U+0000–U+001F into string values — live json_schema output failed `json.loads()`. **Fix:** reject `c < 0x20` in string/escape states of both FSMs.

## Perf 1 — schema mask fast path (102–130 → 147–176 tok/s)

`compute_token_allow_mask` simulated **all 151k vocab tokens** through the pushdown automaton **every decode step**, each via a deep copy of the frame stack (~4.2 ms/token). Two algorithmic fixes with byte-identical mask output: **category prefilter** (the kernel ANDs category and allow — category-failing tokens never needed simulation) and an **in-string O(1) shortcut** (free `STRING_VALUE` accepts any token without `"`/`\`/control chars by construction; pattern/enum/key strings still simulate).

## Perf 2 — pipelined constrained decode (147 → 235 tok/s sustained)

The remaining gap was the per-token eager sync: GPU idle during every host turnaround (FSM update + mask compute + relaunch). New `ConstrainedPipeline` mode (single sequence, graphs on): per tick the host enqueues [penalties + banned + mask + device sampling + cursor advance] for the in-flight forward **and the next forward** — a `CudaGraphRunner` replay reading the freshly sampled token from device memory (same device-fed pattern as the conditional loop). The host waits only for the sampled token; FSM/mask/scheduler latency hides under forward N+1. The grammar FSM stays host-side and authoritative, so correctness is identical to eager **by construction** (masks upload stream-ordered between logits and sampling).

Supported in-pipeline: greedy/top-k/top-p, rep/freq/presence penalties (per-tick upload — the server defaults `repetition_penalty=1.05` / `think_budget=0.5` must not block the fast path), banned tokens, think-budget `</think>` forcing, host think tracking, KV-budget breakout to eager. Stays eager: logprobs, min_p, typical_p, mirostat, DRY, logit_bias, MTP, batch>1.

## Numbers (Qwen3-8B-NVFP4, server, temp=0)

| | before | after |
|---|---|---|
| json_mode/json_schema first request | **SIGBUS** | works |
| json_schema output | invalid JSON (raw control chars) | valid |
| json_schema short-form | 102–130 tok/s | 176–184 tok/s |
| json_schema sustained (600 tok) | ~quit at 147 | **235 tok/s** |
| plain decode (reference) | 270–278 | 270–278 |

## Validation

- Pipeline-vs-eager parity: **IDENTICAL** content (250-token json_schema, greedy)
- New regression tests: `ModelVocabLargerThanTokenizerMasksPadding`, `RawControlCharInStringMasked` (json + schema); constrain suites **23/23**
- `DegenerationTest` 5/5 (Q8 GGUF, stderr clean — no silent graph fallback)
- Full `degen_suite` **33/33** on Qwen3-8B-NVFP4 (think-leak, streaming, multi-turn, anthropic-thinking)
- think+schema budget-force path produces valid JSON; SSE stream terminates correctly
- `verify-fast` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)