### PR TITLE
perf(constrain): schema-mask fast path + pipelined constrained decode (json_schema 102→235 tok/s)

### DIFF
--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -313,7 +313,7 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
 // Compute per-token allow mask (for key names and enum values)
 // ---------------------------------------------------------------------------
 
-void SchemaConstrainer::compute_token_allow_mask() {
+void SchemaConstrainer::compute_token_allow_mask(uint16_t cat_mask) {
     need_token_allow_ = false;
 
     if (stack_.empty())
@@ -328,9 +328,41 @@ void SchemaConstrainer::compute_token_allow_mask() {
     // alongside (it governs EOS / whitespace / structural first-char), so a
     // token must pass BOTH. token_legal() handles empty (EOS/special) tokens by
     // deferring to the category mask.
+    //
+    // Cost control (this loop runs per decode step over the whole vocab, and
+    // token_legal deep-copies the frame stack per candidate — it dominated
+    // json_schema decode at 151k tokens):
+    //  - category prefilter: the kernel ANDs category and allow, so a token
+    //    that fails the category mask is masked regardless of allow — skip
+    //    its simulation entirely. In structural phases the category mask is
+    //    narrow and this eliminates almost all simulations.
+    //  - in-string O(1) shortcut (mirrors JsonConstrainer): in a free string
+    //    value, any token without '"', '\\' or a raw control char stays
+    //    inside the string by construction — sim_advance would accept every
+    //    char without touching the stack, so skip the simulation. Pattern /
+    //    enum / key strings still simulate (prefix & regex constraints).
     need_token_allow_ = true;
+    const bool free_string = (top().phase == SchemaPhase::STRING_VALUE);
     for (int i = 0; i < vocab_size_; i++) {
-        token_allow_[i] = token_legal(token_texts_[i]) ? 1 : 0;
+        if ((token_categories_[i] & cat_mask) == 0) {
+            token_allow_[i] = 0;  // masked by category — simulation irrelevant
+            continue;
+        }
+        const std::string& text = token_texts_[i];
+        if (free_string && !text.empty()) {
+            bool plain = true;
+            for (char c : text) {
+                if (c == '"' || c == '\\' || static_cast<unsigned char>(c) < 0x20) {
+                    plain = false;
+                    break;
+                }
+            }
+            if (plain) {
+                token_allow_[i] = 1;
+                continue;
+            }
+        }
+        token_allow_[i] = token_legal(text) ? 1 : 0;
     }
 }
 
@@ -369,7 +401,7 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
 
     // Compute masks
     uint16_t cat_mask = compute_category_mask();
-    compute_token_allow_mask();
+    compute_token_allow_mask(cat_mask);
 
     // Empty-allow guard: an over-tight schema/state combination (e.g.
     // {"type":"object"} without properties — the key phase knows no legal

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -150,7 +150,9 @@ private:
     void push_value_frame(const SchemaNode* node);
 
     uint16_t compute_category_mask() const;
-    void compute_token_allow_mask();
+    // cat_mask: the current category mask — tokens failing it are masked by
+    // the kernel anyway, so their (expensive) per-token simulation is skipped.
+    void compute_token_allow_mask(uint16_t cat_mask);
 
     // Single-char transition over a frame stack. Returns false when c is not a
     // legal transition for the current phase. Drives both the real update path

--- a/src/exec/executor.cu
+++ b/src/exec/executor.cu
@@ -400,6 +400,64 @@ std::vector<int32_t> GraphExecutor::forward_batch(const InferenceState& state, c
 // Async decode: embedding from device token → forward → sample to device
 // ---------------------------------------------------------------------------
 
+void GraphExecutor::masked_sample_async(const InferenceState& state, const Tensor& logits, int32_t* d_result,
+                                        int32_t* h_pinned, cudaStream_t stream) {
+    int vocab = static_cast<int>(logits.shape[logits.ndim - 1]);
+    float* lp = static_cast<float*>(logits.data);
+
+    // Forced token (think-budget </think> injection): mirrors the eager
+    // sampler — the force overrides bans and constraint masks.
+    if (state.force_token >= 0 && state.force_token < vocab) {
+        force_single_token(lp, vocab, state.force_token, stream);
+        Tensor last_f = logits.slice(0, 1);
+        int64_t vshape_f[1] = {last_f.shape[1]};
+        last_f = last_f.reshape(1, vshape_f);
+        sample_greedy_device(last_f, d_result, h_pinned, stream);
+        return;
+    }
+
+    // Repetition / frequency / presence penalties — same order as the eager
+    // sampler (penalties before bans and constraint mask). The engine uploads
+    // the token history per tick (upload_penalties), exactly like eager.
+    if (state.penalty_tokens != nullptr && state.n_penalty_tokens > 0) {
+        const int32_t* pen_ptr = state.penalty_tokens;
+        int pen_n = state.n_penalty_tokens;
+        if (state.repeat_last_n > 0 && pen_n > state.repeat_last_n) {
+            pen_ptr += (pen_n - state.repeat_last_n);
+            pen_n = state.repeat_last_n;
+        }
+        apply_penalties(lp, vocab, pen_ptr, pen_n, state.repetition_penalty, state.frequency_penalty,
+                        state.presence_penalty, stream);
+    }
+
+    // Banned special tokens — device list, graph-/replay-safe.
+    if (state.d_banned_tokens && state.n_d_banned_tokens > 0) {
+        constexpr int kBanThreads = 256;
+        int blocks = (state.n_d_banned_tokens + kBanThreads - 1) / kBanThreads;
+        ban_logits_kernel<<<blocks, kBanThreads, 0, stream>>>(lp, state.d_banned_tokens,
+                                                              state.n_d_banned_tokens, vocab);
+    }
+
+    // Grammar constraint mask (host-computed this step, uploaded stream-ordered).
+    if (state.schema_constrainer)
+        state.schema_constrainer->apply_mask(lp, vocab, stream);
+    else if (state.json_constrainer)
+        state.json_constrainer->apply_mask(lp, vocab, stream);
+
+    // Device-side sampling → d_result, async copy to h_pinned.
+    Tensor last = logits.slice(0, 1);
+    int64_t vocab_shape[1] = {last.shape[1]};
+    last = last.reshape(1, vocab_shape);
+    if (state.temperature <= 0.0f || state.top_k == 1) {
+        sample_greedy_device(last, d_result, h_pinned, stream);
+    } else {
+        int top_k = state.top_k > 0 ? state.top_k : 50;
+        float top_p = state.top_p > 0.0f ? state.top_p : 1.0f;
+        unsigned int seed = state.seed >= 0 ? static_cast<unsigned int>(state.seed) : 42u;
+        sample_topk_topp_device(last, top_k, top_p, state.temperature, seed, d_result, h_pinned, stream);
+    }
+}
+
 void GraphExecutor::forward_decode_async(const InferenceState& state, int32_t* d_token_id, int32_t* h_mapped,
                                          cudaStream_t stream) {
     if (!initialized_) {

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -124,6 +124,14 @@ public:
     void forward_decode_async(const InferenceState& state, int32_t* d_token_id, int32_t* h_mapped,
                               cudaStream_t stream = nullptr);
 
+    // Constrained async sampling (pipelined constrained decode): applies
+    // device-side banned-token masking + the active json/schema constraint
+    // mask, then samples on device. Writes the token to d_result (which must
+    // be ARGMAX_SCRATCH_BYTES, argmax scratch follows the token) and async-
+    // copies it to h_pinned. No host-device sync — order via an event.
+    void masked_sample_async(const InferenceState& state, const Tensor& logits, int32_t* d_result,
+                             int32_t* h_pinned, cudaStream_t stream);
+
     // Set centralized VRAM allocator for budget-tracked allocations.
     // Must be called before allocate_workspaces() / pre_dequant_weights().
     void set_vram_allocator(class VRAMAllocator* alloc) { vram_alloc_ = alloc; }

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -1040,4 +1040,17 @@ void CudaGraphConditionalRunner::cleanup() {
     last_read_step_ = 0;
 }
 
+// ---------------------------------------------------------------------------
+// Pipelined constrained decode: device-side cursor advance
+// ---------------------------------------------------------------------------
+
+__global__ void pipeline_advance_kernel(int* __restrict__ d_pos, int* __restrict__ d_ctx) {
+    (*d_pos)++;
+    (*d_ctx)++;
+}
+
+void launch_pipeline_advance(int* d_pos, int* d_ctx, cudaStream_t stream) {
+    pipeline_advance_kernel<<<1, 1, 0, stream>>>(d_pos, d_ctx);
+}
+
 }  // namespace imp

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -215,4 +215,9 @@ private:
     bool launched_ = false;
 };
 
+// Advance the device-side decode cursor for the pipelined constrained loop:
+// (*d_pos)++ and (*d_ctx)++ after a token was sampled, so the next (already
+// enqueued) forward replay reads the new position without host involvement.
+void launch_pipeline_advance(int* d_pos, int* d_ctx, cudaStream_t stream);
+
 }  // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -335,6 +335,12 @@ void Engine::invalidate_graphs() {
     async_graph_req_ = nullptr;
     async_pending_tokens_.clear();
     async_pending_cursor_ = 0;
+
+    // The pipelined constrained decode holds a captured forward graph plus
+    // request-specific device state — same invalidation requirement as the
+    // conditional runner.
+    if (cpipe_.active)
+        teardown_constrained_pipeline(/*synchronize=*/true);
 }
 
 int Engine::lora_load(const std::string& path) {

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -303,6 +303,34 @@ private:
     std::vector<int32_t> async_pending_tokens_;
     int async_pending_cursor_ = 0;
 
+    // Pipelined constrained decode (json_mode / json_schema, single sequence).
+    // Constrained requests can't run the conditional graph loop (the grammar
+    // FSM lives on the host), but the eager path leaves the GPU idle during
+    // every host turnaround (FSM update + mask compute + relaunch). This mode
+    // keeps the host FSM authoritative and hides its latency instead: each
+    // tick enqueues [mask + sample + advance] for the in-flight forward AND
+    // the NEXT forward (which reads the freshly sampled token from device
+    // memory), so the GPU is already deep in forward N+1 while the host
+    // processes token N.
+    struct ConstrainedPipeline {
+        bool active = false;
+        std::shared_ptr<Request> req;
+        CudaGraphRunner runner;  // captures forward_logits only
+        InferenceState state{};  // stable device pointers for the whole run
+        Tensor logits;           // fixed-address logits view (workspace buffer)
+        int32_t* d_token = nullptr;  // ARGMAX_SCRATCH_BYTES (token + argmax scratch)
+        int* d_pos = nullptr;        // [1] current position
+        int* d_ctx = nullptr;        // [1] current context length
+        int* d_bt = nullptr;         // uploaded block table
+        int32_t* d_banned = nullptr; // banned token ids (device)
+        int32_t* h_token = nullptr;  // pinned landing for the sampled token
+        cudaEvent_t ev = nullptr;    // sampled-token-ready event
+        int budget = 0;              // tokens coverable by pre-allocated KV
+        int produced = 0;            // tokens harvested by this pipeline
+        bool forward_in_flight = false;
+    };
+    ConstrainedPipeline cpipe_;
+
     // Teacher-forced perplexity capture (begin/end_perplexity_capture).
     // Device buffers of length n; step_prefill_one writes per-position NLL
     // for every forwarded chunk while active.
@@ -500,6 +528,14 @@ private:
     // Returns: 0 = no async graph active, 1 = still running (step returns true),
     //         -1 = graph exhausted/generation done (check scheduler for more work)
     int step_async_graph_resume();
+
+    // Pipelined constrained decode (see ConstrainedPipeline). Launch after the
+    // first decode step of an eligible json/schema request; one tick harvests
+    // one token. Returns: 0 = inactive/exhausted (fall through to eager),
+    // 1 = produced a token and continues, -1 = generation finished.
+    bool try_launch_constrained_pipeline(std::shared_ptr<Request> req, cudaStream_t stream);
+    int step_constrained_pipeline();
+    void teardown_constrained_pipeline(bool synchronize);
 
     // Schedule prefill/decode batches and reconfigure green contexts.
     // Returns true if there is work to do (batches non-empty).

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -1,5 +1,6 @@
 #include "runtime/engine.h"
 #include "runtime/cuda_graph.h"
+#include "runtime/engine_internal.h"
 #include "runtime/think_stop_logic.h"
 #include "memory/kv_cache.h"
 #include "model/chat_template.h"
@@ -230,6 +231,196 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     async_pending_cursor_ = 0;
     IMP_LOG_INFO("AsyncGraphLoop: launched for %d remaining tokens", remaining);
     return true;
+}
+
+// =====================================================================
+// Pipelined constrained decode (json_mode / json_schema, single seq).
+//
+// The conditional graph loop can't run constrained requests (the grammar
+// FSM is host-side), and the eager path leaves the GPU idle during every
+// host turnaround. This mode splits the step: per tick the host enqueues
+// [banned+mask+sample+advance] for the forward already in flight AND the
+// NEXT forward (a CudaGraphRunner replay reading the freshly sampled
+// token from device memory), then waits only for the sampled token. The
+// GPU is already deep in forward N+1 while the host updates the FSM for
+// token N and computes the next mask.
+// =====================================================================
+
+bool Engine::try_launch_constrained_pipeline(std::shared_ptr<Request> req, cudaStream_t stream) {
+    int budget = prepare_graph_loop(req);
+    if (budget <= 0)
+        return false;
+
+    const auto& full_bt = kv_manager_->block_table(req->id);
+    int max_blocks_per_seq = static_cast<int>(full_bt.size());
+
+    auto& p = cpipe_;
+    if (cudaMalloc(&p.d_bt, max_blocks_per_seq * sizeof(int)) != cudaSuccess)
+        return false;
+    bool ok = cudaMalloc(&p.d_token, ARGMAX_SCRATCH_BYTES) == cudaSuccess &&
+              cudaMalloc(&p.d_pos, sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&p.d_ctx, sizeof(int)) == cudaSuccess &&
+              cudaHostAlloc(&p.h_token, sizeof(int32_t), cudaHostAllocDefault) == cudaSuccess &&
+              cudaEventCreateWithFlags(&p.ev, cudaEventDisableTiming) == cudaSuccess;
+    if (!ok) {
+        teardown_constrained_pipeline(/*synchronize=*/false);
+        return false;
+    }
+
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(p.d_bt, full_bt.data(), max_blocks_per_seq * sizeof(int),
+                                       cudaMemcpyHostToDevice, stream));
+    int32_t first_token = req->output_tokens.back();
+    int ctx = req->context_len();
+    int pos = ctx - 1;
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(p.d_token, &first_token, sizeof(int32_t), cudaMemcpyHostToDevice,
+                                       stream));
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(p.d_pos, &pos, sizeof(int), cudaMemcpyHostToDevice, stream));
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(p.d_ctx, &ctx, sizeof(int), cudaMemcpyHostToDevice, stream));
+
+    if (!banned_token_ids_.empty()) {
+        if (cudaMalloc(&p.d_banned, banned_token_ids_.size() * sizeof(int32_t)) == cudaSuccess) {
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(p.d_banned, banned_token_ids_.data(),
+                                               banned_token_ids_.size() * sizeof(int32_t),
+                                               cudaMemcpyHostToDevice, stream));
+        }
+    }
+
+    // Decode workspace (mirrors step_decode_forward's single-seq path).
+    if (executor_->has_decode_workspace())
+        executor_->use_workspace(1);
+    (void)executor_->resize_workspace(1, stream);
+
+    InferenceState& st = p.state;
+    st = InferenceState{};
+    st.token_ids = p.d_token;
+    st.positions = p.d_pos;
+    st.n_tokens = 1;
+    st.kv_cache = kv_cache_raw_;
+    st.block_tables = p.d_bt;
+    st.context_lens = p.d_ctx;
+    st.max_context_len = ctx + budget;
+    st.n_sequences = 1;
+    st.max_blocks_per_seq = max_blocks_per_seq;
+    st.is_prefill = false;
+    fill_recurrent_state(*req, st, /*reset=*/false, stream);
+    if (p.d_banned) {
+        st.d_banned_tokens = p.d_banned;
+        st.n_d_banned_tokens = static_cast<int>(banned_token_ids_.size());
+    }
+    // Sampling params (seed refreshed per tick).
+    st.temperature = req->temperature;
+    st.top_p = req->top_p;
+    st.top_k = req->top_k;
+    st.repetition_penalty = req->repetition_penalty;
+    st.frequency_penalty = req->frequency_penalty;
+    st.presence_penalty = req->presence_penalty;
+    st.repeat_last_n = req->repeat_last_n;
+    // Constraint hooks — the engine-level manager was prepared at admission.
+    st.schema_constrainer = constraints_.schema_constrainer();
+    st.json_constrainer = constraints_.json_constrainer();
+
+    p.runner.set_decode_fn([this](cudaStream_t s) { executor_->forward_logits(cpipe_.state, cpipe_.logits, s); });
+
+    // Prime the pipeline: forward for the NEXT token starts now; the mask for
+    // it is computed on the next tick (the FSM already absorbed first_token in
+    // step_decode_process_outputs).
+    if (!p.runner.execute(stream)) {
+        teardown_constrained_pipeline(/*synchronize=*/true);
+        return false;
+    }
+    p.forward_in_flight = true;
+    p.budget = budget;
+    p.produced = 0;
+    p.req = req;
+    p.active = true;
+    IMP_LOG_INFO("ConstrainedPipeline: launched for %d budgeted tokens (%s)", budget,
+                 st.schema_constrainer ? "schema" : "json");
+    return true;
+}
+
+int Engine::step_constrained_pipeline() {
+    auto& p = cpipe_;
+    if (!p.active)
+        return 0;
+    auto req = p.req;
+    if (!req || req->status != RequestStatus::DECODING) {
+        teardown_constrained_pipeline(/*synchronize=*/true);
+        return 0;
+    }
+
+    cudaStream_t stream = decode_stream();
+
+    // 1. Mask + sample the in-flight forward's logits. The constraint mask is
+    //    host-computed from the FSM state after the last harvested token and
+    //    uploaded stream-ordered behind the forward.
+    p.state.seed = engine_internal::compute_step_seed(*req);
+    // Think-budget enforcement (mirrors fill_sampling_params): when the
+    // reasoning budget is exhausted mid-think, force </think> this step.
+    p.state.force_token = -1;
+    if (think_logic::should_force_think_end(req->think_budget, think_end_id_, req->max_tokens,
+                                            req->output_tokens, think_start_id_, req->started_in_think)) {
+        p.state.force_token = think_end_id_;
+    }
+    // Token-history penalties — per-tick upload, exactly like the eager path.
+    p.state.penalty_tokens = nullptr;
+    p.state.n_penalty_tokens = 0;
+    upload_penalties(*req, p.state, stream);
+    executor_->masked_sample_async(p.state, p.logits, p.d_token, p.h_token, stream);
+    launch_pipeline_advance(p.d_pos, p.d_ctx, stream);
+    IMP_CUDA_CHECK_LOG(cudaEventRecord(p.ev, stream));
+
+    // 2. Enqueue the NEXT forward before the host knows the token — it reads
+    //    d_token (just written by the sampler) on the GPU timeline.
+    bool more = (p.produced + 1 < p.budget) &&
+                (static_cast<int>(req->output_tokens.size()) + 1 < req->max_tokens);
+    if (more)
+        p.runner.execute(stream);
+    p.forward_in_flight = more;
+
+    // 3. Wait only for the sampled token (GPU continues in forward N+1).
+    IMP_CUDA_CHECK_LOG(cudaEventSynchronize(p.ev));
+    int32_t token = *p.h_token;
+
+    // 4. Harvest — mirrors step_decode_process_outputs for one token.
+    req->output_tokens.push_back(token);
+    p.produced++;
+    track_think_state(*req, token);
+    constraints_.update(token);
+    kv_manager_->touch(req->id);
+
+    bool done = should_stop(*req, token) ||
+                static_cast<int>(req->output_tokens.size()) >= req->max_tokens;
+    if (done) {
+        teardown_constrained_pipeline(/*synchronize=*/true);
+        auto saved = req;
+        finish_request(saved);
+        return -1;
+    }
+    if (!more) {
+        // KV budget exhausted — drain and let the eager path continue.
+        teardown_constrained_pipeline(/*synchronize=*/true);
+        return 0;
+    }
+    return 1;
+}
+
+void Engine::teardown_constrained_pipeline(bool synchronize) {
+    auto& p = cpipe_;
+    if (synchronize)
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(decode_stream()));
+    p.runner.invalidate();
+    if (p.d_bt) { IMP_CUDA_CHECK_LOG(cudaFree(p.d_bt)); p.d_bt = nullptr; }
+    if (p.d_token) { IMP_CUDA_CHECK_LOG(cudaFree(p.d_token)); p.d_token = nullptr; }
+    if (p.d_pos) { IMP_CUDA_CHECK_LOG(cudaFree(p.d_pos)); p.d_pos = nullptr; }
+    if (p.d_ctx) { IMP_CUDA_CHECK_LOG(cudaFree(p.d_ctx)); p.d_ctx = nullptr; }
+    if (p.d_banned) { IMP_CUDA_CHECK_LOG(cudaFree(p.d_banned)); p.d_banned = nullptr; }
+    if (p.h_token) { IMP_CUDA_CHECK_LOG(cudaFreeHost(p.h_token)); p.h_token = nullptr; }
+    if (p.ev) { IMP_CUDA_CHECK_LOG(cudaEventDestroy(p.ev)); p.ev = nullptr; }
+    p.req = nullptr;
+    p.active = false;
+    p.forward_in_flight = false;
+    p.produced = 0;
+    p.budget = 0;
 }
 
 }  // namespace imp

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -59,6 +59,14 @@ bool Engine::step() {
         return scheduler_->has_pending() || scheduler_->active_count() > 0;
     }
 
+    // Fast path: pipelined constrained decode (json/schema) — one token/tick.
+    int cp_result = step_constrained_pipeline();
+    if (cp_result == 1)
+        return true;
+    if (cp_result == -1) {
+        return scheduler_->has_pending() || scheduler_->active_count() > 0;
+    }
+
     // Schedule prefill/decode batches and reconfigure green contexts.
     if (!step_schedule())
         return false;
@@ -1431,6 +1439,29 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
             !dreq->output_tokens.empty()) {
             int32_t last_token = dreq->output_tokens.back();
             try_launch_async_graph_loop(dreq, last_token, dec_stream);
+        }
+    }
+
+    // Constrained requests (json_mode / json_schema) can't run the conditional
+    // loop (the grammar FSM is host-side) — launch the pipelined constrained
+    // decode instead: per tick the host enqueues mask+sample AND the next
+    // forward, hiding FSM/mask latency under GPU compute. masked_sample_async
+    // covers banned tokens + greedy/top-k/top-p only — penalties or any
+    // host-side sampling feature stays on the eager path.
+    if (decode_graph_pool_[0].is_ready() && valid_decode.size() == 1 && !offload_mgr_ &&
+        config_.use_cuda_graphs && !async_graph_runner_.is_setup() && !cpipe_.active && !needs_logprobs &&
+        (needs_json_mode || needs_schema_mode)) {
+        auto& dreq = valid_decode[0];
+        // rep/freq/presence penalties and think_budget ARE supported (uploaded /
+        // forced per tick like the eager path) — the server defaults
+        // (repetition_penalty 1.05, think_budget 0.5) must not block the
+        // pipeline. min_p/typical_p/mirostat/DRY/logit_bias stay eager.
+        const bool pipeline_compatible =
+            dreq->logit_bias.empty() && dreq->mirostat == 0 && dreq->dry_multiplier == 0.0f &&
+            dreq->min_p == 0.0f && dreq->typical_p >= 1.0f &&
+            !mtp_spec_decode_enabled() && constraints_.is_active();
+        if (pipeline_compatible && dreq->status == RequestStatus::DECODING && !dreq->output_tokens.empty()) {
+            try_launch_constrained_pipeline(dreq, dec_stream);
         }
     }
 }


### PR DESCRIPTION
Recovery PR: these two commits were pushed to the #650 branch minutes after #650 was squash-merged, so they never landed on main. Re-based cleanly onto current main (which includes #649 + #650); re-validated end-to-end.

## 1. Schema mask fast path (json_schema 102–130 → 147–176 tok/s)

`SchemaConstrainer::compute_token_allow_mask` simulated **all 151k vocab tokens** through the pushdown automaton **every decode step**, each via a deep copy of the frame stack (~4.2 ms/token — the dominant share of the json_schema decode penalty). Two algorithmic fixes with byte-identical mask output:

- **Category prefilter** — the kernel ANDs category and allow, so category-failing tokens never needed simulation (JsonConstrainer already did this; SchemaConstrainer didn't). In structural phases this eliminates almost all simulations.
- **In-string O(1) shortcut** — a free `STRING_VALUE` accepts any token without `"`/`\`/control chars by construction; pattern/enum/key strings still simulate.

## 2. Pipelined constrained decode (147 → 235 tok/s sustained)

Constrained requests can't run the conditional-graph loop (the grammar FSM is host-side), and the eager path leaves the GPU idle during every host turnaround. New `ConstrainedPipeline` engine mode (single sequence, graphs on): per scheduler tick the host enqueues [penalties + banned + constraint mask + device sampling + cursor advance] for the forward already in flight **and the next forward** — a `CudaGraphRunner` replay of `forward_logits` reading the freshly sampled token from device memory (same device-fed pattern as the conditional loop). The host then waits only for the sampled token; FSM update, mask computation and scheduler overhead hide under forward N+1. The grammar FSM stays host-side and authoritative — masks upload stream-ordered between logits and sampling, so correctness is identical to eager **by construction**.

Supported in-pipeline: greedy/top-k/top-p, rep/freq/presence penalties (per-tick history upload — the server defaults `repetition_penalty=1.05` / `think_budget=0.5` must not silently disqualify the fast path), banned tokens, think-budget `</think>` forcing, host think tracking, KV-budget breakout to eager. Stays eager: logprobs, min_p, typical_p, mirostat, DRY, logit_bias, MTP, batch>1.

## Numbers (Qwen3-8B-NVFP4, server, temp=0; plain decode 270–278)

| | before | after |
|---|---|---|
| json_schema short-form | 102–130 tok/s | 176–184 tok/s |
| json_schema sustained (600 tok) | ~147 | **234–239 tok/s** |

## Validation (re-run on this branch after rebase)

- Constrain suites **23/23**; ThinkTokenAccept 6/6 (#649 coexistence)
- Pipeline launches confirmed; sustained 600-token json_schema 234–239 tok/s
- Original branch validation: pipeline-vs-eager parity **IDENTICAL** (250-token greedy), DegenerationTest 5/5 stderr-clean, full degen_suite 33/33, think+schema budget-force valid JSON, SSE termination clean, verify-fast OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)