### PR TITLE
fix(attention): demote fp8-QK FMHA to opt-in — raw e4m3 Q/K conversion corrupted gemma-3 long-ctx prefill (#511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+
+- **fp8-QK FMHA demoted to opt-in — gemma-3 long-context prefill was
+  catastrophically degraded** (#511 reopened/resolved). The raw (unscaled)
+  Q/K→e4m3 conversion compounds per-layer score error on real activations:
+  teacher-forced PPL gemma-3-12b 16.6→549 once chunked prefill crossed the
+  S-matrix cap (~3.5k ctx) and the fp8 kernel started serving (Qwen3-8B
+  forced through it: 40.5→4506). The #511 long-ctx "validation" (needle at
+  5.2k) never exercised the kernel — `fa2_fp16qk` served those chunks.
+  `attention.fp8_fmha` now defaults to `"never"` (strictly opt-in `"on"`);
+  the dispatch-chain FA2 call runs f16-QK; hd≠128 long prefill is served by
+  the FP16 WMMA kernel (PPL-identical to cuBLAS, 15.53 both at n=3441 incl.
+  sliding window). gemma-3-12b @8.3k-token corpus: PPL 549→11.1. Bonus:
+  Qwen3-8B pp4096 +6.9% (the tuned f16-QK FA2 replaces fp8-QK in the
+  unchunked chain). Follow-ups: #654 (broken `flash_attention_blackwell`
+  last-resort), #655 (IMP_PPL_DUMP position mapping).
+
 ## [0.10.0] - 2026-06-09
 
 151 commits since v0.9.1. Headlines: gpt-oss-20b support, LoRA hot-swap, the

--- a/docs/attention-dispatch.md
+++ b/docs/attention-dispatch.md
@@ -43,9 +43,9 @@ if (s_matrix_fits && !prefer_fmha) {
 Tried in order, first hit wins:
 
 1. **`fmha_sm120_mxfp4_prefill`** — opt-in (`attention_mxfp4_available()`), hd%32==0
-2. **`fmha_sm120_fa2_prefill`** — register-resident FA2 (#477/#478, `fmha_fa2 == "on"` default), **hd==128 only**
-3. **`fmha_sm120_fp8_prefill`** — when `attention.fp8_fmha != "never"` (default auto), hd%32==0
-4. **`fmha_sm120_prefill`** — FP16 WMMA, hd%16==0
+2. **`fmha_sm120_fa2_prefill`** — register-resident FA2 (#477/#478, `fmha_fa2 == "on"` default), **hd==128 only**. f16-QK mode unless the fp8-QK pair is explicitly opted in (`fa2_fp16qk=never` AND `fp8_fmha=on`).
+3. **`fmha_sm120_fp8_prefill`** — strictly opt-in (`attention.fp8_fmha == "on"`), hd%32==0. Raw e4m3 Q/K conversion compounds per-layer score error on real activations (#511): teacher-forced PPL gemma-3-12b 16.6→549 / Qwen3-8B 40.5→4506 when it served prefill. Off by default.
+4. **`fmha_sm120_prefill`** — FP16 WMMA, hd%16==0. Default server for hd≠128 long prefill (gemma-3 hd=256: PPL-identical to cuBLAS, 15.53 both at n=3441 incl. sliding window).
 5. **`flash_attention_blackwell`** — WMMA 128×64 tiles as the last resort
 
 The previously-archived variants (`attention_fmha_sm120_cluster.cu`, `attention_fmha_mxf4nvf4_sm120.cu`, `attention_naive.cu`) live in `docs/archive/` with resurrection memos.

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -65,11 +65,15 @@ bitdecoding_residual_tokens = 0
 # Each "auto" key picks the kernel automatically based on weight type +
 # context length. Override only for benchmarking or compatibility tests.
 fp8_prefill          = "auto"
-fp8_fmha             = "auto"
+# fp8-QK FMHA family: strictly opt-in ("on"). The raw e4m3 Q/K conversion
+# compounds per-layer score error on real activations (#511) — teacher-forced
+# PPL gemma-3-12b 16.6 -> 549 when it served prefill. Default "never" routes
+# hd!=128 prefill to the FP16 WMMA kernel instead.
+fp8_fmha             = "never"
 fmha_sm120           = "auto"
 # Register-resident FA2 prefill kernel for long prefill (F16, head_dim=128).
-# Default "on" since PR #478 (+13-19% long-ctx NVFP4 prefill); declines to
-# the FP8 FMHA for unsupported configs. "never" forces legacy FP8 FMHA.
+# Default "on" since PR #478; QK^T runs in f16 unless fa2_fp16qk=never AND
+# fp8_fmha=on (#511). Declines to the FP16 WMMA kernel for unsupported configs.
 fmha_fa2             = "on"
 # FP16-QK FA2 for SHORT prefill (below fmha_prefill_threshold, hd=128):
 # replaces the materialized cuBLAS+softmax path (PR #525, +25-35% pp512

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -46,21 +46,29 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     }
 
     // Register-resident FA2 ("echtes FA"): keeps S/P/O in registers, 1 barrier per
-    // KV tile (vs the FP8 FMHA's smem-materialized S/P/O + 4 barriers). Opt-in via
-    // [attention] fmha_fa2: "on" | "never" (default), env IMP_FMHA_FA2. head_dim=128.
+    // KV tile (vs the FP8 FMHA's smem-materialized S/P/O + 4 barriers). Default on
+    // via [attention] fmha_fa2, env IMP_FMHA_FA2. head_dim=128. QK^T runs in f16
+    // (same numerical class as cuBLAS) unless the user explicitly opts into the
+    // e4m3 fp8-QK mode (fa2_fp16qk=never AND fp8_fmha=on) — raw-converted fp8
+    // scores compound per layer into garbage on real activations (#511).
     if (rcfg.attention.fmha_fa2 == "on") {
-        if (fmha_sm120_fa2_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset)) {
+        const bool fa2_fp8_optin =
+            rcfg.attention.fa2_fp16qk == "never" && rcfg.attention.fp8_fmha == "on";
+        if (fmha_sm120_fa2_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset,
+                                   /*fp16_qk=*/!fa2_fp8_optin)) {
             IMP_LOG_DEBUG("FMHA dispatch: using FA2 register-resident kernel (hd=%d)",
                           static_cast<int>(Q.shape[3]));
             return;
         }
-        // unsupported config (hd!=128) → fall through to FP8/FP16 path
+        // unsupported config (hd!=128) → fall through to FP16 WMMA path
     }
 
-    // Native sm_120 FP8 FMHA: QK^T in FP8 E4M3 (m16n8k32) for 2x score throughput.
-    // PV stays FP16. [attention] fp8_fmha: "auto" (default ON) | "never"
-    const bool use_fp8_fmha = rcfg.attention.fp8_fmha != "never";
-    if (use_fp8_fmha) {
+    // fp8-QK FMHA (smem-materializing): QK^T in raw-converted FP8 E4M3 for 2x
+    // score throughput — but the unscaled e4m3 conversion carries ~10% relative
+    // score error that compounds across layers (#511): teacher-forced PPL
+    // gemma-3-12b 16.6 -> 549 / Qwen3-8B 40.5 -> 4506 when this kernel actually
+    // serves prefill. Strictly opt-in: [attention] fp8_fmha = "on".
+    if (rcfg.attention.fp8_fmha == "on") {
         bool fp8_ok = fmha_sm120_fp8_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
                                               q_offset);
         if (fp8_ok) {

--- a/src/compute/attention_dispatch_decision.h
+++ b/src/compute/attention_dispatch_decision.h
@@ -57,8 +57,12 @@ inline AttnPrefillPath select_attn_prefill_path(const RuntimeConfig& rcfg,
     if (rcfg.attention.fmha_fa2 == "on" && sup.fa2_accepts)
         return AttnPrefillPath::FA2;
 
-    // 3. Native FP8 FMHA — ON unless fp8_fmha == "never".
-    if (rcfg.attention.fp8_fmha != "never" && sup.fp8_accepts)
+    // 3. fp8-QK FMHA — strictly opt-in (== "on"). Raw e4m3 Q/K conversion
+    //    compounds ~10% relative score error per layer on real activations
+    //    (#511): teacher-forced PPL gemma-3-12b 16.6→549, Qwen3-8B 40.5→4506
+    //    when this kernel actually serves prefill. Default routes hd!=128
+    //    to the FP16 WMMA kernel below instead.
+    if (rcfg.attention.fp8_fmha == "on" && sup.fp8_accepts)
         return AttnPrefillPath::FP8;
 
     // 4. Native FP16 WMMA FMHA — ON unless fmha_sm120 == "never".

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -908,8 +908,12 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
             // score noise — the long-context chunked path through the
             // e4m3 FMHA family drifted teacher-forced NLL by up to ~25%
             // (ChunkedPrefillTest.LongContext_Chunk_Invariance is the gate).
-            // The fp8 family stays as fallback for configs f16-QK declines
-            // (hd != 128, fa2_fp16qk=never), and cuBLAS below the threshold.
+            // Configs f16-QK declines (hd != 128, e.g. gemma-3 hd=256) fall
+            // through to the tiled dispatch chain, which serves them with the
+            // FP16 WMMA kernel — the fp8-QK family is opt-in only (#511:
+            // raw e4m3 Q/K conversion read teacher-forced PPL 549 vs 16.6 on
+            // gemma-3-12b when it served these chunks). cuBLAS below the
+            // threshold.
             if (!per_layer_shapes && !attn_sinks &&
                 try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
                                        nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
@@ -951,15 +955,18 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         const bool prefer_fmha = !force_cublas_attn &&
                                  (n >= runtime_config().attention.fmha_prefill_threshold);
 
-        // NOTE (#566): sliding-window prefill used to be routed AWAY from the
-        // cuBLAS path here (`non_gemma4_sliding`) into the WMMA fallback
-        // chain — a relic from before attention_cublas_prefill grew its
-        // sliding_window softmax mask. The WMMA chain's hd=256 + window
-        // combination computes catastrophically wrong attention (gemma-3-12b
-        // at n>1024: teacher-forced PPL 42 vs llama.cpp 1.0; long-prompt
-        // recall answered '77' instead of '477'). The cuBLAS masked softmax
-        // is the correctness reference and handles the window — keep SWA
-        // prefill here whenever the S-matrix fits.
+        // NOTE (#566→#511): sliding-window prefill used to be routed AWAY
+        // from the cuBLAS path here (`non_gemma4_sliding`) into the tiled
+        // fallback chain — a relic from before attention_cublas_prefill grew
+        // its sliding_window softmax mask. The historic "catastrophically
+        // wrong hd=256+window attention" (gemma-3-12b PPL 42 vs llama.cpp
+        // 1.0) was root-caused to the fp8-QK kernel that used to lead that
+        // chain: raw e4m3 Q/K conversion compounds per-layer score error on
+        // real activations (#511) — measured PPL 549 vs 16.6 when it served
+        // gemma-3 chunks. fp8-QK is opt-in now; the FP16 WMMA kernel that
+        // serves hd=256 instead is PPL-identical to cuBLAS (15.53 both,
+        // n=3441 incl. window). cuBLAS stays preferred below the threshold
+        // for throughput and as the materialized reference.
         if (s_matrix_fits && !prefer_fmha) {
             // Below the FMHA threshold: prefer the FP16-QK FA2 kernel over the
             // materialized cuBLAS path (same f16/f32 numerics, O(n) memory).

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -92,17 +92,24 @@ struct RuntimeConfig {
 
     struct Attention {
         std::string fp8_prefill = "auto";
-        std::string fp8_fmha = "auto";
+        // fp8-QK FMHA family (smem-materializing fp8 kernel + FA2 in fp8-QK
+        // mode): converts Q/K to e4m3 RAW (no per-tile scaling) — ~10% relative
+        // score error on real activations that compounds across layers (#511).
+        // Teacher-forced PPL when this kernel actually serves prefill:
+        // gemma-3-12b 16.6 -> 549 (production chunked long-ctx), Qwen3-8B
+        // 40.5 -> 4506 (forced). The #511 "no measurable loss above threshold"
+        // needle check never exercised this kernel (fa2_fp16qk served those
+        // chunks). Opt-in ("on") for experiments; anything else = off.
+        std::string fp8_fmha = "never";
         int fmha_prefill_threshold = -1;  // -1 = auto (derived from S-matrix capacity)
         std::string fmha_sm120 = "auto";
         // Register-resident FA2 prefill kernel (fmha_sm120_fa2_kernel). When "on"
-        // (default) it replaces the smem-materializing FP8 FMHA for supported
-        // configs (F16, head_dim=128) — keeps S/P/O in registers, 1
-        // __syncthreads/KV tile. Measured +13-19% long-ctx NVFP4 prefill
-        // (Qwen3-14B, seq>=4096) at chunk=512; greedy output token-identical to
-        // the FP8 path (validated 2026-05-29). Declines (-> FP8 FMHA) for
-        // hd!=128 (Gemma), non-F16, or insufficient smem, so it's safe by
-        // default. "never" forces the legacy FP8 FMHA. Legacy env: IMP_FMHA_FA2.
+        // (default) it serves supported configs (F16, head_dim=128) in the tiled
+        // prefill chain — keeps S/P/O in registers, 1 __syncthreads/KV tile.
+        // QK^T mode follows fa2_fp16qk: f16-QK by default (no e4m3 score noise,
+        // #511); fp8-QK only when fa2_fp16qk=never AND fp8_fmha=on. Declines
+        // (-> FP16 WMMA FMHA) for hd!=128 (Gemma), non-F16, or insufficient
+        // smem, so it's safe by default. Legacy env: IMP_FMHA_FA2.
         std::string fmha_fa2 = "on";
         // FP16-QK FA2 for SHORT prefill (seq < fmha_prefill_threshold, hd=128):
         // replaces the materialized cuBLAS+softmax path with the register-

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -1,5 +1,13 @@
 // Tests for the FP8 E4M3 FMHA kernel (QK^T in FP8, PV in FP16).
 // Verifies correctness against a CPU reference for various configs.
+//
+// NOTE (#511): these parity cases use small synthetic values (±0.12) where
+// e4m3 quantization error is invisible. On real model activations the raw
+// (unscaled) Q/K→e4m3 conversion compounds per-layer score error into
+// garbage (teacher-forced PPL gemma-3-12b 16.6→549, Qwen3-8B 40.5→4506) —
+// which is why the kernel is opt-in (attention.fp8_fmha = "on") and NOT in
+// the default dispatch chain. These tests pin indexing/masking only, not
+// production quality.
 
 #include <gtest/gtest.h>
 #include "compute/attention_fmha_sm120.h"

--- a/tests/test_routing_decision.cpp
+++ b/tests/test_routing_decision.cpp
@@ -17,7 +17,7 @@ using namespace imp;
 
 namespace {
 
-// Default config: fmha_fa2="on", fp8_fmha="auto", fmha_sm120="auto".
+// Default config: fmha_fa2="on", fp8_fmha="never" (opt-in, #511), fmha_sm120="auto".
 RuntimeConfig default_cfg() { return RuntimeConfig{}; }
 
 // Typical hd=128 F16 prefill: every specialized kernel would accept.
@@ -53,18 +53,36 @@ TEST(AttnDispatchTable, Mxfp4AvailableButDeclinesFallsToFA2) {
     EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FA2);
 }
 
-TEST(AttnDispatchTable, FA2NeverFallsToFP8) {
+TEST(AttnDispatchTable, FA2NeverFallsToFMHANotFP8) {
+    // fp8-QK is opt-in (#511): disabling FA2 must NOT resurrect the e4m3 path.
     auto cfg = default_cfg();
     cfg.attention.fmha_fa2 = "never";
-    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::FP8);
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::FMHA_SM120);
 }
 
-TEST(AttnDispatchTable, FA2OnButDeclinesFallsToFP8) {
-    // hd != 128 (e.g. Gemma): FA2 declines even with fmha_fa2="on".
+TEST(AttnDispatchTable, FA2OnButDeclinesFallsToFMHA) {
+    // hd != 128 (gemma-3 hd=256, the #511 production victim): FA2 declines
+    // even with fmha_fa2="on" → FP16 WMMA serves, never the fp8-QK kernel.
     auto cfg = default_cfg();
     auto sup = all_accept();
     sup.fa2_accepts = false;
-    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FP8);
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FMHA_SM120);
+}
+
+TEST(AttnDispatchTable, FP8AutoIsOff) {
+    // Legacy "auto" (pre-#511-fix default) must behave as OFF, not ON.
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    cfg.attention.fp8_fmha = "auto";
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::FMHA_SM120);
+}
+
+TEST(AttnDispatchTable, FP8OptInServes) {
+    // Explicit fp8_fmha="on" (experiments) restores the fp8 tier behind FA2.
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    cfg.attention.fp8_fmha = "on";
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::FP8);
 }
 
 TEST(AttnDispatchTable, FP8NeverWithFA2NeverFallsToFMHA) {


### PR DESCRIPTION
## The bug

The fp8-QK FMHA family (`fmha_sm120_fp8_kernel` + FA2's fp8-QK mode) converts Q/K to e4m3 **raw, without scaling**. On real model activations the ~10% relative score error compounds across layers into garbage — the exact #511/#512 mechanism, which still applied above `fmha_prefill_threshold`:

| arm (teacher-forced PPL) | before | after |
|---|---|---|
| **gemma-3-12b, production chunked default, 8274-token corpus** | **549.5** | **11.1** |
| gemma-3-12b @3441 tokens (below cap, all-cuBLAS) | 15.53 | 15.54 (unchanged) |
| Qwen3-8B default @3691 | 40.51 | 40.52 (unchanged) |
| Qwen3-8B **forced** through the fp8 kernel | 4506 | (opt-in only) |

**gemma-3 (hd=256) was the production victim:** once chunked prefill crosses the S-matrix cap (~3.5k ctx @16 heads), chunks route into the tiled chain, `fa2_fp16qk` declines hd≠128, and the fp8 kernel served them. The #511 closure ("no measurable loss above threshold") was vacuous — its needle check ran on hd=128 where `fa2_fp16qk` serves every chunk, so the fp8 kernel never executed. Synthetic parity tests pass because ±0.12 inputs make e4m3 noise invisible (indexing is fine — all 6 hd=256 parity locks remain green); the numerics class is the bug.

## The fix

- `attention.fp8_fmha`: default `"auto"` → `"never"`, enabled only when explicitly `"on"`.
- Dispatch-chain FA2 call now runs **f16-QK** (mirrors the #548 chunked routing); fp8-QK only via `fa2_fp16qk=never` **and** `fp8_fmha=on`.
- hd≠128 long prefill lands on the FP16 WMMA kernel: **PPL-identical to cuBLAS** (15.53 both at n=3441 incl. sliding window); coherent long-prompt generation verified (>3.5k-ctx summarization, no loops/garbage).
- Routing-decision mirror + tests updated (12/12 green); stale #566 comments rewritten — the historic "catastrophic hd=256+window" readings were the fp8 kernel leading the chain, not the WMMA kernels.

## Perf

- Decode unchanged (238.1 vs 237.9 tg64).
- **Qwen3-8B pp4096 +6.9%** (11331 vs 10611 tok/s, 3×5 reps interleaved): the tuned f16-QK FA2 (#597/#653) replaces fp8-QK in the unchunked chain. pp512/pp128 untouched (cuBLAS below threshold).
- This intentionally moves long-ctx prefill perf; pp4096 moves UP, no baseline refresh needed.

## Follow-ups filed

- #654 — `flash_attention_blackwell` (final fallback) produces garbage end-to-end (PPL 11.9M when forced).
- #655 — `IMP_PPL_DUMP` per-position NLL assignment differs chunked vs single-shot (values identical as multiset; aggregates unaffected).

verify-fast: gtest PASS (perf/smoke lanes skipped: model symlinks not mounted in that lane). Closes #511's long-ctx leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)