### PR TITLE
fix(attention): prefill dispatch chain exhaustion throws instead of silently emitting garbage (#654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ### Fixed
 
+- **Prefill dispatch chain exhaustion now throws instead of silently emitting
+  garbage** (#654). `flash_attention_blackwell` declined hd=256 (smem over the
+  99 KB sm_120 opt-in) by silently falling back to `flash_attention_prefill_tc`,
+  whose launch also fails at hd=256 — unchecked — leaving the output buffer
+  as garbage (teacher-forced PPL ~1e10 when forced via `fmha_sm120=never`).
+  `flash_attention_blackwell` now returns a decline (`bool`, launch-checked;
+  correct at hd∈{64,96,128}: forced-blackwell Qwen3-8B PPL 40.50 vs cuBLAS
+  40.51), the tc fallback (which also lacked `q_offset` for chunked
+  continuations) is removed from the chain, and `attention_prefill_dispatch`
+  throws a descriptive error when no kernel accepts. Default routing is
+  unaffected (FA2/WMMA serve all supported head dims first).
+
 - **fp8-QK FMHA demoted to opt-in — gemma-3 long-context prefill was
   catastrophically degraded** (#511 reopened/resolved). The raw (unscaled)
   Q/K→e4m3 conversion compounds per-layer score error on real activations:

--- a/docs/attention-dispatch.md
+++ b/docs/attention-dispatch.md
@@ -46,7 +46,8 @@ Tried in order, first hit wins:
 2. **`fmha_sm120_fa2_prefill`** — register-resident FA2 (#477/#478, `fmha_fa2 == "on"` default), **hd==128 only**. f16-QK mode unless the fp8-QK pair is explicitly opted in (`fa2_fp16qk=never` AND `fp8_fmha=on`).
 3. **`fmha_sm120_fp8_prefill`** — strictly opt-in (`attention.fp8_fmha == "on"`), hd%32==0. Raw e4m3 Q/K conversion compounds per-layer score error on real activations (#511): teacher-forced PPL gemma-3-12b 16.6→549 / Qwen3-8B 40.5→4506 when it served prefill. Off by default.
 4. **`fmha_sm120_prefill`** — FP16 WMMA, hd%16==0. Default server for hd≠128 long prefill (gemma-3 hd=256: PPL-identical to cuBLAS, 15.53 both at n=3441 incl. sliding window).
-5. **`flash_attention_blackwell`** — WMMA 128×64 tiles as the last resort
+5. **`flash_attention_blackwell`** — WMMA 128×64 tiles, last tier. Declines hd ∉ {64,96,128,256} and smem-over-limit configs (hd=256 needs ~176 KB at Br=64 vs the 99 KB sm_120 opt-in).
+6. **Chain exhausted → `std::runtime_error`** (#654). The old silent fallback to `flash_attention_prefill_tc` swallowed launch failures at hd=256 (smem over limit, unchecked `cudaGetLastError`) and produced garbage logits (teacher-forced PPL ~1e10); tc also lacks `q_offset`, so chunked continuations would mask wrongly even when it launches. Reaching this tier means a config override disabled the FP16 WMMA tier or an unsupported head_dim — both error loudly now.
 
 The previously-archived variants (`attention_fmha_sm120_cluster.cu`, `attention_fmha_mxf4nvf4_sm120.cu`, `attention_naive.cu`) live in `docs/archive/` with resurrection memos.
 

--- a/src/compute/attention_blackwell.cu
+++ b/src/compute/attention_blackwell.cu
@@ -23,6 +23,7 @@
 
 #include "compute/attention_tc.h"
 #include "compute/attention_paged_common.cuh"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <float.h>
@@ -379,7 +380,7 @@ static size_t compute_smem(int Br, int head_dim) {
 
 // ===== Host-side launcher ====================================================
 
-void flash_attention_blackwell(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
+bool flash_attention_blackwell(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                                bool causal, int sliding_window, float softcap, cudaStream_t stream,
                                int q_offset) {
     const int batch_size = static_cast<int>(Q.shape[0]);
@@ -465,10 +466,21 @@ void flash_attention_blackwell(const Tensor& Q, const Tensor& K, const Tensor& V
     } else if (smem_64 <= (size_t)max_smem) {
         launched = launch(64, smem_64);
     }
-    if (!launched) {
-        // Unsupported head_dim or smem too small; fall back to tc path
-        flash_attention_prefill_tc(Q, K, V, O, scale, causal, sliding_window, softcap, stream);
+    // Unsupported head_dim or smem too small (e.g. hd=256: Br=64 needs ~176 KB
+    // vs the 99 KB sm_120 opt-in) → DECLINE so the dispatcher can fail loudly.
+    // The old silent fallback to flash_attention_prefill_tc was the #654 bug:
+    // the tc launcher also exceeds smem at hd=256, nobody checked the launch
+    // error, and O kept garbage (teacher-forced PPL ~1e10) — and tc has no
+    // q_offset, so chunked continuations would mask wrongly even when it runs.
+    if (launched) {
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("flash_attention_blackwell launch failed (hd=%d): %s", head_dim,
+                          cudaGetErrorString(err));
+            return false;
+        }
     }
+    return launched;
 #undef LAUNCH_BW
 }
 

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -3,7 +3,9 @@
 #include "core/logging.h"
 #include "runtime/config.h"
 #include <cuda_runtime.h>
+#include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 
 #include "compute/attention_fmha_sm120.h"
 #include "compute/attention_fmha_mxfp4_sm120.h"
@@ -86,8 +88,24 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
         }
     }
 
-    // Final fallback: WMMA 128x64 tiles for Blackwell.
-    flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset);
+    // Final tier: WMMA 128x64 tiles for Blackwell. Declines (returns false)
+    // for unsupported configs — hd ∉ {64,96,128,256} or smem over the device
+    // opt-in (hd=256 at Br=64 needs ~176 KB vs 99 KB on sm_120).
+    if (flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset)) {
+        return;
+    }
+
+    // Chain exhausted. Fail loudly instead of leaving O unwritten — the old
+    // silent blackwell→tc fallback at hd=256 swallowed the launch failure and
+    // produced garbage logits (teacher-forced PPL ~1e10, #654). Reaching this
+    // requires disabling the FP16 WMMA tier by config or an unsupported
+    // head_dim; both deserve an error, not silent corruption.
+    char msg[160];
+    snprintf(msg, sizeof(msg),
+             "attention_prefill_dispatch: no prefill kernel accepts head_dim=%d "
+             "(check attention.fmha_sm120/fmha_fa2 config) (#654)",
+             static_cast<int>(Q.shape[3]));
+    throw std::runtime_error(msg);
 }
 
 }  // namespace imp

--- a/src/compute/attention_dispatch_decision.h
+++ b/src/compute/attention_dispatch_decision.h
@@ -30,7 +30,8 @@ enum class AttnPrefillPath {
     FA2,          // fmha_sm120_fa2_prefill (register-resident)
     FP8,          // fmha_sm120_fp8_prefill
     FMHA_SM120,   // fmha_sm120_prefill (WMMA)
-    BLACKWELL,    // flash_attention_blackwell (final fallback)
+    BLACKWELL,    // flash_attention_blackwell (final tier; declines unsupported configs)
+    NONE,         // chain exhausted → attention_prefill_dispatch throws (#654)
 };
 
 // Per-kernel "would this kernel accept the config" flags, mirroring the bool
@@ -43,6 +44,9 @@ struct AttnKernelSupport {
     bool fa2_accepts = false;       // fmha_sm120_fa2_prefill(...) succeeded
     bool fp8_accepts = false;       // fmha_sm120_fp8_prefill(...) succeeded
     bool fmha_sm120_accepts = false;// fmha_sm120_prefill(...) succeeded
+    bool blackwell_accepts = false; // flash_attention_blackwell(...) succeeded
+                                    // (declines hd ∉ {64,96,128,256} and
+                                    // smem-over-limit configs, e.g. hd=256)
 };
 
 // Reproduces attention_prefill_dispatch()'s path selection (config gates +
@@ -69,8 +73,14 @@ inline AttnPrefillPath select_attn_prefill_path(const RuntimeConfig& rcfg,
     if (rcfg.attention.fmha_sm120 != "never" && sup.fmha_sm120_accepts)
         return AttnPrefillPath::FMHA_SM120;
 
-    // 5. Final fallback: WMMA 128x64 Blackwell flash attention (always runs).
-    return AttnPrefillPath::BLACKWELL;
+    // 5. Final tier: WMMA 128x64 Blackwell flash attention (no config gate,
+    //    but declines unsupported configs — see AttnKernelSupport).
+    if (sup.blackwell_accepts)
+        return AttnPrefillPath::BLACKWELL;
+
+    // 6. Chain exhausted: the dispatcher throws instead of producing garbage
+    //    via an unchecked launch (#654).
+    return AttnPrefillPath::NONE;
 }
 
 }  // namespace imp

--- a/src/compute/attention_tc.h
+++ b/src/compute/attention_tc.h
@@ -22,7 +22,11 @@ bool tc_attention_available();
 // Optimized WMMA attention for Blackwell (sm_120+) with 128x64 tiles.
 // Same interface as flash_attention_prefill_tc but with larger tiles and
 // double-buffered KV pipeline for improved compute-to-memory ratio.
-void flash_attention_blackwell(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
+// Returns false (launches nothing) when no template fits the config —
+// hd ∉ {64,96,128,256}, or smem over the device opt-in (hd=256 needs ~176 KB
+// at Br=64 vs 99 KB on sm_120) — or when the launch itself errors. Callers
+// must handle the decline; the old silent tc fallback was #654.
+bool flash_attention_blackwell(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                                bool causal = true, int sliding_window = 0, float softcap = 0.0f,
                                cudaStream_t stream = nullptr, int q_offset = 0);
 

--- a/tests/test_attention_crosspath.cu
+++ b/tests/test_attention_crosspath.cu
@@ -255,12 +255,12 @@ protected:
                 collect(r);
             results.push_back(std::move(r));
         }
-        {  // 6. flash_attention_blackwell (the dispatcher's final fallback)
+        {  // 6. flash_attention_blackwell (the dispatcher's final tier)
             PathResult r{"blackwell"};
             clear_o();
-            flash_attention_blackwell(Q4, K4, V4, O4, scale, causal, sw, softcap, stream_, 0);
-            r.ran = true;
-            collect(r);
+            r.ran = flash_attention_blackwell(Q4, K4, V4, O4, scale, causal, sw, softcap, stream_, 0);
+            if (r.ran)
+                collect(r);
             results.push_back(std::move(r));
         }
 

--- a/tests/test_attention_fmha_mxfp4.cu
+++ b/tests/test_attention_fmha_mxfp4.cu
@@ -98,7 +98,7 @@ void run_compare_test(int B, int SQ, int SKV, int NH, int NKV, int HD, bool caus
         Tensor V(d_v, QType::F16, 4, kv_shape, true);
         Tensor O(d_o_ref, QType::F16, 4, qo_shape, true);
         if (sm >= 120)
-            flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream);
+            ASSERT_TRUE(flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream));
         else
             flash_attention_prefill_tc(Q, K, V, O, scale, causal, sliding_window, softcap, stream);
     }

--- a/tests/test_attention_mxfp4.cu
+++ b/tests/test_attention_mxfp4.cu
@@ -178,7 +178,7 @@ TEST_F(AttentionMxFP4Test, CompareWithFP16Reference) {
         Tensor V(d_v, QType::F16, 4, kv_shape, true);
         Tensor O(d_o_ref, QType::F16, 4, qo_shape, true);
         if (sm_ >= 120) {
-            flash_attention_blackwell(Q, K, V, O, scale, true, 0, 0.0f, stream_);
+            ASSERT_TRUE(flash_attention_blackwell(Q, K, V, O, scale, true, 0, 0.0f, stream_));
         } else {
             flash_attention_prefill_tc(Q, K, V, O, scale, true, 0, 0.0f, stream_);
         }

--- a/tests/test_attention_tc.cu
+++ b/tests/test_attention_tc.cu
@@ -260,7 +260,7 @@ protected:
         Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
         Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
-        flash_attention_blackwell(Qt, Kt, Vt, Ot, scale, causal, 0, 0.0f, stream_);
+        ASSERT_TRUE(flash_attention_blackwell(Qt, Kt, Vt, Ot, scale, causal, 0, 0.0f, stream_));
         cudaStreamSynchronize(stream_);
 
         cudaError_t err = cudaGetLastError();
@@ -429,7 +429,7 @@ TEST_F(AttentionBlackwellTest, SlidingWindow) {
     Tensor Vt(d_v, QType::F16, 4, kv_shape, true);
     Tensor Ot(d_o, QType::F16, 4, q_shape, true);
 
-    flash_attention_blackwell(Qt, Kt, Vt, Ot, scale, /*causal=*/true, sliding_window, 0.0f, stream_);
+    ASSERT_TRUE(flash_attention_blackwell(Qt, Kt, Vt, Ot, scale, /*causal=*/true, sliding_window, 0.0f, stream_));
     cudaStreamSynchronize(stream_);
 
     cudaError_t err = cudaGetLastError();
@@ -452,6 +452,41 @@ TEST_F(AttentionBlackwellTest, SlidingWindow) {
     }
     EXPECT_EQ(non_finite, 0) << "non-finite output/reference elements";
     EXPECT_LT(max_err, 1e-2f) << "Sliding window max relative error " << max_err;
+
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_o);
+}
+
+TEST_F(AttentionBlackwellTest, HeadDim256DeclinesOnSm120) {
+    // hd=256 at Br=64 needs ~176 KB smem vs the 99 KB sm_120 opt-in. The
+    // kernel must DECLINE (return false) so the dispatcher fails loudly —
+    // the old silent fallback to flash_attention_prefill_tc swallowed the
+    // launch failure and produced garbage logits (#654).
+    if (sm_ < 120) {
+        GTEST_SKIP() << "decline contract pinned for sm_120 smem limits";
+    }
+    const int B = 1, Sq = 64, Skv = 64, NH = 2, NKV = 2, HD = 256;
+    size_t elems = (size_t)B * Sq * NH * HD;
+    void *d_q, *d_k, *d_v, *d_o;
+    cudaMalloc(&d_q, elems * sizeof(half));
+    cudaMalloc(&d_k, elems * sizeof(half));
+    cudaMalloc(&d_v, elems * sizeof(half));
+    cudaMalloc(&d_o, elems * sizeof(half));
+    cudaMemset(d_q, 0, elems * sizeof(half));
+    cudaMemset(d_k, 0, elems * sizeof(half));
+    cudaMemset(d_v, 0, elems * sizeof(half));
+    cudaMemset(d_o, 0, elems * sizeof(half));
+    int64_t shape[] = {B, Sq, NH, HD};
+    Tensor Qt(d_q, QType::F16, 4, shape, true);
+    Tensor Kt(d_k, QType::F16, 4, shape, true);
+    Tensor Vt(d_v, QType::F16, 4, shape, true);
+    Tensor Ot(d_o, QType::F16, 4, shape, true);
+
+    EXPECT_FALSE(flash_attention_blackwell(Qt, Kt, Vt, Ot, 0.0625f, true, 0, 0.0f, stream_));
+    cudaStreamSynchronize(stream_);
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
 
     cudaFree(d_q);
     cudaFree(d_k);

--- a/tests/test_routing_decision.cpp
+++ b/tests/test_routing_decision.cpp
@@ -28,6 +28,7 @@ AttnKernelSupport all_accept() {
     s.fa2_accepts = true;
     s.fp8_accepts = true;
     s.fmha_sm120_accepts = true;
+    s.blackwell_accepts = true;
     return s;
 }
 
@@ -108,11 +109,24 @@ TEST(AttnDispatchTable, AllSpecializedDisabledFallsToBlackwell) {
     EXPECT_EQ(select_attn_prefill_path(cfg, all_accept()), AttnPrefillPath::BLACKWELL);
 }
 
-TEST(AttnDispatchTable, AllSpecializedDeclineFallsToBlackwell) {
-    // Unsupported config for every specialized kernel → final WMMA fallback.
+TEST(AttnDispatchTable, AllDeclineIsNoneAndThrows) {
+    // Unsupported config for every kernel incl. the final blackwell tier
+    // (e.g. hd=256 with fmha_sm120=never: blackwell needs ~176 KB smem) →
+    // NONE; the dispatcher throws instead of silently corrupting O (#654).
     auto cfg = default_cfg();
     AttnKernelSupport sup;  // all false
-    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::BLACKWELL);
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::NONE);
+}
+
+TEST(AttnDispatchTable, BlackwellDeclineWithFMHADisabledIsNone) {
+    // The exact #654 production-forced config: hd=256, fmha_sm120=never.
+    // FA2 declines (hd!=128), fp8 opt-in/off, blackwell declines (smem).
+    auto cfg = default_cfg();
+    cfg.attention.fmha_sm120 = "never";
+    auto sup = all_accept();
+    sup.fa2_accepts = false;
+    sup.blackwell_accepts = false;
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::NONE);
 }
 
 TEST(AttnDispatchTable, FMHASm120AutoIsNotNever) {

--- a/tools/imp-bench/bench_attention.cu
+++ b/tools/imp-bench/bench_attention.cu
@@ -78,7 +78,10 @@ static float bench_kernel(const AttentionConfig& cfg, int seq_len, bool use_cutl
             attention_prefill_dispatch(Q, K, V, O, scale, true, 0, 0.0f, stream, rcfg);
             return;
         }
-        flash_attention_blackwell(Q, K, V, O, scale, true, 0, 0.0f, stream);
+        if (!flash_attention_blackwell(Q, K, V, O, scale, true, 0, 0.0f, stream)) {
+            fprintf(stderr, "flash_attention_blackwell declined this config (#654) — nothing to bench\n");
+            exit(1);
+        }
     };
 
     // Warmup


### PR DESCRIPTION
## Root cause — not a math bug

#654's "blackwell produces PPL 11.9M" was a **silently swallowed launch failure**, not wrong attention math:

- `flash_attention_blackwell` has no hd=256 template that fits sm_120 smem (Br=64 needs ~176 KB vs the 99 KB opt-in) → it silently fell back to `flash_attention_prefill_tc`.
- The tc launcher's smem at hd=256 is ~156 KB → `cudaFuncSetAttribute`/launch **fail**, and neither file checks `cudaGetLastError`. The output buffer keeps garbage → teacher-forced PPL ~1e10.
- Bonus defect: `flash_attention_prefill_tc` has no `q_offset` parameter, so chunked continuations would mask wrongly even where it launches.

The kernel is **correct where it accepts**: forced-blackwell Qwen3-8B (hd=128) reads PPL **40.50 vs cuBLAS 40.51**, and all parity cases pass — so it stays (it's also the crosspath/mxfp4 reference arm).

## Fix

- `flash_attention_blackwell` returns `bool`: declines unsupported configs, checks the launch error; the silent tc fallback is removed from the chain.
- `attention_prefill_dispatch` **throws** on chain exhaustion (translated to `ImpError` at the API boundary, per convention). New `AttnPrefillPath::NONE` in the routing mirror.
- Tests: `AttentionBlackwellTest.HeadDim256DeclinesOnSm120` pins the decline contract; routing table 13/13 incl. the exact #654 forced config; crosspath/mxfp4 call sites assert the launch; bench tool exits loudly on decline.

## Verification

| check | result |
|---|---|
| forced exhaustion (gemma-3, `fmha_sm120=never`) | clean `[ERROR] … no prefill kernel accepts head_dim=256 (#654)` (was PPL 4e10) |
| gemma-3 default PPL @3441 | 15.54 (unchanged) |
| forced-blackwell Qwen3-8B hd=128 PPL | 40.50 ≈ cuBLAS 40.51 |
| AttentionBlackwellTest / routing / crosspath+mxfp4 | 8/8, 13/13, 29/29 |
| verify-fast | OK |

Default routing is unaffected — FA2/WMMA serve all supported head dims before this tier.

Closes #654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)