### PR TITLE
feat(eval): IMP_PPL_DUMP=full + #655 forensics — per-position capture is consistent on current main

### DIFF
--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -299,10 +299,15 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
     cudaFree(ppl_capture_.d_nll);
     ppl_capture_ = PplCapture{};
 
-    if (getenv("IMP_PPL_DUMP") != nullptr) {
+    // IMP_PPL_DUMP=1: sparse per-position NLL (first 16, every 16th, tail).
+    // IMP_PPL_DUMP=full: every position — needed for cross-mode forensics;
+    // the sparse form hid that per-position values diverge between chunked
+    // and single-shot runs (#655).
+    if (const char* dump = getenv("IMP_PPL_DUMP")) {
+        const bool full = (strcmp(dump, "full") == 0);
         fprintf(stderr, "[PPL-DUMP] per-pos nll:");
         for (int i = 0; i < n - 1; ++i) {
-            if (i < 16 || i % 16 == 0 || i > n - 6)
+            if (full || i < 16 || i % 16 == 0 || i > n - 6)
                 fprintf(stderr, " [%d]=%.3f", i, h_nll_pos[i]);
         }
         fprintf(stderr, "\n");


### PR DESCRIPTION
## #655 verification

Re-ran the per-position NLL capture across every mode on current main (gemma-3-12b Q4_K_M, `IMP_PPL_DUMP=full`):

| comparison (same corpus prefix) | mean abs diff | positions >0.5 nats |
|---|---|---|
| chunked-512 vs single-shot | 0.0028 | 0 / 1274 |
| chunked-512 vs chunked-256 | 0.0021 | 0 / 1177 |
| threshold=0 vs threshold=999999 | 0.0021 | 0 / 1274 |
| 3441-token vs 1275-token corpus (shared prefix) | 0.0020 | 0 / 1270 |

**The instrument is consistent across chunk modes, thresholds, and corpus lengths on current main.** The divergence #655 reported traces to two runs on the **pre-#656 image** and does not reproduce with identical configs today (3 reproduction attempts incl. exact-config on the same corpus: today's run diverges from the anomalous old dump by the same 1.66 nats the old dump diverged from truth). Most plausible cause: fp8-QK contamination of a sub-path that #656 removed. The old runs' values were deterministic (two old runs agreed with each other cross-corpus) — consistent with a since-removed wrong code path, not noise.

## Change

`IMP_PPL_DUMP=full` prints every position (sparse `=1` form unchanged) — the sparse form was too coarse for exactly this kind of forensics, and the full form is what the #657 matched-positions work needs.

Closes #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)