### PR TITLE
fix(tokenizer): faithful Qwen2 pre-tokenizer — symbol runs and single digits were non-canonical (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ### Fixed
 
+- **Qwen2/Qwen3 tokenization was non-canonical on symbol/digit sequences**
+  (#657). The gpt2 pre-tokenizer fallback split every punctuation character
+  individually and grouped digits in threes, so canonical BPE merges were
+  impossible (`->` became `-`+`>`, `(x):` four chunks) — on a 10 KB
+  code/markdown corpus imp produced 3690 tokens vs llama.cpp's canonical
+  3084 (+20%), inflating teacher-forced NLL on matched text by +70% and
+  segmenting every production prompt containing code non-canonically.
+  New faithful `qwen2_pre_tokenize` (contractions, prefix-char+letter runs,
+  single digits, symbol runs, GPT-2 whitespace backtracking), routed via
+  GGUF `tokenizer.ggml.pre=qwen2` and detected from the HF tokenizer.json
+  Split regex for SafeTensors. Token streams are now id-identical to
+  llama.cpp on probe texts; corpus count 3084 == llama.cpp; matched-band
+  NLL gap vs llama.cpp: +70% → **+1.3%** (Qwen3-8B-Q8_0 PPL on the corpus:
+  40.5 → 10.98). Greedy locks unchanged; code generation verified coherent.
+
 - **Prefill dispatch chain exhaustion now throws instead of silently emitting
   garbage** (#654). `flash_attention_blackwell` declined hd=256 (smem over the
   99 KB sm_120 opt-in) by silently falling back to `flash_attention_prefill_tc`,

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -753,6 +753,156 @@ static std::vector<std::string> gpt2_pre_tokenize(const std::string& text) {
     return result;
 }
 
+// ---- Qwen2 pre-tokenization ----
+//
+// Faithful hand-rolled scan of the Qwen2 pre-tokenizer regex (the canonical
+// segmentation Qwen2/Qwen3 were trained with; llama.cpp LLAMA_VOCAB_PRE_TYPE_QWEN2):
+//
+//   (?i:'s|'t|'re|'ve|'m|'ll|'d)            contractions
+//   | [^\r\n\p{L}\p{N}]?\p{L}+              one optional prefix char + letter run
+//   | \p{N}                                 SINGLE digit
+//   |  ?[^\s\p{L}\p{N}]+[\r\n]*             optional space + SYMBOL RUN + newlines
+//   | \s*[\r\n]+                            whitespace ending in newlines
+//   | \s+(?!\S)                             trailing whitespace
+//   | \s+                                   other whitespace
+//
+// The previous routing sent qwen2 through gpt2_pre_tokenize, whose
+// "punctuation = single character" rule makes cross-symbol BPE merges
+// impossible ("->" became "-", ">"; "(x):" four chunks) and whose
+// digit-groups-of-3 rule is non-canonical for Qwen (single digits). On
+// code/markdown text that produced ~20% more tokens than canonical
+// (llama.cpp control: 3084 vs 3690 on a 10 KB corpus) and +70% teacher-forced
+// NLL on matched text (#657) — and every production prompt containing code
+// was segmented non-canonically. \p{L} is approximated as ASCII isalpha() or
+// any non-ASCII byte (same approximation as the other pre-tokenizers here).
+std::vector<std::string> qwen2_pre_tokenize(const std::string& text) {
+    std::vector<std::string> result;
+    const size_t n = text.size();
+    auto is_letter = [](unsigned char c) { return std::isalpha(c) != 0 || c >= 128; };
+    auto is_dig = [](unsigned char c) { return std::isdigit(c) != 0; };
+    auto is_ws = [](unsigned char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+    };
+    auto is_nl = [](unsigned char c) { return c == '\n' || c == '\r'; };
+
+    size_t i = 0;
+    while (i < n) {
+        const unsigned char c = static_cast<unsigned char>(text[i]);
+
+        // 1. Contractions 's 't 're 've 'm 'll 'd (case-insensitive).
+        if (c == '\'' && i + 1 < n) {
+            const char c1 = static_cast<char>(std::tolower(static_cast<unsigned char>(text[i + 1])));
+            const char c2 =
+                (i + 2 < n) ? static_cast<char>(std::tolower(static_cast<unsigned char>(text[i + 2]))) : 0;
+            size_t clen = 0;
+            if (c1 == 's' || c1 == 't' || c1 == 'm' || c1 == 'd')
+                clen = 2;
+            else if ((c1 == 'r' && c2 == 'e') || (c1 == 'v' && c2 == 'e') || (c1 == 'l' && c2 == 'l'))
+                clen = 3;
+            if (clen > 0) {
+                result.push_back(text.substr(i, clen));
+                i += clen;
+                continue;
+            }
+        }
+
+        // 2. [^\r\n\p{L}\p{N}]?\p{L}+ — one optional non-letter/digit/newline
+        //    prefix char (space, tab, or punctuation) glued to a letter run.
+        {
+            size_t j = i;
+            if (!is_letter(c) && !is_dig(c) && !is_nl(c))
+                j = i + 1;  // candidate prefix char
+            if (j < n && is_letter(static_cast<unsigned char>(text[j]))) {
+                size_t k = j;
+                while (k < n) {
+                    const unsigned char ck = static_cast<unsigned char>(text[k]);
+                    if (!is_letter(ck))
+                        break;
+                    size_t len = 1;
+                    if ((ck & 0xE0) == 0xC0)
+                        len = 2;
+                    else if ((ck & 0xF0) == 0xE0)
+                        len = 3;
+                    else if ((ck & 0xF8) == 0xF0)
+                        len = 4;
+                    k += (len <= n - k) ? len : (n - k);
+                }
+                result.push_back(text.substr(i, k - i));
+                i = k;
+                continue;
+            }
+        }
+
+        // 3. \p{N} — a single digit.
+        if (is_dig(c)) {
+            result.push_back(text.substr(i, 1));
+            i += 1;
+            continue;
+        }
+
+        // 4. ' '?[^\s\p{L}\p{N}]+[\r\n]* — optional space + symbol run + newlines.
+        {
+            size_t j = i + (text[i] == ' ' ? 1 : 0);
+            size_t k = j;
+            while (k < n) {
+                const unsigned char ck = static_cast<unsigned char>(text[k]);
+                if (is_ws(ck) || is_letter(ck) || is_dig(ck))
+                    break;
+                k++;
+            }
+            if (k > j) {
+                while (k < n && is_nl(static_cast<unsigned char>(text[k])))
+                    k++;
+                result.push_back(text.substr(i, k - i));
+                i = k;
+                continue;
+            }
+        }
+
+        // 5.-7. Whitespace rules.
+        if (is_ws(c)) {
+            size_t k = i;
+            size_t last_nl = std::string::npos;
+            while (k < n && is_ws(static_cast<unsigned char>(text[k]))) {
+                if (is_nl(static_cast<unsigned char>(text[k])))
+                    last_nl = k;
+                k++;
+            }
+            if (last_nl != std::string::npos) {
+                // \s*[\r\n]+ — greedy up to the LAST newline in the run; any
+                // trailing spaces/tabs stay for the next match (they become
+                // the ' ?' / prefix of the following chunk).
+                result.push_back(text.substr(i, last_nl + 1 - i));
+                i = last_nl + 1;
+                continue;
+            }
+            if (k >= n) {
+                // \s+(?!\S) — trailing whitespace at end of text.
+                result.push_back(text.substr(i, k - i));
+                i = k;
+                continue;
+            }
+            if (k - i > 1) {
+                // \s+(?!\S) with backtracking: leave ONE space for the next
+                // chunk ("    return" → ["   ", " return"]).
+                result.push_back(text.substr(i, k - i - 1));
+                i = k - 1;
+                continue;
+            }
+            // \s+ — single whitespace char the letter/symbol rules didn't take
+            // (e.g. the space in " 5": digits don't absorb a leading space).
+            result.push_back(text.substr(i, 1));
+            i += 1;
+            continue;
+        }
+
+        // Unreachable in practice (every byte class is handled above).
+        result.push_back(text.substr(i, 1));
+        i += 1;
+    }
+    return result;
+}
+
 // ---- Load vocabulary ----
 
 bool Tokenizer::load(const std::string& path) {
@@ -918,6 +1068,21 @@ bool Tokenizer::load(const std::string& path) {
                         continue;
                     std::string inner_type;
                     jobj_get_string(pt, "type", inner_type);
+                    if (inner_type == "Split") {
+                        // HF Qwen2/Qwen3 tokenizer.json carries the literal
+                        // pre-tokenizer regex in a Split step. Detect the
+                        // contraction signature and route to the faithful
+                        // qwen2 scanner — without this, SafeTensors Qwen
+                        // fell to the gpt2 fallback (per-char punctuation,
+                        // non-canonical segmentation, #657).
+                        const JValue* pattern = jobj_find(pt, "pattern");
+                        std::string rx;
+                        if (pattern && pattern->type == JType::OBJECT)
+                            jobj_get_string(*pattern, "Regex", rx);
+                        if (rx.find("'s|'t|'re|'ve|'m|'ll|'d") != std::string::npos)
+                            pre_tokenizer_ = "qwen2";
+                        continue;
+                    }
                     if (inner_type == "ByteLevel") {
                         type_ = "gpt2";
                         const JValue* prefix = jobj_find(pt, "add_prefix_space");
@@ -1590,6 +1755,11 @@ std::vector<int32_t> Tokenizer::encode_gpt2(const std::string& text) const {
         std::vector<std::string> chunks;
         if (pre_tokenizer_ == "llama3" || pre_tokenizer_ == "llama-v3" || pre_tokenizer_ == "llama-bpe") {
             chunks = llama3_pre_tokenize(bpe_text);
+        } else if (pre_tokenizer_ == "qwen2") {
+            // Qwen2/Qwen3 family: canonical regex incl. symbol RUNS and single
+            // digits — the gpt2 fallback's per-char punctuation made canonical
+            // merges ("->", "():") impossible (#657).
+            chunks = qwen2_pre_tokenize(bpe_text);
         } else {
             chunks = gpt2_pre_tokenize(bpe_text);
         }

--- a/src/model/tokenizer.h
+++ b/src/model/tokenizer.h
@@ -175,4 +175,8 @@ private:
     void build_special_pieces();
 };
 
+// Qwen2/Qwen3 pre-tokenizer scan (canonical regex segmentation; #657).
+// Exposed for unit tests — production use is inside Tokenizer::encode_*.
+std::vector<std::string> qwen2_pre_tokenize(const std::string& text);
+
 }  // namespace imp

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -299,10 +299,15 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
     cudaFree(ppl_capture_.d_nll);
     ppl_capture_ = PplCapture{};
 
-    if (getenv("IMP_PPL_DUMP") != nullptr) {
+    // IMP_PPL_DUMP=1: sparse per-position NLL (first 16, every 16th, tail).
+    // IMP_PPL_DUMP=full: every position — needed for cross-mode forensics;
+    // the sparse form hid that per-position values diverge between chunked
+    // and single-shot runs (#655).
+    if (const char* dump = getenv("IMP_PPL_DUMP")) {
+        const bool full = (strcmp(dump, "full") == 0);
         fprintf(stderr, "[PPL-DUMP] per-pos nll:");
         for (int i = 0; i < n - 1; ++i) {
-            if (i < 16 || i % 16 == 0 || i > n - 6)
+            if (full || i < 16 || i % 16 == 0 || i > n - 6)
                 fprintf(stderr, " [%d]=%.3f", i, h_nll_pos[i]);
         }
         fprintf(stderr, "\n");

--- a/tests/test_tokenizer.cpp
+++ b/tests/test_tokenizer.cpp
@@ -619,5 +619,55 @@ TEST(TokenizerControlTest, PreservesExistingTypes) {
     EXPECT_FALSE(tok.is_control_token(4));  // 'H' still normal
 }
 
+// ---- Qwen2 pre-tokenizer (#657) ----
+//
+// Expected segmentations derived from the canonical Qwen2 regex and verified
+// against llama.cpp `llama-tokenize` on Qwen3-8B (the listed chunks correspond
+// 1:1 to the canonical token ids on these probes). The old gpt2 fallback
+// split every punctuation char individually, making canonical merges
+// ("->", "://", "(x", ".com") impossible.
+
+using Chunks = std::vector<std::string>;
+
+TEST(Qwen2PreTokenizeTest, SymbolRunsMerge) {
+    EXPECT_EQ(qwen2_pre_tokenize("x->bar"), (Chunks{"x", "->", "bar"}));
+    EXPECT_EQ(qwen2_pre_tokenize("https://example.com"),
+              (Chunks{"https", "://", "example", ".com"}));
+}
+
+TEST(Qwen2PreTokenizeTest, PrefixCharGluesToLetterRun) {
+    // [^\r\n\p{L}\p{N}]?\p{L}+ — '(' and '.' attach to the following word.
+    EXPECT_EQ(qwen2_pre_tokenize("def foo(x):\n"),
+              (Chunks{"def", " foo", "(x", "):\n"}));
+}
+
+TEST(Qwen2PreTokenizeTest, SingleDigits) {
+    // Qwen2 splits digits individually (\p{N}), unlike the 3-digit gpt2 rule.
+    EXPECT_EQ(qwen2_pre_tokenize("q=1&r=42"),
+              (Chunks{"q", "=", "1", "&r", "=", "4", "2"}));
+}
+
+TEST(Qwen2PreTokenizeTest, Contractions) {
+    EXPECT_EQ(qwen2_pre_tokenize("don't stop"), (Chunks{"don", "'t", " stop"}));
+}
+
+TEST(Qwen2PreTokenizeTest, IndentationKeepsOneSpaceForWord) {
+    // \s+(?!\S) backtracks one position: 4-space indent → "   " + " return".
+    EXPECT_EQ(qwen2_pre_tokenize("    return x"),
+              (Chunks{"   ", " return", " x"}));
+}
+
+TEST(Qwen2PreTokenizeTest, NewlineRuns) {
+    // \s*[\r\n]+ groups whitespace up to the LAST newline; the remaining
+    // indent feeds the next chunk.
+    EXPECT_EQ(qwen2_pre_tokenize("a\n\n  b"), (Chunks{"a", "\n\n", " ", " b"}));
+    // Symbol run absorbs trailing newlines ([\r\n]*).
+    EXPECT_EQ(qwen2_pre_tokenize("};\n\nint"), (Chunks{"};\n\n", "int"}));
+}
+
+TEST(Qwen2PreTokenizeTest, TrailingWhitespace) {
+    EXPECT_EQ(qwen2_pre_tokenize("abc   "), (Chunks{"abc", "   "}));
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## The find (#657 matched-positions analysis)

Step 1 of #657 verified llama.cpp's `perplexity()` scores only positions ≥ n_ctx/2 (`first = n_ctx/2`, source-checked) — so all prior cross-engine PPL comparisons were methodology-skewed. After correcting for that AND comparing **total NLL over identical text bands** (tokenization-fair), a real gap remained: **Qwen3-8B-Q8_0 +70%** vs llama.cpp on a code/markdown corpus.

Token-level diff against `llama-tokenize` found the cause: the gpt2 pre-tokenizer fallback (serving `pre=qwen2` too) splits **every punctuation char individually** and groups digits in threes. Canonical Qwen2 has symbol **runs**, prefix-char+letter gluing, and **single** digits:

| text | llama.cpp (canonical) | imp before | imp after |
|---|---|---|---|
| `->` | `405` | `12 29` | `405` ✓ |
| `(x):\n` | `2075 982` | `7 87 8 25 198` | `2075 982` ✓ |
| 10 KB corpus | 3084 tokens | 3690 (+20%) | **3084** ✓ |

**Every production prompt containing code was segmented non-canonically** — this was a quality bug, not just eval.

## Fix

New `qwen2_pre_tokenize()` — hand-rolled scan of the canonical regex (contractions, `[^\r\n\p{L}\p{N}]?\p{L}+`, single `\p{N}`, ` ?[^\s\p{L}\p{N}]+[\r\n]*`, GPT-2 whitespace backtracking). Routed via GGUF `tokenizer.ggml.pre=qwen2`; for SafeTensors the HF tokenizer.json `Split` regex contraction signature sets it (the NVFP4 heroes previously fell to the gpt2 fallback).

## Results

| metric | before | after |
|---|---|---|
| matched-band NLL vs llama.cpp | **+70%** | **+1.3%** |
| corpus PPL (Qwen3-8B-Q8_0) | 40.5 | **10.98** (llama.cpp: 9.97 on its skip-half positions) |
| probe token ids | divergent | **byte-identical** to llama-tokenize (GGUF + SafeTensors) |

Validation: 7 new pre-tokenizer unit tests (cases derived from llama-tokenize ids); test-text 178 PASS; **GreedyLockTest PASS** (continuation ids unchanged); code-gen smoke coherent; verify-fast OK.

Not in scope: the gpt2 fallback itself (gpt-oss/cl100k family) has the same per-char punctuation defect — left unchanged for blast-radius control, follow-up tracked in #657. gemma-3's separate +37.5% matched-band gap (tokenizer already near-canonical there) also remains under #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)