### PR TITLE
fix(tokenizer): SPM pre-split includes USER_DEFINED pieces — gemma multi-space runs now canonical (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ### Fixed
 
+- **SPM tokenization: USER_DEFINED pieces now literal-matched — gemma
+  multi-space runs were never canonical** (#657). gemma-3 stores indentation
+  tokens (`'  '`…27×`' '`) and HTML tags as SentencePiece user-defined
+  symbols with literal-space pieces; imp's ▁-substituting BPE could never
+  reproduce them and emitted N single-space tokens per indent run. The
+  special-pieces literal pre-split now includes type-4 (USER_DEFINED)
+  alongside CONTROL. gemma-3-12b: token ids identical to llama.cpp, corpus
+  count 3395 == llama.cpp, matched-band NLL +37.5% → **−0.4%**, corpus PPL
+  15.53 → 10.57. Together with the Qwen2 pre-tokenizer fix, the entire
+  measured cross-engine quality gap was tokenization, not numerics. Also:
+  `--set diagnostics.dump_tokens=true` with `--perplexity` now dumps the
+  full corpus token stream for cross-engine diffs.
+
 - **Qwen2/Qwen3 tokenization was non-canonical on symbol/digit sequences**
   (#657). The gpt2 pre-tokenizer fallback split every punctuation character
   individually and grouped digits in threes, so canonical BPE merges were

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -1179,8 +1179,17 @@ void Tokenizer::build_special_pieces() {
     if (token_types_.empty())
         return;
     for (size_t id = 0; id < token_types_.size() && id < vocab_.size(); ++id) {
-        if (token_types_[id] != 3)
-            continue;  // CONTROL only
+        // CONTROL (3) markers AND USER_DEFINED (4) symbols. SentencePiece
+        // semantics: user-defined symbols match the RAW input literally and
+        // atomically, before normalization/BPE. gemma-3 stores its multi-space
+        // run tokens ('  ', '   ', …, 27×' ') and HTML tags (<code>, <i>, …)
+        // as USER_DEFINED with literal-space pieces — the ▁-substituting BPE
+        // body can never reproduce them ("▁▁" is not in the vocab), so imp
+        // emitted N single-space tokens per indentation run: +1.3% tokens and
+        // a large share of the +37.5% NLL gap vs llama.cpp on code/markdown
+        // (#657). llama.cpp matches these via its user-defined trie.
+        if (token_types_[id] != 3 && token_types_[id] != 4)
+            continue;
         const std::string& s = vocab_[id];
         if (s.empty())
             continue;

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -203,6 +203,14 @@ int main(int argc, char** argv) {
             ppl_tokens.insert(ppl_tokens.begin(), bos);
             n_tok++;
         }
+        // diagnostics.dump_tokens: print the FULL corpus token stream (one id
+        // per line on stderr) — cross-engine tokenizer forensics (#657) diffs
+        // this against `llama-tokenize --ids` output.
+        if (runtime_cfg.diagnostics.dump_tokens) {
+            fprintf(stderr, "[DUMP_PPL_TOKENS] n=%d\n", n_tok);
+            for (int ti = 0; ti < n_tok; ti++)
+                fprintf(stderr, "TOK %d %d\n", ti, ppl_tokens[ti]);
+        }
         // Chunked prefill is the DEFAULT here since the engine-side capture
         // became chunk-aware (#553): per-chunk NLL accumulation makes the
         // teacher-forced score independent of chunking, and the chunked


### PR DESCRIPTION
## The find — the rest of #657's gap

After PR #660 fixed Qwen (+70% → +1.3%), gemma-3 still showed **+37.5%** matched-band NLL vs llama.cpp with a near-matching token count. A full token-stream diff against `llama-tokenize` (new `--perplexity` + `dump_tokens` stream dump) localized it: **all 28 divergent blocks were multi-space runs.**

gemma-3 stores its indentation tokens (`'  '` … 27×`' '`, ids 138–163) and HTML tags (`<code>`, `<i>`, …) as SentencePiece **USER_DEFINED** symbols with **literal-space** pieces. SentencePiece semantics: user-defined symbols match the raw input literally and atomically before normalization. imp's SPM encoder substitutes `' '`→`▁` before BPE — and `▁▁` is not in the vocab — so every indentation run decomposed into N single-space tokens the model never saw in training.

## Fix

Include type-4 (USER_DEFINED) pieces in the existing special-pieces literal pre-split (same mechanism as CONTROL markers, alnum-shadowing guard unchanged) — mirroring llama.cpp's user-defined trie.

## Results (gemma-3-12b Q4_K_M)

| metric | before | after | llama.cpp |
|---|---|---|---|
| probe `'a  b and    c'` | divergent | **id-identical** | — |
| corpus token count | 3440 | **3395** | 3395 |
| matched-band NLL | +37.5% | **−0.4%** | 2484.5 nats |
| corpus PPL | 15.53 | **10.57** | — |

**With #660, the entire measured #657 cross-engine gap was tokenization, not numerics.** All quality-flag suspects (FP8 prefill cache, dp4a LM head, NVFP4 decode cache) were measured innocent (identical PPL with/without).

## Blast radius & validation

- All models with type-4 vocab entries are affected by design (canonical HF/SPM behavior is literal-matching). **Qwen3-8B verified bit-unchanged** (corpus count 3084 and PPL 10.9830 identical, GreedyLockTest PASS — its added markers were already isolated by the qwen2 pre-tokenizer).
- test-text 178 + test-core PASS, gemma generation smoke coherent, verify-fast OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)