### PR TITLE
fix(tokenizer): cl100k pre-tokenizer for Phi-4 — correct three-way Split-regex discrimination (#657)

### DIFF
--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -806,7 +806,10 @@ static bool utf8_punct_symbol(const std::string& text, size_t i) {
 // NLL on matched text (#657) — and every production prompt containing code
 // was segmented non-canonically. \p{L} is approximated as ASCII isalpha() or
 // any non-ASCII byte (same approximation as the other pre-tokenizers here).
-std::vector<std::string> qwen2_pre_tokenize(const std::string& text) {
+// Shared scanner for the qwen2/cl100k regex family — identical except for the
+// digit rule: qwen2 matches single digits (\p{N}), cl100k groups up to three
+// (\p{N}{1,3}; Phi-4 and the GPT-4/tiktoken cl100k lineage).
+static std::vector<std::string> qwen2_like_pre_tokenize(const std::string& text, int max_digit_run) {
     std::vector<std::string> result;
     const size_t n = text.size();
     auto utf8_step = [&](size_t k) -> size_t {
@@ -871,10 +874,14 @@ std::vector<std::string> qwen2_pre_tokenize(const std::string& text) {
             }
         }
 
-        // 3. \p{N} — a single digit.
+        // 3. Digit rule: \p{N} (qwen2) or \p{N}{1,3} (cl100k).
         if (is_dig(c)) {
-            result.push_back(text.substr(i, 1));
-            i += 1;
+            size_t k = i;
+            while (k < n && k - i < static_cast<size_t>(max_digit_run) &&
+                   is_dig(static_cast<unsigned char>(text[k])))
+                k++;
+            result.push_back(text.substr(i, k - i));
+            i = k;
             continue;
         }
 
@@ -939,6 +946,14 @@ std::vector<std::string> qwen2_pre_tokenize(const std::string& text) {
         i += 1;
     }
     return result;
+}
+
+std::vector<std::string> qwen2_pre_tokenize(const std::string& text) {
+    return qwen2_like_pre_tokenize(text, /*max_digit_run=*/1);
+}
+
+std::vector<std::string> cl100k_pre_tokenize(const std::string& text) {
+    return qwen2_like_pre_tokenize(text, /*max_digit_run=*/3);
 }
 
 // ---- o200k pre-tokenization (gpt-oss / GPT-4o family) ----
@@ -1278,8 +1293,14 @@ bool Tokenizer::load(const std::string& path) {
                         std::string rx;
                         if (pattern && pattern->type == JType::OBJECT)
                             jobj_get_string(*pattern, "Regex", rx);
-                        if (rx.find("{1,3}") != std::string::npos)
+                        // Fingerprints, most specific first: only o200k uses
+                        // case classes (\p{Lu}); cl100k shares qwen2's rules
+                        // except digit triples ({1,3}); plain contraction
+                        // alternation → qwen2.
+                        if (rx.find("\\p{Lu}") != std::string::npos)
                             pre_tokenizer_ = "o200k";
+                        else if (rx.find("{1,3}") != std::string::npos)
+                            pre_tokenizer_ = "cl100k";
                         else if (rx.find("'s|'t|'re|'ve|'m|'ll|'d") != std::string::npos)
                             pre_tokenizer_ = "qwen2";
                         continue;
@@ -1974,6 +1995,10 @@ std::vector<int32_t> Tokenizer::encode_gpt2(const std::string& text) const {
             // gpt-oss / GPT-4o family (o200k_harmony): case-aware letter runs,
             // digit triples, slash-aware symbol runs (#657).
             chunks = o200k_pre_tokenize(bpe_text);
+        } else if (pre_tokenizer_ == "cl100k") {
+            // GPT-4/tiktoken cl100k lineage (Phi-4): qwen2 rules with digit
+            // triples (#657).
+            chunks = cl100k_pre_tokenize(bpe_text);
         } else {
             chunks = gpt2_pre_tokenize(bpe_text);
         }

--- a/src/model/tokenizer.h
+++ b/src/model/tokenizer.h
@@ -183,4 +183,8 @@ std::vector<std::string> qwen2_pre_tokenize(const std::string& text);
 // runs, digit triples, slash-aware symbol runs. Exposed for unit tests.
 std::vector<std::string> o200k_pre_tokenize(const std::string& text);
 
+// cl100k pre-tokenizer scan (GPT-4/tiktoken lineage, Phi-4; #657): qwen2
+// rules with digit groups of up to three. Exposed for unit tests.
+std::vector<std::string> cl100k_pre_tokenize(const std::string& text);
+
 }  // namespace imp

--- a/tests/test_tokenizer.cpp
+++ b/tests/test_tokenizer.cpp
@@ -729,5 +729,22 @@ TEST(Qwen2PreTokenizeTest, NonAsciiSymbolsAreSymbolsNotLetters) {
     EXPECT_EQ(qwen2_pre_tokenize("K\xc3\xa4se"), (Chunks{"K\xc3\xa4se"}));
 }
 
+// ---- cl100k pre-tokenizer (GPT-4/tiktoken lineage, Phi-4; #657) ----
+//
+// qwen2 rules with digit triples. Chunk truths verified against HF
+// tokenizers pre_tokenize_str on Phi-4-reasoning-plus.
+
+TEST(Cl100kPreTokenizeTest, DigitTriplesCaseBlindStandaloneContractions) {
+    EXPECT_EQ(cl100k_pre_tokenize("17 + 12345"),
+              (Chunks{"17", " +", " ", "123", "45"}));
+    // Case-blind letter runs: camelCase stays ONE chunk (unlike o200k).
+    EXPECT_EQ(cl100k_pre_tokenize("camelCase HTTPSession"),
+              (Chunks{"camelCase", " HTTPSession"}));
+    // Contractions split standalone (like qwen2, unlike o200k's suffix).
+    EXPECT_EQ(cl100k_pre_tokenize("don't stop"), (Chunks{"don", "'t", " stop"}));
+    EXPECT_EQ(cl100k_pre_tokenize("a->b https://x.com/y"),
+              (Chunks{"a", "->", "b", " https", "://", "x", ".com", "/y"}));
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## Completes the Split-regex family coverage

Phi-4 carries the **cl100k** regex (GPT-4/tiktoken lineage) = qwen2's rules with digit triples, case-blind letter runs, standalone contractions. #662's `{1,3}` fingerprint mis-routed it to **o200k** (case-aware — wrong for cl100k); before that qwen2 (wrong digits); originally gpt2 fallback (wrong everything).

**Fingerprints, most specific first:** `\p{Lu}` (only o200k has case classes) → o200k; `{1,3}` → cl100k; contraction alternation → qwen2.

| family | model | stream vs canonical |
|---|---|---|
| cl100k (new) | **Phi-4-reasoning-plus** | **id-identical to HF** (2967); PPL 12.60 — in family with Qwen 10.98/gemma 10.57 |
| o200k | gpt-oss | unchanged (2966 == HF) |
| qwen2 | Qwen3-8B | unchanged (3084 == llama) |

`qwen2_pre_tokenize` refactored into a shared scanner parameterized by `max_digit_run`. 17 unit tests (Phi-4 chunk truths from HF `pre_tokenize_str`); verify-fast OK.

Phi-4's healthy PPL also further isolates the gpt-oss forward elevation (#663) as gpt-oss-specific, not an NVFP4-SafeTensors-path issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)