### PR TITLE
feat(spec): n-gram prompt-lookup speculative decoding (opt-in, burst-hybrid verify)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,9 @@ set(IMP_RUNTIME_SOURCES
     src/runtime/engine_workspace_warmup.cpp
     src/runtime/engine_graph_decode.cpp
     src/runtime/engine_scheduler.cpp
+    src/runtime/engine_spec_ngram.cpp
     src/runtime/engine_sampling_stop.cpp
+    src/runtime/ngram_draft.cpp
     src/vision/vision_pipeline.cpp
     src/runtime/constraint_manager.cpp
     src/runtime/vram_budget.cpp
@@ -450,6 +452,7 @@ if(IMP_BUILD_TESTS)
         tests/test_safetensors_loader.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
+        tests/test_ngram_draft.cpp
         tests/test_routing_decision.cpp
         tests/test_think_stop_logic.cpp
         tests/test_stream_pipeline.cpp

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -252,8 +252,8 @@ mmproj               = ""
 # disables the async decode graph loop while on. Wins on repetition-heavy
 # (agent/code/RAG) workloads; can cost a few % on free-form prose.
 ngram                = false
-# Draft tokens proposed per verify step.
-k                    = 8
+# Draft tokens proposed per verify step (verify cost is ~flat in k).
+k                    = 16
 # Shortest / longest suffix n-gram match searched.
 min_match            = 3
 max_match            = 8
@@ -265,6 +265,10 @@ give_up_after        = 64
 # many tokens and re-probes for drafts in between (think models reach their
 # draft-rich region only after the reasoning prose). 0 = give-up is final.
 burst                = 128
+# On a draft miss, run the async loop for this many tokens (cheap rearm,
+# no graph recapture) instead of stepping eagerly until the next draft.
+# 0 = stay eager between drafts.
+miss_burst           = 8
 
 [ffn]
 # SwiGLU/GeGLU sparsity probe — instrumentation only, counts skippable

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -244,6 +244,28 @@ generate             = false
 # Path to a vision projector .gguf file (Gemma-3, Mistral3 multimodal).
 mmproj               = ""
 
+[speculative]
+# n-gram (prompt-lookup) speculative decoding: drafts come from suffix
+# matches against the request's own prompt+output — no draft model. Greedy
+# verify accepts the longest matching prefix, so output stays a faithful
+# greedy decode. Batch-1, greedy sampling, dense-attention models only;
+# disables the async decode graph loop while on. Wins on repetition-heavy
+# (agent/code/RAG) workloads; can cost a few % on free-form prose.
+ngram                = false
+# Draft tokens proposed per verify step.
+k                    = 8
+# Shortest / longest suffix n-gram match searched.
+min_match            = 3
+max_match            = 8
+# Give up on speculation (and return to the fast async decode loop) after
+# this many consecutive draft misses, or when acceptance stays under 15%.
+# 0 = never give up.
+give_up_after        = 64
+# Burst-hybrid: a given-up request runs the async loop in bursts of this
+# many tokens and re-probes for drafts in between (think models reach their
+# draft-rich region only after the reasoning prose). 0 = give-up is final.
+burst                = 128
+
 [ffn]
 # SwiGLU/GeGLU sparsity probe — instrumentation only, counts skippable
 # intermediate rows per threshold; no skipping (~1 µs/layer/token when on).

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -875,9 +875,18 @@ ImpError imp_decode_step(ImpContext ctx, const ImpGenerateParams* params, int32_
             // Still have unconsumed tokens from a previous multi-token step
             *out_token = req->output_tokens[ctx->consumed_output++];
         } else {
-            // Need a new engine step
+            // Need a new engine step. A step may legitimately yield ZERO new
+            // tokens when it only launches an async graph-loop burst (n-gram
+            // speculation miss path) — the burst's tokens arrive on the next
+            // step's drain. Retry a bounded number of times; a persistent
+            // zero-token stream is still an internal error.
             size_t prev_output_size = req->output_tokens.size();
-            (void)ctx->engine->step();
+            for (int attempts = 0;
+                 attempts < 8 && req->output_tokens.size() == prev_output_size &&
+                 req->status == imp::RequestStatus::DECODING;
+                 ++attempts) {
+                (void)ctx->engine->step();
+            }
 
             if (req->output_tokens.size() > prev_output_size) {
                 ctx->consumed_output = prev_output_size;

--- a/src/compute/mmq_q8_imma.cu
+++ b/src/compute/mmq_q8_imma.cu
@@ -1306,14 +1306,17 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
 
 bool mmq_q8_imma_gemm(const void* w_q8_blocks, const __half* x_f16, __half* out_f16, int M, int N,
                       int K, cudaStream_t stream, float beta) {
-    if (M < 64 || N % 2 != 0 || K % kBK != 0) return false;
+    // M >= 2 (was >= 64): small-M callers (spec-decode verify chunks, short
+    // prompts) are exactly where the dequant->cuBLAS fallback hurts most; the
+    // tiles zero-fill the M-tail (same machinery as the MoE per-expert path).
+    if (M < 2 || N % 2 != 0 || K % kBK != 0) return false;
     if (beta != 0.0f && beta != 1.0f) return false;
     return gemm_common(w_q8_blocks, 0, x_f16, out_f16, M, N, K, stream, beta, nullptr, 0, 0, 1);
 }
 
 bool mmq_q4k_imma_gemm(const void* w_q4k_blocks, const __half* x_f16, __half* out_f16, int M,
                        int N, int K, cudaStream_t stream, float beta) {
-    if (M < 64 || N % 2 != 0 || K % 256 != 0) return false;
+    if (M < 2 || N % 2 != 0 || K % 256 != 0) return false;
     if (beta != 0.0f && beta != 1.0f) return false;
     return gemm_common(w_q4k_blocks, 1, x_f16, out_f16, M, N, K, stream, beta, nullptr, 0, 0, 1);
 }

--- a/src/compute/mmq_q8_imma.cu
+++ b/src/compute/mmq_q8_imma.cu
@@ -107,13 +107,21 @@ __device__ __forceinline__ void load_kstep(int tid, const int8_t* __restrict__ A
 // out = (or +=, BETA1) the α/β-scaled IMMA over [BM,kBN] tiles. Grouped MoE
 // form: gridDim.z = ne with device expert_offsets; dense passes offsets ==
 // nullptr (z extent 1).
-template <int BM, bool BETA1, bool WB /* weight beta term (Q4_K); false = pure alpha (Q8_0) */>
+// SPLITK (dense-only): gridDim.z = K-split index instead of expert. With a
+// single M-tile the grid is only N/kBN blocks — far too few to hide the
+// K-loop latency (the spec-decode verify bottleneck, issue #667). Each split
+// computes ks_per_split K-steps and stores its fp32 partial tile to
+// split_out[z][M][N]; mmq_splitk_finalize_kernel reduces the slices (fixed
+// order — bit-reproducible) and applies the beta/residual form.
+template <int BM, bool BETA1, bool WB /* weight beta term (Q4_K); false = pure alpha (Q8_0) */,
+          bool SPLITK = false>
 __global__ void __launch_bounds__(kThreads)
     mmq_imma_kernel(const int8_t* __restrict__ X_s8, const __half* __restrict__ x_scale,
                     const float* __restrict__ x_rowsum, const int8_t* __restrict__ W_s8,
                     const __half* __restrict__ w_sc, __half* __restrict__ out, int M, int N,
                     int K, const int32_t* __restrict__ expert_offsets, size_t w_stride,
-                    size_t wsc_stride) {
+                    size_t wsc_stride, float* __restrict__ split_out = nullptr,
+                    int ks_per_split = 0) {
     constexpr int kWM = (BM == 128) ? 4 : 2;  // warp grid
     constexpr int kWN = (BM == 128) ? 2 : 4;
     constexpr int kTileM = BM / kWM;       // 32 / 16
@@ -124,7 +132,7 @@ __global__ void __launch_bounds__(kThreads)
 
     int rows = M;
     size_t row_off = 0;
-    const int e = blockIdx.z;
+    const int e = SPLITK ? 0 : blockIdx.z;  // SPLITK reuses gridDim.z for the K-split
     if (expert_offsets != nullptr) {
         const int32_t o0 = __ldg(&expert_offsets[e]);
         const int32_t o1 = __ldg(&expert_offsets[e + 1]);
@@ -167,14 +175,22 @@ __global__ void __launch_bounds__(kThreads)
             acc[i][j][0] = acc[i][j][1] = acc[i][j][2] = acc[i][j][3] = 0.0f;
 
     const int ksteps = K / kBK;
+    int ks_begin = 0;
+    int ks_end = ksteps;
+    if (SPLITK) {
+        ks_begin = blockIdx.z * ks_per_split;
+        ks_end = min(ksteps, ks_begin + ks_per_split);
+        if (ks_begin >= ks_end)
+            return;
+    }
     load_kstep<BM, WB>(tid, A, Asc, Ars, B, Bsc, sA[0], sB[0], sAsc[0], sArs[0], sBsc[0],
-                       base_m, rows, K, subs, 0, n_rem);
+                       base_m, rows, K, subs, ks_begin * kBK, n_rem);
     cp_async_commit();
 
-    for (int ks = 0; ks < ksteps; ++ks) {
-        const int stage = ks & 1;
-        if (ks + 1 < ksteps) {
-            const int nstage = (ks + 1) & 1;
+    for (int ks = ks_begin; ks < ks_end; ++ks) {
+        const int stage = (ks - ks_begin) & 1;
+        if (ks + 1 < ks_end) {
+            const int nstage = (ks + 1 - ks_begin) & 1;
             load_kstep<BM, WB>(tid, A, Asc, Ars, B, Bsc, sA[nstage], sB[nstage], sAsc[nstage],
                                sArs[nstage], sBsc[nstage], base_m, rows, K, subs, (ks + 1) * kBK,
                                n_rem);
@@ -248,6 +264,31 @@ __global__ void __launch_bounds__(kThreads)
         __syncthreads();
     }
 
+    // SPLITK epilogue: store the fp32 partial tile to this split's slice;
+    // the finalize kernel reduces slices and applies beta/residual.
+    if (SPLITK) {
+        float* Cs = split_out + static_cast<size_t>(blockIdx.z) * (static_cast<size_t>(M) * N);
+#pragma unroll
+        for (int mf = 0; mf < kMF; ++mf) {
+            const int row_lo = base_m + warp_m * kTileM + mf * 16 + rl;
+            const int row_hi = row_lo + 8;
+#pragma unroll
+            for (int nf = 0; nf < kNF; ++nf) {
+                const int col = base_n + warp_n * kTileN + nf * 8 + cl * 2;
+                if (col + 1 >= N) continue;
+                if (row_lo < rows) {
+                    Cs[static_cast<size_t>(row_lo) * N + col] = acc[mf][nf][0];
+                    Cs[static_cast<size_t>(row_lo) * N + col + 1] = acc[mf][nf][1];
+                }
+                if (row_hi < rows) {
+                    Cs[static_cast<size_t>(row_hi) * N + col] = acc[mf][nf][2];
+                    Cs[static_cast<size_t>(row_hi) * N + col + 1] = acc[mf][nf][3];
+                }
+            }
+        }
+        return;
+    }
+
     // Epilogue: FP16 store, M-tail predicated (N is a multiple of kBN).
 #pragma unroll
     for (int mf = 0; mf < kMF; ++mf) {
@@ -269,6 +310,18 @@ __global__ void __launch_bounds__(kThreads)
             }
         }
     }
+}
+
+// Reduce the SPLITK partial slices (fixed order — bit-reproducible) and
+// apply the beta form: out = sum (beta 0) or out += sum (beta 1).
+__global__ void mmq_splitk_finalize_kernel(const float* __restrict__ split_out, int n_splits,
+                                           int total, __half* __restrict__ out, int beta1) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+    float v = 0.0f;
+    for (int s = 0; s < n_splits; ++s)
+        v += split_out[static_cast<size_t>(s) * total + idx];
+    out[idx] = beta1 ? __hadd(out[idx], __float2half(v)) : __float2half(v);
 }
 
 // -----------------------------------------------------------------------------
@@ -1180,6 +1233,26 @@ bool ensure_act(int M, int K, bool capturing) {
     return true;
 }
 
+// SPLITK partial-slice scratch (grow-only, freed in mmq_q8_imma_release_all).
+struct SplitKScratch {
+    float* buf = nullptr;
+    size_t cap = 0;
+};
+SplitKScratch g_splitk;
+
+bool ensure_splitk(size_t floats, bool capturing) {
+    if (g_splitk.buf && g_splitk.cap >= floats) return true;
+    if (capturing) return false;
+    if (g_splitk.buf) cudaFree(g_splitk.buf);
+    if (cudaMalloc(&g_splitk.buf, floats * sizeof(float)) != cudaSuccess) {
+        g_splitk.buf = nullptr;
+        g_splitk.cap = 0;
+        return false;
+    }
+    g_splitk.cap = floats;
+    return true;
+}
+
 void quantize_act(const __half* x, int M, int K, cudaStream_t stream) {
     // NO memoization: workspace buffers (moe gathered, layer activations) are
     // REUSED across layers with the same pointer — a (ptr, M, K) memo served
@@ -1285,6 +1358,34 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
     const auto& w = g_weights[w_blocks];
     const size_t w_stride = static_cast<size_t>(N) * K;
     const size_t wsc_stride = static_cast<size_t>(N) * (K / 32) * 2;
+
+    // Dense small-M split-K: with one M-tile the grid is N/kBN blocks (~20 on
+    // a 2.5k-wide weight) — far too few to hide the K-loop latency. The call
+    // costs ~35 µs regardless of N, which is the spec-decode verify
+    // bottleneck (issue #667). Split the K-steps across gridDim.z into fp32
+    // partial slices and reduce; the finalize kernel applies beta/residual.
+    if (d_offsets == nullptr && M <= 32) {
+        const int ksteps_total = K / kBK;
+        const int n_tiles = (N + kBN - 1) / kBN;
+        int S = 1;
+        while (S < 8 && n_tiles * S < 256 && ksteps_total / (S * 2) >= 2) S *= 2;
+        if (S > 1) {
+            const int ks_per_split = (ksteps_total + S - 1) / S;
+            const int used = (ksteps_total + ks_per_split - 1) / ks_per_split;
+            const size_t slice = static_cast<size_t>(M) * N;
+            if (used > 1 && ensure_splitk(slice * used, capturing)) {
+                dim3 sgrid(n_tiles, 1, used);
+                mmq_imma_kernel<32, false, false, true><<<sgrid, kThreads, 0, stream>>>(
+                    g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K,
+                    nullptr, w_stride, wsc_stride, g_splitk.buf, ks_per_split);
+                const int total = static_cast<int>(slice);
+                mmq_splitk_finalize_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
+                    g_splitk.buf, used, total, out_f16, beta == 1.0f ? 1 : 0);
+                return true;
+            }
+        }
+    }
+
     // plane path = Q8_0 only since the raw-read kernels: pure-alpha (WB=false)
     if (small_m) {
         mmq_imma_kernel<32, false, false><<<grid, kThreads, 0, stream>>>(
@@ -1349,6 +1450,11 @@ bool mmq_imma_moe_gemm(const void* w_blocks, int qkind, const __half* x_f16, __h
 
 void mmq_q8_imma_release_all() {
     std::lock_guard<std::mutex> lk(g_mtx);
+    if (g_splitk.buf) {
+        cudaFree(g_splitk.buf);
+        g_splitk.buf = nullptr;
+        g_splitk.cap = 0;
+    }
     for (auto& [_, w] : g_weights) {
         cudaFree(w.qs);
         cudaFree(w.sc);

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -26,6 +26,7 @@
 #include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <functional>
 #include <vector>
 #include <unordered_map>
 #include <utility>
@@ -107,6 +108,13 @@ public:
     // workspace — call only after all reads of the chunk's logits are done.
     void perplexity_nll_partial(const int32_t* d_tokens, int n_total, int chunk_start,
                                 int chunk_len, double* d_nll, cudaStream_t stream);
+
+    // Greedy verify for n-gram speculative decoding: applies the tier-aware
+    // LM head to hidden_[0..n_rows-1] (the verify chunk that forward_logits
+    // just ran) and writes argmax token ids to d_out[0..n_rows-1]. Same
+    // logits as production greedy sampling (incl. final softcap). Overwrites
+    // the logits_ workspace. Enqueues on `stream` only.
+    void greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream);
 
     // Sample tokens from pre-computed logits (for use after CUDA graph execution).
     std::vector<int32_t> sample_from_logits(const Tensor& logits, const InferenceState& state,
@@ -280,6 +288,14 @@ private:
     void* v_norm_ones_buf_ = nullptr;  // Gemma 4: ones buffer for V-norm (no learned weight)
     bool initialized_ = false;
     int max_tokens_ = 0;
+
+    // Shared eval-side LM-head driver: applies the tier-aware LM head to
+    // hidden_[0..n_rows) in batches of max_logit_tokens_ and calls
+    // consume(logits_view, row0, csz) after each batch's logits (softcap
+    // already applied) land in logits_. Used by perplexity_nll_partial and
+    // greedy_argmax_all.
+    void for_each_lm_head_batch_(int n_rows, cudaStream_t stream,
+                                 const std::function<void(const Tensor&, int, int)>& consume);
 
     // LoRA (issue #522)
     const LoraAdapter* lora_ = nullptr;

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -297,6 +297,11 @@ private:
     void for_each_lm_head_batch_(int n_rows, cudaStream_t stream,
                                  const std::function<void(const Tensor&, int, int)>& consume);
 
+    // Spec-decode verify argmax partials (lazy, grows only; freed in
+    // free_buffers).
+    void* verify_argmax_scratch_ = nullptr;
+    size_t verify_argmax_scratch_sz_ = 0;
+
     // LoRA (issue #522)
     const LoraAdapter* lora_ = nullptr;
     void* lora_scratch_ = nullptr;  // fp32[max_rank] + fp16[max_tokens*max_rank]

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -312,8 +312,12 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         // docs/audit/prefill_gap_2026_06_07.md §4.1). Covers beta=0 and the
         // beta=1 residual-add form; declines (shape / capture-guard) fall
         // through to the dequant fallback below.
+        // M >= 2 (was >= 64): below 64 the dequant tax dominates even harder —
+        // an M=9 spec-decode verify chunk re-dequantized the ENTIRE model every
+        // step (56% of GPU time, issue #667). The IMMA kernel zero-fills M-tail
+        // rows, and the MoE path already runs it at per-expert M≈32.
         const bool imma_eligible = input.qtype == QType::F16 && output.qtype == QType::F16 &&
-                                   M >= 64 && input.stride[0] == h.shape[1] &&
+                                   M >= 2 && input.stride[0] == h.shape[1] &&
                                    output.stride[0] == h.shape[0];
         if (ctx.q8_imma_enabled && h.source_qtype == QType::Q8_0 && imma_eligible) {
             if (mmq_q8_imma_gemm(h.source_data, reinterpret_cast<const __half*>(input.data),

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -29,6 +29,7 @@
 #include "quant/nvfp4_quant.h"
 
 #include <cuda_runtime.h>
+#include <cfloat>
 #include <cmath>
 #include <vector>
 
@@ -89,14 +90,19 @@ __global__ void perplexity_nll_kernel(const float* __restrict__ logits,  // [csz
     }
 }
 
-void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total, int chunk_start,
-                                           int chunk_len, double* d_nll, cudaStream_t stream) {
-    if (!initialized_ || chunk_len <= 0 || n_total < 2 || !d_tokens || !d_nll) {
+// Shared eval-side LM-head driver (perplexity + spec-decode greedy verify):
+// applies the tier-aware LM head to hidden_[0..n_rows) in batches of
+// max_logit_tokens_, then hands each batch's logits_ view (softcap already
+// applied — production parity) to `consume`.
+void GraphExecutor::for_each_lm_head_batch_(int n_rows, cudaStream_t stream,
+                                            const std::function<void(const Tensor&, int, int)>& consume) {
+    if (!initialized_ || n_rows <= 0) {
         return;
     }
     const auto& cfg = model_->config();
     const int V = cfg.vocab_size;
     const int mb = max_logit_tokens_ > 0 ? max_logit_tokens_ : 1;
+    const int chunk_len = n_rows;
 
     GemmContext ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config());
 
@@ -177,9 +183,67 @@ void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total,
                 static_cast<float*>(lg.data), cfg.final_logit_softcap,
                 1.0f / cfg.final_logit_softcap, total);
         }
-        perplexity_nll_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), d_tokens,
-                                                        chunk_start + c, n_total, V, d_nll);
+        consume(lg, c, csz);
     }
+}
+
+void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total, int chunk_start,
+                                           int chunk_len, double* d_nll, cudaStream_t stream) {
+    if (!initialized_ || chunk_len <= 0 || n_total < 2 || !d_tokens || !d_nll) {
+        return;
+    }
+    const int V = model_->config().vocab_size;
+    for_each_lm_head_batch_(chunk_len, stream, [&](const Tensor& lg, int row0, int csz) {
+        perplexity_nll_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), d_tokens,
+                                                       chunk_start + row0, n_total, V, d_nll);
+    });
+}
+
+// One block per row: fp32 argmax → token id. Tie-break = smallest index,
+// matching the production greedy argmax kernels in sampling.cu — spec-decode
+// verify must agree with what plain greedy decode would have sampled.
+__global__ void rowwise_argmax_kernel(const float* __restrict__ logits, int V,
+                                      int32_t* __restrict__ out) {
+    const float* lg = logits + static_cast<int64_t>(blockIdx.x) * V;
+    const int tid = threadIdx.x;
+    float best = -FLT_MAX;
+    int best_idx = 0;
+    for (int i = tid; i < V; i += blockDim.x) {
+        float v = lg[i];
+        if (v > best || (v == best && i < best_idx)) {
+            best = v;
+            best_idx = i;
+        }
+    }
+    __shared__ float s_val[256];
+    __shared__ int s_idx[256];
+    s_val[tid] = best;
+    s_idx[tid] = best_idx;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            if (s_val[tid + s] > s_val[tid] ||
+                (s_val[tid + s] == s_val[tid] && s_idx[tid + s] < s_idx[tid])) {
+                s_val[tid] = s_val[tid + s];
+                s_idx[tid] = s_idx[tid + s];
+            }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        out[blockIdx.x] = s_idx[0];
+    }
+}
+
+void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream) {
+    if (!initialized_ || n_rows <= 0 || d_out == nullptr) {
+        return;
+    }
+    const int V = model_->config().vocab_size;
+    for_each_lm_head_batch_(n_rows, stream, [&](const Tensor& lg, int row0, int csz) {
+        rowwise_argmax_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), V,
+                                                       d_out + row0);
+    });
 }
 
 double GraphExecutor::perplexity_nll(const int32_t* tokens, int n, cudaStream_t stream) {

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -199,16 +199,26 @@ void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total,
     });
 }
 
-// One block per row: fp32 argmax → token id. Tie-break = smallest index,
-// matching the production greedy argmax kernels in sampling.cu — spec-decode
-// verify must agree with what plain greedy decode would have sampled.
-__global__ void rowwise_argmax_kernel(const float* __restrict__ logits, int V,
-                                      int32_t* __restrict__ out) {
-    const float* lg = logits + static_cast<int64_t>(blockIdx.x) * V;
+// Two-phase row-wise argmax. A single block per row reads ~600 KB of fp32
+// logits sequentially (~145 µs/row at vocab 151k); phase 1 splits each row
+// across kArgmaxSplits blocks, phase 2 reduces the partials. Tie-break =
+// smallest index, matching the production greedy argmax in sampling.cu —
+// spec-decode verify must agree with what plain greedy decode would sample.
+constexpr int kArgmaxSplits = 16;
+
+__global__ void rowwise_argmax_partial_kernel(const float* __restrict__ logits, int V,
+                                              float* __restrict__ pvals,
+                                              int* __restrict__ pidxs) {
+    const int row = blockIdx.x;
+    const int split = blockIdx.y;
+    const int chunk = (V + kArgmaxSplits - 1) / kArgmaxSplits;
+    const int begin = split * chunk;
+    const int end = min(V, begin + chunk);
+    const float* lg = logits + static_cast<int64_t>(row) * V;
     const int tid = threadIdx.x;
     float best = -FLT_MAX;
     int best_idx = 0;
-    for (int i = tid; i < V; i += blockDim.x) {
+    for (int i = begin + tid; i < end; i += blockDim.x) {
         float v = lg[i];
         if (v > best || (v == best && i < best_idx)) {
             best = v;
@@ -231,8 +241,29 @@ __global__ void rowwise_argmax_kernel(const float* __restrict__ logits, int V,
         __syncthreads();
     }
     if (tid == 0) {
-        out[blockIdx.x] = s_idx[0];
+        pvals[row * kArgmaxSplits + split] = s_val[0];
+        pidxs[row * kArgmaxSplits + split] = s_idx[0];
     }
+}
+
+// One thread per row: 16 partials is a trivial sequential reduce.
+__global__ void rowwise_argmax_reduce_kernel(const float* __restrict__ pvals,
+                                             const int* __restrict__ pidxs, int n_rows,
+                                             int32_t* __restrict__ out) {
+    const int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= n_rows)
+        return;
+    float best = -FLT_MAX;
+    int best_idx = 0;
+    for (int s = 0; s < kArgmaxSplits; ++s) {
+        const float v = pvals[row * kArgmaxSplits + s];
+        const int i = pidxs[row * kArgmaxSplits + s];
+        if (v > best || (v == best && i < best_idx)) {
+            best = v;
+            best_idx = i;
+        }
+    }
+    out[row] = best_idx;
 }
 
 void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream) {
@@ -240,9 +271,26 @@ void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t s
         return;
     }
     const int V = model_->config().vocab_size;
+    const int mb = max_logit_tokens_ > 0 ? max_logit_tokens_ : 1;
+    const size_t scratch_needed =
+        static_cast<size_t>(mb) * kArgmaxSplits * (sizeof(float) + sizeof(int));
+    if (verify_argmax_scratch_sz_ < scratch_needed) {
+        if (verify_argmax_scratch_)
+            IMP_CUDA_CHECK_LOG(cudaFree(verify_argmax_scratch_));
+        if (cudaMalloc(&verify_argmax_scratch_, scratch_needed) != cudaSuccess) {
+            verify_argmax_scratch_ = nullptr;
+            verify_argmax_scratch_sz_ = 0;
+            return;
+        }
+        verify_argmax_scratch_sz_ = scratch_needed;
+    }
+    float* pvals = static_cast<float*>(verify_argmax_scratch_);
+    int* pidxs = reinterpret_cast<int*>(pvals + static_cast<size_t>(mb) * kArgmaxSplits);
     for_each_lm_head_batch_(n_rows, stream, [&](const Tensor& lg, int row0, int csz) {
-        rowwise_argmax_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), V,
-                                                       d_out + row0);
+        dim3 grid(csz, kArgmaxSplits);
+        rowwise_argmax_partial_kernel<<<grid, 256, 0, stream>>>(
+            static_cast<const float*>(lg.data), V, pvals, pidxs);
+        rowwise_argmax_reduce_kernel<<<1, 32, 0, stream>>>(pvals, pidxs, csz, d_out + row0);
     });
 }
 

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -913,6 +913,11 @@ void GraphExecutor::free_buffers() {
         lora_scratch_ = nullptr;
         lora_scratch_sz_ = 0;
     }
+    if (verify_argmax_scratch_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(verify_argmax_scratch_));
+        verify_argmax_scratch_ = nullptr;
+        verify_argmax_scratch_sz_ = 0;
+    }
     // Helper: free through VRAMAllocator if pointer was tracked, else cudaFree.
     auto vfree = [this](void*& p) {
         if (p) {

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -247,6 +247,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("speculative.max_match", cfg.speculative.max_match);
     I("speculative.give_up_after", cfg.speculative.give_up_after);
     I("speculative.burst", cfg.speculative.burst);
+    I("speculative.miss_burst", cfg.speculative.miss_burst);
 
     if (!matched)
         IMP_LOG_WARN("imp.conf: unknown key '%s' (value '%s') — ignoring", dotted_key.c_str(), val.c_str());

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -240,6 +240,14 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("ffn.sparsity_probe", cfg.ffn.sparsity_probe);
     F("ffn.sparsity_threshold", cfg.ffn.sparsity_threshold);
 
+    // [speculative]
+    B("speculative.ngram", cfg.speculative.ngram);
+    I("speculative.k", cfg.speculative.k);
+    I("speculative.min_match", cfg.speculative.min_match);
+    I("speculative.max_match", cfg.speculative.max_match);
+    I("speculative.give_up_after", cfg.speculative.give_up_after);
+    I("speculative.burst", cfg.speculative.burst);
+
     if (!matched)
         IMP_LOG_WARN("imp.conf: unknown key '%s' (value '%s') — ignoring", dotted_key.c_str(), val.c_str());
 }
@@ -376,6 +384,14 @@ void seed_from_env(RuntimeConfig& cfg) {
     // ffn.sparsity_threshold — IMP_FFN_SPARSITY_THRESHOLD: float.
     if (const char* e = std::getenv("IMP_FFN_SPARSITY_THRESHOLD"))
         cfg.ffn.sparsity_threshold = parse_float(e, cfg.ffn.sparsity_threshold);
+
+    // speculative.ngram — IMP_SPEC_NGRAM: '1' enables.
+    if (const char* e = std::getenv("IMP_SPEC_NGRAM"))
+        cfg.speculative.ngram = (e[0] == '1');
+
+    // speculative.k — IMP_SPEC_K: int.
+    if (const char* e = std::getenv("IMP_SPEC_K"))
+        cfg.speculative.k = parse_int(e, cfg.speculative.k);
 
     // attention.fp8_prefill — IMP_NO_FP8_PREFILL: '1' sets fp8_prefill="never".
     if (const char* e = std::getenv("IMP_NO_FP8_PREFILL"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -406,7 +406,7 @@ struct RuntimeConfig {
     // graph loop), which costs on draft-miss-heavy workloads.
     struct Speculative {
         bool ngram = false;  // enable prompt-lookup speculation (batch-1, greedy)
-        int k = 8;           // draft tokens per verify step
+        int k = 16;          // draft tokens per verify step (verify cost is ~flat in k)
         int min_match = 3;   // shortest accepted suffix n-gram match
         int max_match = 8;   // longest suffix extension searched
         // After this many consecutive draft misses the request gives up on
@@ -419,6 +419,11 @@ struct RuntimeConfig {
         // for a couple of steps (think models produce their draft-rich
         // region only after the reasoning prose). 0 = give-up is final.
         int burst = 128;
+        // On a draft miss the request falls back to the async loop for this
+        // many tokens (cheap rearm, no graph recapture) instead of paying
+        // the ~2x eager per-token tax until the next draft shows up.
+        // 0 = stay eager between drafts (legacy behavior).
+        int miss_burst = 8;
     } speculative;
 
     struct FFN {

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -397,6 +397,30 @@ struct RuntimeConfig {
         std::string mmproj;
     } paths;
 
+    // n-gram (prompt-lookup) speculative decoding. Drafts come from suffix
+    // matches against the request's own prompt+output tokens — no draft
+    // model, no MTP head. Greedy-only Phase 1: the verify step replays the
+    // draft as a teacher-forced continuation chunk and accepts the longest
+    // argmax-matching prefix, so output is token-identical to plain greedy
+    // decode. Opt-in: the verify loop runs eager (no async conditional
+    // graph loop), which costs on draft-miss-heavy workloads.
+    struct Speculative {
+        bool ngram = false;  // enable prompt-lookup speculation (batch-1, greedy)
+        int k = 8;           // draft tokens per verify step
+        int min_match = 3;   // shortest accepted suffix n-gram match
+        int max_match = 8;   // longest suffix extension searched
+        // After this many consecutive draft misses the request gives up on
+        // speculation and re-enters the async conditional graph loop (the
+        // eager per-token path costs ~2x vs the loop — a draft-poor context
+        // must not pay that for the whole generation). 0 = never give up.
+        int give_up_after = 64;
+        // Burst-hybrid: while given up, the async loop runs in bursts of
+        // this many tokens; after each burst the request re-probes drafts
+        // for a couple of steps (think models produce their draft-rich
+        // region only after the reasoning prose). 0 = give-up is final.
+        int burst = 128;
+    } speculative;
+
     struct FFN {
         // SwiGLU/GeGLU sparsity probe (instrumentation-only — no skipping).
         // When enabled, every dense-FFN decode step runs a reduce kernel

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -494,9 +494,20 @@ __global__ void post_decode_step_kernel(
     int32_t* __restrict__ d_penalty_ring,  // may be null if no penalties
     int penalty_prefix_len,
     int* __restrict__ d_penalty_count,  // [1] total penalty token count
+    const int* __restrict__ d_step_limit,  // [1] per-launch cap (0 = max_steps)
     cudaGraphConditionalHandle handle) {
     int step = *d_step_counter;
     int32_t token = *d_token_id;
+
+    // Per-launch step cap: read from device memory so rearm() can bound a
+    // burst without recapturing the graph. max_steps stays the hard capacity
+    // ceiling (ring buffer size).
+    int eff_max = max_steps;
+    if (d_step_limit) {
+        const int lim = *d_step_limit;
+        if (lim > 0 && lim < eff_max)
+            eff_max = lim;
+    }
 
     // Track think state on device. Active whenever a </think> id is known
     // (think_end_id >= 0), independent of the budget — it drives EOS/stop
@@ -548,7 +559,7 @@ __global__ void post_decode_step_kernel(
     bool in_think = (track_think && d_in_think && *d_in_think);
     bool grace = (think_grace_tokens > 0 && d_think_exit_step && *d_think_exit_step >= 0 &&
                   (step - *d_think_exit_step) < think_grace_tokens);
-    bool should_stop = (step + 1 >= max_steps);
+    bool should_stop = (step + 1 >= eff_max);
     if (!in_think && !grace && !ignore_eos) {
         if (token == eos_id)
             should_stop = true;
@@ -568,8 +579,8 @@ __global__ void post_decode_step_kernel(
     if (should_stop) {
         if (d_graph_diag_enabled) {
             int stop_reason = 0;
-            if (step + 1 >= max_steps)
-                stop_reason = 1;  // max_steps
+            if (step + 1 >= eff_max)
+                stop_reason = 1;  // max_steps / step_limit
             else if (!in_think && !grace && !ignore_eos) {
                 if (token == eos_id)
                     stop_reason = 2;  // eos
@@ -620,6 +631,9 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
     if (err != cudaSuccess)
         goto fail;
     err = cudaMalloc(&d_step_counter_, sizeof(int));
+    if (err != cudaSuccess)
+        goto fail;
+    err = cudaMalloc(&d_step_limit_, sizeof(int));
     if (err != cudaSuccess)
         goto fail;
 
@@ -749,6 +763,12 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
             IMP_LOG_ERROR("ConditionalRunner: step_counter init failed: %s", cudaGetErrorString(err));
             goto fail;
         }
+        err = cudaMemcpyAsync(d_step_limit_, &config_.step_limit, sizeof(int),
+                              cudaMemcpyHostToDevice, stream);
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("ConditionalRunner: step_limit init failed: %s", cudaGetErrorString(err));
+            goto fail;
+        }
     }
 
     // ---- Build InferenceState for graph body (uses our device pointers) ----
@@ -859,7 +879,8 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                                                      config_.think_end_id, config_.think_grace_tokens,
                                                      d_think_count_, d_in_think_, d_think_exit_step_,
                                                      config_.ignore_eos ? 1 : 0, d_penalty_ring_,
-                                                     penalty_prefix_len_, d_penalty_count_, handle_);
+                                                     penalty_prefix_len_, d_penalty_count_,
+                                                     d_step_limit_, handle_);
 
         // 5c. End capture
         cudaGraph_t captured_body = nullptr;
@@ -925,6 +946,45 @@ bool CudaGraphConditionalRunner::launch(cudaStream_t stream) {
     return true;
 }
 
+bool CudaGraphConditionalRunner::rearm(int32_t first_token, int position, int context_len,
+                                       int step_limit, bool in_think, cudaStream_t stream) {
+    if (!exec_ || launched_)
+        return false;
+    // The captured graph sized its attention workspace for
+    // initial_context_len + max_steps tokens; never replay past that.
+    const int steps_this_launch = (step_limit > 0) ? step_limit : config_.max_steps;
+    if (context_len + steps_this_launch > captured_context_ceiling())
+        return false;
+
+    auto up = [&](void* dst, const void* src, size_t n, const char* what) {
+        cudaError_t err = cudaMemcpyAsync(dst, src, n, cudaMemcpyHostToDevice, stream);
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("ConditionalRunner: rearm %s upload failed: %s", what,
+                          cudaGetErrorString(err));
+            return false;
+        }
+        return true;
+    };
+    const int zero = 0;
+    const int neg_one = -1;
+    const int think = in_think ? 1 : 0;
+    if (!up(d_token_id_, &first_token, sizeof(int32_t), "token") ||
+        !up(d_position_, &position, sizeof(int), "position") ||
+        !up(d_context_len_, &context_len, sizeof(int), "context_len") ||
+        !up(d_step_counter_, &zero, sizeof(int), "step_counter") ||
+        !up(d_step_limit_, &step_limit, sizeof(int), "step_limit"))
+        return false;
+    if (d_in_think_) {
+        if (!up(d_in_think_, &think, sizeof(int), "in_think") ||
+            !up(d_think_count_, &zero, sizeof(int), "think_count") ||
+            !up(d_think_exit_step_, &neg_one, sizeof(int), "think_exit"))
+            return false;
+    }
+    *h_step_counter_ = 0;
+    last_read_step_ = 0;
+    return true;
+}
+
 std::vector<int32_t> CudaGraphConditionalRunner::wait_and_get_tokens(cudaStream_t stream) {
     if (!launched_)
         return {};
@@ -982,6 +1042,10 @@ void CudaGraphConditionalRunner::cleanup() {
     if (d_position_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_position_));
         d_position_ = nullptr;
+    }
+    if (d_step_limit_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_step_limit_));
+        d_step_limit_ = nullptr;
     }
     if (d_context_len_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_context_len_));

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -145,6 +145,12 @@ public:
         // 0 = no think tracking in the loop (set >0 whenever think_end_id >= 0).
         int think_grace_tokens = 0;
         bool ignore_eos = false;        // don't stop on EOS/stop tokens (benchmark mode)
+        // Per-launch step cap read from device memory (0 = unbounded, i.e.
+        // max_steps). Unlike max_steps it is NOT baked into the captured
+        // graph: rearm() can change it between launches, which makes bounded
+        // "burst" launches cheap (no recapture). max_steps stays the capacity
+        // ceiling (ring buffer size, max_context_len).
+        int step_limit = 0;
         // Penalty parameters (applied to logits before sampling each iteration)
         float repetition_penalty = 1.0f;
         float frequency_penalty = 0.0f;
@@ -165,6 +171,22 @@ public:
 
     // Launch the graph. Returns immediately.
     bool launch(cudaStream_t stream);
+
+    // Re-seed device state for another bounded launch WITHOUT recapturing the
+    // graph (the expensive part of setup). first_token is forwarded at
+    // `position` with context length `context_len` (physical values, no +1
+    // applied inside). step_limit bounds this launch (0 = max_steps). Returns
+    // false when no graph is built, a launch is still in flight, or
+    // context_len would exceed the captured ceiling — caller falls back to a
+    // full setup().
+    bool rearm(int32_t first_token, int position, int context_len, int step_limit, bool in_think,
+               cudaStream_t stream);
+
+    // Context ceiling baked into the captured graph (attention workspace
+    // sizing): initial_context_len + max_steps at setup time.
+    int captured_context_ceiling() const {
+        return config_.initial_context_len + config_.max_steps;
+    }
 
     // Synchronize and return all generated tokens.
     std::vector<int32_t> wait_and_get_tokens(cudaStream_t stream);
@@ -190,6 +212,7 @@ private:
     int* d_position_ = nullptr;      // [1] current position on device
     int* d_context_len_ = nullptr;   // [1] current context length on device
     int* d_step_counter_ = nullptr;  // [1] step counter on device
+    int* d_step_limit_ = nullptr;    // [1] per-launch step cap (0 = max_steps)
     int32_t* d_stop_ids_ = nullptr;  // [n_stop_ids] stop token IDs on device
 
     // Think budget tracking (device-side)

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -75,6 +75,8 @@ Engine::~Engine() {
         IMP_CUDA_CHECK_LOG(cudaFreeHost(h_sample_pinned_));
         h_sample_pinned_ = nullptr;
     }
+    log_spec_stats_();
+    free_spec_buffers_();
     if (prefill_pool_) {
         memory_manager_.vram_allocator().free(prefill_pool_);
         prefill_pool_ = nullptr;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -430,6 +430,38 @@ private:
     std::vector<MtpChainEntry> mtp_pending_chain_;
     std::vector<MtpAccuracy> mtp_chain_accept_;
 
+    // ── n-gram (prompt-lookup) speculative decoding ─────────────────
+    // Drafts come from suffix matches against the request's own context
+    // (runtime_config_.speculative); the verify step replays them as a
+    // teacher-forced continuation chunk and accepts the longest greedy-
+    // matching prefix. Implemented in engine_spec_ngram.cpp.
+    // Returns true when it handled this decode step (tokens emitted);
+    // false → caller falls through to the normal decode path.
+    bool step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream);
+    bool spec_ngram_gates_ok_(const Request& req) const;
+    void spec_maybe_rearm_(Request& req) const;
+    bool ensure_spec_buffers_(int chunk_cap, int max_blocks);
+    void free_spec_buffers_();
+    void log_spec_stats_() const;
+    // Device/pinned staging for the verify chunk (lazy-init, K+1 capacity).
+    int32_t* d_spec_tokens_ = nullptr;
+    int* d_spec_positions_ = nullptr;
+    int* d_spec_block_table_ = nullptr;
+    int* d_spec_context_len_ = nullptr;
+    int32_t* d_spec_argmax_ = nullptr;
+    int32_t* h_spec_argmax_ = nullptr;  // pinned, chunk_cap entries
+    int spec_chunk_cap_ = 0;
+    int spec_block_table_cap_ = 0;
+    // Session telemetry (logged when a request finishes).
+    struct SpecStats {
+        long long verify_steps = 0;  // verify forwards run
+        long long miss_steps = 0;    // decode steps with no usable draft
+        long long drafted = 0;       // draft tokens proposed
+        long long accepted = 0;      // draft tokens accepted
+        long long emitted = 0;       // tokens emitted by verify steps
+    };
+    SpecStats spec_stats_{};
+
     // ── Banned tokens (special/control tokens that must not be generated) ──
     std::vector<int32_t> banned_token_ids_;
 

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -302,6 +302,11 @@ private:
     int32_t* async_d_banned_tokens_ = nullptr;
     std::vector<int32_t> async_pending_tokens_;
     int async_pending_cursor_ = 0;
+    // Burst-hybrid speculation: after a bounded (step_limit) burst drains,
+    // the runner stays "parked" with its captured graph + block-table buffer
+    // so the next burst of the SAME request can rearm instead of recapture.
+    int async_parked_req_id_ = -1;
+    int async_bt_capacity_ = 0;  // block-table slots baked into the graph
 
     // Pipelined constrained decode (json_mode / json_schema, single sequence).
     // Constrained requests can't run the conditional graph loop (the grammar
@@ -439,6 +444,8 @@ private:
     // false → caller falls through to the normal decode path.
     bool step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream);
     bool spec_ngram_gates_ok_(const Request& req) const;
+    bool spec_burst_launch_ok_(const Request& req) const;
+    int spec_effective_miss_burst_(const Request& req) const;
     void spec_maybe_rearm_(Request& req) const;
     bool ensure_spec_buffers_(int chunk_cap, int max_blocks);
     void free_spec_buffers_();
@@ -601,7 +608,8 @@ private:
 
     std::vector<int32_t> try_graph_loop_decode(std::shared_ptr<Request> req, int32_t first_token,
                                                cudaStream_t stream);
-    bool try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t first_token, cudaStream_t stream);
+    bool try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t first_token,
+                                     cudaStream_t stream, int step_limit = 0);
 };
 
 }  // namespace imp

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -25,6 +25,13 @@ int Engine::prepare_graph_loop(std::shared_ptr<Request>& req) {
     if (remaining <= 0)
         return 0;
 
+    // Burst-hybrid n-gram speculation: a given-up request runs the loop in
+    // bounded bursts so the host can re-probe for drafts in between (see
+    // Engine::spec_maybe_rearm_).
+    if (runtime_config_.speculative.ngram && req->spec_ngram_given_up &&
+        runtime_config_.speculative.burst > 0)
+        remaining = std::min(remaining, runtime_config_.speculative.burst);
+
     constexpr int kMaxLayersForConditionalGraph = 128;
     if (model_->config().n_layers > kMaxLayersForConditionalGraph)
         return 0;

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -25,13 +25,6 @@ int Engine::prepare_graph_loop(std::shared_ptr<Request>& req) {
     if (remaining <= 0)
         return 0;
 
-    // Burst-hybrid n-gram speculation: a given-up request runs the loop in
-    // bounded bursts so the host can re-probe for drafts in between (see
-    // Engine::spec_maybe_rearm_).
-    if (runtime_config_.speculative.ngram && req->spec_ngram_given_up &&
-        runtime_config_.speculative.burst > 0)
-        remaining = std::min(remaining, runtime_config_.speculative.burst);
-
     constexpr int kMaxLayersForConditionalGraph = 128;
     if (model_->config().n_layers > kMaxLayersForConditionalGraph)
         return 0;
@@ -175,10 +168,49 @@ std::vector<int32_t> Engine::try_graph_loop_decode(std::shared_ptr<Request> req,
 }
 
 bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t first_token,
-                                         cudaStream_t stream) {
+                                         cudaStream_t stream, int step_limit) {
     int remaining = prepare_graph_loop(req);
     if (remaining <= 0)
         return false;
+
+    // Fast relaunch: a parked runner from a previous burst of the SAME
+    // request keeps its captured graph — reseed device state instead of
+    // recapturing (the burst-hybrid n-gram speculation path relaunches every
+    // few tokens; a full setup costs ~10-20 ms per launch).
+    if (async_graph_runner_.is_setup() && async_parked_req_id_ >= 0) {
+        const auto& bt = kv_manager_->block_table(req->id);
+        const int ctx = req->context_len();
+        if (async_parked_req_id_ == req->id && async_d_block_tables_ != nullptr &&
+            static_cast<int>(bt.size()) <= async_bt_capacity_) {
+            // Verify steps may have appended KV blocks since the park —
+            // refresh the table contents (pointer/capacity baked in graph).
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(async_d_block_tables_, bt.data(),
+                                               bt.size() * sizeof(int), cudaMemcpyHostToDevice,
+                                               stream));
+            if (async_graph_runner_.rearm(first_token, /*position=*/ctx - 1, /*context_len=*/ctx,
+                                          step_limit, req->in_think_block, stream) &&
+                async_graph_runner_.launch(stream)) {
+                async_graph_req_ = req;
+                async_pending_tokens_.clear();
+                async_pending_cursor_ = 0;
+                IMP_LOG_DEBUG("AsyncGraphLoop: rearmed for %d-step burst (ctx=%d)", step_limit,
+                              ctx);
+                return true;
+            }
+        }
+        // Rearm impossible (table outgrew capacity / context past ceiling /
+        // upload failure) — tear down and rebuild below.
+        async_graph_runner_.cleanup();
+        if (async_d_block_tables_) {
+            IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_));
+            async_d_block_tables_ = nullptr;
+        }
+        if (async_d_banned_tokens_) {
+            IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
+            async_d_banned_tokens_ = nullptr;
+        }
+        async_parked_req_id_ = -1;
+    }
 
     const auto& full_bt = kv_manager_->block_table(req->id);
     int max_blocks_per_seq = static_cast<int>(full_bt.size());
@@ -215,6 +247,7 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     }
 
     auto gcfg = build_graph_config(*req, remaining);
+    gcfg.step_limit = step_limit;
 
     if (!async_graph_runner_.setup(executor_.get(), state_template, first_token, gcfg, stream)) {
         if (d_banned)
@@ -233,6 +266,8 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     async_graph_req_ = req;
     async_d_block_tables_ = d_bt;
     async_d_banned_tokens_ = d_banned;
+    async_bt_capacity_ = max_blocks_per_seq;
+    async_parked_req_id_ = -1;
     IMP_LOG_DEBUG("AsyncGraphLoop: launched with %d banned tokens", state_template.n_d_banned_tokens);
     async_pending_tokens_.clear();
     async_pending_cursor_ = 0;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -117,14 +117,24 @@ int Engine::step_async_graph_resume() {
 
         auto saved_req = async_graph_req_;
 
-        async_graph_runner_.cleanup();
-        if (async_d_block_tables_) {
-            IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_));
-            async_d_block_tables_ = nullptr;
-        }
-        if (async_d_banned_tokens_) {
-            IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
-            async_d_banned_tokens_ = nullptr;
+        // Burst-hybrid speculation: keep the captured graph + block-table
+        // buffer parked so the next burst of this request rearms instead of
+        // recapturing (~10-20 ms per capture). Fully torn down on request
+        // finish or when a different request launches.
+        const bool park = runtime_config_.speculative.ngram && !generation_done;
+        if (park) {
+            async_parked_req_id_ = saved_req->id;
+        } else {
+            async_graph_runner_.cleanup();
+            if (async_d_block_tables_) {
+                IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_));
+                async_d_block_tables_ = nullptr;
+            }
+            if (async_d_banned_tokens_) {
+                IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
+                async_d_banned_tokens_ = nullptr;
+            }
+            async_parked_req_id_ = -1;
         }
         async_graph_req_ = nullptr;
         async_pending_tokens_.clear();
@@ -849,6 +859,16 @@ void Engine::step_decode(cudaStream_t dec_stream) {
         if (spec_ngram_gates_ok_(*decode_batch[0])) {
             if (step_spec_verify_(decode_batch[0], dec_stream))
                 return;
+        } else if (decode_batch[0]->spec_ngram_given_up &&
+                   spec_burst_launch_ok_(*decode_batch[0])) {
+            // Given-up request: hand it straight to the loop (no eager probe
+            // step). Doomed = acceptance verdict final → run unbounded;
+            // otherwise bounded so spec_maybe_rearm_ can re-probe later.
+            auto& sreq = decode_batch[0];
+            const int lim =
+                sreq->spec_acceptance_doomed ? 0 : runtime_config_.speculative.burst;
+            if (try_launch_async_graph_loop(sreq, sreq->output_tokens.back(), dec_stream, lim))
+                return;
         } else {
             // One-time diagnosis: say WHY speculation is inactive (gates are
             // silent otherwise and a misconfigured request looks identical
@@ -1444,8 +1464,11 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
     // Try async graph loop after first decode step.
     // Think budget is now handled device-side in post_decode_step_kernel.
     if (decode_graph_pool_[0].is_ready() && valid_decode.size() == 1 && !offload_mgr_ &&
-        config_.use_cuda_graphs && !async_graph_runner_.is_setup() && !needs_logprobs && !needs_json_mode &&
-        !needs_schema_mode) {
+        config_.use_cuda_graphs &&
+        // A PARKED runner (burst-hybrid speculation) is setup but idle — it
+        // must be allowed back in here, or bursts only ever fire once.
+        (!async_graph_runner_.is_setup() || async_parked_req_id_ == valid_decode[0]->id) &&
+        !needs_logprobs && !needs_json_mode && !needs_schema_mode) {
         auto& dreq = valid_decode[0];
         // forward_decode_async only implements banned_tokens + rep/freq/presence
         // penalties device-side. Any sampling feature that requires host-side
@@ -1458,12 +1481,12 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
                                       // conditional-graph loop bypasses it. Stay eager when MTP is on
                                       // so accuracy measurement covers the whole generation.
                                       !mtp_spec_decode_enabled() &&
-                                      // n-gram speculation needs the host in the loop every step
-                                      // (draft match + verify dispatch) — the device-side loop
-                                      // would lock speculation out for the rest of the request.
-                                      // Exception: a request that gave up on speculation
-                                      // (draft-poor context) returns to the loop.
-                                      (!runtime_config_.speculative.ngram || dreq->spec_ngram_given_up);
+                                      // n-gram speculation: the loop runs in bounded bursts
+                                      // (miss_burst) so the host can probe for drafts between
+                                      // bursts; with miss_burst=0 the loop stays blocked while
+                                      // speculation is engaged (legacy eager-miss behavior).
+                                      (!runtime_config_.speculative.ngram || dreq->spec_ngram_given_up ||
+                                       runtime_config_.speculative.miss_burst > 0);
         // Text-fallback think tracking: when <think>/</think> are not single
         // control-token IDs (NVFP4 SafeTensors for Qwen3 / Qwen3.5 / Qwen3.6
         // ship them as added_tokens with special=False, leaving think_end_id_
@@ -1479,7 +1502,17 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
         if (async_compatible && !needs_eager_for_text_think && dreq->status == RequestStatus::DECODING &&
             !dreq->output_tokens.empty()) {
             int32_t last_token = dreq->output_tokens.back();
-            try_launch_async_graph_loop(dreq, last_token, dec_stream);
+            // Burst-hybrid speculation: bound the loop so the host can probe
+            // for drafts when it returns. Engaged requests use the short
+            // miss_burst; given-up requests the long re-probe burst (0 =
+            // run to completion).
+            int spec_limit = 0;
+            if (runtime_config_.speculative.ngram) {
+                spec_limit = dreq->spec_ngram_given_up ? runtime_config_.speculative.burst
+                                                       : spec_effective_miss_burst_(*dreq);
+                if (spec_limit < 0) spec_limit = 0;
+            }
+            try_launch_async_graph_loop(dreq, last_token, dec_stream, spec_limit);
         }
     }
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -840,6 +840,36 @@ void Engine::step_decode(cudaStream_t dec_stream) {
     auto& decode_batch = sched_decode_batch_;
     const int kv_bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
 
+    // n-gram (prompt-lookup) speculation: when a draft is available, the
+    // verify step replaces this decode step entirely (it allocates its own
+    // KV blocks and emits accepted tokens). Falls through to the normal
+    // path on a draft miss or when any gate fails.
+    if (runtime_config_.speculative.ngram && decode_batch.size() == 1) {
+        spec_maybe_rearm_(*decode_batch[0]);
+        if (spec_ngram_gates_ok_(*decode_batch[0])) {
+            if (step_spec_verify_(decode_batch[0], dec_stream))
+                return;
+        } else {
+            // One-time diagnosis: say WHY speculation is inactive (gates are
+            // silent otherwise and a misconfigured request looks identical
+            // to a draft-poor one).
+            static bool s_gate_logged = false;
+            if (!s_gate_logged && !decode_batch[0]->spec_ngram_given_up) {
+                s_gate_logged = true;
+                const auto& r = *decode_batch[0];
+                IMP_LOG_INFO(
+                    "spec-ngram: gates failed (temp=%.2f top_k=%d rep_pen=%.2f freq=%.2f "
+                    "pres=%.2f dry=%.2f mirostat=%d bias=%zu logprobs=%d json=%d schema=%d "
+                    "think_budget=%.2f ssm=%d gdn=%d mtp=%d chunked_prefill=%d)",
+                    r.temperature, r.top_k, r.repetition_penalty, r.frequency_penalty,
+                    r.presence_penalty, r.dry_multiplier, r.mirostat, r.logit_bias.size(),
+                    (int)r.logprobs, (int)r.json_mode, (int)!r.json_schema.empty(), r.think_budget,
+                    (int)(ssm_state_ != nullptr), (int)(gdn_state_ != nullptr),
+                    (int)mtp_spec_decode_enabled(), (int)supports_chunked_prefill_());
+            }
+        }
+    }
+
     // SSM/GDN: limit decode batch to 1 sequence
     if ((ssm_state_ || gdn_state_) && decode_batch.size() > 1) {
         decode_batch.resize(1);
@@ -1427,7 +1457,13 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
                                       // Phase 3.5 MTP telemetry hooks the per-step path; the async
                                       // conditional-graph loop bypasses it. Stay eager when MTP is on
                                       // so accuracy measurement covers the whole generation.
-                                      !mtp_spec_decode_enabled();
+                                      !mtp_spec_decode_enabled() &&
+                                      // n-gram speculation needs the host in the loop every step
+                                      // (draft match + verify dispatch) — the device-side loop
+                                      // would lock speculation out for the rest of the request.
+                                      // Exception: a request that gave up on speculation
+                                      // (draft-poor context) returns to the loop.
+                                      (!runtime_config_.speculative.ngram || dreq->spec_ngram_given_up);
         // Text-fallback think tracking: when <think>/</think> are not single
         // control-token IDs (NVFP4 SafeTensors for Qwen3 / Qwen3.5 / Qwen3.6
         // ship them as added_tokens with special=False, leaving think_end_id_

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -92,7 +92,8 @@ void Engine::free_spec_buffers_() {
 // lock them out exactly there.
 void Engine::spec_maybe_rearm_(Request& req) const {
     const auto& scfg = runtime_config_.speculative;
-    if (!req.spec_ngram_given_up || scfg.burst <= 0 || scfg.give_up_after <= 0)
+    if (!req.spec_ngram_given_up || req.spec_acceptance_doomed || scfg.burst <= 0 ||
+        scfg.give_up_after <= 0)
         return;
     if (static_cast<int>(req.output_tokens.size()) - req.spec_last_giveup_pos < scfg.burst)
         return;
@@ -101,6 +102,38 @@ void Engine::spec_maybe_rearm_(Request& req) const {
     req.spec_verifies = 0;
     req.spec_drafted = 0;
     req.spec_accepted = 0;
+}
+
+// Adaptive miss burst: consecutive draft misses double the burst length
+// (boundary overhead amortizes on draft-poor stretches), a hit resets it.
+// Capped at speculative.burst so re-probing never stops entirely.
+int Engine::spec_effective_miss_burst_(const Request& req) const {
+    const auto& scfg = runtime_config_.speculative;
+    int burst = scfg.miss_burst;
+    if (burst <= 0)
+        return 0;
+    // Cap growth at 4x: longer bursts overshoot draft-rich regions right
+    // after a transition (think prose -> code), losing more speculation
+    // upside than the saved boundary overhead is worth.
+    const int doublings = std::min(2, req.spec_consecutive_misses / 8);
+    burst <<= doublings;
+    const int cap = scfg.burst > 0 ? scfg.burst : 128;
+    return std::min(burst, cap);
+}
+
+// Whether a bounded async-loop burst may be launched directly from the spec
+// hook (mirrors the launch conditions in step_decode_process_outputs).
+bool Engine::spec_burst_launch_ok_(const Request& req) const {
+    if (!decode_graph_pool_[0].is_ready() || offload_mgr_ || !config_.use_cuda_graphs)
+        return false;
+    if (async_graph_runner_.is_setup() && async_parked_req_id_ != req.id)
+        return false;  // runner busy/parked for another request
+    // Text-fallback think tracking needs host-side per-token matching.
+    if (req.in_think_block && think_end_id_ < 0)
+        return false;
+    if (req.output_tokens.empty() || req.status != RequestStatus::DECODING)
+        return false;
+    return true;
 }
 
 bool Engine::spec_ngram_gates_ok_(const Request& req) const {
@@ -150,6 +183,14 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
                          "re-enabling async graph loop",
                          req->id, req->spec_consecutive_misses);
         }
+        // Skip the eager probe step entirely when a bounded loop burst can
+        // take over right away — the eager path costs ~2x per token and the
+        // burst forwards output.back() itself.
+        if (scfg.miss_burst > 0 && !req->spec_ngram_given_up && spec_burst_launch_ok_(*req) &&
+            try_launch_async_graph_loop(req, req->output_tokens.back(), stream,
+                                        spec_effective_miss_burst_(*req))) {
+            return true;  // step handled by the burst launch
+        }
         return false;  // no usable draft — normal decode step
     }
 
@@ -176,12 +217,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     const int chunk_len = K + 1;
     const int ctx_len = p0 + chunk_len;  // context including the full chunk
 
-    // Staging buffers first (no KV side effects yet on failure).
     const int blocks_needed = (ctx_len + kv_bs - 1) / kv_bs;
-    if (!ensure_spec_buffers_(std::max(chunk_len, scfg.k + 1), blocks_needed + 16)) {
-        spec_stats_.miss_steps++;
-        return false;
-    }
 
     // KV blocks for all chunk positions (mirror step_decode's append loop).
     // On allocation failure, trim back to the pre-step valid length (p0 KV
@@ -201,6 +237,14 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     }
     const auto& block_table = kv_manager_->block_table(req->id);
     const int n_blocks = static_cast<int>(block_table.size());
+
+    // Staging capacity follows the REAL table size — the async graph loop
+    // pre-allocates blocks for the whole remaining generation, so the table
+    // is usually much larger than this chunk needs.
+    if (!ensure_spec_buffers_(std::max(chunk_len, scfg.k + 1), n_blocks + 16)) {
+        spec_stats_.miss_steps++;
+        return false;
+    }
 
     // Upload chunk metadata.
     std::vector<int32_t> h_tokens;
@@ -303,12 +347,14 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     req->spec_drafted += K;
     req->spec_accepted += matched;
     const bool acceptance_poor =
-        req->spec_verifies >= 16 &&
+        req->spec_verifies >= 8 &&
         req->spec_accepted * 100 < req->spec_drafted * 15;
     if (!req->spec_ngram_given_up && scfg.give_up_after > 0 &&
         (acceptance_poor || req->spec_consecutive_misses >= scfg.give_up_after)) {
         req->spec_ngram_given_up = true;
         req->spec_last_giveup_pos = static_cast<int>(req->output_tokens.size());
+        if (acceptance_poor)
+            req->spec_acceptance_doomed = true;  // economics verdict is final
         IMP_LOG_INFO("spec-ngram: req %d gave up (%s: verifies=%d accepted=%lld/%lld misses=%d) — "
                      "re-enabling async graph loop",
                      req->id, acceptance_poor ? "acceptance-poor" : "draft-poor",

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -1,0 +1,324 @@
+// =============================================================================
+// engine_spec_ngram.cpp — n-gram (prompt-lookup) speculative decoding
+// =============================================================================
+//
+// Drafts come from suffix matches against the request's own prompt+output
+// tokens (ngram_draft) — no draft model, no MTP head. The verify step replays
+// [t0, d1..dK] as a teacher-forced continuation chunk through the standard
+// chunked-prefill forward (KV written in place), applies the tier-aware LM
+// head to every chunk position (executor greedy_argmax_all) and accepts the
+// longest prefix where the model's greedy token equals the draft. Rejected
+// draft KV entries are dropped via KVCacheManager::rollback — safe because
+// draft blocks were appended this step and are never content-hashed (prefix
+// hashing only covers prompt prefill blocks).
+//
+// Phase 1 scope (gated in spec_ngram_gates_ok_): batch-1, greedy sampling,
+// no penalties / logit_bias / DRY / mirostat, no logprobs, no json/schema
+// constraints, no think budget, no recurrent state (SSM/GDN cannot rewind),
+// chunked-prefill-capable archs only. The verify loop runs eager — the async
+// conditional graph loop stays off while speculation is enabled (the host
+// must see every token to draft the next step).
+// =============================================================================
+
+#include "compute/json_constrain.h"
+#include "core/logging.h"
+#include "exec/executor.h"
+#include "memory/kv_cache_manager.h"
+#include "runtime/engine.h"
+#include "runtime/ngram_draft.h"
+#include "runtime/request.h"
+
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <vector>
+
+namespace imp {
+
+bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
+    if (spec_chunk_cap_ >= chunk_cap && spec_block_table_cap_ >= max_blocks)
+        return true;
+    free_spec_buffers_();
+    bool ok = cudaMalloc(&d_spec_tokens_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
+              cudaMalloc(&d_spec_positions_, chunk_cap * sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&d_spec_block_table_, max_blocks * sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&d_spec_context_len_, sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&d_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
+              cudaMallocHost(&h_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess;
+    if (!ok) {
+        IMP_LOG_WARN("spec-ngram: buffer allocation failed — speculation disabled this step");
+        free_spec_buffers_();
+        return false;
+    }
+    spec_chunk_cap_ = chunk_cap;
+    spec_block_table_cap_ = max_blocks;
+    return true;
+}
+
+void Engine::log_spec_stats_() const {
+    if (spec_stats_.verify_steps + spec_stats_.miss_steps == 0)
+        return;
+    IMP_LOG_INFO("[spec-ngram] verify_steps=%lld miss_steps=%lld drafted=%lld accepted=%lld "
+                 "(%.1f%%) emitted=%lld (%.2f tok/verify)",
+                 spec_stats_.verify_steps, spec_stats_.miss_steps, spec_stats_.drafted,
+                 spec_stats_.accepted,
+                 spec_stats_.drafted ? 100.0 * spec_stats_.accepted / spec_stats_.drafted : 0.0,
+                 spec_stats_.emitted,
+                 spec_stats_.verify_steps
+                     ? static_cast<double>(spec_stats_.emitted) / spec_stats_.verify_steps
+                     : 0.0);
+}
+
+void Engine::free_spec_buffers_() {
+    if (d_spec_tokens_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_tokens_));
+    if (d_spec_positions_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_positions_));
+    if (d_spec_block_table_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_));
+    if (d_spec_context_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_context_len_));
+    if (d_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_argmax_));
+    if (h_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_argmax_));
+    d_spec_tokens_ = nullptr;
+    d_spec_positions_ = nullptr;
+    d_spec_block_table_ = nullptr;
+    d_spec_context_len_ = nullptr;
+    d_spec_argmax_ = nullptr;
+    h_spec_argmax_ = nullptr;
+    spec_chunk_cap_ = 0;
+    spec_block_table_cap_ = 0;
+}
+
+// Burst-hybrid re-arm: a given-up request whose async-loop burst
+// (speculative.burst tokens) has completed gets a short probe window — two
+// draft attempts and a fresh acceptance sample. Think models produce their
+// draft-rich region only after the reasoning prose; a sticky give-up would
+// lock them out exactly there.
+void Engine::spec_maybe_rearm_(Request& req) const {
+    const auto& scfg = runtime_config_.speculative;
+    if (!req.spec_ngram_given_up || scfg.burst <= 0 || scfg.give_up_after <= 0)
+        return;
+    if (static_cast<int>(req.output_tokens.size()) - req.spec_last_giveup_pos < scfg.burst)
+        return;
+    req.spec_ngram_given_up = false;
+    req.spec_consecutive_misses = std::max(0, scfg.give_up_after - 2);
+    req.spec_verifies = 0;
+    req.spec_drafted = 0;
+    req.spec_accepted = 0;
+}
+
+bool Engine::spec_ngram_gates_ok_(const Request& req) const {
+    if (req.spec_ngram_given_up) return false;
+    // Greedy sampling only: verify compares argmax tokens.
+    const bool greedy = (req.temperature <= 0.0f || req.top_k == 1);
+    if (!greedy) return false;
+    // Any logit-shaping the verify chunk does not replicate disqualifies.
+    if (req.repetition_penalty != 1.0f || req.frequency_penalty != 0.0f ||
+        req.presence_penalty != 0.0f || req.dry_multiplier != 0.0f || req.mirostat != 0 ||
+        !req.logit_bias.empty())
+        return false;
+    if (req.logprobs || req.json_mode || !req.json_schema.empty()) return false;
+    // Think budget forces tokens mid-stream (device/host-side) — the verify
+    // path doesn't replicate the forcing, so stay eager-per-token there.
+    if (req.think_budget > 0.0f) return false;
+    if (req.status != RequestStatus::DECODING || req.output_tokens.empty()) return false;
+    // Recurrent state (SSM/GDN) advances on every forwarded token and cannot
+    // be rewound on draft rejection.
+    if (ssm_state_ || gdn_state_) return false;
+    if (mtp_spec_decode_enabled()) return false;
+    if (!supports_chunked_prefill_()) return false;
+    return true;
+}
+
+bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream) {
+    const auto& scfg = runtime_config_.speculative;
+    const int kv_bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+
+    // Build the draft from the request's own token history.
+    std::vector<int32_t> history;
+    history.reserve(req->input_tokens.size() + req->output_tokens.size());
+    history.insert(history.end(), req->input_tokens.begin(), req->input_tokens.end());
+    history.insert(history.end(), req->output_tokens.begin(), req->output_tokens.end());
+    const int hist_n = static_cast<int>(history.size());
+
+    const int k = std::max(1, scfg.k);
+    std::vector<int32_t> draft =
+        ngram_draft(history.data(), hist_n, k, std::max(1, scfg.min_match), scfg.max_match);
+    if (draft.empty()) {
+        spec_stats_.miss_steps++;
+        if (++req->spec_consecutive_misses >= scfg.give_up_after && scfg.give_up_after > 0 &&
+            !req->spec_ngram_given_up) {
+            req->spec_ngram_given_up = true;
+            req->spec_last_giveup_pos = static_cast<int>(req->output_tokens.size());
+            IMP_LOG_INFO("spec-ngram: req %d gave up after %d consecutive draft misses — "
+                         "re-enabling async graph loop",
+                         req->id, req->spec_consecutive_misses);
+        }
+        return false;  // no usable draft — normal decode step
+    }
+
+    // Verify chunk = [t0, d1..dK]: t0 is the last emitted (not yet forwarded)
+    // token; positions p0..p0+K with p0 = context_len-1.
+    const int32_t t0 = req->output_tokens.back();
+    int K = static_cast<int>(draft.size());
+    const int p0 = req->context_len() - 1;
+
+    // attn_scores_ capacity clamp (same rule as chunked prefill):
+    // n_tokens × ctx_len must fit s_cap².
+    if (executor_) {
+        const int s_cap = executor_->attn_scores_cap();
+        if (s_cap > 0) {
+            const int64_t cap2 = static_cast<int64_t>(s_cap) * s_cap;
+            const int64_t ctx_end = static_cast<int64_t>(p0) + 1 + K;
+            while (K > 0 && static_cast<int64_t>(K + 1) * ctx_end > cap2) --K;
+            if (K <= 0) {
+                spec_stats_.miss_steps++;
+                return false;
+            }
+        }
+    }
+    const int chunk_len = K + 1;
+    const int ctx_len = p0 + chunk_len;  // context including the full chunk
+
+    // Staging buffers first (no KV side effects yet on failure).
+    const int blocks_needed = (ctx_len + kv_bs - 1) / kv_bs;
+    if (!ensure_spec_buffers_(std::max(chunk_len, scfg.k + 1), blocks_needed + 16)) {
+        spec_stats_.miss_steps++;
+        return false;
+    }
+
+    // KV blocks for all chunk positions (mirror step_decode's append loop).
+    // On allocation failure, trim back to the pre-step valid length (p0 KV
+    // entries: t0 has not been forwarded yet) and fall through to the normal
+    // decode path.
+    while (static_cast<int>(kv_manager_->block_table(req->id).size()) < blocks_needed) {
+        int new_block = kv_manager_->append_block(req->id);
+        if (new_block < 0) {
+            int evicted = kv_manager_->evict_lru();
+            if (evicted >= 0) new_block = kv_manager_->append_block(req->id);
+            if (new_block < 0) {
+                kv_manager_->rollback(req->id, p0);
+                spec_stats_.miss_steps++;
+                return false;
+            }
+        }
+    }
+    const auto& block_table = kv_manager_->block_table(req->id);
+    const int n_blocks = static_cast<int>(block_table.size());
+
+    // Upload chunk metadata.
+    std::vector<int32_t> h_tokens;
+    h_tokens.reserve(chunk_len);
+    h_tokens.push_back(t0);
+    h_tokens.insert(h_tokens.end(), draft.begin(), draft.begin() + K);
+    std::vector<int> h_positions(chunk_len);
+    for (int i = 0; i < chunk_len; ++i) h_positions[i] = p0 + i;
+
+    auto check = [&](cudaError_t err, const char* op) {
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("spec-ngram: %s failed: %s", op, cudaGetErrorString(err));
+            return false;
+        }
+        return true;
+    };
+    if (!check(cudaMemcpyAsync(d_spec_tokens_, h_tokens.data(), chunk_len * sizeof(int32_t),
+                               cudaMemcpyHostToDevice, stream), "tokens H2D") ||
+        !check(cudaMemcpyAsync(d_spec_positions_, h_positions.data(), chunk_len * sizeof(int),
+                               cudaMemcpyHostToDevice, stream), "positions H2D") ||
+        !check(cudaMemcpyAsync(d_spec_block_table_, block_table.data(), n_blocks * sizeof(int),
+                               cudaMemcpyHostToDevice, stream), "block table H2D") ||
+        !check(cudaMemcpyAsync(d_spec_context_len_, &ctx_len, sizeof(int), cudaMemcpyHostToDevice,
+                               stream), "context len H2D"))
+        return false;
+
+    // Forward the chunk through the standard continuation-prefill path.
+    if (!executor_->resize_workspace(chunk_len, stream)) {
+        spec_stats_.miss_steps++;
+        return false;
+    }
+    if (executor_->has_decode_workspace()) executor_->use_workspace(0);
+
+    InferenceState state;
+    state.token_ids = d_spec_tokens_;
+    state.positions = d_spec_positions_;
+    state.n_tokens = chunk_len;
+    state.kv_cache = kv_cache_raw_;
+    state.block_tables = d_spec_block_table_;
+    state.context_lens = d_spec_context_len_;
+    state.max_context_len = ctx_len;
+    state.n_sequences = 1;
+    state.max_blocks_per_seq = 0;
+    state.is_prefill = true;
+    state.prefill_offset = p0;
+    state.kv_manager = kv_manager_.get();
+    if (kv_manager_ && kv_manager_->residual_enabled()) state.kv_seq_id = req->id;
+
+    Tensor logits_out;
+    executor_->forward_logits(state, logits_out, stream);
+
+    // Greedy token for every chunk position, D2H, host compare.
+    executor_->greedy_argmax_all(chunk_len, d_spec_argmax_, stream);
+    if (!check(cudaMemcpyAsync(h_spec_argmax_, d_spec_argmax_, chunk_len * sizeof(int32_t),
+                               cudaMemcpyDeviceToHost, stream), "argmax D2H"))
+        return false;
+    if (!check(cudaStreamSynchronize(stream), "verify sync")) return false;
+
+    // Accept the longest matching prefix and emit tokens through the same
+    // per-token bookkeeping as the eager decode path.
+    int matched = 0;  // accepted draft tokens (their KV entries are valid)
+    int emitted = 0;
+    for (int j = 0; j < chunk_len; ++j) {
+        const int32_t tokj = h_spec_argmax_[j];
+        req->output_tokens.push_back(tokj);
+        track_think_state(*req, tokj);
+        emitted++;
+        const bool hard_stop = should_stop(*req, tokj) ||
+                               static_cast<int>(req->output_tokens.size()) >= req->max_tokens;
+        constraints_.update(tokj);
+        if (hard_stop) {
+            finish_request(req);
+            break;
+        }
+        if (j >= K || tokj != draft[j]) break;  // bonus token reached or draft diverged
+        matched++;
+    }
+    kv_manager_->touch(req->id);
+
+    // Drop KV for rejected draft positions: keep t0 + matched drafts.
+    kv_manager_->rollback(req->id, p0 + 1 + matched);
+
+    spec_stats_.verify_steps++;
+    spec_stats_.drafted += K;
+    spec_stats_.accepted += matched;
+    spec_stats_.emitted += emitted;
+
+    // Acceptance economics: structured-but-mutating content (number tables,
+    // counters) produces plenty of suffix matches whose continuations are
+    // always wrong — pure miss counting never triggers there while every
+    // step pays a full verify chunk for 1 emitted token. After a fair
+    // sample, an acceptance rate below 15% can't amortize the verify cost;
+    // hand the request back to the async loop.
+    if (matched == 0) {
+        ++req->spec_consecutive_misses;
+    } else {
+        req->spec_consecutive_misses = 0;
+    }
+    req->spec_verifies++;
+    req->spec_drafted += K;
+    req->spec_accepted += matched;
+    const bool acceptance_poor =
+        req->spec_verifies >= 16 &&
+        req->spec_accepted * 100 < req->spec_drafted * 15;
+    if (!req->spec_ngram_given_up && scfg.give_up_after > 0 &&
+        (acceptance_poor || req->spec_consecutive_misses >= scfg.give_up_after)) {
+        req->spec_ngram_given_up = true;
+        req->spec_last_giveup_pos = static_cast<int>(req->output_tokens.size());
+        IMP_LOG_INFO("spec-ngram: req %d gave up (%s: verifies=%d accepted=%lld/%lld misses=%d) — "
+                     "re-enabling async graph loop",
+                     req->id, acceptance_poor ? "acceptance-poor" : "draft-poor",
+                     req->spec_verifies, req->spec_accepted, req->spec_drafted,
+                     req->spec_consecutive_misses);
+    }
+
+    if (req->status == RequestStatus::FINISHED)
+        log_spec_stats_();
+    return true;
+}
+
+}  // namespace imp

--- a/src/runtime/ngram_draft.cpp
+++ b/src/runtime/ngram_draft.cpp
@@ -1,0 +1,46 @@
+#include "runtime/ngram_draft.h"
+
+#include <algorithm>
+
+namespace imp {
+
+std::vector<int32_t> ngram_draft(const int32_t* hist, int n, int k, int min_match, int max_match) {
+    if (hist == nullptr || k <= 0 || min_match < 1 || n < min_match + 1)
+        return {};
+    if (max_match < min_match)
+        max_match = min_match;
+
+    // Single backward pass over candidate end positions of the matched
+    // n-gram. `end` is the index one past the candidate occurrence, i.e.
+    // hist[end-m .. end) is compared against the suffix hist[n-m .. n).
+    // We first test the cheap min_match window, then extend backwards up
+    // to max_match to rank candidates by match length.
+    const int32_t* suffix = hist + n - min_match;
+    int best_end = -1;
+    int best_len = 0;
+    for (int end = n - 1; end >= min_match; --end) {
+        if (!std::equal(suffix, suffix + min_match, hist + end - min_match))
+            continue;
+        int len = min_match;
+        while (len < max_match && end - len - 1 >= 0 && n - len - 1 >= 0 &&
+               hist[end - len - 1] == hist[n - len - 1]) {
+            ++len;
+        }
+        if (len > best_len) {
+            best_len = len;
+            best_end = end;
+            if (best_len >= max_match)
+                break;  // can't do better; most recent due to scan order
+        }
+    }
+    if (best_end < 0)
+        return {};
+
+    int avail = n - best_end;
+    int take = std::min(k, avail);
+    if (take <= 0)
+        return {};
+    return std::vector<int32_t>(hist + best_end, hist + best_end + take);
+}
+
+}  // namespace imp

--- a/src/runtime/ngram_draft.h
+++ b/src/runtime/ngram_draft.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace imp {
+
+// Prompt-lookup draft: find the most recent earlier occurrence of the
+// longest suffix n-gram of `hist[0..n)` (match length in [min_match,
+// max_match]) and return up to `k` tokens that followed that occurrence.
+// Returns an empty vector when no suffix of at least min_match tokens
+// recurs in the history, or when the match is the suffix itself.
+//
+// Tie-breaking: longer match wins; among equal lengths the most recent
+// occurrence wins (recency tracks the model's local phrasing better than
+// distant repeats).
+std::vector<int32_t> ngram_draft(const int32_t* hist, int n, int k, int min_match, int max_match);
+
+}  // namespace imp

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -51,6 +51,17 @@ struct Request {
     float mirostat_eta = 0.1f;        // Learning rate
     float mirostat_mu = 0.0f;         // Running variable (persists across tokens, init = 2*tau)
     bool ignore_eos = false;          // Don't stop on EOS (benchmark mode)
+    // n-gram speculation bookkeeping: consecutive draft misses and per-
+    // request acceptance economics, plus the sticky give-up flag that hands
+    // the request back to the async graph loop once the context proved
+    // draft-poor (speculative.give_up_after) or acceptance-poor (structured
+    // content whose continuations never match, e.g. number tables).
+    int spec_consecutive_misses = 0;
+    int spec_verifies = 0;
+    long long spec_drafted = 0;
+    long long spec_accepted = 0;
+    bool spec_ngram_given_up = false;
+    int spec_last_giveup_pos = 0;  // output size at last give-up (burst re-arm)
     bool in_think_block = false;      // Currently inside <think>...</think> (suppress stop tokens)
     // Generation began inside an injected <think> prefix (the opener lives in
     // the PROMPT, not the output) — seeds the think-budget recount loop and

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -62,6 +62,10 @@ struct Request {
     long long spec_accepted = 0;
     bool spec_ngram_given_up = false;
     int spec_last_giveup_pos = 0;  // output size at last give-up (burst re-arm)
+    // Sticky acceptance verdict: structured-but-mutating content (number
+    // tables) re-trips the acceptance economics after every re-arm window —
+    // once doomed, give-up is final for this request.
+    bool spec_acceptance_doomed = false;
     bool in_think_block = false;      // Currently inside <think>...</think> (suppress stop tokens)
     // Generation began inside an injected <think> prefix (the opener lives in
     // the PROMPT, not the output) — seeds the think-budget recount loop and

--- a/tests/test_mmq_q8_imma.cu
+++ b/tests/test_mmq_q8_imma.cu
@@ -181,6 +181,12 @@ TEST(MmqQ8Imma, MTailNoTail320) { run_case(320, 256, 128, 45, 15e-3f, 2e-2f); }
 TEST(MmqQ8Imma, MTailSeed47) { run_case(313, 256, 128, 47, 15e-3f, 2e-2f); }
 TEST(MmqQ8Imma, MTailBigK) { run_case(313, 256, 1024, 45, 15e-3f, 2e-2f); }
 TEST(MmqQ8Imma, M64Min) { run_case(64, 128, 64, 46, 15e-3f, 2e-2f); }
+// Dense small-M (spec-decode verify chunks) routes through the split-K path
+// (M <= 32, gridDim.z = K-splits, fp32 partial slices + finalize reduce).
+TEST(MmqQ8Imma, SmallMSplitKVerifyShape) { run_case(9, 2560, 2560, 48, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, SmallMSplitKWideK) { run_case(17, 1024, 9728, 49, 15e-3f, 1e-2f); }
+TEST(MmqQ8Imma, SmallMMin2) { run_case(2, 256, 512, 50, 15e-3f, 2e-2f); }
+TEST(MmqQ8Imma, SmallMNoSplitShortK) { run_case(8, 128, 128, 52, 15e-3f, 2e-2f); }
 // ---- Q4_K dense (new stack) — NRMSE vs full-dequant reference ----
 namespace q4k_helpers {
 constexpr int kSuper = 256;
@@ -491,7 +497,8 @@ TEST(MmqQ8Imma, MoeGroupedQ8) {
 }
 
 TEST(MmqQ8Imma, DeclineShapes) {
-    // N not multiple of 128 / K not multiple of 64 / M < 64 → false
+    // N odd / K not multiple of 64 / M < 2 → false. (M down to 2 is accepted
+    // since the small-M split-K path — spec-decode verify chunks.)
     std::vector<uint8_t> W;
     gen_q8_weight(W, 64, 64, 1);
     uint8_t* d_w = nullptr;
@@ -499,7 +506,7 @@ TEST(MmqQ8Imma, DeclineShapes) {
     cudaMalloc(&d_w, W.size());
     cudaMalloc(&d_x, 64 * 64 * sizeof(__half));
     cudaMalloc(&d_out, 64 * 64 * sizeof(__half));
-    EXPECT_FALSE(mmq_q8_imma_gemm(d_w, d_x, d_out, 63, 128, 64, nullptr));  // M < 64
+    EXPECT_FALSE(mmq_q8_imma_gemm(d_w, d_x, d_out, 1, 128, 64, nullptr));   // M < 2
     EXPECT_FALSE(mmq_q8_imma_gemm(d_w, d_x, d_out, 64, 63, 64, nullptr));   // N odd
     EXPECT_FALSE(mmq_q8_imma_gemm(d_w, d_x, d_out, 64, 128, 32, nullptr));  // K % 64
     cudaFree(d_w);

--- a/tests/test_ngram_draft.cpp
+++ b/tests/test_ngram_draft.cpp
@@ -1,0 +1,83 @@
+// Host-side tests for the prompt-lookup n-gram draft matcher
+// (src/runtime/ngram_draft.cpp) used by speculative decoding.
+
+#include "runtime/ngram_draft.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using imp::ngram_draft;
+
+namespace {
+
+std::vector<int32_t> draft(const std::vector<int32_t>& hist, int k, int min_match = 3,
+                           int max_match = 8) {
+    return ngram_draft(hist.data(), static_cast<int>(hist.size()), k, min_match, max_match);
+}
+
+TEST(NgramDraft, EmptyWhenNoRepeat) {
+    EXPECT_TRUE(draft({1, 2, 3, 4, 5, 6, 7, 8}, 4).empty());
+}
+
+TEST(NgramDraft, EmptyWhenTooShort) {
+    EXPECT_TRUE(draft({1, 2, 3}, 4).empty());
+    EXPECT_TRUE(draft({}, 4).empty());
+}
+
+TEST(NgramDraft, FindsSimpleRepeat) {
+    // Suffix [10,11,12] occurred earlier; the draft is what followed it.
+    std::vector<int32_t> h = {10, 11, 12, 13, 14, 99, 10, 11, 12};
+    auto d = draft(h, 4);
+    ASSERT_EQ(d.size(), 4u);
+    EXPECT_EQ(d[0], 13);
+    EXPECT_EQ(d[1], 14);
+    EXPECT_EQ(d[2], 99);
+    EXPECT_EQ(d[3], 10);
+}
+
+TEST(NgramDraft, TruncatesAtK) {
+    std::vector<int32_t> h = {1, 2, 3, 4, 5, 6, 7, 8, 9, 50, 1, 2, 3};
+    auto d = draft(h, 2);
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[0], 4);
+    EXPECT_EQ(d[1], 5);
+}
+
+TEST(NgramDraft, PrefersLongerMatch) {
+    // Two occurrences of suffix [7,8,9]: the earlier one extends to a
+    // 4-gram match [6,7,8,9]; the later only matches 3. Longer must win
+    // even though it is older.
+    std::vector<int32_t> h = {6, 7, 8, 9, 100, 101, 5, 7, 8, 9, 200, 201, 6, 7, 8, 9};
+    auto d = draft(h, 2, 3, 8);
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[0], 100);
+    EXPECT_EQ(d[1], 101);
+}
+
+TEST(NgramDraft, PrefersRecentOnEqualLength) {
+    // Suffix [7,8,9] twice with different continuations and equal match
+    // length (no 4-gram extension anywhere): the more recent wins.
+    std::vector<int32_t> h = {1, 7, 8, 9, 100, 2, 7, 8, 9, 200, 3, 7, 8, 9};
+    auto d = draft(h, 1, 3, 3);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 200);
+}
+
+TEST(NgramDraft, OverlappingPeriodicPattern) {
+    // "A B A B A B" → suffix [A,B] (min_match 2) matches the overlapping
+    // earlier occurrence; the continuation is the periodic extension.
+    std::vector<int32_t> h = {7, 8, 7, 8, 7, 8};
+    auto d = draft(h, 2, 2, 4);
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[0], 7);
+    EXPECT_EQ(d[1], 8);
+}
+
+TEST(NgramDraft, DegenerateParamsRejected) {
+    std::vector<int32_t> h = {1, 2, 3, 1, 2, 3};
+    EXPECT_TRUE(ngram_draft(nullptr, 6, 4, 3, 8).empty());
+    EXPECT_TRUE(draft(h, 0).empty());
+    EXPECT_TRUE(draft(h, 4, 0, 8).empty());
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Opt-in speculative decoding without a draft model: drafts come from suffix matches against the request's own prompt+output (`ngram_draft`), verified as a teacher-forced K+1 continuation chunk with per-position greedy argmax, accepted-prefix emission, and KV rollback (`KVCacheManager::rollback` gains its first real caller). Off by default: `[speculative] ngram = true` or `IMP_SPEC_NGRAM=1`.

Three layers make it net-positive (full history in #667):

1. **Verify forward**: the M=9..17 chunk re-dequantized the entire model through the dequant→cuBLAS fallback (56% of GPU time). The mmq IMMA gate drops M≥64 → M≥2, and a new **dense small-M split-K** path (gridDim.z slices, fp32 partial tiles, fixed-order finalize — bit-reproducible) fixes the K-loop latency (~35 µs/weight → bandwidth-bound). Row-argmax is two-phase (145 → 16 µs/row).
2. **Burst-hybrid scheduling**: misses don't pay the ~2× eager per-token tax. The conditional graph gains a device-side `step_limit` + `rearm()` (reseed without recapture, ~15 ms saved per launch); the engine parks the runner between bounded bursts (adaptive 8→32); acceptance-poor content (<15% after 8 verifies) is doomed back to the unbounded loop. `imp_decode_step` tolerates zero-token launch-only steps.
3. **Gates**: batch-1 greedy, no penalties/logprobs/constraints/recurrent-state, chunked-prefill-capable archs.

## Measured (RTX 5090, 3 trials, spec on vs off)

| Workload | off | on |
|---|---|---|
| Qwen3-4B code-edit | 425 | **438 avg** (417/468/429) |
| Qwen3-8B prose (think) | 278 | **280** (parity) |
| Qwen3-14B-Q6K code-edit | 104.6 | 105.0 |
| Worst case (number tables) | 421 | 368 (economics give-up bounds it) |

- Acceptance 47–56% on code-edit (8.5 tok/verify at the k=16 default).
- Default path (spec off) measurably unchanged; perf baseline untouched.
- PPL identical to the digit (10.8753) after the shared LM-head refactor + split-K.
- Verify-chunk numerics can flip rare greedy ties vs the decode path (same class as chunked prefill, #553): outputs are coherent and NLL-equivalent, not byte-identical.
- New GTests: `NgramDraft.*` (CPU), `MmqQ8Imma` split-K reference shapes (GPU, 17/17 local).

## Follow-ups (tracked in #667)

Q6_K dense small-M (raw-read variant needed — the repack cache would copy ~11 GB on a dense 14B), NVFP4-SafeTensors verify profiling, draft-source improvements against the acceptance ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)