### PR TITLE
feat(spec): server enablement — penalties in verify, think-budget bursts, stale-park fix

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -114,7 +114,17 @@ public:
     // just ran) and writes argmax token ids to d_out[0..n_rows-1]. Same
     // logits as production greedy sampling (incl. final softcap). Overwrites
     // the logits_ workspace. Enqueues on `stream` only.
-    void greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream);
+    //
+    // Optional penalties (exact production parity with apply_penalties):
+    // d_hist[0..n_hist) is the request's output-token history (ends with the
+    // chunk's first token t0); d_draft points at the chunk tokens AFTER t0,
+    // so row j additionally penalizes d_draft[0..j-1] — the same set the
+    // eager path would have accumulated by that step. repeat_last_n != 0 is
+    // the caller's responsibility to gate (window semantics not replicated).
+    void greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream,
+                           const int32_t* d_hist = nullptr, int n_hist = 0,
+                           const int32_t* d_draft = nullptr, float rep_pen = 1.0f,
+                           float freq_pen = 0.0f, float pres_pen = 0.0f);
 
     // Sample tokens from pre-computed logits (for use after CUDA graph execution).
     std::vector<int32_t> sample_from_logits(const Tensor& logits, const InferenceState& state,
@@ -301,6 +311,10 @@ private:
     // free_buffers).
     void* verify_argmax_scratch_ = nullptr;
     size_t verify_argmax_scratch_sz_ = 0;
+    // Spec-decode verify penalty counts: [vocab] int32 occurrence counts of
+    // the shared history (lazy; freed in free_buffers).
+    int32_t* verify_pen_counts_ = nullptr;
+    int verify_pen_counts_cap_ = 0;
 
     // LoRA (issue #522)
     const LoraAdapter* lora_ = nullptr;

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -266,7 +266,51 @@ __global__ void rowwise_argmax_reduce_kernel(const float* __restrict__ pvals,
     out[row] = best_idx;
 }
 
-void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream) {
+// Occurrence counts of the shared history per vocab id (production
+// apply_penalties scans the history per vocab thread the same way; doing it
+// once here amortizes the scan across all chunk rows).
+__global__ void verify_hist_count_kernel(const int32_t* __restrict__ hist, int n_hist, int V,
+                                         int32_t* __restrict__ counts) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= V) return;
+    int c = 0;
+    for (int i = 0; i < n_hist; ++i)
+        if (hist[i] == idx) c++;
+    counts[idx] = c;
+}
+
+// Apply repetition/frequency/presence penalties to a batch of chunk rows.
+// Row `row0 + blockIdx.y` predicts the token after chunk position row0+y;
+// its penalty set = shared history + d_draft[0..row-1] (the draft tokens the
+// eager path would have emitted before this prediction). Formulas identical
+// to apply_penalties_kernel in sampling.cu.
+__global__ void verify_penalties_kernel(float* __restrict__ logits, int row0, int V,
+                                        const int32_t* __restrict__ counts,
+                                        const int32_t* __restrict__ draft, float rep_pen,
+                                        float freq_pen, float pres_pen) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= V) return;
+    const int row = row0 + blockIdx.y;
+    int count = counts[idx];
+    for (int i = 0; i < row; ++i)
+        if (draft[i] == idx) count++;
+    if (count == 0) return;
+    float* lg = logits + static_cast<size_t>(blockIdx.y) * V + idx;
+    float logit = *lg;
+    if (rep_pen != 1.0f) {
+        if (logit > 0.0f)
+            logit /= rep_pen;
+        else
+            logit *= rep_pen;
+    }
+    logit -= freq_pen * static_cast<float>(count);
+    logit -= pres_pen;
+    *lg = logit;
+}
+
+void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream,
+                                      const int32_t* d_hist, int n_hist, const int32_t* d_draft,
+                                      float rep_pen, float freq_pen, float pres_pen) {
     if (!initialized_ || n_rows <= 0 || d_out == nullptr) {
         return;
     }
@@ -286,7 +330,32 @@ void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t s
     }
     float* pvals = static_cast<float*>(verify_argmax_scratch_);
     int* pidxs = reinterpret_cast<int*>(pvals + static_cast<size_t>(mb) * kArgmaxSplits);
+
+    const bool penalties = (rep_pen != 1.0f || freq_pen != 0.0f || pres_pen != 0.0f) &&
+                           d_hist != nullptr && d_draft != nullptr;
+    if (penalties) {
+        if (verify_pen_counts_cap_ < V) {
+            if (verify_pen_counts_)
+                IMP_CUDA_CHECK_LOG(cudaFree(verify_pen_counts_));
+            if (cudaMalloc(&verify_pen_counts_, static_cast<size_t>(V) * sizeof(int32_t)) !=
+                cudaSuccess) {
+                verify_pen_counts_ = nullptr;
+                verify_pen_counts_cap_ = 0;
+                return;
+            }
+            verify_pen_counts_cap_ = V;
+        }
+        verify_hist_count_kernel<<<(V + 255) / 256, 256, 0, stream>>>(d_hist, n_hist, V,
+                                                                      verify_pen_counts_);
+    }
+
     for_each_lm_head_batch_(n_rows, stream, [&](const Tensor& lg, int row0, int csz) {
+        if (penalties) {
+            dim3 pgrid((V + 255) / 256, csz);
+            verify_penalties_kernel<<<pgrid, 256, 0, stream>>>(
+                static_cast<float*>(lg.data), row0, V, verify_pen_counts_, d_draft, rep_pen,
+                freq_pen, pres_pen);
+        }
         dim3 grid(csz, kArgmaxSplits);
         rowwise_argmax_partial_kernel<<<grid, 256, 0, stream>>>(
             static_cast<const float*>(lg.data), V, pvals, pidxs);

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -918,6 +918,11 @@ void GraphExecutor::free_buffers() {
         verify_argmax_scratch_ = nullptr;
         verify_argmax_scratch_sz_ = 0;
     }
+    if (verify_pen_counts_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(verify_pen_counts_));
+        verify_pen_counts_ = nullptr;
+        verify_pen_counts_cap_ = 0;
+    }
     // Helper: free through VRAMAllocator if pointer was tracked, else cudaFree.
     auto vfree = [this](void*& p) {
         if (p) {

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -484,8 +484,10 @@ __global__ void post_decode_step_kernel(
     int* __restrict__ d_context_len,         // [1] current context length
     int* __restrict__ d_step_counter,        // [1] device-side step counter
     int max_steps, int eos_id, const int32_t* __restrict__ d_stop_ids, int n_stop_ids,
-    // Think budget (all 0/-1 when disabled)
-    int think_budget_limit, int32_t think_start_id, int32_t think_end_id, int think_grace_tokens,
+    // Think budget: remaining-budget limit read from device memory so
+    // rearm() can shrink it across bounded burst launches (0 = disabled).
+    const int* __restrict__ d_think_limit, int32_t think_start_id, int32_t think_end_id,
+    int think_grace_tokens,
     int* __restrict__ d_think_count,      // [1] reasoning token counter
     int* __restrict__ d_in_think,         // [1] think block flag
     int* __restrict__ d_think_exit_step,  // [1] step </think> last closed (-1 = never)
@@ -498,6 +500,7 @@ __global__ void post_decode_step_kernel(
     cudaGraphConditionalHandle handle) {
     int step = *d_step_counter;
     int32_t token = *d_token_id;
+    const int think_budget_limit = d_think_limit ? *d_think_limit : 0;
 
     // Per-launch step cap: read from device memory so rearm() can bound a
     // burst without recapturing the graph. max_steps stays the hard capacity
@@ -636,6 +639,9 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
     err = cudaMalloc(&d_step_limit_, sizeof(int));
     if (err != cudaSuccess)
         goto fail;
+    err = cudaMalloc(&d_think_limit_, sizeof(int));
+    if (err != cudaSuccess)
+        goto fail;
 
     // Stop token IDs
     if (!config_.stop_ids.empty()) {
@@ -769,6 +775,13 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
             IMP_LOG_ERROR("ConditionalRunner: step_limit init failed: %s", cudaGetErrorString(err));
             goto fail;
         }
+        err = cudaMemcpyAsync(d_think_limit_, &config_.think_budget_limit, sizeof(int),
+                              cudaMemcpyHostToDevice, stream);
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("ConditionalRunner: think_limit init failed: %s",
+                          cudaGetErrorString(err));
+            goto fail;
+        }
     }
 
     // ---- Build InferenceState for graph body (uses our device pointers) ----
@@ -875,7 +888,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                                                      d_position_, d_context_len_, d_step_counter_,
                                                      config_.max_steps, config_.eos_id, d_stop_ids_,
                                                      static_cast<int>(config_.stop_ids.size()),
-                                                     config_.think_budget_limit, config_.think_start_id,
+                                                     d_think_limit_, config_.think_start_id,
                                                      config_.think_end_id, config_.think_grace_tokens,
                                                      d_think_count_, d_in_think_, d_think_exit_step_,
                                                      config_.ignore_eos ? 1 : 0, d_penalty_ring_,
@@ -947,7 +960,8 @@ bool CudaGraphConditionalRunner::launch(cudaStream_t stream) {
 }
 
 bool CudaGraphConditionalRunner::rearm(int32_t first_token, int position, int context_len,
-                                       int step_limit, bool in_think, cudaStream_t stream) {
+                                       int step_limit, bool in_think, int think_limit,
+                                       cudaStream_t stream) {
     if (!exec_ || launched_)
         return false;
     // The captured graph sized its attention workspace for
@@ -972,7 +986,8 @@ bool CudaGraphConditionalRunner::rearm(int32_t first_token, int position, int co
         !up(d_position_, &position, sizeof(int), "position") ||
         !up(d_context_len_, &context_len, sizeof(int), "context_len") ||
         !up(d_step_counter_, &zero, sizeof(int), "step_counter") ||
-        !up(d_step_limit_, &step_limit, sizeof(int), "step_limit"))
+        !up(d_step_limit_, &step_limit, sizeof(int), "step_limit") ||
+        !up(d_think_limit_, &think_limit, sizeof(int), "think_limit"))
         return false;
     if (d_in_think_) {
         if (!up(d_in_think_, &think, sizeof(int), "in_think") ||
@@ -1046,6 +1061,10 @@ void CudaGraphConditionalRunner::cleanup() {
     if (d_step_limit_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_step_limit_));
         d_step_limit_ = nullptr;
+    }
+    if (d_think_limit_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_think_limit_));
+        d_think_limit_ = nullptr;
     }
     if (d_context_len_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_context_len_));

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -175,12 +175,14 @@ public:
     // Re-seed device state for another bounded launch WITHOUT recapturing the
     // graph (the expensive part of setup). first_token is forwarded at
     // `position` with context length `context_len` (physical values, no +1
-    // applied inside). step_limit bounds this launch (0 = max_steps). Returns
-    // false when no graph is built, a launch is still in flight, or
-    // context_len would exceed the captured ceiling — caller falls back to a
-    // full setup().
+    // applied inside). step_limit bounds this launch (0 = max_steps);
+    // think_limit is the REMAINING think budget for this launch (0 = no
+    // budget; the device counter restarts at 0 every launch, so the caller
+    // passes full_budget - tokens_already_thought). Returns false when no
+    // graph is built, a launch is still in flight, or context_len would
+    // exceed the captured ceiling — caller falls back to a full setup().
     bool rearm(int32_t first_token, int position, int context_len, int step_limit, bool in_think,
-               cudaStream_t stream);
+               int think_limit, cudaStream_t stream);
 
     // Context ceiling baked into the captured graph (attention workspace
     // sizing): initial_context_len + max_steps at setup time.
@@ -213,6 +215,7 @@ private:
     int* d_context_len_ = nullptr;   // [1] current context length on device
     int* d_step_counter_ = nullptr;  // [1] step counter on device
     int* d_step_limit_ = nullptr;    // [1] per-launch step cap (0 = max_steps)
+    int* d_think_limit_ = nullptr;   // [1] per-launch remaining think budget (0 = off)
     int32_t* d_stop_ids_ = nullptr;  // [n_stop_ids] stop token IDs on device
 
     // Think budget tracking (device-side)

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -400,6 +400,10 @@ void Engine::finish_request(std::shared_ptr<Request>& req) {
     kv_manager_->free_sequence(req->id);
     release_recurrent_slot_(req->id);
     constraints_.reset();
+    // Server visibility: the engine outlives requests, so cumulative
+    // speculation telemetry is logged per request end (no-op when idle).
+    if (runtime_config_.speculative.ngram)
+        log_spec_stats_();
 }
 
 // =====================================================================

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -443,7 +443,7 @@ private:
     // Returns true when it handled this decode step (tokens emitted);
     // false → caller falls through to the normal decode path.
     bool step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream);
-    bool spec_ngram_gates_ok_(const Request& req) const;
+    bool spec_ngram_gates_ok_(const Request& req, bool ignore_think = false) const;
     bool spec_burst_launch_ok_(const Request& req) const;
     int spec_effective_miss_burst_(const Request& req) const;
     void spec_maybe_rearm_(Request& req) const;

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -96,8 +96,18 @@ CudaGraphConditionalRunner::Config Engine::build_graph_config(const Request& req
         gcfg.think_end_id = think_end_id_;
         gcfg.initial_in_think = req.in_think_block;
         gcfg.think_grace_tokens = think_logic::kMinAnswerAfterThink;
-        if (req.think_budget > 0.0f)
-            gcfg.think_budget_limit = static_cast<int>(req.max_tokens * req.think_budget);
+        if (req.think_budget > 0.0f) {
+            // The loop's device-side counter starts at 0 every launch; with
+            // bounded bursts (n-gram speculation think-phase) the request
+            // relaunches mid-think, so the per-launch limit must be the
+            // REMAINING budget or every burst would re-grant the full one.
+            const int full = static_cast<int>(req.max_tokens * req.think_budget);
+            bool thinking_now = false;
+            const int used = think_logic::count_reasoning_tokens(
+                req.output_tokens, think_start_id_, think_end_id_, req.started_in_think,
+                thinking_now);
+            gcfg.think_budget_limit = std::max(1, full - used);
+        }
     }
     return gcfg;
 }
@@ -187,8 +197,19 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
             IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(async_d_block_tables_, bt.data(),
                                                bt.size() * sizeof(int), cudaMemcpyHostToDevice,
                                                stream));
+            // Remaining think budget for this launch (the device counter
+            // restarts at 0 per launch; see build_graph_config).
+            int think_limit = 0;
+            if (req->think_budget > 0.0f && think_end_id_ >= 0) {
+                bool thinking_now = false;
+                const int used = think_logic::count_reasoning_tokens(
+                    req->output_tokens, think_start_id_, think_end_id_, req->started_in_think,
+                    thinking_now);
+                think_limit = std::max(
+                    1, static_cast<int>(req->max_tokens * req->think_budget) - used);
+            }
             if (async_graph_runner_.rearm(first_token, /*position=*/ctx - 1, /*context_len=*/ctx,
-                                          step_limit, req->in_think_block, stream) &&
+                                          step_limit, req->in_think_block, think_limit, stream) &&
                 async_graph_runner_.launch(stream)) {
                 async_graph_req_ = req;
                 async_pending_tokens_.clear();

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -23,6 +23,7 @@
 #include "runtime/engine_internal.h"
 #include "runtime/config.h"
 #include "runtime/batch.h"
+#include "runtime/think_stop_logic.h"
 #include "compute/mtp_forward.h"
 #include "memory/kv_cache.h"
 #include "compute/sampling.h"
@@ -869,6 +870,31 @@ void Engine::step_decode(cudaStream_t dec_stream) {
                 sreq->spec_acceptance_doomed ? 0 : runtime_config_.speculative.burst;
             if (try_launch_async_graph_loop(sreq, sreq->output_tokens.back(), dec_stream, lim))
                 return;
+        } else if (decode_batch[0]->think_budget > 0.0f && decode_batch[0]->in_think_block &&
+                   spec_ngram_gates_ok_(*decode_batch[0], /*ignore_think=*/true) &&
+                   spec_burst_launch_ok_(*decode_batch[0]) &&
+                   // Budget exhausted → the EAGER step must run: it forces
+                   // the </think> token. Launching the loop here instead
+                   // produced 1-token budget-stopped loops with a full
+                   // recapture each, and </think> was never forced.
+                   !think_logic::should_force_think_end(
+                       decode_batch[0]->think_budget, think_end_id_, decode_batch[0]->max_tokens,
+                       decode_batch[0]->output_tokens, think_start_id_,
+                       decode_batch[0]->started_in_think)) {
+            // Budgeted think interior: the loop handles the budget device-
+            // side in bounded bursts so the host catches the think→answer
+            // transition and resumes verification in the draft-rich answer
+            // region. Fixed burst (the miss counter stays untouched — these
+            // are not draft misses, and inflating it would instantly trip
+            // give-up on the first real probe after </think>).
+            auto& sreq = decode_batch[0];
+            const int think_burst =
+                std::min(32, runtime_config_.speculative.burst > 0
+                                 ? runtime_config_.speculative.burst
+                                 : 32);
+            if (try_launch_async_graph_loop(sreq, sreq->output_tokens.back(), dec_stream,
+                                            think_burst))
+                return;
         } else {
             // One-time diagnosis: say WHY speculation is inactive (gates are
             // silent otherwise and a misconfigured request looks identical
@@ -1466,8 +1492,9 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
     if (decode_graph_pool_[0].is_ready() && valid_decode.size() == 1 && !offload_mgr_ &&
         config_.use_cuda_graphs &&
         // A PARKED runner (burst-hybrid speculation) is setup but idle — it
-        // must be allowed back in here, or bursts only ever fire once.
-        (!async_graph_runner_.is_setup() || async_parked_req_id_ == valid_decode[0]->id) &&
+        // must be allowed back in here, or bursts only ever fire once. A park
+        // for a DIFFERENT request is torn down inside the launch.
+        (!async_graph_runner_.is_setup() || async_parked_req_id_ >= 0) &&
         !needs_logprobs && !needs_json_mode && !needs_schema_mode) {
         auto& dreq = valid_decode[0];
         // forward_decode_async only implements banned_tokens + rep/freq/presence

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -126,8 +126,12 @@ int Engine::spec_effective_miss_burst_(const Request& req) const {
 bool Engine::spec_burst_launch_ok_(const Request& req) const {
     if (!decode_graph_pool_[0].is_ready() || offload_mgr_ || !config_.use_cuda_graphs)
         return false;
-    if (async_graph_runner_.is_setup() && async_parked_req_id_ != req.id)
-        return false;  // runner busy/parked for another request
+    // A runner that is setup but NOT parked is in flight — blocked. Parked
+    // for a DIFFERENT request is fine: try_launch_async_graph_loop tears the
+    // stale park down and rebuilds (a parked warmup request would otherwise
+    // lock every later server request out of the loop entirely).
+    if (async_graph_runner_.is_setup() && async_parked_req_id_ < 0)
+        return false;
     // Text-fallback think tracking needs host-side per-token matching.
     if (req.in_think_block && think_end_id_ < 0)
         return false;
@@ -136,20 +140,25 @@ bool Engine::spec_burst_launch_ok_(const Request& req) const {
     return true;
 }
 
-bool Engine::spec_ngram_gates_ok_(const Request& req) const {
+bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     if (req.spec_ngram_given_up) return false;
     // Greedy sampling only: verify compares argmax tokens.
     const bool greedy = (req.temperature <= 0.0f || req.top_k == 1);
     if (!greedy) return false;
-    // Any logit-shaping the verify chunk does not replicate disqualifies.
-    if (req.repetition_penalty != 1.0f || req.frequency_penalty != 0.0f ||
-        req.presence_penalty != 0.0f || req.dry_multiplier != 0.0f || req.mirostat != 0 ||
-        !req.logit_bias.empty())
+    // rep/freq/presence penalties are replicated in the verify
+    // (greedy_argmax_all) for the unbounded window; a bounded repeat_last_n
+    // window slides per chunk row and is not replicated — stay eager there.
+    const bool penalties = req.repetition_penalty != 1.0f || req.frequency_penalty != 0.0f ||
+                           req.presence_penalty != 0.0f;
+    if (penalties && req.repeat_last_n != 0) return false;
+    // Logit-shaping the verify chunk does not replicate disqualifies.
+    if (req.dry_multiplier != 0.0f || req.mirostat != 0 || !req.logit_bias.empty())
         return false;
     if (req.logprobs || req.json_mode || !req.json_schema.empty()) return false;
-    // Think budget forces tokens mid-stream (device/host-side) — the verify
-    // path doesn't replicate the forcing, so stay eager-per-token there.
-    if (req.think_budget > 0.0f) return false;
+    // Think budget forces tokens INSIDE the think block (loop/host-side) —
+    // verify only outside it; the think interior runs loop bursts, which
+    // handle the budget device-side.
+    if (!ignore_think && req.think_budget > 0.0f && req.in_think_block) return false;
     if (req.status != RequestStatus::DECODING || req.output_tokens.empty()) return false;
     // Recurrent state (SSM/GDN) advances on every forwarded token and cannot
     // be rewound on draft rejection.
@@ -296,8 +305,29 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     Tensor logits_out;
     executor_->forward_logits(state, logits_out, stream);
 
+    // Penalty history (production parity: output_tokens, unbounded window).
+    const bool penalties = req->repetition_penalty != 1.0f ||
+                           req->frequency_penalty != 0.0f || req->presence_penalty != 0.0f;
+    const int32_t* d_hist = nullptr;
+    int n_hist = 0;
+    if (penalties) {
+        InferenceState pstate;
+        upload_penalties(*req, pstate, stream);
+        if (pstate.penalty_tokens == nullptr) {
+            // Upload failed — an unpenalized verify would diverge from the
+            // eager path; fall back to the normal step.
+            kv_manager_->rollback(req->id, p0);
+            spec_stats_.miss_steps++;
+            return false;
+        }
+        d_hist = pstate.penalty_tokens;
+        n_hist = pstate.n_penalty_tokens;
+    }
+
     // Greedy token for every chunk position, D2H, host compare.
-    executor_->greedy_argmax_all(chunk_len, d_spec_argmax_, stream);
+    executor_->greedy_argmax_all(chunk_len, d_spec_argmax_, stream, d_hist, n_hist,
+                                 d_spec_tokens_ + 1, req->repetition_penalty,
+                                 req->frequency_penalty, req->presence_penalty);
     if (!check(cudaMemcpyAsync(h_spec_argmax_, d_spec_argmax_, chunk_len * sizeof(int32_t),
                                cudaMemcpyDeviceToHost, stream), "argmax D2H"))
         return false;
@@ -321,6 +351,9 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         }
         if (j >= K || tokj != draft[j]) break;  // bonus token reached or draft diverged
         matched++;
+        // Entering a budgeted think block mid-chunk: the budget forcing lives
+        // in the loop/eager path — stop extending; the accepted prefix stays.
+        if (req->think_budget > 0.0f && req->in_think_block) break;
     }
     kv_manager_->touch(req->id);
 
@@ -331,6 +364,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     spec_stats_.drafted += K;
     spec_stats_.accepted += matched;
     spec_stats_.emitted += emitted;
+    // (request-end stats logging lives in finish_request)
 
     // Acceptance economics: structured-but-mutating content (number tables,
     // counters) produces plenty of suffix matches whose continuations are
@@ -362,8 +396,6 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
                      req->spec_consecutive_misses);
     }
 
-    if (req->status == RequestStatus::FINISHED)
-        log_spec_stats_();
     return true;
 }
 


### PR DESCRIPTION
## Summary

Speculation measured well from the CLI but **never engaged through `imp-server`**: the server defaults (`repetition_penalty=1.05`, `think_budget=0.5`) failed the gates, and a second, subtler bug locked the loop out entirely in multi-request mode. Three fixes (history in #667):

1. **Penalties in verify**: `greedy_argmax_all` applies repetition/frequency/presence penalties before the per-row argmax — shared history counts computed once (vocab-parallel, same scan as `apply_penalties_kernel`) plus each row's draft prefix; formulas identical to production. Gated to `repeat_last_n == 0`.
2. **Think budget**: verify runs outside the think block; the budgeted think interior runs bounded loop bursts (budget handled device-side). `think_budget_limit` moves from a baked kernel arg to device memory so `rearm()` passes the **remaining** budget per launch — previously each burst re-granted the full budget, and the spec think-branch bypassed the eager `</think>` forcing (1-token budget-stopped loops with a full recapture each; requests thought to max_tokens). `should_force_think_end` now hands the step back to the eager path when forcing is due.
3. **Stale-park fix (the server killer)**: a runner parked for a finished request blocked every later request's loop launches — both launch gates required `parked_id == req->id` while the mismatch teardown lives inside `try_launch_async_graph_loop`, which was never reached. Every token of every follow-up request ran eager. Parked-for-other-request now passes the gates; the launch tears the stale park down.

Telemetry now logs per request end (`finish_request`) so server logs show speculation stats.

## Measured

| Path | spec off | spec on |
|---|---|---|
| **imp-server**, Qwen3-8B think model, real server defaults (2 runs) | 152.8 / 153.4 | **161.3 / 161.4** (+5.4%, 46% acceptance, 8.4 tok/verify) |
| CLI `--repeat-penalty 1.05`, Qwen3-4B code-edit | 418 | **478** (+14%) |

Exaggerated-penalty check (`--repeat-penalty 1.3`): the penalty visibly shapes accepted draft tokens identically to the eager path. Default path unchanged (off-runs match pre-change baselines); verify-fast green; feature remains opt-in.

Tracking: #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)