### PR TITLE
perf(nvfp4): chunk-2048 default, act-quant dedupe, fa2_f16acc default; fix(moe): grouped GEMM dropped tiles

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -83,8 +83,13 @@ cuBLAS path (attention sinks). Decode 310-345 depending on host state.
 
 On `sm_120`, native-NVFP4 decode is effectively uncontested (vLLM gates its
 NVFP4 path on `tcgen05`/falls back to Marlin on the 5090; llama.cpp has no
-native NVFP4 path). NVFP4 **prefill** trails vLLM by ~1.4× — the gap is in
-attention, not the grouped GEMM (near roofline). Nemotron-3-Nano is
+native NVFP4 path). NVFP4 **prefill** (re-measured 2026-06-11 vs vLLM 0.22.1
+FlashInfer-NVFP4, same day/host, after the chunk-2048 default + act-quant
+dedupe): imp wins TTFT/pp512 outright (2.3–3.3×, vLLM has a flat-cost
+small-M regime), wins MoE pp2048 (39.8k vs 34.5k tok/s), ties dense pp2048
+(25.6k vs 26.6k); vLLM keeps pp4096 (1.32–1.33×, attention-bound — imp FA2
+runs the quartered f32-acc class vs FlashInfer with fp8 KV). Decode: imp
++35–40% (14B 168 vs 121–126; 30B-A3B 323 vs 223–233). Nemotron-3-Nano is
 arch-limited (hybrid Mamba2 + attention FP16-projection mix).
 
 ## Output-quality gate

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ dated, commit-anchored measurements with exact commands):
   (Qwen3-30B-A3B 305, Qwen3-Coder-30B 338, Qwen3.6-35B 257, Gemma-4-26B 266;
   2026-06-09) — effectively uncontested on `sm_120`, where vLLM's NVFP4 path
   needs `tcgen05` and llama.cpp has no native NVFP4 support.
-- Honest losses: NVFP4 long-context prefill (~1.7× behind vLLM at pp4096,
-  attention-bound; imp WINS below ~2k context), Qwen3.6-35B GGUF decode
+- Honest losses: NVFP4 long-context prefill (~1.3× behind vLLM at pp4096,
+  attention-bound; imp WINS TTFT everywhere, MoE pp2048, and ties dense
+  pp2048 since the chunk-2048 default, 2026-06-11), Qwen3.6-35B GGUF decode
   (−31%, structural FP16 GDN-projection tax).
 
 Every number, with date, commit SHA, CUDA version, quant and the exact
@@ -63,7 +64,7 @@ command: **[BENCHMARKS.md](BENCHMARKS.md)**. Methodology details:
 
 - **Single GPU only.** No tensor parallelism, no multi-GPU.
 - **Consumer Blackwell only.** `sm_120a` SASS + `compute_120f` PTX fallback. No Hopper, Ada, Ampere, datacenter Blackwell. No AMD, Intel, Apple, or CPU paths.
-- **GGUF prefill: largely fixed 2026-06-07.** The INT8-IMMA prefill family (#612–#617) puts Qwen3-30B-A3B and Qwen3-14B-Q6_K AHEAD of llama.cpp; Q8_0 dense and gemma-4 sit at 1.20×, Qwen3.6-35B at 1.55× (GDN share is quality-locked). NVFP4 prefill trails vLLM ~1.7× at pp4096 only — imp WINS below ~2k context (see docs/audit/prefill_gap_2026_06_07.md).
+- **GGUF prefill: largely fixed 2026-06-07.** The INT8-IMMA prefill family (#612–#617) puts Qwen3-30B-A3B and Qwen3-14B-Q6_K AHEAD of llama.cpp; Q8_0 dense and gemma-4 sit at 1.20×, Qwen3.6-35B at 1.55× (GDN share is quality-locked). NVFP4 prefill trails vLLM ~1.3× at pp4096 only — imp WINS TTFT everywhere and MoE pp2048 since the chunk-2048 default (2026-06-11; see docs/audit/prefill_gap_2026_06_07.md for the kernel-level decomposition).
 - **MoE/hybrid GGUF decode loses on Qwen3.6-35B** (~−31% vs llama.cpp): an FP16-projection tax on the GDN/attention path that NVFP4 can't address.
 - **Only tested models work reliably.** Anything not on the [supported list](docs/supported-models.md) may load but hasn't been verified.
 - **Prefill numbers are noisy.** cuBLAS autotuning causes up to 2.6× variance across container restarts.

--- a/docs/attention-dispatch.md
+++ b/docs/attention-dispatch.md
@@ -53,7 +53,7 @@ The previously-archived variants (`attention_fmha_sm120_cluster.cu`, `attention_
 
 ### Chunked prefill carve-out (default for most archs)
 
-Per-arch default `prefill_chunk_size = 512` for full-attention models (Qwen3, Llama, Mistral), hybrid GDN+MoE / Mamba2+MoE (Qwen3.5/3.6, Nemotron-H), and Gemma-4. Past chunks' K/V are read from the paged cache via `paged_kv_gather_*` and concatenated with the current chunk; the result then hits the dispatch gate above with `q_offset`-aware causal masking. See `src/exec/executor_attention.cu` chunked-prefill branch, `Engine::resolve_prefill_chunk_size_()`, and the "Chunked prefill scope" entry in `docs/roadmap.md`.
+Per-arch default `prefill_chunk_size = 2048` (512 until 2026-06-11; larger chunks halve/quarter per-chunk weight re-reads — NVFP4-MoE pp4096 +77%) for full-attention models (Qwen3, Llama, Mistral), hybrid GDN+MoE / Mamba2+MoE (Qwen3.5/3.6, Nemotron-H), and Gemma-4. Past chunks' K/V are read from the paged cache via `paged_kv_gather_*` and concatenated with the current chunk; the result then hits the dispatch gate above with `q_offset`-aware causal masking. See `src/exec/executor_attention.cu` chunked-prefill branch, `Engine::resolve_prefill_chunk_size_()`, and the "Chunked prefill scope" entry in `docs/roadmap.md`.
 
 ## Decode — switch on cache_dtype
 

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -92,7 +92,7 @@ ImpConfig imp_config_default(void) {
     config.kv_cache_dtype = IMP_DTYPE_FP16;
     config.ssm_state_dtype = IMP_DTYPE_FP32;
     config.vram_budget_mb = 0;                // use all available
-    config.prefill_chunk_size = -1;           // per-arch default (512 if supported, 0 otherwise)
+    config.prefill_chunk_size = -1;           // per-arch default (2048 if supported, 0 otherwise)
     config.use_fp8_prefill = 0;               // FP16 weight cache by default
     config.use_nvfp4_decode = -1;             // auto (sm_120→mode2, sm_90→mode1)
     config.use_mxfp4_prefill = 0;             // off by default

--- a/src/compute/gemm_cutlass_grouped_3x.cu
+++ b/src/compute/gemm_cutlass_grouped_3x.cu
@@ -606,7 +606,8 @@ bool gemm_grouped_cutlass_3x_nvfp4_device_args(
     if (s_gemm == nullptr)
         s_gemm = new GrpGemm();
 
-    // can_implement memoized per (N, K).
+    // can_implement memoized per (N, K). Uses the M=128 dummy host shapes —
+    // can_implement only checks alignment, which depends on N/K, not M.
     if (N != s_can_impl_N || K != s_can_impl_K) {
         cutlass::Status st = s_gemm->can_implement(arguments);
         if (st != cutlass::Status::kSuccess) {
@@ -618,6 +619,17 @@ bool gemm_grouped_cutlass_3x_nvfp4_device_args(
         s_can_impl_N = N;
         s_can_impl_K = K;
     }
+
+    // Withhold the host shapes from initialize/run: real per-expert M lives
+    // ONLY in d_shapes (device). When host shapes are present the group tile
+    // scheduler sizes its grid from them — the M=128 dummy UNDERSIZED the
+    // tile count, so experts with M_e above the tile height silently lost
+    // their upper row tiles (MoE long-prefill corruption at n ≳ 900, where
+    // hot experts cross the tile boundary; found 2026-06-11). With
+    // host_problem_shapes == nullptr CUTLASS launches the fully persistent
+    // grid (sm_count) and walks the device-side group shapes dynamically —
+    // correct for any routing distribution.
+    arguments.problem_shape.host_problem_shapes = nullptr;
 
     size_t needed = GrpGemm::get_workspace_size(arguments);
     ensure_workspace(needed);

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -517,6 +517,13 @@ private:
     // (dp4a on original quant is fastest). Caller passes both the TensorID
     void gemm_via_handle_(TensorID id, const Tensor& input,
                           Tensor& output, const GemmContext& ctx);
+    // True when an M>1 dispatch of `id` is guaranteed to take the CUTLASS
+    // NVFP4 prefill block in gemm_via_handle_ (which quantizes the input
+    // into the shared activation scratch). Gate for the act-quant-hint
+    // dedupe at the QKV / gate-up call sites — must be CONSERVATIVE: a
+    // false negative just re-quantizes; a false positive would skip with a
+    // stale scratch.
+    bool prefill_routes_cutlass_nvfp4_(TensorID id) const;
     // MoE forward-pass phase helpers. The per-call locals live in the
     // MoeFfnContext struct declared just above the GraphExecutor class.
     void moe_ffn_phase1_setup_(int layer, cudaStream_t stream);

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -503,10 +503,21 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                     // K+V: one batched cuBLAS call
                     gemm_kv_batched(no, *fused_kv, kk, vv, stream);
                 } else {
+                    // NVFP4-CUTLASS prefill QKV reads the SAME normed input
+                    // three times — quantize it into the activation scratch
+                    // once (Q's dispatch) and let K/V skip the re-quantize
+                    // via the act-quant hint. Bit-identical reuse.
+                    GemmContext kv_ctx = ctx;
+                    if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.wq_id) &&
+                        prefill_routes_cutlass_nvfp4_(ly.wk_id) &&
+                        (ly.wv.data == nullptr || prefill_routes_cutlass_nvfp4_(ly.wv_id))) {
+                        kv_ctx = ctx.with_act_quant_hint(no.data, n,
+                                                         static_cast<int>(no.shape[1]));
+                    }
                     gemm_via_handle_(ly.wq_id, no, q_target, ctx);
-                    gemm_via_handle_(ly.wk_id, no, kk, ctx);
+                    gemm_via_handle_(ly.wk_id, no, kk, kv_ctx);
                     if (ly.wv.data != nullptr) {
-                        gemm_via_handle_(ly.wv_id, no, vv, ctx);
+                        gemm_via_handle_(ly.wv_id, no, vv, kv_ctx);
                     }
                     // else: K=V sharing path — vv populated below from kk.
                 }

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -235,8 +235,17 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                     // Batched gate+up: single cuBLAS call for both projections
                     gemm_pair_batched(no, *fused_gu, go, uo, stream);
                 } else {
+                    // NVFP4-CUTLASS prefill gate/up share the normed input —
+                    // gate's dispatch quantizes it into the activation
+                    // scratch, up skips the re-quantize (act-quant hint).
+                    GemmContext up_ctx = ctx;
+                    if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.w_gate_id) &&
+                        prefill_routes_cutlass_nvfp4_(ly.w_up_id)) {
+                        up_ctx = ctx.with_act_quant_hint(no.data, n,
+                                                         static_cast<int>(no.shape[1]));
+                    }
                     gemm_via_handle_(ly.w_gate_id, no, go, ctx);
-                    gemm_via_handle_(ly.w_up_id, no, uo, ctx);
+                    gemm_via_handle_(ly.w_up_id, no, uo, up_ctx);
                 }
             }
         }

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -113,6 +113,34 @@ static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& w
 }
 
 // ---------------------------------------------------------------------------
+// prefill_routes_cutlass_nvfp4_ — conservative mirror of gemm_via_handle_'s
+// M>1 routing: true only when the dispatch is guaranteed to reach the
+// CUTLASS NVFP4 prefill block below (which quantizes the input into the
+// shared activation scratch). Every earlier-return route in gemm_via_handle_
+// must answer false here.
+// ---------------------------------------------------------------------------
+bool GraphExecutor::prefill_routes_cutlass_nvfp4_(TensorID id) const {
+    if (id == kInvalidTensorID)
+        return false;
+    const auto& h = registry_.handle(id);
+    if (h.primary_tier != StorageTier::CUTLASS_NVFP4)
+        return false;
+    StorageTier prefill =
+        (h.prefill_tier != StorageTier::Undefined) ? h.prefill_tier : h.primary_tier;
+    // FP16 / FP8 prefill-cache hits intercept before the CUTLASS block.
+    if (prefill == StorageTier::FP16 && wcache_.fp16.count(h.source_data))
+        return false;
+    if (prefill == StorageTier::FP8 && wcache_.fp8.count(h.source_data))
+        return false;
+    // GGUF source with NVFP4 decode overlay: prefill dequants the original
+    // quant — never reaches the CUTLASS block.
+    if (h.source_data != nullptr && dequant_gpu_supported(h.source_qtype))
+        return false;
+    // The CUTLASS block itself requires the activation scratch.
+    return qscratch_.cutlass_act_data != nullptr && qscratch_.cutlass_act_sf != nullptr;
+}
+
+// ---------------------------------------------------------------------------
 // gemm_via_handle_ — WeightHandle dispatch for all registered weights.
 // M>1 routes through weight_dispatch. M=1 beta=0 routes through gemv_dispatch
 // or tier-specific handlers. M=1 beta!=0 routes through weight_dispatch
@@ -365,6 +393,13 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
             args.cutlass_act_sf = qs->cutlass_act_sf;
             args.cutlass_workspace = qs->cutlass_workspace;
             args.cutlass_workspace_size = qs->cutlass_workspace_size;
+            // Act-quant dedupe: a prior dispatch on this exact input already
+            // quantized it into the activation scratch (QKV / gate-up share
+            // one normed input — see with_act_quant_hint call sites).
+            args.act_prequantized = (ctx.act_quant_hint_data != nullptr &&
+                                     ctx.act_quant_hint_data == input.data &&
+                                     ctx.act_quant_hint_m == M &&
+                                     ctx.act_quant_hint_k == static_cast<int>(input.shape[1]));
             GemmStrategy strat{StorageTier::CUTLASS_NVFP4, QType::F16, false};
             if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;

--- a/src/exec/gemm_context.h
+++ b/src/exec/gemm_context.h
@@ -72,6 +72,25 @@ struct GemmContext {
         c.beta = b;
         return c;
     }
+
+    // Act-quant hint (NVFP4 prefill QKV / gate-up dedupe): the CUTLASS NVFP4
+    // activation scratch already holds quantize(input) for exactly this
+    // (data, M, K) triple — a prior dispatch on the SAME input quantized it.
+    // gemm_via_handle_ forwards the match as args.act_prequantized so the
+    // handler skips its quantize step. Scoped per call site (QKV, gate/up);
+    // never cached across ops — the scratch is clobbered by the next
+    // dispatch on a different input.
+    const void* act_quant_hint_data = nullptr;
+    int act_quant_hint_m = 0;
+    int act_quant_hint_k = 0;
+
+    GemmContext with_act_quant_hint(const void* data, int m, int k) const {
+        GemmContext c = *this;
+        c.act_quant_hint_data = data;
+        c.act_quant_hint_m = m;
+        c.act_quant_hint_k = k;
+        return c;
+    }
 };
 
 }  // namespace imp

--- a/src/exec/gemm_kernel_cutlass_nvfp4.cu
+++ b/src/exec/gemm_kernel_cutlass_nvfp4.cu
@@ -95,8 +95,14 @@ static GemmDispatchResult cutlass_nvfp4_gemm_kernel(const GemmKernelArgs& args) 
 
     // Mirror executor_kernels.cu:2147 + 2179-2181 verbatim — same activation
     // quantization step, same CUTLASS GEMM call, same arg order.
-    quantize_fp16_to_nvfp4_cutlass(args.input->data, args.cutlass_act_data, args.cutlass_act_sf, M, K,
-                                   args.stream);
+    // act_prequantized: the scratch already holds quantize(input) from a
+    // prior dispatch on the same input (QKV / gate-up dedupe) — skip the
+    // re-quantize; the buffer contents are bit-identical by construction.
+    // (mxfp4_payload != nullptr means the dual-cache branch above may have
+    // clobbered the scratch with MXFP4 scale layout — never skip then.)
+    if (!args.act_prequantized || args.mxfp4_payload != nullptr)
+        quantize_fp16_to_nvfp4_cutlass(args.input->data, args.cutlass_act_data, args.cutlass_act_sf, M, K,
+                                       args.stream);
     bool ok = gemm_nvfp4_cutlass_sm120(args.cutlass_act_data, args.cutlass_act_sf, payload,
                                        args.output->data, M, N, K, args.cutlass_workspace,
                                        args.cutlass_workspace_size, args.stream);

--- a/src/exec/gemm_kernel_registry.h
+++ b/src/exec/gemm_kernel_registry.h
@@ -111,6 +111,13 @@ struct GemmKernelArgs {
     void* q8_1_buf = nullptr;
     float* d8_buf = nullptr;
 
+    // Act-quant dedupe (CUTLASS_NVFP4 prefill): cutlass_act_data/_sf already
+    // hold the quantized form of `input` (a prior dispatch on the same input
+    // quantized it). The handler skips quantize_fp16_to_nvfp4_cutlass. Set
+    // by gemm_via_handle_ when the GemmContext act-quant hint matches the
+    // (input.data, M, K) of this call.
+    bool act_prequantized = false;
+
     // Per-model gemma4.force_mmvq override (Phase 5 Track A). Used by the
     // GGUF small-M kernels to decide between the mmvq and dp4a backends.
     // Sourced from ModelConfig::Overrides::Gemma4::force_mmvq via GemmContext.

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -65,7 +65,7 @@ struct EngineConfig {
     int kv_block_size = 0;
 
     // Chunked prefill
-    int prefill_chunk_size = -1;  // -1 = per-arch default (512 if supported, 0 otherwise)
+    int prefill_chunk_size = -1;  // -1 = per-arch default (2048 if supported, 0 otherwise)
 
     // FP8 prefill weight cache: uses FP8 E4M3 instead of FP16 for ~2x prefill throughput
     bool use_fp8_prefill = false;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -252,7 +252,16 @@ bool Engine::supports_chunked_prefill_() const {
 int Engine::resolve_prefill_chunk_size_() const {
     int explicit_val = config_.prefill_chunk_size;
     if (explicit_val < 0) {
-        return supports_chunked_prefill_() ? 512 : 0;
+        // Default 2048 (was 512 until 2026-06-11). Chunked prefill re-reads
+        // every weight once per chunk, so the memory-bound GEMMs pay the
+        // weight traffic per chunk: at pp4096, 512-token chunks cost
+        // NVFP4-MoE −43% prefill vs 2048 (14.8k -> 26.2k tok/s) and dense
+        // −19% at pp2048 (17.6k -> 21.7k). chunk=0 measured equal to 2048,
+        // so 2048 is the sweet spot that still bounds workspace VRAM and
+        // multi-request interleaving latency. Hybrids stay safe: step_prefill
+        // clamps to executor max_tokens (256/512), and step_prefill_one
+        // clamps n × ctx_len into the attn-scores capacity.
+        return supports_chunked_prefill_() ? 2048 : 0;
     }
     if (explicit_val == 0)
         return 0;
@@ -343,7 +352,7 @@ void Engine::step_prefill(cudaStream_t stream) {
     // Hard cap: chunk size must never exceed the executor's max_tokens
     // (which is itself capped to 256 for SSM/GDN+MoE hybrids and 512 for
     // dense GDN to bound workspace VRAM). Without this clamp, a server-side
-    // prefill_chunk_size default of 512 (handlers.cpp) overflows the
+    // prefill_chunk_size default (handlers.cpp) would overflow the
     // workspace and crashes with `n_tokens (X) exceeds max_tokens (Y)` →
     // `terminate: reshape: numel mismatch` on long prompts to e.g. Qwen3.6.
     if (effective_chunk > executor_->max_tokens()) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -31,7 +31,7 @@ struct ServerArgs {
     bool kv_turboquant = false;      // [DEPRECATED] alias for kv_mxfp4
     bool kv_turboquant_lite = false; // [DEPRECATED] alias for kv_mxfp4
     int turboquant_sketch_mult = 2;  // [DEPRECATED] ignored
-    int prefill_chunk_size = -1;  // -1 = per-arch default (512 if supported, 0 otherwise)
+    int prefill_chunk_size = -1;  // -1 = per-arch default (2048 if supported, 0 otherwise)
     int decode_nvfp4 = -1;                      // -1=auto, 0=off, 1=additive, 2=NVFP4-only
     bool mxfp4_prefill = false;                 // --mxfp4-prefill: CUTLASS MXFP4 GEMM for prefill
     bool dual_path_quant = false;               // --dual-path-quant: FP8 attention + NVFP4 FFN


### PR DESCRIPTION
## Summary

Three changes that together move NVFP4 prefill to a new competitive standing (and fix a silent-corruption bug they would otherwise expose):

1. **fix(moe): grouped device-args GEMM silently dropped tiles for experts with M above the tile height.** The device-args grouped NVFP4 GEMM passed dummy host problem shapes (`M=128` per expert) to CUTLASS; the group tile scheduler sizes its launch grid from host shapes when present, so experts whose real per-expert M crossed the tile boundary lost their upper row tiles — no error, garbage output rows. Visible from n ≈ 900 prompt tokens on Qwen3-30B-A3B (top-k 8 / 128 experts); the old 512-token chunk default masked it entirely. **Pre-existing** (reproduced on images back to 06-04). Fix: withhold host shapes from initialize/run (`host_problem_shapes = nullptr`) after the memoized `can_implement` (alignment only needs N/K) — CUTLASS then launches the fully persistent grid and walks the device-resident group shapes dynamically. Teacher-forced PPL on a 5.8k repeated-text corpus: **22278 → 2.25** (single chunk), 10508 → 2.23 (chunk 1024). The host-args variant already passed real M and was unaffected.

2. **perf(prefill): default `prefill_chunk_size` 512 → 2048.** Chunked prefill re-reads every weight once per chunk, so the memory-bound (grouped-)GEMMs pay weight traffic × chunk count; larger chunks also 4× per-expert M in the grouped GEMM. chunk=0 measured equal to 2048 → 2048 is the sweet spot that still bounds workspace VRAM and interleaving latency. Existing guards (executor max_tokens clamp for hybrids, attn-scores s_cap clamp, KV-block floor) cover the rest.

3. **perf(nvfp4): act-quant dedupe.** Q/K/V re-quantized the same normed input 3×, gate/up 2× (7 quantize launches per layer where 4 suffice). Call sites set an act-quant hint on `GemmContext` when the whole group routes to the CUTLASS NVFP4 prefill block (`prefill_routes_cutlass_nvfp4_`, a conservative routing mirror); the handler skips the re-quantize. Bit-identical by construction — PPL unchanged to the last digit at fixed chunk size.

## Measured (RTX 5090, 10 reps, healthy clocks, fixed build)

| Model | pp512 | pp2048 | pp4096 | tg256 |
|---|---|---|---|---|
| Qwen3-14B-NVFP4 | 19.6k | **25.6k** (was 17.6k, +45%) | **19.1k** (was 15.7k, +22%) | 168 |
| Qwen3-30B-A3B-NVFP4 | 20.3k | **39.8k** (was 15.7k, **+153%**) | **27.2k** (was 14.8k, +84%) | 323 |

vs vLLM 0.22.1 FlashInfer-NVFP4 (same day/host, max_num_seqs=1, prefix cache off, median of 5): imp now wins **TTFT everywhere** (2.3–3.3×), **decode everywhere** (+35–40%), **MoE pp2048** (39.8k vs 34.5k), ties dense pp2048 (25.6k vs 26.6k); vLLM keeps pp4096 (1.32–1.33×, attention-bound).

Note on intentional perf movement: prefill moves up far beyond the 5% gate; `tests/perf_baseline.json` gates pp512/tg128 which are essentially unaffected (≤512-token prompts run one chunk either way; decode untouched), so no baseline refresh is needed.

## Also in this PR

4. **perf(attn): fa2_f16acc default on.** Full-rate f16-accumulate QK^T in the FA2 prefill kernel: pp4096 +4.7-5.0% on both heroes, decode neutral. Quality gate: 14B PPL identical, 30B +0.10%, Q8 GGUF +0.013% (5.8k teacher-forced corpus); FMHA/FA2 parity suites 71/71 green with the new default.

## Verification

- Full GPU suite green (0 failures) + `verify-fast` OK on the final build.
- Teacher-forced PPL across chunk {512, 1024, 2048, 0}: 2.2326–2.2462 (MoE), 2.1737 (14B) — consistent; pre-fix the same matrix read 569–22278 for chunk >896.
- Long-prompt (5.8k tokens) greedy coherence on both models at the new default, stderr clean (no fallback/NaN), multi-chunk boundary crossed.
- Dedupe bit-identity: PPL identical to pre-change build at fixed chunk 512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)