### PR TITLE
perf(attn): fa2_f16acc default on — full-rate QK^T accumulate in the FA2 prefill kernel

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -81,9 +81,10 @@ fmha_fa2             = "on"
 fa2_fp16qk           = "on"
 # f16-accumulate QK^T in the fp16-qk FA2 kernel (#597). GeForce sm_120 runs
 # f16-src/f32-acc HMMA at 1/4 rate (#606); f16-acc lifts the score MMA to the
-# full-rate class: +3-4% pp2048/pp4096 NVFP4 prefill (Qwen3-14B) for +0.37% PPL.
-# Opt-in quality tradeoff (default false); only the fa2_fp16qk path is affected.
-fa2_f16acc           = false
+# full-rate class: +4.7-5.0% pp4096 NVFP4 prefill (Qwen3-14B / 30B-A3B). PPL
+# on a 5.8k teacher-forced corpus: 14B identical, 30B +0.10%, Q8 +0.013%.
+# Default true since 2026-06-11; set false to restore f32 accumulate.
+fa2_f16acc           = true
 # Prefill chunk length (tokens) at/above which attention routes to FMHA
 # (tiled, O(n) memory) instead of the materialized cuBLAS S-matrix path.
 # -1 = auto (derived from the cuBLAS S-matrix VRAM cap).

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -122,12 +122,15 @@ struct RuntimeConfig {
         std::string fa2_fp16qk = "on";
         // f16-accumulate QK^T in the FP16-QK FA2 kernel (#597). GeForce sm_120
         // runs f16-src/f32-acc HMMA at 1/4 rate (#606); accumulating the score
-        // MMA in f16 lifts it to the full-rate class. Measured +3-4% pp2048/
-        // pp4096 NVFP4 prefill (Qwen3-14B) for +0.37% PPL — a quality tradeoff
-        // (scores are softmaxed immediately, so the reduced accumulate precision
-        // is low-risk). Opt-in (default off); only affects the fa2_fp16qk path,
+        // MMA in f16 lifts it to the full-rate class. Measured +4.7-5.0%
+        // pp4096 NVFP4 prefill (Qwen3-14B / 30B-A3B, 2026-06-11, chunk-2048
+        // era), decode neutral. Quality gate on a 5.8k teacher-forced corpus:
+        // 14B-NVFP4 PPL identical, 30B-A3B +0.10%, Q8_0 GGUF +0.013% —
+        // scores are softmaxed immediately, so the reduced accumulate
+        // precision stays in the noise. Default ON since 2026-06-11; set
+        // false to restore f32 accumulate. Only affects the fa2_fp16qk path,
         // the fp8-QK path keeps f32 accumulate. Env: IMP_FA2_F16ACC.
-        bool fa2_f16acc = false;
+        bool fa2_f16acc = true;
         std::string mxfp4 = "auto";
         bool mxfp4_fp16_fallback = false;
         // MXFP4 → FP16 cache pruning policy. "legacy" (default) caches FP16


### PR DESCRIPTION
## Summary

Follow-up to #672 (the commit raced auto-merge and missed the squash). Flips `attention.fa2_f16acc` to default ON: GeForce sm_120 quarters f16-src/f32-acc HMMA (#606); accumulating the QK^T score MMA in f16 lifts it to the full-rate class.

## Measured (chunk-2048 era, 10 reps, paired restarts; decode neutral)

- Qwen3-14B-NVFP4 pp4096: 19.1k → **19.9k (+4.7%)**
- Qwen3-30B-A3B-NVFP4 pp4096: 27.6k → **28.9k (+5.0%)**

## Quality gate (5.8k-token teacher-forced corpus)

- 14B-NVFP4: PPL **identical** (2.1737)
- 30B-A3B: +0.10% (2.2334 → 2.2356)
- Qwen3-8B Q8_0 GGUF: +0.013% (2.2382 → 2.2385)

Well inside the band already accepted for `nvfp4_lm_head_gdn` (+2.2%, #483); scores are softmaxed immediately, so the reduced accumulate precision stays in the noise. FMHA/FA2 parity suites green with the new default (71/71, 1 unrelated skip). Set `attention.fa2_f16acc=false` to restore f32 accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)