### PR TITLE
perf(vram): free duplicated per-expert micro-scales on the NVFP4 MoE borrow path (−1728 MiB on 30B-A3B)

### DIFF
--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -1563,6 +1563,10 @@ void QuantPipeline::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         wcache_->nvfp4_moe_bytes = dctx.nvfp4_moe_total;
         IMP_LOG_INFO("NVFP4 MoE cache: %d tensors, %.2f MiB", dctx.nvfp4_moe_count,
                      dctx.nvfp4_moe_total / (1024.0 * 1024.0));
+        if (dctx.nvfp4_moe_ms_freed > 0)
+            IMP_LOG_INFO("NVFP4 MoE cache: freed %.2f MiB duplicated per-expert micro-scales "
+                         "(contiguous ms_ref copies are now the single source)",
+                         dctx.nvfp4_moe_ms_freed / (1024.0 * 1024.0));
     } else if (wcache_->nvfp4.empty()) {
         IMP_LOG_INFO("NVFP4 decode: no eligible weights found (all ≤ 4.5 bits/elem)");
     }
@@ -1657,6 +1661,41 @@ bool QuantPipeline::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
                         packed = Tensor(experts[0].data, QType::NVFP4, 3, shp, /*on_device=*/true);
                         wcache_->nvfp4_moe[experts[0].data] = r;
                         dctx.nvfp4_moe_count++;
+                        // The contiguous micro-scale copy is now the single
+                        // source for every consumer (decode cache via
+                        // r.micro_scales; CUTLASS prefill reads its own
+                        // Phase-0 SfAtom buffers, never the raw scales; the
+                        // Phase-4 registry snapshot runs after this and
+                        // picks up re-stamped pointers). Free the scattered
+                        // per-expert source scales — they were resident
+                        // TWICE, ~1.7 GiB across 144 groups on
+                        // Qwen3-30B-A3B-NVFP4 — and re-stamp the layer
+                        // tensors + per-expert nvfp4 wcache entries onto
+                        // the copy slices. Mirrors the non-borrow branch's
+                        // free-after-copy below.
+                        if (d_ms_copy) {
+                            IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+                            auto* mut_model = const_cast<Model*>(model_);
+                            size_t freed = 0;
+                            for (int e = 0; e < ne_z; ++e) {
+                                auto& w = experts[e];
+                                void* old_sc = w.scales;
+                                void* new_sc = static_cast<char*>(d_ms_copy) +
+                                               static_cast<size_t>(e) * e_ms;
+                                if (old_sc && mut_model->is_base_gpu_allocation(old_sc)) {
+                                    mut_model->release_gpu_allocation(old_sc);
+                                    IMP_CUDA_CHECK_LOG(cudaFree(old_sc));
+                                    freed += e_ms;
+                                }
+                                w.scales = new_sc;
+                                auto nit = wcache_->nvfp4.find(w.data);
+                                if (nit != wcache_->nvfp4.end() &&
+                                    nit->second.micro_scales == old_sc)
+                                    nit->second.micro_scales = new_sc;
+                            }
+                            if (freed)
+                                dctx.nvfp4_moe_ms_freed += freed;
+                        }
                         IMP_LOG_INFO("NVFP4 MoE native: data-borrow decode cache (ne=%d N=%lld K=%lld, "
                                      "scales_contig=%d; gemv_nvfp4_moe fast decode)",
                                      ne_z, (long long)N_z, (long long)K_z, (int)scales_contig);

--- a/src/exec/quant_pipeline.h
+++ b/src/exec/quant_pipeline.h
@@ -38,6 +38,7 @@ struct Nvfp4DecodeContext {
     size_t moe_budget = 0;              // initialised before the MoE-cache phase
     int    nvfp4_moe_count = 0;         // populated by the MoE-cache phase
     size_t nvfp4_moe_total = 0;
+    size_t nvfp4_moe_ms_freed = 0;      // duplicated per-expert micro-scales freed (borrow path)
     // Shared VRAM safety reserve for mode 2 paths (dense incremental,
     // CUTLASS NVFP4, MoE expert caching). Computed once at the top of
     // pre_dequant_phase3_nvfp4_decode_() from the model's actual attention


### PR DESCRIPTION
Second tranche of the VRAM audit (first: #678). The NVFP4 MoE data-borrow decode cache copies non-contiguous per-expert micro-scales into a contiguous `ms_ref` buffer and left the scattered originals resident — **the micro-scales existed twice: 1 728 MiB on Qwen3-30B-A3B-NVFP4** (144 groups, 48 layers × 3 projections).

The copy becomes the single source: decode reads `r.micro_scales`, CUTLASS prefill reads its own Phase-0 SfAtom buffers (never the raw scales), and the Phase-4 registry snapshot runs after Phase 3 so it captures the re-stamped pointers. The change mirrors the non-borrow branch's existing free-after-copy pattern (sync → `release_gpu_allocation` + `cudaFree` of base allocations only → re-stamp layer tensors + per-expert `nvfp4` wcache entries onto copy slices).

## Validation (RTX 5090, Qwen3-30B-A3B-NVFP4)

- `NVFP4 MoE cache: freed 1728.00 MiB duplicated per-expert micro-scales` fires at init
- teacher-forced PPL **6.3871** (14.8k-token corpus) — exactly the known reading
- pp512 **20 911** tok/s, tg **323.9** tok/s — hero baseline
- clean teardown (no double-free; allocations released from the model's tracking before `cudaFree`)
- load-time peak drops by the same ~1.7 GiB (frees are per-group; transient overhead is one group's ~12 MiB)

Known limitation, noted in the commit: the KV cache is sized before Phase 3 runs, so the reclaimed memory shows up as runtime headroom rather than automatic KV growth — teaching the VRAM budget heuristic to credit the projected dedup is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)