### PR TITLE
feat(attn): amax-scaled e4m3 conversion for the fp8-QK FA2 path (#680, opt-in)

### DIFF
--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -591,6 +591,37 @@ __device__ __forceinline__ uint32_t cvt_4xfp16_to_4xe4m3(const half* src) {
     return result;
 }
 
+// Scaled variant (#680 fp8-QK campaign): multiply by 1/s before the convert so
+// the operand uses the full e4m3 dynamic range. The raw (unscaled) conversion
+// is the #511 quality cliff — ~10% relative score error on real activations.
+__device__ __forceinline__ uint32_t cvt_4xfp16_to_4xe4m3_scaled(const half* src, __half2 inv_s) {
+    uint32_t result;
+    uint16_t lo, hi;
+    const __half2* s2 = reinterpret_cast<const __half2*>(src);
+    __half2 a = __hmul2(s2[0], inv_s);
+    __half2 b = __hmul2(s2[1], inv_s);
+    asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(lo)
+                 : "r"(*reinterpret_cast<uint32_t*>(&a)));
+    asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(hi)
+                 : "r"(*reinterpret_cast<uint32_t*>(&b)));
+    result = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 16);
+    return result;
+}
+
+// Grid-stride |x| max over a contiguous fp16 buffer (Q or gathered K of one
+// chunk — small next to the attention itself). Caller zeroes `amax` first.
+__global__ void fa2_amax_fp16_kernel(const half* __restrict__ x, int64_t n, float* __restrict__ amax) {
+    float m = 0.f;
+    for (int64_t i = blockIdx.x * (int64_t)blockDim.x + threadIdx.x; i < n;
+         i += (int64_t)gridDim.x * blockDim.x)
+        m = fmaxf(m, fabsf(__half2float(x[i])));
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1)
+        m = fmaxf(m, __shfl_xor_sync(0xFFFFFFFF, m, off));
+    if ((threadIdx.x & 31) == 0)
+        atomicMax(reinterpret_cast<unsigned int*>(amax), __float_as_uint(m));
+}
+
 template <int Bq, int HD>
 __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 1) fmha_sm120_fp8_kernel(
     const half* __restrict__ Q, const half* __restrict__ K, const half* __restrict__ V, half* __restrict__ O,
@@ -1238,12 +1269,17 @@ __device__ __forceinline__ void prefetch_v_tile(half* V_dst, const half* V_ptr, 
 // from the 1/4-rate f32-acc class to full rate AND halves the O-fragment
 // register footprint (N_O*4 floats -> N_O*2 b32), the dominant per-thread
 // register cost of the Bq=128 band. Requires FP16QK.
+// FP8SCALED (#680): amax-scaled e4m3 conversion for the fp8-QK path. Q and K
+// convert as x*(448/amax) (full e4m3 range, no saturation/mantissa cliff) and
+// the score scale absorbs (amax_q*amax_k/448^2). d_amax = device floats
+// {amax_q, amax_k} produced by fa2_amax_fp16_kernel just before launch.
 template <int Bq, int HD, bool FP16QK = false, bool F16ACC = false, int BKV = 64, bool TWOSLOT = false,
-          bool PVF16 = false>
+          bool PVF16 = false, bool FP8SCALED = false>
 __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __restrict__ K,
                                       const half* __restrict__ V, half* __restrict__ O, int batch_size,
                                       int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale,
-                                      bool causal, int sliding_window, float softcap, int q_offset) {
+                                      bool causal, int sliding_window, float softcap, int q_offset,
+                                      const float* __restrict__ d_amax = nullptr) {
     constexpr int Bkv = BKV;
     static_assert(BKV % 16 == 0 && (BKV / 8) % 2 == 0, "QK n-pair loop and PV K-groups need BKV % 16 == 0");
     constexpr int head_dim = HD;
@@ -1301,6 +1337,24 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
     // exactly once per CTA, and dropping the staging tile frees enough smem
     // for the 8-warp Bq=128 config: the kernel is latency-bound at 4 warps,
     // 1 warp/scheduler). ----
+    // FP8SCALED operand scales (uniform per-thread loads; amax==0 -> identity).
+    float fp8_sq = 1.0f, fp8_sk = 1.0f;
+    __half2 fp8_inv_sq2 = __float2half2_rn(1.0f);
+    __half2 fp8_inv_sk2 = __float2half2_rn(1.0f);
+    if constexpr (FP8SCALED) {
+        const float aq = d_amax ? d_amax[0] : 0.0f;
+        const float ak = d_amax ? d_amax[1] : 0.0f;
+        if (aq > 0.0f) {
+            fp8_sq = aq / 448.0f;
+            fp8_inv_sq2 = __float2half2_rn(448.0f / aq);
+        }
+        if (ak > 0.0f) {
+            fp8_sk = ak / 448.0f;
+            fp8_inv_sk2 = __float2half2_rn(448.0f / ak);
+        }
+    }
+    (void)fp8_sq;
+    (void)fp8_sk;
     if constexpr (!FP16QK) {
         const int total_vec4 = (Bq * head_dim) / 4;
         for (int vi = tid; vi < total_vec4; vi += NTHREADS) {
@@ -1310,6 +1364,8 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
             uint32_t* dst = reinterpret_cast<uint32_t*>(Q_fp8 + r * QSTRIDE + d);
             if (q_start + r >= seq_q) {
                 *dst = 0;
+            } else if constexpr (FP8SCALED) {
+                *dst = cvt_4xfp16_to_4xe4m3_scaled(&Q_ptr[(int64_t)r * q_row_stride + d], fp8_inv_sq2);
             } else {
                 *dst = cvt_4xfp16_to_4xe4m3(&Q_ptr[(int64_t)r * q_row_stride + d]);
             }
@@ -1520,8 +1576,14 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
                     uint32_t a2 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl * 2);
                     uint32_t a3 = *reinterpret_cast<const uint32_t*>(qb + (rl + 8) * QSTRIDE + cl * 2 + 16);
                     const half* kb = K_cur + n * 8 * KVSTRIDE + k * 32;
-                    uint32_t b0 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2);
-                    uint32_t b1 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2 + 16);
+                    uint32_t b0, b1;
+                    if constexpr (FP8SCALED) {
+                        b0 = cvt_4xfp16_to_4xe4m3_scaled(kb + rl * KVSTRIDE + cl * 2, fp8_inv_sk2);
+                        b1 = cvt_4xfp16_to_4xe4m3_scaled(kb + rl * KVSTRIDE + cl * 2 + 16, fp8_inv_sk2);
+                    } else {
+                        b0 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2);
+                        b1 = cvt_4xfp16_to_4xe4m3(kb + rl * KVSTRIDE + cl * 2 + 16);
+                    }
 #if __CUDA_ARCH__ >= 1200
                     asm volatile(
                         "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
@@ -1567,6 +1629,8 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
                 int lq = lqA + ((e < 2) ? 0 : 8);
                 float v = S[n][e];
                 if (lq < seq_q && col < seq_kv) {
+                    if constexpr (FP8SCALED)
+                        v *= fp8_sq * fp8_sk;
                     v *= scale;
                     if (softcap > 0.0f)
                         v = softcap * tanhf(v / softcap);
@@ -1794,6 +1858,7 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
     const bool pv_f16 = f16acc && imp::process_diag_fa2_pv_f16acc();
     int Bq, Bkv;
     bool twoslot = false;
+    bool fp8_scaled = false;
     decltype(&fmha_sm120_fa2_kernel<128, 128>) kern;
     if (fp16_qk) {
         if (blocks_128 >= (long)sm_count) {
@@ -1821,7 +1886,15 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
         const bool use_bq64 = blocks_128 < (long)sm_count;
         Bq = use_bq64 ? 64 : 128;
         Bkv = 64;
-        kern = use_bq64 ? fmha_sm120_fa2_kernel<64, 128> : fmha_sm120_fa2_kernel<128, 128>;
+        // #680 fp8-QK campaign: amax-scaled e4m3 conversion (the raw variant
+        // is the #511 quality cliff and stays the default for A/B).
+        if (imp::process_diag_fp8_qk_scaled()) {
+            fp8_scaled = true;
+            kern = use_bq64 ? fmha_sm120_fa2_kernel<64, 128, false, false, 64, false, false, true>
+                            : fmha_sm120_fa2_kernel<128, 128, false, false, 64, false, false, true>;
+        } else {
+            kern = use_bq64 ? fmha_sm120_fa2_kernel<64, 128> : fmha_sm120_fa2_kernel<128, 128>;
+        }
     }
 
     const size_t smem = compute_smem_fa2(Bq, head_dim, fp16_qk, Bkv, twoslot);
@@ -1845,11 +1918,30 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
             Bq, Bkv, fp16_qk ? "f16" : "e4m3", f16acc ? "f16" : "f32", pv_f16 ? "f16" : "f32",
             twoslot ? "twoslot" : "dbuf", smem, seq_q, seq_kv);
     }
+    // FP8SCALED: per-chunk operand amaxes for Q and the gathered K (two tiny
+    // grid-stride passes; persistent 2-float buffer, process lifetime).
+    static float* s_d_amax = nullptr;
+    if (fp8_scaled) {
+        if (!s_d_amax && cudaMalloc(&s_d_amax, 2 * sizeof(float)) != cudaSuccess) {
+            s_d_amax = nullptr;
+            fp8_scaled = false;  // fall back to raw conversion this call
+        }
+        if (s_d_amax) {
+            cudaMemsetAsync(s_d_amax, 0, 2 * sizeof(float), stream);
+            const int64_t qn = (int64_t)batch_size * seq_q * n_heads * head_dim;
+            const int64_t kn = (int64_t)batch_size * seq_kv * n_kv_heads * head_dim;
+            fa2_amax_fp16_kernel<<<128, 256, 0, stream>>>(reinterpret_cast<const half*>(Q.data), qn,
+                                                          s_d_amax);
+            fa2_amax_fp16_kernel<<<128, 256, 0, stream>>>(reinterpret_cast<const half*>(K.data), kn,
+                                                          s_d_amax + 1);
+        }
+    }
     kern<<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),
                                         reinterpret_cast<const half*>(K.data),
                                         reinterpret_cast<const half*>(V.data),
                                         reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv, n_heads,
-                                        n_kv_heads, scale, causal, sliding_window, softcap, q_offset);
+                                        n_kv_heads, scale, causal, sliding_window, softcap, q_offset,
+                                        fp8_scaled ? s_d_amax : nullptr);
     return true;
 }
 

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -134,6 +134,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("attention.fa2_fp16qk", cfg.attention.fa2_fp16qk);
     B("attention.fa2_f16acc", cfg.attention.fa2_f16acc);
     B("attention.fa2_pv_f16acc", cfg.attention.fa2_pv_f16acc);
+    B("attention.fp8_qk_scaled", cfg.attention.fp8_qk_scaled);
     I("attention.fmha_prefill_threshold", cfg.attention.fmha_prefill_threshold);
     I("attention.attn_scores_mib", cfg.attention.attn_scores_mib);
     S("attention.mxfp4", cfg.attention.mxfp4);
@@ -324,6 +325,11 @@ void seed_from_env(RuntimeConfig& cfg) {
     // PV MMA in f16 (full-rate HMMA + halved O-fragment registers).
     if (const char* e = std::getenv("IMP_FA2_PV_F16ACC"))
         cfg.attention.fa2_pv_f16acc = (std::atoi(e) != 0);
+
+    // attention.fp8_qk_scaled — IMP_FP8_QK_SCALED: '1' enables amax-scaled
+    // e4m3 conversion in the fp8-QK FA2 path (#680).
+    if (const char* e = std::getenv("IMP_FP8_QK_SCALED"))
+        cfg.attention.fp8_qk_scaled = (std::atoi(e) != 0);
 
     // moe.nvfp4_smallM — IMP_NVFP4_SMALLM: integer != 0 enables.
     if (const char* e = std::getenv("IMP_NVFP4_SMALLM"))

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -143,6 +143,12 @@ struct RuntimeConfig {
         // 2026-06-11; set false to restore f32 PV accumulate. Requires
         // fa2_f16acc. Env: IMP_FA2_PV_F16ACC.
         bool fa2_pv_f16acc = true;
+        // amax-scaled e4m3 conversion for the fp8-QK FA2 path (#680). The
+        // raw conversion is the #511 quality cliff; scaling Q and K to the
+        // full e4m3 range is the numerics class FlashInfer runs. Only
+        // takes effect on the fp8-QK path (fa2_fp16qk=never or declined).
+        // Experimental quality probe. Env: IMP_FP8_QK_SCALED.
+        bool fp8_qk_scaled = false;
         std::string mxfp4 = "auto";
         bool mxfp4_fp16_fallback = false;
         // MXFP4 → FP16 cache pruning policy. "legacy" (default) caches FP16

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -31,6 +31,7 @@ struct ProcessDiag {
     bool attention_splitk_pipe = true;
     bool attention_fa2_f16acc = false;
     bool attention_fa2_pv_f16acc = false;
+    bool attention_fp8_qk_scaled = false;
     std::string attention_mxfp4_mode = "auto";
 
     // FFN
@@ -79,6 +80,7 @@ void process_diag_install(const RuntimeConfig& cfg) {
     d.attention_splitk_pipe = cfg.attention.splitk_pipe;
     d.attention_fa2_f16acc = cfg.attention.fa2_f16acc;
     d.attention_fa2_pv_f16acc = cfg.attention.fa2_pv_f16acc;
+    d.attention_fp8_qk_scaled = cfg.attention.fp8_qk_scaled;
     d.attention_mxfp4_mode = cfg.attention.mxfp4;
     d.ffn_sparsity_probe = cfg.ffn.sparsity_probe;
     d.moe_mr_nr = cfg.moe.mr_nr;
@@ -113,6 +115,8 @@ bool process_diag_fa2_f16acc() { return slot().attention_fa2_f16acc; }
 bool process_diag_fa2_pv_f16acc() { return slot().attention_fa2_pv_f16acc; }
 void process_diag_set_fa2_f16acc(bool v) { slot().attention_fa2_f16acc = v; }
 void process_diag_set_fa2_pv_f16acc(bool v) { slot().attention_fa2_pv_f16acc = v; }
+bool process_diag_fp8_qk_scaled() { return slot().attention_fp8_qk_scaled; }
+void process_diag_set_fp8_qk_scaled(bool v) { slot().attention_fp8_qk_scaled = v; }
 const std::string& process_diag_attention_mxfp4_mode() { return slot().attention_mxfp4_mode; }
 bool process_diag_ffn_sparsity_probe() { return slot().ffn_sparsity_probe; }
 int process_diag_moe_mr_nr() { return slot().moe_mr_nr; }

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -63,6 +63,8 @@ bool process_diag_fa2_pv_f16acc();  // f16-accumulate the PV MMA too (#667 follo
 // test hooks (mirror process_diag_set_cublas_fp16_acc)
 void process_diag_set_fa2_f16acc(bool v);
 void process_diag_set_fa2_pv_f16acc(bool v);
+bool process_diag_fp8_qk_scaled();  // amax-scaled e4m3 fp8-QK (#680)
+void process_diag_set_fp8_qk_scaled(bool v);
 // "auto" | "always" | "never" (default "auto"); attention_mxfp4_available()
 // only enables MXFP4 attention when mode == "always".
 const std::string& process_diag_attention_mxfp4_mode();

--- a/tests/test_fmha_fp8.cu
+++ b/tests/test_fmha_fp8.cu
@@ -452,5 +452,26 @@ TEST_F(FmhaFA2PvF16Test, Chunked_GQA3_OddKv) {
 TEST_F(FmhaFA2PvF16Test, Bkv32Band_CausalMultiTile) { run_pv(1, 384, 384, 32, 8, 128, true); }
 TEST_F(FmhaFA2PvF16Test, Bq128Band_LongCtx) { run_pv(1, 768, 768, 32, 8, 128, true); }
 
+// --- amax-scaled fp8-QK (attention.fp8_qk_scaled, #680) ---
+// The raw e4m3 conversion loses mantissa bits at realistic Q/K magnitudes
+// (#511); the scaled variant must hold a much tighter bound exactly there.
+class FmhaFA2Fp8ScaledTest : public FmhaFA2Test {
+protected:
+    void run_scaled(int B, int Sq, int Skv, int NH, int NKV, int HD, bool causal, float amp,
+                    int q_offset = 0) {
+        process_diag_set_fp8_qk_scaled(true);
+        run_fa2(B, Sq, Skv, NH, NKV, HD, causal, 0, 0.0f, amp, /*fp16_qk=*/false, q_offset,
+                /*tol_override=*/0.02f);
+        process_diag_set_fp8_qk_scaled(false);
+    }
+};
+
+TEST_F(FmhaFA2Fp8ScaledTest, Causal) { run_scaled(1, 64, 64, 4, 4, 128, true, 1.0f); }
+TEST_F(FmhaFA2Fp8ScaledTest, RealisticMagnitude) { run_scaled(1, 64, 64, 4, 4, 128, true, 80.0f); }
+TEST_F(FmhaFA2Fp8ScaledTest, RealisticMagnitude_GQA) {
+    run_scaled(1, 136, 136, 32, 8, 128, true, 80.0f);
+}
+TEST_F(FmhaFA2Fp8ScaledTest, Chunked) { run_scaled(1, 64, 512, 24, 8, 128, true, 80.0f, 448); }
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
First slice of the #680 fp8-QK campaign — the quality-feasibility probe.

**Premise:** the fp8-QK FA2 path has the 2× QK MMA density (`m16n8k32.e4m3`) that vLLM/FlashInfer leverage on this hardware, but imp's variant was quality-refuted (#511/#656) because it converts Q/K to e4m3 **raw** — ~10% relative score error on real activations. This adds the amax-scaled conversion (operands use the full e4m3 range; `amax_q·amax_k/448²` folds into the score scale) behind `attention.fp8_qk_scaled` (default **off**, env `IMP_FP8_QK_SCALED`).

**Evidence (unit level):** `FmhaFA2Fp8ScaledTest` 4/4 — the scaled path holds a **2% relative bound at amplitude=80**, the realistic-magnitude regime where the raw conversion has ~2 mantissa bits (raw only ever passed a 5% bound on tiny ±0.12 synthetic values). All 64 attention tests green; every non-FP8SCALED instantiation is template-identical to main.

**Scope guard:** not yet wired into production dispatch — since #656 the fp8 family is deliberately unreachable in default configs (fa2_fp16qk serves hd=128 everywhere; my chunked-PPL probes confirmed the kernel logs `qk=f16` even with `fa2_fp16qk=never`, the chunk path falls to cuBLAS instead). The next slice routes chunked prefill through the scaled kernel behind the knob and collects teacher-forced PPL + pp4096 perf — where the density win would close the remaining 1.19×/1.27× vs vLLM.

Cost when off: none (template-separated). Cost when on: two tiny grid-stride amax passes per chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)