### PR TITLE
fix(kv): scope the FP8-KV deterministic forcing to non-FA2 configs (−35% pp4096 tax removed)

### DIFF
--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -77,7 +77,26 @@ void Engine::init_resolve_kv_dtype_policy_() {
         }
     }
 
-    if (config_.kv_cache_dtype == QType::FP8_E4M3 &&
+    // Scope (2026-06-12, #680 diagnosis): the deterministic forcing below is
+    // a PR-#52-era (April) workaround for NaNs in the cuBLAS-attention + FP8
+    // round-trip — it predates the FA2 default-on stack (#478/#548). When the
+    // f16-QK FA2 chain serves every attention call (hd=128, fa2 enabled),
+    // cuBLAS attention never touches the FP8 KV and the forcing only drags in
+    // the single-block deterministic MoE permute (measured: the entire −35%
+    // pp4096 regression of --kv-fp8 on Qwen3-30B-A3B was that one kernel;
+    // without it kv-fp8 is perf-neutral-to-positive at clean PPL on
+    // Qwen3-30B/14B/8B). Non-FA2 configs (gemma-class hd!=128, attn sinks
+    // via head_dim, fa2 disabled) keep the workaround.
+    const bool fa2_serves_attention = mcfg.head_dim == 128 &&
+                                      runtime_config_.attention.fmha_fa2 != "never" &&
+                                      runtime_config_.attention.fa2_fp16qk != "never";
+    if (config_.kv_cache_dtype == QType::FP8_E4M3 && fa2_serves_attention &&
+        !runtime_config_.runtime.deterministic_gemm) {
+        IMP_LOG_INFO("FP8 KV cache: FA2 serves all attention (hd=128) — skipping the legacy "
+                     "deterministic-cuBLAS forcing (set kv_cache.allow_nondeterministic_fp8=false "
+                     "semantics unchanged for non-FA2 configs)");
+    }
+    if (config_.kv_cache_dtype == QType::FP8_E4M3 && !fa2_serves_attention &&
         !runtime_config_.kv_cache.allow_nondeterministic_fp8 &&
         !runtime_config_.runtime.deterministic_gemm) {
         // Phase 5 Track D: mutate the per-Engine RuntimeConfig in place


### PR DESCRIPTION
Outcome of tonight's #680 diagnosis chain: `--kv-fp8` regressed MoE pp4096 by −35%, and nsys showed the entire regression is ONE kernel — `moe_fused_permute_deterministic_kernel` (536.7 ms, top kernel; FA2/grouped GEMM untouched by the KV dtype). The cause: FP8-KV unconditionally forces `runtime.deterministic_gemm=true`, an April-era NaN workaround for the **cuBLAS-attention** + FP8 round-trip that predates the FA2 default-on stack — and deterministic mode drags the MoE permute into its single-block variant.

**Fix:** skip the forcing when the f16-QK FA2 chain serves every attention call (hd=128, `fmha_fa2`/`fa2_fp16qk` enabled) — cuBLAS attention never touches the FP8 KV there. Non-FA2 configs (gemma-class hd≠128, fa2 disabled) keep the workaround verbatim; `kv_cache.allow_nondeterministic_fp8` semantics unchanged.

## Evidence (RTX 5090, `--kv-fp8`, 10 reps; PPL on the 14.8k-token corpus)

| Model | pp4096 before | after | vs fp16-KV | PPL Δ vs fp16-KV |
|---|---:|---:|---:|---|
| Qwen3-30B-A3B-NVFP4 | 20 527 | **30 990** | ~par (31 335) | −0.5% (MoE noise) |
| Qwen3-14B-NVFP4 | — | 21 073 | par | +0.36% |
| Qwen3-8B Q8_0 | — | **13 950** | **+6%** (13 189) | +0.10% |

Decode unchanged on all three; gemma-3 (hd=256) counter-check still logs the forcing; repeat-exactly greedy probe with kv-fp8 on the MoE model is byte-perfect; KV/Paged suites 91 green.

`--kv-fp8` stays opt-in — this PR just stops punishing it. Practical effect: **halved KV footprint (2× context per VRAM byte) at neutral-to-positive prefill**, which stacks with #678/#679's freed VRAM on the 32 GB card. Whether to honor the author-declared `kv_cache_quant_algo=FP8` hint by default for hd=128-FA2 families is a follow-up decision (needs per-family long-context gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)