### PR TITLE
fix(spec): disable the burst rearm fast path by default (#683 mitigation)

### DIFF
--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -250,6 +250,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("speculative.give_up_after", cfg.speculative.give_up_after);
     I("speculative.burst", cfg.speculative.burst);
     I("speculative.miss_burst", cfg.speculative.miss_burst);
+    B("speculative.burst_rearm", cfg.speculative.burst_rearm);
 
     if (!matched)
         IMP_LOG_WARN("imp.conf: unknown key '%s' (value '%s') — ignoring", dotted_key.c_str(), val.c_str());

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -450,6 +450,12 @@ struct RuntimeConfig {
         // the ~2x eager per-token tax until the next draft shows up.
         // 0 = stay eager between drafts (legacy behavior).
         int miss_burst = 8;
+        // Reuse the parked captured graph across bursts (rearm instead of
+        // recapture, ~10-20 ms saved per burst). DISABLED by default: the
+        // rearmed burst's first forward emits a deterministic wrong token
+        // (#683 — behaves as if the previous burst's last KV entries are
+        // invisible). Re-enable for debugging the root cause only.
+        bool burst_rearm = false;
     } speculative;
 
     struct FFN {

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -187,7 +187,13 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     // request keeps its captured graph — reseed device state instead of
     // recapturing (the burst-hybrid n-gram speculation path relaunches every
     // few tokens; a full setup costs ~10-20 ms per launch).
-    if (async_graph_runner_.is_setup() && async_parked_req_id_ >= 0) {
+    // #683: the rearm fast path's first forward behaves as if the previous
+    // burst's last ~2 KV entries are invisible (deterministic duplicated
+    // token, e.g. "gamma, gamma" on repeat-exactly prompts); a fresh capture
+    // per burst is byte-perfect. Until root-caused, the fast path is opt-in:
+    // correctness beats the ~10-20 ms capture saving per burst.
+    if (runtime_config_.speculative.burst_rearm && async_graph_runner_.is_setup() &&
+        async_parked_req_id_ >= 0) {
         const auto& bt = kv_manager_->block_table(req->id);
         const int ctx = req->context_len();
         if (async_parked_req_id_ == req->id && async_d_block_tables_ != nullptr &&
@@ -208,6 +214,9 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
                 think_limit = std::max(
                     1, static_cast<int>(req->max_tokens * req->think_budget) - used);
             }
+            if (getenv("IMP_SPEC_TRACE"))
+                IMP_LOG_INFO("[burst-launch] REARM seed=%d pos=%d ctx=%d limit=%d", (int)first_token,
+                             ctx - 1, ctx, step_limit);
             if (async_graph_runner_.rearm(first_token, /*position=*/ctx - 1, /*context_len=*/ctx,
                                           step_limit, req->in_think_block, think_limit, stream) &&
                 async_graph_runner_.launch(stream)) {
@@ -267,6 +276,9 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
         }
     }
 
+    if (getenv("IMP_SPEC_TRACE"))
+        IMP_LOG_INFO("[burst-launch] FRESH seed=%d ctx=%d limit=%d remaining=%d", (int)first_token,
+                     req->context_len(), step_limit, remaining);
     auto gcfg = build_graph_config(*req, remaining);
     gcfg.step_limit = step_limit;
 


### PR DESCRIPTION
Conservative correctness mitigation for #683. The burst-hybrid speculation's rearm fast path (reuse the parked captured graph across bursts) emits a **deterministic wrong first token** on the rearmed burst — token-level traces show the first forward behaving as if the previous burst's last ~2 KV entries are invisible, producing visible artifacts (`alpha, beta, gamma, gamma, ...` on repeat-exactly prompts; the server-side dropped-comma case is the same root). All rearm uploads, the harvest ledger and the block-table refresh check out; the fresh-capture path is byte-perfect at the same positions (full forensic dossier in #683).

Until the rearm/replay interaction is root-caused, the fast path is opt-in: `speculative.burst_rearm` (default **false**).

## Validation (Qwen3-8B Q8, greedy)

| Probe | before | after |
|---|---|---|
| repeat-exactly | duplicated token | **byte-perfect** |
| code-rename 400 tok | 627 tok/s | **684.5 tok/s** (93.2% acceptance — fresh capture is faster than the buggy rearm here) |
| prose (draft-poor, burst-heavy) | ~275 | 271.7 (~−2%, the ~10-20 ms recapture per burst; same class as before) |

Speculation remains opt-in overall; this makes opt-in strictly better (correct AND faster on draft-rich workloads). Root-cause hunt continues in #683 with the rearm path now isolated and re-enableable via the knob for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)