### PR TITLE
perf(vram): VRAM audit harness + −1810 MiB CUTLASS SF dedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(IMP_CORE_SOURCES
 set(IMP_MEMORY_SOURCES
     src/memory/device_allocator.cu
     src/memory/vram_allocator.cu
+    src/memory/mem_account.cu
     src/memory/pinned_allocator.cpp
     src/memory/memory_manager.cpp
     src/memory/kv_cache.cu

--- a/docs/vram_audit.md
+++ b/docs/vram_audit.md
@@ -161,3 +161,41 @@ footprint-reduction lever.**
 - Refuted/out-of-scope: ms_ref slab (no win), pool trim (32 MiB), decode-
   redundant prefill weights 7721 MiB (not freeable without a decode-only mode →
   prefill throughput regression).
+
+---
+
+## 2026-06-12 — Lever: drop Phase-0b redundant CUTLASS SF build (−1810 MiB)
+
+Investigation of the CUTLASS NVFP4 SF caches found a **duplicate build**, not two
+independent caches:
+- Phase 0b (`pre_dequant_phase0_nvfp4_loader.cu`) built a CUTLASS SfAtom buffer
+  for every prequant weight (18624 tensors, 1782 MiB) and stored it in
+  `wcache_->cutlass_nvfp4`.
+- Phase 3b (`nvfp4_decode_convert_cutlass_`) then iterates the **same**
+  `wcache_->nvfp4` map and unconditionally rebuilds `cutlass_nvfp4[ptr]` for
+  every entry (18625 tensors, 1800 MiB), **overwriting** Phase 0b's map entries
+  without freeing them (`CutlassNvFP4Weight` has a raw `scale_factors` pointer
+  and no destructor). Phase 4 snapshots the final map (Phase 3b's entries) into
+  the weight handles the GEMM kernels read, so **Phase 0b's 1782 MiB was
+  allocated, orphaned, and resident-dead until process exit** — never wired to
+  any consumer.
+
+Fix: Phase 0b now only seeds `wcache_->nvfp4` (the decode-GEMV registration that
+Phase 3b iterates); the redundant `convert_nvfp4_to_cutlass` build is removed.
+Phase 3b remains the sole, authoritative, budget-aware builder.
+
+### Measured before/after (same fixed workload, deterministic PPL)
+
+| metric | before (fb22c234) | after | Δ |
+|---|---:|---:|---:|
+| device resident MiB | 28218 | **26408** | **−1810** |
+| device free MiB | 4388 | **6198** | **+1810 (+41%)** |
+| Phase 3b cutlass cache | 18625 T / 1800.55 MiB | 18625 T / 1800.55 MiB | identical (live cache unchanged) |
+| Phase 0b | "1782 MiB" SfAtom | "registered 18624" (no alloc) | dedup |
+| **PPL (deterministic, 199 tok)** | **5.7878** (nll 1.7558) | **5.7878** (nll 1.7558) | **0 — byte-identical** |
+| throughput, 8 concurrent | 124.9 tok/s | 136.8 tok/s | no regression |
+
+The PPL match (identical mean_nll to 4 dp on a separate before/after build) plus
+the unchanged Phase-3b cache confirm the saving is pure dead-memory removal with
+**no correctness and no throughput regression**. New peak under load: 26408 MiB
+resident, free headroom 4318 → 6198 MiB.

--- a/docs/vram_audit.md
+++ b/docs/vram_audit.md
@@ -246,3 +246,35 @@ gated metric (pp512) and the short-prefill regime must be measured explicitly.
 - The dominant footprint (weights 14.6 GiB + NVFP4 SF/overlay + scales) and the
   ~1.7 GiB CUDA-context/cuBLAS reservation are structural / irreducible without
   an accuracy or prefill-throughput trade.
+
+---
+
+## 2026-06-12 — Lever C (KV-FP8 storage): viable, accuracy-gated
+
+`--kv-fp8` switches the KV cache to FP8 E4M3 storage (f16 compute, dequant on
+read — the vLLM-style path, NOT the refuted fp8-QK). The model declares
+`kv_cache_quant_algo=FP8`; imp keeps F16 by default. Measured (deterministic PPL
+A/B for accuracy; `imp-cli --bench` 12 reps × 2 trials for throughput):
+
+| metric | F16 | FP8 E4M3 | Δ |
+|---|---:|---:|---:|
+| KV per-token | 1536 MiB / 16384 tok | 768 MiB / 16384 tok (or 1140 MiB / 24320 tok) | **−768 MiB** (or +48% context) |
+| PPL — 199-tok corpus | 5.7878 | 5.7598 | −0.48% (noise, FP8 better) |
+| **PPL — 3766-tok natural prose** | **16.7244** | **16.8627** | **+0.83%** (real, small) |
+| pp2048 | ~43155 tok/s | ~42982 tok/s | −0.4% (parity) |
+| **tg256 (decode)** | 319.3 | **321.9** | **+0.8% (faster)** |
+
+Unlike the three refuted levers, KV-FP8 **delivers**: −768 MiB at fixed context
+(or it unlocks the full 8×4096 KV that F16 cannot fit — F16 caps at 16384 total
+tokens = 2048/seq at batch 8), decode is marginally *faster* (halved KV-read
+bandwidth outweighs the forced `deterministic_gemm` on the FP8 path), prefill at
+parity. The cost is **+0.83% PPL** on real multi-thousand-token context (the
+short corpus is too short to show KV-quant compounding — filler/repetitive text
+gives PPL→1.0 and must not be used to gate this).
+
+Verdict: **viable opt-in** (`--kv-fp8`). Flipping it to default needs the same
++0.83%-class long-context gate per model family (correctness varies by family —
+the engine's F16 default is deliberate); this run validates only Qwen3-Coder-30B.
+It is best understood as a **context-capacity** lever here, since the F16 KV is
+already small (1536 MiB) and min-sized — FP8 lets the requested 8×4096 actually
+fit rather than reclaiming idle VRAM.

--- a/docs/vram_audit.md
+++ b/docs/vram_audit.md
@@ -199,3 +199,50 @@ The PPL match (identical mean_nll to 4 dp on a separate before/after build) plus
 the unchanged Phase-3b cache confirm the saving is pure dead-memory removal with
 **no correctness and no throughput regression**. New peak under load: 26408 MiB
 resident, free headroom 4318 → 6198 MiB.
+
+---
+
+## 2026-06-12 — Lever B (attn_scores → FA2) REFUTED by measurement
+
+Hypothesis: lower `attention.attn_scores_mib` (default 384 → the 380 MiB cuBLAS
+materialized-scores buffer) so the FA2 path covers prefill, freeing 380 MiB. The
+stale note in `executor_workspace_buffers.cu:268` said cuBLAS was only "~30%
+faster than FMHA at n==cap"; FA2 gained ~25% since (#653/#673/#674), so parity
+seemed plausible. Tested via `--set attention.attn_scores_mib=1` (threshold=129,
+buffer → 1 MiB, FA2 handles all prefill); no rebuild (runtime knob).
+
+VRAM + correctness checked out — but the **throughput gate failed catastrophically
+at short prefill** (`imp-cli --bench`, 12 reps, 2-3 trials, healthy host 13801 MHz):
+
+| metric | cuBLAS (default) | FA2 (mib=1) | Δ |
+|---|---:|---:|---:|
+| VRAM (attn_scores buffer) | 380 MiB | 1 MiB | −379 |
+| PPL (deterministic) | 5.7878 | 5.7673 | −0.36% (FA2 marginally better) |
+| **pp512** | **19600 tok/s** | **1480 tok/s** | **−92% (12× slower)** |
+| pp2048 | 43004 tok/s | 42820 tok/s | −0.43% (parity) |
+| tg256 (decode) | 319.3 | 319.2 | ~0% |
+
+**Refuted.** FA2 is at parity only at the larger chunk (pp2048); at short prefill
+(pp512) it is ~12× slower than cuBLAS GEMM+softmax on the small materialized
+matrix — short prefill is exactly where cuBLAS wins most, and it is the common
+TTFT case. The 380 MiB attn_scores buffer is **load-bearing for short-prefill
+throughput** (and, separately, for hd=256 / gemma-3 correctness —
+`executor_attention.cu:973-990`, where FA2 mis-serves hd=256). Not reclaimable.
+
+Lesson: pp2048 alone (−0.43%) would have green-lit a −92% pp512 regression. The
+gated metric (pp512) and the short-prefill regime must be measured explicitly.
+
+---
+
+## Net result of this audit pass
+
+- **Shipped: −1810 MiB** (Phase-0b SF dedup), correctness- and throughput-neutral,
+  applies to every NVFP4-prequant model. Free headroom 4388 → 6198 MiB.
+- **Refuted by measurement: ms_ref slab** (0, #679 done), **pool trim** (32 MiB),
+  **attn_scores→FA2** (−92% pp512). Each would have been a plausible-looking lever
+  on estimate alone.
+- **Remaining, accuracy-gated:** KV FP8 ~768 MiB (per-family long-context PPL
+  gate; better as a context-capacity lever — KV is min-sized at 1536 MiB).
+- The dominant footprint (weights 14.6 GiB + NVFP4 SF/overlay + scales) and the
+  ~1.7 GiB CUDA-context/cuBLAS reservation are structural / irreducible without
+  an accuracy or prefill-throughput trade.

--- a/docs/vram_audit.md
+++ b/docs/vram_audit.md
@@ -1,0 +1,107 @@
+# VRAM Audit — append-only measured breakdown
+
+Per-component VRAM accounting for imp on the single target chip (RTX 5090,
+sm_120a, 32 607 MiB total). **Append-only**: never overwrite a prior run's
+numbers — add a new dated section so before/after deltas stay auditable.
+
+All numbers are **measured**, not estimated:
+- `cudaMemGetInfo` device free/used at lifecycle checkpoints (`MemAccount`,
+  `src/memory/mem_account.{h,cu}`), gated by `diagnostics.vram_audit`.
+- A 2 ms device-used **peak sampler** runs for the whole workload, so any
+  transient prefill activation / score-matrix spike is captured (not just
+  steady state).
+- Per-pool `note()` counters + the existing `VRAMAllocator::report()` tag table
+  + the loaders' own size logs itemise what bypasses the tracker.
+
+### Reproduce
+
+```bash
+make build
+# starts imp-server with the harness, drives the fixed workload, prints tables:
+bash tools/analysis/vram_audit_run.sh
+# harness only, any model:
+imp-server --model <m> --max-batch 8 --set runtime.max_seq_len=4096 \
+  --set diagnostics.vram_audit=true --set diagnostics.vram_audit_dump=/tmp/a.txt
+```
+
+Fixed workload: **Qwen3-Coder-30B-A3B-Instruct NVFP4, ctx=4096, continuous
+batching, 8 concurrent requests** (`--max-batch 8`).
+
+---
+
+## 2026-06-12 — baseline (main @ 13ec1f6e + audit harness)
+
+Model: `Qwen3-Coder-30B-A3B-Instruct-FP4` (qwen3moe, 48 layers, d_model=2048,
+heads=32, kv_heads=4, d_ff=5472, vocab=151936, NVFP4 Model-Optimizer, group=16,
+author kv_cache_quant_algo=FP8). Workload ran clean: 24 reqs, 0 errors, 5106
+stream chunks, 124.9 tok/s aggregate across 8 streams, GPU 491 W / 2670 MHz.
+
+### Totals (device truth)
+
+| metric | MiB | note |
+|---|---:|---|
+| total VRAM | 32607 | |
+| **resident at steady state** | **28289** | free 4318 |
+| **peak under 8-concurrent load** | **28309** | free 4298 |
+| peak − resident | **+20** | **no transient prefill spike — workspaces are statically pre-allocated** |
+
+### Lifecycle phase deltas (measured, full coverage incl. raw cudaMalloc)
+
+| checkpoint | used MiB | free MiB | Δ MiB (phase cost) |
+|---|---:|---:|---:|
+| 00 pre_init (driver + CUDA primary context) | 1679.6 | 30927.0 | — |
+| 01 prewarm_gemm (cuBLAS/CUTLASS prewarm) | 2355.6 | 30251.0 | +676.0 |
+| 02 weights + NVFP4 decode caches | 20697.6 | 11909.0 | +18342.0 |
+| 03 kv_cache + executor workspaces | 28288.7 | 4317.9 | +7591.1 |
+| 04 features (prefix/graph/residual) | 28288.7 | 4317.9 | +0.0 |
+| 05 post_warmup | 28288.7 | 4317.9 | +0.0 |
+
+### Per-component breakdown (reserved vs used vs peak)
+
+Sources: `[note]` MemAccount pool counter; `[vram_alloc]` VRAMAllocator tag
+report; `[loader]` loader size log; `[budget]` vram_budget.cpp.
+
+| component | resident MiB | peak MiB | source / notes |
+|---|---:|---:|---|
+| NVFP4 packed weights (18625 tensors) | 15467 | 15467 | `[note WEIGHTS]` engine "weights ~17280" incl. phase0 cache |
+| CUTLASS NVFP4 SF cache — prefill prequant | 1782 | 1782 | `[loader]` phase0 (18624 tensors) |
+| CUTLASS NVFP4 SF cache — decode overlay | 1800 | 1800 | `[loader]` phase3 weight cache (18625 tensors) |
+| MoE micro-scales `nvfp4_moe_ms_ref` (144 allocs) | 1728 | 1728 | `[vram_alloc]` contiguous ms_ref copies (#679 already freed 1728 dup) |
+| NVFP4 LM-head decode cache | 167 | 167 | `[loader]` phase3 |
+| **KV block pool** (F16, 512 blk = 16384 tok, block_size=32) | **1536** | 1536 | `[note KV_BLOCK_POOL]`+`[loader]` **under-provisioned — see findings** |
+| GEMM prewarm workspace (cuBLAS + CUTLASS) | 676 | 676 | `[budget]` checkpoint 01 |
+| shared_workspace (max attn/ffn/moe/ssm) | 434 | 434 | `[vram_alloc]` saved 232 vs separate alloc |
+| **attn_scores — legacy cuBLAS S-matrix** (32h×2496×2496 FP16) | **380** | 380 | `[vram_alloc]` materialized scores path |
+| persistent_workspace (hidden+resid+norm+logits) | 53 | 53 | `[vram_alloc]` incl. logits 8×vocab |
+| moe_3x_packed/sf, moe_dequant, cutlass_act data/sf | 50 | 50 | `[vram_alloc]` |
+| CUDA context / driver baseline (WSL2/WDDM) | 1679 | 1679 | checkpoint 00 |
+| reconciliation residual (cudaMallocAsync pool reserve + cuBLAS/CUTLASS internal + fragmentation) | ~537 | — | device_used − Σ above |
+| **TOTAL** | **28289** | **28309** | |
+
+### Not consumers (verified, so we don't chase phantoms)
+
+- **FP8 prefill cache budgeted at 9861 MiB but NOT allocated** (`Phase-4 wcache
+  actual: fp8=0`; "FP8 prefill disabled for native NVFP4"). The `fp8=9861` line
+  in the budget log is a reservation ceiling, never realised on sm_120.
+- **CUDA-graph buffers, prefix cache, SSM/GDN state: ~0 MiB** for this model
+  (checkpoint 04 = +0; dense qwen3moe has no GDN/SSM, residual buffer off).
+
+### Key measured findings
+
+1. **Peak ≈ resident (+20 MiB).** The activation / materialized-scores spike the
+   audit worried about is **already statically allocated** (attn_scores 380 +
+   shared_workspace 434). There is no transient prefill peak to cap; reducing it
+   means shrinking the *resident* workspaces, not bounding a spike.
+2. **Weights + NVFP4 overlay dominate: ~20 944 MiB (74%)** = packed 15467 +
+   SF caches 3582 + ms_ref 1728 + LM-head 167.
+3. **KV is min-sized, not over-sized: 1536 MiB / 16384 tokens total.** At
+   batch=8 that is only ~2048 tok/seq — the requested 8×4096 does **not** fit;
+   the budget floor (`min(16384, max_seq_len×4)`) drove it. KV is a *capacity*
+   lever (raise to use the free 4.3 GB), not a VRAM-reduction target. Model
+   declares FP8 KV; imp keeps F16 by default (`--kv-fp8` halves it, correctness
+   varies by family).
+4. **7721 MiB of weights are "decode-redundant"** (overlay covers decode) but
+   kept resident for M>1 prefill (`phase4` upper bound, not freeable as-is).
+5. **Only 4318 MiB free.** Headroom is thin; the levers below are about buying
+   back that headroom (for more KV/context or larger models), since peak does
+   not exceed resident.

--- a/docs/vram_audit.md
+++ b/docs/vram_audit.md
@@ -75,8 +75,19 @@ report; `[loader]` loader size log; `[budget]` vram_budget.cpp.
 | persistent_workspace (hidden+resid+norm+logits) | 53 | 53 | `[vram_alloc]` incl. logits 8×vocab |
 | moe_3x_packed/sf, moe_dequant, cutlass_act data/sf | 50 | 50 | `[vram_alloc]` |
 | CUDA context / driver baseline (WSL2/WDDM) | 1679 | 1679 | checkpoint 00 |
-| reconciliation residual (cudaMallocAsync pool reserve + cuBLAS/CUTLASS internal + fragmentation) | ~537 | — | device_used − Σ above |
+| reconciliation residual (cudaMallocAsync pool reserve + cuBLAS/CUTLASS internal + fragmentation) | ~2537 | — | device_used − Σ above; see note below |
 | **TOTAL** | **28289** | **28309** | |
+
+> Note: the per-pool `note()` counters are write-only — they do not see a raw
+> `cudaFree` that follows (e.g. #679 frees the scattered ms_ref scales after the
+> contiguous copy), so the `WEIGHTS` note can over-read while `nvfp4_moe_ms_ref`
+> double-books the same logical bytes. The lifecycle **checkpoints** and the
+> **device totals** are the ground truth; the residual absorbs both genuine
+> untracked memory and this note skew. The cudaMallocAsync **pool reserve** is a
+> prime residual suspect: imp sets the pool release threshold to UINT64_MAX
+> (`engine_weight_upload.cpp:92`), so init-time `cudaFree`s (incl. #679's ms_ref)
+> are **retained in the pool, not returned to the OS** — still counted as
+> device-used. Quantified in the follow-up section below.
 
 ### Not consumers (verified, so we don't chase phantoms)
 
@@ -105,3 +116,48 @@ report; `[loader]` loader size log; `[budget]` vram_budget.cpp.
 5. **Only 4318 MiB free.** Headroom is thin; the levers below are about buying
    back that headroom (for more KV/context or larger models), since peak does
    not exceed resident.
+
+### Follow-up: cudaMallocAsync pool reserve — MEASURED, refuted as a lever
+
+Hypothesis: the ~2.4 GiB residual is freed-but-retained pool memory (the #679
+ms_ref `cudaFree`s held by the UINT64_MAX release threshold), reclaimable with
+`cudaMemPoolTrimTo`. **Measured on the same workload:**
+
+| | reserved MiB | used MiB | trimmable MiB |
+|---|---:|---:|---:|
+| default mempool at init_complete | 17280 | 17249 | **31** |
+| after `cudaMemPoolTrimTo(0)` | 17248 | 17249 | ~0 |
+
+The pool is ~fully *used* (live NVFP4 weights 15467 + ms_ref copy 1728 ≈ pool
+used); only **31 MiB** is slack and the trim reclaimed **32 MiB**. **Refuted.**
+The #679-freed scatter scales did NOT accumulate as pool slack. The ~2.4 GiB
+residual is therefore **CUDA primary context + cuBLAS/CUTLASS internal
+reservations + WSL2/WDDM driver overhead** (baseline checkpoint 00 alone is
+1679 MiB), which is driver-owned and not cleanly reclaimable.
+
+### Follow-up: Lever-A (`nvfp4_moe_ms_ref` slab) — already shipped, no resident win
+
+The 1728 MiB `nvfp4_moe_ms_ref` is **not a duplicate** — #679 already frees the
+scattered per-expert source scales after the contiguous copy
+(`pre_dequant_phase3_nvfp4_decode.cu:1676`, confirmed in the run log: "freed
+1728.00 MiB duplicated per-expert micro-scales"). Making the SafeTensors loader
+emit a contiguous scale slab would set `scales_contig=true` and skip the *copy*,
+but the scales must be resident for NVFP4 decode either way — it only removes a
+**transient init-time 2× peak**, not steady-state resident VRAM. **Not a
+footprint-reduction lever.**
+
+### Net: which levers actually reduce resident VRAM (measured)
+
+- **attn_scores 380 MiB** — genuinely resident, removable by lowering the FA2
+  prefill threshold (needs FA2 short-prefill PPL+perf parity). The one clean
+  no-accuracy/no-throughput win the data supports.
+- **KV FP8 ~768 MiB** — halves the 1536 MiB F16 KV; author declares FP8 KV.
+  Accuracy trade-off (per-family long-context PPL gate). Better framed as a
+  *context-capacity* lever (KV is min-sized, not over-sized).
+- **CUTLASS NVFP4 SF caches 3582 MiB** (phase0 prefill 1782 + phase3 decode
+  1800) — the only large remaining prize; needs a probe to confirm whether both
+  are independently required or dedupable. Higher risk (touches prefill + decode
+  GEMM correctness).
+- Refuted/out-of-scope: ms_ref slab (no win), pool trim (32 MiB), decode-
+  redundant prefill weights 7721 MiB (not freeable without a decode-only mode →
+  prefill throughput regression).

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -354,7 +354,6 @@ void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
     // CUTLASS fast path for all NVFP4-prequant models uniformly.
     if (cutlass_sm120_nvfp4_available()) {
         int ct_count = 0;
-        size_t ct_total = 0;
         // NOTE on the GDN/SSM quality lock and gemm.nvfp4_ssm_proj:
         // For NATIVE-NVFP4 checkpoints the in_proj/out_proj (ssm_in/ssm_out)
         // weights only EXIST as NVFP4 bytes — there is no FP16 copy and
@@ -368,7 +367,7 @@ void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
         auto register_prequant = [&](const Tensor& w) {
             if (w.qtype != QType::NVFP4 || !w.data || !w.scales)
                 return;
-            if (wcache_->cutlass_nvfp4.count(w.data))
+            if (wcache_->nvfp4.count(w.data))
                 return;
             NvFP4QuantResult tmp;
             tmp.packed_data = w.data;
@@ -381,15 +380,19 @@ void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
             // per-16 FP8 micro_scales, not SfAtom). Without this, decode falls
             // through to the CUTLASS_NVFP4 case which uses source_scales —
             // but that path produced zero output on some models.
+            //
+            // VRAM-AUDIT (2026-06-12): do NOT build the CUTLASS SfAtom buffer
+            // here. Phase 3b (nvfp4_decode_convert_cutlass_) iterates exactly
+            // this wcache_->nvfp4 map and rebuilds cutlass_nvfp4[ptr] for every
+            // entry, unconditionally overwriting whatever this loop inserted —
+            // so a SfAtom built here is immediately orphaned (the map drops the
+            // pointer without freeing it) and stays resident, dead, until exit.
+            // On Qwen3-Coder-30B-A3B NVFP4 that orphan was ~1782 MiB. Phase 3b
+            // is the authoritative, budget-aware builder whose entries Phase 4
+            // snapshots into the weight handles the GEMM kernels actually read;
+            // seeding nvfp4 here is all Phase 0b needs to do.
             wcache_->nvfp4[w.data] = tmp;
-
-            CutlassNvFP4Weight cw;
-            convert_nvfp4_to_cutlass(tmp, cw, stream);
-            if (cw.data) {
-                wcache_->cutlass_nvfp4[w.data] = cw;
-                ct_total += cw.sf_bytes;
-                ct_count++;
-            }
+            ct_count++;
         };
         for (int i = 0; i < cfg.n_layers; i++) {
             const auto& L = mut_model->layer(i);
@@ -412,10 +415,11 @@ void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
         register_prequant(mut_model->out_proj_);
 
         if (ct_count > 0) {
-            IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-            wcache_->cutlass_nvfp4_bytes += ct_total;
-            IMP_LOG_INFO("CUTLASS sm_120 NVFP4 cache (prequant): %d tensors, %.2f MiB", ct_count,
-                         ct_total / (1024.0 * 1024.0));
+            // Decode-cache registration only; Phase 3b builds the CUTLASS SfAtom
+            // for these entries (see register_prequant note above).
+            IMP_LOG_INFO("NVFP4 prequant: registered %d weights in decode cache "
+                         "(CUTLASS SfAtom built once in Phase 3b)",
+                         ct_count);
         }
         {
             int n_ssm = 0;

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -1,5 +1,6 @@
 #include "memory/kv_cache.h"
 #include "memory/vram_allocator.h"
+#include "memory/mem_account.h"
 #include "runtime/graph_diag.h"
 #include "core/logging.h"
 #include <cuda_runtime.h>
@@ -55,6 +56,7 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, QType dtype, int ma
 
     // Zero-initialize the pool so fresh blocks start clean
     IMP_CUDA_CHECK_LOG(cudaMemset(pool_, 0, total));
+    MemAccount::instance().note("KV_BLOCK_POOL", static_cast<std::ptrdiff_t>(total));
 
     // Allocate separate scale buffer for quantized KV cache modes.
     //   INT8/INT4: 1 half (FP16) per head per token slot.
@@ -92,6 +94,7 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, QType dtype, int ma
             throw std::runtime_error(msg);
         }
         IMP_CUDA_CHECK_LOG(cudaMemset(scale_pool_, 0, scale_total));
+        MemAccount::instance().note("KV_BLOCK_POOL", static_cast<std::ptrdiff_t>(scale_total));
     }
 
     // Initialise per-block ref counts (0 = free) and build free list

--- a/src/memory/mem_account.cu
+++ b/src/memory/mem_account.cu
@@ -1,0 +1,179 @@
+#include "memory/mem_account.h"
+#include "core/logging.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+namespace {
+constexpr double kMiB = 1024.0 * 1024.0;
+
+size_t query_free() {
+    size_t free_b = 0, total_b = 0;
+    if (cudaMemGetInfo(&free_b, &total_b) != cudaSuccess)
+        return 0;
+    return free_b;
+}
+
+void query_free_total(size_t& free_b, size_t& total_b) {
+    free_b = 0;
+    total_b = 0;
+    cudaMemGetInfo(&free_b, &total_b);
+}
+}  // namespace
+
+MemAccount& MemAccount::instance() {
+    static MemAccount inst;
+    return inst;
+}
+
+MemAccount::~MemAccount() {
+    sampler_stop();
+}
+
+void MemAccount::set_dump_path(std::string path) {
+    std::lock_guard<std::mutex> lock(mu_);
+    dump_path_ = std::move(path);
+}
+
+MemAccount::Pool& MemAccount::pool_locked(const char* name) {
+    for (auto& p : pools_) {
+        if (p.name == name)
+            return p;
+    }
+    pools_.push_back(Pool{name, 0, 0, 0});
+    return pools_.back();
+}
+
+void MemAccount::note(const char* pool, std::ptrdiff_t delta_bytes) {
+    if (!enabled_.load(std::memory_order_relaxed) || delta_bytes == 0)
+        return;
+    std::lock_guard<std::mutex> lock(mu_);
+    Pool& p = pool_locked(pool);
+    p.current += delta_bytes;
+    if (delta_bytes > 0)
+        p.alloc_count++;
+    if (p.current > p.peak)
+        p.peak = p.current;
+}
+
+void MemAccount::checkpoint(const char* name) {
+    size_t free_b = 0, total_b = 0;
+    query_free_total(free_b, total_b);
+    if (total_b)
+        total_vram_ = total_b;
+    sample_once();  // fold the checkpoint instant into the peak too
+    if (!enabled_.load(std::memory_order_relaxed))
+        return;
+    std::lock_guard<std::mutex> lock(mu_);
+    checkpoints_.push_back(Checkpoint{name, free_b, total_b - free_b});
+}
+
+void MemAccount::sample_once() {
+    size_t free_b = 0, total_b = 0;
+    query_free_total(free_b, total_b);
+    if (!total_b)
+        return;
+    size_t used = total_b - free_b;
+    size_t prev = peak_used_.load(std::memory_order_relaxed);
+    while (used > prev && !peak_used_.compare_exchange_weak(prev, used, std::memory_order_relaxed)) {
+    }
+}
+
+void MemAccount::sampler_start(int interval_us) {
+    if (!enabled_.load(std::memory_order_relaxed))
+        return;
+    if (sampler_run_.exchange(true))
+        return;  // already running
+    sampler_interval_us_ = interval_us > 0 ? interval_us : 2000;
+    sampler_ = std::thread([this] {
+        while (sampler_run_.load(std::memory_order_relaxed)) {
+            sample_once();
+            std::this_thread::sleep_for(std::chrono::microseconds(sampler_interval_us_));
+        }
+    });
+    IMP_LOG_INFO("MemAccount: peak sampler started (interval=%d us)", sampler_interval_us_);
+}
+
+void MemAccount::sampler_stop() {
+    if (!sampler_run_.exchange(false))
+        return;
+    if (sampler_.joinable())
+        sampler_.join();
+}
+
+void MemAccount::report(const char* phase_label) {
+    sample_once();
+
+    size_t free_b = 0, total_b = 0;
+    query_free_total(free_b, total_b);
+    size_t used = total_b ? (total_b - free_b) : 0;
+    size_t peak = peak_used_.load(std::memory_order_relaxed);
+    peak = std::max(peak, used);
+
+    std::lock_guard<std::mutex> lock(mu_);
+
+    // Build the table into a buffer so it lands atomically in the log and the
+    // append-only dump file.
+    std::string out;
+    char line[256];
+    auto emit = [&](const char* fmt, auto... args) {
+        std::snprintf(line, sizeof(line), fmt, args...);
+        out += line;
+        out += '\n';
+    };
+
+    emit("===== VRAM AUDIT [%s] =====", phase_label ? phase_label : "?");
+    emit("device: total=%.0f MiB  used=%.0f MiB  free=%.0f MiB  peak_used=%.0f MiB",
+         total_b / kMiB, used / kMiB, free_b / kMiB, peak / kMiB);
+
+    if (!checkpoints_.empty()) {
+        emit("--- lifecycle checkpoints (phase delta = measured cost) ---");
+        emit("%-26s %12s %12s %12s", "checkpoint", "used_MiB", "free_MiB", "delta_MiB");
+        size_t prev_used = 0;
+        bool first = true;
+        for (const auto& c : checkpoints_) {
+            double delta = first ? 0.0 : (double(c.used_bytes) - double(prev_used)) / kMiB;
+            emit("%-26s %12.1f %12.1f %12.1f", c.name.c_str(), c.used_bytes / kMiB,
+                 c.free_bytes / kMiB, delta);
+            prev_used = c.used_bytes;
+            first = false;
+        }
+    }
+
+    if (!pools_.empty()) {
+        std::vector<Pool> sorted = pools_;
+        std::sort(sorted.begin(), sorted.end(),
+                  [](const Pool& a, const Pool& b) { return a.peak > b.peak; });
+        emit("--- per-pool notes (tracked allocation sites) ---");
+        emit("%-26s %12s %12s %10s", "pool", "current_MiB", "peak_MiB", "allocs");
+        int64_t cur_sum = 0, peak_sum = 0;
+        for (const auto& p : sorted) {
+            emit("%-26s %12.1f %12.1f %10lld", p.name.c_str(), p.current / kMiB, p.peak / kMiB,
+                 (long long)p.alloc_count);
+            cur_sum += p.current;
+            peak_sum += p.peak;
+        }
+        emit("%-26s %12.1f %12.1f", "TRACKED TOTAL", cur_sum / kMiB, peak_sum / kMiB);
+        // Reconciliation: device_used - tracked = untracked (weights bypass the
+        // notes) + allocator fragmentation + driver/context overhead.
+        emit("%-26s %12.1f", "UNTRACKED (weights+frag)", (double(used) - double(cur_sum)) / kMiB);
+    }
+    emit("===== END VRAM AUDIT [%s] =====", phase_label ? phase_label : "?");
+
+    IMP_LOG_INFO("\n%s", out.c_str());
+
+    if (!dump_path_.empty()) {
+        FILE* f = std::fopen(dump_path_.c_str(), "a");
+        if (f) {
+            std::fputs(out.c_str(), f);
+            std::fputc('\n', f);
+            std::fclose(f);
+        }
+    }
+}
+
+}  // namespace imp

--- a/src/memory/mem_account.cu
+++ b/src/memory/mem_account.cu
@@ -130,6 +130,22 @@ void MemAccount::report(const char* phase_label) {
     emit("device: total=%.0f MiB  used=%.0f MiB  free=%.0f MiB  peak_used=%.0f MiB",
          total_b / kMiB, used / kMiB, free_b / kMiB, peak / kMiB);
 
+    // cudaMallocAsync default-pool slack: freed-but-not-returned-to-OS memory
+    // (e.g. the #679 ms_ref cudaFree's) sits here as reserved and still counts
+    // as device-used. reserved - used = trimmable headroom (cudaMemPoolTrimTo).
+    {
+        cudaMemPool_t pool = nullptr;
+        int dev = 0;
+        cudaGetDevice(&dev);
+        if (cudaDeviceGetDefaultMemPool(&pool, dev) == cudaSuccess && pool) {
+            unsigned long long rsv = 0, usd = 0;
+            cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv);
+            cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &usd);
+            emit("mempool(async): reserved=%.0f MiB  used=%.0f MiB  trimmable=%.0f MiB",
+                 rsv / kMiB, usd / kMiB, (double(rsv) - double(usd)) / kMiB);
+        }
+    }
+
     if (!checkpoints_.empty()) {
         emit("--- lifecycle checkpoints (phase delta = measured cost) ---");
         emit("%-26s %12s %12s %12s", "checkpoint", "used_MiB", "free_MiB", "delta_MiB");

--- a/src/memory/mem_account.h
+++ b/src/memory/mem_account.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace imp {
+
+// ─────────────────────────────────────────────────────────────────────
+// MemAccount — process-global VRAM accounting harness (Phase-0 audit).
+//
+// The VRAMAllocator only tracks allocations routed through it (~14 files);
+// the large consumers (KV pool, NVFP4 decode cache, CUTLASS/cuBLAS
+// workspaces, CUDA-graph buffers, weights) call cudaMalloc directly and are
+// invisible to it. MemAccount closes that gap with two complementary,
+// low-overhead signals plus a peak sampler:
+//
+//   1. CHECKPOINTS — a labeled cudaMemGetInfo snapshot at each init phase.
+//      The free-VRAM delta between consecutive checkpoints attributes device
+//      memory to that phase with FULL coverage (it also sees raw cudaMalloc).
+//      This is the ground-truth backbone of the breakdown.
+//
+//   2. NOTES — explicit note(pool, +/-bytes) calls at the big allocation
+//      sites give current + peak attribution WITHIN a phase (e.g. how much of
+//      "init_weights" is the NVFP4 decode cache vs the SafeTensors upload).
+//
+//   3. SAMPLER — a background thread polling cudaMemGetInfo at high frequency
+//      records the true device-used PEAK, capturing transient spikes (the
+//      prefill activation / materialized-scores matrix, CUTLASS autotuning
+//      transients) that a steady-state snapshot would miss.
+//
+// Everything is gated behind RuntimeConfig diagnostics.vram_audit (default
+// off): when disabled, note()/checkpoint() are ~one relaxed atomic / a single
+// cudaMemGetInfo and the sampler thread is never started. Safe to leave the
+// note() calls compiled in on the hot path — they are not on it (allocation
+// sites only), but the gate keeps them free regardless.
+// ─────────────────────────────────────────────────────────────────────
+class MemAccount {
+public:
+    static MemAccount& instance();
+
+    // Enable/disable. When disabled, checkpoint()/report() still take a cheap
+    // cudaMemGetInfo so the device free/used line is always available, but no
+    // history is retained and the sampler never runs.
+    void set_enabled(bool on) { enabled_.store(on, std::memory_order_relaxed); }
+    bool enabled() const { return enabled_.load(std::memory_order_relaxed); }
+
+    // Append-only file the report() table is mirrored into (in addition to the
+    // log). Empty = log only.
+    void set_dump_path(std::string path);
+
+    // Per-pool current + peak attribution. pool must be a string literal /
+    // stable pointer (stored by value into a small fixed registry by name).
+    void note(const char* pool, std::ptrdiff_t delta_bytes);
+
+    // Record a labeled device snapshot (cudaMemGetInfo). The delta vs the
+    // previous checkpoint is the measured cost of the phase just completed.
+    void checkpoint(const char* name);
+
+    // Background device-used peak sampler.
+    void sampler_start(int interval_us = 2000);
+    void sampler_stop();
+
+    // Emit the full audit table: checkpoints + per-pool current/peak + device
+    // free/used/peak + reconciliation residual (device_used - sum(pools) =
+    // untracked weights/fragmentation). phase_label tags the emission point.
+    void report(const char* phase_label);
+
+    // Convenience: largest device-used so far (bytes), 0 if never sampled.
+    size_t device_peak_used() const { return peak_used_.load(std::memory_order_relaxed); }
+
+private:
+    MemAccount() = default;
+    ~MemAccount();
+    MemAccount(const MemAccount&) = delete;
+    MemAccount& operator=(const MemAccount&) = delete;
+
+    struct Pool {
+        std::string name;
+        int64_t current = 0;
+        int64_t peak = 0;
+        int64_t alloc_count = 0;
+    };
+    struct Checkpoint {
+        std::string name;
+        size_t free_bytes = 0;
+        size_t used_bytes = 0;  // total - free
+    };
+
+    Pool& pool_locked(const char* name);
+    void sample_once();  // updates peak_used_ from cudaMemGetInfo
+
+    std::atomic<bool> enabled_{false};
+    mutable std::mutex mu_;
+    std::vector<Pool> pools_;
+    std::vector<Checkpoint> checkpoints_;
+    std::string dump_path_;
+    size_t total_vram_ = 0;
+
+    std::atomic<size_t> peak_used_{0};
+    std::atomic<bool> sampler_run_{false};
+    std::thread sampler_;
+    int sampler_interval_us_ = 2000;
+};
+
+}  // namespace imp

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1,5 +1,6 @@
 #include "model/model.h"
 #include "model/gguf_loader.h"
+#include "memory/mem_account.h"
 #include "quant/dequant_gpu.h"
 #include "quant/dequant_gptq.h"
 #include "core/logging.h"
@@ -39,8 +40,10 @@ static cudaError_t checked_cuda_malloc(void** ptr, size_t size, cudaStream_t str
             return cudaErrorMemoryAllocation;
         }
         cudaError_t err = cudaMallocAsync(ptr, size, stream);
-        if (err == cudaSuccess)
+        if (err == cudaSuccess) {
             g_total_allocated += size;
+            MemAccount::instance().note("WEIGHTS", static_cast<std::ptrdiff_t>(size));
+        }
         return err;
     }
     // Fallback: per-tensor check (used outside upload passes)

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -237,6 +237,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("diagnostics.mtp_pattern_log", cfg.diagnostics.mtp_pattern_log);
     B("diagnostics.mtp_prenorm_h", cfg.diagnostics.mtp_prenorm_h);
     B("diagnostics.audit_nvfp4_scales", cfg.diagnostics.audit_nvfp4_scales);
+    B("diagnostics.vram_audit", cfg.diagnostics.vram_audit);
+    S("diagnostics.vram_audit_dump", cfg.diagnostics.vram_audit_dump);
 
     // [ffn]
     B("ffn.sparsity_probe", cfg.ffn.sparsity_probe);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -510,6 +510,12 @@ struct RuntimeConfig {
         // Audit NVFP4 weight scales at load time. Legacy env:
         // IMP_AUDIT_NVFP4_SCALES.
         bool audit_nvfp4_scales = false;
+        // Per-component VRAM accounting harness (MemAccount): lifecycle
+        // checkpoints + per-pool notes + device-used peak sampler. Default off
+        // (zero overhead). See src/memory/mem_account.h.
+        bool vram_audit = false;
+        // Optional append-only file the VRAM audit table is mirrored into.
+        std::string vram_audit_dump;
         // [RETIRED] tq_skip_qjl removed in Phase 5 (TurboQuant retired 2026-05-17).
     } diagnostics;
 

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -7,6 +7,7 @@
 #include "runtime/batch.h"
 #include "compute/mtp_forward.h"
 #include "memory/kv_cache.h"
+#include "memory/mem_account.h"
 #include "model/gguf_loader.h"
 #include "model/chat_template.h"
 #include "compute/ffn_sparsity_probe.h"
@@ -40,6 +41,11 @@ using engine_internal::ensure_prefill_workspace;
 using engine_internal::free_prefill_buffers;
 
 Engine::~Engine() {
+    // Phase-0 VRAM audit: stop the peak sampler and emit the final table
+    // (captures the device-used peak reached during the workload).
+    MemAccount::instance().sampler_stop();
+    MemAccount::instance().report("shutdown");
+
     // Save prefix cache to disk before shutdown
     if (kv_manager_ && !config_.prefix_cache_path.empty() && kv_manager_->prefix_caching_enabled()) {
         kv_manager_->save_prefix_cache(config_.prefix_cache_path, stream_);
@@ -495,6 +501,16 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     init_compute_max_seq_len_();
 
     // --- Core initialization ---
+    // Phase-0 VRAM audit harness: lifecycle checkpoints bracket each init
+    // sub-phase so the device free-VRAM delta measures that phase's cost with
+    // full coverage (raw cudaMalloc included). Gated, default off.
+    if (runtime_config_.diagnostics.vram_audit) {
+        MemAccount::instance().set_enabled(true);
+        if (!runtime_config_.diagnostics.vram_audit_dump.empty())
+            MemAccount::instance().set_dump_path(runtime_config_.diagnostics.vram_audit_dump);
+    }
+    MemAccount::instance().checkpoint("00_pre_init");
+
     // 5% headroom (was 10%) — MoE models (30B Q6_K) need every MiB on 32GB.
     // WSL2/WDDM has ~500 MiB driver overhead, 5% of 32GB = 1.6 GB covers it.
     if (!memory_manager_.vram_allocator().init(0.05f)) {
@@ -506,19 +522,28 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     gemm_grouped_3x_nvfp4_prewarm();
     scheduler_ = std::make_unique<Scheduler>(config_.max_batch_size);
     (void)stream_.create(cudaStreamNonBlocking);
+    MemAccount::instance().checkpoint("01_prewarm_gemm");
 
     // --- Sub-phases ---
     if (!init_weights())
         return false;
+    MemAccount::instance().checkpoint("02_weights+decode_cache");
     if (!init_kv_cache())
         return false;
+    MemAccount::instance().checkpoint("03_kv_cache");
     if (!init_features())
         return false;
+    MemAccount::instance().checkpoint("04_features");
     if (!runtime_config_.runtime.warmup) {
         IMP_LOG_INFO("Warmup SKIPPED (runtime.warmup=false)");
     } else {
         warmup();
     }
+    MemAccount::instance().checkpoint("05_post_warmup");
+    // Start the device-used peak sampler so the prefill activation / score
+    // matrix spike during the workload is captured, then dump the init table.
+    MemAccount::instance().sampler_start(2000);
+    MemAccount::instance().report("init_complete");
 
     return true;
 }

--- a/tools/analysis/vram_audit_load.py
+++ b/tools/analysis/vram_audit_load.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Phase-0 VRAM-audit load driver.
+
+Drives the fixed audit workload against a running imp-server:
+  Qwen3-Coder-30B-A3B NVFP4, ctx=4096, continuous batching, 8 concurrent reqs.
+
+The server is started separately with the VRAM-audit harness enabled
+(`--max-batch 8 --set runtime.max_seq_len=4096 --set diagnostics.vram_audit=true`).
+This script warms the GPU clocks (>1s ramp on the 5090) and then sustains 8
+concurrent streaming completions with long prompts so the scheduler batches a
+full 8-way decode and the KV pool fills toward ctx=4096 per sequence. The
+server's MemAccount peak sampler captures the device-used peak across the run;
+the per-component table is emitted to the server log + dump file on shutdown.
+
+Usage:
+  python3 vram_audit_load.py --url http://127.0.0.1:8080 --concurrency 8 \
+      --ctx 4096 --rounds 3
+"""
+import argparse
+import json
+import threading
+import time
+import urllib.request
+
+# A chunk of code-like filler (~1 token/word). Repeated to reach the target
+# prompt length so each sequence's KV approaches ctx without needing a corpus.
+FILLER = (
+    "def transform(node, ctx): "
+    "for child in node.children: "
+    "ctx.visit(child); accumulate(child.value, ctx.state); "
+    "return reduce(lambda a, b: a + b, ctx.state, init_value) "
+)
+
+
+def build_prompt(approx_tokens: int) -> str:
+    reps = max(1, approx_tokens // 24)
+    body = FILLER * reps
+    return (
+        "You are a code assistant. Carefully analyze the following program and "
+        "then continue implementing it in detail, explaining each step:\n\n"
+        + body
+        + "\n\nNow continue the implementation step by step with full detail:"
+    )
+
+
+def get_model_id(url):
+    """Strict API (PR #507): the request model name must equal the loaded
+    model's name or the server returns 404. Fetch it from /v1/models."""
+    try:
+        with urllib.request.urlopen(url + "/v1/models", timeout=30) as resp:
+            data = json.loads(resp.read())
+            return data["data"][0]["id"]
+    except Exception as e:  # noqa: BLE001
+        print(f"  could not fetch model id ({e}); falling back to 'default'")
+        return "default"
+
+
+def one_request(url, prompt, max_tokens, idx, stats, model_id):
+    payload = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.7,
+        "stream": True,
+    }
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url + "/v1/chat/completions", data=data,
+        headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    n_tok = 0
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            for raw in resp:
+                line = raw.decode("utf-8", "ignore").strip()
+                if line.startswith("data: ") and "[DONE]" not in line:
+                    n_tok += 1
+    except Exception as e:  # noqa: BLE001
+        stats["errors"] += 1
+        print(f"  [req {idx}] error: {e}")
+        return
+    dt = time.time() - t0
+    stats["tokens"] += n_tok
+    stats["reqs"] += 1
+    print(f"  [req {idx}] {n_tok} chunks in {dt:.1f}s ({n_tok / dt:.1f} tok/s)")
+
+
+def fire_round(url, concurrency, prompt, max_tokens, stats, tag, model_id):
+    print(f"[{tag}] firing {concurrency} concurrent requests...")
+    threads = []
+    for i in range(concurrency):
+        t = threading.Thread(target=one_request,
+                             args=(url, prompt, max_tokens, i, stats, model_id))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://127.0.0.1:8080")
+    ap.add_argument("--concurrency", type=int, default=8)
+    ap.add_argument("--ctx", type=int, default=4096)
+    ap.add_argument("--rounds", type=int, default=3)
+    args = ap.parse_args()
+
+    # Prompt ~60% of ctx; generation fills the rest toward ctx per sequence.
+    prompt = build_prompt(int(args.ctx * 0.6))
+    gen = int(args.ctx * 0.4)
+
+    model_id = get_model_id(args.url)
+    print(f"model id: {model_id}")
+    stats = {"tokens": 0, "reqs": 0, "errors": 0}
+
+    # Warmup: ramp the 5090 clocks (>1s under load) with a discarded round.
+    fire_round(args.url, args.concurrency, build_prompt(256), 128, stats, "warmup", model_id)
+    time.sleep(1.0)
+    stats = {"tokens": 0, "reqs": 0, "errors": 0}
+
+    t0 = time.time()
+    for r in range(args.rounds):
+        fire_round(args.url, args.concurrency, prompt, gen, stats, f"round {r + 1}/{args.rounds}", model_id)
+    dt = time.time() - t0
+
+    print("\n=== load summary ===")
+    print(f"requests: {stats['reqs']}  errors: {stats['errors']}")
+    print(f"chunks:   {stats['tokens']}  wall: {dt:.1f}s")
+    print(f"aggregate: {stats['tokens'] / dt:.1f} tok/s across {args.concurrency} streams")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/analysis/vram_audit_run.sh
+++ b/tools/analysis/vram_audit_run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Phase-0 VRAM-audit run orchestrator.
+#
+# Boots imp-server inside the imp:test container with the MemAccount audit
+# harness enabled, drives the fixed 8-concurrent workload, and collects:
+#   - the init-time per-component VRAM table (server stdout, "init_complete")
+#   - the device-used PEAK + final table on shutdown ("shutdown")
+#   - the append-only dump file (mounted to host)
+#
+# Reproducible: same model, ctx, concurrency every run. Results land in
+# $OUT_DIR (default /tmp/vram_audit). NOT committed — the AUDIT table in
+# docs/vram_audit.md is the curated, append-only record.
+set -euo pipefail
+
+MODEL=${MODEL:-/models/Qwen3-Coder-30B-A3B-Instruct-FP4}
+IMG=${IMG:-imp:test}
+PORT=${PORT:-8080}
+CTX=${CTX:-4096}
+CONC=${CONC:-8}
+ROUNDS=${ROUNDS:-3}
+OUT_DIR=${OUT_DIR:-/tmp/vram_audit}
+NAME=imp-vram-audit
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR/dump.txt"
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+
+echo "== starting imp-server (model=$MODEL, max-batch=$CONC, ctx=$CTX) =="
+docker run -d --name "$NAME" --gpus all \
+  -p "$PORT:$PORT" \
+  -v /home/kekz/models:/models \
+  -v "$OUT_DIR:/audit" \
+  -e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+  "$IMG" imp-server \
+    --model "$MODEL" \
+    --host 0.0.0.0 --port "$PORT" \
+    --max-batch "$CONC" \
+    --max-tokens "$CTX" \
+    --set runtime.max_seq_len="$CTX" \
+    --set runtime.warmup=true \
+    --set diagnostics.vram_audit=true \
+    --set diagnostics.vram_audit_dump=/audit/dump.txt >/dev/null
+
+echo "== waiting for server ready =="
+for _ in $(seq 1 120); do
+  if curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 || \
+     curl -fsS "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
+    echo "  ready."
+    break
+  fi
+  if ! docker ps -q -f name="$NAME" | grep -q .; then
+    echo "!! server container exited early; logs:"; docker logs "$NAME" | tail -40; exit 1
+  fi
+  sleep 2
+done
+
+echo "== driving load ($CONC concurrent x $ROUNDS rounds, ctx=$CTX) =="
+python3 "$(dirname "$0")/vram_audit_load.py" \
+  --url "http://127.0.0.1:$PORT" --concurrency "$CONC" --ctx "$CTX" --rounds "$ROUNDS" \
+  | tee "$OUT_DIR/load.log"
+
+echo "== peak sampled during load; stopping server to emit shutdown table =="
+docker stop -t 30 "$NAME" >/dev/null
+docker logs "$NAME" > "$OUT_DIR/server.log" 2>&1
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+
+echo
+echo "================ INIT TABLE (init_complete) ================"
+sed -n '/VRAM AUDIT \[init_complete\]/,/END VRAM AUDIT \[init_complete\]/p' "$OUT_DIR/server.log" || true
+echo
+echo "================ SHUTDOWN TABLE (peak) ===================="
+sed -n '/VRAM AUDIT \[shutdown\]/,/END VRAM AUDIT \[shutdown\]/p' "$OUT_DIR/server.log" || true
+echo
+echo "Full logs: $OUT_DIR/server.log  |  dump: $OUT_DIR/dump.txt  |  load: $OUT_DIR/load.log"

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -14,6 +14,7 @@ void print_server_usage(const char* prog) {
             "  --host <addr>         Listen address (default: 127.0.0.1)\n"
             "  --port <n>            Listen port (default: 8080)\n"
             "  --max-tokens <n>      Default max tokens (default: 8192)\n"
+            "  --max-batch <n>       Decode batch / KV+workspace sizing (default: 0 = auto)\n"
             "  --gpu-layers <n>      Layers on GPU, -1 = all (default: -1)\n"
             "  --device <n>          CUDA device ID (default: 0)\n"
             "  --chat-template <t>   auto, none, chatml, llama2, llama3, nemotron, gemma\n"
@@ -68,6 +69,8 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.port = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--max-tokens") == 0 && i + 1 < argc) {
             args.max_tokens = std::atoi(argv[++i]);
+        } else if (std::strcmp(arg, "--max-batch") == 0 && i + 1 < argc) {
+            args.max_batch_size = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--gpu-layers") == 0 && i + 1 < argc) {
             args.gpu_layers = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--device") == 0 && i + 1 < argc) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -15,6 +15,7 @@ struct ServerArgs {
     std::string host = "127.0.0.1";
     int port = 8080;
     int max_tokens = 8192;
+    int max_batch_size = 0;  // --max-batch: decode batch / KV+workspace sizing (0 = engine auto)
     int gpu_layers = -1;  // -1 = all on GPU
     int device = 0;
     std::string chat_template = "auto";

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -296,11 +296,12 @@ ImpConfig build_config(const ServerArgs& args, const imp::RuntimeConfig& runtime
     config.device_id = args.device;
 
     // max_seq_len / max_batch_size: 0 = auto-detect in engine.
-    // Override only if explicitly provided via JSON overrides.
+    // JSON override wins; else the --max-batch CLI arg (0 = auto) seeds the
+    // engine sizing. This is the ONLY way to force batched-decode sizing on a
+    // >20 GiB MoE model, whose auto-heuristic picks max_batch_size=1.
     if (overrides.contains("max_seq_len"))
         config.max_seq_len = overrides.value("max_seq_len", 0);
-    if (overrides.contains("max_batch_size"))
-        config.max_batch_size = overrides.value("max_batch_size", 0);
+    config.max_batch_size = overrides.value("max_batch_size", args.max_batch_size);
 
     config.gpu_layers = args.gpu_layers;
     if (args.ssm_fp16)


### PR DESCRIPTION
## Summary

A measured VRAM audit of the fixed workload **Qwen3-Coder-30B-A3B NVFP4, ctx=4096, 8 concurrent** on the single target chip (RTX 5090, 32 GB), plus one shipped reduction and four measured lever verdicts. Every memory claim is measured (`cudaMemGetInfo` + per-pool counters), never estimated.

## What's in here

**Phase 0 — measurement harness (`bccbb599`)**
- `MemAccount` (`src/memory/mem_account.{h,cu}`, gated `diagnostics.vram_audit`, zero overhead by default): lifecycle `cudaMemGetInfo` checkpoints, per-pool `note()` counters, a 2 ms device-used peak sampler, and cudaMallocAsync pool reserved/used/trimmable stats. The existing `VRAMAllocator` only sees ~14 files; the big consumers (KV pool, NVFP4 caches, CUTLASS/cuBLAS workspaces, weights) bypass it via raw `cudaMalloc` — checkpoints close that gap with full coverage.
- New server `--max-batch` flag (the only way to force batched-decode sizing on a >20 GiB MoE model, whose auto-heuristic picks `max_batch_size=1`).
- Load driver + orchestrator under `tools/analysis/`. Append-only breakdown in `docs/vram_audit.md`.

Headline: **28218 MiB resident, peak == resident (+20 MiB)** — no transient prefill spike; the materialized-scores buffer is statically pre-allocated. The budget's `fp8=9861 MiB` line is a phantom reservation (actual `fp8=0` on sm_120).

**Shipped reduction — Phase-0b SF dedup (`f0a630b3`), −1810 MiB**
Phase 0b built a CUTLASS SfAtom buffer per NVFP4-prequant weight (1782 MiB) that Phase 3b immediately orphaned by overwriting `cutlass_nvfp4[ptr]` without freeing it — allocated, dead, resident until exit. Phase 0b now only seeds the decode registration; Phase 3b stays the sole builder (cache byte-identical, 18625 T / 1800.55 MiB). Applies to **every NVFP4-prequant model**.

| metric | before | after | Δ |
|---|---:|---:|---:|
| device resident | 28218 MiB | 26408 MiB | **−1810** |
| device free | 4388 MiB | 6198 MiB | **+41%** |
| PPL (deterministic) | 5.7878 | 5.7878 | **0 — byte-identical** |
| throughput (8 conc) | 124.9 tok/s | 136.8 tok/s | no regression |

**Measured lever verdicts (audit doc, append-only)**
- ❌ ms_ref slab — 0 (already done by #679)
- ❌ cudaMallocAsync pool trim — 32 MiB (pool is ~fully used; residual is CUDA context/cuBLAS)
- ❌ attn_scores → FA2 — VRAM/PPL fine but **−92% pp512** (FA2 ~12× slower at short prefill; the buffer is load-bearing for short-prefill throughput + hd=256 correctness)
- ✅ KV-FP8 (`--kv-fp8`) — viable opt-in: −768 MiB (or unlocks full 8×4096 KV), decode **+0.8%**, prefill parity, at **+0.83% PPL** on 3766-tok natural prose. Default flip needs per-family long-context gates.

The audit's value: three plausible-on-estimate levers refuted before implementation; one real win verified and shipped; one accuracy trade cleanly quantified.

## Verification
- `make verify-fast` green.
- Harness off by default → behavior unchanged.
- SF dedup: separate before/after builds, byte-identical deterministic PPL.
- All throughput A/Bs: `imp-cli --bench`, 12 reps × 2-3 trials, healthy host (13801 MHz mem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)