### PR TITLE
fix(attn): apply attn_logit_softcap on the cuBLAS FP32-S prefill path

### DIFF
--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -352,6 +352,17 @@ __global__ void softcap_fp16_kernel(half* S, int64_t n, float softcap) {
     }
 }
 
+// FP32 counterpart: the use_fp32_s path keeps scores in a float scratch and the
+// FP32 softmax reads them directly, so softcap must be applied to the float
+// buffer here (Gemma-2 attn_logit_softcap=50 was silently dropped on this path).
+__global__ void softcap_fp32_kernel(float* S, int64_t n, float softcap) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float val = S[idx];
+        S[idx] = softcap * tanhf(val / softcap);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Static device pointer arrays for cublasGemmBatchedEx (GQA attention).
 // Allocated once, grown as needed. Layout: [A_ptrs..., B_ptrs..., C_ptrs...]
@@ -480,12 +491,17 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                                    use_fp32_s ? CUDA_R_32F : CUDA_R_16F, ld_s, strideS, n_heads,
                                    CUBLAS_COMPUTE_32F, kGemmAlgo);
 
-        // Softcap (if enabled — only for FP16 path, Gemma-4 has no attn softcap)
-        if (softcap > 0.0f && !use_fp32_s) {
+        // Softcap (if enabled): applied to whichever buffer the softmax reads —
+        // S_f32 on the use_fp32_s path, S_base otherwise. Gemma-2 sets softcap=50;
+        // skipping it on the FP32 path sharpened the softmax incorrectly.
+        if (softcap > 0.0f) {
             int64_t total = static_cast<int64_t>(n_heads) * q_len * kv_len;
             int block = 256;
             int grid_sc = static_cast<int>((total + block - 1) / block);
-            softcap_fp16_kernel<<<grid_sc, block, 0, stream>>>(S_base, total, softcap);
+            if (use_fp32_s)
+                softcap_fp32_kernel<<<grid_sc, block, 0, stream>>>(S_f32, total, softcap);
+            else
+                softcap_fp16_kernel<<<grid_sc, block, 0, stream>>>(S_base, total, softcap);
         }
 
         // Softmax (FP32 or FP16)
@@ -534,12 +550,16 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                             (void**)(s_attn_d_ptrs + 2 * n_heads), use_fp32_s ? CUDA_R_32F : CUDA_R_16F, ld_s,
                             n_heads, CUBLAS_COMPUTE_32F, kGemmAlgo);
 
-        // Softcap (only FP16 path — Gemma-4 has no attn softcap)
-        if (softcap > 0.0f && !use_fp32_s) {
+        // Softcap (if enabled): applied to S_f32 on the use_fp32_s path, else S_base
+        // (same fix as the MHA path above — was dropped on FP32-S for Gemma-2).
+        if (softcap > 0.0f) {
             int64_t total = static_cast<int64_t>(n_heads) * q_len * kv_len;
             int block = 256;
             int grid_sc = static_cast<int>((total + block - 1) / block);
-            softcap_fp16_kernel<<<grid_sc, block, 0, stream>>>(S_base, total, softcap);
+            if (use_fp32_s)
+                softcap_fp32_kernel<<<grid_sc, block, 0, stream>>>(S_f32, total, softcap);
+            else
+                softcap_fp16_kernel<<<grid_sc, block, 0, stream>>>(S_base, total, softcap);
         }
 
         // Softmax

--- a/tests/test_attention_crosspath.cu
+++ b/tests/test_attention_crosspath.cu
@@ -378,5 +378,24 @@ TEST_F(AttentionCrossPathTest, SharpLongGQA_F32ChainStrict) {
                imp_refs::sharp_long_gqa_spot_idx, imp_refs::sharp_long_gqa_spot_val, 64);
 }
 
+// Regression for the FP32-S softcap drop (Gemma-2 attn_logit_softcap=50).
+// The mild softcap config above keeps scores << 50, so tanh(s/50)*50 ≈ s and a
+// dropped softcap is invisible. Here softcap=2 with amp=8 SATURATES the cap
+// (|score| >> 2 → tanh(s/2)*2 → ±2), so the cuBLAS FP32-S path (and the
+// pairwise-equal fa2_f16 path, which applies softcap) MUST cap or they diverge
+// from the capped fp64 reference. No committed golden spots (n_spots=0): the
+// in-test fp64 ref IS ground truth here. Covers both the MHA and GQA softcap
+// launch sites in attention_cublas_prefill. Was RED before the FP32-S softcap
+// kernel was added (softcap was gated behind !use_fp32_s).
+TEST_F(AttentionCrossPathTest, SaturatingSoftcap_FP32S_MHA) {
+    run_config(4, "saturating_softcap_mha", 64, 64, 4, 4, 128, true, 0, /*softcap=*/2.0f, 8.0f,
+               /*mild=*/false, nullptr, nullptr, 0);
+}
+
+TEST_F(AttentionCrossPathTest, SaturatingSoftcap_FP32S_GQA) {
+    run_config(5, "saturating_softcap_gqa", 64, 64, 8, 2, 128, true, 0, /*softcap=*/2.0f, 8.0f,
+               /*mild=*/false, nullptr, nullptr, 0);
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## Summary

`attn_logit_softcap` was silently dropped on the materialized cuBLAS prefill path whenever the FP32-S scratch was used — which is the **default** in normal prefill. Found during an adversarial audit of the cuBLAS attention path.

## The bug

In `attention_cublas_prefill` the softcap pass was gated:

```cpp
if (softcap > 0.0f && !use_fp32_s) { softcap_fp16_kernel<<<...>>>(S_base, ...); }
```

and the FP32 softmax kernel (`causal_softmax_fp32_to_fp16_kernel`) reads the raw scores with no `softcap*tanh(s/softcap)` step. `use_fp32_s = (s_fp32_elems*2 <= s_buf_fp16_elems)` is **true in normal prefill** (the square `s_cap²` S scratch easily holds 2× the f32 matrix). So any model with `attn_logit_softcap > 0` on the cuBLAS path (head_dim != 128) had softcap dropped → uncapped scores into softmax → wrong, over-sharpened attention.

**Trigger:** Gemma-2 (9B/27B) — `attn_logit_softcapping = 50.0`, loaded as the GEMMA3 arch with head_dim=256, so it skips the hd=128 FA2 fast path and lands on cuBLAS prefill. Gemma-3 (softcapping removed upstream), Gemma-4, Qwen, Llama all have softcap=0 → unaffected, which is why it never surfaced on local models.

## Fix

Add `softcap_fp32_kernel` and apply softcap to whichever buffer the softmax reads — `S_f32` on the use_fp32_s path, `S_base` otherwise — in both the MHA and GQA launch sites. No effect when `softcap == 0` (kernel not launched), so every softcap-free model is byte-identical.

## Validation — red/green proof

The existing `MildSlidingWindowSoftcap` config (amp=2, softcap=50) keeps scores ≪ 50, so `tanh(s/50)*50 ≈ s` and a dropped softcap is invisible — that's why the bug hid. New regression tests use **softcap=2 with amp=8** so the cap saturates (`|score| ≫ 2`):

| | main (no fix) | with fix |
|---|---|---|
| `SaturatingSoftcap_FP32S_MHA` | **FAIL** (cuBLAS vs fp64 ref & vs fa2_f16, max_rel 1.75) | **OK** |
| `SaturatingSoftcap_FP32S_GQA` | **FAIL** (max_rel 1.83) | **OK** |

Both new tests exercise the production FP32-S path (S scratch sized 2×). Full `AttentionCrossPathTest` 6/6, `ChunkedPrefillTest` 6/6 green with the fix.

Caveat: no Gemma-2 model available locally, so the Gemma-2 end-to-end improvement is verified by the saturating-softcap unit tests + static analysis, not an e2e PPL run.

## Test plan
- [ ] CI `Build` green
