### PR TITLE
perf(loader): contiguous slab for NVFP4 MoE expert micro-scales (zero-copy decode borrow)

### DIFF
--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -2039,6 +2039,66 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
             t.on_device = true;
             scale_count++;
         };
+        // NVFP4 MoE expert micro-scales: upload one CONTIGUOUS slab per
+        // (layer, projection) so experts[e].scales = base + e*e_ms. Otherwise
+        // each expert's weight_scale is a separate cudaMallocAsync issued in
+        // unordered_map hash order, landing at non-adjacent addresses
+        // (scales_contig=0) — which forces the decode-cache borrow to allocate
+        // a contiguous copy and free the scattered originals at load time
+        // (pre_dequant_phase3_nvfp4_decode.cu, the #679 copy/free dance). A
+        // single slab makes that borrow truly zero-copy. The per-expert sub-
+        // blocks are byte-identical to the individual uploads, so CUTLASS
+        // SfAtom (Phase-3b) and the fused-projection split are unaffected.
+        {
+            int moe_scale_slabs = 0;
+            auto slab_proj_scales = [&](std::vector<Tensor>& experts, int layer, const char* kind) {
+                const int N = static_cast<int>(experts.size());
+                if (N == 0)
+                    return;
+                std::vector<NvFP4PreQuantWeight*> grp(N, nullptr);
+                size_t e_ms = 0;
+                for (int e = 0; e < N; ++e) {
+                    std::string k =
+                        "L" + std::to_string(layer) + "." + kind + "." + std::to_string(e);
+                    auto it = nvfp4_scratch_.find(k);
+                    if (it == nvfp4_scratch_.end())
+                        return;  // not NVFP4-prequant experts — leave to per-tensor upload
+                    Tensor& ws = it->second.weight_scale;
+                    if (!ws.data || ws.on_device || ws.numel() == 0)
+                        return;
+                    size_t b = ws.nbytes();
+                    if (e == 0)
+                        e_ms = b;
+                    else if (b != e_ms)
+                        return;  // ragged — bail, per-tensor upload still correct
+                    grp[e] = &it->second;
+                }
+                if (e_ms == 0)
+                    return;
+                void* slab = nullptr;
+                if (cudaMallocAsync(&slab, static_cast<size_t>(N) * e_ms, stream) != cudaSuccess)
+                    return;
+                gpu_allocations_.push_back(slab);  // single base alloc; ~Model frees it once
+                for (int e = 0; e < N; ++e) {
+                    Tensor& ws = grp[e]->weight_scale;
+                    void* dst = static_cast<char*>(slab) + static_cast<size_t>(e) * e_ms;
+                    cudaMemcpyAsync(dst, ws.data, e_ms, cudaMemcpyHostToDevice, stream);
+                    ws.data = dst;        // interior pointer — NOT tracked as a base alloc
+                    ws.on_device = true;  // existing upload_scale loop now skips it
+                    scale_count++;
+                }
+                ++moe_scale_slabs;
+            };
+            for (size_t i = 0; i < layers_.size(); ++i) {
+                slab_proj_scales(layers_[i].expert_w_gate, static_cast<int>(i), "expert_w_gate");
+                slab_proj_scales(layers_[i].expert_w_up, static_cast<int>(i), "expert_w_up");
+                slab_proj_scales(layers_[i].expert_w_down, static_cast<int>(i), "expert_w_down");
+            }
+            if (moe_scale_slabs > 0)
+                IMP_LOG_INFO("NVFP4 MoE expert micro-scales: %d contiguous (layer,proj) slabs "
+                             "(zero-copy decode borrow, no load-time scale copy)",
+                             moe_scale_slabs);
+        }
         for (auto& [name, sc] : nvfp4_scratch_) {
             // Audit weight_scale_2 BEFORE upload (it's still a host pointer).
             if (audit && sc.weight_scale_2.data && !sc.weight_scale_2.on_device) {


### PR DESCRIPTION
## Summary

Architectural cleanup of the NVFP4-MoE expert micro-scale upload: lay the per-expert scales out contiguously at load time so the decode-cache borrow is truly zero-copy, eliminating the load-time copy/free dance.

## Background

Each NVFP4 MoE expert's `weight_scale` was uploaded by its own `cudaMallocAsync` while iterating `nvfp4_scratch_` (a `std::unordered_map`) in hash-bucket order. Consecutive experts' micro-scales therefore landed at non-adjacent device addresses → `scales_contig=0` at the decode-cache borrow (`pre_dequant_phase3_nvfp4_decode.cu`). The borrow path then allocated a contiguous copy of all expert scales and freed the scattered originals (the PR #679 copy/free dance) — correct, but a load-time churn with a transient ~1.7 GiB 2× peak.

## Change

Upload the expert micro-scales of each `(layer, projection)` group into **one contiguous slab** up front (`experts[e].scales = base + e*e_ms`), tracked as a single base allocation. Phase-0 promotion then lands contiguous pointers, so Phase-3 sees `scales_contig=1` and borrows zero-copy. The copy + per-expert free no longer run; that branch stays as a defensive fallback for any genuinely non-contiguous upload.

Pure load-time relocation of identical scale bytes — CUTLASS SfAtom (Phase-3b) and the fused-projection scale split read the same per-expert sub-blocks, so neither changes. Steady-state resident VRAM is unchanged (already 1× since #679); the win is a clean zero-copy path and no transient copy/free peak.

## Validation (Qwen3-Coder-30B-A3B-NVFP4)

- `NVFP4 MoE expert micro-scales: 144 contiguous (layer,proj) slabs` (48 layers × 3 proj)
- `scales_contig` **0 → 1**; the `nvfp4_moe_ms_ref` copy + the #679 free dance **no longer fire**
- Coherent output (clean recursive Fibonacci), decode/bench unchanged (kernel untouched)
- PPL on a 2900-tok corpus sits **inside the model's own NVFP4-MoE non-determinism envelope** — three runs of the same build: **16.29 / 16.58 / 16.39** — i.e. no measurable change (byte-identical relocation; an offset bug would gross-corrupt, not land inside the run-to-run spread)

## Test plan
- [ ] CI `Build` green
