### PR TITLE
fix(gpt-oss): full GGUF MoE support (MXFP4→NVFP4 experts, biases, sinks, SWA, residual rescale)

### DIFF
--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -342,14 +342,21 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         // LRU expert cache: keeps recently-used host experts on GPU.
         // Only allocated when some experts reside on host (not all fit in VRAM).
         if (max_expert_raw > 0) {
+            // gpt-oss exemption: its MXFP4 experts are host-resident here only
+            // transiently — pre_dequant converts them to on-device NVFP4 +
+            // CUTLASS-grouped before the first forward. They are never
+            // host-offloaded at runtime, so the LRU cache must not be allocated
+            // (it would shadow the converted device experts → garbage output).
             bool has_host_experts = false;
-            for (int li = 0; li < model_->n_layers(); li++) {
-                const auto& L = model_->layer(li);
-                if ((L.expert_up_packed.data && !L.expert_up_packed.on_device) ||
-                    (L.expert_down_packed.data && !L.expert_down_packed.on_device) ||
-                    (L.expert_gate_packed.data && !L.expert_gate_packed.on_device)) {
-                    has_host_experts = true;
-                    break;
+            if (!model_->profile().is_gpt_oss) {
+                for (int li = 0; li < model_->n_layers(); li++) {
+                    const auto& L = model_->layer(li);
+                    if ((L.expert_up_packed.data && !L.expert_up_packed.on_device) ||
+                        (L.expert_down_packed.data && !L.expert_down_packed.on_device) ||
+                        (L.expert_gate_packed.data && !L.expert_gate_packed.on_device)) {
+                        has_host_experts = true;
+                        break;
+                    }
                 }
             }
             if (has_host_experts && !runtime_config().moe.no_expert_cache) {

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <unordered_set>
+#include <cstring>
 #include <vector>
 
 namespace imp {
@@ -1266,41 +1267,101 @@ if (mx_native > 0) {
 // ---------------------------------------------------------------------------
 void QuantPipeline::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4DecodeContext& dctx) {
     int converted = 0;
+
+    // GGUF path helper: convert one host-resident ggml-MXFP4 expert tensor
+    // ([ne, N, K], separate per projection) into a device NvFP4MoEQuantResult.
+    // ggml type-39 packs each 32-element block as [scale(1) | qs(16)] with
+    // SPLIT nibble order (element j = low nibble of qs[j], j+16 = high nibble);
+    // type-31 packs [qs(16) | scale(1)] in LINEAR pair order. The converter
+    // expects linear pairs + a separate ue8m0 scale plane, so normalize here
+    // (mirrors weight_upload.cu's upload_qtype_mxfp4_). stride=1 because GGUF
+    // stores gate and up as distinct tensors (HF interleaves them, stride=2).
+    auto gguf_convert = [&](const Tensor& t, float extra_scale, NvFP4MoEQuantResult& r,
+                            std::vector<float>& ts) -> bool {
+        if (!t.data || t.ndim < 3)
+            return false;
+        const int ne = static_cast<int>(t.shape[0]);
+        const int64_t N = t.shape[1];
+        const int64_t K = t.shape[2];
+        const int64_t kb = K / 32;  // MXFP4 blocks per row
+        const int64_t nblk = static_cast<int64_t>(ne) * N * kb;
+        std::vector<uint8_t> blocks(static_cast<size_t>(nblk) * 16);
+        std::vector<uint8_t> scales(static_cast<size_t>(nblk));
+        const uint8_t* src = static_cast<const uint8_t*>(t.data);
+        const bool v2 = t.mxfp4_layout_v2;
+        for (int64_t blk = 0; blk < nblk; ++blk) {
+            const uint8_t* sb = src + static_cast<size_t>(blk) * 17;  // 17B ggml block
+            uint8_t* db = blocks.data() + static_cast<size_t>(blk) * 16;
+            if (v2) {
+                scales[blk] = sb[0];
+                const uint8_t* qs = sb + 1;
+                for (int b = 0; b < 16; ++b) {
+                    const int e0 = 2 * b, e1 = 2 * b + 1;
+                    const uint8_t n0 = (e0 < 16) ? (qs[e0] & 0xF) : (qs[e0 - 16] >> 4);
+                    const uint8_t n1 = (e1 < 16) ? (qs[e1] & 0xF) : (qs[e1 - 16] >> 4);
+                    db[b] = static_cast<uint8_t>(n0 | (n1 << 4));
+                }
+            } else {
+                std::memcpy(db, sb, 16);
+                scales[blk] = sb[16];
+            }
+        }
+        return gpt_oss_convert_experts_to_nvfp4(blocks.data(), scales.data(), ne, N, K,
+                                                /*offset=*/0, /*stride=*/1, r, extra_scale, &ts);
+    };
+
     for (int i = 0; i < cfg.n_layers; ++i) {
         TransformerLayer& L = const_cast<Model*>(model_)->layer(i);
+
+        int ne = 0;
+        NvFP4MoEQuantResult g{}, u{}, d{};
+        std::vector<float> g_ts, u_ts, d_ts;
+
         const Tensor& gu_b = L.expert_gate_up_packed_blocks;
         const Tensor& gu_s = L.expert_gate_up_packed_scales;
         const Tensor& dn_b = L.expert_down_packed_blocks;
         const Tensor& dn_s = L.expert_down_packed_scales;
-        if (!gu_b.data || !gu_s.data || !dn_b.data || !dn_s.data)
-            continue;
-        if (gu_b.on_device || dn_b.on_device) {
-            IMP_LOG_ERROR("gpt-oss L%d: packed expert tensors unexpectedly on device — skipping", i);
-            continue;
-        }
-        const int ne = static_cast<int>(gu_b.shape[0]);
-        const int64_t gu_rows = gu_b.shape[1];           // 2*d_ff, interleaved
-        const int64_t gu_K = gu_b.shape[2] * 32;         // K from block count
-        const int64_t dn_rows = dn_b.shape[1];           // d_model
-        const int64_t dn_K = dn_b.shape[2] * 32;         // d_ff
 
-        NvFP4MoEQuantResult g{}, u{}, d{};
-        std::vector<float> g_ts, u_ts, d_ts;
-        bool ok = gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
-                                                   static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
-                                                   gu_K, /*offset=*/0, /*stride=*/2, g, 1.0f, &g_ts) &&
-                  gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
-                                                   static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
-                                                   gu_K, /*offset=*/1, /*stride=*/2, u, 1.0f, &u_ts) &&
-                  // down: extra 2^-4 — residual-stream rescale (see arch
-                  // registry comment in model.cpp; bias scaled in the loader).
-                  gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(dn_b.data),
-                                                   static_cast<const uint8_t*>(dn_s.data), ne, dn_rows,
-                                                   dn_K, /*offset=*/0, /*stride=*/1, d,
-                                                   /*extra_scale=*/0.0625f, &d_ts);
-        if (!ok) {
-            IMP_LOG_ERROR("gpt-oss L%d: MXFP4→NVFP4 expert conversion failed (VRAM?)", i);
-            return;
+        if (gu_b.data && gu_s.data && dn_b.data && dn_s.data) {
+            // SafeTensors: HF packed blocks (gate_up interleaved, down separate).
+            if (gu_b.on_device || dn_b.on_device) {
+                IMP_LOG_ERROR("gpt-oss L%d: packed expert tensors unexpectedly on device — skipping", i);
+                continue;
+            }
+            ne = static_cast<int>(gu_b.shape[0]);
+            const int64_t gu_rows = gu_b.shape[1];   // 2*d_ff, interleaved
+            const int64_t gu_K = gu_b.shape[2] * 32;  // K from block count
+            const int64_t dn_rows = dn_b.shape[1];   // d_model
+            const int64_t dn_K = dn_b.shape[2] * 32;  // d_ff
+            bool ok = gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
+                                                       static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
+                                                       gu_K, /*offset=*/0, /*stride=*/2, g, 1.0f, &g_ts) &&
+                      gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(gu_b.data),
+                                                       static_cast<const uint8_t*>(gu_s.data), ne, gu_rows,
+                                                       gu_K, /*offset=*/1, /*stride=*/2, u, 1.0f, &u_ts) &&
+                      // down: extra 2^-4 — residual-stream rescale (see arch
+                      // registry comment in model.cpp; bias scaled in the loader).
+                      gpt_oss_convert_experts_to_nvfp4(static_cast<const uint8_t*>(dn_b.data),
+                                                       static_cast<const uint8_t*>(dn_s.data), ne, dn_rows,
+                                                       dn_K, /*offset=*/0, /*stride=*/1, d,
+                                                       /*extra_scale=*/0.0625f, &d_ts);
+            if (!ok) {
+                IMP_LOG_ERROR("gpt-oss L%d: MXFP4→NVFP4 expert conversion failed (VRAM?)", i);
+                return;
+            }
+        } else if (L.expert_gate_packed.data && !L.expert_gate_packed.on_device &&
+                   L.expert_gate_packed.qtype == QType::MXFP4) {
+            // GGUF: separate ggml-MXFP4 gate/up/down expert tensors (host-mmap),
+            // kept host-resident by weight_upload's gpt-oss carve-out.
+            ne = static_cast<int>(L.expert_gate_packed.shape[0]);
+            if (!gguf_convert(L.expert_gate_packed, 1.0f, g, g_ts) ||
+                !gguf_convert(L.expert_up_packed, 1.0f, u, u_ts) ||
+                !gguf_convert(L.expert_down_packed, 0.0625f, d, d_ts)) {
+                IMP_LOG_ERROR("gpt-oss L%d: GGUF MXFP4→NVFP4 expert conversion failed", i);
+                return;
+            }
+        } else {
+            continue;  // no convertible expert source on this layer
         }
 
         auto install = [&](NvFP4MoEQuantResult& r, Tensor& packed_slot) {

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <unordered_map>
@@ -612,8 +613,16 @@ static bool assign_tensor(Model& model, const std::string& name, const Tensor& t
                 layer.v_bias = tensor;
             else
                 assign_quant(layer.wv, tensor);
-        } else if (field == "attn_output")
-            assign_quant(layer.wo, tensor);
+        } else if (field == "attn_output") {
+            // gpt-oss adds an output-projection bias.
+            if (suffix == "bias")
+                layer.o_bias = tensor;
+            else
+                assign_quant(layer.wo, tensor);
+        }
+        // gpt-oss learned attention sinks: per-head sink logits [n_heads].
+        else if (field == "attn_sinks")
+            layer.attn_sinks = tensor;
         else if (field == "attn_norm")
             layer.attn_norm = tensor;
         else if (field == "attn_q_norm")
@@ -691,21 +700,33 @@ static bool assign_tensor(Model& model, const std::string& name, const Tensor& t
             // this branch the scale would be silently misassigned to layer.moe_gate.
             if (suffix == "scale")
                 layer.ffn_gate_inp_scale = tensor;
+            else if (suffix == "bias")
+                layer.router_bias = tensor;  // gpt-oss router logits bias [n_experts]
             else
                 layer.moe_gate = tensor;
         }
-        // Packed expert tensors: 3D [n_experts, rows, cols]
-        else if (field == "ffn_gate_exps")
-            assign_quant(layer.expert_gate_packed, tensor);
-        else if (field == "ffn_up_exps")
-            assign_quant(layer.expert_up_packed, tensor);
-        else if (field == "ffn_down_exps") {
+        // Packed expert tensors: 3D [n_experts, rows, cols]. gpt-oss adds a
+        // per-expert .bias on each projection — without the suffix split the
+        // bias tensor clobbers the packed weight (load order dependent).
+        else if (field == "ffn_gate_exps") {
+            if (suffix == "bias")
+                layer.expert_gate_bias = tensor;
+            else
+                assign_quant(layer.expert_gate_packed, tensor);
+        } else if (field == "ffn_up_exps") {
+            if (suffix == "bias")
+                layer.expert_up_bias = tensor;
+            else
+                assign_quant(layer.expert_up_packed, tensor);
+        } else if (field == "ffn_down_exps") {
             // Distinguish .weight (the per-expert FFN down weights) from .scale
-            // (per-expert output multiplier, shape [n_expert]). Same 4-part-name
-            // bug as ffn_gate_inp.scale: the scale tensor would otherwise overwrite
-            // expert_down_packed.
+            // (per-expert output multiplier, shape [n_expert]) and gpt-oss's
+            // per-expert .bias. Same 4-part-name bug as ffn_gate_inp.scale: a
+            // non-weight tensor would otherwise overwrite expert_down_packed.
             if (suffix == "scale")
                 layer.expert_down_scale = tensor;
+            else if (suffix == "bias")
+                layer.expert_down_bias = tensor;
             else
                 assign_quant(layer.expert_down_packed, tensor);
         }
@@ -1292,6 +1313,27 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
         // the loaded tensor shapes, not GGUF metadata.
     }
 
+    // gpt-oss: alternating attention — even layers use sliding-window (128),
+    // odd layers use full attention. HF encodes this via layer_types[]; the
+    // GGUF omits the per-layer array (only a scalar attention.sliding_window),
+    // so derive the documented gpt-oss pattern here. Without swa_layers the
+    // ModelProfile resolves attn=standard and every layer runs full attention
+    // → wrong output (PPL ~3000 instead of ~4.7).
+    if (cfg.arch == ModelArch::GPT_OSS) {
+        if (cfg.sliding_window <= 0)
+            cfg.sliding_window = static_cast<int>(get_uint("attention.sliding_window", 128));
+        if (cfg.sliding_window <= 0)
+            cfg.sliding_window = 128;
+        if (cfg.swa_layers.empty()) {
+            cfg.swa_layers.resize(cfg.n_layers, 0);
+            for (int i = 0; i < cfg.n_layers; i++)
+                cfg.swa_layers[i] = ((i % 2) == 0) ? 1 : 0;  // even = sliding_attention
+        }
+        IMP_LOG_INFO("gpt-oss: SWA pattern derived — %zu/%d sliding (even layers, window=%d), rest full",
+                     std::count(cfg.swa_layers.begin(), cfg.swa_layers.end(), uint8_t(1)), cfg.n_layers,
+                     cfg.sliding_window);
+    }
+
     // Attention logit softcapping (Gemma-2/3: tanh(score/cap)*cap)
     cfg.attn_logit_softcap = static_cast<float>(get_float("attn_logit_softcapping", 0.0));
     if (cfg.attn_logit_softcap == 0.0f)
@@ -1659,6 +1701,127 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
         if (n_moe > 0 && n_moe < cfg.n_layers && n_dense_ffn == 0 && n_ssm == 0) {
             IMP_LOG_WARN("Only %d/%d layers have MoE, remaining layers have no FFN", n_moe, cfg.n_layers);
         }
+    }
+
+    // gpt-oss residual-stream 2^-4 rescale (#547, GGUF parity with the
+    // SafeTensors loader). gpt-oss's huge activations overflow imp's FP16
+    // hidden state (hidden L2 reaches ±inf by ~L23 → NaN logits / garbage
+    // decode). Scaling every contributor to the residual stream by 2^-4 is
+    // exact for the model output: the FP16/RMSNorm path is scale-invariant and
+    // the lm_head reads only normed values. Contributors handled elsewhere:
+    //   - embeddings: cfg.embed_scale = 2^-4 (arch registry)
+    //   - expert down weights: tensor_scales in the MXFP4→NVFP4 converter
+    //     (pre_dequant_phase3_nvfp4_decode.cu)
+    // Handled here, host-side (GGUF is mmap'd read-only, so scale into fresh
+    // host_owned_buffers_): attention output Wo + o_bias, and expert down bias.
+    if (cfg.arch == ModelArch::GPT_OSS) {
+        // The GGUF tensor `blk.N.post_attention_norm.weight` is gpt-oss's
+        // PRE-FFN norm (llama convention: post_attention_layernorm gates the
+        // FFN/MoE input — see weight_map.cpp's SafeTensors mapping → ffn_norm).
+        // The generic 4-part handler routed it to post_attn_norm (the Gemma-3
+        // sandwich-norm slot), so the MoE ran on the UN-normalized residual →
+        // router logits ~10x too large → wrong expert selection → garbage.
+        // Move it to ffn_norm (gpt-oss has no sandwich norm).
+        for (auto& ly : model->layers_) {
+            if (!ly.ffn_norm.data && ly.post_attn_norm.data) {
+                ly.ffn_norm = ly.post_attn_norm;
+                ly.post_attn_norm = Tensor();
+            }
+        }
+
+        // ×2^-4 helpers for each dtype a gpt-oss residual contributor (Wo,
+        // o_bias, expert down bias) can appear in across GGUF quants. Q8_0
+        // (Wo on the official mxfp4 GGUF) shifts each block's fp16 d; F16/BF16
+        // (Wo/biases on f16/bf16 GGUFs) shift the per-value exponent (lossless);
+        // F32 (biases) multiplies. All write into fresh host_owned_buffers_
+        // (the GGUF mmap is read-only).
+        auto scale_f32 = [&](Tensor& t) -> bool {
+            int64_t n = t.numel();
+            float* dst = static_cast<float*>(std::malloc(sizeof(float) * n));
+            if (!dst)
+                return false;
+            const float* src = static_cast<const float*>(t.data);
+            for (int64_t i = 0; i < n; i++)
+                dst[i] = src[i] * 0.0625f;
+            model->host_owned_buffers_.push_back(dst);
+            t.data = dst;
+            return true;
+        };
+        // exp_bits/exp_pos: F16 = 5 bits at 10; BF16 = 8 bits at 7. Subtract 4
+        // from the biased exponent; underflow (exp<=4) → signed zero.
+        auto scale_half_like = [&](Tensor& t, int exp_pos, int exp_mask) -> bool {
+            int64_t n = t.numel();
+            uint16_t* dst = static_cast<uint16_t*>(std::malloc(sizeof(uint16_t) * n));
+            if (!dst)
+                return false;
+            const uint16_t* src = static_cast<const uint16_t*>(t.data);
+            const uint16_t sub = static_cast<uint16_t>(4u << exp_pos);
+            for (int64_t i = 0; i < n; i++) {
+                uint16_t v = src[i];
+                int exp = (v >> exp_pos) & exp_mask;
+                if (exp == exp_mask || exp == 0)
+                    dst[i] = v;  // inf/nan/zero/subnormal
+                else if (exp <= 4)
+                    dst[i] = static_cast<uint16_t>(v & 0x8000u);
+                else
+                    dst[i] = static_cast<uint16_t>(v - sub);
+            }
+            model->host_owned_buffers_.push_back(dst);
+            t.data = dst;
+            return true;
+        };
+        auto scale_q8_0 = [&](Tensor& t) -> bool {
+            int64_t n = t.numel();
+            if (n % 32 != 0) {
+                IMP_LOG_ERROR("gpt-oss GGUF rescale: Q8_0 numel %lld not 32-block-aligned", (long long)n);
+                return false;
+            }
+            int64_t nblocks = n / 32;
+            size_t bytes = static_cast<size_t>(nblocks) * 34;  // [fp16 d | 32 int8]
+            uint8_t* dst = static_cast<uint8_t*>(std::malloc(bytes));
+            if (!dst)
+                return false;
+            std::memcpy(dst, t.data, bytes);
+            for (int64_t b = 0; b < nblocks; b++) {
+                uint16_t* d = reinterpret_cast<uint16_t*>(dst + static_cast<size_t>(b) * 34);
+                uint16_t v = *d;
+                int exp = (v >> 10) & 0x1F;
+                if (exp == 0x1F || exp == 0)
+                    continue;
+                if (exp <= 4)
+                    *d = static_cast<uint16_t>(v & 0x8000u);
+                else
+                    *d = static_cast<uint16_t>(v - (4u << 10));
+            }
+            model->host_owned_buffers_.push_back(dst);
+            t.data = dst;
+            return true;
+        };
+        auto scale_any = [&](Tensor& t) -> bool {
+            if (!t.data || t.on_device)
+                return true;
+            switch (t.qtype) {
+                case QType::F32:
+                    return scale_f32(t);
+                case QType::F16:
+                    return scale_half_like(t, 10, 0x1F);
+                case QType::BF16:
+                    return scale_half_like(t, 7, 0xFF);
+                case QType::Q8_0:
+                    return scale_q8_0(t);
+                default:
+                    IMP_LOG_ERROR("gpt-oss GGUF rescale: unsupported qtype %d", (int)t.qtype);
+                    return false;
+            }
+        };
+        bool ok = true;
+        for (auto& ly : model->layers_)
+            ok = ok && scale_any(ly.wo) && scale_any(ly.o_bias) && scale_any(ly.expert_down_bias);
+        if (!ok) {
+            IMP_LOG_ERROR("gpt-oss GGUF: residual-stream rescale failed");
+            return nullptr;
+        }
+        IMP_LOG_INFO("gpt-oss GGUF: residual stream rescaled by 2^-4 (Wo + o_bias + expert down bias)");
     }
 
     // 8. Extract tokenizer from GGUF metadata

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -797,6 +797,11 @@ struct UploadCtx {
     // at conversion time. Applied only on BF16-source paths in upload_weight().
     // Set to 1.0f for QWEN35[_MOE]/QWEN36_MOE, 0.0f otherwise.
     float arch_norm_offset = 0.0f;
+    // gpt-oss MXFP4 MoE experts must stay host-resident through weight upload:
+    // the MXFP4→NVFP4 conversion runs at pre_dequant (needs the executor's
+    // wcache). Set true for ModelArch::GPT_OSS so upload_packed_experts skips
+    // them instead of uploading raw MXFP4 the executor cannot consume.
+    bool is_gpt_oss = false;
 };
 
 // ---------------------------------------------------------------------------
@@ -1616,6 +1621,16 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
             if (packed.on_device)
                 return true;  // already on GPU (e.g. from Gemma 4 fused split)
 
+            // gpt-oss MXFP4 experts: keep host-resident raw. The executor's
+            // pre_dequant phase converts them to NVFP4 + registers the CUTLASS
+            // grouped path (gpt_oss_convert_moe_experts_). Uploading raw MXFP4
+            // here would leave them in a format no MoE kernel consumes (NaN);
+            // the F16-slice fallback below also mis-strides MXFP4 bytes.
+            if (ctx.is_gpt_oss && qtype == QType::MXFP4) {
+                IMP_LOG_DEBUG("  %s: gpt-oss MXFP4 experts kept host-resident for NVFP4 convert", name);
+                return true;
+            }
+
             int n_experts = static_cast<int>(packed.shape[0]);
             int64_t rows = packed.shape[1];
             int64_t cols = packed.shape[2];
@@ -1939,8 +1954,9 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
                                     config_.arch == ModelArch::QWEN36_MOE)
                                        ? 1.0f
                                        : 0.0f;
+    const bool is_gpt_oss = (config_.arch == ModelArch::GPT_OSS);
     UploadCtx ctx{compute_dtype,       stream,          gpu_allocations_, host_pinned_,
-                  host_pinned_allocs_, arch_norm_offset};
+                  host_pinned_allocs_, arch_norm_offset, is_gpt_oss};
 
     // --- Embeddings, output norm, output projection ---
     if (!upload_embeddings_and_output(tok_emb_, out_norm_, out_proj_, ctx)) {

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -188,8 +188,14 @@ bool Engine::init_weights() {
                  free_after / (1024 * 1024), total_after / (1024 * 1024),
                  (free_before - free_after) / (1024 * 1024));
 
-    // Check for host-resident expert weights
-    if (mcfg.n_experts > 0) {
+    // Check for host-resident expert weights.
+    // gpt-oss is exempt: its MXFP4 experts are intentionally kept host-resident
+    // through upload (weight_upload's carve-out) and converted to on-device
+    // NVFP4 + CUTLASS-grouped at pre_dequant. They are NOT host-offloaded at
+    // decode, so treating them as on-host here would wrongly enable the LRU
+    // host-offload path (reading the post-convert device pointers as host
+    // MXFP4 → garbage) and disable CUDA graphs.
+    if (mcfg.n_experts > 0 && !model_->profile().is_gpt_oss) {
         for (int i = 0; i < mcfg.n_layers; i++) {
             if (model_->layer(i).expert_up_packed.data && !model_->layer(i).expert_up_packed.on_device) {
                 experts_on_host_ = true;


### PR DESCRIPTION
## Summary
gpt-oss-20b **GGUF** previously produced NaN on MoE prefill and degenerate decode (`<|startoftext|>` loop). Root cause: the GGUF loader never ran the gpt-oss MXFP4→NVFP4 expert conversion + CUTLASS-grouped registration that the SafeTensors path does (`wcache nvfp4_moe=0`), so the `experts_st_nvfp4` short-circuit skipped the FP16 prefill buffers with no valid expert path behind it. gpt-oss GGUF support was essentially absent, not just the MoE conversion — this adds the missing pieces, mirroring the SafeTensors loader.

- **Loader field-routing:** route gpt-oss `.bias` tensors (`attn_output`→o_bias, `attn_sinks`, `ffn_gate_inp`→router_bias, `ffn_{gate,up,down}_exps`→expert_*_bias) instead of letting them clobber the `.weight` slots (no suffix check before → load-order-dependent corruption).
- **MoE convert GGUF branch:** ggml type-39 split-nibble MXFP4 → linear-pair reorder + separate gate/up (stride=1) / down (extra_scale=0.0625) → NvFP4 grouped. Dequant **bit-identical** to the HF-MXFP4 reference.
- **Host-residency carve-out:** keep gpt-oss MXFP4 experts host-resident through weight upload + exempt them from the LRU host-offload path (weight_upload / executor / engine) so the converted on-device NVFP4 experts are not shadowed → CUDA graphs stay enabled.
- **SWA pattern derived** (even = sliding-window, odd = full; GGUF omits `layer_types[]`, only a scalar `attention.sliding_window`).
- **Residual-stream 2^-4 rescale** for every GGUF dtype a contributor can appear in (Wo Q8_0/F16/BF16; o_bias / expert-down bias F32/F16/BF16) into fresh `host_owned_buffers_` (the GGUF mmap is read-only); plus `post_attention_norm`→`ffn_norm` move (gpt-oss has a pre-FFN norm, no sandwich norm).

## Test Plan
- [x] `make build` — green (CUDA 13.3)
- [x] Unit: gpt-oss MoE-dispatch + MXFP4 suites — 6/6 pass
- [x] E2E GPU on BF16-dense + MXFP4-experts gpt-oss-20b GGUF: **coherent decode** ("…the answer: Paris"), **CUTLASS NVFP4 grouped prefill active** (`nvfp4_moe=72 cutlass_nvfp4=2304` = SafeTensors parity), **no NaN**.
- [x] Perplexity 4.60 — matches SafeTensors 4.73 / HF bf16 4.607 (the correctness gate; wrong nibble order = fluent garbage that misses ~4.6).
- [x] `verify-fast` (pre-push hook) — OK

## Notes
Q8_0-dense gpt-oss GGUFs remain an imp F16-hidden-state precision edge case (coherent in llama.cpp's F32 path; gpt-oss's extreme embedding outliers + Q8_0 block scale corrupt routing-load-bearing dims). That's a separate optional enhancement (F32 hidden state for gpt-oss) — **not required**, since f16/bf16-dense gpt-oss GGUFs now work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)