### PR TITLE
fix(gemm): gemm_kv_batched wrote V at the wrong stride — first-forward V was silently stale (#677)

### DIFF
--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -475,8 +475,24 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
     if (S.ndim >= 3)
         s_buf_fp16_elems *= S.shape[2];
     int64_t s_fp32_elems = static_cast<int64_t>(n_heads) * q_len * kv_len;
-    bool use_fp32_s = (s_fp32_elems * 2 <= s_buf_fp16_elems);
+    // FP32-S needs 3× the score element count, not 2× (#677): the FP32 QK^T
+    // scores occupy the front 2·s_fp32_elems half-slots, and the FP16
+    // probabilities are written to a SEPARATE, non-overlapping region right
+    // after them (S_prob below). Aliasing the two (the old fused in-place
+    // FP32→FP16 downcast wrote FP16 over the front half of the FP32 scores)
+    // is a cross-block WAR hazard: the FP16 output of a higher (head,row)
+    // block overwrites the FP32 scores of a lower block before that block has
+    // read them, so the softmax result depends on block-scheduling order and
+    // the buffer's prior contents — nondeterministic across forward calls. The
+    // band where 2×≤buf<3× falls back to the FP16-S softmax (read/write FP16 at
+    // the SAME address per element — no aliasing); in practice cuBLAS prefill
+    // only serves small/moderate n (large n routes to FA2/FMHA), so FP32-S is
+    // retained wherever it matters (deep-layer NaN avoidance).
+    bool use_fp32_s = (s_fp32_elems * 3 <= s_buf_fp16_elems);
     float* S_f32 = use_fp32_s ? reinterpret_cast<float*>(S.data) : nullptr;
+    // FP16 probabilities: non-overlapping with the FP32 scores on the FP32-S
+    // path; identical to S_base on the FP16-S path (in-place, safe).
+    half* S_prob = use_fp32_s ? (S_base + 2 * s_fp32_elems) : S_base;
 
     if (gqa_ratio == 1) {
         // ---------------------------------------------------------------
@@ -515,16 +531,17 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                 // probabilities to S_base directly. Replaces softmax_fp32_inplace
                 // + fp32_to_fp16_kernel pair (saves one full pass over the tensor).
                 causal_softmax_fp32_to_fp16_kernel<<<grid, threads, 0, stream>>>(
-                    S_f32, S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
+                    S_f32, S_prob, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
             } else {
                 causal_softmax_inplace_kernel<<<grid, threads, 0, stream>>>(
                     S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
             }
         }
 
-        // O = P × V (always FP16)
+        // O = P × V (always FP16). P is read from S_prob (== S_base on the
+        // FP16-S path; the non-overlapping FP16 region on the FP32-S path).
         cublasGemmStridedBatchedEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, head_dim, q_len, kv_len, &one_f,
-                                   V_base, CUDA_R_16F, ld_k, static_cast<long long>(head_dim), S_base,
+                                   V_base, CUDA_R_16F, ld_k, static_cast<long long>(head_dim), S_prob,
                                    CUDA_R_16F, ld_s, strideS, &zero_f, O_base, CUDA_R_16F, ld_o,
                                    static_cast<long long>(head_dim), n_heads, CUBLAS_COMPUTE_32F, kGemmAlgo);
 
@@ -571,7 +588,7 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
             if (use_fp32_s) {
                 // Fused FP32 softmax + downcast (see MHA path above).
                 causal_softmax_fp32_to_fp16_kernel<<<grid, threads, 0, stream>>>(
-                    S_f32, S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
+                    S_f32, S_prob, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
             } else {
                 causal_softmax_inplace_kernel<<<grid, threads, 0, stream>>>(
                     S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
@@ -580,9 +597,10 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
 
         // Step 3: O = P × V — re-fill pointer arrays device-side for the
         // second cuBLAS call. cuBLAS: C = alpha * A * B with A=V (OP_N),
-        // B=P (OP_N). A is GQA-shared, B and C are per-head.
+        // B=P (OP_N). A is GQA-shared, B and C are per-head. P is read from
+        // S_prob (non-overlapping FP16 region on the FP32-S path, #677).
         launch_build_attn_ptrs(s_attn_d_ptrs, n_heads, V_base,
-                               static_cast<int64_t>(head_dim) * sizeof(half), S_base,
+                               static_cast<int64_t>(head_dim) * sizeof(half), S_prob,
                                static_cast<int64_t>(strideS) * sizeof(half), O_base,
                                static_cast<int64_t>(head_dim) * sizeof(half), gqa_ratio, stream);
 

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -1711,7 +1711,27 @@ void gemm_kv_batched(const Tensor& input, const Tensor& weight_kv, Tensor& k_out
     //   input  [M,K] row-major = [K,M] col-major; CUBLAS_OP_N
     //   result [N,M] col-major = [M,N] row-major
     long long weight_stride = static_cast<long long>(N) * K;  // stride between wk and wv in weight_kv
-    long long output_stride = static_cast<long long>(M) * N;  // stride between k_out and v_out
+    // strideC: derive from the ACTUAL pointer distance between the two output
+    // views, like gemm_pair_batched. The old `M*N` only matched the workspace
+    // layout when M == the buffer's max_tokens (the engine maintains that via
+    // resize_workspace, the raw-executor path does not) — for M < max_tokens
+    // the V batch landed inside the K buffer and v_out stayed stale (#677:
+    // first-forward V was silently zero/garbage).
+    long long output_stride = (static_cast<const char*>(v_out.data) -
+                               static_cast<const char*>(k_out.data)) /
+                              static_cast<long long>(dtype_size(input.qtype));
+    if (output_stride < static_cast<long long>(M) * N) {
+        // Outputs not laid out batched-compatibly (or overlapping): fall back
+        // to two separate GEMMs rather than corrupting V.
+        int64_t w_shape[2] = {N, K};
+        Tensor wk(weight_kv.data, weight_kv.qtype, 2, w_shape, true);
+        Tensor wv(static_cast<char*>(weight_kv.data) +
+                      weight_stride * static_cast<long long>(dtype_size(weight_kv.qtype)),
+                  weight_kv.qtype, 2, w_shape, true);
+        gemm(input, wk, k_out, alpha, beta, stream);
+        gemm(input, wv, v_out, alpha, beta, stream);
+        return;
+    }
 
     cublasStatus_t st = cublasGemmStridedBatchedEx(handle, CUBLAS_OP_T, CUBLAS_OP_N, N, M,
                                                    K,                              // cuBLAS m, n, k


### PR DESCRIPTION
## Summary
`QuantIntegrationTest.Q4_0Deterministic` failed reproducibly on main (#677): two identical greedy prefill forwards returned different tokens (31 vs 30).

**Root cause** (traced via per-stage dumps: Q/K/scores/softmax all correct, V = 0 on the first forward only): `gemm_kv_batched` hardcoded the batched-GEMM output stride as `M*N`, but the attention workspace lays out `k_`/`v_` contiguously at `max_tokens*N` — the layout comment even states `output_stride = kv_raw / es`. The engine masks the mismatch by resizing the shared workspace so `M == max_tokens`; the raw-executor path (tests, direct `forward()` callers) does not. For `M < max_tokens` the V batch landed **inside the k_ buffer** and `v_out` was never written — the first forward ran attention with V = stale scratch (zeros), later forwards read whatever scratch reuse left there. Silently wrong V surfacing as "nondeterminism".

- **Fix:** derive strideC from the actual `v_out`/`k_out` pointer distance — the same approach `gemm_pair_batched` already uses since 98b1ae84; the KV variant was missed back then (introduced in e1284ed1). A no-overlap guard falls back to two separate GEMMs for incompatible layouts.
- **Also fixed (found in the same investigation):** latent cross-block WAR hazard in `attention_cublas_prefill`'s fused FP32→FP16 softmax downcast — FP16 probabilities were written over the front half of the FP32 score buffer being concurrently read (block X's output overlaps block X/2's unread input; result depended on block scheduling). Probabilities now go to a separate region behind the FP32 scores; the FP32-S capacity gate tightens 2x→3x score elements with the documented FP16-S softmax as the fallback band.

## Test Plan
- [x] `QuantIntegrationTest.Q4_0Deterministic`: 4/4 green (was 0/5 on main)
- [x] `QuantIntegrationTest.*`: 22/22
- [x] Attention/cuBLAS/FA2 GPU suites: green
- [x] Real-model coherence: Qwen3-8B-Q8 (fused-KV **short** prefill, n=13 — exactly the case the stride fix protects) and gemma-3-12b (hd=256 cuBLAS prefill, exercises the S_prob change) both decode coherent ("Paris")
- [x] `verify-fast` pre-push gate: OK

Fixes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)