### PR TITLE
fix(graph): conditional-loop first forward ran one position too high (#683)

### DIFF
--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -855,8 +855,22 @@ ImpError imp_decode_step(ImpContext ctx, const ImpGenerateParams* params, int32_
             req->status = imp::RequestStatus::DECODING;
         }
 
+        // Drain unconsumed tokens BEFORE the finished check — a multi-token
+        // step (spec-ngram verify chunk) can emit several tokens AND finish
+        // the request in the same engine step; returning the error here would
+        // drop the queued tail (#683: CLI output ended mid-chunk).
+        if (ctx->consumed_output < req->output_tokens.size()) {
+            *out_token = req->output_tokens[ctx->consumed_output++];
+            if (req->status == imp::RequestStatus::FINISHED &&
+                ctx->consumed_output >= req->output_tokens.size()) {
+                ctx->active_request = nullptr;
+            }
+            return IMP_SUCCESS;
+        }
+
         // Check if already finished
         if (req->status == imp::RequestStatus::FINISHED || req->status == imp::RequestStatus::CANCELLED) {
+            ctx->active_request = nullptr;
             return IMP_ERROR_INTERNAL;
         }
 
@@ -867,37 +881,31 @@ ImpError imp_decode_step(ImpContext ctx, const ImpGenerateParams* params, int32_
         req->top_logprobs = std::max(0, std::min(20, params->top_logprobs));
         req->json_mode = (params->json_mode != 0);
 
-        // Self-speculative (and future multi-token) steps may produce
-        // multiple tokens per engine->step().  Track how many have been
-        // consumed so we only call step() when all previous tokens are
-        // returned to the caller.
-        if (ctx->consumed_output < req->output_tokens.size()) {
-            // Still have unconsumed tokens from a previous multi-token step
-            *out_token = req->output_tokens[ctx->consumed_output++];
-        } else {
-            // Need a new engine step. A step may legitimately yield ZERO new
-            // tokens when it only launches an async graph-loop burst (n-gram
-            // speculation miss path) — the burst's tokens arrive on the next
-            // step's drain. Retry a bounded number of times; a persistent
-            // zero-token stream is still an internal error.
-            size_t prev_output_size = req->output_tokens.size();
-            for (int attempts = 0;
-                 attempts < 8 && req->output_tokens.size() == prev_output_size &&
-                 req->status == imp::RequestStatus::DECODING;
-                 ++attempts) {
-                (void)ctx->engine->step();
-            }
-
-            if (req->output_tokens.size() > prev_output_size) {
-                ctx->consumed_output = prev_output_size;
-                *out_token = req->output_tokens[ctx->consumed_output++];
-            } else {
-                return IMP_ERROR_INTERNAL;
-            }
+        // Need a new engine step (the multi-token drain above returned any
+        // leftovers). A step may legitimately yield ZERO new tokens when it
+        // only launches an async graph-loop burst (n-gram speculation miss
+        // path) — the burst's tokens arrive on the next step's drain. Retry a
+        // bounded number of times; a persistent zero-token stream is still an
+        // internal error.
+        size_t prev_output_size = req->output_tokens.size();
+        for (int attempts = 0;
+             attempts < 8 && req->output_tokens.size() == prev_output_size &&
+             req->status == imp::RequestStatus::DECODING;
+             ++attempts) {
+            (void)ctx->engine->step();
         }
 
-        // If the request finished (eos or max_tokens), clean up
-        if (req->status == imp::RequestStatus::FINISHED) {
+        if (req->output_tokens.size() <= prev_output_size) {
+            return IMP_ERROR_INTERNAL;
+        }
+        ctx->consumed_output = prev_output_size;
+        *out_token = req->output_tokens[ctx->consumed_output++];
+
+        // If the request finished (eos or max_tokens), clean up — but only
+        // once every queued token has been handed to the caller (a verify
+        // chunk can emit several tokens and finish in one step).
+        if (req->status == imp::RequestStatus::FINISHED &&
+            ctx->consumed_output >= req->output_tokens.size()) {
             // KV cache is already freed by engine step() on FINISHED
             ctx->active_request = nullptr;
         }

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -451,11 +451,12 @@ struct RuntimeConfig {
         // 0 = stay eager between drafts (legacy behavior).
         int miss_burst = 8;
         // Reuse the parked captured graph across bursts (rearm instead of
-        // recapture, ~10-20 ms saved per burst). DISABLED by default: the
-        // rearmed burst's first forward emits a deterministic wrong token
-        // (#683 — behaves as if the previous burst's last KV entries are
-        // invisible). Re-enable for debugging the root cause only.
-        bool burst_rearm = false;
+        // recapture, ~10-20 ms saved per burst). The #683 wrong-token
+        // artifact was NOT the rearm itself but the fresh-captured loop
+        // initializing position/context one too high (fixed in
+        // CudaGraphConditionalRunner::setup) — rearm and fresh capture now
+        // share the same first-forward semantics.
+        bool burst_rearm = true;
     } speculative;
 
     struct FFN {

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -743,8 +743,14 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
 
     // ---- Initialize device state ----
     {
-        int init_pos = config_.initial_position + 1;     // next position after prefill
-        int init_ctx = config_.initial_context_len + 1;  // context grows by 1
+        // Same semantics as the eager decode step and rearm(): the loop's
+        // first forward processes first_token at slot initial_position with
+        // the context window covering it (#683 — the former +1 here shifted
+        // every fresh-captured loop's KV writes and RoPE one slot too high;
+        // the next correct-positioned writer, e.g. the spec-ngram verify
+        // chunk, then overwrote the burst's last KV entry).
+        int init_pos = config_.initial_position;
+        int init_ctx = config_.initial_context_len;
         int init_step = 0;
         *h_step_counter_ = 0;
         memset(h_ring_buffer_, 0, config_.max_steps * sizeof(int32_t));

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -124,8 +124,12 @@ public:
 
     struct Config {
         int max_steps = 0;              // max tokens to generate
-        int initial_context_len = 0;    // context length after prefill
-        int initial_position = 0;       // position of last prefill token
+        // Position/context of the loop's FIRST forward — identical semantics
+        // to the eager decode step and rearm(): first_token is processed at
+        // slot initial_position with initial_context_len covering it
+        // (callers pass req.context_len()-1 / req.context_len()).
+        int initial_context_len = 0;
+        int initial_position = 0;
         int eos_id = -1;                // EOS token ID
         std::vector<int32_t> stop_ids;  // additional stop token IDs (chat template)
         float temperature = 1.0f;

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -187,11 +187,10 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     // request keeps its captured graph — reseed device state instead of
     // recapturing (the burst-hybrid n-gram speculation path relaunches every
     // few tokens; a full setup costs ~10-20 ms per launch).
-    // #683: the rearm fast path's first forward behaves as if the previous
-    // burst's last ~2 KV entries are invisible (deterministic duplicated
-    // token, e.g. "gamma, gamma" on repeat-exactly prompts); a fresh capture
-    // per burst is byte-perfect. Until root-caused, the fast path is opt-in:
-    // correctness beats the ~10-20 ms capture saving per burst.
+    // #683 postscript: the "rearm emits a wrong token" artifact was the
+    // fresh-captured loop writing KV one slot too high (setup() position
+    // off-by-one) — the correctly-positioned rearm then collided with the
+    // shifted layout. Both paths share the eager first-forward semantics now.
     if (runtime_config_.speculative.burst_rearm && async_graph_runner_.is_setup() &&
         async_parked_req_id_ >= 0) {
         const auto& bt = kv_manager_->block_table(req->id);

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -333,6 +333,17 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         return false;
     if (!check(cudaStreamSynchronize(stream), "verify sync")) return false;
 
+    if (getenv("IMP_SPEC_TRACE")) {
+        std::string s = "[verify] p0=" + std::to_string(p0) + " t0=" + std::to_string(t0) +
+                        " draft=[";
+        for (int j = 0; j < K; ++j) s += std::to_string(draft[j]) + (j + 1 < K ? "," : "");
+        s += "] argmax=[";
+        for (int j = 0; j < chunk_len; ++j)
+            s += std::to_string(h_spec_argmax_[j]) + (j + 1 < chunk_len ? "," : "");
+        s += "]";
+        IMP_LOG_INFO("%s", s.c_str());
+    }
+
     // Accept the longest matching prefix and emit tokens through the same
     // per-token bookkeeping as the eager decode path.
     int matched = 0;  // accepted draft tokens (their KV entries are valid)


### PR DESCRIPTION
## Root cause (#683)

The fresh-captured conditional decode loop (`CudaGraphConditionalRunner::setup`) initialized its device position/context **one past** the eager-decode semantics: `build_graph_config` already passes the first-forward position (`req.context_len()-1`), and `setup()` added another `+1`. Every fresh-captured loop/burst therefore:

- wrote each token's KV one slot too high (and RoPE'd it one position too high),
- left a permanent hole at the launch slot `ctx-1`,
- placed its last KV entry at `p0` — exactly where the next correctly-positioned writer (the spec-ngram verify chunk's row 0, or a `rearm()` launch) writes next, **overwriting the burst's last KV entry**.

The verify argmax then saw a context "as if the last ~2 burst KV entries are missing" (the exact signature documented in #683) and emitted the deterministic duplicated token (`gamma, gamma` / `delta, delta`). This also retroactively explains the #684 rearm dossier: the artifact was never the rearm path — the rearm was *correctly* positioned and collided with the shifted layout left by the preceding fresh burst.

The unbounded loop was self-consistently shifted (hole + uniform +1 RoPE on the suffix), which greedy survives on most content — that is why outputs always looked coherent and goldens never caught it. An eager-vs-loop prose A/B diverged on main and moved to tie-noise-only after the fix.

## Changes

- `cuda_graph.cu/.h`: `setup()` now uses the same first-forward position/context semantics as the eager decode step and `rearm()`; `Config` field docs updated.
- `imp_api.cpp`: `imp_decode_step` drains queued multi-token verify output before acting on `FINISHED` — a verify chunk that emits several tokens and finishes the request in one engine step previously **dropped its queued tail** (CLI output ended mid-chunk).
- `config.h`: `speculative.burst_rearm` back to default **ON** (#684 mitigation no longer needed; validated byte-perfect).
- `engine_spec_ngram.cpp`: draft/argmax verify trace behind `IMP_SPEC_TRACE` (the instrumentation the #683 sessions kept re-adding).

## Validation (RTX 5090, Qwen3-8B-Q8)

- Repeat-exactly repro: **byte-perfect vs spec-off** for `miss_burst=8` (failing case), `=4`, `=0/burst=0`, and `burst_rearm=true`.
- Server comma case (chat API, greedy): byte-perfect spec-on vs spec-off, all three repetitions intact.
- `degen_suite`: 33/33 PASS with spec enabled.
- Full GPU suite: 1222 PASS / 0 FAIL. `verify-fast` incl. perf baseline: decode tg128 +2.3%, pp512 +6.1%, pp4096 +17.6% (healthy clocks sampled), graphs-gate 1.95x, smoke PASS.
- Spec economics intact: code-edit 275→554 tok/s (+101%, 76.6% acceptance, 13.25 tok/verify); prose worst case −0.8%.

Closes #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)