### PR TITLE
chore(graphify): exclude .claude/ from the knowledge graph

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -12,6 +12,10 @@ third_party/
 # the source of the per_kernel / phase_time_ns god-nodes. Kept in git for the
 # regress-trend pipeline, but worthless as graph structure.
 tools/roofline/history/
+# Agent/harness config + skill docs — not imp's architecture. settings.json JSON
+# keys (allow/PreToolUse) were mis-extracted as code nodes and became misleading
+# high-betweenness bridge-nodes in the report.
+.claude/
 
 # --- carried over from root .gitignore (build outputs + vendored deps) ---
 build/


### PR DESCRIPTION
`.claude/` (agent/harness config + skill docs) is not part of imp's architecture, but graphify was extracting it:

- `settings.json` JSON keys (`allow`, `PreToolUse`) were parsed as **code** nodes and surfaced as misleading **high-betweenness bridge-nodes** in `GRAPH_REPORT.md`'s "Surprising Connections" and "Suggested Questions".
- The `.claude/skills/*/SKILL.md` docs added concept-node noise.

Adding `.claude/` to `.graphifyignore` drops ~120 nodes (8344 → 8224) and removes the phantom bridges. After the rebuild the report's surprising connections are all genuine code relationships (e.g. `main()` → `imp_error_string()`), and 0 `allow`/`PreToolUse`/`.claude` nodes remain.

Tooling-only change — affects the local `graphify` corpus, no source/build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)