### PR TITLE
housekeeping: drop dead CUTLASS examples/88_hopper_fmha include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,7 +338,6 @@ if(IMP_USE_CUTLASS)
     target_include_directories(imp PRIVATE
         ${cutlass_SOURCE_DIR}/include
         ${cutlass_SOURCE_DIR}/tools/util/include
-        ${cutlass_SOURCE_DIR}/examples/88_hopper_fmha
     )
     target_compile_definitions(imp PRIVATE IMP_USE_CUTLASS=1)
 endif()


### PR DESCRIPTION
The `-I ${cutlass_SOURCE_DIR}/examples/88_hopper_fmha` entry in `CMakeLists.txt` was dead. Proven two ways:

**Static.** No `#include` across `src/ include/ tools/ tests/` resolves through that directory. The only CUTLASS include in the attention code is `<cute/arch/config.hpp>`, which resolves via `${cutlass_SOURCE_DIR}/include` (the line above it). CUTLASS core (`include/cute`, `include/cutlass`) never depends on `examples/` — the dependency is strictly examples→core — so transitive inclusion through the example dir is impossible.

**Empirical (gold standard).** Removed the line and ran a full Docker rebuild. The Dockerfile `COPY . .` (line 38) invalidates the layer cache for the `cmake -B build && cmake --build` step (lines 46–56) whenever `CMakeLists.txt` changes, and there is no `--mount=type=cache`, so this was a real full `sm_120a` recompile — **exit 0**. A `-I` path can only affect compilation, never runtime, so a green build is complete proof it was unneeded.

Behavior-preserving build-config cleanup; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)