### PR TITLE
docs: reconcile stale decode numbers with canonical BENCHMARKS.md

### DIFF
--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -107,7 +107,7 @@ Quick guidance, not a benchmark:
 
 - **Q8_0** is the cleanest baseline. Use it when output quality matters and VRAM allows.
 - **Q4_K_M** is the most VRAM-efficient GGUF. Sufficient for most chat; can degenerate on long code-gen on Gemma-4 — use Q5_K_M or Q8_0 there.
-- **Q6_K** sits in between. Good MoE pick on Qwen3-Coder-30B (234 tok/s).
+- **Q6_K** sits in between. Good MoE pick on Qwen3-Coder-30B.
 - **IQ4_NL / IQ4_XS** (i-quants) load and run since #556 via the dequant path (FP16-cache decode like Q4_K, dequant→cuBLAS prefill). Supported for community-quant compatibility — at equal VRAM prefer Q4_K_M, which has dedicated dp4a/MMVQ kernels. The IQ1/IQ2/IQ3 families remain unsupported.
-- **NVFP4** (SafeTensors prequant) gives the highest decode throughput on prequant-aware models — Qwen3-Coder-30B at 272 tok/s, Qwen3.6-35B at 217 tok/s, Gemma-4-26B at 213 tok/s. Requires AWQ/SmoothQuant calibration; only Modelopt is fully tested.
+- **NVFP4** (SafeTensors prequant) gives the highest decode throughput on prequant-aware models (current per-model numbers in [`BENCHMARKS.md`](../BENCHMARKS.md)). Requires AWQ/SmoothQuant calibration; only Modelopt is fully tested.
 - **MXFP4** is GGUF-native FP4. Smallest footprint (Qwen3-4B at 2.8 GB), but quality lags Q4_K_M without MR-GPTQ calibration.

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -37,13 +37,13 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | Model | Quant | VRAM | Decode `tg256` | Format |
 |---|---|---:|---:|---|
 | [Qwen3-Coder-30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | Q6_K | 24 GB | 236 | GGUF |
-| [Qwen3-Coder-30B-A3B](https://huggingface.co/NVFP4/Qwen3-Coder-30B-A3B-Instruct-FP4) | NVFP4 | 16 GB | 307 | SafeTensors (Modelopt) |
+| [Qwen3-Coder-30B-A3B](https://huggingface.co/NVFP4/Qwen3-Coder-30B-A3B-Instruct-FP4) | NVFP4 | 16 GB | 338 | SafeTensors (Modelopt) |
 | [Qwen3-30B-A3B](https://huggingface.co/nvidia/Qwen3-30B-A3B-NVFP4) | NVFP4 | 16 GB | 307 | SafeTensors (Modelopt) |
 | [Qwen3.6-35B-A3B](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) | Q4_K_M | 22 GB | 243 | GGUF |
-| [Qwen3.6-35B-A3B](https://huggingface.co/mmangkad/Qwen3.6-35B-A3B-NVFP4) | NVFP4 | 18 GB | 245 | SafeTensors (Modelopt) |
-| [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 259 (tg128) | GGUF |
+| [Qwen3.6-35B-A3B](https://huggingface.co/mmangkad/Qwen3.6-35B-A3B-NVFP4) | NVFP4 | 18 GB | 257 | SafeTensors (Modelopt) |
+| [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 273 (tg128) | GGUF |
 | [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q5_K_M | 17 GB | 65 | GGUF, recommended for code-gen |
-| [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 259 | SafeTensors (Modelopt) |
+| [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 266 | SafeTensors (Modelopt) |
 | [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 126 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited (FP16 GDN/attn-projection tax) |
 | [Nemotron-Labs-3-Elastic-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4) | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
 | [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
@@ -56,7 +56,7 @@ Gemma-3 and Gemma-4 are the multimodal families currently supported. The vision 
 |---|---|---:|---:|---|
 | [Gemma-3-12B-it](https://huggingface.co/bartowski/google_gemma-3-12b-it-GGUF) | Q8_0 | 12 GB | 129 | text + vision (includes mmproj) |
 | [Gemma-3-27B-it](https://huggingface.co/unsloth/gemma-3-27b-it-GGUF) | Q4_K_M | 16 GB | — | largest Gemma-3 |
-| [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 259 (tg128) | text + vision via the gemma4v encoder (separate BF16 mmproj) — see [`vision_gemma4v_spec.md`](vision_gemma4v_spec.md) |
+| [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 273 (tg128) | text + vision via the gemma4v encoder (separate BF16 mmproj) — see [`vision_gemma4v_spec.md`](vision_gemma4v_spec.md) |
 
 Run with both flags:
 


### PR DESCRIPTION
A full staleness pass over the **live** doc set (README, GOAL.md, architecture.md, sm120.md, supported-models, quantization, usage, roadmap, attention-dispatch, DISPATCH, CONTRIBUTING, determinism, nsys_profiling) found the docs **largely clean**: no false arch claims, no live references to removed kernels, and the stale `1258`/`20×` figures already refuted everywhere they appear. (`archive/`, `CHANGELOG`, `MISSION_JOURNAL`, and the `audit/` memos are intentionally historical and were left untouched.)

The one real drift was loose decode tok/s in two docs disagreeing with the SHA-anchored `BENCHMARKS.md`:

- **`quantization.md` "Choosing a quant"** — a section explicitly labelled *"Quick guidance, not a benchmark"* carried 18–25%-stale NVFP4 numbers (272/217/213 vs canonical 338/257/266) plus a stale Q6_K figure. Dropped the brittle per-model tok/s and pointed to `BENCHMARKS.md` — they only drift again otherwise.
- **`supported-models.md`** — aligned the rows `BENCHMARKS.md` anchors: Coder-30B NVFP4 307→338, Qwen3.6-35B NVFP4 245→257, Gemma-4 NVFP4 259→266, Gemma-4 Q4_K_M 259→273 (tg128; MoE + Vision tables — the identical 259 for two different formats was a copy-paste artifact). Un-anchored rows (no `BENCHMARKS.md` entry, within the documented ±5–10% day variance, issue #526) left as-is rather than churned doc-to-doc.

Docs-only; no code or perf-gate change. The `attention_tc` removal (#696) is **not** anticipated here — it's still on `main` until that PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)