### PR TITLE
housekeeping: retire dead generation.think_budget config field

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -217,8 +217,6 @@ q4k_imma_prefill     = false
 [generation]
 no_logit_softcap     = false
 lm_dequant_fp16      = false
-# Max tokens spent in <think>...</think> blocks (0 = unlimited).
-think_budget         = 0
 # Force-prepend BOS token even when the tokenizer says no.
 force_bos            = false
 # Disable the banned-token list (debug).

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -205,7 +205,6 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [generation]
     B("generation.no_logit_softcap", cfg.generation.no_logit_softcap);
     B("generation.lm_dequant_fp16", cfg.generation.lm_dequant_fp16);
-    I("generation.think_budget", cfg.generation.think_budget);
     B("generation.force_bos", cfg.generation.force_bos);
     B("generation.no_ban", cfg.generation.no_ban);
     B("generation.mtp_no_rope", cfg.generation.mtp_no_rope);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -385,7 +385,6 @@ struct RuntimeConfig {
     struct Generation {
         bool no_logit_softcap = false;
         bool lm_dequant_fp16 = false;
-        int think_budget = 0;
         bool force_bos = false;
         // Disable banned-token list (debug). Legacy env: IMP_NO_BAN.
         bool no_ban = false;


### PR DESCRIPTION
`cfg.generation.think_budget` (`RuntimeConfig::Generation`, `int`) was parsed from `imp.conf` and documented in `imp.conf.example`, but **never read anywhere** — a documented knob with zero effect.

It was also a vestigial, never-wired design: the `int` *"max tokens in `<think>` blocks"* semantic in the example diverges from the live **per-request `float` `req.think_budget`** (fraction of `max_tokens`), whose default comes from the server's `--think-budget` flag, not from config.

### Change
Removed the struct field (`config.h`), the binder (`config.cpp`), and the `imp.conf.example` entry (field + comment). **Behavior-preserving** — the field was never read, so nothing changes at runtime.

The 2026-06-09 audit flagged this as *bridge-or-retire*. **Retire** is the cleanup-aligned call: the user-facing knob already exists as `--think-budget`, and bridging would be a feature + type fix, out of scope for housekeeping.

> Note: an existing `imp.conf` that still sets `generation.think_budget` will now log `imp.conf: unknown key` at load — honest, since the key never did anything.

Verified: Docker `sm_120a` build + test compile pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)