### PR TITLE
docs: re-verification sweep — correct stale broken-model claims (06-13)

### DIFF
--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -33,8 +33,9 @@ and every *bounded* lever for it was empirically closed in the 06-12 campaign.
    `kv_cache_quant_algo=FP8` by default.
 3. **GGUF-only gaps (deprioritized — recommend NVFP4):** Q4_K_M prefill MMQ (evidence-refuted, see
    roadmap), MoE/hybrid GGUF decode (dp4a, ~−13%).
-4. **Open model bugs:** Qwen3.5-27B MXFP4 IMA (blocked on public MXFP4 + a NaN bug); Gemma-4 Q4_K_M
-   gen drift (model-intrinsic — use Q5_K_M/Q8_0). gpt-oss GGUF MoE NaN is FIXED (#690).
+4. **Open model bugs:** Qwen3.5-27B/4B MXFP4 (blocked — community files never verified in any engine,
+   27B not even local); Qwen3.6-27B-VL NVFP4 (wontfix — ~30 GB OOMs a 32 GB card). gpt-oss GGUF MoE
+   NaN FIXED (#690); Gemma-4 Q4_K_M code-gen drift no longer reproduces (verified 06-13, see roadmap).
 5. **Small cleanups:** ms_ref loader slab (last VRAM-audit item); spec-decode default-on needs an
    engagement heuristic (opt-in tg128 −15% on short / draft-poor prompts).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,7 +98,12 @@ any future codegen-bound kernel. Memory: `compileiq_ptxas_native_refuted_2026_05
 
 - **Single GPU only.** No tensor parallelism, no multi-GPU.
 - **Blackwell only.** No Hopper, Ada, Ampere. No AMD, Intel, Apple, CPU.
-- **Gemma-4 Q4_K_M code-gen drift** -- accumulated FP16 rounding. Use Q5_K_M or Q8_0.
+- **Gemma-4 Q4_K_M code-gen drift** -- the original `gemma-4-26B-A4B-it-Q4_K_M.gguf` degenerated into
+  backtick loops on code prompts at temp=0 (Q8_0 stayed clean). **No longer reproduces (verified
+  2026-06-13):** the current local `UD-Q4_K_M` produces coherent valid Python on the same prompt.
+  Likely closed by intervening work (tokenizer #657, gemma SWA prefill routing #566/#569) and/or the
+  better Unsloth-dynamic quant; the original file is gone, so it can't be A/B'd. If you hit
+  degeneration on some other Q4_K_M quant of this model, fall back to Q5_K_M or Q8_0.
 - **Qwen3.5-27B MXFP4 fails at load** -- blocked on no public MXFP4 GGUF + NaN bug.
 
 ## Investigated and shelved


### PR DESCRIPTION
## Context

Triaging the open model-correctness bugs, every "broken model" claim turned out to be a **point-in-time memo/doc that rotted** — 40+ intervening PRs (notably the #657 tokenizer fixes) silently repaired paths without anyone updating the "known broken" lists. So I built current main (`da2793f1`) and re-verified every locally-available flagged model greedily (temp=0, to provoke degeneration).

## Sweep results

| Model | Documented as | On current main | Verdict |
|---|---|---|---|
| Gemma-4-26B **Q4_K_M** | backtick degeneration | coherent Python | ✅ silently fixed |
| Qwen3.5-4B **MXFP4** | "random multilingual tokens" | "The capital of France is Paris." | ✅ silently fixed (likely #657) |
| Gemma-4-26B **NVFP4 (llm-compressor)** | "degenerates past ~30 tokens" | 170-token coherent prose | ✅ stale claim — fixed in #65 |
| gpt-oss-20b **GGUF** | MoE NaN | coherent, no NaN | ✅ confirms #690 |
| gpt-oss-20b **SafeTensors** | greedy-loops in analysis (temp 1.0) | coherent at temp=0 (this prompt) | caveat is prompt-dependent, left as-is |
| Nemotron-3 / Elastic NVFP4 | — | coherent | ✅ fine |
| Gemma-4-31B NVFP4 | too big | "Error creating context" | ❌ still fails (capacity) — kept |

(The "count 1 to 20" prompt did trigger a `-20-20-20` greedy repetition loop on Gemma-4-26B NVFP4 — but that's a generic greedy/count-bait artifact, not the quant defect: normal prose runs 170 tokens clean.)

## Changes (docs only)

- `roadmap.md` "Known limitations": Gemma-4 Q4_K_M code-gen drift no longer reproduces.
- `supported-models.md`: drop the stale llm-compressor ">30 token degeneration" claim + its dead roadmap link; reflect the #65 fix.
- `MISSION_JOURNAL` OPEN WORK: correct the model-bugs item (MXFP4 blocked, 27B-VL wontfix, Gemma-4 cases resolved).

Net: of the previously-tracked "open model bugs", **none are open-and-fixable** — they are silently-fixed (now documented), blocked on unavailable/broken model files, or hard capacity limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)