### PR TITLE
chore(skills): freshness pass — reconcile SKILL.md facts with current main

### DIFF
--- a/.claude/skills/add-model-arch/SKILL.md
+++ b/.claude/skills/add-model-arch/SKILL.md
@@ -7,12 +7,12 @@ description: Use when adding support for a new model architecture to imp, portin
 
 ## Integration checklist (gpt-oss PR #572 is the reference example)
 
-1. **Enum + registry**: add to `ModelArch` in `src/model/model_arch.h`; wire `parse_model_arch` (GGUF `general.architecture`, `gguf_loader.cpp:1114`) and/or HF detection (`hf_config_loader.cpp:76` — `architectures` array, `model_type` fallback), `model_arch_name`, `apply_arch_defaults`, sampling defaults in `src/model/model_arch.cpp`. **Then register the arch's traits in `ModelProfile`** (`src/model/model_profile.h` — single source of truth since PRs #622/#623, incl. the `AttnVariant` SWA/NoPE dispatch enum). Never add new `cfg.arch == X` checks in hot-path code — the profile is what dispatch reads.
+1. **Enum + registry**: add to `ModelArch` in `src/model/model_arch.h`; wire `parse_model_arch` (GGUF `general.architecture`, `gguf_loader.cpp:1137`) and/or HF detection (`hf_config_loader.cpp:76` — `architectures` array, `model_type` fallback), `model_arch_name`, `apply_arch_defaults`, sampling defaults in `src/model/model.cpp` (registry + `parse_model_arch`/`apply_arch_defaults` live there; `src/model/model_arch.h` holds only the enum + decls). **Then register the arch's traits in `ModelProfile`** (`src/model/model_profile.h` — single source of truth since PRs #622/#623, incl. the `AttnVariant` SWA/NoPE dispatch enum). Never add new `cfg.arch == X` checks in hot-path code — the profile is what dispatch reads.
 2. **Loader**: tensor-name mapping in `src/model/tensor_kind_matcher.cpp` / `weight_map.cpp`; SafeTensors path in `safetensors_loader.cpp` (NVFP4 prequant via `llm_compressor_loader.cpp` if applicable).
 3. **Arch config**: RoPE variant (NeoX vs GPT-J pair layout! see traps), YaRN/`rope_freq_scale`, SWA layer pattern, attention quirks (NoPE, sinks, softcap), norm placement, MoE router type — in `model_config.h` + `apply_arch_defaults`.
 4. **Chat template**: `src/model/chat_template.cpp` (+ `jinja.cpp` if templated); think/reasoning channel handling if applicable.
 5. **Kernels** only if genuinely new ops (sinks, new gating) — check `src/exec/` + `src/compute/` for an existing path first.
-6. **Verify** (in order): loads → coherent greedy output (run `check-degeneration` battery) → **perplexity vs HF reference** (`imp-cli --perplexity`; expect within ~10-20% of HF, e.g. gpt-oss 7.67 vs HF 6.71) → decode/prefill sanity (`benchmark-cuda`).
+6. **Verify** (in order): loads → coherent greedy output (run `check-degeneration` battery) → **perplexity vs HF reference** (`imp-cli --perplexity`; expect within ~10-20% of HF — often much closer, e.g. gpt-oss imp 4.68 vs HF bf16 4.607, #663: the residual elevation is model-intrinsic) → decode/prefill sanity (`benchmark-cuda`).
 7. **Docs**: row in `docs/supported-models.md` (+ BENCHMARKS.md if hero-class); perf baseline entry if it becomes a gated model.
 
 ## Diagnostic fingerprints (wrong-output triage)

--- a/.claude/skills/benchmark-cuda/SKILL.md
+++ b/.claude/skills/benchmark-cuda/SKILL.md
@@ -127,7 +127,7 @@ Kernel: <name>, config: <block=X, grid=Y, smem=Z>
 
 ## Publishing numbers (keep docs from going stale)
 
-- **`tests/perf_baseline.json`** is the canonical CI gate. Refresh ONLY when a change *intentionally* moves perf: `make gen-perf-baseline`, on a healthy-host day (STOP #4), and say so in the PR. Current Q8 `tg128≈286` was sampled on a **peak day** (normal healthy range 266–278) — a small gate failure on an ordinary day can be host drift against a hot baseline, not a regression; sample clocks before concluding.
+- **`tests/perf_baseline.json`** is the canonical CI gate. Refresh ONLY when a change *intentionally* moves perf: `make gen-perf-baseline`, on a healthy-host day (STOP #4), and say so in the PR. Current Q8 `tg128 = 269.50` (cold-median, 2026-06-12; normal healthy range 266–278). The previous 286.4 baseline (2026-06-07) was sampled on a documented **peak day** — its 3% gate threshold (277.8) sat INSIDE the normal range, so it failed on ordinary days; it was corrected down in #697. A small gate failure can be host drift, not a regression; sample clocks before concluding.
 - **`BENCHMARKS.md`** is SHA-anchored (method, date, commit, command, tok/s). Update it — and the README numbers — in the same commit as the perf change. `scripts/check-release.sh` gates release-touching PRs.
 - `bash scripts/scoreboard.sh` tallies hero-model status vs llama.cpp.
 

--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -29,7 +29,7 @@ verification, not the sweep.
 
 1. **Fan out** — Explore agents / grep to surface candidates (breadth is fine here).
 2. **Verify each** with the recipe above. Demote refuted ones immediately.
-3. **Write it up** — `docs/audit/structural_debt_YYYY-MM-DD.md`. Counts are evidence,
+3. **Write it up** — `docs/audit/structural_debt_YYYY_MM_DD.md`. Counts are evidence,
    not estimates. Keep a **"Refuted (do not re-chase)"** section so the next pass
    doesn't re-flag the same false positives.
 4. **Ship cleanups** as small PRs (REQUIRED SUB-SKILL: building-and-testing) — branch
@@ -38,7 +38,7 @@ verification, not the sweep.
 
 ## Priors — settled, do NOT re-flag
 
-From `docs/audit/structural_debt_2026-06-08.md` (D1–D4) + `..._2026-06-09.md`:
+From `docs/audit/structural_debt_2026_06_08.md` (D1–D4) + `..._2026_06_09.md`:
 - **exec/ god-object** (`GraphExecutor`) is intrinsically forward-pass-coupled; the
   D2 runner-extraction track ENDED (cosmetic friend-backdoor only). Header split done
   (1188→584 lines). Don't re-attempt runner classes.

--- a/.claude/skills/server-api/SKILL.md
+++ b/.claude/skills/server-api/SKILL.md
@@ -23,6 +23,7 @@ Key flags (`imp-server --help` for all): `--port` (8080) · `--chat-template aut
 | `POST /v1/chat/completions` | OpenAI | SSE streaming, tools, json_schema |
 | `POST /v1/completions` | OpenAI legacy | raw text |
 | `POST /v1/messages` | **Anthropic** | thinking, tool use, `cache_control`, **real per-token SSE** (`main.cpp:192` — old "synthetic replay" info is obsolete) |
+| `POST /v1/embeddings` | OpenAI | embedding vectors |
 | `GET /v1/models` | both | **strict semantics since PR #507**: only the loaded model is listed; a foreign `model` field → 404 `model_not_found`; switching models = restart (auto-swap was removed after a reload SIGSEGV) |
 | `POST /tokenize`, `/detokenize` | imp | |
 | `GET /health`, `/metrics` | imp | healthcheck / Prometheus |
@@ -33,6 +34,7 @@ Key flags (`imp-server --help` for all): `--port` (8080) · `--chat-template aut
 - **Constrained decoding** (`response_format: json_schema`): the per-token FSM simulator `sim_advance` is the SINGLE grammar source (`src/compute/schema_constrain.{h,cu}`; schema parsing in `src/compute/json_schema.h`; chain PRs #497–#499). Supports `$ref`/`$defs`. Termination is exact-JSON (CAT_EOS only at DONE, whitespace cap) — the server returns exactly the JSON object.
 - **Constrained-decode perf** (PR #651; the #650 SIGBUS/ctrl-char fixes are prerequisites): category prefilter + in-string shortcut on the schema mask, then `ConstrainedPipeline` (`src/runtime/engine.h`) enqueues forward N+1 *before* the host FSM advances — json_schema 102→235 tok/s (plain ≈270). In-pipeline: greedy/top-k/top-p, rep/freq/presence penalties, banned tokens, think-budget (deliberately, so the server defaults `repetition_penalty=1.05`/`think_budget=0.5` don't silently disqualify it). **Falls back to eager** (slow) for: logprobs, min_p, typical_p, mirostat, DRY, logit_bias, MTP, batch>1 — when measuring constrained perf, check none of these are set or you're benchmarking the eager path.
 - **`cache_control` / prefix cache**: Anthropic `cache_control` pins prompt-KV blocks (budget `server.prefix_pin_budget_pct` = 25% FIFO) and reports `cache_read_input_tokens`/`cache_creation_input_tokens`. `server.prefix_cache` is default ON since the #536/#538 stale-block-table fix; `PrefixCacheE2ETest` is the ship gate.
+- **Speculative decoding** (n-gram prompt-lookup, opt-in, greedy/batch-1): no dedicated server flags — enable via `--set speculative.ngram=true`. Knobs in `src/runtime/config.h` → `struct Speculative` (parsed in `config.cpp:247-254`): `k` (16), `min_match` (6), `max_match` (12), `give_up_after` (64), `burst` (128), `miss_burst` (8), `burst_rearm` (default ON — the #683 wrong-token artifact was the conditional-graph `setup()` position off-by-one, fixed in PR #692, not rearm). Output stays token-identical to plain greedy. CLI win ~+6%; opt-in because draft-poor workloads regress.
 - **Config keys** (`src/runtime/config.h` → `struct Server`): `prefix_cache`, `prefix_pin_budget_pct`, `green_contexts`.
 - **Stop handling**: server stops on turn markers at high temperature (PR #442) — don't remove that guard.
 


### PR DESCRIPTION
## Why

The `.claude/skills/` set was last content-refreshed 2026-06-10 (through PR #651). ~50 PRs have landed since (#652–#702), so several skills carried stale facts. Audited all 9 skills claim-by-claim against the working tree (4 parallel agents, each verifying paths / `file:line` refs / flags / config keys / perf numbers / PR refs against source).

## Result: 8 stale facts fixed across 4 skills; 5 verified still-current

**add-model-arch** — `gguf_loader.cpp:1114`→`:1137`; registry + `parse_model_arch`/`apply_arch_defaults` are in `src/model/model.cpp` (the cited `model_arch.cpp` doesn't exist); stale gpt-oss PPL example `7.67 vs 6.71` → `imp 4.68 vs HF bf16 4.607` (#663, model-intrinsic).

**benchmark-cuda** — canonical Q8 `tg128` `286` (retired peak-day baseline) → `269.50` cold-median, per the #697 reconciliation against `BENCHMARKS.md`.

**server-api** — added `/v1/embeddings` to the endpoint table; added a **speculative-decoding** section (no dedicated server flags; enable with `--set speculative.ngram=true`; real knobs/defaults from `struct Speculative`; the #683 wrong-first-token was the conditional-graph `setup()` off-by-one fixed in #692, *not* rearm).

**codebase-audit** — audit-report date convention `YYYY-MM-DD` → `YYYY_MM_DD` to match the actual `docs/audit/` filenames.

**Verified current, no change:** building-and-testing (dep pins, CI `Build` check, Makefile targets), quant-formats (StorageTier contract; gpt-oss MXFP4→NVFP4 is now true for GGUF too after #690), check-degeneration (degen_suite categories incl. `anthropic-thinking`), docs-sync (doc-ownership paths, `imp.conf.example`↔parser contract).

Skills/docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)