### PR TITLE
feat(kv): kv_cache.dtype=auto — honor FP8-KV hint for verified families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Changed
+
+- **KV cache: `kv_cache.dtype` now defaults to `auto` — honors the model
+  author's `kv_cache_quant_algo=FP8` hint for verified arch families.** Modelopt
+  NVFP4 checkpoints declare `kv_cache_quant_algo=FP8`; imp previously parsed but
+  ignored it (FP16, manual `--kv-fp8` to opt in). `auto` upgrades KV to FP8 E4M3
+  only for arch families that pass a long-context quality gate
+  (`kv_fp8_hint_default_safe`). Allowlisted today: **Qwen3 dense + Qwen3 MoE** —
+  measured on a 3.9k-token context, FP8 vs FP16 KV: Qwen3-14B PPL +1.07%,
+  Qwen3-30B-A3B neutral, both coherent, ~768 MiB KV VRAM saved. Other
+  hint-declaring families (Phi-4, Nemotron-H, Qwen3.5/3.6, Gemma-4) stay FP16
+  until verified. `dtype = "fp16"` opts out; `--kv-fp8` forces FP8 on any model.
+  The `auto` resolver also makes config-file `dtype = "fp8"|"int8"|"int4"|…`
+  selections take effect (previously only the CLI flags did).
+
 ### Fixed
 
 - **SPM tokenization: USER_DEFINED pieces now literal-matched — gemma

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -94,10 +94,12 @@ Set via `--kv-fp8` / `--kv-int8` / `--kv-int4` / `--kv-nvfp4` / `--kv-mxfp4`, or
 
 ```toml
 [kv_cache]
-dtype = "fp16"  # fp16 (default) | fp8 | int8 | int4 | nvfp4 | mxfp4
+dtype = "auto"  # auto (default) | fp16 | fp8 | int8 | int4 | nvfp4 | mxfp4
 ```
 
-The default flipped to FP16 in PR #51 — FP8 had been silently breaking Llama, Mistral, and DeepSeek at first decode. FP8 is now opt-in; it is verified coherent on Qwen3 dense, Qwen3.5 / 3.6 GDN, Llama-3.2, and Gemma-4 (FP8 KV warmup-calibration bug fixed in PR #89; Gemma-4 dual-head_dim carve-out removed in PR #91).
+`dtype = "auto"` (the default) keeps FP16 but upgrades to FP8 E4M3 for models whose author declares `kv_cache_quant_algo=FP8` (Modelopt NVFP4 checkpoints) **and** whose arch family has passed the long-context FP8-KV quality gate (`kv_fp8_hint_default_safe` in `src/model/model.cpp`). Currently allowlisted: **Qwen3 dense + Qwen3 MoE** — measured on a 3.9k-token context, FP8 vs FP16 KV: Qwen3-14B PPL 13.95→14.10 (+1.07%), Qwen3-30B-A3B ~16.20→~15.99 (neutral), both coherent, ~768 MiB KV VRAM saved. Other hint-declaring families (Phi-4, Nemotron-H, Qwen3.5/3.6, Gemma-4) stay FP16 until measured; pass `--kv-fp8` to force, or `dtype = "fp16"` to opt out.
+
+The default flipped to FP16 in PR #51 — FP8 had been silently breaking Llama, Mistral, and DeepSeek at first decode. Beyond the `auto` allowlist, FP8 stays opt-in; it is verified coherent on Qwen3 dense, Qwen3.5 / 3.6 GDN, Llama-3.2, and Gemma-4 (FP8 KV warmup-calibration bug fixed in PR #89; Gemma-4 dual-head_dim carve-out removed in PR #91).
 
 INT4 KV is for VRAM-pressure cases only — coherent but ~22% decode regression at 20K context. NVFP4-KV (`--kv-nvfp4`) and MXFP4-KV (`--kv-mxfp4`, PR #249) both store FP4 at 25% of FP16 — NVFP4 uses E4M3 micro-scales, MXFP4 uses UE8M0; both ship chunked prefill via `paged_kv_gather_*_to_fp16`. The legacy `--kv-turboquant{,-lite}` flags remain as deprecated aliases routing to `--kv-mxfp4` (TurboQuant retired in PR #251).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,9 +28,12 @@ The genuinely-open levers (most of the 06-12 campaign closed everything else —
   **scaled fp8-KV storage with f16 compute** (vLLM's actual win — halves KV traffic, 2× QK density via
   `m16n8k32`), not the refuted raw-e4m3 path. Multi-day, well-scoped.
 
-- **kv-fp8 storage default-on** -- viable opt-in today (−768 MiB VRAM, +0.83% PPL); the −35% MoE tax was
-  diagnosed (deterministic-cuBLAS forcing, not the gather) and removed (#682). Blocked only on building
-  long-context quality gates per model family before honoring `kv_cache_quant_algo=FP8` by default.
+- **kv-fp8 storage default-on** -- SHIPPED for Qwen3 dense + Qwen3 MoE. `kv_cache.dtype` now defaults to
+  `auto`, which honors a model author's `kv_cache_quant_algo=FP8` hint for arch families that pass the
+  long-context quality gate (`kv_fp8_hint_default_safe` — measured on a 3.9k-token context: Qwen3-14B PPL
+  +1.07%, Qwen3-30B-A3B neutral, both coherent; ~768 MiB KV VRAM saved). The −35% MoE tax was removed in
+  #682. **Remaining:** verify the other hint-declaring families (Phi-4, Nemotron-H, Qwen3.5/3.6, Gemma-4)
+  and add them to the allowlist; they stay FP16 (or `--kv-fp8` opt-in) until measured.
 
 The two items below are **retained for the record but evidence-refuted**, not active work:
 

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -48,8 +48,11 @@ debug_raw            = false
 no_vision_graph      = false
 
 [kv_cache]
-# KV-cache element type: fp16 | fp8 | int8 | int4 | nvfp4
-dtype                       = "fp16"
+# KV-cache element type. "auto" (default) keeps FP16 but upgrades to FP8 E4M3 for
+# models whose author declares kv_cache_quant_algo=FP8 and whose arch family is
+# verified safe for long-context FP8 KV (currently Qwen3 dense + Qwen3 MoE; ~768
+# MiB saved, +~1% PPL). "fp16" forces FP16. fp8|int8|int4|nvfp4|mxfp4 force that dtype.
+dtype                       = "auto"
 # Allow cuBLASLt non-deterministic algorithms with FP8 KV. Slightly faster
 # but reproducibility is lost.
 allow_nondeterministic_fp8  = false

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -157,6 +157,25 @@ static const ArchEntry& lookup_arch(ModelArch arch) {
 
 const char* model_arch_name(ModelArch arch) { return lookup_arch(arch).name; }
 
+// Arch families empirically verified safe to honor a model author's
+// kv_cache_quant_algo=FP8 hint BY DEFAULT (kv_cache.dtype=auto, no explicit
+// --kv-fp8). Measured 2026-06-13 on a 3.9k-token context, FP8 vs FP16 KV, same
+// corpus, RTX 5090:
+//   QWEN3     (Qwen3-14B-NVFP4, dense):  PPL 13.95 -> 14.10  (+1.07%), coherent
+//   QWEN3_MOE (Qwen3-30B-A3B-NVFP4):     PPL ~16.20 -> ~15.99 (neutral), coherent
+// Other families (gemma/phi/nemotron/qwen35/qwen36/...) stay FP16 until measured
+// on this box; users can still force FP8 explicitly with --kv-fp8. This list IS
+// the long-context quality gate — keep it conservative, extend only with evidence.
+bool kv_fp8_hint_default_safe(ModelArch arch) {
+    switch (arch) {
+        case ModelArch::QWEN3:
+        case ModelArch::QWEN3_MOE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 int model_arch_c_api_id(ModelArch arch) { return lookup_arch(arch).c_api_id; }
 
 void model_arch_sampling_defaults(ModelArch arch, float& temperature, float& top_p, int& top_k) {

--- a/src/model/model_arch.h
+++ b/src/model/model_arch.h
@@ -24,6 +24,12 @@ enum class ModelArch {
 
 const char* model_arch_name(ModelArch arch);
 
+// True iff this arch family has been empirically verified safe to honor a model
+// author's kv_cache_quant_algo=FP8 hint BY DEFAULT (long-context FP8 KV). This is
+// the long-context quality gate for kv_cache.dtype=auto; see the definition in
+// model.cpp for the measured per-family evidence. Keep the list conservative.
+bool kv_fp8_hint_default_safe(ModelArch arch);
+
 // C API enum value for this architecture.
 int model_arch_c_api_id(ModelArch arch);
 

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1145,9 +1145,9 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
                      nvfp4_cfg.group_size);
         if (!cfg.kv_cache_quant_hint.empty()) {
             IMP_LOG_INFO(
-                "Model author declared kv_cache_quant_algo=%s; imp keeps the "
-                "engine's KV-cache dtype default (FP16). Pass --kv-fp8 to honor "
-                "the author's hint (correctness varies by family — see docs).",
+                "Model author declared kv_cache_quant_algo=%s; with kv_cache.dtype=auto "
+                "(default) imp honors it for arch families verified safe for long-context "
+                "FP8 KV, else keeps FP16. Force with --kv-fp8 or opt out with kv_cache.dtype=fp16.",
                 cfg.kv_cache_quant_hint.c_str());
         }
     }

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -78,7 +78,12 @@ struct RuntimeConfig {
     } runtime;
 
     struct KVCache {
-        std::string dtype = "fp16";  // fp16 | fp8 | int8 | int4 | nvfp4
+        // "auto" (default) keeps FP16 but upgrades to FP8 E4M3 for models whose
+        // author declares kv_cache_quant_algo=FP8 AND whose arch family is
+        // verified safe for long-context FP8 KV (see kv_fp8_hint_default_safe).
+        // "fp16" forces FP16 (opt out of the hint). fp8|int8|int4|nvfp4|mxfp4
+        // force that dtype regardless of the hint.
+        std::string dtype = "auto";
         bool allow_nondeterministic_fp8 = false;
         bool fp8_auto_legacy = false;  // legacy IMP_KV_FP8_AUTO compat
         // BitDecoding Phase 3: residual FP16 cache for newest N tokens.

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -8,6 +8,7 @@
 #include "runtime/engine.h"
 #include "runtime/engine_internal.h"
 #include "runtime/config.h"
+#include "model/model_arch.h"
 #include "runtime/process_diag.h"
 #include "core/logging.h"
 #include "core/tensor.h"
@@ -58,6 +59,36 @@ void Engine::init_resolve_kv_dtype_policy_() {
     const bool debug_raw_ = runtime_config_.runtime.debug_raw;
     const bool force_kv_fp16 = (runtime_config_.kv_cache.dtype == "fp16");
     const bool fp8_auto_legacy = runtime_config_.kv_cache.fp8_auto_legacy;
+
+    // Resolve the config-file KV dtype string into the engine enum. The CLI flags
+    // (--kv-fp8 / --kv-int4 / …) set config_.kv_cache_dtype directly and win — we
+    // only resolve here when the CLI left it at the F16 default. The default "auto"
+    // honors the model author's kv_cache_quant_algo=FP8 hint, but ONLY for arch
+    // families verified safe for long-context FP8 KV (kv_fp8_hint_default_safe — the
+    // measured PPL/coherence gate). Explicit "fp16" opts out; explicit
+    // fp8/int8/int4/nvfp4/mxfp4 force that dtype.
+    if (config_.kv_cache_dtype == QType::F16) {
+        const std::string& kv_str = runtime_config_.kv_cache.dtype;
+        if (kv_str == "fp8") {
+            config_.kv_cache_dtype = QType::FP8_E4M3;
+        } else if (kv_str == "int8") {
+            config_.kv_cache_dtype = QType::INT8;
+        } else if (kv_str == "int4") {
+            config_.kv_cache_dtype = QType::INT4;
+        } else if (kv_str == "nvfp4") {
+            config_.kv_cache_dtype = QType::NVFP4;
+        } else if (kv_str == "mxfp4") {
+            config_.kv_cache_dtype = QType::MXFP4_KV;
+        } else if (kv_str == "auto" && mcfg.kv_cache_quant_hint == "FP8" &&
+                   kv_fp8_hint_default_safe(mcfg.arch)) {
+            config_.kv_cache_dtype = QType::FP8_E4M3;
+            IMP_LOG_INFO("KV cache dtype: FP8_E4M3 (auto — honoring model author's "
+                         "kv_cache_quant_algo=FP8; %s verified safe for long-context FP8 KV; "
+                         "set kv_cache.dtype=fp16 to opt out)",
+                         model_arch_name(mcfg.arch));
+        }
+    }
+
     if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16) {
         config_.kv_cache_dtype = QType::FP8_E4M3;
         IMP_LOG_INFO("KV cache dtype: IMP_KV_FP8_AUTO=1 → FP8_E4M3 (legacy opt-out)");

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "runtime/config.h"
+#include "model/model_arch.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -25,10 +26,23 @@ TEST(RuntimeConfigTest, DefaultsAreSane) {
     EXPECT_FALSE(cfg.runtime.deterministic_gemm);
     EXPECT_EQ(cfg.runtime.cuda_graphs, "auto");
     EXPECT_FALSE(cfg.runtime.warmup);  // off by default; opt-in for prod rollout
-    EXPECT_EQ(cfg.kv_cache.dtype, "fp16");
+    EXPECT_EQ(cfg.kv_cache.dtype, "auto");
     EXPECT_EQ(cfg.moe.expert_overhead_pct, 10);
     EXPECT_FALSE(cfg.gdn.fp32_scan);
     EXPECT_EQ(cfg.diagnostics.exit_layer, -1);
+}
+
+// The long-context FP8-KV quality gate (kv_cache.dtype=auto): only arch families
+// empirically verified safe honor the model author's kv_cache_quant_algo=FP8 hint
+// by default. Keep this allowlist conservative — see model.cpp for the evidence.
+TEST(RuntimeConfigTest, KvFp8HintDefaultSafeAllowlist) {
+    EXPECT_TRUE(kv_fp8_hint_default_safe(ModelArch::QWEN3));
+    EXPECT_TRUE(kv_fp8_hint_default_safe(ModelArch::QWEN3_MOE));
+    // Not yet verified on this box → must stay FP16 by default.
+    EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::GEMMA4));
+    EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::QWEN35));
+    EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::QWEN36_MOE));
+    EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::GENERIC));
 }
 
 TEST(RuntimeConfigTest, ParsesBasicSections) {
@@ -119,7 +133,7 @@ TEST(RuntimeConfigTest, MissingFileFallsBackToDefaults) {
     RuntimeConfig cfg;
     EXPECT_FALSE(cfg.load_from_file("/nonexistent/path/imp.conf"));
     // Defaults still in place.
-    EXPECT_EQ(cfg.kv_cache.dtype, "fp16");
+    EXPECT_EQ(cfg.kv_cache.dtype, "auto");
 }
 
 }  // namespace


### PR DESCRIPTION
## What

Modelopt NVFP4 checkpoints declare `kv_cache_quant_algo=FP8`. imp already **parsed** that hint but deliberately **ignored** it (FP16 default, manual `--kv-fp8` to opt in), with a code comment pointing at the missing piece: a *long-context quality gate per model family*. This PR builds that gate and honors the hint by default for families that pass it.

## How

- **`kv_cache.dtype` now defaults to `auto`** (was `fp16`). `auto` upgrades KV to FP8 E4M3 only when the model declares the FP8 hint **and** its arch family passes `kv_fp8_hint_default_safe()` (the gate). Explicit `dtype = "fp16"` opts out; `--kv-fp8` / `dtype = "fp8"` force FP8 on any model.
- **The gate allowlist** (`src/model/model.cpp`, with the measured evidence inline) starts with **Qwen3 dense + Qwen3 MoE**. Measured on a 3.9k-token context, FP8 vs FP16 KV, same corpus, RTX 5090:
  | family | FP16-KV PPL | FP8-KV PPL | Δ | coherent? |
  |---|---|---|---|---|
  | Qwen3-14B (dense) | 13.95 | 14.10 | **+1.07%** | yes |
  | Qwen3-30B-A3B (MoE) | ~16.20 | ~15.99 | **neutral** | yes |
  
  ~768 MiB KV VRAM saved. Other hint-declaring families (Phi-4, Nemotron-H, Qwen3.5/3.6, Gemma-4) stay FP16 until measured — they're listed as remaining work in the roadmap.
- The `auto` resolver also routes config-file `dtype = fp8|int8|int4|nvfp4|mxfp4` into the engine enum (those strings were previously **silently ignored** — only the CLI flags worked).

## Why it's safe

GGUF models carry no `kv_cache_quant_hint` → always FP16 under `auto`, so the GGUF-based GPU test suite (greedy locks: Qwen3-4B-Q8, Qwen3.5-4B-Q8, gemma-4-Q4_K_M) is **unaffected**. Only Modelopt-NVFP4 Qwen3 models flip.

## Verification

- Behavior: `Qwen3-14B-NVFP4` default → **FP8 auto** (logs the honor); `--set kv_cache.dtype=fp16` → **FP16** (opt-out); `Phi-4-reasoning-plus-NVFP4` (declares hint, not allowlisted) → **FP16** (gate holds).
- New CPU unit test `RuntimeConfigTest.KvFp8HintDefaultSafeAllowlist` (locks the allowlist; CI-runnable, no GPU). `RuntimeConfigTest` 9/9, unit suite 37/37.
- `make verify-fast` PASS.

Docs: roadmap (kv-fp8 marked shipped-for-Qwen3 + remaining families), quantization.md, imp.conf.example, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)