### PR TITLE
docs(changelog): fill in [Unreleased] for the v0.11 cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+
+- **N-gram prompt-lookup speculative decoding** (#668–#670, opt-in). Draft tokens
+  are matched from the prompt/context suffix and verified in a burst-hybrid loop;
+  output stays token-identical to plain greedy. `--set speculative.ngram=true`
+  (knobs: `k`, `min_match` default 6 — precision beats frequency, `give_up_after`,
+  `burst`). CLI ~+6% on long generations; opt-in because draft-poor workloads
+  regress. Server-enabled (penalties in verify, think-budget bursts).
+- **gpt-oss-20b GGUF MoE** (#690) — full GGUF path: MXFP4→NVFP4 expert conversion,
+  expert biases, attention sinks, sliding-window attention, residual rescale. The
+  GGUF checkpoint previously NaN'd in MoE prefill; SafeTensors gpt-oss already
+  worked.
+- **`IMP_PPL_DUMP=full`** dumps per-position NLL for cross-engine perplexity
+  forensics (#655).
+
+### Performance
+
+- **Prefill chunk size default 512 → 2048** (#672) — MoE pp2048 **+127%**
+  (Qwen3-30B-A3B 15.7k→35.7k tok/s), pp4096 +77%; activation-quant dedupe is
+  bit-identical. Also fixed a grouped device-args GEMM silent corruption at n≈900.
+- **FP16-QK FA2 is now the primary hd=128 prefill** (#687) — at-or-above cuBLAS at
+  every pp (pp1024 +24%, pp2048 +52%), so the S-matrix buffer is skipped for
+  hd=128: **−380 MiB** device memory.
+- **FA2 full-rate accumulate default-on** (#673/#674) — f16-accumulate QK^T and PV
+  in the FP16-QK FA2 prefill kernel: −18% pp4096 kernel time, MoE e2e +9.7%, PPL
+  unchanged.
+- **Conditional-graph decode loop for NVFP4 "think" models** (#649) — **+45%**
+  think-decode by keeping the reasoning loop inside one captured graph.
+- **Pipelined constrained decoding** (#650/#651) — schema-mask fast path +
+  forward-N+1 pipeline: `json_schema` decode **102 → 235 tok/s**.
+- **FP8-KV deterministic-cuBLAS forcing scoped to non-FA2 configs** (#682) — removes
+  a −35% pp4096 MoE tax on `--kv-fp8` (it was an April-era forcing of the
+  single-block deterministic MoE permute, not the gather).
+- **VRAM reclamation on NVFP4** — fallback-only workspace buffers skipped on
+  SafeTensors (#678, +827 MiB free), duplicated per-expert micro-scales freed
+  (#679, −1728 MiB on 30B-A3B), CUTLASS scale-factor dedup (#685/#686, −1810 MiB on
+  NVFP4-prequant), contiguous per-(layer,proj) micro-scale slab (#689).
+- **FA2 grid-underfill band** — TWOSLOT K/V rotation runs 2 CTAs/SM at full Bkv=64
+  (#653); Bkv=32 variant for the same band (#597). 16-B vectorized x/gate/up loads
+  in the NVFP4 GEMV dot helpers (#671).
+
 ### Fixed
 
 - **SPM tokenization: USER_DEFINED pieces now literal-matched — gemma
@@ -60,6 +101,23 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   Qwen3-8B pp4096 +6.9% (the tuned f16-QK FA2 replaces fp8-QK in the
   unchunked chain). Follow-ups: #654 (broken `flash_attention_blackwell`
   last-resort), #655 (IMP_PPL_DUMP position mapping).
+
+- **Speculative-decode conditional-graph loop wrote KV one slot too high**
+  (#683 → #692). `CudaGraphConditionalRunner::setup()` double-incremented the
+  first-forward position, so every fresh-captured verify loop duplicated the
+  last burst KV entry (wrong first token on rearm). Root-caused to the
+  position off-by-one (not the rearm fast path, which #684 had disabled as a
+  stopgap and is now default-on again). Byte-perfect across mb=8/4/0, server
+  API, and Q8 / NVFP4-dense / NVFP4-MoE. Also drains the multi-token verify
+  tail when a request finishes mid-chunk.
+- **`attn_logit_softcap` was silently dropped on the cuBLAS FP32-S prefill
+  path** (#688) — Gemma-2-class hd=256 prefill skipped the cap. Fixed via a
+  `softcap_fp32_kernel`; FA2/decode/KV-write paths were already correct.
+- **`gemm_kv_batched` output stride** is now derived from the actual K/V
+  pointer distance (#677/#691), fixing a Q4_0 determinism mismatch plus a
+  cross-block WAR hazard in the fused FP32→FP16 softmax downcast.
+- **Constrained decoding SIGBUS** on SafeTensors `json_mode` + raw control
+  characters in constrained strings (#650).
 
 ## [0.10.0] - 2026-06-09
 


### PR DESCRIPTION
## Why

Prepping for a **v0.11.0** release. The CHANGELOG `[Unreleased]` section had only the three earliest post-0.10.0 fixes (#511/#654/#657), but **47 commits** landed since v0.10.0 (2026-06-09) — ~40 of them unlogged.

## What

Filled in `[Unreleased]` with the substantive user-facing work, categorized per Keep-a-Changelog:

- **Added:** n-gram speculative decoding (#668–#670, opt-in), gpt-oss GGUF MoE (#690), `IMP_PPL_DUMP=full` (#655).
- **Performance:** prefill chunk 2048 (#672, MoE pp2048 **+127%**), FP16-QK FA2 primary hd=128 prefill (#687, **−380 MiB**), FA2 f16-acc default-on (#673/#674), conditional-graph think decode **+45%** (#649), pipelined constrained decode **102→235 tok/s** (#650/#651), kv-fp8 −35% tax removed (#682), NVFP4 VRAM reclamation (#678/#679/#686/#689), FA2 grid-underfill band (#653/#597/#671).
- **Fixed:** spec conditional-loop KV off-by-one (#683/#692), `attn_logit_softcap` on cuBLAS FP32-S prefill (#688), `gemm_kv_batched` stride (#677/#691), constrain SIGBUS (#650).

Pure housekeeping/docs PRs (#665/#666/#675/#693–#702) are omitted, matching how [0.10.0] was written. The `kv_cache.dtype=auto` change stays logged in its own PR (#704) to avoid a duplicate entry. All perf figures come from the merged PRs' own commit messages.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)