### PR TITLE
docs(bench): refresh NVFP4 prefill numbers post-#687 — MoE pp4096 now beats vLLM

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -89,30 +89,29 @@ On `sm_120`, native-NVFP4 decode is effectively uncontested (vLLM gates its
 NVFP4 path on `tcgen05`/falls back to Marlin on the 5090; llama.cpp has no
 native NVFP4 path).
 
-## NVFP4 prefill (post FA2 full-rate accumulate, #673/#674)
+## NVFP4 prefill (post FP16-QK FA2 primary hd=128 prefill, #687)
 
-imp rows: 2026-06-12, commit `bcb7354d`, CUDA 13.3, median of 3 isolated
-trials × 10 reps, fresh container per run, clocks verified healthy. Command:
-`imp-cli --model <dir> --bench --bench-pp <n> --bench-reps 10 --max-tokens 1`.
+imp rows: 2026-06-13, commit `290a163a`, CUDA 13.3, median of 3 isolated
+trials × 40 reps, fresh container per run, clocks verified healthy (warm
+40-rep windows; cross-trial spread <1%). Command:
+`imp-cli --model <dir> --bench --bench-pp <n> --bench-reps 40 --max-tokens 256`.
 vLLM reference: 0.22.1 FlashInfer-NVFP4 (fp8 KV), same host, measured
-2026-06-11 — one day older than the imp rows, so the ratios carry that
-cross-day caveat.
+2026-06-11 — older than the imp rows, so the ratios carry that cross-day caveat.
 
 | Model | pp | imp tok/s | vLLM tok/s (06-11) | verdict |
 |---|---|---:|---:|---|
-| Qwen3-30B-A3B (MoE) | 2048 | **41 668** | 34 500 | **imp +21%** |
-| Qwen3-30B-A3B (MoE) | 4096 | **30 300** | 36 200 | 1.19× behind (was 1.38×) |
-| Qwen3-14B (dense) | 2048 | **25 932** | 26 600 | ~tie (1.03×) |
-| Qwen3-14B (dense) | 4096 | **19 938** | 25 300 | 1.27× behind (was ~1.5×) |
+| Qwen3-30B-A3B (MoE) | 2048 | **43 646** | 34 500 | **imp +27%** |
+| Qwen3-30B-A3B (MoE) | 4096 | **37 639** | 36 200 | **imp +4%** (was 1.19× behind) |
+| Qwen3-14B (dense) | 2048 | **26 918** | 26 600 | ~tie (imp +1.2%) |
+| Qwen3-14B (dense) | 4096 | **24 232** | 25 300 | 1.04× behind (was 1.27×) |
 
-imp wins TTFT/pp512 outright (2.1–3.4×, vLLM has a flat-cost small-M
-regime) and now MoE pp2048 by a clear margin; the remaining pp4096 gap is
-grouped-GEMM/attention mix at long context (FA2 QK^T and PV both run
-full-rate f16-accumulate since #673/#674 — the prior "quartered f32-acc
-class" explanation no longer applies; the FA2 kernel is dependency-chain
-bound, see the 2026-06-12 dead-ends entry). Decode: imp +27–40% (14B
-153–168 vs 121–126; 30B-A3B 291–323 vs 223–233). Nemotron-3-Nano is
-arch-limited (hybrid Mamba2 + attention FP16-projection mix).
+**#687 (FP16-QK FA2 as the primary hd=128 prefill) closed most of the pp4096
+gap:** MoE pp4096 went 30 300 → 37 639 (**+24%**, now *ahead* of vLLM) and dense
+pp4096 19 938 → 24 232 (**+21%**, gap 1.27× → 1.04×). pp2048 moved +3.8–4.7%.
+imp also wins TTFT/pp512 outright (2.1–3.4×, vLLM has a flat-cost small-M regime).
+The lone surviving NVFP4-prefill gap is dense pp4096 at ~1.04×. Decode (tg256
+@ctx2048): 14B 159, 30B-A3B ~317. Nemotron-3-Nano is arch-limited (hybrid
+Mamba2 + attention FP16-projection mix).
 
 ## Output-quality gate
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ dated, commit-anchored measurements with exact commands):
   (Qwen3-30B-A3B 305, Qwen3-Coder-30B 338, Qwen3.6-35B 257, Gemma-4-26B 266;
   2026-06-09) — effectively uncontested on `sm_120`, where vLLM's NVFP4 path
   needs `tcgen05` and llama.cpp has no native NVFP4 support.
-- Honest losses: NVFP4 long-context prefill (~1.2× behind vLLM at pp4096;
-  imp WINS TTFT everywhere, MoE pp2048 by +21%, and ties dense pp2048 —
-  post chunk-2048 default and FA2 full-rate accumulate, 2026-06-12),
-  Qwen3.6-35B GGUF decode (−31%, structural FP16 GDN-projection tax).
+- NVFP4 long-context prefill: after #687 (FP16-QK FA2 as the primary hd=128
+  prefill, 2026-06-13) imp WINS MoE pp4096 (+4% vs vLLM), wins MoE pp2048 (+27%),
+  wins/ties dense pp2048, and wins TTFT everywhere; the lone remaining gap is
+  dense pp4096 at ~1.04× behind. Honest loss: Qwen3.6-35B GGUF decode (−31%,
+  structural FP16 GDN-projection tax).
 
 Every number, with date, commit SHA, CUDA version, quant and the exact
 command: **[BENCHMARKS.md](BENCHMARKS.md)**. Methodology details:
@@ -64,7 +65,7 @@ command: **[BENCHMARKS.md](BENCHMARKS.md)**. Methodology details:
 
 - **Single GPU only.** No tensor parallelism, no multi-GPU.
 - **Consumer Blackwell only.** `sm_120a` SASS + `compute_120f` PTX fallback. No Hopper, Ada, Ampere, datacenter Blackwell. No AMD, Intel, Apple, or CPU paths.
-- **GGUF prefill: largely fixed 2026-06-07.** The INT8-IMMA prefill family (#612–#617) puts Qwen3-30B-A3B and Qwen3-14B-Q6_K AHEAD of llama.cpp; Q8_0 dense and gemma-4 sit at 1.20×, Qwen3.6-35B at 1.55× (GDN share is quality-locked). NVFP4 prefill trails vLLM ~1.2× at pp4096 only — imp WINS TTFT everywhere and MoE pp2048 by +21% (2026-06-12, post #673/#674 FA2 full-rate accumulate; see docs/audit/prefill_gap_2026_06_07.md for the kernel-level decomposition).
+- **GGUF prefill: largely fixed 2026-06-07.** The INT8-IMMA prefill family (#612–#617) puts Qwen3-30B-A3B and Qwen3-14B-Q6_K AHEAD of llama.cpp; Q8_0 dense and gemma-4 sit at 1.20×, Qwen3.6-35B at 1.55× (GDN share is quality-locked). NVFP4 prefill: imp WINS MoE pp4096 (+4% vs vLLM), MoE pp2048 (+27%), and TTFT everywhere; only dense pp4096 still trails, at ~1.04× (2026-06-13, post #687 FP16-QK FA2 primary hd=128 prefill; see docs/audit/prefill_gap_2026_06_07.md for the kernel-level decomposition).
 - **MoE/hybrid GGUF decode loses on Qwen3.6-35B** (~−31% vs llama.cpp): an FP16-projection tax on the GDN/attention path that NVFP4 can't address.
 - **Only tested models work reliably.** Anything not on the [supported list](docs/supported-models.md) may load but hasn't been verified.
 - **Prefill numbers are noisy.** cuBLAS autotuning causes up to 2.6× variance across container restarts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,11 +22,13 @@ The goal is making imp the fastest local engine for AI agent workloads on consum
 
 The genuinely-open levers (most of the 06-12 campaign closed everything else — see "Investigated and shelved"):
 
-- **pp4096 NVFP4 prefill, ~1.19-1.25× behind vLLM** -- the lone remaining competitive gap. FA2 is
-  instruction-mix-bound near its practical ceiling; the bounded levers (Cross-Tile pipeline, Grouped-GEMM
-  tile axis, chunk-4096, occupancy/2-CTA, fp8-QK) are all empirically refuted. The only surviving idea is
-  **scaled fp8-KV storage with f16 compute** (vLLM's actual win — halves KV traffic, 2× QK density via
-  `m16n8k32`), not the refuted raw-e4m3 path. Multi-day, well-scoped.
+- **NVFP4 prefill vs vLLM — mostly closed by #687.** Making FP16-QK FA2 the primary hd=128 prefill
+  (re-measured 2026-06-13, commit `290a163a`) lifted pp4096 +21–24%: **MoE pp4096 is now +4% ahead of
+  vLLM**, MoE pp2048 +27%, dense pp2048 ~tie. The **lone surviving gap is dense pp4096 at ~1.04×**
+  (24.2k vs 25.3k). FA2 is instruction-mix-bound near its practical ceiling and the bounded kernel levers
+  (Cross-Tile pipeline, Grouped-GEMM tile axis, chunk-4096, occupancy/2-CTA, fp8-QK) are all refuted;
+  the only surviving idea for the last ~4% is **scaled fp8-KV storage with f16 compute** (halves KV
+  traffic, 2× QK density via `m16n8k32`). Marginal — the competitive case is essentially won.
 
 - **kv-fp8 storage default-on** -- viable opt-in today (−768 MiB VRAM, +0.83% PPL); the −35% MoE tax was
   diagnosed (deterministic-cuBLAS forcing, not the gather) and removed (#682). Blocked only on building


### PR DESCRIPTION
## Why

Release prep (v0.11). The published NVFP4-prefill numbers were anchored to `bcb7354d` (#675, 06-12) — **before #687** ("FP16-QK FA2 as the primary hd=128 prefill") landed. Re-benched on current main to capture #687's effect.

## Method

`290a163a`, CUDA 13.3, **median of 3 isolated trials × 40 reps**, fresh container per run, `CUBLAS_WORKSPACE_CONFIG=:4096:8`, warm clocks (40-rep windows), cross-trial spread **<1%**.

## Result — #687 closed most of the pp4096 gap

| model | pp | old (bcb7354d) | new (290a163a) | vs vLLM (06-11) |
|---|---|---:|---:|---|
| Qwen3-30B-A3B MoE | 2048 | 41 668 | **43 646** (+4.7%) | **imp +27%** |
| Qwen3-30B-A3B MoE | 4096 | 30 300 | **37 639** (+24%)  | **imp +4%** (was 1.19× behind) |
| Qwen3-14B dense   | 2048 | 25 932 | **26 918** (+3.8%) | ~tie |
| Qwen3-14B dense   | 4096 | 19 938 | **24 232** (+21%)  | 1.04× behind (was 1.27×) |

**MoE pp4096 is now ahead of vLLM**; dense pp4096 is a near-tie. The roadmap's "lone remaining competitive gap" has essentially closed.

## Changes

- `BENCHMARKS.md` — NVFP4 prefill section re-measured + re-anchored to `290a163a`.
- `README.md` — the two competitive-position claims (pp4096 "honest loss" → MoE win + dense near-tie).
- `docs/roadmap.md` — "Open performance work" pp4096 bullet.

## Not changed (deliberate)

- **`perf_baseline.json` (CI gate)** — Q8 tg128 measured 273.8 (vs 269.5, +1.6%, within the 266–278 band — not a sustained floor) and pp512 12 586 (+5.4%), but prefill carries 2.6× restart variance so raising the gate invites flaky failures. Higher actuals pass it fine.
- **GGUF prefill section** — a 2026-06-07 *same-day* imp-vs-llama.cpp snapshot; re-anchoring one row would break the same-day comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)