### PR TITLE
fix(server): embeddings no longer cancels in-flight generations ("0 completion tokens" wedge)

### DIFF
--- a/tests/test_server_embed_chat_interleave.sh
+++ b/tests/test_server_embed_chat_interleave.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# MANUAL tool — not wired into ctest/CI/verify.sh (like test_server_concurrent.sh).
+# Needs a running imp-server on :8080 with a model that supports /v1/embeddings.
+#
+# Regression for the "0 completion tokens" wedge (DEBUG-0tokens.md): the
+# /v1/embeddings handler used to stop() the batching engine for exclusive
+# C-API access, which CANCELLED every in-flight generation. Under interleaved
+# embed+chat load each chat then returned an empty `finish_reason:"cancelled"`
+# completion. The fix drains in-flight work (pause/resume) instead of cancelling.
+#
+# This test hammers chat and embeddings CONCURRENTLY and asserts that no chat
+# completion comes back empty or cancelled.
+set -u
+
+BASE="http://localhost:8080"
+MODEL="${IMP_TEST_MODEL:-Qwen3-8B-NVFP4-cortecs}"
+DURATION="${1:-30}"
+
+# A prompt long enough that generation overlaps incoming embeddings calls.
+PROMPT="Write a detailed multi-paragraph essay about the history of cartography."
+
+RESULT_DIR="$(mktemp -d)"
+EMPTY_FLAG="$RESULT_DIR/empty"
+STOP_FLAG="$RESULT_DIR/stop"
+
+embed_loop() {
+  while [ ! -f "$STOP_FLAG" ]; do
+    curl -s "$BASE/v1/embeddings" -H 'content-type: application/json' \
+      -d "{\"model\":\"$MODEL\",\"input\":\"the quick brown fox jumps over the lazy dog repeatedly\"}" >/dev/null 2>&1
+  done
+}
+
+chat_loop() {
+  local n=0
+  while [ ! -f "$STOP_FLAG" ]; do
+    n=$((n + 1))
+    resp=$(curl -s "$BASE/v1/chat/completions" -H 'content-type: application/json' \
+      -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"$PROMPT\"}],\"max_tokens\":64,\"temperature\":0.7}")
+    content=$(echo "$resp" | jq -r '.choices[0].message.content // empty' 2>/dev/null)
+    finish=$(echo "$resp" | jq -r '.choices[0].finish_reason // empty' 2>/dev/null)
+    reasoning=$(echo "$resp" | jq -r '.choices[0].message.reasoning_content // empty' 2>/dev/null)
+    if { [ -z "$content" ] && [ -z "$reasoning" ]; } || [ "$finish" = "cancelled" ]; then
+      echo "FAIL: chat #$n empty/cancelled (finish=$finish): $resp" | head -c 400
+      echo
+      touch "$EMPTY_FLAG"
+      touch "$STOP_FLAG"
+      return
+    fi
+  done
+  echo "chat issued $n requests, all non-empty"
+}
+
+echo "=== interleaved embed+chat for ${DURATION}s (model=$MODEL) ==="
+embed_loop & E1=$!
+embed_loop & E2=$!
+chat_loop  & C1=$!
+
+sleep "$DURATION"
+touch "$STOP_FLAG"
+wait "$C1" 2>/dev/null
+kill "$E1" "$E2" 2>/dev/null
+wait "$E1" "$E2" 2>/dev/null
+
+if [ -f "$EMPTY_FLAG" ]; then
+  echo "FAIL: a chat completion was cancelled/empty during interleaved embeddings load"
+  rm -rf "$RESULT_DIR"
+  exit 1
+fi
+echo "PASS: all interleaved chat completions stayed non-empty"
+rm -rf "$RESULT_DIR"
+exit 0

--- a/tools/imp-server/batching_engine.cpp
+++ b/tools/imp-server/batching_engine.cpp
@@ -15,6 +15,8 @@ void BatchingEngine::start(ImpContext ctx) {
     }
     ctx_ = ctx;
     stop_requested_.store(false);
+    pause_requested_.store(false);
+    paused_.store(false);
     running_.store(true);
     worker_thread_ = std::thread(&BatchingEngine::worker_loop, this);
 }
@@ -24,6 +26,7 @@ void BatchingEngine::stop() {
         return;
     stop_requested_.store(true);
     queue_cv_.notify_all();
+    pause_cv_.notify_all();  // wake the worker if it is parked in pause()
     if (worker_thread_.joinable()) {
         worker_thread_.join();
     }
@@ -45,6 +48,32 @@ void BatchingEngine::stop() {
     active_requests_.clear();
 }
 
+bool BatchingEngine::pause(int timeout_ms) {
+    if (!running_.load())
+        return true;  // nothing running → caller already has exclusive access
+    pause_requested_.store(true);
+    queue_cv_.notify_all();  // wake the worker if it is idle-waiting
+    std::unique_lock<std::mutex> lock(pause_mutex_);
+    bool ok = pause_cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] {
+        return paused_.load() || !running_.load() || stop_requested_.load();
+    });
+    if (!ok) {
+        // Timed out waiting for the worker to drain in-flight work. Do NOT
+        // proceed (driving engine->step() while the worker is live would race);
+        // clear the request so the worker keeps running normally.
+        pause_requested_.store(false);
+        queue_cv_.notify_all();
+        return false;
+    }
+    return true;
+}
+
+void BatchingEngine::resume() {
+    pause_requested_.store(false);
+    pause_cv_.notify_all();
+    queue_cv_.notify_all();
+}
+
 void BatchingEngine::submit(std::shared_ptr<ServerRequest> req) {
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
@@ -63,27 +92,55 @@ void BatchingEngine::worker_loop() {
     imp::KVCacheManager* kv_mgr = engine->kv_manager();
 
     while (!stop_requested_.load(std::memory_order_relaxed)) {
+        // 0. Graceful pause handshake. When a caller wants exclusive engine
+        //    access (embeddings / blocking vision), it calls pause(). We must
+        //    NOT cancel in-flight generations — instead we keep stepping until
+        //    active work has drained, then park here until resume(). New
+        //    pending requests are left queued (not admitted, not cancelled) so
+        //    they run after resume. The caller holds state.mtx, so no new chat
+        //    can be submitted while we are parked.
+        if (pause_requested_.load(std::memory_order_relaxed) && active_requests_.empty()) {
+            std::unique_lock<std::mutex> lock(pause_mutex_);
+            paused_.store(true);
+            pause_cv_.notify_all();
+            pause_cv_.wait(lock, [this] {
+                return !pause_requested_.load(std::memory_order_relaxed) ||
+                       stop_requested_.load(std::memory_order_relaxed);
+            });
+            paused_.store(false);
+            continue;
+        }
+
         // 1. Drain incoming queue and add new requests to the scheduler
         {
             std::unique_lock<std::mutex> lock(queue_mutex_);
 
-            // If no active work, wait for new requests (with timeout to check stop)
+            // If no active work, wait for new requests (with timeout to check
+            // stop / pause). When a pause is pending we still need to wake so
+            // step 0 can park, hence the predicate also watches pause_requested_.
             if (active_requests_.empty() && pending_queue_.empty()) {
                 queue_cv_.wait_for(lock, std::chrono::milliseconds(10), [this] {
-                    return !pending_queue_.empty() || stop_requested_.load(std::memory_order_relaxed);
+                    return !pending_queue_.empty() ||
+                           stop_requested_.load(std::memory_order_relaxed) ||
+                           pause_requested_.load(std::memory_order_relaxed);
                 });
                 if (stop_requested_.load(std::memory_order_relaxed))
                     break;
             }
 
-            // Move all pending requests to active
-            while (!pending_queue_.empty()) {
-                auto sr = std::move(pending_queue_.front());
-                pending_queue_.pop_front();
+            // While a pause is pending, do not admit new pending requests —
+            // let active work drain so step 0 can park. Leaving them queued
+            // preserves them for after resume().
+            if (!pause_requested_.load(std::memory_order_relaxed)) {
+                // Move all pending requests to active
+                while (!pending_queue_.empty()) {
+                    auto sr = std::move(pending_queue_.front());
+                    pending_queue_.pop_front();
 
-                sr->notified_count = sr->request->output_tokens.size();
-                engine->add_request(sr->request);
-                active_requests_.push_back(std::move(sr));
+                    sr->notified_count = sr->request->output_tokens.size();
+                    engine->add_request(sr->request);
+                    active_requests_.push_back(std::move(sr));
+                }
             }
         }
 

--- a/tools/imp-server/batching_engine.h
+++ b/tools/imp-server/batching_engine.h
@@ -82,8 +82,23 @@ public:
     void start(ImpContext ctx);
 
     // Stop the background worker thread. Must be called before destroying
-    // the ImpContext. Waits for the worker to finish.
+    // the ImpContext. Waits for the worker to finish. Cancels any in-flight
+    // requests — use pause()/resume() instead when the generations must
+    // survive (e.g. embeddings/vision exclusive-access windows).
     void stop();
+
+    // Graceful exclusive-access handshake. pause() lets the worker FINISH all
+    // in-flight requests (it never cancels them), then parks the worker thread
+    // so the caller can drive engine->step() directly (embeddings / blocking
+    // vision) without racing the worker. resume() unparks it. The worker thread
+    // stays alive across the window (no thread churn, no cancellation).
+    //
+    // Caller MUST hold state.mtx so no new request is submitted during the
+    // window (chat submit also takes state.mtx). pause() blocks until the
+    // worker is idle and parked, bounded by timeout_ms (0 = no in-flight work
+    // to drain → returns immediately). Returns true once parked.
+    bool pause(int timeout_ms = 60000);
+    void resume();
 
     // Submit a request for inference. Thread-safe.
     // The request will be picked up by the worker on the next iteration.
@@ -102,6 +117,13 @@ private:
     std::thread worker_thread_;
     std::atomic<bool> running_{false};
     std::atomic<bool> stop_requested_{false};
+
+    // Graceful pause handshake (see pause()/resume()). pause_requested_ tells
+    // the worker to drain in-flight work and park; paused_ reports that it has.
+    std::atomic<bool> pause_requested_{false};
+    std::atomic<bool> paused_{false};
+    std::mutex pause_mutex_;
+    std::condition_variable pause_cv_;
 
     // Incoming request queue (HTTP threads -> worker thread)
     mutable std::mutex queue_mutex_;

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -3512,13 +3512,27 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
         return;
     }
 
-    // Pause batching engine for exclusive C API access, restart on scope exit
+    // Pause the batching engine for exclusive C-API access (imp_prefill drives
+    // engine->step() directly, which must not race the worker). pause() lets
+    // in-flight generations FINISH before parking the worker — stop() would
+    // cancel them, so any chat running concurrently with this embeddings call
+    // returned an empty `finish_reason:"cancelled"` completion (the "0
+    // completion tokens" wedge). We hold state.mtx, so no new chat is admitted
+    // while paused; resume() unparks on scope exit.
     bool had_batching = (state.batching && state.batching->is_running());
-    if (had_batching)
-        state.batching->stop();
+    if (had_batching) {
+        if (!state.batching->pause()) {
+            res.status = 503;
+            json err = {{"error",
+                         {{"message", "Server busy draining in-flight requests. Please retry."},
+                          {"type", "server_error"}}}};
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+    }
     auto restart_batching = [&] {
-        if (had_batching && state.batching && state.ctx)
-            state.batching->start(state.ctx);
+        if (had_batching && state.batching)
+            state.batching->resume();
     };
     // Use a simple scope guard
     struct ScopeGuard {


### PR DESCRIPTION
## Symptom

Under interleaved `/v1/embeddings` + `/v1/chat/completions` load, chat requests start coming back with an **empty assistant message** (`finish_reason:"cancelled"`, one reasoning token → `content:""`, logged as `0 completion tokens`). HTTP 200 + `/health` stay green, so it reads as a silent, "permanent" wedge for as long as the mixed load continues. Reproduces on dense (Qwen3-8B-NVFP4) and MoE (Qwen3.6-35B-A3B-NVFP4) — it is a server-layer bug, model-agnostic.

## Root cause

`handle_embeddings()` needs exclusive C-API access (`imp_prefill` drives `engine->step()` directly, which must not race the batching worker). It got it by calling `BatchingEngine::stop()` — and `stop()` **cancels every in-flight request** (`push_finish("cancelled")`). So any generation running when an embeddings request arrived was killed mid-flight and returned empty.

`stop()` also left the cancelled requests' KV sequences allocated (no `free_sequence`), so orphaned `DECODING` requests accumulated in the scheduler (measured KV in-use **87 → 542 blocks** under sustained overlap).

The reported "sequential, queue_depth ~1" workload still hits this whenever an embeddings call overlaps a not-yet-drained generation (async agent / streaming tail).

## Fix

Add a graceful `BatchingEngine::pause()`/`resume()` handshake:
- `pause()` lets the worker **finish** all in-flight requests, then parks the worker thread (no cancellation, no thread churn) so the caller can drive `engine->step()` safely.
- `resume()` unparks. The embeddings handler holds `state.mtx`, so no new chat is admitted while paused; queued pending requests are preserved.

Replace the embeddings `stop()`/`start()` with `pause()`/`resume()`. (The model-load path keeps `stop()` — cancelling on a model swap is correct. The blocking-vision path has the same latent `stop()` pattern and can adopt `pause()` in a follow-up.)

## Test

`tests/test_server_embed_chat_interleave.sh` (manual server-level, sibling of `test_server_concurrent.sh`) hammers chat + embeddings concurrently and fails if any chat returns empty/cancelled.

- **Before:** wedges immediately (empty completion on the first overlapped chat).
- **After:** 73 chats over 25s interleaved load, **0 empty**; KV in-use stays at one request's worth (no orphan leak); sequential control unaffected; embeddings still return valid vectors.

Verified on RTX 5090 / sm_120 with `Qwen3-8B-NVFP4-cortecs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)