### PR TITLE
fix(server): bad input returns 400 + JSON envelope, never a bare 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **Bad request input now returns 400 + a JSON error envelope, never a bare 500.**
+  Invalid UTF-8 in a request body (e.g. an agent byte-truncating a prompt and
+  splitting a multibyte char) made `json::parse` throw, the error envelope
+  echoed the offending bytes, and `err.dump()` then threw `json::type_error.316`
+  (dump rejects ill-formed UTF-8) — which escaped the parse-error catch and
+  surfaced as an opaque `500 Internal Server Error` with no body. Added a global
+  `set_exception_handler` (json exceptions → 400 `invalid_request_error`, others
+  → 500 with a JSON body) plus a `dump_safe()` helper (`dump` with
+  `error_handler_t::replace`) used on every response / SSE / error / request-log
+  body, so an ill-formed byte can never crash a request. Audited all body-taking
+  endpoints (`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`,
+  `/v1/messages`, `/tokenize`, `/detokenize`). (DEBUG-500-on-bad-input.md)
+
+### Added
+- `tests/test_server_robustness.py` — manual server-level battery asserting that
+  malformed JSON / invalid UTF-8 / non-object / wrong-type / missing-field input
+  on every endpoint returns 4xx + an error envelope (never 5xx) and valid
+  requests return 2xx.
+
 ## [0.11.1] - 2026-06-14
 
 Patch release. Fixes a server wedge where interleaved `/v1/embeddings` +

--- a/tests/TEST_AUDIT.md
+++ b/tests/TEST_AUDIT.md
@@ -147,7 +147,7 @@ evaluated accordingly above.
 | `tests/fixtures/` | **NOT dead** (agent's initial finding wrong): `scripts/validate_safetensors.py:628,892` consumes both files | keep |
 | Stale comment "FMHA sm120 requires sm_90+ (WMMA fallback)" | `test_attention_fmha_sm120.cu:84` | misleading on sm_120a-only engine → fix (low-risk) |
 | Comment "same fate as the SM100-only tcgen05 family" (`tests/bench/mmq_q4k_imma_bench.cu:30`) | agent's initial finding "dead commentary" — checked: correct in context (tcgen05 IS sm_100-only, which is exactly why it is missing on sm_120) | keep |
-| `test_engine_chat.sh`, `test_server_concurrent.sh`, `test_server_embed_chat_interleave.sh`, `test_server_0token_battery.py`, `tests/api/elchtest.sh` | called by no target/CI (need a running server + GPU) | manual tools → documented as manual in each script header, do not delete |
+| `test_engine_chat.sh`, `test_server_concurrent.sh`, `test_server_embed_chat_interleave.sh`, `test_server_0token_battery.py`, `test_server_robustness.py`, `tests/api/elchtest.sh` | called by no target/CI (need a running server + GPU) | manual tools → documented as manual in each script header, do not delete |
 | TurboQuant/BitDecoding/FP4-PV remnants | cleanly removed; only comment reference in CMakeLists (documentary) | ✓ no action needed |
 | Apparent duplicates (mmq_q4k×5, mxf4nvf4×3, attention_mxfp4×2) | checked: pyramid unit→layout→bench resp. paged-vs-FMHA | **no duplicates** |
 | `tests/bench/*.cu` in `IMP_COMPUTE_SOURCES` (CMakeLists ~196–207) | only under `IMP_BUILD_TESTS OR IMP_BUILD_BENCH`, commented (P3/P5 decision) | accepted; no prod leak in the default release without tests |

--- a/tests/test_server_robustness.py
+++ b/tests/test_server_robustness.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""MANUAL tool — not wired into ctest/CI/verify.sh (TEST_AUDIT.md §7).
+Needs a running imp-server on :8080 (default model Qwen3-8B-NVFP4-cortecs).
+
+Robustness battery for the HTTP surface (DEBUG-500-on-bad-input.md). imp must
+NEVER answer client-supplied bad input with a 5xx or a bare/opaque body: bad
+input is a 4xx with an OpenAI-style `{"error":{"message":..,"type":..}}`
+envelope. The original bug: invalid UTF-8 in the body made json::parse throw
+parse_error, the error envelope echoed the offending bytes, and err.dump()
+then threw json::type_error.316 (dump rejects ill-formed UTF-8) which escaped
+the catch → bare HTTP 500. Fix: a global set_exception_handler + dump_safe()
+(dump with error_handler_t::replace) on every response/SSE/error/log body.
+
+This battery hits every body-taking endpoint with many one-variable-off bad
+inputs (invalid UTF-8 via raw socket so the byte survives, malformed JSON,
+empty body, non-object, wrong field types, missing required fields) and asserts:
+  * status is 4xx (never 5xx, never a non-JSON/opaque body),
+  * the body parses as JSON and carries a non-empty error.message,
+and that valid control requests still return 2xx.
+
+Exit code: 0 = all good (PASS), 1 = a case regressed (FAIL).
+"""
+import json, os, socket, sys, urllib.request, urllib.error
+
+HOST = os.environ.get("IMP_HOST", "localhost")
+PORT = int(os.environ.get("IMP_PORT", "8080"))
+M = os.environ.get("IMP_MODEL", "Qwen3-8B-NVFP4-cortecs")
+BASE = f"http://{HOST}:{PORT}"
+
+_fail = []
+_count = 0
+
+
+def raw_post(path, body_bytes):
+    """Send a request over a raw socket so invalid bytes survive (urllib/requests
+    would re-encode or reject). Returns (status:int, body:bytes)."""
+    req = (f"POST {path} HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\n"
+           f"Content-Length: {len(body_bytes)}\r\nConnection: close\r\n\r\n").encode() + body_bytes
+    s = socket.create_connection((HOST, PORT), timeout=60)
+    s.sendall(req)
+    buf = b""
+    while True:
+        d = s.recv(8192)
+        if not d:
+            break
+        buf += d
+    s.close()
+    head, _, body = buf.partition(b"\r\n\r\n")
+    status_line = head.split(b"\r\n", 1)[0].decode("latin1")
+    status = int(status_line.split(" ")[1]) if len(status_line.split(" ")) > 1 else 0
+    # de-chunk if needed (Connection: close usually gives identity; be lenient)
+    return status, body
+
+
+def check_bad(label, path, body_bytes):
+    """A bad-input request must yield 4xx + a JSON error envelope, never 5xx/opaque."""
+    global _count
+    _count += 1
+    try:
+        status, body = raw_post(path, body_bytes)
+    except Exception as e:
+        _fail.append((label, f"transport error: {e}"))
+        print(f"  FAIL {label}: transport error {e}")
+        return
+    ok = True
+    reason = ""
+    if status >= 500 or status < 400:
+        ok = False
+        reason = f"status {status} (want 4xx)"
+    else:
+        try:
+            j = json.loads(body.decode("utf-8", "replace"))
+            msg = (j.get("error") or {}).get("message")
+            if not msg:
+                ok = False
+                reason = f"status {status} but no error.message (body={body[:120]!r})"
+        except Exception:
+            ok = False
+            reason = f"status {status} but non-JSON body ({body[:120]!r})"
+    if ok:
+        print(f"  ok   {label}: {status} + error envelope")
+    else:
+        _fail.append((label, reason))
+        print(f"  FAIL {label}: {reason}")
+
+
+def check_no5xx(label, path, body_bytes):
+    """A lenient case: imp may accept it (2xx) or reject it (4xx+envelope), but it
+    must NEVER 5xx or return an opaque body. Used for wrong-type optional fields
+    where strict-400 vs lenient-coerce is a design choice, not a robustness bug."""
+    global _count
+    _count += 1
+    try:
+        status, body = raw_post(path, body_bytes)
+    except Exception as e:
+        _fail.append((label, f"transport error: {e}"))
+        print(f"  FAIL {label}: transport error {e}")
+        return
+    if status >= 500:
+        _fail.append((label, f"status {status} (5xx on bad input)"))
+        print(f"  FAIL {label}: status {status} (5xx)")
+        return
+    if status >= 400:
+        try:
+            j = json.loads(body.decode("utf-8", "replace"))
+            if not (j.get("error") or {}).get("message"):
+                _fail.append((label, f"4xx without error.message ({body[:120]!r})"))
+                print(f"  FAIL {label}: 4xx without error.message")
+                return
+        except Exception:
+            _fail.append((label, f"4xx non-JSON body ({body[:120]!r})"))
+            print(f"  FAIL {label}: 4xx non-JSON body")
+            return
+    print(f"  ok   {label}: {status} (no 5xx)")
+
+
+def check_valid(label, path, obj):
+    """A valid request must return 2xx."""
+    global _count
+    _count += 1
+    data = json.dumps(obj).encode()
+    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            status = r.status
+            r.read()
+    except urllib.error.HTTPError as e:
+        status = e.code
+    except Exception as e:
+        _fail.append((label, f"transport error: {e}"))
+        print(f"  FAIL {label}: transport error {e}")
+        return
+    if 200 <= status < 300:
+        print(f"  ok   {label}: {status}")
+    else:
+        _fail.append((label, f"status {status} (want 2xx)"))
+        print(f"  FAIL {label}: status {status} (want 2xx)")
+
+
+def jb(obj):
+    return json.dumps(obj).encode()
+
+
+def invalid_utf8_struct(obj):
+    """Valid JSON for obj, then corrupted: drop 3 trailing bytes + inject lone 0x80."""
+    return jb(obj)[:-3] + b"\x80\"}]}"
+
+
+def invalid_utf8_in_string(obj, placeholder="PONGMARK"):
+    """obj must contain the placeholder in a string value; replace with an invalid byte."""
+    return jb(obj).replace(placeholder.encode(), b"hi\x80there")
+
+
+# endpoint -> a minimal valid body + a body that contains PONGMARK in a string field
+ENDPOINTS = {
+    "/v1/chat/completions": (
+        {"model": M, "messages": [{"role": "user", "content": "ok"}], "max_tokens": 8},
+        {"model": M, "messages": [{"role": "user", "content": "PONGMARK"}], "max_tokens": 8},
+    ),
+    "/v1/completions": (
+        {"model": M, "prompt": "ok", "max_tokens": 8},
+        {"model": M, "prompt": "PONGMARK", "max_tokens": 8},
+    ),
+    "/v1/embeddings": (
+        {"model": M, "input": "ok"},
+        {"model": M, "input": "PONGMARK"},
+    ),
+    "/v1/messages": (
+        {"model": M, "messages": [{"role": "user", "content": "ok"}], "max_tokens": 8},
+        {"model": M, "messages": [{"role": "user", "content": "PONGMARK"}], "max_tokens": 8},
+    ),
+    "/tokenize": ({"model": M, "content": "ok"}, {"model": M, "content": "PONGMARK"}),
+    "/detokenize": ({"model": M, "tokens": [1, 2, 3]}, None),
+}
+
+# per-endpoint wrong-type / missing-field bad bodies (valid UTF-8, malformed semantics)
+BAD_SEMANTIC = {
+    "/v1/chat/completions": [
+        ("missing messages", {"model": M, "max_tokens": 8}),
+        ("messages not array", {"model": M, "messages": "hi", "max_tokens": 8}),
+        ("message not object", {"model": M, "messages": [123]}),
+        ("temperature wrong type", {"model": M, "messages": [{"role": "user", "content": "x"}], "temperature": "hot"}),
+        ("max_tokens wrong type", {"model": M, "messages": [{"role": "user", "content": "x"}], "max_tokens": "lots"}),
+        ("top_p wrong type", {"model": M, "messages": [{"role": "user", "content": "x"}], "top_p": "high"}),
+        ("n wrong type", {"model": M, "messages": [{"role": "user", "content": "x"}], "n": "two"}),
+    ],
+    "/v1/completions": [
+        ("missing prompt", {"model": M, "max_tokens": 8}),
+        ("max_tokens wrong type", {"model": M, "prompt": "x", "max_tokens": "lots"}),
+    ],
+    "/v1/embeddings": [
+        ("missing input", {"model": M}),
+        ("input wrong type", {"model": M, "input": 123}),
+        ("input array of non-strings", {"model": M, "input": [1, 2, 3]}),
+    ],
+    "/v1/messages": [
+        ("missing messages", {"model": M, "max_tokens": 8}),
+        ("messages not array", {"model": M, "messages": "hi", "max_tokens": 8}),
+    ],
+    "/tokenize": [
+        ("missing content", {"model": M}),
+        ("content wrong type", {"model": M, "content": 123}),
+    ],
+    "/detokenize": [
+        ("missing tokens", {"model": M}),
+        ("tokens not array", {"model": M, "tokens": "abc"}),
+        ("tokens non-int elements", {"model": M, "tokens": ["a", "b"]}),
+    ],
+}
+
+# generic malformed bodies applied to every endpoint
+def generic_bad_bodies():
+    return [
+        ("malformed JSON", b'{"model": garbage'),
+        ("empty body", b""),
+        ("not an object (array)", b"[]"),
+        ("not an object (string)", b'"hello"'),
+        ("not an object (number)", b"123"),
+        ("truncated", b'{"model":'),
+    ]
+
+
+def main():
+    print(f"imp HTTP robustness battery — base={BASE} model={M}\n")
+
+    print("[1] invalid UTF-8 (raw socket — the original 500 bug):")
+    for path, (valid, marked) in ENDPOINTS.items():
+        check_bad(f"{path}  invalid-UTF-8 (broken struct)", path, invalid_utf8_struct(valid))
+        if marked is not None:
+            check_bad(f"{path}  invalid-UTF-8 (in string)", path, invalid_utf8_in_string(marked))
+
+    print("\n[2] generic malformed bodies on every endpoint:")
+    for path in ENDPOINTS:
+        for label, body in generic_bad_bodies():
+            check_bad(f"{path}  {label}", path, body)
+
+    print("\n[3] semantic errors — missing required field must 4xx; wrong-type may 4xx or 2xx but never 5xx:")
+    for path, cases in BAD_SEMANTIC.items():
+        for label, obj in cases:
+            if label.startswith("missing"):
+                check_bad(f"{path}  {label}", path, jb(obj))
+            else:
+                check_no5xx(f"{path}  {label}", path, jb(obj))
+
+    print("\n[4] oversized field (1 MiB string):")
+    big = "A" * (1024 * 1024)
+    check_no5xx("/v1/chat/completions  huge non-numeric max_tokens",
+                "/v1/chat/completions",
+                jb({"model": M, "messages": [{"role": "user", "content": "x"}], "max_tokens": big}))
+
+    print("\n[5] valid control requests (must be 2xx):")
+    check_valid("/v1/chat/completions valid", "/v1/chat/completions",
+                {"model": M, "messages": [{"role": "user", "content": "Say PONG"}], "max_tokens": 8})
+    check_valid("/v1/completions valid", "/v1/completions", {"model": M, "prompt": "Say PONG", "max_tokens": 8})
+    check_valid("/v1/embeddings valid", "/v1/embeddings", {"model": M, "input": "hello"})
+    check_valid("/tokenize valid", "/tokenize", {"model": M, "content": "hello world"})
+    check_valid("/detokenize valid", "/detokenize", {"model": M, "tokens": [9707, 1879]})
+
+    print()
+    if _fail:
+        print(f"FAIL: {len(_fail)}/{_count} cases regressed:")
+        for label, reason in _fail:
+            print(f"  - {label}: {reason}")
+        return 1
+    print(f"PASS: all {_count} cases robust (bad input -> 4xx+envelope, valid -> 2xx)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tools/imp-server/anthropic.cpp
+++ b/tools/imp-server/anthropic.cpp
@@ -2,6 +2,7 @@
 // See anthropic.h for the public surface.
 
 #include "anthropic.h"
+#include "utils.h"
 
 #include <atomic>
 #include <cstdio>
@@ -95,7 +96,7 @@ void push_assistant_turn(json& out, const json& anth_msg) {
                 {"function",
                  {
                      {"name", name},
-                     {"arguments", input.dump()},
+                     {"arguments", dump_safe(input)},
                  }},
             });
         } else if (type == "thinking") {

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -137,7 +137,7 @@ void handle_health(const httplib::Request& /*req*/, httplib::Response& res, Serv
             queue = state.batching->queue_depth();
     }
     json body = {{"status", "ok"}, {"model_loaded", loaded}, {"queue_depth", queue}};
-    res.set_content(body.dump(), "application/json");
+    res.set_content(dump_safe(body), "application/json");
 }
 
 // Recursively find all model files in a directory, returning (display_name, full_path) pairs.
@@ -206,7 +206,7 @@ void handle_models(const httplib::Request& /*req*/, httplib::Response& res, Serv
     }
 
     json body = {{"object", "list"}, {"data", data}};
-    res.set_content(body.dump(), "application/json");
+    res.set_content(dump_safe(body), "application/json");
 }
 
 // Find a model by name in models_dir. Returns full path or empty string.
@@ -253,7 +253,7 @@ bool ensure_model_loaded(ServerState& state, const std::string& requested_model,
                 {"error",
                  {{"message", "No model loaded and '" + requested_model + "' not found in models directory"},
                   {"type", "server_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return false;
         }
         printf("[auto-load] Loading %s...\n", requested_model.c_str());
@@ -262,7 +262,7 @@ bool ensure_model_loaded(ServerState& state, const std::string& requested_model,
         if (!error.empty()) {
             res.status = 500;
             json err = {{"error", {{"message", "Auto-load failed: " + error}, {"type", "server_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return false;
         }
         printf("[auto-load] %s loaded successfully\n", requested_model.c_str());
@@ -281,7 +281,7 @@ bool ensure_model_loaded(ServerState& state, const std::string& requested_model,
                   {"type", "invalid_request_error"},
                   {"param", "model"},
                   {"code", "model_not_found"}}}};
-    res.set_content(err.dump(), "application/json");
+    res.set_content(dump_safe(err), "application/json");
     return false;
 }
 
@@ -515,7 +515,7 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
         res.status = 400;
         json err = {
             {"error", {{"message", "\"messages\" must be an array"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return false;
     }
 
@@ -526,7 +526,7 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
             json err = {{"error",
                          {{"message", "\"temperature\" must be between 0 and 2"},
                           {"type", "invalid_request_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return false;
         }
     }
@@ -538,7 +538,7 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
             json err = {
                 {"error",
                  {{"message", "\"top_p\" must be between 0 and 1"}, {"type", "invalid_request_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return false;
         }
     }
@@ -550,7 +550,7 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
             json err = {
                 {"error",
                  {{"message", "\"max_tokens\" must be at least 1"}, {"type", "invalid_request_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return false;
         }
     }
@@ -561,7 +561,7 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
             res.status = 400;
             json err = {{"error",
                          {{"message", "\"n\" must be between 1 and 4."}, {"type", "invalid_request_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return false;
         }
     }
@@ -631,11 +631,7 @@ static bool parse_chat_request_params(
     try {
         body = json::parse(req.body);
     } catch (const json::parse_error& e) {
-        res.status = 400;
-        json err = {
-            {"error",
-             {{"message", std::string("Invalid JSON: ") + e.what()}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        send_json_error(res, 400, "invalid_request_error", std::string("Invalid JSON: ") + e.what());
         return false;
     }
 
@@ -650,7 +646,7 @@ static bool parse_chat_request_params(
         json err = {{"error",
                      {{"message", "messages array is required and must not be empty"},
                       {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return false;
     }
     // Bound the conversation length: each message is tokenized + template-expanded
@@ -661,7 +657,7 @@ static bool parse_chat_request_params(
         json err = {{"error",
                      {{"message", "messages array exceeds maximum of 10000 entries"},
                       {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return false;
     }
 
@@ -690,7 +686,7 @@ static bool parse_chat_request_params(
         json err = {
             {"error",
              {{"message", "streaming with n > 1 is not supported"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return false;
     }
 
@@ -758,7 +754,7 @@ static bool parse_chat_request_params(
                                             sch["properties"].empty()) &&
                                            !sch.contains("enum");
                     if (!free_form) {
-                        ctx.params.json_schema_str = sch.dump();
+                        ctx.params.json_schema_str = dump_safe(sch);
                     }
                 }
             }
@@ -901,7 +897,7 @@ static bool parse_chat_request_params(
     if (ctx.params.requested_model.empty()) {
         res.status = 400;
         json err = {{"error", {{"message", "\"model\" is required"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return false;
     }
 
@@ -977,7 +973,7 @@ static bool snapshot_state_and_tokenize_(
                 tf.name = t["function"].value("name", "");
                 tf.description = t["function"].value("description", "");
                 if (t["function"].contains("parameters")) {
-                    tf.parameters_json = t["function"]["parameters"].dump();
+                    tf.parameters_json = dump_safe(t["function"]["parameters"]);
                 }
                 ctx.snap.tool_defs.push_back(std::move(tf));
             }
@@ -992,7 +988,7 @@ static bool snapshot_state_and_tokenize_(
         if (!lock.owns_lock()) {
             res.status = 503;
             json err = {{"error", {{"message", "Server is busy. Please retry."}, {"type", "server_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return false;
         }
         // Stop batching engine for exclusive vision access
@@ -1006,7 +1002,7 @@ static bool snapshot_state_and_tokenize_(
             res.status = 400;
             json error = {
                 {"error", {{"message", "Failed to process image"}, {"type", "invalid_request_error"}}}};
-            res.set_content(error.dump(), "application/json");
+            res.set_content(dump_safe(error), "application/json");
             return false;
         }
     }
@@ -1174,7 +1170,7 @@ static bool snapshot_state_and_tokenize_(
                                         std::to_string(ctx.snap.n_prompt_tokens) + " > " +
                                         std::to_string(state.max_input_tokens) + ")"},
                         {"type", "invalid_request_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return false;
     }
 
@@ -1190,7 +1186,7 @@ static bool snapshot_state_and_tokenize_(
                        {{"message", "Prompt exceeds context window (" + std::to_string(ctx.snap.n_prompt_tokens) +
                                         " tokens >= " + std::to_string(ctx.snap.max_seq_len) + " max)"},
                         {"type", "invalid_request_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return false;
     }
 
@@ -1209,7 +1205,7 @@ static bool snapshot_state_and_tokenize_(
                                {{"message", "Unknown LoRA adapter '" + ctx.params.lora_name +
                                                 "' (load at startup via --lora NAME=PATH)"},
                                 {"type", "invalid_request_error"}}}};
-                res.set_content(error.dump(), "application/json");
+                res.set_content(dump_safe(error), "application/json");
                 return false;
             }
             want = it->second;
@@ -1247,7 +1243,7 @@ static void handle_vision_chat_blocking_(
         json error = {{"error",
                        {{"message", std::string("Context reset failed: ") + imp_error_string(err)},
                         {"type", "server_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return;
     }
 
@@ -1266,7 +1262,7 @@ static void handle_vision_chat_blocking_(
         json error = {{"error",
                        {{"message", std::string("Prefill failed: ") + imp_error_string(err)},
                         {"type", "server_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return;
     }
 
@@ -1370,7 +1366,7 @@ static void handle_vision_chat_blocking_(
                       {{"prompt_tokens", ctx.snap.n_prompt_tokens},
                        {"completion_tokens", n_output_tokens},
                        {"total_tokens", ctx.snap.n_prompt_tokens + n_output_tokens}}}};
-    res.set_content(response.dump(), "application/json");
+    res.set_content(dump_safe(response), "application/json");
 }
 
 // Non-streaming chat completion: run n_completions independent generations
@@ -1736,7 +1732,7 @@ static void nonstream_chat_response_(
                       ctx.log_client_ip, ctx.log_raw_body,
                       ms, ctx.snap.n_prompt_tokens, total_output_tokens, nonstream_finish, response);
 
-    res.set_content(response.dump(), "application/json");
+    res.set_content(dump_safe(response), "application/json");
 }
 
 // Set up SSE chunked content provider for streaming chat completion.
@@ -2173,15 +2169,15 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
                     tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
                     if (tpl_family == imp::ChatTemplateFamily::LLAMA3) {
                         tc.name = tool_fn_name;
-                        tc.arguments = j.dump();
+                        tc.arguments = dump_safe(j);
                     } else {
                         tc.name = j.value("name", "");
                         if (j.contains("arguments")) {
-                            tc.arguments = j["arguments"].dump();
+                            tc.arguments = dump_safe(j["arguments"]);
                         } else {
                             json args = j;
                             args.erase("name");
-                            tc.arguments = args.dump();
+                            tc.arguments = dump_safe(args);
                         }
                     }
                     if (!tc.name.empty()) {
@@ -2545,7 +2541,7 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
                           {"model", snap_model_name},
                           {"choices", json::array()},
                           {"usage", usage}};
-        std::string usage_chunk = "data: " + usage_obj.dump() + "\n\n";
+        std::string usage_chunk = "data: " + dump_safe(usage_obj) + "\n\n";
         sink.write(usage_chunk.data(), usage_chunk.size());
     }
 
@@ -2654,7 +2650,7 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
             json err = {
                 {"error",
                  {{"message", "Inference engine not ready. Please retry."}, {"type", "server_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return;
         }
         state.batching->submit(server_req);
@@ -2676,11 +2672,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
     try {
         body = json::parse(req.body);
     } catch (const json::parse_error& e) {
-        res.status = 400;
-        json err = {
-            {"error",
-             {{"message", std::string("Invalid JSON: ") + e.what()}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        send_json_error(res, 400, "invalid_request_error", std::string("Invalid JSON: ") + e.what());
         return;
     }
 
@@ -2695,7 +2687,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
         json err = {{"error",
                      {{"message", "\"prompt\" is required and must not be empty"},
                       {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -2777,7 +2769,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
     if (requested_model.empty()) {
         res.status = 400;
         json err = {{"error", {{"message", "\"model\" is required"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -2809,7 +2801,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                        {{"message", "Prompt exceeds max input tokens (" + std::to_string(n_prompt_tokens) +
                                         " > " + std::to_string(state.max_input_tokens) + ")"},
                         {"type", "invalid_request_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return;
     }
 
@@ -2819,7 +2811,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                        {{"message", "Prompt exceeds context window (" + std::to_string(n_prompt_tokens) +
                                         " tokens >= " + std::to_string(snap_max_seq_len) + " max)"},
                         {"type", "invalid_request_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return;
     }
 
@@ -2867,7 +2859,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
             json err = {
                 {"error",
                  {{"message", "Inference engine not ready. Please retry."}, {"type", "server_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return;
         }
         state.batching->submit(server_req);
@@ -3057,7 +3049,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                                        {{"prompt_tokens", n_prompt_tokens},
                                         {"completion_tokens", n_output_tokens},
                                         {"total_tokens", n_prompt_tokens + n_output_tokens}}}};
-                    std::string usage_chunk = "data: " + usage_obj.dump() + "\n\n";
+                    std::string usage_chunk = "data: " + dump_safe(usage_obj) + "\n\n";
                     sink.write(usage_chunk.data(), usage_chunk.size());
                 }
 
@@ -3200,7 +3192,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                            {"completion_tokens", n_output_tokens},
                            {"total_tokens", n_prompt_tokens + n_output_tokens}}}};
 
-        res.set_content(response.dump(), "application/json");
+        res.set_content(dump_safe(response), "application/json");
     }
 }
 
@@ -3209,11 +3201,7 @@ void handle_tokenize(const httplib::Request& req, httplib::Response& res, Server
     try {
         body = json::parse(req.body);
     } catch (const json::parse_error& e) {
-        res.status = 400;
-        json err = {
-            {"error",
-             {{"message", std::string("Invalid JSON: ") + e.what()}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        send_json_error(res, 400, "invalid_request_error", std::string("Invalid JSON: ") + e.what());
         return;
     }
 
@@ -3221,7 +3209,7 @@ void handle_tokenize(const httplib::Request& req, httplib::Response& res, Server
     if (content.empty()) {
         res.status = 400;
         json err = {{"error", {{"message", "\"content\" is required"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3234,7 +3222,7 @@ void handle_tokenize(const httplib::Request& req, httplib::Response& res, Server
     if (!snap_model) {
         res.status = 503;
         json err = {{"error", {{"message", "No model loaded"}, {"type", "server_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3246,13 +3234,13 @@ void handle_tokenize(const httplib::Request& req, httplib::Response& res, Server
         json error = {{"error",
                        {{"message", std::string("Tokenize failed: ") + imp_error_string(err)},
                         {"type", "server_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return;
     }
 
     tokens.resize(n_tokens);
     json response = {{"tokens", tokens}};
-    res.set_content(response.dump(), "application/json");
+    res.set_content(dump_safe(response), "application/json");
 }
 
 void handle_detokenize(const httplib::Request& req, httplib::Response& res, ServerState& state) {
@@ -3260,11 +3248,7 @@ void handle_detokenize(const httplib::Request& req, httplib::Response& res, Serv
     try {
         body = json::parse(req.body);
     } catch (const json::parse_error& e) {
-        res.status = 400;
-        json err = {
-            {"error",
-             {{"message", std::string("Invalid JSON: ") + e.what()}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        send_json_error(res, 400, "invalid_request_error", std::string("Invalid JSON: ") + e.what());
         return;
     }
 
@@ -3272,7 +3256,7 @@ void handle_detokenize(const httplib::Request& req, httplib::Response& res, Serv
         res.status = 400;
         json err = {
             {"error", {{"message", "\"tokens\" array is required"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3285,7 +3269,7 @@ void handle_detokenize(const httplib::Request& req, httplib::Response& res, Serv
     if (!snap_model) {
         res.status = 503;
         json err = {{"error", {{"message", "No model loaded"}, {"type", "server_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3296,7 +3280,7 @@ void handle_detokenize(const httplib::Request& req, httplib::Response& res, Serv
         json err = {{"error",
                      {{"message", "tokens array exceeds maximum of 1000000 entries"},
                       {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3309,12 +3293,12 @@ void handle_detokenize(const httplib::Request& req, httplib::Response& res, Serv
         json error = {{"error",
                        {{"message", std::string("Detokenize failed: ") + imp_error_string(err)},
                         {"type", "server_error"}}}};
-        res.set_content(error.dump(), "application/json");
+        res.set_content(dump_safe(error), "application/json");
         return;
     }
 
     json response = {{"content", std::string(buf.data())}};
-    res.set_content(response.dump(), "application/json");
+    res.set_content(dump_safe(response), "application/json");
 }
 
 void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, ServerState& state) {
@@ -3445,11 +3429,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
     try {
         body = json::parse(req.body);
     } catch (const json::parse_error& e) {
-        res.status = 400;
-        json err = {
-            {"error",
-             {{"message", std::string("Invalid JSON: ") + e.what()}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        send_json_error(res, 400, "invalid_request_error", std::string("Invalid JSON: ") + e.what());
         return;
     }
 
@@ -3467,7 +3447,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
                     json err = {
                         {"error",
                          {{"message", "Each input must be a string"}, {"type", "invalid_request_error"}}}};
-                    res.set_content(err.dump(), "application/json");
+                    res.set_content(dump_safe(err), "application/json");
                     return;
                 }
             }
@@ -3476,13 +3456,13 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
             json err = {{"error",
                          {{"message", "\"input\" must be a string or array of strings"},
                           {"type", "invalid_request_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return;
         }
     } else {
         res.status = 400;
         json err = {{"error", {{"message", "\"input\" is required"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3490,7 +3470,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
         res.status = 400;
         json err = {
             {"error", {{"message", "\"input\" must not be empty"}, {"type", "invalid_request_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3501,14 +3481,14 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
         json err = {{"error",
                      {{"message", "Server is busy processing another request. Please retry."},
                       {"type", "server_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
     if (!state.model_loaded()) {
         res.status = 503;
         json err = {{"error", {{"message", "No model loaded"}, {"type", "server_error"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -3526,7 +3506,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
             json err = {{"error",
                          {{"message", "Server busy draining in-flight requests. Please retry."},
                           {"type", "server_error"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return;
         }
     }
@@ -3561,7 +3541,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
             json error = {{"error",
                            {{"message", std::string("Tokenize failed: ") + imp_error_string(err)},
                             {"type", "server_error"}}}};
-            res.set_content(error.dump(), "application/json");
+            res.set_content(dump_safe(error), "application/json");
             return;
         }
         tokens.resize(n_tokens);
@@ -3571,7 +3551,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
             json error = {
                 {"error",
                  {{"message", "Input tokenizes to zero tokens"}, {"type", "invalid_request_error"}}}};
-            res.set_content(error.dump(), "application/json");
+            res.set_content(dump_safe(error), "application/json");
             return;
         }
 
@@ -3585,7 +3565,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
             json error = {{"error",
                            {{"message", std::string("Prefill failed: ") + imp_error_string(err)},
                             {"type", "server_error"}}}};
-            res.set_content(error.dump(), "application/json");
+            res.set_content(dump_safe(error), "application/json");
             return;
         }
 
@@ -3606,7 +3586,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
             json error = {{"error",
                            {{"message", std::string("CUDA memcpy failed: ") + cudaGetErrorString(cuda_err)},
                             {"type", "server_error"}}}};
-            res.set_content(error.dump(), "application/json");
+            res.set_content(dump_safe(error), "application/json");
             return;
         }
 
@@ -3650,7 +3630,7 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
                      {"model", body.value("model", state.model_name)},
                      {"usage",
                       {{"prompt_tokens", total_prompt_tokens}, {"total_tokens", total_prompt_tokens}}}};
-    res.set_content(response.dump(), "application/json");
+    res.set_content(dump_safe(response), "application/json");
 }
 
 // ===========================================================================
@@ -3673,7 +3653,7 @@ struct AnthropicSSE {
         std::string buf = "event: ";
         buf += event_name;
         buf += "\ndata: ";
-        buf += payload.dump();
+        buf += dump_safe(payload);
         buf += "\n\n";
         return sink.write(buf.data(), buf.size());
     }
@@ -4082,15 +4062,15 @@ static bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& c
                     tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
                     if (tpl_family == imp::ChatTemplateFamily::LLAMA3) {
                         tc.name = tool_fn_name;
-                        tc.arguments = j.dump();
+                        tc.arguments = dump_safe(j);
                     } else {
                         tc.name = j.value("name", "");
                         if (j.contains("arguments"))
-                            tc.arguments = j["arguments"].dump();
+                            tc.arguments = dump_safe(j["arguments"]);
                         else {
                             json args = j;
                             args.erase("name");
-                            tc.arguments = args.dump();
+                            tc.arguments = dump_safe(args);
                         }
                     }
                     if (!tc.name.empty()) {
@@ -4366,7 +4346,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
                     {"error",
                      {{"type", "invalid_request_error"},
                       {"message", std::string("Invalid JSON: ") + e.what()}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -4375,7 +4355,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
         json err = {{"type", "error"},
                     {"error",
                      {{"type", "invalid_request_error"}, {"message", "Request body must be a JSON object"}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -4394,7 +4374,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
                     {"error",
                      {{"type", "invalid_request_error"},
                       {"message", std::string("Failed to transform Anthropic body: ") + e.what()}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -4407,7 +4387,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
         httplib::Request shim_req = req;
         json shim_body = oai_body;
         shim_body["stream"] = true;
-        shim_req.body = shim_body.dump();
+        shim_req.body = dump_safe(shim_body);
         shim_req.headers.erase("Content-Length");
         shim_req.headers.erase("content-length");
 
@@ -4428,7 +4408,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
             json out = {{"type", "error"},
                         {"error", parsed.value("error",
                                                json{{"type", "invalid_request_error"}, {"message", "bad request"}})}};
-            res.set_content(out.dump(), "application/json");
+            res.set_content(dump_safe(out), "application/json");
             return;
         }
 
@@ -4454,7 +4434,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
                         {"error",
                          {{"type", "invalid_request_error"},
                           {"message", "Streaming is not supported for vision/image requests"}}}};
-            res.set_content(err.dump(), "application/json");
+            res.set_content(dump_safe(err), "application/json");
             return;
         }
 
@@ -4498,7 +4478,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
                 json err = {{"type", "error"},
                             {"error",
                              {{"type", "server_error"}, {"message", "Inference engine not ready. Please retry."}}}};
-                res.set_content(err.dump(), "application/json");
+                res.set_content(dump_safe(err), "application/json");
                 return;
             }
             state.batching->submit(server_req);
@@ -4525,7 +4505,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
     httplib::Request shim_req = req;
     json shim_body = oai_body;
     shim_body["stream"] = false;
-    shim_req.body = shim_body.dump();
+    shim_req.body = dump_safe(shim_body);
     shim_req.headers.erase("Content-Length");
     shim_req.headers.erase("content-length");
 
@@ -4549,7 +4529,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
         }
         json out = {{"type", "error"},
                     {"error", parsed.value("error", json{{"type", "server_error"}, {"message", "unknown"}})}};
-        res.set_content(out.dump(), "application/json");
+        res.set_content(dump_safe(out), "application/json");
         return;
     }
 
@@ -4562,7 +4542,7 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
                     {"error",
                      {{"type", "server_error"},
                       {"message", std::string("Upstream returned non-JSON: ") + e.what()}}}};
-        res.set_content(err.dump(), "application/json");
+        res.set_content(dump_safe(err), "application/json");
         return;
     }
 
@@ -4585,5 +4565,5 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
     // Non-streaming requests are fully assembled above (the want_stream path
     // returned earlier with a native incremental SSE stream).
     res.status = 200;
-    res.set_content(anth_response.dump(), "application/json");
+    res.set_content(dump_safe(anth_response), "application/json");
 }

--- a/tools/imp-server/handlers.h
+++ b/tools/imp-server/handlers.h
@@ -48,7 +48,10 @@ struct RequestLogger {
         if (!enabled)
             return;
         std::lock_guard<std::mutex> lock(mtx);
-        file << record.dump() << '\n';
+        // replace: the record echoes raw client bodies / decoded model text,
+        // which can contain ill-formed UTF-8 — a plain dump() would throw
+        // (json::type_error.316) and take down the request mid-log.
+        file << record.dump(-1, ' ', false, json::error_handler_t::replace) << '\n';
         file.flush();
     }
 };

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -1,5 +1,6 @@
 #include "args.h"
 #include "handlers.h"
+#include "utils.h"
 #include "model/hf_hub.h"
 #include "runtime/config.h"
 #include "runtime/process_diag.h"
@@ -9,6 +10,7 @@
 
 #include <csignal>
 #include <cstdio>
+#include <exception>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -209,6 +211,26 @@ int main(int argc, char** argv) {
     svr.Get("/metrics", [&state](const httplib::Request& req, httplib::Response& res) {
         handle_metrics(req, res, state);
     });
+
+    // Global safety net: any exception that escapes a handler must become a
+    // JSON error envelope, never a bare "500 Internal Server Error". Malformed
+    // or invalid-UTF-8 client input surfaces as a json::exception (parse_error,
+    // or type_error.316 when an error message echoes the offending bytes) — map
+    // those to 400. Everything else is a genuine internal failure → 500, but
+    // still with a JSON body. dump_safe (inside send_json_error) guarantees the
+    // envelope itself can't throw on bad bytes.
+    svr.set_exception_handler(
+        [](const httplib::Request&, httplib::Response& res, std::exception_ptr ep) {
+            try {
+                std::rethrow_exception(ep);
+            } catch (const nlohmann::json::exception& e) {
+                send_json_error(res, 400, "invalid_request_error", e.what());
+            } catch (const std::exception& e) {
+                send_json_error(res, 500, "server_error", e.what());
+            } catch (...) {
+                send_json_error(res, 500, "server_error", "unknown internal error");
+            }
+        });
 
     // Track failed requests via post-routing
     svr.set_post_routing_handler([&state](const httplib::Request&, httplib::Response& res) {

--- a/tools/imp-server/tool_call.cpp
+++ b/tools/imp-server/tool_call.cpp
@@ -1,4 +1,5 @@
 #include "tool_call.h"
+#include "utils.h"
 
 #include <cstring>
 #include <cstdlib>
@@ -23,7 +24,7 @@ std::string build_tool_prompt(imp::ChatTemplateFamily family, const json& tools,
             json fn_desc = {{"name", fn.value("name", "")},
                             {"description", fn.value("description", "")},
                             {"parameters", fn.value("parameters", json::object())}};
-            prompt += fn_desc.dump() + "\n\n";
+            prompt += dump_safe(fn_desc) + "\n\n";
         }
         prompt +=
             "For each function call, return a JSON object within <function=function_name> tags:\n"
@@ -35,7 +36,7 @@ std::string build_tool_prompt(imp::ChatTemplateFamily family, const json& tools,
             "\n\n# Tools\n\n"
             "You may call one or more functions to assist with the user query.\n\n"
             "<tools>\n" +
-            tools.dump() +
+            dump_safe(tools) +
             "\n</tools>\n\n"
             "For each function call, return a JSON object within <tool_call></tool_call> XML tags:\n"
             "<tool_call>\n"
@@ -135,7 +136,7 @@ static bool parse_qwen36_xml_call(const std::string& body, ParsedToolCall& tc) {
         args[key] = std::move(jv);
         pos = pv_end + 12;
     }
-    tc.arguments = args.dump();
+    tc.arguments = dump_safe(args);
     return true;
 }
 
@@ -197,11 +198,11 @@ std::pair<std::string, std::vector<ParsedToolCall>> parse_tool_calls_chatml(
                 tc.id = "call_imp_" + std::to_string(next_tool_call_id.fetch_add(1));
                 tc.name = j.value("name", "");
                 if (j.contains("arguments")) {
-                    tc.arguments = j["arguments"].dump();
+                    tc.arguments = dump_safe(j["arguments"]);
                 } else {
                     json args = j;
                     args.erase("name");
-                    tc.arguments = args.dump();
+                    tc.arguments = dump_safe(args);
                 }
                 if (!tc.name.empty()) {
                     calls.push_back(std::move(tc));
@@ -271,7 +272,7 @@ std::pair<std::string, std::vector<ParsedToolCall>> parse_tool_calls_llama3(
             ParsedToolCall tc;
             tc.id = "call_imp_" + std::to_string(next_tool_call_id.fetch_add(1));
             tc.name = name;
-            tc.arguments = j.dump();
+            tc.arguments = dump_safe(j);
             calls.push_back(std::move(tc));
         } catch (...) {
             // Malformed JSON — skip
@@ -525,7 +526,7 @@ std::pair<std::string, std::vector<ParsedToolCall>> parse_tool_calls_gemma(
             ParsedToolCall tc;
             tc.id = "call_imp_" + std::to_string(next_tool_call_id.fetch_add(1));
             tc.name = std::move(name);
-            tc.arguments = ok ? args.dump() : "{}";
+            tc.arguments = ok ? dump_safe(args) : "{}";
             if (!tc.name.empty())
                 calls.push_back(std::move(tc));
         }
@@ -558,7 +559,7 @@ static std::string json_to_gemma_value(const json& v) {
     if (v.is_null())
         return "null";
     if (v.is_number())
-        return v.dump();
+        return dump_safe(v);
     if (v.is_array()) {
         std::string out = "[";
         bool first = true;
@@ -583,7 +584,7 @@ static std::string json_to_gemma_value(const json& v) {
         out += "}";
         return out;
     }
-    return v.dump();
+    return dump_safe(v);
 }
 
 std::string reconstruct_tool_call_output(imp::ChatTemplateFamily family, const json& tool_calls,
@@ -619,7 +620,7 @@ std::string reconstruct_tool_call_output(imp::ChatTemplateFamily family, const j
             json call_obj = {{"name", name}, {"arguments", json::parse(args, nullptr, false)}};
             if (call_obj["arguments"].is_discarded())
                 call_obj["arguments"] = args;
-            result += "\n<tool_call>\n" + call_obj.dump() + "\n</tool_call>";
+            result += "\n<tool_call>\n" + dump_safe(call_obj) + "\n</tool_call>";
         }
     }
 
@@ -726,7 +727,7 @@ std::string format_tool_response(imp::ChatTemplateFamily family, const json& msg
     std::string content;
     if (msg.contains("content") && !msg["content"].is_null()) {
         const auto& c = msg["content"];
-        content = c.is_string() ? c.get<std::string>() : c.dump();
+        content = c.is_string() ? c.get<std::string>() : dump_safe(c);
     }
 
     if (family == imp::ChatTemplateFamily::LLAMA3) {

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -3,6 +3,18 @@
 
 #include <cstdio>
 
+std::string dump_safe(const json& j) {
+    // error_handler_t::replace: emit U+FFFD for ill-formed UTF-8 instead of
+    // throwing json::type_error.316. Identical output for valid UTF-8.
+    return j.dump(-1, ' ', false, json::error_handler_t::replace);
+}
+
+void send_json_error(httplib::Response& res, int status, const char* type, const std::string& message) {
+    json err = {{"error", {{"message", message}, {"type", type}}}};
+    res.status = status;
+    res.set_content(dump_safe(err), "application/json");
+}
+
 json safe_token_json(const std::string& text) {
     std::string safe;
     safe.reserve(text.size());
@@ -352,7 +364,7 @@ std::string sse_chunk(const std::string& id, int64_t created, const std::string&
                 {"created", created},
                 {"model", model},
                 {"choices", json::array({choice})}};
-    return "data: " + obj.dump() + "\n\n";
+    return "data: " + dump_safe(obj) + "\n\n";
 }
 
 std::string sse_completion_chunk(const std::string& id, int64_t created, const std::string& model,
@@ -365,5 +377,5 @@ std::string sse_completion_chunk(const std::string& id, int64_t created, const s
                 {"created", created},
                 {"model", model},
                 {"choices", json::array({choice})}};
-    return "data: " + obj.dump() + "\n\n";
+    return "data: " + dump_safe(obj) + "\n\n";
 }

--- a/tools/imp-server/utils.h
+++ b/tools/imp-server/utils.h
@@ -11,6 +11,21 @@
 
 using json = nlohmann::json;
 
+// Serialize `j` to a string that never throws on invalid UTF-8. nlohmann's
+// default dump() throws json::type_error.316 the moment it hits an ill-formed
+// UTF-8 byte; user- and model-derived strings (byte-truncated prompts, decoded
+// tokens) routinely contain those. Invalid bytes are replaced with U+FFFD. For
+// well-formed UTF-8 the output is byte-identical to dump(). Use this for ANY
+// response/SSE/error body that can carry client- or model-supplied text.
+std::string dump_safe(const json& j);
+
+// Send an OpenAI-style error envelope {"error":{"message":..,"type":..}} with
+// the given HTTP status. Dumps via dump_safe so an invalid-UTF-8 byte echoed
+// into the message (e.g. a parse-error what() on byte-truncated input) can
+// never make the dump throw — that throw used to escape the handler and turn a
+// 400-class bad-input case into a bare 500 (DEBUG-500-on-bad-input.md).
+void send_json_error(httplib::Response& res, int status, const char* type, const std::string& message);
+
 json safe_token_json(const std::string& text);
 json token_bytes_json(const std::string& text);
 size_t utf8_complete_len(const std::string& s);


### PR DESCRIPTION
## Bug
Invalid UTF-8 in a request body (e.g. an agent **byte-truncating** a prompt and splitting a multibyte char) made imp answer with an opaque `500 Internal Server Error` and **no body** — masking the real cause (it looked like "empty completions"). Bad *client* input must be a **4xx** with a diagnostic, never a 5xx.

## Root cause
`json::parse(req.body)` throws `parse_error` on the bad byte → the catch builds an error envelope echoing `e.what()` (which contains the offending bytes) → `err.dump()` then throws **`json::type_error.316`** (nlohmann's `dump()` rejects ill-formed UTF-8 by default). That is *not* a `parse_error`, so it escapes the `catch(parse_error&)` and httplib returns a bare 500. There was also **no global exception handler**, so any uncaught handler throw became a bare 500.

## Fix
- **`dump_safe()` + `send_json_error()`** helpers (`utils`): serialize with `error_handler_t::replace` so an ill-formed byte echoed into any response / error / SSE / request-log body emits U+FFFD instead of throwing. Byte-identical to `dump()` for valid UTF-8.
- **Global `svr.set_exception_handler`** (`main.cpp`): `json::exception` → `400 invalid_request_error`, any other `std::exception` → `500 server_error`, **always with a JSON body**. No handler path can emit a bare 500 again.
- **Server-wide audit**: converted every response / SSE / error-envelope / request-log `.dump()` across `handlers.cpp`, `utils.cpp`, `tool_call.cpp`, `anthropic.cpp`, `handlers.h` to the safe form (an Explore-agent audit surfaced ~80 `.dump()` sites and the streaming ones that the global handler can't recover after status 200 is sent).

## Tests (significantly expanded)
`tests/test_server_robustness.py` — fires **malformed JSON, invalid UTF-8 (raw socket), empty body, non-object, wrong-type and missing-field** inputs at **all six body endpoints** (`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/messages`, `/tokenize`, `/detokenize`) and asserts **4xx + error envelope, never 5xx**; valid requests stay 2xx.

Verified on RTX 5090 / Qwen3-8B-NVFP4-cortecs:
- Original repro: invalid UTF-8 (both broken-struct and in-string) → **400** with a precise message (offending bytes replaced with U+FFFD), valid → 200.
- Robustness battery: **72/72 pass** (was: 500 on the UTF-8 cases).
- OpenAI + Anthropic **streaming unaffected**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)