### PR TITLE
fix(server): honor [runtime] max_batch_size from imp.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **`[runtime] max_batch_size` from imp.conf is now honored for engine sizing.**
+  The server built `ImpConfig.max_batch_size` only from the `--max-batch` CLI
+  flag (default 0 = auto), so the imp.conf value was dropped — it reached the
+  engine only as the decode-batch cap, never the scheduler/KV/workspace sizing.
+  Precedence is now: per-request override > `--max-batch` > `[runtime]
+  max_batch_size` > 0 (engine auto-sizes from the model's weight footprint). The
+  `runtime.max_batch_size` default changed 4 → 0 to match the documented
+  "0 = auto" semantics (and the engine now logs the resolved batch size). Audit:
+  this args-vs-imp.conf drop was unique to `max_batch_size`; all other imp.conf
+  keys reach the engine via the ImpConfig builder or a direct `runtime_config_`
+  read.
+
 ## [0.11.2] - 2026-06-14
 
 Patch release. Hardens the HTTP surface so malformed/invalid client input can

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -32,7 +32,10 @@ graph_capture_mode   = "relaxed"
 # Auto-disabled when the model's prefill path is uncapturable.
 prefill_graph        = true
 # Max concurrent sequences in a decode batch (server continuous batching).
-max_batch_size       = 4
+# 0 = auto: the engine sizes it from the model's weight footprint (a >20 GiB
+# MoE auto-picks 1). Set a positive value to force it (e.g. 4). The --max-batch
+# CLI flag and a per-request "max_batch_size" override take precedence.
+max_batch_size       = 0
 # Run a warmup forward pass at engine init to prime cuBLAS handles + L2 cache.
 # Off by default — opt in for prod rollouts where first-request TTFT
 # matters. In dev / CI / one-shot runs the warmup is pure overhead and can

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -74,7 +74,11 @@ struct RuntimeConfig {
         // `--set runtime.prefill_graph=false` or imp.conf if a model
         // regresses. Legacy env: IMP_PREFILL_GRAPH.
         bool prefill_graph = true;
-        int max_batch_size = 4;
+        // 0 = auto: the engine sizes the decode batch from the model's weight
+        // footprint (a >20 GiB MoE auto-picks 1). A positive value forces it.
+        // (Was 4, which both contradicted the documented "0 = auto" semantics
+        // and never reached engine sizing — it only acted as the decode cap.)
+        int max_batch_size = 0;
     } runtime;
 
     struct KVCache {

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -160,6 +160,8 @@ void Engine::init_resolve_kv_dtype_policy_() {
             config_.max_batch_size = 16;
         IMP_LOG_INFO("max_batch_size: auto → %d (approx_weights=%.1f GB)", config_.max_batch_size,
                      approx_weight_bytes / (1024.0 * 1024.0 * 1024.0));
+    } else {
+        IMP_LOG_INFO("max_batch_size: %d (configured)", config_.max_batch_size);
     }
 }
 

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -296,12 +296,16 @@ ImpConfig build_config(const ServerArgs& args, const imp::RuntimeConfig& runtime
     config.device_id = args.device;
 
     // max_seq_len / max_batch_size: 0 = auto-detect in engine.
-    // JSON override wins; else the --max-batch CLI arg (0 = auto) seeds the
-    // engine sizing. This is the ONLY way to force batched-decode sizing on a
-    // >20 GiB MoE model, whose auto-heuristic picks max_batch_size=1.
+    // Precedence for the batch size: per-request JSON override > --max-batch CLI
+    // flag > [runtime] max_batch_size from imp.conf > 0 (engine auto-sizes from
+    // the model's weight footprint; a >20 GiB MoE auto-picks 1). The imp.conf
+    // value used to be dropped here — only the CLI arg seeded sizing — so
+    // `[runtime] max_batch_size` silently affected nothing but the decode cap.
     if (overrides.contains("max_seq_len"))
         config.max_seq_len = overrides.value("max_seq_len", 0);
-    config.max_batch_size = overrides.value("max_batch_size", args.max_batch_size);
+    int batch_cli_or_conf =
+        args.max_batch_size > 0 ? args.max_batch_size : runtime_cfg.runtime.max_batch_size;
+    config.max_batch_size = overrides.value("max_batch_size", batch_cli_or_conf);
 
     config.gpu_layers = args.gpu_layers;
     if (args.ssm_fp16)


### PR DESCRIPTION
## Bug
`[runtime] max_batch_size` set in `imp.conf` was **silently ignored** for engine sizing. The server built `ImpConfig.max_batch_size` only from the `--max-batch` CLI flag (default `0` = auto), so the imp.conf value never reached the scheduler / KV / workspace sizing — it only acted as the decode-batch cap (`engine_scheduler.cpp` reads `runtime_config_.runtime.max_batch_size` separately).

## Fix
- **handlers.cpp** (ImpConfig builder): source the batch size with precedence **override > `--max-batch` CLI > `[runtime] max_batch_size` (imp.conf) > 0 (auto)**.
- **config.h**: `runtime.max_batch_size` default `4 → 0`, matching the documented "0 = auto" semantics. (The old default `4` also silently capped the decode batch below the engine's auto size — e.g. 8 for an 8B model.)
- **engine_init_resolver.cpp**: log the resolved batch size in the configured case too.
- **imp.conf.example**: document `0 = auto` + precedence.

## Verified (RTX 5090 / Qwen3-8B-NVFP4)
- `imp.conf max_batch_size=2` → `max_batch_size: 2 (configured)`
- no config → `max_batch_size: auto → 8 (approx_weights=6.8 GB)` (auto path intact)

## Audit — does this bug exist elsewhere?
**No.** This args-vs-imp.conf drop was **unique to `max_batch_size`**. Every other imp.conf key reaches the engine either via the ImpConfig builder copy (`server.prefix_cache`, `prefix_pin_budget_pct`, `green_contexts`, …) or a direct `runtime_config_.<...>` read in the engine/executor/compute/dispatch layer (`max_seq_len`, `kv_cache.dtype`, all `attention.*`/`gemm.*`/`moe.*`/`gdn.*`/`speculative.*` flags — spot-checked 12/12 consumed in `src/exec`/`src/compute`). A first broad audit flagged ~70 "dropped" keys, but that was a false positive from only grepping `src/runtime/`; they are consumed deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)