### PR TITLE
fix(server): reject over-long prompts (400) instead of SIGSEGV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ## [Unreleased]
 
 ### Fixed
+- **Over-long prompts are rejected (400) instead of crashing the server (SIGSEGV).**
+  The server gated prompt length on the model's *declared* max context
+  (`imp_model_max_seq_len`), but the engine VRAM-auto-sizes the *actual*
+  allocated context, which can be much smaller (e.g. ~4096 for a 14B on a tight
+  budget). A prompt longer than the allocated context but shorter than the model
+  max passed the length check and overran the per-sequence KV/position buffers →
+  SIGSEGV. Added `imp_context_max_seq_len()` (the engine's effective allocated
+  context) and gate on it; also added the missing length guard to the
+  `/v1/embeddings` path. Over-long input now returns
+  `400 "… exceeds context window (N tokens >= M max)"`.
 - **`[runtime] max_batch_size` from imp.conf is now honored for engine sizing.**
   The server built `ImpConfig.max_batch_size` only from the `--max-batch` CLI
   flag (default 0 = auto), so the imp.conf value was dropped — it reached the

--- a/include/imp/imp.h
+++ b/include/imp/imp.h
@@ -50,6 +50,10 @@ int imp_model_n_layers(ImpModel model);
 int imp_model_d_model(ImpModel model);
 int imp_model_vocab_size(ImpModel model);
 int imp_model_max_seq_len(ImpModel model);
+/* Effective context window the engine actually allocated for this context
+ * (VRAM-aware auto-sizing). May be smaller than imp_model_max_seq_len when VRAM
+ * is tight; gate prompt length on this to reject over-long prompts cleanly. */
+int imp_context_max_seq_len(ImpContext ctx);
 /* BOS token id when the model's tokenizer prepends one (add_bos), else -1.
  * Teacher-forced eval (perplexity) must prepend it for BOS-dependent
  * families (Gemma, Llama) or the NLL measures an out-of-distribution

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -328,6 +328,16 @@ int imp_model_max_seq_len(ImpModel model) {
     return model->model->config().max_seq_len;
 }
 
+// Effective context window the engine actually allocated (VRAM-aware auto-size).
+// May be smaller than imp_model_max_seq_len when VRAM is tight — gate prompt
+// length on THIS, not the model's declared max, to avoid KV/position overruns.
+int imp_context_max_seq_len(ImpContext ctx) {
+    if (!ctx || !ctx->engine) {
+        return 0;
+    }
+    return ctx->engine->max_seq_len();
+}
+
 // --- Context / Runtime ---
 
 ImpError imp_context_create(ImpModel model, const ImpConfig* config, ImpContext* out_ctx) {

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -221,6 +221,12 @@ public:
     KVCacheManager* kv_manager() const noexcept { return kv_manager_.get(); }
     KVCache* kv_cache() const noexcept { return kv_cache_raw_; }
     Model* model() const noexcept { return model_.get(); }
+    // Effective context window actually allocated by the engine (after VRAM-aware
+    // auto-sizing in init_compute_max_seq_len_). May be < the model's declared
+    // max context when VRAM is tight — callers MUST gate prompt length on this,
+    // not on model().config().max_seq_len, or an over-long prompt overruns the
+    // KV/position buffers (SIGSEGV instead of a clean rejection).
+    int max_seq_len() const noexcept { return config_.max_seq_len; }
     const ChatTemplate& chat_template() const noexcept { return chat_template_; }
     const std::vector<int32_t>& banned_token_ids() const { return banned_token_ids_; }
     GraphExecutor* executor() const noexcept { return executor_.get(); }

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -461,8 +461,15 @@ std::string load_model_into_state(ServerState& state, const std::string& path, c
         }
     }
 
-    // Store max sequence length for token clamping
-    state.max_seq_len = imp_model_max_seq_len(state.model);
+    // Store max sequence length for prompt-length gating. Use the EFFECTIVE
+    // context the engine actually allocated, not the model's declared max: the
+    // engine VRAM-auto-sizes it and can land well below the model max (e.g.
+    // ~4096 for a 14B on a tight budget). Gating on the model max let an
+    // over-long prompt pass the length check and overrun the KV/position
+    // buffers — a SIGSEGV instead of a clean 400.
+    state.max_seq_len = imp_context_max_seq_len(state.ctx);
+    if (state.max_seq_len <= 0)
+        state.max_seq_len = imp_model_max_seq_len(state.model);
     if (state.max_seq_len <= 0)
         state.max_seq_len = static_cast<int>(config.max_seq_len);
 
@@ -3556,6 +3563,17 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
                 {"error",
                  {{"message", "Input tokenizes to zero tokens"}, {"type", "invalid_request_error"}}}};
             res.set_content(dump_safe(error), "application/json");
+            return;
+        }
+
+        // Reject over-long inputs before prefill: the embeddings path drives
+        // imp_prefill directly, and a prompt longer than the engine's allocated
+        // context overruns the KV/position buffers (SIGSEGV) instead of failing
+        // cleanly. (state.max_seq_len is the effective allocated context.)
+        if (state.max_seq_len > 0 && n_tokens > state.max_seq_len) {
+            send_json_error(res, 400, "invalid_request_error",
+                            "Input exceeds context window (" + std::to_string(n_tokens) +
+                                " tokens > " + std::to_string(state.max_seq_len) + " max)");
             return;
         }
 


### PR DESCRIPTION
## Bug
The imp-server **crashed with SIGSEGV** on a 6001-token prompt when it had auto-allocated only ~4096 tokens of context for a 14B model — instead of rejecting it.

## Root cause
The server gated prompt length on the model's **declared** max context (`imp_model_max_seq_len`, e.g. 40960 for a 14B), but the engine **VRAM-auto-sizes the actually-allocated context** (`init_compute_max_seq_len_`), which can land far below the model max when VRAM is tight (the 14B got ~4096). A prompt longer than the allocated context but shorter than the model max **passed the length guard** and then overran the per-sequence KV/position buffers (the block-table capacity is `max_seq_len / block_size`) → SIGSEGV instead of a clean 400.

## Fix
- `Engine::max_seq_len()` + **`imp_context_max_seq_len()`** expose the engine's effective allocated context.
- `handlers.cpp`: `state.max_seq_len` now comes from `imp_context_max_seq_len(ctx)` (fallback: model max → config), so the existing `/v1/chat/completions` + `/v1/completions` length guards reject at the **real** threshold.
- `handlers.cpp`: added the missing length guard to **`/v1/embeddings`**, which drove `imp_prefill` directly with no guard (same crash class).

## Verified (RTX 5090, Qwen3-8B, `max_seq_len` forced to 512)
```
over-long chat       → 400 "Prompt exceeds context window (2211 tokens >= 512 max)"
over-long embeddings → 400 "Input exceeds context window (2201 tokens > 512 max)"
short chat           → 200
health after         → model_loaded:true   (server stays up — was SIGSEGV before)
```

Note (separate, not fixed here): the engine's VRAM-auto-size floors at 4096 and a 14B on a tight budget lands there — raise `[runtime] max_seq_len` (now honored) or rely on fp8 KV for more. Engine-level defense-in-depth (rejecting in the scheduler) was left out to avoid regressing the chunked perplexity path; the server guards cover the reported surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)