### PR TITLE
test(server): Stage-3 server test gate + Anthropic /v1/messages thinking field

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -394,20 +394,25 @@ summarised in `tests/README.md`.
   matches the direct one (wiring), with the tier hand-set and scales forced to 1.0; the
   format→tier *selection* logic itself is not asserted.
 
-**Two-stage test gate (added this pass, per request):**
+**Three-stage test gate (added this pass, per request):**
 - *Stage 1 — pre-commit (GPU):* `scripts/pre-commit.hook` runs `make test-gpu` (full GTest suite)
   on staged source changes. GPU correctness can only be gated locally — CI has no GPU runner.
 - *Stage 2 — CI (CPU):* `ci.yml` now runs `ctest -L unit` in the build job — every CPU-runnable
   GTest (test-core incl. tool-call + Bearer-auth, test-text, the e2e CPU subset). Before this the
   CPU GTests were built in CI but never run (only `mock-api` + the usually-absent self-hosted GPU
   job executed tests). `make install-hooks` installs the pre-commit hook alongside pre-push.
-- *Tier 2 (infra-blocked):* real-server tests for `/v1/chat/completions` logprob sum + top-k
-  ordering, `/v1/messages` synthetic-streaming sequence, and CI-wiring of the #712 robustness /
-  #710 0-token batteries **all require a running GPU server in CI — and CI has no GPU runner**
-  (§1). These are achievable only as *local-gated* suites; the logprob assembly also lives inside
-  `handlers.cpp` (not a free function) so a CPU unit test would need a larger extraction than the
-  auth one. Committed-golden tokenizer/chat-template parity is blocked on shipping a real
-  tokenizer (large) or running HF in CI (no transformers/model there) — see F2.
+- *Stage 3 — server (GPU, local, opt-in):* `make test-server` (`scripts/test_server.sh`) boots a
+  real `imp-server` against a live model and **gates** on the OpenAI+Anthropic wire batteries —
+  the only place `handlers.cpp` / `batching_engine.cpp` and the SSE protocols run end-to-end. This
+  closes the former "Tier 2 (infra-blocked)" item: the two missing assertions were written
+  (`tests/test_server_logprobs.py` — logprob non-positivity + **top-k descending order** + greedy
+  token == top-1 tie-in; `tests/test_server_messages_stream.py` — `/v1/messages` event sequence
+  `message_start → (content_block_start → delta+ → stop)+ → message_delta → message_stop`, balanced
+  and `event:`-vs-`data.type` consistent), and the pre-existing #712/#710 batteries are now run as
+  hard gates instead of `coverage_server.sh`'s `|| true`. Still GPU-only (not CI-wired): CI has no
+  GPU runner (§1), so this is a *local* stage, run before relying on a server change.
+- *Still infra-blocked:* committed-golden tokenizer/chat-template parity needs a shipped real
+  tokenizer (large) or HF in CI (no transformers/model there) — see F2.
 
 **Deliberately out of scope (unchanged from §5):** `compute-sanitizer` lane (can't run on this
 WSL2 host — WDDM); trivial-handler contract tests; bench-only files; re-enabling the documented

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ test-unit: build
 test-gpu: build
 	$(DOCKER_RUN) imp-tests
 
+# Stage 3 — the SERVER stage (local, GPU-only). Boots a real imp-server against
+# a live model and GATES on the OpenAI+Anthropic wire batteries (endpoints,
+# robustness #712, logprobs, /v1/messages stream, embed/chat interleave,
+# 0-token #710). CI has no GPU runner, so this is the only place handlers.cpp /
+# batching_engine run end-to-end. See the script header for env knobs.
+test-server: build
+	bash scripts/test_server.sh
+
 # Measured gcov line coverage of tools/imp-server/ over an end-to-end GPU run
 # (builds an instrumented imp-server, drives every endpoint + the manual server
 # batteries, reports coverage). Needs a GPU + a local model. See the script header.

--- a/scripts/test_server.sh
+++ b/scripts/test_server.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Stage 3 of the test gate — the SERVER stage (local, GPU-only).
+#
+# CI has no GPU runner, so the real imp-server (handlers.cpp / batching_engine /
+# the OpenAI+Anthropic wire protocols) can only be exercised here, against a
+# live model on the 5090. Stage 1 (pre-commit `make test-gpu`) covers GPU kernel
+# correctness; Stage 2 (CI `ctest -L unit`) covers the CPU helper units; neither
+# boots a server. This script does, and GATES on the result (every battery's
+# exit code is propagated — unlike scripts/coverage_server.sh, which runs the
+# same batteries with `|| true` purely to measure coverage).
+#
+# Boots imp-server once, then runs, as hard gates:
+#   - exercise_all_endpoints.py        every endpoint/mode returns non-5xx
+#   - test_server_robustness.py        bad input -> 4xx+envelope, valid -> 2xx (#712)
+#   - test_server_0token_battery.py    no empty-completion wedge under mixed load (#710)
+#   - test_server_embed_chat_interleave.sh   embeddings don't cancel in-flight chat
+#   - test_server_logprobs.py          logprob sum + top-k descending order
+#   - test_server_messages_stream.py   Anthropic /v1/messages event sequence
+#
+# Usage:   make test-server   (or: scripts/test_server.sh)
+# Env:     IMP_SRV_MODEL    (default Qwen3-8B-NVFP4-cortecs) — needs chat+tools+embeddings
+#          IMP_MODELS_DIR   (default /home/kekz/models)      — host dir mounted at /models
+#          IMP_SRV_PORT     (default 8080)
+#          IMP_TEST_IMG     (default imp:test)               — built by `make build`
+#          IMP_SRV_BUILD    (set to 1 to force a docker build first)
+set -uo pipefail
+
+MODEL="${IMP_SRV_MODEL:-Qwen3-8B-NVFP4-cortecs}"
+MODELS_DIR="${IMP_MODELS_DIR:-/home/kekz/models}"
+PORT="${IMP_SRV_PORT:-8080}"
+IMG="${IMP_TEST_IMG:-imp:test}"
+CTR=imp_test_server
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+    echo "test-server: no GPU on this host — the server stage is GPU-only, skipping." >&2
+    echo "             Run on the 5090 box before relying on server changes." >&2
+    exit 0
+fi
+
+if [ "${IMP_SRV_BUILD:-0}" = "1" ] || ! docker image inspect "$IMG" >/dev/null 2>&1; then
+    echo "== build $IMG =="
+    docker build --build-arg IMP_BUILD_TESTS=ON -t "$IMG" .
+fi
+
+cleanup() { docker rm -f "$CTR" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "== launch imp-server ($MODEL) =="
+docker rm -f "$CTR" >/dev/null 2>&1 || true
+docker run -d --name "$CTR" --gpus all -v "$MODELS_DIR":/models -p "$PORT":"$PORT" "$IMG" \
+    imp-server --model "/models/$MODEL" --host 0.0.0.0 --port "$PORT" \
+    --max-concurrent 8 --rate-limit 100000 --max-input-tokens 100000 >/dev/null
+
+ok=0
+for i in $(seq 1 90); do
+    if curl -s "localhost:$PORT/health" 2>/dev/null | grep -q '"model_loaded":true'; then ok=1; break; fi
+    if ! docker ps -q --no-trunc | grep -q "$(docker inspect -f '{{.Id}}' "$CTR" 2>/dev/null)"; then
+        echo "test-server: server container exited during startup. Logs:" >&2
+        docker logs "$CTR" 2>&1 | tail -30 >&2
+        exit 1
+    fi
+    sleep 2
+done
+if [ "$ok" != "1" ]; then
+    echo "test-server: server did not become healthy within 180s. Logs:" >&2
+    docker logs "$CTR" 2>&1 | tail -30 >&2
+    exit 1
+fi
+
+export IMP_BASE="http://localhost:$PORT" IMP_MODEL="$MODEL"
+export IMP_HOST=localhost IMP_PORT="$PORT" IMP_TEST_MODEL="$MODEL"
+
+fails=()
+run() {  # run <label> <cmd...>
+    local label="$1"; shift
+    echo; echo "== $label =="
+    if "$@"; then echo "   -> PASS ($label)"; else echo "   -> FAIL ($label)"; fails+=("$label"); fi
+}
+
+run "endpoints smoke"     python3 tests/exercise_all_endpoints.py
+run "robustness (#712)"   python3 tests/test_server_robustness.py
+run "logprobs"            python3 tests/test_server_logprobs.py
+run "messages stream"     python3 tests/test_server_messages_stream.py
+run "embed/chat interleave" bash tests/test_server_embed_chat_interleave.sh 15
+run "0-token battery (#710)" env N=8 LOAD=80 FAIL_THRESHOLD=0.10 python3 tests/test_server_0token_battery.py
+
+echo
+if [ "${#fails[@]}" -ne 0 ]; then
+    echo "test-server: FAIL — ${#fails[@]} batterie(s) regressed: ${fails[*]}"
+    exit 1
+fi
+echo "test-server: PASS — all server batteries green"

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,10 +40,10 @@ docker run --rm --gpus all -v /home/kekz/models:/models imp:test \
   test-quant --gtest_filter='GgufDequant/*:GgufRef.*'
 ```
 
-### Two-stage gate (CI has no GPU runner)
+### Three-stage gate (CI has no GPU runner)
 
-GPU correctness cannot run in CI (no GPU runner), so the suite is gated in two
-stages — install both hooks with `make install-hooks`:
+GPU correctness cannot run in CI (no GPU runner), so the suite is gated in
+stages — install the hooks with `make install-hooks`:
 
 - **Stage 1 — pre-commit (GPU), local.** `scripts/pre-commit.hook` runs
   `make test-gpu` (the full GTest suite, which includes the CPU binaries too)
@@ -54,6 +54,19 @@ stages — install both hooks with `make install-hooks`:
   `ctest -L unit` (`test-core` incl. tool-call + Bearer-auth, `test-text`, the
   CPU subset of `test-e2e`) plus the Python mock-API suite. The `gpu`/`perf`
   lanes are skipped (the self-hosted GPU job runs only if `HAS_GPU_RUNNER`).
+- **Stage 3 — server (GPU), local, opt-in.** `make test-server`
+  (`scripts/test_server.sh`) boots a real `imp-server` against a live model and
+  GATES on the OpenAI+Anthropic wire batteries — the only place `handlers.cpp` /
+  `batching_engine.cpp` and the SSE protocols run end-to-end (CI's `mock-api`
+  suite is a contract stub, not the real handlers). It is opt-in (a model load +
+  boot costs minutes), not hooked; run it before relying on a server change.
+  Batteries, all hard-gated:
+  `exercise_all_endpoints.py` (no 5xx), `test_server_robustness.py` (#712 bad
+  input → 4xx+envelope), `test_server_logprobs.py` (logprob sum + top-k
+  descending order), `test_server_messages_stream.py` (Anthropic `/v1/messages`
+  event sequence), `test_server_embed_chat_interleave.sh` + `test_server_0token_battery.py`
+  (#710 no empty-completion wedge). `make coverage` runs the same set
+  ungated to measure `tools/imp-server/` line coverage.
 
 When adding a kernel correctness test, prefer expressing the oracle on the CPU
 side where feasible so a regression is reproducible in CI without the 5090.

--- a/tests/test_server_logprobs.py
+++ b/tests/test_server_logprobs.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""MANUAL gate — part of the local server-test stage (`make test-server`, Stage 3).
+Needs a running imp-server with a chat model (default Qwen3-8B-NVFP4-cortecs).
+
+Asserts the OpenAI `logprobs` payload that handlers.cpp builds (handlers.cpp
+~1621: `logprobs.content[].{token,logprob,bytes,top_logprobs[]}`). The coverage
+driver only checks the endpoint does not 5xx; this asserts the actual numbers:
+
+  * every per-position `logprob` is a real, non-positive float (it is log P);
+  * `top_logprobs` is sorted DESCENDING by logprob (the #1 requirement the audit
+    named — top-k ordering stability);
+  * `len(top_logprobs)` honours the requested cap and is non-empty;
+  * sum of exp(top_logprobs.logprob) is a sub-distribution (<= 1 + eps);
+  * at temperature 0 (greedy) the emitted token IS the top-1 alternative — the
+    chosen token equals top_logprobs[0].token and shares its logprob. This ties
+    the sampler's choice to the reported distribution (a real correctness check,
+    not just a shape check).
+
+Run (stdlib only, no deps):
+    python3 tests/test_server_logprobs.py
+Env:
+    IMP_BASE   (default http://localhost:8080)
+    IMP_MODEL  (default: auto-detected from /v1/models)
+    TOPK       (default 5)   top_logprobs requested
+
+Exit code: 0 = all assertions hold (PASS), 1 = a regression (FAIL).
+"""
+import json, math, os, sys, urllib.request
+
+BASE = os.environ.get("IMP_BASE", "http://localhost:8080").rstrip("/")
+TOPK = int(os.environ.get("TOPK", "5"))
+_fail = []
+
+
+def _post(path, body, timeout=120):
+    req = urllib.request.Request(BASE + path, json.dumps(body).encode(),
+                                 {"Content-Type": "application/json"})
+    return json.load(urllib.request.urlopen(req, timeout=timeout))
+
+
+def model_id():
+    if os.environ.get("IMP_MODEL"):
+        return os.environ["IMP_MODEL"]
+    data = json.load(urllib.request.urlopen(BASE + "/v1/models", timeout=10))
+    return data["data"][0]["id"]
+
+
+M = model_id()
+
+
+def fail(msg):
+    _fail.append(msg)
+    print(f"  FAIL {msg}")
+
+
+def check(cond, msg):
+    if not cond:
+        fail(msg)
+    return cond
+
+
+def main():
+    print(f"logprobs gate: base={BASE} model={M} top_logprobs={TOPK}")
+    r = _post("/v1/chat/completions", {
+        "model": M,
+        "messages": [{"role": "user", "content": "Count: one two three four"}],
+        "max_tokens": 24, "temperature": 0.0,
+        "logprobs": True, "top_logprobs": TOPK,
+    })
+
+    lp = r["choices"][0].get("logprobs")
+    if not check(isinstance(lp, dict) and isinstance(lp.get("content"), list) and lp["content"],
+                 "response has no logprobs.content array"):
+        return _verdict()
+
+    EPS = 1e-3
+    for i, pos in enumerate(lp["content"]):
+        tag = f"content[{i}]"
+        # per-position chosen token
+        check(isinstance(pos.get("token"), str), f"{tag}.token not a string")
+        check(isinstance(pos.get("logprob"), (int, float)), f"{tag}.logprob not numeric")
+        check(isinstance(pos.get("bytes"), list), f"{tag}.bytes not a list")
+        check(pos.get("logprob", 1.0) <= EPS, f"{tag}.logprob {pos.get('logprob')} > 0 (not a log-prob)")
+
+        top = pos.get("top_logprobs")
+        if not check(isinstance(top, list) and top, f"{tag}.top_logprobs empty/missing"):
+            continue
+        check(len(top) <= TOPK, f"{tag} returned {len(top)} > requested {TOPK} top_logprobs")
+
+        lps = [t.get("logprob") for t in top]
+        check(all(isinstance(x, (int, float)) for x in lps), f"{tag} top_logprobs has non-numeric logprob")
+        # THE ordering assertion: descending by logprob.
+        check(all(lps[k] >= lps[k + 1] - EPS for k in range(len(lps) - 1)),
+              f"{tag} top_logprobs NOT descending: {lps}")
+        check(all(x <= EPS for x in lps), f"{tag} top_logprobs has positive logprob: {lps}")
+        # sub-distribution: the top-k probabilities cannot exceed 1.
+        psum = sum(math.exp(x) for x in lps)
+        check(psum <= 1.0 + EPS, f"{tag} sum exp(top_logprobs) = {psum:.4f} > 1")
+
+        # greedy tie-in: at temp 0 the chosen token is the top-1 alternative.
+        if i == 0:
+            check(pos["token"] == top[0].get("token"),
+                  f"{tag} greedy chosen token {pos['token']!r} != top1 {top[0].get('token')!r}")
+            check(abs(pos["logprob"] - top[0].get("logprob", -99)) <= EPS,
+                  f"{tag} chosen logprob {pos['logprob']} != top1 {top[0].get('logprob')}")
+
+    return _verdict()
+
+
+def _verdict():
+    if _fail:
+        print(f"FAIL: {len(_fail)} logprob assertion(s) regressed")
+        return 1
+    print("PASS: logprobs well-formed, top-k descending, greedy token == top1")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tests/test_server_messages_stream.py
+++ b/tests/test_server_messages_stream.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""MANUAL gate — part of the local server-test stage (`make test-server`, Stage 3).
+Needs a running imp-server with a chat model (default Qwen3-8B-NVFP4-cortecs).
+
+Asserts the Anthropic `/v1/messages` streaming EVENT SEQUENCE that handlers.cpp
+emits (AnthropicSSE, handlers.cpp ~3682: `event: <name>\\ndata: <json>\\n\\n`).
+The coverage driver only checks the stream does not 5xx; this asserts the
+protocol-level ordering the audit named:
+
+  message_start
+    (content_block_start  content_block_delta+  content_block_stop)+
+  message_delta            <- carries stop_reason
+  message_stop             <- terminal
+
+Invariants checked:
+  * first event is message_start; last is message_stop;
+  * every `event:` line type matches its `data.type`;
+  * content blocks are balanced — every delta sits inside an open block, every
+    open block is closed, no block opens while another is open;
+  * >=1 content_block_delta of type text_delta carrying non-empty text;
+  * message_delta appears once, after all content blocks, with a stop_reason;
+  * nothing follows message_stop.
+
+Run (stdlib only, no deps):
+    python3 tests/test_server_messages_stream.py
+Env:
+    IMP_BASE   (default http://localhost:8080)
+    IMP_MODEL  (default: auto-detected from /v1/models)
+
+Exit code: 0 = sequence valid (PASS), 1 = a regression (FAIL).
+"""
+import json, os, sys, urllib.request
+
+BASE = os.environ.get("IMP_BASE", "http://localhost:8080").rstrip("/")
+_fail = []
+
+
+def model_id():
+    if os.environ.get("IMP_MODEL"):
+        return os.environ["IMP_MODEL"]
+    data = json.load(urllib.request.urlopen(BASE + "/v1/models", timeout=10))
+    return data["data"][0]["id"]
+
+
+M = model_id()
+
+
+def fail(msg):
+    _fail.append(msg)
+    print(f"  FAIL {msg}")
+
+
+def check(cond, msg):
+    if not cond:
+        fail(msg)
+    return cond
+
+
+def stream_events():
+    """Yield (event_name, data_obj) from the SSE stream in arrival order.
+
+    Stops as soon as `message_stop` arrives — imp-server keeps the chunked
+    connection alive after the terminal event, so reading past it blocks until
+    the socket timeout. A timeout is treated as end-of-stream (the gate then
+    fails on the missing message_stop rather than crashing on a traceback).
+    """
+    # A think-model (Qwen3 default-on) emits a `thinking` block first; the
+    # Anthropic route does not expose a thinking toggle (anthropic_to_openai_body
+    # maps neither `thinking` nor `enable_thinking`), so we don't fight it — we
+    # assert the protocol shape AROUND any thinking block and give a budget large
+    # enough that the whole think+answer completes with a clean message_stop.
+    # `enable_thinking:false` is a harmless no-op here, kept for when the route
+    # learns to honour it. The prompt is trivial so reasoning stays short.
+    body = {"model": M, "max_tokens": 512, "stream": True, "enable_thinking": False,
+            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]}
+    req = urllib.request.Request(BASE + "/v1/messages", json.dumps(body).encode(),
+                                 {"Content-Type": "application/json"})
+    ev = None
+    try:
+        with urllib.request.urlopen(req, timeout=150) as resp:
+            for raw in resp:
+                line = raw.decode("utf-8", "replace").rstrip("\n").rstrip("\r")
+                if line.startswith("event:"):
+                    ev = line[len("event:"):].strip()
+                elif line.startswith("data:"):
+                    payload = line[len("data:"):].strip()
+                    try:
+                        obj = json.loads(payload) if payload else {}
+                    except json.JSONDecodeError:
+                        obj = {"__unparseable__": payload}
+                    yield ev, obj
+                    name, ev = ev, None
+                    if name == "message_stop" or obj.get("type") == "message_stop":
+                        return
+    except TimeoutError:
+        print("  (stream read timed out — treating as end-of-stream)")
+
+
+def main():
+    print(f"messages-stream gate: base={BASE} model={M}")
+    events = list(stream_events())
+    if not check(events, "no SSE events received"):
+        return _verdict()
+
+    names = [e for e, _ in events]
+    print(f"  events: {names}")
+
+    # event: line type must match data.type
+    for e, obj in events:
+        t = obj.get("type")
+        check(e == t, f"event line {e!r} != data.type {t!r}")
+
+    check(names[0] == "message_start", f"first event is {names[0]!r}, want message_start")
+    check(names[-1] == "message_stop", f"last event is {names[-1]!r}, want message_stop")
+    check(names.count("message_start") == 1, "message_start not unique")
+    check(names.count("message_delta") == 1, "message_delta not exactly once")
+    check(names.count("message_stop") == 1, "message_stop not exactly once")
+
+    # message_start payload sanity
+    msg0 = events[0][1].get("message", {})
+    check(msg0.get("role") == "assistant", "message_start.message.role != assistant")
+
+    # Walk content blocks: balance + delta containment. A thinking block (if the
+    # model reasons) and a text block are both valid; we require >=1 text block
+    # carrying the answer, and tolerate a preceding thinking block.
+    open_block = False
+    saw_text_delta = False
+    saw_text_block = False
+    seen_message_delta = False
+    stop_reason = None
+    for i, (e, obj) in enumerate(events):
+        if e == "content_block_start":
+            check(not open_block, f"content_block_start at {i} while a block is open")
+            open_block = True
+            if obj.get("content_block", {}).get("type") == "text":
+                saw_text_block = True
+        elif e == "content_block_delta":
+            check(open_block, f"content_block_delta at {i} with no open block")
+            d = obj.get("delta", {})
+            check(d.get("type") in ("text_delta", "thinking_delta", "input_json_delta"),
+                  f"content_block_delta at {i} has unknown delta type {d.get('type')!r}")
+            if d.get("type") == "text_delta" and d.get("text"):
+                saw_text_delta = True
+        elif e == "content_block_stop":
+            check(open_block, f"content_block_stop at {i} with no open block")
+            open_block = False
+        elif e == "message_delta":
+            seen_message_delta = True
+            check(not open_block, "message_delta arrived with a content block still open")
+            stop_reason = obj.get("delta", {}).get("stop_reason")
+        elif e == "message_stop":
+            check(seen_message_delta, "message_stop before message_delta")
+
+    check(not open_block, "a content block was never closed")
+    check(saw_text_block, "no text content block in the stream")
+    check(saw_text_delta, "no text_delta with non-empty text")
+    check(stop_reason not in (None, ""), f"message_delta carried no stop_reason ({stop_reason!r})")
+
+    return _verdict()
+
+
+def _verdict():
+    if _fail:
+        print(f"FAIL: {len(_fail)} streaming-sequence assertion(s) regressed")
+        return 1
+    print("PASS: Anthropic /v1/messages event sequence valid + balanced")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## What

Two related changes surfaced while wiring the audit's Tier-2 real-server tests:

1. **Stage-3 server test gate** — `make test-server` boots a real `imp-server` against a live model and **gates** on the OpenAI+Anthropic wire batteries. Closes `AUDIT.md` Tier-2 "real-server tests (infra-blocked)": CI has no GPU runner, so `handlers.cpp` / `batching_engine.cpp` and the SSE protocols could previously only be touched by `coverage_server.sh`'s `|| true` driver — never asserted.
2. **Anthropic `/v1/messages` `thinking` field mapping** — building the streaming test exposed that `anthropic_to_openai_body` dropped the `thinking` object entirely, so a think-model always reasoned on `/v1/messages` regardless of the request.

## Three-stage gate

| Stage | Where | Scope |
|---|---|---|
| 1 — pre-commit (GPU) | local | `make test-gpu` kernel/oracle correctness |
| 2 — CI (CPU) | GitHub Actions | `ctest -L unit` |
| **3 — server (GPU)** | **local, opt-in** | **`make test-server` — real server, end-to-end** |

### Batteries (all hard-gated)
- `exercise_all_endpoints.py` — no 5xx on any endpoint/mode
- `test_server_robustness.py` — #712 bad input → 4xx + envelope
- **`test_server_logprobs.py`** *(new)* — logprob non-positivity, **top-k descending order**, sub-distribution `Σexp(top)≤1`, greedy tie-in (temp 0 ⇒ chosen == `top_logprobs[0]`)
- **`test_server_messages_stream.py`** *(new)* — Anthropic `/v1/messages` SSE event sequence `message_start → (content_block_start → delta+ → stop)+ → message_delta → message_stop`, balanced, `event:` == `data.type`
- `test_server_embed_chat_interleave.sh` + `test_server_0token_battery.py` — #710 no empty-completion wedge

`make coverage` still runs the same set ungated for line coverage. Local/opt-in (a model boot costs minutes), GPU-guarded.

## Anthropic `thinking` mapping

`anthropic_to_openai_body` now maps the field to imp's existing controls (same ones the OpenAI path uses):

```
{"type":"disabled"}                    -> enable_thinking=false + think_budget=0
{"type":"enabled","budget_tokens":N}   -> enable_thinking=true  + think_budget=N/max_tokens
```

`think_budget` is a **fraction** of max_tokens in imp (default 0.5), not absolute, so `budget_tokens` maps to `budget_tokens/max_tokens` clamped to 1.0. Disabling needs **both** signals — `suppress_thinking` only engages when `enable_thinking` is false **and** `think_budget<=0` (the default 0.5 budget would otherwise keep thinking on). CPU unit tests `AnthropicThinking.*` (CI-runnable) cover disabled/enabled/budget/clamp/malformed.

### Known limitation (pre-existing, not introduced here)
imp's actual suppression uses a soft `/no_think` system directive that a think-model honours only for **some prompts** — so disabling is best-effort. This reproduces identically on the OpenAI path (`enable_thinking:false`+`think_budget:0`), i.e. it is not specific to this mapping. A robust hard `<think></think>` injection is a separate, cross-endpoint change (touches `chat_template` + `handlers`, needs degeneration validation) — deliberately out of scope here.

## Verification

- 13 `test_anthropic_transform` unit tests green (incl. 6 new `AnthropicThinking.*`).
- Full `make test-server` green end-to-end on the RTX 5090 (`Qwen3-8B-NVFP4-cortecs`): all 6 batteries, exit 0 — both before and after the mapping change.
- Live A/B: `thinking:{type:"enabled","budget_tokens":256}` → 589 reasoning chars; `thinking:{type:"disabled"}` → suppressed where the model honours `/no_think`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)