### PR TITLE
fix: make /no_think thinking-suppression actually work (tokenizer + server)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,29 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ### Added
 - **Anthropic `/v1/messages` honours the `thinking` field.** `{"type":"enabled","budget_tokens":N}`
-  enables extended thinking with a budget and `{"type":"disabled"}` requests it
-  off; previously the field was dropped in the Anthropic→OpenAI conversion, so the
-  request could not influence thinking at all. The field now routes to the same
+  enables extended thinking with a budget and `{"type":"disabled"}` turns it off;
+  previously the field was dropped in the Anthropic→OpenAI conversion, so the
+  request could not influence thinking at all. The field routes to the same
   internal controls as the OpenAI path (`enable_thinking` + `think_budget`);
   `budget_tokens` maps to imp's fractional `think_budget` (`budget_tokens /
-  max_tokens`, clamped to 1.0). Note: actually suppressing a think-model still
-  relies on imp's existing `/no_think` mechanism, which is model/prompt-dependent
-  — a separate pre-existing limitation (reproducible on the OpenAI path too).
+  max_tokens`, clamped to 1.0).
 
 ### Fixed
+- **Disabling thinking now actually suppresses reasoning.** When thinking was
+  turned off, a think-model still reasoned for many prompts (on both `/v1/messages`
+  and the OpenAI path with `enable_thinking:false`+`think_budget:0`). Two root
+  causes, both fixed:
+  - **Tokenizer:** Qwen3 ships `<think>`/`</think>` (and `<tool_call>`, `<|fim_*|>`)
+    as added tokens with `special=false, normalized=false`. imp only atomic-matched
+    `special` tokens, so these were BPE-split into `"<","think",">"` — the model's
+    `<think>` never hit the single-token stop guard, and the template's closed
+    `<think></think>` no-think block was just text the model re-opened. imp now
+    follows HF semantics and atomic-matches any `normalized=false` added token
+    (also fixes tool-call/FIM marker tokenization).
+  - **Server:** the heuristic that re-enables thinking when the prompt tail
+    contains `<think>` (for Nemotron/Phi-4 templates injecting an *open* prefix)
+    fired on the *closed* no-think block too. It now requires an **unclosed**
+    prefix (`<think>` present, no matching `</think>`).
 - **Embeddings reject inputs longer than the single-pass hidden buffer (was a server abort).**
   Follow-up to the over-long-prompt fix below: `/v1/embeddings` mean-pools every
   token's hidden state, which only fits when the whole input is prefilled in one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+- **Anthropic `/v1/messages` honours the `thinking` field.** `{"type":"enabled","budget_tokens":N}`
+  enables extended thinking with a budget and `{"type":"disabled"}` requests it
+  off; previously the field was dropped in the Anthropic→OpenAI conversion, so the
+  request could not influence thinking at all. The field now routes to the same
+  internal controls as the OpenAI path (`enable_thinking` + `think_budget`);
+  `budget_tokens` maps to imp's fractional `think_budget` (`budget_tokens /
+  max_tokens`, clamped to 1.0). Note: actually suppressing a think-model still
+  relies on imp's existing `/no_think` mechanism, which is model/prompt-dependent
+  — a separate pre-existing limitation (reproducible on the OpenAI path too).
+
 ### Fixed
 - **Embeddings reject inputs longer than the single-pass hidden buffer (was a server abort).**
   Follow-up to the over-long-prompt fix below: `/v1/embeddings` mean-pools every

--- a/scripts/test_server.sh
+++ b/scripts/test_server.sh
@@ -83,6 +83,7 @@ run "endpoints smoke"     python3 tests/exercise_all_endpoints.py
 run "robustness (#712)"   python3 tests/test_server_robustness.py
 run "logprobs"            python3 tests/test_server_logprobs.py
 run "messages stream"     python3 tests/test_server_messages_stream.py
+run "thinking toggle"     python3 tests/test_server_thinking_toggle.py
 run "embed/chat interleave" bash tests/test_server_embed_chat_interleave.sh 15
 run "0-token battery (#710)" env N=8 LOAD=80 FAIL_THRESHOLD=0.10 python3 tests/test_server_0token_battery.py
 

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -1217,6 +1217,20 @@ bool Tokenizer::load(const std::string& path) {
             int id = static_cast<int>(id_v->num_val);
             const std::string& content = content_v->str_val;
             bool is_special = special_v && special_v->type == JType::NUMBER && special_v->num_val != 0.0;
+            // HF semantics: an added token with `normalized=false` is matched
+            // ATOMICALLY against the raw input, regardless of `special` (which
+            // only governs decode-skipping / add_special_tokens). imp previously
+            // keyed atomic matching on `special` alone, so Qwen3's non-special
+            // markers — `<think>`/`</think>` (151667/151668), `<tool_call>`,
+            // `<|fim_*|>` — were BPE-split into "<","think",">" pieces. That broke
+            // the `<think>`-as-stop-token guard and no-think suppression (the
+            // closed `<think></think>` prompt block was just text the model
+            // re-opened) and mis-tokenised tool-call markers. Promote them to
+            // USER_DEFINED so build_special_pieces() pre-splits them atomically;
+            // unlike CONTROL(3) they stay visible in decode (special=false).
+            const JValue* normalized_v = jobj_find(tok, "normalized");
+            bool is_normalized_false = normalized_v && normalized_v->type == JType::NUMBER &&
+                                       normalized_v->num_val == 0.0;
 
             // Ensure vectors are large enough
             if (id >= static_cast<int>(vocab_.size())) {
@@ -1231,7 +1245,9 @@ bool Tokenizer::load(const std::string& path) {
             token_to_id_[content] = id;
             added_token_ids_[id] = true;
             if (is_special)
-                token_types_[id] = 3;  // CONTROL
+                token_types_[id] = 3;  // CONTROL (atomic-match + decode-skippable)
+            else if (is_normalized_false)
+                token_types_[id] = 4;  // USER_DEFINED (atomic-match, decode-visible)
 
             // Detect BOS/EOS tokens
             if (content == "<s>" || content == "<|begin_of_text|>" || content == "<|startoftext|>") {

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,9 +64,10 @@ stages — install the hooks with `make install-hooks`:
   `exercise_all_endpoints.py` (no 5xx), `test_server_robustness.py` (#712 bad
   input → 4xx+envelope), `test_server_logprobs.py` (logprob sum + top-k
   descending order), `test_server_messages_stream.py` (Anthropic `/v1/messages`
-  event sequence), `test_server_embed_chat_interleave.sh` + `test_server_0token_battery.py`
-  (#710 no empty-completion wedge). `make coverage` runs the same set
-  ungated to measure `tools/imp-server/` line coverage.
+  event sequence), `test_server_thinking_toggle.py` (thinking actually
+  disables/enables on both dialects), `test_server_embed_chat_interleave.sh` +
+  `test_server_0token_battery.py` (#710 no empty-completion wedge). `make
+  coverage` runs the same set ungated to measure `tools/imp-server/` line coverage.
 
 When adding a kernel correctness test, prefer expressing the oracle on the CPU
 side where feasible so a regression is reproducible in CI without the 5090.

--- a/tests/test_anthropic_transform.cpp
+++ b/tests/test_anthropic_transform.cpp
@@ -116,4 +116,65 @@ TEST(AnthropicCacheUsage, NoDetailsMeansZeroCacheFields) {
     EXPECT_EQ(u.value("cache_creation_input_tokens", -1), 0);
 }
 
+// --- extended-thinking control ---------------------------------------------
+// Anthropic carries thinking in a `thinking` object
+// ({type:"enabled",budget_tokens:N} | {type:"disabled"}); imp's orchestrator
+// reads `enable_thinking` (bool) + `think_budget` on the OpenAI body. Note imp's
+// `think_budget` is a FRACTION of max_tokens (default 0.5), whereas Anthropic's
+// `budget_tokens` is absolute — so we map it to budget_tokens/max_tokens,
+// clamped to [0,1]. Without this mapping /v1/messages on a think-model could
+// never be told NOT to reason (the request's intent was silently dropped).
+
+TEST(AnthropicThinking, NoFieldLeavesThinkingUnset) {
+    json oai = anthropic_to_openai_body(base_request());
+    EXPECT_FALSE(oai.contains("enable_thinking"));
+    EXPECT_FALSE(oai.contains("think_budget"));
+}
+
+TEST(AnthropicThinking, DisabledMapsToEnableThinkingFalseAndZeroBudget) {
+    json req = base_request();
+    req["thinking"] = json{{"type", "disabled"}};
+    json oai = anthropic_to_openai_body(req);
+    ASSERT_TRUE(oai.contains("enable_thinking"));
+    EXPECT_TRUE(oai["enable_thinking"].is_boolean());
+    EXPECT_FALSE(oai.value("enable_thinking", true));
+    // Both signals are required for suppress_thinking — see anthropic.cpp.
+    EXPECT_FLOAT_EQ(oai.value("think_budget", -1.0f), 0.0f);
+}
+
+TEST(AnthropicThinking, EnabledMapsToTrueAndFractionalBudget) {
+    json req = base_request();
+    req["max_tokens"] = 1024;
+    req["thinking"] = json{{"type", "enabled"}, {"budget_tokens", 256}};
+    json oai = anthropic_to_openai_body(req);
+    EXPECT_TRUE(oai.value("enable_thinking", false));
+    EXPECT_FLOAT_EQ(oai.value("think_budget", -1.0f), 0.25f);  // 256 / 1024
+}
+
+TEST(AnthropicThinking, EnabledBudgetClampedToOne) {
+    json req = base_request();  // max_tokens = 64
+    req["thinking"] = json{{"type", "enabled"}, {"budget_tokens", 4096}};
+    json oai = anthropic_to_openai_body(req);
+    EXPECT_TRUE(oai.value("enable_thinking", false));
+    EXPECT_FLOAT_EQ(oai.value("think_budget", -1.0f), 1.0f);  // 4096/64 clamped
+}
+
+TEST(AnthropicThinking, EnabledWithoutBudgetSetsNoBudget) {
+    json req = base_request();
+    req["thinking"] = json{{"type", "enabled"}};
+    json oai = anthropic_to_openai_body(req);
+    EXPECT_TRUE(oai.value("enable_thinking", false));
+    EXPECT_FALSE(oai.contains("think_budget"));
+}
+
+TEST(AnthropicThinking, UnknownTypeOrMalformedIsIgnored) {
+    json req = base_request();
+    req["thinking"] = json{{"type", "weird"}};
+    EXPECT_FALSE(anthropic_to_openai_body(req).contains("enable_thinking"));
+
+    json req2 = base_request();
+    req2["thinking"] = "not-an-object";
+    EXPECT_FALSE(anthropic_to_openai_body(req2).contains("enable_thinking"));
+}
+
 }  // namespace

--- a/tests/test_server_messages_stream.py
+++ b/tests/test_server_messages_stream.py
@@ -64,14 +64,13 @@ def stream_events():
     the socket timeout. A timeout is treated as end-of-stream (the gate then
     fails on the missing message_stop rather than crashing on a traceback).
     """
-    # A think-model (Qwen3 default-on) emits a `thinking` block first; the
-    # Anthropic route does not expose a thinking toggle (anthropic_to_openai_body
-    # maps neither `thinking` nor `enable_thinking`), so we don't fight it — we
-    # assert the protocol shape AROUND any thinking block and give a budget large
-    # enough that the whole think+answer completes with a clean message_stop.
-    # `enable_thinking:false` is a harmless no-op here, kept for when the route
-    # learns to honour it. The prompt is trivial so reasoning stays short.
-    body = {"model": M, "max_tokens": 512, "stream": True, "enable_thinking": False,
+    # `thinking:disabled` is best-effort: imp's underlying /no_think suppression
+    # is model/prompt-dependent (a think-model may still reason), so we don't rely
+    # on it — the budget is large enough for a full think+answer to finish with a
+    # clean message_stop, and the assertions below tolerate a thinking block. The
+    # prompt is trivial so any reasoning stays short.
+    body = {"model": M, "max_tokens": 512, "stream": True,
+            "thinking": {"type": "disabled"},
             "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]}
     req = urllib.request.Request(BASE + "/v1/messages", json.dumps(body).encode(),
                                  {"Content-Type": "application/json"})

--- a/tests/test_server_thinking_toggle.py
+++ b/tests/test_server_thinking_toggle.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""MANUAL gate — part of the local server-test stage (`make test-server`).
+Needs a running imp-server with a THINK-capable model (default Qwen3-8B-NVFP4-cortecs).
+
+Asserts that thinking can actually be turned OFF (and on), end-to-end, on both
+dialects. The bug this guards: Qwen3's template renders a closed `<think></think>`
+block when thinking is disabled, but handlers.cpp re-enabled thinking on seeing
+"<think>" in the prompt tail — so the model reasoned anyway. The fix only
+re-enables on an *unclosed* prefix.
+
+Cases (think-model required; auto-skips with exit 0 if the model never reasons):
+  * Anthropic /v1/messages  thinking:{type:disabled}  -> NO thinking block
+  * Anthropic /v1/messages  thinking:{type:enabled}   -> a thinking block
+  * OpenAI  /v1/chat/completions enable_thinking:false+think_budget:0 -> no reasoning_content
+  * OpenAI  /v1/chat/completions (default)            -> reasoning_content present
+Several prompts are tried because the OLD soft-/no_think suppression was
+prompt-dependent — a single prompt could pass by luck.
+
+Run:  python3 tests/test_server_thinking_toggle.py
+Env:  IMP_BASE (default http://localhost:8080), IMP_MODEL (auto from /v1/models)
+Exit: 0 = pass (or model is non-thinking), 1 = a case regressed.
+"""
+import json, os, sys, urllib.request
+
+BASE = os.environ.get("IMP_BASE", "http://localhost:8080").rstrip("/")
+PROMPTS = [
+    "What is 2+2? Reply with just the number.",
+    "Reply with exactly: hello world",
+    "Name the capital of France in one word.",
+]
+_fail = []
+
+
+def _post(path, body, timeout=180):
+    req = urllib.request.Request(BASE + path, json.dumps(body).encode(),
+                                 {"Content-Type": "application/json"})
+    return json.load(urllib.request.urlopen(req, timeout=timeout))
+
+
+def model_id():
+    if os.environ.get("IMP_MODEL"):
+        return os.environ["IMP_MODEL"]
+    return json.load(urllib.request.urlopen(BASE + "/v1/models", timeout=10))["data"][0]["id"]
+
+
+M = model_id()
+
+
+def fail(msg):
+    _fail.append(msg)
+    print(f"  FAIL {msg}")
+
+
+def anth_thinking_chars(prompt, thinking):
+    r = _post("/v1/messages", {"model": M, "max_tokens": 512, "temperature": 0,
+                               "thinking": thinking,
+                               "messages": [{"role": "user", "content": prompt}]})
+    blk = next((b.get("thinking", "") for b in r.get("content", []) if b.get("type") == "thinking"), None)
+    return len(blk.strip()) if blk is not None else 0
+
+
+def oai_reasoning_chars(prompt, **extra):
+    body = {"model": M, "max_tokens": 512, "temperature": 0,
+            "messages": [{"role": "user", "content": prompt}]}
+    body.update(extra)
+    m = _post("/v1/chat/completions", body)["choices"][0]["message"]
+    rc = m.get("reasoning_content")
+    return len(rc.strip()) if rc else 0
+
+
+def main():
+    print(f"thinking-toggle gate: base={BASE} model={M}")
+
+    # Is this even a think-model? If default never reasons, skip (exit 0).
+    default_reasons = max(oai_reasoning_chars(p) for p in PROMPTS)
+    if default_reasons == 0:
+        print("  SKIP: model does not reason by default (not a think-model)")
+        return 0
+    print(f"  baseline: default reasoning up to {default_reasons} chars")
+
+    for p in PROMPTS:
+        # Anthropic: disabled must suppress, enabled must reason.
+        dis = anth_thinking_chars(p, {"type": "disabled"})
+        if dis > 0:
+            fail(f"/v1/messages disabled still reasoned {dis} chars — prompt={p!r}")
+        en = anth_thinking_chars(p, {"type": "enabled", "budget_tokens": 256})
+        if en == 0:
+            fail(f"/v1/messages enabled produced no thinking — prompt={p!r}")
+
+        # OpenAI: both signals off must suppress.
+        oai_dis = oai_reasoning_chars(p, enable_thinking=False, think_budget=0)
+        if oai_dis > 0:
+            fail(f"/v1/chat/completions disabled still reasoned {oai_dis} chars — prompt={p!r}")
+        print(f"  ok prompt={p!r}: anth dis={dis} en={en}, oai dis={oai_dis}")
+
+    if _fail:
+        print(f"FAIL: {len(_fail)} thinking-toggle case(s) regressed")
+        return 1
+    print("PASS: thinking disables (no reasoning) and enables (reasoning) on both dialects")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tests/test_tokenizer.cpp
+++ b/tests/test_tokenizer.cpp
@@ -1,6 +1,11 @@
 #include "model/tokenizer.h"
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
 namespace imp {
 namespace {
 
@@ -744,6 +749,68 @@ TEST(Cl100kPreTokenizeTest, DigitTriplesCaseBlindStandaloneContractions) {
     EXPECT_EQ(cl100k_pre_tokenize("don't stop"), (Chunks{"don", "'t", " stop"}));
     EXPECT_EQ(cl100k_pre_tokenize("a->b https://x.com/y"),
               (Chunks{"a", "->", "b", " https", "://", "x", ".com", "/y"}));
+}
+
+// ---- Added-token atomic matching: `normalized=false` regardless of `special` ----
+//
+// HF matches an added token atomically against the raw input iff normalized=false
+// (special only governs decode-skipping). Qwen3 ships <think>/</think> and
+// <tool_call> as special=false, normalized=false — they MUST tokenize to their
+// single atomic id, not BPE-split into "<","think",">". A regression here breaks
+// the <think>-as-stop-token guard and no-think suppression.
+
+static std::string write_temp_tokenizer_json(const std::string& body) {
+    std::string path = std::string("/tmp/imp_tok_test_") + std::to_string(::getpid()) +
+                       "_" + std::to_string(reinterpret_cast<uintptr_t>(&body)) + ".json";
+    std::ofstream(path) << body;
+    return path;
+}
+
+// id 200 = <think> (special=false, normalized=false) -> atomic
+// id 201 = <plain> (special=false, normalized=true)  -> NOT atomic (BPE-split)
+// id 202 = <|ctrl|> (special=true)                   -> atomic (control)
+static const char* kAddedTokenJson = R"JSON({
+  "model": { "type": "BPE", "vocab": { "a": 0, "b": 1, "c": 2 }, "merges": [] },
+  "added_tokens": [
+    { "id": 200, "content": "<think>",  "special": false, "normalized": false },
+    { "id": 201, "content": "<plain>",  "special": false, "normalized": true  },
+    { "id": 202, "content": "<|ctrl|>", "special": true,  "normalized": false }
+  ]
+})JSON";
+
+static bool contains_id(const std::vector<int32_t>& v, int32_t id) {
+    for (int32_t x : v)
+        if (x == id)
+            return true;
+    return false;
+}
+
+TEST(TokenizerAddedTokens, NormalizedFalseNonSpecialIsAtomic) {
+    std::string path = write_temp_tokenizer_json(kAddedTokenJson);
+    Tokenizer tok;
+    ASSERT_TRUE(tok.load(path));
+    std::remove(path.c_str());
+
+    // <think>: special=false but normalized=false -> single atomic id 200.
+    auto think = tok.encode("<think>");
+    EXPECT_TRUE(contains_id(think, 200)) << "<think> not matched atomically (BPE-split)";
+
+    // It must NOT decode-skip (special=false stays visible).
+    EXPECT_NE(tok.decode({200}).find("<think>"), std::string::npos);
+
+    // Control token (special=true) is atomic as before.
+    EXPECT_TRUE(contains_id(tok.encode("<|ctrl|>"), 202));
+}
+
+TEST(TokenizerAddedTokens, NormalizedTrueIsNotPromoted) {
+    std::string path = write_temp_tokenizer_json(kAddedTokenJson);
+    Tokenizer tok;
+    ASSERT_TRUE(tok.load(path));
+    std::remove(path.c_str());
+
+    // <plain>: normalized=true -> must NOT be matched as the atomic id 201.
+    EXPECT_FALSE(contains_id(tok.encode("<plain>"), 201))
+        << "normalized=true token should not be promoted to atomic matching";
 }
 
 }  // namespace

--- a/tools/imp-server/anthropic.cpp
+++ b/tools/imp-server/anthropic.cpp
@@ -306,6 +306,37 @@ json anthropic_to_openai_body(const json& anth) {
     if (anth.contains("stop_sequences"))
         oai["stop"] = anth["stop_sequences"];
 
+    // Extended-thinking control. Anthropic uses a `thinking` object:
+    //   {"type":"enabled","budget_tokens":N}  |  {"type":"disabled"}
+    // imp's orchestrator (handlers.cpp) reads `enable_thinking` (bool) and
+    // `think_budget` on the OpenAI body. `think_budget` is a FRACTION of
+    // max_tokens (default 0.5), so map Anthropic's absolute budget_tokens to
+    // budget_tokens/max_tokens, clamped to [0,1]. Without this mapping a
+    // think-model always reasoned on /v1/messages regardless of the request.
+    if (anth.contains("thinking") && anth["thinking"].is_object()) {
+        const auto& think = anth["thinking"];
+        const std::string ttype = think.value("type", "");
+        if (ttype == "disabled") {
+            // Suppressing thinking on a think-model needs BOTH signals: the
+            // orchestrator only sets suppress_thinking (which injects /no_think
+            // so the template emits no <think>) when enable_thinking is false
+            // AND think_budget <= 0 (handlers.cpp). The server's default budget
+            // is 0.5, so without zeroing it the model would still reason.
+            oai["enable_thinking"] = false;
+            oai["think_budget"] = 0.0;
+        } else if (ttype == "enabled") {
+            oai["enable_thinking"] = true;
+            if (think.contains("budget_tokens") && think["budget_tokens"].is_number()) {
+                double budget = think["budget_tokens"].get<double>();
+                double max_tokens = anth.value("max_tokens", 0.0);
+                if (budget > 0.0 && max_tokens > 0.0) {
+                    double frac = budget / max_tokens;
+                    oai["think_budget"] = frac > 1.0 ? 1.0 : frac;
+                }
+            }
+        }
+    }
+
     // Messages -------------------------------------------------------------
     json oai_messages = json::array();
 

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1147,8 +1147,17 @@ static bool snapshot_state_and_tokenize_(
     // level ("<think>" renders as plain text pieces, "</think>" closes it) —
     // when their chat template injects the prefix, the output is reasoning
     // from token 0 and must flow into reasoning_content, not content.
+    //
+    // Only an OPEN think prefix counts: when thinking is suppressed, Qwen3's
+    // template injects a *closed* empty block `<think>\n\n</think>\n\n` (so the
+    // model answers directly). That tail contains "<think>" too — re-enabling on
+    // it would defeat suppression entirely (the model thinks despite the closed
+    // block). Require "<think>" present AND no matching "</think>" in the tail.
+    // Window 16 (not 8) so both tags of the adjacent closed block fall inside
+    // the same tail — otherwise "<think>" could be in-window while "</think>"
+    // just falls off, mis-reading a closed block as an open prefix.
     if (!ctx.snap.enable_thinking) {
-        if (prompt_tail_contains("<think>", 8)) {
+        if (prompt_tail_contains("<think>", 16) && !prompt_tail_contains("</think>", 16)) {
             ctx.snap.enable_thinking = true;
         }
     }


### PR DESCRIPTION
## Problem

Turning thinking **off** (Anthropic `thinking:{type:"disabled"}`, OpenAI `enable_thinking:false`+`think_budget:0`, `/no_think`) silently failed for many prompts on Qwen3 — the model kept reasoning. E.g. `Reply with: hello world` produced 769 chars of reasoning even when disabled, on both dialects.

## Root causes (two), both fixed

**1. Tokenizer (the deep one).** Qwen3 ships `<think>`/`</think>` (ids 151667/151668) — and `<tool_call>`, `<|fim_*|>`, `<tool_response>` — as added tokens with `special=false, normalized=false`. imp only atomic-matched `special` tokens, so `<think>` was **BPE-split into `[13708, 766, 29]`** (`<`,`think`,`>`). Consequences:
- the `<think>`-as-stop-token guard (registers id 151667) never fired — the model emits the 3 text pieces, not 151667;
- the template's closed no-think block `<think>\n\n</think>\n\n` was just *text* the model re-opened at will.

Fix (`src/model/tokenizer.cpp`): follow HF semantics — atomic-match any added token with `normalized==false` regardless of `special` (which only governs decode-skipping). They become `USER_DEFINED` (token type 4): atomic-matched but still decode-visible. Also corrects tool-call / FIM marker tokenization toward HF parity.

**2. Server.** `handlers.cpp` re-enabled thinking whenever the prompt tail contained `<think>` (a heuristic for Nemotron/Phi-4 templates that inject an *open* prefix) — which the closed no-think block also contains. Now requires an **unclosed** prefix (`<think>` present, no matching `</think>`; window widened 8→16 so both tags of the adjacent closed block are seen together).

Also re-lands the Anthropic `thinking`-field mapping that #718's auto-merge dropped (it fired after the first commit; the mapping commit never landed). `{"type":"disabled"}` → `enable_thinking:false`+`think_budget:0` (both required — `suppress_thinking` only engages when budget ≤ 0, and the default is 0.5); `budget_tokens` → fractional `think_budget` (`/max_tokens`, clamped 1.0).

## Verification (RTX 5090, Qwen3-8B-NVFP4-cortecs)

- `<think>` now tokenizes to `[151667]` (was `[13708,766,29]`).
- **Disabling yields 0 reasoning chars on every prompt** incl. the prior `hello world` failure (769→0); enabling still reasons (589/363/497); both `/v1/messages` and OpenAI paths.
- Unit: `TokenizerAddedTokens.*` + `AnthropicThinking.*` (CPU/CI).
- Regression: `test-text` 190/190, `test-core` 271, `make test-gpu` green, **`degen_suite` 33/0** (coherent, no think-tag leaks), `make test-server` 7/7 batteries (incl. new `test_server_thinking_toggle.py` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)