### PR TITLE
chore(tidy): rename reserved _COUNT enum sentinel + calibrate clang-tidy + fix gitignore

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,8 +6,11 @@
 # compiler). For IDEs, clangd picks this file up automatically.
 #
 # Advisory: WarningsAsErrors is empty, so findings surface but do not block. The
-# noisy/opinionated checks below are disabled on purpose for a perf-CUDA codebase
-# (magic numbers, swappable params, cognitive complexity, …). Tighten over time.
+# disabled checks below are calibrated against a full sweep (it reported ~2000
+# findings, ~85% of them low-value style churn). We keep the bugprone-* /
+# performance-* / clang-diagnostic-* signal and drop the cosmetic mass (const on
+# locals, literal-suffix case, anon-namespace style, branch-clone on intentional
+# explicit case enumerations, …) so the gate surfaces real issues, not noise.
 
 Checks: >
   bugprone-*,
@@ -18,16 +21,28 @@ Checks: >
   cppcoreguidelines-pro-type-member-init,
   -bugprone-easily-swappable-parameters,
   -bugprone-narrowing-conversions,
+  -bugprone-branch-clone,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
   -misc-include-cleaner,
+  -misc-const-correctness,
+  -misc-use-anonymous-namespace,
+  -performance-enum-size,
   -readability-magic-numbers,
   -readability-identifier-length,
   -readability-function-cognitive-complexity,
   -readability-braces-around-statements,
   -readability-implicit-bool-conversion,
   -readability-named-parameter,
-  -readability-isolate-declaration
+  -readability-isolate-declaration,
+  -readability-uppercase-literal-suffix,
+  -readability-qualified-auto,
+  -readability-static-definition-in-anonymous-namespace,
+  -readability-avoid-nested-conditional-operator,
+  -readability-use-anyofallof,
+  -readability-else-after-return,
+  -readability-redundant-member-init,
+  -readability-simplify-boolean-expr
 
 WarningsAsErrors: ''
 HeaderFilterRegex: '(src|include/imp)/.*\.(h|hpp)$'

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,11 @@ tools/analysis/bench_*
 *.log
 bringup_artifacts/
 mtp_retest/
-core
-core.*
+# Core dumps — anchored to repo root so the pattern does NOT match the
+# src/core/ source directory (it did; that hid src/core from ripgrep/grep and
+# blocked `git add` of new files there).
+/core
+/core.*
 *.dump
 
 # Model files / weights

--- a/src/core/tensor_kind.h
+++ b/src/core/tensor_kind.h
@@ -70,7 +70,7 @@ enum class TensorKind : uint8_t {
     SIGLIP_NORM,
     MM_PROJ,
 
-    _COUNT,
+    COUNT,
 };
 
 const char* tensor_kind_name(TensorKind k);

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -229,8 +229,8 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
         // model that has tensor kinds the runtime caches but plan_storage
         // doesn't yet enumerate (or vice versa).
         if (registry_count < plan_overlay) {
-            int plan_per_kind[static_cast<int>(TensorKind::_COUNT)] = {0};
-            int registry_per_kind[static_cast<int>(TensorKind::_COUNT)] = {0};
+            int plan_per_kind[static_cast<int>(TensorKind::COUNT)] = {0};
+            int registry_per_kind[static_cast<int>(TensorKind::COUNT)] = {0};
             for (const auto& e : ideal_plan.entries) {
                 bool overlay = (e.tier == StorageTier::FP16 || e.tier == StorageTier::FP8 ||
                                 e.tier == StorageTier::NVFP4 || e.tier == StorageTier::CUTLASS_NVFP4 ||
@@ -241,7 +241,7 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
             for (TensorID id = 0; id < static_cast<TensorID>(registry_->size()); ++id) {
                 ++registry_per_kind[static_cast<int>(registry_->handle(id).kind)];
             }
-            for (int k = 0; k < static_cast<int>(TensorKind::_COUNT); ++k) {
+            for (int k = 0; k < static_cast<int>(TensorKind::COUNT); ++k) {
                 int diff = plan_per_kind[k] - registry_per_kind[k];
                 if (diff > 0) {
                     IMP_LOG_INFO("Phase-4 gap by kind: %s plan=%d registry=%d (uncached=%d)",

--- a/src/lora/lora_adapter.cpp
+++ b/src/lora/lora_adapter.cpp
@@ -227,7 +227,7 @@ bool LoraAdapter::load(const std::string& path, int n_layers) {
 
     // Validate pairs + collect max rank.
     for (size_t li = 0; li < layers_.size(); li++) {
-        for (int pi = 0; pi < static_cast<int>(LoraProj::_COUNT); pi++) {
+        for (int pi = 0; pi < static_cast<int>(LoraProj::COUNT); pi++) {
             LoraWeights& w = layers_[li].proj[pi];
             if ((w.A == nullptr) != (w.B == nullptr)) {
                 IMP_LOG_ERROR("LoRA: layer %zu proj %d has unpaired A/B", li, pi);

--- a/src/lora/lora_adapter.h
+++ b/src/lora/lora_adapter.h
@@ -20,7 +20,7 @@
 
 namespace imp {
 
-enum class LoraProj : uint8_t { Q = 0, K, V, O, GATE, UP, DOWN, _COUNT };
+enum class LoraProj : uint8_t { Q = 0, K, V, O, GATE, UP, DOWN, COUNT };
 
 struct LoraWeights {
     void* A = nullptr;  // device F16 [r, K]
@@ -59,7 +59,7 @@ public:
 
 private:
     struct LayerSlots {
-        LoraWeights proj[static_cast<int>(LoraProj::_COUNT)];
+        LoraWeights proj[static_cast<int>(LoraProj::COUNT)];
     };
     std::vector<LayerSlots> layers_;
     std::vector<void*> device_allocs_;

--- a/src/model/tensor_kind_name.cpp
+++ b/src/model/tensor_kind_name.cpp
@@ -90,7 +90,7 @@ const char* tensor_kind_name(TensorKind k) {
             return "SIGLIP_NORM";
         case TensorKind::MM_PROJ:
             return "MM_PROJ";
-        case TensorKind::_COUNT:
+        case TensorKind::COUNT:
             break;
     }
     return "UNKNOWN";

--- a/src/model/tensor_kind_table.cu
+++ b/src/model/tensor_kind_table.cu
@@ -20,8 +20,8 @@ constexpr TierMask FP16_OR_FP32 = mask(StorageTier::FP16) | mask(StorageTier::FP
 
 constexpr KindCapabilities build(TierMask s, StorageTier f, bool fus = false) { return {s, f, fus}; }
 
-constexpr std::array<KindCapabilities, static_cast<size_t>(TensorKind::_COUNT)> kKindTable = [] {
-    std::array<KindCapabilities, static_cast<size_t>(TensorKind::_COUNT)> t{};
+constexpr std::array<KindCapabilities, static_cast<size_t>(TensorKind::COUNT)> kKindTable = [] {
+    std::array<KindCapabilities, static_cast<size_t>(TensorKind::COUNT)> t{};
     t[(size_t)TensorKind::UNKNOWN] = build(FP16_ONLY, StorageTier::FP16);
     t[(size_t)TensorKind::WQ] = build(ALL_QUANT, StorageTier::NVFP4);
     t[(size_t)TensorKind::WK] = build(ALL_QUANT, StorageTier::FP8, true);
@@ -71,7 +71,7 @@ constexpr std::array<KindCapabilities, static_cast<size_t>(TensorKind::_COUNT)> 
 }  // namespace
 
 const KindCapabilities& capabilities_of(TensorKind k) {
-    IMP_CHECK(k != TensorKind::_COUNT && static_cast<size_t>(k) < kKindTable.size(),
+    IMP_CHECK(k != TensorKind::COUNT && static_cast<size_t>(k) < kKindTable.size(),
               "capabilities_of: invalid TensorKind=%zu (table size=%zu)",
               static_cast<size_t>(k), kKindTable.size());
     return kKindTable[static_cast<size_t>(k)];

--- a/tests/test_tensor_kind_table.cpp
+++ b/tests/test_tensor_kind_table.cpp
@@ -6,7 +6,7 @@
 using namespace imp;
 
 TEST(TensorKindTable, EveryKindHasEntry) {
-    for (int i = 0; i < static_cast<int>(TensorKind::_COUNT); ++i) {
+    for (int i = 0; i < static_cast<int>(TensorKind::COUNT); ++i) {
         auto k = static_cast<TensorKind>(i);
         const auto& cap = capabilities_of(k);
         EXPECT_NE(cap.supported, TierMask{0})
@@ -15,7 +15,7 @@ TEST(TensorKindTable, EveryKindHasEntry) {
 }
 
 TEST(TensorKindTable, RequiredFloorIsInSupported) {
-    for (int i = 0; i < static_cast<int>(TensorKind::_COUNT); ++i) {
+    for (int i = 0; i < static_cast<int>(TensorKind::COUNT); ++i) {
         auto k = static_cast<TensorKind>(i);
         const auto& cap = capabilities_of(k);
         EXPECT_TRUE(mask_contains(cap.supported, cap.required_floor))
@@ -137,7 +137,7 @@ TEST(EffectiveCapabilities, FP16OnlyKindsAreUnaffected) {
 TEST(EffectiveCapabilities, FloorAlwaysInSupported) {
     // For every (kind, qtype) combination, required_floor must remain in
     // supported mask after refinement.
-    for (int k = 0; k < static_cast<int>(TensorKind::_COUNT); ++k) {
+    for (int k = 0; k < static_cast<int>(TensorKind::COUNT); ++k) {
         auto kind = static_cast<TensorKind>(k);
         for (auto qtype : {QType::F16, QType::Q4_K, QType::Q5_K, QType::Q6_K, QType::Q8_0,
                            QType::NVFP4, QType::MXFP4, QType::F32}) {
@@ -150,7 +150,7 @@ TEST(EffectiveCapabilities, FloorAlwaysInSupported) {
 }
 
 TEST(TensorKindTable, EveryKindHasName) {
-    for (int i = 1; i < static_cast<int>(TensorKind::_COUNT); ++i) {
+    for (int i = 1; i < static_cast<int>(TensorKind::COUNT); ++i) {
         auto k = static_cast<TensorKind>(i);
         const char* name = tensor_kind_name(k);
         EXPECT_NE(std::string(name), "UNKNOWN")


### PR DESCRIPTION
Follow-ups from running `make tidy` (clang-tidy over the host C++ TUs).

## Fixed
- **bugprone-reserved-identifier** — `TensorKind` / `LoraProj` enum count sentinels
  were `_COUNT` (leading-underscore-uppercase is reserved by the standard).
  Renamed to `COUNT` everywhere (definitions, uses, tests). Mechanical; build +
  TensorKind/LoRA unit tests green.
- **.clang-tidy calibration** — the first sweep reported ~2000 findings, ~85%
  low-value style churn (const-on-locals 1323, literal-suffix case 313,
  qualified-auto, anon-namespace style, branch-clone on intentional explicit case
  enumerations, …). Disabled those so the advisory gate surfaces the
  bugprone-*/performance-*/clang-diagnostic signal (~100 real findings), not noise.
- **.gitignore** — the unanchored `core` / `core.*` core-dump patterns matched the
  `src/core/` source directory: ripgrep/grep silently skipped it (it actually
  masked `tensor_kind.h` mid-rename here) and `git add` of new src/core/ files
  needed `-f`. Anchored to `/core`.

## Deliberately deferred (not churned blindly)
The remaining real findings are behavior-sensitive server/engine code that needs
server/GPU testing to change safely, so they're left for a focused follow-up:
- a `reasoning_tokens` reporting inconsistency across two handler response paths
  (some count reasoning tokens but don't report them in `completion_tokens_details`),
- `engine.cpp` unchecked-optional accesses (likely safe-by-invariant),
- intentional empty catches (optional-parse fallbacks).

A first attempt to wire the `reasoning_tokens` report was **reverted when the build
gate caught it placed in the wrong handler function** — these need real server
verification, not a blind edit.

## Perf / scope
No kernel or perf-path changes. The .cu files touched are an enum rename only.