### PR TITLE
style: reflow tensor_kind_table IMP_CHECK to clang-format

### DIFF
--- a/src/model/tensor_kind_table.cu
+++ b/src/model/tensor_kind_table.cu
@@ -72,8 +72,8 @@ constexpr std::array<KindCapabilities, static_cast<size_t>(TensorKind::COUNT)> k
 
 const KindCapabilities& capabilities_of(TensorKind k) {
     IMP_CHECK(k != TensorKind::COUNT && static_cast<size_t>(k) < kKindTable.size(),
-              "capabilities_of: invalid TensorKind=%zu (table size=%zu)",
-              static_cast<size_t>(k), kKindTable.size());
+              "capabilities_of: invalid TensorKind=%zu (table size=%zu)", static_cast<size_t>(k),
+              kKindTable.size());
     return kKindTable[static_cast<size_t>(k)];
 }
 


### PR DESCRIPTION
The `_COUNT`->`COUNT` rename in #724 shifted clang-format's wrap of this IMP_CHECK call (the line in #724's Lint log). Whitespace only, identical codegen — clears the last format-dirty line on main.