### PR TITLE
ci(clang-tidy): stop the log flood from dependency-header warning counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,14 @@ jobs:
         continue-on-error: true
         run: |
           apt-get install -y --no-install-recommends clang-tidy
-          clang-tidy -p build --warnings-as-errors= $(find src tools -name '*.cpp')
+          # Filter the noise: clang-tidy prints a "[N/M] Processing file" progress
+          # line and a cumulative "N warnings generated" line per TU. Because our
+          # .cpp pull in CUTLASS/CUDA headers, that generated count runs into the
+          # hundreds of thousands — all suppressed from DISPLAY by the .clang-tidy
+          # HeaderFilterRegex, but the COUNT lines flooded the log. Drop both; what
+          # remains is only our own src/tools diagnostics.
+          clang-tidy -p build --warnings-as-errors= $(find src tools -name '*.cpp') 2>&1 \
+            | grep -vE '^\[[0-9]+/[0-9]+\] Processing file|^[0-9]+ warnings generated\.$' || true
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
The advisory clang-tidy step flooded the CI log with hundreds of thousands of `N warnings generated` count lines — those are clang-tidy *counting* warnings in the CUTLASS/CUDA headers our .cpp include (all suppressed from display by HeaderFilterRegex, but the counts still printed). Filter the `[N/M] Processing file` progress and `N warnings generated` count lines so the log shows only real diagnostics in our own code. Advisory, no behavior change.