### PR TITLE
ci: bump setup-python v5->v6 (Node 24) to clear deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/roofline.yml
+++ b/.github/workflows/roofline.yml
@@ -23,9 +23,9 @@ jobs:
     name: Roofline regress + plots
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
GitHub forces Node-20 actions onto Node 24 and warns each run. `actions/setup-python@v5` (ci.yml + roofline.yml) → `@v6` (Node 24, same API). Also roofline `checkout@v4`→`@v5`. Non-blocking warning; this just clears it. Left `upload-artifact@v4` (major bump changes file handling) and `cache@v4` (already Node 24, unflagged).