### PR TITLE
tools(bench): isolated NVFP4 dense GEMM bench mode; refute the cp.async occupancy hypothesis

### DIFF
--- a/docs/sm120_optimal_kernel.md
+++ b/docs/sm120_optimal_kernel.md
@@ -187,3 +187,39 @@ a kernel-structure trick:
 
 Out-of-the-box (questioning the metric) beat brute force (porting CUTLASS's
 machinery) by ~40 %. The headers of both kernels carry the full ncu trail.
+
+### The occupancy follow-up — REFUTED (2026-06-17)
+
+The standalone's "48 % vs prod ~41 %" raised a hypothesis: does CUTLASS's
+datacenter-tuned **TMA + warp-specialization** pay an *occupancy tax* on consumer
+sm_120 that a simpler cp.async + good-layout path avoids? An isolated GEMM
+microbench (`imp-bench nvfp4`, the dense `gemm_nvfp4_cutlass_sm120` path on square
+and small-M shapes) + apples-to-apples ncu against the standalone, same box, same
+session, **refutes it**:
+
+| @ 4096³ | Prod (`KernelTmaWarpSpecializedCooperativeBlockScaledSm120`) | Standalone (cp.async) |
+|---|---|---|
+| Time (ncu) | **163 µs** | 194 µs (+19 %) |
+| Achieved occupancy | 20.9 % | 31.5 % |
+| SM-pipe throughput | **71 %** | 54 % |
+| DRAM throughput | 11.7 % | 22.3 % |
+| Regs/thread, blocks/SM | 151, 1 | 122, 2 |
+
+- **Prod wins at the peak shape** (903 → 1284 TOP/s @ 4k → 8k = 44.7 → 63.6 % of
+  the 2019-TOPS measured peak; standalone 813 / 972). The earlier "prod ~41 %" was
+  a roofline-pipeline number over real **small-M** model shapes — apples-to-oranges
+  with the standalone's square-cubed measurement, which is what created the
+  illusion that the from-scratch kernel was ahead.
+- **The occupancy "tax" is real but not a cost.** Prod runs at 21 % occupancy
+  (1 block/SM, 151 regs) — exactly the predicted tax — yet converts it into far
+  higher SM-pipe utilisation (71 % vs 54 %). Neither kernel is L2/DRAM-bound at
+  square shapes (prod DRAM 11.7 %), so the standalone's CTA-tile-major +
+  column-interleave L2 tricks buy nothing here.
+- **Small-M prefill (M ≤ 512) is inefficient for both** (12 → 46 %) — pure grid
+  underfill: a 128×128 M-tile leaves most of the 170 SMs idle. The fix is smaller
+  M-tiles / split-K (imp's `gemm_grouped_nvfp4_smallM` path), **not** occupancy;
+  the cp.async standalone uses the same 128×128 tile and underfills identically.
+
+**Verdict:** keep CUTLASS TMA + warp-spec as the production dense NVFP4 GEMM; do
+not port cp.async + layout into prod. The standalone remains a valuable reference
+and `imp-bench nvfp4` a clean per-kernel ncu target.

--- a/tools/imp-bench/bench_gemm.cu
+++ b/tools/imp-bench/bench_gemm.cu
@@ -1,5 +1,7 @@
 #include "compute/gemm.h"
+#include "compute/gemm_cutlass_sm120.h"
 #include "quant/quant_gemm.h"
+#include "quant/nvfp4_quant.h"
 #include "core/tensor.h"
 
 #include <cuda_runtime.h>
@@ -194,6 +196,129 @@ static float bench_int4_gemm(const GemmSize& sz) {
     cudaFree(d_C);
 
     return avg_ms;
+}
+
+// Benchmark the PRODUCTION CUTLASS sm_120 block-scaled NVFP4xNVFP4 dense GEMM
+// (gemm_nvfp4_cutlass_sm120) — the kernel the from-scratch tools/standalone/
+// gemm_nvfp4_sm120a.cu reference beats (48% vs ~41% of FP4 peak). Square shapes
+// match the standalone's M=N=K cubed measurements so ncu profiles line up
+// apples-to-apples (occupancy + lts__t_requests/sectors). Returns avg ms.
+static float bench_nvfp4_cutlass_gemm(const GemmSize& sz) {
+    int64_t M = sz.M, N = sz.N, K = sz.K;
+    if (!cutlass_sm120_nvfp4_available()) {
+        fprintf(stderr, "bench_nvfp4_cutlass_gemm: CUTLASS sm_120 NVFP4 GEMM not compiled\n");
+        return -1.0f;
+    }
+
+    // --- Activation A [M,K] FP16 -> CUTLASS NVFP4 (packed FP4 + SfAtom scales) ---
+    std::vector<half> h_A(static_cast<size_t>(M) * K);
+    fill_random_fp16(h_A.data(), M * K);
+    void* d_A_fp16 = nullptr;
+    cudaMalloc(&d_A_fp16, h_A.size() * sizeof(half));
+    cudaMemcpy(d_A_fp16, h_A.data(), h_A.size() * sizeof(half), cudaMemcpyHostToDevice);
+
+    void* a_data = nullptr;  // [M, K/2] packed FP4
+    void* a_sf = nullptr;    // SfAtom UE4M3 scales
+    cudaMalloc(&a_data, static_cast<size_t>(M) * (K / 2));
+    cudaMalloc(&a_sf, cutlass_nvfp4_sf_size(static_cast<int>(M), static_cast<int>(K)));
+    quantize_fp16_to_nvfp4_cutlass(d_A_fp16, a_data, a_sf, static_cast<int>(M), static_cast<int>(K), nullptr);
+
+    // --- Weight B [N,K] FP16 -> NvFP4QuantResult -> CUTLASS block-scaled ---
+    std::vector<half> h_B(static_cast<size_t>(N) * K);
+    fill_random_fp16(h_B.data(), N * K);
+    void* d_B_fp16 = nullptr;
+    cudaMalloc(&d_B_fp16, h_B.size() * sizeof(half));
+    cudaMemcpy(d_B_fp16, h_B.data(), h_B.size() * sizeof(half), cudaMemcpyHostToDevice);
+    int64_t bshape[2] = {N, K};
+    Tensor b_t(d_B_fp16, QType::F16, 2, bshape, /*on_device=*/true);
+    NvFP4QuantResult qr{};
+    quantize_fp16_to_nvfp4(b_t, qr, nullptr);
+    CutlassNvFP4Weight cw{};
+    convert_nvfp4_to_cutlass(qr, cw, nullptr);
+
+    // --- Output + workspace ---
+    void* d_D = nullptr;
+    cudaMalloc(&d_D, static_cast<size_t>(M) * N * sizeof(half));
+    size_t ws_size = gemm_nvfp4_cutlass_sm120_workspace(static_cast<int>(M), static_cast<int>(N),
+                                                        static_cast<int>(K));
+    void* ws = nullptr;
+    if (ws_size > 0)
+        cudaMalloc(&ws, ws_size);
+    cudaDeviceSynchronize();
+
+    auto run = [&]() {
+        return gemm_nvfp4_cutlass_sm120(a_data, a_sf, cw, d_D, static_cast<int>(M), static_cast<int>(N),
+                                        static_cast<int>(K), ws, ws_size, nullptr);
+    };
+
+    // Warmup >1s to ramp clocks (idle-downclock is the dominant cold-start artifact).
+    bool ok = true;
+    for (int i = 0; i < 50; ++i)
+        ok = run() && ok;
+    cudaDeviceSynchronize();
+    if (!ok)
+        fprintf(stderr, "bench_nvfp4_cutlass_gemm: kernel returned false for M=%ld N=%ld K=%ld\n", M, N, K);
+
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+    cudaEventRecord(start, nullptr);
+    for (int i = 0; i < kTimedIters; ++i)
+        run();
+    cudaEventRecord(stop, nullptr);
+    cudaEventSynchronize(stop);
+    float total_ms = 0.0f;
+    cudaEventElapsedTime(&total_ms, start, stop);
+    float avg_ms = total_ms / static_cast<float>(kTimedIters);
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    free_cutlass_nvfp4_weight(cw);
+    free_nvfp4_result(qr);
+    if (ws)
+        cudaFree(ws);
+    cudaFree(d_D);
+    cudaFree(a_data);
+    cudaFree(a_sf);
+    cudaFree(d_A_fp16);
+    cudaFree(d_B_fp16);
+    return avg_ms;
+}
+
+// Square NVFP4 shapes matching tools/standalone/gemm_nvfp4_sm120a.cu (M=N=K cubed).
+static const GemmSize kNvfp4Sizes[] = {
+    {2048, 2048, 2048, "M=N=K=2048"},
+    {4096, 4096, 4096, "M=N=K=4096"},
+    {8192, 8192, 8192, "M=N=K=8192"},
+    // Realistic prefill shapes (small M = chunk size, N/K = model dims) — the
+    // grid-underfill regime where warp-spec's 1-block/SM could lose to a
+    // higher-occupancy cp.async path. N=K=5120 ~ Qwen3-14B hidden.
+    {128, 5120, 5120, "M=128 N=K=5120"},
+    {256, 5120, 5120, "M=256 N=K=5120"},
+    {512, 5120, 5120, "M=512 N=K=5120"},
+    {1024, 5120, 5120, "M=1024 N=K=5120"},
+    {2048, 5120, 5120, "M=2048 N=K=5120"},
+};
+static constexpr int kNumNvfp4Sizes = sizeof(kNvfp4Sizes) / sizeof(kNvfp4Sizes[0]);
+
+void bench_gemm_nvfp4_cutlass() {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        printf("bench_gemm_nvfp4_cutlass: no CUDA device available, skipping.\n");
+        return;
+    }
+    printf("=== Production CUTLASS sm_120 NVFP4 dense GEMM ===\n");
+    printf("(peak FP4 mma.sync ~2019 TOPS measured; standalone ref hits 48%%)\n\n");
+    for (int i = 0; i < kNumNvfp4Sizes; ++i) {
+        const GemmSize& sz = kNvfp4Sizes[i];
+        float avg_ms = bench_nvfp4_cutlass_gemm(sz);
+        if (avg_ms <= 0.0f)
+            continue;
+        double tops = 2.0 * sz.M * sz.N * sz.K / (avg_ms * 1e-3) / 1e12;
+        double pct_peak = tops / 2019.0 * 100.0;
+        printf("  [%-14s] %8.3f ms  %7.1f TOP/s  %5.1f%% of 2019 peak\n", sz.label, avg_ms, tops, pct_peak);
+    }
+    printf("\n");
 }
 
 void bench_gemm() {

--- a/tools/imp-bench/main.cpp
+++ b/tools/imp-bench/main.cpp
@@ -4,6 +4,7 @@
 
 namespace imp {
 void bench_gemm();
+void bench_gemm_nvfp4_cutlass();
 void bench_attention();
 void bench_paged_attention();
 void bench_e2e();
@@ -13,6 +14,7 @@ static void print_usage(const char* prog) {
     printf("Usage: %s [benchmark] [--help]\n\n", prog);
     printf("Available benchmarks:\n");
     printf("  gemm        GEMM micro-benchmark\n");
+    printf("  nvfp4       Production CUTLASS sm_120 NVFP4 dense GEMM (isolated, ncu target)\n");
     printf("  attention   Flash Attention prefill benchmark\n");
     printf("  decode-attn Paged Attention decode benchmark\n");
     printf("  e2e         End-to-end tok/s benchmark\n");
@@ -26,6 +28,7 @@ int main(int argc, char** argv) {
     printf("==================\n\n");
 
     bool run_gemm = false;
+    bool run_gemm_nvfp4 = false;
     bool run_attention = false;
     bool run_decode_attn = false;
     bool run_e2e = false;
@@ -42,6 +45,8 @@ int main(int argc, char** argv) {
             return 0;
         } else if (strcmp(arg, "gemm") == 0) {
             run_gemm = true;
+        } else if (strcmp(arg, "nvfp4") == 0) {
+            run_gemm_nvfp4 = true;
         } else if (strcmp(arg, "attention") == 0) {
             run_attention = true;
         } else if (strcmp(arg, "decode-attn") == 0) {
@@ -66,6 +71,10 @@ int main(int argc, char** argv) {
 
     if (run_gemm) {
         imp::bench_gemm();
+        ++benchmarks_run;
+    }
+    if (run_gemm_nvfp4) {
+        imp::bench_gemm_nvfp4_cutlass();
         ++benchmarks_run;
     }
     if (run_attention) {


### PR DESCRIPTION
## What

Adds an isolated **`imp-bench nvfp4`** mode that runs *only* the production CUTLASS sm_120 block-scaled NVFP4 dense GEMM (`gemm_nvfp4_cutlass_sm120`) on square + small-M shapes — a clean single-kernel `ncu` target. Documents the verdict in `docs/sm120_optimal_kernel.md`.

## Why — settling the open #720 follow-up

PR #720's from-scratch `tools/standalone/gemm_nvfp4_sm120a.cu` reported "48 % vs prod ~41 %", raising the hypothesis that CUTLASS's TMA + warp-specialization pays an *occupancy tax* on consumer sm_120 that a simpler cp.async + layout path avoids. This was the documented `RESUME HERE`.

Apples-to-apples `ncu` of prod vs the standalone, same box, same session, **refutes it**:

| @ 4096³ | Prod (TMA + warp-spec) | Standalone (cp.async) |
|---|---|---|
| Time (ncu) | **163 µs** | 194 µs (+19 %) |
| Achieved occupancy | 20.9 % | 31.5 % |
| SM-pipe throughput | **71 %** | 54 % |
| DRAM throughput | 11.7 % | 22.3 % |

- **Prod wins at the peak shape** (903 → 1284 TOP/s @ 4k → 8k vs 813 / 972). The old "prod ~41 %" was a roofline number over real **small-M** shapes — apples-to-oranges with the standalone's square-cubed measurement.
- **The occupancy tax is real but not a cost** — prod converts low occupancy into higher SM-pipe utilisation; neither kernel is L2/DRAM-bound at square shapes, so the standalone's L2 layout tricks buy nothing here.
- **Small-M prefill underfills the grid for both** (128×128 M-tile) — fixed by smaller M-tiles / split-K (the `gemm_grouped_nvfp4_smallM` path), not occupancy.

**Verdict:** keep CUTLASS TMA + warp-spec as the production dense NVFP4 GEMM; do not port cp.async + layout into prod.

## Impact

Tooling + docs only — no hot-path or `perf_baseline.json` impact. The new bench file compiles under the CUDA 13.3 toolchain (`imp-bench` built + run locally on the RTX 5090).

🤖 Generated with [Claude Code](https://claude.com/claude-code)