### PR TITLE
perf(load): slab-allocate CUTLASS NVFP4 SF cache (18.6k→1 malloc, ~-785ms MoE load)

### DIFF
--- a/src/compute/gemm_cutlass_sm120.cu
+++ b/src/compute/gemm_cutlass_sm120.cu
@@ -417,6 +417,34 @@ void convert_nvfp4_to_cutlass(const NvFP4QuantResult& src, CutlassNvFP4Weight& d
                   (long long)K, sf_bytes / (1024.0 * 1024.0));
 }
 
+void convert_nvfp4_to_cutlass_borrowed(const NvFP4QuantResult& src, CutlassNvFP4Weight& dst, void* sf_dst,
+                                       cudaStream_t stream) {
+    IMP_CHECK(src.packed_data != nullptr, "convert_nvfp4_to_cutlass_borrowed: src.packed_data is null");
+    IMP_CHECK(sf_dst != nullptr, "convert_nvfp4_to_cutlass_borrowed: sf_dst is null");
+    int64_t N = src.N;
+    int64_t K = src.K;
+
+    // Write micro-scales into the caller's pre-zeroed slab sub-region (no alloc,
+    // no memset — the slab is zeroed once for all entries). Same kernel/layout
+    // as convert_nvfp4_to_cutlass.
+    int K_groups = static_cast<int>(K) / kSFVecSize;
+    int total = static_cast<int>(N) * K_groups;
+    int n_k_tiles = (static_cast<int>(K) + kAtomKElems - 1) / kAtomKElems;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    convert_scales_sfatom_kernel<<<blocks, threads, 0, stream>>>(
+        reinterpret_cast<const uint8_t*>(src.micro_scales), reinterpret_cast<uint8_t*>(sf_dst),
+        static_cast<int>(N), static_cast<int>(K), n_k_tiles);
+
+    dst.data = src.packed_data;  // borrowed pointer (not owned)
+    dst.scale_factors = sf_dst;  // borrowed slab sub-region
+    dst.tensor_scale = src.tensor_scale;
+    dst.N = N;
+    dst.K = K;
+    dst.sf_bytes = cutlass_nvfp4_sf_size(static_cast<int>(N), static_cast<int>(K));
+    dst.sf_borrowed = true;  // slab owns the memory; skip per-tensor cudaFree
+}
+
 void free_cutlass_nvfp4_weight(CutlassNvFP4Weight& w) {
     // data is borrowed from NvFP4QuantResult — do NOT free it
     w.data = nullptr;

--- a/src/compute/gemm_cutlass_sm120.h
+++ b/src/compute/gemm_cutlass_sm120.h
@@ -33,6 +33,14 @@ struct CutlassNvFP4Weight {
 // Borrows packed_data pointer (RowMajor). tensor_scale is stored for GEMM alpha.
 void convert_nvfp4_to_cutlass(const NvFP4QuantResult& src, CutlassNvFP4Weight& dst, cudaStream_t stream);
 
+// Same conversion, but writes the SfAtom scale factors into a caller-provided,
+// pre-zeroed buffer `sf_dst` (a sub-region of a shared slab) instead of doing a
+// per-tensor cudaMalloc+cudaMemset. Sets dst.sf_borrowed=true — the caller owns
+// the backing slab and frees it once. `sf_dst` must have at least
+// cutlass_nvfp4_sf_size(src.N, src.K) bytes and be pre-zeroed (padding rows).
+void convert_nvfp4_to_cutlass_borrowed(const NvFP4QuantResult& src, CutlassNvFP4Weight& dst, void* sf_dst,
+                                       cudaStream_t stream);
+
 void free_cutlass_nvfp4_weight(CutlassNvFP4Weight& w);
 
 // Compute SfAtom buffer size for given dimensions (rows x K).

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1044,11 +1044,18 @@ void GraphExecutor::free_buffers() {
             free_nvfp4_moe_result(result);
         wcache_.nvfp4_moe.clear();
         wcache_.nvfp4_moe_bytes = 0;
-        // CUTLASS NVFP4 cache
+        // CUTLASS NVFP4 cache. Entries' scale_factors are sub-pointers into
+        // cutlass_sf_slab (sf_borrowed=true) so free_cutlass_nvfp4_weight skips
+        // the per-tensor cudaFree; the slab is freed once below.
         for (auto& [ptr, cw] : wcache_.cutlass_nvfp4)
             free_cutlass_nvfp4_weight(cw);
         wcache_.cutlass_nvfp4.clear();
         wcache_.cutlass_nvfp4_bytes = 0;
+        if (wcache_.cutlass_sf_slab) {
+            IMP_CUDA_CHECK_LOG(cudaFree(wcache_.cutlass_sf_slab));
+            wcache_.cutlass_sf_slab = nullptr;
+            wcache_.cutlass_sf_slab_size = 0;
+        }
         // CUTLASS MXFP4 cache
         for (auto& [ptr, mw] : wcache_.cutlass_mxfp4)
             free_cutlass_mxfp4_weight(mw);

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -824,13 +824,18 @@ void QuantPipeline::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
                         ? (remaining_budget - wcache_->nvfp4_bytes)
                         : 0;
     }
-    int ct_count = 0;
-    size_t ct_total = 0;
-    bool ct_exhausted = false;
+    // All SfAtom scale buffers share ONE slab allocation (each entry borrows a
+    // sub-region) instead of a per-tensor cudaMalloc+cudaMemsetAsync. On a
+    // 128-expert MoE the old loop issued ~18.6k allocs + memsets (~600 ms of
+    // load time). Pass 1 selects the included tensors with the SAME skip +
+    // VRAM-budget rules and sums their 256B-aligned SfAtom sizes; Pass 2
+    // converts each into its slab offset (one alloc, one memset, one teardown).
+    constexpr size_t kSfAlign = 256;  // keep each entry's SF base CUTLASS-aligned
+    auto align_up = [](size_t x, size_t a) { return (x + a - 1) / a * a; };
+    std::vector<std::pair<const void*, size_t>> ct_included;  // (src ptr, slab offset)
+    size_t ct_total = 0;  // running padded slab size = real SF VRAM
     int ct_skipped_dead = 0;
     for (auto& [ptr, nvfp4] : wcache_->nvfp4) {
-        if (ct_exhausted)
-            break;
         // G3 (Stage 1.4): skip the CUTLASS SF buffer for weights whose M>1
         // prefill uses IMMA raw-read on the GGUF source — the CUTLASS GEMM path
         // (executor_kernels gemm_via_handle_, primary_tier==CUTLASS_NVFP4) is
@@ -844,22 +849,39 @@ void QuantPipeline::nvfp4_decode_convert_cutlass_(size_t& remaining_budget, cuda
             ++ct_skipped_dead;
             continue;
         }
-        // Estimate CUTLASS allocation (only scale factors — data is borrowed)
-        size_t est = cutlass_nvfp4_sf_size(static_cast<int>(nvfp4.N), static_cast<int>(nvfp4.K));
+        size_t est = align_up(cutlass_nvfp4_sf_size(static_cast<int>(nvfp4.N), static_cast<int>(nvfp4.K)),
+                              kSfAlign);
         if (ct_total + est > ct_budget) {
-            ct_exhausted = true;
             IMP_LOG_INFO(
-                "CUTLASS NVFP4 cache: VRAM budget reached after %d tensors "
+                "CUTLASS NVFP4 cache: VRAM budget reached after %zu tensors "
                 "(%.1f / %.1f MiB)",
-                ct_count, ct_total / (1024.0 * 1024.0), ct_budget / (1024.0 * 1024.0));
+                ct_included.size(), ct_total / (1024.0 * 1024.0), ct_budget / (1024.0 * 1024.0));
             break;
         }
-        CutlassNvFP4Weight cw;
-        convert_nvfp4_to_cutlass(nvfp4, cw, stream);
-        if (cw.data) {
-            wcache_->cutlass_nvfp4[ptr] = cw;
-            ct_total += cw.sf_bytes;
-            ct_count++;
+        ct_included.emplace_back(ptr, ct_total);
+        ct_total += est;
+    }
+
+    int ct_count = 0;
+    if (ct_total > 0) {
+        void* sf_slab = nullptr;
+        IMP_CUDA_CHECK_LOG(cudaMalloc(&sf_slab, ct_total));
+        // Zero every entry's SfAtom padding rows at once (the convert kernel
+        // writes only valid (n, k_group) cells).
+        IMP_CUDA_CHECK_LOG(cudaMemsetAsync(sf_slab, 0, ct_total, stream));
+        wcache_->cutlass_sf_slab = sf_slab;
+        wcache_->cutlass_sf_slab_size = ct_total;
+        for (auto& [ptr, off] : ct_included) {
+            auto it = wcache_->nvfp4.find(ptr);
+            if (it == wcache_->nvfp4.end())
+                continue;
+            CutlassNvFP4Weight cw;
+            convert_nvfp4_to_cutlass_borrowed(it->second, cw, static_cast<uint8_t*>(sf_slab) + off,
+                                              stream);
+            if (cw.data) {
+                wcache_->cutlass_nvfp4[ptr] = cw;
+                ct_count++;
+            }
         }
     }
     if (ct_count > 0) {

--- a/src/exec/weight_caches.h
+++ b/src/exec/weight_caches.h
@@ -76,6 +76,14 @@ struct WeightCaches {
     std::unordered_map<const void*, CutlassNvFP4Weight> cutlass_nvfp4;
     size_t cutlass_nvfp4_bytes = 0;
 
+    // Single bulk allocation backing every cutlass_nvfp4 entry's SfAtom scale
+    // factors (mirrors fp16_bulk_data). Each entry's scale_factors is a
+    // sub-pointer with sf_borrowed=true, so the per-tensor cudaFree is skipped
+    // and this slab is freed once at teardown. Replaces ~18k per-tensor
+    // cudaMalloc+cudaMemsetAsync on large MoE loads (~600 ms of load time).
+    void* cutlass_sf_slab = nullptr;
+    size_t cutlass_sf_slab_size = 0;
+
     // --- CUTLASS sm_120 MXFP4 ---
     std::unordered_map<const void*, CutlassMxFP4Weight> cutlass_mxfp4;
     size_t cutlass_mxfp4_bytes = 0;


### PR DESCRIPTION
## What

The CUTLASS NVFP4 prefill scale-factor cache (`nvfp4_decode_convert_cutlass_` in `pre_dequant_phase3_nvfp4_decode.cu`) allocated **one SfAtom buffer per weight tensor** — **18,625 `cudaMalloc` + `cudaMemsetAsync`** calls on a 128-expert MoE load (Qwen3-Coder-30B-A3B-FP4).

This PR allocates **one slab** for all SF buffers; each `cutlass_nvfp4` entry borrows a 256B-aligned sub-region (`sf_borrowed=true`), so the per-tensor `cudaFree` is skipped and the slab is freed once at teardown. A new `convert_nvfp4_to_cutlass_borrowed()` runs the **same** convert kernel into the slab → SfAtom bytes are **bit-identical**. Mirrors the existing `fp16_bulk_data` pattern. Pass 1 selects the included tensors with the unchanged skip + VRAM-budget rules and sums their aligned sizes; pass 2 converts each into its slab offset.

## Why / measured

nsys CUDA API trace, MoE load, before → after:

| API call | before | after |
|---|---|---|
| `cudaMalloc` | 19445 / 433 ms | **821 / 16.5 ms** |
| `cudaMemsetAsync` | 18626 / 174 ms | **2 / 0.08 ms** |
| `cudaFree` (teardown) | 38494 / 215 ms | **19870 / 21 ms** |

→ **~785 ms of load + teardown time eliminated**; identical 1800.55 MiB SF cache / 18,625 tensors.

## Scope

**Load-time only** — no decode/prefill throughput change, so `tests/perf_baseline.json` is unchanged.

## Verification

- Coherent greedy generation on Qwen3-Coder-30B-A3B-FP4 (exercises the slab'd CUTLASS prefill path).
- 26 CUTLASS / NVFP4 / MoE / StoragePlanner / EngineIntegration GPU unit tests pass.
- Clean shutdown (no double-free); Docker clean build, zero new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)