### PR TITLE
docs(skills): add shipping-prs skill for PR/merge/release mechanics

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -14,12 +14,14 @@ description states when to fire AND when not to — keep that property when edit
 | [quant-formats](quant-formats/SKILL.md) | GGUF/NVFP4/FP8 formats, StorageTier dispatch contract, decode cache, KV dtypes | sm120-cuda-expert |
 | [codebase-audit](codebase-audit/SKILL.md) | Structural-debt / dead-code / god-file / flag audits + the verification discipline that stops fan-out over-flagging; `docs/audit/` convention | building-and-testing, check-degeneration |
 | [docs-sync](docs-sync/SKILL.md) | Keeping architecture.md / README / GOAL.md / supported-models.md / imp.conf.example / CHANGELOG coherent after a change; English-only rule | benchmark-cuda (perf), codebase-audit |
+| [shipping-prs](shipping-prs/SKILL.md) | PR/merge/release mechanics — branch off main, no stacking, squash + auto-merge race (`Build` required check, ruleset 14716423), version bump + CHANGELOG + tag flow | building-and-testing, docs-sync (CHANGELOG prose) |
 
 Boundaries (to avoid trigger collisions):
 
 - *Measure* perf → benchmark-cuda · *write* the kernel → sm120-cuda-expert · *is the output still sane* → check-degeneration.
 - *Build/test mechanics & CI* → building-and-testing · *model output via HTTP* → server-api · *model loads but is wrong* → add-model-arch · *bytes/scales/tiers* → quant-formats.
 - *Is this code dead / should we refactor* → codebase-audit · *keep the docs consistent with the code* → docs-sync. Perf-number measurement + `perf_baseline.json` refresh stay with benchmark-cuda (docs-sync only reconciles the surrounding prose).
+- *Open/merge/release a PR, auto-merge, tag a version* → shipping-prs · *build/test mechanics behind that PR* → building-and-testing (it cross-refs shipping-prs for the merge flow).
 
 Audit history: [AUDIT_skills_2026_06_07.md](AUDIT_skills_2026_06_07.md). Content refresh
 2026-06-10: folded in the post-audit sprint (PRs #608–#651 — IMMA prefill family, TC-rate

--- a/.claude/skills/building-and-testing/SKILL.md
+++ b/.claude/skills/building-and-testing/SKILL.md
@@ -57,4 +57,4 @@ Test binaries in the image: `imp-tests` (full GPU), `imp-tests-unit` (CPU), plus
 
 ## PR / merge conventions
 
-Branch off `main`, `gh pr create --base main`, never stack PRs. Batch related fixes into one PR. CI green (`Build`) + auto-merge; GPU validation stays your job locally. If a change intentionally moves perf, refresh `tests/perf_baseline.json` (see `benchmark-cuda` skill → Publishing numbers) and say so in the PR.
+Branch off `main`, `gh pr create --base main`, never stack PRs, batch related fixes. CI green (`Build`, no GPU runner) + auto-merge; GPU validation stays your job locally (`make verify-fast`). If a change intentionally moves perf, refresh `tests/perf_baseline.json` (see `benchmark-cuda` → Publishing numbers) and say so in the PR. For the full ship/merge/release flow — the **auto-merge race** (pushing after arming auto-merge can drop your last commit), the `Build`-ruleset `BLOCKED` gotcha, and version-bump + CHANGELOG + tag steps — use **`shipping-prs`**.

--- a/.claude/skills/shipping-prs/SKILL.md
+++ b/.claude/skills/shipping-prs/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: shipping-prs
+description: Use when opening, merging, or releasing a PR for imp — branching off main, `gh pr create`, enabling auto-merge, cutting a tagged release (version bump + CHANGELOG + tag). Symptoms — "PR stuck BLOCKED", "my last commit didn't land on main", "which check is required", "how do I cut a release", "auto-merge merged too early". Do NOT use for build/test mechanics (building-and-testing) or perf measurement / baseline refresh (benchmark-cuda).
+---
+
+# Shipping PRs & Releases — imp
+
+## Hard rules (each has cost a recovery PR or lost work)
+
+1. **Always branch off `main`; `gh pr create --base main`. NEVER stack PRs.** Squash-merge + stacking caused recovery-PR cascades. Branch from fresh `main` every time. Prefer fewer, **batched** PRs over one-per-fix.
+2. **English only in the repo.** PR title + body, commits, code comments, docs, `.md` files — all English. (Chat to the user stays German; this rule is only for what lands on GitHub.)
+3. **`main` merges are SQUASH** (each PR → one commit `… (#NNN)`). Write the PR title to be the final squash-commit subject.
+4. **The required GitHub check is named exactly `Build`** (branch ruleset id `14716423`, "Require CI"). If a CI job is renamed without updating the ruleset, every PR hangs at `mergeStateStatus=BLOCKED`. CI has **no GPU runner** — `Build` only compiles + runs CPU/mock tests. GPU correctness/perf is **your job locally** (`make verify-fast` before push).
+5. **Perf-moving change → refresh the baseline IN THE SAME PR and say so.** Regen `tests/perf_baseline.json` via `scripts/gen_perf_baseline.sh` (see `benchmark-cuda`), and state the intended delta in the PR body. CI gate is 3% decode / 5% prefill.
+
+## The auto-merge race (this lost commit `a5403bd5` in #718 — read it)
+
+**Auto-merge squashes the PR the instant `Build` goes green.** If you enable auto-merge and then push another commit, the merge can fire on the OLD head and your later push never lands on `main`.
+
+- Push **ALL** commits FIRST. Enable `gh pr merge --auto --squash` **last**.
+- After it merges, **verify** the squash on `main` actually contains your final work:
+  `git log -1 --stat origin/main` (or diff the merged SHA against your branch head). Don't assume.
+- **Never try to "beat" the race by pushing fast** — if `Build` goes green mid-push, you lose. Disable first.
+
+**Need another commit while auto-merge is already armed** (the common case — do this in order):
+
+```bash
+gh pr merge --disable-auto <PR#|branch|url>   # FIRST, before you even write the code — it can fire any second
+# … add the change; verify GPU locally …
+make verify-fast
+git commit -am "…"   &&   git push            # land everything on the remote
+gh pr merge --auto --squash                    # re-arm LAST
+git log -1 --stat origin/main                  # after merge: confirm your new commit is in the squash
+```
+
+## Ship sequence
+
+```bash
+git switch main && git pull --ff-only          # always start from fresh main
+git switch -c <topic-branch>                   # never reuse / stack
+# … work; verify GPU locally …
+make verify-fast                               # ~90s pre-push gate (build + filtered tests + perf + smoke)
+git push -u origin <topic-branch>              # push EVERYTHING you intend to ship
+gh pr create --base main --title "<squash subject>" --body "<what + why + perf note>"
+# wait for `Build` to be the green required check, then:
+gh pr merge --auto --squash
+# after merge:
+git log -1 --stat origin/main                  # confirm your final commit is in the squash
+```
+
+### `mergeStateStatus=BLOCKED` — triage before assuming
+
+Don't guess. Dump the real state first:
+
+```bash
+gh pr view <PR> --json mergeStateStatus,statusCheckRollup,reviewDecision
+```
+
+- **`Build` shows green but is not registering as satisfied** → the required-check name ≠ `Build` (hard rule 4). This is the imp-specific gotcha and the usual culprit, but confirm it's actually the only required check.
+- `reviewDecision` not `APPROVED`, or an unresolved review thread → needs review action.
+- Branch out-of-date with `main` → `git pull --no-rebase origin main` (or update via the PR), push.
+- A *different* required status (not `Build`) still pending → wait for it.
+
+## Cutting a tagged release (only when explicitly releasing)
+
+Single source of truth for the version is **`CMakeLists.txt`** `project(imp … VERSION X.Y.Z)`. A release is its own PR:
+
+1. Bump `project(... VERSION X.Y.Z)` in `CMakeLists.txt`.
+2. `CHANGELOG.md`: rename the `## [Unreleased]` section to `## [X.Y.Z] - YYYY-MM-DD` (Keep-a-Changelog format; Added / Changed / Fixed). Leave a fresh empty `[Unreleased]`.
+3. `BENCHMARKS.md`: update the "current: **vX.Y.Z**" line — tagged releases snapshot a SHA, so published numbers must name the release they were taken on.
+4. Merge that PR (squash) as usual, then tag the merged commit on `main`: `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`. Tags are `vX.Y.Z` (current: `v0.11.2`).
+
+## Common mistakes → fix
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Last commit missing from `main` | Pushed after enabling auto-merge | Push all first, enable auto-merge last, verify the squash |
+| PR stuck `BLOCKED`, `Build` green | Required-check name ≠ `Build` | Realign CI job name or ruleset 14716423 |
+| Recovery-PR cascade | Stacked PRs on a squash repo | One branch per PR, always off fresh `main` |
+| Perf gate red in CI | Intentional perf change, stale baseline | Refresh `perf_baseline.json` in the same PR + note it |
+| German in PR/commit/docs | Global German default leaked into repo | English only in the repo |
+
+## Red flags — STOP
+
+- About to `gh pr merge --auto` but you still have unpushed/uncommitted work → **push first**.
+- Branched off a feature branch instead of `main` → start over off `main`.
+- Releasing but only bumped one of {CMakeLists VERSION, CHANGELOG, BENCHMARKS} → bump all three.


### PR DESCRIPTION
Adds a `shipping-prs` skill that captures imp's PR/merge/release mechanics in one place, so the auto-merge and required-check gotchas stop being relearned per session.

## What
- **New skill** `.claude/skills/shipping-prs/SKILL.md` — branch-off-main + no-stacking rule, the **auto-merge race** (pushing after arming `--auto` can drop the last commit; cost `a5403bd5` in #718), the `Build` required-check / ruleset-`14716423` `BLOCKED` triage, and the version-bump + CHANGELOG + tag release flow.
- **README** registers the skill in the index + boundaries table.
- **building-and-testing** cross-references it from its PR/merge section.

## Why
The merge/release pitfalls (auto-merge race, renamed-check BLOCKED) have each cost a recovery PR or lost commit. Concentrating them in a dedicated skill with clear boundaries vs `building-and-testing` (build/test mechanics) keeps the trigger surface clean.

Docs-only change under `.claude/skills/` — no `src/include/tools/tests` touched, so no perf-baseline or GPU impact.