### PR TITLE
fix(docker): pass leading-flag args (--help, --version) to imp-server

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,13 @@ set -e
 # Translate environment variables to imp-server CLI flags.
 # Usage: docker run ... -e IMP_MODEL=/models/model.gguf imp:latest
 
+# If the first argument is a flag (e.g. --help, --model, --version), it is meant
+# for the default command, not a command name. Prepend imp-server so the flag
+# reaches the real binary instead of being exec'd as a command.
+if [ "${1#-}" != "$1" ]; then
+    set -- imp-server "$@"
+fi
+
 CMD="$1"
 shift 2>/dev/null || true
 


### PR DESCRIPTION
## What

`docker run ghcr.io/kekzl/imp:latest --help` printed the **bash `exec` builtin's** help (`exec [-cl] [-a name] ...`) instead of imp-server's flags.

## Why

The entrypoint set `CMD="$1"`, so a leading flag like `--help` became the "command". It didn't match `imp-server|imp-cli`, so it fell through to the passthrough branch `exec "$CMD" "$@"` → literally `exec --help` → the shell builtin ate the flag.

## Fix

Adopt the standard official-image pattern: if the first argument starts with `-`, it's a flag for the default command, so prepend `imp-server` before dispatch.

Verified by simulating the dispatch logic:

| `docker run imp:latest …` | before | after |
|---|---|---|
| `--help` / `--version` | `exec --help` → bash builtin help | → `imp-server --help` ✅ |
| `imp-cli -m x` | unchanged | unchanged ✅ |
| `bash` / `sh` | passthrough | passthrough ✅ |
| no args | imp-server | imp-server ✅ |

Empty `$1` is untouched (`${1#-}` == `$1`), so the no-args default still works.

No code/perf impact — shell-only change to `docker-entrypoint.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)