### PR TITLE
docs(sm120): mark multi-request batching as shipped (v0.12.0)

### DIFF
--- a/docs/sm120.md
+++ b/docs/sm120.md
@@ -43,6 +43,7 @@ The `f` family-feature suffix (`compute_120f`) enables FP8 MMA `kind::f8f6f4` an
 | CUTLASS NVFP4 prefill cache for prequant SafeTensors (PR #88) | `executor_pre_dequant.cu` | Qwen3-Coder-30B NVFP4 decode 51 → 272 tok/s |
 | NVFP4 prequant MoE decode fast-path (PR #85) | `cache_moe_native_nvfp4` | Qwen3.6 NVFP4 8.34 → 217 tok/s |
 | MoE expert-offload auto-pick (PR #54) | `executor_moe.cu` | Qwen3-Coder-30B Q6_K 77 → 234 tok/s |
+| VRAM-aware auto `max_batch_size` (server continuous batching, PR #736) | `engine_init_resolver.cpp` | Qwen3-Coder-30B NVFP4 server 258 → 609 tok/s @ conc16 (~2.4×) |
 
 ## Why batch=1 decode is memory-bound
 
@@ -67,7 +68,7 @@ What actually helps decode:
 
 1. **Smaller KV cache** (INT4, NVFP4, MXFP4) — bandwidth reduction is bandwidth gained.
 2. **GPU clock boost** — RTX 5090 boosts to ~2,445 MHz under load (max 3,090 MHz).
-3. **Batch > 1** — multiple sequences share weight loads, raising arithmetic intensity. imp's current decode tuning targets bs=1; multi-request batching is open work.
+3. **Batch > 1** — multiple sequences share weight loads, raising arithmetic intensity. Shipped for serving in v0.12.0 (PR #736): imp-server auto-sizes `max_batch_size` to free-VRAM headroom, so concurrent requests share a paged KV pool (continuous batching) instead of being serialized — Qwen3-Coder-30B NVFP4 cap 1 → 15, ~2.4× aggregate server throughput. `imp-cli` / `--bench` stay bs=1 (single-stream), so the perf baseline is unchanged.
 
 ## NVFP4 prequant pipeline
 


### PR DESCRIPTION
`docs/sm120.md` still listed multi-request batching as **open work** and bs=1 as the current decode tuning. v0.12.0 (PR #736) shipped VRAM-aware auto `max_batch_size` — server continuous batching, ~2.4× MoE throughput.

- "What actually helps decode" → point 3 now says batching is shipped for serving (auto-sized to free-VRAM headroom; `imp-cli`/`--bench` stay bs=1, baseline unchanged).
- "What moved the needle" → added a row: Qwen3-Coder-30B NVFP4 server 258 → 609 tok/s @ conc16 (~2.4×, PR #736).

Docs-only; numbers anchored to PR #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)