### PR TITLE
docs(models): validate Qwable-3.6-27B (Qwen3.6-27B dense GDN)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -30,6 +30,7 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Qwen3.5-4B](https://huggingface.co/unsloth/Qwen3.5-4B-GGUF) | Q8_0 | 4.2 GB | 222 | GGUF |
 | [Qwen3.5-9B](https://huggingface.co/unsloth/Qwen3.5-9B-GGUF) | Q8_0 | 8.9 GB | 142 | GGUF |
 | [Qwen3.5-27B](https://huggingface.co/unsloth/Qwen3.5-27B-GGUF) | Q4_K_M | 16 GB | — | GGUF |
+| [Qwable-3.6-27B](https://huggingface.co/Mia-AiLab/Qwable-3.6-27b) | Q4_K_M | 16 GB | ~18 | GGUF, validated dense-GDN 27B (Qwen3.6-27B fine-tune, 64 layers: 16 attn + 48 GDN). ~29 GB resident (Q4_K + NVFP4 decode cache + GDN state) → relies on the auto KV clamp to serve. Heavy trace-reasoner: give it generous `max_tokens`. |
 | Qwen3.5-27B | MXFP4 | — | — | Loads OOM on 32 GB — see [roadmap](roadmap.md) |
 
 ## Mixture-of-Experts


### PR DESCRIPTION
Brought up **Mia-AiLab/Qwable-3.6-27b** (GGUF Q4_K_M, a Qwen3.6-27B dense-GDN fine-tune) end-to-end. **Zero code change** — the architecture was already supported.

## Findings
- `general.architecture = qwen35` → already maps to `ModelArch::QWEN35` (`model.cpp:199`). No loader/arch work needed.
- 64-layer dense GDN hybrid (16 attention + 48 GDN/SSM layers, 0 MoE) loads clean — no NaN/IMA, GDN CUDA graphs on, NVFP4 decode mode 2 (recurrent projections kept FP16).
- **Coherent** trace-style reasoning; thinking ↔ `reasoning_content` cleanly separated (degen think-leak: all pass); multi-turn GDN state stable (no collapse).
- Decode **~18 tok/s** (Q4_K, 27B GDN). **~29 GB resident** (Q4_K weights + NVFP4 decode cache + GDN state) → it only serves because the **v0.12.0 auto KV clamp** bounds the pool (nice real-world confirmation of that fix).
- degen_suite **31/33** — the 2 "fails" (extraction/needle) are this heavy trace-reasoner exhausting the suite's small `max_tokens`; verified it answers correctly with generous budget (e.g. extraction → reasoning 448 chars then `content="7391"`, finish=stop). Determinism skipped (Qwen3.6 non-deterministic at temp=0).

Docs-only: one row in `docs/supported-models.md` with the perf + VRAM caveat + "give it generous max_tokens" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)