### PR TITLE
perf(decode): batched-M NVFP4 LM head for batch>1 decode (lm_head #2 → 2.5×)

### DIFF
--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -737,8 +737,11 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             dispatch_gemv_fp32(out_qtype, model_->output_proj().data, q8, qscratch_.d8_buf,
                                static_cast<float*>(lg.data), cfg.vocab_size, cfg.d_model, stream);
         } else if (n > 1 && lm_is_nvfp4) {
-            // Per-row NVFP4 GEMV LM head for batched decode.
-            // NVFP4 GEMV is M=1 only — loop over rows.
+            // Batched-M NVFP4 GEMV LM head for batched decode. The old code looped
+            // a single M=1 GEMV per sequence, re-reading the whole ~389 MiB LM-head
+            // matrix from HBM once per row (it does not fit in L2) — the #2 decode
+            // GPU consumer at batch>1. gemv_nvfp4_kpar_batched_fp32 reads the weight
+            // ONCE and reuses it across all rows.
             NvFP4QuantResult nvfp4_lm_r;
             if (lm_nvfp4_secondary) {
                 nvfp4_lm_r = lm_nvfp4_it->second;
@@ -751,14 +754,10 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 nvfp4_lm_r.N = cfg.vocab_size;
                 nvfp4_lm_r.K = cfg.d_model;
             }
-            Tensor no_row = view_tokens(norm_out_, 1);
-            for (int row = 0; row < n; ++row) {
-                Tensor h_row = h_final.slice(row, row + 1);
-                Tensor lg_row = lg.slice(row, row + 1);
-                rmsnorm(h_row, model_->output_norm(), no_row, cfg.rms_norm_eps, stream, norm_w_off_);
-                gemv_nvfp4_kpar_fp32(nvfp4_lm_r, static_cast<const half*>(no_row.data),
-                                     static_cast<float*>(lg_row.data), cfg.vocab_size, cfg.d_model, stream);
-            }
+            Tensor no_final = view_tokens(norm_out_, n);
+            rmsnorm(h_final, model_->output_norm(), no_final, cfg.rms_norm_eps, stream, norm_w_off_);
+            gemv_nvfp4_kpar_batched_fp32(nvfp4_lm_r, static_cast<const half*>(no_final.data),
+                                         static_cast<float*>(lg.data), cfg.vocab_size, cfg.d_model, n, stream);
         } else if (use_dp4a_lm && n > 1) {
             // Per-row Q8_1 GEMV LM head for batched decode.
             // Quantized weights (Q8_0/Q6_K) can't be passed to cuBLAS directly.

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -233,6 +233,81 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_nvfp4_kpar_fp32_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// Batched-M K-parallel GEMV (FP32 out): y[m, n] = A_nvfp4[n,:] @ x[m,:] for the
+// MR activation rows m in this launch. One block per output (vocab) row n; the
+// weight row is loaded ONCE and reused across all MR activation rows (x[m]
+// streams from L2). This removes the per-sequence weight re-read of the batched
+// decode LM head — a single M=1 GEMV per sequence re-read the whole ~389 MiB
+// LM-head matrix from HBM (it does not fit in L2), making it the #2 decode GPU
+// consumer at batch>1. x is [n_act, K] row-major, y is [n_act, N_out] row-major;
+// the caller offsets x/y to this launch's first row.
+// ---------------------------------------------------------------------------
+template <int MR>
+__global__ void __launch_bounds__(kKparThreads) gemv_nvfp4_kpar_mb_fp32_kernel(
+    const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
+    const half* __restrict__ x, float* __restrict__ y, int N_out, int K) {
+    const int n = blockIdx.x;
+    if (n >= N_out)
+        return;
+    const int tid = threadIdx.x;
+    const int n_mb = K / kMicroBlockSize;
+    const uint8_t* row_packed = packed_data + (int64_t)n * (K / 2);
+    const uint8_t* row_ms = micro_scales + (int64_t)n * n_mb;
+
+    float acc[MR];
+#pragma unroll
+    for (int m = 0; m < MR; ++m)
+        acc[m] = 0.0f;
+
+    for (int mi = tid; mi < n_mb; mi += kKparThreads) {
+        int byte_off = mi * 8;
+        uint2 packed2 = *reinterpret_cast<const uint2*>(row_packed + byte_off);  // weight read once
+        const uint8_t* pb = reinterpret_cast<const uint8_t*>(&packed2);
+        // Decode the 16 FP4 weights ONCE and reuse across all MR activation rows
+        // (the old per-row path re-decoded the weight byte per row — 16x cvt).
+        float wf[16];
+#pragma unroll
+        for (int b = 0; b < 8; ++b) {
+            uint32_t w_fp16x2;
+            asm("{ .reg .b8 t; cvt.u8.u32 t, %1; cvt.rn.f16x2.e2m1x2 %0, t; }"
+                : "=r"(w_fp16x2)
+                : "r"(static_cast<uint32_t>(pb[b])));
+            float2 wf2 = __half22float2(*reinterpret_cast<const half2*>(&w_fp16x2));
+            wf[b * 2] = wf2.x;
+            wf[b * 2 + 1] = wf2.y;
+        }
+        float cs = tensor_scale * fp8_e4m3_to_float_fast(row_ms[mi]);
+        const int elem_base = byte_off * 2;
+#pragma unroll
+        for (int m = 0; m < MR; ++m) {
+            const half* xm = x + (int64_t)m * K + elem_base;
+            const uint4 xv0 = *reinterpret_cast<const uint4*>(xm);
+            const uint4 xv1 = *reinterpret_cast<const uint4*>(xm + 8);
+            half2 xh[8];
+            *reinterpret_cast<uint4*>(&xh[0]) = xv0;
+            *reinterpret_cast<uint4*>(&xh[4]) = xv1;
+            float d = 0.0f;
+#pragma unroll
+            for (int b = 0; b < 8; ++b) {
+                float2 xf = __half22float2(xh[b]);
+                d = __fmaf_rn(wf[b * 2], xf.x, d);
+                d = __fmaf_rn(wf[b * 2 + 1], xf.y, d);
+            }
+            acc[m] = __fmaf_rn(d, cs, acc[m]);
+        }
+    }
+
+    __shared__ float warp_sums[kKparWarps];
+#pragma unroll
+    for (int m = 0; m < MR; ++m) {
+        float total = reduce_kpar(acc[m], tid, warp_sums);
+        if (tid == 0)
+            y[(int64_t)m * N_out + n] = total;
+        __syncthreads();  // reuse warp_sums for the next activation row
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Multi-row GEMV: NR rows per block, 256 threads (8 warps).
 // Each warp handles one row, multiple warps process multiple rows in parallel.
 // Amortizes block launch overhead and improves occupancy for small K.
@@ -772,6 +847,43 @@ void gemv_nvfp4_kpar_fp32(const NvFP4QuantResult& A, const half* x, float* y, in
         pdl::launch(gemv_nvfp4_kpar_fp32_kernel, dim3(M), dim3(kKparThreads), size_t(0), stream,
                     reinterpret_cast<const uint8_t*>(A.packed_data),
                     reinterpret_cast<const uint8_t*>(A.micro_scales), A.tensor_scale, x, y, M, K);
+    }
+}
+
+// Batched-M FP32 GEMV for the LM head at batch>1: y[n_act, N_out] = x[n_act,K] @ A^T.
+// Reads the weight matrix ONCE per launch (vs once per activation row in the old
+// per-row M=1 loop). n_act is processed in power-of-two MR chunks so each launch
+// reuses the weight across MR rows; typical decode batches (<=16) need one launch.
+void gemv_nvfp4_kpar_batched_fp32(const NvFP4QuantResult& A, const half* x, float* y, int N_out, int K,
+                                  int n_act, cudaStream_t stream) {
+    const auto* pd = reinterpret_cast<const uint8_t*>(A.packed_data);
+    const auto* ms = reinterpret_cast<const uint8_t*>(A.micro_scales);
+    const float ts = A.tensor_scale;
+    // MR is capped at 4: each accumulator row costs registers, and beyond MR=4
+    // the kernel spills (measured: 91 us/row at MR=4 vs 118 us/row at MR=16). For
+    // M>4 the weight is re-read per MR=4 tile, but the tiled cost still beats the
+    // larger-MR spill (M=16: 4x MR=4 = 1.45 ms < 1x MR=16 = 1.89 ms) and the old
+    // per-row loop (16x M=1 = 4.2 ms).
+    int done = 0;
+    while (done < n_act) {
+        const int rem = n_act - done;
+        const half* xm = x + (int64_t)done * K;
+        float* ym = y + (int64_t)done * N_out;
+        int used;
+        if (rem >= 4) {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp32_kernel<4>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 4;
+        } else if (rem >= 2) {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp32_kernel<2>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 2;
+        } else {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp32_kernel<1>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 1;
+        }
+        done += used;
     }
 }
 

--- a/src/quant/nvfp4_gemm.h
+++ b/src/quant/nvfp4_gemm.h
@@ -33,6 +33,11 @@ void gemv_nvfp4_kpar(const NvFP4QuantResult& A, const half* x, half* y, int M, i
 void gemv_nvfp4_kpar_fp32(const NvFP4QuantResult& A, const half* x, float* y, int M, int K,
                           cudaStream_t stream);
 
+// Batched-M FP32 GEMV (LM head at batch>1): y[n_act, N_out] computed in one weight
+// pass per launch. x is [n_act, K] row-major, y is [n_act, N_out] row-major.
+void gemv_nvfp4_kpar_batched_fp32(const NvFP4QuantResult& A, const half* x, float* y, int N_out, int K,
+                                  int n_act, cudaStream_t stream);
+
 // Fused QKV: 3 weight matrices, shared input, separate outputs
 void gemv_nvfp4_qkv_fused(const NvFP4QuantResult& wq, const NvFP4QuantResult& wk, const NvFP4QuantResult& wv,
                           const half* x, half* yq, half* yk, half* yv, int q_rows, int k_rows, int v_rows,


### PR DESCRIPTION
## What

After the multi-block sampler (#745), profiling batched server decode (Qwen3-14B-NVFP4, 16 concurrent, nsys graphs-off) showed the **NVFP4 LM head was the #2 decode GPU consumer at ~18%**. The `n>1` path in `executor_forward.cu` looped a single **M=1 GEMV per sequence** — each call re-reads the whole **~389 MiB** LM-head matrix from HBM (it does not fit in the 96 MiB L2), so batch=16 read it **16× (~6.2 GB) per step** (~4.2 ms).

This adds `gemv_nvfp4_kpar_batched_fp32`: one block per output (vocab) row, the **weight row loaded once and reused across MR activation rows** (activations stream from L2; each weight micro-block is FP4-decoded once, not once per row). `MR` is capped at **4** — measured **91 µs/row at MR=4 vs 118 µs/row at MR=16**, where the per-row accumulators spill registers; `n_act` is tiled in `MR={4,2,1}` chunks. The math matches the per-row GEMV exactly (same accumulation order) → **bit-identical logits, no quality change**.

## Results (RTX 5090, Qwen3-14B-NVFP4, 16 concurrent, nsys graphs-off)

| | Before | After |
|---|---|---|
| LM head decode GPU-time share | ~17.9% | **~7.1%** (2.5×) |
| LM head per decode step | ~4.2 ms | **~1.5 ms** |

Single-stream (`n==1`) decode is **untouched** — still the M=1 kpar GEMV decode-cache path, so the #465 single-stream win and the perf-baseline gate are unaffected.

The full 16× weight-reuse would need a tensor-core GEMM (CUTLASS layout + activation quant) — out of scope here; the register-bound batched GEMV captures the bulk of the win at **zero extra VRAM**.

## Validation

- `degen_suite.py` **33/0** against a live concurrent server (real temperature sampling + multi-turn + long-context + thinking)
- `DegenerationTest` 5/5
- Distinct concurrent prompts return correct distinct answers (planets vs capital-of-France) — no cross-sequence contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)