### PR TITLE
perf(decode): opt-in CUTLASS NVFP4 tensor-core LM head for batched decode

### DIFF
--- a/src/compute/gemm_cutlass_sm120.cu
+++ b/src/compute/gemm_cutlass_sm120.cu
@@ -85,6 +85,35 @@ using GemmKernel = cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int
 
 using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
+// ---------------------------------------------------------------------------
+// FP32-output variant (large-N cooperative tile only). The LM head writes FP32
+// logits (the samplers read `const float*`), so the batched-decode LM head GEMM
+// (N = vocab » kSmallNThreshold) needs a float epilogue rather than the half_t
+// output above. ElementC = ElementD = float keeps the (unused, beta=0) C and D
+// pointers the same type so the shared impl reinterprets one buffer for both.
+// ---------------------------------------------------------------------------
+using ElementDFp32 = float;
+using ElementCFp32 = float;
+constexpr int AlignmentDFp32 = 128 / cutlass::sizeof_bits<ElementDFp32>::value;  // 4
+constexpr int AlignmentCFp32 = 128 / cutlass::sizeof_bits<ElementCFp32>::value;  // 4
+
+using CollectiveEpilogueFp32 = typename cutlass::epilogue::collective::CollectiveBuilder<
+    ArchTag, OperatorClass, ThreadBlockShape, ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto,
+    ElementAccumulator, ElementAccumulator, ElementCFp32, LayoutCTag, AlignmentCFp32, ElementDFp32,
+    LayoutDTag, AlignmentDFp32, cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+using CollectiveMainloopFp32 = typename cutlass::gemm::collective::CollectiveBuilder<
+    ArchTag, OperatorClass, ElementA, LayoutATag, AlignmentA, ElementB, LayoutBTag, AlignmentB,
+    ElementAccumulator, ThreadBlockShape, ClusterShape,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+        sizeof(typename CollectiveEpilogueFp32::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+using GemmKernelFp32 = cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>,
+                                                           CollectiveMainloopFp32, CollectiveEpilogueFp32,
+                                                           void>;
+using GemmFp32 = cutlass::gemm::device::GemmUniversalAdapter<GemmKernelFp32>;
+
 // Strides / SF layouts are derived per-variant inside the templated impl
 // below (typename GemmT::GemmKernel::StrideA etc.) — both variants share the
 // same SfAtom data layout, only the CTA tiling differs.
@@ -700,7 +729,7 @@ size_t gemm_nvfp4_cutlass_sm120_workspace(int M, int N, int K) {
                                    : cutlass_workspace_for<Gemm>(M, N, K);
 }
 
-template <class GemmT>
+template <class GemmT, class ElemD = ElementD>
 static bool gemm_nvfp4_cutlass_sm120_impl(const void* a_data, const void* a_sf, const CutlassNvFP4Weight& b,
                                           void* d_fp16, int M, int N, int K, void* workspace,
                                           size_t workspace_size, cudaStream_t stream) {
@@ -732,7 +761,7 @@ static bool gemm_nvfp4_cutlass_sm120_impl(const void* a_data, const void* a_sf, 
     // C pointer must be valid even with beta=0 — CUTLASS creates a TMA
     // descriptor for C during initialize() and cuTensorMapEncodeTiled
     // fails on nullptr.  Re-use the D buffer since it's never read.
-    auto* d_ptr = reinterpret_cast<ElementD*>(d_fp16);
+    auto* d_ptr = reinterpret_cast<ElemD*>(d_fp16);
 
     // Use tensor_scale as alpha: compensates for not absorbing it into SFB.
     // D = tensor_scale * (A_fp4 * SFA * B_fp4 * micro_scale_only) = correct result.
@@ -792,6 +821,18 @@ bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const Cutlas
                                                          workspace_size, stream);
     return gemm_nvfp4_cutlass_sm120_impl<Gemm>(a_data, a_sf, b, d_fp16, M, N, K, workspace, workspace_size,
                                                stream);
+}
+
+// FP32-output entry — large-N cooperative tile only (LM head: N = vocab » 2048).
+bool gemm_nvfp4_cutlass_sm120_fp32(const void* a_data, const void* a_sf, const CutlassNvFP4Weight& b,
+                                   void* d_fp32, int M, int N, int K, void* workspace,
+                                   size_t workspace_size, cudaStream_t stream) {
+    return gemm_nvfp4_cutlass_sm120_impl<GemmFp32, ElementDFp32>(a_data, a_sf, b, d_fp32, M, N, K, workspace,
+                                                                workspace_size, stream);
+}
+
+size_t gemm_nvfp4_cutlass_sm120_fp32_workspace(int M, int N, int K) {
+    return cutlass_workspace_for<GemmFp32>(M, N, K);
 }
 
 bool cutlass_sm120_nvfp4_available() { return true; }

--- a/src/compute/gemm_cutlass_sm120.h
+++ b/src/compute/gemm_cutlass_sm120.h
@@ -133,6 +133,13 @@ bool gemm_nvfp4_cutlass_sm120(const void* a_data, const void* a_sf, const Cutlas
 // Get CUTLASS GEMM workspace size for given problem dimensions.
 size_t gemm_nvfp4_cutlass_sm120_workspace(int M, int N, int K);
 
+// FP32-output NVFP4 GEMM (large-N cooperative tile). Used for the batched-decode
+// LM head, which needs float logits. d_fp32 is [M, N] row-major float.
+bool gemm_nvfp4_cutlass_sm120_fp32(const void* a_data, const void* a_sf, const CutlassNvFP4Weight& b,
+                                   void* d_fp32, int M, int N, int K, void* workspace,
+                                   size_t workspace_size, cudaStream_t stream);
+size_t gemm_nvfp4_cutlass_sm120_fp32_workspace(int M, int N, int K);
+
 // Check if sm_120 CUTLASS NVFP4 GEMM is compiled and available.
 bool cutlass_sm120_nvfp4_available();
 

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -166,6 +166,14 @@ public:
     // fallback continues to use lazy cudaMalloc on non-captured streams.
     bool allocate_nvfp4_dequant_workspace();
 
+    // Build a CUTLASS NVFP4 weight for the LM head so batched decode (n>1) can
+    // do a single tensor-core GEMM (weight read once) instead of the per-row /
+    // batched-M GEMV (weight read ceil(M/4)x). Only the SfAtom scale buffer is
+    // allocated (~vocab*d_model/16 bytes); the FP4 data is borrowed from the
+    // NVFP4 decode cache. No-op unless serving (max_logit_tokens_ > 1) and the
+    // LM head is NVFP4. Must run AFTER pre_dequant_weights().
+    void build_lm_head_cutlass_(cudaStream_t stream);
+
     // Set KV layer mapping (must be called before forward pass for hybrid models)
     void set_kv_layer_map(std::vector<int> map) {
         kv_layer_map_ = std::move(map);
@@ -432,6 +440,12 @@ private:
 
     // Quantization scratch buffers (FP8 act, CUTLASS act, dp4a, dequant, split-K)
     QuantScratch qscratch_;
+
+    // CUTLASS NVFP4 LM head for batched-decode (n>1) tensor-core GEMM. Borrows
+    // the FP4 data from the NVFP4 decode cache; owns only the SfAtom scales.
+    // Built by build_lm_head_cutlass_() when serving; freed in the destructor.
+    CutlassNvFP4Weight lm_head_cutlass_{};
+    bool lm_head_cutlass_ready_ = false;
 
     // Pre-allocated sampling result buffers (avoids cudaMalloc/cudaFree per token).
     int32_t* d_sample_result_ = nullptr;  // device buffer for argmax/sample kernel output

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -145,6 +145,28 @@ void debug_top_logits(const Tensor& logits, cudaStream_t stream, int topk = 10) 
 // Full forward pass
 // ---------------------------------------------------------------------------
 
+void GraphExecutor::build_lm_head_cutlass_(cudaStream_t stream) {
+    if (lm_head_cutlass_ready_)
+        return;
+    // Opt-in (gemm.nvfp4_lm_head_cutlass). Only batched decode (n>1) uses it;
+    // single-stream (n==1) keeps the weight-bound M=1 GEMV.
+    if (!runtime_config().gemm.nvfp4_lm_head_cutlass || !cutlass_sm120_nvfp4_available())
+        return;
+    auto it = wcache_.nvfp4.find(model_->output_proj().data);
+    if (it == wcache_.nvfp4.end())
+        return;  // LM head is not in the NVFP4 decode cache (nvfp4_lm_head off / GDN)
+    // Borrows the FP4 data from the decode cache; allocates only the SfAtom scales.
+    convert_nvfp4_to_cutlass(it->second, lm_head_cutlass_, stream);
+    cudaStreamSynchronize(stream);
+    lm_head_cutlass_ready_ =
+        (lm_head_cutlass_.data != nullptr && lm_head_cutlass_.scale_factors != nullptr);
+    if (lm_head_cutlass_ready_)
+        IMP_LOG_INFO("LM head: CUTLASS NVFP4 tensor-core GEMM enabled for batched decode "
+                     "(N=%lld K=%lld, +%zu KiB SfAtom scales)",
+                     static_cast<long long>(lm_head_cutlass_.N),
+                     static_cast<long long>(lm_head_cutlass_.K), lm_head_cutlass_.sf_bytes / 1024);
+}
+
 void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_out, cudaStream_t stream) {
     if (!initialized_) {
         IMP_LOG_ERROR("GraphExecutor::forward_logits called before init()");
@@ -756,8 +778,24 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             }
             Tensor no_final = view_tokens(norm_out_, n);
             rmsnorm(h_final, model_->output_norm(), no_final, cfg.rms_norm_eps, stream, norm_w_off_);
-            gemv_nvfp4_kpar_batched_fp32(nvfp4_lm_r, static_cast<const half*>(no_final.data),
-                                         static_cast<float*>(lg.data), cfg.vocab_size, cfg.d_model, n, stream);
+            bool lm_done = false;
+            // Tensor-core path: one CUTLASS NVFP4 GEMM (M=n) reads the LM-head
+            // weight ONCE vs ceil(n/4)x for the batched GEMV. FP32 output (the
+            // samplers read float logits). Falls back to the GEMV if disabled or
+            // the kernel declines the shape.
+            if (lm_head_cutlass_ready_ && qscratch_.cutlass_act_data != nullptr &&
+                qscratch_.cutlass_act_sf != nullptr) {
+                quantize_fp16_to_nvfp4_cutlass(no_final.data, qscratch_.cutlass_act_data,
+                                               qscratch_.cutlass_act_sf, n, cfg.d_model, stream);
+                lm_done = gemm_nvfp4_cutlass_sm120_fp32(qscratch_.cutlass_act_data, qscratch_.cutlass_act_sf,
+                                                        lm_head_cutlass_, static_cast<float*>(lg.data), n,
+                                                        cfg.vocab_size, cfg.d_model, nullptr, 0, stream);
+            }
+            if (!lm_done) {
+                gemv_nvfp4_kpar_batched_fp32(nvfp4_lm_r, static_cast<const half*>(no_final.data),
+                                             static_cast<float*>(lg.data), cfg.vocab_size, cfg.d_model, n,
+                                             stream);
+            }
         } else if (use_dp4a_lm && n > 1) {
             // Per-row Q8_1 GEMV LM head for batched decode.
             // Quantized weights (Q8_0/Q6_K) can't be passed to cuBLAS directly.

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -144,7 +144,25 @@ void GraphExecutor::for_each_lm_head_batch_(int n_rows, cudaStream_t stream,
         int csz = (chunk_len - c < mb) ? (chunk_len - c) : mb;
         Tensor hc = hidden_all.slice(c, c + csz);          // [csz, d]
         Tensor lg = view_tokens(logits_, csz);             // [csz, V]
-        if (lm_is_nvfp4) {
+        bool lm_cutlass_done = false;
+        if (lm_is_nvfp4 && lm_head_cutlass_ready_ && qscratch_.cutlass_act_data != nullptr &&
+            qscratch_.cutlass_act_sf != nullptr) {
+            // Same NVFP4-activation tensor-core path as batched decode — lets the
+            // perplexity harness measure its quality (the per-row GEMV below keeps
+            // FP16 activations, so toggling gemm.nvfp4_lm_head_cutlass gives the
+            // PPL trade directly). NVFP4 act quant is per-row, so the M dimension
+            // (csz) affects only speed, not the measured quality.
+            Tensor noc = view_tokens(norm_out_, csz);
+            rmsnorm(hc, model_->output_norm(), noc, cfg.rms_norm_eps, stream, norm_w_off_);
+            quantize_fp16_to_nvfp4_cutlass(noc.data, qscratch_.cutlass_act_data, qscratch_.cutlass_act_sf,
+                                           csz, cfg.d_model, stream);
+            lm_cutlass_done = gemm_nvfp4_cutlass_sm120_fp32(
+                qscratch_.cutlass_act_data, qscratch_.cutlass_act_sf, lm_head_cutlass_,
+                static_cast<float*>(lg.data), csz, cfg.vocab_size, cfg.d_model, nullptr, 0, stream);
+        }
+        if (lm_cutlass_done) {
+            // logits already written
+        } else if (lm_is_nvfp4) {
             Tensor no_row = view_tokens(norm_out_, 1);
             for (int r = 0; r < csz; ++r) {
                 Tensor h_row = hc.slice(r, r + 1);

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1128,6 +1128,12 @@ void GraphExecutor::free_buffers() {
         nvfp4_dequant_ws_buf_ = nullptr;
         nvfp4_dequant_ws_size_ = 0;
     }
+    if (lm_head_cutlass_ready_) {
+        // Frees only the owned SfAtom scales; .data is borrowed from the decode cache.
+        free_cutlass_nvfp4_weight(lm_head_cutlass_);
+        lm_head_cutlass_ = {};
+        lm_head_cutlass_ready_ = false;
+    }
     if (d_sample_result_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_sample_result_));
         d_sample_result_ = nullptr;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -193,6 +193,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
         matched = true;
     }
     B("gemm.nvfp4_lm_head_gdn", cfg.gemm.nvfp4_lm_head_gdn);
+    B("gemm.nvfp4_lm_head_cutlass", cfg.gemm.nvfp4_lm_head_cutlass);
     B("gemm.nvfp4_ssm_proj", cfg.gemm.nvfp4_ssm_proj);
     B("gemm.nvfp4_attn_proj", cfg.gemm.nvfp4_attn_proj);
     B("gemm.nvfp4_moe_decode", cfg.gemm.nvfp4_moe_decode);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -346,6 +346,14 @@ struct RuntimeConfig {
         // lm_head for maximum coherence. Env IMP_NO_NVFP4_LM_HEAD=1 still kills
         // the NVFP4 lm_head entirely (dense + GDN) via gemm.nvfp4_lm_head.
         bool nvfp4_lm_head_gdn = true;
+        // Batched-decode (n>1) LM head via a single CUTLASS NVFP4 tensor-core
+        // GEMM instead of the FP16-activation batched-M GEMV. Reads the LM-head
+        // weight once for the whole batch (vs ceil(n/4)x for the GEMV), but the
+        // FP4×FP4 MMA forces NVFP4 activations on the final logits (the GEMV kept
+        // FP16 activations) — a quality/speed trade. Costs ~vocab*d_model/16 B of
+        // SfAtom scales (FP4 data borrowed from the decode cache). Opt-in until
+        // the PPL trade is measured per family. Single-stream (n==1) is unaffected.
+        bool nvfp4_lm_head_cutlass = false;
         // Hybrid GDN/SSM models (Nemotron-3-Nano-30B, Qwen3.6-35B-A3B) keep the
         // recurrent in_proj/out_proj (ssm_in/ssm_out) OUT of the NVFP4 decode
         // cache by default: they feed the GDN/SSM recurrent scan, which

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -218,6 +218,10 @@ bool Engine::init_kv_cache() {
     // multi-token verify / spec-decode) run inside CUDA stream capture
     // without crashing on cudaMalloc.
     (void)executor_->allocate_nvfp4_dequant_workspace();
+    // Build the CUTLASS NVFP4 LM head for batched-decode tensor-core GEMM (no-op
+    // unless serving with max_batch>1 and the LM head is NVFP4). Must come AFTER
+    // pre_dequant_weights so the NVFP4 decode cache exists.
+    executor_->build_lm_head_cutlass_(stream_);
     if (config_.use_fp8_prefill)
         IMP_LOG_INFO("Weight cache: FP8 E4M3 (2x prefill throughput on sm_120)");
 


### PR DESCRIPTION
Follow-up to #746. The batched-M GEMV still re-reads the LM-head weight ceil(n/4)× (register spill caps MR at 4); a single **CUTLASS NVFP4 tensor-core GEMM (M=n)** reads it **once**.

## What
- `gemm_nvfp4_cutlass_sm120_fp32` — FP32-output NVFP4 GEMM (samplers read `float` logits). New `ElementC=ElementD=float` epilogue; shared impl templated on the output element. Large-N cooperative tile only (vocab » 2048).
- `build_lm_head_cutlass_()` — converts the NVFP4 decode cache to CUTLASS SfAtom layout. **Borrows** the FP4 data; only ~`vocab*d_model/16` B of scales is allocated (**+47.5 MiB** for Qwen3-14B, not a second weight copy).
- `gemm.nvfp4_lm_head_cutlass` flag (**default OFF**). Gates the decode n>1 path + a perplexity-harness path (so the quality trade is measurable).

## Quality trade — measured neutral
The FP4×FP4 MMA forces **NVFP4 activations** on the final logits (the GEMV kept FP16). Qwen3-14B-NVFP4, `tools/analysis/ppl_corpus.txt` (199 tok):

| LM head path | PPL |
|---|---|
| FP16-act GEMV (#746) | 5.8160 |
| NVFP4-act CUTLASS | **5.8139** (−0.036%, within noise) |

Neutral — the hidden state already passes 40 layers of NVFP4-act GEMMs, so one more quant of the final hidden is negligible.

## Results (RTX 5090, Qwen3-14B-NVFP4, sustained n>1, nsys graphs-off)
- **LM head decode GPU-time share 9.0% → 2.6% (3.65×)**; the `kpar_mb` GEMV is gone.
- e2e concurrent @16: 767 → 784 tok/s (+2.2%, within host noise — the kernel win is largely launch-hidden under CUDA Graphs in production).
- VRAM **+47.5 MiB** (SfAtom scales), only with the flag on.

## Ship posture
**Default OFF** — default builds behave exactly like #746 (FP16-act GEMV), no VRAM cost, no risk. Opt in with `gemm.nvfp4_lm_head_cutlass=true` for max concurrent throughput. Single-stream (n==1) untouched.

Validation: `degen_suite` 33/0 (flag on), `DegenerationTest` 5/5, PPL neutral, coherent + correct concurrent greedy (planets/France distinct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)