### PR TITLE
fix(server): think_budget=0 now disables thinking (#752)

### DIFF
--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1043,9 +1043,17 @@ static bool snapshot_state_and_tokenize_(
     const bool want_thinking = ctx.params.enable_thinking_set
                                    ? ctx.params.enable_thinking_requested
                                    : thinking_default;
+    // think_budget is the fraction of max_tokens reserved for reasoning;
+    // think_budget <= 0 means "no reasoning headroom" → disable thinking entirely
+    // (documented "0 = disabled"). Folding it into enable_thinking keeps the two
+    // flags consistent: without this, budget=0 left thinking ON yet never armed
+    // the force-close, so the model reasoned to max_tokens and returned empty
+    // content (#752). The Anthropic "disabled" path already zeroes the budget.
+    const bool budget_disables_thinking = ctx.params.think_budget <= 0.0f;
     ctx.snap.enable_thinking = ctx.snap.is_think_model && ctx.snap.think_start_id >= 0 &&
-                               want_thinking;
-    ctx.snap.suppress_thinking = ctx.snap.is_think_model && !ctx.snap.enable_thinking && ctx.params.think_budget <= 0.0f;
+                               want_thinking && !budget_disables_thinking;
+    ctx.snap.suppress_thinking =
+        ctx.snap.is_think_model && !ctx.snap.enable_thinking && budget_disables_thinking;
 
     // If thinking IS enabled, remove the provisional <think> stop token.
     if (ctx.snap.enable_thinking && ctx.snap.think_start_id >= 0) {


### PR DESCRIPTION
**#752**: `think_budget` is documented "0 = disabled" but did the opposite — budget=0 left `enable_thinking` on (its default) and never armed the force-close, so think-capable models reasoned to `max_tokens` and returned **empty `content`** (`finish_reason=length`). Server-wide `--think-budget 0` silently emptied every plain-chat answer.

## Fix
Fold `think_budget <= 0` into the `enable_thinking` computation (handlers.cpp) so the flags stay consistent: budget≤0 → `enable_thinking=false` → `suppress_thinking=true` (injects `/no_think`), matching the documented "0 = disabled" and the existing `enable_thinking:false` path. Default (`budget=0.5`) and the Anthropic `{"type":"disabled"}` path (already zeroes the budget) are unchanged.

## Verified (Qwen3-14B-Q6_K, "What is 2+2?", max_tokens=300, temp=0)
| Setting | reasoning_content | content | finish |
|---|---|---|---|
| `think_budget:0` | **0 chars** | **"2 + 2 equals **4**."** ✅ | stop |
| default | 600 chars | "...2 + 2 = 4" (unchanged) | stop |

degen_suite **33/0**.

Closes #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)