### PR TITLE
fix(schema): cap digit run in json_schema numbers (#751)

### DIFF
--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -294,8 +294,19 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
         case SchemaPhase::STRING_ESCAPE:
             return 0xFFFF;  // any char valid after backslash
 
-        case SchemaPhase::NUMBER_VALUE:
-            return CAT_NUMBER_CONT | CAT_COMMA | CAT_CLOSE_BRACE | CAT_CLOSE_BRACKET;
+        case SchemaPhase::NUMBER_VALUE: {
+            uint16_t m = CAT_COMMA | CAT_CLOSE_BRACE | CAT_CLOSE_BRACKET;
+            // Cap the digit run so a model that degenerates into a digit loop
+            // (e.g. "age":42000000…) can't run an unbounded number to max_tokens
+            // and leave the JSON unterminated (#751). f.string_len counts digits;
+            // once it hits the cap, drop continue-number so the number must close
+            // — the result is a valid (if large) JSON number, not a runaway. The
+            // cap (40) is far beyond any real int64 (≤19) / double (~17 sig) value.
+            constexpr int kMaxNumberDigits = 40;
+            if (f.string_len < kMaxNumberDigits)
+                m |= CAT_NUMBER_CONT;
+            return m;
+        }
 
         case SchemaPhase::LITERAL_VALUE:
             return CAT_LITERAL_CONT;

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -770,6 +770,35 @@ TEST(SchemaConstrainTest, IntegerLeadingZeroRejected) {
     EXPECT_TRUE(a[9]) << "'}' must be allowed to close the number/object";
 }
 
+// #751: an unbounded integer/number must not run digits forever — once the digit
+// run hits the cap the continue-number category is dropped, forcing the number to
+// close (valid, terminated JSON instead of a runaway to max_tokens).
+TEST(SchemaConstrainTest, IntegerDigitRunCappedForcesClose) {
+    SKIP_IF_NO_CUDA();
+    //                                 0       1      2      3    4    5    6    7    8    9
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "n", ":", "1", "0", "}"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"n":{"type":"integer"}},"required":["n"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    for (int t : {3, 4, 5, 4, 6, 7})  // { "n" : 1  -> NUMBER_VALUE, digit_count=1
+        sc.update(t);
+    // Below the cap (after a handful of digits) more digits are still allowed.
+    sc.update(8);  // "0" -> digit_count=2
+    auto below = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(below[8]) << "digit must be allowed well below the cap";
+    // Drive the digit run to the cap (kMaxNumberDigits=40); digit_count is now 2.
+    for (int i = 0; i < 38; i++)
+        sc.update(8);  // -> digit_count=40
+    auto capped = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_FALSE(capped[8]) << "digit must be masked once the digit-run cap is hit";
+    EXPECT_TRUE(capped[9]) << "'}' must be allowed to close the capped number";
+}
+
 // A combined value token must be validated against an enum/integer constraint,
 // not just its opening quote/digit category.
 TEST(SchemaConstrainTest, EnumAndIntegerComboTokensValidated) {


### PR DESCRIPTION
**#751**: `response_format: json_schema` with an unbounded `integer`/`number` field could return **invalid, unterminated JSON** — a degeneration-prone model emits the correct leading digits then a runaway of `0`s that never closes, running to `max_tokens` (`finish_reason=length`). The `NUMBER_VALUE` mask permanently offered continue-number, so nothing forced termination, violating the documented exact-JSON guarantee.

## Fix
`compute_category_mask()` drops `CAT_NUMBER_CONT` once the digit run hits a cap (**40** — far beyond any real int64 ≤19 / double ~17-sig value), leaving only comma/close so the number must terminate. The FSM already tracks the digit count in `f.string_len`, so this is a **mask-only** change; legitimate numbers are untouched.

Bounding the value to the schema's `maximum` is a stronger, separate enhancement; this PR restores the **termination** guarantee, which is the reported bug.

## Verified (Qwen3-4B-Instruct-2507-Q8_0, integer field no max, temp 0)
| | result |
|---|---|
| before | `{"name":"Bob","age":42000…` → runs to max_tokens, **never closes** |
| after | `{"name":"Bob","age":4200…000}` → `finish_reason=stop`, **VALID JSON** ✅ |

Unit test `SchemaConstrainTest.IntegerDigitRunCappedForcesClose` locks it (CI-catchable). Stronger models already returned `{"age":42}` — the cap only engages on degeneration and always yields valid JSON.

Closes #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)