### PR TITLE
fix(server): real per-token SSE + terminate hung streams (#754, #755, #757)

### DIFF
--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1548,7 +1548,16 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
                                                        : spec_effective_miss_burst_(*dreq);
                 if (spec_limit < 0) spec_limit = 0;
             }
-            try_launch_async_graph_loop(dreq, last_token, dec_stream, spec_limit);
+            // #754: an UNBOUNDED loop (spec_limit == 0) generates the whole
+            // remaining sequence on-device and only surfaces its tokens to the
+            // host when the burst finishes — for a streaming request that means
+            // every token lands in the client at generation end (TTFT == full
+            // latency). Keep streaming requests on per-step decode so SSE is
+            // real per-token. Bounded (speculation) bursts still stream in
+            // groups via the per-burst sync, so they stay enabled.
+            const bool stream_unbounded = dreq->stream && spec_limit == 0;
+            if (!stream_unbounded)
+                try_launch_async_graph_loop(dreq, last_token, dec_stream, spec_limit);
         }
     }
 

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -92,6 +92,16 @@ struct Request {
     // survive eviction until the pin budget recycles them (FIFO).
     bool pin_kv_prefix = false;
 
+    // SSE streaming request: the client consumes tokens as they are produced.
+    // The async conditional graph loop (GPU-autonomous multi-token decode) only
+    // surfaces its tokens to the host after the whole burst completes — on this
+    // platform the mapped-pinned ring buffer is not reliably host-visible
+    // mid-flight — so a streamed request would receive every token at
+    // generation end (TTFT == full latency, #754). Streaming requests therefore
+    // stay on per-step decode (one token per step) for real per-token delivery;
+    // non-streaming requests keep the faster autonomous loop.
+    bool stream = false;
+
     // Logprobs
     bool logprobs = false;                          // Return logprobs for sampled tokens
     int top_logprobs = 0;                           // 0-20, number of top alternatives

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1898,6 +1898,15 @@ static bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, S
 
     auto request_start = std::chrono::steady_clock::now();
     for (;;) {
+        // Terminate as soon as a finish reason has been recorded. The is_last
+        // token sets `finish` and then falls through to the per-token
+        // post-processing below, where a think/reasoning/channel `continue`
+        // can skip the trailing `if (finish) break`. Re-checking here means the
+        // stream always ends (and the terminal SSE frame is emitted) even when
+        // the final token is swallowed by one of those paths (#755/#757).
+        if (finish)
+            break;
+
         // Check client disconnect
         if (!sink.is_writable()) {
             server_req->cancel();
@@ -2628,6 +2637,8 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
         // max_tokens (content empty, finish=length).
         req->started_in_think = ctx.snap.enable_thinking;
         req->in_think_block = ctx.snap.enable_thinking;
+        // Stream requests stay on per-step decode for real per-token SSE (#754).
+        req->stream = ctx.params.stream;
         req->status = imp::RequestStatus::PENDING;
         return req;
     };
@@ -2851,6 +2862,8 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
     imp_req->logit_bias = std::move(logit_bias);
     imp_req->think_budget = body.value("think_budget", state.default_think_budget);
     imp_req->pin_kv_prefix = body.value("cache_prompt", false);
+    // Stream requests stay on per-step decode for real per-token SSE (#754).
+    imp_req->stream = stream;
     imp_req->status = imp::RequestStatus::PENDING;
 
     auto server_req = std::make_shared<ServerRequest>();
@@ -2914,6 +2927,16 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
 
                 auto request_start_c = std::chrono::steady_clock::now();
                 for (;;) {
+                    // #757: the is_last token sets `finish` then falls through
+                    // to think-stripping, which `continue`s on every swallowed
+                    // token — bypassing the trailing `if (finish) break`. For a
+                    // think-capable model whose final token lands inside the
+                    // think buffer the loop would otherwise spin on pop_token
+                    // until the client gives up (0 bytes, never terminates).
+                    // Break here so the buffers flush and [DONE] is sent.
+                    if (finish)
+                        break;
+
                     // Check client disconnect
                     if (!sink.is_writable()) {
                         server_req->cancel();
@@ -3872,6 +3895,15 @@ static bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& c
 
     auto request_start = std::chrono::steady_clock::now();
     for (;;) {
+        // #755: when a thinking model exhausts its token budget the final
+        // (is_last) token lands inside the REASONING phase, which `continue`s
+        // and skips the trailing `if (finish) break`. The loop would then spin
+        // on pop_token forever — message_delta/message_stop never emitted, so
+        // the Anthropic client (SDK or curl -N) hangs indefinitely. Breaking
+        // here guarantees the terminal events are always sent.
+        if (finish)
+            break;
+
         if (!sink.is_writable()) {
             server_req->cancel();
             finish = "cancelled";
@@ -4466,6 +4498,9 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
         imp_req->top_k = ctx.params.top_k;
         imp_req->seed = ctx.params.seed;
         imp_req->pin_kv_prefix = ctx.params.cache_prompt;
+        // This is the streaming /v1/messages path — stay on per-step decode so
+        // SSE is real per-token rather than one burst at generation end (#754).
+        imp_req->stream = true;
         imp_req->min_p = ctx.params.min_p;
         imp_req->typical_p = ctx.params.typical_p;
         imp_req->repetition_penalty = ctx.params.repetition_penalty;


### PR DESCRIPTION
Fixes three SSE streaming bugs filed against v0.12.0. All reproduced black-box (raw socket in the server's netns) and re-verified fixed against a fresh build.

## #754 — SSE was buffered (TTFT ≈ full latency), both `/v1/chat/completions` and `/v1/messages`
A batch-1 decode request with default sampling launches the async **conditional graph loop unbounded** (`spec_limit == 0`), which generates the whole remaining sequence GPU-autonomously. Its mapped-pinned ring buffer is only reliably host-visible *after* the burst completes (the unused `poll_new_tokens` reads stale entries mid-flight on this platform — wiring it in produced `!!!!` garbage, which is why it was never hooked up), so every token reaches the client at generation end.

**Fix:** tag streaming requests (new `Request::stream`, plumbed from all three handlers) and keep them on **per-step decode** → real per-token delivery. Non-streaming requests keep the autonomous loop (full perf, unchanged); bounded speculation bursts still stream in groups via their per-burst sync.

Measured streaming cost vs the loop on Qwen3-8B-Q8: **~2–5% decode** (per-step 96 tok/s vs loop ~94–96 tok/s on an 80-token greedy completion; the loop's larger win is in non-streaming/throughput, which is untouched).

## #755 / #757 — streaming hung the client forever
`/v1/messages` (thinking model + small `max_tokens`) and `/v1/completions` (`stream:true`) never terminated. The `is_last` token sets `finish` then falls through to per-token post-processing, where a reasoning / think-strip / channel `continue` skips the trailing `if (finish) break`. When the final token is swallowed by one of those paths the loop spins on `pop_token` until the client gives up — no `message_stop` / `[DONE]` / finish chunk is ever sent.

**Fix:** re-check `if (finish) break` at the top of all three stream loops (chat as a safety net) so the terminal SSE frame is always emitted. Additive — `finish` starts null.

## Validation (fresh build, Qwen3-8B-Q8, CUDA graphs on)
- **#754** chat stream: 174 frames spread evenly across 13×200 ms buckets over a 2.42 s generation (was: one burst at the end) — real per-token, coherent output.
- **#757**: terminates in 0.18 s with content (was: 0 bytes, 20 s client timeout).
- **#755**: terminates in 0.24 s with `message_stop` (was: hang).
- **Byte-identical**: streaming output == non-streaming output at temp=0.
- `degen_suite.py`: **33 checks, 0 FAIL** (incl. `stream == non-stream`, SSE termination, anthropic-thinking stream/non-stream, multi-turn, long-context).
- `make test-unit`: **37/37**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)