### PR TITLE
fix(server): prefix-cache default-on, model-id + load-error UX, version/docs sync (#756 #758 #759 #760)

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           context: .
           push: true
+          # Ship imp-bench in the released image — it is documented (docs/usage.md)
+          # and the only standalone microbench entry point. CI keeps it OFF for
+          # speed; the release image is built once, so the ~30-60s is fine (#760).
+          build-args: |
+            IMP_BUILD_BENCH=ON
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,10 @@ target_include_directories(imp
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stb
 )
 
+# Single-source the runtime version string from the project version so
+# imp_version() / `imp-cli --version` can never drift from CMakeLists (#760).
+target_compile_definitions(imp PRIVATE IMP_VERSION_STRING="${PROJECT_VERSION}")
+
 target_link_libraries(imp
     PUBLIC
         CUDA::cudart

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ command: **[BENCHMARKS.md](BENCHMARKS.md)**. Methodology details:
 
 **Use [vLLM](https://github.com/vllm-project/vllm) if** you serve high-concurrency batched workloads on datacenter GPUs (H100/B200). It has continuous batching, PagedAttention at scale, and production-grade serving.
 
-**Use imp if** you run a Blackwell consumer/workstation card (RTX 5090, RTX PRO 6000) for single-user inference and want every drop of the hardware — it is the fastest engine on the 5090 for both decode and NVFP4 prefill, with native NVFP4/FP4 and no dequant overhead. The trade-off is scope, not speed: single-GPU, single-author, experimental (no continuous batching, no multi-GPU).
+**Use imp if** you run a Blackwell consumer/workstation card (RTX 5090, RTX PRO 6000) for single-user inference and want every drop of the hardware — it is the fastest engine on the 5090 for both decode and NVFP4 prefill, with native NVFP4/FP4 and no dequant overhead. The trade-off is scope, not speed: single-GPU, single-author, experimental (no multi-GPU).
 
 ## Known limitations
 
@@ -91,10 +91,11 @@ mkdir -p models
 docker run --gpus all -v ./models:/models -p 8080:8080 \
   ghcr.io/kekzl/imp:latest --model /models/your-model.gguf
 
-# Hit the OpenAI-compatible endpoint
+# Hit the OpenAI-compatible endpoint (the model id is the file/dir basename;
+# GET /v1/models lists it, and the `model` field is required).
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"messages":[{"role":"user","content":"Hello!"}],"max_tokens":64}'
+  -d '{"model":"your-model.gguf","messages":[{"role":"user","content":"Hello!"}],"max_tokens":64}'
 ```
 
 Or build from source (tracks `main` instead of the latest release):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,7 +76,7 @@ The most common keys are also exposed as named CLI flags (`--kv-fp8`,
 ./build/imp-cli --model model.gguf --prompt "Hello, world!"
 
 # SafeTensors directory (NVFP4 prequant from Model Optimizer or llm-compressor)
-./build/imp-cli --model ./Qwen3-Coder-30B-A3B-FP4/ --prompt "Hello"
+./build/imp-cli --model ./Qwen3-Coder-30B-A3B-FP4 --prompt "Hello"
 
 # Interactive chat
 ./build/imp-cli --model model.gguf --interactive
@@ -193,7 +193,7 @@ Benchmark / eval:
 ./build/imp-server --model model.gguf --port 8080
 
 # Start with SafeTensors (NVFP4 prequant)
-./build/imp-server --model ./Qwen3-Coder-30B-A3B-FP4/ --port 8080
+./build/imp-server --model ./Qwen3-Coder-30B-A3B-FP4 --port 8080
 
 # With vision
 ./build/imp-server --model gemma-3-12b-it.gguf --mmproj mmproj.gguf
@@ -272,6 +272,13 @@ standard pre-norm archs; sandwich-norm o/down (Gemma) and MoE-expert targets
 are declined with a log. C API: `imp_lora_load()` / `imp_lora_set()`.
 
 ## C API
+
+> The C API is consumable only from a **source build**: `cmake --install` stages
+> `libimp.a` and the `include/imp/` headers, which you link against. The prebuilt
+> `ghcr.io/kekzl/imp` runtime image ships only the `imp-server` / `imp-cli` /
+> `imp-bench` binaries — not the static library or headers — so embedding the C
+> API means building from source (or copying the lib/headers out of the Docker
+> `builder` stage).
 
 ```c
 #include <imp/imp.h>

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 #include <new>
 #include <exception>
+#include <filesystem>
 
 #include <cuda_runtime.h>
 
@@ -58,7 +59,7 @@ const char* imp_error_string(ImpError err) {
         case IMP_ERROR_FILE_NOT_FOUND:
             return "file not found";
         case IMP_ERROR_INVALID_MODEL:
-            return "invalid model";
+            return "invalid or corrupt model file";
         case IMP_ERROR_UNSUPPORTED:
             return "unsupported operation";
         case IMP_ERROR_INTERNAL:
@@ -144,7 +145,14 @@ ImpGenerateParams imp_generate_params_default(void) {
 
 // --- Version ---
 
-const char* imp_version(void) { return "0.11.2"; }
+// Single-sourced from the CMake project version (-DIMP_VERSION_STRING=...).
+// Falls back to a sentinel for non-CMake/ad-hoc builds so it never silently
+// drifts from CMakeLists.txt again (#760).
+#ifndef IMP_VERSION_STRING
+#define IMP_VERSION_STRING "0.0.0-dev"
+#endif
+
+const char* imp_version(void) { return IMP_VERSION_STRING; }
 
 // --- Helper: map ImpDType to imp::QType ---
 
@@ -225,6 +233,13 @@ ImpError imp_model_load_ex(const char* path, ImpModelFormat format, int load_mtp
         }
 
         if (!model) {
+            // Distinguish a genuinely missing path from one that exists but
+            // failed to parse (bad GGUF magic, truncated SafeTensors, …). The
+            // loaders return nullptr for both; reporting "file not found" for a
+            // file that is present but corrupt is misleading (#759).
+            std::error_code ec;
+            if (std::filesystem::exists(path, ec))
+                return IMP_ERROR_INVALID_MODEL;
             return IMP_ERROR_FILE_NOT_FOUND;
         }
 

--- a/src/model/hf_hub.cpp
+++ b/src/model/hf_hub.cpp
@@ -1,5 +1,6 @@
 #include "model/hf_hub.h"
 #include "core/logging.h"
+#include <algorithm>
 #include <cstdlib>
 #include <filesystem>
 
@@ -36,8 +37,18 @@ std::string resolve_model_path(const std::string& model_id, const std::string& r
         return model_id;
     }
 
-    // 2. If it doesn't look like a HF repo ID (no '/'), it's a bad path.
-    if (model_id.find('/') == std::string::npos) {
+    // 2. Decide whether this is a missing LOCAL path or a HuggingFace repo id.
+    // A HF repo id is "org/repo": exactly one '/', not absolute/relative, and
+    // no model-file extension. Anything else (an absolute path, a ./ or ../
+    // path, a *.gguf / *.safetensors file, or a multi-segment path) is a local
+    // path that simply doesn't exist — report that instead of nonsensically
+    // suggesting `git clone https://huggingface.co//models/...` (#759).
+    const bool looks_like_hf_repo =
+        !model_id.empty() && model_id.front() != '/' && model_id.front() != '.' &&
+        model_id.front() != '~' && std::count(model_id.begin(), model_id.end(), '/') == 1 &&
+        model_id.find(".gguf") == std::string::npos &&
+        model_id.find(".safetensors") == std::string::npos;
+    if (!looks_like_hf_repo) {
         IMP_LOG_ERROR("Model path does not exist: %s", model_id.c_str());
         return "";
     }

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -411,13 +411,16 @@ struct RuntimeConfig {
     } generation;
 
     struct Server {
-        // Prefix caching: reuse KV blocks for shared prompt prefixes. Defaults
-        // OFF here to match the EngineConfig default (off-by-default for
-        // library/C-API embedders); the server/CLI opt in via imp.conf
-        // ([server] prefix_cache = true, the value in imp.conf.example). The
-        // engine ORs this into EngineConfig.use_prefix_caching at init.
-        // PrefixCacheE2ETest is the ship gate; auto-disabled for SSM/GDN.
-        bool prefix_cache = false;
+        // Prefix caching: reuse KV blocks for shared prompt prefixes. Default
+        // ON for the server/CLI — this is the documented behaviour (README,
+        // imp.conf.example) and what delivers the advertised warm-prompt TTFT
+        // win + cache_read_input_tokens reporting (#758: shipping OFF meant the
+        // prebuilt image never cached unless an imp.conf opted in). Library /
+        // C-API embedders are unaffected — they drive EngineConfig directly
+        // (off-by-default there). The engine ORs this into
+        // EngineConfig.use_prefix_caching at init. PrefixCacheE2ETest is the
+        // ship gate; auto-disabled for SSM/GDN.
+        bool prefix_cache = true;
         // Cap on cache_control/cache_prompt-pinned blocks, % of the KV pool.
         int prefix_pin_budget_pct = 25;
         // Green Contexts / prefill-decode overlap streams in the server engine.

--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -52,7 +52,7 @@ TEST(EndToEndTest, ErrorStrings) {
     EXPECT_STREQ(imp_error_string(IMP_ERROR_OUT_OF_MEMORY), "out of memory");
     EXPECT_STREQ(imp_error_string(IMP_ERROR_CUDA), "CUDA error");
     EXPECT_STREQ(imp_error_string(IMP_ERROR_FILE_NOT_FOUND), "file not found");
-    EXPECT_STREQ(imp_error_string(IMP_ERROR_INVALID_MODEL), "invalid model");
+    EXPECT_STREQ(imp_error_string(IMP_ERROR_INVALID_MODEL), "invalid or corrupt model file");
 }
 
 TEST(EndToEndTest, LoadNonexistentModel) {

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -438,9 +438,15 @@ std::string load_model_into_state(ServerState& state, const std::string& path, c
         return msg;
     }
 
-    // Extract model name from path
-    size_t slash = path.find_last_of('/');
-    state.model_name = (slash != std::string::npos) ? path.substr(slash + 1) : path;
+    // Extract model name from path. Strip trailing separators first so a
+    // directory passed with a trailing slash (e.g. /models/Foo-NVFP4/) still
+    // yields a non-empty id instead of "" — an empty id makes the model
+    // unaddressable over the HTTP API (#756).
+    std::string id_path = path;
+    while (id_path.size() > 1 && (id_path.back() == '/' || id_path.back() == '\\'))
+        id_path.pop_back();
+    size_t slash = id_path.find_last_of('/');
+    state.model_name = (slash != std::string::npos) ? id_path.substr(slash + 1) : id_path;
 
     // Set up tokenizer and chat template
     state.tok = state.model->model->tokenizer();


### PR DESCRIPTION
Four issues from the black-box acceptance test of v0.12.0. All reproduced and re-verified fixed against a fresh build.

Closes #756
Closes #758
Closes #759
Closes #760

## #758 — prefix/prompt caching was a no-op out of the box
`cache_read_input_tokens` stayed 0 with no warm-prompt TTFT win, despite the docs claiming prefix caching is default-on. Root cause: `RuntimeConfig::Server::prefix_cache` defaulted to `false`, so the prebuilt image never cached unless an `imp.conf` opted in. The reuse + reporting paths are correct. **Fix:** default the *server* flag ON (library/C-API embedders drive `EngineConfig` directly, unaffected; auto-disabled for SSM/GDN; ship gate is `PrefixCacheE2ETest`).
Verified (default flags, no `--set`): cold call `cache_creation=736, read=0`; warm call **`cache_read=736, input_tokens=1`**.

## #756 — SafeTensors dir with trailing slash → empty model id
`--model /models/Foo-NVFP4/` made `/v1/models` return `id: ""` → every request 400/404. **Fix:** strip trailing path separators before deriving the id.
Verified: `.../Qwen3-8B-NVFP4-cortecs/` now serves id `Qwen3-8B-NVFP4-cortecs` and accepts requests.

## #759 — misleading model-load errors
- Corrupt file (bad GGUF magic) reported `file not found`. `imp_model_load_ex` now stats the path and returns `IMP_ERROR_INVALID_MODEL` → **"invalid or corrupt model file"** when it exists.
- A missing local path was routed to the HF resolver (`git clone https://huggingface.co//models/x.gguf`). `resolve_model_path` now treats only `org/repo`-shaped ids as HF repos and reports **"Model path does not exist"** for local paths.

## #760 — docs/packaging
- Version string was hardcoded `"0.11.2"` while CMake project version is `0.12.0`. Single-sourced via `-DIMP_VERSION_STRING=${PROJECT_VERSION}` (imp-cli now prints `0.12.0`).
- README: dropped the stale "no continuous batching" claim (server has had it since #736); added the required `model` field to the quickstart curl.
- usage.md: removed the trailing slash from the SafeTensors examples; noted the C API needs a source build (runtime image ships only binaries).
- `release-docker.yml` now builds with `IMP_BUILD_BENCH=ON` so the released image ships `imp-bench`.

## Validation (fresh build, CUDA graphs on)
- All four issues manually reproduced → fixed (see above).
- `degen_suite.py`: **33 checks, 0 FAIL** with prefix-cache now default-on (coherence, multi-turn, stream, anthropic-thinking).
- `make test-unit`: **37/37** (updated the `ErrorStrings` expectation for the new message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)