### PR TITLE
fix(server): incremental /v1/completions stream, port-in-use fail-fast, gpt-oss MXFP4 warning

### DIFF
--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1102,19 +1102,27 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
     // executor_pre_dequant.cu's Phase 0 promote() resolves each scratch key
     // back to the main weight tensor and writes the device pointer onto its
     // .scales / .tensor_scale sidecars. No load-side linking needed here.
-    // MXFP4 detection. We surface the format declaration but do NOT have a
-    // SafeTensors decode path yet — only the GGUF wire format is decoded.
-    // The warn here lets users know they need to convert to GGUF.
+    // MXFP4 detection. gpt-oss MXFP4 experts ARE decoded natively: they are
+    // transcoded MXFP4→NVFP4 at init (pre_dequant_phase3_nvfp4_decode.cu) and
+    // run through the CUTLASS NVFP4 grouped GEMM. Other MXFP4 SafeTensors
+    // architectures have no decode path yet — only those still need the GGUF
+    // conversion warning.
     HFConfigLoader::MxFP4Config mxfp4_cfg;
     if (HFConfigLoader::load_mxfp4_config(model_dir, mxfp4_cfg)) {
         cfg.is_mxfp4_prequant = true;
         cfg.mxfp4_block_size = mxfp4_cfg.block_size;
-        IMP_LOG_WARN(
-            "MXFP4 SafeTensors detected (block_size=%d) — imp does NOT have "
-            "a SafeTensors MXFP4 decode path yet. Weights will load as their "
-            "wire dtype (typically uint8/FP16) and inference will likely be "
-            "incorrect. Convert to GGUF for actual MXFP4 support.",
-            cfg.mxfp4_block_size);
+        if (cfg.arch == ModelArch::GPT_OSS) {
+            IMP_LOG_INFO("MXFP4 SafeTensors (block_size=%d): gpt-oss experts will be "
+                         "transcoded MXFP4→NVFP4 at init (native decode).",
+                         cfg.mxfp4_block_size);
+        } else {
+            IMP_LOG_WARN(
+                "MXFP4 SafeTensors detected (block_size=%d) — imp has no SafeTensors "
+                "MXFP4 decode path for this architecture yet. Weights will load as "
+                "their wire dtype and inference will likely be incorrect. Convert to "
+                "GGUF for actual MXFP4 support.",
+                cfg.mxfp4_block_size);
+        }
     }
 
     // AWQ detection. Same posture as MXFP4: the metadata is parsed and

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -2914,9 +2914,16 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                 std::string pending_text;
                 bool text_stop_matched = false;
 
-                // Strip <think> blocks for completions (no reasoning_content field)
+                // Strip <think> blocks for completions (no reasoning_content field).
+                // think_confirmed starts FALSE so a raw /v1/completions prompt
+                // (no chat template → no injected <think>) streams incrementally
+                // instead of buffering every token into think_buf waiting for a
+                // </think> that never comes (#760: completions stream arrived as
+                // one frame). It flips true only if a real <think> opener shows
+                // up in the first kThinkScanLimit tokens, so genuine think blocks
+                // are still stripped.
                 bool think_strip = (snap_is_think_model && state.default_args.reasoning_format != "none");
-                bool think_confirmed = think_strip;
+                bool think_confirmed = false;
                 std::string think_buf;
                 int think_tokens = 0;
                 const int kThinkScanLimit = 8;

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -66,6 +66,17 @@ int main(int argc, char** argv) {
         printf("Models directory: %s\n", state.models_dir.c_str());
     }
 
+    // Set up the HTTP server and BIND the listen socket now — before the (slow)
+    // model load — so a port conflict fails in <1 s instead of after a full
+    // model load (#760). Routes are registered once the model is ready;
+    // listen_after_bind() below starts accepting connections then.
+    httplib::Server svr;
+    if (svr.bind_to_port(args.host, args.port) == 0) {
+        fprintf(stderr, "Failed to start server on %s:%d: port already in use\n", args.host.c_str(),
+                args.port);
+        return 1;
+    }
+
     printf("Loading model: %s\n", resolved_model.c_str());
     {
         std::string error = load_model_into_state(state, resolved_model);
@@ -86,8 +97,7 @@ int main(int argc, char** argv) {
         printf("LoRA adapter loaded: %s (id=%d) from %s\n", name.c_str(), id, path.c_str());
     }
 
-    // Set up HTTP server
-    httplib::Server svr;
+    // (svr was created + bound to the port above, before the model load.)
 
     // Limit request body size to 100 MiB (prevents DoS via large base64 images)
     svr.set_payload_max_length(static_cast<size_t>(100) * 1024 * 1024);
@@ -260,8 +270,8 @@ int main(int argc, char** argv) {
     printf("  GET    /metrics             Prometheus metrics\n");
     fflush(stdout);
 
-    if (!svr.listen(args.host, args.port)) {
-        // listen() returns false on stop() or bind failure
+    if (!svr.listen_after_bind()) {
+        // listen_after_bind() returns false on stop() or bind failure
         if (!g_server.load(std::memory_order_relaxed)) {
             // Server was nulled by signal — clean shutdown
         } else {


### PR DESCRIPTION
Three follow-ups from the v0.12.1 acceptance re-test (the report's remaining non-gpt-oss-Harmony findings).

## /v1/completions streaming was buffered (not incremental)
For a think-capable model the legacy completions stream arrived as a single SSE frame at the end: the think-strip scanner started **confirmed** and swallowed every token into `think_buf` waiting for a `</think>` that a raw completion (no chat template) never emits. `think_confirmed` now starts **false** and flips only if a real `<think>` opener appears in the first scan window.
Verified: **54 data frames over 0.2–0.75 s** (was 1 frame). Genuine think blocks are still stripped.

## Port-in-use is now fail-fast
The listen socket is bound (`bind_to_port`) **before** the model load, so a port conflict errors in **<1 s** ("port already in use") instead of after a full model load. `listen_after_bind()` serves once the model is ready.
Verified: 2nd server on an occupied port prints the error with **no** "Loading model" line.

## gpt-oss MXFP4 SafeTensors: stale warning removed
The load no longer prints "imp does NOT have a SafeTensors MXFP4 decode path" — **the path exists**: gpt-oss experts are transcoded MXFP4→NVFP4 at init (`pre_dequant_phase3_nvfp4_decode.cu`) and run through the CUTLASS NVFP4 grouped GEMM (coherent output verified). It is now an INFO for gpt-oss; other (genuinely unsupported) MXFP4 archs keep the warning.

> Note: the gpt-oss **Harmony channel output parsing** (`<|channel|>analysis<|message|>…` leaking into `content` over the API) is a separate, larger fix and lands in its own PR.

Validation: 3 fixes reproduced→fixed against a fresh build; `make test-unit` 37/37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)