### PR TITLE
feat(runtime): long-context KV budget defaults for agentic workloads

### DIFF
--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -501,7 +501,14 @@ void Engine::init_compute_max_seq_len_() {
         // afford. (Was 30%, calibrated when weight caches competed at FP16.)
         int max_by_vram = (kv_bytes_per_token > 0) ? static_cast<int>(free_vram * 0.6 / kv_bytes_per_token)
                                                    : 131072;
-        constexpr int kAutoMaxSeqLenCap = 16384;
+        // Agentic workloads (tool loops, accumulating history, large file
+        // context) routinely exceed 16K and run a single long sequence rather
+        // than many short ones, so a high per-request ceiling is the right
+        // default. Cap lifted 16K → 64K; max_by_vram still bounds it to what
+        // VRAM honestly affords and model_ctx to what the model supports, so
+        // this only raises the ceiling on models that declare (and can hold)
+        // more than 16K.
+        constexpr int kAutoMaxSeqLenCap = 65536;
         config_.max_seq_len = std::min({model_ctx, std::max(max_by_vram, 4096), kAutoMaxSeqLenCap});
         IMP_LOG_INFO(
             "max_seq_len: auto → %d (model=%d, vram_cap=%d, auto_cap=%d, kv=%zu B/tok, attn_layers=%d/%d)",

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -196,13 +196,23 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
             // NVFP4 decode cache is critical for performance — ensure it fits first.
             // FP8 prefill cache is nice-to-have but not essential (fallback: dequant on-the-fly).
             budget.nvfp4_cache_bytes = nvfp4_estimate;
-            double kv_fraction = (config.use_nvfp4_decode == 2) ? 0.1 : 0.8;
+            // KV target = 0.8 of available for BOTH modes. Mode 2 (native-NVFP4
+            // second pass) previously used 0.1 and skipped the needed_blocks
+            // floor — intended to leave room for an FP8 prefill cache. But on
+            // sm_120 FP8 prefill is unavailable (native NVFP4 uses the CUTLASS
+            // NVFP4 GEMM, no FP8 weight cache is built), so the 90% reserve was
+            // dead VRAM: an NVFP4 SafeTensors model starved its KV pool to ~24K
+            // tokens while 16 GB sat free — the long-context/agentic default was
+            // effectively broken. target_blocks (below) still clamps mode 2 to
+            // needed_blocks, so 0.8 only lifts KV up to the per-sequence need
+            // and leaves the remainder for FP8 (computed post-clamp) when it IS
+            // enabled — no regression for fp8-prefill configs.
+            double kv_fraction = 0.8;
             budget.kv_cache_bytes = static_cast<size_t>(available * kv_fraction);
             budget.kv_max_blocks = (per_block_total > 0)
                                        ? static_cast<int>(budget.kv_cache_bytes / per_block_total)
                                        : needed_blocks;
-            if (config.use_nvfp4_decode != 2)
-                budget.kv_max_blocks = std::max(budget.kv_max_blocks, needed_blocks);
+            budget.kv_max_blocks = std::max(budget.kv_max_blocks, needed_blocks);
             // FP8 budget is computed below — after the kv_max_blocks clamp /
             // min_kv_blocks enforcement — so it reflects the FINAL KV size.
             budget.nvfp4_second_pass = (config.use_nvfp4_decode == 2);


### PR DESCRIPTION
## What

Two default-sizing fixes so agentic long-context "just works":

- **NVFP4 KV-starve fix** (`vram_budget.cpp`): native-NVFP4 second-pass (mode 2)
  used `kv_fraction=0.1` and skipped the `needed_blocks` floor, reserving ~90% of
  free VRAM for an FP8 prefill cache that is never built on sm_120 (native NVFP4
  uses the CUTLASS NVFP4 GEMM). NVFP4 SafeTensors models therefore starved their KV
  pool to ~24K tokens while 16 GB sat free. Use `kv_fraction=0.8` for both modes and
  apply the `needed_blocks` floor unconditionally; `target_blocks` still clamps mode
  2 to `needed_blocks`, so KV only rises to the per-sequence need and the FP8
  remainder is unaffected for real fp8-prefill configs.
- **Auto `max_seq_len` cap 16384 → 65536** (`engine_init_resolver.cpp`): agentic
  workloads run a single long sequence and routinely exceed 16K. `max_by_vram` and
  `model_ctx` still bind, so this only raises the ceiling where the model declares
  (and VRAM can hold) more than 16K.

## Why

Long context is the core agentic requirement; the NVFP4 default (the priority
format) capped usable context at ~24K despite spare VRAM.

## Verification (RTX 5090)

- Qwen3-14B NVFP4 auto: KV 24K → 40960 (model max), needle@32K recalled, no
  degeneration, 14.8 GB still free.
- Qwen3-14B Q6_K GGUF auto: 32768 (model_ctx binds).
- Unit tests pass; no hot-path kernel change → decode/prefill throughput unaffected
  (perf baseline not touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmippvZucgTNU7HyuWBapy
