### PR TITLE
Audit backlog cleanup — F-A5 (vision concurrency), F-A11, F-A12

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -403,25 +403,34 @@ rock-stable across restarts); prefill pp medians ~20.8k / 48.5k / 42.4k tok/s.
   doc was left unchanged. (Over-flag guard: a "0 references" smell did not survive
   the A/B — the value of the codebase-audit verify rule.)
 
-### Other low / hardening (verified, parked with notes)
-- **F-A5** vision request `stop()/start()` cancels all concurrent in-flight
-  (`handlers.cpp:1004-1018`) — **parked, NOT a safe swap.** On inspection the vision
-  path `stop()`s to get *exclusive* access while it mutates GLOBAL engine image state
-  (`clear_image` + `set_image_from_memory`). The embeddings `pause()/resume()` works
-  there because embeddings don't mutate shared image state; for vision, resuming a
-  concurrent *text* request could make it process with the stale vision image. The
-  real fix is per-request image binding (so vision needn't serialize the whole
-  engine), not a stop→pause swap. (The agent's "mirror embeddings" was an over-flag.)
+### Other low / hardening
+> **Follow-up pass (2026-06-24, branch `audit/backlog-cleanup`):** F-A5, F-A11,
+> F-A12 FIXED (the deeper re-trace below corrected two of the earlier
+> park-rationales). Pass-1 backlog (CI1 format-gate, B2 CMakePresets, TL1
+> .clang-tidy, CI2 tidy-gate) was found ALREADY DONE on main. Only CI3/T1/BM1
+> (self-hosted GPU runner) remains — genuine infra.
+- **F-A5** vision request `stop()/start()` cancelled all concurrent in-flight —
+  **FIXED**: switched to `pause()/resume()`. Re-trace corrected the earlier
+  "not a safe swap" verdict: `pause()` DRAINS in-flight requests (the worker only
+  parks when `active_requests_` is empty — verified `batching_engine.cpp:76-94,127`)
+  so it gives the same exclusivity as `stop()` without cancelling. The global-image
+  hazard is handled by clearing the image before every `resume()` (added at the
+  reject paths that lacked it). Validated: vision e2e correct + concurrent request
+  not cancelled (gemma-3-4b-vl).
 - **F-A10** boundary re-prefill re-quantizes a *shared* KV block with no COW
-  (NVFP4/INT KV only; FP16 safe by idempotency) — `scheduler.cpp:80-83`.
-- **F-A11** `size_t→int` truncation in FP8/NVFP4 migrate APIs
-  (`pre_dequant_phase3_nvfp4_decode.cu:639`, `fp8_quant.cu:277`) — **parked**: genuinely
-  unreachable (largest tensor ~778M ≪ 2³¹), and a correct widen touches the live FP8
-  path's kernel grid math + linear indexing across 3 files — poor risk/reward autonomously.
-- **F-A12** KV-write kernels lack an in-kernel `block_id>=0` guard — **parked**: the
-  shared `kv_resolve_slot` chokepoint is also used by read paths and must not reject
-  StreamingLLM's legitimate `-1` sentinels; LOW + unreachable (host caps) doesn't justify
-  the per-kernel guard risk.
+  (NVFP4/INT KV only; FP16 safe by idempotency) — `scheduler.cpp:80-83`. (still parked, low)
+- **F-A11** `size_t→int` truncation in FP8/NVFP4 migrate APIs — **FIXED**: widened
+  the wrapper to `int64_t` + a loud >INT_MAX guard (the responsible fix — kernels keep
+  int indexing, only ever reached for in-range sizes; avoids touching hot-path indexing
+  for an unreachable case). FP8 oracle tests pass.
+- **F-A12** KV-write `block_id>=0` guard — **FIXED**: re-trace found all 9
+  `kv_resolve_slot` sites are WRITE kernels (none are reads — the earlier
+  "shared with reads" rationale was wrong), so a block-uniform `if (block_id<0) return;`
+  is safe everywhere. StreamingLLM sink-eviction + KV-write tests pass.
+- **F-A14** copyable RAII-owning handle types (LayerOffload/ExpertLRUCache/GreenCtx)
+  — **FIXED**: deleted copy ops → move-only; clean build confirms no copy/move sites.
+- **F-A17** swallowed `cudaStreamSynchronize` return at the burst boundary
+  (`cuda_graph.cu:1014`) — diagnostic hygiene. (still parked, low)
 - **F-A14** copyable RAII-owning handle types (LayerOffload/ExpertLRUCache/GreenCtx)
   — **FIXED**: deleted copy ops → move-only; clean build confirms no copy/move sites.
 - **F-A17** swallowed `cudaStreamSynchronize` return at the burst boundary

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -31,11 +31,14 @@ including the bounded-burst F-A2 fix at ~0 cost). No silent behavior change beyo
 those itemized — the two intentional ones (reject-newest under KV exhaustion;
 det-mode-gated burst bounding) are called out with their before/after.
 
-Two validation insights worth flagging: (1) verification refuted or reshaped four
-"findings" that would have been *unsafe* fixes (F-A9 determinism, F-A5 vision swap,
-F-A12 guard) — the codebase-audit "verify before acting" rule earned its keep; and
-(2) the F-A2 fix only proved safe because validation caught that bounding the loop
-silently broke greedy reproducibility on NVFP4-MoE, forcing the determinism gate.
+Two validation insights worth flagging: (1) verification cuts both ways — the first
+pass's static reasoning *over-parked* F-A5 and F-A12 (a deeper re-trace in the
+follow-up showed pause() drains rather than cancels, and that all kv_resolve_slot
+sites are writes), so both shipped safely; while F-A9 (determinism) was genuinely
+refuted by an A/B. The lesson is the same either way: re-trace before deciding, in
+both directions. (2) the F-A2 fix only proved safe because validation caught that
+bounding the loop silently broke greedy reproducibility on NVFP4-MoE, forcing the
+determinism gate.
 
 ## What was fixed (validated, shipped as gated commits)
 
@@ -101,12 +104,24 @@ cuBLAS-autotune restart variance (informational, not a gate).
 
 ## Prioritized parked backlog (for a follow-up)
 
-1. **F-A5** vision request serialization kills concurrent requests (med) — NOT a
-   stop→pause swap (vision mutates global engine image state; pause/resume could leak
-   the image to a concurrent text request). Real fix: per-request image binding.
-2. **F-A11** `size_t→int` widen (low; unreachable today, touches live FP8 kernel indexing).
-3. **F-A12** KV-write `block_id` guard (low; `kv_resolve_slot` shared w/ reads + StreamingLLM `-1`).
-4. Carried from pass-1: CI3/T1/BM1 (GPU runner), CI1 (format gate), B2 (CMakePresets) — infra.
+**Follow-up pass (2026-06-24) closed the rest:** F-A5, F-A11, F-A12 FIXED (a deeper
+re-trace corrected the F-A5 and F-A12 park-rationales — see below); the pass-1
+build-hygiene backlog (CI1 format-gate, B2 CMakePresets, TL1 .clang-tidy, CI2
+tidy-gate) was found ALREADY DONE on main.
+
+Remaining:
+1. **CI3 / T1 / BM1** — GPU correctness + perf gates are dark without a self-hosted
+   RTX 5090 runner. Genuine infra; cannot be provided from here.
+2. **F-A10** shared-KV COW (low), **F-A17** swallowed sync return (low) — diagnostic/edge.
+
+### Follow-up corrections (verification cuts both ways)
+- **F-A5** was NOT a feature: `pause()` *drains* in-flight requests (verified) so it
+  gives stop()'s exclusivity without cancelling — a safe pause/resume swap + clear-
+  before-resume fixed it. My earlier "needs per-request image binding" was over-cautious.
+- **F-A12**: all 9 `kv_resolve_slot` sites are WRITE kernels (none read), so the guard
+  is safe everywhere — the earlier "shared with reads + StreamingLLM `-1`" was wrong.
+- **F-A11**: fixed the responsible way (int64 wrapper + >INT_MAX guard, kernels untouched)
+  rather than the invasive hot-path widen I'd flagged.
 
 (F-A1b + F-A2 + F-A14 resolved this pass; F-A9 refuted by experiment. **All HIGH
 findings are now fixed-and-validated** — no parked HIGH remaining.)

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -462,6 +462,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_kernel(const half* __restr
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     half* dst = cache_base + static_cast<int64_t>(block_id) * block_stride +
                 static_cast<int64_t>(slot_in_block) * row_elems;
@@ -494,6 +501,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_fused_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     // blockIdx.y selects K (0) or V (1)
     const half* src;
@@ -532,6 +546,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_fp8_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     __nv_fp8_e4m3* dst = cache_base + static_cast<int64_t>(block_id) * block_stride +
                          static_cast<int64_t>(slot_in_block) * row_elems;
@@ -582,6 +603,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_int8_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     // Select K or V based on blockIdx.y
     const half* src_base = (blockIdx.y == 0) ? k_in : v_in;
@@ -667,6 +695,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_int4_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     const half* src_base = (blockIdx.y == 0) ? k_in : v_in;
     uint8_t* cache_base = (blockIdx.y == 0) ? k_cache_base : v_cache_base;
@@ -774,6 +809,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_nvfp4_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     const half* src_base = (blockIdx.y == 0) ? k_in : v_in;
     uint8_t* cache_base = (blockIdx.y == 0) ? k_cache_base : v_cache_base;
@@ -948,6 +990,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_mxfp4_kv_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     const half* src_base = (blockIdx.y == 0) ? k_in : v_in;
     uint8_t* cache_base = (blockIdx.y == 0) ? k_cache_base : v_cache_base;
@@ -1023,6 +1072,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_rope_fused_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     if (blockIdx.y == 0) {
         // K path: apply RoPE during write
@@ -1103,6 +1159,13 @@ __global__ __launch_bounds__(256) void write_kv_cache_fp8_fused_kernel(
     int slot_in_block;
     int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
                                    slot_in_block);
+    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
+    // sentinel, or a future block-table bug — would index the KV pool OOB.
+    // block_id is uniform across the block (derived from blockIdx.x), so this
+    // skips the whole write without divergence. Never fires today (host-side
+    // admission guarantees every written position has a real block).
+    if (block_id < 0)
+        return;
 
     const half* src;
     __nv_fp8_e4m3* dst;

--- a/src/exec/pre_dequant_phase2_fp8_cache.cu
+++ b/src/exec/pre_dequant_phase2_fp8_cache.cu
@@ -195,9 +195,9 @@ void QuantPipeline::pre_dequant_phase2_fp8_cache_(
                 fp8_offset += e.n_elems;
 
                 // Async calibrate + quantize (no host sync)
-                calibrate_and_quantize_fp8_async(qscratch_->dequant, fp8_buf, static_cast<int>(e.n_elems),
-                                                 d_block_maxes, max_grid, d_absmax,
-                                                 d_scales_all + static_cast<ptrdiff_t>(i), stream);
+                calibrate_and_quantize_fp8_async(qscratch_->dequant, fp8_buf,
+                                                 static_cast<int64_t>(e.n_elems), d_block_maxes, max_grid,
+                                                 d_absmax, d_scales_all + static_cast<ptrdiff_t>(i), stream);
 
                 int64_t fp8_shape[4] = {e.weight.shape[0],
                     (e.qtype == QType::NVFP4) ? e.weight.shape[1] * 2 : e.weight.shape[1],

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -637,7 +637,7 @@ void QuantPipeline::nvfp4_decode_free_fp16_and_migrate_fp8_(size_t& remaining_bu
                 fp8_offset += e.n_elems;
 
                 calibrate_and_quantize_fp8_async(e.fp16_tensor.data, fp8_buf,
-                                                 static_cast<int>(e.n_elems), d_block_maxes, max_grid,
+                                                 static_cast<int64_t>(e.n_elems), d_block_maxes, max_grid,
                                                  d_absmax, d_scales_all + i, stream);
 
                 Tensor fp8_t(fp8_buf, QType::FP8_E4M3, e.fp16_tensor.ndim, e.fp16_tensor.shape, true);

--- a/src/quant/fp8_quant.cu
+++ b/src/quant/fp8_quant.cu
@@ -5,6 +5,7 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
+#include <climits>
 #include <cstdint>
 #include <cstring>
 #include <cfloat>
@@ -274,25 +275,36 @@ float calibrate_fp8_scale(const Tensor& input, cudaStream_t stream) {
 // No host sync — caller provides pre-allocated d_block_maxes and d_absmax.
 // The scale is written to d_scale_out on device.
 
-void calibrate_and_quantize_fp8_async(const void* input_fp16, void* output_fp8, int n_elements,
+void calibrate_and_quantize_fp8_async(const void* input_fp16, void* output_fp8, int64_t n_elements,
                                       float* d_block_maxes, int max_grid, float* d_absmax, float* d_scale_out,
                                       cudaStream_t stream) {
     if (!input_fp16 || !output_fp8 || n_elements <= 0)
         return;
+    // The reduction/quantize kernels index with int. No current model is close
+    // (largest tensor ~778M elems), but guard the boundary loudly instead of
+    // silently truncating size_t→int — a >2.1B-element tensor would otherwise
+    // corrupt with a wrong grid + wrapped indices (F-A11). The callers pass the
+    // full size_t now, so the truncation can only ever happen here.
+    if (n_elements > static_cast<int64_t>(INT_MAX)) {
+        IMP_LOG_ERROR("calibrate_and_quantize_fp8_async: n_elements=%lld exceeds int range — skipping",
+                      static_cast<long long>(n_elements));
+        return;
+    }
+    const int n = static_cast<int>(n_elements);
 
-    const int grid = compute_grid(n_elements);
+    const int grid = compute_grid(n);
     const int reduce_grid = (grid <= max_grid) ? grid : max_grid;
 
     // Pass 1: absmax reduction
     absmax_reduce_kernel<<<reduce_grid, kBlockSize, 0, stream>>>(static_cast<const half*>(input_fp16),
-                                                                 d_block_maxes, n_elements);
+                                                                 d_block_maxes, n);
 
     absmax_final_reduce_kernel<<<1, kBlockSize, 0, stream>>>(d_block_maxes, d_absmax, reduce_grid);
 
     // Pass 2: fused scale computation + quantize (reads absmax from device)
     calibrate_quantize_fp8_kernel<<<grid, kBlockSize, 0, stream>>>(static_cast<const half*>(input_fp16),
                                                                    static_cast<uint8_t*>(output_fp8),
-                                                                   d_absmax, d_scale_out, n_elements);
+                                                                   d_absmax, d_scale_out, n);
 }
 
 // ---- quantize_fp16_to_fp8_e4m3 (Tensor API) ------------------------------

--- a/src/quant/fp8_quant.h
+++ b/src/quant/fp8_quant.h
@@ -25,7 +25,7 @@ void quantize_fp16_to_fp8_e4m3_scaled(const void* input_fp16, void* output_fp8, 
 // Fully async calibrate+quantize: no host sync, all on device.
 // Caller provides reusable temp buffers d_block_maxes[max_grid] and d_absmax[1].
 // Scale is written to d_scale_out on device.
-void calibrate_and_quantize_fp8_async(const void* input_fp16, void* output_fp8, int n_elements,
+void calibrate_and_quantize_fp8_async(const void* input_fp16, void* output_fp8, int64_t n_elements,
                                       float* d_block_maxes, int max_grid, float* d_absmax, float* d_scale_out,
                                       cudaStream_t stream = nullptr);
 

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -1018,14 +1018,26 @@ static bool snapshot_state_and_tokenize_(
             res.set_content(dump_safe(err), "application/json");
             return false;
         }
-        // Stop batching engine for exclusive vision access
-        if (state.batching)
-            state.batching->stop();
+        // PAUSE (not stop) the batching engine for exclusive vision access:
+        // pause() drains in-flight generations and parks the worker (same
+        // exclusivity as stop()) but does NOT cancel concurrent/queued requests
+        // — they complete or wait, then resume after the vision op (F-A5).
+        // Every exit below must clear_image() then resume() (the image is
+        // global; clearing before resume keeps a resumed request from binding
+        // stale vision embeddings). On a pause timeout the worker is still live,
+        // so we must NOT drive the engine — return 503.
+        if (state.batching && !state.batching->pause()) {
+            res.status = 503;
+            json err = {{"error", {{"message", "Server is busy. Please retry."}, {"type", "server_error"}}}};
+            res.set_content(dump_safe(err), "application/json");
+            return false;
+        }
 
         state.ctx->engine->clear_image();
         if (!state.ctx->engine->set_image_from_memory(ctx.params.image_data.data(), ctx.params.image_data.size())) {
+            // set_image failed → image already clear (clear_image above); just resume.
             if (state.batching)
-                state.batching->start(state.ctx);
+                state.batching->resume();
             res.status = 400;
             json error = {
                 {"error", {{"message", "Failed to process image"}, {"type", "invalid_request_error"}}}};
@@ -1205,8 +1217,9 @@ static bool snapshot_state_and_tokenize_(
     if (state.max_input_tokens > 0 && ctx.snap.n_prompt_tokens > state.max_input_tokens) {
         if (ctx.snap.has_vision_request) {
             std::lock_guard<std::timed_mutex> lock(state.mtx);
+            state.ctx->engine->clear_image();
             if (state.batching)
-                state.batching->start(state.ctx);
+                state.batching->resume();
         }
         res.status = 400;
         json error = {{"error",
@@ -1222,8 +1235,9 @@ static bool snapshot_state_and_tokenize_(
     if (ctx.snap.n_prompt_tokens >= ctx.snap.max_seq_len) {
         if (ctx.snap.has_vision_request) {
             std::lock_guard<std::timed_mutex> lock(state.mtx);
+            state.ctx->engine->clear_image();
             if (state.batching)
-                state.batching->start(state.ctx);
+                state.batching->resume();
         }
         res.status = 400;
         json error = {{"error",
@@ -1278,7 +1292,7 @@ static void handle_vision_chat_blocking_(httplib::Response& res, ServerState& st
     ImpError err = imp_context_reset(state.ctx);
     if (err != IMP_SUCCESS) {
         state.ctx->engine->clear_image();
-        state.batching->start(state.ctx);
+        state.batching->resume();
         res.status = 500;
         json error = {{"error",
                        {{"message", std::string("Context reset failed: ") + imp_error_string(err)},
@@ -1297,7 +1311,7 @@ static void handle_vision_chat_blocking_(httplib::Response& res, ServerState& st
                                   &prefill_params);
     if (err != IMP_SUCCESS) {
         state.ctx->engine->clear_image();
-        state.batching->start(state.ctx);
+        state.batching->resume();
         res.status = 500;
         json error = {{"error",
                        {{"message", std::string("Prefill failed: ") + imp_error_string(err)},
@@ -1369,7 +1383,7 @@ static void handle_vision_chat_blocking_(httplib::Response& res, ServerState& st
     }
 
     state.ctx->engine->clear_image();
-    state.batching->start(state.ctx);
+    state.batching->resume();
 
     // Build simple non-streaming response for vision
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -4669,8 +4683,9 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
         if (ctx.snap.has_vision_request) {
             {
                 std::lock_guard<std::timed_mutex> lock(state.mtx);
+                state.ctx->engine->clear_image();
                 if (state.batching)
-                    state.batching->start(state.ctx);
+                    state.batching->resume();
             }
             res.status = 400;
             json err = {{"type", "error"},


### PR DESCRIPTION
Follow-up to #772 closing the remaining parked soundness findings. A deeper re-trace **corrected two over-cautious park-rationales** from the first pass — verification cuts both ways.

## Fixed
| ID | Sev | Fix |
|---|---|---|
| **F-A5** | med | **Vision request now `pause()`s the engine instead of `stop()`** — `stop()` cancelled every concurrent in-flight request. The first pass parked this as "needs per-request image binding"; re-trace showed `pause()` *drains* in-flight work (the worker only parks when `active_requests_` is empty — `batching_engine.cpp:76-94,127`), giving the same exclusivity without cancelling. The global-image hazard is handled by clearing the image before every `resume()` (added at the reject paths that lacked it); a `pause()` timeout returns 503. Model-reload keeps `stop()`. |
| **F-A12** | low | **`if (block_id < 0) return;` guard in all 9 paged-KV write kernels** (defense-in-depth vs a negative block_id → OOB write). Re-trace found all `kv_resolve_slot` sites are *write* kernels (the earlier "shared with read paths + StreamingLLM `-1`" rationale was wrong), so the block-uniform guard is safe everywhere. |
| **F-A11** | low | **Widened `calibrate_and_quantize_fp8_async` `n_elements` to `int64_t` + a loud `>INT_MAX` guard.** Callers no longer `static_cast<int>` a `size_t`. The kernels keep `int` indexing (only ever reached for in-range sizes) — the responsible fix, not the invasive hot-path widen. Unreachable today (largest tensor ~778M ≪ 2³¹) but converts a silent truncation→corruption into a clean skip+log. |

## Already done (pass-1 backlog was stale)
CI1 (format-check gate, via `git clang-format` on changed lines), B2 (`CMakePresets.json`), TL1 (`.clang-tidy`), CI2 (advisory clang-tidy gate) are **already on main**. Only **CI3/T1/BM1** remain — they need a self-hosted RTX 5090 CI runner (infra, can't be provided here).

## Validation
- Build GREEN · GPU suite **0 failures**, 8 binaries (FP8 KV oracles, StreamingLLM sink-eviction, KV-write tests all pass — confirms F-A11 + F-A12 don't regress).
- **F-A5 e2e** (gemma-3-4b-vl + mmproj server): vision request returns correct output ("Cat"), and a request concurrent with a vision op completes with `finish=stop` — not cancelled. Concurrent-survival is structurally guaranteed by `pause()` draining (verified in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmippvZucgTNU7HyuWBapy