### PR TITLE
feat: per-request vision binding — vision batches with text (no engine pause)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1,4 +1,7 @@
 #include "runtime/engine.h"
+#include "core/buffer.h"
+#include "vision/image_processor.h"
+#include "runtime/request.h"
 #include "lora/lora_adapter.h"
 #include "runtime/engine_internal.h"
 #include "runtime/config.h"
@@ -418,6 +421,25 @@ bool Engine::set_image_from_memory(const uint8_t* data, size_t len) {
 }
 
 void Engine::clear_image() { vision_.clear_image(); }
+
+bool Engine::preprocess_image(const uint8_t* data, size_t len, ImageData& out) {
+    return vision_.preprocess(data, len, out);
+}
+
+bool Engine::encode_image_for(Request& req) {
+    if (!req.image || !vision_.is_available())
+        return false;
+    auto buf = std::make_shared<Buffer>(Buffer::device(vision_.embeddings_bytes()));
+    if (!*buf)
+        return false;
+    if (!vision_.encode_to(*req.image, buf->as<half>(), stream_))
+        return false;
+    req.vision_emb = std::move(buf);
+    req.vision_token_id = vision_.soft_token_id();
+    req.n_vision_tokens = vision_.num_image_tokens();
+    req.image.reset();  // host pixels no longer needed after encode
+    return true;
+}
 
 // =====================================================================
 // Initialization — decomposed into sub-phases

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -29,6 +29,8 @@
 
 namespace imp {
 
+struct ImageData;  // src/vision/image_processor.h (per-request vision)
+
 struct EngineConfig {
     int max_batch_size = 0;       // 0 = auto (engine detects from model size vs VRAM)
     int max_seq_len = 0;          // 0 = auto (engine detects from model metadata + VRAM)
@@ -163,6 +165,13 @@ public:
     void clear_image();
     bool has_vision() const noexcept { return vision_.is_available(); }
     bool has_vision_input() const noexcept { return vision_.has_input(); }
+    // Per-request vision (server batched path). preprocess_image runs CPU-only
+    // (safe off the worker, e.g. an HTTP handler thread). encode_image_for runs
+    // the GPU encode for req->image into a per-request buffer (req->vision_emb) —
+    // MUST be called from the batch worker (the encode is serialized + uses the
+    // shared encoder workspace). Returns false if no vision model / no image.
+    [[nodiscard]] bool preprocess_image(const uint8_t* data, size_t len, ImageData& out);
+    [[nodiscard]] bool encode_image_for(Request& req);
 
     // Enable MTP-based speculative decoding. K = draft length (1-4 typical).
     // Requires model->mtp_->loaded. Allocates the MTP workspace via the VRAM

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -22,6 +22,7 @@
 #include "runtime/engine.h"
 #include "runtime/engine_internal.h"
 #include "runtime/config.h"
+#include "core/buffer.h"
 #include "runtime/batch.h"
 #include "runtime/think_stop_logic.h"
 #include "compute/mtp_forward.h"
@@ -653,11 +654,13 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     // state built during earlier chunks must carry forward.
     fill_recurrent_state(*req, state, /*reset=*/(offset == 0), pf_stream);
 
-    // Vision embeddings on first chunk
-    if (vision_.has_input() && vision_.is_available() && offset == 0) {
-        state.vision_embeddings = vision_.embeddings();
-        state.vision_token_id = vision_.soft_token_id();
-        state.n_vision_tokens = vision_.num_image_tokens();
+    // Vision embeddings on first chunk. Per-request: the batch worker encoded
+    // req->image into req->vision_emb on admission, so vision requests batch
+    // normally with text (no global has_input_, no engine pause).
+    if (req->vision_emb && offset == 0) {
+        state.vision_embeddings = req->vision_emb->as<half>();
+        state.vision_token_id = req->vision_token_id;
+        state.n_vision_tokens = req->n_vision_tokens;
     }
 
     if (!is_last_chunk) {

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -3,9 +3,14 @@
 #include <vector>
 #include <cstdint>
 #include <string>
+#include <memory>
 #include "model/chat_template.h"
 
 namespace imp {
+
+// Forward declares to keep CUDA / buffer headers out of this widely-included file.
+struct ImageData;  // src/vision/image_processor.h
+class Buffer;       // src/core/buffer.h
 
 // Per-token log probability information (for logprobs output)
 struct TokenLogprob {
@@ -125,6 +130,17 @@ struct Request {
 
     // Logit bias: token_id -> bias value, added to logits before sampling
     std::vector<std::pair<int32_t, float>> logit_bias;
+
+    // Vision (multimodal), per-request binding. `image` carries CPU-preprocessed
+    // pixels set by the server/CLI; the batch worker encodes it into `vision_emb`
+    // (device [n_vision_tokens, d_model] fp16) on admission and clears `image`.
+    // step_prefill_one binds vision_emb at offset==0. shared_ptr → auto-freed on
+    // the last request reference (no manual lifecycle across cancel paths).
+    // Null for text-only requests.
+    std::shared_ptr<ImageData> image;
+    std::shared_ptr<Buffer> vision_emb;
+    int32_t vision_token_id = -1;
+    int n_vision_tokens = 0;
 
     int context_len() const { return static_cast<int>(input_tokens.size() + output_tokens.size()); }
 };

--- a/src/vision/vision_pipeline.cpp
+++ b/src/vision/vision_pipeline.cpp
@@ -30,6 +30,7 @@ bool VisionPipeline::init(const std::string& mmproj_path, int lm_d_model, Model*
     }
 
     int lm_d = model_->lm_d_model > 0 ? model_->lm_d_model : lm_d_model;
+    lm_d_ = lm_d;
     encoder_ = std::make_unique<VisionEncoder>();
     if (!encoder_->init(*model_, lm_d, stream, &alloc)) {
         IMP_LOG_ERROR("Failed to init vision encoder");
@@ -116,6 +117,29 @@ bool VisionPipeline::encode_image(const half* h_pixels, int n_pixels, cudaStream
         IMP_LOG_INFO("Vision: encoded image -> %d tokens", model_->config.num_image_tokens);
     }
     return ok;
+}
+
+bool VisionPipeline::preprocess(const uint8_t* data, size_t len, ImageData& out) const {
+    if (!model_)
+        return false;
+    return load_and_preprocess_image_from_memory(data, len, model_->config.image_size,
+                                                  model_->config.image_mean, model_->config.image_std, out);
+}
+
+bool VisionPipeline::encode_to(const ImageData& img, half* out, cudaStream_t stream) {
+    if (!encoder_ || !d_embeddings_ || !out || img.pixels.empty())
+        return false;
+    // Encode into the stable scratch d_embeddings_ (the encoder CUDA graph is
+    // keyed on the output pointer — encoding straight into a per-request buffer
+    // would recapture ~200 kernels every image), then copy to the caller buffer.
+    if (!encode_image(img.pixels.data(), static_cast<int>(img.pixels.size()), stream))
+        return false;
+    cudaMemcpyAsync(out, d_embeddings_, embeddings_bytes(), cudaMemcpyDeviceToDevice, stream);
+    cudaStreamSynchronize(stream);
+    // encode_image sets the legacy global has_input_ flag as a side effect; the
+    // per-request path doesn't use it, so clear it to avoid leaking global state.
+    has_input_ = false;
+    return true;
 }
 
 bool VisionPipeline::set_image(const std::string& path, cudaStream_t stream) {

--- a/src/vision/vision_pipeline.h
+++ b/src/vision/vision_pipeline.h
@@ -13,6 +13,7 @@
 namespace imp {
 
 class Model;
+struct ImageData;  // src/vision/image_processor.h
 
 // Encapsulates the vision (multimodal) pipeline: model loading, image
 // preprocessing, SigLIP encoding, and embedding buffer management.
@@ -32,6 +33,21 @@ public:
     [[nodiscard]] bool set_image_from_memory(const uint8_t* data, size_t len, cudaStream_t stream);
 
     void clear_image() { has_input_ = false; }
+
+    // --- Per-request binding API (server batched path) -------------------
+    // CPU-only preprocess (decode/resize/normalize) — safe to call off the
+    // batch worker (e.g. an HTTP handler thread). Fills `out` with FP16 pixels.
+    [[nodiscard]] bool preprocess(const uint8_t* data, size_t len, ImageData& out) const;
+    // Encode a preprocessed image into the caller's `out` device buffer (sized
+    // embeddings_bytes()). Encodes into the STABLE scratch d_embeddings_ first
+    // (the encoder CUDA graph is keyed on the output pointer, so a per-request
+    // output would force a full recapture every image) then copies to `out`.
+    // Serialized: the caller MUST be the sole GPU driver (the batch worker).
+    [[nodiscard]] bool encode_to(const ImageData& img, half* out, cudaStream_t stream);
+    size_t embeddings_bytes() const noexcept {
+        return static_cast<size_t>(num_image_tokens()) * static_cast<size_t>(lm_d_) * sizeof(half);
+    }
+    int lm_d() const noexcept { return lm_d_; }
 
     // Accessors
     bool is_available() const noexcept { return encoder_ != nullptr; }
@@ -53,6 +69,7 @@ private:
     size_t d_pixels_size_ = 0;
 
     bool has_input_ = false;
+    int lm_d_ = 0;  // LLM embedding dim (vision embeddings are [num_image_tokens, lm_d_])
     int32_t soft_token_id_ = -1;
     int32_t boi_id_ = -1;
     int32_t eoi_id_ = -1;

--- a/tools/imp-server/batching_engine.cpp
+++ b/tools/imp-server/batching_engine.cpp
@@ -162,6 +162,17 @@ void BatchingEngine::worker_loop() {
                     auto sr = std::move(pending_queue_.front());
                     pending_queue_.pop_front();
 
+                    // Per-request vision: encode the image on THIS worker thread
+                    // (the encode is serialized + uses the shared encoder
+                    // workspace, so it must not run concurrently with step()).
+                    // The result lands in request->vision_emb; the request then
+                    // batches with text like any other — no engine pause.
+                    if (sr->request->image && !engine->encode_image_for(*sr->request)) {
+                        sr->request->status = imp::RequestStatus::CANCELLED;
+                        sr->push_finish("image_encode_failed");
+                        continue;
+                    }
+
                     sr->notified_count = sr->request->output_tokens.size();
                     engine->add_request(sr->request);
                     active_requests_.push_back(std::move(sr));

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -5,6 +5,8 @@
 #include "stream_pipeline.h"
 
 #include "api/imp_internal.h"
+#include "vision/image_processor.h"
+#include "runtime/request.h"
 #include "memory/kv_cache.h"
 #include "model/hf_hub.h"
 #include "runtime/config.h"
@@ -77,6 +79,10 @@ struct ChatStateSnapshot {
     int32_t channel_open_id = -1, channel_close_id = -1, channel_newline_id = -1;
     int max_seq_len = 0;
     bool has_vision_request = false;
+    // Per-request vision (F-A5): CPU-preprocessed image pixels, copied to
+    // req->image at every request-build site. The batch worker encodes + binds
+    // it per-request (no engine pause). Null for text-only requests.
+    std::shared_ptr<imp::ImageData> vision_image;
     std::vector<int32_t> stop_token_ids;
     imp::ChatTemplateFamily tpl_family = imp::ChatTemplateFamily::CHATML;
     std::vector<imp::ToolFunction> tool_defs;
@@ -1009,41 +1015,22 @@ static bool snapshot_state_and_tokenize_(
     // tools_via_jinja tracks whether we'll attempt the Jinja2 tools path
     ctx.snap.tools_via_jinja = !ctx.snap.tool_defs.empty();
 
-    // Handle vision: requires exclusive lock since it modifies engine state
+    // Vision (per-request, F-A5): CPU-preprocess the image into
+    // ctx.snap.vision_image — no engine pause, no global image. Each
+    // request-build site copies it to req->image; the batch worker encodes +
+    // binds it per-request on admission, so a vision request batches like text.
+    // Soft-token placeholders are injected by apply_with_image() below.
     if (ctx.snap.has_vision_request) {
-        std::unique_lock<std::timed_mutex> lock(state.mtx, std::chrono::minutes(5));
-        if (!lock.owns_lock()) {
-            res.status = 503;
-            json err = {{"error", {{"message", "Server is busy. Please retry."}, {"type", "server_error"}}}};
-            res.set_content(dump_safe(err), "application/json");
-            return false;
-        }
-        // PAUSE (not stop) the batching engine for exclusive vision access:
-        // pause() drains in-flight generations and parks the worker (same
-        // exclusivity as stop()) but does NOT cancel concurrent/queued requests
-        // — they complete or wait, then resume after the vision op (F-A5).
-        // Every exit below must clear_image() then resume() (the image is
-        // global; clearing before resume keeps a resumed request from binding
-        // stale vision embeddings). On a pause timeout the worker is still live,
-        // so we must NOT drive the engine — return 503.
-        if (state.batching && !state.batching->pause()) {
-            res.status = 503;
-            json err = {{"error", {{"message", "Server is busy. Please retry."}, {"type", "server_error"}}}};
-            res.set_content(dump_safe(err), "application/json");
-            return false;
-        }
-
-        state.ctx->engine->clear_image();
-        if (!state.ctx->engine->set_image_from_memory(ctx.params.image_data.data(), ctx.params.image_data.size())) {
-            // set_image failed → image already clear (clear_image above); just resume.
-            if (state.batching)
-                state.batching->resume();
+        auto img = std::make_shared<imp::ImageData>();
+        if (!state.ctx->engine->preprocess_image(ctx.params.image_data.data(),
+                                                  ctx.params.image_data.size(), *img)) {
             res.status = 400;
             json error = {
                 {"error", {{"message", "Failed to process image"}, {"type", "invalid_request_error"}}}};
             res.set_content(dump_safe(error), "application/json");
             return false;
         }
+        ctx.snap.vision_image = std::move(img);
     }
 
     // Thinking mode default: ON for think models in plain chat. These models
@@ -1215,12 +1202,6 @@ static bool snapshot_state_and_tokenize_(
     // Server-side input-token limit (--max-input-tokens). Reject before
     // prefill so an oversized prompt never reaches the engine.
     if (state.max_input_tokens > 0 && ctx.snap.n_prompt_tokens > state.max_input_tokens) {
-        if (ctx.snap.has_vision_request) {
-            std::lock_guard<std::timed_mutex> lock(state.mtx);
-            state.ctx->engine->clear_image();
-            if (state.batching)
-                state.batching->resume();
-        }
         res.status = 400;
         json error = {{"error",
                        {{"message", "Prompt exceeds max input tokens (" +
@@ -1233,12 +1214,6 @@ static bool snapshot_state_and_tokenize_(
 
     // Validate prompt length against context window
     if (ctx.snap.n_prompt_tokens >= ctx.snap.max_seq_len) {
-        if (ctx.snap.has_vision_request) {
-            std::lock_guard<std::timed_mutex> lock(state.mtx);
-            state.ctx->engine->clear_image();
-            if (state.batching)
-                state.batching->resume();
-        }
         res.status = 400;
         json error = {{"error",
                        {{"message", "Prompt exceeds context window (" + std::to_string(ctx.snap.n_prompt_tokens) +
@@ -1282,146 +1257,6 @@ static bool snapshot_state_and_tokenize_(
     return true;
 }
 
-// Vision-request blocking decode path: prefill via C API, sample tokens in a
-// blocking loop until EOS/stop/max_tokens, build a non-streaming JSON response
-// (vision doesn't support SSE — state is per-engine, not per-request).
-// Caller must hold no lock on entry. Returns after sending the response.
-static void handle_vision_chat_blocking_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx,
-                                         const std::shared_ptr<imp::Request>& imp_req) {
-    // Vision path: use blocking C API (batching engine is stopped)
-    ImpError err = imp_context_reset(state.ctx);
-    if (err != IMP_SUCCESS) {
-        state.ctx->engine->clear_image();
-        state.batching->resume();
-        res.status = 500;
-        json error = {{"error",
-                       {{"message", std::string("Context reset failed: ") + imp_error_string(err)},
-                        {"type", "server_error"}}}};
-        res.set_content(dump_safe(error), "application/json");
-        return;
-    }
-
-    // Build params now so prefill's first-token sample also honours them
-    ImpGenerateParams prefill_params = imp_generate_params_default();
-    prefill_params.temperature = ctx.params.temperature;
-    prefill_params.top_p = ctx.params.top_p;
-    prefill_params.top_k = ctx.params.top_k;
-    prefill_params.seed = ctx.params.seed;
-    err = imp_prefill_with_params(state.ctx, imp_req->input_tokens.data(), ctx.snap.n_prompt_tokens,
-                                  &prefill_params);
-    if (err != IMP_SUCCESS) {
-        state.ctx->engine->clear_image();
-        state.batching->resume();
-        res.status = 500;
-        json error = {{"error",
-                       {{"message", std::string("Prefill failed: ") + imp_error_string(err)},
-                        {"type", "server_error"}}}};
-        res.set_content(dump_safe(error), "application/json");
-        return;
-    }
-
-    // After prefill, clear vision and restart batching engine
-    // The rest of generation will use the old blocking decode path
-    // (via imp_decode_step, which calls engine->step() directly)
-    // This is safe because batching engine is stopped.
-
-    ImpGenerateParams params = imp_generate_params_default();
-    params.temperature = ctx.params.temperature;
-    params.top_p = ctx.params.top_p;
-    params.top_k = ctx.params.top_k;
-    params.max_tokens = ctx.params.max_tokens;
-    params.seed = ctx.params.seed;
-    params.min_p = ctx.params.min_p;
-    params.typical_p = ctx.params.typical_p;
-    params.repetition_penalty = ctx.params.repetition_penalty;
-    params.frequency_penalty = ctx.params.frequency_penalty;
-    params.presence_penalty = ctx.params.presence_penalty;
-    params.repeat_last_n = ctx.params.repeat_last_n;
-    params.dry_multiplier = ctx.params.dry_multiplier;
-    params.dry_base = ctx.params.dry_base;
-    params.dry_allowed_length = ctx.params.dry_allowed_length;
-    params.dry_penalty_last_n = ctx.params.dry_penalty_last_n;
-    params.mirostat = ctx.params.mirostat;
-    params.mirostat_tau = ctx.params.mirostat_tau;
-    params.mirostat_eta = ctx.params.mirostat_eta;
-    params.logprobs = ctx.params.req_logprobs ? 1 : 0;
-    params.top_logprobs = ctx.params.top_logprobs;
-    params.json_mode = ctx.params.json_mode ? 1 : 0;
-
-    // Blocking decode loop for vision requests
-    std::vector<int32_t> output_ids;
-    int32_t prefill_token = -1;
-    if (state.ctx->active_request && !state.ctx->active_request->output_tokens.empty()) {
-        prefill_token = state.ctx->active_request->output_tokens.back();
-    }
-
-    for (int step = -1; step < ctx.params.max_tokens; step++) {
-        int32_t token = 0;
-        if (step == -1) {
-            if (prefill_token < 0)
-                continue;
-            token = prefill_token;
-        } else {
-            err = imp_decode_step(state.ctx, &params, &token);
-            if (err != IMP_SUCCESS)
-                break;
-        }
-        if (token == ctx.snap.tok->eos_id())
-            break;
-        if (ctx.snap.have_template) {
-            bool is_stop = false;
-            for (int32_t stop_id : ctx.snap.stop_token_ids) {
-                if (token == stop_id) {
-                    is_stop = true;
-                    break;
-                }
-            }
-            if (is_stop)
-                break;
-        }
-        output_ids.push_back(token);
-    }
-
-    state.ctx->engine->clear_image();
-    state.batching->resume();
-
-    // Build simple non-streaming response for vision
-    auto t_end = std::chrono::high_resolution_clock::now();
-    double ms = std::chrono::duration<double, std::milli>(t_end - ctx.t_start).count();
-    int n_output_tokens = static_cast<int>(output_ids.size());
-    std::string content = ctx.snap.tok->decode(output_ids);
-
-    fprintf(stderr, "[%s] vision: %d prompt + %d completion tokens, %.1f ms\n", ctx.req_id.c_str(),
-            ctx.snap.n_prompt_tokens, n_output_tokens, ms);
-    state.metrics.requests_total++;
-    state.metrics.tokens_prompt_total += ctx.snap.n_prompt_tokens;
-    state.metrics.tokens_completion_total += n_output_tokens;
-    state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
-
-    json response_for_log = {{"id", ctx.req_id},
-                             {"object", "chat.completion"},
-                             {"model", ctx.snap.model_name},
-                             {"choices", json::array({{{"index", 0},
-                                                        {"message", {{"role", "assistant"},
-                                                                     {"content", content}}},
-                                                        {"finish_reason", "stop"}}})}};
-    log_request_jsonl(state, ctx.log_skip, ctx.t_log_start, ctx.req_id, ctx.log_endpoint,
-                      ctx.log_client_ip, ctx.log_raw_body, ms,
-                      ctx.snap.n_prompt_tokens, n_output_tokens, "stop", response_for_log);
-
-    json response = {{"id", ctx.req_id},
-                     {"object", "chat.completion"},
-                     {"created", unix_timestamp()},
-                     {"model", ctx.snap.model_name},
-                     {"choices", json::array({{{"index", 0},
-                                               {"message", {{"role", "assistant"}, {"content", content}}},
-                                               {"finish_reason", "stop"}}})},
-                     {"usage",
-                      {{"prompt_tokens", ctx.snap.n_prompt_tokens},
-                       {"completion_tokens", n_output_tokens},
-                       {"total_tokens", ctx.snap.n_prompt_tokens + n_output_tokens}}}};
-    res.set_content(dump_safe(response), "application/json");
-}
 
 // Non-streaming chat completion: run n_completions independent generations
 // sequentially via the batching engine, build the choices array with
@@ -1440,6 +1275,7 @@ static void nonstream_chat_response_(
     // Helper to create an imp::Request with the given completion index
     auto make_imp_request = [&](int completion_idx) {
         auto req = std::make_shared<imp::Request>();
+        req->image = ctx.snap.vision_image;  // per-request vision (null for text)
         req->input_tokens = saved_tokens;
         req->max_tokens = ctx.params.max_tokens;
         req->temperature = ctx.params.temperature;
@@ -2714,6 +2550,7 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
     // Helper to create an imp::Request with the given completion index
     auto make_imp_request = [&](int completion_idx) {
         auto req = std::make_shared<imp::Request>();
+        req->image = ctx.snap.vision_image;  // per-request vision (null for text)
         req->input_tokens = saved_tokens;
         req->max_tokens = ctx.params.max_tokens;
         req->temperature = ctx.params.temperature;
@@ -2763,12 +2600,9 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
     auto server_req = std::make_shared<ServerRequest>();
     server_req->request = imp_req;
 
-    // For vision requests, fall back to blocking mode since vision state
-    // is per-engine (not per-request). Use the old C API path.
-    if (ctx.snap.has_vision_request) {
-        handle_vision_chat_blocking_(res, state, ctx, imp_req);
-        return;
-    }
+    // Vision requests are now per-request (req->image, encoded by the worker on
+    // admission) and flow through the normal batching path below — no blocking
+    // C-API fallback, no engine pause.
 
     // Submit to batching engine for continuous batching
     {
@@ -2949,7 +2783,8 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
 
     auto t_start = std::chrono::high_resolution_clock::now();
 
-    // Create an imp::Request and submit to batching engine
+    // Create an imp::Request and submit to batching engine (/v1/completions is
+    // text-only — no vision).
     auto imp_req = std::make_shared<imp::Request>();
     imp_req->input_tokens = std::move(tokens);
     imp_req->max_tokens = max_tokens;
@@ -4677,26 +4512,9 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
         ctx.log_raw_body = log_raw_body;
         ctx.t_log_start = t_log_start;
 
-        // Vision streaming is unsupported (state is per-engine, not per-req).
-        // snapshot_state_and_tokenize_ stops the batching engine for exclusive
-        // vision access — restart it before bailing out.
-        if (ctx.snap.has_vision_request) {
-            {
-                std::lock_guard<std::timed_mutex> lock(state.mtx);
-                state.ctx->engine->clear_image();
-                if (state.batching)
-                    state.batching->resume();
-            }
-            res.status = 400;
-            json err = {{"type", "error"},
-                        {"error",
-                         {{"type", "invalid_request_error"},
-                          {"message", "Streaming is not supported for vision/image requests"}}}};
-            res.set_content(dump_safe(err), "application/json");
-            return;
-        }
-
+        // Vision is per-request now (req->image) and streams like any request.
         auto imp_req = std::make_shared<imp::Request>();
+        imp_req->image = ctx.snap.vision_image;  // per-request vision (null for text)
         imp_req->input_tokens = ctx.snap.tokens;
         imp_req->max_tokens = ctx.params.max_tokens;
         imp_req->temperature = ctx.params.temperature;


### PR DESCRIPTION
The full F-A5 follow-up. #773 stopped vision requests from *cancelling* concurrent requests (pause-not-stop). This decouples vision from the global `VisionPipeline` state entirely, so a vision request becomes a **normal batched request** — it runs concurrently with text instead of serializing the whole engine.

## What changed
**Engine foundation:**
- `Request` carries per-request `image` (CPU-preprocessed pixels) + `vision_emb` (device embeddings, RAII `shared_ptr<Buffer>` → auto-freed on last ref, no cancel-path lifecycle).
- `VisionPipeline::preprocess()` (CPU, handler-thread-safe) + `encode_to()`: **encodes into the stable scratch `d_embeddings_` then copies to the per-request buffer** — the encoder's CUDA graph is keyed on the output pointer (`vision_encoder.cu:551`), so a per-request output would recapture ~200 kernels/image. Verified.
- `Engine::encode_image_for()`; the `BatchingEngine` worker encodes `req->image` on admission (serialized on the sole GPU-driving thread — **no engine pause**); `step_prefill_one` binds `req->vision_emb` per-request (was global `has_input_`).

**Server:** vision chat/messages flow through the normal submit→worker→batch path. Deleted the separate blocking `handle_vision_chat_blocking_` path + the #773 pause/resume reject paths. **Vision now streams** (per-request state ⇒ the "streaming unsupported for vision" reject is gone). The consume kernel + `InferenceState` are unchanged.

Net **+131 / −211** (the per-request path is simpler than the blocking path it replaces).

## Validation (gemma-3-4b-vl + mmproj, RTX 5090)
- **Vision correct:** non-stream chat with a cat image → "Cat".
- **Concurrent batching (the feature):** a vision request and a text request fired simultaneously **both complete** (text="Okay", vis="Cat", both finish=stop) — batched, not serialized.
- **Vision streaming:** chat `stream:true` delivers SSE token events (was rejected before).
- **No regression:** build GREEN, GPU suite **0 failures** (8 binaries). Per-request encode confirmed in server logs ("encoded image -> 256 tokens" per request).

## Notes
- The shared 595 MiB encoder workspace means image *encode* is still serialized on the worker (one image at a time) — but generation batches freely. This is the intended trade-off (per-request encode workspaces would be far too expensive).
- `/v1/completions` is text-only (no image attach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmippvZucgTNU7HyuWBapy