### PR TITLE
fix(vision): restore global image bind for imp-cli/C-API (#774 regression)

### DIFF
--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -654,13 +654,22 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     // state built during earlier chunks must carry forward.
     fill_recurrent_state(*req, state, /*reset=*/(offset == 0), pf_stream);
 
-    // Vision embeddings on first chunk. Per-request: the batch worker encoded
-    // req->image into req->vision_emb on admission, so vision requests batch
-    // normally with text (no global has_input_, no engine pause).
+    // Vision embeddings on first chunk.
     if (req->vision_emb && offset == 0) {
+        // Per-request (server batched path): the worker encoded req->image into
+        // req->vision_emb on admission, so vision batches with text.
         state.vision_embeddings = req->vision_emb->as<half>();
         state.vision_token_id = req->vision_token_id;
         state.n_vision_tokens = req->n_vision_tokens;
+    } else if (vision_.has_input() && vision_.is_available() && offset == 0) {
+        // Global path: the C-API (imp_set_image) / imp-cli set ONE image on the
+        // engine for the next generation; its request carries no per-request
+        // embeddings, so bind the global ones. (Restores the pre-per-request
+        // binding the server no longer uses — imp_prefill_with_params builds a
+        // bare request, so without this the CLI's image was silently ignored.)
+        state.vision_embeddings = vision_.embeddings();
+        state.vision_token_id = vision_.soft_token_id();
+        state.n_vision_tokens = vision_.num_image_tokens();
     }
 
     if (!is_last_chunk) {


### PR DESCRIPTION
**Regression fix.** #774 (per-request vision) made `step_prefill_one` bind embeddings from `req->vision_emb` and removed the global `vision_.has_input()` bind. The server fills `req->image` (worker encodes on admission), but the C-API prefill `imp_prefill_with_params` — used by **`imp-cli --image`** — builds a *bare* request from raw tokens and sets the image **globally** via `imp_set_image`. With the global bind gone, the image was tokenized into soft-token placeholders but never spliced into the hidden states → `imp-cli --image` (and any `imp_set_image` C-API user) **silently ignored the image**.

Caught during a post-merge hygiene pass (the #774 server e2e couldn't catch it — the server uses the per-request path; the CLI uses the global C-API path).

## Fix
Add the global bind back as an `else` branch in `step_prefill_one`: per-request embeddings win (server), else fall back to the engine's single global image (C-API / CLI). One-branch, additive — the server `if` path is untouched.

## Validation
- `imp-cli --model gemma-3-4b-it … --mmproj … --image test_cat.jpg --prompt "What animal? One word."` → **"Cat"** (was unbound/ignored before this fix).
- GPU suite **0 failures** (8 binaries). Server per-request path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmippvZucgTNU7HyuWBapy