### PR TITLE
feat(spec): n-gram speculative decode default-on (dense), gated off for MoE

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -270,10 +270,11 @@ mmproj               = ""
 # n-gram (prompt-lookup) speculative decoding: drafts come from suffix
 # matches against the request's own prompt+output — no draft model. Greedy
 # verify accepts the longest matching prefix, so output stays a faithful
-# greedy decode. Batch-1, greedy sampling, dense-attention models only;
+# greedy decode. Batch-1, greedy sampling, dense-attention models only
+# (MoE/recurrent gate off automatically — the async decode loop carries them);
 # disables the async decode graph loop while on. Wins on repetition-heavy
-# (agent/code/RAG) workloads; can cost a few % on free-form prose.
-ngram                = false
+# (agent/code/RAG) workloads; ~neutral on free-form prose. Default-ON.
+ngram                = true
 # Draft tokens proposed per verify step (verify cost is ~flat in k).
 k                    = 16
 # Shortest / longest suffix n-gram match searched. Longer min_match =

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -454,10 +454,16 @@ struct RuntimeConfig {
     // model, no MTP head. Greedy-only Phase 1: the verify step replays the
     // draft as a teacher-forced continuation chunk and accepts the longest
     // argmax-matching prefix, so output is token-identical to plain greedy
-    // decode. Opt-in: the verify loop runs eager (no async conditional
-    // graph loop), which costs on draft-miss-heavy workloads.
+    // decode. The verify loop runs eager (no async conditional graph loop);
+    // burst_rearm + miss_burst keep draft-miss fragmentation ~free, so the old
+    // tg128 -15% draft-poor downside no longer reproduces (-0.2%/-0.9% on
+    // dense Q8/NVFP4, 2026-06-16) — hence default-ON. spec_ngram_gates_ok_
+    // confines engagement to batch-1 / greedy / no-penalty-window / no-json /
+    // no-logprobs / non-recurrent / NON-MoE requests; everything else falls
+    // back cleanly, so default-on is a no-op for sampled chat, tool/JSON
+    // calls, concurrent batches, and MoE (which the async loop carries).
     struct Speculative {
-        bool ngram = false;  // enable prompt-lookup speculation (batch-1, greedy)
+        bool ngram = true;  // prompt-lookup speculation, default-on (batch-1, greedy, dense)
         int k = 16;          // draft tokens per verify step (verify cost is ~flat in k)
         // Longer suffix matches trade draft frequency for precision — and
         // precision wins decisively: min_match 6 vs 3 measured +16% on

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -906,12 +906,13 @@ void Engine::step_decode(cudaStream_t dec_stream) {
                 IMP_LOG_INFO(
                     "spec-ngram: gates failed (temp=%.2f top_k=%d rep_pen=%.2f freq=%.2f "
                     "pres=%.2f dry=%.2f mirostat=%d bias=%zu logprobs=%d json=%d schema=%d "
-                    "think_budget=%.2f ssm=%d gdn=%d mtp=%d chunked_prefill=%d)",
+                    "think_budget=%.2f ssm=%d gdn=%d moe=%d mtp=%d chunked_prefill=%d)",
                     r.temperature, r.top_k, r.repetition_penalty, r.frequency_penalty,
                     r.presence_penalty, r.dry_multiplier, r.mirostat, r.logit_bias.size(),
                     (int)r.logprobs, (int)r.json_mode, (int)!r.json_schema.empty(), r.think_budget,
                     (int)(ssm_state_ != nullptr), (int)(gdn_state_ != nullptr),
-                    (int)mtp_spec_decode_enabled(), (int)supports_chunked_prefill_());
+                    (int)model_->profile().is_moe, (int)mtp_spec_decode_enabled(),
+                    (int)supports_chunked_prefill_());
             }
         }
     }

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -163,6 +163,12 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     // Recurrent state (SSM/GDN) advances on every forwarded token and cannot
     // be rewound on draft rejection.
     if (ssm_state_ || gdn_state_) return false;
+    // MoE decode is carried by the async conditional-graph loop (+27-36%, the
+    // MoE-decode foundation). The eager spec-verify path disables that loop and
+    // regresses MoE -11..-73% even at ~99% draft acceptance (perf hunt
+    // 2026-06-18) — the host must see every token to draft+accept. Net-negative
+    // for MoE as-is, so gate it off and stay on the loop (dense keeps the win).
+    if (model_->profile().is_moe) return false;
     if (mtp_spec_decode_enabled()) return false;
     if (!supports_chunked_prefill_()) return false;
     return true;


### PR DESCRIPTION
Flips `speculative.ngram` false→true so dense greedy decode gets prompt-lookup speculation by default — a big win on the repetition-heavy agent/code/RAG workloads the new agentic goal targets — while **protecting MoE heroes** from a regression.

## Why now
The last default-on blocker — the synthetic `tg128 -15%` draft-poor downside — was **refuted on main** (2026-06-16: measured −0.2% Qwen3-14B-NVFP4 / −0.9% Qwen3-8B-Q8). `burst_rearm` (default-on since #683/#692) makes draft-miss fragmentation ~free. The existing `spec_ngram_gates_ok_` already confines engagement to **batch-1 / greedy / no-penalty-window / no-json / no-logprobs / non-recurrent** requests, so default-on is a **no-op** for sampled chat, tool/JSON calls, logprobs, and concurrent (batch>1) decode.

## The MoE gate (the important part)
MoE decode is carried by the **async conditional-graph loop** (+27–36%, the MoE-decode foundation). The eager spec-verify path **disables that loop** and regresses MoE **−11..−73%** even at ~99% draft acceptance (perf hunt 2026-06-18) — and MoE has no GDN/SSM, so the existing recurrent gate didn't catch it. This PR adds:
- `if (model_->profile().is_moe) return false;` in `spec_ngram_gates_ok_`
- a `moe=` field in the gates-failed diagnostic so a MoE block is self-evident (not a mystery "all clean but failed")

## Verification (RTX 5090, imp:test, CUDA 13.3)
| Model | Result |
|---|---|
| **Qwen3-8B-Q8 (dense)** | spec engages, `accepted=53.1%` (9.5 tok/verify) on a repetition prompt; coherent + correct on code / reasoning / list prompts |
| **Qwen3-Coder-30B-FP4 (MoE)** | gate blocks — diagnostic shows `moe=1` with every other condition clean (`top_k=1 rep_pen=1.00 ssm=0 gdn=0 mtp=0 chunked_prefill=1`); full async-loop speed **tg=335** (no −73%), coherent |

`imp.conf.example` updated to `ngram=true`. Reverses the 2026-06-16 "keep opt-in" decision now that the MoE regression has a clean gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)