### PR TITLE
fix(nvfp4): derive prefill-fallback GEMM K from activation, not packed weight shape

### DIFF
--- a/src/compute/weight_dispatch.cu
+++ b/src/compute/weight_dispatch.cu
@@ -90,10 +90,17 @@ void gemm_dispatch(cublasLtHandle_t, const WeightHandle& w, const Tensor& x, Ten
             tmp.tensor_scale = (w.payload.nvfp4.tensor_scale != nullptr) ? *w.payload.nvfp4.tensor_scale
                                                                          : 1.0f;
             tmp.N = w.shape[0];
-            // shape[1] holds LOGICAL K — matches MXFP4 dispatch (line ~348)
-            // and WeightRegistry::reserve(kind, t.shape[0], t.shape[1]) in
-            // executor_pre_dequant.cu where t.shape[1] is logical K.
-            tmp.K = w.shape[1];
+            // Logical K = the activation's K (GEMM contract: x is [M, K], so
+            // x.shape[1] IS the logical K). Deriving K from the weight handle is
+            // unsafe here: shape[1] is PACKED (K/2) for prequant-loaded NVFP4
+            // weights but LOGICAL for handles built elsewhere (e.g. the
+            // WeightDispatchTest fixture) — an inconsistent convention. The old
+            // `= w.shape[1]` took the packed value, so the M>1 dequant→cuBLAS GEMM
+            // fallback aborted "B.shape[1]=<2K> must equal weight K=<K>" whenever a
+            // prefill reached this shim with a prequant weight — e.g. a native-NVFP4
+            // model whose CUTLASS prefill workspace was starved by a large KV budget
+            // (server agentic long-context defaults), forcing the dequant fallback.
+            tmp.K = static_cast<int>(x.shape[1]);
 
             int M = static_cast<int>(x.shape[0]);
             // Diagnostic: diagnostics.nvfp4_force_dequant (legacy IMP_NVFP4_FORCE_DEQUANT=1)

--- a/tests/test_weight_dispatch.cu
+++ b/tests/test_weight_dispatch.cu
@@ -416,6 +416,76 @@ TEST_F(WeightDispatchTest, NVFP4_GemmMatchesDirect) {
     cudaFree(d_y_disp);
 }
 
+// Regression: prequant-loaded NVFP4 weight handles carry the PACKED K/2 in
+// shape[1] (two FP4 nibbles per byte), NOT the logical K — an inconsistent
+// convention vs the handles built above (which use logical K). The phase-2 shim
+// must derive K from the activation, never from the handle, or the M>1 dequant
+// GEMM fallback aborts "B.shape[1]=<K> must equal weight K=<K/2>". This is the
+// native-NVFP4 server crash that surfaced when a large KV budget starved the
+// CUTLASS prefill workspace and forced the dequant fallback. Identical to
+// NVFP4_GemmMatchesDirect except h.shape[1] holds the PACKED dimension.
+TEST_F(WeightDispatchTest, NVFP4_GemmPackedShapeMatchesDirect) {
+    const int N_OUT = 16, M_BATCH = 8, K = 64;
+
+    std::vector<half> h_w(N_OUT * K), h_x(M_BATCH * K);
+    for (int i = 0; i < N_OUT * K; ++i)
+        h_w[i] = __float2half((i % 5) * 0.1f - 0.2f);
+    for (int i = 0; i < M_BATCH * K; ++i)
+        h_x[i] = __float2half((i % 7) * 0.05f - 0.15f);
+
+    half* d_w = dev_alloc_copy(h_w);
+    half* d_x = dev_alloc_copy(h_x);
+
+    int64_t wshape[2] = {N_OUT, K};
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
+
+    NvFP4QuantResult qr;
+    quantize_fp16_to_nvfp4(w_t, qr, stream_);
+    cudaStreamSynchronize(stream_);
+    float saved_ts = qr.tensor_scale;
+    qr.tensor_scale = 1.0f;
+
+    int64_t xshape[2] = {M_BATCH, K}, yshape[2] = {M_BATCH, N_OUT};
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+
+    half *d_y_direct, *d_y_disp;
+    cudaMalloc(&d_y_direct, M_BATCH * N_OUT * sizeof(half));
+    cudaMalloc(&d_y_disp, M_BATCH * N_OUT * sizeof(half));
+    Tensor y_direct(d_y_direct, QType::F16, 2, yshape, true);
+    Tensor y_disp(d_y_disp, QType::F16, 2, yshape, true);
+
+    gemm_nvfp4(qr, x_t, y_direct, stream_);
+    cudaStreamSynchronize(stream_);
+
+    WeightHandle h;
+    h.kind = TensorKind::WQ;
+    h.primary_tier = StorageTier::NVFP4;
+    h.shape[0] = N_OUT;
+    h.shape[1] = K / 2;  // PACKED — mirrors the prequant loader (logical K = shape[1]*2)
+    h.payload.nvfp4.data = static_cast<uint8_t*>(qr.packed_data);
+    h.payload.nvfp4.block_scales = static_cast<uint8_t*>(qr.micro_scales);
+    h.payload.nvfp4.tensor_scale = nullptr;
+    h.payload.nvfp4.tensor_scale_2 = nullptr;
+
+    // With the old `tmp.K = w.shape[1]` this aborted in gemm_nvfp4; the activation-
+    // derived K makes it succeed and match the direct call.
+    gemm_dispatch(lt_, h, x_t, y_disp, 1.0f, 0.0f, workspace_, kWorkspaceBytes, stream_);
+    cudaStreamSynchronize(stream_);
+
+    auto h_direct = dev_read(d_y_direct, M_BATCH * N_OUT);
+    auto h_disp = dev_read(d_y_disp, M_BATCH * N_OUT);
+    for (int i = 0; i < M_BATCH * N_OUT; ++i)
+        EXPECT_EQ(__half_as_ushort(h_direct[i]), __half_as_ushort(h_disp[i]))
+            << "NVFP4 packed-shape GEMM dispatch mismatch at i=" << i;
+
+    qr.tensor_scale = saved_ts;
+    free_nvfp4_result(qr);
+    cudaFree(d_w);
+    cudaFree(d_x);
+    cudaFree(d_y_direct);
+    cudaFree(d_y_disp);
+}
+
 // gemv_dispatch NVFP4 tier (M=1): single-token decode.
 // Same parity approach: force tensor_scale=1.0f in both paths.
 TEST_F(WeightDispatchTest, NVFP4_GemvMatchesDirect) {


### PR DESCRIPTION
## The bug (server crash, found via degeneration sweep)
A `[FATAL] gemm_nvfp4: B.shape[1]=2048 must equal weight K=1024` crashed the server on the very first chat request for native-NVFP4 MoE models (e.g. **Qwen3-30B-A3B-NVFP4**) → HTTP 000.

## Root cause
The phase-2 `weight_dispatch` NVFP4 case derived the dequant→cuBLAS GEMM's `K` from the **weight handle's `shape[1]`**. Prequant-loaded NVFP4 handles store the **packed K/2** there (2 nibbles/byte); handles built elsewhere store the **logical K** — an inconsistent convention. With a prequant weight the M>1 prefill fallback got `K=K/2` → abort.

Why only the server / only now: the **v0.12.3 agentic long-context KV defaults** allocate a huge KV budget that **starves the CUTLASS NVFP4 prefill workspace** (`cutlass_nvfp4=0`), forcing this dequant fallback on the first prefill. imp-cli with a default context keeps the CUTLASS path and never hits it.

## Fix
Derive `K` from the **activation** (`x.shape[1]`) — the GEMM contract makes it the logical K regardless of the handle's shape convention (same as the FP8/MXFP4 cases in this file). One line.

## Verification
- Repro `imp-cli --max-seq-len 250000 --model Qwen3-30B-A3B-NVFP4-Modelopt` (starves CUTLASS → forces the fallback): **no FATAL**, coherent decode.
- Server (agentic defaults), the original crashing request: **HTTP 200**, "Yes, 17 is a prime number."
- New regression test `WeightDispatchTest.NVFP4_GemmPackedShapeMatchesDirect` (packed `shape[1]=K/2`, M>1) — the existing test used logical shape and never exercised the crash.
- test-quant **188/188**, test-compute 181, test-moe-gdn 106; decode of other NVFP4/GGUF models unaffected.

## Follow-up (not this PR)
The agentic KV budget should leave headroom for the CUTLASS prefill workspace so native-NVFP4 prefill keeps the fast path instead of the (now-correct but slow) dequant fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)