### PR TITLE
test(degeneration): support SafeTensors/NVFP4 models (was GGUF-only)

### DIFF
--- a/tests/test_degeneration.cpp
+++ b/tests/test_degeneration.cpp
@@ -23,6 +23,16 @@ static const char* get_model_path() {
     return imp_test::env_cstr_or(imp_test::kEnvModel, "/models/Qwen3-8B-Q8_0.gguf");
 }
 
+// A path that doesn't end in .gguf is a SafeTensors directory (NVFP4 hero models
+// ship as dirs). Without this the battery hard-coded IMP_FORMAT_GGUF and could
+// not load any NVFP4 model — leaving the priority quant with zero degeneration
+// coverage (see the #790 NVFP4 prefill crash, which shipped undetected).
+static ImpModelFormat detect_format(const char* p) {
+    std::string s = p ? p : "";
+    return (s.size() >= 5 && s.substr(s.size() - 5) == ".gguf") ? IMP_FORMAT_GGUF
+                                                                : IMP_FORMAT_SAFETENSORS;
+}
+
 static bool model_exists() {
     FILE* f = fopen(get_model_path(), "r");
     if (f) {
@@ -122,7 +132,7 @@ protected:
     void SetUp() override {
         SKIP_IF_NO_MODEL();
 
-        ASSERT_EQ(imp_model_load(get_model_path(), IMP_FORMAT_GGUF, &model_), IMP_SUCCESS);
+        ASSERT_EQ(imp_model_load(get_model_path(), detect_format(get_model_path()), &model_), IMP_SUCCESS);
 
         ImpConfig config = imp_config_default();
         config.max_seq_len = 2048;


### PR DESCRIPTION
`DegenerationTest` hard-coded `IMP_FORMAT_GGUF`, so `imp_model_load` tried to mmap a SafeTensors directory as a GGUF file (`Failed to mmap GGUF file: …(size=4096)`) and every test failed at load. **NVFP4+SafeTensors is the priority quant, yet its hero models had zero automated degeneration coverage** — which is exactly how the #790 native-NVFP4 prefill crash shipped undetected.

Fix: detect the format from the path (dir / non-`.gguf` → SafeTensors), matching the other e2e tests (`test_determinism_e2e`, `test_prefix_cache_e2e`, …).

Verified: `DegenerationTest` on **Qwen3-14B-NVFP4 (dense) → 5/5 pass** (was 5 load failures, and confirms that model is degeneration-clean); default Qwen3-8B-Q8 GGUF unchanged.

Caveat (documented in the commit): greedy determinism flips on NVFP4 **MoE** (atomic-scatter), so `GreedyDeterminism` is expected to fail there — use NVFP4 **dense** models, or `degen_suite.py --skip-deterministic` for MoE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)