### PR TITLE
fix(think): release post-</think> grace the moment real answer content appears

### DIFF
--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -491,6 +491,7 @@ __global__ void post_decode_step_kernel(
     int* __restrict__ d_think_count,      // [1] reasoning token counter
     int* __restrict__ d_in_think,         // [1] think block flag
     int* __restrict__ d_think_exit_step,  // [1] step </think> last closed (-1 = never)
+    int* __restrict__ d_content_after_think,  // [1] real answer token seen since </think> (0/1)
     int ignore_eos,                   // 1 = don't stop on EOS/stop tokens
     // Penalty ring buffer: d_penalty_ring[prefix_len + step] = token
     int32_t* __restrict__ d_penalty_ring,  // may be null if no penalties
@@ -523,9 +524,27 @@ __global__ void post_decode_step_kernel(
         } else if (token == think_end_id) {
             *d_in_think = 0;
             *d_think_exit_step = step;  // open the post-think grace window
+            if (d_content_after_think)
+                *d_content_after_think = 0;  // fresh grace window: no answer yet
         } else if (*d_in_think && think_budget_limit > 0) {
             (*d_think_count)++;
         }
+    }
+
+    // Post-</think> content detection: the first real answer token (non-stop,
+    // non-marker) emitted after the exit step releases the grace, so a complete
+    // short answer stops on its own EOS instead of being padded/repeated. Must
+    // run before the grace check below. step > exit_step skips the </think>
+    // token itself (set this same invocation).
+    if (track_think && d_content_after_think && d_think_exit_step && *d_think_exit_step >= 0 &&
+        step > *d_think_exit_step && token != think_start_id && token != think_end_id) {
+        bool tok_is_stop = (token == eos_id);
+        for (int i = 0; i < n_stop_ids; i++) {
+            if (token == d_stop_ids[i])
+                tok_is_stop = true;
+        }
+        if (!tok_is_stop)
+            *d_content_after_think = 1;
     }
 
     // Write token to ring buffer (visible to host via mapped memory)
@@ -560,8 +579,13 @@ __global__ void post_decode_step_kernel(
     // grace window after </think> closes (numerically-noisy NVFP4 quants can
     // close an empty block in ~3 tokens then EOS to a 0-content completion).
     bool in_think = (track_think && d_in_think && *d_in_think);
+    // Grace blocks the stop only while no real answer content has appeared yet
+    // (content_after_think == 0); the moment a genuine answer token is emitted,
+    // the model's own stop is honoured. think_grace_tokens stays a hard cap for
+    // the no-content case so generation is still bounded.
     bool grace = (think_grace_tokens > 0 && d_think_exit_step && *d_think_exit_step >= 0 &&
-                  (step - *d_think_exit_step) < think_grace_tokens);
+                  (step - *d_think_exit_step) < think_grace_tokens &&
+                  (!d_content_after_think || *d_content_after_think == 0));
     bool should_stop = (step + 1 >= eff_max);
     if (!in_think && !grace && !ignore_eos) {
         if (token == eos_id)
@@ -670,6 +694,9 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         err = cudaMalloc(&d_think_exit_step_, sizeof(int));
         if (err != cudaSuccess)
             goto fail;
+        err = cudaMalloc(&d_content_after_think_, sizeof(int));
+        if (err != cudaSuccess)
+            goto fail;
         int zero = 0;
         int neg_one = -1;
         int init_think = config_.initial_in_think ? 1 : 0;
@@ -686,6 +713,11 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         err = cudaMemcpyAsync(d_think_exit_step_, &neg_one, sizeof(int), cudaMemcpyHostToDevice, stream);
         if (err != cudaSuccess) {
             IMP_LOG_ERROR("ConditionalRunner: think_exit_step init failed: %s", cudaGetErrorString(err));
+            goto fail;
+        }
+        err = cudaMemcpyAsync(d_content_after_think_, &zero, sizeof(int), cudaMemcpyHostToDevice, stream);
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("ConditionalRunner: content_after_think init failed: %s", cudaGetErrorString(err));
             goto fail;
         }
     }
@@ -898,6 +930,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                                                      d_think_limit_, config_.think_start_id,
                                                      config_.think_end_id, config_.think_grace_tokens,
                                                      d_think_count_, d_in_think_, d_think_exit_step_,
+                                                     d_content_after_think_,
                                                      config_.ignore_eos ? 1 : 0, d_penalty_ring_,
                                                      penalty_prefix_len_, d_penalty_count_,
                                                      d_step_limit_, handle_);
@@ -999,7 +1032,8 @@ bool CudaGraphConditionalRunner::rearm(int32_t first_token, int position, int co
     if (d_in_think_) {
         if (!up(d_in_think_, &think, sizeof(int), "in_think") ||
             !up(d_think_count_, &zero, sizeof(int), "think_count") ||
-            !up(d_think_exit_step_, &neg_one, sizeof(int), "think_exit"))
+            !up(d_think_exit_step_, &neg_one, sizeof(int), "think_exit") ||
+            !up(d_content_after_think_, &zero, sizeof(int), "content_after_think"))
             return false;
     }
     *h_step_counter_ = 0;
@@ -1106,6 +1140,10 @@ void CudaGraphConditionalRunner::cleanup() {
     if (d_think_exit_step_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_think_exit_step_));
         d_think_exit_step_ = nullptr;
+    }
+    if (d_content_after_think_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_content_after_think_));
+        d_content_after_think_ = nullptr;
     }
     if (d_penalty_ring_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_penalty_ring_));

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -226,6 +226,7 @@ private:
     int* d_think_count_ = nullptr;      // [1] reasoning token counter
     int* d_in_think_ = nullptr;         // [1] currently inside <think> block
     int* d_think_exit_step_ = nullptr;  // [1] step at which </think> last closed (-1 = never)
+    int* d_content_after_think_ = nullptr;  // [1] real answer token seen since </think> (0/1)
 
     // Penalty token history: [prefix_len + max_steps] ring buffer for penalty computation.
     // prefix_len tokens are pre-populated from prior output; subsequent slots filled by

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -53,6 +53,7 @@ void Engine::track_think_state(Request& req, int32_t token) const {
     if (token == think_end_id_) {
         req.in_think_block = false;
         req.think_exit_idx = static_cast<int>(req.output_tokens.size());
+        req.content_after_think = false;  // fresh post-think grace window
         return;
     }
 
@@ -83,6 +84,7 @@ void Engine::track_think_state(Request& req, int32_t token) const {
     req.think_text_tail = std::move(ts.think_text_tail);
     if (transitioned && was_in_think && !req.in_think_block) {
         req.think_exit_idx = static_cast<int>(req.output_tokens.size());
+        req.content_after_think = false;  // fresh post-think grace window
     }
 }
 
@@ -103,26 +105,30 @@ bool Engine::should_stop(Request& req, int32_t token) const {
         if (is_stop_token(token)) {
             req.in_think_block = false;
             req.think_exit_idx = static_cast<int>(req.output_tokens.size());
+            req.content_after_think = false;  // fresh post-think grace window
             req.think_text_tail.clear();
         }
         return false;
     }
-    // After </think>: enforce a minimum answer budget when the model
-    // wants to stop. NVFP4 quantization noise on Qwen3.6 lets the model
-    // close an empty thinking block in ~3 tokens and then immediately
-    // emit <|im_end|>; even after surviving that, the post-</think>
-    // logits sometimes tilt toward stop again on the very first content
-    // token (observed: model writes "Ger" — start of "Gerne, ..." —
-    // then EOS). Counting content tokens AND stop tokens against the
-    // grace budget would mean a model that wrote real content past the
-    // budget then stopped naturally still hit the trap. Track stop
-    // tokens separately: if the last N consecutive emissions since
-    // </think> are all stops, accept the finish; if any content token
-    // appeared in between, reset the counter.
+    // After </think>: suppress a too-eager stop ONLY while no real answer
+    // content has been emitted yet. NVFP4 quantization noise on Qwen3.6 lets
+    // the model close an empty thinking block in ~3 tokens and then immediately
+    // emit <|im_end|> to a zero-content completion. But once a genuine answer
+    // token has appeared (content_after_think), honour the model's own stop
+    // instantly — otherwise a complete short answer ("VIOLET-2218", "Paris")
+    // gets padded or repeated until the raw-distance budget elapses. The
+    // budget remains a HARD CAP for the no-content case so generation is still
+    // bounded if the model only ever emits stops.
     if (req.think_exit_idx >= 0 && is_stop_token(token)) {
         if (think_logic::grace_blocks_stop(req.think_exit_idx,
-                                           static_cast<int>(req.output_tokens.size())))
+                                           static_cast<int>(req.output_tokens.size()),
+                                           req.content_after_think))
             return false;
+    } else if (req.think_exit_idx >= 0 &&
+               static_cast<int>(req.output_tokens.size()) > req.think_exit_idx) {
+        // A non-stop token after </think> is real answer content — release the
+        // grace so the model's next stop is honoured immediately.
+        req.content_after_think = true;
     }
     return is_stop_token(token);
 }

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -94,6 +94,11 @@ struct Request {
     // sometimes closes an empty thinking block and would otherwise EOS to
     // a 0-content completion.
     int think_exit_idx = -1;
+    // Whether a real (non-stop) answer token has been emitted since the last
+    // </think>. The post-think grace releases the moment this is true, so a
+    // complete short answer stops on its own <|im_end|> instead of being padded
+    // or repeated. Reset to false at every think exit.
+    bool content_after_think = false;
     float think_budget = 0.0f;  // Fraction of max_tokens for reasoning (0=unlimited)
     int prefill_offset = 0;     // Chunked prefill: tokens processed so far
     int cached_tokens = 0;      // Tokens served from prefix cache (skipped in prefill)

--- a/src/runtime/think_stop_logic.h
+++ b/src/runtime/think_stop_logic.h
@@ -144,15 +144,22 @@ struct TextThinkState {
 
 // --- Post-</think> grace period (should_stop) ---
 //
-// After the think block closes, suppress an early stop until at least
-// kMinAnswerAfterThink content tokens have been emitted: numerically-noisy
-// NVFP4 quants can close an empty thinking block in ~3 tokens and then EOS to a
-// zero-content completion. `think_exit_idx` is the output index at which think
-// last closed (-1 if never), `output_size` the current output length.
+// After the think block closes, a too-eager stop is suppressed ONLY while the
+// model has not yet produced any real answer content: numerically-noisy NVFP4
+// quants can close an empty thinking block in ~3 tokens and then EOS to a
+// zero-content completion. The grace releases the instant a real (non-stop)
+// token appears (`content_after_think`) — so a complete short answer like
+// "Paris" or "VIOLET-2218" stops cleanly on its own `<|im_end|>` instead of
+// being padded/repeated. `kMinAnswerAfterThink` is a HARD CAP: even with no
+// content, the grace lifts after that many tokens so a model that only emits
+// stops still finishes (bounded), it is not a minimum answer length.
+// `think_exit_idx` is the output index at which think last closed (-1 if never),
+// `output_size` the current output length, `content_after_think` whether a
+// non-stop token has been emitted since that exit.
 inline constexpr int kMinAnswerAfterThink = 16;
 
-inline bool grace_blocks_stop(int think_exit_idx, int output_size) {
-    if (think_exit_idx < 0)
+inline bool grace_blocks_stop(int think_exit_idx, int output_size, bool content_after_think) {
+    if (think_exit_idx < 0 || content_after_think)
         return false;
     int tokens_since_exit = output_size - think_exit_idx;
     return tokens_since_exit < kMinAnswerAfterThink;

--- a/tests/test_think_stop_logic.cpp
+++ b/tests/test_think_stop_logic.cpp
@@ -249,19 +249,34 @@ TEST(TextThink, MarkerSurvivesWindowEviction) {
 // kMinAnswerAfterThink == 16: after the block closes, suppress stop until at
 // least 16 content tokens have been produced.
 
-TEST(GracePeriod, BlocksStopImmediatelyAfterExit) {
-    // think_exit_idx=10, output_size=11 -> 1 token since exit < 16 -> blocked.
-    EXPECT_TRUE(grace_blocks_stop(/*think_exit_idx=*/10, /*output_size=*/11));
+TEST(GracePeriod, BlocksStopImmediatelyAfterExitWithNoContent) {
+    // Empty-think case: </think> at 10, EOS at 11, no content emitted yet -> 1
+    // token since exit < 16 -> blocked (force the model to produce something).
+    EXPECT_TRUE(grace_blocks_stop(/*think_exit_idx=*/10, /*output_size=*/11,
+                                  /*content_after_think=*/false));
 }
 
-TEST(GracePeriod, AllowsStopAtBudgetBoundary) {
-    // Exactly 16 tokens since exit -> NOT blocked (>= boundary). 10 -> 26.
-    EXPECT_FALSE(grace_blocks_stop(/*think_exit_idx=*/10, /*output_size=*/26));
-    // 15 since exit is still blocked (just under).
-    EXPECT_TRUE(grace_blocks_stop(/*think_exit_idx=*/10, /*output_size=*/25));
+TEST(GracePeriod, HonorsStopOnceContentSeen) {
+    // THE FIX: the model produced a real answer (content_after_think=true) and
+    // then emitted its stop token only 2 tokens after </think>. Previously the
+    // raw-distance grace blocked this and padded/repeated the answer; now the
+    // stop is honored the instant content exists. (A complete "Paris"/"4".)
+    EXPECT_FALSE(grace_blocks_stop(/*think_exit_idx=*/10, /*output_size=*/12,
+                                   /*content_after_think=*/true));
+}
+
+TEST(GracePeriod, HardCapReleasesEvenWithoutContent) {
+    // Even with NO content, the grace lifts after kMinAnswerAfterThink so a
+    // model that only emits stops still finishes (bounded). 10 -> 26 (==16).
+    EXPECT_FALSE(grace_blocks_stop(/*think_exit_idx=*/10, /*output_size=*/26,
+                                   /*content_after_think=*/false));
+    // 15 since exit, still no content -> blocked (just under the cap).
+    EXPECT_TRUE(grace_blocks_stop(/*think_exit_idx=*/10, /*output_size=*/25,
+                                  /*content_after_think=*/false));
 }
 
 TEST(GracePeriod, NoBlockWhenNeverThought) {
     // think_exit_idx < 0 means the request never entered/exited a think block.
-    EXPECT_FALSE(grace_blocks_stop(/*think_exit_idx=*/-1, /*output_size=*/2));
+    EXPECT_FALSE(grace_blocks_stop(/*think_exit_idx=*/-1, /*output_size=*/2,
+                                   /*content_after_think=*/false));
 }


### PR DESCRIPTION
## What

The post-`</think>` grace period suppressed stop tokens for a fixed `kMinAnswerAfterThink` (16) raw tokens **regardless of whether the model had already produced an answer**. A complete short answer (`VIOLET-2218`, `4`, `Paris`) finished in <16 tokens then emitting its own `<|im_end|>` got that stop swallowed and over-generated — padding or repeating the answer until the raw-distance budget elapsed.

Make the grace **content-aware**: track whether a real (non-stop, non-marker) token has been emitted since the last `</think>`. The grace now releases the instant content exists, so the model's own stop is honoured immediately. `kMinAnswerAfterThink` stays a **hard cap only for the no-content case** (empty-think NVFP4 completions), so generation is still bounded. This preserves the empty-think 0-content protection the grace was introduced for while removing its short-answer over-generation side effect.

## How

Wired through **both** decode paths:
- **Host per-step path** (`engine_sampling_stop.cpp` + new `Request::content_after_think` flag), reset on every think exit (single-token, text-tail, and implicit-stop exit).
- **GPU conditional-graph loop** (`cuda_graph.cu`): new `d_content_after_think_` device buffer mirrored across malloc / init / launch / rearm / free; the kernel resets it on `</think>`, sets it on the first post-exit content token, and gates the grace on it.

`grace_blocks_stop()` gains a `content_after_think` arg; `GracePeriod` unit tests updated + extended (honor-on-content, hard-cap-without-content).

## Validation (GPU, 3 reasoning architectures)

| Model | Reasoning format | degen_suite | 250-prompt corpus | short-answer stop |
|-------|-----------------|-------------|-------------------|-------------------|
| Qwen3-8B-Q8 | single-token `<think>` | — | **28 → 7 FAIL** | clean (was padded/repeated) |
| Qwen3.6-35B-NVFP4 | multi-token `</think>` | 33/0 | 3 FAIL | clean |
| gpt-oss-20b | Harmony analysis/final | 33/0 | 27 FAIL | clean |

All remaining corpus FAILs were triaged to **test-design / adversarial / pre-existing** causes — **zero caused by this change, zero genuine reasoning-leaks**:
- Q8: 7 FAIL = explicit-opener baits, multilingual spelling strictness, needle-label-vs-number, "write forever" torture, model spelling `<|endoftext|>` as plain BPE pieces (not a real token).
- gpt-oss: the empty-content FAILs are **budget exhaustion** (`finish_reason=length`) — gpt-oss's verbose analysis channel exceeds the corpus's tight per-prompt budgets (40–220 tokens) calibrated for terse models; at ample `max_tokens` the answers are correct. The rest are adversarial repeat/marker-elicitation prompts.

Separately surfaced (pre-existing, **not** addressed here): multi-token / Harmony reasoning-channel models get no think-protection on the non-streaming GPU graph path (`track_think = think_end_id >= 0` is false when `</think>` has no single token id), and gpt-oss's verbosity blows tight budgets. Tracked for a follow-up.

`make verify-fast`: OK. Unit tests incl. extended `GracePeriod` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)