### PR TITLE
fix(think): don't let whitespace tokens release the post-</think> grace

### DIFF
--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -492,6 +492,8 @@ __global__ void post_decode_step_kernel(
     int* __restrict__ d_in_think,         // [1] think block flag
     int* __restrict__ d_think_exit_step,  // [1] step </think> last closed (-1 = never)
     int* __restrict__ d_content_after_think,  // [1] real answer token seen since </think> (0/1)
+    const uint8_t* __restrict__ d_token_is_whitespace,  // [vocab] 1 = decodes to whitespace-only
+    int vocab_size,
     int ignore_eos,                   // 1 = don't stop on EOS/stop tokens
     // Penalty ring buffer: d_penalty_ring[prefix_len + step] = token
     int32_t* __restrict__ d_penalty_ring,  // may be null if no penalties
@@ -543,7 +545,11 @@ __global__ void post_decode_step_kernel(
             if (token == d_stop_ids[i])
                 tok_is_stop = true;
         }
-        if (!tok_is_stop)
+        // Whitespace/newline tokens after </think> are not real answer content
+        // and must not release the grace (post-#798 0-content fix).
+        bool tok_is_ws = (d_token_is_whitespace && token >= 0 && token < vocab_size &&
+                          d_token_is_whitespace[token]);
+        if (!tok_is_stop && !tok_is_ws)
             *d_content_after_think = 1;
     }
 
@@ -931,6 +937,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                                                      config_.think_end_id, config_.think_grace_tokens,
                                                      d_think_count_, d_in_think_, d_think_exit_step_,
                                                      d_content_after_think_,
+                                                     config_.token_is_whitespace, config_.vocab_size,
                                                      config_.ignore_eos ? 1 : 0, d_penalty_ring_,
                                                      penalty_prefix_len_, d_penalty_count_,
                                                      d_step_limit_, handle_);

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -148,6 +148,11 @@ public:
         // empty think block in ~3 tokens then EOS to a 0-content completion.
         // 0 = no think tracking in the loop (set >0 whenever think_end_id >= 0).
         int think_grace_tokens = 0;
+        // Device per-token "decodes to whitespace-only" mask (size vocab_size,
+        // nullptr = treat nothing as whitespace). A whitespace/newline token
+        // after </think> must not release the grace (post-#798 0-content fix).
+        const uint8_t* token_is_whitespace = nullptr;
+        int vocab_size = 0;
         bool ignore_eos = false;        // don't stop on EOS/stop tokens (benchmark mode)
         // Per-launch step cap read from device memory (0 = unbounded, i.e.
         // max_steps). Unlike max_steps it is NOT baked into the captured

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -71,6 +71,10 @@ Engine::~Engine() {
         memory_manager_.vram_allocator().free(d_penalty_tokens_);
         d_penalty_tokens_ = nullptr;
     }
+    if (d_token_is_whitespace_) {
+        memory_manager_.vram_allocator().free(d_token_is_whitespace_);
+        d_token_is_whitespace_ = nullptr;
+    }
     if (d_kv_slot_buf_) {
         cudaFree(d_kv_slot_buf_);
         d_kv_slot_buf_ = nullptr;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -582,6 +582,18 @@ private:
     // Think token IDs (cached from chat template init, -1 if not a think model)
     int32_t think_start_id_ = -1;
     int32_t think_end_id_ = -1;
+
+    // Per-token "decodes to whitespace-only (or empty)" mask, built once for
+    // think models. Used by the post-</think> grace so a whitespace/newline
+    // token emitted right after the close does NOT count as real answer content
+    // and prematurely release the grace (was a 0-content-completion bug). Host
+    // vector + device mirror for the GPU conditional-graph loop; size == vocab.
+    std::vector<uint8_t> token_is_whitespace_;
+    uint8_t* d_token_is_whitespace_ = nullptr;
+    bool token_is_whitespace(int32_t token) const {
+        return token >= 0 && token < static_cast<int32_t>(token_is_whitespace_.size()) &&
+               token_is_whitespace_[token];
+    }
     void upload_penalties(const Request& req, InferenceState& state, cudaStream_t stream);
     void fill_sampling_params(const Request& req, InferenceState& state) const;
     void fill_recurrent_state(const Request& req, InferenceState& state, bool reset, cudaStream_t stream);

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -96,6 +96,8 @@ CudaGraphConditionalRunner::Config Engine::build_graph_config(const Request& req
         gcfg.think_end_id = think_end_id_;
         gcfg.initial_in_think = req.in_think_block;
         gcfg.think_grace_tokens = think_logic::kMinAnswerAfterThink;
+        gcfg.token_is_whitespace = d_token_is_whitespace_;
+        gcfg.vocab_size = static_cast<int>(token_is_whitespace_.size());
         if (req.think_budget > 0.0f) {
             // The loop's device-side counter starts at 0 every launch; with
             // bounded bursts (n-gram speculation think-phase) the request

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -125,9 +125,13 @@ bool Engine::should_stop(Request& req, int32_t token) const {
                                            req.content_after_think))
             return false;
     } else if (req.think_exit_idx >= 0 &&
-               static_cast<int>(req.output_tokens.size()) > req.think_exit_idx) {
-        // A non-stop token after </think> is real answer content — release the
-        // grace so the model's next stop is honoured immediately.
+               static_cast<int>(req.output_tokens.size()) > req.think_exit_idx &&
+               !token_is_whitespace(token)) {
+        // A non-stop, non-whitespace token after </think> is real answer content
+        // — release the grace so the model's next stop is honoured immediately.
+        // Whitespace/newline tokens the model routinely emits right after the
+        // close must NOT release it, or a stop following that newline yields a
+        // 0-content completion (the post-#798 regression).
         req.content_after_think = true;
     }
     return is_stop_token(token);

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -93,6 +93,25 @@ bool Engine::init_features() {
             if (accept) {
                 think_start_id_ = ts;
                 think_end_id_ = te;
+                // Build the whitespace-token mask once (only needed by the
+                // post-</think> grace, so only for think models). A token that
+                // decodes to empty/all-whitespace must not count as answer
+                // content. Mirror to device for the conditional-graph loop.
+                token_is_whitespace_.assign(vocab, 0);
+                for (int32_t id = 0; id < vocab; ++id) {
+                    if (think_logic::piece_is_whitespace(ptok->decode_token(id)))
+                        token_is_whitespace_[id] = 1;
+                }
+                d_token_is_whitespace_ = static_cast<uint8_t*>(
+                    memory_manager_.vram_allocator().allocate(vocab * sizeof(uint8_t),
+                                                              "token_is_whitespace"));
+                if (d_token_is_whitespace_) {
+                    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_is_whitespace_,
+                                                       token_is_whitespace_.data(),
+                                                       vocab * sizeof(uint8_t),
+                                                       cudaMemcpyHostToDevice, stream_));
+                    IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream_));
+                }
             }
         }
     }

--- a/src/runtime/think_stop_logic.h
+++ b/src/runtime/think_stop_logic.h
@@ -165,4 +165,14 @@ inline bool grace_blocks_stop(int think_exit_idx, int output_size, bool content_
     return tokens_since_exit < kMinAnswerAfterThink;
 }
 
+// Does a decoded token piece count as real answer content for the grace above?
+// A token whose decoded text is empty or pure whitespace (newlines/spaces the
+// model routinely emits right after </think>, e.g. "\n" / "\n\n") must NOT
+// release the grace — otherwise a model that closes think, emits a newline,
+// then stops yields a 0-content completion (the post-#798 regression). Only a
+// token with at least one non-whitespace byte is real content.
+inline bool piece_is_whitespace(const std::string& piece) {
+    return piece.find_first_not_of(" \t\n\r\f\v") == std::string::npos;
+}
+
 }  // namespace imp::think_logic

--- a/tests/test_think_stop_logic.cpp
+++ b/tests/test_think_stop_logic.cpp
@@ -280,3 +280,20 @@ TEST(GracePeriod, NoBlockWhenNeverThought) {
     EXPECT_FALSE(grace_blocks_stop(/*think_exit_idx=*/-1, /*output_size=*/2,
                                    /*content_after_think=*/false));
 }
+
+TEST(GracePeriod, WhitespacePieceIsNotContent) {
+    // THE post-#798 FIX: a "\n" / "\n\n" / "  " token after </think> must NOT
+    // count as answer content (else a stop right after it yields empty content).
+    EXPECT_TRUE(piece_is_whitespace("\n"));
+    EXPECT_TRUE(piece_is_whitespace("\n\n"));
+    EXPECT_TRUE(piece_is_whitespace("   "));
+    EXPECT_TRUE(piece_is_whitespace(" \t\r\n"));
+    EXPECT_TRUE(piece_is_whitespace(""));  // empty decode (e.g. some specials)
+}
+
+TEST(GracePeriod, RealTextPieceIsContent) {
+    EXPECT_FALSE(piece_is_whitespace("7"));
+    EXPECT_FALSE(piece_is_whitespace("Paris"));
+    EXPECT_FALSE(piece_is_whitespace(" red"));     // leading space, real word
+    EXPECT_FALSE(piece_is_whitespace("\n4"));      // newline + digit
+}


### PR DESCRIPTION
## What

Follow-up to #798 — fixes a 0-content-completion regression it introduced.

#798 made the post-`</think>` grace release the instant any non-stop token appeared. But that includes the `\n` / `\n\n` tokens a reasoning model routinely emits right after closing the think block. On Qwen3.6 this was reproducible (~75% on a terse prompt):

```
Here : ' ' 1  <|im_end|>   ← stop while in-think → implicit close, think_exit=5 (suppressed, ok)
\n (token 198)             ← flips content_after_think TRUE  ← BUG
<|endoftext|>              ← stop now honoured → 0-content completion
```

(Token ids confirmed at runtime: 198=`\n`, 248046=`<|im_end|>`, 248044=`<|endoftext|>`.)

Pre-#798 the raw-distance grace blocked that stop and the model went on to produce real content; the content-aware change regressed it because a newline counted as "content".

## How

Only a token with at least one **non-whitespace** byte counts as answer content. A per-token whitespace mask is built once for think models (decode each vocab id, mark empty/all-whitespace) and consulted in **both** decode paths:
- **host** `should_stop` via `Engine::token_is_whitespace()`
- **GPU** conditional-graph loop via a device mirror `d_token_is_whitespace_`, threaded through `GraphConfig` into `post_decode_step_kernel`

New pure helper `think_logic::piece_is_whitespace()` + unit tests (whitespace-is-not-content, real-text-is-content).

## Validation (GPU)

- **Qwen3.6-35B-NVFP4**: fmt-three-colors **10/10 non-empty** (was ~75% empty); greedy temp=0 short answers clean on the graph-loop path (`ZEBRA-99`, `Paris`, `7`); degen_suite 33/0.
- **Qwen3-8B-Q8**: short answers still stop clean — the #798 win is preserved; 250-corpus **8 FAIL**, all test-design/adversarial (repetition torture, explicit-opener baits, multilingual spelling, `<|endoftext|>` spelled as plain BPE, needle-label), **zero empty-content**, no grace regression. (The one delta vs the #798 run is a multiplication-table repetition-torture prompt flipping on sampling — unrelated to the grace.)

`make verify-fast`: OK. Unit tests incl. new `piece_is_whitespace` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)