### PR TITLE
fix(harmony): give gpt-oss an answer-headroom budget (no empty final channel)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -720,6 +720,16 @@ void Engine::add_request(std::shared_ptr<Request> req) {
                 req->in_think_block = true;
             }
         }
+        // gpt-oss Harmony generation starts in the analysis (reasoning) channel
+        // — the model emits <|channel|>analysis<|message|> as its first output,
+        // there is no <think> opener for the scan above to find. Seed the think
+        // state so the answer-headroom budget counts reasoning from the start
+        // and force-closes the analysis channel (<|end|>) before max_tokens is
+        // exhausted, instead of returning an empty final channel.
+        if (harmony_reasoning_) {
+            req->started_in_think = true;
+            req->in_think_block = true;
+        }
         scheduler_->add_request(std::move(req));
     }
 }

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -582,6 +582,18 @@ private:
     // Think token IDs (cached from chat template init, -1 if not a think model)
     int32_t think_start_id_ = -1;
     int32_t think_end_id_ = -1;
+    // gpt-oss Harmony reasoning: the analysis channel carries chain-of-thought
+    // and closes with <|end|> (mapped to think_end_id_ above); there is no
+    // <think> opener. Set so the answer-headroom budget can force the analysis
+    // -> final channel switch instead of letting reasoning eat all of
+    // max_tokens and return an empty final channel (finish=length).
+    bool harmony_reasoning_ = false;
+    // Forced final-channel opener for the Harmony answer-headroom budget:
+    // <|end|><|start|>assistant<|channel|>final<|message|> as token ids. Empty
+    // unless harmony_reasoning_. Forcing just <|end|> is not enough — gpt-oss
+    // re-opens the analysis channel; forcing the whole opener commits it to the
+    // answer channel so the final content is non-empty under a tight budget.
+    std::vector<int32_t> harmony_force_seq_;
 
     // Per-token "decodes to whitespace-only (or empty)" mask, built once for
     // think models. Used by the post-</think> grace so a whitespace/newline
@@ -595,7 +607,7 @@ private:
                token_is_whitespace_[token];
     }
     void upload_penalties(const Request& req, InferenceState& state, cudaStream_t stream);
-    void fill_sampling_params(const Request& req, InferenceState& state) const;
+    void fill_sampling_params(Request& req, InferenceState& state) const;
     void fill_recurrent_state(const Request& req, InferenceState& state, bool reset, cudaStream_t stream);
     int acquire_recurrent_slot_(int req_id);   // distinct free slot for a new sequence
     void release_recurrent_slot_(int req_id);  // idempotent; returns slot to the pool

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -137,7 +137,7 @@ bool Engine::should_stop(Request& req, int32_t token) const {
     return is_stop_token(token);
 }
 
-void Engine::fill_sampling_params(const Request& req, InferenceState& state) const {
+void Engine::fill_sampling_params(Request& req, InferenceState& state) const {
     state.temperature = req.temperature;
     state.top_p = req.top_p;
     state.top_k = req.top_k;
@@ -181,10 +181,26 @@ void Engine::fill_sampling_params(const Request& req, InferenceState& state) con
     // budget never fires (model thinks until max_tokens, content stays empty).
     // See think_stop_logic.h for the pure recount logic.
     state.force_token = -1;
-    if (think_logic::should_force_think_end(req.think_budget, think_end_id_, req.max_tokens,
-                                            req.output_tokens, think_start_id_,
-                                            req.started_in_think)) {
-        state.force_token = think_end_id_;
+    if (req.harmony_force_idx >= 0) {
+        // Mid-opener: keep forcing the Harmony final-channel sequence until it
+        // is fully emitted, then hand control back to the model (now committed
+        // to the answer channel).
+        if (req.harmony_force_idx < static_cast<int>(harmony_force_seq_.size())) {
+            state.force_token = harmony_force_seq_[req.harmony_force_idx];
+            req.harmony_force_idx++;
+        }
+        if (req.harmony_force_idx >= static_cast<int>(harmony_force_seq_.size()))
+            req.harmony_force_idx = -1;  // opener complete
+    } else if (think_logic::should_force_think_end(req.think_budget, think_end_id_, req.max_tokens,
+                                                   req.output_tokens, think_start_id_,
+                                                   req.started_in_think)) {
+        if (harmony_reasoning_ && !harmony_force_seq_.empty()) {
+            // Start forcing the full <|end|>…<|message|> opener (see above).
+            state.force_token = harmony_force_seq_[0];
+            req.harmony_force_idx = 1;
+        } else {
+            state.force_token = think_end_id_;  // <think> models: single </think>
+        }
     }
 }
 

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -93,10 +93,37 @@ bool Engine::init_features() {
             if (accept) {
                 think_start_id_ = ts;
                 think_end_id_ = te;
-                // Build the whitespace-token mask once (only needed by the
-                // post-</think> grace, so only for think models). A token that
-                // decodes to empty/all-whitespace must not count as answer
-                // content. Mirror to device for the conditional-graph loop.
+            } else if (chat_template_.family() == ChatTemplateFamily::HARMONY) {
+                // gpt-oss Harmony: reasoning lives in the analysis channel and
+                // closes with <|end|>; the model emits <|channel|>analysis
+                // <|message|> itself (no <think> opener, so `accept` is false).
+                // Map <|end|> to think_end so the answer-headroom budget can
+                // force the analysis -> final channel switch when reasoning
+                // would otherwise consume all of max_tokens and leave the final
+                // channel (the answer) empty (finish=length). think_start stays
+                // -1: analysis is the initial state, seeded via started_in_think.
+                int32_t he = ptok->find_token("<|end|>");
+                if (he >= 0) {
+                    think_start_id_ = -1;
+                    think_end_id_ = he;
+                    harmony_reasoning_ = true;
+                    // Forced final-channel opener: <|end|> closes analysis, then
+                    // <|start|>assistant<|channel|>final<|message|> commits the
+                    // model to the answer channel (forcing <|end|> alone lets it
+                    // re-open analysis). Encode the literal so the exact ids
+                    // (incl. role/channel-name pieces) match this tokenizer.
+                    harmony_force_seq_ =
+                        ptok->encode("<|end|><|start|>assistant<|channel|>final<|message|>");
+                    std::string seq;
+                    for (int32_t t : harmony_force_seq_) seq += std::to_string(t) + " ";
+                    IMP_LOG_INFO("Harmony reasoning: <|end|>=%d, force opener=[ %s]", he, seq.c_str());
+                }
+            }
+            // Build the whitespace-token mask once for any think model (the
+            // post-</think>/<|end|> grace needs it). A token that decodes to
+            // empty/all-whitespace must not count as answer content. Mirror to
+            // device for the conditional-graph loop.
+            if (think_end_id_ >= 0) {
                 token_is_whitespace_.assign(vocab, 0);
                 for (int32_t id = 0; id < vocab; ++id) {
                     if (think_logic::piece_is_whitespace(ptok->decode_token(id)))

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -100,6 +100,12 @@ struct Request {
     // or repeated. Reset to false at every think exit.
     bool content_after_think = false;
     float think_budget = 0.0f;  // Fraction of max_tokens for reasoning (0=unlimited)
+    // gpt-oss Harmony answer-headroom force: when reasoning hits the budget we
+    // can't just force <|end|> (the model re-opens the analysis channel) — we
+    // force the whole <|end|><|start|>assistant<|channel|>final<|message|>
+    // opener so the model commits to the final (answer) channel. Index into
+    // Engine::harmony_force_seq_ for the in-flight forced opener (-1 = idle).
+    int harmony_force_idx = -1;
     int prefill_offset = 0;     // Chunked prefill: tokens processed so far
     int cached_tokens = 0;      // Tokens served from prefix cache (skipped in prefill)
     // Pin this request's full prompt blocks in the prefix cache at finish


### PR DESCRIPTION
## What

gpt-oss reasons in the Harmony **analysis** channel and closes it with `<|end|>` before opening `<|start|>assistant<|channel|>final<|message|>` for the answer. It has no `<think>` token, so `think_end_id_` stayed `-1` and the answer-headroom think-budget never armed: under a tight `max_tokens` the model consumed the whole budget inside the analysis channel and returned `finish=length` with an **empty final channel** (`content=""`).

## How

Map the Harmony analysis close to the existing budget machinery: for `HARMONY`-family models set `think_end_id_ = <|end|>`, `think_start_id_ = -1` (analysis is the initial state, seeded via `started_in_think`/`in_think_block` in `add_request`).

Forcing `<|end|>` **alone** is not enough — gpt-oss re-opens a fresh analysis channel (`<|channel|>analysis<|message|>`) and reasons on, so the force never re-fires (`think_start_id_ = -1`) and the budget is still exhausted (diagnosed via runtime logs: `FORCE=1` at the limit, then the model reasons to `max_tokens`). Instead, when reasoning reaches the reserve limit, force the **whole final-channel opener** as a token sequence — `<|end|><|start|>assistant<|channel|>final<|message|>` (encoded once at load into `harmony_force_seq_`) — over consecutive steps via a per-request cursor (`Request::harmony_force_idx`). That commits the model to the answer channel, so the final content is non-empty within the remaining budget. `fill_sampling_params` is now non-const to advance the cursor.

Engine-side only: the server computes its own think ids + Harmony demux (`split_harmony_channels` keyed on the `HARMONY` family), so this does **not** touch reasoning/content splitting or `enable_thinking`. The whitespace-token mask (#799) is now built for any think model incl. Harmony.

## Validation (gpt-oss-20b, GPU)

- Tight budgets that returned empty now answer with non-empty content: seating puzzle `max_tokens=500 -> "10"` / `900 -> "4"` (was empty), "channel marker" `max_tokens=180` non-empty (was empty), needle `max_tokens=40 -> "AMBER-3307"`.
- **250-prompt corpus: 27 → 13 FAIL; empty-content lines 18 → 2.** The budget-exhaustion empties are eliminated; the remaining FAILs are all test-design/adversarial (repeat-forever torture, explicit-opener baits, marker-elicitation, multilingual spelling, ultra-tight mt=40 needles that now recall partial content). The one residual empty is an adversarial "end the conversation" prompt.
- Ample budgets unchanged: full reasoning + answer, the force does not fire early (`ctoks << max_tokens`, natural finish).
- degen_suite 33/0 (a one-off extraction refusal was gpt-oss-20b **MoE session non-determinism** — it cleared on restart with the same build).

`make verify-fast`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)