### PR TITLE
feat(mla): absorbed latent-KV-cache decode (Phase 3, opt-in) + filesize allowlist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/rope.cu
     src/compute/layernorm.cu
     src/compute/mla_kv_assemble.cu
+    src/compute/mla_absorb.cu
     src/compute/activation.cu
     src/compute/embedding.cu
     src/compute/sampling.cu

--- a/src/compute/mla_absorb.cu
+++ b/src/compute/mla_absorb.cu
@@ -1,0 +1,178 @@
+// MLA absorbed-decode kernels (Phase 3, opt-in). See mla_absorb.h.
+
+#include "compute/mla_absorb.h"
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// Latent cache write
+// ---------------------------------------------------------------------------
+__global__ static void mla_latent_cache_write_kernel(
+        const __half* __restrict__ latent,       // [n, kv_lora]
+        const __half* __restrict__ k_assembled,  // [n, n_heads, head_dim]
+        __half* __restrict__ cache,              // [max_seq, kv_lora + rope_dim]
+        const int* __restrict__ positions,       // [n]
+        int n, int n_heads, int head_dim, int rope_dim, int kv_lora, int max_seq) {
+    const int t = blockIdx.x;
+    if (t >= n) return;
+    const int pos = positions[t];
+    if (pos < 0 || pos >= max_seq) return;
+
+    const int width = kv_lora + rope_dim;
+    __half* dst = cache + static_cast<size_t>(pos) * width;
+    const __half* lat = latent + static_cast<size_t>(t) * kv_lora;
+    // k_rope: head 0 of the assembled K (replicated across heads, post-RoPE),
+    // the first rope_dim dims of each head.
+    const __half* krope = k_assembled + static_cast<size_t>(t) * n_heads * head_dim;
+
+    for (int i = threadIdx.x; i < kv_lora; i += blockDim.x)
+        dst[i] = lat[i];
+    for (int i = threadIdx.x; i < rope_dim; i += blockDim.x)
+        dst[kv_lora + i] = krope[i];
+}
+
+void mla_latent_cache_write(const half* latent, const half* k_assembled, half* cache,
+                            const int* positions, int n_tokens, int n_heads, int head_dim,
+                            int rope_dim, int kv_lora_rank, int max_seq, cudaStream_t stream) {
+    if (n_tokens == 0) return;
+    mla_latent_cache_write_kernel<<<n_tokens, 256, 0, stream>>>(
+        reinterpret_cast<const __half*>(latent), reinterpret_cast<const __half*>(k_assembled),
+        reinterpret_cast<__half*>(cache), positions, n_tokens, n_heads, head_dim, rope_dim,
+        kv_lora_rank, max_seq);
+}
+
+// ---------------------------------------------------------------------------
+// Absorbed decode attention (one block per head)
+// ---------------------------------------------------------------------------
+// Shared-memory block reduction helpers (256 threads).
+__device__ __forceinline__ float block_reduce_max(float v, float* sh) {
+    const int tid = threadIdx.x;
+    sh[tid] = v;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) sh[tid] = fmaxf(sh[tid], sh[tid + s]);
+        __syncthreads();
+    }
+    float r = sh[0];
+    __syncthreads();
+    return r;
+}
+__device__ __forceinline__ float block_reduce_sum(float v, float* sh) {
+    const int tid = threadIdx.x;
+    sh[tid] = v;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) sh[tid] += sh[tid + s];
+        __syncthreads();
+    }
+    float r = sh[0];
+    __syncthreads();
+    return r;
+}
+
+__global__ static void mla_absorbed_decode_kernel(
+        const __half* __restrict__ q,      // [n_heads, head_dim] = [pe|nope]
+        const __half* __restrict__ kv_b,   // [n_heads*(nope+v), kv_lora]
+        const __half* __restrict__ cache,  // [max_seq, kv_lora + rope_dim]
+        __half* __restrict__ out,          // [n_heads, v_head_dim]
+        float* __restrict__ scores,        // [n_heads, max_seq]
+        const int* __restrict__ context_lens,
+        int n_heads, int head_dim, int rope_dim, int nope_dim, int kv_lora, int v_head_dim,
+        int max_seq, float scale) {
+    const int h = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int nthreads = blockDim.x;
+    const int ctx = context_lens[0];
+    if (ctx <= 0) return;
+
+    const int width = kv_lora + rope_dim;     // cache row width
+    const int head_out = nope_dim + v_head_dim;  // kv_b rows per head
+
+    extern __shared__ float sh[];
+    float* sh_qabs = sh;                       // [kv_lora]
+    float* sh_qpe = sh_qabs + kv_lora;         // [rope_dim]
+    float* sh_ctx = sh_qpe + rope_dim;         // [kv_lora]
+    float* sh_red = sh_ctx + kv_lora;          // [nthreads]
+
+    const __half* q_h = q + static_cast<size_t>(h) * head_dim;  // [pe|nope]
+    const __half* q_pe = q_h;                                   // [rope_dim]
+    const __half* q_nope = q_h + rope_dim;                      // [nope_dim]
+    const __half* WUK = kv_b + static_cast<size_t>(h) * head_out * kv_lora;          // [nope, kv_lora]
+    const __half* WUV = kv_b + (static_cast<size_t>(h) * head_out + nope_dim) * kv_lora;  // [v, kv_lora]
+    float* my_scores = scores + static_cast<size_t>(h) * max_seq;
+
+    // Load q_pe into shared (small).
+    for (int i = tid; i < rope_dim; i += nthreads)
+        sh_qpe[i] = __half2float(q_pe[i]);
+    __syncthreads();
+
+    // 1. q_absorbed[c] = sum_r q_nope[r] * WUK[r][c]
+    for (int c = tid; c < kv_lora; c += nthreads) {
+        float acc = 0.0f;
+        for (int r = 0; r < nope_dim; r++)
+            acc += __half2float(q_nope[r]) * __half2float(WUK[static_cast<size_t>(r) * kv_lora + c]);
+        sh_qabs[c] = acc;
+    }
+    __syncthreads();
+
+    // 2. scores[t] = scale * (q_absorbed . latent[t] + q_pe . k_rope[t])
+    float local_max = -1e30f;
+    for (int t = tid; t < ctx; t += nthreads) {
+        const __half* lat = cache + static_cast<size_t>(t) * width;
+        const __half* kr = lat + kv_lora;
+        float s = 0.0f;
+        for (int c = 0; c < kv_lora; c++)
+            s += sh_qabs[c] * __half2float(lat[c]);
+        for (int i = 0; i < rope_dim; i++)
+            s += sh_qpe[i] * __half2float(kr[i]);
+        s *= scale;
+        my_scores[t] = s;
+        local_max = fmaxf(local_max, s);
+    }
+    float gmax = block_reduce_max(local_max, sh_red);
+
+    // 3. softmax: exp(score - max), accumulate denom.
+    float local_sum = 0.0f;
+    for (int t = tid; t < ctx; t += nthreads) {
+        float e = __expf(my_scores[t] - gmax);
+        my_scores[t] = e;
+        local_sum += e;
+    }
+    float gsum = block_reduce_sum(local_sum, sh_red);
+    float inv_sum = (gsum > 0.0f) ? (1.0f / gsum) : 0.0f;
+
+    // 4. ctx[c] = (1/sum) * sum_t p[t] * latent[t][c]
+    for (int c = tid; c < kv_lora; c += nthreads) {
+        float acc = 0.0f;
+        for (int t = 0; t < ctx; t++) {
+            const __half* lat = cache + static_cast<size_t>(t) * width;
+            acc += my_scores[t] * __half2float(lat[c]);
+        }
+        sh_ctx[c] = acc * inv_sum;
+    }
+    __syncthreads();
+
+    // 5. out[d] = sum_c ctx[c] * WUV[d][c]
+    __half* out_h = out + static_cast<size_t>(h) * v_head_dim;
+    for (int d = tid; d < v_head_dim; d += nthreads) {
+        float acc = 0.0f;
+        for (int c = 0; c < kv_lora; c++)
+            acc += sh_ctx[c] * __half2float(WUV[static_cast<size_t>(d) * kv_lora + c]);
+        out_h[d] = __float2half(acc);
+    }
+}
+
+void mla_absorbed_decode(const half* q, const half* kv_b, const half* cache, half* out,
+                         float* scores, const int* context_lens, int n_heads, int head_dim,
+                         int rope_dim, int nope_dim, int kv_lora_rank, int v_head_dim, int max_seq,
+                         float scale, cudaStream_t stream) {
+    const int nthreads = 256;
+    // sh: q_absorbed[kv_lora] + q_pe[rope] + ctx[kv_lora] + reduce[nthreads]
+    size_t shmem = (static_cast<size_t>(2 * kv_lora_rank) + rope_dim + nthreads) * sizeof(float);
+    mla_absorbed_decode_kernel<<<n_heads, nthreads, shmem, stream>>>(
+        reinterpret_cast<const __half*>(q), reinterpret_cast<const __half*>(kv_b),
+        reinterpret_cast<const __half*>(cache), reinterpret_cast<__half*>(out), scores, context_lens,
+        n_heads, head_dim, rope_dim, nope_dim, kv_lora_rank, v_head_dim, max_seq, scale);
+}
+
+}  // namespace imp

--- a/src/compute/mla_absorb.h
+++ b/src/compute/mla_absorb.h
@@ -1,0 +1,54 @@
+#pragma once
+// MLA absorbed-decode latent KV cache (Phase 3, opt-in via attention.mla_absorb).
+//
+// Stage A (materialized) reconstructs full per-head K[rope+nope] / V[v_head_dim]
+// from the compressed latent at projection time and runs standard paged
+// attention. Phase 3 stores ONLY the compressed latent + decoupled RoPE key in a
+// dedicated cache and runs the mathematically-equivalent "absorbed" attention
+// at decode, where W_UK is folded into Q and W_UV into the output. The per-token
+// cache footprint is (kv_lora_rank + qk_rope_head_dim) halfs vs the materialized
+// n_heads*(qk+v head dims) — ~9x smaller for DeepSeek-V2-Lite.
+//
+// Both routines are correctness-first (one CUDA block per head, scalar dot
+// products). They are NOT a fused single-kernel optimization.
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+namespace imp {
+
+// Append the current step's RMSNorm'd latent + post-RoPE decoupled key into the
+// per-layer latent cache.
+//
+//   latent:      [n_tokens, kv_lora_rank]            FP16  (mla_latent_buf_)
+//   k_assembled: [n_tokens, n_heads, head_dim]       FP16  (post-RoPE K; the
+//                decoupled RoPE key is replicated across heads MQA-style, so
+//                head 0's first rope_dim dims are read)
+//   cache:       [max_seq, kv_lora_rank + rope_dim]  FP16  (per-layer slice)
+//   positions:   [n_tokens]                          INT32 device — absolute
+//                token position == destination row in the cache.
+//
+void mla_latent_cache_write(const half* latent, const half* k_assembled, half* cache,
+                            const int* positions, int n_tokens, int n_heads, int head_dim,
+                            int rope_dim, int kv_lora_rank, int max_seq,
+                            cudaStream_t stream = nullptr);
+
+// Absorbed MLA decode attention for a single sequence (one query token).
+//
+//   q:            [n_heads, head_dim]                  FP16  per head [pe|nope]
+//   kv_b:         [n_heads*(nope_dim+v_head_dim), kv_lora_rank] FP16 row-major
+//                 (ly.kv_b_proj, a PyTorch Linear weight [out,in]).
+//   cache:        [max_seq, kv_lora_rank + rope_dim]   FP16  (per-layer slice)
+//   out:          [n_heads, v_head_dim]                FP16  (compact, written
+//                 directly — matches the paged decode kernel output layout)
+//   scores:       [n_heads, max_seq]                   FP32  scratch
+//   context_lens: [1]                                  INT32 device — number of
+//                 cached tokens (incl. the current one, already written).
+//   scale:        attention logit scale (1/sqrt(qk_head_dim) * MLA mscale^2).
+//
+void mla_absorbed_decode(const half* q, const half* kv_b, const half* cache, half* out,
+                         float* scores, const int* context_lens, int n_heads, int head_dim,
+                         int rope_dim, int nope_dim, int kv_lora_rank, int v_head_dim,
+                         int max_seq, float scale, cudaStream_t stream = nullptr);
+
+}  // namespace imp

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -419,6 +419,16 @@ private:
     void* mla_k_rope_buf_ = nullptr;  // [max_tokens, qk_rope_head_dim]
     void* mla_kv_b_buf_ = nullptr;    // [max_tokens, n_heads*(qk_nope_head_dim+v_head_dim)]
 
+    // MLA absorbed-decode latent KV cache (Phase 3, opt-in attention.mla_absorb).
+    // Per-layer slice = [max_seq, kv_lora_rank + qk_rope_head_dim] FP16; cols
+    // [0:kv_lora_rank] = RMSNorm'd latent, [kv_lora_rank:] = post-RoPE decoupled
+    // key. Allocated only when mla_absorb is set, the model is_mla(), and every
+    // layer's kv_b_proj is FP16. Single-sequence only.
+    void* mla_absorb_cache_ = nullptr;        // [n_layers, max_seq, kv_lora+rope]
+    float* mla_absorb_scores_ = nullptr;      // [n_heads, max_seq] decode scratch
+    size_t mla_absorb_layer_stride_ = 0;      // halfs per layer = max_seq*(kv_lora+rope)
+    int mla_absorb_max_seq_ = 0;
+
     // Set when allocate_nvfp4_dequant_workspace() could NOT pre-allocate the
     // M>1 dequant scratch (largest NVFP4 weight exceeds the cap, or alloc
     // failed). The fallback then lazy-cudaMallocs, which is illegal inside

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -33,6 +33,7 @@
 #include "quant/mxfp4_gemm.h"
 #include "compute/hadamard.h"
 #include "compute/mla_kv_assemble.h"
+#include "compute/mla_absorb.h"
 #include "core/logging.h"
 #include "memory/kv_cache.h"
 #include "runtime/pdl.h"
@@ -460,6 +461,21 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     // FP16 paged decode kernels understand them — prefill routing below
     // forces the cuBLAS path whenever sinks are present.
     const void* attn_sinks = (prof.is_gpt_oss) ? ly.attn_sinks.data : nullptr;
+
+    // MLA absorbed-decode (Phase 3, opt-in). Populate the per-layer latent cache
+    // with this step's RMSNorm'd latent + post-RoPE decoupled key for BOTH
+    // prefill and decode (so the cache is warm before the first decode step).
+    // Single-sequence only; the absorbed decode below reads this cache.
+    const bool mla_absorb_active =
+        runtime_config().attention.mla_absorb && cfg.is_mla() && mla_absorb_cache_ != nullptr &&
+        state.n_sequences == 1;
+    if (mla_absorb_active) {
+        half* cache_layer = static_cast<half*>(mla_absorb_cache_) +
+                            static_cast<size_t>(layer) * mla_absorb_layer_stride_;
+        mla_latent_cache_write(static_cast<const half*>(mla_latent_buf_),
+                               static_cast<const half*>(kk.data), cache_layer, state.positions, n, nh,
+                               hd, cfg.qk_rope_head_dim, cfg.kv_lora_rank, mla_absorb_max_seq_, stream);
+    }
 
     if (state.is_prefill) {
 #include "exec/executor_attention_prefill.cu"

--- a/src/exec/executor_attention_decode.cu
+++ b/src/exec/executor_attention_decode.cu
@@ -6,6 +6,26 @@
 // list and must not be compiled on its own. The contents are byte-for-byte the
 // original inline block; see executor_attention.cu for surrounding context and
 // local variables in scope (including the `after_attention` label).
+        // MLA absorbed decode (Phase 3, opt-in attention.mla_absorb): the
+        // current token's latent + decoupled key were just written into the
+        // per-layer latent cache (above, before the prefill/decode branch). Run
+        // the mathematically-equivalent absorbed attention directly from the
+        // latent cache — no full per-head K/V materialization, no paged cache
+        // read. Single-token decode (n==1) only; multi-token (spec) decode falls
+        // through to the materialized paged path.
+        if (mla_absorb_active && n == 1) {
+            half* cache_layer = static_cast<half*>(mla_absorb_cache_) +
+                                static_cast<size_t>(layer) * mla_absorb_layer_stride_;
+            // ao is [n, nh*hd]; the absorbed kernel writes nh*v_head_dim compact
+            // (same layout the paged decode kernel produces), narrowed downstream.
+            mla_absorbed_decode(static_cast<const half*>(qv.data),
+                                static_cast<const half*>(ly.kv_b_proj.data), cache_layer,
+                                static_cast<half*>(ao.data), mla_absorb_scores_, state.context_lens,
+                                nh, hd, cfg.qk_rope_head_dim, cfg.qk_nope_head_dim, cfg.kv_lora_rank,
+                                cfg.v_head_dim, mla_absorb_max_seq_, scale, stream);
+            goto after_attention;
+        }
+
         // Decode: write new token's K/V to cache first
         if (rope_k_deferred) {
             // Fused: apply RoPE to K during KV cache write (saves 1 kernel launch)

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -111,6 +111,10 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
     if (max_tokens_ <= 0) {
         max_tokens_ = 4096;
     }
+    // Full sequence-length capacity for the MLA absorbed latent KV cache
+    // (Phase 3). Unlike max_tokens_ (per-forward, capped at 4096), this is the
+    // max cached context the latent cache must hold.
+    mla_absorb_max_seq_ = (effective_seq_len > 0) ? effective_seq_len : 4096;
 
     // Cap max_tokens for hybrid MoE+SSM/GDN models to bound workspace VRAM.
     // SSM state + cuBLAS S-matrix + workspace can exhaust 32 GB VRAM at the

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -51,6 +51,55 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         alloc(&mla_kv_b_buf_, kvb_out, "kv_b");
         IMP_LOG_INFO("MLA QKV scratch: kv_a+latent+k_rope+kv_b for max_tokens=%d (graph-safe)",
                      max_tokens_);
+
+        // Phase 3: absorbed-decode latent KV cache. Opt-in via attention.mla_absorb.
+        // Requires every layer's kv_b_proj to be FP16 (the absorbed path slices
+        // W_UK/W_UV directly from it); skip + warn otherwise so the materialized
+        // default stays unaffected.
+        if (runtime_config().attention.mla_absorb && mla_absorb_max_seq_ > 0) {
+            bool all_fp16 = true;
+            for (int li = 0; li < cfg.n_layers; li++) {
+                const auto& L = model_->layer(li);
+                if (L.kv_b_proj.data == nullptr || L.kv_b_proj.qtype != QType::F16) {
+                    all_fp16 = false;
+                    break;
+                }
+            }
+            if (!all_fp16) {
+                IMP_LOG_WARN("attention.mla_absorb: kv_b_proj is not FP16 on all layers — "
+                             "absorbed decode disabled, using materialized MLA path.");
+            } else {
+                const size_t row_w =
+                    static_cast<size_t>(cfg.kv_lora_rank + cfg.qk_rope_head_dim);
+                mla_absorb_layer_stride_ = static_cast<size_t>(mla_absorb_max_seq_) * row_w;
+                size_t cache_bytes =
+                    static_cast<size_t>(cfg.n_layers) * mla_absorb_layer_stride_ * sizeof(half);
+                size_t scores_bytes =
+                    static_cast<size_t>(cfg.n_heads) * mla_absorb_max_seq_ * sizeof(float);
+                cudaError_t e1 = cudaMalloc(&mla_absorb_cache_, cache_bytes);
+                cudaError_t e2 = cudaMalloc(&mla_absorb_scores_, scores_bytes);
+                if (e1 != cudaSuccess || e2 != cudaSuccess) {
+                    IMP_LOG_ERROR("attention.mla_absorb: latent cache alloc failed (%.1f MiB) — "
+                                  "falling back to materialized.",
+                                  cache_bytes / (1024.0 * 1024.0));
+                    if (mla_absorb_cache_) { cudaFree(mla_absorb_cache_); mla_absorb_cache_ = nullptr; }
+                    if (mla_absorb_scores_) { cudaFree(mla_absorb_scores_); mla_absorb_scores_ = nullptr; }
+                } else {
+                    // VRAM comparison vs the materialized per-token KV footprint.
+                    const size_t mat_per_tok =
+                        static_cast<size_t>(cfg.n_heads) *
+                        ((cfg.qk_rope_head_dim + cfg.qk_nope_head_dim) /*K hd*/ +
+                         (cfg.qk_rope_head_dim + cfg.qk_nope_head_dim) /*V padded to hd*/);
+                    const size_t lat_per_tok = row_w;
+                    IMP_LOG_INFO("MLA absorbed latent cache: %.1f MiB (n_layers=%d, max_seq=%d, "
+                                 "row=%zu halfs). Per-token: latent %zu vs materialized %zu halfs "
+                                 "(%.1fx smaller).",
+                                 cache_bytes / (1024.0 * 1024.0), cfg.n_layers, mla_absorb_max_seq_,
+                                 row_w, lat_per_tok, mat_per_tok,
+                                 static_cast<double>(mat_per_tok) / static_cast<double>(lat_per_tok));
+                }
+            }
+        }
     }
 
     // Dequant scratch buffer for on-the-fly weight dequantization. Every
@@ -1158,6 +1207,14 @@ void GraphExecutor::free_buffers() {
         free_cutlass_nvfp4_weight(lm_head_cutlass_);
         lm_head_cutlass_ = {};
         lm_head_cutlass_ready_ = false;
+    }
+    if (mla_absorb_cache_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(mla_absorb_cache_));
+        mla_absorb_cache_ = nullptr;
+    }
+    if (mla_absorb_scores_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(mla_absorb_scores_));
+        mla_absorb_scores_ = nullptr;
     }
     if (d_sample_result_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_sample_result_));

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -142,6 +142,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("attention.mxfp4_fp16_fallback", cfg.attention.mxfp4_fp16_fallback);
     S("attention.mxfp4_fp16_cache_policy", cfg.attention.mxfp4_fp16_cache_policy);
     B("attention.force_cublas_decode", cfg.attention.force_cublas_decode);
+    B("attention.mla_absorb", cfg.attention.mla_absorb);
     B("attention.no_qknorm_fused", cfg.attention.no_qknorm_fused);
     B("attention.splitk_pipe", cfg.attention.splitk_pipe);
     B("attention.gate_concat", cfg.attention.gate_concat);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -185,6 +185,15 @@ struct RuntimeConfig {
         // ~48 GiB FP16 fallback to ~8-12 GiB.
         std::string mxfp4_fp16_cache_policy = "legacy";
         bool force_cublas_decode = false;
+        // MLA absorbed-decode latent KV cache (DeepSeek-V2/V3, Phase 3). When
+        // off (default) the materialized Stage A path runs (full per-head K/V
+        // reconstructed at projection time + standard paged attention). When on,
+        // decode stores only the compressed latent + decoupled RoPE key and runs
+        // the mathematically-equivalent absorbed attention (~9x smaller per-token
+        // KV footprint). Prefill stays materialized; the latent cache is
+        // populated during prefill/decode. Single-sequence only (falls back to
+        // materialized otherwise). Env: none.
+        bool mla_absorb = false;
         bool no_qknorm_fused = false;
         bool splitk_pipe = true;
         bool gate_concat = false;

--- a/tests/test_mla.cu
+++ b/tests/test_mla.cu
@@ -21,6 +21,7 @@
 #include "compute/gemm.h"
 #include "compute/layernorm.h"
 #include "compute/mla_kv_assemble.h"  // production mla_assemble_kv / mla_reorder_q
+#include "compute/mla_absorb.h"       // production mla_absorbed_decode (Phase 3)
 #include "compute/attention_paged.h"  // paged_attention_decode with v_head_dim
 #include "core/tensor.h"
 #include "test_cuda_skip.h"
@@ -915,6 +916,127 @@ TEST(MLAAttnOutput, RealGeometryNkv16) {
     cudaFree(d_q_dec); cudaFree(d_o_dec);
     cudaFree(d_bt); cudaFree(d_cl);
     cudaFree(d_compact);
+}
+
+// ---------------------------------------------------------------------------
+// Test: MLAAbsorb.MatchesMaterializedReference
+//
+// Phase 3 equivalence gate. The absorbed decode (mla_absorbed_decode) must
+// produce the SAME attention output as the materialized formulation, since it
+// is a mathematically-equivalent reformulation:
+//   materialized: k_nope[t] = latent[t] @ W_UK^T; v[t] = latent[t] @ W_UV^T;
+//                 score[t] = scale*(q_nope.k_nope[t] + q_pe.k_rope[t]);
+//                 out = softmax(score) . v
+//   absorbed:     q_abs = q_nope @ W_UK; score[t] = scale*(q_abs.latent[t] +
+//                 q_pe.k_rope[t]); ctx = softmax(score).latent; out = ctx @ W_UV^T
+// We compute the materialized reference on the CPU (fp32) and compare to the
+// GPU absorbed kernel (cosine similarity > 0.999 per head).
+// ---------------------------------------------------------------------------
+TEST(MLAAbsorb, MatchesMaterializedReference) {
+    SKIP_IF_NO_CUDA();
+
+    static constexpr int nh       = 2;
+    static constexpr int kv_lora  = 16;
+    static constexpr int rope_dim = 8;
+    static constexpr int nope_dim = 16;
+    static constexpr int v_hd     = 16;
+    static constexpr int hd       = rope_dim + nope_dim;       // 24
+    static constexpr int head_out = nope_dim + v_hd;           // 32 kv_b rows/head
+    static constexpr int ctx      = 5;
+    static constexpr int max_seq  = 8;
+    const float scale = 1.0f / std::sqrt((float)hd);
+
+    std::mt19937 rng(123);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+    auto rand_vec = [&](int n) { std::vector<float> v(n); for (auto& x : v) x = dist(rng); return v; };
+
+    // q: [nh, hd] = [pe(rope_dim)|nope(nope_dim)]
+    std::vector<float> h_q = rand_vec(nh * hd);
+    // kv_b: [nh*head_out, kv_lora] row-major (W_UK rows then W_UV rows per head)
+    std::vector<float> h_kvb = rand_vec(nh * head_out * kv_lora);
+    // latent cache: [max_seq, kv_lora + rope_dim] — only first ctx rows valid
+    const int width = kv_lora + rope_dim;
+    std::vector<float> h_cache(max_seq * width, 0.0f);
+    {
+        std::vector<float> tmp = rand_vec(ctx * width);
+        for (int i = 0; i < ctx * width; i++) h_cache[i] = tmp[i];
+    }
+
+    // ---- CPU materialized reference ----
+    std::vector<float> ref(nh * v_hd, 0.0f);
+    for (int h = 0; h < nh; h++) {
+        const float* WUK = h_kvb.data() + (size_t)h * head_out * kv_lora;            // [nope, kv_lora]
+        const float* WUV = h_kvb.data() + ((size_t)h * head_out + nope_dim) * kv_lora; // [v, kv_lora]
+        const float* q_pe = h_q.data() + (size_t)h * hd;
+        const float* q_nope = q_pe + rope_dim;
+        std::vector<float> scores(ctx);
+        for (int t = 0; t < ctx; t++) {
+            const float* lat = h_cache.data() + (size_t)t * width;
+            const float* kr = lat + kv_lora;
+            // k_nope[t][j] = sum_c lat[c]*WUK[j][c]; score += q_nope[j]*k_nope[t][j]
+            float s = 0.0f;
+            for (int j = 0; j < nope_dim; j++) {
+                float kn = 0.0f;
+                for (int c = 0; c < kv_lora; c++) kn += lat[c] * WUK[(size_t)j * kv_lora + c];
+                s += q_nope[j] * kn;
+            }
+            for (int i = 0; i < rope_dim; i++) s += q_pe[i] * kr[i];
+            scores[t] = s * scale;
+        }
+        float mx = scores[0];
+        for (int t = 1; t < ctx; t++) mx = std::max(mx, scores[t]);
+        float sum = 0.0f;
+        for (int t = 0; t < ctx; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
+        for (int t = 0; t < ctx; t++) scores[t] /= sum;
+        // out[d] = sum_t p[t] * v[t][d]; v[t][d] = sum_c lat[c]*WUV[d][c]
+        for (int d = 0; d < v_hd; d++) {
+            float acc = 0.0f;
+            for (int t = 0; t < ctx; t++) {
+                const float* lat = h_cache.data() + (size_t)t * width;
+                float vd = 0.0f;
+                for (int c = 0; c < kv_lora; c++) vd += lat[c] * WUV[(size_t)d * kv_lora + c];
+                acc += scores[t] * vd;
+            }
+            ref[h * v_hd + d] = acc;
+        }
+    }
+
+    // ---- GPU absorbed kernel ----
+    Tensor g_q     = make_gpu_fp16(h_q, {nh, hd});
+    Tensor g_kvb   = make_gpu_fp16(h_kvb, {nh * head_out, kv_lora});
+    Tensor g_cache = make_gpu_fp16(h_cache, {max_seq, width});
+    Tensor g_out   = alloc_gpu_fp16({nh, v_hd});
+    float* d_scores = nullptr;
+    cudaMalloc(&d_scores, (size_t)nh * max_seq * sizeof(float));
+    int* d_cl = nullptr;
+    cudaMalloc(&d_cl, sizeof(int));
+    int h_cl = ctx;
+    cudaMemcpy(d_cl, &h_cl, sizeof(int), cudaMemcpyHostToDevice);
+
+    mla_absorbed_decode(static_cast<const half*>(g_q.data), static_cast<const half*>(g_kvb.data),
+                        static_cast<const half*>(g_cache.data), static_cast<half*>(g_out.data),
+                        d_scores, d_cl, nh, hd, rope_dim, nope_dim, kv_lora, v_hd, max_seq, scale,
+                        nullptr);
+    cudaDeviceSynchronize();
+
+    auto got = read_gpu_fp16(g_out);
+    ASSERT_EQ((int)got.size(), nh * v_hd);
+
+    // Per-head cosine similarity > 0.999.
+    for (int h = 0; h < nh; h++) {
+        double dot = 0, na = 0, nb = 0;
+        for (int d = 0; d < v_hd; d++) {
+            float a = got[h * v_hd + d];
+            float b = ref[h * v_hd + d];
+            dot += (double)a * b; na += (double)a * a; nb += (double)b * b;
+        }
+        double cos = dot / (std::sqrt(na) * std::sqrt(nb) + 1e-12);
+        EXPECT_GT(cos, 0.999) << "absorbed vs materialized cosine too low for head " << h
+                              << " (cos=" << cos << ")";
+    }
+
+    free_gpu(g_q); free_gpu(g_kvb); free_gpu(g_cache); free_gpu(g_out);
+    cudaFree(d_scores); cudaFree(d_cl);
 }
 
 }  // namespace

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -71,6 +71,7 @@ roots = ["src", "tools", "tests"]
 "src/model/safetensors_loader.cpp" = "(c) 1147 code LOC — one loader: header validation + tensor assign + arch inference"
 "src/runtime/engine_scheduler.cpp" = "(c) 1074 code LOC — one scheduler: prefill/decode scheduling + chunked exec + perplexity capture"
 "src/model/weight_map.cpp" = "(c) 966 code LOC — one mapping module: weight-name parse + layer-index + arch inference"
+"src/model/hf_config_loader.cpp" = "(tu) 810 code LOC — central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow"
 "src/runtime/cuda_graph.cu" = "(c) 863 code LOC — one module: graph capture/mode-resolve + PDL edges + barrier insert + replay"
 "src/memory/kv_cache_manager.cpp" = "(c) 852 code LOC — one manager: block alloc + residual pool + prefix cache + eviction"
 "tests/test_quant_integration.cu" = "(c) 1442 code LOC — 24 tests, all exercising the quant_gemm/dequant unit — one test target"


### PR DESCRIPTION
## Summary

Follow-up to #802 (Stage A materialized MLA, now merged). Adds **absorbed latent-KV-cache decode** for DeepSeek-V2 MLA — the long-context VRAM foundation — plus a file-size allowlist fix for `hf_config_loader.cpp`.

**Opt-in, default OFF** (`attention.mla_absorb=true`). Default behavior is the validated Stage A materialized path, unchanged.

## Absorbed decode

Mathematically-equivalent MLA decode that attends directly over the compressed latent (no per-head K/V materialization):
- `q_absorbed[h] = q_nope[h] @ W_UK[h]`; `scores[h,t] = q_absorbed[h]·latent[t] + q_pe[h]·k_rope[t]`; softmax; `ctx[h] = Σ_t p·latent[t]`; `out[h] = ctx[h] @ W_UV[h]ᵀ` (W_UK/W_UV = `kv_b_proj` row slices).
- Cache stores `latent(512)+k_rope(64)=576` halfs/token vs materialized 6144 → **10.7× smaller** (latent cache ~15 MiB logged).

## Verification

**Byte-identical to the materialized Stage A path** (the HF-validated oracle):
- Greedy temp=0, default OFF vs `--set attention.mla_absorb=true` → identical tokens: `8913 11 254 3787 280 2156 285 2126 13 8913 317` = " Paris, the city of light and love. Paris is".
- GTest `MLAAbsorb.MatchesMaterializedReference` (cos>0.999); MLA suite 7/7 green.

## Honest scope (follow-ups, not in this PR)

- Correctness-first **scalar kernel** (one block/head) — no perf claim; a fused/tensor-core kernel is future work.
- Absorbed **decode only**; prefill stays materialized (populates the latent cache).
- The paged KV cache is **still allocated**, so the 10.7× saving is projected, not yet realized as steady-state VRAM — realizing it needs absorbed prefill to drop the paged allocation.
- Single-sequence only; requires FP16 `kv_b_proj`.

Default-off keeps the validated materialized path as the shipping default and as the equivalence oracle.

Also: allowlist `hf_config_loader.cpp` (810 LOC, 10 over the 800 hard threshold after MLA config parsing — monolithic central config→ModelConfig parser) to green the File-size CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QkRojsjC2oNjKMD1TTCJP
