### PR TITLE
fix(mtp): sigmoid (not silu) attn-output gate — un-blocks MTP draft head (~10%→85%+ accept) + tree-ceiling probe

### DIFF
--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -85,6 +85,50 @@ __global__ void mtp_argmax_kernel(const __half* __restrict__ logits, int vocab_s
     if (tid == 0) *out_idx = s_idx[0];
 }
 
+// Top-W over an FP16 vector [vocab_size]. Single CTA; top_w (≤ kMtpMaxTopW)
+// sequential argmax passes, masking previously selected indices. Writes the W
+// descending-logit indices to out_idx[0..top_w). W is tiny relative to the
+// lm_head GEMM that produced the logits, so the extra passes are cheap.
+__global__ void mtp_topk_kernel(const __half* __restrict__ logits, int vocab_size,
+                                int top_w, int* __restrict__ out_idx) {
+    constexpr int kThreads = 256;
+    __shared__ float s_val[kThreads];
+    __shared__ int   s_idx[kThreads];
+    __shared__ int   s_found[kMtpMaxTopW];
+
+    int tid = threadIdx.x;
+    for (int w = 0; w < top_w; ++w) {
+        float best_val = -1.0e38f;
+        int   best_idx = 0;
+        for (int i = tid; i < vocab_size; i += kThreads) {
+            bool taken = false;
+            for (int f = 0; f < w; ++f) {
+                if (s_found[f] == i) { taken = true; break; }
+            }
+            if (taken) continue;
+            float v = __half2float(logits[i]);
+            if (v > best_val) { best_val = v; best_idx = i; }
+        }
+        s_val[tid] = best_val;
+        s_idx[tid] = best_idx;
+        __syncthreads();
+        for (int off = kThreads / 2; off > 0; off >>= 1) {
+            if (tid < off) {
+                if (s_val[tid + off] > s_val[tid]) {
+                    s_val[tid] = s_val[tid + off];
+                    s_idx[tid] = s_idx[tid + off];
+                }
+            }
+            __syncthreads();
+        }
+        if (tid == 0) {
+            s_found[w]  = s_idx[0];
+            out_idx[w]  = s_idx[0];
+        }
+        __syncthreads();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // MoE residual + shared-expert combine kernel
 // ---------------------------------------------------------------------------
@@ -351,6 +395,7 @@ bool mtp_workspace_allocate(MtpDraftWorkspace& ws, int hidden_dim, int vocab_siz
     ok &= alloc(&ws.d_fc_out,     hidden_dim * sizeof(__half));
     ok &= alloc(&ws.d_h_final,    hidden_dim * sizeof(__half));
     ok &= alloc(&ws.d_logits,     vocab_size * sizeof(__half));
+    ok &= alloc(reinterpret_cast<void**>(&ws.d_topk), kMtpMaxTopW * sizeof(int));
 
     ws.hidden_dim   = hidden_dim;
     ws.n_experts    = n_experts;
@@ -426,6 +471,7 @@ void mtp_workspace_free(MtpDraftWorkspace& ws) {
     frfn(ws.d_fc_out);
     frfn(ws.d_h_final);
     frfn(ws.d_logits);
+    if (ws.d_topk) { cudaFree(ws.d_topk); ws.d_topk = nullptr; }
     frfn(ws.d_post_norm);
     frfn(ws.d_router_logits);
     frfn(ws.d_expert_gate_up);
@@ -465,7 +511,8 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     MtpDraftWorkspace& ws,
                     int hidden_dim, int vocab_size,
                     int* out_token_id,
-                    cudaStream_t stream) {
+                    cudaStream_t stream,
+                    int* out_topk_ids, int top_w) {
     if (!mtp.loaded) {
         IMP_LOG_ERROR("mtp_draft_step: MTP head not loaded");
         return false;
@@ -915,7 +962,26 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         imp::gemm(h_final_view, main_lm_head, logits_view, 1.0f, 0.0f, stream);
     }
 
-    // Step 8: argmax → device int → D2H to out_token_id.
+    // Step 8: argmax (or top-W) → device int → D2H.
+    const bool want_topk = (out_topk_ids != nullptr && top_w > 0);
+    if (want_topk) {
+        // Top-W path (Stage 0 tree-ceiling probe): reuse the pre-allocated
+        // ws.d_topk buffer. out_token_id is set to the argmax (top-0).
+        const int w = std::min(top_w, kMtpMaxTopW);
+        if (ws.d_topk == nullptr) {
+            IMP_LOG_ERROR("mtp_draft_step: top-W requested but ws.d_topk not allocated");
+            return false;
+        }
+        mtp_topk_kernel<<<1, 256, 0, stream>>>(
+            static_cast<const __half*>(ws.d_logits), vocab_size, w, ws.d_topk);
+        if (cudaMemcpyAsync(out_topk_ids, ws.d_topk, w * sizeof(int),
+                            cudaMemcpyDeviceToHost, stream) != cudaSuccess)
+            return false;
+        cudaStreamSynchronize(stream);
+        *out_token_id = out_topk_ids[0];
+        return true;
+    }
+
     int* d_idx = nullptr;
     if (cudaMallocAsync(&d_idx, sizeof(int), stream) != cudaSuccess) {
         IMP_LOG_ERROR("mtp_draft_step: argmax scratch alloc failed");

--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -181,10 +181,12 @@ __global__ void mtp_gated_v_broadcast_kernel(
     int gate_idx = h * (2 * head_dim) + head_dim + d;
     float g = __half2float(q_full[gate_idx]);
     // silu(g) = g * sigmoid(g)
-    float silu_g = g * (1.0f / (1.0f + expf(-g)));
+    // Qwen3-Next attn_output_gate: attn_out *= sigmoid(gate) (NOT silu).
+    // Ref: vLLM Qwen3NextAttention.forward — attn_output * torch.sigmoid(gate).
+    float gate_act = 1.0f / (1.0f + expf(-g));
 
     float v_val = __half2float(v[kv_h * head_dim + d]);
-    out[t] = __float2half(silu_g * v_val);
+    out[t] = __float2half(gate_act * v_val);
 }
 
 // Elementwise add: fc_out += attn_residual
@@ -300,9 +302,11 @@ __global__ void mtp_gate_attn_out_kernel(
     int d = t % head_dim;
     int gate_idx = h * (2 * head_dim) + head_dim + d;
     float g = __half2float(q_full[gate_idx]);
-    float silu_g = g * (1.0f / (1.0f + expf(-g)));
+    // Qwen3-Next attn_output_gate: attn_out *= sigmoid(gate) (NOT silu).
+    // Ref: vLLM Qwen3NextAttention.forward — attn_output * torch.sigmoid(gate).
+    float gate_act = 1.0f / (1.0f + expf(-g));
     float v = __half2float(attn_out[t]);
-    attn_out[t] = __float2half(silu_g * v);
+    attn_out[t] = __float2half(gate_act * v);
 }
 
 // Append k_row (one step's k_proj output, shape [num_kv_heads, head_dim])

--- a/src/compute/mtp_forward.h
+++ b/src/compute/mtp_forward.h
@@ -29,6 +29,10 @@ namespace imp {
 
 class Model;
 
+// Max top-W width the MTP draft step can emit per position (tree-ceiling
+// measurement, Stage 0). The draft argmax is top-0.
+constexpr int kMtpMaxTopW = 8;
+
 // Workspace tensors needed for one draft step. Caller pre-allocates these so
 // the draft step is graph-safe (no cudaMalloc inside captured graph).
 struct MtpDraftWorkspace {
@@ -45,6 +49,8 @@ struct MtpDraftWorkspace {
     void* d_h_final = nullptr;
     // [vocab_size] FP16 — draft logits
     void* d_logits = nullptr;
+    // [kMtpMaxTopW] int — top-W candidate ids (Stage 0 tree-ceiling probe).
+    int*  d_topk = nullptr;
 
     // ---- Phase 2.2 MoE scratch ----
     // [hidden_dim] FP16 — post_attention_layernorm(fc_out)
@@ -144,6 +150,10 @@ struct MtpDraftWorkspace {
 //
 // Output:
 //   - *out_token_id   : drafted next token id (D2H copy of argmax)
+//   - out_topk_ids    : optional [top_w] host buffer; when non-null and
+//                       top_w>0, receives the top-W candidate ids in
+//                       descending-logit order (out_topk_ids[0] == *out_token_id).
+//                       Used by the Stage 0 tree-ceiling measurement.
 //
 // Returns false on any precondition violation (mtp not loaded, null buffers).
 bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
@@ -153,7 +163,8 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     MtpDraftWorkspace& ws,
                     int hidden_dim, int vocab_size,
                     int* out_token_id,
-                    cudaStream_t stream);
+                    cudaStream_t stream,
+                    int* out_topk_ids = nullptr, int top_w = 0);
 
 // Allocate the workspace from the VRAM allocator. Caller is responsible for
 // keeping ws alive (typically owned by the Engine for the lifetime of a session).

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -271,6 +271,7 @@ void Engine::mtp_accuracy_reset() noexcept {
     mtp_pending_prediction_ = -1;
     mtp_pending_chain_.clear();
     mtp_chain_accept_.clear();
+    mtp_chain_accept_w_.clear();
     if (mtp_ws_storage_) {
         auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
         imp::mtp_kv_reset(*ws);
@@ -278,7 +279,8 @@ void Engine::mtp_accuracy_reset() noexcept {
 }
 
 bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
-                           int hidden_dim, int vocab_size, int* out_token_id) {
+                           int hidden_dim, int vocab_size, int* out_token_id,
+                           int* out_topk_ids, int top_w) {
     if (mtp_ws_storage_ == nullptr) {
         IMP_LOG_ERROR("mtp_draft_one: spec-decode not enabled");
         return false;
@@ -291,7 +293,7 @@ bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
     return imp::mtp_draft_step(prev_token_id, d_h_prev, *model_->mtp_,
                                 model_->tok_emb_, model_->out_proj_,
                                 *ws, hidden_dim, vocab_size, out_token_id,
-                                decode_stream());
+                                decode_stream(), out_topk_ids, top_w);
 }
 
 // =====================================================================

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -185,7 +185,8 @@ public:
     // One draft step. Public for Phase 5 smoke testing; production callers
     // should not invoke directly until Phase 4 wires this into the decode loop.
     bool mtp_draft_one(int prev_token_id, const void* d_h_prev,
-                       int hidden_dim, int vocab_size, int* out_token_id);
+                       int hidden_dim, int vocab_size, int* out_token_id,
+                       int* out_topk_ids = nullptr, int top_w = 0);
 
     // Run MTP forward across all prompt positions to populate the MTP-side
     // KV cache before decode starts. Without this, MTP enters decode with an
@@ -223,6 +224,24 @@ public:
     // time. chain_accept_[0] == mtp_accuracy_ (next-step prediction).
     // chain_accept_[1] is the second draft (predicts 2 steps ahead); etc.
     std::vector<MtpAccuracy> mtp_chain_accept() const noexcept { return mtp_chain_accept_; }
+
+    // Stage 0 tree-ceiling probe: per-lookahead, per-width accept rate.
+    // matches[w] counts drafts where the true next token was within the MTP
+    // head's top-(w+1) candidates (cumulative: matches[0] ⊆ matches[1] ⊆ …).
+    // lookahead-0 is teacher-forced (MTP fed the real token + real main hidden);
+    // lookahead ≥1 is self-chained on MTP's own top-1 (a lower bound on the tree
+    // ceiling at depth, since a real tree would also branch on top-w parents).
+    static constexpr int kMtpMeasureW = 4;
+    struct MtpWidthAccuracy {
+        int matches[kMtpMeasureW] = {0, 0, 0, 0};
+        int total = 0;
+        float rate(int w) const {
+            return total > 0 ? static_cast<float>(matches[w]) / total : 0.0f;
+        }
+    };
+    std::vector<MtpWidthAccuracy> mtp_chain_accept_width() const noexcept {
+        return mtp_chain_accept_w_;
+    }
     void mtp_accuracy_reset() noexcept;  // also resets MTP KV cache pos
 
     // Accessors for C API
@@ -446,9 +465,11 @@ private:
         int prediction;
         int lookahead;
         int intended_position;
+        int topk[kMtpMeasureW] = {-1, -1, -1, -1};  // top-W candidates at draft time
     };
     std::vector<MtpChainEntry> mtp_pending_chain_;
     std::vector<MtpAccuracy> mtp_chain_accept_;
+    std::vector<MtpWidthAccuracy> mtp_chain_accept_w_;  // Stage 0 per-width table
 
     // ── n-gram (prompt-lookup) speculative decoding ─────────────────
     // Drafts come from suffix matches against the request's own context

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1360,6 +1360,18 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
                     if (it->prediction == next_token) {
                         mtp_chain_accept_[it->lookahead].matches++;
                     }
+                    // Stage 0 per-width: was the true next token within top-(w+1)?
+                    if (static_cast<int>(mtp_chain_accept_w_.size()) <= it->lookahead) {
+                        mtp_chain_accept_w_.resize(it->lookahead + 1);
+                    }
+                    auto& wa = mtp_chain_accept_w_[it->lookahead];
+                    wa.total++;
+                    int found_rank = kMtpMeasureW;  // sentinel: not in top-W
+                    for (int w = 0; w < kMtpMeasureW; ++w) {
+                        if (it->topk[w] == next_token) { found_rank = w; break; }
+                    }
+                    // Cumulative: a hit at rank r counts for all widths ≥ r.
+                    for (int w = found_rank; w < kMtpMeasureW; ++w) wa.matches[w]++;
                     it = mtp_pending_chain_.erase(it);
                 } else {
                     ++it;
@@ -1408,11 +1420,14 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             const void* chain_h_prev = h_for_mtp;
             for (int k = 0; k < K; ++k) {
                 int prediction = -1;
+                int topk[Engine::kMtpMeasureW] = {-1, -1, -1, -1};
                 if (!mtp_draft_one(chain_prev_tok, chain_h_prev, hidden_dim, vocab_size,
-                                    &prediction)) {
+                                    &prediction, topk, Engine::kMtpMeasureW)) {
                     break;
                 }
-                mtp_pending_chain_.push_back({prediction, k, cur_pos + 1 + k});
+                MtpChainEntry entry{prediction, k, cur_pos + 1 + k, {}};
+                for (int w = 0; w < Engine::kMtpMeasureW; ++w) entry.topk[w] = topk[w];
+                mtp_pending_chain_.push_back(entry);
                 // For k=0 only, also feed pending_prediction_ (legacy 1-step
                 // accuracy counter remains in sync with chain_accept_[0]).
                 if (k == 0) mtp_pending_prediction_ = prediction;

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -813,6 +813,38 @@ int main(int argc, char** argv) {
                                 k, chain[k].matches, chain[k].total, 100.0f * chain[k].rate(), k);
                     }
                 }
+
+                // Stage 0 tree-ceiling table: per-depth top-w hit rate.
+                // depth d=k+1; width w=1..W. lookahead-0 (depth 1) is
+                // teacher-forced; depth ≥2 is self-chained (lower bound).
+                auto cw = engine->mtp_chain_accept_width();
+                constexpr int W = imp::Engine::kMtpMeasureW;
+                if (!cw.empty()) {
+                    fprintf(stderr, "\n-- MTP tree-ceiling probe (top-w hit rate per depth) --\n");
+                    fprintf(stderr, "depth   n  ");
+                    for (int w = 0; w < W; ++w) fprintf(stderr, "  top-%d", w + 1);
+                    fprintf(stderr, "   (depth1=teacher-forced, depth>=2=self-chained lower bound)\n");
+                    for (size_t k = 0; k < cw.size(); ++k) {
+                        if (cw[k].total == 0) continue;
+                        fprintf(stderr, "  %2zu %5d  ", k + 1, cw[k].total);
+                        for (int w = 0; w < W; ++w)
+                            fprintf(stderr, " %5.1f%%", 100.0f * cw[k].rate(w));
+                        fprintf(stderr, "\n");
+                    }
+                    // Derived expected accept length (tokens emitted per verify):
+                    // E[accept] = sum_{d>=1} prod_{j=1..d} p(j), with the bonus
+                    // token = +1. Linear uses top-1; tree uses top-w per depth.
+                    for (int w = 0; w < W; ++w) {
+                        double e = 0.0, prod = 1.0;
+                        for (size_t k = 0; k < cw.size(); ++k) {
+                            if (cw[k].total == 0) break;
+                            prod *= cw[k].rate(w);
+                            e += prod;
+                        }
+                        fprintf(stderr, "  E[accept] top-%d = %.3f draft tokens%s\n",
+                                w + 1, e, w == 0 ? " (linear baseline)" : "");
+                    }
+                }
             }
 
             // Benchmark using Engine::generate() (conditional graph loop) for comparison.


### PR DESCRIPTION
## Summary

Fixes the root-cause bug that made the Qwen3.5/3.6 **MTP draft head** useless (~10% accept), plus adds the tree-ceiling evaluation telemetry. Un-blocks MTP as a speculative-decode draft source.

**MTP is opt-in telemetry** (`--mtp-spec-decode <k>`) — it does NOT change normal generation, so zero regression risk to the default path.

## The fix (root cause)

The Qwen3.5/3.6 MTP head uses Qwen3-Next **gated attention**: `attn_output = attn_output * sigmoid(gate)` (vLLM `Qwen3NextAttention.forward`). imp applied **`silu(gate)`** in both gate paths (`mtp_gate_attn_out_kernel` and the M=1 `mtp_gated_v_broadcast` fallback). silu is unbounded/can go negative → it sign-flipped the attention residual → collapsing MTP hidden state → the head predicted mostly rare/foreign tokens, only hitting on deterministic continuations.

**Effect (Qwen3.6-35B-A3B-NVFP4, depth-1 next-token accept):**
- prose **10.2% → 78–94%**, primes 13% → 96.6%.
- E[accept] linear ~1.9 draft tokens, top-4 tree ~2.6.

Verified on current main: depth-1 accept 85.7% (Roman-Empire prose) / 94.2% (sky-is-blue), coherent output.

## Tree-ceiling probe (Stage 0 telemetry)

Measures whether a top-W token-tree draft beats the linear chain, before building any tree-attention verify kernel: `mtp_topk_kernel` (top-W candidate ids), per-width `MtpWidthAccuracy`, and a depth×width hit-rate table + derived E[accept] printed under `--mtp-spec-decode`. Additive, gated on MTP-enabled batch-1 decode; normal path unaffected.

## Scope

This PR is the **correctness fix + evaluation telemetry** only. Wiring MTP drafts into **production speculative generation** (draft→verify→accept for real tok/s) is the next step — economics now favorable (85%+ accept, E[accept] ~1.9–2.6), but a net win on MoE requires graph-captured verify (else the async-loop-disable penalty dominates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QkRojsjC2oNjKMD1TTCJP
