### PR TITLE
feat(kv-cache): default FP8 KV for Nemotron-H MoE (passes long-context gate)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,12 +30,16 @@ The genuinely-open levers (most of the 06-12 campaign closed everything else —
   the only surviving idea for the last ~4% is **scaled fp8-KV storage with f16 compute** (halves KV
   traffic, 2× QK density via `m16n8k32`). Marginal — the competitive case is essentially won.
 
-- **kv-fp8 storage default-on** -- SHIPPED for Qwen3 dense + Qwen3 MoE. `kv_cache.dtype` now defaults to
-  `auto`, which honors a model author's `kv_cache_quant_algo=FP8` hint for arch families that pass the
-  long-context quality gate (`kv_fp8_hint_default_safe` — measured on a 3.9k-token context: Qwen3-14B PPL
-  +1.07%, Qwen3-30B-A3B neutral, both coherent; ~768 MiB KV VRAM saved). The −35% MoE tax was removed in
-  #682. **Remaining:** verify the other hint-declaring families (Phi-4, Nemotron-H, Qwen3.5/3.6, Gemma-4)
-  and add them to the allowlist; they stay FP16 (or `--kv-fp8` opt-in) until measured.
+- **kv-fp8 storage default-on** -- SHIPPED for Qwen3 dense + Qwen3 MoE + Llama (Phi-4) + Nemotron-H MoE.
+  `kv_cache.dtype` now defaults to `auto`, which honors a model author's `kv_cache_quant_algo=FP8` hint for
+  arch families that pass the long-context quality gate (`kv_fp8_hint_default_safe` — Qwen3-14B PPL +1.07%,
+  Qwen3-30B-A3B neutral, Phi-4 +0.25%, Nemotron-3-Nano-30B ~0.00%, all coherent; ~768 MiB KV VRAM saved on
+  the dense-attention models). The −35% MoE tax was removed in #682. The pending hint-declaring families
+  were swept in #749 + 2026-06-29: **Nemotron-H MoE** is now in (its 2026-06-23 single A/B was run-to-run
+  noise — the MoE+Mamba2 hybrid is nondeterministic even in deterministic mode, so a 5-run mean was needed,
+  and FP16 vs FP8 means coincide). **Remaining (blocked, not actionable):** Qwen3.6-35B and Qwen3.5 don't
+  declare the FP8 hint (allowlisting is moot); Gemma-4's baseline PPL on the gate corpus is broken (~243),
+  so it can't be gated on this corpus. These stay FP16 (or `--kv-fp8` opt-in).
 
 The two items below are **retained for the record but evidence-refuted**, not active work:
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -171,10 +171,14 @@ const char* model_arch_name(ModelArch arch) { return lookup_arch(arch).name; }
 //             Llama checkpoints do not declare the FP8 hint, so honoring it for
 //             the LLAMA arch only affects Phi-4-style models whose checkpoint
 //             opts in via kv_cache_quant_algo=FP8.
+//   NEMOTRON_H_MOE (Nemotron-3-Nano-30B): FP8-KV mean PPL 4.2774 vs FP16 4.2774
+//             = ~0.00% over a 26.5k-token corpus (5 runs each), measured 2026-06-29.
+//             The earlier 2026-06-23 single A/B read +0.47%..+1.83%, but that was
+//             run-to-run noise: this MoE+Mamba2 hybrid is nondeterministic even in
+//             deterministic mode (cross-context GDN), and the ~0.9% spread per dtype
+//             swamps the dtype effect — the multi-run means coincide. Only 6/52
+//             layers carry a KV cache (the rest are SSM), so the FP8 surface is small.
 // Measured 2026-06-23 but NOT added (same gate):
-//   NEMOTRON_H_MOE (Nemotron-3-Nano-30B): FP8-KV PPL is run-to-run nondeterministic
-//     (Δ swung +0.47% .. +1.83% across two runs; MoE+Mamba2 hybrid) — inconclusive,
-//     stays FP16 (--kv-fp8 opt-in) until a stable multi-run mean is established.
 //   GEMMA4 (Gemma-4-26B-A4B-NVFP4): baseline PPL on this corpus is broken (~243),
 //     can't gate. QWEN36MOE (Qwen3.6-35B-A3B): quality fine (-0.97%) but the
 //     checkpoint does not declare the hint, so allowlisting is moot.
@@ -186,6 +190,7 @@ bool kv_fp8_hint_default_safe(ModelArch arch) {
         case ModelArch::QWEN3:
         case ModelArch::QWEN3_MOE:
         case ModelArch::LLAMA:
+        case ModelArch::NEMOTRON_H_MOE:
             return true;
         default:
             return false;

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -40,13 +40,15 @@ TEST(RuntimeConfigTest, KvFp8HintDefaultSafeAllowlist) {
     EXPECT_TRUE(kv_fp8_hint_default_safe(ModelArch::QWEN3_MOE));
     // LLAMA: verified via Phi-4-reasoning-plus-NVFP4 (+0.25% PPL, PR #749).
     EXPECT_TRUE(kv_fp8_hint_default_safe(ModelArch::LLAMA));
+    // NEMOTRON_H_MOE: verified via Nemotron-3-Nano-30B — FP8 vs FP16 mean PPL
+    // ~0.00% over a 26.5k-token corpus, 5 runs each (the 2026-06-23 single A/B
+    // was run-to-run noise on this MoE+Mamba2 hybrid).
+    EXPECT_TRUE(kv_fp8_hint_default_safe(ModelArch::NEMOTRON_H_MOE));
     // Not yet verified on this box → must stay FP16 by default. GEMMA4 baseline
-    // PPL broken on the gate corpus; QWEN36_MOE quality fine but no hint declared;
-    // NEMOTRON_H_MOE FP8-KV PPL run-to-run nondeterministic (inconclusive).
+    // PPL broken on the gate corpus; QWEN36_MOE quality fine but no hint declared.
     EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::GEMMA4));
     EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::QWEN35));
     EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::QWEN36_MOE));
-    EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::NEMOTRON_H_MOE));
     EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::GENERIC));
 }
 


### PR DESCRIPTION
## What

Adds `ModelArch::NEMOTRON_H_MOE` to the `kv_fp8_hint_default_safe` allowlist. Models that declare `kv_cache_quant_algo=FP8` (e.g. **Nemotron-3-Nano-30B**) now honor that hint by default under `kv_cache.dtype=auto` — no `--kv-fp8` needed.

This completes the roadmap "kv-fp8 default-on" family rollout for every family that's actually gateable.

## Gate evidence

Nemotron-3-Nano-30B-A3B-NVFP4, 26.5k-token corpus, FP16 vs FP8 KV, `imp:test` (current main):

| dtype | deterministic | non-deterministic | **mean (5 runs)** |
|-------|--------------|-------------------|-------------------|
| FP16  | 4.2788, 4.2862 | 4.2983, 4.2656, 4.2583 | **4.2774** |
| FP8   | 4.2616, 4.2861 | 4.2992, 4.2678, 4.2724 | **4.2774** |

**Δ ≈ −0.0005% (~0.00%)** — far inside the ~1.5% gate.

The earlier 2026-06-23 single A/B (+0.47%..+1.83%, #749) was **run-to-run noise**: this MoE+Mamba2 hybrid is nondeterministic even in deterministic mode (cross-context GDN), and the ~0.9% per-dtype spread swamps the dtype effect. A 5-run mean was required to see the signal — and the means coincide. Only 6/52 layers carry a KV cache (the rest are SSM), so the FP8 surface is small.

## Verification

- `RuntimeConfigTest.KvFp8HintDefaultSafeAllowlist` (test-core) green.
- Default `auto` path now logs `KV cache dtype: FP8_E4M3 (auto — ... nemotron_h_moe verified safe ...)`.
- Generation coherent (correct Rayleigh-scattering answer, no degeneration/NaN).

## Notes

- Roadmap updated: the pending-families sweep is now complete. Remaining families are **blocked, not actionable** — Qwen3.6-35B / Qwen3.5 don't declare the FP8 hint (moot); Gemma-4's baseline PPL on the gate corpus is broken (~243).
- No perf-baseline impact (GGUF greedy-lock tests have empty hints → stay FP16; only Modelopt-NVFP4 Nemotron-H flips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)