### PR TITLE
docs(gpt-oss): record the Q8_0 GGUF rescale fix (#808/#809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   *generation* via this head remains parked — the GDN-hybrid MTP model carries
   irreversible recurrent state through verify and the economics are net-negative;
   it needs a non-recurrent MTP model.)
+- **gpt-oss GGUF 2^-4 residual rescale** — the official Q8_0-dense
+  `gpt-oss-20b-mxfp4.gguf` produced garbage (PPL 2739, degenerate decode) while
+  the bf16-dense GGUF and SafeTensors were fine. The gpt-oss residual-stream
+  rescale (Wo + biases) applied ×2^-4 by subtracting 4 from the fp16/bf16 biased
+  exponent — wrong for small scales: denormal scales (biased exp 0) were left
+  unscaled (16× too large) and exponents 1..4 were flushed to zero. On the
+  official file the attention `wo` had 91922/368640 blocks with exp==0, inflating
+  its L2 to 4.92 vs the correct 2.61, which cascaded into a ~20× layer-0 MoE
+  blowup and wrong expert routing. Now scaled in the float domain (exact for
+  normals, correct for denormals/underflow): Q8_0 PPL 2739 → 4.65, matching the
+  bf16/HF reference, decode coherent (#808). A CPU unit test sweeps all 65536
+  fp16 bit patterns to guard the rescale in CI (#809).
 
 ## [0.12.6] - 2026-06-26
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -48,7 +48,7 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 266 | SafeTensors (Modelopt) |
 | [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 126 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited (FP16 GDN/attn-projection tax) |
 | [Nemotron-Labs-3-Elastic-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4) | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
-| [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
+| [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Also loads the official GGUF (Q8_0- or bf16-dense + MXFP4 experts, e.g. `gpt-oss-20b-mxfp4.gguf` — the Q8_0 residual rescale was fixed in #808). Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
 
 ## Vision
 


### PR DESCRIPTION
Docs follow-up to #808 (Q8_0 GGUF rescale fix) and #809 (CI guard).

- **CHANGELOG.md** — `[Unreleased] → Fixed` entry describing the bug (exponent-bit rescale left denormal scales 16× too large / flushed exp≤4 to zero → ~20× layer-0 MoE blowup → garbage) and the fix (float-domain ×0.0625; PPL 2739 → 4.65).
- **supported-models.md** — the gpt-oss-20b row now notes the official Q8_0/bf16-dense GGUF loads (it previously listed SafeTensors only).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)