### PR TITLE
docs(mla): add DeepSeek-Coder-V2-Lite-Instruct (2nd verified MLA model)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -21,6 +21,7 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 | [DeepSeek-R1-Distill-Qwen-7B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF) | Q8_0 | 7.6 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-14B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF) | Q6_K | 12 GB | — | GGUF |
 | [DeepSeek-V2-Lite](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite) | bf16 | 28 GB | ~30 (eager) | SafeTensors — **MLA** (first Multi-head Latent Attention arch); experts host-offloaded on 32 GB → graphs disabled. PPL 6.06 vs HF 5.07 (+19.6%). |
+| [DeepSeek-Coder-V2-Lite-Instruct](https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct) | bf16 | 30 GB | — (eager) | SafeTensors — **MLA** (same `deepseek_v2` arch as V2-Lite: kv_lora_rank=512, q_lora_rank=0); experts host-offloaded on 32 GB → graphs disabled. Second MLA checkpoint, code-specialized — coherent codegen verified. |
 
 ## Hybrid (Gated DeltaNet + attention)
 


### PR DESCRIPTION
Found + tested on HF while exploring the open MLA-family roadmap item.

**DeepSeek-Coder-V2-Lite-Instruct** loads and generates coherent code on the RTX 5090 via imp's MLA path:
- `arch=deepseek_v2` → `ModelArch::DEEPSEEK`, `attn=mla`; MLA config identical to V2-Lite (`kv_lora_rank=512 q_lora_rank=0 qk_rope=64 qk_nope=128 v_head=128`), 27 layers, 64 experts / 6 active.
- Experts host-offloaded (14/26 MoE layers on GPU → CUDA graphs disabled, same as V2-Lite), no NaN.
- Coherent codegen verified (correct `is_palindrome` with `isalnum` cleanup).

Value: confirms imp's MLA path is **not V2-Lite-overfit** — it generalizes to a second real `deepseek_v2` checkpoint. (The V3 `q_lora_rank>0` Q-LoRA MLA path remains untested — no 32 GB-fitting model has it.)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)