### PR TITLE
feat(nvfp4): load NVFP4-quantized GDN (linear_attn) projections

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -32,6 +32,7 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Qwen3.5-9B](https://huggingface.co/unsloth/Qwen3.5-9B-GGUF) | Q8_0 | 8.9 GB | 142 | GGUF |
 | [Qwen3.5-27B](https://huggingface.co/unsloth/Qwen3.5-27B-GGUF) | Q4_K_M | 16 GB | — | GGUF |
 | [Qwable-3.6-27B](https://huggingface.co/Mia-AiLab/Qwable-3.6-27b) | Q4_K_M | 16 GB | ~18 | GGUF, validated dense-GDN 27B (Qwen3.6-27B fine-tune, 64 layers: 16 attn + 48 GDN). ~29 GB resident (Q4_K + NVFP4 decode cache + GDN state) → relies on the auto KV clamp to serve. Heavy trace-reasoner: give it generous `max_tokens`. |
+| [Qwen3.6-27B-Text-NVFP4-MTP](https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP) | NVFP4 | 17 GB | — | SafeTensors (Modelopt), dense-GDN 27B. **Checkpoint quantizes the GDN `linear_attn` projections to NVFP4** — `ssm_in`/`ssm_out`/`gdn_gate` run native NVFP4, `gdn_alpha`/`gdn_beta` (FP16_ONLY) are dequanted to FP16 at load (#812). |
 | Qwen3.5-27B | MXFP4 | — | — | Loads OOM on 32 GB — see [roadmap](roadmap.md) |
 
 ## Mixture-of-Experts

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -216,6 +216,15 @@ void QuantPipeline::pre_dequant_phase0_promote_nvfp4_sidecars_(
             return &L.ssm_in;
         if (slot == "ssm_out")
             return &L.ssm_out;
+        // GDN (Qwen3.5 linear_attn) NVFP4 projections: gdn_gate runs native
+        // NVFP4 (registered in Phase 0b); gdn_alpha/gdn_beta are FP16_ONLY and
+        // get dequant→FP16 below after promotion.
+        if (slot == "gdn_gate")
+            return &L.gdn_gate;
+        if (slot == "gdn_alpha")
+            return &L.gdn_alpha;
+        if (slot == "gdn_beta")
+            return &L.gdn_beta;
         return nullptr;
     };
 
@@ -276,6 +285,50 @@ void QuantPipeline::pre_dequant_phase0_promote_nvfp4_sidecars_(
         if (n_qkv_split > 0 || n_gateup_split > 0)
             IMP_LOG_INFO("Fused projection scale split: %d QKV + %d gate_up layers",
                          n_qkv_split, n_gateup_split);
+    }
+
+    // GDN alpha/beta (Qwen3.5 linear_attn.in_proj_a/in_proj_b) are FP16_ONLY:
+    // the delta-rule decay / learning-rate projections are precision-sensitive
+    // and the GDN GEMM expects FP16. If the checkpoint stored them NVFP4,
+    // promote() above set qtype=NVFP4; dequant them back to FP16 here (before
+    // plan_storage runs, so it tiers them FP16). ssm_in/ssm_out/gdn_gate stay
+    // native NVFP4 (registered in Phase 0b, gemv_nvfp4 — same as Nemotron-H).
+    {
+        int n_gdn_dequant = 0;
+        for (int i = 0; i < cfg.n_layers; i++) {
+            auto& L = mut_model->layers_[i];
+            for (Tensor* w : {&L.gdn_alpha, &L.gdn_beta}) {
+                if (w->qtype != QType::NVFP4 || !w->data || !w->scales)
+                    continue;
+                int64_t N = w->shape[0];
+                int64_t K = w->shape[1] * 2;  // packed K/2 → logical K
+                NvFP4QuantResult q;
+                q.packed_data = w->data;
+                q.micro_scales = w->scales;
+                q.tensor_scale = w->tensor_scale;
+                q.N = N;
+                q.K = K;
+                q.owned = false;
+                void* fp16buf = nullptr;
+                if (cudaMallocAsync(&fp16buf, static_cast<size_t>(N) * K * 2, stream) != cudaSuccess) {
+                    IMP_LOG_WARN("GDN NVFP4→FP16 dequant: alloc failed (layer %d) — leaving NVFP4", i);
+                    continue;
+                }
+                dequantize_nvfp4_to_fp16(q, fp16buf, stream);
+                // Old FP4 data + borrowed micro_scales are tiny (N≈n_heads); leave
+                // them resident rather than risk a use-after-free on the async stream.
+                w->data = fp16buf;
+                w->qtype = QType::F16;
+                w->scales = nullptr;
+                w->tensor_scale = 1.0f;
+                w->shape[1] = K;
+                w->compute_strides();
+                n_gdn_dequant++;
+            }
+        }
+        if (n_gdn_dequant > 0)
+            IMP_LOG_INFO("GDN NVFP4 alpha/beta: dequantized %d FP16_ONLY projections to FP16",
+                         n_gdn_dequant);
     }
 
     // Drop the scratch — its data pointers (weight_scale, weight_scale_2,
@@ -408,6 +461,7 @@ void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
             register_prequant(L.w_down_shared);
             register_prequant(L.ssm_in);
             register_prequant(L.ssm_out);
+            register_prequant(L.gdn_gate);  // Qwen3.5 GDN output gate — native NVFP4
             for (const auto& ew : L.expert_w_gate) register_prequant(ew);
             for (const auto& ew : L.expert_w_up) register_prequant(ew);
             for (const auto& ew : L.expert_w_down) register_prequant(ew);

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -1132,6 +1132,27 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
                 } else if (kind == "bias" && proj == "conv1d") {
                     layer.ssm_conv1d_b = t;
                     matched = true;
+                } else if (kind == "weight_scale" || kind == "weight_scale_2" ||
+                           kind == "input_scale") {
+                    // NVFP4-quantized GDN (linear_attn) projection scales. Route to
+                    // nvfp4_scratch_ so Phase-0 promote() attaches them. in_proj_a/b
+                    // (gdn_alpha/beta) are FP16_ONLY → dequant→FP16 at load; the rest
+                    // (ssm_in/ssm_out/gdn_gate) run native NVFP4 like Nemotron-H Mamba2.
+                    const char* slot = nullptr;
+                    if (proj == "in_proj_qkv")
+                        slot = "ssm_in";
+                    else if (proj == "in_proj_a")
+                        slot = "gdn_alpha";
+                    else if (proj == "in_proj_b")
+                        slot = "gdn_beta";
+                    else if (proj == "in_proj_z")
+                        slot = "gdn_gate";
+                    else if (proj == "out_proj")
+                        slot = "ssm_out";
+                    if (slot) {
+                        route_nvfp4_scale(model, layer_key_prefix + slot, kind, t);
+                        matched = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

Some Qwen3.5/3.6-arch NVFP4 SafeTensors checkpoints (e.g. [Qwen3.6-27B-Text-NVFP4-MTP](https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP)) quantize the **GDN `linear_attn` projections** to NVFP4. imp expected GDN projections in FP16, so it logged `unrecognised layer weight: ...linear_attn.in_proj_*.weight_scale`, **skipped the scales**, and ran GDN on raw FP4 bytes → **garbage** (endless `<|im_start|>` loop).

## Fix

Wire the load path (mirrors the existing Mamba2 native-NVFP4 handling):
- `weight_map.cpp` routes `linear_attn.*.{weight_scale,weight_scale_2,input_scale}` into `nvfp4_scratch_` (`ssm_in` / `ssm_out` / `gdn_gate` / `gdn_alpha` / `gdn_beta` slots).
- `pre_dequant_phase0` `resolve()` gains the `gdn_gate`/`gdn_alpha`/`gdn_beta` slots.
- **`ssm_in` (in_proj_qkv), `ssm_out` (out_proj), `gdn_gate` (in_proj_z)** run native NVFP4 — registered in the Phase 0b decode cache, `gemv_nvfp4_kpar`, same path as Nemotron-H Mamba2 (no FP16 SSM tax).
- **`gdn_alpha` (in_proj_a) / `gdn_beta` (in_proj_b)** are `FP16_ONLY` (precision-sensitive delta-rule decay / learning-rate); dequant NVFP4→FP16 at load via `dequantize_nvfp4_to_fp16` before `plan_storage` runs.

## Verification (RTX 5090)

- **Qwen3.6-27B-Text-NVFP4-MTP**: loads clean (no `unrecognised` warnings; `96 alpha/beta dequanted to FP16`; `96 recurrent projections in NVFP4 decode cache`) and **generates coherent output** (correct Rayleigh-scattering explanation) — was a `<|im_start|>` garbage loop.
- **No regression**: Nemotron-3-Nano-30B-A3B-NVFP4 (Mamba2 SSM-NVFP4) coherent; dense / non-GDN NVFP4 models execute **zero changed code** (weight_map gated on `linear_attn`, pre_dequant on `gdn_*.qtype==NVFP4 && data`).
- `test-core` 299 + `test-quant` 21 green.

Adds the model to `supported-models.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)