### PR TITLE
fix(nvfp4): guard MoE expert-scale cudaFree against offset pointers

### DIFF
--- a/src/exec/pre_dequant_phase3_moe.cu
+++ b/src/exec/pre_dequant_phase3_moe.cu
@@ -682,17 +682,26 @@ bool QuantPipeline::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
         size_t freed_bytes = 0;
         for (int e = 0; e < ne; ++e) {
             auto& w = experts[e];
+            // Only free BASE allocations (1:1 with cudaMallocAsync). Fused-projection
+            // experts (e.g. Qwen3.6-35B-A3B gate_up) carry OFFSET scale pointers into a
+            // shared buffer; an unguarded cudaFree on an offset returns "invalid
+            // argument" (8415x error flood on Qwen3.6-35B-A3B-NVFP4 — non-fatal but a
+            // small leak + log spam). Mirror the line-528 / Phase-4b drop-source guard.
             if (w.data) {
-                mut_model->release_gpu_allocation(w.data);
-                IMP_CUDA_CHECK_LOG(cudaFree(w.data));
-                freed_bytes += expert_packed_bytes;
+                if (mut_model->is_base_gpu_allocation(w.data)) {
+                    mut_model->release_gpu_allocation(w.data);
+                    IMP_CUDA_CHECK_LOG(cudaFree(w.data));
+                    freed_bytes += expert_packed_bytes;
+                }
                 w.data = nullptr;
                 w.on_device = false;
             }
             if (w.scales) {
-                mut_model->release_gpu_allocation(w.scales);
-                IMP_CUDA_CHECK_LOG(cudaFree(w.scales));
-                freed_bytes += expert_ms_bytes;
+                if (mut_model->is_base_gpu_allocation(w.scales)) {
+                    mut_model->release_gpu_allocation(w.scales);
+                    IMP_CUDA_CHECK_LOG(cudaFree(w.scales));
+                    freed_bytes += expert_ms_bytes;
+                }
                 w.scales = nullptr;
             }
         }


### PR DESCRIPTION
Found during the full-fleet degeneration battery.

`cache_moe_native_nvfp4_` (pre_dequant_phase3_moe.cu) consolidates per-expert NVFP4 weights into one contiguous buffer, then frees the per-expert sources. The free loop called `cudaFree` on each expert's `data` **and** `scales` unconditionally. For **fused-projection experts** (Qwen3.6-35B-A3B `gate_up`), the per-expert **scale is an OFFSET pointer** into a shared buffer (Phase-0 fused-scale split), not a base allocation → `cudaFree` returned `invalid argument`, **flooding stderr 8415× on Qwen3.6-35B-A3B-NVFP4** (non-fatal — output stayed coherent — but a small leak + heavy log spam).

Fix: gate both `cudaFree` calls on `Model::is_base_gpu_allocation()` — the exact guard already used at `pre_dequant_phase3_moe.cu:528` and in Phase 4b. Only base allocations (1:1 with `cudaMallocAsync`) are freed; offsets are reclaimed with their shared base.

**Verified:** Qwen3.6-35B-A3B-NVFP4 `cudaFree` error count **8415 → 0**, output still coherent. Pre-existing (reproduced identically on the pre-#812 build — not a regression from recent work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)