### PR TITLE
feat(gemma4): support gemma4_unified multimodal arch (dense Gemma-4-12B)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -16,6 +16,7 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 | [Qwen3-14B](https://huggingface.co/nvidia/Qwen3-14B-NVFP4) | NVFP4 | 10 GB | 168 | SafeTensors (nvidia) |
 | [Qwen3-32B](https://huggingface.co/unsloth/Qwen3-32B-GGUF) | Q4_K_M | 19 GB | — | GGUF |
 | [Phi-4-reasoning-plus](https://huggingface.co/nvidia/Phi-4-reasoning-plus-NVFP4) | NVFP4 | 9.0 GB | 157 | SafeTensors (nvidia), fused projections |
+| [Gemma-4-12B](https://huggingface.co/AxionML/Gemma-4-12B-NVFP4) | NVFP4 | 11 GB | — | SafeTensors (Modelopt) — **dense** Gemma-4, `gemma4_unified` multimodal wrapper (nested `text_config`, `model.language_model.*` prefix, vision/audio embedders skipped). FFN in NVFP4, attention BF16. |
 | [Llama-3.2-3B-Instruct](https://huggingface.co/unsloth/Llama-3.2-3B-Instruct-GGUF) | Q8_0 | 3.2 GB | 306 | GGUF |
 | [Mistral-Small-3.1-24B](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF) | Q6_K | 19 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-7B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF) | Q8_0 | 7.6 GB | — | GGUF |

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -38,6 +38,7 @@ ModelArch HFConfigLoader::map_architecture(const std::string& hf_arch) {
         {"Gemma3ForConditionalGeneration", ModelArch::GEMMA3},
         {"Gemma4ForCausalLM", ModelArch::GEMMA4},
         {"Gemma4ForConditionalGeneration", ModelArch::GEMMA4},
+        {"Gemma4UnifiedForConditionalGeneration", ModelArch::GEMMA4},  // multimodal unified (text_config nested)
         {"GptOssForCausalLM", ModelArch::GPT_OSS},
         {"DeepseekV2ForCausalLM", ModelArch::DEEPSEEK},
         {"DeepseekV3ForCausalLM", ModelArch::DEEPSEEK},
@@ -110,6 +111,7 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
                 {"gemma2", "Gemma2ForCausalLM"},
                 {"gemma3", "Gemma3ForCausalLM"},
                 {"gemma4", "Gemma4ForCausalLM"},
+                {"gemma4_unified", "Gemma4ForCausalLM"},
                 {"llama4", "Llama4ForCausalLM"},
                 {"deepseek_v2", "DeepseekV2ForCausalLM"},
                 {"deepseek_v3", "DeepseekV3ForCausalLM"},

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -358,6 +358,14 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
                 ++skipped;
                 continue;
             }
+            // Gemma-4 unified multimodal: audio/vision embedders ship under
+            // model.embed_{audio,vision}.* (not under language_model/vision_tower).
+            // Not part of the text LM — skip.
+            if (name.compare(0, 18, "model.embed_audio.") == 0 ||
+                name.compare(0, 19, "model.embed_vision.") == 0) {
+                ++skipped;
+                continue;
+            }
             if (name.compare(0, 4, "mtp.") == 0 ||
                 name.compare(0, 10, "model.mtp.") == 0) {
                 ++skipped;


### PR DESCRIPTION
Found while hunting a working dense Gemma-4 alternative.

The unified multimodal Gemma-4 checkpoints (`model_type: gemma4_unified`, `architectures: Gemma4UnifiedForConditionalGeneration` — e.g. the dense **Gemma-4-12B-NVFP4**) weren't in the arch registry → imp fell back to the **llama path and segfaulted** (gemma-4 needs SWA / QK-norm / softcap / embed-scale the llama path lacks).

Everything else for this layout already existed:
- `hf_config_loader` reads hyperparameters from a nested `text_config` when present;
- `weight_map`'s `is_gemma4` multimodal strip already handles the `model.language_model.*` prefix + vision-tower skip.

So the fix is just:
- map `Gemma4UnifiedForConditionalGeneration` + `model_type: gemma4_unified` → `ModelArch::GEMMA4`;
- skip the unified `model.embed_{audio,vision}.*` embedders (a different prefix than `vision_tower`/`visual`).

**No kernel work** — `attention_k_eq_v` is already handled (the working Gemma-4-26B-A4B-NVFP4 uses it too; the skill's "not implemented" note is stale).

## Verified (RTX 5090, AxionML/Gemma-4-12B-NVFP4)
- Arch now `gemma4` (dense, `attn=gemma4_swa`); loads clean (no unrecognised tensors); **coherent output** (correct Rayleigh-scattering answer) — was a llama-fallback segfault.
- **No regression**: Gemma-4-26B-A4B-NVFP4 (MoE) still coherent ("Paris"); `test-core` 305 green.

Adds the model to `supported-models.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)