### PR TITLE
fix(prefill): offset-aware S-matrix chunk clamp + O(n) chunked attention for uniform-shape hybrids

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -229,6 +229,22 @@ public:
         return attn_scores_buf_ ? static_cast<int>(attn_scores_.shape[1]) : 0;
     }
 
+    // Attention shapes are uniform when the per-layer shape arrays are absent
+    // or carry a single distinct nonzero value (GDN/Mamba2 hybrids fill zeros
+    // for non-attention layers). Uniform models can be served by the O(n)
+    // FA2/FMHA chunked-prefill family; only truly heterogeneous shapes
+    // (Gemma-4 dual head_dim 256/512) require the rectangular cuBLAS path.
+    bool attn_shapes_uniform() const;
+
+    // Largest prefill chunk starting at `offset` that the chunked-attention
+    // dispatch can serve without overflowing the cuBLAS S-matrix (constraint:
+    // n × (offset + n) ≤ s_cap² and n ≤ s_cap), floored to a kv_bs multiple.
+    // Chunks served by the O(n) FA2/FMHA paths need no S-matrix and return
+    // `desired` unchanged. Returns 0 when even a kv_bs-sized chunk cannot be
+    // served (caller must reject the request instead of letting the kernel
+    // capacity guard abort).
+    int max_safe_prefill_chunk(int offset, int desired, int kv_bs) const;
+
     // Get a view of the logits buffer for n tokens (for CUDA graph replay,
     // where forward_logits isn't called but the graph writes to this buffer).
     Tensor get_logits_view(int n) const { return view_tokens(logits_, n); }

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -38,16 +38,17 @@
             int kv_layer = get_kv_layer(kv_layer_map_, layer);
             int kv_bs = cache->block_size();
             int ctx_len = q_offset + n;
-            // Of the three chunked branches below, ONLY cuBLAS consumes attn_scores_.
+            // Of the chunked branches below, ONLY cuBLAS consumes attn_scores_.
             // FP16-QK FA2 (hd=128) and the tiled FMHA dispatch are O(n) and need no
-            // S-matrix, so the capacity guard applies only when neither will serve
-            // this chunk — otherwise a deliberately skipped S-matrix on a fa2-served
-            // hd=128 model (executor_workspace_buffers.cu) would wrongly abort here.
-            const bool chunk_fa2_serves = !per_layer_shapes && !attn_sinks && hd == 128 &&
+            // S-matrix. Uniform per-layer shapes (GDN/Mamba2 hybrids: zeros on
+            // non-attention layers, one distinct nonzero value) are served by the
+            // O(n) family too — only truly heterogeneous shapes (Gemma-4 dual
+            // head_dim 256/512) and learned sinks (gpt-oss) require cuBLAS.
+            const bool shapes_uniform = !per_layer_shapes || attn_shapes_uniform();
+            const bool chunk_fa2_serves = shapes_uniform && !attn_sinks && hd == 128 &&
                                           runtime_config().attention.fa2_fp16qk != "never";
-            const bool chunked_use_fmha = !per_layer_shapes &&  // Gemma-4 hd=512 stays cuBLAS
-                                          (runtime_config().attention.fmha_prefill_threshold > 0 &&
-                                           ctx_len >= runtime_config().attention.fmha_prefill_threshold);
+            // Tiled FMHA correctness domain: uniform shapes, no learned sinks.
+            const bool chunk_fmha_ok = shapes_uniform && !attn_sinks;
             // attn_scores_ is sized [nh, s_cap, s_cap] (square). Chunked cuBLAS stores
             // an [nh, n, ctx_len] FP16 matrix (or FP32 = 2× when use_fp32_s). The
             // capacity constraint is `n * ctx_len <= s_cap²`, NOT `ctx_len <= s_cap`
@@ -60,8 +61,15 @@
             int s_cap = attn_scores_buf_ ? static_cast<int>(attn_scores_.shape[1]) : 0;
             int64_t fp16_elems_needed = static_cast<int64_t>(n) * ctx_len;
             int64_t fp16_elems_avail = static_cast<int64_t>(s_cap) * s_cap;
-            if (!chunk_fa2_serves && !(chunked_use_fmha && !attn_sinks) &&
-                (s_cap == 0 || fp16_elems_needed > fp16_elems_avail || n > s_cap)) {
+            const bool smatrix_fits =
+                s_cap > 0 && n <= s_cap && fp16_elems_needed <= fp16_elems_avail;
+            const bool prefer_fmha = chunk_fmha_ok &&
+                                     runtime_config().attention.fmha_prefill_threshold > 0 &&
+                                     ctx_len >= runtime_config().attention.fmha_prefill_threshold;
+            if (!chunk_fa2_serves && !chunk_fmha_ok && !smatrix_fits) {
+                // Sinks/heterogeneous shapes can ONLY be served by cuBLAS — the
+                // engine clamps chunk sizes (max_safe_prefill_chunk) and rejects
+                // unservable prompts upfront, so this is defense-in-depth.
                 IMP_LOG_ERROR(
                     "chunked_prefill: attn_scores_ capacity %d×%d=%lld too small for "
                     "n=%d × ctx_len=%d = %lld at L%d — engine should have prevented this",
@@ -139,8 +147,8 @@
             // gated behind the S-matrix-capacity threshold where it has
             // history in production. fp8-attention quality above the
             // threshold is tracked separately (see issue #511).
-            // (chunk_fa2_serves / chunked_use_fmha computed above, before the
-            // S-matrix capacity guard.)
+            // (chunk_fa2_serves / prefer_fmha / smatrix_fits computed above,
+            // with the S-matrix capacity guard.)
 
             // Chunked attention routing (#548): prefer the FP16-QK FA2 kernel
             // at EVERY ctx_len, not only below the threshold. It is O(n)
@@ -154,34 +162,24 @@
             // raw e4m3 Q/K conversion read teacher-forced PPL 549 vs 16.6 on
             // gemma-3-12b when it served these chunks). cuBLAS below the
             // threshold.
-            if (!per_layer_shapes && !attn_sinks &&
+            if (chunk_fa2_serves &&
                 try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
                                        nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
                                        q_offset, stream)) {
                 // chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
-            } else if (chunked_use_fmha && !attn_sinks) {
-                // FMHA: no S-matrix needed, O(n) memory. Reshape to 4D for dispatch.
-                int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
-                int64_t kv4s[4] = {1, (int64_t)ctx_len, (int64_t)nkv, (int64_t)hd};
-                int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
-                Tensor q4 = qv.reshape(4, q4s);
-                Tensor k4 = k_full_t.reshape(4, kv4s);
-                Tensor v4 = v_full_t.reshape(4, kv4s);
-                Tensor o4 = ao.reshape(4, o4s);
-                attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
-                                           cfg.attn_logit_softcap, stream, runtime_config(), q_offset);
-            } else if (attn_scores_buf_) {
-                // cuBLAS: needs S-matrix for [n × ctx_len]; also the only chunked
-                // path that honors learned sinks (attn_sinks → gpt-oss).
+            } else if (smatrix_fits && !prefer_fmha) {
+                // cuBLAS: reference path below the FMHA threshold; also the only
+                // chunked path that honors learned sinks (attn_sinks → gpt-oss)
+                // and heterogeneous per-layer shapes (Gemma-4).
                 attention_cublas_prefill(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv, hd, scale,
                                          /*causal=*/true, cfg.attn_logit_softcap, q_offset, stream,
                                          layer_sliding_window, attn_sinks);
             } else {
-                // Safety net: the S-matrix was skipped (hd=128 fa2-served model) but
-                // fa2 unexpectedly declined this chunk and it is below the FMHA
-                // threshold — fall back to the O(n) tiled dispatch rather than
-                // dereferencing a null attn_scores_. Unreachable with attn_sinks:
-                // sink models (gpt-oss, hd=64) always keep the S-matrix.
+                // Tiled FMHA dispatch: no S-matrix needed, O(n) memory. Serves
+                // uniform-shape chunks above the FMHA threshold, any chunk the
+                // S-matrix cannot hold, and fa2-declined chunks on models whose
+                // S-matrix was deliberately skipped (guarded unservable above:
+                // sinks/heterogeneous shapes never reach this branch).
                 int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
                 int64_t kv4s[4] = {1, (int64_t)ctx_len, (int64_t)nkv, (int64_t)hd};
                 int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1237,6 +1237,62 @@ void GraphExecutor::free_buffers() {
     initialized_ = false;
 }
 
+bool GraphExecutor::attn_shapes_uniform() const {
+    const auto& cfg = model_->config();
+    auto uniform = [](const std::vector<int>& v) {
+        int ref = 0;
+        for (int x : v) {
+            if (x <= 0)
+                continue;  // zeros mark non-attention layers (GDN/Mamba2 hybrids)
+            if (ref == 0)
+                ref = x;
+            else if (x != ref)
+                return false;
+        }
+        return true;
+    };
+    return uniform(cfg.head_dim_per_layer) && uniform(cfg.n_kv_heads_per_layer);
+}
+
+int GraphExecutor::max_safe_prefill_chunk(int offset, int desired, int kv_bs) const {
+    const int s_cap = attn_scores_cap();
+    // No S-matrix allocated: the chunked path is served by the O(n) FA2/FMHA
+    // family (fa2_serves_all_prefill) — no capacity constraint applies here.
+    if (s_cap <= 0 || desired <= 0)
+        return desired;
+    const auto& cfg = model_->config();
+    const bool sinks = model_->profile().is_gpt_oss;
+    const bool uniform = attn_shapes_uniform();
+    const auto& att = runtime_config().attention;
+    // Uniform attention head_dim (first nonzero per-layer value, else global).
+    int hd_u = cfg.head_dim > 0 ? cfg.head_dim
+                                : (cfg.n_heads > 0 ? cfg.d_model / cfg.n_heads : 0);
+    for (int x : cfg.head_dim_per_layer) {
+        if (x > 0) {
+            hd_u = x;
+            break;
+        }
+    }
+    // Mirrors the chunked dispatch in executor_attention_prefill.cu:
+    // FP16-QK FA2 serves every hd=128 chunk with no S-matrix.
+    if (uniform && !sinks && hd_u == 128 && att.fa2_fp16qk != "never")
+        return desired;
+    // The tiled FMHA dispatch serves chunks whose ctx_len crosses the
+    // threshold (and any chunk the S-matrix cannot hold) with no S-matrix.
+    if (uniform && !sinks && att.fmha_prefill_threshold > 0 &&
+        offset + desired >= att.fmha_prefill_threshold)
+        return desired;
+    // cuBLAS serves this chunk: n × (offset + n) ≤ s_cap² and n ≤ s_cap.
+    // Solve the quadratic for n; floor to a KV-block multiple.
+    const double cap2 = static_cast<double>(s_cap) * s_cap;
+    const double disc = static_cast<double>(offset) * offset + 4.0 * cap2;
+    int n_max = static_cast<int>((std::sqrt(disc) - offset) / 2.0);
+    n_max = std::min(n_max, s_cap);
+    if (kv_bs > 0)
+        n_max = (n_max / kv_bs) * kv_bs;
+    return std::min(desired, n_max);
+}
+
 // pre_dequant_weights() is in executor_pre_dequant.cu
 // configure_*_workspace(), resize_workspace(), allocate_decode_workspace(),
 // use_workspace(), layer_has_*(), view_tokens(), ensure_logits_pinned()

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -421,6 +421,14 @@ bool Engine::prefill_allocate_kv_blocks_(std::shared_ptr<Request>& req, int kv_b
                 req->prefill_offset = offset;
                 chunk_len = total_input - offset;
                 is_last_chunk = true;
+                // Re-apply the offset-aware S-matrix clamp: the caller computed
+                // effective_chunk for the pre-skip offset, and a cuBLAS-served
+                // chunk at the new (larger) offset may need to be smaller
+                // (n × ctx_len ≤ s_cap²). The upfront servability check in
+                // step_prefill_one guarantees ≥ kv_bs fits at any offset.
+                int max_chunk = executor_->max_safe_prefill_chunk(offset, effective_chunk, kv_bs);
+                if (max_chunk > 0 && max_chunk < effective_chunk)
+                    effective_chunk = max_chunk;
                 if (chunk_len > effective_chunk) {
                     chunk_len = effective_chunk;
                     is_last_chunk = false;
@@ -567,21 +575,34 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         return;
     }
 
-    // Clamp effective_chunk so n × ctx_len ≤ s_cap² where s_cap is the
-    // attn_scores_ workspace dimension. Worst case is the final chunk where
-    // ctx_len ≈ total_input. Without this, long prompts on hybrid models
-    // (Qwen3.5/3.6 GDN, Nemotron-H) hit "attn_scores_ capacity too small"
-    // abort in executor_attention.cu — see chunked_prefill_attn_scores_capacity_bug.
+    // Clamp effective_chunk so the chunked-attention S-matrix cannot overflow
+    // (cuBLAS stores an [nh, n, ctx_len] score matrix; n × ctx_len ≤ s_cap²).
+    // max_safe_prefill_chunk mirrors the executor dispatch and only clamps
+    // chunks that will actually land on cuBLAS (learned sinks → gpt-oss,
+    // heterogeneous shapes → Gemma-4); chunks served by the O(n) FA2/FMHA
+    // family pass through unclamped. The clamp is offset-aware: early chunks
+    // stay large and only late chunks shrink (previously EVERY chunk was
+    // clamped to the final-chunk worst case cap²/total_input — e.g. 32-token
+    // chunks across an entire 128k prompt on hd=256 hybrids).
     if (executor_) {
-        int s_cap = executor_->attn_scores_cap();
-        if (s_cap > 0 && total_input > 0) {
-            int64_t cap2 = static_cast<int64_t>(s_cap) * s_cap;
-            int max_chunk_for_buf = static_cast<int>(cap2 / total_input);
-            max_chunk_for_buf = (max_chunk_for_buf / kv_bs) * kv_bs;
-            if (max_chunk_for_buf > 0 && effective_chunk > max_chunk_for_buf) {
-                effective_chunk = max_chunk_for_buf;
+        if (offset == 0 && total_input > kv_bs) {
+            // Upfront servability check: if even a kv_bs-sized final chunk
+            // cannot fit the S-matrix, reject cleanly instead of letting the
+            // kernel capacity guard abort the process mid-prefill.
+            int last_off = ((total_input - 1) / kv_bs) * kv_bs;
+            if (executor_->max_safe_prefill_chunk(last_off, kv_bs, kv_bs) < kv_bs) {
+                IMP_LOG_ERROR(
+                    "Prompt (%d tokens) exceeds the chunked-attention workspace for this model "
+                    "(S-matrix cap %d; learned-sink/heterogeneous attention requires cuBLAS) — "
+                    "cancelling request %d. Reduce the prompt or raise attention.attn_scores_mib.",
+                    total_input, executor_->attn_scores_cap(), req->id);
+                req->status = RequestStatus::CANCELLED;
+                return;
             }
         }
+        int max_chunk = executor_->max_safe_prefill_chunk(offset, effective_chunk, kv_bs);
+        if (max_chunk > 0 && effective_chunk > max_chunk)
+            effective_chunk = max_chunk;
     }
 
     // Determine chunk boundaries


### PR DESCRIPTION
## What

Long-context (agentic) prefill was needlessly slow for every non-hd-128 model and could kill the server process outright:

1. **Chunk collapse**: the engine clamped EVERY prefill chunk to the final-chunk worst case (`cap²/total_input`) whenever an S-matrix existed — even for chunks the O(n) FA2/FMHA family serves without one. At 128k on hd=256 hybrids that means ~32-token chunks across the whole prompt (minutes-scale TTFT).
2. **Process abort**: when the worst-case clamp rounded below one KV block it was silently *skipped* (`max_chunk_for_buf > 0` guard), the chunk stayed at 2048, and the kernel capacity guard `std::abort()`ed the entire server mid-prefill (reproduced: gpt-oss, 110k-token prompt, `attn_scores_mib=128` → exit 139).
3. **Over-conservative dispatch**: GDN/Mamba2 hybrids (Qwen3.5/3.6, Nemotron-H) populate per-layer shape arrays with zeros for SSM layers, so `per_layer_shapes` excluded them from the FA2/FMHA chunked paths although their attention shapes are uniform — they were stuck on cuBLAS + S-matrix forever.

## How

- `GraphExecutor::max_safe_prefill_chunk(offset, desired, kv_bs)`: mirrors the chunked dispatch; returns `desired` unchanged for FA2/FMHA-served chunks, otherwise solves `n × (offset+n) ≤ s_cap²` per chunk (early chunks stay large, only late chunks shrink).
- `GraphExecutor::attn_shapes_uniform()`: per-layer arrays with a single distinct nonzero value count as uniform → FA2 (hd=128, e.g. Nemotron-H) / tiled FMHA (hd=256, e.g. Qwen3.5/3.6) serve chunked prefill. Truly heterogeneous shapes (Gemma-4 dual head_dim) and learned sinks (gpt-oss) stay on cuBLAS.
- Chunked dispatch restructured around `chunk_fa2_serves / smatrix_fits / prefer_fmha`; the capacity abort remains as defense-in-depth for the cuBLAS-only configs.
- Engine: upfront servability check at prefill start cancels the request with an actionable error instead of the mid-prefill process abort; prefix-cache offset jumps re-apply the clamp (the old code was only safe there because it always clamped to the global worst case).

## Measured (RTX 5090, vs v0.13.0 release image, same prompts)

| Model | Shape class | Prompt | pp before | pp after | Δ | Quality |
|---|---|---|---|---|---|---|
| Qwen3.6-35B-A3B NVFP4 | hd=256 GDN hybrid | 10k | 4777 tok/s | **8610 tok/s** | **+80%** | PPL +0.56% (run-to-run spread) |
| Nemotron-3-Nano-30B NVFP4 | hd=128 hybrid | 10k | 5288 tok/s | **11361 tok/s** | **+115%** | greedy-identical tokens |
| gpt-oss-20b ST | learned sinks | 40k | 703 tok/s | **1191 tok/s** | **+69%** | greedy-identical tokens |
| Gemma-4-26B-A4B NVFP4 | heterogeneous | 10k | 4743 tok/s | **6386 tok/s** | **+35%** | PPL −0.87% |

Abort repro (gpt-oss, 110,663-token prompt, `attn_scores_mib=128`): **main = exit 139 (process killed)** → **this PR = clean request cancel** with "Reduce the prompt or raise attention.attn_scores_mib."

## Verification

- `ChunkedPrefillTest` 6/6, `AttentionChunkedTest` 5/5, `make test-unit` 37/37
- `verify-fast` OK — decode WARN is the depressed-host #526 signature (345W max during bench); the decode path is untouched by this PR and pp512 is +0.99%.
- Perf note: this PR **improves** prefill for hybrid/sink/heterogeneous models; the gated baseline model (Qwen3-8B, hd=128, no S-matrix) is behaviorally unchanged — no baseline refresh needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)