### PR TITLE
fix(constraints): per-request constraint state — json_schema enforced under concurrency

### DIFF
--- a/src/runtime/constraint_manager.h
+++ b/src/runtime/constraint_manager.h
@@ -51,6 +51,11 @@ public:
     bool has_json() const noexcept { return active_json_; }
     bool has_schema() const noexcept { return active_schema_; }
 
+    // Schema string of the cached (initialized) schema constrainer — lets the
+    // engine's manager pool prefer an instance that already classified this
+    // schema over re-classifying the vocab.
+    const std::string& cached_schema() const noexcept { return cached_schema_string_; }
+
 private:
     std::unique_ptr<JsonConstrainer> json_constrainer_;
     std::unique_ptr<SchemaConstrainer> schema_constrainer_;

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -425,11 +425,40 @@ void Engine::finish_request(std::shared_ptr<Request>& req) {
     }
     kv_manager_->free_sequence(req->id);
     release_recurrent_slot_(req->id);
-    constraints_.reset();
+    if (req->constraints)
+        constraints_return_(std::move(req->constraints));
     // Server visibility: the engine outlives requests, so cumulative
     // speculation telemetry is logged per request end (no-op when idle).
     if (spec_ngram_enabled_(*req))
         log_spec_stats_();
+}
+
+std::shared_ptr<ConstraintManager> Engine::constraints_checkout_(const std::string& json_schema) {
+    // Prefer a pooled manager that already classified this schema.
+    if (!json_schema.empty()) {
+        for (auto it = constraint_pool_.begin(); it != constraint_pool_.end(); ++it) {
+            if ((*it)->cached_schema() == json_schema) {
+                auto cm = std::move(*it);
+                constraint_pool_.erase(it);
+                return cm;
+            }
+        }
+    }
+    if (!constraint_pool_.empty()) {
+        auto cm = std::move(constraint_pool_.back());
+        constraint_pool_.pop_back();
+        return cm;
+    }
+    return std::make_shared<ConstraintManager>();
+}
+
+void Engine::constraints_return_(std::shared_ptr<ConstraintManager> cm) {
+    if (!cm)
+        return;
+    cm->reset();
+    constexpr size_t kMaxConstraintPool = 8;
+    if (constraint_pool_.size() < kMaxConstraintPool)
+        constraint_pool_.push_back(std::move(cm));
 }
 
 // =====================================================================

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -401,7 +401,15 @@ private:
 
     // ── Extracted subsystems ─────────────────────────────────────────
     VisionPipeline vision_;
-    ConstraintManager constraints_;
+    // Constraint FSM state lives per-request (Request::constraints) — a
+    // single engine-global manager let any concurrent prefill/finish clobber
+    // another request's FSM and dropped enforcement at decode batch>1. The
+    // pool recycles idle managers so repeat requests with the same
+    // json_schema reuse the classified-token tables instead of re-classifying
+    // ~151K vocab tokens per request.
+    std::vector<std::shared_ptr<ConstraintManager>> constraint_pool_;
+    std::shared_ptr<ConstraintManager> constraints_checkout_(const std::string& json_schema);
+    void constraints_return_(std::shared_ptr<ConstraintManager> cm);
 
     // ── Pre-allocated prefill metadata (eliminates per-request cudaMalloc) ──
     void* prefill_pool_ = nullptr;

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -391,9 +391,9 @@ bool Engine::try_launch_constrained_pipeline(std::shared_ptr<Request> req, cudaS
     st.frequency_penalty = req->frequency_penalty;
     st.presence_penalty = req->presence_penalty;
     st.repeat_last_n = req->repeat_last_n;
-    // Constraint hooks — the engine-level manager was prepared at admission.
-    st.schema_constrainer = constraints_.schema_constrainer();
-    st.json_constrainer = constraints_.json_constrainer();
+    // Constraint hooks — the request's manager was prepared at admission.
+    st.schema_constrainer = req->constraints ? req->constraints->schema_constrainer() : nullptr;
+    st.json_constrainer = req->constraints ? req->constraints->json_constrainer() : nullptr;
 
     p.runner.set_decode_fn([this](cudaStream_t s) { executor_->forward_logits(cpipe_.state, cpipe_.logits, s); });
 
@@ -461,7 +461,8 @@ int Engine::step_constrained_pipeline() {
     req->output_tokens.push_back(token);
     p.produced++;
     track_think_state(*req, token);
-    constraints_.update(token);
+    if (req->constraints)
+        req->constraints->update(token);
     kv_manager_->touch(req->id);
 
     bool done = should_stop(*req, token) ||

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -635,15 +635,24 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     }
     fill_sampling_params(*req, state);
 
-    // Constraints via ConstraintManager
+    // Constraints via the per-request ConstraintManager. The old engine-global
+    // manager was re-prepared here for EVERY prefill (constrained or not),
+    // which clobbered the FSM of any concurrently decoding constrained
+    // request. Prepare once on first need; later chunks reuse the state.
     // thinking_open = req->in_think_block: if the prompt already closed the
     // <think> block (e.g. /no_think emits an empty <think></think> in the
     // prompt), no </think> is ever generated — the preamble gate must enforce
     // immediately instead of absorbing prose until the budget.
-    constraints_.prepare(req->json_mode, req->json_schema, model_->tokenizer(), req->has_tools,
-                         req->tpl_family, /*thinking_open=*/req->in_think_block);
-    state.json_constrainer = constraints_.json_constrainer();
-    state.schema_constrainer = constraints_.schema_constrainer();
+    if ((req->json_mode || !req->json_schema.empty()) && !req->constraints) {
+        req->constraints = constraints_checkout_(req->json_schema);
+        req->constraints->prepare(req->json_mode, req->json_schema, model_->tokenizer(),
+                                  req->has_tools, req->tpl_family,
+                                  /*thinking_open=*/req->in_think_block);
+    }
+    if (req->constraints) {
+        state.json_constrainer = req->constraints->json_constrainer();
+        state.schema_constrainer = req->constraints->schema_constrainer();
+    }
 
     // Penalties
     upload_penalties(*req, state, pf_stream);
@@ -842,7 +851,8 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         }
 
         // Update constraint FSM
-        constraints_.update(next_token);
+        if (req->constraints)
+            req->constraints->update(next_token);
 
         if (should_stop(*req, next_token) || static_cast<int>(req->output_tokens.size()) >= req->max_tokens) {
             finish_request(req);
@@ -1129,18 +1139,23 @@ void Engine::decode_build_inference_state_(GPUBatch& gpu_batch,
             needs_schema_mode = true;
     }
 
-    // Schema/JSON constraints for decode (reuse state from prefill)
-    if (needs_schema_mode && valid_decode.size() == 1 && !valid_decode[0]->json_schema.empty()) {
-        if (constraints_.has_schema()) {
-            state.schema_constrainer = constraints_.schema_constrainer();
+    // Schema/JSON constraints for decode. Lazily create the per-request
+    // manager if needed (decode might be the first step with json_mode).
+    // The single-sequence state carries the request's constrainers (the
+    // graph-loop / constrained-pipeline launch paths read them from state);
+    // batched decode attaches them per row in sample_per_request, so
+    // constraints stay enforced at batch>1 (previously they were silently
+    // dropped whenever a constrained request shared a decode batch).
+    for (auto& r : valid_decode) {
+        if ((r->json_mode || !r->json_schema.empty()) && !r->constraints) {
+            r->constraints = constraints_checkout_(r->json_schema);
+            r->constraints->prepare(r->json_mode, r->json_schema, model_->tokenizer(), r->has_tools,
+                                    r->tpl_family, /*thinking_open=*/r->in_think_block);
         }
     }
-    if (needs_json_mode && valid_decode.size() == 1 && valid_decode[0]->json_mode) {
-        // Lazily init if needed (decode might be first step with json_mode)
-        if (!constraints_.has_json() && !constraints_.has_schema()) {
-            constraints_.prepare(true, "", model_->tokenizer());
-        }
-        state.json_constrainer = constraints_.json_constrainer();
+    if (valid_decode.size() == 1 && valid_decode[0]->constraints) {
+        state.schema_constrainer = valid_decode[0]->constraints->schema_constrainer();
+        state.json_constrainer = valid_decode[0]->constraints->json_constrainer();
     }
 }
 
@@ -1236,6 +1251,17 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
                     per_state.penalty_tokens = d_penalty_tokens_;
                     per_state.n_penalty_tokens = static_cast<int>(rn);
                 }
+            }
+            // Per-row constraint masks: keeps json_schema/json_mode enforced
+            // when the request shares a decode batch (the batch-level state
+            // carries no constrainers at n>1; sample_single_from_logits
+            // applies the mask to this row's logits before sampling).
+            if (req->constraints) {
+                per_state.schema_constrainer = req->constraints->schema_constrainer();
+                per_state.json_constrainer = req->constraints->json_constrainer();
+            } else {
+                per_state.schema_constrainer = nullptr;
+                per_state.json_constrainer = nullptr;
             }
             per_state.n_sequences = 1;
             Tensor seq_logits = logits.slice(i, i + 1);
@@ -1510,11 +1536,15 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
                       req->context_len(), req->context_len() - 1, next_token,
                       tok->decode_token(next_token).c_str());
 
+        // Advance the FSM before finish_request — finishing returns the
+        // request's ConstraintManager to the engine pool.
+        if (req->constraints)
+            req->constraints->update(next_token);
+
         if (should_stop(*req, next_token) || static_cast<int>(req->output_tokens.size()) >= req->max_tokens) {
             finish_request(req);
         }
 
-        constraints_.update(next_token);
         kv_manager_->touch(req->id);
     }
 
@@ -1623,8 +1653,8 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
         // pipeline. min_p/typical_p/mirostat/DRY/logit_bias stay eager.
         const bool pipeline_compatible =
             dreq->logit_bias.empty() && dreq->mirostat == 0 && dreq->dry_multiplier == 0.0f &&
-            dreq->min_p == 0.0f && dreq->typical_p >= 1.0f &&
-            !mtp_spec_decode_enabled() && constraints_.is_active();
+            dreq->min_p == 0.0f && dreq->typical_p >= 1.0f && !mtp_spec_decode_enabled() &&
+            dreq->constraints && dreq->constraints->is_active();
         if (pipeline_compatible && dreq->status == RequestStatus::DECODING && !dreq->output_tokens.empty()) {
             try_launch_constrained_pipeline(dreq, dec_stream);
         }

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -360,7 +360,11 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         emitted++;
         const bool hard_stop = should_stop(*req, tokj) ||
                                static_cast<int>(req->output_tokens.size()) >= req->max_tokens;
-        constraints_.update(tokj);
+        // Per-request FSM; must advance before finish_request returns the
+        // manager to the pool. (Spec gates exclude json/schema requests, so
+        // this is normally null — kept for parity with the eager path.)
+        if (req->constraints)
+            req->constraints->update(tokj);
         if (hard_stop) {
             finish_request(req);
             break;

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -131,6 +131,11 @@ struct Request {
     // JSON mode
     bool json_mode = false;   // Constrain output to valid JSON
     std::string json_schema;  // JSON Schema string (empty = disabled)
+    // Per-request constraint FSM (JsonConstrainer/SchemaConstrainer wrapper).
+    // Owned by the request so concurrent prefills/finishes of OTHER requests
+    // cannot clobber the state, and batched decode can mask per row. Checked
+    // out of Engine::constraint_pool_ on first need, returned at finish.
+    std::shared_ptr<class ConstraintManager> constraints;
 
     // Tool-call coordination: when true and (json_mode || !json_schema.empty()),
     // the preamble gate enters tool-aware mode so the schema/JSON FSM mask

--- a/tests/api/test_concurrency.py
+++ b/tests/api/test_concurrency.py
@@ -127,3 +127,68 @@ class TestConcurrentRequests:
             assert status == 200, f"Stream {i} failed: status={status}"
             assert len(content) > 0, f"Stream {i} produced empty content"
             assert has_done, f"Stream {i} missing [DONE] sentinel"
+
+
+class TestConstrainedUnderConcurrency:
+    def test_json_schema_enforced_while_sharing_decode_batch(self, model):
+        """A json_schema request that decodes concurrently with other requests
+        must still return schema-valid JSON.
+
+        Regression test for the engine-global ConstraintManager: the schema
+        mask was only attached when the decode batch had exactly one sequence,
+        so a constrained request sharing a batch decoded UNCONSTRAINED, and any
+        concurrent prefill/finish reset the FSM mid-generation.
+        """
+        import time
+
+        # enum keeps the answer short so the object closes well within
+        # max_tokens (an unbounded string lets chatty models ramble into the
+        # budget, which truncates the JSON on any engine).
+        schema = {
+            "type": "object",
+            "properties": {
+                "answer": {"type": "string", "enum": ["yes", "no"]},
+                "confidence": {"type": "number"},
+            },
+            "required": ["answer", "confidence"],
+        }
+
+        def schema_request():
+            with httpx.Client(base_url=conftest.BASE_URL, timeout=120.0) as c:
+                return c.post("/v1/chat/completions", json={
+                    "model": model,
+                    "messages": [{"role": "user",
+                                  "content": "Answer as JSON: is water wet?"}],
+                    "max_tokens": 96,
+                    "temperature": 0,
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {"name": "ans", "schema": schema},
+                    },
+                })
+
+        def filler_request(i):
+            with httpx.Client(base_url=conftest.BASE_URL, timeout=120.0) as c:
+                return c.post("/v1/chat/completions", json={
+                    "model": model,
+                    "messages": [{"role": "user",
+                                  "content": f"Write {i + 3} sentences about rivers."}],
+                    "max_tokens": 128,
+                    "temperature": 0,
+                    "seed": i,
+                })
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            fillers = [pool.submit(filler_request, i) for i in range(3)]
+            time.sleep(0.3)  # let fillers reach decode so the schema request joins batch>1
+            schema_result = pool.submit(schema_request).result()
+            filler_results = [f.result() for f in fillers]
+
+        for i, fr in enumerate(filler_results):
+            assert fr.status_code == 200, f"filler {i} failed: {fr.text}"
+        assert schema_result.status_code == 200, schema_result.text
+
+        content = schema_result.json()["choices"][0]["message"]["content"]
+        obj = json.loads(content)  # must parse — unconstrained output usually doesn't
+        assert "answer" in obj, f"schema violated: {content!r}"
+        assert "confidence" in obj, f"schema violated: {content!r}"


### PR DESCRIPTION
## What

`response_format=json_schema/json_object` was silently **unenforced** whenever the constrained request shared a decode batch with any other request — exactly the multi-agent serving shape this engine targets. Root cause: one engine-global `ConstraintManager` with four concurrency holes:

1. The schema/json mask was only attached when `valid_decode.size() == 1` — at batch>1 the request decoded unconstrained.
2. `step_prefill_one` re-prepared the global manager for EVERY prefill (constrained or not), clobbering the FSM of a concurrently decoding constrained request.
3. `finish_request` of ANY request reset the FSM.
4. `step_decode_process_outputs` fed every batch row's token into the single FSM.

## How

- Constraint FSM state moves to `Request::constraints` (`std::shared_ptr<ConstraintManager>`), checked out of a small engine-side pool (`constraint_pool_`, cap 8) that recycles instances — repeat requests with the same schema reuse the classified-token tables instead of re-classifying ~151K vocab tokens per request.
- **Batched decode enforces per row**: `sample_per_request` already samples row-by-row with a per-row `InferenceState`; it now attaches that row's constrainers so `sample_single_from_logits` applies the mask to the row's logits. No new kernels, no graph interaction (batched sampling is eager by design).
- Single-sequence state, constrained-pipeline launch/step, spec-verify, and prefill paths all read the request's own manager; the FSM advances only with its own request's tokens (and before `finish_request` returns the manager to the pool).

## Verification (RTX 5090, Qwen3-8B Q8_0, real server)

| Scenario | main (v0.13.0 image) | this PR |
|---|---|---|
| Single schema request (constrained pipeline) | enforced | enforced ✓ |
| Schema request **sharing a decode batch** with 3 concurrent requests | **VIOLATED** — invented `question` key, enum ignored | **enforced**: `{"answer":"yes","confidence":0.957}` ✓ |
| Two different schemas decoding concurrently | n/a (both unenforced) | both enforced, no cross-contamination ✓ |

- `make test-unit` green; `verify-fast` OK (decode WARN = depressed-host #526 signature — the decode path only gains null-checks; prefill pp4096 PASS).
- New regression test: `tests/api/test_concurrency.py::TestConstrainedUnderConcurrency` (real-server stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)