### PR TITLE
feat(decode): stream through the conditional-graph loop — per-token polling harvest (#754)

### DIFF
--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -500,6 +500,7 @@ __global__ void post_decode_step_kernel(
     int penalty_prefix_len,
     int* __restrict__ d_penalty_count,  // [1] total penalty token count
     const int* __restrict__ d_step_limit,  // [1] per-launch cap (0 = max_steps)
+    int* __restrict__ d_burst_done,     // [1] mapped done flag (host-visible)
     cudaGraphConditionalHandle handle) {
     int step = *d_step_counter;
     int32_t token = *d_token_id;
@@ -630,6 +631,14 @@ __global__ void post_decode_step_kernel(
                 step, token, in_think ? 1 : 0, eos_id, n_stop_ids, stop_reason);
         }
         cudaGraphSetConditional(handle, 0);  // break WHILE loop
+        // Publish burst completion to the host. This is the ONLY loop exit,
+        // so the polling host (try_finish_burst) keys teardown off this flag
+        // — cudaStreamQuery reports the stream idle while the conditional
+        // WHILE graph is still iterating on this platform, so it must not be
+        // trusted. The fence orders the flag after this step's ring/counter
+        // writes above.
+        __threadfence_system();
+        *d_burst_done = 1;
     }
 }
 
@@ -778,6 +787,17 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         err = cudaHostGetDevicePointer(&d_step_counter_mapped_, h_step_counter_, 0);
         if (err != cudaSuccess)
             goto fail;
+
+        err = cudaHostAlloc(&h_burst_done_, sizeof(int), cudaHostAllocMapped);
+        if (err != cudaSuccess)
+            goto fail;
+        err = cudaHostGetDevicePointer(&d_burst_done_mapped_, h_burst_done_, 0);
+        if (err != cudaSuccess)
+            goto fail;
+
+        err = cudaHostAlloc(&h_decode_scratch_, sizeof(int32_t), cudaHostAllocMapped);
+        if (err != cudaSuccess)
+            goto fail;
     }
 
     // ---- Initialize device state ----
@@ -792,6 +812,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         int init_ctx = config_.initial_context_len;
         int init_step = 0;
         *h_step_counter_ = 0;
+        *h_burst_done_ = 0;
         memset(h_ring_buffer_, 0, config_.max_steps * sizeof(int32_t));
 
         err = cudaMemcpyAsync(d_token_id_, &first_token, sizeof(int32_t), cudaMemcpyHostToDevice, stream);
@@ -925,8 +946,11 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         //     Writes sampled token to d_token_id_. The h_mapped parameter receives
         //     a D2H copy each iteration (harmless scratch write; the real ring buffer
         //     write is in post_decode_step_kernel below).
-        executor->forward_decode_async(body_state, d_token_id_, reinterpret_cast<int32_t*>(h_step_counter_),
-                                       stream);
+        // NOTE: the h_mapped scratch must NOT alias h_step_counter_ — the
+        // polling harvest (poll_new_tokens) reads the counter concurrently,
+        // and this per-iteration D2H token copy would transiently overwrite
+        // it with a token id, making the host over-read the ring.
+        executor->forward_decode_async(body_state, d_token_id_, h_decode_scratch_, stream);
 
         // 5b. Post-decode-step kernel: ring buffer write, counter increment, EOS check, think budget
         post_decode_step_kernel<<<1, 1, 0, stream>>>(d_token_id_, d_ring_buffer_, d_step_counter_mapped_,
@@ -940,7 +964,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                                                      config_.token_is_whitespace, config_.vocab_size,
                                                      config_.ignore_eos ? 1 : 0, d_penalty_ring_,
                                                      penalty_prefix_len_, d_penalty_count_,
-                                                     d_step_limit_, handle_);
+                                                     d_step_limit_, d_burst_done_mapped_, handle_);
 
         // 5c. End capture
         cudaGraph_t captured_body = nullptr;
@@ -1044,6 +1068,7 @@ bool CudaGraphConditionalRunner::rearm(int32_t first_token, int position, int co
             return false;
     }
     *h_step_counter_ = 0;
+    *h_burst_done_ = 0;
     last_read_step_ = 0;
     return true;
 }
@@ -1089,6 +1114,41 @@ int CudaGraphConditionalRunner::poll_new_tokens(std::vector<int32_t>& out_tokens
 
 int CudaGraphConditionalRunner::steps_completed() const {
     return h_step_counter_ ? __atomic_load_n(h_step_counter_, __ATOMIC_ACQUIRE) : 0;
+}
+
+bool CudaGraphConditionalRunner::try_finish_burst(cudaStream_t stream) {
+    if (!launched_)
+        return true;
+    // Key off the device-published done flag, NOT cudaStreamQuery — the query
+    // reports the stream idle while the conditional WHILE graph is still
+    // iterating (observed on WSL2/sm_120), and tearing the loop's buffers
+    // down on that signal corrupts generation. The kernel's stop path is the
+    // only loop exit and publishes the flag behind a system fence.
+    if (!h_burst_done_ || __atomic_load_n(h_burst_done_, __ATOMIC_ACQUIRE) == 0)
+        return false;
+    // Loop broke — drain the graph epilogue (near-instant) and surface errors
+    // with the same contract as wait_and_get_tokens (F-A17).
+    cudaError_t sync_err = cudaStreamSynchronize(stream);
+    launched_ = false;
+    if (sync_err != cudaSuccess) {
+        IMP_LOG_ERROR("AsyncGraphLoop: burst failed (%s) — no further tokens from this burst",
+                      cudaGetErrorString(sync_err));
+    }
+    return true;
+}
+
+void CudaGraphConditionalRunner::finish_burst_blocking(cudaStream_t stream) {
+    if (!launched_)
+        return;
+    // Fallback for a device loop that stopped making progress without
+    // publishing the done flag (graph error paths never reach the stop
+    // kernel) — block until the stream drains and surface the error.
+    cudaError_t sync_err = cudaStreamSynchronize(stream);
+    launched_ = false;
+    if (sync_err != cudaSuccess) {
+        IMP_LOG_ERROR("AsyncGraphLoop: blocking burst finish failed (%s)",
+                      cudaGetErrorString(sync_err));
+    }
 }
 
 void CudaGraphConditionalRunner::cleanup() {
@@ -1172,6 +1232,15 @@ void CudaGraphConditionalRunner::cleanup() {
         h_step_counter_ = nullptr;
     }
     d_step_counter_mapped_ = nullptr;
+    if (h_burst_done_) {
+        IMP_CUDA_CHECK_LOG(cudaFreeHost(h_burst_done_));
+        h_burst_done_ = nullptr;
+    }
+    d_burst_done_mapped_ = nullptr;
+    if (h_decode_scratch_) {
+        IMP_CUDA_CHECK_LOG(cudaFreeHost(h_decode_scratch_));
+        h_decode_scratch_ = nullptr;
+    }
 
     // Release the per-device graph memory pool (matches CudaGraphCapture::reset).
     // Keeps long-running sessions from holding stale graph reservations.

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -206,6 +206,22 @@ public:
     // Appends new tokens to out_tokens. Returns count of new tokens.
     int poll_new_tokens(std::vector<int32_t>& out_tokens);
 
+    // Non-blocking burst-completion check: returns true once the device loop
+    // published its done flag (the kernel stop path is the only loop exit),
+    // then drains the graph epilogue and clears the launched flag. A stream
+    // error is surfaced like wait_and_get_tokens (F-A17) and still ends the
+    // burst — tokens already read through poll_new_tokens stand.
+    // Deliberately NOT cudaStreamQuery-based: the query reports the stream
+    // idle while a conditional WHILE graph is still iterating.
+    bool try_finish_burst(cudaStream_t stream);
+
+    // Blocking fallback when the device loop stops making progress without
+    // publishing done (graph error paths): sync the stream, end the burst.
+    void finish_burst_blocking(cudaStream_t stream);
+
+    // A conditional-loop burst is currently running on the device.
+    bool launch_in_flight() const { return launched_; }
+
     // Get number of steps completed so far (non-blocking).
     int steps_completed() const;
 
@@ -245,6 +261,17 @@ private:
     int32_t* d_ring_buffer_ = nullptr;      // device pointer to same ring buffer
     int* h_step_counter_ = nullptr;         // host pointer to step counter mirror
     int* d_step_counter_mapped_ = nullptr;  // device pointer to mapped step counter
+    // Burst-done flag, published by post_decode_step_kernel's stop path (the
+    // only WHILE-loop exit). cudaStreamQuery reports the stream idle while a
+    // conditional WHILE graph is still iterating on this platform, so the
+    // host must not use it to decide teardown.
+    int* h_burst_done_ = nullptr;           // host pointer to done flag
+    int* d_burst_done_mapped_ = nullptr;    // device pointer to same flag
+    // Dedicated scratch for forward_decode_async's per-iteration D2H token
+    // copy. This used to alias h_step_counter_ — harmless when tokens were
+    // only harvested after a full-burst sync, but a polling host could read
+    // the transient token id as the step counter and over-read the ring.
+    int32_t* h_decode_scratch_ = nullptr;
 
     Config config_;
     int last_read_step_ = 0;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -34,6 +34,8 @@
 #include <cmath>
 #include <cstring>
 #include <algorithm>
+#include <chrono>
+#include <thread>
 #include <vector>
 
 namespace imp {
@@ -97,9 +99,42 @@ int Engine::step_async_graph_resume() {
     if (async_graph_runner_.is_setup() && async_graph_req_) {
         auto& req = async_graph_req_;
 
-        if (async_pending_tokens_.empty() && async_pending_cursor_ == 0) {
+        // Incremental harvest (#754): poll the mapped ring buffer instead of
+        // blocking until the whole burst retires, so tokens reach the caller
+        // (server SSE / imp_decode_step) as the device loop produces them.
+        // The old cudaStreamSynchronize surfaced a burst's tokens only when
+        // it finished — which is why streaming requests had to be excluded
+        // from the loop entirely (every token arrived in burst-sized groups).
+        // The micro-poll waits for AT LEAST one new token per step() so the
+        // imp_decode_step zero-token retry bound (8) never trips; the device
+        // loop runs ahead regardless — this only throttles the host to the
+        // same per-token cadence as eager decode.
+        if (async_pending_cursor_ >= static_cast<int>(async_pending_tokens_.size()) &&
+            async_graph_runner_.launch_in_flight()) {
             cudaStream_t dec_stream = decode_stream();
-            async_pending_tokens_ = async_graph_runner_.wait_and_get_tokens(dec_stream);
+            // Safety valve: a graph that errors out never reaches the stop
+            // kernel and thus never publishes done — fall back to a blocking
+            // sync (which surfaces the error) instead of polling forever.
+            // 30 s dwarfs any legitimate inter-token gap (decode ≤ ~100 ms).
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+            while (async_graph_runner_.poll_new_tokens(async_pending_tokens_) == 0) {
+                if (async_graph_runner_.try_finish_burst(dec_stream)) {
+                    // Burst retired between polls — drain the tail and stop.
+                    async_graph_runner_.poll_new_tokens(async_pending_tokens_);
+                    break;
+                }
+                if (std::chrono::steady_clock::now() > deadline) {
+                    IMP_LOG_ERROR("AsyncGraphLoop: no token for 30 s and no done flag — "
+                                  "forcing blocking burst finish");
+                    async_graph_runner_.finish_burst_blocking(dec_stream);
+                    async_graph_runner_.poll_new_tokens(async_pending_tokens_);
+                    break;
+                }
+                // Burst still running, no new token yet (decode steps are
+                // ~3-7 ms; polling every 200 µs keeps SSE latency negligible
+                // without spinning a core).
+                std::this_thread::sleep_for(std::chrono::microseconds(200));
+            }
         }
 
         int32_t token = -1;
@@ -1621,40 +1656,36 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
                                                        : spec_effective_miss_burst_(*dreq);
                 if (spec_limit < 0) spec_limit = 0;
             }
-            // #754: an UNBOUNDED loop (spec_limit == 0) generates the whole
-            // remaining sequence on-device and only surfaces its tokens to the
-            // host when the burst finishes — for a streaming request that means
-            // every token lands in the client at generation end (TTFT == full
-            // latency). Keep streaming requests on per-step decode so SSE is
-            // real per-token. Bounded (speculation) bursts still stream in
-            // groups via the per-burst sync, so they stay enabled.
-            const bool stream_unbounded = dreq->stream && spec_limit == 0;
-            if (!stream_unbounded) {
-                // F-A2: a NON-streaming request with speculation off would run
-                // the UNBOUNDED on-device loop (spec_limit == 0) all the way to
-                // max_tokens while the host blocks — is_cancelled()/timeout are
-                // only polled between bursts, so a client disconnect couldn't
-                // interrupt it and burned a full generation. Bound it to
-                // runtime.decode_burst so the worker regains control to re-poll
-                // cancellation; output is identical (same decode, chunked +
-                // relaunched, exactly like the speculation burst path).
-                // Speculation keeps its own miss_burst limit; <=0 restores the
-                // old unbounded behavior.
-                int launch_limit = spec_limit;
-                // Bound only in the default (non-deterministic) serving mode.
-                // The fully-on-device unbounded loop is the one decode path that
-                // is greedy bit-reproducible run-to-run (no host re-entry);
-                // chunking it would make non-streaming greedy output
-                // non-reproducible, breaking the determinism.md eval guarantee.
-                // Deterministic mode runs to completion and never needs
-                // mid-burst cancellation, so keep it unbounded there. In
-                // production the model is already non-deterministic, so bounding
-                // costs no reproducibility and buys cancel responsiveness.
-                if (launch_limit == 0 && runtime_config_.runtime.decode_burst > 0 &&
-                    !runtime_config_.runtime.deterministic)
-                    launch_limit = runtime_config_.runtime.decode_burst;
-                try_launch_async_graph_loop(dreq, last_token, dec_stream, launch_limit);
-            }
+            // #754 RESOLVED: streaming requests run the loop too, since
+            // step_async_graph_resume now polls the mapped ring buffer and
+            // surfaces tokens per-step while the burst is still running —
+            // SSE stays real per-token (previously the blocking per-burst
+            // sync delivered tokens only in burst-sized groups, so streaming
+            // had to stay on per-step decode and paid the +27-45% loop win).
+            //
+            // F-A2: a request with speculation off would run the UNBOUNDED
+            // on-device loop (spec_limit == 0) all the way to max_tokens —
+            // is_cancelled()/timeout are only polled between bursts, so a
+            // client disconnect couldn't interrupt it and burned a full
+            // generation. Bound it to runtime.decode_burst so the worker
+            // regains control to re-poll cancellation; output is identical
+            // (same decode, chunked + relaunched, exactly like the
+            // speculation burst path). Speculation keeps its own miss_burst
+            // limit; <=0 restores the old unbounded behavior.
+            int launch_limit = spec_limit;
+            // Bound only in the default (non-deterministic) serving mode.
+            // The fully-on-device unbounded loop is the one decode path that
+            // is greedy bit-reproducible run-to-run (no host re-entry);
+            // chunking it would make non-streaming greedy output
+            // non-reproducible, breaking the determinism.md eval guarantee.
+            // Deterministic mode runs to completion and never needs
+            // mid-burst cancellation, so keep it unbounded there. In
+            // production the model is already non-deterministic, so bounding
+            // costs no reproducibility and buys cancel responsiveness.
+            if (launch_limit == 0 && runtime_config_.runtime.decode_burst > 0 &&
+                !runtime_config_.runtime.deterministic)
+                launch_limit = runtime_config_.runtime.decode_burst;
+            try_launch_async_graph_loop(dreq, last_token, dec_stream, launch_limit);
         }
     }
 

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -114,13 +114,12 @@ struct Request {
     bool pin_kv_prefix = false;
 
     // SSE streaming request: the client consumes tokens as they are produced.
-    // The async conditional graph loop (GPU-autonomous multi-token decode) only
-    // surfaces its tokens to the host after the whole burst completes — on this
-    // platform the mapped-pinned ring buffer is not reliably host-visible
-    // mid-flight — so a streamed request would receive every token at
-    // generation end (TTFT == full latency, #754). Streaming requests therefore
-    // stay on per-step decode (one token per step) for real per-token delivery;
-    // non-streaming requests keep the faster autonomous loop.
+    // Streaming runs the async conditional graph loop like everything else:
+    // step_async_graph_resume polls the mapped ring buffer (device publishes
+    // each token behind a __threadfence_system + separate poll counter) and
+    // surfaces tokens per step while the burst is in flight (#754 resolved —
+    // the old blocking per-burst sync delivered tokens only in burst-sized
+    // groups, which is why streaming used to stay on per-step decode).
     bool stream = false;
 
     // Logprobs


### PR DESCRIPTION
## What

Streaming requests — i.e. **every agentic client** (Claude Code, SDKs use `stream:true` exclusively) — were excluded from the async conditional-graph decode loop (#754): the blocking per-burst sync surfaced tokens only when a whole burst retired, so SSE would have delivered tokens in burst-sized groups. They now run the same loop as non-streaming requests; `step_async_graph_resume` polls the mapped ring buffer and hands tokens to the server per step while the burst is still in flight.

## Two latent races fixed (prerequisites)

Making the poll path safe surfaced two real bugs, previously masked because tokens were only ever read after a full-burst `cudaStreamSynchronize`:

1. **Counter/scratch aliasing:** `forward_decode_async` used `h_step_counter_` as its per-iteration D2H token-copy scratch. A polling host could read the transient **token id as the step counter** and over-read the ring — reproduced as instant fake-max_tokens generations full of `!` garbage and duplicated fragments at temp>0. The graph body now uses a dedicated mapped scratch.
2. **cudaStreamQuery lies for conditional WHILE graphs** (observed on WSL2/sm_120): it reports the stream idle while the device loop is still iterating. Teardown on that signal freed the loop's block tables under a running graph. The stop path of `post_decode_step_kernel` — the only loop exit — now publishes a mapped **done flag** behind a `__threadfence_system`; `try_finish_burst` keys off it, with a 30 s blocking-sync fallback for graph error paths that never reach the stop kernel.

The resume micro-poll waits for ≥1 new token per `step()` (200 µs cadence), so the `imp_decode_step` zero-token retry bound never trips and the host throttles to the same per-token rhythm as eager decode while the device loop runs ahead.

## Measured (RTX 5090, real server, vs v0.13.0 image)

| Metric | main | this PR |
|---|---|---|
| Qwen3-8B Q8 max inter-token gap | 197 ms | **17 ms** |
| Qwen3-8B Q8 p95 gap / burst-delivered tokens | 50 ms / 77-93% | **12 ms / 0%** |
| Qwen3-30B-MoE NVFP4 max gap / bursts | 28 ms / 77% | **7.6 ms / 0%** |
| Throughput (Q8 / MoE / spec code-edit) | 162 / 280 / 203.5 tok/s | 160 / 275 / 203.1 (parity) |

Honest note: the audit projected +25-45% streaming decode from this lever; that premise was stale — the eager per-step path has been optimized since (#745/#748) and now matches loop throughput at server level. The delivered value is **per-token SSE smoothness (4-12× better p95/max inter-token gap, zero burst delivery)**, one unified decode path for streaming and non-streaming (streaming now inherits every future loop improvement, incl. speculation bursts), and the two fixed races.

## Verification

- Greedy CLI output **byte-identical** to main; spec burst-hybrid text identical (same tok/s); sampled 400-token CLI at main parity (191 vs 194 tok/s) — the temp>0 corruption repro from race #1 is gone.
- Streaming coherence checked on Qwen3-8B Q8, Qwen3-30B-A3B NVFP4 (MoE), Qwen3.6-35B (GDN hybrid, reasoning+content).
- `DegenerationTest` 5/5, `DeterminismE2E` pass, `make test-unit` 37/37, `verify-fast` OK (decode WARN = depressed-host #526 signature, −6.7% with 339 W max power).

🤖 Generated with [Claude Code](https://claude.com/claude-code)