### PR TITLE
perf(serving): decode-aware prefill chunk cap + admission-aware bursts + cross-turn output KV reuse

### DIFF
--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -119,6 +119,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("runtime.prefill_graph", cfg.runtime.prefill_graph);
     I("runtime.max_batch_size", cfg.runtime.max_batch_size);
     I("runtime.decode_burst", cfg.runtime.decode_burst);
+    I("runtime.prefill_chunk_decode_cap", cfg.runtime.prefill_chunk_decode_cap);
 
     // [kv_cache]
     S("kv_cache.dtype", cfg.kv_cache.dtype);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -93,11 +93,13 @@ struct RuntimeConfig {
         int decode_burst = 128;
         // Cap the prefill chunk while other sequences are DECODING: prefill
         // and decode share one stream, so every chunk forward inserts its
-        // full latency (~40-80 ms at 2048) between two of their decode steps.
-        // 512 bounds the concurrent sessions' inter-token stall ~4x at a
-        // ~10-20% ingest-throughput cost; the full chunk returns as soon as
-        // nobody is decoding. 0 = disabled (always use the full chunk).
-        int prefill_chunk_decode_cap = 512;
+        // full latency between two of their decode steps. Measured (Qwen3-8B
+        // Q8, 7.2k-token ingest against one active decoder): 2048 → decoder
+        // p95 inter-token 164 ms; 1024 → 94 ms at +27% ingest TTFT; 512 →
+        // 65 ms at +85%. 1024 is the default compromise; set 512 for
+        // latency-critical multi-tenant serving, 0 to disable (full chunk).
+        // The full chunk returns as soon as nobody is decoding.
+        int prefill_chunk_decode_cap = 1024;
     } runtime;
 
     struct KVCache {

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -91,6 +91,13 @@ struct RuntimeConfig {
         // the only greedy-bit-reproducible decode path, and evals run to
         // completion (no mid-burst cancel needed), so determinism wins there.
         int decode_burst = 128;
+        // Cap the prefill chunk while other sequences are DECODING: prefill
+        // and decode share one stream, so every chunk forward inserts its
+        // full latency (~40-80 ms at 2048) between two of their decode steps.
+        // 512 bounds the concurrent sessions' inter-token stall ~4x at a
+        // ~10-20% ingest-throughput cost; the full chunk returns as soon as
+        // nobody is decoding. 0 = disabled (always use the full chunk).
+        int prefill_chunk_decode_cap = 512;
     } runtime;
 
     struct KVCache {

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -412,7 +412,23 @@ size_t Engine::effective_free_vram() const {
 void Engine::finish_request(std::shared_ptr<Request>& req) {
     req->status = RequestStatus::FINISHED;
     if (kv_manager_->prefix_caching_enabled()) {
-        kv_manager_->register_block_hashes(req->id, req->input_tokens);
+        // Register input AND generated tokens — minus the final sampled
+        // token, which was never forwarded (its KV entry does not exist; the
+        // spec-verify bonus token has the same property). The next agent turn
+        // re-sends the assistant reply verbatim (tool-call JSON, code edits),
+        // and its KV is live in the block table right now: hashing it turns
+        // the whole previous turn into a prefix-cache hit instead of
+        // re-prefilling the reply from scratch.
+        if (req->output_tokens.size() > 1) {
+            std::vector<int32_t> forwarded;
+            forwarded.reserve(req->input_tokens.size() + req->output_tokens.size() - 1);
+            forwarded.insert(forwarded.end(), req->input_tokens.begin(), req->input_tokens.end());
+            forwarded.insert(forwarded.end(), req->output_tokens.begin(),
+                             req->output_tokens.end() - 1);
+            kv_manager_->register_block_hashes(req->id, forwarded);
+        } else {
+            kv_manager_->register_block_hashes(req->id, req->input_tokens);
+        }
         // cache_control / cache_prompt: protect the prompt's full blocks
         // from eviction (must happen before free_sequence — pinning needs
         // the live block table).

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -365,6 +365,23 @@ void Engine::step_prefill(cudaStream_t stream) {
             effective_chunk = (effective_chunk / bs) * bs;
     }
 
+    // Decode-aware chunking: prefill and decode share one CUDA stream, so
+    // every chunk forward inserts its full latency (~40-80 ms at 2048)
+    // between two decode steps of every concurrently DECODING session. Cap
+    // the chunk while decoders are active so their inter-token latency stays
+    // bounded during another session's ingest; the full chunk (and its
+    // better weight-traffic amortization) returns as soon as nobody decodes.
+    const int decode_cap = runtime_config_.runtime.prefill_chunk_decode_cap;
+    if (decode_cap > 0 && !sched_decode_batch_.empty() && effective_chunk > decode_cap) {
+        int capped = decode_cap;
+        if (kv_manager_) {
+            int bs = kv_manager_->kv_cache()->block_size();
+            if (capped > bs)
+                capped = (capped / bs) * bs;
+        }
+        effective_chunk = capped;
+    }
+
     for (auto& req : sched_prefill_batch_) {
         step_prefill_one(req, effective_chunk, stream);
         kv_manager_->touch(req->id);

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1702,6 +1702,21 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
             if (launch_limit == 0 && runtime_config_.runtime.decode_burst > 0 &&
                 !runtime_config_.runtime.deterministic)
                 launch_limit = runtime_config_.runtime.decode_burst;
+            // Admission-aware burst: while another request is waiting (still
+            // pending admission or mid-prefill), Engine::step short-circuits
+            // to the resume path for the whole burst — the waiting request's
+            // prefill only advances between bursts, inflating its TTFT by
+            // ~0.5-1 s per 128-token burst. Shorten the burst so scheduling
+            // work interleaves every few tokens; the full burst returns when
+            // nothing is waiting. Deterministic mode is exempt (same
+            // reasoning as decode_burst above — reproducible evals are
+            // single-stream, nothing ever waits).
+            if (!runtime_config_.runtime.deterministic &&
+                (scheduler_->has_pending() || !sched_prefill_batch_.empty())) {
+                constexpr int kBusyBurst = 16;
+                if (launch_limit == 0 || launch_limit > kBusyBurst)
+                    launch_limit = kBusyBurst;
+            }
             try_launch_async_graph_loop(dreq, last_token, dec_stream, launch_limit);
         }
     }

--- a/tests/api/test_concurrency.py
+++ b/tests/api/test_concurrency.py
@@ -130,7 +130,7 @@ class TestConcurrentRequests:
 
 
 class TestConstrainedUnderConcurrency:
-    def test_json_schema_enforced_while_sharing_decode_batch(self, model):
+    def test_json_schema_enforced_while_sharing_decode_batch(self, model, is_mock):
         """A json_schema request that decodes concurrently with other requests
         must still return schema-valid JSON.
 
@@ -139,6 +139,8 @@ class TestConstrainedUnderConcurrency:
         so a constrained request sharing a batch decoded UNCONSTRAINED, and any
         concurrent prefill/finish reset the FSM mid-generation.
         """
+        if is_mock:
+            pytest.skip("mock server does not implement constrained decoding")
         import time
 
         # enum keeps the answer short so the object closes well within


### PR DESCRIPTION
## What

Three multi-tenant serving-latency levers from the agentic backlog. All are **no-ops for single-stream decode** and greedy output is **byte-identical to main**; they only change behavior when multiple sessions are in flight.

### 1. Decode-aware prefill chunk cap (`runtime.prefill_chunk_decode_cap`, default 1024)
Prefill and decode share one CUDA stream, so each 2048-token chunk forward inserts its full latency between two decode steps of every concurrently DECODING session. The chunk is capped while decoders are active and restored to full when nobody is decoding.

| cap | decoder p95 inter-token gap during a 7.2k ingest | ingest TTFT cost |
|---|---|---|
| 2048 (main) | 164 ms | — |
| **1024 (new default)** | **94 ms** | +27% |
| 512 | 65 ms | +85% |

Set 512 for latency-critical fleets, 0 to disable.

### 2. Admission-aware bursts
While a request waits (pending admission or mid-prefill), `Engine::step` short-circuits to the graph-loop resume path for a whole 128-token burst, so the waiter's prefill only advances between bursts. The loop burst shrinks to 16 tokens whenever the scheduler has pending/prefilling work, restoring the full burst when idle. Deterministic mode exempt.

### 3. Cross-turn output KV reuse
`finish_request` registered prefix-cache block hashes for `input_tokens` only, so each agent turn re-prefilled the previous assistant reply from scratch despite its KV having just been computed. Now hashes input + generated tokens (minus the final un-forwarded sampled token). **Honest scope:** contiguous continuations and tool-result appends become cache hits; chat-templated turns are **neutral** — the template's assistant/user header tokens between prompt and reply break block alignment, so the reply blocks rarely match — but it never regresses (content-addressed hashing, verified equal `cached_tokens` and coherent 2-turn output).

## Verification (RTX 5090)

- Greedy CLI **byte-identical** to main; `DegenerationTest` 5/5, `SchedulerTest` 19/19, `make test-unit` 37/37.
- `verify-fast` OK — decode WARN is the depressed-host #526 signature (369 W); the single-stream decode path is untouched by all three levers.
- Also fixes the `Mock API contract` CI job: the constraint-concurrency regression test from #821 now skips on the mock server (it has no real constrained decoding), instead of failing on unconstrained mock output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)