### PR TITLE
perf(spec): enable n-gram speculation for native-NVFP4 MoE (code-edit +29-81%)

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -270,11 +270,17 @@ mmproj               = ""
 # n-gram (prompt-lookup) speculative decoding: drafts come from suffix
 # matches against the request's own prompt+output — no draft model. Greedy
 # verify accepts the longest matching prefix, so output stays a faithful
-# greedy decode. Batch-1, greedy sampling, dense-attention models only
-# (MoE/recurrent gate off automatically — the async decode loop carries them);
+# greedy decode. Batch-1, greedy sampling, non-recurrent models only
+# (SSM/GDN hybrids gate off automatically — their state cannot rewind);
 # disables the async decode graph loop while on. Wins on repetition-heavy
 # (agent/code/RAG) workloads; ~neutral on free-form prose. Default-ON.
 ngram                = true
+# Speculation on MoE models with native-NVFP4 experts (Qwen3-Coder-30B-FP4:
+# code-edit +49-81%, draft-poor floor -3-7%). GGUF-MoE never engages (its
+# batched verify re-dequants every activated expert per step, measured -22%)
+# and stays on the async decode loop. imp-cli --bench pins this off to keep
+# the gated tg baseline a raw-decode signal.
+moe                  = true
 # Draft tokens proposed per verify step (verify cost is ~flat in k).
 k                    = 16
 # Shortest / longest suffix n-gram match searched. Longer min_match =

--- a/src/model/model_profile.cpp
+++ b/src/model/model_profile.cpp
@@ -28,6 +28,10 @@ ModelProfile derive_model_profile(const Model& model, const ModelConfig& cfg) {
         if (L.wq.data != nullptr)
             any_attn = true;
     }
+    // NVFP4-prequant checkpoints get the contiguous native NVFP4 expert cache
+    // (pre_dequant_phase3_moe.cu keys the cache build on this same flag), so
+    // batched multi-token MoE forwards read quantized weights directly.
+    p.moe_experts_nvfp4 = p.is_moe && cfg.is_nvfp4_prequant;
     p.is_gdn = any_gdn;
     p.is_ssm = any_ssm;
     p.has_pure_ssm = any_pure_ssm;

--- a/src/model/model_profile.h
+++ b/src/model/model_profile.h
@@ -24,6 +24,10 @@ struct ModelProfile {
                                // e.g. Nemotron-H) — these disable CUDA graphs
     bool is_hybrid = false;    // recurrent (gdn/ssm) AND attention layers coexist
     bool is_dense = true;      // !is_moe
+    bool moe_experts_nvfp4 = false;  // MoE + NVFP4-prequant checkpoint: experts
+                                     // get the contiguous native NVFP4 cache, so
+                                     // batched verify/prefill reads quantized
+                                     // weights directly (no per-chunk dequant)
 
     // --- architecture identity (mirrors ModelConfig::arch) ---
     // The hot path (executor_attention / executor_forward_moe / …) keys many

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -249,6 +249,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
 
     // [speculative]
     B("speculative.ngram", cfg.speculative.ngram);
+    B("speculative.moe", cfg.speculative.moe);
     I("speculative.k", cfg.speculative.k);
     I("speculative.min_match", cfg.speculative.min_match);
     I("speculative.max_match", cfg.speculative.max_match);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -477,11 +477,22 @@ struct RuntimeConfig {
     // tg128 -15% draft-poor downside no longer reproduces (-0.2%/-0.9% on
     // dense Q8/NVFP4, 2026-06-16) — hence default-ON. spec_ngram_gates_ok_
     // confines engagement to batch-1 / greedy / no-penalty-window / no-json /
-    // no-logprobs / non-recurrent / NON-MoE requests; everything else falls
-    // back cleanly, so default-on is a no-op for sampled chat, tool/JSON
-    // calls, concurrent batches, and MoE (which the async loop carries).
+    // no-logprobs / non-recurrent requests (MoE additionally requires
+    // native-NVFP4 experts, see `moe` below); everything else falls back
+    // cleanly, so default-on is a no-op for sampled chat, tool/JSON calls,
+    // concurrent batches, and GGUF-MoE (which the async loop carries).
     struct Speculative {
         bool ngram = true;  // prompt-lookup speculation, default-on (batch-1, greedy, dense)
+        // Speculation on MoE models with NATIVE-NVFP4 experts (the gate
+        // additionally requires profile().moe_experts_nvfp4). Measured on
+        // Qwen3-Coder-30B-FP4 (2026-07-02): code-edit +49-81% (93% accept,
+        // 15.9 tok/verify), draft-poor code-gen -3-7% (miss_burst hybrid
+        // bounds the downside). GGUF-MoE verify re-dequants every activated
+        // expert per step (-22% measured) and never engages regardless of
+        // this flag. imp-cli --bench pins this false so the canonical
+        // perf-baseline decode signal stays raw (verify inherits grouped-GEMM
+        // restart variance).
+        bool moe = true;
         int k = 16;          // draft tokens per verify step (verify cost is ~flat in k)
         // Longer suffix matches trade draft frequency for precision — and
         // precision wins decisively: min_match 6 vs 3 measured +16% on

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1001,12 +1001,14 @@ void Engine::step_decode(cudaStream_t dec_stream) {
                 IMP_LOG_INFO(
                     "spec-ngram: gates failed (temp=%.2f top_k=%d rep_pen=%.2f freq=%.2f "
                     "pres=%.2f dry=%.2f mirostat=%d bias=%zu logprobs=%d json=%d schema=%d "
-                    "think_budget=%.2f ssm=%d gdn=%d moe=%d mtp=%d chunked_prefill=%d)",
+                    "think_budget=%.2f ssm=%d gdn=%d moe=%d moe_nvfp4=%d spec_moe=%d mtp=%d "
+                    "chunked_prefill=%d)",
                     r.temperature, r.top_k, r.repetition_penalty, r.frequency_penalty,
                     r.presence_penalty, r.dry_multiplier, r.mirostat, r.logit_bias.size(),
                     (int)r.logprobs, (int)r.json_mode, (int)!r.json_schema.empty(), r.think_budget,
                     (int)(ssm_state_ != nullptr), (int)(gdn_state_ != nullptr),
-                    (int)model_->profile().is_moe, (int)mtp_spec_decode_enabled(),
+                    (int)model_->profile().is_moe, (int)model_->profile().moe_experts_nvfp4,
+                    (int)runtime_config_.speculative.moe, (int)mtp_spec_decode_enabled(),
                     (int)supports_chunked_prefill_());
             }
         }

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -163,12 +163,15 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     // Recurrent state (SSM/GDN) advances on every forwarded token and cannot
     // be rewound on draft rejection.
     if (ssm_state_ || gdn_state_) return false;
-    // MoE decode is carried by the async conditional-graph loop (+27-36%, the
-    // MoE-decode foundation). The eager spec-verify path disables that loop and
-    // regresses MoE -11..-73% even at ~99% draft acceptance (perf hunt
-    // 2026-06-18) — the host must see every token to draft+accept. Net-negative
-    // for MoE as-is, so gate it off and stay on the loop (dense keeps the win).
-    if (model_->profile().is_moe) return false;
+    // MoE speculation engages only for native-NVFP4 experts: the batched
+    // verify forward reads the NVFP4 expert cache directly and nets +49-81%
+    // on draft-rich code-edit (Qwen3-Coder-30B-FP4, 2026-07-02) with a -3-7%
+    // draft-poor floor (miss_burst hybrid). GGUF-MoE verify re-dequants every
+    // activated expert per step and measured -22% — those stay on the async
+    // conditional-graph loop (as does everything when speculative.moe=false).
+    if (model_->profile().is_moe &&
+        !(runtime_config_.speculative.moe && model_->profile().moe_experts_nvfp4))
+        return false;
     if (mtp_spec_decode_enabled()) return false;
     if (!supports_chunked_prefill_()) return false;
     return true;

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -22,6 +22,18 @@ int main(int argc, char** argv) {
     // Engine::init to pick up (Phase 5 Track D follow-up: replaces the
     // RuntimeConfig::install() process-wide singleton).
     imp::RuntimeConfig runtime_cfg = imp::RuntimeConfig::load(args.config_path, args.config_overrides);
+    // Benchmark mode measures raw engine decode: MoE speculation would fold
+    // draft-acceptance luck + grouped-GEMM restart variance into the gated
+    // tg signal (dense spec stays as-is — measured neutral on the bench
+    // prompt). An explicit --set speculative.moe=… still wins.
+    if (args.bench) {
+        bool user_set = false;
+        for (const auto& ov : args.config_overrides)
+            if (ov.rfind("speculative.moe", 0) == 0)
+                user_set = true;
+        if (!user_set)
+            runtime_cfg.speculative.moe = false;
+    }
     // Cache the few diagnostic / runtime-mode flags that are read from free
     // functions (kernel diagnostics, CUDA-graph capture mode, PDL gate)
     // before set_pending_runtime_config() consumes the value.


### PR DESCRIPTION
## Summary

Backlog item 5 of the agentic campaign: unlock speculative decoding for MoE models. The `is_moe` hard gate in `spec_ngram_gates_ok_` was added by #781 based on the pre-`miss_burst` measurement (-11..-73%, perf hunt 2026-06-18). Re-measured on current main, that regression has inverted: **draft-rich code-edit on Qwen3-Coder-30B-A3B-FP4 now nets +49-81%** (93% accept, 15.9 tok/verify), with the draft-poor floor bounded at -3-7% by the `miss_burst`/`burst` loop hybrid.

## Key insight (no new kernels)

The audit premise "route verify through the batched-decode MoE kernels" turned out to be a false dichotomy: `run_moe_ffn` dispatches on `n_tokens` only, so an M=k+1 verify chunk **already** runs the exact batched grouped path multi-sequence decode uses. The remaining cost is format-dependent:

- **Native-NVFP4 experts** read the contiguous NVFP4 cache directly → verify is cheap → big net win.
- **GGUF-MoE** re-dequants every activated expert per verify step → measured **-22%** → stays on the async loop.

The gate therefore keys on the new `profile().moe_experts_nvfp4` (= `is_moe && cfg.is_nvfp4_prequant`, the same flag `pre_dequant_phase3_moe.cu` keys the cache build on) plus a new `speculative.moe` knob (default **true**).

## Perf-gate protection

`imp-cli --bench` pins `speculative.moe=false` (an explicit `--set speculative.moe=…` still wins), because verify inherits grouped-GEMM restart variance (420 vs 280 tok/s across restarts at identical accept stats) and would pollute the gated 3% decode signal. **`tests/perf_baseline.json` semantics are unchanged — no refresh needed** (verified: bench tg 351 vs 346-357 raw, gate log shows `spec_moe=0`).

## Measurements (RTX 5090, 3 trials, clocks warm)

| Workload | before | after | Δ |
|---|---|---|---|
| Qwen3-Coder-30B-FP4 code-edit | 322.7 tok/s | 480-586 tok/s | **+49-81%** |
| Qwen3-30B-Modelopt code-edit | ~320 | 415 | **+29%** (82% accept) |
| Gemma-4-26B-A4B code-edit | 268 | 290 | +8% (97% accept) |
| Coder draft-poor code-gen | 327 | 303-331 | -7..+1% |
| GGUF-MoE Q4_K_M (blocked) | 192-198 | unchanged (loop) | 0 (spec would be -22%) |
| `--bench` tg (pinned off) | 346-357 | 351 | unchanged |

## Verification

- Code-edit output byte-identical to spec-off (modulo interleaved log lines); `TTLCache` rename correct.
- Coherence battery (TCP/UDP, bash one-liner, Fibonacci) all correct; draft-poor prompts ride the burst hybrid cleanly.
- Gates-failed diagnostic extended with `moe_nvfp4=`/`spec_moe=` fields; verified `moe_nvfp4=0` blocks GGUF-MoE and gpt-oss/MXFP4 stays excluded.
- GDN/SSM hybrids (Qwen3.6, Nemotron) remain blocked by the recurrent-state gate as before.
- `verify-fast`: PASS (decode WARN = known depressed-host signature #526, 369W; dense paths untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz4AjAECTf9WVEjM2PXPER