### PR TITLE
fix(jinja): strip template's trailing newline — fixes Qwen3-Coder multi-turn empty output

### DIFF
--- a/src/model/jinja.cpp
+++ b/src/model/jinja.cpp
@@ -2597,9 +2597,23 @@ Template::~Template() = default;
 Template::Template(Template&&) noexcept = default;
 Template& Template::operator=(Template&&) noexcept = default;
 
-bool Template::parse(const std::string& source) {
+bool Template::parse(const std::string& source_in) {
     error_.clear();
     nodes_.clear();
+
+    // Match Jinja2's keep_trailing_newline=False default — the setting HF
+    // transformers and vLLM use when applying chat templates: strip a single
+    // trailing newline from the template source. Without this, a template file
+    // that ends in a newline (Qwen3-Coder's chat_template.jinja ends
+    // "{%- endif %}\n") renders "<|im_start|>assistant\n\n"; that extra blank
+    // line makes the model emit an immediate EOS (empty completion) on
+    // borderline multi-turn contexts. Templates without a trailing newline
+    // (Qwen3 / Modelopt) are unaffected. Strips one \n, \r\n, or \r.
+    std::string source = source_in;
+    if (source.size() >= 2 && source[source.size() - 2] == '\r' && source.back() == '\n')
+        source.erase(source.size() - 2);
+    else if (!source.empty() && (source.back() == '\n' || source.back() == '\r'))
+        source.pop_back();
 
     detail::Lexer lexer(source);
     auto tokens = lexer.tokenize();

--- a/tests/test_jinja.cpp
+++ b/tests/test_jinja.cpp
@@ -73,6 +73,28 @@ TEST(JinjaTest, VariableSubstitution) {
     EXPECT_EQ(tpl.render({{"name", Value(std::string("World"))}}), "Hello, World!");
 }
 
+// keep_trailing_newline=False (Jinja2/HF/vLLM default): a single trailing
+// newline in the template source is stripped. A Qwen3-Coder chat template ends
+// "...assistant\n' }}\n{%- endif %}\n"; without this, the generation prompt
+// renders "<|im_start|>assistant\n\n" and the model emits an immediate EOS.
+TEST(JinjaTest, StripsSingleTrailingNewline) {
+    Template a;
+    ASSERT_TRUE(a.parse("{{- 'assistant\\n' }}\n"));  // template file ends in a newline
+    EXPECT_EQ(a.render({}), "assistant\n");            // trailing template newline stripped
+
+    Template b;
+    ASSERT_TRUE(b.parse("{{- 'assistant\\n' }}"));  // no trailing newline in source
+    EXPECT_EQ(b.render({}), "assistant\n");
+
+    Template crlf;
+    ASSERT_TRUE(crlf.parse("X\r\n"));  // strips \r\n as one newline
+    EXPECT_EQ(crlf.render({}), "X");
+
+    Template two;
+    ASSERT_TRUE(two.parse("X\n\n"));  // only ONE trailing newline stripped
+    EXPECT_EQ(two.render({}), "X\n");
+}
+
 TEST(JinjaTest, ExpressionConcat) {
     Template tpl;
     ASSERT_TRUE(tpl.parse("{{ 'a' + 'b' + 'c' }}"));


### PR DESCRIPTION
## Summary

imp's from-scratch Jinja engine did not strip a single trailing newline from the template source, unlike Jinja2's `keep_trailing_newline=False` default that HF transformers and vLLM use when applying chat templates.

Qwen3-Coder-30B's `chat_template.jinja` **file ends with a newline** (`...assistant\n' }}\n{%- endif %}\n`), so imp rendered the generation prompt as `<|im_start|>assistant\n\n` (an extra blank line). That extra newline makes the model emit an **immediate EOS (empty completion)** on borderline multi-turn conversations — turns 3-5+ of a growing chat came back empty. It was **non-deterministic** (Qwen3-30B-A3B MoE routing atomics masked the magnitude), which is why it flip-flopped run to run.

Templates that end **without** a trailing newline (Qwen3 / Modelopt-30B) render `<|im_start|>assistant\n` and were unaffected — which made the bug look Coder-specific and initially pointed at FP8-KV / forward-accuracy / MoE. Those were all dead ends.

## Root cause (how it was found)

Diffed imp's rendered prompt (`--set diagnostics.debug_template=true`) against vLLM's rendering of the identical messages: **identical 5445 tokens except imp's had one extra trailing `\n`**. Decisive discriminator:
- imp `/v1/completions` on vLLM's **exact rendered string** → 0/8 empty (generates fine).
- imp `/v1/chat/completions` (imp's jinja) → 8/8 empty.

## Fix

`Template::parse()` (`src/model/jinja.cpp`) strips one trailing `\n`, `\r\n`, or `\r` from the source before lexing — matching Jinja2's `keep_trailing_newline=False`.

## Verification

- **Qwen3-Coder-30B multi-turn: 12/12 turns generate** (was ~half empty); rendered prompt now ends `assistant\n`.
- Regression coherent on Q8-dense (gguf template), Gemma-4-26B-A4B (different family), Modelopt-30B (no trailing newline), gpt-oss-20b (Harmony).
- 44 `JinjaTest` pass incl. new `StripsSingleTrailingNewline` (covers `\n`, `\r\n`, no-newline, and only-one-stripped cases).
- `verify-fast`: OK (decode WARN = depressed-host #526, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz4AjAECTf9WVEjM2PXPER