### PR TITLE
feat(hybrid): prefix caching via recurrent-state snapshots + decode fairness rotation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(IMP_MEMORY_SOURCES
     src/memory/memory_manager.cpp
     src/memory/kv_cache.cu
     src/memory/kv_cache_manager.cpp
+    src/memory/recurrent_snapshot_store.cpp
     src/memory/ssm_state.cu
     src/memory/gdn_state.cu
     src/memory/layer_offload.cu
@@ -618,6 +619,7 @@ if(IMP_BUILD_TESTS)
         tests/test_kv_gather.cu
         tests/test_green_ctx.cu
         tests/test_prefix_cache_equiv.cpp
+        tests/test_recurrent_snapshot_store.cpp
     )
 
     imp_add_test_module(test-moe-gdn SOURCES

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,6 +137,11 @@ Per token:
 - **Memory** — `src/memory/vram_allocator.cu`, `src/memory/kv_cache.cu`,
   `src/memory/kv_cache_manager.cpp`, `src/memory/layer_offload.cu`,
   `src/runtime/vram_budget.cpp`, `src/runtime/storage_planner.cpp`.
+  Prefix caching (content-addressed KV block reuse) works on hybrid SSM/GDN
+  models via `src/memory/recurrent_snapshot_store.cpp`: one recurrent-state
+  slab per prefill is snapshotted at the largest block-aligned prompt
+  position and restored on a prefix hit — KV blocks alone cannot skip
+  prefill for a recurrent model.
 - **Kernels** — `src/compute/` (attention, GEMM, RMSNorm, RoPE, SwiGLU,
   softmax, sampling) and `src/quant/` (dequant, FP8 quant, NVFP4 quant).
 - **Public C API** — `include/imp/{imp,types,error,config}.h`,

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -44,6 +44,13 @@ max_batch_size       = 0
 # paths are unaffected. 0 = legacy unbounded behavior. Ignored when
 # deterministic = true (the unbounded loop stays for bit-reproducible evals).
 decode_burst         = 128
+# Hybrid (SSM/GDN) decode fairness: the recurrent scan kernels are single-
+# sequence, so concurrent sessions time-slice the decode. Slice length in
+# tokens; after it the engine rotates round-robin to the next decoding
+# request. Rotation re-captures the decode graphs (~10-20 ms), which the
+# slice amortizes (~1-2% at 128). 0 = old head-of-line behavior (the first
+# request runs to completion before the next produces a token).
+hybrid_decode_quantum = 128
 # Run a warmup forward pass at engine init to prime cuBLAS handles + L2 cache.
 # Off by default — opt in for prod rollouts where first-request TTFT
 # matters. In dev / CI / one-shot runs the warmup is pure overhead and can
@@ -246,13 +253,20 @@ mtp_no_rope          = false
 # Prefix caching: reuse KV blocks for shared prompt prefixes (system
 # prompts, multi-turn history). Read by the engine and ORed into the live
 # config at init; PrefixCacheE2ETest guards hit==fresh equality.
-# Auto-disabled for recurrent (SSM/GDN) models. (Library/C-API embedders
-# that do not load imp.conf default to OFF.)
+# (Library/C-API embedders that do not load imp.conf default to OFF.)
 prefix_cache         = true
 # Cap on KV blocks pinned by Anthropic cache_control / "cache_prompt"
 # requests, as percent of the KV pool. Oldest pins recycle FIFO. 0 = pin
 # requests are ignored.
 prefix_pin_budget_pct = 25
+# Device budget (MiB) for recurrent-state snapshots — what makes prefix
+# caching work on hybrid (SSM/GDN) models: reused KV blocks alone cannot
+# skip prefill there, the recurrent state at the skip boundary must be
+# restored too. One snapshot = one per-sequence state slab (~64 MiB on
+# Qwen3.6-35B), saved once per prefill, LRU-evicted; buffers pre-allocated
+# at engine init. imp-cli --bench pins this to 0. 0 disables snapshots and
+# with them hybrid prefix caching (dense models unaffected).
+recurrent_snapshot_mb = 256
 # Green Contexts / prefill-decode overlap streams in the server engine.
 # Opt-in (off by default): suspected memSyncDomain race on sm_120 fallback
 # streams (gemma-3-12b IMA). Set true to enable.

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -961,6 +961,8 @@ ImpError imp_context_reset(ImpContext ctx) {
         ctx->engine->kv_manager()->free_sequence(ctx->active_request->id);
         // Evict all cached blocks to prevent prefix cache hits with stale data
         while (ctx->engine->kv_manager()->evict_cached_block()) {}
+        // Drop recurrent-state snapshots for the same reason (hybrid models)
+        ctx->engine->clear_recurrent_snapshots();
         // Reset SSM state for hybrid models (Mamba2)
         ctx->engine->reset_ssm_state(ctx->active_request->id);
         ctx->active_request->status = imp::RequestStatus::CANCELLED;

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -416,7 +416,30 @@ bool KVCacheManager::can_allocate(int num_blocks) const {
 
 // ─── Content-addressed prefix caching ────────────────────────────────
 
-int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int32_t> tokens) {
+int KVCacheManager::longest_cached_prefix_blocks(std::span<const int32_t> tokens,
+                                                 std::vector<size_t>& chain_hashes) const {
+    chain_hashes.clear();
+    const int num_tokens = static_cast<int>(tokens.size());
+    const int full_blocks = num_tokens / cache_->block_size();
+    int cached = 0;
+    bool chain_intact = true;
+    size_t parent_hash = 0;
+    for (int b = 0; b < full_blocks; ++b) {
+        size_t h = compute_block_hash(
+            tokens.subspan(static_cast<size_t>(b) * cache_->block_size(), cache_->block_size()),
+            parent_hash);
+        chain_hashes.push_back(h);
+        parent_hash = h;
+        if (chain_intact && block_hash_to_id_.find(h) != block_hash_to_id_.end())
+            cached = b + 1;
+        else
+            chain_intact = false;
+    }
+    return cached;
+}
+
+int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int32_t> tokens,
+                                                int max_reuse_blocks) {
     const int num_tokens = static_cast<int>(tokens.size());
     if (num_tokens <= 0)
         return 0;
@@ -439,6 +462,12 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
     auto& hashes = seq_block_hashes_[seq_id];
     int reused_blocks = 0;
     size_t parent_hash = 0;
+    // Reuse must form a contiguous prefix: once a block misses (or the
+    // caller's cap is reached), later hash hits must NOT be shared — the
+    // caller skips prefill for reused*block_size tokens, so a hole would
+    // leave uncomputed KV inside the "skipped" range (possible when LRU
+    // eviction removed an early block while later chain blocks survive).
+    bool reuse_open = true;
 
     for (int b = 0; b < total_blocks; ++b) {
         int block_start = b * cache_->block_size();
@@ -447,11 +476,14 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
         // Only full blocks are cacheable.
         bool is_full_block = (block_tokens == cache_->block_size());
 
+        if (max_reuse_blocks >= 0 && b >= max_reuse_blocks)
+            reuse_open = false;
+
         if (prefix_caching_enabled_ && is_full_block) {
             size_t block_hash = compute_block_hash(tokens.subspan(block_start, block_tokens), parent_hash);
 
             // Check if this block already exists in the hash table.
-            auto hit = block_hash_to_id_.find(block_hash);
+            auto hit = reuse_open ? block_hash_to_id_.find(block_hash) : block_hash_to_id_.end();
             if (hit != block_hash_to_id_.end()) {
                 int cached_block = hit->second;
 
@@ -477,7 +509,8 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
                 continue;
             }
 
-            // No cache hit — allocate a fresh block and register it.
+            // No cache hit (or reuse closed) — allocate a fresh block.
+            reuse_open = false;
             int block_id = allocate_block_with_eviction();
             if (block_id < 0) {
                 // Rollback everything we allocated/shared in this call.

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -84,8 +84,22 @@ public:
     // Returns the number of prefix blocks that were reused (i.e., the
     // number of blocks whose KV data is already computed). The caller
     // should skip prefill for the first `result * kKVBlockSize` tokens.
+    // Reuse stops at the first non-cached block (a hole after an evicted
+    // block must not count — skipped tokens need a contiguous KV prefix).
+    // `max_reuse_blocks` caps reuse (-1 = unlimited); hybrid models pass
+    // the recurrent-snapshot boundary so prefill never re-writes shared
+    // blocks beyond the restorable state position.
     // Returns -1 on allocation failure.
-    [[nodiscard]] int allocate_blocks_with_prefix(int seq_id, std::span<const int32_t> tokens);
+    [[nodiscard]] int allocate_blocks_with_prefix(int seq_id, std::span<const int32_t> tokens,
+                                                  int max_reuse_blocks = -1);
+
+    // Read-only probe: length (in blocks) of the longest fully-cached
+    // contiguous block prefix for `tokens`, without allocating anything.
+    // Fills `chain_hashes` with the chained hash of every FULL block of
+    // `tokens` (independent of cache state). Used by the hybrid recurrent-
+    // snapshot lookup to pick a restore boundary before allocation.
+    int longest_cached_prefix_blocks(std::span<const int32_t> tokens,
+                                     std::vector<size_t>& chain_hashes) const;
 
     // Register the block hashes for a sequence after prefill completes.
     // This must be called so that future sequences can match against

--- a/src/memory/recurrent_snapshot_store.cpp
+++ b/src/memory/recurrent_snapshot_store.cpp
@@ -1,0 +1,129 @@
+#include "memory/recurrent_snapshot_store.h"
+#include "core/logging.h"
+
+namespace imp {
+
+RecurrentSnapshotStore::~RecurrentSnapshotStore() {
+    if (!pool_)
+        return;
+    std::vector<void*> to_free;
+    {
+        std::lock_guard<std::mutex> lk(pool_->mu);
+        pool_->shutdown = true;
+        to_free.swap(pool_->free_bufs);
+    }
+    for (void* p : to_free)
+        cudaFree(p);
+    // Entries still held by requests free their buffers via the deleter.
+}
+
+void RecurrentSnapshotStore::init(size_t entry_bytes, size_t budget_bytes) {
+    entry_bytes_ = entry_bytes;
+    int want = (entry_bytes > 0) ? static_cast<int>(budget_bytes / entry_bytes) : 0;
+    if (want <= 0) {
+        IMP_LOG_INFO("RecurrentSnapshotStore: disabled (budget %.0f MiB < one %.1f MiB slot)",
+                     budget_bytes / (1024.0 * 1024.0), entry_bytes / (1024.0 * 1024.0));
+        return;
+    }
+    // Allocate the buffers EAGERLY: engine init sizes the weight caches, KV
+    // clamp and workspace pools to fill the card (and the async mempool
+    // retains the slack), so at serving time free VRAM is ~0 by design —
+    // lazy allocation would never get a byte on tight models. Claiming the
+    // budget here makes the downstream sizing account for it; a failed
+    // malloc just caps the slot count.
+    pool_ = std::make_shared<BufferPool>();
+    for (int i = 0; i < want; ++i) {
+        void* p = nullptr;
+        if (cudaMalloc(&p, entry_bytes_) != cudaSuccess)
+            break;
+        pool_->free_bufs.push_back(p);
+        allocated_bufs_++;
+    }
+    capacity_ = allocated_bufs_;
+    if (capacity_ == 0)
+        pool_.reset();
+    IMP_LOG_INFO("RecurrentSnapshotStore: %d/%d slots x %.1f MiB pre-allocated (budget %.0f MiB)",
+                 capacity_, want, entry_bytes / (1024.0 * 1024.0), budget_bytes / (1024.0 * 1024.0));
+}
+
+std::shared_ptr<const RecurrentSnapshotEntry> RecurrentSnapshotStore::find(size_t key) {
+    auto it = entries_.find(key);
+    if (it == entries_.end())
+        return nullptr;
+    auto lit = lru_map_.find(key);
+    if (lit != lru_map_.end()) {
+        lru_.erase(lit->second);
+        lru_.push_back(key);
+        lit->second = std::prev(lru_.end());
+    }
+    return it->second;
+}
+
+void* RecurrentSnapshotStore::acquire_buffer_() {
+    {
+        std::lock_guard<std::mutex> lk(pool_->mu);
+        if (!pool_->free_bufs.empty()) {
+            void* p = pool_->free_bufs.back();
+            pool_->free_bufs.pop_back();
+            return p;
+        }
+    }
+    // All buffers were pre-allocated at init. None free: evict LRU-head
+    // entries until a buffer comes back. An
+    // entry whose buffer is still held by a request releases it later —
+    // keep evicting map entries until one deleter actually recycles.
+    while (!lru_.empty()) {
+        size_t victim = lru_.front();
+        lru_.pop_front();
+        lru_map_.erase(victim);
+        entries_.erase(victim);  // may run the deleter right here
+        std::lock_guard<std::mutex> lk(pool_->mu);
+        if (!pool_->free_bufs.empty()) {
+            void* p = pool_->free_bufs.back();
+            pool_->free_bufs.pop_back();
+            return p;
+        }
+    }
+    return nullptr;  // every buffer is held by an in-flight request
+}
+
+bool RecurrentSnapshotStore::save(size_t key, int n_tokens, const void* src, cudaStream_t stream) {
+    if (!enabled() || src == nullptr || n_tokens <= 0)
+        return false;
+    if (entries_.count(key) != 0)
+        return true;  // identical prefix already snapshotted
+    void* buf = acquire_buffer_();
+    if (!buf)
+        return false;
+    if (cudaMemcpyAsync(buf, src, entry_bytes_, cudaMemcpyDeviceToDevice, stream) != cudaSuccess) {
+        std::lock_guard<std::mutex> lk(pool_->mu);
+        pool_->free_bufs.push_back(buf);
+        return false;
+    }
+    auto pool = pool_;
+    auto entry = std::shared_ptr<RecurrentSnapshotEntry>(new RecurrentSnapshotEntry{key, n_tokens, buf},
+                                                         [pool](RecurrentSnapshotEntry* e) {
+                                                             {
+                                                                 std::lock_guard<std::mutex> lk(pool->mu);
+                                                                 if (!pool->shutdown) {
+                                                                     pool->free_bufs.push_back(e->data);
+                                                                     delete e;
+                                                                     return;
+                                                                 }
+                                                             }
+                                                             cudaFree(e->data);
+                                                             delete e;
+                                                         });
+    entries_[key] = entry;
+    lru_.push_back(key);
+    lru_map_[key] = std::prev(lru_.end());
+    return true;
+}
+
+void RecurrentSnapshotStore::clear() {
+    entries_.clear();
+    lru_.clear();
+    lru_map_.clear();
+}
+
+}  // namespace imp

--- a/src/memory/recurrent_snapshot_store.h
+++ b/src/memory/recurrent_snapshot_store.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cuda_runtime_api.h>
+#include <cstddef>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace imp {
+
+// One stored recurrent-state snapshot: the full per-sequence SSM/GDN state
+// slab as it was after prefilling exactly `n_tokens` tokens. `key` is the
+// chained KV block hash of those tokens (n_tokens is always a multiple of
+// the KV block size, so the key identifies the byte-exact token prefix).
+struct RecurrentSnapshotEntry {
+    size_t key = 0;
+    int n_tokens = 0;
+    void* data = nullptr;  // device buffer of entry_bytes
+};
+
+// Device-side LRU store of recurrent-state snapshots for hybrid (SSM/GDN)
+// models. Dense models reuse KV blocks at block granularity; recurrent state
+// is cumulative, so a prefix can only be skipped when the state at exactly
+// that boundary was saved. The engine saves one snapshot per prefill (at the
+// largest block-aligned prompt position) and restores the longest match on
+// admission, turning multi-turn full-history re-prefill into a tail-only
+// prefill.
+//
+// Threading: save/find/clear run on the engine worker thread. Entries are
+// handed out as shared_ptr; a Request may hold one across steps and release
+// it from another thread (server request teardown), so buffer recycling goes
+// through a mutex-guarded pool shared with the entry deleters. An evicted
+// entry's buffer is recycled only after the last holder releases it — an
+// in-flight restore can never read a reused buffer.
+class RecurrentSnapshotStore {
+public:
+    ~RecurrentSnapshotStore();
+
+    // entry_bytes: size of one snapshot (the SSM per-seq slab).
+    // budget_bytes: total device memory cap; capacity = budget / entry_bytes.
+    void init(size_t entry_bytes, size_t budget_bytes);
+
+    bool enabled() const { return capacity_ > 0; }
+    size_t entry_bytes() const { return entry_bytes_; }
+    int capacity() const { return capacity_; }
+    int size() const { return static_cast<int>(entries_.size()); }
+
+    bool contains(size_t key) const { return entries_.count(key) != 0; }
+
+    // Look up a snapshot by key and mark it most-recently-used.
+    std::shared_ptr<const RecurrentSnapshotEntry> find(size_t key);
+
+    // Copy entry_bytes from `src` (device) into the store on `stream`.
+    // Evicts the LRU entry if at capacity. Returns false when no buffer is
+    // available (all entries held by in-flight requests) or on alloc failure.
+    bool save(size_t key, int n_tokens, const void* src, cudaStream_t stream);
+
+    // Drop all entries (context reset). Outstanding request-held entries
+    // stay valid until released.
+    void clear();
+
+private:
+    // Shared with entry deleters so buffers outlive the store if needed.
+    struct BufferPool {
+        std::mutex mu;
+        std::vector<void*> free_bufs;
+        bool shutdown = false;  // deleters cudaFree instead of recycling
+    };
+
+    void* acquire_buffer_();
+
+    std::shared_ptr<BufferPool> pool_;
+    size_t entry_bytes_ = 0;
+    int capacity_ = 0;
+    int allocated_bufs_ = 0;  // pre-allocated at init (== capacity_)
+
+    std::unordered_map<size_t, std::shared_ptr<RecurrentSnapshotEntry>> entries_;
+    // LRU: most-recently-used at the tail.
+    std::list<size_t> lru_;
+    std::unordered_map<size_t, std::list<size_t>::iterator> lru_map_;
+};
+
+}  // namespace imp

--- a/src/memory/ssm_state.h
+++ b/src/memory/ssm_state.h
@@ -32,6 +32,13 @@ public:
     // Zero-initialize all state for a sequence (on new request).
     void reset_sequence(int seq_id, cudaStream_t stream);
 
+    // Base pointer / size of one sequence's full state slab (all layers,
+    // conv + h contiguous) — the unit copied by recurrent-state snapshots.
+    void* seq_base(int seq_id) {
+        return static_cast<char*>(pool_) + static_cast<size_t>(seq_id) * per_seq_bytes_;
+    }
+    size_t per_seq_bytes() const { return per_seq_bytes_; }
+
     int max_sequences() const { return max_sequences_; }
     int n_ssm_layers() const { return n_ssm_layers_; }
     QType h_dtype() const { return h_dtype_; }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -120,6 +120,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("runtime.max_batch_size", cfg.runtime.max_batch_size);
     I("runtime.decode_burst", cfg.runtime.decode_burst);
     I("runtime.prefill_chunk_decode_cap", cfg.runtime.prefill_chunk_decode_cap);
+    I("runtime.hybrid_decode_quantum", cfg.runtime.hybrid_decode_quantum);
 
     // [kv_cache]
     S("kv_cache.dtype", cfg.kv_cache.dtype);
@@ -216,6 +217,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [server]
     B("server.prefix_cache", cfg.server.prefix_cache);
     I("server.prefix_pin_budget_pct", cfg.server.prefix_pin_budget_pct);
+    I("server.recurrent_snapshot_mb", cfg.server.recurrent_snapshot_mb);
     B("server.green_contexts", cfg.server.green_contexts);
 
     // [bench]

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -100,6 +100,15 @@ struct RuntimeConfig {
         // latency-critical multi-tenant serving, 0 to disable (full chunk).
         // The full chunk returns as soon as nobody is decoding.
         int prefill_chunk_decode_cap = 1024;
+        // Hybrid (SSM/GDN) decode fairness: the recurrent scan kernels are
+        // single-sequence, so concurrent sessions time-slice the decode.
+        // This is the slice length in tokens — after it, the engine rotates
+        // to the next DECODING request (round-robin). Rotation re-captures
+        // the decode graphs for the new sequence's state slot (~10-20 ms),
+        // so smaller values buy latency fairness at capture overhead
+        // (128 ≈ 1-2% at typical hybrid decode rates). 0 restores the old
+        // head-of-line behavior (first request runs to completion).
+        int hybrid_decode_quantum = 128;
     } runtime;
 
     struct KVCache {
@@ -449,10 +458,21 @@ struct RuntimeConfig {
         // C-API embedders are unaffected — they drive EngineConfig directly
         // (off-by-default there). The engine ORs this into
         // EngineConfig.use_prefix_caching at init. PrefixCacheE2ETest is the
-        // ship gate; auto-disabled for SSM/GDN.
+        // ship gate. For hybrid (SSM/GDN) models it additionally requires the
+        // recurrent snapshot store below.
         bool prefix_cache = true;
         // Cap on cache_control/cache_prompt-pinned blocks, % of the KV pool.
         int prefix_pin_budget_pct = 25;
+        // Device budget (MiB) for recurrent-state snapshots — what makes
+        // prefix caching work on hybrid (SSM/GDN) models: KV blocks alone
+        // cannot skip prefill there, the recurrent state at the skip boundary
+        // must be restored too. One snapshot = one per-sequence state slab
+        // (~64 MiB for Qwen3.6-35B), saved per prefill, LRU-evicted. Buffers
+        // are pre-allocated at engine init (free VRAM is ~0 at serving time
+        // by design) and accounted in the expert-offload reserve. imp-cli
+        // --bench pins this to 0 (baseline semantics unchanged).
+        // 0 disables snapshots AND hybrid prefix caching (dense unaffected).
+        int recurrent_snapshot_mb = 256;
         // Green Contexts / prefill-decode overlap streams in the server engine.
         // OFF by default (suspected memSyncDomain race on sm_120 fallback
         // streams — gemma-3-12b IMA); opt in via [server] green_contexts = true.

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -60,8 +60,10 @@ Engine::~Engine() {
     MemAccount::instance().sampler_stop();
     MemAccount::instance().report("shutdown");
 
-    // Save prefix cache to disk before shutdown
-    if (kv_manager_ && !config_.prefix_cache_path.empty() && kv_manager_->prefix_caching_enabled()) {
+    // Save prefix cache to disk before shutdown (dense only — hybrid reuse
+    // needs recurrent snapshots, which are device-resident and not persisted)
+    if (kv_manager_ && !config_.prefix_cache_path.empty() && kv_manager_->prefix_caching_enabled() &&
+        !ssm_state_) {
         kv_manager_->save_prefix_cache(config_.prefix_cache_path, model_fingerprint_(), stream_);
     }
 
@@ -441,6 +443,7 @@ void Engine::finish_request(std::shared_ptr<Request>& req) {
     }
     kv_manager_->free_sequence(req->id);
     release_recurrent_slot_(req->id);
+    req->recurrent_restore.reset();  // release the snapshot buffer for recycling
     if (req->constraints)
         constraints_return_(std::move(req->constraints));
     // Server visibility: the engine outlives requests, so cumulative

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -14,6 +14,7 @@
 #include "memory/kv_cache_manager.h"
 #include "memory/ssm_state.h"
 #include "memory/gdn_state.h"
+#include "memory/recurrent_snapshot_store.h"
 #include "memory/layer_offload.h"
 #include "memory/memory_manager.h"
 #include "memory/vram_allocator.h"
@@ -129,6 +130,13 @@ public:
 
     // Reset SSM state for a sequence (call on context_reset for hybrid models)
     void reset_ssm_state(int seq_id);
+
+    // Drop all recurrent-state snapshots (call on context_reset alongside the
+    // prefix-cache block eviction — stale snapshots must not match new data)
+    void clear_recurrent_snapshots() {
+        if (recurrent_snapshots_)
+            recurrent_snapshots_->clear();
+    }
 
     // Invalidate all cached CUDA graphs (call on context_reset to ensure
     // deterministic output — stale graph captures can produce different results)
@@ -393,6 +401,22 @@ private:
     std::vector<int> free_recurrent_slots_;           // available slot ids
     std::unordered_map<int, int> recurrent_slot_of_;  // req.id -> slot
     bool recurrent_slots_initialized_ = false;
+    // Recurrent-state snapshots (hybrid prefix caching): LRU store of
+    // per-sequence SSM/GDN state slabs keyed by the chained KV block hash of
+    // the block-aligned prompt prefix they cover. Saved once per prefill,
+    // restored at admission so multi-turn requests skip re-prefilling the
+    // shared history (see docs — dense models need KV blocks only; hybrids
+    // additionally need the recurrent state at the skip boundary).
+    std::unique_ptr<RecurrentSnapshotStore> recurrent_snapshots_;
+    // Hybrid decode fairness: round-robin rotation state for the batch-1
+    // recurrent decode (quantum-based; see step_decode).
+    int hybrid_active_req_ = -1;    // request id currently holding the decode slice
+    int hybrid_slice_start_ = 0;    // its output_tokens.size() at slice start
+    bool hybrid_decode_waiting_ = false;  // other hybrid requests wait this step
+    // Recurrent slot whose state pointers the decode graph pool captured.
+    // A replay for a request in a DIFFERENT slot would read/write the wrong
+    // sequence's state — invalidate (graph-exec update) on slot change.
+    int decode_graph_recurrent_slot_ = -1;
     bool has_pure_ssm_layers_ = false;  // true if model has Mamba2 SSM layers (not GDN)
     std::unique_ptr<LayerOffloadManager> offload_mgr_;
     bool experts_on_host_ = false;
@@ -640,6 +664,11 @@ private:
     void fill_recurrent_state(const Request& req, InferenceState& state, bool reset, cudaStream_t stream);
     int acquire_recurrent_slot_(int req_id);   // distinct free slot for a new sequence
     void release_recurrent_slot_(int req_id);  // idempotent; returns slot to the pool
+    // Recurrent-state snapshots (hybrid prefix caching, engine_sampling_stop.cpp):
+    // admission hook (longest restorable prefix, in blocks) + save/position helpers.
+    int hybrid_prefix_reuse_limit_(Request& req);
+    int hybrid_snapshot_end_(const Request& req) const;  // block-aligned save position, 0 = none
+    void maybe_save_recurrent_snapshot_(const Request& req, int snap_end, cudaStream_t stream);
     void finish_request(std::shared_ptr<Request>& req);
 
     // ── step() sub-phases ─────────────────────────────────────────────

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -171,26 +171,24 @@ bool Engine::init_kv_cache() {
     }
 
     if (config_.use_prefix_caching) {
-        if (mcfg.ssm_inner_size > 0) {
-            IMP_LOG_WARN(
-                "Prefix caching disabled for recurrent model — "
-                "SSM/GDN state requires full sequential prefill");
-        } else {
-            kv_manager_->set_prefix_caching_enabled(true);
-            // cache_control/cache_prompt pin budget: percent of the pool,
-            // floor of 1 block when enabled at all.
-            int pin_pct = std::min(std::max(config_.prefix_pin_budget_pct, 0), 100);
-            int pin_budget =
-                pin_pct > 0 ? std::max(1, kv_manager_->kv_cache()->total_blocks() * pin_pct / 100) : 0;
-            kv_manager_->set_pin_budget_blocks(pin_budget);
-            IMP_LOG_INFO("Prefix caching enabled (pin budget %d blocks)", pin_budget);
-            if (!config_.prefix_cache_path.empty()) {
-                int restored = kv_manager_->load_prefix_cache(config_.prefix_cache_path,
-                                                              model_fingerprint_(), stream_);
-                if (restored > 0)
-                    IMP_LOG_INFO("Restored %d prefix cache blocks from %s", restored,
-                                 config_.prefix_cache_path.c_str());
-            }
+        kv_manager_->set_prefix_caching_enabled(true);
+        // cache_control/cache_prompt pin budget: percent of the pool,
+        // floor of 1 block when enabled at all.
+        int pin_pct = std::min(std::max(config_.prefix_pin_budget_pct, 0), 100);
+        int pin_budget =
+            pin_pct > 0 ? std::max(1, kv_manager_->kv_cache()->total_blocks() * pin_pct / 100) : 0;
+        kv_manager_->set_pin_budget_blocks(pin_budget);
+        IMP_LOG_INFO("Prefix caching enabled (pin budget %d blocks)", pin_budget);
+        // Persistent cache is dense-only: restored KV blocks are only usable
+        // for hybrids together with a recurrent-state snapshot, and snapshots
+        // are not persisted. (For hybrids the recurrent-snapshot store below
+        // must also come up, or caching is turned back off.)
+        if (mcfg.ssm_inner_size == 0 && !config_.prefix_cache_path.empty()) {
+            int restored = kv_manager_->load_prefix_cache(config_.prefix_cache_path,
+                                                          model_fingerprint_(), stream_);
+            if (restored > 0)
+                IMP_LOG_INFO("Restored %d prefix cache blocks from %s", restored,
+                             config_.prefix_cache_path.c_str());
         }
     }
 
@@ -215,6 +213,33 @@ bool Engine::init_kv_cache() {
                                   mcfg.ssm_state_size, config_.ssm_state_dtype, &memory_manager_.vram_allocator())) {
                 IMP_LOG_WARN("Failed to init SSM state, continuing without it");
                 ssm_state_.reset();
+            }
+        }
+
+        // Recurrent-state snapshots: KV block reuse alone cannot skip prefill
+        // for a recurrent model (the state at the skip boundary would be
+        // zero), so hybrid prefix caching needs the snapshot store. Without
+        // it, turn prefix caching back off — retaining hashed blocks that can
+        // never be reused just churns the pool.
+        if (kv_manager_->prefix_caching_enabled()) {
+            int budget_mb = runtime_config_.server.recurrent_snapshot_mb;
+            if (ssm_state_ && budget_mb > 0) {
+                recurrent_snapshots_ = std::make_unique<RecurrentSnapshotStore>();
+                recurrent_snapshots_->init(ssm_state_->per_seq_bytes(),
+                                           static_cast<size_t>(budget_mb) << 20);
+                if (recurrent_snapshots_->enabled()) {
+                    scheduler_->set_prefix_reuse_limit(
+                        [this](Request& r) { return hybrid_prefix_reuse_limit_(r); });
+                } else {
+                    recurrent_snapshots_.reset();
+                }
+            }
+            if (!recurrent_snapshots_) {
+                kv_manager_->set_prefix_caching_enabled(false);
+                IMP_LOG_INFO(
+                    "Prefix caching disabled for recurrent model (snapshot store off — "
+                    "server.recurrent_snapshot_mb=%d)",
+                    budget_mb);
             }
         }
     }

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 
 #include <algorithm>
+#include <span>
 #include <string>
 
 namespace imp {
@@ -285,14 +286,104 @@ void Engine::fill_recurrent_state(const Request& req, InferenceState& state, boo
     if (ssm_state_) {
         state.ssm_state = ssm_state_.get();
         state.ssm_seq_id = slot;
-        if (reset)
-            ssm_state_->reset_sequence(slot, stream);
+        if (reset) {
+            // Prefix-cache hit with a matching recurrent snapshot: restore
+            // the state at exactly req.cached_tokens instead of zeroing —
+            // prefill then continues from the snapshot boundary. All snapshot
+            // copies run on the prefill stream, so save/restore/recycle
+            // ordering is the stream order.
+            if (req.recurrent_restore && req.recurrent_restore->data &&
+                recurrent_snapshots_ &&
+                recurrent_snapshots_->entry_bytes() == ssm_state_->per_seq_bytes()) {
+                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(
+                    ssm_state_->seq_base(slot), req.recurrent_restore->data,
+                    ssm_state_->per_seq_bytes(), cudaMemcpyDeviceToDevice, stream));
+                IMP_LOG_DEBUG("RecurrentSnapshot: restored %d-token state for req %d (slot %d)",
+                              req.recurrent_restore->n_tokens, req.id, slot);
+            } else {
+                ssm_state_->reset_sequence(slot, stream);
+            }
+        }
     }
     if (gdn_state_) {
         state.gdn_state = gdn_state_.get();
         state.gdn_seq_id = slot;
         if (reset)
             gdn_state_->reset_sequence(slot, stream);
+    }
+}
+
+// ─── Recurrent-state snapshots (hybrid prefix caching) ──────────────────
+//
+// Dense models reuse prefix KV at block granularity; recurrent (SSM/GDN)
+// state is cumulative, so prefill can only be skipped up to a position where
+// the exact state was snapshotted. The engine saves one snapshot per prefill
+// at the largest block-aligned prompt position (step_prefill_one ends a chunk
+// there), keyed by the chained KV block hash. On admission the scheduler asks
+// hybrid_prefix_reuse_limit_ for the longest restorable prefix and caps KV
+// block reuse to it — blocks past the snapshot are freshly allocated, so the
+// continuation prefill never re-writes blocks shared with other sequences.
+
+int Engine::hybrid_prefix_reuse_limit_(Request& req) {
+    req.recurrent_restore.reset();
+    if (!recurrent_snapshots_ || !recurrent_snapshots_->enabled() || !ssm_state_)
+        return 0;
+    // Restoring means starting prefill at offset > 0 — a chunked continuation.
+    if (!supports_chunked_prefill_())
+        return 0;
+    // Vision prompts: image content is not represented in the token ids the
+    // hash covers — never match snapshots across them.
+    if (req.vision_emb || req.image || vision_.has_input())
+        return 0;
+    const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    const int total = static_cast<int>(req.input_tokens.size());
+    std::vector<size_t> hashes;
+    int cached = kv_manager_->longest_cached_prefix_blocks(req.input_tokens, hashes);
+    // At least one token must remain to forward (the model needs logits).
+    int max_b = std::min(cached, (total - 1) / bs);
+    for (int b = max_b; b >= 1; --b) {
+        auto entry = recurrent_snapshots_->find(hashes[b - 1]);
+        if (entry && entry->n_tokens == b * bs) {
+            req.recurrent_restore = std::move(entry);
+            return b;
+        }
+    }
+    return 0;
+}
+
+int Engine::hybrid_snapshot_end_(const Request& req) const {
+    if (!recurrent_snapshots_ || !recurrent_snapshots_->enabled() || !ssm_state_)
+        return 0;
+    if (!supports_chunked_prefill_())
+        return 0;
+    if (req.vision_emb || req.image || vision_.has_input())
+        return 0;
+    const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    return (static_cast<int>(req.input_tokens.size()) / bs) * bs;
+}
+
+void Engine::maybe_save_recurrent_snapshot_(const Request& req, int snap_end, cudaStream_t stream) {
+    if (!recurrent_snapshots_ || !recurrent_snapshots_->enabled() || !ssm_state_ || snap_end <= 0)
+        return;
+    const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    size_t key = 0;
+    for (int b = 0; b < snap_end / bs; ++b) {
+        key = KVCacheManager::compute_block_hash(
+            std::span<const int32_t>(req.input_tokens).subspan(static_cast<size_t>(b) * bs, bs), key);
+    }
+    if (recurrent_snapshots_->contains(key))
+        return;  // identical prefix already snapshotted (e.g. it was just restored)
+    auto it = recurrent_slot_of_.find(req.id);
+    if (it == recurrent_slot_of_.end())
+        return;
+    if (recurrent_snapshots_->save(key, snap_end, ssm_state_->seq_base(it->second), stream)) {
+        // The copy must complete before anything else mutates the slot. Later
+        // prefill chunks run on this same stream (ordered); the first DECODE
+        // step may run on a different stream (green contexts), so make the
+        // last-chunk save visible before returning. One sync per prefill.
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+        IMP_LOG_DEBUG("RecurrentSnapshot: saved %d-token state for req %d (%d/%d slots)", snap_end,
+                      req.id, recurrent_snapshots_->size(), recurrent_snapshots_->capacity());
     }
 }
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -31,6 +31,7 @@
 #include "compute/layernorm.h"
 #include "core/logging.h"
 
+#include <climits>
 #include <cmath>
 #include <cstring>
 #include <algorithm>
@@ -665,6 +666,17 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         is_last_chunk = false;
     }
 
+    // Recurrent-state snapshot boundary (hybrid prefix caching): end a chunk
+    // exactly at the largest block-aligned prompt position so the state there
+    // can be captured — the snapshot is only restorable where reused KV
+    // blocks cover the whole prefix, and only full blocks are cacheable. The
+    // extra tail chunk is at most block_size-1 tokens.
+    const int snap_end = hybrid_snapshot_end_(*req);
+    if (snap_end > offset && snap_end < offset + chunk_len) {
+        chunk_len = snap_end - offset;
+        is_last_chunk = false;
+    }
+
     int ctx_len = offset + chunk_len;
     (void)executor_->resize_workspace(chunk_len, pf_stream);
 
@@ -733,8 +745,10 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     // Recurrent state (SSM/GDN)
     // Reset on the first chunk of a new request so previous-request state
     // doesn't leak in.  Subsequent chunks must NOT reset — the recurrent
-    // state built during earlier chunks must carry forward.
-    fill_recurrent_state(*req, state, /*reset=*/(offset == 0), pf_stream);
+    // state built during earlier chunks must carry forward. The first chunk
+    // starts at cached_tokens (> 0 on a prefix-cache hit, where "reset"
+    // restores the matching recurrent snapshot instead of zeroing).
+    fill_recurrent_state(*req, state, /*reset=*/(offset == req->cached_tokens), pf_stream);
 
     // Vision embeddings on first chunk.
     if (req->vision_emb && offset == 0) {
@@ -771,8 +785,14 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         // couldn't be pre-allocated (largest weight > cap) — illegal under CUDA
         // graph capture (cublasLt status 14 → cascading "previous error during
         // capture"). Run prefill eager for those models (Qwen3.6-35B pp>=4096).
+        // The recurrent-snapshot boundary chunk has a request-dependent odd
+        // shape (prompt mod chunk size) — capturing it churns the prefill
+        // graph every request AND the odd-M cuBLAS call can lazily allocate
+        // workspace, which is illegal under capture (cublasLt status 14 →
+        // cascading capture failure, observed on GGUF mxfp4 GDN). Run eager.
+        const bool ends_at_snapshot = (snap_end > 0 && offset + chunk_len == snap_end);
         const bool can_capture = prefill_graph_enabled && pf_pool_used && config_.use_cuda_graphs &&
-                                 !executor_->nvfp4_dequant_uncapturable();
+                                 !ends_at_snapshot && !executor_->nvfp4_dequant_uncapturable();
         if (can_capture) {
             const int block_count = static_cast<int>(block_table.size());
             if (chunk_len != last_prefill_chunk_len_ || block_count != last_prefill_block_count_) {
@@ -806,6 +826,10 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         req->prefill_offset = offset + chunk_len;
         IMP_LOG_DEBUG("Chunked prefill: req %d chunk [%d, %d) of %d", req->id, offset, offset + chunk_len,
                       total_input);
+        // The chunk ended exactly at the snapshot boundary — capture the
+        // recurrent state now, before the next chunk advances it.
+        if (snap_end > 0 && req->prefill_offset == snap_end)
+            maybe_save_recurrent_snapshot_(*req, snap_end, pf_stream);
     } else {
         // Last chunk: forward + sample
         int32_t next_token;
@@ -869,6 +893,12 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
                 free_prefill_buffers(d_token_ids, d_positions, d_block_tables, d_context_lens, pf_stream);
             }
         }
+
+        // Block-aligned prompt: the snapshot boundary coincides with the last
+        // chunk's end — capture after the forward (the sampling above only
+        // reads logits, never the recurrent state).
+        if (snap_end == total_input)
+            maybe_save_recurrent_snapshot_(*req, snap_end, pf_stream);
 
         if (req->mirostat == 2)
             req->mirostat_mu = state.mirostat_mu;
@@ -1014,8 +1044,56 @@ void Engine::step_decode(cudaStream_t dec_stream) {
         }
     }
 
-    // SSM/GDN: limit decode batch to 1 sequence
+    // SSM/GDN: the recurrent scan kernels are single-sequence, so decode one
+    // sequence per step. The old resize(1) kept the OLDEST active request
+    // every step — concurrent sessions serialized head-of-line (the first
+    // request ran to completion before the second produced a token). Rotate
+    // the slice holder round-robin every hybrid_decode_quantum tokens
+    // instead; the decode graphs re-capture for the new sequence's state
+    // slot on rotation (~10-20 ms), which the quantum amortizes.
+    hybrid_decode_waiting_ = false;
     if ((ssm_state_ || gdn_state_) && decode_batch.size() > 1) {
+        const int quantum = runtime_config_.runtime.hybrid_decode_quantum;
+        if (quantum > 0) {
+            int cur = -1;
+            for (size_t i = 0; i < decode_batch.size(); ++i) {
+                if (decode_batch[i]->id == hybrid_active_req_) {
+                    cur = static_cast<int>(i);
+                    break;
+                }
+            }
+            bool rotate = (cur < 0) || (static_cast<int>(decode_batch[cur]->output_tokens.size()) -
+                                            hybrid_slice_start_ >=
+                                        quantum);
+            if (rotate) {
+                // Next request in cyclic id order after the current holder —
+                // ids are monotonically increasing, so this is admission
+                // round-robin.
+                int next = 0;
+                int best_id = INT_MAX, best_wrap_id = INT_MAX;
+                int next_wrap = 0;
+                for (size_t i = 0; i < decode_batch.size(); ++i) {
+                    int id = decode_batch[i]->id;
+                    if (id > hybrid_active_req_ && id < best_id) {
+                        best_id = id;
+                        next = static_cast<int>(i);
+                    }
+                    if (id < best_wrap_id) {
+                        best_wrap_id = id;
+                        next_wrap = static_cast<int>(i);
+                    }
+                }
+                cur = (best_id != INT_MAX) ? next : next_wrap;
+                hybrid_active_req_ = decode_batch[cur]->id;
+                hybrid_slice_start_ = static_cast<int>(decode_batch[cur]->output_tokens.size());
+            }
+            if (cur > 0)
+                std::swap(decode_batch[0], decode_batch[cur]);
+            // Others are waiting: bound the async graph-loop burst to the
+            // slice remainder (step_decode_process_outputs) so rotation
+            // actually gets a chance to run.
+            hybrid_decode_waiting_ = true;
+        }
         decode_batch.resize(1);
     }
 
@@ -1383,6 +1461,20 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             graph_runner.invalidate_for_update();
             last_decode_max_blocks_per_graph_[graph_idx] = bucketed_max_blocks;
         }
+        // Recurrent (SSM/GDN) state pointers are baked into the capture as
+        // kernel params. A replay for a request in a DIFFERENT state slot
+        // would read/write the previous sequence's state — possible whenever
+        // request lifetimes overlap (the next request acquired its slot while
+        // the previous one was live) and every time the hybrid decode slice
+        // rotates. Same-topology re-capture via graph-exec update.
+        if (ssm_state_ && gpu_batch.n_sequences == 1) {
+            auto slot_it = recurrent_slot_of_.find(valid_decode[0]->id);
+            const int slot = (slot_it != recurrent_slot_of_.end()) ? slot_it->second : -1;
+            if (slot != decode_graph_recurrent_slot_) {
+                graph_runner.invalidate_for_update();
+                decode_graph_recurrent_slot_ = slot;
+            }
+        }
         // Graph captures ONLY forward_logits — sampling runs eager after
         Tensor logits_out;
         graph_runner.set_decode_fn(
@@ -1718,6 +1810,17 @@ void Engine::step_decode_process_outputs(std::vector<std::shared_ptr<Request>>& 
                 constexpr int kBusyBurst = 16;
                 if (launch_limit == 0 || launch_limit > kBusyBurst)
                     launch_limit = kBusyBurst;
+            }
+            // Hybrid decode fairness: other recurrent sequences are waiting
+            // for the slice — bound the burst to the slice remainder so the
+            // round-robin rotation in step_decode actually runs.
+            if (!runtime_config_.runtime.deterministic && hybrid_decode_waiting_) {
+                const int quantum = runtime_config_.runtime.hybrid_decode_quantum;
+                int slice_left = quantum - (static_cast<int>(dreq->output_tokens.size()) -
+                                            hybrid_slice_start_);
+                slice_left = std::max(1, slice_left);
+                if (launch_limit == 0 || launch_limit > slice_left)
+                    launch_limit = slice_left;
             }
             try_launch_async_graph_loop(dreq, last_token, dec_stream, launch_limit);
         }

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -155,6 +155,13 @@ bool Engine::init_weights() {
                                    sizeof(float) +
                                static_cast<size_t>(n_heads) * hd_ssm * mcfg.ssm_state_size *
                                    dtype_size(config_.ssm_state_dtype));
+            // Recurrent-snapshot store (hybrid prefix caching): its buffers
+            // are pre-allocated eagerly at KV-cache init, so the offload
+            // decision must leave room for them.
+            if (config_.use_prefix_caching || runtime_config_.server.prefix_cache) {
+                expert_reserve +=
+                    static_cast<size_t>(std::max(runtime_config_.server.recurrent_snapshot_mb, 0)) << 20;
+            }
         }
 
         size_t safety = 256ULL * 1024 * 1024;  // base safety

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -118,6 +118,11 @@ struct Request {
     int harmony_force_idx = -1;
     int prefill_offset = 0;     // Chunked prefill: tokens processed so far
     int cached_tokens = 0;      // Tokens served from prefix cache (skipped in prefill)
+    // Hybrid (SSM/GDN) prefix caching: snapshot of the recurrent state at
+    // exactly `cached_tokens` tokens, set at admission when the prompt prefix
+    // matches a stored snapshot. Restored into the request's recurrent slot
+    // on the first prefill chunk instead of zeroing (engine_sampling_stop).
+    std::shared_ptr<const struct RecurrentSnapshotEntry> recurrent_restore;
     // Pin this request's full prompt blocks in the prefix cache at finish
     // (Anthropic cache_control / OpenAI-route cache_prompt). Pinned blocks
     // survive eviction until the pin budget recycles them (FIFO).

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -68,10 +68,33 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
                 }
                 // Reserve blocks, using prefix caching when enabled.
                 if (kv_manager_->prefix_caching_enabled()) {
-                    int reused = kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens);
+                    // Hybrid models cap reuse at the recurrent-snapshot
+                    // boundary (and attach the snapshot to the request).
+                    int max_reuse = prefix_reuse_limit_ ? prefix_reuse_limit_(*req) : -1;
+                    int reused =
+                        kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens, max_reuse);
                     if (reused < 0) {
                         ++it;
                         continue;
+                    }
+                    if (max_reuse >= 0 && reused != max_reuse) {
+                        // Defensive: the snapshot boundary was probed against
+                        // the cache a moment ago, so this should not happen.
+                        // The restore position no longer matches the reused
+                        // KV prefix — release everything (a full prefill must
+                        // not re-write blocks still shared with other seqs)
+                        // and fall back to plain allocation.
+                        IMP_LOG_WARN(
+                            "Scheduler: hybrid prefix reuse mismatch (reused=%d, snapshot=%d "
+                            "blocks) — full prefill for req %d",
+                            reused, max_reuse, req->id);
+                        req->recurrent_restore.reset();
+                        kv_manager_->free_sequence(req->id);
+                        if (!kv_manager_->allocate_blocks(req->id, blocks_needed)) {
+                            ++it;
+                            continue;
+                        }
+                        reused = 0;
                     }
                     // Skip prefill for tokens covered by reused blocks.
                     if (reused > 0) {

--- a/src/runtime/scheduler.h
+++ b/src/runtime/scheduler.h
@@ -3,6 +3,7 @@
 #include "runtime/request.h"
 #include <vector>
 #include <deque>
+#include <functional>
 #include <memory>
 
 namespace imp {
@@ -26,12 +27,22 @@ public:
     // Memory-aware scheduling: set KV cache manager to check budget
     void set_kv_manager(KVCacheManager* mgr) { kv_manager_ = mgr; }
 
+    // Hybrid (SSM/GDN) prefix caching: cap on reusable prefix blocks for a
+    // request being admitted. The engine's hook finds the longest recurrent-
+    // state snapshot matching the prompt, attaches it to the request, and
+    // returns its block boundary (0 = no restorable prefix, so no KV reuse
+    // — skipping prefill without the matching recurrent state would decode
+    // from a zero state). Unset (dense models) = unlimited reuse.
+    using PrefixReuseLimitFn = std::function<int(Request&)>;
+    void set_prefix_reuse_limit(PrefixReuseLimitFn fn) { prefix_reuse_limit_ = std::move(fn); }
+
 private:
     int max_batch_size_;
     bool pending_dirty_ = false;
     std::deque<std::shared_ptr<Request>> pending_;
     std::vector<std::shared_ptr<Request>> active_;
     KVCacheManager* kv_manager_ = nullptr;  // optional, for memory-aware scheduling
+    PrefixReuseLimitFn prefix_reuse_limit_;  // optional, hybrid snapshot boundary
 };
 
 }  // namespace imp

--- a/tests/api/test_concurrency.py
+++ b/tests/api/test_concurrency.py
@@ -129,6 +129,66 @@ class TestConcurrentRequests:
             assert has_done, f"Stream {i} missing [DONE] sentinel"
 
 
+class TestDecodeFairness:
+    def test_second_stream_progresses_before_first_finishes(self, model, is_mock):
+        """Two long concurrent streams must interleave: the second request has
+        to produce its first token BEFORE the first request finishes.
+
+        Dense models decode batched, so this holds trivially. Hybrid (SSM/GDN)
+        models decode one sequence per step — before the quantum rotation
+        (runtime.hybrid_decode_quantum) the head request ran to completion
+        while the second starved (FIFO head-of-line). This is the regression
+        test for that rotation.
+        """
+        if is_mock:
+            pytest.skip("mock server responds instantly — no decode to interleave")
+
+        import threading
+        import time
+
+        events = []  # (timestamp, stream_id, kind)
+        events_lock = threading.Lock()
+
+        def stream_request(i):
+            first_token_seen = False
+            with httpx.Client(base_url=conftest.BASE_URL, timeout=300.0) as c:
+                with c.stream("POST", "/v1/chat/completions", json={
+                    "model": model,
+                    "messages": [{"role": "user",
+                                  "content": f"Write a long story about journey {i}."}],
+                    "max_tokens": 400,
+                    "temperature": 0,
+                    "seed": i,
+                    "stream": True,
+                }) as r:
+                    assert r.status_code == 200
+                    for line in r.iter_lines():
+                        if not line.startswith("data: ") or line == "data: [DONE]":
+                            continue
+                        chunk = json.loads(line[len("data: "):])
+                        delta = chunk.get("choices", [{}])[0].get("delta", {})
+                        if delta.get("content") and not first_token_seen:
+                            first_token_seen = True
+                            with events_lock:
+                                events.append((time.monotonic(), i, "first_token"))
+            with events_lock:
+                events.append((time.monotonic(), i, "finished"))
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            f0 = pool.submit(stream_request, 0)
+            time.sleep(0.5)  # let request 0 reach decode before 1 arrives
+            f1 = pool.submit(stream_request, 1)
+            f0.result()
+            f1.result()
+
+        by_kind = {(sid, kind): t for t, sid, kind in events}
+        assert (1, "first_token") in by_kind, "second stream never produced a token"
+        assert by_kind[(1, "first_token")] < by_kind[(0, "finished")], (
+            "second stream got its first token only after the first request "
+            "finished — hybrid decode is serializing head-of-line (rotation broken)"
+        )
+
+
 class TestConstrainedUnderConcurrency:
     def test_json_schema_enforced_while_sharing_decode_batch(self, model, is_mock):
         """A json_schema request that decodes concurrently with other requests

--- a/tests/test_prefix_cache_e2e.cpp
+++ b/tests/test_prefix_cache_e2e.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 #include "imp/imp.h"
+#include "api/imp_internal.h"
 #include "test_models.h"
 
 #include <cstdlib>
@@ -153,6 +154,16 @@ TEST_F(PrefixCacheE2ETest, FreshVsPrefixHitTokenEqual) {
 //    output for the same greedy request. This pins the cache path to the
 //    canonical fresh-prefill result, not merely to "self-consistent".
 TEST_F(PrefixCacheE2ETest, PrefixCacheMatchesNoCacheBaseline) {
+    // Hybrid (SSM/GDN) models: with caching ON, prefill ends a chunk at the
+    // recurrent-snapshot boundary; with caching OFF it does not. Different
+    // chunk boundaries change accumulation order, so cross-CONFIG bitwise
+    // equality is unattainable by design (chunked-vs-unchunked prefill was
+    // never bit-equal). The hit==fresh guarantee for hybrids is tests 1+3,
+    // where both runs share the same boundary.
+    if (model_ && model_->model && model_->model->config().ssm_inner_size > 0)
+        GTEST_SKIP() << "recurrent model: snapshot chunk boundary makes cache-on/off "
+                        "prefill chunking differ — bitwise cross-config equality N/A";
+
     // Baseline: caching OFF.
     MakeContext(/*prefix_cache=*/false);
     std::string baseline = gen(kPrompt, kGen);

--- a/tests/test_prefix_cache_equiv.cpp
+++ b/tests/test_prefix_cache_equiv.cpp
@@ -323,5 +323,94 @@ TEST(PrefixEquivTest, NonAlignedPrefixReusesFullBlocksOnly) {
     mgr->free_sequence(1);
 }
 
+// ── (8) chain hole must not count as reused prefix ────────────────────────
+// LRU eviction removes cached blocks front-first, so an EARLY block of a
+// cached chain can be gone while LATER chain blocks survive. Reuse must stop
+// at the first miss: counting later hits would make the caller skip prefill
+// across a hole with uncomputed KV (silent garbage attention reads).
+TEST(PrefixEquivTest, ChainHoleStopsReuse) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+
+    std::vector<int32_t> tokens(48);  // 3 full blocks
+    std::iota(tokens.begin(), tokens.end(), 42);
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens), 0);
+    mgr->register_block_hashes(0, tokens);
+    mgr->free_sequence(0);
+    ASSERT_EQ(mgr->num_cached_blocks(), 3);
+
+    // Evict exactly ONE cached block — LRU head = block 0 of the chain
+    // (free_sequence pushes blocks to the cached-LRU in table order).
+    ASSERT_TRUE(mgr->evict_cached_block());
+    ASSERT_EQ(mgr->num_cached_blocks(), 2);
+
+    // Blocks 1 and 2 of the chain still sit in the hash table, but the
+    // prefix is broken at block 0 — nothing may be reused.
+    int reused = mgr->allocate_blocks_with_prefix(1, tokens);
+    EXPECT_EQ(reused, 0) << "hole in the chain counted as reused prefix — "
+                            "caller would skip prefill over uncomputed KV";
+    mgr->free_sequence(1);
+}
+
+// ── (9) max_reuse_blocks caps reuse (hybrid snapshot boundary) ────────────
+// Hybrid models can only skip prefill up to the recurrent-snapshot position;
+// blocks past the cap must be freshly allocated (never shared), because the
+// continuation prefill will WRITE them.
+TEST(PrefixEquivTest, MaxReuseBlocksCapsSharing) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+    KVCache* c = mgr->kv_cache();
+
+    std::vector<int32_t> tokens(48);  // 3 full blocks
+    std::iota(tokens.begin(), tokens.end(), 7000);
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens), 0);
+    const std::vector<int> blocks_a = mgr->block_table(0);
+    mgr->register_block_hashes(0, tokens);
+    mgr->free_sequence(0);
+
+    int reused = mgr->allocate_blocks_with_prefix(1, tokens, /*max_reuse_blocks=*/1);
+    EXPECT_EQ(reused, 1);
+    const std::vector<int>& blocks_b = mgr->block_table(1);
+    ASSERT_EQ(blocks_b.size(), 3u);
+    EXPECT_EQ(blocks_b[0], blocks_a[0]) << "block below the cap must be the shared cached block";
+    // Blocks past the cap are fresh allocations the continuation prefill may
+    // write — they must not alias the cached chain blocks.
+    EXPECT_NE(blocks_b[1], blocks_a[1]);
+    EXPECT_NE(blocks_b[2], blocks_a[2]);
+    EXPECT_EQ(c->ref_count(blocks_b[1]), 1);
+    mgr->free_sequence(1);
+}
+
+// ── (10) longest_cached_prefix_blocks probe ───────────────────────────────
+// Read-only probe used by the hybrid snapshot lookup: reports the contiguous
+// cached chain length without allocating, and fills the per-block chain
+// hashes for all full blocks.
+TEST(PrefixEquivTest, LongestCachedPrefixProbe) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+
+    std::vector<int32_t> tokens(40);  // 2 full blocks + partial
+    std::iota(tokens.begin(), tokens.end(), 123);
+
+    std::vector<size_t> hashes;
+    EXPECT_EQ(mgr->longest_cached_prefix_blocks(tokens, hashes), 0);
+    EXPECT_EQ(hashes.size(), 2u) << "hashes cover all FULL blocks regardless of cache state";
+
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens), 0);
+    mgr->register_block_hashes(0, tokens);
+    mgr->free_sequence(0);
+
+    EXPECT_EQ(mgr->longest_cached_prefix_blocks(tokens, hashes), 2);
+    // Probe must not have allocated anything.
+    EXPECT_EQ(mgr->num_cached_blocks(), 2);
+
+    // Break the chain at block 0 → probe reports 0 despite block 1 cached.
+    ASSERT_TRUE(mgr->evict_cached_block());
+    EXPECT_EQ(mgr->longest_cached_prefix_blocks(tokens, hashes), 0);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_recurrent_snapshot_store.cpp
+++ b/tests/test_recurrent_snapshot_store.cpp
@@ -1,0 +1,132 @@
+// RecurrentSnapshotStore — hybrid (SSM/GDN) prefix-cache snapshots.
+//
+// The store is plain LRU bookkeeping over fixed-size device buffers; what
+// needs guarding is the lifetime contract: an entry handed out to a request
+// (shared_ptr) must keep its device buffer valid across eviction, and the
+// buffer must be recycled — not leaked — once the holder releases it.
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+
+#include "memory/recurrent_snapshot_store.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "test_cuda_skip.h"
+
+namespace imp {
+namespace {
+
+constexpr size_t kEntryBytes = 4096;
+
+// Device buffer filled with a marker byte, for save() sources.
+struct DeviceSrc {
+    void* d = nullptr;
+    explicit DeviceSrc(uint8_t marker) {
+        EXPECT_EQ(cudaMalloc(&d, kEntryBytes), cudaSuccess);
+        std::vector<uint8_t> h(kEntryBytes, marker);
+        EXPECT_EQ(cudaMemcpy(d, h.data(), kEntryBytes, cudaMemcpyHostToDevice), cudaSuccess);
+    }
+    ~DeviceSrc() { cudaFree(d); }
+};
+
+static std::vector<uint8_t> ReadEntry(const RecurrentSnapshotEntry& e) {
+    std::vector<uint8_t> h(kEntryBytes);
+    EXPECT_EQ(cudaMemcpy(h.data(), e.data, kEntryBytes, cudaMemcpyDeviceToHost), cudaSuccess);
+    return h;
+}
+
+TEST(RecurrentSnapshotStoreTest, SaveFindRoundTrip) {
+    SKIP_IF_NO_CUDA();
+    RecurrentSnapshotStore store;
+    store.init(kEntryBytes, 4 * kEntryBytes);
+    ASSERT_TRUE(store.enabled());
+    ASSERT_EQ(store.capacity(), 4);
+
+    DeviceSrc src(0xAB);
+    ASSERT_TRUE(store.save(/*key=*/111, /*n_tokens=*/32, src.d, /*stream=*/nullptr));
+    cudaStreamSynchronize(nullptr);
+
+    auto e = store.find(111);
+    ASSERT_NE(e, nullptr);
+    EXPECT_EQ(e->n_tokens, 32);
+    EXPECT_EQ(ReadEntry(*e), std::vector<uint8_t>(kEntryBytes, 0xAB));
+    EXPECT_EQ(store.find(222), nullptr);
+
+    // Duplicate key: no-op success (identical prefix already snapshotted).
+    DeviceSrc other(0xCD);
+    EXPECT_TRUE(store.save(111, 32, other.d, nullptr));
+    cudaStreamSynchronize(nullptr);
+    EXPECT_EQ(ReadEntry(*store.find(111)), std::vector<uint8_t>(kEntryBytes, 0xAB))
+        << "duplicate save must not overwrite the stored snapshot";
+}
+
+TEST(RecurrentSnapshotStoreTest, LRUEvictionAtCapacity) {
+    SKIP_IF_NO_CUDA();
+    RecurrentSnapshotStore store;
+    store.init(kEntryBytes, 2 * kEntryBytes);  // capacity 2
+    ASSERT_EQ(store.capacity(), 2);
+
+    DeviceSrc a(0x01), b(0x02), c(0x03);
+    ASSERT_TRUE(store.save(1, 16, a.d, nullptr));
+    ASSERT_TRUE(store.save(2, 16, b.d, nullptr));
+    // Touch key 1 → key 2 becomes LRU.
+    ASSERT_NE(store.find(1), nullptr);
+    ASSERT_TRUE(store.save(3, 16, c.d, nullptr));
+    cudaStreamSynchronize(nullptr);
+
+    EXPECT_EQ(store.find(2), nullptr) << "LRU entry must have been evicted";
+    ASSERT_NE(store.find(1), nullptr);
+    ASSERT_NE(store.find(3), nullptr);
+    EXPECT_EQ(store.size(), 2);
+    EXPECT_EQ(ReadEntry(*store.find(3)), std::vector<uint8_t>(kEntryBytes, 0x03));
+}
+
+TEST(RecurrentSnapshotStoreTest, HeldEntrySurvivesEvictionThenRecycles) {
+    SKIP_IF_NO_CUDA();
+    RecurrentSnapshotStore store;
+    store.init(kEntryBytes, kEntryBytes);  // capacity 1
+    ASSERT_EQ(store.capacity(), 1);
+
+    DeviceSrc a(0x11), b(0x22);
+    ASSERT_TRUE(store.save(1, 16, a.d, nullptr));
+    auto held = store.find(1);  // request holds the entry across eviction
+    ASSERT_NE(held, nullptr);
+
+    // Capacity 1 + buffer held: the save must fail (no buffer available),
+    // and the held entry must stay intact — never overwritten in place.
+    EXPECT_FALSE(store.save(2, 16, b.d, nullptr));
+    cudaStreamSynchronize(nullptr);
+    EXPECT_EQ(ReadEntry(*held), std::vector<uint8_t>(kEntryBytes, 0x11));
+
+    // Release → buffer recycles → the next save succeeds.
+    held.reset();
+    EXPECT_TRUE(store.save(2, 16, b.d, nullptr));
+    cudaStreamSynchronize(nullptr);
+    auto e2 = store.find(2);
+    ASSERT_NE(e2, nullptr);
+    EXPECT_EQ(ReadEntry(*e2), std::vector<uint8_t>(kEntryBytes, 0x22));
+}
+
+TEST(RecurrentSnapshotStoreTest, ClearDropsEntriesButHeldBufferStaysValid) {
+    SKIP_IF_NO_CUDA();
+    RecurrentSnapshotStore store;
+    store.init(kEntryBytes, 2 * kEntryBytes);
+
+    DeviceSrc a(0x33);
+    ASSERT_TRUE(store.save(7, 48, a.d, nullptr));
+    auto held = store.find(7);
+    ASSERT_NE(held, nullptr);
+
+    store.clear();
+    EXPECT_EQ(store.find(7), nullptr);
+    EXPECT_EQ(store.size(), 0);
+    cudaStreamSynchronize(nullptr);
+    EXPECT_EQ(ReadEntry(*held), std::vector<uint8_t>(kEntryBytes, 0x33))
+        << "held entry must stay valid after clear()";
+    held.reset();  // recycles into the pool, freed by the store dtor
+}
+
+}  // namespace
+}  // namespace imp

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -33,6 +33,16 @@ int main(int argc, char** argv) {
                 user_set = true;
         if (!user_set)
             runtime_cfg.speculative.moe = false;
+        // Recurrent snapshots (hybrid prefix caching) are dead weight in the
+        // single-shot bench but their eager buffers shift the MoE expert
+        // offload budget — pin them off so hybrid GGUF baselines are
+        // unaffected. An explicit --set server.recurrent_snapshot_mb=… wins.
+        bool snap_set = false;
+        for (const auto& ov : args.config_overrides)
+            if (ov.rfind("server.recurrent_snapshot_mb", 0) == 0)
+                snap_set = true;
+        if (!snap_set)
+            runtime_cfg.server.recurrent_snapshot_mb = 0;
     }
     // Cache the few diagnostic / runtime-mode flags that are read from free
     // functions (kernel diagnostics, CUDA-graph capture mode, PDL gate)


### PR DESCRIPTION
# feat(hybrid): prefix caching via recurrent-state snapshots + decode fairness rotation

Two agentic-serving gaps for hybrid (SSM/GDN) models — Qwen3.5/3.6, Nemotron-H:

1. **Prefix caching was disabled entirely** for `ssm_inner_size > 0` (`engine_kv_cache_init.cpp`), so every multi-turn request re-prefilled the full conversation history from scratch (Qwen3.6 agent sessions pay O(history) TTFT per turn).
2. **Concurrent decode serialized head-of-line**: the SSM/GDN batch-1 clamp kept `decode_batch[0]` every step, so a second session produced its first token only after the first request ran to completion.

## 1. Recurrent-state snapshots (`src/memory/recurrent_snapshot_store.{h,cpp}`)

KV block reuse alone cannot skip prefill for a recurrent model — the recurrent state at the skip boundary would be zero. The engine now:

- ends a prefill chunk at the **largest block-aligned prompt position** and snapshots the per-sequence SSM/GDN state slab there (one D2D copy, keyed by the chained KV block hash — same identity as the block prefix cache);
- on admission, probes the longest cached KV chain with a matching snapshot, **caps KV block reuse exactly at that boundary** (blocks past it are freshly allocated, so continuation prefill never re-writes shared blocks), and restores the snapshot into the request's state slot instead of zeroing;
- multi-turn requests therefore prefill only the delta (previous reply + new message + ≤15-token tail) instead of the whole history.

Store: device-side LRU, `server.recurrent_snapshot_mb` budget (default 256 MiB = 4 Qwen3.6-35B slots / 10 Nemotron slots). Buffers are **pre-allocated at engine init** and accounted in the expert-offload reserve — at serving time free VRAM is ~0 by design (weight caches, KV clamp, mempool), so lazy allocation would never get a byte on tight models (measured: 48 MiB free on Qwen3.6-35B @12k). `imp-cli --bench` pins the budget to 0 so hybrid GGUF baselines keep their expert-offload budget (mirrors the `speculative.moe` pin). Entries are handed to requests as shared_ptr, so eviction can never recycle a buffer under an in-flight restore. `imp_context_reset` clears the store alongside the block eviction (bench reps stay honest). Chunk-boundary consistency: every run splits at the snapshot position, so a restore-continuation is **bit-identical** to the fresh prefill that saved it (greedy hit == fresh, verified e2e on Qwen3.5-4B GDN).

The snapshot-boundary chunk runs eager (excluded from prefill-graph capture): its request-dependent odd shape churned the graph and the odd-M cuBLAS call lazily allocates workspace — illegal under capture (cublasLt status 14 cascade, observed on GGUF mxfp4 GDN).

Also fixes a latent prefix-cache bug (dense too): **reuse now stops at the first non-cached block**. LRU eviction can remove an early chain block while later ones survive; the old code counted those later hits as "reused prefix", making the caller skip prefill across a hole with uncomputed KV.

## 2. Hybrid decode fairness (`runtime.hybrid_decode_quantum`, default 128)

`resize(1)` becomes a round-robin rotation: the slice holder decodes `hybrid_decode_quantum` tokens, then the next DECODING request (cyclic id order) takes the slot. Async graph-loop bursts are bounded to the slice remainder so rotation actually runs. Rotation re-captures the decode graphs for the new sequence's state slot (~10-20 ms per rotation, ~1-2% at 128). `0` restores the old head-of-line behavior.

This also fixes a latent stale-pointer bug: the decode graph pool bakes the recurrent state pointers of the captured slot, but overlapping request lifetimes already produced back-to-back requests in different slots — replays read/wrote the previous sequence's state. The pool now invalidates (graph-exec update) whenever the batch-1 recurrent slot changes.

## Tests

- `test_prefix_cache_equiv.cpp`: +3 (chain-hole must not count, `max_reuse_blocks` cap, `longest_cached_prefix_blocks` probe)
- `test_recurrent_snapshot_store.cpp` (new): round-trip, LRU eviction, held-entry survives eviction + recycles, clear-with-held-entry
- `PrefixCacheE2ETest` on Qwen3.5-4B-mxfp4 (GDN): control PASS, fresh-vs-hit token-equal PASS, shared-prefix+new-suffix stable PASS. Cross-config baseline test now skips for recurrent models (cache-on splits chunks at the snapshot boundary, cache-off doesn't — bitwise cross-config equality is unattainable by design, chunked-vs-unchunked was never bit-equal). All 4 still pass on dense (Qwen3-8B-Q8_0).
- `tests/api/test_concurrency.py::TestDecodeFairness`: second concurrent stream must produce a token before the first finishes (regression test for the rotation).
- Full `make test-gpu`: green. Degeneration + measurements below.

Pre-existing, unrelated: #830 (IMA at second-engine init on the same loaded GDN mxfp4 model — reproduces on clean main).

## Measurements (RTX 5090, imp-server, `--set runtime.max_seq_len=12288`)

**Multi-turn TTFT, Qwen3.6-35B-A3B-NVFP4** — 6 turns, ~2k tokens added per turn, full history re-sent each turn (standard OpenAI-API agent pattern):

| Turn (history) | main | this PR | cached_tokens |
|---|---|---|---|
| 1 (fresh) | 1.62 s | 1.89 s | — |
| 2 (~2k) | 2.85 s | 1.41 s | 2016 |
| 3 (~4k) | 3.08 s | 1.55 s | 4064 |
| 4 (~6k) | 4.31 s | 1.40 s | 6080 |
| 5 (~8k) | 5.68 s | 1.51 s | 8128 |
| 6 (~10k) | 6.70 s | **1.94 s (3.5×)** | 10176 |

main grows linearly with history (full re-prefill); this PR is flat — the gap keeps growing with context length. `usage.prompt_tokens_details.cached_tokens` now reports hybrid cache hits (Anthropic `cache_read_input_tokens` too).

**Nemotron-3-Nano-30B (pure SSM, CUDA graphs off)**: TTFT flat at ~0.22 s across 5 turns (turn 1: 0.34 s), snapshots active, focused degen probes (repetition / long-context / multi-turn) 0 FAIL.

**Decode fairness, Qwen3.6-35B, two concurrent 400-token streams**: on main the second stream's first token arrived 6.6 s AFTER the first request had fully finished (head-of-line starvation, `TestDecodeFairness` FAILS); with rotation the second stream produces tokens while the first is mid-generation (test PASSES).

**Quality**: full `tools/analysis/degen_suite.py --skip-deterministic` against the Qwen3.6-35B server: 33 checks, 0 FAIL. `make test-gpu` green; `make verify-fast` green (north-star dense perf gate untouched — decode paths and `--bench` semantics are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz4AjAECTf9WVEjM2PXPER
