### PR TITLE
fix(load): reject encoder-only models on the HF path + second engine on a consumed model (#818, #830)

### DIFF
--- a/src/exec/pre_dequant_phase3_cutlass.cu
+++ b/src/exec/pre_dequant_phase3_cutlass.cu
@@ -366,6 +366,11 @@ if (mx_native > 0) {
     IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
     wcache_->cutlass_mxfp4_bytes += mx_native_bytes;
     wcache_->use_mxfp4 = true;
+    // unpack_mxfp4_gguf compacts the GGUF raw blocks IN PLACE inside the
+    // model's source buffers — a second engine on this model handle cannot
+    // re-run the unpack (it would read the already-compacted layout as raw
+    // blocks → illegal access, #830). Engine::init rejects it up front.
+    const_cast<Model*>(model_)->mark_sources_consumed();
     IMP_LOG_INFO("Native MXFP4 GGUF: %d tensors, %.2f MiB (direct → CUTLASS)", mx_native,
                  mx_native_bytes / (1024.0 * 1024.0));
 

--- a/src/exec/pre_dequant_phase3c_mxfp4.cu
+++ b/src/exec/pre_dequant_phase3c_mxfp4.cu
@@ -120,6 +120,11 @@ void QuantPipeline::pre_dequant_phase3c_standalone_mxfp4_(
                             if (it != wcache_->fp16.end() && qt == QType::MXFP4) {
                                 w = it->second;
                                 qt = QType::F16;
+                                // The model tensor now points at EXECUTOR-owned
+                                // cache memory (fp16_bulk_data) — a second
+                                // engine on this handle would read it dangling
+                                // after this executor's teardown (#830).
+                                const_cast<Model*>(model_)->mark_sources_consumed();
                             }
                         };
                         replace(L.gdn_alpha, L.gdn_alpha.qtype);
@@ -169,6 +174,13 @@ void QuantPipeline::pre_dequant_phase3c_standalone_mxfp4_(
             // SAME buffer. No separate data allocation, no free needed.
             // The raw buffer tail (scale bytes) is wasted (~6% overhead) but
             // avoids the 50% peak VRAM spike of out-of-place unpack.
+            //
+            // The compaction is DESTRUCTIVE: the model's source buffers no
+            // longer hold GGUF raw MXFP4 blocks, so a second engine on this
+            // model handle cannot re-run this unpack (it would read the
+            // already-compacted layout as raw blocks → illegal access, #830).
+            // Mark the model so Engine::init rejects a second engine cleanly.
+            const_cast<Model*>(model_)->mark_sources_consumed();
             IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
             {
                 cudaError_t e = cudaGetLastError();

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -597,6 +597,9 @@ void QuantPipeline::pre_dequant_phase4b_drop_redundant_sources_(
         try_mark(mut_model->tok_emb_, mut_model->tok_emb_id);
 
     if (marked_count > 0) {
+        // Source tensors are now freed (their .data is dangling). release_gpu_-
+        // allocation() above already flagged the model as sources-consumed so a
+        // second engine on this handle is rejected up front (#830).
         IMP_LOG_INFO(
             "Phase-4b drop-source: %s %zu sources (%.2f MiB). "
             "Skipped %zu sources (%.2f MiB) that are offsets into shared "

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -77,6 +77,15 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
     // Architecture detection: prefer "architectures" array, fall back to "model_type"
     const JValue* archs = jobj_find(root, "architectures");
     if (archs && archs->type == JType::ARRAY && !archs->arr.empty()) {
+        // Encoder-only (BERT/RoBERTa/embedding) models have no causal LM head and
+        // need pooling — the GGUF loader already rejects them at load; the
+        // SafeTensors/HF path must too, or a `NomicBertModel` falls through to
+        // the generic decoder and hits a CUDA IMA on the first request (#818).
+        if (is_encoder_only_arch(archs->arr[0].str_val)) {
+            throw std::runtime_error("encoder-only architecture '" + archs->arr[0].str_val +
+                                     "' is not supported (imp runs causal decoder LMs; "
+                                     "embedding encoders need pooling support)");
+        }
         cfg.arch = map_architecture(archs->arr[0].str_val);
         if (archs->arr.size() > 1) {
             std::string dropped;
@@ -93,6 +102,13 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
         // Fallback: map model_type string to arch
         std::string model_type;
         if (jobj_get_string(root, "model_type", model_type)) {
+            // Same encoder-only reject on the model_type path (e.g. a config with
+            // only `"model_type": "nomic_bert"` and no `architectures` array).
+            if (is_encoder_only_arch(model_type)) {
+                throw std::runtime_error("encoder-only model_type '" + model_type +
+                                         "' is not supported (imp runs causal decoder LMs; "
+                                         "embedding encoders need pooling support)");
+            }
             // Common model_type values → architecture class names
             static const std::unordered_map<std::string, std::string> type_to_class = {
                 {"llama", "LlamaForCausalLM"},

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -3,6 +3,7 @@
 #include "core/logging.h"
 #include <cuda_runtime.h>
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <unordered_map>
@@ -67,6 +68,12 @@ void Model::release_gpu_allocation(void* ptr) {
     auto it = std::find(gpu_allocations_.begin(), gpu_allocations_.end(), ptr);
     if (it != gpu_allocations_.end()) {
         gpu_allocations_.erase(it);
+        // Every caller releases a source weight tensor it is about to cudaFree
+        // (Phase-3 MoE expert-source drop, Phase-4b redundant-source drop). Once
+        // a source is freed the model can no longer rebuild caches for a SECOND
+        // engine on this handle — mark it so Engine::init rejects that cleanly
+        // instead of reading freed memory and poisoning the CUDA context (#830).
+        sources_consumed_ = true;
     }
 }
 
@@ -268,14 +275,23 @@ ModelArch parse_model_arch(const std::string& s) {
 }
 
 bool is_encoder_only_arch(const std::string& s) {
-    // llama.cpp GGUF arch ids for BERT-style encoders: "bert", "nomic-bert",
-    // "nomic-bert-moe", "jina-bert-v2"/"-v3", "modern-bert", "roberta-bert" —
-    // bge/e5 checkpoints ship one of these. Substring match covers the family
-    // (no decoder arch string contains "bert").
-    if (s.find("bert") != std::string::npos)
+    // Matches BOTH naming conventions: llama.cpp GGUF arch ids (lowercase,
+    // e.g. "nomic-bert", "jina-bert-v2", "roberta") AND HuggingFace config.json
+    // `architectures` class names (CamelCase, e.g. "NomicBertModel",
+    // "BertModel", "XLMRobertaModel", "MPNetModel"). The GGUF path fed lowercase
+    // ids; the SafeTensors/HF path feeds CamelCase, so a case-sensitive
+    // find("bert") missed "NomicBertModel" and let it fall through to the
+    // generic decoder → CUDA IMA on the first request (#818). Lowercase first.
+    std::string l;
+    l.reserve(s.size());
+    for (char c : s)
+        l += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    // No causal-decoder arch name (GGUF id or HF class) contains any of these.
+    if (l.find("bert") != std::string::npos || l.find("roberta") != std::string::npos ||
+        l.find("mpnet") != std::string::npos)
         return true;
-    // Encoder-only T5 + defensive aliases for embedding-model names.
-    return s == "t5encoder" || s == "roberta" || s == "e5" || s == "bge";
+    // Encoder-only T5 + embedding-family aliases (exact ids).
+    return l == "t5encoder" || l == "e5" || l == "bge";
 }
 
 void apply_arch_defaults(ModelConfig& cfg) {

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -51,6 +51,23 @@ public:
 
     bool gpu_weights_ready() const { return gpu_weights_ready_; }
 
+    // True once the executor's pre-dequant consumed source weights in a way a
+    // rebuild cannot survive:
+    //  - freed source tensors to reclaim VRAM (Phase-3 MoE expert-source drop,
+    //    Phase-4b redundant-source drop — both via release_gpu_allocation(),
+    //    which sets this): their .data pointers are dangling afterwards;
+    //  - destructively converted sources in place (Phase-3c MXFP4 unpack
+    //    compacts the GGUF raw blocks within the SAME buffer) or re-pointed
+    //    model tensors at executor-owned cache memory (Phase-3c gdn_alpha/beta
+    //    FP16 replace) — sets this explicitly via mark_sources_consumed().
+    // Either way a SECOND engine on the same model handle would read freed or
+    // already-transformed memory and poison the CUDA context with an illegal
+    // access (#830) — Engine::init rejects it up front. Reload the model for a
+    // fresh engine. Models whose sources stay intact (e.g. dense Q8_0) leave
+    // this false and support create/free/create on one handle.
+    void mark_sources_consumed() { sources_consumed_ = true; }
+    bool sources_consumed() const { return sources_consumed_; }
+
     // Remove a pointer from gpu_allocations_ tracking (does not free).
     void release_gpu_allocation(void* ptr);
 
@@ -96,6 +113,7 @@ public:
     std::vector<std::pair<void*, size_t>> split_mmaps_;  // additional shard mmaps
 
     bool gpu_weights_ready_ = false;
+    bool sources_consumed_ = false;  // Phase-4b freed source tensors (#830)
     std::vector<void*> gpu_allocations_;
     std::vector<void*> host_pinned_;         // mmap regions pinned via cudaHostRegister
     std::vector<void*> host_pinned_allocs_;  // cudaHostAlloc'd expert buffers (WSL2 DMA path)

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -524,6 +524,21 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     if (!model)
         return false;
 
+    // A previous engine on this same model handle freed the model's source
+    // weight tensors to reclaim VRAM (Phase-4b drop); their .data pointers are
+    // dangling now, so rebuilding this engine's weight caches would read freed
+    // memory and poison the CUDA context with an illegal access (#830). Reject
+    // up front with a clear error. Reload the model for a second engine. (Dense
+    // models that never drop sources are unaffected — create/free/create works.)
+    if (model->sources_consumed()) {
+        IMP_LOG_ERROR(
+            "Engine::init: this model handle was already bound to an engine whose "
+            "weight caches consumed (freed) the model's source tensors — a second "
+            "engine cannot be built on it. Reload the model (imp_model_load) to "
+            "create another engine.");
+        return false;
+    }
+
     model_ = std::move(model);
     config_ = config;
 

--- a/tests/test_engine_relaunch.cpp
+++ b/tests/test_engine_relaunch.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include "imp/imp.h"
+#include "api/imp_internal.h"
 #include "test_models.h"
 
 #include <cuda_runtime.h>
@@ -113,5 +114,86 @@ TEST(EngineRelaunchTest, ReloadAfterInferenceReleasesVramAndDoesNotCrash) {
 
     // Re-init after inference: before the prewarm stream-rebind fix this
     // segfaulted (dangling stream on the global attention-cuBLAS handle).
+    run_one_cycle(get_model_path());
+}
+
+// #830: a SECOND engine on the SAME model handle (load once, create/free/create
+// context) must not CUDA-IMA. Some models free their source weight tensors for
+// VRAM during the first engine's pre-dequant (Phase-4b), leaving dangling
+// pointers a second build would read. The engine now rejects that up front
+// (clean error), while models that never drop sources (dense Q8_0) still support
+// create/free/create. Either outcome is acceptable here — the invariant is "no
+// illegal access / no crash", and the process stays usable afterward.
+TEST(EngineRelaunchTest, SecondEngineOnSameModelHandleNeverIMAs) {
+    SKIP_IF_NO_MODEL();
+
+    ImpModel model = nullptr;
+    ASSERT_EQ(imp_model_load(get_model_path(), IMP_FORMAT_GGUF, &model), IMP_SUCCESS);
+
+    // Lifecycle diagnostic (#830): dump the model's key tensor pointers/qtypes
+    // at each phase so a mutation by engine #1 (which engine #2 then reads as
+    // dangling) shows up as a diff in the test log.
+    auto dump_state = [&](const char* tag) {
+        imp::Model* m = model->model.get();
+        fprintf(stderr,
+                "[TENSORDUMP %s] tok_emb{d=%p q=%d sc=%p dev=%d} out_proj{d=%p q=%d sc=%p} "
+                "allocs=%zu consumed=%d\n",
+                tag, m->tok_emb_.data, (int)m->tok_emb_.qtype, m->tok_emb_.scales,
+                (int)m->tok_emb_.on_device, m->out_proj_.data, (int)m->out_proj_.qtype,
+                m->out_proj_.scales, m->gpu_allocations_.size(), (int)m->sources_consumed());
+        for (int i = 0; i < 2 && i < m->n_layers(); ++i) {
+            const auto& L = m->layer(i);
+            fprintf(stderr,
+                    "[TENSORDUMP %s] L%d wq{d=%p q=%d sc=%p} w_gate{d=%p q=%d sc=%p} "
+                    "w_up{d=%p q=%d} ssm_in{d=%p q=%d sc=%p} ssm_out{d=%p q=%d}\n",
+                    tag, i, L.wq.data, (int)L.wq.qtype, L.wq.scales, L.w_gate.data,
+                    (int)L.w_gate.qtype, L.w_gate.scales, L.w_up.data, (int)L.w_up.qtype,
+                    L.ssm_in.data, (int)L.ssm_in.qtype, L.ssm_in.scales, L.ssm_out.data,
+                    (int)L.ssm_out.qtype);
+        }
+    };
+    dump_state("post-load");
+
+    ImpConfig config = imp_config_default();
+    config.max_seq_len = 1024;
+    config.max_batch_size = 1;
+
+    ImpGenerateParams params = imp_generate_params_default();
+    params.seed = 42;
+    params.max_tokens = 8;
+    params.temperature = 0.7f;
+    params.apply_chat_template = 1;
+
+    // First engine on the handle: create, generate, free.
+    ImpContext ctx1 = nullptr;
+    ASSERT_EQ(imp_context_create(model, &config, &ctx1), IMP_SUCCESS);
+    dump_state("post-ctx1-init");
+    char buf1[1024] = {};
+    size_t n1 = 0;
+    EXPECT_EQ(imp_generate(ctx1, "Say hi.", &params, buf1, sizeof(buf1), &n1), IMP_SUCCESS);
+    EXPECT_GT(n1, 0u);
+    imp_context_free(ctx1);
+    dump_state("post-ctx1-free");
+
+    // Second engine on the SAME handle. Must return cleanly — success or a
+    // plain error — never an illegal memory access.
+    ImpContext ctx2 = nullptr;
+    ImpError err = imp_context_create(model, &config, &ctx2);
+    if (err == IMP_SUCCESS) {
+        // Accepted (sources not dropped) → it must actually work.
+        ASSERT_NE(ctx2, nullptr);
+        char buf2[1024] = {};
+        size_t n2 = 0;
+        EXPECT_EQ(imp_generate(ctx2, "Say hi.", &params, buf2, sizeof(buf2), &n2), IMP_SUCCESS);
+        EXPECT_GT(n2, 0u);
+        imp_context_free(ctx2);
+    } else {
+        // Rejected (sources consumed) → clean error, no context handed out.
+        EXPECT_EQ(ctx2, nullptr);
+    }
+
+    // The process must still be usable: a freshly LOADED model works regardless
+    // of which branch above ran (proves the CUDA context was not poisoned).
+    imp_model_free(model);
     run_one_cycle(get_model_path());
 }

--- a/tests/test_gguf_loader.cpp
+++ b/tests/test_gguf_loader.cpp
@@ -170,8 +170,21 @@ TEST(GgufLoaderTest, EncoderOnlyArchDetection) {
     EXPECT_TRUE(is_encoder_only_arch("t5encoder"));
     EXPECT_TRUE(is_encoder_only_arch("e5"));
     EXPECT_TRUE(is_encoder_only_arch("bge"));
-    // Decoder archs must never be rejected.
+    // HuggingFace config.json `architectures` class names (CamelCase) — the
+    // SafeTensors/HF path feeds these, and a case-sensitive find("bert") used
+    // to miss them, letting NomicBertModel fall through to the decoder (#818).
+    EXPECT_TRUE(is_encoder_only_arch("BertModel"));
+    EXPECT_TRUE(is_encoder_only_arch("NomicBertModel"));
+    EXPECT_TRUE(is_encoder_only_arch("BertForMaskedLM"));
+    EXPECT_TRUE(is_encoder_only_arch("RobertaModel"));
+    EXPECT_TRUE(is_encoder_only_arch("XLMRobertaModel"));
+    EXPECT_TRUE(is_encoder_only_arch("MPNetModel"));
+    EXPECT_TRUE(is_encoder_only_arch("nomic_bert"));  // model_type form
+    // Decoder archs must never be rejected (neither GGUF id nor HF class name).
     EXPECT_FALSE(is_encoder_only_arch("llama"));
+    EXPECT_FALSE(is_encoder_only_arch("LlamaForCausalLM"));
+    EXPECT_FALSE(is_encoder_only_arch("Qwen3ForCausalLM"));
+    EXPECT_FALSE(is_encoder_only_arch("Gemma4ForCausalLM"));
     EXPECT_FALSE(is_encoder_only_arch("qwen3"));
     EXPECT_FALSE(is_encoder_only_arch("qwen3moe"));
     EXPECT_FALSE(is_encoder_only_arch("gemma4"));


### PR DESCRIPTION
Fixes the two open load-robustness bugs. Both share the failure shape "loads fine, then CUDA illegal memory access poisons the process" — both now fail loudly and early instead.

## #818 — encoder-only models on the SafeTensors/HF path (Fixes #818)

The GGUF loader already rejects encoder-only archs at load (#820), but two gaps remained:

- **`is_encoder_only_arch` was case-sensitive** (`find("bert")`), so it matched the lowercase GGUF ids (`nomic-bert`) but not the HuggingFace `config.json` class names (`NomicBertModel`, `BertModel`, `XLMRobertaModel`, …). Now lowercases first and also covers `mpnet`.
- **The SafeTensors/HF-config path had no reject at all** — a BERT-family `architectures[0]` (or `model_type`) fell through `map_architecture` to GENERIC and ran the causal-LM prefill + sampler → IMA on the first request. Both the `architectures` and the `model_type` fallback path now throw the same clear error as the GGUF loader.

Verified against the real reproducer: `nomic-embed-text-v1.5.Q8_0.gguf` now fails at load with `encoder-only architecture 'nomic-bert' is not supported (imp runs causal decoder LMs; embedding encoders need pooling support)` instead of IMA'ing on `/v1/embeddings`.

The *feature* half of #818 (actual embedding-model support: encoder forward + pooling on `/v1/embeddings`) is intentionally out of scope — follow-up issue filed.

## #830 — IMA at second-engine init on the same loaded model (Fixes #830)

Root cause (instrumented lifecycle dump in the new test): for GGUF MXFP4 GDN models, the first engine's pre-dequant **destructively consumes the model's source weights** —

- `unpack_mxfp4_gguf` compacts the GGUF raw blocks **in place** inside the model's source buffers, and
- the GDN-forced FP16 fallback **re-points the model weight tensors** (qtype MXFP4→F16) at the executor-owned `fp16_bulk_data`.

After `imp_context_free`, that executor memory is gone but the model tensors still point at it — a second `imp_context_create` on the same handle rebuilt its caches from dangling/transformed memory → sticky IMA that poisons the whole process (and made the *next* context creation return -7).

Fix: `Model::sources_consumed()` — set by every destructive site (`release_gpu_allocation()` for the Phase-3 MoE expert-source and Phase-4b redundant-source drops; explicit marks at the Phase-3/3c in-place MXFP4 unpacks and the gdn_alpha/beta cache re-point). `Engine::init` rejects a second engine on a consumed model with a clear error ("Reload the model to create another engine") instead of reading freed memory. Models whose sources stay intact keep supporting create/free/create on one handle.

## Validation (RTX 5090, local)

| Case | Result |
|---|---|
| nomic-embed GGUF load | clean reject at load (was: healthy + IMA on first request) |
| Qwen3.5-4B-mxfp4 (GDN) create→free→create | clean `Engine::init` reject, **no IMA**, process stays usable (fresh load afterwards works) — new regression test `EngineRelaunchTest.SecondEngineOnSameModelHandleNeverIMAs` PASSES (FAILED with IMA before) |
| Qwen3-8B-Q8_0 create→free→create | still works (no false reject); `PrefixCacheE2ETest` 4/4 (two contexts on one handle) |
| Unit | `GgufLoaderTest` 9/9 incl. new HF CamelCase cases; `make test-unit` 37/37 |
| Gate | `make verify-fast` green |

Pre-existing, found during validation (filed separately, reproduced on clean main): #834 — `EngineRelaunchTest.ReloadAfterInferenceReleasesVramAndDoesNotCrash` VRAM-trim assertion fails (~8.3 GiB retained in the mempool after teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz4AjAECTf9WVEjM2PXPER
