### PR TITLE
fix(vram): free stream-ordered weight allocations with cudaFreeAsync — unload leaked weights-sized VRAM (#834)

### DIFF
--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -38,7 +38,16 @@ void trim_default_mempool() {
     cudaMemPool_t pool = nullptr;
     if (cudaGetDevice(&dev) == cudaSuccess &&
         cudaDeviceGetDefaultMemPool(&pool, dev) == cudaSuccess && pool != nullptr) {
-        cudaMemPoolTrimTo(pool, 0);
+        unsigned long long rsv_before = 0, used_before = 0, rsv_after = 0, used_after = 0;
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv_before);
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &used_before);
+        cudaError_t te = cudaMemPoolTrimTo(pool, 0);
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv_after);
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &used_after);
+        IMP_LOG_INFO("mempool trim: reserved %.0f->%.0f MiB used %.0f->%.0f MiB (rc=%s)",
+                     rsv_before / (1024.0 * 1024.0), rsv_after / (1024.0 * 1024.0),
+                     used_before / (1024.0 * 1024.0), used_after / (1024.0 * 1024.0),
+                     cudaGetErrorString(te));
     }
 }
 

--- a/src/exec/pre_dequant_phase3_moe.cu
+++ b/src/exec/pre_dequant_phase3_moe.cu
@@ -527,7 +527,12 @@ bool QuantPipeline::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
                                                static_cast<size_t>(e) * e_ms;
                                 if (old_sc && mut_model->is_base_gpu_allocation(old_sc)) {
                                     mut_model->release_gpu_allocation(old_sc);
-                                    IMP_CUDA_CHECK_LOG(cudaFree(old_sc));
+                                    // cudaFreeAsync, NOT cudaFree: on this stack a
+                                    // sync free of a stream-ordered allocation
+                                    // returns success without returning the block
+                                    // to the async mempool (#834) — the "freed"
+                                    // VRAM would be phantom.
+                                    IMP_CUDA_CHECK_LOG(cudaFreeAsync(old_sc, stream));
                                     freed += e_ms;
                                 }
                                 w.scales = new_sc;
@@ -687,10 +692,15 @@ bool QuantPipeline::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
             // shared buffer; an unguarded cudaFree on an offset returns "invalid
             // argument" (8415x error flood on Qwen3.6-35B-A3B-NVFP4 — non-fatal but a
             // small leak + log spam). Mirror the line-528 / Phase-4b drop-source guard.
+            // cudaFreeAsync, NOT cudaFree (#834): a sync free of a stream-
+            // ordered allocation returns success without returning the block
+            // to the async mempool on this stack — the freed_bytes would be
+            // phantom. Stream-ordered on `stream` also sequences the frees
+            // behind the copies above without a device sync.
             if (w.data) {
                 if (mut_model->is_base_gpu_allocation(w.data)) {
                     mut_model->release_gpu_allocation(w.data);
-                    IMP_CUDA_CHECK_LOG(cudaFree(w.data));
+                    IMP_CUDA_CHECK_LOG(cudaFreeAsync(w.data, stream));
                     freed_bytes += expert_packed_bytes;
                 }
                 w.data = nullptr;
@@ -699,7 +709,7 @@ bool QuantPipeline::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
             if (w.scales) {
                 if (mut_model->is_base_gpu_allocation(w.scales)) {
                     mut_model->release_gpu_allocation(w.scales);
-                    IMP_CUDA_CHECK_LOG(cudaFree(w.scales));
+                    IMP_CUDA_CHECK_LOG(cudaFreeAsync(w.scales, stream));
                     freed_bytes += expert_ms_bytes;
                 }
                 w.scales = nullptr;

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -16,12 +16,39 @@ namespace imp {
 
 Model::~Model() {
     // Free all GPU-side weight buffers (allocated via cudaMallocAsync).
+    //
+    // #834: these MUST be freed with cudaFreeAsync, not cudaFree. On this
+    // stack (CUDA 13.3 / WSL2) cudaFree on a stream-ordered allocation
+    // returns cudaSuccess but does NOT return the block to the async mempool
+    // — the pool's used counter keeps counting it, cudaMemPoolTrimTo can
+    // reclaim nothing, and every model unload leaks weights-sized VRAM
+    // (~8.3 GiB per Qwen3-8B-Q8_0 cycle; the reload test's cycle-2 audit
+    // showed pool used=16600 MiB > reserved=8320 MiB). cudaFreeAsync on the
+    // legacy stream + a sync retires the frees so the trim in
+    // imp_model_free/imp_context_free actually hands the memory back.
+    //
     // At program exit the CUDA runtime may tear down the default mempool
-    // before this destructor runs, making cudaFree return cudaErrorInvalidValue.
-    // Silently ignore — the driver reclaims all device memory on context destroy.
+    // before this destructor runs, making the frees return an error.
+    // Silently ignore — the driver reclaims all device memory on context
+    // destroy.
+    int free_fail = 0;
+    cudaError_t first_err = cudaSuccess;
     for (void* ptr : gpu_allocations_) {
-        if (ptr)
-            (void)cudaFree(ptr);
+        if (ptr) {
+            cudaError_t e = cudaFreeAsync(ptr, nullptr);
+            if (e != cudaSuccess) {
+                if (free_fail == 0)
+                    first_err = e;
+                free_fail++;
+            }
+        }
+    }
+    if (!gpu_allocations_.empty())
+        (void)cudaStreamSynchronize(nullptr);  // retire the frees for the pool
+    if (free_fail > 0) {
+        IMP_LOG_WARN("Model teardown: %d/%zu weight frees failed (first: %s)", free_fail,
+                     gpu_allocations_.size(), cudaGetErrorString(first_err));
+        (void)cudaGetLastError();  // clear sticky error (e.g. process-exit teardown)
     }
     gpu_allocations_.clear();
 

--- a/tests/test_engine_relaunch.cpp
+++ b/tests/test_engine_relaunch.cpp
@@ -103,14 +103,25 @@ TEST(EngineRelaunchTest, ReloadAfterInferenceReleasesVramAndDoesNotCrash) {
     if (::testing::Test::HasFatalFailure())
         return;
 
-    // Teardown must hand the weights back to the driver, not park them in the
-    // default mempool: the next load sizes itself via cudaMemGetInfo and
-    // uploads through plain-cudaMalloc-visible memory. Allow ~2 GiB slack for
-    // persistent CUDA/cuBLAS context overhead from the first cycle.
+    // Teardown must hand the weights back, not park them in the default
+    // mempool. The trim (imp_model_free → cudaMemPoolTrimTo) verifiably
+    // returns the pool to reserved=0, but on WSL2/WDDM cudaMemGetInfo can
+    // under-report the reclaimed pages, so the raw free-MiB comparison is
+    // only a first check. The contract that matters (#507: the next load
+    // failed its upload) is that the memory is ALLOCATABLE again — probe it
+    // with a real cudaMalloc of the apparently-missing amount.
     size_t free_between = device_free_mib();
-    EXPECT_GT(free_between + 2048, free_before)
-        << "teardown retained " << (free_before - free_between)
-        << " MiB — default mempool not trimmed back to the driver";
+    if (free_between + 2048 < free_before) {
+        size_t missing_mib = free_before - free_between - 1024;  // 1 GiB slack
+        void* probe = nullptr;
+        cudaError_t pe = cudaMalloc(&probe, missing_mib << 20);
+        EXPECT_EQ(pe, cudaSuccess)
+            << "teardown retained " << (free_before - free_between)
+            << " MiB and a " << missing_mib << " MiB probe alloc FAILS — the memory "
+            << "is genuinely leaked, not just under-reported by cudaMemGetInfo";
+        if (probe)
+            cudaFree(probe);
+    }
 
     // Re-init after inference: before the prewarm stream-rebind fix this
     // segfaulted (dangling stream on the global attention-cuBLAS handle).


### PR DESCRIPTION
Fixes #834. Two distinct problems hid behind the failing assertion; one is a real leak-class bug, one is a WDDM reporting artifact.

## 1. Real bug: `cudaFree` on stream-ordered allocations silently corrupts the pool accounting

Model weights are allocated with `cudaMallocAsync` (default async mempool), but `Model::~Model` — and the Phase-3 MoE expert-source drops — freed them with **plain `cudaFree`**. On this stack (CUDA 13.3 / WSL2) that returns `cudaSuccess` but does **not** return the blocks to the pool: after one unload/reload cycle the pool audit showed `used=16600 MiB > reserved=8320 MiB` (the freed weights were still counted as used, double-booked against the new ones), `cudaMemPoolTrimTo` could reclaim nothing, and every model unload leaked weights-sized VRAM.

Fixed by using `cudaFreeAsync` (the canonical free for stream-ordered allocations) in:
- `Model::~Model` (all `gpu_allocations_`, + stream sync so the trim in `imp_model_free` sees them free),
- the two Phase-3 MoE expert-source drop sites (their `freed_bytes` savings were phantom before — the "freed" VRAM never became allocatable),

and swallowed-error diagnostics in the destructor (failed frees now log instead of vanishing). With the fix the trim verifiably works: `mempool trim: reserved 8320->0 MiB used 0->0 MiB` (new one-line diagnostic in `trim_default_mempool`, also proved the fix on the 30B MoE: `17280->0`).

## 2. Reporting artifact: `cudaMemGetInfo` under-reports the reclaimed pages on WSL2/WDDM

Even with the pool verifiably at `reserved=0`, `cudaMemGetInfo` still reported the ~8.3 GiB as missing — but a probe `cudaMalloc` of that exact amount **succeeds**, and the second load cycle uploads fine. The memory is reclaimable; only the free-MiB readout lags. The test's raw `free_between + 2048 > free_before` comparison therefore tested the wrong property. It now probes the contract that #507 was actually about (the next load must get the memory): if the raw readout looks short, it `cudaMalloc`s the apparently-missing amount and only fails if that allocation fails.

## Validation (RTX 5090, local)

- `EngineRelaunchTest.ReloadAfterInferenceReleasesVramAndDoesNotCrash`: **PASSES** (was red since ~06-30, silently — model-gated).
- `EngineRelaunchTest.SecondEngineOnSameModelHandleNeverIMAs`: passes on Q8 (second engine works) and GDN-mxfp4 (clean #830 reject) — the dtor change doesn't disturb either path.
- MoE expert-drop path (Qwen3-30B-A3B-NVFP4-Modelopt, the modified free sites): loads, generates coherently ("The capital of France is **Paris**."), teardown trims `17280->0 MiB`.
- `make test-unit` 37/37, `make verify-fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz4AjAECTf9WVEjM2PXPER
