### PR TITLE
feat(vram): hard per-process VRAM budget — run multiple imp-servers on one GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(IMP_MEMORY_SOURCES
     src/memory/kv_cache.cu
     src/memory/kv_cache_manager.cpp
     src/memory/recurrent_snapshot_store.cpp
+    src/memory/vram_query.cpp
     src/memory/ssm_state.cu
     src/memory/gdn_state.cu
     src/memory/layer_offload.cu
@@ -620,6 +621,7 @@ if(IMP_BUILD_TESTS)
         tests/test_green_ctx.cu
         tests/test_prefix_cache_equiv.cpp
         tests/test_recurrent_snapshot_store.cpp
+        tests/test_vram_query.cpp
     )
 
     imp_add_test_module(test-moe-gdn SOURCES

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -110,6 +110,21 @@ dtype after model-specific overrides (e.g. Gemma-4 → FP16 KV via the
 `engine.cpp:547` carve-out). `--min-kv-tokens` overrides the defensive
 80% cap and trades FP16 weight-cache capacity for more context.
 
+`--vram-budget <mb>` (also `[runtime] vram_budget_mb` in imp.conf) hard-caps
+this process's VRAM: every sizing decision — weight caches, KV clamp, expert
+offload, workspaces, upload gates — sees a virtual GPU of that size, so
+multiple imp-server processes can share one card:
+
+```bash
+imp-server --model Qwen3-4B-Instruct-2507-Q8_0.gguf --port 8080 --vram-budget 9000 &
+imp-server --model Llama-3.2-3B-Instruct-Q8_0.gguf  --port 8081 --vram-budget 8000 &
+```
+
+Best-effort cap: small fixed buffers and cuBLAS internals sit outside the
+sizing gates, so leave ~1 GiB of real headroom between the sum of budgets
+and the card. A model whose weights don't fit the budget fails cleanly at
+load instead of starving the neighbour.
+
 <details>
 <summary>Full CLI options</summary>
 
@@ -129,6 +144,7 @@ Generation:
   --max-tokens <n>          Max tokens to generate (default: 256)
   --max-seq-len <n>         KV context ceiling in tokens (default: auto)
   --min-kv-tokens <n>       Minimum KV capacity in tokens (default: auto)
+  --vram-budget <mb>        Hard per-process VRAM cap in MiB (default: 0 = uncapped)
   --interactive             Interactive chat mode
   --stop <str>              Stop sequence (repeatable, up to 4)
   --chat-template <t>       auto|none|chatml|llama2|llama3|nemotron|gemma|deepseek_r1|phi

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -58,6 +58,14 @@ hybrid_decode_quantum = 128
 warmup               = false
 # Override the model's max_seq_len (0 = use the model default).
 max_seq_len          = 0
+# Hard VRAM budget for this process in MiB (0 = uncapped). Every sizing
+# decision (weight caches, KV clamp, expert offload, workspaces, upload
+# gates) sees a virtual GPU of this size — run multiple imp-server
+# processes on one card by giving each a slice. Best-effort cap: leave
+# ~1 GiB real headroom between the sum of budgets and the card (small
+# fixed buffers + cuBLAS internals sit outside the gates). CLI flag
+# --vram-budget overrides.
+vram_budget_mb       = 0
 # Disable Programmatic Dependent Launch (PDL). Diagnostic; small perf impact.
 no_pdl               = false
 # Naked FP16 path with FP8/NVFP4/graphs/warmup all forced off.

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -8,6 +8,7 @@
 // below.
 
 #include "exec/executor.h"
+#include "memory/vram_query.h"
 #include "exec/quant_pipeline.h"
 #include "core/logging.h"
 #include "runtime/storage_planner.h"
@@ -45,7 +46,7 @@ void QuantPipeline::build(const Model& model, const RuntimeConfig& rcfg, VRAMAll
     // This preserves the existing per-phase budget tracking while the VRAMBudget
     // struct controls strategy-level decisions (which phases to skip).
     size_t free_vram = 0, total_vram = 0;
-    IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_vram, &total_vram));
+    vram_budget_mem_get_info(&free_vram, &total_vram);
     // Reserve at least 10% of total VRAM as headroom to avoid shared/system
     // memory fallback on WSL2 (not visible via nvidia-smi).
     size_t min_reserve = std::max(budget.reserve_bytes, total_vram / 10);

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -3,6 +3,7 @@
 // MoE workspace, FP8 activation, CUTLASS NVFP4/MXFP4 activation buffers.
 
 #include "exec/executor.h"
+#include "memory/vram_query.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
 #include "exec/gemm_scratch.h"  // prewarm_mmvq_scratch
@@ -439,7 +440,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 // KV cache + weight caches (FP8/NVFP4) need the remaining VRAM,
                 // so expert cache must not over-commit.
                 size_t free_mem = 0, total_mem = 0;
-                IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
+                vram_budget_mem_get_info(&free_mem, &total_mem);
                 size_t safety = 128 << 20;  // 128 MiB reserve
                 size_t budget = (free_mem > safety) ? free_mem - safety : 0;
                 budget = static_cast<size_t>(budget * 0.15);  // 15% of available
@@ -494,7 +495,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
             // floor → long-prompt hang. Leaving ≥ 1 GiB free here covers
             // vram_budget reserve (~768 MiB) plus a useful KV cache.
             size_t free_now = 0, total_now = 0;
-            cudaMemGetInfo(&free_now, &total_now);
+            vram_budget_mem_get_info(&free_now, &total_now);
             constexpr size_t kPostBufReserve = 1024ULL * 1024 * 1024;
             size_t cap_bytes = (free_now > kPostBufReserve) ? (free_now - kPostBufReserve) : 0;
 
@@ -535,7 +536,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                                  static_cast<size_t>(cfg.n_experts_active) *
                                  static_cast<size_t>(d) * sizeof(float);
                 size_t free_bytes = 0, total_bytes = 0;
-                cudaMemGetInfo(&free_bytes, &total_bytes);
+                vram_budget_mem_get_info(&free_bytes, &total_bytes);
                 constexpr size_t kReserve = 256ULL * 1024 * 1024;
                 if (fp32_sz > 0 && free_bytes > fp32_sz + kReserve) {
                     moe_.fp32_down_buf = vram_alloc(vram_alloc_, fp32_sz, "moe_fp32_down");

--- a/src/exec/pre_dequant_phase3_cutlass.cu
+++ b/src/exec/pre_dequant_phase3_cutlass.cu
@@ -5,6 +5,7 @@
 // for shared declarations.
 
 #include "exec/executor.h"
+#include "memory/vram_query.h"
 #include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "compute/gemm_cutlass_sm120.h"
@@ -40,7 +41,7 @@ void QuantPipeline::nvfp4_decode_convert_cutlass_(const ModelConfig& cfg, size_t
     if (wcache_->nvfp4_decode_mode == 2) {
         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
         size_t free_mem = 0, total_mem = 0;
-        IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
+        vram_budget_mem_get_info(&free_mem, &total_mem);
         // Intentionally NOT using dctx.safety_reserve here: populating
         // cutlass_nvfp4 in mode 2 destabilised CUDA-graph capture on
         // Qwen3-14B Q6_K (bimodal 97 vs 145 tok/s decode across trials).
@@ -469,7 +470,7 @@ if (mx_native > 0) {
         // Refuse the alloc instead of paging — keeps the failure mode
         // legible.
         size_t free_mem = 0, total_mem = 0;
-        cudaMemGetInfo(&free_mem, &total_mem);
+        vram_budget_mem_get_info(&free_mem, &total_mem);
         constexpr size_t kRuntimeHeadroom = static_cast<size_t>(2) * 1024 * 1024 * 1024;
         bool oversubscribe = (free_mem <= kRuntimeHeadroom ||
                               fp16_total + kRuntimeHeadroom > free_mem);

--- a/src/exec/pre_dequant_phase3_moe.cu
+++ b/src/exec/pre_dequant_phase3_moe.cu
@@ -6,6 +6,7 @@
 // for shared declarations.
 
 #include "exec/executor.h"
+#include "memory/vram_query.h"
 #include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "compute/gemm_cutlass_sm120.h"
@@ -242,7 +243,7 @@ void QuantPipeline::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
     // Cache MoE expert weights — done after FP16 free so mode 2 has full budget
     if (wcache_->nvfp4_decode_mode == 2) {
         size_t free_mem = 0, total_mem = 0;
-        IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
+        vram_budget_mem_get_info(&free_mem, &total_mem);
         // Reserve VRAM so the KV cache (sized after this in init_kv_cache)
         // can fit `min_kv_tokens` (default 16K) + workspaces. Computed from
         // the model's actual attention layout — the previous 1 GiB constant

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -14,6 +14,7 @@
 // See pre_dequant_internal.h for shared helpers.
 
 #include "exec/executor.h"
+#include "memory/vram_query.h"
 #include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "compute/gemm_cutlass_sm120.h"
@@ -403,7 +404,7 @@ void QuantPipeline::nvfp4_decode_quantize_mode2_(cudaStream_t stream, Nvfp4Decod
         // Check actual free VRAM against the per-call safety reserve computed
         // in pre_dequant_phase3_nvfp4_decode_ (see dctx.safety_reserve).
         size_t free_mem = 0, total_mem = 0;
-        IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem, &total_mem));
+        vram_budget_mem_get_info(&free_mem, &total_mem);
         size_t nvfp4_safety = std::max(dctx.safety_reserve, static_cast<size_t>(1024 * 1024));
         if (free_mem < nvfp4_bytes + nvfp4_safety) {
             IMP_LOG_INFO(
@@ -605,7 +606,7 @@ void QuantPipeline::nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStre
                              static_cast<size_t>(rows) * cols / 16 + 4;
 
         size_t free_mem2 = 0, total_mem2 = 0;
-        IMP_CUDA_CHECK_LOG(cudaMemGetInfo(&free_mem2, &total_mem2));
+        vram_budget_mem_get_info(&free_mem2, &total_mem2);
         size_t nvfp4_safety2 = std::max(total_mem2 / 10, static_cast<size_t>(1024 * 1024));
         if (free_mem2 < nvfp4_bytes + nvfp4_safety2)
             break;

--- a/src/memory/vram_allocator.cu
+++ b/src/memory/vram_allocator.cu
@@ -1,4 +1,5 @@
 #include "memory/vram_allocator.h"
+#include "memory/vram_query.h"
 #include "core/logging.h"
 
 #include <algorithm>
@@ -13,9 +14,8 @@ VRAMAllocator::~VRAMAllocator() {
 
 bool VRAMAllocator::init(float headroom_fraction) {
     size_t free_mem = 0;
-    cudaError_t err = cudaMemGetInfo(&free_mem, &total_);
-    if (err != cudaSuccess) {
-        IMP_LOG_ERROR("VRAMAllocator: cudaMemGetInfo failed: %s", cudaGetErrorString(err));
+    if (!vram_budget_mem_get_info(&free_mem, &total_)) {
+        IMP_LOG_ERROR("VRAMAllocator: cudaMemGetInfo failed");
         return false;
     }
 
@@ -37,7 +37,7 @@ void* VRAMAllocator::allocate(size_t bytes, const char* tag, bool bypass_headroo
         // the 10% headroom is too conservative. Critical allocations (workspace,
         // SSM state, dequant scratch) should still succeed if CUDA has memory.
         size_t free_mem = 0, total_mem = 0;
-        cudaMemGetInfo(&free_mem, &total_mem);
+        vram_budget_mem_get_info(&free_mem, &total_mem);
         if (free_mem >= bytes + (64 << 20)) {  // 64 MiB minimum safety
             IMP_LOG_WARN(
                 "VRAMAllocator: %s (%.2f MiB) exceeds headroom, "
@@ -104,7 +104,7 @@ bool VRAMAllocator::can_allocate(size_t bytes) const {
     // Check against actual free VRAM (not just our tracking)
     // to account for external allocations (driver, other processes).
     size_t free_mem = 0, total = 0;
-    cudaMemGetInfo(&free_mem, &total);
+    vram_budget_mem_get_info(&free_mem, &total);
 
     return free_mem >= bytes + headroom_;
 }
@@ -114,7 +114,7 @@ size_t VRAMAllocator::available() const {
         return 0;
 
     size_t free_mem = 0, total = 0;
-    cudaMemGetInfo(&free_mem, &total);
+    vram_budget_mem_get_info(&free_mem, &total);
 
     return (free_mem > headroom_) ? (free_mem - headroom_) : 0;
 }

--- a/src/memory/vram_query.cpp
+++ b/src/memory/vram_query.cpp
@@ -1,0 +1,69 @@
+#include "memory/vram_query.h"
+#include "core/logging.h"
+
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <atomic>
+
+namespace imp {
+
+namespace {
+// Process-wide budget state. Written once by vram_budget_install (engine
+// init), read from every sizing site afterwards.
+std::atomic<size_t> g_budget_bytes{0};
+std::atomic<size_t> g_free_at_install{0};
+}  // namespace
+
+void vram_budget_install(size_t budget_mb) {
+    size_t budget = budget_mb << 20;
+    if (budget == 0) {
+        g_budget_bytes.store(0, std::memory_order_relaxed);
+        return;
+    }
+    size_t free_b = 0, total_b = 0;
+    if (cudaMemGetInfo(&free_b, &total_b) != cudaSuccess) {
+        IMP_LOG_WARN("vram_budget: cudaMemGetInfo failed — budget disabled");
+        g_budget_bytes.store(0, std::memory_order_relaxed);
+        return;
+    }
+    if (budget > total_b) {
+        IMP_LOG_WARN("vram_budget: %zu MiB exceeds device total %zu MiB — clamping", budget_mb,
+                     total_b >> 20);
+        budget = total_b;
+    }
+    g_free_at_install.store(free_b, std::memory_order_relaxed);
+    g_budget_bytes.store(budget, std::memory_order_relaxed);
+    IMP_LOG_INFO("VRAM budget: %.0f MiB (device free at install: %.0f MiB) — sizing sees a "
+                 "virtual %.0f MiB GPU",
+                 budget / (1024.0 * 1024.0), free_b / (1024.0 * 1024.0),
+                 budget / (1024.0 * 1024.0));
+}
+
+size_t vram_budget_bytes() { return g_budget_bytes.load(std::memory_order_relaxed); }
+
+bool vram_budget_mem_get_info(size_t* free_bytes, size_t* total_bytes) {
+    size_t free_b = 0, total_b = 0;
+    if (cudaMemGetInfo(&free_b, &total_b) != cudaSuccess) {
+        if (free_bytes)
+            *free_bytes = 0;
+        if (total_bytes)
+            *total_bytes = 0;
+        return false;
+    }
+    const size_t budget = g_budget_bytes.load(std::memory_order_relaxed);
+    if (budget > 0) {
+        const size_t baseline = g_free_at_install.load(std::memory_order_relaxed);
+        const size_t my_used = (baseline > free_b) ? (baseline - free_b) : 0;
+        const size_t budget_left = (budget > my_used) ? (budget - my_used) : 0;
+        free_b = std::min(free_b, budget_left);
+        total_b = budget;
+    }
+    if (free_bytes)
+        *free_bytes = free_b;
+    if (total_bytes)
+        *total_bytes = total_b;
+    return true;
+}
+
+}  // namespace imp

--- a/src/memory/vram_query.h
+++ b/src/memory/vram_query.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+
+namespace imp {
+
+// ─────────────────────────────────────────────────────────────────────
+// Budget-aware VRAM query — the "pretend the GPU is only X MiB" view.
+//
+// Multiple imp-server processes sharing one GPU need each process to size
+// itself (weight caches, KV clamp, expert offload, workspaces, upload gates)
+// against ITS slice of the card, not against whatever cudaMemGetInfo happens
+// to report. EngineConfig.vram_budget_mb declares that slice;
+// vram_budget_mem_get_info() is the drop-in replacement for cudaMemGetInfo
+// at every SIZING/decision site (diagnostic/audit sites keep the raw call).
+//
+// Semantics (budget installed):
+//   my_used = free_at_install − free_now   (baseline delta: covers ALL of
+//             this process's allocations — async pool, plain cudaMalloc,
+//             cuBLAS-internal — without per-site tracking)
+//   free'   = min(free_now, budget − my_used)
+//   total'  = budget
+// so used' = total' − free' = my_used: a consistent virtual small GPU. The
+// total'-capping also right-sizes the various total/10 headroom heuristics.
+//
+// A neighbour process allocating AFTER our install inflates my_used and
+// shrinks our view — the conservative direction (we size smaller, never
+// overcommit the card). Frees by this process shrink my_used again.
+//
+// Best-effort hard cap, not an OS limit: allocations that bypass the sizing
+// gates (small fixed buffers, cuBLAS handles) still land outside the budget;
+// leave ~1 GiB of real headroom between the sum of budgets and the card.
+//
+// Not thread-safe against concurrent install; install once from
+// Engine::init (single-engine-per-process is the supported deployment).
+// Budget 0 = uncapped (raw cudaMemGetInfo passthrough).
+// ─────────────────────────────────────────────────────────────────────
+
+// Install (or clear, budget_mb=0) the process-wide budget and snapshot the
+// baseline. Called from Engine::init once the config is resolved.
+void vram_budget_install(size_t budget_mb);
+
+// Installed budget in bytes (0 = uncapped).
+size_t vram_budget_bytes();
+
+// cudaMemGetInfo with the budget view applied. Either out pointer may be
+// null. Returns false (zeros) if the raw query fails.
+bool vram_budget_mem_get_info(size_t* free_bytes, size_t* total_bytes);
+
+}  // namespace imp

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1,4 +1,5 @@
 #include "model/model.h"
+#include "memory/vram_query.h"
 #include "model/gguf_loader.h"
 #include "memory/mem_account.h"
 #include "quant/dequant_gpu.h"
@@ -48,7 +49,7 @@ static cudaError_t checked_cuda_malloc(void** ptr, size_t size, cudaStream_t str
     }
     // Fallback: per-tensor check (used outside upload passes)
     size_t free_mem = 0, total_mem = 0;
-    cudaMemGetInfo(&free_mem, &total_mem);
+    vram_budget_mem_get_info(&free_mem, &total_mem);
     if (size + reserve > free_mem) {
         *ptr = nullptr;
         return cudaErrorMemoryAllocation;
@@ -1517,7 +1518,7 @@ static void decide_expert_layer_placement_(const std::vector<size_t>& layer_expe
         return;
 
     size_t free_mem = 0, total_mem = 0;
-    cudaMemGetInfo(&free_mem, &total_mem);
+    vram_budget_mem_get_info(&free_mem, &total_mem);
 
     // Auto-pick default: use 10% (aggressive) if ALL experts would fit with
     // that overhead, else 30% (conservative). This saves users from a
@@ -1993,7 +1994,7 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
     // Cache VRAM state to avoid per-tensor cudaMemGetInfo calls
     {
         size_t free_mem = 0, total_mem = 0;
-        cudaMemGetInfo(&free_mem, &total_mem);
+        vram_budget_mem_get_info(&free_mem, &total_mem);
         g_cached_free_mem = free_mem;
         g_total_allocated = 0;
         IMP_LOG_DEBUG("VRAM at upload start: %.2f GiB free / %.2f GiB total",

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -121,6 +121,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("runtime.decode_burst", cfg.runtime.decode_burst);
     I("runtime.prefill_chunk_decode_cap", cfg.runtime.prefill_chunk_decode_cap);
     I("runtime.hybrid_decode_quantum", cfg.runtime.hybrid_decode_quantum);
+    I("runtime.vram_budget_mb", cfg.runtime.vram_budget_mb);
 
     // [kv_cache]
     S("kv_cache.dtype", cfg.kv_cache.dtype);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -40,6 +40,14 @@ struct RuntimeConfig {
         std::string cuda_graphs = "auto";  // "auto" | "always" | "never"
         bool warmup = false;               // opt-in for prod rollout; off in dev/CI
         int max_seq_len = 0;               // 0 = use model default
+        // Hard VRAM budget for THIS process (MiB, 0 = uncapped). Every sizing
+        // decision (weight caches, KV clamp, expert offload, workspaces,
+        // upload gates) sees a virtual GPU of this size, so multiple
+        // imp-server processes can share one card without overcommitting it.
+        // Best-effort: leave ~1 GiB real headroom between the sum of budgets
+        // and the card (small fixed buffers + cuBLAS internals sit outside).
+        // CLI flag --vram-budget / C-API ImpConfig.vram_budget_mb override.
+        int vram_budget_mb = 0;
         bool no_pdl = false;
         bool debug_raw = false;        // raw stream debug
         bool no_vision_graph = false;  // disable SigLIP graph capture

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -11,6 +11,7 @@
 #include "compute/mtp_forward.h"
 #include "memory/kv_cache.h"
 #include "memory/mem_account.h"
+#include "memory/vram_query.h"
 #include "model/gguf_loader.h"
 #include "model/chat_template.h"
 #include "compute/ffn_sparsity_probe.h"
@@ -399,15 +400,13 @@ bool Engine::lora_set(int id) {
 }
 
 size_t Engine::effective_free_vram() const {
-    size_t free_mem = 0, total_mem = 0;
-    if (cudaMemGetInfo(&free_mem, &total_mem) != cudaSuccess) {
+    // Budget-aware view (installed in init from config_.vram_budget_mb).
+    // The old inline formula counted GLOBAL device usage against the budget,
+    // which mis-charged a co-tenant server's memory to this process;
+    // vram_query uses the process baseline delta instead.
+    size_t free_mem = 0;
+    if (!vram_budget_mem_get_info(&free_mem, nullptr))
         return 0;
-    }
-    if (config_.vram_budget_mb > 0) {
-        size_t budget = config_.vram_budget_mb * 1024ULL * 1024;
-        size_t used = total_mem - free_mem;
-        free_mem = (budget > used) ? (budget - used) : 0;
-    }
     return free_mem;
 }
 
@@ -567,6 +566,13 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         config_.prefix_pin_budget_pct = runtime_config_.server.prefix_pin_budget_pct;
     if (config_.mmproj_path.empty())
         config_.mmproj_path = runtime_config_.paths.mmproj;
+    if (config_.vram_budget_mb == 0 && runtime_config_.runtime.vram_budget_mb > 0)
+        config_.vram_budget_mb = static_cast<size_t>(runtime_config_.runtime.vram_budget_mb);
+
+    // Install the process-wide VRAM budget view BEFORE any sizing runs —
+    // every cudaMemGetInfo-based decision below (weight upload gates, cache
+    // budgets, KV clamp, workspaces) reads through vram_budget_mem_get_info.
+    vram_budget_install(config_.vram_budget_mb);
 
     // The deterministic kernel gate lives in process_diag (compute kernels
     // read process_diag_deterministic_gemm()), but process_diag_install()

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -6,6 +6,7 @@
 #include "model/chat_template.h"
 #include "compute/sampling.h"
 #include "core/logging.h"
+#include "memory/vram_query.h"
 
 #include <cstring>
 #include <algorithm>
@@ -31,7 +32,7 @@ int Engine::prepare_graph_loop(std::shared_ptr<Request>& req) {
 
     {
         size_t f = 0, t = 0;
-        cudaMemGetInfo(&f, &t);
+        vram_budget_mem_get_info(&f, &t);
         if (f < 256ULL * 1024 * 1024)
             return 0;
     }

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -12,6 +12,7 @@
 #include "runtime/process_diag.h"
 #include "core/logging.h"
 #include "core/tensor.h"
+#include "memory/vram_query.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -177,7 +178,7 @@ void Engine::init_resolve_kv_dtype_policy_() {
         int auto_batch = tier;
         size_t free_vram = 0, total_vram = 0;
         size_t headroom = 0;
-        if (cudaMemGetInfo(&free_vram, &total_vram) == cudaSuccess && free_vram > 0) {
+        if (vram_budget_mem_get_info(&free_vram, &total_vram) && free_vram > 0) {
             constexpr int kRefCtxTokens = 4096;  // per-slot serving context floor
             constexpr int kMaxAutoBatch = 32;
             constexpr double kKvHeadroomFrac = 0.6;  // rest: workspaces + long-ctx + safety
@@ -475,7 +476,7 @@ void Engine::init_compute_max_seq_len_() {
     if (config_.max_seq_len <= 0) {
         int model_ctx = mcfg.max_seq_len;  // from GGUF metadata
         size_t free_vram = 0, total_vram = 0;
-        cudaMemGetInfo(&free_vram, &total_vram);
+        vram_budget_mem_get_info(&free_vram, &total_vram);
         int head_dim = mcfg.head_dim > 0 ? mcfg.head_dim : (mcfg.d_model / mcfg.n_heads);
         // Hybrid models (Qwen3.5/3.6 GDN, Nemotron-H Mamba2) populate
         // n_kv_heads_per_layer with zeros for non-attention layers — those don't

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -13,6 +13,7 @@
 #include "runtime/config.h"
 #include "core/cuda_raii.h"
 #include "core/logging.h"
+#include "memory/vram_query.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -133,7 +134,7 @@ bool Engine::init_weights() {
                         kv_block_bytes;
         {
             size_t total_vram = 0, f = 0;
-            cudaMemGetInfo(&f, &total_vram);
+            vram_budget_mem_get_info(&f, &total_vram);
             // For large MoE models (128 experts), prefer fitting all experts on GPU
             // over reserving huge KV cache. All-GPU experts enable the decode fast
             // path (dp4a GEMV, no D2H sync) and CUDA graph capture.

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -2,6 +2,7 @@
 #include "runtime/engine.h"  // EngineConfig full definition
 #include "runtime/storage_planner.h"
 #include "core/logging.h"
+#include "memory/vram_query.h"
 #include <algorithm>
 #include <cuda_runtime.h>
 
@@ -46,7 +47,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
     size_t total_vram = 0;
     {
         size_t f;
-        cudaMemGetInfo(&f, &total_vram);
+        vram_budget_mem_get_info(&f, &total_vram);
     }
     if (config.use_nvfp4_decode != 2) {
         budget.reserve_bytes = std::max(budget.reserve_bytes, total_vram / 10);

--- a/tests/test_vram_query.cpp
+++ b/tests/test_vram_query.cpp
@@ -1,0 +1,90 @@
+// vram_query — the budget-aware cudaMemGetInfo view behind
+// EngineConfig.vram_budget_mb ("pretend the GPU is only X MiB").
+//
+// Semantics under test:
+//   my_used = free_at_install − free_now   (baseline delta)
+//   free'   = min(free_now, budget − my_used)
+//   total'  = budget
+// so a co-tenant's pre-existing usage never counts against this process,
+// while this process's own allocations shrink the budgeted view 1:1.
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+
+#include "memory/vram_query.h"
+
+#include "test_cuda_skip.h"
+
+namespace imp {
+namespace {
+
+class VramQueryTest : public ::testing::Test {
+protected:
+    void TearDown() override { vram_budget_install(0); }  // never leak the cap
+};
+
+TEST_F(VramQueryTest, UncappedIsPassthrough) {
+    SKIP_IF_NO_CUDA();
+    vram_budget_install(0);
+    size_t raw_free = 0, raw_total = 0;
+    ASSERT_EQ(cudaMemGetInfo(&raw_free, &raw_total), cudaSuccess);
+    size_t f = 0, t = 0;
+    ASSERT_TRUE(vram_budget_mem_get_info(&f, &t));
+    EXPECT_EQ(t, raw_total);
+    // free can jitter between the two calls — allow small drift.
+    EXPECT_NEAR(static_cast<double>(f), static_cast<double>(raw_free), 64.0 * 1024 * 1024);
+}
+
+TEST_F(VramQueryTest, BudgetCapsTotalAndTracksOwnUsage) {
+    SKIP_IF_NO_CUDA();
+    constexpr size_t kBudgetMb = 1024;
+    vram_budget_install(kBudgetMb);
+    ASSERT_EQ(vram_budget_bytes(), kBudgetMb << 20);
+
+    size_t f0 = 0, t0 = 0;
+    ASSERT_TRUE(vram_budget_mem_get_info(&f0, &t0));
+    EXPECT_EQ(t0, kBudgetMb << 20) << "total' must be the virtual GPU size";
+    EXPECT_LE(f0, kBudgetMb << 20);
+    // Nothing allocated since install → the full budget is visible
+    // (device free far exceeds 1 GiB on the test box).
+    EXPECT_GT(f0, (kBudgetMb - 64) << 20);
+
+    // Allocate 256 MiB — the budgeted view must shrink by ~that amount.
+    void* p = nullptr;
+    ASSERT_EQ(cudaMalloc(&p, 256ULL << 20), cudaSuccess);
+    size_t f1 = 0;
+    ASSERT_TRUE(vram_budget_mem_get_info(&f1, nullptr));
+    EXPECT_LT(f1, f0 - (200ULL << 20)) << "own allocation must count against the budget";
+    EXPECT_GT(f1 + (320ULL << 20), f0) << "…but not by much more than its size";
+
+    // Free it — the budget must come back.
+    ASSERT_EQ(cudaFree(p), cudaSuccess);
+    size_t f2 = 0;
+    ASSERT_TRUE(vram_budget_mem_get_info(&f2, nullptr));
+    EXPECT_GT(f2 + (64ULL << 20), f0) << "freed memory must return to the budget";
+}
+
+TEST_F(VramQueryTest, BudgetExhaustionClampsToZero) {
+    SKIP_IF_NO_CUDA();
+    vram_budget_install(128);  // tiny budget
+    void* p = nullptr;
+    ASSERT_EQ(cudaMalloc(&p, 256ULL << 20), cudaSuccess);  // overshoot it
+    size_t f = 0, t = 0;
+    ASSERT_TRUE(vram_budget_mem_get_info(&f, &t));
+    EXPECT_EQ(f, 0u) << "over-budget usage must clamp free' to 0, not underflow";
+    EXPECT_EQ(t, 128ULL << 20);
+    ASSERT_EQ(cudaFree(p), cudaSuccess);
+}
+
+TEST_F(VramQueryTest, InstallClampsToDeviceTotal) {
+    SKIP_IF_NO_CUDA();
+    size_t raw_total = 0, raw_free = 0;
+    ASSERT_EQ(cudaMemGetInfo(&raw_free, &raw_total), cudaSuccess);
+    vram_budget_install((raw_total >> 20) * 4);  // absurd budget
+    size_t f = 0, t = 0;
+    ASSERT_TRUE(vram_budget_mem_get_info(&f, &t));
+    EXPECT_EQ(t, raw_total) << "budget beyond the card clamps to device total";
+}
+
+}  // namespace
+}  // namespace imp

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -18,6 +18,8 @@ void print_usage(const char* prog) {
             "  --prompt <text>       Input prompt for generation\n"
             "  --max-tokens <n>      Maximum tokens to generate (default: 256)\n"
             "  --max-seq-len <n>     KV context ceiling in tokens (default: auto from VRAM)\n"
+            "  --vram-budget <mb>    Hard per-process VRAM cap in MiB — size everything as if\n"
+            "                        the GPU only had this much (multi-server on one GPU)\n"
             "  --min-kv-tokens <n>   Minimum KV capacity in tokens (default: auto)\n"
             "  --temperature <f>     Sampling temperature (default: 0.7)\n"
             "  --top-p <f>           Top-p (nucleus) sampling (default: 0.9)\n"
@@ -114,6 +116,8 @@ CliArgs parse_args(int argc, char** argv) {
             args.max_tokens_set = true;
         } else if (std::strcmp(arg, "--max-seq-len") == 0 && i + 1 < argc) {
             args.max_seq_len = std::atoi(argv[++i]);
+        } else if (std::strcmp(arg, "--vram-budget") == 0 && i + 1 < argc) {
+            args.vram_budget_mb = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--min-kv-tokens") == 0 && i + 1 < argc) {
             args.min_kv_tokens = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--temperature") == 0 && i + 1 < argc) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -16,6 +16,7 @@ struct CliArgs {
     std::string perplexity_file;  // --perplexity <file>: teacher-forced PPL over the file's text
     int max_tokens = 256;
     int max_seq_len = 0;    // --max-seq-len: KV context ceiling (0 = auto from VRAM)
+    int vram_budget_mb = 0; // --vram-budget: hard per-process VRAM cap in MiB (0 = uncapped)
     int min_kv_tokens = 0;  // --min-kv-tokens: floor KV capacity (0 = auto)
     float temperature = 0.7f;
     float top_p = 0.9f;

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -122,6 +122,8 @@ int main(int argc, char** argv) {
     // max_seq_len: 0 = auto-detect in engine (from model metadata + VRAM)
     if (args.max_seq_len > 0)
         config.max_seq_len = args.max_seq_len;
+    if (args.vram_budget_mb > 0)
+        config.vram_budget_mb = args.vram_budget_mb;
     if (args.min_kv_tokens > 0)
         config.min_kv_tokens = args.min_kv_tokens;
     config.gpu_layers = args.gpu_layers;

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -36,6 +36,8 @@ void print_server_usage(const char* prog) {
             "  --models-dir <path>   Directory to scan for .gguf models (auto-load on select)\n"
             "  --api-key <key>       Require Bearer token authentication\n"
             "  --reasoning-format <f> deepseek (default) or none\n"
+            "  --vram-budget <mb>    Hard per-process VRAM cap in MiB — size everything as if\n"
+            "                        the GPU only had this much (multi-server on one GPU)\n"
             "  --think-budget <f>    Fraction of max_tokens for reasoning (default: 0.5, 0=disabled)\n"
             "  --max-concurrent <n>  Max simultaneous requests (default: 64, 0=unlimited)\n"
             "  --request-timeout <s> Per-request timeout in seconds (default: 300, 0=unlimited)\n"
@@ -127,6 +129,8 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.api_key = argv[++i];
         } else if (std::strcmp(arg, "--reasoning-format") == 0 && i + 1 < argc) {
             args.reasoning_format = argv[++i];
+        } else if (std::strcmp(arg, "--vram-budget") == 0 && i + 1 < argc) {
+            args.vram_budget_mb = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--think-budget") == 0 && i + 1 < argc) {
             args.think_budget = std::atof(argv[++i]);
         } else if (std::strcmp(arg, "--max-concurrent") == 0 && i + 1 < argc) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -40,6 +40,7 @@ struct ServerArgs {
     std::string models_dir;                     // --models-dir: scan for .gguf files
     std::string api_key;                        // --api-key: require Bearer token auth
     std::string reasoning_format = "deepseek";  // --reasoning-format: deepseek or none
+    int vram_budget_mb = 0;  // --vram-budget: hard per-process VRAM cap in MiB (0 = uncapped)
     float think_budget =
         0.5f;  // --think-budget: fraction of max_tokens for reasoning (1.0=unlimited, 0=disabled).
                // 0.5 matches docs/usage.md and guarantees answer headroom — at 1.0 a

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -221,6 +221,12 @@ ImpConfig build_config(const ServerArgs& args, const imp::RuntimeConfig& runtime
         args.max_batch_size > 0 ? args.max_batch_size : runtime_cfg.runtime.max_batch_size;
     config.max_batch_size = overrides.value("max_batch_size", batch_cli_or_conf);
 
+    // Hard per-process VRAM cap for multi-server-per-GPU deployments.
+    // Precedence: --vram-budget CLI flag > [runtime] vram_budget_mb from
+    // imp.conf (the engine bridges the imp.conf key itself when this is 0).
+    if (args.vram_budget_mb > 0)
+        config.vram_budget_mb = args.vram_budget_mb;
+
     config.gpu_layers = args.gpu_layers;
     if (args.ssm_fp16)
         config.ssm_state_dtype = IMP_DTYPE_FP16;


### PR DESCRIPTION
Adds a hard per-process VRAM cap so multiple imp-server processes can share one GPU: `--vram-budget <mb>` (imp-server + imp-cli), `[runtime] vram_budget_mb` in imp.conf, and the existing-but-inert C-API `ImpConfig.vram_budget_mb`.

## Semantics: "pretend the GPU is only X MiB"

New `src/memory/vram_query.{h,cpp}`: `vram_budget_install()` snapshots the device free at engine init as a baseline; `vram_budget_mem_get_info()` is the drop-in replacement for `cudaMemGetInfo` at sizing sites:

```
my_used = free_at_install − free_now      (baseline delta — covers ALL of this
                                           process's allocations: async pool,
                                           plain cudaMalloc, cuBLAS-internal,
                                           without per-site tracking)
free'   = min(free_now, budget − my_used)
total'  = budget
```

A co-tenant's **pre-existing** usage never counts against this process (the old `effective_free_vram` formula charged global device usage to the budget, starving the second server); a neighbour allocating **concurrently** inflates `my_used` and shrinks our view — the conservative direction (size smaller, never overcommit the card).

## Coverage

All 19 sizing/decision sites now read the budgeted view (diagnostic/audit sites keep raw `cudaMemGetInfo`): max_seq_len + max_batch_size auto-sizing, KV clamp + the total-derived reserves (`vram_budget.cpp`), expert-offload placement + the upload oversubscription gates (`weight_upload.cu`), QuantPipeline cache budgets (phases 1-3, NVFP4/CUTLASS/MXFP4 gates), executor workspace caps, decode-time graph gate, and the VRAMAllocator headroom family. `total'`-capping also right-sizes the `total/10` headroom heuristics to the slice.

Best-effort cap (documented): small fixed buffers and cuBLAS internals sit outside the gates — leave ~1 GiB real headroom between the sum of budgets and the card. Default `0` = uncapped, byte-identical passthrough (baselines untouched; `make verify-fast` green).

## Validation (RTX 5090, local)

- **Unit** (`tests/test_vram_query.cpp`, 4 tests): passthrough when uncapped, total'=budget + own-usage tracking ±alloc size, over-budget clamps free'=0 (no underflow), absurd budget clamps to device total.
- **Sizing plumbs through** (Qwen3-4B-Q8, `--vram-budget 8000`): `max_seq_len: auto → 34133` (was 262144-capped-to-65536), `KV clamped 2134 → 792 blocks`, NVFP4 cache skipped for budget — and generation stays correct.
- **The actual use case**: two imp-servers started SIMULTANEOUSLY on one GPU (Qwen3-4B-Q8 `--vram-budget 9000` + Llama-3.2-3B-Q8 `--vram-budget 8000`) — both healthy, both answer concurrent requests correctly, device total 15.9 GiB used (within the 17 GiB budget sum). The concurrent start exercises the conservative overlap mode (both baselines read the empty card).
- `make test-unit` 37/37, `make verify-fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz4AjAECTf9WVEjM2PXPER
