### PR TITLE
fix(constraints): raise the tools+json_schema preamble slack — mask no longer fires mid-deliberation (#840)

### DIFF
--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -89,8 +89,15 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
     // every request on a think-capable tokenizer an 8192-token unmasked
     // preamble — a non-thinking json_mode request never emits </think>, so the
     // grammar never engaged and the output was unconstrained garbage.
-    //   - has_tools: 64-token slack so short verbal preambles ("Sure! ")
-    //     don't squeeze out the tool-tag opener.
+    //   - has_tools: 512-token slack. Think-capable models with thinking
+    //     suppressed (json/tools requests) deliberate in PLAIN TEXT before
+    //     opening the tool tag — Qwen3-8B spends 60-130 tokens of prose
+    //     deciding to call get_weather. The old 64-token slack (sized for
+    //     "Sure! "-style preambles) expired mid-sentence, and the schema
+    //     mask then forced a contentless `{"answer":""}` INSTEAD of the
+    //     tool call the model was about to make (#840). 512 covers real
+    //     deliberation while still bounding a model that never produces
+    //     structure.
     //   - no tools: 0 — the old 8-token "markdown fence" slack let the model
     //     open ```json fences that then leaked into content around otherwise
     //     perfect JSON. With the mask active from token 1 the model starts
@@ -99,7 +106,7 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
     if (thinking_open && think_close >= 0) {
         preamble_budget = 8192;
     } else if (has_tools) {
-        preamble_budget = 64;
+        preamble_budget = 512;
     } else {
         preamble_budget = 0;
     }


### PR DESCRIPTION
Fixes #840.

## Root cause (traced via per-token stream inspection)

With `tools` + `response_format: json_schema`, thinking is suppressed — so a think-capable model deliberates in **plain text**: Qwen3-8B emits 60-130 tokens of "Okay, the user is asking… I need to call that function…" before opening `<tool_call>`. The tool-aware preamble gate's 64-token budget (sized for `"Sure! "`-style preambles) expired mid-sentence; the schema mask then engaged with the FSM at START and forced a contentless `{"answer":""}` — the tool call the model was about to make never happened, and the reasoning split chopped the forced JSON into the corrupt `"answer":""}` / empty-content artifacts from the issue.

## Fix

Raise the `has_tools` preamble slack 64 → 512 tokens (`constraint_manager.cpp`). That covers real plain-text deliberation while still bounding a model that never produces structure (the mask still engages at 512 and the schema guarantee holds). The no-tools path (budget 0, mask from token 1) and the reasoning path (8192 with `</think>` close) are untouched.

## Validation (RTX 5090, Qwen3-8B-Q8 live)

| Case | Before | After |
|---|---|---|
| tools + json_schema, max_tokens 128 | `content: "answer":""}`, no tool call | **`get_weather{"city":"Paris"}`, finish=tool_calls** |
| tools + json_schema, max_tokens 256 | `content: ''`, JSON lost in reasoning split | **same correct tool call** |
| json_schema without tools | valid | unchanged, valid |

`tests/api/test_tools.py::TestToolCalling::test_tools_plus_json_schema_passes_through` red→green; full tools/responses/streaming pytest 15/15; `make verify-fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz4AjAECTf9WVEjM2PXPER