### PR TITLE
feat(spec): SuffixDecoding — suffix-indexed drafter with frequency voting + adaptive draft length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,7 @@ set(IMP_RUNTIME_SOURCES
     src/runtime/engine_spec_ngram.cpp
     src/runtime/engine_sampling_stop.cpp
     src/runtime/ngram_draft.cpp
+    src/runtime/suffix_draft.cpp
     src/vision/vision_pipeline.cpp
     src/runtime/constraint_manager.cpp
     src/runtime/vram_budget.cpp
@@ -508,6 +509,7 @@ if(IMP_BUILD_TESTS)
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
         tests/test_ngram_draft.cpp
+        tests/test_suffix_draft.cpp
         tests/test_routing_decision.cpp
         tests/test_think_stop_logic.cpp
         tests/test_stream_pipeline.cpp

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -305,6 +305,14 @@ ngram                = true
 moe                  = true
 # Draft tokens proposed per verify step (verify cost is ~flat in k).
 k                    = 16
+# Suffix-indexed drafting (SuffixDecoding-style): hash-indexed suffix
+# matching instead of a per-step backward scan, continuations picked by
+# frequency vote across all occurrences, and adaptive draft length — a
+# draft backed by multiple agreeing occurrences (or a maximal-length
+# context match, e.g. the `prediction` region) extends past k up to
+# suffix_k_max. false = legacy single-most-recent scan.
+suffix               = true
+suffix_k_max         = 64
 # Shortest / longest suffix n-gram match searched. Longer min_match =
 # fewer but far more precise drafts (6 vs 3: +16% on code-edit, and the
 # number-table worst case shrinks from -13% to -2%).

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -254,6 +254,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("speculative.ngram", cfg.speculative.ngram);
     B("speculative.moe", cfg.speculative.moe);
     I("speculative.k", cfg.speculative.k);
+    B("speculative.suffix", cfg.speculative.suffix);
+    I("speculative.suffix_k_max", cfg.speculative.suffix_k_max);
     I("speculative.min_match", cfg.speculative.min_match);
     I("speculative.max_match", cfg.speculative.max_match);
     I("speculative.give_up_after", cfg.speculative.give_up_after);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -522,6 +522,15 @@ struct RuntimeConfig {
         // restart variance).
         bool moe = true;
         int k = 16;          // draft tokens per verify step (verify cost is ~flat in k)
+        // SuffixDecoding-style indexed drafting (arXiv 2411.04975):
+        // hash-indexed suffix matching (O(1) amortized vs the legacy O(n)
+        // backward scan per verify step) with frequency-voted continuations
+        // across all occurrences, and adaptive draft length — a draft backed
+        // by multiple agreeing occurrences or a maximal-length (max_match)
+        // context match extends past `k` up to `suffix_k_max`. false =
+        // legacy single-most-recent scan.
+        bool suffix = true;
+        int suffix_k_max = 64;
         // Longer suffix matches trade draft frequency for precision — and
         // precision wins decisively: min_match 6 vs 3 measured +16% on
         // code-edit (50% acceptance) while cutting the structured-content

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -443,6 +443,7 @@ void Engine::finish_request(std::shared_ptr<Request>& req) {
     kv_manager_->free_sequence(req->id);
     release_recurrent_slot_(req->id);
     req->recurrent_restore.reset();  // release the snapshot buffer for recycling
+    spec_suffix_idx_.erase(req->id);
     if (req->constraints)
         constraints_return_(std::move(req->constraints));
     // Server visibility: the engine outlives requests, so cumulative

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -10,6 +10,7 @@
 #include "vision/vision_pipeline.h"
 #include "runtime/constraint_manager.h"
 #include "runtime/config.h"
+#include "runtime/suffix_draft.h"
 #include "memory/kv_cache.h"
 #include "memory/kv_cache_manager.h"
 #include "memory/ssm_state.h"
@@ -524,6 +525,11 @@ private:
     bool ensure_spec_buffers_(int chunk_cap, int max_blocks);
     void free_spec_buffers_();
     void log_spec_stats_() const;
+    // Per-request suffix index (speculative.suffix): lazily built over
+    // input ++ prediction, extended with output tokens as they land.
+    // Erased when the request finishes.
+    SuffixDraftIndex& spec_suffix_index_(const Request& req);
+    std::unordered_map<int, SuffixDraftIndex> spec_suffix_idx_;
     // Device/pinned staging for the verify chunk (lazy-init, K+1 capacity).
     int32_t* d_spec_tokens_ = nullptr;
     int* d_spec_positions_ = nullptr;

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -3,7 +3,10 @@
 // =============================================================================
 //
 // Drafts come from suffix matches against the request's own prompt+output
-// tokens (ngram_draft) — no draft model, no MTP head. The verify step replays
+// tokens — no draft model, no MTP head. Two matchers: the suffix index
+// (SuffixDraftIndex, speculative.suffix, default) with frequency-voted
+// continuations and adaptive draft length, or the legacy single-most-recent
+// backward scan (ngram_draft). The verify step replays
 // [t0, d1..dK] as a teacher-forced continuation chunk through the standard
 // chunked-prefill forward (KV written in place), applies the tier-aware LM
 // head to every chunk position (executor greedy_argmax_all) and accepts the
@@ -27,6 +30,7 @@
 #include "runtime/engine.h"
 #include "runtime/ngram_draft.h"
 #include "runtime/request.h"
+#include "runtime/suffix_draft.h"
 
 #include <cuda_runtime.h>
 #include <algorithm>
@@ -177,6 +181,20 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     return true;
 }
 
+SuffixDraftIndex& Engine::spec_suffix_index_(const Request& req) {
+    auto it = spec_suffix_idx_.find(req.id);
+    if (it == spec_suffix_idx_.end()) {
+        const auto& scfg = runtime_config_.speculative;
+        it = spec_suffix_idx_
+                 .emplace(req.id, SuffixDraftIndex(std::max(1, scfg.min_match), scfg.max_match))
+                 .first;
+        it->second.append(req.input_tokens.data(), static_cast<int>(req.input_tokens.size()));
+        it->second.append(req.prediction_tokens.data(),
+                          static_cast<int>(req.prediction_tokens.size()));
+    }
+    return it->second;
+}
+
 bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream) {
     const auto& scfg = runtime_config_.speculative;
     const int kv_bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
@@ -186,21 +204,32 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     // between prompt and output so the current output suffix stays the tail:
     // a completion that tracks the prediction finds max_match-length matches
     // in the prediction region every verify step.
-    std::vector<int32_t> history;
-    history.reserve(req->input_tokens.size() + req->prediction_tokens.size() +
-                    req->output_tokens.size());
-    history.insert(history.end(), req->input_tokens.begin(), req->input_tokens.end());
-    history.insert(history.end(), req->prediction_tokens.begin(), req->prediction_tokens.end());
-    history.insert(history.end(), req->output_tokens.begin(), req->output_tokens.end());
-    const int hist_n = static_cast<int>(history.size());
     const int pred_begin = static_cast<int>(req->input_tokens.size());
     const int pred_end = pred_begin + static_cast<int>(req->prediction_tokens.size());
 
     const int k = std::max(1, scfg.k);
     int draft_start = -1;
-    std::vector<int32_t> draft = ngram_draft(history.data(), hist_n, k,
-                                             std::max(1, scfg.min_match), scfg.max_match,
-                                             &draft_start);
+    std::vector<int32_t> draft;
+    if (scfg.suffix) {
+        // Suffix index: input ++ prediction indexed at first use, output
+        // tokens appended incrementally (every emit path lands in
+        // output_tokens, so loop-burst tokens are picked up here too).
+        SuffixDraftIndex& idx = spec_suffix_index_(*req);
+        const int out_indexed = idx.size() - pred_end;
+        idx.append(req->output_tokens.data() + out_indexed,
+                   static_cast<int>(req->output_tokens.size()) - out_indexed);
+        draft = idx.draft(k, std::max(k, scfg.suffix_k_max), &draft_start);
+    } else {
+        std::vector<int32_t> history;
+        history.reserve(req->input_tokens.size() + req->prediction_tokens.size() +
+                        req->output_tokens.size());
+        history.insert(history.end(), req->input_tokens.begin(), req->input_tokens.end());
+        history.insert(history.end(), req->prediction_tokens.begin(),
+                       req->prediction_tokens.end());
+        history.insert(history.end(), req->output_tokens.begin(), req->output_tokens.end());
+        draft = ngram_draft(history.data(), static_cast<int>(history.size()), k,
+                            std::max(1, scfg.min_match), scfg.max_match, &draft_start);
+    }
     const bool draft_from_prediction = draft_start >= pred_begin && draft_start < pred_end;
     if (draft.empty()) {
         spec_stats_.miss_steps++;

--- a/src/runtime/suffix_draft.cpp
+++ b/src/runtime/suffix_draft.cpp
@@ -1,0 +1,139 @@
+#include "runtime/suffix_draft.h"
+
+#include <algorithm>
+
+namespace imp {
+
+namespace {
+// Occurrence-list cap per gram key. Voting cost per drafted token is
+// O(survivors); degenerate histories (whitespace runs, separator-heavy
+// tables) would otherwise accumulate thousands of occurrences of the same
+// gram. Most recent occurrences are kept — they track local phrasing best.
+constexpr int kMaxOccurrences = 64;
+}  // namespace
+
+SuffixDraftIndex::SuffixDraftIndex(int min_match, int max_match)
+    : min_match_(std::max(1, min_match)), max_match_(std::max(max_match, min_match_)) {}
+
+uint64_t SuffixDraftIndex::gram_hash_at_(int end) const {
+    // FNV-1a over the min_match_ tokens ending at `end`, finalized with a
+    // splitmix64-style mix. Collisions are guarded by token comparison in
+    // draft(), so hash quality only affects bucket balance.
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (int i = end - min_match_; i < end; ++i) {
+        h ^= static_cast<uint32_t>(hist_[i]);
+        h *= 0x100000001b3ULL;
+    }
+    h ^= h >> 30;
+    h *= 0xbf58476d1ce4e5b9ULL;
+    h ^= h >> 27;
+    return h;
+}
+
+void SuffixDraftIndex::append(const int32_t* toks, int n) {
+    if (toks == nullptr || n <= 0)
+        return;
+    hist_.insert(hist_.end(), toks, toks + n);
+    const int total = static_cast<int>(hist_.size());
+    // A gram window [end - min_match, end) is new iff it covers at least one
+    // appended token, i.e. end > total - n (windows straddling the boundary
+    // included — they were not indexable before this append).
+    for (int end = std::max(min_match_, total - n + 1); end <= total; ++end) {
+        auto& occ = index_[gram_hash_at_(end)];
+        if (static_cast<int>(occ.size()) >= kMaxOccurrences)
+            occ.erase(occ.begin());
+        occ.push_back(end);
+    }
+}
+
+std::vector<int32_t> SuffixDraftIndex::draft(int k, int k_max, int* draft_start) const {
+    if (draft_start)
+        *draft_start = -1;
+    const int n = static_cast<int>(hist_.size());
+    if (k <= 0 || n < min_match_ + 1)
+        return {};
+    k_max = std::max(k, k_max);
+
+    const auto it = index_.find(gram_hash_at_(n));
+    if (it == index_.end())
+        return {};
+
+    // Candidate occurrences of the current suffix gram (collision-checked),
+    // each with its backward context-match length in [min_match_, max_match_].
+    const int32_t* suffix = hist_.data() + n - min_match_;
+    struct Candidate {
+        int end;  // one past the matched gram
+        int len;  // backward match length
+    };
+    std::vector<Candidate> cands;
+    cands.reserve(it->second.size());
+    for (const int end : it->second) {
+        if (end >= n)
+            continue;  // the suffix itself
+        if (!std::equal(suffix, suffix + min_match_, hist_.data() + end - min_match_))
+            continue;  // hash collision
+        int len = min_match_;
+        while (len < max_match_ && end - len - 1 >= 0 && n - len - 1 >= 0 &&
+               hist_[end - len - 1] == hist_[n - len - 1])
+            ++len;
+        cands.push_back({end, len});
+    }
+    if (cands.empty())
+        return {};
+
+    // Frequency-voted forward walk. Survivors are occurrences whose
+    // continuation matched every drafted token so far.
+    std::vector<int32_t> out;
+    out.reserve(k);
+    int rep_end = -1;  // representative survivor (longest len, then most recent)
+    for (int i = 0; i < k_max; ++i) {
+        int32_t best_tok = -1;
+        int best_votes = 0, best_len = 0, best_end = -1;
+        int voters = 0;
+        for (const auto& c : cands) {
+            if (c.end + i >= n)
+                continue;  // exhausted
+            ++voters;
+            const int32_t tok = hist_[c.end + i];
+            int votes = 0, longest = 0, recent = -1;
+            for (const auto& d : cands) {
+                if (d.end + i < n && hist_[d.end + i] == tok) {
+                    ++votes;
+                    longest = std::max(longest, d.len);
+                    recent = std::max(recent, d.end);
+                }
+            }
+            if (votes > best_votes || (votes == best_votes && longest > best_len) ||
+                (votes == best_votes && longest == best_len && recent > best_end)) {
+                best_tok = tok;
+                best_votes = votes;
+                best_len = longest;
+                best_end = recent;
+            }
+        }
+        if (voters == 0)
+            break;
+        // Past the base k, extend only on strong evidence: multiple
+        // agreeing occurrences, or a maximal-length context match (e.g.
+        // the prediction region tracking the completion token-exact).
+        const bool unanimous = best_votes == voters;
+        if (i >= k && !(unanimous && (best_votes >= 2 || best_len >= max_match_)))
+            break;
+        out.push_back(best_tok);
+        if (i == 0)
+            rep_end = best_end;  // source region of the draft's first token
+        // Drop disagreeing/exhausted occurrences.
+        cands.erase(std::remove_if(cands.begin(), cands.end(),
+                                   [&](const Candidate& c) {
+                                       return c.end + i >= n || hist_[c.end + i] != best_tok;
+                                   }),
+                    cands.end());
+    }
+    if (out.empty())
+        return {};
+    if (draft_start)
+        *draft_start = rep_end;
+    return out;
+}
+
+}  // namespace imp

--- a/src/runtime/suffix_draft.h
+++ b/src/runtime/suffix_draft.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace imp {
+
+// Suffix-indexed prompt-lookup drafting (SuffixDecoding-style, arXiv
+// 2411.04975). Same query contract as ngram_draft() — "longest suffix
+// match → continuation" — with three upgrades:
+//
+//   1. O(1) amortized matching: every min_match-gram of the history is
+//      hash-indexed as tokens arrive, instead of an O(n) backward scan
+//      per verify step (the scan also required rebuilding the full
+//      input++prediction++output vector each step).
+//   2. Frequency-voted continuations: the draft follows the majority
+//      next-token across ALL occurrences of the matched suffix, not the
+//      single most recent one (ties: longer context match, then recency).
+//   3. Adaptive draft length: a continuation backed by strong evidence —
+//      multiple agreeing occurrences, or a maximal-length (max_match)
+//      context match such as the OpenAI `prediction` region — extends
+//      past the base k up to k_max.
+//
+// The index owns a copy of the history (append-only; the engine feeds
+// input ++ prediction ++ output incrementally). Host memory only:
+// ~4 B/token history + ~16 B/token index — a few MiB at 128k context.
+class SuffixDraftIndex {
+public:
+    SuffixDraftIndex(int min_match, int max_match);
+
+    // Append tokens to the indexed history.
+    void append(const int32_t* toks, int n);
+    int size() const { return static_cast<int>(hist_.size()); }
+
+    // Draft up to k (base) / k_max (evidence-backed) tokens continuing the
+    // current history suffix. Returns empty when no min_match suffix gram
+    // recurs. draft_start (optional) receives the history index the winning
+    // continuation was copied from — one past the matched occurrence — for
+    // source-region classification (prompt / prediction / prior output).
+    std::vector<int32_t> draft(int k, int k_max, int* draft_start = nullptr) const;
+
+private:
+    uint64_t gram_hash_at_(int end) const;  // hash of hist_[end - min_match_, end)
+
+    int min_match_;
+    int max_match_;
+    std::vector<int32_t> hist_;
+    // gram hash → end positions (one past the gram), most recent last.
+    // Capped per key (most recent kept) to bound vote cost on degenerate
+    // histories (whitespace runs, repeated separators).
+    std::unordered_map<uint64_t, std::vector<int32_t>> index_;
+};
+
+}  // namespace imp

--- a/tests/test_suffix_draft.cpp
+++ b/tests/test_suffix_draft.cpp
@@ -1,0 +1,178 @@
+// Host-side tests for the suffix-indexed draft matcher
+// (src/runtime/suffix_draft.cpp) used by speculative decoding
+// (speculative.suffix). Mirrors the ngram_draft battery where semantics
+// coincide, plus the vote/adaptive-length/incremental behaviors that differ.
+
+#include "runtime/suffix_draft.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using imp::SuffixDraftIndex;
+
+namespace {
+
+SuffixDraftIndex make_index(const std::vector<int32_t>& hist, int min_match = 3, int max_match = 8) {
+    SuffixDraftIndex idx(min_match, max_match);
+    idx.append(hist.data(), static_cast<int>(hist.size()));
+    return idx;
+}
+
+std::vector<int32_t> draft(const std::vector<int32_t>& hist, int k, int min_match = 3, int max_match = 8,
+                           int k_max = 0, int* start = nullptr) {
+    auto idx = make_index(hist, min_match, max_match);
+    return idx.draft(k, k_max > 0 ? k_max : k, start);
+}
+
+TEST(SuffixDraft, EmptyWhenNoRepeat) { EXPECT_TRUE(draft({1, 2, 3, 4, 5, 6, 7, 8}, 4).empty()); }
+
+TEST(SuffixDraft, EmptyWhenTooShort) {
+    EXPECT_TRUE(draft({1, 2, 3}, 4).empty());
+    EXPECT_TRUE(draft({}, 4).empty());
+}
+
+TEST(SuffixDraft, FindsSimpleRepeat) {
+    std::vector<int32_t> h = {10, 11, 12, 13, 14, 99, 10, 11, 12};
+    auto d = draft(h, 4);
+    ASSERT_EQ(d.size(), 4u);
+    EXPECT_EQ(d[0], 13);
+    EXPECT_EQ(d[1], 14);
+    EXPECT_EQ(d[2], 99);
+    EXPECT_EQ(d[3], 10);
+}
+
+TEST(SuffixDraft, TruncatesAtK) {
+    std::vector<int32_t> h = {1, 2, 3, 4, 5, 6, 7, 8, 9, 50, 1, 2, 3};
+    auto d = draft(h, 2);
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[0], 4);
+    EXPECT_EQ(d[1], 5);
+}
+
+TEST(SuffixDraft, PrefersLongerMatchOnVoteTie) {
+    // Two occurrences of suffix [7,8,9] with different continuations
+    // (1 vote each): the one with the longer backward context match wins.
+    std::vector<int32_t> h = {6, 7, 8, 9, 100, 101, 5, 7, 8, 9, 200, 201, 6, 7, 8, 9};
+    auto d = draft(h, 2, 3, 8);
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[0], 100);
+    EXPECT_EQ(d[1], 101);
+}
+
+TEST(SuffixDraft, PrefersRecentOnEqualLength) {
+    std::vector<int32_t> h = {1, 7, 8, 9, 100, 2, 7, 8, 9, 200, 3, 7, 8, 9};
+    auto d = draft(h, 1, 3, 3);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 200);
+}
+
+TEST(SuffixDraft, MajorityVoteBeatsRecency) {
+    // Suffix [7,8,9] occurs three times: twice continuing with 100, once
+    // (most recently) with 200. Frequency wins over recency — this is the
+    // deliberate semantic upgrade over ngram_draft.
+    std::vector<int32_t> h = {1, 7, 8, 9, 100, 2, 7, 8, 9, 100, 3, 7, 8, 9, 200, 4, 7, 8, 9};
+    auto d = draft(h, 1, 3, 3);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 100);
+}
+
+TEST(SuffixDraft, VoteNarrowsToSurvivors) {
+    // Both occurrences agree on the first continuation token (20) then
+    // diverge (100 vs 200); after the divergence only the surviving branch
+    // keeps voting. Majority path: 20, then tie broken by recency → 200.
+    std::vector<int32_t> h = {7, 8, 9, 20, 100, 5, 7, 8, 9, 20, 200, 6, 7, 8, 9};
+    auto d = draft(h, 3, 3, 3);
+    ASSERT_EQ(d.size(), 3u);
+    EXPECT_EQ(d[0], 20);
+    EXPECT_EQ(d[1], 200);
+    EXPECT_EQ(d[2], 6);
+}
+
+TEST(SuffixDraft, OverlappingPeriodicPattern) {
+    std::vector<int32_t> h = {7, 8, 7, 8, 7, 8};
+    auto d = draft(h, 2, 2, 4);
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[0], 7);
+    EXPECT_EQ(d[1], 8);
+}
+
+TEST(SuffixDraft, DegenerateParamsRejected) {
+    std::vector<int32_t> h = {1, 2, 3, 1, 2, 3};
+    auto idx = make_index(h);
+    EXPECT_TRUE(idx.draft(0, 0).empty());
+    SuffixDraftIndex empty_idx(3, 8);
+    empty_idx.append(nullptr, 5);
+    EXPECT_EQ(empty_idx.size(), 0);
+    EXPECT_TRUE(empty_idx.draft(4, 4).empty());
+}
+
+TEST(SuffixDraft, IncrementalAppendMatchesBulkBuild) {
+    // Building the index token-by-token (the engine's steady state) must
+    // produce the same drafts as one bulk append — boundary grams included.
+    std::vector<int32_t> h = {10, 11, 12, 13, 14, 99, 42, 10, 11, 12, 13, 14, 99, 10, 11, 12};
+    auto bulk = make_index(h, 3, 8);
+    SuffixDraftIndex inc(3, 8);
+    for (const int32_t t : h)
+        inc.append(&t, 1);
+    ASSERT_EQ(bulk.size(), inc.size());
+    int s1 = -1, s2 = -1;
+    auto d1 = bulk.draft(8, 8, &s1);
+    auto d2 = inc.draft(8, 8, &s2);
+    EXPECT_EQ(d1, d2);
+    EXPECT_EQ(s1, s2);
+    ASSERT_FALSE(d1.empty());
+    EXPECT_EQ(d1[0], 13);
+}
+
+TEST(SuffixDraft, AdaptiveLengthExtendsOnMultiOccurrenceAgreement) {
+    // The continuation [20..29] appears after [7,8,9] twice and both
+    // occurrences agree: the draft may extend past base k (4) up to k_max.
+    std::vector<int32_t> h;
+    for (int rep = 0; rep < 2; ++rep) {
+        h.insert(h.end(), {7, 8, 9});
+        for (int i = 0; i < 10; ++i)
+            h.push_back(20 + i);
+        h.push_back(90 + rep);  // diverge after the shared run
+    }
+    h.insert(h.end(), {7, 8, 9});
+    auto d = draft(h, 4, 3, 3, /*k_max=*/16);
+    ASSERT_EQ(d.size(), 10u);  // unanimous shared run, stops at divergence
+    for (int i = 0; i < 10; ++i)
+        EXPECT_EQ(d[i], 20 + i);
+}
+
+TEST(SuffixDraft, AdaptiveLengthStopsAtKForSingleWeakMatch) {
+    // A single occurrence with a minimal (min_match-length) context match
+    // is weak evidence: the draft must stop at base k.
+    std::vector<int32_t> h = {5, 7, 8, 9, 20, 21, 22, 23, 24, 25, 26, 27, 6, 7, 8, 9};
+    auto d = draft(h, 4, 3, 8, /*k_max=*/16);
+    ASSERT_EQ(d.size(), 4u);
+    EXPECT_EQ(d[0], 20);
+    EXPECT_EQ(d[3], 23);
+}
+
+TEST(SuffixDraft, AdaptiveLengthExtendsOnMaximalContextMatch) {
+    // A single occurrence whose backward match saturates max_match (the
+    // prediction-region case) is strong evidence: extend to k_max.
+    std::vector<int32_t> h;
+    for (int i = 0; i < 20; ++i)
+        h.push_back(100 + i);  // "prediction"
+    h.push_back(999);
+    for (int i = 0; i < 8; ++i)
+        h.push_back(100 + i);  // completion tracks it
+    auto d = draft(h, 4, 3, /*max_match=*/6, /*k_max=*/10);
+    ASSERT_EQ(d.size(), 10u);
+    for (int i = 0; i < 10; ++i)
+        EXPECT_EQ(d[i], 108 + i);
+}
+
+TEST(SuffixDraft, DraftStartClassifiesSourceRegion) {
+    std::vector<int32_t> h = {10, 11, 12, 13, 14, 99, 10, 11, 12};
+    int start = -1;
+    auto idx = make_index(h);
+    auto d = idx.draft(4, 4, &start);
+    ASSERT_FALSE(d.empty());
+    EXPECT_EQ(start, 3);  // one past the matched [10,11,12] occurrence
+}
+
+}  // namespace

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -33,6 +33,16 @@ int main(int argc, char** argv) {
                 user_set = true;
         if (!user_set)
             runtime_cfg.speculative.moe = false;
+        // The suffix drafter is decidedly NOT bench-neutral (frequency-voted
+        // adaptive drafts hit +170% tg128 on the bench prompt) — pin it to
+        // the legacy scan so tests/perf_baseline.json keeps its raw-decode
+        // semantics. An explicit --set speculative.suffix=… still wins.
+        bool suffix_set = false;
+        for (const auto& ov : args.config_overrides)
+            if (ov.rfind("speculative.suffix=", 0) == 0)
+                suffix_set = true;
+        if (!suffix_set)
+            runtime_cfg.speculative.suffix = false;
         // Recurrent snapshots (hybrid prefix caching) are dead weight in the
         // single-shot bench but their eager buffers shift the MoE expert
         // offload budget — pin them off so hybrid GGUF baselines are


### PR DESCRIPTION
## Summary

Implements #843 (frontier scan Tier 1): a SuffixDecoding-style (arXiv 2411.04975) suffix-indexed drafter as the successor to the n-gram prompt-lookup matcher, behind `speculative.suffix` (default **on**; `false` = legacy scan).

Three upgrades over `ngram_draft`, all host-side — the verify loop, gates, miss-burst/give-up economics, KV rollback, and MoE gate are untouched:

1. **O(1) amortized matching** — every `min_match`-gram of `input ++ prediction ++ output` is hash-indexed incrementally (`SuffixDraftIndex`, new TU `src/runtime/suffix_draft.{h,cpp}`), replacing the per-step O(n) backward scan *and* the per-step full history-vector rebuild.
2. **Frequency-voted continuations** — the draft follows the majority next-token across ALL occurrences of the matched suffix (ties: longer context match, then recency) instead of the single most recent occurrence.
3. **Adaptive draft length** — a continuation backed by strong evidence (≥2 agreeing occurrences, or a maximal-length `max_match` context match, e.g. the OpenAI `prediction` region) extends past `k` up to `suffix_k_max` (default 64).

Per-request index lives in an engine-side map (built lazily at first verify, extended with output tokens as they land — loop-burst tokens included; erased on request finish).

## Measurements (RTX 5090, healthy clocks sampled during runs)

Code-edit workload (rename-class over a ~100-line file, temp 0, 3 trials):

| Model | spec off | legacy ngram | suffix | Δ vs legacy |
|---|---|---|---|---|
| Qwen3-Coder-30B-A3B-FP4 (MoE) | 329 | 536-584 | **1016-1194** | **~+2×** |
| Qwen3-8B-Q8 (dense) | 197 | 489 | **762** | **+56%** |

Accept economics shift as designed: legacy 98% accept @ 16.7 tok/verify → suffix 84% accept @ **44.9 tok/verify** (fewer, longer verify chunks; 17 vs 44 verify forwards for the same completion).

Draft-poor floor unchanged: free-form prose produces 0 drafts in both matchers (identical miss counts → same burst-hybrid path).

## Losslessness

Q8 dense, code-edit prompt: completion text **identical** across suffix / legacy / spec-off (whitespace-exact after stripping interleaved log lines). Greedy verify semantics are untouched, so this holds by construction; measured anyway.

## Bench-gate protection

`imp-cli --bench` now pins `speculative.suffix=false` (explicit `--set speculative.suffix=…` wins), mirroring the #824 `speculative.moe` pin: the suffix drafter is decidedly not bench-neutral (+172% tg128 on the bench prompt), and `tests/perf_baseline.json` keeps its raw-ish semantics. **No baseline refresh.**

Verified gate parity vs main (interleaved A/B on the exact gate invocation): identical spec stats (112 verifies, 3.99 tok/verify, 99.7% accept) and identical raw decode (263 vs 263 tok/s); the residual scatter in spec-engaged bench mode is the documented verify-inherits-prefill restart variance (#824). Pre-existing observation, out of scope here: the canonical gate bench engages legacy n-gram speculation on the bench prompt (~4 tok/verify) on main too — worth a follow-up decision whether the gate should pin `speculative.ngram=false` entirely.

## Tests

- 15 new host-side unit tests (`tests/test_suffix_draft.cpp`): ngram-battery parity where semantics coincide, plus majority-vote, survivor-narrowing, incremental-append == bulk-build, adaptive-length (extend on multi-occurrence / maximal-context, stop on weak single match), draft_start classification.
- `make test-gpu` full suite green (exit 0, 1371 tests PASSED across the split binaries, 0 failed).
- `verify-fast` green (fast gtest filter + perf gate + long-ctx FA2 gate, models mounted).

Follow-up (#843 option 2, not in this PR): cross-request corpus (server-side session store) for drafting from prior requests' outputs.

Closes #843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxKdHw92QcwfMZSj9aMisW