### PR TITLE
fix(constraints): reject backslash escapes in schema object keys (#850)

### DIFF
--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -759,8 +759,13 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                 f.phase = SchemaPhase::OBJECT_AFTER_KEY;
                 return true;
             }
+            // No escapes in keys (#850): accepting '\' and dropping it let
+            // the NEXT char match the property prefix while the emitted
+            // text carried the escape — `{"\number_x":5}` passed the mask.
+            // Property names are matched on raw chars (escapes were never
+            // decoded), so no legal key needs one.
             if (c == '\\')
-                return true;  // key escape (rare)
+                return false;
             if (!f.node || !is_valid_key_prefix(f.node, f.key_buffer + c, f.emitted_keys))
                 return false;
             f.key_buffer += c;

--- a/tests/test_schema_constrain.cu
+++ b/tests/test_schema_constrain.cu
@@ -213,6 +213,42 @@ TEST(SchemaConstrainTest, PrematureObjectCloseRejected) {
     EXPECT_FALSE(a[5]) << "'{}' combined token must be rejected — required 'code' unmet";
 }
 
+// #850: a backslash inside an object KEY was accepted and silently dropped
+// (no phase change, no buffer append), so the NEXT char matched the property
+// prefix while the emitted text carried the escape — `{"\number_x":5}`-style
+// schema-invalid keys observed live on Qwen3-8B json_schema. Property names
+// are matched on raw chars (escape sequences were never decoded), so no
+// legal key needs an escape: reject `\` in keys outright, single-char and
+// smuggled inside a multi-char token alike.
+TEST(SchemaConstrainTest, BackslashInKeyRejected) {
+    SKIP_IF_NO_CUDA();
+    //                                 0       1      2      3    4     5    6     7      8
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "n", "\\", "\"\\n", "um"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"num":{"type":"string"}},"required":["num"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+
+    // At OBJECT_OPEN: a combined token opening the key with an escape
+    // (`"\n`) must be masked; the bare quote stays legal.
+    sc.update(3);  // "{" -> OBJECT_OPEN
+    auto open = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(open[4]) << "bare '\"' must open the key";
+    EXPECT_FALSE(open[7]) << "'\"\\n' must be masked — escape smuggled into the key";
+
+    // Inside OBJECT_KEY: the bare backslash must be masked; real key
+    // prefixes stay legal.
+    sc.update(4);  // '"' -> OBJECT_KEY
+    auto key = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(key[5]) << "'n' is a valid prefix of 'num'";
+    EXPECT_FALSE(key[6]) << "'\\' must be masked inside a key (#850)";
+    EXPECT_FALSE(key[8]) << "'um' is not a valid prefix of 'num'";
+}
+
 // After the last property's value, a comma would dangle (no key can follow) —
 // it must be masked, leaving only the closing brace. Prevents `{"a":"x",}`.
 TEST(SchemaConstrainTest, TrailingCommaRejected) {


### PR DESCRIPTION
Fixes #850.

## Root cause

`sim_advance`'s `OBJECT_KEY` phase accepted `\` and **silently dropped it** — no phase change, no `key_buffer` append (`schema_constrain.cu`, the old `if (c == '\\') return true;  // key escape (rare)`). The next char then matched the property prefix (`is_valid_key_prefix("n…")` → `number_…`) while the emitted text carried the escape, so the mask admitted schema-invalid keys like `{"\number_of_forecast_days":5}` (observed live on Qwen3-8B Q8, json_schema, greedy).

## Fix

Reject `\` in keys outright. Property names are matched on **raw** chars (escape sequences were never decoded anywhere in the key path), so no legal key ever needs an escape — properties whose names would require one (`"` or `\` in the name) were already silently broken before this change. `token_legal` simulates char-by-char, so multi-char tokens smuggling the escape (`"\n…` opening the key) are masked too.

## Second symptom from the issue: not a bug

The "Invalid control character" parse error was **max_tokens truncation** mid-string plus the test harness's trailing newline — the error position is the last byte of the truncated document. `STRING_VALUE`/`STRING_PATTERN`/`STRING_ESCAPE` already reject raw control chars. `ENUM_VALUE` has no escape hole either (raw prefix match).

## Tests

- New `SchemaConstrainTest.BackslashInKeyRejected` — RED against the old code (the `"\n` smuggle token passed the mask), GREEN with the fix; bare `\` and multi-char smuggle both covered, valid prefixes stay legal.
- Full constrain suite 66/66 green on GPU.
- e2e: original repro prompt (nested weather schema) on Qwen3-8B Q8 — keys now clean (`{"weather_forecast_request":{"location_city_name":…`), no backslash keys across reps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)