### PR TITLE
feat(spec): hybrid-safe verify (recurrent-state snapshot/replay) + MTP drafts as verify source (#847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+- **Speculative decoding on hybrid (GDN/SSM) models** — `speculative.hybrid`
+  (default on; imp-cli `--bench` pins it off): the verify chunk snapshots the
+  committed recurrent-state slab and, on partial acceptance, restores it and
+  re-forwards the accepted prefix, so suffix/n-gram speculation now engages on
+  Qwen3.5/3.6 and Nemotron-H hybrids. Measured (greedy, temp 0): Nemotron-3-
+  Nano-30B code-edit +60% tg, Qwen3.6-35B code-edit +18%, Qwen3.6-27B
+  prompt-echo prose +156%; draft-poor prompts are unchanged (miss-burst
+  hybrid). Token-lossless verified on Qwen3.5-4B (#847 enabler).
+- **MTP verify activation** (#847) — the trained MTP head now feeds the
+  verify loop as a draft source when the suffix matcher has no match
+  (`--mtp-spec-decode <k>` / `speculative.mtp_k`, default off). Loads both
+  sidecar MoE heads (Qwen3.6-35B `model_mtp.safetensors`) and embedded dense
+  heads (Qwen3.6-27B `mtp.*` in the main shard, new). Chunked-prefill-capable
+  MTP cache feed with DeepSeek-aligned pairing and feed-only forwards (no
+  lm_head), multi-turn prefix resume, and an economics guard that dooms MTP
+  drafting per request when average emitted/verify cannot beat the async
+  loop (measured: accept 44-91% but net-negative on current verify
+  economics — see #847 for follow-ups).
+
 ## [0.16.0] - 2026-07-02
 
 Multi-server-per-GPU (hard VRAM budget) + load/teardown robustness.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ set(IMP_RUNTIME_SOURCES
     src/runtime/engine_graph_decode.cpp
     src/runtime/engine_scheduler.cpp
     src/runtime/engine_spec_ngram.cpp
+    src/runtime/engine_spec_mtp.cpp
     src/runtime/engine_sampling_stop.cpp
     src/runtime/ngram_draft.cpp
     src/runtime/suffix_draft.cpp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,7 +130,17 @@ Per token:
    `src/compute/sampling.{h,cu}` (`sample_greedy`, `sample_topk_topp`,
    `sample_mirostat_v2`, `apply_typical_p`).
 7. **Stop check** — EOS, max_tokens, stop strings.
-8. **(Optional) MTP spec-decode draft** — `src/compute/mtp_forward.cu`.
+8. **(Optional) speculative decoding** — batch-1 greedy requests verify
+   drafts as teacher-forced continuation chunks
+   (`src/runtime/engine_spec_ngram.cpp`). Draft sources: the suffix index /
+   n-gram matcher (`src/runtime/suffix_draft.{h,cpp}`,
+   `src/runtime/ngram_draft.h`), and — opt-in — the trained MTP head
+   (`src/runtime/engine_spec_mtp.cpp`, forward in
+   `src/compute/mtp_forward.cu`). Hybrid (SSM/GDN) models participate via a
+   recurrent-state slab snapshot around the verify chunk (a partial
+   acceptance restores the slab and re-forwards the accepted prefix);
+   `speculative.hybrid` in `imp.conf` gates it, imp-cli `--bench` pins it
+   off.
 
 ## Subsystems referenced across phases
 

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -333,6 +333,15 @@ miss_burst           = 8
 # Re-arm an existing conditional decode graph on a draft miss instead of a
 # fresh capture (both share the same first-forward semantics since #692).
 burst_rearm          = true
+# Speculation on hybrid (GDN/SSM) models: the committed recurrent-state slab
+# is snapshotted around the verify chunk; a partial acceptance restores it and
+# re-forwards the accepted prefix. imp-cli --bench pins this false.
+hybrid               = true
+# MTP-head chain-draft length (models shipping model_mtp.safetensors, e.g.
+# Qwen3.6). 0 = off. When > 0 the server loads the head (~1.6 GiB VRAM) and
+# MTP chains fill verify steps where the suffix matcher has no draft.
+# imp-cli equivalent: --mtp-spec-decode <k>.
+mtp_k                = 0
 
 [constrained]
 # Jump-ahead over schema-forced spans (#844): when the json_schema FSM

--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -434,20 +434,12 @@ bool mtp_workspace_allocate(MtpDraftWorkspace& ws, int hidden_dim, int vocab_siz
     }
 
     // Phase 2.2 MoE buffers (only if n_experts > 0)
-    if (ok && n_experts > 0 && top_k > 0 && expert_d_ff > 0) {
-        ok &= alloc(&ws.d_post_norm,       hidden_dim * sizeof(__half));
+    const bool has_moe = n_experts > 0 && top_k > 0 && expert_d_ff > 0;
+    if (ok && has_moe) {
         ok &= alloc(&ws.d_router_logits,   n_experts * sizeof(__half));
         ok &= alloc(&ws.d_expert_gate_up,  2 * expert_d_ff * sizeof(__half));
         ok &= alloc(&ws.d_expert_act,      expert_d_ff * sizeof(__half));
         ok &= alloc(&ws.d_expert_outputs,  top_k * hidden_dim * sizeof(__half));
-        ok &= alloc(&ws.d_moe_out,         hidden_dim * sizeof(__half));
-
-        if (shared_d_ff > 0) {
-            ok &= alloc(&ws.d_shared_gate, shared_d_ff * sizeof(__half));
-            ok &= alloc(&ws.d_shared_up,   shared_d_ff * sizeof(__half));
-            ok &= alloc(&ws.d_shared_act,  shared_d_ff * sizeof(__half));
-            ok &= alloc(&ws.d_shared_out,  hidden_dim * sizeof(__half));
-        }
 
         // Routing pool (max 1 token for M=1 decode).
         ws.routing_buf.allocate(/*max_tokens=*/1, /*max_experts=*/n_experts, /*top_k=*/top_k);
@@ -459,6 +451,19 @@ bool mtp_workspace_allocate(MtpDraftWorkspace& ws, int hidden_dim, int vocab_siz
             ok &= (cudaHostAlloc(reinterpret_cast<void**>(&ws.h_expert_weights),
                                   top_k * sizeof(float), cudaHostAllocDefault) == cudaSuccess);
         }
+    }
+    // MLP scratch shared by both variants: the MoE shared expert AND the
+    // dense MTP MLP (Qwen3.6 dense checkpoints embed a plain SwiGLU MLP,
+    // mapped onto the shared_expert fields — no router, no sigmoid gate).
+    if (ok && (has_moe || shared_d_ff > 0)) {
+        ok &= alloc(&ws.d_post_norm, hidden_dim * sizeof(__half));
+        ok &= alloc(&ws.d_moe_out,   hidden_dim * sizeof(__half));
+    }
+    if (ok && shared_d_ff > 0) {
+        ok &= alloc(&ws.d_shared_gate, shared_d_ff * sizeof(__half));
+        ok &= alloc(&ws.d_shared_up,   shared_d_ff * sizeof(__half));
+        ok &= alloc(&ws.d_shared_act,  shared_d_ff * sizeof(__half));
+        ok &= alloc(&ws.d_shared_out,  hidden_dim * sizeof(__half));
     }
 
     if (!ok) mtp_workspace_free(ws);
@@ -521,7 +526,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         IMP_LOG_ERROR("mtp_draft_step: MTP head not loaded");
         return false;
     }
-    if (!d_h_prev || !out_token_id) return false;
+    if (!d_h_prev) return false;  // out_token_id == nullptr → feed-only step
     if (!ws.d_emb_norm || !ws.d_h_norm || !ws.d_fc_in || !ws.d_fc_out ||
         !ws.d_h_final || !ws.d_logits) {
         IMP_LOG_ERROR("mtp_draft_step: workspace not allocated");
@@ -780,12 +785,20 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         (void)mtp.k_norm;
     }
 
-    // 5.B — MoE (Phase 2.2.MoE, this commit): full 256-expert top-8 MoE
-    //   forward + shared-expert with sigmoid gating. Uses the existing
-    //   imp::moe_gate_topk_fused / swiglu / shared_expert_gate_scale
-    //   primitives.
-    if (ws.n_experts > 0 && ws.top_k > 0 && ws.expert_d_ff > 0 &&
-        mtp.router.data != nullptr) {
+    // 5.B — MLP block. Two checkpoint variants:
+    //   MoE (Qwen3.6-35B sidecar): 256-expert top-8 MoE + shared expert with
+    //     sigmoid gating (imp::moe_gate_topk_fused / swiglu /
+    //     shared_expert_gate_scale primitives).
+    //   Dense (Qwen3.6-27B embedded head): a plain SwiGLU MLP — loaded onto
+    //     the shared_expert fields, no router, no sigmoid gate. Runs as
+    //     "residual + shared path" with the expert stage skipped.
+    const bool mtp_has_moe = ws.n_experts > 0 && ws.top_k > 0 && ws.expert_d_ff > 0 &&
+                             mtp.router.data != nullptr;
+    const bool mtp_has_dense_mlp = !mtp_has_moe && ws.shared_d_ff > 0 &&
+                                   mtp.shared_expert_gate_proj.data != nullptr &&
+                                   mtp.shared_expert_up_proj.data != nullptr &&
+                                   mtp.shared_expert_down_proj.data != nullptr;
+    if (mtp_has_moe || mtp_has_dense_mlp) {
         const int hd = hidden_dim;
         const int d_ff_e = ws.expert_d_ff;
         const int d_ff_s = ws.shared_d_ff;
@@ -800,6 +813,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
             imp::rmsnorm(fc_out_view, mtp.post_attention_layernorm, pn_view, 1e-6f, stream);
         }
 
+        if (mtp_has_moe) {
         // 5.B.2 — Router + top-k. moe_gate_topk_fused: router @ post_norm,
         //         softmax, top-k. Writes into ws.routing_buf.
         MoeRoutingResult routing{};
@@ -881,12 +895,19 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
             /*d_model=*/       hd,
             /*top_k=*/         top_k,
             stream);
+        } else {
+            // Dense variant: no experts — the accumulator starts as the pure
+            // residual and the "shared" path below IS the MLP.
+            cudaMemcpyAsync(ws.d_moe_out, ws.d_fc_out, hd * sizeof(__half),
+                            cudaMemcpyDeviceToDevice, stream);
+        }
 
-        // 5.B.6 — Shared expert (if present): silu(gate_proj·x) * (up_proj·x),
-        //         scale by sigmoid(shared_expert_gate_inp · x), then add to
-        //         moe_out (which already includes the attention residual).
+        // 5.B.6 — Shared expert / dense MLP: silu(gate_proj·x) * (up_proj·x),
+        //         optionally scaled by sigmoid(shared_expert_gate · x) (MoE
+        //         checkpoints only), added to moe_out (which already includes
+        //         the attention residual).
         if (d_ff_s > 0 && mtp.shared_expert_gate_proj.data && mtp.shared_expert_up_proj.data &&
-            mtp.shared_expert_down_proj.data && mtp.shared_expert_gate.data) {
+            mtp.shared_expert_down_proj.data) {
             // shared_gate = shared_expert_gate_proj @ post_norm  → [d_ff_s]
             {
                 int64_t in_shape[2]  = {1, hd};
@@ -920,15 +941,18 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                 imp::gemm(in_view, mtp.shared_expert_down_proj, out_view, 1.0f, 0.0f, stream);
             }
             // Apply sigmoid(shared_expert_gate · post_norm) scalar to shared_out
-            // in-place via the existing fused kernel.
-            imp::shared_expert_gate_scale(
-                /*x=*/ ws.d_post_norm,
-                /*W=*/ mtp.shared_expert_gate.data,
-                /*y_inout=*/ ws.d_shared_out,
-                /*n=*/ 1,
-                /*d_model=*/ hd,
-                /*d=*/ hd,
-                stream);
+            // in-place via the existing fused kernel. MoE checkpoints only —
+            // the dense-MLP variant has no gate tensor and is unscaled.
+            if (mtp.shared_expert_gate.data != nullptr) {
+                imp::shared_expert_gate_scale(
+                    /*x=*/ ws.d_post_norm,
+                    /*W=*/ mtp.shared_expert_gate.data,
+                    /*y_inout=*/ ws.d_shared_out,
+                    /*n=*/ 1,
+                    /*d_model=*/ hd,
+                    /*d=*/ hd,
+                    stream);
+            }
 
             // moe_out += shared_out → write back into d_fc_out for downstream
             {
@@ -956,6 +980,11 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         Tensor h_final_view(ws.d_h_final, QType::F16, 2, hd1_shape, true);
         imp::rmsnorm(fc_out_view, mtp.final_norm, h_final_view, 1e-6f, stream);
     }
+
+    // Feed-only step (prefill / verify catch-up): the KV append above is the
+    // whole point — skip the lm_head GEMV, argmax and stream sync.
+    if (out_token_id == nullptr)
+        return true;
 
     // Step 7: logits = lm_head @ h_final
     {

--- a/src/compute/mtp_forward.h
+++ b/src/compute/mtp_forward.h
@@ -149,7 +149,13 @@ struct MtpDraftWorkspace {
 //   - stream
 //
 // Output:
-//   - *out_token_id   : drafted next token id (D2H copy of argmax)
+//   - *out_token_id   : drafted next token id (D2H copy of argmax). Pass
+//                       nullptr to skip the lm_head GEMV + argmax + stream
+//                       sync entirely — a cache-feed-only step (prefill /
+//                       verify catch-up positions whose prediction is never
+//                       consumed). The lm_head read (~1 GiB FP16 on Qwen3.6's
+//                       248k vocab) dominates per-step cost, so feed-only
+//                       steps are ~an order of magnitude cheaper.
 //   - out_topk_ids    : optional [top_w] host buffer; when non-null and
 //                       top_w>0, receives the top-W candidate ids in
 //                       descending-logit order (out_topk_ids[0] == *out_token_id).

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -556,9 +556,14 @@ struct ShardInfo {
     size_t mmap_size = 0;
 };
 
+// mtp_out (optional): when non-null, `mtp.*` / `model.mtp.*` tensors — which
+// translate_name otherwise SKIPs — are collected there under their raw
+// `mtp.*` name (the `model.` prefix stripped). Dense Qwen3.6 checkpoints
+// embed the MTP head in the main shard instead of a sidecar.
 static bool load_shard(const std::string& path, std::unordered_map<std::string, Tensor>& tensor_map,
                        ShardInfo& shard, bool llm_compressor_format,
-                       imp::llm_compressor::TranslationCounters& counters) {
+                       imp::llm_compressor::TranslationCounters& counters,
+                       std::unordered_map<std::string, Tensor>* mtp_out = nullptr) {
     int fd = open(path.c_str(), O_RDONLY);
     if (fd < 0) {
         IMP_LOG_ERROR("Failed to open: %s", path.c_str());
@@ -640,11 +645,23 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
             continue;
 
         // Translate llm-compressor names → modelopt names if applicable.
+        bool divert_to_mtp = false;
         if (llm_compressor_format) {
             auto translated = imp::llm_compressor::translate_name(tensor_name, counters);
-            if (translated.action == imp::llm_compressor::NameTranslation::SKIP)
-                continue;
-            tensor_name = std::move(translated.out_name);
+            if (translated.action == imp::llm_compressor::NameTranslation::SKIP) {
+                // Embedded MTP head: keep the tensor, but route it to the
+                // separate MTP map under its raw mtp.* name.
+                if (mtp_out != nullptr) {
+                    if (tensor_name.rfind("model.mtp.", 0) == 0)
+                        tensor_name = tensor_name.substr(6);  // strip "model."
+                    if (tensor_name.rfind("mtp.", 0) == 0)
+                        divert_to_mtp = true;
+                }
+                if (!divert_to_mtp)
+                    continue;
+            } else {
+                tensor_name = std::move(translated.out_name);
+            }
         }
 
         const JValue* dtype_val = jobj_find(tensor_meta, "dtype");
@@ -713,7 +730,7 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
 
         void* tensor_ptr = tensor_data_base + offset_start;
         Tensor t(tensor_ptr, dtype, ndim, shape, /*on_device=*/false);
-        tensor_map.emplace(tensor_name, t);
+        (divert_to_mtp ? *mtp_out : tensor_map).emplace(tensor_name, t);
 
         IMP_LOG_DEBUG("Tensor: %s dtype=%s shape=[%ld%s%s%s%s] offsets=[%lu,%lu]", tensor_name.c_str(),
                       dtype_val->str_val.c_str(), (long)shape[0], ndim > 1 ? "," : "",
@@ -877,13 +894,18 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
                                  probe_cfg.format == imp::HFConfigLoader::NvFP4Format::LLM_COMPRESSOR;
     imp::llm_compressor::TranslationCounters tcounters{};
 
-    // Try loading tensors
+    // Try loading tensors. embedded_mtp_map collects `mtp.*` tensors that
+    // dense Qwen3.6 checkpoints embed in the main shard (no sidecar); only
+    // populated when the caller asked for the MTP head.
     bool loaded = false;
+    std::unordered_map<std::string, Tensor> embedded_mtp_map;
+    auto* mtp_collect = load_mtp_head ? &embedded_mtp_map : nullptr;
 
     if (!single_file.empty()) {
         // Single file mode
         ShardInfo shard;
-        loaded = load_shard(single_file, tensor_map, shard, llm_compressor_format, tcounters);
+        loaded = load_shard(single_file, tensor_map, shard, llm_compressor_format, tcounters,
+                            mtp_collect);
         if (loaded)
             shards.push_back(shard);
     } else {
@@ -896,7 +918,8 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             std::string st_path = model_dir + "/model.safetensors";
             if (fs::exists(st_path)) {
                 ShardInfo shard;
-                loaded = load_shard(st_path, tensor_map, shard, llm_compressor_format, tcounters);
+                loaded = load_shard(st_path, tensor_map, shard, llm_compressor_format, tcounters,
+                                    mtp_collect);
                 if (loaded)
                     shards.push_back(shard);
             }
@@ -931,74 +954,98 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
     std::optional<imp::MtpHead> mtp_local;
     std::unordered_map<std::string, Tensor> mtp_tensor_map;
     ShardInfo mtp_shard{};
+
+    // Dispatch a raw mtp.* tensor map to MtpHead fields. Two MLP variants:
+    //   MoE (Qwen3.6-35B): router + packed experts + gated shared expert.
+    //   Dense (Qwen3.6-27B embedded head): plain SwiGLU gate/up/down —
+    //     mapped onto the shared_expert fields (router/experts stay empty;
+    //     mtp_forward runs it as "residual + shared path", no sigmoid gate).
+    auto dispatch_mtp = [](std::unordered_map<std::string, Tensor>& tm, const std::string& src,
+                           size_t bytes) -> imp::MtpHead {
+        imp::MtpHead head;
+        head.info.path       = src;
+        head.info.file_bytes = bytes;
+        head.info.n_tensors  = static_cast<int>(tm.size());
+        auto take = [&](const char* key, Tensor& dst) -> bool {
+            auto it = tm.find(key);
+            if (it == tm.end()) return false;
+            dst = it->second;
+            return true;
+        };
+        bool ok = true;
+        ok &= take("mtp.pre_fc_norm_embedding.weight", head.pre_fc_norm_embedding);
+        ok &= take("mtp.pre_fc_norm_hidden.weight",    head.pre_fc_norm_hidden);
+        ok &= take("mtp.fc.weight",                    head.fc);
+        ok &= take("mtp.layers.0.input_layernorm.weight",          head.input_layernorm);
+        ok &= take("mtp.layers.0.post_attention_layernorm.weight", head.post_attention_layernorm);
+        ok &= take("mtp.layers.0.self_attn.q_proj.weight", head.q_proj);
+        ok &= take("mtp.layers.0.self_attn.k_proj.weight", head.k_proj);
+        ok &= take("mtp.layers.0.self_attn.v_proj.weight", head.v_proj);
+        ok &= take("mtp.layers.0.self_attn.o_proj.weight", head.o_proj);
+        ok &= take("mtp.layers.0.self_attn.q_norm.weight", head.q_norm);
+        ok &= take("mtp.layers.0.self_attn.k_norm.weight", head.k_norm);
+        ok &= take("mtp.norm.weight", head.final_norm);
+
+        const bool moe =
+            take("mtp.layers.0.mlp.gate.weight", head.router) &&
+            take("mtp.layers.0.mlp.experts.gate_up_proj", head.experts_gate_up_packed) &&
+            take("mtp.layers.0.mlp.experts.down_proj", head.experts_down_packed) &&
+            take("mtp.layers.0.mlp.shared_expert.gate_proj.weight", head.shared_expert_gate_proj) &&
+            take("mtp.layers.0.mlp.shared_expert.up_proj.weight", head.shared_expert_up_proj) &&
+            take("mtp.layers.0.mlp.shared_expert.down_proj.weight", head.shared_expert_down_proj) &&
+            take("mtp.layers.0.mlp.shared_expert_gate.weight", head.shared_expert_gate);
+        const bool dense =
+            !moe &&
+            take("mtp.layers.0.mlp.gate_proj.weight", head.shared_expert_gate_proj) &&
+            take("mtp.layers.0.mlp.up_proj.weight", head.shared_expert_up_proj) &&
+            take("mtp.layers.0.mlp.down_proj.weight", head.shared_expert_down_proj);
+        ok &= (moe || dense);
+
+        head.loaded = ok;
+        if (ok) {
+            IMP_LOG_INFO("MTP head loaded: %s (%d tensors, %s MLP, BF16)", src.c_str(),
+                         head.info.n_tensors, moe ? "MoE" : "dense");
+        } else {
+            IMP_LOG_WARN("MTP head detected at %s but some expected tensors were missing; "
+                         "spec-decode disabled for this model", src.c_str());
+        }
+        return head;
+    };
+
     if (load_mtp_head && !model_dir.empty()) {
         std::string mtp_path = model_dir + "/model_mtp.safetensors";
         std::error_code ec;
         auto sz = fs::file_size(mtp_path, ec);
         if (!ec && sz > 0) {
-            // Load the file as a standalone shard. llm_compressor_format=false
-            // so translate_name() is NOT applied — MTP tensor names need to
-            // stay literal for dispatch.
+            // Sidecar variant. Load the file as a standalone shard.
+            // llm_compressor_format=false so translate_name() is NOT applied —
+            // MTP tensor names need to stay literal for dispatch.
             imp::llm_compressor::TranslationCounters mtp_counters{};
             bool mtp_loaded = load_shard(mtp_path, mtp_tensor_map, mtp_shard,
                                           /*llm_compressor_format=*/false, mtp_counters);
             if (mtp_loaded) {
-                imp::MtpHead head;
-                head.info.path       = mtp_path;
-                head.info.file_bytes = static_cast<size_t>(sz);
-                head.info.n_tensors  = static_cast<int>(mtp_tensor_map.size());
-
-                // Dispatch tensors to named fields. Returns true when assigned.
-                auto take = [&](const char* key, Tensor& dst) -> bool {
-                    auto it = mtp_tensor_map.find(key);
-                    if (it == mtp_tensor_map.end()) return false;
-                    dst = it->second;
-                    return true;
-                };
-
-                bool ok = true;
-                ok &= take("mtp.pre_fc_norm_embedding.weight", head.pre_fc_norm_embedding);
-                ok &= take("mtp.pre_fc_norm_hidden.weight",    head.pre_fc_norm_hidden);
-                ok &= take("mtp.fc.weight",                    head.fc);
-                ok &= take("mtp.layers.0.input_layernorm.weight",
-                           head.input_layernorm);
-                ok &= take("mtp.layers.0.post_attention_layernorm.weight",
-                           head.post_attention_layernorm);
-                ok &= take("mtp.layers.0.self_attn.q_proj.weight", head.q_proj);
-                ok &= take("mtp.layers.0.self_attn.k_proj.weight", head.k_proj);
-                ok &= take("mtp.layers.0.self_attn.v_proj.weight", head.v_proj);
-                ok &= take("mtp.layers.0.self_attn.o_proj.weight", head.o_proj);
-                ok &= take("mtp.layers.0.self_attn.q_norm.weight", head.q_norm);
-                ok &= take("mtp.layers.0.self_attn.k_norm.weight", head.k_norm);
-                ok &= take("mtp.layers.0.mlp.gate.weight", head.router);
-                ok &= take("mtp.layers.0.mlp.experts.gate_up_proj",
-                           head.experts_gate_up_packed);
-                ok &= take("mtp.layers.0.mlp.experts.down_proj",
-                           head.experts_down_packed);
-                ok &= take("mtp.layers.0.mlp.shared_expert.gate_proj.weight",
-                           head.shared_expert_gate_proj);
-                ok &= take("mtp.layers.0.mlp.shared_expert.up_proj.weight",
-                           head.shared_expert_up_proj);
-                ok &= take("mtp.layers.0.mlp.shared_expert.down_proj.weight",
-                           head.shared_expert_down_proj);
-                ok &= take("mtp.layers.0.mlp.shared_expert_gate.weight",
-                           head.shared_expert_gate);
-                ok &= take("mtp.norm.weight", head.final_norm);
-
-                head.loaded = ok;
-                if (ok) {
-                    IMP_LOG_INFO("MTP head loaded: %s (%.2f GiB, %d tensors, BF16)",
-                                 mtp_path.c_str(),
-                                 static_cast<double>(sz) / (1024.0 * 1024.0 * 1024.0),
-                                 head.info.n_tensors);
-                } else {
-                    IMP_LOG_WARN("MTP head detected at %s but some expected tensors were "
-                                 "missing; spec-decode disabled for this model",
-                                 mtp_path.c_str());
-                }
-                mtp_local = std::move(head);
+                mtp_local = dispatch_mtp(mtp_tensor_map, mtp_path, static_cast<size_t>(sz));
             } else {
                 IMP_LOG_WARN("MTP head file %s present but failed to load", mtp_path.c_str());
+            }
+        } else {
+            // Embedded variant. llm-compressor checkpoints had their mtp.*
+            // tensors diverted into embedded_mtp_map during load_shard
+            // (translate_name SKIPs them); Model-Optimizer checkpoints keep
+            // them in the main tensor_map (weight_map skips them later) —
+            // harvest from there.
+            if (embedded_mtp_map.empty()) {
+                for (const auto& kv : tensor_map) {
+                    if (kv.first.rfind("mtp.", 0) == 0)
+                        embedded_mtp_map.emplace(kv.first, kv.second);
+                    else if (kv.first.rfind("model.mtp.", 0) == 0)
+                        embedded_mtp_map.emplace(kv.first.substr(6), kv.second);
+                }
+            }
+            if (!embedded_mtp_map.empty()) {
+                size_t bytes = 0;
+                for (const auto& kv : embedded_mtp_map) bytes += kv.second.nbytes();
+                mtp_local = dispatch_mtp(embedded_mtp_map, path + " (embedded mtp.*)", bytes);
             }
         }
     }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -266,6 +266,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("speculative.burst", cfg.speculative.burst);
     I("speculative.miss_burst", cfg.speculative.miss_burst);
     B("speculative.burst_rearm", cfg.speculative.burst_rearm);
+    B("speculative.hybrid", cfg.speculative.hybrid);
+    I("speculative.mtp_k", cfg.speculative.mtp_k);
 
     if (!matched)
         IMP_LOG_WARN("imp.conf: unknown key '%s' (value '%s') — ignoring", dotted_key.c_str(), val.c_str());

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -560,6 +560,22 @@ struct RuntimeConfig {
         // CudaGraphConditionalRunner::setup) — rearm and fresh capture now
         // share the same first-forward semantics.
         bool burst_rearm = true;
+        // Speculation on hybrid (GDN/SSM) models. The verify chunk advances
+        // recurrent state through rejected draft positions, so the committed
+        // per-sequence state slab is snapshotted before the chunk; a fully
+        // accepted draft pays only that copy (~60 MiB D2D on Qwen3.6-35B),
+        // a partial acceptance restores the slab and re-forwards the
+        // accepted prefix (one extra chunk forward, amortized over the
+        // accepted tokens). imp-cli --bench pins this false (same
+        // baseline-semantics rule as the moe/suffix pins).
+        bool hybrid = true;
+        // MTP-head chain-draft length for the verify loop (models shipping a
+        // trained MTP head, e.g. Qwen3.6 model_mtp.safetensors). 0 = off.
+        // When >0 the server loads the head (~1.6 GiB VRAM) and enables MTP;
+        // drafts fill verify steps where the suffix/ngram matcher has no
+        // match (draft-poor prose — 78-94% depth-1 accept on Qwen3.6-35B-A3B,
+        // PR #804). imp-cli equivalent: --mtp-spec-decode <k>.
+        int mtp_k = 0;
     } speculative;
 
     // Constrained decoding (json_mode / json_schema).

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -153,10 +153,21 @@ bool Engine::enable_mtp_spec_decode(int k) {
     }
     const int hidden_dim   = model_->config_.d_model;
     const int vocab_size   = model_->config_.vocab_size;
-    const int n_experts    = model_->config_.n_experts;
-    const int top_k        = model_->config_.n_experts_active;
-    const int expert_d_ff  = model_->config_.expert_d_ff;
-    const int shared_d_ff  = model_->config_.expert_shared_d_ff;
+    // MLP dims come from the HEAD tensors, not the main-model config: the
+    // dense 27B checkpoint pairs a MoE-free MTP head with a plain SwiGLU MLP
+    // (mapped onto the shared_expert fields), and the 35B head's expert d_ff
+    // differs from the main model's.
+    const auto& head       = *model_->mtp_;
+    const bool head_moe    = head.router.data != nullptr &&
+                             head.experts_gate_up_packed.data != nullptr;
+    const int n_experts    = head_moe ? static_cast<int>(head.router.shape[0]) : 0;
+    const int top_k        = head_moe ? model_->config_.n_experts_active : 0;
+    const int expert_d_ff  = head_moe
+                                 ? static_cast<int>(head.experts_gate_up_packed.shape[1]) / 2
+                                 : 0;
+    const int shared_d_ff  = head.shared_expert_gate_proj.data != nullptr
+                                 ? static_cast<int>(head.shared_expert_gate_proj.shape[0])
+                                 : 0;
 
     // MTP attention dims: derived from the MTP head's q_proj / v_proj shapes
     // because the MTP attention head config differs from the main model
@@ -238,52 +249,9 @@ bool Engine::enable_mtp_spec_decode(int k) {
     return true;
 }
 
-bool Engine::mtp_prefill_prompt(const int32_t* prompt_tokens, const void* d_hidden, int n) {
-    if (mtp_ws_storage_ == nullptr) return false;
-    if (!model_ || !model_->mtp_.has_value() || !model_->mtp_->loaded) return false;
-    if (n <= 0 || prompt_tokens == nullptr || d_hidden == nullptr) return false;
-
-    auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
-    if (ws->mtp_pos > 0) {
-        IMP_LOG_WARN("mtp_prefill_prompt: cache already populated (pos=%d); skipping", ws->mtp_pos);
-        return false;
-    }
-
-    const int hidden_dim = model_->config_.d_model;
-    const int vocab_size = model_->config_.vocab_size;
-    const __half* hidden = static_cast<const __half*>(d_hidden);
-
-    // For each prompt position i in [0, n): run MTP forward with prev_token =
-    // prompt_tokens[i] and d_h_prev = hidden[i]. Each call appends one row to
-    // the MTP KV cache and advances mtp_pos. The last position's prediction
-    // (i.e., what MTP thinks comes AFTER the prompt) becomes the pending
-    // prediction for accuracy measurement on the first decode step.
-    int last_prediction = -1;
-    for (int i = 0; i < n; ++i) {
-        const void* h_i = hidden + static_cast<int64_t>(i) * hidden_dim;
-        int prediction = -1;
-        bool ok = imp::mtp_draft_step(
-            prompt_tokens[i],
-            h_i,
-            *model_->mtp_,
-            model_->tok_emb_,
-            model_->out_proj_,
-            *ws,
-            hidden_dim, vocab_size,
-            &prediction,
-            decode_stream());
-        if (!ok) {
-            IMP_LOG_WARN("mtp_prefill_prompt: forward failed at position %d/%d — abandoning", i, n);
-            return false;
-        }
-        last_prediction = prediction;
-    }
-
-    mtp_pending_prediction_ = last_prediction;
-    IMP_LOG_INFO("MTP prefill: %d prompt positions cached (mtp_pos=%d), pending prediction=%d",
-                 n, ws->mtp_pos, last_prediction);
-    return true;
-}
+// (mtp_prefill_prompt was replaced by the per-chunk mtp_prefill_feed_chunk
+// in engine_spec_mtp.cpp — chunked-prefill capable, DeepSeek-aligned pairing,
+// feed-only forwards without the lm_head GEMV.)
 
 void Engine::mtp_accuracy_reset() noexcept {
     mtp_accuracy_ = {};
@@ -291,6 +259,12 @@ void Engine::mtp_accuracy_reset() noexcept {
     mtp_pending_chain_.clear();
     mtp_chain_accept_.clear();
     mtp_chain_accept_w_.clear();
+    mtp_bound_req_ = -1;
+    mtp_history_.clear();
+    mtp_pending_draft_.clear();
+    mtp_draft_ctx_ = -1;
+    mtp_econ_verifies_ = 0;
+    mtp_econ_emitted_ = 0;
     if (mtp_ws_storage_) {
         auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
         imp::mtp_kv_reset(*ws);

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -197,23 +197,17 @@ public:
                        int hidden_dim, int vocab_size, int* out_token_id,
                        int* out_topk_ids = nullptr, int top_w = 0);
 
-    // Run MTP forward across all prompt positions to populate the MTP-side
-    // KV cache before decode starts. Without this, MTP enters decode with an
-    // empty KV cache while the main model has the entire prompt context —
-    // a fundamental asymmetry that caps achievable accept rate.
-    //
-    // Inputs:
-    //   prompt_tokens : the full prompt token ids (host array of length n)
-    //   d_hidden      : device buffer [n, hidden_dim] FP16 — main-model hidden
-    //                   states for every prompt position (executor's hidden_
-    //                   buffer right after the prefill forward).
-    //   n             : number of prompt tokens
-    // Side effects:
-    //   - Advances ws.mtp_pos from 0 to n.
-    //   - Stores the LAST position's MTP prediction in mtp_pending_prediction_
-    //     so that the first decode step's accuracy is measured correctly.
-    // Returns false if MTP is disabled or any forward fails (best-effort).
-    bool mtp_prefill_prompt(const int32_t* prompt_tokens, const void* d_hidden, int n);
+    // Feed one prefill chunk's (token, hidden) pairs into the MTP-side KV
+    // cache so the head enters decode with the same context as the main
+    // model. Called per chunk right after the chunk forward (the executor's
+    // hidden_ buffer holds exactly this chunk). Pairs follow the DeepSeek MTP
+    // convention (emb(t_{i+1}), h_i); the final pair of the LAST chunk uses
+    // the just-sampled next_token and also seeds the pending draft chain.
+    // Handles bind/reuse across requests (longest-common-prefix truncation of
+    // the previously fed history) and unbinds on any gap it cannot cover.
+    // Best-effort: failure just disables MTP drafting for this request.
+    void mtp_prefill_feed_chunk(const Request& req, int offset, int chunk_len,
+                                int next_token /* -1 on non-last chunks */);
 
     // Phase 3.5 telemetry: tracks "what fraction of decode-step next-tokens
     // would the MTP head have correctly predicted from the previous step?"
@@ -539,6 +533,46 @@ private:
     std::vector<MtpAccuracy> mtp_chain_accept_;
     std::vector<MtpWidthAccuracy> mtp_chain_accept_w_;  // Stage 0 per-width table
 
+    // ── MTP verify consumer (#847) — implemented in engine_spec_mtp.cpp ──
+    // The MTP head is a draft SOURCE for step_spec_verify_: when the
+    // suffix/ngram matcher has no draft, the pending MTP chain fills the
+    // verify chunk. The single MTP workspace tracks ONE request at a time
+    // (batch-1 gate, same as the verify loop itself).
+    //
+    // Sync invariant: ws->mtp_pos == req->context_len() - 1 — pair i is
+    // (emb(t_{i+1}), h_i), so after P pairs the head is ready to draft the
+    // token after t_P. mtp_history_ holds the covered tokens t_0..t_P
+    // (size == mtp_pos + 1) and lets a follow-up request resume the cache
+    // over a shared prefix (multi-turn) via longest-common-prefix match.
+    int mtp_bound_req_ = -1;
+    std::vector<int32_t> mtp_history_;
+    std::vector<int32_t> mtp_pending_draft_;  // chain drafted for mtp_draft_ctx_
+    int mtp_draft_ctx_ = -1;                  // context_len the draft targets
+    // True when the request's context advanced without MTP pairs (async-loop
+    // burst, chunked-prefill gap) — drafting stays off for the request.
+    bool mtp_stale_logged_ = false;
+    // Economics guard: an MTP-filled verify step costs ~2x a loop step
+    // (eager chunk) plus K chain forwards with full lm_head GEMVs plus the
+    // hybrid partial-accept replay — the classic acceptance_poor gate (<15%)
+    // never fires at MTP's 44-90% accept even when the step economics lose
+    // outright (measured -58..-77% tg on Qwen3.6-27B draft-poor prose).
+    // Track emitted-per-MTP-verify and doom MTP drafting for the request
+    // when the average can't beat the break-even.
+    int mtp_econ_verifies_ = 0;
+    long long mtp_econ_emitted_ = 0;
+    // Consume the pending MTP chain as the verify draft for req (empty when
+    // MTP is off / unbound / stale / KV-cap reached).
+    std::vector<int32_t> mtp_take_draft_(const Request& req);
+    // After a verify step: feed the emitted tokens' (token, hidden-row)
+    // pairs, then chain-draft the next mtp_spec_k_ tokens for the next
+    // verify step. Must run BEFORE the hybrid partial-accept re-forward
+    // (it reads this chunk's hidden rows).
+    void mtp_post_verify_update_(const Request& req, int emitted);
+    // Shared helper: run pair catch-up + chain draft from host token list.
+    bool mtp_feed_pairs_(const int32_t* tokens, const void* d_hidden_rows,
+                         int n_pairs, bool chain_after);
+    void mtp_unbind_(const char* why);
+
     // ── n-gram (prompt-lookup) speculative decoding ─────────────────
     // Drafts come from suffix matches against the request's own context
     // (runtime_config_.speculative); the verify step replays them as a
@@ -574,6 +608,14 @@ private:
     int32_t* h_spec_argmax_ = nullptr;  // pinned, chunk_cap entries
     int spec_chunk_cap_ = 0;
     int spec_block_table_cap_ = 0;
+    // Hybrid (SSM/GDN) verify: device scratch holding the committed
+    // recurrent-state slab across the speculative chunk forward (the chunk
+    // advances state through rejected draft positions; on partial acceptance
+    // the slab is restored and the accepted prefix re-forwarded).
+    void* spec_state_scratch_ = nullptr;
+    size_t spec_state_scratch_bytes_ = 0;
+    bool ensure_spec_state_scratch_();
+    int recurrent_slot_for_(int req_id) const;
     // Session telemetry (logged when a request finishes).
     struct SpecStats {
         long long verify_steps = 0;  // verify forwards run

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -823,6 +823,11 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
             free_prefill_buffers(d_token_ids, d_positions, d_block_tables, d_context_lens, pf_stream);
         }
 
+        // MTP: feed this chunk's (token, hidden) pairs while the executor's
+        // hidden_ buffer still holds it (feed-only forwards, no lm_head).
+        if (mtp_spec_decode_enabled())
+            mtp_prefill_feed_chunk(*req, offset, chunk_len, /*next_token=*/-1);
+
         req->prefill_offset = offset + chunk_len;
         IMP_LOG_DEBUG("Chunked prefill: req %d chunk [%d, %d) of %d", req->id, offset, offset + chunk_len,
                       total_input);
@@ -936,22 +941,11 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         IMP_LOG_DEBUG("Prefill -> token %d (ctx=%d): id=%d [%s]", (int)req->output_tokens.size(),
                       req->context_len(), next_token, tok->decode_token(next_token).c_str());
 
-        // MTP prefill: populate MTP KV cache with all prompt position hidden
-        // states so the head enters decode with the same context as the main
-        // model. Only the LAST chunk (where we have the complete tail of the
-        // prompt in executor's hidden_ buffer) and only the non-chunked path
-        // for now (chunked prefill would need per-chunk capture). Cost: ~n
-        // extra MTP forwards, one-time per session.
-        if (mtp_spec_decode_enabled() && offset == 0 && req->prefill_offset == 0) {
-            // executor's hidden_ buffer holds [chunk_len, d_model] FP16 right
-            // after forward_logits; that matches the whole prompt when
-            // offset==0 and is_last_chunk==true.
-            const int n_prompt = chunk_len;
-            imp::Tensor h_view = executor_->view_hidden(n_prompt);
-            if (h_view.data != nullptr) {
-                mtp_prefill_prompt(req->input_tokens.data(), h_view.data, n_prompt);
-            }
-        }
+        // MTP: feed the last chunk's (token, hidden) pairs — earlier chunks
+        // were fed inside the chunked-prefill branch above; the final pair
+        // uses the just-sampled next_token and seeds the pending draft chain.
+        if (mtp_spec_decode_enabled())
+            mtp_prefill_feed_chunk(*req, offset, chunk_len, next_token);
 
         // Update constraint FSM
         if (req->constraints)
@@ -1572,8 +1566,19 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             }
         }
 
+        // Verify-consumer sync gate (#847): the chain feed below appends a
+        // (next_token, h) pair at ws->mtp_pos — valid only while the cache
+        // exactly covers the pre-step context. After an async-loop burst
+        // (device-side tokens, no host hiddens) the cache is stale — skip
+        // feeding so it never desynchronizes silently.
+        auto* ws_gate = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
+        const bool mtp_synced = ws_gate != nullptr && mtp_bound_req_ == valid_decode[0]->id &&
+                                ws_gate->mtp_pos == cur_pos &&
+                                (ws_gate->max_seq_len <= 0 ||
+                                 ws_gate->mtp_pos + std::max(1, mtp_spec_k_) <
+                                     ws_gate->max_seq_len);
         Tensor h_view = executor_->view_hidden(1);  // [1, d_model] FP16
-        if (h_view.data != nullptr) {
+        if (h_view.data != nullptr && mtp_synced) {
             const int hidden_dim = model_->config_.d_model;
             const int vocab_size = model_->config_.vocab_size;
 
@@ -1611,6 +1616,8 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             const int mtp_pos_before = ws->mtp_pos;
             int chain_prev_tok = next_token;
             const void* chain_h_prev = h_for_mtp;
+            std::vector<int32_t> chain_preds;
+            chain_preds.reserve(K);
             for (int k = 0; k < K; ++k) {
                 int prediction = -1;
                 int topk[Engine::kMtpMeasureW] = {-1, -1, -1, -1};
@@ -1621,6 +1628,7 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
                 MtpChainEntry entry{prediction, k, cur_pos + 1 + k, {}};
                 for (int w = 0; w < Engine::kMtpMeasureW; ++w) entry.topk[w] = topk[w];
                 mtp_pending_chain_.push_back(entry);
+                chain_preds.push_back(prediction);
                 // For k=0 only, also feed pending_prediction_ (legacy 1-step
                 // accuracy counter remains in sync with chain_accept_[0]).
                 if (k == 0) mtp_pending_prediction_ = prediction;
@@ -1632,6 +1640,16 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             // The first chained step (k=0) IS the real "next step" prediction
             // and matches what would have been drafted in K=1 mode — keep it.
             ws->mtp_pos = std::min(ws->mtp_pos, mtp_pos_before + 1);
+            // Verify-consumer bookkeeping (#847): the kept pair covers
+            // next_token; the chain IS the draft for the next verify step.
+            mtp_history_.push_back(next_token);
+            if (!chain_preds.empty()) {
+                mtp_pending_draft_ = std::move(chain_preds);
+                mtp_draft_ctx_ = static_cast<int>(mtp_history_.size());
+            } else {
+                mtp_pending_draft_.clear();
+                mtp_draft_ctx_ = -1;
+            }
         } else {
             mtp_pending_prediction_ = -1;
         }

--- a/src/runtime/engine_spec_mtp.cpp
+++ b/src/runtime/engine_spec_mtp.cpp
@@ -1,0 +1,217 @@
+// =============================================================================
+// engine_spec_mtp.cpp — MTP head as a draft source for the verify loop (#847)
+// =============================================================================
+//
+// The trained MTP head (model_mtp.safetensors, DeepSeek-V3-family — e.g.
+// Qwen3.6) chain-drafts the next mtp_spec_k_ tokens; step_spec_verify_
+// consumes the chain whenever the suffix/ngram matcher has no draft
+// (draft-poor prose is where the trained head shines: 78-94% depth-1 accept
+// on Qwen3.6-35B-A3B, PR #804).
+//
+// Pairing convention (DeepSeek MTP): cache pair i is (emb(t_{i+1}), h_i) —
+// after P pairs the head is ready to draft the token following t_P. The
+// per-step decode telemetry (engine_scheduler.cpp) always fed exactly this;
+// the prefill feed here aligns with it (the pre-#847 prefill fed the
+// off-by-one (t_i, h_i) pairing).
+//
+// The single MTP workspace tracks ONE request at a time (verify is batch-1).
+// mtp_history_ records the covered tokens t_0..t_P so a follow-up request
+// (multi-turn agent loop) resumes the cache over the shared prefix instead
+// of restarting. Any gap the cache cannot cover — async-loop burst tokens
+// (no host hidden states), a prefix-cache hit beyond the fed history —
+// unbinds drafting for the request; the suffix matcher keeps working.
+// =============================================================================
+
+#include "compute/mtp_forward.h"
+#include "core/logging.h"
+#include "exec/executor.h"
+#include "model/model.h"
+#include "runtime/engine.h"
+#include "runtime/request.h"
+
+#include <cuda_fp16.h>
+#include <algorithm>
+
+namespace imp {
+
+void Engine::mtp_unbind_(const char* why) {
+    if (mtp_bound_req_ >= 0 && !mtp_stale_logged_) {
+        IMP_LOG_INFO("mtp-spec: drafting off for req %d (%s)", mtp_bound_req_, why);
+        mtp_stale_logged_ = true;
+    }
+    mtp_bound_req_ = -1;
+    mtp_pending_draft_.clear();
+    mtp_draft_ctx_ = -1;
+}
+
+std::vector<int32_t> Engine::mtp_take_draft_(const Request& req) {
+    if (mtp_bound_req_ != req.id || mtp_pending_draft_.empty())
+        return {};
+    // Drafted for a different context (an async-loop burst or eager steps
+    // advanced the request without refreshing the chain) — not usable.
+    if (mtp_draft_ctx_ != req.context_len())
+        return {};
+    return mtp_pending_draft_;
+}
+
+// Feed n_pairs (token, hidden-row) pairs into the MTP KV cache, then
+// (optionally) chain-draft mtp_spec_k_ tokens for the next verify step.
+// Only the final pair of a chaining feed needs logits/argmax — all other
+// forwards skip the lm_head GEMV entirely (it dominates per-pair cost:
+// ~1 GiB read on Qwen3.6's 248k vocab).
+bool Engine::mtp_feed_pairs_(const int32_t* tokens, const void* d_hidden_rows, int n_pairs,
+                             bool chain_after) {
+    auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
+    if (ws == nullptr || n_pairs <= 0)
+        return false;
+    const int hidden_dim = model_->config_.d_model;
+    const int vocab_size = model_->config_.vocab_size;
+    const int K = std::max(1, mtp_spec_k_);
+    // MTP KV capacity (kMtpKvCap clamp at enable time): past it the cache
+    // addressing is undefined — stop drafting instead.
+    if (ws->max_seq_len > 0 && ws->mtp_pos + n_pairs + (chain_after ? K : 0) > ws->max_seq_len)
+        return false;
+
+    const char* base = static_cast<const char*>(d_hidden_rows);
+    int pred = -1;
+    for (int j = 0; j < n_pairs; ++j) {
+        const void* h_j = base + static_cast<size_t>(j) * hidden_dim * sizeof(__half);
+        int* out = (chain_after && j == n_pairs - 1) ? &pred : nullptr;
+        if (!mtp_draft_one(tokens[j], h_j, hidden_dim, vocab_size, out))
+            return false;
+        mtp_history_.push_back(tokens[j]);
+    }
+    if (!chain_after)
+        return true;
+    if (pred < 0 || pred >= vocab_size)
+        return false;
+
+    // Chain: continue on the head's own h_final. The chained KV appends are
+    // speculative — roll the cache back so only the real pairs persist.
+    const int pos_after = ws->mtp_pos;
+    std::vector<int32_t> chain;
+    chain.reserve(K);
+    chain.push_back(pred);
+    int prev = pred;
+    for (int k = 1; k < K; ++k) {
+        int p = -1;
+        if (!mtp_draft_one(prev, ws->d_h_final, hidden_dim, vocab_size, &p) || p < 0 ||
+            p >= vocab_size)
+            break;
+        chain.push_back(p);
+        prev = p;
+    }
+    ws->mtp_pos = pos_after;
+    mtp_pending_draft_ = std::move(chain);
+    mtp_draft_ctx_ = static_cast<int>(mtp_history_.size());
+    mtp_pending_prediction_ = mtp_pending_draft_[0];  // legacy accuracy counter
+    return true;
+}
+
+void Engine::mtp_post_verify_update_(const Request& req, int emitted) {
+    if (mtp_bound_req_ != req.id || emitted <= 0)
+        return;
+    auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
+    if (ws == nullptr)
+        return;
+    // Sync check: the cache must cover exactly the pre-step context
+    // (pos == p0 == context_len - emitted - 1).
+    const int p0 = req.context_len() - emitted - 1;
+    if (ws->mtp_pos != p0) {
+        mtp_unbind_("desync before verify feed");
+        return;
+    }
+    // Row j of this verify chunk produced emitted token j — the (token,
+    // hidden) pairs are exactly (emitted_j, h_row_j). Must run before the
+    // hybrid partial-accept re-forward overwrites the hidden buffer.
+    Tensor h = executor_->view_hidden(emitted);
+    if (h.data == nullptr) {
+        mtp_unbind_("no hidden view after verify");
+        return;
+    }
+    const int32_t* toks = req.output_tokens.data() + req.output_tokens.size() - emitted;
+    if (!mtp_feed_pairs_(toks, h.data, emitted, /*chain_after=*/req.status == RequestStatus::DECODING))
+        mtp_unbind_("verify feed failed (kv cap or forward error)");
+}
+
+void Engine::mtp_prefill_feed_chunk(const Request& req, int offset, int chunk_len,
+                                    int next_token) {
+    if (!mtp_spec_decode_enabled() || mtp_ws_storage_ == nullptr)
+        return;
+    if (!model_ || !model_->mtp_.has_value() || !model_->mtp_->loaded)
+        return;
+    if (chunk_len <= 0)
+        return;
+    auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
+    const auto& in = req.input_tokens;
+
+    // (Re)bind on this request's first chunk: resume over the longest common
+    // prefix of the previously fed history and this prompt (multi-turn agent
+    // loops re-send the prior turn verbatim — the cache carries over).
+    if (mtp_bound_req_ != req.id) {
+        size_t L = 0;
+        while (L < mtp_history_.size() && L < in.size() && mtp_history_[L] == in[L])
+            ++L;
+        const int keep_pairs = std::max(0, static_cast<int>(L) - 1);
+        ws->mtp_pos = std::min(ws->mtp_pos, keep_pairs);
+        if (mtp_history_.size() > static_cast<size_t>(ws->mtp_pos) + 1)
+            mtp_history_.resize(static_cast<size_t>(ws->mtp_pos) + 1);
+        mtp_bound_req_ = req.id;
+        mtp_stale_logged_ = false;
+        mtp_pending_draft_.clear();
+        mtp_draft_ctx_ = -1;
+        mtp_econ_verifies_ = 0;
+        mtp_econ_emitted_ = 0;
+        if (mtp_history_.empty() || ws->mtp_pos == 0) {
+            // Nothing usable carried over — restart the cache. Pair 0 needs
+            // h_0, so the prompt must actually be forwarded from position 0.
+            ws->mtp_pos = 0;
+            mtp_history_.clear();
+            if (offset == 0 && !in.empty()) {
+                mtp_history_.push_back(in[0]);
+            } else {
+                mtp_unbind_("prefix-cache gap without matching MTP history");
+                return;
+            }
+        }
+    }
+
+    // Pair i consumes h_i; this chunk holds h_i for i in [offset,
+    // offset+chunk_len). Resume at the cache position.
+    const int start = ws->mtp_pos;
+    const int end = offset + chunk_len;
+    if (start < offset) {
+        mtp_unbind_("hidden gap before chunk");
+        return;
+    }
+    if (start >= end)
+        return;  // chunk fully covered by the resumed cache
+
+    std::vector<int32_t> toks;
+    toks.reserve(end - start);
+    for (int i = start; i < end; ++i) {
+        if (i + 1 < static_cast<int>(in.size()))
+            toks.push_back(in[i + 1]);
+        else if (next_token >= 0)
+            toks.push_back(next_token);  // final pair of the last chunk
+        else
+            break;  // unreachable for non-last chunks (end < input size)
+    }
+    if (toks.empty())
+        return;
+
+    Tensor h = executor_->view_hidden(chunk_len);
+    if (h.data == nullptr) {
+        mtp_unbind_("no hidden view during prefill");
+        return;
+    }
+    const int hidden_dim = model_->config_.d_model;
+    const char* rows = static_cast<const char*>(h.data) +
+                       static_cast<size_t>(start - offset) * hidden_dim * sizeof(__half);
+    const bool last_chunk = next_token >= 0;
+    if (!mtp_feed_pairs_(toks.data(), rows, static_cast<int>(toks.size()),
+                         /*chain_after=*/last_chunk))
+        mtp_unbind_("prefill feed failed (kv cap or forward error)");
+}
+
+}  // namespace imp

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -17,10 +17,20 @@
 //
 // Phase 1 scope (gated in spec_ngram_gates_ok_): batch-1, greedy sampling,
 // no penalties / logit_bias / DRY / mirostat, no logprobs, no json/schema
-// constraints, no think budget, no recurrent state (SSM/GDN cannot rewind),
-// chunked-prefill-capable archs only. The verify loop runs eager — the async
-// conditional graph loop stays off while speculation is enabled (the host
-// must see every token to draft the next step).
+// constraints, no think budget, chunked-prefill-capable archs only. The
+// verify loop runs eager — the async conditional graph loop stays off while
+// speculation is enabled (the host must see every token to draft the next
+// step).
+//
+// Hybrid (SSM/GDN) models (speculative.hybrid): the chunk forward advances
+// recurrent state through rejected draft positions, so the committed
+// per-sequence state slab is copied to scratch before the chunk; a full
+// acceptance keeps the advanced state as-is (it covers exactly the forwarded
+// tokens), a partial acceptance restores the slab and re-forwards the
+// accepted prefix (~one extra chunk forward, amortized over the accepted
+// tokens). Draft sources: the suffix/ngram matcher first; when it has no
+// match and an MTP head is enabled (--mtp-spec-decode / speculative.mtp_k),
+// the pending MTP chain fills the chunk (engine_spec_mtp.cpp).
 // =============================================================================
 
 #include "compute/json_constrain.h"
@@ -72,7 +82,42 @@ void Engine::log_spec_stats_() const {
                      : 0.0);
 }
 
+// Hybrid verify: scratch slab holding the committed recurrent state across
+// the speculative chunk forward. Sized once (per_seq_bytes is fixed after
+// init); freed with the other spec buffers.
+bool Engine::ensure_spec_state_scratch_() {
+    if (!ssm_state_) return false;
+    const size_t bytes = ssm_state_->per_seq_bytes();
+    if (spec_state_scratch_ && spec_state_scratch_bytes_ >= bytes) return true;
+    if (spec_state_scratch_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(spec_state_scratch_));
+        spec_state_scratch_ = nullptr;
+        spec_state_scratch_bytes_ = 0;
+    }
+    if (cudaMalloc(&spec_state_scratch_, bytes) != cudaSuccess) {
+        IMP_LOG_WARN("spec-hybrid: state scratch alloc failed (%zu bytes) — "
+                     "speculation disabled this step", bytes);
+        return false;
+    }
+    spec_state_scratch_bytes_ = bytes;
+    return true;
+}
+
+// Mirror of fill_recurrent_state's slot resolution (decode requests own a
+// slot acquired at prefill; the modulo fallback matches its legacy path).
+int Engine::recurrent_slot_for_(int req_id) const {
+    auto it = recurrent_slot_of_.find(req_id);
+    if (it != recurrent_slot_of_.end()) return it->second;
+    const int cap = ssm_state_ ? ssm_state_->max_sequences() : 0;
+    return cap > 0 ? req_id % cap : 0;
+}
+
 void Engine::free_spec_buffers_() {
+    if (spec_state_scratch_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(spec_state_scratch_));
+        spec_state_scratch_ = nullptr;
+        spec_state_scratch_bytes_ = 0;
+    }
     if (d_spec_tokens_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_tokens_));
     if (d_spec_positions_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_positions_));
     if (d_spec_block_table_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_));
@@ -164,9 +209,12 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     // handle the budget device-side.
     if (!ignore_think && req.think_budget > 0.0f && req.in_think_block) return false;
     if (req.status != RequestStatus::DECODING || req.output_tokens.empty()) return false;
-    // Recurrent state (SSM/GDN) advances on every forwarded token and cannot
-    // be rewound on draft rejection.
-    if (ssm_state_ || gdn_state_) return false;
+    // Recurrent state (SSM/GDN) advances on every forwarded token. The
+    // hybrid verify path (speculative.hybrid) rides SSMState's contiguous
+    // per-sequence slab for snapshot/restore; the legacy GGUF-era GDNState
+    // pool has no slab accessor and stays excluded.
+    if (gdn_state_) return false;
+    if (ssm_state_ && !runtime_config_.speculative.hybrid) return false;
     // MoE speculation engages only for native-NVFP4 experts: the batched
     // verify forward reads the NVFP4 expert cache directly and nets +49-81%
     // on draft-rich code-edit (Qwen3-Coder-30B-FP4, 2026-07-02) with a -3-7%
@@ -176,7 +224,6 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     if (model_->profile().is_moe &&
         !(runtime_config_.speculative.moe && model_->profile().moe_experts_nvfp4))
         return false;
-    if (mtp_spec_decode_enabled()) return false;
     if (!supports_chunked_prefill_()) return false;
     return true;
 }
@@ -231,6 +278,17 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
                             std::max(1, scfg.min_match), scfg.max_match, &draft_start);
     }
     const bool draft_from_prediction = draft_start >= pred_begin && draft_start < pred_end;
+    // MTP fallback: when the matcher has no draft, the pending MTP chain
+    // (drafted at the end of the previous verify step / prefill tail) fills
+    // the chunk — the trained head drafts where suffix matching cannot
+    // (78-94% depth-1 accept on Qwen3.6, PR #804). Subject to the economics
+    // guard below: high accept alone does not pay for the eager chunk +
+    // chain lm_head GEMVs + hybrid replay.
+    bool draft_from_mtp = false;
+    if (draft.empty() && mtp_spec_decode_enabled()) {
+        draft = mtp_take_draft_(*req);
+        draft_from_mtp = !draft.empty();
+    }
     if (draft.empty()) {
         spec_stats_.miss_steps++;
         if (++req->spec_consecutive_misses >= scfg.give_up_after && scfg.give_up_after > 0 &&
@@ -350,6 +408,27 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     state.kv_manager = kv_manager_.get();
     if (kv_manager_ && kv_manager_->residual_enabled()) state.kv_seq_id = req->id;
 
+    // Hybrid (SSM/GDN): bind the recurrent state and preserve the committed
+    // slab — the chunk forward advances it through rejected draft positions.
+    const bool hybrid = ssm_state_ != nullptr;
+    int rec_slot = -1;
+    if (hybrid) {
+        if (!ensure_spec_state_scratch_()) {
+            kv_manager_->rollback(req->id, p0);
+            spec_stats_.miss_steps++;
+            return false;
+        }
+        rec_slot = recurrent_slot_for_(req->id);
+        if (!check(cudaMemcpyAsync(spec_state_scratch_, ssm_state_->seq_base(rec_slot),
+                                   ssm_state_->per_seq_bytes(), cudaMemcpyDeviceToDevice, stream),
+                   "state snapshot D2D")) {
+            kv_manager_->rollback(req->id, p0);
+            spec_stats_.miss_steps++;
+            return false;
+        }
+        fill_recurrent_state(*req, state, /*reset=*/false, stream);
+    }
+
     Tensor logits_out;
     executor_->forward_logits(state, logits_out, stream);
 
@@ -363,7 +442,12 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         upload_penalties(*req, pstate, stream);
         if (pstate.penalty_tokens == nullptr) {
             // Upload failed — an unpenalized verify would diverge from the
-            // eager path; fall back to the normal step.
+            // eager path; fall back to the normal step. The chunk forward
+            // already ran: restore the committed hybrid state.
+            if (hybrid)
+                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(
+                    ssm_state_->seq_base(rec_slot), spec_state_scratch_,
+                    ssm_state_->per_seq_bytes(), cudaMemcpyDeviceToDevice, stream));
             kv_manager_->rollback(req->id, p0);
             spec_stats_.miss_steps++;
             return false;
@@ -376,10 +460,20 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     executor_->greedy_argmax_all(chunk_len, d_spec_argmax_, stream, d_hist, n_hist,
                                  d_spec_tokens_ + 1, req->repetition_penalty,
                                  req->frequency_penalty, req->presence_penalty);
-    if (!check(cudaMemcpyAsync(h_spec_argmax_, d_spec_argmax_, chunk_len * sizeof(int32_t),
-                               cudaMemcpyDeviceToHost, stream), "argmax D2H"))
+    const bool argmax_ok =
+        check(cudaMemcpyAsync(h_spec_argmax_, d_spec_argmax_, chunk_len * sizeof(int32_t),
+                              cudaMemcpyDeviceToHost, stream), "argmax D2H") &&
+        check(cudaStreamSynchronize(stream), "verify sync");
+    if (!argmax_ok) {
+        // No tokens were emitted; leave the request exactly as before the
+        // step (the chunk forward advanced hybrid state — restore it).
+        if (hybrid)
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(ssm_state_->seq_base(rec_slot), spec_state_scratch_,
+                                               ssm_state_->per_seq_bytes(),
+                                               cudaMemcpyDeviceToDevice, stream));
+        kv_manager_->rollback(req->id, p0);
         return false;
-    if (!check(cudaStreamSynchronize(stream), "verify sync")) return false;
+    }
 
     if (getenv("IMP_SPEC_TRACE")) {
         std::string s = "[verify] p0=" + std::to_string(p0) + " t0=" + std::to_string(t0) +
@@ -420,8 +514,33 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     }
     kv_manager_->touch(req->id);
 
+    // MTP bookkeeping runs BEFORE the hybrid re-forward below — it consumes
+    // this chunk's hidden rows, which the re-forward overwrites.
+    if (mtp_spec_decode_enabled())
+        mtp_post_verify_update_(*req, emitted);
+
     // Drop KV for rejected draft positions: keep t0 + matched drafts.
     kv_manager_->rollback(req->id, p0 + 1 + matched);
+
+    // Hybrid, partial acceptance: the in-place state advanced through
+    // rejected draft positions — restore the committed slab and re-advance
+    // it over the accepted prefix ([t0, d1..d_matched] is still staged in
+    // d_spec_tokens_). Full acceptance keeps the advanced state (it covers
+    // exactly the forwarded tokens); finished requests skip (the slot is
+    // released and nothing reads the state again). The replay rewrites the
+    // kept KV rows with identical values.
+    if (hybrid && matched < K && req->status != RequestStatus::FINISHED) {
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(ssm_state_->seq_base(rec_slot), spec_state_scratch_,
+                                           ssm_state_->per_seq_bytes(),
+                                           cudaMemcpyDeviceToDevice, stream));
+        const int replay_ctx = p0 + 1 + matched;
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_spec_context_len_, &replay_ctx, sizeof(int),
+                                           cudaMemcpyHostToDevice, stream));
+        state.n_tokens = matched + 1;
+        state.max_context_len = replay_ctx;
+        Tensor replay_logits;
+        executor_->forward_logits(state, replay_logits, stream);
+    }
 
     spec_stats_.verify_steps++;
     spec_stats_.drafted += K;
@@ -446,6 +565,20 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     if (draft_from_prediction) {
         req->pred_accepted += matched;
         req->pred_rejected += K - matched;
+    }
+    // MTP economics: an MTP-filled verify must emit enough tokens to beat
+    // the async loop it displaces (eager chunk ≈ 2x a loop step, plus the
+    // chain's full-vocab lm_head GEMVs, plus the hybrid partial-accept
+    // replay). Below ~4 emitted/verify the step loses outright — doom MTP
+    // drafting for this request; the suffix matcher and miss bursts carry on.
+    if (draft_from_mtp) {
+        mtp_econ_verifies_++;
+        mtp_econ_emitted_ += emitted;
+        constexpr int kMtpEconSample = 8;        // fair sample before judging
+        constexpr int kMtpEconMinEmitx10 = 40;   // avg emitted/verify >= 4.0
+        if (mtp_econ_verifies_ >= kMtpEconSample &&
+            mtp_econ_emitted_ * 10 < static_cast<long long>(mtp_econ_verifies_) * kMtpEconMinEmitx10)
+            mtp_unbind_("uneconomic: avg emitted/verify below break-even");
     }
     const bool acceptance_poor =
         req->spec_verifies >= 8 &&

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -63,7 +63,7 @@ void print_usage(const char* prog) {
             "deepseek_r1, phi\n"
             "  --prefill-chunk-size <n> Max tokens per prefill chunk (0 = single-chunk, default: per-arch)\n"
             "  --prefill-fp8         Use FP8 E4M3 weight cache for ~2x prefill throughput\n"
-            "  --mtp-spec-decode <k> Enable MTP spec-decode with draft length k (requires model_mtp.safetensors)\n"
+            "  --mtp-spec-decode <k> MTP drafting for the verify loop, chain length k (sidecar or embedded mtp.* head)\n"
             "  --decode-nvfp4        Force mode 1 (additive: FP8 prefill + NVFP4 decode caches).\n"
             "                        Auto-default for dense Q*_K (6-8 bit GGUF) on sm_120 since\n"
             "                        PR #367 — +4 % decode vs mode 2 at -9 % prefill on\n"

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -53,6 +53,15 @@ int main(int argc, char** argv) {
                 snap_set = true;
         if (!snap_set)
             runtime_cfg.server.recurrent_snapshot_mb = 0;
+        // Hybrid (GDN/SSM) verify would fold draft-acceptance luck into the
+        // gated tg signal exactly like the moe pin above — keep the
+        // canonical baseline raw-decode. An explicit --set wins.
+        bool hybrid_set = false;
+        for (const auto& ov : args.config_overrides)
+            if (ov.rfind("speculative.hybrid", 0) == 0)
+                hybrid_set = true;
+        if (!hybrid_set)
+            runtime_cfg.speculative.hybrid = false;
     }
     // Cache the few diagnostic / runtime-mode flags that are read from free
     // functions (kernel diagnostics, CUDA-graph capture mode, PDL gate)

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -335,8 +335,12 @@ std::string load_model_into_state(ServerState& state, const std::string& path, c
     // Auto-detect format from path
     ImpModelFormat format = imp::is_safetensors_dir(path) ? IMP_FORMAT_SAFETENSORS : IMP_FORMAT_GGUF;
 
-    // Load model
-    ImpError err = imp_model_load(path.c_str(), format, &state.model);
+    // Load model. speculative.mtp_k > 0 opts into loading the MTP draft-head
+    // sidecar (~1.6 GiB VRAM; SafeTensors models shipping
+    // model_mtp.safetensors) so MTP drafting can be enabled below.
+    const int mtp_k = state.runtime_config.speculative.mtp_k;
+    ImpError err = imp_model_load_ex(path.c_str(), format, /*load_mtp_head=*/mtp_k > 0 ? 1 : 0,
+                                     &state.model);
     if (err != IMP_SUCCESS) {
         std::string msg = std::string("Failed to load model: ") + imp_error_string(err);
         state.model = nullptr;
@@ -356,6 +360,16 @@ std::string load_model_into_state(ServerState& state, const std::string& path, c
         imp_model_free(state.model);
         state.model = nullptr;
         return msg;
+    }
+
+    // MTP drafting for the verify loop (speculative.mtp_k). Best-effort: a
+    // model without a loadable head just runs without MTP drafts.
+    if (mtp_k > 0) {
+        ImpError mtp_err = imp_enable_mtp_spec_decode(state.ctx, mtp_k);
+        if (mtp_err != IMP_SUCCESS)
+            fprintf(stderr, "Warning: speculative.mtp_k=%d requested but MTP enable failed (%s); "
+                            "continuing without MTP drafts\n",
+                    mtp_k, imp_error_string(mtp_err));
     }
 
     // Extract model name from path. Strip trailing separators first so a


### PR DESCRIPTION
## Summary

Two pieces, one enabler:

**1. Speculative decoding now works on hybrid (GDN/SSM) models** — the structural blocker behind #847. The verify chunk advances recurrent state through rejected draft positions, so the committed per-sequence state slab (`SSMState::seq_base`, the same unit #831's snapshots copy) is copied to a scratch buffer before the chunk; a **full acceptance** keeps the advanced state as-is (it covers exactly the forwarded tokens, zero extra cost beyond the ~60 MiB D2D copy), a **partial acceptance** restores the slab and re-forwards the accepted prefix (one extra chunk forward, amortized over the accepted tokens; KV rows are rewritten with identical values). Gated by `speculative.hybrid` (default on); imp-cli `--bench` pins it off (same baseline-semantics rule as the `moe`/`suffix` pins — verified: bench disengages, `ssm=1` gate line). Legacy GGUF-era `GDNState` (no slab accessor) stays excluded.

**2. MTP verify activation (#847)** — the trained MTP head is now a draft *source* for `step_spec_verify_` (was telemetry-only; the old `mtp_spec_decode_enabled()` verify lockout is gone). Opt-in: `--mtp-spec-decode <k>` (CLI) / `speculative.mtp_k` (server loads the head + enables). MTP chains fill verify steps where the suffix matcher has no match.

### MTP plumbing (all three #847 blockers addressed)
- **Per-chunk prefill feed** replaces the single-chunk-only `mtp_prefill_prompt` host loop: every prefill chunk feeds its (token, hidden) pairs while the executor's hidden buffer holds them; **feed-only forwards skip the lm_head GEMV + stream sync** (the dominant per-pair cost — 2.5 GB read on Qwen3.6-27B's 248k×5120 head). Pairing is now DeepSeek-aligned (`emb(t_{i+1}), h_i`) — the old prefill fed the off-by-one `(t_i, h_i)` while decode fed the aligned pair.
- **`kMtpKvCap` guard**: feeding/drafting stops cleanly at the MTP KV capacity instead of running into undefined addressing.
- **Verify consumer**: post-verify catch-up feeds the emitted tokens' hidden rows (before the hybrid replay overwrites them), then chain-drafts the next `k`; multi-turn requests resume the MTP cache over the longest-common-prefix of fed history (agent loops re-send the prior turn verbatim). Desyncs (async-loop bursts, prefix-cache gaps) unbind MTP for the request — suffix drafting and miss-bursts carry on.
- **Embedded dense MTP heads load** (new): Qwen3.6-27B ships `mtp.*` in the main shard with a plain SwiGLU MLP — loader collects them (both Model-Optimizer and llm-compressor formats), `mtp_forward` runs the dense MLP variant (no router, no sigmoid gate), dims derived from head tensors instead of main-model config.

## Measurements (RTX 5090, greedy temp 0, clocks healthy)

Suffix speculation on hybrids (the enabler win; `off` = `speculative.ngram=false`):

| Model | Workload | off | on | delta |
|---|---|---|---|---|
| Nemotron-3-Nano-30B-A3B-NVFP4 (Mamba2 MoE) | code-edit | 145.0 tok/s | 232.5 tok/s | **+60%** |
| Qwen3.6-35B-A3B-NVFP4 (GDN MoE) | code-edit, 800 tok | 101.4 | 119.5 | **+18%** |
| Qwen3.6-27B-NVFP4 (GDN dense) | prompt-echo prose | 88.6 | 227.3 | **+156%** |
| Qwen3.6-27B-NVFP4 | draft-poor story | 88.65 | 88.65 | ±0 (miss-burst) |

- **Token-lossless** verified on Qwen3.5-4B-mxfp4 (GDN hybrid, deterministic): identical output spec-on vs spec-off, including partial-accept verifies (28% accept → restore+replay path exercised). Qwen3.6-27B divergences are the documented NVFP4 prefill-vs-decode near-tie cross-path property (same as #824/#825), confirmed against an off-vs-off determinism control.
- **Degeneration**: 800-token technical answer on 27B, no repeated 6-grams, coherent tail. `make test-gpu` 1382 tests green; `verify-fast` green.
- **Perf baseline untouched**: `--bench` pins `speculative.hybrid=false` (verified disengaged), so `tests/perf_baseline.json` semantics are unchanged — no refresh needed.

### MTP honest verdict (measured, Qwen3.6-27B)
Accept rates confirm PR #804 (91% prompt-echo prose, 44-78% elsewhere; **misses drop to 0** — MTP always drafts). But at current verify economics the step **loses net**: an MTP-filled verify costs an eager chunk (~2× a loop step) + k full-vocab chain lm_head GEMVs + the hybrid partial-accept replay, against E[emitted] of only 2.4-3.3. Measured k=4: −77% on draft-poor story, k=2: −58%; even mixed with suffix it dragged 227→65 tok/s. The classic acceptance-poor gate (<15%) never fires at these accept rates, so this PR adds an **economics guard**: after an 8-verify sample, average emitted/verify < 4.0 dooms MTP drafting for the request (measured: bounds the story case to 58 tok/s and the request falls back to suffix + miss-bursts). MTP stays **default-off**; follow-ups for making it profitable (NVFP4 lm_head for the chain, graph-captured verify) go to #847.

## Files
- `src/runtime/engine_spec_ngram.cpp` — hybrid gate + snapshot/restore/replay, MTP draft fallback, economics guard
- `src/runtime/engine_spec_mtp.cpp` (new) — MTP feed/chain/bind/resume logic
- `src/compute/mtp_forward.{h,cu}` — feed-only mode (nullable `out_token_id`), dense-MLP variant, workspace restructure
- `src/model/safetensors_loader.cpp` — embedded `mtp.*` collection + MoE/dense dispatch
- `src/runtime/engine_scheduler.cpp` — per-chunk prefill feed hooks, telemetry sync gate + draft refresh
- config/CLI/server wiring, `imp.conf.example`, `docs/architecture.md`, CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)