### PR TITLE
feat(diag): decode-cache-off bisection knob + greedy top1-match probe in perplexity (#845 probe)

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -389,6 +389,9 @@ graph_diag           = false
 graph_dump_dir       = ""
 # Force NVFP4 dispatch through dequant→FP16 GEMV (M=1 bisection tool).
 nvfp4_force_dequant  = false
+# Skip building the NVFP4 decode cache: decode runs on the source-precision
+# paths (dp4a GEMV / FP16 GEMV) — bisection / quality-baseline tool.
+no_nvfp4_decode_cache = false
 # Log shape + per-candidate algo for every cuBLASLt algo selection.
 log_gemm_algo        = false
 # MTP diagnostics: per-step pattern log / pass post-RMSNorm hidden to head.

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -106,8 +106,11 @@ public:
     // n_total owned by the caller (Engine ppl capture). Enqueues on `stream`
     // only; the caller reduces after a sync. Overwrites the logits_
     // workspace — call only after all reads of the chunk's logits are done.
+    // Optional d_match[global_pos] ∈ {0,1}: greedy argmax == actual next
+    // token (production tie-break) — teacher-forced greedy-agreement probe.
     void perplexity_nll_partial(const int32_t* d_tokens, int n_total, int chunk_start,
-                                int chunk_len, double* d_nll, cudaStream_t stream);
+                                int chunk_len, double* d_nll, cudaStream_t stream,
+                                int32_t* d_match = nullptr);
 
     // Greedy verify for n-gram speculative decoding: applies the tier-aware
     // LM head to hidden_[0..n_rows-1] (the verify chunk that forward_logits

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -42,7 +42,8 @@ namespace imp {
 // cross-block atomic accumulation order varies run-to-run.
 __global__ void perplexity_nll_kernel(const float* __restrict__ logits,  // [csz, V]
                                        const int32_t* __restrict__ tokens, int chunk_start, int n,
-                                       int V, double* __restrict__ nll_per_pos) {
+                                       int V, double* __restrict__ nll_per_pos,
+                                       int32_t* __restrict__ match_per_pos) {
     int row = blockIdx.x;                 // local row in this chunk
     int global_pos = chunk_start + row;   // position in the corpus
     if (global_pos >= n - 1)
@@ -54,20 +55,38 @@ __global__ void perplexity_nll_kernel(const float* __restrict__ logits,  // [csz
     __shared__ double s_sum;
     int tid = threadIdx.x;
 
-    // max over V
+    // max over V — track the argmax index alongside (smallest index on
+    // ties, matching the production greedy argmax in sampling.cu), so the
+    // corpus doubles as a teacher-forced greedy-agreement probe.
     float local_max = -INFINITY;
-    for (int i = tid; i < V; i += blockDim.x)
-        local_max = fmaxf(local_max, lg[i]);
+    int local_idx = 0;
+    for (int i = tid; i < V; i += blockDim.x) {
+        float v = lg[i];
+        if (v > local_max || (v == local_max && i < local_idx)) {
+            local_max = v;
+            local_idx = i;
+        }
+    }
     __shared__ float red[256];
+    __shared__ int redi[256];
     red[tid] = local_max;
+    redi[tid] = local_idx;
     __syncthreads();
     for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s)
-            red[tid] = fmaxf(red[tid], red[tid + s]);
+        if (tid < s) {
+            if (red[tid + s] > red[tid] ||
+                (red[tid + s] == red[tid] && redi[tid + s] < redi[tid])) {
+                red[tid] = red[tid + s];
+                redi[tid] = redi[tid + s];
+            }
+        }
         __syncthreads();
     }
-    if (tid == 0)
+    if (tid == 0) {
         s_max = red[0];
+        if (match_per_pos)
+            match_per_pos[global_pos] = (redi[0] == target) ? 1 : 0;
+    }
     __syncthreads();
     float mx = s_max;
 
@@ -206,14 +225,16 @@ void GraphExecutor::for_each_lm_head_batch_(int n_rows, cudaStream_t stream,
 }
 
 void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total, int chunk_start,
-                                           int chunk_len, double* d_nll, cudaStream_t stream) {
+                                           int chunk_len, double* d_nll, cudaStream_t stream,
+                                           int32_t* d_match) {
     if (!initialized_ || chunk_len <= 0 || n_total < 2 || !d_tokens || !d_nll) {
         return;
     }
     const int V = model_->config().vocab_size;
     for_each_lm_head_batch_(chunk_len, stream, [&](const Tensor& lg, int row0, int csz) {
         perplexity_nll_kernel<<<csz, 256, 0, stream>>>(static_cast<const float*>(lg.data), d_tokens,
-                                                       chunk_start + row0, n_total, V, d_nll);
+                                                       chunk_start + row0, n_total, V, d_nll,
+                                                       d_match);
     });
 }
 

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -286,6 +286,11 @@ void QuantPipeline::pre_dequant_phase3_nvfp4_decode_(
     size_t& remaining_budget, cudaStream_t stream) {
     if (wcache_->nvfp4_decode_mode <= 0)
         return;
+    if (runtime_config().diagnostics.no_nvfp4_decode_cache) {
+        IMP_LOG_INFO("NVFP4 decode cache DISABLED (diagnostics.no_nvfp4_decode_cache) — "
+                     "decode runs on source-precision paths");
+        return;
+    }
 
     Nvfp4DecodeContext dctx;
     dctx.mode_str = (wcache_->nvfp4_decode_mode == 1) ? "additive" : "only";

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -239,6 +239,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("diagnostics.graph_diag", cfg.diagnostics.graph_diag);
     S("diagnostics.graph_dump_dir", cfg.diagnostics.graph_dump_dir);
     B("diagnostics.nvfp4_force_dequant", cfg.diagnostics.nvfp4_force_dequant);
+    B("diagnostics.no_nvfp4_decode_cache", cfg.diagnostics.no_nvfp4_decode_cache);
     B("diagnostics.log_gemm_algo", cfg.diagnostics.log_gemm_algo);
     B("diagnostics.mtp_pattern_log", cfg.diagnostics.mtp_pattern_log);
     B("diagnostics.mtp_prenorm_h", cfg.diagnostics.mtp_prenorm_h);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -641,6 +641,12 @@ struct RuntimeConfig {
         // tool — see Mistral-Small-3.2-NVFP4 long-form repetition loops).
         // Legacy env: IMP_NVFP4_FORCE_DEQUANT.
         bool nvfp4_force_dequant = false;
+        // Skip building the NVFP4 decode cache entirely (bisection/eval
+        // tool): decode runs on the source-precision paths (dp4a GEMV for
+        // GGUF quants, FP16 GEMV otherwise) — the pre-cache decode
+        // semantics. Distinct from nvfp4_force_dequant, which dequantizes
+        // the already-NVFP4-quantized cache and so keeps NVFP4 values.
+        bool no_nvfp4_decode_cache = false;
         // Log shape + per-candidate algoId/tileId + chosen algo for every
         // benchmark_and_select_algo call. Legacy env: IMP_LOG_GEMM_ALGO.
         bool log_gemm_algo = false;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -416,6 +416,7 @@ private:
         int n = 0;
         int32_t* d_tokens = nullptr;
         double* d_nll = nullptr;
+        int32_t* d_match = nullptr;  // per-pos greedy-argmax == next-token
     } ppl_capture_;
 
     // ── Model-specific state ─────────────────────────────────────────

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -335,6 +335,14 @@ bool Engine::begin_perplexity_capture(const int32_t* tokens, int n) {
     IMP_CUDA_CHECK_LOG(cudaMemcpy(ppl_capture_.d_tokens, tokens,
                                   static_cast<size_t>(n) * sizeof(int32_t), cudaMemcpyHostToDevice));
     IMP_CUDA_CHECK_LOG(cudaMemset(ppl_capture_.d_nll, 0, static_cast<size_t>(n) * sizeof(double)));
+    // Greedy-agreement probe rides along for free (fused into the NLL max
+    // pass); allocation failure just disables it.
+    if (cudaMalloc(&ppl_capture_.d_match, static_cast<size_t>(n) * sizeof(int32_t)) == cudaSuccess) {
+        IMP_CUDA_CHECK_LOG(
+            cudaMemset(ppl_capture_.d_match, 0, static_cast<size_t>(n) * sizeof(int32_t)));
+    } else {
+        ppl_capture_.d_match = nullptr;
+    }
     ppl_capture_.n = n;
     ppl_capture_.active = true;
     return true;
@@ -352,6 +360,17 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
     std::vector<double> h_nll_pos(static_cast<size_t>(n), 0.0);
     IMP_CUDA_CHECK_LOG(cudaMemcpy(h_nll_pos.data(), ppl_capture_.d_nll,
                                   static_cast<size_t>(n) * sizeof(double), cudaMemcpyDeviceToHost));
+    long match_sum = -1;
+    if (ppl_capture_.d_match) {
+        std::vector<int32_t> h_match(static_cast<size_t>(n), 0);
+        IMP_CUDA_CHECK_LOG(cudaMemcpy(h_match.data(), ppl_capture_.d_match,
+                                      static_cast<size_t>(n) * sizeof(int32_t),
+                                      cudaMemcpyDeviceToHost));
+        match_sum = 0;
+        for (int i = 0; i < n - 1; ++i)
+            match_sum += h_match[i];
+        cudaFree(ppl_capture_.d_match);
+    }
     cudaFree(ppl_capture_.d_tokens);
     cudaFree(ppl_capture_.d_nll);
     ppl_capture_ = PplCapture{};
@@ -374,6 +393,9 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
         h_nll += h_nll_pos[i];
     double ppl = std::exp(h_nll / static_cast<double>(n - 1));
     IMP_LOG_INFO("perplexity_nll: n=%d  mean_nll=%.4f  PPL=%.4f", n, h_nll / (n - 1), ppl);
+    if (match_sum >= 0)
+        IMP_LOG_INFO("greedy top1 match: %ld/%d (%.2f%%)", match_sum, n - 1,
+                     100.0 * static_cast<double>(match_sum) / static_cast<double>(n - 1));
     if (out_ppl)
         *out_ppl = ppl;
     return true;
@@ -816,7 +838,8 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         // holds exactly this chunk and nothing reads logits_ afterwards.
         if (ppl_capture_.active) {
             executor_->perplexity_nll_partial(ppl_capture_.d_tokens, ppl_capture_.n, offset,
-                                              chunk_len, ppl_capture_.d_nll, pf_stream);
+                                              chunk_len, ppl_capture_.d_nll, pf_stream,
+                                              ppl_capture_.d_match);
         }
 
         if (!pf_pool_used) {
@@ -931,7 +954,8 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         // slices the last token for the production LM head).
         if (ppl_capture_.active) {
             executor_->perplexity_nll_partial(ppl_capture_.d_tokens, ppl_capture_.n, offset,
-                                              chunk_len, ppl_capture_.d_nll, pf_stream);
+                                              chunk_len, ppl_capture_.d_nll, pf_stream,
+                                              ppl_capture_.d_match);
         }
 
         req->output_tokens.push_back(next_token);


### PR DESCRIPTION
Diagnostics kept from the #845 (NVFP4 self-draft) economics probe — the probe itself **refuted** the idea; full evidence in the issue comment on #845.

## What

- **`diagnostics.no_nvfp4_decode_cache`** (default `false`): skip building the NVFP4 decode cache so decode runs on the source-precision paths (dp4a GEMV for GGUF quants, FP16 GEMV otherwise) — the quality baseline the cache replaces. Complements `diagnostics.nvfp4_force_dequant`, which dequantizes the *already NVFP4-quantized* cache and therefore keeps NVFP4 values. Measured on Qwen3-8B Q8_0: 270 tok/s (cache) vs 152 tok/s (source paths).
- **`--perplexity` now also reports `greedy top1 match`**: how often the greedy argmax (production tie-break, smallest index) equals the actual next corpus token. On a transcript generated greedily by the same model this measures the argmax agreement between the decode path and the full-precision verify path — i.e. the acceptance ceiling a spec verify pass would see (measured ~90% on prose *and* code for Q8→NVFP4-cache, which is what killed #845). The argmax rides along in the NLL kernel's existing max pass; NLL math untouched. Chunked-capture flow only (single-chunk `perplexity_nll` passes `nullptr`).

No hot-path changes: the knob is opt-in and load-time-only; the kernel addition is eval-only (`--perplexity`).

## Testing

- `make test-unit` 37/37, `make verify-fast` OK (model stages skip: container symlink gotcha, known).
- Manual: `--perplexity` PPL values unchanged-plausible on self-generated transcripts (1.53/1.72); knob verified via decode A/B above (coherent output, log line confirms skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)