### PR TITLE
perf(spec): batched verify/eval LM head — one weight pass per 4 rows instead of per row (#847)

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -356,7 +356,7 @@ private:
     void* lora_scratch_ = nullptr;  // fp32[max_rank] + fp16[max_tokens*max_rank]
     size_t lora_scratch_sz_ = 0;
     void lora_delta_(const LoraWeights& w, const void* x, void* y, int n, cudaStream_t stream);
-    int max_logit_tokens_ = 0;     // max tokens needing LM head projection (= max_batch_size)
+    int max_logit_tokens_ = 0;     // max tokens needing LM head projection (= max(max_batch_size, 8))
     int cur_n_tokens_ = 0;         // set by forward_logits for use by run_ffn
     int cur_decode_step_ = 0;      // set by forward_logits for debug dump tagging
     bool cur_force_fp16_ = false;  // set by forward_logits, bypasses FP8 GEMM paths

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -182,14 +182,16 @@ void GraphExecutor::for_each_lm_head_batch_(int n_rows, cudaStream_t stream,
         if (lm_cutlass_done) {
             // logits already written
         } else if (lm_is_nvfp4) {
-            Tensor no_row = view_tokens(norm_out_, 1);
-            for (int r = 0; r < csz; ++r) {
-                Tensor h_row = hc.slice(r, r + 1);
-                Tensor lg_row = lg.slice(r, r + 1);
-                rmsnorm(h_row, model_->output_norm(), no_row, cfg.rms_norm_eps, stream, norm_w_off_);
-                gemv_nvfp4_kpar_fp32(nvfp4_lm_r, static_cast<const half*>(no_row.data),
-                                     static_cast<float*>(lg_row.data), cfg.vocab_size, cfg.d_model, stream);
-            }
+            // Batched-M GEMV: one weight pass per MR=4 rows instead of a full
+            // vocab×d_model weight read per row. On a 65-row verify chunk
+            // (Qwen3-Coder-30B) the per-row loop spent 7.2 ms re-reading the
+            // LM head 65×; batched it's ~1.9 ms. Row math is unchanged (FP16
+            // activations, same kernel family as production batched decode).
+            Tensor noc = view_tokens(norm_out_, csz);
+            rmsnorm(hc, model_->output_norm(), noc, cfg.rms_norm_eps, stream, norm_w_off_);
+            gemv_nvfp4_kpar_batched_fp32(nvfp4_lm_r, static_cast<const half*>(noc.data),
+                                         static_cast<float*>(lg.data), cfg.vocab_size, cfg.d_model,
+                                         csz, stream);
         } else if (use_dp4a_lm) {
             // Per-row: fused RMSNorm→Q8_1 quantize + dp4a GEMV (the q8_1
             // scratch holds exactly one row — same as production decode).

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -136,7 +136,15 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
     // Logits buffer only needs to hold tokens that require LM head projection:
     // - Prefill: 1 (last token only)
     // - Decode:  n_sequences (one per batch slot)
-    max_logit_tokens_ = std::max(max_batch_size, 1);
+    // - Eval/verify (spec-decode greedy verify, --perplexity): chunk rows are
+    //   processed through this buffer in batches of max_logit_tokens_. Floor 8:
+    //   at batch=1 the buffer was [1, vocab], which serialized the verify LM
+    //   head into one full-weight GEMV per row (a 65-row verify chunk re-read
+    //   the LM head 65x — 7.2 of 30 ms/cycle on Qwen3-Coder-30B). With >=4
+    //   rows the batched-M GEMV reuses each weight read across MR=4 rows;
+    //   8 halves the outer-loop iterations for ~5 MB of logits (+split-K
+    //   scratch scales with this too, ~1 MB/row).
+    max_logit_tokens_ = std::max({max_batch_size, 8, 1});
 
     // Wire the scratch-arena component with the live context it sizes against
     // (pointers to GraphExecutor members so e.g. has_gdn_ is read live — still


### PR DESCRIPTION
Attacks the dominant verify-cost term identified in the #847 follow-ups ("graph-captured verify / verify economics"), located by nsys on Qwen3-Coder-30B: the spec-verify LM head re-read the full NVFP4 LM-head weights **once per chunk row**.

## Root cause (two layers)

1. `for_each_lm_head_batch_` (shared by spec-verify `greedy_argmax_all`, `--perplexity`, `project_logits_all`) ran a per-row `gemv_nvfp4_kpar_fp32` loop — one full vocab×d_model weight read per row. A 65-row verify chunk read the 166 MB LM head 65× = 7.2 ms of a 30 ms verify cycle.
2. Even after switching to the batched-M GEMV, nothing changed at batch=1: `max_logit_tokens_ = max_batch_size` sizes the `logits_` buffer to **[1, vocab]** in CLI/single-stream sessions, so the "batch" was always one row. Floored at 8 (MR=4 weight reuse saturates at 4; 8 halves outer iterations; ~5 MB logits + ~1 MB/row split-K scratch).

The dp4a (raw-GGUF-quant LM head) arm keeps its per-row GEMV loop (single-row q8_1 scratch) — batching that is a separate slice — but GGUF still gains from batched argmax/penalties and fewer outer iterations.

## Measured (RTX 5090, healthy clocks, CUBLAS_WORKSPACE_CONFIG=:4096:8)

Echo workload (repeat-exactly, suffix spec fully engaged, ~62 tok/verify):

| Model | before | after | Δ |
|---|---|---|---|
| Qwen3-Coder-30B-A3B NVFP4 (MoE) | 1336 tok/s | **~2000–2180 tok/s** | **+50%** |
| Qwen3-8B Q8_0 (GGUF, dp4a lm_head) | 1120 tok/s | ~1380 tok/s | +22% |
| Qwen3-8B-NVFP4-cortecs (dense) | — | 2072 tok/s | — |

nsys per-verify-cycle anatomy (Coder-30B, ~62-token chunk):

| | before | after |
|---|---|---|
| cycle wall | 30.0 ms | **23.5 ms** |
| LM-head GEMV | 7.2 ms / 66 launches | **3.46 ms / 18 launches** |
| GPU idle (launch pacing) | ~8 ms | ~7–8 ms (unchanged — that's the remaining graph-capture lever, ~1800 launches/cycle) |

Draft-poor / plain decode is untouched (production `forward_logits` M=1 GEMV unchanged; `--bench` numbers unaffected — bench pins spec off).

## Correctness

- **Lossless check**: Qwen3-8B-NVFP4-cortecs (dense), spec on vs off at temp=0 — byte-identical output (whitespace-normalized), 2481/2481 chars.
- **Verify decisions unchanged**: identical accept telemetry on all echo runs (Coder 848/848 accepted, same chunk structure).
- **Perplexity anchor bit-exact** on Q8 (dp4a arm): PPL 1.5296, greedy top1 match 868/976 — identical to pre-change.
- **DegenerationTest** 5/5 (Q8-8B); Nemotron-3-Nano NVFP4 hybrid echo coherent with 94.4% accept incl. partial-accept replay path; stderr greps clean (no NaN / capture failed / falling back).
- The batched GEMV (`gemv_nvfp4_kpar_mb_fp32_kernel`) computes the same FP16-activation dot products as the per-row path (same family as production batched decode); logit last-bit differences vs the M=1 kernel are within the already-documented prefill≠decode near-tie class — empirically zero flips in all runs above.
- `make verify-fast` OK, `make test-unit` 37/37.

## Follow-ups (tracked in #847)

- GGUF dp4a LM-head batching (needs a multi-row q8_1 scratch or dequant→GEMM route).
- The remaining ~7–8 ms/cycle GPU idle is eager launch pacing (~1800 kernels/cycle) — the graph-captured/bucketed verify chunk lever.
- MTP chain lm_heads are sequential (drafting), not covered by this — needs the NVFP4-lm_head-for-chain slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
