### PR TITLE
perf(spec): graph-captured verify chunk — per-bucket CUDA graphs replace the eager verify forward (#847)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ set(IMP_RUNTIME_SOURCES
     src/runtime/engine_graph_decode.cpp
     src/runtime/engine_scheduler.cpp
     src/runtime/engine_spec_ngram.cpp
+    src/runtime/engine_spec_capture.cpp
     src/runtime/engine_spec_mtp.cpp
     src/runtime/engine_sampling_stop.cpp
     src/runtime/ngram_draft.cpp

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -342,6 +342,17 @@ hybrid               = true
 # MTP chains fill verify steps where the suffix matcher has no draft.
 # imp-cli equivalent: --mtp-spec-decode <k>.
 mtp_k                = 0
+# Graph-captured verify (#847): cache one CUDA graph per draft-length bucket
+# and replay it each verify step (all growing lengths are read from device
+# buffers), removing the eager launch-pacing tax. Engages only where the
+# FP16-QK FA2 kernel serves the chunk (uniform hd=128, no sinks/MLA/LongRoPE)
+# on non-hybrid models; capture failures fall back to the eager verify.
+# imp-cli --bench pins this false (raw-decode baseline semantics).
+capture              = true
+# Context capacity the captured grids and the persistent K/V scratch cover
+# (2 x cap x nkv x hd x 2B VRAM); verify steps beyond it run eager. Clamped
+# to the model's max_seq_len.
+capture_ctx_cap      = 32768
 
 [constrained]
 # Jump-ahead over schema-forced spans (#844): when the json_schema FSM

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -1278,7 +1278,8 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
                                       const half* __restrict__ V, half* __restrict__ O, int batch_size,
                                       int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale,
                                       bool causal, int sliding_window, float softcap, int q_offset,
-                                      const float* __restrict__ d_amax = nullptr) {
+                                      const float* __restrict__ d_amax = nullptr,
+                                      const int* __restrict__ d_kv_len = nullptr) {
     constexpr int Bkv = BKV;
     static_assert(BKV % 16 == 0 && (BKV / 8) % 2 == 0, "QK n-pair loop and PV K-groups need BKV % 16 == 0");
     constexpr int head_dim = HD;
@@ -1297,6 +1298,15 @@ __global__ void fmha_sm120_fa2_kernel(const half* __restrict__ Q, const half* __
     const int batch_idx = batch_head / n_heads;
     const int head_idx = batch_head % n_heads;
     const int kv_head = head_idx / (n_heads / n_kv_heads);
+
+    // Graph-captured verify (#847): the real KV length lives on device and the
+    // baked seq_kv is only the buffer capacity (single-sequence chunks, so the
+    // batch stride it feeds is inert). q_offset follows from the chunked
+    // continuation invariant seq_kv == q_offset + seq_q.
+    if (d_kv_len != nullptr) {
+        seq_kv = __ldg(d_kv_len);
+        q_offset = seq_kv - seq_q;
+    }
 
     const int lane = threadIdx.x;     // 0..31
     const int warp_id = threadIdx.y;  // 0..7  → this warp's row tile
@@ -1809,9 +1819,11 @@ static size_t compute_smem_fa2(int Bq, int head_dim, bool fp16_qk, int Bkv, bool
 
 bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                             bool causal, int sliding_window, float softcap, cudaStream_t stream, int q_offset,
-                            bool fp16_qk) {
+                            bool fp16_qk, const int* d_kv_len) {
     if (Q.qtype != QType::F16)
         return false;
+    if (d_kv_len != nullptr && !fp16_qk)
+        return false;  // device-length replay is wired for the f16-QK path only
     const int batch_size = static_cast<int>(Q.shape[0]);
     const int seq_q = static_cast<int>(Q.shape[1]);
     const int n_heads = static_cast<int>(Q.shape[2]);
@@ -1940,7 +1952,7 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
                                         reinterpret_cast<const half*>(V.data),
                                         reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv, n_heads,
                                         n_kv_heads, scale, causal, sliding_window, softcap, q_offset,
-                                        fp8_scaled ? s_d_amax : nullptr);
+                                        fp8_scaled ? s_d_amax : nullptr, d_kv_len);
     return true;
 }
 

--- a/src/compute/attention_fmha_sm120.h
+++ b/src/compute/attention_fmha_sm120.h
@@ -46,8 +46,15 @@ bool fmha_sm120_fp8_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
 // score noise — safe below fmha_prefill_threshold where the fp8 variants
 // compound per-layer noise into prompt-blind output (#511/#512). Bq=64 only
 // (f16 Q tile at Bq=128 exceeds the sm_120 smem opt-in).
+//
+// d_kv_len: optional DEVICE int overriding the KV length. When set, K.shape[1]
+// only carries the buffer CAPACITY (batch stride, prefetch upper bound) and
+// the kernel reads the real seq_kv from device, deriving q_offset as
+// seq_kv - seq_q (chunked continuation invariant). Grid dims depend only on
+// seq_q, so a captured graph replays correctly as the context grows between
+// replays (#847 graph-captured verify). fp16_qk path only.
 bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                             bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                            int q_offset = 0, bool fp16_qk = false);
+                            int q_offset = 0, bool fp16_qk = false, const int* d_kv_len = nullptr);
 
 }  // namespace imp

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -1,4 +1,5 @@
 #include "compute/gemm.h"
+#include <atomic>
 #include "compute/gemm_capture_fp16_sm120.h"
 #include "compute/gemm_internal.cuh"
 #include "core/logging.h"
@@ -27,6 +28,16 @@
     } while (0)
 
 namespace imp {
+
+// #847 graph-captured verify: see gemm.h. Single engine thread writes it;
+// relaxed atomic keeps tsan honest without cost.
+static std::atomic<bool> g_lt_capture_allowed{false};
+void gemm_set_lt_capture_allowed(bool allowed) {
+    g_lt_capture_allowed.store(allowed, std::memory_order_relaxed);
+}
+bool gemm_lt_capture_allowed() {
+    return g_lt_capture_allowed.load(std::memory_order_relaxed);
+}
 
 // warp_reduce_sum / kGemvThreads / kGemvWarps / gemv_blocks live in
 // gemm_internal.cuh (shared with gemm_gemv_dtype.cu + gemm_moe_gemv.cu).
@@ -500,9 +511,17 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C, f
 
     // Capture-safe path: cuBLASLt fails with CUBLAS_STATUS_INTERNAL_ERROR
     // (status 14) under stream capture on sm_120 — heuristic + workspace
-    // allocation paths aren't graph-safe. Route FP16×FP16→FP16 GEMMs to the
-    // hand-tuned sm_120 WMMA kernel when the stream is in capture mode.
-    if (A.qtype == QType::F16 && B.qtype == QType::F16 && C.qtype == QType::F16) {
+    // allocation paths aren't graph-safe on a COLD shape. Route FP16×FP16→FP16
+    // GEMMs to the hand-tuned sm_120 WMMA kernel when the stream is in capture
+    // mode — unless the capturer opted in via gemm_set_lt_capture_allowed():
+    // the graph-captured verify chunk (#847) warms every shape eagerly before
+    // capturing, so Lt's heuristic cache and handle workspace are populated
+    // and the call records cleanly (the WMMA fallback measured ~5x slower than
+    // Lt's nvjet kernels on the verify GEMMs — 167 ms/1400 tok on Q8-8B). A
+    // residual status-14 fails that one capture; the engine falls back to the
+    // eager verify and disables capture after repeated failures.
+    if (A.qtype == QType::F16 && B.qtype == QType::F16 && C.qtype == QType::F16 &&
+        !gemm_lt_capture_allowed()) {
         cudaStreamCaptureStatus cap_status = cudaStreamCaptureStatusNone;
         if (cudaStreamIsCapturing(stream, &cap_status) == cudaSuccess &&
             cap_status == cudaStreamCaptureStatusActive) {

--- a/src/compute/gemm.h
+++ b/src/compute/gemm.h
@@ -10,6 +10,13 @@ namespace imp {
 // to ensure workspace is allocated while GPU memory is available.
 void gemm_init();
 
+// Graph-captured verify (#847): allow cuBLASLt calls to record into an active
+// stream capture. Default off — cold-shape Lt calls fail with status 14 under
+// capture on sm_120 (heuristic/workspace paths); the verify capturer warms
+// every shape eagerly first and toggles this around its capture.
+void gemm_set_lt_capture_allowed(bool allowed);
+bool gemm_lt_capture_allowed();
+
 // Destroy cached cuBLASLt descriptors. Call at shutdown (e.g. Engine destructor).
 void gemm_cleanup();
 

--- a/src/compute/kv_gather.cu
+++ b/src/compute/kv_gather.cu
@@ -16,12 +16,18 @@ namespace imp {
 //
 // NOTE: __ldcs is a streaming hint — KV bytes don't pollute L2, matching
 // paged_attention_decode_fp8 / decode_int8 / decode behavior.
+//
+// d_n_past (all kernels): optional DEVICE override of the n_past bound. When
+// set, the host n_past only sized the (oversized) grid and the real token
+// count is read from device — the graph-captured verify path (#847) replays
+// a baked grid while the context grows between replays.
 
 static constexpr int TOKENS_PER_BLOCK = 8;
 
 __global__ void paged_kv_gather_fp16_kernel(half* __restrict__ dst, const half* __restrict__ src,
                                             const int* __restrict__ block_table, int n_past,
-                                            int block_size, int nkv, int hd) {
+                                            int block_size, int nkv, int hd,
+                                            const int* __restrict__ d_n_past) {
     const int block_group = blockIdx.x;     // group of TOKENS_PER_BLOCK tokens
     const int kv_head = blockIdx.y;
     const int tid = threadIdx.x;
@@ -29,6 +35,8 @@ __global__ void paged_kv_gather_fp16_kernel(half* __restrict__ dst, const half* 
     const int token_in_block = tid / threads_per_token;
     const int d_lane = tid % threads_per_token;
 
+    if (d_n_past)
+        n_past = __ldg(d_n_past);
     const int pos = block_group * TOKENS_PER_BLOCK + token_in_block;
     if (pos >= n_past)
         return;
@@ -57,7 +65,8 @@ __global__ void paged_kv_gather_fp8_to_fp16_kernel(half* __restrict__ dst,
                                                     const __nv_fp8_e4m3* __restrict__ src,
                                                     const int* __restrict__ block_table,
                                                     float kv_scale, int n_past, int block_size,
-                                                    int nkv, int hd) {
+                                                    int nkv, int hd,
+                                                    const int* __restrict__ d_n_past) {
     const int block_group = blockIdx.x;
     const int kv_head = blockIdx.y;
     const int tid = threadIdx.x;
@@ -65,6 +74,8 @@ __global__ void paged_kv_gather_fp8_to_fp16_kernel(half* __restrict__ dst,
     const int token_in_block = tid / threads_per_token;
     const int d_lane = tid % threads_per_token;
 
+    if (d_n_past)
+        n_past = __ldg(d_n_past);
     const int pos = block_group * TOKENS_PER_BLOCK + token_in_block;
     if (pos >= n_past)
         return;
@@ -92,26 +103,28 @@ __global__ void paged_kv_gather_fp8_to_fp16_kernel(half* __restrict__ dst,
 }
 
 void paged_kv_gather_fp16(half* dst, const half* src, const int* block_table, int n_past,
-                          int block_size, int nkv, int hd, cudaStream_t stream) {
+                          int block_size, int nkv, int hd, cudaStream_t stream,
+                          const int* d_n_past) {
     if (n_past <= 0 || nkv <= 0 || hd <= 0)
         return;
     int n_block_groups = (n_past + TOKENS_PER_BLOCK - 1) / TOKENS_PER_BLOCK;
     dim3 grid(n_block_groups, nkv);
     int threads = 256;  // 8 tokens × 32 lanes; works for hd up to 256 with stride-32, OK for hd=512 too
     paged_kv_gather_fp16_kernel<<<grid, threads, 0, stream>>>(dst, src, block_table, n_past,
-                                                              block_size, nkv, hd);
+                                                              block_size, nkv, hd, d_n_past);
 }
 
 void paged_kv_gather_fp8_to_fp16(half* dst, const __nv_fp8_e4m3* src, const int* block_table,
                                  float kv_scale, int n_past, int block_size, int nkv, int hd,
-                                 cudaStream_t stream) {
+                                 cudaStream_t stream, const int* d_n_past) {
     if (n_past <= 0 || nkv <= 0 || hd <= 0)
         return;
     int n_block_groups = (n_past + TOKENS_PER_BLOCK - 1) / TOKENS_PER_BLOCK;
     dim3 grid(n_block_groups, nkv);
     int threads = 256;
     paged_kv_gather_fp8_to_fp16_kernel<<<grid, threads, 0, stream>>>(dst, src, block_table, kv_scale,
-                                                                      n_past, block_size, nkv, hd);
+                                                                      n_past, block_size, nkv, hd,
+                                                                      d_n_past);
 }
 
 // NVFP4 → FP16 dequant gather. Same TOKENS_PER_BLOCK / threads_per_token grid
@@ -124,7 +137,8 @@ __global__ void paged_kv_gather_nvfp4_to_fp16_kernel(
     const uint8_t* __restrict__ src_packed,    // [block, slot, nkv, hd/2]
     const uint8_t* __restrict__ src_scales,    // [block, slot, nkv, hd/16] UE4M3
     const int* __restrict__ block_table,
-    int n_past, int block_size, int nkv, int hd) {
+    int n_past, int block_size, int nkv, int hd,
+    const int* __restrict__ d_n_past) {
     constexpr int kGroup = 16;
 
     const int block_group = blockIdx.x;
@@ -134,6 +148,8 @@ __global__ void paged_kv_gather_nvfp4_to_fp16_kernel(
     const int token_in_block = tid / threads_per_token;
     const int d_lane = tid % threads_per_token;
 
+    if (d_n_past)
+        n_past = __ldg(d_n_past);
     const int pos = block_group * TOKENS_PER_BLOCK + token_in_block;
     if (pos >= n_past)
         return;
@@ -179,14 +195,14 @@ __global__ void paged_kv_gather_nvfp4_to_fp16_kernel(
 void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
                                    const uint8_t* src_scales, const int* block_table,
                                    int n_past, int block_size, int nkv, int hd,
-                                   cudaStream_t stream) {
+                                   cudaStream_t stream, const int* d_n_past) {
     if (n_past <= 0 || nkv <= 0 || hd <= 0)
         return;
     int n_block_groups = (n_past + TOKENS_PER_BLOCK - 1) / TOKENS_PER_BLOCK;
     dim3 grid(n_block_groups, nkv);
     int threads = 256;
     paged_kv_gather_nvfp4_to_fp16_kernel<<<grid, threads, 0, stream>>>(
-        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd);
+        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd, d_n_past);
 }
 
 // ---------------------------------------------------------------------------
@@ -198,7 +214,8 @@ __global__ void paged_kv_gather_mxfp4_kv_to_fp16_kernel(
     const uint8_t* __restrict__ src_packed,  // [block, slot, nkv, hd/2]
     const uint8_t* __restrict__ src_scales,  // [block, slot, nkv, hd/16] UE8M0
     const int* __restrict__ block_table,
-    int n_past, int block_size, int nkv, int hd) {
+    int n_past, int block_size, int nkv, int hd,
+    const int* __restrict__ d_n_past) {
     constexpr int kGroup = 16;
 
     const int block_group = blockIdx.x;
@@ -208,6 +225,8 @@ __global__ void paged_kv_gather_mxfp4_kv_to_fp16_kernel(
     const int token_in_block = tid / threads_per_token;
     const int d_lane = tid % threads_per_token;
 
+    if (d_n_past)
+        n_past = __ldg(d_n_past);
     const int pos = block_group * TOKENS_PER_BLOCK + token_in_block;
     if (pos >= n_past)
         return;
@@ -251,14 +270,14 @@ __global__ void paged_kv_gather_mxfp4_kv_to_fp16_kernel(
 void paged_kv_gather_mxfp4_kv_to_fp16(half* dst, const uint8_t* src_packed,
                                        const uint8_t* src_scales, const int* block_table,
                                        int n_past, int block_size, int nkv, int hd,
-                                       cudaStream_t stream) {
+                                       cudaStream_t stream, const int* d_n_past) {
     if (n_past <= 0 || nkv <= 0 || hd <= 0)
         return;
     int n_block_groups = (n_past + TOKENS_PER_BLOCK - 1) / TOKENS_PER_BLOCK;
     dim3 grid(n_block_groups, nkv);
     int threads = 256;
     paged_kv_gather_mxfp4_kv_to_fp16_kernel<<<grid, threads, 0, stream>>>(
-        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd);
+        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd, d_n_past);
 }
 
 // INT4 → FP16 dequant gather. Symmetric 4-bit, per-head FP16 scale.
@@ -270,7 +289,8 @@ __global__ void paged_kv_gather_int4_to_fp16_kernel(
     const uint8_t* __restrict__ src_packed,  // [block, slot, nkv, hd/2]
     const half* __restrict__ src_scales,     // [block, slot, nkv]
     const int* __restrict__ block_table,
-    int n_past, int block_size, int nkv, int hd) {
+    int n_past, int block_size, int nkv, int hd,
+    const int* __restrict__ d_n_past) {
     const int block_group = blockIdx.x;
     const int kv_head = blockIdx.y;
     const int tid = threadIdx.x;
@@ -278,6 +298,8 @@ __global__ void paged_kv_gather_int4_to_fp16_kernel(
     const int token_in_block = tid / threads_per_token;
     const int d_lane = tid % threads_per_token;
 
+    if (d_n_past)
+        n_past = __ldg(d_n_past);
     const int pos = block_group * TOKENS_PER_BLOCK + token_in_block;
     if (pos >= n_past)
         return;
@@ -317,14 +339,33 @@ __global__ void paged_kv_gather_int4_to_fp16_kernel(
 void paged_kv_gather_int4_to_fp16(half* dst, const uint8_t* src_packed,
                                   const half* src_scales, const int* block_table,
                                   int n_past, int block_size, int nkv, int hd,
-                                  cudaStream_t stream) {
+                                  cudaStream_t stream, const int* d_n_past) {
     if (n_past <= 0 || nkv <= 0 || hd <= 0)
         return;
     int n_block_groups = (n_past + TOKENS_PER_BLOCK - 1) / TOKENS_PER_BLOCK;
     dim3 grid(n_block_groups, nkv);
     int threads = 256;
     paged_kv_gather_int4_to_fp16_kernel<<<grid, threads, 0, stream>>>(
-        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd);
+        dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd, d_n_past);
+}
+
+// Chunk append at device-computed row offset (see kv_gather.h). n ≤ ~65 rows,
+// row_elems = nkv*hd — a single thread block per row keeps this trivial.
+__global__ void kv_chunk_append_fp16_kernel(half* __restrict__ dst, const half* __restrict__ src,
+                                            const int* __restrict__ d_past_len, int row_elems) {
+    const int row = blockIdx.x;
+    const int past = __ldg(d_past_len);
+    half* dst_row = dst + ((size_t)past + row) * row_elems;
+    const half* src_row = src + (size_t)row * row_elems;
+    for (int e = threadIdx.x; e < row_elems; e += blockDim.x)
+        dst_row[e] = src_row[e];
+}
+
+void kv_chunk_append_fp16(half* dst, const half* src, const int* d_past_len, int n,
+                          int row_elems, cudaStream_t stream) {
+    if (n <= 0 || row_elems <= 0)
+        return;
+    kv_chunk_append_fp16_kernel<<<n, 256, 0, stream>>>(dst, src, d_past_len, row_elems);
 }
 
 }  // namespace imp

--- a/src/compute/kv_gather.h
+++ b/src/compute/kv_gather.h
@@ -18,14 +18,21 @@ namespace imp {
 // block_size:  KV cache block_size (e.g. 16)
 // nkv:         number of KV heads
 // hd:          head_dim
+// d_n_past:    optional DEVICE int overriding n_past as the gather bound.
+//              When set, the host n_past only sizes the grid (an upper
+//              capacity) and the kernel reads the real token count from
+//              device — required for CUDA-graph replay across context growth
+//              (#847 graph-captured verify), where the graph bakes the grid
+//              but the context keeps growing between replays.
 void paged_kv_gather_fp16(half* dst, const half* src, const int* block_table,
-                          int n_past, int block_size, int nkv, int hd, cudaStream_t stream);
+                          int n_past, int block_size, int nkv, int hd, cudaStream_t stream,
+                          const int* d_n_past = nullptr);
 
 // FP8 E4M3 paged → FP16 flat with per-tensor scalar dequant: dst[i] = (half)((float)src[i] * kv_scale).
 // Same indexing as paged_kv_gather_fp16; src is FP8 E4M3 (1 byte / elem).
 void paged_kv_gather_fp8_to_fp16(half* dst, const __nv_fp8_e4m3* src, const int* block_table,
                                  float kv_scale, int n_past, int block_size, int nkv, int hd,
-                                 cudaStream_t stream);
+                                 cudaStream_t stream, const int* d_n_past = nullptr);
 
 // NVFP4 paged → FP16 flat with per-group-of-16 UE4M3 scale dequant.
 // src_packed layout: [num_blocks, block_size, nkv, hd/2] uint8 (2 FP4 nibbles/byte).
@@ -35,7 +42,7 @@ void paged_kv_gather_fp8_to_fp16(half* dst, const __nv_fp8_e4m3* src, const int*
 void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
                                    const uint8_t* src_scales, const int* block_table,
                                    int n_past, int block_size, int nkv, int hd,
-                                   cudaStream_t stream);
+                                   cudaStream_t stream, const int* d_n_past = nullptr);
 
 // MXFP4-KV paged → FP16 flat with per-group-of-16 UE8M0 scale dequant.
 // Layout identical to NVFP4; only the scale byte semantics differ (UE8M0 vs UE4M3).
@@ -43,7 +50,7 @@ void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
 void paged_kv_gather_mxfp4_kv_to_fp16(half* dst, const uint8_t* src_packed,
                                        const uint8_t* src_scales, const int* block_table,
                                        int n_past, int block_size, int nkv, int hd,
-                                       cudaStream_t stream);
+                                       cudaStream_t stream, const int* d_n_past = nullptr);
 
 // INT4 paged → FP16 flat with per-head FP16 scale dequant (symmetric, range [-8,7]).
 // src_packed layout: [num_blocks, block_size, nkv, hd/2] uint8 (low nibble=even d, high=odd d).
@@ -52,6 +59,14 @@ void paged_kv_gather_mxfp4_kv_to_fp16(half* dst, const uint8_t* src_packed,
 void paged_kv_gather_int4_to_fp16(half* dst, const uint8_t* src_packed,
                                   const half* src_scales, const int* block_table,
                                   int n_past, int block_size, int nkv, int hd,
-                                  cudaStream_t stream);
+                                  cudaStream_t stream, const int* d_n_past = nullptr);
+
+// Append the current chunk's contiguous FP16 K (or V) rows behind the gathered
+// past rows, at a DEVICE-computed row offset: dst[*d_past_len + i] = src[i]
+// for i in [0, n). Replaces the host-offset cudaMemcpyAsync in the chunked
+// continuation path for graph-captured verify (#847) — the destination offset
+// must track the growing context between graph replays.
+void kv_chunk_append_fp16(half* dst, const half* src, const int* d_past_len, int n,
+                          int row_elems, cudaStream_t stream);
 
 }  // namespace imp

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -256,6 +256,22 @@ public:
     // capacity guard abort).
     int max_safe_prefill_chunk(int offset, int desired, int kv_bs) const;
 
+    // Graph-captured verify chunk (#847). The chunked continuation forward is
+    // replayable (InferenceState::ctx_capacity mode) only when the FP16-QK FA2
+    // kernel serves EVERY attention layer with device-read lengths: uniform
+    // hd=128 shapes, no learned sinks, no MLA, no LongRoPE (host branch on
+    // max_context_len selects the freq table), fa2_fp16qk not disabled.
+    bool chunk_capture_supported() const;
+    // Persistent K/V scratch for the replayable chunked continuation
+    // ([ctx_capacity, nkv, hd] FP16 each) — replaces the per-layer
+    // cudaMallocAsync whose size would bake the growing ctx_len into the
+    // graph. Idempotent; returns false on allocation failure.
+    [[nodiscard]] bool ensure_chunk_capture_scratch(int ctx_capacity);
+    // Bumped whenever the shared forward workspace is reallocated. A captured
+    // verify graph holds raw pointers into it — the engine invalidates its
+    // graphs when this changes.
+    uint64_t workspace_generation() const { return ws_.generation(); }
+
     // Get a view of the logits buffer for n tokens (for CUDA graph replay,
     // where forward_logits isn't called but the graph writes to this buffer).
     Tensor get_logits_view(int n) const { return view_tokens(logits_, n); }
@@ -403,6 +419,13 @@ private:
     void* attn_scores_buf_ = nullptr;
     size_t attn_scores_buf_size_ = 0;
     Tensor attn_scores_;  // 3D tensor view into attn_scores_buf_
+
+    // Persistent K/V scratch for the graph-captured verify chunk (#847),
+    // sized by ensure_chunk_capture_scratch. chunk_capture_ctx_ is the
+    // ctx_capacity the buffers cover (0 = unallocated).
+    half* chunk_capture_k_ = nullptr;
+    half* chunk_capture_v_ = nullptr;
+    int chunk_capture_ctx_ = 0;
 
     // Dense FFN phase tensors (views into shared_workspace_, set by configure_ffn_workspace)
     Tensor gate_out_;    // [max_tokens, d_ff]

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -1,4 +1,5 @@
 #include "exec/executor.h"
+#include <stdexcept>
 #include "lora/lora_adapter.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"

--- a/src/exec/executor_attention_internal.h
+++ b/src/exec/executor_attention_internal.h
@@ -33,7 +33,7 @@ namespace imp {
 static bool try_fa2_fp16qk_prefill(const RuntimeConfig& rcfg, const Tensor& q, const Tensor& k,
                                    const Tensor& v, Tensor& o, int n, int kv_len, int nh, int nkv, int hd,
                                    float scale, int sliding_window, float softcap, int q_offset,
-                                   cudaStream_t stream) {
+                                   cudaStream_t stream, const int* d_kv_len = nullptr) {
     if (rcfg.attention.fa2_fp16qk == "never" || hd != 128)
         return false;
     // Chunk CONTINUATION (q_offset > 0, queries attend gathered past KV) is
@@ -60,7 +60,7 @@ static bool try_fa2_fp16qk_prefill(const RuntimeConfig& rcfg, const Tensor& q, c
     Tensor v4 = v.reshape(4, kv4s);
     Tensor o4 = o.reshape(4, q4s);
     return fmha_sm120_fa2_prefill(q4, k4, v4, o4, scale, /*causal=*/true, sliding_window, softcap, stream,
-                                  q_offset, /*fp16_qk=*/true);
+                                  q_offset, /*fp16_qk=*/true, d_kv_len);
 }
 
 // Fused QKV GEMV dispatch by quant type (all share identical signatures).

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -77,61 +77,99 @@
                     layer);
                 std::abort();
             }
+            // Graph-captured verify replay mode (#847): kernels must not bake
+            // the growing q_offset/ctx_len — grids and the persistent KV
+            // scratch are sized for ctx_capacity and the real lengths are read
+            // from device (d_past_len for the gather bound and append offset,
+            // context_lens[0] for the attention KV length).
+            const bool cap_replay = state.ctx_capacity > 0 && state.d_past_len != nullptr;
+            if (cap_replay &&
+                (!chunk_fa2_serves || ctx_len > state.ctx_capacity || state.n_sequences != 1 ||
+                 chunk_capture_k_ == nullptr || chunk_capture_ctx_ < state.ctx_capacity)) {
+                // The engine gates capture on chunk_capture_supported() and
+                // pre-allocates the scratch — reaching here is a wiring bug.
+                // Throwing fails the capture (or the eager warmup) cleanly and
+                // the engine dooms capture for this model.
+                throw std::runtime_error("chunked_prefill: capture-replay preconditions violated");
+            }
+            const int gather_cap = cap_replay ? state.ctx_capacity : q_offset;
+            const int* d_past = cap_replay ? state.d_past_len : nullptr;
             size_t full_bytes = (size_t)ctx_len * nkv * hd * sizeof(half);
 
             half* k_full = nullptr;
             half* v_full = nullptr;
-            cudaMallocAsync(&k_full, full_bytes, stream);
-            cudaMallocAsync(&v_full, full_bytes, stream);
+            if (cap_replay) {
+                k_full = chunk_capture_k_;
+                v_full = chunk_capture_v_;
+            } else {
+                cudaMallocAsync(&k_full, full_bytes, stream);
+                cudaMallocAsync(&v_full, full_bytes, stream);
+            }
 
             // Gather past KV [0, q_offset) directly into k_full[0..q_offset], v_full[0..q_offset].
             if (kvt == QType::F16) {
                 paged_kv_gather_fp16(k_full, static_cast<const half*>(cache->k_ptr(kv_layer, 0)),
-                                     state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                     state.block_tables, gather_cap, kv_bs, nkv, hd, stream, d_past);
                 paged_kv_gather_fp16(v_full, static_cast<const half*>(cache->v_ptr(kv_layer, 0)),
-                                     state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                     state.block_tables, gather_cap, kv_bs, nkv, hd, stream, d_past);
             } else if (kvt == QType::FP8_E4M3) {
                 float kv_scale = (!kv_scales_.empty() && kv_layer < (int)kv_scales_.size())
                                      ? kv_scales_[kv_layer]
                                      : 1.0f;
                 paged_kv_gather_fp8_to_fp16(k_full,
                                             static_cast<const __nv_fp8_e4m3*>(cache->k_ptr(kv_layer, 0)),
-                                            state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
+                                            state.block_tables, kv_scale, gather_cap, kv_bs, nkv, hd,
+                                            stream, d_past);
                 paged_kv_gather_fp8_to_fp16(v_full,
                                             static_cast<const __nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)),
-                                            state.block_tables, kv_scale, q_offset, kv_bs, nkv, hd, stream);
+                                            state.block_tables, kv_scale, gather_cap, kv_bs, nkv, hd,
+                                            stream, d_past);
             } else if (kvt == QType::NVFP4) {
                 paged_kv_gather_nvfp4_to_fp16(k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                                               static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
-                                              state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                              state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                              d_past);
                 paged_kv_gather_nvfp4_to_fp16(v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
                                               static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                                              state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                              state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                              d_past);
             } else if (kvt == QType::MXFP4_KV) {
                 paged_kv_gather_mxfp4_kv_to_fp16(k_full,
                                                  static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                                                  static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
-                                                 state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                                 state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                                 d_past);
                 paged_kv_gather_mxfp4_kv_to_fp16(v_full,
                                                  static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
                                                  static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                                                 state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                                 state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                                 d_past);
             } else {  // INT4 — symmetric 4-bit with per-head FP16 scale
                 paged_kv_gather_int4_to_fp16(k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                                              static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
-                                             state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                             state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                             d_past);
                 paged_kv_gather_int4_to_fp16(v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
                                              static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
-                                             state.block_tables, q_offset, kv_bs, nkv, hd, stream);
+                                             state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                             d_past);
             }
 
             // Append current chunk's K/V at offset q_offset.
-            cudaMemcpyAsync(k_full + (size_t)q_offset * nkv * hd, kk.data,
-                            (size_t)n * nkv * hd * sizeof(half), cudaMemcpyDeviceToDevice, stream);
-            cudaMemcpyAsync(v_full + (size_t)q_offset * nkv * hd, vv.data,
-                            (size_t)n * nkv * hd * sizeof(half), cudaMemcpyDeviceToDevice, stream);
+            if (cap_replay) {
+                kv_chunk_append_fp16(k_full, static_cast<const half*>(kk.data), state.d_past_len, n,
+                                     nkv * hd, stream);
+                kv_chunk_append_fp16(v_full, static_cast<const half*>(vv.data), state.d_past_len, n,
+                                     nkv * hd, stream);
+            } else {
+                cudaMemcpyAsync(k_full + (size_t)q_offset * nkv * hd, kk.data,
+                                (size_t)n * nkv * hd * sizeof(half), cudaMemcpyDeviceToDevice, stream);
+                cudaMemcpyAsync(v_full + (size_t)q_offset * nkv * hd, vv.data,
+                                (size_t)n * nkv * hd * sizeof(half), cudaMemcpyDeviceToDevice, stream);
+            }
 
-            int64_t kv_full_shape[2] = {(int64_t)ctx_len, (int64_t)(nkv * hd)};
+            int64_t kv_full_shape[2] = {(int64_t)(cap_replay ? state.ctx_capacity : ctx_len),
+                                        (int64_t)(nkv * hd)};
             Tensor k_full_t(k_full, QType::F16, 2, kv_full_shape, /*on_device=*/true);
             Tensor v_full_t(v_full, QType::F16, 2, kv_full_shape, /*on_device=*/true);
 
@@ -162,7 +200,18 @@
             // raw e4m3 Q/K conversion read teacher-forced PPL 549 vs 16.6 on
             // gemma-3-12b when it served these chunks). cuBLAS below the
             // threshold.
-            if (chunk_fa2_serves &&
+            if (cap_replay) {
+                // Replay mode is FA2-only: the S-matrix/FMHA fallbacks size and
+                // bound work from the baked ctx_len. A decline here means the
+                // engine-side eligibility check and the kernel disagree — fail
+                // the capture rather than record a stale-length fallback.
+                if (!try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n,
+                                            state.ctx_capacity, nh, nkv, hd, scale,
+                                            layer_sliding_window, cfg.attn_logit_softcap, q_offset,
+                                            stream, state.context_lens)) {
+                    throw std::runtime_error("chunked_prefill: FA2 declined a capture-replay chunk");
+                }
+            } else if (chunk_fa2_serves &&
                 try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
                                        nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
                                        q_offset, stream)) {
@@ -191,8 +240,10 @@
                                            cfg.attn_logit_softcap, stream, runtime_config(), q_offset);
             }
 
-            cudaFreeAsync(k_full, stream);
-            cudaFreeAsync(v_full, stream);
+            if (!cap_replay) {
+                cudaFreeAsync(k_full, stream);
+                cudaFreeAsync(v_full, stream);
+            }
 
             // Persist current chunk's K/V (same as non-chunked path)
             write_kv_cache(layer, state, stream);

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -500,6 +500,7 @@ bool Workspace::allocate_shared_workspace(int max_tokens) {
     if (max_shared == 0)
         return true;  // no workspace needed
 
+    generation_++;  // fresh arena — any prior baked pointers are dead
     shared_workspace_ = vram_alloc(vram_alloc_, max_shared, "shared_workspace");
     if (!shared_workspace_) {
         // Shared workspace is critical for GEMV scratch buffers. Fall back to
@@ -536,6 +537,7 @@ void Workspace::free_buffers() {
     if (shared_workspace_) {
         vram_free(vram_alloc_, shared_workspace_);
         shared_workspace_ = nullptr;
+        generation_++;
     }
     shared_workspace_size_ = 0;
     if (persistent_workspace_) {

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1232,6 +1232,15 @@ void GraphExecutor::free_buffers() {
     }
     vfree(attn_scores_buf_);
     attn_scores_buf_size_ = 0;
+    if (chunk_capture_k_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(chunk_capture_k_));
+        chunk_capture_k_ = nullptr;
+    }
+    if (chunk_capture_v_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(chunk_capture_v_));
+        chunk_capture_v_ = nullptr;
+    }
+    chunk_capture_ctx_ = 0;
     ws_.free_buffers();  // shared + persistent workspace (Workspace-owned)
     vfree(fp32_accum_buf_);
     ssm_layer_map_.clear();
@@ -1292,6 +1301,75 @@ int GraphExecutor::max_safe_prefill_chunk(int offset, int desired, int kv_bs) co
     if (kv_bs > 0)
         n_max = (n_max / kv_bs) * kv_bs;
     return std::min(desired, n_max);
+}
+
+bool GraphExecutor::chunk_capture_supported() const {
+    const auto& cfg = model_->config();
+    if (cfg.is_mla())
+        return false;  // absorbed-decode latent cache writes are host-parameterized
+    if (model_->profile().is_gpt_oss)
+        return false;  // learned sinks — cuBLAS-only chunked attention
+    if (longrope_short_freqs_ != nullptr)
+        return false;  // host branch on max_context_len picks the freq table
+    if (!attn_shapes_uniform())
+        return false;
+    int hd_u = cfg.head_dim > 0 ? cfg.head_dim
+                                : (cfg.n_heads > 0 ? cfg.d_model / cfg.n_heads : 0);
+    for (int x : cfg.head_dim_per_layer) {
+        if (x > 0) {
+            hd_u = x;
+            break;
+        }
+    }
+    if (hd_u != 128)
+        return false;  // FP16-QK FA2 is the only device-length chunked kernel
+    if (runtime_config().attention.fa2_fp16qk == "never")
+        return false;
+    return true;
+}
+
+bool GraphExecutor::ensure_chunk_capture_scratch(int ctx_capacity) {
+    if (ctx_capacity <= 0)
+        return false;
+    if (chunk_capture_k_ && chunk_capture_ctx_ >= ctx_capacity)
+        return true;
+    const auto& cfg = model_->config();
+    // Size for the largest per-layer shape (uniform under the eligibility
+    // gate, but the max keeps the scratch safe regardless).
+    int nkv_u = 0;
+    for (int x : cfg.n_kv_heads_per_layer) nkv_u = std::max(nkv_u, x);
+    if (nkv_u <= 0) nkv_u = cfg.n_kv_heads;
+    int hd_u = 0;
+    for (int x : cfg.head_dim_per_layer) hd_u = std::max(hd_u, x);
+    if (hd_u <= 0)
+        hd_u = cfg.head_dim > 0 ? cfg.head_dim
+                                : (cfg.n_heads > 0 ? cfg.d_model / cfg.n_heads : 0);
+    if (nkv_u <= 0 || hd_u <= 0)
+        return false;
+    const size_t bytes = static_cast<size_t>(ctx_capacity) * nkv_u * hd_u * sizeof(half);
+    if (chunk_capture_k_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(chunk_capture_k_));
+        chunk_capture_k_ = nullptr;
+    }
+    if (chunk_capture_v_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(chunk_capture_v_));
+        chunk_capture_v_ = nullptr;
+    }
+    chunk_capture_ctx_ = 0;
+    if (cudaMalloc(&chunk_capture_k_, bytes) != cudaSuccess ||
+        cudaMalloc(&chunk_capture_v_, bytes) != cudaSuccess) {
+        IMP_LOG_WARN("chunk-capture scratch alloc failed (2x %.1f MiB) — captured verify disabled",
+                     bytes / (1024.0 * 1024.0));
+        if (chunk_capture_k_) {
+            IMP_CUDA_CHECK_LOG(cudaFree(chunk_capture_k_));
+            chunk_capture_k_ = nullptr;
+        }
+        return false;
+    }
+    chunk_capture_ctx_ = ctx_capacity;
+    IMP_LOG_INFO("chunk-capture K/V scratch: 2x %.1f MiB (ctx_capacity=%d, nkv=%d, hd=%d)",
+                 bytes / (1024.0 * 1024.0), ctx_capacity, nkv_u, hd_u);
+    return true;
 }
 
 // pre_dequant_weights() is in executor_pre_dequant.cu

--- a/src/exec/executor_workspace_config.cu
+++ b/src/exec/executor_workspace_config.cu
@@ -155,6 +155,7 @@ bool Workspace::resize_workspace(int new_max_tokens, cudaStream_t stream) {
         if (shared_workspace_) {
             IMP_CUDA_CHECK_LOG(cudaFreeAsync(shared_workspace_, stream));
         }
+        generation_++;  // arena moves — captured verify graphs must invalidate
         cudaError_t err = cudaMallocAsync(&shared_workspace_, new_shared, stream);
         if (err != cudaSuccess) {
             IMP_LOG_ERROR("Failed to resize shared workspace to %zu bytes: %s", new_shared,

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -156,6 +156,16 @@ struct InferenceState {
     // When true, use per-row Q8_1 GEMV for LM head instead of batched FP8 GEMM.
     // Avoids FP8 per-tensor quantization artifacts in batched verification.
     bool per_row_lm_head = false;
+
+    // Graph-captured verify chunk (#847). When ctx_capacity > 0 the chunked
+    // continuation attention path becomes replayable across context growth:
+    // gather grids and the KV scratch are sized for ctx_capacity, and the
+    // kernels read the REAL lengths from device (context_lens[0] for the
+    // total, d_past_len for the already-cached prefix) instead of baking
+    // max_context_len / prefill_offset. Requires n_sequences == 1 and an
+    // FA2-served attention config (GraphExecutor::chunk_capture_supported).
+    int ctx_capacity = 0;
+    const int* d_past_len = nullptr;  // device int == prefill_offset
 };
 
 }  // namespace imp

--- a/src/exec/workspace.h
+++ b/src/exec/workspace.h
@@ -4,6 +4,7 @@
 #include "core/qtype.h"
 #include <cuda_runtime.h>
 #include <cstddef>
+#include <cstdint>
 
 namespace imp {
 
@@ -72,6 +73,10 @@ public:
     int shared_max_tokens() const { return shared_workspace_max_tokens_; }
     int active() const { return active_workspace_; }
     bool has_decode_workspace() const { return decode_workspace_ != nullptr; }
+    // Bumped whenever shared_workspace_ is (re)allocated or freed — consumers
+    // holding raw pointers into the arena (captured verify graphs, #847) use
+    // this to detect that their baked addresses died.
+    uint64_t generation() const { return generation_; }
 
     // --- moved lifecycle methods ---
     [[nodiscard]] bool allocate_persistent_workspace(int max_tokens);
@@ -122,6 +127,7 @@ private:
     void* shared_workspace_ = nullptr;
     size_t shared_workspace_size_ = 0;
     int shared_workspace_max_tokens_ = 0;
+    uint64_t generation_ = 1;  // see generation()
 
     // Pre-computed phase sizes (for max_tokens_).
     size_t attn_shared_size_ = 0;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -270,6 +270,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("speculative.burst_rearm", cfg.speculative.burst_rearm);
     B("speculative.hybrid", cfg.speculative.hybrid);
     I("speculative.mtp_k", cfg.speculative.mtp_k);
+    B("speculative.capture", cfg.speculative.capture);
+    I("speculative.capture_ctx_cap", cfg.speculative.capture_ctx_cap);
 
     if (!matched)
         IMP_LOG_WARN("imp.conf: unknown key '%s' (value '%s') — ignoring", dotted_key.c_str(), val.c_str());

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -576,6 +576,23 @@ struct RuntimeConfig {
         // match (draft-poor prose — 78-94% depth-1 accept on Qwen3.6-35B-A3B,
         // PR #804). imp-cli equivalent: --mtp-spec-decode <k>.
         int mtp_k = 0;
+        // Graph-captured verify chunk (#847): cache one CUDA graph per
+        // draft-length bucket and replay it each verify step — the chunk
+        // metadata and KV lengths are read from device buffers, so the graph
+        // survives context growth. Removes the eager launch-pacing tax
+        // (~1800 launches/verify cycle). Drafts are padded up to the bucket
+        // length (extra rows are causally invisible to the real rows and
+        // their KV is rolled back with the rejected drafts). Engages only
+        // where the FP16-QK FA2 kernel serves the chunk (uniform hd=128, no
+        // sinks/MLA/LongRoPE) on non-hybrid models; anything else stays
+        // eager. Any capture failure falls back to the eager verify and
+        // disables capture for the process after repeated failures.
+        bool capture = true;
+        // Context capacity the captured gather grids and the persistent K/V
+        // scratch are sized for (2 x ctx_cap x nkv x hd x 2B VRAM, e.g. 2x
+        // 32 MiB at 32k for nkv=4/hd=128). Verify steps whose context
+        // exceeds this run eager. Clamped to the model's max_seq_len.
+        int capture_ctx_cap = 32768;
     } speculative;
 
     // Constrained decoding (json_mode / json_schema).

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -346,6 +346,10 @@ void Engine::invalidate_graphs() {
     // conditional runner.
     if (cpipe_.active)
         teardown_constrained_pipeline(/*synchronize=*/true);
+
+    // Captured verify-chunk graphs (#847) baked the forward as well (incl.
+    // any active LoRA kernels/pointers) — recapture costs two verify steps.
+    free_spec_graphs_();
 }
 
 int Engine::lora_load(const std::string& path) {

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -23,8 +23,10 @@
 #include "core/cuda_raii.h"
 #include <memory>
 #include <vector>
+#include <map>
 #include <unordered_map>
 #include <string>
+#include <cstdint>
 #include <cuda_runtime.h>
 
 #include "lora/lora_adapter.h"
@@ -587,6 +589,44 @@ private:
     // graph launch when possible, eagerly otherwise.
     void spec_capture_probe_forward_(InferenceState& state, Tensor& logits_out,
                                      cudaStream_t stream);
+    // ── Graph-captured verify chunk (#847), engine_spec_capture.cpp ──
+    // One cached cudaGraphExec_t per padded chunk length (bucket); replayed
+    // every verify step after per-step device-buffer refresh. The chunk
+    // forward reads all growing lengths from device (InferenceState
+    // ctx_capacity mode), so a graph stays valid across context growth.
+    struct SpecVerifyGraph {
+        cudaGraphExec_t exec = nullptr;
+        int eager_uses = 0;  // first use per slot runs eager (algo warmup)
+    };
+    // Keyed by (padded chunk length, ctx tier). The tier (power of two the
+    // context is rounded up to) sizes the gather grids — a graph baked for
+    // the full 32k capacity spends ~3x the gather time at short contexts, so
+    // graphs re-capture when the context outgrows their tier (rare,
+    // amortized over thousands of verify steps).
+    std::map<std::pair<int, int>, SpecVerifyGraph> spec_graphs_;
+    int spec_capture_ctx_tier_(int ctx_padded) const;
+    int* d_spec_past_len_ = nullptr;  // device int: p0 (cached-prefix length)
+    int spec_capture_ctx_cap_ = -1;   // resolved capacity; -1 = unresolved, 0 = disabled
+    uint64_t spec_capture_ws_gen_ = 0;
+    int spec_capture_failures_ = 0;
+    bool spec_capture_doomed_ = false;
+    // True when this verify step may use the captured path: config on, not
+    // doomed, non-hybrid, no MoE offload, executor-supported attention
+    // config, padded context within the resolved capacity. Resolves the
+    // capacity + allocates the executor scratch on first eligible use.
+    bool spec_capture_ready_(int ctx_padded);
+    // Round the real chunk length up to its capture bucket.
+    int spec_capture_bucket_(int chunk_len) const;
+    int spec_capture_bucket_max_() const;
+    // Launch the cached graph for state.n_tokens (or warm up / capture one).
+    // Returns true when the forward ran (graph replay or captured+launched);
+    // false → caller runs the eager forward itself (warmup use, capture
+    // failure, launch failure). Sets spec_capture_doomed_ after repeated
+    // failures — the caller must then clear the state's capture fields
+    // before its eager forward (a doom inside the forward means the capture
+    // path itself threw).
+    bool spec_captured_forward_(InferenceState& state, Tensor& logits_out, cudaStream_t stream);
+    void free_spec_graphs_();
     // Effective n-gram speculation state for a request: honors the per-request
     // tri-state override (Request::spec_ngram_override), else the global default.
     bool spec_ngram_enabled_(const Request& req) const {

--- a/src/runtime/engine_spec_capture.cpp
+++ b/src/runtime/engine_spec_capture.cpp
@@ -1,0 +1,275 @@
+// =============================================================================
+// engine_spec_capture.cpp — graph-captured verify chunk (#847)
+// =============================================================================
+//
+// The eager verify forward pays ~1800 kernel launches per cycle in host
+// launch pacing (~8 ms on Qwen3-Coder-30B after the #854 LM-head batching).
+// This module captures the chunk forward into one CUDA graph per padded
+// chunk length ("bucket") and replays it every verify step.
+//
+// Replay across context growth is the hard part: the chunked-continuation
+// attention path historically baked q_offset/ctx_len into gather grids,
+// scratch sizes and FA2 kernel arguments. In capture mode (InferenceState::
+// ctx_capacity > 0) those kernels read the REAL lengths from device instead
+// (context_lens[0] and d_past_len), grids and the persistent K/V scratch are
+// sized once for ctx_capacity, and everything that varies per step lives in
+// device buffers the engine refreshes via H2D before each replay
+// (d_spec_tokens_/positions_/block_table_/context_len_/past_len_).
+//
+// Bucketing: drafts are padded up to {9, 17, 33, k_max+1} tokens with copies
+// of t0. Padded rows sit at positions AFTER every real row, so causal masking
+// makes them invisible to the real rows; their KV entries are dropped by the
+// same rollback that drops rejected drafts. The verify consumes argmax rows
+// [0, real_chunk_len) only.
+//
+// Safety: the first use of a bucket runs eager through the SAME capture-mode
+// code path (cuBLASLt/CUTLASS algo warmup — census PR #855 showed only the
+// first chunk per shape fails capture); the second use captures. Any capture
+// or launch failure falls back to the eager forward, and repeated failures
+// doom capture for the process (the census crash class — e.g. a forward that
+// syncs on host — would otherwise retry forever). Graphs hold raw pointers
+// into the executor workspace and the engine's spec staging buffers; both
+// invalidate the graph cache when they move (workspace_generation, and
+// free_spec_buffers_ → free_spec_graphs_).
+// =============================================================================
+
+#include "compute/gemm.h"
+#include "core/logging.h"
+#include "exec/executor.h"
+#include "runtime/engine.h"
+
+#include <cuda_runtime.h>
+#include <algorithm>
+
+namespace imp {
+
+int Engine::spec_capture_bucket_max_() const {
+    const auto& scfg = runtime_config_.speculative;
+    int k_max = std::max(1, scfg.k);
+    if (scfg.suffix)
+        k_max = std::max(k_max, scfg.suffix_k_max);
+    if (mtp_spec_decode_enabled())
+        k_max = std::max(k_max, mtp_spec_decode_k());
+    return k_max + 1;
+}
+
+// Context tier: power of two >= ctx (floor 4096), clamped to the resolved
+// capacity. Sizes the baked gather grids close to the real context.
+int Engine::spec_capture_ctx_tier_(int ctx_padded) const {
+    int tier = 4096;
+    while (tier < ctx_padded)
+        tier <<= 1;
+    return std::min(tier, std::max(spec_capture_ctx_cap_, ctx_padded));
+}
+
+int Engine::spec_capture_bucket_(int chunk_len) const {
+    const int cap = std::max(chunk_len, spec_capture_bucket_max_());
+    for (int b : {9, 17, 33}) {
+        if (chunk_len <= b && b <= cap)
+            return b;
+    }
+    return cap;
+}
+
+bool Engine::spec_capture_ready_(int ctx_padded) {
+    const auto& scfg = runtime_config_.speculative;
+    if (!scfg.capture || spec_capture_doomed_)
+        return false;
+    // The census probe owns the forward when enabled (capture+destroy per
+    // chunk, diagnostics only).
+    if (runtime_config_.diagnostics.spec_capture_probe)
+        return false;
+    // Hybrids: census showed the recurrent chunk path consumes a D2H result
+    // under capture that never executed (misaligned-address context poison).
+    // MoE host-offload syncs on the host per layer.
+    if (ssm_state_ || gdn_state_ || offload_mgr_)
+        return false;
+    // BitDecoding residual KV advances ring state on the host per forward.
+    if (kv_manager_ && kv_manager_->residual_enabled())
+        return false;
+    if (!executor_)
+        return false;
+    if (spec_capture_ctx_cap_ < 0) {  // resolve once per engine
+        spec_capture_ctx_cap_ = 0;
+        if (executor_->chunk_capture_supported()) {
+            int cap = scfg.capture_ctx_cap;
+            if (config_.max_seq_len > 0)
+                cap = std::min(cap, config_.max_seq_len);
+            if (cap > 0 && executor_->ensure_chunk_capture_scratch(cap))
+                spec_capture_ctx_cap_ = cap;
+        }
+        IMP_LOG_INFO("[spec-capture] %s (ctx_cap=%d)",
+                     spec_capture_ctx_cap_ > 0 ? "enabled" : "not applicable for this model",
+                     spec_capture_ctx_cap_);
+    }
+    return spec_capture_ctx_cap_ > 0 && ctx_padded <= spec_capture_ctx_cap_;
+}
+
+void Engine::free_spec_graphs_() {
+    for (auto& [len, g] : spec_graphs_) {
+        if (g.exec)
+            IMP_CUDA_CHECK_LOG(cudaGraphExecDestroy(g.exec));
+    }
+    spec_graphs_.clear();
+}
+
+bool Engine::spec_captured_forward_(InferenceState& state, Tensor& logits_out,
+                                    cudaStream_t stream) {
+    // The graphs bake workspace pointers — invalidate when the arena moved.
+    const uint64_t ws_gen = executor_->workspace_generation();
+    if (ws_gen != spec_capture_ws_gen_) {
+        if (!spec_graphs_.empty()) {
+            IMP_LOG_INFO("[spec-capture] workspace reallocated — dropping %zu cached graphs",
+                         spec_graphs_.size());
+            free_spec_graphs_();
+        }
+        spec_capture_ws_gen_ = ws_gen;
+    }
+
+    auto& slot = spec_graphs_[{state.n_tokens, state.ctx_capacity}];
+    if (slot.exec) {
+        cudaError_t err = cudaGraphLaunch(slot.exec, stream);
+        if (err == cudaSuccess)
+            return true;
+        IMP_LOG_WARN("[spec-capture] graph launch failed (%s) — dropping graph cache",
+                     cudaGetErrorString(err));
+        cudaGetLastError();
+        free_spec_graphs_();
+        return false;  // caller runs the eager forward
+    }
+    if (slot.eager_uses++ == 0)
+        return false;  // warmup: caller runs eager through the capture-mode path
+
+    auto doom_check = [this](const char* why) {
+        if (++spec_capture_failures_ >= 2) {
+            spec_capture_doomed_ = true;
+            IMP_LOG_WARN("[spec-capture] disabled after repeated failures (%s)", why);
+        }
+    };
+
+    cudaError_t err = cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal);
+    if (err != cudaSuccess) {
+        IMP_LOG_WARN("[spec-capture] begin capture failed: %s", cudaGetErrorString(err));
+        cudaGetLastError();
+        doom_check("begin capture");
+        return false;
+    }
+    // Let cuBLASLt record into the capture instead of the ~5x-slower WMMA
+    // fallback (GGUF verify GEMMs) — every shape ran eagerly in the warmup
+    // use, so Lt's algo cache and static workspace are warm. See gemm.cu.
+    gemm_set_lt_capture_allowed(true);
+    bool forward_threw = false;
+    std::string what;
+    try {
+        executor_->forward_logits(state, logits_out, stream);
+    } catch (const std::exception& e) {
+        forward_threw = true;
+        what = e.what();
+    } catch (...) {
+        forward_threw = true;
+        what = "(non-std exception)";
+    }
+    gemm_set_lt_capture_allowed(false);
+    cudaGraph_t graph = nullptr;
+    err = cudaStreamEndCapture(stream, &graph);
+    if (forward_threw || err != cudaSuccess || graph == nullptr) {
+        IMP_LOG_WARN("[spec-capture] capture failed: %s%s%s",
+                     err != cudaSuccess ? cudaGetErrorString(err) : "(forward threw)",
+                     forward_threw ? " — " : "", forward_threw ? what.c_str() : "");
+        if (graph)
+            cudaGraphDestroy(graph);
+        cudaGetLastError();
+        doom_check("capture");
+        return false;
+    }
+    cudaGraphExec_t exec = nullptr;
+    err = cudaGraphInstantiate(&exec, graph, 0);
+    cudaGraphDestroy(graph);
+    if (err != cudaSuccess) {
+        IMP_LOG_WARN("[spec-capture] instantiate failed: %s", cudaGetErrorString(err));
+        cudaGetLastError();
+        doom_check("instantiate");
+        return false;
+    }
+    err = cudaGraphLaunch(exec, stream);
+    if (err != cudaSuccess) {
+        IMP_LOG_WARN("[spec-capture] first launch failed: %s", cudaGetErrorString(err));
+        cudaGetLastError();
+        cudaGraphExecDestroy(exec);
+        doom_check("first launch");
+        return false;
+    }
+    slot.exec = exec;
+    spec_capture_failures_ = 0;
+    IMP_LOG_INFO("[spec-capture] verify chunk graph cached (n_tokens=%d, ctx_tier=%d)",
+                 state.n_tokens, state.ctx_capacity);
+    return true;
+}
+
+// =============================================================================
+// #847 graph-captured-verify feasibility probe (diagnostics.spec_capture_probe)
+// =============================================================================
+// Stream-captures the chunk forward, instantiates and launches the graph once,
+// then destroys it. Any failure (capture-illegal call inside the forward,
+// instantiate error — the cuBLASLt status-14 class) falls back to the eager
+// forward, so the verify step always completes. Capture+instantiate every
+// chunk is NOT a perf path; this only answers "is the verify forward
+// capturable, and from which chunk on" per model class.
+void Engine::spec_capture_probe_forward_(InferenceState& state, Tensor& logits_out,
+                                         cudaStream_t stream) {
+    static long probes = 0, launched = 0;
+    probes++;
+    cudaError_t err = cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal);
+    if (err != cudaSuccess) {
+        IMP_LOG_WARN("[spec-capture-probe] begin capture failed: %s", cudaGetErrorString(err));
+        cudaGetLastError();
+        executor_->forward_logits(state, logits_out, stream);
+        return;
+    }
+    bool forward_threw = false;
+    const char* what = "";
+    try {
+        executor_->forward_logits(state, logits_out, stream);
+    } catch (const std::exception& e) {
+        forward_threw = true;
+        what = e.what();
+    } catch (...) {
+        forward_threw = true;
+        what = "(non-std exception)";
+    }
+    cudaGraph_t graph = nullptr;
+    err = cudaStreamEndCapture(stream, &graph);
+    bool ran = false;
+    if (!forward_threw && err == cudaSuccess && graph != nullptr) {
+        cudaGraphExec_t exec = nullptr;
+        err = cudaGraphInstantiate(&exec, graph, 0);
+        if (err == cudaSuccess) {
+            err = cudaGraphLaunch(exec, stream);
+            if (err == cudaSuccess) {
+                ran = true;
+                launched++;
+            } else {
+                IMP_LOG_WARN("[spec-capture-probe] graph launch failed: %s",
+                             cudaGetErrorString(err));
+            }
+            cudaGraphExecDestroy(exec);
+        } else {
+            IMP_LOG_WARN("[spec-capture-probe] instantiate failed: %s", cudaGetErrorString(err));
+        }
+    } else {
+        IMP_LOG_WARN("[spec-capture-probe] capture failed: %s%s%s",
+                     err != cudaSuccess ? cudaGetErrorString(err) : "(forward threw)",
+                     forward_threw ? " forward exception: " : "", forward_threw ? what : "");
+    }
+    if (graph != nullptr)
+        cudaGraphDestroy(graph);
+    cudaGetLastError();
+    IMP_LOG_INFO("[spec-capture-probe] chunk n_tokens=%d %s (launched %ld/%ld)", state.n_tokens,
+                 ran ? "CAPTURED+LAUNCHED" : "eager fallback", launched, probes);
+    if (!ran) {
+        // Nothing executed during a failed capture — run the forward for real.
+        executor_->forward_logits(state, logits_out, stream);
+    }
+}
+
+}  // namespace imp

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -56,6 +56,7 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
               cudaMalloc(&d_spec_positions_, chunk_cap * sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_block_table_, max_blocks * sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_context_len_, sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&d_spec_past_len_, sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
               cudaMallocHost(&h_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess;
     if (!ok) {
@@ -113,6 +114,8 @@ int Engine::recurrent_slot_for_(int req_id) const {
 }
 
 void Engine::free_spec_buffers_() {
+    // Captured verify graphs bake these buffer pointers — drop them first.
+    free_spec_graphs_();
     if (spec_state_scratch_) {
         IMP_CUDA_CHECK_LOG(cudaFree(spec_state_scratch_));
         spec_state_scratch_ = nullptr;
@@ -122,12 +125,14 @@ void Engine::free_spec_buffers_() {
     if (d_spec_positions_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_positions_));
     if (d_spec_block_table_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_));
     if (d_spec_context_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_context_len_));
+    if (d_spec_past_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_past_len_));
     if (d_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_argmax_));
     if (h_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_argmax_));
     d_spec_tokens_ = nullptr;
     d_spec_positions_ = nullptr;
     d_spec_block_table_ = nullptr;
     d_spec_context_len_ = nullptr;
+    d_spec_past_len_ = nullptr;
     d_spec_argmax_ = nullptr;
     h_spec_argmax_ = nullptr;
     spec_chunk_cap_ = 0;
@@ -331,7 +336,14 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         }
     }
     const int chunk_len = K + 1;
-    const int ctx_len = p0 + chunk_len;  // context including the full chunk
+    // Graph-captured verify (#847): pad the chunk up to its bucket length so
+    // one cached graph serves every draft length in the bucket. Pad rows
+    // (copies of t0 at positions after every real row) are causally invisible
+    // to the real rows; their KV entries fall to the same rollback that drops
+    // rejected drafts, and the argmax window below stays [0, chunk_len).
+    const bool capture_on = spec_capture_ready_(p0 + spec_capture_bucket_(chunk_len));
+    const int chunk_pad = capture_on ? spec_capture_bucket_(chunk_len) : chunk_len;
+    const int ctx_len = p0 + chunk_pad;  // context including the full (padded) chunk
 
     const int blocks_needed = (ctx_len + kv_bs - 1) / kv_bs;
 
@@ -355,19 +367,28 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
 
     // Staging capacity follows the REAL table size — the async graph loop
     // pre-allocates blocks for the whole remaining generation, so the table
-    // is usually much larger than this chunk needs.
-    if (!ensure_spec_buffers_(std::max(chunk_len, scfg.k + 1), n_blocks + 16)) {
+    // is usually much larger than this chunk needs. Captured graphs bake the
+    // staging pointers, so size for the largest bucket up front (a later
+    // realloc would silently invalidate every cached graph).
+    const int chunk_cap =
+        std::max({chunk_pad, scfg.k + 1, capture_on ? spec_capture_bucket_max_() : 0});
+    const int table_cap = capture_on
+                              ? std::max(n_blocks + 16,
+                                         (spec_capture_ctx_cap_ + kv_bs - 1) / kv_bs + 16)
+                              : n_blocks + 16;
+    if (!ensure_spec_buffers_(chunk_cap, table_cap)) {
         spec_stats_.miss_steps++;
         return false;
     }
 
     // Upload chunk metadata.
     std::vector<int32_t> h_tokens;
-    h_tokens.reserve(chunk_len);
+    h_tokens.reserve(chunk_pad);
     h_tokens.push_back(t0);
     h_tokens.insert(h_tokens.end(), draft.begin(), draft.begin() + K);
-    std::vector<int> h_positions(chunk_len);
-    for (int i = 0; i < chunk_len; ++i) h_positions[i] = p0 + i;
+    h_tokens.resize(chunk_pad, t0);  // bucket padding
+    std::vector<int> h_positions(chunk_pad);
+    for (int i = 0; i < chunk_pad; ++i) h_positions[i] = p0 + i;
 
     auto check = [&](cudaError_t err, const char* op) {
         if (err != cudaSuccess) {
@@ -376,18 +397,24 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         }
         return true;
     };
-    if (!check(cudaMemcpyAsync(d_spec_tokens_, h_tokens.data(), chunk_len * sizeof(int32_t),
+    if (!check(cudaMemcpyAsync(d_spec_tokens_, h_tokens.data(), chunk_pad * sizeof(int32_t),
                                cudaMemcpyHostToDevice, stream), "tokens H2D") ||
-        !check(cudaMemcpyAsync(d_spec_positions_, h_positions.data(), chunk_len * sizeof(int),
+        !check(cudaMemcpyAsync(d_spec_positions_, h_positions.data(), chunk_pad * sizeof(int),
                                cudaMemcpyHostToDevice, stream), "positions H2D") ||
         !check(cudaMemcpyAsync(d_spec_block_table_, block_table.data(), n_blocks * sizeof(int),
                                cudaMemcpyHostToDevice, stream), "block table H2D") ||
         !check(cudaMemcpyAsync(d_spec_context_len_, &ctx_len, sizeof(int), cudaMemcpyHostToDevice,
-                               stream), "context len H2D"))
+                               stream), "context len H2D") ||
+        (capture_on &&
+         !check(cudaMemcpyAsync(d_spec_past_len_, &p0, sizeof(int), cudaMemcpyHostToDevice,
+                                stream), "past len H2D")))
         return false;
 
     // Forward the chunk through the standard continuation-prefill path.
-    if (!executor_->resize_workspace(chunk_len, stream)) {
+    // Capture mode pins the workspace layout to the largest bucket so every
+    // bucket's graph bakes the same activation-tensor carve.
+    if (!executor_->resize_workspace(
+            capture_on ? std::max(chunk_pad, spec_capture_bucket_max_()) : chunk_len, stream)) {
         spec_stats_.miss_steps++;
         return false;
     }
@@ -396,7 +423,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     InferenceState state;
     state.token_ids = d_spec_tokens_;
     state.positions = d_spec_positions_;
-    state.n_tokens = chunk_len;
+    state.n_tokens = chunk_pad;
     state.kv_cache = kv_cache_raw_;
     state.block_tables = d_spec_block_table_;
     state.context_lens = d_spec_context_len_;
@@ -407,6 +434,12 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     state.prefill_offset = p0;
     state.kv_manager = kv_manager_.get();
     if (kv_manager_ && kv_manager_->residual_enabled()) state.kv_seq_id = req->id;
+    if (capture_on) {
+        // The tier (not the full capacity) sizes the baked gather grids; the
+        // executor scratch covers the full capacity, so any tier fits it.
+        state.ctx_capacity = spec_capture_ctx_tier_(ctx_len);
+        state.d_past_len = d_spec_past_len_;
+    }
 
     // Hybrid (SSM/GDN): bind the recurrent state and preserve the committed
     // slab — the chunk forward advances it through rejected draft positions.
@@ -432,6 +465,18 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     Tensor logits_out;
     if (runtime_config().diagnostics.spec_capture_probe) {
         spec_capture_probe_forward_(state, logits_out, stream);
+    } else if (capture_on) {
+        if (!spec_captured_forward_(state, logits_out, stream)) {
+            // Warmup use, or capture/launch failed (nothing executed) — run
+            // eagerly. A doomed capture means the capture-mode path itself
+            // threw; strip the capture fields so the eager forward takes the
+            // plain host-length chunk path (the padded chunk stays valid).
+            if (spec_capture_doomed_) {
+                state.ctx_capacity = 0;
+                state.d_past_len = nullptr;
+            }
+            executor_->forward_logits(state, logits_out, stream);
+        }
     } else {
         executor_->forward_logits(state, logits_out, stream);
     }
@@ -603,71 +648,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     return true;
 }
 
-
-// =============================================================================
-// #847 graph-captured-verify feasibility probe (diagnostics.spec_capture_probe)
-// =============================================================================
-// Stream-captures the chunk forward, instantiates and launches the graph once,
-// then destroys it. Any failure (capture-illegal call inside the forward,
-// instantiate error — the cuBLASLt status-14 class) falls back to the eager
-// forward, so the verify step always completes. Capture+instantiate every
-// chunk is NOT a perf path; this only answers "is the verify forward
-// capturable, and from which chunk on" per model class.
-void Engine::spec_capture_probe_forward_(InferenceState& state, Tensor& logits_out,
-                                         cudaStream_t stream) {
-    static long probes = 0, launched = 0;
-    probes++;
-    cudaError_t err = cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal);
-    if (err != cudaSuccess) {
-        IMP_LOG_WARN("[spec-capture-probe] begin capture failed: %s", cudaGetErrorString(err));
-        cudaGetLastError();
-        executor_->forward_logits(state, logits_out, stream);
-        return;
-    }
-    bool forward_threw = false;
-    const char* what = "";
-    try {
-        executor_->forward_logits(state, logits_out, stream);
-    } catch (const std::exception& e) {
-        forward_threw = true;
-        what = e.what();
-    } catch (...) {
-        forward_threw = true;
-        what = "(non-std exception)";
-    }
-    cudaGraph_t graph = nullptr;
-    err = cudaStreamEndCapture(stream, &graph);
-    bool ran = false;
-    if (!forward_threw && err == cudaSuccess && graph != nullptr) {
-        cudaGraphExec_t exec = nullptr;
-        err = cudaGraphInstantiate(&exec, graph, 0);
-        if (err == cudaSuccess) {
-            err = cudaGraphLaunch(exec, stream);
-            if (err == cudaSuccess) {
-                ran = true;
-                launched++;
-            } else {
-                IMP_LOG_WARN("[spec-capture-probe] graph launch failed: %s",
-                             cudaGetErrorString(err));
-            }
-            cudaGraphExecDestroy(exec);
-        } else {
-            IMP_LOG_WARN("[spec-capture-probe] instantiate failed: %s", cudaGetErrorString(err));
-        }
-    } else {
-        IMP_LOG_WARN("[spec-capture-probe] capture failed: %s%s%s",
-                     err != cudaSuccess ? cudaGetErrorString(err) : "(forward threw)",
-                     forward_threw ? " forward exception: " : "", forward_threw ? what : "");
-    }
-    if (graph != nullptr)
-        cudaGraphDestroy(graph);
-    cudaGetLastError();
-    IMP_LOG_INFO("[spec-capture-probe] chunk n_tokens=%d %s (launched %ld/%ld)", state.n_tokens,
-                 ran ? "CAPTURED+LAUNCHED" : "eager fallback", launched, probes);
-    if (!ran) {
-        // Nothing executed during a failed capture — run the forward for real.
-        executor_->forward_logits(state, logits_out, stream);
-    }
-}
+// spec_capture_probe_forward_ (diagnostics census) and the production
+// graph-captured verify (#847) live in engine_spec_capture.cpp.
 
 }  // namespace imp

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -62,6 +62,15 @@ int main(int argc, char** argv) {
                 hybrid_set = true;
         if (!hybrid_set)
             runtime_cfg.speculative.hybrid = false;
+        // Graph-captured verify (#847) changes verify-step timing (and pads
+        // chunks) — keep the canonical baseline on the eager verify path.
+        // An explicit --set speculative.capture=… still wins.
+        bool capture_set = false;
+        for (const auto& ov : args.config_overrides)
+            if (ov.rfind("speculative.capture", 0) == 0)
+                capture_set = true;
+        if (!capture_set)
+            runtime_cfg.speculative.capture = false;
     }
     // Cache the few diagnostic / runtime-mode flags that are read from free
     // functions (kernel diagnostics, CUDA-graph capture mode, PDL gate)


### PR DESCRIPTION
## What

Closes the top remaining lever from #847: the eager verify forward paid ~1800 kernel launches per cycle in host launch pacing (~8 ms/cycle on Qwen3-Coder-30B after #854's LM-head batching). This PR caches one CUDA graph per **(padded chunk length, ctx tier)** and replays it every verify step.

## How replay survives context growth

The census (PR #855) proved capturability but not replayability: the chunked-continuation attention path baked `q_offset`/`ctx_len` into gather grids, per-layer `cudaMallocAsync` sizes, the chunk-append memcpy offset and the FA2 `seq_kv`/`q_offset` kernel args. New capture mode (`InferenceState::ctx_capacity` + `d_past_len`):

- `paged_kv_gather_*` take an optional device bound (`d_n_past`); the host value only sizes the (tier-capacity) grid.
- `fmha_sm120_fa2_prefill` takes an optional `d_kv_len`; the kernel reads the real `seq_kv` from device and derives `q_offset = seq_kv - seq_q`. Grid dims already depend only on `seq_q`.
- The per-layer K/V rematerialization scratch is persistent (`ensure_chunk_capture_scratch`), the chunk append runs through a device-offset kernel instead of a host-offset memcpy.
- All per-step metadata (tokens/positions/block table/context len/past len) lives in device buffers refreshed via H2D before each replay.

Drafts are padded up to the bucket length ({9,17,33,k_max+1}); pad rows sit at positions after every real row (causally invisible) and their KV entries fall to the existing rollback. The argmax window stays the real chunk length.

## Safety

- First use per slot runs eager (cuBLASLt/CUTLASS algo warmup), capture on second use; any capture/launch failure falls back to the eager verify, repeated failures disable capture for the process.
- Graphs invalidate on workspace reallocation (new `Workspace::generation()`), spec-buffer reallocation and `invalidate_graphs()` (LoRA swap / context reset).
- Hybrids (GDN/SSM — census crash class), MoE host-offload, residual KV, MLA, LongRoPE, learned sinks and non-hd128 attention stay on the eager verify.
- cuBLASLt is allowed to record into the verify capture (`gemm_set_lt_capture_allowed`): the status-14 class only reproduced on cold shapes, and the WMMA capture fallback measured ~5x slower on the GGUF verify GEMMs (167 ms/1400 tok on Q8-8B). A residual failure dooms capture cleanly.
- `speculative.capture` default ON, `capture_ctx_cap` 32768 (clamped to max_seq_len); contexts beyond it run eager. imp-cli `--bench` pins capture off — `tests/perf_baseline.json` semantics unchanged, no baseline refresh needed.

## Measured (RTX 5090, warm-server echo, median of reqs 3–10, accept rates identical on/off)

| model | eager verify | captured | delta |
|---|---|---|---|
| Qwen3-Coder-30B-A3B-FP4 (MoE) | 1700 tok/s | 2812 tok/s | **+65%** |
| Qwen3-8B-Q8_0 (GGUF) | 1304 tok/s | 1396 tok/s | +7% |

Verify cycle on the Coder echo: ~30.5 ms → ~18.4 ms.

Correctness: capture on == off **byte-identical** (Qwen3-4B Q8 with fp16 AND fp8 KV; Qwen3-8B-cortecs dense NVFP4, 8/8 requests); Q8 perplexity bit-exact vs the current main image (mean_nll 2.6062); `make test-gpu` green (incl. DegenerationTest); Nemotron hybrid coherent on the eager path; `verify-fast` OK (decode WARN = depressed-host signature per #526, 324–356 W during bench).

One non-reproduced anomaly for the record: the very first cortecs server run with capture produced incoherent output; 18+ subsequent requests across identical and stress configs (8× on/off request-parity) never reproduced it, and the later fixes changed the captured kernel mix. Watching for it; capture failures degrade to eager by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBxj5AM7sGzgkhn957KoHH