### PR TITLE
perf(eval): batched dp4a LM head — one weight pass per activation batch instead of per row (#847)

### DIFF
--- a/src/compute/gemm.h
+++ b/src/compute/gemm.h
@@ -311,4 +311,12 @@ void gemv_q2_k_q8_1_fp32(const void* W, const block_q8_1* q8_1, const float* d8,
 void gemv_q3_k_q8_1_fp32(const void* W, const block_q8_1* q8_1, const float* d8, float* y, int M, int K,
                          cudaStream_t stream = nullptr);
 
+// Batched-activation variant for the spec-verify LM head (#847 lever 2):
+// n_act pre-quantized activation rows (row r at q8_1/d8 + r*act_stride_blocks)
+// share one pass over W; logits land at y + r*M. Falls back to the per-row
+// GEMV when a quant type has no dp4a traits or the rows don't fit smem.
+void gemv_dp4a_fp32_batched(QType qtype, const void* W, const block_q8_1* q8_1, const float* d8,
+                            float* y, int M, int K, int n_act, int act_stride_blocks,
+                            cudaStream_t stream = nullptr);
+
 }  // namespace imp

--- a/src/compute/gemm_dp4a.cu
+++ b/src/compute/gemm_dp4a.cu
@@ -365,6 +365,42 @@ void gemv_q3_k_q8_1_fp32(const void* W, const block_q8_1* q8_1, const float* d8,
     launch_gemv_dp4a_fp32<Q3_K_Traits>(static_cast<const uint8_t*>(W), q8_1, d8, y, M, K, stream);
 }
 
+void gemv_dp4a_fp32_batched(QType qtype, const void* W, const block_q8_1* q8_1, const float* d8,
+                            float* y, int M, int K, int n_act, int act_stride_blocks,
+                            cudaStream_t stream) {
+    const uint8_t* w = static_cast<const uint8_t*>(W);
+    switch (qtype) {
+        case QType::Q6_K:
+            launch_gemv_dp4a_fp32_batched<Q6_K_Traits>(w, q8_1, d8, y, M, K, n_act, act_stride_blocks,
+                                                       stream);
+            break;
+        case QType::Q4_0:
+            launch_gemv_dp4a_fp32_batched<Q4_0_Traits>(w, q8_1, d8, y, M, K, n_act, act_stride_blocks,
+                                                       stream);
+            break;
+        case QType::Q4_K:
+            launch_gemv_dp4a_fp32_batched<Q4_K_Traits>(w, q8_1, d8, y, M, K, n_act, act_stride_blocks,
+                                                       stream);
+            break;
+        case QType::Q5_K:
+            launch_gemv_dp4a_fp32_batched<Q5_K_Traits>(w, q8_1, d8, y, M, K, n_act, act_stride_blocks,
+                                                       stream);
+            break;
+        case QType::Q2_K:
+            launch_gemv_dp4a_fp32_batched<Q2_K_Traits>(w, q8_1, d8, y, M, K, n_act, act_stride_blocks,
+                                                       stream);
+            break;
+        case QType::Q3_K:
+            launch_gemv_dp4a_fp32_batched<Q3_K_Traits>(w, q8_1, d8, y, M, K, n_act, act_stride_blocks,
+                                                       stream);
+            break;
+        default:
+            launch_gemv_dp4a_fp32_batched<Q8_0_Traits>(w, q8_1, d8, y, M, K, n_act, act_stride_blocks,
+                                                       stream);
+            break;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // QKV fused wrappers (7 functions, one per quant type)
 // ---------------------------------------------------------------------------

--- a/src/compute/gemv_dp4a_traits.cuh
+++ b/src/compute/gemv_dp4a_traits.cuh
@@ -1059,6 +1059,142 @@ static void launch_gemv_dp4a_fp32(const uint8_t* W, const block_q8_1* q8_1, cons
 }
 
 // ============================================================================
+// Template kernel #2b: FP32 output, batched activations (spec-verify LM head,
+// #847 lever 2). MR activation rows share ONE pass over W — the per-row loop
+// re-read the full vocab x d_model LM head once per chunk row (0.44 ms/row on
+// Qwen3-8B Q8_0, the dominant term of the GGUF verify cycle after #856).
+// Each warp owns one weight row (the LM-head N is the vocab — the grid never
+// underfills, so the N_ROWS/kpar heuristics of kernel #2 don't apply) and
+// accumulates MR dot products against activation rows staged in smem.
+// All current DequantTraits have kNeedsQ8Sum == false; static-assert guards
+// the smem layout if that ever changes.
+// ============================================================================
+
+template <typename QT, int MR>
+__global__ void gemv_dp4a_fp32_batched_kernel(const uint8_t* __restrict__ W,
+                                              const block_q8_1* __restrict__ q8_1,
+                                              const float* __restrict__ d8, float* __restrict__ y,
+                                              int M, int K, int n_act, int act_stride_blocks) {
+    static_assert(!QT::kNeedsQ8Sum, "batched fp32 GEMV smem layout has no q8 sum plane");
+    const int warps_per_block = blockDim.x / 32;
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int row = blockIdx.x * warps_per_block + warp_id;  // weight row
+
+    const int total_q8 = (K / QT::kBlockElems) * QT::kQ8PerWeight;
+    const size_t row_bytes = (size_t)(K / QT::kBlockElems) * QT::kBlockBytes;
+
+    extern __shared__ char smem_q8[];
+    const int qs_ints_per_row = total_q8 * kSmemQ8Stride;
+    int* smem_qs = reinterpret_cast<int*>(smem_q8);
+    float* smem_d = reinterpret_cast<float*>(smem_qs + (size_t)qs_ints_per_row * MR);
+
+    for (int r = 0; r < MR && r < n_act; ++r) {
+        const block_q8_1* q8r = q8_1 + (size_t)r * act_stride_blocks;
+        for (int i = threadIdx.x; i < total_q8 * 8; i += blockDim.x) {
+            int blk = i >> 3, w = i & 7;
+            int val;
+            memcpy(&val, q8r[blk].qs + w * 4, 4);
+            smem_qs[r * qs_ints_per_row + blk * kSmemQ8Stride + w] = val;
+        }
+        for (int i = threadIdx.x; i < total_q8; i += blockDim.x)
+            smem_d[r * total_q8 + i] = d8[(size_t)r * act_stride_blocks + i];
+    }
+    __syncthreads();
+
+    if (row >= M)
+        return;
+
+    float sum[MR];
+#pragma unroll
+    for (int r = 0; r < MR; r++)
+        sum[r] = 0.0f;
+
+    for (int b = lane; b < total_q8; b += 32) {
+        const int wb = b / QT::kQ8PerWeight;
+        const int sub = b % QT::kQ8PerWeight;
+        const uint8_t* bp = W + (size_t)row * row_bytes + (size_t)wb * QT::kBlockBytes;
+#pragma unroll
+        for (int r = 0; r < MR; r++) {
+            if (r >= n_act)
+                break;
+            int xi[8];
+            memcpy(xi, smem_qs + r * qs_ints_per_row + b * kSmemQ8Stride, 32);
+            sum[r] += QT::dp4a_block(bp, sub, xi, smem_d[r * total_q8 + b], 0.0f);
+        }
+    }
+
+#pragma unroll
+    for (int r = 0; r < MR; r++) {
+        for (int off = 16; off > 0; off >>= 1)
+            sum[r] += __shfl_down_sync(0xFFFFFFFF, sum[r], off);
+        if (lane == 0 && r < n_act)
+            y[(size_t)r * M + row] = sum[r];
+    }
+}
+
+// Launch helper: picks the largest MR in {8,4,2} whose activation staging fits
+// the smem opt-in budget, and loops over the activation rows in MR chunks.
+// n_act == 1 should route through launch_gemv_dp4a_fp32 instead (kpar/NR
+// heuristics); this launcher still handles it correctly as a tail case.
+template <typename QT>
+static void launch_gemv_dp4a_fp32_batched(const uint8_t* W, const block_q8_1* q8_1, const float* d8,
+                                          float* y, int M, int K, int n_act, int act_stride_blocks,
+                                          cudaStream_t stream) {
+    const int threads_per_block = 256;
+    const int warps_per_block = threads_per_block / 32;
+    const int blocks = (M + warps_per_block - 1) / warps_per_block;
+    const int total_q8 = (K / QT::kBlockElems) * QT::kQ8PerWeight;
+    const size_t per_row = (size_t)total_q8 * (kSmemQ8Stride * 4 + 4);
+
+    static int s_max_smem = 0;
+    if (s_max_smem == 0) {
+        int dev = 0;
+        cudaGetDevice(&dev);
+        cudaDeviceGetAttribute(&s_max_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, dev);
+        if (s_max_smem <= 0)
+            s_max_smem = 48 * 1024;
+    }
+    if (per_row * 2 > (size_t)s_max_smem) {
+        // K too large to stage even two activation rows — per-row fallback.
+        for (int r = 0; r < n_act; ++r)
+            launch_gemv_dp4a_fp32<QT>(W, q8_1 + (size_t)r * act_stride_blocks,
+                                      d8 + (size_t)r * act_stride_blocks, y + (size_t)r * M, M, K,
+                                      stream);
+        return;
+    }
+
+    auto run = [&](auto mr_tag, int r0, int rn) {
+        constexpr int MR = decltype(mr_tag)::value;
+        const size_t smem = per_row * MR;
+        if (smem > 48 * 1024)
+            cudaFuncSetAttribute(gemv_dp4a_fp32_batched_kernel<QT, MR>,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, (int)smem);
+        pdl::launch(gemv_dp4a_fp32_batched_kernel<QT, MR>, dim3(blocks), dim3(threads_per_block), smem,
+                    stream, W, q8_1 + (size_t)r0 * act_stride_blocks, d8 + (size_t)r0 * act_stride_blocks,
+                    y + (size_t)r0 * M, M, K, rn, act_stride_blocks);
+    };
+
+    int r0 = 0;
+    while (r0 < n_act) {
+        const int rem = n_act - r0;
+        if (rem >= 5 && per_row * 8 <= (size_t)s_max_smem) {
+            run(std::integral_constant<int, 8>{}, r0, rem < 8 ? rem : 8);
+            r0 += rem < 8 ? rem : 8;
+        } else if (rem >= 3 && per_row * 4 <= (size_t)s_max_smem) {
+            run(std::integral_constant<int, 4>{}, r0, rem < 4 ? rem : 4);
+            r0 += rem < 4 ? rem : 4;
+        } else if (rem >= 2 && per_row * 2 <= (size_t)s_max_smem) {
+            run(std::integral_constant<int, 2>{}, r0, 2);
+            r0 += 2;
+        } else {
+            run(std::integral_constant<int, 2>{}, r0, 1);  // tail row (MR=2 template, n_act=1)
+            r0 += 1;
+        }
+    }
+}
+
+// ============================================================================
 // Template kernel #3: QKV Fused (replaces 5 hand-written kernels)
 // ============================================================================
 

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -20,6 +20,7 @@
 
 #include "exec/executor.h"
 #include "exec/executor_gemv_helpers.h"
+#include "compute/gemm.h"
 #include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
 #include "compute/layernorm.h"
@@ -27,6 +28,7 @@
 #include "core/tensor.h"
 #include "quant/nvfp4_gemm.h"
 #include "quant/nvfp4_quant.h"
+#include <algorithm>
 
 #include <cuda_runtime.h>
 #include <cfloat>
@@ -193,18 +195,40 @@ void GraphExecutor::for_each_lm_head_batch_(int n_rows, cudaStream_t stream,
                                          static_cast<float*>(lg.data), cfg.vocab_size, cfg.d_model,
                                          csz, stream);
         } else if (use_dp4a_lm) {
-            // Per-row: fused RMSNorm→Q8_1 quantize + dp4a GEMV (the q8_1
-            // scratch holds exactly one row — same as production decode).
+            // Fused RMSNorm→Q8_1 quantize per row, then ONE batched dp4a GEMV
+            // whose weight pass is shared across the rows (#847 lever 2). The
+            // per-row loop re-read the full LM head once per chunk row
+            // (0.44 ms/row on Qwen3-8B Q8_0 — the dominant GGUF verify term
+            // after #856). Falls back to per-row when the multi-row scratch
+            // is unavailable (q8_1_rows == 1) or the batch is a single row.
             auto* q8 = static_cast<block_q8_1*>(qscratch_.q8_1_buf);
-            for (int r = 0; r < csz; ++r) {
-                Tensor h_row = hc.slice(r, r + 1);
-                Tensor lg_row = lg.slice(r, r + 1);
-                rmsnorm_quantize_q8_1(static_cast<const half*>(h_row.data),
-                                      static_cast<const half*>(model_->output_norm().data), q8,
-                                      qscratch_.d8_buf, nullptr, cfg.d_model, cfg.rms_norm_eps, stream,
-                                      norm_w_off_);
-                dispatch_gemv_fp32(out_qtype, model_->output_proj().data, q8, qscratch_.d8_buf,
-                                   static_cast<float*>(lg_row.data), cfg.vocab_size, cfg.d_model, stream);
+            const int stride = qscratch_.q8_1_max_blocks;
+            if (csz > 1 && qscratch_.q8_1_rows >= 2) {
+                for (int r0 = 0; r0 < csz; r0 += qscratch_.q8_1_rows) {
+                    const int rn = std::min(qscratch_.q8_1_rows, csz - r0);
+                    for (int r = 0; r < rn; ++r) {
+                        Tensor h_row = hc.slice(r0 + r, r0 + r + 1);
+                        rmsnorm_quantize_q8_1(static_cast<const half*>(h_row.data),
+                                              static_cast<const half*>(model_->output_norm().data),
+                                              q8 + (size_t)r * stride, qscratch_.d8_buf + (size_t)r * stride,
+                                              nullptr, cfg.d_model, cfg.rms_norm_eps, stream, norm_w_off_);
+                    }
+                    gemv_dp4a_fp32_batched(out_qtype, model_->output_proj().data, q8, qscratch_.d8_buf,
+                                           static_cast<float*>(lg.data) + (size_t)r0 * cfg.vocab_size,
+                                           cfg.vocab_size, cfg.d_model, rn, stride, stream);
+                }
+            } else {
+                for (int r = 0; r < csz; ++r) {
+                    Tensor h_row = hc.slice(r, r + 1);
+                    Tensor lg_row = lg.slice(r, r + 1);
+                    rmsnorm_quantize_q8_1(static_cast<const half*>(h_row.data),
+                                          static_cast<const half*>(model_->output_norm().data), q8,
+                                          qscratch_.d8_buf, nullptr, cfg.d_model, cfg.rms_norm_eps, stream,
+                                          norm_w_off_);
+                    dispatch_gemv_fp32(out_qtype, model_->output_proj().data, q8, qscratch_.d8_buf,
+                                       static_cast<float*>(lg_row.data), cfg.vocab_size, cfg.d_model,
+                                       stream);
+                }
             }
         } else {
             Tensor noc = view_tokens(norm_out_, csz);      // [csz, d]

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -183,8 +183,14 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         int max_blocks = std::max(max_k / 32, max_moe_down_blocks);
         if (max_blocks > 0) {
             qscratch_.q8_1_max_blocks = max_blocks;
-            size_t q8_1_sz = static_cast<size_t>(qscratch_.q8_1_max_blocks) * sizeof(block_q8_1);
-            size_t d8_sz = static_cast<size_t>(qscratch_.q8_1_max_blocks) * sizeof(float);
+            // Rows: the batched verify LM head quantizes one chunk batch
+            // (max_logit_tokens_, floor 8) at a time; cap the multiplier so
+            // large-batch servers don't inflate this K-sized scratch.
+            qscratch_.q8_1_rows = std::min(std::max(max_logit_tokens_, 8), 16);
+            size_t q8_1_sz = static_cast<size_t>(qscratch_.q8_1_max_blocks) * qscratch_.q8_1_rows *
+                             sizeof(block_q8_1);
+            size_t d8_sz = static_cast<size_t>(qscratch_.q8_1_max_blocks) * qscratch_.q8_1_rows *
+                           sizeof(float);
             cudaError_t err1 = cudaMalloc(&qscratch_.q8_1_buf, q8_1_sz);
             cudaError_t err2 = cudaMalloc(reinterpret_cast<void**>(&qscratch_.d8_buf), d8_sz);
             if (err1 != cudaSuccess || err2 != cudaSuccess) {

--- a/src/exec/quant_scratch.h
+++ b/src/exec/quant_scratch.h
@@ -43,9 +43,13 @@ struct QuantScratch {
     size_t mxfp4_workspace_size = 0;
 
     // --- dp4a (MMVQ) scratch for quantized input vector (M=1 decode) ---
+    // Sized q8_1_rows x q8_1_max_blocks: production decode uses row 0 only;
+    // the spec-verify batched LM head (#847 lever 2) quantizes up to
+    // q8_1_rows chunk rows at stride q8_1_max_blocks.
     void* q8_1_buf = nullptr;  // block_q8_1 array
     float* d8_buf = nullptr;   // float scale array
-    int q8_1_max_blocks = 0;   // max K/32
+    int q8_1_max_blocks = 0;   // max K/32 (per-row stride)
+    int q8_1_rows = 1;
 
     // --- dp4a prefill scratch for M>1 dense GEMM (Q4_K/Q5_K) ---
     // Sized for max_tokens * max_k/32 blocks. Eliminates the FP16 weight


### PR DESCRIPTION
## What

#847 lever 2, honestly re-scoped: the eval/verify LM-head driver's **dp4a arm** re-read the full vocab × d_model weight once per chunk row. That arm serves GGUF-quant lm_heads **without** an NVFP4 decode-cache entry — tied-embedding Gemma GGUF, `--no-nvfp4` runs, and decode-cache-off diagnostics (the #845 probe configuration the 0.44 ms/row slope was measured in). Models whose lm_head lives in the NVFP4 decode cache (Qwen Q8_0/Q6_K defaults) already batch since #854 and are unaffected.

## How

- New `gemv_dp4a_fp32_batched_kernel<QT, MR>` (one templated kernel covering all `DequantTraits`): up to 8 pre-quantized activation rows staged in smem share one pass over W; each warp owns one weight row (LM-head N = vocab, the grid never underfills) and accumulates MR dot products. MR ∈ {8,4,2} picked by the smem opt-in budget, per-row fallback for oversized K.
- The q8_1 MMVQ scratch grows to `min(max_logit_tokens_, 16)` rows (production decode keeps using row 0); the dp4a arm in `for_each_lm_head_batch_` quantizes each batch's rows into it and issues one batched GEMV.

## Measured

- **gemma-3-12b-Q4_K_M teacher-forced perplexity phase: 9 s → 2 s (~4.5×)** on 4927 positions (262k vocab), PPL unchanged (0.3783, 4-decimal-identical to main).
- Small-corpus (297 tok) mean_nll differs from main by 0.008% (2.4429 vs 2.4431) — the old path summed through the kpar kernel, the batched kernel uses the NR-kernel order; deterministic, declared.
- Q8-8B PPL anchor bit-exact (mean_nll 2.6062, top1 165/290 — NVFP4-lm arm untouched); verify byte-identity vs the #856 references holds; `make test-gpu` green; `verify-fast` OK (decode WARN = depressed-host signature per #526).

No perf-baseline impact (canonical bench models use the NVFP4 lm_head arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBxj5AM7sGzgkhn957KoHH