### PR TITLE
fix(nvfp4): capture-refusal in the M>1 dequant fallback fails loud + capped workspace pre-alloc (#847)

### DIFF
--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -936,11 +936,20 @@ bool GraphExecutor::allocate_nvfp4_dequant_workspace() {
     // bytes). MoE caches contribute per-expert weights (callers slice one
     // expert at a time into a synthetic NvFP4QuantResult before invoking
     // gemm_nvfp4 — see executor_forward_moe.cu).
-    size_t max_bytes = 0;
-    auto consider = [&max_bytes](int64_t N, int64_t K) {
+    // Weights above kCap don't get a workspace (an NVFP4 LM head would be
+    // ~1.5 GiB) — track the covered maximum separately so ONE oversized
+    // tensor no longer disables the workspace for every other weight (the
+    // all-or-nothing skip left Nemotron with no workspace at all, which is
+    // what made its verify-chunk capture fail: #855 census crash class).
+    constexpr size_t kCap = 512ULL * 1024 * 1024;  // 512 MiB
+    size_t max_bytes = 0;         // largest dequant target overall
+    size_t covered_bytes = 0;     // largest target we will actually cover
+    auto consider = [&](int64_t N, int64_t K) {
         size_t bytes = static_cast<size_t>(N) * static_cast<size_t>(K) * sizeof(half);
         if (bytes > max_bytes)
             max_bytes = bytes;
+        if (bytes <= kCap && bytes > covered_bytes)
+            covered_bytes = bytes;
     };
     for (const auto& [ptr, qr] : wcache_.nvfp4)
         consider(qr.N, qr.K);
@@ -995,38 +1004,39 @@ bool GraphExecutor::allocate_nvfp4_dequant_workspace() {
         return true;
     }
 
-    // Sanity cap: skip workspace alloc for huge weights (e.g. NVFP4 LM head
-    // would be ~1.5 GiB for Qwen3.6-class models). The fallback continues
-    // to use lazy cudaMalloc on non-captured streams; graph capture will
-    // fail-loud via the cudaStreamIsCapturing guard.
-    constexpr size_t kCap = 512ULL * 1024 * 1024;  // 512 MiB
+    // Weights beyond the workspace stay on the lazy-cudaMalloc fallback on
+    // non-captured streams; hitting one of them under capture now throws
+    // (gemm_nvfp4) and the capture fails cleanly.
     if (max_bytes > kCap) {
         IMP_LOG_WARN(
-            "gemm_nvfp4 dequant workspace: largest NVFP4 weight is %.2f MiB > %.0f MiB cap, "
-            "skipping pre-alloc — prefill graph capture disabled (M>1 fallback runs eager).",
-            max_bytes / (1024.0 * 1024.0), kCap / (1024.0 * 1024.0));
+            "gemm_nvfp4 dequant workspace: largest NVFP4 weight is %.2f MiB > %.0f MiB cap "
+            "(covered: %.2f MiB) — prefill graph capture disabled (a captured M>1 fallback "
+            "on the oversized weight fails loud).",
+            max_bytes / (1024.0 * 1024.0), kCap / (1024.0 * 1024.0),
+            covered_bytes / (1024.0 * 1024.0));
         nvfp4_dequant_uncapturable_ = true;  // scheduler will skip prefill-graph capture
-        return false;
     }
+    if (covered_bytes == 0)
+        return !nvfp4_dequant_uncapturable_;
 
-    nvfp4_dequant_ws_buf_ = vram_alloc(vram_alloc_, max_bytes, "nvfp4_dequant");
+    nvfp4_dequant_ws_buf_ = vram_alloc(vram_alloc_, covered_bytes, "nvfp4_dequant");
     if (!nvfp4_dequant_ws_buf_) {
         IMP_LOG_WARN("gemm_nvfp4 dequant workspace: alloc failed (%zu bytes) — prefill graph "
                      "capture disabled (M>1 fallback runs eager).",
-                     max_bytes);
+                     covered_bytes);
         nvfp4_dequant_ws_size_ = 0;
         nvfp4_dequant_uncapturable_ = true;
         return false;
     }
-    nvfp4_dequant_ws_size_ = max_bytes;
+    nvfp4_dequant_ws_size_ = covered_bytes;
     set_nvfp4_dequant_workspace(nvfp4_dequant_ws_buf_, nvfp4_dequant_ws_size_);
     IMP_LOG_INFO(
         "gemm_nvfp4 dequant workspace: %.2f MiB (graph-safe M>1 fallback; "
         "covers dense=%zu, moe=%zu, cutlass=%zu cache entries + per-layer "
         "SafeTensors NVFP4 expert tensors)",
-        max_bytes / (1024.0 * 1024.0), wcache_.nvfp4.size(), wcache_.nvfp4_moe.size(),
+        covered_bytes / (1024.0 * 1024.0), wcache_.nvfp4.size(), wcache_.nvfp4_moe.size(),
         wcache_.cutlass_nvfp4.size());
-    return true;
+    return !nvfp4_dequant_uncapturable_;
 }
 
 void GraphExecutor::release_moe_batch_buf() {

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cassert>
 #include <mutex>
+#include <stdexcept>
 
 namespace imp {
 
@@ -205,8 +206,17 @@ void gemm_nvfp4(const NvFP4QuantResult& A, const Tensor& B, Tensor& C, cudaStrea
 
     size_t A_fp16_bytes = (size_t)(N * K) * sizeof(half);
     void* dequant_buf = ensure_dequant_buffer(A_fp16_bytes, stream);
-    if (!dequant_buf)
-        return;
+    if (!dequant_buf) {
+        // A silent return here corrupts whatever runs next: the output tensor
+        // keeps garbage, and under stream capture the recorded graph simply
+        // LACKS this GEMM — the #855 census "hybrid crash" was this exact
+        // hole (Nemotron: pre-alloc skipped for a >cap weight, fallback
+        // refused mid-capture, graph launched with an uninitialized
+        // activation buffer -> misaligned address). Throw instead; the
+        // verify capturer fails the capture cleanly and falls back eager.
+        throw std::runtime_error("gemm_nvfp4: no dequant workspace for M>1 fallback (capture-active "
+                                 "or allocation failure) — cannot run this GEMM");
+    }
 
     dequantize_nvfp4_to_fp16(A, dequant_buf, stream);
 

--- a/tests/test_nvfp4_gemm_graph_capture.cu
+++ b/tests/test_nvfp4_gemm_graph_capture.cu
@@ -24,6 +24,7 @@
 
 #include <gtest/gtest.h>
 #include <cuda_runtime.h>
+#include <stdexcept>
 #include <cuda_fp16.h>
 #include <vector>
 
@@ -146,8 +147,11 @@ TEST_F(NvFP4GemmGraphCapture, FallbackInsideCaptureWithoutWorkspaceFailsLoud) {
     int64_t cshape[2] = {tw.M, tw.N};
     Tensor a_t(tw.d_a, QType::F16, 2, ashape, /*on_device=*/true);
     Tensor c_t(tw.d_c, QType::F16, 2, cshape, /*on_device=*/true);
-    // Should NOT crash — guarded by cudaStreamIsCapturing inside ensure_dequant_buffer.
-    gemm_nvfp4(tw.qr, a_t, c_t, stream_);
+    // Must fail LOUD: a silent skip records a graph that lacks this GEMM and
+    // launches with an uninitialized activation buffer (the #855 census
+    // "hybrid crash" — misaligned address on Nemotron). The capture-refusal
+    // in ensure_dequant_buffer now surfaces as a throw the capturer catches.
+    EXPECT_THROW(gemm_nvfp4(tw.qr, a_t, c_t, stream_), std::runtime_error);
 
     cudaGraph_t graph = nullptr;
     cudaError_t end_err = cudaStreamEndCapture(stream_, &graph);


### PR DESCRIPTION
## Root cause of the #855 census "hybrid crash"

When the largest NVFP4 weight exceeded the 512 MiB dequant-workspace cap, `allocate_nvfp4_dequant_workspace` skipped the pre-alloc **entirely** — and `gemm_nvfp4`'s capture-refusal branch then **silently returned**, recording a graph that simply lacks the GEMM. The graph launched with an uninitialized activation buffer and died with `misaligned address` (context poison). Nemotron-3-Nano was the only NVFP4 model with a >cap weight (672 MiB), which made the crash look hybrid/SSM-specific — it never was.

## Fixes

1. **`gemm_nvfp4` throws on capture-refusal** (and on lazy-alloc failure) instead of silently skipping the GEMM. The verify capturer catches it, fails the capture cleanly and falls back to the eager verify (doom after repeated failures — the #856 machinery).
2. **Capped pre-alloc instead of all-or-nothing**: cover the largest weight ≤ 512 MiB (Nemotron: 52.83 MiB covers every chunk-path GEMM); only oversized weights stay on the fail-loud path. `nvfp4_dequant_uncapturable_` semantics unchanged (still set when any weight exceeds the cap — the prefill scheduler stays conservative).

With this, the capturability probe on Nemotron records and launches the verify chunk graph cleanly (`n_tokens=17 CAPTURED+LAUNCHED`, coherent output). Production verify capture still excludes hybrids: replaying a **padded** chunk would advance the recurrent state through pad rows — lifting that needs device-length state updates in the SSM/GDN scan (follow-up slice noted in #847).

Test updated: `NvFP4GemmGraphCapture.FallbackInsideCaptureWithoutWorkspaceFailsLoud` now expects the throw (that IS the loud failure).

## Gates

Coder-30B captured verify 2808 tok/s (unchanged vs 2812), cortecs byte-identity vs the #856 references holds, `make test-gpu` green (188+ tests), `verify-fast` OK (decode WARN = depressed-host signature per #526). No perf-baseline impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBxj5AM7sGzgkhn957KoHH