### PR TITLE
feat(spec): hybrid verify capture foundation + MoE host-args capture guards (#847)

### DIFF
--- a/src/compute/ssm.cu
+++ b/src/compute/ssm.cu
@@ -199,10 +199,12 @@ __global__ void ssm_conv1d_prefill_kernel(
     const half* __restrict__ weight,  // [channels, kernel_size] from GGUF (ne[0]=K, ne[1]=C)
     const half* __restrict__ bias,    // [channels] or nullptr
     half* __restrict__ x_out,         // [n_tokens, channels]
-    int n_tokens, int channels, int kernel_size) {
+    int n_tokens, int channels, int kernel_size,
+    const int* __restrict__ d_real_n) {  // device chunk length (padded verify chunk) or nullptr
     int token = blockIdx.x;
     if (token >= n_tokens)
         return;
+    const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
 
     for (int ch = threadIdx.x; ch < channels; ch += blockDim.x) {
         float sum = 0.0f;
@@ -231,26 +233,30 @@ __global__ void ssm_conv1d_prefill_kernel(
         }
         x_out[token * channels + ch] = __float2half(sum);
 
-        // For the last token, write conv_state
-        if (token == n_tokens - 1) {
+        // For the last (real) token, write conv_state. Chunks shorter than
+        // kernel_size shift the missing leading values in from the previous
+        // chunk's conv_state (per-thread read index real_n+k stays ahead of
+        // every write index k, so the in-place shift is ordered correctly).
+        if (token == real_n - 1 && conv_state) {
             float* state = conv_state + ch * kernel_size;
             for (int k = 0; k < kernel_size; k++) {
-                int src_t = n_tokens - kernel_size + k;
-                state[k] = (src_t >= 0) ? __half2float(x_in[src_t * channels + ch]) : 0.0f;
+                int src_t = real_n - kernel_size + k;
+                state[k] = (src_t >= 0) ? __half2float(x_in[src_t * channels + ch])
+                                        : state[src_t + kernel_size];
             }
         }
     }
 }
 
 void ssm_conv1d_prefill(void* conv_state, const Tensor& x_in, const Tensor& weight, const Tensor& bias,
-                        Tensor& x_out, int conv_kernel, cudaStream_t stream) {
+                        Tensor& x_out, int conv_kernel, cudaStream_t stream, const int* d_real_n) {
     int n_tokens = static_cast<int>(x_in.shape[0]);
     int channels = static_cast<int>(x_in.shape[1]);
 
     ssm_conv1d_prefill_kernel<<<n_tokens, 256, 0, stream>>>(
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
-        static_cast<half*>(x_out.data), n_tokens, channels, conv_kernel);
+        static_cast<half*>(x_out.data), n_tokens, channels, conv_kernel, d_real_n);
 }
 
 // ---------------------------------------------------------------------------
@@ -262,10 +268,11 @@ __global__ void ssm_conv1d_prefill_f32_silu_kernel(float* __restrict__ conv_stat
                                                    const half* __restrict__ weight,
                                                    const half* __restrict__ bias,
                                                    float* __restrict__ x_out_f32, int n_tokens, int channels,
-                                                   int kernel_size) {
+                                                   int kernel_size, const int* __restrict__ d_real_n) {
     int token = blockIdx.x;
     if (token >= n_tokens)
         return;
+    const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
 
     for (int ch = threadIdx.x; ch < channels; ch += blockDim.x) {
         float sum = 0.0f;
@@ -292,25 +299,29 @@ __global__ void ssm_conv1d_prefill_f32_silu_kernel(float* __restrict__ conv_stat
         // Fused SiLU + FP32 output
         x_out_f32[token * channels + ch] = sum / (1.0f + expf(-sum));
 
-        // Update conv_state for last token
-        if (token == n_tokens - 1) {
+        // Update conv_state for the last (real) token; short chunks shift the
+        // missing leading values in from the previous chunk's conv_state (see
+        // ssm_conv1d_prefill_kernel).
+        if (token == real_n - 1 && conv_state) {
             float* state = conv_state + ch * kernel_size;
             for (int k = 0; k < kernel_size; k++) {
-                int src_t = n_tokens - kernel_size + k;
-                state[k] = (src_t >= 0) ? __half2float(x_in[src_t * channels + ch]) : 0.0f;
+                int src_t = real_n - kernel_size + k;
+                state[k] = (src_t >= 0) ? __half2float(x_in[src_t * channels + ch])
+                                        : state[src_t + kernel_size];
             }
         }
     }
 }
 
 void ssm_conv1d_prefill_f32_silu(void* conv_state, const Tensor& x_in, const Tensor& weight,
-                                 const Tensor& bias, float* x_out_f32, int conv_kernel, cudaStream_t stream) {
+                                 const Tensor& bias, float* x_out_f32, int conv_kernel, cudaStream_t stream,
+                                 const int* d_real_n) {
     int n_tokens = static_cast<int>(x_in.shape[0]);
     int channels = static_cast<int>(x_in.shape[1]);
     ssm_conv1d_prefill_f32_silu_kernel<<<n_tokens, 256, 0, stream>>>(
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
-        x_out_f32, n_tokens, channels, conv_kernel);
+        x_out_f32, n_tokens, channels, conv_kernel, d_real_n);
 }
 
 // ---------------------------------------------------------------------------
@@ -352,10 +363,15 @@ __global__ void ssm_scan_kernel(
     void* __restrict__ h_state,         // [n_heads, state_size, head_dim_ssm] (transposed)
     half* __restrict__ y,               // [n_tokens, inner_size]
     const half* __restrict__ z,         // [n_tokens, inner_size] (gate, only if FUSE_GATE)
-    int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups, int s_tiles) {
+    int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups, int s_tiles,
+    const int* __restrict__ d_real_n) {  // device chunk length (padded verify chunk) or nullptr
     int h = blockIdx.x;
     if (h >= n_heads)
         return;
+    // Padded verify chunk (#847): y is produced for every row (padding rows
+    // are causally invisible downstream), but h_state stops advancing after
+    // the real last row so the committed recurrent state ignores the pads.
+    const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
 
     int heads_per_group = n_heads / n_groups;
     int g = h / heads_per_group;
@@ -405,10 +421,12 @@ __global__ void ssm_scan_kernel(
                 h_old = static_cast<float*>(h_state)[idx];
             }
             float h_new = a_bar * h_old + dt_val * x_val * b_s;
-            if constexpr (H_FP16) {
-                static_cast<half*>(h_state)[idx] = __float2half(h_new);
-            } else {
-                static_cast<float*>(h_state)[idx] = h_new;
+            if (t < real_n) {
+                if constexpr (H_FP16) {
+                    static_cast<half*>(h_state)[idx] = __float2half(h_new);
+                } else {
+                    static_cast<float*>(h_state)[idx] = h_new;
+                }
             }
             y_partial += h_new * c_s;
         }
@@ -453,7 +471,7 @@ __global__ void ssm_scan_kernel(
 static void ssm_scan_launch(const half* x, const half* B, const half* C, const half* dt, const float* A_log,
                             const float* D, const float* dt_bias, void* h_state, half* y, const half* z,
                             int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            QType h_dtype, cudaStream_t stream) {
+                            QType h_dtype, cudaStream_t stream, const int* d_real_n = nullptr) {
     // Pick s_tiles to maximize thread count per block (power of 2, up to 1024 threads)
     int hd = std::max(head_dim_ssm, 1);
     int max_s_tiles = std::min(state_size, 1024 / hd);
@@ -470,7 +488,8 @@ static void ssm_scan_launch(const half* x, const half* B, const half* C, const h
 #define SSM_SCAN_LAUNCH(H_FP16_V, FUSE_V)                                                                   \
     ssm_scan_kernel<H_FP16_V, FUSE_V>                                                                       \
         <<<n_heads, threads, smem_bytes, stream>>>(x, B, C, dt, A_log, D, dt_bias, h_state, y, z, n_tokens, \
-                                                   n_heads, head_dim_ssm, state_size, n_groups, s_tiles)
+                                                   n_heads, head_dim_ssm, state_size, n_groups, s_tiles,    \
+                                                   d_real_n)
 
     if (fp16) {
         if (fused)
@@ -501,13 +520,13 @@ void ssm_scan_decode(const Tensor& x, const Tensor& B, const Tensor& C, const Te
 void ssm_scan_prefill(const Tensor& x, const Tensor& B, const Tensor& C, const Tensor& dt,
                       const Tensor& A_log, const Tensor& D, const Tensor& dt_bias, void* h_state, Tensor& y,
                       const void* z, int n_tokens, int n_heads, int head_dim_ssm, int state_size,
-                      int n_groups, QType h_dtype, cudaStream_t stream) {
+                      int n_groups, QType h_dtype, cudaStream_t stream, const int* d_real_n) {
     ssm_scan_launch(static_cast<const half*>(x.data), static_cast<const half*>(B.data),
                     static_cast<const half*>(C.data), static_cast<const half*>(dt.data),
                     static_cast<const float*>(A_log.data), static_cast<const float*>(D.data),
                     static_cast<const float*>(dt_bias.data), h_state, static_cast<half*>(y.data),
                     static_cast<const half*>(z), n_tokens, n_heads, head_dim_ssm, state_size, n_groups,
-                    h_dtype, stream);
+                    h_dtype, stream, d_real_n);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/compute/ssm.h
+++ b/src/compute/ssm.h
@@ -20,19 +20,28 @@ void ssm_conv1d_decode(void* conv_state, const Tensor& x_in, const Tensor& weigh
                        Tensor& x_out, int conv_kernel, cudaStream_t stream);
 
 // Conv1d prefill: causal 1D convolution over full sequence.
-// Also updates conv_state with the last conv_kernel values.
+// Also updates conv_state with the last conv_kernel values (for chunks
+// shorter than conv_kernel the missing leading values shift in from the
+// previous chunk's conv_state).
 // conv_state: [conv_channels, conv_kernel] float (written with last values)
 // x_in:       [n_tokens, conv_channels] compute_dtype
 // weight:     [conv_channels, conv_kernel] float
 // bias:       [conv_channels] float, can be nullptr
 // x_out:      [n_tokens, conv_channels] compute_dtype
+// d_real_n:   optional device int — real chunk length when the chunk is
+//             padded for a captured verify graph (#847). Rows past it still
+//             produce conv outputs (causally invisible padding), but the
+//             conv_state tail is written from the real last rows only.
 void ssm_conv1d_prefill(void* conv_state, const Tensor& x_in, const Tensor& weight, const Tensor& bias,
-                        Tensor& x_out, int conv_kernel, cudaStream_t stream);
+                        Tensor& x_out, int conv_kernel, cudaStream_t stream,
+                        const int* d_real_n = nullptr);
 
 // Fused conv1d + SiLU + FP32 output for prefill (GDN layers).
 // Replaces 3 separate kernels (conv → SiLU → FP16→FP32) with one launch.
+// d_real_n: see ssm_conv1d_prefill.
 void ssm_conv1d_prefill_f32_silu(void* conv_state, const Tensor& x_in, const Tensor& weight,
-                                 const Tensor& bias, float* x_out_f32, int conv_kernel, cudaStream_t stream);
+                                 const Tensor& bias, float* x_out_f32, int conv_kernel, cudaStream_t stream,
+                                 const int* d_real_n = nullptr);
 
 // Mamba2 SSM scan decode (single step per sequence).
 // x:        [inner_size] compute_dtype — input after conv + SiLU
@@ -55,10 +64,14 @@ void ssm_scan_decode(const Tensor& x, const Tensor& B, const Tensor& C, const Te
 
 // SSM scan prefill: iterate scan_decode over all tokens sequentially.
 // z: [n_tokens, inner_size] gate input (nullptr = no fusion).
+// d_real_n: optional device int — real chunk length when the chunk is padded
+//           for a captured verify graph (#847). y is written for all rows,
+//           but h_state stops advancing after the real last row.
 void ssm_scan_prefill(const Tensor& x, const Tensor& B, const Tensor& C, const Tensor& dt,
                       const Tensor& A_log, const Tensor& D, const Tensor& dt_bias, void* h_state, Tensor& y,
                       const void* z, int n_tokens, int n_heads, int head_dim_ssm, int state_size,
-                      int n_groups, QType h_dtype = QType::F32, cudaStream_t stream = nullptr);
+                      int n_groups, QType h_dtype = QType::F32, cudaStream_t stream = nullptr,
+                      const int* d_real_n = nullptr);
 
 // Group RMSNorm: normalize each of n_groups groups independently.
 // x:      [n_tokens, dim] compute_dtype (dim = n_groups * group_size)

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -71,6 +71,7 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
     if (layer == 0)
         IMP_LOG_INFO("MoE prefill: NVFP4→FP16 batch path (n=%d, expanded=%d)", ctx.n, ctx.expanded);
 
+    moe_host_args_capture_guard(stream);
     std::vector<int32_t> h_offsets(ctx.ne + 1);
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_offsets.data(), ctx.routing.expert_offsets.data,
                                        static_cast<size_t>(ctx.ne + 1) * sizeof(int32_t),
@@ -366,6 +367,7 @@ bool GraphExecutor::try_run_moe_fp8_batch_prefill(int layer, cudaStream_t stream
         }
 
         size_t expert_fp8_sz = static_cast<size_t>(rows) * cols;
+        moe_host_args_capture_guard(stream);
         std::vector<int32_t> h_offsets(ne + 1);
         cudaMemcpyAsync(h_offsets.data(), routing.expert_offsets.data,
                         static_cast<size_t>(ne + 1) * sizeof(int32_t), cudaMemcpyDeviceToHost,
@@ -418,6 +420,7 @@ bool GraphExecutor::try_run_moe_fp16_batch_prefill(int layer, cudaStream_t strea
                      expanded);
 
     // One D2H sync per layer for expert offsets
+    moe_host_args_capture_guard(stream);
     std::vector<int32_t> h_offsets(ne + 1);
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_offsets.data(), routing.expert_offsets.data,
                                        static_cast<size_t>(ne + 1) * sizeof(int32_t),
@@ -561,6 +564,7 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
     // top_k is bounded by FFN active-expert count (max 32 per kernel
     // launch guard at line ~2154 in the old per-token form). Use a
     // std::vector since n*top_k can exceed the old 32-entry stack array.
+    moe_host_args_capture_guard(stream);
     std::vector<int32_t> h_all_experts(static_cast<size_t>(n) * top_k);
     cudaMemcpyAsync(h_all_experts.data(), routing.expert_indices.data,
                     static_cast<size_t>(n) * top_k * sizeof(int32_t),

--- a/src/exec/executor_forward_moe_cutlass.cu
+++ b/src/exec/executor_forward_moe_cutlass.cu
@@ -314,6 +314,7 @@ if (!ctx.moe_gather_done) {
 }
 
 // Legacy D2H+sync + smallM + non-smallM dispatch path.
+moe_host_args_capture_guard(stream);
 std::vector<int32_t> h_offsets(ne + 1);
 IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_offsets.data(), routing.expert_offsets.data,
                                    static_cast<size_t>(ne + 1) * sizeof(int32_t),

--- a/src/exec/executor_forward_moe_internal.h
+++ b/src/exec/executor_forward_moe_internal.h
@@ -7,7 +7,24 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <stdexcept>
+
 namespace imp {
+
+// Several MoE prefill paths read routing metadata on the host (D2H + stream
+// sync) to size the per-expert GEMMs. Under an active stream capture that
+// sync fails SILENTLY (the error was unchecked) and the host reads
+// uninitialized offsets — the recorded graph then launches expert GEMMs with
+// garbage geometry and dies with `misaligned address` at graph launch (the
+// #855 census crash class; root-caused on Nemotron-H NVFP4 in #847). Only
+// the CUTLASS 3.x device-args path records cleanly; every host-args path
+// must fail the capture loudly instead (same lesson as #858).
+inline void moe_host_args_capture_guard(cudaStream_t stream) {
+    cudaStreamCaptureStatus st = cudaStreamCaptureStatusNone;
+    if (cudaStreamIsCapturing(stream, &st) == cudaSuccess && st != cudaStreamCaptureStatusNone)
+        throw std::runtime_error(
+            "MoE host-args prefill path reads routing on the host — not graph-capturable");
+}
 
 __global__ void sanitize_fp16_kernel(__half* __restrict__ data, int64_t n);
 __global__ void moe_apply_per_expert_scale_kernel(

--- a/src/exec/executor_forward_moe_legacy.cu
+++ b/src/exec/executor_forward_moe_legacy.cu
@@ -67,6 +67,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
         IMP_LOG_INFO("MoE prefill: legacy FP16 fallback path (n=%d, expanded=%d)", n,
                      expanded);
     {
+        moe_host_args_capture_guard(stream);
         std::vector<int32_t> h_offsets(ne + 1);
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_offsets.data(), routing.expert_offsets.data,
                                            static_cast<size_t>(ne + 1) * sizeof(int32_t),

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -14,6 +14,8 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
+#include <stdexcept>
+
 namespace imp {
 
 // Helper: FP32 ssm_out + FP16 residual → FP16 h. Preserves FP32 GEMM-accum
@@ -127,7 +129,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
     if (conv_st) {
         if (state.is_prefill) {
             ssm_conv1d_prefill(conv_st, xBC_in, ly.ssm_conv1d_w, ly.ssm_conv1d_b, xBC_out, conv_kernel,
-                               stream);
+                               stream, state.d_chunk_len);
         } else {
             ssm_conv1d_decode(conv_st, xBC_in, ly.ssm_conv1d_w, ly.ssm_conv1d_b, xBC_out, conv_kernel,
                               stream);
@@ -229,8 +231,8 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
             Tensor y_all(y_buf.data, compute_dtype_, 2, x_shape, true);
 
             ssm_scan_prefill(x_all, B_all, C_all, dt_all, ly.ssm_a, ly.ssm_d, ly.ssm_dt_b, h_st, y_all,
-                             static_cast<const half*>(z_buf.data), n, n_heads, head_dim_ssm, ssize, n_groups,
-                             h_dtype, stream);
+                             static_cast<const half*>(z_buf.data), n, n_heads, head_dim_ssm, ssize,
+                             n_groups, h_dtype, stream, state.d_chunk_len);
         }
     }
 
@@ -257,6 +259,13 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
 
 void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t stream) {
     configure_ssm_workspace(ws_.shared_max_tokens());
+
+    // The GDN scan kernels are not device-length-aware yet — a padded verify
+    // chunk would advance the recurrent state through pad rows. Unreachable
+    // today (chunk_capture_supported requires hd==128 and every GDN model is
+    // hd=256/FMHA), but fail loud rather than corrupt state silently (#858).
+    if (state.d_chunk_len != nullptr)
+        throw std::runtime_error("run_gdn: GDN scan is not device-length-aware (captured verify chunk)");
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -9,6 +9,7 @@
 #include "exec/gemm_scratch.h"  // prewarm_mmvq_scratch
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
+#include "compute/gemm_cutlass_grouped_3x.h"
 #include "compute/sampling.h"
 #include "runtime/config.h"
 #include "quant/quant_gemm.h"
@@ -1341,6 +1342,60 @@ bool GraphExecutor::chunk_capture_supported() const {
         return false;  // FP16-QK FA2 is the only device-length chunked kernel
     if (runtime_config().attention.fa2_fp16qk == "never")
         return false;
+    // MoE: only the CUTLASS 3.x device-args grouped path records into a
+    // graph without host-side routing reads — every other MoE prefill path
+    // does a D2H+sync per layer to size the expert GEMMs (capture-illegal;
+    // guarded by moe_host_args_capture_guard). Require the static
+    // device-args conditions for every MoE layer. Models whose experts live
+    // in the data-borrow decode slabs (e.g. Nemotron-H NVFP4: expert ids not
+    // in the CUTLASS tier) fall out here until a device-args grouped GEMM
+    // exists for that layout (#847 follow-up).
+    bool any_moe = false;
+    for (int i = 0; i < cfg.n_layers && !any_moe; ++i)
+        any_moe = layer_has_moe(i);
+    // moe.skip (debug) removes the MoE pass from eager and capture alike —
+    // the recorded graph stays consistent, so it does not block capture.
+    if (any_moe && !runtime_config().moe.skip) {
+        if (runtime_config().moe.no_cutlass3x || !runtime_config().moe.nvfp4_device_args)
+            return false;
+        if (!cutlass_grouped_3x_nvfp4_available())
+            return false;
+        const int ne = cfg.n_experts;
+        if (!moe_.cutlass3x_packed || !moe_.cutlass3x_sf || !moe_.d_M_per ||
+            moe_.d_M_per_count < ne || !moe_.d_sfa_offsets || !moe_.d_B_ptrs_cache ||
+            !moe_.d_SFB_ptrs_cache || !moe_.d_alpha_full || !moe_.cutlass3x_sfa_ptrs ||
+            moe_.cutlass3x_sfa_ptrs_count < ne)
+            return false;
+        auto covers = [&](const std::vector<TensorID>& ids) {
+            if (static_cast<int>(ids.size()) < ne)
+                return false;
+            for (int e = 0; e < ne; ++e) {
+                if (ids[e] == kInvalidTensorID)
+                    return false;
+                if (registry_.handle(ids[e]).primary_tier != StorageTier::CUTLASS_NVFP4)
+                    return false;
+            }
+            return true;
+        };
+        for (int i = 0; i < cfg.n_layers; ++i) {
+            if (!layer_has_moe(i))
+                continue;
+            const auto& ly = model_->layer(i);
+            const bool gated = !(ly.expert_gate_packed.data == nullptr &&
+                                 (ly.expert_w_gate.empty() || ly.expert_w_gate[0].data == nullptr));
+            // Non-gated experts (RELU² — Nemotron-H): the device-args grouped
+            // GEMM passes every static check here, records cleanly, and the
+            // captured graph still dies with `misaligned address` on launch
+            // (repro: Nemotron-3-Nano verify capture; the gated Qwen3-Coder /
+            // Modelopt graphs are clean). Root cause in the non-gated
+            // device-args replay is open — keep it eager until then.
+            if (!gated)
+                return false;
+            if (!covers(ly.expert_up_ids) || !covers(ly.expert_down_ids) ||
+                !covers(ly.expert_gate_ids))
+                return false;
+        }
+    }
     return true;
 }
 

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -166,6 +166,10 @@ struct InferenceState {
     // FA2-served attention config (GraphExecutor::chunk_capture_supported).
     int ctx_capacity = 0;
     const int* d_past_len = nullptr;  // device int == prefill_offset
+    // Device int == real (unpadded) chunk length. Hybrid recurrent-state
+    // updates (conv tail, scan final state) read it so the padding rows of a
+    // captured verify chunk don't advance the committed state.
+    const int* d_chunk_len = nullptr;
 };
 
 }  // namespace imp

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 #include <map>
+#include <tuple>
 #include <unordered_map>
 #include <string>
 #include <cstdint>
@@ -598,22 +599,29 @@ private:
         cudaGraphExec_t exec = nullptr;
         int eager_uses = 0;  // first use per slot runs eager (algo warmup)
     };
-    // Keyed by (padded chunk length, ctx tier). The tier (power of two the
-    // context is rounded up to) sizes the gather grids — a graph baked for
-    // the full 32k capacity spends ~3x the gather time at short contexts, so
-    // graphs re-capture when the context outgrows their tier (rare,
-    // amortized over thousands of verify steps).
-    std::map<std::pair<int, int>, SpecVerifyGraph> spec_graphs_;
+    // Keyed by (padded chunk length, ctx tier, recurrent slot). The tier
+    // (power of two the context is rounded up to) sizes the gather grids — a
+    // graph baked for the full 32k capacity spends ~3x the gather time at
+    // short contexts, so graphs re-capture when the context outgrows their
+    // tier (rare, amortized over thousands of verify steps). Hybrids bake
+    // the recurrent-slab pointers (SSMState::seq_base(slot)) into the graph,
+    // so each slot keys its own graphs (-1 for dense models); slot count is
+    // bounded by SSMState::max_sequences and verify is batch-1-gated.
+    std::map<std::tuple<int, int, int>, SpecVerifyGraph> spec_graphs_;
     int spec_capture_ctx_tier_(int ctx_padded) const;
-    int* d_spec_past_len_ = nullptr;  // device int: p0 (cached-prefix length)
-    int spec_capture_ctx_cap_ = -1;   // resolved capacity; -1 = unresolved, 0 = disabled
+    int* d_spec_past_len_ = nullptr;   // device int: p0 (cached-prefix length)
+    int* d_spec_chunk_len_ = nullptr;  // device int: real (unpadded) chunk length
+    int spec_capture_ctx_cap_ = -1;    // resolved capacity; -1 = unresolved, 0 = disabled
     uint64_t spec_capture_ws_gen_ = 0;
     int spec_capture_failures_ = 0;
     bool spec_capture_doomed_ = false;
     // True when this verify step may use the captured path: config on, not
-    // doomed, non-hybrid, no MoE offload, executor-supported attention
-    // config, padded context within the resolved capacity. Resolves the
-    // capacity + allocates the executor scratch on first eligible use.
+    // doomed, no legacy-GGUF GDN state, no MoE offload, executor-supported
+    // attention config, padded context within the resolved capacity.
+    // Resolves the capacity + allocates the executor scratch on first
+    // eligible use. Hybrids with SSMState qualify: the recurrent chunk
+    // kernels read the real chunk length from device (d_chunk_len) so pad
+    // rows never advance the committed state.
     bool spec_capture_ready_(int ctx_padded);
     // Round the real chunk length up to its capture bucket.
     int spec_capture_bucket_(int chunk_len) const;

--- a/src/runtime/engine_spec_capture.cpp
+++ b/src/runtime/engine_spec_capture.cpp
@@ -22,6 +22,13 @@
 // same rollback that drops rejected drafts. The verify consumes argmax rows
 // [0, real_chunk_len) only.
 //
+// Hybrids (SSMState): the recurrent state has no causal-masking escape — pad
+// rows would advance the conv tail and scan state in place. The chunk
+// kernels therefore read the real chunk length from device (InferenceState::
+// d_chunk_len, refreshed per step like the other lengths) and stop the state
+// updates at the real last row. The slab pointers (seq_base(slot)) are baked
+// into the graph, so the cache key includes the recurrent slot.
+//
 // Safety: the first use of a bucket runs eager through the SAME capture-mode
 // code path (cuBLASLt/CUTLASS algo warmup — census PR #855 showed only the
 // first chunk per shape fails capture); the second use captures. Any capture
@@ -79,10 +86,13 @@ bool Engine::spec_capture_ready_(int ctx_padded) {
     // chunk, diagnostics only).
     if (runtime_config_.diagnostics.spec_capture_probe)
         return false;
-    // Hybrids: census showed the recurrent chunk path consumes a D2H result
-    // under capture that never executed (misaligned-address context poison).
-    // MoE host-offload syncs on the host per layer.
-    if (ssm_state_ || gdn_state_ || offload_mgr_)
+    // SSMState hybrids are capture-eligible: the recurrent chunk kernels
+    // read the real chunk length from device (InferenceState::d_chunk_len)
+    // so pad rows never advance the committed state, and the graph cache is
+    // keyed on the recurrent slot (the slab pointers are baked). The legacy
+    // GGUF GDNState path has no slab accessor (excluded from spec verify
+    // altogether); MoE host-offload syncs on the host per layer.
+    if (gdn_state_ || offload_mgr_)
         return false;
     // BitDecoding residual KV advances ring state on the host per forward.
     if (kv_manager_ && kv_manager_->residual_enabled())
@@ -126,7 +136,10 @@ bool Engine::spec_captured_forward_(InferenceState& state, Tensor& logits_out,
         spec_capture_ws_gen_ = ws_gen;
     }
 
-    auto& slot = spec_graphs_[{state.n_tokens, state.ctx_capacity}];
+    // Hybrids bake the recurrent-slab pointers (seq_base(slot)) into the
+    // graph — key it on the slot so a slot change gets its own graph.
+    const int rec_slot = state.ssm_state ? state.ssm_seq_id : -1;
+    auto& slot = spec_graphs_[{state.n_tokens, state.ctx_capacity, rec_slot}];
     if (slot.exec) {
         cudaError_t err = cudaGraphLaunch(slot.exec, stream);
         if (err == cudaSuccess)
@@ -201,8 +214,8 @@ bool Engine::spec_captured_forward_(InferenceState& state, Tensor& logits_out,
     }
     slot.exec = exec;
     spec_capture_failures_ = 0;
-    IMP_LOG_INFO("[spec-capture] verify chunk graph cached (n_tokens=%d, ctx_tier=%d)",
-                 state.n_tokens, state.ctx_capacity);
+    IMP_LOG_INFO("[spec-capture] verify chunk graph cached (n_tokens=%d, ctx_tier=%d, rec_slot=%d)",
+                 state.n_tokens, state.ctx_capacity, rec_slot);
     return true;
 }
 

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -57,6 +57,7 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
               cudaMalloc(&d_spec_block_table_, max_blocks * sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_context_len_, sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_past_len_, sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&d_spec_chunk_len_, sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
               cudaMallocHost(&h_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess;
     if (!ok) {
@@ -126,6 +127,7 @@ void Engine::free_spec_buffers_() {
     if (d_spec_block_table_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_));
     if (d_spec_context_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_context_len_));
     if (d_spec_past_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_past_len_));
+    if (d_spec_chunk_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_chunk_len_));
     if (d_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_argmax_));
     if (h_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_argmax_));
     d_spec_tokens_ = nullptr;
@@ -133,6 +135,7 @@ void Engine::free_spec_buffers_() {
     d_spec_block_table_ = nullptr;
     d_spec_context_len_ = nullptr;
     d_spec_past_len_ = nullptr;
+    d_spec_chunk_len_ = nullptr;
     d_spec_argmax_ = nullptr;
     h_spec_argmax_ = nullptr;
     spec_chunk_cap_ = 0;
@@ -406,8 +409,10 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         !check(cudaMemcpyAsync(d_spec_context_len_, &ctx_len, sizeof(int), cudaMemcpyHostToDevice,
                                stream), "context len H2D") ||
         (capture_on &&
-         !check(cudaMemcpyAsync(d_spec_past_len_, &p0, sizeof(int), cudaMemcpyHostToDevice,
-                                stream), "past len H2D")))
+         (!check(cudaMemcpyAsync(d_spec_past_len_, &p0, sizeof(int), cudaMemcpyHostToDevice,
+                                 stream), "past len H2D") ||
+          !check(cudaMemcpyAsync(d_spec_chunk_len_, &chunk_len, sizeof(int),
+                                 cudaMemcpyHostToDevice, stream), "chunk len H2D"))))
         return false;
 
     // Forward the chunk through the standard continuation-prefill path.
@@ -439,6 +444,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         // executor scratch covers the full capacity, so any tier fits it.
         state.ctx_capacity = spec_capture_ctx_tier_(ctx_len);
         state.d_past_len = d_spec_past_len_;
+        state.d_chunk_len = d_spec_chunk_len_;
     }
 
     // Hybrid (SSM/GDN): bind the recurrent state and preserve the committed
@@ -474,6 +480,8 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
             if (spec_capture_doomed_) {
                 state.ctx_capacity = 0;
                 state.d_past_len = nullptr;
+                // Keep d_chunk_len: the chunk stays padded, and the hybrid
+                // recurrent-state updates must still stop at the real length.
             }
             executor_->forward_logits(state, logits_out, stream);
         }
@@ -587,6 +595,11 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
                                            cudaMemcpyHostToDevice, stream));
         state.n_tokens = matched + 1;
         state.max_context_len = replay_ctx;
+        // The replay is an unpadded eager forward of the accepted prefix —
+        // run it on the plain host-length chunk path, not the capture path.
+        state.ctx_capacity = 0;
+        state.d_past_len = nullptr;
+        state.d_chunk_len = nullptr;
         Tensor replay_logits;
         executor_->forward_logits(state, replay_logits, stream);
     }

--- a/tests/test_ssm.cu
+++ b/tests/test_ssm.cu
@@ -395,5 +395,241 @@ TEST(SSMConv1dTest, ChunkedPrefillEquivalence) {
     free_tensor(d_out_b);
 }
 
+// ===========================================================================
+// Test: Chunk shorter than kernel_size — the conv_state tail must shift the
+// missing leading values in from the previous chunk's state instead of
+// zero-padding. This is the hybrid verify partial-accept replay shape
+// (matched+1 tokens, often < conv_kernel).
+// ===========================================================================
+TEST(SSMConv1dTest, ChunkedPrefillShortChunkEquivalence) {
+    SKIP_IF_NO_CUDA();
+
+    constexpr int channels = 4;
+    constexpr int kernel_size = 4;
+    constexpr int n_chunk_a = 5;
+    constexpr int n_chunk_b = 2;  // < kernel_size: tail must read old conv_state
+    constexpr int n_total = n_chunk_a + n_chunk_b;
+
+    std::vector<float> h_x(n_total * channels);
+    for (int i = 0; i < n_total * channels; i++)
+        h_x[i] = std::cos(static_cast<float>(i) * 0.9f) * 1.5f;
+    std::vector<float> h_w(channels * kernel_size);
+    for (int i = 0; i < channels * kernel_size; i++)
+        h_w[i] = (i % 3 == 0) ? 0.4f : -0.2f;
+
+    // Reference: single full-sequence prefill.
+    float* d_state_full;
+    cudaMalloc(&d_state_full, channels * kernel_size * sizeof(float));
+    cudaMemset(d_state_full, 0, channels * kernel_size * sizeof(float));
+    Tensor d_x_full = make_fp16_gpu(h_x.data(), {n_total, channels});
+    Tensor d_w = make_fp16_gpu(h_w.data(), {channels, kernel_size});
+    Tensor d_out_full = alloc_fp16_gpu({n_total, channels});
+    Tensor d_bias = make_empty_tensor();
+    ssm_conv1d_prefill(d_state_full, d_x_full, d_w, d_bias, d_out_full, kernel_size, nullptr);
+    cudaDeviceSynchronize();
+    auto out_full = read_fp16(d_out_full);
+    std::vector<float> state_full(channels * kernel_size);
+    cudaMemcpy(state_full.data(), d_state_full, channels * kernel_size * sizeof(float),
+               cudaMemcpyDeviceToHost);
+
+    // Chunked: 5 tokens, then a 2-token continuation chunk.
+    float* d_state_chunked;
+    cudaMalloc(&d_state_chunked, channels * kernel_size * sizeof(float));
+    cudaMemset(d_state_chunked, 0, channels * kernel_size * sizeof(float));
+    Tensor d_x_a = make_fp16_gpu(h_x.data(), {n_chunk_a, channels});
+    Tensor d_out_a = alloc_fp16_gpu({n_chunk_a, channels});
+    ssm_conv1d_prefill(d_state_chunked, d_x_a, d_w, d_bias, d_out_a, kernel_size, nullptr);
+    cudaDeviceSynchronize();
+    Tensor d_x_b = make_fp16_gpu(h_x.data() + n_chunk_a * channels, {n_chunk_b, channels});
+    Tensor d_out_b = alloc_fp16_gpu({n_chunk_b, channels});
+    ssm_conv1d_prefill(d_state_chunked, d_x_b, d_w, d_bias, d_out_b, kernel_size, nullptr);
+    cudaDeviceSynchronize();
+
+    auto out_b = read_fp16(d_out_b);
+    std::vector<float> state_chunked(channels * kernel_size);
+    cudaMemcpy(state_chunked.data(), d_state_chunked, channels * kernel_size * sizeof(float),
+               cudaMemcpyDeviceToHost);
+
+    for (int t = 0; t < n_chunk_b; t++)
+        for (int ch = 0; ch < channels; ch++)
+            EXPECT_NEAR(out_full[(n_chunk_a + t) * channels + ch], out_b[t * channels + ch], 1e-2f)
+                << "Short chunk output mismatch at t=" << t << " ch=" << ch;
+    for (int i = 0; i < channels * kernel_size; i++)
+        EXPECT_NEAR(state_full[i], state_chunked[i], 1e-2f)
+            << "Short chunk state mismatch at i=" << i;
+
+    cudaFree(d_state_full);
+    cudaFree(d_state_chunked);
+    free_tensor(d_x_full);
+    free_tensor(d_w);
+    free_tensor(d_out_full);
+    free_tensor(d_x_a);
+    free_tensor(d_out_a);
+    free_tensor(d_x_b);
+    free_tensor(d_out_b);
+}
+
+// ===========================================================================
+// Test: Padded verify chunk (#847) — with d_real_n set, the conv_state tail
+// must come from the real last rows; pad rows only produce (discarded)
+// outputs. Both prefill variants share the tail logic; the fused f32+SiLU
+// variant is covered by FP32SiLUFused for the output math.
+// ===========================================================================
+TEST(SSMConv1dTest, PrefillPaddedChunkDeviceLength) {
+    SKIP_IF_NO_CUDA();
+
+    constexpr int channels = 4;
+    constexpr int kernel_size = 4;
+    constexpr int n_real = 5;
+    constexpr int n_padded = 12;  // pad rows repeat the first token (t0 copies)
+
+    std::vector<float> h_x(n_padded * channels);
+    for (int i = 0; i < n_padded * channels; i++)
+        h_x[i] = std::sin(static_cast<float>(i) * 0.3f);
+    std::vector<float> h_w(channels * kernel_size);
+    for (int i = 0; i < channels * kernel_size; i++)
+        h_w[i] = 0.25f * ((i % 4) - 1.5f);
+
+    // Reference: plain run over the real rows only.
+    float* d_state_ref;
+    cudaMalloc(&d_state_ref, channels * kernel_size * sizeof(float));
+    cudaMemset(d_state_ref, 0, channels * kernel_size * sizeof(float));
+    Tensor d_x_ref = make_fp16_gpu(h_x.data(), {n_real, channels});
+    Tensor d_w = make_fp16_gpu(h_w.data(), {channels, kernel_size});
+    Tensor d_out_ref = alloc_fp16_gpu({n_real, channels});
+    Tensor d_bias = make_empty_tensor();
+    ssm_conv1d_prefill(d_state_ref, d_x_ref, d_w, d_bias, d_out_ref, kernel_size, nullptr);
+    cudaDeviceSynchronize();
+    auto out_ref = read_fp16(d_out_ref);
+    std::vector<float> state_ref(channels * kernel_size);
+    cudaMemcpy(state_ref.data(), d_state_ref, channels * kernel_size * sizeof(float),
+               cudaMemcpyDeviceToHost);
+
+    // Padded run with the real length in a device int.
+    float* d_state_pad;
+    cudaMalloc(&d_state_pad, channels * kernel_size * sizeof(float));
+    cudaMemset(d_state_pad, 0, channels * kernel_size * sizeof(float));
+    int* d_real_n;
+    cudaMalloc(&d_real_n, sizeof(int));
+    int real_n = n_real;
+    cudaMemcpy(d_real_n, &real_n, sizeof(int), cudaMemcpyHostToDevice);
+    Tensor d_x_pad = make_fp16_gpu(h_x.data(), {n_padded, channels});
+    Tensor d_out_pad = alloc_fp16_gpu({n_padded, channels});
+    ssm_conv1d_prefill(d_state_pad, d_x_pad, d_w, d_bias, d_out_pad, kernel_size, nullptr, d_real_n);
+    cudaDeviceSynchronize();
+    auto out_pad = read_fp16(d_out_pad);
+    std::vector<float> state_pad(channels * kernel_size);
+    cudaMemcpy(state_pad.data(), d_state_pad, channels * kernel_size * sizeof(float),
+               cudaMemcpyDeviceToHost);
+
+    for (int t = 0; t < n_real; t++)
+        for (int ch = 0; ch < channels; ch++)
+            EXPECT_NEAR(out_ref[t * channels + ch], out_pad[t * channels + ch], 1e-2f)
+                << "Real-row output mismatch at t=" << t << " ch=" << ch;
+    for (int i = 0; i < channels * kernel_size; i++)
+        EXPECT_NEAR(state_ref[i], state_pad[i], 1e-2f)
+            << "Padded-chunk state mismatch at i=" << i;
+
+    cudaFree(d_state_ref);
+    cudaFree(d_state_pad);
+    cudaFree(d_real_n);
+    free_tensor(d_x_ref);
+    free_tensor(d_w);
+    free_tensor(d_out_ref);
+    free_tensor(d_x_pad);
+    free_tensor(d_out_pad);
+}
+
+// ===========================================================================
+// Test: Padded verify chunk (#847), Mamba2 scan — with d_real_n set, y is
+// produced for every row but h_state must stop advancing after the real
+// last row (bit-equal to a plain run over the real rows).
+// ===========================================================================
+TEST(SSMScanTest, PrefillPaddedChunkDeviceLength) {
+    SKIP_IF_NO_CUDA();
+
+    constexpr int n_heads = 2;
+    constexpr int head_dim = 4;
+    constexpr int state_size = 8;
+    constexpr int n_groups = 1;
+    constexpr int inner = n_heads * head_dim;
+    constexpr int bc = n_groups * state_size;
+    constexpr int n_real = 5;
+    constexpr int n_padded = 12;
+
+    std::vector<float> h_x(n_padded * inner), h_B(n_padded * bc), h_C(n_padded * bc),
+        h_dt(n_padded * n_heads), h_z(n_padded * inner);
+    for (size_t i = 0; i < h_x.size(); i++) h_x[i] = std::sin(0.37f * i);
+    for (size_t i = 0; i < h_B.size(); i++) h_B[i] = std::cos(0.21f * i);
+    for (size_t i = 0; i < h_C.size(); i++) h_C[i] = std::sin(0.11f * i + 1.0f);
+    for (size_t i = 0; i < h_dt.size(); i++) h_dt[i] = 0.1f + 0.05f * (i % 7);
+    for (size_t i = 0; i < h_z.size(); i++) h_z[i] = std::cos(0.53f * i);
+    std::vector<float> h_A(n_heads, -0.5f), h_D(n_heads, 0.3f), h_dtb(n_heads, 0.2f);
+
+    auto make_f32_gpu = [](const float* host, size_t n) {
+        float* d;
+        cudaMalloc(&d, n * sizeof(float));
+        cudaMemcpy(d, host, n * sizeof(float), cudaMemcpyHostToDevice);
+        return d;
+    };
+    float* d_A = make_f32_gpu(h_A.data(), n_heads);
+    float* d_D = make_f32_gpu(h_D.data(), n_heads);
+    float* d_dtb = make_f32_gpu(h_dtb.data(), n_heads);
+    int64_t head_shape[1] = {n_heads};
+    Tensor t_A(d_A, QType::F32, 1, head_shape, true);
+    Tensor t_D(d_D, QType::F32, 1, head_shape, true);
+    Tensor t_dtb(d_dtb, QType::F32, 1, head_shape, true);
+
+    const size_t h_elems = static_cast<size_t>(n_heads) * state_size * head_dim;
+
+    auto run = [&](int n_tokens, const int* d_real_n, std::vector<float>& y_out,
+                   std::vector<float>& h_out) {
+        Tensor d_x = make_fp16_gpu(h_x.data(), {n_tokens, inner});
+        Tensor d_B = make_fp16_gpu(h_B.data(), {n_tokens, bc});
+        Tensor d_C = make_fp16_gpu(h_C.data(), {n_tokens, bc});
+        Tensor d_dt = make_fp16_gpu(h_dt.data(), {n_tokens, n_heads});
+        Tensor d_z = make_fp16_gpu(h_z.data(), {n_tokens, inner});
+        Tensor d_y = alloc_fp16_gpu({n_tokens, inner});
+        float* d_h;
+        cudaMalloc(&d_h, h_elems * sizeof(float));
+        cudaMemset(d_h, 0, h_elems * sizeof(float));
+        ssm_scan_prefill(d_x, d_B, d_C, d_dt, t_A, t_D, t_dtb, d_h, d_y, d_z.data, n_tokens,
+                         n_heads, head_dim, state_size, n_groups, QType::F32, nullptr, d_real_n);
+        cudaDeviceSynchronize();
+        y_out = read_fp16(d_y);
+        h_out.resize(h_elems);
+        cudaMemcpy(h_out.data(), d_h, h_elems * sizeof(float), cudaMemcpyDeviceToHost);
+        cudaFree(d_h);
+        free_tensor(d_x);
+        free_tensor(d_B);
+        free_tensor(d_C);
+        free_tensor(d_dt);
+        free_tensor(d_z);
+        free_tensor(d_y);
+    };
+
+    std::vector<float> y_ref, h_ref;
+    run(n_real, nullptr, y_ref, h_ref);
+
+    int* d_real_n;
+    cudaMalloc(&d_real_n, sizeof(int));
+    int real_n = n_real;
+    cudaMemcpy(d_real_n, &real_n, sizeof(int), cudaMemcpyHostToDevice);
+    std::vector<float> y_pad, h_pad;
+    run(n_padded, d_real_n, y_pad, h_pad);
+    cudaFree(d_real_n);
+
+    for (int t = 0; t < n_real; t++)
+        for (int i = 0; i < inner; i++)
+            EXPECT_NEAR(y_ref[t * inner + i], y_pad[t * inner + i], 1e-3f)
+                << "y mismatch at t=" << t << " i=" << i;
+    for (size_t i = 0; i < h_elems; i++)
+        EXPECT_EQ(h_ref[i], h_pad[i]) << "h_state mismatch at i=" << i;
+
+    cudaFree(d_A);
+    cudaFree(d_D);
+    cudaFree(d_dtb);
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## What

Foundation slice for extending the graph-captured verify chunk (#856) to SSMState hybrids, plus the root-cause fix for the #855 census crash class it uncovered.

### Hybrid verify capture (device-length recurrent state)
- `ssm_conv1d_prefill{,_f32_silu}` and the Mamba2 scan take an optional **device chunk length** (`InferenceState::d_chunk_len`, uploaded per verify step like the other lengths). Pad rows of a bucket-padded chunk still produce causally-invisible outputs, but the conv tail and scan state stop advancing at the real last row.
- The verify graph cache key gains the **recurrent slot** — `SSMState::seq_base(slot)` pointers are baked into the graph.
- The `ssm_state_` exclusion in `spec_capture_ready_` is lifted; `run_gdn` fails loud if it ever sees a padded chunk (GDN scans are not device-length-aware yet; structurally unreachable via the `hd==128` gate — the hd=256/FMHA slice is a #847 follow-up).
- Partial-accept replay and the doomed-capture fallback handle the capture fields explicitly (the padded doomed-eager case keeps `d_chunk_len` so pads never advance hybrid state).

### Bugfix: conv-tail zero-fill on short chunks (eager path, all hybrids)
Chunks shorter than `conv_kernel` wrote **zeros** into the leading conv-state slots instead of shifting them in from the previous chunk's state. This corrupts the eager hybrid **partial-accept replay** (`matched+1 < kernel_size`) shipped in #852. Now shifts from the old state; covered by a new short-chunk equivalence test that fails on main.

### Root cause + fix: MoE host-args prefill paths are capture-illegal (#855 crash class)
Enabling capture on Nemotron-H exposed the real census crash: most MoE prefill paths do a **D2H of `expert_offsets` + an UNCHECKED `cudaStreamSynchronize`** to size the per-expert GEMMs. Under an active stream capture the sync fails silently, the host reads uninitialized offsets, and the recorded expert GEMMs carry garbage geometry → `misaligned address` at graph launch + poisoned context. (The census probe captured the host-length path without capture fields, so it could never see this; #858 explained only the workspace half.)
- **`moe_host_args_capture_guard()`**: all six host-args MoE prefill sites now throw under active capture — capture fails cleanly, eager fallback, no silent corruption (same lesson as #858).
- **`chunk_capture_supported()`** requires the CUTLASS 3.x device-args conditions for every MoE layer (the only capture-safe MoE path).
- **Non-gated experts (RELU², Nemotron-H) stay excluded**: their device-args graphs record cleanly but still IMA on launch — tracked as a follow-up; gated NVFP4-MoE (Qwen3-Coder / Modelopt) keeps capture exactly as shipped in #856.

## Verification (RTX 5090, local)
- **Nemotron-3-Nano-30B-A3B-NVFP4**: capture cleanly disabled (`not applicable`), eager verify 14 tok/verify, echo byte-correct across requests, 0 IMA (main + this branch pre-gate: IMA + `<unk>` degeneration).
- **Qwen3-Coder-30B-A3B-FP4** (dense-MoE capture regression): graphs cached + replayed (buckets 17/65), 92.4% accept, 55 tok/verify, output correct, 0 IMA.
- **Qwen3.5-4B** (GDN hybrid, eager): spec on == off **byte-identical**, 96.6% accept over 37 verifies incl. partial-accept replays (exercises the conv-tail fix).
- **Qwen3-8B-Q8** dense: clean.
- 3 new SSM unit tests (short-chunk equivalence, padded-chunk device-length conv + scan); full GPU suite green (`make test-gpu` exit 0).

No perf-baseline change: hybrids stay eager (as before), dense capture behavior unchanged, `--bench` pins capture off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)