### PR TITLE
fix(moe): non-gated NVFP4 da_cache never built — stack-UAF memcpy nodes in captured verify graphs (#860)

### DIFF
--- a/src/exec/executor_forward_moe_cutlass.cu
+++ b/src/exec/executor_forward_moe_cutlass.cu
@@ -201,6 +201,11 @@ bool device_args_done = false;
                 if (!d_B || !d_SFB || !d_a) {
                     // Pre-cache miss — fall back to per-call H2D
                     // into the workspace caches from Step 1.
+                    // NOT graph-capturable: the memcpy sources are stack
+                    // vectors, so a recorded node would read a dead stack
+                    // address on every replay (#860 — nondeterministic
+                    // garbage B pointers, misaligned-address graph launches).
+                    moe_host_args_capture_guard(stream);
                     std::vector<const void*> h_B_ptrs(ne), h_SFB_ptrs(ne);
                     std::vector<float> h_alpha(ne);
                     for (int e = 0; e < ne; ++e) {

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1383,16 +1383,14 @@ bool GraphExecutor::chunk_capture_supported() const {
             const auto& ly = model_->layer(i);
             const bool gated = !(ly.expert_gate_packed.data == nullptr &&
                                  (ly.expert_w_gate.empty() || ly.expert_w_gate[0].data == nullptr));
-            // Non-gated experts (RELU² — Nemotron-H): the device-args grouped
-            // GEMM passes every static check here, records cleanly, and the
-            // captured graph still dies with `misaligned address` on launch
-            // (repro: Nemotron-3-Nano verify capture; the gated Qwen3-Coder /
-            // Modelopt graphs are clean). Root cause in the non-gated
-            // device-args replay is open — keep it eager until then.
-            if (!gated)
+            // Require the per-layer da_cache: without it dispatch_device
+            // falls back to per-call H2D from stack vectors, which is not
+            // graph-capturable (#860; the fallback also guards itself).
+            if (i >= static_cast<int>(moe_.per_layer_da_cache.size()) ||
+                !moe_.per_layer_da_cache[i].ready)
                 return false;
             if (!covers(ly.expert_up_ids) || !covers(ly.expert_down_ids) ||
-                !covers(ly.expert_gate_ids))
+                (gated && !covers(ly.expert_gate_ids)))
                 return false;
         }
     }

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -14,6 +14,7 @@
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <algorithm>
 #include <cstdlib>
 #include <string>
 #include <vector>
@@ -428,11 +429,22 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
         int built_layers = 0;
         int host_resident_layers = 0;  // intentionally not built (force_host or budget offload)
         std::vector<int> failed_layers;
+        // The loader pre-sizes the expert id vectors on EVERY layer of a
+        // hybrid model (SSM/attention layers carry all-invalid ids), so
+        // "has expert ids" must mean "has at least one VALID id" — the
+        // empty()-based checks misclassified all 29 Nemotron-H non-MoE
+        // layers as MoE-eligible (tripping the QW8 abort) and left the
+        // non-gated gate projection permanently "present but failed".
+        auto any_valid_id = [](const std::vector<TensorID>& ids) {
+            return std::any_of(ids.begin(), ids.end(),
+                               [](TensorID id) { return id != kInvalidTensorID; });
+        };
         for (int li = 0; li < n_layers; ++li) {
             const auto& L = model_->layer(li);
             auto& c = moe_->per_layer_da_cache[li];
-            const bool moe_layer = !L.expert_up_ids.empty() || !L.expert_down_ids.empty() ||
-                                   !L.expert_gate_ids.empty();
+            const bool moe_layer = any_valid_id(L.expert_up_ids) ||
+                                   any_valid_id(L.expert_down_ids) ||
+                                   any_valid_id(L.expert_gate_ids);
             if (!moe_layer) {
                 // Pure dense layer in a hybrid model (e.g. attention-only layer
                 // alongside MoE layers). Not eligible for the da_cache; skip
@@ -457,16 +469,20 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
                 continue;
             }
             ++eligible_layers;
-            bool g_ok = !L.expert_gate_ids.empty() &&
+            // Non-gated experts (RELU² — Nemotron-H) have no gate projection:
+            // gate ids are absent (empty or all-invalid). The empty()-only
+            // check left c.ready=false on every Nemotron-H layer, silently
+            // forcing the per-call H2D fallback dispatch (and, under graph
+            // capture, a memcpy node reading a dead stack buffer — #860).
+            const bool gate_absent = !any_valid_id(L.expert_gate_ids);
+            bool g_ok = !gate_absent &&
                         build_proj(L.expert_gate_ids, c.d_gate_B_ptrs,
                                    c.d_gate_SFB_ptrs, c.d_gate_alpha);
             bool u_ok = build_proj(L.expert_up_ids, c.d_up_B_ptrs,
                                    c.d_up_SFB_ptrs, c.d_up_alpha);
             bool d_ok = build_proj(L.expert_down_ids, c.d_down_B_ptrs,
                                    c.d_down_SFB_ptrs, c.d_down_alpha);
-            // For non-gated experts (e.g. Gemma-4 SwiGLU absorbing W_gate),
-            // expert_gate_ids may be empty by design — accept up+down only.
-            c.ready = (g_ok || L.expert_gate_ids.empty()) && u_ok && d_ok;
+            c.ready = (g_ok || gate_absent) && u_ok && d_ok;
             if (c.ready) {
                 ++built_layers;
                 any_built = true;


### PR DESCRIPTION
## What

Root cause + fix for #860 (`misaligned address` on captured non-gated MoE verify graphs), in two parts:

### 1. The per-layer NVFP4 device-args cache was never built for non-gated models
The da_cache build treated "has expert gate ids" as `!empty()`, but the loader pre-sizes the id vectors on **every** layer (all-invalid entries on non-MoE and non-gated layers). On Nemotron-H (non-gated RELU² experts):
- `g_ok` was false on all 23 MoE layers → `c.ready` never set → **0/23 built** ("nothing built" bypasses the QW8 abort) → every prefill dispatch silently took the per-call H2D fallback.
- The same `empty()`-based **eligibility** check misclassified the 29 SSM/attention layers as MoE-eligible — which the QW8 gate then (correctly) tripped on once the real MoE layers started building.

Both checks now require **at least one valid id** (`any_valid_id`); non-gated layers build up+down and mark ready. Nemotron-H: `Pre-cached per-layer NVFP4 device-args ptr arrays for 23/23 layers`.

### 2. The fallback dispatch is a stack-UAF under graph capture
On a pre-cache miss, `dispatch_device` `cudaMemcpyAsync`s the B/SFB/alpha pointer arrays from **stack `std::vector`s**. Recorded into a verify graph, the memcpy node keeps the dead stack address — every replay copies whatever currently lives there: nondeterministic garbage B pointers → `misaligned address` graph launches. This was the remaining #855/#860 crash class after PR #859 (and a plausible cause of the one non-reproducible corrupt run noted in #856). The fallback now throws under an active capture (`moe_host_args_capture_guard`), and `chunk_capture_supported()` requires `per_layer_da_cache.ready` for every MoE layer — replacing the blanket non-gated exclusion from #859.

## Verification (RTX 5090, local)
- **Nemotron-3-Nano-30B-A3B-NVFP4**: da_cache 23/23; captured verify graphs record + replay cleanly — the slot-keyed hybrid graphs from #859 are live (`rec_slot=0`), 0 IMA across all runs, echo correct and deterministic per server instance. On/off outputs diverge at an early free-text near-tie (documented NVFP4-MoE property — pad rows shift expert sort order → scatter summation order), both sides coherent, accept parity.
- **Qwen3-Coder-30B-A3B-FP4** regression: 48/48 da_cache (unchanged), graphs cached, 96.2% accept, output correct, 0 IMA.
- Full GPU suite green.

## Perf note
Capture on Nemotron-H measures **~0** (fixed 500-token budget, symmetric runs: 15.49 s vs 14.97 s on/off; longer free-running trials favor capture 3/3 but diverge in content and are not cleanly comparable). The hybrid verify cycle is **Mamba2-scan-dominated, not launch-dominated**, and bucket padding scales the scan/MoE cost linearly — the #856 launch-pacing win does not transfer to Mamba2 hybrids. This ships for **correctness**: the fallback UAF could bite any future capture user, and the da_cache fix also removes 3 H2D syncs per MoE layer per eager prefill chunk on non-gated models. No perf-baseline change.

Closes #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)