### PR TITLE
feat(spec): MTP chain lm_head via NVFP4 decode cache + configurable econ guard (#847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   drafting per request when average emitted/verify cannot beat the async
   loop (measured: accept 44-91% but net-negative on current verify
   economics — see #847 for follow-ups).
+- **MTP chain lm_head via the NVFP4 decode cache** (#847 lever 3) — the MTP
+  chain's per-draft full-vocab logits GEMV reads the NVFP4 LM-head decode
+  cache when one exists (~3.5x less HBM traffic than the raw FP16 weight:
+  2.5 GB → 0.7 GB per drafted token on Qwen3.6-27B's 248k vocab).
+  `speculative.mtp_nvfp4_head` (default on) is the kill switch; draft-only
+  precision, verification stays lossless. The MTP economics-guard threshold
+  is now configurable (`speculative.mtp_econ_min_emit`, default 4.0,
+  0 disables) since the break-even moves with chain/verify costs — note a
+  chain of k emits at most k+1 tokens per verify, so k=2 cannot pass the
+  default threshold and dooms by construction.
 
 ## [0.16.0] - 2026-07-02
 

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -342,6 +342,15 @@ hybrid               = true
 # MTP chains fill verify steps where the suffix matcher has no draft.
 # imp-cli equivalent: --mtp-spec-decode <k>.
 mtp_k                = 0
+# Serve the MTP chain's full-vocab logits GEMV from the NVFP4 LM-head decode
+# cache when one exists (~4x less HBM traffic per drafted token; the chain
+# re-reads the LM head once per draft). Draft-only precision — verification
+# stays lossless. false = keep the FP16 chain GEMV.
+mtp_nvfp4_head       = true
+# MTP economics guard: after an 8-verify sample, avg emitted tokens per
+# MTP-filled verify below this dooms MTP drafting for the request. 0 disables
+# the guard. Note: a chain of k emits at most k+1 per verify.
+mtp_econ_min_emit    = 4.0
 # Graph-captured verify (#847): cache one CUDA graph per draft-length bucket
 # and replay it each verify step (all growing lengths are read from device
 # buffers), removing the eager launch-pacing tax. Engages only where the

--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -16,6 +16,7 @@
 #include "compute/activation.h"     // swiglu, shared_expert_gate_scale
 #include "compute/embedding.h"      // embedding_lookup (handles quantized tables)
 #include "compute/gemm.h"
+#include "quant/nvfp4_gemm.h"       // gemv_nvfp4_kpar_fp32 (NVFP4 chain lm_head)
 #include "compute/layernorm.h"
 #include "compute/moe_routing.h"
 #include "compute/rope.h"           // qknorm_rope_fused
@@ -51,10 +52,14 @@ __global__ void mtp_concat_kernel(const __half* __restrict__ a, const __half* __
     out[t] = (t < hidden_dim) ? a[t] : b[t - hidden_dim];
 }
 
-// Argmax over an FP16 vector [vocab_size]. Single CTA; uses shared-memory
+__device__ __forceinline__ float mtp_logit_to_float(__half v) { return __half2float(v); }
+__device__ __forceinline__ float mtp_logit_to_float(float v)  { return v; }
+
+// Argmax over an FP16/FP32 vector [vocab_size]. Single CTA; uses shared-memory
 // reduction. Writes the argmax index to *out_idx as int32. Caller must ensure
 // vocab_size fits one block (i.e., we strip-mine over vocab_size).
-__global__ void mtp_argmax_kernel(const __half* __restrict__ logits, int vocab_size,
+template <typename T>
+__global__ void mtp_argmax_kernel(const T* __restrict__ logits, int vocab_size,
                                    int* __restrict__ out_idx) {
     constexpr int kThreads = 256;
     __shared__ float s_val[kThreads];
@@ -64,7 +69,7 @@ __global__ void mtp_argmax_kernel(const __half* __restrict__ logits, int vocab_s
     float best_val = -1.0e38f;
     int   best_idx = 0;
     for (int i = tid; i < vocab_size; i += kThreads) {
-        float v = __half2float(logits[i]);
+        float v = mtp_logit_to_float(logits[i]);
         if (v > best_val) {
             best_val = v;
             best_idx = i;
@@ -85,11 +90,12 @@ __global__ void mtp_argmax_kernel(const __half* __restrict__ logits, int vocab_s
     if (tid == 0) *out_idx = s_idx[0];
 }
 
-// Top-W over an FP16 vector [vocab_size]. Single CTA; top_w (≤ kMtpMaxTopW)
+// Top-W over an FP16/FP32 vector [vocab_size]. Single CTA; top_w (≤ kMtpMaxTopW)
 // sequential argmax passes, masking previously selected indices. Writes the W
 // descending-logit indices to out_idx[0..top_w). W is tiny relative to the
 // lm_head GEMM that produced the logits, so the extra passes are cheap.
-__global__ void mtp_topk_kernel(const __half* __restrict__ logits, int vocab_size,
+template <typename T>
+__global__ void mtp_topk_kernel(const T* __restrict__ logits, int vocab_size,
                                 int top_w, int* __restrict__ out_idx) {
     constexpr int kThreads = 256;
     __shared__ float s_val[kThreads];
@@ -106,7 +112,7 @@ __global__ void mtp_topk_kernel(const __half* __restrict__ logits, int vocab_siz
                 if (s_found[f] == i) { taken = true; break; }
             }
             if (taken) continue;
-            float v = __half2float(logits[i]);
+            float v = mtp_logit_to_float(logits[i]);
             if (v > best_val) { best_val = v; best_idx = i; }
         }
         s_val[tid] = best_val;
@@ -399,6 +405,7 @@ bool mtp_workspace_allocate(MtpDraftWorkspace& ws, int hidden_dim, int vocab_siz
     ok &= alloc(&ws.d_fc_out,     hidden_dim * sizeof(__half));
     ok &= alloc(&ws.d_h_final,    hidden_dim * sizeof(__half));
     ok &= alloc(&ws.d_logits,     vocab_size * sizeof(__half));
+    ok &= alloc(&ws.d_logits_f32, vocab_size * sizeof(float));
     ok &= alloc(reinterpret_cast<void**>(&ws.d_topk), kMtpMaxTopW * sizeof(int));
 
     ws.hidden_dim   = hidden_dim;
@@ -480,6 +487,7 @@ void mtp_workspace_free(MtpDraftWorkspace& ws) {
     frfn(ws.d_fc_out);
     frfn(ws.d_h_final);
     frfn(ws.d_logits);
+    frfn(ws.d_logits_f32);
     if (ws.d_topk) { cudaFree(ws.d_topk); ws.d_topk = nullptr; }
     frfn(ws.d_post_norm);
     frfn(ws.d_router_logits);
@@ -521,7 +529,8 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     int hidden_dim, int vocab_size,
                     int* out_token_id,
                     cudaStream_t stream,
-                    int* out_topk_ids, int top_w) {
+                    int* out_topk_ids, int top_w,
+                    const NvFP4QuantResult* lm_head_nvfp4) {
     if (!mtp.loaded) {
         IMP_LOG_ERROR("mtp_draft_step: MTP head not loaded");
         return false;
@@ -986,8 +995,16 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
     if (out_token_id == nullptr)
         return true;
 
-    // Step 7: logits = lm_head @ h_final
-    {
+    // Step 7: logits = lm_head @ h_final. When an NVFP4 decode-cache view of
+    // the lm_head is available, use it — the full-vocab weight read dominates
+    // per-draft cost (~2.5 GB FP16 on Qwen3.6-27B's 248k vocab; NVFP4 reads
+    // ~4x less). Draft-only precision: verification stays lossless.
+    const bool nvfp4_lm = (lm_head_nvfp4 != nullptr && ws.d_logits_f32 != nullptr);
+    if (nvfp4_lm) {
+        gemv_nvfp4_kpar_fp32(*lm_head_nvfp4, static_cast<const half*>(ws.d_h_final),
+                             static_cast<float*>(ws.d_logits_f32), vocab_size, hidden_dim,
+                             stream);
+    } else {
         int64_t h_final_shape[2] = {1, hidden_dim};
         int64_t logits_shape[2]  = {1, vocab_size};
         Tensor h_final_view(ws.d_h_final, QType::F16, 2, h_final_shape, true);
@@ -1005,8 +1022,13 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
             IMP_LOG_ERROR("mtp_draft_step: top-W requested but ws.d_topk not allocated");
             return false;
         }
-        mtp_topk_kernel<<<1, 256, 0, stream>>>(
-            static_cast<const __half*>(ws.d_logits), vocab_size, w, ws.d_topk);
+        if (nvfp4_lm) {
+            mtp_topk_kernel<<<1, 256, 0, stream>>>(
+                static_cast<const float*>(ws.d_logits_f32), vocab_size, w, ws.d_topk);
+        } else {
+            mtp_topk_kernel<<<1, 256, 0, stream>>>(
+                static_cast<const __half*>(ws.d_logits), vocab_size, w, ws.d_topk);
+        }
         if (cudaMemcpyAsync(out_topk_ids, ws.d_topk, w * sizeof(int),
                             cudaMemcpyDeviceToHost, stream) != cudaSuccess)
             return false;
@@ -1020,8 +1042,13 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         IMP_LOG_ERROR("mtp_draft_step: argmax scratch alloc failed");
         return false;
     }
-    mtp_argmax_kernel<<<1, 256, 0, stream>>>(
-        static_cast<const __half*>(ws.d_logits), vocab_size, d_idx);
+    if (nvfp4_lm) {
+        mtp_argmax_kernel<<<1, 256, 0, stream>>>(
+            static_cast<const float*>(ws.d_logits_f32), vocab_size, d_idx);
+    } else {
+        mtp_argmax_kernel<<<1, 256, 0, stream>>>(
+            static_cast<const __half*>(ws.d_logits), vocab_size, d_idx);
+    }
     if (cudaMemcpyAsync(out_token_id, d_idx, sizeof(int),
                         cudaMemcpyDeviceToHost, stream) != cudaSuccess) {
         cudaFreeAsync(d_idx, stream);

--- a/src/compute/mtp_forward.h
+++ b/src/compute/mtp_forward.h
@@ -28,6 +28,7 @@
 namespace imp {
 
 class Model;
+struct NvFP4QuantResult;
 
 // Max top-W width the MTP draft step can emit per position (tree-ceiling
 // measurement, Stage 0). The draft argmax is top-0.
@@ -49,6 +50,9 @@ struct MtpDraftWorkspace {
     void* d_h_final = nullptr;
     // [vocab_size] FP16 — draft logits
     void* d_logits = nullptr;
+    // [vocab_size] FP32 — draft logits when the lm_head GEMV runs through the
+    // NVFP4 decode cache (gemv_nvfp4_kpar_fp32 writes FP32). ~1 MiB.
+    void* d_logits_f32 = nullptr;
     // [kMtpMaxTopW] int — top-W candidate ids (Stage 0 tree-ceiling probe).
     int*  d_topk = nullptr;
 
@@ -160,6 +164,12 @@ struct MtpDraftWorkspace {
 //                       top_w>0, receives the top-W candidate ids in
 //                       descending-logit order (out_topk_ids[0] == *out_token_id).
 //                       Used by the Stage 0 tree-ceiling measurement.
+//   - lm_head_nvfp4   : optional NVFP4 decode-cache view of main_lm_head
+//                       (GraphExecutor::lm_head_nvfp4_view). When set, the
+//                       chain logits GEMV reads ~4x less HBM than the FP16
+//                       weight — the dominant per-draft cost on large-vocab
+//                       models. Draft-only: verification stays lossless
+//                       regardless of the draft head's precision.
 //
 // Returns false on any precondition violation (mtp not loaded, null buffers).
 bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
@@ -170,7 +180,8 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     int hidden_dim, int vocab_size,
                     int* out_token_id,
                     cudaStream_t stream,
-                    int* out_topk_ids = nullptr, int top_w = 0);
+                    int* out_topk_ids = nullptr, int top_w = 0,
+                    const NvFP4QuantResult* lm_head_nvfp4 = nullptr);
 
 // Allocate the workspace from the VRAM allocator. Caller is responsible for
 // keeping ws alive (typically owned by the Engine for the lifetime of a session).

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -185,6 +185,15 @@ public:
     // LM head is NVFP4. Must run AFTER pre_dequant_weights().
     void build_lm_head_cutlass_(cudaStream_t stream);
 
+    // NVFP4 view of the LM head for the MTP draft chain's M=1 logits GEMV.
+    // Fills `out` from the secondary decode cache (wcache_.nvfp4) or the
+    // native-NVFP4 registry tier — the same sources the decode-path LM head
+    // dispatch uses. Returns false when the LM head is not NVFP4-served
+    // (cache disabled, FP8 LM head, or quantized source without a cache
+    // entry); callers then keep the FP16 GEMV. The returned pointers borrow
+    // executor-owned storage — do not free.
+    bool lm_head_nvfp4_view(NvFP4QuantResult& out) const;
+
     // Set KV layer mapping (must be called before forward pass for hybrid models)
     void set_kv_layer_map(std::vector<int> map) {
         kv_layer_map_ = std::move(map);

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -104,6 +104,39 @@ void QuantPipeline::build(const Model& model, const RuntimeConfig& rcfg, VRAMAll
     pre_dequant_phase4b_drop_redundant_sources_(cfg, stream);
 }
 
+// NVFP4 view of the LM head for the MTP draft chain — mirrors the decode-path
+// LM-head dispatch (executor_forward.cu): secondary wcache_.nvfp4 entry first,
+// then the native-NVFP4 registry tier; FP8 takes precedence and disables it.
+bool GraphExecutor::lm_head_nvfp4_view(NvFP4QuantResult& out) const {
+    if (!model_)
+        return false;
+    const Tensor& lm = model_->output_proj();
+    if (!lm.data)
+        return false;
+    if (wcache_.fp8.count(lm.data))
+        return false;
+    auto it = wcache_.nvfp4.find(lm.data);
+    if (it != wcache_.nvfp4.end()) {
+        out = it->second;
+        out.owned = false;  // borrows the decode-cache storage
+        return true;
+    }
+    if (model_->out_proj_id == kInvalidTensorID)
+        return false;
+    const WeightHandle& h = registry_.handle(model_->out_proj_id);
+    if (h.primary_tier != StorageTier::NVFP4 || h.payload.nvfp4.data == nullptr)
+        return false;
+    out.packed_data  = h.payload.nvfp4.data;
+    out.micro_scales = h.payload.nvfp4.block_scales;
+    out.tensor_scale = (h.payload.nvfp4.tensor_scale != nullptr)
+                           ? *h.payload.nvfp4.tensor_scale
+                           : 1.0f;
+    out.N = model_->config().vocab_size;
+    out.K = model_->config().d_model;
+    out.owned = false;
+    return true;
+}
+
 // Fold the scattered arch-specific overlay rules into one pass over the plan so
 // the plan reproduces what the legacy builders do (the precondition for making
 // builders plan-driven without changing behaviour). Driven by the Phase-4

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -270,6 +270,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("speculative.burst_rearm", cfg.speculative.burst_rearm);
     B("speculative.hybrid", cfg.speculative.hybrid);
     I("speculative.mtp_k", cfg.speculative.mtp_k);
+    B("speculative.mtp_nvfp4_head", cfg.speculative.mtp_nvfp4_head);
+    F("speculative.mtp_econ_min_emit", cfg.speculative.mtp_econ_min_emit);
     B("speculative.capture", cfg.speculative.capture);
     I("speculative.capture_ctx_cap", cfg.speculative.capture_ctx_cap);
 

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -576,6 +576,21 @@ struct RuntimeConfig {
         // match (draft-poor prose — 78-94% depth-1 accept on Qwen3.6-35B-A3B,
         // PR #804). imp-cli equivalent: --mtp-spec-decode <k>.
         int mtp_k = 0;
+        // Serve the MTP chain's full-vocab logits GEMV from the NVFP4 LM-head
+        // decode cache when one exists (#847 lever 3). The chain re-reads the
+        // LM head once per drafted token (~2.5 GB FP16 on Qwen3.6-27B's 248k
+        // vocab — more traffic than the main forward at k=4); NVFP4 reads ~4x
+        // less. Draft-only precision, verification stays lossless. Off = keep
+        // the FP16 chain GEMV (A/B kill switch).
+        bool mtp_nvfp4_head = true;
+        // MTP economics guard: after an 8-verify sample, average emitted
+        // tokens per MTP-filled verify below this dooms MTP drafting for the
+        // request (the verify chunk + chain cost can't amortize). 0 disables
+        // the guard (raw-economics measurement). Default from the #852
+        // break-even measurement; re-derive when chain/verify costs change —
+        // note a chain of k can emit at most k+1 per verify, so values >= k+1
+        // doom that k unconditionally.
+        float mtp_econ_min_emit = 4.0f;
         // Graph-captured verify chunk (#847): cache one CUDA graph per
         // draft-length bucket and replay it each verify step — the chunk
         // metadata and KV lengths are read from device buffers, so the graph

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -283,10 +283,26 @@ bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
         return false;
     }
     auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
+    // Chain lm_head via the NVFP4 decode cache when available: the full-vocab
+    // FP16 GEMV is the dominant per-draft cost (#847 lever 3). Draft-only
+    // precision — verify stays lossless. Falls back to the FP16 GEMV when no
+    // cache entry exists (nvfp4_lm_head/_gdn off, or FP8 LM head).
+    imp::NvFP4QuantResult lm_nvfp4;
+    const imp::NvFP4QuantResult* lm_nvfp4_p = nullptr;
+    if (runtime_config_.speculative.mtp_nvfp4_head && executor_ &&
+        executor_->lm_head_nvfp4_view(lm_nvfp4)) {
+        lm_nvfp4_p = &lm_nvfp4;
+        static bool logged = false;  // once-per-process path attribution
+        if (!logged) {
+            logged = true;
+            IMP_LOG_INFO("MTP chain lm_head: NVFP4 decode-cache view engaged (N=%lld K=%lld)",
+                         static_cast<long long>(lm_nvfp4.N), static_cast<long long>(lm_nvfp4.K));
+        }
+    }
     return imp::mtp_draft_step(prev_token_id, d_h_prev, *model_->mtp_,
                                 model_->tok_emb_, model_->out_proj_,
                                 *ws, hidden_dim, vocab_size, out_token_id,
-                                decode_stream(), out_topk_ids, top_w);
+                                decode_stream(), out_topk_ids, top_w, lm_nvfp4_p);
 }
 
 // =====================================================================

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -636,10 +636,14 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     if (draft_from_mtp) {
         mtp_econ_verifies_++;
         mtp_econ_emitted_ += emitted;
-        constexpr int kMtpEconSample = 8;        // fair sample before judging
-        constexpr int kMtpEconMinEmitx10 = 40;   // avg emitted/verify >= 4.0
-        if (mtp_econ_verifies_ >= kMtpEconSample &&
-            mtp_econ_emitted_ * 10 < static_cast<long long>(mtp_econ_verifies_) * kMtpEconMinEmitx10)
+        constexpr int kMtpEconSample = 8;  // fair sample before judging
+        // Break-even avg emitted/verify is configurable (0 disables): the
+        // right value depends on the chain lm_head cost (NVFP4 vs FP16) and
+        // the verify-chunk cost, both of which have moved since #852.
+        const float min_emit = runtime_config_.speculative.mtp_econ_min_emit;
+        if (min_emit > 0.0f && mtp_econ_verifies_ >= kMtpEconSample &&
+            static_cast<float>(mtp_econ_emitted_) <
+                static_cast<float>(mtp_econ_verifies_) * min_emit)
             mtp_unbind_("uneconomic: avg emitted/verify below break-even");
     }
     const bool acceptance_poor =

--- a/tests/test_mtp_forward.cpp
+++ b/tests/test_mtp_forward.cpp
@@ -17,6 +17,7 @@
 #include "model/safetensors_loader.h"
 #include "runtime/engine.h"
 #include "compute/mtp_forward.h"
+#include "quant/nvfp4_quant.h"
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
@@ -132,6 +133,37 @@ TEST(MtpForwardTest, DraftStepProducesValidToken) {
     EXPECT_GE(out_token_id, 0);
     EXPECT_LT(out_token_id, vocab_size);
 
+    // NVFP4 chain lm_head (#847 lever 3): quantize the FP16 lm_head the same
+    // way the decode cache does, then draft through the NVFP4 GEMV + FP32
+    // argmax path. Same synthetic inputs — assert a valid token and that the
+    // NVFP4 path is deterministic against itself.
+    imp::NvFP4QuantResult lm4{};
+    imp::quantize_fp16_to_nvfp4(model->out_proj_, lm4, /*stream=*/nullptr);
+    ASSERT_NE(lm4.packed_data, nullptr);
+    ASSERT_NE(lm4.micro_scales, nullptr);
+
+    int out_token_nvfp4 = -1;
+    imp::mtp_kv_reset(ws);
+    ok = imp::mtp_draft_step(123, d_h_prev, *model->mtp_, model->tok_emb_,
+                             model->out_proj_, ws, hidden_dim, vocab_size,
+                             &out_token_nvfp4, /*stream=*/nullptr,
+                             /*out_topk_ids=*/nullptr, /*top_w=*/0, &lm4);
+    EXPECT_TRUE(ok) << "mtp_draft_step (NVFP4 lm_head) returned false";
+    EXPECT_GE(out_token_nvfp4, 0);
+    EXPECT_LT(out_token_nvfp4, vocab_size);
+
+    int out_token_nvfp4_b = -1;
+    imp::mtp_kv_reset(ws);
+    ok = imp::mtp_draft_step(123, d_h_prev, *model->mtp_, model->tok_emb_,
+                             model->out_proj_, ws, hidden_dim, vocab_size,
+                             &out_token_nvfp4_b, /*stream=*/nullptr,
+                             /*out_topk_ids=*/nullptr, /*top_w=*/0, &lm4);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(out_token_nvfp4, out_token_nvfp4_b)
+        << "NVFP4 chain lm_head draft is not deterministic";
+
+    if (lm4.packed_data) cudaFree(lm4.packed_data);
+    if (lm4.micro_scales) cudaFree(lm4.micro_scales);
     cudaFree(d_h_prev);
     imp::mtp_workspace_free(ws);
 }


### PR DESCRIPTION
## What

**Lever 3 from the #847 ranking**: the MTP chain's per-draft full-vocab logits GEMV bypassed the NVFP4 LM-head decode cache and re-read the raw FP16 weight — ~2.5 GB per drafted token on Qwen3.6-27B (248320×5120), more traffic than the main forward at k=4.

- `GraphExecutor::lm_head_nvfp4_view()` — NVFP4 view of the LM head from the same sources as the decode-path dispatch (secondary `wcache_.nvfp4` entry, else native-NVFP4 registry tier; FP8 takes precedence). Borrowed storage, nothing to free.
- `mtp_draft_step` takes the view optionally and serves the chain GEMV via `gemv_nvfp4_kpar_fp32` (~0.7 GB per draft, ~3.5x less HBM), FP32 logits buffer + argmax/top-W kernels templated on the logits dtype. Feed-only steps unaffected.
- `speculative.mtp_nvfp4_head` (default **on**) is the kill switch. Draft-only precision — verification stays lossless. Once-per-process attribution log.
- **Econ guard now configurable**: `speculative.mtp_econ_min_emit` (default 4.0, 0 disables). The old `constexpr` 4.0 doomed k=2 by construction (a chain of k emits at most k+1 per verify) and the break-even moves with chain/verify costs.

## Measured (Qwen3.6-27B-Text-NVFP4-MTP, greedy, fixed 500-token budget)

Honest verdict — **MTP-only economics stay structurally negative on the 27B** even after #854/#856/#857 + this lever (full data in the #847 comment):

- MTP-only verify cycle costs **~85–90 ms** vs ~11.2 ms per async loop step. Even at 100% accept, k=4 (max 5 emitted/verify) tops out at ~55 tok/s vs 89 tok/s async — no accept rate can win until the per-verify cost drops (27B is a GDN hybrid: verify chunk stays eager, no #856 capture; plus hybrid partial-accept replay).
- The NVFP4-chain delta (theoretical ~2.6 ms/verify at k=2, ~5 ms at k=4) is **below the ±10–12% cross-process noise floor** — no regression measured in either direction; the lever is kernel-math-justified (same GEMV family as the main-decode NVFP4 lm_head, measured +11.4% there).
- Bimodal side-finding: with suffix ON + MTP k=2 (guard off), draft-poor story runs land at **155 tok/s** (content branch turns repetitive → MTP keeps the request in the verify loop, suffix piggybacks: 89% accept, 11.6 tok/verify) or **~29 tok/s** (creative branch) — base async is content-independent ~89. The default guard bounds the downside.

## Gates

- `MtpForwardTest` extended: NVFP4 chain path on the real 35B checkpoint (valid token + self-determinism) — green.
- `verify --fast`: full gtest suite, e2e lane split, decode/prefill/long-ctx perf gates **PASS**. The graphs-ON/OFF gate read 1.07–1.26x (<1.3x) — **pre-existing/host-state, not this branch**: the unmodified `ghcr.io/kekzl/imp:latest` (main) reads **1.008x** under the same conditions, and the run itself flagged the depressed-host signature (#526; mem 13801 MHz, power ≤319 W). All changes are MTP-gated (default path untouched).

Closes nothing; continues #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)