### PR TITLE
perf(nvfp4): small-M batched GEMV replaces per-chunk dequant fallback in gemm_nvfp4 (#847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Changed
+- **Small-M NVFP4 GEMM: batched GEMV replaces the dequant fallback** — for
+  M ≤ 16 (spec-verify chunks of drafts+1, short/boundary prefills),
+  `gemm_nvfp4` now runs the batched-M K-parallel GEMV (weight read once per
+  MR=4 tile at 0.25x FP16 bytes) instead of dequantizing the whole weight to
+  FP16 and calling cuBLAS (~2.25x FP16 bytes, re-paid EVERY chunk). nsys on
+  Qwen3.6-27B MTP-only verify: `dequantize_nvfp4_kernel` drops from 48% to
+  4% of GPU time; ms/verify k=2 ~77 → ~60, k=4 ~87 → ~76; Coder-30B echo
+  verify unregressed. `beta != 0`, non-F16 tensors, and the
+  `nvfp4-force-dequant` bisect flag keep the fallback.
+
 ### Added
 - **Speculative decoding on hybrid (GDN/SSM) models** — `speculative.hybrid`
   (default on; imp-cli `--bench` pins it off): the verify chunk snapshots the

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -4,6 +4,7 @@
 #include "core/tensor.h"
 #include "core/logging.h"
 #include "runtime/pdl.h"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cublasLt.h>
@@ -111,6 +112,15 @@ static void* s_nvfp4_dequant_buf = nullptr;
 static size_t s_nvfp4_dequant_buf_size = 0;
 static std::mutex s_nvfp4_dequant_mtx;
 
+// FP32 -> FP16 copy for the small-M batched-GEMV path (the batched kernel
+// accumulates and writes FP32; gemm_nvfp4's contract is an FP16 C).
+__global__ void nvfp4_fp32_to_fp16_kernel(const float* __restrict__ in, __half* __restrict__ out,
+                                          int64_t n) {
+    int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < n)
+        out[i] = __float2half(in[i]);
+}
+
 // Pre-allocated workspace from the executor. When set, ensure_dequant_buffer
 // uses this instead of the lazy cudaMalloc path — which would fail inside
 // CUDA stream capture. Lifetime owned by caller of set_nvfp4_dequant_workspace.
@@ -187,6 +197,36 @@ void gemm_nvfp4(const NvFP4QuantResult& A, const Tensor& B, Tensor& C, cudaStrea
     if (M == 1) {
         gemv_nvfp4(A, B, C, stream);
         return;
+    }
+
+    // Small-M chunks (spec-verify: M = drafts+1, short/boundary prefills): the
+    // dequant fallback below rewrites the whole FP16 weight EVERY call — on
+    // Qwen3.6-27B MTP-only verify that was 49% of all GPU time (nsys, ~52
+    // dequants x ~600 us per verify). The batched-M GEMV reads the NVFP4
+    // weight once per MR=4 tile instead: at M<=16 that is <=4 passes at 0.25x
+    // FP16 bytes vs the fallback's ~2.25x (dequant read+write + GEMM read).
+    // beta!=0, non-F16 output, and the nvfp4-force-dequant bisect flag keep
+    // the fallback. FP32 accumulate + convert — same numerics class as the
+    // M=1 decode GEMV.
+    constexpr int64_t kSmallMBatchedGemv = 16;
+    if (M <= kSmallMBatchedGemv && beta == 0.0f && B.qtype == QType::F16 &&
+        C.qtype == QType::F16 && !process_diag_nvfp4_force_dequant()) {
+        std::lock_guard<std::mutex> lock(s_nvfp4_dequant_mtx);
+        const size_t y32_bytes = static_cast<size_t>(M * N) * sizeof(float);
+        void* y32 = ensure_dequant_buffer(y32_bytes, stream);
+        if (y32 != nullptr) {
+            gemv_nvfp4_kpar_batched_fp32(A, reinterpret_cast<const half*>(B.data),
+                                         static_cast<float*>(y32), static_cast<int>(N),
+                                         static_cast<int>(K), static_cast<int>(M), stream);
+            const int64_t total = M * N;
+            const int block = 256;
+            const int grid = static_cast<int>((total + block - 1) / block);
+            nvfp4_fp32_to_fp16_kernel<<<grid, block, 0, stream>>>(
+                static_cast<const float*>(y32), reinterpret_cast<half*>(C.data), total);
+            return;
+        }
+        // Scratch unavailable (capture-active without workspace): fall through —
+        // the dequant path below throws the loud capture error.
     }
 
     // Fallback path: dequantize full weight matrix to FP16 and use cuBLAS GEMM.

--- a/tests/test_gemm_kernel_registry.cu
+++ b/tests/test_gemm_kernel_registry.cu
@@ -632,6 +632,67 @@ TEST_F(GemmKernelRegistryTest, Nvfp4GemmRegistryDispatchMatchesDirectPath) {
     cudaFree(d_out_registry);
 }
 
+// Small-M gemm_nvfp4 routes through the batched-M GEMV (spec-verify chunks:
+// M = drafts+1) instead of the dequant→cuBLAS fallback. Correctness oracle:
+// each output row must match the proven M=1 decode GEMV (same kpar quant
+// math, FP32 accumulate) within FP16 rounding of the accumulation order.
+TEST_F(GemmKernelRegistryTest, Nvfp4GemmSmallMBatchedGemvMatchesPerRowGemv) {
+    constexpr int M = 5;   // verify-chunk-like (k=4 drafts + 1)
+    constexpr int N = 32;
+    constexpr int K = 128;  // multiple of micro-block (16)
+
+    std::vector<__half> h_input(M * K);
+    std::vector<__half> h_weight_fp16(N * K);
+    for (int i = 0; i < M * K; ++i) h_input[i] = __float2half(((i * 13) % 9) * 0.03125f - 0.125f);
+    for (int i = 0; i < N * K; ++i) h_weight_fp16[i] = __float2half(((i * 7) % 11) * 0.03125f - 0.15625f);
+
+    __half *d_input = nullptr, *d_weight_fp16 = nullptr;
+    cudaMalloc(&d_input, sizeof(__half) * M * K);
+    cudaMalloc(&d_weight_fp16, sizeof(__half) * N * K);
+    cudaMemcpy(d_input, h_input.data(), sizeof(__half) * M * K, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_weight_fp16, h_weight_fp16.data(), sizeof(__half) * N * K, cudaMemcpyHostToDevice);
+
+    int64_t in_shape[2] = {M, K};
+    int64_t w_shape[2] = {N, K};
+    int64_t out_shape[2] = {M, N};
+    Tensor input(d_input, QType::F16, 2, in_shape, /*on_device=*/true);
+    Tensor weight_fp16(d_weight_fp16, QType::F16, 2, w_shape, /*on_device=*/true);
+
+    NvFP4QuantResult nv4{};
+    quantize_fp16_to_nvfp4(weight_fp16, nv4, stream_);
+
+    // Path 1: gemm_nvfp4 with M=5 (takes the small-M batched-GEMV route).
+    __half* d_out_gemm = nullptr;
+    cudaMalloc(&d_out_gemm, sizeof(__half) * M * N);
+    Tensor out_gemm(d_out_gemm, QType::F16, 2, out_shape, /*on_device=*/true);
+    gemm_nvfp4(nv4, input, out_gemm, stream_);
+
+    // Path 2: per-row M=1 decode GEMV (proven path).
+    __half* d_out_rows = nullptr;
+    cudaMalloc(&d_out_rows, sizeof(__half) * M * N);
+    for (int m = 0; m < M; ++m) {
+        gemv_nvfp4_kpar(nv4, d_input + static_cast<int64_t>(m) * K,
+                        d_out_rows + static_cast<int64_t>(m) * N, N, K, stream_);
+    }
+    cudaStreamSynchronize(stream_);
+
+    std::vector<__half> h_out_gemm(M * N), h_out_rows(M * N);
+    cudaMemcpy(h_out_gemm.data(), d_out_gemm, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_out_rows.data(), d_out_rows, sizeof(__half) * M * N, cudaMemcpyDeviceToHost);
+
+    for (int i = 0; i < M * N; ++i) {
+        const float a = __half2float(h_out_gemm[i]);
+        const float b = __half2float(h_out_rows[i]);
+        EXPECT_NEAR(a, b, 5e-3f) << "row " << i / N << " col " << i % N;
+    }
+
+    free_nvfp4_result(nv4);
+    cudaFree(d_input);
+    cudaFree(d_weight_fp16);
+    cudaFree(d_out_gemm);
+    cudaFree(d_out_rows);
+}
+
 // End-to-end correctness: register-then-dispatch produces the same output
 // as calling gemm() directly. Uses small dims so the test is fast.
 TEST_F(GemmKernelRegistryTest, Fp16RegistryDispatchMatchesDirectGemm) {


### PR DESCRIPTION
## What

`gemm_nvfp4`'s M>1 path always dequantized the **whole NVFP4 weight to FP16 and ran cuBLAS** — re-paid on every call. On spec-verify chunks (M = drafts+1) this dominated: nsys on the Qwen3.6-27B MTP-only verify cycle showed **`dequantize_nvfp4_kernel` at 49% of all GPU time** (~52 dequants × ~600 µs per verify ≈ 31 ms/verify).

For **M ≤ 16** the call now routes through `gemv_nvfp4_kpar_batched_fp32` (the #854 batched-M kernel: weight read once per MR=4 tile, 0.25× FP16 bytes vs ~2.25× for the fallback's dequant read+write+GEMM read) plus an FP32→FP16 convert. Guards: `beta != 0`, non-F16 in/out, and the `nvfp4-force-dequant` bisect flag keep the old fallback; the FP32 scratch reuses the pre-allocated dequant workspace, so capture semantics are unchanged (fail-loud when uncovered, per #858).

## Measured (RTX 5090)

- **nsys, 27B MTP-only verify (k=4)**: `dequantize_nvfp4_kernel` **48% → 4.2%** of GPU time (1085 → 139 instances; the rest is CUTLASS chunk GEMMs at 45%, GDN FP16 GEMVs, conv/scan).
- **ms/verify (fixed 500-tok budget, MTP-only)**: k=2 **~77 → ~60**, k=4 **~87 → ~76**; MTP-only e2e 27–32 → 34–39 tok/s. (Still econ-negative vs the 89 tok/s async loop — the remaining ~30 ms/verify is host-gap, next slice in #847.)
- **Coder-30B-FP4 echo verify** (captured graphs, MoE): branch 769–855 tok/s vs main image 312–488 in the same window — no regression, likely a gain (short-run noise; measured in a depressed-host window, relative comparison only).
- Full GPU suite green; degeneration probe on the 27B clean (800 tok, no repetition, stderr clean); new parity test `Nvfp4GemmSmallMBatchedGemvMatchesPerRowGemv` (small-M batched path vs proven per-row M=1 GEMV).
- `verify --fast`: suite/e2e/prefill/long-ctx/smoke PASS; decode WARN + graphs-gate FAIL are the **documented depressed-host state** (the gate itself flagged the #526 signature: mem 7001 MHz median vs healthy 13801; unmodified main reads 1.008x on the same gate). The Q8 decode path does not touch this diff.

Chunk-forward numerics change class (FP32-acc GEMV instead of dequant+cuBLAS) — same accumulate class as the proven M=1 decode GEMV; near-tie chunk-vs-decode flips remain in the documented #824 property class.

Continues #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)