### PR TITLE
refactor(spec): device-side MTP draft chain — one D2H per chain instead of k host round-trips (#847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   4% of GPU time; ms/verify k=2 ~77 → ~60, k=4 ~87 → ~76; Coder-30B echo
   verify unregressed. `beta != 0`, non-F16 tensors, and the
   `nvfp4-force-dequant` bisect flag keep the fallback.
+- **Device-side MTP draft chain** (dense MTP heads) — chain step i's argmax
+  lands in a device slot and feeds step i+1's embedding lookup on-device;
+  one D2H + sync drains the whole chain instead of one host round-trip per
+  drafted token (process StreamSynchronize count roughly halved on an
+  MTP-only run; e2e-neutral today — the verify wall is elsewhere — but
+  required groundwork for capturing the chain into a CUDA graph). MoE MTP
+  heads keep the host loop (expert routing needs a per-step D2H). Also:
+  persistent argmax scratch replaces a per-draft cudaMallocAsync/Free pair.
 
 ### Added
 - **Speculative decoding on hybrid (GDN/SSM) models** — `speculative.hybrid`

--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -407,6 +407,8 @@ bool mtp_workspace_allocate(MtpDraftWorkspace& ws, int hidden_dim, int vocab_siz
     ok &= alloc(&ws.d_logits,     vocab_size * sizeof(__half));
     ok &= alloc(&ws.d_logits_f32, vocab_size * sizeof(float));
     ok &= alloc(reinterpret_cast<void**>(&ws.d_topk), kMtpMaxTopW * sizeof(int));
+    ok &= alloc(reinterpret_cast<void**>(&ws.d_chain_tokens), kMtpMaxChainK * sizeof(int32_t));
+    ok &= alloc(reinterpret_cast<void**>(&ws.d_argmax), sizeof(int));
 
     ws.hidden_dim   = hidden_dim;
     ws.n_experts    = n_experts;
@@ -489,6 +491,8 @@ void mtp_workspace_free(MtpDraftWorkspace& ws) {
     frfn(ws.d_logits);
     frfn(ws.d_logits_f32);
     if (ws.d_topk) { cudaFree(ws.d_topk); ws.d_topk = nullptr; }
+    if (ws.d_chain_tokens) { cudaFree(ws.d_chain_tokens); ws.d_chain_tokens = nullptr; }
+    if (ws.d_argmax) { cudaFree(ws.d_argmax); ws.d_argmax = nullptr; }
     frfn(ws.d_post_norm);
     frfn(ws.d_router_logits);
     frfn(ws.d_expert_gate_up);
@@ -530,7 +534,9 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     int* out_token_id,
                     cudaStream_t stream,
                     int* out_topk_ids, int top_w,
-                    const NvFP4QuantResult* lm_head_nvfp4) {
+                    const NvFP4QuantResult* lm_head_nvfp4,
+                    const int32_t* d_prev_token,
+                    int32_t* d_out_token) {
     if (!mtp.loaded) {
         IMP_LOG_ERROR("mtp_draft_step: MTP head not loaded");
         return false;
@@ -545,7 +551,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         IMP_LOG_ERROR("mtp_draft_step: main embedding or lm_head not on GPU");
         return false;
     }
-    if (prev_token_id < 0 || prev_token_id >= vocab_size) {
+    if (d_prev_token == nullptr && (prev_token_id < 0 || prev_token_id >= vocab_size)) {
         IMP_LOG_ERROR("mtp_draft_step: token_id %d out of range [0,%d)",
                       prev_token_id, vocab_size);
         return false;
@@ -557,7 +563,14 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
     // raw FP16 produces garbage — every "embedding" decoded to the same
     // bit pattern, locking MTP predictions to a single token regardless
     // of input. imp::embedding_lookup handles the qtype dispatch.
-    {
+    if (d_prev_token != nullptr) {
+        // Device-chain input: the previous step's argmax already lives on
+        // device — no upload, no scratch.
+        int64_t out_shape[2] = {1, hidden_dim};
+        Tensor  out_view(ws.d_fc_in, QType::F16, 2, out_shape, /*on_device=*/true);
+        imp::embedding_lookup(main_tok_emb, d_prev_token, /*n_tokens=*/1, out_view,
+                              main_tok_emb.qtype, stream);
+    } else {
         // Upload prev_token_id to a tiny device buffer so embedding_lookup
         // can dispatch with the correct signature. (The graph-friendly
         // _from_device overload also exists if needed.)
@@ -992,7 +1005,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
 
     // Feed-only step (prefill / verify catch-up): the KV append above is the
     // whole point — skip the lm_head GEMV, argmax and stream sync.
-    if (out_token_id == nullptr)
+    if (out_token_id == nullptr && d_out_token == nullptr)
         return true;
 
     // Step 7: logits = lm_head @ h_final. When an NVFP4 decode-cache view of
@@ -1010,6 +1023,19 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         Tensor h_final_view(ws.d_h_final, QType::F16, 2, h_final_shape, true);
         Tensor logits_view (ws.d_logits,  QType::F16, 2, logits_shape,  true);
         imp::gemm(h_final_view, main_lm_head, logits_view, 1.0f, 0.0f, stream);
+    }
+
+    // Step 8 (device chain): argmax straight into the caller's device slot —
+    // no D2H, no sync; the caller drains the chain in one copy at the end.
+    if (d_out_token != nullptr) {
+        if (nvfp4_lm) {
+            mtp_argmax_kernel<<<1, 256, 0, stream>>>(
+                static_cast<const float*>(ws.d_logits_f32), vocab_size, d_out_token);
+        } else {
+            mtp_argmax_kernel<<<1, 256, 0, stream>>>(
+                static_cast<const __half*>(ws.d_logits), vocab_size, d_out_token);
+        }
+        return true;
     }
 
     // Step 8: argmax (or top-W) → device int → D2H.
@@ -1037,10 +1063,16 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         return true;
     }
 
-    int* d_idx = nullptr;
-    if (cudaMallocAsync(&d_idx, sizeof(int), stream) != cudaSuccess) {
-        IMP_LOG_ERROR("mtp_draft_step: argmax scratch alloc failed");
-        return false;
+    // Host path: persistent argmax scratch (ws.d_argmax) — a per-draft
+    // cudaMallocAsync/cudaFreeAsync pair costs host time on the chain.
+    int* d_idx = ws.d_argmax;
+    bool owned_idx = false;
+    if (d_idx == nullptr) {
+        if (cudaMallocAsync(&d_idx, sizeof(int), stream) != cudaSuccess) {
+            IMP_LOG_ERROR("mtp_draft_step: argmax scratch alloc failed");
+            return false;
+        }
+        owned_idx = true;
     }
     if (nvfp4_lm) {
         mtp_argmax_kernel<<<1, 256, 0, stream>>>(
@@ -1051,10 +1083,10 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
     }
     if (cudaMemcpyAsync(out_token_id, d_idx, sizeof(int),
                         cudaMemcpyDeviceToHost, stream) != cudaSuccess) {
-        cudaFreeAsync(d_idx, stream);
+        if (owned_idx) cudaFreeAsync(d_idx, stream);
         return false;
     }
-    cudaFreeAsync(d_idx, stream);
+    if (owned_idx) cudaFreeAsync(d_idx, stream);
     cudaStreamSynchronize(stream);
     return true;
 }

--- a/src/compute/mtp_forward.h
+++ b/src/compute/mtp_forward.h
@@ -34,6 +34,10 @@ struct NvFP4QuantResult;
 // measurement, Stage 0). The draft argmax is top-0.
 constexpr int kMtpMaxTopW = 8;
 
+// Max device-side chain length (capacity of MtpDraftWorkspace::d_chain_tokens).
+// Longer speculative.mtp_k values fall back to the host chain loop.
+constexpr int kMtpMaxChainK = 16;
+
 // Workspace tensors needed for one draft step. Caller pre-allocates these so
 // the draft step is graph-safe (no cudaMalloc inside captured graph).
 struct MtpDraftWorkspace {
@@ -55,6 +59,13 @@ struct MtpDraftWorkspace {
     void* d_logits_f32 = nullptr;
     // [kMtpMaxTopW] int — top-W candidate ids (Stage 0 tree-ceiling probe).
     int*  d_topk = nullptr;
+    // [kMtpMaxChainK] int — device-side chain slots: step i's argmax lands in
+    // d_chain_tokens[i] and feeds step i+1's embedding lookup without a host
+    // round-trip; one D2H of the whole chain at the end.
+    int32_t* d_chain_tokens = nullptr;
+    // [1] int — persistent argmax scratch for the host-path draft step
+    // (replaces a per-draft cudaMallocAsync/cudaFreeAsync pair).
+    int*  d_argmax = nullptr;
 
     // ---- Phase 2.2 MoE scratch ----
     // [hidden_dim] FP16 — post_attention_layernorm(fc_out)
@@ -170,6 +181,14 @@ struct MtpDraftWorkspace {
 //                       weight — the dominant per-draft cost on large-vocab
 //                       models. Draft-only: verification stays lossless
 //                       regardless of the draft head's precision.
+//   - d_prev_token    : device-chain input — read the previous token id from
+//                       this device int instead of prev_token_id (which is
+//                       then ignored, pass -1). No H2D upload, no host
+//                       bounds check (validate the chain once after D2H).
+//   - d_out_token     : device-chain output — write the argmax to this device
+//                       int; NO D2H copy, NO stream sync (out_token_id and
+//                       the top-W path are ignored). The caller drains the
+//                       whole chain with a single D2H + sync.
 //
 // Returns false on any precondition violation (mtp not loaded, null buffers).
 bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
@@ -181,7 +200,9 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     int* out_token_id,
                     cudaStream_t stream,
                     int* out_topk_ids = nullptr, int top_w = 0,
-                    const NvFP4QuantResult* lm_head_nvfp4 = nullptr);
+                    const NvFP4QuantResult* lm_head_nvfp4 = nullptr,
+                    const int32_t* d_prev_token = nullptr,
+                    int32_t* d_out_token = nullptr);
 
 // Allocate the workspace from the VRAM allocator. Caller is responsible for
 // keeping ws alive (typically owned by the Engine for the lifetime of a session).

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -273,7 +273,8 @@ void Engine::mtp_accuracy_reset() noexcept {
 
 bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
                            int hidden_dim, int vocab_size, int* out_token_id,
-                           int* out_topk_ids, int top_w) {
+                           int* out_topk_ids, int top_w,
+                           const int32_t* d_prev_token, int32_t* d_out_token) {
     if (mtp_ws_storage_ == nullptr) {
         IMP_LOG_ERROR("mtp_draft_one: spec-decode not enabled");
         return false;
@@ -302,7 +303,8 @@ bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
     return imp::mtp_draft_step(prev_token_id, d_h_prev, *model_->mtp_,
                                 model_->tok_emb_, model_->out_proj_,
                                 *ws, hidden_dim, vocab_size, out_token_id,
-                                decode_stream(), out_topk_ids, top_w, lm_nvfp4_p);
+                                decode_stream(), out_topk_ids, top_w, lm_nvfp4_p,
+                                d_prev_token, d_out_token);
 }
 
 // =====================================================================

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -198,7 +198,9 @@ public:
     // should not invoke directly until Phase 4 wires this into the decode loop.
     bool mtp_draft_one(int prev_token_id, const void* d_h_prev,
                        int hidden_dim, int vocab_size, int* out_token_id,
-                       int* out_topk_ids = nullptr, int top_w = 0);
+                       int* out_topk_ids = nullptr, int top_w = 0,
+                       const int32_t* d_prev_token = nullptr,
+                       int32_t* d_out_token = nullptr);
 
     // Feed one prefill chunk's (token, hidden) pairs into the MTP-side KV
     // cache so the head enters decode with the same context as the main

--- a/src/runtime/engine_spec_mtp.cpp
+++ b/src/runtime/engine_spec_mtp.cpp
@@ -72,34 +72,80 @@ bool Engine::mtp_feed_pairs_(const int32_t* tokens, const void* d_hidden_rows, i
     if (ws->max_seq_len > 0 && ws->mtp_pos + n_pairs + (chain_after ? K : 0) > ws->max_seq_len)
         return false;
 
+    // Device-side chain: dense MTP heads have no host dependency between
+    // chain steps (the MoE head's expert routing needs a per-step D2H) —
+    // each step's argmax lands in ws->d_chain_tokens[i] and feeds step i+1's
+    // embedding lookup on device. One D2H + sync drains the whole chain,
+    // replacing K host round-trips (each of which stalls the GPU pipeline).
+    const bool device_chain = chain_after && ws->n_experts == 0 &&
+                              ws->d_chain_tokens != nullptr && K <= imp::kMtpMaxChainK;
+
     const char* base = static_cast<const char*>(d_hidden_rows);
     int pred = -1;
     for (int j = 0; j < n_pairs; ++j) {
         const void* h_j = base + static_cast<size_t>(j) * hidden_dim * sizeof(__half);
-        int* out = (chain_after && j == n_pairs - 1) ? &pred : nullptr;
-        if (!mtp_draft_one(tokens[j], h_j, hidden_dim, vocab_size, out))
-            return false;
+        const bool last = (j == n_pairs - 1);
+        if (chain_after && last && device_chain) {
+            if (!mtp_draft_one(tokens[j], h_j, hidden_dim, vocab_size, nullptr,
+                               nullptr, 0, nullptr, /*d_out_token=*/ws->d_chain_tokens))
+                return false;
+        } else {
+            int* out = (chain_after && last) ? &pred : nullptr;
+            if (!mtp_draft_one(tokens[j], h_j, hidden_dim, vocab_size, out))
+                return false;
+        }
         mtp_history_.push_back(tokens[j]);
     }
     if (!chain_after)
         return true;
-    if (pred < 0 || pred >= vocab_size)
-        return false;
 
     // Chain: continue on the head's own h_final. The chained KV appends are
     // speculative — roll the cache back so only the real pairs persist.
     const int pos_after = ws->mtp_pos;
     std::vector<int32_t> chain;
     chain.reserve(K);
-    chain.push_back(pred);
-    int prev = pred;
-    for (int k = 1; k < K; ++k) {
-        int p = -1;
-        if (!mtp_draft_one(prev, ws->d_h_final, hidden_dim, vocab_size, &p) || p < 0 ||
-            p >= vocab_size)
-            break;
-        chain.push_back(p);
-        prev = p;
+    if (device_chain) {
+        int launched = 1;  // d_chain_tokens[0] came from the last feed pair
+        for (int k = 1; k < K; ++k) {
+            if (!mtp_draft_one(-1, ws->d_h_final, hidden_dim, vocab_size, nullptr,
+                               nullptr, 0, /*d_prev_token=*/ws->d_chain_tokens + k - 1,
+                               /*d_out_token=*/ws->d_chain_tokens + k))
+                break;
+            launched++;
+        }
+        int32_t h_chain[imp::kMtpMaxChainK];
+        cudaStream_t stream = decode_stream();
+        if (cudaMemcpyAsync(h_chain, ws->d_chain_tokens,
+                            static_cast<size_t>(launched) * sizeof(int32_t),
+                            cudaMemcpyDeviceToHost, stream) != cudaSuccess) {
+            ws->mtp_pos = pos_after;
+            return false;
+        }
+        cudaStreamSynchronize(stream);
+        for (int k = 0; k < launched; ++k) {
+            if (h_chain[k] < 0 || h_chain[k] >= vocab_size)
+                break;  // NaN-logits guard — keep the valid prefix
+            chain.push_back(h_chain[k]);
+        }
+        if (chain.empty()) {
+            ws->mtp_pos = pos_after;
+            return false;
+        }
+    } else {
+        if (pred < 0 || pred >= vocab_size) {
+            ws->mtp_pos = pos_after;
+            return false;
+        }
+        chain.push_back(pred);
+        int prev = pred;
+        for (int k = 1; k < K; ++k) {
+            int p = -1;
+            if (!mtp_draft_one(prev, ws->d_h_final, hidden_dim, vocab_size, &p) || p < 0 ||
+                p >= vocab_size)
+                break;
+            chain.push_back(p);
+            prev = p;
+        }
     }
     ws->mtp_pos = pos_after;
     mtp_pending_draft_ = std::move(chain);


### PR DESCRIPTION
## What

Dense MTP heads chain their k draft steps **on-device**: step i's argmax is written to `ws.d_chain_tokens[i]` and read by step i+1's embedding lookup (device-pointer dispatch already existed); a single D2H + sync drains the whole chain. Previously every drafted token paid argmax-D2H + `cudaStreamSynchronize` (GPU pipeline drain) + a per-step `cudaMalloc` for the token upload.

- MoE MTP heads (35B sidecar) keep the host loop — their expert routing does a per-step D2H by construction. Gated on `n_experts == 0`; `speculative.mtp_k > 16` also falls back.
- Host-path draft steps now use a persistent argmax scratch (kills a per-draft `cudaMallocAsync`/`FreeAsync` pair).
- Chain tokens are validated once after the drain (argmax output is always in-range; the check guards NaN-logits garbage) — invalid tail truncates the draft.

## Measured (Qwen3.6-27B, MTP-only, fixed 500-tok budget)

**Honest: e2e-neutral.** ms/verify ~62 (k=2) / ~78 (k=4), same as before within noise; accept rates unchanged (54–55% / 41–45%). nsys API sum confirms the mechanism worked — process `cudaStreamSynchronize` count roughly halved — but the remaining verify wall is eager-chunk host overhead (per-layer `cudaMallocAsync`, cuBLASLt algo-selection churn on the variable-M partial-accept replay, launch pacing), not chain syncs. That anatomy is the next #847 slice.

Shipped as **groundwork**: capturing the chain into a CUDA graph — the actual pacing fix for the chain segment — requires exactly this no-host-round-trip structure.

## Gates

- `MtpForwardTest` (real 35B checkpoint = MoE-head host path) green.
- `verify --fast`: suite/e2e/prefill/long-ctx/smoke PASS; decode WARN + graphs-gate FAIL are the documented depressed-host state (#526 signature flagged by the gate itself, mem 7001 MHz median; unmodified main read 1.008x on the same gate earlier today).
- All changes MTP-gated; default decode path untouched.

Continues #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)