### PR TITLE
perf(attn): small hd!=128 chunks prefer tiled FMHA — kills cuBLAS per-new-shape algo churn on spec-verify (#847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ## [Unreleased]
 
 ### Changed
+- **Small hd≠128 verify/boundary chunks prefer the tiled FMHA over cuBLAS**
+  — cuBLAS re-runs its per-new-shape algo selection on every call (100 MiB
+  workspace memset + candidate benchmark + blocking event sync); spec-verify
+  chunks grow `ctx_len` every step, so hd=256 models paid ~93 such trios per
+  verify (~12-15 ms of churn, nsys timeline on Qwen3.6-27B MTP-only). Chunks
+  with n ≤ 32 and hd ≠ 128 now route to the tiled FMHA (shape-stateless,
+  PPL-identical per #511) inside its correctness domain; learned sinks and
+  heterogeneous shapes keep cuBLAS. Measured: 27B MTP-only verify 78 → 59
+  ms/verify, 34 → 44-46 tok/s (+31%).
 - **Small-M NVFP4 GEMM: batched GEMV replaces the dequant fallback** — for
   M ≤ 16 (spec-verify chunks of drafts+1, short/boundary prefills),
   `gemm_nvfp4` now runs the batched-M K-parallel GEMV (weight read once per

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -63,9 +63,23 @@
             int64_t fp16_elems_avail = static_cast<int64_t>(s_cap) * s_cap;
             const bool smatrix_fits =
                 s_cap > 0 && n <= s_cap && fp16_elems_needed <= fp16_elems_avail;
-            const bool prefer_fmha = chunk_fmha_ok &&
-                                     runtime_config().attention.fmha_prefill_threshold > 0 &&
-                                     ctx_len >= runtime_config().attention.fmha_prefill_threshold;
+            // Spec-verify chunks (small n, ctx_len grows EVERY verify step) on
+            // hd!=128 configs land on cuBLAS below the FMHA threshold — and
+            // cuBLAS re-runs its per-new-shape algo selection on each call
+            // (100 MiB workspace memset + candidate benchmark + blocking
+            // event sync, per layer per verify: ~93 such trios/verify measured
+            // on Qwen3.6-27B MTP-only, 12-15 ms/verify of pure churn; FMHA
+            // reads ms/verify 78 → 60, +31% e2e, #847). The tiled FMHA keeps
+            // no shape-keyed state — prefer it for small chunks inside its
+            // correctness domain. hd==128 never reaches this (FA2 serves it);
+            // learned sinks / heterogeneous shapes are excluded by
+            // chunk_fmha_ok and keep cuBLAS.
+            const bool small_growing_chunk = n <= 32 && hd != 128;
+            const bool prefer_fmha =
+                chunk_fmha_ok &&
+                ((runtime_config().attention.fmha_prefill_threshold > 0 &&
+                  ctx_len >= runtime_config().attention.fmha_prefill_threshold) ||
+                 small_growing_chunk);
             if (!chunk_fa2_serves && !chunk_fmha_ok && !smatrix_fits) {
                 // Sinks/heterogeneous shapes can ONLY be served by cuBLAS — the
                 // engine clamps chunk sizes (max_safe_prefill_chunk) and rejects


### PR DESCRIPTION
## What

nsys steady-state timeline (12 s window, load excluded) on the Qwen3.6-27B MTP-only verify cycle found the dominant host-gap term: **~93 `memset(100 MiB) + benchmark-kernel + cudaEventSynchronize` trios per verify — 26% of wall time**. That is cuBLAS-internal algo selection re-running on **every** call: the verify chunk's `ctx_len` grows each step, so every hd=256 attention GEMM presents a new shape (2 GEMMs × ~7 layers-equivalents × ~7 candidates ≈ 93).

Fix: chunks with **n ≤ 32 && hd ≠ 128** now prefer the tiled FMHA (shape-stateless; PPL-identical to cuBLAS on this domain per the #511 measurements) inside `chunk_fmha_ok` — learned sinks and heterogeneous per-layer shapes keep cuBLAS, hd=128 keeps FA2, large chunks keep the existing threshold logic.

## Measured (RTX 5090, fixed 500-tok budget, greedy)

- **27B MTP-only k=4: 78 → 59 ms/verify, 34 → 44–46 tok/s (+31%)**, accept rates unchanged (identical drafts).
- Config-override experiment (`fmha_prefill_threshold=1`) reproduced the same number before the code change — the fix just defaults it for the affected chunk class.
- Applies to every hd≠128 spec-verify workload (Qwen3.6-27B/35B suffix verify inherits the same chunk path).
- ChunkedPrefill* + DegenerationTest green (11/11); verify-fast: suite/e2e/prefill/long-ctx/smoke PASS, decode WARN + graphs-gate FAIL = documented depressed-host state (#526; flagged by the gate itself).

## Session context

Third slice of the #847 verify-economics ladder (after #862/#863/#864): 27B MTP-only verify is now 90 → 59 ms cumulative this session. Break-even vs the 89 tok/s async loop needs <56 ms at k=4 — one slice away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)