### PR TITLE
feat(embed): nomic-bert encoder support + /v1/embeddings (#836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+- **Encoder/embedding-model support** (#836) — `nomic-bert` GGUF checkpoints
+  (nomic-embed-text-v1.5) load into a dedicated encoder path: bidirectional
+  no-KV forward (post-LN with bias, rotary, SwiGLU), BERT WordPiece
+  tokenizer (llama.cpp GGUFs store it in SPM convention: word-initial `▁`,
+  bare continuations), true LayerNorm-with-bias kernel, mean pooling + L2
+  on device. `/v1/embeddings` serves it with [CLS]/[SEP] framing.
+  HF-oracle-verified: cos(imp, HF trust_remote_code) ≥ 0.999 on Q8_0.
+  Classic BERT/bge/e5 (learned positions, CLS pooling) stay rejected.
+
 ### Changed
 - **Persistent K/V gather scratch for the eager chunked path** — spec-verify
   re-enters the chunked attention per layer per verify; the per-call

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,7 @@ if(IMP_BUILD_TESTS)
         tests/test_e2e_llm_compressor.cpp
         tests/test_chunked_prefill.cu
         tests/test_mtp_forward.cpp
+        tests/test_encoder_embed.cpp
         tests/test_api_generate.cpp
         tests/test_engine_relaunch.cpp
         tests/test_lora.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ set(IMP_RUNTIME_SOURCES
     src/runtime/presets.cpp
     src/runtime/storage_planner.cpp
     src/compute/mtp_forward.cu
+    src/compute/encoder_forward.cu
 )
 
 set(IMP_EXEC_SOURCES

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -8,6 +8,7 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 
 | Model | Quant | VRAM | Decode `tg256` | Format |
 |---|---|---:|---:|---|
+| [nomic-embed-text-v1.5](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF) | Q8_0 | 0.2 GB | embeddings (`/v1/embeddings`, HF-oracle cos ≥ 0.999) | GGUF |
 | [Qwen3-4B](https://huggingface.co/unsloth/Qwen3-4B-GGUF) | Q8_0 | 4.0 GB | 236 | GGUF |
 | Qwen3-4B | MXFP4 | 2.8 GB | 124 | GGUF (imp-converted) |
 | [Qwen3-8B](https://huggingface.co/unsloth/Qwen3-8B-GGUF) | Q8_0 | 8.2 GB | **268** (tg128, CI baseline #540) | GGUF |

--- a/include/imp/types.h
+++ b/include/imp/types.h
@@ -38,6 +38,7 @@ typedef enum {
     IMP_ARCH_GEMMA4 = 12,
     IMP_ARCH_QWEN36_MOE = 13,
     IMP_ARCH_GPT_OSS = 14,
+    IMP_ARCH_NOMIC_BERT = 15,
 } ImpModelArch;
 
 typedef enum {

--- a/src/compute/encoder_forward.cu
+++ b/src/compute/encoder_forward.cu
@@ -1,0 +1,230 @@
+// =============================================================================
+// encoder_forward.cu — encoder-only embedder forward (#836, nomic-bert)
+// =============================================================================
+// See header for the pass structure. Everything runs on one stream; the only
+// syncs are the final D2H of the pooled vector (encoder_embed) and the
+// one-time dequant in encoder_workspace_init.
+// =============================================================================
+
+#include "compute/encoder_forward.h"
+#include "compute/activation.h"
+#include "compute/attention_cublas.h"
+#include "compute/embedding.h"
+#include "compute/gemm.h"
+#include "compute/layernorm.h"
+#include "compute/rope.h"
+#include "core/logging.h"
+#include "model/model.h"
+#include "quant/dequant_gpu.h"
+#include <cuda_fp16.h>
+#include <numeric>
+
+namespace imp {
+
+namespace {
+
+// h[i, :] += type_row[:]  (token_type embedding, row 0 for plain text)
+__global__ void encoder_add_type_kernel(__half* __restrict__ h, const __half* __restrict__ type_row,
+                                        int n, int d) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx < static_cast<int64_t>(n) * d)
+        h[idx] = __float2half(__half2float(h[idx]) + __half2float(type_row[idx % d]));
+}
+
+// out[j] = mean_i h[i, j]; then L2-normalize out in a second kernel.
+__global__ void encoder_mean_pool_kernel(const __half* __restrict__ h, float* __restrict__ out,
+                                         int n, int d) {
+    const int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j >= d) return;
+    float s = 0.0f;
+    for (int i = 0; i < n; ++i) s += __half2float(h[static_cast<int64_t>(i) * d + j]);
+    out[j] = s / n;
+}
+
+__global__ void encoder_l2_normalize_kernel(float* __restrict__ v, int d) {
+    __shared__ float warp_sums[32];
+    float s = 0.0f;
+    for (int i = threadIdx.x; i < d; i += blockDim.x) s += v[i] * v[i];
+    const int lane = threadIdx.x % 32, warp = threadIdx.x / 32;
+    for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffff, s, m);
+    if (lane == 0) warp_sums[warp] = s;
+    __syncthreads();
+    const int n_warps = (blockDim.x + 31) / 32;
+    float total = (threadIdx.x < n_warps) ? warp_sums[threadIdx.x] : 0.0f;
+    if (threadIdx.x < 32)
+        for (int m = 16; m > 0; m >>= 1) total += __shfl_xor_sync(0xffffffff, total, m);
+    if (threadIdx.x == 0) warp_sums[0] = total;
+    __syncthreads();
+    const float inv = rsqrtf(warp_sums[0] + 1e-12f);
+    for (int i = threadIdx.x; i < d; i += blockDim.x) v[i] *= inv;
+}
+
+// Dequantize one weight tensor to a fresh FP16 device buffer. F16 sources are
+// device-copied as-is.
+void* dequant_to_fp16(const Tensor& w, cudaStream_t stream) {
+    if (!w.data) return nullptr;
+    const int rows = static_cast<int>(w.shape[0]);
+    const int cols = static_cast<int>(w.shape[1]);
+    void* dst = nullptr;
+    if (cudaMalloc(&dst, static_cast<size_t>(rows) * cols * sizeof(__half)) != cudaSuccess)
+        return nullptr;
+    if (w.qtype == QType::F16) {
+        cudaMemcpyAsync(dst, w.data, static_cast<size_t>(rows) * cols * sizeof(__half),
+                        cudaMemcpyDeviceToDevice, stream);
+    } else if (dequant_gpu_supported(w.qtype)) {
+        dequant_gpu(w.data, dst, w.qtype, rows, cols, stream);
+    } else {
+        IMP_LOG_ERROR("encoder: unsupported weight qtype %d", static_cast<int>(w.qtype));
+        cudaFree(dst);
+        return nullptr;
+    }
+    return dst;
+}
+
+Tensor fp16_view(void* p, int64_t r, int64_t c) {
+    int64_t s[2] = {r, c};
+    return Tensor(p, QType::F16, 2, s, /*on_device=*/true);
+}
+
+}  // namespace
+
+bool encoder_workspace_init(EncoderWorkspace& ws, const Model& model, int max_tokens,
+                            cudaStream_t stream) {
+    const ModelConfig& cfg = model.config();
+    ws.max_tokens = max_tokens;
+    ws.d_model = cfg.d_model;
+    ws.d_ff = cfg.d_ff;
+    ws.n_layers = cfg.n_layers;
+    ws.n_heads = cfg.n_heads;
+    ws.head_dim = cfg.head_dim > 0 ? cfg.head_dim : cfg.d_model / cfg.n_heads;
+    ws.rope_theta = cfg.rope_theta;
+    ws.ln_eps = cfg.rms_norm_eps;  // GGUF layer_norm_epsilon lands here
+
+    ws.layers.resize(ws.n_layers);
+    for (int i = 0; i < ws.n_layers; ++i) {
+        const auto& L = model.layer(i);
+        auto& E = ws.layers[i];
+        E.wq = dequant_to_fp16(L.wq, stream);
+        E.wk = dequant_to_fp16(L.wk, stream);
+        E.wv = dequant_to_fp16(L.wv, stream);
+        E.wo = dequant_to_fp16(L.wo, stream);
+        E.wg = dequant_to_fp16(L.w_gate, stream);
+        E.wu = dequant_to_fp16(L.w_up, stream);
+        E.wd = dequant_to_fp16(L.w_down, stream);
+        if (!E.wq || !E.wk || !E.wv || !E.wo || !E.wg || !E.wu || !E.wd) {
+            IMP_LOG_ERROR("encoder: weight dequant failed at layer %d", i);
+            encoder_workspace_free(ws);
+            return false;
+        }
+    }
+
+    const size_t nd = static_cast<size_t>(max_tokens) * ws.d_model * sizeof(__half);
+    const size_t nff = static_cast<size_t>(max_tokens) * ws.d_ff * sizeof(__half);
+    const size_t ns = static_cast<size_t>(ws.n_heads) * max_tokens * max_tokens * sizeof(float);
+    bool ok = true;
+    auto alloc = [&](void** p, size_t bytes) { ok &= cudaMalloc(p, bytes) == cudaSuccess; };
+    alloc(reinterpret_cast<void**>(&ws.d_tokens), max_tokens * sizeof(int32_t));
+    alloc(reinterpret_cast<void**>(&ws.d_positions), max_tokens * sizeof(int32_t));
+    alloc(&ws.d_h, nd);
+    alloc(&ws.d_q, nd);
+    alloc(&ws.d_k, nd);
+    alloc(&ws.d_v, nd);
+    alloc(&ws.d_attn, nd);
+    alloc(&ws.d_proj, nd);
+    alloc(&ws.d_gate, nff);
+    alloc(&ws.d_up, nff);
+    alloc(&ws.d_act, nff);
+    alloc(&ws.d_scores, ns);
+    alloc(reinterpret_cast<void**>(&ws.d_pooled), ws.d_model * sizeof(float));
+    if (!ok) {
+        IMP_LOG_ERROR("encoder: scratch alloc failed (max_tokens=%d)", max_tokens);
+        encoder_workspace_free(ws);
+        return false;
+    }
+
+    // Positions 0..max_n-1 once (rope reads per-row).
+    std::vector<int32_t> pos(max_tokens);
+    std::iota(pos.begin(), pos.end(), 0);
+    cudaMemcpyAsync(ws.d_positions, pos.data(), max_tokens * sizeof(int32_t),
+                    cudaMemcpyHostToDevice, stream);
+    cudaStreamSynchronize(stream);
+    return true;
+}
+
+void encoder_workspace_free(EncoderWorkspace& ws) {
+    for (auto& E : ws.layers)
+        for (void* p : {E.wq, E.wk, E.wv, E.wo, E.wg, E.wu, E.wd})
+            if (p) cudaFree(p);
+    ws.layers.clear();
+    for (void* p : {static_cast<void*>(ws.d_tokens), static_cast<void*>(ws.d_positions), ws.d_h,
+                    ws.d_q, ws.d_k, ws.d_v, ws.d_attn, ws.d_proj, ws.d_gate, ws.d_up, ws.d_act,
+                    ws.d_scores, static_cast<void*>(ws.d_pooled)})
+        if (p) cudaFree(p);
+    ws.d_tokens = nullptr;
+    ws.d_positions = nullptr;
+    ws.d_h = ws.d_q = ws.d_k = ws.d_v = ws.d_attn = ws.d_proj = nullptr;
+    ws.d_gate = ws.d_up = ws.d_act = ws.d_scores = nullptr;
+    ws.d_pooled = nullptr;
+    ws.max_tokens = 0;
+}
+
+bool encoder_embed(const Model& model, EncoderWorkspace& ws, const int32_t* tokens, int n,
+                   float* out_host, cudaStream_t stream) {
+    if (ws.max_tokens == 0 || n <= 0 || n > ws.max_tokens || !out_host)
+        return false;
+    const int d = ws.d_model;
+    const int dff = ws.d_ff;
+
+    cudaMemcpyAsync(ws.d_tokens, tokens, n * sizeof(int32_t), cudaMemcpyHostToDevice, stream);
+
+    // Embedding + token-type row 0 + post-embedding LayerNorm.
+    Tensor h = fp16_view(ws.d_h, n, d);
+    embedding_lookup(model.tok_emb_, ws.d_tokens, n, h, model.tok_emb_.qtype, stream);
+    if (model.token_types_.data) {
+        const int block = 256;
+        const int64_t total = static_cast<int64_t>(n) * d;
+        encoder_add_type_kernel<<<static_cast<int>((total + block - 1) / block), block, 0, stream>>>(
+            static_cast<__half*>(ws.d_h), static_cast<const __half*>(model.token_types_.data), n, d);
+    }
+    Tensor none{};
+    layernorm_residual(h, none, model.tok_emb_norm_, model.tok_emb_norm_bias_, h, ws.ln_eps, stream);
+
+    const float scale = 1.0f / sqrtf(static_cast<float>(ws.head_dim));
+    for (int i = 0; i < ws.n_layers; ++i) {
+        const auto& L = model.layer(i);
+        const auto& E = ws.layers[i];
+        Tensor q = fp16_view(ws.d_q, n, d), k = fp16_view(ws.d_k, n, d), v = fp16_view(ws.d_v, n, d);
+        gemm(h, fp16_view(E.wq, d, d), q, 1.0f, 0.0f, stream);
+        gemm(h, fp16_view(E.wk, d, d), k, 1.0f, 0.0f, stream);
+        gemm(h, fp16_view(E.wv, d, d), v, 1.0f, 0.0f, stream);
+        rope_forward(q, k, ws.d_positions, ws.head_dim, ws.rope_theta, 1.0f, /*rope_dim=*/0,
+                     /*neox=*/true, 0.0f, 1.0f, nullptr, stream);
+
+        Tensor attn = fp16_view(ws.d_attn, n, d);
+        int64_t s_shape[2] = {static_cast<int64_t>(ws.n_heads), static_cast<int64_t>(n) * n};
+        Tensor S(ws.d_scores, QType::F32, 2, s_shape, true);
+        attention_cublas_prefill(q, k, v, attn, S, ws.n_heads, ws.n_heads, ws.head_dim, scale,
+                                 /*causal=*/false, 0.0f, /*q_offset=*/0, stream);
+
+        Tensor proj = fp16_view(ws.d_proj, n, d);
+        gemm(attn, fp16_view(E.wo, d, d), proj, 1.0f, 0.0f, stream);
+        layernorm_residual(proj, h, L.post_attn_norm, L.post_attn_norm_bias, h, ws.ln_eps, stream);
+
+        Tensor g = fp16_view(ws.d_gate, n, dff), u = fp16_view(ws.d_up, n, dff),
+               a = fp16_view(ws.d_act, n, dff);
+        gemm(h, fp16_view(E.wg, dff, d), g, 1.0f, 0.0f, stream);
+        gemm(h, fp16_view(E.wu, dff, d), u, 1.0f, 0.0f, stream);
+        swiglu(g, u, a, stream);
+        gemm(a, fp16_view(E.wd, d, dff), proj, 1.0f, 0.0f, stream);
+        layernorm_residual(proj, h, L.post_ffn_norm, L.post_ffn_norm_bias, h, ws.ln_eps, stream);
+    }
+
+    // Mean pool + L2 normalize + D2H.
+    encoder_mean_pool_kernel<<<(d + 255) / 256, 256, 0, stream>>>(
+        static_cast<const __half*>(ws.d_h), ws.d_pooled, n, d);
+    encoder_l2_normalize_kernel<<<1, 256, 0, stream>>>(ws.d_pooled, d);
+    cudaMemcpyAsync(out_host, ws.d_pooled, d * sizeof(float), cudaMemcpyDeviceToHost, stream);
+    return cudaStreamSynchronize(stream) == cudaSuccess;
+}
+
+}  // namespace imp

--- a/src/compute/encoder_forward.cu
+++ b/src/compute/encoder_forward.cu
@@ -197,7 +197,9 @@ bool encoder_embed(const Model& model, EncoderWorkspace& ws, const int32_t* toke
         gemm(h, fp16_view(E.wq, d, d), q, 1.0f, 0.0f, stream);
         gemm(h, fp16_view(E.wk, d, d), k, 1.0f, 0.0f, stream);
         gemm(h, fp16_view(E.wv, d, d), v, 1.0f, 0.0f, stream);
-        rope_forward(q, k, ws.d_positions, ws.head_dim, ws.rope_theta, 1.0f, /*rope_dim=*/0,
+        int64_t r4[4] = {1, n, ws.n_heads, ws.head_dim};
+        Tensor q4 = q.reshape(4, r4), k4 = k.reshape(4, r4);
+        rope_forward(q4, k4, ws.d_positions, ws.head_dim, ws.rope_theta, 1.0f, /*rope_dim=*/0,
                      /*neox=*/true, 0.0f, 1.0f, nullptr, stream);
 
         Tensor attn = fp16_view(ws.d_attn, n, d);

--- a/src/compute/encoder_forward.h
+++ b/src/compute/encoder_forward.h
@@ -1,0 +1,83 @@
+#pragma once
+// =============================================================================
+// encoder_forward.h — encoder-only embedder forward (#836, nomic-bert)
+// =============================================================================
+//
+// Self-contained bidirectional encoder pass (post-LN BERT variant with rotary
+// positions and SwiGLU FFN — the nomic-embed recipe). Deliberately independent
+// of GraphExecutor: no KV cache, no CUDA graphs, no sampling. Reuses the
+// shared primitives (embedding_lookup, gemm, rope_forward,
+// attention_cublas_prefill, swiglu, layernorm_residual).
+//
+// Per input:
+//   h = LayerNorm(tok_emb[t] + token_types[0])           (post-embedding LN)
+//   12 x [ q,k,v = h @ Wq/Wk/Wv ; rope(q,k) ;
+//          a = softmax(qk^T)v (bidirectional) @ Wo ;
+//          h = LayerNorm(h + a) ;                        (attn_output_norm)
+//          f = swiglu(h@Wg, h@Wu) @ Wd ;
+//          h = LayerNorm(h + f) ]                        (layer_output_norm)
+//   out = L2-normalize(mean(h, axis=0))
+//
+// Weights arrive Q8_0 from GGUF; encoder_workspace_init dequantizes them ONCE
+// to FP16 side buffers (~230 MB for nomic's 137M params) so the forward is
+// plain FP16 GEMMs.
+// =============================================================================
+
+#include "core/tensor.h"
+#include <cuda_runtime.h>
+#include <vector>
+
+namespace imp {
+
+class Model;
+
+struct EncoderLayerWeights {
+    void* wq = nullptr;  // [d, d] FP16
+    void* wk = nullptr;
+    void* wv = nullptr;
+    void* wo = nullptr;
+    void* wg = nullptr;  // [d_ff, d]
+    void* wu = nullptr;  // [d_ff, d]
+    void* wd = nullptr;  // [d, d_ff]
+};
+
+struct EncoderWorkspace {
+    int max_tokens = 0;
+    int d_model = 0;
+    int d_ff = 0;
+    int n_layers = 0;
+    int n_heads = 0;
+    int head_dim = 0;
+    float rope_theta = 10000.0f;
+    float ln_eps = 1e-12f;
+
+    // Dequantized FP16 weights (owned).
+    std::vector<EncoderLayerWeights> layers;
+
+    // Activation scratch (owned), sized for max_tokens.
+    int32_t* d_tokens = nullptr;     // [max_n]
+    int32_t* d_positions = nullptr;  // [max_n]
+    void* d_h = nullptr;             // [max_n, d] FP16 hidden
+    void* d_q = nullptr;             // [max_n, d]
+    void* d_k = nullptr;             // [max_n, d]
+    void* d_v = nullptr;             // [max_n, d]
+    void* d_attn = nullptr;          // [max_n, d] attention out
+    void* d_proj = nullptr;          // [max_n, d] o/down proj out
+    void* d_gate = nullptr;          // [max_n, d_ff]
+    void* d_up = nullptr;            // [max_n, d_ff]
+    void* d_act = nullptr;           // [max_n, d_ff]
+    void* d_scores = nullptr;        // [n_heads, max_n, max_n] FP32 S-matrix
+    float* d_pooled = nullptr;       // [d] pooled + normalized output
+};
+
+// Dequantize weights + allocate scratch. Call once after upload_weights_gpu.
+bool encoder_workspace_init(EncoderWorkspace& ws, const Model& model, int max_tokens,
+                            cudaStream_t stream);
+void encoder_workspace_free(EncoderWorkspace& ws);
+
+// Full pass: host tokens -> pooled, L2-normalized embedding (host float[d]).
+// Returns false on precondition violation (n > max_tokens, ws not init).
+bool encoder_embed(const Model& model, EncoderWorkspace& ws, const int32_t* tokens, int n,
+                   float* out_host, cudaStream_t stream);
+
+}  // namespace imp

--- a/src/compute/layernorm.cu
+++ b/src/compute/layernorm.cu
@@ -500,4 +500,73 @@ void layernorm_pdl_register() {
     pdl::enable(reinterpret_cast<const void*>(&rmsnorm_residual_fp32_kernel));
 }
 
+// --------------------------------------------------------------------------
+// True LayerNorm with bias + optional residual (#836, encoder post-LN).
+// One CTA per row; the row is staged in dynamic shared memory (d_model * 4 B
+// = 3 KiB at nomic's 768), mean/var via two block reductions.
+// --------------------------------------------------------------------------
+namespace {
+__device__ __forceinline__ float ln_param(const void* p, bool f32, int i) {
+    return f32 ? static_cast<const float*>(p)[i]
+               : __half2float(static_cast<const __half*>(p)[i]);
+}
+
+__device__ float ln_block_sum(float v) {
+    __shared__ float warp_sums[32];
+    const int lane = threadIdx.x % 32, warp = threadIdx.x / 32;
+    for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffff, v, m);
+    if (lane == 0) warp_sums[warp] = v;
+    __syncthreads();
+    const int n_warps = (blockDim.x + 31) / 32;
+    float total = (threadIdx.x < n_warps) ? warp_sums[threadIdx.x] : 0.0f;
+    if (threadIdx.x < 32)
+        for (int m = 16; m > 0; m >>= 1) total += __shfl_xor_sync(0xffffffff, total, m);
+    if (threadIdx.x == 0) warp_sums[0] = total;
+    __syncthreads();
+    return warp_sums[0];
+}
+
+__global__ void layernorm_residual_kernel(const __half* __restrict__ x,
+                                          const __half* __restrict__ residual,
+                                          const void* __restrict__ w, bool w_f32,
+                                          const void* __restrict__ b, bool b_f32,
+                                          __half* __restrict__ out, int d, float eps) {
+    extern __shared__ float row[];
+    const size_t base = static_cast<size_t>(blockIdx.x) * d;
+    float sum = 0.0f;
+    for (int i = threadIdx.x; i < d; i += blockDim.x) {
+        float v = __half2float(x[base + i]);
+        if (residual) v += __half2float(residual[base + i]);
+        row[i] = v;
+        sum += v;
+    }
+    __syncthreads();
+    const float mean = ln_block_sum(sum) / d;
+    float var_sum = 0.0f;
+    for (int i = threadIdx.x; i < d; i += blockDim.x) {
+        const float c = row[i] - mean;
+        var_sum += c * c;
+    }
+    __syncthreads();
+    const float rstd = rsqrtf(ln_block_sum(var_sum) / d + eps);
+    for (int i = threadIdx.x; i < d; i += blockDim.x) {
+        const float bias = b ? ln_param(b, b_f32, i) : 0.0f;
+        out[base + i] = __float2half((row[i] - mean) * rstd * ln_param(w, w_f32, i) + bias);
+    }
+}
+}  // namespace
+
+void layernorm_residual(const Tensor& x, const Tensor& residual, const Tensor& weight,
+                        const Tensor& bias, Tensor& out, float eps, cudaStream_t stream) {
+    const int rows = static_cast<int>(x.shape[0]);
+    const int d = static_cast<int>(x.shape[1]);
+    const bool w_f32 = weight.qtype == QType::F32;
+    const bool b_f32 = bias.qtype == QType::F32;
+    const size_t shmem = static_cast<size_t>(d) * sizeof(float);
+    layernorm_residual_kernel<<<rows, 256, shmem, stream>>>(
+        static_cast<const __half*>(x.data),
+        residual.data ? static_cast<const __half*>(residual.data) : nullptr, weight.data, w_f32,
+        bias.data, b_f32, static_cast<__half*>(out.data), d, eps);
+}
+
 }  // namespace imp

--- a/src/compute/layernorm.h
+++ b/src/compute/layernorm.h
@@ -25,6 +25,14 @@ void rmsnorm_fp32_to_fp16(const Tensor& x_fp32, const Tensor& weight, Tensor& ou
 void rmsnorm_fp32_to_fp32(const Tensor& x_fp32, const Tensor& weight, float* out_fp32, int rows, int d_model,
                           float eps = 1e-5f, cudaStream_t stream = nullptr, float weight_offset = 0.0f);
 
+// True LayerNorm with residual add (#836, encoder post-LN):
+//   out = ((x + residual) - mean) / sqrt(var + eps) * weight + bias
+// x/residual/out: [rows, d_model] FP16; weight/bias: [d_model] F32 or F16.
+// residual may be empty (Tensor{}) for the post-embedding norm.
+void layernorm_residual(const Tensor& x, const Tensor& residual, const Tensor& weight,
+                        const Tensor& bias, Tensor& out, float eps = 1e-12f,
+                        cudaStream_t stream = nullptr);
+
 // Register layernorm kernels for PDL tail/head overlap.
 void layernorm_pdl_register();
 

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -287,10 +287,15 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
     // healthy, and then hit a CUDA illegal memory access on the first request
     // (causal-LM prefill + sampling on a model with no LM head), poisoning the
     // CUDA context for the whole process. Fail loudly at load instead.
-    if (is_encoder_only_arch(arch_str)) {
+    // nomic-bert has a dedicated encoder path (#836): rotary positions,
+    // post-LN, mean pooling — served by the encoder forward. Other encoder
+    // archs (classic BERT/bge/e5: learned absolute positions + token-type
+    // sequences + CLS pooling) stay rejected until implemented.
+    if (is_encoder_only_arch(arch_str) && cfg.arch != ModelArch::NOMIC_BERT) {
         throw std::runtime_error("encoder-only architecture '" + arch_str +
                                  "' is not supported (imp runs causal decoder LMs; "
-                                 "embedding encoders need pooling support)");
+                                 "embedding encoders need pooling support — only "
+                                 "nomic-bert is wired, #836)");
     }
 
     IMP_LOG_INFO("Architecture: %s -> %s", arch_str.c_str(), model_arch_name(cfg.arch));

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -994,6 +994,9 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
         // Gemma-4 uses SPM-style BPE: ▁ for spaces + BPE merge ranks.
         else if (tm == "gemma4")
             tok_type = "gemma4";
+        // BERT WordPiece (#836, nomic-bert embedder).
+        else if (tm == "bert")
+            tok_type = "bert";
     }
     tokenizer->set_type(tok_type);
 

--- a/src/model/gguf_tensor_assign.cpp
+++ b/src/model/gguf_tensor_assign.cpp
@@ -40,6 +40,20 @@ bool assign_tensor(Model& model, const std::string& name, const Tensor& tensor, 
         assign_quant(model.out_norm_, tensor);
         return true;
     }
+    // Encoder embedder (#836, nomic-bert): post-embedding LayerNorm + token
+    // types. F32 vectors / tiny table — no quant handling needed.
+    if (name == "token_embd_norm.weight") {
+        model.tok_emb_norm_ = tensor;
+        return true;
+    }
+    if (name == "token_embd_norm.bias") {
+        model.tok_emb_norm_bias_ = tensor;
+        return true;
+    }
+    if (name == "token_types.weight") {
+        model.token_types_ = tensor;
+        return true;
+    }
     if (name == "rope_freqs.weight") {
         model.layers_[0].rope_freqs = tensor;
         return true;
@@ -114,6 +128,19 @@ bool assign_tensor(Model& model, const std::string& name, const Tensor& tensor, 
             layer.attn_sinks = tensor;
         else if (field == "attn_norm")
             layer.attn_norm = tensor;
+        // Encoder post-LN (#836, nomic-bert): LayerNorm AFTER the residual
+        // add; weights reuse the Gemma-3 post-norm fields, biases are new.
+        else if (field == "attn_output_norm") {
+            if (suffix == "bias")
+                layer.post_attn_norm_bias = tensor;
+            else
+                layer.post_attn_norm = tensor;
+        } else if (field == "layer_output_norm") {
+            if (suffix == "bias")
+                layer.post_ffn_norm_bias = tensor;
+            else
+                layer.post_ffn_norm = tensor;
+        }
         else if (field == "attn_q_norm")
             layer.attn_q_norm = tensor;
         else if (field == "attn_k_norm")

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -151,6 +151,7 @@ enum {
     kApiGemma4 = 12,
     kApiQwen36Moe = 13,
     kApiGptOss = 14,
+    kApiNomicBert = 15,
 };
 
 static constexpr ArchEntry kArchRegistry[] = {
@@ -182,6 +183,10 @@ static constexpr ArchEntry kArchRegistry[] = {
     {ModelArch::GEMMA3, "gemma3", kApiGemma3, -1, 0, 1, 1, false, false, 0.6f, 0.95f, 0},
     {ModelArch::GEMMA4, "gemma4", kApiGemma4, -1, 0, 1, 1, false, true, 0.6f, 0.9f, 20},
     {ModelArch::LLAMA4, "llama4", kApiLlama4, 0, 0, -1, -1, false, false, 0.6f, 0.95f, 0},
+    // Encoder-only embedder (#836): rotary (neox pairs), SwiGLU FFN; sampling
+    // defaults unused (no LM head). Post-LN + pooling handled by the encoder
+    // forward, not the decoder loop.
+    {ModelArch::NOMIC_BERT, "nomic-bert", kApiNomicBert, 1, 0, -1, -1, false, false, 1.0f, 1.0f, 0},
     {ModelArch::GENERIC, "generic", kApiGeneric, -1, 0, -1, -1, false, false, 0.6f, 0.95f, 0},
 };
 
@@ -263,6 +268,7 @@ ModelArch parse_model_arch(const std::string& s) {
         {"gemma2", ModelArch::GEMMA3},
         {"gemma4", ModelArch::GEMMA4},
         {"llama4", ModelArch::LLAMA4},
+        {"nomic-bert", ModelArch::NOMIC_BERT},
         {"qwen2", ModelArch::LLAMA},
         {"phi3", ModelArch::LLAMA},
         // HuggingFace architecture class names (from config.json "architectures")

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -83,6 +83,10 @@ public:
     ModelProfile profile_;
     HFConfigLoader::GenerationConfig generation_config_;
     Tensor tok_emb_, out_norm_, out_proj_;
+    // Encoder embedder extras (#836, nomic-bert): post-embedding LayerNorm
+    // (weight+bias) and the token-type embedding table [n_types, d_model]
+    // (row 0 is added to every text token's embedding).
+    Tensor tok_emb_norm_, tok_emb_norm_bias_, token_types_;
     // (qtype mirrors removed in Stage G — read tok_emb_.qtype directly.)
     TensorID out_proj_id = kInvalidTensorID;  // registry handle for LM head (Task 3.5)
     TensorID tok_emb_id = kInvalidTensorID;   // registry handle for token embedding

--- a/src/model/model_arch.h
+++ b/src/model/model_arch.h
@@ -19,6 +19,7 @@ enum class ModelArch {
     GEMMA3,
     GEMMA4,
     LLAMA4,
+    NOMIC_BERT,  // encoder-only embedder (#836): bidirectional, post-LN, mean-pool
     GENERIC,
 };
 

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -216,6 +216,9 @@ struct TransformerLayer {
     Tensor expert_down_packed_scales;      // U8 [ne, d_model, d_ff/32]
     Tensor attn_q_norm, attn_k_norm;       // QK-norm (Qwen3-style per-head RMSNorm)
     Tensor post_attn_norm, post_ffn_norm;  // Post-layer norms (Gemma-3)
+    // Encoder post-LN biases (#836, nomic-bert): true LayerNorm with bias,
+    // applied AFTER the residual add (weights live in post_attn/ffn_norm).
+    Tensor post_attn_norm_bias, post_ffn_norm_bias;
     // Gemma 4 extras
     Tensor ffn_pre_norm_2;      // pre-norm for expert branch (operates on attn_out)
     Tensor ffn_post_norm_1;     // post-norm for shared MLP branch

--- a/src/model/model_profile.cpp
+++ b/src/model/model_profile.cpp
@@ -43,6 +43,7 @@ ModelProfile derive_model_profile(const Model& model, const ModelConfig& cfg) {
     p.is_gemma4 = cfg.arch == ModelArch::GEMMA4;
     p.is_gpt_oss = cfg.arch == ModelArch::GPT_OSS;
     p.is_llama4 = cfg.arch == ModelArch::LLAMA4;
+    p.is_encoder = cfg.arch == ModelArch::NOMIC_BERT;
 
     // Attention variant. MLA and NoPE are mutually exclusive with the SWA
     // patterns. MLA is checked first (DeepSeek-V2/V3 have neither SWA nor

--- a/src/model/model_profile.h
+++ b/src/model/model_profile.h
@@ -39,6 +39,10 @@ struct ModelProfile {
     bool is_gemma4 = false;
     bool is_gpt_oss = false;
     bool is_llama4 = false;
+    // Encoder-only embedder (#836, nomic-bert): bidirectional attention,
+    // post-LN with bias, no KV cache / LM head / sampling. Served by the
+    // dedicated encoder forward, never by the decoder loop.
+    bool is_encoder = false;
 
     // --- attention variant (drives the SWA / NoPE dispatch in run_attention) ---
     // The attention path forks on how positions + sliding windows work. Encoding

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -2478,7 +2478,12 @@ std::vector<int32_t> Tokenizer::encode_wordpiece(const std::string& text) const 
             size_t end = w.size();
             int32_t id = -1;
             while (end > start) {
-                std::string sub = (start > 0 ? "##" : "") + w.substr(start, end - start);
+                // llama.cpp's BERT-GGUF vocab stores WordPiece in SPM
+                // convention: word-initial pieces carry "▁", continuations
+                // are bare (HF "##xyz" -> "xyz", "xyz" -> "▁xyz").
+                std::string sub =
+                    (start == 0 ? std::string("\xE2\x96\x81") : std::string()) +
+                    w.substr(start, end - start);
                 auto it = token_to_id_.find(sub);
                 if (it != token_to_id_.end()) {
                     id = it->second;

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -2420,7 +2420,85 @@ std::vector<int32_t> Tokenizer::encode(const std::string& text, bool no_prefix) 
     if (type_ == "gemma4") {
         return encode_gemma4(normalized);
     }
+    if (type_ == "bert") {
+        return encode_wordpiece(normalized);
+    }
     return encode_spm(normalized, no_prefix);
+}
+
+// ---- BERT WordPiece (#836) ----
+// Uncased basic tokenizer (ASCII lowercase, whitespace split, punctuation
+// isolated) followed by greedy longest-match WordPiece: the first piece of a
+// word matches the raw vocab entry, continuations match "##"-prefixed
+// entries; a word with no full segmentation becomes [UNK]. Accent stripping
+// (NFD + combining-mark removal) is not implemented — the uncased vocab is
+// effectively ASCII and the HF-oracle cosine check gates correctness.
+std::vector<int32_t> Tokenizer::encode_wordpiece(const std::string& text) const {
+    std::vector<int32_t> out;
+    auto it_unk = token_to_id_.find("[UNK]");
+    const int32_t unk_id = (it_unk != token_to_id_.end()) ? it_unk->second : 100;
+
+    std::vector<std::string> words;
+    std::string cur;
+    auto flush = [&] {
+        if (!cur.empty()) {
+            words.push_back(cur);
+            cur.clear();
+        }
+    };
+    for (size_t i = 0; i < text.size();) {
+        const unsigned char c = static_cast<unsigned char>(text[i]);
+        if (c < 0x80) {
+            const char lc = static_cast<char>(std::tolower(c));
+            if (std::isspace(static_cast<unsigned char>(lc))) {
+                flush();
+                ++i;
+            } else if (std::ispunct(static_cast<unsigned char>(lc))) {
+                flush();
+                words.emplace_back(1, lc);
+                ++i;
+            } else {
+                cur += lc;
+                ++i;
+            }
+        } else {
+            // Multibyte codepoint: keep as-is inside the current word.
+            const size_t len = (c >= 0xF0) ? 4u : (c >= 0xE0) ? 3u : 2u;
+            cur += text.substr(i, std::min(len, text.size() - i));
+            i += len;
+        }
+    }
+    flush();
+
+    for (const auto& w : words) {
+        std::vector<int32_t> pieces;
+        size_t start = 0;
+        bool bad = false;
+        while (start < w.size()) {
+            size_t end = w.size();
+            int32_t id = -1;
+            while (end > start) {
+                std::string sub = (start > 0 ? "##" : "") + w.substr(start, end - start);
+                auto it = token_to_id_.find(sub);
+                if (it != token_to_id_.end()) {
+                    id = it->second;
+                    break;
+                }
+                --end;
+            }
+            if (id < 0) {
+                bad = true;
+                break;
+            }
+            pieces.push_back(id);
+            start = end;
+        }
+        if (bad)
+            out.push_back(unk_id);
+        else
+            out.insert(out.end(), pieces.begin(), pieces.end());
+    }
+    return out;
 }
 
 // ---- Decode (SentencePiece) ----

--- a/src/model/tokenizer.h
+++ b/src/model/tokenizer.h
@@ -141,6 +141,10 @@ private:
     // GPT2-style byte-level BPE (merge-rank based)
     std::vector<int32_t> encode_gpt2(const std::string& text) const;
 
+    // BERT WordPiece (#836, nomic-bert embedder): lowercase basic tokenizer +
+    // greedy longest-match with "##" continuation pieces, [UNK] fallback.
+    std::vector<int32_t> encode_wordpiece(const std::string& text) const;
+
     // GPT2 decode (reverse byte encoding)
     std::string decode_gpt2(const std::vector<int32_t>& tokens) const;
     std::string decode_gpt2_token(int32_t token) const;

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1159,7 +1159,8 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i, const Upl
     }
 
     // Post-layer norms (Gemma-3/4)
-    for (auto* norm : {&L.post_attn_norm, &L.post_ffn_norm, &L.ffn_pre_norm_2, &L.ffn_post_norm_1,
+    for (auto* norm : {&L.post_attn_norm, &L.post_ffn_norm, &L.post_attn_norm_bias,
+                       &L.post_ffn_norm_bias, &L.ffn_pre_norm_2, &L.ffn_post_norm_1,
                        &L.ffn_post_norm_2, &L.ffn_gate_inp_scale, &L.layer_out_scale, &L.expert_down_scale}) {
         if (norm->data && !norm->on_device) {
             if (!upload_unquantized_weight(*norm, QType::NONE, ctx.compute_dtype, ctx.stream,
@@ -2016,6 +2017,17 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
     // --- Embeddings, output norm, output projection ---
     if (!upload_embeddings_and_output(tok_emb_, out_norm_, out_proj_, ctx)) {
         return false;
+    }
+
+    // --- Encoder embedder extras (#836, nomic-bert) ---
+    for (auto* t : {&tok_emb_norm_, &tok_emb_norm_bias_, &token_types_}) {
+        if (t->data && !t->on_device) {
+            if (!upload_unquantized_weight(*t, QType::NONE, ctx.compute_dtype, ctx.stream,
+                                           ctx.gpu_allocs)) {
+                IMP_LOG_ERROR("Failed to upload encoder embedding norm/type tensor");
+                return false;
+            }
+        }
     }
 
     // =========================================================================

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -9,6 +9,7 @@
 #include "runtime/vram_budget.h"
 #include "runtime/batch.h"
 #include "compute/mtp_forward.h"
+#include "compute/encoder_forward.h"
 #include "memory/kv_cache.h"
 #include "memory/mem_account.h"
 #include "memory/vram_query.h"
@@ -119,6 +120,13 @@ Engine::~Engine() {
     if (pf_staging_evt_) {
         IMP_CUDA_CHECK_LOG(cudaEventDestroy(pf_staging_evt_));
         pf_staging_evt_ = nullptr;
+    }
+    // Encoder embedder workspace cleanup (#836)
+    if (encoder_ws_storage_) {
+        auto* ews = static_cast<imp::EncoderWorkspace*>(encoder_ws_storage_);
+        imp::encoder_workspace_free(*ews);
+        delete ews;
+        encoder_ws_storage_ = nullptr;
     }
     // MTP spec-decode workspace cleanup
     if (mtp_ws_storage_) {
@@ -269,6 +277,16 @@ void Engine::mtp_accuracy_reset() noexcept {
         auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
         imp::mtp_kv_reset(*ws);
     }
+}
+
+bool Engine::encoder_embed(const int32_t* tokens, int n, std::vector<float>& out) {
+    if (encoder_ws_storage_ == nullptr || !model_) {
+        IMP_LOG_ERROR("encoder_embed: no encoder workspace (not an encoder model?)");
+        return false;
+    }
+    auto* ews = static_cast<imp::EncoderWorkspace*>(encoder_ws_storage_);
+    out.resize(model_->config_.d_model);
+    return imp::encoder_embed(*model_, *ews, tokens, n, out.data(), stream_);
 }
 
 bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
@@ -629,6 +647,28 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     scheduler_ = std::make_unique<Scheduler>(config_.max_batch_size);
     (void)stream_.create(cudaStreamNonBlocking);
     MemAccount::instance().checkpoint("01_prewarm_gemm");
+
+    // --- Encoder-only embedder (#836): no executor, KV cache, decoder
+    // features, or warmup. Upload weights, dequant them into the dedicated
+    // encoder workspace, done — /v1/embeddings drives encoder_embed().
+    if (model_->profile().is_encoder) {
+        if (!model_->upload_weights_gpu(config_.compute_dtype, stream_, 1ULL << 30)) {
+            IMP_LOG_ERROR("encoder: weight upload failed");
+            return false;
+        }
+        auto* ews = new imp::EncoderWorkspace();
+        int cap = model_->config_.max_seq_len > 0 ? model_->config_.max_seq_len : 2048;
+        if (config_.max_seq_len > 0)
+            cap = std::min(cap, config_.max_seq_len);
+        if (!imp::encoder_workspace_init(*ews, *model_, cap, stream_)) {
+            delete ews;
+            return false;
+        }
+        encoder_ws_storage_ = ews;
+        IMP_LOG_INFO("Encoder embedder ready (arch=%s, max_tokens=%d, d=%d)",
+                     model_arch_name(model_->config_.arch), cap, model_->config_.d_model);
+        return true;
+    }
 
     // --- Sub-phases ---
     if (!init_weights())

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -196,6 +196,11 @@ public:
 
     // One draft step. Public for Phase 5 smoke testing; production callers
     // should not invoke directly until Phase 4 wires this into the decode loop.
+    // Encoder embedder (#836): pooled + L2-normalized embedding for `tokens`.
+    // Only valid when the loaded model is encoder-only (profile().is_encoder).
+    bool encoder_embed(const int32_t* tokens, int n, std::vector<float>& out);
+    bool is_encoder_model() const { return encoder_ws_storage_ != nullptr; }
+
     bool mtp_draft_one(int prev_token_id, const void* d_h_prev,
                        int hidden_dim, int vocab_size, int* out_token_id,
                        int* out_topk_ids = nullptr, int top_w = 0,
@@ -517,6 +522,7 @@ private:
     // Defined in <compute/mtp_forward.h>; forward-declared to avoid include.
     int mtp_spec_k_ = 0;
     void* mtp_ws_storage_ = nullptr;  // type-erased MtpDraftWorkspace*
+    void* encoder_ws_storage_ = nullptr;  // type-erased EncoderWorkspace* (#836)
 
     // Phase 3.5 telemetry: rolling MTP-draft-accuracy across the active session.
     // mtp_pending_prediction_ is the prediction made at the end of the

--- a/tests/test_encoder_embed.cpp
+++ b/tests/test_encoder_embed.cpp
@@ -1,0 +1,81 @@
+// =============================================================================
+// test_encoder_embed.cpp — encoder-only embedder e2e (#836, nomic-bert)
+// =============================================================================
+// Loads the real nomic-embed-text-v1.5 Q8_0 GGUF through the full engine path
+// (encoder branch: upload + workspace, no KV/warmup/executor) and checks:
+//   1. WordPiece tokenization matches the HF reference ids for a fixed string.
+//   2. encoder_embed returns a unit-norm vector of d_model floats.
+//   3. Semantic structure: cos(paraphrase pair) >> cos(unrelated pair), with
+//      the HF-oracle-verified reference values as loose anchors
+//      (imp 0.903 / 0.395; oracle cos(imp, hf) >= 0.999 on 2026-07-04).
+// GTEST_SKIPs when the model file is absent.
+// =============================================================================
+
+#include "model/gguf_loader.h"
+#include "model/model.h"
+#include "runtime/engine.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace {
+constexpr const char kNomicGguf[] = "/models/nomic-embed-text-v1.5.Q8_0.gguf";
+
+float cosine(const std::vector<float>& a, const std::vector<float>& b) {
+    float s = 0.0f;
+    for (size_t i = 0; i < a.size(); ++i) s += a[i] * b[i];
+    return s;
+}
+}  // namespace
+
+TEST(EncoderEmbedTest, NomicBertEmbedsMatchReferenceStructure) {
+    if (!fs::exists(kNomicGguf))
+        GTEST_SKIP() << "nomic GGUF not present at " << kNomicGguf;
+
+    std::shared_ptr<imp::Model> model = imp::load_gguf(kNomicGguf);
+    ASSERT_NE(model, nullptr);
+    ASSERT_TRUE(model->profile().is_encoder);
+
+    // 1. WordPiece vs HF reference ids (bert-base-uncased vocab):
+    //    "The lighthouse keeper swept the stairs." (no [CLS]/[SEP]).
+    auto toks = model->tokenizer()->encode("The lighthouse keeper swept the stairs.");
+    const std::vector<int32_t> ref = {1996, 10171, 10684, 7260, 1996, 5108, 1012};
+    ASSERT_EQ(toks.size(), ref.size());
+    for (size_t i = 0; i < ref.size(); ++i) EXPECT_EQ(toks[i], ref[i]) << "token " << i;
+
+    auto* tok = model->tokenizer();
+    imp::EngineConfig ecfg{};
+    imp::Engine engine;
+    ASSERT_TRUE(engine.init(model, ecfg));
+    ASSERT_TRUE(engine.is_encoder_model());
+
+    auto embed = [&](const std::string& text) {
+        std::vector<int32_t> t = tok->encode(text);
+        std::vector<int32_t> framed;
+        framed.push_back(101);  // [CLS]
+        framed.insert(framed.end(), t.begin(), t.end());
+        framed.push_back(102);  // [SEP]
+        std::vector<float> out;
+        EXPECT_TRUE(engine.encoder_embed(framed.data(), static_cast<int>(framed.size()), out));
+        return out;
+    };
+
+    auto a = embed("The lighthouse keeper swept the stairs.");
+    auto b = embed("A keeper of a lighthouse cleaned the steps.");
+    auto c = embed("Quantum chromodynamics describes the strong interaction.");
+
+    // 2. Unit norm, right dimensionality.
+    ASSERT_EQ(a.size(), 768u);
+    EXPECT_NEAR(std::sqrt(cosine(a, a)), 1.0f, 1e-3f);
+
+    // 3. Semantic structure (HF-oracle anchors 0.903 / 0.395, loose bounds).
+    const float sim_para = cosine(a, b);
+    const float sim_unrel = cosine(a, c);
+    EXPECT_GT(sim_para, 0.85f);
+    EXPECT_LT(sim_unrel, 0.55f);
+    EXPECT_GT(sim_para - sim_unrel, 0.3f);
+}

--- a/tests/test_encoder_embed.cpp
+++ b/tests/test_encoder_embed.cpp
@@ -38,6 +38,7 @@ TEST(EncoderEmbedTest, NomicBertEmbedsMatchReferenceStructure) {
 
     std::shared_ptr<imp::Model> model = imp::load_gguf(kNomicGguf);
     ASSERT_NE(model, nullptr);
+    model->build_profile();  // Engine::init does this in production
     ASSERT_TRUE(model->profile().is_encoder);
 
     // 1. WordPiece vs HF reference ids (bert-base-uncased vocab):

--- a/tests/test_gguf_loader.cpp
+++ b/tests/test_gguf_loader.cpp
@@ -194,9 +194,11 @@ TEST(GgufLoaderTest, EncoderOnlyArchDetection) {
 }
 
 TEST(GgufLoaderTest, EncoderArchGgufRejectedAtLoad) {
-    // Minimal valid GGUF v3 with general.architecture = "nomic-bert" and no
-    // tensors. The loader must throw a clear error (translated to ImpError at
-    // the C-API boundary) instead of mapping the arch to the generic decoder.
+    // Minimal valid GGUF v3 with general.architecture = "bert" and no
+    // tensors. Encoder archs WITHOUT a dedicated path (classic BERT/bge/e5:
+    // learned positions, CLS pooling) must still throw a clear error instead
+    // of mapping to the generic decoder. nomic-bert is admitted since #836
+    // (dedicated encoder forward — e2e covered by EncoderEmbedTest).
     auto append_str = [](std::vector<uint8_t>& buf, const std::string& s) {
         uint64_t len = s.size();
         const uint8_t* lp = reinterpret_cast<const uint8_t*>(&len);
@@ -208,7 +210,7 @@ TEST(GgufLoaderTest, EncoderArchGgufRejectedAtLoad) {
     uint32_t t_string = 8;  // GGUFValueType::STRING
     const uint8_t* tp = reinterpret_cast<const uint8_t*>(&t_string);
     data.insert(data.end(), tp, tp + 4);
-    append_str(data, "nomic-bert");
+    append_str(data, "bert");
 
     std::string path = write_temp_gguf(data);
     ASSERT_FALSE(path.empty());
@@ -219,7 +221,7 @@ TEST(GgufLoaderTest, EncoderArchGgufRejectedAtLoad) {
                << (model ? "a model" : "nullptr");
     } catch (const std::exception& e) {
         EXPECT_NE(std::string(e.what()).find("encoder-only"), std::string::npos) << e.what();
-        EXPECT_NE(std::string(e.what()).find("nomic-bert"), std::string::npos) << e.what();
+        EXPECT_NE(std::string(e.what()).find("bert"), std::string::npos) << e.what();
     }
 
     unlink(path.c_str());

--- a/tools/imp-server/handlers_misc.cpp
+++ b/tools/imp-server/handlers_misc.cpp
@@ -398,6 +398,39 @@ void handle_embeddings(const httplib::Request& req, httplib::Response& res, Serv
             return;
         }
 
+        // Encoder-only embedder (#836, nomic-bert): the dedicated bidirectional
+        // forward pools + L2-normalizes on device. Frame with [CLS]/[SEP]
+        // (BERT convention; ids come from the GGUF bos/eos metadata).
+        if (state.ctx && state.ctx->engine && state.ctx->engine->is_encoder_model()) {
+            auto* engine = state.ctx->engine.get();
+            std::vector<int32_t> framed;
+            framed.reserve(n_tokens + 2);
+            const int32_t cls = imp_model_bos_token(state.model);
+            const int32_t sep = (engine->model() && engine->model()->tokenizer())
+                                    ? engine->model()->tokenizer()->eos_id()
+                                    : -1;
+            if (cls >= 0 && (n_tokens == 0 || tokens[0] != cls))
+                framed.push_back(cls);
+            framed.insert(framed.end(), tokens.begin(), tokens.begin() + n_tokens);
+            if (sep >= 0 && framed.back() != sep)
+                framed.push_back(sep);
+            std::vector<float> emb;
+            if (!engine->encoder_embed(framed.data(), static_cast<int>(framed.size()), emb)) {
+                nlohmann::json error = {
+                    {"error",
+                     {{"message", "encoder forward failed (input too long for the encoder "
+                                  "workspace?)"},
+                      {"type", "server_error"}}}};
+                res.status = 500;
+                res.set_content(dump_safe(error), "application/json");
+                return;
+            }
+            data.push_back(
+                {{"object", "embedding"}, {"embedding", emb}, {"index", input_idx}});
+            total_prompt_tokens += static_cast<int>(framed.size());
+            continue;
+        }
+
         // Reject over-long inputs before prefill. Two independent bounds:
         //   1. the engine's allocated context (state.max_seq_len), and
         //   2. the executor's single-pass hidden capacity (max_tokens()): the


### PR DESCRIPTION
## What

Embedding models are served for real: `nomic-bert` GGUF checkpoints (reference: nomic-embed-text-v1.5 Q8_0) load into a **dedicated encoder path** — no KV cache, no executor/decoder loop, no warmup/graphs.

- **Encoder forward** (`src/compute/encoder_forward.{h,cu}`): bidirectional attention (`attention_cublas_prefill(causal=false)`), post-LN BERT structure with bias, rotary positions (θ=1000), SwiGLU FFN, token-type row 0, mean pooling + L2 normalize on device. Q8_0 weights are dequantized once at init into an owned FP16 workspace (~230 MB).
- **BERT WordPiece tokenizer** — llama.cpp's BERT GGUFs store the vocab in **SPM convention** (word-initial `▁`, bare continuations — NOT HF's `##`); token streams now match HF exactly.
- **True LayerNorm-with-bias kernel** (`layernorm_residual`) — imp only had RMSNorm.
- **Engine encoder branch** before `init_weights` (upload + encoder workspace, skip all decoder machinery); teardown wired.
- **`/v1/embeddings`** routes encoder models with [CLS]/[SEP] framing; decoder models keep the existing last-hidden mean-pool path.
- Loader admits **only** `nomic-bert`; classic BERT/bge/e5 (learned positions, token-type sequences, CLS pooling) and the SafeTensors path stay rejected with the #835 error until implemented.

## Verification

- **HF oracle** (same inputs, HF `trust_remote_code` reference, CPU): **cos(imp, hf) = 0.99914 / 0.99923 / 0.99898** on Q8_0; similarity matrix matches HF (imp 0.903/0.395 vs hf 0.903/0.397). Two bugs found by the oracle en route: the SPM vocab convention (0.48 → 0.91) and `rope_forward` needing 4D views (0.91 → 0.999 — 2D views silently rotate garbage; the tell was neox=true/false producing identical output).
- **`EncoderEmbedTest`** e2e (real GGUF): WordPiece ids vs HF reference, unit norm, semantic structure anchors.
- Full GPU suite green (incl. updated `GgufLoaderTest.EncoderArchGgufRejectedAtLoad` — now asserts on `bert`, since nomic-bert is admitted).
- `verify --fast`: suite/e2e/prefill/long-ctx/smoke PASS; decode WARN + graphs-gate FAIL are the documented depressed-host state (#526, self-flagged by the gate; unmodified main read 1.008x on the same gate today).

Closes #836 (GGUF/nomic-bert scope; SafeTensors + classic-BERT follow-ups noted in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)