### PR TITLE
spike(attention): SageAttention3 NVFP4-attention recipe — flag-gated, quality-refuted at LLM context (#846)

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -128,6 +128,18 @@ fa2_pv_f16acc        = true
 # -1 = auto (derived from the cuBLAS S-matrix VRAM cap).
 fmha_prefill_threshold = -1
 mxfp4                = "auto"
+# #846 NVFP4-attention spike (SageAttention3 recipe), all require
+# mxfp4 = "always" (+ fa2_fp16qk = "never" so the MXFP4 FMHA actually serves
+# hd=128 prefill). QUALITY-NEGATIVE on LLMs at real context lengths
+# (Qwen3-14B-NVFP4 teacher-forced NLL +10% at 9k tokens, full recipe) —
+# diagnostic/research knobs, keep off in production.
+# blockscale: per-16-element UE4M3 scales in the mxf4nvf4.block_scale MMA
+#   (vs legacy per-row software scales, which are catastrophically lossy).
+# ksmooth: subtract per-(batch,kv_head,channel) K mean before quantization.
+# pv_fp4: P·V in NVFP4 too (two-level P scaling).
+mxfp4_blockscale     = false
+mxfp4_ksmooth        = false
+mxfp4_pv_fp4         = false
 mxfp4_fp16_fallback  = false
 # MXFP4 → FP16 cache pruning policy: "legacy" caches FP16 for every MXFP4
 # tensor; "pruned" skips MoE expert weights + LM head (32 GiB-class loads).

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -2,6 +2,7 @@
 #include "compute/attention_tc.h"
 #include "core/logging.h"
 #include "runtime/config.h"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cstdio>
 #include <cstdlib>
@@ -39,9 +40,12 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
                                 const RuntimeConfig& rcfg, int q_offset) {
     // MXFP4 Flash Attention: tiled FP4 E2M1 Q·K^T with online softmax.
     // O(n) memory, ~4x score throughput over FP16, ~2x over FP8.
-    // Enabled with IMP_MXFP4_ATTENTION=1.
+    // Enabled with [attention] mxfp4 = "always". Blockscale/ksmooth/pv_fp4
+    // (#846 SageAttention3-recipe spike) are read from process_diag inside
+    // the launcher.
     if (attention_mxfp4_available()) {
-        if (fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream)) {
+        if (fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
+                                     process_diag_mxfp4_blockscale(), q_offset)) {
             return;
         }
         // Fall through: head_dim not supported (e.g. < 32), use FP8/FP16 path

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -24,6 +24,7 @@
 #include "compute/attention_paged_common.cuh"
 #include "core/logging.h"
 #include "quant/fp8_utils.cuh"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <float.h>
@@ -53,6 +54,14 @@ static constexpr int MX_MMA_K = 32;  // same as FP8
 static constexpr int MX_WMMA_M = 16;
 static constexpr int MX_WMMA_N = 16;
 static constexpr int MX_WMMA_K = 16;
+
+// PVFP4 two-level P scaling (#846 / SageAttention3 §3.2): each P row is
+// rescaled so its max lands at 448·6 before 1x16 microscaling — the largest
+// value an E2M1 nibble (max 6) times the largest UE4M3 scale (448) can carry.
+// Tail blocks (post-softmax P spans 6+ orders of magnitude) then map to
+// mid-range UE4M3 scales instead of collapsing to zero, which is the measured
+// failure mode of single-level per-16 quantization (fp4_pv_bench, p99=797%).
+static constexpr float MX_PV_LEVEL1 = 448.0f * 6.0f;
 
 // =============================================================================
 // Device helpers: FP4 E2M1 quantization
@@ -104,11 +113,25 @@ __device__ __forceinline__ uint8_t pack_fp4_pair(float v0, float v1) {
 //                         Quantization uses per-k_group (16 elements) absmax,
 //                         preserving local precision vs per-row. Post-MMA manual
 //                         scaling is dropped — HW scales during the dot product.
-template <int Bq, int HD, bool UseBlockScaleMma = false>
+// PVFP4 (#846, requires UseBlockScaleMma): P·V also runs on the block-scaled
+//                         MMA. P is quantized per-row TWO-LEVEL: each row is
+//                         rescaled so its max hits the full E4M3-scale range
+//                         (448·6) before 1x16 microscaling — small-magnitude
+//                         tail blocks then get representable UE4M3 scales
+//                         instead of collapsing to zero. The inverse row factor
+//                         is applied when accumulating the MMA output into
+//                         O_acc. V is quantized per-16-block along the KV dim
+//                         into a transposed smem tile (B-operand layout).
+// d_kmean (#846 K-smoothing): per-(batch, kv_head, channel) mean of K,
+//                         subtracted before quantization (nullptr = off). The
+//                         dropped Q·mean^T term is constant per query row and
+//                         cancels under softmax (launcher gates softcap == 0).
+template <int Bq, int HD, bool UseBlockScaleMma = false, bool PVFP4 = false>
 __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
     const half* __restrict__ Q, const half* __restrict__ K, const half* __restrict__ V, half* __restrict__ O,
     int batch_size, int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale, bool causal,
-    int sliding_window, float softcap) {
+    int sliding_window, float softcap, int q_offset, const float* __restrict__ d_kmean) {
+    static_assert(!PVFP4 || UseBlockScaleMma, "PVFP4 rides on the block-scaled MMA path");
     constexpr int Bkv = MX_Bkv;
     constexpr int head_dim = HD;
     constexpr int hd_half = HD / 2;  // packed FP4 data bytes per row
@@ -177,8 +200,24 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
     // Each row has n_k_groups = HD/16 scales (one per 16-K-block).
     // Only populated when UseBlockScaleMma=true. Placed at the tail.
     constexpr int n_k_groups = HD / 16;
-    uint8_t* q_scales_fp8 = reinterpret_cast<uint8_t*>(row_l + Bq);
+    // PVFP4 buffers (sized 0-ish when off; kept in the pointer chain so the
+    // layout matches compute_smem_mxfp4). All strides are multiples of 4 so
+    // the uint32 sfa/sfb loads stay aligned. p_rowf goes first (float align).
+    constexpr int n_kv_groups = Bkv / 16;              // P/V k-groups (KV dim)
+    constexpr int kv_half_padded = Bkv / 2 + 4;        // packed P/V^T row bytes
+    float* p_rowf = row_l + Bq;                        // [Bq] per-row PV post-factor
+    float* p_rowq = p_rowf + (PVFP4 ? Bq : 0);         // [Bq] per-row P quant multiplier
+    uint8_t* q_scales_fp8 = reinterpret_cast<uint8_t*>(p_rowq + (PVFP4 ? Bq : 0));
     uint8_t* k_scales_fp8 = q_scales_fp8 + Bq * n_k_groups;
+    uint8_t* p_scales_fp8 = k_scales_fp8 + Bkv * n_k_groups;  // [Bq][n_kv_groups]
+    uint8_t* v_scales_fp8 = p_scales_fp8 + Bq * n_kv_groups;  // [HD][n_kv_groups]
+    uint8_t* P_fp4 = v_scales_fp8 + HD * n_kv_groups;         // [Bq][kv_half_padded]
+    uint8_t* V_fp4T = P_fp4 + Bq * kv_half_padded;            // [HD][kv_half_padded]
+
+    // K-smoothing: per-channel mean pointer for this (batch, kv_head).
+    const float* kmean = (d_kmean != nullptr)
+                             ? d_kmean + ((int64_t)batch_idx * n_kv_heads + kv_head) * head_dim
+                             : nullptr;
 
     // Pre-compute sqrt(attention_scale) to absorb into Q and K scales (Opt 3).
     // S_true[i,j] = q_scale[i] * k_scale[j] * mma[i,j], and we want the result
@@ -355,7 +394,7 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
     // ---- KV tile loop bounds ----
     int num_kv_tiles, first_kv_tile;
     compute_kv_tile_bounds(q_start, Bq, Bkv, seq_q, seq_kv, causal, sliding_window, first_kv_tile,
-                           num_kv_tiles);
+                           num_kv_tiles, q_offset);
 
     // FP4 MMA tiling: m16n8k32 E2M1
     constexpr int FP4_K = MX_MMA_K;              // 32
@@ -392,7 +431,18 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                     if (kv_start + r < seq_kv) {
                         const float4* src = reinterpret_cast<const float4*>(
                             &K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]);
-                        *dst = *src;
+                        if (kmean == nullptr) {
+                            *dst = *src;
+                        } else {
+                            // K-smoothing: stage K - mean(K) so absmax + quant
+                            // both see the smoothed values.
+                            float4 raw = *src;
+                            half* h = reinterpret_cast<half*>(&raw);
+#pragma unroll
+                            for (int e = 0; e < 8; e++)
+                                h[e] = __float2half(__half2float(h[e]) - kmean[d + e]);
+                            *dst = raw;
+                        }
                     } else {
                         *dst = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
                     }
@@ -475,8 +525,12 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                     if (kv_start + r < seq_kv) {
                         const half* row = &K_ptr[(int64_t)(kv_start + r) * kv_row_stride + kg * 16];
 #pragma unroll
-                        for (int i = 0; i < 16; i++)
-                            absmax = fmaxf(absmax, fabsf(__half2float(row[i])));
+                        for (int i = 0; i < 16; i++) {
+                            float kv = __half2float(row[i]);
+                            if (kmean != nullptr)
+                                kv -= kmean[kg * 16 + i];
+                            absmax = fmaxf(absmax, fabsf(kv));
+                        }
                     }
                     float raw = absmax / 6.0f;
                     k_scales_fp8[r * n_k_groups + kg] = float_to_fp8_e4m3(raw * sqrt_scale);
@@ -513,11 +567,13 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                         } else {
                             inv_scale = (k_scales[r] > 0.0f) ? (sqrt_scale / k_scales[r]) : 0.0f;
                         }
-                        float v0 = __half2float(K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]) *
-                                   inv_scale;
-                        float v1 = __half2float(K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d + 1]) *
-                                   inv_scale;
-                        KV_fp4[r * hd_half_padded + d_byte] = pack_fp4_pair(v0, v1);
+                        float v0 = __half2float(K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d]);
+                        float v1 = __half2float(K_ptr[(int64_t)(kv_start + r) * kv_row_stride + d + 1]);
+                        if (kmean != nullptr) {
+                            v0 -= kmean[d];
+                            v1 -= kmean[d + 1];
+                        }
+                        KV_fp4[r * hd_half_padded + d_byte] = pack_fp4_pair(v0 * inv_scale, v1 * inv_scale);
                     } else {
                         KV_fp4[r * hd_half_padded + d_byte] = 0;
                     }
@@ -694,12 +750,14 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                 int r0 = (lane_id / 4) % 8;
                 int c0 = (lane_id % 4) * 2;
 
-#define FUSED_STORE(val, gq, gk, qs, ks, idx)                           \
+// lq = local Q row (bounds vs seq_q); gq = q_offset + lq (causal/SWA masks,
+// chunked-prefill continuation).
+#define FUSED_STORE(val, lq, gq, gk, qs, ks, idx)                       \
     do {                                                                \
         float s = (val) * (qs) * (ks);                                  \
         if (softcap > 0.0f)                                             \
             s = softcap * tanhf(s / softcap);                           \
-        if ((gq) >= seq_q || (gk) >= seq_kv)                            \
+        if ((lq) >= seq_q || (gk) >= seq_kv)                            \
             s = -FLT_MAX;                                               \
         else if (causal && (gq) < (gk))                                 \
             s = -FLT_MAX;                                               \
@@ -708,20 +766,22 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
         S_tile[idx] = s;                                                \
     } while (0)
 
-                int gq0 = q_start + base_row + r0;
-                int gq1 = q_start + base_row + r0 + 8;
+                int lq0 = q_start + base_row + r0;
+                int lq1 = q_start + base_row + r0 + 8;
+                int gq0 = q_offset + lq0;
+                int gq1 = q_offset + lq1;
 
                 if constexpr (UseBlockScaleMma) {
 // 4-issue path: store 4 ci's, scales already HW-applied
-#define STORE_CI(d_a, d_b, d_c, d_d, ci_off)                                                       \
-    do {                                                                                           \
-        int base_col_x = (ci_meta_base + ci_off) * MX_MMA_N;                                       \
-        int gk0_x = kv_start + base_col_x + c0;                                                    \
-        int gk1_x = kv_start + base_col_x + c0 + 1;                                                \
-        FUSED_STORE(d_a, gq0, gk0_x, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_x + c0);         \
-        FUSED_STORE(d_b, gq0, gk1_x, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_x + c0 + 1);     \
-        FUSED_STORE(d_c, gq1, gk0_x, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_x + c0);     \
-        FUSED_STORE(d_d, gq1, gk1_x, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_x + c0 + 1); \
+#define STORE_CI(d_a, d_b, d_c, d_d, ci_off)                                                             \
+    do {                                                                                                 \
+        int base_col_x = (ci_meta_base + ci_off) * MX_MMA_N;                                             \
+        int gk0_x = kv_start + base_col_x + c0;                                                          \
+        int gk1_x = kv_start + base_col_x + c0 + 1;                                                      \
+        FUSED_STORE(d_a, lq0, gq0, gk0_x, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_x + c0);          \
+        FUSED_STORE(d_b, lq0, gq0, gk1_x, 1.0f, 1.0f, (base_row + r0) * Bkv + base_col_x + c0 + 1);      \
+        FUSED_STORE(d_c, lq1, gq1, gk0_x, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_x + c0);      \
+        FUSED_STORE(d_d, lq1, gq1, gk1_x, 1.0f, 1.0f, (base_row + r0 + 8) * Bkv + base_col_x + c0 + 1);  \
     } while (0)
                     STORE_CI(d0, d1, d2, d3, 0);
                     STORE_CI(d4, d5, d6, d7, 1);
@@ -737,10 +797,10 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                     float ks1 = k_scales[base_col + c0 + 1];
                     int gk0 = kv_start + base_col + c0;
                     int gk1 = kv_start + base_col + c0 + 1;
-                    FUSED_STORE(d0, gq0, gk0, qs0, ks0, (base_row + r0) * Bkv + base_col + c0);
-                    FUSED_STORE(d1, gq0, gk1, qs0, ks1, (base_row + r0) * Bkv + base_col + c0 + 1);
-                    FUSED_STORE(d2, gq1, gk0, qs1, ks0, (base_row + r0 + 8) * Bkv + base_col + c0);
-                    FUSED_STORE(d3, gq1, gk1, qs1, ks1, (base_row + r0 + 8) * Bkv + base_col + c0 + 1);
+                    FUSED_STORE(d0, lq0, gq0, gk0, qs0, ks0, (base_row + r0) * Bkv + base_col + c0);
+                    FUSED_STORE(d1, lq0, gq0, gk1, qs0, ks1, (base_row + r0) * Bkv + base_col + c0 + 1);
+                    FUSED_STORE(d2, lq1, gq1, gk0, qs1, ks0, (base_row + r0 + 8) * Bkv + base_col + c0);
+                    FUSED_STORE(d3, lq1, gq1, gk1, qs1, ks1, (base_row + r0 + 8) * Bkv + base_col + c0 + 1);
                 }
 #undef FUSED_STORE
             }
@@ -796,11 +856,15 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
             float m_new = fmaxf(m_old, m_ij);
             float alpha = __expf(m_old - m_new);
 
-            // Step 3: Exp + sum
+            // Step 3: Exp + sum. Sentinel guard: fully-masked rows (m_new
+            // stuck at -FLT_MAX) would turn every masked score into
+            // expf(0) = 1 — map masked scores to 0 explicitly (mirrors the
+            // guard in fmha_sm120_kernel / the FA2 kernel).
             float partial_sum = 0.0f;
             if (row_valid) {
                 for (int c = sm_lane; c < Bkv; c += TPR) {
-                    float p = __expf(S_tile[r * Bkv + c] - m_new);
+                    float s_val = S_tile[r * Bkv + c];
+                    float p = (s_val <= -FLT_MAX * 0.5f) ? 0.0f : __expf(s_val - m_new);
                     partial_sum += p;
                     S_tile[r * Bkv + c] = p;
                 }
@@ -826,28 +890,163 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                 }
             }
 
-            // Step 6: Normalize + float→half for P.
-            // In-place float→half compaction: stage in registers + barrier
-            // (SP_half row r aliases the bytes of float row r/2 — unsynced
-            // stores clobber float scores other threads have not read yet,
-            // issue #528; see attention_fmha_sm120.cu).
-            constexpr int CPT = Bkv / TPR;
-            float spv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
-            half hbuf[CPT];
+            if constexpr (!PVFP4) {
+                // Step 6: Normalize + float→half for P.
+                // In-place float→half compaction: stage in registers + barrier
+                // (SP_half row r aliases the bytes of float row r/2 — unsynced
+                // stores clobber float scores other threads have not read yet,
+                // issue #528; see attention_fmha_sm120.cu).
+                constexpr int CPT = Bkv / TPR;
+                float spv = (l_new > 0.0f) ? (1.0f / l_new) : 0.0f;
+                half hbuf[CPT];
 #pragma unroll
-            for (int i = 0; i < CPT; i++) {
-                int c = sm_lane + i * TPR;
-                hbuf[i] = __float2half(row_valid ? S_tile[r * Bkv + c] * spv : 0.0f);
+                for (int i = 0; i < CPT; i++) {
+                    int c = sm_lane + i * TPR;
+                    hbuf[i] = __float2half(row_valid ? S_tile[r * Bkv + c] * spv : 0.0f);
+                }
+                __syncthreads();  // all float reads of S_tile complete before any half write
+#pragma unroll
+                for (int i = 0; i < CPT; i++)
+                    SP_half[r * Bkv + sm_lane + i * TPR] = hbuf[i];
+            } else {
+                // Step 6' (#846): two-level FP4 quantization of P.
+                // Level 1: the row's tile-local max p is exp(m_ij - m_new);
+                // rescale the row so that max lands at MX_PV_LEVEL1 (448·6).
+                // Level 2: per-16 absmax → UE4M3 scale, nibbles vs dequantized
+                // scale (mirrors the Q/K blockscale quant above). The inverse
+                // row factor (including the 1/l_new normalization the legacy
+                // path folds into P) is applied post-MMA via p_rowf.
+                float rowmax_p = (m_ij <= -FLT_MAX * 0.5f) ? 0.0f : __expf(m_ij - m_new);
+                if (sm_lane == 0 && r < Bq) {
+                    const bool ok = row_valid && l_new > 0.0f && rowmax_p > 0.0f;
+                    p_rowf[r] = ok ? rowmax_p / (MX_PV_LEVEL1 * l_new) : 0.0f;
+                    p_rowq[r] = ok ? MX_PV_LEVEL1 / rowmax_p : 0.0f;
+                }
+                __syncthreads();  // p values (Step 3) + row factors visible block-wide
+
+                const int total_groups = Bq * n_kv_groups;
+                for (int idx = tid; idx < total_groups; idx += MX_BLOCK_THREADS) {
+                    const int rr = idx / n_kv_groups;
+                    const int kg = idx % n_kv_groups;
+                    const float rq = p_rowq[rr];
+                    const float* prow = &S_tile[rr * Bkv + kg * 16];
+                    float bmax = 0.0f;  // p >= 0, no fabs needed
+#pragma unroll
+                    for (int i = 0; i < 16; i++)
+                        bmax = fmaxf(bmax, prow[i]);
+                    bmax *= rq;
+                    const uint8_t sf = float_to_fp8_e4m3(bmax / 6.0f);
+                    p_scales_fp8[rr * n_kv_groups + kg] = sf;
+                    const float dq = fp8_e4m3_to_float_fast(sf);
+                    const float inv = (dq > 0.0f) ? (rq / dq) : 0.0f;
+                    uint8_t* dst = &P_fp4[rr * kv_half_padded + kg * 8];
+#pragma unroll
+                    for (int i = 0; i < 8; i++)
+                        dst[i] = pack_fp4_pair(prow[2 * i] * inv, prow[2 * i + 1] * inv);
+                }
+                (void)SP_half;
             }
-            __syncthreads();  // all float reads of S_tile complete before any half write
-#pragma unroll
-            for (int i = 0; i < CPT; i++)
-                SP_half[r * Bkv + sm_lane + i * TPR] = hbuf[i];
         }
 
         // Wait for V prefetch to complete, then sync all SMEM writes (P + V)
         cp_async_wait_group<0>();
         __syncthreads();
+
+        if constexpr (PVFP4) {
+            // ============================================================
+            // Phase 3' (#846): V^T per-16-block quant + FP4 P·V MMA
+            // ============================================================
+            // V^T quant: one (hd_col, kv_group) block = 16 consecutive KV
+            // rows at one head_dim column; packed transposed so the PV
+            // B-operand reads k-consecutive nibbles (KV is the MMA k-dim).
+            {
+                const int total_groups = head_dim * n_kv_groups;
+                for (int idx = tid; idx < total_groups; idx += MX_BLOCK_THREADS) {
+                    const int dcol = idx / n_kv_groups;
+                    const int kg = idx % n_kv_groups;
+                    float vals[16];
+                    float bmax = 0.0f;
+#pragma unroll
+                    for (int i = 0; i < 16; i++) {
+                        vals[i] = __half2float(KV_fp16[(kg * 16 + i) * head_dim + dcol]);
+                        bmax = fmaxf(bmax, fabsf(vals[i]));
+                    }
+                    const uint8_t sf = float_to_fp8_e4m3(bmax / 6.0f);
+                    v_scales_fp8[dcol * n_kv_groups + kg] = sf;
+                    const float dq = fp8_e4m3_to_float_fast(sf);
+                    const float inv = (dq > 0.0f) ? (1.0f / dq) : 0.0f;
+                    uint8_t* dst = &V_fp4T[dcol * kv_half_padded + kg * 8];
+#pragma unroll
+                    for (int i = 0; i < 8; i++)
+                        dst[i] = pack_fp4_pair(vals[2 * i] * inv, vals[2 * i + 1] * inv);
+                }
+            }
+            __syncthreads();
+
+            // FP4 P·V: m16n8k64, k = Bkv = 64 → exactly ONE block-scaled MMA
+            // per 16×8 O tile. Same operand/scale register layout as the QK
+            // blockscale path above ((T32,V32)→(M16,K64) per CUTLASS traits).
+            static_assert(!PVFP4 || Bkv == 64, "PV MMA consumes k = 64 = Bkv in one issue");
+            {
+                const int pv_col_tiles = head_dim / MX_MMA_N;
+                const int pv_total = (Bq / MX_MMA_M) * pv_col_tiles;
+                const int group_id = lane_id / 4;
+                const int byte_offset = (lane_id % 4) * 4;
+                const int m_sfa = (lane_id / 4) + (lane_id % 2) * 8;
+                const int n_sfb = lane_id / 4;
+                constexpr uint16_t bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+                for (int tile_idx = warp_id; tile_idx < pv_total; tile_idx += MX_NUM_WARPS) {
+                    const int ri = tile_idx / pv_col_tiles;
+                    const int ci = tile_idx % pv_col_tiles;
+                    float d0 = 0.0f, d1 = 0.0f, d2 = 0.0f, d3 = 0.0f;
+                    const uint8_t* p_base = P_fp4 + ri * MX_MMA_M * kv_half_padded;
+                    uint32_t a0 = *reinterpret_cast<const uint32_t*>(p_base + group_id * kv_half_padded +
+                                                                     byte_offset);
+                    uint32_t a1 = *reinterpret_cast<const uint32_t*>(
+                        p_base + (group_id + 8) * kv_half_padded + byte_offset);
+                    uint32_t a2 = *reinterpret_cast<const uint32_t*>(p_base + group_id * kv_half_padded +
+                                                                     16 + byte_offset);
+                    uint32_t a3 = *reinterpret_cast<const uint32_t*>(
+                        p_base + (group_id + 8) * kv_half_padded + 16 + byte_offset);
+                    const uint8_t* v_base = V_fp4T + (size_t)(ci * MX_MMA_N) * kv_half_padded;
+                    uint32_t b0 = *reinterpret_cast<const uint32_t*>(v_base + group_id * kv_half_padded +
+                                                                     byte_offset);
+                    uint32_t b1 = *reinterpret_cast<const uint32_t*>(v_base + group_id * kv_half_padded +
+                                                                     16 + byte_offset);
+                    uint32_t sfa = *reinterpret_cast<const uint32_t*>(
+                        &p_scales_fp8[(ri * MX_MMA_M + m_sfa) * n_kv_groups]);
+                    uint32_t sfb = *reinterpret_cast<const uint32_t*>(
+                        &v_scales_fp8[(ci * MX_MMA_N + n_sfb) * n_kv_groups]);
+#if __CUDA_ARCH__ >= 1200
+                    asm volatile(
+                        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32."
+                        "e2m1.e2m1.f32.ue4m3 "
+                        "{%0, %1, %2, %3},"
+                        "{%4, %5, %6, %7},"
+                        "{%8, %9},"
+                        "{%10, %11, %12, %13},"
+                        "{%14},"
+                        "{%15, %16},"
+                        "{%17},"
+                        "{%18, %19};\n"
+                        : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+                        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d0), "f"(d1), "f"(d2),
+                          "f"(d3), "r"(sfa), "h"(bidA), "h"(tidA), "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+                    // Per-row two-level factor folds back the level-1 rescale
+                    // AND the 1/l_new softmax normalization.
+                    const int r0 = ri * MX_MMA_M + (lane_id / 4);
+                    const int c0 = ci * MX_MMA_N + (lane_id % 4) * 2;
+                    O_acc[r0 * head_dim + c0] += p_rowf[r0] * d0;
+                    O_acc[r0 * head_dim + c0 + 1] += p_rowf[r0] * d1;
+                    O_acc[(r0 + 8) * head_dim + c0] += p_rowf[r0 + 8] * d2;
+                    O_acc[(r0 + 8) * head_dim + c0 + 1] += p_rowf[r0 + 8] * d3;
+                }
+            }
+            first_kv_iter = false;
+            __syncthreads();
+            continue;
+        }
 
         // ============================================================
         // Phase 3: O_acc += P · V using FP16 WMMA (m16n16k16)
@@ -906,7 +1105,7 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
 // Shared memory computation
 // =============================================================================
 
-static size_t compute_smem_mxfp4(int Bq, int Bkv, int head_dim) {
+static size_t compute_smem_mxfp4(int Bq, int Bkv, int head_dim, bool pv_fp4 = false) {
     size_t q_fp4 = (size_t)Bq * (head_dim / 2 + 4);         // Q packed FP4 (padded stride)
     size_t q_scales = (size_t)Bq * sizeof(float);           // Q row scales
     size_t align = 16;                                      // alignment padding
@@ -917,7 +1116,38 @@ static size_t compute_smem_mxfp4(int Bq, int Bkv, int head_dim) {
     size_t softmax = 2 * (size_t)Bq * sizeof(float);        // row_m + row_l
     int n_k_groups = head_dim / 16;
     size_t scales_fp8 = (size_t)(Bq + Bkv) * n_k_groups;  // UE4M3 per-16-K scales (blockscale)
-    return q_fp4 + q_scales + align + kv_buf + k_scales + s_tile + o_acc + softmax + scales_fp8;
+    size_t pv = 0;
+    if (pv_fp4) {
+        const int n_kv_groups = Bkv / 16;
+        const int kv_half_padded = Bkv / 2 + 4;
+        pv = 2 * (size_t)Bq * sizeof(float)          // p_rowf + p_rowq
+             + (size_t)Bq * n_kv_groups              // P scales
+             + (size_t)head_dim * n_kv_groups        // V scales
+             + (size_t)Bq * kv_half_padded           // P_fp4
+             + (size_t)head_dim * kv_half_padded;    // V_fp4T
+    }
+    return q_fp4 + q_scales + align + kv_buf + k_scales + s_tile + o_acc + softmax + scales_fp8 + pv;
+}
+
+// =============================================================================
+// K per-channel mean pre-pass (#846 smoothing)
+// =============================================================================
+// One block per (batch, kv_head); threads stride over head_dim channels, each
+// summing seq_kv rows (consecutive threads read consecutive channels →
+// coalesced per row). Output: mean[batch * n_kv_heads + kv_head][head_dim].
+__global__ void mxfp4_k_channel_mean_kernel(const half* __restrict__ K, float* __restrict__ mean,
+                                            int seq_kv, int n_kv_heads, int head_dim) {
+    const int bh = blockIdx.x;
+    const int batch = bh / n_kv_heads;
+    const int kvh = bh % n_kv_heads;
+    const int64_t row_stride = (int64_t)n_kv_heads * head_dim;
+    const half* base = K + (int64_t)batch * seq_kv * row_stride + (int64_t)kvh * head_dim;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        float s = 0.0f;
+        for (int r = 0; r < seq_kv; r++)
+            s += __half2float(base[(int64_t)r * row_stride + d]);
+        mean[(int64_t)bh * head_dim + d] = s / (float)seq_kv;
+    }
 }
 
 // =============================================================================
@@ -926,7 +1156,7 @@ static size_t compute_smem_mxfp4(int Bq, int Bkv, int head_dim) {
 
 bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                               bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                              bool use_blockscale) {
+                              bool use_blockscale, int q_offset) {
     if (Q.qtype != QType::F16)
         return false;
     // Blockscale MMA operates on K=64 per issue; head_dim must be a multiple of 64.
@@ -949,6 +1179,12 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
     if (head_dim % MX_MMA_K != 0)
         return false;  // FP4 MMA needs head_dim % 32 == 0
 
+    // #846 recipe knobs (blockscale only). K-smoothing needs softcap == 0:
+    // the dropped Q·mean^T term only cancels under a pure shift-invariant
+    // softmax — tanh softcapping breaks that.
+    const bool pv_fp4 = use_blockscale && process_diag_mxfp4_pv_fp4();
+    const bool ksmooth = use_blockscale && process_diag_mxfp4_ksmooth() && softcap == 0.0f;
+
     int device = 0;
     cudaGetDevice(&device);
     int max_smem = 0;
@@ -957,9 +1193,9 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
     // Select Bq: prefer larger tiles, fall back for larger HD
     int Bq;
     {
-        size_t smem_128 = compute_smem_mxfp4(128, MX_Bkv, head_dim);
-        size_t smem_64 = compute_smem_mxfp4(64, MX_Bkv, head_dim);
-        size_t smem_32 = compute_smem_mxfp4(32, MX_Bkv, head_dim);
+        size_t smem_128 = compute_smem_mxfp4(128, MX_Bkv, head_dim, pv_fp4);
+        size_t smem_64 = compute_smem_mxfp4(64, MX_Bkv, head_dim, pv_fp4);
+        size_t smem_32 = compute_smem_mxfp4(32, MX_Bkv, head_dim, pv_fp4);
         if (smem_128 <= (size_t)max_smem) {
             Bq = 128;
         } else if (smem_64 <= (size_t)max_smem) {
@@ -973,7 +1209,40 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
         }
     }
 
-    const size_t smem = compute_smem_mxfp4(Bq, MX_Bkv, head_dim);
+    const size_t smem = compute_smem_mxfp4(Bq, MX_Bkv, head_dim, pv_fp4);
+
+    // K-smoothing pre-pass: per-(batch, kv_head, channel) mean into a
+    // persistent grow-only scratch (process lifetime, tiny: bh × hd floats).
+    const float* d_kmean = nullptr;
+    if (ksmooth) {
+        static float* s_d_kmean = nullptr;
+        static size_t s_kmean_cap = 0;
+        const size_t need = (size_t)batch_size * n_kv_heads * head_dim;
+        if (need > s_kmean_cap) {
+            if (s_d_kmean != nullptr)
+                cudaFree(s_d_kmean);
+            if (cudaMalloc(&s_d_kmean, need * sizeof(float)) != cudaSuccess) {
+                s_d_kmean = nullptr;
+                s_kmean_cap = 0;
+            } else {
+                s_kmean_cap = need;
+            }
+        }
+        if (s_d_kmean != nullptr) {
+            mxfp4_k_channel_mean_kernel<<<batch_size * n_kv_heads, 128, 0, stream>>>(
+                reinterpret_cast<const half*>(K.data), s_d_kmean, seq_kv, n_kv_heads, head_dim);
+            d_kmean = s_d_kmean;
+        }
+    }
+
+    // Engagement log (INFO once): the quality gate is only meaningful if this
+    // kernel actually serves prefill — see the #511/#656 vacuous-closure lesson.
+    static bool logged_once = false;
+    if (!logged_once) {
+        logged_once = true;
+        IMP_LOG_INFO("FMHA MXFP4 sm120 ACTIVE (hd=%d, Bq=%d, blockscale=%d, ksmooth=%d, pv_fp4=%d)",
+                     head_dim, Bq, (int)use_blockscale, (int)(d_kmean != nullptr), (int)pv_fp4);
+    }
 
     const int num_q_tiles = (seq_q + Bq - 1) / Bq;
     dim3 grid(num_q_tiles, batch_size * n_heads);
@@ -985,9 +1254,9 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
         batch_size, seq_q, seq_kv, n_heads, n_kv_heads, head_dim, Bq, MX_Bkv, smem, causal, sliding_window,
         softcap);
 
-#define LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, BS)                                                                 \
+#define LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, BS, PV)                                                             \
     do {                                                                                                   \
-        cudaError_t attr_err = cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS>,                   \
+        cudaError_t attr_err = cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV>,               \
                                                     cudaFuncAttributeMaxDynamicSharedMemorySize,           \
                                                     static_cast<int>(smem));                               \
         if (attr_err != cudaSuccess) {                                                                     \
@@ -995,23 +1264,26 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                          (int)BS, smem, cudaGetErrorString(attr_err));                                     \
             return false;                                                                                  \
         }                                                                                                  \
-        cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS>,                                          \
+        cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV>,                                      \
                              cudaFuncAttributePreferredSharedMemoryCarveout,                               \
                              cudaSharedmemCarveoutMaxShared);                                              \
-        fmha_sm120_mxfp4_kernel<BQ, HD, BS>                                                                \
+        fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV>                                                            \
             <<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),                         \
                                             reinterpret_cast<const half*>(K.data),                         \
                                             reinterpret_cast<const half*>(V.data),                         \
                                             reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv,    \
-                                            n_heads, n_kv_heads, scale, causal, sliding_window, softcap);  \
+                                            n_heads, n_kv_heads, scale, causal, sliding_window, softcap,   \
+                                            q_offset, d_kmean);                                            \
     } while (0)
 
-#define LAUNCH_FMHA_MXFP4(BQ, HD)                  \
-    do {                                           \
-        if (use_blockscale)                        \
-            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true);  \
-        else                                       \
-            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, false); \
+#define LAUNCH_FMHA_MXFP4(BQ, HD)                         \
+    do {                                                  \
+        if (pv_fp4)                                       \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, true);   \
+        else if (use_blockscale)                          \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, false);  \
+        else                                              \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, false, false); \
     } while (0)
 
     if (Bq == 128) {

--- a/src/compute/attention_fmha_mxfp4_sm120.h
+++ b/src/compute/attention_fmha_mxfp4_sm120.h
@@ -27,12 +27,26 @@ namespace imp {
 //   mma.sync.kind::f8f6f4.m16n8k32   (legacy, 2× K-chunks per issue)
 // to
 //   mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64  (half MMA count)
-// with uniform sfa=sfb=1.0 so output is bit-equivalent. head_dim must be a
-// multiple of 64 (legacy path requires only multiple of 32); unsupported
-// head_dim 96 falls through to the legacy path. Up to ~1.5-2× Phase 1
-// speedup measured on raw MMA (254 vs 102 TOPS).
+// with REAL per-16-element UE4M3 scales (per-(row, k_group) absmax) applied by
+// the hardware — finer quantization granularity than the legacy per-row path.
+// head_dim must be a multiple of 64 (legacy path requires only multiple of
+// 32); unsupported head_dim 96 falls through to the legacy path.
+//
+// #846 SageAttention3-recipe knobs (read from process_diag, blockscale only):
+//   mxfp4_ksmooth: K per-channel mean smoothing — a pre-pass computes the
+//     per-(batch, kv_head, channel) mean of K over seq_kv and the kernel
+//     subtracts it before quantization. The dropped Q·mean^T score term is
+//     constant per query row, so softmax is invariant. Auto-disabled when
+//     softcap > 0 (tanh breaks the shift invariance).
+//   mxfp4_pv_fp4: P·V in NVFP4 too — P quantized per-row two-level (rescaled
+//     to the full E4M3 scale range before 1x16 microscaling to prevent
+//     scale-factor collapse on the post-softmax long tail), V per-16-block
+//     along the KV dim, PV via the same block-scaled MMA.
+//
+// q_offset: global position of Q row 0 (chunked-prefill continuation) —
+// causal/sliding-window masks use q_offset + local row.
 bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                               bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                              bool use_blockscale = false);
+                              bool use_blockscale = false, int q_offset = 0);
 
 }  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -142,6 +142,9 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("attention.fmha_prefill_threshold", cfg.attention.fmha_prefill_threshold);
     I("attention.attn_scores_mib", cfg.attention.attn_scores_mib);
     S("attention.mxfp4", cfg.attention.mxfp4);
+    B("attention.mxfp4_blockscale", cfg.attention.mxfp4_blockscale);
+    B("attention.mxfp4_ksmooth", cfg.attention.mxfp4_ksmooth);
+    B("attention.mxfp4_pv_fp4", cfg.attention.mxfp4_pv_fp4);
     B("attention.mxfp4_fp16_fallback", cfg.attention.mxfp4_fp16_fallback);
     S("attention.mxfp4_fp16_cache_policy", cfg.attention.mxfp4_fp16_cache_policy);
     B("attention.force_cublas_decode", cfg.attention.force_cublas_decode);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -197,6 +197,20 @@ struct RuntimeConfig {
         // Experimental quality probe. Env: IMP_FP8_QK_SCALED.
         bool fp8_qk_scaled = false;
         std::string mxfp4 = "auto";
+        // #846 NVFP4-attention spike (SageAttention3 recipe). All three only
+        // take effect when the MXFP4 FMHA serves prefill (mxfp4 = "always").
+        // mxfp4_blockscale: per-16-element UE4M3 block scales applied by the
+        //   mxf4nvf4.block_scale MMA (vs legacy per-row software scales).
+        // mxfp4_ksmooth: subtract the per-(batch,kv_head,channel) K mean before
+        //   quantization — the dropped Q·mean^T term is per-row-constant and
+        //   cancels under softmax. Auto-disabled when softcap > 0 (tanh breaks
+        //   the shift invariance). Requires mxfp4_blockscale.
+        // mxfp4_pv_fp4: P·V in NVFP4 too — P quantized per-row two-level
+        //   (rescaled to the full E4M3 scale range before 1x16 microscaling),
+        //   V per-16-block along KV. Requires mxfp4_blockscale.
+        bool mxfp4_blockscale = false;
+        bool mxfp4_ksmooth = false;
+        bool mxfp4_pv_fp4 = false;
         bool mxfp4_fp16_fallback = false;
         // MXFP4 → FP16 cache pruning policy. "legacy" (default) caches FP16
         // for every MXFP4 tensor. "pruned" skips MoE expert_*_packed and

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -34,6 +34,9 @@ struct ProcessDiag {
     bool attention_fp8_qk_scaled = false;
     bool force_splitk_fallback = false;  // test hook
     std::string attention_mxfp4_mode = "auto";
+    bool mxfp4_blockscale = false;
+    bool mxfp4_ksmooth = false;
+    bool mxfp4_pv_fp4 = false;
 
     // FFN
     bool ffn_sparsity_probe = false;
@@ -83,6 +86,9 @@ void process_diag_install(const RuntimeConfig& cfg) {
     d.attention_fa2_pv_f16acc = cfg.attention.fa2_pv_f16acc;
     d.attention_fp8_qk_scaled = cfg.attention.fp8_qk_scaled;
     d.attention_mxfp4_mode = cfg.attention.mxfp4;
+    d.mxfp4_blockscale = cfg.attention.mxfp4_blockscale;
+    d.mxfp4_ksmooth = cfg.attention.mxfp4_ksmooth;
+    d.mxfp4_pv_fp4 = cfg.attention.mxfp4_pv_fp4;
     d.ffn_sparsity_probe = cfg.ffn.sparsity_probe;
     d.moe_mr_nr = cfg.moe.mr_nr;
     d.moe_expert_overhead_pct = cfg.moe.expert_overhead_pct;
@@ -121,6 +127,12 @@ void process_diag_set_fp8_qk_scaled(bool v) { slot().attention_fp8_qk_scaled = v
 bool process_diag_force_splitk_fallback() { return slot().force_splitk_fallback; }
 void process_diag_set_force_splitk_fallback(bool v) { slot().force_splitk_fallback = v; }
 const std::string& process_diag_attention_mxfp4_mode() { return slot().attention_mxfp4_mode; }
+bool process_diag_mxfp4_blockscale() { return slot().mxfp4_blockscale; }
+bool process_diag_mxfp4_ksmooth() { return slot().mxfp4_ksmooth; }
+bool process_diag_mxfp4_pv_fp4() { return slot().mxfp4_pv_fp4; }
+void process_diag_set_mxfp4_blockscale(bool v) { slot().mxfp4_blockscale = v; }
+void process_diag_set_mxfp4_ksmooth(bool v) { slot().mxfp4_ksmooth = v; }
+void process_diag_set_mxfp4_pv_fp4(bool v) { slot().mxfp4_pv_fp4 = v; }
 bool process_diag_ffn_sparsity_probe() { return slot().ffn_sparsity_probe; }
 int process_diag_moe_mr_nr() { return slot().moe_mr_nr; }
 int process_diag_moe_expert_overhead_pct() { return slot().moe_expert_overhead_pct; }

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -73,6 +73,13 @@ void process_diag_set_force_splitk_fallback(bool v);
 // "auto" | "always" | "never" (default "auto"); attention_mxfp4_available()
 // only enables MXFP4 attention when mode == "always".
 const std::string& process_diag_attention_mxfp4_mode();
+// #846 NVFP4-attention spike knobs (only meaningful when mxfp4 == "always").
+bool process_diag_mxfp4_blockscale();
+bool process_diag_mxfp4_ksmooth();
+bool process_diag_mxfp4_pv_fp4();
+void process_diag_set_mxfp4_blockscale(bool v);
+void process_diag_set_mxfp4_ksmooth(bool v);
+void process_diag_set_mxfp4_pv_fp4(bool v);
 
 // FFN
 bool process_diag_ffn_sparsity_probe();

--- a/tests/test_attention_fmha_mxfp4.cu
+++ b/tests/test_attention_fmha_mxfp4.cu
@@ -8,6 +8,7 @@
 #include "compute/attention.h"
 #include "compute/attention_tc.h"
 #include "core/tensor.h"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <vector>
@@ -58,9 +59,19 @@ static void compute_errors(const half* ref, const half* test, size_t n, float& m
     mean_err = static_cast<float>(sum_err / n);
 }
 
+// #846 recipe knobs for run_compare_test. ksmooth/pv_fp4 are read from
+// process_diag inside the launcher — set + restore around the call.
+struct MxRecipe {
+    bool blockscale = false;
+    bool ksmooth = false;
+    bool pv_fp4 = false;
+    int q_offset = 0;
+};
+
 // Helper to run test with given dimensions
 void run_compare_test(int B, int SQ, int SKV, int NH, int NKV, int HD, bool causal, int sliding_window,
-                      float softcap, float max_err_limit, float mean_err_limit, cudaStream_t stream, int sm) {
+                      float softcap, float max_err_limit, float mean_err_limit, cudaStream_t stream, int sm,
+                      MxRecipe recipe = {}) {
     size_t qo_elems = (size_t)B * SQ * NH * HD;
     size_t kv_elems = (size_t)B * SKV * NKV * HD;
 
@@ -86,7 +97,12 @@ void run_compare_test(int B, int SQ, int SKV, int NH, int NKV, int HD, bool caus
         Tensor K(d_k, QType::F16, 4, kv_shape, true);
         Tensor V(d_v, QType::F16, 4, kv_shape, true);
         Tensor O(d_o_mxfp4, QType::F16, 4, qo_shape, true);
-        bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream);
+        process_diag_set_mxfp4_ksmooth(recipe.ksmooth);
+        process_diag_set_mxfp4_pv_fp4(recipe.pv_fp4);
+        bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
+                                           recipe.blockscale, recipe.q_offset);
+        process_diag_set_mxfp4_ksmooth(false);
+        process_diag_set_mxfp4_pv_fp4(false);
         ASSERT_TRUE(ok) << "MXFP4 FMHA returned false for HD=" << HD;
     }
 
@@ -98,7 +114,8 @@ void run_compare_test(int B, int SQ, int SKV, int NH, int NKV, int HD, bool caus
         Tensor V(d_v, QType::F16, 4, kv_shape, true);
         Tensor O(d_o_ref, QType::F16, 4, qo_shape, true);
         ASSERT_GE(sm, 120) << "imp targets sm_120 only";
-        ASSERT_TRUE(flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream));
+        ASSERT_TRUE(flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
+                                              recipe.q_offset));
     }
 
     cudaStreamSynchronize(stream);
@@ -344,6 +361,99 @@ TEST_F(FhmaMxFP4Test, RejectsHD48) {
     cudaFree(d_k);
     cudaFree(d_v);
     cudaFree(d_o);
+}
+
+// ============================================================================
+// #846 SageAttention3-recipe variants (blockscale MMA + K-smoothing + FP4 PV)
+// ============================================================================
+
+TEST_F(FhmaMxFP4Test, BlockscaleHD128) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, BlockscaleHD64) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    run_compare_test(1, 128, 128, 4, 2, 64, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, BlockscaleKsmoothHD128) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, BlockscaleKsmoothSlidingWindow) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    // Smoothing + SWA: the mean is global over seq_kv while the window masks
+    // per row — the dropped Q·mean^T term must still cancel row-wise.
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 64, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, BlockscalePvFp4HD128) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.pv_fp4 = true;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, FullRecipeLongSeq) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    // Full #846 recipe on a multi-tile sequence (online-softmax rescale
+    // interacts with the per-row two-level P factor across KV tiles).
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    r.pv_fp4 = true;
+    run_compare_test(1, 512, 512, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, FullRecipeGQA8x) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    r.pv_fp4 = true;
+    run_compare_test(1, 256, 256, 32, 4, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, BlockscaleQOffsetChunk) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    // Chunked-prefill continuation: Q is a 64-row chunk at global offset 192
+    // within a 256-token context (seq_kv == q_offset + seq_q invariant).
+    MxRecipe r;
+    r.blockscale = true;
+    r.q_offset = 192;
+    run_compare_test(1, 64, 256, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+TEST_F(FhmaMxFP4Test, FullRecipeQOffsetChunk) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    r.pv_fp4 = true;
+    r.q_offset = 192;
+    run_compare_test(1, 64, 256, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
 }
 
 }  // namespace


### PR DESCRIPTION
## What

Ports the three SageAttention3 recipe elements from #846 into the opt-in MXFP4 FMHA (`attention.mxfp4 = "always"`), each behind its own default-off knob:

- **`attention.mxfp4_blockscale`** — real per-16-element UE4M3 scales through the existing `mxf4nvf4.block_scale.scale_vec::4X.m16n8k64` path (per-(row, k-group) absmax for Q and K; the header's stale "uniform sfa=1.0" comment updated).
- **`attention.mxfp4_ksmooth`** — K per-channel mean smoothing: a pre-pass kernel computes the per-(batch, kv_head, channel) mean over seq_kv into a persistent scratch, the kernel subtracts it before quantization. The dropped Q·mean^T term is per-query-row constant → softmax-invariant. Auto-disabled for softcap models (tanh breaks shift invariance).
- **`attention.mxfp4_pv_fp4`** — P·V in NVFP4: P quantized per-row **two-level** (row rescaled to the full E4M3-scale range 448·6 before 1x16 microscaling — prevents the scale-factor collapse measured in the fp4_pv benches), V per-16-block along KV in a transposed smem tile, PV on the same block-scaled MMA with the inverse row factor folded into the O accumulate.

Latent fixes to the opt-in MXFP4 FMHA that hold regardless of the recipe:
- **q_offset plumbing** — chunked-prefill continuation previously masked with local row indices (wrong causal/SWA masks on every chunk after the first).
- **Fully-masked-row sentinel guard** in the online softmax (parity with the FA2/FP16 kernels).

## Kill-switch verdict (why the knobs stay off)

Qwen3-14B-NVFP4, teacher-forced NLL, **kernel engagement verified via the new ACTIVE log line** (needs `fmha_prefill_threshold=1` + `fa2_fp16qk=never`, else FA2 serves hd=128 and the reading is vacuous — the #656 lesson):

| arm | 199 tok | 1k (single chunk) | 9k (chunked) |
|---|---|---|---|
| baseline (FA2 f16) | nll 1.7606 | 0.8659 | 1.1500 |
| legacy per-row FP4-QK | **PPL 31546** | — | **PPL 39062** |
| blockscale | +0.9% | — | +16.7% |
| blockscale+ksmooth | +1.3% | +7.8% | +10.5% |
| full recipe (+pv_fp4) | +1.1% | — | **+10.0%** |

- Per-16 hardware block scaling alone recovers FP4-QK from catastrophic (PPL 31546) to +~1% at short context — **granularity was the missing piece behind the refuted #511/#681/INT8 experiments, exactly as #846 hypothesized**.
- K-smoothing is worth ~6 NLL points at long context; FP4-PV with two-level P is quality-neutral on top (+0.2%).
- But the noise **compounds with context length** (+7.8% NLL at 1k single-shot already, +10% at 9k) → fails the ~1% gate. Consistent with the Attn-QAT finding the issue cites. Next step if ever funded: ThriftAttention-style top-5% QK-block FP16 promotion.

No perf round (quality gate failed first, per the spike order). Default paths untouched; all knobs default-off. 27 FhmaMxFP4 GPU tests (incl. blockscale/ksmooth/pv_fp4/q_offset variants) + full test-attention suite green, verify-fast OK.

Closes nothing; findings comment goes to #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)