### PR TITLE
spike(attention): ThriftAttention outlier promotion — FP4 attention quality gate PASSES at 5% budget (#846)

### DIFF
--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -485,3 +485,26 @@ All three degen-verified (55 server-suite checks, 0 fail; dense byte-exact strea
 Methodology note: deterministic ncu/nsys gates caught two near-phantom "wins" that were host-day decode
 variance, and pre-empted two multi-day kernel rewrites (TC attention, spec-verify) shown futile by a
 single measurement. Refutations > wins here — they save the next session from re-treading dead ends.
+
+### 2026-07-04 — ThriftAttention outlier promotion: FP4 attention quality gate PASSES (#846 reopened)
+
+Spike #846 (SageAttention3 recipe) was quality-refuted on 07-04 (noise compounds with context).
+Web recheck found the documented reopen path had matured: ThriftAttention (arXiv 2605.23081) is
+measured on GB202/sm_120 with Apache-2.0 sm120 kernels — runtime block-mean scores Q̄·K̄^T, top-k
+KV-tile promotion to exact compute, online-softmax merge. Implemented flag-gated in the #868
+scaffold (`attention.mxfp4_promote_budget`, default 0): pre-pass (tile means + top-k select, sink
++ diagonal force-included), `Promote` template param, promoted tiles = FP32 scores from global
+FP16 (kmean-consistent under ksmooth) + FP16 WMMA PV.
+
+**Teacher-forced NLL, Qwen3-14B-NVFP4, natural-prose corpus (Gutenberg 1342), Δ vs FA2 baseline:**
+full recipe no-promote **+9.9% @1k / +4.4% @9.3k** (failure mode reproduced); promote=1.0 sanity
++1.4% / −0.4%; **budget 0.05 → −0.6% / −0.2% — GATE PASSED** (0.10: −0.6% / +0.2%; 0.25: −1.3% /
++0.07%; blockscale-only+0.10: −1.8% / +0.4%). Two findings: (a) sink+diagonal promotion ALONE
+recovers most of the error at ≤1k (budgets ≤10% reduce to the 2 forced tiles there); (b) with
+promotion active, ksmooth/pv_fp4 stop mattering (bs-only arm ≈ full recipe). Docs/markdown corpus
+degrades far less (+1.9% @11.6k no-promote) — corpus choice is load-bearing for this failure mode.
+
+**Caveats:** quality spike only — promoted path is scalar FP32 from global (slow by design), knob
+default-off, NO perf round run (per spike order). A perf phase needs a register-resident FA2-class
+port of the FP4+promotion path; decode-side expectations remain dampened (KV already NVFP4-stored,
+long-ctx decode attention is latency-bound, see 2026-06-18 refutations).

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -137,9 +137,15 @@ mxfp4                = "auto"
 #   (vs legacy per-row software scales, which are catastrophically lossy).
 # ksmooth: subtract per-(batch,kv_head,channel) K mean before quantization.
 # pv_fp4: P·V in NVFP4 too (two-level P scaling).
+# promote_budget: ThriftAttention-style outlier promotion (arXiv 2605.23081) —
+#   per q-tile, the top-scoring fraction of visible 64-token KV tiles (block-
+#   mean score Q̄·K̄^T, sink + diagonal force-included) computes exactly in
+#   FP32/FP16 instead of FP4. 0 = off, 1 = promote everything. Requires
+#   blockscale; head_dim 64/128 only.
 mxfp4_blockscale     = false
 mxfp4_ksmooth        = false
 mxfp4_pv_fp4         = false
+mxfp4_promote_budget = 0.0
 mxfp4_fp16_fallback  = false
 # MXFP4 → FP16 cache pruning policy: "legacy" caches FP16 for every MXFP4
 # tensor; "pruned" skips MoE expert weights + LM head (32 GiB-class loads).

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -126,12 +126,23 @@ __device__ __forceinline__ uint8_t pack_fp4_pair(float v0, float v1) {
 //                         subtracted before quantization (nullptr = off). The
 //                         dropped Q·mean^T term is constant per query row and
 //                         cancels under softmax (launcher gates softcap == 0).
-template <int Bq, int HD, bool UseBlockScaleMma = false, bool PVFP4 = false>
+// Promote (#846 ThriftAttention, arXiv 2605.23081): d_promote is a per-
+//                         (batch_head, q_tile, kv_tile) uint8 mask from the
+//                         block-mean top-k pre-pass. Promoted KV tiles skip FP4
+//                         quantization entirely: S is computed exactly in FP32
+//                         from global-memory FP16 Q/K, and P·V takes the FP16
+//                         WMMA path even under PVFP4. The promotion flag is
+//                         uniform per (block, kv tile), so phase-level branches
+//                         are __syncthreads()-safe. Quality spike — the FP32
+//                         dot path is not a perf path.
+template <int Bq, int HD, bool UseBlockScaleMma = false, bool PVFP4 = false, bool Promote = false>
 __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
     const half* __restrict__ Q, const half* __restrict__ K, const half* __restrict__ V, half* __restrict__ O,
     int batch_size, int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale, bool causal,
-    int sliding_window, float softcap, int q_offset, const float* __restrict__ d_kmean) {
+    int sliding_window, float softcap, int q_offset, const float* __restrict__ d_kmean,
+    const uint8_t* __restrict__ d_promote, int n_kv_tiles_mask) {
     static_assert(!PVFP4 || UseBlockScaleMma, "PVFP4 rides on the block-scaled MMA path");
+    static_assert(!Promote || UseBlockScaleMma, "Promote rides on the block-scaled MMA path");
     constexpr int Bkv = MX_Bkv;
     constexpr int head_dim = HD;
     constexpr int hd_half = HD / 2;  // packed FP4 data bytes per row
@@ -416,8 +427,17 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
     for (int j = first_kv_tile; j < num_kv_tiles; j++) {
         const int kv_start = j * Bkv;
 
+        // #846 promotion: block-uniform per-tile flag. Promoted tiles skip the
+        // K-quant phase and the FP4 QK MMA; Phase 1' computes exact scores.
+        bool promoted = false;
+        if constexpr (Promote) {
+            promoted = d_promote[((size_t)batch_head * gridDim.x + tile_q) * n_kv_tiles_mask + j] != 0;
+        }
+
         // ---- Quantize K tile to FP4 (Opt 1: shared-memory staging) ----
-        if constexpr (can_stage_in_stile) {
+        if (promoted) {
+            // Promoted tile: no K-side quantization work.
+        } else if constexpr (can_stage_in_stile) {
             // Load K FP16 → S_tile (as staging buffer), then read from shared
             // float4 = 8 halves per iter
             half* K_stage = reinterpret_cast<half*>(S_tile);
@@ -602,7 +622,46 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
         const int s_meta_total_tiles = s_row_tiles * s_col_tile_metas;
         const int outer_total = UseBlockScaleMma ? s_meta_total_tiles : s_total_tiles;
 
-        for (int tile_idx = warp_id; tile_idx < outer_total; tile_idx += MX_NUM_WARPS) {
+        if (Promote && promoted) {
+            // ============================================================
+            // Phase 1' (#846 promotion): exact FP32 scores from global FP16.
+            // Scalar dots are slower than the MMA but exact — this is the
+            // quality arm, not a perf path. With ksmooth active the FP4
+            // tiles score Q·(K−mean)^T; the promoted tile MUST apply the
+            // same shift, otherwise its columns sit on a different additive
+            // offset inside the same softmax row (silent corruption).
+            // ============================================================
+            const int r = sm_row;  // TPR lanes cooperate per Q row
+            const int lq = q_start + r;
+            const int gq = q_offset + lq;
+            const half* qrow = &Q_ptr[(int64_t)r * q_row_stride];
+            for (int c = sm_lane; c < Bkv; c += TPR) {
+                const int gk = kv_start + c;
+                float s = -FLT_MAX;
+                if (lq < seq_q && gk < seq_kv && !(causal && gq < gk) &&
+                    !(sliding_window > 0 && (gq - gk) >= sliding_window)) {
+                    const half* krow = &K_ptr[(int64_t)gk * kv_row_stride];
+                    float acc = 0.0f;
+                    for (int d = 0; d < head_dim; d += 2) {
+                        const half2 qh = *reinterpret_cast<const half2*>(&qrow[d]);
+                        const half2 kh = *reinterpret_cast<const half2*>(&krow[d]);
+                        float k0 = __half2float(kh.x);
+                        float k1 = __half2float(kh.y);
+                        if (kmean != nullptr) {
+                            k0 -= kmean[d];
+                            k1 -= kmean[d + 1];
+                        }
+                        acc = fmaf(__half2float(qh.x), k0, acc);
+                        acc = fmaf(__half2float(qh.y), k1, acc);
+                    }
+                    s = acc * scale;
+                    if (softcap > 0.0f)
+                        s = softcap * tanhf(s / softcap);
+                }
+                S_tile[r * Bkv + c] = s;
+            }
+        }
+        for (int tile_idx = warp_id; !promoted && tile_idx < outer_total; tile_idx += MX_NUM_WARPS) {
             int ri, ci;
             int ci_meta_base = 0;
             if constexpr (UseBlockScaleMma) {
@@ -890,7 +949,10 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
                 }
             }
 
-            if constexpr (!PVFP4) {
+            // Promoted tiles always take the FP16 P path (their P·V runs on
+            // the FP16 WMMA Phase 3 below, even under PVFP4). The condition
+            // folds to a compile-time constant unless Promote is instantiated.
+            if (!PVFP4 || (Promote && promoted)) {
                 // Step 6: Normalize + float→half for P.
                 // In-place float→half compaction: stage in registers + barrier
                 // (SP_half row r aliases the bytes of float row r/2 — unsynced
@@ -952,7 +1014,9 @@ __global__ void __launch_bounds__(MX_BLOCK_THREADS, 1) fmha_sm120_mxfp4_kernel(
         cp_async_wait_group<0>();
         __syncthreads();
 
-        if constexpr (PVFP4) {
+        // Promoted tiles fall through to the FP16 WMMA Phase 3 (V is already
+        // FP16 in KV_fp16); constant-folds unless Promote is instantiated.
+        if (PVFP4 && !(Promote && promoted)) {
             // ============================================================
             // Phase 3' (#846): V^T per-16-block quant + FP4 P·V MMA
             // ============================================================
@@ -1151,6 +1215,125 @@ __global__ void mxfp4_k_channel_mean_kernel(const half* __restrict__ K, float* _
 }
 
 // =============================================================================
+// Promotion pre-pass (#846 ThriftAttention outlier selection)
+// =============================================================================
+// Generic per-tile channel mean over [batch, seq, heads, head_dim] FP16 input.
+// One block per (tile, batch*head); threads stride head_dim (coalesced per
+// row). Output: mean[(bh * gridDim.x + tile) * head_dim + d]. Serves both Q̄
+// (tile_rows = Bq) and K̄ (tile_rows = MX_Bkv).
+__global__ void mxfp4_tile_mean_kernel(const half* __restrict__ X, float* __restrict__ mean, int seq,
+                                       int n_heads_x, int head_dim, int tile_rows) {
+    const int tile = blockIdx.x;
+    const int bh = blockIdx.y;
+    const int batch = bh / n_heads_x;
+    const int h = bh % n_heads_x;
+    const int64_t row_stride = (int64_t)n_heads_x * head_dim;
+    const int r0 = tile * tile_rows;
+    const int rows = min(tile_rows, seq - r0);
+    const half* base = X + (int64_t)batch * seq * row_stride + (int64_t)r0 * row_stride +
+                       (int64_t)h * head_dim;
+    const float inv = 1.0f / (float)rows;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        float s = 0.0f;
+        for (int r = 0; r < rows; r++)
+            s += __half2float(base[(int64_t)r * row_stride + d]);
+        mean[((int64_t)bh * gridDim.x + tile) * head_dim + d] = s * inv;
+    }
+}
+
+// Top-k KV-tile selection per (batch_head, q_tile): importance score
+// Ŝ_j = Q̄_i · K̄_j (ThriftAttention block-mean heuristic), budget = fraction
+// of the causally visible tiles, sink tile (j=0) and diagonal tile (j=last)
+// force-included within the budget. Sliding-window occlusion is ignored here
+// (a promoted-but-masked tile is wasted work, never wrong). Dynamic smem:
+// head_dim + n_kv_tiles floats. Writes a uint8 mask row [n_kv_tiles].
+__global__ void mxfp4_promote_select_kernel(const float* __restrict__ qmean,
+                                            const float* __restrict__ kmean_tiles,
+                                            uint8_t* __restrict__ mask, int n_heads, int n_kv_heads,
+                                            int n_q_tiles, int n_kv_tiles, int bq, int seq_q, int q_offset,
+                                            bool causal, float budget, int head_dim) {
+    const int q_tile = blockIdx.x;
+    const int bh = blockIdx.y;  // batch * n_heads + head
+    const int batch = bh / n_heads;
+    const int head = bh % n_heads;
+    const int kvh = head / (n_heads / n_kv_heads);
+    const int bkvh = batch * n_kv_heads + kvh;
+
+    extern __shared__ float sel_sm[];
+    float* qm = sel_sm;                 // [head_dim]
+    float* score = sel_sm + head_dim;   // [n_kv_tiles]
+    __shared__ float red_v[128];
+    __shared__ int red_j[128];
+
+    const float* qmv = qmean + ((int64_t)bh * n_q_tiles + q_tile) * head_dim;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x)
+        qm[d] = qmv[d];
+
+    int last = n_kv_tiles - 1;
+    if (causal) {
+        const int gq_max = q_offset + min(seq_q, (q_tile + 1) * bq) - 1;
+        last = min(last, gq_max / MX_Bkv);
+        last = max(last, 0);
+    }
+
+    uint8_t* mrow = mask + ((int64_t)bh * n_q_tiles + q_tile) * n_kv_tiles;
+    for (int j = threadIdx.x; j < n_kv_tiles; j += blockDim.x)
+        mrow[j] = 0;
+    __syncthreads();
+
+    for (int j = threadIdx.x; j <= last; j += blockDim.x) {
+        const float* km = kmean_tiles + ((int64_t)bkvh * n_kv_tiles + j) * head_dim;
+        float s = 0.0f;
+        for (int d = 0; d < head_dim; d++)
+            s = fmaf(qm[d], km[d], s);
+        score[j] = s;
+    }
+    __syncthreads();
+
+    int k = (int)ceilf(budget * (float)(last + 1));
+    k = max(k, 1);
+    k = min(k, last + 1);
+    if (threadIdx.x == 0) {
+        mrow[0] = 1;
+        mrow[last] = 1;
+        score[0] = -FLT_MAX;
+        score[last] = -FLT_MAX;
+    }
+    __syncthreads();
+
+    // Iterative block-wide argmax for the remaining budget.
+    for (int sel = (last == 0) ? 1 : 2; sel < k; sel++) {
+        __syncthreads();  // break-check reads of red_j[0] complete before rewrite
+        float bv = -FLT_MAX;
+        int bj = -1;
+        for (int j = threadIdx.x; j <= last; j += blockDim.x) {
+            if (score[j] > bv) {
+                bv = score[j];
+                bj = j;
+            }
+        }
+        red_v[threadIdx.x] = bv;
+        red_j[threadIdx.x] = bj;
+        __syncthreads();
+        if (threadIdx.x == 0) {
+            for (int t = 1; t < blockDim.x; t++) {
+                if (red_v[t] > red_v[0]) {
+                    red_v[0] = red_v[t];
+                    red_j[0] = red_j[t];
+                }
+            }
+            if (red_j[0] >= 0) {
+                mrow[red_j[0]] = 1;
+                score[red_j[0]] = -FLT_MAX;
+            }
+        }
+        __syncthreads();
+        if (red_j[0] < 0)
+            break;  // all visible tiles already selected (uniform read)
+    }
+}
+
+// =============================================================================
 // Host launcher
 // =============================================================================
 
@@ -1235,16 +1418,74 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
         }
     }
 
+    const int num_q_tiles = (seq_q + Bq - 1) / Bq;
+
+    // #846 ThriftAttention promotion pre-pass: block means → top-k mask.
+    // Grow-only static scratch (process lifetime), same pattern as s_d_kmean.
+    // Promote instantiations exist only for head_dim 64/128 (bounds ptxas
+    // time; the PPL target Qwen3-14B is hd=128).
+    const float promote_budget = use_blockscale ? process_diag_mxfp4_promote_budget() : 0.0f;
+    const int n_kv_tiles = (seq_kv + MX_Bkv - 1) / MX_Bkv;
+    const uint8_t* d_promote = nullptr;
+    if (promote_budget > 0.0f && (head_dim == 64 || head_dim == 128)) {
+        static float* s_d_means = nullptr;  // Q̄ tile means followed by K̄ tile means
+        static size_t s_means_cap = 0;
+        static uint8_t* s_d_promote = nullptr;
+        static size_t s_promote_cap = 0;
+        const size_t qmean_elems = (size_t)batch_size * n_heads * num_q_tiles * head_dim;
+        const size_t kmean_elems = (size_t)batch_size * n_kv_heads * n_kv_tiles * head_dim;
+        const size_t means_need = qmean_elems + kmean_elems;
+        const size_t mask_need = (size_t)batch_size * n_heads * num_q_tiles * n_kv_tiles;
+        if (means_need > s_means_cap) {
+            if (s_d_means != nullptr)
+                cudaFree(s_d_means);
+            if (cudaMalloc(&s_d_means, means_need * sizeof(float)) != cudaSuccess) {
+                s_d_means = nullptr;
+                s_means_cap = 0;
+            } else {
+                s_means_cap = means_need;
+            }
+        }
+        if (mask_need > s_promote_cap) {
+            if (s_d_promote != nullptr)
+                cudaFree(s_d_promote);
+            if (cudaMalloc(&s_d_promote, mask_need) != cudaSuccess) {
+                s_d_promote = nullptr;
+                s_promote_cap = 0;
+            } else {
+                s_promote_cap = mask_need;
+            }
+        }
+        if (s_d_means != nullptr && s_d_promote != nullptr) {
+            float* d_qmean = s_d_means;
+            float* d_kmean_tiles = s_d_means + qmean_elems;
+            dim3 qmg(num_q_tiles, batch_size * n_heads);
+            mxfp4_tile_mean_kernel<<<qmg, 128, 0, stream>>>(reinterpret_cast<const half*>(Q.data), d_qmean,
+                                                            seq_q, n_heads, head_dim, Bq);
+            dim3 kmg(n_kv_tiles, batch_size * n_kv_heads);
+            mxfp4_tile_mean_kernel<<<kmg, 128, 0, stream>>>(reinterpret_cast<const half*>(K.data),
+                                                            d_kmean_tiles, seq_kv, n_kv_heads, head_dim,
+                                                            MX_Bkv);
+            dim3 sg(num_q_tiles, batch_size * n_heads);
+            const size_t sel_smem = (size_t)(head_dim + n_kv_tiles) * sizeof(float);
+            mxfp4_promote_select_kernel<<<sg, 128, sel_smem, stream>>>(
+                d_qmean, d_kmean_tiles, s_d_promote, n_heads, n_kv_heads, num_q_tiles, n_kv_tiles, Bq, seq_q,
+                q_offset, causal, promote_budget, head_dim);
+            d_promote = s_d_promote;
+        }
+    }
+
     // Engagement log (INFO once): the quality gate is only meaningful if this
     // kernel actually serves prefill — see the #511/#656 vacuous-closure lesson.
     static bool logged_once = false;
     if (!logged_once) {
         logged_once = true;
-        IMP_LOG_INFO("FMHA MXFP4 sm120 ACTIVE (hd=%d, Bq=%d, blockscale=%d, ksmooth=%d, pv_fp4=%d)",
-                     head_dim, Bq, (int)use_blockscale, (int)(d_kmean != nullptr), (int)pv_fp4);
+        IMP_LOG_INFO(
+            "FMHA MXFP4 sm120 ACTIVE (hd=%d, Bq=%d, blockscale=%d, ksmooth=%d, pv_fp4=%d, promote=%.2f)",
+            head_dim, Bq, (int)use_blockscale, (int)(d_kmean != nullptr), (int)pv_fp4,
+            (d_promote != nullptr) ? promote_budget : 0.0f);
     }
 
-    const int num_q_tiles = (seq_q + Bq - 1) / Bq;
     dim3 grid(num_q_tiles, batch_size * n_heads);
     dim3 block(MX_WARP_SIZE, MX_NUM_WARPS);
 
@@ -1254,9 +1495,9 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
         batch_size, seq_q, seq_kv, n_heads, n_kv_heads, head_dim, Bq, MX_Bkv, smem, causal, sliding_window,
         softcap);
 
-#define LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, BS, PV)                                                             \
+#define LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, BS, PV, PR)                                                         \
     do {                                                                                                   \
-        cudaError_t attr_err = cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV>,               \
+        cudaError_t attr_err = cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV, PR>,           \
                                                     cudaFuncAttributeMaxDynamicSharedMemorySize,           \
                                                     static_cast<int>(smem));                               \
         if (attr_err != cudaSuccess) {                                                                     \
@@ -1264,26 +1505,42 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                          (int)BS, smem, cudaGetErrorString(attr_err));                                     \
             return false;                                                                                  \
         }                                                                                                  \
-        cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV>,                                      \
+        cudaFuncSetAttribute(fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV, PR>,                                  \
                              cudaFuncAttributePreferredSharedMemoryCarveout,                               \
                              cudaSharedmemCarveoutMaxShared);                                              \
-        fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV>                                                            \
+        fmha_sm120_mxfp4_kernel<BQ, HD, BS, PV, PR>                                                        \
             <<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),                         \
                                             reinterpret_cast<const half*>(K.data),                         \
                                             reinterpret_cast<const half*>(V.data),                         \
                                             reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv,    \
                                             n_heads, n_kv_heads, scale, causal, sliding_window, softcap,   \
-                                            q_offset, d_kmean);                                            \
+                                            q_offset, d_kmean, d_promote, n_kv_tiles);                     \
     } while (0)
 
-#define LAUNCH_FMHA_MXFP4(BQ, HD)                         \
-    do {                                                  \
-        if (pv_fp4)                                       \
-            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, true);   \
-        else if (use_blockscale)                          \
-            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, false);  \
-        else                                              \
-            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, false, false); \
+// Promote variants only instantiated for head_dim 64/128 (see the pre-pass
+// gate above) — HD 96/256 use the no-promote macro to bound ptxas time.
+#define LAUNCH_FMHA_MXFP4(BQ, HD)                                \
+    do {                                                         \
+        if (d_promote != nullptr && pv_fp4)                      \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, true, true);    \
+        else if (d_promote != nullptr)                           \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, false, true);   \
+        else if (pv_fp4)                                         \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, true, false);   \
+        else if (use_blockscale)                                 \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, false, false);  \
+        else                                                     \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, false, false, false); \
+    } while (0)
+
+#define LAUNCH_FMHA_MXFP4_NOPROMOTE(BQ, HD)                      \
+    do {                                                         \
+        if (pv_fp4)                                              \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, true, false);   \
+        else if (use_blockscale)                                 \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, true, false, false);  \
+        else                                                     \
+            LAUNCH_FMHA_MXFP4_IMPL(BQ, HD, false, false, false); \
     } while (0)
 
     if (Bq == 128) {
@@ -1292,13 +1549,13 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                 LAUNCH_FMHA_MXFP4(128, 64);
                 return true;
             case 96:
-                LAUNCH_FMHA_MXFP4(128, 96);
+                LAUNCH_FMHA_MXFP4_NOPROMOTE(128, 96);
                 return true;
             case 128:
                 LAUNCH_FMHA_MXFP4(128, 128);
                 return true;
             case 256:
-                LAUNCH_FMHA_MXFP4(128, 256);
+                LAUNCH_FMHA_MXFP4_NOPROMOTE(128, 256);
                 return true;
             default:
                 break;
@@ -1309,13 +1566,13 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                 LAUNCH_FMHA_MXFP4(64, 64);
                 return true;
             case 96:
-                LAUNCH_FMHA_MXFP4(64, 96);
+                LAUNCH_FMHA_MXFP4_NOPROMOTE(64, 96);
                 return true;
             case 128:
                 LAUNCH_FMHA_MXFP4(64, 128);
                 return true;
             case 256:
-                LAUNCH_FMHA_MXFP4(64, 256);
+                LAUNCH_FMHA_MXFP4_NOPROMOTE(64, 256);
                 return true;
             default:
                 break;
@@ -1326,13 +1583,13 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                 LAUNCH_FMHA_MXFP4(32, 64);
                 return true;
             case 96:
-                LAUNCH_FMHA_MXFP4(32, 96);
+                LAUNCH_FMHA_MXFP4_NOPROMOTE(32, 96);
                 return true;
             case 128:
                 LAUNCH_FMHA_MXFP4(32, 128);
                 return true;
             case 256:
-                LAUNCH_FMHA_MXFP4(32, 256);
+                LAUNCH_FMHA_MXFP4_NOPROMOTE(32, 256);
                 return true;
             default:
                 break;
@@ -1340,6 +1597,7 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
     }
 
 #undef LAUNCH_FMHA_MXFP4
+#undef LAUNCH_FMHA_MXFP4_NOPROMOTE
 #undef LAUNCH_FMHA_MXFP4_IMPL
     return false;
 }

--- a/src/compute/attention_fmha_mxfp4_sm120.h
+++ b/src/compute/attention_fmha_mxfp4_sm120.h
@@ -42,6 +42,14 @@ namespace imp {
 //     to the full E4M3 scale range before 1x16 microscaling to prevent
 //     scale-factor collapse on the post-softmax long tail), V per-16-block
 //     along the KV dim, PV via the same block-scaled MMA.
+//   mxfp4_promote_budget: ThriftAttention-style outlier promotion (arXiv
+//     2605.23081). A pre-pass scores every (q_tile, kv_tile) pair by the
+//     block-mean dot Q̄·K̄^T and promotes the top budget-fraction of visible
+//     KV tiles (sink + diagonal always included) to exact compute: FP32
+//     scores from global FP16, FP16 WMMA P·V. Requires blockscale; head_dim
+//     64/128 only. INVARIANT: with ksmooth active, the promoted score path
+//     subtracts the same K channel mean — mixing shifted (FP4) and unshifted
+//     (promoted) columns inside one softmax row would corrupt the result.
 //
 // q_offset: global position of Q row 0 (chunked-prefill continuation) —
 // causal/sliding-window masks use q_offset + local row.

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -145,6 +145,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("attention.mxfp4_blockscale", cfg.attention.mxfp4_blockscale);
     B("attention.mxfp4_ksmooth", cfg.attention.mxfp4_ksmooth);
     B("attention.mxfp4_pv_fp4", cfg.attention.mxfp4_pv_fp4);
+    F("attention.mxfp4_promote_budget", cfg.attention.mxfp4_promote_budget);
     B("attention.mxfp4_fp16_fallback", cfg.attention.mxfp4_fp16_fallback);
     S("attention.mxfp4_fp16_cache_policy", cfg.attention.mxfp4_fp16_cache_policy);
     B("attention.force_cublas_decode", cfg.attention.force_cublas_decode);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -208,9 +208,16 @@ struct RuntimeConfig {
         // mxfp4_pv_fp4: P·V in NVFP4 too — P quantized per-row two-level
         //   (rescaled to the full E4M3 scale range before 1x16 microscaling),
         //   V per-16-block along KV. Requires mxfp4_blockscale.
+        // mxfp4_promote_budget: ThriftAttention-style outlier promotion
+        //   (arXiv 2605.23081) — per q-tile, the top-scoring fraction of
+        //   causally visible 64-token KV tiles (block-mean importance score
+        //   Q̄·K̄^T; sink + diagonal tiles force-included) is computed exactly
+        //   in FP32/FP16 instead of FP4. 0 = off, 1 = promote everything.
+        //   Requires mxfp4_blockscale; head_dim 64/128 only.
         bool mxfp4_blockscale = false;
         bool mxfp4_ksmooth = false;
         bool mxfp4_pv_fp4 = false;
+        float mxfp4_promote_budget = 0.0f;
         bool mxfp4_fp16_fallback = false;
         // MXFP4 → FP16 cache pruning policy. "legacy" (default) caches FP16
         // for every MXFP4 tensor. "pruned" skips MoE expert_*_packed and

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -37,6 +37,7 @@ struct ProcessDiag {
     bool mxfp4_blockscale = false;
     bool mxfp4_ksmooth = false;
     bool mxfp4_pv_fp4 = false;
+    float mxfp4_promote_budget = 0.0f;
 
     // FFN
     bool ffn_sparsity_probe = false;
@@ -89,6 +90,7 @@ void process_diag_install(const RuntimeConfig& cfg) {
     d.mxfp4_blockscale = cfg.attention.mxfp4_blockscale;
     d.mxfp4_ksmooth = cfg.attention.mxfp4_ksmooth;
     d.mxfp4_pv_fp4 = cfg.attention.mxfp4_pv_fp4;
+    d.mxfp4_promote_budget = cfg.attention.mxfp4_promote_budget;
     d.ffn_sparsity_probe = cfg.ffn.sparsity_probe;
     d.moe_mr_nr = cfg.moe.mr_nr;
     d.moe_expert_overhead_pct = cfg.moe.expert_overhead_pct;
@@ -133,6 +135,8 @@ bool process_diag_mxfp4_pv_fp4() { return slot().mxfp4_pv_fp4; }
 void process_diag_set_mxfp4_blockscale(bool v) { slot().mxfp4_blockscale = v; }
 void process_diag_set_mxfp4_ksmooth(bool v) { slot().mxfp4_ksmooth = v; }
 void process_diag_set_mxfp4_pv_fp4(bool v) { slot().mxfp4_pv_fp4 = v; }
+float process_diag_mxfp4_promote_budget() { return slot().mxfp4_promote_budget; }
+void process_diag_set_mxfp4_promote_budget(float v) { slot().mxfp4_promote_budget = v; }
 bool process_diag_ffn_sparsity_probe() { return slot().ffn_sparsity_probe; }
 int process_diag_moe_mr_nr() { return slot().moe_mr_nr; }
 int process_diag_moe_expert_overhead_pct() { return slot().moe_expert_overhead_pct; }

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -80,6 +80,9 @@ bool process_diag_mxfp4_pv_fp4();
 void process_diag_set_mxfp4_blockscale(bool v);
 void process_diag_set_mxfp4_ksmooth(bool v);
 void process_diag_set_mxfp4_pv_fp4(bool v);
+// ThriftAttention-style outlier promotion budget (0 = off, requires blockscale).
+float process_diag_mxfp4_promote_budget();
+void process_diag_set_mxfp4_promote_budget(float v);
 
 // FFN
 bool process_diag_ffn_sparsity_probe();

--- a/tests/test_attention_fmha_mxfp4.cu
+++ b/tests/test_attention_fmha_mxfp4.cu
@@ -65,6 +65,7 @@ struct MxRecipe {
     bool blockscale = false;
     bool ksmooth = false;
     bool pv_fp4 = false;
+    float promote_budget = 0.0f;
     int q_offset = 0;
 };
 
@@ -99,10 +100,12 @@ void run_compare_test(int B, int SQ, int SKV, int NH, int NKV, int HD, bool caus
         Tensor O(d_o_mxfp4, QType::F16, 4, qo_shape, true);
         process_diag_set_mxfp4_ksmooth(recipe.ksmooth);
         process_diag_set_mxfp4_pv_fp4(recipe.pv_fp4);
+        process_diag_set_mxfp4_promote_budget(recipe.promote_budget);
         bool ok = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
                                            recipe.blockscale, recipe.q_offset);
         process_diag_set_mxfp4_ksmooth(false);
         process_diag_set_mxfp4_pv_fp4(false);
+        process_diag_set_mxfp4_promote_budget(0.0f);
         ASSERT_TRUE(ok) << "MXFP4 FMHA returned false for HD=" << HD;
     }
 
@@ -454,6 +457,96 @@ TEST_F(FhmaMxFP4Test, FullRecipeQOffsetChunk) {
     r.pv_fp4 = true;
     r.q_offset = 192;
     run_compare_test(1, 64, 256, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+// ============================================================================
+// #846 ThriftAttention outlier promotion (mxfp4_promote_budget)
+// ============================================================================
+
+// budget=1.0 → every visited KV tile is promoted → the kernel runs exact FP32
+// scores + FP16 WMMA PV everywhere. Output must be near-FP16-tight against
+// the reference (validates the exact path, masking, and softmax merge — no
+// FP4 error budget left to hide behind).
+TEST_F(FhmaMxFP4Test, PromoteAllMatchesFP16) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.promote_budget = 1.0f;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 0, 0.0f, 0.05f, 0.005f, stream_, sm_, r);
+}
+
+// Same, with ksmooth on: the promoted FP32 path must subtract the same K
+// channel mean as the FP4 tiles — a missing subtraction shows up here as a
+// gross mismatch (shift no longer cancels row-wise under softmax).
+TEST_F(FhmaMxFP4Test, PromoteAllKsmoothMatchesFP16) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    r.promote_budget = 1.0f;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 0, 0.0f, 0.05f, 0.005f, stream_, sm_, r);
+}
+
+// budget=1.0 + pv_fp4: promoted tiles bypass the FP4 P·V path at runtime, so
+// the pv_fp4 knob must have no effect — still FP16-tight.
+TEST_F(FhmaMxFP4Test, PromoteAllBypassesPvFp4) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.pv_fp4 = true;
+    r.promote_budget = 1.0f;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 0, 0.0f, 0.05f, 0.005f, stream_, sm_, r);
+}
+
+// Partial budget on the full recipe: promotion must never make error worse
+// than the unpromoted full recipe (same tolerances as FullRecipeLongSeq).
+TEST_F(FhmaMxFP4Test, PromotePartialFullRecipe) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    r.pv_fp4 = true;
+    r.promote_budget = 0.1f;
+    run_compare_test(1, 512, 512, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+// Chunked-prefill continuation with promotion: the mask's causal visibility
+// must use global positions (q_offset), matching the kernel's masks.
+TEST_F(FhmaMxFP4Test, PromoteQOffsetChunk) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.ksmooth = true;
+    r.pv_fp4 = true;
+    r.promote_budget = 0.1f;
+    r.q_offset = 192;
+    run_compare_test(1, 64, 256, 4, 2, 128, true, 0, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
+}
+
+// Promotion + GQA + HD64 (the second instantiated head_dim).
+TEST_F(FhmaMxFP4Test, PromoteAllHD64GQA) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.promote_budget = 1.0f;
+    run_compare_test(1, 256, 256, 32, 4, 64, true, 0, 0.0f, 0.05f, 0.005f, stream_, sm_, r);
+}
+
+// Sliding window with partial promotion: selection ignores SWA occlusion
+// (wasted picks allowed), but promoted tiles must still apply the SWA mask.
+TEST_F(FhmaMxFP4Test, PromoteSlidingWindow) {
+    if (!can_run())
+        GTEST_SKIP() << "Requires sm_120+";
+    MxRecipe r;
+    r.blockscale = true;
+    r.promote_budget = 0.25f;
+    run_compare_test(1, 256, 256, 4, 2, 128, true, 64, 0.0f, 0.5f, 0.1f, stream_, sm_, r);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Implements the documented #846 reopen path: **ThriftAttention-style outlier block promotion** (arXiv 2605.23081) flag-gated into the MXFP4 FMHA scaffold from #868 — and the FP4-attention LLM quality gate that the pure SageAttention3 recipe failed **now passes at 5% promotion budget**.

New knob `attention.mxfp4_promote_budget` (default **0 = off**, requires `mxfp4_blockscale`, hd 64/128 only):
- **Pre-pass** (`mxfp4_tile_mean_kernel` + `mxfp4_promote_select_kernel`): per (batch_head, q_tile), score every visible 64-token KV tile by the block-mean dot Q̄·K̄ᵀ, promote the top `budget` fraction (sink tile + causal-diagonal tile force-included), uint8 mask in grow-only device scratch (same lifetime pattern as the ksmooth scratch).
- **Kernel** (`Promote` template param, existing instantiations byte-identical): promoted tiles skip FP4 K-quant and the QK MMA entirely — scores computed **exactly in FP32 from global FP16** (subtracting the same K channel mean when ksmooth is active, else the softmax row mixes shifted and unshifted columns), P·V taken through the FP16 WMMA phase (PVFP4 bypassed per promoted tile). The promotion flag is block-uniform per KV tile, so all phase branches stay `__syncthreads()`-safe.

## Measurements (teacher-forced NLL, Qwen3-14B-NVFP4, engagement verified per arm)

Natural-prose corpus (Gutenberg #1342; base NLL 1.189 @1053 tok, 1.643 @9326 tok), Δ mean-NLL vs FA2 baseline (A0):

| arm | 1k | 9.3k |
|---|---|---|
| full recipe, no promotion (A1) | **+9.9%** | **+4.4%** |
| promote=1.0 sanity anchor (A2) | +1.4% | −0.4% |
| **budget 0.05 (A3)** | **−0.6%** | **−0.2%** |
| budget 0.10 (A4) | −0.6% | +0.2% |
| budget 0.25 (A5) | −1.3% | +0.07% |
| budget 0.10, blockscale-only (A6) | −1.8% | +0.4% |

The docs/markdown corpus (secondary matrix, 186/1.1k/11.6k tokens) shows the same ordering but a much milder no-promote failure (+1.9% @11.6k) — the context-compounding failure mode is corpus-dependent; natural prose is the discriminating testbed.

Findings worth keeping:
1. **Sink + diagonal promotion alone recovers most of the error at ≤1k** (budgets ≤10% reduce to the 2 forced tiles there: ceil(0.05·17) ≤ 2) — +9.9% → −0.6% from 2 exact tiles per q-tile.
2. **With promotion active, ksmooth/pv_fp4 stop mattering** (blockscale-only arm ≈ full recipe) — the recipe complexity was compensating for exactly the outlier blocks that promotion computes exactly.
3. Promotion arms landing slightly *below* the FA2 baseline is expected: promoted scores are FP32-exact vs the baseline's f16-mma QK.

## Tests

- 7 new GTest arms in `test_attention_fmha_mxfp4.cu` (34/34 green): budget=1.0 matches the FP16 reference near-tight incl. ksmooth-consistency and PVFP4-bypass arms (HD64 exact, max_err 0.0000), q_offset chunked-prefill mask indexing, sliding window, partial-budget never-worse.
- Full `make test-gpu` suite green; `make verify-fast` green; default path untouched (`Promote=false` instantiations byte-identical, dispatch unchanged).

## Scope / non-goals

Quality spike per the #846 reopen bar — **no perf round**. The promoted path is scalar FP32 from global memory (slow by design) and all knobs ship default-off as research scaffold. A perf phase would need a register-resident FA2-class port of the FP4+promotion path; decode-side expectations stay dampened (imp already stores KV NVFP4; long-ctx decode attention is latency-bound per the 06-18 refutations). Follow-up decision tracked in #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)