### PR TITLE
cleanup: retire the legacy config surface — env seeding, turboquant aliases, dead flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ make format        # clang-format
 - **English only in the repo.** All PRs (title + body), commit messages, code comments, docs, and `.md` files are written entirely in English. (Chat replies to the user stay German per global instructions — this rule covers artifacts that land in the repository or on GitHub.)
 - **Always branch off `main` and `gh pr create --base main`.** Never stack PRs (squash-merge + stacking caused recovery-PR cascades). Prefer fewer, batched PRs over one-per-fix.
 - **Performance is gated.** `tests/perf_baseline.json` is the canonical baseline (CI: 3% decode / 5% prefill thresholds). Refresh via `scripts/gen_perf_baseline.sh` when a change intentionally moves perf, and say so in the PR.
-- Runtime config lives in `src/runtime/config.h` as `RuntimeConfig` (loaded from `imp.conf` + `--config`; legacy `IMP_*` env vars still seed it). Don't reintroduce ad-hoc env-var reads.
+- Runtime config lives in `src/runtime/config.h` as `RuntimeConfig` (loaded from `imp.conf` + `--config` + `--set`; the only env vars still seeded are `IMP_DETERMINISTIC` and `IMP_FMHA_FA2` — the rest of the legacy `IMP_*` surface was retired 2026-07-07). Don't reintroduce ad-hoc env-var reads.
 - Internal errors throw and are translated to `ImpError` at the `src/api/imp_api.cpp` boundary — this is intentional, don't convert those throws to status returns.
 - Match surrounding code style; keep it simple and direct, no speculative abstraction.
 

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -101,7 +101,7 @@ dtype = "auto"  # auto (default) | fp16 | fp8 | int8 | int4 | nvfp4 | mxfp4
 
 The default flipped to FP16 in PR #51 — FP8 had been silently breaking Llama, Mistral, and DeepSeek at first decode. Beyond the `auto` allowlist, FP8 stays opt-in; it is verified coherent on Qwen3 dense, Qwen3.5 / 3.6 GDN, Llama-3.2, and Gemma-4 (FP8 KV warmup-calibration bug fixed in PR #89; Gemma-4 dual-head_dim carve-out removed in PR #91).
 
-INT4 KV is for VRAM-pressure cases only — coherent but ~22% decode regression at 20K context. NVFP4-KV (`--kv-nvfp4`) and MXFP4-KV (`--kv-mxfp4`, PR #249) both store FP4 at 25% of FP16 — NVFP4 uses E4M3 micro-scales, MXFP4 uses UE8M0; both ship chunked prefill via `paged_kv_gather_*_to_fp16`. The legacy `--kv-turboquant{,-lite}` flags remain as deprecated aliases routing to `--kv-mxfp4` (TurboQuant retired in PR #251).
+INT4 KV is for VRAM-pressure cases only — coherent but ~22% decode regression at 20K context. NVFP4-KV (`--kv-nvfp4`) and MXFP4-KV (`--kv-mxfp4`, PR #249) both store FP4 at 25% of FP16 — NVFP4 uses E4M3 micro-scales, MXFP4 uses UE8M0; both ship chunked prefill via `paged_kv_gather_*_to_fp16`. (TurboQuant was retired in PR #251; its deprecated `--kv-turboquant{,-lite}` alias flags were removed 2026-07-07.)
 
 ## Choosing a quant
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -172,8 +172,8 @@ Performance:
   --kv-int4                 INT4 KV cache (quality cost; long-ctx only)
   --kv-nvfp4                NVFP4 KV cache (FP4 + E4M3 scales, 25% of FP16)
   --kv-mxfp4                MXFP4-KV cache (FP4 + UE8M0 scales, 25% of FP16)
-  --kv-fp16                 Force FP16 KV cache (the current default)
-  (--kv-turboquant{,-lite}  DEPRECATED post-PR #251; aliased to --kv-mxfp4)
+  --kv-fp16                 Force FP16 KV cache (opts out of the auto FP8
+                            upgrade for models with a kv-FP8 author hint)
   --prefill-fp8             FP8 weight cache for prefill
   --prefill-chunk-size <n>  Max tokens per prefill chunk (default: 0)
   --decode-nvfp4            NVFP4 decode cache (FP16 prefill + NVFP4 decode)

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -108,7 +108,6 @@ fp8_prefill          = "auto"
 fp8_fmha             = "never"
 # amax-scaled e4m3 QK conversion on the fp8-QK path (only takes effect when
 # fa2_fp16qk=never or declined). Experimental quality probe; default off.
-# Legacy env: IMP_FP8_QK_SCALED.
 fp8_qk_scaled        = false
 fmha_sm120           = "auto"
 # Register-resident FA2 prefill kernel for long prefill (F16, head_dim=128).

--- a/include/imp/config.h
+++ b/include/imp/config.h
@@ -13,8 +13,7 @@ typedef struct {
     int device_id;
 
     // Memory
-    size_t gpu_memory_pool_size;  // Pre-allocated GPU pool (bytes), 0 = auto
-    size_t kv_cache_max_blocks;   // Max KV cache blocks, 0 = auto
+    size_t kv_cache_max_blocks;  // Max KV cache blocks, 0 = auto
 
     // Inference
     int max_batch_size;
@@ -38,11 +37,6 @@ typedef struct {
 
     // KV cache precision
     ImpDType kv_cache_dtype;  // FP16 (default), FP8_E4M3, INT8, INT4, NVFP4, or MXFP4_KV
-
-    // [DEPRECATED, ignored] turboquant_sketch_multiplier was the QJL sketch dimension
-    // multiplier for TurboQuant Lite. TurboQuant was retired in Phase 5 (2026-05-17).
-    // Retained for ABI compatibility; the engine ignores this value.
-    int turboquant_sketch_multiplier;  // deprecated, ignored
 
     // SSM state precision
     ImpDType ssm_state_dtype;  // FP32 (default) or FP16 for SSM h_state
@@ -89,9 +83,6 @@ typedef struct {
     int streaming_kv_window;     // sliding window size (0 = use ModelConfig::sliding_window)
     int streaming_kv_threshold;  // ctx_len at which streaming activates
                                  // (0 = auto: n_sinks + window + 2*kKVBlockSize)
-
-    // Threading
-    int num_cpu_threads;  // 0 = auto (hardware_concurrency)
 
     // Vision (multimodal)
     const char* mmproj_path;  // Path to mmproj GGUF file (NULL = text-only)

--- a/include/imp/types.h
+++ b/include/imp/types.h
@@ -16,8 +16,8 @@ typedef enum {
     IMP_DTYPE_INT4 = 6,
     IMP_DTYPE_INT32 = 7,
     IMP_DTYPE_FP4_E2M1 = 8,
-    IMP_DTYPE_TURBOQUANT = 9,        // DEPRECATED: TurboQuant retired (Phase 5, 2026-05-17). Alias for IMP_DTYPE_MXFP4_KV.
-    IMP_DTYPE_TURBOQUANT_LITE = 10,  // DEPRECATED: TurboQuant Lite retired (Phase 5, 2026-05-17). Alias for IMP_DTYPE_MXFP4_KV.
+    // Values 9 and 10 (TURBOQUANT / TURBOQUANT_LITE aliases) removed 2026-07-07
+    // (TurboQuant retired Phase 5, 2026-05-17; the aliases had no callers).
     IMP_DTYPE_NVFP4 = 11,            // NVFP4 KV cache: packed FP4 + UE4M3 per-group_of_16 scales
     IMP_DTYPE_MXFP4_KV = 12,        // MXFP4-KV cache: packed FP4 + UE8M0 per-group_of_16 scales (Path A retirement target)
 } ImpDType;

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -85,8 +85,7 @@ const char* imp_error_string(ImpError err) {
 ImpConfig imp_config_default(void) {
     ImpConfig config;
     config.device_id = 0;
-    config.gpu_memory_pool_size = 0;  // auto
-    config.kv_cache_max_blocks = 0;   // auto
+    config.kv_cache_max_blocks = 0;  // auto
     config.max_batch_size = 0;        // auto (engine detects from model size)
     config.max_seq_len = 0;           // auto (engine detects from model metadata + VRAM)
     config.compute_dtype = IMP_DTYPE_FP16;
@@ -111,9 +110,7 @@ ImpConfig imp_config_default(void) {
     config.use_prefix_caching = 0;            // off by default
     config.prefix_cache_path[0] = '\0';       // no persistence by default
     config.prefix_pin_budget_pct = 25;        // cache_control pins capped at 25% of the KV pool
-    config.num_cpu_threads = 0;               // auto
     config.mmproj_path = NULL;                // no vision model
-    config.turboquant_sketch_multiplier = 2;  // sketch_dim = 2 * head_dim
     config.streaming_kv_enabled = 0;          // off by default (opt-in)
     config.streaming_kv_auto = 1;             // auto-enable when KV cache >90% full
     config.streaming_kv_n_sinks = 4;          // StreamingLLM paper default
@@ -185,30 +182,6 @@ static imp::QType map_dtype(ImpDType dt) {
             return imp::QType::INT32;
         case IMP_DTYPE_FP4_E2M1:
             return imp::QType::FP4_E2M1;
-        case IMP_DTYPE_TURBOQUANT:
-            // DEPRECATED: TurboQuant retired. IMP_DTYPE_TURBOQUANT is kept for ABI
-            // compatibility and silently maps to MXFP4_KV. Callers should switch to
-            // IMP_DTYPE_MXFP4_KV. A one-shot warning is printed the first time.
-            {
-                static bool warned = false;
-                if (!warned) {
-                    warned = true;
-                    IMP_LOG_WARN("IMP_DTYPE_TURBOQUANT is deprecated (TurboQuant retired). "
-                                 "Using IMP_DTYPE_MXFP4_KV instead.");
-                }
-            }
-            return imp::QType::MXFP4_KV;
-        case IMP_DTYPE_TURBOQUANT_LITE:
-            // DEPRECATED: TurboQuant Lite retired. Maps to MXFP4_KV.
-            {
-                static bool warned = false;
-                if (!warned) {
-                    warned = true;
-                    IMP_LOG_WARN("IMP_DTYPE_TURBOQUANT_LITE is deprecated (TurboQuant retired). "
-                                 "Using IMP_DTYPE_MXFP4_KV instead.");
-                }
-            }
-            return imp::QType::MXFP4_KV;
         case IMP_DTYPE_NVFP4:
             return imp::QType::NVFP4;
         case IMP_DTYPE_MXFP4_KV:
@@ -403,8 +376,6 @@ ImpError imp_context_create(ImpModel model, const ImpConfig* config, ImpContext*
         if (config->prefix_cache_path[0] != '\0')
             ecfg.prefix_cache_path = config->prefix_cache_path;
         ecfg.prefix_pin_budget_pct = config->prefix_pin_budget_pct;
-        // config->turboquant_sketch_multiplier is deprecated and ignored (kept in
-        // ImpConfig for ABI compatibility only).
         if (config->mmproj_path)
             ecfg.mmproj_path = config->mmproj_path;
         ecfg.streaming_kv_enabled = (config->streaming_kv_enabled != 0);

--- a/src/compute/ffn_sparsity_probe.h
+++ b/src/compute/ffn_sparsity_probe.h
@@ -16,8 +16,7 @@ namespace imp {
 // (one line per (layer, threshold) pair + one model-aggregate line) and
 // resets the counters.
 //
-// Off unless ffn.sparsity_probe = true in imp.conf (or
-// IMP_FFN_SPARSITY_PROBE=1 in the env). When off, the public functions
+// Off unless ffn.sparsity_probe = true in imp.conf. When off, the public functions
 // short-circuit before any device work.
 void probe_ffn_silu_sparsity(int layer, const __half* gate, const __half* up, int K,
                              cudaStream_t stream);

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -320,8 +320,7 @@ static inline void set_gemm_scale_pointers(cublasLtMatmulDesc_t opDesc, const fl
 static constexpr int kMaxAlgoCandidates = 8;
 static constexpr int kBenchmarkIters = 5;
 
-// Diagnostic: when diagnostics.log_gemm_algo (legacy IMP_LOG_GEMM_ALGO=1)
-// is set, log shape + per-candidate algoId/tileId + chosen algo for every
+// Diagnostic: when diagnostics.log_gemm_algo is set, log shape + per-candidate algoId/tileId + chosen algo for every
 // benchmark_and_select_algo call. Used to enumerate which exact GEMM shapes
 // select cuBLAS legacy WMMA kernels (Finding 1/5).
 static int gemm_algo_log_enabled() { return imp::process_diag_log_gemm_algo() ? 1 : 0; }
@@ -352,7 +351,7 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
         entry.workspace_size = 0;
         return;
     }
-    // [diag] IMP_LOG_GEMM_ALGO: dump shape + per-candidate algoId/tileId.
+    // [diag] diagnostics.log_gemm_algo: dump shape + per-candidate algoId/tileId.
     // Helps identify which shapes are stuck on legacy WMMA candidates.
     if (gemm_algo_log_enabled() && M > 0) {
         fprintf(stderr, "[gemm-algo] shape M=%d N=%d K=%d  candidates=%d\n", M, N, K, nresults);

--- a/src/compute/weight_dispatch.cu
+++ b/src/compute/weight_dispatch.cu
@@ -103,7 +103,7 @@ void gemm_dispatch(cublasLtHandle_t, const WeightHandle& w, const Tensor& x, Ten
             tmp.K = static_cast<int>(x.shape[1]);
 
             int M = static_cast<int>(x.shape[0]);
-            // Diagnostic: diagnostics.nvfp4_force_dequant (legacy IMP_NVFP4_FORCE_DEQUANT=1)
+            // Diagnostic: diagnostics.nvfp4_force_dequant
             // routes the M=1 decode path through gemm_nvfp4 (dequant→cuBLAS
             // GEMV) instead of the native gemv_nvfp4_kpar kernel. Used to
             // bisect Mistral-Small-3.2-NVFP4 long-form repetition loops — if

--- a/src/core/qtype.h
+++ b/src/core/qtype.h
@@ -43,8 +43,7 @@ enum class QType : uint16_t {
     NVFP4 = 71,
     MXFP4_KV = 72,
     // Values 80 and 81 (TURBOQUANT / TURBOQUANT_LITE) were removed in Phase 5
-    // (2026-05-17). The C-API constants IMP_DTYPE_TURBOQUANT(_LITE) are kept
-    // for ABI compatibility but map to MXFP4_KV at the imp_api.cpp boundary.
+    // (2026-05-17); the C-API aliases followed 2026-07-07.
 };
 
 // True for block-quantised disk formats (Q*_K, Q*_0, Q*_1, IQ4_*, MXFP4, NVFP4).

--- a/src/exec/executor_attention_decode.cu
+++ b/src/exec/executor_attention_decode.cu
@@ -163,8 +163,7 @@
         } else if (cache_dtype == QType::NVFP4) {
             // NVFP4 paged attention: packed FP4 + UE4M3 per-group_of_16 scales (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
-            // BitDecoding TC dispatch opt-in: kv_cache.bitdecoding_qk (legacy
-            // IMP_USE_BITDECODING_QK=1) routes to the WMMA-Q.K variant; default
+            // BitDecoding TC dispatch opt-in: kv_cache.bitdecoding_qk routes to the WMMA-Q.K variant; default
             // keeps the scalar-FFMA path unchanged.
             const bool use_bitdecoding_tc = runtime_config().kv_cache.bitdecoding_qk;
             if (use_bitdecoding_tc) {

--- a/src/exec/executor_forward_moe_cutlass.cu
+++ b/src/exec/executor_forward_moe_cutlass.cu
@@ -92,7 +92,7 @@ bool device_args_done = false;
     // pp512 vs the legacy host-args + smallM dispatch on
     // Qwen3-Coder / Qwen3.6 / Qwen3-30B-Modelopt / Gemma-4
     // NVFP4 (decode unchanged). Set moe.nvfp4_device_args=false
-    // (legacy IMP_NVFP4_DEVICE_ARGS=0) to force the legacy
+    // to force the legacy
     // path for A/B or workarounds.
     const bool da_enabled = runtime_config().moe.nvfp4_device_args;
     // gpt-oss (#547): the fused act+quantize kernel knows SwiGLU/GeGLU/ReLU2
@@ -114,7 +114,7 @@ bool device_args_done = false;
         if (layer == 0 && !s_da_logged.exchange(true))
             IMP_LOG_INFO(
                 "MoE prefill: CUTLASS 3.x device-args full path "
-                "(default; set IMP_NVFP4_DEVICE_ARGS=0 to disable)");
+                "(default; set moe.nvfp4_device_args=false to disable)");
         // Populate device-resident d_M_per (no D2H).
         imp::compute_M_per_from_offsets_device(
             static_cast<const int32_t*>(routing.expert_offsets.data),
@@ -345,8 +345,8 @@ char* expert_swiglu_base = static_cast<char*>(moe_.expert_swiglu.data);
 char* expert_down_base = static_cast<char*>(moe_.expert_down.data);
 
 // ---------------------------------------------------------------------
-// Optional smallM kernel branch — opt-in via IMP_NVFP4_SMALLM=1.
-// Activates when max(M_per) <= IMP_NVFP4_SMALLM_THRESHOLD (default 64)
+// Optional smallM kernel branch — opt-in via moe.nvfp4_smallM.
+// Activates when max(M_per) <= moe.nvfp4_smallM_threshold (default 64)
 // AND all three NVFP4 native MoE pointers are populated for this layer
 // (the native [n_experts, N, K/16] layout is what smallM consumes).
 // Falls through to CUTLASS 3.x on any failure / unavailability.

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -354,12 +354,12 @@ void QuantPipeline::pre_dequant_phase0_promote_nvfp4_sidecars_(
             // at inference: the long-context-bug investigation refuted the
             // hypothesis that absorbing it would fix Mistral-3.2-NVFP4
             // drift (see memory `llm_compressor_input_scale_dead_end_2026_05_07.md`).
-            // Loading is kept as a diagnostic path: pass IMP_AUDIT_NVFP4_SCALES=1
-            // for per-Linear stats. Without that env var, scratch tensors
+            // Loading is kept as a diagnostic path: set diagnostics.audit_nvfp4_scales
+            // for per-Linear stats. Without it, scratch tensors
             // are skipped during GPU upload (no VRAM cost).
             IMP_LOG_INFO(
                 "NVFP4 prequant: %d Linears carry input_scale (intentionally NOT applied; "
-                "set IMP_AUDIT_NVFP4_SCALES=1 for stats).",
+                "set diagnostics.audit_nvfp4_scales=true for stats).",
                 n_with_input_scale);
         }
     }

--- a/src/exec/pre_dequant_phase3_moe.cu
+++ b/src/exec/pre_dequant_phase3_moe.cu
@@ -255,7 +255,7 @@ void QuantPipeline::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         // RELEASE budget, never tighten it vs the previous behavior. Floor
         // at 256 MiB to keep workspace + scratch room.
         //
-        // IMP_MOE_RESERVE_MIB still overrides for manual tuning (range
+        // moe.reserve_mib still overrides for manual tuning (range
         // 128-4096 MiB).
         int n_attn_layers = 0;
         for (int i = 0; i < cfg.n_layers; i++) {

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -374,8 +374,8 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
     // -----------------------------------------------------------------------
     // Phase 3c-full Step 3: pre-cache per-layer NVFP4 device-args ptr arrays.
     // -----------------------------------------------------------------------
-    // The CUTLASS 3.x device-args dispatch (Phase 3c-full Step 2b, opt-in via
-    // IMP_NVFP4_DEVICE_ARGS=1) consumes per-expert weight pointers as
+    // The CUTLASS 3.x device-args dispatch (Phase 3c-full Step 2b,
+    // moe.nvfp4_device_args) consumes per-expert weight pointers as
     // device-resident arrays. Per-call host iteration + 3× cudaMemcpyAsync
     // (~3 KiB total) was the residual overhead blocking full CUDA-graph
     // capture of the MoE prefill. Build the caches once here while the

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -376,7 +376,7 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
         //
         // Cross-converted checkpoints (HF → GGUF → HF, or weights re-packed by
         // a third-party tool) can ship in the opposite layout. Override via
-        // gdn.layout_override="tiled" (legacy IMP_GDN_LAYOUT=tiled); default
+        // gdn.layout_override="tiled"; default
         // for SafeTensors stays grouped.
         cfg.gdn_grouped_head_layout = true;
         {

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -2084,8 +2084,8 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
     // canonical slot name; replaced the per-layer NvFP4PreQuantWeight slots.
     if (config_.is_nvfp4_prequant) {
         int scale_count = 0;
-        // Diagnostic: diagnostics.audit_nvfp4_scales (legacy
-        // IMP_AUDIT_NVFP4_SCALES=1) dumps per-slot stats for weight_scale_2
+        // Diagnostic: diagnostics.audit_nvfp4_scales
+        // dumps per-slot stats for weight_scale_2
         // (tensor-level FP32 scalar) BEFORE upload, so we can bisect
         // Mistral-3.2-NVFP4 long-form bugs by comparing scale ranges against
         // a known-good model (e.g. Gemma-4-NVFP4).

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <fstream>
 #include <sstream>
 #include <unistd.h>
@@ -299,9 +298,13 @@ std::string home_dir() {
     return {};
 }
 
-// Backward-compat: legacy IMP_* env vars seed the matching RuntimeConfig
-// fields before [imp.conf] file overrides. Semantics preserved exactly
-// per original call-site checks (see review/phase3_maint.md §9.1).
+// Env seeding, deliberately minimal. imp.conf + --set replaced the old
+// ~30-var legacy IMP_* surface (retired 2026-07-07 — no producers existed);
+// only the two vars with real in-repo producers remain:
+//   IMP_DETERMINISTIC — set by tests (test_determinism_e2e, test_lora) to
+//     inject determinism through the public API without a config file.
+//   IMP_FMHA_FA2 — set by the roofline A/B harness (tools/roofline/roofline.py)
+//     to toggle the FA2 prefill kernel per subprocess.
 void seed_from_env(RuntimeConfig& cfg) {
     // runtime.deterministic — IMP_DETERMINISTIC: '1'/'true' enables full
     // reproducibility (also implies deterministic_gemm).
@@ -311,134 +314,10 @@ void seed_from_env(RuntimeConfig& cfg) {
             cfg.runtime.deterministic_gemm = true;
     }
 
-    // moe.reserve_mib — IMP_MOE_RESERVE_MIB: integer MiB.
-    if (const char* e = std::getenv("IMP_MOE_RESERVE_MIB"))
-        cfg.moe.reserve_mib = parse_int(e, cfg.moe.reserve_mib);
-
-    // kv_cache.bitdecoding_qk — IMP_USE_BITDECODING_QK: '1' enables.
-    if (const char* e = std::getenv("IMP_USE_BITDECODING_QK"))
-        cfg.kv_cache.bitdecoding_qk = (e[0] == '1');
-
-    // moe.nvfp4_device_args — IMP_NVFP4_DEVICE_ARGS: '0' disables, default ON.
-    if (const char* e = std::getenv("IMP_NVFP4_DEVICE_ARGS"))
-        cfg.moe.nvfp4_device_args = (std::atoi(e) != 0);
-
-    // gemm.nvfp4_lm_head — IMP_NO_NVFP4_LM_HEAD: '1' disables the FP16-LM-head
-    // NVFP4 decode cache (default ON).
-    if (const char* e = std::getenv("IMP_NO_NVFP4_LM_HEAD"))
-        cfg.gemm.nvfp4_lm_head = (std::atoi(e) == 0);
-
-    // gemm.nvfp4_moe_decode — IMP_NO_NVFP4_MOE_DECODE: '1' disables the fast
-    // per-expert NVFP4 MoE decode path (default ON).
-    if (const char* e = std::getenv("IMP_NO_NVFP4_MOE_DECODE"))
-        cfg.gemm.nvfp4_moe_decode = (std::atoi(e) == 0);
-
-    // attention.attn_scores_mib — IMP_ATTN_SCORES_MIB: cuBLAS attention S-matrix cap.
-    if (const char* e = std::getenv("IMP_ATTN_SCORES_MIB")) {
-        int v = std::atoi(e);
-        if (v > 0)
-            cfg.attention.attn_scores_mib = v;
-    }
-
     // attention.fmha_fa2 — IMP_FMHA_FA2: '1' enables the register-resident FA2
     // prefill kernel (A/B vs the legacy FP8 FMHA), '0' forces it off.
     if (const char* e = std::getenv("IMP_FMHA_FA2"))
         cfg.attention.fmha_fa2 = (std::atoi(e) != 0) ? "on" : "never";
-
-    // attention.fa2_f16acc — IMP_FA2_F16ACC: '1' enables f16-accumulate QK^T
-    // in the fp16-qk FA2 kernel (#597, +3-4% long-ctx prefill / +0.37% PPL).
-    if (const char* e = std::getenv("IMP_FA2_F16ACC"))
-        cfg.attention.fa2_f16acc = (std::atoi(e) != 0);
-
-    // attention.fa2_pv_f16acc — IMP_FA2_PV_F16ACC: '1' also accumulates the
-    // PV MMA in f16 (full-rate HMMA + halved O-fragment registers).
-    if (const char* e = std::getenv("IMP_FA2_PV_F16ACC"))
-        cfg.attention.fa2_pv_f16acc = (std::atoi(e) != 0);
-
-    // attention.fp8_qk_scaled — IMP_FP8_QK_SCALED: '1' enables amax-scaled
-    // e4m3 conversion in the fp8-QK FA2 path (#680).
-    if (const char* e = std::getenv("IMP_FP8_QK_SCALED"))
-        cfg.attention.fp8_qk_scaled = (std::atoi(e) != 0);
-
-    // moe.nvfp4_smallM — IMP_NVFP4_SMALLM: integer != 0 enables.
-    if (const char* e = std::getenv("IMP_NVFP4_SMALLM"))
-        cfg.moe.nvfp4_smallM = (std::atoi(e) != 0);
-
-    // moe.nvfp4_smallM_threshold — IMP_NVFP4_SMALLM_THRESHOLD: clamped int.
-    if (const char* e = std::getenv("IMP_NVFP4_SMALLM_THRESHOLD")) {
-        int v = std::atoi(e);
-        if (v < 0)
-            v = 0;
-        if (v > 128)
-            v = 128;
-        cfg.moe.nvfp4_smallM_threshold = v;
-    }
-
-    // moe.mr_nr — IMP_MOE_MR_NR: rows-per-block for NVFP4 MoE decode kernels.
-    if (const char* e = std::getenv("IMP_MOE_MR_NR"))
-        cfg.moe.mr_nr = std::atoi(e);
-
-    // diagnostics.nvfp4_force_dequant — IMP_NVFP4_FORCE_DEQUANT: '1' only.
-    if (const char* e = std::getenv("IMP_NVFP4_FORCE_DEQUANT"))
-        cfg.diagnostics.nvfp4_force_dequant = (e[0] == '1');
-
-    // diagnostics.log_gemm_algo — IMP_LOG_GEMM_ALGO: '1' only.
-    if (const char* e = std::getenv("IMP_LOG_GEMM_ALGO"))
-        cfg.diagnostics.log_gemm_algo = (e[0] == '1');
-
-    // runtime.graph_capture_mode — IMP_GRAPH_CAPTURE_MODE: string.
-    if (const char* e = std::getenv("IMP_GRAPH_CAPTURE_MODE"))
-        cfg.runtime.graph_capture_mode = e;
-
-    // runtime.prefill_graph — IMP_PREFILL_GRAPH: presence enables.
-    if (std::getenv("IMP_PREFILL_GRAPH") != nullptr)
-        cfg.runtime.prefill_graph = true;
-
-    // generation.no_ban — IMP_NO_BAN: '1' only.
-    if (const char* e = std::getenv("IMP_NO_BAN"))
-        cfg.generation.no_ban = (e[0] == '1');
-
-    // generation.mtp_no_rope — IMP_MTP_NO_ROPE: set AND first char != '0'.
-    // Note: empty string ('\0' != '0') enables. Preserves original behavior.
-    if (const char* e = std::getenv("IMP_MTP_NO_ROPE"))
-        cfg.generation.mtp_no_rope = (e[0] != '0');
-
-    // diagnostics.mtp_pattern_log — IMP_MTP_PATTERN_LOG: non-empty AND first char != '0'.
-    if (const char* e = std::getenv("IMP_MTP_PATTERN_LOG"))
-        cfg.diagnostics.mtp_pattern_log = (std::strlen(e) > 0 && e[0] != '0');
-
-    // diagnostics.mtp_prenorm_h — IMP_MTP_PRENORM_H: same convention.
-    if (const char* e = std::getenv("IMP_MTP_PRENORM_H"))
-        cfg.diagnostics.mtp_prenorm_h = (std::strlen(e) > 0 && e[0] != '0');
-
-    // diagnostics.audit_nvfp4_scales — IMP_AUDIT_NVFP4_SCALES: presence enables.
-    if (std::getenv("IMP_AUDIT_NVFP4_SCALES") != nullptr)
-        cfg.diagnostics.audit_nvfp4_scales = true;
-
-    // gdn.layout_override — IMP_GDN_LAYOUT: string value.
-    if (const char* e = std::getenv("IMP_GDN_LAYOUT"))
-        cfg.gdn.layout_override = e;
-
-    // ffn.sparsity_probe — IMP_FFN_SPARSITY_PROBE: '1' enables.
-    if (const char* e = std::getenv("IMP_FFN_SPARSITY_PROBE"))
-        cfg.ffn.sparsity_probe = (e[0] == '1');
-
-    // ffn.sparsity_threshold — IMP_FFN_SPARSITY_THRESHOLD: float.
-    if (const char* e = std::getenv("IMP_FFN_SPARSITY_THRESHOLD"))
-        cfg.ffn.sparsity_threshold = parse_float(e, cfg.ffn.sparsity_threshold);
-
-    // speculative.ngram — IMP_SPEC_NGRAM: '1' enables.
-    if (const char* e = std::getenv("IMP_SPEC_NGRAM"))
-        cfg.speculative.ngram = (e[0] == '1');
-
-    // speculative.k — IMP_SPEC_K: int.
-    if (const char* e = std::getenv("IMP_SPEC_K"))
-        cfg.speculative.k = parse_int(e, cfg.speculative.k);
-
-    // attention.fp8_prefill — IMP_NO_FP8_PREFILL: '1' sets fp8_prefill="never".
-    if (const char* e = std::getenv("IMP_NO_FP8_PREFILL"))
-        if (e[0] == '1')
-            cfg.attention.fp8_prefill = "never";
 }
 
 }  // anonymous namespace

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -65,7 +65,7 @@ struct RuntimeConfig {
         // Set graph_capture_mode = "global" via imp.conf to opt back into
         // the legacy strict mode (any decode regression should also be
         // investigated under "thread_local" before assuming relaxed is the
-        // cause). Legacy env: IMP_GRAPH_CAPTURE_MODE.
+        // cause).
         std::string graph_capture_mode = "relaxed";
         // Capture prefill into a CUDA graph (in addition to decode). Default
         // flipped 2026-05-17 after the M3 Phase 4 A/B sweep across
@@ -80,7 +80,7 @@ struct RuntimeConfig {
         // noise documented in CLAUDE.md) but the candidate (relaxed)
         // never regressed below baseline. Opt out via
         // `--set runtime.prefill_graph=false` or imp.conf if a model
-        // regresses. Legacy env: IMP_PREFILL_GRAPH.
+        // regresses.
         bool prefill_graph = true;
         // 0 = auto: the engine sizes the decode batch from the model's weight
         // footprint (a >20 GiB MoE auto-picks 1). A positive value forces it.
@@ -135,8 +135,7 @@ struct RuntimeConfig {
         // 0 = disabled (keeps Phase 1+2 behavior). Typical: 4..32.
         // Only meaningful with kv_cache.dtype = "nvfp4" + kv_cache.bitdecoding_qk.
         int bitdecoding_residual_tokens = 0;
-        // BitDecoding TC path for NVFP4 paged attention QK. Legacy env:
-        // IMP_USE_BITDECODING_QK.
+        // BitDecoding TC path for NVFP4 paged attention QK.
         bool bitdecoding_qk = false;
     } kv_cache;
 
@@ -179,7 +178,7 @@ struct RuntimeConfig {
         // scores are softmaxed immediately, so the reduced accumulate
         // precision stays in the noise. Default ON since 2026-06-11; set
         // false to restore f32 accumulate. Only affects the fa2_fp16qk path,
-        // the fp8-QK path keeps f32 accumulate. Env: IMP_FA2_F16ACC.
+        // the fp8-QK path keeps f32 accumulate.
         bool fa2_f16acc = true;
         // f16-accumulate the PV MMA as well. Post-#673 the PV accumulate was
         // the last 1/4-rate HMMA in the FA2 kernel, dominating its tensor-
@@ -191,13 +190,13 @@ struct RuntimeConfig {
         // convex combinations of V, so range is safe; the per-tile rescale
         // rounding stays below the f16 output precision). Default ON since
         // 2026-06-11; set false to restore f32 PV accumulate. Requires
-        // fa2_f16acc. Env: IMP_FA2_PV_F16ACC.
+        // fa2_f16acc.
         bool fa2_pv_f16acc = true;
         // amax-scaled e4m3 conversion for the fp8-QK FA2 path (#680). The
         // raw conversion is the #511 quality cliff; scaling Q and K to the
         // full e4m3 range is the numerics class FlashInfer runs. Only
         // takes effect on the fp8-QK path (fa2_fp16qk=never or declined).
-        // Experimental quality probe. Env: IMP_FP8_QK_SCALED.
+        // Experimental quality probe.
         bool fp8_qk_scaled = false;
         std::string mxfp4 = "auto";
         // #846 NVFP4-attention spike (SageAttention3 recipe). All three only
@@ -260,7 +259,7 @@ struct RuntimeConfig {
         // 256 MiB caps ~32-head models at seq 2048 but high-head-count models
         // (e.g. Qwen3-14B, 40 heads → ~1824) drop to the slower FMHA at 2048.
         // Larger = longer prefill on the fast path, at the cost of KV headroom.
-        // Legacy env: IMP_ATTN_SCORES_MIB. Auto-shrinks if the alloc fails.
+        // Auto-shrinks if the alloc fails.
         // 384 keeps the fast cuBLAS attention path up to seq 2048 for up to
         // 48-head models (e.g. Qwen3-14B, 40 heads: +21% pp2048 vs the old 256
         // cap which dropped it to FMHA at ~1824). Only allocates what the
@@ -301,24 +300,20 @@ struct RuntimeConfig {
         bool no_shexp_gate = false;
         bool no_cutlass3x = false;
         // Per-process MoE workspace reserve override (MiB). 0 = use computed
-        // default. Legacy env: IMP_MOE_RESERVE_MIB.
+        // default.
         int reserve_mib = 0;
         // CUTLASS 3.x device-args full path for NVFP4 MoE prefill. Default ON
-        // since 2026-05-14 (+11-39% pp512 on 4-model A/B). Legacy env:
-        // IMP_NVFP4_DEVICE_ARGS (0 disables).
+        // since 2026-05-14 (+11-39% pp512 on 4-model A/B).
         bool nvfp4_device_args = true;
-        // Opt-in smallM kernel branch for NVFP4 MoE prefill. Legacy env:
-        // IMP_NVFP4_SMALLM.
+        // Opt-in smallM kernel branch for NVFP4 MoE prefill.
         bool nvfp4_smallM = false;
-        // Threshold M for smallM kernel (clamped to [0,128]). Legacy env:
-        // IMP_NVFP4_SMALLM_THRESHOLD.
+        // Threshold M for smallM kernel (clamped to [0,128]).
         int nvfp4_smallM_threshold = 64;
         // Rows-per-block (NR) for multi-row NVFP4 MoE decode kernels
         // (gemv_nvfp4_moe_{gate_up,decode}_mr<NR>). One warp computes one
         // row, so threads-per-block = NR * 32. Higher NR amortizes block
         // launch overhead at the cost of fewer concurrent CTAs. Valid
         // values: 4, 8 (default), 16, 32. Other values fall back to 8.
-        // Env: IMP_MOE_MR_NR.
         int mr_nr = 8;
     } moe;
 
@@ -348,7 +343,7 @@ struct RuntimeConfig {
         // exhaustively benched, Phase 1b.1 remains the fastest chunkwise
         // path on sm_120 — the WY-rep + TC-MMA variants all stay behind it.
         bool chunkwise_scan = true;
-        // Override gated-DeltaNet weight layout. Legacy env: IMP_GDN_LAYOUT.
+        // Override gated-DeltaNet weight layout.
         std::string layout_override;
     } gdn;
 
@@ -392,8 +387,7 @@ struct RuntimeConfig {
         // The GGUF path already NVFP4-caches a Q*_K/Q8_0 output_proj; this
         // extends the same win to native-NVFP4 dense models. Excluded for
         // GDN/SSM-hybrid models (LM-head NVFP4 degrades recurrent-state
-        // quality — see memory lm_head_only_nvfp4_qwen3_6_refuted). Legacy
-        // env: IMP_NO_NVFP4_LM_HEAD=1 to disable.
+        // quality — see memory lm_head_only_nvfp4_qwen3_6_refuted).
         bool nvfp4_lm_head = true;
         // FP16-accumulate cuBLAS prefill GEMMs (CUBLAS_COMPUTE_16F instead of
         // 32F). GeForce sm_120 runs FP16 tensor cores with FP32 accumulate at
@@ -421,8 +415,8 @@ struct RuntimeConfig {
         // run-to-run, so it's signal not noise). Default ON: the +11.4% decode
         // gain serves the primary mission metric (best batch=1 tok/s on the
         // 5090) and the +2.2% PPL cost is small; set false to keep the FP16
-        // lm_head for maximum coherence. Env IMP_NO_NVFP4_LM_HEAD=1 still kills
-        // the NVFP4 lm_head entirely (dense + GDN) via gemm.nvfp4_lm_head.
+        // lm_head for maximum coherence. gemm.nvfp4_lm_head=false still kills
+        // the NVFP4 lm_head entirely (dense + GDN).
         bool nvfp4_lm_head_gdn = true;
         // Batched-decode (n>1) LM head via a single CUTLASS NVFP4 tensor-core
         // GEMM instead of the FP16-activation batched-M GEMV. Reads the LM-head
@@ -468,7 +462,7 @@ struct RuntimeConfig {
         // already-resident contiguous expert data + scales, instead of the
         // CUTLASS grouped-GEMM (which under-utilizes the GPU at M=1). +54-80%
         // MoE decode on Qwen3-30B-A3B / Coder-30B / Gemma-4-26B. Prefill stays
-        // on CUTLASS. Legacy env: IMP_NO_NVFP4_MOE_DECODE=1 to disable.
+        // on CUTLASS.
         bool nvfp4_moe_decode = true;
     } gemm;
 
@@ -481,10 +475,9 @@ struct RuntimeConfig {
         bool no_logit_softcap = false;
         bool lm_dequant_fp16 = false;
         bool force_bos = false;
-        // Disable banned-token list (debug). Legacy env: IMP_NO_BAN.
+        // Disable banned-token list (debug).
         bool no_ban = false;
-        // Disable RoPE inside the MTP draft head (diagnostic). Legacy env:
-        // IMP_MTP_NO_ROPE.
+        // Disable RoPE inside the MTP draft head (diagnostic).
         bool mtp_no_rope = false;
     } generation;
 
@@ -702,7 +695,6 @@ struct RuntimeConfig {
         std::string graph_dump_dir;
         // Force NVFP4 dispatch through dequant->FP16 GEMV (M=1 bisection
         // tool — see Mistral-Small-3.2-NVFP4 long-form repetition loops).
-        // Legacy env: IMP_NVFP4_FORCE_DEQUANT.
         bool nvfp4_force_dequant = false;
         // Skip building the NVFP4 decode cache entirely (bisection/eval
         // tool): decode runs on the source-precision paths (dp4a GEMV for
@@ -716,16 +708,14 @@ struct RuntimeConfig {
         // outcomes — a capturability census, not a perf path.
         bool spec_capture_probe = false;
         // Log shape + per-candidate algoId/tileId + chosen algo for every
-        // benchmark_and_select_algo call. Legacy env: IMP_LOG_GEMM_ALGO.
+        // benchmark_and_select_algo call.
         bool log_gemm_algo = false;
-        // MTP pattern logging (predicted, actual, match per step). Legacy
-        // env: IMP_MTP_PATTERN_LOG.
+        // MTP pattern logging (predicted, actual, match per step).
         bool mtp_pattern_log = false;
         // MTP: pass main model's post-RMSNorm hidden to draft head (vLLM
-        // variant). Legacy env: IMP_MTP_PRENORM_H.
+        // variant).
         bool mtp_prenorm_h = false;
-        // Audit NVFP4 weight scales at load time. Legacy env:
-        // IMP_AUDIT_NVFP4_SCALES.
+        // Audit NVFP4 weight scales at load time.
         bool audit_nvfp4_scales = false;
         // Per-component VRAM accounting harness (MemAccount): lifecycle
         // checkpoints + per-pool notes + device-used peak sampler. Default off

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -13,7 +13,7 @@
 namespace imp {
 
 // runtime.graph_capture_mode = "global" | "relaxed" (default) | "thread_local"
-// (legacy env: IMP_GRAPH_CAPTURE_MODE). Selects the cudaStreamCaptureMode
+// Selects the cudaStreamCaptureMode
 // used by CudaGraphCapture::begin_capture and the ConditionalRunner body-graph
 // capture. Probed at first call and cached.
 //

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -234,7 +234,7 @@ bool Engine::enable_mtp_spec_decode(int k) {
         ws->mrope_sec1 = 0;
         ws->mrope_sec2 = 0;
     }
-    // Diagnostic: generation.mtp_no_rope (legacy IMP_MTP_NO_ROPE=1) disables RoPE entirely.
+    // Diagnostic: generation.mtp_no_rope disables RoPE entirely.
     if (runtime_config_.generation.mtp_no_rope) {
         ws->rope_dim = 0;
     }

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -328,7 +328,7 @@ private:
     // Prefill graph runner — captures forward_logits for non-last chunks of
     // chunked prefill. Single runner: in practice chunk_len == prefill_chunk_size
     // for all non-last chunks, so per-shape variability collapses to one shape.
-    // Opt-in via IMP_PREFILL_GRAPH=1 (Phase 4 of MoE-prefill-graphs work).
+    // Gated by runtime.prefill_graph (Phase 4 of MoE-prefill-graphs work).
     CudaGraphRunner prefill_graph_runner_;
     int last_prefill_chunk_len_ = -1;
     int last_prefill_block_count_ = -1;
@@ -743,7 +743,7 @@ private:
     // in generated output (e.g. <|im_start|>, <|endoftext|>). Scans tokenizer
     // for control-tagged tokens (authoritative GGUF token_types) or falls back
     // to heuristic patterns. Excludes stop/EOS/think/channel tokens. Bypassed
-    // by IMP_NO_BAN=1 for bisecting NVFP4 repetition issues.
+    // by generation.no_ban for bisecting NVFP4 repetition issues.
     void build_banned_token_list();
 
     // ── Inference helpers ────────────────────────────────────────────

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -254,7 +254,7 @@ void Engine::init_resolve_fp8_prefill_() {
             IMP_LOG_INFO("FP8 prefill: auto → enabled");
         }
     } else if (no_fp8_prefill) {
-        IMP_LOG_INFO("FP8 prefill: disabled (IMP_NO_FP8_PREFILL=1)");
+        IMP_LOG_INFO("FP8 prefill: disabled (attention.fp8_prefill=never)");
     }
 }
 

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -170,7 +170,7 @@ bool Engine::init_features() {
 }
 
 void Engine::build_banned_token_list() {
-    // Diagnostic bypass: generation.no_ban (legacy IMP_NO_BAN=1) disables the
+    // Diagnostic bypass: generation.no_ban disables the
     // ban list. Used to bisect Mistral-Small-3.2-NVFP4 long-form repetition
     // (ban vs weight quality).
     if (runtime_config_.generation.no_ban) {

--- a/tests/test_attention_paged_nvfp4_tc.cu
+++ b/tests/test_attention_paged_nvfp4_tc.cu
@@ -21,7 +21,7 @@ namespace {
 // Equivalence on REAL input is covered by:
 // 1. Phase-0 microbench (`tools/analysis/bench_nvfp4_qk_tc_vs_scalar.sh`):
 //    isolated Q.K dot, max_abs_err 9.15e-05 rel 1.10e-04 vs scalar reference.
-// 2. End-to-end smoke (Qwen3-8B Q8_0 + --kv-nvfp4 + IMP_USE_BITDECODING_QK=1):
+// 2. End-to-end smoke (Qwen3-8B Q8_0 + --kv-nvfp4 + kv_cache.bitdecoding_qk=true):
 //    both paths produce "The capital of France is Paris" coherent.
 // 3. SASS audit: TC kernel emits 24 HMMA per template instantiation; scalar
 //    kernel remains 0 HMMA / 346 scalar (default path unchanged).

--- a/tools/analysis/sass_omma_audit.sh
+++ b/tools/analysis/sass_omma_audit.sh
@@ -94,7 +94,7 @@ with open('/tmp/imp-omma-audit.kernels.tsv') as f:
         omma, hmma = int(omma), int(hmma)
 
         if 'gemm_grouped_nvfp4_smallM_cu' in kern:
-            label = 'src/compute/gemm_grouped_nvfp4_smallM.cu (opt-in IMP_NVFP4_SMALLM)'
+            label = 'src/compute/gemm_grouped_nvfp4_smallM.cu (opt-in moe.nvfp4_smallM)'
         elif 'gemm_cutlass_mxfp4_sm120_cu' in kern:
             label = 'src/compute/gemm_cutlass_mxfp4_sm120.cu'
         elif 'gemm_cutlass_grouped_3x_cu' in kern:

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -47,8 +47,8 @@ void print_usage(const char* prog) {
             "                        Default is FP16 KV — FP8 is not safe on every\n"
             "                        model (Mistral-Small-3.1 Q6_K, DeepSeek-R1,\n"
             "                        Qwen3.5-GDN Q8_0, Gemma-4 all hit a stride bug).\n"
-            "  --kv-fp16             (default, no-op) — was an escape hatch under\n"
-            "                        the old auto-FP8 default.\n"
+            "  --kv-fp16             Force FP16 KV cache (opts out of the auto FP8\n"
+            "                        upgrade for models with a kv-FP8 author hint).\n"
             "  --no-fp8-prefill      Disable auto FP8 weight cache for prefill.\n"
             "                        Use with --kv-fp16 --no-nvfp4 for full FP16\n"
             "                        path (fixes DeepSeek-R1 Q6_K garbage output).\n"
@@ -56,11 +56,7 @@ void print_usage(const char* prog) {
             "  --kv-int4             Use INT4 KV cache (quarters KV memory)\n"
             "  --kv-nvfp4            Use NVFP4 KV cache (quarters KV memory; FP4 + E4M3 scales)\n"
             "  --kv-mxfp4            Use MXFP4-KV cache (quarters KV memory; FP4 + UE8M0 scales)\n"
-            "  --kv-turboquant       [DEPRECATED] Alias for --kv-mxfp4\n"
-            "  --kv-turboquant-lite  [DEPRECATED] Alias for --kv-mxfp4\n"
-            "  --tq-sketch-mult <n>  [DEPRECATED, ignored]\n"
             "  --ssm-fp16            Use FP16 for SSM h_state (saves ~50% SSM VRAM)\n"
-            "  --cuda-graphs         (default, no-op — graphs enabled by default)\n"
             "  --no-cuda-graphs      Disable CUDA Graph capture for decode\n"
             "  --chat-template <t>   Chat template: auto, none, chatml, llama2, llama3, nemotron, gemma, "
             "deepseek_r1, phi\n"
@@ -171,10 +167,11 @@ CliArgs parse_args(int argc, char** argv) {
         } else if (std::strcmp(arg, "--kv-fp8") == 0) {
             args.kv_fp8 = true;
         } else if (std::strcmp(arg, "--kv-fp16") == 0) {
-            // Force FP16 KV cache via the same IMP_KV_FP16 env var the engine reads.
-            setenv("IMP_KV_FP16", "1", 1);
+            // Force FP16 KV cache — opts out of the "auto" FP8 upgrade for
+            // models that ship a kv_cache_quant_algo=FP8 hint.
+            args.config_overrides.push_back("kv_cache.dtype=fp16");
         } else if (std::strcmp(arg, "--no-fp8-prefill") == 0) {
-            setenv("IMP_NO_FP8_PREFILL", "1", 1);
+            args.config_overrides.push_back("attention.fp8_prefill=never");
         } else if (std::strcmp(arg, "--kv-int8") == 0) {
             args.kv_int8 = true;
         } else if (std::strcmp(arg, "--kv-int4") == 0) {
@@ -183,16 +180,8 @@ CliArgs parse_args(int argc, char** argv) {
             args.kv_nvfp4 = true;
         } else if (std::strcmp(arg, "--kv-mxfp4") == 0) {
             args.kv_mxfp4 = true;
-        } else if (std::strcmp(arg, "--kv-turboquant") == 0) {
-            args.kv_turboquant = true;  // deprecated alias → kv_mxfp4
-        } else if (std::strcmp(arg, "--kv-turboquant-lite") == 0) {
-            args.kv_turboquant_lite = true;  // deprecated alias → kv_mxfp4
-        } else if (std::strcmp(arg, "--tq-sketch-mult") == 0 && i + 1 < argc) {
-            ++i;  // consume the argument; flag is deprecated and ignored
         } else if (std::strcmp(arg, "--ssm-fp16") == 0) {
             args.ssm_fp16 = true;
-        } else if (std::strcmp(arg, "--cuda-graphs") == 0) {
-            // no-op: cuda graphs enabled by default now
         } else if (std::strcmp(arg, "--no-cuda-graphs") == 0) {
             args.no_cuda_graphs = true;
         } else if (std::strcmp(arg, "--chat-template") == 0 && i + 1 < argc) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -50,8 +50,6 @@ struct CliArgs {
     bool kv_int4 = false;                // Use INT4 KV cache (quarter size)
     bool kv_nvfp4 = false;               // Use NVFP4 KV cache (quarter size, FP4 E2M1 + UE4M3 scales)
     bool kv_mxfp4 = false;              // Use MXFP4-KV cache (packed FP4 + UE8M0 scales)
-    bool kv_turboquant = false;          // [DEPRECATED] alias for kv_mxfp4 — emits one-shot WARN
-    bool kv_turboquant_lite = false;     // [DEPRECATED] alias for kv_mxfp4 — emits one-shot WARN
     bool ssm_fp16 = false;               // Use FP16 for SSM h_state
     bool no_cuda_graphs = false;         // Disable CUDA Graph capture for decode
     std::string chat_template = "auto";  // auto, none, chatml, llama2, llama3, nemotron, gemma

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -165,24 +165,6 @@ int main(int argc, char** argv) {
         config.kv_cache_dtype = IMP_DTYPE_NVFP4;
     if (args.kv_mxfp4)
         config.kv_cache_dtype = IMP_DTYPE_MXFP4_KV;
-    if (args.kv_turboquant) {
-        static bool warned_tq = false;
-        if (!warned_tq) {
-            fprintf(stderr, "[IMP WARN] --kv-turboquant is deprecated; TurboQuant has been retired. "
-                            "Using --kv-mxfp4 instead.\n");
-            warned_tq = true;
-        }
-        config.kv_cache_dtype = IMP_DTYPE_MXFP4_KV;
-    }
-    if (args.kv_turboquant_lite) {
-        static bool warned_tql = false;
-        if (!warned_tql) {
-            fprintf(stderr, "[IMP WARN] --kv-turboquant-lite is deprecated; TurboQuant has been retired. "
-                            "Using --kv-mxfp4 instead.\n");
-            warned_tql = true;
-        }
-        config.kv_cache_dtype = IMP_DTYPE_MXFP4_KV;
-    }
     if (args.ssm_fp16)
         config.ssm_state_dtype = IMP_DTYPE_FP16;
     if (args.no_cuda_graphs)

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -105,12 +105,6 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.kv_nvfp4 = true;
         } else if (std::strcmp(arg, "--kv-mxfp4") == 0) {
             args.kv_mxfp4 = true;
-        } else if (std::strcmp(arg, "--kv-turboquant") == 0) {
-            args.kv_turboquant = true;  // deprecated alias → kv_mxfp4
-        } else if (std::strcmp(arg, "--kv-turboquant-lite") == 0) {
-            args.kv_turboquant_lite = true;  // deprecated alias → kv_mxfp4
-        } else if (std::strcmp(arg, "--tq-sketch-mult") == 0 && i + 1 < argc) {
-            ++i;  // consume the argument; flag is deprecated and ignored
         } else if (std::strcmp(arg, "--prefill-chunk-size") == 0 && i + 1 < argc) {
             args.prefill_chunk_size = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--decode-nvfp4") == 0) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -29,8 +29,6 @@ struct ServerArgs {
     bool kv_int4 = false;
     bool kv_nvfp4 = false;
     bool kv_mxfp4 = false;
-    bool kv_turboquant = false;      // [DEPRECATED] alias for kv_mxfp4
-    bool kv_turboquant_lite = false; // [DEPRECATED] alias for kv_mxfp4
     int prefill_chunk_size = -1;  // -1 = per-arch default (2048 if supported, 0 otherwise)
     int decode_nvfp4 = -1;                      // -1=auto, 0=off, 1=additive, 2=NVFP4-only
     bool mxfp4_prefill = false;                 // --mxfp4-prefill: CUTLASS MXFP4 GEMM for prefill

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -246,8 +246,6 @@ ImpConfig build_config(const ServerArgs& args, const imp::RuntimeConfig& runtime
     bool kv_int4 = overrides.value("kv_int4", args.kv_int4);
     bool kv_nvfp4 = overrides.value("kv_nvfp4", args.kv_nvfp4);
     bool kv_mxfp4 = overrides.value("kv_mxfp4", args.kv_mxfp4);
-    bool kv_turboquant = overrides.value("kv_turboquant", args.kv_turboquant);
-    bool kv_turboquant_lite = overrides.value("kv_turboquant_lite", args.kv_turboquant_lite);
     if (kv_fp8)
         config.kv_cache_dtype = IMP_DTYPE_FP8_E4M3;
     if (kv_int8)
@@ -258,26 +256,6 @@ ImpConfig build_config(const ServerArgs& args, const imp::RuntimeConfig& runtime
         config.kv_cache_dtype = IMP_DTYPE_NVFP4;
     if (kv_mxfp4)
         config.kv_cache_dtype = IMP_DTYPE_MXFP4_KV;
-    if (kv_turboquant) {
-        // DEPRECATED: TurboQuant retired — falls back to MXFP4-KV
-        static bool warned_tq = false;
-        if (!warned_tq) {
-            fprintf(stderr, "[IMP WARN] --kv-turboquant is deprecated; TurboQuant has been retired. "
-                            "Using --kv-mxfp4 instead.\n");
-            warned_tq = true;
-        }
-        config.kv_cache_dtype = IMP_DTYPE_MXFP4_KV;
-    }
-    if (kv_turboquant_lite) {
-        // DEPRECATED: TurboQuant Lite retired — falls back to MXFP4-KV
-        static bool warned_tql = false;
-        if (!warned_tql) {
-            fprintf(stderr, "[IMP WARN] --kv-turboquant-lite is deprecated; TurboQuant has been retired. "
-                            "Using --kv-mxfp4 instead.\n");
-            warned_tql = true;
-        }
-        config.kv_cache_dtype = IMP_DTYPE_MXFP4_KV;
-    }
 
     int chunk = overrides.value("prefill_chunk_size", args.prefill_chunk_size);
     // Default chunk = -1 → engine resolver picks per-arch default (512 for


### PR DESCRIPTION
## What

Simplification pass over the config/CLI layer, follow-up to #878's consistency audit. **−305/+70 LOC.** Every removal was verified to have zero producers/consumers in the repo (grep across src/, tools/, tests/, scripts/, .github/, Dockerfile, docker-entrypoint); all removed knobs stay reachable via imp.conf / `--set`.

## Changes

**Legacy env seeding trimmed 29 → 2** (`seed_from_env`, src/runtime/config.cpp): only `IMP_DETERMINISTIC` (set by `test_determinism_e2e`/`test_lora` to inject determinism through the public API) and `IMP_FMHA_FA2` (set by the roofline A/B harness per subprocess) have real producers — the other 27 vars had none anywhere. All stale `Legacy env: IMP_*` comments and log strings swept repo-wide (config.h, kernels, resolver logs); CLAUDE.md and imp.conf.example updated to match.

**`--kv-fp16` was a silent no-op — now fixed**: it `setenv`'d `IMP_KV_FP16`, which no code has ever read (the comment claiming "the engine reads it" was wrong). It now pushes `kv_cache.dtype=fp16`, actually forcing FP16 KV and opting out of the auto FP8-hint upgrade — matching its documented semantics. `--no-fp8-prefill` similarly drops its env round-trip for a direct `attention.fp8_prefill=never` override.

**TurboQuant surface fully retired** (deprecated since Phase 5, 2026-05-17; zero callers): `--kv-turboquant{,-lite}` + `--tq-sketch-mult` flags in both binaries, the per-request JSON overrides, the one-shot WARN blocks duplicated in imp-cli/main.cpp and imp-server/handlers.cpp, the `IMP_DTYPE_TURBOQUANT(_LITE)` C-API enum aliases, and the ignored `turboquant_sketch_multiplier` ImpConfig field. (The live `quant/turboquant_fp4.cuh` FP4 helpers used by MXFP4-KV are untouched.)

**Dead code deleted**: `--cuda-graphs` no-op flag; `ImpConfig.gpu_memory_pool_size` and `ImpConfig.num_cpu_threads` (default-initialized, never read anywhere).

## Deliberately NOT touched (audited, kept)

- Default-off research scaffolds from closed programs (mxfp4 attention family, BitDecoding, FFN sparsity, q4k_hmma, spec_capture_probe) — kept per the explicit #846/#873 decision to ship them as quality-validated scaffolds.
- Dev-only `getenv(IMP_SPEC_TRACE/IMP_JUMP_TRACE/IMP_PPL_DUMP)` trace toggles.
- The two near-duplicate args parsers — 27 byte-identical branches, but unifying them is speculative abstraction without a concrete bug; the ugliest duplication (turboquant WARN blocks) dies in this PR anyway.

## Verification

- `make build` + `make test-unit` (37/37) + `make verify-fast` (fast gtest filter PASS).
- GPU smoke (Qwen3-8B-Q8_0, both arms): `--kv-fp16 --no-fp8-prefill` resolves end-to-end (log: `FP8 prefill: disabled (attention.fp8_prefill=never)`), generation coherent and identical to the default arm.
- Removed flags fail fast: `imp-cli --kv-turboquant` / `imp-server --tq-sketch-mult` → `Unknown argument`.
- No hot-path change (kernel files only had comment/log-string edits); baseline untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)