### PR TITLE
fix(mla): YaRN rope-mscale uses the HF ratio, not mscale_all_dim alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **MLA (DeepSeek-V2/V3) YaRN rope-mscale**: the RoPE cos/sin were scaled by
+  `yarn_get_mscale(factor, mscale_all_dim)` (=1.261 for V2-Lite) instead of the
+  HF ratio `yarn_get_mscale(factor, mscale) / yarn_get_mscale(factor, mscale_all_dim)`
+  (=1.0 when the two coincide, as in V2-Lite). imp was inflating the rotary
+  embedding by 1.261×; the error compounds with position, so teacher-forced PPL
+  degraded with sequence length. `mscale` and `mscale_all_dim` are now loaded
+  separately: the softmax attention scale keeps `mscale_all_dim²` (unchanged),
+  the rope factor uses the ratio. Same-corpus PPL vs HF bf16 on DeepSeek-V2-Lite:
+  534-tok **+24.4% → +2.75%** (imp 7.78→6.43, HF 6.25); 196-tok +5.0% → +0.8%.
+  The residual ~1-3% is F16-vs-bf16 compute precision. Applies to both
+  DeepSeek-V2-Lite and DeepSeek-Coder-V2-Lite (same config); generalizes
+  correctly to V3 (where the two mscales differ).
+
 ## [0.16.2] - 2026-07-04
 
 FP4-attention research batch: the #846 program (SageAttention3 → ThriftAttention →

--- a/GOAL.md
+++ b/GOAL.md
@@ -72,7 +72,7 @@ benchmark numbers):
 | Model | State (2026-06-06) |
 |---|---|
 | DeepSeek-R1-Distill-7B/14B | Never benched locally. Arch is Qwen2/Llama (covered). |
-| DeepSeek-V2-Lite (MLA) | **Supported** — first Multi-head Latent Attention arch (#802 materialized Stage A, #803 absorbed latent-KV decode, opt-in). Validated locally at bf16 (28 GB, experts host-offloaded → graphs disabled); PPL 6.06 vs HF 5.07. Real V2/V3/R1 MLA checkpoints now load via this path. |
+| DeepSeek-V2-Lite (MLA) | **Supported** — first Multi-head Latent Attention arch (#802 materialized Stage A, #803 absorbed latent-KV decode, opt-in). Validated locally at bf16 (28 GB, experts host-offloaded → graphs disabled); same-corpus PPL within ~3% of HF bf16 (imp 6.43 vs HF 6.25, 534-tok) after the 2026-07-07 YaRN rope-mscale fix. Real V2/V3/R1 MLA checkpoints now load via this path. |
 | Gemma-3 27B | 12B Q4_K_M + 4B-VL validated locally; 27B never staged. |
 | Phi-4 14B | NVFP4 (reasoning-plus) validated locally; GGUF Q6_K never staged. |
 | Mixtral 8x7B | Arch in the enum, chat-template test only; never staged. |

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -179,7 +179,7 @@ history.
   latent + 64-dim decoupled-RoPE key, paged-latent attention kernel).
 
 **Outcome:** both stages shipped — Stage A materialized (#802), Phase 3 absorbed latent-KV-cache
-decode (#803, opt-in). First MLA arch in imp; validated on DeepSeek-V2-Lite (PPL 6.06 vs HF 5.07).
+decode (#803, opt-in). First MLA arch in imp; validated on DeepSeek-V2-Lite (same-corpus PPL within ~3% of HF bf16 after the 2026-07-07 YaRN rope-mscale fix; the original "6.06 vs 5.07" was cross-corpus).
 Current state lives in [`../supported-models.md`](../supported-models.md), [`../roadmap.md`](../roadmap.md),
 and the `src/compute/mla_*.{cu,h}` headers.
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -22,7 +22,7 @@ Anything not on this list may still load (the GGUF and SafeTensors paths cover m
 | [Mistral-Small-3.1-24B](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF) | Q6_K | 19 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-7B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF) | Q8_0 | 7.6 GB | — | GGUF |
 | [DeepSeek-R1-Distill-Qwen-14B](https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF) | Q6_K | 12 GB | — | GGUF |
-| [DeepSeek-V2-Lite](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite) | bf16 | 28 GB | ~30 (eager) | SafeTensors — **MLA** (first Multi-head Latent Attention arch); experts host-offloaded on 32 GB → graphs disabled. PPL 6.06 vs HF 5.07 (+19.6%). |
+| [DeepSeek-V2-Lite](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite) | bf16 | 28 GB | ~30 (eager) | SafeTensors — **MLA** (first Multi-head Latent Attention arch); experts host-offloaded on 32 GB → graphs disabled. Same-corpus teacher-forced PPL within ~3% of HF bf16 (imp 6.43 vs HF 6.25 on a 534-tok corpus). The earlier "+19.6%" figure was a cross-corpus artifact compounded by a YaRN rope-mscale bug (imp inflated the RoPE cos/sin by 1.261× where HF applies 1.0; fixed 2026-07-07). |
 | [DeepSeek-Coder-V2-Lite-Instruct](https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct) | bf16 | 30 GB | — (eager) | SafeTensors — **MLA** (same `deepseek_v2` arch as V2-Lite: kv_lora_rank=512, q_lora_rank=0); experts host-offloaded on 32 GB → graphs disabled. Second MLA checkpoint, code-specialized — coherent codegen verified. |
 
 ## Hybrid (Gated DeltaNet + attention)

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -652,14 +652,24 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
             // non-RoPE dims plus qk_rope_head_dim RoPE dims.
             cfg.head_dim = cfg.qk_nope_head_dim + cfg.qk_rope_head_dim;
             cfg.rope_dim = cfg.qk_rope_head_dim;
-            // YaRN mscale from rope_scaling. Use mscale_all_dim (the value
-            // that HF applies to the softmax scale) with a fallback to mscale.
-            // In DeepSeek-V2-Lite both are 0.707; V3 may differ.
+            // YaRN mscale from rope_scaling. HF DeepSeek-V2 uses the two mscale
+            // fields DIFFERENTLY and they must NOT be conflated:
+            //   - the softmax attention scale gets yarn_get_mscale(factor, mscale_all_dim)^2
+            //   - the RoPE cos/sin get the RATIO
+            //       yarn_get_mscale(factor, mscale) / yarn_get_mscale(factor, mscale_all_dim)
+            // For DeepSeek-V2-Lite both are 0.707, so the rope ratio is exactly
+            // 1.0 (no cos/sin scaling); V3 may differ. Load both separately.
             const JValue* rs = jobj_find(eff, "rope_scaling");
             if (rs && rs->type == JType::OBJECT) {
-                jobj_get_float(*rs, "mscale", cfg.mla_mscale);
-                // Override with mscale_all_dim if present (preferred for softmax scale).
-                jobj_get_float(*rs, "mscale_all_dim", cfg.mla_mscale);
+                float mscale = 1.0f, mscale_all_dim = 1.0f;
+                bool has_mscale = jobj_get_float(*rs, "mscale", mscale);
+                bool has_all_dim = jobj_get_float(*rs, "mscale_all_dim", mscale_all_dim);
+                // Softmax scale prefers mscale_all_dim, falls back to mscale.
+                cfg.mla_mscale = has_all_dim ? mscale_all_dim : (has_mscale ? mscale : 1.0f);
+                // RoPE ratio numerator is the raw mscale (fallback: mscale_all_dim
+                // → ratio 1.0, i.e. no rope scaling, which is HF's default when
+                // the two coincide).
+                cfg.mla_mscale_num = has_mscale ? mscale : cfg.mla_mscale;
             }
             IMP_LOG_INFO("  MLA: kv_lora_rank=%d q_lora_rank=%d "
                          "qk_rope=%d qk_nope=%d v_head=%d head_dim=%d mla_mscale=%.4f",
@@ -668,31 +678,35 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
                          cfg.head_dim, cfg.mla_mscale);
             // MLA + YaRN rope mscale correction.
             //
-            // The rope_yarn kernel computes:
+            // imp's rope_yarn kernel scales cos/sin by:
             //   mscale_final = yarn_attn_factor * (1 + 0.1 * log(rope_freq_scale))
             //
-            // HF DeepSeek-V2 applies to cos/sin:
-            //   mscale = yarn_get_mscale(factor, config.rope_scaling.mscale)
-            //           = 0.1 * mscale * log(factor) + 1
+            // HF DeepseekV2YarnRotaryEmbedding scales cos/sin by the RATIO of the
+            // two configured mscales (modeling_deepseek.py):
+            //   _mscale = yarn_get_mscale(factor, mscale)
+            //             / yarn_get_mscale(factor, mscale_all_dim)
+            // where yarn_get_mscale(f, m) = 0.1*m*ln(f) + 1.
             //
-            // With the default yarn_attn_factor=1.0, imp gives 1 + 0.1*log(factor)
-            // which ignores the config's mscale field.  Correct it by adjusting
-            // yarn_attn_factor so mscale_final matches HF.  mla_mscale is loaded
-            // from mscale_all_dim (preferred) or mscale; for V2-Lite both are 0.707.
+            // For V2-Lite (factor=40, mscale == mscale_all_dim == 0.707) this
+            // ratio is EXACTLY 1.0 — HF does not scale the rotary at all. The
+            // earlier code used yarn_get_mscale(factor, mscale_all_dim)=1.261 as
+            // the target, inflating the rope cos/sin by 1.261x; the error
+            // compounds with position and cost ~+24% PPL at 512 tokens. Set
+            // yarn_attn_factor so mscale_final == the HF ratio.
             //
-            // For V2-Lite (factor=40, mscale=0.707):
-            //   HF rope mscale = 0.1*0.707*ln(40)+1 = 1.261
-            //   imp default     = 0.1*1.0 *ln(40)+1 = 1.369
-            //   yarn_attn_factor = 1.261 / 1.369 = 0.9208
+            // (The softmax attention scale separately receives
+            // yarn_get_mscale(factor, mscale_all_dim)^2 via
+            // mla_attention_scale_multiplier — that is unchanged.)
             if (cfg.yarn_ext_factor > 0.0f && cfg.rope_freq_scale > 1.0f) {
                 const float log_scale = std::log(cfg.rope_freq_scale);
-                const float hf_mscale = 0.1f * cfg.mla_mscale * log_scale + 1.0f;
+                const float ms_num = 0.1f * cfg.mla_mscale_num * log_scale + 1.0f;
+                const float ms_den = 0.1f * cfg.mla_mscale     * log_scale + 1.0f;
+                const float hf_rope_mscale = ms_num / ms_den;
                 const float imp_mscale = 0.1f * log_scale + 1.0f;
-                cfg.yarn_attn_factor = hf_mscale / imp_mscale;
+                cfg.yarn_attn_factor = hf_rope_mscale / imp_mscale;
                 IMP_LOG_INFO("  MLA YaRN rope-mscale adjust: yarn_attn_factor=%.4f "
-                             "(hf_mscale=%.4f, attn_scale_multiplier=%.4f)",
-                             cfg.yarn_attn_factor, hf_mscale,
-                             hf_mscale * hf_mscale);
+                             "(hf_rope_mscale=%.4f, softmax_scale_mult=%.4f)",
+                             cfg.yarn_attn_factor, hf_rope_mscale, ms_den * ms_den);
             }
         }
     }

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -60,6 +60,14 @@ struct ModelConfig {
     // Stores rope_scaling.mscale_all_dim if present, else rope_scaling.mscale.
     // For DeepSeek-V2-Lite both are 0.707; the distinction matters for V3.
     float mla_mscale        = 1.0f;
+    // Raw rope_scaling.mscale (the numerator of the RoPE cos/sin scale).
+    // HF DeepseekV2YarnRotaryEmbedding scales cos/sin by the RATIO
+    //   yarn_get_mscale(factor, mscale) / yarn_get_mscale(factor, mscale_all_dim),
+    // which for V2-Lite (mscale == mscale_all_dim == 0.707) is exactly 1.0 —
+    // NOT yarn_get_mscale(factor, mscale_all_dim). Kept separate from
+    // mla_mscale (= mscale_all_dim, used by the softmax scale) so the rope
+    // factor below can form the ratio instead of double-applying the mscale.
+    float mla_mscale_num    = 1.0f;
     bool  is_mla() const { return kv_lora_rank > 0; }
     int   first_k_dense_replace = 0; // layers [0, k) use dense FFN even in a MoE model
     // NoPE attention (Nemotron-H family): attention layers use NO rotary

--- a/tests/test_mla.cpp
+++ b/tests/test_mla.cpp
@@ -13,6 +13,8 @@
 // Set IMP_TEST_MODEL_DEEPSEEK to the directory path, or place the model at
 // /models/DeepSeek-V2-Lite (Docker bind-mount fallback). Skipped if absent.
 
+#include <cmath>
+
 #include "model/hf_config_loader.h"
 #include "model/model.h"
 #include "model/model_config.h"
@@ -91,15 +93,48 @@ TEST(MLAConfig, ParsesDeepSeekV2LiteFields) {
     // head_dim overridden to nope+rope = 128+64 = 192 for MLA models
     EXPECT_EQ(cfg.head_dim, 192);
 
-    // mla_mscale: raw 0.707 from rope_scaling.mscale
-    // (yarn-adjusted attention scale formula is Task 2.5)
+    // mla_mscale: mscale_all_dim (0.707), used by the softmax attention scale.
     EXPECT_NEAR(cfg.mla_mscale, 0.707f, 1e-3f);
+    // mla_mscale_num: raw rope_scaling.mscale (0.707), the ratio numerator.
+    EXPECT_NEAR(cfg.mla_mscale_num, 0.707f, 1e-3f);
 
     // MoE shared experts
     EXPECT_EQ(cfg.n_experts_shared, 2);
 
     // First k dense layers (hybrid MoE)
     EXPECT_EQ(cfg.first_k_dense_replace, 1);
+}
+
+// Regression: the RoPE cos/sin mscale for DeepSeek-V2-Lite must be 1.0, NOT
+// yarn_get_mscale(factor, mscale_all_dim)=1.261. HF scales cos/sin by the ratio
+// yarn_get_mscale(factor, mscale) / yarn_get_mscale(factor, mscale_all_dim),
+// which is exactly 1.0 when the two mscales coincide (as in V2-Lite). imp's
+// rope_yarn applies mscale_final = yarn_attn_factor * (1 + 0.1*ln(freq_scale));
+// this must equal the HF ratio. The pre-fix code inflated it to 1.261, which
+// compounded with position and cost ~+24% PPL at 512 tokens.
+TEST(MLAConfig, YarnRopeMscaleIsUnityForV2Lite) {
+    std::string dir = imp_test::env_path_or(imp_test::kEnvModelDeepSeek,
+                                            "/models/DeepSeek-V2-Lite");
+    if (!std::filesystem::exists(dir)) {
+        GTEST_SKIP() << "Set IMP_TEST_MODEL_DEEPSEEK or place model at "
+                     << dir << " to run MLA rope-mscale tests";
+    }
+
+    ModelConfig cfg;
+    ASSERT_TRUE(HFConfigLoader::load_config(dir, cfg));
+    ASSERT_TRUE(cfg.is_mla());
+    ASSERT_GT(cfg.rope_freq_scale, 1.0f);
+    ASSERT_GT(cfg.yarn_ext_factor, 0.0f);
+
+    // Effective rope cos/sin scale imp's rope_yarn kernel will apply.
+    const float imp_builtin = 1.0f + 0.1f * std::log(cfg.rope_freq_scale);
+    const float rope_mscale = cfg.yarn_attn_factor * imp_builtin;
+    EXPECT_NEAR(rope_mscale, 1.0f, 1e-3f)
+        << "MLA rope cos/sin mscale must be the HF ratio (1.0 for V2-Lite), "
+           "not yarn_get_mscale(factor, mscale_all_dim)";
+
+    // The softmax attention scale is unaffected (still mscale_all_dim^2 ≈ 1.59).
+    EXPECT_NEAR(imp::mla_attention_scale_multiplier(cfg), 1.261f * 1.261f, 1e-2f);
 }
 
 TEST(MLAConfig, IsMlaReturnsFalseForNonMLA) {


### PR DESCRIPTION
## Summary

The documented "DeepSeek-V2-Lite MLA quality gap, PPL 6.06 vs HF 5.07 (+19.6%)" turned out to be **two** things: a cross-corpus measurement artifact **and** a real YaRN rope-mscale bug. This fixes the bug and corrects the docs.

**Root cause.** HF `DeepseekV2YarnRotaryEmbedding` scales the RoPE cos/sin by the **ratio**
`yarn_get_mscale(factor, mscale) / yarn_get_mscale(factor, mscale_all_dim)`, which is **exactly 1.0** when the two mscales coincide (DeepSeek-V2-Lite: both `0.707`). imp conflated the two `rope_scaling` fields into one (`mla_mscale`, loading only `mscale_all_dim` and overwriting `mscale`) and applied `yarn_get_mscale(40, 0.707) = 1.261` to the rotary — **inflating the RoPE cos/sin by 1.261×**. The softmax attention scale (`mscale_all_dim²` ≈ 1.590) was already correct.

Because the inflation corrupts the positional encoding, the error **compounds with position**, so teacher-forced PPL degraded with sequence length — the classic signature of a positional/RoPE bug.

## Fix

Load `mscale` and `mscale_all_dim` separately:
- softmax attention scale keeps `mscale_all_dim²` (unchanged),
- the rope `yarn_attn_factor` is now derived from the **ratio** → `0.7305` for V2-Lite, so the rope cos/sin mscale = `0.7305 × (1 + 0.1·ln 40)` = **1.0**.

Generalizes correctly to V3 (where `mscale ≠ mscale_all_dim` → a non-1.0 ratio). Applies to DeepSeek-Coder-V2-Lite too (same config).

## Verification (same-corpus teacher-forced PPL vs HF bf16)

HF reference computed via `transformers==4.44.2` on `DeepSeek-V2-Lite` (the vllm image's transformers is too new for DeepSeek's remote modeling code).

| corpus | imp before | imp after | HF | gap after |
|---|---|---|---|---|
| 534 tok | 7.78 (+24.4%) | **6.43** | 6.25 | **+2.75%** |
| 196 tok | 7.40 (+5.0%) | **7.10** | 7.05 | **+0.8%** |

Residual ~1–3% is F16-vs-bf16 compute precision (imp runs bf16 weights in F16; a global property, not MLA-specific). Coherent greedy output verified. New regression test `MLAConfig.YarnRopeMscaleIsUnityForV2Lite`; all 6 `MLAConfig.*` tests pass.

Config log after the fix:
```
MLA YaRN rope-mscale adjust: yarn_attn_factor=0.7305 (hf_rope_mscale=1.0000, softmax_scale_mult=1.5896)
```

## Notes
- No default-path behavior change for non-MLA models.
- GPU validation is local (no GPU/model runner in CI); the `MLAConfig.*` tests skip without `IMP_TEST_MODEL_DEEPSEEK` / `/models/DeepSeek-V2-Lite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)