### PR TITLE
test: cover imp-server CLI flag parsing (--vram-budget + server limits) [#896]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,12 +526,14 @@ if(IMP_BUILD_TESTS)
             tools/imp-server/responses.cpp
             tools/imp-server/utils.cpp
             tools/imp-server/tool_call.cpp
+            tools/imp-server/args.cpp
             tests/test_anthropic_transform.cpp
             tests/test_responses_transform.cpp
             tests/test_sse_stream_utils.cpp
             tests/test_tool_call.cpp
             tests/test_tool_stream_filter.cpp
-            tests/test_server_auth.cpp)
+            tests/test_server_auth.cpp
+            tests/test_server_args.cpp)
         target_include_directories(test-core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools/imp-server)
         target_link_libraries(test-core PRIVATE nlohmann_json::nlohmann_json httplib::httplib)
     endif()

--- a/tests/test_server_args.cpp
+++ b/tests/test_server_args.cpp
@@ -1,0 +1,74 @@
+// =============================================================================
+// Unit tests for imp-server CLI flag parsing (parse_server_args) — closes the
+// "--vram-budget flag parse and the server-limit flags are untested" gap from
+// issue #896. The planner logic behind --vram-budget is well covered elsewhere
+// (test_vram_budget_reserve / test_weight_registry_preservation); this asserts
+// the literal CLI parse that feeds it, on the CPU, in CI (the real server main
+// never runs there).
+// =============================================================================
+
+#include <gtest/gtest.h>
+#include "args.h"
+
+#include <string>
+#include <vector>
+
+namespace {
+
+// parse_server_args takes (argc, char** argv). Build a mutable argv from
+// strings (argv[0] is the program name; parsing starts at index 1).
+ServerArgs parse(std::vector<std::string> args) {
+    std::vector<std::string> argv_storage;
+    argv_storage.reserve(args.size() + 1);
+    argv_storage.emplace_back("imp-server");
+    for (auto& a : args)
+        argv_storage.push_back(std::move(a));
+    std::vector<char*> argv;
+    argv.reserve(argv_storage.size());
+    for (auto& s : argv_storage)
+        argv.push_back(s.data());
+    return parse_server_args(static_cast<int>(argv.size()), argv.data());
+}
+
+}  // namespace
+
+TEST(ServerArgs, DefaultsWhenNoFlags) {
+    ServerArgs a = parse({});
+    EXPECT_EQ(a.vram_budget_mb, 0);   // 0 = uncapped
+    EXPECT_EQ(a.max_concurrent, 64);  // guard active out of the box
+    EXPECT_EQ(a.request_timeout, 300);
+    EXPECT_EQ(a.rate_limit, 0);        // 0 = unlimited
+    EXPECT_EQ(a.max_input_tokens, 0);  // 0 = unlimited
+    EXPECT_EQ(a.port, 8080);
+}
+
+TEST(ServerArgs, VramBudgetParsed) {
+    EXPECT_EQ(parse({"--vram-budget", "4096"}).vram_budget_mb, 4096);
+    EXPECT_EQ(parse({"--vram-budget", "0"}).vram_budget_mb, 0);
+}
+
+TEST(ServerArgs, ServerLimitFlagsParsed) {
+    ServerArgs a = parse({"--max-concurrent", "8", "--request-timeout", "120", "--rate-limit", "30",
+                          "--max-input-tokens", "2000"});
+    EXPECT_EQ(a.max_concurrent, 8);
+    EXPECT_EQ(a.request_timeout, 120);
+    EXPECT_EQ(a.rate_limit, 30);
+    EXPECT_EQ(a.max_input_tokens, 2000);
+}
+
+TEST(ServerArgs, ZeroDisablesLimits) {
+    // 0 is the documented "unlimited/uncapped" sentinel for every limit flag.
+    ServerArgs a = parse({"--max-concurrent", "0", "--rate-limit", "0", "--request-timeout", "0"});
+    EXPECT_EQ(a.max_concurrent, 0);
+    EXPECT_EQ(a.rate_limit, 0);
+    EXPECT_EQ(a.request_timeout, 0);
+}
+
+TEST(ServerArgs, UnrelatedFlagsLeaveLimitsAtDefault) {
+    // A --vram-budget request must not perturb the other limits.
+    ServerArgs a = parse({"--vram-budget", "8192", "--port", "9099"});
+    EXPECT_EQ(a.vram_budget_mb, 8192);
+    EXPECT_EQ(a.port, 9099);
+    EXPECT_EQ(a.max_concurrent, 64);
+    EXPECT_EQ(a.max_input_tokens, 0);
+}


### PR DESCRIPTION
## Summary

Partially addresses **#896**: the `--vram-budget` flag parse plus the `--max-concurrent` / `--request-timeout` / `--rate-limit` / `--max-input-tokens` server-limit flags had **zero test coverage**. The planner logic behind `--vram-budget` is covered (`test_vram_budget_reserve` / `test_weight_registry_preservation`), but not the literal CLI parse that feeds it.

- Adds `tests/test_server_args.cpp` — a CPU-only unit test of `parse_server_args` (defaults, `--vram-budget`, the four server-limit flags, the `0 = unlimited` sentinels, and non-interference between flags), following the same extract-and-test-on-CPU pattern as `test_server_auth.cpp`.
- Links `tools/imp-server/args.cpp` into the `test-core` module — `args.cpp` has no CUDA / httplib / json dependencies, so it stays in the CPU test target.

Runs in `make test-unit` (no GPU).

## Scope note

This does **not** close #896 — the remaining items (MTP verify-economics guard, spec graph-capture path, `/health` 503-on-faulted, nomic-bert `/v1/embeddings`, `/v1/responses` HTTP e2e) require the RTX 5090 or a running server and are left for a GPU-side follow-up.

## Test plan

- [ ] `make verify-fast` (or `make test-unit`) green — could not run locally (no Docker/CUDA toolkit in this environment); relying on CI Build + the `test-core` module.
- [ ] For perf changes: n/a
- [ ] For new model architectures: n/a
- [ ] For C-API changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAGnJ2rje1sC3YD9U9AQXN)_