### PR TITLE
test: base64 codec + Anthropic tool_choice/parallel_tool_calls coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,7 +533,8 @@ if(IMP_BUILD_TESTS)
             tests/test_tool_call.cpp
             tests/test_tool_stream_filter.cpp
             tests/test_server_auth.cpp
-            tests/test_server_args.cpp)
+            tests/test_server_args.cpp
+            tests/test_base64.cpp)
         target_include_directories(test-core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools/imp-server)
         target_link_libraries(test-core PRIVATE nlohmann_json::nlohmann_json httplib::httplib)
     endif()

--- a/tests/test_anthropic_transform.cpp
+++ b/tests/test_anthropic_transform.cpp
@@ -177,4 +177,59 @@ TEST(AnthropicThinking, UnknownTypeOrMalformedIsIgnored) {
     EXPECT_FALSE(anthropic_to_openai_body(req2).contains("enable_thinking"));
 }
 
+// ---- tool_choice conversion + parallel_tool_calls (issue #892) -------------
+
+TEST(AnthropicToolChoice, AbsentLeavesToolChoiceUnset) {
+    json oai = anthropic_to_openai_body(base_request());
+    EXPECT_FALSE(oai.contains("tool_choice"));
+    EXPECT_FALSE(oai.contains("parallel_tool_calls"));
+}
+
+TEST(AnthropicToolChoice, AutoNoneAnyMap) {
+    json req = base_request();
+    req["tool_choice"] = json{{"type", "auto"}};
+    EXPECT_EQ(anthropic_to_openai_body(req)["tool_choice"], "auto");
+
+    req["tool_choice"] = json{{"type", "none"}};
+    EXPECT_EQ(anthropic_to_openai_body(req)["tool_choice"], "none");
+
+    // Anthropic "any" (must call some tool) → OpenAI "required".
+    req["tool_choice"] = json{{"type", "any"}};
+    EXPECT_EQ(anthropic_to_openai_body(req)["tool_choice"], "required");
+}
+
+TEST(AnthropicToolChoice, NamedToolMapsToFunction) {
+    json req = base_request();
+    req["tool_choice"] = json{{"type", "tool"}, {"name", "get_weather"}};
+    json tc = anthropic_to_openai_body(req)["tool_choice"];
+    EXPECT_EQ(tc.value("type", ""), "function");
+    EXPECT_EQ(tc["function"].value("name", ""), "get_weather");
+}
+
+TEST(AnthropicToolChoice, StringPassthrough) {
+    // A client that already supplied the OpenAI string form is kept as-is.
+    json req = base_request();
+    req["tool_choice"] = "required";
+    EXPECT_EQ(anthropic_to_openai_body(req)["tool_choice"], "required");
+}
+
+TEST(AnthropicToolChoice, DisableParallelToolUseSetsFlag) {
+    json req = base_request();
+    req["tool_choice"] = json{{"type", "auto"}, {"disable_parallel_tool_use", true}};
+    json oai = anthropic_to_openai_body(req);
+    EXPECT_EQ(oai["tool_choice"], "auto");
+    EXPECT_FALSE(oai.value("parallel_tool_calls", true));  // mapped to false
+}
+
+TEST(AnthropicToolChoice, ParallelDefaultLeavesFlagUnset) {
+    // Without disable_parallel_tool_use the flag must not be forced (default is
+    // parallel-allowed on the OpenAI side).
+    json req = base_request();
+    req["tool_choice"] = json{{"type", "auto"}};
+    EXPECT_FALSE(anthropic_to_openai_body(req).contains("parallel_tool_calls"));
+
+    req["tool_choice"] = json{{"type", "auto"}, {"disable_parallel_tool_use", false}};
+    EXPECT_FALSE(anthropic_to_openai_body(req).contains("parallel_tool_calls"));
+}
+
 }  // namespace

--- a/tests/test_base64.cpp
+++ b/tests/test_base64.cpp
@@ -1,0 +1,80 @@
+// CPU unit tests for the base64 codec in tools/imp-server/utils.cpp.
+// base64_encode was added for the OpenAI `encoding_format: "base64"` embeddings
+// response (the little-endian float32 array encoded as bytes) and had no
+// coverage; base64_decode backs the image-data path. These assert the RFC 4648
+// vectors, padding at every residue, and a bytes round-trip.
+
+#include "utils.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string enc(const std::string& s) {
+    return base64_encode(reinterpret_cast<const uint8_t*>(s.data()), s.size());
+}
+
+std::string dec(const std::string& s) {
+    auto v = base64_decode(s);
+    return std::string(v.begin(), v.end());
+}
+
+}  // namespace
+
+TEST(Base64, Rfc4648Vectors) {
+    // The canonical test vectors from RFC 4648 §10.
+    EXPECT_EQ(enc(""), "");
+    EXPECT_EQ(enc("f"), "Zg==");
+    EXPECT_EQ(enc("fo"), "Zm8=");
+    EXPECT_EQ(enc("foo"), "Zm9v");
+    EXPECT_EQ(enc("foob"), "Zm9vYg==");
+    EXPECT_EQ(enc("fooba"), "Zm9vYmE=");
+    EXPECT_EQ(enc("foobar"), "Zm9vYmFy");
+}
+
+TEST(Base64, PaddingAtEveryResidue) {
+    // len % 3 == 1 → two '=', == 2 → one '=', == 0 → none.
+    EXPECT_EQ(enc("f").size() % 4, 0u);
+    EXPECT_EQ(enc("f").substr(2), "==");
+    EXPECT_EQ(enc("fo").substr(3), "=");
+    EXPECT_EQ(enc("foo").find('='), std::string::npos);
+}
+
+TEST(Base64, DecodeInvertsEncode) {
+    for (const std::string& s : {std::string(""), std::string("a"), std::string("ab"),
+                                 std::string("abc"), std::string("hello, world"),
+                                 std::string("\x00\x01\x02\xff\xfe", 5)}) {
+        EXPECT_EQ(dec(enc(s)), s) << "round-trip failed for len " << s.size();
+    }
+}
+
+TEST(Base64, EncodesRawFloatBytes) {
+    // The embeddings path encodes the little-endian float32 array as bytes;
+    // decoding must reproduce the exact float payload.
+    std::vector<float> v = {0.0f, 1.0f, -2.5f, 3.14159f};
+    std::string b64 = base64_encode(reinterpret_cast<const uint8_t*>(v.data()), v.size() * sizeof(float));
+    auto bytes = base64_decode(b64);
+    ASSERT_EQ(bytes.size(), v.size() * sizeof(float));
+    std::vector<float> back(v.size());
+    std::memcpy(back.data(), bytes.data(), bytes.size());
+    for (size_t i = 0; i < v.size(); ++i)
+        EXPECT_FLOAT_EQ(back[i], v[i]);
+}
+
+TEST(Base64, HandlesAllByteValues) {
+    std::vector<uint8_t> all(256);
+    for (int i = 0; i < 256; ++i)
+        all[i] = static_cast<uint8_t>(i);
+    std::string b64 = base64_encode(all.data(), all.size());
+    // No stray characters outside the standard alphabet + padding.
+    for (char c : b64)
+        EXPECT_TRUE((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                    c == '+' || c == '/' || c == '=')
+            << "unexpected char in output: " << c;
+    EXPECT_EQ(base64_decode(b64), all);
+}


### PR DESCRIPTION
## Summary

Server-API-layer CPU test coverage (no GPU) — targets pure logic merged recently with no accompanying tests.

- **`tests/test_base64.cpp`** (new) — covers the `base64_encode` codec added in #901 for the OpenAI `encoding_format: "base64"` embeddings response (it had zero tests), plus `base64_decode`: RFC 4648 §10 vectors, padding at every residue class, byte/float round-trips, and a full 0–255 alphabet check.
- **`tests/test_anthropic_transform.cpp`** (extended) — covers `tool_choice` conversion (`auto`/`none`/`any`→`required`, `tool`→`function`, OpenAI-string passthrough) and the `disable_parallel_tool_use` → `parallel_tool_calls=false` mapping added in #892, which had no coverage.

Both run in the `test-core` module (`make test-unit`), linking only the already-present `tools/imp-server/utils.cpp` / `anthropic.cpp` — no new deps.

## Test plan

- [ ] `make test-unit` green — could not run locally (no Docker/CUDA toolkit in this environment); relying on CI Build + `test-core`.
- [ ] For perf changes: n/a
- [ ] For new model architectures: n/a
- [ ] For C-API changes: n/a

Part of an ongoing server-API-layer coverage push (follow-up to #901/#902).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAGnJ2rje1sC3YD9U9AQXN)_