### PR TITLE
fix(build): add missing <algorithm> includes for GCC 15

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -26,6 +26,7 @@
 #include "runtime/config.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <algorithm>
 #include <functional>
 #include <vector>
 #include <unordered_map>

--- a/tests/test_activation.cu
+++ b/tests/test_activation.cu
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cmath>
 #include <limits>
+#include <algorithm>
 
 namespace imp {
 namespace {

--- a/tests/test_chat_template.cpp
+++ b/tests/test_chat_template.cpp
@@ -2,6 +2,7 @@
 #include "model/hf_config_loader.h"
 #include "model/model_arch.h"
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 

--- a/tests/test_forward_pass.cu
+++ b/tests/test_forward_pass.cu
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <cmath>
+#include <algorithm>
 
 namespace imp {
 namespace {

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -12,6 +12,7 @@
 #include "model/hf_hub.h"
 #include "runtime/config.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdio>

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -18,6 +18,7 @@
 #include "model/hf_hub.h"
 #include "runtime/config.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdio>


### PR DESCRIPTION
Fixes #903 — build failure on GCC 15.2 / CUDA 13.3 hosts.

## Why

libstdc++ 15 no longer provides `<algorithm>` transitively through other standard headers. Six TUs used `std::find` / `std::count` / `std::search` / `std::max_element` / `std::sort` / `std::fill` / `std::remove` (iterator overload) without including it; the Docker toolchain's older libstdc++ pulled it in transitively, so this was never caught.

## What

Adds `#include <algorithm>` to:

- `tests/test_activation.cu`, `tests/test_chat_template.cpp`, `tests/test_forward_pass.cu` (the three files from the report's log)
- `src/exec/executor.h` (`std::fill`), `tools/imp-server/handlers.cpp` (`std::sort`), `tools/imp-server/handlers_chat_core.cpp` (iterator `std::remove`) — found by a repo-wide sweep for algorithm uses without the include

The sweep's four other hits (`std::remove(path.c_str())` in tests) are the `<cstdio>` file-removal overload and those files already include `<cstdio>`.

Include-only change, no functional impact. Docker build + `make verify-fast` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXm3AoXmxQ1gkesrp8EsT