### PR TITLE
chore(build): move build toolchain to Ubuntu 26.04 / GCC 15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     container:
       # Native CUDA devel image: nvcc $CUDA_VERSION is on PATH at /usr/local/cuda
       # out of the box (matches the Dockerfile builder). No apt toolkit install.
-      image: nvidia/cuda:13.3.0-devel-ubuntu24.04
+      # Ubuntu 26.04 → GCC 15.2, so CI compiles on the same libstdc++ 15 as the
+      # release image and catches missing-include regressions (#903) here.
+      image: nvidia/cuda:13.3.0-devel-ubuntu26.04
 
     env:
       # CUDA toolchain version — used by the verify step and cache keys. Kept in
@@ -194,7 +196,7 @@ jobs:
     if: needs.build.outputs.code == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: nvidia/cuda:13.3.0-devel-ubuntu24.04
+      image: nvidia/cuda:13.3.0-devel-ubuntu26.04
     env:
       CUDA_VERSION: "13.3"
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@
 # install needed. The host driver (UMD 13.3) supports it. sm_120 gains the 13.3
 # ptxas/PTX-ISA-9.3 codegen; no new tensor-core HW (still mma.sync, no
 # tcgen05/wgmma).
-FROM nvidia/cuda:13.3.0-devel-ubuntu24.04 AS builder
+# Ubuntu 26.04 LTS host userland → GCC 15.2 / libstdc++ 15. GCC 15 no longer
+# pulls <algorithm>/<numeric> in transitively through other headers, so it
+# catches the missing-include class of bugs at build time (see #903) that the
+# older GCC 13 toolchain silently accepted.
+FROM nvidia/cuda:13.3.0-devel-ubuntu26.04 AS builder
 
 ARG CMAKE_BUILD_TYPE=Release
 
@@ -79,7 +83,7 @@ RUN cmake -B build -G Ninja \
 # Native CUDA 13.3 runtime image already ships the matching cudart + cuBLAS
 # (and transitive deps like libnvjitlink) at /usr/local/cuda; only the small
 # entrypoint/healthcheck helpers need adding.
-FROM nvidia/cuda:13.3.0-runtime-ubuntu24.04
+FROM nvidia/cuda:13.3.0-runtime-ubuntu26.04
 
 # OCI image metadata — GHCR renders org.opencontainers.image.description on the
 # package page (https://github.com/kekzl/imp/pkgs/container/imp). Hardcoded here


### PR DESCRIPTION
Moves the build toolchain from Ubuntu 24.04 / GCC 13.3 to **Ubuntu 26.04 LTS / GCC 15.2** (libstdc++ 15), CUDA stays pinned at 13.3.

## What

- `Dockerfile`: builder + runtime base `nvidia/cuda:13.3.0-{devel,runtime}-ubuntu24.04` → `-ubuntu26.04`.
- `.github/workflows/ci.yml`: both CUDA compile containers (the `Build` job and `clang-tidy`) → `-ubuntu26.04`, so CI compiles on the same libstdc++ 15 as the release image.

## Why

libstdc++ 15 no longer provides `<algorithm>` / `<numeric>` transitively through other standard headers. That's exactly what surfaced #903 — a build break that only appeared on an external GCC 15 host because our GCC 13 toolchain pulled the headers in silently. Compiling CI on GCC 15 makes that whole class of missing-include regressions fail **in CI** instead of reaching users. (The #903 include fixes already landed in #906; this closes the loop by making CI able to catch the next one.)

## Verification (local, on the new base)

- Clean build under GCC 15.2 (`g++ 15.2.0`, `Ubuntu 26.04 LTS` confirmed in the built image).
- CPU unit tests: **37/37**.
- Full GPU suite (`imp-tests`): all assertions green. The one `EncoderEmbedTest.NomicBertEmbedsMatchReferenceStructure` failure in the aggregate run is a pre-existing VRAM test-ordering artifact (`free=49 MiB` after a preceding 15 GiB MoE test) — it passes in isolation (918 ms) and in direct adjacency with `MtpForwardTest`; unrelated to the toolchain.

## Out of scope

- `tools/analysis/ptx_*.sh` stay pinned to `cuda:13.2.1-devel-ubuntu24.04` on purpose (reproducible PTX-ISA survey at a fixed toolkit, not the imp build).
- `runs-on: ubuntu-24.04` host-runner labels are unchanged — the compile happens inside the CUDA container; GitHub-hosted `ubuntu-26.04` runners are a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXm3AoXmxQ1gkesrp8EsT