### PR TITLE
chore(analysis): PTX survey scripts always target the latest CUDA toolkit

### DIFF
--- a/tools/analysis/latest_cuda_img.sh
+++ b/tools/analysis/latest_cuda_img.sh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+# Resolve the newest nvidia/cuda *devel* image tag (X.Y.Z-devel-ubuntuNN.NN).
+# Sourced by the ptx_*_survey.sh scripts so a survey always runs against the
+# current CUDA toolkit — "re-run after a CUDA upgrade" needs no code edit.
+#
+# Honours an explicit $CUDA_IMG (or a script's --image flag). Falls back to a
+# pinned recent tag when curl/jq are missing or the registry query fails
+# (offline), so surveys still run without a network round-trip.
+latest_cuda_devel_img() {
+    local fallback="nvidia/cuda:13.3.0-devel-ubuntu26.04"
+    command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1 || { echo "$fallback"; return; }
+    local tag
+    tag=$(curl -fsS --max-time 8 \
+        "https://registry.hub.docker.com/v2/repositories/nvidia/cuda/tags?page_size=100&name=devel-ubuntu" 2>/dev/null \
+        | jq -r '.results[].name
+                 | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+-devel-ubuntu[0-9]+\\.[0-9]+$"))' 2>/dev/null \
+        | sort -Vr | head -1)
+    [ -n "$tag" ] && echo "nvidia/cuda:$tag" || echo "$fallback"
+}

--- a/tools/analysis/ptx_async_survey.sh
+++ b/tools/analysis/ptx_async_survey.sh
@@ -3,7 +3,9 @@
 # Covers: cp.async (legacy), cp.async.bulk (TMA), mbarrier, st.async, fence.proxy.
 
 set -e
-CUDA_IMG=${CUDA_IMG:-nvidia/cuda:13.2.1-devel-ubuntu24.04}
+# shellcheck source=tools/analysis/latest_cuda_img.sh
+source "$(dirname "${BASH_SOURCE[0]}")/latest_cuda_img.sh"
+CUDA_IMG=${CUDA_IMG:-$(latest_cuda_devel_img)}
 ARCH=${ARCH:-compute_120f,code=sm_120}
 WORK=$(mktemp -d)
 trap "rm -rf $WORK" EXIT

--- a/tools/analysis/ptx_atomic_survey.sh
+++ b/tools/analysis/ptx_atomic_survey.sh
@@ -3,7 +3,9 @@
 # Covers: atom.global.* on FP/INT/vector types, red.global.*, redux.sync.*
 
 set -e
-CUDA_IMG=${CUDA_IMG:-nvidia/cuda:13.2.1-devel-ubuntu24.04}
+# shellcheck source=tools/analysis/latest_cuda_img.sh
+source "$(dirname "${BASH_SOURCE[0]}")/latest_cuda_img.sh"
+CUDA_IMG=${CUDA_IMG:-$(latest_cuda_devel_img)}
 ARCH=${ARCH:-compute_120f,code=sm_120}
 WORK=$(mktemp -d)
 trap "rm -rf $WORK" EXIT

--- a/tools/analysis/ptx_cluster_survey.sh
+++ b/tools/analysis/ptx_cluster_survey.sh
@@ -4,7 +4,9 @@
 # available on consumer Blackwell sm_120f.
 
 set -e
-CUDA_IMG=${CUDA_IMG:-nvidia/cuda:13.2.1-devel-ubuntu24.04}
+# shellcheck source=tools/analysis/latest_cuda_img.sh
+source "$(dirname "${BASH_SOURCE[0]}")/latest_cuda_img.sh"
+CUDA_IMG=${CUDA_IMG:-$(latest_cuda_devel_img)}
 ARCH=${ARCH:-compute_120f,code=sm_120}
 WORK=$(mktemp -d)
 trap "rm -rf $WORK" EXIT

--- a/tools/analysis/ptx_cvt_survey.sh
+++ b/tools/analysis/ptx_cvt_survey.sh
@@ -20,7 +20,9 @@
 
 set -u
 
-CUDA_IMG=${CUDA_IMG:-nvidia/cuda:13.2.1-devel-ubuntu24.04}
+# shellcheck source=tools/analysis/latest_cuda_img.sh
+source "$(dirname "${BASH_SOURCE[0]}")/latest_cuda_img.sh"
+CUDA_IMG=${CUDA_IMG:-$(latest_cuda_devel_img)}
 ARCH=${ARCH:-compute_120f,code=sm_120}
 QUICK=0
 

--- a/tools/analysis/ptx_mma_survey.sh
+++ b/tools/analysis/ptx_mma_survey.sh
@@ -3,7 +3,9 @@
 # Compiles ONE variant at a time so a single ptxas error never poisons others.
 
 set -e
-CUDA_IMG=${CUDA_IMG:-nvidia/cuda:13.2.1-devel-ubuntu24.04}
+# shellcheck source=tools/analysis/latest_cuda_img.sh
+source "$(dirname "${BASH_SOURCE[0]}")/latest_cuda_img.sh"
+CUDA_IMG=${CUDA_IMG:-$(latest_cuda_devel_img)}
 ARCH=${ARCH:-compute_120f,code=sm_120}
 
 WORK=$(mktemp -d)

--- a/tools/analysis/ptx_special_survey.sh
+++ b/tools/analysis/ptx_special_survey.sh
@@ -4,7 +4,9 @@
 # packed FP16 arithmetic (add/mul/fma f16x2/bf16x2), and special activations.
 
 set -e
-CUDA_IMG=${CUDA_IMG:-nvidia/cuda:13.2.1-devel-ubuntu24.04}
+# shellcheck source=tools/analysis/latest_cuda_img.sh
+source "$(dirname "${BASH_SOURCE[0]}")/latest_cuda_img.sh"
+CUDA_IMG=${CUDA_IMG:-$(latest_cuda_devel_img)}
 ARCH=${ARCH:-compute_120f,code=sm_120}
 WORK=$(mktemp -d)
 trap "rm -rf $WORK" EXIT

--- a/tools/analysis/ptx_survey_all.sh
+++ b/tools/analysis/ptx_survey_all.sh
@@ -12,6 +12,9 @@
 set -e
 
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=tools/analysis/latest_cuda_img.sh
+source "$DIR/latest_cuda_img.sh"
+CUDA_IMG=${CUDA_IMG:-$(latest_cuda_devel_img)}
 SURVEYS=(
     ptx_cvt_survey.sh
     ptx_mma_survey.sh
@@ -24,7 +27,7 @@ SURVEYS=(
 echo "# PTX feature acceptance survey for sm_120f"
 echo ""
 echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-echo "Toolkit:   $(docker run --rm nvidia/cuda:13.2.1-devel-ubuntu24.04 nvcc --version 2>/dev/null | grep -oE 'V[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+echo "Toolkit:   $(docker run --rm "$CUDA_IMG" nvcc --version 2>/dev/null | grep -oE 'V[0-9]+\.[0-9]+\.[0-9]+' | head -1) ($CUDA_IMG)"
 echo "Arch:      compute_120f / sm_120 (RTX 5090 GB202)"
 echo ""
 echo "Each section is a separate ptxas-acceptance test for one PTX instruction"


### PR DESCRIPTION
Per request: the `tools/analysis/ptx_*_survey.sh` scripts should always survey the **latest** CUDA toolkit, not a fixed pin.

## Problem

Every survey hardcoded `nvidia/cuda:13.2.1-devel-ubuntu24.04` — a now-stale toolkit. Since the entire point of these scripts is to re-check ptxas acceptance of FP4/MMA/async/cluster PTX after a CUDA upgrade, a stale pin defeats them.

## Change

- New `tools/analysis/latest_cuda_img.sh`: `latest_cuda_devel_img()` resolves the newest `nvidia/cuda:X.Y.Z-devel-ubuntuNN.NN` tag from the Docker Hub registry API (currently → `13.3.0-devel-ubuntu26.04`), version-sorted. Honours an explicit `$CUDA_IMG` env var (and the `--image` flag where a script has one); falls back to a pinned recent tag when `curl`/`jq` are missing or the query fails (offline).
- All 6 surveys + the `ptx_survey_all.sh` orchestrator (incl. its `Toolkit:` banner) now source the helper instead of hardcoding a tag.

## Verified

- `bash -n` on all 8 scripts.
- Resolver online → `nvidia/cuda:13.3.0-devel-ubuntu26.04`; offline fallback path exercised.
- End-to-end smoke: `ptx_cvt_survey.sh --quick` pulls the resolved image and produces the expected FP4 `cvt` acceptance table (header shows the resolved image).

Analysis tooling only — no build/runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXm3AoXmxQ1gkesrp8EsT