### PR TITLE
test(quant): remove Q5_K all-NaN self-skip — cuBLAS pollution no longer reproduces

### DIFF
--- a/tests/test_quant_integration.cu
+++ b/tests/test_quant_integration.cu
@@ -1695,17 +1695,6 @@ TEST(QuantIntegrationTest, Q5_KForwardPass) {
     std::vector<float> h_logits(32);
     cudaMemcpy(h_logits.data(), logits.data, 32 * sizeof(float), cudaMemcpyDeviceToHost);
 
-    int nan_count = 0;
-    for (int i = 0; i < 32; ++i) {
-        if (std::isnan(h_logits[i]))
-            nan_count++;
-    }
-    if (nan_count == 32) {
-        // Known issue: Q4_KMultiLayer's 4-layer forward pass leaves stale
-        // cuBLAS global state that makes a subsequent Q5_K executor produce
-        // all-NaN. Passes in isolation; fails only as part of the full suite.
-        GTEST_SKIP() << "Q5_K all-NaN: stale cuBLAS state from Q4_KMultiLayer (known test-ordering issue)";
-    }
     for (int i = 0; i < 32; ++i) {
         EXPECT_FALSE(std::isnan(h_logits[i])) << "Q5_K logit NaN at " << i;
         EXPECT_FALSE(std::isinf(h_logits[i])) << "Q5_K logit Inf at " << i;


### PR DESCRIPTION
Fixes #895.

## Background

`QuantIntegrationTest.Q5_KForwardPass` conditionally skipped itself when its forward produced 32 NaN logits, blaming stale cuBLAS global state left by a prior `Q4_KMultiLayer` forward (skip added 2026-05-27 in #445). Per #895 this is bad on two counts: it masked a supposed product-code bug, and any genuine future Q5_K all-NaN regression would be silently reclassified as "known ordering issue" while CI stayed green.

## Investigation

The underlying NaN **no longer reproduces on current main**. Confirmed the all-NaN does not occur in any ordering, with the real no-NaN/no-Inf assertion active:

- `Q5_KForwardPass` in isolation ✅
- directly after `Q4_KMultiLayer` (the accused predecessor) ✅
- the full `QuantIntegrationTest` suite (22/22) ✅
- the full aggregate `imp-tests` binary — the exact "fails only as part of the full suite" scenario from the report — ✅ (`Q5_KForwardPass` OK, 134 ms)

Root cause of the resolution: the global cuBLAS handle + shared cuBLASLt workspace in `src/compute/gemm.cu` are process-persistent and idempotent by design — that is the same shared state two sequential executors legitimately use in production (model swap), so it was never a real product risk in the way the skip's comment implied. The executor / VRAM-cache / GEMM rewrites merged since #445 evidently fixed whatever produced the original corruption. It is not reproducible to root-cause further, and the conditional skip had degenerated into a pure latent regression-mask.

## Change

Remove the conditional `GTEST_SKIP()` so the no-NaN/no-Inf assertion runs unconditionally — a future all-NaN regression now fails loudly instead of skipping.

## Verification note

The full aggregate `imp-tests` run is green **except** for one unrelated, pre-existing failure: `EncoderEmbedTest.NomicBertEmbedsMatchReferenceStructure` OOMs on token-embedding upload (`free=49 MiB`) because the preceding ~15 GiB MoE `MtpForwardTest` leaves ~14 GiB reserved in the async mempool. It passes in isolation and in adjacency — a separate test-isolation/mempool-trim issue, not touched here (worth its own issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXm3AoXmxQ1gkesrp8EsT