### PR TITLE
fix(mtp): apply YaRN/rope-scaling in the draft-head mrope kernel

### DIFF
--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -20,6 +20,7 @@
 #include "compute/layernorm.h"
 #include "compute/moe_routing.h"
 #include "compute/rope.h"           // qknorm_rope_fused
+#include "compute/rope_yarn.cuh"    // rope_yarn (shared YaRN device math)
 #include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -355,7 +356,11 @@ __global__ void mtp_mrope_kernel(
     __half* __restrict__ x,           // Q: [n_heads, head_dim], K: [n_kv_heads, head_dim]
     int n_heads, int head_dim, int rope_dim, float theta,
     int sec0, int sec1, int sec2,    // mrope_section half-counts (sec0+sec1+sec2 == rope_dim/2)
-    int pos_t, int pos_h, int pos_w) {
+    int pos_t, int pos_h, int pos_w,
+    // RoPE scaling — mirrors rope.cu's rope_forward_kernel so the draft head
+    // rotates identically to the verifier (issue #897). inv_scaling = 1/freq_scale;
+    // ext_factor > 0 engages YaRN blending (corr_dim_0/1, attn_factor=mscale).
+    float inv_scaling, float ext_factor, float attn_factor, float corr_dim_0, float corr_dim_1) {
     int h = blockIdx.x;
     if (h >= n_heads) return;
     __half* row = x + static_cast<int64_t>(h) * head_dim;
@@ -368,11 +373,20 @@ __global__ void mtp_mrope_kernel(
         if      (k < s01) pos = pos_t;
         else if (k < s12) pos = pos_h;
         else              pos = pos_w;
-        // Frequency: theta^(-2k/rope_dim)
-        float inv_freq = expf(-static_cast<float>(2 * k) / static_cast<float>(rope_dim) * logf(theta));
-        float angle = static_cast<float>(pos) * inv_freq;
-        float c = __cosf(angle);
-        float s = __sinf(angle);
+        // cos/sin with the same YaRN / linear-scaling math as the main forward.
+        float c, s;
+        if (ext_factor != 0.0f) {
+            // YaRN mode: per-dimension frequency blending.
+            float theta_extrap =
+                static_cast<float>(pos) / powf(theta, static_cast<float>(2 * k) / static_cast<float>(rope_dim));
+            rope_yarn(theta_extrap, inv_scaling, corr_dim_0, corr_dim_1, 2 * k, ext_factor, attn_factor, c, s);
+        } else {
+            // Linear mode: frequency = theta^(-2k/rope_dim), scaled by inv_scaling.
+            float freq = inv_scaling / powf(theta, static_cast<float>(2 * k) / static_cast<float>(rope_dim));
+            float angle = static_cast<float>(pos) * freq;
+            c = __cosf(angle);
+            s = __sinf(angle);
+        }
         // NeoX-style pair: (x[k], x[k + rope_dim/2])
         int i0 = k;
         int i1 = k + pairs;
@@ -384,6 +398,28 @@ __global__ void mtp_mrope_kernel(
     // (void) IsKv — currently unused but reserved for any future per-head
     // GQA/MQA divergences. Both Q and K paths share the same rotation math.
     if (false) (void)IsKv;
+}
+
+// Host wrapper: apply the YaRN-aware mrope rotation to a single MTP step's
+// Q [n_heads, head_dim] and K [n_kv_heads, head_dim] in place. Text-only, so
+// the three mrope position components collapse to `pos`. Shared by the draft
+// step and the rope-parity unit test (issue #897).
+void mtp_apply_mrope(void* d_q, int n_heads, void* d_k, int n_kv_heads, int head_dim, int rope_dim,
+                     float theta, int sec0, int sec1, int sec2, int pos, float inv_scaling,
+                     float ext_factor, float attn_factor, float corr_dim_0, float corr_dim_1,
+                     cudaStream_t stream) {
+    if (rope_dim <= 0 || sec0 + sec1 + sec2 != rope_dim / 2) return;
+    const int kBlock = 128;
+    if (n_heads > 0 && d_q) {
+        mtp_mrope_kernel<false><<<n_heads, kBlock, 0, stream>>>(
+            static_cast<__half*>(d_q), n_heads, head_dim, rope_dim, theta, sec0, sec1, sec2,
+            pos, pos, pos, inv_scaling, ext_factor, attn_factor, corr_dim_0, corr_dim_1);
+    }
+    if (n_kv_heads > 0 && d_k) {
+        mtp_mrope_kernel<true><<<n_kv_heads, kBlock, 0, stream>>>(
+            static_cast<__half*>(d_k), n_kv_heads, head_dim, rope_dim, theta, sec0, sec1, sec2,
+            pos, pos, pos, inv_scaling, ext_factor, attn_factor, corr_dim_0, corr_dim_1);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -716,22 +752,13 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
             // is structured to support distinct T/H/W positions for future
             // multimodal token handling. NeoX-style pairing only.
             if (ws.rope_dim > 0 && ws.mrope_sec0 + ws.mrope_sec1 + ws.mrope_sec2 == ws.rope_dim / 2) {
-                const int pos_t = ws.mtp_pos;  // text-only: T=H=W=mtp_pos
-                const int pos_h = ws.mtp_pos;
-                const int pos_w = ws.mtp_pos;
-                const int kBlock = 128;
-                // Q rotation: nh CTAs, each handles head_dim/2 pairs
-                mtp_mrope_kernel<false><<<nh, kBlock, 0, stream>>>(
-                    static_cast<__half*>(ws.d_q_attn),
-                    nh, hdh, ws.rope_dim, ws.rope_theta,
-                    ws.mrope_sec0, ws.mrope_sec1, ws.mrope_sec2,
-                    pos_t, pos_h, pos_w);
-                // K rotation: nkv CTAs
-                mtp_mrope_kernel<true><<<nkv, kBlock, 0, stream>>>(
-                    static_cast<__half*>(ws.d_k_proj),
-                    nkv, hdh, ws.rope_dim, ws.rope_theta,
-                    ws.mrope_sec0, ws.mrope_sec1, ws.mrope_sec2,
-                    pos_t, pos_h, pos_w);
+                // RoPE-scaling params mirrored from the main forward (issue #897):
+                // inv_scaling = 1/freq_scale; ext_factor>0 → YaRN. Defaults leave
+                // the base (unscaled) rope unchanged. Text-only → single position.
+                mtp_apply_mrope(ws.d_q_attn, nh, ws.d_k_proj, nkv, hdh, ws.rope_dim, ws.rope_theta,
+                                ws.mrope_sec0, ws.mrope_sec1, ws.mrope_sec2, ws.mtp_pos,
+                                1.0f / ws.rope_freq_scale, ws.yarn_ext_factor, ws.yarn_attn_factor,
+                                ws.yarn_corr_dim_0, ws.yarn_corr_dim_1, stream);
             }
             const int pos = ws.mtp_pos;
             // 5.A.4.a — append k_step, v_step into cache at pos

--- a/src/compute/mtp_forward.h
+++ b/src/compute/mtp_forward.h
@@ -143,6 +143,17 @@ struct MtpDraftWorkspace {
     int   mrope_sec0      = 0;
     int   mrope_sec1      = 0;
     int   mrope_sec2      = 0;
+    // RoPE scaling — must mirror the main forward's rope path or the drafter
+    // rotates Q/K differently from the verifier at extended positions, silently
+    // degrading acceptance with position (issue #897). rope_freq_scale is the
+    // linear scaling (main uses inv_scaling = 1/freq_scale); yarn_ext_factor > 0
+    // engages YaRN blending with yarn_corr_dim_0/1 (from rope_yarn_corr_dims())
+    // and yarn_attn_factor (mscale). Defaults = no scaling (Qwen3.6 base).
+    float rope_freq_scale = 1.0f;
+    float yarn_ext_factor  = 0.0f;
+    float yarn_attn_factor = 1.0f;
+    float yarn_corr_dim_0  = 0.0f;
+    float yarn_corr_dim_1  = 0.0f;
     float rms_norm_eps    = 1e-6f;
     float arch_norm_offset = 0.0f;  // for q_norm/k_norm (Qwen3.5/3.6 gamma=1+W)
 };
@@ -200,6 +211,17 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     const NvFP4QuantResult* lm_head_nvfp4 = nullptr,
                     const int32_t* d_prev_token = nullptr,
                     int32_t* d_out_token = nullptr);
+
+// Apply the YaRN-aware mrope rotation to a single MTP step's Q [n_heads, head_dim]
+// and K [n_kv_heads, head_dim] (FP16) in place at position `pos`. Mirrors the main
+// forward's rope_forward math so the draft head and the verifier rotate Q/K
+// identically on rope-scaled models (issue #897): inv_scaling = 1/rope_freq_scale,
+// ext_factor > 0 engages YaRN blending via corr_dim_0/1 + attn_factor (mscale).
+// Exposed for the rope-parity unit test. Pass null d_q or d_k to skip that side.
+void mtp_apply_mrope(void* d_q, int n_heads, void* d_k, int n_kv_heads, int head_dim, int rope_dim,
+                     float theta, int sec0, int sec1, int sec2, int pos, float inv_scaling,
+                     float ext_factor, float attn_factor, float corr_dim_0, float corr_dim_1,
+                     cudaStream_t stream);
 
 // Allocate the workspace from the VRAM allocator. Caller is responsible for
 // keeping ws alive (typically owned by the Engine for the lifetime of a session).

--- a/src/compute/rope.cu
+++ b/src/compute/rope.cu
@@ -1,4 +1,5 @@
 #include "compute/rope.h"
+#include "compute/rope_yarn.cuh"
 #include "compute/warp_reduce.cuh"
 #include "runtime/pdl.h"
 #include "core/tensor.h"
@@ -9,34 +10,8 @@
 
 namespace imp {
 
-// --------------------------------------------------------------------------
-// YaRN device helpers
-// --------------------------------------------------------------------------
-
-// Linear ramp: 1.0 when i0/2 <= low, 0.0 when i0/2 >= high, linear blend between
-static __device__ __forceinline__ float rope_yarn_ramp(float low, float high, int i0) {
-    float y = (i0 / 2.0f - low) / fmaxf(0.001f, high - low);
-    return 1.0f - fminf(1.0f, fmaxf(0.0f, y));
-}
-
-// YaRN frequency blending: blends between interpolated (freq_scale * theta_extrap)
-// and extrapolated (theta_extrap) based on the correction dimension ramp.
-// When ext_factor == 0, reduces to pure linear scaling (theta = freq_scale * theta_extrap).
-static __device__ __forceinline__ void rope_yarn(float theta_extrap, float freq_scale, float corr_dim_0,
-                                                 float corr_dim_1, int i0, float ext_factor, float mscale,
-                                                 float& cos_theta, float& sin_theta) {
-    float theta_interp = freq_scale * theta_extrap;
-    float theta = theta_interp;
-
-    if (ext_factor != 0.0f) {
-        float ramp_mix = rope_yarn_ramp(corr_dim_0, corr_dim_1, i0) * ext_factor;
-        theta = theta_interp * (1.0f - ramp_mix) + theta_extrap * ramp_mix;
-        mscale *= 1.0f + 0.1f * logf(1.0f / freq_scale);
-    }
-
-    cos_theta = __cosf(theta) * mscale;
-    sin_theta = __sinf(theta) * mscale;
-}
+// YaRN device helpers (rope_yarn_ramp / rope_yarn) live in compute/rope_yarn.cuh,
+// shared with the MTP draft head so the two rope paths cannot drift (issue #897).
 
 // --------------------------------------------------------------------------
 // RoPE element access traits: abstracts FP32 (direct) vs FP16 (convert)

--- a/src/compute/rope_yarn.cuh
+++ b/src/compute/rope_yarn.cuh
@@ -1,0 +1,36 @@
+#pragma once
+// Shared YaRN RoPE device helpers. Single source of truth for the frequency
+// ramp + blending math used by both the main forward's rope kernel (rope.cu)
+// and the MTP draft head's mrope kernel (mtp_forward.cu). Keeping one copy
+// prevents the two paths from drifting (see issue #897 / the #880 YaRN class).
+
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// Linear ramp: 1.0 when i0/2 <= low, 0.0 when i0/2 >= high, linear blend between.
+static __device__ __forceinline__ float rope_yarn_ramp(float low, float high, int i0) {
+    float y = (i0 / 2.0f - low) / fmaxf(0.001f, high - low);
+    return 1.0f - fminf(1.0f, fmaxf(0.0f, y));
+}
+
+// YaRN frequency blending: blends between interpolated (freq_scale * theta_extrap)
+// and extrapolated (theta_extrap) based on the correction dimension ramp.
+// When ext_factor == 0, reduces to pure linear scaling (theta = freq_scale * theta_extrap).
+static __device__ __forceinline__ void rope_yarn(float theta_extrap, float freq_scale, float corr_dim_0,
+                                                 float corr_dim_1, int i0, float ext_factor, float mscale,
+                                                 float& cos_theta, float& sin_theta) {
+    float theta_interp = freq_scale * theta_extrap;
+    float theta = theta_interp;
+
+    if (ext_factor != 0.0f) {
+        float ramp_mix = rope_yarn_ramp(corr_dim_0, corr_dim_1, i0) * ext_factor;
+        theta = theta_interp * (1.0f - ramp_mix) + theta_extrap * ramp_mix;
+        mscale *= 1.0f + 0.1f * logf(1.0f / freq_scale);
+    }
+
+    cos_theta = __cosf(theta) * mscale;
+    sin_theta = __sinf(theta) * mscale;
+}
+
+}  // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -9,6 +9,7 @@
 #include "runtime/vram_budget.h"
 #include "runtime/batch.h"
 #include "compute/mtp_forward.h"
+#include "compute/rope.h"           // rope_yarn_corr_dims (MTP rope-scaling parity)
 #include "compute/encoder_forward.h"
 #include "memory/kv_cache.h"
 #include "memory/mem_account.h"
@@ -234,6 +235,36 @@ bool Engine::enable_mtp_spec_decode(int k) {
         ws->mrope_sec1 = 0;
         ws->mrope_sec2 = 0;
     }
+    // RoPE scaling — mirror the main forward so the drafter rotates Q/K the
+    // same way as the verifier at extended positions (issue #897). Without
+    // this a rope-scaled model's draft head diverges and acceptance silently
+    // degrades with position.
+    ws->rope_freq_scale  = model_->config_.rope_freq_scale;
+    ws->yarn_ext_factor  = model_->config_.yarn_ext_factor;
+    ws->yarn_attn_factor = model_->config_.yarn_attn_factor;
+    if (model_->config_.yarn_ext_factor > 0.0f) {
+        int hd = model_->config_.head_dim > 0 ? model_->config_.head_dim
+                                              : (model_->config_.d_model / model_->config_.n_heads);
+        int n_dims = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : hd;
+        int n_ctx_orig = model_->config_.rope_n_ctx_orig > 0 ? model_->config_.rope_n_ctx_orig
+                                                             : model_->config_.max_seq_len;
+        float corr[2] = {0.0f, 0.0f};
+        imp::rope_yarn_corr_dims(n_dims, n_ctx_orig, model_->config_.rope_theta,
+                                 model_->config_.yarn_beta_fast, model_->config_.yarn_beta_slow, corr);
+        ws->yarn_corr_dim_0 = corr[0];
+        ws->yarn_corr_dim_1 = corr[1];
+        IMP_LOG_INFO("MTP YaRN: ext=%.2f attn=%.3f freq_scale=%.4f corr_dims=[%.1f, %.1f]",
+                     ws->yarn_ext_factor, ws->yarn_attn_factor, ws->rope_freq_scale,
+                     ws->yarn_corr_dim_0, ws->yarn_corr_dim_1);
+    }
+    // LongRoPE (Phi-family) isn't plumbed into the single-token MTP kernel — no
+    // MTP model ships it today (Qwen uses YaRN/linear). Warn rather than silently
+    // diverge if that ever changes.
+    if (!model_->config_.rope_short_factor.empty() || !model_->config_.rope_long_factor.empty()) {
+        IMP_LOG_WARN("MTP spec-decode: model uses LongRoPE scaling, which the draft head does not apply "
+                     "— draft rope will diverge from the verifier; expect degraded acceptance");
+    }
+
     // Diagnostic: generation.mtp_no_rope disables RoPE entirely.
     if (runtime_config_.generation.mtp_no_rope) {
         ws->rope_dim = 0;

--- a/tests/test_rope.cu
+++ b/tests/test_rope.cu
@@ -3,6 +3,7 @@
 #include <cuda_fp16.h>
 #include "core/tensor.h"
 #include "compute/rope.h"
+#include "compute/mtp_forward.h"
 #include <vector>
 #include <cmath>
 #include <cstdlib>
@@ -511,6 +512,89 @@ TEST(RoPETest, PartialRoPE) {
     cudaFree(q_dev);
     cudaFree(k_dev);
     cudaFree(pos_dev);
+}
+
+// =========================================================================
+// MtpMropeMatchesMainYarn (issue #897)
+//   The MTP draft head must rotate Q/K identically to the main forward on a
+//   rope-scaled (YaRN) model. Runs the shared main rope_forward and the MTP
+//   mtp_apply_mrope with the SAME YaRN params at an extended position and
+//   asserts they agree — the exact drift the old inline plain-RoPE caused.
+// =========================================================================
+TEST(RoPETest, MtpMropeMatchesMainYarn) {
+    const int n_heads = 2, n_kv_heads = 2;
+    const int head_dim = 256, rope_dim = 64;   // Qwen3.x partial rope
+    const float theta = 1000000.0f;
+    const float freq_scale = 4.0f;             // rope-scaled (YaRN)
+    const float ext_factor = 1.0f;             // YaRN on
+    const float attn_factor = 1.0f;
+    const int pos = 6000;                      // extended position (> n_ctx_orig)
+
+    // YaRN correction dims, exactly as the engine/executor compute them.
+    float corr[2] = {0.0f, 0.0f};
+    rope_yarn_corr_dims(rope_dim, /*n_ctx_orig=*/2048, theta, /*beta_fast=*/32.0f, /*beta_slow=*/1.0f, corr);
+
+    // Identical FP16 Q/K for both paths (single token).
+    const int64_t qn = (int64_t)n_heads * head_dim;
+    const int64_t kn = (int64_t)n_kv_heads * head_dim;
+    std::vector<float> qf(qn), kf(kn);
+    fill_linear(qf);
+    fill_linear(kf);
+    std::vector<__half> qh(qn), kh(kn);
+    for (int64_t i = 0; i < qn; i++) qh[i] = __float2half(qf[i]);
+    for (int64_t i = 0; i < kn; i++) kh[i] = __float2half(kf[i]);
+
+    // --- Main forward path (verifier): neox, YaRN ---
+    __half* q_main = to_device(qh.data(), qn);
+    __half* k_main = to_device(kh.data(), kn);
+    int pos_arr = pos;
+    int* pos_dev = to_device(&pos_arr, 1);
+    Tensor Qm = make_device_tensor(q_main, QType::F16, 1, 1, n_heads, head_dim);
+    Tensor Km = make_device_tensor(k_main, QType::F16, 1, 1, n_kv_heads, head_dim);
+    rope_forward(Qm, Km, pos_dev, head_dim, theta, freq_scale, rope_dim, /*neox=*/true, ext_factor,
+                 attn_factor, corr, /*stream=*/nullptr, /*longrope=*/nullptr);
+    CUDA_CHECK(cudaDeviceSynchronize());
+    auto q_main_out = to_host(q_main, qn);
+    auto k_main_out = to_host(k_main, kn);
+
+    // --- MTP draft path: same params, Qwen3.6 mrope section split [11,11,10] ---
+    __half* q_mtp = to_device(qh.data(), qn);
+    __half* k_mtp = to_device(kh.data(), kn);
+    mtp_apply_mrope(q_mtp, n_heads, k_mtp, n_kv_heads, head_dim, rope_dim, theta, /*sec0=*/11,
+                    /*sec1=*/11, /*sec2=*/10, pos, /*inv_scaling=*/1.0f / freq_scale, ext_factor,
+                    attn_factor, corr[0], corr[1], /*stream=*/nullptr);
+    CUDA_CHECK(cudaDeviceSynchronize());
+    auto q_mtp_out = to_host(q_mtp, qn);
+    auto k_mtp_out = to_host(k_mtp, kn);
+
+    // --- Parity: MTP must match the verifier within FP16 tolerance ---
+    const float tol = 3e-3f;
+    for (int64_t i = 0; i < qn; i++) {
+        EXPECT_NEAR(__half2float(q_mtp_out[i]), __half2float(q_main_out[i]), tol)
+            << "Q mismatch at " << i << " (MTP draft rope drifted from verifier)";
+    }
+    for (int64_t i = 0; i < kn; i++) {
+        EXPECT_NEAR(__half2float(k_mtp_out[i]), __half2float(k_main_out[i]), tol)
+            << "K mismatch at " << i;
+    }
+
+    // --- Guard: the YaRN scaling must actually change the result, else the
+    // parity above could pass trivially (both silently ignoring the params).
+    __half* q_plain = to_device(qh.data(), qn);
+    __half* k_plain = to_device(kh.data(), kn);
+    mtp_apply_mrope(q_plain, n_heads, k_plain, n_kv_heads, head_dim, rope_dim, theta, 11, 11, 10, pos,
+                    /*inv_scaling=*/1.0f, /*ext_factor=*/0.0f, /*attn_factor=*/1.0f, 0.0f, 0.0f,
+                    /*stream=*/nullptr);
+    CUDA_CHECK(cudaDeviceSynchronize());
+    auto q_plain_out = to_host(q_plain, qn);
+    float max_diff = 0.0f;
+    for (int64_t i = 0; i < qn; i++)
+        max_diff = std::fmax(max_diff, std::fabs(__half2float(q_mtp_out[i]) - __half2float(q_plain_out[i])));
+    EXPECT_GT(max_diff, 1e-2f) << "YaRN scaling had no effect vs plain RoPE — params ignored?";
+
+    cudaFree(q_main);  cudaFree(k_main);  cudaFree(pos_dev);
+    cudaFree(q_mtp);   cudaFree(k_mtp);
+    cudaFree(q_plain); cudaFree(k_plain);
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes #897.

## Problem

`mtp_mrope_kernel` (the MTP draft head) computed cos/sin as plain NeoX RoPE and ignored the model's rope-scaling config (YaRN ext/attn factors, frequency scale, correction dims). On a rope-scaled model the drafter rotated Q/K differently from the verifier at extended positions, so **acceptance rate silently degraded with position** — reading as "MTP is uneconomic" rather than a bug. Same drift class as the #880 MLA YaRN fix, which only touched the main rope path.

Latent on today's MTP models (Qwen3.6 family ships base rope), but nothing warned when a rope-scaled model loaded with `mtp_k > 0`.

## Fix

- Extract `rope_yarn` / `rope_yarn_ramp` into `compute/rope_yarn.cuh`, now shared by `rope.cu` and `mtp_forward.cu` — one source of truth so the two paths can't drift again (addresses the duplication the audit flagged).
- `mtp_mrope_kernel` takes `inv_scaling` / `ext_factor` / `attn_factor` / `corr_dims` and applies the **identical** YaRN (ext_factor>0) or linear (freq-scaled) math as `rope_forward`. The two `<<<>>>` launches are factored into a testable `mtp_apply_mrope()` host wrapper used by both the draft step and the unit test.
- `engine.cpp` populates the MTP workspace's rope-scaling fields from the model config (computing YaRN `corr_dims` via `rope_yarn_corr_dims`, exactly as the executor does), and **warns** if a LongRoPE model enables MTP — that scaling family isn't plumbed into the single-token kernel, and no MTP model ships it today.

## Verification

- New `RoPETest.MtpMropeMatchesMainYarn`: runs the shared `rope_forward` (verifier) and `mtp_apply_mrope` (drafter) with the **same** YaRN params at an extended position (6000) and asserts they agree within FP16 tolerance — this fails on the old plain-RoPE code. Includes a guard that the YaRN scaling actually changes the output vs plain RoPE (so parity can't pass trivially).
- Full `RoPETest` suite 7/7 (the `rope.cu` extraction is behavior-identical).
- `MtpForwardTest.DraftStepProducesValidToken` on the real Qwen3.6-27B-MTP model (base rope) still green — the linear path with `inv_scaling=1` / `ext_factor=0` reduces exactly to the previous behavior.

Output correctness was never at risk (drafts are verified exactly); this recovers acceptance rate on rope-scaled models. No perf-path change (`tests/perf_baseline.json` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXm3AoXmxQ1gkesrp8EsT