### PR TITLE
fix(mem): trim async mempool on Model teardown, not just at the C-API boundary

### DIFF
--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -6,6 +6,7 @@
 #include "model/tokenizer.h"
 #include "model/chat_template.h"
 #include "memory/kv_cache.h"
+#include "memory/mem_account.h"  // trim_device_mempool
 
 #include "core/logging.h"
 
@@ -18,40 +19,6 @@
 
 #include <cuda_runtime.h>
 
-namespace {
-
-// Return retained default-mempool blocks to the driver after a teardown.
-//
-// Engine init raises the default cudaMallocAsync pool's release threshold to
-// UINT64_MAX so freed blocks are kept for re-use. Model weights are allocated
-// from that pool (weight_upload.cu checked_cuda_malloc), so freeing a model
-// parks ~weights-sized memory in the pool instead of returning it. The next
-// model load can't see it: cudaMemGetInfo-based sizing (engine_init_resolver,
-// the upload oversubscription gate) and plain-cudaMalloc paths only observe
-// driver-free memory. Symptom: server auto-swap found ~1.5 GB free on a 32 GB
-// card and failed with "Failed to upload token embedding".
-void trim_default_mempool() {
-    // Retire pending async frees before trimming, otherwise their blocks are
-    // still referenced and survive the trim.
-    cudaDeviceSynchronize();
-    int dev = 0;
-    cudaMemPool_t pool = nullptr;
-    if (cudaGetDevice(&dev) == cudaSuccess &&
-        cudaDeviceGetDefaultMemPool(&pool, dev) == cudaSuccess && pool != nullptr) {
-        unsigned long long rsv_before = 0, used_before = 0, rsv_after = 0, used_after = 0;
-        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv_before);
-        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &used_before);
-        cudaError_t te = cudaMemPoolTrimTo(pool, 0);
-        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv_after);
-        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &used_after);
-        IMP_LOG_INFO("mempool trim: reserved %.0f->%.0f MiB used %.0f->%.0f MiB (rc=%s)",
-                     rsv_before / (1024.0 * 1024.0), rsv_after / (1024.0 * 1024.0),
-                     used_before / (1024.0 * 1024.0), used_after / (1024.0 * 1024.0),
-                     cudaGetErrorString(te));
-    }
-}
-
-}  // namespace
 
 // --- Error string ---
 
@@ -253,7 +220,7 @@ void imp_model_free(ImpModel model) {
     if (!model)
         return;
     delete model;
-    trim_default_mempool();
+    imp::trim_device_mempool();
 }
 
 ImpModelArch imp_model_arch(ImpModel model) {
@@ -416,7 +383,7 @@ void imp_context_free(ImpContext ctx) {
     if (!ctx)
         return;
     delete ctx;
-    trim_default_mempool();
+    imp::trim_device_mempool();
 }
 
 // --- Helper: tokenize a prompt using chat template or raw encoding ---

--- a/src/memory/mem_account.cu
+++ b/src/memory/mem_account.cu
@@ -197,4 +197,28 @@ void MemAccount::report(const char* phase_label) {
     }
 }
 
+void trim_device_mempool() {
+    // Retire pending async frees before trimming, otherwise their blocks are
+    // still referenced and survive the trim.
+    cudaDeviceSynchronize();
+    int dev = 0;
+    cudaMemPool_t pool = nullptr;
+    if (cudaGetDevice(&dev) == cudaSuccess &&
+        cudaDeviceGetDefaultMemPool(&pool, dev) == cudaSuccess && pool != nullptr) {
+        unsigned long long rsv_before = 0, used_before = 0, rsv_after = 0, used_after = 0;
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv_before);
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &used_before);
+        cudaError_t te = cudaMemPoolTrimTo(pool, 0);
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv_after);
+        cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &used_after);
+        IMP_LOG_INFO("mempool trim: reserved %.0f->%.0f MiB used %.0f->%.0f MiB (rc=%s)",
+                     rsv_before / kMiB, rsv_after / kMiB, used_before / kMiB, used_after / kMiB,
+                     cudaGetErrorString(te));
+    }
+    // Clear any sticky error (e.g. sync/trim during process-exit teardown when
+    // the runtime has already torn the pool down) so a later cudaGetLastError
+    // in a caller's destructor doesn't misattribute it.
+    (void)cudaGetLastError();
+}
+
 }  // namespace imp

--- a/src/memory/mem_account.h
+++ b/src/memory/mem_account.h
@@ -108,4 +108,15 @@ private:
     int sampler_interval_us_ = 2000;
 };
 
+// Retire pending stream-ordered frees and return the default CUDA mempool's
+// unused reserved slack to the driver (cudaMemPoolTrimTo). Engine init raises
+// the default cudaMallocAsync pool's release threshold to UINT64_MAX so freed
+// blocks are kept for re-use, so cudaFreeAsync alone only parks weights-sized
+// memory in the pool — the next plain-cudaMalloc path (cudaMemGetInfo-based
+// sizing, token-embedding upload) can't see it and OOMs. Call after tearing
+// down anything that freed large async allocations (model/context teardown).
+// Safe at process exit (guards a torn-down pool, clears sticky errors). Logs
+// the reserved delta.
+void trim_device_mempool();
+
 }  // namespace imp

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -1,6 +1,7 @@
 #include "model/model.h"
 #include "model/model_arch.h"
 #include "core/logging.h"
+#include "memory/mem_account.h"  // trim_device_mempool
 #include <cuda_runtime.h>
 #include <algorithm>
 #include <cctype>
@@ -31,6 +32,7 @@ Model::~Model() {
     // before this destructor runs, making the frees return an error.
     // Silently ignore — the driver reclaims all device memory on context
     // destroy.
+    const bool had_gpu_weights = !gpu_allocations_.empty();
     int free_fail = 0;
     cudaError_t first_err = cudaSuccess;
     for (void* ptr : gpu_allocations_) {
@@ -43,7 +45,7 @@ Model::~Model() {
             }
         }
     }
-    if (!gpu_allocations_.empty())
+    if (had_gpu_weights)
         (void)cudaStreamSynchronize(nullptr);  // retire the frees for the pool
     if (free_fail > 0) {
         IMP_LOG_WARN("Model teardown: %d/%zu weight frees failed (first: %s)", free_fail,
@@ -51,6 +53,15 @@ Model::~Model() {
         (void)cudaGetLastError();  // clear sticky error (e.g. process-exit teardown)
     }
     gpu_allocations_.clear();
+    // Return the freed weights to the driver. The default cudaMallocAsync pool
+    // runs with an unbounded release threshold (engine init), so cudaFreeAsync
+    // above only parks weights-sized memory in the pool — the next plain
+    // cudaMalloc (e.g. a subsequent model's token-embedding upload) can't see
+    // it and OOMs. Previously this trim only ran at the C-API teardown boundary
+    // (imp_model_free), so direct-C++ model teardown (tests, embedders) leaked
+    // the reservation. Trim here so ANY model destruction returns it.
+    if (had_gpu_weights)
+        trim_device_mempool();
 
     for (void* ptr : host_pinned_) {
         if (ptr)

--- a/tests/test_quant_integration.cu
+++ b/tests/test_quant_integration.cu
@@ -9,6 +9,7 @@
 #include "compute/gemm.h"
 #include "compute/gemm_q4k.h"
 #include "core/tensor.h"
+#include "memory/mem_account.h"  // trim_device_mempool (mempool-trim regression)
 
 #include <vector>
 #include <cstdint>
@@ -1995,6 +1996,68 @@ TEST(DualPathQuant, WeightCachesFlag) {
 
     wcache.dual_path_quant = true;
     EXPECT_TRUE(wcache.dual_path_quant);
+}
+
+// ===========================================================================
+// Model teardown must trim the async mempool (issue: EncoderEmbed OOM)
+// ---------------------------------------------------------------------------
+// The default cudaMallocAsync pool runs with an unbounded release threshold,
+// so freeing a model's weights (cudaFreeAsync) parks weights-sized memory in
+// the pool instead of returning it to the driver. A later plain cudaMalloc
+// (the next model's token-embedding upload) then OOMs even though the memory
+// is "free". The trim used to run only at the C-API teardown boundary; the
+// direct-C++ path (tests, embedders) leaked the reservation and, in the full
+// aggregate suite, starved EncoderEmbedTest after the heavy MoE MtpForwardTest.
+// After the fix, ~Model() trims, so destroying a model leaves ~no trimmable
+// slack in the pool.
+// ===========================================================================
+namespace {
+double mempool_trimmable_mib() {
+    cudaDeviceSynchronize();
+    int dev = 0;
+    cudaMemPool_t pool = nullptr;
+    if (cudaGetDevice(&dev) != cudaSuccess ||
+        cudaDeviceGetDefaultMemPool(&pool, dev) != cudaSuccess || pool == nullptr)
+        return -1.0;
+    unsigned long long rsv = 0, usd = 0;
+    cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReservedMemCurrent, &rsv);
+    cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &usd);
+    return (rsv >= usd) ? static_cast<double>(rsv - usd) / (1024.0 * 1024.0) : 0.0;
+}
+}  // namespace
+
+TEST(QuantIntegrationTest, ModelTeardownTrimsAsyncPool) {
+    SKIP_IF_NO_CUDA();
+    // Reproduce the real condition: engine init raises the default async pool's
+    // release threshold to UINT64_MAX, so freed blocks are NOT auto-returned on
+    // sync — only an explicit trim reclaims them. Set it here (save/restore so
+    // other tests in the binary are unaffected).
+    cudaMemPool_t pool = nullptr;
+    int dev = 0;
+    ASSERT_EQ(cudaGetDevice(&dev), cudaSuccess);
+    ASSERT_EQ(cudaDeviceGetDefaultMemPool(&pool, dev), cudaSuccess);
+    uint64_t prev_threshold = 0;
+    cudaMemPoolGetAttribute(pool, cudaMemPoolAttrReleaseThreshold, &prev_threshold);
+    uint64_t maxed = UINT64_MAX;
+    ASSERT_EQ(cudaMemPoolSetAttribute(pool, cudaMemPoolAttrReleaseThreshold, &maxed), cudaSuccess);
+
+    // A model with ~1.5 GiB of FP16 weights: big enough that an untrimmed pool
+    // leaves an unambiguous reservation. Uploaded via cudaMallocAsync, so the
+    // destructor's cudaFreeAsync + trim is exercised.
+    {
+        auto model = make_q8_0_test_model(/*d_model=*/2048, /*d_ff=*/5504, /*n_heads=*/16,
+                                          /*n_kv_heads=*/16, /*n_layers=*/6, /*vocab_size=*/32000);
+        ASSERT_TRUE(model->upload_weights_gpu(QType::F16, nullptr));
+        // model destroyed here at scope exit → ~Model() must trim the pool.
+    }
+    // cudaMemPoolTrimTo(pool, 0) returns reserved down to used, so trimmable
+    // slack must be ~0. Pre-fix (no ~Model trim) this held the freed weights
+    // (~1.5 GiB) because the raised threshold suppresses auto-release.
+    double slack = mempool_trimmable_mib();
+    cudaMemPoolSetAttribute(pool, cudaMemPoolAttrReleaseThreshold, &prev_threshold);
+    ASSERT_GE(slack, 0.0) << "no default mempool on this device";
+    EXPECT_LT(slack, 128.0) << "async mempool retained " << slack
+                            << " MiB of trimmable slack after model teardown (not trimmed)";
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes the `EncoderEmbedTest` OOM in the full aggregate `imp-tests` suite (surfaced while verifying #895).

## Root cause

Engine init raises the default `cudaMallocAsync` pool's release threshold to `UINT64_MAX` so freed blocks are retained for reuse. A model's weights are freed with `cudaFreeAsync` in `~Model`, which parks weights-sized memory in the pool — only `cudaMemPoolTrimTo` returns it to the driver. That trim ran **only** at the C-API teardown boundary (`imp_model_free` / `imp_context_free`), so the direct-C++ path (GTest, embedders) never reclaimed it.

In the full aggregate `imp-tests` binary the parked reservations accumulated until `EncoderEmbedTest` — right after the ~15 GiB MoE `MtpForwardTest` — OOM'd on its token-embedding upload (`free=49 MiB`), turning an otherwise-green suite red. It's the same `Failed to upload token embedding` symptom the **server auto-swap** hit before the C-API trim was originally added — the C-API path was fixed then, the direct-C++ path was not.

## Fix

- Extract the trim into `imp::trim_device_mempool()` (in `memory/mem_account`), now the single owner of the pool-trim logic. `imp_api.cpp` calls it instead of keeping a private copy.
- Call it from `Model::~Model()` after the weight frees, so **any** model destruction returns the reservation — not just teardown through the C API. Guarded on `had_gpu_weights`, safe at process exit (tolerates a torn-down pool, clears sticky errors).

## Verification

- New `QuantIntegrationTest.ModelTeardownTrimsAsyncPool`: raises the release threshold exactly as engine init does, loads + destroys a model, and asserts the pool's trimmable slack is ~0 afterwards. It **fails without the fix** (576 MiB retained) and passes with it (trim logs `reserved 576->0`). A genuine regression guard.
- Full aggregate `imp-tests` now exits **0**: `EncoderEmbedTest.NomicBertEmbedsMatchReferenceStructure` passes (527 ms), zero `Failed to upload token embedding`. Previously exit 1 on that one test.

Memory-management fix only; no perf-path change (`tests/perf_baseline.json` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXm3AoXmxQ1gkesrp8EsT