### PR TITLE
chore(build): migrate to C++23 (CXX + CUDA)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 project(imp LANGUAGES C CXX CUDA VERSION 0.16.2)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CUDA_STANDARD 20)
+set(CMAKE_CUDA_STANDARD 23)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+# CMake's NVIDIA-CUDA module (through 4.3.x) tops out at c++20 — it defines no
+# CUDA23 dialect flag, so `CMAKE_CUDA_STANDARD 23` fails with "CMake does not know
+# the flags to enable it". nvcc 13.3 does accept `-std=c++23`, so teach CMake the
+# flag directly. Drop this once the module ships a native CUDA23 mapping.
+if(NOT DEFINED CMAKE_CUDA23_STANDARD_COMPILE_OPTION)
+  set(CMAKE_CUDA23_STANDARD_COMPILE_OPTION  "-std=c++23")
+  set(CMAKE_CUDA23_EXTENSION_COMPILE_OPTION "-std=c++23")
+endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Custom cmake modules

--- a/docs/audit/cpp23_migration_2026_07_08.md
+++ b/docs/audit/cpp23_migration_2026_07_08.md
@@ -66,16 +66,18 @@ nvcc warning : The -std=c++23 flag is not supported with the configured host com
 and compiles as the default dialect **without failing**. The production builder
 (Ubuntu 26.04 / GCC 15.2) is fine. Implication: bumping the standard requires the
 **profiling / ncu image (`impdev:ncu`) to be rebuilt on the 26.04/GCC-15 base too**,
-or profiling/roofline builds quietly compile non-c++23 and diverge from CI. This is
-the single action item; it's the same "impdev:ncu stale" trap already noted in memory.
+or profiling/roofline builds quietly compile non-c++23 and diverge from CI. It's the
+same "impdev:ncu stale" trap already noted in memory. **Done:** `impdev:ncu` rebuilt
+on the 26.04 base; the recipe is now committed at `tools/Dockerfile.ncu` (verified:
+nvcc honours `-std=c++23`, no drop warning) to end the "no recipe / stale COPY" trap.
 
 ## What the migration actually is
 
-1. `CMakeLists.txt:4-7` — flip `CMAKE_CXX_STANDARD 20`→`23` and `CMAKE_CUDA_STANDARD 20`→`23`.
-2. Rebuild `impdev:ncu` (and any other dev/profiling image) on `ubuntu26.04` / GCC 15.2.
-3. Full `make build` + `make test-unit` / `test-gpu` (this audit compiled representative
-   TUs, not the whole tree — the residual unknown is only the ~110 host TUs and ~200 `.cu`
-   not individually sampled; risk is low given no `-Werror` and c++23 ≈ superset here).
+1. `CMakeLists.txt:4-7` — flip `CMAKE_CXX_STANDARD 20`→`23` and `CMAKE_CUDA_STANDARD 20`→`23`
+   (plus a CMake shim teaching it the `-std=c++23` CUDA flag — see above).
+2. Rebuild `impdev:ncu` on `ubuntu26.04` / GCC 15.2 — done; recipe at `tools/Dockerfile.ncu`.
+3. Full `make build` + `make test-unit` / `test-gpu` — done: whole tree 0 errors, unit
+   37/37, gpu 0 failures.
 
 ## Residual low-risk items to watch during the full build
 

--- a/docs/audit/cpp23_migration_2026_07_08.md
+++ b/docs/audit/cpp23_migration_2026_07_08.md
@@ -1,0 +1,95 @@
+# C++23 migration audit (2026-07-08)
+
+Question: where can moving imp from C++20 → C++23 break? Every finding below was
+**verified against the real toolchain / code**, not inferred. Verification used
+nvcc 13.3 (V13.3.33) + GCC 15.2 (the production `nvidia/cuda:13.3.0-devel-ubuntu26.04`
+base), compiling the actual TUs with the real flags from `build/compile_commands.json`.
+
+## TL;DR
+
+Migration is **low-risk and technically clear**. The two things that could have been
+show-stoppers — nvcc dialect support and CUTLASS-under-c++23 — both pass a live compile.
+No `-Werror`, so any residual C++23 deprecation is a warning, not a build break.
+The only real gotcha is a **toolchain-version coupling** (below).
+
+## Verified: no blockers
+
+| Check | Result | How verified |
+|---|---|---|
+| nvcc 13.3 accepts `-std=c++23` | YES | `nvcc --help` lists `c++23`; forwards dialect to host compiler |
+| CUTLASS v4.5.2 device TUs under c++23 | **all 5 compile clean** (0 err / 0 warn) | live `nvcc -std=c++23 -c` of `gemm_cutlass_sm120`, `gemm_cutlass_mxfp4_sm120`, `gemm_cutlass_grouped_3x`, `gemm_grouped_nvfp4_smallM`, `attention_fmha_sm120` w/ GCC 15.2 host |
+| First-party host TUs under c++23 | clean, **zero new diagnostics** vs c++20 | `g++-15 -std=gnu++23 -fsyntax-only -Wall -Wextra -Wpedantic` on tensor/model/config/vision/lora TUs |
+| `--expt-relaxed-constexpr` set | YES (`cmake/CompilerFlags.cmake:17`) | covers C++23's expanded `constexpr` stdlib in device code |
+| CMake supports `CUDA_STANDARD 23` | YES | Dockerfile installs CMake **4.3.1** (`Dockerfile:24`) |
+| Removed features in use (`std::aligned_storage`/`aligned_union`, `<codecvt>`, `unary_function`, `throw()` dyn-spec, GC `declare_reachable`) | **none present** | grep `src/ include/ tools/ tests/` |
+| `u8""` / `char8_t` literals | none | grep |
+| `[=]` implicit-`this` captures (deprecated) | **none** — code uses explicit captures | grep (0 hits) |
+| `volatile` compound assignment (deprecated) | none | grep (83 `volatile` uses, all plain load/store in kernels) |
+| `-Werror` anywhere | **no** — only `-Wall -Wextra -Wpedantic`, CXX-only, not nvcc, not deps (`CMakeLists.txt:18-20`) | grep CMake + `.github/` |
+
+## The actual blocker (found during migration) — CMake has no CUDA23 dialect
+
+`set(CMAKE_CUDA_STANDARD 23)` fails at configure time:
+
+```
+Target "imp" requires the language dialect "CUDA23".  But the current compiler
+"NVIDIA" does not support this, or CMake does not know the flags to enable it.
+```
+
+Root cause is **CMake, not the toolchain**: `Compiler/NVIDIA.cmake` in CMake 4.3.1
+(`__compiler_nvidia_cxx_standards`) defines `..._STANDARD_COMPILE_OPTION` only up to
+c++20 — there is no `CMAKE_CUDA23_STANDARD_COMPILE_OPTION`. nvcc 13.3 *does* accept
+`-std=c++23` (verified), CMake just doesn't emit it for the CUDA language yet. Fix is
+to teach CMake the flag before targets are defined (in `CMakeLists.txt`):
+
+```cmake
+if(NOT DEFINED CMAKE_CUDA23_STANDARD_COMPILE_OPTION)
+  set(CMAKE_CUDA23_STANDARD_COMPILE_OPTION  "-std=c++23")
+  set(CMAKE_CUDA23_EXTENSION_COMPILE_OPTION "-std=c++23")
+endif()
+```
+
+Verified in a minimal CUDA project (configure + compile of a c++23 template-lambda TU
+pass) and in the full imp build. `CMAKE_CUDA_EXTENSIONS OFF` alone does **not** fix it
+(there's no non-extension CUDA23 mapping either). Remove the shim once the CMake module
+ships a native CUDA23 entry.
+
+## The other gotcha — host-compiler coupling
+
+`nvcc --std=c++23` is **silently ignored** if the host compiler is judged too old.
+Observed live: on the stale `impdev:ncu` image (GCC 13.3 / Ubuntu 24.04), nvcc emits
+
+```
+nvcc warning : The -std=c++23 flag is not supported with the configured host compiler. Flag will be ignored.
+```
+
+and compiles as the default dialect **without failing**. The production builder
+(Ubuntu 26.04 / GCC 15.2) is fine. Implication: bumping the standard requires the
+**profiling / ncu image (`impdev:ncu`) to be rebuilt on the 26.04/GCC-15 base too**,
+or profiling/roofline builds quietly compile non-c++23 and diverge from CI. This is
+the single action item; it's the same "impdev:ncu stale" trap already noted in memory.
+
+## What the migration actually is
+
+1. `CMakeLists.txt:4-7` — flip `CMAKE_CXX_STANDARD 20`→`23` and `CMAKE_CUDA_STANDARD 20`→`23`.
+2. Rebuild `impdev:ncu` (and any other dev/profiling image) on `ubuntu26.04` / GCC 15.2.
+3. Full `make build` + `make test-unit` / `test-gpu` (this audit compiled representative
+   TUs, not the whole tree — the residual unknown is only the ~110 host TUs and ~200 `.cu`
+   not individually sampled; risk is low given no `-Werror` and c++23 ≈ superset here).
+
+## Residual low-risk items to watch during the full build
+
+- **P2266 implicit-move on return** (c++23 hardens `return local;` to move): can turn a
+  copy-only-from-lvalue local return into an error. None seen in sampled TUs; a full
+  build is the real check. Hard error if it hits, not silent.
+- **libstdc++15 header transitivity**: GCC 15 already tightened this at c++20 (the
+  `<algorithm>`/`<numeric>` sweep, PR #906). c++23 mode may expose a few more missing
+  includes → hard error, trivial fix.
+- CUTLASS deprecation warnings under c++23 would be **invisible anyway** — deps and nvcc
+  TUs are not compiled with `-Wall` (`imp_warnings` is CXX-only, first-party-only).
+
+## Refuted (do not re-chase)
+
+- "nvcc can't do c++23" — false, 13.3 supports it.
+- "CUTLASS 4.5.2 won't build under c++23" — false, all 5 TUs clean.
+- "new C++23 warnings will break the build" — false, no `-Werror`.

--- a/tools/Dockerfile.ncu
+++ b/tools/Dockerfile.ncu
@@ -1,0 +1,33 @@
+# impdev:ncu — profiling / dev image (Nsight Compute `ncu` + `nsys` + nvcc + GCC 15.2).
+#
+# Build (needs `imp:test` from `make build` first, which supplies the C++23 binaries):
+#   docker build -f tools/Dockerfile.ncu -t impdev:ncu .
+#
+# Run (source mounted at /src, models at /models):
+#   docker run --rm --gpus all -v $PWD:/src -v /home/kekz/models:/models \
+#     -w /src impdev:ncu ncu --set full ./build/<binary>
+#
+# MUST stay on the ubuntu26.04 (GCC 15.2) base: on the old ubuntu24.04/GCC-13 base
+# nvcc SILENTLY dropped `-std=c++23` (warning, not error) and recompiles inside the
+# image diverged from the C++23 CI build. Nsight Compute and nsys already ship in
+# this CUDA devel base.
+FROM nvidia/cuda:13.3.0-devel-ubuntu26.04
+
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends libdw1t64 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
+
+# Prebuilt C++23 imp binaries from the current imp:test image (keeps them in sync
+# with the build under profile). Recompilation uses the mounted source at /src.
+COPY --from=imp:test /usr/local/bin/imp-cli    /usr/local/bin/imp-cli
+COPY --from=imp:test /usr/local/bin/imp-server /usr/local/bin/imp-server
+COPY --from=imp:test /usr/local/bin/test-core       /usr/local/bin/test-core
+COPY --from=imp:test /usr/local/bin/test-text       /usr/local/bin/test-text
+COPY --from=imp:test /usr/local/bin/test-compute    /usr/local/bin/test-compute
+COPY --from=imp:test /usr/local/bin/test-attention  /usr/local/bin/test-attention
+COPY --from=imp:test /usr/local/bin/test-quant      /usr/local/bin/test-quant
+COPY --from=imp:test /usr/local/bin/test-kv         /usr/local/bin/test-kv
+COPY --from=imp:test /usr/local/bin/test-moe-gdn    /usr/local/bin/test-moe-gdn
+COPY --from=imp:test /usr/local/bin/test-e2e        /usr/local/bin/test-e2e


### PR DESCRIPTION
Bumps the project from C++20 to **C++23** for both the host (`CMAKE_CXX_STANDARD`) and device (`CMAKE_CUDA_STANDARD`) languages.

## What changed
- `CMakeLists.txt`: `20 → 23` for CXX + CUDA.
- Added a small shim teaching CMake the CUDA `-std=c++23` flag (see below).
- `docs/audit/cpp23_migration_2026_07_08.md`: the pre-migration audit + verification record.

**No source changes were required.** The audit confirmed the codebase uses none of the C++23-removed/deprecated features (`std::aligned_storage`, `<codecvt>`, `unary_function`, `throw()` dyn-spec, GC API), no `u8`/`char8_t` literals, no `[=]` implicit-`this` captures, and no `volatile` compound assignment. The full-tree build surfaced no P2266 (implicit-move) or libstdc++15 header-transitivity breakage.

## The one non-obvious bit — a CMake shim
`set(CMAKE_CUDA_STANDARD 23)` fails at **configure** time:
```
Target "imp" requires the language dialect "CUDA23". But the current compiler
"NVIDIA" does not support this, or CMake does not know the flags to enable it.
```
Root cause is **CMake, not the toolchain**: `Compiler/NVIDIA.cmake` (through CMake 4.3.x) defines dialect flags only up to c++20 — there is no `CMAKE_CUDA23_STANDARD_COMPILE_OPTION`. nvcc 13.3 *does* accept `-std=c++23` (verified by direct compile), so the fix teaches CMake the flag:
```cmake
if(NOT DEFINED CMAKE_CUDA23_STANDARD_COMPILE_OPTION)
  set(CMAKE_CUDA23_STANDARD_COMPILE_OPTION  "-std=c++23")
  set(CMAKE_CUDA23_EXTENSION_COMPILE_OPTION "-std=c++23")
endif()
```
Remove once the CMake module ships a native CUDA23 mapping.

## Heads-up: dev/profiling images
`nvcc --std=c++23` is **silently ignored** (warning, not error) if the host compiler is too old — observed live on the stale `impdev:ncu` image (GCC 13.3), where nvcc drops the flag and compiles as the default dialect. Production builds (Ubuntu 26.04 / GCC 15.2) are fine, but **`impdev:ncu` and any other profiling image must be rebuilt on the 26.04/GCC-15 base**, or profiling/roofline builds quietly diverge from CI.

## Verification (local, RTX 5090)
- `make build` — whole tree (~310 TUs) compiles under C++23, **0 errors, 0 new warnings** (the 2 warnings present are pre-existing and dialect-independent).
- `make test-unit` — **37/37 passed**.
- `make test-gpu` — **0 failures** (gaps are known `DISABLED_`/model-skipped tests).
- CUTLASS 4.5.2 (all 5 cute/CUTLASS TUs) compiles clean under `-std=c++23` with nvcc 13.3 + GCC 15.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)