### PR TITLE
docs(standalone): bump example compile commands to C++23

### DIFF
--- a/tools/analysis/tile_fa2_probe.cu
+++ b/tools/analysis/tile_fa2_probe.cu
@@ -4,7 +4,7 @@
 // into imp — pure viability/correctness prototype (zero degeneration risk).
 //
 // Run via the WSL-driver dev recipe (see docs/archive/tile-fa2-dispatch-shelved.md). Build:
-//   nvcc -std=c++20 --enable-tile -arch=sm_120a -o tile_fa2_probe tile_fa2_probe.cu
+//   nvcc -std=c++23 --enable-tile -arch=sm_120a -o tile_fa2_probe tile_fa2_probe.cu
 #include "cuda_tile.h"
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>

--- a/tools/standalone/fa2_sm120a_optimal.cu
+++ b/tools/standalone/fa2_sm120a_optimal.cu
@@ -48,8 +48,8 @@
 // Still simplified vs production: f32 QK^T accumulate, MHA only (no GQA grouping).
 //
 // Build & run (host has no CUDA toolkit — use the CUDA 13.3 container):
-//   docker run --rm --gpus all -v "$PWD":/w -w /w nvidia/cuda:13.3.0-devel-ubuntu24.04 \
-//     sh -c 'nvcc -O3 -std=c++17 -arch=sm_120a fa2_sm120a_optimal.cu -o fa2 && ./fa2'
+//   docker run --rm --gpus all -v "$PWD":/w -w /w nvidia/cuda:13.3.0-devel-ubuntu26.04 \
+//     sh -c 'nvcc -O3 -std=c++23 -arch=sm_120a fa2_sm120a_optimal.cu -o fa2 && ./fa2'
 // (imp's own image already has nvcc: imp:test works as the image too.)
 // -----------------------------------------------------------------------------
 

--- a/tools/standalone/gemm_nvfp4_sm120a.cu
+++ b/tools/standalone/gemm_nvfp4_sm120a.cu
@@ -54,8 +54,8 @@
 // Build & run (host has no CUDA toolkit — use the CUDA 13.3 container).
 // NOTE: block-scale mxf4nvf4 needs the explicit compute_120a gencode; the
 // `-arch=sm_120a` shorthand does NOT enable .block_scale (ptxas rejects it):
-//   docker run --rm --gpus all -v "$PWD":/w -w /w nvidia/cuda:13.3.0-devel-ubuntu24.04 \
-//     sh -c 'nvcc -O3 -std=c++17 --generate-code=arch=compute_120a,code=sm_120a \
+//   docker run --rm --gpus all -v "$PWD":/w -w /w nvidia/cuda:13.3.0-devel-ubuntu26.04 \
+//     sh -c 'nvcc -O3 -std=c++23 --generate-code=arch=compute_120a,code=sm_120a \
 //            gemm_nvfp4_sm120a.cu -o gemm && ./gemm'
 // -----------------------------------------------------------------------------
 

--- a/tools/standalone/gemm_nvfp4_sm120a_tma.cu
+++ b/tools/standalone/gemm_nvfp4_sm120a_tma.cu
@@ -70,8 +70,8 @@
 // Build & run (host has no CUDA toolkit — use the CUDA 13.3 container).
 // NOTE: block-scale mxf4nvf4 needs the explicit compute_120a gencode; the
 // `-arch=sm_120a` shorthand does NOT enable .block_scale (ptxas rejects it):
-//   docker run --rm --gpus all -v "$PWD":/w -w /w nvidia/cuda:13.3.0-devel-ubuntu24.04 \
-//     sh -c 'nvcc -O3 -std=c++17 --generate-code=arch=compute_120a,code=sm_120a \
+//   docker run --rm --gpus all -v "$PWD":/w -w /w nvidia/cuda:13.3.0-devel-ubuntu26.04 \
+//     sh -c 'nvcc -O3 -std=c++23 --generate-code=arch=compute_120a,code=sm_120a \
 //            gemm_nvfp4_sm120a.cu -o gemm && ./gemm'
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to the C++23 migration (#916). The standalone reference kernels and the shelved tile-fa2 probe are **hand-compiled** (not part of the CMake build), so their header-comment example commands were untouched by #916 and still pinned older standards.

- `tools/standalone/gemm_nvfp4_sm120a.cu` — `-std=c++17` → `-std=c++23`
- `tools/standalone/gemm_nvfp4_sm120a_tma.cu` — `-std=c++17` → `-std=c++23`
- `tools/standalone/fa2_sm120a_optimal.cu` — `-std=c++17` → `-std=c++23`
- `tools/analysis/tile_fa2_probe.cu` — `-std=c++20` → `-std=c++23`

For the three container-based commands, the base image is also bumped **ubuntu24.04 → ubuntu26.04**: on the GCC-13 (24.04) base nvcc *silently drops* `-std=c++23` (warning, not error), so the standard bump alone would be a no-op there.

**Verified:** all three standalone kernels compile clean under `-std=c++23` with GCC 15.2 (nvcc 13.3). `tile_fa2_probe` is comment-only — it's a shelved probe and its `cuda_tile.h` is not in-repo, so it isn't compile-checked.

Comment-only change; no build/runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)