### PR TITLE
refactor: adopt C++23 idioms (to_underlying, deducing this, static operator())

### DIFF
--- a/src/compute/encoder_forward.cu
+++ b/src/compute/encoder_forward.cu
@@ -18,6 +18,7 @@
 #include "quant/dequant_gpu.h"
 #include <cuda_fp16.h>
 #include <numeric>
+#include <utility>
 
 namespace imp {
 
@@ -74,7 +75,7 @@ void* dequant_to_fp16(const Tensor& w, cudaStream_t stream) {
     } else if (dequant_gpu_supported(w.qtype)) {
         dequant_gpu(w.data, dst, w.qtype, rows, cols, stream);
     } else {
-        IMP_LOG_ERROR("encoder: unsupported weight qtype %d", static_cast<int>(w.qtype));
+        IMP_LOG_ERROR("encoder: unsupported weight qtype %d", std::to_underlying(w.qtype));
         cudaFree(dst);
         return nullptr;
     }

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <mutex>
 #include <vector>
+#include <utility>
 
 #define CUBLASLT_CHECK(call)                                                        \
     do {                                                                            \
@@ -142,7 +143,7 @@ static cudaDataType_t dtype_to_cuda(QType dt) {
         case QType::INT32:
             return CUDA_R_32I;
         default:
-            fprintf(stderr, "imp::gemm: unsupported dtype %d\n", (int)dt);
+            fprintf(stderr, "imp::gemm: unsupported dtype %d\n", std::to_underlying(dt));
             return CUDA_R_16F;  // fallback (caller guard should prevent reaching here)
     }
 }
@@ -212,7 +213,7 @@ struct GemmCacheKey {
 };
 
 struct GemmCacheKeyHash {
-    size_t operator()(const GemmCacheKey& k) const {
+    static size_t operator()(const GemmCacheKey& k) {
         size_t h = 14695981039346656037ULL;
         auto mix = [&](uint64_t v) {
             h ^= v;

--- a/src/compute/gemm_dp4a.cu
+++ b/src/compute/gemm_dp4a.cu
@@ -29,8 +29,8 @@ namespace imp {
 // ---------------------------------------------------------------------------
 
 struct IdentityAct {
-    __device__ __forceinline__ float operator()(const half* input, const half* /*unused*/, int idx,
-                                                int total) const {
+    __device__ __forceinline__ static float operator()(const half* input, const half* /*unused*/, int idx,
+                                                       int total) {
         // Early-out for OOB threads (preserves original quantize_fp16_to_q8_1 behavior
         // where partial-warp threads return instead of contributing val=0).
         (void)total;
@@ -42,8 +42,8 @@ struct IdentityAct {
 
 struct SwiGLUAct {
     // SwiGLU: silu(gate) * up = gate * sigmoid(gate) * up
-    __device__ __forceinline__ float operator()(const half* gate, const half* up, int idx,
-                                                int /*total*/) const {
+    __device__ __forceinline__ static float operator()(const half* gate, const half* up, int idx,
+                                                       int /*total*/) {
         float g = __half2float(gate[idx]);
         float u = __half2float(up[idx]);
         return g / (1.0f + expf(-g)) * u;
@@ -54,8 +54,8 @@ struct SwiGLUAct {
 
 struct GeGLUAct {
     // GEGLU: gelu_tanh(gate) * up
-    __device__ __forceinline__ float operator()(const half* gate, const half* up, int idx,
-                                                int /*total*/) const {
+    __device__ __forceinline__ static float operator()(const half* gate, const half* up, int idx,
+                                                       int /*total*/) {
         constexpr float SQRT_2_PI = 0.7978845608028654f;
         constexpr float COEFF = 0.044715f;
         float g = __half2float(gate[idx]);
@@ -69,8 +69,8 @@ struct GeGLUAct {
 
 struct ReLUSqrAct {
     // relu²(x) = max(0, x)²
-    __device__ __forceinline__ float operator()(const half* input, const half* /*unused*/, int idx,
-                                                int /*total*/) const {
+    __device__ __forceinline__ static float operator()(const half* input, const half* /*unused*/, int idx,
+                                                       int /*total*/) {
         float v = __half2float(input[idx]);
         return (v > 0.0f) ? v * v : 0.0f;
     }

--- a/src/compute/gemm_grouped.cu
+++ b/src/compute/gemm_grouped.cu
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <cstdint>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -52,7 +53,7 @@ static cudaDataType_t dtype_to_cuda(QType dt) {
         case QType::INT32:
             return CUDA_R_32I;
         default:
-            fprintf(stderr, "imp::gemm_grouped: unsupported dtype %d\n", (int)dt);
+            fprintf(stderr, "imp::gemm_grouped: unsupported dtype %d\n", std::to_underlying(dt));
             abort();
     }
 }

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -5,6 +5,7 @@
 #include <cfloat>
 #include <cstring>
 #include <algorithm>
+#include <utility>
 
 namespace imp {
 
@@ -467,7 +468,7 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
                 token_allow_[eid] = 1;
         }
         IMP_LOG_WARN("JsonConstrainer: no token satisfies the grammar in state %d — allowing EOS",
-                     static_cast<int>(current_state_));
+                     std::to_underlying(current_state_));
     }
 
     if (!d_token_allow_) {

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -7,6 +7,7 @@
 #include <float.h>
 #include <algorithm>
 #include <cstring>
+#include <utility>
 
 namespace imp {
 
@@ -60,7 +61,7 @@ bool SchemaConstrainer::init(const Tokenizer& tok, std::unique_ptr<SchemaNode> s
     initialized_ = true;
 
     IMP_LOG_INFO("SchemaConstrainer: initialized with %d tokens, schema type=%d", vocab_size_,
-                 static_cast<int>(schema_->type));
+                 std::to_underlying(schema_->type));
     return true;
 }
 
@@ -432,12 +433,12 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
                     token_allow_[e] = 1;
             cat_mask = 0xFFFF;
             IMP_LOG_WARN("SchemaConstrainer: no token satisfies the schema in phase %d — allowing EOS",
-                         static_cast<int>(top().phase));
+                         std::to_underlying(top().phase));
         }
     }
 
     IMP_LOG_DEBUG("SchemaConstrainer::apply_mask phase=%d cat_mask=0x%04x need_allow=%d stack=%zu",
-                  static_cast<int>(top().phase), cat_mask, need_token_allow_, stack_.size());
+                  std::to_underlying(top().phase), cat_mask, need_token_allow_, stack_.size());
 
     // Upload category mask
     IMP_CUDA_CHECK_LOG(
@@ -478,7 +479,7 @@ void SchemaConstrainer::update(int32_t token) {
     }
     if (!stack_.empty()) {
         IMP_LOG_DEBUG("SchemaConstrainer::update token=%d [%s] phase %d->%d stack=%zu", token, text.c_str(),
-                      static_cast<int>(before), static_cast<int>(top().phase), stack_.size());
+                      std::to_underlying(before), std::to_underlying(top().phase), stack_.size());
     }
 }
 

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -156,8 +156,11 @@ private:
     PreambleGate preamble_;
 
     // Helpers
-    SchemaFrame& top() { return stack_.back(); }
-    const SchemaFrame& top() const { return stack_.back(); }
+    // C++23 deducing this: one overload serves const and non-const callers.
+    template <typename Self>
+    auto&& top(this Self&& self) {
+        return self.stack_.back();
+    }
 
     void push_value_frame(const SchemaNode* node);
 

--- a/src/compute/weight_dispatch.cu
+++ b/src/compute/weight_dispatch.cu
@@ -12,6 +12,7 @@
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -274,7 +275,7 @@ void gemm_dispatch(cublasLtHandle_t, const WeightHandle& w, const Tensor& x, Ten
 
         case StorageTier::FP32:
         case StorageTier::Undefined:
-            IMP_LOG_FATAL("gemm_dispatch: handle in invalid tier %d", static_cast<int>(w.primary_tier));
+            IMP_LOG_FATAL("gemm_dispatch: handle in invalid tier %d", std::to_underlying(w.primary_tier));
             return;
     }
 }
@@ -374,7 +375,7 @@ void gemv_dispatch(const WeightHandle& w, const Tensor& x, Tensor& y, cudaStream
         }
 
         default:
-            IMP_LOG_FATAL("gemv_dispatch: handle in invalid tier %d", static_cast<int>(w.primary_tier));
+            IMP_LOG_FATAL("gemv_dispatch: handle in invalid tier %d", std::to_underlying(w.primary_tier));
             return;
     }
 }
@@ -456,7 +457,7 @@ void gemm_grouped_dispatch(cublasLtHandle_t /*lt*/, std::span<const WeightHandle
             return;
 
         default:
-            IMP_LOG_FATAL("gemm_grouped_dispatch: undefined tier %d", static_cast<int>(tier));
+            IMP_LOG_FATAL("gemm_grouped_dispatch: undefined tier %d", std::to_underlying(tier));
             return;
     }
 }

--- a/src/core/logging.cpp
+++ b/src/core/logging.cpp
@@ -3,6 +3,7 @@
 #include <cstdarg>
 #include <ctime>
 #include <atomic>
+#include <utility>
 
 namespace imp {
 
@@ -27,7 +28,7 @@ static const char* level_str(LogLevel level) {
 }
 
 void log_message(LogLevel level, const char* file, int line, const char* fmt, ...) {
-    if (static_cast<int>(level) < static_cast<int>(g_log_level.load(std::memory_order_relaxed))) {
+    if (std::to_underlying(level) < std::to_underlying(g_log_level.load(std::memory_order_relaxed))) {
         return;
     }
 

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -47,6 +47,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <algorithm>
+#include <utility>
 
 #include "exec/executor_attention_internal.h"
 namespace imp {
@@ -629,7 +630,7 @@ after_attention:
             debug_tensor_rows("ao_pre_wo-0", view_tokens(ao, n), stream);
             // dump wo weight shape info
             fprintf(stderr, "[DEBUG_FWD] wo_shape: ndim=%d shape=[%ld,%ld] qtype=%d\n", ly.wo.ndim,
-                    (long)ly.wo.shape[0], (long)ly.wo.shape[1], (int)ly.wo.qtype);
+                    (long)ly.wo.shape[0], (long)ly.wo.shape[1], std::to_underlying(ly.wo.qtype));
         }
         if (has_post_attn_norm && using_fp32_accum) {
             // Sandwich norm with FP32 accumulator (Gemma-3):

--- a/src/exec/executor_attention_decode.cu
+++ b/src/exec/executor_attention_decode.cu
@@ -1,4 +1,5 @@
 // Decode attention dispatch block for GraphExecutor::run_attention.
+#include <utility>
 //
 // This is NOT a standalone translation unit — it is textually #include'd inside
 // the body of GraphExecutor::run_attention (executor_attention.cu), inside the
@@ -272,7 +273,7 @@
                 warned_sinks_kv = true;
                 IMP_LOG_WARN("attention sinks: only the FP16 paged decode kernels apply sinks — "
                              "kv_cache.dtype=%d ignores them; use fp16 KV for this model.",
-                             (int)cache_dtype);
+                             std::to_underlying(cache_dtype));
             }
         }
 

--- a/src/exec/executor_debug.h
+++ b/src/exec/executor_debug.h
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -135,7 +136,7 @@ inline void debug_tensor_stats(const char* name, const Tensor& t, cudaStream_t s
                                            n * sizeof(float), cudaMemcpyDeviceToHost, stream));
         cudaStreamSynchronize(stream);
     } else {
-        fprintf(stderr, "[DEBUG_FWD] %s: unsupported dtype %d\n", name, (int)t.qtype);
+        fprintf(stderr, "[DEBUG_FWD] %s: unsupported dtype %d\n", name, std::to_underlying(t.qtype));
         return;
     }
 
@@ -218,7 +219,7 @@ inline void debug_tensor_stats_all(const char* name, const Tensor& t, cudaStream
     int nrows = static_cast<int>(t.shape[0]);
     int64_t n = static_cast<int64_t>(cols) * nrows;
     if (t.qtype != QType::F16 && t.qtype != QType::F32) {
-        fprintf(stderr, "[DEBUG_FWD_ALL] %s: unsupported dtype %d\n", name, (int)t.qtype);
+        fprintf(stderr, "[DEBUG_FWD_ALL] %s: unsupported dtype %d\n", name, std::to_underlying(t.qtype));
         return;
     }
     std::vector<float> host(n);

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -48,6 +48,7 @@
 #include <cmath>
 #include <vector>
 #include <algorithm>
+#include <utility>
 
 namespace imp {
 
@@ -909,7 +910,8 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
                                             expert_indices, norm_ptr, gate_buf, up_buf, eff, d,
                                             gate_stride, up_stride_bytes, /*x_stride=*/0, top_k, stream);
             } else {
-                IMP_LOG_ERROR("MoE non-dp4a gate_up_fused: no kernel for qtype %d", (int)up_qtype);
+                IMP_LOG_ERROR("MoE non-dp4a gate_up_fused: no kernel for qtype %d",
+                              std::to_underlying(up_qtype));
             }
         } else {
             if (up_qtype == QType::Q6_K) {
@@ -919,7 +921,8 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
                 gemv_q8_0_moe_decode(ly.expert_up_packed.data, expert_indices, norm_ptr, up_buf, eff, d,
                                      up_stride_bytes, /*x_stride=*/0, top_k, stream);
             } else {
-                IMP_LOG_ERROR("MoE non-dp4a up projection: no kernel for qtype %d", (int)up_qtype);
+                IMP_LOG_ERROR("MoE non-dp4a up projection: no kernel for qtype %d",
+                              std::to_underlying(up_qtype));
             }
         }
     }
@@ -964,7 +967,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
                                  down_stride, /*x_stride=*/eff, top_k, stream);
         } else {
             IMP_LOG_ERROR("MoE non-dp4a down projection: no kernel for qtype %d",
-                          (int)ly.expert_down_packed.qtype);
+                          std::to_underlying(ly.expert_down_packed.qtype));
         }
     }
 

--- a/src/exec/executor_forward_moe_legacy.cu
+++ b/src/exec/executor_forward_moe_legacy.cu
@@ -46,6 +46,7 @@
 #include <cmath>
 #include <vector>
 #include <algorithm>
+#include <utility>
 
 namespace imp {
 
@@ -92,7 +93,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                     "dequant_expert: OOB! expert %d offset=%zu + raw=%zu > total=%zu "
                     "(packed shape [%ld,%ld,%ld] qtype=%u)",
                     expert_idx, offset, expert_raw, total_raw, (long)packed.shape[0],
-                    (long)packed.shape[1], (long)packed.shape[2], (unsigned)qtype);
+                    (long)packed.shape[1], (long)packed.shape[2], std::to_underlying(qtype));
                 return Tensor();
             }
 

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -1,4 +1,5 @@
 // executor_gemm_dispatch.cu — GEMM dispatch entry for the executor.
+#include <utility>
 //
 // Extracted from executor_kernels.cu (D3, structural-debt audit): the
 // WeightHandle-keyed GEMM dispatch (GraphExecutor::gemm_via_handle_) and its
@@ -67,7 +68,7 @@ static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& w
         }
         IMP_LOG_ERROR(
             "gemm_dispatch_uncached_fallback: beta=%.3f but no FP16 path for qtype=%d",
-            ctx.beta, (int)qtype);
+            ctx.beta, std::to_underlying(qtype));
         return;
     }
 
@@ -94,7 +95,7 @@ static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& w
             IMP_LOG_WARN(
                 "gemm_dispatch_uncached_fallback: dropped weight at final fallback! "
                 "M=%d qtype=%d kind=%s — overlay coverage gap.",
-                M, static_cast<int>(qtype), tensor_kind_name(weight.kind));
+                M, std::to_underlying(qtype), tensor_kind_name(weight.kind));
         }
         return;
     }

--- a/src/exec/expert_cache.cu
+++ b/src/exec/expert_cache.cu
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstring>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -188,7 +189,7 @@ void* ExpertLRUCache::find(int layer, ExpertCacheKey key) {
 void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
                                   const void* src_host, size_t expert_bytes,
                                   cudaStream_t stream) {
-    const int proj_idx = static_cast<int>(proj);
+    const int proj_idx = std::to_underlying(proj);
     if (layer < 0 || layer >= n_layers_) {
         IMP_LOG_ERROR("ExpertLRUCache::get_or_load: layer %d out of range [0, %d)", layer,
                       n_layers_);

--- a/src/exec/expert_cache.h
+++ b/src/exec/expert_cache.h
@@ -27,7 +27,7 @@ struct ExpertCacheKey {
 };
 
 struct ExpertCacheKeyHash {
-    size_t operator()(const ExpertCacheKey& k) const {
+    static size_t operator()(const ExpertCacheKey& k) {
         // Combine pointer hash and expert index
         size_t h = std::hash<const void*>{}(k.packed_ptr);
         h ^= std::hash<int>{}(k.expert_idx) + 0x9e3779b9 + (h << 6) + (h >> 2);

--- a/src/exec/gemm_kernel_registry.cu
+++ b/src/exec/gemm_kernel_registry.cu
@@ -1,4 +1,5 @@
 #include "exec/gemm_kernel_registry.h"
+#include <utility>
 #include "compute/gemm.h"
 #include "core/logging.h"
 
@@ -19,7 +20,7 @@ void GemmKernelRegistry::register_kernel(GemmStrategy strategy, GemmKernelFn fn)
         if (entries_[i].strategy == strategy) {
             IMP_LOG_WARN(
                 "GemmKernelRegistry: overriding existing entry (tier=%d qtype=%d m_is_one=%d)",
-                static_cast<int>(strategy.tier), static_cast<int>(strategy.weight_qtype),
+                std::to_underlying(strategy.tier), std::to_underlying(strategy.weight_qtype),
                 strategy.m_is_one ? 1 : 0);
             entries_[i].fn = fn;
             return;
@@ -59,7 +60,7 @@ static GemmDispatchResult fp16_gemm_kernel(const GemmKernelArgs& args) {
 
     const Tensor& weight = *static_cast<const Tensor*>(args.weight_payload);
     IMP_CHECK(weight.qtype == QType::F16, "fp16_gemm_kernel: weight qtype=%d, expected F16",
-              static_cast<int>(weight.qtype));
+              std::to_underlying(weight.qtype));
     gemm(*args.input, weight, *args.output, /*alpha=*/1.0f, args.beta, args.stream);
     return GemmDispatchResult::Ok;
 }

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include <utility>
 
 using imp::pre_dequant_internal::borrow_payload_from_wcache;
 using imp::pre_dequant_internal::infer_tier_from_wcache;
@@ -235,19 +236,19 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
         // model that has tensor kinds the runtime caches but plan_storage
         // doesn't yet enumerate (or vice versa).
         if (registry_count < plan_overlay) {
-            int plan_per_kind[static_cast<int>(TensorKind::COUNT)] = {0};
-            int registry_per_kind[static_cast<int>(TensorKind::COUNT)] = {0};
+            int plan_per_kind[std::to_underlying(TensorKind::COUNT)] = {0};
+            int registry_per_kind[std::to_underlying(TensorKind::COUNT)] = {0};
             for (const auto& e : ideal_plan.entries) {
                 bool overlay = (e.tier == StorageTier::FP16 || e.tier == StorageTier::FP8 ||
                                 e.tier == StorageTier::NVFP4 || e.tier == StorageTier::CUTLASS_NVFP4 ||
                                 e.tier == StorageTier::MXFP4);
                 if (overlay)
-                    ++plan_per_kind[static_cast<int>(e.kind)];
+                    ++plan_per_kind[std::to_underlying(e.kind)];
             }
             for (TensorID id = 0; id < static_cast<TensorID>(registry_->size()); ++id) {
                 ++registry_per_kind[static_cast<int>(registry_->handle(id).kind)];
             }
-            for (int k = 0; k < static_cast<int>(TensorKind::COUNT); ++k) {
+            for (int k = 0; k < std::to_underlying(TensorKind::COUNT); ++k) {
                 int diff = plan_per_kind[k] - registry_per_kind[k];
                 if (diff > 0) {
                     IMP_LOG_INFO("Phase-4 gap by kind: %s plan=%d registry=%d (uncached=%d)",
@@ -320,8 +321,8 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
                     ++mismatch;
                     StorageTier actual = infer_tier_from_wcache(*wcache_, e.source_data);
                     IMP_LOG_INFO("Phase-4 plan/actual MISMATCH: %s plan-tier=%d actual-tier=%d",
-                                 tensor_kind_name(e.kind), static_cast<int>(e.tier),
-                                 static_cast<int>(actual));
+                                 tensor_kind_name(e.kind), std::to_underlying(e.tier),
+                                 std::to_underlying(actual));
                 } else {
                     ++evicted;  // planned overlay but not cached (budget / native fallback)
                 }

--- a/src/exec/weight_handle.cu
+++ b/src/exec/weight_handle.cu
@@ -3,6 +3,7 @@
 #include "core/logging.h"
 
 #include <cstring>
+#include <utility>
 
 namespace imp {
 
@@ -18,20 +19,6 @@ TensorID WeightRegistry::reserve(TensorKind kind, int64_t rows, int64_t cols) {
     std::memset(&h.payload, 0, sizeof(h.payload));
     handles_.push_back(h);
     return id;
-}
-
-WeightHandle& WeightRegistry::handle(TensorID id) {
-    if (id < 0 || id >= static_cast<TensorID>(handles_.size())) {
-        IMP_LOG_FATAL("WeightRegistry::handle: id %d out of range [0, %zu)", id, handles_.size());
-    }
-    return handles_[id];
-}
-
-const WeightHandle& WeightRegistry::handle(TensorID id) const {
-    if (id < 0 || id >= static_cast<TensorID>(handles_.size())) {
-        IMP_LOG_FATAL("WeightRegistry::handle: id %d out of range [0, %zu)", id, handles_.size());
-    }
-    return handles_[id];
 }
 
 void WeightRegistry::clear() { handles_.clear(); }
@@ -85,7 +72,7 @@ size_t WeightRegistry::free_owned_storage(VRAMAllocator* alloc) {
                     "WeightRegistry::free_owned_storage: handle id=%d "
                     "kind=%d tier=%d has owned_bytes=%lld but no "
                     "type-specific free is wired; skipping.",
-                    h.id, static_cast<int>(h.kind), static_cast<int>(h.primary_tier),
+                    h.id, std::to_underlying(h.kind), std::to_underlying(h.primary_tier),
                     static_cast<long long>(h.owned_bytes));
                 break;
         }

--- a/src/exec/weight_handle.h
+++ b/src/exec/weight_handle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/logging.h"
 #include "core/qtype.h"
 #include "core/tensor_kind.h"
 #include "core/storage_tier.h"
@@ -109,8 +110,15 @@ class VRAMAllocator;
 class WeightRegistry {
 public:
     TensorID reserve(TensorKind kind, int64_t rows, int64_t cols);
-    WeightHandle& handle(TensorID id);
-    const WeightHandle& handle(TensorID id) const;
+
+    // C++23 deducing this: one overload serves const and non-const callers.
+    template <typename Self>
+    auto&& handle(this Self&& self, TensorID id) {
+        if (id < 0 || id >= static_cast<TensorID>(self.handles_.size())) {
+            IMP_LOG_FATAL("WeightRegistry::handle: id %d out of range [0, %zu)", id, self.handles_.size());
+        }
+        return self.handles_[id];
+    }
     size_t size() const { return handles_.size(); }
 
     void clear();

--- a/src/lora/lora_adapter.cpp
+++ b/src/lora/lora_adapter.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <utility>
 
 namespace imp {
 
@@ -211,7 +212,7 @@ bool LoraAdapter::load(const std::string& path, int n_layers) {
         }
         device_allocs_.push_back(dev);
 
-        LoraWeights& w = layers_[layer].proj[static_cast<int>(proj)];
+        LoraWeights& w = layers_[layer].proj[std::to_underlying(proj)];
         if (is_A) {
             w.A = dev;
             w.r = static_cast<int>(shape[0]);
@@ -227,7 +228,7 @@ bool LoraAdapter::load(const std::string& path, int n_layers) {
 
     // Validate pairs + collect max rank.
     for (size_t li = 0; li < layers_.size(); li++) {
-        for (int pi = 0; pi < static_cast<int>(LoraProj::COUNT); pi++) {
+        for (int pi = 0; pi < std::to_underlying(LoraProj::COUNT); pi++) {
             LoraWeights& w = layers_[li].proj[pi];
             if ((w.A == nullptr) != (w.B == nullptr)) {
                 IMP_LOG_ERROR("LoRA: layer %zu proj %d has unpaired A/B", li, pi);

--- a/src/lora/lora_adapter.h
+++ b/src/lora/lora_adapter.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -59,7 +60,7 @@ public:
 
 private:
     struct LayerSlots {
-        LoraWeights proj[static_cast<int>(LoraProj::COUNT)];
+        LoraWeights proj[std::to_underlying(LoraProj::COUNT)];
     };
     std::vector<LayerSlots> layers_;
     std::vector<void*> device_allocs_;

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <utility>
 
 namespace imp {
 
@@ -932,7 +933,7 @@ int KVCacheManager::save_prefix_cache(const std::string& path, uint64_t model_fi
     hdr.n_layers = static_cast<uint32_t>(nl);
     hdr.n_kv_heads = static_cast<uint32_t>(cache_->n_kv_heads());
     hdr.head_dim = static_cast<uint32_t>(cache_->head_dim());
-    hdr.dtype = static_cast<uint32_t>(cache_->qtype());
+    hdr.dtype = std::to_underlying(cache_->qtype());
     hdr.block_bytes = bb;
     hdr.model_fingerprint = model_fingerprint;
 
@@ -1055,12 +1056,12 @@ int KVCacheManager::load_prefix_cache(const std::string& path, uint64_t model_fi
     if (hdr.n_layers != static_cast<uint32_t>(cache_->n_layers()) ||
         hdr.n_kv_heads != static_cast<uint32_t>(cache_->n_kv_heads()) ||
         hdr.head_dim != static_cast<uint32_t>(cache_->head_dim()) ||
-        hdr.dtype != static_cast<uint32_t>(cache_->qtype()) || hdr.block_bytes != cache_->block_bytes()) {
+        hdr.dtype != std::to_underlying(cache_->qtype()) || hdr.block_bytes != cache_->block_bytes()) {
         IMP_LOG_WARN(
             "Prefix cache: config mismatch (layers=%u/%d, heads=%u/%d, "
             "dim=%u/%d, dtype=%u/%d)",
             hdr.n_layers, cache_->n_layers(), hdr.n_kv_heads, cache_->n_kv_heads(), hdr.head_dim,
-            cache_->head_dim(), hdr.dtype, static_cast<int>(cache_->qtype()));
+            cache_->head_dim(), hdr.dtype, std::to_underlying(cache_->qtype()));
         fclose(f);
         return -1;
     }

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -38,6 +38,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -967,7 +968,7 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
                 case QType::Q8_0:
                     return scale_q8_0(t);
                 default:
-                    IMP_LOG_ERROR("gpt-oss GGUF rescale: unsupported qtype %d", (int)t.qtype);
+                    IMP_LOG_ERROR("gpt-oss GGUF rescale: unsupported qtype %d", std::to_underlying(t.qtype));
                     return false;
             }
         };

--- a/src/model/gguf_tensor_assign.cpp
+++ b/src/model/gguf_tensor_assign.cpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -31,7 +32,7 @@ static std::vector<std::string> split(const std::string& s, char delim) {
 // ---- Assign a single tensor to the model by GGUF name ----
 
 bool assign_tensor(Model& model, const std::string& name, const Tensor& tensor, GgufWireType gtype) {
-    auto qtype = static_cast<QType>(static_cast<uint32_t>(gtype));
+    auto qtype = static_cast<QType>(std::to_underlying(gtype));
     if (name == "token_embd.weight") {
         assign_quant(model.tok_emb_, tensor);
         return true;

--- a/src/model/jinja.cpp
+++ b/src/model/jinja.cpp
@@ -13,6 +13,7 @@
 #include <ctime>
 #include <sstream>
 #include <unordered_map>
+#include <utility>
 
 namespace imp::jinja {
 
@@ -808,8 +809,8 @@ private:
 
     void expect(TokenType t) {
         if (!check(t)) {
-            IMP_LOG_WARN("jinja: expected token type %d, got %d ('%s')", static_cast<int>(t),
-                         static_cast<int>(peek().type), peek().value.c_str());
+            IMP_LOG_WARN("jinja: expected token type %d, got %d ('%s')", std::to_underlying(t),
+                         std::to_underlying(peek().type), peek().value.c_str());
         }
         advance();
     }

--- a/src/model/jinja.h
+++ b/src/model/jinja.h
@@ -65,8 +65,11 @@ public:
     double as_double() const { return std::get<double>(data_); }
     const std::string& as_string() const { return std::get<std::string>(data_); }
     const Array& as_array() const { return std::get<Array>(data_); }
-    const Object& as_object() const { return std::get<Object>(data_); }
-    Object& as_object() { return std::get<Object>(data_); }
+    // C++23 deducing this: one overload serves const and non-const callers.
+    template <typename Self>
+    auto&& as_object(this Self&& self) {
+        return std::get<Object>(self.data_);
+    }
 
     // Truthiness (Python/Jinja2 rules)
     bool truthy() const;

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -31,8 +31,11 @@ public:
     // generation_config.json (SafeTensors only; empty for GGUF). Sentinel
     // values (<0) mean the field was not present.
     const HFConfigLoader::GenerationConfig& generation_config() const { return generation_config_; }
-    const TransformerLayer& layer(int i) const { return layers_[i]; }
-    TransformerLayer& layer(int i) { return layers_[i]; }
+    // C++23 deducing this: one overload serves const and non-const callers.
+    template <typename Self>
+    auto&& layer(this Self&& self, int i) {
+        return self.layers_[i];
+    }
     const Tensor& token_embedding() const { return tok_emb_; }
     const Tensor& output_norm() const { return out_norm_; }
     const Tensor& output_proj() const { return out_proj_; }

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -24,6 +24,7 @@
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include <utility>
 
 namespace imp {
 
@@ -1478,7 +1479,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             if (!t.data || t.on_device)
                 return true;
             if (t.qtype != QType::BF16) {
-                IMP_LOG_ERROR("gpt-oss rescale: expected BF16, got qtype %d", (int)t.qtype);
+                IMP_LOG_ERROR("gpt-oss rescale: expected BF16, got qtype %d", std::to_underlying(t.qtype));
                 return false;
             }
             int64_t n = t.numel();

--- a/src/model/tensor_kind_table.cu
+++ b/src/model/tensor_kind_table.cu
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cassert>
+#include <utility>
 
 namespace imp {
 
@@ -20,58 +21,58 @@ constexpr TierMask FP16_OR_FP32 = mask(StorageTier::FP16) | mask(StorageTier::FP
 
 constexpr KindCapabilities build(TierMask s, StorageTier f, bool fus = false) { return {s, f, fus}; }
 
-constexpr std::array<KindCapabilities, static_cast<size_t>(TensorKind::COUNT)> kKindTable = [] {
-    std::array<KindCapabilities, static_cast<size_t>(TensorKind::COUNT)> t{};
-    t[(size_t)TensorKind::UNKNOWN] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::WQ] = build(ALL_QUANT, StorageTier::NVFP4);
-    t[(size_t)TensorKind::WK] = build(ALL_QUANT, StorageTier::FP8, true);
-    t[(size_t)TensorKind::WV] = build(ALL_QUANT, StorageTier::FP8, true);
-    t[(size_t)TensorKind::WO] = build(ALL_QUANT, StorageTier::NVFP4);
-    t[(size_t)TensorKind::QKV_FUSED] = build(NO_MXFP4, StorageTier::FP8);
+constexpr std::array<KindCapabilities, std::to_underlying(TensorKind::COUNT)> kKindTable = [] {
+    std::array<KindCapabilities, std::to_underlying(TensorKind::COUNT)> t{};
+    t[std::to_underlying(TensorKind::UNKNOWN)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::WQ)] = build(ALL_QUANT, StorageTier::NVFP4);
+    t[std::to_underlying(TensorKind::WK)] = build(ALL_QUANT, StorageTier::FP8, true);
+    t[std::to_underlying(TensorKind::WV)] = build(ALL_QUANT, StorageTier::FP8, true);
+    t[std::to_underlying(TensorKind::WO)] = build(ALL_QUANT, StorageTier::NVFP4);
+    t[std::to_underlying(TensorKind::QKV_FUSED)] = build(NO_MXFP4, StorageTier::FP8);
     // MLA (DeepSeek-V2/V3) latent projections.
     // kv_a_proj is precision-sensitive (latent down-proj) → no aggressive FP4 default.
-    t[(size_t)TensorKind::KV_A_PROJ] = build(NO_MXFP4, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::KV_A_PROJ)] = build(NO_MXFP4, StorageTier::FP16);
     // kv_a_layernorm is an RMSNorm weight → never quantized.
-    t[(size_t)TensorKind::KV_A_NORM] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::KV_A_NORM)] = build(FP32_ONLY, StorageTier::FP32);
     // kv_b_proj is a standard up-proj → mirror WO.
-    t[(size_t)TensorKind::KV_B_PROJ] = build(ALL_QUANT, StorageTier::NVFP4);
-    t[(size_t)TensorKind::W_GATE] = build(ALL_QUANT, StorageTier::NVFP4, true);
-    t[(size_t)TensorKind::W_UP] = build(ALL_QUANT, StorageTier::NVFP4, true);
-    t[(size_t)TensorKind::W_DOWN] = build(ALL_QUANT, StorageTier::NVFP4);
-    t[(size_t)TensorKind::EXPERT_GATE] = build(ALL_QUANT, StorageTier::NVFP4, true);
-    t[(size_t)TensorKind::EXPERT_UP] = build(ALL_QUANT, StorageTier::NVFP4, true);
-    t[(size_t)TensorKind::EXPERT_DOWN] = build(ALL_QUANT, StorageTier::NVFP4);
-    t[(size_t)TensorKind::FUSED_KV] = build(NO_MXFP4, StorageTier::FP8);
-    t[(size_t)TensorKind::FUSED_GATE_UP] = build(ALL_QUANT, StorageTier::NVFP4);
-    t[(size_t)TensorKind::TOK_EMBED] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::LM_HEAD] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::ROUTER] = build(FP16_OR_FP32, StorageTier::FP32);
-    t[(size_t)TensorKind::SHARED_EXPERT_GATE] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::SSM_IN] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::SSM_OUT] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::CONV1D_W] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::CONV1D_B] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::A_LOG] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::DT_BIAS] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::BETA] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::ALPHA] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::SSM_GROUP_NORM] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::GDN_GATE] = build(ALL_QUANT, StorageTier::NVFP4);
-    t[(size_t)TensorKind::GDN_ALPHA] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::GDN_BETA] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::GDN_ALPHA_BETA_PACKED] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::GDN_INPUT_PACKED] = build(FP16_ONLY, StorageTier::FP16);
-    t[(size_t)TensorKind::ATTN_NORM] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::FFN_NORM] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::POST_ATTN_NORM] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::POST_FFN_NORM] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::QK_NORM_Q] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::QK_NORM_K] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::ROPE_FREQS] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::SIGLIP_ATTN] = build(NO_MXFP4, StorageTier::FP16);
-    t[(size_t)TensorKind::SIGLIP_FFN] = build(NO_MXFP4, StorageTier::FP16);
-    t[(size_t)TensorKind::SIGLIP_NORM] = build(FP32_ONLY, StorageTier::FP32);
-    t[(size_t)TensorKind::MM_PROJ] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::KV_B_PROJ)] = build(ALL_QUANT, StorageTier::NVFP4);
+    t[std::to_underlying(TensorKind::W_GATE)] = build(ALL_QUANT, StorageTier::NVFP4, true);
+    t[std::to_underlying(TensorKind::W_UP)] = build(ALL_QUANT, StorageTier::NVFP4, true);
+    t[std::to_underlying(TensorKind::W_DOWN)] = build(ALL_QUANT, StorageTier::NVFP4);
+    t[std::to_underlying(TensorKind::EXPERT_GATE)] = build(ALL_QUANT, StorageTier::NVFP4, true);
+    t[std::to_underlying(TensorKind::EXPERT_UP)] = build(ALL_QUANT, StorageTier::NVFP4, true);
+    t[std::to_underlying(TensorKind::EXPERT_DOWN)] = build(ALL_QUANT, StorageTier::NVFP4);
+    t[std::to_underlying(TensorKind::FUSED_KV)] = build(NO_MXFP4, StorageTier::FP8);
+    t[std::to_underlying(TensorKind::FUSED_GATE_UP)] = build(ALL_QUANT, StorageTier::NVFP4);
+    t[std::to_underlying(TensorKind::TOK_EMBED)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::LM_HEAD)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::ROUTER)] = build(FP16_OR_FP32, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::SHARED_EXPERT_GATE)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::SSM_IN)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::SSM_OUT)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::CONV1D_W)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::CONV1D_B)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::A_LOG)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::DT_BIAS)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::BETA)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::ALPHA)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::SSM_GROUP_NORM)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::GDN_GATE)] = build(ALL_QUANT, StorageTier::NVFP4);
+    t[std::to_underlying(TensorKind::GDN_ALPHA)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::GDN_BETA)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::GDN_ALPHA_BETA_PACKED)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::GDN_INPUT_PACKED)] = build(FP16_ONLY, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::ATTN_NORM)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::FFN_NORM)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::POST_ATTN_NORM)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::POST_FFN_NORM)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::QK_NORM_Q)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::QK_NORM_K)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::ROPE_FREQS)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::SIGLIP_ATTN)] = build(NO_MXFP4, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::SIGLIP_FFN)] = build(NO_MXFP4, StorageTier::FP16);
+    t[std::to_underlying(TensorKind::SIGLIP_NORM)] = build(FP32_ONLY, StorageTier::FP32);
+    t[std::to_underlying(TensorKind::MM_PROJ)] = build(FP16_ONLY, StorageTier::FP16);
     return t;
 }();
 

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -16,6 +16,7 @@
 #ifdef __linux__
 #include <fstream>
 #include <string>
+#include <utility>
 #endif
 
 namespace imp {
@@ -701,7 +702,7 @@ static bool upload_qtype_raw_fallback_(Tensor& weight, QType qtype, cudaStream_t
                                        std::vector<void*>& gpu_allocs) {
     size_t bytes = weight.nbytes();
     if (bytes == 0) {
-        IMP_LOG_WARN("Empty raw weight for qtype %u, skipping", static_cast<unsigned>(qtype));
+        IMP_LOG_WARN("Empty raw weight for qtype %u, skipping", std::to_underlying(qtype));
         return false;
     }
     void* d_data = nullptr;
@@ -1328,7 +1329,7 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i, const UploadCtx
             }
         } else {
             IMP_LOG_ERROR("SSM scalar tensor has unexpected qtype %u (layer %d)",
-                          static_cast<unsigned>(t->qtype), i);
+                          std::to_underlying(t->qtype), i);
             return false;
         }
 

--- a/src/quant/dequant_gpu.cu
+++ b/src/quant/dequant_gpu.cu
@@ -3,6 +3,7 @@
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 #include <cstdio>
+#include <utility>
 
 namespace imp {
 
@@ -844,7 +845,7 @@ void dequant_gpu_fp8(const void* src, void* dst, QType qtype, int rows, int cols
             break;
         }
         default:
-            IMP_LOG_ERROR("dequant_gpu_fp8: unsupported qtype %u", static_cast<unsigned>(qtype));
+            IMP_LOG_ERROR("dequant_gpu_fp8: unsupported qtype %u", std::to_underlying(qtype));
             break;
     }
 }
@@ -892,7 +893,7 @@ void dequant_gpu(const void* src, void* dst, QType qtype, int rows, int cols, cu
             DEQUANT_CASE(IQ4_XS, dequant_iq4_xs_kernel)
 
         default:
-            IMP_LOG_ERROR("dequant_gpu: unsupported qtype %u", static_cast<unsigned>(qtype));
+            IMP_LOG_ERROR("dequant_gpu: unsupported qtype %u", std::to_underlying(qtype));
             break;
     }
 }

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <mutex>
 #include <stdexcept>
+#include <utility>
 
 namespace imp {
 
@@ -89,8 +90,8 @@ void gemv_nvfp4(const NvFP4QuantResult& A, const Tensor& x, Tensor& y, cudaStrea
     IMP_CHECK(A.packed_data != nullptr, "gemv_nvfp4: A.packed_data is null");
     IMP_CHECK(x.on_device, "gemv_nvfp4: x must be on device");
     IMP_CHECK(y.on_device, "gemv_nvfp4: y must be on device");
-    IMP_CHECK(x.qtype == QType::F16, "gemv_nvfp4: x must be FP16, got qtype=%d", static_cast<int>(x.qtype));
-    IMP_CHECK(y.qtype == QType::F16, "gemv_nvfp4: y must be FP16, got qtype=%d", static_cast<int>(y.qtype));
+    IMP_CHECK(x.qtype == QType::F16, "gemv_nvfp4: x must be FP16, got qtype=%d", std::to_underlying(x.qtype));
+    IMP_CHECK(y.qtype == QType::F16, "gemv_nvfp4: y must be FP16, got qtype=%d", std::to_underlying(y.qtype));
 
     int M = static_cast<int>(A.N);
     int K = static_cast<int>(A.K);

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <cfloat>
 #include <cmath>
+#include <utility>
 
 namespace imp {
 
@@ -379,7 +380,7 @@ __global__ void dequantize_nvfp4_kernel(const uint8_t* __restrict__ packed_data,
 float calibrate_nvfp4_scales(const Tensor& input, cudaStream_t stream, float* d_reusable_max) {
     IMP_CHECK(input.on_device, "calibrate_nvfp4_scales: input must be on device");
     IMP_CHECK(input.qtype == QType::F16, "calibrate_nvfp4_scales: input must be FP16, got qtype=%d",
-              static_cast<int>(input.qtype));
+              std::to_underlying(input.qtype));
 
     int64_t n_elements = input.numel();
 
@@ -421,7 +422,7 @@ float calibrate_nvfp4_scales(const Tensor& input, cudaStream_t stream, float* d_
 void quantize_fp16_to_nvfp4(const Tensor& input, NvFP4QuantResult& result, cudaStream_t stream) {
     IMP_CHECK(input.on_device, "quantize_fp16_to_nvfp4: input must be on device");
     IMP_CHECK(input.qtype == QType::F16, "quantize_fp16_to_nvfp4: input must be FP16, got qtype=%d",
-              static_cast<int>(input.qtype));
+              std::to_underlying(input.qtype));
     IMP_CHECK(input.ndim == 2, "quantize_fp16_to_nvfp4: input must be 2D [N, K], got ndim=%d", input.ndim);
 
     int64_t N = input.shape[0];
@@ -466,7 +467,7 @@ void quantize_fp16_to_nvfp4_async(const Tensor& input, NvFP4QuantResult& result,
                                   float* d_tensor_scale_buf, cudaStream_t stream) {
     IMP_CHECK(input.on_device, "quantize_fp16_to_nvfp4_async: input must be on device");
     IMP_CHECK(input.qtype == QType::F16, "quantize_fp16_to_nvfp4_async: input must be FP16, got qtype=%d",
-              static_cast<int>(input.qtype));
+              std::to_underlying(input.qtype));
     IMP_CHECK(input.ndim == 2, "quantize_fp16_to_nvfp4_async: input must be 2D [N, K], got ndim=%d",
               input.ndim);
 

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -1,4 +1,5 @@
 #include "runtime/constraint_manager.h"
+#include <utility>
 
 namespace imp {
 
@@ -119,7 +120,7 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
             // no char fallback — degrade to current "drop schema" behaviour.
             IMP_LOG_INFO(
                 "ConstraintManager: no tool-tag dialect for family %d, dropping schema/json_mode",
-                static_cast<int>(tpl_family));
+                std::to_underlying(tpl_family));
             return;
         }
     }

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <memory>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -39,7 +40,7 @@ uint64_t Engine::model_fingerprint_() const {
     uint64_t h = 0xcbf29ce484222325ULL;
     const auto& c = model_->config();
     const uint32_t ids[] = {
-        static_cast<uint32_t>(c.arch),    static_cast<uint32_t>(c.n_layers),
+        std::to_underlying(c.arch),    static_cast<uint32_t>(c.n_layers),
         static_cast<uint32_t>(c.n_heads), static_cast<uint32_t>(c.n_kv_heads),
         static_cast<uint32_t>(c.d_model), static_cast<uint32_t>(c.d_ff),
         static_cast<uint32_t>(c.vocab_size), static_cast<uint32_t>(c.head_dim),

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -38,6 +38,7 @@
 #include <chrono>
 #include <thread>
 #include <vector>
+#include <utility>
 
 namespace imp {
 
@@ -306,8 +307,8 @@ int Engine::resolve_prefill_chunk_size_() const {
     if (!supports_chunked_prefill_()) {
         IMP_LOG_WARN(
             "prefill_chunk_size=%d ignored: arch=%d / kv_dtype=%d not in chunked-prefill scope; using 0",
-            explicit_val, (int)model_->config().arch,
-            kv_cache_raw_ ? (int)kv_cache_raw_->qtype() : -1);
+            explicit_val, std::to_underlying(model_->config().arch),
+            kv_cache_raw_ ? std::to_underlying(kv_cache_raw_->qtype()) : -1);
         return 0;
     }
     return explicit_val;

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <utility>
 
 namespace imp {
 
@@ -47,7 +48,7 @@ bool Engine::init_weights() {
                 IMP_LOG_WARN(
                     "StreamingLLM smart KV cache requires FP16 KV cache "
                     "(requested %d) — disabling streaming.",
-                    static_cast<int>(config_.kv_cache_dtype));
+                    std::to_underlying(config_.kv_cache_dtype));
                 config_.streaming_kv_enabled = false;
             } else {
                 int n_sinks = (config_.streaming_kv_n_sinks > 0) ? config_.streaming_kv_n_sinks : 4;

--- a/src/runtime/storage_planner.cpp
+++ b/src/runtime/storage_planner.cpp
@@ -5,6 +5,7 @@
 #include "core/tensor.h"
 
 #include <algorithm>
+#include <utility>
 
 namespace imp {
 
@@ -64,7 +65,7 @@ StorageTier pick_initial_tier(TensorKind kind, const KindCapabilities& cap, cons
 // StorageTier enum order: FP32=1, FP16=2, FP8=3, NVFP4=4, CUTLASS_NVFP4=5, MXFP4=6
 // Higher integer = more compressed, so "downgrade" = increase enum value.
 StorageTier downgrade_one(StorageTier current, StorageTier floor, const KindCapabilities& cap) {
-    for (int s = static_cast<int>(current) + 1; s <= static_cast<int>(StorageTier::MXFP4); ++s) {
+    for (int s = std::to_underlying(current) + 1; s <= std::to_underlying(StorageTier::MXFP4); ++s) {
         auto candidate = static_cast<StorageTier>(s);
         if (!mask_contains(cap.supported, candidate))
             continue;

--- a/src/vision/vision_loader.cpp
+++ b/src/vision/vision_loader.cpp
@@ -15,6 +15,7 @@
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <utility>
 
 namespace imp {
 
@@ -240,7 +241,7 @@ bool upload_tensor_fp16(const void* src, GgufWireType type, int64_t n_elements, 
         }
         IMP_CUDA_CHECK_LOG(cudaMemcpy(d_ptr, h_fp16.data(), fp16_bytes, cudaMemcpyHostToDevice));
     } else {
-        IMP_LOG_ERROR("Vision: unsupported GGML type %u for tensor upload", static_cast<uint32_t>(type));
+        IMP_LOG_ERROR("Vision: unsupported GGML type %u for tensor upload", std::to_underlying(type));
         return false;
     }
 
@@ -273,7 +274,7 @@ bool upload_tensor_fp16_transposed(const void* src, GgufWireType type, int64_t r
         }
     } else {
         IMP_LOG_ERROR("Vision: unsupported GGML type %u for transposed upload",
-                      static_cast<uint32_t>(type));
+                      std::to_underlying(type));
         return false;
     }
 


### PR DESCRIPTION
## What

Broad, behavior-neutral C++23 idiom sweep now that the tree builds as C++23 (#916). No functional change — identical values, same accessors, same functors.

**`std::to_underlying`** — ~67 real enum-to-underlying cast sites across 34 files, replacing `static_cast<int/unsigned/size_t/uint32_t>(enum)` and C-style `(int)enum`; each touched TU gains `#include <utility>`. `to_underlying` is a hard compile error on non-enums, so the build itself confirms every site is a genuine enum and the integer value is identical to the prior cast. (Non-enum `static_cast`s — shapes, offsets, indices, `cublasStatus_t`, `bool` — were left untouched.)

**`deducing this`** — collapses four duplicated const/non-const accessor pairs into one overload each:
- `Model::layer`, `SchemaConstrain::top`, jinja `Value::as_object`
- `WeightRegistry::handle` (out-of-line defs moved into a header template)

**`static operator()`** — six stateless functors:
- host hash functors `ExpertCacheKeyHash`, `GemmCacheKeyHash`
- four `__device__` activation functors in `gemm_dp4a.cu` (Identity / SwiGLU / GeGLU / ReLU²)

## Why

Adopt the C++23 idioms that actually fit this codebase after the C++23 toolchain migration. `std::expected` / `std::mdspan` / `std::print` were deliberately **not** adopted — they conflict with the throw-based error model and device-side (nvcc) code. `std::byteswap` had zero real sites (loaders read little-endian on x86).

## Verification (no GPU runner in CI — done locally)

- Build clean (full `make build`).
- Unit tests green; GPU `test-quant` (189), `test-core` (455), `test-e2e` (97) all pass, 0 failures.
- Qwen3-14B-NVFP4 decode coherent at ~171 tok/s — no regression, no degeneration.

Not a perf-moving change, so `tests/perf_baseline.json` is unchanged.
