### PR TITLE
feat(kv): SWA-aware KV sizing for sliding-window layers

### DIFF
--- a/imp.conf.example
+++ b/imp.conf.example
@@ -96,6 +96,14 @@ bitdecoding_qk              = false
 # BitDecoding residual FP16 cache for the newest N tokens (0 = disabled;
 # typical 4..32; only with dtype = "nvfp4" + bitdecoding_qk).
 bitdecoding_residual_tokens = 0
+# SWA-aware KV sizing: sliding-window layers (gpt-oss window=128 on every
+# other layer, gemma-3 5:1 pattern) allocate only the trailing window in a
+# small dedicated block group instead of full-length KV — ~2x more KV tokens
+# on gpt-oss, ~5-6x on gemma-3. Auto-disabled (logged) for models without
+# SWA layers, INT8/INT4 KV, hybrids, MLA, StreamingLLM, green contexts, and
+# deterministic mode; prefix caching is forced off while active (freed
+# window blocks can't back prefix reuse). Default off until validated.
+swa_sizing                  = false
 
 [rope]
 # Runtime RoPE-scaling override: stretch a model's usable context past its

--- a/src/compute/kv_gather.cu
+++ b/src/compute/kv_gather.cu
@@ -48,10 +48,20 @@ __global__ void paged_kv_gather_fp16_kernel(half* __restrict__ dst, const half* 
     const int kv_block_stride = block_size * nkv * hd;
     const int kv_slot_stride = nkv * hd;
 
+    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
+    if (phys_block < 0) {
+        // -1 sentinel: SWA trailing-free hole (kv_cache.swa_sizing) or
+        // StreamingLLM-evicted block. Rows this far back are never consumed
+        // (the chunk attention kernels skip pre-window tiles) — zero-fill so
+        // the gathered buffer stays deterministic and NaN-free.
+        for (int d = d_lane; d < hd; d += threads_per_token)
+            dst_row[d] = __float2half(0.0f);
+        return;
+    }
+
     const half* src_row = src + (size_t)phys_block * kv_block_stride
                               + (size_t)slot * kv_slot_stride
                               + (size_t)kv_head * hd;
-    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
 
     for (int d = d_lane; d < hd; d += threads_per_token) {
         // Streaming load (skip L1, evict-first from L2) so KV bytes don't pollute
@@ -87,10 +97,18 @@ __global__ void paged_kv_gather_fp8_to_fp16_kernel(half* __restrict__ dst,
     const int kv_block_stride = block_size * nkv * hd;
     const int kv_slot_stride = nkv * hd;
 
+    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
+    if (phys_block < 0) {
+        // -1 sentinel: SWA trailing-free / StreamingLLM hole — zero-fill (see
+        // paged_kv_gather_fp16_kernel).
+        for (int d = d_lane; d < hd; d += threads_per_token)
+            dst_row[d] = __float2half(0.0f);
+        return;
+    }
+
     const __nv_fp8_e4m3* src_row = src + (size_t)phys_block * kv_block_stride
                                        + (size_t)slot * kv_slot_stride
                                        + (size_t)kv_head * hd;
-    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
 
     for (int d = d_lane; d < hd; d += threads_per_token) {
         // Streaming load via __ldcs on uint8 (FP8 is 1 byte).
@@ -163,13 +181,21 @@ __global__ void paged_kv_gather_nvfp4_to_fp16_kernel(
     const int sc_block_stride = block_size * nkv * (hd / kGroup);
     const int sc_slot_stride = nkv * (hd / kGroup);
 
+    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
+    if (phys_block < 0) {
+        // -1 sentinel: SWA trailing-free / StreamingLLM hole — zero-fill (see
+        // paged_kv_gather_fp16_kernel).
+        for (int d = d_lane; d < hd; d += threads_per_token)
+            dst_row[d] = __float2half(0.0f);
+        return;
+    }
+
     const uint8_t* src_row = src_packed + (size_t)phys_block * kv_block_stride_bytes
                                         + (size_t)slot * kv_slot_stride_bytes
                                         + (size_t)kv_head * (hd / 2);
     const uint8_t* sc_row = src_scales + (size_t)phys_block * sc_block_stride
                                        + (size_t)slot * sc_slot_stride
                                        + (size_t)kv_head * (hd / kGroup);
-    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
 
     for (int d = d_lane; d < hd; d += threads_per_token) {
         // FP4 nibble decode: PTX cvt produces a half2 from two packed nibbles.
@@ -240,13 +266,21 @@ __global__ void paged_kv_gather_mxfp4_kv_to_fp16_kernel(
     const int sc_block_stride = block_size * nkv * (hd / kGroup);
     const int sc_slot_stride = nkv * (hd / kGroup);
 
+    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
+    if (phys_block < 0) {
+        // -1 sentinel: SWA trailing-free / StreamingLLM hole — zero-fill (see
+        // paged_kv_gather_fp16_kernel).
+        for (int d = d_lane; d < hd; d += threads_per_token)
+            dst_row[d] = __float2half(0.0f);
+        return;
+    }
+
     const uint8_t* src_row = src_packed + (size_t)phys_block * kv_block_stride_bytes
                                         + (size_t)slot * kv_slot_stride_bytes
                                         + (size_t)kv_head * (hd / 2);
     const uint8_t* sc_row = src_scales + (size_t)phys_block * sc_block_stride
                                        + (size_t)slot * sc_slot_stride
                                        + (size_t)kv_head * (hd / kGroup);
-    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
 
     for (int d = d_lane; d < hd; d += threads_per_token) {
         // FP4 nibble decode: same as NVFP4 (E2M1 format identical)
@@ -313,6 +347,18 @@ __global__ void paged_kv_gather_int4_to_fp16_kernel(
     const int sc_block_stride = block_size * nkv;
     const int sc_slot_stride = nkv;
 
+    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
+    if (phys_block < 0) {
+        // -1 sentinel: SWA trailing-free / StreamingLLM hole — zero-fill (see
+        // paged_kv_gather_fp16_kernel).
+        for (int d = d_lane * 2; d < hd; d += threads_per_token * 2) {
+            dst_row[d] = __float2half(0.0f);
+            if (d + 1 < hd)
+                dst_row[d + 1] = __float2half(0.0f);
+        }
+        return;
+    }
+
     const uint8_t* src_row = src_packed + (size_t)phys_block * kv_block_stride_bytes
                                         + (size_t)slot * kv_slot_stride_bytes
                                         + (size_t)kv_head * (hd / 2);
@@ -320,7 +366,6 @@ __global__ void paged_kv_gather_int4_to_fp16_kernel(
                               + (size_t)slot * sc_slot_stride
                               + (size_t)kv_head];
     float scale = __half2float(scale_h);
-    half* dst_row = dst + (size_t)pos * nkv * hd + (size_t)kv_head * hd;
 
     // Each lane writes 2 FP16 values per byte read. We iterate in steps of 2
     // along head_dim so each thread handles one packed byte.

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -239,10 +239,12 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     }
 
 
-    // Per-layer RoPE theta and sliding window (Gemma-3: alternating local/global layers)
+    // Per-layer RoPE theta and sliding window (Gemma-3: alternating local/global layers).
+    // The window decision itself is centralized in layer_swa_window() (shared with
+    // the SWA-aware KV sizing); this block only resolves the per-layer RoPE params.
     float layer_rope_theta = cfg.rope_theta;
     float layer_rope_freq_scale = cfg.rope_freq_scale;
-    int layer_sliding_window = cfg.sliding_window;
+    int layer_sliding_window = layer_swa_window(cfg, prof, layer);
     // StreamingLLM: only meaningful when this layer also has a sliding window
     // (otherwise full attention covers the full context anyway). Resolved
     // again per-layer below in case Gemma-3 disables SWA on this layer.
@@ -253,24 +255,15 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         if (is_swa) {
             layer_rope_theta = (cfg.rope_theta_swa > 0.0f) ? cfg.rope_theta_swa : cfg.rope_local_theta;
             layer_rope_freq_scale = 1.0f;
-            // layer_sliding_window stays at cfg.sliding_window (1024)
-        } else {
-            // Global layer: full attention, model rope_theta, with freq scaling
-            layer_sliding_window = 0;
         }
+        // Global layer: full attention, model rope_theta, with freq scaling.
     } else if (prof.attn_variant == AttnVariant::GPTOSS_SWA) {
         // gpt-oss (#547): even layers sliding_attention (window 128), odd
         // layers full attention. Same RoPE (YaRN) on both layer types —
         // only the window toggles.
-        bool is_swa = (layer < (int)cfg.swa_layers.size() && cfg.swa_layers[layer]);
-        if (!is_swa)
-            layer_sliding_window = 0;
     } else if (cfg.sliding_window_pattern > 0) {
         bool is_global = (layer % cfg.sliding_window_pattern) == (cfg.sliding_window_pattern - 1);
-        if (is_global) {
-            // Global layer: full attention, model-level rope_theta, with freq scaling
-            layer_sliding_window = 0;
-        } else {
+        if (!is_global) {
             // Local layer: sliding window, local rope_theta, no freq scaling
             if (cfg.rope_local_theta > 0.0f)
                 layer_rope_theta = cfg.rope_local_theta;
@@ -282,6 +275,14 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
         layer_sliding_window = streaming_window_;
     if (layer_sliding_window <= 0)
         layer_n_sinks = 0;
+
+    // SWA-aware KV sizing (kv_cache.swa_sizing): windowed layers read/write
+    // the small SWA block group through the parallel table (-1 holes outside
+    // the trailing window — the kernels' window mask never reaches them).
+    // nullptr table = feature off → every layer shares state.block_tables.
+    const int* layer_block_tables =
+        (state.block_tables_swa != nullptr && layer_sliding_window > 0) ? state.block_tables_swa
+                                                                        : state.block_tables;
 
     // Select LongRoPE frequency table based on context length (nullptr if not longrope)
     const float* longrope_freqs = nullptr;

--- a/src/exec/executor_attention_decode.cu
+++ b/src/exec/executor_attention_decode.cu
@@ -53,7 +53,7 @@
             dim3 fused_grid(n, 2);
             write_kv_cache_rope_fused_kernel<<<fused_grid, threads, 0, stream>>>(
                 static_cast<const half*>(kv_view.data), static_cast<const half*>(vv_view.data),
-                state.positions, state.block_tables, static_cast<half*>(cache->k_ptr(kv_layer, 0)),
+                state.positions, layer_block_tables, static_cast<half*>(cache->k_ptr(kv_layer, 0)),
                 static_cast<half*>(cache->v_ptr(kv_layer, 0)), block_stride, row_elems, kv_block_size_d, n,
                 state.max_blocks_per_seq, state.n_sequences, nkv, hd, layer_rope_theta, inv_scaling, pairs,
                 cfg.rope_neox, longrope_freqs);
@@ -81,10 +81,16 @@
             // Heap-sized to n_blocks — a fixed [1024] stack array overran 4x at
             // the 64K context cap (n_blocks=4096) and silently smashed the frame.
             std::vector<int32_t> h_block_table(n_blocks > 0 ? n_blocks : 1);
-            cudaMemcpy(h_block_table.data(), state.block_tables, n_blocks * sizeof(int32_t),
+            cudaMemcpy(h_block_table.data(), layer_block_tables, n_blocks * sizeof(int32_t),
                        cudaMemcpyDeviceToHost);
+            // SWA trailing-free holes (-1) leave their rows zeroed — they sit
+            // outside the window mask, so the reference output is unaffected.
+            cudaMemset(k_flat, 0, kv_elems * sizeof(half));
+            cudaMemset(v_flat, 0, kv_elems * sizeof(half));
             for (int b = 0; b < n_blocks; b++) {
                 int block_id = h_block_table[b];
+                if (block_id < 0)
+                    continue;
                 int toks_in_block = std::min(kv_bs, ctx_len - b * kv_bs);
                 size_t row_bytes = nkv * hd * sizeof(half);
                 half* k_src = static_cast<half*>(cache_dbg->k_ptr(kv_layer_dbg, block_id));
@@ -158,7 +164,7 @@
             paged_attention_decode_int4(q4, k_c, v_c, o4,
                                         static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
                                         static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
-                                        state.block_tables, state.context_lens, kv_bs, scale,
+                                        layer_block_tables, state.context_lens, kv_bs, scale,
                                         state.max_context_len, layer_sliding_window, cfg.attn_logit_softcap,
                                         stream, state.max_blocks_per_seq);
         } else if (cache_dtype == QType::NVFP4) {
@@ -177,7 +183,7 @@
                 const uint8_t* k_scales = static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0));
                 const uint8_t* v_scales = static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0));
                 if (!residual_on) {
-                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, state.block_tables,
+                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, layer_block_tables,
                                                     state.context_lens, kv_bs, scale, state.max_context_len,
                                                     layer_sliding_window, cfg.attn_logit_softcap, stream,
                                                     state.max_blocks_per_seq);
@@ -215,7 +221,7 @@
                         res_count = rs.fill_count;
                         res_widx = rs.write_idx;
                     }
-                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, state.block_tables,
+                    paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, layer_block_tables,
                                                     state.context_lens, kv_bs, scale, state.max_context_len,
                                                     layer_sliding_window, cfg.attn_logit_softcap, stream,
                                                     state.max_blocks_per_seq, 0, k_res, v_res, res_count,
@@ -229,7 +235,7 @@
                 paged_attention_decode_nvfp4(q4, k_c, v_c, o4,
                                              static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
                                              static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                                             state.block_tables, state.context_lens, kv_bs, scale,
+                                             layer_block_tables, state.context_lens, kv_bs, scale,
                                              state.max_context_len, layer_sliding_window,
                                              cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
             }
@@ -240,7 +246,7 @@
             paged_attention_decode_mxfp4_kv(q4, k_c, v_c, o4,
                                             static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
                                             static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                                            state.block_tables, state.context_lens, kv_bs, scale,
+                                            layer_block_tables, state.context_lens, kv_bs, scale,
                                             state.max_context_len, layer_sliding_window,
                                             cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
         } else if (cache_dtype == QType::INT8) {
@@ -249,7 +255,7 @@
             paged_attention_decode_int8(q4, k_c, v_c, o4,
                                         static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
                                         static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
-                                        state.block_tables, state.context_lens, kv_bs, scale,
+                                        layer_block_tables, state.context_lens, kv_bs, scale,
                                         state.max_context_len, layer_sliding_window, cfg.attn_logit_softcap,
                                         stream, state.max_blocks_per_seq);
         } else if (cache_dtype == QType::FP8_E4M3) {
@@ -258,12 +264,12 @@
                                  ? kv_scales_[kv_layer]
                                  : 1.0f;
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
-            paged_attention_decode_fp8(q4, k_c, v_c, o4, state.block_tables, state.context_lens, kv_bs, scale,
+            paged_attention_decode_fp8(q4, k_c, v_c, o4, layer_block_tables, state.context_lens, kv_bs, scale,
                                        kv_scale, state.max_context_len, layer_sliding_window,
                                        cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
         } else {
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
-            paged_attention_decode(q4, k_c, v_c, o4, state.block_tables, state.context_lens, kv_bs, scale,
+            paged_attention_decode(q4, k_c, v_c, o4, layer_block_tables, state.context_lens, kv_bs, scale,
                                    state.max_context_len, layer_sliding_window, cfg.attn_logit_softcap,
                                    stream, state.max_blocks_per_seq, layer_n_sinks, attn_sinks, vhd);
         }

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -126,7 +126,7 @@
                         static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                         static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
                         static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
-                        static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)), state.block_tables,
+                        static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)), layer_block_tables,
                         kv_bs, ctx_len, nkv, scale, /*causal=*/true, layer_sliding_window,
                         cfg.attn_logit_softcap, stream, q_offset,
                         runtime_config().attention.mxfp4_promote_budget)) {
@@ -178,49 +178,49 @@
             // Gather past KV [0, q_offset) directly into k_full[0..q_offset], v_full[0..q_offset].
             if (kvt == QType::F16) {
                 paged_kv_gather_fp16(k_full, static_cast<const half*>(cache->k_ptr(kv_layer, 0)),
-                                     state.block_tables, gather_cap, kv_bs, nkv, hd, stream, d_past);
+                                     layer_block_tables, gather_cap, kv_bs, nkv, hd, stream, d_past);
                 paged_kv_gather_fp16(v_full, static_cast<const half*>(cache->v_ptr(kv_layer, 0)),
-                                     state.block_tables, gather_cap, kv_bs, nkv, hd, stream, d_past);
+                                     layer_block_tables, gather_cap, kv_bs, nkv, hd, stream, d_past);
             } else if (kvt == QType::FP8_E4M3) {
                 float kv_scale = (!kv_scales_.empty() && kv_layer < (int)kv_scales_.size())
                                      ? kv_scales_[kv_layer]
                                      : 1.0f;
                 paged_kv_gather_fp8_to_fp16(k_full,
                                             static_cast<const __nv_fp8_e4m3*>(cache->k_ptr(kv_layer, 0)),
-                                            state.block_tables, kv_scale, gather_cap, kv_bs, nkv, hd,
+                                            layer_block_tables, kv_scale, gather_cap, kv_bs, nkv, hd,
                                             stream, d_past);
                 paged_kv_gather_fp8_to_fp16(v_full,
                                             static_cast<const __nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)),
-                                            state.block_tables, kv_scale, gather_cap, kv_bs, nkv, hd,
+                                            layer_block_tables, kv_scale, gather_cap, kv_bs, nkv, hd,
                                             stream, d_past);
             } else if (kvt == QType::NVFP4) {
                 paged_kv_gather_nvfp4_to_fp16(k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                                               static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
-                                              state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                              layer_block_tables, gather_cap, kv_bs, nkv, hd, stream,
                                               d_past);
                 paged_kv_gather_nvfp4_to_fp16(v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
                                               static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                                              state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                              layer_block_tables, gather_cap, kv_bs, nkv, hd, stream,
                                               d_past);
             } else if (kvt == QType::MXFP4_KV) {
                 paged_kv_gather_mxfp4_kv_to_fp16(k_full,
                                                  static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                                                  static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
-                                                 state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                                 layer_block_tables, gather_cap, kv_bs, nkv, hd, stream,
                                                  d_past);
                 paged_kv_gather_mxfp4_kv_to_fp16(v_full,
                                                  static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
                                                  static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0)),
-                                                 state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                                 layer_block_tables, gather_cap, kv_bs, nkv, hd, stream,
                                                  d_past);
             } else {  // INT4 — symmetric 4-bit with per-head FP16 scale
                 paged_kv_gather_int4_to_fp16(k_full, static_cast<const uint8_t*>(cache->k_ptr(kv_layer, 0)),
                                              static_cast<const half*>(cache->k_scale_ptr(kv_layer, 0)),
-                                             state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                             layer_block_tables, gather_cap, kv_bs, nkv, hd, stream,
                                              d_past);
                 paged_kv_gather_int4_to_fp16(v_full, static_cast<const uint8_t*>(cache->v_ptr(kv_layer, 0)),
                                              static_cast<const half*>(cache->v_scale_ptr(kv_layer, 0)),
-                                             state.block_tables, gather_cap, kv_bs, nkv, hd, stream,
+                                             layer_block_tables, gather_cap, kv_bs, nkv, hd, stream,
                                              d_past);
             }
 

--- a/src/exec/executor_kv_write.cu
+++ b/src/exec/executor_kv_write.cu
@@ -30,6 +30,12 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
     KVCache* cache = state.kv_cache;
     int n = state.n_tokens;
     const auto& cfg = model_->config();
+    // SWA-aware KV sizing (kv_cache.swa_sizing): windowed layers write into
+    // the SWA block group through the parallel table (-1 holes below the
+    // window are skipped by the kernels' block_id<0 guard).
+    const int* block_tables = state.block_tables;
+    if (state.block_tables_swa != nullptr && layer_swa_window(cfg, model_->profile(), layer) > 0)
+        block_tables = state.block_tables_swa;
     // Per-layer shape support (Gemma 4 dual attention geometry)
     int nkv, hd;
     if (!cfg.n_kv_heads_per_layer.empty() && layer < (int)cfg.n_kv_heads_per_layer.size() &&
@@ -64,7 +70,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
         dim3 grid_nvfp4(n, 2);
         write_kv_cache_nvfp4_kernel<<<grid_nvfp4, 256, 0, stream>>>(
             static_cast<const half*>(kv.data), static_cast<const half*>(vv.data), state.positions,
-            state.block_tables, static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
+            block_tables, static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
             static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
             static_cast<uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
             static_cast<uint8_t*>(cache->v_scale_ptr(kv_layer, 0)), nvfp4_block_stride,
@@ -79,7 +85,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
         dim3 grid_mxfp4(n, 2);
         write_kv_cache_mxfp4_kv_kernel<<<grid_mxfp4, 256, 0, stream>>>(
             static_cast<const half*>(kv.data), static_cast<const half*>(vv.data), state.positions,
-            state.block_tables, static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
+            block_tables, static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
             static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
             static_cast<uint8_t*>(cache->k_scale_ptr(kv_layer, 0)),
             static_cast<uint8_t*>(cache->v_scale_ptr(kv_layer, 0)), mxfp4_block_stride,
@@ -94,7 +100,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
         dim3 grid_int4(n, 2);
         write_kv_cache_int4_kernel<<<grid_int4, 256, 0, stream>>>(
             static_cast<const half*>(kv.data), static_cast<const half*>(vv.data), state.positions,
-            state.block_tables, static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
+            block_tables, static_cast<uint8_t*>(cache->k_ptr(kv_layer, 0)),
             static_cast<uint8_t*>(cache->v_ptr(kv_layer, 0)),
             static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
             static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)), int4_block_stride, scale_block_stride, nkv,
@@ -108,7 +114,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
         dim3 grid_int8(n, 2);  // blockIdx.y: 0=K, 1=V
         write_kv_cache_int8_kernel<<<grid_int8, 256, 0, stream>>>(
             static_cast<const half*>(kv.data), static_cast<const half*>(vv.data), state.positions,
-            state.block_tables, static_cast<int8_t*>(cache->k_ptr(kv_layer, 0)),
+            block_tables, static_cast<int8_t*>(cache->k_ptr(kv_layer, 0)),
             static_cast<int8_t*>(cache->v_ptr(kv_layer, 0)),
             static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
             static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)), block_stride, scale_block_stride, nkv, hd,
@@ -169,7 +175,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
         dim3 fp8_grid(n, 2);
         write_kv_cache_fp8_fused_kernel<<<fp8_grid, threads, 0, stream>>>(
             static_cast<const half*>(kv.data), static_cast<const half*>(vv.data), state.positions,
-            state.block_tables, static_cast<__nv_fp8_e4m3*>(cache->k_ptr(kv_layer, 0)),
+            block_tables, static_cast<__nv_fp8_e4m3*>(cache->k_ptr(kv_layer, 0)),
             static_cast<__nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)), inv_scale, block_stride, row_elems,
             kv_block_size, n, state.max_blocks_per_seq, state.n_sequences);
     } else {
@@ -186,7 +192,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
         dim3 fused_grid(n, 2);  // blockIdx.y: 0=K, 1=V
         write_kv_cache_fused_kernel<<<fused_grid, threads, 0, stream>>>(
             static_cast<const half*>(kv.data), static_cast<const half*>(vv.data), state.positions,
-            state.block_tables, static_cast<half*>(cache->k_ptr(kv_layer, 0)),
+            block_tables, static_cast<half*>(cache->k_ptr(kv_layer, 0)),
             static_cast<half*>(cache->v_ptr(kv_layer, 0)), block_stride, row_elems, kv_block_size, n,
             state.max_blocks_per_seq, state.n_sequences);
     }

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -26,6 +26,11 @@ struct InferenceState {
     // KV cache for paged attention (decode)
     KVCache* kv_cache = nullptr;
     const int* block_tables = nullptr;  // [n_sequences, max_blocks_per_seq] on device (2D padded)
+    // SWA-group block tables (kv_cache.swa_sizing): same shape/stride as
+    // block_tables, -1 holes outside the trailing window. Sliding-window
+    // layers read/write through this table; nullptr when the feature is off
+    // (all layers use block_tables, today's behavior).
+    const int* block_tables_swa = nullptr;
     const int* context_lens = nullptr;  // [n_sequences] on device
     int max_context_len = 0;
 

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -110,11 +110,24 @@ KVCache::KVCache(int n_layers, int n_kv_heads, int head_dim, QType dtype, int ma
 // ---------------------------------------------------------------------------
 KVCache::KVCache(int n_layers, const std::vector<int>& n_kv_heads_per_layer,
                  const std::vector<int>& head_dim_per_layer, QType dtype, int max_blocks, int block_size,
-                 VRAMAllocator* alloc)
-    : n_layers_(n_layers), max_blocks_(max_blocks), block_size_(block_size), dtype_(dtype), alloc_(alloc) {
+                 VRAMAllocator* alloc, const std::vector<char>& layer_is_swa, int swa_max_blocks)
+    : n_layers_(n_layers), max_blocks_(max_blocks), block_size_(block_size), dtype_(dtype), alloc_(alloc),
+      layer_is_swa_(layer_is_swa), swa_max_blocks_(swa_max_blocks) {
     bool packed_4bit = (dtype == QType::INT4 || dtype == QType::NVFP4 || dtype == QType::MXFP4_KV);
     size_t elem_size = packed_4bit ? 0  // 4-bit modes use /2 below
                                    : dtype_size(dtype);
+
+    // SWA group only meaningful with both a flag vector and a capacity.
+    if (layer_is_swa_.empty() || swa_max_blocks_ <= 0) {
+        layer_is_swa_.clear();
+        swa_max_blocks_ = 0;
+    }
+    // Per-layer region capacity: SWA layers hold only the trailing window.
+    auto layer_capacity = [&](int l) -> size_t {
+        return (swa_max_blocks_ > 0 && l < static_cast<int>(layer_is_swa_.size()) && layer_is_swa_[l])
+                   ? static_cast<size_t>(swa_max_blocks_)
+                   : static_cast<size_t>(max_blocks_);
+    };
 
     // Compute per-layer block bytes and offsets.
     layer_block_bytes_.resize(n_layers_);
@@ -141,9 +154,9 @@ KVCache::KVCache(int n_layers, const std::vector<int>& n_kv_heads_per_layer,
 
         // Layout: K region then V region for this layer.
         layer_k_offset_[l] = running;
-        running += static_cast<size_t>(max_blocks_) * bb;
+        running += layer_capacity(l) * bb;
         layer_v_offset_[l] = running;
-        running += static_cast<size_t>(max_blocks_) * bb;
+        running += layer_capacity(l) * bb;
     }
     size_t total = running;
 
@@ -200,9 +213,9 @@ KVCache::KVCache(int n_layers, const std::vector<int>& n_kv_heads_per_layer,
             size_t sbb = static_cast<size_t>(block_size_) * nkv * (hd / kNVFP4Group);
             layer_scale_block_bytes_[l] = sbb;
             layer_k_scale_offset_[l] = srunning;
-            srunning += static_cast<size_t>(max_blocks_) * sbb;
+            srunning += layer_capacity(l) * sbb;
             layer_v_scale_offset_[l] = srunning;
-            srunning += static_cast<size_t>(max_blocks_) * sbb;
+            srunning += layer_capacity(l) * sbb;
         }
         size_t sc_total = srunning;
         if (alloc_) {
@@ -235,6 +248,22 @@ KVCache::KVCache(int n_layers, const std::vector<int>& n_kv_heads_per_layer,
     free_list_.reserve(max_blocks_);
     for (int i = max_blocks_ - 1; i >= 0; --i) {
         free_list_.push_back(i);
+    }
+
+    // SWA group: separate id space with its own free list.
+    if (swa_max_blocks_ > 0) {
+        swa_ref_counts_.resize(swa_max_blocks_, 0);
+        swa_free_list_.reserve(swa_max_blocks_);
+        for (int i = swa_max_blocks_ - 1; i >= 0; --i) {
+            swa_free_list_.push_back(i);
+        }
+        int n_swa_layers = 0;
+        for (char f : layer_is_swa_)
+            if (f)
+                n_swa_layers++;
+        IMP_LOG_INFO("KVCache (per-layer): SWA group %d blocks × %d windowed layers "
+                     "(global group %d blocks × %d layers)",
+                     swa_max_blocks_, n_swa_layers, max_blocks_, n_layers_ - n_swa_layers);
     }
 
     IMP_LOG_INFO("KVCache (per-layer): %zu layers, pool %.2f MiB, max nkv=%d, max hd=%d", (size_t)n_layers_,
@@ -302,6 +331,29 @@ void KVCache::free_block(int block_id) {
     if (ref_counts_[block_id] == 0) {
         free_list_.push_back(block_id);
     }
+}
+
+// ---------------------------------------------------------------------------
+// SWA block group (kv_cache.swa_sizing): separate id space, no sharing —
+// SWA blocks are never prefix-cached or pinned, so ref counts stay 0/1.
+// ---------------------------------------------------------------------------
+
+int KVCache::allocate_swa_block() {
+    if (swa_free_list_.empty())
+        return -1;
+    int block_id = swa_free_list_.back();
+    swa_free_list_.pop_back();
+    swa_ref_counts_[block_id] = 1;
+    return block_id;
+}
+
+void KVCache::free_swa_block(int block_id) {
+    if (block_id < 0 || block_id >= swa_max_blocks_)
+        return;
+    if (swa_ref_counts_[block_id] <= 0)
+        return;
+    if (--swa_ref_counts_[block_id] == 0)
+        swa_free_list_.push_back(block_id);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -23,14 +23,32 @@ public:
     // Per-layer-shape constructor (Gemma 4 dual attention geometry).
     // n_kv_heads_per_layer[l] and head_dim_per_layer[l] define layer l's
     // KV shape. The scale/sketch pools are sized using max across layers.
+    //
+    // SWA-aware sizing (kv_cache.swa_sizing): when `layer_is_swa` is non-empty,
+    // layers flagged 1 get a small dedicated block group of `swa_max_blocks`
+    // capacity instead of the full `max_blocks` — sliding-window layers only
+    // ever hold the trailing window, so their regions shrink accordingly.
+    // SWA blocks live in a SEPARATE block-id space [0, swa_max_blocks) with
+    // their own free list (allocate_swa_block/free_swa_block); k_ptr/v_ptr
+    // interpret block_id in the layer's group space (per-layer offsets).
     KVCache(int n_layers, const std::vector<int>& n_kv_heads_per_layer,
             const std::vector<int>& head_dim_per_layer, QType dtype, int max_blocks, int block_size,
-            VRAMAllocator* alloc);
+            VRAMAllocator* alloc, const std::vector<char>& layer_is_swa = {}, int swa_max_blocks = 0);
     ~KVCache();
 
     // Block allocation / deallocation
     int allocate_block();
     void free_block(int block_id);
+
+    // ── SWA block group (separate id space, no ref-count sharing) ────
+    bool swa_enabled() const { return swa_max_blocks_ > 0; }
+    bool layer_is_swa(int layer) const {
+        return layer >= 0 && layer < static_cast<int>(layer_is_swa_.size()) && layer_is_swa_[layer];
+    }
+    int allocate_swa_block();
+    void free_swa_block(int block_id);
+    int num_free_swa_blocks() const { return static_cast<int>(swa_free_list_.size()); }
+    int swa_total_blocks() const { return swa_max_blocks_; }
 
     // Reference counting (for copy-on-write / prefix caching)
     int ref_count(int block_id) const;
@@ -93,6 +111,13 @@ private:
     void* scale_pool_ = nullptr;
     size_t scale_block_bytes_ = 0;  // block_size * n_kv_heads * sizeof(half)
 
+    // ── SWA block group state (per-layer ctor only) ──────────────────
+    // layer_is_swa_[l] = 1 → layer l's region has swa_max_blocks_ capacity and
+    // block ids passed to k_ptr/v_ptr for it come from the SWA id space.
+    std::vector<char> layer_is_swa_;
+    int swa_max_blocks_ = 0;
+    std::vector<int> swa_ref_counts_;
+    std::vector<int> swa_free_list_;
 };
 
 }  // namespace imp

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -332,6 +332,16 @@ void KVCacheManager::free_sequence(int seq_id) {
 
     seq_blocks_.erase(it);
     seq_block_hashes_.erase(seq_id);
+
+    // SWA table: free every live SWA-group block (never hashed/pinned/shared).
+    if (auto sit = seq_swa_blocks_.find(seq_id); sit != seq_swa_blocks_.end()) {
+        for (int bid : sit->second)
+            if (bid >= 0)
+                cache_->free_swa_block(bid);
+        seq_swa_blocks_.erase(sit);
+        swa_trim_cursor_.erase(seq_id);
+    }
+
     // Phase 3: reset residual ring state AND return the slot to the free list.
     // release_residual_slot is a no-op if no slot was allocated for this seq.
     release_residual_slot(seq_id);
@@ -753,6 +763,89 @@ void KVCacheManager::unpin_prefix(int seq_id) {
 
 int KVCacheManager::num_pinned_blocks() const { return static_cast<int>(pinned_blocks_.size()); }
 
+// ─── SWA-aware sizing (kv_cache.swa_sizing) ──────────────────────────
+
+void KVCacheManager::enable_swa_sizing(int window_tokens, int slack_tokens) {
+    if (!cache_->swa_enabled() || window_tokens <= 0) {
+        IMP_LOG_WARN("KVCacheManager: enable_swa_sizing ignored (cache swa group %s, window=%d)",
+                     cache_->swa_enabled() ? "present" : "absent", window_tokens);
+        return;
+    }
+    swa_window_ = window_tokens;
+    // Slack floor of one block covers the partially-filled boundary block;
+    // the caller adds the spec-decode rollback depth on top.
+    swa_slack_ = std::max(slack_tokens, cache_->block_size());
+    IMP_LOG_INFO("KVCacheManager: SWA sizing enabled (window=%d, slack=%d, group=%d blocks)",
+                 swa_window_, swa_slack_, cache_->swa_total_blocks());
+}
+
+bool KVCacheManager::swa_prepare(int seq_id, int from_tokens, int upto_tokens) {
+    if (swa_window_ <= 0 || upto_tokens <= 0)
+        return true;
+    auto git = seq_blocks_.find(seq_id);
+    if (git == seq_blocks_.end())
+        return true;  // no global blocks yet — nothing to mirror
+    auto& swa = seq_swa_blocks_[seq_id];
+    const int bs = cache_->block_size();
+    // Pad to the global table's length: new slots start as holes; only the
+    // live tail below gets physical blocks.
+    if (swa.size() < git->second.size())
+        swa.resize(git->second.size(), -1);
+
+    const long long live_start_tok =
+        static_cast<long long>(std::min(from_tokens, upto_tokens)) - swa_window_ - swa_slack_;
+    const int first_live = live_start_tok > 0 ? static_cast<int>(live_start_tok / bs) : 0;
+    const int end_block = std::min(static_cast<int>((upto_tokens + bs - 1) / bs),
+                                   static_cast<int>(swa.size()));
+    for (int b = first_live; b < end_block; ++b) {
+        if (swa[b] >= 0)
+            continue;
+        int id = cache_->allocate_swa_block();
+        if (id < 0) {
+            IMP_LOG_ERROR(
+                "KVCacheManager: SWA block group exhausted (seq %d, block %d/%d, 0 free) — "
+                "group undersized for the live span",
+                seq_id, b, end_block);
+            return false;
+        }
+        swa[b] = id;
+    }
+    return true;
+}
+
+void KVCacheManager::swa_trim(int seq_id, int committed_tokens) {
+    if (swa_window_ <= 0)
+        return;
+    auto it = seq_swa_blocks_.find(seq_id);
+    if (it == seq_swa_blocks_.end())
+        return;
+    auto& swa = it->second;
+    const int bs = cache_->block_size();
+    const long long dead_end_tok =
+        static_cast<long long>(committed_tokens) - swa_window_ - swa_slack_;
+    if (dead_end_tok <= 0)
+        return;
+    // Block b is dead when it ends at or before dead_end_tok: (b+1)*bs <= dead_end.
+    const int dead_blocks = static_cast<int>(
+        std::min<long long>(dead_end_tok / bs, static_cast<long long>(swa.size())));
+    int& cursor = swa_trim_cursor_[seq_id];
+    for (int b = cursor; b < dead_blocks; ++b) {
+        if (swa[b] >= 0) {
+            cache_->free_swa_block(swa[b]);
+            swa[b] = -1;
+        }
+    }
+    cursor = std::max(cursor, dead_blocks);
+}
+
+const std::vector<int>& KVCacheManager::swa_block_table(int seq_id) const {
+    static const std::vector<int> empty;
+    auto it = seq_swa_blocks_.find(seq_id);
+    if (it == seq_swa_blocks_.end())
+        return empty;
+    return it->second;
+}
+
 // ─── Speculative decoding rollback ───────────────────────────────────
 
 int KVCacheManager::evict_middle_blocks(int seq_id, int n_sink_tokens, int n_window_tokens) {
@@ -853,6 +946,19 @@ void KVCacheManager::rollback(int seq_id, int new_seq_len) {
         while (static_cast<int>(hashes.size()) > blocks_needed) {
             hashes.pop_back();
         }
+    }
+
+    // SWA table: drop the tail in lockstep (trimmed holes stay holes — the
+    // slack guarantees anything a post-rollback forward reads is still live).
+    if (auto sit = seq_swa_blocks_.find(seq_id); sit != seq_swa_blocks_.end()) {
+        auto& swa = sit->second;
+        while (static_cast<int>(swa.size()) > blocks_needed) {
+            if (swa.back() >= 0)
+                cache_->free_swa_block(swa.back());
+            swa.pop_back();
+        }
+        if (auto cit = swa_trim_cursor_.find(seq_id); cit != swa_trim_cursor_.end())
+            cit->second = std::min(cit->second, blocks_needed);
     }
 }
 

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -141,6 +141,37 @@ public:
     // excluding pinned blocks. O(1).
     int num_reclaimable_cached_blocks() const { return reclaimable_cached_count_; }
 
+    // ── SWA-aware sizing (kv_cache.swa_sizing) ───────────────────────
+    //
+    // Sliding-window layers read/write a small dedicated block group
+    // (KVCache SWA group); the manager keeps a second positional table per
+    // sequence, same length/indexing as the global table, with -1 holes
+    // for positions outside the trailing window. Engine contract:
+    //   - swa_prepare(seq, from_tokens, upto_tokens) BEFORE forwarding the
+    //     token range [from, upto) (prefill chunk / decode step / on-device
+    //     burst incl. spec drafts): pads the SWA table to the global
+    //     table's length and allocates live entries for blocks intersecting
+    //     [from - window - slack, upto) — every write in the range plus the
+    //     window each query reads. Earlier slots stay/become -1.
+    //   - swa_trim(seq, committed_tokens) after the step commits: frees
+    //     entries fully below committed - window - slack. The slack must
+    //     cover the deepest spec-decode rollback (rollback never restores
+    //     positions older than slack tokens behind the prepared tail).
+    //   - rollback() / free_sequence() handle the SWA table automatically.
+    // SWA blocks are never hashed, pinned, persisted, or shared.
+    void enable_swa_sizing(int window_tokens, int slack_tokens);
+    bool swa_sizing_enabled() const { return swa_window_ > 0; }
+    int swa_window() const { return swa_window_; }
+    int swa_slack() const { return swa_slack_; }
+    [[nodiscard]] bool swa_prepare(int seq_id, int from_tokens, int upto_tokens);
+    [[nodiscard]] bool swa_prepare(int seq_id, int upto_tokens) {
+        return swa_prepare(seq_id, upto_tokens, upto_tokens);
+    }
+    void swa_trim(int seq_id, int committed_tokens);
+    // Positional SWA block table (parallel to block_table; -1 = hole).
+    // Empty vector if unknown seq or SWA sizing disabled.
+    const std::vector<int>& swa_block_table(int seq_id) const;
+
     // ── Speculative decoding rollback ────────────────────────────────
 
     // Truncate a sequence's block table to fit `new_seq_len` tokens.
@@ -287,6 +318,17 @@ private:
 
     // seq_id -> ordered list of block ids.
     std::unordered_map<int, std::vector<int>> seq_blocks_;
+
+    // ── SWA-aware sizing state ───────────────────────────────────────
+    // seq_id -> positional SWA-group block table (parallel to seq_blocks_,
+    // -1 holes outside the trailing window). Only populated when
+    // enable_swa_sizing() armed the feature.
+    std::unordered_map<int, std::vector<int>> seq_swa_blocks_;
+    // seq_id -> first not-yet-trimmed SWA table index (amortizes swa_trim
+    // to O(new dead blocks) per call instead of O(table)).
+    std::unordered_map<int, int> swa_trim_cursor_;
+    int swa_window_ = 0;  // 0 = SWA sizing disabled
+    int swa_slack_ = 0;
 
     // ── LRU tracking ─────────────────────────────────────────────────
     // Doubly-linked list of seq_ids; most recently used at the *tail*.

--- a/src/model/model_profile.cpp
+++ b/src/model/model_profile.cpp
@@ -66,4 +66,29 @@ ModelProfile derive_model_profile(const Model& model, const ModelConfig& cfg) {
     return p;
 }
 
+int layer_swa_window(const ModelConfig& cfg, const ModelProfile& prof, int layer) {
+    if (cfg.sliding_window <= 0)
+        return 0;
+    switch (prof.attn_variant) {
+        case ModelProfile::AttnVariant::GEMMA4_SWA:
+        case ModelProfile::AttnVariant::GPTOSS_SWA: {
+            // Per-layer SWA mask in cfg.swa_layers (1 = sliding, 0 = global).
+            bool is_swa = (layer < static_cast<int>(cfg.swa_layers.size()) && cfg.swa_layers[layer]);
+            return is_swa ? cfg.sliding_window : 0;
+        }
+        case ModelProfile::AttnVariant::MLA:
+        case ModelProfile::AttnVariant::NOPE:
+            return 0;
+        case ModelProfile::AttnVariant::STANDARD:
+            break;
+    }
+    if (cfg.sliding_window_pattern > 0) {
+        // Gemma-3: every sliding_window_pattern-th layer is global.
+        bool is_global = (layer % cfg.sliding_window_pattern) == (cfg.sliding_window_pattern - 1);
+        return is_global ? 0 : cfg.sliding_window;
+    }
+    // Plain sliding_window (Mistral/Qwen3 style): every layer is windowed.
+    return cfg.sliding_window;
+}
+
 }  // namespace imp

--- a/src/model/model_profile.h
+++ b/src/model/model_profile.h
@@ -64,4 +64,12 @@ struct ModelProfile {
 // Pure: no side effects, no allocation. Reads the model's layers + config once.
 ModelProfile derive_model_profile(const Model& model, const ModelConfig& cfg);
 
+// Per-layer sliding-window size: 0 for global-attention layers, the window in
+// tokens for SWA layers. Single source of truth for the four SWA variants
+// (Gemma-4 / gpt-oss swa_layers[], Gemma-3 sliding_window_pattern, plain
+// Mistral-style sliding_window) — consumed by the attention dispatch mask AND
+// the SWA-aware KV sizing, so the two can't drift. `layer` is the global layer
+// index (not the compacted KV-layer index).
+int layer_swa_window(const ModelConfig& cfg, const ModelProfile& prof, int layer);
+
 }  // namespace imp

--- a/src/runtime/batch.cpp
+++ b/src/runtime/batch.cpp
@@ -89,18 +89,22 @@ void BatchBuilder::reset() {
     batch_.positions.clear();
     batch_.seq_offsets.clear();
     batch_.block_tables.clear();
+    batch_.block_tables_swa.clear();
     batch_.context_lens.clear();
     batch_.n_sequences = 0;
     batch_.total_tokens = 0;
     batch_.max_blocks_per_seq = 0;
     batch_.actual_blocks_per_seq = 0;
     raw_block_tables_.clear();
+    raw_swa_block_tables_.clear();
+    any_swa_tables_ = false;
 
     batch_.seq_offsets.push_back(0);
 }
 
 void BatchBuilder::add_prefill_sequence(const int32_t* tokens, int n_tokens, const int* block_table,
-                                        int n_blocks, int start_pos) {
+                                        int n_blocks, int start_pos, const int* swa_block_table,
+                                        int n_swa_blocks) {
     for (int i = 0; i < n_tokens; ++i) {
         batch_.token_ids.push_back(tokens[i]);
         batch_.positions.push_back(start_pos + i);
@@ -108,6 +112,8 @@ void BatchBuilder::add_prefill_sequence(const int32_t* tokens, int n_tokens, con
 
     batch_.context_lens.push_back(start_pos + n_tokens);
     raw_block_tables_.push_back({block_table, n_blocks});
+    raw_swa_block_tables_.push_back({swa_block_table, n_swa_blocks});
+    any_swa_tables_ |= (swa_block_table != nullptr);
 
     batch_.total_tokens += n_tokens;
     batch_.n_sequences++;
@@ -115,11 +121,13 @@ void BatchBuilder::add_prefill_sequence(const int32_t* tokens, int n_tokens, con
 }
 
 void BatchBuilder::add_decode_sequence(int32_t token, int position, const int* block_table, int n_blocks,
-                                       int context_len) {
+                                       int context_len, const int* swa_block_table, int n_swa_blocks) {
     batch_.token_ids.push_back(token);
     batch_.positions.push_back(position);
     batch_.context_lens.push_back(context_len);
     raw_block_tables_.push_back({block_table, n_blocks});
+    raw_swa_block_tables_.push_back({swa_block_table, n_swa_blocks});
+    any_swa_tables_ |= (swa_block_table != nullptr);
 
     batch_.total_tokens += 1;
     batch_.n_sequences++;
@@ -146,6 +154,20 @@ Batch BatchBuilder::build() {
         }
     }
 
+    // Parallel SWA tables (same shape/stride). Padded with -1 — a padded slot
+    // must read as a hole, never as SWA block 0.
+    if (any_swa_tables_) {
+        batch_.block_tables_swa.assign(static_cast<unsigned long>(batch_.n_sequences) * max_blocks, -1);
+        for (int s = 0; s < batch_.n_sequences; s++) {
+            auto& [ptr, n] = raw_swa_block_tables_[s];
+            if (!ptr)
+                continue;
+            for (int b = 0; b < n && b < max_blocks; b++) {
+                batch_.block_tables_swa[s * max_blocks + b] = ptr[b];
+            }
+        }
+    }
+
     return std::move(batch_);
 }
 
@@ -155,13 +177,15 @@ Batch BatchBuilder::build() {
 
 GPUBatchPool::~GPUBatchPool() { free_pool(); }
 
-void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllocator* alloc) {
+void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllocator* alloc,
+                            bool with_swa_tables) {
     free_pool();
     alloc_ = alloc;
 
     max_batch_size_ = max_batch_size;
     max_blocks_per_seq_ = max_blocks_per_seq;
     last_upload_block_tables_.clear();
+    last_upload_block_tables_swa_.clear();
 
     // Compute sizes with 256-byte alignment per sub-buffer
     auto align256 = [](size_t x) -> size_t { return (x + 255) & ~size_t(255); };
@@ -170,10 +194,12 @@ void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllo
     size_t positions_sz = align256(static_cast<size_t>(max_batch_size) * sizeof(int));
     size_t seq_offsets_sz = align256(static_cast<size_t>(max_batch_size + 1) * sizeof(int));
     size_t block_tab_sz = align256(static_cast<size_t>(max_batch_size) * max_blocks_per_seq * sizeof(int));
+    size_t swa_tab_sz = with_swa_tables ? block_tab_sz : 0;
     size_t ctx_lens_sz = align256(static_cast<size_t>(max_batch_size) * sizeof(int));
     size_t sample_res_sz = align256(sizeof(int32_t));
 
-    pool_size_ = token_ids_sz + positions_sz + seq_offsets_sz + block_tab_sz + ctx_lens_sz + sample_res_sz;
+    pool_size_ = token_ids_sz + positions_sz + seq_offsets_sz + block_tab_sz + swa_tab_sz + ctx_lens_sz +
+                 sample_res_sz;
 
     if (alloc_) {
         pool_ = alloc_->allocate(pool_size_, "batch_pool");
@@ -196,6 +222,10 @@ void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllo
     ptr += seq_offsets_sz;
     d_block_tables_ = reinterpret_cast<int*>(ptr);
     ptr += block_tab_sz;
+    if (with_swa_tables) {
+        d_block_tables_swa_ = reinterpret_cast<int*>(ptr);
+        ptr += swa_tab_sz;
+    }
     d_context_lens_ = reinterpret_cast<int*>(ptr);
     ptr += ctx_lens_sz;
     d_sample_result_ = reinterpret_cast<int32_t*>(ptr);
@@ -215,6 +245,8 @@ GPUBatch GPUBatchPool::upload_into_pool(const Batch& batch, cudaStream_t stream)
     gpu.d_positions = d_positions_;
     gpu.d_seq_offsets = d_seq_offsets_;
     gpu.d_block_tables = d_block_tables_;
+    gpu.d_block_tables_swa =
+        (!batch.block_tables_swa.empty() && d_block_tables_swa_) ? d_block_tables_swa_ : nullptr;
     gpu.d_context_lens = d_context_lens_;
 
     // Async copy data into pool
@@ -249,6 +281,22 @@ GPUBatch GPUBatchPool::upload_into_pool(const Batch& batch, cudaStream_t stream)
         }
     }
 
+    // SWA-group tables: same shape/dedupe as the main table.
+    if (gpu.d_block_tables_swa && batch.max_blocks_per_seq > 0) {
+        if (batch.n_sequences == 1 && batch.block_tables_swa == last_upload_block_tables_swa_) {
+            // Skip — content identical to last upload
+        } else {
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_block_tables_swa_, batch.block_tables_swa.data(),
+                                               static_cast<unsigned long>(batch.n_sequences) *
+                                                   batch.max_blocks_per_seq * sizeof(int),
+                                               cudaMemcpyHostToDevice, stream));
+            if (batch.n_sequences == 1)
+                last_upload_block_tables_swa_ = batch.block_tables_swa;
+            else
+                last_upload_block_tables_swa_.clear();
+        }
+    }
+
     return gpu;
 }
 
@@ -265,9 +313,11 @@ void GPUBatchPool::free_pool() {
     d_positions_ = nullptr;
     d_seq_offsets_ = nullptr;
     d_block_tables_ = nullptr;
+    d_block_tables_swa_ = nullptr;
     d_context_lens_ = nullptr;
     d_sample_result_ = nullptr;
     last_upload_block_tables_.clear();
+    last_upload_block_tables_swa_.clear();
 }
 
 }  // namespace imp

--- a/src/runtime/batch.h
+++ b/src/runtime/batch.h
@@ -15,6 +15,10 @@ struct Batch {
     std::vector<int32_t> positions;     // position ids
     std::vector<int32_t> seq_offsets;   // [n_seqs+1] ragged offsets
     std::vector<int32_t> block_tables;  // flattened KV block tables (padded per seq)
+    // Parallel SWA-group block tables (kv_cache.swa_sizing): same
+    // [n_seqs, max_blocks_per_seq] shape/stride as block_tables, -1 = hole.
+    // Empty when SWA sizing is off.
+    std::vector<int32_t> block_tables_swa;
     std::vector<int32_t> context_lens;  // [n_seqs] context lengths
 
     int n_sequences = 0;
@@ -29,6 +33,7 @@ struct GPUBatch {
     int* d_positions = nullptr;      // [total_tokens]
     int* d_seq_offsets = nullptr;    // [n_sequences+1]
     int* d_block_tables = nullptr;   // [n_sequences, max_blocks_per_seq] padded
+    int* d_block_tables_swa = nullptr;  // SWA-group tables (same shape) or nullptr
     int* d_context_lens = nullptr;   // [n_sequences]
 
     int n_sequences = 0;
@@ -53,7 +58,10 @@ public:
     ~GPUBatchPool();
 
     // Allocate pool for the given max configuration. Call once at init.
-    void allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllocator* alloc = nullptr);
+    // with_swa_tables adds a second block-table region for the SWA-group
+    // tables (kv_cache.swa_sizing) — same stride, stable pointer.
+    void allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllocator* alloc = nullptr,
+                  bool with_swa_tables = false);
 
     // Upload a CPU batch into the pre-allocated pool (async).
     // Returns a GPUBatch with pointers into the pool (caller must NOT free them).
@@ -64,7 +72,10 @@ public:
 
     bool is_allocated() const { return pool_ != nullptr; }
     int max_blocks_per_seq() const { return max_blocks_per_seq_; }
-    void reset_upload_cache() { last_upload_block_tables_.clear(); }
+    void reset_upload_cache() {
+        last_upload_block_tables_.clear();
+        last_upload_block_tables_swa_.clear();
+    }
 
     // Pre-allocated single int32 result buffer for sampling kernels
     int32_t* d_sample_result() const { return d_sample_result_; }
@@ -79,6 +90,7 @@ private:
     int* d_positions_ = nullptr;
     int* d_seq_offsets_ = nullptr;
     int* d_block_tables_ = nullptr;
+    int* d_block_tables_swa_ = nullptr;
     int* d_context_lens_ = nullptr;
     int32_t* d_sample_result_ = nullptr;
 
@@ -97,6 +109,7 @@ private:
     // addresses" when prefix caching was first turned off). A host-side
     // vector compare of <=max_blocks ints costs nanoseconds per decode step.
     std::vector<int> last_upload_block_tables_;
+    std::vector<int> last_upload_block_tables_swa_;
 };
 
 class BatchBuilder {
@@ -105,19 +118,24 @@ public:
 
     void reset();
 
-    // Add a prefill sequence (multiple tokens)
+    // Add a prefill sequence (multiple tokens). swa_block_table (optional)
+    // is the parallel SWA-group table — pass nullptr when SWA sizing is off.
     void add_prefill_sequence(const int32_t* tokens, int n_tokens, const int* block_table, int n_blocks,
-                              int start_pos);
+                              int start_pos, const int* swa_block_table = nullptr,
+                              int n_swa_blocks = 0);
 
     // Add a decode sequence (single token)
     void add_decode_sequence(int32_t token, int position, const int* block_table, int n_blocks,
-                             int context_len);
+                             int context_len, const int* swa_block_table = nullptr,
+                             int n_swa_blocks = 0);
 
     Batch build();
 
 private:
     Batch batch_;
     std::vector<std::pair<const int*, int>> raw_block_tables_;  // (ptr, n_blocks)
+    std::vector<std::pair<const int*, int>> raw_swa_block_tables_;
+    bool any_swa_tables_ = false;
 };
 
 }  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -128,6 +128,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("kv_cache.fp8_auto_legacy", cfg.kv_cache.fp8_auto_legacy);
     I("kv_cache.bitdecoding_residual_tokens", cfg.kv_cache.bitdecoding_residual_tokens);
     B("kv_cache.bitdecoding_qk", cfg.kv_cache.bitdecoding_qk);
+    B("kv_cache.swa_sizing", cfg.kv_cache.swa_sizing);
 
     // [attention]
     S("attention.fp8_prefill", cfg.attention.fp8_prefill);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -137,6 +137,16 @@ struct RuntimeConfig {
         int bitdecoding_residual_tokens = 0;
         // BitDecoding TC path for NVFP4 paged attention QK.
         bool bitdecoding_qk = false;
+        // SWA-aware KV sizing: sliding-window layers (gpt-oss window=128 on
+        // every other layer, gemma-3 5:1 pattern) allocate only the trailing
+        // window in a small dedicated block group instead of full-length KV
+        // (~2x more KV tokens on gpt-oss, ~5-6x on gemma-3). Auto-disabled
+        // (logged) for models without SWA layers, INT8/INT4 KV, hybrids,
+        // MLA, StreamingLLM, green contexts, and deterministic mode; prefix
+        // caching is forced off while active (freed window blocks cannot
+        // back prefix reuse — snapshot-based reuse is a follow-up).
+        // Default off until validated across the SWA model zoo.
+        bool swa_sizing = false;
     } kv_cache;
 
     struct Attention {

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -84,6 +84,10 @@ Engine::~Engine() {
         IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_));
         async_d_block_tables_ = nullptr;
     }
+    if (async_d_block_tables_swa_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_swa_));
+        async_d_block_tables_swa_ = nullptr;
+    }
     if (async_d_banned_tokens_) {
         IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
         async_d_banned_tokens_ = nullptr;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -304,6 +304,7 @@ private:
     GPUBatchPool decode_batch_pool_;
     BatchBuilder decode_builder_;
     std::vector<int> padded_block_table_;
+    std::vector<int> padded_swa_block_table_;
     std::vector<std::shared_ptr<Request>> sched_prefill_batch_;
     std::vector<std::shared_ptr<Request>> sched_decode_batch_;
     std::vector<std::shared_ptr<Request>> valid_decode_;
@@ -345,6 +346,7 @@ private:
     // so the next burst of the SAME request can rearm instead of recapture.
     int async_parked_req_id_ = -1;
     int async_bt_capacity_ = 0;  // block-table slots baked into the graph
+    int* async_d_block_tables_swa_ = nullptr;  // SWA-group mirror (kv_cache.swa_sizing)
 
     // Pipelined constrained decode (json_mode / json_schema, single sequence).
     // Constrained requests can't run the conditional graph loop (the grammar
@@ -365,6 +367,7 @@ private:
         int* d_pos = nullptr;        // [1] current position
         int* d_ctx = nullptr;        // [1] current context length
         int* d_bt = nullptr;         // uploaded block table
+        int* d_bt_swa = nullptr;     // SWA-group mirror (kv_cache.swa_sizing)
         int32_t* d_banned = nullptr; // banned token ids (device)
         int32_t* h_token = nullptr;  // pinned landing for the sampled token
         cudaEvent_t ev = nullptr;    // sampled-token-ready event
@@ -472,6 +475,7 @@ private:
     int32_t* d_pf_token_ids_ = nullptr;
     int* d_pf_positions_ = nullptr;
     int* d_pf_block_tables_ = nullptr;
+    int* d_pf_block_tables_swa_ = nullptr;  // SWA-group mirror (kv_cache.swa_sizing)
     int* d_pf_context_lens_ = nullptr;
     int* h_pf_positions_ = nullptr;      // pinned host staging
     int32_t* h_pf_token_ids_ = nullptr;  // pinned host staging
@@ -655,6 +659,7 @@ private:
     int32_t* d_spec_tokens_ = nullptr;
     int* d_spec_positions_ = nullptr;
     int* d_spec_block_table_ = nullptr;
+    int* d_spec_block_table_swa_ = nullptr;  // SWA-group mirror (kv_cache.swa_sizing)
     int* d_spec_context_len_ = nullptr;
     int32_t* d_spec_argmax_ = nullptr;
     int32_t* h_spec_argmax_ = nullptr;  // pinned, chunk_cap entries
@@ -677,6 +682,19 @@ private:
         long long emitted = 0;       // tokens emitted by verify steps
     };
     SpecStats spec_stats_{};
+
+    // ── SWA-aware KV sizing (kv_cache.swa_sizing) ────────────────────
+    // Resolved once in init_kv_cache (gate + geometry). When active, every
+    // forward's SWA layers go through the parallel SWA-group block tables;
+    // the engine calls kv_manager_->swa_prepare/swa_trim around each
+    // forwarded token range (prefill chunks, decode steps, on-device
+    // bursts, spec verify chunks).
+    bool swa_sizing_active_ = false;
+    int swa_window_max_ = 0;        // largest per-layer sliding window (tokens)
+    int swa_slack_tokens_ = 0;      // rollback/boundary cushion (tokens)
+    // Longest on-device burst span the SWA group is sized for — the graph
+    // decode loop clamps its step budget to this (no host trim mid-burst).
+    int swa_burst_cap_tokens_ = 0;
 
     // ── Banned tokens (special/control tokens that must not be generated) ──
     std::vector<int32_t> banned_token_ids_;
@@ -723,11 +741,12 @@ private:
     // the matching free path.
     [[nodiscard]] bool prefill_upload_metadata_(std::shared_ptr<Request>& req,
                                                 const std::vector<int>& block_table,
+                                                const std::vector<int>& swa_block_table,
                                                 int chunk_len, int offset, int ctx_len,
                                                 cudaStream_t pf_stream,
                                                 int32_t*& d_token_ids, int*& d_positions,
-                                                int*& d_block_tables, int*& d_context_lens,
-                                                bool& pf_pool_used);
+                                                int*& d_block_tables, int*& d_block_tables_swa,
+                                                int*& d_context_lens, bool& pf_pool_used);
     // step_decode_forward sub-phase: populate `state` from the uploaded
     // GPU batch + per-seq residual metadata + sampling params + recurrent
     // state + JSON/schema constrainers. Returns `needs_logprobs` so the

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -52,7 +52,21 @@ int Engine::prepare_graph_loop(std::shared_ptr<Request>& req) {
     int capped = blocks_got * kv_bs - ctx_len;
     if (capped <= 0)
         return 0;
-    return std::min(capped, remaining);
+    int steps = std::min(capped, remaining);
+
+    // SWA-aware sizing: the loop runs on-device with no host trim mid-burst,
+    // so the WHOLE burst span must have live SWA blocks. Clamp the burst to
+    // the span the SWA group is sized for (the loop relaunches afterwards)
+    // and prepare the range up front.
+    if (swa_sizing_active_) {
+        steps = std::min(steps, swa_burst_cap_tokens_);
+        if (steps <= 0)
+            return 0;
+        kv_manager_->swa_trim(req->id, ctx_len);
+        if (!kv_manager_->swa_prepare(req->id, ctx_len, ctx_len + steps))
+            return 0;
+    }
+    return steps;
 }
 
 CudaGraphConditionalRunner::Config Engine::build_graph_config(const Request& req, int remaining) const {
@@ -129,12 +143,27 @@ std::vector<int32_t> Engine::try_graph_loop_decode(std::shared_ptr<Request> req,
         return {};
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_block_tables, full_bt.data(), max_blocks_per_seq * sizeof(int),
                                        cudaMemcpyHostToDevice, stream));
+    int* d_block_tables_swa = nullptr;
+    if (swa_sizing_active_) {
+        const auto& swa_bt = kv_manager_->swa_block_table(req->id);
+        if (static_cast<int>(swa_bt.size()) == max_blocks_per_seq &&
+            cudaMallocAsync(&d_block_tables_swa, max_blocks_per_seq * sizeof(int), stream) ==
+                cudaSuccess) {
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_block_tables_swa, swa_bt.data(),
+                                               max_blocks_per_seq * sizeof(int),
+                                               cudaMemcpyHostToDevice, stream));
+        } else {
+            IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables, stream));
+            return {};
+        }
+    }
 
     (void)executor_->resize_workspace(1, stream);
 
     InferenceState state_template;
     state_template.kv_cache = kv_cache_raw_;
     state_template.block_tables = d_block_tables;
+    state_template.block_tables_swa = d_block_tables_swa;
     state_template.n_sequences = 1;
     state_template.max_blocks_per_seq = max_blocks_per_seq;
     state_template.is_prefill = false;
@@ -161,12 +190,16 @@ std::vector<int32_t> Engine::try_graph_loop_decode(std::shared_ptr<Request> req,
     if (!runner.setup(executor_.get(), state_template, first_token, gcfg, stream)) {
         if (d_banned)
             IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_banned, stream));
+        if (d_block_tables_swa)
+            IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables_swa, stream));
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables, stream));
         return {};
     }
     if (!runner.launch(stream)) {
         if (d_banned)
             IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_banned, stream));
+        if (d_block_tables_swa)
+            IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables_swa, stream));
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables, stream));
         return {};
     }
@@ -174,6 +207,8 @@ std::vector<int32_t> Engine::try_graph_loop_decode(std::shared_ptr<Request> req,
     auto tokens = runner.wait_and_get_tokens(stream);
     if (d_banned)
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_banned, stream));
+    if (d_block_tables_swa)
+        IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables_swa, stream));
     IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables, stream));
     IMP_LOG_INFO("ConditionalGraph: generated %zu tokens in graph loop", tokens.size());
     runner.cleanup();
@@ -198,13 +233,22 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
         async_parked_req_id_ >= 0) {
         const auto& bt = kv_manager_->block_table(req->id);
         const int ctx = req->context_len();
-        if (async_parked_req_id_ == req->id && async_d_block_tables_ != nullptr &&
+        // SWA table must exist at matching length for a rearm (swa_prepare in
+        // prepare_graph_loop already covered the new burst range).
+        const auto& swa_bt = kv_manager_->swa_block_table(req->id);
+        const bool swa_ok = !swa_sizing_active_ ||
+                            (async_d_block_tables_swa_ != nullptr && swa_bt.size() == bt.size());
+        if (async_parked_req_id_ == req->id && async_d_block_tables_ != nullptr && swa_ok &&
             static_cast<int>(bt.size()) <= async_bt_capacity_) {
             // Verify steps may have appended KV blocks since the park —
             // refresh the table contents (pointer/capacity baked in graph).
             IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(async_d_block_tables_, bt.data(),
                                                bt.size() * sizeof(int), cudaMemcpyHostToDevice,
                                                stream));
+            if (swa_sizing_active_)
+                IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(async_d_block_tables_swa_, swa_bt.data(),
+                                                   swa_bt.size() * sizeof(int),
+                                                   cudaMemcpyHostToDevice, stream));
             // Remaining think budget for this launch (the device counter
             // restarts at 0 per launch; see build_graph_config).
             int think_limit = 0;
@@ -237,6 +281,10 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
             IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_));
             async_d_block_tables_ = nullptr;
         }
+        if (async_d_block_tables_swa_) {
+            IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_swa_));
+            async_d_block_tables_swa_ = nullptr;
+        }
         if (async_d_banned_tokens_) {
             IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
             async_d_banned_tokens_ = nullptr;
@@ -252,12 +300,24 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
         return false;
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_bt, full_bt.data(), max_blocks_per_seq * sizeof(int),
                                        cudaMemcpyHostToDevice, stream));
+    int* d_bt_swa = nullptr;
+    if (swa_sizing_active_) {
+        const auto& swa_bt = kv_manager_->swa_block_table(req->id);
+        if (static_cast<int>(swa_bt.size()) != max_blocks_per_seq ||
+            cudaMalloc(&d_bt_swa, max_blocks_per_seq * sizeof(int)) != cudaSuccess) {
+            IMP_CUDA_CHECK_LOG(cudaFree(d_bt));
+            return false;
+        }
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_bt_swa, swa_bt.data(), max_blocks_per_seq * sizeof(int),
+                                           cudaMemcpyHostToDevice, stream));
+    }
 
     (void)executor_->resize_workspace(1, stream);
 
     InferenceState state_template;
     state_template.kv_cache = kv_cache_raw_;
     state_template.block_tables = d_bt;
+    state_template.block_tables_swa = d_bt_swa;
     state_template.n_sequences = 1;
     state_template.max_blocks_per_seq = max_blocks_per_seq;
     state_template.is_prefill = false;
@@ -287,6 +347,8 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     if (!async_graph_runner_.setup(executor_.get(), state_template, first_token, gcfg, stream)) {
         if (d_banned)
             IMP_CUDA_CHECK_LOG(cudaFree(d_banned));
+        if (d_bt_swa)
+            IMP_CUDA_CHECK_LOG(cudaFree(d_bt_swa));
         IMP_CUDA_CHECK_LOG(cudaFree(d_bt));
         return false;
     }
@@ -294,12 +356,15 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
         async_graph_runner_.cleanup();
         if (d_banned)
             IMP_CUDA_CHECK_LOG(cudaFree(d_banned));
+        if (d_bt_swa)
+            IMP_CUDA_CHECK_LOG(cudaFree(d_bt_swa));
         IMP_CUDA_CHECK_LOG(cudaFree(d_bt));
         return false;
     }
 
     async_graph_req_ = req;
     async_d_block_tables_ = d_bt;
+    async_d_block_tables_swa_ = d_bt_swa;
     async_d_banned_tokens_ = d_banned;
     async_bt_capacity_ = max_blocks_per_seq;
     async_parked_req_id_ = -1;
@@ -324,6 +389,12 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
 // =====================================================================
 
 bool Engine::try_launch_constrained_pipeline(std::shared_ptr<Request> req, cudaStream_t stream) {
+    // SWA-aware sizing: the pipeline captures a decode graph with a baked
+    // block-table pointer + jump-ahead chunk, neither wired for the per-step
+    // SWA table rewrite. Fall back to eager constrained decode (step_decode,
+    // which threads the SWA table) — correct, just not pipelined.
+    if (swa_sizing_active_)
+        return false;
     int budget = prepare_graph_loop(req);
     if (budget <= 0)
         return false;

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -492,6 +492,23 @@ void Engine::init_compute_max_seq_len_() {
             if (populated > 0)
                 kv_layer_count = populated;
         }
+        // SWA-aware sizing (kv_cache.swa_sizing): sliding-window layers hold
+        // only a fixed trailing window, so they don't scale with context —
+        // count only global layers for the per-token cost. (The final gate is
+        // resolved in init_kv_cache; if it declines there the budget clamps
+        // conservatively, never OOMs.)
+        if (runtime_config_.kv_cache.swa_sizing) {
+            int swa_layers = 0;
+            for (int l = 0; l < mcfg.n_layers; l++)
+                if (layer_swa_window(mcfg, model_->profile(), l) > 0)
+                    ++swa_layers;
+            if (swa_layers > 0 && swa_layers < kv_layer_count) {
+                IMP_LOG_INFO("max_seq_len auto: SWA sizing — %d/%d windowed layers excluded "
+                             "from per-token KV cost",
+                             swa_layers, kv_layer_count);
+                kv_layer_count -= swa_layers;
+            }
+        }
         auto kv = config_.kv_cache_dtype;
         bool packed_int4 = (kv == QType::INT4);
         size_t per_tok_elems = static_cast<size_t>(mcfg.n_kv_heads) * head_dim * kv_layer_count *

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -99,9 +99,78 @@ bool Engine::init_kv_cache() {
     const int kv_bs = config_.kv_block_size;
     int blocks_per_seq = (config_.max_seq_len + kv_bs - 1) / kv_bs;
 
+    // ── SWA-aware KV sizing gate (kv_cache.swa_sizing) ────────────────
+    // Sliding-window layers get a small dedicated block group instead of
+    // full-length KV. Resolve the gate + geometry before the VRAM budget so
+    // the budget charges SWA layers window-cost, not context-cost.
+    swa_sizing_active_ = false;
+    swa_window_max_ = 0;
+    int n_swa_layers = 0;
+    if (runtime_config_.kv_cache.swa_sizing) {
+        const auto& prof = model_->profile();
+        for (int i = 0; i < mcfg.n_layers; i++) {
+            if (kv_layer_map[i] < 0)
+                continue;  // non-attention layer
+            int w = layer_swa_window(mcfg, prof, i);
+            if (w > 0) {
+                n_swa_layers++;
+                swa_window_max_ = std::max(swa_window_max_, w);
+            }
+        }
+        const char* off_reason = nullptr;
+        if (n_swa_layers == 0)
+            off_reason = "model has no sliding-window layers";
+        else if (n_swa_layers == n_kv_layers && swa_window_max_ >= config_.max_seq_len)
+            off_reason = "window >= max_seq_len (nothing to save)";
+        else if (config_.kv_cache_dtype == QType::INT8 || config_.kv_cache_dtype == QType::INT4)
+            off_reason = "INT8/INT4 KV lacks the per-layer cache path";
+        else if (prof.is_ssm || prof.is_gdn)
+            off_reason = "hybrid recurrent model (conservative)";
+        else if (mcfg.is_mla())
+            off_reason = "MLA attention";
+        else if (config_.streaming_kv_enabled)
+            off_reason = "StreamingLLM is enabled";
+        else if (config_.use_green_contexts)
+            off_reason = "green contexts (cross-stream block reuse unordered)";
+        else if (runtime_config_.runtime.deterministic)
+            off_reason = "deterministic mode (unbounded graph loop would be burst-chunked)";
+        if (off_reason) {
+            IMP_LOG_INFO("kv_cache.swa_sizing=true ignored: %s", off_reason);
+            swa_window_max_ = 0;
+            n_swa_layers = 0;
+        } else {
+            swa_sizing_active_ = true;
+            // Slack must cover the deepest speculative rollback (verify
+            // chunks roll back rejected drafts) plus the partial boundary
+            // block. Sized from the spec config so the assert can't trip.
+            const auto& sc = runtime_config_.speculative;
+            int spec_depth = std::max({sc.k, sc.suffix_k_max, sc.mtp_k + 1, kJumpRowsCap});
+            swa_slack_tokens_ = std::max(2 * kv_bs, spec_depth + kv_bs);
+            // Longest on-device burst span (graph decode loop) plus the
+            // largest prefill chunk the live window must ride through.
+            int chunk_peak = config_.prefill_chunk_size > 0 ? config_.prefill_chunk_size : 2048;
+            int burst_peak = runtime_config_.runtime.decode_burst > 0
+                                 ? runtime_config_.runtime.decode_burst
+                                 : 512;
+            swa_burst_cap_tokens_ = std::max(chunk_peak, burst_peak);
+            // Prefix caching cannot reuse freed window blocks — force it off
+            // (snapshot-based SWA reuse is a follow-up).
+            if (config_.use_prefix_caching) {
+                config_.use_prefix_caching = false;
+                IMP_LOG_INFO("kv_cache.swa_sizing: prefix caching disabled (freed window "
+                             "blocks cannot back prefix reuse)");
+            }
+            // StreamingLLM auto-enable frees middle blocks of the GLOBAL
+            // table — redundant and conflicting here.
+            config_.streaming_kv_auto = false;
+        }
+    }
+    const int swa_live_tokens =
+        swa_sizing_active_ ? swa_window_max_ + swa_slack_tokens_ + swa_burst_cap_tokens_ : 0;
+
     // VRAM budget
-    auto vram_budget =
-        compute_vram_budget(*model_, config_, n_kv_layers, head_dim, effective_free_vram());
+    auto vram_budget = compute_vram_budget(*model_, config_, n_kv_layers, head_dim,
+                                           effective_free_vram(), swa_live_tokens, n_swa_layers);
     int max_blocks = config_.kv_cache_max_blocks > 0 ? config_.kv_cache_max_blocks
                                                      : vram_budget.kv_max_blocks;
 
@@ -119,31 +188,42 @@ bool Engine::init_kv_cache() {
 
     // Per-layer KV shape path (Gemma 4 dual attention geometry): build per-layer
     // nkv/hd arrays restricted to attention layers (hybrid models may have non-attn layers).
+    // SWA sizing also requires the per-layer path (per-layer region capacities).
     std::unique_ptr<KVCache> kv_cache;
-    if (!mcfg.head_dim_per_layer.empty() && config_.kv_cache_dtype != QType::INT8 &&
-        config_.kv_cache_dtype != QType::INT4) {
+    if ((!mcfg.head_dim_per_layer.empty() || swa_sizing_active_) &&
+        config_.kv_cache_dtype != QType::INT8 && config_.kv_cache_dtype != QType::INT4) {
         std::vector<int> per_layer_nkv(n_kv_layers, 0);
         std::vector<int> per_layer_hd(n_kv_layers, 0);
+        std::vector<char> per_layer_swa(swa_sizing_active_ ? n_kv_layers : 0, 0);
         for (int l = 0, k = 0; l < mcfg.n_layers && k < n_kv_layers; l++) {
             // Only attention layers get KV cache entries
             int attn_nkv = (l < (int)mcfg.n_kv_heads_per_layer.size()) ? mcfg.n_kv_heads_per_layer[l]
                                                                        : mcfg.n_kv_heads;
-            if (attn_nkv <= 0)
+            if (kv_layer_map[l] < 0)
                 continue;  // non-attention layer (SSM/GDN)
+            if (attn_nkv <= 0)
+                attn_nkv = mcfg.n_kv_heads;
             per_layer_nkv[k] = attn_nkv;
             per_layer_hd[k] = (l < (int)mcfg.head_dim_per_layer.size() && mcfg.head_dim_per_layer[l] > 0)
                                   ? mcfg.head_dim_per_layer[l]
                                   : head_dim;
+            if (swa_sizing_active_)
+                per_layer_swa[k] = layer_swa_window(mcfg, model_->profile(), l) > 0 ? 1 : 0;
             k++;
         }
         kv_cache = std::make_unique<KVCache>(n_kv_layers, per_layer_nkv, per_layer_hd, config_.kv_cache_dtype,
-                                             max_blocks, kv_bs, &vram_alloc_);
+                                             max_blocks, kv_bs, &vram_alloc_, per_layer_swa,
+                                             swa_sizing_active_ ? vram_budget.swa_max_blocks : 0);
     } else {
         kv_cache = std::make_unique<KVCache>(n_kv_layers, mcfg.n_kv_heads, head_dim, config_.kv_cache_dtype,
                                              max_blocks, kv_bs, &vram_alloc_);
     }
     kv_cache_raw_ = kv_cache.get();
     kv_manager_ = std::make_unique<KVCacheManager>(std::move(kv_cache));
+    if (swa_sizing_active_) {
+        kv_manager_->enable_swa_sizing(swa_window_max_, swa_slack_tokens_);
+        swa_sizing_active_ = kv_manager_->swa_sizing_enabled();
+    }
 
     // BitDecoding Phase 3: residual FP16 cache (opt-in).
     //
@@ -304,7 +384,8 @@ bool Engine::init_kv_cache() {
         IMP_LOG_INFO("Weight cache: FP8 E4M3 (2x prefill throughput on sm_120)");
 
     // Pre-allocate decode batch pool + penalty buffer
-    decode_batch_pool_.allocate(config_.max_batch_size, blocks_per_seq, &vram_alloc_);
+    decode_batch_pool_.allocate(config_.max_batch_size, blocks_per_seq, &vram_alloc_,
+                                /*with_swa_tables=*/swa_sizing_active_);
     {
         d_penalty_tokens_capacity_ = static_cast<size_t>(config_.max_seq_len);
         d_penalty_tokens_ = static_cast<int32_t*>(
@@ -324,15 +405,20 @@ bool Engine::init_kv_cache() {
         // max_blocks so the H2D copy at the prefill metadata upload site
         // doesn't overflow on long-cumulative-KV requests.
         size_t bt_bytes = static_cast<size_t>(max_blocks) * sizeof(int);
+        size_t swa_bt_bytes = swa_sizing_active_ ? bt_bytes : 0;
         size_t cl_bytes = sizeof(int);
-        prefill_pool_size_ = tok_bytes + pos_bytes + bt_bytes + cl_bytes;
+        prefill_pool_size_ = tok_bytes + pos_bytes + bt_bytes + swa_bt_bytes + cl_bytes;
         prefill_pool_ = vram_alloc_.allocate(prefill_pool_size_, "prefill_pool");
         if (prefill_pool_) {
             auto* base = static_cast<char*>(prefill_pool_);
             d_pf_token_ids_ = reinterpret_cast<int32_t*>(base);
             d_pf_positions_ = reinterpret_cast<int*>(base + tok_bytes);
             d_pf_block_tables_ = reinterpret_cast<int*>(base + tok_bytes + pos_bytes);
-            d_pf_context_lens_ = reinterpret_cast<int*>(base + tok_bytes + pos_bytes + bt_bytes);
+            if (swa_sizing_active_)
+                d_pf_block_tables_swa_ =
+                    reinterpret_cast<int*>(base + tok_bytes + pos_bytes + bt_bytes);
+            d_pf_context_lens_ =
+                reinterpret_cast<int*>(base + tok_bytes + pos_bytes + bt_bytes + swa_bt_bytes);
         } else {
             IMP_LOG_WARN("Failed to pre-allocate prefill pool, will use per-request malloc");
         }

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -169,6 +169,10 @@ int Engine::step_async_graph_resume() {
                 IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_));
                 async_d_block_tables_ = nullptr;
             }
+            if (async_d_block_tables_swa_) {
+                IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_swa_));
+                async_d_block_tables_swa_ = nullptr;
+            }
             if (async_d_banned_tokens_) {
                 IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
                 async_d_banned_tokens_ = nullptr;
@@ -537,16 +541,19 @@ bool Engine::prefill_allocate_kv_blocks_(std::shared_ptr<Request>& req, int kv_b
 // pageable→pinned copy inside cuMemcpy).
 bool Engine::prefill_upload_metadata_(std::shared_ptr<Request>& req,
                                       const std::vector<int>& block_table,
+                                      const std::vector<int>& swa_block_table,
                                       int chunk_len, int offset, int ctx_len,
                                       cudaStream_t pf_stream,
                                       int32_t*& d_token_ids, int*& d_positions,
-                                      int*& d_block_tables, int*& d_context_lens,
-                                      bool& pf_pool_used) {
+                                      int*& d_block_tables, int*& d_block_tables_swa,
+                                      int*& d_context_lens, bool& pf_pool_used) {
     d_token_ids = nullptr;
     d_positions = nullptr;
     d_block_tables = nullptr;
+    d_block_tables_swa = nullptr;
     d_context_lens = nullptr;
     pf_pool_used = false;
+    const bool want_swa = swa_sizing_active_ && !swa_block_table.empty();
 
     auto check = [&req](cudaError_t err, const char* op) {
         if (err != cudaSuccess) {
@@ -560,6 +567,8 @@ bool Engine::prefill_upload_metadata_(std::shared_ptr<Request>& req,
         d_token_ids = d_pf_token_ids_;
         d_positions = d_pf_positions_;
         d_block_tables = d_pf_block_tables_;
+        if (want_swa)
+            d_block_tables_swa = d_pf_block_tables_swa_;
         d_context_lens = d_pf_context_lens_;
         pf_pool_used = true;
     } else {
@@ -568,6 +577,9 @@ bool Engine::prefill_upload_metadata_(std::shared_ptr<Request>& req,
             !check(cudaMallocAsync(&d_positions, chunk_len * sizeof(int), pf_stream), "malloc positions") ||
             !check(cudaMallocAsync(&d_block_tables, block_table.size() * sizeof(int), pf_stream),
                    "malloc block_tables") ||
+            (want_swa &&
+             !check(cudaMallocAsync(&d_block_tables_swa, swa_block_table.size() * sizeof(int), pf_stream),
+                    "malloc block_tables_swa")) ||
             !check(cudaMallocAsync(&d_context_lens, sizeof(int), pf_stream), "malloc context_lens")) {
             if (d_token_ids)
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_token_ids, pf_stream));
@@ -575,6 +587,8 @@ bool Engine::prefill_upload_metadata_(std::shared_ptr<Request>& req,
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_positions, pf_stream));
             if (d_block_tables)
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables, pf_stream));
+            if (d_block_tables_swa)
+                IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_block_tables_swa, pf_stream));
             if (d_context_lens)
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_context_lens, pf_stream));
             kv_manager_->free_sequence(req->id);
@@ -626,6 +640,11 @@ bool Engine::prefill_upload_metadata_(std::shared_ptr<Request>& req,
     check(cudaMemcpyAsync(d_block_tables, block_table.data(), block_table.size() * sizeof(int),
                           cudaMemcpyHostToDevice, pf_stream),
           "memcpy block_tables");
+    if (want_swa && d_block_tables_swa) {
+        check(cudaMemcpyAsync(d_block_tables_swa, swa_block_table.data(),
+                              swa_block_table.size() * sizeof(int), cudaMemcpyHostToDevice, pf_stream),
+              "memcpy block_tables_swa");
+    }
     check(cudaMemcpyAsync(d_context_lens, &ctx_len, sizeof(int), cudaMemcpyHostToDevice, pf_stream),
           "memcpy context_lens");
     return true;
@@ -708,16 +727,30 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         return;  // caller already set req->status = CANCELLED
     }
 
+    // SWA-aware sizing: live window blocks for this chunk's write range plus
+    // the window its queries/continuation-gathers read back into. Trimming of
+    // blocks that fell out of the window happens after the chunk commits.
+    if (swa_sizing_active_) {
+        kv_manager_->swa_trim(req->id, offset);
+        if (!kv_manager_->swa_prepare(req->id, offset, ctx_len)) {
+            kv_manager_->free_sequence(req->id);
+            req->status = RequestStatus::CANCELLED;
+            return;
+        }
+    }
+
     const auto& block_table = kv_manager_->block_table(req->id);
+    const auto& swa_block_table = kv_manager_->swa_block_table(req->id);
 
     int32_t* d_token_ids = nullptr;
     int* d_positions = nullptr;
     int* d_block_tables = nullptr;
+    int* d_block_tables_swa = nullptr;
     int* d_context_lens = nullptr;
     bool pf_pool_used = false;
-    if (!prefill_upload_metadata_(req, block_table, chunk_len, offset, ctx_len, pf_stream,
-                                  d_token_ids, d_positions, d_block_tables, d_context_lens,
-                                  pf_pool_used)) {
+    if (!prefill_upload_metadata_(req, block_table, swa_block_table, chunk_len, offset, ctx_len,
+                                  pf_stream, d_token_ids, d_positions, d_block_tables,
+                                  d_block_tables_swa, d_context_lens, pf_pool_used)) {
         return;  // caller already set req->status = CANCELLED
     }
 
@@ -728,6 +761,7 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     state.n_tokens = chunk_len;
     state.kv_cache = kv_cache_raw_;
     state.block_tables = d_block_tables;
+    state.block_tables_swa = d_block_tables_swa;
     state.context_lens = d_context_lens;
     state.max_context_len = ctx_len;
     state.n_sequences = 1;
@@ -1154,9 +1188,21 @@ void Engine::step_decode(cudaStream_t dec_stream) {
             }
         }
 
+        // SWA-aware sizing: keep the trailing window live for this step's
+        // write + reads; retire blocks that fell out of the window.
+        if (swa_sizing_active_) {
+            kv_manager_->swa_trim(req->id, ctx_len);
+            if (!kv_manager_->swa_prepare(req->id, ctx_len)) {
+                kv_manager_->free_sequence(req->id);
+                req->status = RequestStatus::CANCELLED;
+                continue;
+            }
+        }
+
         // Auto-activate StreamingLLM when KV cache is nearly exhausted.
         // Only fires once (guards on !streaming_kv_enabled) and only for FP16
         // KV — quantized variants don't support sentinel-block skipping yet.
+        // Never under SWA sizing (streaming_kv_auto is cleared at init there).
         if (!config_.streaming_kv_enabled && config_.streaming_kv_auto) {
             auto st = kv_manager_->stats();
             if (st.total_blocks > 0 && st.free_blocks < st.total_blocks / 10) {
@@ -1225,6 +1271,7 @@ void Engine::decode_build_inference_state_(GPUBatch& gpu_batch,
     state.max_blocks_per_seq = gpu_batch.max_blocks_per_seq;
     state.kv_cache = kv_cache_raw_;
     state.block_tables = gpu_batch.d_block_tables;
+    state.block_tables_swa = gpu_batch.d_block_tables_swa;
     state.context_lens = gpu_batch.d_context_lens;
     state.max_context_len = max_ctx;
     state.is_prefill = false;
@@ -1359,8 +1406,11 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
         int position = ctx_len - 1;
 
         const auto& bt = kv_manager_->block_table(req->id);
+        const auto& sbt = kv_manager_->swa_block_table(req->id);
         decode_builder_.add_decode_sequence(last_token, position, bt.data(), static_cast<int>(bt.size()),
-                                            ctx_len);
+                                            ctx_len,
+                                            swa_sizing_active_ && !sbt.empty() ? sbt.data() : nullptr,
+                                            static_cast<int>(sbt.size()));
     }
 
     Batch batch = decode_builder_.build();
@@ -1381,6 +1431,17 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
                 }
             }
             batch.block_tables.swap(padded_block_table_);
+            // Re-pad the SWA tables at the same stride (-1 = hole, never 0).
+            if (!batch.block_tables_swa.empty()) {
+                padded_swa_block_table_.assign(needed, -1);
+                for (int s = 0; s < n_seq; s++) {
+                    for (int b = 0; b < old_stride; b++) {
+                        padded_swa_block_table_[s * pool_max + b] =
+                            batch.block_tables_swa[s * old_stride + b];
+                    }
+                }
+                batch.block_tables_swa.swap(padded_swa_block_table_);
+            }
             batch.max_blocks_per_seq = pool_max;
         }
         gpu_batch = decode_batch_pool_.upload_into_pool(batch, dec_stream);

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -59,7 +59,11 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
               cudaMalloc(&d_spec_past_len_, sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_chunk_len_, sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
-              cudaMallocHost(&h_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess;
+              cudaMallocHost(&h_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
+              // SWA-group mirror (kv_cache.swa_sizing): same capacity as the
+              // main table. Allocated unconditionally so a mid-session gate
+              // flip can't leave it null; tiny (max_blocks ints).
+              cudaMalloc(&d_spec_block_table_swa_, max_blocks * sizeof(int)) == cudaSuccess;
     if (!ok) {
         IMP_LOG_WARN("spec-ngram: buffer allocation failed — speculation disabled this step");
         free_spec_buffers_();
@@ -125,6 +129,7 @@ void Engine::free_spec_buffers_() {
     if (d_spec_tokens_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_tokens_));
     if (d_spec_positions_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_positions_));
     if (d_spec_block_table_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_));
+    if (d_spec_block_table_swa_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_swa_));
     if (d_spec_context_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_context_len_));
     if (d_spec_past_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_past_len_));
     if (d_spec_chunk_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_chunk_len_));
@@ -133,6 +138,7 @@ void Engine::free_spec_buffers_() {
     d_spec_tokens_ = nullptr;
     d_spec_positions_ = nullptr;
     d_spec_block_table_ = nullptr;
+    d_spec_block_table_swa_ = nullptr;
     d_spec_context_len_ = nullptr;
     d_spec_past_len_ = nullptr;
     d_spec_chunk_len_ = nullptr;
@@ -342,7 +348,11 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     // (copies of t0 at positions after every real row) are causally invisible
     // to the real rows; their KV entries fall to the same rollback that drops
     // rejected drafts, and the argmax window below stays [0, chunk_len).
-    const bool capture_on = spec_capture_ready_(p0 + spec_capture_bucket_(chunk_len));
+    // SWA-aware sizing: the verify chunk stays EAGER (captured verify bakes
+    // full-context gather grids + a static block-table pointer; the SWA table
+    // rewrites every step). Correctness still requires the SWA table below.
+    const bool capture_on =
+        !swa_sizing_active_ && spec_capture_ready_(p0 + spec_capture_bucket_(chunk_len));
     const int chunk_pad = capture_on ? spec_capture_bucket_(chunk_len) : chunk_len;
     const int ctx_len = p0 + chunk_pad;  // context including the full (padded) chunk
 
@@ -363,8 +373,21 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
             return false;
         }
     }
+    // SWA-aware sizing: keep the trailing window live across the whole
+    // chunk's write+read span [p0, ctx_len). Runs after the global append
+    // loop above so the SWA table can pad to the grown global length.
+    if (swa_sizing_active_) {
+        kv_manager_->swa_trim(req->id, p0);
+        if (!kv_manager_->swa_prepare(req->id, p0, ctx_len)) {
+            kv_manager_->rollback(req->id, p0);
+            spec_stats_.miss_steps++;
+            return false;
+        }
+    }
+
     const auto& block_table = kv_manager_->block_table(req->id);
     const int n_blocks = static_cast<int>(block_table.size());
+    const auto& swa_block_table = kv_manager_->swa_block_table(req->id);
 
     // Staging capacity follows the REAL table size — the async graph loop
     // pre-allocates blocks for the whole remaining generation, so the table
@@ -404,6 +427,10 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
                                cudaMemcpyHostToDevice, stream), "positions H2D") ||
         !check(cudaMemcpyAsync(d_spec_block_table_, block_table.data(), n_blocks * sizeof(int),
                                cudaMemcpyHostToDevice, stream), "block table H2D") ||
+        (swa_sizing_active_ && !swa_block_table.empty() &&
+         !check(cudaMemcpyAsync(d_spec_block_table_swa_, swa_block_table.data(),
+                                static_cast<int>(swa_block_table.size()) * sizeof(int),
+                                cudaMemcpyHostToDevice, stream), "swa block table H2D")) ||
         !check(cudaMemcpyAsync(d_spec_context_len_, &ctx_len, sizeof(int), cudaMemcpyHostToDevice,
                                stream), "context len H2D") ||
         (capture_on &&
@@ -429,6 +456,8 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     state.n_tokens = chunk_pad;
     state.kv_cache = kv_cache_raw_;
     state.block_tables = d_spec_block_table_;
+    state.block_tables_swa =
+        (swa_sizing_active_ && !swa_block_table.empty()) ? d_spec_block_table_swa_ : nullptr;
     state.context_lens = d_spec_context_len_;
     state.max_context_len = ctx_len;
     state.n_sequences = 1;

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -320,6 +320,10 @@ void Engine::warmup() {
         IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_));
         async_d_block_tables_ = nullptr;
     }
+    if (async_d_block_tables_swa_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_swa_));
+        async_d_block_tables_swa_ = nullptr;
+    }
     if (async_d_banned_tokens_) {
         IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
         async_d_banned_tokens_ = nullptr;

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -9,7 +9,7 @@
 namespace imp {
 
 VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, int n_kv_layers, int head_dim,
-                               size_t free_vram) {
+                               size_t free_vram, int swa_live_tokens, int n_swa_layers) {
     VRAMBudget budget;
     const auto& mcfg = model.config();
 
@@ -91,17 +91,36 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
         single_block_bytes = static_cast<size_t>(bs) * mcfg.n_kv_heads * head_dim *
                              dtype_size(config.kv_cache_dtype);
     }
-    // K+V (2x) for all supported dtypes.
-    size_t per_block_total = single_block_bytes * 2 * n_kv_layers;
+    // Per-token scale overhead folded into the per-layer block bytes.
+    size_t scale_per_block = 0;
     if (config.kv_cache_dtype == QType::INT8 || config.kv_cache_dtype == QType::INT4) {
-        size_t scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * sizeof(half);
-        per_block_total += scale_per_block * 2 * n_kv_layers;  // K scales + V scales (always 2x)
+        scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * sizeof(half);
+    } else if (config.kv_cache_dtype == QType::NVFP4 || config.kv_cache_dtype == QType::MXFP4_KV) {
+        scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * (head_dim / 16);
     }
-    // NVFP4 / MXFP4_KV: 1 scale byte per 16 elems per head per token, K+V (2x).
-    if (config.kv_cache_dtype == QType::NVFP4 || config.kv_cache_dtype == QType::MXFP4_KV) {
-        size_t scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * (head_dim / 16);
-        per_block_total += scale_per_block * 2 * n_kv_layers;
+    const size_t per_layer_block_bytes = (single_block_bytes + scale_per_block) * 2;  // K+V
+
+    // SWA-aware sizing (kv_cache.swa_sizing): sliding-window layers hold a
+    // fixed live span (window + slack + burst/chunk peak) per sequence slot —
+    // charge them batch-shaped up front, exactly like the SSM state slabs,
+    // and let only the global layers scale with context below.
+    int n_global_layers = n_kv_layers;
+    if (swa_live_tokens > 0 && n_swa_layers > 0 && n_swa_layers <= n_kv_layers) {
+        n_global_layers = n_kv_layers - n_swa_layers;
+        int swa_blocks_per_seq = (swa_live_tokens + bs - 1) / bs + 1;
+        int batch = config.max_batch_size > 0 ? config.max_batch_size : 1;
+        budget.swa_max_blocks = swa_blocks_per_seq * batch;
+        size_t swa_footprint = static_cast<size_t>(budget.swa_max_blocks) * per_layer_block_bytes *
+                               static_cast<size_t>(n_swa_layers);
+        available = (available > swa_footprint) ? (available - swa_footprint) : 0;
+        IMP_LOG_INFO("VRAM budget: SWA group %d blocks × %d layers = %.1f MiB "
+                     "(live span %d tokens, %d global layers keep full context)",
+                     budget.swa_max_blocks, n_swa_layers, swa_footprint / (1024.0 * 1024.0),
+                     swa_live_tokens, n_global_layers);
     }
+
+    // K+V (2x) per GLOBAL layer — SWA layers were charged batch-shaped above.
+    size_t per_block_total = per_layer_block_bytes * n_global_layers;
 
     int blocks_per_seq = (config.max_seq_len + bs - 1) / bs;
     int needed_blocks = blocks_per_seq * config.max_batch_size;

--- a/src/runtime/vram_budget.h
+++ b/src/runtime/vram_budget.h
@@ -18,13 +18,22 @@ struct VRAMBudget {
     size_t nvfp4_cache_bytes = 0;
     size_t reserve_bytes = 1024ULL * 1024 * 1024;  // 1 GiB safety
     int kv_max_blocks = 0;
+    // SWA-aware sizing (kv_cache.swa_sizing): capacity of the dedicated
+    // sliding-window block group (0 = feature off). Sized batch-shaped:
+    // ceil(swa_live_tokens / block_size) + 1 blocks per sequence slot.
+    int swa_max_blocks = 0;
     bool nvfp4_second_pass = false;  // true → re-run NVFP4 after FP16-Free
 };
 
 // Pure computation: plan VRAM allocation split between KV cache, FP8 prefill
 // cache, and NVFP4 decode cache based on model characteristics and config.
 // No GPU allocation — just arithmetic.
+//
+// swa_live_tokens / n_swa_layers (kv_cache.swa_sizing, both 0 = off):
+// sliding-window layers are charged a fixed per-sequence live span of
+// swa_live_tokens (window + slack + burst/chunk peak) instead of
+// max_seq_len; only the remaining global layers scale with context.
 VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, int n_kv_layers, int head_dim,
-                               size_t free_vram);
+                               size_t free_vram, int swa_live_tokens = 0, int n_swa_layers = 0);
 
 }  // namespace imp

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -1448,5 +1448,120 @@ TEST(KVCacheManagerTest, CacheHitOnCachedBlockKeepsReclaimableCountExact) {
     EXPECT_EQ(mgr->num_reclaimable_cached_blocks(), 2);
 }
 
+// ============================================================================
+// SWA-aware KV sizing (kv_cache.swa_sizing) — dedicated block group + the
+// trailing-free positional table in the manager.
+// ============================================================================
+
+// Per-layer ctor with a SWA group: windowed layers draw from a separate,
+// smaller block-id space; global layers keep the full pool.
+TEST(KVCacheTest, SwaGroupCapacityAndIdSpace) {
+    SKIP_IF_NO_CUDA();
+
+    const int n_layers = 4;
+    const int global_max = 64;
+    const int swa_max = 6;
+    std::vector<int> nkv(n_layers, 4);
+    std::vector<int> hd(n_layers, 64);
+    std::vector<char> is_swa = {1, 0, 1, 0};  // layers 0,2 windowed
+
+    KVCache cache(n_layers, nkv, hd, QType::F16, global_max, kKVBlockSize, nullptr, is_swa, swa_max);
+    ASSERT_TRUE(cache.swa_enabled());
+    EXPECT_TRUE(cache.layer_is_swa(0));
+    EXPECT_FALSE(cache.layer_is_swa(1));
+    EXPECT_EQ(cache.swa_total_blocks(), swa_max);
+
+    // Global id space: global_max blocks.
+    EXPECT_EQ(cache.num_free_blocks(), global_max);
+    // SWA id space: swa_max blocks, allocated independently.
+    EXPECT_EQ(cache.num_free_swa_blocks(), swa_max);
+    std::vector<int> swa_ids;
+    for (int i = 0; i < swa_max; ++i) {
+        int id = cache.allocate_swa_block();
+        ASSERT_GE(id, 0);
+        ASSERT_LT(id, swa_max);
+        swa_ids.push_back(id);
+    }
+    EXPECT_EQ(cache.allocate_swa_block(), -1);  // group exhausted
+    EXPECT_EQ(cache.num_free_blocks(), global_max);  // global untouched
+    cache.free_swa_block(swa_ids[0]);
+    EXPECT_EQ(cache.num_free_swa_blocks(), 1);
+    // k_ptr for a windowed layer with a SWA-space id resolves inside the pool.
+    EXPECT_NE(cache.k_ptr(0, swa_ids[1]), nullptr);
+}
+
+// Manager trailing-free: swa_prepare allocates only the live window tail;
+// earlier positions are -1 holes; swa_trim frees blocks that fell out.
+TEST(KVCacheManagerTest, SwaTrailingFreeTable) {
+    SKIP_IF_NO_CUDA();
+
+    const int bs = 16;
+    const int n_layers = 2;
+    std::vector<int> nkv(n_layers, 4), hd(n_layers, 64);
+    std::vector<char> is_swa = {1, 0};
+    const int swa_max = 8;
+    auto cache = std::make_unique<KVCache>(n_layers, nkv, hd, QType::F16, /*global*/ 256, bs, nullptr,
+                                           is_swa, swa_max);
+    KVCacheManager mgr(std::move(cache));
+    const int window = 2 * bs;   // 32 tokens
+    const int slack = bs;        // 16
+    mgr.enable_swa_sizing(window, slack);
+    ASSERT_TRUE(mgr.swa_sizing_enabled());
+
+    // Grow the global table to 10 blocks (160 tokens), as prefill would.
+    ASSERT_TRUE(mgr.allocate_blocks(0, 10));
+    // Prepare the live window for a forward up to token 160.
+    ASSERT_TRUE(mgr.swa_prepare(0, /*upto*/ 160));
+    const auto& swa = mgr.swa_block_table(0);
+    ASSERT_EQ(static_cast<int>(swa.size()), 10);
+    // Live span = [160 - 32 - 16, 160) → tokens 112.., i.e. blocks 7,8,9.
+    for (int b = 0; b < 7; ++b)
+        EXPECT_EQ(swa[b], -1) << "block " << b << " must be a hole";
+    for (int b = 7; b < 10; ++b)
+        EXPECT_GE(swa[b], 0) << "block " << b << " must be live";
+    int live_after_prepare = swa_max - mgr.kv_cache()->num_free_swa_blocks();
+    EXPECT_EQ(live_after_prepare, 3);
+
+    // Advance context and trim: blocks that fall fully out of window get freed.
+    // At committed=160, dead end = 160-32-16 = 112 → block 6 (ends at 112) dead;
+    // already a hole, so no change. Grow to 240 tokens (15 blocks) then trim.
+    ASSERT_TRUE(mgr.allocate_blocks(0, 5));  // 15 blocks total
+    ASSERT_TRUE(mgr.swa_prepare(0, 240));
+    mgr.swa_trim(0, 240);
+    const auto& swa2 = mgr.swa_block_table(0);
+    // Live span for 240 = [192, 240) → blocks 12,13,14; earlier live blocks freed.
+    for (int b = 0; b < 12; ++b)
+        EXPECT_EQ(swa2[b], -1) << "block " << b << " must be trimmed to a hole";
+    for (int b = 12; b < 15; ++b)
+        EXPECT_GE(swa2[b], 0) << "block " << b << " must be live";
+
+    // free_sequence returns every live SWA block.
+    mgr.free_sequence(0);
+    EXPECT_EQ(mgr.kv_cache()->num_free_swa_blocks(), swa_max);
+}
+
+// rollback drops the SWA tail in lockstep with the global table.
+TEST(KVCacheManagerTest, SwaRollback) {
+    SKIP_IF_NO_CUDA();
+
+    const int bs = 16;
+    std::vector<int> nkv(2, 4), hd(2, 64);
+    std::vector<char> is_swa = {1, 0};
+    auto cache = std::make_unique<KVCache>(2, nkv, hd, QType::F16, 256, bs, nullptr, is_swa, 16);
+    KVCacheManager mgr(std::move(cache));
+    mgr.enable_swa_sizing(bs, bs);  // window=16, slack=16
+
+    ASSERT_TRUE(mgr.allocate_blocks(0, 10));
+    ASSERT_TRUE(mgr.swa_prepare(0, 160));
+    int live_before = 16 - mgr.kv_cache()->num_free_swa_blocks();
+    EXPECT_GT(live_before, 0);
+
+    // Roll back to 5 blocks (80 tokens) — the SWA table shrinks to match and
+    // frees the dropped tail.
+    mgr.rollback(0, 80);
+    EXPECT_EQ(static_cast<int>(mgr.swa_block_table(0).size()), 5);
+    EXPECT_EQ(static_cast<int>(mgr.block_table(0).size()), 5);
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## What

Sliding-window attention layers (gpt-oss: window=128 on every other layer; gemma-3: 5:1 local/global) previously allocated **full-length KV** exactly like global layers — `sliding_window`/`swa_layers[]` was only ever used as a kernel mask, never for sizing. This PR gives windowed layers a small dedicated block group holding only the trailing window (+ slack), freeing the rest of the pool for context.

Opt-in via `kv_cache.swa_sizing=true` (**default off** until validated across the model zoo). Measured on gpt-oss-20b: **peak VRAM 25937 → 20146 MiB (−22%)** at byte-identical output.

## Design (trailing-free, not a modulo ring)

- **`layer_swa_window()`** (`model_profile`): one source of truth for the per-layer window, shared by the attention-dispatch mask *and* the sizing path so they can't drift.
- **KVCache**: per-layer region capacity + a separate SWA block-id space with its own free list. Requires the per-layer ctor ⇒ excluded for INT8/INT4 KV (same gate as Gemma-4 dual-geometry).
- **KVCacheManager**: a parallel positional SWA table per sequence with `-1` holes (the `evict_middle_blocks` sentinel convention). `swa_prepare` allocates only the live window tail; `swa_trim` retires out-of-window blocks. Slack = `max(2·bs, spec_depth + bs)` covers spec-decode rollback + the boundary block. `rollback`/`free_sequence` handle both tables. SWA blocks are never hashed, pinned, or persisted.
- **Sentinel-safe kernels**: KV-write kernels already skipped `block_id<0`; `paged_kv_gather_*` now zero-fill hole rows (never consumed — the chunk kernels skip pre-window tiles).
- **Plumbing**: a second device block table through `DecodeBatchPool`, the prefill pool, the decode loop, the async graph loop, and spec verify (eager under SWA — captured verify + the constrained pipeline fall back to the already-wired eager paths).
- **Budget** (`vram_budget.cpp`): SWA layers are charged batch-shaped (window + slack + burst/chunk peak) like the SSM state slabs; only global layers scale with `max_seq_len`. Mirrored in the auto-`max_seq_len` estimate.

## Gate + interactions

`kv_cache.swa_sizing=false` default. Auto-disabled (logged) for: models with no SWA layers, INT8/INT4 KV, hybrids (SSM/GDN), MLA, StreamingLLM, green contexts, deterministic mode. Prefix-cache reuse is forced off while active (freed window blocks can't back reuse — snapshot-based reuse is a follow-up).

## Verification (local GPU)

- **Unit**: `KVCacheTest.SwaGroupCapacityAndIdSpace`, `KVCacheManagerTest.SwaTrailingFreeTable`, `.SwaRollback` (+ all 50 existing KVCache tests green).
- **Golden equivalence** (the key test): gpt-oss-20b *and* gemma-3-12b, greedy (temp 0, seed 1), prompt+generation ≫ window — `swa_sizing` on vs off produces **byte-identical generated text**. The only diffs are timestamps and VRAM counters.
- **VRAM**: gpt-oss-20b peak 25937 → 20146 MiB (−22%).
- **Coherence**: 700-token gpt-oss-20b run under SWA (trimming fires repeatedly past the 128 window) — no repetition loops / stuck tokens.
- `make test-unit`, `make verify-fast` green.
- **Perf gate**: unaffected — feature is default-off, so `tests/perf_baseline.json` runs unchanged. No baseline refresh needed.

## Not in this PR

No modulo ring / no decode-kernel changes; no SWA prefix-reuse snapshots (follow-up); no SWA sizing for INT8/INT4/streaming/hybrid/MLA; no default flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXm3AoXmxQ1gkesrp8EsT