### PR TITLE
fix(nvfp4): keep prequant MoE experts on-device — host-offload leaked raw INT8 to cuBLAS (status 15)

### DIFF
--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -3,6 +3,7 @@
 #include "compute/gemm_capture_fp16_sm120.h"
 #include "compute/gemm_internal.cuh"
 #include "core/logging.h"
+#include "core/tensor_kind.h"
 #include "runtime/pdl.h"
 #include "runtime/process_diag.h"
 
@@ -660,6 +661,32 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C, f
 }
 
 void gemm(const Tensor& A, const Tensor& B, Tensor& C, float alpha, float beta, cudaStream_t stream) {
+    // Defensive guard: a packed NVFP4 weight (or its INT8-typed packed
+    // payload) must never reach the generic FP16 cuBLAS path. cuBLAS rejects
+    // the FP16xINT8/NVFP4 operand mix with CUBLAS_STATUS_NOT_SUPPORTED
+    // (status 15) and leaves an uninitialised output buffer — silent
+    // repeated-token garbage plus downstream illegal-memory-access crashes.
+    // The correct dispatch for these weights is the NVFP4 decode/CUTLASS cache
+    // (see pre_dequant_phase3_*), which the budget planner now reserves for
+    // (the double-counted-reserve fix). If one still slips through — a future
+    // budget regression or an un-tiered weight — fail LOUD and skip the
+    // multiply instead of corrupting the forward pass. The output buffer is
+    // pre-zeroed by the caller, so an early return is safe (wrong-but-bounded,
+    // never an IMA). Log the exact identity, bounded to avoid flooding.
+    if ((B.qtype == QType::INT8 || B.qtype == QType::NVFP4) && A.qtype == QType::F16) {
+        static std::atomic<int> leak_count{0};
+        int n = leak_count.fetch_add(1, std::memory_order_relaxed);
+        if (n < 20) {
+            IMP_LOG_ERROR(
+                "gemm(): packed NVFP4 weight reached the generic cuBLAS path — "
+                "kind=%s B.qtype=%d scales=%s M=%ld K=%ld N=%ld — skipping "
+                "(routing/tier bug; expected NVFP4 decode/CUTLASS dispatch)",
+                tensor_kind_name(B.kind), std::to_underlying(B.qtype),
+                B.scales ? "SET" : "NULL",
+                (long)A.shape[0], (long)A.shape[1], (long)B.shape[0]);
+        }
+        return;
+    }
     // Guard against quantized weight tensors (e.g. MXFP4 with dtype=INT4)
     // that should have been handled by the FP16 weight cache path.
     // Passing raw quantized data to cuBLAS causes illegal memory access

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -154,6 +154,12 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
 
     if (h.primary_tier == StorageTier::Undefined) {
         Tensor weight(const_cast<void*>(h.source_data), h.source_qtype, 2, h.shape, true);
+        // Preserve semantic identity + NVFP4 scale sidecars so the uncached
+        // fallback can (a) diagnose which weight leaked and (b) route packed
+        // NVFP4 to a real dequant instead of feeding raw bytes to cuBLAS.
+        weight.kind = h.kind;
+        weight.scales = h.source_scales;
+        weight.tensor_scale = h.source_tensor_scale;
         gemm_dispatch_uncached_fallback(input, weight, output, ctx);
         return;
     }
@@ -415,6 +421,33 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
             return;
         }
     }
+
+    // Native-NVFP4 prefill (M>1) safety net: dequant the packed weight to FP16
+    // and run cuBLAS. Reached when the fast CUTLASS-NVFP4 path above declined
+    // (e.g. kernel shape/workspace decline) and there is no FP16/FP8 prefill
+    // companion — the source is native NVFP4, which dequant_gpu_supported()
+    // rejects, so the GGUF-overlay dequant (above) was skipped too. Without
+    // this, dispatch falls through to imp::gemm_dispatch → the generic gemm(),
+    // which sees the raw packed NVFP4 payload (QType::INT8-typed bytes) and
+    // hands cuBLAS an unsupported FP16×INT8 GEMM → CUBLAS_STATUS_NOT_SUPPORTED
+    // (status 15) → silent repeated-token garbage + downstream IMA. This hit
+    // the Qwen3.6-35B-A3B-NVFP4 shared-expert gate/up projections (the only
+    // native-NVFP4 dense weights routed through gemm_via_handle_). Slower than
+    // CUTLASS but correct; only fires on the decline.
+    if (M > 1 && h.source_data && h.source_scales &&
+        (h.primary_tier == StorageTier::CUTLASS_NVFP4 || h.primary_tier == StorageTier::NVFP4) &&
+        (h.source_qtype == QType::NVFP4 || h.source_qtype == QType::INT8)) {
+        NvFP4QuantResult nv;
+        nv.packed_data = const_cast<void*>(h.source_data);
+        nv.micro_scales = h.source_scales;
+        nv.tensor_scale = h.source_tensor_scale;
+        nv.N = h.shape[0];
+        nv.K = h.shape[1] * 2;  // packed K/2 → logical K
+        nv.owned = false;       // borrows resident weight storage
+        gemm_nvfp4(nv, input, output, ctx.stream, ctx.beta);
+        return;
+    }
+
     imp::gemm_dispatch(nullptr, h, input, output, 1.0f, ctx.beta,
                        ws_.shared(), ws_.shared_size(), ctx.stream);
 }

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -804,6 +804,11 @@ struct UploadCtx {
     // wcache). Set true for ModelArch::GPT_OSS so upload_packed_experts skips
     // them instead of uploading raw MXFP4 the executor cannot consume.
     bool is_gpt_oss = false;
+    // NVFP4-prequant SafeTensors: the MoE host-offload path does NOT support
+    // native-NVFP4 experts (they stay QType::INT8 packed and leak to the
+    // generic cuBLAS GEMM → status-15 garbage). Force all experts on-device for
+    // these models so Phase-0 promotes them; see decide_expert_layer_placement_.
+    bool is_nvfp4_prequant = false;
 };
 
 // ---------------------------------------------------------------------------
@@ -1515,7 +1520,8 @@ static size_t compute_expert_layer_costs_(const std::vector<TransformerLayer>& l
 // reserve.
 static void decide_expert_layer_placement_(const std::vector<size_t>& layer_expert_bytes,
                                            size_t total_expert_bytes, size_t expert_reserve_bytes,
-                                           int n_layers, std::vector<bool>& experts_upload_layer) {
+                                           int n_layers, std::vector<bool>& experts_upload_layer,
+                                           bool is_nvfp4_prequant) {
     if (total_expert_bytes == 0)
         return;
 
@@ -1544,9 +1550,27 @@ static void decide_expert_layer_placement_(const std::vector<size_t>& layer_expe
                 total_expert_bytes / (1024.0 * 1024.0 * 1024.0), free_mem / (1024.0 * 1024.0 * 1024.0));
         }
     }
+    // NVFP4-prequant experts have NO working host-offload path: kept host-
+    // resident they stay QType::INT8 packed (Phase-0 promote never runs on
+    // them), and at inference the MoE fallback hands their raw packed bytes to
+    // the generic cuBLAS GEMM → CUBLAS_STATUS_NOT_SUPPORTED (status 15) →
+    // repeated-token garbage + IMA (Qwen3.6-35B-A3B-NVFP4: default context
+    // offloaded layers 23-39 → gibberish). They are mandatory on-device. Drop
+    // the KV/workspace overhead reserve so they all upload when they physically
+    // fit; the KV pool is sized later from the remaining VRAM (with a min
+    // floor) and shrinks to accommodate — correctness over context length.
+    if (is_nvfp4_prequant)
+        overhead_pct = 0;
     size_t overhead = static_cast<size_t>(free_mem * overhead_pct / 100);
     size_t total_reserve = expert_reserve_bytes + overhead;
     size_t budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
+    if (is_nvfp4_prequant && budget < total_expert_bytes) {
+        IMP_LOG_WARN(
+            "NVFP4-prequant experts (%.2f GiB) exceed on-device budget (%.2f GiB free) — "
+            "some experts will be host-resident, which is UNSUPPORTED for NVFP4 and will "
+            "produce garbage. Reduce context (runtime.max_seq_len) or KV dtype (--kv-nvfp4).",
+            total_expert_bytes / (1024.0 * 1024.0 * 1024.0), free_mem / (1024.0 * 1024.0 * 1024.0));
+    }
 
     int force_host_n = process_diag_moe_force_host_experts();
     if (force_host_n < 0)
@@ -1621,7 +1645,7 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
 
     std::vector<bool> experts_upload_layer(n_layers, false);
     decide_expert_layer_placement_(layer_expert_bytes, total_expert_bytes, expert_reserve_bytes, n_layers,
-                                   experts_upload_layer);
+                                   experts_upload_layer, ctx.is_nvfp4_prequant);
 
     // Upload expert weights for each layer
     for (int i = 0; i < n_layers; ++i) {
@@ -2013,7 +2037,8 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
                                        : 0.0f;
     const bool is_gpt_oss = (config_.arch == ModelArch::GPT_OSS);
     UploadCtx ctx{compute_dtype,       stream,          gpu_allocations_, host_pinned_,
-                  host_pinned_allocs_, arch_norm_offset, is_gpt_oss};
+                  host_pinned_allocs_, arch_norm_offset, is_gpt_oss,
+                  config_.is_nvfp4_prequant};
 
     // --- Embeddings, output norm, output projection ---
     if (!upload_embeddings_and_output(tok_emb_, out_norm_, out_proj_, ctx)) {


### PR DESCRIPTION
## Problem

`Qwen3.6-35B-A3B-NVFP4` (GDN+MoE hybrid, native-NVFP4 SafeTensors) loads and reports **healthy**, but every generation is pure repeated-token garbage (`"endahendahendah…"`), stderr floods with `cublasGemmEx ... status 15`, and the server intermittently crashes with an illegal memory access. `Qwen3-Coder-30B-A3B-FP4` (non-hybrid NVFP4) works fine on the same build.

Filed as `BUGREPORT-qwen3.6-35B-A3B-NVFP4.md`.

## Root cause (verified by reproduction + counter-test)

The bug report's guess (MoE router / GDN) was wrong for this checkpoint — the router is BF16. The real chain:

1. NVFP4 `weight_packed` (U8) loads as `QType::INT8` internally; Phase-0 promotes it to `NVFP4` + attaches scales **only for on-device weights**.
2. `decide_expert_layer_placement_` (`weight_upload.cu`) **partially offloads MoE expert layers to host** when the on-device budget (free VRAM − a 30% KV/workspace overhead reserve) can't hold all of them. At the model's auto context (`max_seq_len 65536`) that reserve pushed **layers 23-39 to host** (layers 0-22 on device).
3. Host-resident NVFP4 experts are **never promoted** → stay `QType::INT8` packed. At inference the MoE legacy fallback (`executor_forward_moe_legacy.cu:327`) hands their raw packed FP4 bytes to the generic cuBLAS GEMM as an **FP16×INT8** matmul → `CUBLAS_STATUS_NOT_SUPPORTED` (status 15) → uninitialised output → repeated-token gibberish + downstream IMA.

**Counter-test that pinned it:** `--set runtime.max_seq_len=2048` (tiny KV → all experts fit on device) already produced coherent output. Per-layer instrumentation confirmed the clean layer-23 promotion cutoff.

## Fix

For `is_nvfp4_prequant` models, experts are **mandatory on-device** (host-offload is unsupported for them), so drop the overhead reserve for the placement decision — they all upload when they physically fit, and the KV pool is sized afterwards from the remaining VRAM (with its own min floor) and simply shrinks. If they genuinely don't fit, **warn loudly** that NVFP4 host-offload is unsupported instead of silently producing garbage.

Plus defense-in-depth (belt-and-suspenders, no longer triggered by this bug):
- `gemm()`: a packed NVFP4/INT8 weight reaching the generic cuBLAS path is now logged loudly and **skipped** rather than issuing the status-15 call + corrupting the forward pass with an IMA.
- `gemm_via_handle_`: native-NVFP4 M>1 GEMMs that decline the CUTLASS path now dequant the packed weight to FP16 instead of falling through to the generic path.

## Verification (RTX 5090, sm_120)

- **Qwen3.6-35B-A3B-NVFP4, default config (the failing one):** now `Expert weights: 15.00 GiB -> uploading ALL to GPU`; coherent output (counts 1-5, 220-token prose, no repetition); **0 status-15 / 0 leak-guard hits**; KV still sized to 168k tokens (auto FP8).
- **Qwen3-Coder-30B-A3B-FP4 (regression):** uploads all experts, coherent output, 0 status-15.

Built via incremental `ninja imp-server` (CUDA 13.3). CI `Build` job covers compile + unit tests (no GPU runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F