### PR TITLE
fix(vram): reserve mandatory NVFP4 decode caches before workspaces + KV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **VRAM ordering: mandatory NVFP4 decode caches are now reserved before
+  workspaces and the KV pool.** For native-NVFP4 models the CUTLASS SfAtom SF
+  slab (~2 GB) and the nvfp4_moe decode cache were built last from already-
+  starved free VRAM; partial caches abort decode CUDA-graph capture (one
+  uncovered MoE layer -> host-args path -> capture throws), pinning
+  Qwen3.6-35B-A3B-NVFP4 at 26-40 tok/s under default config. A balloon
+  allocation right after weight upload holds the exact demand (new
+  `compute_native_cache_demand`, sized with `cutlass_nvfp4_sf_size` and now
+  including the GDN/SSM projections the old estimate missed) until the cache
+  build, and the phase-3 budgets are floored at the balloon-backed guarantee
+  (live `cudaMemGetInfo` lags async frees). Default config now reaches full
+  caches + captured decode graph: 247-249 tok/s with a 138k-token KV pool
+  (was 26-40). Non-prequant (GGUF/FP16) budget arithmetic is unchanged
+  (pinned by test); escape hatch `[vram] native_cache_reserve` (default on).
+  A new post-build coverage log states FULL/PARTIAL cache status and remedies.
+
 ## [0.17.2] - 2026-07-08
 
 Small server-compatibility release: the served context window is now

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -137,6 +137,11 @@ kv_fraction       = 0.8
 # at 256 MiB absolute. Clamped to [0, 50]. Default 10 ≈ 3.2 GiB on a 32 GiB
 # card — lower to hand more VRAM to the KV pool.
 reserve_floor_pct = 10
+# Native-NVFP4 (prequant) models only: physically reserve the mandatory
+# decode caches (CUTLASS SfAtom slab + nvfp4_moe) right after weight upload,
+# before workspaces/KV consume the headroom. Partial caches abort decode
+# CUDA-graph capture (~10x decode hit). Escape hatch only - leave on.
+native_cache_reserve = true
 
 [attention]
 # Each "auto" key picks the kernel automatically based on weight type +

--- a/src/exec/pre_dequant_phase3_cutlass.cu
+++ b/src/exec/pre_dequant_phase3_cutlass.cu
@@ -34,8 +34,8 @@ using imp::pre_dequant_internal::deduct_budget;
 // Must run after FP16-free; the CUTLASS cache approximately doubles NVFP4
 // VRAM (repacked data + SfAtom scales).  Budget-aware: stops if VRAM
 // budget runs out and emits an info line.
-void QuantPipeline::nvfp4_decode_convert_cutlass_(const ModelConfig& cfg, size_t& remaining_budget,
-                                                  cudaStream_t stream) {
+void QuantPipeline::nvfp4_decode_convert_cutlass_(const ModelConfig& cfg, const VRAMBudget& budget,
+                                                  size_t& remaining_budget, cudaStream_t stream) {
     // After incremental mode, remaining_budget is stale.  Use actual free VRAM.
     size_t ct_budget;
     if (wcache_->nvfp4_decode_mode == 2) {
@@ -50,6 +50,18 @@ void QuantPipeline::nvfp4_decode_convert_cutlass_(const ModelConfig& cfg, size_t
         // capture-failure root cause is understood.
         size_t kCtReserve = vram_reserve_floor(total_mem);
         ct_budget = (free_mem > kCtReserve) ? (free_mem - kCtReserve) : 0;
+        // Prequant models: the Engine's balloon physically reserved the SF
+        // slab bytes (released just before this build), so the demand is
+        // guaranteed even when cudaMemGetInfo under-reports free (async
+        // frees are reclaimed late on this driver). Floor, don't trust
+        // live-free below the guarantee.
+        if (budget.mandatory_sf_bytes > ct_budget) {
+            IMP_LOG_INFO("CUTLASS NVFP4 cache: budget floored at guaranteed %.1f MiB "
+                         "(live-free-derived %.1f MiB under-reports)",
+                         budget.mandatory_sf_bytes / (1024.0 * 1024.0),
+                         ct_budget / (1024.0 * 1024.0));
+            ct_budget = budget.mandatory_sf_bytes;
+        }
     } else {
         ct_budget = (remaining_budget > wcache_->nvfp4_bytes)
                         ? (remaining_budget - wcache_->nvfp4_bytes)
@@ -171,6 +183,14 @@ void QuantPipeline::nvfp4_decode_convert_cutlass_(const ModelConfig& cfg, size_t
     if (ct_total > 0) {
         void* sf_slab = nullptr;
         IMP_CUDA_CHECK_LOG(cudaMalloc(&sf_slab, ct_total));
+        if (!sf_slab) {
+            // Defensive (floor over-commit or genuine exhaustion): a null
+            // slab must not be offset into by the convert passes below.
+            IMP_LOG_WARN("CUTLASS NVFP4 cache: slab cudaMalloc(%.1f MiB) failed — "
+                         "cache skipped (decode falls back; expect degraded perf)",
+                         ct_total / (1024.0 * 1024.0));
+            return;
+        }
         // Zero every entry's SfAtom padding rows at once (convert kernels write
         // only valid (n, k_group) cells).
         IMP_CUDA_CHECK_LOG(cudaMemsetAsync(sf_slab, 0, ct_total, stream));

--- a/src/exec/pre_dequant_phase3_moe.cu
+++ b/src/exec/pre_dequant_phase3_moe.cu
@@ -235,6 +235,7 @@ void QuantPipeline::gpt_oss_convert_moe_experts_(const ModelConfig& cfg, Nvfp4De
 }
 
 void QuantPipeline::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
+                                                    const VRAMBudget& budget,
                                                     size_t& remaining_budget,
                                                     cudaStream_t stream,
                                                     Nvfp4DecodeContext& dctx) {
@@ -287,6 +288,21 @@ void QuantPipeline::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         constexpr size_t kRuntimeHeadroom = 512ULL * 1024 * 1024;
         size_t total_reserve = kMoeReserve + kRuntimeHeadroom;
         moe_budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
+        // Prequant models: the Engine's balloon physically reserved the MoE
+        // slab bytes (released just before phase 3), so the guarantee holds
+        // even when cudaMemGetInfo under-reports free after async frees.
+        // The +128 MiB covers the borrow branch's small ts/ms-copy + SfAtom
+        // side allocations; the copy branch is net-zero per projection via
+        // the moe_logical_avail refund below.
+        if (budget.mandatory_moe_bytes > 0) {
+            size_t guaranteed = budget.mandatory_moe_bytes + 128ULL * 1024 * 1024;
+            if (guaranteed > moe_budget) {
+                IMP_LOG_INFO("NVFP4 MoE cache: budget floored at guaranteed %.1f MiB "
+                             "(live-free-derived %.1f MiB under-reports)",
+                             guaranteed / (1024.0 * 1024.0), moe_budget / (1024.0 * 1024.0));
+                moe_budget = guaranteed;
+            }
+        }
     } else {
         moe_budget = (remaining_budget > wcache_->nvfp4_bytes) ? (remaining_budget - wcache_->nvfp4_bytes)
                                                               : 0;

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -358,7 +358,7 @@ void QuantPipeline::pre_dequant_phase3_nvfp4_decode_(
     nvfp4_decode_cache_fp16_projections_(cfg, stream);
 
     if (!wcache_->nvfp4.empty() && cutlass_sm120_nvfp4_available()) {
-        nvfp4_decode_convert_cutlass_(cfg, remaining_budget, stream);
+        nvfp4_decode_convert_cutlass_(cfg, budget, remaining_budget, stream);
     }
 
     nvfp4_decode_convert_mxfp4_and_native_(cfg, stream);
@@ -369,7 +369,7 @@ void QuantPipeline::pre_dequant_phase3_nvfp4_decode_(
 
     if (model_->profile().is_gpt_oss)
         gpt_oss_convert_moe_experts_(cfg, dctx);
-    nvfp4_decode_cache_moe_experts_(cfg, remaining_budget, stream, dctx);
+    nvfp4_decode_cache_moe_experts_(cfg, budget, remaining_budget, stream, dctx);
 }
 
 // Mode 2 ("only") incremental NVFP4 quantize. Process FP16-cached entries

--- a/src/exec/quant_pipeline.h
+++ b/src/exec/quant_pipeline.h
@@ -117,12 +117,13 @@ private:
                                                  Nvfp4DecodeContext& dctx);
     void nvfp4_decode_second_pass_(const VRAMBudget& budget, cudaStream_t stream,
                                    Nvfp4DecodeContext& dctx);
-    void nvfp4_decode_convert_cutlass_(const ModelConfig& cfg, size_t& remaining_budget,
-                                       cudaStream_t stream);
+    void nvfp4_decode_convert_cutlass_(const ModelConfig& cfg, const VRAMBudget& budget,
+                                       size_t& remaining_budget, cudaStream_t stream);
     void nvfp4_decode_convert_mxfp4_and_native_(const ModelConfig& cfg, cudaStream_t stream);
     void nvfp4_decode_mxfp4_fp16_fallback_(const ModelConfig& cfg, cudaStream_t stream);
-    void nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg, size_t& remaining_budget,
-                                         cudaStream_t stream, Nvfp4DecodeContext& dctx);
+    void nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg, const VRAMBudget& budget,
+                                         size_t& remaining_budget, cudaStream_t stream,
+                                         Nvfp4DecodeContext& dctx);
     bool cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>& experts, cudaStream_t stream,
                                  Nvfp4DecodeContext& dctx, bool& moe_budget_exhausted,
                                  size_t& moe_logical_avail);

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -141,6 +141,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [vram]
     F("vram.kv_fraction", cfg.vram.kv_fraction);
     I("vram.reserve_floor_pct", cfg.vram.reserve_floor_pct);
+    B("vram.native_cache_reserve", cfg.vram.native_cache_reserve);
 
     // [attention]
     S("attention.fp8_prefill", cfg.attention.fp8_prefill);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -183,6 +183,14 @@ struct RuntimeConfig {
         // Default 10 ≈ 3.2 GiB on a 32 GiB card — lower to trade headroom
         // for KV pool.
         int reserve_floor_pct = 10;
+        // Native-NVFP4 (prequant) models: physically reserve the mandatory
+        // decode caches (CUTLASS SfAtom SF slab + nvfp4_moe) right after
+        // weight upload — BEFORE workspaces and the KV pool consume the
+        // headroom — via a balloon allocation released just before the
+        // cache build. Partial caches abort decode CUDA-graph capture
+        // (~10× decode hit), so the caches rank above KV/context size.
+        // Escape hatch only; leave on.
+        bool native_cache_reserve = true;
     } vram;
 
     struct Attention {

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -63,6 +63,10 @@ Engine::~Engine() {
     MemAccount::instance().sampler_stop();
     MemAccount::instance().report("shutdown");
 
+    // Defensive: the mandatory-cache balloon is normally released before
+    // pre_dequant_weights; don't leak it if init aborted in between.
+    release_native_cache_balloon_("teardown");
+
     // Save prefix cache to disk before shutdown (dense only — hybrid reuse
     // needs recurrent snapshots, which are device-resident and not persisted)
     if (kv_manager_ && !config_.prefix_cache_path.empty() && kv_manager_->prefix_caching_enabled() &&
@@ -716,11 +720,15 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     }
 
     // --- Sub-phases ---
-    if (!init_weights())
+    if (!init_weights()) {
+        release_native_cache_balloon_("init_weights failed");
         return false;
+    }
     MemAccount::instance().checkpoint("02_weights+decode_cache");
-    if (!init_kv_cache())
+    if (!init_kv_cache()) {
+        release_native_cache_balloon_("init_kv_cache failed");
         return false;
+    }
     MemAccount::instance().checkpoint("03_kv_cache");
     if (!init_features())
         return false;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -471,6 +471,15 @@ private:
     std::unique_ptr<LayerOffloadManager> offload_mgr_;
     bool experts_on_host_ = false;
     bool dequant_done_ = false;
+    // Balloon reservation for the mandatory native-NVFP4 decode caches
+    // (CUTLASS SfAtom slab + nvfp4_moe). Held from right after weight
+    // upload (before workspaces/KV consume the headroom) until just before
+    // pre_dequant_weights builds the caches into the guaranteed space.
+    // Plain cudaMalloc (NOT the async pool) so the release is immediately
+    // visible to cudaMemGetInfo readers.
+    void* native_cache_balloon_ = nullptr;
+    size_t native_cache_balloon_bytes_ = 0;
+    void release_native_cache_balloon_(const char* when);
     ChatTemplate chat_template_;
 
     // ── Extracted subsystems ─────────────────────────────────────────

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -8,6 +8,7 @@
 #include "runtime/engine.h"
 #include "runtime/engine_internal.h"
 #include "runtime/config.h"
+#include "runtime/vram_budget.h"
 #include "model/model_arch.h"
 #include "runtime/process_diag.h"
 #include "core/logging.h"
@@ -18,6 +19,22 @@
 #include <cstdlib>
 
 namespace imp {
+
+namespace {
+
+// Crude pre-upload weight-footprint estimate (weights are still host/mmap at
+// resolver time, so cudaMemGetInfo reports the near-empty card). Shared by
+// the auto max_batch_size and auto max_seq_len resolvers.
+size_t approx_weight_footprint_bytes(const ModelConfig& mcfg) {
+    size_t bytes = static_cast<size_t>(mcfg.d_model) * mcfg.d_model * mcfg.n_layers * 12;
+    if (mcfg.n_experts > 0) {
+        bytes += static_cast<size_t>(mcfg.n_experts) * mcfg.expert_d_ff * mcfg.d_model *
+                 mcfg.n_layers * 2;
+    }
+    return bytes;
+}
+
+}  // namespace
 
 // IMP_DEBUG_RAW meta-flag: forces the engine into a "naked" FP16 forward pass
 // for reproducible byte-level comparison against a reference implementation
@@ -237,11 +254,7 @@ void Engine::init_resolve_kv_dtype_policy_() {
     }
 
     if (config_.max_batch_size <= 0) {
-        size_t approx_weight_bytes = static_cast<size_t>(mcfg.d_model) * mcfg.d_model * mcfg.n_layers * 12;
-        if (mcfg.n_experts > 0) {
-            approx_weight_bytes += static_cast<size_t>(mcfg.n_experts) * mcfg.expert_d_ff * mcfg.d_model *
-                                   mcfg.n_layers * 2;
-        }
+        size_t approx_weight_bytes = approx_weight_footprint_bytes(mcfg);
         // Weight-footprint tier — kept as a FLOOR so this never regresses below
         // the previous default for any model.
         int tier;
@@ -279,7 +292,14 @@ void Engine::init_resolve_kv_dtype_policy_() {
             // real post-load headroom. approx_weight_bytes under-counts the NVFP4
             // decode + CUTLASS-SF caches, but kKvHeadroomFrac (0.6) reserves for
             // those + workspaces, and the downstream KV clamp is the hard backstop.
-            headroom = (free_vram > approx_weight_bytes) ? (free_vram - approx_weight_bytes) : 0;
+            size_t upload_bytes = approx_weight_bytes;
+            // Native-NVFP4 models: the mandatory decode caches (CUTLASS SfAtom
+            // slab + nvfp4_moe) are physically reserved right after upload
+            // (vram.native_cache_reserve balloon) — subtract them too so the
+            // auto batch doesn't size workspaces into the reserved bytes.
+            if (mcfg.is_nvfp4_prequant)
+                upload_bytes += compute_native_cache_demand(*model_).total();
+            headroom = (free_vram > upload_bytes) ? (free_vram - upload_bytes) : 0;
             int nkv = mcfg.n_kv_heads > 0 ? mcfg.n_kv_heads : 1;
             int hd = mcfg.head_dim > 0 ? mcfg.head_dim
                                        : (mcfg.n_heads > 0 ? mcfg.d_model / mcfg.n_heads : 128);
@@ -611,8 +631,19 @@ void Engine::init_compute_max_seq_len_() {
         // keeps tracking a tuned vram.kv_fraction. (Was a flat 30%, calibrated
         // when weight caches competed at FP16.)
         float kv_fraction = std::clamp(config_.kv_fraction, 0.05f, 0.95f);
+        // Native-NVFP4 models: weights + the mandatory decode caches (CUTLASS
+        // SfAtom slab + nvfp4_moe, physically reserved right after upload)
+        // will consume most of the card — subtract them so the auto context
+        // reflects the KV room that actually remains. GGUF models keep the
+        // historical raw-free overshoot (absorbed by the downstream KV clamp).
+        size_t free_for_kv = free_vram;
+        if (mcfg.is_nvfp4_prequant) {
+            size_t reserved = approx_weight_footprint_bytes(mcfg) +
+                              compute_native_cache_demand(*model_).total();
+            free_for_kv = (free_vram > reserved) ? (free_vram - reserved) : 0;
+        }
         int max_by_vram = (kv_bytes_per_token > 0)
-                              ? static_cast<int>(free_vram * (0.75 * kv_fraction) / kv_bytes_per_token)
+                              ? static_cast<int>(free_for_kv * (0.75 * kv_fraction) / kv_bytes_per_token)
                               : 131072;
         // Agentic workloads (tool loops, accumulating history, large file
         // context) routinely exceed 16K and run a single long sequence rather

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -168,9 +168,12 @@ bool Engine::init_kv_cache() {
     const int swa_live_tokens =
         swa_sizing_active_ ? swa_window_max_ + swa_slack_tokens_ + swa_burst_cap_tokens_ : 0;
 
-    // VRAM budget
+    // VRAM budget. The mandatory-cache balloon (init_weights) is still held
+    // here — effective_free_vram() excludes it, and passing the held bytes
+    // keeps the prequant reserve from charging KV for the same demand twice.
     auto vram_budget = compute_vram_budget(*model_, config_, n_kv_layers, head_dim,
-                                           effective_free_vram(), swa_live_tokens, n_swa_layers);
+                                           effective_free_vram(), swa_live_tokens, n_swa_layers,
+                                           native_cache_balloon_bytes_);
     int max_blocks = config_.kv_cache_max_blocks > 0 ? config_.kv_cache_max_blocks
                                                      : vram_budget.kv_max_blocks;
 
@@ -365,10 +368,50 @@ bool Engine::init_kv_cache() {
         }
     }
 
+    // Hand the reserved space to the cache build: everything elastic (KV
+    // pool, workspaces, SSM state) has allocated by now, so the freed bytes
+    // go to phase 3's CUTLASS-SF + nvfp4_moe builds — which additionally
+    // floor their live-free-derived budgets at vram_budget.mandatory_*.
+    release_native_cache_balloon_("cache build");
+
     // Dequant weights → FP16/FP8/NVFP4 caches
     executor_->pre_dequant_weights(stream_, vram_budget);
     dequant_done_ = true;
     cudaStreamSynchronize(stream_);
+
+    // Coverage check: for prequant MoE models the nvfp4_moe decode cache is
+    // all-or-nothing (predicate mirrors executor_forward_moe.cu
+    // nvfp4_covers_layer) — one uncovered layer makes decode fall to the
+    // host-args legacy path, which throws under CUDA-graph capture and
+    // aborts the WHOLE decode graph. Surface partial coverage loudly.
+    if (mcfg.is_nvfp4_prequant && mcfg.n_experts > 0) {
+        int moe_layers = 0, covered = 0;
+        for (int i = 0; i < mcfg.n_layers; i++) {
+            const auto& L = model_->layer(i);
+            bool has_experts = L.expert_up_packed.data != nullptr ||
+                               (!L.expert_w_up.empty() && L.expert_w_up[0].data != nullptr);
+            if (!has_experts)
+                continue;
+            moe_layers++;
+            bool ok = L.nvfp4_moe_up_ptr != nullptr && L.nvfp4_moe_down_ptr != nullptr;
+            if (ok && L.expert_gate_packed.data != nullptr)
+                ok = L.nvfp4_moe_gate_ptr != nullptr;
+            if (ok)
+                covered++;
+        }
+        if (moe_layers > 0 && covered == moe_layers) {
+            IMP_LOG_INFO("NVFP4 decode caches: FULL (%d/%d MoE layers) — decode graph "
+                         "capture eligible",
+                         covered, moe_layers);
+        } else if (moe_layers > 0) {
+            IMP_LOG_WARN(
+                "NVFP4 decode caches: PARTIAL (%d/%d MoE layers covered) — decode "
+                "CUDA-graph capture will abort and decode runs per-step (~10x slower). "
+                "Remedies: lower runtime.max_seq_len or max_batch_size (both shrink the "
+                "workspaces/KV competing for cache VRAM), or check the [vram] knobs.",
+                covered, moe_layers);
+        }
+    }
 
     // Pre-allocate the gemm_nvfp4 fallback dequant workspace. Sized from
     // wcache_.nvfp4 which is populated by pre_dequant_weights above, so this

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -11,6 +11,7 @@
 
 #include "runtime/engine.h"
 #include "runtime/config.h"
+#include "runtime/vram_budget.h"
 #include "core/cuda_raii.h"
 #include "core/logging.h"
 #include "memory/vram_query.h"
@@ -268,6 +269,87 @@ bool Engine::init_weights() {
         // never captured in CUDA graphs.
     }
 
+    // Balloon reservation for the mandatory native-NVFP4 decode caches
+    // (CUTLASS SfAtom slab + nvfp4_moe). They are all-or-nothing for decode
+    // CUDA-graph capture — one uncovered MoE layer falls to the host-args
+    // legacy path, throws under capture, and the WHOLE decode graph aborts
+    // (26-40 tok/s per-step instead of ~250 captured on Qwen3.6-35B). They
+    // are built LAST (pre_dequant, after KV init), so without this hold the
+    // workspaces below + the KV pool starve them. Holding the bytes now
+    // makes every later live-free reader (workspaces, vram budget, KV, SSM)
+    // see reduced free; released just before pre_dequant_weights builds the
+    // caches into the guaranteed space (engine_kv_cache_init.cpp).
+    if (mcfg.is_nvfp4_prequant && config_.use_nvfp4_decode == 2 && !experts_on_host_ &&
+        runtime_config_.vram.native_cache_reserve) {
+        NativeCacheDemand demand = compute_native_cache_demand(*model_);
+        constexpr size_t kBalloonPad = 64ULL * 1024 * 1024;  // alloc granularity slack
+        size_t want = demand.total() + kBalloonPad;
+        // The hold must leave room for the ESSENTIAL allocations that run
+        // while it is held: the executor workspaces (a rejected persistent
+        // workspace is fatal — "cannot run inference") plus the
+        // VRAMAllocator's own free-headroom policy (~5% of total). If the
+        // card can't fit both, shrink the hold (SF-only) or skip it — the
+        // legacy partial-cache behavior beats a non-functional engine.
+        size_t free_now = 0, total_now = 0;
+        vram_budget_mem_get_info(&free_now, &total_now);
+        size_t essential = executor_->workspace_estimate() + total_now / 20 +
+                           256ULL * 1024 * 1024;
+        size_t grantable = (free_now > essential) ? free_now - essential : 0;
+        if (want > grantable) {
+            if (demand.sf_bytes <= grantable) {
+                // Partial: guarantee at least the SF slab (phase 3b runs
+                // first and is the larger, persistent cache).
+                want = demand.sf_bytes;
+                IMP_LOG_WARN("VRAM reserve: shrinking hold to %.0f MiB (SF slab only; "
+                             "%.0f MiB wanted, %.0f MiB grantable after workspaces) — "
+                             "the MoE cache may come out partial",
+                             want / (1024.0 * 1024.0), (demand.total() + kBalloonPad) / (1024.0 * 1024.0),
+                             grantable / (1024.0 * 1024.0));
+            } else {
+                want = 0;
+            }
+        }
+        auto try_alloc = [&](size_t bytes) {
+            void* p = nullptr;
+            // Plain cudaMalloc, NOT the async pool: the release must be
+            // immediately visible to the cudaMemGetInfo readers downstream.
+            if (cudaMalloc(&p, bytes) == cudaSuccess)
+                return p;
+            (void)cudaGetLastError();  // clear the sticky OOM
+            return static_cast<void*>(nullptr);
+        };
+        if (want > 0) {
+            native_cache_balloon_ = try_alloc(want);
+            if (!native_cache_balloon_) {
+                // The default async pool retains upload-time frees (release
+                // threshold UINT64_MAX above) — trim once and retry before
+                // concluding the VRAM is genuinely short.
+                cudaMemPool_t default_pool = nullptr;
+                int dev = 0;
+                cudaGetDevice(&dev);
+                if (cudaDeviceGetDefaultMemPool(&default_pool, dev) == cudaSuccess && default_pool)
+                    cudaMemPoolTrimTo(default_pool, 0);
+                native_cache_balloon_ = try_alloc(want);
+            }
+            if (native_cache_balloon_)
+                native_cache_balloon_bytes_ = want;
+        }
+        if (native_cache_balloon_) {
+            IMP_LOG_INFO("VRAM reserve: holding %.0f MiB for mandatory NVFP4 decode caches "
+                         "(sf=%.0f MiB, moe_slab=%.0f MiB) until cache build",
+                         native_cache_balloon_bytes_ / (1024.0 * 1024.0),
+                         demand.sf_bytes / (1024.0 * 1024.0),
+                         demand.moe_slab_bytes / (1024.0 * 1024.0));
+        } else {
+            IMP_LOG_WARN(
+                "VRAM reserve: could not hold %.0f MiB for the mandatory NVFP4 decode "
+                "caches (weights + workspaces leave too little VRAM). Caches may come out "
+                "partial → decode CUDA-graph capture will abort (~10x slower per-step "
+                "decode). Lower runtime.max_seq_len / max_batch_size or use a smaller model.",
+                (demand.total() + kBalloonPad) / (1024.0 * 1024.0));
+        }
+    }
+
     // Phase 2: allocate GPU workspace
     (void)executor_->allocate_workspaces(experts_on_host_);
 
@@ -281,6 +363,22 @@ bool Engine::init_weights() {
     }
 
     return true;
+}
+
+// Release the mandatory-decode-cache balloon (idempotent). Called right
+// before pre_dequant_weights builds the caches into the freed space, and
+// defensively from ~Engine / init-failure paths so the hold can't leak.
+void Engine::release_native_cache_balloon_(const char* when) {
+    if (!native_cache_balloon_)
+        return;
+    size_t held = native_cache_balloon_bytes_;
+    IMP_CUDA_CHECK_LOG(cudaFree(native_cache_balloon_));
+    native_cache_balloon_ = nullptr;
+    native_cache_balloon_bytes_ = 0;
+    size_t free_mem = 0, total_mem = 0;
+    vram_budget_mem_get_info(&free_mem, &total_mem);
+    IMP_LOG_INFO("VRAM reserve: released %.0f MiB (%s; free now %.0f MiB)",
+                 held / (1024.0 * 1024.0), when, free_mem / (1024.0 * 1024.0));
 }
 
 }  // namespace imp

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -1,6 +1,7 @@
 #include "runtime/vram_budget.h"
 #include "runtime/engine.h"  // EngineConfig full definition
 #include "runtime/storage_planner.h"
+#include "compute/gemm_cutlass_sm120.h"  // cutlass_nvfp4_sf_size (SfAtom padding)
 #include "core/logging.h"
 #include "memory/vram_query.h"
 #include <algorithm>
@@ -8,8 +9,100 @@
 
 namespace imp {
 
+NativeCacheDemand compute_native_cache_demand(const Model& model) {
+    NativeCacheDemand d;
+    const auto& mcfg = model.config();
+    if (!mcfg.is_nvfp4_prequant)
+        return d;
+
+    // Mirrors phase 3b's slab sizing (pre_dequant_phase3_cutlass.cu): each
+    // slab entry is align_up(cutlass_nvfp4_sf_size(N, K), 256); contiguous
+    // MoE expert groups occupy align_up(ne × sf_size, 256) as ONE entry.
+    // Wire shapes store the PACKED byte dim (K/2 for e2m1 pairs), so
+    // logical K = 2 × shape[1]. The previous elems/16+256 heuristic was
+    // NOT an upper bound under SfAtom padding (rows→128, K→64 elems).
+    constexpr size_t kSfAlign = 256;
+    auto align_up = [](size_t x, size_t a) { return (x + a - 1) / a * a; };
+
+    auto add_dense = [&](const Tensor& w) {
+        if (!w.data || w.ndim < 2)
+            return;
+        if (w.ndim >= 3) {
+            // Packed 3D experts [ne, N, K/2] (GGUF / Gemma-4 loaders): one
+            // contiguous group entry + the transient per-(layer,proj) copy.
+            int ne = static_cast<int>(w.shape[0]);
+            int N = static_cast<int>(w.shape[1]);
+            int64_t K = static_cast<int64_t>(w.shape[2]) * 2;
+            d.sf_bytes += align_up(static_cast<size_t>(ne) *
+                                       cutlass_nvfp4_sf_size(N, static_cast<int>(K)),
+                                   kSfAlign);
+            size_t slab = static_cast<size_t>(ne) * N * (K / 2) +
+                          static_cast<size_t>(ne) * N * (K / 16) +
+                          static_cast<size_t>(ne) * sizeof(float);
+            d.moe_slab_bytes = std::max(d.moe_slab_bytes, slab);
+            return;
+        }
+        int N = static_cast<int>(w.shape[0]);
+        int64_t K = static_cast<int64_t>(w.shape[1]) * 2;
+        d.sf_bytes += align_up(cutlass_nvfp4_sf_size(N, static_cast<int>(K)), kSfAlign);
+    };
+    auto add_experts = [&](const std::vector<Tensor>& ws) {
+        if (ws.empty() || !ws[0].data || ws[0].ndim < 2)
+            return;
+        int ne = static_cast<int>(ws.size());
+        int N = static_cast<int>(ws[0].shape[0]);
+        int64_t Kp = ws[0].shape[1];
+        int64_t K = Kp * 2;
+        d.sf_bytes += align_up(static_cast<size_t>(ne) *
+                                   cutlass_nvfp4_sf_size(N, static_cast<int>(K)),
+                               kSfAlign);
+        // Transient contiguous-copy slab (phase 3-moe copy branch: packed +
+        // micro-scales + tensor-scales, matching add_bytes there). The
+        // zero-copy borrow branch needs ~none — this is the upper bound.
+        size_t slab = static_cast<size_t>(ne) * N * Kp + static_cast<size_t>(ne) * N * (K / 16) +
+                      static_cast<size_t>(ne) * sizeof(float);
+        d.moe_slab_bytes = std::max(d.moe_slab_bytes, slab);
+    };
+
+    // The same tensor set phase 0b registers for the decode cache
+    // (pre_dequant_phase0_nvfp4_loader.cu register_prequant) — including
+    // ssm_in/ssm_out/gdn_gate, which the previous inline scan omitted
+    // (under-count on GDN hybrids, i.e. Qwen3.6-35B itself).
+    add_dense(model.output_proj());
+    for (int i = 0; i < mcfg.n_layers; i++) {
+        const auto& L = model.layer(i);
+        add_dense(L.wq);
+        add_dense(L.wk);
+        add_dense(L.wv);
+        add_dense(L.wo);
+        add_dense(L.w_gate);
+        add_dense(L.w_up);
+        add_dense(L.w_down);
+        add_dense(L.w_gate_shared);
+        add_dense(L.w_up_shared);
+        add_dense(L.w_down_shared);
+        add_dense(L.ssm_in);
+        add_dense(L.ssm_out);
+        add_dense(L.gdn_gate);
+        if (L.expert_gate_packed.data)
+            add_dense(L.expert_gate_packed);
+        else
+            add_experts(L.expert_w_gate);
+        if (L.expert_up_packed.data)
+            add_dense(L.expert_up_packed);
+        else
+            add_experts(L.expert_w_up);
+        if (L.expert_down_packed.data)
+            add_dense(L.expert_down_packed);
+        else
+            add_experts(L.expert_w_down);
+    }
+    return d;
+}
+
 VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, int n_kv_layers, int head_dim,
-                               size_t free_vram, int swa_live_tokens, int n_swa_layers) {
+                               size_t free_vram, int swa_live_tokens, int n_swa_layers,
+                               size_t mandatory_cache_prealloc) {
     VRAMBudget budget;
     const auto& mcfg = model.config();
 
@@ -203,73 +296,34 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
             // Both the count above AND the plan classify by source qtype,
             // which at budget time is still the wire dtype (NVFP4-ness lives
             // in the nvfp4_scratch_ sidecars until phase 0 promotes it) — so
-            // scan the projection tensors directly, no qtype filter: on an
-            // NVFP4-prequant checkpoint these are exactly the quantized set.
-            size_t sf_bytes = 0;
-            size_t max_moe_slab = 0;
-            // Wire shapes store the PACKED byte dim (K/2 for e2m1 pairs), so
-            // logical elems = 2 × shape product — verified against the built
-            // caches: Coder-30B SfAtom 1800.55 MiB vs 914 unscaled, 14B
-            // 833.87 vs 440 (both exactly 2×).
-            auto count_native = [&](const Tensor& w) {
-                if (!w.data || w.ndim < 2 || w.shape[1] % 16 != 0)
-                    return;
-                size_t elems = 2;
-                for (int d = 0; d < w.ndim; d++)
-                    elems *= static_cast<size_t>(w.shape[d]);
-                sf_bytes += elems / 16 + 256;  // + per-entry SfAtom align slack
-                if (w.ndim >= 3)  // packed experts: transient copy per (layer,proj)
-                    max_moe_slab = std::max(max_moe_slab, elems / 2 + elems / 16);
-            };
-            auto count_native_vec = [&](const std::vector<Tensor>& ws) {
-                size_t elems = 0;
-                for (const auto& w : ws) {
-                    if (!w.data || w.ndim < 2)
-                        continue;
-                    size_t e = 2;
-                    for (int d = 0; d < w.ndim; d++)
-                        e *= static_cast<size_t>(w.shape[d]);
-                    elems += e;
-                }
-                if (!elems)
-                    return;
-                sf_bytes += elems / 16 + 256 * ws.size();
-                max_moe_slab = std::max(max_moe_slab, elems / 2 + elems / 16);
-            };
-            count_native(model.output_proj());
-            for (int i = 0; i < mcfg.n_layers; i++) {
-                const auto& L = model.layer(i);
-                count_native(L.wq);
-                count_native(L.wk);
-                count_native(L.wv);
-                count_native(L.wo);
-                count_native(L.w_gate);
-                count_native(L.w_up);
-                count_native(L.w_down);
-                count_native(L.w_gate_shared);
-                count_native(L.w_up_shared);
-                count_native(L.w_down_shared);
-                if (L.expert_gate_packed.data)
-                    count_native(L.expert_gate_packed);
-                else
-                    count_native_vec(L.expert_w_gate);
-                if (L.expert_up_packed.data)
-                    count_native(L.expert_up_packed);
-                else
-                    count_native_vec(L.expert_w_up);
-                if (L.expert_down_packed.data)
-                    count_native(L.expert_down_packed);
-                else
-                    count_native_vec(L.expert_w_down);
-            }
+            // compute_native_cache_demand scans the projection tensors
+            // directly, no qtype filter: on an NVFP4-prequant checkpoint
+            // these are exactly the quantized set.
+            NativeCacheDemand demand = compute_native_cache_demand(model);
+            // Floors are only handed to phase 3 when the balloon physically
+            // guaranteed the bytes — an unbacked floor on a genuinely tight
+            // card would over-commit the SF slab cudaMalloc. Phase 3b (SF)
+            // runs before phase 3-moe, so an sf-only balloon still floors SF.
+            budget.mandatory_sf_bytes =
+                (mandatory_cache_prealloc >= demand.sf_bytes) ? demand.sf_bytes : 0;
+            budget.mandatory_moe_bytes =
+                (mandatory_cache_prealloc >= demand.total()) ? demand.moe_slab_bytes : 0;
             size_t phase3_reserve =
                 vram_reserve_floor(total_vram, reserve_floor_pct) + 1024ULL * 1024 * 1024;
-            size_t native_need = sf_bytes + max_moe_slab + phase3_reserve;
+            // Bytes already physically held by the Engine's balloon are
+            // excluded from free_vram — charge KV only for the UNCOVERED
+            // remainder (normally 0) so the demand isn't counted twice.
+            size_t uncovered = (demand.total() > mandatory_cache_prealloc)
+                                   ? demand.total() - mandatory_cache_prealloc
+                                   : 0;
+            size_t native_need = uncovered + phase3_reserve;
             if (native_need > cutlass_sf_estimate) {
                 IMP_LOG_INFO("VRAM budget: native-NVFP4 weight-cache reserve %.1f MiB "
-                             "(sf=%.1f, moe_slab=%.1f, phase3+workspaces=%.1f)",
-                             native_need / (1024.0 * 1024.0), sf_bytes / (1024.0 * 1024.0),
-                             max_moe_slab / (1024.0 * 1024.0),
+                             "(sf=%.1f, moe_slab=%.1f, prealloc-covered=%.1f, "
+                             "phase3+workspaces=%.1f)",
+                             native_need / (1024.0 * 1024.0), demand.sf_bytes / (1024.0 * 1024.0),
+                             demand.moe_slab_bytes / (1024.0 * 1024.0),
+                             std::min(demand.total(), mandatory_cache_prealloc) / (1024.0 * 1024.0),
                              phase3_reserve / (1024.0 * 1024.0));
                 cutlass_sf_estimate = native_need;
             }

--- a/src/runtime/vram_budget.h
+++ b/src/runtime/vram_budget.h
@@ -8,6 +8,31 @@ namespace imp {
 
 struct EngineConfig;  // forward declaration
 
+// Mandatory decode-cache demand of a native-NVFP4 (is_nvfp4_prequant)
+// checkpoint. These caches are all-or-nothing for CUDA-graph decode: a
+// single MoE layer without its nvfp4_moe entry falls to the host-args
+// legacy path, which throws under capture and aborts the WHOLE decode
+// graph (26-40 tok/s per-step instead of ~250 captured on Qwen3.6-35B).
+struct NativeCacheDemand {
+    // Persistent CUTLASS SfAtom SF slab (phase 3b) across ALL registered
+    // NVFP4 weights — dense projections, experts, GDN/SSM projections,
+    // LM head. Sized with cutlass_nvfp4_sf_size() + the slab's 256-byte
+    // per-entry alignment, mirroring pre_dequant_phase3_cutlass.cu.
+    size_t sf_bytes = 0;
+    // Largest transient per-(layer,proj) contiguous MoE expert copy
+    // (phase 3-moe copy branch: packed + micro-scales + tensor-scales).
+    // The zero-copy borrow branch needs ~none of this — it is an upper
+    // bound, held only until the balloon is released before phase 3.
+    size_t moe_slab_bytes = 0;
+    size_t total() const { return sf_bytes + moe_slab_bytes; }
+};
+
+// Scan the model's projection/expert tensor shapes and compute the
+// mandatory decode-cache demand. Reads only shapes + data-non-null, so it
+// works pre-upload (resolver time, host tensors) and post-upload alike.
+// Returns all-zero for non-prequant models.
+NativeCacheDemand compute_native_cache_demand(const Model& model);
+
 // VRAM budget for weight cache allocation (computed by Engine::plan_vram_budget).
 // Replaces ad-hoc "remaining_budget" with per-phase caps computed upfront.
 struct VRAMBudget {
@@ -23,6 +48,13 @@ struct VRAMBudget {
     // ceil(swa_live_tokens / block_size) + 1 blocks per sequence slot.
     int swa_max_blocks = 0;
     bool nvfp4_second_pass = false;  // true → re-run NVFP4 after FP16-Free
+    // Guaranteed byte-floors for the mandatory native-NVFP4 decode caches
+    // (0 for non-prequant models). Phase 3b / phase 3-moe floor their live-
+    // free-derived mode-2 budgets at these values so a lagging
+    // cudaMemGetInfo (async frees are reclaimed late on this driver) can't
+    // starve a cache whose room was physically reserved via the balloon.
+    size_t mandatory_sf_bytes = 0;
+    size_t mandatory_moe_bytes = 0;
 };
 
 // Pure computation: plan VRAM allocation split between KV cache, FP8 prefill
@@ -33,7 +65,13 @@ struct VRAMBudget {
 // sliding-window layers are charged a fixed per-sequence live span of
 // swa_live_tokens (window + slack + burst/chunk peak) instead of
 // max_seq_len; only the remaining global layers scale with context.
+//
+// mandatory_cache_prealloc: bytes already physically reserved for the
+// mandatory native-NVFP4 decode caches (Engine's balloon, held while this
+// runs — free_vram excludes it). The prequant reserve then only charges KV
+// for the UNCOVERED remainder, preventing a double-count.
 VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, int n_kv_layers, int head_dim,
-                               size_t free_vram, int swa_live_tokens = 0, int n_swa_layers = 0);
+                               size_t free_vram, int swa_live_tokens = 0, int n_swa_layers = 0,
+                               size_t mandatory_cache_prealloc = 0);
 
 }  // namespace imp

--- a/tests/test_vram_budget_reserve.cpp
+++ b/tests/test_vram_budget_reserve.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "compute/gemm_cutlass_sm120.h"
 #include "memory/vram_query.h"
 #include "model/model.h"
 #include "model/model_config.h"
@@ -203,6 +204,124 @@ TEST(VramBudgetReserve, ReserveFloorPctScalesReserve) {
     EXPECT_EQ(b20.reserve_bytes,
               std::max<size_t>(512ull * 1024 * 1024, vram_reserve_floor(total_vram, 20)));
     EXPECT_GE(b20.reserve_bytes, b10.reserve_bytes);
+}
+
+// --- Mandatory native-NVFP4 decode-cache demand + balloon prealloc ---
+//
+// compute_native_cache_demand must mirror phase 3b's SfAtom slab sizing
+// exactly (cutlass_nvfp4_sf_size + 256-byte per-entry alignment; contiguous
+// expert groups as ONE entry) and include the GDN/SSM projections that
+// phase 0b registers — the old inline elems/16 heuristic omitted them and
+// was not an upper bound under SfAtom padding.
+
+namespace {
+
+// Fake prequant hybrid: 2 layers, dense attention proj + GDN projections +
+// 4-expert MoE (per-expert 2D views, the SafeTensors prequant layout).
+// Shapes store the PACKED byte dim (K/2), mirroring the NVFP4 wire format.
+void fill_prequant_model(Model& m) {
+    m.config_.n_layers = 2;
+    m.config_.n_kv_heads = 8;
+    m.config_.n_experts = 4;
+    m.config_.is_nvfp4_prequant = true;
+    uintptr_t next = 1;
+    for (int i = 0; i < 2; ++i) {
+        TransformerLayer L;
+        L.wq = make_weight(TensorKind::WQ, 1024, 512, QType::INT8, next++);
+        L.ssm_in = make_weight(TensorKind::WQ, 2048, 1024, QType::INT8, next++);
+        L.gdn_gate = make_weight(TensorKind::WQ, 512, 1024, QType::INT8, next++);
+        for (int e = 0; e < 4; ++e) {
+            L.expert_w_up.push_back(make_weight(TensorKind::EXPERT_UP, 768, 512, QType::INT8, next++));
+            L.expert_w_down.push_back(
+                make_weight(TensorKind::EXPERT_DOWN, 256, 768, QType::INT8, next++));
+        }
+        m.layers_.push_back(std::move(L));
+    }
+}
+
+size_t sf_entry(int n, int k_packed) {
+    constexpr size_t kSfAlign = 256;
+    size_t sz = imp::cutlass_nvfp4_sf_size(n, k_packed * 2);
+    return (sz + kSfAlign - 1) / kSfAlign * kSfAlign;
+}
+
+size_t sf_group(int ne, int n, int k_packed) {
+    constexpr size_t kSfAlign = 256;
+    size_t sz = static_cast<size_t>(ne) * imp::cutlass_nvfp4_sf_size(n, k_packed * 2);
+    return (sz + kSfAlign - 1) / kSfAlign * kSfAlign;
+}
+
+size_t moe_slab(int ne, int n, int k_packed) {
+    int64_t k = static_cast<int64_t>(k_packed) * 2;
+    return static_cast<size_t>(ne) * n * k_packed + static_cast<size_t>(ne) * n * (k / 16) +
+           static_cast<size_t>(ne) * sizeof(float);
+}
+
+}  // namespace
+
+TEST(VramBudgetReserve, NativeCacheDemandMatchesPhase3Sizing) {
+    Model m;
+    fill_prequant_model(m);
+
+    NativeCacheDemand d = compute_native_cache_demand(m);
+
+    const size_t expected_sf = 2 * (sf_entry(1024, 512)      // wq
+                                    + sf_entry(2048, 1024)   // ssm_in (GDN hybrid!)
+                                    + sf_entry(512, 1024)    // gdn_gate
+                                    + sf_group(4, 768, 512)  // expert up group
+                                    + sf_group(4, 256, 768)  // expert down group
+                                   );
+    EXPECT_EQ(d.sf_bytes, expected_sf);
+
+    const size_t expected_slab = std::max(moe_slab(4, 768, 512), moe_slab(4, 256, 768));
+    EXPECT_EQ(d.moe_slab_bytes, expected_slab);
+    EXPECT_EQ(d.total(), expected_sf + expected_slab);
+}
+
+TEST(VramBudgetReserve, NativeCacheDemandZeroForNonPrequant) {
+    Model m;
+    fill_model(m, QType::Q6_K, QType::Q6_K);
+
+    NativeCacheDemand d = compute_native_cache_demand(m);
+    EXPECT_EQ(d.sf_bytes, 0u);
+    EXPECT_EQ(d.moe_slab_bytes, 0u);
+}
+
+TEST(VramBudgetReserve, PreallocCoversDemandAndFreesKv) {
+    SKIP_IF_NO_CUDA();
+
+    Model m;
+    fill_prequant_model(m);
+
+    EngineConfig config;
+    config.max_seq_len = 32768;
+    config.max_batch_size = 8;
+    config.use_nvfp4_decode = 2;
+    config.use_cuda_graphs = false;
+    config.kv_cache_dtype = QType::F16;
+
+    const size_t GiB = 1024ull * 1024 * 1024;
+    NativeCacheDemand d = compute_native_cache_demand(m);
+    ASSERT_GT(d.total(), 0u);
+
+    // Without prealloc: full demand charged against KV; floors unbacked → 0.
+    VRAMBudget none = compute_vram_budget(m, config, 2, 128, 4 * GiB);
+    EXPECT_EQ(none.mandatory_sf_bytes, 0u);
+    EXPECT_EQ(none.mandatory_moe_bytes, 0u);
+
+    // With the balloon held (free_vram already excludes it): only the
+    // uncovered remainder (0) is charged, and the floors are backed.
+    VRAMBudget held =
+        compute_vram_budget(m, config, 2, 128, 4 * GiB, /*swa_live_tokens=*/0,
+                            /*n_swa_layers=*/0, /*mandatory_cache_prealloc=*/d.total());
+    EXPECT_EQ(held.mandatory_sf_bytes, d.sf_bytes);
+    EXPECT_EQ(held.mandatory_moe_bytes, d.moe_slab_bytes);
+    EXPECT_GE(held.kv_max_blocks, none.kv_max_blocks);
+
+    // Partial (SF-only) balloon: SF floor backed, MoE floor not.
+    VRAMBudget sf_only = compute_vram_budget(m, config, 2, 128, 4 * GiB, 0, 0, d.sf_bytes);
+    EXPECT_EQ(sf_only.mandatory_sf_bytes, d.sf_bytes);
+    EXPECT_EQ(sf_only.mandatory_moe_bytes, 0u);
 }
 
 TEST(VramBudgetReserve, VramKnobsAreClamped) {

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -58,6 +58,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/attention_paged.cu" = "(c) 1134 code LOC — one paged-attention family: gqa-prefill, decode, splitk, reduce, cluster — shared block/KV layout"
 "src/compute/attention_paged_nvfp4_tc.cu" = "(c) 845 code LOC — NVFP4 tensor-core paged-attn family (decode/splitk/reduce) — shared TC path"
 "src/compute/attention_fmha_mxfp4_sm120.cu" = "(c) 810 code LOC — single MXFP4 FA2 attention kernel family"
+"src/compute/gemm.cu" = "(c) 613 code LOC — one module: generic cuBLAS GEMM wrapper + algo-reselect/fallback chain + packed-weight leak guards (pushed over 600 by the #925 defense-in-depth guards)"
 "src/compute/gemm_grouped_nvfp4_smallM.cu" = "(c) 718 code LOC — one small-M grouped-GEMM family (software-ref + prod + smoke variants)"
 "src/compute/schema_constrain.cu" = "(c) 676 code LOC — one module: schema-constrained decode token-mask compute (host-side)"
 "src/compute/mtp_forward.cu" = "(c) 651 code LOC — MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature"


### PR DESCRIPTION
## Problem

For native-NVFP4 MoE models the **mandatory decode caches** — the CUTLASS SfAtom SF slab
(~2 GB) and the nvfp4_moe decode cache (~144 MiB) — are built **last** during init
(`pre_dequant_weights`, after workspaces and the KV pool), each from live `cudaMemGetInfo`.
When the elastic consumers have already eaten the post-weight headroom, the caches come out
**partial**. They are all-or-nothing for CUDA-graph decode: a single uncovered MoE layer falls
to the host-args legacy path, which throws under capture and aborts the **whole** decode graph.

Measured on Qwen3.6-35B-A3B-NVFP4 (23 GB weights on the 32 GB 5090, follow-up to #925):
default config decoded at **26–40 tok/s** (partial caches, per-step decode) vs **250 tok/s**
with hand-tuned `--max-batch 1 --set runtime.max_seq_len=32768`. A batch-cap-only fix was
tried and reverted — both batch-scaled workspaces AND seq-scaled allocations starve the caches.

## Fix: reserve-early / build-late

New priority order: **weights → mandatory decode caches → workspaces (tiered) → KV (elastic)**.

1. **Balloon reservation** (`engine_weight_upload.cpp`): right after weight upload — before
   `allocate_workspaces` — plain-`cudaMalloc` a placeholder sized by the new
   `compute_native_cache_demand()`. Every later live-free reader (workspaces, budget planner,
   KV pool, SSM state) automatically sees reduced free. Released immediately before
   `pre_dequant_weights` builds the caches into the guaranteed space. On alloc failure: trim
   the async mempool once + retry, then SF-only fallback, then loud WARN (legacy behavior).
2. **Enforced floors** (`pre_dequant_phase3_cutlass.cu` / `_moe.cu`): the mode-2 budgets stay
   live-free-derived but are floored at the balloon-backed guarantee — `cudaMemGetInfo` lags
   async frees on this driver and otherwise under-reports (observed: the MoE floor engaged with
   live-free reporting **0.0 MiB**; without it the MoE cache would have built empty again).
   Floors are only set when the balloon physically covered the bytes (no unbacked over-commit).
3. **Exact demand helper** (`compute_native_cache_demand`, `vram_budget.{h,cpp}`): refactors the
   inline prequant scan with two correctness fixes — uses `cutlass_nvfp4_sf_size()` + the slab's
   256-byte per-entry alignment (the old `elems/16+256` heuristic is not an upper bound under
   SfAtom padding), and includes `ssm_in`/`ssm_out`/`gdn_gate` which phase 0b registers but the
   scan omitted (under-count on GDN hybrids — the exact failing model class).
4. **No double-count** (`compute_vram_budget` new `mandatory_cache_prealloc` param): with the
   balloon held, KV only cedes `phase3_reserve` instead of `phase3_reserve + sf + slab` — more
   KV/context than before at equal safety.
5. **Coverage check** (`engine_kv_cache_init.cpp`): after the cache build, log
   `NVFP4 decode caches: FULL (n/n)` or a loud WARN naming the consequence + remedies.
6. **Resolver awareness** (`engine_init_resolver.cpp`): auto max_batch/max_seq_len subtract the
   cache demand for prequant models (GGUF resolvers unchanged).
7. Escape hatch: `[vram] native_cache_reserve = true` (default on).

Defensive extras: null-check on the SF slab cudaMalloc (no more offsetting into a null slab),
balloon released on init-failure paths and in `~Engine()`.

## Non-prequant models

Balloon gated off, `mandatory_*` floors stay 0, `prealloc` defaults 0 → the budget arithmetic
is unchanged for GGUF/FP16/MXFP4 models (pinned by unit test).

## Verified (RTX 5090)

| Model / config | before | after |
|---|---|---|
| Qwen3.6-35B-A3B-NVFP4, **pure defaults** (auto batch=11, seq=65536) | 26–40 tok/s, caches partial (58–120/14848–30720), capture aborts | **caches FULL (40/40, CUTLASS 30881), graph captures, 247–249 tok/s**, KV pool 138k tokens |
| Qwen3-Coder-30B-A3B-FP4, defaults | — (reference ~317–323) | FULL (48/48), CUTLASS 1800.55 MiB (exact prior value), **383–388 tok/s**, coherent |
| Qwen3-8B-Q8_0 (GGUF hero) | baseline tg128 269.50 | see below (within gate) |

- Qwen3.6-35B: counting, essay, multi-turn recall (turn-3 recalls turn-1 fact) all coherent;
  **0 × status-15 / leak-guard / IMA** in the logs.
- The MoE budget floor was load-bearing in the verification run (live free read 0.0 MiB right
  after the CUTLASS build; the guarantee kept the cache full).
- Unit: 5 new tests in `test_vram_budget_reserve.cpp` (demand exactness vs
  `cutlass_nvfp4_sf_size`, prealloc semantics, zero-demand for GGUF); full VramBudgetReserve
  suite 9/9 green.

Perf-gate note: no intentional perf change for baseline (GGUF) models — arithmetic is
byte-identical there; the NVFP4-prequant improvement is init-ordering only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F
