### PR TITLE
fix(vram): loud WARN when the KV pool collapses below its token floor

### DIFF
--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -459,6 +459,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
         min_kv_tok = std::min(16384, config.max_seq_len * 4);
     }
     int min_kv_blocks = (min_kv_tok + bs - 1) / bs;
+    const int min_kv_blocks_wanted = min_kv_blocks;  // pre-cap: what the floor asked for
     int max_affordable = (per_block_total > 0) ? static_cast<int>(available / per_block_total)
                                                : budget.kv_max_blocks;
     // Defensive cap for auto mode (leaves room for weight caches). When the
@@ -472,6 +473,20 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
                      min_kv_blocks, min_kv_tok);
         budget.kv_max_blocks = min_kv_blocks;
         budget.kv_cache_bytes = static_cast<size_t>(min_kv_blocks) * per_block_total;
+    }
+    // Loud when the pool STILL can't hold the KV floor after every clamp: any
+    // request longer than the pool is rejected/cancelled at admission while
+    // /v1/models keeps advertising max_seq_len. Observed: --max-batch 64 on
+    // Qwen3.6-35B-A3B-NVFP4 (32 GB card) collapsed KV to 16 blocks = 512
+    // tokens — every longer prompt came back finish_reason=cancelled with no
+    // hint why. Batch-scaled workspaces are the usual culprit.
+    if (budget.kv_max_blocks < min_kv_blocks_wanted) {
+        IMP_LOG_WARN(
+            "VRAM budget: KV pool holds only %d tokens (< %d-token floor; requested context "
+            "%d). Longer requests will be rejected or cancelled at admission. Lower "
+            "max_batch_size (batch-scaled workspaces are the usual VRAM consumer) or "
+            "runtime.max_seq_len, or use a smaller model/quant.",
+            budget.kv_max_blocks * bs, min_kv_tok, config.max_seq_len);
     }
 
     // FP8 prefill: use remaining VRAM after NVFP4 decode + the *final* KV size.


### PR DESCRIPTION
Follow-up to #926, found while re-testing the original bug-report config (`--max-batch 64` on Qwen3.6-35B-A3B-NVFP4).

With the new cache-first ordering that config now serves coherent output at ~206 tok/s (caches FULL 40/40) — but the batch-scaled workspaces eat the remaining headroom and the KV pool silently collapses to the 16-block minimum (**512 tokens**). Every longer request returns `finish_reason=cancelled` with no diagnostic, while `/v1/models` keeps advertising `max_model_len=65536`.

This adds a WARN at the end of `compute_vram_budget` when the post-clamp pool still undershoots the min-KV floor, naming the actual pool size and the remedies (lower `max_batch_size` / `runtime.max_seq_len`). Log-only, no sizing change.

Verified on the 5090: WARN fires on the `--max-batch 64` repro, absent on default config (138k-token pool); `VramBudgetReserve` 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F