### PR TITLE
feat(attn): stage 3 — fa2_hd256 default-on, single-shot FA2 for uniform hybrids, FP8-KV forcing lifted, S-matrix skip for FA2-served configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Changed
+- **HD=256 FA2 default-on + FP8-KV deterministic forcing lifted (stage 3).**
+  `attention.fa2_hd256` now defaults to true: head_dim=256 models (Qwen3.6
+  hybrids, gemma-3-class) route prefill through the register-resident f16-QK
+  FA2 kernel by default. The single-shot prefill path gains the chunked
+  path's uniform-shape refinement — GDN/Mamba2 hybrids (one distinct
+  attention shape) now take FA2 single-shot at any head_dim instead of
+  unconditionally falling to cuBLAS; learned sinks (gpt-oss) and
+  heterogeneous per-layer shapes (gemma-4) keep cuBLAS. With FA2 serving
+  every attention call on uniform hd=128/256 models, the FP8-KV
+  deterministic-cuBLAS forcing (`engine_init_resolver`) is skipped for
+  hd=256 too — FP8 KV on Qwen3.6-35B no longer drags in the model-wide
+  deterministic algo pinning. Validation battery in PR.
+
 ### Added
 - **Stage-1 HD=256 FA2 port (`attention.fa2_hd256`, default off).** The
   register-resident FA2 prefill kernel gains head_dim=256 instances (fp16-qk,

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -175,10 +175,11 @@ fa2_f16acc           = true
 # PPL on a 14.8k teacher-forced corpus: 14B −0.06%, 30B −0.30%, Q8 +0.002%
 # (noise). Default true since 2026-06-11. Needs fa2_f16acc.
 fa2_pv_f16acc        = true
-# Stage-1 HD=256 FA2 port: route head_dim=256 prefill (Qwen3.6 hybrids,
-# gemma-class) through the register-resident FA2 kernel (fp16-qk, Bq=64,
-# TWOSLOT) instead of the SMEM-tiled WMMA FMHA. A/B lever, default off.
-fa2_hd256            = false
+# HD=256 FA2 port: route head_dim=256 prefill (Qwen3.6 hybrids, gemma-class)
+# through the register-resident FA2 kernel (fp16-qk, Bq=64, TWOSLOT) instead
+# of the SMEM-tiled WMMA FMHA / cuBLAS. Default on since stage 3; also lifts
+# the FP8-KV deterministic-cuBLAS forcing for hd=256 models.
+fa2_hd256            = true
 # Prefill chunk length (tokens) at/above which attention routes to FMHA
 # (tiled, O(n) memory) instead of the materialized cuBLAS S-matrix path.
 # -1 = auto (derived from the cuBLAS S-matrix VRAM cap).

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -327,7 +327,16 @@
 
         // Prefill dispatch (post-Phase-2 + Phase-5 Track D):
         // attn_sinks: only the cuBLAS softmax understands learned sinks.
-        const bool force_cublas_attn = per_layer_shapes || attn_sinks != nullptr;
+        // Uniform per-layer shapes (GDN/Mamba2 hybrids: zeros on non-attention
+        // layers, one distinct nonzero value) are FA2-servable — same
+        // refinement the chunked path has used since #924. Only truly
+        // heterogeneous shapes (gemma-4 dual head_dim) and learned sinks
+        // (gpt-oss) require cuBLAS. Without this, hybrids never took
+        // single-shot FA2 at any head_dim, and the FP8-KV deterministic skip
+        // ("FA2 serves all attention") would be a lie for prompts below the
+        // chunk size.
+        const bool force_cublas_attn =
+            (per_layer_shapes && !attn_shapes_uniform()) || attn_sinks != nullptr;
         const bool s_matrix_fits = attn_scores_buf_ != nullptr &&
                                    n <= static_cast<int>(attn_scores_.shape[1]);
         // FMHA only above the S-matrix threshold — see the chunked path above

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -303,22 +303,34 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
     }
 
     // cuBLAS attention S-matrix workspace: [n_heads, attn_seq, attn_seq] FP16.
-    // Only the materialized cuBLAS prefill fallback consumes this. On hd=128
-    // models without learned sinks (gpt-oss is hd=64, so hd==128 already excludes
-    // it) or per-layer shapes, FP16-QK FA2 serves ALL prefill at-or-above cuBLAS
-    // at every length (Qwen3-Coder-30B NVFP4: ~parity pp512, +24% pp1024, +52%
-    // pp2048, measured 2026-06-12) — the buffer is dead weight there, so skip it (reclaims
-    // up to ~380 MiB at batch8/ctx4096). cuBLAS stays the reference for hd != 128
-    // (gemma hd=256), per-layer shapes (gemma-4 hd=512), and the explicit
+    // Only the materialized cuBLAS prefill fallback consumes this. On uniform-
+    // shape models without learned sinks whose head_dim FA2 covers (128 always,
+    // 256 behind attention.fa2_hd256), FP16-QK FA2 serves ALL prefill at-or-above
+    // cuBLAS at every length (hd=128: Qwen3-Coder-30B NVFP4 ~parity pp512, +24%
+    // pp1024, +52% pp2048, 2026-06-12; hd=256 rides the #930/#932 port) — the
+    // buffer is dead weight there, so skip it (reclaims up to ~380 MiB at
+    // batch8/ctx4096). Uniform per-layer shapes (GDN/Mamba2 hybrids: zeros on
+    // non-attention layers) take FA2 too since the #932 single-shot refinement.
+    // cuBLAS stays the reference for heterogeneous shapes (gemma-4 dual head_dim),
+    // learned sinks (gpt-oss), hd=256 with fa2_hd256 off, and the explicit
     // fa2_fp16qk=never opt-out. See the run_attention dispatch (FA2 tried first).
-    const int hd_for_attn = cfg.head_dim > 0 ? cfg.head_dim : (cfg.d_model / cfg.n_heads);
-    const bool fa2_serves_all_prefill = hd_for_attn == 128 &&
+    int hd_for_attn = cfg.head_dim > 0 ? cfg.head_dim : (cfg.d_model / cfg.n_heads);
+    for (int x : cfg.head_dim_per_layer) {
+        if (x > 0) {
+            hd_for_attn = x;  // hybrids: first attention layer's head_dim
+            break;
+        }
+    }
+    const bool fa2_hd_ok = hd_for_attn == 128 ||
+                           (hd_for_attn == 256 && runtime_config().attention.fa2_hd256);
+    const bool fa2_serves_all_prefill = fa2_hd_ok &&
                                         runtime_config().attention.fa2_fp16qk != "never" &&
-                                        cfg.head_dim_per_layer.empty() &&
-                                        cfg.n_kv_heads_per_layer.empty();
+                                        attn_shapes_uniform() &&
+                                        !model_->profile().is_gpt_oss;
     if (fa2_serves_all_prefill) {
-        IMP_LOG_INFO("cuBLAS attention S-matrix: skipped (FP16-QK FA2 serves all hd=128 prefill — "
-                     "no S-matrix needed)");
+        IMP_LOG_INFO("cuBLAS attention S-matrix: skipped (FP16-QK FA2 serves all hd=%d prefill — "
+                     "no S-matrix needed)",
+                     hd_for_attn);
     } else if (!skip_batch_dequant) {
         int nh = cfg.n_heads;
         // 256 MiB: cuBLAS handles short sequences (up to ~1448 attn_seq for

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -246,13 +246,15 @@ struct RuntimeConfig {
         // 2026-06-11; set false to restore f32 PV accumulate. Requires
         // fa2_f16acc.
         bool fa2_pv_f16acc = true;
-        // Stage-1 HD=256 FA2 port (Qwen3.6 hybrids / gemma-class): route
-        // head_dim=256 prefill through the register-resident FA2 kernel
-        // (fp16-qk, Bq=64/TWOSLOT) instead of the SMEM-tiled WMMA FMHA.
-        // Default off — the HD=256 instances run at ~2x the register
-        // pressure of the tuned hd=128 mainline; enable for A/B only until
-        // the split-D stage-2 port lands.
-        bool fa2_hd256 = false;
+        // HD=256 FA2 port (Qwen3.6 hybrids / gemma-class): route head_dim=256
+        // prefill through the register-resident FA2 kernel (fp16-qk,
+        // Bq=64/TWOSLOT) instead of the SMEM-tiled WMMA FMHA / cuBLAS.
+        // Default ON since stage 3 (#930 measured: kernel 4.3x vs WMMA,
+        // e2e +10.6% pp4096 / +24.8% pp8192, PPL 10.44 vs 10.58 on
+        // Qwen3.6-35B; split-D stage 2 was refuted — the 4-warp instance is
+        // the keeper). Also gates the FP8-KV deterministic-cuBLAS skip for
+        // hd=256 models (engine_init_resolver fa2_serves_attention).
+        bool fa2_hd256 = true;
         // amax-scaled e4m3 conversion for the fp8-QK FA2 path (#680). The
         // raw conversion is the #511 quality cliff; scaling Q and K to the
         // full e4m3 range is the numerics class FlashInfer runs. Only

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -227,14 +227,22 @@ void Engine::init_resolve_kv_dtype_policy_() {
     // without it kv-fp8 is perf-neutral-to-positive at clean PPL on
     // Qwen3-30B/14B/8B). Non-FA2 configs (gemma-class hd!=128, attn sinks
     // via head_dim, fa2 disabled) keep the workaround.
-    const bool fa2_serves_attention = mcfg.head_dim == 128 &&
+    // hd=256 rides the FA2 port (#930) since attention.fa2_hd256 went
+    // default-on: with the single-shot uniform-hybrid refinement the f16-QK
+    // FA2 chain serves every attention call on uniform hd=128/256 models —
+    // cuBLAS attention (the FP8-KV NaN-roundtrip risk this forcing guards)
+    // only remains for learned sinks (gpt-oss, hd=64) and heterogeneous
+    // per-layer shapes (gemma-4), which keep the workaround below.
+    const bool fa2_hd_ok = mcfg.head_dim == 128 ||
+                           (mcfg.head_dim == 256 && runtime_config_.attention.fa2_hd256);
+    const bool fa2_serves_attention = fa2_hd_ok &&
                                       runtime_config_.attention.fmha_fa2 != "never" &&
                                       runtime_config_.attention.fa2_fp16qk != "never";
     if (config_.kv_cache_dtype == QType::FP8_E4M3 && fa2_serves_attention &&
         !runtime_config_.runtime.deterministic_gemm) {
-        IMP_LOG_INFO("FP8 KV cache: FA2 serves all attention (hd=128) — skipping the legacy "
-                     "deterministic-cuBLAS forcing (set kv_cache.allow_nondeterministic_fp8=false "
-                     "semantics unchanged for non-FA2 configs)");
+        IMP_LOG_INFO("FP8 KV cache: FA2 serves all attention (hd=128/256) — skipping the legacy "
+                     "deterministic-cuBLAS forcing (non-FA2 configs — learned sinks, heterogeneous "
+                     "per-layer shapes — keep it; set runtime.deterministic_gemm=true to force)");
     }
     if (config_.kv_cache_dtype == QType::FP8_E4M3 && !fa2_serves_attention &&
         !runtime_config_.kv_cache.allow_nondeterministic_fp8 &&


### PR DESCRIPTION
Finishes the #930 HD=256 FA2 arc (stage 2 split-D was refuted in #931 — stage 1 is the keeper kernel). Three coupled changes:

1. **`attention.fa2_hd256` default ON** — hd=256 models (Qwen3.6 hybrids, gemma-3-class) take the register-resident f16-QK FA2 prefill kernel by default.
2. **Single-shot uniform-hybrid refinement** — `force_cublas_attn = (per_layer_shapes && !attn_shapes_uniform()) || sinks`, mirroring the chunked path (#924 helper). GDN/Mamba2 hybrids previously **never** took single-shot FA2 at any head_dim; every sub-chunk-size prompt ran cuBLAS attention. Sinks (gpt-oss) and heterogeneous shapes (gemma-4) keep cuBLAS.
3. **FP8-KV deterministic forcing lifted for hd=256** — with FA2 serving every attention call on uniform hd=128/256 models, `fa2_serves_attention` accepts hd=256 and the PR-#52-era NaN workaround no longer drags model-wide deterministic algo pinning into Qwen3.6-35B FP8-KV serving. (+ stale skip-log text fixed.)

## Validation battery (RTX 5090)

| Gate | Result |
|---|---|
| 35B **FP8-KV unforced** PPL (the NaN risk) | **10.4789** vs 10.5596 F16-KV — no regression, coherent, 0 status-14/15 |
| Forcing cost recovered | FP8-KV pp4096 **12219 → 15400 tok/s (+26%)** vs `deterministic_gemm=true` (old behavior) |
| gemma-3-12b (hd=256+**SWA**, #566 anchor) | PPL 7.9316 (on) vs 7.9302 (off) — 0.02%, noise |
| Qwen3.5-4B GDN (hd=128 hybrid, single-shot change) | PPL 13.0775 (FA2) vs 13.0793 (old cuBLAS routing) |
| 35B pp2048 single-shot | 15433 tok/s vs 15030–15295 cuBLAS ref |
| Q8 hero (dense hd=128, untouched routing) | tg 275.98 vs baseline 269.50 |
| gpt-oss-20b (sinks) | unchanged path, coherent, 389 tok/s |
| Unit / verify-fast | 67/67 FA2+routing tests; OK |

Perf-baseline note: no intentional change for baseline dense-hd=128 models — their routing is untouched.


## Follow-up commit: S-matrix skip on all FA2-served configs

`fa2_serves_all_prefill` (workspace alloc) now mirrors the routing above: uniform per-layer shapes (GDN/Mamba2 hybrids) and hd=256 behind `attention.fa2_hd256` skip the cuBLAS attention S-matrix workspace. Head dim resolves from the first attention layer for hybrids; learned sinks excluded explicitly, heterogeneous shapes via `attn_shapes_uniform()`. All `s_cap` consumers already degrade gracefully at cap=0 (`max_safe_prefill_chunk`, spec-ngram clamp, constrained-jump clamp, auto `fmha_prefill_threshold` → 1).

| Gate | Result |
|---|---|
| Qwen3.6-35B-A3B-NVFP4 (hd=256 hybrid) | S-matrix **skipped, −128 MiB**; PPL 12.13 (FA2) vs 12.37 (`fa2_hd256=false` cuBLAS ref) |
| gemma-3-12b (hd=256+SWA) | S-matrix **skipped, −381.57 MiB**; PPL 9.1900 vs 9.1883 (0.02%, noise) |
| Qwen3.5-4B GDN (uniform hybrid, newly skipped) | PPL 15.40 sane, greedy output coherent |
| gemma-4-26B (heterogeneous shapes) | buffer **kept** (381.57 MiB), output correct |
| gpt-oss-20b (learned sinks) | buffer **kept** (378.12 MiB), output correct |
| Q8 hero (hd=128 dense, identical predicate result) | tg 274.98 vs baseline band 268–278 |
| Unit + full GPU suites | all green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F
