### PR TITLE
feat(spec): graph-captured verify for hd=256 GDN hybrids

### DIFF
--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -1,6 +1,9 @@
 #include "compute/gdn_internal.cuh"
 #include "core/logging.h"
 
+#include <stdexcept>
+#include <string>
+
 namespace imp {
 
 // Forward declarations
@@ -33,11 +36,17 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_fused_kernel(
     const float* __restrict__ dt_bias,   // [n_heads] FP32
     float* __restrict__ h_state,         // [n_heads, SS, HD] FP32
     YOut* __restrict__ y_out,            // [n_tokens, n_heads * HD] FP16 or FP32
-    int n_tokens, int n_heads, int n_groups, int conv_channels, int grouped_layout) {
+    int n_tokens, int n_heads, int n_groups, int conv_channels, int grouped_layout,
+    const int* __restrict__ d_real_n) {  // device chunk length (padded verify chunk) or nullptr
     const int h = blockIdx.x;
     if (h >= n_heads)
         return;
     const int d = threadIdx.x;
+    // Padded verify chunk (#847): y is produced for every row (padding rows
+    // are causally invisible downstream), but the committed h_state is the
+    // register snapshot at the real last row — H_reg keeps evolving through
+    // the pads only to define their (discarded) y values.
+    const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
 
     // Head-to-K-group mapping. GGUF stores heads in tiled layout where head h's
     // group is `h % n_groups`. HF SafeTensors (Qwen3.5/3.6) stores heads in
@@ -164,19 +173,21 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_fused_kernel(
             }
         }
 
+        // Commit the state at the real last row (per-thread register column,
+        // no barrier needed). For the unpadded case real_n == n_tokens and
+        // this is the single end-of-scan store the kernel always did.
+        if (t + 1 == real_n) {
+            float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
+#pragma unroll
+            for (int s = 0; s < SS; s++)
+                H_col[s * HD] = H_reg[s];
+        }
+
         // Sync before next token — the next iteration overwrites s_k/s_q in
         // shared memory. Without this barrier, fast threads can overwrite
         // s_k/s_q while slow threads are still reading them in the loops above.
         if (t + 1 < n_tokens)
             __syncthreads();
-    }
-
-    // Store state back to global memory (once, at the end)
-    {
-        float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
-#pragma unroll
-        for (int s = 0; s < SS; s++)
-            H_col[s * HD] = H_reg[s];
     }
 }
 
@@ -305,7 +316,7 @@ void vhead_tiled_to_grouped_f32(const float* src, float* dst, int n_tokens, int 
 void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                         const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
                         int n_heads, int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
-                        int grouped_layout) {
+                        int grouped_layout, const int* d_real_n) {
     // Shared memory: K_norm[SS] + Q_norm[SS] + reduce[HD]
     size_t smem = (2 * state_size + head_dim_ssm) * sizeof(float);
 
@@ -313,13 +324,18 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
     if (head_dim_ssm == 128 && state_size == 128) {
         gdn_scan_fused_kernel<128, 128, half>
             <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
-                                             n_heads, n_groups, conv_channels, grouped_layout);
+                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, half>
             <<<n_heads, 64, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
-                                            n_heads, n_groups, conv_channels, grouped_layout);
+                                            n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
     } else {
-        // Fallback: per-token loop (for unsupported HD/SS sizes)
+        // Fallback: per-token loop (for unsupported HD/SS sizes). The host
+        // loop cannot bound itself by a device-side length — reject padded
+        // verify chunks loudly instead of advancing state through pad rows.
+        if (d_real_n != nullptr)
+            throw std::runtime_error("gdn_scan_fused_f32: padded verify chunk unsupported for HD=" +
+                                     std::to_string(head_dim_ssm) + " SS=" + std::to_string(state_size));
         int inner = n_heads * head_dim_ssm;
         int BC_size = n_groups * state_size;
         size_t smem_old = 2 * state_size * sizeof(float) + 2 * sizeof(float);
@@ -338,17 +354,20 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
 void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                             int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            cudaStream_t stream, int grouped_layout) {
+                            cudaStream_t stream, int grouped_layout, const int* d_real_n) {
     size_t smem = (2 * state_size + head_dim_ssm) * sizeof(float);
     if (head_dim_ssm == 128 && state_size == 128) {
         gdn_scan_fused_kernel<128, 128, float>
             <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
-                                             n_heads, n_groups, conv_channels, grouped_layout);
+                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, float>
             <<<n_heads, 64, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
-                                            n_heads, n_groups, conv_channels, grouped_layout);
+                                            n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
     } else {
+        if (d_real_n != nullptr)
+            throw std::runtime_error("gdn_scan_fused_fp32out: padded verify chunk unsupported for HD=" +
+                                     std::to_string(head_dim_ssm) + " SS=" + std::to_string(state_size));
         // No FP32 fallback: supported sizes are HD=SS=128 / 64 only.
         // Fall back to FP16 path + post-hoc upcast (precision loss intact).
         int inner = n_heads * head_dim_ssm;
@@ -398,13 +417,16 @@ __global__ void gdn_scan_reference_kernel(
     float* __restrict__ h_state,         // [n_heads, state_size, head_dim_v] FP32
     half* __restrict__ y_out,            // [n_tokens, n_heads * head_dim_v] FP16
     int n_tokens, int n_heads, int n_groups, int head_dim_v, int state_size, int conv_channels,
-    int grouped_layout) {
+    int grouped_layout, const int* __restrict__ d_real_n) {
     const int h = blockIdx.x;
     if (h >= n_heads)
         return;
     const int d = threadIdx.x;  // [0, head_dim_v)
     const int SS = state_size;
     const int HD = head_dim_v;
+    // Padded verify chunk (#847): commit the state at the real last row; pads
+    // only define their (discarded) y rows. See gdn_scan_fused_kernel.
+    const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
 
     const int g = grouped_layout ? (h / (n_heads / n_groups)) : (h % n_groups);
     const int inner = n_heads * HD;
@@ -513,22 +535,23 @@ __global__ void gdn_scan_reference_kernel(
 
         y_out[t * inner + h * HD + d] = __float2half(y_partial * rsqrtf(static_cast<float>(HD)));
 
-        __syncthreads();  // before next token overwrites s_k/s_q/s_v
-    }
-
-    // Store state back to global.
-    {
-        float* H_dst = h_state + static_cast<size_t>(h) * SS * HD;
-        for (int idx = d; idx < SS * HD; idx += HD) {
-            H_dst[idx] = s_H[idx];
+        // Commit the state at the real last row. Each thread copies exactly
+        // the column (d, d+HD, ...) it wrote above — no barrier needed.
+        if (t + 1 == real_n) {
+            float* H_dst = h_state + static_cast<size_t>(h) * SS * HD;
+            for (int idx = d; idx < SS * HD; idx += HD) {
+                H_dst[idx] = s_H[idx];
+            }
         }
+
+        __syncthreads();  // before next token overwrites s_k/s_q/s_v
     }
 }
 
 void gdn_scan_reference_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
                             int n_heads, int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
-                            int grouped_layout) {
+                            int grouped_layout, const int* d_real_n) {
     // Shared memory: state slab [SS*HD] + K[SS] + Q[SS] + V[HD] + reduce[HD]
     // For Qwen 3.6 (SS=128, HD=128): ~66 KB — exceeds 48 KB default per block,
     // needs the opt-in dynamic-shared attribute.
@@ -542,7 +565,8 @@ void gdn_scan_reference_f32(const float* conv_f32, int conv_channels, const half
     gdn_scan_reference_kernel<<<n_heads, head_dim_ssm, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias,
                                                                        h_state, y, n_tokens, n_heads,
                                                                        n_groups, head_dim_ssm, state_size,
-                                                                       conv_channels, grouped_layout);
+                                                                       conv_channels, grouped_layout,
+                                                                       d_real_n);
 }
 
 // FP32-input variant: reads y as FP32, writes FP16. Used together with

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -14,10 +14,13 @@ namespace imp {
 // grouped_layout: 0 = GGUF/tiled (kernel uses g = h % n_groups; default).
 //                 1 = HF SafeTensors/grouped (g = h / (n_heads / n_groups);
 //                     used by Qwen3.5/3.6 NVFP4 SafeTensors).
+// d_real_n: optional device int — real chunk length when the chunk is padded
+//           (#847 captured verify). y is written for every row; the committed
+//           h_state stops at the real last row so pads never advance it.
 void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                         const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
                         int n_heads, int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
-                        int grouped_layout = 0);
+                        int grouped_layout = 0, const int* d_real_n = nullptr);
 
 // EXPERIMENTAL — Phase 1b scaffolding for chunkwise SSD scan.
 // Same signature as `gdn_scan_fused_f32`. Will eventually implement the
@@ -38,7 +41,8 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
 void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
                             int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0);
+                            cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0,
+                            const int* d_real_n = nullptr);
 
 // FP32-output chunkwise variant — matches `gdn_scan_fused_fp32out`'s contract.
 // Same chunked shared-memory layout as `gdn_scan_chunkwise_f32`, output kept
@@ -46,7 +50,8 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
 void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                                 const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                                 int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                                cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0);
+                                cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0,
+                                const int* d_real_n = nullptr);
 
 // Phase 2a — WY-representation parallel delta-rule scan prototype.
 // Numerically equivalent to the sequential delta rule but factors the
@@ -117,7 +122,7 @@ void gdn_rmsnorm_gated_silu_fp32inout(float* y_fp32_out, const float* y_fp32_in,
 void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                             int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            cudaStream_t stream, int grouped_layout = 0);
+                            cudaStream_t stream, int grouped_layout = 0, const int* d_real_n = nullptr);
 
 // ---------------------------------------------------------------------------
 // Reference multi-token GDN scan.
@@ -129,7 +134,7 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half
 void gdn_scan_reference_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
                             int n_heads, int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
-                            int grouped_layout = 0);
+                            int grouped_layout = 0, const int* d_real_n = nullptr);
 
 // ---------------------------------------------------------------------------
 // Legacy per-token interfaces (kept for fallback / testing)

--- a/src/compute/gdn_scan.cu
+++ b/src/compute/gdn_scan.cu
@@ -476,7 +476,16 @@ static void gdn_scan_chunkwise_dispatch(const float* conv_f32, int conv_channels
                                         const half* beta, const float* A_log, const float* dt_bias,
                                         float* h_state, YOut* y, int n_tokens, int n_heads, int head_dim_ssm,
                                         int state_size, int n_groups, cudaStream_t stream, int chunk_size,
-                                        int grouped_layout, FusedFallback fused) {
+                                        int grouped_layout, const int* d_real_n, FusedFallback fused) {
+    // Padded verify chunk (#847): the host cannot split a device-side length
+    // across chunks, and neither the chunkwise fast kernel nor the wrapper
+    // loop is device-length-aware. Run the whole (small — verify buckets are
+    // ≤ k_max+1 tokens) padded chunk through one sequential fused call, which
+    // commits the state at the real last row.
+    if (d_real_n != nullptr) {
+        fused(conv_f32, alpha, beta, h_state, y, n_tokens, d_real_n);
+        return;
+    }
     if (chunk_size <= 0)
         chunk_size = 64;
     if (chunk_size > n_tokens)
@@ -521,7 +530,7 @@ static void gdn_scan_chunkwise_dispatch(const float* conv_f32, int conv_channels
     while (t < n_tokens) {
         const int this_chunk = (t + chunk_size <= n_tokens) ? chunk_size : (n_tokens - t);
         fused(conv_f32 + static_cast<size_t>(t) * conv_channels, alpha + t * n_heads, beta + t * n_heads,
-              h_state, y + static_cast<size_t>(t) * inner, this_chunk);
+              h_state, y + static_cast<size_t>(t) * inner, this_chunk, nullptr);
         t += this_chunk;
     }
 }
@@ -529,15 +538,15 @@ static void gdn_scan_chunkwise_dispatch(const float* conv_f32, int conv_channels
 void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, half* y,
                             int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            cudaStream_t stream, int chunk_size, int grouped_layout) {
+                            cudaStream_t stream, int chunk_size, int grouped_layout, const int* d_real_n) {
     gdn_scan_chunkwise_dispatch<half>(
         conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, head_dim_ssm,
-        state_size, n_groups, stream, chunk_size, grouped_layout,
+        state_size, n_groups, stream, chunk_size, grouped_layout, d_real_n,
         [&](const float* row_conv, const half* row_alpha, const half* row_beta, float* h_state_, half* y_,
-            int n_tok_chunk) {
+            int n_tok_chunk, const int* d_real_n_chunk) {
             gdn_scan_fused_f32(row_conv, conv_channels, row_alpha, row_beta, A_log, dt_bias, h_state_, y_,
                                n_tok_chunk, n_heads, head_dim_ssm, state_size, n_groups, stream,
-                               grouped_layout);
+                               grouped_layout, d_real_n_chunk);
         });
 }
 
@@ -548,15 +557,16 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
 void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                                 const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                                 int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                                cudaStream_t stream, int chunk_size, int grouped_layout) {
+                                cudaStream_t stream, int chunk_size, int grouped_layout,
+                                const int* d_real_n) {
     gdn_scan_chunkwise_dispatch<float>(
         conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens, n_heads, head_dim_ssm,
-        state_size, n_groups, stream, chunk_size, grouped_layout,
+        state_size, n_groups, stream, chunk_size, grouped_layout, d_real_n,
         [&](const float* row_conv, const half* row_alpha, const half* row_beta, float* h_state_, float* y_,
-            int n_tok_chunk) {
+            int n_tok_chunk, const int* d_real_n_chunk) {
             gdn_scan_fused_fp32out(row_conv, conv_channels, row_alpha, row_beta, A_log, dt_bias, h_state_, y_,
                                    n_tok_chunk, n_heads, head_dim_ssm, state_size, n_groups, stream,
-                                   grouped_layout);
+                                   grouped_layout, d_real_n_chunk);
         });
 }
 

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -260,12 +260,10 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
 void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t stream) {
     configure_ssm_workspace(ws_.shared_max_tokens());
 
-    // The GDN scan kernels are not device-length-aware yet — a padded verify
-    // chunk would advance the recurrent state through pad rows. Unreachable
-    // today (chunk_capture_supported requires hd==128 and every GDN model is
-    // hd=256/FMHA), but fail loud rather than corrupt state silently (#858).
-    if (state.d_chunk_len != nullptr)
-        throw std::runtime_error("run_gdn: GDN scan is not device-length-aware (captured verify chunk)");
+    // Padded verify chunk (#847): state.d_chunk_len carries the real chunk
+    // length on device. The conv1d and delta-rule scan kernels below commit
+    // conv tail + h_state at the real last row; pad rows only produce their
+    // (causally discarded) y values. Same contract as run_ssm.
 
     const auto& cfg = model_->config();
     const auto& ly = model_->layer(layer);
@@ -342,7 +340,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                 static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_),
                                 cudaMemcpyDeviceToDevice, stream));
             ssm_conv1d_prefill_f32_silu(conv_st, xBC_out, ly.ssm_conv1d_w, ly.ssm_conv1d_b, conv_f32,
-                                        conv_kernel, stream);
+                                        conv_kernel, stream, state.d_chunk_len);
         } else {
             // Decode: FP32 fused conv+SiLU (matching llama.cpp precision).
             // Copy FP16 input to xBC_out first to avoid aliasing: conv_f32
@@ -505,14 +503,15 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                            static_cast<const float*>(ly.ssm_a.data),
                                            static_cast<const float*>(ly.ssm_dt_b.data),
                                            static_cast<float*>(h_st), y_fp32, n, n_heads, head_dim_ssm, ssize,
-                                           n_groups, stream, /*chunk_size=*/64, gl);
+                                           n_groups, stream, /*chunk_size=*/64, gl, state.d_chunk_len);
             } else {
                 gdn_scan_fused_fp32out(conv_f32, conv_channels,
                                        static_cast<const half*>(alpha_proj_out.data),
                                        static_cast<const half*>(beta_proj_out.data),
                                        static_cast<const float*>(ly.ssm_a.data),
                                        static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
-                                       y_fp32, n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl);
+                                       y_fp32, n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl,
+                                       state.d_chunk_len);
             }
             // FP32-in, FP32-out RMSNorm+Gate+SiLU: preserves precision for the
             // ssm_out matmul. The FP32→FP16 copy below is REQUIRED, not optional
@@ -538,7 +537,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                    static_cast<const float*>(ly.ssm_a.data),
                                    static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
                                    static_cast<half*>(y_buf.data), n, n_heads, head_dim_ssm, ssize, n_groups,
-                                   stream, gl);
+                                   stream, gl, state.d_chunk_len);
         } else {
             const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
             if (use_chunkwise) {
@@ -548,14 +547,14 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                        static_cast<const float*>(ly.ssm_a.data),
                                        static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
                                        static_cast<half*>(y_buf.data), n, n_heads, head_dim_ssm, ssize,
-                                       n_groups, stream, /*chunk_size=*/64, gl);
+                                       n_groups, stream, /*chunk_size=*/64, gl, state.d_chunk_len);
             } else {
                 gdn_scan_fused_f32(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
                                    static_cast<const half*>(beta_proj_out.data),
                                    static_cast<const float*>(ly.ssm_a.data),
                                    static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
                                    static_cast<half*>(y_buf.data), n, n_heads, head_dim_ssm, ssize, n_groups,
-                                   stream, gl);
+                                   stream, gl, state.d_chunk_len);
             }
         }
     }

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1369,8 +1369,13 @@ bool GraphExecutor::chunk_capture_supported() const {
             break;
         }
     }
-    if (hd_u != 128)
-        return false;  // FP16-QK FA2 is the only device-length chunked kernel
+    // FP16-QK FA2 is the only device-length chunked attention kernel. hd=256
+    // rides the #930 port (d_kv_len is a runtime kernel argument shared by
+    // every instance); the GDN/Mamba2 recurrent kernels stop state updates at
+    // the device chunk length (d_chunk_len), so hd=256 hybrids (Qwen3.5/3.6)
+    // are capture-eligible when the fa2_hd256 flag is on.
+    if (hd_u != 128 && !(hd_u == 256 && runtime_config().attention.fa2_hd256))
+        return false;
     if (runtime_config().attention.fa2_fp16qk == "never")
         return false;
     // MoE: only the CUTLASS 3.x device-args grouped path records into a

--- a/tests/test_gdn.cu
+++ b/tests/test_gdn.cu
@@ -1208,5 +1208,111 @@ TEST(GDNScanTest, RMSNormGatedSiLU) {
     cudaFree(d_weight);
 }
 
+// ===========================================================================
+// Test: Padded verify chunk (#847), GDN scans — with d_real_n set, y is
+// produced for every row but h_state must stop advancing after the real
+// last row (bit-equal to a plain run over the real rows). Covers the fused
+// kernel, the chunkwise entry (routes padded chunks through one fused call)
+// and the reference kernel.
+// ===========================================================================
+TEST(GDNScanTest, PaddedChunkDeviceLength) {
+    constexpr int n_heads = 4;
+    constexpr int n_groups = 2;
+    constexpr int head_dim = 64;
+    constexpr int state_size = 64;
+    constexpr int inner = n_heads * head_dim;
+    constexpr int BC_size = n_groups * state_size;
+    constexpr int conv_channels = 2 * BC_size + inner;
+    constexpr int n_real = 5;
+    constexpr int n_padded = 12;
+
+    std::vector<float> conv_f32(n_padded * conv_channels);
+    std::vector<half> h_alpha(n_padded * n_heads), h_beta(n_padded * n_heads);
+    std::vector<float> h_A_log(n_heads, -0.5f), h_dt_bias(n_heads, 0.5f);
+    for (size_t i = 0; i < conv_f32.size(); i++)
+        conv_f32[i] = std::sin(0.37f * i);
+    for (size_t i = 0; i < h_alpha.size(); i++) {
+        h_alpha[i] = __float2half(std::cos(0.21f * i));
+        h_beta[i] = __float2half(std::sin(0.11f * i + 1.0f));
+    }
+
+    float *d_conv, *d_A, *d_dt;
+    half *d_alpha, *d_beta;
+    cudaMalloc(&d_conv, conv_f32.size() * sizeof(float));
+    cudaMalloc(&d_A, n_heads * sizeof(float));
+    cudaMalloc(&d_dt, n_heads * sizeof(float));
+    cudaMalloc(&d_alpha, h_alpha.size() * sizeof(half));
+    cudaMalloc(&d_beta, h_beta.size() * sizeof(half));
+    cudaMemcpy(d_conv, conv_f32.data(), conv_f32.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_A, h_A_log.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_dt, h_dt_bias.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha, h_alpha.data(), h_alpha.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_beta, h_beta.data(), h_beta.size() * sizeof(half), cudaMemcpyHostToDevice);
+
+    int* d_real_n;
+    cudaMalloc(&d_real_n, sizeof(int));
+    int real_n = n_real;
+    cudaMemcpy(d_real_n, &real_n, sizeof(int), cudaMemcpyHostToDevice);
+
+    const size_t h_elems = static_cast<size_t>(n_heads) * state_size * head_dim;
+
+    // scan_fn(n_tokens, d_real_n, d_state, d_y)
+    auto check_variant = [&](const char* name, auto scan_fn) {
+        float* d_state;
+        half* d_y;
+        cudaMalloc(&d_state, h_elems * sizeof(float));
+        cudaMalloc(&d_y, static_cast<size_t>(n_padded) * inner * sizeof(half));
+
+        // Reference: plain run over the real rows only.
+        cudaMemset(d_state, 0, h_elems * sizeof(float));
+        scan_fn(n_real, static_cast<const int*>(nullptr), d_state, d_y);
+        cudaDeviceSynchronize();
+        std::vector<float> h_ref(h_elems);
+        std::vector<half> y_ref(static_cast<size_t>(n_real) * inner);
+        cudaMemcpy(h_ref.data(), d_state, h_elems * sizeof(float), cudaMemcpyDeviceToHost);
+        cudaMemcpy(y_ref.data(), d_y, y_ref.size() * sizeof(half), cudaMemcpyDeviceToHost);
+
+        // Padded run with the device-side real length.
+        cudaMemset(d_state, 0, h_elems * sizeof(float));
+        scan_fn(n_padded, static_cast<const int*>(d_real_n), d_state, d_y);
+        cudaDeviceSynchronize();
+        std::vector<float> h_pad(h_elems);
+        std::vector<half> y_pad(static_cast<size_t>(n_padded) * inner);
+        cudaMemcpy(h_pad.data(), d_state, h_elems * sizeof(float), cudaMemcpyDeviceToHost);
+        cudaMemcpy(y_pad.data(), d_y, y_pad.size() * sizeof(half), cudaMemcpyDeviceToHost);
+
+        for (int t = 0; t < n_real; t++)
+            for (int i = 0; i < inner; i++)
+                EXPECT_EQ(__half2float(y_ref[t * inner + i]), __half2float(y_pad[t * inner + i]))
+                    << name << ": y mismatch at t=" << t << " i=" << i;
+        for (size_t i = 0; i < h_elems; i++)
+            EXPECT_EQ(h_ref[i], h_pad[i]) << name << ": h_state mismatch at i=" << i;
+
+        cudaFree(d_state);
+        cudaFree(d_y);
+    };
+
+    check_variant("fused", [&](int n_tok, const int* d_rn, float* d_state, half* d_y) {
+        gdn_scan_fused_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state, d_y, n_tok, n_heads,
+                           head_dim, state_size, n_groups, nullptr, /*grouped_layout=*/0, d_rn);
+    });
+    check_variant("chunkwise", [&](int n_tok, const int* d_rn, float* d_state, half* d_y) {
+        gdn_scan_chunkwise_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state, d_y, n_tok,
+                               n_heads, head_dim, state_size, n_groups, nullptr, /*chunk_size=*/64,
+                               /*grouped_layout=*/0, d_rn);
+    });
+    check_variant("reference", [&](int n_tok, const int* d_rn, float* d_state, half* d_y) {
+        gdn_scan_reference_f32(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state, d_y, n_tok,
+                               n_heads, head_dim, state_size, n_groups, nullptr, /*grouped_layout=*/0, d_rn);
+    });
+
+    cudaFree(d_real_n);
+    cudaFree(d_conv);
+    cudaFree(d_A);
+    cudaFree(d_dt);
+    cudaFree(d_alpha);
+    cudaFree(d_beta);
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
Closes the last open item from the #930/#932 HD=256 arc: the #847 graph-captured verify path now serves hd=256 GDN hybrids (Qwen3.5/3.6).

## What

Two things blocked capture for these models — a kernel gap and a gate:

1. **GDN scan was not device-length-aware** (`run_gdn` threw on captured verify chunks, the #858 fail-loud guard). `gdn_scan_fused_kernel` and `gdn_scan_reference_kernel` now take `d_real_n` and commit the recurrent state at the real last row — pad rows keep evolving the register/smem state only to define their causally-discarded y rows (identical contract to the Mamba2 scan). `gdn_scan_chunkwise_*` route padded chunks through one sequential fused call, since a host-side chunk loop cannot split a device-side length. `run_gdn` passes `state.d_chunk_len` into conv1d (which already supported `d_real_n`) and all five scan call sites. Unsupported HD/SS shapes throw loudly instead of corrupting state.
2. **`chunk_capture_supported()` required hd==128.** hd=256 is accepted behind `attention.fa2_hd256`: `d_kv_len` is a runtime kernel argument shared by every FA2 instance including the #930 hd=256 port, and the capture K/V scratch is hd-generic — no attention work was needed.

No config changes; everything rides the existing default-on `speculative.capture`.

## Validation (RTX 5090)

| Gate | Result |
|---|---|
| New GTest `GDNScanTest.PaddedChunkDeviceLength` | fused/chunkwise/reference vs unpadded run: y[0..real) and h_state **bit-equal** |
| Unit + full GPU suites | all green (0 failures) |
| Qwen3.6-27B-Text-NVFP4-MTP (GDN+MoE hd=256, deterministic) | 939-token echo **byte-identical** capture on/off; graphs cached (buckets 17/33/65, rec_slot keyed) |
| Qwen3.6-35B-A3B-NVFP4 echo workload | 243 → **276 tok/s (+13.6%)** with capture; coherent |
| Qwen3.6-27B echo | perf-neutral (high-accept workload, few verify steps) |
| Qwen3-Coder-30B FP4 (hd=128 non-hybrid regression) | capture path unchanged (rec_slot=-1), coherent |
| Q8 hero (dense hd=128) | tg 270.2 vs baseline band 268–278 |

Perf-baseline note: no intentional change to baseline models — dense hd=128 routing and eager paths are untouched; the change only activates on padded captured verify chunks.

Side observation (pre-existing, not addressed here): Qwen3.5-4B-mxfp4 degenerates ("!!!…") via imp-server on both /v1/completions and /v1/chat/completions while imp-cli is coherent — reproduced identically on the v0.17.3 release image, independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F