### PR TITLE
fix(vram): reserve MXFP4->FP16 decode fallback on GDN hybrids (#934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   gemma-class models.
 
 ### Fixed
+- **MXFP4-GDN hybrids no longer serve `!!!…` garbage when VRAM is tight
+  (#934).** On GDN hybrids the native MXFP4 GEMV is unavailable, so decode
+  requires the FP16 dequant cache (~4x the raw MXFP4 bytes) resident alongside
+  the weights — but the VRAM budget never charged for it. At the server's
+  default (large) `max_seq_len` the KV pool ate the headroom, the FP16 fallback
+  then failed to allocate, and decode ran against weights with no usable kernel
+  → uniform logits → token-0 (`!`) garbage. `compute_vram_budget` now reserves
+  the MXFP4→FP16 fallback up front (mirroring the SWA/SSM/NVFP4/Q4_K reserves)
+  so the KV pool sizes down to leave room, and the fallback path in
+  `pre_dequant_phase3_cutlass` now throws a legible out-of-VRAM error at load
+  instead of silently skipping the alloc and serving garbage. Verified on
+  Qwen3.5-4B-mxfp4 via imp-server at default context: coherent output restored.
 - **Deterministic cuBLAS GEMM now validates its algo choice (intermittent
   status-14 garbage on FP8-KV / head_dim=256 models).** `runtime.deterministic_gemm`
   (also force-enabled for FP8 KV on non-FA2 / head_dim!=128 models like

--- a/src/exec/pre_dequant_phase3_cutlass.cu
+++ b/src/exec/pre_dequant_phase3_cutlass.cu
@@ -24,6 +24,8 @@
 #include <cstdlib>
 #include <unordered_set>
 #include <cstring>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace imp {
@@ -500,18 +502,24 @@ if (mx_native > 0) {
         // old IMP_MXFP4_FP16_FALLBACK=1 semantics); the legacy =force escape
         // hatch is obsolete, so oversubscription is always refused here.
         if (oversubscribe) {
-            IMP_LOG_ERROR(
-                "MXFP4 FP16 fallback would oversubscribe VRAM "
-                "(need %.1f GiB + %.1f GiB runtime headroom, %.1f GiB free). "
-                "Model is too large for this GPU with the FP16 decode "
-                "fallback. Use a smaller quant or a smaller model.",
-                fp16_total / (1024.0 * 1024.0 * 1024.0),
-                kRuntimeHeadroom / (1024.0 * 1024.0 * 1024.0),
-                free_mem / (1024.0 * 1024.0 * 1024.0));
-            // Skip the alloc — wcache_->fp16 stays empty for these weights.
-            // Downstream code will detect the missing entries and bail
-            // with its own diagnostic instead of silently corrupting state.
-            fp16_total = 0;
+            // We are inside `if (!mxfp4_gemv_available)`: the native MXFP4
+            // GEMV is unavailable (GDN weights / forced / non-linear scales),
+            // so this FP16 fallback is the ONLY valid decode path for these
+            // weights. Skipping it does NOT degrade gracefully — decode then
+            // runs against weights with no usable kernel and emits uniform
+            // logits → token-0 ("!") garbage (#934). The earlier "downstream
+            // will bail" assumption was false. Fail loud at load instead: the
+            // VRAM budget reserves this fallback up front (vram_budget.cpp), so
+            // reaching here means the model genuinely does not fit — surface
+            // that instead of serving garbage.
+            throw std::runtime_error(
+                "MXFP4 FP16 decode fallback would oversubscribe VRAM (need " +
+                std::to_string(fp16_total / (1024 * 1024)) + " MiB + " +
+                std::to_string(kRuntimeHeadroom / (1024 * 1024)) + " MiB runtime headroom, " +
+                std::to_string(free_mem / (1024 * 1024)) +
+                " MiB free). This model needs the FP16 decode cache (native MXFP4 GEMV is "
+                "unavailable on its weights) and does not fit on this GPU at the requested "
+                "context length. Reduce --min-kv-tokens / max context, or use a smaller model.");
         }
     }
     if (fp16_total > 0) {

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -170,8 +170,49 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
         }
     }
 
+    // Mandatory MXFP4 → FP16 decode-fallback reserve. On GDN hybrids the
+    // native MXFP4 GEMV is disabled (cuBLAS status-14 cascade on the GDN
+    // projections — see pre_dequant_phase3_cutlass.cu and
+    // qwen35_27b_mxfp4_ima_2026_04_25.md), so decode REQUIRES the FP16
+    // dequant cache (~4× the raw MXFP4 bytes, resident alongside it). The
+    // StoragePlanner classifies these tensors at their MXFP4 wire size and
+    // never sees the fallback, so without charging it here the KV clamp ate
+    // the headroom (server default max_seq_len fills VRAM): the fallback
+    // then failed to allocate and decode ran against no valid weights →
+    // uniform logits → token-0 ("!") garbage (#934). Charge it as overhead
+    // so the KV pool sizes down to leave room, mirroring the SWA/SSM
+    // footprints above. Same failure class as the NVFP4 (#926) and Q4_K
+    // (#874) weight-cache reserves; MXFP4-GDN was simply missed.
+    size_t mxfp4_fp16_fallback_bytes = 0;
+    if (mcfg.ssm_inner_size > 0) {
+        auto count_mxfp4 = [&](const Tensor& w, QType qt) {
+            if (w.data && qt == QType::MXFP4)
+                mxfp4_fp16_fallback_bytes += static_cast<size_t>(w.shape[0]) * w.shape[1] * sizeof(half);
+        };
+        count_mxfp4(model.output_proj(), model.out_proj_.qtype);
+        for (int i = 0; i < mcfg.n_layers; i++) {
+            const auto& L = model.layer(i);
+            count_mxfp4(L.wq, L.wq.qtype);
+            count_mxfp4(L.wk, L.wk.qtype);
+            count_mxfp4(L.wv, L.wv.qtype);
+            count_mxfp4(L.wo, L.wo.qtype);
+            count_mxfp4(L.w_gate, L.w_gate.qtype);
+            count_mxfp4(L.w_up, L.w_up.qtype);
+            count_mxfp4(L.w_down, L.w_down.qtype);
+            count_mxfp4(L.w_gate_shared, L.w_gate_shared.qtype);
+            count_mxfp4(L.w_up_shared, L.w_up_shared.qtype);
+            count_mxfp4(L.w_down_shared, L.w_down_shared.qtype);
+            count_mxfp4(L.ssm_in, L.ssm_in.qtype);
+            count_mxfp4(L.ssm_out, L.ssm_out.qtype);
+        }
+        if (mxfp4_fp16_fallback_bytes > 0)
+            IMP_LOG_INFO("VRAM budget: MXFP4-GDN FP16 decode fallback reserve %.1f MiB (mandatory — "
+                         "native MXFP4 GEMV unavailable on GDN weights)",
+                         mxfp4_fp16_fallback_bytes / (1024.0 * 1024.0));
+    }
+
     size_t available = free_vram;
-    size_t overhead = budget.reserve_bytes + ssm_footprint;
+    size_t overhead = budget.reserve_bytes + ssm_footprint + mxfp4_fp16_fallback_bytes;
     available = (available > overhead) ? (available - overhead) : 0;
 
     // --- 4. Compute KV cache per-block cost ---


### PR DESCRIPTION
## What

Fixes #934 — `imp-server` served `!!!…` garbage for `Qwen3.5-4B-mxfp4` on `/v1/completions` and `/v1/chat/completions` (CLI was coherent on the same build).

## Root cause

On GDN hybrids the native MXFP4 GEMV is unavailable (cuBLAS status-14 cascade on the GDN projections), so decode **requires** the FP16 dequant cache (~4× the raw MXFP4 bytes) resident alongside the weights. The `StoragePlanner` classifies these tensors at their MXFP4 wire size and never sees the fallback, so `compute_vram_budget` never charged for it. At the server's default (large) `max_seq_len` the KV pool ate the headroom → the FP16 fallback failed to allocate → decode ran against weights with no usable kernel → uniform logits → token-0 (`!`) garbage.

The CLI was coherent because it runs at a smaller default context, leaving room for the fallback by luck.

## Fix

- **`vram_budget.cpp`**: charge the MXFP4→FP16 fallback as mandatory overhead (gated on `ssm_inner_size > 0` + `qtype == MXFP4`) so the KV pool sizes down to leave room — mirrors the existing SWA/SSM (#…) and NVFP4 (#926) / Q4_K (#874) weight-cache reserves; MXFP4-GDN was simply missed. No-op for every non-MXFP4-GDN model.
- **`pre_dequant_phase3_cutlass.cu`**: the oversubscribe branch inside `!mxfp4_gemv_available` now **throws a legible out-of-VRAM error at load** instead of silently zeroing `fp16_total` and skipping the alloc. The old "downstream will bail with its own diagnostic" assumption was false — downstream served garbage.

## Verification

- `make build` + `make verify-fast`: green.
- `imp-server --model Qwen3.5-4B-mxfp4.gguf` at **default context**: budget log now shows `MXFP4-GDN FP16 decode fallback reserve 7532.5 MiB`, KV sizes down to fit, the 8020 MiB FP16 cache allocates, and output is coherent (`Paris`; a full 64-token story) where before it was `!!!…` from token 0.

## Scope / out of scope

This resolves the token-0 `!` garbage (the core of #934). Two **pre-existing, orthogonal** issues remain on this specific model and are **not** addressed here:
- its chat template auto-detects `chatml` but the weights emit DeepSeek-style `<|User|>`/`<|Assistant|>` tokens, so answer text lands in `reasoning_content` and the model echoes a spurious `<|User|>` turn;
- the FP16 GDN GEMM hits cuBLAS status-14 during graph capture, so decode falls back to per-step (the #929 "abort rather than emit garbage" net — coherent, just ungraphed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)