### PR TITLE
fix(server): reconcile enable_thinking with rendered prompt; capture-safe narrow-N GEMM (#934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,25 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   gemma-class models.
 
 ### Fixed
+- **Qwen3.5-4B-mxfp4 (and any closed-block reasoning template) now returns its
+  answer in `content`, not `reasoning_content` (#934 follow-up).** The server
+  defaulted thinking ON whenever the chat template merely *mentioned*
+  `enable_thinking`, but Qwen3.5-4B's template defaults it to a pre-*closed*
+  empty block `<think>\n\n</think>\n\n` (the model answers directly). Starting
+  the reasoning splitter in REASONING then trapped the whole answer in
+  `reasoning_content` with empty user-visible `content` on every OpenAI /
+  Anthropic / Responses endpoint. `enable_thinking` is now reconciled against
+  what the template *actually* rendered into the prompt tail (open prefix →
+  thinking on; pre-closed block → off), via a pure, unit-tested helper. Genuine
+  reasoning models (open-`<think>` prefix, e.g. Qwen3-14B) are unaffected.
+- **Qwen3.5-4B-mxfp4 decode no longer aborts CUDA-graph capture with cuBLAS
+  status-14.** The GDN projection GEMM (FP16, N=32) was rejected by the
+  capture-safe sm_120 WMMA kernel's `N < BN` guard and fell through to
+  cuBLASLt, which fails under stream capture on sm_120 → the whole decode graph
+  fell back to per-step. The kernel already masks partial N/M tiles in both the
+  load (cp.async src-size=0 zero-fill) and the store (`g_col >= N`), so the
+  guard was needlessly conservative; narrow N is now accepted and capture
+  succeeds. Correctness pinned by a new N=32 test.
 - **MXFP4-GDN hybrids no longer serve `!!!…` garbage when VRAM is tight
   (#934).** On GDN hybrids the native MXFP4 GEMV is unavailable, so decode
   requires the FP16 dequant cache (~4x the raw MXFP4 bytes) resident alongside

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,6 +542,7 @@ if(IMP_BUILD_TESTS)
             tests/test_sse_stream_utils.cpp
             tests/test_tool_call.cpp
             tests/test_tool_stream_filter.cpp
+            tests/test_reasoning_reconcile.cpp
             tests/test_server_auth.cpp
             tests/test_server_args.cpp
             tests/test_base64.cpp)

--- a/src/compute/gemm_capture_fp16_sm120.cu
+++ b/src/compute/gemm_capture_fp16_sm120.cu
@@ -294,10 +294,13 @@ bool gemm_capture_fp16_sm120(const void* A, const void* B, void* D, int M, int N
                               float beta, cudaStream_t stream) {
     if (!capture_gemm_fp16_sm120_available()) return false;
     if (M <= 0 || N <= 0 || K <= 0) return false;
-    // K must be a multiple of BK=32 (cp.async chunks fill full tiles). N must be
-    // at least one BN-block. M is handled by either BM=64 or BM=128 variant.
+    // K must be a multiple of BK=32 (cp.async chunks fill full tiles). N and M
+    // partial tiles are handled by both the load (cp.async src-size=0 zero-fill
+    // for g_row/g_col past N/M) and the store (masked `g_col >= N`), so any
+    // positive N is safe — a narrow N < BN just wastes part of the BN=128 tile.
+    // Accepting it is what matters under capture: cuBLASLt would else fail with
+    // status 14 and abort the whole decode graph (#934, GDN N=32 projections).
     if (K % BK != 0) return false;
-    if (N < BN) return false;
 
     bool use_bm64 = should_use_bm64(M, N);
     int BM_v     = use_bm64 ? 64 : 128;

--- a/tests/test_gemm_capture_fp16_sm120.cu
+++ b/tests/test_gemm_capture_fp16_sm120.cu
@@ -113,6 +113,33 @@ TEST_F(GemmCaptureSm120, Correctness_128x128x32_alpha1_beta0) {
     EXPECT_LT(m, 5e-2) << "max abs diff " << m;
 }
 
+TEST_F(GemmCaptureSm120, Correctness_NarrowN_2048x32x2560) {
+    // The GDN-projection shape that used to be rejected (N=32 < BN=128) and fell
+    // through to cuBLASLt → status-14 under capture → whole decode graph aborted
+    // (#934 residual). The partial-N tile must be masked correctly.
+    constexpr int M = 2048, N = 32, K = 2560;
+    std::vector<float> A(M * K), B(N * K), D_ref(M * N, 0.0f);
+    std::mt19937 rng(4);
+    std::uniform_real_distribution<float> dist(-0.3f, 0.3f);
+    for (auto& v : A) v = dist(rng);
+    for (auto& v : B) v = dist(rng);
+
+    cpu_gemm_ref(A, B, D_ref, M, N, K, 1.0f, 0.0f);
+
+    DeviceFp16 dA(M * K), dB(N * K), dD(M * N);
+    upload_fp16(dA.data, A);
+    upload_fp16(dB.data, B);
+    cudaMemset(dD.data, 0, M * N * sizeof(__half));
+
+    ASSERT_TRUE(gemm_capture_fp16_sm120(dA.data, dB.data, dD.data, M, N, K, 1.0f, 0.0f, 0));
+    cudaDeviceSynchronize();
+
+    auto got = download_fp16(dD.data, M * N);
+    // K=2560, FP16 accumulation → looser tolerance (matches the VsCublas case).
+    double m = max_abs_diff(got, D_ref);
+    EXPECT_LT(m, 0.5) << "max abs diff " << m;
+}
+
 TEST_F(GemmCaptureSm120, Correctness_256x256x256_alpha_beta) {
     constexpr int M = 256, N = 256, K = 256;
     std::vector<float> A(M * K), B(N * K), D(M * N), D_ref(M * N);

--- a/tests/test_reasoning_reconcile.cpp
+++ b/tests/test_reasoning_reconcile.cpp
@@ -1,0 +1,58 @@
+// Unit tests for reconcile_thinking_with_prompt_tail (reasoning_split.h):
+// the rendered chat-prompt tail is ground truth for whether generation begins
+// inside an open <think> block. Regression cover for #934 — Qwen3.5-4B's
+// template mentions enable_thinking but defaults to a *closed* empty block, so
+// the heuristic's ON default must be overridden to OFF or the whole answer is
+// trapped in reasoning_content.
+
+#include <gtest/gtest.h>
+
+#include "reasoning_split.h"
+
+using imp::server::reconcile_thinking_with_prompt_tail;
+
+// current, explicit_set, tail_has_think, tail_has_close
+namespace {
+constexpr bool kNotExplicit = false;
+constexpr bool kExplicit = true;
+}  // namespace
+
+TEST(ThinkingReconcile, ClosedBlockDefaultsOff) {
+    // #934: heuristic defaulted ON, template rendered a pre-closed block.
+    EXPECT_FALSE(reconcile_thinking_with_prompt_tail(/*current=*/true, kNotExplicit,
+                                                     /*think=*/true, /*close=*/true));
+}
+
+TEST(ThinkingReconcile, OpenPrefixTurnsOn) {
+    // Qwen3.6-style open <think>\n prefix: model is mid-reasoning.
+    EXPECT_TRUE(reconcile_thinking_with_prompt_tail(/*current=*/false, kNotExplicit,
+                                                    /*think=*/true, /*close=*/false));
+}
+
+TEST(ThinkingReconcile, OpenPrefixWinsEvenWhenExplicit) {
+    // An open block is unambiguous ground truth regardless of the request flag.
+    EXPECT_TRUE(reconcile_thinking_with_prompt_tail(/*current=*/false, kExplicit,
+                                                    /*think=*/true, /*close=*/false));
+}
+
+TEST(ThinkingReconcile, NoThinkKeepsCurrent) {
+    // Templateless / force-append path: no <think> in the tail — leave the
+    // upstream decision (heuristic or explicit) untouched, both directions.
+    EXPECT_TRUE(reconcile_thinking_with_prompt_tail(/*current=*/true, kNotExplicit,
+                                                    /*think=*/false, /*close=*/false));
+    EXPECT_FALSE(reconcile_thinking_with_prompt_tail(/*current=*/false, kNotExplicit,
+                                                     /*think=*/false, /*close=*/false));
+}
+
+TEST(ThinkingReconcile, ExplicitRequestNotDowngradedOnClosedBlock) {
+    // A caller that explicitly asked for thinking keeps their choice; a
+    // closed-block template cannot honor it, but we do not silently flip it.
+    EXPECT_TRUE(reconcile_thinking_with_prompt_tail(/*current=*/true, kExplicit,
+                                                    /*think=*/true, /*close=*/true));
+}
+
+TEST(ThinkingReconcile, StrayCloseWithoutOpenKeepsCurrent) {
+    // </think> with no <think> in-window is not a closed block — keep current.
+    EXPECT_TRUE(reconcile_thinking_with_prompt_tail(/*current=*/true, kNotExplicit,
+                                                    /*think=*/false, /*close=*/true));
+}

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -10,6 +10,7 @@
 #include "tool_call.h"
 #include "anthropic.h"
 #include "stream_pipeline.h"
+#include "reasoning_split.h"
 
 #include "api/imp_internal.h"
 #include "vision/image_processor.h"
@@ -630,9 +631,28 @@ bool snapshot_state_and_tokenize_(
     // Window 16 (not 8) so both tags of the adjacent closed block fall inside
     // the same tail — otherwise "<think>" could be in-window while "</think>"
     // just falls off, mis-reading a closed block as an open prefix.
-    if (!ctx.snap.enable_thinking) {
-        if (prompt_tail_contains("<think>", 16) && !prompt_tail_contains("</think>", 16)) {
-            ctx.snap.enable_thinking = true;
+    // Reconcile enable_thinking with what the template actually rendered — the
+    // prompt tail is ground truth. An OPEN prefix (<think>, no </think>) is
+    // mid-reasoning and turns thinking ON; a pre-closed block (<think> AND
+    // </think>) means the template chose answer-directly and turns it OFF, even
+    // if the heuristic defaulted it ON (#934: Qwen3.5-4B mentions enable_thinking
+    // but defaults to a closed block — without this the whole answer is trapped
+    // in reasoning_content). Window 16 so both tags of the adjacent closed block
+    // fall in the same tail (a lone in-window "<think>" would else read as open).
+    {
+        const bool tail_has_think = prompt_tail_contains("<think>", 16);
+        const bool tail_has_close = prompt_tail_contains("</think>", 16);
+        const bool was_thinking = ctx.snap.enable_thinking;
+        ctx.snap.enable_thinking = imp::server::reconcile_thinking_with_prompt_tail(
+            ctx.snap.enable_thinking, ctx.params.enable_thinking_set, tail_has_think, tail_has_close);
+        // If the reconcile turned thinking OFF after the snapshot had removed the
+        // provisional <think> stop token (removed above while it was ON), restore
+        // it: a non-thinking think-model still needs the phantom-"<think>"-turn
+        // guard. (The upgrade direction keeps the prior behavior untouched.)
+        if (was_thinking && !ctx.snap.enable_thinking && ctx.snap.think_start_id >= 0) {
+            auto& ids = ctx.snap.stop_token_ids;
+            if (std::find(ids.begin(), ids.end(), ctx.snap.think_start_id) == ids.end())
+                ids.push_back(ctx.snap.think_start_id);
         }
     }
 

--- a/tools/imp-server/reasoning_split.h
+++ b/tools/imp-server/reasoning_split.h
@@ -30,6 +30,31 @@
 
 namespace imp::server {
 
+// Reconcile a heuristic "thinking is on" default against what the chat
+// template ACTUALLY rendered into the prompt tail. The render is ground truth
+// for whether the model's generation begins inside an open <think> block:
+//   open block   (<think> present, no matching </think>) -> thinking ON
+//   closed block (<think> AND </think> present)          -> thinking OFF
+//   no <think>   (neither)                               -> keep `current`
+// The closed-block downgrade is #934: templates such as Qwen3.5-4B default
+// enable_thinking to a pre-closed empty block `<think>\n\n</think>\n\n` (the
+// model answers directly), but the upstream heuristic only sees the template
+// *mention* thinking (its Jinja names `enable_thinking`) and turns it ON.
+// Starting the reasoning splitter in REASONING then traps the whole answer in
+// reasoning_content with empty user-visible content. The upgrade direction was
+// already handled inline; this makes the decision symmetric and testable. An
+// explicit caller `enable_thinking` request is left untouched (a closed-block
+// template cannot honor an explicit `true` anyway, and we do not silently flip
+// an explicit choice — that is the caller's to make).
+inline bool reconcile_thinking_with_prompt_tail(bool current, bool explicit_set,
+                                                bool tail_has_think, bool tail_has_close) {
+    if (tail_has_think && !tail_has_close)
+        return true;  // open prefix: model is mid-reasoning
+    if (tail_has_think && tail_has_close && !explicit_set)
+        return false;  // pre-closed block: model answers directly (#934)
+    return current;    // no <think> at all, or explicit request — leave as-is
+}
+
 enum class ThinkPhase { SCAN, REASONING, CONTENT };
 
 class StreamReasoningSplitter {


### PR DESCRIPTION
Fixes the two pre-existing residual issues on `Qwen3.5-4B-mxfp4` that surfaced once #935 restored coherent output (both were masked by the `!!!` garbage before). Follow-up to #935 / issue #934.

## 1. Reasoning channel mis-routing (answer trapped in `reasoning_content`)

**Symptom:** every OpenAI/Anthropic/Responses request returned `content: ""` with the whole answer in `reasoning_content` (`finish: stop`).

**Root cause:** the server's `thinking_default` turned thinking ON whenever the chat template merely *mentioned* `enable_thinking`. But this template defaults `enable_thinking` to a pre-**closed** empty block `<think>\n\n</think>\n\n` — the model answers directly, emitting plain content. The reasoning splitter still started in `REASONING` and, never seeing a `</think>` in the *generation* (it was in the prompt), classified the whole answer as reasoning. The existing tail-detection only ever *upgraded* OFF→ON; it never handled the closed-block downgrade.

**Fix:** the rendered prompt tail is ground truth. `enable_thinking` is reconciled against it — open `<think>` prefix → on, pre-closed block → off — through a pure, unit-tested helper `reconcile_thinking_with_prompt_tail` in `reasoning_split.h`. Applied once in the shared `snapshot_state_and_tokenize_`, so it covers all three endpoints. The provisional `<think>` stop token is restored on downgrade.

## 2. CUDA-graph capture aborts with cuBLAS status-14

**Symptom:** load log showed `cublasLtMatmul failed (status 14)` → `aborting capture and falling back to per-step decode`.

**Root cause:** the GDN FP16 projection GEMM (`M=2048 K=2560 N=32`) was rejected by the capture-safe sm_120 WMMA kernel's `N < BN` (128) guard and fell through to cuBLASLt, which fails under stream capture on sm_120. That aborted the whole decode graph.

**Fix:** the kernel already masks partial N/M tiles in both the load (`cp.async` src-size=0 zero-fill for indices past N/M) and the store (`g_col >= N`), so the `N < BN` guard was needlessly conservative. Narrow N is now accepted; capture succeeds. This path is only reached under capture (cuBLASLt is used otherwise), so the normal path is unchanged. Correctness pinned by a new `N=32` test.

## Verification (Qwen3.5-4B-mxfp4 via imp-server)
- content populated on **both** stream and non-stream; `degen_suite` **0 FAIL** (was 9).
- **no** `status 14` / capture-abort in the load log; `capturing CUDA graph (step 1)` with no fallback.
- coherent output ("Gravity is a fundamental force…").
- **Regression:** Qwen3-14B-Q6_K (genuine open-`<think>` reasoning model) still splits `reasoning_content` correctly.
- New unit tests: `ThinkingReconcile.*` (6) and `GemmCaptureSm120.Correctness_NarrowN_2048x32x2560`. `make verify-fast` green.

Not addressed (out of scope): an explicit `enable_thinking: true` request cannot open a think block on a template that renders a closed one — a closed-block template physically can't honor it. The default path (the actual bug) is fixed; an explicit request is left as the caller's choice rather than silently flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)