### PR TITLE
fix(server): honor explicit enable_thinking=true on closed-block templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **An explicit `enable_thinking: true` request is now honored on templates
+  that default the switch to a closed block** (e.g. Qwen3.5-4B). The chat
+  render only ever stamped `enable_thinking=false` (suppression); an explicit
+  *true* was silently dropped, so the template kept rendering its pre-closed
+  `<think>\n\n</think>\n\n` block and the model answered directly instead of
+  reasoning. The server now stamps `enable_thinking=true` into the render for
+  an explicit request, so such templates open the think block; the reasoning
+  then separates into `reasoning_content` as expected. Default (no explicit
+  request) still leaves the variable undefined so each template author's own
+  default wins. The thinking-state decision is documented as one pipeline
+  (intent → render → rendered-prompt ground truth).
+
 ## [0.18.0] - 2026-07-09
 
 ### Changed

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -421,12 +421,12 @@ static std::vector<ChatMessage> maybe_suppress_default_system(const Tokenizer& t
 }
 
 std::vector<int32_t> ChatTemplate::apply(const Tokenizer& tok, const std::vector<ChatMessage>& messages,
-                                         bool suppress_thinking) const {
+                                         bool suppress_thinking, bool force_thinking) const {
     auto eff_msgs = maybe_suppress_default_system(tok, messages);
     // Prefer Jinja2 rendering when available (data-driven from GGUF).
     // Falls back to hardcoded families if Jinja rendering fails.
     if (use_jinja_ && jinja_tpl_) {
-        auto tokens = apply_jinja(tok, eff_msgs, true, suppress_thinking);
+        auto tokens = apply_jinja(tok, eff_msgs, true, suppress_thinking, force_thinking);
         if (!tokens.empty())
             return tokens;
         IMP_LOG_WARN("Jinja2 render produced empty result, falling back to hardcoded template");
@@ -747,7 +747,8 @@ void ChatTemplate::auto_detect_stop_tokens(const jinja::Context& ctx) const {
 }
 
 std::vector<int32_t> ChatTemplate::apply_jinja(const Tokenizer& tok, const std::vector<ChatMessage>& msgs,
-                                               bool add_generation_prompt, bool suppress_thinking) const {
+                                               bool add_generation_prompt, bool suppress_thinking,
+                                               bool force_thinking) const {
     if (!jinja_tpl_)
         return {};
 
@@ -765,8 +766,14 @@ std::vector<int32_t> ChatTemplate::apply_jinja(const Tokenizer& tok, const std::
     // verbose-think loop with no exit ("* Wait, I should...", "* Let's try
     // a simpler one:", repeating). Leaving the variable undefined for the
     // default case lets each template author's default win.
+    // force_thinking stamps enable_thinking=true so a template that defaults the
+    // variable to a pre-CLOSED block (Qwen3.5-4B) opens the block for an explicit
+    // caller request — without it, `enable_thinking:true` was silently a no-op on
+    // such templates. suppress wins if both are set.
     if (suppress_thinking) {
         ctx["enable_thinking"] = jinja::Value(false);
+    } else if (force_thinking) {
+        ctx["enable_thinking"] = jinja::Value(true);
     }
     ctx["bos_token"] = (bos_id_ >= 0) ? jinja::Value(tok.token_text(bos_id_)) : jinja::Value(std::string(""));
     ctx["eos_token"] = jinja::Value(tok.token_text(tok.eos_id()));
@@ -819,7 +826,8 @@ bool ChatTemplate::probe_render_mentions_think(const Tokenizer& tok) const {
 
 std::vector<int32_t> ChatTemplate::apply_jinja_with_tools(
     const Tokenizer& tok, const std::vector<ChatMessage>& msgs, const std::vector<ToolFunction>& tools,
-    const std::string& tool_choice, bool add_generation_prompt, bool suppress_thinking) const {
+    const std::string& tool_choice, bool add_generation_prompt, bool suppress_thinking,
+    bool force_thinking) const {
     if (!jinja_tpl_)
         return {};
 
@@ -854,7 +862,7 @@ std::vector<int32_t> ChatTemplate::apply_jinja_with_tools(
     // which trains the model to skip tool selection and answer in plain text).
     if (suppress_thinking) {
         ctx["enable_thinking"] = jinja::Value(false);
-    } else if (family_ == ChatTemplateFamily::GEMMA) {
+    } else if (force_thinking || family_ == ChatTemplateFamily::GEMMA) {
         ctx["enable_thinking"] = jinja::Value(true);
     }
     ctx["bos_token"] = (bos_id_ >= 0) ? jinja::Value(tok.token_text(bos_id_)) : jinja::Value(std::string(""));
@@ -884,12 +892,14 @@ std::vector<int32_t> ChatTemplate::apply_with_tools(const Tokenizer& tok,
                                                     const std::vector<ChatMessage>& messages,
                                                     const std::vector<ToolFunction>& tools,
                                                     const std::string& tool_choice,
-                                                    bool suppress_thinking) const {
+                                                    bool suppress_thinking,
+                                                    bool force_thinking) const {
     // Try Jinja2 tools-aware path. Returns empty if Jinja2 is unavailable or
     // rendering fails, signaling the caller to fall back to text-based tool injection.
     if (use_jinja_ && jinja_tpl_ && !tools.empty()) {
         auto eff_msgs = maybe_suppress_default_system(tok, messages);
-        auto tokens = apply_jinja_with_tools(tok, eff_msgs, tools, tool_choice, true, suppress_thinking);
+        auto tokens =
+            apply_jinja_with_tools(tok, eff_msgs, tools, tool_choice, true, suppress_thinking, force_thinking);
         if (!tokens.empty())
             return tokens;
         IMP_LOG_WARN("Jinja2 tools render failed, caller should inject text-based tool prompt");

--- a/src/model/chat_template.h
+++ b/src/model/chat_template.h
@@ -54,22 +54,30 @@ public:
     // parseable, the engine renders via Jinja2 instead of hardcoded families.
     bool init(ChatTemplateFamily family, const Tokenizer& tokenizer, const std::string& jinja_str = "");
 
-    // Build token ID vector: special tokens as raw IDs, text segments encoded
-    // suppress_thinking: inject /no_think for Qwen3 models to prevent thinking
+    // Build token ID vector: special tokens as raw IDs, text segments encoded.
+    // suppress_thinking: inject /no_think + stamp enable_thinking=false so the
+    //   template renders its answer-directly branch.
+    // force_thinking: stamp enable_thinking=true so a template that defaults the
+    //   variable to a *closed* block (e.g. Qwen3.5-4B: `<think>\n\n</think>\n\n`)
+    //   instead opens the block for an explicit caller request. suppress wins if
+    //   both are set. Default (neither) leaves the variable undefined so each
+    //   template author's own default applies (Qwen3 open vs Gemma-4 closed).
     std::vector<int32_t> apply(const Tokenizer& tok, const std::vector<ChatMessage>& messages,
-                               bool suppress_thinking = false) const;
+                               bool suppress_thinking = false, bool force_thinking = false) const;
 
     // Build token ID vector with tool definitions passed to Jinja2 context.
     // Falls back to standard apply() if Jinja2 doesn't handle tools.
     std::vector<int32_t> apply_with_tools(const Tokenizer& tok, const std::vector<ChatMessage>& messages,
                                           const std::vector<ToolFunction>& tools,
                                           const std::string& tool_choice = "auto",
-                                          bool suppress_thinking = false) const;
+                                          bool suppress_thinking = false,
+                                          bool force_thinking = false) const;
 
     // Build token ID vector with image tokens inserted before the first user message.
     // Produces: <boi> <img_soft_token>*n_image_tokens <eoi> \n {text}
     std::vector<int32_t> apply_with_image(const Tokenizer& tok, const std::vector<ChatMessage>& messages,
-                                          int n_image_tokens, bool suppress_thinking = false) const;
+                                          int n_image_tokens, bool suppress_thinking = false,
+                                          bool force_thinking = false) const;
 
     const std::vector<int32_t>& stop_token_ids() const { return stop_token_ids_; }
     ChatTemplateFamily family() const { return family_; }
@@ -153,14 +161,16 @@ private:
     // Jinja2-based apply: render template, split on control tokens, encode
     bool probe_render_mentions_think(const Tokenizer& tok) const;
     std::vector<int32_t> apply_jinja(const Tokenizer& tok, const std::vector<ChatMessage>& msgs,
-                                     bool add_generation_prompt = true, bool suppress_thinking = false) const;
+                                     bool add_generation_prompt = true, bool suppress_thinking = false,
+                                     bool force_thinking = false) const;
 
     // Jinja2-based apply with tool definitions in context
     std::vector<int32_t> apply_jinja_with_tools(const Tokenizer& tok, const std::vector<ChatMessage>& msgs,
                                                 const std::vector<ToolFunction>& tools,
                                                 const std::string& tool_choice,
                                                 bool add_generation_prompt = true,
-                                                bool suppress_thinking = false) const;
+                                                bool suppress_thinking = false,
+                                                bool force_thinking = false) const;
 
     // Shared helper: split rendered string on control tokens and encode
     std::vector<int32_t> tokenize_rendered(const Tokenizer& tok, const std::string& rendered) const;

--- a/src/model/chat_template_families.cpp
+++ b/src/model/chat_template_families.cpp
@@ -392,11 +392,12 @@ std::vector<int32_t> ChatTemplate::apply_harmony(const Tokenizer& tok,
 
 std::vector<int32_t> ChatTemplate::apply_with_image(const Tokenizer& tok,
                                                     const std::vector<ChatMessage>& messages,
-                                                    int n_image_tokens, bool suppress_thinking) const {
+                                                    int n_image_tokens, bool suppress_thinking,
+                                                    bool force_thinking) const {
     // Currently only Gemma family supports vision tokens.
     // For other families, fall back to text-only apply.
     if (family_ != ChatTemplateFamily::GEMMA || boi_id_ < 0 || eoi_id_ < 0 || img_soft_token_id_ < 0) {
-        return apply(tok, messages, suppress_thinking);
+        return apply(tok, messages, suppress_thinking, force_thinking);
     }
 
     // Gemma vision format:

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -535,12 +535,21 @@ bool snapshot_state_and_tokenize_(
         ctx.params.stop_sequences.push_back("\nHuman");
     }
 
+    // force_thinking stamps enable_thinking=true INTO the Jinja render, so a
+    // template that defaults the variable to a pre-closed block (Qwen3.5-4B)
+    // actually opens the think block when the caller EXPLICITLY asked for
+    // thinking — otherwise `enable_thinking:true` was a silent no-op on such
+    // templates. Only for an explicit request: the default case stays undefined
+    // so each template author's own default wins (Qwen3 open vs Gemma-4 closed).
+    const bool force_thinking = ctx.params.enable_thinking_set &&
+                                ctx.params.enable_thinking_requested && ctx.snap.enable_thinking;
+
     // Tokenize with chat template (with image tokens if vision is active)
     if (ctx.snap.have_template && ctx.snap.has_vision_request) {
-        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_image(*ctx.snap.tok, ctx.params.chat_msgs, 256, ctx.snap.suppress_thinking);
+        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_image(*ctx.snap.tok, ctx.params.chat_msgs, 256, ctx.snap.suppress_thinking, force_thinking);
     } else if (ctx.snap.have_template && ctx.snap.tools_via_jinja) {
         std::string tc_str = ctx.params.tool_choice.is_string() ? ctx.params.tool_choice.get<std::string>() : "auto";
-        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_tools(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.tool_defs, tc_str, ctx.snap.suppress_thinking);
+        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_tools(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.tool_defs, tc_str, ctx.snap.suppress_thinking, force_thinking);
         // If Jinja2 tools render failed, fall back to text-based tool prompt injection
         if (ctx.snap.tokens.empty()) {
             IMP_LOG_INFO("Jinja2 tools path failed, falling back to text-based tool prompt");
@@ -562,7 +571,7 @@ bool snapshot_state_and_tokenize_(
                     ctx.params.chat_msgs.insert(ctx.params.chat_msgs.begin(), {"system", sys});
                 }
             }
-            ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.suppress_thinking);
+            ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.suppress_thinking, force_thinking);
         }
     } else if (ctx.snap.have_template) {
         // No tools, or no Jinja2 support — inject text-based tool prompt if tools present
@@ -586,7 +595,7 @@ bool snapshot_state_and_tokenize_(
                 }
             }
         }
-        ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.suppress_thinking);
+        ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.suppress_thinking, force_thinking);
     } else {
         // Concatenate all message content as raw text
         std::string raw;
@@ -595,6 +604,16 @@ bool snapshot_state_and_tokenize_(
         ctx.snap.tokens = ctx.snap.tok->encode(raw);
     }
 
+    // Thinking-state pipeline (single source of truth = the rendered prompt):
+    //   1. INTENT  — `want_thinking` above: explicit request, else heuristic.
+    //   2. RENDER  — apply() stamps enable_thinking only when we force/suppress
+    //      (above); otherwise the template author's own default decides.
+    //   3. GROUND TRUTH — the block below reconciles enable_thinking against what
+    //      the render actually produced in the prompt tail (open <think> prefix →
+    //      thinking on; pre-closed block → off), then force-appends <think> for
+    //      templateless think-models. Stages 2–3 keep the splitter's start phase
+    //      consistent with the bytes the model will actually continue from.
+    //
     // Detect chat-template-injected <think> prefix (Qwen3 / Qwen3.5 / Qwen3.6
     // / DeepSeek-R1 add `<think>\n` via add_generation_prompt by default). When
     // present, the model output starts mid-thinking with no opener — only a


### PR DESCRIPTION
Tier-1 follow-up to #937. Makes an explicit `enable_thinking: true` actually work on chat templates whose default is a *closed* think block.

## Problem
The chat render (`apply_jinja`) only ever stamped `enable_thinking=false` (the suppression path); an explicit **true** was never stamped, so the Jinja variable stayed undefined. On templates that default the switch to a pre-closed block — Qwen3.5-4B renders `<|im_start|>assistant\n<think>\n\n</think>\n\n` — the model then answers directly even when the caller explicitly asked it to reason. `enable_thinking: true` was effectively a no-op there.

## Fix
- **chat_template**: thread an optional `force_thinking` (defaulted false, so every existing caller — engine, CLI, C-API, tests — is unchanged) through `apply` / `apply_jinja` / `apply_with_tools` / `apply_with_image`. When set, stamp `enable_thinking=true` into the Jinja context so the template opens the block. `suppress` still wins if both are set.
- **handlers_chat_core**: pass `force_thinking` **only for an explicit request**. The default case stays undefined so each template author's own default applies (Qwen3 open vs Gemma-4 closed — forcing `true` unconditionally previously drove Gemma-4 NVFP4 into a verbose-think loop, which is why the render deliberately leaves it undefined by default).
- Documents the thinking-state decision as one pipeline: **intent → render → rendered-prompt ground truth** (the #937 tail reconciliation is the final authority).

## Verification (Qwen3.5-4B-mxfp4 via imp-server)
| request | content | reasoning_content |
|---|---|---|
| default | answer ✓ | empty ✓ |
| `enable_thinking:true` | `6 times 7 is **42**` ✓ | **446 chars** ✓ (now reasons) |
| `enable_thinking:false` | answer ✓ | empty ✓ |

- `degen_suite` 0 FAIL. Qwen3-14B (genuine open-`<think>` reasoning model) still separates reasoning correctly. 53 chat-template + 6 reconcile unit tests pass; `make verify-fast` green.

## Deliberately not included (was Tier-1 candidate #2)
Tightening `mentions_thinking()`'s coarse `find("enable_thinking")` heuristic. It's a **no-op on real models** (every thinking template names the variable, hitting the string short-circuit before the render probe is ever consulted), it's already backstopped by the #937 rendered-tail reconciliation, and changing the short-circuit itself would flip the spontaneous-`<think>` models (Qwen3-14B) from a REASONING to a SCAN start — a behavior change on working models with no live bug to justify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)