### PR TITLE
audit: structural pass #6 — dead code, stale hd=256 comments/docs, process_diag default contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Changed
+- **Structural audit #6** (`docs/audit/structural_debt_2026_07_10.md`): swept the
+  ~40 PRs since audit #5. Confirmed findings filed as #941 (responses-stream
+  metrics/keepalive drift), #942 (pre-upload KV reserve computes 0 bytes for
+  4-bit KV dtypes), #943 (`workspace_estimate()` still reserves the S-matrix on
+  FA2-served configs). Cleanup landed alongside: dead `MemAccount::total_vram_`
+  and unused `KVCacheManager::swa_window()/swa_slack()` getters removed; stale
+  "fa2_hd256 default off" comments (#932 flipped it on) and hd=256 routing docs
+  (`attention-dispatch.md`, `architecture.md`) refreshed; `process_diag`
+  fallback defaults for `fa2_f16acc`/`fa2_pv_f16acc`/`fa2_hd256` aligned with
+  the config defaults per the header's own contract (the crosspath test now
+  pins the f32-score-chain explicitly instead of inheriting it).
+
 ### Fixed
 - **An explicit `enable_thinking: true` request is now honored on templates
   that default the switch to a closed block** (e.g. Qwen3.5-4B). The chat

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,11 +94,14 @@ else
     attention_prefill_dispatch(...);                        // per-dtype FMHA family
 ```
 
-The FP16-QK FA2 kernel is the primary hd=128 path at every length (at-or-above the
+The FP16-QK FA2 kernel is the primary path for hd=128 and — since #930/#932
+(`attention.fa2_hd256`, default on) — hd=256 at every length (at-or-above the
 materialized cuBLAS path: ~parity pp512, +24% pp1024, +52% pp2048) and needs no
 S-matrix. `attention_cublas_prefill` (cuBLAS QK^T → ~384 MiB S-matrix → causal
-softmax → cuBLAS PV) stays the fallback for the configs FA2 declines — `hd != 128`
-(e.g. Gemma hd=256) and `force_cublas_attn` (learned sinks / per-layer shapes).
+softmax → cuBLAS PV) stays the fallback for the configs FA2 declines — `hd ∉
+{128, 256}`, hd=256 with `fa2_hd256=false`, and `force_cublas_attn` (learned
+sinks / truly heterogeneous per-layer shapes; uniform GDN/Mamba2-hybrid shapes
+are FA2-servable since #932).
 Everything else falls through to `attention_prefill_dispatch`, which selects among
 the per-dtype FMHA kernels. Full coverage matrix: [`attention-dispatch.md`](attention-dispatch.md).
 
@@ -159,8 +162,8 @@ Per token:
 
 ## Known limitations
 
-- **The cuBLAS attention path allocates ~384 MiB of S-matrix workspace** (default `attention.attn_scores_mib`), which caps maximum context length for that legacy path; since #687 FA2 is the primary hd=128 prefill kernel (S-matrix skipped), so this only applies to the hd≠128 cuBLAS fallback (e.g. Gemma hd=256).
-- **`RuntimeConfig::current()` is a global singleton** rather than per-Engine, preventing true multi-engine use in a single process.
+- **The cuBLAS attention path allocates ~384 MiB of S-matrix workspace** (default `attention.attn_scores_mib`), which caps maximum context length for that legacy path; FA2 is the primary prefill kernel for hd=128 (#687) and hd=256 (#932), and on FA2-served configs the S-matrix is skipped entirely at init — so this only applies to the remaining cuBLAS fallback configs (heterogeneous shapes, learned sinks, opted-out hd=256).
+- **`process_diag` is a process-wide config snapshot.** `RuntimeConfig` itself is per-Engine since Phase 5 Track D, but the leaf-utility diagnostics cache (`src/runtime/process_diag.h`) is seeded once per process — two Engines with *different* diagnostics/attention-variant settings in one process would fight over it.
 
 ## Re-rendering the diagram
 

--- a/docs/attention-dispatch.md
+++ b/docs/attention-dispatch.md
@@ -8,34 +8,37 @@ If this doc and the code disagree, the code wins. Source of truth is `src/exec/e
 > on hd=128 models (Qwen3 dense/MoE — Q8_0, Q4_K_M, NVFP4) the legacy
 > materialized cuBLAS+softmax path is **0.0% of prefill time** at pp512–pp4096
 > — FP16-QK FA2 (#525) covers the short range, FA2/FP8-FMHA the long range.
-> Only hd≠128 models (gemma-3-12b, hd=256) still hit it: 3.6–6.9% of prefill
-> time = 92–99% of their attention time.
+> At the time of that measurement hd≠128 models (gemma-3-12b, hd=256) still hit
+> it (3.6–6.9% of prefill time); since #930/#932 hd=256 rides the FA2 port too
+> (`attention.fa2_hd256`, default on), so the cuBLAS path now serves only
+> heterogeneous-shape / sinks / opted-out configs.
 
-## Prefill — gate (post #525: FA2 f16-QK first, cuBLAS as hd≠128 fallback)
+## Prefill — gate (post #525/#932: FA2 f16-QK first at hd 128 and 256, cuBLAS as fallback)
 
-The prefill dispatch in `src/exec/executor_attention.cu` (~line 942) tries the
-FP16-QK FA2 drop-in before the materialized cuBLAS path:
+The prefill dispatch in `src/exec/executor_attention_prefill.cu` (~line 338) tries
+the FP16-QK FA2 drop-in before the materialized cuBLAS path:
 
 ```cpp
-const bool force_cublas_attn = per_layer_shapes || attn_sinks != nullptr;
+// Uniform per-layer shapes (GDN/Mamba2 hybrids: zeros on non-attention layers)
+// are FA2-servable since #932 — only truly heterogeneous shapes (gemma-4 dual
+// head_dim) and learned sinks (gpt-oss) force cuBLAS.
+const bool force_cublas_attn = (per_layer_shapes && !attn_shapes_uniform()) ||
+                               attn_sinks != nullptr;
 const bool s_matrix_fits     = attn_scores_buf_ != nullptr &&
                                n <= attn_scores_.shape[1];
 const bool prefer_fmha       = !force_cublas_attn &&
                                (n >= attention.fmha_prefill_threshold);
 
-if (s_matrix_fits && !prefer_fmha) {
-    if (!force_cublas_attn && try_fa2_fp16qk_prefill(...)) { /* FA2 f16-QK */ }
-    else attention_cublas_prefill(...);            // legacy materialized
-} else {
-    attention_prefill_dispatch(...);               // FMHA chain
-}
+if (!force_cublas_attn && try_fa2_fp16qk_prefill(...)) { /* FA2 f16-QK */ }
+else if (s_matrix_fits && !prefer_fmha) attention_cublas_prefill(...); // legacy materialized
+else attention_prefill_dispatch(...);                                  // FMHA chain
 ```
 
 | Condition | Path | Why |
 |---|---|---|
-| short seq (n < `fmha_prefill_threshold`, auto ≈ S-matrix cap + 1), **hd=128**, `fa2_fp16qk != "never"` | `fmha_sm120_fa2_kernel<…,FP16QK=1>` | FP16-QK FA2 drop-in (#525): cuBLAS-FP16-quality without the materialized S-matrix. |
-| short seq, **hd≠128** (gemma hd=256) or `attn_sinks`/per-layer shapes | `attention_cublas_prefill` | Legacy materialized path: cuBLAS QK^T → [nh, n, n] FP16 S-matrix (`attn_scores_mib`, default 384 MiB) → causal softmax → cuBLAS PV. The only remaining production user. |
-| long seq (n ≥ threshold) | FMHA chain below | Tiled O(n) memory; no materialized S. |
+| **hd=128, or hd=256 with `fa2_hd256` (default on)**, uniform shapes, no sinks, `fa2_fp16qk != "never"` | `fmha_sm120_fa2_kernel<…,FP16QK=1>` | FP16-QK FA2 (#525, hd=256 since #930/#932): cuBLAS-FP16-quality without the materialized S-matrix, at every length. |
+| short seq, FA2 declined (heterogeneous shapes, `attn_sinks`, hd ∉ {128, 256}, or `fa2_hd256=false`) | `attention_cublas_prefill` | Legacy materialized path: cuBLAS QK^T → [nh, n, n] FP16 S-matrix (`attn_scores_mib`, default 384 MiB; skipped entirely at init when FA2 serves all prefill, #932) → causal softmax → cuBLAS PV. |
+| long seq (n ≥ threshold), FA2 declined | FMHA chain below | Tiled O(n) memory; no materialized S. |
 | chunked continuation (`q_offset > 0`) with cumulative ctx < threshold | `attention_cublas_prefill` | FA2 f16-QK still declines `q_offset > 0` (conservative blanket gate post-#548); the FMHA chain needs ctx ≥ threshold. |
 
 ### FMHA chain (`src/compute/attention_dispatch.cu`, host model: `attention_dispatch_decision.h`)
@@ -43,9 +46,9 @@ if (s_matrix_fits && !prefer_fmha) {
 Tried in order, first hit wins:
 
 1. **`fmha_sm120_mxfp4_prefill`** — opt-in (`attention_mxfp4_available()`), hd%32==0
-2. **`fmha_sm120_fa2_prefill`** — register-resident FA2 (#477/#478, `fmha_fa2 == "on"` default), **hd==128 only**. f16-QK mode unless the fp8-QK pair is explicitly opted in (`fa2_fp16qk=never` AND `fp8_fmha=on`).
+2. **`fmha_sm120_fa2_prefill`** — register-resident FA2 (#477/#478, `fmha_fa2 == "on"` default), **hd 128 and 256** (hd=256 via `attention.fa2_hd256`, default on since #932; Bq=64/TWOSLOT instance). f16-QK mode unless the fp8-QK pair is explicitly opted in (`fa2_fp16qk=never` AND `fp8_fmha=on`).
 3. **`fmha_sm120_fp8_prefill`** — strictly opt-in (`attention.fp8_fmha == "on"`), hd%32==0. Raw e4m3 Q/K conversion compounds per-layer score error on real activations (#511): teacher-forced PPL gemma-3-12b 16.6→549 / Qwen3-8B 40.5→4506 when it served prefill. Off by default.
-4. **`fmha_sm120_prefill`** — FP16 WMMA, hd%16==0. Default server for hd≠128 long prefill (gemma-3 hd=256: PPL-identical to cuBLAS, 15.53 both at n=3441 incl. sliding window).
+4. **`fmha_sm120_prefill`** — FP16 WMMA, hd%16==0. Fallback for the configs FA2 declines: hd=256 with `fa2_hd256=false`, FA2-declined chunk continuations (`q_offset > 0`), other head dims (gemma-3 hd=256: PPL-identical to cuBLAS, 15.53 both at n=3441 incl. sliding window).
 5. **`flash_attention_blackwell`** — WMMA 128×64 tiles, last tier. Declines hd ∉ {64,96,128,256} and smem-over-limit configs (hd=256 needs ~176 KB at Br=64 vs the 99 KB sm_120 opt-in).
 6. **Chain exhausted → `std::runtime_error`** (#654). The old silent fallback to `flash_attention_prefill_tc` swallowed launch failures at hd=256 (smem over limit, unchecked `cudaGetLastError`) and produced garbage logits (teacher-forced PPL ~1e10); tc also lacks `q_offset`, so chunked continuations would mask wrongly even when it launches. Reaching this tier means a config override disabled the FP16 WMMA tier or an unsupported head_dim — both error loudly now.
 
@@ -82,4 +85,4 @@ cuBLAS path passes `cfg.attn_logit_softcap` through `attention_cublas_prefill`. 
 
 ## Known wounds
 
-- **~384 MiB cuBLAS S-matrix workspace** (default `attention.attn_scores_mib`, `executor_workspace_buffers.cu`). Caps maximum context length for the legacy hd≠128 cuBLAS fallback (FA2 is the primary hd=128 path since #687). Phase 5 Track E (the six-variant tiled streaming softmax) was **closed**, not deferred — code removed in PR #358. Reopens only if a regression specifically attributes to the workspace cap.
+- **~384 MiB cuBLAS S-matrix workspace** (default `attention.attn_scores_mib`, `executor_workspace_buffers.cu`). Caps maximum context length for the legacy cuBLAS fallback (FA2 is the primary path for hd 128 since #687 and hd 256 since #932; the S-matrix is skipped entirely at init on FA2-served configs). Phase 5 Track E (the six-variant tiled streaming softmax) was **closed**, not deferred — code removed in PR #358. Reopens only if a regression specifically attributes to the workspace cap.

--- a/docs/audit/structural_debt_2026_07_10.md
+++ b/docs/audit/structural_debt_2026_07_10.md
@@ -1,0 +1,111 @@
+# Structural audit — 2026-07-10
+
+Sixth structural pass (prior: `structural_debt_2026_07_07.md`, whose findings
+#888–#897 are all closed — the server-debt backlog from pass #5 was fully worked
+off). Since that pass: ~40 PRs (#898–#940), so this sweep focused on the surfaces
+they touched — the VRAM ordering/balloon rework (#923/#924/#926/#927/#935), the
+FA2 hd=256 arc (#930–#933), GDN verify-capture (#933), the server thinking-state
+pipeline (#937/#939), the C++23 migration (#916/#919), and the deterministic-GEMM
+validation (#929). Method per the codebase-audit skill: five fan-out sweeps
+(server, VRAM/init, attention/capture, config/docs, dead-code/comments), then
+every candidate re-verified against the code before filing.
+
+File-size gate: 0 violations, 34 warnings (27 allowlisted). New over the warn
+threshold since pass #5: `tools/imp-server/handlers_chat.cpp` (623 code-LOC,
+warn>600 — it was deliberately relocated under the gate in #901 and has crept
+back) and `src/exec/executor_forward_moe.cu` (521, warn>500). Neither is near
+hard-review; no action.
+
+## Confirmed findings → issues
+
+| # | Finding | Issue |
+|---|---------|-------|
+| 1 | `/v1/responses` **streaming** updates no metrics (`requests_total`, token counters, TTFT/duration histograms — only `requests_cancelled` at `handlers_responses.cpp:343`) and sends no ~10s idle keepalive (chat: `handlers_chat_stream.cpp:263-270`, messages: `handlers_messages.cpp:331`, responses: bare `continue;` at `:356-358`). Third + fourth concrete drift instance in the triplicated SSE loop family (#892 was the first two) — the inner state machines are shared (`stream_pipeline.h`/`reasoning_split.h`/`tool_stream_filter.h`) but the outer per-token loop is still hand-copied 3×, plus 5 hand-copies of the OpenAI-params→`imp::Request` field mapping (`handlers_chat.cpp:44-88`, `:301-342`, `handlers_chat_core.cpp:777-819`, `handlers_messages.cpp:767-801`, `handlers_responses.cpp:673-705`). Extraction of the shared loop is no longer speculative — the drift class keeps producing real bugs. | [#941](https://github.com/kekzl/imp/issues/941) |
+| 2 | Pre-upload KV reserve (`engine_weight_upload.cpp:125-136`) uses raw `dtype_size(kv_cache_dtype)`: `qtype_elem_bytes` has no NVFP4/MXFP4_KV case → **0 bytes** reserved (offload keeps too many experts on-device, KV pool collapses toward the #927 floor); INT4 → 2× over-reserve; scale bytes omitted. Same bug class `vram_budget.cpp:220-241` already fixed for itself. | [#942](https://github.com/kekzl/imp/issues/942) |
+| 3 | `workspace_estimate()` (`executor_workspace.cu:351-359`) still adds up to 256 MiB S-matrix for every non-MoE model, while the allocator skips it on FA2-served configs since #932 (`executor_workspace_buffers.cu:326-335`). The estimate feeds the pre-upload reserve and the #926 balloon floor, so the #932 reclaim never reaches the planners. | [#943](https://github.com/kekzl/imp/issues/943) |
+
+## Confirmed nits → fixed in the audit-cleanup PR
+
+- **Dead code:** `MemAccount::total_vram_` (write-only: `mem_account.h:103`,
+  `mem_account.cu:67`, zero reads across src/tests/tools); `KVCacheManager::swa_window()`
+  / `swa_slack()` public getters (added #924, zero callers — the backing members are
+  live internally; independently confirmed by two sweeps); redundant local forward
+  declaration of `run_chat_stream_` (`handlers_chat_stream.cpp:37`, already declared
+  in `handlers_internal.h:163`).
+- **Stale comments:** four sites still describe `attention.fa2_hd256` as
+  "default off"/"opt-in" after the #932 default-ON flip
+  (`attention_fmha_sm120.cu:1839`, `process_diag.h:68`,
+  `executor_attention_prefill.cu:48-49`, `executor_attention_internal.h:39`);
+  `gemm.cu:380` says FP8-KV "forces this path model-wide on head_dim!=128 models"
+  (post-#932 the gate is "not FA2-served"); `handlers_internal.h:128-132` documents
+  `g_in_anthropic_shim` as messages-only (now also set by `handle_responses` and
+  `handle_count_tokens`).
+- **Latent default mismatch:** `process_diag.cpp:36` seeds
+  `attention_fa2_hd256 = false` while the config default is `true` — inert today
+  (overwritten from cfg at `:93`) but a wrong fallback if ever read pre-seed.
+- **Docs drift (hd=256 arc):** `docs/attention-dispatch.md` still presents
+  cuBLAS/WMMA as the default hd=256 prefill path (lines 11-12, 20, 37, 46, 48 —
+  pre-#930/#932); `docs/architecture.md:100-101,162` still calls hd=256 a blanket
+  FA2-decline; `docs/architecture.md:163` claims `RuntimeConfig::current()` is a
+  global singleton — that accessor was retired (Phase 5 Track D; per-Engine
+  snapshot, `engine.h:287`). README.md was already correct, making the docs
+  internally inconsistent.
+
+## Noted, not actioned (low priority)
+
+- `conv_ch = ssm_inner_size + 2*ssm_group_count*ssm_state_size` is derived
+  identically at **5** sites (`engine_kv_cache_init.cpp:292`,
+  `engine_weight_upload.cpp:149`, `vram_budget.cpp:162`,
+  `executor_workspace_buffers.cu:739`, `gguf_tensor_assign.cpp:156`), and the full
+  per-batch SSM-state footprint formula is hand-copied at the first two + the
+  authoritative alloc. No drift bug found yet — a one-line `ModelConfig` accessor
+  becomes worth it the moment one appears (or fold into the #942 fix if it touches
+  the same lines).
+- `compute_native_cache_demand()` re-walks every layer 3× per init (resolver ×2 +
+  weight-upload balloon). Init-time only; not worth caching yet.
+- `/v1/completions` carries a fourth, bespoke think-strip implementation
+  (`handlers_chat.cpp:394-503`) — documented as deliberate (`:386-393`, no
+  `reasoning_content` field on that API). Consistency note only.
+
+## Checked and NOT flagged — do not re-chase
+
+- **Admission control (#888 fix) is complete**: `is_inference_endpoint`
+  (`main.cpp:26-29`) covers all five capacity-consuming routes incl.
+  `/v1/responses` and `/v1/embeddings`; count_tokens/tokenize/detokenize are
+  deliberately outside (no engine submission). No bypass.
+- **Thinking-state pipeline (#937 reconcile vs #939 force) is complementary, not
+  duplicated**: `force_thinking` acts at render time (explicit requests on
+  closed-default templates), `reconcile_thinking_with_prompt_tail` post-render
+  (prompt tail = ground truth, explicit requests left untouched). No dead
+  parameter, no contradictory branch.
+- **Old hd=256 WMMA path is LIVE**, not orphaned: `fmha_sm120_prefill` `case 256`
+  is the dispatch fallback for `fa2_hd256=false` and FA2-declined chunk
+  continuations (`q_offset>0`), with live tests (`FmhaSm120Test.HD256_LongSeq*`).
+- **FP8-KV forcing removal (#932) left no dead branch**: the forcing is still
+  legitimately live for `!fa2_serves_attention` (sinks/heterogeneous/flag-off),
+  hd=256 folded into `fa2_hd_ok` (`engine_init_resolver.cpp:237`).
+- **No stale "GDN can't capture" gate** after #933; the #858 fail-loud guard is
+  gone, `chunk_capture_supported` accepts hd=256 hybrids. No stale "N=32
+  unsupported under capture" comment after #937.
+- **Config surface is clean**: every key added/changed since 07-07 (`fa2_hd256`,
+  `fp8_tile`/`fp8_tile_gqa`, `swa_sizing`, all six `[rope]` keys, all three
+  `[vram]` keys) is parsed AND value-read on a live path; all 145 dotted keys are
+  present in `imp.conf.example` with defaults matching `config.h`; `docs/usage.md`
+  defaults correct. The rope override lives in `engine_init_resolver` → live on
+  the C-API path too.
+- **`MemAccount::device_peak_used` (pass-#5 #894) was actually removed** — does
+  not linger. `VramOwned` still does not exist (recurring hallucination).
+- **#926 balloon fields all live** (`mandatory_sf_bytes`/`mandatory_moe_bytes`
+  written in vram_budget, consumed in pre_dequant phase 3); ordering comments
+  (`executor_pre_dequant.cu:57`, `engine_weight_upload.cpp:277`) are consistent
+  with the new reserve-before/build-last order.
+- **Deterministic-GEMM (#929) left no dead old path**: the remaining `results[0]`
+  uses (`gemm.cu:428-429`, `:284`) are legitimate no-scratch fallback /
+  post-heuristic reselect, not the old blind path.
+- **No debug code left enabled** in the touched set (every `fprintf`/printf is
+  flag-gated); **no C++23 half-migrations**; **no stale TODOs** referencing closed
+  issues; **no duplicated new helpers** (`align_up` etc. single-sourced).
+- **SWA sizing (#924)**: `layer_swa_window()` is the single centralized window
+  predicate shared by budget/write/attention paths; no duplicated group logic.
+- `workspace_estimate()` itself is single-sourced (3 call sites, no
+  reimplementation) — the S-matrix gate (#943) is its only staleness.

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -1836,7 +1836,7 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
     if (seq_q == 0 || seq_kv == 0)
         return false;
     // HD=128 is the tuned mainline. HD=256 (Qwen3.6 hybrids, gemma-class) is a
-    // stage-1 port behind attention.fa2_hd256 (default off): fp16-qk only,
+    // stage-1 port behind attention.fa2_hd256 (default ON since #932): fp16-qk only,
     // fixed Bq=64/Bkv=64/TWOSLOT (double-buffer at HD=256 needs 135 KB smem >
     // the 99 KB opt-in; TWOSLOT fits at 67.6 KB). Register pressure doubles
     // with HD (a_frag + O accumulator scale linearly), so the HD=256 instances

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -378,8 +378,9 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
         // those in its warmup, but deterministic mode skips timing. Blindly
         // trusting results[0] here is what let an unvalidated algo reach the
         // real matmul and corrupt the forward pass (FP8-KV forces this path
-        // model-wide on head_dim!=128 models; the failure surfaced as silent
-        // repeated-token garbage on Qwen3.6-35B FFN GEMMs). Warmup-probe the
+        // model-wide on models FA2 doesn't serve — pre-#932 that included all
+        // hd=256 models; the failure surfaced as silent repeated-token garbage
+        // on Qwen3.6-35B FFN GEMMs). Warmup-probe the
         // candidates in heuristic order and pick the FIRST that survives —
         // that order is stable across runs, so determinism is preserved.
         int pick = 0;

--- a/src/exec/executor_attention_internal.h
+++ b/src/exec/executor_attention_internal.h
@@ -36,8 +36,8 @@ static bool try_fa2_fp16qk_prefill(const RuntimeConfig& rcfg, const Tensor& q, c
                                    cudaStream_t stream, const int* d_kv_len = nullptr) {
     if (rcfg.attention.fa2_fp16qk == "never")
         return false;
-    // hd=256: stage-1 FA2 port, opt-in (attention.fa2_hd256). Other head
-    // dims decline as before; the kernel wrapper re-checks the same gate.
+    // hd=256: stage-1 FA2 port (attention.fa2_hd256, default on since #932).
+    // Other head dims decline as before; the kernel wrapper re-checks the gate.
     if (hd != 128 && !(hd == 256 && rcfg.attention.fa2_hd256))
         return false;
     // Chunk CONTINUATION (q_offset > 0, queries attend gathered past KV) is

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -46,7 +46,7 @@
             // head_dim 256/512) and learned sinks (gpt-oss) require cuBLAS.
             const bool shapes_uniform = !per_layer_shapes || attn_shapes_uniform();
             // hd=256 rides the stage-1 FA2 port (attention.fa2_hd256, default
-            // off): same fp16-qk kernel family, Bq=64/TWOSLOT instance.
+            // on since #932): same fp16-qk kernel family, Bq=64/TWOSLOT instance.
             const bool fa2_hd_ok =
                 hd == 128 || (hd == 256 && runtime_config().attention.fa2_hd256);
             const bool chunk_fa2_serves = shapes_uniform && !attn_sinks && fa2_hd_ok &&
@@ -364,8 +364,9 @@
         // fast path does not depend on the attn_scores buffer being allocated or
         // large enough for n: a too-small buffer used to make s_matrix_fits false
         // and drop n≈512 chunks into the slow tiled dispatch (−93% pp512). cuBLAS
-        // stays the fallback for the configs f16-QK declines (hd != 128) and for
-        // force_cublas_attn (learned sinks / per-layer shapes).
+        // stays the fallback for the configs f16-QK declines (hd ∉ {128, 256},
+        // or hd=256 with fa2_hd256 off) and for force_cublas_attn (learned
+        // sinks / heterogeneous per-layer shapes).
         if (!force_cublas_attn &&
             try_fa2_fp16qk_prefill(runtime_config(), qv, kk, vv, ao, n, n, nh, nkv, hd, scale,
                                    layer_sliding_window, cfg.attn_logit_softcap, /*q_offset=*/0,

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -161,8 +161,6 @@ public:
     // SWA blocks are never hashed, pinned, persisted, or shared.
     void enable_swa_sizing(int window_tokens, int slack_tokens);
     bool swa_sizing_enabled() const { return swa_window_ > 0; }
-    int swa_window() const { return swa_window_; }
-    int swa_slack() const { return swa_slack_; }
     [[nodiscard]] bool swa_prepare(int seq_id, int from_tokens, int upto_tokens);
     [[nodiscard]] bool swa_prepare(int seq_id, int upto_tokens) {
         return swa_prepare(seq_id, upto_tokens, upto_tokens);

--- a/src/memory/mem_account.cu
+++ b/src/memory/mem_account.cu
@@ -63,8 +63,6 @@ void MemAccount::note(const char* pool, std::ptrdiff_t delta_bytes) {
 void MemAccount::checkpoint(const char* name) {
     size_t free_b = 0, total_b = 0;
     query_free_total(free_b, total_b);
-    if (total_b)
-        total_vram_ = total_b;
     sample_once();  // fold the checkpoint instant into the peak too
     if (!enabled_.load(std::memory_order_relaxed))
         return;

--- a/src/memory/mem_account.h
+++ b/src/memory/mem_account.h
@@ -100,7 +100,6 @@ private:
     std::vector<Pool> pools_;
     std::vector<Checkpoint> checkpoints_;
     std::string dump_path_;
-    size_t total_vram_ = 0;
 
     std::atomic<size_t> peak_used_{0};
     std::atomic<bool> sampler_run_{false};

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -31,9 +31,9 @@ struct ProcessDiag {
     bool attention_splitk_pipe = true;
     bool attention_fp8_tile = true;
     bool attention_fp8_tile_gqa = true;
-    bool attention_fa2_f16acc = false;
-    bool attention_fa2_pv_f16acc = false;
-    bool attention_fa2_hd256 = false;
+    bool attention_fa2_f16acc = true;     // matches the config.h default
+    bool attention_fa2_pv_f16acc = true;  // matches the config.h default
+    bool attention_fa2_hd256 = true;  // matches the config.h default (on since #932)
     bool attention_fp8_qk_scaled = false;
     bool force_splitk_fallback = false;  // test hook
     std::string attention_mxfp4_mode = "auto";

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -65,7 +65,7 @@ bool process_diag_fa2_pv_f16acc();  // f16-accumulate the PV MMA too (#667 follo
 // test hooks (mirror process_diag_set_cublas_fp16_acc)
 void process_diag_set_fa2_f16acc(bool v);
 void process_diag_set_fa2_pv_f16acc(bool v);
-bool process_diag_fa2_hd256();  // stage-1 HD=256 FA2 port (attention.fa2_hd256, default off)
+bool process_diag_fa2_hd256();  // HD=256 FA2 port (attention.fa2_hd256, default on since #932)
 void process_diag_set_fa2_hd256(bool v);
 bool process_diag_fp8_qk_scaled();  // amax-scaled e4m3 fp8-QK (#680)
 void process_diag_set_fp8_qk_scaled(bool v);

--- a/tests/test_attention_crosspath.cu
+++ b/tests/test_attention_crosspath.cu
@@ -26,6 +26,7 @@
 #include "compute/attention_tc.h"
 #include "core/tensor.h"
 #include "refs/attention_crosspath_golden.h"
+#include "runtime/process_diag.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <algorithm>
@@ -140,8 +141,24 @@ ErrStats err_stats(const std::vector<float>& got, const std::vector<double>& ref
 
 class AttentionCrossPathTest : public ::testing::Test {
 protected:
-    void SetUp() override { cudaStreamCreate(&stream_); }
-    void TearDown() override { cudaStreamDestroy(stream_); }
+    void SetUp() override {
+        cudaStreamCreate(&stream_);
+        // The strictness model below assumes FA2-f16 runs the f32-score-chain
+        // variant. Pin it explicitly — the process_diag defaults follow the
+        // production config (f16acc on since #674), which only meets the wider
+        // f16-class envelope, not the 1e-2 pairwise assert.
+        saved_f16acc_ = imp::process_diag_fa2_f16acc();
+        saved_pv_f16acc_ = imp::process_diag_fa2_pv_f16acc();
+        imp::process_diag_set_fa2_f16acc(false);
+        imp::process_diag_set_fa2_pv_f16acc(false);
+    }
+    void TearDown() override {
+        imp::process_diag_set_fa2_f16acc(saved_f16acc_);
+        imp::process_diag_set_fa2_pv_f16acc(saved_pv_f16acc_);
+        cudaStreamDestroy(stream_);
+    }
+    bool saved_f16acc_ = false;
+    bool saved_pv_f16acc_ = false;
 
     // Strictness model (see tests/refs/README.md):
     // the f32-score-chain paths (cuBLAS FP32-S, FA2-f16) and — since the

--- a/tools/imp-server/handlers_chat_stream.cpp
+++ b/tools/imp-server/handlers_chat_stream.cpp
@@ -34,9 +34,7 @@
 // must outlive the SSE response (httplib invokes the chunked provider after
 // this function returns; ctx is a stack-local in handle_chat_completions
 // which keeps the request frame alive until the response is fully sent).
-bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
-                             const std::shared_ptr<ServerRequest>& server_req);
-
+// run_chat_stream_ itself is declared in handlers_internal.h.
 void stream_chat_response_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx,
                                   const std::shared_ptr<ServerRequest>& server_req) {
     // SSE streaming response

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -125,10 +125,10 @@ inline int cache_creation_tokens_(const std::shared_ptr<imp::Request>& req, int 
     return creation > 0 ? creation : 0;
 }
 
-// Set true on the calling thread when handle_messages is delegating to
-// handle_chat_completions via a shim — suppresses inner request-log entries
-// so the Anthropic call only logs once at the outer handler. Defined in
-// handlers_chat_core.cpp.
+// Set true on the calling thread when a shim handler (handle_messages,
+// handle_responses, handle_count_tokens) is delegating to
+// handle_chat_completions — suppresses inner request-log entries so the
+// call only logs once at the outer handler. Defined in handlers_chat_core.cpp.
 extern thread_local bool g_in_anthropic_shim;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sixth structural audit (report in `docs/audit/structural_debt_2026_07_10.md`), covering the ~40 PRs since audit #5 (#898–#940). All pass-#5 findings (#888–#897) were verified closed. Behavior-touching findings from this pass are filed as issues — #941 (responses-stream metrics/keepalive drift), #942 (pre-upload KV reserve computes 0 bytes for NVFP4/MXFP4_KV cache dtypes), #943 (`workspace_estimate()` still reserves the S-matrix on FA2-served configs) — this PR batches the behavior-neutral cleanup:

- **Dead code**: `MemAccount::total_vram_` (write-only), `KVCacheManager::swa_window()`/`swa_slack()` getters (zero callers across src/tests/tools, confirmed by two independent sweeps), redundant local forward decl of `run_chat_stream_`.
- **Stale comments** (post-#932): five sites still called `attention.fa2_hd256` "default off"/"opt-in"; the gemm.cu deterministic-path note still framed FP8-KV forcing as "head_dim!=128 model-wide"; `g_in_anthropic_shim` was documented as messages-only.
- **process_diag default contract**: the header states "Default values match the RuntimeConfig defaults", but `fa2_f16acc`/`fa2_pv_f16acc` (config-true since #674) and `fa2_hd256` (config-true since #932) were seeded `false`. Aligned. The crosspath suite relied on those wrong defaults to select the f32-score-chain — it now pins the flags explicitly in SetUp/TearDown (which it should have done regardless).
- **Docs**: `attention-dispatch.md` gate/table/FMHA-chain rewritten for post-#932 hd=256 FA2 routing; `architecture.md` hd=256 fallback claims refreshed; retired `RuntimeConfig::current()` singleton limitation replaced with the actual process-wide `process_diag` caveat.

Config surface came back clean (all keys since 07-07 live + `imp.conf.example` in sync); file-size gate 0 violations. Full checked-and-NOT-flagged list is in the report.

## Test plan

- [x] Docker `make build`
- [x] `make test-unit` — 709/709
- [x] Targeted GPU battery (`AttentionCrossPathTest` + `FmhaFA2*` + `FmhaFP8Test` + `FmhaSm120Test`): 113 pass, 1 pre-existing deliberate skip (`FmhaFP8Test.HD64`). The crosspath suite initially went red on the default flip — root cause was the implicit f32-chain inheritance, fixed by pinning in the fixture.
- [x] `make verify-fast` OK (perf/smoke stages skip without mounted models; no hot-path change in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F