### PR TITLE
fix(server,vram): responses-stream metrics+keepalive; packing-aware KV reserve; S-matrix estimate gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **Streaming `/v1/responses` requests now update server metrics and send SSE
+  keepalives** (#941). The responses token loop never touched `requests_total`,
+  the token counters, or the TTFT/duration/inter-token histograms (only
+  `requests_cancelled`), and emitted nothing during long prefills — reverse
+  proxies could kill the idle stream. Both blocks now match the chat/messages
+  streams.
+- **The pre-upload KV reserve computed 0 bytes for NVFP4/MXFP4_KV cache
+  dtypes** (#942): it multiplied by raw `dtype_size()`, which has no case for
+  the packed 4-bit KV dtypes (and counts INT4 at twice its packed size, with
+  no scale overhead anywhere). The packing- and scale-aware per-block
+  calculation is now shared (`kv_block_bytes_per_layer`) between the VRAM
+  budget planner, the expert-offload reserve, and the KV init log.
+- **`workspace_estimate()` no longer charges the 256 MiB cuBLAS S-matrix on
+  FA2-served configs** (#943): the allocator skips that buffer since #932, but
+  the estimate still reserved it, holding phantom headroom out of the
+  cache/KV planners during weight upload. The gate (`fa2_serves_all_prefill`)
+  is now a shared predicate so the two sites cannot drift.
+
 ### Changed
 - **Structural audit #6** (`docs/audit/structural_debt_2026_07_10.md`): swept the
   ~40 PRs since audit #5. Confirmed findings filed as #941 (responses-stream

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -77,8 +77,13 @@ public:
     [[nodiscard]] bool allocate_workspaces(bool experts_on_host = false);
 
     // Estimated GPU memory needed by allocate_workspaces().
-    // Used by Engine to compute the expert upload reserve.
-    size_t workspace_estimate() const { return ws_.workspace_estimate(); }
+    // Used by Engine to compute the expert upload reserve. The S-matrix term
+    // is included only when the allocator would actually build one (#943) —
+    // on FA2-served configs it is skipped there, so charging it here would
+    // hold up to 256 MiB of phantom headroom out of the cache/KV planners.
+    size_t workspace_estimate() const {
+        return ws_.workspace_estimate(/*include_attn_scores=*/!fa2_serves_all_prefill());
+    }
 
     // Run the full forward pass and return the sampled token ID.
     int32_t forward(const InferenceState& state, cudaStream_t stream = nullptr);
@@ -256,6 +261,12 @@ public:
     // FA2/FMHA chunked-prefill family; only truly heterogeneous shapes
     // (Gemma-4 dual head_dim 256/512) require the rectangular cuBLAS path.
     bool attn_shapes_uniform() const;
+
+    // True when FP16-QK FA2 serves ALL prefill for this model (uniform
+    // shapes, no learned sinks, head_dim covered: 128 always, 256 behind
+    // attention.fa2_hd256, fa2_fp16qk != "never"). Shared by the S-matrix
+    // allocator skip and workspace_estimate() so the two cannot drift (#943).
+    bool fa2_serves_all_prefill() const;
 
     // Largest prefill chunk starting at `offset` that the chunked-attention
     // dispatch can serve without overflowing the cuBLAS S-matrix (constraint:

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -295,12 +295,12 @@ bool GraphExecutor::allocate_workspaces(bool experts_on_host) {
     // MemAccount per-pool attribution (vram_audit diagnostic). The estimate
     // covers persistent + shared workspace, the dominant executor buffers.
     MemAccount::instance().note("EXEC_WORKSPACES",
-                                static_cast<std::ptrdiff_t>(ws_.workspace_estimate()));
+                                static_cast<std::ptrdiff_t>(workspace_estimate()));
 
     return true;
 }
 
-size_t Workspace::workspace_estimate() const {
+size_t Workspace::workspace_estimate(bool include_attn_scores) const {
     if (!model_)
         return 0;
     const auto& cfg = model_->config();
@@ -314,9 +314,6 @@ size_t Workspace::workspace_estimate() const {
     // Shared: max of phases (already computed in compute_shared_sizes)
     size_t shared = std::max({attn_shared_size_, ffn_shared_size_, moe_shared_size_, ssm_shared_size_});
 
-    // S-matrix is NOT included here — it's optional (flash attention fallback works).
-    // This maximizes VRAM available for expert layers during weight upload.
-    // S-matrix is allocated opportunistically from remaining VRAM.
 
     // FP32 accumulator for post-norm models (Gemma-3): 1 × max_tokens × d_model × 4
     bool has_post_norms = (cfg.norm_placement == NormPlacement::POST_NORM);
@@ -348,12 +345,13 @@ size_t Workspace::workspace_estimate() const {
     auxiliary += static_cast<size_t>(*max_logit_tokens_) * nh_est * 32 * (2 + hd_est) *
                  sizeof(float);  // split-K
 
-    // S-matrix for cuBLAS attention fallback — only needed when CUTLASS FMHA
-    // is unavailable or unsupported (e.g., softcap, sliding window).
-    // Skip for MoE-heavy models where VRAM is tight: WMMA/CUTLASS FMHA
-    // doesn't need the S-matrix. This saves up to 256 MiB.
+    // S-matrix for the cuBLAS attention fallback. Skipped for MoE-heavy
+    // models (VRAM is tight; the FMHA family doesn't need it) and whenever
+    // the caller knows the allocator won't build one — FA2-served configs
+    // skip the buffer entirely (#932), so charging it here would hold up to
+    // 256 MiB of phantom headroom (#943).
     bool is_moe = (cfg.n_experts > 0 && cfg.n_experts_active > 0);
-    if (!is_moe) {
+    if (include_attn_scores && !is_moe) {
         auxiliary += std::min(static_cast<size_t>(nh_est) * *max_tokens_ * *max_tokens_ * sizeof(half),
                               static_cast<size_t>(256) << 20);
     }

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -314,23 +314,9 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
     // cuBLAS stays the reference for heterogeneous shapes (gemma-4 dual head_dim),
     // learned sinks (gpt-oss), hd=256 with fa2_hd256 off, and the explicit
     // fa2_fp16qk=never opt-out. See the run_attention dispatch (FA2 tried first).
-    int hd_for_attn = cfg.head_dim > 0 ? cfg.head_dim : (cfg.d_model / cfg.n_heads);
-    for (int x : cfg.head_dim_per_layer) {
-        if (x > 0) {
-            hd_for_attn = x;  // hybrids: first attention layer's head_dim
-            break;
-        }
-    }
-    const bool fa2_hd_ok = hd_for_attn == 128 ||
-                           (hd_for_attn == 256 && runtime_config().attention.fa2_hd256);
-    const bool fa2_serves_all_prefill = fa2_hd_ok &&
-                                        runtime_config().attention.fa2_fp16qk != "never" &&
-                                        attn_shapes_uniform() &&
-                                        !model_->profile().is_gpt_oss;
-    if (fa2_serves_all_prefill) {
-        IMP_LOG_INFO("cuBLAS attention S-matrix: skipped (FP16-QK FA2 serves all hd=%d prefill — "
-                     "no S-matrix needed)",
-                     hd_for_attn);
+    if (fa2_serves_all_prefill()) {
+        IMP_LOG_INFO("cuBLAS attention S-matrix: skipped (FP16-QK FA2 serves all prefill — "
+                     "no S-matrix needed)");
     } else if (!skip_batch_dequant) {
         int nh = cfg.n_heads;
         // 256 MiB: cuBLAS handles short sequences (up to ~1448 attn_seq for
@@ -1310,6 +1296,21 @@ bool GraphExecutor::attn_shapes_uniform() const {
         return true;
     };
     return uniform(cfg.head_dim_per_layer) && uniform(cfg.n_kv_heads_per_layer);
+}
+
+bool GraphExecutor::fa2_serves_all_prefill() const {
+    const auto& cfg = model_->config();
+    int hd_for_attn = cfg.head_dim > 0 ? cfg.head_dim : (cfg.d_model / cfg.n_heads);
+    for (int x : cfg.head_dim_per_layer) {
+        if (x > 0) {
+            hd_for_attn = x;  // hybrids: first attention layer's head_dim
+            break;
+        }
+    }
+    const bool fa2_hd_ok = hd_for_attn == 128 ||
+                           (hd_for_attn == 256 && runtime_config().attention.fa2_hd256);
+    return fa2_hd_ok && runtime_config().attention.fa2_fp16qk != "never" &&
+           attn_shapes_uniform() && !model_->profile().is_gpt_oss;
 }
 
 int GraphExecutor::max_safe_prefill_chunk(int offset, int desired, int kv_bs) const {

--- a/src/exec/workspace.h
+++ b/src/exec/workspace.h
@@ -85,7 +85,12 @@ public:
     void use_workspace(int slot);
     [[nodiscard]] bool resize_workspace(int new_max_tokens, cudaStream_t stream);
     void compute_shared_sizes(int max_tokens);
-    size_t workspace_estimate() const;
+    // include_attn_scores: charge the cuBLAS S-matrix term (capped 256 MiB,
+    // non-MoE only). Pass false when FA2 serves all prefill — the allocator
+    // skips the buffer there (#932), so the estimate must not hold phantom
+    // headroom for it (#943). GraphExecutor::workspace_estimate() derives
+    // the flag from fa2_serves_all_prefill().
+    size_t workspace_estimate(bool include_attn_scores) const;
 
     // Free the owned shared + persistent workspace buffers (called from
     // GraphExecutor::free_buffers). Mirrors the original free path exactly:

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -179,8 +179,8 @@ bool Engine::init_kv_cache() {
 
     {
         QType kv_dtype = config_.kv_cache_dtype;
-        size_t block_bytes = static_cast<size_t>(kv_bs) * mcfg.n_kv_heads * head_dim * dtype_size(kv_dtype);
-        size_t total_kv = static_cast<size_t>(n_kv_layers) * max_blocks * 2 * block_bytes;
+        size_t total_kv = static_cast<size_t>(n_kv_layers) * max_blocks *
+                          kv_block_bytes_per_layer(kv_dtype, kv_bs, mcfg.n_kv_heads, head_dim);
         IMP_LOG_INFO(
             "KV cache: %d blocks (%.0f tokens), %.2f MiB, dtype=%s "
             "(layers=%d/%d, kv_heads=%d, head_dim=%d, block_size=%d)",

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -122,7 +122,6 @@ bool Engine::init_weights() {
     size_t expert_reserve = executor_->workspace_estimate();
     {
         int head_dim_est = mcfg.head_dim > 0 ? mcfg.head_dim : (mcfg.d_model / mcfg.n_heads);
-        size_t elem_sz = dtype_size(config_.kv_cache_dtype);
         int est_bs = config_.kv_block_size > 0 ? config_.kv_block_size : kKVBlockSize;
         int blocks_per_seq = (config_.max_seq_len + est_bs - 1) / est_bs;
         int n_attn = 0;
@@ -131,9 +130,12 @@ bool Engine::init_weights() {
                 n_attn++;
         if (n_attn == 0)
             n_attn = mcfg.n_layers;
-        size_t kv_block_bytes = static_cast<size_t>(est_bs) * mcfg.n_kv_heads * head_dim_est * elem_sz;
-        size_t kv_est = static_cast<size_t>(blocks_per_seq * config_.max_batch_size) * 2 * n_attn *
-                        kv_block_bytes;
+        // Packing- and scale-aware K+V per-layer block bytes (#942): the raw
+        // dtype_size() this used to multiply by returns 0 for NVFP4/MXFP4_KV,
+        // which zeroed the KV headroom out of the expert-offload decision.
+        size_t kv_est = static_cast<size_t>(blocks_per_seq * config_.max_batch_size) * n_attn *
+                        kv_block_bytes_per_layer(config_.kv_cache_dtype, est_bs, mcfg.n_kv_heads,
+                                                 head_dim_est);
         {
             size_t total_vram = 0, f = 0;
             vram_budget_mem_get_info(&f, &total_vram);

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -217,27 +217,8 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
 
     // --- 4. Compute KV cache per-block cost ---
     int bs = config.kv_block_size > 0 ? config.kv_block_size : kKVBlockSize;
-    size_t single_block_bytes;
-    // Packed 4-bit KV dtypes: 2 elements per byte (FP4 nibbles or INT4 packed).
-    // NVFP4 was historically missing from this OR-chain — fell through to the
-    // dtype_size() fallback which returns 0 for QType::NVFP4, silently zeroing
-    // out NVFP4's KV-cache budget contribution. Pre-existing pre-MXFP4-KV; the
-    // Slice 2 spec reviewer flagged it during the MXFP4-KV scope review.
-    if (config.kv_cache_dtype == QType::INT4 || config.kv_cache_dtype == QType::NVFP4 ||
-        config.kv_cache_dtype == QType::MXFP4_KV) {
-        single_block_bytes = static_cast<size_t>(bs) * mcfg.n_kv_heads * head_dim / 2;
-    } else {
-        single_block_bytes = static_cast<size_t>(bs) * mcfg.n_kv_heads * head_dim *
-                             dtype_size(config.kv_cache_dtype);
-    }
-    // Per-token scale overhead folded into the per-layer block bytes.
-    size_t scale_per_block = 0;
-    if (config.kv_cache_dtype == QType::INT8 || config.kv_cache_dtype == QType::INT4) {
-        scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * sizeof(half);
-    } else if (config.kv_cache_dtype == QType::NVFP4 || config.kv_cache_dtype == QType::MXFP4_KV) {
-        scale_per_block = static_cast<size_t>(bs) * mcfg.n_kv_heads * (head_dim / 16);
-    }
-    const size_t per_layer_block_bytes = (single_block_bytes + scale_per_block) * 2;  // K+V
+    const size_t per_layer_block_bytes =
+        kv_block_bytes_per_layer(config.kv_cache_dtype, bs, mcfg.n_kv_heads, head_dim);
 
     // SWA-aware sizing (kv_cache.swa_sizing): sliding-window layers hold a
     // fixed live span (window + slack + burst/chunk peak) per sequence slot —
@@ -570,6 +551,29 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
         budget.reserve_bytes / (1024.0 * 1024.0), budget.nvfp4_second_pass ? "yes" : "no");
 
     return budget;
+}
+
+size_t kv_block_bytes_per_layer(QType kv_dtype, int block_size, int n_kv_heads, int head_dim) {
+    size_t single_block_bytes;
+    // Packed 4-bit KV dtypes: 2 elements per byte (FP4 nibbles or INT4 packed).
+    // NVFP4 was historically missing from this OR-chain — fell through to the
+    // dtype_size() fallback which returns 0 for QType::NVFP4, silently zeroing
+    // out NVFP4's KV-cache budget contribution. Pre-existing pre-MXFP4-KV; the
+    // Slice 2 spec reviewer flagged it during the MXFP4-KV scope review.
+    if (kv_dtype == QType::INT4 || kv_dtype == QType::NVFP4 || kv_dtype == QType::MXFP4_KV) {
+        single_block_bytes = static_cast<size_t>(block_size) * n_kv_heads * head_dim / 2;
+    } else {
+        single_block_bytes =
+            static_cast<size_t>(block_size) * n_kv_heads * head_dim * dtype_size(kv_dtype);
+    }
+    // Per-token scale overhead folded into the per-layer block bytes.
+    size_t scale_per_block = 0;
+    if (kv_dtype == QType::INT8 || kv_dtype == QType::INT4) {
+        scale_per_block = static_cast<size_t>(block_size) * n_kv_heads * sizeof(half);
+    } else if (kv_dtype == QType::NVFP4 || kv_dtype == QType::MXFP4_KV) {
+        scale_per_block = static_cast<size_t>(block_size) * n_kv_heads * (head_dim / 16);
+    }
+    return (single_block_bytes + scale_per_block) * 2;  // K+V
 }
 
 }  // namespace imp

--- a/src/runtime/vram_budget.h
+++ b/src/runtime/vram_budget.h
@@ -74,4 +74,12 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
                                size_t free_vram, int swa_live_tokens = 0, int n_swa_layers = 0,
                                size_t mandatory_cache_prealloc = 0);
 
+// Bytes of one paged KV block for a single layer, K+V combined (2x),
+// packing- and scale-aware. Single source for every KV-size estimate
+// (#942): raw dtype_size() returns 0 for NVFP4/MXFP4_KV (zeroing the
+// estimate), counts INT4 at 1 byte/elem (2x the packed size), and knows
+// nothing about the per-token (INT8/INT4) or per-16-element-group
+// (NVFP4/MXFP4_KV) scale overhead the cache actually stores.
+size_t kv_block_bytes_per_layer(QType kv_dtype, int block_size, int n_kv_heads, int head_dim);
+
 }  // namespace imp

--- a/tests/test_vram_budget_reserve.cpp
+++ b/tests/test_vram_budget_reserve.cpp
@@ -21,6 +21,7 @@
 #include "runtime/vram_budget.h"
 
 #include <algorithm>
+#include <cuda_fp16.h>
 
 #include "test_cuda_skip.h"
 
@@ -344,4 +345,33 @@ TEST(VramBudgetReserve, VramKnobsAreClamped) {
     EXPECT_EQ(a.reserve_bytes, b.reserve_bytes);
     EXPECT_EQ(a.kv_cache_bytes, b.kv_cache_bytes);
     EXPECT_EQ(a.kv_max_blocks, b.kv_max_blocks);
+}
+
+// kv_block_bytes_per_layer (#942): the single source for KV-size estimates.
+// The pre-upload expert-offload reserve used to multiply by raw dtype_size(),
+// which returns 0 for NVFP4/MXFP4_KV (zeroing the KV headroom) and 1 byte/elem
+// for INT4 (2x the packed size), and never counted scale overhead.
+TEST(VramBudgetReserve, KvBlockBytesPerLayerIsPackingAndScaleAware) {
+    constexpr int bs = 16, nkv = 8, hd = 128;
+    const size_t elems = static_cast<size_t>(bs) * nkv * hd;
+
+    // Plain dtypes: elems * elem_size * 2 (K+V), no scale overhead.
+    EXPECT_EQ(kv_block_bytes_per_layer(QType::F16, bs, nkv, hd), elems * 2 * 2);
+    EXPECT_EQ(kv_block_bytes_per_layer(QType::FP8_E4M3, bs, nkv, hd), elems * 1 * 2);
+
+    // INT8: 1 byte/elem + per-token half scale.
+    EXPECT_EQ(kv_block_bytes_per_layer(QType::INT8, bs, nkv, hd),
+              (elems + static_cast<size_t>(bs) * nkv * sizeof(half)) * 2);
+
+    // INT4: packed 2 elems/byte + per-token half scale — NOT dtype_size()'s
+    // 1 byte/elem.
+    EXPECT_EQ(kv_block_bytes_per_layer(QType::INT4, bs, nkv, hd),
+              (elems / 2 + static_cast<size_t>(bs) * nkv * sizeof(half)) * 2);
+
+    // NVFP4 / MXFP4_KV: packed + per-16-element-group scales; raw dtype_size()
+    // returns 0 here, which is exactly the #942 failure mode.
+    const size_t packed4 = (elems / 2 + static_cast<size_t>(bs) * nkv * (hd / 16)) * 2;
+    EXPECT_EQ(kv_block_bytes_per_layer(QType::NVFP4, bs, nkv, hd), packed4);
+    EXPECT_EQ(kv_block_bytes_per_layer(QType::MXFP4_KV, bs, nkv, hd), packed4);
+    EXPECT_GT(kv_block_bytes_per_layer(QType::NVFP4, bs, nkv, hd), 0u);
 }

--- a/tools/imp-server/handlers_responses.cpp
+++ b/tools/imp-server/handlers_responses.cpp
@@ -284,6 +284,7 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
     };
 
     int n_output_tokens = 0;
+    double ttft_ms = 0.0;  // Time to first token
     const char* finish = nullptr;
 
     std::string utf8_buf;      // confirmed-UTF8 content buffer
@@ -334,6 +335,7 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
     };
 
     auto request_start = std::chrono::steady_clock::now();
+    auto last_keepalive = request_start;
     for (;;) {
         if (finish)
             break;
@@ -354,8 +356,19 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
         }
 
         TokenEvent evt{};
-        if (!server_req->pop_token(evt))
+        if (!server_req->pop_token(evt)) {
+            // No token ready yet (long prefill / queued behind other work).
+            // Emit an SSE comment as keepalive every ~10s so reverse proxies
+            // and SDK idle-timeouts don't kill the connection — same cadence
+            // as the chat stream (#941).
+            auto now = std::chrono::steady_clock::now();
+            if (now - last_keepalive > std::chrono::seconds(10)) {
+                last_keepalive = now;
+                static constexpr char kKeepalive[] = ": keepalive\n\n";
+                sink.write(kKeepalive, sizeof(kKeepalive) - 1);
+            }
             continue;
+        }
 
         if (evt.token_id < 0) {
             finish = evt.finish_reason ? evt.finish_reason : "stop";
@@ -396,6 +409,10 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
         }
 
         n_output_tokens++;
+        if (n_output_tokens == 1) {
+            auto t_first = std::chrono::high_resolution_clock::now();
+            ttft_ms = std::chrono::duration<double, std::milli>(t_first - t_start).count();
+        }
         std::string piece = snap_tok->decode_token(token);
 
         if (harmony) {
@@ -587,16 +604,33 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
     response["output"] = std::move(final_output);
     if (incomplete)
         response["incomplete_details"] = {{"reason", "max_output_tokens"}};
-    {
-        int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
-        response["usage"] = {{"input_tokens", n_prompt_tokens},
-                             {"output_tokens", n_output_tokens},
-                             {"total_tokens", n_prompt_tokens + n_output_tokens},
-                             {"input_tokens_details", {{"cached_tokens", cached}}},
-                             {"output_tokens_details", {{"reasoning_tokens", 0}}}};
-    }
+    int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
+    response["usage"] = {{"input_tokens", n_prompt_tokens},
+                         {"output_tokens", n_output_tokens},
+                         {"total_tokens", n_prompt_tokens + n_output_tokens},
+                         {"input_tokens_details", {{"cached_tokens", cached}}},
+                         {"output_tokens_details", {{"reasoning_tokens", 0}}}};
     out.emit(incomplete ? "response.incomplete" : "response.completed",
              json{{"response", std::move(response)}});
+
+    // Server metrics — same accounting as the chat/messages streams (#941):
+    // without this every streaming /v1/responses request was invisible to
+    // /metrics (only requests_cancelled was ever touched).
+    {
+        auto t_end = std::chrono::high_resolution_clock::now();
+        double ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+        state.metrics.requests_total++;
+        state.metrics.tokens_prompt_total += n_prompt_tokens;
+        state.metrics.tokens_completion_total += n_output_tokens;
+        state.metrics.tokens_cached_total += cached;
+        state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
+        state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+        state.metrics.request_duration.observe(ms / 1000.0);
+        if (n_output_tokens > 0)
+            state.metrics.ttft.observe(ttft_ms / 1000.0);
+        if (n_output_tokens > 1)
+            state.metrics.inter_token.observe((ms - ttft_ms) / 1000.0 / (n_output_tokens - 1));
+    }
 
     // JSONL request log (outer Responses shapes).
     if (!ctx.log_skip) {


### PR DESCRIPTION
Closes #941
Closes #942
Closes #943

## Summary

Batches the three behavior findings from structural audit #6 (`docs/audit/structural_debt_2026_07_10.md`):

- **#941** — `run_responses_stream_` now updates `requests_total`, the prompt/completion/cached token counters, and the TTFT/duration/inter-token histograms at stream end (it only ever touched `requests_cancelled`, so every streaming `/v1/responses` request was invisible to `/metrics`), and emits the same ~10s `: keepalive` SSE comment as the chat stream while waiting on `pop_token` (long prefills could get the stream killed by reverse-proxy/SDK idle timeouts).
- **#942** — the pre-upload expert-offload KV reserve multiplied by raw `dtype_size()`, which returns **0** for NVFP4/MXFP4_KV (no case → zero KV headroom, KV pool collapses toward the #927 floor on 4-bit-KV MoE configs) and 1 byte/elem for INT4 (2× the packed size), with no scale overhead anywhere. The packing- and scale-aware per-block calculation is now a shared helper — `kv_block_bytes_per_layer()` in `vram_budget` — used by the budget planner, the weight-upload reserve, and the KV-init log, so the three sites cannot drift again.
- **#943** — `Workspace::workspace_estimate()` now takes `include_attn_scores`, derived in the `GraphExecutor` wrapper from a new shared `fa2_serves_all_prefill()` predicate (extracted verbatim from the #932 allocator skip). FA2-served configs no longer hold up to 256 MiB of phantom S-matrix headroom out of the cache/KV planners during weight upload.

## Test plan

- [x] Docker `make build`
- [x] `make test-unit` green, incl. new `VramBudgetReserve.KvBlockBytesPerLayerIsPackingAndScaleAware` (per-dtype expectations: F16/FP8 plain, INT8 +scale, INT4 packed+scale, NVFP4/MXFP4_KV packed+group-scale — the exact #942 failure mode)
- [x] `make test-server` PASS — all wire batteries green, incl. the `/v1/responses` streaming battery
- [x] Manual e2e (Qwen3-4B-Q8): one streaming `/v1/responses` request moves `imp_requests_total` 0→1, `imp_tokens_completion_total` 0→4, `imp_last_ttft_ms`=295, ttft/inter-token histogram counts 0→1
- [x] `make verify-fast` OK. Planner-only VRAM changes + server accounting; no hot-path kernel change, no perf impact expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F