### PR TITLE
feat(gemm): FP8 per-row-scale decode sidecar for GDN/SSM projections — Qwen3.6-35B decode +19%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+- **`gemm.fp8_ssm_proj` (default ON): FP8 E4M3 decode sidecar for the
+  native-precision GDN/Mamba in/out projections on NVFP4 hybrids — Qwen3.6-35B
+  decode +19%** (tg256 268.6 → 320.3 spec-off, 261 → 308 with default
+  speculation), PPL flat with per-row scales (one per-tensor scale over the
+  heterogeneous fused GDN input pack cost +4% PPL; per-row is 8.021 → 8.012).
+  These projections were the single largest decode slice (34.6% of GPU time as
+  FP16 GEMVs) because the producer recipes exclude them from NVFP4 and 4-bit
+  GEMV on their wide shapes *regresses* (measured 2026-05-30). FP8 halves the
+  bytes with byte-aligned loads instead. Prefill and M>1 verify chunks keep the
+  FP16 source; only the M=1 decode GEMV (`gemv_fp8_rowscale`) takes the sidecar.
+  Nemotron-3-Nano PPL flat (4.184 → 4.117); no-op on GGUF hybrids (see
+  `nvfp4_ssm_proj`) and on checkpoints whose SSM projections are already NVFP4
+  (Qwen3.6-27B).
+
 ### Fixed
 - **Streaming `/v1/responses` requests now update server metrics and send SSE
   keepalives** (#941). The responses token loop never touched `requests_total`,

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -80,10 +80,16 @@ Decode carries ±5–10 % day-to-day variance (issue #526); clocks logged health
 | Qwen3-14B | 14B | 159 |
 | Qwen3-30B-A3B-Modelopt | 30B (3B) | 305 |
 | Qwen3-Coder-30B-A3B | 30B (3B) | 338 |
-| Qwen3.6-35B-A3B | 35B (3B) | 257 |
+| Qwen3.6-35B-A3B | 35B (3B) | 257 → **320**¹ᵇ |
 | Gemma-4-26B-A4B | 26B (4B) | 266 |
 | Nemotron-3-Nano-30B | 30B (3B) | 128 |
 | gpt-oss-20b¹ | 21B (3.6B) | 325 |
+
+¹ᵇ 2026-07-10, commit `80864b06` + `gemm.fp8_ssm_proj` (default on since that
+PR): FP8 E4M3 per-row-scale decode sidecar for the BF16 GDN in/out projections
+— tg256 268.6 → **320.3** spec-off (+19.2%), 261 → 308 with default
+speculation; PPL flat (8.021 → 8.012 same-session teacher-forced). Same
+command pattern as the table; healthy-host clocks sampled during the run.
 
 ¹ gpt-oss (PRs #572/#574): SafeTensors MXFP4 source, experts converted to
 NVFP4 at load (bit-exact nibbles, power-of-two scales) and registered for the

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -314,6 +314,10 @@ nvfp4_ssm_proj       = false
 # Quantize recipe-excluded BF16 attention q/k/v/o on native-NVFP4 hybrids
 # (Nemotron-3-Nano: +3.8% decode, PPL-neutral). Opt-in.
 nvfp4_attn_proj      = false
+# FP8 E4M3 decode sidecar (per-row scales) for the native-precision GDN/Mamba
+# in/out projections on NVFP4 hybrids: halves the dominant FP16-GEMV decode
+# bytes; prefill keeps the FP16 source. Qwen3.6-35B decode +19%, PPL flat.
+fp8_ssm_proj         = true
 # Route native-NVFP4 MoE expert decode (M=1) through per-expert GEMV
 # kernels instead of grouped CUTLASS (+54-80% MoE decode). Default ON.
 nvfp4_moe_decode     = true

--- a/src/compute/gemm.h
+++ b/src/compute/gemm.h
@@ -41,6 +41,9 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y, cudaStream_t stream = nul
 // FP8 E4M3 GEMV: y = A_fp8 @ x_fp16 (with per-tensor scale)
 // A: [M, K] FP8_E4M3, x: [K] FP16, y: [M] FP16
 void gemv_fp8(const Tensor& A, const Tensor& x, Tensor& y, float scale, cudaStream_t stream = nullptr);
+// Per-row-scale variant (scale[row] = row_absmax/448, e.g. the fp8_ssm_proj sidecar).
+void gemv_fp8_rowscale(const Tensor& A, const Tensor& x, Tensor& y, const float* d_row_scales,
+                       cudaStream_t stream = nullptr);
 
 // Fused quantized GEMV: dequant + dot product in one pass (no intermediate FP16 buffer).
 // W: raw quantized bytes [M rows, K cols], x: [K] FP16, y: [M] FP16.

--- a/src/compute/gemm_gemv_dtype.cu
+++ b/src/compute/gemm_gemv_dtype.cu
@@ -352,10 +352,15 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y, cudaStream_t stream) {
 
 // ---------------------------------------------------------------------------
 // FP8 E4M3 GEMV kernel -- 16 FP8 values per load (16 bytes)
-// Each warp handles one row. Dequant on-the-fly with per-tensor scale.
+// Each warp handles one row. Dequant on-the-fly; ROWSCALE selects a per-row
+// (output-channel) scale lookup instead of the single per-tensor scale (the
+// fp8_ssm_proj sidecar quantizes heterogeneous packed rows, where one tensor
+// scale wastes e4m3 range).
 // ---------------------------------------------------------------------------
+template <bool ROWSCALE>
 __global__ void gemv_fp8_e4m3_kernel(const uint8_t* __restrict__ A, const half* __restrict__ x,
-                                     half* __restrict__ y, int M, int K, float scale) {
+                                     half* __restrict__ y, int M, int K, float scale,
+                                     const float* __restrict__ row_scales) {
     const int warps_per_block = blockDim.x / 32;
     const int warp_id = threadIdx.x / 32;
     const int lane = threadIdx.x % 32;
@@ -363,6 +368,8 @@ __global__ void gemv_fp8_e4m3_kernel(const uint8_t* __restrict__ A, const half* 
 
     if (row >= M)
         return;
+    if constexpr (ROWSCALE)
+        scale = row_scales[row];
 
     const uint8_t* A_row = A + (int64_t)row * K;
 
@@ -539,10 +546,22 @@ void gemv_fp8(const Tensor& A, const Tensor& x, Tensor& y, float scale, cudaStre
     const int M = (int)A.shape[0];
     const int K = (int)A.shape[1];
 
-    gemv_fp8_e4m3_kernel<<<gemv_blocks(M), kGemvThreads, 0, stream>>>(static_cast<const uint8_t*>(A.data),
-                                                                      static_cast<const half*>(x.data),
-                                                                      static_cast<half*>(y.data), M, K,
-                                                                      scale);
+    gemv_fp8_e4m3_kernel<false>
+        <<<gemv_blocks(M), kGemvThreads, 0, stream>>>(static_cast<const uint8_t*>(A.data),
+                                                      static_cast<const half*>(x.data),
+                                                      static_cast<half*>(y.data), M, K, scale, nullptr);
+}
+
+void gemv_fp8_rowscale(const Tensor& A, const Tensor& x, Tensor& y, const float* d_row_scales,
+                       cudaStream_t stream) {
+    const int M = (int)A.shape[0];
+    const int K = (int)A.shape[1];
+
+    gemv_fp8_e4m3_kernel<true>
+        <<<gemv_blocks(M), kGemvThreads, 0, stream>>>(static_cast<const uint8_t*>(A.data),
+                                                      static_cast<const half*>(x.data),
+                                                      static_cast<half*>(y.data), M, K, 0.0f,
+                                                      d_row_scales);
 }
 
 }  // namespace imp

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -187,11 +187,17 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
             }
             case StorageTier::FP8: {
                 auto fp8_it = wcache_.fp8.find(h.source_data);
-                if (fp8_it != wcache_.fp8.end()) {
+                // gemv_fp8 writes half — decline non-F16 outputs (falls back
+                // to the source-tier GEMV below, matching the FP16 case).
+                if (fp8_it != wcache_.fp8.end() && output.qtype == QType::F16) {
                     int64_t wshape[2] = {h.shape[0],
                         (h.primary_tier == StorageTier::CUTLASS_NVFP4) ? h.shape[1] * 2 : h.shape[1]};
                     Tensor fp8_w(fp8_it->second.weight.data, QType::FP8_E4M3, 2, wshape, true);
-                    gemv_fp8(fp8_w, input, output, fp8_it->second.host_scale, ctx.stream);
+                    if (fp8_it->second.d_row_scales)
+                        gemv_fp8_rowscale(fp8_w, input, output, fp8_it->second.d_row_scales,
+                                          ctx.stream);
+                    else
+                        gemv_fp8(fp8_w, input, output, fp8_it->second.host_scale, ctx.stream);
                     return;
                 }
                 break;
@@ -311,6 +317,20 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
             auto fp16_it = wcache_.fp16.find(h.source_data);
             if (fp16_it != wcache_.fp16.end()) {
                 gemm(input, fp16_it->second, output, 1.0f, ctx.beta, ctx.stream);
+                return;
+            }
+            // FP16-resident source with no cache entry — the source IS the
+            // FP16 weight (e.g. a weight whose only cache is the fp8_ssm_proj
+            // decode sidecar). Route through the uncached fallback exactly as
+            // the pre-sidecar Undefined tier did; falling further through
+            // would hand a null payload pointer to cuBLAS.
+            if (h.source_data &&
+                (h.source_qtype == QType::F16 || h.source_qtype == QType::BF16)) {
+                Tensor weight(const_cast<void*>(h.source_data), h.source_qtype, 2, h.shape, true);
+                weight.kind = h.kind;
+                weight.scales = h.source_scales;
+                weight.tensor_scale = h.source_tensor_scale;
+                gemm_dispatch_uncached_fallback(input, weight, output, ctx);
                 return;
             }
         }

--- a/src/exec/executor_pre_dequant.cu
+++ b/src/exec/executor_pre_dequant.cu
@@ -91,6 +91,10 @@ void QuantPipeline::build(const Model& model, const RuntimeConfig& rcfg, VRAMAll
     // --- Phase 2: FP8 cache for uncached weights (extracted) ---
     pre_dequant_phase2_fp8_cache_(cfg, budget, remaining_budget, stream);
 
+    // --- Phase 2b: FP8 decode sidecar for native-precision GDN/SSM
+    // projections (gemm.fp8_ssm_proj) ---
+    pre_dequant_phase2b_fp8_ssm_sidecar_(cfg, stream);
+
     // --- Phase 3: NVFP4 decode weight cache + 3b CUTLASS + 3c-native (extracted) ---
     pre_dequant_phase3_nvfp4_decode_(cfg, budget, remaining_budget, stream);
 

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1177,7 +1177,14 @@ void GraphExecutor::free_buffers() {
                                    reinterpret_cast<uintptr_t>(entry.weight.data) <
                                        reinterpret_cast<uintptr_t>(wcache_.fp8_overflow_data) +
                                            wcache_.fp8_overflow_data_size;
-                if (!in_migrated && !in_overflow)
+                bool in_ssm_sidecar =
+                    wcache_.fp8_ssm_sidecar_data &&
+                    reinterpret_cast<uintptr_t>(entry.weight.data) >=
+                        reinterpret_cast<uintptr_t>(wcache_.fp8_ssm_sidecar_data) &&
+                    reinterpret_cast<uintptr_t>(entry.weight.data) <
+                        reinterpret_cast<uintptr_t>(wcache_.fp8_ssm_sidecar_data) +
+                            wcache_.fp8_ssm_sidecar_data_size;
+                if (!in_migrated && !in_overflow && !in_ssm_sidecar)
                     cudaFree(entry.weight.data);
             }
             if (entry.d_scale) {
@@ -1213,6 +1220,15 @@ void GraphExecutor::free_buffers() {
             vram_free(vram_alloc_, wcache_.fp8_overflow_data);
             wcache_.fp8_overflow_data = nullptr;
             wcache_.fp8_overflow_data_size = 0;
+        }
+        if (wcache_.fp8_ssm_sidecar_data) {
+            vram_free(vram_alloc_, wcache_.fp8_ssm_sidecar_data);
+            wcache_.fp8_ssm_sidecar_data = nullptr;
+            wcache_.fp8_ssm_sidecar_data_size = 0;
+        }
+        if (wcache_.fp8_ssm_sidecar_row_scales) {
+            IMP_CUDA_CHECK_LOG(cudaFree(wcache_.fp8_ssm_sidecar_row_scales));
+            wcache_.fp8_ssm_sidecar_row_scales = nullptr;
         }
     }
 

--- a/src/exec/pre_dequant_phase2_fp8_cache.cu
+++ b/src/exec/pre_dequant_phase2_fp8_cache.cu
@@ -247,4 +247,107 @@ void QuantPipeline::pre_dequant_phase2_fp8_cache_(
     deduct_budget(remaining_budget, wcache_->fp8_bytes + phase2_fp16_bytes);
 }
 
+// Phase 2b: FP8 E4M3 decode sidecar for the native-precision GDN/Mamba
+// in/out projections (gemm.fp8_ssm_proj). On native-NVFP4 hybrids the
+// producer recipe leaves ssm_in/ssm_out BF16 → they decode as FP16 GEMVs,
+// the single largest decode slice (34.6% on Qwen3.6-35B, 2026-07-10 nsys).
+// NVFP4 on these wide GDN shapes REGRESSES (see config.h note); FP8 halves
+// the bytes with byte-aligned loads instead. The sidecar only serves the
+// M=1 decode GEMV — prefill and verify chunks keep the FP16 source, and
+// the recurrent-scan state stays FP16, so the quality exposure is one
+// 8-bit weight read per token, not error accumulation in the state.
+void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
+                                                         cudaStream_t stream) {
+    if (!runtime_config().gemm.fp8_ssm_proj)
+        return;
+
+    struct Entry {
+        const void* ptr;
+        size_t n_elems;
+        int rows;
+        int cols;
+    };
+    std::vector<Entry> entries;
+    size_t total_bytes = 0;
+    for (int i = 0; i < cfg.n_layers; i++) {
+        const auto& L = model_->layer(i);
+        // At decode the fused GDN input pack ([ssm_in | gate | alpha | beta]
+        // row-concat) replaces the ssm_in dispatch entirely (run_gdn n==1
+        // fused_input path), so the sidecar must target the pack where it
+        // exists; ssm_in then only serves prefill and stays FP16.
+        const Tensor* in_side = L.gdn_input_packed.data ? &L.gdn_input_packed : &L.ssm_in;
+        for (const Tensor* w : {in_side, &L.ssm_out}) {
+            if (!w->data || !w->on_device)
+                continue;
+            // Native-precision sources only: quantized sources go through the
+            // nvfp4_ssm_proj / dp4a paths, and anything already in a decode
+            // cache keeps its faster tier. F16 strictly — the calibration
+            // kernel reads __half, and post-upload residents are F16 (BF16
+            // checkpoints are converted at upload; a genuine BF16-resident
+            // would already break the FP16 GEMV this replaces).
+            if (w->qtype != QType::F16)
+                continue;
+            if (wcache_->fp8.count(w->data) || wcache_->nvfp4.count(w->data) ||
+                wcache_->cutlass_nvfp4.count(w->data))
+                continue;
+            size_t n = static_cast<size_t>(w->shape[0]) * w->shape[1];
+            if (n == 0 || (w->shape[1] % 16) != 0)
+                continue;
+            entries.push_back({w->data, n, static_cast<int>(w->shape[0]),
+                               static_cast<int>(w->shape[1])});
+            total_bytes += n;
+        }
+    }
+    if (entries.empty())
+        return;
+
+    uint8_t* d_bulk =
+        static_cast<uint8_t*>(vram_alloc(vram_alloc_, total_bytes, "fp8_ssm_sidecar"));
+    if (!d_bulk) {
+        cudaError_t e = cudaGetLastError();
+        IMP_LOG_WARN("fp8_ssm_proj: sidecar alloc failed (%.1f MiB): %s — decode keeps FP16",
+                     total_bytes / (1024.0 * 1024.0), cudaGetErrorString(e));
+        return;
+    }
+
+    // Per-ROW scales: one scale per output channel. A single per-tensor scale
+    // measurably hurts PPL here (+4% on Qwen3.6-35B) because the fused GDN
+    // input pack concatenates row blocks with very different magnitudes
+    // (conv | gate | alpha | beta) — one amax wastes e4m3 range on most rows.
+    size_t total_rows = 0;
+    for (const auto& e : entries)
+        total_rows += static_cast<size_t>(e.rows);
+    float* d_row_scales = nullptr;
+    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_row_scales, total_rows * sizeof(float)));
+    if (!d_row_scales) {
+        vram_free(vram_alloc_, d_bulk);
+        IMP_LOG_WARN("fp8_ssm_proj: row-scale alloc failed — decode keeps FP16");
+        return;
+    }
+
+    size_t offset = 0, row_offset = 0;
+    for (const auto& e : entries) {
+        quantize_fp8_rows_async(e.ptr, d_bulk + offset, e.rows, e.cols,
+                                d_row_scales + row_offset, stream);
+        int64_t fp8_shape[4] = {e.rows, e.cols, 0, 0};
+        Tensor fp8_t(d_bulk + offset, QType::FP8_E4M3, 2, fp8_shape, true);
+        FP8CacheEntry entry{};
+        entry.weight = fp8_t;
+        entry.d_row_scales = d_row_scales + row_offset;
+        wcache_->fp8[e.ptr] = entry;
+        offset += e.n_elems;
+        row_offset += static_cast<size_t>(e.rows);
+    }
+    IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+
+    wcache_->fp8_bytes += total_bytes;
+    wcache_->fp8_ssm_sidecar_data = d_bulk;
+    wcache_->fp8_ssm_sidecar_data_size = total_bytes;
+    wcache_->fp8_ssm_sidecar_row_scales = d_row_scales;
+
+    IMP_LOG_INFO("fp8_ssm_proj: FP8 decode sidecar for %zu GDN/SSM projections "
+                 "(%.1f MiB, %zu per-row scales; FP16 source retained for prefill)",
+                 entries.size(), total_bytes / (1024.0 * 1024.0), total_rows);
+}
+
 }  // namespace imp

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -38,6 +38,14 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
         if (!t.data)
             return kInvalidTensorID;
         StorageTier tier = infer_tier_from_wcache(*wcache_, t.data);
+        // FP8 decode SIDECAR on a native-precision weight (gemm.fp8_ssm_proj):
+        // the wcache fp8 entry must not become the primary tier — prefill and
+        // M>1 verify chunks stay on the resident FP16 source (quality), only
+        // the M=1 decode GEMV takes the FP8 copy. Demote BEFORE the payload
+        // borrow below, or the union would carry an fp8 payload into FP16 paths.
+        const bool fp8_decode_sidecar = tier == StorageTier::FP8 && t.qtype == QType::F16;
+        if (fp8_decode_sidecar)
+            tier = StorageTier::FP16;
         TensorID id = registry_->reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);
         auto& h = registry_->handle(id);
         h.primary_tier = tier;
@@ -64,6 +72,8 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
             h.decode_tier = StorageTier::FP8;
         } else if (tier == StorageTier::CUTLASS_NVFP4 && wcache_->nvfp4.count(t.data)) {
             h.decode_tier = StorageTier::NVFP4;
+        } else if (fp8_decode_sidecar) {
+            h.decode_tier = StorageTier::FP8;
         }
         return id;
     };

--- a/src/exec/quant_pipeline.h
+++ b/src/exec/quant_pipeline.h
@@ -102,6 +102,9 @@ private:
                                         size_t& remaining_budget, cudaStream_t stream);
     void pre_dequant_phase2_fp8_cache_(const ModelConfig& cfg, const VRAMBudget& budget,
                                        size_t& remaining_budget, cudaStream_t stream);
+    // FP8 E4M3 decode sidecar for native-precision GDN/SSM projections
+    // (gemm.fp8_ssm_proj) — lives in pre_dequant_phase2_fp8_cache.cu.
+    void pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg, cudaStream_t stream);
     void pre_dequant_phase3_nvfp4_decode_(const ModelConfig& cfg, const VRAMBudget& budget,
                                           size_t& remaining_budget, cudaStream_t stream);
     // Sub-phase helpers for pre_dequant_phase3_nvfp4_decode_. Each operates

--- a/src/exec/weight_caches.h
+++ b/src/exec/weight_caches.h
@@ -17,6 +17,9 @@ struct FP8CacheEntry {
     Tensor weight;     // [N, K] FP8_E4M3 on device
     float host_scale{};  // absmax / 448
     float* d_scale{};    // device-side scale (1 float)
+    // Per-row (output-channel) scales — set by the fp8_ssm_proj sidecar
+    // (points into fp8_ssm_sidecar_row_scales); null = per-tensor scale.
+    const float* d_row_scales{};
 };
 
 // ---------------------------------------------------------------------------
@@ -61,6 +64,12 @@ struct WeightCaches {
     int fp8_overflow_count = 0;
     void* fp8_overflow_data = nullptr;
     size_t fp8_overflow_data_size = 0;
+
+    // FP8 decode sidecar for GDN/SSM projections (gemm.fp8_ssm_proj); entries
+    // carry per-row scales (d_row_scales into the bulk below, d_scale = null).
+    void* fp8_ssm_sidecar_data = nullptr;
+    size_t fp8_ssm_sidecar_data_size = 0;
+    float* fp8_ssm_sidecar_row_scales = nullptr;
 
     // --- NVFP4 decode weight cache ---
     // Mode: 0=off, 1=additive, 2=only

--- a/src/quant/fp8_quant.cu
+++ b/src/quant/fp8_quant.cu
@@ -307,6 +307,59 @@ void calibrate_and_quantize_fp8_async(const void* input_fp16, void* output_fp8, 
                                                                    d_absmax, d_scale_out, n);
 }
 
+// ---- quantize_fp8_rows_async ----------------------------------------------
+// Per-ROW (per-output-channel) E4M3 quantization: one block per row reduces
+// the row absmax, derives scale = absmax/448, records it in d_row_scales[row]
+// and quantizes the row with it. Per-row scales avoid the range waste of one
+// per-tensor scale across heterogeneous row blocks (e.g. the fused GDN input
+// pack [conv | gate | alpha | beta]). Init-time only — the row is read twice
+// from L2, which is irrelevant there.
+
+__global__ void quantize_fp8_rows_kernel(const half* __restrict__ in, uint8_t* __restrict__ out,
+                                         int K, float* __restrict__ d_row_scales) {
+    const int row = blockIdx.x;
+    const half* r = in + static_cast<int64_t>(row) * K;
+    uint8_t* o = out + static_cast<int64_t>(row) * K;
+
+    float m = 0.0f;
+    for (int i = threadIdx.x; i < K; i += blockDim.x)
+        m = fmaxf(m, fabsf(__half2float(r[i])));
+    __shared__ float s_warp[32];
+    for (int off = 16; off; off >>= 1)
+        m = fmaxf(m, __shfl_down_sync(0xffffffffu, m, off));
+    if ((threadIdx.x & 31) == 0)
+        s_warp[threadIdx.x >> 5] = m;
+    __syncthreads();
+    const int n_warps = blockDim.x >> 5;
+    if (threadIdx.x < 32) {
+        m = (threadIdx.x < n_warps) ? s_warp[threadIdx.x] : 0.0f;
+        for (int off = 16; off; off >>= 1)
+            m = fmaxf(m, __shfl_down_sync(0xffffffffu, m, off));
+    }
+    __shared__ float s_scale;
+    if (threadIdx.x == 0) {
+        float sc = (m > 0.0f) ? m / kFP8E4M3Max : 1.0f;
+        s_scale = sc;
+        d_row_scales[row] = sc;
+    }
+    __syncthreads();
+
+    const float inv = 1.0f / s_scale;
+    for (int i = threadIdx.x; i < K; i += blockDim.x) {
+        __nv_fp8_e4m3 q(__half2float(r[i]) * inv);
+        o[i] = *reinterpret_cast<const uint8_t*>(&q);
+    }
+}
+
+void quantize_fp8_rows_async(const void* input_fp16, void* output_fp8, int rows, int K,
+                             float* d_row_scales, cudaStream_t stream) {
+    if (!input_fp16 || !output_fp8 || !d_row_scales || rows <= 0 || K <= 0)
+        return;
+    quantize_fp8_rows_kernel<<<rows, 256, 0, stream>>>(static_cast<const half*>(input_fp16),
+                                                       static_cast<uint8_t*>(output_fp8), K,
+                                                       d_row_scales);
+}
+
 // ---- quantize_fp16_to_fp8_e4m3 (Tensor API) ------------------------------
 
 void quantize_fp16_to_fp8_e4m3(const Tensor& input, Tensor& output, float* d_scale_out, cudaStream_t stream,

--- a/src/quant/fp8_quant.h
+++ b/src/quant/fp8_quant.h
@@ -22,6 +22,11 @@ float calibrate_fp8_scale(const Tensor& input, cudaStream_t stream = nullptr);
 void quantize_fp16_to_fp8_e4m3_scaled(const void* input_fp16, void* output_fp8, int n_elements, float scale,
                                       cudaStream_t stream = nullptr);
 
+// Per-row (output-channel) E4M3 quantize: writes scale[row] = row_absmax/448
+// to d_row_scales and the quantized rows to output_fp8. Async, init-time.
+void quantize_fp8_rows_async(const void* input_fp16, void* output_fp8, int rows, int K,
+                             float* d_row_scales, cudaStream_t stream = nullptr);
+
 // Fully async calibrate+quantize: no host sync, all on device.
 // Caller provides reusable temp buffers d_block_maxes[max_grid] and d_absmax[1].
 // Scale is written to d_scale_out on device.

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -222,6 +222,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("gemm.nvfp4_lm_head_cutlass", cfg.gemm.nvfp4_lm_head_cutlass);
     B("gemm.nvfp4_ssm_proj", cfg.gemm.nvfp4_ssm_proj);
     B("gemm.nvfp4_attn_proj", cfg.gemm.nvfp4_attn_proj);
+    B("gemm.fp8_ssm_proj", cfg.gemm.fp8_ssm_proj);
     B("gemm.nvfp4_moe_decode", cfg.gemm.nvfp4_moe_decode);
 
     // [gemma4] section moved to ModelConfig::Overrides::Gemma4 in Phase 5

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -527,6 +527,23 @@ struct RuntimeConfig {
         // those projections FP16 is correct for SPEED (not just quality); no flag
         // is provided for them. (See docs/MTP/SafeTensors profiling notes.)
         bool nvfp4_attn_proj = false;
+        // FP8 (E4M3, per-tensor amax scale) DECODE sidecar for the native-
+        // precision GDN/Mamba in_proj/out_proj that the NVFP4 lever above
+        // regresses on: FP8 halves the FP16 GEMV bytes with byte-aligned dense
+        // loads (none of the 4-bit packing overhead that made NVFP4 lose to the
+        // tuned FP16 GEMV on the wide GDN shapes), and its quality risk into
+        // the recurrent scan is far smaller than 4-bit. Prefill and the M>1
+        // verify chunks keep the resident FP16 source (quality); only the M=1
+        // decode GEMV dispatches the FP8 copy (gemv_fp8_rowscale, per-row
+        // scales — one per-tensor scale over the heterogeneous GDN input pack
+        // cost +4% PPL; per-row is PPL-flat). Costs +0.5 byte/elem VRAM for
+        // the sidecar copies. No-op on models without F16-resident SSM
+        // projections (GGUF hybrids → see nvfp4_ssm_proj; 27B-class checkpoints
+        // whose SSM projections are already native NVFP4).
+        // MEASURED (2026-07-10): Qwen3.6-35B-A3B-NVFP4 decode +19% (268.6→320.3
+        // tok/s spec-off, 261→308 with default spec), PPL flat (8.021→8.012);
+        // Nemotron-3-Nano PPL flat (4.184→4.117). Default ON.
+        bool fp8_ssm_proj = true;
         // Route native-NVFP4 (Modelopt/llm-compressor) MoE expert DECODE (M=1)
         // through the fast per-expert gemv_nvfp4_moe kernels by borrowing the
         // already-resident contiguous expert data + scales, instead of the

--- a/tools/analysis/fp8_ssm_proj_ab.sh
+++ b/tools/analysis/fp8_ssm_proj_ab.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# A/B the FP8 E4M3 decode sidecar for native-precision GDN/SSM projections
+# (gemm.fp8_ssm_proj) on NVFP4 hybrids: decode tg256 (10-rep, spec off for the
+# kernel-level signal + defaults-on for the user-visible number), perplexity
+# (teacher-forced, same-corpus delta), and a coherence sample.
+set -uo pipefail
+
+IMG=${IMG:-imp:test}
+MODELS=/home/kekz/models
+CORPUS=/work/tools/analysis/ppl_corpus.txt
+REPO=$(cd "$(dirname "$0")/../.." && pwd)
+PROMPT="Explain why the sky is blue, then say why sunsets are red."
+
+run() {
+  docker run --rm --gpus all -e CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+    -v "$MODELS":/models -v "$REPO":/work "$IMG" "$@"
+}
+
+decode() { # model flag spec
+  local spec_args=""
+  if [ "$3" = "nospec" ]; then
+    spec_args="--set speculative.suffix=false --set speculative.ngram=false --set speculative.moe=false"
+  fi
+  run imp-cli --model "/models/$(basename "$1")" --bench --bench-pp 16 \
+      --bench-reps 10 --max-tokens 256 --temperature 0 \
+      --set gemm.fp8_ssm_proj="$2" $spec_args 2>&1 \
+    | grep -E '^tg|fp8_ssm_proj'
+}
+
+ppl() { # model flag
+  run imp-cli --model "/models/$(basename "$1")" --perplexity "$CORPUS" \
+      --temperature 0 --set gemm.fp8_ssm_proj="$2" 2>&1 \
+    | grep -E '^perplexity|fp8_ssm_proj'
+}
+
+cohere() { # model flag
+  run imp-cli --model "/models/$(basename "$1")" --prompt "$PROMPT" \
+      --max-tokens 80 --temperature 0 --set gemm.fp8_ssm_proj="$2" 2>&1 \
+    | grep -oE '\][^[]*' | sed -E 's/^\] ?//' | tr -d '\n'
+}
+
+MODEL="$1"
+echo "######## MODEL: $(basename "$MODEL") ########"
+for flag in false true; do
+  echo "===== fp8_ssm_proj=$flag ====="
+  echo "--- decode (spec off) ---"; decode "$MODEL" "$flag" nospec
+  echo "--- decode (defaults) ---"; decode "$MODEL" "$flag" default
+  echo "--- ppl ---";              ppl    "$MODEL" "$flag"
+  echo "--- text ---";             cohere "$MODEL" "$flag"; echo
+done
+echo "DONE $(basename "$MODEL")"


### PR DESCRIPTION
## Summary

Fresh nsys profile (2026-07-10) showed the recipe-excluded BF16 GDN in/out projections are still the single largest decode slice on NVFP4 hybrids — **34.6% of GPU time as `gemv_fp16`** on Qwen3.6-35B. NVFP4 on these wide shapes is a measured dead end (−9…−20%, 2026-05-30). FP8 E4M3 halves the bytes with byte-aligned loads and none of the 4-bit packing overhead:

- **`gemm.fp8_ssm_proj` (default ON)** — pre-dequant phase 2b quantizes the F16-resident `ssm_in`/`ssm_out` (or the fused GDN input pack `[conv|gate|alpha|beta]`, which is what decode actually dispatches) into an FP8 sidecar with **per-row scales** (`quantize_fp8_rows_async`; one per-tensor scale over the heterogeneous pack cost +4% PPL — per-row is PPL-flat).
- Only the **M=1 decode GEMV** takes the sidecar (`gemv_fp8_rowscale`, templated from the existing FP8 GEMV; declines non-F16 outputs). **Prefill and M>1 verify chunks keep the FP16 source**, and the recurrent-scan state stays FP16 — the quality exposure is one 8-bit weight read per token, not error accumulation in the state.
- Registry: the fp8 wcache hit is demoted to primary/prefill FP16 with `decode_tier=FP8` (before the payload borrow — the union must not carry an fp8 payload into FP16 paths). The M>1 FP16-tier dispatch grows the missing uncached-fallback route for F16-resident sources (pre-sidecar these weights ran as tier `Undefined`; without the route a null payload pointer reached cuBLAS → status 7).
- Teardown: sidecar bulk + row-scale buffers tracked in `WeightCaches`, freed in `free_buffers`.

## Measurements (10 reps, isolated, `CUBLAS_WORKSPACE_CONFIG=:4096:8`, healthy clocks)

| Model | Metric | off | on | Δ |
|---|---|---:|---:|---|
| Qwen3.6-35B-A3B-NVFP4 | tg256, spec off | 268.6 | **320.3** | **+19.2%** |
| Qwen3.6-35B-A3B-NVFP4 | tg256, default spec | 261.1 | **308.2** | **+18.0%** |
| Qwen3.6-35B-A3B-NVFP4 | PPL (same-session) | 8.021 | 8.012 | flat |
| Nemotron-3-Nano-30B | PPL | 4.184 | 4.117 | flat |
| Qwen3.6-27B (SSM already NVFP4) | tg256 | 90.80 | 90.79 | no-op ✓ |

A/B harness committed as `tools/analysis/fp8_ssm_proj_ab.sh`. `docs/BENCHMARKS.md` row updated (SHA-anchored). `tests/perf_baseline.json` untouched — the gate model (Qwen3-8B dense) has no SSM projections.

## Quality gates

- Per-row scales are the load-bearing quality fix (per-tensor was +4% PPL → refused).
- Coherence probes clean; CLI generation with captured spec-verify replay clean; `MtpForwardTest` (loads the real 35B, now default-on) green; `test-moe-gdn` 121/121; `WeightDispatchTest` 11/11; `make test-unit` green; `make verify-fast` OK.
- **Pre-existing, not this PR**: the degen suite wedges the 35B *server* after ~14 mixed requests (illegal memory access, engine never recovers) — reproduced byte-identically with the flag **off** (control run). Filed as #948 with both logs. Every check that differentiates the arms is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F