### PR TITLE
fix(graphs): re-derive decode-graph launch topology on context growth — long prompt after short requests wedged the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **The decode CUDA graph now re-derives its launch topology when the context
+  high-water mark grows — a long-prompt request after short ones no longer
+  wedges the engine with an illegal memory access** (#948). The decode-
+  attention launch topology (split-K `num_splits`, GQA-vs-split-K kernel
+  choice) derives from `max_context_len` on the host and is baked into the
+  captured graph. The intended re-capture trigger — the pow2 `max_blocks`
+  bucket — never fires because the decode batch pool pads
+  `max_blocks_per_seq` to the pool stride, so a graph captured at ctx≈35
+  replayed a stale topology at ctx≈2400 and faulted; the engine then never
+  recovered (every subsequent request returned 0 tokens after 300 s,
+  `/health` unhealthy). New trigger: pow2-bucketed context high-water mark
+  (monotonic, ~log2(max ctx) re-captures per process; shrink replays are
+  served by the large-ctx capture via the split-K empty-split sentinels).
+  The full degeneration suite now passes against the Qwen3.6-35B server for
+  the first time (33 checks, 38 s — previously wedged at ~14 requests).
+  Also hardened `resize_workspace` against running while the decode
+  workspace is the active alias (would free the decode-shared buffer and
+  leave it dangling — latent, found during the same investigation).
+
 ### Added
 - **`gemm.fp8_ssm_proj` (default ON): FP8 E4M3 decode sidecar for the
   native-precision GDN/Mamba in/out projections on NVFP4 hybrids — Qwen3.6-35B

--- a/src/exec/executor_workspace_config.cu
+++ b/src/exec/executor_workspace_config.cu
@@ -134,6 +134,17 @@ void GraphExecutor::configure_ssm_workspace(int max_tokens) {
 }
 
 bool Workspace::resize_workspace(int new_max_tokens, cudaStream_t stream) {
+    // Resize targets the PREFILL shared arena. While the decode workspace is
+    // active (slot 1), shared_workspace_ aliases the fixed-size decode buffer
+    // — growing through that alias cudaFreeAsync's the decode buffer and
+    // leaves decode_shared_workspace_ dangling; the next use_workspace(1)
+    // re-installs the freed pointer and decode kernels write into freed
+    // memory (#948: server wedged with an illegal memory access whenever a
+    // chunked prefill followed a batch=1 decode, which leaves slot 1 active).
+    // Restore the prefill workspace first, exactly like the decode path does
+    // before its own resize (step_decode_forward).
+    if (active_workspace_ == 1)
+        use_workspace(0);
     if (new_max_tokens == shared_workspace_max_tokens_ || new_max_tokens <= 0)
         return true;
     if (new_max_tokens > *max_tokens_)

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -341,6 +341,16 @@ private:
     std::vector<std::unique_ptr<LoraAdapter>> lora_adapters_;
     int active_lora_ = 0;
     int last_decode_max_blocks_per_graph_[kMaxGraphPoolSize] = {};
+    // pow2-bucketed context HIGH-WATER MARK at the last (re)capture — the
+    // decode-attention launch topology (split-K num_splits, GQA vs split
+    // kernel choice) derives from max_context_len on the HOST, so a graph
+    // captured at a small context replays a stale topology at a much larger
+    // one (#948: IMA when a request with a long prompt follows short ones).
+    // The max_blocks bucket above never trips (the batch pool pads to pool
+    // stride), so this is the trigger that actually fires as context grows.
+    // Monotonic: shrink replays are served by the large-ctx capture (empty
+    // split-K splits write sentinels), only growth forces a re-derivation.
+    int last_decode_max_ctx_per_graph_[kMaxGraphPoolSize] = {};
 
     // Prefill graph runner — captures forward_logits for non-last chunks of
     // chunked prefill. Single runner: in practice chunk_len == prefill_chunk_size

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1545,6 +1545,27 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             graph_runner.invalidate_for_update();
             last_decode_max_blocks_per_graph_[graph_idx] = bucketed_max_blocks;
         }
+        // #948: the decode-attention LAUNCH topology derives from
+        // max_context_len on the host (split-K num_splits / GQA-vs-split-K
+        // kernel choice, scratch clamping) and is baked into the capture. The
+        // max_blocks bucket above was meant to catch context growth but never
+        // trips — the decode batch pool pads max_blocks_per_seq to the pool
+        // stride. Re-derive the graph when the pow2 context bucket GROWS past
+        // the captured one: a graph captured at ctx≈35 replayed at ctx≈2400
+        // dereferences a stale-topology kernel and wedges the engine with an
+        // illegal memory access. Growth-only (monotonic high-water mark,
+        // ~log2(max ctx) captures per process — an on-any-change trigger
+        // re-captured 1-2x per request under short/long ping-pong): replaying
+        // a large-ctx capture for a SHORT request is safe, surplus split-K
+        // splits write their empty-split sentinels and the reduce merges
+        // them; the reverse direction is the crash. cudaGraphExecUpdate
+        // absorbs same-topology re-captures; a kernel-choice change fails
+        // the update and re-instantiates.
+        const int bucketed_max_ctx = bucket_pow2(max_ctx);
+        if (bucketed_max_ctx > last_decode_max_ctx_per_graph_[graph_idx]) {
+            graph_runner.invalidate_for_update();
+            last_decode_max_ctx_per_graph_[graph_idx] = bucketed_max_ctx;
+        }
         // Recurrent (SSM/GDN) state pointers are baked into the capture as
         // kernel params. A replay for a request in a DIFFERENT state slot
         // would read/write the previous sequence's state — possible whenever

--- a/tests/test_e2e_models.cpp
+++ b/tests/test_e2e_models.cpp
@@ -473,3 +473,69 @@ TEST_F(Gemma4GraphsTest, LongDecodeStaysCoherent) {
 }
 
 }  // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// #948 regression: decode-graph launch-topology re-derivation on ctx growth.
+//
+// The per-step decode graph bakes launch topology derived from the HOST
+// max_context_len (split-K num_splits / GQA-vs-split-K kernel choice). The
+// intended re-capture trigger — the pow2 max_blocks bucket — never fires
+// because the decode batch pool pads max_blocks_per_seq to the pool stride.
+// Pre-fix, a graph captured during a SHORT request replayed with a stale
+// topology for the next LONG-prompt request (> prefill_chunk_size) and hit an
+// illegal memory access at its first decode step, wedging the engine for the
+// rest of the process. This test is the minimal HTTP repro as a C-API test:
+// short request → >2048-token prompt → another short request.
+// ---------------------------------------------------------------------------
+TEST(DecodeGraphCtxGrowthTest, LongPromptAfterShortRequestStaysAlive) {
+    const char* path = primary_model();
+    if (!path)
+        GTEST_SKIP() << "Set IMP_TEST_MODEL to run";
+
+    ImpModel model = nullptr;
+    ImpContext ctx = nullptr;
+    ASSERT_EQ(imp_model_load(path, IMP_FORMAT_GGUF, &model), IMP_SUCCESS);
+    ImpConfig cfg = imp_config_default();
+    cfg.max_seq_len = 4096;
+    cfg.max_batch_size = 1;
+    cfg.enable_cuda_graphs = 1;  // the bug lives in decode-graph replay
+    ASSERT_EQ(imp_context_create(model, &cfg, &ctx), IMP_SUCCESS);
+
+    ImpGenerateParams params = imp_generate_params_default();
+    params.temperature = 0.0f;
+    params.apply_chat_template = 0;
+
+    char output[8192];
+    size_t len = 0;
+
+    // Request 1: short — captures the decode graph at a tiny context.
+    params.max_tokens = 16;
+    ASSERT_EQ(imp_generate(ctx, "The capital of France is", &params, output, sizeof(output), &len),
+              IMP_SUCCESS);
+    EXPECT_GT(len, 0u);
+
+    // Request 2: prompt > prefill_chunk_size (2048 tokens) → chunked prefill,
+    // then decode replays the pooled graph at a ~70x larger context.
+    std::string filler;
+    for (int i = 0; i < 300; i++)
+        filler += "The maintenance log notes routine checks of pumps and valves. ";
+    std::string prompt =
+        "Remember this code: ZEBRA-9134.\n\n" + filler + "\nThe code I was asked to remember is";
+    params.max_tokens = 24;
+    ASSERT_EQ(imp_generate(ctx, prompt.c_str(), &params, output, sizeof(output), &len), IMP_SUCCESS);
+    EXPECT_GT(len, 0u);
+    std::string text2(output, len);
+    EXPECT_NE(text2.find("ZEBRA"), std::string::npos)
+        << "needle lost after chunked prefill: " << text2;
+
+    // Request 3: the engine must still be alive (pre-fix: every request after
+    // the wedge returned 0 tokens on a poisoned CUDA context).
+    params.max_tokens = 16;
+    ASSERT_EQ(imp_generate(ctx, "The capital of Italy is", &params, output, sizeof(output), &len),
+              IMP_SUCCESS);
+    std::string text3(output, len);
+    EXPECT_NE(text3.find("Rome"), std::string::npos) << "engine wedged after ctx growth: " << text3;
+
+    imp_context_free(ctx);
+    imp_model_free(model);
+}


### PR DESCRIPTION
Closes #948

## Root cause

The per-step decode CUDA graph bakes launch topology derived from `max_context_len` on the **host** — split-K `num_splits`, the GQA-vs-split-K kernel choice, scratch clamping (`attention_paged.cu:1340-1405`). The re-capture trigger that was designed to catch context growth — the pow2 `max_blocks` bucket (`engine_scheduler.cpp`) — **never fires**, because the decode batch pool pads `max_blocks_per_seq` up to the pool stride before the comparison (the code comment even documents "in practice this comparison never trips").

Consequence: a decode graph captured during a short request (ctx≈35 → `num_splits=1`, GQA kernel baked) replays that stale topology for the next long-prompt request (ctx≈2400) and hits an **illegal memory access** at its first decode step. The engine never recovers — every subsequent request returns 0 tokens after the 300 s timeout, `/health` reports unhealthy, and the log fills with ~150k repeats of the same sticky-error cascade.

## Fix

- **pow2-bucketed context high-water mark** as an additional `invalidate_for_update` trigger. Monotonic (grow-only): ~log2(max ctx) re-captures per process; shrink replays are served by the large-ctx capture (surplus split-K splits write their empty-split sentinels, the reduce merges them) — the reverse direction is the crash. An on-any-change trigger measured 86 re-captures across the degen suite (1–2 per request under short/long ping-pong); grow-only is 7.
- **Latent hardening**: `Workspace::resize_workspace` now restores the prefill workspace before growing — running it while the decode workspace is the active alias would `cudaFreeAsync` the decode-shared buffer through the alias and leave `decode_shared_workspace_` dangling for the next `use_workspace(1)`. Not reachable on this box (no green contexts → no decode workspace) but a real footgun on hosts that have one; found during the same investigation.

## Debugging trail

Flag bisect eliminated spec-capture, speculation, and prefix cache (all still wedged); `--no-cuda-graphs` was clean; predecessor bisect showed **any single completed request** suffices; chunk-length bisect discriminated 1741 tokens (single chunk — clean) vs 2441 (chunked — wedge); env-gated sync probes finally pinned the first fault to the **first decode-graph replay** of the long request (`max_ctx=2442` on a graph captured at 35). Two red herrings documented and discarded on the way (penalty-buffer realloc, snapshot-boundary chunk split — both exonerated by control experiments).

## Test plan

- [x] Minimal repro (short request → 2441-token prompt → follow-up) green with correct answers (`Paris` / `ZEBRA-9134` / `42`), 0 IMA — previously wedged 100%
- [x] **Full degeneration suite vs the Qwen3.6-35B server passes for the first time**: 33 checks, 0 FAIL, 38 s (previously wedged at ~14 requests, 3/3 runs)
- [x] New e2e regression test `DecodeGraphCtxGrowthTest.LongPromptAfterShortRequestStaysAlive` (in `test-e2e`, dense Qwen3-4B — the bug is model-agnostic) green
- [x] `DegenerationTest` 6/6, `test-moe-gdn` 121/121, `make test-unit` green, `make verify-fast` OK
- [x] 35B decode sanity: tg256 = 311 tok/s (healthy band, the fp8_ssm_proj gains intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F