### PR TITLE
refactor(server): extract shared SSE token-stream driver + imp::Request builder

### DIFF
--- a/.claude/skills/server-api/SKILL.md
+++ b/.claude/skills/server-api/SKILL.md
@@ -5,7 +5,7 @@ description: Use when working on or testing imp-server and its HTTP APIs — Ope
 
 # Server & API — imp-server
 
-Source: `tools/imp-server/` — `main.cpp` (routes) · `args.cpp` (CLI flags + `--help` text) · `handlers_chat_core.cpp`/`handlers_chat.cpp`/`handlers_chat_stream.cpp` (OpenAI chat: params→render→stream) · `handlers_messages.cpp`+`anthropic.cpp` (Anthropic dialect) · `responses.cpp`/`handlers_responses.cpp` (Responses API) · `reasoning_split.h` (think/content channel split) · `tool_call.cpp`/`tool_stream_filter.h` (tool calling) · `batching_engine.cpp` (scheduler).
+Source: `tools/imp-server/` — `main.cpp` (routes) · `args.cpp` (CLI flags + `--help` text) · `handlers_chat_core.cpp`/`handlers_chat.cpp`/`handlers_chat_stream.cpp` (OpenAI chat: params→render→stream) · `stream_driver.cpp` (shared per-token SSE loop; the three streaming handlers are thin dialect adapters over it) · `handlers_messages.cpp`+`anthropic.cpp` (Anthropic dialect) · `responses.cpp`/`handlers_responses.cpp` (Responses API) · `reasoning_split.h` (think/content channel split) · `tool_call.cpp`/`tool_stream_filter.h` (tool calling) · `batching_engine.cpp` (scheduler).
 
 ## Start the server
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,7 @@ if(IMP_BUILD_SERVER)
         tools/imp-server/handlers_chat.cpp
         tools/imp-server/handlers_chat_core.cpp
         tools/imp-server/handlers_chat_stream.cpp
+        tools/imp-server/stream_driver.cpp
         tools/imp-server/handlers_messages.cpp
         tools/imp-server/handlers_responses.cpp
         tools/imp-server/handlers_misc.cpp

--- a/tools/imp-server/handlers_chat.cpp
+++ b/tools/imp-server/handlers_chat.cpp
@@ -40,55 +40,8 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
     // Save input tokens for potential reuse with n > 1
     std::vector<int32_t> saved_tokens = ctx.snap.tokens;
 
-    // Helper to create an imp::Request with the given completion index
-    auto make_imp_request = [&](int completion_idx) {
-        auto req = std::make_shared<imp::Request>();
-        req->image = ctx.snap.vision_image;  // per-request vision (null for text)
-        req->input_tokens = saved_tokens;
-        req->max_tokens = ctx.params.max_tokens;
-        req->temperature = ctx.params.temperature;
-        req->top_p = ctx.params.top_p;
-        req->top_k = ctx.params.top_k;
-        req->seed = (ctx.params.seed != -1) ? ctx.params.seed + completion_idx : -1;
-        req->pin_kv_prefix = ctx.params.cache_prompt;
-        req->spec_ngram_override = ctx.params.spec_ngram_override;
-        req->prediction_tokens = ctx.snap.prediction_tokens;
-        req->min_p = ctx.params.min_p;
-        req->typical_p = ctx.params.typical_p;
-        req->repetition_penalty = ctx.params.repetition_penalty;
-        req->frequency_penalty = ctx.params.frequency_penalty;
-        req->presence_penalty = ctx.params.presence_penalty;
-        req->repeat_last_n = ctx.params.repeat_last_n;
-        req->dry_multiplier = ctx.params.dry_multiplier;
-        req->dry_base = ctx.params.dry_base;
-        req->dry_allowed_length = ctx.params.dry_allowed_length;
-        req->dry_penalty_last_n = ctx.params.dry_penalty_last_n;
-        req->mirostat = ctx.params.mirostat;
-        req->mirostat_tau = ctx.params.mirostat_tau;
-        req->mirostat_eta = ctx.params.mirostat_eta;
-        req->logprobs = ctx.params.req_logprobs;
-        req->top_logprobs = ctx.params.top_logprobs;
-        req->json_mode = ctx.params.json_mode;
-        req->json_schema = ctx.params.json_schema_str;
-        req->has_tools = ctx.params.has_tools;
-        req->tpl_family = ctx.snap.tpl_family;
-        req->logit_bias = ctx.params.logit_bias;
-        req->think_budget = ctx.params.think_budget;
-        // Generation starts INSIDE the think block when the prompt carries the
-        // <think> prefix (template-injected or server-appended). Without this
-        // the engine's think-budget enforcement never sees an opener in the
-        // output, counts zero reasoning tokens, and lets the model think until
-        // max_tokens (content empty, finish=length).
-        req->started_in_think = ctx.snap.enable_thinking;
-        req->in_think_block = ctx.snap.enable_thinking;
-        // Stream requests stay on per-step decode for real per-token SSE (#754).
-        req->stream = ctx.params.stream;
-        req->status = imp::RequestStatus::PENDING;
-        return req;
-    };
-
     // Create first request
-    auto imp_req = make_imp_request(0);
+    auto imp_req = build_imp_request_(ctx, saved_tokens, /*completion_idx=*/0, ctx.params.stream);
 
     // Create a ServerRequest wrapper and submit to the batching engine
     auto server_req = std::make_shared<ServerRequest>();

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -759,6 +759,56 @@ bool snapshot_state_and_tokenize_(
 }
 
 
+// Single params->request mapping for the ctx-based submission sites (see
+// handlers_internal.h).
+std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
+                                                 const std::vector<int32_t>& input_tokens,
+                                                 int completion_idx, bool stream) {
+    auto req = std::make_shared<imp::Request>();
+    req->image = ctx.snap.vision_image;  // per-request vision (null for text)
+    req->input_tokens = input_tokens;
+    req->max_tokens = ctx.params.max_tokens;
+    req->temperature = ctx.params.temperature;
+    req->top_p = ctx.params.top_p;
+    req->top_k = ctx.params.top_k;
+    req->seed = (ctx.params.seed != -1) ? ctx.params.seed + completion_idx : -1;
+    req->pin_kv_prefix = ctx.params.cache_prompt;
+    req->spec_ngram_override = ctx.params.spec_ngram_override;
+    req->prediction_tokens = ctx.snap.prediction_tokens;
+    req->min_p = ctx.params.min_p;
+    req->typical_p = ctx.params.typical_p;
+    req->repetition_penalty = ctx.params.repetition_penalty;
+    req->frequency_penalty = ctx.params.frequency_penalty;
+    req->presence_penalty = ctx.params.presence_penalty;
+    req->repeat_last_n = ctx.params.repeat_last_n;
+    req->dry_multiplier = ctx.params.dry_multiplier;
+    req->dry_base = ctx.params.dry_base;
+    req->dry_allowed_length = ctx.params.dry_allowed_length;
+    req->dry_penalty_last_n = ctx.params.dry_penalty_last_n;
+    req->mirostat = ctx.params.mirostat;
+    req->mirostat_tau = ctx.params.mirostat_tau;
+    req->mirostat_eta = ctx.params.mirostat_eta;
+    req->logprobs = ctx.params.req_logprobs;
+    req->top_logprobs = ctx.params.top_logprobs;
+    req->json_mode = ctx.params.json_mode;
+    req->json_schema = ctx.params.json_schema_str;
+    req->has_tools = ctx.params.has_tools;
+    req->tpl_family = ctx.snap.tpl_family;
+    req->logit_bias = ctx.params.logit_bias;
+    req->think_budget = ctx.params.think_budget;
+    // Generation starts INSIDE the think block when the prompt carries the
+    // <think> prefix (template-injected or server-appended). Without this
+    // the engine's think-budget enforcement never sees an opener in the
+    // output, counts zero reasoning tokens, and lets the model think until
+    // max_tokens (content empty, finish=length).
+    req->started_in_think = ctx.snap.enable_thinking;
+    req->in_think_block = ctx.snap.enable_thinking;
+    // Stream requests stay on per-step decode for real per-token SSE (#754).
+    req->stream = stream;
+    req->status = imp::RequestStatus::PENDING;
+    return req;
+}
+
 // Non-streaming chat completion: run n_completions independent generations
 // sequentially via the batching engine, build the choices array with
 // reasoning_content / tool_calls / logprobs as appropriate, send a single
@@ -773,51 +823,6 @@ void nonstream_chat_response_(
     const std::string& comp_id,
     int64_t created)
 {
-    // Helper to create an imp::Request with the given completion index
-    auto make_imp_request = [&](int completion_idx) {
-        auto req = std::make_shared<imp::Request>();
-        req->image = ctx.snap.vision_image;  // per-request vision (null for text)
-        req->input_tokens = saved_tokens;
-        req->max_tokens = ctx.params.max_tokens;
-        req->temperature = ctx.params.temperature;
-        req->top_p = ctx.params.top_p;
-        req->top_k = ctx.params.top_k;
-        req->seed = (ctx.params.seed != -1) ? ctx.params.seed + completion_idx : -1;
-        req->pin_kv_prefix = ctx.params.cache_prompt;
-        req->spec_ngram_override = ctx.params.spec_ngram_override;
-        req->prediction_tokens = ctx.snap.prediction_tokens;
-        req->min_p = ctx.params.min_p;
-        req->typical_p = ctx.params.typical_p;
-        req->repetition_penalty = ctx.params.repetition_penalty;
-        req->frequency_penalty = ctx.params.frequency_penalty;
-        req->presence_penalty = ctx.params.presence_penalty;
-        req->repeat_last_n = ctx.params.repeat_last_n;
-        req->dry_multiplier = ctx.params.dry_multiplier;
-        req->dry_base = ctx.params.dry_base;
-        req->dry_allowed_length = ctx.params.dry_allowed_length;
-        req->dry_penalty_last_n = ctx.params.dry_penalty_last_n;
-        req->mirostat = ctx.params.mirostat;
-        req->mirostat_tau = ctx.params.mirostat_tau;
-        req->mirostat_eta = ctx.params.mirostat_eta;
-        req->logprobs = ctx.params.req_logprobs;
-        req->top_logprobs = ctx.params.top_logprobs;
-        req->json_mode = ctx.params.json_mode;
-        req->json_schema = ctx.params.json_schema_str;
-        req->has_tools = ctx.params.has_tools;
-        req->tpl_family = ctx.snap.tpl_family;
-        req->logit_bias = ctx.params.logit_bias;
-        req->think_budget = ctx.params.think_budget;
-        // Generation starts INSIDE the think block when the prompt carries the
-        // <think> prefix (template-injected or server-appended). Without this
-        // the engine's think-budget enforcement never sees an opener in the
-        // output, counts zero reasoning tokens, and lets the model think until
-        // max_tokens (content empty, finish=length).
-        req->started_in_think = ctx.snap.enable_thinking;
-        req->in_think_block = ctx.snap.enable_thinking;
-        req->status = imp::RequestStatus::PENDING;
-        return req;
-    };
-
     // Non-streaming: decode all tokens, return complete response
     // For n > 1, run multiple independent generations sequentially
     json choices = json::array();
@@ -826,7 +831,7 @@ void nonstream_chat_response_(
     for (int ci = 0; ci < ctx.params.n_completions; ci++) {
         // For subsequent completions, create a new request and submit it
         if (ci > 0) {
-            imp_req = make_imp_request(ci);
+            imp_req = build_imp_request_(ctx, saved_tokens, ci, /*stream=*/false);
             server_req = std::make_shared<ServerRequest>();
             server_req->request = imp_req;
             {

--- a/tools/imp-server/handlers_chat_stream.cpp
+++ b/tools/imp-server/handlers_chat_stream.cpp
@@ -1,33 +1,19 @@
-// AUTO-SPLIT from handlers.cpp (verbatim move; see handlers_internal.h).
-// Streaming chat-completion machinery: the SSE chunked-provider setup
-// (stream_chat_response_) and the per-token streaming loop body
-// (run_chat_stream_). Used by handlers_chat.cpp and handlers_messages.cpp.
+// OpenAI chat-completions streaming: the SSE chunked-provider setup
+// (stream_chat_response_) and the chat dialect adapter for the shared token
+// loop (stream_driver.h) — pre-built envelope templates, per-token logprobs,
+// tool_calls deltas, usage chunk, [DONE].
 
 #include "handlers.h"
 #include "handlers_internal.h"
+#include "stream_driver.h"
 #include "utils.h"
 #include "tool_call.h"
-#include "tool_stream_filter.h"
-#include "anthropic.h"
-#include "stream_pipeline.h"
-#include "reasoning_split.h"
 
-#include "api/imp_internal.h"
-#include "vision/image_processor.h"
 #include "runtime/request.h"
-#include "memory/kv_cache.h"
-#include "model/hf_hub.h"
-#include "runtime/config.h"
 
-#include <chrono>
-#include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <filesystem>
-#include <functional>
-#include <vector>
-
-#include <cuda_runtime.h>
+#include <string>
 
 // Set up SSE chunked content provider for streaming chat completion.
 // Captures state and ctx by reference for the chunked-provider lambda. ctx
@@ -51,53 +37,18 @@ void stream_chat_response_(httplib::Response& res, ServerState& state, ChatReque
         });
 }
 
-// Streaming chat response loop body. Extracted from the
-// res.set_chunked_content_provider() lambda in stream_chat_response_ so
-// the 760-LOC body is no longer a god-function nested four levels deep.
-// httplib calls the lambda repeatedly until it returns false; the lambda
-// just dispatches to this function. ctx is captured by value into the
-// lambda (so it survives stream_chat_response_'s return); state is
-// captured by reference (lives in the long-lived ServerState).
+// Chat dialect adapter: emits OpenAI chat.completion.chunk SSE frames around
+// the shared token loop (run_stream_loop_). httplib calls the chunked-provider
+// lambda repeatedly until it returns false; the lambda dispatches here. ctx is
+// captured by value into the lambda (so it survives stream_chat_response_'s
+// return); state is captured by reference (lives in the long-lived
+// ServerState).
 bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
                              const std::shared_ptr<ServerRequest>& server_req) {
-    // Local aliases so the body reads unchanged from its previous
-    // capture-list-based form. These were 30+ individual lambda captures
-    // before this refactor.
-    const std::string& comp_id          = ctx.comp_id;
-    int64_t            created          = ctx.created;
-    int                n_prompt_tokens  = ctx.snap.n_prompt_tokens;
-    auto               t_start          = ctx.t_start;
-    const auto&        stop_sequences   = ctx.params.stop_sequences;
-    // Derive max_stop_len from the FINAL stop list, not ctx.params.max_stop_len:
-    // the snapshot phase may inject server-side stops ("\nHuman" turn guard for
-    // think models) AFTER request parsing computed max_stop_len. A stale 0 made
-    // the partial-match holdback `size - max_stop_len + 1` flush one byte PAST
-    // pending_text's end — emitting the std::string NUL terminator into every
-    // SSE content delta ("4\0") and disabling cross-token stop matching.
-    size_t             max_stop_len     = 0;
-    for (const auto& s : stop_sequences)
-        max_stop_len = std::max(max_stop_len, s.size());
-    int                req_logprobs     = ctx.params.req_logprobs;
-    bool               include_usage    = ctx.params.include_usage;
-    bool               enable_thinking  = ctx.snap.enable_thinking;
-    bool               has_tools        = ctx.params.has_tools;
-    auto               tpl_family       = ctx.snap.tpl_family;
-    float              think_budget     = ctx.params.think_budget;
-    auto               snap_tok         = ctx.snap.tok;
-    bool               snap_have_template = ctx.snap.have_template;
-    const std::string& snap_model_name  = ctx.snap.model_name;
-    bool               snap_is_think_model      = ctx.snap.is_think_model;
-    int                snap_think_start_id      = ctx.snap.think_start_id;
-    int                snap_think_end_id        = ctx.snap.think_end_id;
-    int                snap_channel_open_id     = ctx.snap.channel_open_id;
-    int                snap_channel_close_id    = ctx.snap.channel_close_id;
-    int                snap_channel_newline_id  = ctx.snap.channel_newline_id;
-    const auto&        snap_stop_token_ids      = ctx.snap.stop_token_ids;
-    bool               log_skip         = ctx.log_skip;
-    auto               t_log_start      = ctx.t_log_start;
-    const std::string& log_endpoint     = ctx.log_endpoint;
-    const std::string& log_client_ip    = ctx.log_client_ip;
-    const std::string& log_raw_body     = ctx.log_raw_body;
+    const std::string& comp_id = ctx.comp_id;
+    int64_t created = ctx.created;
+    const std::string& snap_model_name = ctx.snap.model_name;
+    bool req_logprobs = ctx.params.req_logprobs;
 
     // Active request ref for logprobs access
     auto active_req = server_req->request;
@@ -110,552 +61,136 @@ bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
     std::string chunk = sse_chunk(comp_id, created, snap_model_name, role_delta, nullptr);
     sink.write(chunk.data(), chunk.size());
 
-    int n_output_tokens = 0;
-    const char* finish = nullptr;
-    double ttft_ms = 0.0;  // Time to first token
-
-    // Buffer for incomplete UTF-8 sequences across token boundaries
-    std::string utf8_buf;
-
-    // Buffered output for stop sequence matching in streaming mode.
-    // We hold back text until we're sure it doesn't contain a stop match.
-    std::string pending_text;
-    bool text_stop_matched = false;
-
-    // Streaming tool-call demux (tool_stream_filter.h) — pure state machine
-    // shared with the Anthropic path. Detects ChatML/Llama3/Gemma-4 open
-    // markers, holds back potential-tag text, parses completed bodies (JSON,
-    // Qwen3.6 XML fallback, Gemma call:NAME{...}) and restores unparseable
-    // ones to the content stream instead of dropping them.
-    imp::server::StreamToolCallFilter tool_filter(tpl_family);
-    std::vector<ParsedToolCall> stream_tool_calls;
-    bool tool_calls_emitted = false;
-    // parallel_tool_calls=false: a second streamed call was opened by the
-    // filter but is being suppressed (skip its deltas/END too).
-    bool stream_call_suppressed = false;
-    // The full accumulated output (only used when has_tools, for fallback)
-    std::string full_output;
-
-    // Reasoning content extraction (DeepSeek format). enable_thinking also
-    // covers text-level thinkers (Nemotron: template-injected "<think>" as
-    // plain text, no special token — is_think_model is false but the output
-    // starts mid-reasoning and exits via the literal "</think>").
-    // Reasoning/content demux is shared with the Anthropic path via the pure
-    // StreamReasoningSplitter (reasoning_split.h) — single source of truth for
-    // the streaming first-vs-last </think> handling
-    // (BUGREPORT-qwen36-reasoning-leaks-into-content).
-    const bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
-                                (snap_is_think_model || enable_thinking));
-    const bool think_active = use_reasoning || enable_thinking;
-    imp::server::ThinkPhase think_start_phase;
-    if (enable_thinking)
-        think_start_phase = imp::server::ThinkPhase::REASONING;  // <think> in prefill
-    else if (use_reasoning && think_budget > 0.0f)
-        think_start_phase = imp::server::ThinkPhase::SCAN;  // model decides
-    else
-        think_start_phase = imp::server::ThinkPhase::CONTENT;  // no extraction
-    imp::server::StreamReasoningSplitter think_split(think_start_phase, snap_think_start_id,
-                                                     snap_think_end_id);
-    int n_reasoning_tokens = 0;
-
-    // Gemma-4 channel filter state: when we see <|channel> or <channel|>,
-    // skip tokens until the next newline (the channel header).
-    bool channel_header_active = false;
-
-    // Helper: emit reasoning_content SSE chunk
-    auto emit_reasoning = [&](const std::string& text) -> bool {
+    StreamLoopResult out;
+    StreamDialect dialect;
+    // Harmony reasoning is its own mechanism (not the deepseek <think> path), so
+    // it's gated on reasoning_format alone — emit reasoning_content unless the
+    // caller explicitly asked for none.
+    dialect.harmony_reasoning_on = (state.default_args.reasoning_format != "none");
+    dialect.emit_text = [&](const std::string& text) -> bool {
+        if (text.empty())
+            return true;
+        return sse_writer.write_content(text, sink);
+    };
+    dialect.emit_reasoning = [&](const std::string& text) -> bool {
         if (text.empty())
             return true;
         return sse_writer.write_reasoning(text, sink);
     };
-
-    // gpt-oss Harmony streaming filter. The model emits
-    //   <|channel|>analysis<|message|>…<|end|><|start|>assistant<|channel|>final<|message|>…
-    // Route analysis/commentary channels to reasoning_content and the final
-    // channel to content, stripping the control markers (which arrive as atomic
-    // special-token pieces) and the <|start|>role plumbing. hm_buf holds the
-    // current channel's bytes so a token that splits a multibyte char is not
-    // emitted mid-codepoint (#760).
-    const bool harmony = (tpl_family == imp::ChatTemplateFamily::HARMONY);
-    // Harmony reasoning is its own mechanism (not the deepseek <think> path), so
-    // it's gated on reasoning_format alone — emit reasoning_content unless the
-    // caller explicitly asked for none.
-    const bool hm_reasoning_on = (state.default_args.reasoning_format != "none");
-    std::string hm_channel, hm_name, hm_buf;
-    bool hm_in_msg = false, hm_reading_name = false;
-    auto hm_flush = [&](bool force) -> bool {
-        size_t complete = force ? hm_buf.size() : utf8_complete_len(hm_buf);
-        if (complete == 0)
-            return true;
-        std::string chunk = hm_buf.substr(0, complete);
-        hm_buf.erase(0, complete);
-        if (hm_channel == "analysis" || hm_channel == "commentary")
-            return hm_reasoning_on ? emit_reasoning(chunk) : true;
-        return sse_writer.write_content(chunk.data(), chunk.size(), sink);
-    };
-
-    // Helper: flush confirmed text up to a byte position
-    auto flush_text = [&](size_t up_to) {
-        up_to = std::min(up_to, pending_text.size());  // never read past the buffer
-        if (up_to == 0)
-            return true;
-        bool ok = sse_writer.write_content(pending_text.data(), up_to, sink);
-        pending_text.erase(0, up_to);
-        return ok;
-    };
-
-    // Flush held content buffers before emitting a tool-call (or directly
-    // emitted text) SSE frame, so stream order is preserved. A complete stop
-    // match cannot be pending here: the normal emission path checks after
-    // every append with the same holdback decision.
-    auto flush_buffered_content = [&]() -> bool {
-        if (stop_sequences.empty()) {
-            size_t complete = utf8_complete_len(utf8_buf);
-            if (complete > 0) {
-                if (!sse_writer.write_content(utf8_buf.data(), complete, sink))
-                    return false;
-                utf8_buf.erase(0, complete);
+    dialect.emit_content_token = [&](const std::string& text) -> bool {
+        if (req_logprobs && active_req) {
+            // Logprobs path: fall back to sse_chunk (rare)
+            json content_delta = {{"content", text}};
+            json lp_chunk = nullptr;
+            size_t lp_idx = static_cast<size_t>(out.n_output_tokens) - 1;
+            if (lp_idx < active_req->output_logprobs.size()) {
+                const auto& lp = active_req->output_logprobs[lp_idx];
+                json top_arr = json::array();
+                for (const auto& t : lp.top) {
+                    top_arr.push_back({{"token", safe_token_json(t.text)},
+                                       {"logprob", t.logprob},
+                                       {"bytes", token_bytes_json(t.text)}});
+                }
+                lp_chunk = {
+                    {"content", json::array({{{"token", safe_token_json(lp.text)},
+                                              {"logprob", lp.logprob},
+                                              {"bytes", token_bytes_json(lp.text)},
+                                              {"top_logprobs", top_arr}}})}};
             }
-        } else if (!pending_text.empty()) {
-            auto d = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
-            if (!flush_text(d.flush_len))
-                return false;
+            std::string sse = sse_chunk(comp_id, created, snap_model_name, content_delta,
+                                        nullptr, lp_chunk);
+            return sink.write(sse.data(), sse.size());
+        }
+        // Fast path: pre-formatted template
+        return sse_writer.write_content(text, sink);
+    };
+    dialect.keepalive = [&]() -> bool {
+        // SSE comment lines are spec-compliant and ignored by SSE parsers.
+        static constexpr char kKeepalive[] = ": keepalive\n\n";
+        return sink.write(kKeepalive, sizeof(kKeepalive) - 1);
+    };
+    dialect.on_call_begin = [&](const ParsedToolCall& tc) -> bool {
+        int idx = static_cast<int>(out.tool_calls.size()) - 1;
+        json name_delta = {
+            {"tool_calls",
+             json::array({{{"index", idx},
+                           {"id", tc.id},
+                           {"type", "function"},
+                           {"function", {{"name", tc.name}, {"arguments", ""}}}}})}};
+        std::string sse = sse_chunk(comp_id, created, snap_model_name, name_delta, nullptr);
+        sink.write(sse.data(), sse.size());
+        return true;
+    };
+    dialect.on_call_args_delta = [&](const std::string& partial) -> bool {
+        int idx = static_cast<int>(out.tool_calls.size()) - 1;
+        json args_delta = {
+            {"tool_calls",
+             json::array({{{"index", idx}, {"function", {{"arguments", partial}}}}})}};
+        std::string sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
+        sink.write(sse.data(), sse.size());
+        return true;
+    };
+    dialect.on_call_end = [&](ParsedToolCall*) -> bool {
+        // Deltas already on the wire; arguments recorded by the driver.
+        return true;
+    };
+    dialect.on_call_buffered = [&](ParsedToolCall& tc) -> bool {
+        // Buffered call (non-JSON layouts): emit the name chunk + arguments in
+        // bounded deltas.
+        int idx = static_cast<int>(out.tool_calls.size()) - 1;
+        json name_delta = {
+            {"tool_calls",
+             json::array({{{"index", idx},
+                           {"id", tc.id},
+                           {"type", "function"},
+                           {"function", {{"name", tc.name}, {"arguments", ""}}}}})}};
+        std::string sse = sse_chunk(comp_id, created, snap_model_name, name_delta, nullptr);
+        sink.write(sse.data(), sse.size());
+
+        constexpr size_t kArgChunk = 48;
+        const std::string& full_args = tc.arguments;
+        if (full_args.empty()) {
+            json args_delta = {
+                {"tool_calls",
+                 json::array({{{"index", idx}, {"function", {{"arguments", ""}}}}})}};
+            sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
+            sink.write(sse.data(), sse.size());
+        }
+        for (size_t aoff = 0; aoff < full_args.size(); aoff += kArgChunk) {
+            size_t an = std::min(kArgChunk, full_args.size() - aoff);
+            json args_delta = {
+                {"tool_calls",
+                 json::array({{{"index", idx},
+                               {"function", {{"arguments", full_args.substr(aoff, an)}}}}})}};
+            sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
+            sink.write(sse.data(), sse.size());
         }
         return true;
     };
 
-    auto request_start = std::chrono::steady_clock::now();
-    auto last_keepalive = request_start;
-    for (;;) {
-        // Terminate as soon as a finish reason has been recorded. The is_last
-        // token sets `finish` and then falls through to the per-token
-        // post-processing below, where a think/reasoning/channel `continue`
-        // can skip the trailing `if (finish) break`. Re-checking here means the
-        // stream always ends (and the terminal SSE frame is emitted) even when
-        // the final token is swallowed by one of those paths (#755/#757).
-        if (finish)
-            break;
+    if (!run_stream_loop_(sink, ctx, state, server_req, dialect, out))
+        return false;
 
-        // Check client disconnect
-        if (!sink.is_writable()) {
-            server_req->cancel();
-            state.metrics.requests_cancelled++;
-            finish = "cancelled";
-            break;
-        }
-
-        // Check request timeout
-        if (state.request_timeout > 0) {
-            auto elapsed = std::chrono::steady_clock::now() - request_start;
-            if (elapsed > std::chrono::seconds(state.request_timeout)) {
-                server_req->cancel();
-                finish = "length";
-                break;
-            }
-        }
-
-        // Read next token from the batching engine (with timeout)
-        TokenEvent evt{};
-        if (!server_req->pop_token(evt)) {
-            // No token ready yet (long prefill / queued behind other work).
-            // Emit an SSE comment as keepalive every ~10s so reverse proxies
-            // and SDK idle-timeouts don't kill the connection; comment lines
-            // are spec-compliant and ignored by SSE parsers.
-            auto now = std::chrono::steady_clock::now();
-            if (now - last_keepalive > std::chrono::seconds(10)) {
-                last_keepalive = now;
-                static constexpr char kKeepalive[] = ": keepalive\n\n";
-                sink.write(kKeepalive, sizeof(kKeepalive) - 1);
-            }
-            continue;  // timeout — loop back to check disconnect/timeout
-        }
-
-        if (evt.token_id < 0) {
-            // Finish event with no token
-            finish = evt.finish_reason ? evt.finish_reason : "stop";
-            break;
-        }
-
-        int32_t token = evt.token_id;
-
-        // Silently drop structural stop tokens that slipped through.
-        // The engine's think-block implicit-close (Engine::should_stop)
-        // passes ONE EOS-like token through to recover from empty
-        // thinking. That token must not appear as user-visible content
-        // (would render as "<|im_end|>" / "<|endoftext|>" in chat).
-        if (!evt.is_last) {
-            bool is_structural_stop = (token == snap_tok->eos_id());
-            if (!is_structural_stop && snap_have_template) {
-                for (int32_t stop_id : snap_stop_token_ids) {
-                    if (token == stop_id) {
-                        is_structural_stop = true;
-                        break;
-                    }
-                }
-            }
-            if (is_structural_stop)
-                continue;
-        }
-
-        // Check stop conditions (EOS/stop tokens already detected by engine)
-        if (evt.is_last) {
-            // The engine marked this as the last token.
-            // Don't emit EOS/stop tokens — they're structural, not content.
-            if (token == snap_tok->eos_id()) {
-                finish = evt.finish_reason ? evt.finish_reason : "stop";
-                break;
-            }
-            bool is_stop = false;
-            if (snap_have_template) {
-                for (int32_t stop_id : snap_stop_token_ids) {
-                    if (token == stop_id) {
-                        is_stop = true;
-                        break;
-                    }
-                }
-            }
-            if (is_stop) {
-                finish = evt.finish_reason ? evt.finish_reason : "stop";
-                break;
-            }
-            // Not a stop token — emit it, then finish after this iteration
-            finish = evt.finish_reason ? evt.finish_reason : "length";
-        }
-
-        n_output_tokens++;
-        if (n_output_tokens == 1) {
-            auto t_first = std::chrono::high_resolution_clock::now();
-            ttft_ms = std::chrono::duration<double, std::milli>(t_first - t_start).count();
-        }
-        std::string piece = snap_tok->decode_token(token);
-
-        // gpt-oss Harmony channel routing (analysis/commentary -> reasoning,
-        // final -> content). Markers arrive as atomic special-token pieces.
-        if (harmony) {
-            if (piece == "<|channel|>" || piece == "<|message|>" || piece == "<|end|>" ||
-                piece == "<|return|>" || piece == "<|start|>") {
-                if (hm_in_msg && !hm_flush(/*force=*/true))
-                    return false;
-                if (piece == "<|channel|>") {
-                    hm_reading_name = true;
-                    hm_in_msg = false;
-                    hm_name.clear();
-                } else if (piece == "<|message|>") {
-                    size_t s = hm_name.find_first_not_of("\n\r\t ");
-                    size_t e = hm_name.find_last_not_of("\n\r\t ");
-                    hm_channel = (s == std::string::npos) ? std::string() : hm_name.substr(s, e - s + 1);
-                    hm_reading_name = false;
-                    hm_in_msg = true;
-                } else {  // <|end|> / <|return|> / <|start|>: close the block
-                    hm_in_msg = false;
-                    hm_reading_name = false;
-                    hm_channel.clear();
-                }
-                continue;
-            }
-            if (hm_reading_name) {  // channel name between <|channel|> and <|message|>
-                hm_name += piece;
-                continue;
-            }
-            if (!hm_in_msg)  // role text / inter-block plumbing
-                continue;
-            hm_buf += piece;
-            if (!hm_flush(/*force=*/false))
-                return false;
-            continue;
-        }
-
-        // Gemma-4 channel filter: strip "<|channel>NAME\n" structural
-        // headers from the content stream. `<channel|>` is the
-        // channel-switch marker — strip the token but do NOT enter
-        // the scan-until-newline mode, because Q5_K_M sometimes
-        // emits the final answer directly after it with no newline
-        // (observed: "<|channel>thought\n<channel|>5 + 3 = 8").
-        if (snap_channel_open_id >= 0) {
-            if (channel_header_active) {
-                if (token == snap_channel_newline_id ||
-                    (!piece.empty() && piece.back() == '\n')) {
-                    channel_header_active = false;
-                }
-                continue;
-            }
-            if (token == snap_channel_open_id) {
-                channel_header_active = true;
-                continue;
-            }
-            if (token == snap_channel_close_id) {
-                // Drop just the marker; the next token is body.
-                continue;
-            }
-        }
-
-        // Reasoning/content demux (DeepSeek <think>) — shared, fixed state
-        // machine in reasoning_split.h. Routes reasoning to reasoning_content
-        // and hands back the user-visible content for this step (empty when the
-        // whole piece was reasoning or is being held for boundary detection).
-        if (think_active) {
-            auto rs = think_split.feed(std::move(piece), token);
-            n_reasoning_tokens += rs.reasoning_tokens;
-            if (!rs.reasoning.empty() && !emit_reasoning(rs.reasoning))
-                return false;
-            if (rs.content.empty())
-                continue;
-            piece = std::move(rs.content);
-        }
-
-        // Streaming tool-call demux (only when tools are present): the filter
-        // returns the user-visible content and any completed tool calls, in
-        // stream order. Content before/between calls is emitted directly
-        // (matching the previous inline machine); trailing content after the
-        // last call falls through to the normal emission path below.
-        if (has_tools) {
-            full_output += piece;
-            auto segs = tool_filter.feed(std::move(piece));
-            piece.clear();
-            using SegKind = imp::server::StreamToolCallFilter::Segment::Kind;
-            for (size_t si = 0; si < segs.size(); ++si) {
-                auto& seg = segs[si];
-                if (seg.kind == SegKind::TEXT) {
-                    if (si + 1 == segs.size()) {
-                        piece = std::move(seg.text);  // trailing content
-                    } else {
-                        if (!flush_buffered_content())
-                            return false;
-                        json cd = {{"content", seg.text}};
-                        std::string sse = sse_chunk(comp_id, created, snap_model_name, cd, nullptr);
-                        sink.write(sse.data(), sse.size());
-                    }
-                    continue;
-                }
-                // parallel_tool_calls=false: stream at most one tool call.
-                // (For a streamed call the gate fires at CALL_BEGIN, so the
-                // later deltas/END of a suppressed call are skipped too.)
-                if (!ctx.params.parallel_tool_calls &&
-                    ((seg.kind == SegKind::CALL && !stream_tool_calls.empty()) ||
-                     (seg.kind == SegKind::CALL_BEGIN && !stream_tool_calls.empty()) ||
-                     (seg.kind != SegKind::CALL && stream_call_suppressed))) {
-                    if (seg.kind == SegKind::CALL_BEGIN)
-                        stream_call_suppressed = true;
-                    if (seg.kind == SegKind::CALL_END)
-                        stream_call_suppressed = false;
-                    continue;
-                }
-
-                if (seg.kind == SegKind::CALL_BEGIN) {
-                    // Streamed call opens: emit the name chunk now; the
-                    // argument bytes follow as CALL_ARGS_DELTA segments while
-                    // the model is still generating them (previously the
-                    // whole body was buffered until the close tag — 20-60 s
-                    // of zero SSE bytes on a big code edit).
-                    ParsedToolCall tc = std::move(seg.call);
-                    tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
-                    if (!flush_buffered_content())
-                        return false;
-                    int idx = static_cast<int>(stream_tool_calls.size());
-                    json name_delta = {
-                        {"tool_calls",
-                         json::array({{{"index", idx},
-                                       {"id", tc.id},
-                                       {"type", "function"},
-                                       {"function", {{"name", tc.name}, {"arguments", ""}}}}})}};
-                    std::string sse = sse_chunk(comp_id, created, snap_model_name, name_delta, nullptr);
-                    sink.write(sse.data(), sse.size());
-                    stream_tool_calls.push_back(std::move(tc));
-                    tool_calls_emitted = true;
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_ARGS_DELTA) {
-                    int idx = static_cast<int>(stream_tool_calls.size()) - 1;
-                    json args_delta = {
-                        {"tool_calls",
-                         json::array({{{"index", idx},
-                                       {"function", {{"arguments", seg.text}}}}})}};
-                    std::string sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
-                    sink.write(sse.data(), sse.size());
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_END) {
-                    // Deltas already on the wire — record the full arguments
-                    // for bookkeeping (request log / finish handling).
-                    if (!stream_tool_calls.empty())
-                        stream_tool_calls.back().arguments = std::move(seg.call.arguments);
-                    continue;
-                }
-
-                // SegKind::CALL — buffered call (non-JSON layouts): emit the
-                // name chunk + arguments in bounded deltas, as before.
-                ParsedToolCall tc = std::move(seg.call);
-                tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
-                if (!flush_buffered_content())
-                    return false;
-                int idx = static_cast<int>(stream_tool_calls.size());
-                json name_delta = {
-                    {"tool_calls",
-                     json::array({{{"index", idx},
-                                   {"id", tc.id},
-                                   {"type", "function"},
-                                   {"function", {{"name", tc.name}, {"arguments", ""}}}}})}};
-                std::string sse = sse_chunk(comp_id, created, snap_model_name, name_delta, nullptr);
-                sink.write(sse.data(), sse.size());
-
-                constexpr size_t kArgChunk = 48;
-                const std::string& full_args = tc.arguments;
-                if (full_args.empty()) {
-                    json args_delta = {
-                        {"tool_calls",
-                         json::array({{{"index", idx}, {"function", {{"arguments", ""}}}}})}};
-                    sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
-                    sink.write(sse.data(), sse.size());
-                }
-                for (size_t aoff = 0; aoff < full_args.size(); aoff += kArgChunk) {
-                    size_t an = std::min(kArgChunk, full_args.size() - aoff);
-                    json args_delta = {
-                        {"tool_calls",
-                         json::array({{{"index", idx},
-                                       {"function", {{"arguments", full_args.substr(aoff, an)}}}}})}};
-                    sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
-                    sink.write(sse.data(), sse.size());
-                }
-
-                stream_tool_calls.push_back(std::move(tc));
-                tool_calls_emitted = true;
-            }
-            if (piece.empty())
-                continue;
-        }
-
-        // Normal content emission (no tool tag detected)
-        if (stop_sequences.empty()) {
-            // No stop sequences: stream directly (with UTF-8 buffering)
-            utf8_buf += piece;
-            size_t complete = utf8_complete_len(utf8_buf);
-            if (complete > 0) {
-                if (req_logprobs && active_req) {
-                    // Logprobs path: fall back to sse_chunk (rare)
-                    std::string to_emit = utf8_buf.substr(0, complete);
-                    utf8_buf.erase(0, complete);
-                    json content_delta = {{"content", to_emit}};
-                    json lp_chunk = nullptr;
-                    size_t lp_idx = n_output_tokens - 1;
-                    if (lp_idx < active_req->output_logprobs.size()) {
-                        const auto& lp = active_req->output_logprobs[lp_idx];
-                        json top_arr = json::array();
-                        for (const auto& t : lp.top) {
-                            top_arr.push_back({{"token", safe_token_json(t.text)},
-                                               {"logprob", t.logprob},
-                                               {"bytes", token_bytes_json(t.text)}});
-                        }
-                        lp_chunk = {
-                            {"content", json::array({{{"token", safe_token_json(lp.text)},
-                                                      {"logprob", lp.logprob},
-                                                      {"bytes", token_bytes_json(lp.text)},
-                                                      {"top_logprobs", top_arr}}})}};
-                    }
-                    std::string chunk = sse_chunk(comp_id, created, snap_model_name,
-                                                  content_delta, nullptr, lp_chunk);
-                    if (!sink.write(chunk.data(), chunk.size()))
-                        return false;
-                } else {
-                    // Fast path: pre-formatted template
-                    if (!sse_writer.write_content(utf8_buf.data(), complete, sink))
-                        return false;
-                    utf8_buf.erase(0, complete);
-                }
-            }
-        } else {
-            // Buffer text and check for stop matches via the pure holdback
-            // pipeline (stream_pipeline.h). It returns the safe-to-emit prefix
-            // and whether a complete stop sequence is present.
-            pending_text += piece;
-            auto d = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
-            if (!flush_text(d.flush_len))
-                return false;
-            if (d.complete_match) {
-                text_stop_matched = true;
-                finish = "stop";
-                break;
-            }
-        }
-
-        // Break after processing the last non-EOS token from batching engine
-        if (finish)
-            break;
-    }
-
-    // Flush scan buffer if we never left SCAN phase (model didn't think)
-    // Harmony: flush the final channel's tail (the final block usually ends at
-    // EOS/<|return|> with no trailing <|end|>). The other buffers below stay
-    // empty for harmony, so they're no-ops.
-    if (harmony && !hm_buf.empty())
-        hm_flush(/*force=*/true);
-
-    // Flush the splitter's held tail at stream end: buffered reasoning ->
-    // reasoning_content, any held/undecided content -> the content flush below.
-    if (think_active) {
-        auto rs = think_split.finish();
-        if (!rs.reasoning.empty())
-            emit_reasoning(rs.reasoning);
-        if (!rs.content.empty())
-            utf8_buf += rs.content;
-    }
-
-    // If the model exhausted tokens while still reasoning and never
-    // produced content, emit a notice so the user sees something
-    // instead of a blank response. Only fire this when max_tokens
-    // was actually the cause (finish == "length") — a model that
-    // naturally hit EOS during thinking will already have its
-    // reasoning_content delivered, and the notice would be
-    // misleading ("increase max_tokens" doesn't help when the model
-    // chose to stop).
-    if (think_active && think_split.phase() == imp::server::ThinkPhase::REASONING &&
-        utf8_buf.empty() && pending_text.empty() && finish &&
-        std::strcmp(finish, "length") == 0) {
+    // If the model exhausted tokens while still reasoning and never produced
+    // content, emit a notice so the user sees something instead of a blank
+    // response (fires only when max_tokens was the cause — see the driver's
+    // reasoning_truncated contract).
+    if (out.reasoning_truncated) {
         std::string notice = "[Reasoning truncated — increase max_tokens for a complete answer]";
         sse_writer.write_content(notice, sink);
     }
 
-    // Handle incomplete tool call at end (max_tokens hit while in tag/body):
-    // release the held raw text as content, finish_reason stays "length".
-    if (has_tools && tool_filter.mid_tool() && !tool_calls_emitted) {
-        std::string leftover = tool_filter.finish();
-        if (!leftover.empty()) {
-            utf8_buf += leftover;
-        }
-    }
-    // A STREAMED call cut off mid-arguments: its name chunk + deltas are
-    // already on the wire (nothing restorable) — record what was streamed
-    // for bookkeeping; the client sees finish_reason=length below.
-    if (has_tools && tool_filter.call_open() && !stream_tool_calls.empty() &&
-        stream_tool_calls.back().arguments.empty()) {
-        stream_tool_calls.back().arguments = tool_filter.streamed_arguments();
-    }
-
-    // Flush any remaining UTF-8 buffer (only if no tool calls were emitted)
-    if (!utf8_buf.empty() && !text_stop_matched && !tool_calls_emitted) {
-        sse_writer.write_content(utf8_buf, sink);
-    }
-
-    // Flush any remaining buffered text (skip if text-level stop was matched)
-    if (!pending_text.empty() && !text_stop_matched && !tool_calls_emitted) {
-        sse_writer.write_content(pending_text, sink);
-    }
-
-    if (!finish) {
-        finish = tool_calls_emitted ? "tool_calls" : "length";
-    } else if (tool_calls_emitted && strcmp(finish, "stop") == 0) {
-        finish = "tool_calls";
-    }
-
     // Send final chunk with finish_reason
     json empty_delta = json::object();
-    std::string final_chunk = sse_chunk(comp_id, created, snap_model_name, empty_delta, finish);
+    std::string final_chunk = sse_chunk(comp_id, created, snap_model_name, empty_delta, out.finish);
     sink.write(final_chunk.data(), final_chunk.size());
 
     // Send usage chunk if requested
-    if (include_usage) {
+    if (ctx.params.include_usage) {
+        int n_prompt_tokens = ctx.snap.n_prompt_tokens;
         json usage = {{"prompt_tokens", n_prompt_tokens},
-                      {"completion_tokens", n_output_tokens},
-                      {"total_tokens", n_prompt_tokens + n_output_tokens}};
+                      {"completion_tokens", out.n_output_tokens},
+                      {"total_tokens", n_prompt_tokens + out.n_output_tokens}};
         // Report prefix cache hit (OpenAI-compatible prompt_tokens_details)
         if (active_req && (active_req->cached_tokens > 0 || active_req->pin_kv_prefix)) {
             json details = {{"cached_tokens", active_req->cached_tokens}};
@@ -664,8 +199,8 @@ bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
                 details["cache_creation_tokens"] = creation;
             usage["prompt_tokens_details"] = std::move(details);
         }
-        if (n_reasoning_tokens > 0) {
-            usage["completion_tokens_details"] = {{"reasoning_tokens", n_reasoning_tokens}};
+        if (out.n_reasoning_tokens > 0) {
+            usage["completion_tokens_details"] = {{"reasoning_tokens", out.n_reasoning_tokens}};
         }
         // Predicted Outputs accounting (mirrors the non-streaming path).
         if (active_req && !active_req->prediction_tokens.empty()) {
@@ -689,32 +224,6 @@ bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
     sink.write(done.data(), done.size());
     sink.done();
 
-    // Log request with TTFT and cache hit info
-    auto t_end = std::chrono::high_resolution_clock::now();
-    double ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-    int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
-    fprintf(stderr, "[%s] %d prompt + %d completion tokens, %.1f ms (ttft=%.1f ms, cached=%d)\n",
-            comp_id.c_str(), n_prompt_tokens, n_output_tokens, ms, ttft_ms, cached);
-    state.metrics.requests_total++;
-    state.metrics.tokens_prompt_total += n_prompt_tokens;
-    state.metrics.tokens_completion_total += n_output_tokens;
-    state.metrics.tokens_cached_total += cached;
-    state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
-    state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
-    state.metrics.request_duration.observe(ms / 1000.0);
-    if (n_output_tokens > 0)
-        state.metrics.ttft.observe(ttft_ms / 1000.0);
-    // Mean inter-token latency: post-first-token decode time spread over the
-    // remaining tokens. Streaming-only (non-stream has no per-token cadence).
-    if (n_output_tokens > 1)
-        state.metrics.inter_token.observe((ms - ttft_ms) / 1000.0 / (n_output_tokens - 1));
-
-    // Streaming response content is not accumulated across SSE
-    // chunks, so the JSONL `response` field stays null. The
-    // request body, token counts, finish reason, and latency
-    // still reflect everything the client did.
-    log_request_jsonl(state, log_skip, t_log_start, comp_id, log_endpoint, log_client_ip,
-                      log_raw_body, ms, n_prompt_tokens, n_output_tokens, finish, json());
-
+    finish_stream_accounting_(state, ctx, active_req, out, comp_id, "");
     return true;
 }

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -151,6 +151,15 @@ bool parse_chat_request_params(const httplib::Request& req, httplib::Response& r
                                ServerState& state, ChatRequestContext& ctx);
 bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state,
                                   ChatRequestContext& ctx);
+// Build an imp::Request from a parsed+snapshotted chat request context — the
+// single params->request mapping for all four ctx-based submission sites
+// (chat streaming + non-streaming, /v1/messages streaming, /v1/responses
+// streaming); this was hand-copied per site and drifted (#941).
+// completion_idx offsets the seed for n>1 choice generation; stream keeps the
+// request on per-step decode for real per-token SSE (#754).
+std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
+                                                 const std::vector<int32_t>& input_tokens,
+                                                 int completion_idx, bool stream);
 void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx,
                              std::shared_ptr<imp::Request>& imp_req,
                              std::shared_ptr<ServerRequest>& server_req,

--- a/tools/imp-server/handlers_messages.cpp
+++ b/tools/imp-server/handlers_messages.cpp
@@ -1,34 +1,21 @@
-// AUTO-SPLIT from handlers.cpp (verbatim move; see handlers_internal.h).
 // Anthropic /v1/messages: the handle_messages endpoint (bottom of file) plus
-// its streaming machinery — the AnthropicSSE event writer and
-// run_anthropic_stream_ (drives the real token loop, emits native Anthropic
-// SSE events).
+// its streaming machinery — the AnthropicSSE event writer and the Anthropic
+// dialect adapter for the shared token loop (stream_driver.h), which emits
+// native Anthropic SSE events.
 
 #include "handlers.h"
 #include "handlers_internal.h"
+#include "stream_driver.h"
 #include "utils.h"
 #include "tool_call.h"
-#include "tool_stream_filter.h"
 #include "anthropic.h"
-#include "stream_pipeline.h"
-#include "reasoning_split.h"
 
-#include "api/imp_internal.h"
-#include "vision/image_processor.h"
 #include "runtime/request.h"
-#include "memory/kv_cache.h"
-#include "model/hf_hub.h"
-#include "runtime/config.h"
 
 #include <chrono>
-#include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <filesystem>
-#include <functional>
-#include <vector>
-
-#include <cuda_runtime.h>
+#include <string>
 
 // ===========================================================================
 // Anthropic /v1/messages — native SSE streaming
@@ -36,8 +23,8 @@
 //
 // Non-streaming reuses the OpenAI code path (Anthropic→OpenAI body in,
 // OpenAI→Anthropic response out). Streaming drives the same real per-token
-// batching-engine loop the OpenAI streaming path uses (pop_token), but emits
-// native Anthropic SSE events incrementally so TTFT == real first-token
+// batching-engine loop the OpenAI streaming path uses (run_stream_loop_), but
+// emits native Anthropic SSE events incrementally so TTFT == real first-token
 // latency rather than full-generation latency.
 // ---------------------------------------------------------------------------
 
@@ -63,9 +50,7 @@ enum class AnthBlock { NONE, THINKING, TEXT, TOOL_USE };
 
 }  // anonymous namespace
 
-// Drives the real token loop and emits native Anthropic SSE events. Mirrors
-// the token-handling of run_chat_stream_ (reasoning extraction, channel
-// filter, tool-call tag state machine) but maps it onto Anthropic blocks:
+// Anthropic dialect adapter: maps the shared token loop onto Anthropic blocks:
 //   reasoning -> thinking block (thinking_delta)
 //   content   -> text block (text_delta)
 //   tool call -> tool_use block (input_json_delta, chunked)
@@ -73,28 +58,7 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
                                   const std::shared_ptr<ServerRequest>& server_req,
                                   const std::string& anth_model, const std::string& msg_id) {
     AnthropicSSE out{sink};
-
-    const auto& stop_sequences = ctx.params.stop_sequences;
-    // Derive from the FINAL stop list (server-injected stops update it late) —
-    // see the matching comment in the chat streaming path.
-    size_t max_stop_len = 0;
-    for (const auto& s : stop_sequences)
-        max_stop_len = std::max(max_stop_len, s.size());
-    bool enable_thinking = ctx.snap.enable_thinking;
-    bool has_tools = ctx.params.has_tools;
-    auto tpl_family = ctx.snap.tpl_family;
-    float think_budget = ctx.params.think_budget;
-    auto snap_tok = ctx.snap.tok;
-    bool snap_have_template = ctx.snap.have_template;
-    bool snap_is_think_model = ctx.snap.is_think_model;
-    int snap_think_start_id = ctx.snap.think_start_id;
-    int snap_think_end_id = ctx.snap.think_end_id;
-    int snap_channel_open_id = ctx.snap.channel_open_id;
-    int snap_channel_close_id = ctx.snap.channel_close_id;
-    int snap_channel_newline_id = ctx.snap.channel_newline_id;
-    const auto& snap_stop_token_ids = ctx.snap.stop_token_ids;
     auto active_req = server_req->request;
-    auto t_start = ctx.t_start;
     int n_prompt_tokens = ctx.snap.n_prompt_tokens;
 
     // ---- message_start ----------------------------------------------------
@@ -116,11 +80,10 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
     // ---- ping (initial keepalive) -----------------------------------------
     // Anthropic streams emit periodic `ping` events; sending one immediately
     // signals liveness before the first token (TTFT can be >1s under load /
-    // long prefills), and the loop below re-pings during idle gaps so clients
+    // long prefills), and the shared loop re-pings during idle gaps so clients
     // and intermediary proxies don't time out the connection.
     if (!out.emit("ping", json{{"type", "ping"}}))
         return false;
-    auto last_ping = std::chrono::steady_clock::now();
 
     int block_index = -1;
     AnthBlock open_block = AnthBlock::NONE;
@@ -177,23 +140,6 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
                              {"index", block_index},
                              {"delta", {{"type", "thinking_delta"}, {"thinking", text}}}});
     };
-
-    // gpt-oss Harmony streaming filter (analysis/commentary -> thinking block,
-    // final -> text block); markers arrive as atomic special-token pieces. See
-    // the matching filter in run_chat_stream_ (#760).
-    const bool harmony = (ctx.snap.tpl_family == imp::ChatTemplateFamily::HARMONY);
-    std::string hm_channel, hm_name, hm_buf;
-    bool hm_in_msg = false, hm_reading_name = false;
-    auto hm_flush = [&](bool force) -> bool {
-        size_t complete = force ? hm_buf.size() : utf8_complete_len(hm_buf);
-        if (complete == 0)
-            return true;
-        std::string chunk = hm_buf.substr(0, complete);
-        hm_buf.erase(0, complete);
-        if (hm_channel == "analysis" || hm_channel == "commentary")
-            return emit_thinking(chunk);
-        return emit_text(chunk);
-    };
     // Open a tool_use block (content_block_start). Arguments follow as
     // input_json_delta events — incrementally for streamed (JSON-layout)
     // calls, chunked-after-the-fact for buffered ones.
@@ -219,8 +165,38 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
                              {"delta",
                               {{"type", "input_json_delta"}, {"partial_json", partial}}}});
     };
-    // Buffered call path: open block + chunked arg deltas + close.
-    auto emit_tool_use = [&](const ParsedToolCall& tc) -> bool {
+
+    StreamLoopResult res;
+    StreamDialect dialect;
+    dialect.emit_text = emit_text;
+    dialect.emit_reasoning = emit_thinking;
+    dialect.emit_content_token = emit_text;
+    dialect.keepalive = [&]() -> bool { return out.emit("ping", json{{"type", "ping"}}); };
+    dialect.on_call_begin = [&](const ParsedToolCall& tc) -> bool {
+        // Streamed call: open the tool_use block now; the argument bytes
+        // follow as input_json_delta events while the model is still
+        // generating them.
+        return open_tool_use_block(tc);
+    };
+    dialect.on_call_args_delta = emit_tool_args_delta;
+    dialect.on_call_end = [&](ParsedToolCall* tc) -> bool {
+        if (tc) {
+            validate_tool_call(*tc, ctx.params.tools);
+            if (!tc->valid) {
+                fprintf(stderr, "[%s] tool-call arg validation failed: %s: %s\n",
+                        msg_id.c_str(), tc->name.c_str(), tc->error.c_str());
+            }
+        }
+        return stop_block();
+    };
+    dialect.on_call_buffered = [&](ParsedToolCall& tc) -> bool {
+        // Buffered call (non-JSON layouts): open block + chunked arg deltas +
+        // close.
+        validate_tool_call(tc, ctx.params.tools);
+        if (!tc.valid) {
+            fprintf(stderr, "[%s] tool-call arg validation failed: %s: %s\n",
+                    msg_id.c_str(), tc.name.c_str(), tc.error.c_str());
+        }
         if (!open_tool_use_block(tc))
             return false;
         const std::string& args = tc.arguments;
@@ -233,378 +209,29 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
         return stop_block();
     };
 
-    int n_output_tokens = 0;
-    const char* finish = nullptr;
-    double ttft_ms = 0.0;
-
-    std::string utf8_buf;        // confirmed-UTF8 content buffer
-    std::string pending_text;    // stop-sequence holdback
-    bool text_stop_matched = false;
-
-    // Streaming tool-call demux — same shared state machine as
-    // run_chat_stream_ (tool_stream_filter.h): ChatML/Llama3/Gemma-4 markers,
-    // JSON + Qwen3.6-XML + Gemma body parsing, raw-restore on failure.
-    imp::server::StreamToolCallFilter tool_filter(tpl_family);
-    std::vector<ParsedToolCall> stream_tool_calls;
-    bool tool_calls_emitted = false;
-    // parallel_tool_calls=false: a second streamed call was opened by the
-    // filter but is being suppressed (skip its deltas/END too).
-    bool stream_call_suppressed = false;
-
-    // Reasoning extraction (DeepSeek <think>). enable_thinking also covers
-    // text-level thinkers (Nemotron) — see the chat streaming path.
-    // Shared reasoning/content demux (reasoning_split.h) — identical to the
-    // OpenAI streaming path; emit_thinking is the Anthropic reasoning sink.
-    const bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
-                                (snap_is_think_model || enable_thinking));
-    const bool think_active = use_reasoning || enable_thinking;
-    imp::server::ThinkPhase think_start_phase;
-    if (enable_thinking)
-        think_start_phase = imp::server::ThinkPhase::REASONING;
-    else if (use_reasoning && think_budget > 0.0f)
-        think_start_phase = imp::server::ThinkPhase::SCAN;
-    else
-        think_start_phase = imp::server::ThinkPhase::CONTENT;
-    imp::server::StreamReasoningSplitter think_split(think_start_phase, snap_think_start_id,
-                                                     snap_think_end_id);
-    bool channel_header_active = false;
-
-    auto flush_text = [&](size_t up_to) -> bool {
-        if (up_to == 0)
-            return true;
-        bool ok = emit_text(pending_text.substr(0, up_to));
-        pending_text.erase(0, up_to);
-        return ok;
-    };
-
-    // Flush held content buffers before a tool_use block (or directly emitted
-    // text) so block order matches the model's output order. A complete stop
-    // match cannot be pending here — the normal emission path checks after
-    // every append with the same holdback decision.
-    auto flush_buffered_content = [&]() -> bool {
-        if (stop_sequences.empty()) {
-            size_t complete = utf8_complete_len(utf8_buf);
-            if (complete > 0) {
-                if (!emit_text(utf8_buf.substr(0, complete)))
-                    return false;
-                utf8_buf.erase(0, complete);
-            }
-        } else if (!pending_text.empty()) {
-            auto d = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
-            if (!flush_text(d.flush_len))
-                return false;
-        }
-        return true;
-    };
-
-    auto request_start = std::chrono::steady_clock::now();
-    for (;;) {
-        // #755: when a thinking model exhausts its token budget the final
-        // (is_last) token lands inside the REASONING phase, which `continue`s
-        // and skips the trailing `if (finish) break`. The loop would then spin
-        // on pop_token forever — message_delta/message_stop never emitted, so
-        // the Anthropic client (SDK or curl -N) hangs indefinitely. Breaking
-        // here guarantees the terminal events are always sent.
-        if (finish)
-            break;
-
-        if (!sink.is_writable()) {
-            server_req->cancel();
-            state.metrics.requests_cancelled++;
-            finish = "cancelled";
-            break;
-        }
-        if (state.request_timeout > 0) {
-            auto elapsed = std::chrono::steady_clock::now() - request_start;
-            if (elapsed > std::chrono::seconds(state.request_timeout)) {
-                server_req->cancel();
-                finish = "length";
-                break;
-            }
-        }
-
-        TokenEvent evt{};
-        if (!server_req->pop_token(evt)) {
-            // No token ready yet (prefill / generation gap). Re-ping at most
-            // every ~10s so idle streams stay alive without spamming.
-            auto now = std::chrono::steady_clock::now();
-            if (now - last_ping > std::chrono::seconds(10)) {
-                last_ping = now;
-                if (!out.emit("ping", json{{"type", "ping"}}))
-                    break;
-            }
-            continue;
-        }
-
-        if (evt.token_id < 0) {
-            finish = evt.finish_reason ? evt.finish_reason : "stop";
-            break;
-        }
-        int32_t token = evt.token_id;
-
-        if (!evt.is_last) {
-            bool is_structural_stop = (token == snap_tok->eos_id());
-            if (!is_structural_stop && snap_have_template) {
-                for (int32_t stop_id : snap_stop_token_ids)
-                    if (token == stop_id) {
-                        is_structural_stop = true;
-                        break;
-                    }
-            }
-            if (is_structural_stop)
-                continue;
-        }
-        if (evt.is_last) {
-            if (token == snap_tok->eos_id()) {
-                finish = evt.finish_reason ? evt.finish_reason : "stop";
-                break;
-            }
-            bool is_stop = false;
-            if (snap_have_template) {
-                for (int32_t stop_id : snap_stop_token_ids)
-                    if (token == stop_id) {
-                        is_stop = true;
-                        break;
-                    }
-            }
-            if (is_stop) {
-                finish = evt.finish_reason ? evt.finish_reason : "stop";
-                break;
-            }
-            finish = evt.finish_reason ? evt.finish_reason : "length";
-        }
-
-        n_output_tokens++;
-        if (n_output_tokens == 1)
-            ttft_ms = std::chrono::duration<double, std::milli>(
-                          std::chrono::high_resolution_clock::now() - t_start)
-                          .count();
-        std::string piece = snap_tok->decode_token(token);
-
-        // gpt-oss Harmony channel routing (analysis/commentary -> thinking,
-        // final -> text). Markers arrive as atomic special-token pieces.
-        if (harmony) {
-            if (piece == "<|channel|>" || piece == "<|message|>" || piece == "<|end|>" ||
-                piece == "<|return|>" || piece == "<|start|>") {
-                if (hm_in_msg && !hm_flush(/*force=*/true))
-                    return false;
-                if (piece == "<|channel|>") {
-                    hm_reading_name = true;
-                    hm_in_msg = false;
-                    hm_name.clear();
-                } else if (piece == "<|message|>") {
-                    size_t s = hm_name.find_first_not_of("\n\r\t ");
-                    size_t e = hm_name.find_last_not_of("\n\r\t ");
-                    hm_channel = (s == std::string::npos) ? std::string() : hm_name.substr(s, e - s + 1);
-                    hm_reading_name = false;
-                    hm_in_msg = true;
-                } else {
-                    hm_in_msg = false;
-                    hm_reading_name = false;
-                    hm_channel.clear();
-                }
-                continue;
-            }
-            if (hm_reading_name) {
-                hm_name += piece;
-                continue;
-            }
-            if (!hm_in_msg)
-                continue;
-            hm_buf += piece;
-            if (!hm_flush(/*force=*/false))
-                return false;
-            continue;
-        }
-
-        // Gemma-4 channel filter.
-        if (snap_channel_open_id >= 0) {
-            if (channel_header_active) {
-                if (token == snap_channel_newline_id || (!piece.empty() && piece.back() == '\n'))
-                    channel_header_active = false;
-                continue;
-            }
-            if (token == snap_channel_open_id) {
-                channel_header_active = true;
-                continue;
-            }
-            if (token == snap_channel_close_id)
-                continue;
-        }
-
-        // Reasoning extraction.
-        // Reasoning/content demux (reasoning_split.h) — shared with the OpenAI
-        // streaming path. Reasoning goes to the Anthropic thinking sink.
-        if (think_active) {
-            auto rs = think_split.feed(std::move(piece), token);
-            if (!rs.reasoning.empty() && !emit_thinking(rs.reasoning))
-                return false;
-            if (rs.content.empty())
-                continue;
-            piece = std::move(rs.content);
-        }
-
-        // Streaming tool-call demux (see the matching block in
-        // run_chat_stream_): completed calls become tool_use blocks; content
-        // before/between calls is emitted directly; trailing content after
-        // the last call falls through to the normal emission path below.
-        if (has_tools) {
-            auto segs = tool_filter.feed(std::move(piece));
-            piece.clear();
-            using SegKind = imp::server::StreamToolCallFilter::Segment::Kind;
-            for (size_t si = 0; si < segs.size(); ++si) {
-                auto& seg = segs[si];
-                if (seg.kind == SegKind::TEXT) {
-                    if (si + 1 == segs.size()) {
-                        piece = std::move(seg.text);  // trailing content
-                    } else {
-                        if (!flush_buffered_content())
-                            return false;
-                        if (!emit_text(seg.text))
-                            return false;
-                    }
-                    continue;
-                }
-                // parallel_tool_calls=false: stream at most one tool call.
-                // (For a streamed call the gate fires at CALL_BEGIN, so the
-                // later deltas/END of a suppressed call are skipped too.)
-                if (!ctx.params.parallel_tool_calls &&
-                    ((seg.kind == SegKind::CALL && !stream_tool_calls.empty()) ||
-                     (seg.kind == SegKind::CALL_BEGIN && !stream_tool_calls.empty()) ||
-                     (seg.kind != SegKind::CALL && stream_call_suppressed))) {
-                    if (seg.kind == SegKind::CALL_BEGIN)
-                        stream_call_suppressed = true;
-                    if (seg.kind == SegKind::CALL_END)
-                        stream_call_suppressed = false;
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_BEGIN) {
-                    // Streamed call: open the tool_use block now; the
-                    // argument bytes follow as input_json_delta events while
-                    // the model is still generating them.
-                    ParsedToolCall tc = std::move(seg.call);
-                    tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
-                    if (!flush_buffered_content())
-                        return false;
-                    if (!open_tool_use_block(tc))
-                        return false;
-                    stream_tool_calls.push_back(std::move(tc));
-                    tool_calls_emitted = true;
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_ARGS_DELTA) {
-                    if (!emit_tool_args_delta(seg.text))
-                        return false;
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_END) {
-                    if (!stream_tool_calls.empty()) {
-                        stream_tool_calls.back().arguments = std::move(seg.call.arguments);
-                        validate_tool_call(stream_tool_calls.back(), ctx.params.tools);
-                        if (!stream_tool_calls.back().valid) {
-                            fprintf(stderr, "[%s] tool-call arg validation failed: %s: %s\n",
-                                    msg_id.c_str(), stream_tool_calls.back().name.c_str(),
-                                    stream_tool_calls.back().error.c_str());
-                        }
-                    }
-                    if (!stop_block())
-                        return false;
-                    continue;
-                }
-                // SegKind::CALL — buffered call (non-JSON layouts).
-                ParsedToolCall tc = std::move(seg.call);
-                tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
-                validate_tool_call(tc, ctx.params.tools);
-                if (!tc.valid) {
-                    fprintf(stderr, "[%s] tool-call arg validation failed: %s: %s\n",
-                            msg_id.c_str(), tc.name.c_str(), tc.error.c_str());
-                }
-                if (!flush_buffered_content())
-                    return false;
-                if (!emit_tool_use(tc))
-                    return false;
-                stream_tool_calls.push_back(std::move(tc));
-                tool_calls_emitted = true;
-            }
-            if (piece.empty())
-                continue;
-        }
-
-        // Normal content emission.
-        if (stop_sequences.empty()) {
-            utf8_buf += piece;
-            size_t complete = utf8_complete_len(utf8_buf);
-            if (complete > 0) {
-                if (!emit_text(utf8_buf.substr(0, complete)))
-                    return false;
-                utf8_buf.erase(0, complete);
-            }
-        } else {
-            pending_text += piece;
-            auto d = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
-            if (!flush_text(d.flush_len))
-                return false;
-            if (d.complete_match) {
-                text_stop_matched = true;
-                finish = "stop";
-                break;
-            }
-        }
-
-        if (finish)
-            break;
-    }
-
-    // Flush trailing buffers.
-    // Harmony: flush the final channel's tail (ends at EOS/<|return|> with no
-    // trailing <|end|>); the other buffers below stay empty for harmony.
-    if (harmony && !hm_buf.empty())
-        hm_flush(/*force=*/true);
-
-    // Flush the splitter's held tail: buffered reasoning -> thinking sink,
-    // held/undecided content -> the content flush below.
-    if (think_active) {
-        auto rs = think_split.finish();
-        if (!rs.reasoning.empty())
-            emit_thinking(rs.reasoning);
-        if (!rs.content.empty())
-            utf8_buf += rs.content;
-    }
-    if (has_tools && tool_filter.mid_tool() && !tool_calls_emitted) {
-        std::string leftover = tool_filter.finish();
-        if (!leftover.empty())
-            utf8_buf += leftover;
-    }
-    if (!utf8_buf.empty() && !text_stop_matched && !tool_calls_emitted)
-        emit_text(utf8_buf);
-    if (!pending_text.empty() && !text_stop_matched && !tool_calls_emitted)
-        emit_text(pending_text);
+    if (!run_stream_loop_(sink, ctx, state, server_req, dialect, res))
+        return false;
 
     // Close any block still open.
     stop_block();
 
-    if (!finish)
-        finish = tool_calls_emitted ? "tool_calls" : "length";
-    else if (tool_calls_emitted && strcmp(finish, "stop") == 0)
-        finish = "tool_calls";
-
     // Map finish_reason -> Anthropic stop_reason.
     std::string stop_reason;
-    if (strcmp(finish, "stop") == 0)
+    if (strcmp(res.finish, "stop") == 0)
         stop_reason = "end_turn";
-    else if (strcmp(finish, "length") == 0)
+    else if (strcmp(res.finish, "length") == 0)
         stop_reason = "max_tokens";
-    else if (strcmp(finish, "tool_calls") == 0)
+    else if (strcmp(res.finish, "tool_calls") == 0)
         stop_reason = "tool_use";
-    else if (strcmp(finish, "cancelled") == 0)
+    else if (strcmp(res.finish, "cancelled") == 0)
         stop_reason = "end_turn";
     else
-        stop_reason = finish;
+        stop_reason = res.finish;
 
     // ---- message_delta + message_stop ------------------------------------
     // Cache accounting is only known after prefill ran, so it rides on the
     // final usage update instead of message_start.
-    json delta_usage = {{"output_tokens", n_output_tokens}};
+    json delta_usage = {{"output_tokens", res.n_output_tokens}};
     {
         int cached_now = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
         int creation = cache_creation_tokens_(active_req, n_prompt_tokens);
@@ -621,23 +248,7 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
     out.emit("message_stop", json{{"type", "message_stop"}});
     sink.done();
 
-    // Metrics + log.
-    auto t_end = std::chrono::high_resolution_clock::now();
-    double ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-    int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
-    state.metrics.requests_total++;
-    state.metrics.tokens_prompt_total += n_prompt_tokens;
-    state.metrics.tokens_completion_total += n_output_tokens;
-    state.metrics.tokens_cached_total += cached;
-    state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
-    state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
-    state.metrics.request_duration.observe(ms / 1000.0);
-    if (n_output_tokens > 0)
-        state.metrics.ttft.observe(ttft_ms / 1000.0);
-    log_request_jsonl(state, ctx.log_skip, ctx.t_log_start, msg_id, ctx.log_endpoint, ctx.log_client_ip,
-                      ctx.log_raw_body, ms, n_prompt_tokens, n_output_tokens, finish, json());
-    fprintf(stderr, "[%s] messages stream: %d prompt + %d completion tokens, %.1f ms (ttft=%.1f ms)\n",
-            msg_id.c_str(), n_prompt_tokens, n_output_tokens, ms, ttft_ms);
+    finish_stream_accounting_(state, ctx, active_req, res, msg_id, "messages stream: ");
     return true;
 }
 
@@ -763,42 +374,10 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
         ctx.log_raw_body = log_raw_body;
         ctx.t_log_start = t_log_start;
 
-        // Vision is per-request now (req->image) and streams like any request.
-        auto imp_req = std::make_shared<imp::Request>();
-        imp_req->image = ctx.snap.vision_image;  // per-request vision (null for text)
-        imp_req->input_tokens = ctx.snap.tokens;
-        imp_req->max_tokens = ctx.params.max_tokens;
-        imp_req->temperature = ctx.params.temperature;
-        imp_req->top_p = ctx.params.top_p;
-        imp_req->top_k = ctx.params.top_k;
-        imp_req->seed = ctx.params.seed;
-        imp_req->pin_kv_prefix = ctx.params.cache_prompt;
-        imp_req->spec_ngram_override = ctx.params.spec_ngram_override;
         // This is the streaming /v1/messages path — stay on per-step decode so
         // SSE is real per-token rather than one burst at generation end (#754).
-        imp_req->stream = true;
-        imp_req->min_p = ctx.params.min_p;
-        imp_req->typical_p = ctx.params.typical_p;
-        imp_req->repetition_penalty = ctx.params.repetition_penalty;
-        imp_req->frequency_penalty = ctx.params.frequency_penalty;
-        imp_req->presence_penalty = ctx.params.presence_penalty;
-        imp_req->repeat_last_n = ctx.params.repeat_last_n;
-        imp_req->dry_multiplier = ctx.params.dry_multiplier;
-        imp_req->dry_base = ctx.params.dry_base;
-        imp_req->dry_allowed_length = ctx.params.dry_allowed_length;
-        imp_req->dry_penalty_last_n = ctx.params.dry_penalty_last_n;
-        imp_req->mirostat = ctx.params.mirostat;
-        imp_req->mirostat_tau = ctx.params.mirostat_tau;
-        imp_req->mirostat_eta = ctx.params.mirostat_eta;
-        imp_req->logprobs = ctx.params.req_logprobs;
-        imp_req->top_logprobs = ctx.params.top_logprobs;
-        imp_req->json_mode = ctx.params.json_mode;
-        imp_req->json_schema = ctx.params.json_schema_str;
-        imp_req->has_tools = ctx.params.has_tools;
-        imp_req->tpl_family = ctx.snap.tpl_family;
-        imp_req->logit_bias = ctx.params.logit_bias;
-        imp_req->think_budget = ctx.params.think_budget;
-        imp_req->status = imp::RequestStatus::PENDING;
+        auto imp_req = build_imp_request_(ctx, ctx.snap.tokens, /*completion_idx=*/0,
+                                          /*stream=*/true);
 
         auto server_req = std::make_shared<ServerRequest>();
         server_req->request = imp_req;

--- a/tools/imp-server/handlers_responses.cpp
+++ b/tools/imp-server/handlers_responses.cpp
@@ -1,8 +1,8 @@
 // OpenAI Responses API (/v1/responses) — the dialect the OpenAI Agents SDK
 // and Codex CLI speak by default. Non-streaming reuses the chat-completions
 // code path via the transform shim (responses.h, same pattern as the
-// Anthropic adapter); streaming drives the same real per-token batching-
-// engine loop the other SSE paths use and emits native Responses events
+// Anthropic adapter); streaming drives the shared token loop
+// (stream_driver.h) and emits native Responses events
 // (response.created … response.output_text.delta …
 // response.function_call_arguments.delta … response.completed) so TTFT is
 // real first-token latency and tool-call arguments stream incrementally
@@ -10,23 +10,18 @@
 
 #include "handlers.h"
 #include "handlers_internal.h"
+#include "stream_driver.h"
 #include "utils.h"
 #include "tool_call.h"
-#include "tool_stream_filter.h"
 #include "responses.h"
-#include "stream_pipeline.h"
-#include "reasoning_split.h"
 
-#include "api/imp_internal.h"
 #include "runtime/request.h"
-#include "runtime/config.h"
 
 #include <chrono>
 #include <cstdio>
 #include <ctime>
 #include <cstring>
-#include <functional>
-#include <vector>
+#include <string>
 
 namespace rsp = imp_server::responses;
 
@@ -65,9 +60,8 @@ json response_skeleton(const std::string& response_id, const std::string& model,
 
 }  // anonymous namespace
 
-// Drives the real token loop and emits native Responses SSE events. Mirrors
-// run_anthropic_stream_ (handlers_messages.cpp) with the Anthropic block
-// model replaced by Responses output items:
+// Responses dialect adapter: maps the shared token loop onto Responses output
+// items:
 //   reasoning -> reasoning item (reasoning_summary_text.delta)
 //   content   -> message item (output_text.delta)
 //   tool call -> function_call item (function_call_arguments.delta,
@@ -78,26 +72,7 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
                                   const std::string& req_model,
                                   const std::string& response_id) {
     ResponsesSSE out{sink};
-
-    const auto& stop_sequences = ctx.params.stop_sequences;
-    size_t max_stop_len = 0;
-    for (const auto& s : stop_sequences)
-        max_stop_len = std::max(max_stop_len, s.size());
-    bool enable_thinking = ctx.snap.enable_thinking;
-    bool has_tools = ctx.params.has_tools;
-    auto tpl_family = ctx.snap.tpl_family;
-    float think_budget = ctx.params.think_budget;
-    auto snap_tok = ctx.snap.tok;
-    bool snap_have_template = ctx.snap.have_template;
-    bool snap_is_think_model = ctx.snap.is_think_model;
-    int snap_think_start_id = ctx.snap.think_start_id;
-    int snap_think_end_id = ctx.snap.think_end_id;
-    int snap_channel_open_id = ctx.snap.channel_open_id;
-    int snap_channel_close_id = ctx.snap.channel_close_id;
-    int snap_channel_newline_id = ctx.snap.channel_newline_id;
-    const auto& snap_stop_token_ids = ctx.snap.stop_token_ids;
     auto active_req = server_req->request;
-    auto t_start = ctx.t_start;
     int n_prompt_tokens = ctx.snap.n_prompt_tokens;
 
     const std::string model_name = req_model.empty() ? ctx.snap.model_name : req_model;
@@ -115,9 +90,12 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
     uint64_t item_counter = 0;
     std::string cur_item_id;
 
+    // Loop result — declared before the item lambdas so stop_item can read the
+    // current tool call (the driver appends to lres.tool_calls live).
+    StreamLoopResult lres;
+
     // Accumulators for the final `response` object.
     std::string acc_text, acc_reasoning;
-    std::vector<ParsedToolCall> stream_tool_calls;
     json final_output = json::array();
 
     auto stop_item = [&]() -> bool {
@@ -161,7 +139,7 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
                                 json{{"output_index", output_index}, {"item", item}});
             final_output.push_back(std::move(item));
         } else if (open_item == RspItem::FUNCTION_CALL) {
-            const auto& tc = stream_tool_calls.back();
+            const auto& tc = lres.tool_calls.back();
             ok = out.emit("response.function_call_arguments.done",
                           json{{"item_id", cur_item_id},
                                {"output_index", output_index},
@@ -267,338 +245,40 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
                              {"delta", partial}});
     };
 
-    // gpt-oss Harmony streaming filter (analysis/commentary -> reasoning item,
-    // final -> message item). Markers arrive as atomic special-token pieces.
-    const bool harmony = (ctx.snap.tpl_family == imp::ChatTemplateFamily::HARMONY);
-    std::string hm_channel, hm_name, hm_buf;
-    bool hm_in_msg = false, hm_reading_name = false;
-    auto hm_flush = [&](bool force) -> bool {
-        size_t complete = force ? hm_buf.size() : utf8_complete_len(hm_buf);
-        if (complete == 0)
-            return true;
-        std::string chunk = hm_buf.substr(0, complete);
-        hm_buf.erase(0, complete);
-        if (hm_channel == "analysis" || hm_channel == "commentary")
-            return emit_thinking(chunk);
-        return emit_text(chunk);
+    StreamDialect dialect;
+    dialect.emit_text = emit_text;
+    dialect.emit_reasoning = emit_thinking;
+    dialect.emit_content_token = emit_text;
+    dialect.keepalive = [&]() -> bool {
+        // SSE comment lines are spec-compliant and ignored by SSE parsers —
+        // same cadence as the chat stream (#941).
+        static constexpr char kKeepalive[] = ": keepalive\n\n";
+        return sink.write(kKeepalive, sizeof(kKeepalive) - 1);
+    };
+    dialect.on_call_begin = [&](const ParsedToolCall& tc) -> bool {
+        return open_function_call_item(tc);
+    };
+    dialect.on_call_args_delta = emit_args_delta;
+    dialect.on_call_end = [&](ParsedToolCall*) -> bool { return stop_item(); };
+    dialect.on_call_buffered = [&](ParsedToolCall& tc) -> bool {
+        // Buffered call (non-JSON layouts): open the item, emit the whole
+        // arguments as one delta, close (stop_item reads the call the driver
+        // just recorded in lres.tool_calls).
+        if (!open_function_call_item(tc))
+            return false;
+        if (!tc.arguments.empty() && !emit_args_delta(tc.arguments))
+            return false;
+        return stop_item();
     };
 
-    int n_output_tokens = 0;
-    double ttft_ms = 0.0;  // Time to first token
-    const char* finish = nullptr;
-
-    std::string utf8_buf;      // confirmed-UTF8 content buffer
-    std::string pending_text;  // stop-sequence holdback
-    bool text_stop_matched = false;
-
-    imp::server::StreamToolCallFilter tool_filter(tpl_family);
-    bool tool_calls_emitted = false;
-    // parallel_tool_calls=false: a second streamed call was opened by the
-    // filter but is being suppressed (skip its deltas/END too).
-    bool stream_call_suppressed = false;
-
-    const bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
-                                (snap_is_think_model || enable_thinking));
-    const bool think_active = use_reasoning || enable_thinking;
-    imp::server::ThinkPhase think_start_phase;
-    if (enable_thinking)
-        think_start_phase = imp::server::ThinkPhase::REASONING;
-    else if (use_reasoning && think_budget > 0.0f)
-        think_start_phase = imp::server::ThinkPhase::SCAN;
-    else
-        think_start_phase = imp::server::ThinkPhase::CONTENT;
-    imp::server::StreamReasoningSplitter think_split(think_start_phase, snap_think_start_id,
-                                                     snap_think_end_id);
-    bool channel_header_active = false;
-
-    auto flush_text = [&](size_t up_to) -> bool {
-        if (up_to == 0)
-            return true;
-        bool ok = emit_text(pending_text.substr(0, up_to));
-        pending_text.erase(0, up_to);
-        return ok;
-    };
-    auto flush_buffered_content = [&]() -> bool {
-        if (stop_sequences.empty()) {
-            size_t complete = utf8_complete_len(utf8_buf);
-            if (complete > 0) {
-                if (!emit_text(utf8_buf.substr(0, complete)))
-                    return false;
-                utf8_buf.erase(0, complete);
-            }
-        } else if (!pending_text.empty()) {
-            auto d = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
-            if (!flush_text(d.flush_len))
-                return false;
-        }
-        return true;
-    };
-
-    auto request_start = std::chrono::steady_clock::now();
-    auto last_keepalive = request_start;
-    for (;;) {
-        if (finish)
-            break;
-
-        if (!sink.is_writable()) {
-            server_req->cancel();
-            state.metrics.requests_cancelled++;
-            finish = "cancelled";
-            break;
-        }
-        if (state.request_timeout > 0) {
-            auto elapsed = std::chrono::steady_clock::now() - request_start;
-            if (elapsed > std::chrono::seconds(state.request_timeout)) {
-                server_req->cancel();
-                finish = "length";
-                break;
-            }
-        }
-
-        TokenEvent evt{};
-        if (!server_req->pop_token(evt)) {
-            // No token ready yet (long prefill / queued behind other work).
-            // Emit an SSE comment as keepalive every ~10s so reverse proxies
-            // and SDK idle-timeouts don't kill the connection — same cadence
-            // as the chat stream (#941).
-            auto now = std::chrono::steady_clock::now();
-            if (now - last_keepalive > std::chrono::seconds(10)) {
-                last_keepalive = now;
-                static constexpr char kKeepalive[] = ": keepalive\n\n";
-                sink.write(kKeepalive, sizeof(kKeepalive) - 1);
-            }
-            continue;
-        }
-
-        if (evt.token_id < 0) {
-            finish = evt.finish_reason ? evt.finish_reason : "stop";
-            break;
-        }
-        int32_t token = evt.token_id;
-
-        if (!evt.is_last) {
-            bool is_structural_stop = (token == snap_tok->eos_id());
-            if (!is_structural_stop && snap_have_template) {
-                for (int32_t stop_id : snap_stop_token_ids)
-                    if (token == stop_id) {
-                        is_structural_stop = true;
-                        break;
-                    }
-            }
-            if (is_structural_stop)
-                continue;
-        }
-        if (evt.is_last) {
-            if (token == snap_tok->eos_id()) {
-                finish = evt.finish_reason ? evt.finish_reason : "stop";
-                break;
-            }
-            bool is_stop = false;
-            if (snap_have_template) {
-                for (int32_t stop_id : snap_stop_token_ids)
-                    if (token == stop_id) {
-                        is_stop = true;
-                        break;
-                    }
-            }
-            if (is_stop) {
-                finish = evt.finish_reason ? evt.finish_reason : "stop";
-                break;
-            }
-            finish = evt.finish_reason ? evt.finish_reason : "length";
-        }
-
-        n_output_tokens++;
-        if (n_output_tokens == 1) {
-            auto t_first = std::chrono::high_resolution_clock::now();
-            ttft_ms = std::chrono::duration<double, std::milli>(t_first - t_start).count();
-        }
-        std::string piece = snap_tok->decode_token(token);
-
-        if (harmony) {
-            if (piece == "<|channel|>" || piece == "<|message|>" || piece == "<|end|>" ||
-                piece == "<|return|>" || piece == "<|start|>") {
-                if (hm_in_msg && !hm_flush(/*force=*/true))
-                    return false;
-                if (piece == "<|channel|>") {
-                    hm_reading_name = true;
-                    hm_in_msg = false;
-                    hm_name.clear();
-                } else if (piece == "<|message|>") {
-                    size_t s = hm_name.find_first_not_of("\n\r\t ");
-                    size_t e = hm_name.find_last_not_of("\n\r\t ");
-                    hm_channel =
-                        (s == std::string::npos) ? std::string() : hm_name.substr(s, e - s + 1);
-                    hm_reading_name = false;
-                    hm_in_msg = true;
-                } else {
-                    hm_in_msg = false;
-                    hm_reading_name = false;
-                    hm_channel.clear();
-                }
-                continue;
-            }
-            if (hm_reading_name) {
-                hm_name += piece;
-                continue;
-            }
-            if (!hm_in_msg)
-                continue;
-            hm_buf += piece;
-            if (!hm_flush(/*force=*/false))
-                return false;
-            continue;
-        }
-
-        // Gemma-4 channel filter.
-        if (snap_channel_open_id >= 0) {
-            if (channel_header_active) {
-                if (token == snap_channel_newline_id || (!piece.empty() && piece.back() == '\n'))
-                    channel_header_active = false;
-                continue;
-            }
-            if (token == snap_channel_open_id) {
-                channel_header_active = true;
-                continue;
-            }
-            if (token == snap_channel_close_id)
-                continue;
-        }
-
-        // Reasoning/content demux (reasoning_split.h).
-        if (think_active) {
-            auto rs2 = think_split.feed(std::move(piece), token);
-            if (!rs2.reasoning.empty() && !emit_thinking(rs2.reasoning))
-                return false;
-            if (rs2.content.empty())
-                continue;
-            piece = std::move(rs2.content);
-        }
-
-        // Streaming tool-call demux — incremental argument deltas for JSON
-        // layouts (see the matching block in run_chat_stream_).
-        if (has_tools) {
-            auto segs = tool_filter.feed(std::move(piece));
-            piece.clear();
-            using SegKind = imp::server::StreamToolCallFilter::Segment::Kind;
-            for (size_t si = 0; si < segs.size(); ++si) {
-                auto& seg = segs[si];
-                if (seg.kind == SegKind::TEXT) {
-                    if (si + 1 == segs.size()) {
-                        piece = std::move(seg.text);  // trailing content
-                    } else {
-                        if (!flush_buffered_content())
-                            return false;
-                        if (!emit_text(seg.text))
-                            return false;
-                    }
-                    continue;
-                }
-                // parallel_tool_calls=false: stream at most one tool call.
-                // (For a streamed call the gate fires at CALL_BEGIN, so the
-                // later deltas/END of a suppressed call are skipped too.)
-                if (!ctx.params.parallel_tool_calls &&
-                    ((seg.kind == SegKind::CALL && !stream_tool_calls.empty()) ||
-                     (seg.kind == SegKind::CALL_BEGIN && !stream_tool_calls.empty()) ||
-                     (seg.kind != SegKind::CALL && stream_call_suppressed))) {
-                    if (seg.kind == SegKind::CALL_BEGIN)
-                        stream_call_suppressed = true;
-                    if (seg.kind == SegKind::CALL_END)
-                        stream_call_suppressed = false;
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_BEGIN) {
-                    ParsedToolCall tc = std::move(seg.call);
-                    tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
-                    if (!flush_buffered_content())
-                        return false;
-                    if (!open_function_call_item(tc))
-                        return false;
-                    stream_tool_calls.push_back(std::move(tc));
-                    tool_calls_emitted = true;
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_ARGS_DELTA) {
-                    if (!emit_args_delta(seg.text))
-                        return false;
-                    continue;
-                }
-                if (seg.kind == SegKind::CALL_END) {
-                    if (!stream_tool_calls.empty())
-                        stream_tool_calls.back().arguments = std::move(seg.call.arguments);
-                    if (!stop_item())
-                        return false;
-                    continue;
-                }
-                // SegKind::CALL — buffered call (non-JSON layouts): open the
-                // item, emit the whole arguments as one delta, close.
-                ParsedToolCall tc = std::move(seg.call);
-                tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
-                if (!flush_buffered_content())
-                    return false;
-                if (!open_function_call_item(tc))
-                    return false;
-                stream_tool_calls.push_back(std::move(tc));
-                if (!tc.arguments.empty() && !emit_args_delta(tc.arguments))
-                    return false;
-                if (!stop_item())
-                    return false;
-                tool_calls_emitted = true;
-            }
-            if (piece.empty())
-                continue;
-        }
-
-        // Normal content emission.
-        if (stop_sequences.empty()) {
-            utf8_buf += piece;
-            size_t complete = utf8_complete_len(utf8_buf);
-            if (complete > 0) {
-                if (!emit_text(utf8_buf.substr(0, complete)))
-                    return false;
-                utf8_buf.erase(0, complete);
-            }
-        } else {
-            pending_text += piece;
-            auto d = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
-            if (!flush_text(d.flush_len))
-                return false;
-            if (d.complete_match) {
-                text_stop_matched = true;
-                finish = "stop";
-                break;
-            }
-        }
-    }
-
-    // ---- Stream-end flushing (mirrors the Anthropic path) ------------------
-    if (think_active) {
-        auto rs2 = think_split.finish();
-        if (!rs2.reasoning.empty())
-            emit_thinking(rs2.reasoning);
-        if (!rs2.content.empty())
-            utf8_buf += rs2.content;
-    }
-    if (has_tools && tool_filter.mid_tool() && !tool_calls_emitted) {
-        std::string leftover = tool_filter.finish();
-        if (!leftover.empty())
-            utf8_buf += leftover;
-    }
-    if (has_tools && tool_filter.call_open() && !stream_tool_calls.empty() &&
-        stream_tool_calls.back().arguments.empty())
-        stream_tool_calls.back().arguments = tool_filter.streamed_arguments();
-    if (!utf8_buf.empty() && !text_stop_matched && !tool_calls_emitted)
-        emit_text(utf8_buf);
-    if (!pending_text.empty() && !text_stop_matched && !tool_calls_emitted)
-        emit_text(pending_text);
+    if (!run_stream_loop_(sink, ctx, state, server_req, dialect, lres))
+        return false;
 
     stop_item();
 
-    if (!finish)
-        finish = tool_calls_emitted ? "tool_calls" : "length";
-
     // ---- response.completed / response.incomplete --------------------------
-    const bool incomplete = (strcmp(finish, "length") == 0 || strcmp(finish, "cancelled") == 0);
+    const bool incomplete =
+        (strcmp(lres.finish, "length") == 0 || strcmp(lres.finish, "cancelled") == 0);
     json response = response_skeleton(response_id, model_name,
                                       incomplete ? "incomplete" : "completed");
     response["output"] = std::move(final_output);
@@ -606,43 +286,15 @@ static bool run_responses_stream_(httplib::DataSink& sink, ChatRequestContext& c
         response["incomplete_details"] = {{"reason", "max_output_tokens"}};
     int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
     response["usage"] = {{"input_tokens", n_prompt_tokens},
-                         {"output_tokens", n_output_tokens},
-                         {"total_tokens", n_prompt_tokens + n_output_tokens},
+                         {"output_tokens", lres.n_output_tokens},
+                         {"total_tokens", n_prompt_tokens + lres.n_output_tokens},
                          {"input_tokens_details", {{"cached_tokens", cached}}},
-                         {"output_tokens_details", {{"reasoning_tokens", 0}}}};
+                         {"output_tokens_details", {{"reasoning_tokens", lres.n_reasoning_tokens}}}};
     out.emit(incomplete ? "response.incomplete" : "response.completed",
              json{{"response", std::move(response)}});
-
-    // Server metrics — same accounting as the chat/messages streams (#941):
-    // without this every streaming /v1/responses request was invisible to
-    // /metrics (only requests_cancelled was ever touched).
-    {
-        auto t_end = std::chrono::high_resolution_clock::now();
-        double ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-        state.metrics.requests_total++;
-        state.metrics.tokens_prompt_total += n_prompt_tokens;
-        state.metrics.tokens_completion_total += n_output_tokens;
-        state.metrics.tokens_cached_total += cached;
-        state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
-        state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
-        state.metrics.request_duration.observe(ms / 1000.0);
-        if (n_output_tokens > 0)
-            state.metrics.ttft.observe(ttft_ms / 1000.0);
-        if (n_output_tokens > 1)
-            state.metrics.inter_token.observe((ms - ttft_ms) / 1000.0 / (n_output_tokens - 1));
-    }
-
-    // JSONL request log (outer Responses shapes).
-    if (!ctx.log_skip) {
-        auto t_end = std::chrono::system_clock::now();
-        double ms =
-            std::chrono::duration<double, std::milli>(t_end - ctx.t_log_start).count();
-        log_request_jsonl(state, /*skip=*/false, ctx.t_log_start, response_id, ctx.log_endpoint,
-                          ctx.log_client_ip, ctx.log_raw_body, ms, n_prompt_tokens,
-                          n_output_tokens, finish, json());
-    }
-
     sink.done();
+
+    finish_stream_accounting_(state, ctx, active_req, lres, response_id, "responses stream: ");
     return true;
 }
 
@@ -704,39 +356,9 @@ void handle_responses(const httplib::Request& req, httplib::Response& res, Serve
         ctx.log_raw_body = log_raw_body;
         ctx.t_log_start = t_log_start;
 
-        auto imp_req = std::make_shared<imp::Request>();
-        imp_req->image = ctx.snap.vision_image;
-        imp_req->input_tokens = ctx.snap.tokens;
-        imp_req->max_tokens = ctx.params.max_tokens;
-        imp_req->temperature = ctx.params.temperature;
-        imp_req->top_p = ctx.params.top_p;
-        imp_req->top_k = ctx.params.top_k;
-        imp_req->seed = ctx.params.seed;
-        imp_req->pin_kv_prefix = ctx.params.cache_prompt;
-        imp_req->spec_ngram_override = ctx.params.spec_ngram_override;
-        imp_req->stream = true;
-        imp_req->min_p = ctx.params.min_p;
-        imp_req->typical_p = ctx.params.typical_p;
-        imp_req->repetition_penalty = ctx.params.repetition_penalty;
-        imp_req->frequency_penalty = ctx.params.frequency_penalty;
-        imp_req->presence_penalty = ctx.params.presence_penalty;
-        imp_req->repeat_last_n = ctx.params.repeat_last_n;
-        imp_req->dry_multiplier = ctx.params.dry_multiplier;
-        imp_req->dry_base = ctx.params.dry_base;
-        imp_req->dry_allowed_length = ctx.params.dry_allowed_length;
-        imp_req->dry_penalty_last_n = ctx.params.dry_penalty_last_n;
-        imp_req->mirostat = ctx.params.mirostat;
-        imp_req->mirostat_tau = ctx.params.mirostat_tau;
-        imp_req->mirostat_eta = ctx.params.mirostat_eta;
-        imp_req->logprobs = ctx.params.req_logprobs;
-        imp_req->top_logprobs = ctx.params.top_logprobs;
-        imp_req->json_mode = ctx.params.json_mode;
-        imp_req->json_schema = ctx.params.json_schema_str;
-        imp_req->has_tools = ctx.params.has_tools;
-        imp_req->tpl_family = ctx.snap.tpl_family;
-        imp_req->logit_bias = ctx.params.logit_bias;
-        imp_req->think_budget = ctx.params.think_budget;
-        imp_req->status = imp::RequestStatus::PENDING;
+        // Streaming stays on per-step decode for real per-token SSE (#754).
+        auto imp_req = build_imp_request_(ctx, ctx.snap.tokens, /*completion_idx=*/0,
+                                          /*stream=*/true);
 
         auto server_req = std::make_shared<ServerRequest>();
         server_req->request = imp_req;

--- a/tools/imp-server/stream_driver.cpp
+++ b/tools/imp-server/stream_driver.cpp
@@ -1,0 +1,506 @@
+// Shared per-token SSE streaming loop (see stream_driver.h). The dialect
+// adapters live in handlers_chat_stream.cpp (OpenAI chat),
+// handlers_messages.cpp (Anthropic) and handlers_responses.cpp (Responses).
+
+#include "stream_driver.h"
+
+#include "utils.h"
+#include "tool_stream_filter.h"
+#include "stream_pipeline.h"
+#include "reasoning_split.h"
+
+#include "runtime/request.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+
+bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
+                      const std::shared_ptr<ServerRequest>& server_req, StreamDialect& d,
+                      StreamLoopResult& out) {
+    const auto& stop_sequences = ctx.params.stop_sequences;
+    // Derive max_stop_len from the FINAL stop list, not ctx.params.max_stop_len:
+    // the snapshot phase may inject server-side stops ("\nHuman" turn guard for
+    // think models) AFTER request parsing computed max_stop_len. A stale 0 made
+    // the partial-match holdback `size - max_stop_len + 1` flush one byte PAST
+    // pending_text's end — emitting the std::string NUL terminator into every
+    // SSE content delta ("4\0") and disabling cross-token stop matching.
+    size_t max_stop_len = 0;
+    for (const auto& s : stop_sequences)
+        max_stop_len = std::max(max_stop_len, s.size());
+    const bool enable_thinking = ctx.snap.enable_thinking;
+    const bool has_tools = ctx.params.has_tools;
+    const auto tpl_family = ctx.snap.tpl_family;
+    const float think_budget = ctx.params.think_budget;
+    const auto snap_tok = ctx.snap.tok;
+    const bool snap_have_template = ctx.snap.have_template;
+    const auto& snap_stop_token_ids = ctx.snap.stop_token_ids;
+    const auto t_start = ctx.t_start;
+
+    const char* finish = nullptr;
+
+    // Buffer for incomplete UTF-8 sequences across token boundaries.
+    std::string utf8_buf;
+    // Buffered output for stop-sequence matching: text is held back until it
+    // provably does not contain (a prefix of) a stop match.
+    std::string pending_text;
+    bool text_stop_matched = false;
+
+    // Streaming tool-call demux (tool_stream_filter.h) — pure state machine.
+    // Detects ChatML/Llama3/Gemma-4 open markers, holds back potential-tag
+    // text, parses completed bodies (JSON, Qwen3.6 XML fallback, Gemma
+    // call:NAME{...}) and restores unparseable ones to the content stream.
+    imp::server::StreamToolCallFilter tool_filter(tpl_family);
+    // parallel_tool_calls=false: a second streamed call was opened by the
+    // filter but is being suppressed (skip its deltas/END too).
+    bool stream_call_suppressed = false;
+
+    // Reasoning/content demux (DeepSeek <think>) — shared state machine in
+    // reasoning_split.h. enable_thinking also covers text-level thinkers
+    // (Nemotron: template-injected "<think>" as plain text, no special token).
+    const bool use_reasoning = (state.default_args.reasoning_format == "deepseek" &&
+                                (ctx.snap.is_think_model || enable_thinking));
+    const bool think_active = use_reasoning || enable_thinking;
+    imp::server::ThinkPhase think_start_phase;
+    if (enable_thinking)
+        think_start_phase = imp::server::ThinkPhase::REASONING;  // <think> in prefill
+    else if (use_reasoning && think_budget > 0.0f)
+        think_start_phase = imp::server::ThinkPhase::SCAN;  // model decides
+    else
+        think_start_phase = imp::server::ThinkPhase::CONTENT;  // no extraction
+    imp::server::StreamReasoningSplitter think_split(think_start_phase, ctx.snap.think_start_id,
+                                                     ctx.snap.think_end_id);
+
+    // Gemma-4 channel filter state: when we see <|channel> or <channel|>,
+    // skip tokens until the next newline (the channel header).
+    bool channel_header_active = false;
+
+    // gpt-oss Harmony streaming filter. The model emits
+    //   <|channel|>analysis<|message|>…<|end|><|start|>assistant<|channel|>final<|message|>…
+    // Route analysis/commentary channels to the reasoning sink and the final
+    // channel to content, stripping the control markers (which arrive as atomic
+    // special-token pieces) and the <|start|>role plumbing. hm_buf holds the
+    // current channel's bytes so a token that splits a multibyte char is not
+    // emitted mid-codepoint (#760).
+    const bool harmony = (tpl_family == imp::ChatTemplateFamily::HARMONY);
+    std::string hm_channel, hm_name, hm_buf;
+    bool hm_in_msg = false, hm_reading_name = false;
+    auto hm_flush = [&](bool force) -> bool {
+        size_t complete = force ? hm_buf.size() : utf8_complete_len(hm_buf);
+        if (complete == 0)
+            return true;
+        std::string chunk = hm_buf.substr(0, complete);
+        hm_buf.erase(0, complete);
+        if (hm_channel == "analysis" || hm_channel == "commentary")
+            return d.harmony_reasoning_on ? d.emit_reasoning(chunk) : true;
+        return d.emit_text(chunk);
+    };
+
+    // Flush confirmed holdback text up to a byte position.
+    auto flush_text = [&](size_t up_to) -> bool {
+        up_to = std::min(up_to, pending_text.size());  // never read past the buffer
+        if (up_to == 0)
+            return true;
+        bool ok = d.emit_text(pending_text.substr(0, up_to));
+        pending_text.erase(0, up_to);
+        return ok;
+    };
+
+    // Flush held content buffers before emitting a tool call (or directly
+    // emitted text), so stream order is preserved. A complete stop match
+    // cannot be pending here: the normal emission path checks after every
+    // append with the same holdback decision.
+    auto flush_buffered_content = [&]() -> bool {
+        if (stop_sequences.empty()) {
+            size_t complete = utf8_complete_len(utf8_buf);
+            if (complete > 0) {
+                std::string chunk = utf8_buf.substr(0, complete);
+                utf8_buf.erase(0, complete);
+                if (!d.emit_text(chunk))
+                    return false;
+            }
+        } else if (!pending_text.empty()) {
+            auto hd = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
+            if (!flush_text(hd.flush_len))
+                return false;
+        }
+        return true;
+    };
+
+    auto request_start = std::chrono::steady_clock::now();
+    auto last_keepalive = request_start;
+    for (;;) {
+        // Terminate as soon as a finish reason has been recorded. The is_last
+        // token sets `finish` and then falls through to the per-token
+        // post-processing below, where a think/reasoning/channel `continue`
+        // can skip the trailing `if (finish) break`. Re-checking here means the
+        // stream always ends (and the terminal SSE frame is emitted) even when
+        // the final token is swallowed by one of those paths (#755/#757).
+        if (finish)
+            break;
+
+        // Check client disconnect.
+        if (!sink.is_writable()) {
+            server_req->cancel();
+            state.metrics.requests_cancelled++;
+            finish = "cancelled";
+            break;
+        }
+
+        // Check request timeout.
+        if (state.request_timeout > 0) {
+            auto elapsed = std::chrono::steady_clock::now() - request_start;
+            if (elapsed > std::chrono::seconds(state.request_timeout)) {
+                server_req->cancel();
+                finish = "length";
+                break;
+            }
+        }
+
+        // Read next token from the batching engine (with timeout).
+        TokenEvent evt{};
+        if (!server_req->pop_token(evt)) {
+            // No token ready yet (long prefill / queued behind other work).
+            // Emit a dialect keepalive every ~10s so reverse proxies and SDK
+            // idle-timeouts don't kill the connection. A failed keepalive
+            // write means the client is gone — cancel like a disconnect.
+            auto now = std::chrono::steady_clock::now();
+            if (now - last_keepalive > std::chrono::seconds(10)) {
+                last_keepalive = now;
+                if (!d.keepalive()) {
+                    server_req->cancel();
+                    state.metrics.requests_cancelled++;
+                    finish = "cancelled";
+                    break;
+                }
+            }
+            continue;  // timeout — loop back to check disconnect/timeout
+        }
+
+        if (evt.token_id < 0) {
+            // Finish event with no token.
+            finish = evt.finish_reason ? evt.finish_reason : "stop";
+            break;
+        }
+
+        int32_t token = evt.token_id;
+
+        // Silently drop structural stop tokens that slipped through. The
+        // engine's think-block implicit-close (Engine::should_stop) passes ONE
+        // EOS-like token through to recover from empty thinking. That token
+        // must not appear as user-visible content (would render as
+        // "<|im_end|>" / "<|endoftext|>" in chat).
+        if (!evt.is_last) {
+            bool is_structural_stop = (token == snap_tok->eos_id());
+            if (!is_structural_stop && snap_have_template) {
+                for (int32_t stop_id : snap_stop_token_ids) {
+                    if (token == stop_id) {
+                        is_structural_stop = true;
+                        break;
+                    }
+                }
+            }
+            if (is_structural_stop)
+                continue;
+        }
+
+        // Check stop conditions (EOS/stop tokens already detected by engine).
+        if (evt.is_last) {
+            // The engine marked this as the last token. Don't emit EOS/stop
+            // tokens — they're structural, not content.
+            if (token == snap_tok->eos_id()) {
+                finish = evt.finish_reason ? evt.finish_reason : "stop";
+                break;
+            }
+            bool is_stop = false;
+            if (snap_have_template) {
+                for (int32_t stop_id : snap_stop_token_ids) {
+                    if (token == stop_id) {
+                        is_stop = true;
+                        break;
+                    }
+                }
+            }
+            if (is_stop) {
+                finish = evt.finish_reason ? evt.finish_reason : "stop";
+                break;
+            }
+            // Not a stop token — emit it, then finish after this iteration.
+            finish = evt.finish_reason ? evt.finish_reason : "length";
+        }
+
+        out.n_output_tokens++;
+        if (out.n_output_tokens == 1) {
+            auto t_first = std::chrono::high_resolution_clock::now();
+            out.ttft_ms = std::chrono::duration<double, std::milli>(t_first - t_start).count();
+        }
+        std::string piece = snap_tok->decode_token(token);
+
+        // gpt-oss Harmony channel routing. Markers arrive as atomic
+        // special-token pieces.
+        if (harmony) {
+            if (piece == "<|channel|>" || piece == "<|message|>" || piece == "<|end|>" ||
+                piece == "<|return|>" || piece == "<|start|>") {
+                if (hm_in_msg && !hm_flush(/*force=*/true))
+                    return false;
+                if (piece == "<|channel|>") {
+                    hm_reading_name = true;
+                    hm_in_msg = false;
+                    hm_name.clear();
+                } else if (piece == "<|message|>") {
+                    size_t s = hm_name.find_first_not_of("\n\r\t ");
+                    size_t e = hm_name.find_last_not_of("\n\r\t ");
+                    hm_channel = (s == std::string::npos) ? std::string() : hm_name.substr(s, e - s + 1);
+                    hm_reading_name = false;
+                    hm_in_msg = true;
+                } else {  // <|end|> / <|return|> / <|start|>: close the block
+                    hm_in_msg = false;
+                    hm_reading_name = false;
+                    hm_channel.clear();
+                }
+                continue;
+            }
+            if (hm_reading_name) {  // channel name between <|channel|> and <|message|>
+                hm_name += piece;
+                continue;
+            }
+            if (!hm_in_msg)  // role text / inter-block plumbing
+                continue;
+            hm_buf += piece;
+            if (!hm_flush(/*force=*/false))
+                return false;
+            continue;
+        }
+
+        // Gemma-4 channel filter: strip "<|channel>NAME\n" structural headers
+        // from the content stream. `<channel|>` is the channel-switch marker —
+        // strip the token but do NOT enter the scan-until-newline mode,
+        // because Q5_K_M sometimes emits the final answer directly after it
+        // with no newline (observed: "<|channel>thought\n<channel|>5 + 3 = 8").
+        if (ctx.snap.channel_open_id >= 0) {
+            if (channel_header_active) {
+                if (token == ctx.snap.channel_newline_id || (!piece.empty() && piece.back() == '\n')) {
+                    channel_header_active = false;
+                }
+                continue;
+            }
+            if (token == ctx.snap.channel_open_id) {
+                channel_header_active = true;
+                continue;
+            }
+            if (token == ctx.snap.channel_close_id) {
+                // Drop just the marker; the next token is body.
+                continue;
+            }
+        }
+
+        // Reasoning/content demux (DeepSeek <think>): routes reasoning to the
+        // dialect's reasoning sink and hands back the user-visible content for
+        // this step (empty when the whole piece was reasoning or is being held
+        // for boundary detection).
+        if (think_active) {
+            auto rs = think_split.feed(std::move(piece), token);
+            out.n_reasoning_tokens += rs.reasoning_tokens;
+            if (!rs.reasoning.empty() && !d.emit_reasoning(rs.reasoning))
+                return false;
+            if (rs.content.empty())
+                continue;
+            piece = std::move(rs.content);
+        }
+
+        // Streaming tool-call demux (only when tools are present): the filter
+        // returns the user-visible content and any completed tool calls, in
+        // stream order. Content before/between calls is emitted directly;
+        // trailing content after the last call falls through to the normal
+        // emission path below.
+        if (has_tools) {
+            auto segs = tool_filter.feed(std::move(piece));
+            piece.clear();
+            using SegKind = imp::server::StreamToolCallFilter::Segment::Kind;
+            for (size_t si = 0; si < segs.size(); ++si) {
+                auto& seg = segs[si];
+                if (seg.kind == SegKind::TEXT) {
+                    if (si + 1 == segs.size()) {
+                        piece = std::move(seg.text);  // trailing content
+                    } else {
+                        if (!flush_buffered_content())
+                            return false;
+                        if (!d.emit_text(seg.text))
+                            return false;
+                    }
+                    continue;
+                }
+                // parallel_tool_calls=false: stream at most one tool call.
+                // (For a streamed call the gate fires at CALL_BEGIN, so the
+                // later deltas/END of a suppressed call are skipped too.)
+                if (!ctx.params.parallel_tool_calls &&
+                    ((seg.kind == SegKind::CALL && !out.tool_calls.empty()) ||
+                     (seg.kind == SegKind::CALL_BEGIN && !out.tool_calls.empty()) ||
+                     (seg.kind != SegKind::CALL && stream_call_suppressed))) {
+                    if (seg.kind == SegKind::CALL_BEGIN)
+                        stream_call_suppressed = true;
+                    if (seg.kind == SegKind::CALL_END)
+                        stream_call_suppressed = false;
+                    continue;
+                }
+
+                if (seg.kind == SegKind::CALL_BEGIN) {
+                    // Streamed call opens: the dialect emits its open frame
+                    // now; the argument bytes follow as CALL_ARGS_DELTA
+                    // segments while the model is still generating them
+                    // (previously the whole body was buffered until the close
+                    // tag — 20-60 s of zero SSE bytes on a big code edit).
+                    ParsedToolCall tc = std::move(seg.call);
+                    tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
+                    if (!flush_buffered_content())
+                        return false;
+                    out.tool_calls.push_back(std::move(tc));
+                    out.tool_calls_emitted = true;
+                    if (!d.on_call_begin(out.tool_calls.back()))
+                        return false;
+                    continue;
+                }
+                if (seg.kind == SegKind::CALL_ARGS_DELTA) {
+                    if (!d.on_call_args_delta(seg.text))
+                        return false;
+                    continue;
+                }
+                if (seg.kind == SegKind::CALL_END) {
+                    // Deltas already on the wire — record the full arguments
+                    // for bookkeeping; the dialect closes its frame.
+                    if (!out.tool_calls.empty())
+                        out.tool_calls.back().arguments = std::move(seg.call.arguments);
+                    if (!d.on_call_end(out.tool_calls.empty() ? nullptr : &out.tool_calls.back()))
+                        return false;
+                    continue;
+                }
+
+                // SegKind::CALL — buffered call (non-JSON layouts): the
+                // dialect emits the whole call (open + arguments + close).
+                ParsedToolCall tc = std::move(seg.call);
+                tc.id = "call_imp_" + std::to_string(state.next_tool_call_id.fetch_add(1));
+                if (!flush_buffered_content())
+                    return false;
+                out.tool_calls.push_back(std::move(tc));
+                out.tool_calls_emitted = true;
+                if (!d.on_call_buffered(out.tool_calls.back()))
+                    return false;
+            }
+            if (piece.empty())
+                continue;
+        }
+
+        // Normal content emission (no tool tag detected).
+        if (stop_sequences.empty()) {
+            // No stop sequences: stream directly (with UTF-8 buffering).
+            utf8_buf += piece;
+            size_t complete = utf8_complete_len(utf8_buf);
+            if (complete > 0) {
+                std::string chunk = utf8_buf.substr(0, complete);
+                utf8_buf.erase(0, complete);
+                if (!d.emit_content_token(chunk))
+                    return false;
+            }
+        } else {
+            // Buffer text and check for stop matches via the pure holdback
+            // pipeline (stream_pipeline.h). It returns the safe-to-emit prefix
+            // and whether a complete stop sequence is present.
+            pending_text += piece;
+            auto hd = imp::stream::holdback_decision(pending_text, max_stop_len, stop_sequences);
+            if (!flush_text(hd.flush_len))
+                return false;
+            if (hd.complete_match) {
+                text_stop_matched = true;
+                finish = "stop";
+                break;
+            }
+        }
+
+        // Break after processing the last non-EOS token from batching engine.
+        if (finish)
+            break;
+    }
+
+    // Harmony: flush the final channel's tail (the final block usually ends at
+    // EOS/<|return|> with no trailing <|end|>). The other buffers below stay
+    // empty for harmony, so they're no-ops.
+    if (harmony && !hm_buf.empty())
+        hm_flush(/*force=*/true);
+
+    // Flush the splitter's held tail at stream end: buffered reasoning -> the
+    // reasoning sink, any held/undecided content -> the content flush below.
+    if (think_active) {
+        auto rs = think_split.finish();
+        if (!rs.reasoning.empty())
+            d.emit_reasoning(rs.reasoning);
+        if (!rs.content.empty())
+            utf8_buf += rs.content;
+    }
+
+    // The model exhausted max_tokens while still reasoning and never produced
+    // content (finish == "length" — a model that naturally hit EOS during
+    // thinking already has its reasoning delivered). The chat dialect emits a
+    // user-visible notice on this flag.
+    out.reasoning_truncated = think_active && think_split.phase() == imp::server::ThinkPhase::REASONING &&
+                              utf8_buf.empty() && pending_text.empty() && finish &&
+                              std::strcmp(finish, "length") == 0;
+
+    // Handle incomplete tool call at end (max_tokens hit while in tag/body):
+    // release the held raw text as content, finish_reason stays "length".
+    if (has_tools && tool_filter.mid_tool() && !out.tool_calls_emitted) {
+        std::string leftover = tool_filter.finish();
+        if (!leftover.empty())
+            utf8_buf += leftover;
+    }
+    // A STREAMED call cut off mid-arguments: its open frame + deltas are
+    // already on the wire (nothing restorable) — record what was streamed for
+    // bookkeeping; the client sees finish_reason=length.
+    if (has_tools && tool_filter.call_open() && !out.tool_calls.empty() &&
+        out.tool_calls.back().arguments.empty()) {
+        out.tool_calls.back().arguments = tool_filter.streamed_arguments();
+    }
+
+    // Flush any remaining buffers (skip after a text-level stop match or when
+    // tool calls were emitted).
+    if (!utf8_buf.empty() && !text_stop_matched && !out.tool_calls_emitted)
+        d.emit_text(utf8_buf);
+    if (!pending_text.empty() && !text_stop_matched && !out.tool_calls_emitted)
+        d.emit_text(pending_text);
+
+    if (!finish)
+        finish = out.tool_calls_emitted ? "tool_calls" : "length";
+    else if (out.tool_calls_emitted && std::strcmp(finish, "stop") == 0)
+        finish = "tool_calls";
+    out.finish = finish;
+    return true;
+}
+
+void finish_stream_accounting_(ServerState& state, ChatRequestContext& ctx,
+                               const std::shared_ptr<imp::Request>& active_req, const StreamLoopResult& out,
+                               const std::string& req_id, const char* label) {
+    auto t_end = std::chrono::high_resolution_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t_end - ctx.t_start).count();
+    int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
+    int n_prompt_tokens = ctx.snap.n_prompt_tokens;
+    fprintf(stderr, "[%s] %s%d prompt + %d completion tokens, %.1f ms (ttft=%.1f ms, cached=%d)\n",
+            req_id.c_str(), label, n_prompt_tokens, out.n_output_tokens, ms, out.ttft_ms, cached);
+    state.metrics.requests_total++;
+    state.metrics.tokens_prompt_total += n_prompt_tokens;
+    state.metrics.tokens_completion_total += out.n_output_tokens;
+    state.metrics.tokens_cached_total += cached;
+    state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
+    state.metrics.last_ttft_ms = static_cast<int64_t>(out.ttft_ms);
+    state.metrics.request_duration.observe(ms / 1000.0);
+    if (out.n_output_tokens > 0)
+        state.metrics.ttft.observe(out.ttft_ms / 1000.0);
+    // Mean inter-token latency: post-first-token decode time spread over the
+    // remaining tokens. Streaming-only (non-stream has no per-token cadence).
+    if (out.n_output_tokens > 1)
+        state.metrics.inter_token.observe((ms - out.ttft_ms) / 1000.0 / (out.n_output_tokens - 1));
+
+    // Streaming response content is not accumulated across SSE chunks, so the
+    // JSONL `response` field stays null. The request body, token counts,
+    // finish reason, and latency still reflect everything the client did.
+    log_request_jsonl(state, ctx.log_skip, ctx.t_log_start, req_id, ctx.log_endpoint, ctx.log_client_ip,
+                      ctx.log_raw_body, ms, n_prompt_tokens, out.n_output_tokens, out.finish, json());
+}

--- a/tools/imp-server/stream_driver.h
+++ b/tools/imp-server/stream_driver.h
@@ -1,0 +1,84 @@
+#pragma once
+
+// Shared per-token SSE streaming loop for the three streaming dialects
+// (/v1/chat/completions, /v1/messages, /v1/responses). The outer token loop —
+// disconnect/timeout/keepalive handling, batching-engine pop_token, structural
+// stop-token filtering, the Harmony and Gemma-4 channel filters, the
+// reasoning/content demux, the streaming tool-call demux, stop-sequence
+// holdback and UTF-8 buffering, and end-of-stream flushing — used to be
+// hand-copied per dialect (~600 LOC each) and drifted repeatedly (#941 was the
+// 3rd/4th drift bug: /v1/responses had no metrics and no keepalive). The loop
+// now lives once in stream_driver.cpp; each dialect supplies only its wire
+// format via StreamDialect callbacks and emits its own terminal events after
+// the loop returns.
+
+#include "handlers.h"
+#include "handlers_internal.h"
+#include "tool_call.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Dialect emission callbacks. Every emitter returns false when the client
+// write failed; the driver then aborts the stream and returns false (no
+// terminal events, no accounting — matching the previous per-dialect code).
+struct StreamDialect {
+    // User-visible content / reasoning deltas.
+    std::function<bool(const std::string&)> emit_text;
+    std::function<bool(const std::string&)> emit_reasoning;
+    // Content from the no-stop-sequence hot path, called once per decoded
+    // token: the chat dialect attaches per-token logprobs here (the index is
+    // StreamLoopResult::n_output_tokens - 1, updated live by the driver); the
+    // other dialects alias this to emit_text.
+    std::function<bool(const std::string&)> emit_content_token;
+    // Idle keepalive, sent when no token arrived for ~10s. A false return is
+    // treated as a client disconnect (request cancelled).
+    std::function<bool()> keepalive;
+    // Tool calls. A streamed (JSON-layout) call arrives as on_call_begin ->
+    // on_call_args_delta* -> on_call_end; a buffered (non-JSON layout) call as
+    // a single on_call_buffered. The driver assigns tc.id and appends the call
+    // to StreamLoopResult::tool_calls BEFORE invoking on_call_begin /
+    // on_call_buffered — the callback receives a reference to the recorded
+    // element (its index is tool_calls.size() - 1) and may mutate it
+    // (validation). on_call_end receives the completed call (arguments
+    // recorded), or nullptr when no call was recorded.
+    std::function<bool(const ParsedToolCall&)> on_call_begin;
+    std::function<bool(const std::string&)> on_call_args_delta;
+    std::function<bool(ParsedToolCall*)> on_call_end;
+    std::function<bool(ParsedToolCall&)> on_call_buffered;
+    // Harmony (gpt-oss) reasoning-channel gate: the chat dialect drops
+    // analysis/commentary text when reasoning_format == "none"; the native
+    // thinking dialects always emit it.
+    bool harmony_reasoning_on = true;
+};
+
+// Loop outcome, consumed by the dialect's terminal-event section and by
+// finish_stream_accounting_. n_output_tokens and tool_calls are updated live
+// (see StreamDialect::emit_content_token / on_call_begin).
+struct StreamLoopResult {
+    const char* finish = nullptr;
+    int n_output_tokens = 0;
+    int n_reasoning_tokens = 0;
+    double ttft_ms = 0.0;
+    bool tool_calls_emitted = false;
+    // Generation hit max_tokens while still inside reasoning and produced no
+    // content (the chat dialect emits its "[Reasoning truncated ...]" notice).
+    bool reasoning_truncated = false;
+    std::vector<ParsedToolCall> tool_calls;
+};
+
+// Drive the token loop until a finish reason is recorded. Returns false when a
+// client write failed mid-stream (adapter returns false to httplib without
+// terminal events); true otherwise, with out.finish always set.
+bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
+                      const std::shared_ptr<ServerRequest>& server_req, StreamDialect& d,
+                      StreamLoopResult& out);
+
+// Shared post-stream accounting: server metrics (request/token counters, TTFT,
+// inter-token latency), the JSONL request log, and the stderr summary line.
+// label prefixes the stderr line ("" for chat, "messages stream: ", ...).
+void finish_stream_accounting_(ServerState& state, ChatRequestContext& ctx,
+                               const std::shared_ptr<imp::Request>& active_req, const StreamLoopResult& out,
+                               const std::string& req_id, const char* label);


### PR DESCRIPTION
## What

Executes the extraction justified by #941: the outer per-token SSE streaming loop was hand-copied 3x (`handlers_chat_stream.cpp` / `handlers_messages.cpp` / `handlers_responses.cpp`, ~600 LOC each) and the OpenAI-params -> `imp::Request` field mapping 4x. The inner state machines were already shared (`stream_pipeline.h` / `reasoning_split.h` / `tool_stream_filter.h`); the outer loop was not, and the drift class kept producing real bugs (#892, #941 were instances 1-4).

- **`stream_driver.cpp`** (new): the single token loop — disconnect/timeout/keepalive, `pop_token`, structural-stop filtering, Harmony + Gemma-4 channel filters, reasoning/content demux, streaming tool-call demux (incl. `parallel_tool_calls` suppression + id assignment), stop-sequence holdback + UTF-8 buffering, end-of-stream flushing, and shared metrics/JSONL accounting. Each dialect supplies only its wire format via `StreamDialect` callbacks and its own terminal events.
- **`build_imp_request_()`**: single params->request mapping for the four ctx-based submission sites (chat stream + non-stream, messages stream, responses stream). `/v1/completions` keeps its own raw-body mapping (different source shape, deliberately not forced through this).

Net **-732 LOC**.

## Drift fixes that fall out of the unification

- **/v1/messages**: `inter_token` metric was never observed; streamed tool-call arguments were not recorded on a mid-args cutoff; a failed keepalive write broke the loop without cancelling the engine request (now treated as a disconnect: cancel + `requests_cancelled`).
- **/v1/messages + /v1/responses**: `started_in_think` / `in_think_block` were never set, so the engine's think-budget enforcement did not engage on those routes; `prediction_tokens` (Predicted Outputs) were dropped.
- **/v1/responses**: buffered (non-JSON layout) tool calls emitted an **empty** `function_call_arguments.delta` — the old code read `tc.arguments` after `std::move(tc)`; args only appeared in the `.done` event. `usage.output_tokens_details.reasoning_tokens` was hardcoded 0, now the real count. Terminal `finish` now gets the same stop->tool_calls promotion as the other dialects (no observable change: `incomplete` only checks length/cancelled).
- **chat**: dead `full_output` accumulator removed (appended per token, never read).
- stderr per-request summary lines unified (messages/responses now include `cached=`; responses previously logged nothing).

## Verification

- `make build` + `make test-unit` green; `make verify-fast` OK; file-size gate 0 violations (new TU ~500 LOC).
- Live smoke on Qwen3-14B-Q6_K: all three SSE dialects exercised — chat (reasoning/content demux, usage incl. `reasoning_tokens`, `[DONE]`), chat+messages+responses tool-call streaming (incremental args deltas, correct indices/blocks/items), stop-sequence holdback (stops before match, no NUL leak), client-disconnect -> `requests_cancelled`.
- `/metrics` after the smoke run: `requests_total` counts all three dialects, `inter_token` observed for every stream (incl. messages).
- `degen_suite.py`: **33 checks, 0 FAIL** (incl. stream + anthropic-thinking categories, stream == non-stream at temp=0).
- `tests/api` pytest vs the live server: 63/66 + tools 5/5; the 3 failures are pre-existing expectation drift in `test_errors.py` vs the real server's error wording (`handlers.cpp` untouched by this PR; those tests only ran against the mock).

No kernel/engine changes; no perf-baseline impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F