### PR TITLE
chore(runtime,exec): single-source SSM conv-channel formula + once-per-init native-cache-demand scan

### DIFF
--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -51,7 +51,7 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
     int n_groups = cfg.ssm_group_count;
     int ssize = cfg.ssm_state_size;
     int conv_kernel = cfg.ssm_conv_kernel;
-    int conv_channels = inner + 2 * n_groups * ssize;
+    int conv_channels = cfg.ssm_conv_channels();
     int n_heads = cfg.ssm_dt_rank;
     int head_dim_ssm = inner / n_heads;
 
@@ -273,7 +273,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     int n_groups = cfg.ssm_group_count;
     int ssize = cfg.ssm_state_size;
     int conv_kernel = cfg.ssm_conv_kernel;
-    int conv_channels = inner + 2 * n_groups * ssize;
+    int conv_channels = cfg.ssm_conv_channels();
     int n_heads = cfg.ssm_dt_rank;
     int head_dim_ssm = (n_heads > 0) ? inner / n_heads : 0;
 

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -426,10 +426,8 @@ void Workspace::compute_shared_sizes(int max_tokens) {
     // SSM phase
     if (*has_ssm_) {
         int inner = cfg.ssm_inner_size;
-        int n_groups = cfg.ssm_group_count;
-        int state_size = cfg.ssm_state_size;
         int n_heads = cfg.ssm_dt_rank;
-        int conv_channels = inner + 2 * n_groups * state_size;
+        int conv_channels = cfg.ssm_conv_channels();
         int ssm_in_dim = inner + conv_channels + n_heads;
 
         size_t proj_elem_size = *has_gdn_ ? sizeof(float) : es;

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -722,7 +722,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                            cfg.n_heads * (cfg.head_dim > 0 ? cfg.head_dim : (cfg.d_model / cfg.n_heads)));
         // SSM dimensions
         if (cfg.ssm_inner_size > 0) {
-            int conv_ch = cfg.ssm_inner_size + 2 * cfg.ssm_group_count * cfg.ssm_state_size;
+            int conv_ch = cfg.ssm_conv_channels();
             int ssm_in_dim = cfg.ssm_inner_size + conv_ch + cfg.ssm_dt_rank;
             int gdn_fused_total = conv_ch + cfg.ssm_inner_size + 2 * cfg.ssm_dt_rank;
             max_dim = std::max(max_dim, ssm_in_dim);

--- a/src/exec/executor_workspace_config.cu
+++ b/src/exec/executor_workspace_config.cu
@@ -95,10 +95,8 @@ void GraphExecutor::configure_ssm_workspace(int max_tokens) {
     const auto& cfg = model_->config();
     int d = cfg.d_model;
     int inner = cfg.ssm_inner_size;
-    int n_groups = cfg.ssm_group_count;
-    int state_size = cfg.ssm_state_size;
     int n_heads = cfg.ssm_dt_rank;
-    int conv_channels = inner + 2 * n_groups * state_size;
+    int conv_channels = cfg.ssm_conv_channels();
     int ssm_in_dim = inner + conv_channels + n_heads;
     size_t es = dtype_size(compute_dtype_);
 

--- a/src/model/gguf_tensor_assign.cpp
+++ b/src/model/gguf_tensor_assign.cpp
@@ -153,7 +153,7 @@ bool assign_tensor(Model& model, const std::string& name, const Tensor& tensor, 
             int64_t d_model = tensor.shape[1];     // inner dim
 
             // Check if this is a GDN layer (total rows match SSM conv_channels)
-            int ssm_conv_channels = cfg.ssm_inner_size + 2 * cfg.ssm_group_count * cfg.ssm_state_size;
+            int ssm_conv_channels = cfg.ssm_conv_channels();
             if (cfg.ssm_inner_size > 0 && total_rows == ssm_conv_channels) {
                 // GDN layer: treat attn_qkv as ssm_in (fused projection → conv1d input)
                 assign_quant(layer.ssm_in, tensor);

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -40,6 +40,10 @@ struct ModelConfig {
     int ssm_group_count = 0;  // 8
     int ssm_inner_size = 0;   // 4096
     int ssm_dt_rank = 0;      // 64
+    // Conv1d channel count (xBC width: x plus the B/C group states). Derived,
+    // not stored — the single source for what used to be hand-derived at
+    // every SSM sizing/upload/assign site. 0 on non-SSM models.
+    int ssm_conv_channels() const { return ssm_inner_size + 2 * ssm_group_count * ssm_state_size; }
     // Asymmetric-head GDN (n_v_heads > n_k_heads) head storage layout.
     // false (default): heads in tiled order (h % n_groups gives group_id).
     //                  GGUF Qwen3.5/3.6 converters use this layout.

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -11,6 +11,7 @@
 #include "runtime/constraint_manager.h"
 #include "runtime/config.h"
 #include "runtime/suffix_draft.h"
+#include "runtime/vram_budget.h"
 #include "memory/kv_cache.h"
 #include "memory/kv_cache_manager.h"
 #include "memory/ssm_state.h"
@@ -306,6 +307,21 @@ private:
     RuntimeConfig runtime_config_;
     std::shared_ptr<Model> model_;
     EngineConfig config_;
+
+    // compute_native_cache_demand(*model_) is a pure function of the
+    // checkpoint's tensor shapes (stable pre- and post-upload by contract);
+    // it used to be re-scanned at every init phase that needs it (auto
+    // batch/ctx sizing, VRAM budget planning, balloon reserve). Scan once,
+    // reuse everywhere.
+    const NativeCacheDemand& native_cache_demand() {
+        if (!native_cache_demand_valid_) {
+            native_cache_demand_ = compute_native_cache_demand(*model_);
+            native_cache_demand_valid_ = true;
+        }
+        return native_cache_demand_;
+    }
+    NativeCacheDemand native_cache_demand_{};
+    bool native_cache_demand_valid_ = false;
     std::unique_ptr<Scheduler> scheduler_;
     std::unique_ptr<KVCacheManager> kv_manager_;
     KVCache* kv_cache_raw_ = nullptr;  // Non-owning pointer (owned by kv_manager_)

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -306,7 +306,7 @@ void Engine::init_resolve_kv_dtype_policy_() {
             // (vram.native_cache_reserve balloon) — subtract them too so the
             // auto batch doesn't size workspaces into the reserved bytes.
             if (mcfg.is_nvfp4_prequant)
-                upload_bytes += compute_native_cache_demand(*model_).total();
+                upload_bytes += native_cache_demand().total();
             headroom = (free_vram > upload_bytes) ? (free_vram - upload_bytes) : 0;
             int nkv = mcfg.n_kv_heads > 0 ? mcfg.n_kv_heads : 1;
             int hd = mcfg.head_dim > 0 ? mcfg.head_dim
@@ -647,7 +647,7 @@ void Engine::init_compute_max_seq_len_() {
         size_t free_for_kv = free_vram;
         if (mcfg.is_nvfp4_prequant) {
             size_t reserved = approx_weight_footprint_bytes(mcfg) +
-                              compute_native_cache_demand(*model_).total();
+                              native_cache_demand().total();
             free_for_kv = (free_vram > reserved) ? (free_vram - reserved) : 0;
         }
         int max_by_vram = (kv_bytes_per_token > 0)

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -173,7 +173,7 @@ bool Engine::init_kv_cache() {
     // keeps the prequant reserve from charging KV for the same demand twice.
     auto vram_budget = compute_vram_budget(*model_, config_, n_kv_layers, head_dim,
                                            effective_free_vram(), swa_live_tokens, n_swa_layers,
-                                           native_cache_balloon_bytes_);
+                                           native_cache_balloon_bytes_, &native_cache_demand());
     int max_blocks = config_.kv_cache_max_blocks > 0 ? config_.kv_cache_max_blocks
                                                      : vram_budget.kv_max_blocks;
 
@@ -289,7 +289,7 @@ bool Engine::init_kv_cache() {
             if (model_->layer(i).ssm_in.data != nullptr)
                 n_ssm++;
         if (n_ssm > 0) {
-            int conv_ch = mcfg.ssm_inner_size + 2 * mcfg.ssm_group_count * mcfg.ssm_state_size;
+            int conv_ch = mcfg.ssm_conv_channels();
             int n_heads = mcfg.ssm_dt_rank;
             int hd = (n_heads > 0) ? mcfg.ssm_inner_size / n_heads : 0;
             ssm_state_ = std::make_unique<SSMState>();

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -148,7 +148,7 @@ bool Engine::init_weights() {
         expert_reserve += kv_est;
 
         if (mcfg.ssm_inner_size > 0) {
-            int conv_ch = mcfg.ssm_inner_size + 2 * mcfg.ssm_group_count * mcfg.ssm_state_size;
+            int conv_ch = mcfg.ssm_conv_channels();
             int n_heads = mcfg.ssm_dt_rank;
             int hd_ssm = (n_heads > 0) ? mcfg.ssm_inner_size / n_heads : 0;
             int n_ssm = 0;
@@ -283,7 +283,7 @@ bool Engine::init_weights() {
     // caches into the guaranteed space (engine_kv_cache_init.cpp).
     if (mcfg.is_nvfp4_prequant && config_.use_nvfp4_decode == 2 && !experts_on_host_ &&
         runtime_config_.vram.native_cache_reserve) {
-        NativeCacheDemand demand = compute_native_cache_demand(*model_);
+        const NativeCacheDemand& demand = native_cache_demand();
         constexpr size_t kBalloonPad = 64ULL * 1024 * 1024;  // alloc granularity slack
         size_t want = demand.total() + kBalloonPad;
         // The hold must leave room for the ESSENTIAL allocations that run

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -102,7 +102,8 @@ NativeCacheDemand compute_native_cache_demand(const Model& model) {
 
 VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, int n_kv_layers, int head_dim,
                                size_t free_vram, int swa_live_tokens, int n_swa_layers,
-                               size_t mandatory_cache_prealloc) {
+                               size_t mandatory_cache_prealloc,
+                               const NativeCacheDemand* native_demand) {
     VRAMBudget budget;
     const auto& mcfg = model.config();
 
@@ -159,7 +160,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
             if (model.layer(i).ssm_in.data != nullptr)
                 n_ssm++;
         if (n_ssm > 0) {
-            int conv_ch = mcfg.ssm_inner_size + 2 * mcfg.ssm_group_count * mcfg.ssm_state_size;
+            int conv_ch = mcfg.ssm_conv_channels();
             int n_heads = mcfg.ssm_dt_rank;
             int hd_ssm = (n_heads > 0) ? mcfg.ssm_inner_size / n_heads : 0;
             ssm_footprint = static_cast<size_t>(n_ssm) * config.max_batch_size *
@@ -321,7 +322,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
             // compute_native_cache_demand scans the projection tensors
             // directly, no qtype filter: on an NVFP4-prequant checkpoint
             // these are exactly the quantized set.
-            NativeCacheDemand demand = compute_native_cache_demand(model);
+            NativeCacheDemand demand = native_demand ? *native_demand : compute_native_cache_demand(model);
             // Floors are only handed to phase 3 when the balloon physically
             // guaranteed the bytes — an unbacked floor on a genuinely tight
             // card would over-commit the SF slab cudaMalloc. Phase 3b (SF)

--- a/src/runtime/vram_budget.h
+++ b/src/runtime/vram_budget.h
@@ -70,9 +70,13 @@ struct VRAMBudget {
 // mandatory native-NVFP4 decode caches (Engine's balloon, held while this
 // runs — free_vram excludes it). The prequant reserve then only charges KV
 // for the UNCOVERED remainder, preventing a double-count.
+//
+// native_demand: precomputed NativeCacheDemand (Engine's cached scan) to
+// skip the tensor rescan; nullptr computes it locally (tests, standalone).
 VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, int n_kv_layers, int head_dim,
                                size_t free_vram, int swa_live_tokens = 0, int n_swa_layers = 0,
-                               size_t mandatory_cache_prealloc = 0);
+                               size_t mandatory_cache_prealloc = 0,
+                               const NativeCacheDemand* native_demand = nullptr);
 
 // Bytes of one paged KV block for a single layer, K+V combined (2x),
 // packing- and scale-aware. Single source for every KV-size estimate


### PR DESCRIPTION
## What

Closes the two remaining low-prio items from the 2026-07-10 structural audit (`docs/audit/structural_debt_2026_07_10.md`, noted alongside #941-#943).

- **`ModelConfig::ssm_conv_channels()`**: the conv1d channel count (`ssm_inner_size + 2*ssm_group_count*ssm_state_size`) was hand-derived identically at **9 sites** (gguf_tensor_assign, executor_ssm_gdn ×2, executor_workspace, executor_workspace_config, executor_workspace_buffers, vram_budget, engine_kv_cache_init, engine_weight_upload) — a per-site typo would desync workspace sizing from the kernels. Now one derived helper; locals that only fed the formula are dropped.
- **`compute_native_cache_demand()` once per init**: the tensor-shape scan ran 4× per init (resolver auto-batch, resolver auto-ctx, VRAM budget planning, balloon reserve). The Engine now caches it behind a lazy accessor; `compute_vram_budget` takes an optional precomputed `NativeCacheDemand*` (defaulted null) so its ~14 standalone test call sites are untouched. The balloon/floor logic already assumed the demand is identical across phases — the cache makes that assumption structural.

No behavioral change: same arithmetic, one source. No perf-baseline impact (init-time only; decode kernels unchanged).

## Verification

- `make build` + `make test-unit` (709 tests) green; `make test-gpu` 0 failures; `make verify-fast` OK; file-size gate 0 violations.
- Live coherence check on Ornith-1.0-35B-NVFP4 (GDN + native-NVFP4 prequant — exercises every touched path: conv-channel sizing, balloon reserve, budget planning): loads clean, coherent thinking + answer, decode 264 tok/s cold single-shot (in line with the 279 baseline given the ~1s clock-ramp artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F