### PR TITLE
chore(deps): bump CUTLASS v4.5.2 -> v4.5.3

### DIFF
--- a/cmake/imp-deps.cmake
+++ b/cmake/imp-deps.cmake
@@ -8,6 +8,6 @@
 # Used by: CMakeLists.txt FetchContent_Declare GIT_TAG entries.
 
 set(IMP_DEP_GOOGLETEST_TAG    v1.17.0  CACHE STRING "googletest git tag")
-set(IMP_DEP_CUTLASS_TAG       v4.5.2   CACHE STRING "NVIDIA/cutlass git tag")
+set(IMP_DEP_CUTLASS_TAG       v4.5.3   CACHE STRING "NVIDIA/cutlass git tag")
 set(IMP_DEP_HTTPLIB_TAG       v0.48.0  CACHE STRING "cpp-httplib git tag")
 set(IMP_DEP_NLOHMANN_JSON_TAG v3.12.0  CACHE STRING "nlohmann/json git tag")


### PR DESCRIPTION
Maintenance release: fixes a CuTe-DSL compilation-time regression introduced in 4.5.0. No sm_120a / NVFP4 / grouped-GEMM functional changes — imp consumes CUTLASS as C++ headers only, so this is a hygiene bump keeping the pin current.

## Verification (local, RTX 5090)
- Full GPU suite green on the bumped image (8/8 binaries, 0 failures, incl. CUTLASS NVFP4/grouped kernels and the model-mounted e2e battery).
- NVFP4 SafeTensors coherence smoke (Qwen3-8B-NVFP4, CUTLASS prefill path): coherent output, pp512-class prefill 1112 tok/s, tg 250 tok/s.
- No perf-relevant change expected; baseline untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F