### PR TITLE
feat(runtime): on-disk warm weight cache — cold boots skip weight conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ### Added
 - **On-disk warm weight cache** (`[warm_cache] enabled`, default on): the
   first fully-cold model load persists its TRANSFORMED weight uploads
-  (BF16→FP16 host conversions, GPU dequants, split layouts) next to the model
-  (`<file>.impwcache` / `<dir>/.imp_warm_cache`); later boots restore those
-  bytes and skip the conversion work. Raw quant payloads are never duplicated
+  (BF16→FP16 host conversions, GPU dequants, split layouts) into
+  `~/.cache/imp/warm` (override: `[warm_cache] dir`); later boots mmap the
+  cache and skip the conversion work. Raw quant payloads are never duplicated
   — the model file already holds them — so the cache is near-zero for
   raw-served GGUF quants and NVFP4-prequant SafeTensors and ~model-size only
   for BF16-dense checkpoints (where it saves the most startup time). Guarded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ## [Unreleased]
 
 ### Added
+- **On-disk warm weight cache** (`[warm_cache] enabled`, default on): the
+  first fully-cold model load persists its TRANSFORMED weight uploads
+  (BF16→FP16 host conversions, GPU dequants, split layouts) next to the model
+  (`<file>.impwcache` / `<dir>/.imp_warm_cache`); later boots restore those
+  bytes and skip the conversion work. Raw quant payloads are never duplicated
+  — the model file already holds them — so the cache is near-zero for
+  raw-served GGUF quants and NVFP4-prequant SafeTensors and ~model-size only
+  for BF16-dense checkpoints (where it saves the most startup time). Guarded
+  by a format version and a model-content fingerprint; stale or corrupt
+  caches are ignored (normal cold load). Reuses the suspend-to-RAM restore
+  machinery, including its per-tensor cold fallback.
 - **Suspend to RAM** (`POST /admin/suspend` / `POST /admin/resume`): park the
   loaded model's weights in host RAM and free the GPU completely (engine +
   model teardown, mempool trim, and — default on — a CUDA primary-context

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(IMP_MEMORY_SOURCES
     src/memory/kv_cache_manager.cpp
     src/memory/recurrent_snapshot_store.cpp
     src/memory/weight_snapshot.cpp
+    src/memory/weight_cache_file.cpp
     src/memory/vram_query.cpp
     src/memory/ssm_state.cu
     src/memory/layer_offload.cu
@@ -679,6 +680,7 @@ if(IMP_BUILD_TESTS)
         tests/test_api_generate.cpp
         tests/test_engine_relaunch.cpp
         tests/test_suspend_resume.cu
+        tests/test_warm_cache.cu
         tests/test_lora.cpp
         tests/test_prefix_cache_e2e.cpp
         tests/test_determinism_e2e.cpp

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -242,12 +242,16 @@ non-streaming), `/tokenize`, `/detokenize`, `/health`, `/props`, `/info`,
 Tool/function calling, streaming usage stats, logprobs, and API-key auth
 (`--api-key`) supported.
 
-**Warm weight cache.** The first cold load of a model writes a small cache
-next to it (`<file>.impwcache` for GGUF, `.imp_warm_cache` inside a
-SafeTensors directory) holding the converted weight buffers; subsequent
-starts restore them and skip the conversion work. On by default
-(`[warm_cache] enabled = false` to opt out); stale caches (changed model
-file) are detected and ignored. Delete the cache file at any time — the next
+**Warm weight cache.** The first cold load of a model writes a cache file
+(`<model-name>-<hash>.impwcache`) into `~/.cache/imp/warm` (override with
+`[warm_cache] dir`) holding the converted weight buffers; subsequent starts
+mmap it and skip the conversion work. Raw quant payloads are never
+duplicated, so the cache is small for raw-served GGUF quants and
+NVFP4-prequant models and ~model-size for BF16-dense checkpoints. On by
+default (`[warm_cache] enabled = false` to opt out); stale caches (changed
+model file) are detected and ignored — delete the directory at any time. In
+containers, mount a persistent volume at the cache dir; if it is not
+writable, loads simply stay cold (INFO log). Delete the cache file at any time — the next
 load is simply cold and rewrites it.
 
 **Suspend to RAM.** `POST /admin/suspend` drains in-flight requests, parks

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -242,6 +242,14 @@ non-streaming), `/tokenize`, `/detokenize`, `/health`, `/props`, `/info`,
 Tool/function calling, streaming usage stats, logprobs, and API-key auth
 (`--api-key`) supported.
 
+**Warm weight cache.** The first cold load of a model writes a small cache
+next to it (`<file>.impwcache` for GGUF, `.imp_warm_cache` inside a
+SafeTensors directory) holding the converted weight buffers; subsequent
+starts restore them and skip the conversion work. On by default
+(`[warm_cache] enabled = false` to opt out); stale caches (changed model
+file) are detected and ignored. Delete the cache file at any time — the next
+load is simply cold and rewrites it.
+
 **Suspend to RAM.** `POST /admin/suspend` drains in-flight requests, parks
 the model weights in host RAM, and frees the GPU completely (with
 `[suspend] device_reset` — the default — the CUDA context is reset too, so

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -380,6 +380,15 @@ recurrent_snapshot_mb = 256
 # streams (gemma-3-12b IMA). Set true to enable.
 green_contexts       = false
 
+[warm_cache]
+# On-disk warm weight cache: the first fully-cold model load persists its
+# converted weight buffers next to the model (".impwcache" / ".imp_warm_cache");
+# later boots restore them and skip the conversion work. Raw quant payloads are
+# never duplicated (the model file already holds them), so the cache is tiny
+# for GGUF quants / NVFP4 SafeTensors and ~model-size only for BF16-dense
+# checkpoints. Stale caches (model file changed) are ignored automatically.
+enabled              = true
+
 [suspend]
 # Suspend-to-RAM (POST /admin/suspend): weights are snapshotted to host RAM,
 # all VRAM is freed, and POST /admin/resume restores them in seconds.

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -388,6 +388,10 @@ green_contexts       = false
 # for GGUF quants / NVFP4 SafeTensors and ~model-size only for BF16-dense
 # checkpoints. Stale caches (model file changed) are ignored automatically.
 enabled              = true
+# Cache directory. Empty = default: $XDG_CACHE_HOME/imp/warm (or
+# ~/.cache/imp/warm). In containers, mount a persistent volume there (or set
+# this to one) — an ephemeral cache is rewritten on every start.
+dir                  = ""
 
 [suspend]
 # Suspend-to-RAM (POST /admin/suspend): weights are snapshotted to host RAM,

--- a/src/memory/weight_cache_file.cpp
+++ b/src/memory/weight_cache_file.cpp
@@ -1,0 +1,272 @@
+#include "memory/weight_cache_file.h"
+#include "core/logging.h"
+#include "memory/weight_snapshot.h"
+#include "model/model.h"
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <unistd.h>
+#include <vector>
+
+namespace imp {
+
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr char kMagic[8] = {'I', 'M', 'P', 'W', 'C', 'A', 'C', 'H'};
+constexpr uint32_t kVersion = 1;
+
+struct FileHeader {
+    char magic[8];
+    uint32_t version;
+    uint32_t tensor_pod_size;  // sizeof(Tensor) sanity guard across rebuilds
+    int32_t arch_id;
+    int32_t n_layers;
+    uint64_t fp_total_bytes;
+    int64_t fp_mtime_max;
+    uint32_t record_count;
+    uint32_t reserved = 0;
+};
+
+struct RecordHeader {
+    uint32_t key_len;
+    int32_t src_qtype;
+    int64_t src_numel;
+    uint64_t src_nbytes;
+    int32_t data_alloc;
+    uint64_t data_off;
+    int32_t scales_alloc;
+    uint64_t scales_off;
+    uint32_t n_allocs;
+};
+
+int64_t mtime_seconds(const fs::directory_entry& e, std::error_code& ec) {
+    auto t = e.last_write_time(ec);
+    if (ec)
+        return 0;
+    return std::chrono::duration_cast<std::chrono::seconds>(t.time_since_epoch()).count();
+}
+
+}  // namespace
+
+std::string weight_cache_path_for(const std::string& model_path) {
+    std::error_code ec;
+    if (fs::is_directory(model_path, ec)) {
+        std::string p = model_path;
+        while (p.size() > 1 && p.back() == '/')
+            p.pop_back();
+        return p + "/.imp_warm_cache";
+    }
+    return model_path + ".impwcache";
+}
+
+WeightCacheFingerprint weight_cache_fingerprint(const std::string& model_path) {
+    WeightCacheFingerprint fp;
+    std::error_code ec;
+    if (fs::is_directory(model_path, ec)) {
+        const std::string cache_name = ".imp_warm_cache";
+        for (const auto& e : fs::recursive_directory_iterator(
+                 model_path, fs::directory_options::skip_permission_denied, ec)) {
+            if (ec)
+                break;
+            std::error_code fec;
+            if (!e.is_regular_file(fec) || fec)
+                continue;
+            if (e.path().filename() == cache_name)
+                continue;  // the cache must not fingerprint itself
+            fp.total_bytes += e.file_size(fec);
+            fp.mtime_max = std::max(fp.mtime_max, mtime_seconds(e, fec));
+        }
+    } else {
+        fs::directory_entry e(model_path, ec);
+        std::error_code fec;
+        if (!ec && e.is_regular_file(fec) && !fec) {
+            fp.total_bytes = e.file_size(fec);
+            fp.mtime_max = mtime_seconds(e, fec);
+        }
+    }
+    return fp;
+}
+
+bool weight_cache_write(const Model& model, const std::string& cache_path) {
+    const WeightUploadLog* log = model.upload_log();
+    if (!log || model.source_path().empty())
+        return false;
+
+    // Collect the transformed live records.
+    std::vector<const WeightUploadRecord*> recs;
+    size_t total = 0;
+    for (const auto& rec : log->records()) {
+        if (rec.dead || rec.raw_from_source)
+            continue;
+        recs.push_back(&rec);
+        for (const auto& a : rec.allocs)
+            total += a.bytes;
+    }
+    if (recs.empty()) {
+        IMP_LOG_INFO("Warm cache: nothing to persist — every upload is raw-from-source");
+        return false;
+    }
+
+    const WeightCacheFingerprint fp = weight_cache_fingerprint(model.source_path());
+
+    // PID-unique tmp so concurrent processes loading the same model cannot
+    // interleave writes; the rename below is atomic either way.
+    const std::string tmp_path = cache_path + ".tmp." + std::to_string(getpid());
+    std::ofstream f(tmp_path, std::ios::binary | std::ios::trunc);
+    if (!f) {
+        IMP_LOG_WARN("Warm cache: cannot write %s (directory read-only?) — skipping", tmp_path.c_str());
+        return false;
+    }
+
+    FileHeader hdr{};
+    memcpy(hdr.magic, kMagic, sizeof(kMagic));
+    hdr.version = kVersion;
+    hdr.tensor_pod_size = static_cast<uint32_t>(sizeof(Tensor));
+    hdr.arch_id = static_cast<int32_t>(model.config().arch);
+    hdr.n_layers = model.n_layers();
+    hdr.fp_total_bytes = fp.total_bytes;
+    hdr.fp_mtime_max = fp.mtime_max;
+    hdr.record_count = static_cast<uint32_t>(recs.size());
+    f.write(reinterpret_cast<const char*>(&hdr), sizeof(hdr));
+
+    // Retire outstanding device work once, then D2H each alloc via a reusable
+    // host bounce buffer streamed straight to disk.
+    cudaError_t sync = cudaDeviceSynchronize();
+    if (sync != cudaSuccess) {
+        IMP_LOG_WARN("Warm cache: device sync failed (%s) — skipping write", cudaGetErrorString(sync));
+        return false;
+    }
+    std::vector<uint8_t> bounce;
+    for (const WeightUploadRecord* rec : recs) {
+        RecordHeader rh{};
+        rh.key_len = static_cast<uint32_t>(rec->key.size());
+        rh.src_qtype = static_cast<int32_t>(rec->src_qtype);
+        rh.src_numel = rec->src_numel;
+        rh.src_nbytes = rec->src_nbytes;
+        rh.data_alloc = rec->data_alloc;
+        rh.data_off = rec->data_off;
+        rh.scales_alloc = rec->scales_alloc;
+        rh.scales_off = rec->scales_off;
+        rh.n_allocs = static_cast<uint32_t>(rec->allocs.size());
+        f.write(reinterpret_cast<const char*>(&rh), sizeof(rh));
+        f.write(rec->key.data(), static_cast<std::streamsize>(rec->key.size()));
+        // Post-upload tensor state verbatim; the two device pointers inside are
+        // fixed up by try_restore at load. Guarded by tensor_pod_size + version.
+        f.write(reinterpret_cast<const char*>(&rec->tensor), sizeof(Tensor));
+        for (const auto& a : rec->allocs) {
+            uint64_t bytes = a.bytes;
+            f.write(reinterpret_cast<const char*>(&bytes), sizeof(bytes));
+            bounce.resize(a.bytes);
+            if (cudaMemcpy(bounce.data(), a.ptr, a.bytes, cudaMemcpyDeviceToHost) != cudaSuccess) {
+                IMP_LOG_WARN("Warm cache: D2H failed for %s — aborting write", rec->key.c_str());
+                f.close();
+                std::error_code ec;
+                fs::remove(tmp_path, ec);
+                return false;
+            }
+            f.write(reinterpret_cast<const char*>(bounce.data()), static_cast<std::streamsize>(a.bytes));
+        }
+    }
+    f.flush();
+    if (!f) {
+        IMP_LOG_WARN("Warm cache: write to %s failed (disk full?) — skipping", tmp_path.c_str());
+        f.close();
+        std::error_code ec;
+        fs::remove(tmp_path, ec);
+        return false;
+    }
+    f.close();
+
+    std::error_code ec;
+    fs::rename(tmp_path, cache_path, ec);
+    if (ec) {
+        IMP_LOG_WARN("Warm cache: rename to %s failed: %s", cache_path.c_str(), ec.message().c_str());
+        fs::remove(tmp_path, ec);
+        return false;
+    }
+    IMP_LOG_INFO("Warm cache: persisted %zu transformed uploads (%.2f GiB) to %s", recs.size(),
+                 total / (1024.0 * 1024.0 * 1024.0), cache_path.c_str());
+    return true;
+}
+
+std::unique_ptr<WeightSnapshot> weight_cache_load(const std::string& cache_path, const Model& model) {
+    std::ifstream f(cache_path, std::ios::binary);
+    if (!f)
+        return nullptr;  // no cache — the normal case on first load
+
+    FileHeader hdr{};
+    f.read(reinterpret_cast<char*>(&hdr), sizeof(hdr));
+    if (!f || memcmp(hdr.magic, kMagic, sizeof(kMagic)) != 0 || hdr.version != kVersion ||
+        hdr.tensor_pod_size != sizeof(Tensor)) {
+        IMP_LOG_INFO("Warm cache: %s has an incompatible format — ignoring (cold load)",
+                     cache_path.c_str());
+        return nullptr;
+    }
+    if (hdr.arch_id != static_cast<int32_t>(model.config().arch) || hdr.n_layers != model.n_layers()) {
+        IMP_LOG_INFO("Warm cache: %s does not match this model (arch/layers) — ignoring", cache_path.c_str());
+        return nullptr;
+    }
+    const WeightCacheFingerprint now = weight_cache_fingerprint(model.source_path());
+    if (now.total_bytes != hdr.fp_total_bytes || now.mtime_max != hdr.fp_mtime_max) {
+        IMP_LOG_INFO("Warm cache: %s is stale (model file changed) — ignoring (cold load)",
+                     cache_path.c_str());
+        return nullptr;
+    }
+
+    auto snap = std::make_unique<WeightSnapshot>();
+    snap->builder_set_identity(hdr.arch_id, hdr.n_layers);
+    for (uint32_t i = 0; i < hdr.record_count; ++i) {
+        RecordHeader rh{};
+        f.read(reinterpret_cast<char*>(&rh), sizeof(rh));
+        if (!f || rh.key_len == 0 || rh.key_len > 256 || rh.n_allocs == 0 || rh.n_allocs > 16) {
+            IMP_LOG_WARN("Warm cache: %s truncated/corrupt at record %u — ignoring (cold load)",
+                         cache_path.c_str(), i);
+            return nullptr;
+        }
+        WeightUploadRecord rec;
+        rec.key.resize(rh.key_len);
+        f.read(rec.key.data(), rh.key_len);
+        f.read(reinterpret_cast<char*>(&rec.tensor), sizeof(Tensor));
+        rec.src_qtype = static_cast<QType>(rh.src_qtype);
+        rec.src_numel = rh.src_numel;
+        rec.src_nbytes = rh.src_nbytes;
+        rec.data_alloc = rh.data_alloc;
+        rec.data_off = rh.data_off;
+        rec.scales_alloc = rh.scales_alloc;
+        rec.scales_off = rh.scales_off;
+
+        std::vector<std::unique_ptr<uint8_t[]>> host_data;
+        host_data.reserve(rh.n_allocs);
+        for (uint32_t a = 0; a < rh.n_allocs; ++a) {
+            uint64_t bytes = 0;
+            f.read(reinterpret_cast<char*>(&bytes), sizeof(bytes));
+            if (!f || bytes == 0 || bytes > (64ull << 30)) {
+                IMP_LOG_WARN("Warm cache: %s corrupt alloc size at record %u — ignoring", cache_path.c_str(),
+                             i);
+                return nullptr;
+            }
+            std::unique_ptr<uint8_t[]> buf(new uint8_t[bytes]);
+            f.read(reinterpret_cast<char*>(buf.get()), static_cast<std::streamsize>(bytes));
+            if (!f) {
+                IMP_LOG_WARN("Warm cache: %s truncated in record %u — ignoring", cache_path.c_str(), i);
+                return nullptr;
+            }
+            rec.allocs.push_back({nullptr, static_cast<size_t>(bytes)});  // device ptr set at restore
+            host_data.push_back(std::move(buf));
+        }
+        snap->builder_add(std::move(rec), std::move(host_data));
+    }
+
+    IMP_LOG_INFO("Warm cache: loaded %zu transformed uploads (%.2f GiB) from %s", snap->record_count(),
+                 snap->total_bytes() / (1024.0 * 1024.0 * 1024.0), cache_path.c_str());
+    return snap;
+}
+
+}  // namespace imp

--- a/src/memory/weight_cache_file.cpp
+++ b/src/memory/weight_cache_file.cpp
@@ -7,9 +7,13 @@
 
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
 
@@ -55,15 +59,36 @@ int64_t mtime_seconds(const fs::directory_entry& e, std::error_code& ec) {
 
 }  // namespace
 
-std::string weight_cache_path_for(const std::string& model_path) {
+// Default cache directory: $XDG_CACHE_HOME/imp/warm, else $HOME/.cache/imp/warm,
+// else /tmp/imp-warm-cache. Deliberately NOT next to the model: model mounts
+// are often read-only for the serving user, and cache files should not clutter
+// (or invalidate tooling checksums of) model directories.
+static std::string default_warm_cache_dir() {
+    if (const char* xdg = getenv("XDG_CACHE_HOME"); xdg && *xdg)
+        return std::string(xdg) + "/imp/warm";
+    if (const char* home = getenv("HOME"); home && *home)
+        return std::string(home) + "/.cache/imp/warm";
+    return "/tmp/imp-warm-cache";
+}
+
+std::string weight_cache_path_for(const std::string& model_path, const std::string& cache_dir) {
     std::error_code ec;
-    if (fs::is_directory(model_path, ec)) {
-        std::string p = model_path;
-        while (p.size() > 1 && p.back() == '/')
-            p.pop_back();
-        return p + "/.imp_warm_cache";
+    std::string p = model_path;
+    while (p.size() > 1 && p.back() == '/')
+        p.pop_back();
+    std::string dir = cache_dir.empty() ? default_warm_cache_dir() : cache_dir;
+    while (dir.size() > 1 && dir.back() == '/')
+        dir.pop_back();
+    fs::create_directories(dir, ec);      // best-effort; write fails loudly later
+    uint64_t h = 1469598103934665603ull;  // FNV-1a over the full model path
+    for (unsigned char c : p) {
+        h ^= c;
+        h *= 1099511628211ull;
     }
-    return model_path + ".impwcache";
+    char hex[17];
+    snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(h));
+    std::string base = fs::path(p).filename().string();
+    return dir + "/" + base + "-" + hex + ".impwcache";
 }
 
 WeightCacheFingerprint weight_cache_fingerprint(const std::string& model_path) {
@@ -121,7 +146,10 @@ bool weight_cache_write(const Model& model, const std::string& cache_path) {
     const std::string tmp_path = cache_path + ".tmp." + std::to_string(getpid());
     std::ofstream f(tmp_path, std::ios::binary | std::ios::trunc);
     if (!f) {
-        IMP_LOG_WARN("Warm cache: cannot write %s (directory read-only?) — skipping", tmp_path.c_str());
+        // Expected in containers where the model mount is read-only for the
+        // serving user — point [warm_cache] dir at a writable volume to enable.
+        IMP_LOG_INFO("Warm cache: %s not writable — skipping (set [warm_cache] dir to enable)",
+                     tmp_path.c_str());
         return false;
     }
 
@@ -197,14 +225,40 @@ bool weight_cache_write(const Model& model, const std::string& cache_path) {
 }
 
 std::unique_ptr<WeightSnapshot> weight_cache_load(const std::string& cache_path, const Model& model) {
-    std::ifstream f(cache_path, std::ios::binary);
-    if (!f)
+    int fd = open(cache_path.c_str(), O_RDONLY);
+    if (fd < 0)
         return nullptr;  // no cache — the normal case on first load
 
+    struct stat st{};
+    if (fstat(fd, &st) != 0 || st.st_size < static_cast<off_t>(sizeof(FileHeader))) {
+        close(fd);
+        return nullptr;
+    }
+    const size_t map_size = static_cast<size_t>(st.st_size);
+    void* base = mmap(nullptr, map_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);  // mapping keeps the file alive
+    if (base == MAP_FAILED)
+        return nullptr;
+    // Kick off readahead: the blobs are consumed once, sequentially, during
+    // the upload pass — overlap disk with the loader/H2D work.
+    (void)madvise(base, map_size, MADV_WILLNEED);
+
+    auto snap = std::make_unique<WeightSnapshot>();
+    snap->builder_set_mmap(base, map_size);  // snapshot dtor munmaps on ALL exits below
+
+    const uint8_t* cur = static_cast<const uint8_t*>(base);
+    const uint8_t* end = cur + map_size;
+    auto take = [&cur, end](void* dst, size_t n) {
+        if (static_cast<size_t>(end - cur) < n)
+            return false;
+        memcpy(dst, cur, n);
+        cur += n;
+        return true;
+    };
+
     FileHeader hdr{};
-    f.read(reinterpret_cast<char*>(&hdr), sizeof(hdr));
-    if (!f || memcmp(hdr.magic, kMagic, sizeof(kMagic)) != 0 || hdr.version != kVersion ||
-        hdr.tensor_pod_size != sizeof(Tensor)) {
+    if (!take(&hdr, sizeof(hdr)) || memcmp(hdr.magic, kMagic, sizeof(kMagic)) != 0 ||
+        hdr.version != kVersion || hdr.tensor_pod_size != sizeof(Tensor)) {
         IMP_LOG_INFO("Warm cache: %s has an incompatible format — ignoring (cold load)",
                      cache_path.c_str());
         return nullptr;
@@ -220,20 +274,20 @@ std::unique_ptr<WeightSnapshot> weight_cache_load(const std::string& cache_path,
         return nullptr;
     }
 
-    auto snap = std::make_unique<WeightSnapshot>();
-    snap->builder_set_identity(hdr.arch_id, hdr.n_layers);
     for (uint32_t i = 0; i < hdr.record_count; ++i) {
         RecordHeader rh{};
-        f.read(reinterpret_cast<char*>(&rh), sizeof(rh));
-        if (!f || rh.key_len == 0 || rh.key_len > 256 || rh.n_allocs == 0 || rh.n_allocs > 16) {
+        if (!take(&rh, sizeof(rh)) || rh.key_len == 0 || rh.key_len > 256 || rh.n_allocs == 0 ||
+            rh.n_allocs > 16) {
             IMP_LOG_WARN("Warm cache: %s truncated/corrupt at record %u — ignoring (cold load)",
                          cache_path.c_str(), i);
             return nullptr;
         }
         WeightUploadRecord rec;
         rec.key.resize(rh.key_len);
-        f.read(rec.key.data(), rh.key_len);
-        f.read(reinterpret_cast<char*>(&rec.tensor), sizeof(Tensor));
+        if (!take(rec.key.data(), rh.key_len) || !take(&rec.tensor, sizeof(Tensor))) {
+            IMP_LOG_WARN("Warm cache: %s truncated in record %u — ignoring", cache_path.c_str(), i);
+            return nullptr;
+        }
         rec.src_qtype = static_cast<QType>(rh.src_qtype);
         rec.src_numel = rh.src_numel;
         rec.src_nbytes = rh.src_nbytes;
@@ -242,29 +296,24 @@ std::unique_ptr<WeightSnapshot> weight_cache_load(const std::string& cache_path,
         rec.scales_alloc = rh.scales_alloc;
         rec.scales_off = rh.scales_off;
 
-        std::vector<std::unique_ptr<uint8_t[]>> host_data;
-        host_data.reserve(rh.n_allocs);
+        std::vector<const uint8_t*> views;
+        views.reserve(rh.n_allocs);
         for (uint32_t a = 0; a < rh.n_allocs; ++a) {
             uint64_t bytes = 0;
-            f.read(reinterpret_cast<char*>(&bytes), sizeof(bytes));
-            if (!f || bytes == 0 || bytes > (64ull << 30)) {
-                IMP_LOG_WARN("Warm cache: %s corrupt alloc size at record %u — ignoring", cache_path.c_str(),
-                             i);
+            if (!take(&bytes, sizeof(bytes)) || bytes == 0 ||
+                bytes > static_cast<uint64_t>(end - cur)) {
+                IMP_LOG_WARN("Warm cache: %s corrupt alloc size at record %u — ignoring",
+                             cache_path.c_str(), i);
                 return nullptr;
             }
-            std::unique_ptr<uint8_t[]> buf(new uint8_t[bytes]);
-            f.read(reinterpret_cast<char*>(buf.get()), static_cast<std::streamsize>(bytes));
-            if (!f) {
-                IMP_LOG_WARN("Warm cache: %s truncated in record %u — ignoring", cache_path.c_str(), i);
-                return nullptr;
-            }
+            views.push_back(cur);  // zero-copy: blob stays in the mapping
+            cur += bytes;
             rec.allocs.push_back({nullptr, static_cast<size_t>(bytes)});  // device ptr set at restore
-            host_data.push_back(std::move(buf));
         }
-        snap->builder_add(std::move(rec), std::move(host_data));
+        snap->builder_add_views(std::move(rec), std::move(views));
     }
 
-    IMP_LOG_INFO("Warm cache: loaded %zu transformed uploads (%.2f GiB) from %s", snap->record_count(),
+    IMP_LOG_INFO("Warm cache: mapped %zu transformed uploads (%.2f GiB) from %s", snap->record_count(),
                  snap->total_bytes() / (1024.0 * 1024.0 * 1024.0), cache_path.c_str());
     return snap;
 }

--- a/src/memory/weight_cache_file.h
+++ b/src/memory/weight_cache_file.h
@@ -1,0 +1,59 @@
+#pragma once
+
+// On-disk warm weight cache — cold-boot companion to the suspend-to-RAM
+// snapshot (weight_snapshot.h).
+//
+// At the end of a fully-cold weight upload, the TRANSFORMED upload records
+// (host BF16→FP16 conversions, GPU dequants, split layouts — everything whose
+// device bytes differ from the model file) are copied D2H once and persisted
+// next to the model. Raw-from-source records are deliberately NOT stored: a
+// cold re-upload from the model file mmap is byte-equivalent and costs the
+// same, so the cache stays small (near-zero for raw-served GGUF quants and
+// NVFP4-prequant SafeTensors; ~model-size only for BF16-dense checkpoints,
+// which is exactly where it saves the most startup time).
+//
+// At the next boot the cache is loaded into a WeightSnapshot and armed for
+// the upload pass — the same per-key restore machinery as suspend/resume,
+// with the same safety property: any miss or mismatch falls back to the
+// normal cold path per tensor.
+//
+// Staleness guards: format version, model arch + layer count, and a content
+// fingerprint of the model path (total regular-file bytes + newest mtime).
+// The file is written atomically (tmp + rename) and is best-effort in both
+// directions — any failure just means a normal cold load.
+
+#include <memory>
+#include <string>
+
+namespace imp {
+
+class Model;
+class WeightSnapshot;
+
+// "<file>.impwcache" for a regular file, "<dir>/.imp_warm_cache" for a
+// SafeTensors directory.
+std::string weight_cache_path_for(const std::string& model_path);
+
+struct WeightCacheFingerprint {
+    uint64_t total_bytes = 0;
+    int64_t mtime_max = 0;  // seconds since epoch of the newest regular file
+    bool operator==(const WeightCacheFingerprint&) const = default;
+};
+
+// Content fingerprint of a model file or SafeTensors directory (recursive,
+// regular files only; the cache file itself is excluded). Zero-initialized
+// result if the path does not exist.
+WeightCacheFingerprint weight_cache_fingerprint(const std::string& model_path);
+
+// Persist the model's transformed live upload records (device bytes D2H'd
+// here). Returns false and logs on any failure; never throws. Writes nothing
+// when there are no transformed records to store.
+bool weight_cache_write(const Model& model, const std::string& cache_path);
+
+// Load + validate a cache file against the model's identity (arch, n_layers)
+// and the current fingerprint of its source path. Returns nullptr on any
+// mismatch or parse problem (logged at INFO — stale caches are expected
+// after a model re-download).
+std::unique_ptr<WeightSnapshot> weight_cache_load(const std::string& cache_path, const Model& model);
+
+}  // namespace imp

--- a/src/memory/weight_cache_file.h
+++ b/src/memory/weight_cache_file.h
@@ -6,7 +6,7 @@
 // At the end of a fully-cold weight upload, the TRANSFORMED upload records
 // (host BF16→FP16 conversions, GPU dequants, split layouts — everything whose
 // device bytes differ from the model file) are copied D2H once and persisted
-// next to the model. Raw-from-source records are deliberately NOT stored: a
+// into a dedicated cache directory (~/.cache/imp/warm by default). Raw-from-source records are deliberately NOT stored: a
 // cold re-upload from the model file mmap is byte-equivalent and costs the
 // same, so the cache stays small (near-zero for raw-served GGUF quants and
 // NVFP4-prequant SafeTensors; ~model-size only for BF16-dense checkpoints,
@@ -30,9 +30,11 @@ namespace imp {
 class Model;
 class WeightSnapshot;
 
-// "<file>.impwcache" for a regular file, "<dir>/.imp_warm_cache" for a
-// SafeTensors directory.
-std::string weight_cache_path_for(const std::string& model_path);
+// "<dir>/<model-basename>-<path-hash>.impwcache" where dir is cache_dir
+// ([warm_cache] dir) or, when empty, the default cache directory
+// ($XDG_CACHE_HOME/imp/warm, else ~/.cache/imp/warm, else
+// /tmp/imp-warm-cache). The directory is created best-effort.
+std::string weight_cache_path_for(const std::string& model_path, const std::string& cache_dir = {});
 
 struct WeightCacheFingerprint {
     uint64_t total_bytes = 0;

--- a/src/memory/weight_snapshot.cpp
+++ b/src/memory/weight_snapshot.cpp
@@ -24,7 +24,8 @@ const char* make_weight_key(char* buf, size_t buf_len, const char* name, int lay
 // ---------------------------------------------------------------------------
 
 void WeightUploadLog::record(const char* key, const void* const* allocs, size_t n_allocs,
-                             const Tensor& post, QType src_qtype, int64_t src_numel) {
+                             const Tensor& post, QType src_qtype, int64_t src_numel,
+                             size_t src_nbytes) {
     if (!key || n_allocs == 0)
         return;
 
@@ -63,6 +64,11 @@ void WeightUploadLog::record(const char* key, const void* const* allocs, size_t 
     rec.tensor = post;
     rec.src_qtype = src_qtype;
     rec.src_numel = src_numel;
+    rec.src_nbytes = src_nbytes;
+    // See the field comment: heuristic only gates warm-cache persistence.
+    rec.raw_from_source = rec.allocs.size() == 1 && post.qtype == src_qtype &&
+                          src_qtype != QType::MXFP4 && post.scales == nullptr &&
+                          rec.allocs[0].bytes == src_nbytes;
 
     auto it = by_key_.find(rec.key);
     if (it != by_key_.end()) {
@@ -252,7 +258,7 @@ bool WeightSnapshot::try_restore(const char* key, Tensor& weight, cudaStream_t s
         // note_alloc happened inside ops.alloc (checked_cuda_malloc); re-record
         // so a subsequent suspend of the resumed model captures this slot again.
         new_log->record(key, const_cast<const void* const*>(new_allocs.data()), new_allocs.size(),
-                        weight, rec.src_qtype, rec.src_numel);
+                        weight, rec.src_qtype, rec.src_numel, rec.src_nbytes);
     }
     hits_++;
     return true;

--- a/src/memory/weight_snapshot.cpp
+++ b/src/memory/weight_snapshot.cpp
@@ -7,6 +7,10 @@
 #include <sstream>
 #include <stdexcept>
 
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
+
 namespace imp {
 
 const char* make_weight_key(char* buf, size_t buf_len, const char* name, int layer) {
@@ -17,6 +21,13 @@ const char* make_weight_key(char* buf, size_t buf_len, const char* name, int lay
     else
         snprintf(buf, buf_len, "%s", name);
     return buf;
+}
+
+WeightSnapshot::~WeightSnapshot() {
+#ifdef __linux__
+    if (mmap_base_ && mmap_size_ > 0)
+        munmap(mmap_base_, mmap_size_);
+#endif
 }
 
 // ---------------------------------------------------------------------------
@@ -182,7 +193,8 @@ std::unique_ptr<WeightSnapshot> WeightSnapshot::capture(const Model& model,
         }
         Blob blob;
         blob.rec = rec;
-        blob.host_data.reserve(rec.allocs.size());
+        blob.owned.reserve(rec.allocs.size());
+        blob.views.reserve(rec.allocs.size());
         for (const auto& a : rec.allocs) {
             // Default-initialized (no memset) — filled entirely by the D2H copy.
             std::unique_ptr<uint8_t[]> buf(new uint8_t[a.bytes]);
@@ -194,7 +206,8 @@ std::unique_ptr<WeightSnapshot> WeightSnapshot::capture(const Model& model,
                 throw std::runtime_error(msg);
             }
             snap->total_bytes_ += a.bytes;
-            blob.host_data.push_back(std::move(buf));
+            blob.views.push_back(buf.get());
+            blob.owned.push_back(std::move(buf));
         }
         snap->blobs_.emplace(rec.key, std::move(blob));
         captured++;
@@ -237,7 +250,7 @@ bool WeightSnapshot::try_restore(const char* key, Tensor& weight, cudaStream_t s
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(q, stream));
             return false;  // out of VRAM — cold path will make its own call
         }
-        if (ops.copy_h2d(p, blob.host_data[i].get(), rec.allocs[i].bytes, stream) != cudaSuccess) {
+        if (ops.copy_h2d(p, blob.views[i], rec.allocs[i].bytes, stream) != cudaSuccess) {
             IMP_CUDA_CHECK_LOG(cudaFreeAsync(p, stream));
             for (void* q : new_allocs)
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(q, stream));

--- a/src/memory/weight_snapshot.h
+++ b/src/memory/weight_snapshot.h
@@ -73,8 +73,16 @@ struct WeightUploadRecord {
     // (or divergent load config) falls back to the cold path per tensor.
     QType src_qtype = QType::NONE;
     int64_t src_numel = 0;
+    size_t src_nbytes = 0;
     // Source dropped by the pipeline (release_gpu_allocation) — not capturable.
     bool dead = false;
+    // Device bytes are a verbatim copy of the host source (plain h2d, no
+    // conversion/reorder). Derived heuristically in record(): single alloc,
+    // same qtype, same byte count, no scales sidecar (MXFP4 excluded — its
+    // split reorder keeps size + qtype). Only gates what the on-disk warm
+    // cache persists: a false "raw" merely skips caching that tensor, the
+    // cold re-upload is byte-equivalent either way.
+    bool raw_from_source = false;
 };
 
 class WeightUploadLog {
@@ -86,7 +94,7 @@ public:
     // silently (leaving the tensor cold-only) if any size is unknown or the
     // tensor data pointer is not backed by the listed allocations.
     void record(const char* key, const void* const* allocs, size_t n_allocs, const Tensor& post,
-                QType src_qtype, int64_t src_numel);
+                QType src_qtype, int64_t src_numel, size_t src_nbytes);
 
     // Mark every record touching ptr dead (pipeline dropped the source).
     void evict_ptr(void* ptr);
@@ -131,6 +139,20 @@ public:
     // Test hook: drop one captured record so that key takes the cold path at
     // resume — proves warm and cold uploads mix byte-safely.
     bool drop_key(const std::string& key) { return blobs_.erase(key) > 0; }
+
+    // Builder API for the on-disk warm cache (memory/weight_cache_file.cpp):
+    // assembles a snapshot from deserialized records instead of a live capture.
+    void builder_set_identity(int arch_id, int n_layers) {
+        arch_id_ = arch_id;
+        n_layers_ = n_layers;
+    }
+    void builder_add(WeightUploadRecord rec, std::vector<std::unique_ptr<uint8_t[]>> host_data) {
+        for (const auto& a : rec.allocs)
+            total_bytes_ += a.bytes;
+        std::string key = rec.key;
+        blobs_.emplace(std::move(key), Blob{std::move(rec), std::move(host_data)});
+    }
+    size_t record_count() const { return blobs_.size(); }
 
 private:
     struct Blob {

--- a/src/memory/weight_snapshot.h
+++ b/src/memory/weight_snapshot.h
@@ -146,20 +146,39 @@ public:
         arch_id_ = arch_id;
         n_layers_ = n_layers;
     }
-    void builder_add(WeightUploadRecord rec, std::vector<std::unique_ptr<uint8_t[]>> host_data) {
+    // Zero-copy variant: blob bytes are VIEWS into an mmap the snapshot takes
+    // ownership of via builder_set_mmap (munmapped in the destructor).
+    void builder_add_views(WeightUploadRecord rec, std::vector<const uint8_t*> views) {
         for (const auto& a : rec.allocs)
             total_bytes_ += a.bytes;
         std::string key = rec.key;
-        blobs_.emplace(std::move(key), Blob{std::move(rec), std::move(host_data)});
+        Blob blob;
+        blob.rec = std::move(rec);
+        blob.views = std::move(views);
+        blobs_.emplace(std::move(key), std::move(blob));
+    }
+    void builder_set_mmap(void* base, size_t size) {
+        mmap_base_ = base;
+        mmap_size_ = size;
     }
     size_t record_count() const { return blobs_.size(); }
 
+    WeightSnapshot() = default;
+    ~WeightSnapshot();
+    WeightSnapshot(const WeightSnapshot&) = delete;
+    WeightSnapshot& operator=(const WeightSnapshot&) = delete;
+
 private:
     struct Blob {
-        WeightUploadRecord rec;                            // pointers inside are STALE (old device)
-        std::vector<std::unique_ptr<uint8_t[]>> host_data;  // one buffer per rec.allocs entry
+        WeightUploadRecord rec;  // pointers inside are STALE (old device)
+        // One view per rec.allocs entry. Points into `owned` (suspend capture)
+        // or into the snapshot's cache-file mmap (warm-cache load).
+        std::vector<const uint8_t*> views;
+        std::vector<std::unique_ptr<uint8_t[]>> owned;
     };
     std::unordered_map<std::string, Blob> blobs_;
+    void* mmap_base_ = nullptr;  // warm-cache file mapping (read-only)
+    size_t mmap_size_ = 0;
     size_t total_bytes_ = 0;
     int arch_id_ = -1;
     int n_layers_ = -1;

--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -273,6 +273,7 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
 
     // 6. Extract model config from metadata
     auto model = std::make_unique<Model>();
+    model->source_path_ = path;
     model->mmap_base_ = mmap_base;
     model->mmap_size_ = file_size;
     model->split_mmaps_ = std::move(extra_mmaps);

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -58,7 +58,8 @@ public:
     // model (memory/weight_cache_file.h) — skipped when a suspend-to-RAM
     // snapshot is armed (that takes precedence).
     bool upload_weights_gpu(QType compute_dtype = QType::F16, cudaStream_t stream = nullptr,
-                            size_t expert_reserve_bytes = 1ULL << 30, bool warm_cache = false);
+                            size_t expert_reserve_bytes = 1ULL << 30, bool warm_cache = false,
+                            const std::string& warm_cache_dir = {});
 
     bool gpu_weights_ready() const { return gpu_weights_ready_; }
 

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -54,8 +54,11 @@ public:
     // For Q8_0: dequantizes to FP16 on GPU.
     // For F16/BF16: direct upload.
     // For F32: converts to compute_dtype and uploads.
+    // warm_cache: consult/write the on-disk warm weight cache next to the
+    // model (memory/weight_cache_file.h) — skipped when a suspend-to-RAM
+    // snapshot is armed (that takes precedence).
     bool upload_weights_gpu(QType compute_dtype = QType::F16, cudaStream_t stream = nullptr,
-                            size_t expert_reserve_bytes = 1ULL << 30);
+                            size_t expert_reserve_bytes = 1ULL << 30, bool warm_cache = false);
 
     bool gpu_weights_ready() const { return gpu_weights_ready_; }
 
@@ -87,9 +90,16 @@ public:
     void mark_device_sources_mutated() { device_sources_mutated_ = true; }
     bool device_sources_mutated() const { return device_sources_mutated_; }
 
+    // Path the loader was invoked with; empty for synthetic models.
+    const std::string& source_path() const { return source_path_; }
+
     // Upload log for suspend-to-RAM (memory/weight_snapshot.h). Created by
     // upload_weights_gpu; null before the first upload.
     WeightUploadLog* upload_log() const { return upload_log_.get(); }
+
+    // Uploads restored from a warm source (suspend snapshot or disk cache)
+    // during the last upload_weights_gpu pass. 0 for a fully-cold load.
+    int last_warm_hits() const { return last_warm_hits_; }
 
     // Remove a pointer from gpu_allocations_ tracking (does not free).
     void release_gpu_allocation(void* ptr);
@@ -143,6 +153,11 @@ public:
     bool sources_consumed_ = false;         // Phase-4b freed source tensors (#830)
     bool device_sources_mutated_ = false;   // in-place transformed device sources
     std::unique_ptr<WeightUploadLog> upload_log_;
+    int last_warm_hits_ = 0;
+    // Path the loader was invoked with (GGUF file or SafeTensors directory).
+    // Used to derive the on-disk warm-cache location and its fingerprint
+    // (memory/weight_cache_file.h). Empty for synthetically-built models.
+    std::string source_path_;
     std::vector<void*> gpu_allocations_;
     std::vector<void*> host_pinned_;         // mmap regions pinned via cudaHostRegister
     std::vector<void*> host_pinned_allocs_;  // cudaHostAlloc'd expert buffers (WSL2 DMA path)

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1053,6 +1053,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
 
     // Create model
     auto model = std::make_unique<Model>();
+    model->source_path_ = path;
     if (mtp_local.has_value()) {
         model->mtp_ = std::move(mtp_local);
         // Retain MTP mmap so Tensor data pointers stay valid for the lifetime

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -783,7 +783,14 @@ static bool upload_weight(Tensor& weight, QType qtype, QType compute_dtype, cuda
                           ? make_weight_key(keybuf, sizeof(keybuf), wname, wlayer)
                           : nullptr;
     const QType src_qtype = weight.qtype;
-    const size_t src_nbytes = weight.nbytes();
+    // True source byte count for the raw-from-source heuristic: the row-based
+    // formula the raw upload branches use. Tensor::nbytes() rounds per-element
+    // for block quants (Q8_0 = 34 bytes / 32 elements) and would never match.
+    size_t src_nbytes = weight.nbytes();
+    if (weight.ndim >= 2 && weight.shape[weight.ndim - 1] > 0) {
+        const int64_t k = weight.shape[weight.ndim - 1];
+        src_nbytes = static_cast<size_t>(weight.numel() / k) * qtype_row_bytes(src_qtype, k);
+    }
 
     if (key && g_warm &&
         g_warm->try_restore(key, weight, stream, gpu_allocs, kWarmOps, g_upload_log))
@@ -2105,7 +2112,7 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
 // ---------------------------------------------------------------------------
 
 bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t expert_reserve_bytes,
-                               bool warm_cache) {
+                               bool warm_cache, const std::string& warm_cache_dir) {
     if (gpu_weights_ready_) {
         IMP_LOG_WARN("Weights already uploaded to GPU");
         return true;
@@ -2147,7 +2154,7 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
     // suspend snapshot is armed. Owns its blobs for the duration of this pass.
     std::unique_ptr<WeightSnapshot> disk_cache;
     if (!g_warm && warm_cache && !source_path_.empty()) {
-        disk_cache = weight_cache_load(weight_cache_path_for(source_path_), *this);
+        disk_cache = weight_cache_load(weight_cache_path_for(source_path_, warm_cache_dir), *this);
         if (disk_cache)
             g_warm = disk_cache.get();
     }
@@ -2492,7 +2499,7 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
     // the conversion work. Best-effort; skipped for models whose device
     // sources were mutated in place during upload (Gemma-4 fused split).
     if (warm_cache && fully_cold && !device_sources_mutated_ && !source_path_.empty())
-        weight_cache_write(*this, weight_cache_path_for(source_path_));
+        weight_cache_write(*this, weight_cache_path_for(source_path_, warm_cache_dir));
 
     IMP_LOG_INFO("All model weights uploaded to GPU (%zu allocations)", gpu_allocations_.size());
     return true;

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1,6 +1,7 @@
 #include "model/model.h"
 #include "memory/vram_query.h"
 #include "memory/weight_snapshot.h"
+#include "memory/weight_cache_file.h"
 #include "model/gguf_loader.h"
 #include "memory/mem_account.h"
 #include "quant/dequant_gpu.h"
@@ -782,6 +783,7 @@ static bool upload_weight(Tensor& weight, QType qtype, QType compute_dtype, cuda
                           ? make_weight_key(keybuf, sizeof(keybuf), wname, wlayer)
                           : nullptr;
     const QType src_qtype = weight.qtype;
+    const size_t src_nbytes = weight.nbytes();
 
     if (key && g_warm &&
         g_warm->try_restore(key, weight, stream, gpu_allocs, kWarmOps, g_upload_log))
@@ -794,7 +796,8 @@ static bool upload_weight(Tensor& weight, QType qtype, QType compute_dtype, cuda
 
     if (key && g_upload_log && gpu_allocs.size() > allocs_before) {
         g_upload_log->record(key, const_cast<const void* const*>(gpu_allocs.data()) + allocs_before,
-                             gpu_allocs.size() - allocs_before, weight, src_qtype, n_elements);
+                             gpu_allocs.size() - allocs_before, weight, src_qtype, n_elements,
+                             src_nbytes);
     }
     return true;
 }
@@ -1803,7 +1806,8 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
                         ctx.gpu_allocs.push_back(gpu_ptr);
                         if (key && g_upload_log) {
                             const void* const rec_allocs[] = {gpu_ptr};
-                            g_upload_log->record(key, rec_allocs, 1, packed, src_qtype, src_numel);
+                            g_upload_log->record(key, rec_allocs, 1, packed, src_qtype, src_numel,
+                                                 total_raw);
                         }
                         IMP_LOG_DEBUG("  %s: %d experts uploaded to GPU (%.2f MiB)", name, n_experts,
                                       total_raw / (1024.0 * 1024.0));
@@ -2100,7 +2104,8 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
 // Model::upload_weights_gpu
 // ---------------------------------------------------------------------------
 
-bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t expert_reserve_bytes) {
+bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t expert_reserve_bytes,
+                               bool warm_cache) {
     if (gpu_weights_ready_) {
         IMP_LOG_WARN("Weights already uploaded to GPU");
         return true;
@@ -2137,6 +2142,16 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
             IMP_LOG_WARN("Armed weight snapshot does not match this model (arch/layers) — ignoring");
         }
     }
+
+    // On-disk warm cache (memory/weight_cache_file.h): consulted only when no
+    // suspend snapshot is armed. Owns its blobs for the duration of this pass.
+    std::unique_ptr<WeightSnapshot> disk_cache;
+    if (!g_warm && warm_cache && !source_path_.empty()) {
+        disk_cache = weight_cache_load(weight_cache_path_for(source_path_), *this);
+        if (disk_cache)
+            g_warm = disk_cache.get();
+    }
+    const bool fully_cold = (g_warm == nullptr);
 
     // Use Engine's computed reserve (workspace + KV cache + SSM state + safety)
     // directly — no additional margin needed here.
@@ -2468,8 +2483,17 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
     }
 
     gpu_weights_ready_ = true;
+    last_warm_hits_ = g_warm ? g_warm->hits() : 0;
     if (g_warm)
-        IMP_LOG_INFO("Warm resume: %d uploads restored from host snapshot", g_warm->hits());
+        IMP_LOG_INFO("Warm restore: %d uploads served from %s", g_warm->hits(),
+                     disk_cache ? "the on-disk warm cache" : "the suspend snapshot");
+
+    // Fully-cold load: persist the transformed records so the NEXT boot skips
+    // the conversion work. Best-effort; skipped for models whose device
+    // sources were mutated in place during upload (Gemma-4 fused split).
+    if (warm_cache && fully_cold && !device_sources_mutated_ && !source_path_.empty())
+        weight_cache_write(*this, weight_cache_path_for(source_path_));
+
     IMP_LOG_INFO("All model weights uploaded to GPU (%zu allocations)", gpu_allocations_.size());
     return true;
 }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -243,6 +243,9 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("server.recurrent_snapshot_mb", cfg.server.recurrent_snapshot_mb);
     B("server.green_contexts", cfg.server.green_contexts);
 
+    // [warm_cache]
+    B("warm_cache.enabled", cfg.warm_cache.enabled);
+
     // [suspend]
     B("suspend.device_reset", cfg.suspend.device_reset);
     I("suspend.host_ram_headroom_mb", cfg.suspend.host_ram_headroom_mb);

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -245,6 +245,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
 
     // [warm_cache]
     B("warm_cache.enabled", cfg.warm_cache.enabled);
+    S("warm_cache.dir", cfg.warm_cache.dir);
 
     // [suspend]
     B("suspend.device_reset", cfg.suspend.device_reset);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -608,6 +608,12 @@ struct RuntimeConfig {
         // only for BF16-dense checkpoints. Guarded by a format version and a
         // model-content fingerprint; any mismatch = normal cold load.
         bool enabled = true;
+        // Where to store cache files. Empty (default) = next to the model
+        // ("<file>.impwcache" / "<dir>/.imp_warm_cache"). Point this at a
+        // writable volume when the model directory is read-only for the
+        // serving user (the prebuilt container runs as uid 1001): files are
+        // then named "<model-basename>-<path-hash>.impwcache" inside it.
+        std::string dir;
     } warm_cache;
 
     struct Suspend {

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -598,6 +598,18 @@ struct RuntimeConfig {
         bool green_contexts = false;
     } server;
 
+    struct WarmCache {
+        // On-disk warm weight cache: at the first fully-cold load, persist the
+        // TRANSFORMED weight uploads (BF16->FP16 conversions, dequants, split
+        // layouts) next to the model; later boots restore them instead of
+        // re-converting. Raw-from-source uploads are never stored (the model
+        // file already holds those bytes), so the cache is near-zero for
+        // raw-served GGUF quants / NVFP4-prequant SafeTensors and ~model-size
+        // only for BF16-dense checkpoints. Guarded by a format version and a
+        // model-content fingerprint; any mismatch = normal cold load.
+        bool enabled = true;
+    } warm_cache;
+
     struct Suspend {
         // Suspend-to-RAM (/admin/suspend): after model/engine teardown, also
         // cudaDeviceReset() so the CUDA primary context (+ module code,

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -194,7 +194,8 @@ bool Engine::init_weights() {
     cudaStream_t upload_stream = upload_stream_raii.get();  // may be null
 
     if (!model_->upload_weights_gpu(config_.compute_dtype, upload_stream ? upload_stream : stream_,
-                                    expert_reserve, runtime_config_.warm_cache.enabled)) {
+                                    expert_reserve, runtime_config_.warm_cache.enabled,
+                                    runtime_config_.warm_cache.dir)) {
         IMP_LOG_ERROR("Weight upload failed. Try a smaller quantization.");
         return false;
     }

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -194,7 +194,7 @@ bool Engine::init_weights() {
     cudaStream_t upload_stream = upload_stream_raii.get();  // may be null
 
     if (!model_->upload_weights_gpu(config_.compute_dtype, upload_stream ? upload_stream : stream_,
-                                    expert_reserve)) {
+                                    expert_reserve, runtime_config_.warm_cache.enabled)) {
         IMP_LOG_ERROR("Weight upload failed. Try a smaller quantization.");
         return false;
     }

--- a/tests/test_warm_cache.cu
+++ b/tests/test_warm_cache.cu
@@ -1,0 +1,134 @@
+// On-disk warm weight cache (GPU, real model): a fully-cold load persists the
+// transformed uploads next to the model; the next load restores them (warm
+// hits > 0) and must produce token-identical greedy output. A corrupted cache
+// is ignored (clean cold load). See memory/weight_cache_file.h.
+//
+// Requires a real model on disk: IMP_TEST_MODEL or /models/Qwen3-8B-Q8_0.gguf.
+// The default runtime config has warm_cache.enabled = true, so the plain
+// C-API load path exercises the cache without extra plumbing.
+
+#include <gtest/gtest.h>
+
+#include "imp/imp.h"
+#include "api/imp_internal.h"
+#include "memory/weight_cache_file.h"
+#include "test_models.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+static const char* get_model_path() {
+    return imp_test::env_cstr_or(imp_test::kEnvModel, "/models/Qwen3-8B-Q8_0.gguf");
+}
+
+static bool model_exists() {
+    FILE* f = fopen(get_model_path(), "r");
+    if (f) {
+        fclose(f);
+        return true;
+    }
+    return false;
+}
+
+#define SKIP_IF_NO_MODEL()                                           \
+    do {                                                             \
+        if (!model_exists())                                         \
+            GTEST_SKIP() << "Model not found: " << get_model_path(); \
+    } while (0)
+
+struct Cycle {
+    ImpModel model = nullptr;
+    ImpContext ctx = nullptr;
+    std::string output;
+
+    bool up(const char* path) {
+        if (imp_model_load(path, IMP_FORMAT_GGUF, &model) != IMP_SUCCESS)
+            return false;
+        ImpConfig config = imp_config_default();
+        config.max_seq_len = 1024;
+        config.max_batch_size = 1;
+        return imp_context_create(model, &config, &ctx) == IMP_SUCCESS;
+    }
+
+    bool generate_greedy() {
+        ImpGenerateParams params = imp_generate_params_default();
+        params.seed = 42;
+        params.max_tokens = 16;
+        params.temperature = 0.0f;
+        params.apply_chat_template = 1;
+        char buf[2048] = {};
+        size_t n = 0;
+        if (imp_generate(ctx, "Name three colors.", &params, buf, sizeof(buf), &n) != IMP_SUCCESS)
+            return false;
+        output.assign(buf, n);
+        return n > 0;
+    }
+
+    void down() {
+        if (ctx) {
+            imp_context_free(ctx);
+            ctx = nullptr;
+        }
+        if (model) {
+            imp_model_free(model);
+            model = nullptr;
+        }
+    }
+};
+
+struct CacheCleanup {
+    std::string path;
+    explicit CacheCleanup(std::string p) : path(std::move(p)) { remove(); }
+    ~CacheCleanup() { remove(); }
+    void remove() {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+};
+
+}  // namespace
+
+TEST(WarmCacheTest, ColdLoadWritesCacheWarmBootTokenIdentical) {
+    SKIP_IF_NO_MODEL();
+    const std::string cache = imp::weight_cache_path_for(get_model_path());
+    CacheCleanup cleanup(cache);  // start from a guaranteed-cold state
+
+    Cycle cold;
+    ASSERT_TRUE(cold.up(get_model_path()));
+    EXPECT_EQ(cold.model->model->last_warm_hits(), 0) << "first load must be fully cold";
+    ASSERT_TRUE(cold.generate_greedy());
+    cold.down();
+
+    ASSERT_TRUE(std::filesystem::exists(cache))
+        << "cold load did not persist a warm cache at " << cache;
+
+    Cycle warm;
+    ASSERT_TRUE(warm.up(get_model_path()));
+    EXPECT_GT(warm.model->model->last_warm_hits(), 0) << "second load ignored the warm cache";
+    ASSERT_TRUE(warm.generate_greedy());
+    EXPECT_EQ(warm.output, cold.output) << "warm boot diverged from cold boot";
+    warm.down();
+}
+
+TEST(WarmCacheTest, CorruptCacheIsIgnored) {
+    SKIP_IF_NO_MODEL();
+    const std::string cache = imp::weight_cache_path_for(get_model_path());
+    CacheCleanup cleanup(cache);
+
+    {
+        std::ofstream f(cache, std::ios::binary | std::ios::trunc);
+        f << "NOTACACHEFILE garbage garbage garbage";
+    }
+
+    Cycle c;
+    ASSERT_TRUE(c.up(get_model_path()));
+    EXPECT_EQ(c.model->model->last_warm_hits(), 0) << "corrupt cache must fall back to a cold load";
+    ASSERT_TRUE(c.generate_greedy());
+    c.down();
+}

--- a/tests/test_warm_cache.cu
+++ b/tests/test_warm_cache.cu
@@ -4,14 +4,15 @@
 // is ignored (clean cold load). See memory/weight_cache_file.h.
 //
 // Requires a real model on disk: IMP_TEST_MODEL or /models/Qwen3-8B-Q8_0.gguf.
-// The default runtime config has warm_cache.enabled = true, so the plain
-// C-API load path exercises the cache without extra plumbing.
+// The cache is redirected to a scratch [warm_cache] dir (the model mount is
+// read-only for the container user), which also exercises the dir override.
 
 #include <gtest/gtest.h>
 
 #include "imp/imp.h"
 #include "api/imp_internal.h"
 #include "memory/weight_cache_file.h"
+#include "runtime/config.h"
 #include "test_models.h"
 
 #include <cuda_runtime.h>
@@ -42,6 +43,8 @@ static bool model_exists() {
             GTEST_SKIP() << "Model not found: " << get_model_path(); \
     } while (0)
 
+constexpr const char* kCacheDir = "/tmp/imp-warm-cache-test";
+
 struct Cycle {
     ImpModel model = nullptr;
     ImpContext ctx = nullptr;
@@ -50,6 +53,12 @@ struct Cycle {
     bool up(const char* path) {
         if (imp_model_load(path, IMP_FORMAT_GGUF, &model) != IMP_SUCCESS)
             return false;
+        // Redirect the warm cache into a writable scratch dir. The pending
+        // runtime config is consumed per context create, so re-arm each time.
+        imp::RuntimeConfig rc;
+        rc.warm_cache.enabled = true;
+        rc.warm_cache.dir = kCacheDir;
+        imp::set_pending_runtime_config(rc);
         ImpConfig config = imp_config_default();
         config.max_seq_len = 1024;
         config.max_batch_size = 1;
@@ -96,7 +105,7 @@ struct CacheCleanup {
 
 TEST(WarmCacheTest, ColdLoadWritesCacheWarmBootTokenIdentical) {
     SKIP_IF_NO_MODEL();
-    const std::string cache = imp::weight_cache_path_for(get_model_path());
+    const std::string cache = imp::weight_cache_path_for(get_model_path(), kCacheDir);
     CacheCleanup cleanup(cache);  // start from a guaranteed-cold state
 
     Cycle cold;
@@ -118,7 +127,7 @@ TEST(WarmCacheTest, ColdLoadWritesCacheWarmBootTokenIdentical) {
 
 TEST(WarmCacheTest, CorruptCacheIsIgnored) {
     SKIP_IF_NO_MODEL();
-    const std::string cache = imp::weight_cache_path_for(get_model_path());
+    const std::string cache = imp::weight_cache_path_for(get_model_path(), kCacheDir);
     CacheCleanup cleanup(cache);
 
     {

--- a/tests/test_weight_snapshot.cpp
+++ b/tests/test_weight_snapshot.cpp
@@ -55,7 +55,7 @@ TEST(WeightUploadLogTest, RecordResolvesSizesAndOffsets) {
     post.scales = f.a2;                                                // scales in the second alloc
 
     const void* const allocs[] = {f.a1, f.a2};
-    log.record("L0.wq", allocs, 2, post, QType::BF16, 128);
+    log.record("L0.wq", allocs, 2, post, QType::BF16, 128, 256);
 
     ASSERT_EQ(log.records().size(), 1u);
     const auto& rec = log.records()[0];
@@ -79,7 +79,7 @@ TEST(WeightUploadLogTest, UnknownAllocSizeSkipsRecord) {
     int64_t shape[4] = {4, 4, 0, 0};
     Tensor post(f.a1, QType::F16, 2, shape, true);
     const void* const allocs[] = {f.a1};
-    log.record("L0.wq", allocs, 1, post, QType::F16, 16);
+    log.record("L0.wq", allocs, 1, post, QType::F16, 16, 32);
     EXPECT_TRUE(log.records().empty());
 }
 
@@ -90,7 +90,7 @@ TEST(WeightUploadLogTest, DataOutsideAllocationsSkipsRecord) {
     int64_t shape[4] = {4, 4, 0, 0};
     Tensor post(f.a2, QType::F16, 2, shape, true);  // data not backed by a1
     const void* const allocs[] = {f.a1};
-    log.record("L0.wq", allocs, 1, post, QType::F16, 16);
+    log.record("L0.wq", allocs, 1, post, QType::F16, 16, 32);
     EXPECT_TRUE(log.records().empty());
 }
 
@@ -104,8 +104,8 @@ TEST(WeightUploadLogTest, SameKeyReplaces) {
     Tensor post2(f.a2, QType::F16, 2, shape, true);
     const void* const allocs1[] = {f.a1};
     const void* const allocs2[] = {f.a2};
-    log.record("L0.wq", allocs1, 1, post1, QType::F16, 16);
-    log.record("L0.wq", allocs2, 1, post2, QType::F16, 16);
+    log.record("L0.wq", allocs1, 1, post1, QType::F16, 16, 32);
+    log.record("L0.wq", allocs2, 1, post2, QType::F16, 16, 32);
     ASSERT_EQ(log.records().size(), 1u);
     EXPECT_EQ(log.records()[0].allocs[0].ptr, static_cast<void*>(f.a2));
 }
@@ -120,8 +120,8 @@ TEST(WeightUploadLogTest, EvictMarksDeadAndDropsLiveBytes) {
     Tensor p2(f.a2, QType::F16, 2, shape, true);
     const void* const allocs1[] = {f.a1};
     const void* const allocs2[] = {f.a2};
-    log.record("L0.wq", allocs1, 1, p1, QType::F16, 16);
-    log.record("L0.wk", allocs2, 1, p2, QType::F16, 16);
+    log.record("L0.wq", allocs1, 1, p1, QType::F16, 16, 32);
+    log.record("L0.wk", allocs2, 1, p2, QType::F16, 16, 32);
     EXPECT_EQ(log.live_bytes(), sizeof(f.a1) + sizeof(f.a2));
 
     log.evict_ptr(f.a1);
@@ -132,6 +132,38 @@ TEST(WeightUploadLogTest, EvictMarksDeadAndDropsLiveBytes) {
 
     log.evict_ptr(nullptr);  // no-op
     EXPECT_EQ(log.live_bytes(), sizeof(f.a2));
+}
+
+TEST(WeightUploadLogTest, RawFromSourceHeuristic) {
+    FakeAllocs f;
+    WeightUploadLog log;
+    log.note_alloc(f.a1, sizeof(f.a1));
+    log.note_alloc(f.a2, sizeof(f.a2));
+    int64_t shape[4] = {4, 4, 0, 0};
+
+    // Verbatim h2d: one alloc, same qtype, byte count matches the source.
+    Tensor raw_post(f.a1, QType::Q8_0, 2, shape, true);
+    const void* const a1[] = {f.a1};
+    log.record("L0.raw", a1, 1, raw_post, QType::Q8_0, 16, sizeof(f.a1));
+    EXPECT_TRUE(log.records().back().raw_from_source);
+
+    // Converted: qtype changed (BF16 -> F16 upload).
+    Tensor conv_post(f.a2, QType::F16, 2, shape, true);
+    const void* const a2[] = {f.a2};
+    log.record("L0.conv", a2, 1, conv_post, QType::BF16, 16, sizeof(f.a2));
+    EXPECT_FALSE(log.records().back().raw_from_source);
+
+    // MXFP4 keeps qtype + byte count but reorders — excluded from "raw".
+    Tensor mx_post(f.a1, QType::MXFP4, 2, shape, true);
+    log.record("L0.mx", a1, 1, mx_post, QType::MXFP4, 16, sizeof(f.a1));
+    EXPECT_FALSE(log.records().back().raw_from_source);
+
+    // Split upload (two allocs, scales sidecar) is never raw.
+    Tensor split_post(f.a1, QType::Q4_0, 2, shape, true);
+    split_post.scales = f.a2;
+    const void* const both[] = {f.a1, f.a2};
+    log.record("L0.split", both, 2, split_post, QType::Q4_0, 16, sizeof(f.a1) + sizeof(f.a2));
+    EXPECT_FALSE(log.records().back().raw_from_source);
 }
 
 TEST(WeightSnapshotArmSlotTest, ArmTakeDisarm) {


### PR DESCRIPTION
## What

The first fully-cold model load persists its TRANSFORMED weight uploads (host BF16→FP16 conversion loops, GPU dequants, split layouts — everything whose device bytes differ from the model file) into a dedicated cache directory (`~/.cache/imp/warm` by default, `[warm_cache] dir` to override). Later boots mmap the cache (zero-copy views + `MADV_WILLNEED` readahead) and restore the bytes through the suspend-to-RAM machinery (#954) instead of re-running the conversions — with the same safety property: any per-tensor miss or mismatch falls back to the normal cold path.

Raw-from-source uploads are deliberately never stored (heuristic on the upload record: single alloc, same qtype, row-based byte count matches, no scales sidecar; MXFP4 excluded because its split reorder keeps size+qtype) — the model file already holds those bytes, so a cold re-upload is byte-equivalent. A false "raw" only skips caching, never affects correctness.

- Staleness guards: format version, `sizeof(Tensor)` POD guard, model arch + layer count, content fingerprint (total bytes + newest mtime of the model path). Stale/corrupt caches are ignored with an INFO log.
- Atomic write (PID-unique tmp + rename), best-effort in both directions; unwritable cache dir ⇒ INFO + cold load.
- Suspend-to-RAM snapshot takes precedence when armed; the cache is written only on fully-cold loads.
- Config: `[warm_cache] enabled` (default true), `dir`.

## Measured (RTX 5090, local)

| Model | Cache size | Cold init | Warm init |
|---|---|---|---|
| DeepSeek-V2-Lite (BF16-dense SafeTensors) | 16.9 GiB | 68.2 s | **21.4 s** (17.0 s page-cache-hot) |
| Qwen3-8B-Q8_0 (GGUF, raw-served) | few MB (109 records — norms/F32 conversions only) | — | — |

## Verification

- Unit: raw-heuristic cases (verbatim/converted/MXFP4/split), existing log/keys/meminfo/arm-slot suites — 718 green.
- GPU: `tests/test_warm_cache.cu` — cold load writes cache, warm boot has warm hits and is token-identical, corrupt cache falls back cold; full `SuspendResumeTest` interop green (snapshot precedence over disk cache); full `make test-gpu` green (8/8 binaries).
- No hot-path change (init-time only); perf baseline untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F