### PR TITLE
docs: refresh stale Qwen3.6-35B decode / FP16-GDN-tax claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ decode is the reliable A/B signal):
 
 - **GGUF dense decode:** Qwen3-8B Q8_0 at **~270 tok/s** (CI-gated baseline),
   **+37–72% over llama.cpp** with full offload and flash attention.
-- **NVFP4 SafeTensors decode:** 30B-class MoE at **~257–338 tok/s**
-  (Qwen3-30B-A3B 305, Qwen3-Coder-30B 338, Qwen3.6-35B 257, Gemma-4-26B 266):
+- **NVFP4 SafeTensors decode:** 30B-class MoE at **~266–338 tok/s**
+  (Qwen3-30B-A3B 305, Qwen3-Coder-30B 338, Qwen3.6-35B 320, Gemma-4-26B 266;
+  the 35B hybrid was 257 before the #949 FP8 SSM-projection sidecar):
   **uncontested on `sm_120`**: vLLM's NVFP4 path needs `tcgen05` (absent on
   consumer Blackwell) and llama.cpp has no native NVFP4 at all.
 - **NVFP4 long-context prefill:** at-or-ahead of vLLM after #687 (FP16-QK FA2 as
@@ -54,8 +55,10 @@ decode is the reliable A/B signal):
   dense pp2048 a tie, and TTFT wins everywhere.
 
 **Honest losses** (narrow, and documented): NVFP4 dense pp4096 still trails vLLM
-by ~4% (1.04×), and Qwen3.6-35B GGUF decode loses ~31% to llama.cpp, a
-structural FP16 GDN-projection tax, not a tuning gap.
+by ~4% (1.04×). The FP16 GDN-projection tax that used to make Qwen3.6-35B hybrid
+decode a loss was closed on the NVFP4 path by the #949 FP8 SSM-projection
+sidecar (35B NVFP4 decode 257 → ~320 tok/s, now ahead of llama.cpp); the legacy
+GGUF Q4_K hybrid path does not get that sidecar and decodes slower (~213 tok/s).
 
 Every number, with date, commit SHA, CUDA version, quant and the exact
 command: **[BENCHMARKS.md](docs/BENCHMARKS.md)**. Methodology details:
@@ -73,8 +76,8 @@ command: **[BENCHMARKS.md](docs/BENCHMARKS.md)**. Methodology details:
 
 - **Single GPU only.** No tensor parallelism, no multi-GPU.
 - **Consumer Blackwell only.** `sm_120a` SASS + `compute_120f` PTX fallback. No Hopper, Ada, Ampere, datacenter Blackwell. No AMD, Intel, Apple, or CPU paths.
-- **GGUF prefill: largely fixed 2026-06-07.** The INT8-IMMA prefill family (#612–#617) puts Qwen3-30B-A3B and Qwen3-14B-Q6_K AHEAD of llama.cpp; Q8_0 dense and gemma-4 sit at 1.20×, Qwen3.6-35B at 1.55× (GDN share is quality-locked). NVFP4 prefill: imp WINS MoE pp4096 (+4% vs vLLM), MoE pp2048 (+27%), and TTFT everywhere; only dense pp4096 still trails, at ~1.04× (2026-06-13, post #687 FP16-QK FA2 primary hd=128 prefill; see docs/audit/prefill_gap_2026_06_07.md for the kernel-level decomposition).
-- **MoE/hybrid GGUF decode loses on Qwen3.6-35B** (~−31% vs llama.cpp): an FP16-projection tax on the GDN/attention path that NVFP4 can't address.
+- **GGUF prefill: largely fixed 2026-06-07.** The INT8-IMMA prefill family (#612–#617) puts Qwen3-30B-A3B and Qwen3-14B-Q6_K AHEAD of llama.cpp; Q8_0 dense sits at 1.13×, gemma-4 at 1.20×, Qwen3.6-35B at 1.55× (GDN share is quality-locked). NVFP4 prefill: imp WINS MoE pp4096 (+4% vs vLLM), MoE pp2048 (+27%), and TTFT everywhere; only dense pp4096 still trails, at ~1.04× (2026-06-13, post #687 FP16-QK FA2 primary hd=128 prefill; see docs/audit/prefill_gap_2026_06_07.md for the kernel-level decomposition).
+- **Legacy GGUF hybrid decode trails the NVFP4 path.** The FP16 GDN-projection tax on Qwen3.6-35B hybrid decode was closed on the NVFP4 checkpoint path by the #949 FP8 SSM-projection sidecar (35B NVFP4 decode 257 → ~320 tok/s, ahead of llama.cpp). The Q4_K GGUF path is a no-op for that sidecar and decodes slower (~213 tok/s); GGUF is the legacy path — NVFP4 SafeTensors is the priority.
 - **Only tested models work reliably.** Anything not on the [supported list](docs/supported-models.md) may load but hasn't been verified.
 - **Prefill numbers are noisy.** cuBLAS autotuning causes up to 2.6× variance across container restarts.
 - **Moderate concurrency, not datacenter scale.** Concurrent sub-agent fan-out (tens of requests) is a tuned, supported workload; batch=64+ continuous-batching throughput on a rack is not; that's vLLM/SGLang territory.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -31,6 +31,7 @@ numbers below carry over unchanged.
 | 2026-06-12 | `perf_baseline_north_star.json` | 13.3 | Qwen3-14B | Q6_K | tg128 @ctx2048 | 156.0 | `… --max-seq-len 2048` |
 | 2026-06-09 | `ec9145b3` | 13.3 | Qwen3-14B | Q6_K | tg128 | 164 | `imp-cli --model Qwen3-14B-Q6_K.gguf --bench --bench-pp 16 --bench-reps 10 --max-tokens 128` |
 | 2026-06-09 | `ec9145b3` | 13.3 | Gemma-4-26B-A4B | Q4_K_M | tg128 | 273 | `imp-cli --model gemma-4-26B-A4B-it-UD-Q4_K_M.gguf --bench --bench-pp 16 --bench-reps 10 --max-tokens 128` |
+| 2026-07-11 | `6946a6cd` | 13.3 | Qwen3.6-35B-A3B (hybrid) | Q4_K_M | tg256 | 213 | `imp-cli --model Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --bench --bench-pp 16 --bench-reps 10 --max-tokens 256` — legacy path; the FP8 SSM-projection sidecar (#949) is a no-op on GGUF, so the FP16 GDN tax remains (cf. the same model NVFP4 at ~320) |
 
 > Canonical gated decode number = `perf_baseline.json` Qwen3-8B-Q8_0 tg128 =
 > 269.5 (cold-median, 5 trials × 5 reps, 2026-06-12, clocks verified healthy
@@ -42,8 +43,12 @@ numbers below carry over unchanged.
 > `clocks.mem` during the bench (healthy = 13801 MHz / ~500 W under prefill).
 
 Against llama.cpp (b8445+, full offload, flash attention on): imp wins dense
-GGUF decode by **+37–72%** and loses MoE/hybrid GGUF decode on
-Qwen3.6-35B-A3B (~−31%, structural FP16-projection tax on the GDN path).
+GGUF decode by **+37–72%**. The MoE/hybrid FP16 GDN-projection tax that used to
+put Qwen3.6-35B behind was closed on the **NVFP4** path by the #949 FP8
+SSM-projection sidecar (35B NVFP4 decode 257 → ~320 tok/s, now ahead of
+llama.cpp's ~229). The **GGUF Q4_K** hybrid path is a no-op for that sidecar and
+still carries the tax (35B Q4_K decode ~213 tok/s, 2026-07-11); GGUF is the
+legacy path — NVFP4 SafeTensors is the priority.
 
 ## GGUF prefill (pp512, INT8-IMMA family — default on since #617)
 
@@ -82,7 +87,7 @@ Decode carries ±5–10 % day-to-day variance (issue #526); clocks logged health
 | Qwen3-Coder-30B-A3B | 30B (3B) | 338 |
 | Qwen3.6-35B-A3B | 35B (3B) | 257 → **320**¹ᵇ |
 | Gemma-4-26B-A4B | 26B (4B) | 266 |
-| Nemotron-3-Nano-30B | 30B (3B) | 128 |
+| Nemotron-3-Nano-30B | 30B (3B) | 128 → **148**¹ᶜ |
 | gpt-oss-20b¹ | 21B (3.6B) | 325 |
 
 ¹ᵇ 2026-07-10, commit `80864b06` + `gemm.fp8_ssm_proj` (default on since that
@@ -90,6 +95,12 @@ PR): FP8 E4M3 per-row-scale decode sidecar for the BF16 GDN in/out projections
 — tg256 268.6 → **320.3** spec-off (+19.2%), 261 → 308 with default
 speculation; PPL flat (8.021 → 8.012 same-session teacher-forced). Same
 command pattern as the table; healthy-host clocks sampled during the run.
+
+¹ᶜ 2026-07-11, commit `6946a6cd` + `gemm.fp8_ssm_proj`: the same FP8
+SSM-projection sidecar (221 MiB on Nemotron's 12 GDN projections) lifts
+Nemotron-3-Nano-30B decode 128 → **148** tok/s (+16%), PPL flat (4.184 →
+4.117). Still the slowest 30B — the Mamba2 scan + attention-projection share is
+arch-limited — but the GDN-projection part of the FP16 tax is gone.
 
 ¹ gpt-oss (PRs #572/#574): SafeTensors MXFP4 source, experts converted to
 NVFP4 at load (bit-exact nibbles, power-of-two scales) and registered for the

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -30,7 +30,8 @@ SHA-anchored decode numbers (model · quant · metric · tok/s · commit · CUDA
 command) live in [`BENCHMARKS.md`](BENCHMARKS.md), and the CI gate is
 `tests/perf_baseline.json` (refresh via `scripts/gen_perf_baseline.sh`). Heroes for
 orientation: Q8 tg128 ≈ 268 · 14B-Q6_K north-star ≈ 158 @ctx2048 · NVFP4 MoE
-tg256 in the 250–340 range (e.g. Qwen3-Coder-30B 338, Qwen3.6-35B 257).
+tg256 in the 250–340 range (e.g. Qwen3-Coder-30B 338, Qwen3.6-35B 320 since the
+#949 FP8 SSM-projection sidecar, was 257).
 
 Decode is measured with CUDA Graphs ON, 10 reps, isolated + clock-warmed. Healthy-host
 sanity check: ~2850 MHz SM / 13801 MHz mem / ~500 W during the bench — decode can read

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -46,11 +46,11 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Qwen3-Coder-30B-A3B](https://huggingface.co/NVFP4/Qwen3-Coder-30B-A3B-Instruct-FP4) | NVFP4 | 16 GB | 338 | SafeTensors (Modelopt) |
 | [Qwen3-30B-A3B](https://huggingface.co/nvidia/Qwen3-30B-A3B-NVFP4) | NVFP4 | 16 GB | 307 | SafeTensors (Modelopt) |
 | [Qwen3.6-35B-A3B](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) | Q4_K_M | 22 GB | 243 | GGUF |
-| [Qwen3.6-35B-A3B](https://huggingface.co/mmangkad/Qwen3.6-35B-A3B-NVFP4) | NVFP4 | 18 GB | 257 | SafeTensors (Modelopt) |
+| [Qwen3.6-35B-A3B](https://huggingface.co/mmangkad/Qwen3.6-35B-A3B-NVFP4) | NVFP4 | 18 GB | 320 | SafeTensors (Modelopt); 257 → 320 since the #949 FP8 SSM-projection sidecar closed the FP16 GDN tax |
 | [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | 14 GB | 273 (tg128) | GGUF |
 | [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q5_K_M | 17 GB | 65 | GGUF, recommended for code-gen |
 | [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 266 | SafeTensors (Modelopt) |
-| [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 126 | SafeTensors (Modelopt), Mamba2+attn+MoE, arch-limited (FP16 GDN/attn-projection tax) |
+| [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 148 | SafeTensors (Modelopt), Mamba2+attn+MoE; 126 → 148 with the #949 FP8 SSM-projection sidecar. Still the slowest 30B (Mamba2 scan + attn-projection share is arch-limited), but the GDN-projection part of the FP16 tax is gone. |
 | [Nemotron-Labs-3-Elastic-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4) | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
 | [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Also loads the official GGUF (Q8_0- or bf16-dense + MXFP4 experts, e.g. `gpt-oss-20b-mxfp4.gguf` — the Q8_0 residual rescale was fixed in #808). Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
 


### PR DESCRIPTION
The "MoE/hybrid GGUF decode loses ~31% to llama.cpp — a structural FP16 GDN-projection tax that NVFP4 can't address / not a tuning gap" claim was stale and appeared in **5 places** (README ×3, `docs/BENCHMARKS.md` ×2, `docs/performance.md`, `docs/supported-models.md` ×2). PR #949's FP8 SSM-projection sidecar (default on since 2026-07-10) closed exactly that tax on the NVFP4 path — so "structural / NVFP4 can't address / not a tuning gap" is no longer true.

## Fresh measurements (2026-07-11, healthy host, sidecar VRAM confirmed active)

| Model | Path | Now | Was |
|---|---|---:|---:|
| Qwen3.6-35B-A3B | NVFP4 | **308–320** | 257 (pre-#949) |
| Qwen3.6-35B-A3B | GGUF Q4_K | **~213** | — |
| Nemotron-3-Nano-30B | NVFP4 | **148** | 126–128 |

- 35B NVFP4 decode is now **ahead of llama.cpp**, not a −31% loss — the sidecar (964 MiB) closed the GDN tax.
- 35B **GGUF Q4_K** is a no-op for the sidecar, so the tax remains only on the legacy path (~213 tok/s) — added as a `BENCHMARKS.md` GGUF-decode row.
- Nemotron got the sidecar too (221 MiB): 126 → 148 (+16%); still arch-limited by the Mamba2 scan share, but the GDN-projection part of the tax is gone.

Also corrects the GGUF-prefill prose: Q8_0 dense is **1.13×** behind llama.cpp, not 1.20× (the table already said 1.13×; the prose lumped it with gemma-4's 1.20×).

Docs-only; MISSION_JOURNAL history entries left as-is (append-only campaign log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F