### PR TITLE
feat(gemm): extend FP8 SSM-projection decode sidecar to GGUF hybrids — Qwen3.6-35B Q4_K_M decode +21%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Changed
+- **FP8 SSM-projection decode sidecar extended to GGUF hybrids**
+  (`gemm.fp8_ssm_proj`, default on): the Q8_0-kept GDN projections of UD
+  quants (ssm_in / gdn_gate / ssm_out) were in no decode cache at all
+  (Undefined tier, quality-locked out of NVFP4) and paid a full
+  dequant→cuBLAS round-trip per decode token. They are now dequanted once at
+  init and per-row FP8-quantized into the same sidecar the native-NVFP4 path
+  uses; prefill keeps the Q8_0 source. Qwen3.6-35B-A3B UD-Q4_K_M decode
+  224.4 → 272.0 tok/s defaults (+21%, spec-off 219.2 → 265.9) — now ahead of
+  llama.cpp (~229). PPL 4.215 → 4.289 (+1.8% on the 201-token corpus, E4M3
+  stacked on the Q8_0 lattice) — a documented trade in the
+  `nvfp4_lm_head_gdn` class; `--set gemm.fp8_ssm_proj=false` reverts.
+  degen_suite 33/33; native-NVFP4 and dense paths measured unchanged.
+  Sub-8-bit GDN sources (plain Q4_K_M GGUFs) are deliberately excluded (FP8
+  would increase their decode bytes). Adds a kernel-chain regression test
+  (Q8_0 → dequant → FP8 rows → rowscale GEMV vs fp64 reference).
+
 ### Fixed
 - **gemma-3-12b GGUF decode illegal-memory-access** (last hard crash in the
   known-issues list): gemma-3's NVFP4 decode cache must be built from an FP16

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -31,7 +31,8 @@ numbers below carry over unchanged.
 | 2026-06-12 | `perf_baseline_north_star.json` | 13.3 | Qwen3-14B | Q6_K | tg128 @ctx2048 | 156.0 | `… --max-seq-len 2048` |
 | 2026-06-09 | `ec9145b3` | 13.3 | Qwen3-14B | Q6_K | tg128 | 164 | `imp-cli --model Qwen3-14B-Q6_K.gguf --bench --bench-pp 16 --bench-reps 10 --max-tokens 128` |
 | 2026-06-09 | `ec9145b3` | 13.3 | Gemma-4-26B-A4B | Q4_K_M | tg128 | 273 | `imp-cli --model gemma-4-26B-A4B-it-UD-Q4_K_M.gguf --bench --bench-pp 16 --bench-reps 10 --max-tokens 128` |
-| 2026-07-11 | `6946a6cd` | 13.3 | Qwen3.6-35B-A3B (hybrid) | Q4_K_M | tg256 | 213 | `imp-cli --model Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --bench --bench-pp 16 --bench-reps 10 --max-tokens 256` — legacy path; the FP8 SSM-projection sidecar (#949) is a no-op on GGUF, so the FP16 GDN tax remains (cf. the same model NVFP4 at ~320) |
+| 2026-07-11 | `6946a6cd` | 13.3 | Qwen3.6-35B-A3B (hybrid) | Q4_K_M | tg256 | 213 | `imp-cli --model Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --bench --bench-pp 16 --bench-reps 10 --max-tokens 256` — legacy path; superseded by the row below |
+| 2026-07-11 | fp8-ssm-gguf | 13.3 | Qwen3.6-35B-A3B (hybrid) | Q4_K_M | tg256 | **272** | same command — `gemm.fp8_ssm_proj` now also covers the Q8_0-kept GDN projections of UD quants (dequant→FP8 sidecar at init): 224.4 → 272.0 defaults (+21%), 219.2 → 265.9 spec-off, same session. PPL 4.215 → 4.289 (+1.8%, 201-token corpus) — documented trade like `nvfp4_lm_head_gdn`; degen_suite 33/33 PASS. Now ahead of llama.cpp (~229) |
 
 > Canonical gated decode number = `perf_baseline.json` Qwen3-8B-Q8_0 tg128 =
 > 269.5 (cold-median, 5 trials × 5 reps, 2026-06-12, clocks verified healthy
@@ -43,12 +44,12 @@ numbers below carry over unchanged.
 > `clocks.mem` during the bench (healthy = 13801 MHz / ~500 W under prefill).
 
 Against llama.cpp (b8445+, full offload, flash attention on): imp wins dense
-GGUF decode by **+37–72%**. The MoE/hybrid FP16 GDN-projection tax that used to
-put Qwen3.6-35B behind was closed on the **NVFP4** path by the #949 FP8
-SSM-projection sidecar (35B NVFP4 decode 257 → ~320 tok/s, now ahead of
-llama.cpp's ~229). The **GGUF Q4_K** hybrid path is a no-op for that sidecar and
-still carries the tax (35B Q4_K decode ~213 tok/s, 2026-07-11); GGUF is the
-legacy path — NVFP4 SafeTensors is the priority.
+GGUF decode by **+37–72%**. The MoE/hybrid GDN-projection tax that used to put
+Qwen3.6-35B behind was closed on the **NVFP4** path by the #949 FP8
+SSM-projection sidecar (35B NVFP4 decode 257 → ~320 tok/s) and on the **GGUF
+Q4_K** hybrid path by extending that sidecar to the Q8_0-kept GDN projections
+(35B Q4_K decode 224 → 272 tok/s, 2026-07-11) — both now ahead of llama.cpp's
+~229. GGUF remains the legacy path — NVFP4 SafeTensors is the priority.
 
 ## GGUF prefill (pp512, INT8-IMMA family — default on since #617)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,7 @@ The batch=1 *competitive campaigns* are closed as programs -- every lever they l
 
 - **FA2 hd=256 prefill default-on** (#930/#932) -- Qwen3.6/Qwen3.5 hybrids, pp4096 +26% over the WMMA path it replaced.
 - **FP8 tile attention** (#899/#900) -- FP8-KV decode tiles + GQA batching, long-context decode +14%.
-- **FP8 SSM projection sidecar** (#949) -- per-row-scale FP8 for GDN in/out projections; Qwen3.6-35B decode +19% (tg ~320).
+- **FP8 SSM projection sidecar** (#949) -- per-row-scale FP8 for GDN in/out projections; Qwen3.6-35B NVFP4 decode +19% (tg ~320). Extended to GGUF hybrids' Q8_0-kept GDN projections (dequant→FP8 at init): 35B UD-Q4_K_M decode +21% (tg 272, ahead of llama.cpp) -- closed the last decode combo where llama.cpp led.
 - **Speculative decoding economics** (#852/#862-#866) -- hybrid-safe verify + MTP drafts; echo-heavy agent workloads up to +156% on 27B.
 
 Closed competitive records (kept for the record, not active work):

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -319,13 +319,15 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
                 gemm(input, fp16_it->second, output, 1.0f, ctx.beta, ctx.stream);
                 return;
             }
-            // FP16-resident source with no cache entry — the source IS the
-            // FP16 weight (e.g. a weight whose only cache is the fp8_ssm_proj
-            // decode sidecar). Route through the uncached fallback exactly as
-            // the pre-sidecar Undefined tier did; falling further through
-            // would hand a null payload pointer to cuBLAS.
+            // FP16-resident or dequantable source with no cache entry — the
+            // source IS the weight (e.g. one whose only cache is the
+            // fp8_ssm_proj decode sidecar: F16 on native hybrids, Q8_0 on GGUF
+            // hybrids). Route through the uncached fallback exactly as the
+            // pre-sidecar Undefined tier did (block quants dequant→cuBLAS);
+            // falling further through would hand a null payload to cuBLAS.
             if (h.source_data &&
-                (h.source_qtype == QType::F16 || h.source_qtype == QType::BF16)) {
+                (h.source_qtype == QType::F16 || h.source_qtype == QType::BF16 ||
+                 dequant_gpu_supported(h.source_qtype))) {
                 Tensor weight(const_cast<void*>(h.source_data), h.source_qtype, 2, h.shape, true);
                 weight.kind = h.kind;
                 weight.scales = h.source_scales;

--- a/src/exec/pre_dequant_phase2_fp8_cache.cu
+++ b/src/exec/pre_dequant_phase2_fp8_cache.cu
@@ -247,15 +247,26 @@ void QuantPipeline::pre_dequant_phase2_fp8_cache_(
     deduct_budget(remaining_budget, wcache_->fp8_bytes + phase2_fp16_bytes);
 }
 
-// Phase 2b: FP8 E4M3 decode sidecar for the native-precision GDN/Mamba
-// in/out projections (gemm.fp8_ssm_proj). On native-NVFP4 hybrids the
-// producer recipe leaves ssm_in/ssm_out BF16 → they decode as FP16 GEMVs,
-// the single largest decode slice (34.6% on Qwen3.6-35B, 2026-07-10 nsys).
-// NVFP4 on these wide GDN shapes REGRESSES (see config.h note); FP8 halves
-// the bytes with byte-aligned loads instead. The sidecar only serves the
-// M=1 decode GEMV — prefill and verify chunks keep the FP16 source, and
-// the recurrent-scan state stays FP16, so the quality exposure is one
-// 8-bit weight read per token, not error accumulation in the state.
+// Phase 2b: FP8 E4M3 decode sidecar for the GDN/Mamba in/out projections
+// (gemm.fp8_ssm_proj). On native-NVFP4 hybrids the producer recipe leaves
+// ssm_in/ssm_out BF16 → they decode as FP16 GEMVs, the single largest
+// decode slice (34.6% on Qwen3.6-35B, 2026-07-10 nsys). NVFP4 on these
+// wide GDN shapes REGRESSES (see config.h note); FP8 halves the bytes with
+// byte-aligned loads instead. The sidecar only serves the M=1 decode GEMV —
+// prefill and verify chunks keep the full-precision source, and the
+// recurrent-scan state stays FP16, so the quality exposure is one 8-bit
+// weight read per token, not error accumulation in the state.
+//
+// GGUF hybrids (e.g. Qwen3.6-35B-A3B UD-Q4_K_M): the recurrent projections
+// are excluded from the NVFP4 decode cache (quality lock, phase 3) and are
+// in no other cache, so their handles were Undefined-tier → decode paid a
+// full dequant→cuBLAS round-trip per token. UD quants keep exactly these
+// tensors at Q8_0, so an FP8 copy costs the same bytes but runs the tuned
+// rowscale GEMV instead. Quantized sources are dequanted into the shared
+// scratch first; only ≥8-bit sources (Q8_0) qualify — for 4/5/6-bit
+// sources FP8 would *increase* the decode bytes, and stacking FP8 rounding
+// on a coarser lattice is exactly the recurrent-scan quality risk the
+// phase-3 exclusion exists for.
 void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
                                                          cudaStream_t stream) {
     if (!runtime_config().gemm.fp8_ssm_proj)
@@ -266,26 +277,36 @@ void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
         size_t n_elems;
         int rows;
         int cols;
+        QType src_qtype;  // F16 = quantize in place; else dequant to scratch first
     };
     std::vector<Entry> entries;
     size_t total_bytes = 0;
+    // Explicit user opt-in gemm.nvfp4_ssm_proj wins for quantized sources:
+    // phase 3 will force them into the NVFP4 decode cache, and a shadow FP8
+    // copy would just burn VRAM (infer_tier prefers NVFP4 over FP8 anyway).
+    const bool nvfp4_ssm_opt_in = runtime_config().gemm.nvfp4_ssm_proj;
     for (int i = 0; i < cfg.n_layers; i++) {
         const auto& L = model_->layer(i);
         // At decode the fused GDN input pack ([ssm_in | gate | alpha | beta]
         // row-concat) replaces the ssm_in dispatch entirely (run_gdn n==1
         // fused_input path), so the sidecar must target the pack where it
-        // exists; ssm_in then only serves prefill and stays FP16.
+        // exists; ssm_in then only serves prefill and stays full-precision.
+        // Without a pack (quantized GGUF sources never build one) decode runs
+        // the 4-call path — ssm_in AND gdn_gate GEMVs every token, so both
+        // are sidecar targets there.
         const Tensor* in_side = L.gdn_input_packed.data ? &L.gdn_input_packed : &L.ssm_in;
-        for (const Tensor* w : {in_side, &L.ssm_out}) {
-            if (!w->data || !w->on_device)
+        const Tensor* gate_side = L.gdn_input_packed.data ? nullptr : &L.gdn_gate;
+        for (const Tensor* w : {in_side, gate_side, &L.ssm_out}) {
+            if (!w || !w->data || !w->on_device)
                 continue;
-            // Native-precision sources only: quantized sources go through the
-            // nvfp4_ssm_proj / dp4a paths, and anything already in a decode
-            // cache keeps its faster tier. F16 strictly — the calibration
-            // kernel reads __half, and post-upload residents are F16 (BF16
-            // checkpoints are converted at upload; a genuine BF16-resident
-            // would already break the FP16 GEMV this replaces).
-            if (w->qtype != QType::F16)
+            // F16 (native residents; BF16 checkpoints are converted at
+            // upload) quantizes straight from the resident weight — the
+            // calibration kernel reads __half. Q8_0 (GGUF) dequants into the
+            // shared scratch first; see the byte/quality rationale above.
+            const bool f16_src = w->qtype == QType::F16;
+            const bool q8_src = w->qtype == QType::Q8_0 && !nvfp4_ssm_opt_in &&
+                                qscratch_->dequant != nullptr;
+            if (!f16_src && !q8_src)
                 continue;
             if (wcache_->fp8.count(w->data) || wcache_->nvfp4.count(w->data) ||
                 wcache_->cutlass_nvfp4.count(w->data))
@@ -293,8 +314,10 @@ void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
             size_t n = static_cast<size_t>(w->shape[0]) * w->shape[1];
             if (n == 0 || (w->shape[1] % 16) != 0)
                 continue;
+            if (q8_src && n * sizeof(half) > qscratch_->dequant_size)
+                continue;
             entries.push_back({w->data, n, static_cast<int>(w->shape[0]),
-                               static_cast<int>(w->shape[1])});
+                               static_cast<int>(w->shape[1]), w->qtype});
             total_bytes += n;
         }
     }
@@ -327,7 +350,14 @@ void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
 
     size_t offset = 0, row_offset = 0;
     for (const auto& e : entries) {
-        quantize_fp8_rows_async(e.ptr, d_bulk + offset, e.rows, e.cols,
+        const void* f16_src = e.ptr;
+        if (e.src_qtype != QType::F16) {
+            // Serialized on `stream`, so the shared scratch is safe to reuse
+            // across entries: each dequant completes before the next overwrites it.
+            dequant_gpu(e.ptr, qscratch_->dequant, e.src_qtype, e.rows, e.cols, stream);
+            f16_src = qscratch_->dequant;
+        }
+        quantize_fp8_rows_async(f16_src, d_bulk + offset, e.rows, e.cols,
                                 d_row_scales + row_offset, stream);
         int64_t fp8_shape[4] = {e.rows, e.cols, 0, 0};
         Tensor fp8_t(d_bulk + offset, QType::FP8_E4M3, 2, fp8_shape, true);
@@ -346,7 +376,7 @@ void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
     wcache_->fp8_ssm_sidecar_row_scales = d_row_scales;
 
     IMP_LOG_INFO("fp8_ssm_proj: FP8 decode sidecar for %zu GDN/SSM projections "
-                 "(%.1f MiB, %zu per-row scales; FP16 source retained for prefill)",
+                 "(%.1f MiB, %zu per-row scales; full-precision source retained for prefill)",
                  entries.size(), total_bytes / (1024.0 * 1024.0), total_rows);
 }
 

--- a/src/exec/pre_dequant_phase4_tensor_registry.cu
+++ b/src/exec/pre_dequant_phase4_tensor_registry.cu
@@ -10,6 +10,7 @@
 #include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
 #include "core/logging.h"
+#include "quant/dequant_gpu.h"
 #include "runtime/storage_planner.h"
 
 #include <cuda_runtime.h>
@@ -38,12 +39,26 @@ void QuantPipeline::pre_dequant_phase4_tensor_registry_(
         if (!t.data)
             return kInvalidTensorID;
         StorageTier tier = infer_tier_from_wcache(*wcache_, t.data);
-        // FP8 decode SIDECAR on a native-precision weight (gemm.fp8_ssm_proj):
-        // the wcache fp8 entry must not become the primary tier — prefill and
-        // M>1 verify chunks stay on the resident FP16 source (quality), only
-        // the M=1 decode GEMV takes the FP8 copy. Demote BEFORE the payload
-        // borrow below, or the union would carry an fp8 payload into FP16 paths.
-        const bool fp8_decode_sidecar = tier == StorageTier::FP8 && t.qtype == QType::F16;
+        // FP8 decode SIDECAR (gemm.fp8_ssm_proj): the wcache fp8 entry must
+        // not become the primary tier — prefill and M>1 verify chunks stay on
+        // the full-precision source (quality), only the M=1 decode GEMV takes
+        // the FP8 copy. Demote BEFORE the payload borrow below, or the union
+        // would carry an fp8 payload into FP16 paths.
+        // A native F16 resident with an fp8 entry is always the sidecar (the
+        // phase-2 prefill cache never keys F16 sources). A quantized (GGUF)
+        // source is the sidecar only when the entry carries per-row scales —
+        // the sidecar's marker — since the phase-2 FP8 *prefill* cache also
+        // keys quantized sources (per-tensor scale) and must stay primary.
+        bool fp8_decode_sidecar = false;
+        if (tier == StorageTier::FP8) {
+            if (t.qtype == QType::F16) {
+                fp8_decode_sidecar = true;
+            } else if (dequant_gpu_supported(t.qtype)) {
+                auto it = wcache_->fp8.find(t.data);
+                fp8_decode_sidecar =
+                    it != wcache_->fp8.end() && it->second.d_row_scales != nullptr;
+            }
+        }
         if (fp8_decode_sidecar)
             tier = StorageTier::FP16;
         TensorID id = registry_->reserve(kind, t.shape[0], t.ndim > 1 ? t.shape[1] : 1);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -511,15 +511,16 @@ struct RuntimeConfig {
         // recurrent in_proj/out_proj (ssm_in/ssm_out) OUT of the NVFP4 decode
         // cache by default: they feed the GDN/SSM recurrent scan, which
         // accumulates quantization error in the state H across tokens, so 4-bit
-        // was thought to degrade quality on 9B+ models. At decode they therefore
-        // GGUF hybrid models (e.g. Qwen3.6-35B-A3B Q4_K_M): the GDN/SSM
-        // in_proj/out_proj are excluded from the NVFP4 decode cache (Q4_K source
-        // is not nvfp4_beneficial), so decode runs them via Q4_K→FP16→cuBLAS — a
-        // memory-bound tax. This opt-in forces them into the NVFP4 decode cache.
+        // was thought to degrade quality on 9B+ models. On GGUF hybrids (e.g.
+        // Qwen3.6-35B-A3B Q4_K_M) that exclusion left them in no decode cache
+        // — dequant→cuBLAS per token, a memory-bound tax. This opt-in forces
+        // them into the NVFP4 decode cache anyway.
         // MEASURED (2026-05-30): Qwen3.6-35B Q4_K_M **+53% decode** (161→248
         // tok/s), perplexity flat (−0.01%), coherent — reverses the documented
         // −31% GGUF-hybrid-decode loss vs llama.cpp. No-op on native-NVFP4 models
-        // (their SSM projections are already NVFP4-cached). Default false.
+        // (their SSM projections are already NVFP4-cached). Default false —
+        // the default GGUF-hybrid decode path for Q8_0-kept GDN projections is
+        // the fp8_ssm_proj sidecar below; this opt-in takes precedence when set.
         bool nvfp4_ssm_proj = false;
         // Native-NVFP4 hybrid models store SOME projections BF16 because the
         // Modelopt/llm-compressor recipe excluded them from NVFP4. At decode these
@@ -548,12 +549,24 @@ struct RuntimeConfig {
         // decode GEMV dispatches the FP8 copy (gemv_fp8_rowscale, per-row
         // scales — one per-tensor scale over the heterogeneous GDN input pack
         // cost +4% PPL; per-row is PPL-flat). Costs +0.5 byte/elem VRAM for
-        // the sidecar copies. No-op on models without F16-resident SSM
-        // projections (GGUF hybrids → see nvfp4_ssm_proj; 27B-class checkpoints
-        // whose SSM projections are already native NVFP4).
+        // the sidecar copies.
+        // GGUF hybrids: also covers Q8_0-source ssm_in/gdn_gate/ssm_out
+        // (UD-Q4_K_M keeps exactly these at Q8_0). Those handles were in no
+        // decode cache at all (phase-3 quality lock) → every decode token
+        // paid a full dequant→cuBLAS round-trip; the FP8 copy is byte-neutral
+        // vs Q8_0 but runs the tuned rowscale GEMV. Sub-8-bit sources are
+        // excluded (FP8 would increase decode bytes and stack rounding on a
+        // coarse lattice); gemm.nvfp4_ssm_proj opt-in takes precedence.
+        // No-op on 27B-class checkpoints whose SSM projections are already
+        // native NVFP4.
         // MEASURED (2026-07-10): Qwen3.6-35B-A3B-NVFP4 decode +19% (268.6→320.3
         // tok/s spec-off, 261→308 with default spec), PPL flat (8.021→8.012);
-        // Nemotron-3-Nano PPL flat (4.184→4.117). Default ON.
+        // Nemotron-3-Nano PPL flat (4.184→4.117).
+        // MEASURED (2026-07-11, GGUF branch): Qwen3.6-35B UD-Q4_K_M decode +21%
+        // (224.4→272.0 defaults, 219.2→265.9 spec-off), PPL 4.215→4.289 (+1.8%
+        // on the 201-token corpus — E4M3 stacked on the Q8_0 lattice; an
+        // accepted trade like nvfp4_lm_head_gdn, set false to revert),
+        // degen_suite 33/33. Default ON.
         bool fp8_ssm_proj = true;
         // Route native-NVFP4 (Modelopt/llm-compressor) MoE expert DECODE (M=1)
         // through the fast per-expert gemv_nvfp4_moe kernels by borrowing the

--- a/tests/test_fp8_gemm.cu
+++ b/tests/test_fp8_gemm.cu
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "compute/gemm.h"
 #include "quant/fp8_quant.h"
+#include "quant/dequant_gpu.h"
 #include "core/tensor.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -8,6 +9,8 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 namespace imp {
 namespace {
@@ -200,6 +203,115 @@ TEST_F(FP8GemmTest, GemvFP8NonzeroMatchesReference) {
     cudaFree(d_a);
     cudaFree(d_x);
     cudaFree(d_y);
+}
+
+// The GGUF branch of the fp8_ssm_proj decode sidecar: a Q8_0-source GDN
+// projection is dequanted (dequant_gpu) at init, per-row FP8-quantized
+// (quantize_fp8_rows_async), and decoded via gemv_fp8_rowscale. This chains
+// those three kernels exactly as pre_dequant_phase2b does and checks the GEMV
+// against an fp64 dot over the format-derived Q8_0 dequant reference. The
+// only spread vs that reference is the E4M3 re-quantization (per-row scale =
+// row_absmax/448) plus accumulation order, so a wrong block layout, scale
+// application, or row indexing shows up as O(1) error against the ~1e-2-class
+// rounding floor.
+TEST_F(FP8GemmTest, RowscaleGemvFromQ8SourceMatchesReference) {
+    const int M = 192, K = 2048;  // K % 32 == 0 (Q8_0 blocks), K % 16 == 0 (sidecar gate)
+    constexpr int kQ8BlockBytes = 34;  // [ d:f16 | qs:int8[32] ]
+    const int blocks_per_row = K / 32;
+    const size_t q8_bytes = static_cast<size_t>(M) * blocks_per_row * kQ8BlockBytes;
+
+    // Random Q8_0 blocks (fixed seed) + fp64 dequant reference: val = d * q.
+    std::vector<uint8_t> h_q8(q8_bytes);
+    std::vector<double> wref(static_cast<size_t>(M) * K);
+    std::srand(1234);
+    for (int r = 0; r < M; ++r) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            uint8_t* blk = h_q8.data() + (static_cast<size_t>(r) * blocks_per_row + b) * kQ8BlockBytes;
+            half d = __float2half(0.001f + 0.05f * (std::rand() / (float)RAND_MAX));
+            std::memcpy(blk, &d, 2);
+            int8_t* qs = reinterpret_cast<int8_t*>(blk + 2);
+            double dd = static_cast<double>(__half2float(d));
+            for (int j = 0; j < 32; ++j) {
+                qs[j] = static_cast<int8_t>(std::rand() % 255 - 127);
+                wref[(static_cast<size_t>(r) * K) + b * 32 + j] = dd * qs[j];
+            }
+        }
+    }
+    std::vector<half> h_x(K);
+    for (int k = 0; k < K; ++k)
+        h_x[k] = __float2half(((std::rand() / (float)RAND_MAX) - 0.5f) * 2.0f);
+
+    void *d_q8 = nullptr, *d_fp16 = nullptr, *d_fp8 = nullptr, *d_x = nullptr, *d_y = nullptr;
+    float* d_row_scales = nullptr;
+    cudaMalloc(&d_q8, q8_bytes);
+    cudaMalloc(&d_fp16, static_cast<size_t>(M) * K * sizeof(half));
+    cudaMalloc(&d_fp8, static_cast<size_t>(M) * K);
+    cudaMalloc(&d_x, K * sizeof(half));
+    cudaMalloc(&d_y, M * sizeof(half));
+    cudaMalloc(&d_row_scales, M * sizeof(float));
+    cudaMemcpy(d_q8, h_q8.data(), q8_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, h_x.data(), K * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_y, 0, M * sizeof(half));
+
+    // The sidecar chain: Q8_0 → FP16 scratch → per-row FP8 → rowscale GEMV.
+    dequant_gpu(d_q8, d_fp16, QType::Q8_0, M, K, stream_);
+    quantize_fp8_rows_async(d_fp16, d_fp8, M, K, d_row_scales, stream_);
+    int64_t a_shape[] = {M, K};
+    int64_t x_shape[] = {K};
+    int64_t y_shape[] = {M};
+    Tensor A(d_fp8, QType::FP8_E4M3, 2, a_shape, true);
+    Tensor x(d_x, QType::F16, 1, x_shape, true);
+    Tensor y(d_y, QType::F16, 1, y_shape, true);
+    gemv_fp8_rowscale(A, x, y, d_row_scales, stream_);
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_y(M);
+    cudaMemcpy(h_y.data(), d_y, M * sizeof(half), cudaMemcpyDeviceToHost);
+
+    std::vector<double> yref(M);
+    double sum_sq = 0.0;
+    for (int r = 0; r < M; ++r) {
+        double acc = 0.0;
+        for (int k = 0; k < K; ++k)
+            acc += wref[(static_cast<size_t>(r) * K) + k] * static_cast<double>(__half2float(h_x[k]));
+        yref[r] = acc;
+        sum_sq += acc * acc;
+    }
+    double ref_rms = std::sqrt(sum_sq / M);
+    double inv = ref_rms > 1e-9 ? 1.0 / ref_rms : 0.0;
+    double max_rel = 0.0, sum_rel_sq = 0.0;
+    int worst = 0;
+    bool any_nan_inf = false;
+    for (int r = 0; r < M; ++r) {
+        float gf = __half2float(h_y[r]);
+        if (std::isnan(gf) || std::isinf(gf))
+            any_nan_inf = true;
+        double rel = std::fabs(static_cast<double>(gf) - yref[r]) * inv;
+        sum_rel_sq += rel * rel;
+        if (rel > max_rel) {
+            max_rel = rel;
+            worst = r;
+        }
+    }
+    double rms_rel = std::sqrt(sum_rel_sq / M);
+    printf("[sidecar q8→fp8 rowscale] M=%d K=%d max_rel=%.3e rms_rel=%.3e ref_rms=%.4f "
+           "(row=%d gpu=%.4f ref=%.4f)\n",
+           M, K, max_rel, rms_rel, ref_rms, worst, __half2float(h_y[worst]), yref[worst]);
+    EXPECT_FALSE(any_nan_inf) << "sidecar chain produced NaN/Inf on finite weights";
+    // E4M3 rounding floor for this input: dot error rms ≈ √K·rms(w·x)·2⁻⁴/√3
+    // ≈ 2.0 against ref_rms ≈ 61 (random signs cancel the reference ~25× below
+    // Σ|w·x|, which amplifies the normalized error) → expected rms_rel ≈ 3e-2;
+    // measured 2.5e-2 / max 6.4e-2. Layout/scale/indexing bugs produce O(1)
+    // errors — orders above these gates.
+    EXPECT_LT(max_rel, 1.2e-1) << "rowscale GEMV diverges from Q8_0 dequant reference";
+    EXPECT_LT(rms_rel, 4e-2) << "rowscale GEMV rms error above the E4M3 rounding floor";
+
+    cudaFree(d_q8);
+    cudaFree(d_fp16);
+    cudaFree(d_fp8);
+    cudaFree(d_x);
+    cudaFree(d_y);
+    cudaFree(d_row_scales);
 }
 
 }  // namespace


### PR DESCRIPTION
## What

`gemm.fp8_ssm_proj` (#949) now also covers **GGUF hybrids**: the Q8_0-kept GDN projections of UD quants (`ssm_in` / `gdn_gate` / `ssm_out`) are dequanted once at init and per-row FP8-quantized into the same decode sidecar the native-NVFP4 path uses. Prefill and M>1 verify chunks keep the Q8_0 source (dequant→cuBLAS, unchanged); only the M=1 decode GEMV dispatches the FP8 copy.

## Why

Gap analysis found the last decode combo where a competitor leads: Qwen3.6-35B UD-Q4_K_M at 213 tok/s vs llama.cpp ~229. Root cause: the phase-3 quality lock excludes GDN projections from the NVFP4 decode cache, and on GGUF they were in **no** cache at all — `Undefined` tier, i.e. a full dequant→cuBLAS round-trip per decode token. UD quants keep exactly these tensors at Q8_0, so an FP8 copy is byte-neutral but runs the tuned rowscale GEMV.

## Changes

- **phase 2b** (`pre_dequant_phase2_fp8_cache.cu`): collect Q8_0-source GDN projections (plus `gdn_gate` on the pack-less 4-call path), dequant to the shared scratch, `quantize_fp8_rows_async` into the sidecar. `gemm.nvfp4_ssm_proj` opt-in takes precedence; sub-8-bit sources stay excluded (FP8 would increase their decode bytes and stack rounding on a coarse lattice).
- **phase 4 registry**: a quantized-source fp8 entry with per-row scales (the sidecar marker) demotes to FP16 primary + `decode_tier=FP8` — same shape as the native F16 sidecar; the FP8 *prefill* cache (per-tensor scale) is unaffected.
- **dispatch**: the M>1 FP16 branch routes cache-less dequantable sources through the uncached fallback, exactly as the pre-sidecar `Undefined` tier did.
- **test**: kernel-chain regression `Q8_0 → dequant_gpu → quantize_fp8_rows_async → gemv_fp8_rowscale` vs an fp64 reference (the rowscale GEMV had no unit coverage).

## Measurements (RTX 5090, same session, healthy clocks, 10 reps)

| Config | tg256 |
|---|---:|
| off (old path) defaults | 224.4 |
| **FP8 sidecar (default) defaults** | **272.0 (+21%)** |
| off / FP8, spec-off | 219.2 / 265.9 |
| `nvfp4_ssm_proj` opt-in (#486) | 71.1 (bit-rotted, see note) |

- Now **ahead of llama.cpp (~229)** — closes the last decode gap in the GOAL bar.
- **PPL 4.215 → 4.289 (+1.8%** on the 201-token corpus): E4M3 stacked on the Q8_0 lattice. Documented `nvfp4_lm_head_gdn`-class trade; `--set gemm.fp8_ssm_proj=false` reverts.
- **degen_suite 33/33 PASS** (server-level, all categories); long-form counting/squares coherent.
- **No collateral**: native-NVFP4 35B 318.3 spec-off (#949 measured 320.3, within noise; same 60-projection sidecar), dense Q8 hero tg128 285.6 (baseline 269.5). Not a baseline-model change → `perf_baseline.json` untouched.

Note: the `gemm.nvfp4_ssm_proj` opt-in (+53% when measured 2026-05-30) now measures 71 tok/s — it has bit-rotted somewhere in the tier refactors since. Left as-is (opt-in, default off); candidate for removal in a follow-up.

Sub-8-bit GDN sources (plain Q4_K_M GGUFs like ornith-35b / Qwable-27b) still decode via the old path — extending FP8 there is a possible follow-up but needs its own PPL gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F