### PR TITLE
chore: release-bar hygiene — remove bit-rotted nvfp4_ssm_proj, list the #962 PPL trade, first long-context + refreshed concurrency numbers

### DIFF
--- a/.claude/skills/quant-formats/SKILL.md
+++ b/.claude/skills/quant-formats/SKILL.md
@@ -16,7 +16,7 @@ description: Use when working on imp's quantization formats, loaders, or dequant
 | Prefill | cuBLAS on dequanted source (full precision) | CUTLASS NVFP4 GEMM (sm_120 TC) |
 | Priority | legacy/maintenance — esp. community MXFP4 quality bugs: don't sink time | **the strategic path** |
 
-- GGUF→NVFP4 decode cache: weights converted at init; `nvfp4_beneficial` weights skip the FP16 cache. Opt-in extensions: `gemm.nvfp4_ssm_proj` (+53% GGUF hybrid), `gemm.nvfp4_attn_proj`.
+- GGUF→NVFP4 decode cache: weights converted at init; `nvfp4_beneficial` weights skip the FP16 cache. GDN/SSM projections are excluded (quality lock) and served by the `gemm.fp8_ssm_proj` decode sidecar instead (default on; covers native-F16 AND GGUF-Q8_0 sources since #962 — the old `nvfp4_ssm_proj` opt-in was removed 2026-07-11, bit-rotted). `gemm.nvfp4_attn_proj` stays opt-in.
 - gpt-oss: native MXFP4 experts are converted to NVFP4 at load.
 
 ## StorageTier is the dispatch contract (`src/core/storage_tier.h`)

--- a/.claude/skills/sm120-cuda-expert/SKILL.md
+++ b/.claude/skills/sm120-cuda-expert/SKILL.md
@@ -51,7 +51,7 @@ Optimal-kernel reference for RTX 5090 (GB202, **sm_120a** — consumer Blackwell
 | cuBLAS f16-accumulate prefill (`gemm.cublas_fp16_acc=auto`) | +17% Q8 pp512 | PR #611 default-on via per-arch auto (denied: Gemma-3/4, gpt-oss — PPL). |
 | Warp-per-row FP16 RMSNorm for batch prefill | shipped | PR #620 (#602). |
 | NVFP4 lm_head (`gemm.nvfp4_lm_head`, `…_gdn` default ON) | +8–16% dense, +11.4% Qwen3.6 decode | BF16 lm_head quantized to NVFP4 at load; costs +2.2% PPL (owner-accepted). |
-| GGUF `gemm.nvfp4_ssm_proj` (opt-in) | +53% GGUF-hybrid decode | reverses the −31% GGUF Qwen3.6 loss vs llama.cpp; `nvfp4_attn_proj` +3.8% Nemotron. **NVFP4 on GDN in/out projections REGRESSES −9 to −20% — dead end.** |
+| FP8 SSM sidecar (`gemm.fp8_ssm_proj`, default ON) | +19% native (#949), +21% GGUF-Q8_0 (#962) Qwen3.6-35B decode | per-row-scale FP8 copy for GDN in/out projections, decode-only; `nvfp4_attn_proj` +3.8% Nemotron. **NVFP4 on GDN in/out projections REGRESSES −9 to −20% — dead end** (the old `nvfp4_ssm_proj` opt-in was removed 2026-07-11). |
 | NVFP4 prmt register LUT | +4.7–16% | `prmt.b32` replaces SMEM LUT |
 | Inline Q8_1 in O-projection | +5–10% | Eliminates 1 launch + 1 DRAM round-trip |
 | `__ldcs` on KV cache reads | +2–4% decode | Bypass L1, evict-first L2. **KV only, NOT weights.** |

--- a/.claude/skills/sm120-cuda-expert/references/known-issues.md
+++ b/.claude/skills/sm120-cuda-expert/references/known-issues.md
@@ -83,7 +83,7 @@ These bugs were diagnosed at high cost. The current kernels assume the fix is in
 
 - **Generic `compute_120` PTX fallback.** Lacks FP8 MMA + block-scale. Always pin `compute_120a/sm_120a`.
 - **FP8×FP8 cuBLAS prefill on sm_120.** Disabled by default since 2026-05-28: cuBLAS FP8 returns `NOT_SUPPORTED` at non-aligned M on consumer Blackwell (`engine_init_resolver.cpp:156`, config `attention.fp8_prefill`). Prefill levers are the FA2 family instead.
-- **NVFP4 on GDN in/out projections.** REGRESSES −9 to −20% on wide GDN shapes — FP16 wins there. (`gemm.nvfp4_ssm_proj` for GGUF hybrids and `gemm.nvfp4_attn_proj` are the shipped, measured exceptions.)
+- **NVFP4 on GDN in/out projections.** REGRESSES −9 to −20% on wide GDN shapes — FP16 wins there; the byte-aligned `gemm.fp8_ssm_proj` sidecar is the shipped answer (native +19% #949, GGUF-Q8_0 +21% #962). The old `gemm.nvfp4_ssm_proj` GGUF opt-in was removed 2026-07-11 (bit-rotted to 71 tok/s, superseded); `gemm.nvfp4_attn_proj` remains a measured opt-in exception.
 - **Occupancy raise / KPAR→MR reroute on the NVFP4 decode GEMV path.** Refuted by the 2026-05-30 nsys+ncu roofline sweep — decode plateau is a 4-bit-dequant co-limit (L1TEX 91%), not occupancy.
 - **Batch-1 MoE decode GEMV beyond 30% roofline.** Structural (#600/PR #642): shallow grids (1.5–2 waves) + tiny K (1.5–4 loads/lane); occupancy is already HIGHER than dense. `moe.mr_nr` is saturated — NR=4 +0.9%, NR≥16 regresses. Don't re-pursue.
 - **MoE grouped-GEMM (NVFP4 prefill) beyond 41% roofline.** Structural (#601/PR #644): grid=170 (1 wave), 23% occupancy, per-expert M≈32. `moe.nvfp4_smallM` REGRESSES vs the device-args default (which is +25–32%) — keep it OFF. The NVFP4 prefill lever is attention, not grouped GEMM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Removed
+- **`gemm.nvfp4_ssm_proj`** (the 2026-05-30 opt-in forcing GGUF-hybrid GDN
+  projections into the NVFP4 decode cache): bit-rotted in the tier refactors
+  (measured 71 tok/s vs its original 248 on Qwen3.6-35B Q4_K_M) and superseded
+  by the GGUF branch of `gemm.fp8_ssm_proj` (#962), which is faster than the
+  flag ever was and quality-safer than 4-bit into the recurrent scan. Stale
+  `imp.conf` entries now log the standard unknown-key warning and are ignored.
+
+
 ### Changed
 - **FP8 SSM-projection decode sidecar extended to GGUF hybrids**
   (`gemm.fp8_ssm_proj`, default on): the Q8_0-kept GDN projections of UD

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -136,6 +136,36 @@ The lone surviving NVFP4-prefill gap is dense pp4096 at ~1.04×. Decode (tg256
 @ctx2048): 14B 159, 30B-A3B ~317. Nemotron-3-Nano is arch-limited (hybrid
 Mamba2 + attention FP16-projection mix).
 
+## Long context (pp8192 / tg512 @ 16k ctx)
+
+First tracked long-context table (the GOAL benchmarking discipline asks for
+pp8192 + tg at 16k; nothing was tabulated before 2026-07-11). All rows
+2026-07-11, commit `e66f24b5`, CUDA 13.3, isolated runs, healthy-host clocks;
+command pattern `imp-cli --model <m> --bench --bench-pp {8192|16384}
+--bench-reps {5|3} --max-tokens {64|512} --max-seq-len {9216|17408}`. pp
+carries the usual restart variance; tg is the signal.
+
+| Model | Quant | pp8192 tok/s | tg512 @16k (defaults) | tg512 @16k (spec off) |
+|---|---|---:|---:|---:|
+| Qwen3-8B | Q8_0 | 13 268 | **58.7** ⚠ | 154.1 (214.9 with `--kv-fp8`) |
+| Qwen3-Coder-30B-A3B | NVFP4 | 35 516 | 269.5 | 274.1 |
+| Qwen3.6-35B-A3B | NVFP4 | 14 887 | **IMA crash** (#963) | **IMA crash** (#963) |
+| Qwen3.6-35B-A3B | Q4_K_M (GGUF) | 9 436 (pp16384) | 69.6 (tg64) | — |
+
+Two release-bar-relevant findings came out of this first sweep:
+
+- ⚠ **Default-on n-gram speculation regresses dense long-context decode**
+  (#964): −4% @2k, −15% @8k, **−62% @16k** on Qwen3-8B — a M=2 verify step
+  costs ~5.2× an M=1 step at 16k despite 100% draft acceptance. MoE (Coder)
+  shows no cliff.
+- **Qwen3.6-35B-A3B-NVFP4 crashes (illegal memory access) at 16k context**
+  (#963): works ≤14336, dies at 16384 with and without CUDA graphs; the GGUF
+  variant is unaffected (NVFP4-path-specific).
+- FP8-KV is worth **+39%** at 16k on Qwen3-8B but does not auto-engage on
+  GGUF sources (the `kv_cache.dtype=auto` FP8 upgrade is keyed on the
+  checkpoint's `kv_cache_quant_algo` hint, which GGUF files don't carry) —
+  `--kv-fp8` is a manual win for long-context GGUF sessions.
+
 ## Concurrent serving throughput (batched decode)
 
 The VRAM-aware auto `max_batch_size` (#736) made concurrent decode the common
@@ -148,7 +178,8 @@ up to 439 W).
 
 | Date | Commit | Model | Concurrency | Aggregate tok/s | Note |
 |---|---|---|---:|---:|---|
-| 2026-06-23 | `b56e9ae5` | Qwen3-14B-NVFP4 | 16 | **767** | #745 + #746 |
+| 2026-07-11 | `e66f24b5` | Qwen3-14B-NVFP4 | 16 | **864** (822/904/864, median) | re-measure post #941-#943/#951/#957; `gemm.nvfp4_lm_head_cutlass=true` adds ~+8% (932/946) and stays coherent |
+| 2026-06-23 | `b56e9ae5` | Qwen3-14B-NVFP4 | 16 | 767 | #745 + #746 |
 | 2026-06-23 | pre-`#745` | Qwen3-14B-NVFP4 | 16 | 472 | single-block sampler + per-row LM head |
 
 **+62 %** from the two fixes. Drivers (nsys, graphs-off, share of decode GPU

--- a/docs/GOAL.md
+++ b/docs/GOAL.md
@@ -156,7 +156,9 @@ Defining this is as important as defining the mission. These are explicit non-go
 
 A release is shippable when, on RTX 5090:
 
-1. All hero models pass correctness tests: perplexity within 0.5% of llama.cpp reference at the same quant **with documented owner-approved speed/quality trades excluded** — currently `gemm.nvfp4_lm_head_gdn` default-ON (#483): +2.2% PPL for +11.4% decode on GDN hybrids; each such trade must be opt-out via config and listed here.
+1. All hero models pass correctness tests: perplexity within 0.5% of llama.cpp reference at the same quant **with documented owner-approved speed/quality trades excluded**; each such trade must be opt-out via config and listed here. Current trades:
+   - `gemm.nvfp4_lm_head_gdn` default-ON (#483): +2.2% PPL for +11.4% decode on GDN hybrids.
+   - `gemm.fp8_ssm_proj` on **GGUF** hybrids default-ON (#962): +1.8% PPL (201-token corpus) for +21% decode on Qwen3.6-35B UD-Q4_K_M — E4M3 stacked on the Q8_0 lattice; the native-NVFP4 branch of the same flag is PPL-flat (#949) and is not a trade.
 2. Decode tok/s leads llama.cpp by ≥5% on every hero model.
 3. Prefill tok/s ≥ llama.cpp on every dense **NVFP4/SafeTensors** hero. GGUF prefill is explicitly best-effort: the Q4K-MMQ experiment (2026-05-28) showed imp's GGUF prefill ceiling is architectural (ties cuBLAS at ~4.3% of peak; llama.cpp's MMQ leads 1.3-2.4×) — the old "≥ llama.cpp on every dense GGUF hero" bar was permanently violated as written and is dropped (realignment 2026-06-06, #550).
 4. Prefill tok/s ≥ 70% of vLLM single-seq on every MoE hero (measured ~1.4× gap 2026-05-31; the remaining levers are prefill attention and the grouped-GEMM launch/occupancy scheduler, #558).

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -310,9 +310,6 @@ nvfp4_lm_head_gdn    = true
 # forces NVFP4 activations on the final logits (quality/speed trade). Opt-in
 # until the PPL trade is measured per family; single-stream is unaffected.
 nvfp4_lm_head_cutlass = false
-# Force GGUF-hybrid GDN/SSM in/out projections into the NVFP4 decode cache
-# (Qwen3.6-35B Q4_K_M: +53% decode, PPL flat). Opt-in.
-nvfp4_ssm_proj       = false
 # Quantize recipe-excluded BF16 attention q/k/v/o on native-NVFP4 hybrids
 # (Nemotron-3-Nano: +3.8% decode, PPL-neutral). Opt-in.
 nvfp4_attn_proj      = false

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -407,16 +407,16 @@ void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
     // CUTLASS fast path for all NVFP4-prequant models uniformly.
     if (cutlass_sm120_nvfp4_available()) {
         int ct_count = 0;
-        // NOTE on the GDN/SSM quality lock and gemm.nvfp4_ssm_proj:
+        // NOTE on the GDN/SSM quality lock:
         // For NATIVE-NVFP4 checkpoints the in_proj/out_proj (ssm_in/ssm_out)
         // weights only EXIST as NVFP4 bytes — there is no FP16 copy and
         // dequant_gpu has no NVFP4 path, so they MUST be registered here or
         // decode produces garbage (the uncached fallback would run cuBLAS on
         // raw NVFP4 bytes). They are therefore ALREADY in the NVFP4 decode
         // cache and already use the fast gemv_nvfp4_kpar path — the "FP16 SSM
-        // tax" does not apply to native-NVFP4 hybrids. The gemm.nvfp4_ssm_proj
-        // opt-in is meaningful only for GGUF-quant hybrids (Qwen3.6-35B Q4_K_M),
-        // gated in pre_dequant_phase3's collect_candidates. Always register.
+        // tax" does not apply to native-NVFP4 hybrids. GGUF-quant hybrids
+        // (Qwen3.6-35B Q4_K_M) are served by the gemm.fp8_ssm_proj sidecar
+        // instead (phase 2b). Always register.
         auto register_prequant = [&](const Tensor& w) {
             if (w.qtype != QType::NVFP4 || !w.data || !w.scales)
                 return;

--- a/src/exec/pre_dequant_phase2_fp8_cache.cu
+++ b/src/exec/pre_dequant_phase2_fp8_cache.cu
@@ -281,10 +281,6 @@ void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
     };
     std::vector<Entry> entries;
     size_t total_bytes = 0;
-    // Explicit user opt-in gemm.nvfp4_ssm_proj wins for quantized sources:
-    // phase 3 will force them into the NVFP4 decode cache, and a shadow FP8
-    // copy would just burn VRAM (infer_tier prefers NVFP4 over FP8 anyway).
-    const bool nvfp4_ssm_opt_in = runtime_config().gemm.nvfp4_ssm_proj;
     for (int i = 0; i < cfg.n_layers; i++) {
         const auto& L = model_->layer(i);
         // At decode the fused GDN input pack ([ssm_in | gate | alpha | beta]
@@ -304,8 +300,7 @@ void QuantPipeline::pre_dequant_phase2b_fp8_ssm_sidecar_(const ModelConfig& cfg,
             // calibration kernel reads __half. Q8_0 (GGUF) dequants into the
             // shared scratch first; see the byte/quality rationale above.
             const bool f16_src = w->qtype == QType::F16;
-            const bool q8_src = w->qtype == QType::Q8_0 && !nvfp4_ssm_opt_in &&
-                                qscratch_->dequant != nullptr;
+            const bool q8_src = w->qtype == QType::Q8_0 && qscratch_->dequant != nullptr;
             if (!f16_src && !q8_src)
                 continue;
             if (wcache_->fp8.count(w->data) || wcache_->nvfp4.count(w->data) ||

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -62,14 +62,14 @@ void QuantPipeline::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
                      dctx.exclude_ptrs.size());
     }
 
-    // GDN/SSM models: exclude ssm_in/ssm_out projections from NVFP4.
-    // These feed the recurrent scan which accumulates quantization error
-    // in state H across tokens. 4-bit degrades quality on 9B+ models.
-    // Opt-in gemm.nvfp4_ssm_proj keeps them IN the cache to measure the
-    // speed/quality tradeoff (mirrors nvfp4_lm_head_gdn). This gate covers the
-    // GGUF-source hybrids (Qwen3.6-35B-A3B Q4_K_M); native-NVFP4 SSM weights
-    // are handled identically by the phase0b register gate.
-    if (!runtime_config().gemm.nvfp4_ssm_proj) {
+    // GDN/SSM models: exclude ssm_in/ssm_out projections from NVFP4 —
+    // unconditionally. These feed the recurrent scan which accumulates
+    // quantization error in state H across tokens; 4-bit degrades quality on
+    // 9B+ models. (The former gemm.nvfp4_ssm_proj opt-in that kept them IN
+    // the cache was removed 2026-07-11: bit-rotted, and superseded by the
+    // GGUF branch of gemm.fp8_ssm_proj — see config.h.) Native-NVFP4 SSM
+    // weights are handled identically by the phase0b register gate.
+    {
         int n_ssm_excluded = 0;
         for (int i = 0; i < cfg.n_layers; i++) {
             const auto& L = model_->layer(i);
@@ -84,18 +84,13 @@ void QuantPipeline::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
         }
         if (n_ssm_excluded > 0)
             IMP_LOG_INFO("GDN/SSM: excluding %d recurrent projections from NVFP4 cache", n_ssm_excluded);
-    } else {
-        IMP_LOG_INFO("GDN/SSM: nvfp4_ssm_proj ON — recurrent projections eligible for NVFP4 cache");
     }
 
     const bool decode_all = runtime_config().gemm.nvfp4_decode_all;
-    // force_beneficial bypasses the nvfp4_beneficial(qtype) gate — used by the
-    // opt-in SSM path so a Q4_K/Q5_K recurrent projection (normally only
-    // eligible under nvfp4_decode_all) can be cached on its own merit.
-    auto collect_weight_nvfp4 = [&](const Tensor& w, QType qtype, bool force_beneficial) {
+    auto collect_weight_nvfp4 = [&](const Tensor& w, QType qtype) {
         if (!w.data)
             return;
-        if (!force_beneficial && !nvfp4_beneficial(qtype, decode_all))
+        if (!nvfp4_beneficial(qtype, decode_all))
             return;
         if (wcache_->nvfp4.count(w.data))
             return;
@@ -128,28 +123,12 @@ void QuantPipeline::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
     };
 
     // LM head first: largest single weight (vocab × d_model), biggest bandwidth win.
-    collect_weight_nvfp4(model_->output_proj(), model_->out_proj_.qtype, false);
+    collect_weight_nvfp4(model_->output_proj(), model_->out_proj_.qtype);
 
     // Dense attention + FFN: every tensor benefits every decode step.
     for_each_dense_weight(*model_, cfg, [&](const Tensor& w, QType qtype) {
-        collect_weight_nvfp4(w, qtype, false);
+        collect_weight_nvfp4(w, qtype);
     });
-
-    // GGUF-source GDN/SSM recurrent projections (opt-in). For native-NVFP4
-    // hybrids the SSM weights are already cached in phase0b (no FP16/quant
-    // source), so this loop is a no-op there; it only fires for quantized-
-    // source hybrids (e.g. Qwen3.6-35B-A3B Q4_K_M), where it forces the Q4_K
-    // recurrent projections into the NVFP4 decode cache to remove the FP16
-    // dequant→cuBLAS SSM tax. Quality risk is highest here (recurrent scan).
-    if (runtime_config().gemm.nvfp4_ssm_proj) {
-        for (int i = 0; i < cfg.n_layers; i++) {
-            const auto& L = model_->layer(i);
-            if (L.ssm_in.data)
-                collect_weight_nvfp4(L.ssm_in, L.ssm_in.qtype, true);
-            if (L.ssm_out.data)
-                collect_weight_nvfp4(L.ssm_out, L.ssm_out.qtype, true);
-        }
-    }
 }
 
 void QuantPipeline::nvfp4_decode_cache_fp16_lm_head_(const ModelConfig& cfg, cudaStream_t stream) {

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -220,7 +220,6 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     }
     B("gemm.nvfp4_lm_head_gdn", cfg.gemm.nvfp4_lm_head_gdn);
     B("gemm.nvfp4_lm_head_cutlass", cfg.gemm.nvfp4_lm_head_cutlass);
-    B("gemm.nvfp4_ssm_proj", cfg.gemm.nvfp4_ssm_proj);
     B("gemm.nvfp4_attn_proj", cfg.gemm.nvfp4_attn_proj);
     B("gemm.fp8_ssm_proj", cfg.gemm.fp8_ssm_proj);
     B("gemm.nvfp4_moe_decode", cfg.gemm.nvfp4_moe_decode);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -507,21 +507,15 @@ struct RuntimeConfig {
         // SfAtom scales (FP4 data borrowed from the decode cache). Opt-in until
         // the PPL trade is measured per family. Single-stream (n==1) is unaffected.
         bool nvfp4_lm_head_cutlass = false;
-        // Hybrid GDN/SSM models (Nemotron-3-Nano-30B, Qwen3.6-35B-A3B) keep the
-        // recurrent in_proj/out_proj (ssm_in/ssm_out) OUT of the NVFP4 decode
-        // cache by default: they feed the GDN/SSM recurrent scan, which
-        // accumulates quantization error in the state H across tokens, so 4-bit
-        // was thought to degrade quality on 9B+ models. On GGUF hybrids (e.g.
-        // Qwen3.6-35B-A3B Q4_K_M) that exclusion left them in no decode cache
-        // — dequant→cuBLAS per token, a memory-bound tax. This opt-in forces
-        // them into the NVFP4 decode cache anyway.
-        // MEASURED (2026-05-30): Qwen3.6-35B Q4_K_M **+53% decode** (161→248
-        // tok/s), perplexity flat (−0.01%), coherent — reverses the documented
-        // −31% GGUF-hybrid-decode loss vs llama.cpp. No-op on native-NVFP4 models
-        // (their SSM projections are already NVFP4-cached). Default false —
-        // the default GGUF-hybrid decode path for Q8_0-kept GDN projections is
-        // the fp8_ssm_proj sidecar below; this opt-in takes precedence when set.
-        bool nvfp4_ssm_proj = false;
+        // (gemm.nvfp4_ssm_proj — the 2026-05-30 opt-in that forced GGUF-hybrid
+        // GDN projections into the NVFP4 decode cache — was REMOVED 2026-07-11:
+        // it had bit-rotted in the tier refactors (measured 71 tok/s vs its
+        // original 248 on Qwen3.6-35B Q4_K_M) and is superseded by the GGUF
+        // branch of fp8_ssm_proj below, which is faster than the flag ever was
+        // and quality-safer than 4-bit into the recurrent scan. The recurrent
+        // in_proj/out_proj stay OUT of the NVFP4 decode cache unconditionally:
+        // they feed the GDN/SSM scan, which accumulates quantization error in
+        // the state H across tokens.)
         // Native-NVFP4 hybrid models store SOME projections BF16 because the
         // Modelopt/llm-compressor recipe excluded them from NVFP4. At decode these
         // run as FP16 GEMVs (gemv_fp16_kernel). This opt-in quantizes the
@@ -556,9 +550,8 @@ struct RuntimeConfig {
         // paid a full dequant→cuBLAS round-trip; the FP8 copy is byte-neutral
         // vs Q8_0 but runs the tuned rowscale GEMV. Sub-8-bit sources are
         // excluded (FP8 would increase decode bytes and stack rounding on a
-        // coarse lattice); gemm.nvfp4_ssm_proj opt-in takes precedence.
-        // No-op on 27B-class checkpoints whose SSM projections are already
-        // native NVFP4.
+        // coarse lattice). No-op on 27B-class checkpoints whose SSM
+        // projections are already native NVFP4.
         // MEASURED (2026-07-10): Qwen3.6-35B-A3B-NVFP4 decode +19% (268.6→320.3
         // tok/s spec-off, 261→308 with default spec), PPL flat (8.021→8.012);
         // Nemotron-3-Nano PPL flat (4.184→4.117).


### PR DESCRIPTION
Follow-up batch from the 2026-07-11 gap analysis (round 2: GOAL/release-bar dimensions).

## Docs / release bar

- **GOAL.md bar 1** requires every owner-approved speed/quality trade to be listed — the #962 `fp8_ssm_proj` GGUF trade (+1.8% PPL for +21% decode) is now listed alongside `nvfp4_lm_head_gdn`.

## Flag audit (each opt-in GPU-smoked on the matching model)

| Flag | Verdict |
|---|---|
| `gemm.nvfp4_ssm_proj` | **REMOVED** — bit-rotted (71 tok/s today vs its original 248 on 35B Q4_K_M) and superseded by the #962 GGUF branch of `fp8_ssm_proj` (faster than the flag ever was, quality-safer than 4-bit into the recurrent scan). Phase-3 GDN/SSM exclusion is now unconditional; stale conf keys warn+ignore. |
| `gemm.nvfp4_attn_proj` | works: +7.7% Nemotron decode spec-off (124.0 → 133.6), coherent |
| `gemm.nvfp4_decode_all` | works mechanically (25 → 193 cached tensors on 30B Q4_K_M); regresses decode 271.8 → 249.9 exactly as the default `nvfp4_beneficial` policy predicts — diagnostic knob, kept |
| `gemm.nvfp4_lm_head_cutlass` | works: engages at n>1 ("LM head: CUTLASS NVFP4 ... enabled"), +8% aggregate @16 concurrent (932/946 vs 864 median), coherent |

## Measurements (BENCHMARKS.md)

- **First tracked long-context table** (pp8192 / tg512 @16k — the GOAL benchmarking discipline asked for this; nothing was tabulated before). The sweep surfaced two release-bar findings, filed with full data:
  - **#963** Qwen3.6-35B-A3B-**NVFP4 illegal-memory-access at 16k context** (works ≤14336; with AND without CUDA graphs; GGUF variant unaffected → NVFP4-path-specific).
  - **#964** default-on n-gram speculation **regresses dense long-context decode**: −4% @2k, −15% @8k, −62% @16k on Qwen3-8B despite 100% draft accept (M=2 verify step costs ~5.2× an M=1 step at 16k).
  - FP8-KV is +39% @16k on Qwen3-8B but never auto-engages on GGUF (the auto upgrade is keyed on the checkpoint's `kv_cache_quant_algo` hint) — documented as a manual `--kv-fp8` win.
- **Concurrency re-measure @16** (Qwen3-14B-NVFP4): **864 tok/s median** (822/904/864) vs 767 on 2026-06-23 — +13%, no regression from #941-#943/#951/#957.
- **#965** filed: 35B GGUF decode-graph update fails once per process start (pre-existing WARN).

## Verification

- `make verify-fast` OK; FP8 GPU tests 4/4 on the removal binary.
- 35B GGUF post-removal: sidecar unchanged (90 projections, 960 MiB), decode 271.4 tok/s (matches #962's 272).
- Stale `--set gemm.nvfp4_ssm_proj=true` logs the standard unknown-key warning and continues.
- Not a baseline-model change → `perf_baseline.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F