### PR TITLE
fix(kv): StreamingLLM eviction retains the kernels' floor-aligned window start — 16k+ context IMA/garbage on Qwen3.6-35B (#963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   (Q8_0 → dequant → FP8 rows → rowscale GEMV vs fp64 reference).
 
 ### Fixed
+- **Qwen3.6-35B illegal memory access / silent garbage at 16k+ context**
+  (#963): when StreamingLLM auto-enabled (KV pool >90% full), the
+  middle-block eviction retained the sliding window ceil-aligned from the
+  sequence tail while the paged decode kernels start reading at
+  floor((ctx − window) / block_size) — for non-block-aligned context (every
+  decode step after an aligned prefill) the kernels read a freed −1
+  sentinel block: an illegal memory access on a VRAM-full card (35B NVFP4),
+  silent out-of-bounds garbage attention otherwise (35B GGUF). Eviction now
+  retains one extra boundary block, and the four plain-loop paged kernels
+  skip negative sentinels outright (defense-in-depth). Adds a host-side
+  KVCacheManager regression test pinning the eviction/kernel window
+  invariant.
 - **gemma-3-12b GGUF decode illegal-memory-access** (last hard crash in the
   known-issues list): gemma-3's NVFP4 decode cache must be built from an FP16
   companion copy — a from-scratch build (Q4_K → dequant → NVFP4) corrupts

--- a/src/compute/attention_paged.cu
+++ b/src/compute/attention_paged.cu
@@ -352,6 +352,13 @@ __global__ void paged_attention_decode_kernel(const half* __restrict__ Q, const 
 
     for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read (#963). The host-side
+        // eviction keeps the kernels' window range valid — this guard is
+        // defense-in-depth so any future range drift degrades to a skipped
+        // block instead of an illegal access / silent garbage.
+        if (phys_block < 0)
+            continue;
         const half* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const half* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
 
@@ -506,6 +513,13 @@ __global__ void paged_attention_decode_kernel_generic(
 
     for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read (#963). The host-side
+        // eviction keeps the kernels' window range valid — this guard is
+        // defense-in-depth so any future range drift degrades to a skipped
+        // block instead of an illegal access / silent garbage.
+        if (phys_block < 0)
+            continue;
         const half* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const half* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
 
@@ -694,6 +708,13 @@ __global__ void paged_attention_splitk_kernel(
     // ---- Iterate over assigned KV blocks ----
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read (#963). The host-side
+        // eviction keeps the kernels' window range valid — this guard is
+        // defense-in-depth so any future range drift degrades to a skipped
+        // block instead of an illegal access / silent garbage.
+        if (phys_block < 0)
+            continue;
         const half* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const half* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
 
@@ -913,6 +934,13 @@ __global__ void paged_attention_splitk_pipeline_kernel(
     // ---- Iterate over assigned KV blocks ----
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read (#963). The host-side
+        // eviction keeps the kernels' window range valid — this guard is
+        // defense-in-depth so any future range drift degrades to a skipped
+        // block instead of an illegal access / silent garbage.
+        if (phys_block < 0)
+            continue;
         const half* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const half* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
 

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -865,7 +865,16 @@ int KVCacheManager::evict_middle_blocks(int seq_id, int n_sink_tokens, int n_win
 
     const int sink_end_block = (n_sink_tokens + block_size - 1) / block_size;
     const int window_block_count = (n_window_tokens + block_size - 1) / block_size;
-    const int window_start_block = std::max(0, total_blocks - window_block_count);
+    // Retain ONE extra boundary block beyond the ceil-aligned window (#963):
+    // the paged decode kernels compute their window start as
+    // floor((ctx_len - window) / block_size), which for non-block-aligned
+    // ctx_len (every decode step after an aligned prefill) lands one block
+    // BEFORE ceil-aligned tail retention — the kernels then read a -1
+    // sentinel, and phys_block = -1 is an out-of-bounds KV access (IMA on a
+    // full-VRAM card, silent garbage attention otherwise). One 32-token
+    // block of extra KV is the price of keeping host eviction and device
+    // window math aligned regardless of ctx alignment or call ordering.
+    const int window_start_block = std::max(0, total_blocks - window_block_count - 1);
 
     if (sink_end_block >= window_start_block) {
         // Sinks and window overlap (sequence too short) — nothing to free.

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -1220,29 +1220,32 @@ TEST(KVCacheManagerTest, EvictMiddleBlocksKeepsSinksAndWindow) {
     // Snapshot the original block IDs so we can verify which survive.
     auto bt_before = mgr->block_table(0);
 
-    // Keep first 4 sink tokens (=> 1 sink block) and last 64 window tokens
-    // (=> 4 window blocks). Middle = 20 - 1 - 4 = 15 blocks should be freed.
+    // Keep first 4 sink tokens (=> 1 sink block), last 64 window tokens
+    // (=> 4 window blocks) plus ONE extra boundary block (#963: the decode
+    // kernels' floor-aligned window start must stay readable for
+    // non-block-aligned ctx). Middle = 20 - 1 - 4 - 1 = 14 blocks freed.
     int freed = mgr->evict_middle_blocks(/*seq_id=*/0,
                                          /*n_sink_tokens=*/4,
                                          /*n_window_tokens=*/64);
-    EXPECT_EQ(freed, 15);
+    EXPECT_EQ(freed, 14);
 
     const auto& bt_after = mgr->block_table(0);
     ASSERT_EQ(static_cast<int>(bt_after.size()), 20);  // unchanged length
     EXPECT_EQ(bt_after[0], bt_before[0]);              // sink survives
     EXPECT_EQ(bt_after[1], -1);                        // first middle slot freed
-    EXPECT_EQ(bt_after[15], -1);                       // last middle slot freed
+    EXPECT_EQ(bt_after[14], -1);                       // last middle slot freed
+    EXPECT_EQ(bt_after[15], bt_before[15]);            // boundary block survives (#963)
     EXPECT_EQ(bt_after[16], bt_before[16]);            // window survives
     EXPECT_EQ(bt_after[19], bt_before[19]);            // last block survives
 
-    // 15 freed back into the pool.
-    EXPECT_EQ(mgr->num_free_blocks(), 12 + 15);
+    // 14 freed back into the pool.
+    EXPECT_EQ(mgr->num_free_blocks(), 12 + 14);
     EXPECT_EQ(mgr->num_pinned_blocks(), 1);  // sink block was pinned
 
     // Idempotent: calling again must not crash and not free more.
     int freed2 = mgr->evict_middle_blocks(0, 4, 64);
     EXPECT_EQ(freed2, 0);
-    EXPECT_EQ(mgr->num_free_blocks(), 12 + 15);
+    EXPECT_EQ(mgr->num_free_blocks(), 12 + 14);
 
     // free_sequence keeps the pinned sink block alive (pin_prefix semantics).
     mgr->free_sequence(0);
@@ -1561,6 +1564,52 @@ TEST(KVCacheManagerTest, SwaRollback) {
     mgr.rollback(0, 80);
     EXPECT_EQ(static_cast<int>(mgr.swa_block_table(0).size()), 5);
     EXPECT_EQ(static_cast<int>(mgr.block_table(0).size()), 5);
+}
+
+// Regression for #963: StreamingLLM middle-block eviction must retain the
+// block containing the decode kernels' window start. The paged decode
+// kernels compute window_start_block = floor((ctx_len - window) /
+// block_size); the eviction retained ceil-aligned from the sequence tail
+// (total_blocks - ceil(window / block_size)). For non-block-aligned
+// ctx_len those differ by one — the kernels' first window block held a -1
+// sentinel, and phys_block = -1 produced an out-of-bounds KV read (an
+// illegal memory access on a full-VRAM card, silent garbage attention
+// otherwise). The eviction must keep one extra boundary block.
+TEST(KVCacheManagerTest, EvictMiddleBlocksRetainsKernelWindowStart) {
+    SKIP_IF_NO_CUDA();
+
+    auto mgr = MakeManager(64);
+    const int bs = mgr->kv_cache()->block_size();
+    const int n_sinks = 4;            // < bs → sinks live in block 0
+    const int window = 4 * bs;        // 4-block sliding window
+
+    // Non-block-aligned context: one token into the 21st block — exactly the
+    // state of the first decode step after a block-aligned prefill.
+    const int ctx_len = 20 * bs + 1;
+    const int total_blocks = (ctx_len + bs - 1) / bs;  // 21
+    ASSERT_TRUE(mgr->allocate_blocks(0, total_blocks));
+
+    int freed = mgr->evict_middle_blocks(0, n_sinks, window);
+    EXPECT_GT(freed, 0);
+
+    const auto& table = mgr->block_table(0);
+    ASSERT_EQ(static_cast<int>(table.size()), total_blocks);
+
+    // Sink block survives.
+    EXPECT_GE(table[0], 0) << "sink block evicted";
+    // Deep-middle block is really gone (the test is not vacuous).
+    EXPECT_EQ(table[8], -1) << "middle block not evicted";
+
+    // The kernels' window start (floor((ctx - window) / bs) = block 16 here)
+    // must be retained — this is the off-by-one that crashed Qwen3.6-35B at
+    // 16k context (#963).
+    const int kernel_window_start_block = (ctx_len - window) / bs;
+    EXPECT_GE(table[kernel_window_start_block], 0)
+        << "kernels read block " << kernel_window_start_block
+        << " under classical sliding window, but eviction freed it";
+    // Everything from there to the tail is readable.
+    for (int b = kernel_window_start_block; b < total_blocks; ++b)
+        EXPECT_GE(table[b], 0) << "window block " << b << " evicted";
 }
 
 }  // namespace


### PR DESCRIPTION
Closes #963.

## Root cause

Block-granularity mismatch between host eviction and device window math:

- `evict_middle_blocks` retained the sliding window **ceil-aligned from the sequence tail**: `window_start_block = total_blocks − ceil(window/bs)`
- the paged decode kernels read from `floor((ctx_len − window)/bs)` (`compute_context_range`, classical sliding-window fallback — the split-K/MHA variants force `n_sinks=0`)

For non-block-aligned `ctx_len` — i.e. **every decode step after a block-aligned prefill** — those differ by one block: the kernels' first window block held a freed `-1` sentinel, and `phys_block = -1` became an out-of-bounds KV read.

- **35B NVFP4** (VRAM-full, adjacent pages unmapped): illegal memory access, engine dead — the #963 symptom.
- **35B GGUF** (7.8 GiB free around the pool): the same OOB read landed in mapped memory → **silent garbage attention**. The "GGUF is unaffected" observation in #963 was silent corruption, not correctness.

Trigger chain: pp ≥ ~90% of the KV pool → StreamingLLM auto-enables (sinks=4, window=4096) → `evict_middle_blocks` writes `-1` sentinels → first decode step reads the boundary block. Explains the measured bracket exactly: 14336 OK (<90% of the 513-block pool), 15360+ dead.

## Fix

1. **Eviction keeps one extra boundary block** (32 tokens of KV): host retention now covers the kernels' floor-aligned window start regardless of ctx alignment or eviction/append ordering.
2. **Defense-in-depth**: the four plain-loop paged decode kernels skip `phys_block < 0` outright — any future range drift degrades to a skipped block instead of an IMA/silent garbage.

## Verification

| Check | Result |
|---|---|
| pp16384 → 3×512 decode, 35B-NVFP4 (was: IMA) | clean through StreamingLLM enable |
| Needle recall @16.2k ctx under streaming (gen past pool size) | **ZEBRA-7742 recalled correctly**, coherent, 252 tok/s |
| 35B GGUF pp16384 | clean |
| Short-ctx regression: 35B-NVFP4 318.6 tg256 spec-off, Q8 hero 286.4 tg128 | unchanged — sentinel guards cost nothing |
| KVCache/KVCacheManager suite | 54/54 |
| verify-fast | OK |

Adds `KVCacheManagerTest.EvictMiddleBlocksRetainsKernelWindowStart` pinning the eviction/kernel window invariant (fails on the old retention math); the pre-existing `EvictMiddleBlocksKeepsSinksAndWindow` expectations are updated to the new retention (one extra block → 14 freed instead of 15).

Not perf-relevant to the baseline model; `perf_baseline.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F