### PR TITLE
fix(spec): context cap for dense chunk-verify drafting — long-context decode −62% @16k recovered (#964 interim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   (Q8_0 → dequant → FP8 rows → rowscale GEMV vs fp64 reference).
 
 ### Fixed
+- **Default-on n-gram speculation regressed long-context decode** (#964,
+  partial): the chunk verify runs the FA2 prefill tile over the full context
+  plus a paged-KV gather, costing ~2.1× a decode step at 2k ctx and ~5.2× at
+  16k (nsys: +2.05 s fmha_sm120_fa2 + 0.32 s paged_kv_gather in a 96-token
+  decode window) while paying out at most k+1 tokens — end-to-end −4% @2k,
+  −15% @8k, −62% @16k on Qwen3-8B Q8_0 even at 100% draft accept. Root
+  cause: the captured verify is sized to the pow2 ctx TIER (floor 4096,
+  clamped to max_seq_len) — its cost follows the tier, not the live context.
+  New `speculative.draft_ctx_cap` (default 2048, 0 = off) gates DENSE
+  drafting once a request's context crosses the cap, checked per step;
+  MoE-NVFP4 and GDN-hybrid drafts are exempt (deep drafts — Coder-30B
+  code-edit 15.9 tok/verify, MTP chains — pay for the verify). Long-context
+  dense decode recovers to the spec-off rate (152 tok/s @16k, was 58.7);
+  short-context is unchanged (pp16 parity). The structural fix (verify cost
+  following live ctx instead of the tier) stays tracked in #964.
 - **Qwen3.6-35B illegal memory access / silent garbage at 16k+ context**
   (#963): when StreamingLLM auto-enabled (KV pool >90% full), the
   middle-block eviction retained the sliding window ceil-aligned from the

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -421,6 +421,11 @@ mmproj               = ""
 # disables the async decode graph loop while on. Wins on repetition-heavy
 # (agent/code/RAG) workloads; ~neutral on free-form prose. Default-ON.
 ngram                = true
+# Context cap for DENSE chunk-verify drafting (#964): the captured verify
+# costs ~2.1x a decode step at 2k ctx and ~5.2x at 16k (FA2 tile over the
+# pow2 ctx tier), so dense speculation (~2 tok/verify) is net-negative past
+# ~2k. Per-step gate; MoE-NVFP4 and GDN-hybrid drafts are exempt. 0 = no cap.
+draft_ctx_cap        = 2048
 # Speculation on MoE models with native-NVFP4 experts (Qwen3-Coder-30B-FP4:
 # code-edit +49-81%, draft-poor floor -3-7%). GGUF-MoE never engages (its
 # batched verify re-dequants every activated expert per step, measured -22%)

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -287,6 +287,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
 
     // [speculative]
     B("speculative.ngram", cfg.speculative.ngram);
+    I("speculative.draft_ctx_cap", cfg.speculative.draft_ctx_cap);
     B("speculative.moe", cfg.speculative.moe);
     I("speculative.k", cfg.speculative.k);
     B("speculative.suffix", cfg.speculative.suffix);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -669,6 +669,20 @@ struct RuntimeConfig {
     // concurrent batches, and GGUF-MoE (which the async loop carries).
     struct Speculative {
         bool ngram = true;  // prompt-lookup speculation, default-on (batch-1, greedy, dense)
+        // Context cap for DENSE chunk-verify drafting (#964). The captured
+        // verify runs the FA2 tile + paged-KV gather over the ctx TIER
+        // (pow2, floor 4096, clamped to max_seq_len) — its cost follows the
+        // tier, not the live context, while dense ngram pays out only ~2
+        // tokens per verify. MEASURED (2026-07-11, Qwen3-8B Q8_0): verify ≈
+        // 2.1× a decode step at 2k ctx, ~5.2× at 16k; end-to-end decode −4%
+        // @2k, −15% @8k, −62% @16k at 100% draft accept — net-negative past
+        // ~2k regardless of accept rate. Drafting is gated once a request's
+        // context crosses the cap (checked per step). MoE-NVFP4 and
+        // GDN-hybrid requests are exempt (deep drafts: Coder-30B code-edit
+        // 15.9 tok/verify, MTP chains — the verify pays for itself there).
+        // The structural fix (verify cost following live ctx instead of the
+        // tier) is tracked in #964. 0 = no cap.
+        int draft_ctx_cap = 2048;
         // Speculation on MoE models with NATIVE-NVFP4 experts (the gate
         // additionally requires profile().moe_experts_nvfp4). Measured on
         // Qwen3-Coder-30B-FP4 (2026-07-02): code-edit +49-81% (93% accept,

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -235,6 +235,25 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     // handle the budget device-side.
     if (!ignore_think && req.think_budget > 0.0f && req.in_think_block) return false;
     if (req.status != RequestStatus::DECODING || req.output_tokens.empty()) return false;
+    // Long-context economics on the DENSE path (#964): the captured chunk
+    // verify runs the FA2 tile + paged-KV gather over the ctx TIER (pow2,
+    // floor 4096, clamped to max_seq_len) — its cost follows the tier, not
+    // the live context. Measured 2026-07-11 (Qwen3-8B Q8_0): a verify step
+    // costs ~2.1× a decode step at 2k ctx and ~5.2× at 16k, so with dense
+    // ngram's ~2 tok/verify payout speculation turns net-negative past ~2k
+    // (−62% at 16k). Gate drafting once the request's context crosses the
+    // cap, checked per step. MoE-NVFP4 and GDN-hybrid requests are exempt:
+    // their drafts run much deeper (Coder-30B code-edit 15.9 tok/verify,
+    // MTP chains), which pays for the verify at any measured context.
+    {
+        const int cap = runtime_config_.speculative.draft_ctx_cap;
+        const bool moe_nvfp4_path = model_->profile().is_moe &&
+                                    runtime_config_.speculative.moe &&
+                                    model_->profile().moe_experts_nvfp4;
+        const bool hybrid_path = ssm_state_ != nullptr;  // only reachable with speculative.hybrid
+        if (!moe_nvfp4_path && !hybrid_path && cap > 0 && req.context_len() > cap)
+            return false;
+    }
     // Recurrent state (SSM/GDN) advances on every forwarded token. The
     // hybrid verify path (speculative.hybrid) rides SSMState's contiguous
     // per-sequence slab for snapshot/restore.


### PR DESCRIPTION
Interim fix for #964 (issue stays open for the structural fix).

## Root cause (profiled)

The graph-captured chunk verify runs the **FA2 tile + paged-KV gather over the pow2 ctx TIER** (`spec_capture_ctx_tier_`: floor 4096, clamped to max_seq_len) — its cost follows the tier, not the live context:

- nsys (pp16384 → 96-token decode window, Qwen3-8B Q8_0): spec arm carries **+2.05 s `fmha_sm120_fa2_kernel` + 0.32 s `paged_kv_gather_fp16_kernel`** vs spec-off.
- At identical ctx≈512, varying only max_seq_len: 240.8 tok/s (tier 1024) vs 191.8 (tier 4096) vs 277.1 spec-off.
- A verify step costs ~2.1× a decode step at 2k ctx, ~5.2× at 16k; dense ngram pays out only ~2 tok/verify → net-negative past ~2k regardless of accept rate (−4% @2k, −15% @8k, **−62% @16k** at 100% accept).

## Change

New **`speculative.draft_ctx_cap`** (default **2048**, 0 = off): gates DENSE drafting once a request's context crosses the cap, checked per step (a growing request stops speculating when it crosses). **MoE-NVFP4 and GDN-hybrid drafts are exempt** — their deep drafts (Coder-30B code-edit 15.9 tok/verify, MTP chains) pay for the verify, and neither engages at default config anyway (`speculative.moe`/`.hybrid` are opt-in). At defaults this affects exactly the measured dense regression and nothing else.

## Verification

| Check | Result |
|---|---|
| 8B Q8 @16k defaults | **58.7 → 152.3 tok/s** (= spec-off rate) |
| 8B pp16 hero | 286.0 (spec-off 290.6 — parity, CI gate unaffected) |
| Coder-30B @4k / 35B-NVFP4 @4k | 336.8 / 299.9 — unchanged (chunk-verify not engaged at their defaults) |
| verify-fast | OK |

BENCHMARKS.md long-context table gets refreshed once the remaining #964 work lands. Full measurement matrix in the issue comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F