### PR TITLE
fix(vram): KV floor covers the full advertised context when KV is cheap — 35B @16k runs streaming-free (#963 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   (Q8_0 → dequant → FP8 rows → rowscale GEMV vs fp64 reference).
 
 ### Fixed
+- **KV floor now covers the full advertised context on cheap-KV models**
+  (#963 follow-up): the auto floor was min(16384, 4×max_seq_len), so a
+  max_seq_len=17408 hybrid (10 attention layers, ~0.3 MiB/block) got a
+  16.4k-token pool that a 16k prompt fills to 94% — tripping the >90%
+  StreamingLLM valve (CUDA graphs off, windowed attention) on a request
+  that fits outright. When full coverage plus 12.5% streaming headroom
+  costs ≤1 GiB, the floor now takes it; expensive-KV models (dense 64k ≈
+  9 GiB) keep the old floor, and the kv_fraction affordability cap keeps
+  protecting the weight-cache budget either way.
 - **Default-on n-gram speculation regressed long-context decode** (#964,
   partial): the chunk verify runs the FA2 prefill tile over the full context
   plus a paged-KV gather, costing ~2.1× a decode step at 2k ctx and ~5.2× at

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -480,6 +480,23 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
     bool user_requested_min = (min_kv_tok > 0);
     if (!user_requested_min) {
         min_kv_tok = std::min(16384, config.max_seq_len * 4);
+        // Cover the full advertised context when that is CHEAP (#963
+        // follow-up): the 16384-token floor left a max_seq_len=17408 hybrid
+        // with a pool a 16k prompt fills to 94% — tripping the >90%
+        // StreamingLLM valve (block-table mutation, graphs off, windowed
+        // attention) on a request that fits outright. Hybrids price KV at
+        // ~0.02 MiB/token (few attention layers), so full coverage plus the
+        // 12.5% streaming headroom costs ~400 MiB — take it whenever it
+        // stays under 1 GiB. Expensive-KV models (dense 64k ≈ 9 GiB) keep
+        // the old floor and the kv_fraction affordability cap below keeps
+        // protecting the weight-cache budget either way.
+        const int full_cov_tok = config.max_seq_len + config.max_seq_len / 8;
+        if (full_cov_tok > min_kv_tok && per_block_total > 0) {
+            const size_t full_cov_bytes =
+                static_cast<size_t>((full_cov_tok + bs - 1) / bs) * per_block_total;
+            if (full_cov_bytes <= 1024ULL * 1024 * 1024)
+                min_kv_tok = full_cov_tok;
+        }
     }
     int min_kv_blocks = (min_kv_tok + bs - 1) / bs;
     const int min_kv_blocks_wanted = min_kv_blocks;  // pre-cap: what the floor asked for

--- a/tests/test_vram_budget_reserve.cpp
+++ b/tests/test_vram_budget_reserve.cpp
@@ -95,6 +95,41 @@ TEST(VramBudgetReserve, PlannerDemandKeepsKvPoolFromEatingWeightCacheRoom) {
         << "KV pool ate the weight-cache room again (heuristic-only backstop)";
 }
 
+// #963 follow-up: when KV is cheap (hybrid — few attention layers), the
+// auto floor must cover the full advertised context plus the StreamingLLM
+// headroom, not stop at the flat 16384-token cap. With the old floor a
+// max_seq_len=17408 hybrid got a pool a 16k prompt fills to 94%, tripping
+// the >90% streaming valve (graphs off, windowed attention) on a request
+// that fits outright.
+TEST(VramBudgetReserve, CheapKvFloorCoversFullMaxSeqLen) {
+    SKIP_IF_NO_CUDA();
+
+    Model m;
+    fill_model(m, QType::Q6_K, QType::Q6_K);
+    m.config_.n_kv_heads = 2;  // hybrid-class cheap KV (Qwen3.6-35B: 2 heads)
+
+    EngineConfig config;
+    config.max_seq_len = 17408;
+    config.max_batch_size = 1;
+    config.use_nvfp4_decode = 2;
+    config.use_cuda_graphs = false;
+    config.kv_cache_dtype = QType::F16;
+
+    const int n_kv_layers = 10;  // 10 attention layers out of 40 (GDN hybrid)
+    const int head_dim = 256;
+    const size_t GiB = 1024ull * 1024 * 1024;
+
+    VRAMBudget budget = compute_vram_budget(m, config, n_kv_layers, head_dim, 8 * GiB);
+
+    // Full coverage + 12.5% streaming headroom ≈ 383 MiB here (well under the
+    // 1 GiB cheap-KV bound) — the pool must hold max_seq_len plus headroom so
+    // a full-length request never trips the >90% streaming valve.
+    const int bs = 16;  // kKVBlockSize (config.kv_block_size unset)
+    const int full_cov_tok = config.max_seq_len + config.max_seq_len / 8;
+    EXPECT_GE(budget.kv_max_blocks * bs, full_cov_tok)
+        << "cheap-KV floor stopped below the advertised context again";
+}
+
 TEST(VramBudgetReserve, BeneficialSourcesKeepFullKvPool) {
     SKIP_IF_NO_CUDA();
 


### PR DESCRIPTION
## Problem

The auto KV floor was `min(16384, 4×max_seq_len)`. A `max_seq_len=17408` hybrid (10 attention layers, 2 kv_heads → ~0.31 MiB per 32-token block) got a 16.4k-token pool that a 16k prompt fills to **94%** — tripping the >90% StreamingLLM valve (CUDA graphs off, block-table mutation, windowed attention) on a request that **fits outright**. The valve's sentinel path is also where #963 lived; staying off it entirely for in-capacity requests is strictly better.

## Fix

When full context coverage plus 12.5% streaming headroom costs **≤ 1 GiB**, the floor takes it. Expensive-KV models (dense 64k ≈ 9 GiB) keep the old floor; the `kv_fraction` affordability cap keeps protecting the weight-cache budget either way (the Coder@45k lesson stays intact).

## Verification

| Check | Result |
|---|---|
| 35B-NVFP4 @ msl 17408, pp16384+tg512 | pool 603 blocks (19 296 tok, 376.9 MiB), **no StreamingLLM**, decode **72.7 → 264.3 tok/s (+263%)** at full attention quality, graphs on |
| 35B short-ctx | 318.2 tok/s, FP8 sidecar fully resident (60 projections) — no weight-cache cannibalization |
| Qwen3-8B | unchanged (cheap-KV branch not taken: full coverage ≈ 2.7 GiB > 1 GiB) |
| VramBudgetReserve suite | 11/11 incl. new `CheapKvFloorCoversFullMaxSeqLen` regression test |
| verify-fast | OK |

With this, the 35B long-context story of today's session closes end-to-end: #967 fixed the streaming-eviction OOB, #968 the dense verify economics, and this makes the hero avoid the streaming degradation entirely inside its advertised context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P79pmYssX3FQFSNUDK49F