### PR TITLE
perf(kv): auto-enable FP8 KV on hint-less Qwen3 dense/MoE checkpoints — +41% GGUF decode at 16k, PPL-neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ## [Unreleased]
 
 ### Changed
+- **FP8 KV cache now auto-enables on GGUF Qwen3 dense/MoE**
+  (`kv_cache.dtype = "auto"`): the auto policy previously honored only the
+  checkpoint's `kv_cache_quant_algo=FP8` hint, which GGUF exports never
+  declare — long-context GGUF decode was leaving −39..41% on the table
+  (Qwen3-8B Q8_0 at 16k context: 150 → 211 tok/s with FP8 KV). A new
+  stricter no-hint arch gate (`kv_fp8_no_hint_default_safe`) upgrades
+  hint-less checkpoints for families measured PPL-neutral at 16k
+  (teacher-forced, ~13.5k-token corpus, fresh process per run): QWEN3
+  (Q8_0 +0.05%, Q6_K +0.10%, bit-stable) and QWEN3_MOE (Q4_K_M −0.15%,
+  3 runs/arm). Measured but excluded: QWEN36_MOE (GGUF neutral, but the
+  arch-wide flip would cost the NVFP4 35B a real +1.47% PPL and hybrids
+  have little KV surface to win back) and LLAMA (gate-corpus baseline
+  broken). Short-context decode is not a trade-off either: same-day
+  baseline-method tg128 reads +2.9% with FP8 KV (287.8 vs 279.7 median).
+  The perf baseline is deliberately NOT re-pinned in this PR — it was
+  measured on a top-of-range host day and baking it in would repeat the
+  #697 peak-day false-fail; the existing (FP16-measured) bar stays valid
+  and conservative under the faster FP8 default. Opt out with
+  `kv_cache.dtype = "fp16"`.
 - **`gemm.nvfp4_lm_head_cutlass` is now default ON** — the batched-decode
   (n>1) LM head runs as one CUTLASS NVFP4 tensor-core GEMM (one LM-head
   weight read per batch instead of ceil(n/4)), which was the opt-in behind

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -94,8 +94,11 @@ no_vision_graph      = false
 [kv_cache]
 # KV-cache element type. "auto" (default) keeps FP16 but upgrades to FP8 E4M3 for
 # models whose author declares kv_cache_quant_algo=FP8 and whose arch family is
-# verified safe for long-context FP8 KV (currently Qwen3 dense + Qwen3 MoE; ~768
-# MiB saved, +~1% PPL). "fp16" forces FP16. fp8|int8|int4|nvfp4|mxfp4 force that dtype.
+# verified safe for long-context FP8 KV (Qwen3 dense/MoE, llama, nemotron_h_moe;
+# ~768 MiB saved, +~1% PPL). Since 2026-07-12 "auto" ALSO upgrades hint-less
+# checkpoints (i.e. every GGUF) for arch families measured PPL-neutral at 16k
+# context (Qwen3 dense + Qwen3 MoE): +41% decode at 16k on Qwen3-8B Q8_0.
+# "fp16" forces FP16. fp8|int8|int4|nvfp4|mxfp4 force that dtype.
 dtype                       = "auto"
 # Allow cuBLASLt non-deterministic algorithms with FP8 KV. Slightly faster
 # but reproducibility is lost.

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -253,6 +253,38 @@ bool kv_fp8_hint_default_safe(ModelArch arch) {
     }
 }
 
+// Arch families verified safe for default FP8 KV WITHOUT a checkpoint hint.
+// GGUF exports never declare kv_cache_quant_algo, so the hint gate alone left
+// every GGUF model on FP16 KV — measured −39%..−41% decode at 16k context
+// (Qwen3-8B Q8_0: 150→211 tok/s with FP8 KV, 2026-07-12). Evidence bar is
+// stricter than the hint list (the author did not opt in): teacher-forced PPL
+// over a ~13.5k-token corpus at max_seq_len 16384, FP8 vs FP16 KV, fresh
+// process per run, measured 2026-07-12:
+//   QWEN3     Qwen3-8B Q8_0    11.0906 → 11.0962 (+0.05%, bit-stable ×3 runs)
+//             Qwen3-14B Q6_K    9.4706 →  9.4797 (+0.10%, bit-stable ×2)
+//   QWEN3_MOE Qwen3-30B Q4_K_M  mean 11.506 → 11.489 (−0.15%, 3 runs/arm —
+//             inside the ±0.17% MoE run-to-run spread; neutral)
+// Measured but NOT added (same session):
+//   QWEN36_MOE: GGUF 35B UD-Q4KM is neutral (−0.15%, 3 runs/arm), but the
+//     no-hint list is arch-wide and would also flip Qwen3.6-35B-NVFP4, where
+//     FP8 KV costs a REAL +1.47% PPL (13.746→13.948 mean, arms non-overlapping
+//     across 2 runs each — NVFP4 attention weights compound with FP8 KV).
+//     Hybrids also have a small KV surface (most layers are GDN), so the
+//     long-context decode upside is small; not worth the NVFP4 quality cost.
+//   LLAMA: Llama-3.2-3B Q8_0 reads +0.87%, but its baseline PPL on the gate
+//     corpus is broken-high (252 — same class as the GEMMA4 ~243 exclusion),
+//     so the measurement doesn't clear the evidence bar. Phi-4-style LLAMA
+//     checkpoints that DO declare the hint still upgrade via the hint list.
+bool kv_fp8_no_hint_default_safe(ModelArch arch) {
+    switch (arch) {
+        case ModelArch::QWEN3:
+        case ModelArch::QWEN3_MOE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 int model_arch_c_api_id(ModelArch arch) { return lookup_arch(arch).c_api_id; }
 
 void model_arch_sampling_defaults(ModelArch arch, float& temperature, float& top_p, int& top_k) {

--- a/src/model/model_arch.h
+++ b/src/model/model_arch.h
@@ -31,6 +31,14 @@ const char* model_arch_name(ModelArch arch);
 // model.cpp for the measured per-family evidence. Keep the list conservative.
 bool kv_fp8_hint_default_safe(ModelArch arch);
 
+// True iff this arch family has been empirically verified safe for DEFAULT FP8 KV
+// even when the checkpoint declares NO kv_cache_quant_algo hint (GGUF exports never
+// carry one, so the hint gate alone left GGUF long-context decode on FP16 KV —
+// −39% at 16k on Qwen3-8B Q8_0). Stricter evidence bar than the hint list: the
+// author didn't opt in, so the family must gate ~neutral, not merely ≤1.5%. See
+// model.cpp for the per-family evidence and the measured exclusions.
+bool kv_fp8_no_hint_default_safe(ModelArch arch);
+
 // C API enum value for this architecture.
 int model_arch_c_api_id(ModelArch arch);
 

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -195,6 +195,15 @@ void Engine::init_resolve_kv_dtype_policy_() {
                          "kv_cache_quant_algo=FP8; %s verified safe for long-context FP8 KV; "
                          "set kv_cache.dtype=fp16 to opt out)",
                          model_arch_name(mcfg.arch));
+        } else if (kv_str == "auto" && kv_fp8_no_hint_default_safe(mcfg.arch)) {
+            // No checkpoint hint (GGUF exports never carry one) — upgrade on the
+            // stricter arch-measured no-hint gate. Long-context GGUF decode was
+            // leaving −39% at 16k on the table under the hint-only policy.
+            config_.kv_cache_dtype = QType::FP8_E4M3;
+            IMP_LOG_INFO("KV cache dtype: FP8_E4M3 (auto — %s measured PPL-neutral for "
+                         "long-context FP8 KV without a checkpoint hint; "
+                         "set kv_cache.dtype=fp16 to opt out)",
+                         model_arch_name(mcfg.arch));
         }
     }
 

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -52,6 +52,21 @@ TEST(RuntimeConfigTest, KvFp8HintDefaultSafeAllowlist) {
     EXPECT_FALSE(kv_fp8_hint_default_safe(ModelArch::GENERIC));
 }
 
+// The NO-HINT FP8-KV gate (kv_cache.dtype=auto on checkpoints without a
+// kv_cache_quant_algo hint — i.e. every GGUF). Stricter bar than the hint list:
+// the family must gate ~PPL-neutral at 16k context. See model.cpp for the
+// 2026-07-12 evidence and the measured exclusions (QWEN36_MOE: +1.47% real on
+// the NVFP4 variant; LLAMA: gate-corpus baseline broken).
+TEST(RuntimeConfigTest, KvFp8NoHintDefaultSafeAllowlist) {
+    EXPECT_TRUE(kv_fp8_no_hint_default_safe(ModelArch::QWEN3));
+    EXPECT_TRUE(kv_fp8_no_hint_default_safe(ModelArch::QWEN3_MOE));
+    EXPECT_FALSE(kv_fp8_no_hint_default_safe(ModelArch::LLAMA));
+    EXPECT_FALSE(kv_fp8_no_hint_default_safe(ModelArch::QWEN36_MOE));
+    EXPECT_FALSE(kv_fp8_no_hint_default_safe(ModelArch::NEMOTRON_H_MOE));
+    EXPECT_FALSE(kv_fp8_no_hint_default_safe(ModelArch::GEMMA4));
+    EXPECT_FALSE(kv_fp8_no_hint_default_safe(ModelArch::GENERIC));
+}
+
 TEST(RuntimeConfigTest, ParsesBasicSections) {
     TempFile f(R"(
 [runtime]


### PR DESCRIPTION
## What

`kv_cache.dtype = "auto"` gains a second, stricter upgrade path: arch families measured **PPL-neutral at 16k context without a checkpoint hint** (`kv_fp8_no_hint_default_safe`) now default to FP8 KV. GGUF exports never declare `kv_cache_quant_algo`, so the hint-only policy left every GGUF on FP16 KV — the gap flagged in the 2026-07-11 gap analysis.

**Perf:** Qwen3-8B Q8_0 @16k context decode **150 → 211 tok/s (+41%)** (re-confirmed today, 3 reps/arm). Short context is not a trade-off either: same-day baseline-method tg128 reads **+2.9%** with FP8 KV (287.8 vs 279.7 median, 5 cold trials each, healthy clocks sampled during).

## Quality gate (teacher-forced PPL, ~13.5k-token corpus, msl 16384, fresh process per run)

| Model (arch) | FP16 KV | FP8 KV | Δ |
|---|---|---|---|
| Qwen3-8B Q8_0 (QWEN3) | 11.0906 (bit-stable ×3) | 11.0962 | **+0.05%** |
| Qwen3-14B Q6_K (QWEN3) | 9.4706 (×2) | 9.4797 | **+0.10%** |
| Qwen3-30B-A3B Q4_K_M (QWEN3_MOE) | 11.506 mean (3 runs) | 11.489 | **−0.15%** (neutral) |

**Measured but excluded** (documented in `model.cpp`):
- **QWEN36_MOE**: GGUF 35B UD-Q4KM is neutral (−0.15%, 3 runs/arm), but the arch-wide flip would also hit Qwen3.6-35B-NVFP4, where FP8 KV costs a **real +1.47% PPL** (13.746 → 13.948 mean, arms non-overlapping — NVFP4 attention weights compound with FP8 KV). Hybrids also have a small KV surface (most layers GDN), so the long-context upside is small.
- **LLAMA**: Llama-3.2-3B Q8_0 reads +0.87%, but its baseline PPL on the gate corpus is broken-high (252 — same exclusion class as GEMMA4's ~243). Phi-4-style checkpoints that declare the hint still upgrade via the existing hint list.

## Perf baseline deliberately NOT re-pinned

A refresh was generated and **reverted**: today is a top-of-range host day (FP16 tg128 median 279.7 vs the normal 266–278 band), and pinning the fresh 287.80 would put the 3% gate threshold at 279.2 — inside the ordinary-day range, repeating the #697 peak-day false-fail. The existing FP16-measured bar (269.50) stays valid and strictly conservative under the faster FP8 default; re-pin on a documented median day.

## Validation

- Full GPU test suite green (0 FAILED) with the new default.
- New CPU test `RuntimeConfigTest.KvFp8NoHintDefaultSafeAllowlist` locks the allowlist.
- Auto-upgrade log line fires on GGUF Q8 (`FP8_E4M3 (auto — qwen3 measured PPL-neutral …)`); explicit `kv_cache.dtype=fp16` opts out unchanged.
- Long-context generation smoke coherent (8B Q8 and 30B Q4_K_M, 3.5k–8k-token prompts, defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ