### PR TITLE
perf(spec): #964 stage 1 — verify-chunk attention on the decode split-K path; dense n-gram now wins long context (+43% @2k, +25% @8k, +29% @12k)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ## [Unreleased]
 
 ### Changed
+- **Dense n-gram speculation now WINS on long context** (#964 structural
+  fix, stage 1): the verify chunk's attention runs on the batched-decode
+  split-K paged kernels — chunk rows become same-KV "sequences" with
+  per-row context lens (causality by construction), reading quantized KV
+  directly — instead of the small-M prefill FA2 tile plus a full-context
+  FP16 KV gather (557 → ~65 µs/layer at 16k; also why FP8 KV never moved
+  the verify cost). New finer capture buckets {3,5} keep the baked
+  split-K geometry close to the real 2-row draft (a 9-row pad halved the
+  split count 4×). Measured route+capture vs speculation-off (Qwen3-8B
+  Q8_0, 3 trials): **+44% @512, +43% @2k, +25% @8k, +29% @12288** — the
+  pre-fix numbers were −8/−16/−32/−62%. `speculative.draft_ctx_cap`
+  default rises 2048 → 12288; the near-msl band (15872 @ msl 16384)
+  still loses −23% (capture-ready ceiling + weight-bound small-M verify
+  GEMMs + per-step host work — follow-ups in #964). Output stays
+  token-identical to plain greedy. Opt out with
+  `speculative.verify_decode_attn = false`. Note: `imp-cli --bench`
+  pins the verify EAGER (`speculative.capture=false`) by design — the
+  full win shows on the server/captured path; pass
+  `--set speculative.capture=true` to reproduce it in the CLI.
 - **FP8 KV cache now auto-enables on GGUF Qwen3 dense/MoE**
   (`kv_cache.dtype = "auto"`): the auto policy previously honored only the
   checkpoint's `kv_cache_quant_algo=FP8` hint, which GGUF exports never

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -481,7 +481,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                hd, cfg.qk_rope_head_dim, cfg.kv_lora_rank, mla_absorb_max_seq_, stream);
     }
 
-    if (state.is_prefill) {
+    if (state.is_prefill && !state.chunk_decode_attn) {
 #include "exec/executor_attention_prefill.cu"
     } else {
 #include "exec/executor_attention_decode.cu"

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -64,6 +64,12 @@ struct InferenceState {
     // Batching
     int n_sequences = 1;         // number of sequences in the batch
     int max_blocks_per_seq = 0;  // max blocks per sequence (for 2D block_table indexing)
+    // Spec-verify chunk whose ATTENTION runs on the batched-decode split-K
+    // path (#964): the chunk rows are presented as n_sequences same-KV
+    // "sequences" with per-row context_lens (p0+1+i, causality via lengths)
+    // and row-replicated block_tables. is_prefill stays true so everything
+    // outside run_attention keeps the chunk-forward semantics.
+    bool chunk_decode_attn = false;
     const int* seq_offsets =
         nullptr;  // [n_sequences+1] for ragged prefill token offsets (optional, nullptr for decode)
 

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -289,6 +289,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [speculative]
     B("speculative.ngram", cfg.speculative.ngram);
     I("speculative.draft_ctx_cap", cfg.speculative.draft_ctx_cap);
+    B("speculative.verify_decode_attn", cfg.speculative.verify_decode_attn);
     B("speculative.moe", cfg.speculative.moe);
     I("speculative.k", cfg.speculative.k);
     B("speculative.suffix", cfg.speculative.suffix);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -688,20 +688,34 @@ struct RuntimeConfig {
     // concurrent batches, and GGUF-MoE (which the async loop carries).
     struct Speculative {
         bool ngram = true;  // prompt-lookup speculation, default-on (batch-1, greedy, dense)
-        // Context cap for DENSE chunk-verify drafting (#964). The captured
-        // verify runs the FA2 tile + paged-KV gather over the ctx TIER
-        // (pow2, floor 4096, clamped to max_seq_len) — its cost follows the
-        // tier, not the live context, while dense ngram pays out only ~2
-        // tokens per verify. MEASURED (2026-07-11, Qwen3-8B Q8_0): verify ≈
-        // 2.1× a decode step at 2k ctx, ~5.2× at 16k; end-to-end decode −4%
-        // @2k, −15% @8k, −62% @16k at 100% draft accept — net-negative past
-        // ~2k regardless of accept rate. Drafting is gated once a request's
-        // context crosses the cap (checked per step). MoE-NVFP4 and
-        // GDN-hybrid requests are exempt (deep drafts: Coder-30B code-edit
-        // 15.9 tok/verify, MTP chains — the verify pays for itself there).
-        // The structural fix (verify cost following live ctx instead of the
-        // tier) is tracked in #964. 0 = no cap.
-        int draft_ctx_cap = 2048;
+        // Context cap for DENSE chunk-verify drafting (#964). With the
+        // verify_decode_attn route below (2026-07-12), dense n-gram WINS up
+        // to at least 12k context on the captured-verify (server) path:
+        // Qwen3-8B Q8_0 route+capture vs spec-off +44% @512, +43% @2k,
+        // +25% @8k, +29% @12288 — but still −23% at 15872 (the near-msl
+        // band: the capture-ready ceiling ends there and the remaining
+        // verify cost is the weight-bound small-M GEMMs + per-step host
+        // work, not attention). Drafting is gated once a request's context
+        // crosses the cap (checked per step). MoE-NVFP4 and GDN-hybrid
+        // requests are exempt (deep drafts: Coder-30B code-edit 15.9
+        // tok/verify, MTP chains — the verify pays for itself there).
+        // History: pre-route the FA2-tile verify was net-negative past ~2k
+        // (−62% @16k, 2026-07-11) and the cap defaulted 2048. 0 = no cap.
+        int draft_ctx_cap = 12288;
+        // #964 structural fix: run the dense verify chunk's ATTENTION through
+        // the batched-decode split-K paged kernels (rows become same-KV
+        // "sequences" with per-row context lens p0+1+i — causality holds by
+        // construction; pad rows attend 1 token) instead of the small-M
+        // prefill FA2 tile + full-context FP16 KV gather. nsys @16k (Qwen3-8B
+        // Q8_0): 557 us/layer FA2 vs ~65 us/layer split-K — ~20 ms of the
+        // ~30 ms verify step, and the reason FP8 KV never moved the verify
+        // cost (the old path gathered to FP16 first). Composes with the
+        // captured verify; requires the 3/5 capture buckets (the split count
+        // bakes from the PADDED row count). Measured end-to-end (route +
+        // capture vs spec-off, 3 trials): +44% @512, +43% @2k, +25% @8k,
+        // +29% @12288. Dense non-MLA/non-SWA/non-MoE/non-hybrid only;
+        // MoE/hybrid keep the FA2 chunk path. Kill switch for A/B.
+        bool verify_decode_attn = true;
         // Speculation on MoE models with NATIVE-NVFP4 experts (the gate
         // additionally requires profile().moe_experts_nvfp4). Measured on
         // Qwen3-Coder-30B-FP4 (2026-07-02): code-edit +49-81% (93% accept,

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -752,6 +752,13 @@ private:
     int* d_spec_context_len_ = nullptr;
     int32_t* d_spec_argmax_ = nullptr;
     int32_t* h_spec_argmax_ = nullptr;  // pinned, chunk_cap entries
+    // #964 decode-attention verify route (dense, eager): per-row context lens
+    // [chunk_cap] and row-replicated block tables [chunk_cap * table_cap] so
+    // the chunk's attention runs the batched-decode split-K kernels — row i
+    // becomes a same-KV "sequence" with ctx p0+1+i (causality via lengths).
+    int* d_spec_row_ctx_lens_ = nullptr;
+    int* d_spec_row_block_tables_ = nullptr;
+    std::vector<int32_t> h_spec_row_tables_;  // host staging, reused per step
     int spec_chunk_cap_ = 0;
     int spec_block_table_cap_ = 0;
     // Hybrid (SSM/GDN) verify: device scratch holding the committed

--- a/src/runtime/engine_spec_capture.cpp
+++ b/src/runtime/engine_spec_capture.cpp
@@ -71,7 +71,12 @@ int Engine::spec_capture_ctx_tier_(int ctx_padded) const {
 
 int Engine::spec_capture_bucket_(int chunk_len) const {
     const int cap = std::max(chunk_len, spec_capture_bucket_max_());
-    for (int b : {9, 17, 33}) {
+    // 3/5 buckets (#964): the decode-attention verify route derives its
+    // split-K count from the PADDED row count at capture time — a 2-row
+    // draft padded to 9 rows baked 5 splits instead of 21 and the per-CTA
+    // KV walk grew 4x (251 vs 65 us/layer at 16k). Finer buckets keep the
+    // baked split geometry close to the real chunk; pad rows attend 1 token.
+    for (int b : {3, 5, 9, 17, 33}) {
         if (chunk_len <= b && b <= cap)
             return b;
     }

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -63,7 +63,11 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
               // SWA-group mirror (kv_cache.swa_sizing): same capacity as the
               // main table. Allocated unconditionally so a mid-session gate
               // flip can't leave it null; tiny (max_blocks ints).
-              cudaMalloc(&d_spec_block_table_swa_, max_blocks * sizeof(int)) == cudaSuccess;
+              cudaMalloc(&d_spec_block_table_swa_, max_blocks * sizeof(int)) == cudaSuccess &&
+              // #964 decode-attention verify route staging (see engine.h).
+              cudaMalloc(&d_spec_row_ctx_lens_, chunk_cap * sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&d_spec_row_block_tables_,
+                         static_cast<size_t>(chunk_cap) * max_blocks * sizeof(int)) == cudaSuccess;
     if (!ok) {
         IMP_LOG_WARN("spec-ngram: buffer allocation failed — speculation disabled this step");
         free_spec_buffers_();
@@ -130,6 +134,8 @@ void Engine::free_spec_buffers_() {
     if (d_spec_positions_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_positions_));
     if (d_spec_block_table_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_));
     if (d_spec_block_table_swa_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_swa_));
+    if (d_spec_row_ctx_lens_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_row_ctx_lens_));
+    if (d_spec_row_block_tables_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_row_block_tables_));
     if (d_spec_context_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_context_len_));
     if (d_spec_past_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_past_len_));
     if (d_spec_chunk_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_chunk_len_));
@@ -139,6 +145,8 @@ void Engine::free_spec_buffers_() {
     d_spec_positions_ = nullptr;
     d_spec_block_table_ = nullptr;
     d_spec_block_table_swa_ = nullptr;
+    d_spec_row_ctx_lens_ = nullptr;
+    d_spec_row_block_tables_ = nullptr;
     d_spec_context_len_ = nullptr;
     d_spec_past_len_ = nullptr;
     d_spec_chunk_len_ = nullptr;
@@ -382,6 +390,17 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     // SWA-aware sizing: the verify chunk stays EAGER (captured verify bakes
     // full-context gather grids + a static block-table pointer; the SWA table
     // rewrites every step). Correctness still requires the SWA table below.
+    // #964: dense verify chunks route their attention through the batched-
+    // decode split-K paged kernels (see the route block below). Composes with
+    // capture: the decode kernels pay per-ROW KV traffic, but the per-row
+    // context lens are data — pad rows get ctx_len=1, so the capture bucket
+    // padding (2 real rows -> 9) costs ~nothing in attention while the graph
+    // still swallows the ~200 eager launches per verify step. MoE/hybrid keep
+    // the FA2 chunk path (deep drafts amortize it; the hybrid scan needs the
+    // chunk-forward semantics).
+    const bool decode_attn_route = runtime_config_.speculative.verify_decode_attn &&
+                                   ssm_state_ == nullptr && !model_->profile().is_moe &&
+                                   !model_->config().is_mla() && !swa_sizing_active_;
     const bool capture_on =
         !swa_sizing_active_ && spec_capture_ready_(p0 + spec_capture_bucket_(chunk_len));
     const int chunk_pad = capture_on ? spec_capture_bucket_(chunk_len) : chunk_len;
@@ -503,6 +522,48 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         state.ctx_capacity = spec_capture_ctx_tier_(ctx_len);
         state.d_past_len = d_spec_past_len_;
         state.d_chunk_len = d_spec_chunk_len_;
+    }
+
+    // #964 decode-attention route: present the chunk rows as n same-KV
+    // "sequences" with per-row context lens (p0+1+i) and row-replicated block
+    // tables — causality holds by construction, and run_attention takes the
+    // batched-decode split-K path (quantized-KV direct reads, context split
+    // across CTAs) instead of the small-M prefill FA2 tile + full-context
+    // FP16 KV gather (557 vs ~44 us/layer at 16k, nsys 2026-07-12).
+    if (decode_attn_route) {
+        std::vector<int> h_row_lens(chunk_pad);
+        // Pad rows (i >= chunk_len, capture-bucket fill) attend a single
+        // token: their output is never read, and a 1-token walk keeps the
+        // per-row KV traffic at real-chunk cost.
+        for (int i = 0; i < chunk_pad; ++i)
+            h_row_lens[i] = (i < chunk_len) ? (p0 + i + 1) : 1;
+        h_spec_row_tables_.assign(
+            static_cast<size_t>(chunk_pad) * spec_block_table_cap_, 0);
+        for (int i = 0; i < chunk_pad; ++i)
+            std::copy(block_table.begin(), block_table.end(),
+                      h_spec_row_tables_.begin() +
+                          static_cast<size_t>(i) * spec_block_table_cap_);
+        if (check(cudaMemcpyAsync(d_spec_row_ctx_lens_, h_row_lens.data(),
+                                  chunk_pad * sizeof(int), cudaMemcpyHostToDevice, stream),
+                  "row ctx lens H2D") &&
+            check(cudaMemcpyAsync(d_spec_row_block_tables_, h_spec_row_tables_.data(),
+                                  h_spec_row_tables_.size() * sizeof(int32_t),
+                                  cudaMemcpyHostToDevice, stream),
+                  "row block tables H2D")) {
+            state.chunk_decode_attn = true;
+            state.n_sequences = chunk_pad;
+            state.context_lens = d_spec_row_ctx_lens_;
+            state.block_tables = d_spec_row_block_tables_;
+            state.max_blocks_per_seq = spec_block_table_cap_;
+            // Captured graphs bake the split-K grid from max_context_len at
+            // capture time — bake the tier ceiling so later replays in the
+            // same tier stay covered (per-row device lens bound the real
+            // work; #948/#950 pow2-bucket class).
+            if (capture_on)
+                state.max_context_len = spec_capture_ctx_tier_(ctx_len);
+        }
+        // On H2D failure the state keeps the plain single-sequence chunk
+        // fields and the FA2 prefill path serves the forward (correct, slow).
     }
 
     // Hybrid (SSM/GDN): bind the recurrent state and preserve the committed


### PR DESCRIPTION
## What

Stage 1 of the #964 structural fix. The dense n-gram verify chunk routes its **attention** through the batched-decode split-K paged kernels instead of the small-M prefill FA2 tile + full-context FP16 KV gather. Chunk rows are presented as `n_sequences` same-KV "sequences" with per-row `context_lens` (p0+1+i) and row-replicated block tables — causality holds by construction, pad rows attend 1 token, `is_prefill` stays true for everything outside `run_attention`.

## Why (nsys attribution)

At 16k context a verify step cost ~30 ms vs a 4.7 ms decode step:
- **20.5 ms**: `fmha_sm120_fa2_kernel<64,128>` at 557 µs/layer — one Q-tile, head-level parallelism only, serial 16k KV walk. The decode split-K kernels do the same job at **~65 µs/layer**.
- Plus a full-context FP8→FP16 KV gather per layer — which is also why FP8 KV (#977) never moved the verify cost.
- The remainder (weight-bound small-M GEMMs ~7.4 ms + per-step host work) is follow-up material, tracked in #964.

Second fix: finer capture buckets **{3,5}** — the split-K count bakes from the *padded* row count at capture time, so a 2-row draft padded to 9 rows baked 5 splits instead of 21 (4× longer per-CTA KV walk, 251 vs 65 µs/layer).

## Measured (Qwen3-8B Q8_0, msl 16384, route+capture vs speculation off, 3 trials, spread ±0.3%, healthy clocks)

| ctx | route+capture | spec off | Δ | pre-fix |
|---|---:|---:|---|---|
| 512 | **412.4** | 286.1 | **+44%** | −8% |
| 2048 | **390.6** | 274.1 | **+43%** | −16% |
| 8192 | **308.3** | 245.7 | **+25%** | −32% |
| 12288 | **295.9** | 229.0 | **+29%** | — |
| 15872 | 168.6 | 218.1 | −23% | −62% |

`speculative.draft_ctx_cap` default rises **2048 → 12288**. The near-msl band (15872 @ msl 16k) still loses: the capture-ready ceiling ends there and the residual cost is GEMMs + host work — follow-ups in #964. MoE/hybrid keep the FA2 chunk path unchanged (deep drafts amortize it; the hybrid scan needs chunk semantics). Kill switch: `speculative.verify_decode_attn = false`.

Note for reproducing: `imp-cli --bench` pins the verify **eager** (`speculative.capture=false`, by design since #847) — the full win shows on the server/captured path; pass `--set speculative.capture=true` in the CLI. The default CLI bench is neutral (257.9 vs 256.6 tg256).

## Validation

- **Server-JSON greedy output BYTE-IDENTICAL** route on/off over a 400-token completion (fresh server per arm); token-identical to plain greedy.
- Full GPU test suite green (0 FAILED); `make verify-fast` green (pre-push hook).
- Split-K scratch safety: `compute_splitk_splits` capacity-clamps; at verify row counts the tile-GQA grid is parallel enough that splits stay small.
- Capture bakes `max_context_len` at the ctx-tier ceiling (#948/#950 class); per-row device lens bound the real work; H2D updates (lens/row tables) are data-only before each replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ