### PR TITLE
fix: qwen35 pre-tokenizer routing + dead NVFP4-LM-head opt-outs on GGUF; first bar-1 PPL-parity sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,22 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   (Q8_0 → dequant → FP8 rows → rowscale GEMV vs fp64 reference).
 
 ### Fixed
+- **Qwen3.5/3.6 GGUF tokenization was non-canonical** (`tokenizer.ggml.pre =
+  "qwen35"` fell through to the gpt2 per-char-punct fallback): symbol runs
+  were over-split — +13% tokens on a 95 KB docs corpus (35 807 vs 31 620) and
+  off-distribution splits on every real prompt. "qwen35" (qwen2 rules plus
+  `\p{M}` in the letter run, which the scanner's letter classifier already
+  covers) now routes to the qwen2 scanner; token streams verified IDENTICAL
+  to `llama-tokenize` on the 35B hero. Found by the first release-bar-1
+  PPL-parity sweep (`docs/audit/ppl_parity_2026_07_12.md`).
+- **The NVFP4-LM-head opt-outs were dead on GGUF checkpoints**: the
+  quantized-source decode-cache collector added the LM head unconditionally,
+  so `gemm.nvfp4_lm_head=false` and the GOAL-listed
+  `gemm.nvfp4_lm_head_gdn=false` trade opt-out silently did nothing for GGUF
+  models (the head's NVFP4 quantization costs +1.5…+4.8% teacher-forced PPL,
+  model-size-dependent — the entire cross-engine PPL gap vs llama.cpp, see
+  the audit doc). The collector now applies the same gates as the
+  native-precision paths; defaults (both flags on) are byte-identical.
 - **KV floor now covers the full advertised context on cheap-KV models**
   (#963 follow-up): the auto floor was min(16384, 4×max_seq_len), so a
   max_seq_len=17408 hybrid (10 attention layers, ~0.3 MiB/block) got a
@@ -211,6 +227,14 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   byte-identical. See docs/determinism.md.
 
 ### Added
+- **`diagnostics.ppl_first` / `diagnostics.ppl_last`**: NLL counting window
+  for `imp-cli --perplexity` (row i predicts token i+1; count rows
+  [first, last]). Matches llama-perplexity's `first = n_ctx/2` convention via
+  `-c C --chunks 1` for exact cross-engine window alignment — the measurement
+  recipe for GOAL release bar 1 (`docs/audit/ppl_parity_2026_07_12.md`:
+  with the LM-head opt-out imp reads at or slightly below llama.cpp
+  (−0.8%…+0.2%) on every comparable GGUF hero; llama.cpp runs need
+  `--no-escape` or the token streams desync on corpora containing `\"`).
 - **On-disk warm weight cache** (`[warm_cache] enabled`, default on): the
   first fully-cold model load persists its TRANSFORMED weight uploads
   (BF16→FP16 host conversions, GPU dequants, split layouts) into

--- a/docs/GOAL.md
+++ b/docs/GOAL.md
@@ -159,6 +159,8 @@ A release is shippable when, on RTX 5090:
 1. All hero models pass correctness tests: perplexity within 0.5% of llama.cpp reference at the same quant **with documented owner-approved speed/quality trades excluded**; each such trade must be opt-out via config and listed here. Current trades:
    - `gemm.nvfp4_lm_head_gdn` default-ON (#483): +2.2% PPL for +11.4% decode on GDN hybrids.
    - `gemm.fp8_ssm_proj` on **GGUF** hybrids default-ON (#962): +1.8% PPL (201-token corpus) for +21% decode on Qwen3.6-35B UD-Q4_K_M — E4M3 stacked on the Q8_0 lattice; the native-NVFP4 branch of the same flag is PPL-flat (#949) and is not a trade.
+
+   First systematic cross-engine measurement 2026-07-12 (`docs/audit/ppl_parity_2026_07_12.md`): with the LM-head opt-out imp is at parity (−0.8%…+0.2%) with llama.cpp on every comparable GGUF hero. **Open owner decision:** `gemm.nvfp4_lm_head` default-ON (the dense LM-head NVFP4 decode cache, ~14% of dense decode) costs +1.5…+4.8% teacher-forced PPL model-size-dependent and is not yet listed above — list it as a trade or revisit the default.
 2. Decode tok/s leads llama.cpp by ≥5% on every hero model.
 3. Prefill tok/s ≥ llama.cpp on every dense **NVFP4/SafeTensors** hero. GGUF prefill is explicitly best-effort: the Q4K-MMQ experiment (2026-05-28) showed imp's GGUF prefill ceiling is architectural (ties cuBLAS at ~4.3% of peak; llama.cpp's MMQ leads 1.3-2.4×) — the old "≥ llama.cpp on every dense GGUF hero" bar was permanently violated as written and is dropped (realignment 2026-06-06, #550).
 4. Prefill tok/s ≥ 70% of vLLM single-seq on every MoE hero (measured ~1.4× gap 2026-05-31; the remaining levers are prefill attention and the grouped-GEMM launch/occupancy scheduler, #558).

--- a/docs/audit/ppl_parity_2026_07_12.md
+++ b/docs/audit/ppl_parity_2026_07_12.md
@@ -1,0 +1,127 @@
+# Cross-engine PPL parity vs llama.cpp — first release-bar-1 measurement (2026-07-12)
+
+**Bar (docs/GOAL.md, release bar 1):** hero-model perplexity within 0.5% of the
+llama.cpp reference at the same quant, documented owner-approved speed/quality
+trades excluded. This is the first systematic end-to-end measurement of that bar.
+
+**Headline:** with the LM-head opt-out the imp forward pass is at parity with
+llama.cpp on every comparable GGUF hero (−0.8%…+0.2%, i.e. at or slightly
+below the reference). The entire default-config
+gap (+1.4…+4.1%) is one deliberate perf feature: the **NVFP4 LM-head decode
+cache** (`gemm.nvfp4_lm_head`, default on, ~14% of dense decode — quantified
+2026-05-29 in `src/runtime/config.h`). It has a config opt-out but was never
+listed in the GOAL bar-1 trades — that listing decision is the open follow-up.
+
+## Methodology (reproducible)
+
+- **Reference:** llama.cpp build 9976 (`e3546c794`), image
+  `ghcr.io/ggml-org/llama.cpp:full-cuda` (pulled 2026-07-12), `-ngl 99`,
+  defaults otherwise (f16 KV). imp at this PR's commit, image `imp:test`.
+- **Corpus:** first 95 000 bytes of the repo-docs concatenation (architecture,
+  sm120, BENCHMARKING, usage, quantization, attention-dispatch, determinism,
+  supported-models, MISSION_JOURNAL, vram_audit, sm120_optimal_kernel,
+  nsys_profiling, roadmap, quant-pipeline, performance, CONTRIBUTING, AGENTS —
+  working tree at `6c5e5b31`), sha256 `8ad55557…0513ec7bcee`. Gemma-4 used the
+  first 36 000 bytes (imp KV pool ceiling at 26 GiB weights, see exclusions).
+- **Window alignment:** llama-perplexity counts NLL only over the second half
+  of each chunk (`first = n_ctx/2`, logit rows `[first, n_ctx-2]`) and requires
+  ≥ 2·n_ctx corpus tokens. Both engines were pinned to the **identical logit
+  rows**: llama.cpp `-c C --chunks 1` (C = ⌊T/2⌋ of the model's corpus token
+  count T), imp full-corpus teacher-forced prefill with
+  `diagnostics.ppl_first = C/2`, `diagnostics.ppl_last = C-2` (added in this
+  PR). Chunk 1 starts at the corpus start → conditioning is identical too.
+- **`--no-escape` on every llama.cpp run.** llama-perplexity/llama-tokenize
+  apply `string_process_escapes` to the input by default; the docs corpus
+  contains shell examples with `\"` sequences, which silently desynced the
+  token streams (6 tokens) and shifted the counting windows in a first sweep.
+- **Tokenizer parity verified per model:** imp `diagnostics.dump_tokens` diffed
+  against `llama-tokenize --ids --no-escape` — **IDENTICAL streams for all
+  seven cells** (Qwen3.6 requires the qwen35 pre-tokenizer routing fix from
+  this PR).
+- **Trials:** dense GGUF PPL is bit-stable run-to-run (2 trials); MoE/hybrid 3
+  trials, median (process-start cuBLAS algo selection perturbs ±0.3-0.5%).
+- **Trades excluded per the bar:** Qwen3.6-35B ran with
+  `gemm.fp8_ssm_proj=false gemm.nvfp4_lm_head_gdn=false`.
+
+Command skeleton (per model, T from llama-tokenize):
+
+```
+llama-perplexity -m <gguf> -f <corpus> --no-escape -c <T/2> --chunks 1 -b 2048 -ngl 99
+imp-cli --model <gguf> --perplexity <corpus> --temperature 0 \
+        --set diagnostics.ppl_first=<T/4> --set diagnostics.ppl_last=<T/2-2>
+```
+
+## Results
+
+| model (GGUF) | llama.cpp | imp defaults | Δ defaults | imp `gemm.nvfp4_lm_head=false`* | Δ opt-out | bar (±0.5%) |
+|---|---|---|---|---|---|---|
+| Qwen3-4B-Instruct-2507 Q8_0 | 8.3299 | 8.6348 | +3.66% | 8.3224 | −0.09% | **PASS** |
+| Qwen3-8B Q8_0 | 8.0360 | 8.2292 | +2.40% | 8.0224 | −0.17% | **PASS** |
+| Qwen3-14B Q6_K | 7.1123 | 7.2758 | +2.30% | 7.1288 | +0.23% | **PASS** |
+| Qwen3-30B-A3B Q4_K_M | 8.2058 | 8.5438 | +4.12% | 8.1394 | −0.81% | PASS-by-intent (imp *better*; MoE single-trial spread ±0.3-0.5%) |
+| Qwen3.6-35B UD-Q4_K_M | 4.8993 | 4.9671 | +1.38% | 4.8972 | −0.04% | **PASS** |
+
+\* the targeted opt-out, measured after this PR's fix (pre-fix it was silently
+ignored on GGUF checkpoints — finding 3 below; the 35B cell uses
+`gemm.nvfp4_lm_head_gdn=false`, its GDN-specific gate). The coarse
+`diagnostics.no_nvfp4_decode_cache=true` control reproduces the same parity
+(4B 8.2961, 8B 8.0129, 14B 7.1288, 30B 8.1541, 35B 4.8920). Defaults column
+includes FP8-KV auto (#977), which accounts for only ~0.2% of the defaults
+delta (fp16-KV control: 8.6148 on 4B).
+
+**Attribution (Qwen3-4B bisection, llama ref 8.3299):** defaults 8.6348 →
+`no_nvfp4_decode_cache` 8.2961 (gap gone) → `kv_cache.dtype=fp16` alone 8.6148
+(FP8-KV ≈ +0.23%). The LM-head NVFP4 quantization is the whole story
+(defaults vs targeted opt-out): +3.8% (4B), +2.6% (8B), +2.1% (14B), +5.0%
+(30B MoE), +1.4% (35B — its sweep run had `nvfp4_lm_head_gdn=false`, but that
+opt-out was dead on GGUF, finding 3). Cost scales inversely with model size,
+as expected for an lm_head effect.
+
+## Exclusions
+
+- **NVFP4/SafeTensors heroes** (Qwen3-Coder-30B FP4, Nemotron-H, Qwen3.6-35B
+  NVFP4, Gemma-4 NVFP4, Qwen3-14B NVFP4): no llama.cpp counterpart at the same
+  quant — the bar is only measurable on shared GGUF quants.
+- **gpt-oss-20b MXFP4:** imp ships MXFP4 in GGUF under a proprietary tensor
+  type code; llama.cpp reads it as a removed format (docs/quantization.md) —
+  not comparable.
+- **Nemotron-H:** no GGUF staged locally; NVFP4-only.
+- **Gemma-4-26B-A4B:** the llama.cpp reference itself reads PPL ≈ 309/330 on
+  this corpus (UD-Q4_K_M / Q8_0, reproducible ×2) and imp's MoE trial spread in
+  that regime is ±4% (319–348) — the regime carries no parity signal. Token
+  streams are IDENTICAL (11 346). The Q8_0 imp cell additionally cannot run at
+  equal windows: 26 GiB weights leave a 7 168-token KV pool, below the 11.3k
+  corpus (imp prefills the full corpus; llama.cpp only allocates the C=5.7k
+  window).
+
+## Findings shipped in this PR
+
+1. **`tokenizer.ggml.pre = "qwen35"` routed to the gpt2 fallback** — Qwen3.5/3.6
+   GGUFs (incl. the 35B hero) over-split symbol runs: 35 807 vs 31 620 tokens
+   (+13%) on this corpus, i.e. every real prompt tokenized non-canonically
+   (more prefill tokens + off-distribution splits). Now routed to the qwen2
+   scanner (qwen35 only adds `\p{M}` to the letter run, which the scanner's
+   letter classifier already covers). Regression test in test_tokenizer.cpp.
+2. **`diagnostics.ppl_first` / `diagnostics.ppl_last`** — NLL counting window
+   for `imp-cli --perplexity`, enabling exact llama.cpp window alignment.
+3. **The NVFP4-LM-head opt-outs were dead on GGUF checkpoints:** the
+   quantized-source decode-cache collector added the LM head unconditionally,
+   so neither `gemm.nvfp4_lm_head=false` nor the GOAL-listed
+   `gemm.nvfp4_lm_head_gdn=false` trade opt-out had any effect on GGUF models
+   (verified: 4B PPL unchanged at 8.6348 with the flag off; the 35B "trades
+   excluded" run still carried +1.5% from the head). The collector now applies
+   the same gates as the native-precision paths. Defaults are byte-identical
+   (both flags default on).
+
+## Open follow-ups
+
+1. **Bar-1 trade listing decision (owner):** `gemm.nvfp4_lm_head` default-on is
+   a real +1.5…+4.8% PPL trade for ~14% dense decode. Either list it in
+   docs/GOAL.md release-bar trades (opt-out exists) or revisit the default for
+   small-vocab-pressure models where the cost is largest.
+2. **Diagnostics combination bug:** `diagnostics.no_nvfp4_decode_cache=true` +
+   `kv_cache.dtype=fp16` yields PPL 15.35 vs 8.30 on Qwen3-4B Q8 (bit-exact
+   reproducible; each flag alone is sane). fp16 KV cannot be worse than FP8 —
+   some fallback path in that combination is broken.
+3. Gemma-4 quality regime (PPL ~300 on raw docs in BOTH engines' ballpark)
+   deserves its own investigation before any Gemma parity claim.

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -544,6 +544,12 @@ dump_logits_dir      = ""
 dump_routing_dir     = ""
 # Print prefill token IDs to stderr (truncated to 20).
 dump_tokens          = false
+# Teacher-forced perplexity (--perplexity): restrict the NLL sum to logit
+# rows [ppl_first, ppl_last] (row i predicts token i+1; ppl_last=-1 = end).
+# Matches llama-perplexity's counting window (first = n_ctx/2) for the
+# cross-engine PPL-parity bar — see docs/GOAL.md release bar 1.
+ppl_first            = 0
+ppl_last             = -1
 # Stop forward pass after layer N (-1 = run full forward).
 exit_layer           = -1
 profile              = false

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -122,8 +122,22 @@ void QuantPipeline::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
         dctx.entries.push_back({w.data, w, qtype, from_scratch});
     };
 
-    // LM head first: largest single weight (vocab × d_model), biggest bandwidth win.
-    collect_weight_nvfp4(model_->output_proj(), model_->out_proj_.qtype);
+    // LM head first: largest single weight (vocab × d_model), biggest bandwidth
+    // win. Same gates as the native-precision paths (executor_pre_dequant plan /
+    // nvfp4_decode_cache_fp16_lm_head_): gemm.nvfp4_lm_head opts out entirely,
+    // GDN/SSM hybrids keep the source-precision head unless nvfp4_lm_head_gdn.
+    // This call used to be unconditional, which silently voided both opt-outs
+    // on every quantized-source (GGUF) checkpoint (PPL-parity audit 2026-07-12).
+    {
+        const auto& prof = model_->profile();
+        const bool gdn_head_ok = !(prof.is_gdn || prof.is_ssm) ||
+                                 runtime_config().gemm.nvfp4_lm_head_gdn;
+        if (runtime_config().gemm.nvfp4_lm_head && gdn_head_ok)
+            collect_weight_nvfp4(model_->output_proj(), model_->out_proj_.qtype);
+        else
+            IMP_LOG_INFO("NVFP4 LM head: skipped (gemm.nvfp4_lm_head%s)",
+                         gdn_head_ok ? "=false" : "_gdn=false, GDN/SSM hybrid");
+    }
 
     // Dense attention + FFN: every tensor benefits every decode step.
     for_each_dense_weight(*model_, cfg, [&](const Tensor& w, QType qtype) {

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -1685,10 +1685,14 @@ std::vector<int32_t> Tokenizer::encode_gpt2(const std::string& text) const {
         std::vector<std::string> chunks;
         if (pre_tokenizer_ == "llama3" || pre_tokenizer_ == "llama-v3" || pre_tokenizer_ == "llama-bpe") {
             chunks = llama3_pre_tokenize(bpe_text);
-        } else if (pre_tokenizer_ == "qwen2") {
+        } else if (pre_tokenizer_ == "qwen2" || pre_tokenizer_ == "qwen35") {
             // Qwen2/Qwen3 family: canonical regex incl. symbol RUNS and single
             // digits — the gpt2 fallback's per-char punctuation made canonical
-            // merges ("->", "():") impossible (#657).
+            // merges ("->", "():") impossible (#657). "qwen35" (Qwen3.5/3.6
+            // GGUFs) differs from qwen2 only by adding \p{M} to the letter
+            // run, which is_letter_at already treats as letters — falling
+            // through to gpt2 instead over-split symbol runs (+13% tokens on
+            // the 35B hero corpus).
             chunks = qwen2_pre_tokenize(bpe_text);
         } else if (pre_tokenizer_ == "o200k" || pre_tokenizer_ == "gpt-4o") {
             // gpt-oss / GPT-4o family (o200k_harmony): case-aware letter runs,

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -264,6 +264,8 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("diagnostics.dump_logits_dir", cfg.diagnostics.dump_logits_dir);
     S("diagnostics.dump_routing_dir", cfg.diagnostics.dump_routing_dir);
     B("diagnostics.dump_tokens", cfg.diagnostics.dump_tokens);
+    I("diagnostics.ppl_first", cfg.diagnostics.ppl_first);
+    I("diagnostics.ppl_last", cfg.diagnostics.ppl_last);
     I("diagnostics.exit_layer", cfg.diagnostics.exit_layer);
     B("diagnostics.profile", cfg.diagnostics.profile);
     B("diagnostics.graph_diag", cfg.diagnostics.graph_diag);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -885,6 +885,17 @@ struct RuntimeConfig {
         std::string dump_logits_dir;   // path or empty
         std::string dump_routing_dir;  // path or empty
         bool dump_tokens = false;
+        // Teacher-forced perplexity: restrict the NLL sum to logit rows
+        // i in [ppl_first, ppl_last] (row i predicts token i+1); ppl_last=-1
+        // means "through the end" (n-2). Matches llama-perplexity's window
+        // (`first = n_ctx/2`, rows [first, n_ctx-2]) when llama.cpp runs the
+        // same corpus with `-c C --chunks 1` (llama-perplexity refuses
+        // single-chunk-over-everything: it wants >= 2*n_ctx total tokens):
+        // set ppl_first = C/2, ppl_last = C-2 (+ token-offset if the streams
+        // are BOS-shifted). The cross-engine PPL-parity bar (GOAL release
+        // bar 1) is measured this way.
+        int ppl_first = 0;
+        int ppl_last = -1;
         int exit_layer = -1;
         bool profile = false;
         bool graph_diag = false;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -370,6 +370,11 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
         return false;
     }
     const int n = ppl_capture_.n;
+    // diagnostics.ppl_first/ppl_last: llama-perplexity comparability (see
+    // config.h). Row i predicts token i+1; count rows [first, last].
+    const int first = std::clamp(runtime_config_.diagnostics.ppl_first, 0, n - 2);
+    const int cfg_last = runtime_config_.diagnostics.ppl_last;
+    const int last = (cfg_last < 0) ? n - 2 : std::clamp(cfg_last, first, n - 2);
     IMP_CUDA_CHECK_LOG(cudaDeviceSynchronize());
 
     // Fixed-order host reduction over per-position NLLs (bit-reproducible —
@@ -384,7 +389,7 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
                                       static_cast<size_t>(n) * sizeof(int32_t),
                                       cudaMemcpyDeviceToHost));
         match_sum = 0;
-        for (int i = 0; i < n - 1; ++i)
+        for (int i = first; i <= last; ++i)
             match_sum += h_match[i];
         cudaFree(ppl_capture_.d_match);
     }
@@ -406,13 +411,15 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
         fprintf(stderr, "\n");
     }
     double h_nll = 0.0;
-    for (int i = 0; i < n - 1; ++i)
+    for (int i = first; i <= last; ++i)
         h_nll += h_nll_pos[i];
-    double ppl = std::exp(h_nll / static_cast<double>(n - 1));
-    IMP_LOG_INFO("perplexity_nll: n=%d  mean_nll=%.4f  PPL=%.4f", n, h_nll / (n - 1), ppl);
+    const int counted = last - first + 1;
+    double ppl = std::exp(h_nll / static_cast<double>(counted));
+    IMP_LOG_INFO("perplexity_nll: n=%d first=%d last=%d counted=%d mean_nll=%.4f  PPL=%.4f", n,
+                 first, last, counted, h_nll / counted, ppl);
     if (match_sum >= 0)
-        IMP_LOG_INFO("greedy top1 match: %ld/%d (%.2f%%)", match_sum, n - 1,
-                     100.0 * static_cast<double>(match_sum) / static_cast<double>(n - 1));
+        IMP_LOG_INFO("greedy top1 match: %ld/%d (%.2f%%)", match_sum, counted,
+                     100.0 * static_cast<double>(match_sum) / static_cast<double>(counted));
     if (out_ppl)
         *out_ppl = ppl;
     return true;

--- a/tests/test_tokenizer.cpp
+++ b/tests/test_tokenizer.cpp
@@ -185,6 +185,14 @@ static Tokenizer make_gpt2_tokenizer() {
     (void)llo_id;
     (void)Hello_id;
 
+    // "->" merged token: only reachable when the pre-tokenizer keeps symbol
+    // runs together (qwen2/qwen35 routing test below).
+    std::string dash_tok = codepoint_to_utf8(BYTE_TO_CP['-']);
+    std::string gt_tok = codepoint_to_utf8(BYTE_TO_CP['>']);
+    std::string arrow_tok = dash_tok + gt_tok;
+    tokens.push_back(arrow_tok);
+    scores.push_back(0.0f);
+
     Tokenizer tok;
     tok.load_vocab(tokens, scores, /*bos_id=*/1, /*eos_id=*/2);
     tok.set_type("gpt2");
@@ -196,6 +204,7 @@ static Tokenizer make_gpt2_tokenizer() {
         l_tok + " " + l_tok,     // l + l -> ll (rank 1)
         ll_tok + " " + o_tok,    // ll + o -> llo (rank 2)
         He_tok + " " + llo_tok,  // He + llo -> Hello (rank 3)
+        dash_tok + " " + gt_tok, // - + > -> -> (rank 4)
     };
     tok.load_merges(merges);
 
@@ -672,6 +681,23 @@ TEST(Qwen2PreTokenizeTest, NewlineRuns) {
 
 TEST(Qwen2PreTokenizeTest, TrailingWhitespace) {
     EXPECT_EQ(qwen2_pre_tokenize("abc   "), (Chunks{"abc", "   "}));
+}
+
+// Qwen3.5/3.6 GGUFs declare tokenizer.ggml.pre = "qwen35" (qwen2 rules plus
+// \p{M} in the letter run — identical on ASCII). The routing used to fall
+// through to the gpt2 per-char-punct fallback, over-splitting symbol runs
+// (+13% tokens on the 35B hero corpus) and making canonical merges
+// unreachable.
+TEST(Qwen2PreTokenizeTest, Qwen35RoutesToQwen2NotGpt2) {
+    Tokenizer tok = make_gpt2_tokenizer();
+    tok.set_pre_tokenizer("qwen2");
+    const auto qwen2_ids = tok.encode("x->y", /*no_prefix=*/true);
+    tok.set_pre_tokenizer("qwen35");
+    EXPECT_EQ(tok.encode("x->y", /*no_prefix=*/true), qwen2_ids);
+    // gpt2 fallback splits "->" per char, so the merged token stays
+    // unreachable — guards against qwen35 regressing to the fallback.
+    tok.set_pre_tokenizer("gpt2");
+    EXPECT_NE(tok.encode("x->y", /*no_prefix=*/true), qwen2_ids);
 }
 
 // ---- o200k pre-tokenizer (gpt-oss / GPT-4o, #657) ----


### PR DESCRIPTION
First systematic measurement of GOAL release bar 1 (PPL within 0.5% of llama.cpp at the same quant) — full methodology + results in `docs/audit/ppl_parity_2026_07_12.md`. The sweep surfaced and this PR fixes two real defects:

## Fixes

1. **`tokenizer.ggml.pre = "qwen35"` routed to the gpt2 fallback** — Qwen3.5/3.6 GGUFs (incl. the 35B hero) over-split symbol runs: **+13% tokens** (35 807 vs 31 620 on a 95 KB docs corpus) and non-canonical, off-distribution splits on every real prompt. Now routed to the qwen2 scanner (qwen35 only adds `\p{M}` to the letter run, already covered by the scanner's letter classifier). Token streams now verified **byte-identical** to `llama-tokenize` on all 7 tested models. Regression test added.
2. **The NVFP4-LM-head opt-outs were dead on GGUF checkpoints**: the quantized-source decode-cache collector added the LM head unconditionally, so `gemm.nvfp4_lm_head=false` and the GOAL-listed `gemm.nvfp4_lm_head_gdn=false` trade opt-out silently did nothing (verified pre-fix: PPL unchanged with the flag off). The collector now applies the same gates as the native-precision paths.

## Added

- `diagnostics.ppl_first` / `diagnostics.ppl_last`: NLL counting window for `imp-cli --perplexity`, enabling exact alignment with llama-perplexity's `first = n_ctx/2` convention (`-c C --chunks 1`). This is the bar-1 measurement recipe; note llama.cpp needs `--no-escape` or token streams silently desync on corpora containing `\"`.

## Bar-1 result (llama.cpp b9976 e3546c794, identical token streams + identical counted logit rows)

| model (GGUF) | llama.cpp | imp defaults | imp LM-head opt-out | Δ opt-out |
|---|---|---|---|---|
| Qwen3-4B-2507 Q8_0 | 8.3299 | 8.6348 | 8.3224 | −0.09% |
| Qwen3-8B Q8_0 | 8.0360 | 8.2292 | 8.0224 | −0.17% |
| Qwen3-14B Q6_K | 7.1123 | 7.2758 | 7.1288 | +0.23% |
| Qwen3-30B-A3B Q4_K_M | 8.2058 | 8.5438 | 8.1394 | −0.81% (imp better) |
| Qwen3.6-35B UD-Q4_K_M | 4.8993 | 4.9671 | 4.8972 | −0.04% |

The forward pass is at parity everywhere; the entire defaults gap is the NVFP4 LM-head decode cache (+1.4…+5.0% PPL, size-dependent) → owner decision tracked in #982. Diagnostics-combination bug found on the way: #981. NVFP4/MXFP4 heroes and Gemma-4 are excluded/non-probative — reasons in the audit doc.

## Perf

No perf change intended: both LM-head flags default on → default decode-cache contents byte-identical; `--bench` uses synthetic tokens, so the tokenizer fix does not touch the perf gate (it makes *real* 35B prompts ~13% cheaper to prefill). Full GPU suite green locally (492/192/194/189/192/54/121/86); verify-fast OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ