### PR TITLE
fix(prefill): capture only offset-0 chunks in the prefill graph; exclude quantized-KV appends from capture (#981)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Fixed
+- **Prefill CUDA graph replayed stale chunk geometry on continuation chunks**
+  (#981): the captured chunk forward bakes `ctx_len`/`q_offset` as host args
+  into the attention launches, and the graph was only invalidated on
+  (chunk_len, block_count) changes — so chunk 2+ of a multi-chunk prefill
+  replayed chunk 1's graph and attended with chunk-1 geometry, silently
+  truncating long context (teacher-forced PPL 8.30 → 15.35 past the second
+  chunk on Qwen3-4B Q8). The scheduler now captures only offset-0 chunks
+  (whose geometry repeats across requests); continuation chunks run eager.
+  Exposure was narrow — quantized-KV appends abort the capture (see below)
+  and the NVFP4 M>1 dequant fallback marks most GGUF models uncapturable —
+  but any capturable fp16-KV config with prompts past one chunk was silently
+  wrong. Regression test: ChunkedPrefillTest.LongContext_Chunk_Invariance_GraphsOn.
+- **Quantized-KV prefill chunks no longer attempt graph capture**: the
+  dynamic-scale KV append does a D2H absmax sync per chunk, which is illegal
+  under capture — every chunk aborted its capture, spamming CUDA errors and
+  wasting one full forward per chunk (Qwen3 GGUFs have been on FP8-KV-auto
+  since #977, so every >2048-token prompt paid this). F16 KV remains the only
+  capturable append path; the rest run eager without the wasted forward.
+
 ## [0.19.0] - 2026-07-12
 
 Highlights: first cross-engine PPL-parity measurement (release bar 1) with two

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -870,8 +870,22 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         // moe_prefill_uncapturable: legacy host-args MoE prefill (GGUF Q*_K
         // MoE) reads routing on the host — its capture guard throws and the
         // aborted capture costs a wasted forward per chunk. Run eager (#874).
+        // Quantized KV append runs a dynamic-scale reduction with a D2H
+        // absmax sync per chunk — illegal under capture (the capture aborts
+        // every chunk, spamming errors and wasting one forward per chunk).
+        // F16 KV is the only append path that captures cleanly; run the rest
+        // eager.
+        const bool kv_append_capturable = (config_.kv_cache_dtype == QType::F16);
+        // Continuation chunks (offset > 0) bake ctx_len/q_offset as host args
+        // into the attention launches, so a replay only fits the exact same
+        // offset — which never repeats within a request. Replaying chunk 1's
+        // graph for chunk 2+ attended with chunk-1 geometry and silently
+        // truncated long-context prefill (#981: teacher-forced PPL
+        // 8.30 -> 15.35 past chunk 2). Capture only the offset-0 chunk, whose
+        // geometry DOES repeat across requests; continuations run eager.
         const bool can_capture = prefill_graph_enabled && pf_pool_used && config_.use_cuda_graphs &&
-                                 !ends_at_snapshot && !executor_->nvfp4_dequant_uncapturable() &&
+                                 kv_append_capturable && offset == 0 && !ends_at_snapshot &&
+                                 !executor_->nvfp4_dequant_uncapturable() &&
                                  !executor_->moe_prefill_uncapturable();
         if (can_capture) {
             const int block_count = static_cast<int>(block_table.size());

--- a/tests/test_chunked_prefill.cu
+++ b/tests/test_chunked_prefill.cu
@@ -95,7 +95,8 @@ static std::string generate_greedy(const char* model_path, const std::string& pr
 // Teacher-forced perplexity of `prompt` at a given prefill_chunk_size.
 // Returns -1.0 on any API failure.
 static double ppl_for_chunk(const char* model_path, const std::string& prompt,
-                            int chunk_size, bool use_fp8_kv = false) {
+                            int chunk_size, bool use_fp8_kv = false,
+                            bool enable_graphs = false) {
     ImpModel model = nullptr;
     if (imp_model_load(model_path, IMP_FORMAT_GGUF, &model) != IMP_SUCCESS || !model)
         return -1.0;
@@ -112,7 +113,7 @@ static double ppl_for_chunk(const char* model_path, const std::string& prompt,
     ImpConfig cfg = imp_config_default();
     cfg.max_seq_len = 4096;
     cfg.max_batch_size = 1;
-    cfg.enable_cuda_graphs = 0;
+    cfg.enable_cuda_graphs = enable_graphs ? 1 : 0;
     cfg.prefill_chunk_size = chunk_size;
     if (use_fp8_kv)
         cfg.kv_cache_dtype = IMP_DTYPE_FP8_E4M3;
@@ -329,6 +330,32 @@ TEST_F(ChunkedPrefillTest, LongContext_Chunk_Invariance) {
         ASSERT_GT(ppl, 0.0) << "chunk=" << chunk << " perplexity failed";
         EXPECT_NEAR(ppl, base, base * kFp16RelTol)
             << "chunk=" << chunk << " long-context teacher-forced PPL diverges";
+    }
+}
+
+// Same invariance with CUDA graphs ON (FP16 KV). Guards the prefill-graph
+// replay path (#981): the captured chunk forward bakes ctx_len/q_offset as
+// host args, so replaying an earlier chunk's graph for a continuation chunk
+// attends with stale geometry and silently truncates long context — the
+// scheduler must not reuse a prefill graph across chunk offsets. Whether the
+// graph actually captures depends on the model's capturability gates; the
+// invariance must hold either way.
+TEST_F(ChunkedPrefillTest, LongContext_Chunk_Invariance_GraphsOn) {
+    const char* path = llama_3b_path();
+    if (!model_exists(path))
+        GTEST_SKIP() << "model not present: " << path;
+
+    const std::string prompt = long_prompt();  // ~3.1k tokens, >2 non-last chunks at chunk=512
+
+    const double base = ppl_for_chunk(path, prompt, /*chunk=*/0);
+    ASSERT_GT(base, 0.0) << "reference perplexity failed";
+
+    for (int chunk : {512, 1024}) {
+        const double ppl =
+            ppl_for_chunk(path, prompt, chunk, /*use_fp8_kv=*/false, /*enable_graphs=*/true);
+        ASSERT_GT(ppl, 0.0) << "chunk=" << chunk << " perplexity failed";
+        EXPECT_NEAR(ppl, base, base * kFp16RelTol)
+            << "chunk=" << chunk << " graphs-on long-context PPL diverges (#981 class)";
     }
 }
 


### PR DESCRIPTION
Root-caused and fixes #981 (`diagnostics.no_nvfp4_decode_cache + kv_cache.dtype=fp16` → PPL 8.30→15.35).

**Root cause:** the prefill CUDA graph (`runtime.prefill_graph`, default on) was invalidated only when `(chunk_len, block_count)` changed. Continuation chunks bake `ctx_len`/`q_offset` as **host args** into the attention launches, so chunk 2+ of a multi-chunk prefill replayed chunk 1's graph and attended with chunk-1 geometry — silently truncating long context. nsys evidence: the continuation FA2 launches ran at a constant chunk-1 duration (median 227 µs vs 706 µs eager); per-position NLL was bit-identical through the first chunk and degraded steadily after it.

**Why it hid:** quantized-KV appends abort every capture (D2H absmax sync → CUDA error spam + one wasted forward per chunk — this is what "protected" FP8-KV-auto models, i.e. all Qwen3 GGUFs since #977), and the NVFP4 M>1-dequant uncapturable gate masks most other GGUF configs. Any *capturable* fp16-KV config with a >1-chunk prompt was silently wrong. Yesterday's PPL-parity numbers are unaffected (all measured arms ran eager via those gates — verified).

**Fix:**
1. Capture only offset-0 chunks — continuation offsets never repeat within a request, so a replay could never be valid; offset-0 geometry does repeat across requests and keeps the graph's purpose.
2. Quantized-KV chunks skip capture entirely: removes the guaranteed abort, the error spam, and the wasted forward per chunk that FP8-KV models paid on every >2048-token prompt.

**Verified (Qwen3-4B Q8):** broken combo 15.3498 → **8.3157** (matches the eager/single-chunk reference), defaults **bit-identical** (8.6348), fp8-KV runs now log **zero** capture errors; pp4096 smoke clean. Full GPU suite green (492/192/194/189/192/54/121/86). New regression test `ChunkedPrefillTest.LongContext_Chunk_Invariance_GraphsOn` (graphs-on chunk invariance) passes with models mounted.

No intended perf change on the CI gate (pp128/pp512 are single-chunk). Multi-chunk prefill on quantized-KV models gets strictly faster (wasted forward removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ