### PR TITLE
ci(dependabot): stop scanning /tools/analysis docker files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,15 @@ updates:
         patterns:
           - "*"
 
-  # Docker base images (root + analysis/roofline tools)
+  # Docker base images (root + roofline plot tool).
+  # /tools/analysis is deliberately NOT scanned: its Dockerfiles build FROM
+  # local-only stages (imp:ciq, imp:builder-133), which Dependabot resolves
+  # as docker.io/library/imp and fails the whole docker update run with
+  # private_source_authentication_failure (run 29214173834, 2026-07-12).
+  # There is no external base image in that directory to update.
   - package-ecosystem: "docker"
     directories:
       - "/"
-      - "/tools/analysis"
       - "/tools/roofline"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## What

The weekly Dependabot docker run fails red on main (run 29214173834): `tools/analysis/Dockerfile.cutile` / `Dockerfile.ciq` build `FROM imp:ciq` / `FROM imp:builder-133` — local-only images that Dependabot resolves as `docker.io/library/imp` and dies with `private_source_authentication_failure`, taking the whole docker ecosystem update down with it.

There is no external base image in that directory to update, so the fix is to drop it from the scanned directories (root `nvidia/cuda` and `tools/roofline` `python:3.14-slim` stay covered). Rationale documented in the config comment.

Verification: config-only change; the next weekly Dependabot docker run (or a manual "Check for updates" from the Dependency-graph UI) should complete green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ