### PR TITLE
docs: publish gpt-oss +12% decode (PR #990) — b9976 tie becomes +13-19% lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+- **`gemm.fp8_attn_proj` — FP8 decode sidecar for full-precision attention
+  projections** (#984, PR #990): per-row-scale FP8 E4M3 copies of BF16/F16
+  wq/wk/wv/wo, decode-only (prefill keeps the full-precision source).
+  Default "auto" = full q/k/v/o on gpt-oss, whose BF16 dense projections had
+  no decode cache and ran as 2 B/elem FP16 GEMVs (33.5% of the decode
+  window). gpt-oss-20b decode 349.7 → 391.2 tok/s (+12%), turning the
+  llama.cpp b9976 statistical tie into a +13–19% lead. Teacher-forced PPL
+  unaffected by construction (nsys-verified); degen_suite 33/33. Modes:
+  `auto` / `qo` (q+o only) / `on` / `off`.
+
+### Changed
+- **`gemm.nvfp4_lm_head` is now `"auto"` with a per-model net rule** (#982,
+  PR #990): ON for native BF16/F16 LM heads (+8-16% decode, +2.2% PPL — the
+  long-standing documented trade) and for small dense GGUF heads
+  (d_model ≤ 4096, where the measured decode win exceeds the PPL cost);
+  OFF for larger or MoE GGUF heads (14B/30B-A3B measured net-negative in the
+  2026-07-12 parity sweep — those now return to default PPL parity at the
+  cost of −1.9%/−3.4% decode). Legacy `true`/`false` values still parse.
+
 ### Fixed
 - **Prefill CUDA graph replayed stale chunk geometry on continuation chunks**
   (#981): the captured chunk forward bakes `ctx_len`/`q_offset` as host args

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ decode is the reliable A/B signal):
 
 **Honest losses & ties** (narrow, and documented): NVFP4 dense pp4096 still
 trails vLLM by ~4% (1.04×). llama.cpp's MXFP4/MoE-GGUF decode caught up
-substantially by build 9976: gpt-oss-20b is now a statistical tie (imp ~344 vs
-llama 329–345 across runs, #984) and the non-hero Qwen3-30B Q4_K_M margin is
-within noise (+1.7%). The former 35B-hybrid GGUF loss was closed by extending
+substantially by build 9976: the non-hero Qwen3-30B Q4_K_M margin is within
+noise (+1.7%). The brief gpt-oss-20b tie from that sweep was reversed by the
+FP8 attention-projection decode sidecar (#984/PR #990: imp ~391 vs llama
+329–345, +13–19%). The former 35B-hybrid GGUF loss was closed by extending
 the FP8 SSM-projection sidecar to UD quants (#962, 224 → 267–272 tok/s, +18%
 ahead of llama.cpp).
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -67,11 +67,18 @@ matrix appended to [`scoreboard.tsv`](scoreboard.tsv).
 | Qwen3.6-35B-A3B UD-Q4_K_M (hybrid) | 266.8 | 226.5 ± 5.9 | **+18%** |
 | Gemma-4-26B-A4B UD-Q4_K_M (MoE) | 261.3 | 216.0 ± 3.5 | **+21%** |
 | Qwen3-30B-A3B Q4_K_M (MoE, non-hero) | 324.7 | 319.2 ± 7.0 | +1.7% |
-| gpt-oss-20b MXFP4 (imp: SafeTensors, llama: GGUF) | 343.6–344.4 | 328.6–345.4 (run-to-run ±5%) | statistical tie |
+| gpt-oss-20b MXFP4 (imp: SafeTensors, llama: GGUF) | 389.7–391.2¹ᵍ | 328.6–345.4 (run-to-run ±5%) | **+13–19%** |
 
-llama.cpp's MoE/MXFP4 decode has improved substantially since the 06-07
-reference: the former gpt-oss ≥5% lead is gone (tie), and the non-hero
-Qwen3-30B GGUF margin narrowed to noise — tracked in #984. Dense GGUF, the
+¹ᵍ imp re-measured 2026-07-13 at commit `63df2d30` (PR #990,
+`gemm.fp8_attn_proj` FP8 decode sidecar for the BF16 q/k/v/o projections,
+default auto): tg128 391.2 median of 3 isolated trials, same command as the
+sweep, healthy clocks sampled. The llama.cpp column is the unchanged
+2026-07-12 b9976 measurement. Pre-sidecar imp measured 343.6–350.3 — a
+statistical tie, formerly tracked in #984 (resolved by PR #990).
+
+llama.cpp's MoE/MXFP4 decode improved substantially at b9976 (the 07-12 sweep
+measured a gpt-oss tie); the FP8 attention-projection sidecar restored the
+lead. The non-hero Qwen3-30B GGUF margin remains noise-level. Dense GGUF, the
 hybrid hero and Gemma-4 remain clear wins; NVFP4 SafeTensors stays uncontested
 (no llama.cpp counterpart). The pp512 column is not tabulated per the prefill
 variance policy above; on this sweep imp led NVFP4 prefill (e.g. 8B NVFP4
@@ -116,7 +123,7 @@ Decode carries ±5–10 % day-to-day variance (issue #526); clocks logged health
 | Qwen3.6-35B-A3B | 35B (3B) | 257 → **320**¹ᵇ |
 | Gemma-4-26B-A4B | 26B (4B) | 266 |
 | Nemotron-3-Nano-30B | 30B (3B) | 128 → **148**¹ᶜ |
-| gpt-oss-20b¹ | 21B (3.6B) | 325 |
+| gpt-oss-20b¹ | 21B (3.6B) | 325 → **391**¹ᵈ |
 
 ¹ᵇ 2026-07-10, commit `80864b06` + `gemm.fp8_ssm_proj` (default on since that
 PR): FP8 E4M3 per-row-scale decode sidecar for the BF16 GDN in/out projections
@@ -129,6 +136,14 @@ SSM-projection sidecar (221 MiB on Nemotron's 12 GDN projections) lifts
 Nemotron-3-Nano-30B decode 128 → **148** tok/s (+16%), PPL flat (4.184 →
 4.117). Still the slowest 30B — the Mamba2 scan + attention-projection share is
 arch-limited — but the GDN-projection part of the FP16 tax is gone.
+
+¹ᵈ 2026-07-13, commit `63df2d30` (PR #990) + `gemm.fp8_attn_proj` (default
+auto since that PR): FP8 E4M3 per-row-scale decode sidecar for the BF16
+q/k/v/o attention projections — the roofline cell
+(`docs/audit/roofline_gptoss_2026_07_13.md`) showed them at 33.5% of the
+decode window as 2 B/elem FP16 GEMVs. tg128 ~350 → **391.2** (+12%).
+Teacher-forced PPL unaffected by construction (decode-only sidecar;
+nsys-verified zero FP8 kernels in a `--perplexity` run); degen_suite 33/33.
 
 ¹ gpt-oss (PRs #572/#574): SafeTensors MXFP4 source, experts converted to
 NVFP4 at load (bit-exact nibbles, power-of-two scales) and registered for the

--- a/docs/MISSION_JOURNAL.md
+++ b/docs/MISSION_JOURNAL.md
@@ -559,3 +559,20 @@ across chunk sizes). NVFP4 KV Δnll vs FP16: −0.12% @2048 → +0.58% @64 → *
 fully coherent). FP8 (auto default) clean at every granularity. Methodology rule: any nvfp4-KV
 quality claim needs a small-chunk (≤64) PPL arm — standard chunked PPL understates the cost by
 ~1 percentage point. Closes the last open measurement of the FP4-attention program.
+
+### 2026-07-13 — gpt-oss decode tie reversed: FP8 attention-projection sidecar (+12%), lm_head net rule
+
+The b9976 competitive sweep had reduced gpt-oss-20b to a statistical tie (#984). A dedicated
+roofline cell (PR #987, after fixing a gpt-oss teardown double-free that SIGSEGV'd nsys and an
+unused nsys flag that killed profiling) attributed 33.5% of the decode window to BF16 q/k/v/o
+running as 2 B/elem FP16 GEMVs — `nvfp4_beneficial()` is GGUF-only, so SafeTensors dense weights
+never got a decode cache. `gemm.fp8_attn_proj` (PR #990) extends the #949 per-row FP8 sidecar to
+those projections: 349.7 → 391.2 tok/s (+12%), llama.cpp lead restored to +13–19%. Quality gates:
+teacher-forced PPL untouched by construction (nsys shows zero FP8 kernels in --perplexity — an
+apparent +2.6% PPL shift was cuBLAS algo re-selection from the 600 MiB VRAM move, a measurement
+lesson now in the skills), degen_suite 33/33. Same PR resolves #982: `nvfp4_lm_head="auto"` net
+rule (native + small-dense-GGUF heads ON, ≥14B/MoE GGUF heads OFF → default PPL parity, north-star
+−1.9% accepted). A parallel Qwen-30B+ campaign refuted the launch-latency lever class wholesale
+(PR #988): under graphs+PDL, no-graphs kernel-time shares overstate tiny-kernel classes ~1.8× —
+router-chain fusion measured 0% e2e despite bit-identical outputs, split-K caps regressed −21…−35%.
+Only bytes-on-critical-path levers transfer.

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -52,7 +52,7 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Gemma-4-26B-A4B-it](https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4) | NVFP4 | 14 GB | 266 | SafeTensors (Modelopt) |
 | [Nemotron-3-Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) | NVFP4 | 18 GB | 148 | SafeTensors (Modelopt), Mamba2+attn+MoE; 126 → 148 with the #949 FP8 SSM-projection sidecar. Still the slowest 30B (Mamba2 scan + attn-projection share is arch-limited), but the GDN-projection part of the FP16 tax is gone. |
 | [Nemotron-Labs-3-Elastic-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4) | NVFP4 | 18 GB | 70 | SafeTensors (QAD), same arch as Nano |
-| [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **345** | SafeTensors; experts converted to NVFP4 at load. Also loads the official GGUF (Q8_0- or bf16-dense + MXFP4 experts, e.g. `gpt-oss-20b-mxfp4.gguf` — the Q8_0 residual rescale was fixed in #808). Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
+| [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | MXFP4 (native) | 15 GB | **391** | SafeTensors; experts converted to NVFP4 at load. Also loads the official GGUF (Q8_0- or bf16-dense + MXFP4 experts, e.g. `gpt-oss-20b-mxfp4.gguf` — the Q8_0 residual rescale was fixed in #808). Harmony chat format (analysis/final channels split into `reasoning_content`/`content`). Use temperature 1.0 — greedy loops in the analysis channel (model-intrinsic). Prefill ≈ 16-19k tok/s (CUTLASS grouped GEMM). |
 
 ## Vision
 


### PR DESCRIPTION
## What

Publishes the PR #990 result across the doc set (repo rule: perf numbers ship with the change — this trails #990 by one PR, flagged in the session):

- **docs/BENCHMARKS.md**: competitive-table row updated (gpt-oss tg128 389.7–391.2 vs llama.cpp b9976 328.6–345.4 → **+13–19% lead**) with a SHA-anchored footnote (63df2d30, 3 isolated trials, healthy clocks; llama column unchanged from 2026-07-12); hero-table row 325 → 391 with methodology footnote.
- **README**: honest-ties paragraph — gpt-oss tie reversed by the sidecar.
- **docs/supported-models.md**: gpt-oss decode 345 → 391.
- **CHANGELOG [Unreleased]**: Added `gemm.fp8_attn_proj`, Changed `gemm.nvfp4_lm_head` auto net rule.
- **docs/MISSION_JOURNAL.md**: 2026-07-13 session entry (roofline cell, sidecar, lm_head rule, launch-latency lever-class refutation).

Docs only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ