### PR TITLE
perf(gpt-oss): sink-capable WMMA FMHA prefill — closes the silent-wrong S-matrix-overflow hole (#992)

### DIFF
--- a/src/compute/attention.h
+++ b/src/compute/attention.h
@@ -2,6 +2,7 @@
 
 #include "core/tensor.h"
 #include <cuda_runtime.h>
+#include <cuda_fp16.h>
 
 namespace imp {
 
@@ -10,9 +11,14 @@ struct RuntimeConfig;  // fwd, defined in runtime/config.h
 // Runtime-dispatched attention prefill (SM120 / Blackwell).
 // Dispatch: MXFP4 FMHA -> FP8 FMHA -> FP16 FMHA -> Blackwell WMMA 128x64.
 // rcfg is read for attention.{fp8_fmha,fmha_sm120} ladder gates.
+// attn_sinks (optional, [n_heads] FP16 device ptr): learned attention sinks
+// (gpt-oss #547). Only the FP16 WMMA FMHA tier understands them (#992) —
+// when set, every other tier is skipped, and an FMHA decline throws instead
+// of falling through to a sink-blind kernel (silent-wrong-output guard).
 void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                                 bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                                const RuntimeConfig& rcfg, int q_offset = 0);
+                                const RuntimeConfig& rcfg, int q_offset = 0,
+                                const half* attn_sinks = nullptr);
 
 // Query the compute capability of the current device.
 int get_device_sm_version();

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -37,7 +37,25 @@ int get_device_sm_version() {
 // change MUST be reflected in that header or the unit test will diverge.
 void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                                 bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                                const RuntimeConfig& rcfg, int q_offset) {
+                                const RuntimeConfig& rcfg, int q_offset, const half* attn_sinks) {
+    // Learned attention sinks (gpt-oss #547/#992): only the FP16 WMMA FMHA
+    // tier folds them into its online softmax. Route straight there and fail
+    // loudly on decline — falling through to a sink-blind kernel produces
+    // silently wrong output (the pre-#992 executor WARN case).
+    if (attn_sinks != nullptr) {
+        if (rcfg.attention.fmha_sm120 != "never" &&
+            fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset,
+                               attn_sinks)) {
+            return;
+        }
+        char msg[160];
+        snprintf(msg, sizeof(msg),
+                 "attention_prefill_dispatch: learned sinks set but the FP16 WMMA FMHA "
+                 "declined head_dim=%d (or fmha_sm120=never) — no sink-capable kernel (#992)",
+                 static_cast<int>(Q.shape[3]));
+        throw std::runtime_error(msg);
+    }
+
     // MXFP4 Flash Attention: tiled FP4 E2M1 Q·K^T with online softmax.
     // O(n) memory, ~4x score throughput over FP16, ~2x over FP8.
     // Enabled with [attention] mxfp4 = "always". Blockscale/ksmooth/pv_fp4

--- a/src/compute/attention_dispatch_decision.h
+++ b/src/compute/attention_dispatch_decision.h
@@ -51,8 +51,19 @@ struct AttnKernelSupport {
 
 // Reproduces attention_prefill_dispatch()'s path selection (config gates +
 // fall-through on kernel decline). Returns the path that would actually run.
+// has_sinks mirrors the #992 pre-gate: learned sinks (gpt-oss) route straight
+// to the FP16 WMMA FMHA (the only sink-capable tier) and the dispatch THROWS
+// on decline instead of falling through to a sink-blind kernel.
 inline AttnPrefillPath select_attn_prefill_path(const RuntimeConfig& rcfg,
-                                                const AttnKernelSupport& sup) {
+                                                const AttnKernelSupport& sup,
+                                                bool has_sinks = false) {
+    // 0. Learned sinks (#992): FP16 WMMA FMHA or nothing.
+    if (has_sinks) {
+        if (rcfg.attention.fmha_sm120 != "never" && sup.fmha_sm120_accepts)
+            return AttnPrefillPath::FMHA_SM120;
+        return AttnPrefillPath::NONE;  // dispatcher throws (silent-wrong guard)
+    }
+
     // 1. MXFP4 Flash Attention (opt-in, outer availability + per-config accept).
     if (sup.mxfp4_available && sup.mxfp4_accepts)
         return AttnPrefillPath::MXFP4;

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -70,7 +70,7 @@ template <int Bq, int HD>
 __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 2) fmha_sm120_kernel(
     const half* __restrict__ Q, const half* __restrict__ K, const half* __restrict__ V, half* __restrict__ O,
     int batch_size, int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale, bool causal,
-    int sliding_window, float softcap, int q_offset) {
+    int sliding_window, float softcap, int q_offset, const half* __restrict__ sinks) {
     constexpr int Bkv = SM120_Bkv;
     constexpr int head_dim = HD;
 
@@ -144,8 +144,19 @@ __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 2) fmha_sm120_kernel(
         }
     }
     if (tid < Bq) {
-        row_m[tid] = -FLT_MAX;
-        row_l[tid] = 0.0f;
+        if (sinks != nullptr) {
+            // gpt-oss learned sink (#547/#992): a virtual extra logit column
+            // with no V contribution. Seeding the online-softmax state with it
+            // (m = sink, l = exp(sink - sink) = 1) keeps the sink term
+            // correctly rescaled by every subsequent l *= exp(m_old - m_new)
+            // — identical math to the cuBLAS softmax's max/denominator join
+            // (attention_cublas.cu), just in running form.
+            row_m[tid] = __half2float(sinks[head_idx]);
+            row_l[tid] = 1.0f;
+        } else {
+            row_m[tid] = -FLT_MAX;
+            row_l[tid] = 0.0f;
+        }
     }
     __syncthreads();
 
@@ -414,7 +425,8 @@ static size_t compute_smem_sm120(int Bq, int Bkv, int head_dim) {
 // =============================================================================
 
 bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
-                        bool causal, int sliding_window, float softcap, cudaStream_t stream, int q_offset) {
+                        bool causal, int sliding_window, float softcap, cudaStream_t stream, int q_offset,
+                        const half* sinks) {
     if (Q.qtype != QType::F16)
         return false;
 
@@ -496,7 +508,7 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
         fmha_sm120_kernel<BQ, HD><<<grid, block, smem, stream>>>(                                        \
             reinterpret_cast<const half*>(Q.data), reinterpret_cast<const half*>(K.data),                \
             reinterpret_cast<const half*>(V.data), reinterpret_cast<half*>(O.data), batch_size, seq_q,   \
-            seq_kv, n_heads, n_kv_heads, scale, causal, sliding_window, softcap, q_offset);              \
+            seq_kv, n_heads, n_kv_heads, scale, causal, sliding_window, softcap, q_offset, sinks);       \
     } while (0)
 
     if (Bq == 128) {

--- a/src/compute/attention_fmha_sm120.h
+++ b/src/compute/attention_fmha_sm120.h
@@ -2,6 +2,7 @@
 
 #include "core/tensor.h"
 #include <cuda_runtime.h>
+#include <cuda_fp16.h>
 
 namespace imp {
 

--- a/src/compute/attention_fmha_sm120.h
+++ b/src/compute/attention_fmha_sm120.h
@@ -20,9 +20,12 @@ namespace imp {
 // O: [batch, seq_q, n_heads, head_dim]
 //
 // Returns true on success, false if config unsupported (caller falls back).
+// sinks: optional per-head learned attention sinks ([n_heads] FP16, gpt-oss
+// #547) — a virtual extra logit column with no V contribution, folded into
+// the online-softmax init (m = sink, l = 1). nullptr = no sinks.
 bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                         bool causal, int sliding_window, float softcap, cudaStream_t stream,
-                        int q_offset = 0);
+                        int q_offset = 0, const half* sinks = nullptr);
 
 // FP8 variant: QK^T computed in FP8 E4M3 (m16n8k32) for 2x score throughput.
 // Q,K converted to FP8 on-the-fly in shared memory. PV stays FP16.

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -51,8 +51,10 @@
                 hd == 128 || (hd == 256 && runtime_config().attention.fa2_hd256);
             const bool chunk_fa2_serves = shapes_uniform && !attn_sinks && fa2_hd_ok &&
                                           runtime_config().attention.fa2_fp16qk != "never";
-            // Tiled FMHA correctness domain: uniform shapes, no learned sinks.
-            const bool chunk_fmha_ok = shapes_uniform && !attn_sinks;
+            // Tiled FMHA correctness domain: uniform shapes. Learned sinks are
+            // servable since #992 (the WMMA FMHA folds them into its online
+            // softmax init); only heterogeneous shapes still require cuBLAS.
+            const bool chunk_fmha_ok = shapes_uniform;
             // attn_scores_ is sized [nh, s_cap, s_cap] (square). Chunked cuBLAS stores
             // an [nh, n, ctx_len] FP16 matrix (or FP32 = 2× when use_fp32_s). The
             // capacity constraint is `n * ctx_len <= s_cap²`, NOT `ctx_len <= s_cap`
@@ -291,8 +293,9 @@
                 // chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
             } else if (smatrix_fits && !prefer_fmha) {
                 // cuBLAS: reference path below the FMHA threshold; also the only
-                // chunked path that honors learned sinks (attn_sinks → gpt-oss)
-                // and heterogeneous per-layer shapes (Gemma-4).
+                // chunked path that honors heterogeneous per-layer shapes
+                // (Gemma-4); it also serves learned sinks below the FMHA
+                // threshold (both softmaxes understand sinks since #992).
                 attention_cublas_prefill(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv, hd, scale,
                                          /*causal=*/true, cfg.attn_logit_softcap, q_offset, stream,
                                          layer_sliding_window, attn_sinks);
@@ -300,8 +303,8 @@
                 // Tiled FMHA dispatch: no S-matrix needed, O(n) memory. Serves
                 // uniform-shape chunks above the FMHA threshold, any chunk the
                 // S-matrix cannot hold, and fa2-declined chunks on models whose
-                // S-matrix was deliberately skipped (guarded unservable above:
-                // sinks/heterogeneous shapes never reach this branch).
+                // S-matrix was deliberately skipped. Learned sinks ride along
+                // since #992 (heterogeneous shapes still never reach here).
                 int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
                 int64_t kv4s[4] = {1, (int64_t)ctx_len, (int64_t)nkv, (int64_t)hd};
                 int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
@@ -310,7 +313,8 @@
                 Tensor v4 = v_full_t.reshape(4, kv4s);
                 Tensor o4 = ao.reshape(4, o4s);
                 attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
-                                           cfg.attn_logit_softcap, stream, runtime_config(), q_offset);
+                                           cfg.attn_logit_softcap, stream, runtime_config(), q_offset,
+                                           attn_sinks);
             }
 
             if (!cap_replay && !used_eager_scratch) {
@@ -335,8 +339,13 @@
         // single-shot FA2 at any head_dim, and the FP8-KV deterministic skip
         // ("FA2 serves all attention") would be a lie for prompts below the
         // chunk size.
-        const bool force_cublas_attn =
-            (per_layer_shapes && !attn_shapes_uniform()) || attn_sinks != nullptr;
+        // Heterogeneous per-layer shapes (Gemma-4 dual head_dim) are the only
+        // remaining cuBLAS-exclusive config; learned sinks (gpt-oss) are FMHA-
+        // servable since #992 and follow the same threshold policy as every
+        // other non-FA2 model — FA2 itself still declines sinks (kept out of
+        // the try below).
+        const bool hetero_shapes = per_layer_shapes && !attn_shapes_uniform();
+        const bool force_cublas_attn = hetero_shapes;
         const bool s_matrix_fits = attn_scores_buf_ != nullptr &&
                                    n <= static_cast<int>(attn_scores_.shape[1]);
         // FMHA only above the S-matrix threshold — see the chunked path above
@@ -367,7 +376,7 @@
         // stays the fallback for the configs f16-QK declines (hd ∉ {128, 256},
         // or hd=256 with fa2_hd256 off) and for force_cublas_attn (learned
         // sinks / heterogeneous per-layer shapes).
-        if (!force_cublas_attn &&
+        if (!force_cublas_attn && attn_sinks == nullptr &&
             try_fa2_fp16qk_prefill(runtime_config(), qv, kk, vv, ao, n, n, nh, nkv, hd, scale,
                                    layer_sliding_window, cfg.attn_logit_softcap, /*q_offset=*/0,
                                    stream)) {
@@ -377,16 +386,9 @@
                                      /*causal=*/true, cfg.attn_logit_softcap,
                                      /*q_offset=*/0, stream, layer_sliding_window, attn_sinks);
         } else {
-            if (attn_sinks) {
-                static bool warned_sinks_fmha = false;
-                if (!warned_sinks_fmha) {
-                    warned_sinks_fmha = true;
-                    IMP_LOG_WARN("attention sinks: S-matrix too small (n=%d) — FMHA fallback IGNORES "
-                                 "sinks; output will be wrong. Lower the prefill chunk size.",
-                                 n);
-                }
-            }
-            // FMHA fallback: tiled O(n) memory chain.
+            // FMHA fallback: tiled O(n) memory chain. Sink-capable since #992
+            // (the dispatch routes sinks to the WMMA FMHA and throws instead
+            // of falling through to a sink-blind kernel).
             int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
             int64_t kv4s[4] = {1, (int64_t)n, (int64_t)nkv, (int64_t)hd};
             int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
@@ -395,7 +397,8 @@
             Tensor v4 = vv.reshape(4, kv4s);
             Tensor o4 = ao.reshape(4, o4s);
             attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
-                                       cfg.attn_logit_softcap, stream, runtime_config(), /*q_offset=*/0);
+                                       cfg.attn_logit_softcap, stream, runtime_config(), /*q_offset=*/0,
+                                       attn_sinks);
         }
 
         // Persist K, V into cache for later decode steps

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -314,7 +314,7 @@
                 Tensor o4 = ao.reshape(4, o4s);
                 attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
                                            cfg.attn_logit_softcap, stream, runtime_config(), q_offset,
-                                           attn_sinks);
+                                           static_cast<const half*>(attn_sinks));
             }
 
             if (!cap_replay && !used_eager_scratch) {
@@ -398,7 +398,7 @@
             Tensor o4 = ao.reshape(4, o4s);
             attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
                                        cfg.attn_logit_softcap, stream, runtime_config(), /*q_offset=*/0,
-                                       attn_sinks);
+                                       static_cast<const half*>(attn_sinks));
         }
 
         // Persist K, V into cache for later decode steps

--- a/tests/test_gpt_oss_sinks_ref.cu
+++ b/tests/test_gpt_oss_sinks_ref.cu
@@ -30,6 +30,7 @@
 
 #include "core/tensor.h"
 #include "compute/attention_cublas.h"
+#include "compute/attention_fmha_sm120.h"
 #include "compute/attention_paged_common.cuh"
 
 #include <vector>
@@ -182,6 +183,56 @@ std::vector<double> run_kernel(const std::vector<half>& Qh, const std::vector<ha
     return Od;
 }
 
+// Run the WMMA FMHA prefill (#992 sink support) with optional per-head sink
+// logits. Same memory layout as run_kernel ([seq, nh, hd] row-major); the
+// FMHA entry point takes 4D [batch, seq, nh, hd] views of the same buffers.
+std::vector<double> run_kernel_fmha(const std::vector<half>& Qh, const std::vector<half>& Kh,
+                                    const std::vector<half>& Vh, const std::vector<double>& sink_logit,
+                                    int q_len, int kv_len, int n_heads, int n_kv_heads, int head_dim,
+                                    bool causal, int sliding_window) {
+    AttnDevBufs b;
+    const size_t qn = static_cast<size_t>(q_len) * n_heads * head_dim;
+    const size_t kn = static_cast<size_t>(kv_len) * n_kv_heads * head_dim;
+
+    EXPECT_EQ(cudaMalloc(&b.Q, qn * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&b.K, kn * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&b.V, kn * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&b.O, qn * sizeof(half)), cudaSuccess);
+    cudaMemcpy(b.Q, Qh.data(), qn * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(b.K, Kh.data(), kn * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(b.V, Vh.data(), kn * sizeof(half), cudaMemcpyHostToDevice);
+
+    const half* sinks_ptr = nullptr;
+    if (!sink_logit.empty()) {
+        std::vector<half> sh(n_heads);
+        for (int h = 0; h < n_heads; h++) sh[h] = __float2half(static_cast<float>(sink_logit[h]));
+        EXPECT_EQ(cudaMalloc(&b.sinks, n_heads * sizeof(half)), cudaSuccess);
+        cudaMemcpy(b.sinks, sh.data(), n_heads * sizeof(half), cudaMemcpyHostToDevice);
+        sinks_ptr = b.sinks;
+    }
+
+    int64_t qshape[4] = {1, q_len, n_heads, head_dim};
+    int64_t kshape[4] = {1, kv_len, n_kv_heads, head_dim};
+    Tensor Q(b.Q, QType::F16, 4, qshape, true);
+    Tensor K(b.K, QType::F16, 4, kshape, true);
+    Tensor V(b.V, QType::F16, 4, kshape, true);
+    Tensor O(b.O, QType::F16, 4, qshape, true);
+
+    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    bool ok = fmha_sm120_prefill(Q, K, V, O, scale, causal, /*sliding_window=*/sliding_window,
+                                 /*softcap=*/0.0f, /*stream=*/nullptr, /*q_offset=*/0, sinks_ptr);
+    EXPECT_TRUE(ok) << "fmha_sm120_prefill declined the config";
+    cudaDeviceSynchronize();
+
+    std::vector<half> Oh(qn);
+    cudaMemcpy(Oh.data(), b.O, qn * sizeof(half), cudaMemcpyDeviceToHost);
+    b.free();
+
+    std::vector<double> Od(qn);
+    for (size_t i = 0; i < qn; i++) Od[i] = __half2float(Oh[i]);
+    return Od;
+}
+
 double max_rel_err(const std::vector<double>& got, const std::vector<double>& ref) {
     // Normalize by the RMS magnitude of the reference output, not per-element
     // |ref[i]|. Diffuse-softmax attention outputs are V-averages clustered
@@ -257,6 +308,49 @@ TEST(GptOssSinkRef, SinkLogitShiftMatchesReference) {
         double e = max_rel_err(got, ref);
         EXPECT_LT(e, kRelTol) << c.name << " sink rel err " << e;
         printf("[sink] %-18s with-sink rel=%.2e\n", c.name, e);
+    }
+}
+
+TEST(GptOssSinkRef, FmhaSinkMatchesReference) {
+    // #992: the WMMA FMHA folds the sink into its online-softmax init
+    // (m = sink, l = 1). Same fp64 reference and tolerance class as the
+    // cuBLAS test above — full-attention AND sliding-window configs (gpt-oss
+    // alternates SWA=128 layers, so the SWA×sink interaction is load-bearing).
+    for (const auto& c : kCfgs) {
+        auto Q = lcg_fill_f16(0x4001u, static_cast<size_t>(c.q_len) * c.n_heads * c.head_dim, 2.0f);
+        auto K = lcg_fill_f16(0x5002u, static_cast<size_t>(c.kv_len) * c.n_kv_heads * c.head_dim, 2.0f);
+        auto V = lcg_fill_f16(0x6003u, static_cast<size_t>(c.kv_len) * c.n_kv_heads * c.head_dim, 2.0f);
+
+        std::vector<double> sink(c.n_heads);
+        for (int h = 0; h < c.n_heads; h++)
+            sink[h] = -1.5 + 0.5 * (h % 7);
+
+        auto ref = ref_attention_sink(Q, K, V, sink, c.q_len, c.kv_len, c.n_heads, c.n_kv_heads,
+                                       c.head_dim, c.causal, c.sliding_window);
+        auto got = run_kernel_fmha(Q, K, V, sink, c.q_len, c.kv_len, c.n_heads, c.n_kv_heads,
+                                   c.head_dim, c.causal, c.sliding_window);
+        double e = max_rel_err(got, ref);
+        EXPECT_LT(e, kRelTol) << c.name << " FMHA sink rel err " << e;
+        printf("[sink] %-18s FMHA with-sink rel=%.2e\n", c.name, e);
+    }
+}
+
+TEST(GptOssSinkRef, FmhaNoSinkUnchanged) {
+    // sinks=nullptr must leave the FMHA's plain-softmax path bit-compatible
+    // with its pre-#992 behavior (init still -FLT_MAX/0): compare against the
+    // fp64 no-sink reference.
+    for (const auto& c : kCfgs) {
+        auto Q = lcg_fill_f16(0x4001u, static_cast<size_t>(c.q_len) * c.n_heads * c.head_dim, 2.0f);
+        auto K = lcg_fill_f16(0x5002u, static_cast<size_t>(c.kv_len) * c.n_kv_heads * c.head_dim, 2.0f);
+        auto V = lcg_fill_f16(0x6003u, static_cast<size_t>(c.kv_len) * c.n_kv_heads * c.head_dim, 2.0f);
+        std::vector<double> no_sink(c.n_heads, -INFINITY);
+        auto ref = ref_attention_sink(Q, K, V, no_sink, c.q_len, c.kv_len, c.n_heads, c.n_kv_heads,
+                                       c.head_dim, c.causal, c.sliding_window);
+        auto got = run_kernel_fmha(Q, K, V, {}, c.q_len, c.kv_len, c.n_heads, c.n_kv_heads, c.head_dim,
+                                   c.causal, c.sliding_window);
+        double e = max_rel_err(got, ref);
+        EXPECT_LT(e, kRelTol) << c.name << " FMHA no-sink rel err " << e;
+        printf("[sink] %-18s FMHA no-sink rel=%.2e\n", c.name, e);
     }
 }
 

--- a/tests/test_routing_decision.cpp
+++ b/tests/test_routing_decision.cpp
@@ -235,3 +235,28 @@ TEST(MoePrefillTable, GptOssNoCutlass3xFallsToLegacy) {
     EXPECT_EQ(select_moe_prefill_path(ModelArch::GPT_OSS, cfg, all_ready()),
               MoePrefillPath::LEGACY);
 }
+
+// ---- #992: learned-sink pre-gate ------------------------------------------
+
+TEST(AttnDispatchTable, SinksRouteToFMHAEvenWhenFA2Accepts) {
+    // gpt-oss learned sinks: only the FP16 WMMA FMHA folds them into its
+    // online softmax — FA2/MXFP4/FP8 must not serve sink configs.
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), all_accept(), /*has_sinks=*/true),
+              AttnPrefillPath::FMHA_SM120);
+}
+
+TEST(AttnDispatchTable, SinksWithFMHADeclineIsNoneNotBlackwell) {
+    // A sink-blind fallback would produce silently wrong output — the
+    // dispatcher throws (NONE), it must NOT fall through to Blackwell.
+    auto sup = all_accept();
+    sup.fmha_sm120_accepts = false;
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), sup, /*has_sinks=*/true),
+              AttnPrefillPath::NONE);
+}
+
+TEST(AttnDispatchTable, SinksWithFMHANeverIsNone) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_sm120 = "never";
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept(), /*has_sinks=*/true),
+              AttnPrefillPath::NONE);
+}


### PR DESCRIPTION
## What

gpt-oss prefill attention ran 92.4% on the legacy materialized cuBLAS path: every O(n) tier was gated on `!attn_sinks` (FA2 additionally declines hd=64). Worse, when a sink prompt's chunk overflowed the S-matrix, the executor fell into the tiled FMHA chain anyway and logged 'FMHA fallback IGNORES sinks; output will be wrong' — a silent-wrong-output hole.

The sink is a virtual extra logit column with no V contribution, which maps exactly onto the online-softmax state init: seed `row_m = sink[head]`, `row_l = 1` — every subsequent `l *= exp(m_old - m_new)` rescale keeps the sink term correct (identical math to the cuBLAS softmax's max/denominator join).

- `fmha_sm120_kernel`/`-prefill` take an optional per-head sinks pointer
- `attention_prefill_dispatch` pre-gates sinks to the WMMA FMHA tier and **throws on decline** instead of falling through to a sink-blind kernel
- executor: sinks follow the same FMHA-threshold policy as every other non-FA2 model (chunked + unchunked); heterogeneous shapes (Gemma-4) remain the only cuBLAS-exclusive config; the old WARN block is gone
- gpt-oss spec-verify chunks (n ≤ 32, hd ≠ 128) now take the tiled FMHA instead of per-shape cuBLAS algo churn (the #847 class)
- decision-table mirror + 3 routing tests for the sink pre-gate

## Correctness

- **fp64 reference parity** (new GTests in test_gpt_oss_sinks_ref.cu): FMHA-with-sink rel err 5.6e-3 (full) / 5.8e-3 (SWA=128) — same f16-score-chain error class as the cuBLAS sink path (5.3e-3 / 6.0e-3); no-sink FMHA regression case included.
- Single-path PPL isolation (deterministic, short corpus): old-cuBLAS == new-cuBLAS **bit-identical** (mean_nll 3.4966 both) — the cuBLAS path is untouched. FMHA arm 3.5204 (+0.68% NLL) is the WMMA-vs-cuBLAS reduction-order class on this order-hypersensitive model (a pure cuBLAS algo re-selection alone moved the same corpus +0.5% NLL earlier today) — adjudicated by the fp64 parity tests above, not by PPL.
- Greedy 200-token generation coherent (analysis/final channels), fallback-grep clean, `make verify-fast` green.

## Perf

pp512: not resolvable e2e (cuBLAS arm restart spread 17.2k–26.2k tok/s; measured delta −5.7% is inside that noise). pp2048: FMHA-preferred **+6.7%** (28.5k vs 26.7k, tight arms, 3 interleaved trials). Defaults keep the existing threshold policy (cuBLAS below `attention.fmha_prefill_threshold`), so headline numbers do not move; the win is correctness + the long-ctx/verify-chunk routing. No baseline refresh needed.

Closes #992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ