### PR TITLE
deps: bump CUTLASS to v4.6.0 and cpp-httplib to v0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   `auto` / `qo` (q+o only) / `on` / `off`.
 
 ### Changed
+- **Dependency bumps**: CUTLASS v4.5.3 → v4.6.0 (upstream changes are
+  CuTe-DSL/Python-centric; measured perf-neutral on sm_120 decode A/B —
+  Qwen3-8B Q8_0 +0.8%, Qwen3-14B NVFP4 −0.5%, within trial spread) and
+  cpp-httplib v0.48.0 → v0.50.1 (picks up three security fixes: multipart
+  `Content-Disposition` header injection, CRLF injection in chunked
+  trailers, TLS use-after-free in `SSLClient`/WebSocket teardown — imp-server
+  uses `SSLClient` for image-URL fetches). Dockerfile ARG defaults re-synced
+  with `cmake/imp-deps.cmake` (CUTLASS default had drifted at v4.5.2).
 - **`gemm.nvfp4_lm_head` is now `"auto"` with a per-model net rule** (#982,
   PR #990): ON for native BF16/F16 LM heads (+8-16% decode, +2.2% PPL — the
   long-standing documented trade) and for small dense GGUF heads

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ ENV CUDA_HOME=/usr/local/cuda
 # --build-arg from that file. The defaults below keep a bare `docker build .`
 # working and MUST match cmake/imp-deps.cmake.
 ARG IMP_DEP_GOOGLETEST_TAG=v1.17.0
-ARG IMP_DEP_CUTLASS_TAG=v4.5.2
-ARG IMP_DEP_HTTPLIB_TAG=v0.48.0
+ARG IMP_DEP_CUTLASS_TAG=v4.6.0
+ARG IMP_DEP_HTTPLIB_TAG=v0.50.1
 ARG IMP_DEP_NLOHMANN_JSON_TAG=v3.12.0
 RUN git clone --depth=1 --branch ${IMP_DEP_GOOGLETEST_TAG} https://github.com/google/googletest.git /deps/googletest \
  && git clone --depth=1 --branch ${IMP_DEP_CUTLASS_TAG}    https://github.com/NVIDIA/cutlass.git    /deps/cutlass    \

--- a/cmake/imp-deps.cmake
+++ b/cmake/imp-deps.cmake
@@ -8,6 +8,6 @@
 # Used by: CMakeLists.txt FetchContent_Declare GIT_TAG entries.
 
 set(IMP_DEP_GOOGLETEST_TAG    v1.17.0  CACHE STRING "googletest git tag")
-set(IMP_DEP_CUTLASS_TAG       v4.5.3   CACHE STRING "NVIDIA/cutlass git tag")
-set(IMP_DEP_HTTPLIB_TAG       v0.48.0  CACHE STRING "cpp-httplib git tag")
+set(IMP_DEP_CUTLASS_TAG       v4.6.0   CACHE STRING "NVIDIA/cutlass git tag")
+set(IMP_DEP_HTTPLIB_TAG       v0.50.1  CACHE STRING "cpp-httplib git tag")
 set(IMP_DEP_NLOHMANN_JSON_TAG v3.12.0  CACHE STRING "nlohmann/json git tag")


### PR DESCRIPTION
## What

- CUTLASS `v4.5.3` → `v4.6.0`
- cpp-httplib `v0.48.0` → `v0.50.1`
- Re-sync Dockerfile ARG defaults with `cmake/imp-deps.cmake` (the CUTLASS default had drifted at v4.5.2)
- CHANGELOG entry under Unreleased/Changed

## Why

**httplib** picks up three security fixes since 0.48.0: multipart `Content-Disposition` header injection (0.49.0), CRLF injection in chunked response trailers (0.50.0), and TLS use-after-free in `SSLClient`/WebSocket teardown (0.50.x). imp-server uses `httplib::SSLClient` for image-URL fetches (`handlers_chat_core.cpp`). The 0.50.0 breaking change — `Get(path, {{...}})` overload ambiguity — does not affect imp: no braced-initializer header calls in tree.

**CUTLASS 4.6.0** is CuTe-DSL/Python-centric upstream; taken to stay current on the primary GEMM path.

## Perf

Not a perf-moving change; baseline untouched. Validated with an interleaved same-session decode A/B (old vs new image, 3 trials each, 10 reps, `speculative.ngram=false`, healthy clocks 2865 MHz SM / 13801 MHz mem / ~484 W sampled during the runs):

| Model (tg256) | v4.5.3 median | v4.6.0 median | delta |
|---|---|---|---|
| Qwen3-8B Q8_0 (dense) | 203.3 | 204.9 | +0.8% (pairs +1.7/+3.0/−1.7%) |
| Qwen3-14B NVFP4 (CUTLASS path) | 125.5 | 122.9 | −0.5% pair mean, within trial spread |

NVFP4 pp512 read slightly higher on the new arm (~17.8k → ~18.4k tok/s), prefill noise notwithstanding. Full verify-fast with models mounted: gtests PASS, smoke PASS (baseline decode delta carried the depressed-host signature per issue 526 and was auto-degraded to WARN — hence the A/B above as the authoritative signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ