### PR TITLE
spec: route verify-chunk GEMMs through the NVFP4 decode overlay (#998)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   cost of −1.9%/−3.4% decode). Legacy `true`/`false` values still parse.
 
 ### Fixed
+- **#998 — n-gram spec decode −39% at moderate context on GGUF K-quants**:
+  the verify-chunk forward (M = 2..33) took the M>1 prefill dispatch, which
+  dequantizes the full quantized source per GEMM — on Qwen3-14B Q6_K a
+  verify step cost ~7x a decode step (`dequant_q6k` alone was 52% of the tg
+  window at ctx 2048), so speculation lost even at 100% accept and 4
+  tok/verify. Verify-chunk GEMMs now read the NVFP4 decode overlay in one
+  weight pass per MR≤4 tile (`gemm_nvfp4_batched`, same tiling as the
+  batched LM head; kill switch `speculative.verify_nvfp4_gemm`). 14B Q6_K
+  tg128 at ctx 2048: 91.9 → 153.2 tok/s (+67%, now ahead of spec-off
+  150.6); ctx 4096: 89.7 → 138.0. Qwen3-8B Q8_0 at ctx 2048: 209.8 → 312.6
+  (+49% — the single weight pass also beats the M-independent mmq_imma
+  path). Real prefills never take the branch; greedy output is
+  byte-identical to spec-off and to the previous dequant verify.
 - **Prefill CUDA graph replayed stale chunk geometry on continuation chunks**
   (#981): the captured chunk forward bakes `ctx_len`/`q_offset` as host args
   into the attention launches, and the graph was only invalidated on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,6 +619,7 @@ if(IMP_BUILD_TESTS)
         tests/test_nvfp4_compressed_tensors_ref.cu
         tests/test_nvfp4_outlier_ref.cu
         tests/test_nvfp4_gemv_kpar_loop.cu
+        tests/test_nvfp4_gemm_batched.cu
         tests/test_nvfp4_gemv_gemma3_dims.cu
         tests/test_nvfp4_gemm_graph_capture.cu
         # tests/test_turboquant.cu removed (TurboQuant retired Phase 5, 2026-05-17)

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -446,6 +446,7 @@ private:
     int cur_n_tokens_ = 0;         // set by forward_logits for use by run_ffn
     int cur_decode_step_ = 0;      // set by forward_logits for debug dump tagging
     bool cur_force_fp16_ = false;  // set by forward_logits, bypasses FP8 GEMM paths
+    bool cur_spec_verify_ = false; // set by forward_logits: spec-verify chunk (#998)
     bool cur_per_row_lm_ = false;  // set by forward_logits, per-row Q8_1 LM head
 
     // Programmatic Dependent Launch: when true, custom kernels have the PDL

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -203,7 +203,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
 
     // GemmContext for all weight GEMM dispatches in this function.
     auto ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config(), cur_force_fp16_,
-                                 model_->config().overrides.gemma4.force_mmvq);
+                                 model_->config().overrides.gemma4.force_mmvq, cur_spec_verify_);
 
     // 3. QKV projections:  [n, d] @ W^T -> [n, proj_dim]
     //    For decode (n=1) with matching quant types: fused RMSNorm→Q8_1→QKV GEMV.

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -114,7 +114,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
 
     // GemmContext for all weight GEMM dispatches in this function.
     auto ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config(), cur_force_fp16_,
-                                 model_->config().overrides.gemma4.force_mmvq);
+                                 model_->config().overrides.gemma4.force_mmvq, cur_spec_verify_);
 
     // 3. Gate and Up projections
     //    For decode (n=1): fuse RMSNorm→Q8_1→GEMV to avoid redundant quantization.

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -201,6 +201,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
     const int decode_step = (n == 1) ? s_decode_step : 0;
     cur_decode_step_ = decode_step;
     cur_force_fp16_ = state.force_fp16_gemm;
+    cur_spec_verify_ = state.spec_verify_chunk;
     cur_per_row_lm_ = state.per_row_lm_head;
 
     // Clear any stale CUDA error state before starting the forward pass.

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -264,6 +264,30 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         if (prefill == StorageTier::Undefined)
             prefill = h.primary_tier;
 
+        // Spec-verify chunk (#998): read the NVFP4 decode overlay in one
+        // weight pass per MR<=4 tile instead of dequantizing the source. On
+        // GGUF K-quants (no direct small-M kernel, e.g. Q6_K) the per-chunk
+        // dequant made a verify step cost ~7x a decode step (dequant_q6k =
+        // 52% of the tg window at ctx 2048, tg −39% vs spec-off). Reading
+        // the same weights as decode also aligns verify argmax with what
+        // the decode path would emit. M cap = largest capture bucket (33).
+        // Scoped to dequantable GGUF sources: native-ST NVFP4 weights already
+        // read NVFP4 directly via the CUTLASS prefill block below (and the
+        // prefill_routes_cutlass_nvfp4_ mirror above must stay in sync with
+        // every earlier return here — dequantable sources answer false there).
+        if (ctx.spec_verify_small_m && ctx.beta == 0.0f && M <= 33 &&
+            input.qtype == QType::F16 && output.qtype == QType::F16 &&
+            h.source_data != nullptr && dequant_gpu_supported(h.source_qtype)) {
+            auto it = ctx.wcache->nvfp4.find(h.source_data);
+            if (it != ctx.wcache->nvfp4.end()) {
+                gemm_nvfp4_batched(it->second, reinterpret_cast<const half*>(input.data),
+                                   reinterpret_cast<half*>(output.data),
+                                   static_cast<int>(h.shape[0]), static_cast<int>(h.shape[1]),
+                                   M, ctx.stream);
+                return;
+            }
+        }
+
         // Q4_K HMMA GEMM: in-SMEM dequant + FP16 HMMA m16n8k16 tile kernel.
         // Config-gated (gemm.q4k_hmma_enabled, default false). Bypasses
         // dequant-to-FP16 + cuBLAS by decoding Q4_K nibbles directly in SMEM.

--- a/src/exec/gemm_context.h
+++ b/src/exec/gemm_context.h
@@ -41,6 +41,13 @@ struct GemmContext {
     bool gemm_no_mmvq_q8_0 = false;
     bool gemm_no_dp4a_gemv = false;
 
+    // Spec-verify chunk forward (#998): small-M GEMMs (M <= largest capture
+    // bucket) prefer the NVFP4 decode overlay over the M>1 prefill dequant
+    // path. Set from InferenceState::spec_verify_chunk gated on
+    // speculative.verify_nvfp4_gemm; never set for real prefills, so prompt
+    // processing quality is unaffected.
+    bool spec_verify_small_m = false;
+
     // Quantization scratch buffers (non-owning)
     const QuantScratch* qscratch = nullptr;
 
@@ -50,7 +57,7 @@ struct GemmContext {
     // and gemm_kernel_gguf).
     static GemmContext make(cudaStream_t s, const WeightCaches& wc, const QuantScratch& qs,
                             const RuntimeConfig& rcfg, bool force_fp16 = false,
-                            bool force_mmvq = false) {
+                            bool force_mmvq = false, bool spec_verify = false) {
         GemmContext ctx;
         ctx.stream = s;
         ctx.wcache = &wc;
@@ -63,6 +70,7 @@ struct GemmContext {
         ctx.gemm_no_mmvq = rcfg.gemm.no_mmvq;
         ctx.gemm_no_mmvq_q8_0 = rcfg.gemm.no_mmvq_q8_0;
         ctx.gemm_no_dp4a_gemv = rcfg.gemm.no_dp4a_gemv;
+        ctx.spec_verify_small_m = spec_verify && rcfg.speculative.verify_nvfp4_gemm;
         return ctx;
     }
 

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -70,6 +70,12 @@ struct InferenceState {
     // and row-replicated block_tables. is_prefill stays true so everything
     // outside run_attention keeps the chunk-forward semantics.
     bool chunk_decode_attn = false;
+    // Spec-verify chunk forward (#998): small-M GEMMs may read the NVFP4
+    // decode overlay (one weight pass per MR tile) instead of the M>1
+    // prefill dequant path — on GGUF K-quants the per-chunk source dequant
+    // cost ~7x a decode step and made speculation net-negative. Set for
+    // every verify chunk regardless of the attention route.
+    bool spec_verify_chunk = false;
     const int* seq_offsets =
         nullptr;  // [n_sequences+1] for ragged prefill token offsets (optional, nullptr for decode)
 

--- a/src/quant/nvfp4_gemm.h
+++ b/src/quant/nvfp4_gemm.h
@@ -38,6 +38,15 @@ void gemv_nvfp4_kpar_fp32(const NvFP4QuantResult& A, const half* x, float* y, in
 void gemv_nvfp4_kpar_batched_fp32(const NvFP4QuantResult& A, const half* x, float* y, int N_out, int K,
                                   int n_act, cudaStream_t stream);
 
+// Batched-M FP16 GEMM for small-M chunk forwards (spec-verify, #998):
+// y[n_act, N_out] = x[n_act, K] @ A^T, reading each NVFP4 weight row once per
+// MR<=4 activation tile instead of dequantizing the source (the M>1 prefill
+// fallback costs a full FP16 materialization of the weight per call — 52% of
+// the decode window on Qwen3-14B Q6_K verify chunks). Same tiling as the
+// FP32 LM-head variant above.
+void gemm_nvfp4_batched(const NvFP4QuantResult& A, const half* x, half* y, int N_out, int K,
+                        int n_act, cudaStream_t stream);
+
 // Fused QKV: 3 weight matrices, shared input, separate outputs
 void gemv_nvfp4_qkv_fused(const NvFP4QuantResult& wq, const NvFP4QuantResult& wk, const NvFP4QuantResult& wv,
                           const half* x, half* yq, half* yk, half* yv, int q_rows, int k_rows, int v_rows,

--- a/src/quant/nvfp4_gemv_dense.cu
+++ b/src/quant/nvfp4_gemv_dense.cu
@@ -448,6 +448,102 @@ void gemv_nvfp4_kpar_batched_fp32(const NvFP4QuantResult& A, const half* x, floa
     }
 }
 
+// FP16-output twin of gemv_nvfp4_kpar_mb_fp32_kernel for spec-verify chunk
+// GEMMs (#998): one block per weight row n, the row decoded once and reused
+// across the MR activation rows of this launch.
+template <int MR>
+__global__ void __launch_bounds__(kKparThreads) gemv_nvfp4_kpar_mb_fp16_kernel(
+    const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
+    const half* __restrict__ x, half* __restrict__ y, int N_out, int K) {
+    const int n = blockIdx.x;
+    if (n >= N_out)
+        return;
+    const int tid = threadIdx.x;
+    const int n_mb = K / kMicroBlockSize;
+    const uint8_t* row_packed = packed_data + (int64_t)n * (K / 2);
+    const uint8_t* row_ms = micro_scales + (int64_t)n * n_mb;
+
+    float acc[MR];
+#pragma unroll
+    for (int m = 0; m < MR; ++m)
+        acc[m] = 0.0f;
+
+    for (int mi = tid; mi < n_mb; mi += kKparThreads) {
+        int byte_off = mi * 8;
+        uint2 packed2 = *reinterpret_cast<const uint2*>(row_packed + byte_off);  // weight read once
+        const uint8_t* pb = reinterpret_cast<const uint8_t*>(&packed2);
+        float wf[16];
+#pragma unroll
+        for (int b = 0; b < 8; ++b) {
+            uint32_t w_fp16x2;
+            asm("{ .reg .b8 t; cvt.u8.u32 t, %1; cvt.rn.f16x2.e2m1x2 %0, t; }"
+                : "=r"(w_fp16x2)
+                : "r"(static_cast<uint32_t>(pb[b])));
+            float2 wf2 = __half22float2(*reinterpret_cast<const half2*>(&w_fp16x2));
+            wf[b * 2] = wf2.x;
+            wf[b * 2 + 1] = wf2.y;
+        }
+        float cs = tensor_scale * fp8_e4m3_to_float_fast(row_ms[mi]);
+        const int elem_base = byte_off * 2;
+#pragma unroll
+        for (int m = 0; m < MR; ++m) {
+            const half* xm = x + (int64_t)m * K + elem_base;
+            const uint4 xv0 = *reinterpret_cast<const uint4*>(xm);
+            const uint4 xv1 = *reinterpret_cast<const uint4*>(xm + 8);
+            half2 xh[8];
+            *reinterpret_cast<uint4*>(&xh[0]) = xv0;
+            *reinterpret_cast<uint4*>(&xh[4]) = xv1;
+            float d = 0.0f;
+#pragma unroll
+            for (int b = 0; b < 8; ++b) {
+                float2 xf = __half22float2(xh[b]);
+                d = __fmaf_rn(wf[b * 2], xf.x, d);
+                d = __fmaf_rn(wf[b * 2 + 1], xf.y, d);
+            }
+            acc[m] = __fmaf_rn(d, cs, acc[m]);
+        }
+    }
+
+    __shared__ float warp_sums[kKparWarps];
+#pragma unroll
+    for (int m = 0; m < MR; ++m) {
+        float total = reduce_kpar(acc[m], tid, warp_sums);
+        if (tid == 0)
+            y[(int64_t)m * N_out + n] = __float2half(total);
+        __syncthreads();  // reuse warp_sums for the next activation row
+    }
+}
+
+// Batched-M FP16 GEMM for spec-verify chunks (#998). MR cap of 4 mirrors the
+// FP32 LM-head launcher: larger MR spills registers and loses to tiling.
+void gemm_nvfp4_batched(const NvFP4QuantResult& A, const half* x, half* y, int N_out, int K,
+                        int n_act, cudaStream_t stream) {
+    const auto* pd = reinterpret_cast<const uint8_t*>(A.packed_data);
+    const auto* ms = reinterpret_cast<const uint8_t*>(A.micro_scales);
+    const float ts = A.tensor_scale;
+    int done = 0;
+    while (done < n_act) {
+        const int rem = n_act - done;
+        const half* xm = x + (int64_t)done * K;
+        half* ym = y + (int64_t)done * N_out;
+        int used;
+        if (rem >= 4) {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<4>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 4;
+        } else if (rem >= 2) {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<2>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 2;
+        } else {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<1>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 1;
+        }
+        done += used;
+    }
+}
+
 void gemv_nvfp4_residual(const NvFP4QuantResult& A, const half* x, half* y, const half* residual, int M,
                          int K, cudaStream_t stream) {
     const int n_mb = K / kMicroBlockSize;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -294,6 +294,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("speculative.draft_ctx_cap", cfg.speculative.draft_ctx_cap);
     I("speculative.shallow_draft_ctx", cfg.speculative.shallow_draft_ctx);
     B("speculative.verify_decode_attn", cfg.speculative.verify_decode_attn);
+    B("speculative.verify_nvfp4_gemm", cfg.speculative.verify_nvfp4_gemm);
     B("speculative.moe", cfg.speculative.moe);
     I("speculative.k", cfg.speculative.k);
     B("speculative.suffix", cfg.speculative.suffix);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -748,6 +748,15 @@ struct RuntimeConfig {
         // +29% @12288. Dense non-MLA/non-SWA/non-MoE/non-hybrid only;
         // MoE/hybrid keep the FA2 chunk path. Kill switch for A/B.
         bool verify_decode_attn = true;
+        // #998: verify-chunk GEMMs (M <= largest capture bucket) read the
+        // NVFP4 decode overlay in one weight pass per MR tile instead of the
+        // M>1 prefill dequant path. On GGUF K-quants without a direct
+        // small-M kernel (Q6_K) the per-chunk source dequant cost ~7x a
+        // decode step (dequant = 52% of the tg window at ctx 2048 on
+        // Qwen3-14B Q6_K, tg -39% vs spec-off). Also aligns verify argmax
+        // with the decode path (same weights). Real prefills are never
+        // affected. Kill switch for A/B.
+        bool verify_nvfp4_gemm = true;
         // Speculation on MoE models with NATIVE-NVFP4 experts (the gate
         // additionally requires profile().moe_experts_nvfp4). Measured on
         // Qwen3-Coder-30B-FP4 (2026-07-02): code-edit +49-81% (93% accept,

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -527,6 +527,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     state.max_blocks_per_seq = 0;
     state.is_prefill = true;
     state.prefill_offset = p0;
+    state.spec_verify_chunk = true;
     state.kv_manager = kv_manager_.get();
     if (kv_manager_ && kv_manager_->residual_enabled()) state.kv_seq_id = req->id;
     if (capture_on) {

--- a/tests/test_nvfp4_gemm_batched.cu
+++ b/tests/test_nvfp4_gemm_batched.cu
@@ -1,0 +1,118 @@
+// gemm_nvfp4_batched: batched-M FP16-output NVFP4 GEMM for spec-verify chunks
+// (#998). The verify chunk forward (M = 2..33 rows) previously took the M>1
+// prefill dispatch, which on GGUF-with-NVFP4-overlay dequantizes the full
+// quantized source per GEMM — measured 52% of the tg window at ctx 2048 on
+// Qwen3-14B Q6_K (dequant_q6k_v2 329 ms of a 634 ms window, tg −39% vs
+// spec-off). The batched kernel reads each NVFP4 weight row once and reuses
+// it across up to 4 activation rows per pass (same MR tiling as the LM-head
+// gemv_nvfp4_kpar_batched_fp32).
+//
+// Reference path: gemm_nvfp4 (dequant → cuBLAS) on identical quantized
+// weights — the two paths must agree within FP16 accumulation-order noise.
+
+#include "quant/nvfp4_quant.h"
+#include "quant/nvfp4_gemm.h"
+#include "core/tensor.h"
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cmath>
+#include <vector>
+
+namespace imp {
+namespace {
+
+class GemmNvfp4Batched : public ::testing::Test {
+protected:
+    void SetUp() override { cudaStreamCreate(&stream_); }
+    void TearDown() override { cudaStreamDestroy(stream_); }
+
+    // Quantize a synthetic FP16 weight [N,K], run gemm_nvfp4_batched vs
+    // gemm_nvfp4 on the same activations [M,K], compare outputs [M,N].
+    void run_case(int N, int K, int M) {
+        std::vector<half> h_w(static_cast<size_t>(N) * K);
+        std::vector<half> h_a(static_cast<size_t>(M) * K);
+        for (size_t i = 0; i < h_w.size(); ++i)
+            h_w[i] = __float2half(((static_cast<int>(i * 17u) % 31) - 15) * 0.01f);
+        for (size_t i = 0; i < h_a.size(); ++i)
+            h_a[i] = __float2half(((static_cast<int>(i * 23u) % 29) - 14) * 0.02f);
+
+        half *d_w = nullptr, *d_a = nullptr, *d_y = nullptr, *d_y_ref = nullptr;
+        cudaMalloc(&d_w, h_w.size() * sizeof(half));
+        cudaMalloc(&d_a, h_a.size() * sizeof(half));
+        cudaMalloc(&d_y, static_cast<size_t>(M) * N * sizeof(half));
+        cudaMalloc(&d_y_ref, static_cast<size_t>(M) * N * sizeof(half));
+        cudaMemcpy(d_w, h_w.data(), h_w.size() * sizeof(half), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_a, h_a.data(), h_a.size() * sizeof(half), cudaMemcpyHostToDevice);
+
+        int64_t wshape[2] = {N, K};
+        Tensor w_t(d_w, QType::F16, 2, wshape, /*on_device=*/true);
+        NvFP4QuantResult qr;
+        quantize_fp16_to_nvfp4(w_t, qr, stream_);
+        cudaStreamSynchronize(stream_);
+
+        cudaMemsetAsync(d_y, 0, static_cast<size_t>(M) * N * sizeof(half), stream_);
+        gemm_nvfp4_batched(qr, d_a, d_y, N, K, M, stream_);
+        cudaStreamSynchronize(stream_);
+        ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+        int64_t ashape[2] = {M, K};
+        int64_t yshape[2] = {M, N};
+        Tensor a_t(d_a, QType::F16, 2, ashape, /*on_device=*/true);
+        Tensor y_ref_t(d_y_ref, QType::F16, 2, yshape, /*on_device=*/true);
+        cudaMemsetAsync(d_y_ref, 0, static_cast<size_t>(M) * N * sizeof(half), stream_);
+        gemm_nvfp4(qr, a_t, y_ref_t, stream_);
+        cudaStreamSynchronize(stream_);
+
+        std::vector<half> h_y(static_cast<size_t>(M) * N);
+        std::vector<half> h_y_ref(static_cast<size_t>(M) * N);
+        cudaMemcpy(h_y.data(), d_y, h_y.size() * sizeof(half), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_y_ref.data(), d_y_ref, h_y_ref.size() * sizeof(half), cudaMemcpyDeviceToHost);
+
+        int n_nan = 0;
+        float max_abs_diff = 0.0f;
+        for (size_t i = 0; i < h_y.size(); ++i) {
+            float a = __half2float(h_y[i]);
+            float b = __half2float(h_y_ref[i]);
+            if (std::isnan(a))
+                ++n_nan;
+            float d = std::fabs(a - b);
+            if (d > max_abs_diff)
+                max_abs_diff = d;
+        }
+        EXPECT_EQ(n_nan, 0) << "batched GEMM produced NaNs (N=" << N << " K=" << K << " M=" << M << ")";
+        EXPECT_LT(max_abs_diff, 0.5f)
+            << "gemm_nvfp4_batched diverges from gemm_nvfp4 (N=" << N << " K=" << K << " M=" << M << ")";
+
+        free_nvfp4_result(qr);
+        cudaFree(d_w);
+        cudaFree(d_a);
+        cudaFree(d_y);
+        cudaFree(d_y_ref);
+    }
+
+    cudaStream_t stream_ = nullptr;
+};
+
+// Qwen3-14B verify-chunk shapes: d_model=5120, d_ff=13824. M covers the
+// capture buckets {3,5,9,17,33} plus the MR tiling edges (1,2,4,5).
+TEST_F(GemmNvfp4Batched, MatchesDequantRefAtAttnProjDims) {
+    for (int M : {1, 2, 3, 4, 5, 9}) run_case(5120, 5120, M);
+}
+
+TEST_F(GemmNvfp4Batched, MatchesDequantRefAtFfnDims) {
+    for (int M : {2, 5, 17, 33}) run_case(13824, 5120, M);
+}
+
+TEST_F(GemmNvfp4Batched, MatchesDequantRefAtDownProjDims) {
+    for (int M : {5, 9}) run_case(5120, 13824, M);
+}
+
+// Odd K edge: micro-block count not divisible by thread count.
+TEST_F(GemmNvfp4Batched, MatchesDequantRefAtNarrowDims) {
+    run_case(704, 2816, 7);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Closes #998.

## Root cause

The verify-chunk forward (M = 2..33 rows, `is_prefill=true`) took the M>1 prefill GEMM dispatch, which on GGUF sources **dequantizes the full quantized weight per GEMM**. Qwen3-14B Q6_K has no direct small-M kernel (unlike Q8_0 mmq / Q4_K–Q5_K dp4a), so every verify step paid ~11.3 GB source read + ~46 GB FP16 round-trip: nsys (software CUDA tracing — hardware tracing lost GPU timestamps after the 07-14 WSL driver update) shows `dequant_q6k_v2` at **52% of the tg window** (329 ms of 634 ms busy), plus 185 ms nvjet GEMMs on the dequant output. A verify step cost ~46 ms vs a 6.7 ms decode step (~7x), so speculation lost −39% even at 100% accept and 4.0 tok/verify.

Two datapoints from the issue explained along the way:
- **"Spec wins at ctx 512" was never verification** — the bench prompt yields zero drafts at pp512 (`verify_steps=0, miss_steps=50`); the speed came from the miss/burst decode path. Verification first engages at pp1024+.
- The −19% pp tax with spec ON is not a prefill-side spec cost (prefill timing covers only prefill chunks); it reads as the known cuBLAS algo-selection/VRAM-layout restart-variance class. Not addressed here.

## Fix

New `gemm_nvfp4_batched` — FP16-output twin of the batched LM-head GEMV (`gemv_nvfp4_kpar_batched_fp32`): one block per weight row, the NVFP4 row decoded once and reused across MR≤4 activation rows per pass. A spec-verify-only dispatch branch reads the NVFP4 decode overlay instead of dequantizing, plumbed `InferenceState::spec_verify_chunk` → `GemmContext::spec_verify_small_m` (same pattern as `force_fp16_gemm`). Scoped to dequantable GGUF sources (native-ST NVFP4 prefill already reads NVFP4 via CUTLASS; the `prefill_routes_cutlass_nvfp4_` mirror contract holds), beta=0, M ≤ 33 (largest capture bucket). Kill switch: `speculative.verify_nvfp4_gemm` (default on).

Side benefit: verify now reads the **same weights as decode**, aligning verify argmax with what the decode path would emit.

## Measured (RTX 5090, 5 reps, healthy clocks sampled)

| Config | tg128 at ctx 2048 | tg128 at ctx 4096 |
|---|---|---|
| 14B Q6_K spec-on **before** | 91.9 | 89.7 |
| 14B Q6_K spec-on **after** | **153.2 (+67%)** | **138.0 (+54%)** |
| 14B Q6_K spec-off | 150.6 | — |
| 8B Q8_0 spec-on before → after | 209.8 → **312.6 (+49%)** | — |

- Kill switch reproduces the old 91.9 exactly — delta fully attributable.
- The single NVFP4 weight pass also beats Q8_0's M-independent `mmq_imma` path.
- Greedy output **byte-identical** across spec-on/spec-off/old-dequant-verify (14B, 400 tokens).
- Composes with graph-captured verify (`speculative.capture=true`: 153.1, clean).
- verify-fast with models mounted: decode/prefill/long-ctx gates PASS, degeneration smoke PASS.
- Unit test `GemmNvfp4Batched` pins the kernel against the dequant reference at attn/FFN/down dims, M ∈ {1,2,3,4,5,7,9,17,33}.

Perf baselines untouched: the pp512 gate/north-star configs never engage verification (0 drafts at 512), and the north-star `tg128_at_ctx_2048` field is measured spec-off by definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhnpVUzKtwvBcc1GABVdNZ