### PR TITLE
deps: bump CUTLASS to v4.6.1; mount models in verify.sh docker re-exec

### DIFF
--- a/cmake/imp-deps.cmake
+++ b/cmake/imp-deps.cmake
@@ -8,6 +8,6 @@
 # Used by: CMakeLists.txt FetchContent_Declare GIT_TAG entries.
 
 set(IMP_DEP_GOOGLETEST_TAG    v1.17.0  CACHE STRING "googletest git tag")
-set(IMP_DEP_CUTLASS_TAG       v4.6.0   CACHE STRING "NVIDIA/cutlass git tag")
+set(IMP_DEP_CUTLASS_TAG       v4.6.1   CACHE STRING "NVIDIA/cutlass git tag")
 set(IMP_DEP_HTTPLIB_TAG       v0.50.1  CACHE STRING "cpp-httplib git tag")
 set(IMP_DEP_NLOHMANN_JSON_TAG v3.12.0  CACHE STRING "nlohmann/json git tag")

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -48,6 +48,7 @@ if ! command -v cmake >/dev/null 2>&1 && [ "${IMP_VERIFY_IN_DOCKER:-0}" != "1" ]
     echo "verify: host cmake unavailable — re-executing in imp:test container"
     exec docker run --rm --gpus all \
         -v "$ROOT":/src -w /src \
+        -v "$HOME/models":"$HOME/models":ro \
         -e IMP_VERIFY_IN_DOCKER=1 \
         -e IMP_VERIFY_BIN=/usr/local/bin/imp-cli \
         -e IMP_VERIFY_TESTS=/usr/local/bin/imp-tests \


### PR DESCRIPTION
## What

- Bump CUTLASS pin in `cmake/imp-deps.cmake` from v4.6.0 to v4.6.1 (patch release from 2026-07-15, CuTe DSL fixes only — no changes to the C++ GEMM collectives imp uses).
- Fix a silent gap in `scripts/verify.sh`: the auto-re-exec into the `imp:test` container (clean-host workflow, no cmake on host) only mounted the repo, so the `models/` symlink farm resolved to an unmounted `$HOME/models` and the **perf gate + smoke prompts were silently SKIPped**. The re-exec now mounts the symlink target read-only, so the full gate actually runs.

## Validation

- `make build` with the new pin: clean.
- `make verify-fast` (now with the perf gate actually executing): all gates PASS — decode 341–365 tok/s vs baseline 269.5 (well above threshold; baseline is stale and a guarded re-pin is queued separately), prefill within threshold, smoke prompts pass.
- Perf-neutral change; no baseline update in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)