### PR TITLE
fix: #982 net rule silently voided nvfp4_lm_head_gdn on quantized GDN hybrids

### DIFF
--- a/src/exec/pre_dequant_internal.h
+++ b/src/exec/pre_dequant_internal.h
@@ -31,12 +31,18 @@ namespace imp::pre_dequant_internal {
 //    dense models (4B +6.6% decode/+3.8% PPL, 8B +5.8%/+2.6%); net-NEGATIVE at
 //    14B Q6_K (+1.9%/+2.1%) and 30B-A3B Q4_K_M (+3.7%/+5.0%), 35B a wash.
 //    auto → ON iff dense && d_model <= 4096 (the measured net-positive set).
+//    EXCEPTION — GDN/SSM hybrids: their head trade is owned by
+//    gemm.nvfp4_lm_head_gdn (GOAL-listed, default ON: +5.3% decode / +1.4% PPL
+//    on the Qwen3.6-35B UD-Q4_K_M hero, re-measured 2026-07-15). The dense/MoE
+//    net rule's is_dense=false arm silently voided that flag on quantized
+//    hybrids and cost the hero −5% decode — pass is_gdn_hybrid so auto defers
+//    to the callers' nvfp4_lm_head_gdn gate instead.
 //  - NATIVE (F16/BF16) heads: 2 B/elem cuBLAS GEMV is the alternative, the
 //    cache is a 4x byte win (+8-16% decode, +2.2% PPL, owner-accepted trade,
 //    GOAL-listed). auto → ON (unchanged).
 // GDN/SSM hybrids remain additionally gated by gemm.nvfp4_lm_head_gdn.
 inline bool nvfp4_lm_head_enabled(const RuntimeConfig& rc, bool quantized_source, bool is_dense,
-                                  int d_model) {
+                                  int d_model, bool is_gdn_hybrid = false) {
     const std::string& v = rc.gemm.nvfp4_lm_head;
     if (v == "on" || v == "true" || v == "1")
         return true;
@@ -44,6 +50,8 @@ inline bool nvfp4_lm_head_enabled(const RuntimeConfig& rc, bool quantized_source
         return false;
     if (!quantized_source)
         return true;
+    if (is_gdn_hybrid)
+        return true;  // decided by the callers' gemm.nvfp4_lm_head_gdn gate
     return is_dense && d_model <= 4096;
 }
 

--- a/src/exec/pre_dequant_phase3_nvfp4_decode.cu
+++ b/src/exec/pre_dequant_phase3_nvfp4_decode.cu
@@ -140,8 +140,11 @@ void QuantPipeline::nvfp4_decode_collect_candidates_(const ModelConfig& cfg,
         const QType head_qtype = model_->out_proj_.qtype;
         const bool quantized_head = head_qtype != QType::F16 && head_qtype != QType::BF16;
         // #982 net rule for quantized heads — see nvfp4_lm_head_enabled().
+        // GDN/SSM hybrids defer to the gdn_head_ok gate above instead of the
+        // dense/MoE net rule (GOAL-listed nvfp4_lm_head_gdn trade).
         const bool head_on = nvfp4_lm_head_enabled(runtime_config(), /*quantized_source=*/true,
-                                                   prof.is_dense, cfg.d_model);
+                                                   prof.is_dense, cfg.d_model,
+                                                   /*is_gdn_hybrid=*/prof.is_gdn || prof.is_ssm);
         if (quantized_head) {
             if (head_on && gdn_head_ok)
                 collect_weight_nvfp4(model_->output_proj(), head_qtype);


### PR DESCRIPTION
## What

`nvfp4_lm_head_enabled()` (the #982 net rule, PR #990) returns `is_dense && d_model <= 4096` for quantized (GGUF) heads on auto. Its `is_dense=false` arm swallowed GDN/SSM hybrids, so the GOAL-listed `gemm.nvfp4_lm_head_gdn` trade (default ON) became silently ineffective on every quantized-source hybrid: the Qwen3.6-35B UD-Q4_K_M hero lost its NVFP4 head cache and dropped from ~272 to ~259 tok/s decode.

This PR passes `is_gdn_hybrid` into the rule; for quantized GDN/SSM hybrids auto now defers to the callers' existing `nvfp4_lm_head_gdn` gate (its documented contract) instead of the dense/MoE net rule. Dense and pure-MoE behavior is unchanged (30B-A3B Q4_K_M stays skipped, verified via init log).

## Why

Same-day competitive sweep (2026-07-15, llama.cpp build 10015): the 35B hybrid hero lead had shrunk to +8% (246.9 back-to-back / 258.7 isolated vs llama 227.7) from the documented +18%. Bisected to this rule (landed 07-13 between sweeps). Flag-rot class already documented in the 07-12 parity audit: opt-out claims must be measured, and this one regressed the opposite direction — a documented default-ON trade went dead.

## Perf

Interleaved A/B, 3 trials/arm, spec-off, pp512/tg128, healthy clocks sampled, Qwen3.6-35B-A3B UD-Q4_K_M:

| arm | tg128 |
|---|---|
| main (2fbcaa37) | 258.8 / 259.0 / 259.4 |
| this PR (defaults) | 271.8 / 273.1 / 273.6 (**+5.5%**) |

vs llama.cpp b10015 same day: 227.7 ± 5.8 → lead restored to **+19%**. PPL trade is the known, GOAL-listed one (+1.4% on this hero per the 2026-07-12 parity audit — smallest of all heroes). No gated-baseline model is affected (Q8 dense and 14B north-star behavior unchanged); `tests/perf_baseline.json` needs no refresh.

## Verification

- `make verify-fast` PASS (graphs gate 2.39x, smoke, perf gates)
- degen_suite on the 35B server build: 36/40 PASS; the 4 constrained-decoding FAILs reproduce identically on main and are pre-existing → filed #1014
- Init-log check: 35B head cached, 30B-A3B still skipped (net rule intact)
- stderr grep clean (no NaN/fallback/capture errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWC5Hbut7zT8R5THUTYmYA