### PR TITLE
fix(constrained): enforce minItems/maxItems; cap enum-items arrays at enum cardinality (#1014)

### DIFF
--- a/src/compute/json_schema.cpp
+++ b/src/compute/json_schema.cpp
@@ -310,6 +310,14 @@ private:
                 node->items = parse_schema_object();
                 if (!has_type)
                     node->type = SchemaType::ARRAY;
+            } else if (key == "minItems") {
+                long v = 0;
+                if (parse_int(v))
+                    node->min_items = static_cast<int>(v);
+            } else if (key == "maxItems") {
+                long v = 0;
+                if (parse_int(v))
+                    node->max_items = static_cast<int>(v);
             } else if (key == "enum") {
                 skip_ws();
                 if (expect('[')) {
@@ -520,6 +528,8 @@ std::unique_ptr<SchemaNode> SchemaNode::clone() const {
     c->min_length = min_length;
     c->max_length = max_length;
     c->pattern_nfa = pattern_nfa;  // shared; compiled NFA is immutable
+    c->min_items = min_items;
+    c->max_items = max_items;
     c->ref_name = ref_name;
     for (auto& [name, def] : defs)
         c->defs.emplace_back(name, def->clone());

--- a/src/compute/json_schema.h
+++ b/src/compute/json_schema.h
@@ -120,6 +120,9 @@ struct SchemaNode {
 
     // ARRAY
     std::unique_ptr<SchemaNode> items;
+    // ARRAY constraints (JSON Schema "minItems" / "maxItems"). -1 = unset.
+    int min_items = -1;
+    int max_items = -1;
 
     // ENUM
     std::vector<std::string> enum_values;

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -6,6 +6,7 @@
 #include <cuda_fp16.h>
 #include <float.h>
 #include <algorithm>
+#include <climits>
 #include <cstring>
 #include <utility>
 
@@ -16,6 +17,24 @@ namespace imp {
 // reachable via recursive $ref schemas; hitting the cap forces closure (still
 // schema-valid — any finite nesting satisfies a recursive schema).
 static constexpr size_t kMaxSchemaStackDepth = 192;
+
+// Effective item ceiling for an array frame: explicit "maxItems" wins; an
+// enum-items array without one is capped at the enum's cardinality — a list
+// that repeats an enum member more often than the enum has members carries no
+// information, and an unbounded enum array is the observed degeneration loop
+// of a reasoning model whose think block was budget-force-closed (#1014:
+// `["tech","tech","tech",...` until max_tokens). Same anti-runaway class as
+// the number-digit cap (#751). INT_MAX = unbounded.
+static int effective_max_items(const SchemaNode* root, const SchemaNode* array_node) {
+    if (!array_node)
+        return INT_MAX;
+    if (array_node->max_items >= 0)
+        return array_node->max_items;
+    const SchemaNode* items = resolve_schema_ref(root, array_node->items.get());
+    if (items && items->type == SchemaType::ENUM && !items->enum_values.empty())
+        return static_cast<int>(items->enum_values.size());
+    return INT_MAX;
+}
 
 // ---------------------------------------------------------------------------
 // Initialization
@@ -249,7 +268,8 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
         }
 
         case SchemaPhase::ARRAY_OPEN: {
-            uint16_t mask = CAT_CLOSE_BRACKET;
+            // minItems > 0: the empty array may not close yet.
+            uint16_t mask = (f.node && f.node->min_items > 0) ? 0 : CAT_CLOSE_BRACKET;
             // Allow value start for first item ($ref items resolve first)
             const SchemaNode* items =
                 f.node ? resolve_schema_ref(schema_.get(), f.node->items.get()) : nullptr;
@@ -281,8 +301,18 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
             return mask;
         }
 
-        case SchemaPhase::ARRAY_AFTER_ITEM:
-            return CAT_COMMA | CAT_CLOSE_BRACKET;
+        case SchemaPhase::ARRAY_AFTER_ITEM: {
+            uint16_t mask = 0;
+            if (f.item_count < effective_max_items(schema_.get(), f.node))
+                mask |= CAT_COMMA;
+            if (!f.node || f.node->min_items < 0 || f.item_count >= f.node->min_items)
+                mask |= CAT_CLOSE_BRACKET;
+            // Contradictory bounds (maxItems < minItems): let the array close
+            // rather than deadlock the mask.
+            if (mask == 0)
+                mask = CAT_CLOSE_BRACKET;
+            return mask;
+        }
 
         case SchemaPhase::STRING_VALUE:
             return CAT_STRING_CHAR | CAT_QUOTE;
@@ -610,8 +640,10 @@ static void sim_fixup_parent(std::vector<SchemaFrame>& stk) {
     if (parent.phase == SchemaPhase::OBJECT_COLON)
         parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
     else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM)
+             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM) {
         parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
+        parent.item_count++;  // one completed item per child-frame pop
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -831,6 +863,8 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
             if (space)
                 return true;
             if (c == ']') {
+                if (f.node && f.node->min_items > 0)
+                    return false;  // empty array below minItems
                 stk.pop_back();
                 sim_fixup_parent(stk);
                 return true;
@@ -845,12 +879,22 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
         case SchemaPhase::ARRAY_AFTER_ITEM: {
             if (space)
                 return true;
+            const int max_items = effective_max_items(schema_.get(), f.node);
+            const bool can_close =
+                !f.node || f.node->min_items < 0 || f.item_count >= f.node->min_items;
             if (c == ',') {
+                // At the item ceiling the array must close (unless closing is
+                // itself illegal via contradictory minItems — then allow the
+                // comma rather than deadlock; the mask mirrors this).
+                if (f.item_count >= max_items && can_close)
+                    return false;
                 if (f.node && f.node->items)
                     push_value(f.node->items.get());
                 return true;
             }
             if (c == ']') {
+                if (!can_close && f.item_count < max_items)
+                    return false;  // below minItems and comma is still legal
                 stk.pop_back();
                 sim_fixup_parent(stk);
                 return true;

--- a/tests/test_schema_constrain.cu
+++ b/tests/test_schema_constrain.cu
@@ -363,6 +363,105 @@ TEST(SchemaConstrainTest, EnumAndIntegerComboTokensValidated) {
 }
 
 // ---------------------------------------------------------------------------
+// minItems / maxItems (#1014) — the degeneration guard: a budget-force-closed
+// reasoning model loops enum array items (`["tech","tech",...`) to max_tokens.
+// Explicit maxItems must hard-stop the array; an enum-items array without one
+// is capped at the enum's cardinality; minItems blocks premature close.
+// ---------------------------------------------------------------------------
+
+namespace {
+// Shared vocab for the array-bounds tests:
+//  0        1      2       3    4     5    6    7    8    9    10   11
+std::vector<std::string> array_vocab() {
+    return {"<unk>", "<s>", "</s>", "{", "\"", "t", ":", "[", "]", ",", "a", "}"};
+}
+constexpr int kTokOpenBrace = 3, kTokQuote = 4, kTokKey = 5, kTokColon = 6;
+constexpr int kTokOpenBracket = 7, kTokCloseBracket = 8, kTokComma = 9, kTokItemA = 10;
+
+// Drive `{"t":[` then `n` complete items ("a"), leaving the FSM in
+// ARRAY_AFTER_ITEM (or ARRAY_OPEN for n=0).
+void drive_array(SchemaConstrainer& sc, int n_items) {
+    for (int t : {kTokOpenBrace, kTokQuote, kTokKey, kTokQuote, kTokColon, kTokOpenBracket})
+        sc.update(t);
+    for (int i = 0; i < n_items; i++) {
+        if (i > 0)
+            sc.update(kTokComma);
+        sc.update(kTokQuote);
+        sc.update(kTokItemA);
+        sc.update(kTokQuote);
+    }
+}
+}  // namespace
+
+TEST(SchemaConstrainTest, MaxItemsMasksCommaAtCap) {
+    SKIP_IF_NO_CUDA();
+    auto toks = array_vocab();
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"t":{"type":"array","maxItems":2,)"
+        R"("items":{"type":"string"}}},"required":["t"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    drive_array(sc, 1);
+    auto one = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(one[kTokComma]) << "below maxItems the array may continue";
+    EXPECT_TRUE(one[kTokCloseBracket]) << "no minItems — close always legal";
+    // Item 2 on the same FSM: `,"a"` — now at the cap.
+    sc.update(kTokComma), sc.update(kTokQuote), sc.update(kTokItemA), sc.update(kTokQuote);
+    auto capped = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_FALSE(capped[kTokComma]) << "at maxItems the comma must be masked";
+    EXPECT_TRUE(capped[kTokCloseBracket]) << "']' must stay legal at the cap";
+}
+
+TEST(SchemaConstrainTest, EnumItemsArrayCappedAtCardinality) {
+    SKIP_IF_NO_CUDA();
+    auto toks = array_vocab();
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    // Two-member enum, NO maxItems: effective cap = 2 (see effective_max_items).
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"t":{"type":"array",)"
+        R"("items":{"type":"string","enum":["a","aa"]}}},"required":["t"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    drive_array(sc, 2);
+    auto capped = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_FALSE(capped[kTokComma])
+        << "enum-items array without maxItems must cap at the enum cardinality";
+    EXPECT_TRUE(capped[kTokCloseBracket]) << "']' must stay legal at the cap";
+}
+
+TEST(SchemaConstrainTest, MinItemsBlocksPrematureClose) {
+    SKIP_IF_NO_CUDA();
+    auto toks = array_vocab();
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"t":{"type":"array","minItems":2,)"
+        R"("items":{"type":"string"}}},"required":["t"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    drive_array(sc, 0);
+    auto empty = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_FALSE(empty[kTokCloseBracket]) << "empty array below minItems may not close";
+    // First item on the same FSM: `"a"`.
+    sc.update(kTokQuote), sc.update(kTokItemA), sc.update(kTokQuote);
+    auto one = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_FALSE(one[kTokCloseBracket]) << "one item below minItems=2 may not close";
+    EXPECT_TRUE(one[kTokComma]) << "the array must be allowed to continue";
+    sc.update(kTokComma), sc.update(kTokQuote), sc.update(kTokItemA), sc.update(kTokQuote);
+    auto two = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(two[kTokCloseBracket]) << "minItems satisfied — close must be legal";
+}
+
+// ---------------------------------------------------------------------------
 // $ref / $defs (issue #555) — pydantic/zod emit $defs+$ref for EVERY nested
 // model, so this is the agent-framework path, not an exotic corner.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The schema FSM declared `SchemaFrame::item_count` but never maintained it, and the schema parser ignored `minItems`/`maxItems` entirely — every array was unbounded. This PR:

- parses `minItems`/`maxItems` into `SchemaNode` (clone included),
- counts completed items in `sim_fixup_parent` (single source of truth for both the real update path and per-token mask simulation),
- masks `,` at the item ceiling and `]` below `minItems`, in both the category mask and `sim_advance` (contradictory bounds degrade to allowing close rather than deadlocking),
- default-caps an **enum-items array without explicit maxItems at the enum's cardinality** — same anti-runaway class as the #751 number-digit cap; a list repeating an enum member more often than the enum has members carries no information.

## Why (#1014)

The degen_suite constrained category fails on Qwen3.6-35B with `["tech","tech","tech",...` until max_tokens. Root cause chain, established by probe: at the suite's `max_tokens=200`, the think-budget logic force-closes the model's reasoning mid-sentence (think length scales exactly with max_tokens: 375/414/495 chars at 200/220/256, natural close at 585 with 300), and the yanked model degenerates inside the unbounded array state — greedy `,` never loses to `]`. With the cap, the FSM forces closure after |enum| items and the output is schema-valid.

## Verification

- 3 new GTests (`MaxItemsMasksCommaAtCap`, `EnumItemsArrayCappedAtCardinality`, `MinItemsBlocksPrematureClose`); full schema/json constrain suite 38/38 PASS.
- degen_suite constrained category on the 35B server: was 3-4/7 FAIL → **7/7 PASS**; full suite 39/40 (the remaining intermittent is `json_object` — generic JSON mode, no schema to cap; same forced-think-close root cause, noted in #1014).
- `make verify-fast` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWC5Hbut7zT8R5THUTYmYA