### PR TITLE
feat(spec): round-robin verify at batch>1 with pipeline yield + draft-depth floor — experimental, default off (#1003)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-vision test-perf test-golden bench bench-agentic check-gpu verify verify-fast verify-chunked gen-perf-baseline install-hooks format format-check tidy sanitize coverage
+.PHONY: roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-vision test-perf test-golden test-agents bench bench-agentic check-gpu verify verify-fast verify-chunked gen-perf-baseline install-hooks format format-check tidy sanitize coverage
 
 # Check that no other process is using the GPU (games, other inference, etc.)
 check-gpu:
@@ -130,6 +130,22 @@ bench-agentic: build check-gpu
 	python3 tools/agent_bench.py --url http://localhost:8080 --model $(AGENTIC_MODEL) --concurrency 1,4,16; \
 	echo "--- multi-turn replay ---"; \
 	python3 tools/agent_replay_bench.py --url http://localhost:8080 --model $(AGENTIC_MODEL) --turns 16
+
+# Agent-harness E2E battery (#1007): boots a real imp-server and drives the
+# wire patterns real agent harnesses generate — multi-turn tool loops in the
+# Anthropic (/v1/messages), OpenAI chat and /v1/responses dialects, with
+# cache_control reuse, FSM-enforced tool_choice and streaming delta assembly.
+# Gates on every check (exit 1 on failure). GPU + local model, like test-server.
+test-agents: build check-gpu
+	@echo "=== imp agent-loop battery — model=$(AGENTIC_MODEL) ==="
+	@docker rm -f imp-agent-suite >/dev/null 2>&1 || true
+	@docker run -d --name imp-agent-suite --gpus all -p 8080:8080 \
+		-v $(HOME)/models:/models $(DOCKER_IMG) \
+		imp-server --host 0.0.0.0 --model /models/$(AGENTIC_MODEL) >/dev/null
+	@echo "waiting for server..."; \
+	for i in $$(seq 1 90); do curl -sf http://localhost:8080/health >/dev/null 2>&1 && break; sleep 2; done; \
+	trap 'docker rm -f imp-agent-suite >/dev/null 2>&1' EXIT; \
+	python3 tools/analysis/agent_loop_suite.py --url http://localhost:8080
 
 # Golden output comparison (greedy, temp=0)
 test-golden: build

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -767,6 +767,19 @@ struct RuntimeConfig {
         // perf-baseline decode signal stays raw (verify inherits grouped-GEMM
         // restart variance).
         bool moe = true;
+        // #1003 stage 1 (EXPERIMENTAL, default off): at decode batch > 1, ONE
+        // request per step may run its spec verify (round-robin, cyclic id
+        // order) while the remaining rows decode batched; the pipelined
+        // batched decode yields its chain every 8 steps so turns can fire.
+        // Verified mechanics (2026-07-15, Qwen3-8B echo workload at batch 4):
+        // 9-12 verify turns/request, 85-98% accept, 54-62 tok/verify, outputs
+        // coherent. Measured NET: ~0 — the verify gains were offset by the
+        // yield breaks + pipeline re-entries on that workload, and shallow
+        // drafts are guarded by a depth floor (min_draft = 2x batch) because
+        // the whole batch pays for the verify (~-10% unguarded). Flip on for
+        // deep-draft fan-out workloads (code-edit suffix echo, Coder-30B
+        // class); the healthy-host bench matrix decides the default.
+        bool batch_rr = false;
         int k = 16;          // draft tokens per verify step (verify cost is ~flat in k)
         // SuffixDecoding-style indexed drafting (arXiv 2411.04975):
         // hash-indexed suffix matching (O(1) amortized vs the legacy O(n)

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -386,6 +386,9 @@ private:
         // (the chained forward writes their next KV slot), so free_sequence
         // et al. are deferred to the drain (finish_request_release_).
         std::vector<std::shared_ptr<Request>> deferred_release;
+        // #1003: chained steps since the last spec-yield probe — the chain
+        // breaks every N steps so the plain path's round-robin verify can run.
+        int steps_since_spec_yield = 0;
     };
     BatchedDecodePipeline bd_pipe_;
     // Mapped-pinned block-table patch staging for the chain-advance kernel
@@ -585,6 +588,10 @@ private:
     cudaEvent_t pf_staging_evt_ = nullptr;
 
     // ── Penalty token buffer ─────────────────────────────────────────
+    // #1003: round-robin cursor for batched spec verify — id of the request
+    // that ran the last verify turn at batch > 1 (cyclic id order).
+    int spec_rr_last_id_ = -1;
+
     int32_t* d_penalty_tokens_ = nullptr;
     // Embedding pooling scratch (#1005): [d_model] fp32 chunk partial sums,
     // consumed synchronously per chunk (host accumulation on the request) so
@@ -687,7 +694,10 @@ private:
     // matching prefix. Implemented in engine_spec_ngram.cpp.
     // Returns true when it handled this decode step (tokens emitted);
     // false → caller falls through to the normal decode path.
-    bool step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream);
+    // min_draft > 0 (#1003 batch-RR): soft-decline (return false, no miss
+    // accounting) when the draft is shallower — at batch > 1 the whole batch
+    // pays for the verify, so only deep drafts are worth a turn.
+    bool step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream, int min_draft = 0);
     // #847 capturability census for the verify chunk forward (see
     // diagnostics.spec_capture_probe). Runs the forward via stream capture +
     // graph launch when possible, eagerly otherwise.

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1163,6 +1163,51 @@ void Engine::step_decode(cudaStream_t dec_stream) {
         }
     }
 
+    // #1003 stage 1: at batch > 1 (dense, non-recurrent), ONE request per
+    // step may run its spec verify while the rest decode batched below —
+    // round-robin in cyclic id order (the hybrid-rotation pattern), so every
+    // eligible request gets verify turns under sub-agent fan-out instead of
+    // silently losing speculation to the batch-size-1 dispatch gate above.
+    // The verify emits that request's tokens for this step; it is removed
+    // from this step's batched decode and rejoins next step.
+    if (decode_batch.size() > 1 && !ssm_state_ && runtime_config_.speculative.batch_rr &&
+        runtime_config_.speculative.ngram) {
+        int cand = -1;
+        int best_id = INT_MAX, wrap_id = INT_MAX, wrap_idx = -1;
+        for (size_t i = 0; i < decode_batch.size(); ++i) {
+            auto& r = decode_batch[i];
+            if (!spec_ngram_enabled_(*r))
+                continue;
+            spec_maybe_rearm_(*r);
+            if (!spec_ngram_gates_ok_(*r))
+                continue;
+            const int id = r->id;
+            if (id > spec_rr_last_id_ && id < best_id) {
+                best_id = id;
+                cand = static_cast<int>(i);
+            }
+            if (id < wrap_id) {
+                wrap_id = id;
+                wrap_idx = static_cast<int>(i);
+            }
+        }
+        if (cand < 0)
+            cand = wrap_idx;  // wrap around (or stay -1: none eligible)
+        if (cand >= 0) {
+            auto holder = decode_batch[cand];
+            // Depth floor ~2x batch: the verify must plausibly emit more
+            // tokens than the batch-wide stall it costs (see min_draft).
+            const int min_draft = 2 * static_cast<int>(decode_batch.size());
+            if (step_spec_verify_(holder, dec_stream, min_draft)) {
+                spec_rr_last_id_ = holder->id;
+                decode_batch.erase(decode_batch.begin() + cand);
+                if (decode_batch.empty())
+                    return;
+                // fall through: the remaining rows decode batched this step
+            }
+        }
+    }
+
     // SSM/GDN: the recurrent scan kernels are single-sequence, so decode one
     // sequence per step. The old resize(1) kept the OLDEST active request
     // every step — concurrent sessions serialized head-of-line (the first
@@ -2413,6 +2458,7 @@ bool Engine::pipeline_enter_(std::vector<std::shared_ptr<Request>>& rows, const 
     bd_pipe_.base_state = state;
     bd_pipe_.parity = 0;
     bd_pipe_.in_flight = false;
+    bd_pipe_.steps_since_spec_yield = 0;
     if (pipeline_enqueue_next_(1, stream)) {
         bd_pipe_.in_flight = true;
         bd_pipe_.parity = 1;
@@ -2464,6 +2510,24 @@ void Engine::step_decode_pipeline_(cudaStream_t stream) {
     }
     if (cont)
         cont = pipeline_batch_eligible_(bd_pipe_.rows);
+
+    // #1003: yield the chain periodically so the plain path's round-robin
+    // spec verify gets a turn — once in flight the pipeline otherwise chains
+    // until the composition changes, and batch>1 speculation never fires
+    // (observed verify_steps=1 per request). Fields-only candidate check;
+    // the draft-depth economics (min_draft) run in the RR branch. The chain
+    // re-engages on the following step via the normal plain-path entry.
+    if (cont && runtime_config_.speculative.batch_rr && runtime_config_.speculative.ngram &&
+        !ssm_state_ && ++bd_pipe_.steps_since_spec_yield >= 8) {
+        bd_pipe_.steps_since_spec_yield = 0;
+        for (const auto& r : bd_pipe_.rows) {
+            if (r->status == RequestStatus::DECODING && spec_ngram_enabled_(*r) &&
+                !r->spec_ngram_given_up) {
+                cont = false;
+                break;
+            }
+        }
+    }
 
     const int next_parity = bd_pipe_.parity ^ 1;
     const bool chained = cont && pipeline_enqueue_next_(next_parity, stream);

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -295,7 +295,7 @@ SuffixDraftIndex& Engine::spec_suffix_index_(const Request& req) {
     return it->second;
 }
 
-bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream) {
+bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream, int min_draft) {
     const auto& scfg = runtime_config_.speculative;
     const int kv_bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
 
@@ -355,6 +355,14 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         draft = mtp_take_draft_(*req);
         draft_from_mtp = !draft.empty();
     }
+    // #1003 batch-RR economics: at batch > 1 the WHOLE batch waits for the
+    // verify forward (~1.4-2.6x a decode step) while only this request
+    // benefits — a shallow draft is net-negative (measured -10% aggregate at
+    // batch 4 on shallow drafts). Soft-decline below the caller's depth
+    // floor: no miss accounting, no give-up pressure — the request decodes
+    // batched this step and gets its next turn with a hopefully deeper draft.
+    if (min_draft > 0 && static_cast<int>(draft.size()) < min_draft)
+        return false;
     if (draft.empty()) {
         spec_stats_.miss_steps++;
         if (++req->spec_consecutive_misses >= scfg.give_up_after && scfg.give_up_after > 0 &&

--- a/tools/analysis/agent_loop_suite.py
+++ b/tools/analysis/agent_loop_suite.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Agent-harness E2E battery (#1007, stage 1).
+
+Drives imp-server with the exact wire patterns real agent harnesses generate —
+multi-turn tool loops in all three dialects — as a repeatable gate:
+
+  anthropic-loop   /v1/messages: forced tool_use -> tool_result -> final answer,
+                   cache_control prefix reuse across turns, streaming event order
+  openai-loop      /v1/chat/completions: tool_choice=required -> role:tool ->
+                   final answer; streaming tool_calls delta assembly
+  responses-loop   /v1/responses: OpenAI Agents SDK dialect — response.created,
+                   function_call_arguments.delta assembly, response.completed
+
+Pass = every check green: tool calls parse, arguments match the tool's schema,
+the final answer uses the tool result, no stream stalls (>30s gap = fail).
+Stdlib-only, mirrors tools/analysis/degen_suite.py conventions.
+
+Usage:
+  python3 tools/analysis/agent_loop_suite.py [--url http://localhost:8080]
+                                             [--only anthropic-loop,openai-loop]
+Exit codes: 0 = clean, 1 = failures, 2 = server unreachable.
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+TOOLS_OAI = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}]
+
+TOOLS_ANTH = [{
+    "name": "get_weather",
+    "description": "Get the current weather for a city",
+    "input_schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}]
+
+TOOL_RESULT_TEXT = "19 degrees celsius, light rain"
+PROMPT = "What's the weather in Paris right now? Use the tool."
+SYSTEM = ("You are a terse weather assistant. Always answer with the exact "
+          "temperature the tool reports. " + "Padding for cacheable prefix. " * 40)
+
+
+class Suite:
+    def __init__(self, url):
+        self.url = url
+        self.model = self._model_id()
+        self.results = []
+
+    def _model_id(self):
+        with urllib.request.urlopen(self.url + "/v1/models", timeout=30) as r:
+            return json.load(r)["data"][0]["id"]
+
+    def record(self, cat, name, ok, detail=""):
+        self.results.append((cat, name, ok, detail))
+        mark = "\033[32mPASS\033[0m" if ok else "\033[31mFAIL\033[0m"
+        print(f"  [{mark}] {name}" + ("" if ok else f": {detail}"))
+
+    def post(self, path, body, timeout=120):
+        req = urllib.request.Request(self.url + path, json.dumps(body).encode(),
+                                     {"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r)
+
+    def post_sse(self, path, body, timeout=120):
+        """Collect SSE events; fail on inter-event gaps > 30s (stream stall)."""
+        req = urllib.request.Request(self.url + path, json.dumps(body).encode(),
+                                     {"Content-Type": "application/json"})
+        events = []
+        last = time.monotonic()
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            for raw in r:
+                now = time.monotonic()
+                if now - last > 30:
+                    raise RuntimeError("stream stalled > 30s between events")
+                last = now
+                line = raw.decode().strip()
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    events.append(json.loads(line[6:]))
+        return events
+
+    # ---- anthropic-loop -----------------------------------------------------
+
+    def run_anthropic_loop(self):
+        print("== anthropic-loop ==")
+        cat = "anthropic-loop"
+        sysblk = [{"type": "text", "text": SYSTEM,
+                   "cache_control": {"type": "ephemeral"}}]
+        base = {"model": self.model, "max_tokens": 400, "system": sysblk,
+                "tools": TOOLS_ANTH,
+                "tool_choice": {"type": "tool", "name": "get_weather"}}
+        msgs = [{"role": "user", "content": PROMPT}]
+
+        # Turn 1: forced tool call.
+        r = self.post("/v1/messages", {**base, "messages": msgs})
+        tool_use = next((b for b in r.get("content", []) if b.get("type") == "tool_use"), None)
+        self.record(cat, "turn 1: stop_reason is tool_use",
+                    r.get("stop_reason") == "tool_use", f"got {r.get('stop_reason')}")
+        self.record(cat, "turn 1: tool_use block present", tool_use is not None,
+                    f"content={json.dumps(r.get('content'))[:120]}")
+        if not tool_use:
+            return
+        self.record(cat, "turn 1: forced tool name honored",
+                    tool_use.get("name") == "get_weather", f"got {tool_use.get('name')}")
+        args_ok = isinstance(tool_use.get("input"), dict) and "city" in tool_use["input"]
+        self.record(cat, "turn 1: input matches the tool schema", args_ok,
+                    f"input={tool_use.get('input')}")
+
+        # Turn 2: tool_result -> final answer must carry the tool's value.
+        msgs = msgs + [
+            {"role": "assistant", "content": [tool_use]},
+            {"role": "user", "content": [{"type": "tool_result",
+                                          "tool_use_id": tool_use.get("id", ""),
+                                          "content": TOOL_RESULT_TEXT}]},
+        ]
+        r2 = self.post("/v1/messages",
+                       {**base, "tool_choice": {"type": "auto"}, "messages": msgs})
+        text = " ".join(b.get("text", "") for b in r2.get("content", [])
+                        if b.get("type") == "text")
+        self.record(cat, "turn 2: final answer uses the tool result", "19" in text,
+                    f"text={text[:120]!r}")
+        cache_read = r2.get("usage", {}).get("cache_read_input_tokens", 0)
+        self.record(cat, "turn 2: cache_control prefix reused", cache_read > 0,
+                    f"cache_read_input_tokens={cache_read}")
+
+        # Streaming: event order + input_json_delta assembly.
+        events = self.post_sse("/v1/messages", {**base, "messages":
+                               [{"role": "user", "content": PROMPT}], "stream": True})
+        types = [e.get("type") for e in events]
+        self.record(cat, "stream: message_start first",
+                    bool(types) and types[0] == "message_start", f"first={types[:1]}")
+        self.record(cat, "stream: message_stop terminates",
+                    "message_stop" in types, f"types={types[-3:]}")
+        frags = "".join(e["delta"].get("partial_json", "") for e in events
+                        if e.get("type") == "content_block_delta" and
+                        e.get("delta", {}).get("type") == "input_json_delta")
+        ok_json = True
+        if frags:
+            try:
+                json.loads(frags)
+            except ValueError:
+                ok_json = False
+        self.record(cat, "stream: input_json_delta assembles to valid JSON",
+                    ok_json and bool(frags), f"frags={frags[:80]!r}")
+
+    # ---- openai-loop --------------------------------------------------------
+
+    def run_openai_loop(self):
+        print("== openai-loop ==")
+        cat = "openai-loop"
+        base = {"model": self.model, "max_tokens": 400, "temperature": 0.0,
+                "tools": TOOLS_OAI}
+        msgs = [{"role": "system", "content": SYSTEM},
+                {"role": "user", "content": PROMPT}]
+
+        # Turn 1: required tool call (FSM-enforced since #1017).
+        r = self.post("/v1/chat/completions",
+                      {**base, "tool_choice": "required", "messages": msgs})
+        choice = r["choices"][0]
+        tcs = choice["message"].get("tool_calls") or []
+        self.record(cat, "turn 1: finish_reason is tool_calls",
+                    choice.get("finish_reason") == "tool_calls",
+                    f"got {choice.get('finish_reason')}")
+        self.record(cat, "turn 1: exactly one tool call parses", len(tcs) == 1,
+                    f"n={len(tcs)}")
+        if not tcs:
+            return
+        try:
+            args = json.loads(tcs[0]["function"]["arguments"])
+            args_ok = "city" in args
+        except ValueError:
+            args_ok = False
+        self.record(cat, "turn 1: arguments match the tool schema", args_ok,
+                    f"args={tcs[0]['function']['arguments'][:80]}")
+
+        # Turn 2: tool result -> final answer.
+        msgs = msgs + [
+            {"role": "assistant", "tool_calls": tcs, "content": None},
+            {"role": "tool", "tool_call_id": tcs[0]["id"], "content": TOOL_RESULT_TEXT},
+        ]
+        r2 = self.post("/v1/chat/completions", {**base, "messages": msgs})
+        text = r2["choices"][0]["message"].get("content") or ""
+        self.record(cat, "turn 2: final answer uses the tool result", "19" in text,
+                    f"text={text[:120]!r}")
+
+        # Streaming tool-call delta assembly.
+        req = urllib.request.Request(
+            self.url + "/v1/chat/completions",
+            json.dumps({**base, "tool_choice": "required", "stream": True,
+                        "messages": [{"role": "system", "content": SYSTEM},
+                                     {"role": "user", "content": PROMPT}]}).encode(),
+            {"Content-Type": "application/json"})
+        name, frags = "", ""
+        last = time.monotonic()
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            for raw in resp:
+                now = time.monotonic()
+                if now - last > 30:
+                    self.record(cat, "stream: no stalls", False, "gap > 30s")
+                    return
+                last = now
+                line = raw.decode().strip()
+                if not line.startswith("data: ") or line == "data: [DONE]":
+                    continue
+                d = json.loads(line[6:])
+                for tc in (d["choices"][0].get("delta", {}).get("tool_calls") or []):
+                    fn = tc.get("function", {})
+                    name += fn.get("name", "") or ""
+                    frags += fn.get("arguments", "") or ""
+        ok_json = False
+        try:
+            ok_json = "city" in json.loads(frags)
+        except ValueError:
+            pass
+        self.record(cat, "stream: tool_calls deltas assemble to a valid call",
+                    name == "get_weather" and ok_json,
+                    f"name={name!r} args={frags[:80]!r}")
+
+    # ---- responses-loop -----------------------------------------------------
+
+    def run_responses_loop(self):
+        print("== responses-loop ==")
+        cat = "responses-loop"
+        body = {"model": self.model, "max_output_tokens": 400, "stream": True,
+                "tools": [{"type": "function", "name": "get_weather",
+                           "description": "Get the current weather for a city",
+                           "parameters": TOOLS_OAI[0]["function"]["parameters"]}],
+                "tool_choice": "required",
+                "input": [{"role": "user", "content": PROMPT}]}
+        try:
+            events = self.post_sse("/v1/responses", body)
+        except urllib.error.HTTPError as e:
+            self.record(cat, "endpoint available", False, f"HTTP {e.code}")
+            return
+        types = [e.get("type") for e in events]
+        self.record(cat, "response.created emitted", "response.created" in types,
+                    f"types={types[:3]}")
+        self.record(cat, "response.completed terminates",
+                    "response.completed" in types, f"types={types[-3:]}")
+        frags = "".join(e.get("delta", "") for e in events
+                        if e.get("type") == "response.function_call_arguments.delta")
+        ok_json = False
+        try:
+            ok_json = "city" in json.loads(frags)
+        except ValueError:
+            pass
+        self.record(cat, "function_call_arguments.delta assembles", ok_json,
+                    f"frags={frags[:80]!r}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://localhost:8080")
+    ap.add_argument("--only", default="",
+                    help="comma list: anthropic-loop,openai-loop,responses-loop")
+    args = ap.parse_args()
+
+    try:
+        suite = Suite(args.url)
+    except Exception as e:
+        print(f"server unreachable at {args.url}: {e}")
+        return 2
+
+    only = {c for c in args.only.split(",") if c} or None
+    t0 = time.monotonic()
+    if not only or "anthropic-loop" in only:
+        suite.run_anthropic_loop()
+    if not only or "openai-loop" in only:
+        suite.run_openai_loop()
+    if not only or "responses-loop" in only:
+        suite.run_responses_loop()
+
+    fails = [r for r in suite.results if not r[2]]
+    dt = time.monotonic() - t0
+    print("=" * 60)
+    print(f"agent_loop_suite: {len(suite.results)} checks, {len(fails)} FAIL ({dt:.0f}s)")
+    for cat, name, _, detail in fails:
+        print(f"  FAIL [{cat}] {name}: {detail}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What (stage 1 of #1003, experimental — `speculative.batch_rr`, default OFF)

Sub-agent fan-out lost speculation entirely: the verify dispatch gated on `decode_batch.size() == 1`. This PR adds the issue's stage-1 round-robin:

- At batch > 1 (dense, non-recurrent), ONE request per step may run its spec verify (cyclic id order, the hybrid-rotation pattern); it is removed from that step's batched decode and the remaining rows decode normally in the same step.
- **Draft-depth floor**: `step_spec_verify_` gains a `min_draft` soft-decline (no miss accounting, no give-up pressure) — the RR turn requires a draft ≥ 2× batch size, because the whole batch pays the verify stall (~1.4–2.6× a decode step). Unguarded shallow-draft RR measured **−10% aggregate** at batch 4.
- **Pipeline yield**: once the pipelined batched decode is in flight it chains until the composition changes, so RR turns never fired (observed `verify_steps=1` per request). The chain now yields every 8 steps when a spec-eligible row exists; it re-engages on the following step via the normal entry path.

## Measured (Qwen3-8B Q8_0, batch 4, 2026-07-15 evening)

- Mechanics verified: 9–12 verify turns per request, **85–98% accept, 54–62 tok/verify** on a code-echo workload; outputs coherent; 3-arm divergences are the pre-existing #957 batch-composition class (the two no-RR arms diverge from each other identically).
- Net throughput: **~0 on echo** (verify gains ≈ yield + pipeline re-entry overhead), noise-dominated on shallow workloads (content flips swamp the signal at ±15%).

Hence **default OFF**: the capability and its guards are in and correct, but the default flip needs the healthy-host bench matrix on the deep-draft fan-out workloads this is for (Coder-30B code-edit class, 15.9 tok/verify) — tracked in #1003.

## Verification

- test-core KVCache/Batch 54/54, test-e2e ContinuousBatching PASS, `make verify-fast` functional gates PASS (decode-baseline check reads −5.8% = the documented evening host drift, main-identical; default-off makes this diff inert for the bench anyway).
- Default-off path exercised as the `norr` arm of every A/B in this campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWC5Hbut7zT8R5THUTYmYA