### PR TITLE
perf(spec): batch>1 round-robin verify default ON — adaptive yield cadence closes the draft-poor overhead (#1003)

### DIFF
--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -767,19 +767,20 @@ struct RuntimeConfig {
         // perf-baseline decode signal stays raw (verify inherits grouped-GEMM
         // restart variance).
         bool moe = true;
-        // #1003 stage 1 (EXPERIMENTAL, default off): at decode batch > 1, ONE
-        // request per step may run its spec verify (round-robin, cyclic id
-        // order) while the remaining rows decode batched; the pipelined
-        // batched decode yields its chain every 8 steps so turns can fire.
-        // Verified mechanics (2026-07-15, Qwen3-8B echo workload at batch 4):
-        // 9-12 verify turns/request, 85-98% accept, 54-62 tok/verify, outputs
-        // coherent. Measured NET: ~0 — the verify gains were offset by the
-        // yield breaks + pipeline re-entries on that workload, and shallow
-        // drafts are guarded by a depth floor (min_draft = 2x batch) because
-        // the whole batch pays for the verify (~-10% unguarded). Flip on for
-        // deep-draft fan-out workloads (code-edit suffix echo, Coder-30B
-        // class); the healthy-host bench matrix decides the default.
-        bool batch_rr = false;
+        // #1003 stage 1: at decode batch > 1, ONE request per step may run
+        // its spec verify (round-robin, cyclic id order) while the remaining
+        // rows decode batched. Three guards make it pay: a draft-depth floor
+        // (min_draft = 2x batch — the whole batch stalls for the verify, so
+        // shallow drafts measured -10% unguarded), a pipeline yield (the
+        // chained batched decode otherwise never gives a turn), and an
+        // ADAPTIVE yield cadence (8 -> 64 steps exponential backoff on empty
+        // turns; fruitless chain breaks alone cost -1.5..-2.7% before it).
+        // Default-ON matrix (Coder-30B NVFP4, 2026-07-15, 2 trials/cell,
+        // stream-free host): code-edit +7.9/+11.0% at batch 8 (twice,
+        // non-overlapping trials), +2.6/+4.4% at 16; diverse chat neutral
+        // (+2.2/+3.5% at 4/8, remaining negatives inside the +-6% intra-arm
+        // trial spread). Batch-1 behavior unchanged. Kill switch for A/B.
+        bool batch_rr = true;
         int k = 16;          // draft tokens per verify step (verify cost is ~flat in k)
         // SuffixDecoding-style indexed drafting (arXiv 2411.04975):
         // hash-indexed suffix matching (O(1) amortized vs the legacy O(n)

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -591,6 +591,11 @@ private:
     // #1003: round-robin cursor for batched spec verify — id of the request
     // that ran the last verify turn at batch > 1 (cyclic id order).
     int spec_rr_last_id_ = -1;
+    // Adaptive yield cadence: the pipeline breaks its chain every this many
+    // steps to offer a verify turn. Doubles (up to 64) whenever a turn comes
+    // up empty (soft-decline / no candidate) so draft-poor batches pay ~no
+    // break overhead; resets to 8 on a successful verify.
+    int spec_rr_yield_interval_ = 8;
 
     int32_t* d_penalty_tokens_ = nullptr;
     // Embedding pooling scratch (#1005): [d_model] fp32 chunk partial sums,

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1193,19 +1193,25 @@ void Engine::step_decode(cudaStream_t dec_stream) {
         }
         if (cand < 0)
             cand = wrap_idx;  // wrap around (or stay -1: none eligible)
+        bool verified = false;
         if (cand >= 0) {
             auto holder = decode_batch[cand];
             // Depth floor ~2x batch: the verify must plausibly emit more
             // tokens than the batch-wide stall it costs (see min_draft).
             const int min_draft = 2 * static_cast<int>(decode_batch.size());
             if (step_spec_verify_(holder, dec_stream, min_draft)) {
+                verified = true;
                 spec_rr_last_id_ = holder->id;
                 decode_batch.erase(decode_batch.begin() + cand);
-                if (decode_batch.empty())
-                    return;
-                // fall through: the remaining rows decode batched this step
             }
         }
+        // Adaptive yield cadence: empty turns (shallow drafts / no candidate)
+        // back the pipeline-break interval off exponentially — a draft-poor
+        // batch measured -1.5..-2.7% from fruitless chain breaks alone.
+        spec_rr_yield_interval_ = verified ? 8 : std::min(spec_rr_yield_interval_ * 2, 64);
+        if (verified && decode_batch.empty())
+            return;
+        // fall through: the remaining rows decode batched this step
     }
 
     // SSM/GDN: the recurrent scan kernels are single-sequence, so decode one
@@ -2518,7 +2524,7 @@ void Engine::step_decode_pipeline_(cudaStream_t stream) {
     // the draft-depth economics (min_draft) run in the RR branch. The chain
     // re-engages on the following step via the normal plain-path entry.
     if (cont && runtime_config_.speculative.batch_rr && runtime_config_.speculative.ngram &&
-        !ssm_state_ && ++bd_pipe_.steps_since_spec_yield >= 8) {
+        !ssm_state_ && ++bd_pipe_.steps_since_spec_yield >= spec_rr_yield_interval_) {
         bd_pipe_.steps_since_spec_yield = 0;
         for (const auto& r : bd_pipe_.rows) {
             if (r->status == RequestStatus::DECODING && spec_ngram_enabled_(*r) &&


### PR DESCRIPTION
## What (completes #1003 stage 1 — follow-up to #1021)

Flips `speculative.batch_rr` to **default ON**, justified by the decision matrix #1021 asked for, plus the third guard that made it safe:

- **Adaptive yield cadence**: the pipeline-chain break interval backs off exponentially (8 → 64 steps) whenever a verify turn comes up empty (soft-decline / no candidate) and resets to 8 on a successful verify. Fruitless chain breaks alone cost −1.5…−2.7% on draft-poor traffic before this; after, diverse chat measures neutral-to-positive.

## Decision matrix (Coder-30B NVFP4, batch 4/8/16, 2 trials/cell, stream-free verified host)

| workload | batch | OFF | ON | delta |
|---|---:|---:|---:|---:|
| code-edit | 8 | 802.6 | **890.8** | **+11.0%** (non-overlapping trials; prior run +7.9%) |
| code-edit | 16 | 769.0 | 802.7 | +4.4% (positive in both runs) |
| diverse | 4 | 405.8 | 414.6 | +2.2% |
| diverse | 8 | 612.8 | 634.3 | +3.5% |
| code-edit | 4 | 494.0 | 474.8 | −3.9% (inside the ±6% intra-arm spread; prior run −0.3%) |
| diverse | 16 | 825.0 | 799.8 | −3.1% (one intra-arm outlier trial; heavy overlap) |

The target workload — sub-agent fan-out with code-edit patterns — gains +8–11% at batch 8 reproducibly; every negative cell sits inside trial noise. Batch-1 behavior is untouched.

## Verification

- `make verify-fast` fully green including the decode gate: **tg128 = 287.88 vs baseline 288.02 (−0.05%)** — the evening's "host drift" was definitively identified as concurrent video streaming on the Windows side (3–4% GPU, invisible to compute-apps queries and below the check-gpu utilization threshold); with the stream off the band restored exactly. Pushed through the regular pre-push hook (no bypass).
- test-core KVCache/Batch 54/54 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWC5Hbut7zT8R5THUTYmYA