### PR TITLE
cleanup(server): de-duplicate tool-call body decode + <think> demux

### DIFF
--- a/tests/test_reasoning_reconcile.cpp
+++ b/tests/test_reasoning_reconcile.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "reasoning_split.h"
+#include "utils.h"  // extract_reasoning, strip_think_block
 
 using imp::server::reconcile_thinking_with_prompt_tail;
 
@@ -55,4 +56,31 @@ TEST(ThinkingReconcile, StrayCloseWithoutOpenKeepsCurrent) {
     // </think> with no <think> in-window is not a closed block — keep current.
     EXPECT_TRUE(reconcile_thinking_with_prompt_tail(/*current=*/true, kNotExplicit,
                                                     /*think=*/false, /*close=*/true));
+}
+
+// ---------------------------------------------------------------------------
+// strip_think_block edge cases exercised by the shared split_last_think helper.
+// extract_reasoning + the strip_think_block happy path are already covered in
+// test_sse_stream_utils.cpp (issue #557, which also uses extract_reasoning as
+// the oracle for the streaming splitter). These pin the strip-only edge paths
+// that the shared-helper refactor restructured — an unclosed trailing/leading
+// <think> is discarded (the model never finished the block).
+// ---------------------------------------------------------------------------
+
+TEST(StripThinkBlock, DiscardsUnclosedTrailingThink) {
+    std::string text = "<think>reasoning</think><think>unclosed";
+    strip_think_block(text);
+    EXPECT_EQ(text, "");
+}
+
+TEST(StripThinkBlock, EmptyContentAfterCloseClears) {
+    std::string text = "<think>a</think>";
+    strip_think_block(text);
+    EXPECT_EQ(text, "");
+}
+
+TEST(StripThinkBlock, UnclosedLeadingThinkClears) {
+    std::string text = "<think>never finished thinking";
+    strip_think_block(text);
+    EXPECT_EQ(text, "");
 }

--- a/tools/imp-server/tool_call.cpp
+++ b/tools/imp-server/tool_call.cpp
@@ -229,36 +229,14 @@ std::pair<std::string, std::vector<ParsedToolCall>> parse_tool_calls_chatml(
         if (bs != std::string::npos && be != std::string::npos)
             body = body.substr(bs, be - bs + 1);
 
-        // Two flavours: classic ChatML JSON ({"name": ..., "arguments": ...})
-        // and Qwen3.6's XML-styled <function=...><parameter=...>... layout.
-        bool parsed = false;
-        if (!body.empty() && body[0] == '{') {
-            try {
-                json j = json::parse(body);
-                ParsedToolCall tc;
-                tc.id = "call_imp_" + std::to_string(next_tool_call_id.fetch_add(1));
-                tc.name = j.value("name", "");
-                if (j.contains("arguments")) {
-                    tc.arguments = dump_safe(j["arguments"]);
-                } else {
-                    json args = j;
-                    args.erase("name");
-                    tc.arguments = dump_safe(args);
-                }
-                if (!tc.name.empty()) {
-                    calls.push_back(std::move(tc));
-                    parsed = true;
-                }
-            } catch (...) {
-                // Not valid JSON tool-call syntax — fall through to other formats
-            }
-        }
-        if (!parsed && body.find("<function=") != std::string::npos) {
-            ParsedToolCall tc;
+        // Decode the body through the shared streaming body-parser — classic
+        // ChatML JSON ({"name":..., "arguments":...}) then Qwen3.6's XML-styled
+        // <function=...><parameter=...>... fallback — so the streaming and
+        // non-streaming paths cannot drift. id is assigned only on success.
+        ParsedToolCall tc;
+        if (parse_stream_tool_body(body, /*gemma_body=*/false, /*fn_name=*/"", tc)) {
             tc.id = "call_imp_" + std::to_string(next_tool_call_id.fetch_add(1));
-            if (parse_qwen36_xml_call(body, tc)) {
-                calls.push_back(std::move(tc));
-            }
+            calls.push_back(std::move(tc));
         }
 
         pos = end + skip_len;
@@ -308,16 +286,12 @@ std::pair<std::string, std::vector<ParsedToolCall>> parse_tool_calls_llama3(
         if (bs != std::string::npos && be != std::string::npos)
             body = body.substr(bs, be - bs + 1);
 
-        try {
-            // Validate it's valid JSON
-            json j = json::parse(body);
-            ParsedToolCall tc;
+        // Same shared body-parser: with fn_name set it takes the Llama3 branch
+        // (name from the open tag, body is the bare JSON args). id on success.
+        ParsedToolCall tc;
+        if (parse_stream_tool_body(body, /*gemma_body=*/false, /*fn_name=*/name, tc)) {
             tc.id = "call_imp_" + std::to_string(next_tool_call_id.fetch_add(1));
-            tc.name = name;
-            tc.arguments = dump_safe(j);
             calls.push_back(std::move(tc));
-        } catch (...) {
-            // Malformed JSON — skip
         }
 
         pos = end + 11;  // skip "</function>"

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -199,40 +199,44 @@ std::vector<uint8_t> base64_decode(const std::string& encoded) {
     return out;
 }
 
-void strip_think_block(std::string& text) {
-    // Find the last </think> — everything after it is the actual response
+// Split `text` at the LAST "</think>". On success fills `reasoning` (the text
+// before it, a leading "<think>" stripped, trimmed both ends) and `content`
+// (the text after it, leading whitespace trimmed) and returns true; returns
+// false (out-params untouched) when there is no "</think>". Shared by the two
+// non-streaming reasoning demuxers below so their split point cannot drift.
+static bool split_last_think(const std::string& text, std::string& reasoning, std::string& content) {
     auto last_end = text.rfind("</think>");
-    if (last_end != std::string::npos) {
-        std::string after = text.substr(last_end + 8);
-        auto start = after.find_first_not_of("\n\r\t ");
-        if (start != std::string::npos) {
-            after = after.substr(start);
-            // If remaining text starts with another unclosed <think>, strip it
-            if (after.compare(0, 7, "<think>") == 0) {
-                auto next_end = after.find("</think>", 7);
-                if (next_end == std::string::npos) {
-                    // Unclosed trailing <think> block — discard
-                    text.clear();
-                    return;
-                }
-                // Recursive case: more think blocks after the last </think>
-                text = after;
-                strip_think_block(text);
-                return;
-            }
-            text = after;
-        } else {
-            text.clear();
-        }
+    if (last_end == std::string::npos)
+        return false;
+
+    reasoning = text.substr(0, last_end);
+    auto think_start = reasoning.find("<think>");
+    if (think_start != std::string::npos)
+        reasoning = reasoning.substr(think_start + 7);
+    auto rs = reasoning.find_first_not_of("\n\r\t ");
+    auto re = reasoning.find_last_not_of("\n\r\t ");
+    reasoning =
+        (rs != std::string::npos && re != std::string::npos) ? reasoning.substr(rs, re - rs + 1) : std::string();
+
+    content = text.substr(last_end + 8);
+    auto cs = content.find_first_not_of("\n\r\t ");
+    content = (cs != std::string::npos) ? content.substr(cs) : std::string();
+    return true;
+}
+
+void strip_think_block(std::string& text) {
+    std::string reasoning, content;
+    if (split_last_think(text, reasoning, content)) {
+        // Content after the last </think>. If it re-opens an (unclosed) <think>,
+        // the model never finished that block — discard it.
+        text = (content.compare(0, 7, "<think>") == 0) ? std::string() : content;
         return;
     }
 
-    // No </think> found — check if there's an opening <think>
+    // No </think> — an unclosed leading <think> means thinking never finished.
     auto first = text.find_first_not_of("\n\r\t ");
-    if (first != std::string::npos && text.compare(first, 7, "<think>") == 0) {
-        // Unclosed <think> block — model didn't finish thinking, clear output
+    if (first != std::string::npos && text.compare(first, 7, "<think>") == 0)
         text.clear();
-    }
 }
 
 ChannelSegments split_channel_segments(const std::string& text) {
@@ -453,48 +457,21 @@ void strip_channel_headers(std::string& text) {
 }
 
 std::pair<std::string, std::string> extract_reasoning(const std::string& text) {
-    // Find the last </think>
-    auto last_end = text.rfind("</think>");
-    if (last_end != std::string::npos) {
-        std::string reasoning = text.substr(0, last_end);
-        // Strip leading <think> tag
-        auto think_start = reasoning.find("<think>");
-        if (think_start != std::string::npos) {
-            reasoning = reasoning.substr(think_start + 7);
-        }
-        // Trim leading/trailing whitespace from reasoning
-        auto rs = reasoning.find_first_not_of("\n\r\t ");
-        auto re = reasoning.find_last_not_of("\n\r\t ");
-        if (rs != std::string::npos && re != std::string::npos) {
-            reasoning = reasoning.substr(rs, re - rs + 1);
-        } else {
-            reasoning.clear();
-        }
-
-        std::string content = text.substr(last_end + 8);
-        auto cs = content.find_first_not_of("\n\r\t ");
-        content = (cs != std::string::npos) ? content.substr(cs) : "";
-
+    std::string reasoning, content;
+    if (split_last_think(text, reasoning, content))
         return {reasoning, content};
-    }
 
-    // No </think> — check for unclosed <think>
+    // No </think> — an unclosed <think> makes everything after it reasoning.
     auto think_start = text.find("<think>");
     if (think_start != std::string::npos) {
-        std::string reasoning = text.substr(think_start + 7);
-        auto rs = reasoning.find_first_not_of("\n\r\t ");
-        auto re = reasoning.find_last_not_of("\n\r\t ");
-        if (rs != std::string::npos && re != std::string::npos) {
-            reasoning = reasoning.substr(rs, re - rs + 1);
-        } else {
-            reasoning.clear();
-        }
-        return {reasoning, ""};
+        std::string reasoning_only = text.substr(think_start + 7);
+        auto rs = reasoning_only.find_first_not_of("\n\r\t ");
+        auto re = reasoning_only.find_last_not_of("\n\r\t ");
+        reasoning_only = (rs != std::string::npos && re != std::string::npos)
+                             ? reasoning_only.substr(rs, re - rs + 1)
+                             : std::string();
+        return {reasoning_only, ""};
     }
-
-    // Check for </think> without opening (special token was skipped)
-    // — text before </think> is reasoning
-    // (This case shouldn't happen since we checked rfind above, but handle gracefully)
 
     return {"", text};
 }


### PR DESCRIPTION
Two byte-for-byte drift hazards from the duplication audit, both on response-parsing paths where **streaming and non-streaming could silently diverge**. Behavior-preserving; build + full GPU suite green (0 failed).

## Tool-call body decode
`parse_tool_calls_chatml` and `parse_tool_calls_llama3` (non-streaming) each carried a copy of the ChatML JSON-envelope / Llama3 bare-args decode **byte-identical** to `parse_stream_tool_body` (streaming). Both non-streaming parsers now delegate the body step to `parse_stream_tool_body` — one decoder, no drift. `id` is assigned on success, preserving all tested id sequencing (`ToolCallChatML.MultipleCallsGetSequentialIds` etc.).

## `<think>` reasoning demux
`strip_think_block` and `extract_reasoning` both split at the **last** `</think>` but re-implemented the scan independently (the header even documents a past Qwen3.6 leak from this class of divergence). Extracted a shared `split_last_think()` helper both call; `strip_think_block` also loses a dead recursive branch (unreachable — `rfind` already returns the last close tag). The streaming `StreamReasoningSplitter` is token-based and intentionally splits at the **first** `</think>` — left untouched.

## Validation
- Existing suites stay green: `test_tool_call`, `test_tool_stream_filter`, `test_sse_stream_utils` (issue #557, which uses `extract_reasoning` as the streaming oracle).
- Added 3 `strip_think_block` edge tests for the paths the shared helper restructured (unclosed trailing/leading `<think>` → discarded).
- `make build` + `make test-gpu` — 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)