### PR TITLE
test(hygiene): drop duplicate SoftmaxTest.SingleElement + fix stale comment

### DIFF
--- a/tests/test_activation.cu
+++ b/tests/test_activation.cu
@@ -458,20 +458,10 @@ TEST(SoftmaxTest, NumericalStability) {
     free_gpu_tensor(d_out);
 }
 
-TEST(SoftmaxTest, SingleElement) {
-    std::vector<float> h_x = {5.0f};
-    Tensor d_x = make_gpu_tensor(h_x.data(), QType::F32, {1, 1});
-    Tensor d_out = alloc_gpu_tensor(QType::F32, {1, 1});
-
-    softmax(d_x, d_out);
-    cudaDeviceSynchronize();
-
-    auto h_out = read_gpu_tensor(d_out);
-    EXPECT_NEAR(h_out[0], 1.0f, 1e-6f);
-
-    free_gpu_tensor(d_x);
-    free_gpu_tensor(d_out);
-}
+// NOTE: SoftmaxTest.SingleElement lives in test_softmax.cu — the copy that was
+// here collided with it (same suite.test name in the same test-compute binary)
+// and asserted the identical single-element→1.0 property. Removed to keep one
+// registration.
 
 TEST(SoftmaxTest, FP16) {
     constexpr int rows = 1;

--- a/tests/test_chunked_prefill.cu
+++ b/tests/test_chunked_prefill.cu
@@ -217,8 +217,8 @@ protected:
     // BIT-IDENTICAL across chunk={64,128,512,1024}; Llama-3.2-3B is within
     // 0.01% (continuation chunks route through cuBLAS, first chunk through
     // FA2-f16qk). Above ~2.5k context the late chunks route through the
-    // fp8/e4m3 FMHA family and drift up to ~25% NLL — that open issue is
-    // tracked by the DISABLED_ long-context test below.
+    // fp8/e4m3 FMHA family and drift up to ~25% NLL — that remains an open
+    // issue (no dedicated regression test exists in this file yet).
     static std::string probe_prompt() {
         std::string p = "Summarize the following list:\n";
         for (int i = 0; i < 54; i++) {


### PR DESCRIPTION
Test-suite housekeeping from the test-quality audit.

- `SoftmaxTest.SingleElement` was defined in **both** `test_activation.cu:461` and `test_softmax.cu:161`, which compile into the same `test-compute` binary — a `suite.test` **name collision** (two registrations; `--gtest_filter` matches both) asserting the identical single-element→1.0 property. Removed the `test_activation.cu` copy; `test_softmax.cu` keeps it. `SoftmaxTest` now registers **9** tests (was a 10th duplicate), all green.
- `test_chunked_prefill.cu:221` referenced "the `DISABLED_` long-context test below" that does not exist in the file — corrected the dangling pointer.

Build + `test-compute` (SoftmaxTest.*) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)