### PR TITLE
test(hygiene): give the two FP4 bench tests honest gates/names

### DIFF
--- a/tests/test_mxf4nvf4_mma_variants_bench.cu
+++ b/tests/test_mxf4nvf4_mma_variants_bench.cu
@@ -26,10 +26,15 @@ TEST(MmaVariantsBench, Compare) {
     }
     std::printf("\n");
 
-    // Diagnostic — none of the variants are required to launch successfully.
-    // The test PASSES regardless. The output reveals which variants are
-    // viable and their relative throughput.
-    SUCCEED();
+    // The throughput ranking is diagnostic, but at least one variant must be
+    // viable: on sm_120a the mxf4/nvf4 mma.sync path is imp's core FP4 kernel,
+    // so if EVERY variant fails to launch the FP4 tensor-core path is broken,
+    // not merely "some datacenter-only variants got rejected".
+    ASSERT_GT(r.count, 0) << "bench_mma_variants produced no entries";
+    bool any_viable = false;
+    for (int i = 0; i < r.count; ++i)
+        if (r.entries[i].tops >= 0) any_viable = true;
+    EXPECT_TRUE(any_viable) << "no mxf4/nvf4 MMA variant launched on this GPU";
 
     cudaStreamDestroy(stream);
 }

--- a/tests/test_tma_block_scale_bench.cu
+++ b/tests/test_tma_block_scale_bench.cu
@@ -23,7 +23,11 @@
 // — TMA bulk on sm_120 is empirically equivalent or slower than cp.async for
 // our workload sizes; the perceived advantage of fused descriptors over
 // separate doesn't materialise either.
-TEST(TmaBlockScaleBench, FusedFasterThanSeparate) {
+//
+// Renamed from FusedFasterThanSeparate: that property was refuted (above), and
+// the test's actual gate is that both descriptor variants launch — the name now
+// says so instead of asserting a speedup the code deliberately does not check.
+TEST(TmaBlockScaleBench, BothDescriptorsLaunch) {
     int dev = 0;
     cudaGetDevice(&dev);
     int major = 0, minor = 0;


### PR DESCRIPTION
From the test-quality audit — two GPU bench "tests" that could not catch a regression.

- **`MmaVariantsBench.Compare`** ended in an unconditional `SUCCEED()` ("PASSES regardless"), so a total FP4 tensor-core launch failure would still show green. Replaced with a real gate: the bench must produce entries **and at least one mxf4/nvf4 MMA variant must launch** on sm_120a (imp's core FP4 path — if none launch, that path is broken). The throughput ranking stays diagnostic.
- **`TmaBlockScaleBench.FusedFasterThanSeparate`** was misnamed: the fused>separate hypothesis was refuted by measurement (the `EXPECT_GT(1.05)` was already retired), and the test's real gate is that both descriptor variants launch. Renamed to **`BothDescriptorsLaunch`** so the name matches what it asserts.

Both green on sm_120a (`test-quant`). These run under `make test-gpu` (GPU label), not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)