### PR TITLE
test(hygiene): relocate JsonConstrainTest cases + real PDL smoke assertions

### DIFF
--- a/tests/test_green_ctx.cu
+++ b/tests/test_green_ctx.cu
@@ -347,12 +347,12 @@ TEST(CudaGraphRunnerTest, NoDecodeFn) {
 // PDL Tests
 // ============================================================================
 
-// 14. PDL is_available check (doesn't crash)
+// 14. PDL is_available check: must not crash and must be deterministic
 TEST(PDLTest, IsAvailableCheck) {
-    // Just check it doesn't crash; result depends on hardware
+    // Result depends on hardware/CUDA, but repeated calls must agree — a
+    // non-deterministic capability probe would make PDL dispatch flaky.
     bool avail = pdl::is_available();
-    (void)avail;
-    EXPECT_TRUE(true);
+    EXPECT_EQ(avail, pdl::is_available()) << "is_available() must be deterministic";
 }
 
 // 15. PDL enable/disable on kernel (doesn't crash)
@@ -383,11 +383,13 @@ TEST(PDLTest, EnableDisableKernel) {
     cudaFree(d_data);
 }
 
-// 16. PDL enable with null is safe
+// 16. PDL enable with null is safe: a no-op that must not corrupt PDL state
 TEST(PDLTest, EnableNullSafe) {
+    const bool before = pdl::is_available();
     pdl::enable(nullptr);
     pdl::disable(nullptr);
-    EXPECT_TRUE(true);
+    EXPECT_FALSE(pdl::is_enabled(nullptr)) << "null kernel must never register as PDL-enabled";
+    EXPECT_EQ(pdl::is_available(), before) << "null enable/disable must not change PDL availability";
 }
 
 // 17. ScopedPDL RAII

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -533,5 +533,65 @@ TEST(PreambleGateTest, BudgetOnlyModeUnaffectedByThinkingFlag) {
     EXPECT_TRUE(g.active());
 }
 
+
+TEST(JsonConstrainTest, RawControlCharInStringMasked) {
+    SKIP_IF_NO_CUDA();
+
+    //          0        1      2       3    4     5      6
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "\"\n", "\"ok"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    JsonConstrainer jc;
+    ASSERT_TRUE(jc.init(tok));
+    jc.update(3);  // '{' → OBJECT_START, next token may open a key string
+
+    const int vocab = static_cast<int>(toks.size());
+    std::vector<float> h(vocab, 1.0f);
+    float* d = nullptr;
+    cudaMalloc(&d, vocab * sizeof(float));
+    cudaMemcpy(d, h.data(), vocab * sizeof(float), cudaMemcpyHostToDevice);
+    jc.apply_mask(d, vocab, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, vocab * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+
+    EXPECT_GT(h[6], -1e30f) << "'\"ok' (quote + printable key chars) must be allowed";
+    EXPECT_FLOAT_EQ(h[5], -FLT_MAX) << "'\"<newline>' must be masked — raw control char in string";
+}
+
+TEST(JsonConstrainTest, ModelVocabLargerThanTokenizerMasksPadding) {
+    SKIP_IF_NO_CUDA();
+
+    //          0        1      2       3    4     5    6
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "}", "0"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    JsonConstrainer jc;
+    ASSERT_TRUE(jc.init(tok));
+
+    const int tok_vocab = static_cast<int>(toks.size());
+    const int model_vocab = tok_vocab + 9;  // simulated lm_head padding rows
+
+    std::vector<float> h(model_vocab, 1.0f);
+    float* d = nullptr;
+    cudaMalloc(&d, model_vocab * sizeof(float));
+    cudaMemcpy(d, h.data(), model_vocab * sizeof(float), cudaMemcpyHostToDevice);
+    jc.apply_mask(d, model_vocab, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, model_vocab * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+
+    // '{' starts a JSON document — must stay alive.
+    EXPECT_GT(h[3], -1e30f) << "'{' must be allowed at document start";
+    // Every padding id (no tokenizer entry) must be masked.
+    for (int i = tok_vocab; i < model_vocab; i++) {
+        EXPECT_FLOAT_EQ(h[i], -FLT_MAX) << "padding id " << i << " leaked through the json mask";
+    }
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_schema_constrain.cu
+++ b/tests/test_schema_constrain.cu
@@ -725,65 +725,6 @@ TEST(SchemaConstrainTest, RawControlCharInStringMasked) {
     EXPECT_FALSE(a[8]) << "'\"<newline>' must be masked — raw control char inside a string";
 }
 
-TEST(JsonConstrainTest, RawControlCharInStringMasked) {
-    SKIP_IF_NO_CUDA();
-
-    //          0        1      2       3    4     5      6
-    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "\"\n", "\"ok"};
-    std::vector<float> scores(toks.size(), 0.0f);
-    Tokenizer tok;
-    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
-
-    JsonConstrainer jc;
-    ASSERT_TRUE(jc.init(tok));
-    jc.update(3);  // '{' → OBJECT_START, next token may open a key string
-
-    const int vocab = static_cast<int>(toks.size());
-    std::vector<float> h(vocab, 1.0f);
-    float* d = nullptr;
-    cudaMalloc(&d, vocab * sizeof(float));
-    cudaMemcpy(d, h.data(), vocab * sizeof(float), cudaMemcpyHostToDevice);
-    jc.apply_mask(d, vocab, 0);
-    cudaDeviceSynchronize();
-    cudaMemcpy(h.data(), d, vocab * sizeof(float), cudaMemcpyDeviceToHost);
-    cudaFree(d);
-
-    EXPECT_GT(h[6], -1e30f) << "'\"ok' (quote + printable key chars) must be allowed";
-    EXPECT_FLOAT_EQ(h[5], -FLT_MAX) << "'\"<newline>' must be masked — raw control char in string";
-}
-
-TEST(JsonConstrainTest, ModelVocabLargerThanTokenizerMasksPadding) {
-    SKIP_IF_NO_CUDA();
-
-    //          0        1      2       3    4     5    6
-    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "}", "0"};
-    std::vector<float> scores(toks.size(), 0.0f);
-    Tokenizer tok;
-    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
-
-    JsonConstrainer jc;
-    ASSERT_TRUE(jc.init(tok));
-
-    const int tok_vocab = static_cast<int>(toks.size());
-    const int model_vocab = tok_vocab + 9;  // simulated lm_head padding rows
-
-    std::vector<float> h(model_vocab, 1.0f);
-    float* d = nullptr;
-    cudaMalloc(&d, model_vocab * sizeof(float));
-    cudaMemcpy(d, h.data(), model_vocab * sizeof(float), cudaMemcpyHostToDevice);
-    jc.apply_mask(d, model_vocab, 0);
-    cudaDeviceSynchronize();
-    cudaMemcpy(h.data(), d, model_vocab * sizeof(float), cudaMemcpyDeviceToHost);
-    cudaFree(d);
-
-    // '{' starts a JSON document — must stay alive.
-    EXPECT_GT(h[3], -1e30f) << "'{' must be allowed at document start";
-    // Every padding id (no tokenizer entry) must be masked.
-    for (int i = tok_vocab; i < model_vocab; i++) {
-        EXPECT_FLOAT_EQ(h[i], -FLT_MAX) << "padding id " << i << " leaked through the json mask";
-    }
-}
-
 TEST(SchemaConstrainTest, ModelVocabLargerThanTokenizerMasksPadding) {
     SKIP_IF_NO_CUDA();
 


### PR DESCRIPTION
Loose ends from the test-quality audit.

- Two `JsonConstrainTest` cases (`RawControlCharInStringMasked`, `ModelVocabLargerThanTokenizerMasksPadding`) lived in `test_schema_constrain.cu`, parked next to their `SchemaConstrainTest` siblings even though they exercise `JsonConstrainer`. Moved them to `test_json_constrain.cu` where the rest of the suite lives — both files compile into `test-moe-gdn`, so **no CMake change and no coverage change**, purely discoverability. The identically-named `SchemaConstrainTest.ModelVocabLargerThanTokenizerMasksPadding` (a different suite) stays put.
- `PDLTest.IsAvailableCheck` and `PDLTest.EnableNullSafe` ended in `EXPECT_TRUE(true)` (no behavioral check). Gave them real, can't-false-fail assertions: `is_available()` must be deterministic; a null enable/disable must not register as enabled or change availability.

All green: 30 tests across `JsonConstrainTest`+`SchemaConstrainTest` (`test-moe-gdn`), `PDLTest` (`test-kv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)