### PR TITLE
feat(tools): strict:true optional tool calls enforced by the FSM (#1002 stage 2)

### DIFF
--- a/src/compute/preamble_gate.h
+++ b/src/compute/preamble_gate.h
@@ -28,18 +28,25 @@ namespace imp {
 //
 //   ACTIVE        — preamble running; mask off; transitions:
 //                     · `{`/`[`/close-token/budget → OFF (mask kicks in)
-//                     · tool-opener (token or char-prefix) → TOOL_BODY
+//                     · tool-opener (token or char-prefix) → TOOL_BODY (legacy)
+//                       or TOOL_ARGS (strict_tool mode)
 //   TOOL_BODY     — inside a tool call; mask off; transitions:
 //                     · tool-close (token or char-suffix) → TERMINAL_OFF
+//   TOOL_ARGS     — inside a tool call, strict_tool mode; mask ENGAGED so the
+//                   TOOL_CALL body FSM constrains the arguments (#1002 strict:
+//                   the envelope is emitted freely, only the body is enforced).
+//                   The gate absorbs the opener token, then forwards every body
+//                   token to the FSM (which drives body + close literal + EOS).
 //   TERMINAL_OFF  — tool call closed; mask off forever (parallel calls,
 //                   trailing text, EOS all pass through).
 //   OFF           — preamble exited normally; FSM mask now applies.
 //
 // External API stays binary:
 //   active() = true  → mask is bypassed (ACTIVE / TOOL_BODY / TERMINAL_OFF)
-//   active() = false → mask is enforced by FSM (OFF only)
+//   active() = false → mask is enforced by FSM (OFF / TOOL_ARGS)
 //   absorb() returns true if the token was consumed by the gate, false
-//   only on the ACTIVE → OFF transition via `{`/`[` (forwarded to FSM).
+//   on the ACTIVE → OFF transition via `{`/`[` (forwarded to FSM) and for
+//   every body token once in TOOL_ARGS (the FSM drives the tool-call body).
 class PreambleGate {
 public:
     // Existing two-arg overload — preserved for non-tool callers.
@@ -58,12 +65,13 @@ public:
     //
     // Empty open_tokens AND empty open_prefix means "tool detection
     // disabled" — gate behaves exactly like the legacy two-arg configure.
-    void configure_with_tools(int32_t close_token, int max_tokens,
-                              std::vector<int32_t> open_tokens,
-                              std::vector<int32_t> close_tokens,
-                              std::string open_prefix,
-                              std::string close_suffix,
-                              bool thinking_open = true) {
+    //
+    // strict_tool: on the tool opener, enter TOOL_ARGS (mask ENGAGED) instead
+    // of TOOL_BODY (mask off) so the TOOL_CALL body FSM constrains the arguments
+    // of an OPTIONAL (model-chosen) tool call — OpenAI `strict: true` (#1002).
+    void configure_with_tools(int32_t close_token, int max_tokens, std::vector<int32_t> open_tokens,
+                              std::vector<int32_t> close_tokens, std::string open_prefix,
+                              std::string close_suffix, bool thinking_open = true, bool strict_tool = false) {
         max_tokens_ = max_tokens > 0 ? max_tokens : 0;
         close_token_ = close_token;
         open_tokens_ = std::move(open_tokens);
@@ -71,6 +79,7 @@ public:
         open_prefix_ = std::move(open_prefix);
         close_suffix_ = std::move(close_suffix);
         thinking_open_ = thinking_open;
+        strict_tool_ = strict_tool;
         configured_ = (close_token >= 0) || (max_tokens_ > 0);
         reset();
     }
@@ -84,19 +93,25 @@ public:
         // the structural mask enforces immediately. Tool-aware mode keeps ACTIVE
         // (tool openers may still appear post-think) and budget-only mode is
         // unaffected (close_token_ < 0).
-        const bool reasoning_already_closed =
-            (close_token_ >= 0) && !thinking_open_ && !tool_detection_active();
+        const bool reasoning_already_closed = (close_token_ >= 0) && !thinking_open_ &&
+                                              !tool_detection_active();
         state_ = (configured_ && !reasoning_already_closed) ? State::ACTIVE : State::OFF;
         seen_ = 0;
         char_buf_.clear();
     }
 
-    // active() returns true whenever the FSM mask should be skipped.
-    // That's three of the four internal states: ACTIVE (preamble),
-    // TOOL_BODY (inside a tool call), TERMINAL_OFF (after a tool call
-    // closed). Only OFF — reached via {/[/think-close/budget — lets
-    // the FSM mask through.
-    bool active() const noexcept { return state_ != State::OFF; }
+    // active() returns true whenever the FSM mask should be skipped:
+    // ACTIVE (preamble), TOOL_BODY (unconstrained tool call), TERMINAL_OFF
+    // (after a tool call closed). OFF (via {/[/think-close/budget) and
+    // TOOL_ARGS (strict tool-call body) let the FSM mask through.
+    bool active() const noexcept {
+        return state_ == State::ACTIVE || state_ == State::TOOL_BODY || state_ == State::TERMINAL_OFF;
+    }
+
+    // True once a strict optional tool call opened and its body is now
+    // FSM-constrained (#1002) — the constrainer engages its TOOL_CALL body
+    // frame on the ACTIVE → TOOL_ARGS transition.
+    bool in_tool_args() const noexcept { return state_ == State::TOOL_ARGS; }
 
     // Returns true if the token was fully consumed by the gate (FSM should
     // NOT process it). Returns false only for the one transition where
@@ -109,6 +124,8 @@ public:
                 return absorb_tool_body(token, text);
             case State::TERMINAL_OFF:
                 return true;  // permanently absorbing
+            case State::TOOL_ARGS:
+                return false;  // strict body: every token is driven by the FSM
             case State::OFF:
                 return false;
         }
@@ -116,7 +133,7 @@ public:
     }
 
 private:
-    enum class State : uint8_t { ACTIVE, TOOL_BODY, TERMINAL_OFF, OFF };
+    enum class State : uint8_t { ACTIVE, TOOL_BODY, TOOL_ARGS, TERMINAL_OFF, OFF };
 
     bool absorb_active(int32_t token, const std::string& text) {
         seen_++;
@@ -136,9 +153,10 @@ private:
             return true;
         }
 
-        // Tool-opener detection (token-set fast-path).
+        // Tool-opener detection (token-set fast-path). strict_tool → TOOL_ARGS
+        // (mask engaged, FSM constrains the body); legacy → TOOL_BODY (mask off).
         if (is_tool_open_token(token)) {
-            state_ = State::TOOL_BODY;
+            state_ = strict_tool_ ? State::TOOL_ARGS : State::TOOL_BODY;
             char_buf_.clear();
             return true;
         }
@@ -147,7 +165,7 @@ private:
         if (!open_prefix_.empty()) {
             append_char_buf(text);
             if (char_buf_.find(open_prefix_) != std::string::npos) {
-                state_ = State::TOOL_BODY;
+                state_ = strict_tool_ ? State::TOOL_ARGS : State::TOOL_BODY;
                 char_buf_.clear();
                 return true;
             }
@@ -191,9 +209,7 @@ private:
         return true;  // body content is always absorbed
     }
 
-    bool tool_detection_active() const {
-        return !open_tokens_.empty() || !open_prefix_.empty();
-    }
+    bool tool_detection_active() const { return !open_tokens_.empty() || !open_prefix_.empty(); }
 
     bool is_tool_open_token(int32_t token) const {
         if (token < 0)
@@ -224,6 +240,7 @@ private:
 
     bool configured_ = false;
     bool thinking_open_ = true;  // false = thinking already closed at gen start (e.g. /no_think)
+    bool strict_tool_ = false;   // true = opener enters TOOL_ARGS (FSM constrains body)
     State state_ = State::OFF;
     int32_t close_token_ = -1;
     int max_tokens_ = 0;

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -90,7 +90,14 @@ bool SchemaConstrainer::init(const Tokenizer& tok, std::unique_ptr<SchemaNode> s
 
 void SchemaConstrainer::reset() {
     stack_.clear();
-    if (!envelope_open_.empty()) {
+    if (strict_optional_envelope_) {
+        // Strict OPTIONAL tool call: the model may or may not call. Leave the
+        // stack EMPTY — the tool-aware preamble gate is ACTIVE (mask bypassed),
+        // so free text / a plain answer passes through unconstrained. update()
+        // installs the body frame (engage_tool_body) only if the gate detects
+        // the opener; until then apply_mask/forced_text no-op on the empty stack
+        // behind the active gate.
+    } else if (!envelope_open_.empty()) {
         // Envelope wrapper frame: forces the open literal, then hosts the root
         // value; when the value pops it flips to ENVELOPE_CLOSE (#1002).
         SchemaFrame env;
@@ -105,6 +112,21 @@ void SchemaConstrainer::reset() {
     need_token_allow_ = false;
     std::fill(token_allow_.begin(), token_allow_.end(), (uint8_t)1);
     preamble_.reset();
+}
+
+void SchemaConstrainer::engage_tool_body() {
+    // Install the post-ENVELOPE_OPEN state: an envelope frame armed to force the
+    // close literal after the body pops (mirrors ENVELOPE_OPEN's completion at
+    // sim_advance), plus the TOOL_CALL body value-frame on top. The model has
+    // already emitted the open tag (absorbed by the gate); the body FSM enforces
+    // the arguments, then the close literal is forced, then EOS.
+    SchemaFrame env;
+    env.node = schema_.get();
+    env.phase = SchemaPhase::ENVELOPE_CLOSE;
+    env.literal_target = envelope_close_;
+    env.literal_pos = 0;
+    stack_.push_back(std::move(env));
+    push_value_frame(schema_.get());
 }
 
 void SchemaConstrainer::push_value_frame(const SchemaNode* node) {
@@ -293,8 +315,8 @@ uint16_t SchemaConstrainer::compute_category_mask() const {
             // minItems > 0: the empty array may not close yet.
             uint16_t mask = (f.node && f.node->min_items > 0) ? 0 : CAT_CLOSE_BRACKET;
             // Allow value start for first item ($ref items resolve first)
-            const SchemaNode* items =
-                f.node ? resolve_schema_ref(schema_.get(), f.node->items.get()) : nullptr;
+            const SchemaNode* items = f.node ? resolve_schema_ref(schema_.get(), f.node->items.get())
+                                             : nullptr;
             if (items) {
                 switch (items->type) {
                     case SchemaType::STRING:
@@ -458,10 +480,10 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
             if (e >= 0 && e < vocab_size_)
                 token_allow_[e] = 1;
         uint16_t all_cats = 0xFFFF;
-        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_allowed_mask_, &all_cats, sizeof(uint16_t),
+        IMP_CUDA_CHECK_LOG(
+            cudaMemcpyAsync(d_allowed_mask_, &all_cats, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, token_allow_.data(), vocab_size_ * sizeof(uint8_t),
                                            cudaMemcpyHostToDevice, stream));
-        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, token_allow_.data(),
-                                           vocab_size_ * sizeof(uint8_t), cudaMemcpyHostToDevice, stream));
         int t = 256, b = (vocab_size + t - 1) / t;
         constrain_mask_allow_kernel<<<b, t, 0, stream>>>(d_logits, d_token_categories_, d_token_allow_,
                                                          d_allowed_mask_, vocab_size,
@@ -524,11 +546,21 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
 // ---------------------------------------------------------------------------
 
 void SchemaConstrainer::update(int32_t token) {
-    if (token < 0 || token >= vocab_size_ || stack_.empty())
+    if (token < 0 || token >= vocab_size_)
         return;
 
     const auto& text = token_texts_[token];
-    if (preamble_.absorb(token, text))
+    // Feed the gate BEFORE the empty-stack guard: in strict optional mode the
+    // stack is empty during free generation, and the gate must still see every
+    // token to detect the tool-call opener.
+    if (preamble_.absorb(token, text)) {
+        // Opener just seen in strict mode → install the body FSM (once: the
+        // push makes the stack non-empty so this cannot re-fire).
+        if (strict_optional_envelope_ && preamble_.in_tool_args() && stack_.empty())
+            engage_tool_body();
+        return;
+    }
+    if (stack_.empty())
         return;
     SchemaPhase before = top().phase;
     for (char c : text) {
@@ -570,13 +602,27 @@ int SchemaConstrainer::forced_text(std::string& out, int max_chars) const {
                 if (!f.node)
                     return static_cast<int>(out.size());
                 switch (f.node->type) {
-                    case SchemaType::OBJECT: cands = "{"; break;
-                    case SchemaType::TOOL_CALL: cands = "{"; break;
-                    case SchemaType::ARRAY: cands = "["; break;
-                    case SchemaType::STRING: cands = "\""; break;  // opening quote; interior is free
-                    case SchemaType::ENUM: cands = "\""; break;
-                    case SchemaType::NULL_TYPE: cands = "n"; break;
-                    case SchemaType::BOOLEAN: cands = "tf"; break;  // two legal starts — stops below
+                    case SchemaType::OBJECT:
+                        cands = "{";
+                        break;
+                    case SchemaType::TOOL_CALL:
+                        cands = "{";
+                        break;
+                    case SchemaType::ARRAY:
+                        cands = "[";
+                        break;
+                    case SchemaType::STRING:
+                        cands = "\"";
+                        break;  // opening quote; interior is free
+                    case SchemaType::ENUM:
+                        cands = "\"";
+                        break;
+                    case SchemaType::NULL_TYPE:
+                        cands = "n";
+                        break;
+                    case SchemaType::BOOLEAN:
+                        cands = "tf";
+                        break;  // two legal starts — stops below
                     default:
                         // number/integer/anyOf/unknown: first char is a real choice
                         return static_cast<int>(out.size());
@@ -677,8 +723,7 @@ static void sim_fixup_parent(std::vector<SchemaFrame>& stk) {
     SchemaFrame& parent = stk.back();
     if (parent.phase == SchemaPhase::OBJECT_COLON)
         parent.phase = SchemaPhase::OBJECT_AFTER_VALUE;
-    else if (parent.phase == SchemaPhase::ARRAY_OPEN ||
-             parent.phase == SchemaPhase::ARRAY_AFTER_ITEM) {
+    else if (parent.phase == SchemaPhase::ARRAY_OPEN || parent.phase == SchemaPhase::ARRAY_AFTER_ITEM) {
         parent.phase = SchemaPhase::ARRAY_AFTER_ITEM;
         parent.item_count++;  // one completed item per child-frame pop
     }
@@ -770,19 +815,38 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                     if (c == '-' || (c >= '0' && c <= '9')) {
                         f.phase = SchemaPhase::NUMBER_VALUE;
                         f.string_len = (c >= '0' && c <= '9') ? 1 : 0;  // digit count
-                        f.num_leading_zero = (c == '0');  // "0..." forbids more int digits
+                        f.num_leading_zero = (c == '0');                // "0..." forbids more int digits
                         return true;
                     }
                     return false;
                 case SchemaType::BOOLEAN:
-                    if (c == 't') { f.phase = SchemaPhase::LITERAL_VALUE; f.literal_target = "true"; f.literal_pos = 1; return true; }
-                    if (c == 'f') { f.phase = SchemaPhase::LITERAL_VALUE; f.literal_target = "false"; f.literal_pos = 1; return true; }
+                    if (c == 't') {
+                        f.phase = SchemaPhase::LITERAL_VALUE;
+                        f.literal_target = "true";
+                        f.literal_pos = 1;
+                        return true;
+                    }
+                    if (c == 'f') {
+                        f.phase = SchemaPhase::LITERAL_VALUE;
+                        f.literal_target = "false";
+                        f.literal_pos = 1;
+                        return true;
+                    }
                     return false;
                 case SchemaType::NULL_TYPE:
-                    if (c == 'n') { f.phase = SchemaPhase::LITERAL_VALUE; f.literal_target = "null"; f.literal_pos = 1; return true; }
+                    if (c == 'n') {
+                        f.phase = SchemaPhase::LITERAL_VALUE;
+                        f.literal_target = "null";
+                        f.literal_pos = 1;
+                        return true;
+                    }
                     return false;
                 case SchemaType::ENUM:
-                    if (c == '"') { f.phase = SchemaPhase::ENUM_VALUE; f.enum_buffer.clear(); return true; }
+                    if (c == '"') {
+                        f.phase = SchemaPhase::ENUM_VALUE;
+                        f.enum_buffer.clear();
+                        return true;
+                    }
                     return false;
                 case SchemaType::ANY_OF:
                     // anyOf is hard to constrain precisely — accept as free string.
@@ -832,7 +896,10 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                         if (f.node->type == SchemaType::TOOL_CALL &&
                             !tool_call_key_available(name, f.emitted_keys))
                             continue;
-                        if (!f.emitted_keys.count(name) && name == f.key_buffer) { complete = true; break; }
+                        if (!f.emitted_keys.count(name) && name == f.key_buffer) {
+                            complete = true;
+                            break;
+                        }
                     }
                 }
                 if (!complete)
@@ -941,8 +1008,7 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
             if (space)
                 return true;
             const int max_items = effective_max_items(schema_.get(), f.node);
-            const bool can_close =
-                !f.node || f.node->min_items < 0 || f.item_count >= f.node->min_items;
+            const bool can_close = !f.node || f.node->min_items < 0 || f.item_count >= f.node->min_items;
             if (c == ',') {
                 // At the item ceiling the array must close (unless closing is
                 // itself illegal via contradictory minItems — then allow the
@@ -964,7 +1030,10 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
         }
 
         case SchemaPhase::STRING_VALUE: {
-            if (c == '\\') { f.phase = SchemaPhase::STRING_ESCAPE; return true; }
+            if (c == '\\') {
+                f.phase = SchemaPhase::STRING_ESCAPE;
+                return true;
+            }
             if (c == '"') {
                 stk.pop_back();
                 sim_fixup_parent(stk);
@@ -992,8 +1061,8 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
             if (f.node && f.node->max_length >= 0 && f.string_len + 1 > f.node->max_length)
                 return false;
             if (f.node && f.node->pattern_nfa && f.node->pattern_nfa->compiled()) {
-                std::vector<int> next =
-                    f.node->pattern_nfa->step(f.regex_states, static_cast<unsigned char>(c));
+                std::vector<int> next = f.node->pattern_nfa->step(f.regex_states,
+                                                                  static_cast<unsigned char>(c));
                 if (next.empty())
                     return false;  // pattern prefix died
                 f.regex_states = std::move(next);
@@ -1052,7 +1121,10 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                 bool exact = false;
                 if (f.node) {
                     for (auto& v : f.node->enum_values)
-                        if (v == f.enum_buffer) { exact = true; break; }
+                        if (v == f.enum_buffer) {
+                            exact = true;
+                            break;
+                        }
                 }
                 if (!exact)
                     return false;  // close only on an exact enum value
@@ -1116,7 +1188,7 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
 
 bool SchemaConstrainer::token_legal(const std::string& text) const {
     if (text.empty())
-        return true;  // EOS / special tokens — governed by the category mask
+        return true;                        // EOS / special tokens — governed by the category mask
     std::vector<SchemaFrame> sim = stack_;  // deep copy of the frame stack
     for (char c : text) {
         if (!sim_advance(sim, c))

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -116,6 +116,16 @@ public:
         envelope_close_ = std::move(close);
     }
 
+    // Strict OPTIONAL tool call (#1002, OpenAI `strict: true` with a model-chosen
+    // call): the envelope is emitted freely by the model — the preamble gate
+    // detects the opener and hands off to the TOOL_CALL body FSM (which enforces
+    // the arguments, then forces the close literal + EOS). Unlike set_envelope's
+    // forced mode, no tool call is forced: if the model answers in text, the
+    // constraint never engages. Requires set_envelope (for the close literal)
+    // and a tool-aware preamble configured with strict_tool=true. Configure
+    // BEFORE reset().
+    void set_strict_optional_envelope(bool v) { strict_optional_envelope_ = v; }
+
     bool is_initialized() const { return initialized_; }
 
     // See JsonConstrainer::set_preamble for semantics — close-token mode for
@@ -128,17 +138,13 @@ public:
     // a tool-call body (delimited by open_tokens/close_tokens or the
     // open_prefix/close_suffix char fallback) and never re-enables the mask
     // after the tool closes. See PreambleGate::configure_with_tools.
-    void set_preamble_with_tools(int32_t close_token, int max_tokens,
-                                 std::vector<int32_t> open_tokens,
-                                 std::vector<int32_t> close_tokens,
-                                 std::string open_prefix,
-                                 std::string close_suffix,
-                                 bool thinking_open = true) {
-        preamble_.configure_with_tools(close_token, max_tokens,
-                                       std::move(open_tokens),
-                                       std::move(close_tokens),
-                                       std::move(open_prefix),
-                                       std::move(close_suffix), thinking_open);
+    void set_preamble_with_tools(int32_t close_token, int max_tokens, std::vector<int32_t> open_tokens,
+                                 std::vector<int32_t> close_tokens, std::string open_prefix,
+                                 std::string close_suffix, bool thinking_open = true,
+                                 bool strict_tool = false) {
+        preamble_.configure_with_tools(close_token, max_tokens, std::move(open_tokens),
+                                       std::move(close_tokens), std::move(open_prefix),
+                                       std::move(close_suffix), thinking_open, strict_tool);
     }
 
 private:
@@ -173,6 +179,10 @@ private:
     std::string envelope_open_;
     std::string envelope_close_;
 
+    // Strict OPTIONAL tool call: the open literal is NOT forced (the model emits
+    // it freely); the preamble gate hands off to the body FSM on the opener.
+    bool strict_optional_envelope_ = false;
+
     // Helpers
     // C++23 deducing this: one overload serves const and non-const callers.
     template <typename Self>
@@ -181,6 +191,12 @@ private:
     }
 
     void push_value_frame(const SchemaNode* node);
+
+    // Strict optional tool call (#1002): the preamble gate has just seen the
+    // opener, so install the TOOL_CALL body frame with the close literal armed
+    // (the post-ENVELOPE_OPEN state) — the FSM now enforces the body, then the
+    // forced close literal, then EOS.
+    void engage_tool_body();
 
     uint16_t compute_category_mask() const;
     // cat_mask: the current category mask — tokens failing it are masked by

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -23,8 +23,7 @@ struct ToolDialect {
     std::string close_suffix;
 
     bool empty() const {
-        return open_tokens.empty() && close_tokens.empty() && open_prefix.empty() &&
-               close_suffix.empty();
+        return open_tokens.empty() && close_tokens.empty() && open_prefix.empty() && close_suffix.empty();
     }
 };
 
@@ -118,18 +117,17 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
         if (dialect.empty()) {
             // Tokenizer surfaced none of the dialect tags AND the family had
             // no char fallback — degrade to current "drop schema" behaviour.
-            IMP_LOG_INFO(
-                "ConstraintManager: no tool-tag dialect for family %d, dropping schema/json_mode",
-                std::to_underlying(tpl_family));
+            IMP_LOG_INFO("ConstraintManager: no tool-tag dialect for family %d, dropping schema/json_mode",
+                         std::to_underlying(tpl_family));
             return;
         }
     }
 
     auto configure_gate = [&](auto* constrainer) {
         if (has_tools) {
-            constrainer->set_preamble_with_tools(think_close, preamble_budget,
-                                                 dialect.open_tokens, dialect.close_tokens,
-                                                 dialect.open_prefix, dialect.close_suffix, thinking_open);
+            constrainer->set_preamble_with_tools(think_close, preamble_budget, dialect.open_tokens,
+                                                 dialect.close_tokens, dialect.open_prefix,
+                                                 dialect.close_suffix, thinking_open);
         } else {
             constrainer->set_preamble(think_close, preamble_budget, thinking_open);
         }
@@ -194,11 +192,27 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
     }
 }
 
-bool ConstraintManager::prepare_tool_call(
-    const std::vector<std::pair<std::string, std::string>>& tools, const std::string& envelope_open,
-    const std::string& envelope_close, Tokenizer* tokenizer, bool thinking_open) {
+bool ConstraintManager::prepare_tool_call(const std::vector<std::pair<std::string, std::string>>& tools,
+                                          const std::string& envelope_open, const std::string& envelope_close,
+                                          Tokenizer* tokenizer, bool thinking_open, bool optional,
+                                          ChatTemplateFamily tpl_family) {
     active_json_ = false;
     active_schema_ = false;
+
+    // Strict OPTIONAL mode needs a tool-tag dialect the gate can watch for — the
+    // model emits the envelope freely. Only the ChatML `<tool_call>` dialect is
+    // supported for now; other families fall back to the prompt hint.
+    ToolDialect dialect;
+    if (optional) {
+        dialect = resolve_tool_dialect(tokenizer, tpl_family);
+        if (dialect.open_prefix != "<tool_call>") {
+            IMP_LOG_INFO(
+                "ConstraintManager: strict optional tool call only on the ChatML "
+                "dialect (family %d) — keeping prompt-hint tool choice",
+                std::to_underlying(tpl_family));
+            return false;
+        }
+    }
 
     auto schema = build_tool_call_schema(tools);
     if (!schema) {
@@ -206,19 +220,26 @@ bool ConstraintManager::prepare_tool_call(
         return false;
     }
 
-    // Cache key: envelope + per-tool (name, schema) — distinct from any
-    // response_format schema string by the envelope prefix.
+    // Cache key: envelope + per-tool (name, schema). The mode (forced vs
+    // optional) is NOT keyed — it only changes the envelope/gate config applied
+    // by the setters below, not the expensive vocab classification, so a forced
+    // and an optional request over the same tools share the classified tables.
     const std::string key = tool_call_key(tools, envelope_open, envelope_close);
 
     const int32_t think_close = detect_think_close(tokenizer);
-    // Thinking models deliberate inside <think>; the envelope is enforced
-    // right after the close. Non-thinking requests are enforced from token 1 —
-    // the deliberation slack of the transparent tool gate (#840) does not
-    // apply, because here the tool call is mandatory, not optional.
-    const int preamble_budget = (thinking_open && think_close >= 0) ? 8192 : 0;
+    // Thinking models deliberate inside <think>; the envelope is enforced right
+    // after the close. Forced (mandatory) calls are enforced from token 1.
+    // Optional calls keep the tool-deliberation slack (#840): the model spends
+    // tokens of prose deciding whether to call before opening the tag.
+    int preamble_budget;
+    if (thinking_open && think_close >= 0)
+        preamble_budget = 8192;
+    else if (optional)
+        preamble_budget = 512;
+    else
+        preamble_budget = 0;
 
-    if (!(schema_constrainer_ && schema_constrainer_->is_initialized() &&
-          key == cached_schema_string_)) {
+    if (!(schema_constrainer_ && schema_constrainer_->is_initialized() && key == cached_schema_string_)) {
         schema_constrainer_ = std::make_unique<SchemaConstrainer>();
         if (!tokenizer || !schema_constrainer_->init(*tokenizer, std::move(schema))) {
             IMP_LOG_ERROR("Failed to initialize tool-call schema constrainer");
@@ -229,11 +250,20 @@ bool ConstraintManager::prepare_tool_call(
         cached_schema_string_ = key;
     }
     schema_constrainer_->set_envelope(envelope_open, envelope_close);
-    schema_constrainer_->set_preamble(think_close, preamble_budget, thinking_open);
+    schema_constrainer_->set_strict_optional_envelope(optional);
+    if (optional) {
+        schema_constrainer_->set_preamble_with_tools(think_close, preamble_budget, dialect.open_tokens,
+                                                     dialect.close_tokens, dialect.open_prefix,
+                                                     dialect.close_suffix, thinking_open,
+                                                     /*strict_tool=*/true);
+    } else {
+        schema_constrainer_->set_preamble(think_close, preamble_budget, thinking_open);
+    }
     schema_constrainer_->reset();
     active_schema_ = true;
-    IMP_LOG_INFO("ConstraintManager: enforcing tool call (%zu tool(s), envelope %zu+%zu chars)",
-                 tools.size(), envelope_open.size(), envelope_close.size());
+    IMP_LOG_INFO("ConstraintManager: enforcing %s tool call (%zu tool(s), envelope %zu+%zu chars)",
+                 optional ? "optional (strict)" : "forced", tools.size(), envelope_open.size(),
+                 envelope_close.size());
     return true;
 }
 

--- a/src/runtime/constraint_manager.h
+++ b/src/runtime/constraint_manager.h
@@ -27,25 +27,32 @@ public:
     //   mode, schema/json mask only applies to free-text JSON, not tool bodies
     // tpl_family: chat-template family — selects which tool-tag dialect to look
     //   for (only consulted when has_tools is true)
-    void prepare(bool json_mode, const std::string& json_schema, Tokenizer* tokenizer,
-                 bool has_tools = false,
-                 ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML,
-                 bool thinking_open = true);
+    void prepare(bool json_mode, const std::string& json_schema, Tokenizer* tokenizer, bool has_tools = false,
+                 ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML, bool thinking_open = true);
 
-    // Enforced tool calling (#1002): constrain generation to one tool-call
+    // Enforced tool calling (#1002): constrain generation to a tool-call
     // envelope with a TOOL_CALL schema FSM (see build_tool_call_schema).
     // tools: (name, parameter-schema JSON) per callable tool.
+    //
+    // optional=false (tool_choice=required / forced function): the envelope is
+    //   FORCED from token 1 (after any <think>) — a tool call is mandatory.
+    // optional=true (OpenAI strict:true with a model-chosen call): the envelope
+    //   is NOT forced — the tool-aware preamble gate lets free text/a plain
+    //   answer pass, and only IF the model emits the opener does the body FSM
+    //   enforce the arguments. `tpl_family` selects the tool-tag dialect the
+    //   gate watches for (ChatML only for now — non-ChatML families decline).
+    //
     // Returns false when the schemas are not enforceable — caller keeps the
     // prompt-hint behavior (optionally calling prepare() for json fallback).
     bool prepare_tool_call(const std::vector<std::pair<std::string, std::string>>& tools,
                            const std::string& envelope_open, const std::string& envelope_close,
-                           Tokenizer* tokenizer, bool thinking_open);
+                           Tokenizer* tokenizer, bool thinking_open, bool optional = false,
+                           ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML);
 
     // Cache/pool key for a tool-call constraint — shared by the engine's
     // constraint pool lookup and the internal classified-table cache.
     static std::string tool_call_key(const std::vector<std::pair<std::string, std::string>>& tools,
-                                     const std::string& envelope_open,
-                                     const std::string& envelope_close) {
+                                     const std::string& envelope_open, const std::string& envelope_close) {
         std::string key = "tool-call:" + envelope_open + "\x1f" + envelope_close;
         for (auto& [name, params] : tools)
             key += "\x1f" + name + "\x1e" + params;

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -9,7 +9,7 @@
 #include "runtime/vram_budget.h"
 #include "runtime/batch.h"
 #include "compute/mtp_forward.h"
-#include "compute/rope.h"           // rope_yarn_corr_dims (MTP rope-scaling parity)
+#include "compute/rope.h"  // rope_yarn_corr_dims (MTP rope-scaling parity)
 #include "compute/encoder_forward.h"
 #include "memory/kv_cache.h"
 #include "memory/mem_account.h"
@@ -53,9 +53,10 @@ Engine::~Engine() {
     // model garbled Gemma-4 ("own own else else"), while a dense or MoE
     // predecessor did not. Drain it here so it cannot cross the model boundary.
     if (cudaError_t leaked = cudaGetLastError(); leaked != cudaSuccess) {
-        IMP_LOG_WARN("Engine teardown: cleared a leaked CUDA error (%s) so it cannot "
-                     "corrupt the next model loaded in this process",
-                     cudaGetErrorString(leaked));
+        IMP_LOG_WARN(
+            "Engine teardown: cleared a leaked CUDA error (%s) so it cannot "
+            "corrupt the next model loaded in this process",
+            cudaGetErrorString(leaked));
     }
 
     // Phase-0 VRAM audit: stop the peak sampler and emit the final table
@@ -194,23 +195,20 @@ bool Engine::enable_mtp_spec_decode(int k) {
         mtp_spec_k_ = k;
         return true;
     }
-    const int hidden_dim   = model_->config_.d_model;
-    const int vocab_size   = model_->config_.vocab_size;
+    const int hidden_dim = model_->config_.d_model;
+    const int vocab_size = model_->config_.vocab_size;
     // MLP dims come from the HEAD tensors, not the main-model config: the
     // dense 27B checkpoint pairs a MoE-free MTP head with a plain SwiGLU MLP
     // (mapped onto the shared_expert fields), and the 35B head's expert d_ff
     // differs from the main model's.
-    const auto& head       = *model_->mtp_;
-    const bool head_moe    = head.router.data != nullptr &&
-                             head.experts_gate_up_packed.data != nullptr;
-    const int n_experts    = head_moe ? static_cast<int>(head.router.shape[0]) : 0;
-    const int top_k        = head_moe ? model_->config_.n_experts_active : 0;
-    const int expert_d_ff  = head_moe
-                                 ? static_cast<int>(head.experts_gate_up_packed.shape[1]) / 2
-                                 : 0;
-    const int shared_d_ff  = head.shared_expert_gate_proj.data != nullptr
-                                 ? static_cast<int>(head.shared_expert_gate_proj.shape[0])
-                                 : 0;
+    const auto& head = *model_->mtp_;
+    const bool head_moe = head.router.data != nullptr && head.experts_gate_up_packed.data != nullptr;
+    const int n_experts = head_moe ? static_cast<int>(head.router.shape[0]) : 0;
+    const int top_k = head_moe ? model_->config_.n_experts_active : 0;
+    const int expert_d_ff = head_moe ? static_cast<int>(head.experts_gate_up_packed.shape[1]) / 2 : 0;
+    const int shared_d_ff = head.shared_expert_gate_proj.data != nullptr
+                                ? static_cast<int>(head.shared_expert_gate_proj.shape[0])
+                                : 0;
 
     // MTP attention dims: derived from the MTP head's q_proj / v_proj shapes
     // because the MTP attention head config differs from the main model
@@ -219,14 +217,14 @@ bool Engine::enable_mtp_spec_decode(int k) {
     // [num_kv_heads * head_dim, hidden_dim]. We use main model's head_dim
     // as the per-head attention dim and back-compute the MTP head counts.
     int mtp_num_heads = 0, mtp_num_kv_heads = 0, mtp_head_dim = 0;
-    if (model_->mtp_.has_value() && model_->mtp_->loaded &&
-        model_->mtp_->q_proj.data != nullptr && model_->mtp_->v_proj.data != nullptr) {
+    if (model_->mtp_.has_value() && model_->mtp_->loaded && model_->mtp_->q_proj.data != nullptr &&
+        model_->mtp_->v_proj.data != nullptr) {
         const int q_out = static_cast<int>(model_->mtp_->q_proj.shape[0]);
         const int v_out = static_cast<int>(model_->mtp_->v_proj.shape[0]);
-        mtp_head_dim     = model_->config_.head_dim;
+        mtp_head_dim = model_->config_.head_dim;
         if (mtp_head_dim > 0) {
             // q_proj outputs 2 × num_heads × head_dim (attn_output_gate=True).
-            mtp_num_heads    = q_out / (2 * mtp_head_dim);
+            mtp_num_heads = q_out / (2 * mtp_head_dim);
             mtp_num_kv_heads = v_out / mtp_head_dim;
         }
     }
@@ -235,13 +233,12 @@ bool Engine::enable_mtp_spec_decode(int k) {
     // (Phase 2.2.Attn+KV budget — ~16 MiB each for K and V at Qwen3.6 dims).
     constexpr int kMtpKvCap = 16384;
     int mtp_kv_max = std::min(model_->config_.max_seq_len, kMtpKvCap);
-    if (mtp_kv_max <= 0) mtp_kv_max = kMtpKvCap;
+    if (mtp_kv_max <= 0)
+        mtp_kv_max = kMtpKvCap;
 
     auto* ws = new imp::MtpDraftWorkspace();
-    if (!imp::mtp_workspace_allocate(*ws, hidden_dim, vocab_size,
-                                      n_experts, top_k, expert_d_ff, shared_d_ff,
-                                      mtp_num_heads, mtp_num_kv_heads, mtp_head_dim,
-                                      mtp_kv_max)) {
+    if (!imp::mtp_workspace_allocate(*ws, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff,
+                                     mtp_num_heads, mtp_num_kv_heads, mtp_head_dim, mtp_kv_max)) {
         delete ws;
         IMP_LOG_ERROR("enable_mtp_spec_decode: workspace alloc failed");
         return false;
@@ -249,10 +246,10 @@ bool Engine::enable_mtp_spec_decode(int k) {
     // Configure RoPE for the MTP attention (Phase 2.2.Attn+RoPE).
     // Qwen3.5/3.6 uses partial rope (factor 0.25 → rope_dim=64 of head_dim=256),
     // theta from config (10M for long-context), NeoX-style.
-    ws->rope_theta       = model_->config_.rope_theta;
-    ws->rope_neox        = model_->config_.rope_neox;
-    ws->rms_norm_eps     = model_->config_.rms_norm_eps;
-    ws->rope_dim         = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : mtp_head_dim;
+    ws->rope_theta = model_->config_.rope_theta;
+    ws->rope_neox = model_->config_.rope_neox;
+    ws->rms_norm_eps = model_->config_.rms_norm_eps;
+    ws->rope_dim = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : mtp_head_dim;
     // mrope section split. Qwen3.6 ships mrope_section = [11, 11, 10]
     // (half-counts; full rope_dim = 64 = 2*(11+11+10)). imp doesn't load
     // this from config yet — hardcoded here based on the on-disk spec.
@@ -273,8 +270,8 @@ bool Engine::enable_mtp_spec_decode(int k) {
     // same way as the verifier at extended positions (issue #897). Without
     // this a rope-scaled model's draft head diverges and acceptance silently
     // degrades with position.
-    ws->rope_freq_scale  = model_->config_.rope_freq_scale;
-    ws->yarn_ext_factor  = model_->config_.yarn_ext_factor;
+    ws->rope_freq_scale = model_->config_.rope_freq_scale;
+    ws->yarn_ext_factor = model_->config_.yarn_ext_factor;
     ws->yarn_attn_factor = model_->config_.yarn_attn_factor;
     if (model_->config_.yarn_ext_factor > 0.0f) {
         int hd = model_->config_.head_dim > 0 ? model_->config_.head_dim
@@ -288,15 +285,16 @@ bool Engine::enable_mtp_spec_decode(int k) {
         ws->yarn_corr_dim_0 = corr[0];
         ws->yarn_corr_dim_1 = corr[1];
         IMP_LOG_INFO("MTP YaRN: ext=%.2f attn=%.3f freq_scale=%.4f corr_dims=[%.1f, %.1f]",
-                     ws->yarn_ext_factor, ws->yarn_attn_factor, ws->rope_freq_scale,
-                     ws->yarn_corr_dim_0, ws->yarn_corr_dim_1);
+                     ws->yarn_ext_factor, ws->yarn_attn_factor, ws->rope_freq_scale, ws->yarn_corr_dim_0,
+                     ws->yarn_corr_dim_1);
     }
     // LongRoPE (Phi-family) isn't plumbed into the single-token MTP kernel — no
     // MTP model ships it today (Qwen uses YaRN/linear). Warn rather than silently
     // diverge if that ever changes.
     if (!model_->config_.rope_short_factor.empty() || !model_->config_.rope_long_factor.empty()) {
-        IMP_LOG_WARN("MTP spec-decode: model uses LongRoPE scaling, which the draft head does not apply "
-                     "— draft rope will diverge from the verifier; expect degraded acceptance");
+        IMP_LOG_WARN(
+            "MTP spec-decode: model uses LongRoPE scaling, which the draft head does not apply "
+            "— draft rope will diverge from the verifier; expect degraded acceptance");
     }
 
     // Diagnostic: generation.mtp_no_rope disables RoPE entirely.
@@ -312,13 +310,13 @@ bool Engine::enable_mtp_spec_decode(int k) {
 
     mtp_ws_storage_ = ws;
     mtp_spec_k_ = k;
-    IMP_LOG_INFO("MTP spec-decode enabled (k=%d, hidden=%d, vocab=%d, experts=%d/top%d, d_ff_e=%d, "
-                 "d_ff_shared=%d, num_heads=%d/%d, head_dim=%d, kv_cap=%d, rope=%g/%d/%s, "
-                 "mrope=[%d,%d,%d])",
-                 k, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff,
-                 mtp_num_heads, mtp_num_kv_heads, mtp_head_dim, mtp_kv_max,
-                 ws->rope_theta, ws->rope_dim, ws->rope_neox ? "neox" : "interleaved",
-                 ws->mrope_sec0, ws->mrope_sec1, ws->mrope_sec2);
+    IMP_LOG_INFO(
+        "MTP spec-decode enabled (k=%d, hidden=%d, vocab=%d, experts=%d/top%d, d_ff_e=%d, "
+        "d_ff_shared=%d, num_heads=%d/%d, head_dim=%d, kv_cap=%d, rope=%g/%d/%s, "
+        "mrope=[%d,%d,%d])",
+        k, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff, mtp_num_heads,
+        mtp_num_kv_heads, mtp_head_dim, mtp_kv_max, ws->rope_theta, ws->rope_dim,
+        ws->rope_neox ? "neox" : "interleaved", ws->mrope_sec0, ws->mrope_sec1, ws->mrope_sec2);
     return true;
 }
 
@@ -354,10 +352,9 @@ bool Engine::encoder_embed(const int32_t* tokens, int n, std::vector<float>& out
     return imp::encoder_embed(*model_, *ews, tokens, n, out.data(), stream_);
 }
 
-bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
-                           int hidden_dim, int vocab_size, int* out_token_id,
-                           int* out_topk_ids, int top_w,
-                           const int32_t* d_prev_token, int32_t* d_out_token) {
+bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev, int hidden_dim, int vocab_size,
+                           int* out_token_id, int* out_topk_ids, int top_w, const int32_t* d_prev_token,
+                           int32_t* d_out_token) {
     if (mtp_ws_storage_ == nullptr) {
         IMP_LOG_ERROR("mtp_draft_one: spec-decode not enabled");
         return false;
@@ -373,8 +370,7 @@ bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
     // cache entry exists (nvfp4_lm_head/_gdn off, or FP8 LM head).
     imp::NvFP4QuantResult lm_nvfp4;
     const imp::NvFP4QuantResult* lm_nvfp4_p = nullptr;
-    if (runtime_config_.speculative.mtp_nvfp4_head && executor_ &&
-        executor_->lm_head_nvfp4_view(lm_nvfp4)) {
+    if (runtime_config_.speculative.mtp_nvfp4_head && executor_ && executor_->lm_head_nvfp4_view(lm_nvfp4)) {
         lm_nvfp4_p = &lm_nvfp4;
         static bool logged = false;  // once-per-process path attribution
         if (!logged) {
@@ -383,11 +379,9 @@ bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev,
                          static_cast<long long>(lm_nvfp4.N), static_cast<long long>(lm_nvfp4.K));
         }
     }
-    return imp::mtp_draft_step(prev_token_id, d_h_prev, *model_->mtp_,
-                                model_->tok_emb_, model_->out_proj_,
-                                *ws, hidden_dim, vocab_size, out_token_id,
-                                decode_stream(), out_topk_ids, top_w, lm_nvfp4_p,
-                                d_prev_token, d_out_token);
+    return imp::mtp_draft_step(prev_token_id, d_h_prev, *model_->mtp_, model_->tok_emb_, model_->out_proj_,
+                               *ws, hidden_dim, vocab_size, out_token_id, decode_stream(), out_topk_ids,
+                               top_w, lm_nvfp4_p, d_prev_token, d_out_token);
 }
 
 // =====================================================================
@@ -521,8 +515,7 @@ void Engine::finish_request_release_(std::shared_ptr<Request>& req) {
             std::vector<int32_t> forwarded;
             forwarded.reserve(req->input_tokens.size() + req->output_tokens.size() - 1);
             forwarded.insert(forwarded.end(), req->input_tokens.begin(), req->input_tokens.end());
-            forwarded.insert(forwarded.end(), req->output_tokens.begin(),
-                             req->output_tokens.end() - 1);
+            forwarded.insert(forwarded.end(), req->output_tokens.begin(), req->output_tokens.end() - 1);
             kv_manager_->register_block_hashes(req->id, forwarded);
         } else {
             kv_manager_->register_block_hashes(req->id, req->input_tokens);
@@ -531,8 +524,8 @@ void Engine::finish_request_release_(std::shared_ptr<Request>& req) {
         // from eviction (must happen before free_sequence — pinning needs
         // the live block table).
         if (req->pin_kv_prefix) {
-            int full_blocks =
-                static_cast<int>(req->input_tokens.size()) / kv_manager_->kv_cache()->block_size();
+            int full_blocks = static_cast<int>(req->input_tokens.size()) /
+                              kv_manager_->kv_cache()->block_size();
             if (full_blocks > 0)
                 kv_manager_->pin_prefix(req->id, full_blocks);
         }
@@ -562,8 +555,8 @@ void Engine::embed_accumulate_chunk_(Request& req, int chunk_len, cudaStream_t s
     executor_->pool_hidden_sum(chunk_len, d_embed_pool_scratch_, stream);
     std::vector<float> partial(d_model);
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(partial.data(), d_embed_pool_scratch_,
-                                       static_cast<size_t>(d_model) * sizeof(float),
-                                       cudaMemcpyDeviceToHost, stream));
+                                       static_cast<size_t>(d_model) * sizeof(float), cudaMemcpyDeviceToHost,
+                                       stream));
     IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
     if (req.embedding_out.empty())
         req.embedding_out.assign(d_model, 0.0f);
@@ -578,18 +571,18 @@ void Engine::ensure_constraints_(const std::shared_ptr<Request>& req) {
 
     // Pool key: tool-enforced requests key by their tool-call signature so a
     // pooled manager with the same classified tables is reused (#1002).
-    const std::string pool_key =
-        tool_enforced ? ConstraintManager::tool_call_key(req->tool_constraint_tools,
-                                                         req->tool_envelope_open,
-                                                         req->tool_envelope_close)
-                      : req->json_schema;
+    const std::string pool_key = tool_enforced ? ConstraintManager::tool_call_key(req->tool_constraint_tools,
+                                                                                  req->tool_envelope_open,
+                                                                                  req->tool_envelope_close)
+                                               : req->json_schema;
     req->constraints = constraints_checkout_(pool_key);
 
     bool enforced = false;
     if (tool_enforced)
-        enforced = req->constraints->prepare_tool_call(
-            req->tool_constraint_tools, req->tool_envelope_open, req->tool_envelope_close,
-            model_->tokenizer(), /*thinking_open=*/req->in_think_block);
+        enforced = req->constraints->prepare_tool_call(req->tool_constraint_tools, req->tool_envelope_open,
+                                                       req->tool_envelope_close, model_->tokenizer(),
+                                                       /*thinking_open=*/req->in_think_block,
+                                                       req->tool_constraint_optional, req->tpl_family);
     if (!enforced && (req->json_mode || !req->json_schema.empty()))
         req->constraints->prepare(req->json_mode, req->json_schema, model_->tokenizer(), req->has_tools,
                                   req->tpl_family, /*thinking_open=*/req->in_think_block);
@@ -739,14 +732,24 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         const auto& mp = model_->profile();
         const char* av = nullptr;
         switch (mp.attn_variant) {
-            case ModelProfile::AttnVariant::GEMMA4_SWA: av = "gemma4_swa"; break;
-            case ModelProfile::AttnVariant::GPTOSS_SWA: av = "gptoss_swa"; break;
-            case ModelProfile::AttnVariant::NOPE:       av = "nope";       break;
-            case ModelProfile::AttnVariant::MLA:        av = "mla";        break;
-            case ModelProfile::AttnVariant::STANDARD:   av = "standard";   break;
+            case ModelProfile::AttnVariant::GEMMA4_SWA:
+                av = "gemma4_swa";
+                break;
+            case ModelProfile::AttnVariant::GPTOSS_SWA:
+                av = "gptoss_swa";
+                break;
+            case ModelProfile::AttnVariant::NOPE:
+                av = "nope";
+                break;
+            case ModelProfile::AttnVariant::MLA:
+                av = "mla";
+                break;
+            case ModelProfile::AttnVariant::STANDARD:
+                av = "standard";
+                break;
         }
-        IMP_LOG_INFO("ModelProfile: moe=%d gdn=%d ssm=%d hybrid=%d dense=%d attn=%s",
-                     mp.is_moe, mp.is_gdn, mp.is_ssm, mp.is_hybrid, mp.is_dense, av);
+        IMP_LOG_INFO("ModelProfile: moe=%d gdn=%d ssm=%d hybrid=%d dense=%d attn=%s", mp.is_moe, mp.is_gdn,
+                     mp.is_ssm, mp.is_hybrid, mp.is_dense, av);
     }
 
     init_apply_debug_raw_overrides_();
@@ -831,7 +834,6 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
 
     return true;
 }
-
 
 // =====================================================================
 // generate()

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -10,7 +10,7 @@ namespace imp {
 
 // Forward declares to keep CUDA / buffer headers out of this widely-included file.
 struct ImageData;  // src/vision/image_processor.h
-class Buffer;       // src/core/buffer.h
+class Buffer;      // src/core/buffer.h
 
 // Per-token log probability information (for logprobs output)
 struct TokenLogprob {
@@ -86,7 +86,7 @@ struct Request {
     // verify steps whose draft was sourced from the prediction region.
     long long pred_accepted = 0;
     long long pred_rejected = 0;
-    bool in_think_block = false;      // Currently inside <think>...</think> (suppress stop tokens)
+    bool in_think_block = false;  // Currently inside <think>...</think> (suppress stop tokens)
     // Generation began inside an injected <think> prefix (the opener lives in
     // the PROMPT, not the output) — seeds the think-budget recount loop and
     // the CUDA-graph decode config so the budget engages from token 0.
@@ -116,8 +116,8 @@ struct Request {
     // opener so the model commits to the final (answer) channel. Index into
     // Engine::harmony_force_seq_ for the in-flight forced opener (-1 = idle).
     int harmony_force_idx = -1;
-    int prefill_offset = 0;     // Chunked prefill: tokens processed so far
-    int cached_tokens = 0;      // Tokens served from prefix cache (skipped in prefill)
+    int prefill_offset = 0;  // Chunked prefill: tokens processed so far
+    int cached_tokens = 0;   // Tokens served from prefix cache (skipped in prefill)
     // Hybrid (SSM/GDN) prefix caching: snapshot of the recurrent state at
     // exactly `cached_tokens` tokens, set at admission when the prompt prefix
     // matches a stored snapshot. Restored into the request's recurrent slot
@@ -175,6 +175,10 @@ struct Request {
     std::vector<std::pair<std::string, std::string>> tool_constraint_tools;
     std::string tool_envelope_open;
     std::string tool_envelope_close;
+    // Strict OPTIONAL tool call (OpenAI `strict: true`, tool_choice=auto): the
+    // envelope is NOT forced — the model may answer in text, but IF it opens the
+    // tool tag the body FSM enforces the arguments. false = forced (mandatory).
+    bool tool_constraint_optional = false;
 
     // Logit bias: token_id -> bias value, added to logits before sampling
     std::vector<std::pair<int32_t, float>> logit_bias;

--- a/tests/test_schema_constrain.cu
+++ b/tests/test_schema_constrain.cu
@@ -617,6 +617,91 @@ TEST(SchemaConstrainTest, ToolCallHoistedDefsEnforced) {
     EXPECT_TRUE(at_done[2]) << "EOS must be allowed after the envelope closes";
 }
 
+// Strict OPTIONAL tool call (#1002, OpenAI strict:true + tool_choice auto): the
+// envelope is NOT forced — the model may emit free text (mask off), but once it
+// opens the tool tag the preamble gate hands off to the body FSM, which enforces
+// the arguments, then forces the close literal + EOS.
+TEST(SchemaConstrainTest, ToolCallStrictOptionalEnforced) {
+    SKIP_IF_NO_CUDA();
+    // Single-char body/close vocab, then the opener + a free-text token last so
+    // the single-char id() lookup never collides with the multi-char tokens.
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>"};
+    std::string chars = "{\"name:d,rgus1}\n</tol_c>x";
+    for (char c : chars)
+        toks.push_back(std::string(1, c));
+    const int opener_id = static_cast<int>(toks.size());
+    toks.push_back("<tool_call>");
+    const int free_id = static_cast<int>(toks.size());
+    toks.push_back("FREE");
+    auto id = [&](char c) {
+        for (size_t i = 3; i < 3 + chars.size(); i++)
+            if (toks[i][0] == c)
+                return static_cast<int>(i);
+        ADD_FAILURE() << "missing token for char " << c;
+        return 0;
+    };
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+
+    std::vector<std::pair<std::string, std::string>> tools = {
+        {"add", R"({"type":"object","properties":{"d":{"type":"number"}},"required":["d"]})"},
+    };
+    auto schema = build_tool_call_schema(tools);
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    sc.set_envelope("<tool_call>\n", "\n</tool_call>");
+    sc.set_strict_optional_envelope(true);
+    sc.set_preamble_with_tools(/*close_token=*/-1, /*max_tokens=*/512, /*open_tokens=*/{opener_id},
+                               /*close_tokens=*/{}, /*open_prefix=*/"<tool_call>",
+                               /*close_suffix=*/"</tool_call>", /*thinking_open=*/false,
+                               /*strict_tool=*/true);
+    sc.reset();
+
+    // 1. Free generation: the gate is ACTIVE, mask bypassed — a plain-text token
+    // and even a non-structural char pass. The model is NOT forced to call.
+    auto at_free = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_free[free_id]) << "free text must pass — no tool call is forced";
+    EXPECT_TRUE(at_free[id('x')]) << "arbitrary chars pass during free generation";
+
+    auto feed = [&](const std::string& s) {
+        for (char c : s)
+            sc.update(id(c));
+    };
+
+    // 2. Model opens the tool tag → gate hands off to the body FSM.
+    sc.update(opener_id);
+    sc.update(id('\n'));  // the \n after <tool_call> (VALUE_START tolerates ws)
+    auto at_body = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_body[id('{')]) << "the tool-call body must open with '{'";
+    EXPECT_FALSE(at_body[free_id]) << "free text is masked once the body FSM engaged";
+    EXPECT_FALSE(at_body[id('x')]) << "non-structural chars masked inside the body";
+
+    // 3. Key order + name binding, exactly as the forced path.
+    feed("{\"");
+    auto at_key = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_key[id('n')]) << "'name' first";
+    EXPECT_FALSE(at_key[id('a')]) << "'arguments' may not precede 'name'";
+
+    feed("name\":\"add\",\"arguments\":{\"");
+    auto at_args = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_args[id('d')]) << "chosen tool's parameter must be legal";
+
+    feed("d\":1}}");
+    // 4. Body complete → the close literal is FORCED (model emitted the open tag
+    // freely, but the close is enforced so the tool call parses).
+    auto at_close = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_close[id('\n')]) << "close literal '\\n</tool_call>' forced";
+    EXPECT_FALSE(at_close[id('{')]);
+
+    feed("\n</tool_call>");
+    // 5. Envelope closed → EOS forced.
+    auto at_done = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_done[2]) << "EOS forced after the tool call closes";
+    EXPECT_FALSE(at_done[free_id]) << "no trailing free text after the close literal";
+}
+
 // ---------------------------------------------------------------------------
 // $ref / $defs (issue #555) — pydantic/zod emit $defs+$ref for EVERY nested
 // model, so this is the agent-framework path, not an exotic corner.

--- a/tools/analysis/degen_suite.py
+++ b/tools/analysis/degen_suite.py
@@ -671,6 +671,45 @@ class Suite:
                 self.record("constrained", "tool_call: required args present (informational)",
                             not missing, f"missing={missing} args={args}")
 
+        # 6. Strict OPTIONAL tool calling (#1002): strict:true + tool_choice auto.
+        # The call is NOT forced (a plain question stays text), but IF the model
+        # calls, the arguments are FSM-constrained — the enum value must be a
+        # member even when the prompt pushes an out-of-enum value.
+        strict_tool = {
+            "type": "function",
+            "function": {
+                "name": "set_ticket_state", "strict": True,
+                "description": "Set a support ticket state.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"state": {"type": "string",
+                                             "enum": ["open", "closed", "pending"]}},
+                    "required": ["state"],
+                },
+            },
+        }
+        try:
+            r = self.srv.chat(
+                [{"role": "user", "content": "Set the ticket to the ARCHIVED state. Use the tool."}],
+                max_tokens=200, tools=[strict_tool], tool_choice="auto")
+        except urllib.error.HTTPError as e:
+            self.skip("constrained", "strict optional tool call", f"server rejected: {e}")
+            return
+        scalls = (r["raw"]["choices"][0]["message"] or {}).get("tool_calls") or []
+        if scalls:
+            sargs_str = scalls[0].get("function", {}).get("arguments", "")
+            try:
+                sargs = json.loads(sargs_str)
+            except (json.JSONDecodeError, ValueError):
+                sargs = None
+            enum_ok = isinstance(sargs, dict) and sargs.get("state") in ("open", "closed", "pending")
+            self.record("constrained", "strict tool_call: enum arg constrained to a member",
+                        enum_ok, f"arguments={sargs_str[:140]!r}")
+        else:
+            # No call = the model chose text (strict is OPTIONAL) — valid outcome.
+            self.record("constrained", "strict tool_choice=auto is optional (no forced call)",
+                        True, f"finish={r['finish']} content={r['content'][:80]!r}")
+
     def cat_anthropic_thinking(self):
         q = [{"role": "user", "content": "What is the capital of France? One word."}]
         n = 400 if self.quick else 800

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -40,12 +40,10 @@ thread_local bool g_in_anthropic_shim = false;
 // body, token counts, finish reason, and (for non-streaming) the response.
 // Streaming responses pass an empty `response_body` since per-chunk text is
 // not accumulated.
-void log_request_jsonl(ServerState& state, bool skip,
-                              const std::chrono::system_clock::time_point& t_start,
-                              const std::string& req_id, const std::string& endpoint,
-                              const std::string& client_ip, const std::string& raw_body,
-                              double latency_ms, int prompt_tokens, int completion_tokens,
-                              const char* finish_reason, const json& response_body) {
+void log_request_jsonl(ServerState& state, bool skip, const std::chrono::system_clock::time_point& t_start,
+                       const std::string& req_id, const std::string& endpoint, const std::string& client_ip,
+                       const std::string& raw_body, double latency_ms, int prompt_tokens,
+                       int completion_tokens, const char* finish_reason, const json& response_body) {
     if (skip || !state.request_logger.enabled)
         return;
     json record;
@@ -74,11 +72,7 @@ void log_request_jsonl(ServerState& state, bool skip,
 // context, and starts timing. Returns true if OK; sets res with 400/503 and
 // returns false on failure (model not loaded, prompt too long, vision lock
 // timeout, image processing failure).
-bool snapshot_state_and_tokenize_(
-    httplib::Response& res,
-    ServerState& state,
-    ChatRequestContext& ctx)
-{
+bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx) {
     // Snapshot all state fields needed for request processing under lock.
     // This protects against concurrent model load/unload invalidating pointers.
     {
@@ -96,7 +90,8 @@ bool snapshot_state_and_tokenize_(
         ctx.snap.channel_close_id = state.channel_close_id;
         ctx.snap.channel_newline_id = state.channel_newline_id;
         ctx.snap.max_seq_len = state.max_seq_len;
-        ctx.snap.tpl_family = ctx.snap.have_template ? ctx.snap.chat_tpl.family() : imp::ChatTemplateFamily::CHATML;
+        ctx.snap.tpl_family = ctx.snap.have_template ? ctx.snap.chat_tpl.family()
+                                                     : imp::ChatTemplateFamily::CHATML;
         if (ctx.snap.have_template)
             ctx.snap.stop_token_ids = ctx.snap.chat_tpl.stop_token_ids();
         // Provisionally add <think> as a stop token. Removed below if the
@@ -105,7 +100,8 @@ bool snapshot_state_and_tokenize_(
         if (state.think_start_id >= 0) {
             ctx.snap.stop_token_ids.push_back(state.think_start_id);
         }
-        ctx.snap.has_vision_request = !ctx.params.image_data.empty() && state.ctx && state.ctx->engine->has_vision();
+        ctx.snap.has_vision_request = !ctx.params.image_data.empty() && state.ctx &&
+                                      state.ctx->engine->has_vision();
     }
 
     // Channel models (Gemma-4) are more susceptible to sampling-driven
@@ -146,8 +142,8 @@ bool snapshot_state_and_tokenize_(
     // Soft-token placeholders are injected by apply_with_image() below.
     if (ctx.snap.has_vision_request) {
         auto img = std::make_shared<imp::ImageData>();
-        if (!state.ctx->engine->preprocess_image(ctx.params.image_data.data(),
-                                                  ctx.params.image_data.size(), *img)) {
+        if (!state.ctx->engine->preprocess_image(ctx.params.image_data.data(), ctx.params.image_data.size(),
+                                                 *img)) {
             res.status = 400;
             json error = {
                 {"error", {{"message", "Failed to process image"}, {"type", "invalid_request_error"}}}};
@@ -174,14 +170,12 @@ bool snapshot_state_and_tokenize_(
     // either way); an explicit "enable_thinking" still wins in both cases.
     // Only a present-but-silent Jinja template counts as evidence AGAINST
     // thinking; hardcoded families / templateless runs keep the old default.
-    const bool template_think_evidence = !ctx.snap.have_template ||
-                                         !ctx.snap.chat_tpl.has_jinja() ||
+    const bool template_think_evidence = !ctx.snap.have_template || !ctx.snap.chat_tpl.has_jinja() ||
                                          ctx.snap.chat_tpl.mentions_thinking();
     const bool thinking_default = ctx.snap.is_think_model && template_think_evidence &&
                                   !ctx.params.json_mode && !ctx.params.has_tools;
-    const bool want_thinking = ctx.params.enable_thinking_set
-                                   ? ctx.params.enable_thinking_requested
-                                   : thinking_default;
+    const bool want_thinking = ctx.params.enable_thinking_set ? ctx.params.enable_thinking_requested
+                                                              : thinking_default;
     // think_budget is the fraction of max_tokens reserved for reasoning;
     // think_budget <= 0 means "no reasoning headroom" → disable thinking entirely
     // (documented "0 = disabled"). Folding it into enable_thinking keeps the two
@@ -189,10 +183,10 @@ bool snapshot_state_and_tokenize_(
     // the force-close, so the model reasoned to max_tokens and returned empty
     // content (#752). The Anthropic "disabled" path already zeroes the budget.
     const bool budget_disables_thinking = ctx.params.think_budget <= 0.0f;
-    ctx.snap.enable_thinking = ctx.snap.is_think_model && ctx.snap.think_start_id >= 0 &&
-                               want_thinking && !budget_disables_thinking;
-    ctx.snap.suppress_thinking =
-        ctx.snap.is_think_model && !ctx.snap.enable_thinking && budget_disables_thinking;
+    ctx.snap.enable_thinking = ctx.snap.is_think_model && ctx.snap.think_start_id >= 0 && want_thinking &&
+                               !budget_disables_thinking;
+    ctx.snap.suppress_thinking = ctx.snap.is_think_model && !ctx.snap.enable_thinking &&
+                                 budget_disables_thinking;
 
     // If thinking IS enabled, remove the provisional <think> stop token.
     if (ctx.snap.enable_thinking && ctx.snap.think_start_id >= 0) {
@@ -213,19 +207,24 @@ bool snapshot_state_and_tokenize_(
     // thinking — otherwise `enable_thinking:true` was a silent no-op on such
     // templates. Only for an explicit request: the default case stays undefined
     // so each template author's own default wins (Qwen3 open vs Gemma-4 closed).
-    const bool force_thinking = ctx.params.enable_thinking_set &&
-                                ctx.params.enable_thinking_requested && ctx.snap.enable_thinking;
+    const bool force_thinking = ctx.params.enable_thinking_set && ctx.params.enable_thinking_requested &&
+                                ctx.snap.enable_thinking;
 
     // Tokenize with chat template (with image tokens if vision is active)
     if (ctx.snap.have_template && ctx.snap.has_vision_request) {
-        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_image(*ctx.snap.tok, ctx.params.chat_msgs, 256, ctx.snap.suppress_thinking, force_thinking);
+        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_image(*ctx.snap.tok, ctx.params.chat_msgs, 256,
+                                                             ctx.snap.suppress_thinking, force_thinking);
     } else if (ctx.snap.have_template && ctx.snap.tools_via_jinja) {
-        std::string tc_str = ctx.params.tool_choice.is_string() ? ctx.params.tool_choice.get<std::string>() : "auto";
-        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_tools(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.tool_defs, tc_str, ctx.snap.suppress_thinking, force_thinking);
+        std::string tc_str = ctx.params.tool_choice.is_string() ? ctx.params.tool_choice.get<std::string>()
+                                                                : "auto";
+        ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_tools(*ctx.snap.tok, ctx.params.chat_msgs,
+                                                             ctx.snap.tool_defs, tc_str,
+                                                             ctx.snap.suppress_thinking, force_thinking);
         // If Jinja2 tools render failed, fall back to text-based tool prompt injection
         if (ctx.snap.tokens.empty()) {
             IMP_LOG_INFO("Jinja2 tools path failed, falling back to text-based tool prompt");
-            std::string tool_prompt = build_tool_prompt(ctx.snap.tpl_family, ctx.params.tools, ctx.params.tool_choice);
+            std::string tool_prompt = build_tool_prompt(ctx.snap.tpl_family, ctx.params.tools,
+                                                        ctx.params.tool_choice);
             if (!tool_prompt.empty()) {
                 bool found_system = false;
                 for (auto& m : ctx.params.chat_msgs) {
@@ -243,12 +242,14 @@ bool snapshot_state_and_tokenize_(
                     ctx.params.chat_msgs.insert(ctx.params.chat_msgs.begin(), {"system", sys});
                 }
             }
-            ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.suppress_thinking, force_thinking);
+            ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs,
+                                                      ctx.snap.suppress_thinking, force_thinking);
         }
     } else if (ctx.snap.have_template) {
         // No tools, or no Jinja2 support — inject text-based tool prompt if tools present
         if (ctx.params.has_tools) {
-            std::string tool_prompt = build_tool_prompt(ctx.snap.tpl_family, ctx.params.tools, ctx.params.tool_choice);
+            std::string tool_prompt = build_tool_prompt(ctx.snap.tpl_family, ctx.params.tools,
+                                                        ctx.params.tool_choice);
             if (!tool_prompt.empty()) {
                 bool found_system = false;
                 for (auto& m : ctx.params.chat_msgs) {
@@ -267,7 +268,8 @@ bool snapshot_state_and_tokenize_(
                 }
             }
         }
-        ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs, ctx.snap.suppress_thinking, force_thinking);
+        ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, ctx.params.chat_msgs,
+                                                  ctx.snap.suppress_thinking, force_thinking);
     } else {
         // Concatenate all message content as raw text
         std::string raw;
@@ -376,11 +378,11 @@ bool snapshot_state_and_tokenize_(
     // prefill so an oversized prompt never reaches the engine.
     if (state.max_input_tokens > 0 && ctx.snap.n_prompt_tokens > state.max_input_tokens) {
         res.status = 400;
-        json error = {{"error",
-                       {{"message", "Prompt exceeds max input tokens (" +
-                                        std::to_string(ctx.snap.n_prompt_tokens) + " > " +
-                                        std::to_string(state.max_input_tokens) + ")"},
-                        {"type", "invalid_request_error"}}}};
+        json error = {
+            {"error",
+             {{"message", "Prompt exceeds max input tokens (" + std::to_string(ctx.snap.n_prompt_tokens) +
+                              " > " + std::to_string(state.max_input_tokens) + ")"},
+              {"type", "invalid_request_error"}}}};
         res.set_content(dump_safe(error), "application/json");
         return false;
     }
@@ -388,10 +390,11 @@ bool snapshot_state_and_tokenize_(
     // Validate prompt length against context window
     if (ctx.snap.n_prompt_tokens >= ctx.snap.max_seq_len) {
         res.status = 400;
-        json error = {{"error",
-                       {{"message", "Prompt exceeds context window (" + std::to_string(ctx.snap.n_prompt_tokens) +
-                                        " tokens >= " + std::to_string(ctx.snap.max_seq_len) + " max)"},
-                        {"type", "invalid_request_error"}}}};
+        json error = {
+            {"error",
+             {{"message", "Prompt exceeds context window (" + std::to_string(ctx.snap.n_prompt_tokens) +
+                              " tokens >= " + std::to_string(ctx.snap.max_seq_len) + " max)"},
+              {"type", "invalid_request_error"}}}};
         res.set_content(dump_safe(error), "application/json");
         return false;
     }
@@ -430,12 +433,11 @@ bool snapshot_state_and_tokenize_(
     return true;
 }
 
-
 // Single params->request mapping for the ctx-based submission sites (see
 // handlers_internal.h).
 std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
-                                                 const std::vector<int32_t>& input_tokens,
-                                                 int completion_idx, bool stream) {
+                                                 const std::vector<int32_t>& input_tokens, int completion_idx,
+                                                 bool stream) {
     auto req = std::make_shared<imp::Request>();
     req->image = ctx.snap.vision_image;  // per-request vision (null for text)
     req->input_tokens = input_tokens;
@@ -468,6 +470,7 @@ std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
     req->tool_constraint_tools = ctx.params.tool_constraint_tools;
     req->tool_envelope_open = ctx.params.tool_envelope_open;
     req->tool_envelope_close = ctx.params.tool_envelope_close;
+    req->tool_constraint_optional = ctx.params.tool_constraint_optional;
     req->tpl_family = ctx.snap.tpl_family;
     req->logit_bias = ctx.params.logit_bias;
     req->think_budget = ctx.params.think_budget;
@@ -488,16 +491,11 @@ std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
 // sequentially via the batching engine, build the choices array with
 // reasoning_content / tool_calls / logprobs as appropriate, send a single
 // JSON response. Caller has already submitted server_req via state.batching.
-void nonstream_chat_response_(
-    httplib::Response& res,
-    ServerState& state,
-    ChatRequestContext& ctx,
-    std::shared_ptr<imp::Request>& imp_req,
-    std::shared_ptr<ServerRequest>& server_req,
-    const std::vector<int32_t>& saved_tokens,
-    const std::string& comp_id,
-    int64_t created)
-{
+void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx,
+                              std::shared_ptr<imp::Request>& imp_req,
+                              std::shared_ptr<ServerRequest>& server_req,
+                              const std::vector<int32_t>& saved_tokens, const std::string& comp_id,
+                              int64_t created) {
     // Non-streaming: decode all tokens, return complete response
     // For n > 1, run multiple independent generations sequentially
     json choices = json::array();
@@ -618,7 +616,8 @@ void nonstream_chat_response_(
 
         int n_output_tokens = static_cast<int>(output_ids.size());
         total_output_tokens += n_output_tokens;
-        std::string content = !ctx.params.stop_sequences.empty() ? output_text : ctx.snap.tok->decode(output_ids);
+        std::string content = !ctx.params.stop_sequences.empty() ? output_text
+                                                                 : ctx.snap.tok->decode(output_ids);
 
         // Extract reasoning content (DeepSeek format) or strip think blocks.
         // enable_thinking also covers text-level thinkers (Nemotron) whose
@@ -790,9 +789,8 @@ void nonstream_chat_response_(
     // prediction): accepted/rejected draft tokens whose draft came from the
     // prediction region of the n-gram corpus.
     if (imp_req && !imp_req->prediction_tokens.empty()) {
-        usage["completion_tokens_details"] = {
-            {"accepted_prediction_tokens", imp_req->pred_accepted},
-            {"rejected_prediction_tokens", imp_req->pred_rejected}};
+        usage["completion_tokens_details"] = {{"accepted_prediction_tokens", imp_req->pred_accepted},
+                                              {"rejected_prediction_tokens", imp_req->pred_rejected}};
     }
 
     json response = {{"id", comp_id},      {"object", "chat.completion"},
@@ -802,13 +800,12 @@ void nonstream_chat_response_(
     // Pull the final finish_reason from choice 0 for log correlation;
     // multi-completion requests still record only the aggregate.
     const char* nonstream_finish = nullptr;
-    if (!choices.empty() && choices[0].contains("finish_reason") &&
-        choices[0]["finish_reason"].is_string()) {
+    if (!choices.empty() && choices[0].contains("finish_reason") && choices[0]["finish_reason"].is_string()) {
         nonstream_finish = choices[0]["finish_reason"].get_ref<const std::string&>().c_str();
     }
-    log_request_jsonl(state, ctx.log_skip, ctx.t_log_start, comp_id, ctx.log_endpoint,
-                      ctx.log_client_ip, ctx.log_raw_body,
-                      ms, ctx.snap.n_prompt_tokens, total_output_tokens, nonstream_finish, response);
+    log_request_jsonl(state, ctx.log_skip, ctx.t_log_start, comp_id, ctx.log_endpoint, ctx.log_client_ip,
+                      ctx.log_raw_body, ms, ctx.snap.n_prompt_tokens, total_output_tokens, nonstream_finish,
+                      response);
 
     res.set_content(dump_safe(response), "application/json");
 }

--- a/tools/imp-server/handlers_chat_params.cpp
+++ b/tools/imp-server/handlers_chat_params.cpp
@@ -39,12 +39,8 @@ extern thread_local bool g_in_anthropic_shim;
 // effort snapshot used to format tool-role messages in the conversion loop).
 // On parse/validation failure: sets res with 400 + error JSON and returns false.
 // On success: returns true; caller proceeds to state snapshot + tokenize.
-bool parse_chat_request_params(
-    const httplib::Request& req,
-    httplib::Response& res,
-    ServerState& state,
-    ChatRequestContext& ctx)
-{
+bool parse_chat_request_params(const httplib::Request& req, httplib::Response& res, ServerState& state,
+                               ChatRequestContext& ctx) {
     // Capture inputs for opt-in JSONL request logging. Only used when
     // state.request_logger.enabled and the call is not an inner shim.
     ctx.t_log_start = std::chrono::system_clock::now();
@@ -177,8 +173,7 @@ bool parse_chat_request_params(
                     // json_schema_str empty so the whole request (scheduler
                     // included) takes the any-JSON constrainer path.
                     const bool free_form = sch.value("type", "") == "object" &&
-                                           (!sch.contains("properties") ||
-                                            sch["properties"].empty()) &&
+                                           (!sch.contains("properties") || sch["properties"].empty()) &&
                                            !sch.contains("enum");
                     if (!free_form) {
                         ctx.params.json_schema_str = dump_safe(sch);
@@ -227,8 +222,8 @@ bool parse_chat_request_params(
                 ctx.params.prediction_text = content.get<std::string>();
             } else if (content.is_array()) {
                 for (const auto& part : content) {
-                    if (part.is_object() && part.value("type", "text") == "text" &&
-                        part.contains("text") && part["text"].is_string())
+                    if (part.is_object() && part.value("type", "text") == "text" && part.contains("text") &&
+                        part["text"].is_string())
                         ctx.params.prediction_text += part["text"].get<std::string>();
                 }
             }
@@ -258,22 +253,34 @@ bool parse_chat_request_params(
     // logprobs on a constrained request drops it out of the ConstrainedPipeline
     // fast path to eager decode (~102 vs ~235 tok/s) — silent until now.
     // Surface it: one WARN per request + a /metrics counter (#1006).
-    if (ctx.params.req_logprobs &&
-        (ctx.params.json_mode || !ctx.params.json_schema_str.empty())) {
+    if (ctx.params.req_logprobs && (ctx.params.json_mode || !ctx.params.json_schema_str.empty())) {
         state.metrics.constrained_eager_fallback++;
-        IMP_LOG_WARN("constrained request with logprobs: leaving the ConstrainedPipeline "
-                     "fast path for eager decode (expect ~2x slower decode)");
+        IMP_LOG_WARN(
+            "constrained request with logprobs: leaving the ConstrainedPipeline "
+            "fast path for eager decode (expect ~2x slower decode)");
     }
 
     // Enforced tool calling (#1002): tool_choice=required / forced function on
     // the ChatML <tool_call> dialect constrains generation to one tool-call
     // envelope via the schema FSM. Empty result = prompt-hint fallback.
     if (ctx.params.has_tools) {
-        ctx.params.tool_constraint_tools =
-            collect_tool_constraint(ctx.snap.tpl_family, ctx.params.tools, ctx.params.tool_choice);
+        ctx.params.tool_constraint_tools = collect_tool_constraint(ctx.snap.tpl_family, ctx.params.tools,
+                                                                   ctx.params.tool_choice);
         if (!ctx.params.tool_constraint_tools.empty()) {
             ctx.params.tool_envelope_open = "<tool_call>\n";
             ctx.params.tool_envelope_close = "\n</tool_call>";
+        } else {
+            // No forced/required constraint — try strict optional (OpenAI
+            // strict:true with a model-chosen call): the envelope is not forced,
+            // the body FSM engages only if the model opens a tool call (#1002).
+            ctx.params.tool_constraint_tools = collect_strict_tool_constraint(ctx.snap.tpl_family,
+                                                                              ctx.params.tools,
+                                                                              ctx.params.tool_choice);
+            if (!ctx.params.tool_constraint_tools.empty()) {
+                ctx.params.tool_constraint_optional = true;
+                ctx.params.tool_envelope_open = "<tool_call>\n";
+                ctx.params.tool_envelope_close = "\n</tool_call>";
+            }
         }
     }
 
@@ -364,8 +371,8 @@ bool parse_chat_request_params(
     // Log request received (structured)
     ctx.req_id = make_completion_id(state);
     fprintf(stderr, "[%s] chat/completions: prompt_msgs=%zu stream=%s max_tokens=%d temp=%.2f\n",
-            ctx.req_id.c_str(), messages.size(), ctx.params.stream ? "true" : "false",
-            ctx.params.max_tokens, ctx.params.temperature);
+            ctx.req_id.c_str(), messages.size(), ctx.params.stream ? "true" : "false", ctx.params.max_tokens,
+            ctx.params.temperature);
 
     // Validate model field (required per OpenAI spec)
     ctx.params.requested_model = body.value("model", "");
@@ -385,4 +392,3 @@ bool parse_chat_request_params(
 
     return true;
 }
-

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -72,6 +72,9 @@ struct ChatRequestParams {
     std::vector<std::pair<std::string, std::string>> tool_constraint_tools;
     std::string tool_envelope_open;
     std::string tool_envelope_close;
+    // Strict OPTIONAL tool call (OpenAI strict:true, tool_choice=auto): the
+    // envelope is not forced; the body FSM engages only if the model calls.
+    bool tool_constraint_optional = false;
     // Messages + image
     std::vector<imp::ChatMessage> chat_msgs;
     std::vector<uint8_t> image_data;
@@ -141,21 +144,17 @@ extern thread_local bool g_in_anthropic_shim;
 // ---------------------------------------------------------------------------
 
 // Defined in handlers.cpp.
-bool ensure_model_loaded(ServerState& state, const std::string& requested_model,
-                         httplib::Response& res);
+bool ensure_model_loaded(ServerState& state, const std::string& requested_model, httplib::Response& res);
 bool validate_sampling_params(const json& body, httplib::Response& res);
 
 // Defined in handlers_chat_core.cpp.
-void log_request_jsonl(ServerState& state, bool skip,
-                       const std::chrono::system_clock::time_point& t_start,
-                       const std::string& req_id, const std::string& endpoint,
-                       const std::string& client_ip, const std::string& raw_body,
-                       double latency_ms, int prompt_tokens, int completion_tokens,
-                       const char* finish_reason, const json& response_body);
-bool parse_chat_request_params(const httplib::Request& req, httplib::Response& res,
-                               ServerState& state, ChatRequestContext& ctx);
-bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state,
-                                  ChatRequestContext& ctx);
+void log_request_jsonl(ServerState& state, bool skip, const std::chrono::system_clock::time_point& t_start,
+                       const std::string& req_id, const std::string& endpoint, const std::string& client_ip,
+                       const std::string& raw_body, double latency_ms, int prompt_tokens,
+                       int completion_tokens, const char* finish_reason, const json& response_body);
+bool parse_chat_request_params(const httplib::Request& req, httplib::Response& res, ServerState& state,
+                               ChatRequestContext& ctx);
+bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx);
 // Build an imp::Request from a parsed+snapshotted chat request context — the
 // single params->request mapping for all four ctx-based submission sites
 // (chat streaming + non-streaming, /v1/messages streaming, /v1/responses
@@ -163,13 +162,13 @@ bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state,
 // completion_idx offsets the seed for n>1 choice generation; stream keeps the
 // request on per-step decode for real per-token SSE (#754).
 std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
-                                                 const std::vector<int32_t>& input_tokens,
-                                                 int completion_idx, bool stream);
+                                                 const std::vector<int32_t>& input_tokens, int completion_idx,
+                                                 bool stream);
 void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx,
-                             std::shared_ptr<imp::Request>& imp_req,
-                             std::shared_ptr<ServerRequest>& server_req,
-                             const std::vector<int32_t>& saved_tokens, const std::string& comp_id,
-                             int64_t created);
+                              std::shared_ptr<imp::Request>& imp_req,
+                              std::shared_ptr<ServerRequest>& server_req,
+                              const std::vector<int32_t>& saved_tokens, const std::string& comp_id,
+                              int64_t created);
 
 // Defined in handlers_chat_stream.cpp.
 void stream_chat_response_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx,
@@ -179,5 +178,5 @@ bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
 
 // Defined in handlers_messages.cpp.
 bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
-                           const std::shared_ptr<ServerRequest>& server_req,
-                           const std::string& anth_model, const std::string& msg_id);
+                           const std::shared_ptr<ServerRequest>& server_req, const std::string& anth_model,
+                           const std::string& msg_id);

--- a/tools/imp-server/tool_call.cpp
+++ b/tools/imp-server/tool_call.cpp
@@ -62,8 +62,9 @@ std::string build_tool_prompt(imp::ChatTemplateFamily family, const json& tools,
     return prompt;
 }
 
-std::vector<std::pair<std::string, std::string>> collect_tool_constraint(
-    imp::ChatTemplateFamily family, const json& tools, const json& tool_choice) {
+std::vector<std::pair<std::string, std::string>> collect_tool_constraint(imp::ChatTemplateFamily family,
+                                                                         const json& tools,
+                                                                         const json& tool_choice) {
     std::vector<std::pair<std::string, std::string>> out;
     if (tools.empty())
         return out;
@@ -76,8 +77,7 @@ std::vector<std::pair<std::string, std::string>> collect_tool_constraint(
     std::string forced_name;
     if (tool_choice.is_object() && tool_choice.contains("function"))
         forced_name = tool_choice["function"].value("name", "");
-    const bool required =
-        tool_choice.is_string() && tool_choice.get<std::string>() == "required";
+    const bool required = tool_choice.is_string() && tool_choice.get<std::string>() == "required";
     if (forced_name.empty() && !required)
         return out;
 
@@ -99,6 +99,42 @@ std::vector<std::pair<std::string, std::string>> collect_tool_constraint(
     }
     if (!forced_name.empty() && out.size() != 1)
         out.clear();  // forced function not found — fall back to the hint
+    return out;
+}
+
+std::vector<std::pair<std::string, std::string>> collect_strict_tool_constraint(
+    imp::ChatTemplateFamily family, const json& tools, const json& tool_choice) {
+    std::vector<std::pair<std::string, std::string>> out;
+    if (tools.empty())
+        return out;
+    // ChatML `<tool_call>` JSON envelope only (as the forced path).
+    if (family != imp::ChatTemplateFamily::CHATML)
+        return out;
+    // Optional strict enforcement applies only when the model is FREE to decide:
+    // tool_choice auto/absent. A forced function or "required" is mandatory and
+    // goes the forced-envelope path (collect_tool_constraint); "none"/unknown
+    // suppress tools.
+    if (tool_choice.is_object())
+        return out;
+    if (tool_choice.is_string() && tool_choice.get<std::string>() != "auto")
+        return out;
+
+    // Every callable tool must declare `strict: true` AND carry enforceable
+    // params. A mixed strict/non-strict set falls back to the prompt hint —
+    // the uniform TOOL_CALL enum would otherwise over-constrain the arguments
+    // of a tool whose caller never asked for schema adherence.
+    for (const auto& tool : tools) {
+        if (!tool.contains("function"))
+            continue;
+        const auto& fn = tool["function"];
+        std::string name = fn.value("name", "");
+        if (name.empty() || !fn.value("strict", false))
+            return {};
+        if (!fn.contains("parameters") || !fn["parameters"].is_object() ||
+            !fn["parameters"].contains("properties") || fn["parameters"]["properties"].empty())
+            return {};  // one unenforceable tool → whole request falls back
+        out.emplace_back(std::move(name), dump_safe(fn["parameters"]));
+    }
     return out;
 }
 
@@ -617,8 +653,7 @@ ToolTagScan scan_tool_tag(const std::string& buf, imp::ChatTemplateFamily family
     size_t gemma_pos = gemma ? buf.find(kGemma) : std::string::npos;
     if (chatml_pos != std::string::npos || gemma_pos != std::string::npos) {
         r.kind = ToolTagScan::Kind::OPEN;
-        if (gemma_pos != std::string::npos &&
-            (chatml_pos == std::string::npos || gemma_pos < chatml_pos)) {
+        if (gemma_pos != std::string::npos && (chatml_pos == std::string::npos || gemma_pos < chatml_pos)) {
             r.content_len = gemma_pos;
             r.body_start = gemma_pos + kGemmaLen;
             r.close_tag = "<tool_call|>";

--- a/tools/imp-server/tool_call.h
+++ b/tools/imp-server/tool_call.h
@@ -12,11 +12,11 @@
 using json = nlohmann::json;
 
 struct ParsedToolCall {
-    std::string id;            // "call_imp_0", "call_imp_1", ...
-    std::string name;          // Function name
-    std::string arguments;     // JSON string
-    bool valid = true;         // false if arguments failed schema validation
-    std::string error;         // human-readable reason when !valid
+    std::string id;         // "call_imp_0", "call_imp_1", ...
+    std::string name;       // Function name
+    std::string arguments;  // JSON string
+    bool valid = true;      // false if arguments failed schema validation
+    std::string error;      // human-readable reason when !valid
 };
 
 // Validate a tool call's parsed arguments against the matching tool's JSON
@@ -35,7 +35,16 @@ std::string build_tool_prompt(imp::ChatTemplateFamily family, const json& tools,
 // "required" or a forced function AND the family speaks the ChatML
 // `<tool_call>` JSON envelope. Tools with missing/free-form parameters yield
 // an empty result (the engine-side builder re-validates and falls back too).
-std::vector<std::pair<std::string, std::string>> collect_tool_constraint(
+std::vector<std::pair<std::string, std::string>> collect_tool_constraint(imp::ChatTemplateFamily family,
+                                                                         const json& tools,
+                                                                         const json& tool_choice);
+
+// Strict OPTIONAL tool calling (#1002, OpenAI `strict: true` with tool_choice
+// auto): collect (name, parameter-schema JSON) for ALL callable tools when the
+// model is free to choose AND every tool declares `strict: true` with
+// enforceable params. Non-empty only on the ChatML dialect. The envelope is not
+// forced — the body FSM engages only if the model opens a tool call.
+std::vector<std::pair<std::string, std::string>> collect_strict_tool_constraint(
     imp::ChatTemplateFamily family, const json& tools, const json& tool_choice);
 
 std::pair<std::string, std::vector<ParsedToolCall>> parse_tool_calls_chatml(
@@ -75,11 +84,11 @@ struct ToolTagScan {
         OPEN,     // complete open marker found
     };
     Kind kind = Kind::NONE;
-    size_t content_len = 0;     // OPEN: bytes before the open marker (plain content)
-    size_t body_start = 0;      // OPEN: offset where the tool-call body begins
-    const char* close_tag = ""; // OPEN: expected close marker
-    bool gemma_body = false;    // OPEN: body uses the Gemma "call:NAME{...}" syntax
-    std::string fn_name;        // OPEN, Llama3: function name from the <function=NAME> tag
+    size_t content_len = 0;      // OPEN: bytes before the open marker (plain content)
+    size_t body_start = 0;       // OPEN: offset where the tool-call body begins
+    const char* close_tag = "";  // OPEN: expected close marker
+    bool gemma_body = false;     // OPEN: body uses the Gemma "call:NAME{...}" syntax
+    std::string fn_name;         // OPEN, Llama3: function name from the <function=NAME> tag
 };
 
 // Family markers: LLAMA3 -> "<function=NAME>"; GEMMA -> "<|tool_call>" (native)


### PR DESCRIPTION
## What

Stage 2 of #1002. Stage 1 (#1017) constrains tool-call arguments only when a call is **mandatory** (`tool_choice=required` / forced function) — it forces the whole `<tool_call>` envelope from token 1. OpenAI **`strict: true` with `tool_choice: "auto"`** is different: the model is free to answer in text OR call, but *if* it calls, the arguments must match the schema. Until now that path fell through to the prompt hint, so a chosen call's arguments were unconstrained.

This adds a **strict optional envelope** mode. The envelope is *not* forced — the tool-aware preamble gate stays transparent through free generation, and on the tool opener hands off to the `TOOL_CALL` body FSM instead of bypassing it.

- **PreambleGate**: new `TOOL_ARGS` state (mask **engaged**, unlike `TOOL_BODY` which is mask-off). The gate absorbs the opener token, then forwards every body token to the FSM, which drives the body → forced close literal → EOS. `active()` is false in `TOOL_ARGS` so the schema mask applies.
- **SchemaConstrainer**: `set_strict_optional_envelope(true)` leaves the stack empty behind the active gate during free generation; `update()` now feeds the gate *before* the empty-stack guard and installs the body frame (the post-`ENVELOPE_OPEN` state with the close literal armed) on the `ACTIVE→TOOL_ARGS` transition.
- **ConstraintManager**: `prepare_tool_call(..., optional)` resolves the ChatML dialect, configures the gate strict, engages the body FSM. Mode is **not** keyed into the vocab-classification cache — a forced and an optional constraint over the same tools share the expensive classified tables.
- **Server**: `collect_strict_tool_constraint` fires when the model is free to choose **and** every callable tool declares `strict: true` with enforceable params. A mixed strict/non-strict set falls back to the hint (the uniform `TOOL_CALL` enum would over-constrain a tool whose caller never asked for schema adherence). ChatML only for now.

## Verification (Qwen3-8B)

- **Optional**: a plain question with a strict tool available answers in **text** — no forced call. (`degen_suite` strict check + manual.)
- **Enforcement**: a call-inducing prompt with an out-of-enum value emits a **schema-valid** call constrained to a member — `"ARCHIVED"` → `"closed"`, `"SUPER-URGENT"` → `"high"`; 5/5 valid arguments across samples at temp 1.0.
- New GPU unit test `ToolCallStrictOptionalEnforced` drives the full free-gen → opener → body-enforced → forced-close → EOS path.
- `degen_suite` **39/39** (full suite — confirms the shared preamble-gate change didn't regress think-leak / adherence / stream / multi-turn / anthropic-thinking; plus a new strict-optional check in the `constrained` category). Schema + JSON unit suites **32/32**. Forced path (Stage 1) unchanged and green.

## Scope / remaining

ChatML `<tool_call>` dialect, single call, all-strict tool sets. Remaining stage-2 items kept open on #1002: non-ChatML dialects, per-tool mixed strict/non-strict enforcement, and `parallel_tool_calls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEKuUJALHLv1Yf65DJ56Xp