### PR TITLE
feat(tools): parallel_tool_calls in the strict optional tool-call FSM (#1002 stage 2)

### DIFF
--- a/src/compute/preamble_gate.h
+++ b/src/compute/preamble_gate.h
@@ -113,6 +113,16 @@ public:
     // frame on the ACTIVE → TOOL_ARGS transition.
     bool in_tool_args() const noexcept { return state_ == State::TOOL_ARGS; }
 
+    // Re-arm after a strict tool-call body completed, for parallel_tool_calls
+    // (#1002): TOOL_ARGS → ACTIVE so free text / EOS / another tool opener all
+    // pass again, and a following `<tool_call>` engages a fresh body FSM. The
+    // preamble budget restarts (a fresh slack window for the inter-call gap).
+    void rearm_after_call() noexcept {
+        state_ = State::ACTIVE;
+        seen_ = 0;
+        char_buf_.clear();
+    }
+
     // Returns true if the token was fully consumed by the gate (FSM should
     // NOT process it). Returns false only for the one transition where
     // the token must be forwarded to the FSM: ACTIVE → OFF via `{` or `[`.

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -567,6 +567,13 @@ void SchemaConstrainer::update(int32_t token) {
         if (!sim_advance(stack_, c))
             break;  // illegal char (mask should have prevented this) — stop early
     }
+    // parallel_tool_calls (#1002): a strict tool-call body just drained the
+    // stack (envelope close consumed). Instead of forcing EOS, re-arm the gate
+    // so the model may open another `<tool_call>` (fresh body FSM) or stop.
+    if (strict_optional_envelope_ && allow_parallel_ && stack_.empty() && preamble_.in_tool_args()) {
+        preamble_.rearm_after_call();
+        return;
+    }
     if (!stack_.empty()) {
         IMP_LOG_DEBUG("SchemaConstrainer::update token=%d [%s] phase %d->%d stack=%zu", token, text.c_str(),
                       std::to_underlying(before), std::to_underlying(top().phase), stack_.size());

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -126,6 +126,13 @@ public:
     // BEFORE reset().
     void set_strict_optional_envelope(bool v) { strict_optional_envelope_ = v; }
 
+    // parallel_tool_calls (#1002, strict optional mode only): when true, the gate
+    // re-arms after each tool-call body completes instead of forcing EOS, so the
+    // model may emit several tool calls (each body FSM-enforced) or stop. When
+    // false, EOS is forced after the first call (at most one). Configure BEFORE
+    // reset().
+    void set_allow_parallel(bool v) { allow_parallel_ = v; }
+
     bool is_initialized() const { return initialized_; }
 
     // See JsonConstrainer::set_preamble for semantics — close-token mode for
@@ -182,6 +189,10 @@ private:
     // Strict OPTIONAL tool call: the open literal is NOT forced (the model emits
     // it freely); the preamble gate hands off to the body FSM on the opener.
     bool strict_optional_envelope_ = false;
+
+    // parallel_tool_calls: re-arm the gate after each strict tool-call body so
+    // the model may emit several calls (strict mode only).
+    bool allow_parallel_ = false;
 
     // Helpers
     // C++23 deducing this: one overload serves const and non-const callers.

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -195,7 +195,7 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
 bool ConstraintManager::prepare_tool_call(const std::vector<std::pair<std::string, std::string>>& tools,
                                           const std::string& envelope_open, const std::string& envelope_close,
                                           Tokenizer* tokenizer, bool thinking_open, bool optional,
-                                          ChatTemplateFamily tpl_family) {
+                                          ChatTemplateFamily tpl_family, bool parallel) {
     active_json_ = false;
     active_schema_ = false;
 
@@ -251,6 +251,9 @@ bool ConstraintManager::prepare_tool_call(const std::vector<std::pair<std::strin
     }
     schema_constrainer_->set_envelope(envelope_open, envelope_close);
     schema_constrainer_->set_strict_optional_envelope(optional);
+    // parallel_tool_calls only re-arms in strict optional mode; forced calls
+    // remain single (their gate is not tool-aware, so re-arm never fires).
+    schema_constrainer_->set_allow_parallel(optional && parallel);
     if (optional) {
         schema_constrainer_->set_preamble_with_tools(think_close, preamble_budget, dialect.open_tokens,
                                                      dialect.close_tokens, dialect.open_prefix,

--- a/src/runtime/constraint_manager.h
+++ b/src/runtime/constraint_manager.h
@@ -44,10 +44,12 @@ public:
     //
     // Returns false when the schemas are not enforceable — caller keeps the
     // prompt-hint behavior (optionally calling prepare() for json fallback).
+    // parallel (strict optional mode only): true = the model may emit several
+    // tool calls (each body enforced); false = at most one, then EOS.
     bool prepare_tool_call(const std::vector<std::pair<std::string, std::string>>& tools,
                            const std::string& envelope_open, const std::string& envelope_close,
                            Tokenizer* tokenizer, bool thinking_open, bool optional = false,
-                           ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML);
+                           ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML, bool parallel = true);
 
     // Cache/pool key for a tool-call constraint — shared by the engine's
     // constraint pool lookup and the internal classified-table cache.

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -582,7 +582,8 @@ void Engine::ensure_constraints_(const std::shared_ptr<Request>& req) {
         enforced = req->constraints->prepare_tool_call(req->tool_constraint_tools, req->tool_envelope_open,
                                                        req->tool_envelope_close, model_->tokenizer(),
                                                        /*thinking_open=*/req->in_think_block,
-                                                       req->tool_constraint_optional, req->tpl_family);
+                                                       req->tool_constraint_optional, req->tpl_family,
+                                                       req->tool_constraint_parallel);
     if (!enforced && (req->json_mode || !req->json_schema.empty()))
         req->constraints->prepare(req->json_mode, req->json_schema, model_->tokenizer(), req->has_tools,
                                   req->tpl_family, /*thinking_open=*/req->in_think_block);

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -179,6 +179,9 @@ struct Request {
     // envelope is NOT forced — the model may answer in text, but IF it opens the
     // tool tag the body FSM enforces the arguments. false = forced (mandatory).
     bool tool_constraint_optional = false;
+    // parallel_tool_calls (strict optional only): true = the gate re-arms after
+    // each enforced call so the model may emit several; false = at most one.
+    bool tool_constraint_parallel = true;
 
     // Logit bias: token_id -> bias value, added to logits before sampling
     std::vector<std::pair<int32_t, float>> logit_bias;

--- a/tests/test_schema_constrain.cu
+++ b/tests/test_schema_constrain.cu
@@ -702,6 +702,73 @@ TEST(SchemaConstrainTest, ToolCallStrictOptionalEnforced) {
     EXPECT_FALSE(at_done[free_id]) << "no trailing free text after the close literal";
 }
 
+// parallel_tool_calls (#1002): in strict optional mode with allow_parallel, the
+// gate RE-ARMS after each tool-call body instead of forcing EOS — the model may
+// emit a second `<tool_call>` (fresh body FSM) or stop.
+TEST(SchemaConstrainTest, ToolCallStrictParallelReArms) {
+    SKIP_IF_NO_CUDA();
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>"};
+    std::string chars = "{\"name:d,rgus1}\n</tol_c>x";
+    for (char c : chars)
+        toks.push_back(std::string(1, c));
+    const int opener_id = static_cast<int>(toks.size());
+    toks.push_back("<tool_call>");
+    const int free_id = static_cast<int>(toks.size());
+    toks.push_back("FREE");
+    auto id = [&](char c) {
+        for (size_t i = 3; i < 3 + chars.size(); i++)
+            if (toks[i][0] == c)
+                return static_cast<int>(i);
+        ADD_FAILURE() << "missing token for char " << c;
+        return 0;
+    };
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+
+    std::vector<std::pair<std::string, std::string>> tools = {
+        {"add", R"({"type":"object","properties":{"d":{"type":"number"}},"required":["d"]})"},
+    };
+    auto schema = build_tool_call_schema(tools);
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    sc.set_envelope("<tool_call>\n", "\n</tool_call>");
+    sc.set_strict_optional_envelope(true);
+    sc.set_allow_parallel(true);
+    sc.set_preamble_with_tools(-1, 512, {opener_id}, {}, "<tool_call>", "</tool_call>",
+                               /*thinking_open=*/false, /*strict_tool=*/true);
+    sc.reset();
+
+    auto feed = [&](const std::string& s) {
+        for (char c : s)
+            sc.update(id(c));
+    };
+
+    // First call: open → body → close literal.
+    sc.update(opener_id);
+    feed("\n{\"name\":\"add\",\"arguments\":{\"d\":1}}\n</tool_call>");
+
+    // Re-armed: the gate is ACTIVE again (mask off) — NOT a forced EOS. Free
+    // text, EOS, and another opener are all legal now.
+    auto at_between = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_between[free_id]) << "after a call the model may emit more (parallel)";
+    EXPECT_TRUE(at_between[2]) << "EOS is also legal — the model may stop";
+
+    // Second call opens → the body FSM engages a fresh frame.
+    sc.update(opener_id);
+    sc.update(id('\n'));
+    auto at_body2 = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_body2[id('{')]) << "second tool-call body must open with '{'";
+    EXPECT_FALSE(at_body2[id('x')]) << "second body is FSM-constrained too";
+    EXPECT_FALSE(at_body2[free_id]) << "free text masked inside the second body";
+
+    feed("{\"name\":\"add\",\"arguments\":{\"d\":1}}\n</tool_call>");
+    // Re-armed once more → EOS still legal to finish.
+    auto at_end = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_end[2]) << "EOS legal after the second call";
+}
+
 // ---------------------------------------------------------------------------
 // $ref / $defs (issue #555) — pydantic/zod emit $defs+$ref for EVERY nested
 // model, so this is the agent-framework path, not an exotic corner.

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -471,6 +471,7 @@ std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
     req->tool_envelope_open = ctx.params.tool_envelope_open;
     req->tool_envelope_close = ctx.params.tool_envelope_close;
     req->tool_constraint_optional = ctx.params.tool_constraint_optional;
+    req->tool_constraint_parallel = ctx.params.parallel_tool_calls;
     req->tpl_family = ctx.snap.tpl_family;
     req->logit_bias = ctx.params.logit_bias;
     req->think_budget = ctx.params.think_budget;


### PR DESCRIPTION
## What

Stage 2 of #1002, building on #1035. The strict optional path forced EOS after a single tool call, so a model that wanted to call several tools (OpenAI's `parallel_tool_calls` **default true**) was cut off after the first — even though the server already parses and returns multiple `<tool_call>` blocks from *unconstrained* output.

Small, contained fix: after a strict tool-call body drains the stack (envelope close consumed), **re-arm** the preamble gate instead of forcing EOS.

- `PreambleGate::rearm_after_call()`: `TOOL_ARGS → ACTIVE` (fresh budget) — free text / EOS / another `<tool_call>` opener all pass again, and a following opener engages a fresh body FSM.
- `SchemaConstrainer::set_allow_parallel(bool)`; `update()` re-arms when a strict body just drained the stack and `allow_parallel` is set (otherwise the existing force-EOS-after-one behavior stands).
- `ConstraintManager::prepare_tool_call(parallel)`: `set_allow_parallel(optional && parallel)` — forced calls never re-arm (their gate isn't tool-aware, so the guard never fires anyway).
- Threaded the already-parsed `parallel_tool_calls` request field through to the constraint (default true).

## Verification (Qwen3-8B)

- `parallel_tool_calls: true` — "get the weather for both Paris and Tokyo" with strict tools emits **two** schema-valid calls (`{"city":"Paris"}`, `{"city":"Tokyo"}`), 3/3.
- `parallel_tool_calls: false` — same prompt emits **exactly one**, 3/3.
- New GPU unit test `ToolCallStrictParallelReArms` drives open → body → close → re-arm → second body → EOS.
- Constrain + gate suites **60/60**; `degen_suite --only constrained` **8/8**. Forced and single-call strict paths unchanged.

## Scope / remaining

Strict optional (auto) path, ChatML. Remaining stage-2 items kept open on #1002: non-ChatML dialects, `parallel` on the forced/`required` path, and per-tool mixed strict/non-strict enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEKuUJALHLv1Yf65DJ56Xp