### PR TITLE
feat(tools): Llama3 forced tool-call arg enforcement (#1002 stage 2)

### DIFF
--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -195,7 +195,7 @@ void ConstraintManager::prepare(bool json_mode, const std::string& json_schema, 
 bool ConstraintManager::prepare_tool_call(const std::vector<std::pair<std::string, std::string>>& tools,
                                           const std::string& envelope_open, const std::string& envelope_close,
                                           Tokenizer* tokenizer, bool thinking_open, bool optional,
-                                          ChatTemplateFamily tpl_family, bool parallel) {
+                                          ChatTemplateFamily tpl_family, bool parallel, bool bare_args) {
     active_json_ = false;
     active_schema_ = false;
 
@@ -214,7 +214,26 @@ bool ConstraintManager::prepare_tool_call(const std::vector<std::pair<std::strin
         }
     }
 
-    auto schema = build_tool_call_schema(tools);
+    // Llama3 bare-args: the `<function=NAME>{args}</function>` body IS the
+    // arguments object, so the constraint root is the tool's parameter schema
+    // directly (the per-tool envelope carries the name). Otherwise the ChatML
+    // TOOL_CALL {"name","arguments"} wrapper.
+    std::unique_ptr<SchemaNode> schema;
+    if (bare_args) {
+        if (tools.size() != 1) {
+            IMP_LOG_INFO("ConstraintManager: bare-args tool call needs exactly one tool");
+            return false;
+        }
+        auto parsed = parse_json_schema(tools[0].second);
+        const SchemaNode* res = parsed ? resolve_schema_ref(parsed.get(), parsed.get()) : nullptr;
+        if (!res || res->type != SchemaType::OBJECT || res->properties.empty()) {
+            IMP_LOG_INFO("ConstraintManager: bare-args parameter schema not enforceable");
+            return false;
+        }
+        schema = std::move(parsed);
+    } else {
+        schema = build_tool_call_schema(tools);
+    }
     if (!schema) {
         IMP_LOG_INFO("ConstraintManager: tool schemas not enforceable — keeping prompt-hint tool choice");
         return false;

--- a/src/runtime/constraint_manager.h
+++ b/src/runtime/constraint_manager.h
@@ -46,10 +46,14 @@ public:
     // prompt-hint behavior (optionally calling prepare() for json fallback).
     // parallel (strict optional mode only): true = the model may emit several
     // tool calls (each body enforced); false = at most one, then EOS.
+    // bare_args (Llama3 `<function=NAME>{args}</function>`): the constraint root
+    // is the single tool's bare parameter schema (the body is the arguments
+    // object), not a TOOL_CALL {"name","arguments"} wrapper.
     bool prepare_tool_call(const std::vector<std::pair<std::string, std::string>>& tools,
                            const std::string& envelope_open, const std::string& envelope_close,
                            Tokenizer* tokenizer, bool thinking_open, bool optional = false,
-                           ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML, bool parallel = true);
+                           ChatTemplateFamily tpl_family = ChatTemplateFamily::CHATML, bool parallel = true,
+                           bool bare_args = false);
 
     // Cache/pool key for a tool-call constraint — shared by the engine's
     // constraint pool lookup and the internal classified-table cache.

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -583,7 +583,8 @@ void Engine::ensure_constraints_(const std::shared_ptr<Request>& req) {
                                                        req->tool_envelope_close, model_->tokenizer(),
                                                        /*thinking_open=*/req->in_think_block,
                                                        req->tool_constraint_optional, req->tpl_family,
-                                                       req->tool_constraint_parallel);
+                                                       req->tool_constraint_parallel,
+                                                       req->tool_constraint_bare_args);
     if (!enforced && (req->json_mode || !req->json_schema.empty()))
         req->constraints->prepare(req->json_mode, req->json_schema, model_->tokenizer(), req->has_tools,
                                   req->tpl_family, /*thinking_open=*/req->in_think_block);

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -182,6 +182,10 @@ struct Request {
     // parallel_tool_calls (strict optional only): true = the gate re-arms after
     // each enforced call so the model may emit several; false = at most one.
     bool tool_constraint_parallel = true;
+    // Llama3 forced call: the constraint root is the bare parameter schema (the
+    // `<function=NAME>{args}</function>` body is the arguments object), not a
+    // TOOL_CALL {"name","arguments"} wrapper.
+    bool tool_constraint_bare_args = false;
 
     // Logit bias: token_id -> bias value, added to logits before sampling
     std::vector<std::pair<int32_t, float>> logit_bias;

--- a/tests/test_tool_call_constrain.cu
+++ b/tests/test_tool_call_constrain.cu
@@ -344,5 +344,61 @@ TEST(SchemaConstrainTest, ToolCallStrictParallelReArms) {
     EXPECT_TRUE(at_end[2]) << "EOS legal after the second call";
 }
 
+// Llama3 forced tool call (#1002): `<function=NAME>{args}</function>` — the body
+// is the bare arguments object, so the constraint root is the parameter schema
+// directly (per-tool envelope), not a TOOL_CALL wrapper.
+TEST(SchemaConstrainTest, Llama3BareArgsForcedEnvelope) {
+    SKIP_IF_NO_CUDA();
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>"};
+    std::string chars = "<functio=ad>/{\":1}x";
+    for (char c : chars)
+        toks.push_back(std::string(1, c));
+    auto id = [&](char c) {
+        for (size_t i = 3; i < toks.size(); i++)
+            if (toks[i][0] == c)
+                return static_cast<int>(i);
+        ADD_FAILURE() << "missing token for char " << c;
+        return 0;
+    };
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, 1, 2);
+
+    // Bare parameter schema (NOT a TOOL_CALL wrapper).
+    auto schema = parse_json_schema(
+        R"({"type":"object","properties":{"d":{"type":"number"}},"required":["d"]})");
+    ASSERT_TRUE(schema != nullptr);
+    SchemaConstrainer sc;
+    ASSERT_TRUE(sc.init(tok, std::move(schema)));
+    sc.set_envelope("<function=add>", "</function>");  // forced (no strict flag)
+    sc.reset();
+
+    auto feed = [&](const std::string& s) {
+        for (char c : s)
+            sc.update(id(c));
+    };
+
+    // 1. Envelope open forced: '<' legal, the body '{' is not yet.
+    auto at_start = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_start[id('<')]) << "the <function=...> envelope must open first";
+    EXPECT_FALSE(at_start[id('{')]) << "the args body may not start before the envelope";
+
+    feed("<function=add>{\"");
+    // 2. Inside the bare args object: the parameter 'd' is a legal key, 'x' not.
+    auto at_key = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_key[id('d')]) << "the tool parameter must be legal";
+    EXPECT_FALSE(at_key[id('x')]) << "a non-parameter key must be masked";
+
+    feed("d\":1}");
+    // 3. Body complete → the close literal '</function>' is forced.
+    auto at_close = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_close[id('<')]) << "close literal must be legal after the body";
+    EXPECT_FALSE(at_close[id('{')]);
+
+    feed("</function>");
+    auto at_done = schema_allowed(sc, static_cast<int>(toks.size()));
+    EXPECT_TRUE(at_done[2]) << "EOS forced after the envelope closes";
+}
+
 }  // namespace
 }  // namespace imp

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -472,6 +472,7 @@ std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
     req->tool_envelope_close = ctx.params.tool_envelope_close;
     req->tool_constraint_optional = ctx.params.tool_constraint_optional;
     req->tool_constraint_parallel = ctx.params.parallel_tool_calls;
+    req->tool_constraint_bare_args = ctx.params.tool_constraint_bare_args;
     req->tpl_family = ctx.snap.tpl_family;
     req->logit_bias = ctx.params.logit_bias;
     req->think_budget = ctx.params.think_budget;

--- a/tools/imp-server/handlers_chat_params.cpp
+++ b/tools/imp-server/handlers_chat_params.cpp
@@ -282,6 +282,19 @@ bool parse_chat_request_params(const httplib::Request& req, httplib::Response& r
                 ctx.params.tool_envelope_close = "\n</tool_call>";
             }
         }
+        // Llama3 `<function=NAME>{args}</function>` forced function: constrain the
+        // bare parameter schema with a per-tool envelope (#1002). Only when the
+        // ChatML paths above found nothing (different family).
+        if (ctx.params.tool_constraint_tools.empty()) {
+            auto [ln, lparams] = collect_llama3_forced_tool(ctx.snap.tpl_family, ctx.params.tools,
+                                                            ctx.params.tool_choice);
+            if (!ln.empty()) {
+                ctx.params.tool_constraint_tools = {{ln, lparams}};
+                ctx.params.tool_constraint_bare_args = true;
+                ctx.params.tool_envelope_open = "<function=" + ln + ">";
+                ctx.params.tool_envelope_close = "</function>";
+            }
+        }
     }
 
     // Convert JSON messages to ChatMessage vector, extracting image data if present

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -75,6 +75,10 @@ struct ChatRequestParams {
     // Strict OPTIONAL tool call (OpenAI strict:true, tool_choice=auto): the
     // envelope is not forced; the body FSM engages only if the model calls.
     bool tool_constraint_optional = false;
+    // Llama3 `<function=NAME>{args}</function>` forced call: the constraint root
+    // is the bare parameter schema (the body is the arguments object), not a
+    // TOOL_CALL {"name","arguments"} wrapper.
+    bool tool_constraint_bare_args = false;
     // Messages + image
     std::vector<imp::ChatMessage> chat_msgs;
     std::vector<uint8_t> image_data;

--- a/tools/imp-server/tool_call.cpp
+++ b/tools/imp-server/tool_call.cpp
@@ -102,6 +102,37 @@ std::vector<std::pair<std::string, std::string>> collect_tool_constraint(imp::Ch
     return out;
 }
 
+std::pair<std::string, std::string> collect_llama3_forced_tool(imp::ChatTemplateFamily family,
+                                                               const json& tools, const json& tool_choice) {
+    // Llama3 tool calls are `<function=NAME>{JSON args}</function>` — the body
+    // IS the arguments object (name is in the tag), so a forced single function
+    // maps onto the plain parameter schema with a per-tool envelope. Only the
+    // forced-function case is enforceable here: "required"/auto would need a
+    // name-in-tag enum binding (follow-up); Gemma/Qwen3.6-XML bodies are
+    // non-JSON and need a separate grammar (out of scope for the JSON FSM).
+    if (family != imp::ChatTemplateFamily::LLAMA3 || tools.empty())
+        return {};
+    if (!tool_choice.is_object() || !tool_choice.contains("function"))
+        return {};
+    std::string forced = tool_choice["function"].value("name", "");
+    if (forced.empty())
+        return {};
+    for (const auto& tool : tools) {
+        if (!tool.contains("function"))
+            continue;
+        const auto& fn = tool["function"];
+        if (fn.value("name", "") != forced)
+            continue;
+        // Enforceable parameters only (an absent/free-form schema dead-ends the
+        // FSM's key phase — the engine-side parser re-checks).
+        if (!fn.contains("parameters") || !fn["parameters"].is_object() ||
+            !fn["parameters"].contains("properties") || fn["parameters"]["properties"].empty())
+            return {};
+        return {forced, dump_safe(fn["parameters"])};
+    }
+    return {};
+}
+
 std::vector<std::pair<std::string, std::string>> collect_strict_tool_constraint(
     imp::ChatTemplateFamily family, const json& tools, const json& tool_choice) {
     std::vector<std::pair<std::string, std::string>> out;

--- a/tools/imp-server/tool_call.h
+++ b/tools/imp-server/tool_call.h
@@ -47,6 +47,14 @@ std::vector<std::pair<std::string, std::string>> collect_tool_constraint(imp::Ch
 std::vector<std::pair<std::string, std::string>> collect_strict_tool_constraint(
     imp::ChatTemplateFamily family, const json& tools, const json& tool_choice);
 
+// Llama3 forced tool calling (#1002): `<function=NAME>{JSON args}</function>` —
+// the body IS the arguments object, so a forced single function constrains the
+// bare parameter schema (per-tool `<function=NAME>` envelope), not a TOOL_CALL
+// wrapper. Returns {name, params-JSON} for a forced enforceable Llama3 function,
+// or {} otherwise. Gemma / Qwen3.6-XML bodies are non-JSON (separate grammar).
+std::pair<std::string, std::string> collect_llama3_forced_tool(imp::ChatTemplateFamily family,
+                                                               const json& tools, const json& tool_choice);
+
 std::pair<std::string, std::vector<ParsedToolCall>> parse_tool_calls_chatml(
     const std::string& text, std::atomic<int>& next_tool_call_id);
 


### PR DESCRIPTION
## What

Extends the constrained tool-call FSM to the **Llama3 `<function=NAME>{args}</function>`** dialect. Unlike ChatML's `{"name","arguments"}` envelope, the Llama3 body IS the bare arguments object (name is in the tag) — so a forced single function maps onto the tool's **parameter schema directly** with a per-tool `<function=NAME>` / `</function>` envelope, reusing the existing forced-envelope machinery with a non-`TOOL_CALL` root.

- `collect_llama3_forced_tool` (server): fires on `family=LLAMA3` + a forced function with enforceable params.
- `prepare_tool_call(bare_args)`: constraint root = `parse_json_schema(params)` (an OBJECT) instead of `build_tool_call_schema` — the envelope carries the name.
- Threaded `tool_constraint_bare_args` through params/request/engine.

## Verification (Llama-3.2-3B)

Forced `set_priority` with an out-of-enum urgency push → `<function=set_priority>{"level":"high","task":"deploy"}</function>` — the enum arg constrained to a member, args schema-valid (4/4 at temp 1.0; the sole earlier "no call" was a `max_tokens` truncation before `</function>`). New GPU unit test `Llama3BareArgsForcedEnvelope`; `degen_suite` tool checks green on Llama3.

(Note: `degen_suite` flagged a pre-existing `json_object` number-degeneration `{"neutral":0.0.0.0…}` on this 3B model — that's the any-JSON `JsonConstrainer` number FSM, untouched by this change.)

## Scope

Llama3 **forced-function**. Gemma (`call:NAME{key:value}`) and Qwen3.6-XML bodies are **non-JSON** and need a separate constrained-grammar engine (out of scope for the JSON schema FSM); Llama3 required/auto would need a name-in-tag enum binding. Tracked on #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEKuUJALHLv1Yf65DJ56Xp