### PR TITLE
test(agents): real agent-harness E2E stage 2 — model-driven loop + external aider (#1007)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize coverage
+.PHONY: roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize coverage
 
 # Check that no other process is using the GPU (games, other inference, etc.)
 check-gpu:
@@ -145,7 +145,18 @@ test-agents: build check-gpu
 	@echo "waiting for server..."; \
 	for i in $$(seq 1 90); do curl -sf http://localhost:8080/health >/dev/null 2>&1 && break; sleep 2; done; \
 	trap 'docker rm -f imp-agent-suite >/dev/null 2>&1' EXIT; \
-	python3 tools/analysis/agent_loop_suite.py --url http://localhost:8080
+	echo "--- stage 1: wire-conformance (forced flows, 3 dialects) ---"; \
+	python3 tools/analysis/agent_loop_suite.py --url http://localhost:8080; \
+	echo "--- stage 2: real model-driven loop (auto tool_choice, real tools) ---"; \
+	python3 tools/analysis/agent_task_loop.py --url http://localhost:8080 --model $(AGENTIC_MODEL)
+
+# #1007 stage-2 EXTERNAL gate (opt-in): a real third-party coding agent (aider)
+# driving imp-server through a genuine edit loop — proves the whole loop survives
+# an ACTUAL agent binary. Heavier than `test-agents` (builds a harness image with
+# aider baked in, uses --network host), so it is a separate opt-in target rather
+# than part of the default agent battery. GPU + local model.
+test-agents-external: build check-gpu
+	bash tools/analysis/agent_external_smoke.sh $(AGENTIC_MODEL) 8080
 
 # Golden output comparison (greedy, temp=0)
 test-golden: build

--- a/tools/Dockerfile.agents
+++ b/tools/Dockerfile.agents
@@ -1,0 +1,16 @@
+# Harness image for the #1007 stage-2 EXTERNAL agent gate: a real third-party
+# coding agent (aider) driving imp-server over the OpenAI dialect. Kept separate
+# from the runtime image (which ships no Python) so the gate is self-contained;
+# deps are baked at build time (network available then) so the test run is offline.
+#
+# Build:  docker build -f tools/Dockerfile.agents -t imp:agents tools/
+# Usage:  see the `test-agents-external` Makefile target.
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# aider-chat speaks OpenAI-compatible bases via litellm. Pin a known-good line.
+RUN pip install --no-cache-dir "aider-chat==0.86.1"
+
+WORKDIR /work

--- a/tools/analysis/agent_external_smoke.sh
+++ b/tools/analysis/agent_external_smoke.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# #1007 stage-2 EXTERNAL gate: a real third-party coding agent (aider) driving
+# imp-server over the OpenAI dialect through a real edit loop. Proves the whole
+# loop survives an ACTUAL agent binary, not just our own driver.
+#
+# Boots imp-server (imp:test), runs aider (imp:agents) with OPENAI_API_BASE
+# pointed at it on a throwaway git repo, asks for a one-function edit, and asserts
+# the function landed in the file. Opt-in (heavier: builds a harness image + uses
+# --network host) — the hard gate is `make test-agents` (agent_task_loop.py).
+#
+# Usage: tools/analysis/agent_external_smoke.sh [MODEL] [PORT]
+set -euo pipefail
+
+MODEL="${1:-Qwen3-8B-Q8_0.gguf}"
+PORT="${2:-8080}"
+IMG_SERVER="${DOCKER_IMG:-imp:test}"
+IMG_AGENTS="imp:agents"
+SRV_NAME="imp-agent-external"
+WORK="$(mktemp -d)"
+
+cleanup() {
+    docker rm -f "$SRV_NAME" >/dev/null 2>&1 || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "=== #1007 external agent smoke: aider -> imp-server (model=$MODEL) ==="
+
+# 1. Harness image (aider). Baked deps => the run itself is offline.
+docker build -q -f tools/Dockerfile.agents -t "$IMG_AGENTS" tools/ >/dev/null
+echo "harness image ready ($IMG_AGENTS)"
+
+# 2. Boot imp-server.
+docker rm -f "$SRV_NAME" >/dev/null 2>&1 || true
+docker run -d --name "$SRV_NAME" --gpus all -p "${PORT}:8080" \
+    -v "$HOME/models:/models" "$IMG_SERVER" \
+    imp-server --host 0.0.0.0 --model "/models/$MODEL" >/dev/null
+echo -n "waiting for server"
+for _ in $(seq 1 90); do
+    if curl -sf "http://localhost:${PORT}/health" >/dev/null 2>&1; then echo " ok"; break; fi
+    echo -n "."; sleep 2
+done
+curl -sf "http://localhost:${PORT}/health" >/dev/null || { echo "server did not come up"; exit 1; }
+
+# 3. Throwaway repo + the edit task.
+git -C "$WORK" init -q
+git -C "$WORK" config user.email t@t.t
+git -C "$WORK" config user.name t
+printf '# math helpers\n' > "$WORK/math_utils.py"
+git -C "$WORK" add -A
+git -C "$WORK" commit -qm init
+
+# 4. Real agent: aider makes its own edit decisions and applies the diff.
+docker run --rm --network host -v "$WORK:/work" -w /work \
+    -e OPENAI_API_BASE="http://localhost:${PORT}/v1" -e OPENAI_API_KEY=dummy \
+    "$IMG_AGENTS" aider --model "openai/${MODEL}" \
+    --yes-always --no-auto-commits --no-check-update --no-show-model-warnings \
+    --no-gitignore --map-tokens 0 \
+    --message "Add a function add(a, b) that returns a + b to math_utils.py" \
+    math_utils.py 2>&1 | tail -15
+
+# 5. Gate: the function must have landed in the file.
+if grep -Eq 'def[[:space:]]+add[[:space:]]*\([[:space:]]*a[[:space:]]*,[[:space:]]*b' "$WORK/math_utils.py"; then
+    echo "PASS: aider applied a real edit (add(a, b)) via imp-server"
+    exit 0
+fi
+echo "FAIL: expected add(a, b) in math_utils.py, got:"; cat "$WORK/math_utils.py"
+exit 1

--- a/tools/analysis/agent_task_loop.py
+++ b/tools/analysis/agent_task_loop.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Real model-driven agent loop against imp-server (#1007, stage 2).
+
+Where stage 1 (agent_loop_suite.py) drives FORCED wire patterns, this stage lets
+the MODEL drive: a multi-step task, `tool_choice:auto`, REAL local tools executed
+for real, looping turn-by-turn until the model stops calling tools — the actual
+agent loop a harness runs. Gates on task completion, not wire shape.
+
+Tasks (per dialect — OpenAI /v1/chat/completions + Anthropic /v1/messages):
+  chain     "compute (17+25)*3" with add()/multiply() tools — the model must
+            call add -> read the result -> call multiply -> answer 126. A genuine
+            2-step chain the model sequences itself.
+  optional  a plain question with tools available — the model must answer WITHOUT
+            calling (auto is optional), proving tools don't force a call.
+  lookup    "what's the capital stored for 'FR'?" with a get(key) tool over a
+            fixed table — one call, then the answer must use the returned value.
+
+Pass = every task completes: tool calls parse, arguments run the real tool, the
+final answer reflects the tool results, no turn stalls (>60s = fail), loop
+terminates within the turn cap. Stdlib-only; mirrors degen_suite conventions.
+
+Usage:
+  python3 tools/analysis/agent_task_loop.py [--url http://localhost:8080]
+                                            [--model NAME] [--only openai,anthropic]
+"""
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+MAX_TURNS = 6
+TIMEOUT = 60
+
+# ---- real tools the model can call (executed for real, no stubs) -------------
+_TABLE = {"FR": "Paris", "JP": "Tokyo", "BR": "Brasilia"}
+
+
+def tool_add(a, b):
+    return {"result": float(a) + float(b)}
+
+
+def tool_multiply(a, b):
+    return {"result": float(a) * float(b)}
+
+
+def tool_get(key):
+    return {"value": _TABLE.get(str(key), None)}
+
+
+TOOLS_IMPL = {"add": tool_add, "multiply": tool_multiply, "get": tool_get}
+
+# OpenAI-dialect tool schemas (Anthropic derives from these below).
+OAI_TOOLS = [
+    {"type": "function", "function": {
+        "name": "add", "description": "Add two numbers.",
+        "parameters": {"type": "object",
+                       "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+                       "required": ["a", "b"]}}},
+    {"type": "function", "function": {
+        "name": "multiply", "description": "Multiply two numbers.",
+        "parameters": {"type": "object",
+                       "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+                       "required": ["a", "b"]}}},
+    {"type": "function", "function": {
+        "name": "get", "description": "Look up the capital city stored for a 2-letter country code.",
+        "parameters": {"type": "object", "properties": {"key": {"type": "string"}},
+                       "required": ["key"]}}},
+]
+
+
+def _anthropic_tools():
+    return [{"name": t["function"]["name"], "description": t["function"]["description"],
+             "input_schema": t["function"]["parameters"]} for t in OAI_TOOLS]
+
+
+class Suite:
+    def __init__(self, url, model):
+        self.url = url.rstrip("/")
+        self.model = model
+        self.results = []
+
+    def record(self, cat, name, ok, detail=""):
+        self.results.append((cat, name, ok, detail))
+        mark = "\033[32mPASS\033[0m" if ok else "\033[31mFAIL\033[0m"
+        print(f"  [{mark}] {name}" + (f" — {detail}" if detail and not ok else ""))
+
+    def _post(self, path, body):
+        data = json.dumps(body).encode()
+        req = urllib.request.Request(self.url + path, data=data,
+                                     headers={"Content-Type": "application/json"})
+        t0 = time.monotonic()
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+            payload = json.loads(r.read())
+        return payload, time.monotonic() - t0
+
+    # ---- OpenAI /v1/chat/completions driver --------------------------------
+    def run_openai(self, cat, messages, expect_substr, force_no_call=False):
+        max_stall = 0.0
+        calls_made = 0
+        for turn in range(MAX_TURNS):
+            body = {"model": self.model, "messages": messages, "tools": OAI_TOOLS,
+                    "tool_choice": "auto", "temperature": 0.3, "max_tokens": 400}
+            try:
+                rsp, dt = self._post("/v1/chat/completions", body)
+            except (urllib.error.URLError, TimeoutError) as e:
+                self.record(cat, "openai loop completes", False, f"turn {turn}: {e}")
+                return
+            max_stall = max(max_stall, dt)
+            msg = rsp["choices"][0]["message"]
+            tcs = msg.get("tool_calls") or []
+            if not tcs:
+                content = msg.get("content") or ""
+                if force_no_call:
+                    self.record(cat, "openai: no forced call (auto is optional)",
+                                calls_made == 0, f"calls={calls_made} content={content[:60]!r}")
+                    return
+                ok = expect_substr.lower() in content.lower()
+                self.record(cat, "openai: final answer uses tool results", ok,
+                            f"answer={content[:80]!r} want~{expect_substr!r}")
+                self.record(cat, "openai: no turn stall", max_stall < TIMEOUT,
+                            f"max_turn={max_stall:.1f}s")
+                return
+            # Execute every requested tool for real and feed results back.
+            messages.append(msg)
+            for tc in tcs:
+                calls_made += 1
+                fn = tc["function"]["name"]
+                try:
+                    args = json.loads(tc["function"]["arguments"])
+                    out = TOOLS_IMPL[fn](**args)
+                    ok = True
+                except (json.JSONDecodeError, TypeError, KeyError, ValueError) as e:
+                    out, ok = {"error": str(e)}, False
+                if not ok:
+                    self.record(cat, "openai: tool call args run the real tool", False,
+                                f"fn={fn} args={tc['function']['arguments'][:80]!r}")
+                    return
+                messages.append({"role": "tool", "tool_call_id": tc.get("id", ""),
+                                 "content": json.dumps(out)})
+        self.record(cat, "openai loop terminates within turn cap", False,
+                    f"still calling after {MAX_TURNS} turns")
+
+    # ---- Anthropic /v1/messages driver -------------------------------------
+    def run_anthropic(self, cat, first_user, expect_substr):
+        messages = [{"role": "user", "content": first_user}]
+        max_stall = 0.0
+        calls_made = 0
+        for turn in range(MAX_TURNS):
+            body = {"model": self.model, "messages": messages, "tools": _anthropic_tools(),
+                    "max_tokens": 400, "temperature": 0.3}
+            try:
+                rsp, dt = self._post("/v1/messages", body)
+            except (urllib.error.URLError, TimeoutError) as e:
+                self.record(cat, "anthropic loop completes", False, f"turn {turn}: {e}")
+                return
+            max_stall = max(max_stall, dt)
+            blocks = rsp.get("content", [])
+            tool_uses = [b for b in blocks if b.get("type") == "tool_use"]
+            if not tool_uses:
+                text = " ".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+                ok = expect_substr.lower() in text.lower()
+                self.record(cat, "anthropic: final answer uses tool results", ok,
+                            f"answer={text[:80]!r} want~{expect_substr!r}")
+                self.record(cat, "anthropic: no turn stall", max_stall < TIMEOUT,
+                            f"max_turn={max_stall:.1f}s")
+                return
+            messages.append({"role": "assistant", "content": blocks})
+            tool_results = []
+            for tu in tool_uses:
+                calls_made += 1
+                fn = tu.get("name", "")
+                try:
+                    out = TOOLS_IMPL[fn](**(tu.get("input") or {}))
+                    ok = True
+                except (TypeError, KeyError, ValueError) as e:
+                    out, ok = {"error": str(e)}, False
+                if not ok:
+                    self.record(cat, "anthropic: tool_use input runs the real tool", False,
+                                f"fn={fn} input={tu.get('input')}")
+                    return
+                tool_results.append({"type": "tool_result", "tool_use_id": tu.get("id", ""),
+                                     "content": json.dumps(out)})
+            messages.append({"role": "user", "content": tool_results})
+        self.record(cat, "anthropic loop terminates within turn cap", False,
+                    f"still calling after {MAX_TURNS} turns")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://localhost:8080")
+    ap.add_argument("--model", default="Qwen3-8B-Q8_0.gguf")
+    ap.add_argument("--only", default="")
+    args = ap.parse_args()
+    only = {c for c in args.only.split(",") if c} or None
+
+    suite = Suite(args.url, args.model)
+    t0 = time.monotonic()
+
+    chain_prompt = ("Compute (17 + 25) * 3 using the add and multiply tools, one step "
+                    "at a time. Add first, then multiply the sum by 3. Report the final number.")
+    lookup_prompt = "Use the get tool to look up the capital stored for country code 'FR', then tell me the city."
+    plain_prompt = "In one word, what color is a clear daytime sky? Do not use any tools."
+
+    if not only or "openai" in only:
+        print("== openai (model-driven, real tools) ==")
+        suite.run_openai("openai", [{"role": "user", "content": chain_prompt}], "126")
+        suite.run_openai("openai", [{"role": "user", "content": lookup_prompt}], "Paris")
+        suite.run_openai("openai", [{"role": "user", "content": plain_prompt}], "", force_no_call=True)
+    if not only or "anthropic" in only:
+        print("== anthropic (model-driven, real tools) ==")
+        suite.run_anthropic("anthropic", chain_prompt, "126")
+        suite.run_anthropic("anthropic", lookup_prompt, "Paris")
+
+    fails = [r for r in suite.results if not r[2]]
+    dt = time.monotonic() - t0
+    print("=" * 60)
+    print(f"agent_task_loop: {len(suite.results)} checks, {len(fails)} FAIL ({dt:.0f}s)")
+    for cat, name, _, detail in fails:
+        print(f"  FAIL [{cat}] {name}: {detail}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Stage 1 (#1020) gates wire-conformance with **forced** flows. Stage 2 adds the piece the issue calls for: a **real agent driving imp-server, making its own decisions**.

- **`tools/analysis/agent_task_loop.py`** — a genuine model-driven loop (stdlib, host-run like stage 1): a multi-step task with `tool_choice: "auto"` and **real local tools** (`add`/`multiply`/`get`) executed for real, looped turn-by-turn until the model stops calling. The model:
  - sequences a 2-step chain itself: `(17+25)*3 → 126`,
  - does a table lookup: `get('FR') → Paris`,
  - answers a plain question **without** calling (auto is optional).
  
  Across the OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) dialects. Wired as **`make test-agents` stage 2** (hard gate).
- **`tools/analysis/agent_external_smoke.sh` + `tools/Dockerfile.agents`** — an **external real coding agent** (aider) driving imp-server over the OpenAI dialect through a genuine edit loop, asserting a one-function edit lands in the file. Opt-in **`make test-agents-external`** (heavier: harness image with aider baked in + `--network host`). Codex / Claude Code CLI are auth/network-gated → unfit for an offline gate (documented).

## Verification (Qwen3-8B)

- `agent_task_loop.py`: **9/9 in 12s**, both dialects — real 2-step chain, lookup, and the optional (no-call) case.
- `agent_external_smoke.sh`: aider applied a real `def add(a, b): return a + b` edit via imp-server, gate **PASS**.

No runtime-image change — both run host/harness-side against the server container, matching the existing `test-agents` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEKuUJALHLv1Yf65DJ56Xp