### PR TITLE
feat(serving): long-context hygiene — NIAH gate past 16K, SWA validated, max_seq_len docs (#1022)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize coverage
+.PHONY: roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize coverage
 
 # Check that no other process is using the GPU (games, other inference, etc.)
 check-gpu:
@@ -149,6 +149,23 @@ test-agents: build check-gpu
 	python3 tools/analysis/agent_loop_suite.py --url http://localhost:8080; \
 	echo "--- stage 2: real model-driven loop (auto tool_choice, real tools) ---"; \
 	python3 tools/analysis/agent_task_loop.py --url http://localhost:8080 --model $(AGENTIC_MODEL)
+
+# Needle-in-a-haystack retrieval gate past 16K (#1022): boots a model that fits
+# a long context and asserts a planted needle is retrieved at 16K and 32K across
+# depths. A CORRECTNESS gate (retrieval success), independent of timing — safe on
+# any host. The TTFT timing gates at 32K-64K need a verified-healthy host to pin
+# their numbers (benchmarking contract) and are run separately.
+NIAH_MODEL ?= Qwen3-14B-Q6_K.gguf
+test-niah: build check-gpu
+	@docker rm -f imp-niah >/dev/null 2>&1 || true
+	@docker run -d --name imp-niah --gpus all -p 8080:8080 \
+		-v $(HOME)/models:/models $(DOCKER_IMG) \
+		imp-server --host 0.0.0.0 --model /models/$(NIAH_MODEL) --set runtime.max_seq_len=40000 >/dev/null
+	@echo "waiting for server..."; \
+	for i in $$(seq 1 90); do curl -sf http://localhost:8080/health >/dev/null 2>&1 && break; sleep 2; done; \
+	trap 'docker rm -f imp-niah >/dev/null 2>&1' EXIT; \
+	python3 tools/analysis/niah_check.py --url http://localhost:8080 --model $(NIAH_MODEL) \
+		--lengths 16000,32000 --depths 0.1,0.5,0.9
 
 # #1007 stage-2 EXTERNAL gate (opt-in): a real third-party coding agent (aider)
 # driving imp-server through a genuine edit loop — proves the whole loop survives

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -74,7 +74,12 @@ decode_pipeline      = true
 # (docs/determinism.md). ON by default; set false in dev/CI where init time
 # matters more than reproducibility.
 warmup               = true
-# Override the model's max_seq_len (0 = use the model default).
+# Override the model's max_seq_len (0 = auto-detect). Auto-detection caps at 64K
+# (bounded further by VRAM and the model's declared context). A model that
+# declares MORE than 64K needs this set explicitly to run past 64K — the auto
+# path never selects above the 64K ceiling. Long-context TTFT grows with the
+# attention math (Qwen3-14B Q6_K measured ~3.7s at 32K, ~10s at 64K), so raise
+# it deliberately for long-transcript / agentic workloads.
 max_seq_len          = 0
 # Hard VRAM budget for this process in MiB (0 = uncapped). Every sizing
 # decision (weight caches, KV clamp, expert offload, workspaces, upload
@@ -111,12 +116,20 @@ bitdecoding_qk              = false
 # typical 4..32; only with dtype = "nvfp4" + bitdecoding_qk).
 bitdecoding_residual_tokens = 0
 # SWA-aware KV sizing: sliding-window layers (gpt-oss window=128 on every
-# other layer, gemma-3 5:1 pattern) allocate only the trailing window in a
-# small dedicated block group instead of full-length KV — ~2x more KV tokens
-# on gpt-oss, ~5-6x on gemma-3. Auto-disabled (logged) for models without
-# SWA layers, INT8/INT4 KV, hybrids, MLA, StreamingLLM, green contexts, and
-# deterministic mode; prefix caching is forced off while active (freed
-# window blocks can't back prefix reuse). Default off until validated.
+# other layer, gemma-3/4 5:1 pattern) allocate only the trailing window in a
+# small dedicated block group instead of full-length KV. The saving grows with
+# the max_seq_len : window ratio — modest at 16K, large at 64K-128K where the
+# fixed window is a small fraction of the context. VALIDATED on Gemma-4-26B
+# (2026-07-16): windowed layers size to the window while the global layers keep
+# full context, so retrieval is intact — a needle placed early in a 3.2K context
+# is still retrieved (the 5 global layers carry it), output stays coherent, and
+# the full max_seq_len fits in VRAM that otherwise capped short.
+# Auto-disabled (logged) for models without SWA layers, INT8/INT4 KV, hybrids,
+# MLA, StreamingLLM, green contexts, and deterministic mode.
+# TRADEOFF — kept OPT-IN: prefix caching is forced off while active (freed
+# window blocks can't back prefix reuse), which costs agentic TTFT on repeated
+# prompts. Enable it for long single-sequence contexts where KV VRAM is the
+# bottleneck; leave it off when the prefix cache earns its keep.
 swa_sizing                  = false
 
 [rope]

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -593,8 +593,11 @@ void Engine::init_resolve_quant_flags_() {
 
 // Auto-detect max_seq_len. Runs AFTER model-specific overrides (Gemma-4
 // forces FP16 KV etc.) so the per-token cost reflects the actual dtype
-// that will be allocated. Conservative cap at 16K; the user can override
-// via runtime.max_seq_len.
+// that will be allocated. Auto ceiling is kAutoMaxSeqLenCap (64K) — bounded
+// further by what VRAM affords and what the model declares. A model that
+// declares MORE than 64K needs an explicit `--max-seq-len` / runtime.max_seq_len
+// override to exceed the auto cap (documented in imp.conf.example); the manual
+// path bypasses the auto resolver entirely (short-circuit below).
 void Engine::init_compute_max_seq_len_() {
     const auto& mcfg = model_->config();
     if (int v = runtime_config_.runtime.max_seq_len; v > 0) {

--- a/tools/analysis/niah_check.py
+++ b/tools/analysis/niah_check.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Needle-in-a-haystack retrieval gate past 16K (#1022).
+
+Drives a running imp-server: builds a filler haystack to a target token length,
+plants a unique needle at a given depth, asks for it, and asserts the answer
+carries the needle. A CORRECTNESS gate (retrieval success), independent of
+timing — safe to run without a pinned-perf host. Complements the TTFT gates
+(which need a verified-healthy host to pin numbers).
+
+Extends the ≤16K coverage to 32K/64K. Needs a server whose max_seq_len admits
+the longest prompt (e.g. `--set runtime.max_seq_len=40000` for 32K). On a
+sliding-window model this exercises the SWA global layers carrying long-range
+recall (`--set kv_cache.swa_sizing=true`).
+
+Usage:
+  python3 tools/analysis/niah_check.py --url http://localhost:8080 --model NAME \
+      --lengths 16000,32000 --depths 0.1,0.5,0.9
+"""
+import argparse
+import json
+import sys
+import time
+import urllib.request
+
+FILLER = ("The quarterly logistics report notes routine warehouse throughput and "
+          "nominal transit times across the regional distribution network. ")
+
+
+def approx_tokens(s):
+    # ~0.75 words/token for English; good enough to size the haystack.
+    return int(len(s.split()) / 0.75)
+
+
+def build_prompt(needle, target_tokens, depth):
+    reps = max(1, int(target_tokens / approx_tokens(FILLER)))
+    body = [FILLER] * reps
+    at = min(len(body), max(0, int(len(body) * depth)))
+    body.insert(at, needle + " ")
+    haystack = "".join(body)
+    q = (" Question: What is the secret vault access code mentioned earlier? "
+         "Answer with ONLY the code, nothing else.")
+    return haystack + q
+
+
+def post(url, body):
+    req = urllib.request.Request(url + "/v1/chat/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=180) as r:
+        return json.loads(r.read())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://localhost:8080")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--lengths", default="16000,32000")
+    ap.add_argument("--depths", default="0.1,0.5,0.9")
+    args = ap.parse_args()
+    lengths = [int(x) for x in args.lengths.split(",") if x]
+    depths = [float(x) for x in args.depths.split(",") if x]
+
+    fails = 0
+    total = 0
+    t0 = time.monotonic()
+    for length in lengths:
+        for depth in depths:
+            total += 1
+            code = f"ZEBRA-{length}-{int(depth*100):02d}"
+            needle = f"The secret vault access code is {code}."
+            prompt = build_prompt(needle, length, depth)
+            # Budget covers a thinking model's reasoning + the short answer;
+            # /no_think suppresses it on models that honor the hint (Qwen3).
+            body = {"model": args.model, "temperature": 0.0, "max_tokens": 512,
+                    "messages": [{"role": "user", "content": prompt + " /no_think"}]}
+            try:
+                rsp = post(args.url, body)
+                ptok = rsp.get("usage", {}).get("prompt_tokens", "?")
+                ans = (rsp["choices"][0]["message"].get("content") or "")
+                ok = code in ans
+            except Exception as e:  # noqa: BLE001 — report any transport/parse failure as a fail
+                ptok, ans, ok = "?", f"ERROR {e}", False
+            if not ok:
+                fails += 1
+            mark = "\033[32mPASS\033[0m" if ok else "\033[31mFAIL\033[0m"
+            print(f"  [{mark}] len~{length} depth={depth:.1f} ptok={ptok}: "
+                  f"want {code} got {ans[:40]!r}")
+    dt = time.monotonic() - t0
+    print("=" * 60)
+    print(f"niah_check: {total} probes, {fails} FAIL ({dt:.0f}s)")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Three long-context-serving items from #1022:

1. **NIAH retrieval gate past 16K** — `tools/analysis/niah_check.py` plants a needle at a depth in a filler haystack and asserts retrieval, at **16K and 32K** across depths. A **correctness** gate (retrieval success), independent of timing → runs on any host. Wired as `make test-niah`. Verified: **6/6** probes retrieve at 16K + 32K (26K prompt tokens) on Qwen3-14B, all depths. (The **TTFT timing** gates at 32K-64K need a verified-healthy host to pin numbers per the benchmarking contract — left as a separate measurement.)

2. **SWA-aware KV sizing validated** — the feature was built but doc-flagged "off until validated". Validated on Gemma-4-26B: windowed layers (25/30) size to the 1K window while the 5 global layers keep full context — a needle early in a 3.2K context is still retrieved (global layers carry it), output stays coherent, and the full `max_seq_len` fits VRAM that otherwise capped short. Kept **opt-in** (it forces prefix caching off — an agentic-TTFT tradeoff); `imp.conf.example` now documents the validated behavior + tradeoff.

3. **max_seq_len auto cap** — the 64K cap was already deliberate (VRAM/model_ctx bound it further); fixed the stale "16K" function-doc comment and documented in `imp.conf.example` that models declaring >64K need an explicit `--max-seq-len` (with the TTFT reality: ~3.7s@32K, ~10s@64K on Qwen3-14B Q6_K).

No hot-path code change — SWA sizing was already implemented; this validates it + adds a retrieval gate + docs.

## Remaining (deferred, needs a verified-healthy host)

TTFT timing baselines at 32K/64K (the pinned-number gates) per the benchmarking contract — a measurement task, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEKuUJALHLv1Yf65DJ56Xp