### PR TITLE
perf(gate): pin 32K-64K TTFT baselines + gate long-context prefill (#1022)

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -386,28 +386,34 @@ else
                     pass "prefill within ${PRE_THR}% threshold"
                 fi
 
-                # ---- long-context prefill (pp4096, single-chunk) ----
+                # ---- long-context prefill (single-chunk FA2): pp4096..pp65536 ----
                 # Crosses the cuBLAS→FMHA threshold so it exercises the
                 # register-resident FA2 kernel (attention.fmha_fa2=on default).
-                # Guards the FA2 prefill win; warn-only like pp512 (prefill noise).
-                BL_PP4096=$(jq -r '.metrics.prefill_tps.pp4096 // empty' "$BASELINE")
-                if [ -n "$BL_PP4096" ]; then
+                # Guards the FA2 prefill win AND the #1022 32K-64K TTFT band.
+                # Warn-only (prefill-noise convention) — though large-context
+                # prefill is actually stable (<0.5% cross-restart at 32K, measured
+                # 2026-07-16, unlike pp512's cuBLAS-algo jitter). Lengths past the
+                # model ctx or the 70K bench ceiling simply have no baseline key
+                # and are skipped. TTFT ms ≈ pp_len / pp_tps.
+                for PPLEN in 4096 8192 16384 32768 65536; do
+                    BL_PP=$(jq -r ".metrics.prefill_tps.pp${PPLEN} // empty" "$BASELINE")
+                    [ -z "$BL_PP" ] && continue
                     ERR2=$(mktemp)
-                    "$BIN" --model "$MODEL_PATH" --bench --bench-pp 4096 --bench-reps $REPS \
-                          --prefill-chunk-size 0 --max-tokens 1 --temperature 0 >/dev/null 2>"$ERR2"
-                    PP4096=$(grep -oP '^pp\s+4096\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' "$ERR2" | head -1)
+                    "$BIN" --model "$MODEL_PATH" --bench --bench-pp "$PPLEN" --bench-reps $REPS \
+                          --prefill-chunk-size 0 --max-tokens 1 --temperature 0 --max-seq-len 70000 \
+                          >/dev/null 2>"$ERR2"
+                    PPTPS=$(grep -oP "^pp\s+${PPLEN}\s.*\(\s*\K[0-9.]+(?=\s+tok/s)" "$ERR2" | head -1)
                     rm -f "$ERR2"
-                    if [ -n "$PP4096" ]; then
-                        P4_DELTA=$(awk -v cur="$PP4096" -v base="$BL_PP4096" 'BEGIN{printf "%.2f", (cur-base)/base*100}')
-                        P4_REG=$(awk -v d="$P4_DELTA" -v t="$PRE_THR" 'BEGIN{print (-d > t) ? 1 : 0}')
-                        printf "  prefill pp4096= %7.2f tok/s  (baseline %7.2f, delta %+s%%, FA2)\n" "$PP4096" "$BL_PP4096" "$P4_DELTA"
-                        if [ "$P4_REG" = "1" ]; then
-                            echo "${YLW}WARN${RST} long-ctx prefill (pp4096/FA2) regression > ${PRE_THR}% — check attention.fmha_fa2"
-                        else
-                            pass "long-ctx prefill (pp4096/FA2) within ${PRE_THR}% threshold"
-                        fi
+                    [ -z "$PPTPS" ] && continue
+                    PP_DELTA=$(awk -v cur="$PPTPS" -v base="$BL_PP" 'BEGIN{printf "%.2f", (cur-base)/base*100}')
+                    PP_REG=$(awk -v d="$PP_DELTA" -v t="$PRE_THR" 'BEGIN{print (-d > t) ? 1 : 0}')
+                    printf "  prefill pp%-5s= %7.2f tok/s  (baseline %7.2f, delta %+s%%, FA2)\n" "$PPLEN" "$PPTPS" "$BL_PP" "$PP_DELTA"
+                    if [ "$PP_REG" = "1" ]; then
+                        echo "${YLW}WARN${RST} long-ctx prefill (pp${PPLEN}/FA2) regression > ${PRE_THR}% — check attention.fmha_fa2"
+                    else
+                        pass "long-ctx prefill (pp${PPLEN}/FA2) within ${PRE_THR}% threshold"
                     fi
-                fi
+                done
             fi
         fi
     fi

--- a/tests/perf_baseline_north_star.json
+++ b/tests/perf_baseline_north_star.json
@@ -14,8 +14,13 @@
       "pp128": 3285.86,
       "pp512": 8435.03,
       "pp2048": 10731.51,
-      "pp4096": 12974.85
+      "pp4096": 12974.85,
+      "pp8192": 11421.11,
+      "pp16384": 10040.13,
+      "pp32768": 8053.95,
+      "pp65536": 5790.49
     },
+    "_ttft_note": "pp8192..pp65536 pinned 2026-07-16 (#1022 long-context TTFT gate), Qwen3-14B Q6_K single-chunk prefill (--prefill-chunk-size 0), 5 reps, verified-healthy host (mem 13801 MHz / ~570 W); cross-restart spread <0.5% at 32k (large-context prefill is compute/bandwidth-bound, not cuBLAS-algo-volatile like pp512). TTFT ms: 8k=717 / 16k=1632 / 32k=4069 / 64k=11318.",
     "decode_tps": {
       "tg128": 166.00,
       "tg128_at_ctx_2048": 149.54


### PR DESCRIPTION
## What

Closes the deferred **TTFT-gate** half of #1022 (the code + NIAH correctness gate landed in #1040; this pins the long-context latency baselines that needed a verified-healthy host).

- Pins single-chunk prefill baselines `pp8192/16384/32768/65536` in the north-star baseline (Qwen3-14B Q6_K).
- Extends `verify.sh`'s long-context prefill gate from `pp4096`-only to the **4096..65536** sweep (warn-only, per the prefill-gate convention).

## Measurement (verified-healthy host, 2026-07-16)

User-confirmed graphics-free; **mem 13801 MHz / ~570 W** during the bench, 5 reps, gate-matched flags (`--prefill-chunk-size 0 --max-tokens 1 --temperature 0`):

| length | prefill | TTFT |
|---|---|---|
| pp8192  | 11421 tok/s | 0.72 s |
| pp16384 | 10040 tok/s | 1.63 s |
| pp32768 |  8054 tok/s | 4.07 s |
| pp65536 |  5790 tok/s | 11.32 s |

**Cross-restart spread at 32K was <0.5%** (3 isolated trials: 4389/4391/4399 ms) — large-context prefill is compute/bandwidth-bound, not cuBLAS-algo-volatile like `pp512`, so a tight band is honest. Lengths past the model ctx or the 70K bench ceiling have no baseline key and are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEKuUJALHLv1Yf65DJ56Xp