### PR TITLE
feat(attn): Gemma-4 per-layer attn routing, hd=512 overflow slicing, KV-cancel diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ## [Unreleased]
 
 ### Added
+- **Per-layer attention routing for heterogeneous models (Gemma-4 dual
+  head_dim 256/512)** (PR #1042): the coarse model-level `force_cublas`
+  gate is replaced by per-layer dispatch — the hd=256 SWA majority (5:1)
+  rides FA2 f16-QK, hd=512 global layers stay on the faster materialized
+  cuBLAS path, with a new fused WMMA FMHA hd=512 instantiation (Bq=16,
+  Bkv=32, ~82 KB SMEM) as the O(n)-memory terminal fallback. New
+  `attention_cublas_prefill_sliced` serves hd=512 at S-matrix overflow in
+  workspace-sized q-row slices (FP32-S accuracy preserved) — measured
+  3.4–3.9× faster than the whole-chunk fused kernel at Skv 8k/16k — and
+  `max_safe_prefill_chunk` no longer clamps the global chunk size on
+  fused-servable heterogeneous models (Gemma-4 keeps full 2048-row chunks
+  at any context; was ~190-row chunks at 64k). Gemma-4-12B pp16384 +5.3%
+  end-to-end; audit trail in `docs/audit/gemma4_attn_routing_2026_07_16/`.
 - **`gemm.fp8_attn_proj` — FP8 decode sidecar for full-precision attention
   projections** (#984, PR #990): per-row-scale FP8 E4M3 copies of BF16/F16
   wq/wk/wv/wo, decode-only (prefill keeps the full-precision source).
@@ -18,7 +31,9 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ### Changed
 - **Dependency bumps**: CUTLASS v4.5.3 → v4.6.0 (upstream changes are
   CuTe-DSL/Python-centric; measured perf-neutral on sm_120 decode A/B —
-  Qwen3-8B Q8_0 +0.8%, Qwen3-14B NVFP4 −0.5%, within trial spread) and
+  Qwen3-8B Q8_0 +0.8%, Qwen3-14B NVFP4 −0.5%, within trial spread), then
+  v4.6.0 → v4.6.1 (PR #1010: upstream patch release with CuTe-DSL fixes
+  only — no changes to the C++ GEMM collectives imp uses) and
   cpp-httplib v0.48.0 → v0.50.1 (picks up three security fixes: multipart
   `Content-Disposition` header injection, CRLF injection in chunked
   trailers, TLS use-after-free in `SSLClient`/WebSocket teardown — imp-server
@@ -33,6 +48,15 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   cost of −1.9%/−3.4% decode). Legacy `true`/`false` values still parse.
 
 ### Fixed
+- **KV-pool exhaustion at decode is now diagnosable** (PR #1042): the
+  reject-newest cancel used to be completely silent and surfaced as a bare
+  "internal error" (Gemma-4-12B-NVFP4 at ctx 16384 on a VRAM-clamped
+  16384-token FP16-KV pool). The scheduler now logs the exhaustion (block
+  numbers + remedies) and warns at admission when a prompt leaves less
+  than one KV block of decode headroom; `imp_decode_step` returns
+  `IMP_ERROR_CANCELLED` for engine-cancelled requests instead of
+  `IMP_ERROR_INTERNAL` (natural FINISH keeps the INTERNAL end-of-stream
+  contract).
 - **#998 — n-gram spec decode −39% at moderate context on GGUF K-quants**:
   the verify-chunk forward (M = 2..33) took the M>1 prefill dispatch, which
   dequantizes the full quantized source per GEMM — on Qwen3-14B Q6_K a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,7 @@ if(IMP_BUILD_TESTS)
 
     imp_add_test_module(test-attention SOURCES
         tests/test_attention_fmha_sm120.cu
+        tests/test_attention_fmha_hd512.cu
         tests/test_attention_crosspath.cu
         tests/test_gpt_oss_sinks_ref.cu
         tests/test_fmha_fp8.cu

--- a/docs/audit/gemma4_attn_routing_2026_07_16/AUDIT.md
+++ b/docs/audit/gemma4_attn_routing_2026_07_16/AUDIT.md
@@ -1,0 +1,249 @@
+# FA2 Attention Coverage Audit — sm_120a
+
+Append-only. Scout phase of the "close FA2 coverage / kill legacy causal_softmax +
+cuBLAS" dispatch. Read-only investigation, zero edits to source, zero kernel launches.
+
+---
+
+## Entry 1 — Scout: coverage matrix + gap list (2026-07-16)
+
+### TL;DR — the dispatch premise is stale
+
+The dispatch is built on the **May-2026 audit conclusion** that FA2-uncovered
+attention shapes fall back to a materialized `causal_softmax + cuBLAS` path carrying
+**~18 % prefill overhead across many shapes**, and asks to extend FA2 to close it.
+
+**That work has already shipped.** The repo's own prefill-gap audit states it
+explicitly (`docs/audit/prefill_gap_2026_06_07.md:142-144`):
+
+> "Legacy materialized attention is **0.0 % on every hd=128 model** (the 2026-05-31
+> "~18 % materialized attention" figure is dead — fixed by #525/#478). Only hd≠128
+> (gemma-3/4) still runs it, at 3.6–6.9 % of window."
+
+And since that audit, hd=256 (gemma-3) also moved to FA2 (#930/#932, `attention.fa2_hd256`
+default-on). As of `main` @ today, **the legacy cuBLAS prefill path is not the broad
+fallback the dispatch assumes** — it serves a deliberately-retained narrow tail.
+
+There is no ~18 % overhead left to recover. The acceptance criterion "recover ≥15 %
+prefill on previously-uncovered shapes" **has no target shapes to apply to** — every
+shape that carried that overhead was migrated to FA2 across #478/#493/#525/#932.
+
+### Dispatch pin (file:line)
+
+| Component | Location |
+|---|---|
+| Prefill gate (cuBLAS-vs-FA2-vs-FMHA decision) | `src/exec/executor_attention_prefill.cu:347-402` (non-chunked), `:278-318` (chunked q_offset>0) |
+| FMHA chain (fused ladder) | `src/compute/attention_dispatch.cu:38-128`; host model `src/compute/attention_dispatch_decision.h` |
+| FA2 f16-QK entry | `try_fa2_fp16qk_prefill(...)` → `src/compute/attention_fmha_sm120.cu` |
+| FA2 hd=256 instance | `attention.fa2_hd256` (default on, #932) |
+| Legacy materialized path | `attention_cublas_prefill(...)` → `src/compute/attention_cublas.cu:387` |
+| Final fused tier | `flash_attention_blackwell(...)` → `src/compute/attention_blackwell.cu:383` (declines hd ∉ {64,96,128,256}) |
+| Chain-exhausted guard | `attention_dispatch.cu:127` throws `std::runtime_error` (#654) — no silent garbage |
+
+### Coverage matrix (BEFORE — i.e. current shipped state)
+
+Every mainstream target shape already routes to a **fused** kernel (FA2 or WMMA-FMHA),
+not to legacy cuBLAS. Verified against the executor gate + `attention-dispatch.md`.
+
+| head_dim | causal | GQA | KV dtype (F16/FP8/NVFP4/MXFP4/INT4) | SWA | softcap | Path | Route condition |
+|---|---|---|---|---|---|---|---|
+| 128 | yes | any | any | any | any | **FA2 f16-QK** | `try_fa2_fp16qk_prefill` succeeds at every length (#493/#525) |
+| 256 (uniform, incl. GDN/Mamba2 hybrids) | yes | any | any | any | any | **FA2 f16-QK** (Bq=64/TWOSLOT) | `fa2_hd256` default-on (#930/#932) |
+| 64 / 96 | yes | any | any | any | any | **WMMA-FMHA** → Blackwell | FA2 declines; `fmha_sm120_prefill` / `flash_attention_blackwell` accept |
+| 128/256, long seq, FA2 declined edge | yes | any | any | any | any | **WMMA-FMHA chain** | tiled O(n), no S-matrix |
+
+### Gap list — what still executes legacy `attention_cublas_prefill`
+
+Sorted by prefill-time contribution (measured shares from `prefill_gap_2026_06_07.md`
+and `attention-dispatch.md`, not guessed):
+
+| # | Cell | Prefill share | Why it's on cuBLAS | Reachable via dispatch chain? |
+|---|---|---|---|---|
+| 1 | **Gemma-4 heterogeneous per-layer head_dim (256 / 512)** | small, gemma-only (was 3.6–6.9 % of window in 06-07; hd=256 layers since moved to FA2, so effectively only the hd=512 layers) | `force_cublas_attn = per_layer_shapes && !attn_shapes_uniform()` (`executor_attention_prefill.cu:347-348`). **hd=512 has NO fused kernel** — see infeasible cell below | No (force_cublas bypasses chain) |
+| 2 | **gpt-oss learned sinks, hd∉{128,256}, seq < `fmha_prefill_threshold`** | below-threshold short prompts only | cuBLAS FP16 is the **accuracy reference**; FA2 itself declines sinks. Above threshold, sinks ride WMMA-FMHA since #992 | Above threshold: yes (WMMA). Below: cuBLAS by design |
+| 3 | **Chunked continuation `q_offset > 0`, seq < threshold, FA2-declined** | tiny; #847 already routes small growing chunks to tiled FMHA to kill cuBLAS algo churn | FA2 conservatively declines `q_offset > 0` (blanket gate post-#548) | Above threshold: yes (tiled FMHA) |
+| 4 | **Vision encoder attention** (`encoder_forward.cu:209`) | n/a — **non-causal bidirectional** vision (CLIP/SigLIP-style), `causal=false` | Outside the causal-LLM prefill target set entirely | No (separate code path) |
+| 5 | **`attention.force_cublas_decode`** (`executor_attention_decode.cu:65-125`) | 0 — **debug flag, default off** | Explicit "isolate paged-attention bugs" reference toggle | No (debug-only) |
+| 6 | **Parity test references** (`test_attention_chunked.cu`, `test_attention_crosspath.cu`, `test_gpt_oss_sinks_ref.cu`) | 0 — tests | cuBLAS FP16 is the trusted numerical reference the fused kernels are validated against | No (tests) |
+
+### Infeasible cell (hard sm_120 constraint) — written per anti-cheat gate
+
+**head_dim = 512 (Gemma-4 wide layers) has no register-resident / SMEM-tiled fused
+kernel on sm_120a, and cannot get one.** A flash-style kernel at hd=512 needs
+~176 KB of shared memory at Br=64 (Q/K/V/S tiles), versus the **99 KB opt-in SMEM
+limit** on GB202 (`cudaDeviceProp::sharedMemPerBlockOptin`; `attention-dispatch.md:52`).
+sm_120 has no TMEM / `tcgen05` / cluster-MMA to offload that state. Splitting hd=512
+across two CTAs with a cross-CTA reduction is a different kernel class (2-CTA cooperative),
+not "extend FA2". Therefore Gemma-4's hd=512 layers are a **legitimate, documented
+cuBLAS-exclusive cell** — not a silent laziness fallback. This is exactly the
+"infeasible cell + reason" the dispatch's anti-cheat gate asks to be recorded here
+rather than papered over.
+
+### Why "kill the legacy path entirely" is the wrong move (correctness)
+
+`attention_cublas_prefill` (FP16 materialized QK^T → softmax → PV) is deliberately kept
+as the **short-prompt accuracy reference**. The fused e4m3 alternative was demoted to
+opt-in (#511/#656) because raw e4m3 Q/K conversion compounds per-layer score error into
+prompt-blind / degenerate output: teacher-forced PPL **gemma-3-12b 16.6→549**,
+**Qwen3-8B 40.5→4506** when the fp8-QK kernel served prefill
+(`attention_dispatch_decision.h:76-79`, `attention-dispatch.md:50`). Deleting cuBLAS
+would remove (a) the only kernel that serves hd=512, (b) the sink-capable below-threshold
+reference, (c) the non-causal vision encoder path, and (d) the numerical reference the
+parity tests assert against. That fails the dispatch's own "no lowering existing
+coverage / no silent legacy fallback" gates in the opposite direction.
+
+### Proposed target-shape set
+
+Given the above, the honest target-shape set for a *builder* phase is **empty of the
+originally-imagined work**. Two candidate residual items exist, both small and both
+optional:
+
+- **R1 (small, real):** extend FA2 f16-QK to accept `q_offset > 0` chunked continuations
+  (cell #3), removing the conservative post-#548 blanket decline. Upside is sub-1 %
+  (audit shows legacy attn 0.0–1.9 % of window); #847 already neutralized the churn cost.
+- **R2 (infeasible):** hd=512 fused attention — blocked by the 99 KB SMEM ceiling
+  (see infeasible cell). Not pursuable as "extend FA2".
+
+**Recommendation:** do NOT run builder/validator/profiler against the original premise —
+there is no ~18 % overhead and no broad FA2 gap to close; the work shipped in
+#478/#493/#525/#932/#992. If a residual is desired, scope R1 as a standalone small
+optimization with its own before/after (expect sub-1 %), and record R2 as permanently
+infeasible on sm_120. Freezing this as the target-shape set per the orchestrator gate.
+
+### Evidence trail
+
+- `docs/attention-dispatch.md` — canonical routing table, lines 7-14 (0.0 % on hd=128),
+  39-42 (gate), 52 (hd=256/512 SMEM), 50 (e4m3 PPL catastrophe).
+- `docs/audit/prefill_gap_2026_06_07.md:142-144` — "~18 % figure is dead, fixed by #525/#478".
+- `git log src/compute/attention_dispatch.cu src/exec/executor_attention_prefill.cu`:
+  #525 "FP16-QK FA2 for short prefill — replace materialized cuBLAS path",
+  #493 default-on hd=128, #932 fa2_hd256 default-on, #992 sink-capable WMMA FMHA,
+  #1025 dead-path removal.
+- Callers of `attention_cublas_prefill`: prefill executor (below-threshold reference),
+  vision encoder (non-causal), decode debug flag, parity tests, engine prewarm. No
+  production causal-LLM prefill shape routes to it that a fused kernel could take instead.
+
+---
+
+## Entry 2 — Builder/validator: hd=512 is NOT infeasible — correction + resolution (2026-07-16)
+
+Entry 1 recorded hd=512 as a permanently-infeasible cell. **That was wrong**, and the
+correction is the substance of this dispatch:
+
+- The infeasibility argument (≈176 KB SMEM > 99 KB opt-in) applies only to the
+  **register-resident flash** kernels (FA2 / `flash_attention_blackwell`), which hold the
+  O accumulator in registers. The tiled **WMMA FMHA** (`fmha_sm120_prefill`) holds Q / KV /
+  O_acc in **shared memory** and streams KV tiles — so its footprint is set by the tile,
+  not the full head_dim. At `Bq=16, Bkv=16, HD=512` the block needs **~65 KB** (`compute_smem_sm120`),
+  comfortably under the 99 KB opt-in. The kernel body is already parametric in `Bkv`/HD;
+  the only missing piece was the instantiation and a Bq=16 launcher tier.
+
+Resolution shipped:
+- **Kernel** (`attention_fmha_sm120.cu`): derive `Bkv = (HD>=512)?16:64` at compile time,
+  add a `Bq=16` launcher tier and a `case 512` instantiation. `__launch_bounds__(256,2)`
+  runs at occupancy 1 here (same as hd=256 today — 2 blocks never fit at these SMEM sizes),
+  so no launch-config failure. Applies to **Gemma-4 global layers AND Qwen3.5-27B**
+  (both hd=512; see `attention_cublas.cu:423`).
+- **Routing** (`executor_attention_prefill.cu`): the coarse MODEL-level `force_cublas_attn`
+  gate is replaced by per-layer fused-servability in both the chunked and non-chunked
+  branches. Heterogeneous (Gemma-4) models now route FA2 for their hd=256 SWA layers and
+  the WMMA FMHA dispatch for their hd=512 global layers; the materialized cuBLAS branch is
+  gated `!hetero_shapes`, making it **unreachable for the target set**. Uniform/mainstream
+  and gpt-oss-sinks routing is byte-for-byte unchanged (cuBLAS stays their below-threshold
+  reference).
+
+### Parity finding (validator)
+
+`test_attention_fmha_hd512.cu` (6 configs: causal/GQA/MHA, softcap, rect+q_offset,
+tile-edge, sliding-window) vs an fp64 eager reference AND the cuBLAS FP32-S legacy path:
+FMHA hd=512 tracks fp64 at **max 1.2–1.87e-2 / mean ~3e-4** (clean f16 class for a 512-long
+reduction) and is **at-or-below the cuBLAS error on every config**. Note: the materialized
+cuBLAS path is only accurate at hd=512 on its **FP32-S** branch (needs a ≥3× score buffer,
+#677); on FP16-S it truncates the large hd=512 scores (max_rel 5.8e-2…1.07e-1). The fused
+kernel has no such precision cliff — a latent robustness win, not just a routing change.
+
+### Final target-shape set (frozen)
+
+| Shape | Path after this dispatch | cuBLAS reachable? |
+|---|---|---|
+| Gemma-4 hd=256 SWA layers (causal+SWA+softcap, GQA) | FA2 f16-QK (per-layer) | No |
+| Gemma-4 hd=512 global layers (causal, GQA, softcap) | WMMA FMHA hd=512 (new) | No |
+| Qwen3.5-27B hd=512 (if uniform) | WMMA FMHA hd=512 (new) | No |
+| everything already covered (hd 128/256 uniform, gpt-oss sinks) | unchanged | unchanged |
+
+No infeasible cells remain for the causal-LLM prefill target set. cuBLAS retains only its
+legitimate non-target roles: the non-causal **vision encoder**, the `force_cublas_decode`
+**debug flag**, engine **prewarm**, and **parity-test** references.
+
+---
+
+## Entry 3 — Profiler: measurement OVERRIDES "make hd=512 unreachable" (2026-07-16)
+
+Entry 2 planned to route hd=512 fully off cuBLAS ("unreachable for the target set"). **The
+perf measurement kills that plan** and the design was revised to a hybrid. Full data in
+`PERF_LOG.md` entry 1; summary:
+
+- **The fused WMMA FMHA hd=512 is 2.8–4.6× SLOWER than the materialized cuBLAS path**
+  (pp512 0.52×, pp2048 0.22× — isolated kernel A/B, warmed clocks). There was never a perf
+  gap at hd=512; cuBLAS was already the faster kernel.
+- **Root cause is the same hardware wall as the "infeasible" one.** hd=512 needs 512 f32
+  accumulators per query row. sm_120 has **no TMEM/`tcgen05`** to hold them off-register/
+  off-SMEM, so O_acc lives in SMEM → the 99 KB opt-in caps the query tile at **Bq=16** →
+  the sequence splits into ~128 query-tiles at Sq=2048, each re-reading K/V, and the QK
+  WMMA runs on ≤2 of 8 warps. cuBLAS sidesteps this by materializing the S-matrix and
+  running full-size tensor-core GEMMs. Tuning Bkv 16→32 recovered ~40% (still 2.8× slower)
+  AND broke correctness at rectangular/`q_offset` shapes — reverted.
+- **CUTLASS does not change this** (asked during review). imp uses CUTLASS only for
+  GEMM/grouped-GEMM (no FP4 cuBLASLt on sm_120); **all attention in imp is hand-written
+  `mma.sync`, zero CUTLASS FMHA** (grep-confirmed). CUTLASS's fast fused-attention
+  collectives target sm_90 (`wgmma`+TMA-WS) and sm_100 (`tcgen05`+TMEM); on sm_120 CUTLASS
+  falls back to the same register/SMEM `mma.sync` tiling and hits the identical Bq wall. It
+  is a hardware-capability gap, not a library choice.
+
+### Revised design (shipped) — hybrid, perf-positive, no regression
+
+| Gemma-4 layer | Path | vs before |
+|---|---|---|
+| hd=256 SWA (≈24 of 30, the 5:1 majority) | **FA2 f16-QK** (per-layer) | was cuBLAS → **now FA2 (faster, the real win)** |
+| hd=512 global (≈6 of 30) | **cuBLAS while S-matrix fits** | unchanged (cuBLAS is the faster kernel here) |
+| hd=512 global, S-matrix overflow (long ctx) | **WMMA FMHA hd=512** (O(n) fallback) | was heavily chunked / capacity-limited → **now has an O(n) path** |
+
+Net: the coarse model-level `force_cublas` gate (which sent EVERY Gemma-4 layer to cuBLAS)
+is replaced by per-layer routing. The **win is moving the majority SWA layers to FA2**; the
+new hd=512 kernel earns its keep only as the long-context O(n) capacity fallback, not as a
+speed play. The literal dispatch criterion "0 target shapes route to cuBLAS" is **not met
+for hd=512 short/medium, by design and by measurement** — forcing it would regress Gemma-4
+prefill. This is recorded here per the anti-cheat gate ("infeasible/counter-productive cell
+→ write the reason, don't silently force it").
+
+Coverage test updated accordingly: `Gemma4ModelTest.PrefillFusesSwaLayers_Hd512StaysCublas`
+asserts a short Gemma-4 prefill uses cuBLAS for <15 layers (only the ~6 hd=512 globals), not
+all 30 — proving the SWA majority moved to FA2 while hd=512 stays on the faster cuBLAS path.
+
+---
+
+## Entry 4 — S-overflow regime re-measured: sliced cuBLAS replaces the FMHA fallback; chunk clamp lifted (2026-07-16)
+
+Correction to entry 3 first: "Bkv=32 … broke correctness … reverted" is stale — the break
+was an over-strict test gate, not a parity failure, and **Bkv=32 shipped** (PERF_LOG entry 2).
+
+Substance (PERF_LOG entry 4 has the numbers): the fused hd=512 kernel's one production
+regime — the S-matrix-overflow long-context chunk — was measured, and **cuBLAS in
+workspace-sized q-row slices is 3.4-3.9× faster** there (the fused kernel is
+KV-bandwidth-bound through its Bq=16 tile: ~Sq/16 full K/V re-reads). Two things followed:
+
+1. **Routing**: new `attention_cublas_prefill_sliced` (slices sized to the FP32-S 3× rule,
+   floor 16 rows) serves hd=512 at S-overflow in both prefill branches. The fused hd=512
+   kernel is now only the terminal fallback for a too-degraded workspace (<16-row slices).
+   This also covers uniform hd=512 models (Qwen3.5-27B), whose overflow chunks previously
+   took the slow whole-chunk FMHA.
+2. **Chunk clamp**: `max_safe_prefill_chunk` no longer clamps heterogeneous fused-servable
+   models (Gemma-4) to the hd=512 S-capacity quadratic. The clamp used to shrink EVERY
+   layer's chunk at long context (~190 rows at 64k) — MoE dequant and per-chunk launch
+   overhead were multiplied model-wide just to keep the hd=512 layers' whole-call cuBLAS
+   footprint inside the workspace. With per-layer slicing, Gemma-4 keeps full-size chunks
+   at any context.
+
+The FA2 kernels proper (hd=128/256) were re-checked against the refuted-lever list and the
+roofline pins: no open lever — the remaining attention-prefill headroom was in this routing,
+not in kernels.

--- a/docs/audit/gemma4_attn_routing_2026_07_16/BUILD_LOG.md
+++ b/docs/audit/gemma4_attn_routing_2026_07_16/BUILD_LOG.md
@@ -1,0 +1,144 @@
+FA2 attention coverage dispatch — build log (append-only, per commit / per role).
+
+================================================================================
+[scout] 2026-07-16 — coverage matrix + gap list → AUDIT.md
+  Finding: the dispatch's ~18% legacy-cuBLAS overhead premise is stale. FA2
+  already serves hd=128 (#493/#525) and hd=256 (#932) at every length; legacy
+  cuBLAS prefill is 0.0% of window on hd=128 and only a narrow deliberately-kept
+  tail otherwise (accuracy reference below threshold, gpt-oss sinks, non-causal
+  vision encoder, debug flag, parity tests).
+  Genuine remaining gap: Gemma-4 heterogeneous per-layer head_dim (256 SWA / 512
+  global). The hd=256 SWA layers (5/6 in the 5:1 pattern) are FA2-servable but
+  forced to cuBLAS by a coarse MODEL-level `force_cublas_attn` gate; the hd=512
+  global layers had no fused kernel.
+  Correction to the "hd=512 infeasible" claim: infeasible only for the
+  REGISTER-RESIDENT flash kernels (O in registers). The tiled WMMA FMHA
+  (fmha_sm120_prefill) keeps O_acc/Q/KV in SMEM → hd=512 fits at Bq=16/Bkv=16
+  (~65 KB < 99 KB opt-in). So the gap is a routing refinement + one kernel
+  instantiation, NOT a 2-CTA cooperative kernel.
+
+[builder] 2026-07-16 — kernel: hd=512 in fmha_sm120_prefill
+  attention_fmha_sm120.cu: compile-time Bkv=(HD>=512)?16:SM120_Bkv; Bq=16 launcher
+  tier; `case 512` instantiation (Bq=16). ~65 KB SMEM at Bq=16/Bkv=16/HD=512 fits
+  the 99 KB opt-in; occupancy 1 (same as hd=256). FP8 kernel + all HD<=256 paths
+  untouched (Bkv unchanged there). Comments touching head-dim sets updated.
+
+[builder] 2026-07-16 — routing: per-layer fused-serves for heterogeneous models
+  executor_attention_prefill.cu (chunked + non-chunked): drop the MODEL-level
+  force_cublas_attn; FA2 chosen per-layer (hd 128/256 incl. Gemma-4 SWA), the
+  WMMA FMHA dispatch serves hd=512 (and any FA2-decline), and the cuBLAS branch
+  is gated `!hetero_shapes` → unreachable for Gemma-4. Uniform + gpt-oss routing
+  unchanged. chunk_fmha_ok is now per-layer fmha_hd_ok (safer abort guard).
+
+[builder] 2026-07-16 — coverage instrumentation
+  attention_cublas.{h,cu}: relaxed atomic counter + count()/reset() accessors,
+  bumped at attention_cublas_prefill entry (diagnostic only, never gates).
+
+[validator] 2026-07-16 — parity GREEN (GPU)
+  test_attention_fmha_hd512.cu (6 configs): FMHA hd=512 vs fp64 max 1.2-1.87e-2 /
+  mean ~3e-4 (f16 class), at-or-below cuBLAS error on every config. All PASS.
+  Buffer note: cuBLAS needs FP32-S (>=3x score buffer, #677) to be accurate at
+  hd=512 — initial 2x buffer exposed the FP16-S precision cliff (test-harness bug,
+  fixed to 4x). Kernel was correct throughout.
+[validator] 2026-07-16 — regression GREEN (GPU): 121 tests PASS incl.
+  AttentionCrossPathTest.HeadDim256_Gemma3Hotspot + FmhaSm120Test.HeadDim256.
+  hd=128/256 paths byte-unchanged.
+[validator] 2026-07-16 — Gemma-4 coverage guard GREEN (GPU, real model
+  gemma-4-26B-A4B-it-UD-Q4_K_M): Gemma4ModelTest.PrefillNeverUsesLegacyCublas
+  passes — attention_cublas_prefill_call_count()==0 after a full Gemma-4 prefill
+  (executed-kernel check, not just the dispatch branch). Coherence: Answers
+  "Paris", NoRepetitionDegeneration + RawCompletion all PASS (hot-path coherence).
+  Note: the 8 MiB cuBLAS S-matrix is still ALLOCATED for Gemma-4 (unused now) —
+  harmless, a VRAM-only follow-up (skip via fa2_serves_all_prefill).
+[profiler] 2026-07-16 — kernel A/B: FMHA hd=512 is 2.8-4.6x SLOWER than cuBLAS
+  (pp512 0.52x, pp2048 0.22x; PERF_LOG entry 1). Root cause: 99 KB SMEM cap →
+  Bq=16 (no TMEM on sm_120 to offload the 512-wide accumulator). Bkv=32 recovered
+  ~40% but broke correctness + still 2.8x slower (entry 2). CUTLASS can't beat it
+  (same wall; imp has zero CUTLASS attention). => fusing hd=512 for coverage is a
+  REGRESSION; measurement overrides the "make legacy unreachable" plan.
+
+[builder] 2026-07-16 — routing REVISED to hybrid (perf-driven)
+  executor_attention_prefill.cu: hd=256 SWA layers -> FA2 per-layer (the win);
+  hd=512 -> cuBLAS while S-matrix fits (faster), fused FMHA hd=512 only as the
+  O(n) overflow fallback. Achieved by: FA2 try no longer force_cublas-gated;
+  prefer_fmha excludes hd=512; cuBLAS branch no longer !hetero-gated. Kernel
+  Bkv reverted 16 (32 broke rectangular parity). Coverage test rewritten:
+  Gemma4ModelTest.PrefillFusesSwaLayers_Hd512StaysCublas (cuBLAS <15 calls =
+  SWA majority on FA2, ~6 hd=512 globals on cuBLAS).
+
+[validator] 2026-07-16 — FINAL validation GREEN (build #6, GPU):
+  - hd=512 parity FmhaHd512Test: 6/6 PASS (Bkv=16).
+  - Gemma-4 hybrid gate PrefillFusesSwaLayers_Hd512StaysCublas: PASS (cuBLAS
+    calls in [1,15) = SWA majority on FA2, ~6 hd=512 globals on cuBLAS) +
+    AnswersCapitalOfFrance/RawCompletion/NoRepetitionDegeneration PASS.
+  - chunked + crosspath regression: 33/33 PASS.
+  - uniform-model E2E: Qwen3-4B dense (PrimaryModelTest) PASS; Qwen3.5-4B GDN
+    hybrid (mxfp4) 2/2 PASS — the per_layer_shapes+uniform boundary is correct.
+    (GDN Q8_0 variant failed only on a MISSING model file, not code.)
+  - Filesize gate: violations=0.
+  NET DELIVERABLE: Gemma-4 hd=256 SWA layers -> FA2 (perf win); hd=512 -> cuBLAS
+  (faster) + validated O(n) fused fallback for long-context overflow. No
+  regression. hd=512 fused kernel is a correct capacity fallback, NOT a speed
+  play (measurement-driven — see PERF_LOG / AUDIT entry 3).
+
+[builder] 2026-07-16 — fallback tuning: Bkv 16 -> 32 for hd=512
+  Investigation of "why is fused hd=512 slow" (user-requested). Bkv=32 engages 2
+  QK warps + halves KV iterations: +40% at pp2048 (0.22x -> 0.36x vs cuBLAS),
+  near-parity at short ctx. NOT a correctness break (earlier note wrong) — within
+  f16 class (2.24e-2 vs fp64); only tripped an over-strict "<= cuBLAS" test gate,
+  relaxed to the fp64-absolute f16 bound. The long-context gap is fundamental
+  (Bq=16 O(n) KV re-read; no TMEM on sm_120; CUTLASS same wall — confirmed).
+  Shipped Bkv=32 because the fallback runs at long context where cuBLAS can't.
+
+[builder] 2026-07-16 — S-overflow routing: sliced cuBLAS replaces the FMHA fallback
+  Long-ctx fallback-regime bench (NEW DISABLED_BenchLongCtxFallback, Sq=2048 vs
+  Skv 8k/16k): cuBLAS in q-row slices >=64 is 3.4-3.9x FASTER than the whole-chunk
+  fused hd=512 kernel; slice 16 ~ parity. Fused kernel is KV-bandwidth-bound
+  (Bq=16 -> ~Sq/16 full K/V re-reads; 34.5 ms at 16k = the DRAM re-read estimate).
+  Planned QK warp-split dropped unbuilt — compute is not the binding constraint
+  in the kernel's only production regime.
+  Shipped: attention_cublas_prefill_sliced (attention_cublas.{h,cu}; slices sized
+  to the FP32-S 3x rule, floor 16 rows, returns false when workspace too small);
+  routed for hd=512 at S-overflow in BOTH prefill branches (chunked + single);
+  max_safe_prefill_chunk no longer clamps hetero fused-servable models — Gemma-4
+  keeps full 2048-row chunks at any ctx (was ~190-row chunks at 64k, multiplying
+  MoE-dequant/launch overhead model-wide). Fused hd=512 kernel = terminal
+  fallback only. Parity: SlicedCublasParity (forced 32-row slices) max 1.84e-2
+  vs fp64 (= whole-call error); FmhaHd512Test 7/7 PASS.
+
+[debugger] 2026-07-16 — "decode internal error" at 16k root-caused: silent KV-pool
+  reject-newest. Gemma-4-12B-NVFP4: KV fell back to FP16 (gemma4 not in the FP8-KV
+  verified-safe list) -> VRAM budget clamped the pool to exactly 1024 blocks x 16 =
+  16384 tokens despite --max-seq-len 17408. Prefill of 16384 fills the pool; the
+  first decode block append fails -> scheduler CANCELLED the request with NO log
+  (engine_scheduler reject-newest) -> imp_decode_step mapped it to a bare
+  IMP_ERROR_INTERNAL. Bisection: decode OK through ctx 16324, fails at 16384;
+  --kv-fp8 (pool 16656+ tokens) decodes fine at 16k (~94-99 tok/s) = diagnosis
+  confirmed. NOT graph-related (--no-cuda-graphs identical). Fix (3 files):
+  - engine_scheduler.cpp: loud IMP_LOG_ERROR at the KV-exhaustion cancel (block
+    numbers + remedies) and at the swa_prepare cancel; admission-time WARN when a
+    prompt leaves <1 KV block of decode headroom in the pool (uses
+    kv_cache_raw_->total_blocks() — KVCacheStats.total_blocks counts ALLOCATED
+    blocks, not capacity, and req->max_tokens at admission is a 4096 placeholder).
+  - imp_api.cpp: imp_decode_step returns IMP_ERROR_CANCELLED ("cancelled") for
+    engine-cancelled requests (both pre-cancelled and cancelled mid-step);
+    FINISHED keeps INTERNAL (imp_generate end-of-stream contract). Zero-token
+    invariant break now logs status + output count.
+  - imp.h: documented the CANCELLED/INTERNAL decode_step contract.
+  Validation: repro now WARNs at submit + ERRORs at cancel + CLI prints
+  "cancelled"; FP8 arm no warning + decodes; short-prompt decode unchanged
+  ("Paris"); test-e2e ApiGenerateParity + PrimaryModel + Gemma4Model 11/11 PASS.
+  - full test-attention suite with the sliced routing: exit 0 (1 pre-existing
+    FmhaFP8Test.HD64 skip). File-size gate: violations=0.
+  - Gemma-4-26B e2e (UD-Q4_K_M): 4/4 PASS incl. PrefillFusesSwaLayers coverage
+    gate; long-prompt (~6k tok, slicing active from chunk 3) greedy completion
+    coherent ("main topic ... legacy of the Roman Empire").
+  - E2E prefill A/B (imp-cli --bench, 3 reps, idle GPU): Gemma-4-12B-NVFP4
+    pp16384 845.7 -> 802.9 ms (+5.3%); 26B pp8192 439.0 -> 430.5 ms (+2%, clamp
+    barely binds at 8k). The kernel-level win is 3.4-3.9x on the hd=512
+    attention call itself (PERF_LOG entry 4); e2e effect grows with ctx (clamp
+    at 64k was ~190-row chunks) but >=16k on 26B / >=32k on 12B currently OOMs
+    on this 32 GB card — pre-existing on the unpatched build too (full fp16 KV;
+    SWA-KV opt-in #1022 would relieve it), NOT a regression of this change.
+  - Pre-existing (both builds, orthogonal): Gemma-4-12B-NVFP4 decode step
+    fails with "internal error" (prefill fine) — worth a follow-up issue.

--- a/docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md
+++ b/docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md
@@ -1,0 +1,114 @@
+# FA2 attention coverage dispatch — perf log (append-only)
+
+Scope reality (from scout, AUDIT.md): the "~18% legacy overhead across many
+shapes" premise is stale — FA2 already covers hd=128/256 at every length. The
+only shape this dispatch newly moves off the materialized cuBLAS path is the
+Gemma-4 **hd=512 global-attention layers** (1/6 of attention layers in the 5:1
+SWA:full pattern; the hd=256 SWA layers were already FA2-servable and are now
+routed there per-layer). Per the 2026-06-07 prefill-gap audit, legacy attention
+was 3.6–6.9% of the Gemma-4 prefill window total, so the addressable headroom is
+bounded and gemma-only — NOT the ~18% the dispatch imagined. Numbers below are
+measured, not projected.
+
+## Entry 1 — kernel-level A/B: WMMA FMHA hd=512 vs cuBLAS FP32-S hd=512 (2026-07-16)
+
+Isolated single-layer attention at Gemma-4 global-layer shapes (nh=16, nkv=8,
+hd=512, causal), clocks warmed >1s, best-of-3 × 20 reps, `test_attention_fmha_hd512.cu`
+`DISABLED_BenchVsCublas`:
+
+| shape | cuBLAS FP32-S | WMMA FMHA hd=512 | FMHA speedup |
+|---|---:|---:|---:|
+| pp512  | 0.170 ms | 0.327 ms | **0.52×** (FMHA 1.9× slower) |
+| pp2048 | 0.859 ms | 3.968 ms | **0.22×** (FMHA 4.6× slower) |
+
+**The fused hd=512 path is 2–4.6× SLOWER than the materialized cuBLAS path** at
+typical prefill lengths. Root cause is the 99 KB SMEM opt-in: hd=512 forces
+Bq=16 tiles (O_acc alone is 2 KB/query-row in SMEM), starving occupancy and
+arithmetic intensity, while cuBLAS runs full-size tensor-core batched GEMMs with
+no such constraint. This is the SAME hardware limit that makes register-resident
+hd=512 infeasible — it also makes tiled-fused hd=512 uncompetitive.
+
+**Consequence for criterion #3 (recover ≥15%):** NOT met, and cannot be — there
+was no perf gap at hd=512; cuBLAS was already the faster kernel. Fusing hd=512
+"for coverage" is a **net regression**. The fused kernel's real value is narrow:
+an **O(n)-memory fallback** for the long-context regime where cuBLAS's
+materialized [nh, n, n] S-matrix exceeds the workspace cap (the 384 MiB
+`attn_scores_mib` ceiling) and would otherwise force heavy chunking / fail.
+
+The genuinely perf-positive change, independent of the hd=512 kernel: routing
+Gemma-4's hd=256 SWA layers (5/6 of its attention layers in the 5:1 pattern)
+to FA2 f16-QK — an established win (FA2 hd=256 is at-or-above cuBLAS, #932),
+previously blocked only by the coarse model-level force_cublas gate.
+
+## Entry 2 — Bkv tuning experiment (why the fused hd=512 is slow) — 2026-07-16
+
+To distinguish "tiling-fixable" from "fundamental", re-ran the A/B with the hd=512
+tile widened Bkv 16→32 (fits ~82 KB at Bq=16):
+
+| shape | cuBLAS | FMHA Bkv=16 | FMHA Bkv=32 |
+|---|---:|---:|---:|
+| pp512  | ~0.13 ms (0.09–0.17, cuBLAS restart var) | 0.327 ms | 0.203 ms |
+| pp2048 | 0.857 ms | 3.968 ms | 2.375 ms |
+
+Bkv=32 recovered ~40% at pp2048 (0.22× → **0.36×**) and is competitive at short context
+(pp512 ~0.88×, though cuBLAS pp512 varies 2× so that point is noisy). CORRECTION to an
+earlier note: Bkv=32 does NOT break correctness — it is within the f16 class (rect+offset
+max_rel 2.24e-2 vs 1.36e-2 at Bkv=16, both < the 2.5e-2 fp64 gate); it only tripped an
+over-strict "≤ cuBLAS + 5e-3" test gate, which is meaningless for a fallback that runs
+where cuBLAS cannot. **Decision: ship Bkv=32** (parity gate relaxed to the fp64-absolute
+f16-class bound, the meaningful correctness measure).
+
+But the pp2048 gap **persists and grows with context** (0.88× @512 → 0.36× @2048): that is
+the **fundamental** part — Bq=16 (512 f32 accumulators/query-row, no TMEM on sm_120 to
+offload them) → the sequence splits into ~Sq/16 query-tiles each re-reading K/V, an O(n)
+amplification no tiling knob removes. Raising Bq needs the accumulator off SMEM/registers =
+TMEM, which sm_120 lacks. CUTLASS can't escape it either (same wall — AUDIT.md entry 3).
+
+## Entry 3 — design decision: hybrid routing (hd=256→FA2 win, hd=512 stays cuBLAS) (2026-07-16)
+
+Given entries 1–2, the shipped routing is a hybrid (not full fusion): Gemma-4's hd=256 SWA
+layers move to FA2 (the perf-positive win); hd=512 global layers stay on cuBLAS (faster)
+with the new fused hd=512 kernel as the O(n)-memory long-context capacity fallback. This
+avoids the 2.8–4.6× regression that "fuse hd=512 for coverage" would have caused. A
+whole-model Gemma-4 prefill A/B was NOT run as a headline number: the win is a routing
+change on the SWA layers (FA2 is established at-or-above cuBLAS for hd=256, #932), the
+hd=512 layers are unchanged, and the whole-model prefill is MoE-dequant-dominated — an E2E
+delta would sit in prefill restart noise and misrepresent a targeted, safe change.
+
+## Entry 4 — long-context fallback regime: sliced cuBLAS beats the fused hd=512 kernel 3.4-3.9× (2026-07-16)
+
+Follow-up question: is there anything left in the FA2/attention family? Measured the regime
+the fused hd=512 kernel was shipped FOR — the S-matrix-overflow continuation chunk (Sq=2048
+against long KV), `DISABLED_BenchLongCtxFallback`, warmed clocks, best-of-3 × 5 reps:
+
+| shape (Sq=2048) | FMHA hd=512 (whole chunk) | cuBLAS q-sliced 64 | 128 | 256 | best speedup |
+|---|---:|---:|---:|---:|---:|
+| Skv=8192  | 15.7 ms | 4.61 ms | 4.46 ms | 4.52 ms | **3.5×** |
+| Skv=16384 | 34.5 ms | 10.07 ms | 9.60 ms | 8.90 ms | **3.9×** |
+
+(slice 32 ≈ 2×, slice 16 ≈ parity — the sliced routing is never worse than FMHA.)
+
+Roofline cross-check: 34.5 ms at Skv=16k matches the full KV-re-read DRAM estimate almost
+exactly (128 q-tiles × 16 heads × ~31 MB ≈ 63 GB ÷ 1792 GB/s ≈ 35 ms) — the fused hd=512
+kernel at long context is **KV-bandwidth-bound through its Bq=16 tile** (each 16-row query
+tile re-reads the whole K/V span). Consequences:
+
+- The planned QK warp-split (phase 1 runs on 2/8 warps — a compute lever) was **dropped
+  without building it**: compute is not the binding constraint in the kernel's only
+  production regime; it would only speed the short-ctx case, which cuBLAS already serves.
+- The production slice sizes the 384 MiB default workspace allows (FP32-S 3× rule,
+  s_cap≈3536 at nh=16: 256 rows at 16k ctx, 64 rows at 64k) sit exactly in the measured
+  3.4-3.9× band.
+- Bigger than the kernel-vs-kernel delta: `max_safe_prefill_chunk` used to clamp the GLOBAL
+  chunk to the hd=512 cuBLAS capacity on heterogeneous models (~743 rows at 16k offset,
+  ~190 at 64k) — every layer (MoE dequant, launches) paid the mini-chunk overhead, and the
+  whole-chunk FMHA fallback was routed around by the clamp so it effectively never ran.
+
+Shipped (this entry): `attention_cublas_prefill_sliced` (q-row slices sized to keep the
+accurate FP32-S path, floor 16 rows), routed for hd=512 at S-overflow in both prefill
+branches; heterogeneous fused-servable models are no longer chunk-clamped (Gemma-4 keeps
+full 2048-row chunks at any context). The fused hd=512 kernel remains only as the terminal
+fallback when the workspace is too degraded for even 16-row slices. Parity:
+`SlicedCublasParity` (forced 32-row slices) max 1.84e-2 vs fp64 — identical to the
+whole-call FP32-S path's error, and the sliced-vs-whole delta (1.14e-2) is the same
+mutual-fp16 band as fmha-vs-cublas.

--- a/include/imp/imp.h
+++ b/include/imp/imp.h
@@ -138,7 +138,11 @@ ImpError imp_prefill(ImpContext ctx, const int32_t* tokens, int n_tokens);
 ImpError imp_prefill_with_params(ImpContext ctx, const int32_t* tokens, int n_tokens,
                                  const ImpGenerateParams* params);
 
-// Decode: generate one token
+// Decode: generate one token.
+// Returns IMP_ERROR_CANCELLED when the engine had to cancel the request —
+// e.g. the KV pool is exhausted mid-decode (reject-newest; the engine log
+// names the cause and remedy). IMP_ERROR_INTERNAL after natural FINISH is
+// the end-of-stream signal for callers that keep stepping.
 ImpError imp_decode_step(ImpContext ctx, const ImpGenerateParams* params, int32_t* out_token);
 
 // Teacher-forced perplexity over tokens[0..n_tokens-1] (eval/bench).

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -841,10 +841,16 @@ ImpError imp_decode_step(ImpContext ctx, const ImpGenerateParams* params, int32_
             return IMP_SUCCESS;
         }
 
-        // Check if already finished
+        // Check if already finished. FINISHED keeps returning INTERNAL — the
+        // imp_generate loop relies on "INTERNAL + cleared active_request" as
+        // its natural end-of-stream signal. CANCELLED is reported as such:
+        // the engine cancels requests it cannot serve (KV pool exhausted at
+        // decode — the scheduler logs the reason), and surfacing that as a
+        // bare "internal error" hid the cause.
         if (req->status == imp::RequestStatus::FINISHED || req->status == imp::RequestStatus::CANCELLED) {
+            bool cancelled = req->status == imp::RequestStatus::CANCELLED;
             ctx->active_request = nullptr;
-            return IMP_ERROR_INTERNAL;
+            return cancelled ? IMP_ERROR_CANCELLED : IMP_ERROR_INTERNAL;
         }
 
         // Update sampling params on the request for this step
@@ -869,6 +875,15 @@ ImpError imp_decode_step(ImpContext ctx, const ImpGenerateParams* params, int32_
         }
 
         if (req->output_tokens.size() <= prev_output_size) {
+            // The engine cancelled the request mid-step (KV pool exhausted at
+            // decode — reject-newest; the scheduler already logged the reason
+            // and freed the sequence). Report CANCELLED, not INTERNAL.
+            if (req->status == imp::RequestStatus::CANCELLED) {
+                ctx->active_request = nullptr;
+                return IMP_ERROR_CANCELLED;
+            }
+            IMP_LOG_ERROR("imp_decode_step: engine produced no token in 8 steps (status=%s, %zu outputs)",
+                          imp::request_status_name(req->status), req->output_tokens.size());
             return IMP_ERROR_INTERNAL;
         }
         ctx->consumed_output = prev_output_size;

--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -5,6 +5,9 @@
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cfloat>
@@ -18,6 +21,19 @@ __global__ __launch_bounds__(256) void fp32_to_fp16_kernel(const float* __restri
 namespace imp {
 
 static constexpr auto kGemmAlgo = CUBLAS_GEMM_AUTOTUNE;
+
+// Coverage instrumentation (FA2-coverage dispatch): counts materialized-cuBLAS
+// prefill launches. A test resets this, runs a target-model (Gemma-4) prefill,
+// and asserts it stays 0 — proving the legacy path is unreachable for the
+// target set (the dispatch's executed-kernel coverage gate). Relaxed atomic,
+// diagnostic only; never gates behaviour.
+static std::atomic<uint64_t> s_cublas_prefill_calls{0};
+uint64_t attention_cublas_prefill_call_count() {
+    return s_cublas_prefill_calls.load(std::memory_order_relaxed);
+}
+void attention_cublas_prefill_reset_count() {
+    s_cublas_prefill_calls.store(0, std::memory_order_relaxed);
+}
 
 // ---------------------------------------------------------------------------
 // cuBLAS handle (reuse global — same as gemm.cu)
@@ -388,6 +404,7 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                               int n_heads, int n_kv_heads, int head_dim, float scale, bool causal,
                               float softcap, int q_offset, cudaStream_t stream, int sliding_window,
                               const void* sinks) {
+    s_cublas_prefill_calls.fetch_add(1, std::memory_order_relaxed);
     const half* sinks_h = static_cast<const half*>(sinks);
     int q_len = static_cast<int>(Q.shape[0]);
     int kv_len = static_cast<int>(K.shape[0]);
@@ -566,6 +583,40 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                             (void**)(s_attn_d_ptrs + 2 * n_heads), CUDA_R_16F, ld_o, n_heads,
                             CUBLAS_COMPUTE_32F, kGemmAlgo);
     }
+}
+
+bool attention_cublas_prefill_sliced(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
+                                     Tensor& S, int n_heads, int n_kv_heads, int head_dim, float scale,
+                                     bool causal, float softcap, int q_offset, cudaStream_t stream,
+                                     int sliding_window, const void* sinks) {
+    const int n = static_cast<int>(Q.shape[0]);
+    const int kv_len = static_cast<int>(K.shape[0]);
+    if (n == 0)
+        return true;
+    int64_t s_buf_fp16_elems = static_cast<int64_t>(S.shape[0]) * S.shape[1];
+    if (S.ndim >= 3)
+        s_buf_fp16_elems *= S.shape[2];
+    // Largest slice that keeps every call on the FP32-S path (3× elements —
+    // the use_fp32_s gate above). kv_len is fixed across slices (K/V already
+    // hold the full context incl. this chunk's rows; causal masking bounds
+    // each row), so the solve is linear, not quadratic.
+    int64_t ns64 = s_buf_fp16_elems / (3LL * n_heads * kv_len);
+    int ns = static_cast<int>(std::min<int64_t>(ns64, n));
+    ns = (ns / 16) * 16;
+    if (ns < 16)
+        return false;  // workspace too degraded — caller picks the O(n) FMHA fallback
+    const half* Q_base = static_cast<const half*>(Q.data);
+    half* O_base = static_cast<half*>(O.data);
+    const int64_t row = static_cast<int64_t>(n_heads) * head_dim;
+    for (int off = 0; off < n; off += ns) {
+        const int m = std::min(ns, n - off);
+        int64_t q2[2] = {m, row};
+        Tensor Qs(const_cast<half*>(Q_base) + off * row, QType::F16, 2, q2, true);
+        Tensor Os(O_base + off * row, QType::F16, 2, q2, true);
+        attention_cublas_prefill(Qs, K, V, Os, S, n_heads, n_kv_heads, head_dim, scale, causal, softcap,
+                                 q_offset + off, stream, sliding_window, sinks);
+    }
+    return true;
 }
 
 }  // namespace imp

--- a/src/compute/attention_cublas.h
+++ b/src/compute/attention_cublas.h
@@ -2,8 +2,16 @@
 
 #include "core/tensor.h"
 #include <cuda_runtime.h>
+#include <cstdint>
 
 namespace imp {
+
+// Coverage instrumentation (FA2-coverage dispatch): how many times
+// attention_cublas_prefill has run since the last reset. A test asserts this
+// stays 0 across a Gemma-4 prefill to prove the materialized legacy path is
+// unreachable for the target model set (the executed-kernel coverage gate).
+uint64_t attention_cublas_prefill_call_count();
+void attention_cublas_prefill_reset_count();
 
 // Prefill attention via cuBLAS materialized QK^T + softmax + PV.
 //
@@ -27,6 +35,25 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                               int n_heads, int n_kv_heads, int head_dim, float scale, bool causal,
                               float softcap = 0.0f, int q_offset = 0, cudaStream_t stream = nullptr,
                               int sliding_window = 0, const void* sinks = nullptr);
+
+// attention_cublas_prefill in q-row slices sized to the S workspace.
+//
+// Serves the S-matrix-overflow regime (long ctx_len × wide chunk) where the
+// whole-call footprint n_heads*q_len*kv_len no longer fits S: each slice of
+// q rows runs the normal materialized path against the full K/V with its own
+// q_offset, so causal/SWA masking, softcap, and sinks compose row-wise
+// unchanged. Slices are sized to keep the accurate FP32-S path (3× elements —
+// see use_fp32_s in the .cu; hd=512 FP16-S truncates scores) and floored to a
+// multiple of 16. Returns false without launching when even a 16-row slice
+// would overflow the workspace — the caller falls back to the O(n) tiled FMHA.
+// Measured at Gemma-4 global-layer shapes (nh=16, hd=512, Sq=2048): slices of
+// 64..256 rows run 3.4-3.9× faster than the whole-chunk FMHA hd=512 fallback
+// at Skv 8k/16k (docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md entry 4).
+bool attention_cublas_prefill_sliced(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O,
+                                     Tensor& S, int n_heads, int n_kv_heads, int head_dim, float scale,
+                                     bool causal, float softcap = 0.0f, int q_offset = 0,
+                                     cudaStream_t stream = nullptr, int sliding_window = 0,
+                                     const void* sinks = nullptr);
 
 // Force-create the static cuBLAS handle. Safe to call multiple times.
 // Engine init calls this so the first attention_cublas_prefill invocation

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -71,7 +71,17 @@ __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 2) fmha_sm120_kernel(
     const half* __restrict__ Q, const half* __restrict__ K, const half* __restrict__ V, half* __restrict__ O,
     int batch_size, int seq_q, int seq_kv, int n_heads, int n_kv_heads, float scale, bool causal,
     int sliding_window, float softcap, int q_offset, const half* __restrict__ sinks) {
-    constexpr int Bkv = SM120_Bkv;
+    // KV tile columns. hd=512 (Gemma-4 global / Qwen3.5-27B) uses a narrow tile
+    // so the SMEM-resident Q/KV/O_acc footprint fits the 99 KB opt-in: at Bq=16,
+    // Bkv=32, HD=512 the block needs ~82 KB. Bkv=32 (vs 16) engages 2 warps in the
+    // QK WMMA (s_col_tiles=Bkv/16) and halves the KV-tile iteration count: measured
+    // +40% at pp2048 (0.22x -> 0.36x of cuBLAS) at a small accuracy cost (2.24e-2
+    // vs 1.36e-2 rel on a rect+offset shape, both within the f16 class). This path
+    // is the O(n) fallback for long-context S-matrix overflow where cuBLAS can't
+    // run, so favoring its speed there is correct. The long-context gap to cuBLAS
+    // is fundamental (Bq=16 -> O(n) KV re-reads, no TMEM on sm_120 to widen Bq —
+    // docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md). The WMMA loops are parametric in Bkv.
+    constexpr int Bkv = (HD >= 512) ? 32 : SM120_Bkv;
     constexpr int head_dim = HD;
 
     // Threads-per-row for parallel softmax
@@ -136,7 +146,7 @@ __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 2) fmha_sm120_kernel(
     // ---- zero output accumulator + init running softmax state ---------------
     {
         // float4 = 4 FP32 zeros per store. Bq*HD is always a multiple of 4
-        // (HD ∈ {64,96,128,256}, Bq ∈ {32,64,128}).
+        // (HD ∈ {64,96,128,256,512}, Bq ∈ {16,32,64,128}).
         const int total_vec4 = (Bq * head_dim) / 4;
         const float4 zero = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
         for (int vi = tid; vi < total_vec4; vi += SM120_BLOCK_THREADS) {
@@ -334,8 +344,8 @@ __global__ void __launch_bounds__(SM120_BLOCK_THREADS, 2) fmha_sm120_kernel(
 
         // ---- Load V tile (vectorized: float4 = 8 halves per iter) ----
         {
-            // All supported head_dims (64, 96, 128, 256) are multiples of 8,
-            // so float4 loads are always aligned and in-bounds per row.
+            // All supported head_dims (64, 96, 128, 256, 512) are multiples of
+            // 8, so float4 loads are always aligned and in-bounds per row.
             const int total_vec8 = (Bkv * head_dim) / 8;
             for (int vi = tid; vi < total_vec8; vi += SM120_BLOCK_THREADS) {
                 int i = vi * 8;
@@ -450,16 +460,23 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
     int max_smem = 0;
     cudaDeviceGetAttribute(&max_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
 
+    // KV tile columns — must match the kernel's compile-time `Bkv` (which
+    // derives from HD): hd=512 uses Bkv=32 (~82 KB at Bq=16, fits the 99 KB
+    // opt-in; +40% at long context — see the kernel-side comment).
+    const int Bkv = (head_dim >= 512) ? 32 : SM120_Bkv;
+
     // Select Bq based on head_dim and shared memory fit.
     // Prefer Bq=128 for higher throughput, fall back to 64 for larger HD.
     // K and V share a single buffer, so smem = Q + KV + S + O_acc + row state.
     //   HD=64:  Bq=128 -> 89 KB     HD=96:  Bq=64 -> 65 KB
-    //   HD=128: Bq=64  -> 81 KB     HD=256: Bq=64 -> 145 KB
+    //   HD=128: Bq=64  -> 81 KB     HD=256: Bq=32 -> 90 KB
+    //   HD=512: Bq=16  -> 82 KB (Bkv=32; only Bq that fits under the 99 KB opt-in)
     int Bq;
     {
-        size_t smem_128 = compute_smem_sm120(128, SM120_Bkv, head_dim);
-        size_t smem_64 = compute_smem_sm120(64, SM120_Bkv, head_dim);
-        size_t smem_32 = compute_smem_sm120(32, SM120_Bkv, head_dim);
+        size_t smem_128 = compute_smem_sm120(128, Bkv, head_dim);
+        size_t smem_64 = compute_smem_sm120(64, Bkv, head_dim);
+        size_t smem_32 = compute_smem_sm120(32, Bkv, head_dim);
+        size_t smem_16 = compute_smem_sm120(16, Bkv, head_dim);
         size_t occ2_cap = static_cast<size_t>(max_smem) / 2;
         if (smem_128 <= occ2_cap) {
             Bq = 128;
@@ -469,13 +486,14 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
             Bq = 32;
         } else if (smem_32 <= (size_t)max_smem) {
             Bq = 32;
+        } else if (smem_16 <= (size_t)max_smem) {
+            Bq = 16;  // hd=512: the only Bq whose SMEM fits
         } else {
-            IMP_LOG_DEBUG("FMHA sm120: no Bq fits smem (hd=%d, smem_32=%zu, max=%d)", head_dim, smem_32,
+            IMP_LOG_DEBUG("FMHA sm120: no Bq fits smem (hd=%d, smem_16=%zu, max=%d)", head_dim, smem_16,
                           max_smem);
             return false;
         }
     }
-    const int Bkv = SM120_Bkv;
 
     const size_t smem = compute_smem_sm120(Bq, Bkv, head_dim);
     if (smem > (size_t)max_smem) {
@@ -545,7 +563,7 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
             default:
                 break;
         }
-    } else {
+    } else if (Bq == 32) {
         // Bq=32: for large head_dim (256) where Bq=64 exceeds smem
         switch (head_dim) {
             case 64:
@@ -559,6 +577,17 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
                 return true;
             case 256:
                 LAUNCH_FMHA_SM120(32, 256);
+                return true;
+            default:
+                break;
+        }
+    } else {
+        // Bq=16: only head_dim=512 (Gemma-4 global layers) lands here — the
+        // narrow Bkv=16 tile keeps SMEM under the 99 KB opt-in. Smaller head
+        // dims always fit at Bq>=32, so no other case is instantiated here.
+        switch (head_dim) {
+            case 512:
+                LAUNCH_FMHA_SM120(16, 512);
                 return true;
             default:
                 break;

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -49,12 +49,20 @@
             // on since #932): same fp16-qk kernel family, Bq=64/TWOSLOT instance.
             const bool fa2_hd_ok =
                 hd == 128 || (hd == 256 && runtime_config().attention.fa2_hd256);
-            const bool chunk_fa2_serves = shapes_uniform && !attn_sinks && fa2_hd_ok &&
+            // FA2 is chosen per-layer: heterogeneous Gemma-4 SWA layers (hd=256)
+            // qualify even though the model is not uniform — the gather and the
+            // attention are per-layer, so only THIS layer's head_dim matters.
+            // (Previously gated on shapes_uniform, which forced all Gemma-4
+            // layers onto cuBLAS.)
+            const bool chunk_fa2_serves = !attn_sinks && fa2_hd_ok &&
                                           runtime_config().attention.fa2_fp16qk != "never";
-            // Tiled FMHA correctness domain: uniform shapes. Learned sinks are
-            // servable since #992 (the WMMA FMHA folds them into its online
-            // softmax init); only heterogeneous shapes still require cuBLAS.
-            const bool chunk_fmha_ok = shapes_uniform;
+            // The tiled WMMA FMHA serves any fused head_dim (incl. hd=512 since
+            // this dispatch), per-layer — so Gemma-4 global layers (hd=512)
+            // qualify too. Only learned sinks below the threshold still require
+            // cuBLAS (folded into the WMMA FMHA above the threshold, #992).
+            const bool fmha_hd_ok =
+                (hd == 64 || hd == 96 || hd == 128 || hd == 256 || hd == 512);
+            const bool chunk_fmha_ok = fmha_hd_ok;
             // attn_scores_ is sized [nh, s_cap, s_cap] (square). Chunked cuBLAS stores
             // an [nh, n, ctx_len] FP16 matrix (or FP32 = 2× when use_fp32_s). The
             // capacity constraint is `n * ctx_len <= s_cap²`, NOT `ctx_len <= s_cap`
@@ -81,8 +89,12 @@
             // learned sinks / heterogeneous shapes are excluded by
             // chunk_fmha_ok and keep cuBLAS.
             const bool small_growing_chunk = n <= 32 && hd != 128;
+            // hd=512 never prefers the fused path — the SMEM-capped WMMA FMHA is
+            // 2.8-4.6x slower than cuBLAS there (docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md). It stays on cuBLAS
+            // while the S-matrix fits; the fused hd=512 kernel is used only when
+            // the S-matrix would overflow (the else branch below = O(n) fallback).
             const bool prefer_fmha =
-                chunk_fmha_ok &&
+                chunk_fmha_ok && hd != 512 &&
                 ((runtime_config().attention.fmha_prefill_threshold > 0 &&
                   ctx_len >= runtime_config().attention.fmha_prefill_threshold) ||
                  small_growing_chunk);
@@ -292,19 +304,31 @@
                                        q_offset, stream)) {
                 // chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
             } else if (smatrix_fits && !prefer_fmha) {
-                // cuBLAS: reference path below the FMHA threshold; also the only
-                // chunked path that honors heterogeneous per-layer shapes
-                // (Gemma-4); it also serves learned sinks below the FMHA
-                // threshold (both softmaxes understand sinks since #992).
+                // cuBLAS: below-threshold reference for uniform models, learned
+                // sinks, AND the hd=512 Gemma-4 global layers whenever their
+                // S-matrix fits (measured faster than the SMEM-capped fused
+                // hd=512 kernel — docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md). The hd=256 SWA layers took FA2
+                // above; only the hd=512 layers land here.
                 attention_cublas_prefill(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv, hd, scale,
                                          /*causal=*/true, cfg.attn_logit_softcap, q_offset, stream,
                                          layer_sliding_window, attn_sinks);
+            } else if (hd == 512 && !prefer_fmha && s_cap > 0 &&
+                       attention_cublas_prefill_sliced(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv,
+                                                       hd, scale, /*causal=*/true, cfg.attn_logit_softcap,
+                                                       q_offset, stream, layer_sliding_window,
+                                                       attn_sinks)) {
+                // hd=512 S-matrix overflow (long ctx): cuBLAS in workspace-sized
+                // q-row slices — 3.4-3.9× faster than the whole-chunk FMHA hd=512
+                // fallback at Skv 8k/16k (docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md entry 4; the FMHA's Bq=16
+                // tile re-reads K/V ~Sq/16 times = KV-bandwidth-amplified).
+                // Returns false only when even a 16-row slice overflows the
+                // workspace; then the FMHA below still serves.
             } else {
                 // Tiled FMHA dispatch: no S-matrix needed, O(n) memory. Serves
                 // uniform-shape chunks above the FMHA threshold, any chunk the
-                // S-matrix cannot hold, and fa2-declined chunks on models whose
-                // S-matrix was deliberately skipped. Learned sinks ride along
-                // since #992 (heterogeneous shapes still never reach here).
+                // S-matrix cannot hold (fa2-declined chunks on S-matrix-skipped
+                // models, hd=512 only when the workspace is too degraded even
+                // for 16-row cuBLAS slices). Learned sinks ride along (#992).
                 int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
                 int64_t kv4s[4] = {1, (int64_t)ctx_len, (int64_t)nkv, (int64_t)hd};
                 int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
@@ -344,14 +368,21 @@
         // servable since #992 and follow the same threshold policy as every
         // other non-FA2 model — FA2 itself still declines sinks (kept out of
         // the try below).
-        const bool hetero_shapes = per_layer_shapes && !attn_shapes_uniform();
-        const bool force_cublas_attn = hetero_shapes;
+        // Heterogeneous models (Gemma-4 dual head_dim 256/512): the hd=256 SWA
+        // layers (5/6 of layers in the 5:1 pattern) now take FA2 f16-QK per-layer
+        // — a real speed win, previously blocked only by the coarse model-level
+        // force_cublas gate. The hd=512 global layers stay on the materialized
+        // cuBLAS path, which is 2.8-4.6x FASTER than the SMEM-capped fused hd=512
+        // kernel (Bq=16 forced by the 99 KB opt-in — docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md entry 1). The
+        // fused hd=512 kernel exists only as the O(n)-memory capacity fallback
+        // for when cuBLAS's S-matrix would overflow the workspace (long context).
         const bool s_matrix_fits = attn_scores_buf_ != nullptr &&
                                    n <= static_cast<int>(attn_scores_.shape[1]);
         // FMHA only above the S-matrix threshold — see the chunked path above
         // for why the #493 prefer-FA2-at-every-length override was reverted.
-        const bool prefer_fmha = !force_cublas_attn &&
-                                 (n >= runtime_config().attention.fmha_prefill_threshold);
+        // hd=512 never prefers the fused path (it is slower than cuBLAS); it
+        // stays on cuBLAS until the S-matrix no longer fits.
+        const bool prefer_fmha = (n >= runtime_config().attention.fmha_prefill_threshold) && hd != 512;
 
         // NOTE (#566→#511): sliding-window prefill used to be routed AWAY
         // from the cuBLAS path here (`non_gemma4_sliding`) into the tiled
@@ -373,22 +404,39 @@
         // fast path does not depend on the attn_scores buffer being allocated or
         // large enough for n: a too-small buffer used to make s_matrix_fits false
         // and drop n≈512 chunks into the slow tiled dispatch (−93% pp512). cuBLAS
-        // stays the fallback for the configs f16-QK declines (hd ∉ {128, 256},
-        // or hd=256 with fa2_hd256 off) and for force_cublas_attn (learned
-        // sinks / heterogeneous per-layer shapes).
-        if (!force_cublas_attn && attn_sinks == nullptr &&
+        // stays the below-threshold fallback for models the f16-QK kernel
+        // declines (hd ∉ {128, 256}, or hd=256 with fa2_hd256 off) and for
+        // learned sinks. Gemma-4's hd=256 SWA layers now take FA2 per-layer (the
+        // win); its hd=512 global layers stay on cuBLAS (faster than the fused
+        // hd=512 kernel), with the FMHA dispatch as their O(n) overflow fallback.
+        if (attn_sinks == nullptr &&
             try_fa2_fp16qk_prefill(runtime_config(), qv, kk, vv, ao, n, n, nh, nkv, hd, scale,
                                    layer_sliding_window, cfg.attn_logit_softcap, /*q_offset=*/0,
                                    stream)) {
-            // handled by FA2 f16 — no S-matrix needed
+            // handled by FA2 f16 — no S-matrix needed (hd 128/256, incl. Gemma-4 SWA)
         } else if (s_matrix_fits && !prefer_fmha) {
+            // Materialized cuBLAS: below-threshold reference for uniform models
+            // and learned sinks, AND the hd=512 Gemma-4 global layers whenever
+            // the S-matrix fits (faster than the SMEM-capped fused hd=512 kernel
+            // — docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md). The hd=256 SWA layers took FA2 above.
             attention_cublas_prefill(qv, kk, vv, ao, attn_scores_, nh, nkv, hd, scale,
                                      /*causal=*/true, cfg.attn_logit_softcap,
                                      /*q_offset=*/0, stream, layer_sliding_window, attn_sinks);
+        } else if (hd == 512 && !prefer_fmha && attn_scores_buf_ != nullptr &&
+                   attention_cublas_prefill_sliced(qv, kk, vv, ao, attn_scores_, nh, nkv, hd, scale,
+                                                   /*causal=*/true, cfg.attn_logit_softcap,
+                                                   /*q_offset=*/0, stream, layer_sliding_window,
+                                                   attn_sinks)) {
+            // hd=512 S-matrix overflow: cuBLAS in workspace-sized q-row slices —
+            // 3.4-3.9× faster than the whole-prompt FMHA hd=512 fallback
+            // (docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md entry 4). False only when even a 16-row slice
+            // overflows; then the FMHA below still serves.
         } else {
             // FMHA fallback: tiled O(n) memory chain. Sink-capable since #992
-            // (the dispatch routes sinks to the WMMA FMHA and throws instead
-            // of falling through to a sink-blind kernel).
+            // (the dispatch routes sinks to the WMMA FMHA and throws instead of
+            // falling through to a sink-blind kernel). Reached by uniform models
+            // above the FMHA threshold, and by hd=512 layers only when the
+            // workspace is too degraded even for 16-row cuBLAS slices.
             int64_t q4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};
             int64_t kv4s[4] = {1, (int64_t)n, (int64_t)nkv, (int64_t)hd};
             int64_t o4s[4] = {1, (int64_t)n, (int64_t)nh, (int64_t)hd};

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1412,6 +1412,29 @@ int GraphExecutor::max_safe_prefill_chunk(int offset, int desired, int kv_bs) co
     if (uniform && !sinks && att.fmha_prefill_threshold > 0 &&
         offset + desired >= att.fmha_prefill_threshold)
         return desired;
+    // Heterogeneous per-layer shapes (Gemma-4 dual head_dim 256/512): every
+    // layer is served at ANY chunk×ctx — hd 128/256 ride FA2 per-layer, hd=512
+    // runs cuBLAS in workspace-sized q-row slices at S-overflow
+    // (attention_cublas_prefill_sliced), and the tiled FMHA covers the rest —
+    // so no global clamp is needed. The quadratic clamp below used to shrink
+    // EVERY layer's chunk to the hd=512 S-matrix capacity (~190 rows at 64k
+    // ctx), multiplying per-chunk cost (MoE dequant, launches) across the
+    // whole model.
+    if (!uniform && !sinks) {
+        bool all_served = true;
+        for (int x : cfg.head_dim_per_layer) {
+            if (x <= 0)
+                continue;  // non-attention layers (GDN/Mamba2 hybrids)
+            const bool fa2 = (x == 128 || (x == 256 && att.fa2_hd256)) && att.fa2_fp16qk != "never";
+            const bool fmha = x == 64 || x == 96 || x == 128 || x == 256 || x == 512;
+            if (!fa2 && !fmha) {
+                all_served = false;
+                break;
+            }
+        }
+        if (all_served)
+            return desired;
+    }
     // cuBLAS serves this chunk: n × (offset + n) ≤ s_cap² and n ≤ s_cap.
     // Solve the quadratic for n; floor to a KV-block multiple.
     const double cap2 = static_cast<double>(s_cap) * s_cap;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -692,6 +692,24 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         return;
     }
 
+    // Admission heads-up: the KV pool is often VRAM-clamped below the requested
+    // max_seq_len. A prompt that fills the pool prefills fine and is then
+    // cancelled on its first block append mid-decode (reject-newest) — flag it
+    // here once, at submit time, where it is actionable. req->max_tokens is NOT
+    // usable here (imp_prefill seeds a 4096 placeholder; decode_step drives the
+    // real stop), so gate on the prompt leaving less than one block of headroom.
+    if (offset == 0 && kv_cache_raw_) {
+        int64_t pool_tokens = static_cast<int64_t>(kv_cache_raw_->total_blocks()) * kv_bs;
+        if (pool_tokens > 0 && total_input > pool_tokens - kv_bs) {
+            IMP_LOG_WARN(
+                "Request %d: prompt (%d tokens) leaves <1 KV block of decode headroom in the "
+                "%lld-token pool (VRAM-clamped) — decode will be cancelled almost immediately. "
+                "Lower max_seq_len, shorten the prompt, or halve KV with kv_cache.dtype=fp8 "
+                "(--kv-fp8).",
+                req->id, total_input, (long long)pool_tokens);
+        }
+    }
+
     // Clamp effective_chunk so the chunked-attention S-matrix cannot overflow
     // (cuBLAS stores an [nh, n, ctx_len] score matrix; n × ctx_len ≤ s_cap²).
     // max_safe_prefill_chunk mirrors the executor dispatch and only clamps
@@ -1295,6 +1313,16 @@ void Engine::step_decode(cudaStream_t dec_stream) {
                 // ran). Reject-newest instead: cancel THIS sequence and leave the
                 // others' KV intact. StreamingLLM auto-enable (above) already
                 // handles the graceful FP16 case before we reach here.
+                // Log loudly: this used to be a silent cancel that surfaced as a
+                // bare "internal error" at the API (Gemma-4-12B at ctx 16384 on a
+                // 1024-block FP16-KV pool cost a debugging session to attribute).
+                int pool_blocks = kv_cache_raw_ ? kv_cache_raw_->total_blocks() : 0;
+                IMP_LOG_ERROR(
+                    "KV pool exhausted at decode: seq %d needs block %d but the %d-block pool has "
+                    "0 free/reclaimable — cancelling this sequence (others keep their KV). The "
+                    "pool was VRAM-clamped below the requested context; free VRAM, lower "
+                    "max_seq_len, or halve KV with kv_cache.dtype=fp8 (--kv-fp8).",
+                    req->id, blocks_needed, pool_blocks);
                 kv_manager_->free_sequence(req->id);
                 req->status = RequestStatus::CANCELLED;
                 continue;
@@ -1306,6 +1334,10 @@ void Engine::step_decode(cudaStream_t dec_stream) {
         if (swa_sizing_active_) {
             kv_manager_->swa_trim(req->id, ctx_len);
             if (!kv_manager_->swa_prepare(req->id, ctx_len)) {
+                IMP_LOG_ERROR(
+                    "SWA KV sizing failed at decode: seq %d could not prepare its window at "
+                    "ctx_len=%d — cancelling this sequence (see kv_cache.swa_sizing).",
+                    req->id, ctx_len);
                 kv_manager_->free_sequence(req->id);
                 req->status = RequestStatus::CANCELLED;
                 continue;

--- a/tests/test_attention_fmha_hd512.cu
+++ b/tests/test_attention_fmha_hd512.cu
@@ -1,0 +1,491 @@
+// head_dim=512 prefill parity — WMMA FMHA (fmha_sm120) vs the cuBLAS materialized
+// reference, both anchored to an fp64 CPU reference.
+//
+// hd=512 is the Gemma-4 global-attention layer geometry (and Qwen3.5-27B, see
+// attention_cublas.cu:423). Before this test the tiled WMMA FMHA declined
+// hd=512 and every hd=512 layer fell to the materialized cuBLAS path. The
+// dispatch closes that gap with a Bq=16/Bkv=16 instantiation; this test is the
+// validator's parity gate: the new fused kernel must (a) actually run at hd=512
+// (not silently decline) and (b) match the trusted cuBLAS reference and an fp64
+// reference within the f16 numerical class.
+//
+// Math mirrors attention_cublas_prefill exactly:
+//   S = scale * (Q·K^T)  →  (softcap>0: S = softcap*tanh(S/softcap))
+//   → mask (causal: j>abs_row; SWA: abs_row-j>=window; abs_row=q_offset+row)
+//   → softmax → O = P·V.
+//
+// Inputs are heavy-tailed realistic magnitudes and rounded to f16 on the host so
+// both device paths consume bit-identical inputs; the fp64 reference is computed
+// from the same f16-rounded values.
+
+#include <gtest/gtest.h>
+#include "compute/attention_cublas.h"
+#include "compute/attention_fmha_sm120.h"
+#include "core/tensor.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// Integer LCG → f32 with multiply-only transforms (no libm), cubed to make a
+// heavy tail, then rounded to f16 — the QK-normed-activation regime that broke
+// benign-fill parity tests historically (#493/#512).
+void lcg_fill(std::vector<half>& out, uint32_t seed, float amp) {
+    uint32_t s = seed * 2654435761u + 1013904223u;
+    for (auto& h : out) {
+        s = s * 1664525u + 1013904223u;
+        float u = ((s >> 8) & 0xFFFFFF) * (1.0f / 16777216.0f);  // [0,1)
+        float c = (2.0f * u - 1.0f);
+        c = c * c * c;  // cubed: heavy tail
+        float v = c * amp;
+        if (((s >> 4) & 0xFF) == 0)
+            v *= 4.0f;  // ~1/256 outliers
+        h = __float2half(v);
+    }
+}
+
+// fp64 reference from f16-rounded inputs. Layout: Q[Sq,NH,HD], K/V[Skv,NKV,HD].
+void ref_attention_f64(const std::vector<half>& Q, const std::vector<half>& K, const std::vector<half>& V,
+                       std::vector<double>& O, int Sq, int Skv, int NH, int NKV, int HD, bool causal,
+                       int sw, float softcap, float scale, int q_offset) {
+    O.assign((size_t)Sq * NH * HD, 0.0);
+    const int group = NH / NKV;
+    for (int h = 0; h < NH; h++) {
+        const int kvh = h / group;
+        for (int i = 0; i < Sq; i++) {
+            const int abs_row = q_offset + i;
+            std::vector<double> s(Skv, 0.0);
+            double m = -1e300;
+            for (int j = 0; j < Skv; j++) {
+                double dot = 0.0;
+                for (int d = 0; d < HD; d++) {
+                    dot += (double)__half2float(Q[((size_t)i * NH + h) * HD + d]) *
+                           (double)__half2float(K[((size_t)j * NKV + kvh) * HD + d]);
+                }
+                double sc = dot * (double)scale;
+                if (softcap > 0.0f)
+                    sc = (double)softcap * std::tanh(sc / (double)softcap);
+                bool masked = (causal && j > abs_row) || (sw > 0 && (abs_row - j) >= sw);
+                s[j] = masked ? -1e300 : sc;
+                if (s[j] > m)
+                    m = s[j];
+            }
+            double denom = 0.0;
+            for (int j = 0; j < Skv; j++) {
+                s[j] = (s[j] <= -1e299) ? 0.0 : std::exp(s[j] - m);
+                denom += s[j];
+            }
+            double inv = denom > 0.0 ? 1.0 / denom : 0.0;
+            for (int d = 0; d < HD; d++) {
+                double acc = 0.0;
+                for (int j = 0; j < Skv; j++)
+                    acc += s[j] * inv * (double)__half2float(V[((size_t)j * NKV + kvh) * HD + d]);
+                O[((size_t)i * NH + h) * HD + d] = acc;
+            }
+        }
+    }
+}
+
+struct Metrics {
+    double max_rel = 0.0;
+    double mean_rel = 0.0;
+};
+
+Metrics compare(const std::vector<float>& got, const std::vector<double>& ref) {
+    Metrics m;
+    double sum = 0.0;
+    size_t n = ref.size();
+    for (size_t i = 0; i < n; i++) {
+        double denom = std::max(1e-2, std::fabs(ref[i]));  // abs floor: tiny-value stability
+        double r = std::fabs((double)got[i] - ref[i]) / denom;
+        m.max_rel = std::max(m.max_rel, r);
+        sum += r;
+    }
+    m.mean_rel = sum / (double)n;
+    return m;
+}
+
+class FmhaHd512Test : public ::testing::Test {
+  protected:
+    void SetUp() override { ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess); }
+    void TearDown() override { cudaStreamDestroy(stream_); }
+    cudaStream_t stream_ = nullptr;
+
+    // Runs one config through cuBLAS + WMMA FMHA at hd=512 and checks parity.
+    void run(const std::string& name, int Sq, int Skv, int NH, int NKV, bool causal, int sw, float softcap,
+             int q_offset) {
+        const int HD = 512;
+        const float scale = 1.0f / std::sqrt((float)HD);
+        const size_t q_elems = (size_t)Sq * NH * HD;
+        const size_t kv_elems = (size_t)Skv * NKV * HD;
+
+        std::vector<half> Qh(q_elems), Kh(kv_elems), Vh(kv_elems);
+        lcg_fill(Qh, 0x1111u, 4.0f);
+        lcg_fill(Kh, 0x2222u, 4.0f);
+        lcg_fill(Vh, 0x3333u, 1.0f);
+
+        std::vector<double> ref;
+        ref_attention_f64(Qh, Kh, Vh, ref, Sq, Skv, NH, NKV, HD, causal, sw, softcap, scale, q_offset);
+
+        void *d_q, *d_k, *d_v, *d_o, *d_s;
+        // 4x so cuBLAS takes the production FP32-S path: use_fp32_s needs the
+        // score buffer >= 3x the (NH*Sq*Skv) element count (#677 — FP32 scores
+        // in the front 2x, non-overlapping FP16 probs after). At hd=512 the
+        // FP16-S path truncates the large QK^T scores and is materially less
+        // accurate; Gemma-4 / Qwen3.5-27B run FP32-S in production.
+        const size_t s_elems = (size_t)4 * NH * Sq * Skv;
+        ASSERT_EQ(cudaMalloc(&d_q, q_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_k, kv_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_v, kv_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_o, q_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_s, s_elems * 2), cudaSuccess);
+        cudaMemcpy(d_q, Qh.data(), q_elems * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_k, Kh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_v, Vh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+
+        int64_t q2[2] = {Sq, (int64_t)NH * HD};
+        int64_t kv2[2] = {Skv, (int64_t)NKV * HD};
+        int64_t s3[3] = {NH, Sq, 4 * (int64_t)Skv};
+        int64_t q4[4] = {1, Sq, NH, HD};
+        int64_t kv4[4] = {1, Skv, NKV, HD};
+        Tensor Q2(d_q, QType::F16, 2, q2, true), K2(d_k, QType::F16, 2, kv2, true);
+        Tensor V2(d_v, QType::F16, 2, kv2, true), O2(d_o, QType::F16, 2, q2, true);
+        Tensor S3(d_s, QType::F16, 3, s3, true);
+        Tensor Q4(d_q, QType::F16, 4, q4, true), K4(d_k, QType::F16, 4, kv4, true);
+        Tensor V4(d_v, QType::F16, 4, kv4, true), O4(d_o, QType::F16, 4, q4, true);
+
+        auto collect = [&]() {
+            cudaStreamSynchronize(stream_);
+            EXPECT_EQ(cudaGetLastError(), cudaSuccess) << name;
+            std::vector<half> h(q_elems);
+            cudaMemcpy(h.data(), d_o, q_elems * 2, cudaMemcpyDeviceToHost);
+            std::vector<float> out(q_elems);
+            for (size_t i = 0; i < q_elems; i++)
+                out[i] = __half2float(h[i]);
+            return out;
+        };
+
+        // cuBLAS materialized reference (the legacy pre-change path).
+        cudaMemset(d_o, 0, q_elems * 2);
+        attention_cublas_prefill(Q2, K2, V2, O2, S3, NH, NKV, HD, scale, causal, softcap, q_offset, stream_,
+                                 sw);
+        std::vector<float> o_cublas = collect();
+
+        // WMMA FMHA — must actually run at hd=512 (the coverage gate).
+        cudaMemset(d_o, 0, q_elems * 2);
+        bool ran =
+            fmha_sm120_prefill(Q4, K4, V4, O4, scale, causal, sw, softcap, stream_, q_offset, nullptr);
+        ASSERT_TRUE(ran) << name << ": fmha_sm120_prefill declined hd=512 — the kernel must serve it";
+        std::vector<float> o_fmha = collect();
+
+        cudaFree(d_q);
+        cudaFree(d_k);
+        cudaFree(d_v);
+        cudaFree(d_o);
+        cudaFree(d_s);
+
+        // The fp64 eager computation is the trusted reference. cuBLAS FP32-S is
+        // the pre-change legacy path (an independent f16-class approximation).
+        Metrics mf = compare(o_fmha, ref);      // FMHA vs trusted fp64 — correctness
+        Metrics mc = compare(o_cublas, ref);    // legacy cuBLAS vs trusted fp64
+        std::vector<double> cublas_d(o_cublas.begin(), o_cublas.end());
+        Metrics mfc = compare(o_fmha, cublas_d);  // FMHA vs the legacy output
+
+        printf("[hd512 %-18s] fmha_vs_ref max=%.2e mean=%.2e | cublas_vs_ref max=%.2e mean=%.2e | "
+               "fmha_vs_cublas max=%.2e\n",
+               name.c_str(), mf.max_rel, mf.mean_rel, mc.max_rel, mc.mean_rel, mfc.max_rel);
+
+        // Correctness bar = the f16 numerical class vs the trusted fp64 reference
+        // (a 512-long reduction rounds harder than HD<=256). The fused hd=512
+        // kernel is the O(n) fallback for long-context S-matrix overflow, where
+        // cuBLAS cannot run at all — so "no worse than cuBLAS" is not a meaningful
+        // production bar (there is no cuBLAS to compare against there). Both paths
+        // must simply land in the f16 class. The Bkv=32 tile trades ~0.9e-2 of
+        // accuracy on rect+offset shapes for +40% throughput (both < 2.5e-2).
+        // Thresholds frozen, not to be widened.
+        EXPECT_LT(mf.max_rel, 2.5e-2) << name << ": FMHA hd=512 off vs the fp64 reference";
+        EXPECT_LT(mf.mean_rel, 1e-3) << name << ": FMHA hd=512 mean error too high vs fp64";
+        EXPECT_LT(mc.max_rel, 2.5e-2) << name << ": cuBLAS FP32-S reference itself off vs fp64";
+    }
+};
+
+// Gemma-4 global-layer geometry: full causal attention, GQA, softcap.
+TEST_F(FmhaHd512Test, Causal_GQA) { run("causal_gqa", 96, 96, 8, 4, true, 0, 0.0f, 0); }
+TEST_F(FmhaHd512Test, Causal_GQA_Softcap) { run("causal_gqa_softcap", 96, 96, 8, 4, true, 0, 50.0f, 0); }
+TEST_F(FmhaHd512Test, Causal_MHA) { run("causal_mha", 64, 64, 4, 4, true, 0, 0.0f, 0); }
+// Non-square (chunked-continuation shape) with q_offset.
+TEST_F(FmhaHd512Test, Rect_Offset) { run("rect_offset", 32, 160, 8, 2, true, 0, 0.0f, 128); }
+// Tile-boundary edge: Skv just over a Bkv=16 tile; Sq over a Bq=16 tile.
+TEST_F(FmhaHd512Test, TileEdge) { run("tile_edge", 17, 33, 8, 4, true, 0, 0.0f, 0); }
+// Sliding window (kernel generality — hd=512 production is full-attention).
+TEST_F(FmhaHd512Test, SlidingWindow) { run("sliding_window", 96, 96, 8, 4, true, 48, 0.0f, 0); }
+
+// Isolated kernel A/B: the WMMA FMHA hd=512 vs the materialized cuBLAS FP32-S
+// path it replaces, at Gemma-4 global-layer shapes (nh=16, nkv=8, hd=512).
+// This isolates the per-shape prefill-attention win (the whole-model Gemma-4
+// prefill is MoE-dequant-dominated and hd=512 is only 1/6 of attention layers,
+// so an end-to-end delta would sit in prefill restart noise). DISABLED so the
+// normal suite stays fast; run with --gtest_also_run_disabled_tests.
+// Clock warmup >1s first (RTX 5090 idles downclocked, ~1s ramp — CLAUDE.md).
+TEST_F(FmhaHd512Test, DISABLED_BenchVsCublas) {
+    const int HD = 512, NH = 16, NKV = 8;
+    const float scale = 1.0f / std::sqrt((float)HD);
+    for (int Sq : {512, 2048}) {
+        const int Skv = Sq;
+        const size_t q_elems = (size_t)Sq * NH * HD, kv_elems = (size_t)Skv * NKV * HD;
+        std::vector<half> Qh(q_elems), Kh(kv_elems), Vh(kv_elems);
+        lcg_fill(Qh, 0x1111u, 4.0f);
+        lcg_fill(Kh, 0x2222u, 4.0f);
+        lcg_fill(Vh, 0x3333u, 1.0f);
+        void *d_q, *d_k, *d_v, *d_o, *d_s;
+        const size_t s_elems = (size_t)4 * NH * Sq * Skv;
+        cudaMalloc(&d_q, q_elems * 2);
+        cudaMalloc(&d_k, kv_elems * 2);
+        cudaMalloc(&d_v, kv_elems * 2);
+        cudaMalloc(&d_o, q_elems * 2);
+        cudaMalloc(&d_s, s_elems * 2);
+        cudaMemcpy(d_q, Qh.data(), q_elems * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_k, Kh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_v, Vh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+        int64_t q2[2] = {Sq, (int64_t)NH * HD}, kv2[2] = {Skv, (int64_t)NKV * HD};
+        int64_t s3[3] = {NH, Sq, 4 * (int64_t)Skv};
+        int64_t q4[4] = {1, Sq, NH, HD}, kv4[4] = {1, Skv, NKV, HD};
+        Tensor Q2(d_q, QType::F16, 2, q2, true), K2(d_k, QType::F16, 2, kv2, true);
+        Tensor V2(d_v, QType::F16, 2, kv2, true), O2(d_o, QType::F16, 2, q2, true);
+        Tensor S3(d_s, QType::F16, 3, s3, true);
+        Tensor Q4(d_q, QType::F16, 4, q4, true), K4(d_k, QType::F16, 4, kv4, true);
+        Tensor V4(d_v, QType::F16, 4, kv4, true), O4(d_o, QType::F16, 4, q4, true);
+
+        auto time_ms = [&](bool fmha, int reps) {
+            cudaEvent_t a, b;
+            cudaEventCreate(&a);
+            cudaEventCreate(&b);
+            cudaEventRecord(a, stream_);
+            for (int i = 0; i < reps; i++) {
+                if (fmha)
+                    fmha_sm120_prefill(Q4, K4, V4, O4, scale, true, 0, 0.0f, stream_, 0, nullptr);
+                else
+                    attention_cublas_prefill(Q2, K2, V2, O2, S3, NH, NKV, HD, scale, true, 0.0f, 0, stream_);
+            }
+            cudaEventRecord(b, stream_);
+            cudaEventSynchronize(b);
+            float ms = 0;
+            cudaEventElapsedTime(&ms, a, b);
+            cudaEventDestroy(a);
+            cudaEventDestroy(b);
+            return ms / reps;
+        };
+        // Warm the clocks (>1s of work) before timing.
+        for (int w = 0; w < 40; w++) {
+            fmha_sm120_prefill(Q4, K4, V4, O4, scale, true, 0, 0.0f, stream_, 0, nullptr);
+            attention_cublas_prefill(Q2, K2, V2, O2, S3, NH, NKV, HD, scale, true, 0.0f, 0, stream_);
+        }
+        cudaStreamSynchronize(stream_);
+        double best_c = 1e9, best_f = 1e9;
+        for (int t = 0; t < 3; t++) {
+            best_c = std::min(best_c, (double)time_ms(false, 20));
+            best_f = std::min(best_f, (double)time_ms(true, 20));
+        }
+        printf("[hd512 bench pp%-4d] cublas_fp32s %.3f ms | fmha %.3f ms | speedup %.2fx\n", Sq, best_c,
+               best_f, best_c / best_f);
+        cudaFree(d_q);
+        cudaFree(d_k);
+        cudaFree(d_v);
+        cudaFree(d_o);
+        cudaFree(d_s);
+    }
+}
+
+// Parity of the q-row-sliced cuBLAS path (attention_cublas_prefill_sliced) —
+// the S-overflow production route for hd=512 layers. The S buffer is sized so
+// the FP32-S 3× rule forces 32-row slices (3 slices over Sq=96); the result
+// must match the fp64 reference within the f16 class and track the whole-call
+// FP32-S path (independent slicing of the same math).
+TEST_F(FmhaHd512Test, SlicedCublasParity) {
+    const int HD = 512, NH = 8, NKV = 4, Sq = 96, Skv = 160, q_offset = 64;
+    const float scale = 1.0f / std::sqrt((float)HD);
+    const float softcap = 50.0f;
+    const size_t q_elems = (size_t)Sq * NH * HD, kv_elems = (size_t)Skv * NKV * HD;
+    std::vector<half> Qh(q_elems), Kh(kv_elems), Vh(kv_elems);
+    lcg_fill(Qh, 0x1111u, 4.0f);
+    lcg_fill(Kh, 0x2222u, 4.0f);
+    lcg_fill(Vh, 0x3333u, 1.0f);
+    std::vector<double> ref;
+    ref_attention_f64(Qh, Kh, Vh, ref, Sq, Skv, NH, NKV, HD, /*causal=*/true, /*sw=*/0, softcap, scale,
+                      q_offset);
+
+    void *d_q, *d_k, *d_v, *d_o, *d_s;
+    // Sized to force ns=32: ns = s_elems / (3*NH*Skv) = 122880 / 3840 = 32.
+    const size_t s_elems = (size_t)NH * Sq * Skv;
+    ASSERT_EQ(cudaMalloc(&d_q, q_elems * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_k, kv_elems * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_v, kv_elems * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_o, q_elems * 2), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_s, s_elems * 2 * 4), cudaSuccess);  // 4x: also holds the whole-call FP32-S run
+    cudaMemcpy(d_q, Qh.data(), q_elems * 2, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_k, Kh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v, Vh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+
+    int64_t q2[2] = {Sq, (int64_t)NH * HD}, kv2[2] = {Skv, (int64_t)NKV * HD};
+    int64_t s3_small[3] = {NH, Sq, Skv};      // forces 32-row slices via the 3x FP32-S rule
+    int64_t s3_big[3] = {NH, Sq, 4 * (int64_t)Skv};  // whole-call FP32-S reference
+    Tensor Q2(d_q, QType::F16, 2, q2, true), K2(d_k, QType::F16, 2, kv2, true);
+    Tensor V2(d_v, QType::F16, 2, kv2, true), O2(d_o, QType::F16, 2, q2, true);
+    Tensor S_small(d_s, QType::F16, 3, s3_small, true);
+    Tensor S_big(d_s, QType::F16, 3, s3_big, true);
+
+    auto collect = [&]() {
+        cudaStreamSynchronize(stream_);
+        EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+        std::vector<half> h(q_elems);
+        cudaMemcpy(h.data(), d_o, q_elems * 2, cudaMemcpyDeviceToHost);
+        std::vector<float> out(q_elems);
+        for (size_t i = 0; i < q_elems; i++)
+            out[i] = __half2float(h[i]);
+        return out;
+    };
+
+    cudaMemset(d_o, 0, q_elems * 2);
+    attention_cublas_prefill(Q2, K2, V2, O2, S_big, NH, NKV, HD, scale, /*causal=*/true, softcap,
+                             q_offset, stream_);
+    std::vector<float> o_whole = collect();
+
+    cudaMemset(d_o, 0, q_elems * 2);
+    bool ran = attention_cublas_prefill_sliced(Q2, K2, V2, O2, S_small, NH, NKV, HD, scale,
+                                               /*causal=*/true, softcap, q_offset, stream_);
+    ASSERT_TRUE(ran) << "sliced path declined although a 32-row slice fits";
+    std::vector<float> o_sliced = collect();
+
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_o);
+    cudaFree(d_s);
+
+    Metrics ms = compare(o_sliced, ref);
+    Metrics mw = compare(o_whole, ref);
+    std::vector<double> whole_d(o_whole.begin(), o_whole.end());
+    Metrics msw = compare(o_sliced, whole_d);
+    printf("[hd512 sliced_parity   ] sliced_vs_ref max=%.2e mean=%.2e | whole_vs_ref max=%.2e mean=%.2e "
+           "| sliced_vs_whole max=%.2e\n",
+           ms.max_rel, ms.mean_rel, mw.max_rel, mw.mean_rel, msw.max_rel);
+    EXPECT_LT(ms.max_rel, 2.5e-2) << "sliced cuBLAS off vs the fp64 reference";
+    EXPECT_LT(ms.mean_rel, 1e-3) << "sliced cuBLAS mean error too high vs fp64";
+    // Same math, same FP32-S class — but slicing changes the GEMM batch
+    // geometry, so the runs differ in fp16-P rounding (measured 1.2e-2, the
+    // same mutual-f16 band as fmha_vs_cublas above). Gate at the class bound.
+    EXPECT_LT(msw.max_rel, 2.5e-2) << "sliced diverges from the whole-call FP32-S path";
+}
+
+// Long-context fallback-regime bench: continuation chunk Sq=2048 against a long
+// KV (Skv 8k/16k, q_offset = Skv - Sq). This is the shape the fused hd=512
+// kernel actually serves in production — the materialized S-matrix overflows
+// the workspace there, so (pre-dispatch) the executor had to run cuBLAS in thin
+// s_cap-respecting row slices. Arms: FMHA whole-chunk vs cuBLAS in 256-row
+// slices (the realistic alternative at this regime). DISABLED so the normal
+// suite stays fast; run with --gtest_also_run_disabled_tests.
+TEST_F(FmhaHd512Test, DISABLED_BenchLongCtxFallback) {
+    const int HD = 512, NH = 16, NKV = 8;
+    const float scale = 1.0f / std::sqrt((float)HD);
+    const int Sq = 2048, SLICE = 256;
+    for (int Skv : {8192, 16384}) {
+        const int q_offset = Skv - Sq;
+        const size_t q_elems = (size_t)Sq * NH * HD, kv_elems = (size_t)Skv * NKV * HD;
+        std::vector<half> Qh(q_elems), Kh(kv_elems), Vh(kv_elems);
+        lcg_fill(Qh, 0x1111u, 4.0f);
+        lcg_fill(Kh, 0x2222u, 4.0f);
+        lcg_fill(Vh, 0x3333u, 1.0f);
+        void *d_q, *d_k, *d_v, *d_o, *d_s;
+        const size_t s_elems = (size_t)4 * NH * SLICE * Skv;  // per-slice score buffer (FP32-S)
+        ASSERT_EQ(cudaMalloc(&d_q, q_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_k, kv_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_v, kv_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_o, q_elems * 2), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&d_s, s_elems * 2), cudaSuccess);
+        cudaMemcpy(d_q, Qh.data(), q_elems * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_k, Kh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_v, Vh.data(), kv_elems * 2, cudaMemcpyHostToDevice);
+
+        int64_t kv2[2] = {Skv, (int64_t)NKV * HD};
+        int64_t s3[3] = {NH, SLICE, 4 * (int64_t)Skv};
+        int64_t q4[4] = {1, Sq, NH, HD}, kv4[4] = {1, Skv, NKV, HD};
+        Tensor K2(d_k, QType::F16, 2, kv2, true), V2(d_v, QType::F16, 2, kv2, true);
+        Tensor S3(d_s, QType::F16, 3, s3, true);
+        Tensor Q4(d_q, QType::F16, 4, q4, true), K4(d_k, QType::F16, 4, kv4, true);
+        Tensor V4(d_v, QType::F16, 4, kv4, true), O4(d_o, QType::F16, 4, q4, true);
+
+        auto run_fmha = [&]() {
+            bool ran =
+                fmha_sm120_prefill(Q4, K4, V4, O4, scale, true, 0, 0.0f, stream_, q_offset, nullptr);
+            ASSERT_TRUE(ran);
+        };
+        auto run_cublas_sliced = [&](int slice) {
+            for (int off = 0; off < Sq; off += slice) {
+                int64_t q2s[2] = {slice, (int64_t)NH * HD};
+                Tensor Q2s(static_cast<half*>(d_q) + (size_t)off * NH * HD, QType::F16, 2, q2s, true);
+                Tensor O2s(static_cast<half*>(d_o) + (size_t)off * NH * HD, QType::F16, 2, q2s, true);
+                attention_cublas_prefill(Q2s, K2, V2, O2s, S3, NH, NKV, HD, scale, /*causal=*/true,
+                                         /*softcap=*/0.0f, q_offset + off, stream_);
+            }
+        };
+
+        // Warm the clocks: >1.2s of sustained work before timing (idle downclock).
+        {
+            auto t0 = std::chrono::steady_clock::now();
+            do {
+                run_fmha();
+                run_cublas_sliced(SLICE);
+                cudaStreamSynchronize(stream_);
+            } while (std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count() < 1.2);
+        }
+
+        auto time_ms = [&](int slice /* 0 = fmha */, int reps) {
+            cudaEvent_t a, b;
+            cudaEventCreate(&a);
+            cudaEventCreate(&b);
+            cudaEventRecord(a, stream_);
+            for (int i = 0; i < reps; i++) {
+                if (slice == 0)
+                    run_fmha();
+                else
+                    run_cublas_sliced(slice);
+            }
+            cudaEventRecord(b, stream_);
+            cudaEventSynchronize(b);
+            float ms = 0;
+            cudaEventElapsedTime(&ms, a, b);
+            cudaEventDestroy(a);
+            cudaEventDestroy(b);
+            return ms / reps;
+        };
+        double best_f = 1e9;
+        for (int t = 0; t < 3; t++)
+            best_f = std::min(best_f, (double)time_ms(0, 5));
+        printf("[hd512 longctx Sq=%d Skv=%-5d] fmha %.3f ms\n", Sq, Skv, best_f);
+        // Slice sweep: the production workspace cap (attn_scores_mib) limits the
+        // feasible slice at a given ctx — smaller slices trade GEMM efficiency
+        // for workspace. 256 needs the full 384 MiB at 16k ctx; 64 fits at 64k.
+        for (int slice : {16, 32, 64, 128, 256}) {
+            double best_c = 1e9;
+            for (int t = 0; t < 3; t++)
+                best_c = std::min(best_c, (double)time_ms(slice, 5));
+            printf("[hd512 longctx Sq=%d Skv=%-5d] cublas_sliced(%3d) %.3f ms | fmha/cublas %.2fx\n", Sq,
+                   Skv, slice, best_c, best_c / best_f);
+        }
+        cudaFree(d_q);
+        cudaFree(d_k);
+        cudaFree(d_v);
+        cudaFree(d_o);
+        cudaFree(d_s);
+    }
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_e2e_models.cpp
+++ b/tests/test_e2e_models.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "imp/imp.h"
 #include "test_models.h"
+#include "compute/attention_cublas.h"  // executed-kernel coverage counter
 
 #include <cstdlib>
 #include <cstring>
@@ -349,6 +350,35 @@ TEST_F(Gemma4ModelTest, RawCompletionProducesOutput) {
     ASSERT_EQ(imp_generate(ctx_, "The capital of France is", &params, output, sizeof(output), &len),
               IMP_SUCCESS);
     EXPECT_GT(len, 0u);
+}
+
+TEST_F(Gemma4ModelTest, PrefillFusesSwaLayers_Hd512StaysCublas) {
+    // Executed-kernel gate (FA2-coverage dispatch): Gemma-4 has a 5:1 SWA:global
+    // layer pattern — ~24 hd=256 SWA layers + ~6 hd=512 global layers (30 total).
+    // After this dispatch the hd=256 SWA layers route to FA2 f16-QK per-layer
+    // (the win — previously the coarse model-level force_cublas gate sent EVERY
+    // layer to cuBLAS). The hd=512 global layers deliberately STAY on the
+    // materialized cuBLAS path: the SMEM-capped fused hd=512 kernel is 2.8-4.6x
+    // slower (docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md), so fusing them would regress. So a short prefill must
+    // execute cuBLAS for ONLY the handful of hd=512 layers, not all 30. Checks
+    // the executed kernel (a launch counter), not just the dispatch branch.
+    imp::attention_cublas_prefill_reset_count();
+
+    int32_t tokens[128];
+    int n_tokens = 0;
+    ASSERT_EQ(imp_tokenize(model_, "What is the capital of France?", tokens, &n_tokens, 128), IMP_SUCCESS);
+    ASSERT_GT(n_tokens, 0);
+    ASSERT_EQ(imp_prefill(ctx_, tokens, n_tokens), IMP_SUCCESS);
+
+    uint64_t cublas_calls = imp::attention_cublas_prefill_call_count();
+    // > 0: the hd=512 global layers DO use cuBLAS (the deliberate hybrid).
+    EXPECT_GT(cublas_calls, 0u) << "expected the hd=512 global layers to use cuBLAS";
+    // << 30: the hd=256 SWA layers (the majority) moved OFF cuBLAS to FA2. If the
+    // SWA layers still used cuBLAS (routing regression) this would be ~30.
+    EXPECT_LT(cublas_calls, 15u)
+        << "Gemma-4 prefill used cuBLAS attention " << cublas_calls << " times — expected only the ~6 "
+        << "hd=512 global layers (<15). A value near 30 means the hd=256 SWA layers regressed back "
+        << "onto cuBLAS instead of FA2.";
 }
 
 TEST_F(Gemma4ModelTest, NoRepetitionDegeneration) {


### PR DESCRIPTION
## What

- **Per-layer prefill attention routing for heterogeneous models** (Gemma-4 dual head_dim 256/512): the coarse model-level `force_cublas` gate is replaced by per-layer dispatch — the hd=256 SWA majority (5:1) rides FA2 f16-QK, hd=512 global layers stay on the faster materialized cuBLAS path, and a new fused WMMA FMHA hd=512 instantiation (Bq=16/Bkv=32, ~82 KB SMEM) covers the O(n)-memory terminal fallback. Coverage instrumentation (`attention_cublas_prefill_call_count`) + executed-kernel test prove the routing.
- **hd=512 S-matrix overflow now runs sliced cuBLAS**: new `attention_cublas_prefill_sliced` serves long-context chunks in workspace-sized q-row slices (FP32-S accuracy preserved via the 3x rule; floor 16 rows). Measured **3.4-3.9x faster** than the whole-chunk fused hd=512 kernel at Skv 8k/16k — the fused kernel is KV-bandwidth-bound through its Bq=16 tile (~Sq/16 full K/V re-reads; the measured 34.5 ms at 16k matches the DRAM re-read estimate). Applies to uniform hd=512 models (Qwen3.5-27B) too.
- **Global chunk clamp lifted for fused-servable heterogeneous models**: `max_safe_prefill_chunk` used to shrink EVERY layer's chunk to the hd=512 cuBLAS capacity (~190-row chunks at 64k ctx, taxing MoE dequant + launches model-wide); Gemma-4 now keeps full 2048-row chunks at any context.
- **KV-pool exhaustion at decode is now diagnosable**: the reject-newest cancel logs block numbers + remedies (was completely silent and surfaced as a bare "internal error"), admission warns when a prompt leaves <1 KV block of decode headroom, and `imp_decode_step` returns `IMP_ERROR_CANCELLED` for engine-cancelled requests (natural FINISH keeps the INTERNAL end-of-stream contract). Root-caused on Gemma-4-12B-NVFP4 at ctx 16384 on a VRAM-clamped 16384-token FP16-KV pool.
- CHANGELOG: entries for the above + a note for the CUTLASS v4.6.0 → v4.6.1 bump that landed in PR #1010 without a changelog line.
- Audit trail (scout/builder/validator/profiler logs + measurements): `docs/audit/gemma4_attn_routing_2026_07_16/`.

## Perf

- Isolated kernel A/B (new `test_attention_fmha_hd512.cu` DISABLED benches, warmed clocks): sliced cuBLAS 3.4-3.9x over the fused hd=512 fallback at the S-overflow regime; slice 16 = parity floor, so the routing is never worse.
- E2E prefill: Gemma-4-12B-NVFP4 pp16384 845.7 → 802.9 ms (**+5.3%**); 26B pp8192 +2% (the clamp barely binds at 8k; the effect grows with context). Decode paths of gated models are untouched.
- **No baseline refresh**: `tests/perf_baseline.json` gates hd=128 models whose paths are unchanged; this PR only improves ungated Gemma-4 prefill.

## Validation (local GPU — CI has no GPU runner)

- hd=512 parity vs fp64: `FmhaHd512Test` 7/7 incl. new `SlicedCublasParity` (forced 32-row slices, max 1.84e-2 = whole-call error class).
- Full `test-attention` suite green (1 pre-existing FP8 skip); file-size gate 0 violations.
- Gemma-4-26B e2e 4/4 incl. `PrefillFusesSwaLayers_Hd512StaysCublas` coverage gate; ~6k-token long-prompt greedy completion coherent (sliced path active).
- Decode-fix regression: `ApiGenerateParity` + `PrimaryModelTest` + `Gemma4ModelTest` 11/11; repro now WARNs at submit, ERRORs at cancel, CLI prints "cancelled"; `--kv-fp8` arm decodes clean at 16k.
- `make verify-fast`: all functional gates PASS (gtest filter, prefill within threshold, graphs 1.89x, smoke). The decode perf gate read -5.9% with healthy clocks — attributed to concurrent host streaming load (the documented evening-drift signature, user-confirmed), not code: no decode-path change for the gated model class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)