### PR TITLE
hardening: post-launch CUDA error checks, KV prefix-hash double-free fix, warning cleanup

### DIFF
--- a/docs/audit/DISPATCH_BASELINE_2026_07_17.md
+++ b/docs/audit/DISPATCH_BASELINE_2026_07_17.md
@@ -1,0 +1,110 @@
+# Phase-0 baseline snapshot — dispatch-hardening campaign (2026-07-17)
+
+Anti-cheat reference for the "DISPATCH_HARDENING" brief. Every later claim in the
+campaign is diffed against this table. Captured on `main` @ `f7119ad1` (v0.19.1),
+RTX 5090 / driver 610.62 / CUDA 13.3, WSL2, healthy host (2902 MHz SM / 13801 MHz
+mem sampled DURING the bench). No source edits in this phase.
+
+Note on brief staleness: the brief describes the repo as "C++20, ~161k LOC" and
+lists gaps that were closed between May and July 2026. Measured reality below;
+claim-by-claim verification in the companion matrix at the end.
+
+## Baseline table
+
+| Dimension | Metric | Baseline (2026-07-17) |
+|---|---|---|
+| Build | compiler warnings, full rebuild, `-Wall -Wextra -Wpedantic` (CXX) | **2** (1 in src: `-Wnarrowing` `src/runtime/engine_kv_cache_init.cpp:43`; 1 in tests: `-Wunused-result` `tests/test_tool_stream_filter.cpp:238`) + 5 informational ptxas C7504 (`setmaxnreg` ignored) |
+| Build | clang-tidy | advisory CI job (differential); GitHub API 503 during snapshot — not re-run locally to keep the bench host quiet. Local target: `make tidy` |
+| Build | file-size gate `tools/check_filesize.py` | **0 violations** (31 warn, 27 allowlisted; 582 files scanned) |
+| Build | LOC (src/ + include/, .cpp/.cu/.h/.cuh/.hpp) | **119,813** (brief's "161k" includes tests/tools) |
+| Safety | compute-sanitizer (memcheck/racecheck/synccheck) | **N/A on this host** — WSL2/WDDM exposes no debugger interface (documented, `make sanitize` is native-Linux-only) |
+| Safety | ASan+UBSan host code (`IMP_SANITIZERS=ON`, RelWithDebInfo, test-core + test-text) | **0 imp-code findings.** test-core 274/274 pass, test-text 192/192 pass (1 skipped). 1 UBSan hit: misaligned int store in vendored `third_party/stb/stb_image_resize2.h:8659` (third-party, known stb pattern). LeakSanitizer: 50,960 B / 5 allocations, all traces without imp frames (CUDA-driver/dlopen one-time allocs) |
+| Tests | CPU unit suite (`make test-unit`) | **37/37 pass** |
+| Tests | GPU suite (`make test-gpu`, all split binaries) | **exit 0, 0 failures** (1,617 test cases ran; 143 SKIPPED = model-gated without `IMP_TEST_MODEL`; 2 DISABLED = known determinism boundaries, intentionally kept) |
+| Perf | Qwen3-Coder-30B-A3B-Instruct-FP4, spec-OFF, median of 5 isolated trials | see table below |
+| Roofline | pinned BASELINE run | `cf1b382a_20260711_193211` (ncu clock-locked, 2 restarts/cell) — see `roofline_2026_07_11.md` |
+
+## Perf baseline (median of N=5, isolated processes, same harness)
+
+Model: `Qwen3-Coder-30B-A3B-Instruct-FP4` (NVFP4 MoE, the brief's designated model).
+Command (one line, per cell):
+
+```
+docker run --rm --gpus all -e CUBLAS_WORKSPACE_CONFIG=:4096:8 -v $HOME/models:/models imp:test \
+  imp-cli --model /models/Qwen3-Coder-30B-A3B-Instruct-FP4 --bench --bench-pp <PP> --bench-reps 10 \
+  --set speculative.ngram=false
+```
+
+| Cell | Median tok/s | Trial spread | Notes |
+|---|---|---|---|
+| pp512 | **19,739** | 17,177 – 22,695 (±14%) | spread = documented cuBLAS-autotune restart variance |
+| pp2048 | **46,843** | 45,401 – 47,169 | |
+| pp4096 | **41,030** | 40,932 – 41,138 | |
+| tg256 @pp512 | **402.6** | 402.2 – 403.8 (<0.5%) | decode = the reliable A/B signal |
+| tg256 @pp2048 | **367.7** | 367.4 – 367.8 | |
+| tg256 @pp4096 | **346.4** | 346.3 – 346.8 | |
+
+Clocks sampled during the run: 2902 MHz SM / 13801 MHz mem / ~394 W — healthy-host
+day, numbers trustworthy. CI decode gate (different model/metric, for reference):
+Qwen3-8B Q8_0 spec-OFF tg128 = 288.02 (band 275–290), `tests/perf_baseline.json`.
+
+## Roofline utilization per hot kernel (BASELINE `cf1b382a`, nvfp4-moe cells)
+
+| Kernel class | Cell | Time share | %-roofline (med) | bound-by |
+|---|---|---|---|---|
+| gemm_grouped_nvfp4 | pp512 | 49.7% | 51.4 | memory |
+| gemm_cutlass_nvfp4 | pp2048 | 9.9% | 47.2 | compute |
+| attn_fa2 | pp4096 | 37.3% | 22.0 | compute |
+| gemv_nvfp4 | tg256 | 60.6% | 37.6 | memory |
+| attn_decode_paged | tg256 | 11.8% | 2.3 | memory |
+| moe_routing | tg256 | 13.5% | 2.2 | memory (launch-latency class — no-graphs artifact, see benchmark-cuda STOP #7) |
+
+Legacy-attention coverage (Module 2 of the roofline report): **0.0% of window in
+all 21 cells** — the materialized `causal_softmax`+cuBLAS path holds no measurable
+prefill time on any standard cell.
+
+## Claim-verification matrix (brief vs. repo @ v0.19.1)
+
+Four independent read-only scouts verified each brief claim against code/docs.
+
+| Brief claim | Verdict | Evidence |
+|---|---|---|
+| "C++20, ~161k LOC" | STALE | C++23 since PR #916 (`CMakeLists.txt:4-7`); 119,813 LOC src+include |
+| G: README carries stale "1258 tok/s / 20× behind" | ALREADY FIXED | zero live-doc hits; survives only in archive/audit docs marked *refuted* (`docs/GOAL.md:99`, `docs/audit/housekeeping_2026_06_13.md`) |
+| G: stale multi-arch language in CLAUDE.md/AGENTS.md | NOT FOUND | all sm_90/sm_100/Hopper/WGMMA mentions are explicit *exclusion* statements (`AGENTS.md:11`, `CLAUDE.md:84`, `README.md:27,29,83,147`, `docs/sm120.md:23`) |
+| G: README should say "~200 tok/s decode, pp ≈ 16.5k/17.2k/18.2k" | STALE — WOULD REGRESS DOCS | current README numbers (07-12 sweep) are higher and SHA-anchored: decode 271–390 tok/s NVFP4 heroes; measured today: pp2048 = 46.8k tok/s. Applying the brief's numbers would be a factual downgrade → refused per invariant §0 |
+| B: "primary lever = FA2 coverage on MoE prefill; legacy path ~18% overhead" | STALE — NO HOT TARGET | legacy path = 0.0% of prefill window on all cells (roofline Module 2); hd=128 (incl. Coder-30B) is 100% FA2 since #478/#525/#932. Remaining cuBLAS tail is deliberate: Gemma-4 hd=512 globals (cuBLAS 2.8–4.6× FASTER than fused, PR #1042), gpt-oss sinks < threshold (accuracy reference), q_offset>0 short chunks (<1% upside), vision (non-causal), debug/parity paths. "Retire legacy" would regress Gemma-4 |
+| B: "investigate cuBLAS autotune pinning" | OPEN (known) | variance documented (2.6× across restarts, README:87, BENCHMARKS.md:14); decode-first methodology is the shipped mitigation; pinning attempt = deterministic_gemm exists (`gemm.cu:374`, pins cuBLASLt algo, deterministic mode only) |
+| A: MoE-atomics determinism flag | ALREADY IMPLEMENTED | `runtime.deterministic` → ordered single-thread scatter (`moe_routing.cu:444,605,720`), implies `deterministic_gemm`; asserting tests: `test_determinism_e2e.cpp` (greedy + bit-identical PPL), `test_moe_executor.cu:163,220` (token-equality + bounded logit drift). Known boundary: cross-fresh-context on GDN-hybrids = 2 DISABLED tests (intentional) |
+| D: `/v1/messages` streaming synthetic | ALREADY IMPLEMENTED | true per-token SSE since #754 (`handlers_messages.cpp:353-427`, `anthropic.cpp:58-263`); TTFT measured at first token (`stream_driver.cpp:233-235`) |
+| D: per-request speculative toggle absent | ALREADY IMPLEMENTED | `"speculative"` bool on both APIs (`handlers_chat_params.cpp:208-211`, `anthropic.cpp:327-330`); note: MTP-head spec remains load-time-only |
+| D: cache_control not implemented | PARTIAL | parsed + honored as all-or-nothing prompt-prefix pin (`anthropic.cpp:291-310,410-413`, reports `cache_read_input_tokens`); per-breakpoint granularity + ephemeral TTL tiers not modeled |
+| D: no p50/p99 metrics endpoint | ALREADY IMPLEMENTED | Prometheus histograms on `/metrics`: `imp_request_duration_seconds`, `imp_ttft_seconds`, `imp_inter_token_seconds` (`handlers_misc.cpp:185-224`); p50/p99 via `histogram_quantile()` |
+| C: RAII coverage gaps | **CONFIRMED — REAL FINDING** | wrappers exist (`CudaStream`/`CudaEvent`/`Buffer`/`PoolAllocator`/`VRAMAllocator`) but **no owner for `cudaGraph_t`/`cudaGraphExec_t`/`cudaMemPool_t`**; ~801 raw `cudaMalloc*/cudaFree*` sites outside owners (top: `executor_workspace_buffers.cu` 68, `engine_graph_decode.cpp` 38, `weight_upload.cu` 29) |
+| A: missing post-launch error checks | **CONFIRMED — REAL FINDING** | 415 kernel-launch sites in src/, only ~5 have `cudaGetLastError` within 3 lines (~1%); 50+ launch-containing files have zero checks. `IMP_CUDA_CHECK_LOG` (601 uses) covers API returns, not launches |
+| C: KV leak-under-churn regression test | **CONFIRMED — REAL GAP** | LRU eviction + prefix churn well covered (54 cases in `test_kv_cache.cpp`, 9 eviction + 10 prefix-integrity tests), but no sustained N-iteration churn test asserting free-block count returns to baseline |
+| E: golden/numerical/determinism test matrix | PARTIAL (pre-existing) | ~574 GTest incl. per-quant + golden coverage; per-arch golden matrix not 1:1 with the brief's list; determinism tests exist (above) |
+
+## Bottom line for the campaign
+
+Work items with real substance, in brief-priority order (A → C):
+
+1. **A: post-launch `cudaGetLastError` coverage** (~410 unchecked launch sites) —
+   mechanical, zero-perf-risk (debug-gated or log-once), high diagnostic value.
+2. **C: RAII owners for CUDA graphs** (`cudaGraph_t`/`cudaGraphExec_t`; 26+38 raw
+   sites in `cuda_graph.cu`/`engine_graph_decode.cpp`) and audit of the 801 raw
+   alloc sites for throw-path leaks (most sit behind init-once paths — triage, not
+   blanket rewrite).
+3. **C: KV leak-under-churn stress test** (bounded: N alloc/evict/prefix cycles,
+   assert pool returns to baseline).
+4. **A: fix the single src warning** (`-Wnarrowing`, `engine_kv_cache_init.cpp:43`)
+   + the test `-Wunused-result`.
+5. **D (optional, additive): cache_control per-breakpoint granularity / TTL tiers**
+   — only if API parity is wanted; current pin semantics are functional.
+6. **F (third-party, low): UBSan misaligned-store in vendored stb** — upstream
+   pattern; suppress or bump vendored copy, not a hand-patch candidate.
+
+Everything else in the brief (B attention lever, D streaming/toggle/metrics, G doc
+purges, A determinism caveat) is already shipped, refuted by measurement, or would
+actively regress the repo (README numbers). Per invariant §0 those lines of work
+are STOPPED with this report as evidence.

--- a/docs/audit/PERF_LOG.md
+++ b/docs/audit/PERF_LOG.md
@@ -4,6 +4,46 @@ Append-only. Each entry: date, build, protocol, before/after. Newest first.
 
 ---
 
+## 2026-07-17 · Post-launch error checks (399 sites) + KV prefix-hash double-free fix — decode neutral
+
+Hardening WI-1/WI-2 (branch hardening/launch-checks-and-kv-churn, baseline
+`docs/audit/DISPATCH_BASELINE_2026_07_17.md`):
+`IMP_CUDA_CHECK_LAUNCH()` (cudaPeekAtLastError — logs at the launch site, does
+NOT clear, downstream propagation unchanged) after 399 previously-unchecked
+kernel launches in 82 .cu files, plus the KVCacheManager stale-prefix-hash
+double-free fix (below). Perf gate, same harness as the Phase-0 baseline
+(median of 5 isolated trials, spec-OFF, healthy clocks sampled 2902/13801):
+
+```
+docker run --rm --gpus all -e CUBLAS_WORKSPACE_CONFIG=:4096:8 -v $HOME/models:/models imp:test \
+  imp-cli --model /models/Qwen3-Coder-30B-A3B-Instruct-FP4 --bench --bench-pp 512 --bench-reps 10 \
+  --set speculative.ngram=false
+```
+
+| Metric | Baseline (same day) | After | Δ |
+|---|---|---|---|
+| tg256 @pp512 (graphs ON) | 402.59 | 402.90 | **+0.08% (noise)** |
+| pp512 | 19,739 | 20,304 | within restart variance |
+
+No-graphs decode (informational, no before-arm — debug path only): 118.8/126.7/122.1
+tok/s over 3 trials; theoretical check overhead <0.1 ms on an 8.4 ms wall step.
+
+**KV double-free root cause** (found by the new `LeakUnderSustainedChurn` test —
+free-count exceeded pool size, 34>32): `rollback()` and
+`rollback_partial_allocation()` freed hash-REGISTERED blocks to ref 0 without
+erasing `block_hash_to_id_`/`block_id_to_hash_`; a later same-prefix
+`allocate_blocks_with_prefix` hit the stale entry, took the "actively
+referenced — share it" branch and `inc_ref`'d a block sitting in the free
+list → the next free pushed it into the free list a second time. Production
+trigger: KV-pool pressure during prefix-cache allocation (scheduler
+`prefill_allocate_kv_blocks_` → partial-rollback → client retries same
+prefix) = silent cross-request KV corruption. Fix:
+`free_block_dropping_stale_hash()` in both rollback paths (erase hash entries
+when the free drops ref to 0; shared blocks keep their entry) + a loud WARN
+guard in the reuse path that treats a ref==0 non-cached hash hit as a miss.
+Validation: 45/45 KVCacheManager tests (incl. 200-cycle churn), PrefixCacheE2E
+4/4 with Qwen3-4B Q8_0, full GPU suite 0 failures.
+
 ## 2026-07-07 · Token-tiled FP8 split-K decode attention (hd=128) — long-ctx decode +51%
 
 `paged_attention_splitk_fp8_pipeline_kernel` was the top GPU-time consumer at

--- a/src/compute/activation.cu
+++ b/src/compute/activation.cu
@@ -1,6 +1,7 @@
 #include "compute/activation.h"
 #include "runtime/pdl.h"
 #include "core/tensor.h"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdint>
@@ -274,11 +275,13 @@ static void dispatch_gated_activation(const Tensor& gate, const Tensor& up, Tens
                 fp32_vec4<<<grid, block, 0, stream>>>(static_cast<const float*>(gate.data),
                                                       static_cast<const float*>(up.data),
                                                       static_cast<float*>(out.data), n);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 const int grid = static_cast<int>((n + block - 1) / block);
                 fp32_scalar<<<grid, block, 0, stream>>>(static_cast<const float*>(gate.data),
                                                         static_cast<const float*>(up.data),
                                                         static_cast<float*>(out.data), n);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             break;
         case QType::F16: {
@@ -292,6 +295,7 @@ static void dispatch_gated_activation(const Tensor& gate, const Tensor& up, Tens
                 fp16_kernel<<<grid, block, 0, stream>>>(static_cast<const __half*>(gate.data),
                                                         static_cast<const __half*>(up.data),
                                                         static_cast<__half*>(out.data), n);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             break;
         }
@@ -348,10 +352,12 @@ void gelu(const Tensor& x, Tensor& out, cudaStream_t stream) {
                 const int grid = static_cast<int>((n / 4 + block - 1) / block);
                 gelu_fp32_vec4_kernel<<<grid, block, 0, stream>>>(static_cast<const float*>(x.data),
                                                                   static_cast<float*>(out.data), n);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 const int grid = static_cast<int>((n + block - 1) / block);
                 gelu_fp32_kernel<<<grid, block, 0, stream>>>(static_cast<const float*>(x.data),
                                                              static_cast<float*>(out.data), n);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             break;
         case QType::F16: {
@@ -359,6 +365,7 @@ void gelu(const Tensor& x, Tensor& out, cudaStream_t stream) {
             const int grid = static_cast<int>((half_n + block - 1) / block);
             gelu_fp16_kernel<<<grid, block, 0, stream>>>(static_cast<const __half*>(x.data),
                                                          static_cast<__half*>(out.data), n);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
         default:
@@ -433,6 +440,7 @@ void shared_expert_gate_scale(const void* x_fp16, const void* W_fp16, void* y_fp
     shared_expert_gate_scale_kernel<<<n, block, 0, stream>>>(static_cast<const __half*>(x_fp16),
                                                              static_cast<const __half*>(W_fp16),
                                                              static_cast<__half*>(y_fp16_inout), d_model, d);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // --------------------------------------------------------------------------

--- a/src/compute/attention_blackwell.cu
+++ b/src/compute/attention_blackwell.cu
@@ -413,6 +413,7 @@ bool flash_attention_blackwell(const Tensor& Q, const Tensor& K, const Tensor& V
                                             reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv,   \
                                             n_heads, n_kv_heads, scale, causal, sliding_window, softcap,  \
                                             q_offset);                                                    \
+        IMP_CUDA_CHECK_LAUNCH();                                                                          \
     } while (0)
 
     // Select Br and compute grid

--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -385,6 +385,7 @@ static inline void launch_build_attn_ptrs(void** d_ptrs, int n_heads, const void
         d_ptrs + 2 * n_heads, reinterpret_cast<const char*>(base_A), stride_A_bytes,
         reinterpret_cast<const char*>(base_B), stride_B_bytes, reinterpret_cast<char*>(base_C),
         stride_C_bytes, gqa_ratio, n_heads);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -487,10 +488,13 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
             int64_t total = static_cast<int64_t>(n_heads) * q_len * kv_len;
             int block = 256;
             int grid_sc = static_cast<int>((total + block - 1) / block);
-            if (use_fp32_s)
+            if (use_fp32_s) {
                 softcap_fp32_kernel<<<grid_sc, block, 0, stream>>>(S_f32, total, softcap);
-            else
+                IMP_CUDA_CHECK_LAUNCH();
+            } else {
                 softcap_fp16_kernel<<<grid_sc, block, 0, stream>>>(S_base, total, softcap);
+                IMP_CUDA_CHECK_LAUNCH();
+            }
         }
 
         // Softmax (FP32 or FP16)
@@ -505,9 +509,11 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                 // + fp32_to_fp16_kernel pair (saves one full pass over the tensor).
                 causal_softmax_fp32_to_fp16_kernel<<<grid, threads, 0, stream>>>(
                     S_f32, S_prob, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 causal_softmax_inplace_kernel<<<grid, threads, 0, stream>>>(
                     S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
+                IMP_CUDA_CHECK_LAUNCH();
             }
         }
 
@@ -546,10 +552,13 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
             int64_t total = static_cast<int64_t>(n_heads) * q_len * kv_len;
             int block = 256;
             int grid_sc = static_cast<int>((total + block - 1) / block);
-            if (use_fp32_s)
+            if (use_fp32_s) {
                 softcap_fp32_kernel<<<grid_sc, block, 0, stream>>>(S_f32, total, softcap);
-            else
+                IMP_CUDA_CHECK_LAUNCH();
+            } else {
                 softcap_fp16_kernel<<<grid_sc, block, 0, stream>>>(S_base, total, softcap);
+                IMP_CUDA_CHECK_LAUNCH();
+            }
         }
 
         // Softmax
@@ -562,9 +571,11 @@ void attention_cublas_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                 // Fused FP32 softmax + downcast (see MHA path above).
                 causal_softmax_fp32_to_fp16_kernel<<<grid, threads, 0, stream>>>(
                     S_f32, S_prob, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 causal_softmax_inplace_kernel<<<grid, threads, 0, stream>>>(
                     S_base, q_len, kv_len, q_offset, causal, sliding_window, sinks_h);
+                IMP_CUDA_CHECK_LAUNCH();
             }
         }
 

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -1660,6 +1660,7 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
         if (s_d_kmean != nullptr) {
             mxfp4_k_channel_mean_kernel<<<batch_size * n_kv_heads, 128, 0, stream>>>(
                 reinterpret_cast<const half*>(K.data), s_d_kmean, seq_kv, n_kv_heads, head_dim);
+            IMP_CUDA_CHECK_LAUNCH();
             d_kmean = s_d_kmean;
         }
     }
@@ -1705,15 +1706,18 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
             dim3 qmg(num_q_tiles, batch_size * n_heads);
             mxfp4_tile_mean_kernel<<<qmg, 128, 0, stream>>>(reinterpret_cast<const half*>(Q.data), d_qmean,
                                                             seq_q, n_heads, head_dim, Bq);
+            IMP_CUDA_CHECK_LAUNCH();
             dim3 kmg(n_kv_tiles, batch_size * n_kv_heads);
             mxfp4_tile_mean_kernel<<<kmg, 128, 0, stream>>>(reinterpret_cast<const half*>(K.data),
                                                             d_kmean_tiles, seq_kv, n_kv_heads, head_dim,
                                                             MX_Bkv);
+            IMP_CUDA_CHECK_LAUNCH();
             dim3 sg(num_q_tiles, batch_size * n_heads);
             const size_t sel_smem = (size_t)(head_dim + n_kv_tiles) * sizeof(float);
             mxfp4_promote_select_kernel<<<sg, 128, sel_smem, stream>>>(
                 d_qmean, d_kmean_tiles, s_d_promote, n_heads, n_kv_heads, num_q_tiles, n_kv_tiles, Bq, seq_q,
                 q_offset, causal, promote_budget, head_dim);
+            IMP_CUDA_CHECK_LAUNCH();
             d_promote = s_d_promote;
         }
     }
@@ -1758,6 +1762,7 @@ bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V,
                                             reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv,    \
                                             n_heads, n_kv_heads, scale, causal, sliding_window, softcap,   \
                                             q_offset, d_kmean, d_promote, n_kv_tiles);                     \
+        IMP_CUDA_CHECK_LAUNCH();                                                                           \
     } while (0)
 
 // Promote variants only instantiated for head_dim 64/128 (see the pre-pass
@@ -1938,15 +1943,18 @@ bool fmha_sm120_mxfp4_prefill_paged(const Tensor& Q, Tensor& O, const half* k_fr
             dim3 qmg(num_q_tiles, n_heads);
             mxfp4_tile_mean_kernel<<<qmg, 128, 0, stream>>>(reinterpret_cast<const half*>(Q.data), d_qmean,
                                                             seq_q, n_heads, head_dim, Bq);
+            IMP_CUDA_CHECK_LAUNCH();
             dim3 kmg(n_kv_tiles, n_kv_heads);
             mxfp4_tile_mean_paged_kernel<<<kmg, 128, 0, stream>>>(k_data, k_scales, block_table,
                                                                   block_size, seq_kv, n_kv_heads,
                                                                   head_dim, MX_Bkv, d_kmean_tiles);
+            IMP_CUDA_CHECK_LAUNCH();
             dim3 sg(num_q_tiles, n_heads);
             const size_t sel_smem = (size_t)(head_dim + n_kv_tiles) * sizeof(float);
             mxfp4_promote_select_kernel<<<sg, 128, sel_smem, stream>>>(
                 d_qmean, d_kmean_tiles, s_d_promote_paged, n_heads, n_kv_heads, num_q_tiles, n_kv_tiles, Bq,
                 seq_q, q_offset, causal, promote_budget, head_dim);
+            IMP_CUDA_CHECK_LAUNCH();
             d_promote = s_d_promote_paged;
         }
     }
@@ -1986,6 +1994,7 @@ bool fmha_sm120_mxfp4_prefill_paged(const Tensor& Q, Tensor& O, const half* k_fr
             reinterpret_cast<const half*>(Q.data), k_fresh, v_fresh, reinterpret_cast<half*>(O.data),    \
             batch_size, seq_q, seq_kv, n_heads, n_kv_heads, scale, causal, sliding_window, softcap,      \
             q_offset, /*d_kmean=*/nullptr, d_promote, n_kv_tiles, pkv);                                  \
+        IMP_CUDA_CHECK_LAUNCH();                                                                         \
     } while (0)
 
     // Promote is always instantiated: current-chunk tiles ride the promoted

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -527,6 +527,7 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
             reinterpret_cast<const half*>(Q.data), reinterpret_cast<const half*>(K.data),                \
             reinterpret_cast<const half*>(V.data), reinterpret_cast<half*>(O.data), batch_size, seq_q,   \
             seq_kv, n_heads, n_kv_heads, scale, causal, sliding_window, softcap, q_offset, sinks);       \
+        IMP_CUDA_CHECK_LAUNCH();                                                                         \
     } while (0)
 
     if (Bq == 128) {
@@ -1081,6 +1082,7 @@ bool fmha_sm120_fp8_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
             reinterpret_cast<const half*>(Q.data), reinterpret_cast<const half*>(K.data),                   \
             reinterpret_cast<const half*>(V.data), reinterpret_cast<half*>(O.data), batch_size, seq_q,      \
             seq_kv, n_heads, n_kv_heads, scale, causal, sliding_window, softcap, q_offset);                 \
+        IMP_CUDA_CHECK_LAUNCH();                                                                            \
     } while (0)
 
     if (Bq == 128) {
@@ -2013,8 +2015,10 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
             const int64_t kn = (int64_t)batch_size * seq_kv * n_kv_heads * head_dim;
             fa2_amax_fp16_kernel<<<128, 256, 0, stream>>>(reinterpret_cast<const half*>(Q.data), qn,
                                                           s_d_amax);
+            IMP_CUDA_CHECK_LAUNCH();
             fa2_amax_fp16_kernel<<<128, 256, 0, stream>>>(reinterpret_cast<const half*>(K.data), kn,
                                                           s_d_amax + 1);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
     kern<<<grid, block, smem, stream>>>(reinterpret_cast<const half*>(Q.data),
@@ -2023,6 +2027,7 @@ bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, T
                                         reinterpret_cast<half*>(O.data), batch_size, seq_q, seq_kv, n_heads,
                                         n_kv_heads, scale, causal, sliding_window, softcap, q_offset,
                                         fp8_scaled ? s_d_amax : nullptr, d_kv_len);
+    IMP_CUDA_CHECK_LAUNCH();
     return true;
 }
 

--- a/src/compute/attention_mxfp4_prefill.cu
+++ b/src/compute/attention_mxfp4_prefill.cu
@@ -452,6 +452,7 @@ bool attention_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, 
             quantize_fp16_mxfp4_strided_kernel<<<k_blocks, 256, 0, stream>>>(
                 K_head, kv_row_stride, static_cast<uint8_t*>(s_ws.k_packed), static_cast<uint8_t*>(s_ws.k_sf),
                 seq_kv, hd, n_k_tiles);
+            IMP_CUDA_CHECK_LAUNCH();
 
             // ---- Process each Q head in this GQA group ----
             for (int h_local = 0; h_local < gqa_ratio; h_local++) {
@@ -463,6 +464,7 @@ bool attention_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, 
                 quantize_fp16_mxfp4_strided_kernel<<<q_blocks, 256, 0, stream>>>(
                     Q_head, q_row_stride, static_cast<uint8_t*>(s_ws.q_packed),
                     static_cast<uint8_t*>(s_ws.q_sf), seq_q, hd, n_k_tiles);
+                IMP_CUDA_CHECK_LAUNCH();
 
                 // MXFP4 GEMM: S[seq_q, seq_kv] = Q_mxfp4 @ K_mxfp4^T
                 bool ok = gemm_mxfp4_cutlass_sm120(s_ws.q_packed, s_ws.q_sf, k_weight, S, seq_q, seq_kv, hd,
@@ -475,6 +477,7 @@ bool attention_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, 
                 // Scale + softcap + causal mask + softmax
                 mxfp4_attn_softmax_kernel<<<seq_q, sm_threads, 0, stream>>>(S, seq_q, seq_kv, /*q_offset=*/0,
                                                                             scale, softcap, causal);
+                IMP_CUDA_CHECK_LAUNCH();
 
                 // P·V via cuBLAS: O[seq_q, hd] = S[seq_q, seq_kv] @ V[seq_kv, hd]
                 //

--- a/src/compute/attention_paged.cu
+++ b/src/compute/attention_paged.cu
@@ -1147,6 +1147,7 @@ void paged_attention_launch_reduce(float* partial, half* O, int batch_size, int 
     dim3 block(128);
     paged_attention_reduce_kernel<<<grid, block, 0, stream>>>(partial, O, n_heads, head_dim, num_splits,
                                                               /*attn_sinks=*/nullptr);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -1529,6 +1530,7 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
             dim3 block2(128);
             paged_attention_reduce_kernel<<<grid2, block2, 0, stream>>>(
                 partial, reinterpret_cast<half*>(O.data), n_heads, head_dim, num_splits, sinks_h);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 
@@ -1661,6 +1663,7 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
                 reinterpret_cast<const half*>(V_cache.data), reinterpret_cast<half*>(O.data), block_tables,
                 context_lens, batch_size, n_heads, n_kv_heads, head_dim, block_size, scale, max_context_len,
                 max_num_blocks, n_q_per_kv, warps_per_q, sliding_window, n_sinks, softcap, sinks_h);
+            IMP_CUDA_CHECK_LAUNCH();
         } else if (!used_cluster) {
             // MHA fallback for n_q_per_kv > MAX_Q_PER_KV without cluster
             goto mha_fallback;
@@ -1687,7 +1690,8 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
         reinterpret_cast<const half*>(Q.data), reinterpret_cast<const half*>(K_cache.data),                \
         reinterpret_cast<const half*>(V_cache.data), reinterpret_cast<half*>(O.data), block_tables,        \
         context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len, max_num_blocks, \
-        sliding_window, n_sinks, softcap)
+        sliding_window, n_sinks, softcap);                                                                 \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:
@@ -1713,6 +1717,7 @@ void paged_attention_decode(const Tensor& Q, const Tensor& K_cache, const Tensor
                     reinterpret_cast<const half*>(V_cache.data), reinterpret_cast<half*>(O.data),
                     block_tables, context_lens, batch_size, n_heads, n_kv_heads, head_dim, vhd, block_size,
                     scale, max_context_len, max_num_blocks, sliding_window, n_sinks, softcap);
+                IMP_CUDA_CHECK_LAUNCH();
                 break;
         }
 #undef LAUNCH_MHA

--- a/src/compute/attention_paged_fp8.cu
+++ b/src/compute/attention_paged_fp8.cu
@@ -640,7 +640,8 @@ void paged_attention_decode_fp8(const Tensor& Q, const Tensor& K_cache, const Te
                                                  reinterpret_cast<const uint8_t*>(V_cache.data), partial, \
                                                  block_tables, context_lens, batch_size, n_heads,         \
                                                  n_kv_heads, block_size, scale, kv_scale, max_num_blocks, \
-                                                 num_splits, sliding_window, softcap)
+                                                 num_splits, sliding_window, softcap);                    \
+    IMP_CUDA_CHECK_LAUNCH()
 
             switch (head_dim) {
                 case 64:
@@ -671,7 +672,8 @@ void paged_attention_decode_fp8(const Tensor& Q, const Tensor& K_cache, const Te
                                                 reinterpret_cast<const uint8_t*>(V_cache.data), partial,     \
                                                 block_tables, context_lens, batch_size, n_heads, n_kv_heads, \
                                                 block_size, scale, kv_scale, max_num_blocks, num_splits,     \
-                                                sliding_window, softcap)
+                                                sliding_window, softcap);                                    \
+    IMP_CUDA_CHECK_LAUNCH()
 
             switch (head_dim) {
                 case 64:
@@ -711,7 +713,8 @@ void paged_attention_decode_fp8(const Tensor& Q, const Tensor& K_cache, const Te
                                               reinterpret_cast<const uint8_t*>(V_cache.data),               \
                                               reinterpret_cast<half*>(O.data), block_tables, context_lens,  \
                                               batch_size, n_heads, n_kv_heads, block_size, scale, kv_scale, \
-                                              max_context_len, max_num_blocks, sliding_window, softcap)
+                                              max_context_len, max_num_blocks, sliding_window, softcap);  \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:

--- a/src/compute/attention_paged_fp8_tile.cu
+++ b/src/compute/attention_paged_fp8_tile.cu
@@ -520,6 +520,7 @@ void paged_attention_splitk_fp8_tile_launch(const half* Q, const uint8_t* K_cach
     paged_attention_splitk_fp8_tile_kernel<kTileHeadDim><<<grid, block, kBlockSmemBytes, stream>>>(
         Q, K_cache, V_cache, partial_out, block_tables, context_lens, batch_size, n_heads, n_kv_heads,
         block_size, scale, kv_scale, max_num_blocks, num_splits, sliding_window, softcap);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Split count for the GQA variant's geometry: with grid.y = n_kv_heads (G x
@@ -567,6 +568,7 @@ void paged_attention_splitk_fp8_tile_gqa_launch(const half* Q, const uint8_t* K_
     paged_attention_splitk_fp8_tile_gqa_kernel<kTileHeadDim><<<grid, block, 0, stream>>>(
         Q, K_cache, V_cache, partial_out, block_tables, context_lens, batch_size, n_heads, n_kv_heads,
         block_size, scale, kv_scale, max_num_blocks, num_splits, sliding_window, softcap);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/attention_paged_int4.cu
+++ b/src/compute/attention_paged_int4.cu
@@ -556,7 +556,8 @@ void paged_attention_decode_int4(const Tensor& Q, const Tensor& K_cache, const T
                                                  reinterpret_cast<const uint8_t*>(V_cache.data), K_scales,  \
                                                  V_scales, partial, block_tables, context_lens, batch_size, \
                                                  n_heads, n_kv_heads, block_size, scale, max_num_blocks,    \
-                                                 num_splits, sliding_window, softcap)
+                                                 num_splits, sliding_window, softcap);                      \
+    IMP_CUDA_CHECK_LAUNCH()
 
             switch (head_dim) {
                 case 64:
@@ -584,7 +585,8 @@ void paged_attention_decode_int4(const Tensor& Q, const Tensor& K_cache, const T
                                                 reinterpret_cast<const uint8_t*>(V_cache.data), K_scales,  \
                                                 V_scales, partial, block_tables, context_lens, batch_size, \
                                                 n_heads, n_kv_heads, block_size, scale, max_num_blocks,    \
-                                                num_splits, sliding_window, softcap)
+                                                num_splits, sliding_window, softcap);                      \
+    IMP_CUDA_CHECK_LAUNCH()
 
             switch (head_dim) {
                 case 64:
@@ -619,7 +621,8 @@ void paged_attention_decode_int4(const Tensor& Q, const Tensor& K_cache, const T
         reinterpret_cast<const half*>(Q.data), reinterpret_cast<const uint8_t*>(K_cache.data),               \
         reinterpret_cast<const uint8_t*>(V_cache.data), K_scales, V_scales, reinterpret_cast<half*>(O.data), \
         block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len,     \
-        max_num_blocks, sliding_window, softcap)
+        max_num_blocks, sliding_window, softcap);                                                            \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:

--- a/src/compute/attention_paged_int8.cu
+++ b/src/compute/attention_paged_int8.cu
@@ -494,7 +494,8 @@ void paged_attention_decode_int8(const Tensor& Q, const Tensor& K_cache, const T
                                                 reinterpret_cast<const int8_t*>(V_cache.data), K_scales,   \
                                                 V_scales, partial, block_tables, context_lens, batch_size, \
                                                 n_heads, n_kv_heads, block_size, scale, max_num_blocks,    \
-                                                num_splits, sliding_window, softcap)
+                                                num_splits, sliding_window, softcap);                      \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:
@@ -528,7 +529,8 @@ void paged_attention_decode_int8(const Tensor& Q, const Tensor& K_cache, const T
         reinterpret_cast<const half*>(Q.data), reinterpret_cast<const int8_t*>(K_cache.data),               \
         reinterpret_cast<const int8_t*>(V_cache.data), K_scales, V_scales, reinterpret_cast<half*>(O.data), \
         block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len,    \
-        max_num_blocks, sliding_window, softcap)
+        max_num_blocks, sliding_window, softcap);                                                           \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:

--- a/src/compute/attention_paged_nvfp4.cu
+++ b/src/compute/attention_paged_nvfp4.cu
@@ -390,7 +390,8 @@ void paged_attention_decode_nvfp4(const Tensor& Q, const Tensor& K_cache, const 
                                                 reinterpret_cast<const uint8_t*>(V_cache.data), K_scales,  \
                                                 V_scales, partial, block_tables, context_lens, batch_size, \
                                                 n_heads, n_kv_heads, block_size, scale, max_num_blocks,    \
-                                                num_splits, sliding_window, softcap)
+                                                num_splits, sliding_window, softcap);                      \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:
@@ -422,7 +423,8 @@ void paged_attention_decode_nvfp4(const Tensor& Q, const Tensor& K_cache, const 
         reinterpret_cast<const half*>(Q.data), reinterpret_cast<const uint8_t*>(K_cache.data),               \
         reinterpret_cast<const uint8_t*>(V_cache.data), K_scales, V_scales, reinterpret_cast<half*>(O.data), \
         block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len,     \
-        max_num_blocks, sliding_window, softcap)
+        max_num_blocks, sliding_window, softcap);                                                            \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:
@@ -484,7 +486,8 @@ void paged_attention_decode_mxfp4_kv(const Tensor& Q, const Tensor& K_cache, con
                                                 reinterpret_cast<const uint8_t*>(V_cache.data), K_scales,  \
                                                 V_scales, partial, block_tables, context_lens, batch_size, \
                                                 n_heads, n_kv_heads, block_size, scale, max_num_blocks,    \
-                                                num_splits, sliding_window, softcap)
+                                                num_splits, sliding_window, softcap);                      \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:
@@ -516,7 +519,8 @@ void paged_attention_decode_mxfp4_kv(const Tensor& Q, const Tensor& K_cache, con
         reinterpret_cast<const half*>(Q.data), reinterpret_cast<const uint8_t*>(K_cache.data),               \
         reinterpret_cast<const uint8_t*>(V_cache.data), K_scales, V_scales, reinterpret_cast<half*>(O.data), \
         block_tables, context_lens, batch_size, n_heads, n_kv_heads, block_size, scale, max_context_len,     \
-        max_num_blocks, sliding_window, softcap)
+        max_num_blocks, sliding_window, softcap);                                                            \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:

--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -1107,7 +1107,8 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
                                                 reinterpret_cast<const uint8_t*>(V_cache.data), K_scales,  \
                                                 V_scales, partial, block_tables, context_lens, batch_size, \
                                                 n_heads, n_kv_heads, block_size, scale, max_num_blocks,    \
-                                                num_splits, sliding_window, softcap)
+                                                num_splits, sliding_window, softcap);                      \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:
@@ -1153,7 +1154,8 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
         residual_active_multiseq ? d_residual_counts : nullptr,                                               \
         residual_active_multiseq ? d_residual_write_idxes : nullptr,                                          \
         residual_active_multiseq ? d_residual_fc_per_slot : nullptr,                                          \
-        residual_active_multiseq ? d_residual_widx_per_slot : nullptr)
+        residual_active_multiseq ? d_residual_widx_per_slot : nullptr);                                       \
+    IMP_CUDA_CHECK_LAUNCH()
             switch (head_dim) {
                 case 64:  LAUNCH_RESIDUAL_REDUCE(64);  break;
                 case 128: LAUNCH_RESIDUAL_REDUCE(128); break;
@@ -1188,7 +1190,8 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
         residual_active_multiseq ? residual_seq_stride_elems : 0,                                              \
         residual_active_multiseq ? d_residual_seq_slots : nullptr,                                             \
         residual_active_multiseq ? d_residual_counts : nullptr,                                                \
-        residual_active_multiseq ? d_residual_write_idxes : nullptr)
+        residual_active_multiseq ? d_residual_write_idxes : nullptr);                                          \
+    IMP_CUDA_CHECK_LAUNCH()
 
         switch (head_dim) {
             case 64:

--- a/src/compute/embedding.cu
+++ b/src/compute/embedding.cu
@@ -182,10 +182,12 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids, int n_token
                 embedding_lookup_vec_kernel<float>
                     <<<n_tokens, block, 0, stream>>>(static_cast<const float*>(table.data), token_ids,
                                                      static_cast<float*>(out.data), d_model);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 embedding_lookup_scalar_kernel<float>
                     <<<n_tokens, block, 0, stream>>>(static_cast<const float*>(table.data), token_ids,
                                                      static_cast<float*>(out.data), d_model);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             break;
         }
@@ -194,10 +196,12 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids, int n_token
                 embedding_lookup_vec_kernel<__half>
                     <<<n_tokens, block, 0, stream>>>(static_cast<const __half*>(table.data), token_ids,
                                                      static_cast<__half*>(out.data), d_model);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 embedding_lookup_scalar_kernel<__half>
                     <<<n_tokens, block, 0, stream>>>(static_cast<const __half*>(table.data), token_ids,
                                                      static_cast<__half*>(out.data), d_model);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             break;
         }
@@ -205,6 +209,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids, int n_token
             embedding_lookup_vec_kernel<uint16_t>
                 <<<n_tokens, block, 0, stream>>>(static_cast<const uint16_t*>(table.data), token_ids,
                                                  static_cast<uint16_t*>(out.data), d_model);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
         default:
@@ -228,6 +233,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids, int n_token
         embedding_lookup_q8_0_kernel<<<n_tokens, block, 0, stream>>>(static_cast<const uint8_t*>(table.data),
                                                                      token_ids, static_cast<half*>(out.data),
                                                                      d_model);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
 
@@ -235,6 +241,7 @@ void embedding_lookup(const Tensor& table, const int32_t* token_ids, int n_token
         embedding_lookup_q6k_kernel<<<n_tokens, block, 0, stream>>>(static_cast<const uint8_t*>(table.data),
                                                                     token_ids, static_cast<half*>(out.data),
                                                                     d_model);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
 
@@ -309,6 +316,7 @@ void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id
         embedding_lookup_fp16_device_kernel<<<1, block, 0, stream>>>(static_cast<const __half*>(table.data),
                                                                      d_token_id,
                                                                      static_cast<__half*>(out.data), d_model);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (table.qtype == QType::F32) {
         // For FP32 tables, fall back to regular path with a device-to-host copy
         // (FP32 embedding tables are uncommon in quantized models)
@@ -329,6 +337,7 @@ void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id
         embedding_lookup_q8_0_device_kernel<<<1, block, 0, stream>>>(static_cast<const uint8_t*>(table.data),
                                                                      d_token_id, static_cast<half*>(out.data),
                                                                      d_model);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
 
@@ -336,6 +345,7 @@ void embedding_lookup_from_device(const Tensor& table, const int32_t* d_token_id
         embedding_lookup_q6k_device_kernel<<<1, block, 0, stream>>>(static_cast<const uint8_t*>(table.data),
                                                                     d_token_id, static_cast<half*>(out.data),
                                                                     d_model);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
 

--- a/src/compute/encoder_forward.cu
+++ b/src/compute/encoder_forward.cu
@@ -186,6 +186,7 @@ bool encoder_embed(const Model& model, EncoderWorkspace& ws, const int32_t* toke
         const int64_t total = static_cast<int64_t>(n) * d;
         encoder_add_type_kernel<<<static_cast<int>((total + block - 1) / block), block, 0, stream>>>(
             static_cast<__half*>(ws.d_h), static_cast<const __half*>(model.token_types_.data), n, d);
+        IMP_CUDA_CHECK_LAUNCH();
     }
     Tensor none{};
     layernorm_residual(h, none, model.tok_emb_norm_, model.tok_emb_norm_bias_, h, ws.ln_eps, stream);
@@ -225,7 +226,9 @@ bool encoder_embed(const Model& model, EncoderWorkspace& ws, const int32_t* toke
     // Mean pool + L2 normalize + D2H.
     encoder_mean_pool_kernel<<<(d + 255) / 256, 256, 0, stream>>>(
         static_cast<const __half*>(ws.d_h), ws.d_pooled, n, d);
+    IMP_CUDA_CHECK_LAUNCH();
     encoder_l2_normalize_kernel<<<1, 256, 0, stream>>>(ws.d_pooled, d);
+    IMP_CUDA_CHECK_LAUNCH();
     cudaMemcpyAsync(out_host, ws.d_pooled, d * sizeof(float), cudaMemcpyDeviceToHost, stream);
     return cudaStreamSynchronize(stream) == cudaSuccess;
 }

--- a/src/compute/ffn_sparsity_mask.cu
+++ b/src/compute/ffn_sparsity_mask.cu
@@ -1,5 +1,6 @@
 #include "compute/ffn_sparsity_mask.h"
 #include "compute/gemm.h"
+#include "core/logging.h"
 #include "runtime/pdl.h"
 
 #include <cuda_runtime.h>
@@ -127,6 +128,7 @@ void build_swiglu_block_mask(const __half* gate, const __half* up, uint32_t* mas
     const int n_blocks = K >> 5;
     const size_t smem = static_cast<size_t>(n_blocks) * sizeof(unsigned int);
     build_swiglu_block_mask_kernel<THREADS><<<1, THREADS, smem, stream>>>(gate, up, mask, K, threshold);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void gemv_q8_0_q8_1_residual_masked(const void* W, const block_q8_1* q8_1, const float* d8,

--- a/src/compute/ffn_sparsity_probe.cu
+++ b/src/compute/ffn_sparsity_probe.cu
@@ -102,6 +102,7 @@ void probe_ffn_silu_sparsity(int layer, const __half* gate, const __half* up, in
 
     constexpr int kThreads = 256;
     probe_silu_kernel<<<1, kThreads, 0, stream>>>(layer, gate, up, K, g_state.d_counters);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void flush_ffn_sparsity_probe_log() {

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -268,6 +268,7 @@ void vhead_tiled_to_grouped(const half* src, half* dst, int n_tokens, int n_head
     int blocks = (total + threads - 1) / threads;
     vhead_tiled_to_grouped_kernel<<<blocks, threads, 0, stream>>>(src, dst, n_tokens, n_heads, head_dim,
                                                                   n_groups);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // FP32 variant for conv1d-SiLU output (= scan V input). Same math as FP16,
@@ -302,6 +303,7 @@ void vhead_tiled_to_grouped_f32(const float* src, float* dst, int n_tokens, int 
     int blocks = (total + threads - 1) / threads;
     vhead_tiled_to_grouped_f32_kernel<<<blocks, threads, 0, stream>>>(src, dst, n_tokens, n_heads, head_dim,
                                                                       n_groups);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -325,10 +327,12 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
         gdn_scan_fused_kernel<128, 128, half>
             <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
                                              n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, half>
             <<<n_heads, 64, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         // Fallback: per-token loop (for unsupported HD/SS sizes). The host
         // loop cannot bound itself by a device-side length — reject padded
@@ -345,6 +349,7 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
                 row + 2 * BC_size, row + BC_size, row, alpha + t * n_heads, beta + t * n_heads, A_log,
                 dt_bias, h_state, y + t * inner, nullptr, n_heads, head_dim_ssm, state_size, n_groups,
                 grouped_layout);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 }
@@ -360,10 +365,12 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half
         gdn_scan_fused_kernel<128, 128, float>
             <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
                                              n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, float>
             <<<n_heads, 64, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         if (d_real_n != nullptr)
             throw std::runtime_error("gdn_scan_fused_fp32out: padded verify chunk unsupported for HD=" +
@@ -382,6 +389,7 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half
                 row + 2 * BC_size, row + BC_size, row, alpha + t * n_heads, beta + t * n_heads, A_log,
                 dt_bias, h_state, scratch_dev + t * inner, nullptr, n_heads, head_dim_ssm, state_size,
                 n_groups, grouped_layout);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         // Convert FP16 scratch → FP32. Simple elementwise cast kernel not
         // present; do it via cuda memcpy + cast on device via small kernel.
@@ -567,6 +575,7 @@ void gdn_scan_reference_f32(const float* conv_f32, int conv_channels, const half
                                                                        n_groups, head_dim_ssm, state_size,
                                                                        conv_channels, grouped_layout,
                                                                        d_real_n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // FP32-input variant: reads y as FP32, writes FP16. Used together with
@@ -612,6 +621,7 @@ void gdn_rmsnorm_gated_silu_fp32in(half* y_fp16_out, const float* y_fp32_in, con
     dim3 grid(n_tokens, n_heads);
     gdn_rmsnorm_gated_silu_fp32in_kernel<<<grid, head_dim, smem, stream>>>(y_fp16_out, y_fp32_in, gate,
                                                                            weight, eps, n_heads, head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // FP32-in, FP32-out: keeps full precision through gated norm so ssm_out GEMM
@@ -657,6 +667,7 @@ void gdn_rmsnorm_gated_silu_fp32inout(float* y_fp32_out, const float* y_fp32_in,
     dim3 grid(n_tokens, n_heads);
     gdn_rmsnorm_gated_silu_fp32inout_kernel<<<grid, head_dim, smem, stream>>>(y_fp32_out, y_fp32_in, gate,
                                                                               weight, eps, n_heads, head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused RMSNormGated + SiLU
@@ -665,6 +676,7 @@ void gdn_rmsnorm_gated_silu(half* y, const half* gate, const half* weight, float
     size_t smem = head_dim * sizeof(float);
     dim3 grid(n_tokens, n_heads);
     gdn_rmsnorm_gated_silu_kernel<<<grid, head_dim, smem, stream>>>(y, gate, weight, eps, n_heads, head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -745,6 +757,7 @@ void gdn_scan_decode_f32(const float* x, const float* B, const float* C, const h
     gdn_scan_decode_kernel<<<n_heads, head_dim_ssm, smem, stream>>>(x, B, C, alpha, beta, A_log, dt_bias,
                                                                     h_state, y, z, n_heads, head_dim_ssm,
                                                                     state_size, n_groups, grouped_layout);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void gdn_scan_prefill_f32(const float* x, const float* B, const float* C, const half* alpha, const half* beta,
@@ -761,6 +774,7 @@ void gdn_scan_prefill_f32(const float* x, const float* B, const float* C, const 
                                                                         h_state, y + t * inner, nullptr,
                                                                         n_heads, head_dim_ssm, state_size,
                                                                         n_groups, grouped_layout);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 

--- a/src/compute/gdn_scan.cu
+++ b/src/compute/gdn_scan.cu
@@ -1,4 +1,5 @@
 #include "compute/gdn_internal.cuh"
+#include "core/logging.h"
 
 namespace imp {
 
@@ -508,6 +509,7 @@ static void gdn_scan_chunkwise_dispatch(const float* conv_f32, int conv_channels
             gdn_scan_chunkwise_kernel<HD, SS, CHUNK, YOut><<<n_heads, HD, smem, stream>>>(
                 conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
                 grouped_layout);
+            IMP_CUDA_CHECK_LAUNCH();
             return;
         }
         if (head_dim_ssm == 64 && state_size == 64) {
@@ -517,6 +519,7 @@ static void gdn_scan_chunkwise_dispatch(const float* conv_f32, int conv_channels
             gdn_scan_chunkwise_kernel<HD, SS, CHUNK, YOut><<<n_heads, HD, smem, stream>>>(
                 conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
                 grouped_layout);
+            IMP_CUDA_CHECK_LAUNCH();
             return;
         }
     }
@@ -605,6 +608,7 @@ void gdn_scan_chunkwise_wy_f32(const float* conv_f32, int conv_channels, const h
         gdn_scan_chunkwise_wy_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
             grouped_layout);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
     // Unsupported shape — fall back to the sequential kernel for safety.

--- a/src/compute/gdn_scan_tc.cu
+++ b/src/compute/gdn_scan_tc.cu
@@ -1,4 +1,5 @@
 #include "compute/gdn_internal.cuh"
+#include "core/logging.h"
 #include <mma.h>
 
 namespace imp {
@@ -684,6 +685,7 @@ void gdn_scan_chunkwise_wy_tc_f32(const float* conv_f32, int conv_channels, cons
         gdn_scan_chunkwise_wy_tc_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
             grouped_layout);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
     gdn_scan_fused_f32(conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads,
@@ -711,6 +713,7 @@ void gdn_scan_chunkwise_wy_tc2_f32(const float* conv_f32, int conv_channels, con
         gdn_scan_chunkwise_wy_tc2_kernel<HD, SS, CHUNK><<<n_heads, HD, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels,
             grouped_layout);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
     gdn_scan_fused_f32(conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y, n_tokens, n_heads,

--- a/src/compute/gemm_capture_fp16_sm120.cu
+++ b/src/compute/gemm_capture_fp16_sm120.cu
@@ -322,6 +322,7 @@ bool gemm_capture_fp16_sm120(const void* A, const void* B, void* D, int M, int N
         gemm_fp16_kernel<64, 2><<<grid, block, smem_bytes, stream>>>(
             reinterpret_cast<const __half*>(A), reinterpret_cast<const __half*>(B),
             reinterpret_cast<__half*>(D), M, N, K, alpha, beta);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         gemm_fp16_kernel<128, 2><<<grid, block, smem_bytes, stream>>>(
             reinterpret_cast<const __half*>(A), reinterpret_cast<const __half*>(B),

--- a/src/compute/gemm_cutlass_grouped_3x.cu
+++ b/src/compute/gemm_cutlass_grouped_3x.cu
@@ -574,6 +574,7 @@ bool gemm_grouped_cutlass_3x_nvfp4_device_args(
         args.d_B_ptrs, args.d_SFB_ptrs,
         args.base_D,
         N, K, n_experts);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // ----- Build Arguments -----
     typename GrpGemm::Arguments arguments;

--- a/src/compute/gemm_cutlass_mxfp4_sm120.cu
+++ b/src/compute/gemm_cutlass_mxfp4_sm120.cu
@@ -222,6 +222,7 @@ void convert_nvfp4_to_mxfp4_cutlass(const NvFP4QuantResult& src, CutlassMxFP4Wei
         reinterpret_cast<const uint8_t*>(src.micro_scales), reinterpret_cast<uint8_t*>(d_sf),
         reinterpret_cast<uint8_t*>(d_linear_sf), src.tensor_scale, static_cast<int>(N), static_cast<int>(K),
         n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 
     dst.data = src.packed_data;
     dst.scale_factors = d_sf;
@@ -294,6 +295,7 @@ bool unpack_mxfp4_gguf(const void* raw_gpu, int64_t N, int64_t K, CutlassMxFP4We
     build_mxfp4_scales_kernel<<<grid, threads, 0, stream>>>(scale_src, static_cast<uint8_t*>(d_sf),
                                                             static_cast<uint8_t*>(d_linear_sf), total_blocks,
                                                             blocks_per_row, n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 
     dst.data = raw_gpu;  // data at start of buffer (contiguous packed nibbles)
     dst.scale_factors = d_sf;
@@ -368,6 +370,7 @@ void dequant_mxfp4_to_fp16(const void* raw_mxfp4_data, int64_t N, int64_t K, voi
                                                              static_cast<half*>(dst_fp16),
                                                              static_cast<int>(N), static_cast<int>(K),
                                                              blocks_per_row);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Forward declaration (defined below in activation quantization section)
@@ -417,6 +420,7 @@ void convert_nvfp4_to_mxfp4_hadamard(const NvFP4QuantResult& src, CutlassMxFP4We
     quantize_fp16_mxfp4_cutlass_kernel<<<blocks, threads, 0, stream>>>(
         reinterpret_cast<const half*>(scratch_fp16), reinterpret_cast<uint8_t*>(d_packed),
         reinterpret_cast<uint8_t*>(d_sf), static_cast<int>(N), static_cast<int>(K), n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 
     dst.data = d_packed;
     dst.scale_factors = d_sf;
@@ -557,6 +561,7 @@ void quantize_fp16_to_mxfp4_cutlass(const void* src_fp16, void* dst_data, void* 
     quantize_fp16_mxfp4_cutlass_kernel<<<blocks, threads, 0, stream>>>(
         reinterpret_cast<const half*>(src_fp16), reinterpret_cast<uint8_t*>(dst_data),
         reinterpret_cast<uint8_t*>(dst_sf), M, K, n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/compute/gemm_cutlass_sm120.cu
+++ b/src/compute/gemm_cutlass_sm120.cu
@@ -434,6 +434,7 @@ void convert_nvfp4_to_cutlass(const NvFP4QuantResult& src, CutlassNvFP4Weight& d
         convert_scales_sfatom_kernel<<<blocks, threads, 0, stream>>>(
             reinterpret_cast<const uint8_t*>(src.micro_scales), reinterpret_cast<uint8_t*>(d_sf),
             static_cast<int>(N), static_cast<int>(K), n_k_tiles);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     dst.data = src.packed_data;  // borrowed pointer (not owned)
@@ -465,6 +466,7 @@ void convert_nvfp4_to_cutlass_borrowed(const NvFP4QuantResult& src, CutlassNvFP4
     convert_scales_sfatom_kernel<<<blocks, threads, 0, stream>>>(
         reinterpret_cast<const uint8_t*>(src.micro_scales), reinterpret_cast<uint8_t*>(sf_dst),
         static_cast<int>(N), static_cast<int>(K), n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 
     dst.data = src.packed_data;  // borrowed pointer (not owned)
     dst.scale_factors = sf_dst;  // borrowed slab sub-region
@@ -508,6 +510,7 @@ void convert_nvfp4_moe_scales_to_sfatom(const void* src_native_ms, void* dst_sfa
     convert_scales_sfatom_moe_kernel<<<grid, threads, 0, stream>>>(
         reinterpret_cast<const uint8_t*>(src_native_ms), reinterpret_cast<uint8_t*>(dst_sfatom_sf), N, K,
         n_k_tiles, native_stride, sfatom_stride);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void quantize_fp16_to_nvfp4_cutlass(const void* src_fp16, void* dst_data, void* dst_sf, int M, int K,
@@ -529,6 +532,7 @@ void quantize_fp16_to_nvfp4_cutlass(const void* src_fp16, void* dst_data, void* 
     quantize_fp16_nvfp4_cutlass_kernel<<<blocks, threads, 0, stream>>>(
         reinterpret_cast<const half*>(src_fp16), reinterpret_cast<uint8_t*>(dst_data),
         reinterpret_cast<uint8_t*>(dst_sf), M, K, n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void quantize_fp16_to_nvfp4_cutlass_moe(const void* src_fp16, void* dst_packed, uint8_t* const* d_sfa_bases,
@@ -549,6 +553,7 @@ void quantize_fp16_to_nvfp4_cutlass_moe(const void* src_fp16, void* dst_packed, 
         reinterpret_cast<const half*>(src_fp16), /*gather=*/nullptr,
         reinterpret_cast<uint8_t*>(dst_packed), d_sfa_bases,
         d_offsets, expanded, K, ne, n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void quantize_fp16_to_nvfp4_cutlass_moe_gather(const void* src_fp16,
@@ -574,6 +579,7 @@ void quantize_fp16_to_nvfp4_cutlass_moe_gather(const void* src_fp16,
         reinterpret_cast<const half*>(src_fp16), sorted_token_ids,
         reinterpret_cast<uint8_t*>(dst_packed), d_sfa_bases,
         d_offsets, expanded, K, ne, n_k_tiles);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -680,6 +686,7 @@ void fused_act_quantize_fp16_to_nvfp4_cutlass_moe(const void* gate_fp16, const v
             fused_act_quantize_fp16_nvfp4_cutlass_moe_kernel<0>
                 <<<blocks, threads, 0, stream>>>(gate_p, up_p, dst_p, d_sfa_bases, d_offsets, expanded, K,
                                                  ne, n_k_tiles);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         case FFNActivation::GEGLU:
             IMP_CHECK(gate_p != nullptr,
@@ -687,11 +694,13 @@ void fused_act_quantize_fp16_to_nvfp4_cutlass_moe(const void* gate_fp16, const v
             fused_act_quantize_fp16_nvfp4_cutlass_moe_kernel<1>
                 <<<blocks, threads, 0, stream>>>(gate_p, up_p, dst_p, d_sfa_bases, d_offsets, expanded, K,
                                                  ne, n_k_tiles);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         case FFNActivation::RELU_SQR:
             fused_act_quantize_fp16_nvfp4_cutlass_moe_kernel<2>
                 <<<blocks, threads, 0, stream>>>(nullptr, up_p, dst_p, d_sfa_bases, d_offsets, expanded, K,
                                                  ne, n_k_tiles);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
     }
 }

--- a/src/compute/gemm_dp4a.cu
+++ b/src/compute/gemm_dp4a.cu
@@ -2,6 +2,7 @@
 #include "compute/gemv_dp4a_traits.cuh"
 #include "runtime/pdl.h"
 #include "model/model_config.h"  // QType
+#include "core/logging.h"
 
 #include <cuda_fp16.h>
 #include <cstdio>
@@ -145,6 +146,7 @@ void quantize_fp16_to_q8_1(const half* x, block_q8_1* q8_1_out, float* d8_out, i
         return;
     fused_act_quantize_q8_1_kernel<<<n_blocks, 32, 0, stream>>>(x, nullptr, q8_1_out, d8_out, K,
                                                                 IdentityAct{});
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Pad to the next Q6_K block boundary (256 elements = 8 Q8_1 blocks).
     // When K is not a multiple of 256, the dp4a GEMV reads ceil(K/256)*8
@@ -168,6 +170,7 @@ void swiglu_quantize_q8_1(const half* gate, const half* up, block_q8_1* q8_out, 
         return;
     fused_act_quantize_q8_1_kernel<<<n_blocks, 32, 0, stream>>>(gate, up, q8_out, d8_out, total_elements,
                                                                 SwiGLUAct{});
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused GEGLU + Q8_1 quantization.
@@ -181,6 +184,7 @@ void geglu_quantize_q8_1(const half* gate, const half* up, block_q8_1* q8_out, f
         return;
     fused_act_quantize_q8_1_kernel<<<n_blocks, 32, 0, stream>>>(gate, up, q8_out, d8_out, total_elements,
                                                                 GeGLUAct{});
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused relu² + Q8_1 quantization.
@@ -194,6 +198,7 @@ void relu_sqr_quantize_q8_1(const half* input, block_q8_1* q8_out, float* d8_out
         return;
     fused_act_quantize_q8_1_kernel<<<n_blocks, 32, 0, stream>>>(input, nullptr, q8_out, d8_out,
                                                                 total_elements, ReLUSqrAct{});
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -295,6 +300,7 @@ void rmsnorm_quantize_q8_1(const half* x, const half* weight, block_q8_1* q8_out
     const int threads = 1024;
     rmsnorm_quantize_q8_1_kernel<<<1, threads, 0, stream>>>(x, weight, q8_out, d8_out, norm_out, d_model, eps,
                                                             weight_offset);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 // ===========================================================================
 // dp4a GEMV template instantiations (consolidated from 33 hand-written kernels)

--- a/src/compute/gemm_gemv_dtype.cu
+++ b/src/compute/gemm_gemv_dtype.cu
@@ -1,5 +1,6 @@
 #include "compute/gemm.h"
 #include "compute/gemm_internal.cuh"
+#include "core/logging.h"
 
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
@@ -304,6 +305,7 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y, cudaStream_t stream) {
                 const float* x_ptr = static_cast<const float*>(x.data) + (int64_t)b * K;
                 float* y_ptr = static_cast<float*>(y.data) + (int64_t)b * M;
                 gemv_fp32_kernel<<<blocks, kGemvThreads, 0, stream>>>(A_ptr, x_ptr, y_ptr, M, K);
+                IMP_CUDA_CHECK_LAUNCH();
                 break;
             }
             case QType::F16: {
@@ -311,6 +313,7 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y, cudaStream_t stream) {
                 const half* x_ptr = static_cast<const half*>(x.data) + (int64_t)b * K;
                 half* y_ptr = static_cast<half*>(y.data) + (int64_t)b * M;
                 gemv_fp16_kernel<<<blocks, kGemvThreads, 0, stream>>>(A_ptr, x_ptr, y_ptr, M, K);
+                IMP_CUDA_CHECK_LAUNCH();
                 break;
             }
             case QType::BF16: {
@@ -318,6 +321,7 @@ void gemv(const Tensor& A, const Tensor& x, Tensor& y, cudaStream_t stream) {
                 const __nv_bfloat16* x_ptr = static_cast<const __nv_bfloat16*>(x.data) + (int64_t)b * K;
                 __nv_bfloat16* y_ptr = static_cast<__nv_bfloat16*>(y.data) + (int64_t)b * M;
                 gemv_bf16_kernel<<<blocks, kGemvThreads, 0, stream>>>(A_ptr, x_ptr, y_ptr, M, K);
+                IMP_CUDA_CHECK_LAUNCH();
                 break;
             }
             default: {
@@ -497,6 +501,7 @@ __global__ void gemv_q6k_kernel(const uint8_t* __restrict__ W, const half* __res
 
 void gemv_q6k(const void* W, const half* x, half* y, int M, int K, cudaStream_t stream) {
     gemv_q6k_kernel<<<gemv_blocks(M), kGemvThreads, 0, stream>>>(static_cast<const uint8_t*>(W), x, y, M, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -536,6 +541,7 @@ __global__ void gemv_q8_0_kernel(const uint8_t* __restrict__ W, const half* __re
 
 void gemv_q8_0(const void* W, const half* x, half* y, int M, int K, cudaStream_t stream) {
     gemv_q8_0_kernel<<<gemv_blocks(M), kGemvThreads, 0, stream>>>(static_cast<const uint8_t*>(W), x, y, M, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -550,6 +556,7 @@ void gemv_fp8(const Tensor& A, const Tensor& x, Tensor& y, float scale, cudaStre
         <<<gemv_blocks(M), kGemvThreads, 0, stream>>>(static_cast<const uint8_t*>(A.data),
                                                       static_cast<const half*>(x.data),
                                                       static_cast<half*>(y.data), M, K, scale, nullptr);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void gemv_fp8_rowscale(const Tensor& A, const Tensor& x, Tensor& y, const float* d_row_scales,
@@ -562,6 +569,7 @@ void gemv_fp8_rowscale(const Tensor& A, const Tensor& x, Tensor& y, const float*
                                                       static_cast<const half*>(x.data),
                                                       static_cast<half*>(y.data), M, K, 0.0f,
                                                       d_row_scales);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/gemm_grouped_nvfp4_smallM.cu
+++ b/src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -590,6 +590,7 @@ extern "C" bool gemm_grouped_nvfp4_smallM_software_ref(
         (const void* const*)d_A, (const void* const*)d_SFA,
         (const void* const*)d_B, (const void* const*)d_SFB,
         d_D, dev_alpha, d_M, N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 
     cudaFreeAsync(d_A, stream);   cudaFreeAsync(d_SFA, stream);
     cudaFreeAsync(d_B, stream);   cudaFreeAsync(d_SFB, stream);
@@ -621,6 +622,7 @@ extern "C" void smallM_smoke_single_mma(
     float* d_out, const uint32_t* a, const uint32_t* b,
     uint32_t sfa, uint32_t sfb, cudaStream_t stream) {
     imp_test::smallM_smoke_single_mma_kernel<<<1, 32, 0, stream>>>(d_out, a, b, sfa, sfb);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 #endif  // SMALLM_TEST_HOOKS
 
@@ -920,6 +922,7 @@ bool gemm_grouped_nvfp4_smallM(
             (const void* const*)d_A, (const void* const*)d_SFA,
             (const void* const*)d_B, (const void* const*)d_SFB,
             d_D, dev_alpha, d_M, d_descs, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     };
 
     using IC2  = std::integral_constant<int, 2>;

--- a/src/compute/gemm_moe_fused.cu
+++ b/src/compute/gemm_moe_fused.cu
@@ -1,5 +1,7 @@
 #include "compute/gemm_moe_fused.h"
 
+#include "core/logging.h"
+
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdio>
@@ -167,6 +169,7 @@ void gemm_q6k_fused_moe_prefill(const void* packed_weights, const void* activati
                                                                   static_cast<const half*>(activations),
                                                                   static_cast<half*>(output), d_offsets, N, K,
                                                                   expert_stride_bytes, n_experts);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/gemm_moe_fused_tc.cu
+++ b/src/compute/gemm_moe_fused_tc.cu
@@ -1,4 +1,5 @@
 #include "compute/gemm_moe_fused_tc.h"
+#include "core/logging.h"
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -267,6 +268,7 @@ void gemm_q6k_fused_moe_prefill_tc(const void* packed_weights, const void* activ
         static_cast<const uint8_t*>(packed_weights), static_cast<const half*>(activations),
         static_cast<half*>(output), d_offsets, sorted_token_ids, N, K, expert_stride_bytes, n_experts,
         d_tile_counter);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/gemm_moe_gemv.cu
+++ b/src/compute/gemm_moe_gemv.cu
@@ -1,5 +1,6 @@
 #include "compute/gemm.h"
 #include "compute/gemm_internal.cuh"
+#include "core/logging.h"
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -86,6 +87,7 @@ void gemv_q6k_moe_decode(const void* packed_weights, const int32_t* expert_indic
     gemv_q6k_moe_decode_kernel<<<top_k * blocks_per_expert, kGemvThreads, 0, stream>>>(
         static_cast<const uint8_t*>(packed_weights), expert_indices, x, y, rows, K, expert_stride_bytes,
         x_stride, blocks_per_expert);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 __global__ void gemv_q8_0_moe_decode_kernel(const uint8_t* __restrict__ packed_weights,
@@ -133,6 +135,7 @@ void gemv_q8_0_moe_decode(const void* packed_weights, const int32_t* expert_indi
     gemv_q8_0_moe_decode_kernel<<<top_k * blocks_per_expert, kGemvThreads, 0, stream>>>(
         static_cast<const uint8_t*>(packed_weights), expert_indices, x, y, rows, K, expert_stride_bytes,
         x_stride, blocks_per_expert);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -181,6 +184,7 @@ __global__ void gemv_gate_fp32_kernel(const half* __restrict__ W, const half* __
 
 void gemv_gate_fp32(const half* W, const half* x, float* y, int M, int K, cudaStream_t stream) {
     gemv_gate_fp32_kernel<<<gemv_blocks(M), kGemvThreads, 0, stream>>>(W, x, y, M, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // FP32-input variant: avoids FP16 truncation of router input for MoE precision.
@@ -218,6 +222,7 @@ __global__ void gemv_gate_fp32_fp32input_kernel(const half* __restrict__ W, cons
 
 void gemv_gate_fp32_fp32input(const half* W, const float* x, float* y, int M, int K, cudaStream_t stream) {
     gemv_gate_fp32_fp32input_kernel<<<gemv_blocks(M), kGemvThreads, 0, stream>>>(W, x, y, M, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -314,6 +319,7 @@ void gemv_q6k_moe_gate_up_fused(const void* gate_weights, const void* up_weights
     gemv_q6k_moe_gate_up_fused_kernel<<<grid, kGemvThreads, 0, stream>>>(
         static_cast<const uint8_t*>(gate_weights), static_cast<const uint8_t*>(up_weights), expert_indices, x,
         y_gate, y_up, rows, K, gate_stride_bytes, up_stride_bytes, x_stride, blocks_per_expert);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 __global__ void gemv_q8_0_moe_gate_up_fused_kernel(const uint8_t* __restrict__ gate_weights,
@@ -371,6 +377,7 @@ void gemv_q8_0_moe_gate_up_fused(const void* gate_weights, const void* up_weight
     gemv_q8_0_moe_gate_up_fused_kernel<<<grid, kGemvThreads, 0, stream>>>(
         static_cast<const uint8_t*>(gate_weights), static_cast<const uint8_t*>(up_weights), expert_indices, x,
         y_gate, y_up, rows, K, gate_stride_bytes, up_stride_bytes, x_stride, blocks_per_expert);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/gemm_q4k.cu
+++ b/src/compute/gemm_q4k.cu
@@ -12,6 +12,7 @@
 
 #include "compute/gemm_q4k.h"
 #include "compute/gemm.h"
+#include "core/logging.h"
 
 #include <cuda_fp16.h>
 #include <cstdint>
@@ -546,6 +547,7 @@ static void launch_dense_dp4a(const void* packed_weight, const block_q8_1* q8_ba
     gemm_qk_dp4a_dense_kernel<BT><<<grid, block, smem_bytes, stream>>>(
         static_cast<const uint8_t*>(packed_weight), q8_base, d8_base,
         output, M, K, N, q8_per_row);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -579,6 +581,7 @@ static void launch_dp4a(const void* packed_weight, const block_q8_1* q8_base, co
     gemm_qk_dp4a_moe_fused_kernel<BT><<<grid, block, smem_bytes, stream>>>(
         static_cast<const uint8_t*>(packed_weight), q8_base, d8_base,
         static_cast<half*>(c_base), offsets, K, N, weight_stride, q8_per_row);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -601,6 +604,7 @@ static void launch_scalar(const void* packed_weights, const void* activations, v
         static_cast<const half*>(activations),
         static_cast<half*>(output),
         d_offsets, N, K, expert_stride_bytes, n_experts);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/compute/gemm_q6k.cu
+++ b/src/compute/gemm_q6k.cu
@@ -1,5 +1,6 @@
 #include "compute/gemm_q6k.h"
 #include "compute/gemm.h"  // block_q8_1, quantize_fp16_to_q8_1
+#include "core/logging.h"
 
 #include <cuda_fp16.h>
 #include <cstdio>
@@ -233,6 +234,7 @@ void gemm_q6k_moe_fused(const void* packed_weight, const block_q8_1* q8_base, co
                                                                    q8_base, d8_base,
                                                                    static_cast<half*>(c_base), offsets, K, N,
                                                                    weight_stride, q8_per_row);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/gemv_ggml_compat.cu
+++ b/src/compute/gemv_ggml_compat.cu
@@ -154,6 +154,7 @@ void gemv_q4k_ggml_compat(const uint8_t* W, const half* x, half* y, int rows, in
     size_t smem = q8_blocks * (sizeof(float) + 32);  // Q8Block per block
     int threads = 32;                                // one warp per row
     gemv_q4k_ggml_compat_kernel<<<rows, threads, smem, stream>>>(W, x, y, rows, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/ggml_mmvq.cu
+++ b/src/compute/ggml_mmvq.cu
@@ -3,6 +3,7 @@
 // Self-contained: no ggml header dependencies.
 
 #include "ggml_mmvq.h"
+#include "core/logging.h"
 #include <cuda_fp16.h>
 #include <cstdint>
 #include <cstdio>
@@ -523,6 +524,7 @@ void ggml_mmvq_q4k(const void* W, const half* x, half* y, int M, int N, int K, v
         const int threads = 256;
         const int nblk = (total_q8_blocks + threads - 1) / threads;
         quantize_fp16_to_q8_1_ggml_kernel<<<nblk, threads, 0, stream>>>(x, x_q8, M * K);
+        IMP_CUDA_CHECK_LAUNCH();
         // (Q8_1 quantization verified correct — debug dumps removed)
     }
     {
@@ -530,6 +532,7 @@ void ggml_mmvq_q4k(const void* W, const half* x, half* y, int M, int N, int K, v
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
         mmvq_kernel<MMVQTag::Q4_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -547,6 +550,7 @@ void ggml_mmvq_q5_1(const void* W, const half* x, half* y, int M, int N, int K, 
         const int threads = 256;
         const int blocks = (total_q8_blocks + threads - 1) / threads;
         quantize_fp16_to_q8_1_ggml_kernel<<<blocks, threads, 0, stream>>>(x, x_q8, M * K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // MMVQ kernel: grid(N, M), block(32, 4)
@@ -555,6 +559,7 @@ void ggml_mmvq_q5_1(const void* W, const half* x, half* y, int M, int N, int K, 
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
         mmvq_kernel<MMVQTag::Q5_1><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -572,12 +577,14 @@ void ggml_mmvq_q4k_f32(const void* W, const float* x, half* y, int M, int N, int
         const int threads = 256;
         const int nblk = (total_q8_blocks + threads - 1) / threads;
         quantize_fp32_to_q8_1_ggml_kernel<<<nblk, threads, 0, stream>>>(x, x_q8, M * K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
     {
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
         mmvq_kernel<MMVQTag::Q4_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -597,12 +604,14 @@ void ggml_mmvq_q5k(const void* W, const half* x, half* y, int M, int N, int K, v
         const int threads = 256;
         const int nblk = (total_q8_blocks + threads - 1) / threads;
         quantize_fp16_to_q8_1_ggml_kernel<<<nblk, threads, 0, stream>>>(x, x_q8, M * K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
     {
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
         mmvq_kernel<MMVQTag::Q5_K><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -619,12 +628,14 @@ void ggml_mmvq_q8_0(const void* W, const half* x, half* y, int M, int N, int K, 
         const int threads = 256;
         const int nblk = (total_q8_blocks + threads - 1) / threads;
         quantize_fp16_to_q8_1_ggml_kernel<<<nblk, threads, 0, stream>>>(x, x_q8, M * K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
     {
         constexpr int nwarps = 4;
         dim3 block(WARP_SIZE, nwarps);
         dim3 grid(N, M);
         mmvq_kernel<MMVQTag::Q8_0><<<grid, block, 0, stream>>>(W, x_q8, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 

--- a/src/compute/hadamard.cu
+++ b/src/compute/hadamard.cu
@@ -195,6 +195,7 @@ void hadamard_transform_fp16(const half* input, half* output, int M, int K, int 
             int blocks_per_cta = warps_per_cta;
             int grid = (total_blocks + blocks_per_cta - 1) / blocks_per_cta;
             hadamard_warp_kernel<16><<<grid, warps_per_cta * 32, 0, stream>>>(input, output, M, K);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
         case 32: {
@@ -202,16 +203,19 @@ void hadamard_transform_fp16(const half* input, half* output, int M, int K, int 
             int blocks_per_cta = warps_per_cta;
             int grid = (total_blocks + blocks_per_cta - 1) / blocks_per_cta;
             hadamard_warp_kernel<32><<<grid, warps_per_cta * 32, 0, stream>>>(input, output, M, K);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
         case 64: {
             // One CTA (64 threads) per block.
             hadamard_64_kernel<<<total_blocks, 64, 0, stream>>>(input, output, M, K);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
         case 128: {
             // One CTA (128 threads) per block.
             hadamard_128_kernel<<<total_blocks, 128, 0, stream>>>(input, output, M, K);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
         default:

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -489,6 +489,7 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
     constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_categories_,
                                                                 d_token_allow_, d_allowed_mask_, vocab_size,
                                                                 n_classified, /*use_token_allow=*/true);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/kv_gather.cu
+++ b/src/compute/kv_gather.cu
@@ -1,4 +1,5 @@
 #include "compute/kv_gather.h"
+#include "core/logging.h"
 #include <cstdint>
 #include <cstring>
 #include <cuda_runtime.h>
@@ -130,6 +131,7 @@ void paged_kv_gather_fp16(half* dst, const half* src, const int* block_table, in
     int threads = 256;  // 8 tokens × 32 lanes; works for hd up to 256 with stride-32, OK for hd=512 too
     paged_kv_gather_fp16_kernel<<<grid, threads, 0, stream>>>(dst, src, block_table, n_past,
                                                               block_size, nkv, hd, d_n_past);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void paged_kv_gather_fp8_to_fp16(half* dst, const __nv_fp8_e4m3* src, const int* block_table,
@@ -143,6 +145,7 @@ void paged_kv_gather_fp8_to_fp16(half* dst, const __nv_fp8_e4m3* src, const int*
     paged_kv_gather_fp8_to_fp16_kernel<<<grid, threads, 0, stream>>>(dst, src, block_table, kv_scale,
                                                                       n_past, block_size, nkv, hd,
                                                                       d_n_past);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // NVFP4 → FP16 dequant gather. Same TOKENS_PER_BLOCK / threads_per_token grid
@@ -229,6 +232,7 @@ void paged_kv_gather_nvfp4_to_fp16(half* dst, const uint8_t* src_packed,
     int threads = 256;
     paged_kv_gather_nvfp4_to_fp16_kernel<<<grid, threads, 0, stream>>>(
         dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd, d_n_past);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -312,6 +316,7 @@ void paged_kv_gather_mxfp4_kv_to_fp16(half* dst, const uint8_t* src_packed,
     int threads = 256;
     paged_kv_gather_mxfp4_kv_to_fp16_kernel<<<grid, threads, 0, stream>>>(
         dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd, d_n_past);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // INT4 → FP16 dequant gather. Symmetric 4-bit, per-head FP16 scale.
@@ -392,6 +397,7 @@ void paged_kv_gather_int4_to_fp16(half* dst, const uint8_t* src_packed,
     int threads = 256;
     paged_kv_gather_int4_to_fp16_kernel<<<grid, threads, 0, stream>>>(
         dst, src_packed, src_scales, block_table, n_past, block_size, nkv, hd, d_n_past);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Chunk append at device-computed row offset (see kv_gather.h). n ≤ ~65 rows,
@@ -411,6 +417,7 @@ void kv_chunk_append_fp16(half* dst, const half* src, const int* d_past_len, int
     if (n <= 0 || row_elems <= 0)
         return;
     kv_chunk_append_fp16_kernel<<<n, 256, 0, stream>>>(dst, src, d_past_len, row_elems);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/layernorm.cu
+++ b/src/compute/layernorm.cu
@@ -2,6 +2,7 @@
 #include "compute/warp_reduce.cuh"
 #include "runtime/pdl.h"
 #include "core/tensor.h"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdint>
@@ -567,6 +568,7 @@ void layernorm_residual(const Tensor& x, const Tensor& residual, const Tensor& w
         static_cast<const __half*>(x.data),
         residual.data ? static_cast<const __half*>(residual.data) : nullptr, weight.data, w_f32,
         bias.data, b_f32, static_cast<__half*>(out.data), d, eps);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/mla_absorb.cu
+++ b/src/compute/mla_absorb.cu
@@ -1,6 +1,7 @@
 // MLA absorbed-decode kernels (Phase 3, opt-in). See mla_absorb.h.
 
 #include "compute/mla_absorb.h"
+#include "core/logging.h"
 
 namespace imp {
 
@@ -39,6 +40,7 @@ void mla_latent_cache_write(const half* latent, const half* k_assembled, half* c
         reinterpret_cast<const __half*>(latent), reinterpret_cast<const __half*>(k_assembled),
         reinterpret_cast<__half*>(cache), positions, n_tokens, n_heads, head_dim, rope_dim,
         kv_lora_rank, max_seq);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -173,6 +175,7 @@ void mla_absorbed_decode(const half* q, const half* kv_b, const half* cache, hal
         reinterpret_cast<const __half*>(q), reinterpret_cast<const __half*>(kv_b),
         reinterpret_cast<const __half*>(cache), reinterpret_cast<__half*>(out), scores, context_lens,
         n_heads, head_dim, rope_dim, nope_dim, kv_lora_rank, v_head_dim, max_seq, scale);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/mla_kv_assemble.cu
+++ b/src/compute/mla_kv_assemble.cu
@@ -11,6 +11,7 @@
 // V output: [n_tokens, n_heads, v_head_dim]
 
 #include "compute/mla_kv_assemble.h"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
@@ -118,6 +119,7 @@ void mla_assemble_kv(const half* kv_b, const half* k_rope,
         reinterpret_cast<__half*>(K_out),
         reinterpret_cast<__half*>(V_out),
         n_heads, nope_dim, v_head_dim, rope_dim, v_dst_hd);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void mla_reorder_q(half* q_data, int n_tokens, int n_heads,
@@ -129,6 +131,7 @@ void mla_reorder_q(half* q_data, int n_tokens, int n_heads,
     mla_reorder_q_kernel<<<grid, 64, smem, stream>>>(
         reinterpret_cast<__half*>(q_data),
         n_heads, nope_dim, rope_dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void mla_compact_attn_output(const half* src, half* dst,
@@ -142,6 +145,7 @@ void mla_compact_attn_output(const half* src, half* dst,
         reinterpret_cast<const __half*>(src),
         reinterpret_cast<__half*>(dst),
         n_heads, head_dim, v_head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/mmq_q4k_hmma.cu
+++ b/src/compute/mmq_q4k_hmma.cu
@@ -273,6 +273,7 @@ bool mmq_q4k_hmma_gemm(const void* A_fp16, const void* B_q4k, void* C_fp16,
         static_cast<const uint8_t*>(B_q4k),
         static_cast<__half*>(C_fp16),
         M, N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 
     return true;
 }

--- a/src/compute/mmq_q4k_imma_layout.cu
+++ b/src/compute/mmq_q4k_imma_layout.cu
@@ -29,6 +29,7 @@
 //    inner loop produces 32 low nibbles then 32 high nibbles.)
 
 #include "compute/mmq_q4k_imma_layout.h"
+#include "core/logging.h"
 
 #include <cuda_fp16.h>
 #include <cstdint>
@@ -143,6 +144,7 @@ void mmq_q4k_imma_reorder(const void* q4k_blocks, int N, int K, int8_t* w_sym_s8
     dim3 block(32, 1, 1);
     mmq_q4k_imma_reorder_kernel<<<grid, block, 0, stream>>>(
         static_cast<const uint8_t*>(q4k_blocks), N, K, w_sym_s8, eff_alpha, eff_beta);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/mmq_q4k_imma_tile.cu
+++ b/src/compute/mmq_q4k_imma_tile.cu
@@ -240,6 +240,7 @@ void mmq_q4k_imma_tile(const int8_t* X_s8, const __half* x_scale, const float* x
     dim3 block(kThreadsPerCTA, 1, 1);
     mmq_q4k_imma_tile_kernel<<<grid, block, 0, stream>>>(
         X_s8, x_scale, x_rowsum, W_s8, eff_alpha, eff_beta, out, M, N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // =============================================================================
@@ -298,6 +299,7 @@ void quantize_fp16_to_int8_subblock(const __half* X_fp16, int M, int K, int8_t* 
     dim3 block(32, 1, 1);
     quantize_fp16_to_int8_subblock_kernel<<<grid, block, 0, stream>>>(X_fp16, M, K, X_s8, x_scale,
                                                                      x_rowsum);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // =============================================================================

--- a/src/compute/mmq_q8_imma.cu
+++ b/src/compute/mmq_q8_imma.cu
@@ -440,6 +440,7 @@ bool ensure_weight(const void* src, int N, int K, cudaStream_t stream, bool capt
     const int total = N * static_cast<int>(subs);
     q8_split_kernel<<<(total + 255) / 256, 256, 0, stream>>>(static_cast<const uint8_t*>(src),
                                                              w.qs, w.sc, total);
+    IMP_CUDA_CHECK_LAUNCH();
     g_weights[src] = w;
     return true;
 }
@@ -454,6 +455,7 @@ bool ensure_q6k(const void* src, size_t n_blocks, cudaStream_t stream, bool capt
     const size_t total = n_blocks * 105;
     q6k_repack_kernel<<<static_cast<unsigned>((total + 255) / 256), 256, 0, stream>>>(
         static_cast<const uint8_t*>(src), r.blocks, n_blocks);
+    IMP_CUDA_CHECK_LAUNCH();
     g_q6k[src] = r;
     return true;
 }
@@ -506,6 +508,7 @@ void quantize_act(const __half* x, int M, int K, cudaStream_t stream) {
     const int blocks = min(2048, (total_warps + 7) / 8);
     quantize_act_fast_kernel<<<blocks, 256, 0, stream>>>(x, M, K, g_act.xs8, g_act.xscale,
                                                          g_act.xrowsum);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __half* x_f16,
@@ -535,14 +538,17 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
             mmq_imma_q4k_raw_kernel<32, false><<<grid, kThreads, 0, stream>>>(
                 g_act.xs8, g_act.xscale, g_act.xrowsum, w4, out_f16, M, N, K, d_offsets,
                 w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         } else if (beta == 1.0f) {
             mmq_imma_q4k_raw_kernel<128, true><<<grid, kThreads, 0, stream>>>(
                 g_act.xs8, g_act.xscale, g_act.xrowsum, w4, out_f16, M, N, K, d_offsets,
                 w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             mmq_imma_q4k_raw_kernel<128, false><<<grid, kThreads, 0, stream>>>(
                 g_act.xs8, g_act.xscale, g_act.xrowsum, w4, out_f16, M, N, K, d_offsets,
                 w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         return true;
     }
@@ -553,14 +559,17 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
             mmq_imma_q51_raw_kernel<32, false><<<grid, kThreads, 0, stream>>>(
                 g_act.xs8, g_act.xscale, g_act.xrowsum, w5, out_f16, M, N, K, d_offsets,
                 w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         } else if (beta == 1.0f) {
             mmq_imma_q51_raw_kernel<128, true><<<grid, kThreads, 0, stream>>>(
                 g_act.xs8, g_act.xscale, g_act.xrowsum, w5, out_f16, M, N, K, d_offsets,
                 w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             mmq_imma_q51_raw_kernel<128, false><<<grid, kThreads, 0, stream>>>(
                 g_act.xs8, g_act.xscale, g_act.xrowsum, w5, out_f16, M, N, K, d_offsets,
                 w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         return true;
     }
@@ -585,16 +594,19 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
                 <<<grid, kThreads, q6k_smem_bytes(32), stream>>>(g_act.xs8, g_act.xscale, w6,
                                                                  out_f16, M, N, K, d_offsets,
                                                                  w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         } else if (beta == 1.0f) {
             mmq_imma_q6k_raw_kernel<128, true>
                 <<<grid, kThreads, q6k_smem_bytes(128), stream>>>(g_act.xs8, g_act.xscale, w6,
                                                                   out_f16, M, N, K, d_offsets,
                                                                   w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             mmq_imma_q6k_raw_kernel<128, false>
                 <<<grid, kThreads, q6k_smem_bytes(128), stream>>>(g_act.xs8, g_act.xscale, w6,
                                                                   out_f16, M, N, K, d_offsets,
                                                                   w_stride_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         return true;
     }
@@ -622,9 +634,11 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
                 mmq_imma_kernel<32, false, false, true><<<sgrid, kThreads, 0, stream>>>(
                     g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K,
                     nullptr, w_stride, wsc_stride, g_splitk.buf, ks_per_split);
+                IMP_CUDA_CHECK_LAUNCH();
                 const int total = static_cast<int>(slice);
                 mmq_splitk_finalize_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
                     g_splitk.buf, used, total, out_f16, beta == 1.0f ? 1 : 0);
+                IMP_CUDA_CHECK_LAUNCH();
                 return true;
             }
         }
@@ -635,14 +649,17 @@ bool gemm_common(const void* w_blocks, int qkind /*0=q8 1=q4k 2=q6k*/, const __h
         mmq_imma_kernel<32, false, false><<<grid, kThreads, 0, stream>>>(
             g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K, d_offsets,
             w_stride, wsc_stride);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (beta == 1.0f) {
         mmq_imma_kernel<128, true, false><<<grid, kThreads, 0, stream>>>(
             g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K, d_offsets,
             w_stride, wsc_stride);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         mmq_imma_kernel<128, false, false><<<grid, kThreads, 0, stream>>>(
             g_act.xs8, g_act.xscale, g_act.xrowsum, w.qs, w.sc, out_f16, M, N, K, d_offsets,
             w_stride, wsc_stride);
+        IMP_CUDA_CHECK_LAUNCH();
     }
     return true;
 }

--- a/src/compute/moe_routing.cu
+++ b/src/compute/moe_routing.cu
@@ -599,6 +599,7 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingResult& res
                                                                       d_expert_indices, d_expert_weights,
                                                                       use_sigmoid, normalize_weights,
                                                                       static_cast<const half*>(score_bias));
+    IMP_CUDA_CHECK_LAUNCH();
 
     // ---- Fused count + scan + scatter (single kernel) ----
     size_t smem_permute = static_cast<size_t>(n_experts) * 2 * sizeof(int32_t);
@@ -606,11 +607,13 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingResult& res
         moe_fused_permute_deterministic_kernel<<<1, BLOCK_SIZE, smem_permute, stream>>>(
             d_expert_indices, n_tokens, top_k, n_experts, d_sorted_token_ids, d_sorted_flat_idx,
             d_expert_offsets, nullptr);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         moe_fused_permute_kernel<<<1, BLOCK_SIZE, smem_permute, stream>>>(d_expert_indices, n_tokens, top_k,
                                                                           n_experts, d_sorted_token_ids,
                                                                           d_sorted_flat_idx, d_expert_offsets,
                                                                           nullptr);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ---- Fill result struct ----
@@ -712,6 +715,7 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingBuffers& bu
                                                                       d_expert_indices, d_expert_weights,
                                                                       use_sigmoid, normalize_weights,
                                                                       static_cast<const half*>(score_bias));
+    IMP_CUDA_CHECK_LAUNCH();
 
     if (!skip_sorting) {
         int32_t* d_sorted_flat_idx = d_sorted_token_ids + total_assignments;
@@ -721,12 +725,14 @@ void moe_topk_gating(const Tensor& gate_logits, int top_k, MoeRoutingBuffers& bu
             moe_fused_permute_deterministic_kernel<<<1, BLOCK_SIZE, smem_bytes, stream>>>(
                 d_expert_indices, n_tokens, top_k, n_experts, d_sorted_token_ids, d_sorted_flat_idx,
                 d_expert_offsets, buffers.token_to_expanded);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             moe_fused_permute_kernel<<<1, BLOCK_SIZE, smem_bytes, stream>>>(d_expert_indices, n_tokens, top_k,
                                                                             n_experts, d_sorted_token_ids,
                                                                             d_sorted_flat_idx,
                                                                             d_expert_offsets,
                                                                             buffers.token_to_expanded);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 
@@ -760,6 +766,7 @@ void moe_gate_topk_fused(const void* W_gate, const void* x, int n_experts, int d
                                                                  buffers.expert_weights, use_sigmoid,
                                                                  normalize_weights,
                                                                  static_cast<const half*>(score_bias));
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Fill result struct (no ownership — memory belongs to buffers)
     result.owns_memory = false;

--- a/src/compute/moe_routing_permute.cu
+++ b/src/compute/moe_routing_permute.cu
@@ -144,11 +144,13 @@ void moe_gather(const Tensor& input, const MoeRoutingResult& routing, Tensor& ga
         half* d_gathered = static_cast<half*>(gathered.data);
         moe_gather_kernel_impl<<<total_tokens, BLOCK_SIZE, 0, stream>>>(d_input, d_sorted, d_gathered,
                                                                         total_tokens, d_model);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         const float* d_input = static_cast<const float*>(input.data);
         float* d_gathered = static_cast<float*>(gathered.data);
         moe_gather_kernel_impl<<<total_tokens, BLOCK_SIZE, 0, stream>>>(d_input, d_sorted, d_gathered,
                                                                         total_tokens, d_model);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -184,28 +186,33 @@ void moe_scatter(const Tensor& expert_output, const MoeRoutingResult& routing, T
             moe_scatter_deterministic_kernel_impl<<<n_tokens, BLOCK_SIZE, 0, stream>>>(
                 d_expert_out, d_sorted_token_ids, d_sorted_flat_idx, d_expert_weights, d_output, total_tokens,
                 n_tokens, d_model);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             const float* d_expert_out = static_cast<const float*>(expert_output.data);
             moe_scatter_deterministic_kernel_impl<<<n_tokens, BLOCK_SIZE, 0, stream>>>(
                 d_expert_out, d_sorted_token_ids, d_sorted_flat_idx, d_expert_weights, d_output, total_tokens,
                 n_tokens, d_model);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         return;
     }
 
     // Zero the output first (scatter-add accumulates into it)
     zero_float_kernel<<<grid_z, BLOCK_SIZE, 0, stream>>>(d_output, total_out_elems);
+    IMP_CUDA_CHECK_LAUNCH();
 
     if (expert_output.qtype == QType::F16) {
         const half* d_expert_out = static_cast<const half*>(expert_output.data);
         moe_scatter_kernel_impl<<<total_tokens, BLOCK_SIZE, 0, stream>>>(d_expert_out, d_sorted_token_ids,
                                                                          d_sorted_flat_idx, d_expert_weights,
                                                                          d_output, total_tokens, d_model);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         const float* d_expert_out = static_cast<const float*>(expert_output.data);
         moe_scatter_kernel_impl<<<total_tokens, BLOCK_SIZE, 0, stream>>>(d_expert_out, d_sorted_token_ids,
                                                                          d_sorted_flat_idx, d_expert_weights,
                                                                          d_output, total_tokens, d_model);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -241,6 +248,7 @@ void moe_weighted_sum_residual(const void* expert_outputs, const float* expert_w
                                                                      static_cast<const half*>(residual),
                                                                      static_cast<half*>(output), d_model,
                                                                      top_k);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ============================================================================
@@ -282,6 +290,7 @@ void moe_scatter_fused_residual(const void* expert_output, const int32_t* token_
     moe_scatter_fused_residual_kernel<<<n_tokens, threads, 0, stream>>>(
         static_cast<const half*>(expert_output), token_to_expanded, expert_weights,
         static_cast<const half*>(residual), static_cast<half*>(output), d_model, top_k);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // FP32-input variant: expert_output is float* (not half*).
@@ -314,6 +323,7 @@ void moe_scatter_fused_residual_fp32in(const void* expert_output_fp32, const int
     moe_scatter_fused_residual_fp32in_kernel<<<n_tokens, threads, 0, stream>>>(
         static_cast<const float*>(expert_output_fp32), token_to_expanded, expert_weights,
         static_cast<const half*>(residual), static_cast<half*>(output), d_model, top_k);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ============================================================================
@@ -366,6 +376,7 @@ void moe_add_logit_bias(float* logits_f32, const void* bias_fp16, int n, int ne,
     int blocks = static_cast<int>((total + threads - 1) / threads);
     moe_add_logit_bias_kernel<<<blocks, threads, 0, stream>>>(
         logits_f32, static_cast<const half*>(bias_fp16), total, ne);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void moe_add_expert_bias_indexed(void* buf_fp16, const void* bias_fp16, const int32_t* expert_indices,
@@ -377,6 +388,7 @@ void moe_add_expert_bias_indexed(void* buf_fp16, const void* bias_fp16, const in
     int blocks = static_cast<int>((total + threads - 1) / threads);
     moe_add_expert_bias_indexed_kernel<<<blocks, threads, 0, stream>>>(
         static_cast<half*>(buf_fp16), static_cast<const half*>(bias_fp16), expert_indices, total, dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void moe_add_expert_bias_sorted(void* buf_fp16, const void* bias_fp16, const int32_t* expert_offsets,
@@ -388,6 +400,7 @@ void moe_add_expert_bias_sorted(void* buf_fp16, const void* bias_fp16, const int
     int blocks = static_cast<int>((total + threads - 1) / threads);
     moe_add_expert_bias_sorted_kernel<<<blocks, threads, 0, stream>>>(
         static_cast<half*>(buf_fp16), static_cast<const half*>(bias_fp16), expert_offsets, ne, total, dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -405,11 +405,13 @@ void mtp_apply_mrope(void* d_q, int n_heads, void* d_k, int n_kv_heads, int head
         mtp_mrope_kernel<false><<<n_heads, kBlock, 0, stream>>>(
             static_cast<__half*>(d_q), n_heads, head_dim, rope_dim, theta, sec0, sec1, sec2,
             pos, pos, pos, inv_scaling, ext_factor, attn_factor, corr_dim_0, corr_dim_1);
+        IMP_CUDA_CHECK_LAUNCH();
     }
     if (n_kv_heads > 0 && d_k) {
         mtp_mrope_kernel<true><<<n_kv_heads, kBlock, 0, stream>>>(
             static_cast<__half*>(d_k), n_kv_heads, head_dim, rope_dim, theta, sec0, sec1, sec2,
             pos, pos, pos, inv_scaling, ext_factor, attn_factor, corr_dim_0, corr_dim_1);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -636,6 +638,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
             static_cast<const __half*>(ws.d_h_norm),
             static_cast<__half*>(ws.d_fc_in),
             hidden_dim);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Step 4: fc_out = fc @ fc_in  ([hidden_dim, 2*hidden_dim] x [2*hidden_dim] = [hidden_dim])
@@ -762,6 +765,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     static_cast<__half*>(ws.d_k_cache),
                     static_cast<__half*>(ws.d_v_cache),
                     pos, nkv, hdh);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             // 5.A.4.b — softmax attention scan over [0, pos+1)
             //   shared mem: seq_len * sizeof(float). Cap with the kernel's
@@ -779,6 +783,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     static_cast<const __half*>(ws.d_v_cache),
                     static_cast<__half*>(ws.d_attn_out),
                     seq_len, nh, nkv, hdh, ws.max_seq_len, scale);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             // 5.A.4.c — silu(gate) * attn_out (in-place)
             {
@@ -788,6 +793,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     static_cast<__half*>(ws.d_attn_out),
                     static_cast<const __half*>(ws.d_q_full),
                     nh, hdh);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             ws.mtp_pos = pos + 1;
         } else {
@@ -799,6 +805,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                 static_cast<const __half*>(ws.d_v_proj),
                 static_cast<__half*>(ws.d_attn_out),
                 nh, nkv, hdh);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         // 5.A.5 — o_proj @ d_attn_out → d_attn_residual
         {
@@ -816,6 +823,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                 static_cast<__half*>(ws.d_fc_out),
                 static_cast<const __half*>(ws.d_attn_residual),
                 hd);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         // (K is computed for shape symmetry but unused in the M=1, no-history MVP.)
         (void)mtp.k_proj;
@@ -1000,6 +1008,7 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
                     static_cast<__half*>(ws.d_moe_out),
                     static_cast<const __half*>(ws.d_shared_out),
                     hd);
+                IMP_CUDA_CHECK_LAUNCH();
             }
         }
         // Copy d_moe_out → d_fc_out (overwrite) so downstream RMSNorm reads the
@@ -1047,9 +1056,11 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         if (nvfp4_lm) {
             mtp_argmax_kernel<<<1, 256, 0, stream>>>(
                 static_cast<const float*>(ws.d_logits_f32), vocab_size, d_out_token);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             mtp_argmax_kernel<<<1, 256, 0, stream>>>(
                 static_cast<const __half*>(ws.d_logits), vocab_size, d_out_token);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         return true;
     }
@@ -1067,9 +1078,11 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         if (nvfp4_lm) {
             mtp_topk_kernel<<<1, 256, 0, stream>>>(
                 static_cast<const float*>(ws.d_logits_f32), vocab_size, w, ws.d_topk);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             mtp_topk_kernel<<<1, 256, 0, stream>>>(
                 static_cast<const __half*>(ws.d_logits), vocab_size, w, ws.d_topk);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         if (cudaMemcpyAsync(out_topk_ids, ws.d_topk, w * sizeof(int),
                             cudaMemcpyDeviceToHost, stream) != cudaSuccess)
@@ -1093,9 +1106,11 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
     if (nvfp4_lm) {
         mtp_argmax_kernel<<<1, 256, 0, stream>>>(
             static_cast<const float*>(ws.d_logits_f32), vocab_size, d_idx);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         mtp_argmax_kernel<<<1, 256, 0, stream>>>(
             static_cast<const __half*>(ws.d_logits), vocab_size, d_idx);
+        IMP_CUDA_CHECK_LAUNCH();
     }
     if (cudaMemcpyAsync(out_token_id, d_idx, sizeof(int),
                         cudaMemcpyDeviceToHost, stream) != cudaSuccess) {

--- a/src/compute/nvfp4_quant_hw.cu
+++ b/src/compute/nvfp4_quant_hw.cu
@@ -279,6 +279,7 @@ bool nvfp4_quant_hw_fp16(const half* d_input, uint8_t* d_nvfp4, uint8_t* d_sf, i
                                          stride_bz_input, stride_h_input, stride_seq_input, stride_bz_output,
                                          stride_h_output, stride_seq_output, stride_bz_output_sf,
                                          stride_h_output_sf, stride_seq_output_sf);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         nvfp4_quant_hw_kernel<64, BLOCK_SIZE>
             <<<grid, block, 0, stream>>>(d_input, d_nvfp4, d_sf, batch_size, n_heads, n_tokens,
@@ -310,6 +311,7 @@ bool nvfp4_dequant_hw_fp16(const uint8_t* d_nvfp4, const uint8_t* d_sf, half* d_
                                          stride_bz_input, stride_h_input, stride_seq_input, stride_bz_output,
                                          stride_h_output, stride_seq_output, stride_bz_input_sf,
                                          stride_h_input_sf, stride_seq_input_sf);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         nvfp4_dequant_hw_kernel<64, BLOCK_SIZE>
             <<<grid, block, 0, stream>>>(d_nvfp4, d_sf, d_output, batch_size, n_heads, n_tokens,

--- a/src/compute/nvfp4_quant_ref.cu
+++ b/src/compute/nvfp4_quant_ref.cu
@@ -12,6 +12,7 @@
 // =============================================================================
 
 #include "compute/nvfp4_quant_ref.h"
+#include "core/logging.h"
 #include <cuda_fp8.h>
 #include <cstdint>
 
@@ -148,6 +149,7 @@ void nvfp4_quant_linear_fp16(const half* d_input, uint8_t* d_nvfp4, uint8_t* d_s
     const int groups = (n_elements + 15) / 16;
     const int blocks = (groups + threads - 1) / threads;
     nvfp4_quant_linear_kernel<<<blocks, threads, 0, stream>>>(d_input, d_nvfp4, d_sf, n_elements);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void nvfp4_dequant_linear_fp16(const uint8_t* d_nvfp4, const uint8_t* d_sf, half* d_output, int n_elements,
@@ -156,6 +158,7 @@ void nvfp4_dequant_linear_fp16(const uint8_t* d_nvfp4, const uint8_t* d_sf, half
     const int groups = (n_elements + 15) / 16;
     const int blocks = (groups + threads - 1) / threads;
     nvfp4_dequant_linear_kernel<<<blocks, threads, 0, stream>>>(d_nvfp4, d_sf, d_output, n_elements);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/quantize_fp16_nvfp4_moe_native.cu
+++ b/src/compute/quantize_fp16_nvfp4_moe_native.cu
@@ -257,6 +257,7 @@ static void quantize_fp16_to_nvfp4_moe_native_impl(
         dim3 block(256);
         nvfp4_moe_native_absmax_kernel<<<grid, block, 0, stream>>>(
             src_fp16, d_expert_offsets, K, d_absmax);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Optional pass 1.5: write per-expert tensor_scales = absmax/6 to caller buffer.
@@ -265,6 +266,7 @@ static void quantize_fp16_to_nvfp4_moe_native_impl(
         int blocks = (n_experts + threads - 1) / threads;
         nvfp4_moe_native_finalize_scales_kernel<<<blocks, threads, 0, stream>>>(
             d_absmax, d_tensor_scales_opt, n_experts);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Pass 2: quantize (one CTA-x per expert, CTA-y slices for parallelism).
@@ -278,6 +280,7 @@ static void quantize_fp16_to_nvfp4_moe_native_impl(
             d_expert_offsets,
             d_absmax,
             K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     IMP_CUDA_CHECK_LOG(cudaFreeAsync(d_packed_dev, stream));
@@ -343,6 +346,7 @@ void compute_moe_alpha_device(
     int blocks  = (n_experts + threads - 1) / threads;
     moe_alpha_mul_kernel<<<blocks, threads, 0, stream>>>(
         d_act_scales, d_weight_scales, d_alpha_out, n_experts);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -370,6 +374,7 @@ void compute_M_per_from_offsets_device(
     int blocks  = (n_experts + threads - 1) / threads;
     moe_compute_M_per_kernel<<<blocks, threads, 0, stream>>>(
         d_expert_offsets, d_M_per_out, n_experts);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -432,6 +437,7 @@ void compact_alpha_active(
               n_experts);
     compact_alpha_active_kernel<<<1, 256, 0, stream>>>(
         d_alpha, d_M_per, d_alpha_compact, d_na_out, n_experts);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -505,6 +511,7 @@ void compute_sfa_offsets_device(
               n_experts);
     compute_sfa_offsets_kernel<<<1, 256, 0, stream>>>(
         d_M_per, d_sfa_offsets_out, n_experts, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -534,6 +541,7 @@ void build_sfa_bases_device(
     int blocks  = (n_experts + threads - 1) / threads;
     build_sfa_bases_kernel<<<blocks, threads, 0, stream>>>(
         d_sfa_bases_out, static_cast<uint8_t*>(base_sf), d_sfa_offsets, n_experts);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -593,6 +601,7 @@ void bzero_sfa_active(
     bzero_sfa_active_kernel<<<static_cast<int>(blocks_needed), kThreads, 0, stream>>>(
         static_cast<uint8_t*>(dst), d_sfa_offsets, n_experts,
         static_cast<int64_t>(max_bytes));
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/reduce.cu
+++ b/src/compute/reduce.cu
@@ -1,5 +1,6 @@
 #include "compute/reduce.h"
 #include "compute/warp_reduce.cuh"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cfloat>
@@ -359,9 +360,11 @@ void reduce_sum(const Tensor& input, Tensor& output, int dim, cudaStream_t strea
             const half* d_input = static_cast<const half*>(input.data);
             reduce_sum_last_dim_fp16_kernel<<<num_rows, BLOCK_SIZE, 0, stream>>>(d_input, d_output,
                                                                                  reduce_size);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             const float* d_input = static_cast<const float*>(input.data);
             reduce_sum_last_dim_kernel<<<num_rows, BLOCK_SIZE, 0, stream>>>(d_input, d_output, reduce_size);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     } else {
         // General case: reduce along arbitrary dimension
@@ -371,10 +374,12 @@ void reduce_sum(const Tensor& input, Tensor& output, int dim, cudaStream_t strea
             reduce_sum_general_fp16_kernel<<<num_output, BLOCK_SIZE, 0, stream>>>(d_input, d_output,
                                                                                   outer_size, reduce_size,
                                                                                   inner_size);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             const float* d_input = static_cast<const float*>(input.data);
             reduce_sum_general_kernel<<<num_output, BLOCK_SIZE, 0, stream>>>(d_input, d_output, outer_size,
                                                                              reduce_size, inner_size);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 }
@@ -394,9 +399,11 @@ void reduce_max(const Tensor& input, Tensor& output, int dim, cudaStream_t strea
             const half* d_input = static_cast<const half*>(input.data);
             reduce_max_last_dim_fp16_kernel<<<num_rows, BLOCK_SIZE, 0, stream>>>(d_input, d_output,
                                                                                  reduce_size);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             const float* d_input = static_cast<const float*>(input.data);
             reduce_max_last_dim_kernel<<<num_rows, BLOCK_SIZE, 0, stream>>>(d_input, d_output, reduce_size);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     } else {
         int num_output = outer_size * inner_size;
@@ -405,10 +412,12 @@ void reduce_max(const Tensor& input, Tensor& output, int dim, cudaStream_t strea
             reduce_max_general_fp16_kernel<<<num_output, BLOCK_SIZE, 0, stream>>>(d_input, d_output,
                                                                                   outer_size, reduce_size,
                                                                                   inner_size);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             const float* d_input = static_cast<const float*>(input.data);
             reduce_max_general_kernel<<<num_output, BLOCK_SIZE, 0, stream>>>(d_input, d_output, outer_size,
                                                                              reduce_size, inner_size);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 }

--- a/src/compute/sampling.cu
+++ b/src/compute/sampling.cu
@@ -156,6 +156,7 @@ int32_t sample_greedy(const Tensor& logits, cudaStream_t stream) {
     }
 
     argmax_kernel<<<1, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size, d_result);
+    IMP_CUDA_CHECK_LAUNCH();
 
     int32_t h_result = 0;
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(&h_result, d_result, sizeof(int32_t), cudaMemcpyDeviceToHost, stream));
@@ -177,7 +178,9 @@ int32_t sample_greedy(const Tensor& logits, int32_t* d_result, cudaStream_t stre
 
     argmax_partial_kernel<<<ARGMAX_NBLOCKS, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size, partial_vals,
                                                                      partial_idxs);
+    IMP_CUDA_CHECK_LAUNCH();
     argmax_reduce_kernel<<<1, WARP_SIZE, 0, stream>>>(partial_vals, partial_idxs, ARGMAX_NBLOCKS, d_result);
+    IMP_CUDA_CHECK_LAUNCH();
 
     int32_t h_result = 0;
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(&h_result, d_result, sizeof(int32_t), cudaMemcpyDeviceToHost, stream));
@@ -199,7 +202,9 @@ void sample_greedy_async(const Tensor& logits, int32_t* d_result, cudaStream_t s
 
     argmax_partial_kernel<<<ARGMAX_NBLOCKS, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size, partial_vals,
                                                                      partial_idxs);
+    IMP_CUDA_CHECK_LAUNCH();
     argmax_reduce_kernel<<<1, WARP_SIZE, 0, stream>>>(partial_vals, partial_idxs, ARGMAX_NBLOCKS, d_result);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ===========================================================================
@@ -217,7 +222,9 @@ void sample_greedy_device(const Tensor& logits, int32_t* d_result, int32_t* h_ma
 
     argmax_partial_kernel<<<ARGMAX_NBLOCKS, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size, partial_vals,
                                                                      partial_idxs);
+    IMP_CUDA_CHECK_LAUNCH();
     argmax_reduce_kernel<<<1, WARP_SIZE, 0, stream>>>(partial_vals, partial_idxs, ARGMAX_NBLOCKS, d_result);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Async copy to mapped pinned memory — no sync needed.
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_mapped, d_result, sizeof(int32_t), cudaMemcpyDeviceToHost, stream));

--- a/src/compute/sampling_filters.cu
+++ b/src/compute/sampling_filters.cu
@@ -1,6 +1,7 @@
 #include "compute/sampling.h"
 #include "compute/sampling_internal.cuh"
 #include "compute/warp_reduce.cuh"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cmath>
 #include <cfloat>
@@ -57,6 +58,7 @@ void apply_min_p(float* logits, int vocab_size, float min_p, cudaStream_t stream
 
     float log_min_p = logf(min_p);
     apply_min_p_kernel<<<1, BLOCK_SIZE, 0, stream>>>(logits, vocab_size, log_min_p);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ===========================================================================
@@ -205,6 +207,7 @@ void apply_typical_p(float* logits, int vocab_size, float typical_p, cudaStream_
         return;
 
     apply_typical_p_kernel<<<1, BLOCK_SIZE, 0, stream>>>(logits, vocab_size, typical_p);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/compute/sampling_penalties.cu
+++ b/src/compute/sampling_penalties.cu
@@ -110,6 +110,7 @@ __global__ void force_single_token_kernel(float* logits, int vocab_size, int32_t
 void force_single_token(float* logits, int vocab_size, int32_t keep_token, cudaStream_t stream) {
     int blocks = (vocab_size + 255) / 256;
     force_single_token_kernel<<<blocks, 256, 0, stream>>>(logits, vocab_size, keep_token);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void apply_penalties(float* logits, int vocab_size, const int32_t* token_ids, int n_tokens,
@@ -124,6 +125,7 @@ void apply_penalties(float* logits, int vocab_size, const int32_t* token_ids, in
     apply_penalties_kernel<<<blocks, BLOCK_SIZE, 0, stream>>>(logits, token_ids, n_tokens, vocab_size,
                                                               repetition_penalty, frequency_penalty,
                                                               presence_penalty);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void apply_penalties_device_count(float* logits, int vocab_size, const int32_t* token_ids,
@@ -138,6 +140,7 @@ void apply_penalties_device_count(float* logits, int vocab_size, const int32_t* 
                                                                            repetition_penalty,
                                                                            frequency_penalty,
                                                                            presence_penalty);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ===========================================================================
@@ -251,6 +254,7 @@ void apply_dry_penalty(float* d_logits, int vocab_size, const int32_t* host_toke
 
     int grid = (n + BLOCK_SIZE - 1) / BLOCK_SIZE;
     apply_dry_sparse_kernel<<<grid, BLOCK_SIZE, 0, stream>>>(d_logits, s_dry_tokens_buf, s_dry_values_buf, n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ===========================================================================
@@ -400,6 +404,7 @@ static int32_t sample_mirostat_v2_impl(const Tensor& logits, float temperature, 
 
     mirostat_v2_sample_kernel<<<1, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size, *mu, inv_temperature, seed,
                                                             d_result, d_surprise);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Read results
     int32_t h_result = 0;

--- a/src/compute/sampling_topk_topp.cu
+++ b/src/compute/sampling_topk_topp.cu
@@ -321,9 +321,11 @@ static void launch_topk_topp_multiblock(const float* d_logits, int vocab_size, i
 
     topk_partial_kernel<<<SAMPLE_NBLOCKS, BLOCK_SIZE, smem1, stream>>>(
         d_logits, vocab_size, top_k, inv_temperature, block_max, block_sum, cand_val, cand_idx);
+    IMP_CUDA_CHECK_LAUNCH();
     topk_finalize_kernel<<<1, BLOCK_SIZE, smem2, stream>>>(top_k, top_p, inv_temperature, seed,
                                                            SAMPLE_NBLOCKS, block_max, block_sum, cand_val,
                                                            cand_idx, d_result);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_topk_topp_rows(const TopkRowArgs* d_rows, int n_rows, int max_top_k, int vocab_size,
@@ -337,7 +339,9 @@ void launch_topk_topp_rows(const TopkRowArgs* d_rows, int n_rows, int max_top_k,
                    static_cast<size_t>(max_top_k) * (sizeof(float) + sizeof(int));
     dim3 grid1(SAMPLE_NBLOCKS, n_rows);
     topk_partial_rows_kernel<<<grid1, BLOCK_SIZE, smem1, stream>>>(d_rows, vocab_size);
+    IMP_CUDA_CHECK_LAUNCH();
     topk_finalize_rows_kernel<<<n_rows, BLOCK_SIZE, smem2, stream>>>(d_rows, SAMPLE_NBLOCKS);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ============================================================================
@@ -598,6 +602,7 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
     // Phase 1: global max (result in d_max_sum[0]). atomicMax on the int-bitcast
     // of the max is order-independent and exact, so it is already deterministic.
     softmax_max_kernel<<<stats_blocks, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size, sc.d_max_sum);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Phase 2: sum of exp — reads max from device memory (no D2H sync).
     // The default multi-block kernel sums via cross-block FP atomicAdd, whose
@@ -606,10 +611,12 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
     if (deterministic) {
         softmax_sum_device_max_single_block_kernel<<<1, BLOCK_SIZE, 0, stream>>>(
             d_logits, vocab_size, inv_temperature, sc.d_max_sum, sc.d_max_sum + 1);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         softmax_sum_device_max_kernel<<<stats_blocks, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size,
                                                                                inv_temperature, sc.d_max_sum,
                                                                                sc.d_max_sum + 1);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Step 2: Compute probabilities reading max/sum from device memory (no D2H sync)
@@ -617,6 +624,7 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
     softmax_to_pairs_device_kernel<<<pair_blocks, BLOCK_SIZE, 0, stream>>>(d_logits, vocab_size,
                                                                            inv_temperature, sc.d_max_sum,
                                                                            sc.d_keys_in, sc.d_vals_in);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Step 3: extract top_k via DeviceTopK (unsorted), then sort just those k.
     // Much faster than a full radix sort over the whole vocab when k << vocab.
@@ -654,6 +662,7 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
     // Step 4: Top-p filter + sample from sorted top-k
     topp_sample_from_sorted_kernel<<<1, 1, 0, stream>>>(sc.d_keys_out, sc.d_vals_out, top_k, top_p, seed,
                                                         d_result);
+    IMP_CUDA_CHECK_LAUNCH();
 
     int32_t h_result = 0;
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(&h_result, d_result, sizeof(int32_t), cudaMemcpyDeviceToHost, stream));

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -488,6 +488,7 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
         constrain_mask_allow_kernel<<<b, t, 0, stream>>>(d_logits, d_token_categories_, d_token_allow_,
                                                          d_allowed_mask_, vocab_size,
                                                          /*n_classified=*/vocab_size_, /*use_allow=*/true);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
 
@@ -539,6 +540,7 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
                                                                 d_allowed_mask_, vocab_size,
                                                                 /*n_classified=*/vocab_size_,
                                                                 need_token_allow_);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/compute/softmax.cu
+++ b/src/compute/softmax.cu
@@ -1,6 +1,7 @@
 #include "compute/softmax.h"
 #include "compute/warp_reduce.cuh"
 #include "core/tensor.h"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdint>
@@ -179,11 +180,13 @@ void softmax(const Tensor& input, Tensor& output, cudaStream_t stream) {
             softmax_fp32_kernel<<<grid, block, 0, stream>>>(static_cast<const float*>(input.data),
                                                             static_cast<float*>(output.data),
                                                             static_cast<int>(cols));
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         case QType::F16:
             softmax_fp16_kernel<<<grid, block, 0, stream>>>(static_cast<const __half*>(input.data),
                                                             static_cast<__half*>(output.data),
                                                             static_cast<int>(cols));
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         default:
             break;

--- a/src/compute/ssm.cu
+++ b/src/compute/ssm.cu
@@ -24,6 +24,7 @@ void silu_inplace(Tensor& x, cudaStream_t stream) {
     int blocks = static_cast<int>((n + threads - 1) / threads);
     if (x.qtype == QType::F16) {
         silu_inplace_fp16_kernel<<<blocks, threads, 0, stream>>>(static_cast<half*>(x.data), n);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -47,6 +48,7 @@ void relu_sqr_inplace(Tensor& x, cudaStream_t stream) {
     int blocks = static_cast<int>((n + threads - 1) / threads);
     if (x.qtype == QType::F16) {
         relu_sqr_inplace_fp16_kernel<<<blocks, threads, 0, stream>>>(static_cast<half*>(x.data), n);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -74,6 +76,7 @@ void sigmoid_mul(const Tensor& a, const Tensor& b, Tensor& out, cudaStream_t str
         sigmoid_mul_fp16_kernel<<<blocks, threads, 0, stream>>>(static_cast<const half*>(a.data),
                                                                 static_cast<const half*>(b.data),
                                                                 static_cast<half*>(out.data), n);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -94,6 +97,7 @@ void elementwise_mul(const Tensor& a, const Tensor& b, Tensor& out, cudaStream_t
         elementwise_mul_fp16_kernel<<<blocks, threads, 0, stream>>>(static_cast<const half*>(a.data),
                                                                     static_cast<const half*>(b.data),
                                                                     static_cast<half*>(out.data), n);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -173,6 +177,7 @@ void ssm_conv1d_decode_f32_silu(void* conv_state, const Tensor& x_in, const Tens
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
         x_out_f32, channels, conv_kernel);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void ssm_conv1d_decode(void* conv_state, const Tensor& x_in, const Tensor& weight, const Tensor& bias,
@@ -185,6 +190,7 @@ void ssm_conv1d_decode(void* conv_state, const Tensor& x_in, const Tensor& weigh
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
         static_cast<half*>(x_out.data), channels, conv_kernel);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -257,6 +263,7 @@ void ssm_conv1d_prefill(void* conv_state, const Tensor& x_in, const Tensor& weig
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
         static_cast<half*>(x_out.data), n_tokens, channels, conv_kernel, d_real_n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -322,6 +329,7 @@ void ssm_conv1d_prefill_f32_silu(void* conv_state, const Tensor& x_in, const Ten
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
         x_out_f32, n_tokens, channels, conv_kernel, d_real_n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -486,10 +494,13 @@ static void ssm_scan_launch(const half* x, const half* B, const half* C, const h
     bool fused = (z != nullptr);
 
 #define SSM_SCAN_LAUNCH(H_FP16_V, FUSE_V)                                                                   \
-    ssm_scan_kernel<H_FP16_V, FUSE_V>                                                                       \
-        <<<n_heads, threads, smem_bytes, stream>>>(x, B, C, dt, A_log, D, dt_bias, h_state, y, z, n_tokens, \
-                                                   n_heads, head_dim_ssm, state_size, n_groups, s_tiles,    \
-                                                   d_real_n)
+    do {                                                                                                    \
+        ssm_scan_kernel<H_FP16_V, FUSE_V>                                                                   \
+            <<<n_heads, threads, smem_bytes, stream>>>(x, B, C, dt, A_log, D, dt_bias, h_state, y, z,       \
+                                                       n_tokens, n_heads, head_dim_ssm, state_size,         \
+                                                       n_groups, s_tiles, d_real_n);                        \
+        IMP_CUDA_CHECK_LAUNCH();                                                                            \
+    } while (0)
 
     if (fp16) {
         if (fused)
@@ -587,6 +598,7 @@ void group_rmsnorm(const Tensor& x, const Tensor& weight, Tensor& out, int n_gro
                                                                static_cast<const half*>(weight.data),
                                                                static_cast<half*>(out.data), total_dim,
                                                                n_groups, eps);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -87,6 +87,20 @@ void log_message(LogLevel level, const char* file, int line, const char* fmt, ..
         }                                                                            \
     } while (0)
 
+// Post-launch check: place immediately after a kernel `<<<>>>` launch. Surfaces
+// launch-time failures (invalid configuration, missing kernel image, OOM at
+// launch) at the launch site instead of at the next synchronizing call.
+// Uses cudaPeekAtLastError() so the sticky error is NOT cleared — existing
+// downstream IMP_CUDA_CHECK_* handling still sees and propagates it.
+#define IMP_CUDA_CHECK_LAUNCH()                                                      \
+    do {                                                                             \
+        cudaError_t err_ = cudaPeekAtLastError();                                    \
+        if (err_ != cudaSuccess) {                                                   \
+            IMP_LOG_ERROR("CUDA kernel launch failed at %s:%d — %s", __FILE__,       \
+                          __LINE__, cudaGetErrorString(err_));                       \
+        }                                                                            \
+    } while (0)
+
 // Check + return void: for void-returning functions.
 #define IMP_CUDA_CHECK_VOID(call)                                                    \
     do {                                                                             \

--- a/src/exec/decode_pipeline_advance.cu
+++ b/src/exec/decode_pipeline_advance.cu
@@ -57,6 +57,7 @@ void decode_pipeline_advance(int n_rows, const int32_t* slot_tokens, size_t slot
         n_rows, reinterpret_cast<const char*>(slot_tokens), slot_stride_bytes, d_token_ids,
         d_positions, d_context_lens, d_block_tables, n_patches, d_patch_offsets, d_patch_values,
         d_hist_base, hist_stride, d_hist_pos);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/exec/executor.cu
+++ b/src/exec/executor.cu
@@ -51,6 +51,7 @@ void GraphExecutor::pool_hidden_sum(int n_tokens, float* d_out, cudaStream_t str
     const int blocks = (d_model + threads - 1) / threads;
     hidden_pool_sum_kernel<<<blocks, threads, 0, stream>>>(
         static_cast<const __half*>(hidden.data), n_tokens, d_model, d_out);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 int32_t GraphExecutor::forward(const InferenceState& state, cudaStream_t stream) {
@@ -426,6 +427,7 @@ void GraphExecutor::apply_row_filters_(float* lp, int vocab, const InferenceStat
             int blocks = (state.n_banned_tokens + kBanThreads - 1) / kBanThreads;
             ban_logits_kernel<<<blocks, kBanThreads, 0, stream>>>(lp, d_banned_cache_,
                                                                   state.n_banned_tokens, vocab);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
     // Apply logit bias
@@ -672,6 +674,7 @@ void GraphExecutor::masked_sample_async(const InferenceState& state, const Tenso
         int blocks = (state.n_d_banned_tokens + kBanThreads - 1) / kBanThreads;
         ban_logits_kernel<<<blocks, kBanThreads, 0, stream>>>(lp, state.d_banned_tokens,
                                                               state.n_d_banned_tokens, vocab);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Grammar constraint mask (host-computed this step, uploaded stream-ordered).
@@ -720,6 +723,7 @@ void GraphExecutor::forward_decode_async(const InferenceState& state, int32_t* d
         int blocks = (state.n_d_banned_tokens + kBanThreads - 1) / kBanThreads;
         ban_logits_kernel<<<blocks, kBanThreads, 0, stream>>>(
             lp, state.d_banned_tokens, state.n_d_banned_tokens, vocab);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Repetition / frequency / presence penalties — device counter grows each

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -391,6 +391,7 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
                                                                        state.positions, nh, hd,
                                                                        layer_rope_theta, inv_scaling, pairs,
                                                                        cfg.rope_neox, longrope_freqs);
+            IMP_CUDA_CHECK_LAUNCH();
             rope_k_deferred = true;
         } else {
             // Separate path: QK-norm (if present) + RoPE on both Q and K.
@@ -679,11 +680,13 @@ after_attention:
                     static_cast<const float*>(po_fp32_buf), static_cast<const half*>(ly.post_attn_norm.data),
                     static_cast<float*>(fp32_h.data), static_cast<half*>(h.data), model_->config().d_model,
                     eps, norm_w_off_);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 rmsnorm_fp32_accum_to_fp16_kernel<<<n, 256, 0, stream>>>(
                     static_cast<const half*>(po.data), static_cast<const half*>(ly.post_attn_norm.data),
                     static_cast<float*>(fp32_h.data), static_cast<half*>(h.data), model_->config().d_model,
                     eps, norm_w_off_);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             if (layer == 0 && debug_attn_steps) {
                 debug_tensor_stats_all("L0_post_fp32accum_h", view_tokens(h, n), stream);

--- a/src/exec/executor_attention_decode.cu
+++ b/src/exec/executor_attention_decode.cu
@@ -57,6 +57,7 @@
                 static_cast<half*>(cache->v_ptr(kv_layer, 0)), block_stride, row_elems, kv_block_size_d, n,
                 state.max_blocks_per_seq, state.n_sequences, nkv, hd, layer_rope_theta, inv_scaling, pairs,
                 cfg.rope_neox, longrope_freqs);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             write_kv_cache(layer, state, stream);
         }

--- a/src/exec/executor_elementwise.cu
+++ b/src/exec/executor_elementwise.cu
@@ -433,6 +433,7 @@ void device_copy_async(void* dst, const void* src, size_t bytes, cudaStream_t st
         int blocks = static_cast<int>((n4 + threads - 1) / threads);
         device_copy_v4_kernel<<<blocks, threads, 0, stream>>>(static_cast<const uint4*>(src),
                                                               static_cast<uint4*>(dst), n4);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
     cudaError_t e = cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToDevice, stream);
@@ -481,6 +482,7 @@ void add_bias(Tensor& out, const Tensor& bias, cudaStream_t stream) {
     broadcast_add_bias_fp16_kernel<<<blocks, threads, 0, stream>>>(static_cast<half*>(out.data),
                                                                    static_cast<const half*>(bias.data), rows,
                                                                    cols);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused 3-way bias add: applies up to 3 biases in a single kernel launch.
@@ -549,6 +551,7 @@ void add_bias_3way(Tensor& out_a, const Tensor& bias_a, Tensor& out_b, const Ten
         bias_b.data ? static_cast<const half*>(bias_b.data) : nullptr, cols_b,
         bias_c.data ? static_cast<half*>(out_c.data) : nullptr,
         bias_c.data ? static_cast<const half*>(bias_c.data) : nullptr, cols_c, rows);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused residual add + RMSNorm: hidden += residual; output = rmsnorm(hidden, weight).
@@ -616,6 +619,7 @@ void residual_add_rmsnorm(Tensor& hidden, const Tensor& residual, const Tensor& 
                                                        static_cast<const half*>(weight.data),
                                                        static_cast<half*>(output.data), d_model, eps,
                                                        weight_offset);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused add-store + RMSNorm in-place: hidden = rmsnorm(a + b, weight).
@@ -683,6 +687,7 @@ void add_rmsnorm_inplace(const Tensor& a, const Tensor& b, Tensor& hidden, const
                                                       static_cast<half*>(hidden.data),
                                                       static_cast<const half*>(weight.data), d_model, eps,
                                                       weight_offset);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused RMSNorm + residual add: output = rmsnorm(input, weight) + residual.
@@ -748,6 +753,7 @@ void rmsnorm_add_residual(const Tensor& input, const Tensor& weight, const Tenso
                                                        static_cast<const half*>(residual.data),
                                                        static_cast<half*>(output.data), d_model, eps,
                                                        weight_offset);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Create a view of the first n_tokens rows from a [max_tokens, cols] buffer.

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -413,6 +413,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
             rmsnorm_fp32_accum_to_fp16_kernel<<<n, 256, 0, stream>>>(
                 static_cast<const half*>(fo.data), static_cast<const half*>(ly.post_ffn_norm.data),
                 static_cast<float*>(fp32_h.data), static_cast<half*>(h.data), cfg.d_model, eps, norm_w_off_);
+            IMP_CUDA_CHECK_LAUNCH();
         } else if (has_post_ffn_norm && using_fp32_accum && n == 1 && q8 != nullptr &&
                    qscratch_.d8_buf != nullptr && is_dp4a_qtype(ly.w_down.qtype)) {
             // Post-norm FP32 accum decode: fused activation→Q8_1 + GEMV + fused post-norm.
@@ -432,6 +433,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
             rmsnorm_fp32_accum_to_fp16_kernel<<<n, 256, 0, stream>>>(
                 static_cast<const half*>(fo.data), static_cast<const half*>(ly.post_ffn_norm.data),
                 static_cast<float*>(fp32_h.data), static_cast<half*>(h.data), cfg.d_model, eps, norm_w_off_);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             // Non-dp4a paths: activation must produce FP16 intermediate in so.
             switch (cfg.ffn_activation) {
@@ -469,6 +471,7 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                         static_cast<const half*>(fo.data), static_cast<const half*>(ly.post_ffn_norm.data),
                         static_cast<float*>(fp32_h.data), static_cast<half*>(h.data), cfg.d_model, eps,
                         norm_w_off_);
+                    IMP_CUDA_CHECK_LAUNCH();
                 } else if (has_post_ffn_norm) {
                     // Post-FFN norm + residual: h = rmsnorm(fo) + r
                     // Fused: 2 ops → 1 kernel

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -296,6 +296,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         int blocks = static_cast<int>((total / 2 + threads - 1) / threads);
         scale_fp16_kernel<<<blocks, threads, 0, stream>>>(static_cast<half*>(h.data),
                                                           __float2half(cfg.embed_scale), total);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Replace vision token positions with vision embeddings (multimodal)
@@ -320,6 +321,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         int blocks = static_cast<int>((total + threads - 1) / threads);
         fp16_to_fp32_kernel<<<blocks, threads, 0, stream>>>(
             static_cast<const half*>(h.data), static_cast<float*>(view_tokens(fp32_hidden_, n).data), total);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Dump FP32 accumulator for decode debugging
@@ -437,6 +439,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 int blocks = static_cast<int>((total / 2 + threads - 1) / threads);
                 scale_fp16_by_fp16ptr_kernel<<<blocks, threads, 0, stream>>>(
                     static_cast<half*>(h.data), static_cast<const half*>(ly.layer_out_scale.data), total);
+                IMP_CUDA_CHECK_LAUNCH();
                 // Also scale the FP32 residual accumulator so next layer's
                 // attention sees the correctly-scaled residual stream.
                 // Without this the FP32 accum grows unbounded (layer_out_scale
@@ -446,6 +449,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                     scale_fp32_by_fp16ptr_kernel<<<blocks_f32, threads, 0, stream>>>(
                         static_cast<float*>(view_tokens(fp32_hidden_, n).data),
                         static_cast<const half*>(ly.layer_out_scale.data), total);
+                    IMP_CUDA_CHECK_LAUNCH();
                 }
                 if (debug_forward_enabled()) {
                     float sval = 0.0f;
@@ -515,6 +519,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             int blocks = static_cast<int>((total + threads - 1) / threads);
             fp16_to_fp32_kernel<<<blocks, threads, 0, stream>>>(static_cast<const half*>(h.data),
                                                                 static_cast<float*>(fp32_h.data), total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // Layer-diff dump: Snapshot C — end-of-layer state (input to next layer).
@@ -552,6 +557,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 state.kv_manager->d_residual_fc_ptr(),
                 slot,
                 state.kv_manager->residual_n_tokens());
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 
@@ -569,6 +575,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         fp32_to_fp16_rowscale_kernel<<<n, 256, 256 * sizeof(float), stream>>>(
             static_cast<const float*>(view_tokens(fp32_hidden_, n).data), static_cast<half*>(h.data), n,
             cfg.d_model);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ---- Step 3+4: Final RMSNorm + LM head projection ----
@@ -857,6 +864,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         logit_softcap_fp32_kernel<<<blocks, threads, 0, stream>>>(static_cast<float*>(logits_out.data),
                                                                   cfg.final_logit_softcap,
                                                                   1.0f / cfg.final_logit_softcap, n_logits);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ---- Profile summary ----

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -263,6 +263,7 @@ void GraphExecutor::moe_ffn_phase3_route_(int layer, cudaStream_t stream, MoeFfn
                 int thr = 256;
                 int blk = static_cast<int>((total + thr - 1) / thr);
                 scale_fp32_kernel<<<blk, thr, 0, stream>>>(fp32_router, inv_sqrt_d, total);
+                IMP_CUDA_CHECK_LAUNCH();
             }
             // Gate GEMV directly from FP32 router → FP32 logits (no FP16 truncation).
             // Writes to moe_.gate_logits — same buffer the topk gating reads from.
@@ -288,6 +289,7 @@ void GraphExecutor::moe_ffn_phase3_route_(int layer, cudaStream_t stream, MoeFfn
             float inv_sqrt_d = 1.0f / std::sqrt(static_cast<float>(ctx.d));
             scale_fp16_kernel<<<blocks_s, threads_s, 0, stream>>>(static_cast<half*>(router_in.data),
                                                                   __float2half(inv_sqrt_d), total_elems);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 
@@ -645,6 +647,7 @@ void GraphExecutor::moe_ffn_phase7_scatter_(int layer, cudaStream_t stream, MoeF
             fp32_to_fp16_kernel<<<blocks, threads, 0, stream>>>(
                 static_cast<const float*>(moe_.scatter_out.data),
                 static_cast<half*>(ctx.h.data), numel);
+            IMP_CUDA_CHECK_LAUNCH();
         } else {
             IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(ctx.h.data, moe_.scatter_out.data,
                                                static_cast<size_t>(numel) * sizeof(float),
@@ -724,6 +727,7 @@ void GraphExecutor::moe_ffn_phase8_post_(int layer, cudaStream_t stream, MoeFfnC
             static_cast<const half*>(ctx.h.data), static_cast<const half*>(ly.post_ffn_norm.data),
             static_cast<float*>(fp32_h.data), static_cast<half*>(ctx.h.data), cfg.d_model, ctx.eps,
             norm_w_off_);
+        IMP_CUDA_CHECK_LAUNCH();
         if (layer == 0) {
             char buf[64];
             snprintf(buf, sizeof(buf), "L%d_combined_post_post_ffn_norm_fp32accum", layer);

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -739,6 +739,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
                 fp16_to_fp32_kernel<<<blocks, threads, 0, stream>>>(
                     static_cast<const half*>(gate_logits_tmp.data),
                     static_cast<float*>(gate_logits_f32.data), numel);
+                IMP_CUDA_CHECK_LAUNCH();
             } else {
                 IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(gate_logits_f32.data, gate_logits_tmp.data,
                                                    static_cast<size_t>(numel) * sizeof(float),
@@ -790,6 +791,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
         int blocks_s = static_cast<int>((n_weights + threads_s - 1) / threads_s);
         scale_fp32_kernel<<<blocks_s, threads_s, 0, stream>>>(
             static_cast<float*>(routing.expert_weights.data), cfg.expert_weights_scale, n_weights);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Gemma-4: per-expert output scale absorbed into routing weights.
@@ -802,6 +804,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
             static_cast<float*>(routing.expert_weights.data),
             static_cast<const int32_t*>(routing.expert_indices.data),
             static_cast<const half*>(ly.expert_down_scale.data), static_cast<int>(n_weights));
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 

--- a/src/exec/executor_kernels.cu
+++ b/src/exec/executor_kernels.cu
@@ -104,6 +104,7 @@ void attn_gate_split_interleaved(const void* src, void* q_dst, void* gate_dst, i
         attn_gate_split_interleaved_kernel<half><<<grid, threads, 0, stream>>>(
             static_cast<const half*>(src), static_cast<half*>(q_dst), static_cast<half*>(gate_dst), n_tokens,
             nh, hd, q_out_dim);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         // FP32 fallback — uses uint32_t reinterpret since templated half→FP32
         // dispatch requires another instantiation. For now log + fall through

--- a/src/exec/executor_kv_write.cu
+++ b/src/exec/executor_kv_write.cu
@@ -76,6 +76,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
             static_cast<uint8_t*>(cache->v_scale_ptr(kv_layer, 0)), nvfp4_block_stride,
             nvfp4_scale_block_stride, nkv, hd, kv_block_size, n, state.max_blocks_per_seq,
             state.n_sequences);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (use_mxfp4_kv) {
         // MXFP4-KV quantized KV cache write — identical layout to NVFP4 but UE8M0 scales
         Tensor kv = view_tokens(k_, n);
@@ -91,6 +92,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
             static_cast<uint8_t*>(cache->v_scale_ptr(kv_layer, 0)), mxfp4_block_stride,
             mxfp4_scale_block_stride, nkv, hd, kv_block_size, n, state.max_blocks_per_seq,
             state.n_sequences);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (use_int4) {
         // INT4 quantized KV cache write — 2 values packed per byte, per-head scales
         Tensor kv = view_tokens(k_, n);
@@ -105,6 +107,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
             static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
             static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)), int4_block_stride, scale_block_stride, nkv,
             hd, kv_block_size, n, state.max_blocks_per_seq, state.n_sequences);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (use_int8) {
         // INT8 quantized KV cache write path with per-head scales.
         Tensor kv = view_tokens(k_, n);
@@ -119,6 +122,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
             static_cast<half*>(cache->k_scale_ptr(kv_layer, 0)),
             static_cast<half*>(cache->v_scale_ptr(kv_layer, 0)), block_stride, scale_block_stride, nkv, hd,
             kv_block_size, n, state.max_blocks_per_seq, state.n_sequences);
+        IMP_CUDA_CHECK_LAUNCH();
     } else if (use_fp8) {
         // FP8 E4M3 quantized KV cache write path with online calibration.
         //
@@ -178,6 +182,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
             block_tables, static_cast<__nv_fp8_e4m3*>(cache->k_ptr(kv_layer, 0)),
             static_cast<__nv_fp8_e4m3*>(cache->v_ptr(kv_layer, 0)), inv_scale, block_stride, row_elems,
             kv_block_size, n, state.max_blocks_per_seq, state.n_sequences);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         // Standard FP16 KV cache write path — fused K+V in single launch.
         //
@@ -195,6 +200,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
             block_tables, static_cast<half*>(cache->k_ptr(kv_layer, 0)),
             static_cast<half*>(cache->v_ptr(kv_layer, 0)), block_stride, row_elems, kv_block_size, n,
             state.max_blocks_per_seq, state.n_sequences);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ─── Phase 3c: BitDecoding residual write-through (decode only) ────────
@@ -255,6 +261,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
                             src_k_base, src_v_base,
                             static_cast<half*>(base_k), static_cast<half*>(base_v),
                             state.kv_manager->d_residual_widx_ptr(), slot, slot_elems);
+                        IMP_CUDA_CHECK_LAUNCH();
                         // No host advance_residual: ring state lives on device, advanced
                         // once per step by advance_residual_state_kernel in forward_logits.
                     }
@@ -286,6 +293,7 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
                 dim3 grid_multi(n, 2);
                 residual_kv_write_multi_kernel<<<grid_multi, kThreads, 0, stream>>>(
                     src_k_base, src_v_base, d_k_ptrs, d_v_ptrs, slot_elems);
+                IMP_CUDA_CHECK_LAUNCH();
                 cudaFreeAsync(d_k_ptrs, stream);
                 cudaFreeAsync(d_v_ptrs, stream);
                 for (int s = 0; s < n; s++) {

--- a/src/exec/executor_lora.cu
+++ b/src/exec/executor_lora.cu
@@ -91,10 +91,12 @@ void GraphExecutor::lora_delta_(const LoraWeights& w, const void* x, void* y, in
         float* t = static_cast<float*>(lora_scratch_);
         lora_gemv_a_kernel<<<w.r, 256, 0, stream>>>(static_cast<const half*>(w.A),
                                                     static_cast<const half*>(x), t, w.r, w.K);
+        IMP_CUDA_CHECK_LAUNCH();
         int threads = 256;
         int blocks = (w.N + threads - 1) / threads;
         lora_gemv_b_kernel<<<blocks, threads, 0, stream>>>(static_cast<const half*>(w.B), t,
                                                            static_cast<half*>(y), s, w.N, w.r);
+        IMP_CUDA_CHECK_LAUNCH();
         return;
     }
     // Prefill: t = x · A^T  (gemm computes C = alpha · A_in @ B_w^T + beta · C

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -245,6 +245,7 @@ void GraphExecutor::for_each_lm_head_batch_(int n_rows, cudaStream_t stream, boo
             logit_softcap_fp32_kernel<<<blocks, threads, 0, stream>>>(
                 static_cast<float*>(lg.data), cfg.final_logit_softcap,
                 1.0f / cfg.final_logit_softcap, total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         consume(lg, c, csz);
     }
@@ -267,6 +268,7 @@ void GraphExecutor::perplexity_nll_partial(const int32_t* d_tokens, int n_total,
                                 perplexity_nll_kernel<<<csz, 256, 0, stream>>>(
                                     static_cast<const float*>(lg.data), d_tokens, chunk_start + row0,
                                     n_total, V, d_nll, d_match);
+                                IMP_CUDA_CHECK_LAUNCH();
                             });
 }
 
@@ -418,6 +420,7 @@ void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t s
         }
         verify_hist_count_kernel<<<(V + 255) / 256, 256, 0, stream>>>(d_hist, n_hist, V,
                                                                       verify_pen_counts_);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // allow_cutlass=false: verify logits decide (and emit) the accepted batch=1
@@ -430,11 +433,14 @@ void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t s
             verify_penalties_kernel<<<pgrid, 256, 0, stream>>>(
                 static_cast<float*>(lg.data), row0, V, verify_pen_counts_, d_draft, rep_pen,
                 freq_pen, pres_pen);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         dim3 grid(csz, kArgmaxSplits);
         rowwise_argmax_partial_kernel<<<grid, 256, 0, stream>>>(
             static_cast<const float*>(lg.data), V, pvals, pidxs);
+        IMP_CUDA_CHECK_LAUNCH();
         rowwise_argmax_reduce_kernel<<<1, 32, 0, stream>>>(pvals, pidxs, csz, d_out + row0);
+        IMP_CUDA_CHECK_LAUNCH();
     });
 }
 

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -364,6 +364,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         int blocks = static_cast<int>((total + threads - 1) / threads);
         fp16_to_fp32_kernel<<<blocks, threads, 0, stream>>>(static_cast<const half*>(xBC_out.data), conv_f32,
                                                             total);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Per-element dump: post-conv1d post-SiLU FP32 scan input.
@@ -529,6 +530,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                 fp32_to_fp16_kernel<<<blocks_, threads_, 0, stream>>>(y_fp32_postnorm,
                                                                       static_cast<__half*>(y_buf.data),
                                                                       total);
+                IMP_CUDA_CHECK_LAUNCH();
             }
         } else if (use_ref) {
             const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
@@ -621,6 +623,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         fp32_plus_fp16_to_fp16<<<blocks, threads, 0, stream>>>(static_cast<const float*>(fp32_out),
                                                                static_cast<const __half*>(r.data),
                                                                static_cast<__half*>(h.data), total);
+        IMP_CUDA_CHECK_LAUNCH();
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(fp32_out, stream));
     } else {
         gemm_via_handle_(ly.ssm_out_id, y_buf, out_buf, ctx);

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -14,26 +14,29 @@
 
 namespace imp {
 
-namespace {
+void KVCacheManager::free_block_dropping_stale_hash(int block_id) {
+    if (block_id >= 0 && cache_->ref_count(block_id) == 1) {
+        auto hit = block_id_to_hash_.find(block_id);
+        if (hit != block_id_to_hash_.end()) {
+            block_hash_to_id_.erase(hit->second);
+            block_id_to_hash_.erase(hit);
+        }
+    }
+    cache_->free_block(block_id);
+}
 
-// Rollback a partial block allocation: free blocks added after original_size,
-// trim the blocks/hashes vectors, and erase the sequence entries if empty.
-static void rollback_partial_allocation(KVCache* cache, std::unordered_map<int, std::vector<int>>& seq_blocks,
-                                        std::unordered_map<int, std::vector<size_t>>& seq_block_hashes,
-                                        int seq_id, std::vector<int>& blocks, std::vector<size_t>& hashes,
-                                        size_t original_size) {
+void KVCacheManager::rollback_partial_allocation(int seq_id, std::vector<int>& blocks,
+                                                 std::vector<size_t>& hashes, size_t original_size) {
     for (size_t j = original_size; j < blocks.size(); ++j) {
-        cache->free_block(blocks[j]);
+        free_block_dropping_stale_hash(blocks[j]);
     }
     blocks.resize(original_size);
     hashes.resize(original_size);
     if (blocks.empty()) {
-        seq_blocks.erase(seq_id);
-        seq_block_hashes.erase(seq_id);
+        seq_blocks_.erase(seq_id);
+        seq_block_hashes_.erase(seq_id);
     }
 }
-
-}  // anonymous namespace
 
 // ─── Construction / destruction ──────────────────────────────────────
 
@@ -497,6 +500,16 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
 
             // Check if this block already exists in the hash table.
             auto hit = reuse_open ? block_hash_to_id_.find(block_hash) : block_hash_to_id_.end();
+            if (hit != block_hash_to_id_.end() && cache_->ref_count(hit->second) == 0 &&
+                cached_blocks_map_.find(hit->second) == cached_blocks_map_.end()) {
+                // Stale entry: the mapped block is free-listed (ref 0, not
+                // cached). Reusing it would double-own the block. Drop the
+                // entry loudly and treat as a miss.
+                IMP_LOG_WARN("prefix cache: stale hash entry for free block %d — dropping", hit->second);
+                block_id_to_hash_.erase(hit->second);
+                block_hash_to_id_.erase(hit);
+                hit = block_hash_to_id_.end();
+            }
             if (hit != block_hash_to_id_.end()) {
                 int cached_block = hit->second;
 
@@ -527,8 +540,7 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
             int block_id = allocate_block_with_eviction();
             if (block_id < 0) {
                 // Rollback everything we allocated/shared in this call.
-                rollback_partial_allocation(cache_.get(), seq_blocks_, seq_block_hashes_, seq_id, blocks,
-                                            hashes, original_size);
+                rollback_partial_allocation(seq_id, blocks, hashes, original_size);
                 return -1;
             }
 
@@ -541,8 +553,7 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
             // Partial block or prefix caching disabled — plain allocation.
             int block_id = allocate_block_with_eviction();
             if (block_id < 0) {
-                rollback_partial_allocation(cache_.get(), seq_blocks_, seq_block_hashes_, seq_id, blocks,
-                                            hashes, original_size);
+                rollback_partial_allocation(seq_id, blocks, hashes, original_size);
                 return -1;
             }
 
@@ -945,8 +956,10 @@ void KVCacheManager::rollback(int seq_id, int new_seq_len) {
     int blocks_needed = (new_seq_len + cache_->block_size() - 1) / cache_->block_size();
     while (static_cast<int>(blocks.size()) > blocks_needed) {
         // -1 sentinels (StreamingLLM evicted middle slots) need no free.
+        // Hash-registered blocks must leave the prefix-hash table when this
+        // free drops them to ref 0 (stale entry = double-ownership bug).
         if (blocks.back() >= 0)
-            cache_->free_block(blocks.back());
+            free_block_dropping_stale_hash(blocks.back());
         blocks.pop_back();
     }
 

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -311,6 +311,19 @@ public:
     static size_t compute_block_hash(std::span<const int32_t> tokens, size_t parent_hash);
 
 private:
+    // Free a block that is about to leave its owning sequence. When this
+    // free drops the ref count to 0, the block's prefix-hash entries are
+    // erased first — a stale hash->id entry on a free-listed block lets a
+    // later prefix match inc_ref a block the allocator still hands out
+    // (double ownership -> free-list duplicates). See LeakUnderSustainedChurn.
+    void free_block_dropping_stale_hash(int block_id);
+
+    // Rollback a partial block allocation: free blocks added after
+    // original_size, trim the blocks/hashes vectors, and erase the
+    // sequence entries if empty.
+    void rollback_partial_allocation(int seq_id, std::vector<int>& blocks, std::vector<size_t>& hashes,
+                                     size_t original_size);
+
     // Underlying block-level cache (owns the memory pool).
     std::unique_ptr<KVCache> cache_;
 

--- a/src/quant/dequant_gptq.cu
+++ b/src/quant/dequant_gptq.cu
@@ -1,4 +1,5 @@
 #include "quant/dequant_gptq.h"
+#include "core/logging.h"
 #include <cuda_fp16.h>
 #include <cstdint>
 
@@ -64,6 +65,7 @@ void dequant_gptq4(half* out, const int32_t* qweight, const int32_t* qzeros, con
     dim3 block(16, 16);
     dim3 grid((N + block.x - 1) / block.x, (K + block.y - 1) / block.y);
     dequant_gptq4_kernel<<<grid, block, 0, stream>>>(out, qweight, qzeros, scales, g_idx, N, K, group_size);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/quant/dequant_gpu.cu
+++ b/src/quant/dequant_gpu.cu
@@ -738,6 +738,7 @@ void dequant_gpu_fp8(const void* src, void* dst, QType qtype, int rows, int cols
             dequant_q6k_to_fp8_kernel<<<total_blocks, 128, 0, stream>>>(static_cast<const uint8_t*>(src),
                                                                         static_cast<uint8_t*>(dst),
                                                                         total_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
         default:
@@ -755,6 +756,7 @@ void dequant_gpu_fp8(const void* src, void* dst, QType qtype, int rows, int cols
     case QType::QTYPE:                                                                                    \
         KERNEL<<<blocks, threads, 0, stream>>>(static_cast<const uint8_t*>(src), static_cast<half*>(dst), \
                                                rows, cols);                                               \
+        IMP_CUDA_CHECK_LAUNCH();                                                                          \
         break;
 
 void dequant_gpu(const void* src, void* dst, QType qtype, int rows, int cols, cudaStream_t stream) {
@@ -772,6 +774,7 @@ void dequant_gpu(const void* src, void* dst, QType qtype, int rows, int cols, cu
             dequant_q6k_v2_kernel<<<total_q6k_blocks, 128, 0, stream>>>(static_cast<const uint8_t*>(src),
                                                                         static_cast<half*>(dst),
                                                                         total_q6k_blocks);
+            IMP_CUDA_CHECK_LAUNCH();
             break;
         }
 

--- a/src/quant/fp8_quant.cu
+++ b/src/quant/fp8_quant.cu
@@ -214,9 +214,11 @@ float calibrate_fp8_scale(const Tensor& input, cudaStream_t stream) {
     // First-level reduction: per-block absmax.
     absmax_reduce_kernel<<<grid, kBlockSize, 0, stream>>>(static_cast<const half*>(input.data), d_block_maxes,
                                                           n);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Second-level reduction: reduce block results to a single scalar.
     absmax_final_reduce_kernel<<<1, kBlockSize, 0, stream>>>(d_block_maxes, d_result, grid);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Copy result back to host.
     float absmax = 0.0f;
@@ -265,13 +267,16 @@ void calibrate_and_quantize_fp8_async(const void* input_fp16, void* output_fp8, 
     // Pass 1: absmax reduction
     absmax_reduce_kernel<<<reduce_grid, kBlockSize, 0, stream>>>(static_cast<const half*>(input_fp16),
                                                                  d_block_maxes, n);
+    IMP_CUDA_CHECK_LAUNCH();
 
     absmax_final_reduce_kernel<<<1, kBlockSize, 0, stream>>>(d_block_maxes, d_absmax, reduce_grid);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Pass 2: fused scale computation + quantize (reads absmax from device)
     calibrate_quantize_fp8_kernel<<<grid, kBlockSize, 0, stream>>>(static_cast<const half*>(input_fp16),
                                                                    static_cast<uint8_t*>(output_fp8),
                                                                    d_absmax, d_scale_out, n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---- quantize_fp8_rows_async ----------------------------------------------
@@ -325,6 +330,7 @@ void quantize_fp8_rows_async(const void* input_fp16, void* output_fp8, int rows,
     quantize_fp8_rows_kernel<<<rows, 256, 0, stream>>>(static_cast<const half*>(input_fp16),
                                                        static_cast<uint8_t*>(output_fp8), K,
                                                        d_row_scales);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---- quantize_fp16_to_fp8_e4m3 (Tensor API) ------------------------------
@@ -371,8 +377,10 @@ void quantize_fp16_to_fp8_e4m3(const Tensor& input, Tensor& output, float* d_sca
 
     absmax_reduce_kernel<<<grid, kBlockSize, 0, stream>>>(static_cast<const half*>(input.data), d_block_maxes,
                                                           n);
+    IMP_CUDA_CHECK_LAUNCH();
 
     absmax_final_reduce_kernel<<<1, kBlockSize, 0, stream>>>(d_block_maxes, d_scale_device, grid);
+    IMP_CUDA_CHECK_LAUNCH();
 
     float absmax = 0.0f;
     IMP_CUDA_CHECK_LOG(

--- a/src/quant/mxfp4_gemm.cu
+++ b/src/quant/mxfp4_gemm.cu
@@ -462,10 +462,12 @@ void gemv_mxfp4_kpar(const CutlassMxFP4Weight& W, const half* x, half* y, int N,
         gemv_mxfp4_multirow_kernel<kMRWarps>
             <<<mr_blocks, kMRThreads, 0, stream>>>(static_cast<const uint8_t*>(W.data),
                                                    static_cast<const uint8_t*>(W.linear_scales), x, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         gemv_mxfp4_kpar_kernel<<<N, kKparThreads, 0, stream>>>(static_cast<const uint8_t*>(W.data),
                                                                static_cast<const uint8_t*>(W.linear_scales),
                                                                x, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -477,9 +479,11 @@ void gemv_mxfp4_kpar_fp32(const CutlassMxFP4Weight& W, const half* x, float* y, 
         gemv_mxfp4_multirow_fp32_kernel<kMRWarps>
             <<<mr_blocks, kMRThreads, 0, stream>>>(static_cast<const uint8_t*>(W.data),
                                                    static_cast<const uint8_t*>(W.linear_scales), x, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     } else {
         gemv_mxfp4_kpar_fp32_kernel<<<N, kKparThreads, 0, stream>>>(
             static_cast<const uint8_t*>(W.data), static_cast<const uint8_t*>(W.linear_scales), x, y, N, K);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 }
 
@@ -492,6 +496,7 @@ void gemv_mxfp4_qkv_fused(const CutlassMxFP4Weight& wq, const CutlassMxFP4Weight
         static_cast<const uint8_t*>(wk.data), static_cast<const uint8_t*>(wk.linear_scales),
         static_cast<const uint8_t*>(wv.data), static_cast<const uint8_t*>(wv.linear_scales), x, yq, yk, yv,
         q_rows, k_rows, v_rows, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void gemv_mxfp4_gate_up_fused(const CutlassMxFP4Weight& wg, const CutlassMxFP4Weight& wu, const half* x,
@@ -500,6 +505,7 @@ void gemv_mxfp4_gate_up_fused(const CutlassMxFP4Weight& wg, const CutlassMxFP4We
         static_cast<const uint8_t*>(wg.data), static_cast<const uint8_t*>(wg.linear_scales),
         static_cast<const uint8_t*>(wu.data), static_cast<const uint8_t*>(wu.linear_scales), x, yg, yu, rows,
         K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void gemv_mxfp4_residual(const CutlassMxFP4Weight& W, const half* x, half* y, const half* residual, int N,
@@ -507,6 +513,7 @@ void gemv_mxfp4_residual(const CutlassMxFP4Weight& W, const half* x, half* y, co
     gemv_mxfp4_residual_kernel<<<N, kKparThreads, 0, stream>>>(static_cast<const uint8_t*>(W.data),
                                                                static_cast<const uint8_t*>(W.linear_scales),
                                                                x, y, residual, N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void gemv_mxfp4_swiglu_residual(const CutlassMxFP4Weight& W, const half* gate, const half* up, half* y,
@@ -515,6 +522,7 @@ void gemv_mxfp4_swiglu_residual(const CutlassMxFP4Weight& W, const half* gate, c
                                                                       static_cast<const uint8_t*>(
                                                                           W.linear_scales),
                                                                       gate, up, y, residual, N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void gemv_mxfp4_geglu_residual(const CutlassMxFP4Weight& W, const half* gate, const half* up, half* y,
@@ -523,6 +531,7 @@ void gemv_mxfp4_geglu_residual(const CutlassMxFP4Weight& W, const half* gate, co
                                                                      static_cast<const uint8_t*>(
                                                                          W.linear_scales),
                                                                      gate, up, y, residual, N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // One-time L1 cache carveout for MXFP4 GEMV kernels (bandwidth-bound, no SMEM).

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -236,6 +236,7 @@ void gemm_nvfp4(const NvFP4QuantResult& A, const Tensor& B, Tensor& C, cudaStrea
             const int grid = static_cast<int>((total + block - 1) / block);
             nvfp4_fp32_to_fp16_kernel<<<grid, block, 0, stream>>>(
                 static_cast<const float*>(y32), reinterpret_cast<half*>(C.data), total);
+            IMP_CUDA_CHECK_LAUNCH();
             return;
         }
         // Scratch unavailable (capture-active without workspace): fall through —

--- a/src/quant/nvfp4_quant.cu
+++ b/src/quant/nvfp4_quant.cu
@@ -399,6 +399,7 @@ float calibrate_nvfp4_scales(const Tensor& input, cudaStream_t stream, float* d_
 
     absmax_kernel<<<num_blocks, kBlockSize, 0, stream>>>(reinterpret_cast<const half*>(input.data),
                                                          n_elements, d_global_max);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Read back the result.
     float h_absmax = 0.0f;
@@ -449,6 +450,7 @@ void quantize_fp16_to_nvfp4(const Tensor& input, NvFP4QuantResult& result, cudaS
     quantize_nvfp4_kernel<<<num_blocks, kBlockSize, 0, stream>>>(reinterpret_cast<const half*>(input.data),
                                                                  d_packed, d_micro_scales, tensor_scale, N,
                                                                  K);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Fill result.
     result.packed_data = d_packed;
@@ -485,6 +487,7 @@ void quantize_fp16_to_nvfp4_async(const Tensor& input, NvFP4QuantResult& result,
 
     absmax_kernel<<<absmax_blocks, kBlockSize, 0, stream>>>(reinterpret_cast<const half*>(input.data),
                                                             n_elements, d_absmax_buf);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // Step 2: Allocate output buffers
     int64_t packed_bytes = N * (K / 2);
@@ -502,6 +505,7 @@ void quantize_fp16_to_nvfp4_async(const Tensor& input, NvFP4QuantResult& result,
     quantize_nvfp4_from_absmax_kernel<<<num_blocks, kBlockSize, 0, stream>>>(
         reinterpret_cast<const half*>(input.data), d_packed, d_micro_scales, d_absmax_buf, d_tensor_scale_buf,
         N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 
     result.packed_data = d_packed;
     result.micro_scales = d_micro_scales;
@@ -524,6 +528,7 @@ void dequantize_nvfp4_to_fp16(const NvFP4QuantResult& quant, void* output_fp16, 
         reinterpret_cast<const uint8_t*>(quant.packed_data),
         reinterpret_cast<const uint8_t*>(quant.micro_scales), quant.tensor_scale,
         reinterpret_cast<half*>(output_fp16), N, K);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -593,6 +598,7 @@ void dequantize_nvfp4_moe_to_fp16(const NvFP4MoEQuantResult& result, void* outpu
         reinterpret_cast<const uint8_t*>(result.micro_scales), result.tensor_scales,
         reinterpret_cast<half*>(output_fp16), result.n_experts, result.N, result.K,
         result.expert_stride_packed, result.expert_stride_ms);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void free_nvfp4_result(NvFP4QuantResult& result) {
@@ -662,6 +668,7 @@ void quantize_packed_experts_to_nvfp4(const void* packed_ggml_data, QType qtype,
         if (absmax_blocks > 2048)
             absmax_blocks = 2048;
         absmax_kernel<<<absmax_blocks, kBlockSize, 0, stream>>>(scratch, n_elements, d_global_max);
+        IMP_CUDA_CHECK_LAUNCH();
 
         float h_absmax = 0.0f;
         IMP_CUDA_CHECK_LOG(
@@ -680,6 +687,7 @@ void quantize_packed_experts_to_nvfp4(const void* packed_ggml_data, QType qtype,
                                                                        d_micro_scales + e * expert_ms_bytes,
                                                                        ts, static_cast<int64_t>(eff),
                                                                        static_cast<int64_t>(K));
+        IMP_CUDA_CHECK_LAUNCH();
 
         // Must sync before scratch is reused by next expert
         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -1011,6 +1011,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                                                      config_.ignore_eos ? 1 : 0, d_penalty_ring_,
                                                      penalty_prefix_len_, d_penalty_count_,
                                                      d_step_limit_, d_burst_done_mapped_, handle_);
+        IMP_CUDA_CHECK_LAUNCH();
 
         // 5c. End capture
         cudaGraph_t captured_body = nullptr;
@@ -1311,6 +1312,7 @@ __global__ void pipeline_advance_kernel(int* __restrict__ d_pos, int* __restrict
 
 void launch_pipeline_advance(int* d_pos, int* d_ctx, cudaStream_t stream) {
     pipeline_advance_kernel<<<1, 1, 0, stream>>>(d_pos, d_ctx);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -40,7 +40,7 @@ uint64_t Engine::model_fingerprint_() const {
     uint64_t h = 0xcbf29ce484222325ULL;
     const auto& c = model_->config();
     const uint32_t ids[] = {
-        std::to_underlying(c.arch),    static_cast<uint32_t>(c.n_layers),
+        static_cast<uint32_t>(std::to_underlying(c.arch)), static_cast<uint32_t>(c.n_layers),
         static_cast<uint32_t>(c.n_heads), static_cast<uint32_t>(c.n_kv_heads),
         static_cast<uint32_t>(c.d_model), static_cast<uint32_t>(c.d_ff),
         static_cast<uint32_t>(c.vocab_size), static_cast<uint32_t>(c.head_dim),

--- a/src/vision/vision_encoder.cu
+++ b/src/vision/vision_encoder.cu
@@ -530,6 +530,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
 
     // ---- Step 1: Extract patches ----
     extract_patches_kernel<<<np, 256, 0, stream>>>(d_pixels, d_patches_, img, img, ps, grid, grid, patch_dim);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // ---- Step 2: Patch embedding: patches @ patch_embd_w^T + bias -> hidden ----
     // patch_embd_w: [hidden_size, patch_dim]
@@ -542,6 +543,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
         int total = np * hd;
         add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
             d_hidden_, static_cast<const half*>(model_->patch_embd_b.data), np, hd);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ---- Step 3: Add position embeddings ----
@@ -549,6 +551,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
         int total = np * hd;
         add_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
             d_hidden_, static_cast<const half*>(model_->position_embd.data), d_hidden_, total);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ---- Step 4: Transformer layers ----
@@ -559,6 +562,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
         vision_layernorm_kernel<<<np, 256, 0, stream>>>(d_hidden_, static_cast<const half*>(lw.ln1_w.data),
                                                         static_cast<const half*>(lw.ln1_b.data), d_residual_,
                                                         hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
 
         // Q, K, V projections
         vision_gemm(d_residual_, static_cast<const half*>(lw.wq.data), d_q_, np, hd, hd, 1.0f, 0.0f, stream);
@@ -571,12 +575,15 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
             add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_q_,
                                                                      static_cast<const half*>(lw.bq.data), np,
                                                                      hd);
+            IMP_CUDA_CHECK_LAUNCH();
             add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_k_,
                                                                      static_cast<const half*>(lw.bk.data), np,
                                                                      hd);
+            IMP_CUDA_CHECK_LAUNCH();
             add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_v_,
                                                                      static_cast<const half*>(lw.bv.data), np,
                                                                      hd);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // Multi-head attention via batched GEMM
@@ -627,6 +634,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
         // Non-causal softmax
         int total_rows = nh * np;
         softmax_2d_kernel<<<total_rows, 256, 0, stream>>>(d_attn_scores_, np);
+        IMP_CUDA_CHECK_LAUNCH();
 
         // attn_out = scores @ V
         {
@@ -663,6 +671,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
             add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_residual_,
                                                                      static_cast<const half*>(lw.bo.data), np,
                                                                      hd);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // Residual add: hidden += attn_output
@@ -670,12 +679,14 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
             int total = np * hd;
             add_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_hidden_, d_residual_, d_hidden_,
                                                                         total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // Pre-FFN LayerNorm
         vision_layernorm_kernel<<<np, 256, 0, stream>>>(d_hidden_, static_cast<const half*>(lw.ln2_w.data),
                                                         static_cast<const half*>(lw.ln2_b.data), d_residual_,
                                                         hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
 
         // FFN up: residual @ ffn_up_w^T + bias -> ffn
         vision_gemm(d_residual_, static_cast<const half*>(lw.ffn_up_w.data), d_ffn_, np, ff, hd, 1.0f, 0.0f,
@@ -684,12 +695,14 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
             int total = np * ff;
             add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
                 d_ffn_, static_cast<const half*>(lw.ffn_up_b.data), np, ff);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // GELU activation
         {
             int total = np * ff;
             gelu_tanh_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_ffn_, total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // FFN down: ffn @ ffn_down_w^T + bias -> residual
@@ -699,6 +712,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
             int total = np * hd;
             add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
                 d_residual_, static_cast<const half*>(lw.ffn_down_b.data), np, hd);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // Residual add: hidden += ffn_output
@@ -706,6 +720,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
             int total = np * hd;
             add_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_hidden_, d_residual_, d_hidden_,
                                                                         total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 
@@ -715,6 +730,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
                                                         static_cast<const half*>(model_->post_norm_w.data),
                                                         static_cast<const half*>(model_->post_norm_b.data),
                                                         d_hidden_, hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ---- Step 6: Average pool 4x4 spatial ----
@@ -727,6 +743,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
 
     avg_pool_spatial_kernel<<<n_pooled, 256, 0, stream>>>(d_hidden_, d_pooled_, grid, grid, hd, pool_factor,
                                                           out_h, out_w);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // ---- Step 7: Multimodal projector ----
     // RMSNorm -> Linear -> RMSNorm
@@ -735,6 +752,7 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
     if (model_->mm_pre_norm_w.data) {
         vision_rmsnorm_kernel<<<n_pooled, 256, 0, stream>>>(
             d_pooled_, static_cast<const half*>(model_->mm_pre_norm_w.data), d_pooled_, hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Linear projection: [256, 1152] @ mm_proj_w^T + bias -> [256, d_model]
@@ -745,12 +763,14 @@ bool VisionEncoder::encode_impl(const half* d_pixels, half* d_output, cudaStream
         int total = n_pooled * lm_d_model_;
         add_bias_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
             d_output, static_cast<const half*>(model_->mm_proj_b.data), n_pooled, lm_d_model_);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Post-projection RMSNorm
     if (model_->mm_post_norm_w.data) {
         vision_rmsnorm_kernel<<<n_pooled, 256, 0, stream>>>(
             d_output, static_cast<const half*>(model_->mm_post_norm_w.data), d_output, lm_d_model_, eps);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     return true;
@@ -778,6 +798,7 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
 
     // ---- Patch embed (no bias) ----
     extract_patches_kernel<<<np, 256, 0, stream>>>(d_pixels, d_patches_, img, img, ps, grid, grid, patch_dim);
+    IMP_CUDA_CHECK_LAUNCH();
     vision_gemm(d_patches_, static_cast<const half*>(model_->patch_embd_w.data), d_hidden_, np, hd, patch_dim,
                 1.0f, 0.0f, stream);
 
@@ -788,6 +809,7 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
         axial_pos_add_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
             d_hidden_, static_cast<const half*>(model_->position_embd.data), d_pos_x_, d_pos_y_, np, hd,
             pos_size);
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // ---- 27 transformer layers ----
@@ -798,6 +820,7 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
         // pre-attention RMSNorm (full-width, weighted)
         vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
             d_hidden_, static_cast<const half*>(lw.ln1_w.data), d_residual_, hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
 
         // Q, K, V projections (no bias)
         vision_gemm(d_residual_, static_cast<const half*>(lw.wq.data), d_q_, np, hd, hd, 1.0f, 0.0f, stream);
@@ -807,18 +830,23 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
         // per-head q/k RMSNorm (weighted [head_dim]) → 2D RoPE; per-head v RMSNorm (weightless)
         vision_rmsnorm_opt_kernel<<<rows, 64, 0, stream>>>(
             d_q_, static_cast<const half*>(lw.q_norm.data), d_q_, head_dim, eps);
+        IMP_CUDA_CHECK_LAUNCH();
         vision_rmsnorm_opt_kernel<<<rows, 64, 0, stream>>>(
             d_k_, static_cast<const half*>(lw.k_norm.data), d_k_, head_dim, eps);
+        IMP_CUDA_CHECK_LAUNCH();
         {
             int pairs = (head_dim / 2) / 2;
             int total = np * nh * pairs;
             int blocks = (total + 127) / 128;
             vision_rope2d_neox_kernel<<<blocks, 128, 0, stream>>>(d_q_, d_pos_x_, d_pos_y_, np, nh, head_dim,
                                                                   rope_base);
+            IMP_CUDA_CHECK_LAUNCH();
             vision_rope2d_neox_kernel<<<blocks, 128, 0, stream>>>(d_k_, d_pos_x_, d_pos_y_, np, nh, head_dim,
                                                                   rope_base);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         vision_rmsnorm_opt_kernel<<<rows, 64, 0, stream>>>(d_v_, nullptr, d_v_, head_dim, eps);
+        IMP_CUDA_CHECK_LAUNCH();
 
         // attention: scores = Q @ K^T, kq_scale = 1.0 (q/k-norm controls magnitude)
         {
@@ -833,6 +861,7 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
                                        CUBLAS_GEMM_DEFAULT);
         }
         softmax_2d_kernel<<<nh * np, 256, 0, stream>>>(d_attn_scores_, np);
+        IMP_CUDA_CHECK_LAUNCH();
         {
             auto handle = get_vision_cublas_handle();
             cublasSetStream(handle, stream);
@@ -850,15 +879,18 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
         // sandwich: post-attention RMSNorm BEFORE residual add
         vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
             d_residual_, static_cast<const half*>(lw.attn_post_norm.data), d_residual_, hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
         {
             int total = np * hd;
             add_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_hidden_, d_residual_, d_hidden_,
                                                                         total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
 
         // pre-FFN RMSNorm → GeGLU(up, gate) → down
         vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
             d_hidden_, static_cast<const half*>(lw.ln2_w.data), d_residual_, hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
         vision_gemm(d_residual_, static_cast<const half*>(lw.ffn_up_w.data), d_ffn_, np, ff, hd, 1.0f, 0.0f,
                     stream);
         vision_gemm(d_residual_, static_cast<const half*>(lw.ffn_gate_w.data), d_gate_, np, ff, hd, 1.0f, 0.0f,
@@ -866,17 +898,21 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
         {
             int total = np * ff;
             gelu_tanh_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_gate_, total);
+            IMP_CUDA_CHECK_LAUNCH();
             mul_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_gate_, d_ffn_, d_ffn_, total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
         vision_gemm(d_ffn_, static_cast<const half*>(lw.ffn_down_w.data), d_residual_, np, hd, ff, 1.0f, 0.0f,
                     stream);
         // sandwich: post-FFN RMSNorm BEFORE residual add
         vision_rmsnorm_opt_kernel<<<np, 256, 0, stream>>>(
             d_residual_, static_cast<const half*>(lw.ffn_post_norm.data), d_residual_, hd, eps);
+        IMP_CUDA_CHECK_LAUNCH();
         {
             int total = np * hd;
             add_tensors_kernel<<<(total + 255) / 256, 256, 0, stream>>>(d_hidden_, d_residual_, d_hidden_,
                                                                         total);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 
@@ -886,6 +922,7 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
     int n_pooled = out_h * out_w;
     avg_pool_spatial_kernel<<<n_pooled, 256, 0, stream>>>(d_hidden_, d_pooled_, grid, grid, hd, pool, out_h,
                                                           out_w);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // ---- Fused FP32 tail: ×√hd → (x-std_bias)*std_scale → pre-projection RMSNorm.
     // Gemma vision activations reach ~3000; ×√hd would overflow FP16 if stored, so
@@ -893,6 +930,7 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
     gemma4v_tail_norm_kernel<<<n_pooled, 256, hd * sizeof(float), stream>>>(
         d_pooled_, static_cast<const half*>(model_->std_bias.data),
         static_cast<const half*>(model_->std_scale.data), d_pooled_, hd, sqrtf(static_cast<float>(hd)), eps);
+    IMP_CUDA_CHECK_LAUNCH();
 
     // ---- Linear projection ----
     vision_gemm(d_pooled_, static_cast<const half*>(model_->mm_proj_w.data), d_output, n_pooled, lm_d_model_,
@@ -910,6 +948,7 @@ void launch_replace_vision_embeddings(half* hidden, const int32_t* token_ids, co
     replace_vision_embeddings_v2_kernel<<<n_vision_tokens, 256, 0, stream>>>(hidden, token_ids, vision_emb,
                                                                              vision_token_id, n_tokens,
                                                                              d_model, n_vision_tokens);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -1086,6 +1086,56 @@ TEST(KVCacheManagerTest, EvictAllCachedBlocksPoolIntegrity) {
     EXPECT_EQ(mgr->num_free_blocks(), 8);  // All returned to free pool
 }
 
+// Leak-under-churn regression: sustained allocate / prefix-register / rollback /
+// free / evict cycles. After every full drain the pool must return EXACTLY to
+// baseline — any monotonic drift in free/cached/reclaimable/active counters is
+// a leak or double-free in the block bookkeeping.
+TEST(KVCacheManagerTest, LeakUnderSustainedChurn) {
+    SKIP_IF_NO_CUDA();
+
+    constexpr int kPoolBlocks = 32;
+    constexpr int kCycles = 200;
+    auto mgr = MakeManager(kPoolBlocks);
+    mgr->set_prefix_caching_enabled(true);
+
+    for (int cycle = 0; cycle < kCycles; ++cycle) {
+        const int seq_base = cycle * 3;
+        // 3 sequences per cycle with overlapping prefixes (8 rotating prefix
+        // families) and varying lengths (32..80 tokens = 2..5 blocks).
+        for (int s = 0; s < 3; ++s) {
+            const int seq_id = seq_base + s;
+            const int n_tokens = 32 + ((cycle + s) % 4) * 16;
+            std::vector<int32_t> tokens(n_tokens);
+            std::iota(tokens.begin(), tokens.end(), (cycle % 8) * 1000);
+            int reused = mgr->allocate_blocks_with_prefix(seq_id, tokens);
+            if (reused < 0) {
+                // Pool pressure: reclaim cached blocks and retry once.
+                while (mgr->evict_cached_block()) {
+                }
+                reused = mgr->allocate_blocks_with_prefix(seq_id, tokens);
+            }
+            ASSERT_GE(reused, 0) << "alloc failed after evict-all, cycle " << cycle;
+            mgr->register_block_hashes(seq_id, tokens);
+            // Interleave speculative-style rollbacks (partial-block frees).
+            if ((cycle + s) % 5 == 0)
+                mgr->rollback(seq_id, n_tokens / 2);
+        }
+        for (int s = 0; s < 3; ++s)
+            mgr->free_sequence(seq_base + s);
+
+        // Every 10th cycle: drain the cache and assert exact pool baseline.
+        if (cycle % 10 == 9) {
+            while (mgr->evict_cached_block()) {
+            }
+            ASSERT_EQ(mgr->num_cached_blocks(), 0) << "cycle " << cycle;
+            ASSERT_EQ(mgr->num_free_blocks(), kPoolBlocks) << "cycle " << cycle;
+            ASSERT_EQ(mgr->num_reclaimable_cached_blocks(), 0) << "cycle " << cycle;
+            ASSERT_EQ(mgr->num_active_sequences(), 0) << "cycle " << cycle;
+            ASSERT_EQ(mgr->total_allocated_blocks(), 0) << "cycle " << cycle;
+        }
+    }
+}
+
 // ============================================================================
 // Edge case tests
 // ============================================================================

--- a/tests/test_tool_stream_filter.cpp
+++ b/tests/test_tool_stream_filter.cpp
@@ -22,6 +22,7 @@
 
 #include <random>
 #include <string>
+#include <tuple>
 #include <vector>
 
 using imp::ChatTemplateFamily;
@@ -235,7 +236,7 @@ TEST(ToolStreamFilterChatML, StreamedArgsHandleStringsEscapesAndAngles) {
         EXPECT_EQ(r.calls[0].arguments, args_json);
         ASSERT_EQ(r.delta_concats.size(), 1u);
         EXPECT_EQ(r.delta_concats[0], args_json);
-        EXPECT_NO_THROW(json::parse(r.calls[0].arguments)) << "chunk=" << chunk;
+        EXPECT_NO_THROW(std::ignore = json::parse(r.calls[0].arguments)) << "chunk=" << chunk;
         EXPECT_EQ(r.content, "");
     }
 }

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -59,6 +59,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/attention_paged_nvfp4_tc.cu" = "(c) 845 code LOC — NVFP4 tensor-core paged-attn family (decode/splitk/reduce) — shared TC path"
 "src/compute/attention_fmha_mxfp4_sm120.cu" = "(c) 810 code LOC — single MXFP4 FA2 attention kernel family"
 "src/compute/gemm.cu" = "(c) 613 code LOC — one module: generic cuBLAS GEMM wrapper + algo-reselect/fallback chain + packed-weight leak guards (pushed over 600 by the #925 defense-in-depth guards)"
+"src/compute/gemm_dp4a.cu" = "(c) 601 code LOC — one dp4a q8_1 family: activation/rmsnorm quantize kernels + the per-qtype GEMV launcher set (pushed to 601 by the 2026-07-17 post-launch error checks)"
 "src/compute/gemm_grouped_nvfp4_smallM.cu" = "(c) 718 code LOC — one small-M grouped-GEMM family (software-ref + prod + smoke variants)"
 "src/compute/schema_constrain.cu" = "(c) 676 code LOC — one module: schema-constrained decode token-mask compute (host-side)"
 "src/compute/mtp_forward.cu" = "(c) 651 code LOC — MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature"


### PR DESCRIPTION
## Summary

First gated work-item batch of the dispatch-hardening campaign (Phase-0 baseline + claim matrix: `docs/audit/DISPATCH_BASELINE_2026_07_17.md`).

- **399 post-launch error checks** via new `IMP_CUDA_CHECK_LAUNCH()` (cudaPeekAtLastError: logs file:line at the launch site, does NOT clear the sticky error — downstream `IMP_CUDA_CHECK_*` propagation unchanged). Coverage went from ~1% to 100% of `<<<>>>` sites in src/; deliberate skips only where the error is drained for a handled fallback (paged-attention splitk).
- **fix(kv): stale prefix-hash entries after rollback = block double-ownership.** `rollback()` / `rollback_partial_allocation()` freed hash-registered blocks without erasing the hash maps; a later same-prefix allocation inc_ref'd a free-listed block (free count exceeded pool size, silent cross-request KV corruption under pool pressure + retry). Fixed in both rollback paths + a WARN guard in the reuse path. Found by the new `LeakUnderSustainedChurn` regression test (200 churn cycles, exact pool-baseline assertions).
- **Warning cleanup**: full rebuild is now 0 warnings under -Wall -Wextra -Wpedantic.
- `gemm_dp4a.cu` allowlisted at 601 code LOC (+1 from checks, cohesive dp4a q8_1 family).

## Validation

- Build: 0 warnings. File-size gate OK.
- Unit 37/37, full GPU suite 0 failures, KVCacheManager 45/45 (incl. new churn test), PrefixCacheE2E 4/4 with Qwen3-4B Q8_0.
- `make verify-fast` green (perf gate, long-ctx prefill, graphs ON/OFF gate, degeneration smoke).
- Decode perf gate (same-day baseline, median of 5 isolated trials, spec-OFF, Qwen3-Coder-30B NVFP4): tg256 at pp512 402.59 -> 402.90 (noise). Repro one-liner + details in `docs/audit/PERF_LOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fTwmujYTCJmRBRr1xoevs