### PR TITLE
hardening: RAII owners for CUDA graph handles

### DIFF
--- a/docs/audit/PERF_LOG.md
+++ b/docs/audit/PERF_LOG.md
@@ -4,6 +4,22 @@ Append-only. Each entry: date, build, protocol, before/after. Newest first.
 
 ---
 
+## 2026-07-17 · CUDA-graph RAII owners (WI-3) — decode neutral
+
+`CudaGraph`/`CudaGraphExec` move-only owners in core/cuda_raii.h; adopted by
+CudaGraphCapture, CudaGraphConditionalRunner, SpecVerifyGraph and the
+spec-capture locals — every manual `cudaGraphDestroy`/`cudaGraphExecDestroy`
++ null-out pair replaced by reset()/move, throw paths structurally safe.
+Semantics preserved 1:1 (exec-update fast path, drop_graph_keep_exec,
+mem-trim-on-reset). Validation: GPU suite 0 fail, capture/green-ctx tests
+11/11, DegenerationTest 5/5, verify-fast OK. Decode (same harness as
+baseline, 5 trials, spec-OFF Coder-30B): tg256 402.59 -> 402.92 (+0.08%,
+noise). Note: the "Engine teardown: cleared a leaked CUDA error (graph
+update constraint)" WARN in the Degeneration battery is PRE-EXISTING
+(reproduced on unmodified main, same day) — the ExecUpdate->reinstantiate
+fallback has always left the sticky error for the teardown net; candidate
+one-line follow-up: clear it at the fallback site.
+
 ## 2026-07-17 · Post-launch error checks (399 sites) + KV prefix-hash double-free fix — decode neutral
 
 Hardening WI-1/WI-2 (branch hardening/launch-checks-and-kv-churn, baseline

--- a/src/core/cuda_raii.h
+++ b/src/core/cuda_raii.h
@@ -105,4 +105,87 @@ private:
     cudaEvent_t event_ = nullptr;
 };
 
+// RAII wrapper for cudaGraph_t. Graphs come out of cudaStreamEndCapture /
+// capture APIs as raw handles — adopt them via reset(raw).
+class CudaGraph {
+public:
+    CudaGraph() = default;
+
+    ~CudaGraph() {
+        if (graph_)
+            cudaGraphDestroy(graph_);
+    }
+
+    CudaGraph(const CudaGraph&) = delete;
+    CudaGraph& operator=(const CudaGraph&) = delete;
+
+    CudaGraph(CudaGraph&& o) noexcept : graph_(std::exchange(o.graph_, nullptr)) {}
+    CudaGraph& operator=(CudaGraph&& o) noexcept {
+        if (this != &o) {
+            if (graph_)
+                cudaGraphDestroy(graph_);
+            graph_ = std::exchange(o.graph_, nullptr);
+        }
+        return *this;
+    }
+
+    // Destroy the held graph (if any) and adopt `g`.
+    void reset(cudaGraph_t g = nullptr) noexcept {
+        if (graph_)
+            cudaGraphDestroy(graph_);
+        graph_ = g;
+    }
+
+    cudaGraph_t get() const noexcept { return graph_; }
+    operator cudaGraph_t() const noexcept { return graph_; }
+    explicit operator bool() const noexcept { return graph_ != nullptr; }
+
+    // Release ownership without destroying.
+    cudaGraph_t release() noexcept { return std::exchange(graph_, nullptr); }
+
+private:
+    cudaGraph_t graph_ = nullptr;
+};
+
+// RAII wrapper for cudaGraphExec_t (instantiated executable graph).
+class CudaGraphExec {
+public:
+    CudaGraphExec() = default;
+
+    ~CudaGraphExec() {
+        if (exec_)
+            cudaGraphExecDestroy(exec_);
+    }
+
+    CudaGraphExec(const CudaGraphExec&) = delete;
+    CudaGraphExec& operator=(const CudaGraphExec&) = delete;
+
+    CudaGraphExec(CudaGraphExec&& o) noexcept : exec_(std::exchange(o.exec_, nullptr)) {}
+    CudaGraphExec& operator=(CudaGraphExec&& o) noexcept {
+        if (this != &o) {
+            if (exec_)
+                cudaGraphExecDestroy(exec_);
+            exec_ = std::exchange(o.exec_, nullptr);
+        }
+        return *this;
+    }
+
+    // Destroy the held exec (if any) and adopt `e`.
+    void reset(cudaGraphExec_t e = nullptr) noexcept {
+        if (exec_)
+            cudaGraphExecDestroy(exec_);
+        exec_ = e;
+    }
+
+    cudaGraphExec_t get() const noexcept { return exec_; }
+    operator cudaGraphExec_t() const noexcept { return exec_; }
+    explicit operator bool() const noexcept { return exec_ != nullptr; }
+
+    // Release ownership without destroying.
+    cudaGraphExec_t release() noexcept { return std::exchange(exec_, nullptr); }
+
+private:
+    cudaGraphExec_t exec_ = nullptr;
+};
+
 }  // namespace imp

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -203,13 +203,15 @@ bool CudaGraphCapture::end_capture() {
         return false;
     }
 
-    cudaError_t err = cudaStreamEndCapture(capture_stream_, &graph_);
+    cudaGraph_t raw_graph = nullptr;
+    cudaError_t err = cudaStreamEndCapture(capture_stream_, &raw_graph);
     graph_diag::g_phase = graph_diag::Phase::NORMAL;
     if (err != cudaSuccess) {
         IMP_LOG_ERROR("CudaGraphCapture: end_capture failed: %s", cudaGetErrorString(err));
         capture_stream_ = nullptr;
         return false;
     }
+    graph_.reset(raw_graph);
 
     // Convert kernel→kernel edges to PDL edges for tail/head overlap
     if (pdl::is_available()) {
@@ -221,14 +223,15 @@ bool CudaGraphCapture::end_capture() {
     graph_diag::log_kernel_nodes(graph_, "capture.plain");
     graph_diag::dump_graph(graph_, "capture.plain");
 
-    err = cudaGraphInstantiate(&graph_exec_, graph_, 0);
+    cudaGraphExec_t raw_exec = nullptr;
+    err = cudaGraphInstantiate(&raw_exec, graph_, 0);
     if (err != cudaSuccess) {
         IMP_LOG_ERROR("CudaGraphCapture: instantiate failed: %s", cudaGetErrorString(err));
-        cudaGraphDestroy(graph_);
-        graph_ = nullptr;
+        graph_.reset();
         capture_stream_ = nullptr;
         return false;
     }
+    graph_exec_.reset(raw_exec);
 
     captured_ = true;
     capture_stream_ = nullptr;
@@ -251,10 +254,7 @@ bool CudaGraphCapture::replay(cudaStream_t stream) {
 }
 
 void CudaGraphCapture::drop_graph_keep_exec() {
-    if (graph_) {
-        cudaGraphDestroy(graph_);
-        graph_ = nullptr;
-    }
+    graph_.reset();
     capture_stream_ = nullptr;
     // graph_exec_ stays valid; captured_ stays true since the exec is usable.
 }
@@ -264,14 +264,16 @@ bool CudaGraphCapture::end_capture_and_update() {
         return false;
     }
 
-    cudaGraph_t new_graph = nullptr;
-    cudaError_t err = cudaStreamEndCapture(capture_stream_, &new_graph);
+    cudaGraph_t raw_new = nullptr;
+    cudaError_t err = cudaStreamEndCapture(capture_stream_, &raw_new);
     graph_diag::g_phase = graph_diag::Phase::NORMAL;
     if (err != cudaSuccess) {
         IMP_LOG_ERROR("CudaGraphCapture: end_capture failed: %s", cudaGetErrorString(err));
         capture_stream_ = nullptr;
         return false;
     }
+    CudaGraph new_graph;
+    new_graph.reset(raw_new);
 
     // Log node composition (gated by diagnostics.graph_diag in imp.conf). Symmetric
     // with the end_capture() / ConditionalRunner paths so prefill/decode graphs are
@@ -287,33 +289,29 @@ bool CudaGraphCapture::end_capture_and_update() {
 
     // Fast path: try to update existing exec in place. Avoids destroying and
     // re-allocating the graph mem pool.
-    if (graph_exec_ != nullptr) {
+    if (graph_exec_) {
         cudaGraphExecUpdateResultInfo info;
         cudaError_t ue = cudaGraphExecUpdate(graph_exec_, new_graph, &info);
         if (ue == cudaSuccess && info.result == cudaGraphExecUpdateSuccess) {
-            if (graph_)
-                cudaGraphDestroy(graph_);
-            graph_ = new_graph;
+            graph_ = std::move(new_graph);
             captured_ = true;
             capture_stream_ = nullptr;
             return true;
         }
         // Update failed (topology changed) — fall through to reinstantiate.
-        cudaGraphExecDestroy(graph_exec_);
-        graph_exec_ = nullptr;
+        graph_exec_.reset();
     }
 
-    if (graph_)
-        cudaGraphDestroy(graph_);
-    graph_ = new_graph;
-    err = cudaGraphInstantiate(&graph_exec_, graph_, 0);
+    graph_ = std::move(new_graph);
+    cudaGraphExec_t raw_exec = nullptr;
+    err = cudaGraphInstantiate(&raw_exec, graph_, 0);
     if (err != cudaSuccess) {
         IMP_LOG_ERROR("CudaGraphCapture: instantiate failed: %s", cudaGetErrorString(err));
-        cudaGraphDestroy(graph_);
-        graph_ = nullptr;
+        graph_.reset();
         capture_stream_ = nullptr;
         return false;
     }
+    graph_exec_.reset(raw_exec);
 
     captured_ = true;
     capture_stream_ = nullptr;
@@ -349,15 +347,9 @@ void abort_stream_capture(cudaStream_t stream) {
 }
 
 void CudaGraphCapture::reset() {
-    bool had_exec = (graph_exec_ != nullptr);
-    if (graph_exec_) {
-        cudaGraphExecDestroy(graph_exec_);
-        graph_exec_ = nullptr;
-    }
-    if (graph_) {
-        cudaGraphDestroy(graph_);
-        graph_ = nullptr;
-    }
+    bool had_exec = static_cast<bool>(graph_exec_);
+    graph_exec_.reset();
+    graph_.reset();
     capture_stream_ = nullptr;
     captured_ = false;
     // Release the per-device graph memory pool. Without this, instantiated
@@ -930,7 +922,8 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
 
         // ---- Construct CUDA graph with conditional WHILE node ----
         // 1. Create top-level graph
-        err = cudaGraphCreate(&graph_, 0);
+        cudaGraph_t raw_graph = nullptr;
+        err = cudaGraphCreate(&raw_graph, 0);
         if (err != cudaSuccess) {
             IMP_LOG_ERROR(
                 "ConditionalRunner: cudaGraphCreate failed: %s — falling back to "
@@ -939,6 +932,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                 cudaGetErrorString(err));
             goto fail;
         }
+        graph_.reset(raw_graph);
 
         // 2. Create conditional handle (default value = 1 = "continue looping")
         err = cudaGraphConditionalHandleCreate(&handle_, graph_, 1, cudaGraphCondAssignDefault);
@@ -1038,7 +1032,8 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
         graph_diag::dump_graph(graph_, "capture.cond_top");
 
         // 6. Instantiate the top-level graph
-        err = cudaGraphInstantiate(&exec_, graph_, 0);
+        cudaGraphExec_t raw_exec = nullptr;
+        err = cudaGraphInstantiate(&raw_exec, graph_, 0);
         if (err != cudaSuccess) {
             IMP_LOG_ERROR(
                 "ConditionalRunner: graph instantiation failed: %s — falling back "
@@ -1046,6 +1041,7 @@ bool CudaGraphConditionalRunner::setup(GraphExecutor* executor, const InferenceS
                 cudaGetErrorString(err));
             goto fail;
         }
+        exec_.reset(raw_exec);
 
         IMP_LOG_INFO("ConditionalRunner: graph built (max_steps=%d)", config_.max_steps);
     }
@@ -1205,15 +1201,9 @@ void CudaGraphConditionalRunner::cleanup() {
         launched_ = false;
     }
 
-    bool had_exec = (exec_ != nullptr);
-    if (exec_) {
-        cudaGraphExecDestroy(exec_);
-        exec_ = nullptr;
-    }
-    if (graph_) {
-        cudaGraphDestroy(graph_);
-        graph_ = nullptr;
-    }
+    bool had_exec = static_cast<bool>(exec_);
+    exec_.reset();
+    graph_.reset();
 
     if (d_token_id_) {
         IMP_CUDA_CHECK_LOG(cudaFree(d_token_id_));

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <cstdint>
 
+#include "core/cuda_raii.h"
+
 namespace imp {
 
 class GraphExecutor;
@@ -48,9 +50,9 @@ public:
     void abort_capture();
 
 private:
-    cudaGraph_t graph_ = nullptr;
-    cudaGraphExec_t graph_exec_ = nullptr;
-    cudaStream_t capture_stream_ = nullptr;
+    CudaGraph graph_;
+    CudaGraphExec graph_exec_;
+    cudaStream_t capture_stream_ = nullptr;  // non-owning (engine's stream)
     bool captured_ = false;
 };
 
@@ -265,11 +267,11 @@ public:
 
     void cleanup();
 
-    bool is_setup() const { return exec_ != nullptr; }
+    bool is_setup() const { return static_cast<bool>(exec_); }
 
 private:
-    cudaGraph_t graph_ = nullptr;
-    cudaGraphExec_t exec_ = nullptr;
+    CudaGraph graph_;
+    CudaGraphExec exec_;
     cudaGraphConditionalHandle handle_{};
 
     // Device-side state (allocated by setup, freed by cleanup)

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -714,7 +714,7 @@ private:
     // forward reads all growing lengths from device (InferenceState
     // ctx_capacity mode), so a graph stays valid across context growth.
     struct SpecVerifyGraph {
-        cudaGraphExec_t exec = nullptr;
+        CudaGraphExec exec;  // RAII: destroyed on map erase/clear
         int eager_uses = 0;  // first use per slot runs eager (algo warmup)
     };
     // Keyed by (padded chunk length, ctx tier, recurrent slot). The tier

--- a/src/runtime/engine_spec_capture.cpp
+++ b/src/runtime/engine_spec_capture.cpp
@@ -120,10 +120,7 @@ bool Engine::spec_capture_ready_(int ctx_padded) {
 }
 
 void Engine::free_spec_graphs_() {
-    for (auto& [len, g] : spec_graphs_) {
-        if (g.exec)
-            IMP_CUDA_CHECK_LOG(cudaGraphExecDestroy(g.exec));
-    }
+    // SpecVerifyGraph::exec is a CudaGraphExec — clear() destroys the handles.
     spec_graphs_.clear();
 }
 
@@ -187,21 +184,23 @@ bool Engine::spec_captured_forward_(InferenceState& state, Tensor& logits_out,
         what = "(non-std exception)";
     }
     gemm_set_lt_capture_allowed(false);
-    cudaGraph_t graph = nullptr;
-    err = cudaStreamEndCapture(stream, &graph);
-    if (forward_threw || err != cudaSuccess || graph == nullptr) {
+    cudaGraph_t raw_graph = nullptr;
+    err = cudaStreamEndCapture(stream, &raw_graph);
+    CudaGraph graph;
+    graph.reset(raw_graph);
+    if (forward_threw || err != cudaSuccess || !graph) {
         IMP_LOG_WARN("[spec-capture] capture failed: %s%s%s",
                      err != cudaSuccess ? cudaGetErrorString(err) : "(forward threw)",
                      forward_threw ? " — " : "", forward_threw ? what.c_str() : "");
-        if (graph)
-            cudaGraphDestroy(graph);
         cudaGetLastError();
         doom_check("capture");
         return false;
     }
-    cudaGraphExec_t exec = nullptr;
-    err = cudaGraphInstantiate(&exec, graph, 0);
-    cudaGraphDestroy(graph);
+    cudaGraphExec_t raw_exec = nullptr;
+    err = cudaGraphInstantiate(&raw_exec, graph, 0);
+    CudaGraphExec exec;
+    exec.reset(raw_exec);
+    graph.reset();
     if (err != cudaSuccess) {
         IMP_LOG_WARN("[spec-capture] instantiate failed: %s", cudaGetErrorString(err));
         cudaGetLastError();
@@ -212,11 +211,10 @@ bool Engine::spec_captured_forward_(InferenceState& state, Tensor& logits_out,
     if (err != cudaSuccess) {
         IMP_LOG_WARN("[spec-capture] first launch failed: %s", cudaGetErrorString(err));
         cudaGetLastError();
-        cudaGraphExecDestroy(exec);
         doom_check("first launch");
         return false;
     }
-    slot.exec = exec;
+    slot.exec = std::move(exec);
     spec_capture_failures_ = 0;
     IMP_LOG_INFO("[spec-capture] verify chunk graph cached (n_tokens=%d, ctx_tier=%d, rec_slot=%d)",
                  state.n_tokens, state.ctx_capacity, rec_slot);
@@ -254,12 +252,16 @@ void Engine::spec_capture_probe_forward_(InferenceState& state, Tensor& logits_o
         forward_threw = true;
         what = "(non-std exception)";
     }
-    cudaGraph_t graph = nullptr;
-    err = cudaStreamEndCapture(stream, &graph);
+    cudaGraph_t raw_graph = nullptr;
+    err = cudaStreamEndCapture(stream, &raw_graph);
+    CudaGraph graph;
+    graph.reset(raw_graph);
     bool ran = false;
-    if (!forward_threw && err == cudaSuccess && graph != nullptr) {
-        cudaGraphExec_t exec = nullptr;
-        err = cudaGraphInstantiate(&exec, graph, 0);
+    if (!forward_threw && err == cudaSuccess && graph) {
+        cudaGraphExec_t raw_exec = nullptr;
+        err = cudaGraphInstantiate(&raw_exec, graph, 0);
+        CudaGraphExec exec;
+        exec.reset(raw_exec);
         if (err == cudaSuccess) {
             err = cudaGraphLaunch(exec, stream);
             if (err == cudaSuccess) {
@@ -269,7 +271,6 @@ void Engine::spec_capture_probe_forward_(InferenceState& state, Tensor& logits_o
                 IMP_LOG_WARN("[spec-capture-probe] graph launch failed: %s",
                              cudaGetErrorString(err));
             }
-            cudaGraphExecDestroy(exec);
         } else {
             IMP_LOG_WARN("[spec-capture-probe] instantiate failed: %s", cudaGetErrorString(err));
         }
@@ -278,8 +279,6 @@ void Engine::spec_capture_probe_forward_(InferenceState& state, Tensor& logits_o
                      err != cudaSuccess ? cudaGetErrorString(err) : "(forward threw)",
                      forward_threw ? " forward exception: " : "", forward_threw ? what : "");
     }
-    if (graph != nullptr)
-        cudaGraphDestroy(graph);
     cudaGetLastError();
     IMP_LOG_INFO("[spec-capture-probe] chunk n_tokens=%d %s (launched %ld/%ld)", state.n_tokens,
                  ran ? "CAPTURED+LAUNCHED" : "eager fallback", launched, probes);


### PR DESCRIPTION
## Summary

Work item 3 of the dispatch-hardening campaign (baseline: `docs/audit/DISPATCH_BASELINE_2026_07_17.md`; WI-1/WI-2 shipped in #1044).

- New `CudaGraph` / `CudaGraphExec` move-only owners in `core/cuda_raii.h` (same idiom as `CudaStream`/`CudaEvent`).
- Adopted in `CudaGraphCapture`, `CudaGraphConditionalRunner`, `SpecVerifyGraph` (per-bucket verify graphs) and the spec-capture/probe locals — every manual destroy+null pair becomes `reset()`/move, so error and throw paths are structurally leak-safe.
- Semantics preserved 1:1: exec-update fast path, `drop_graph_keep_exec`, mem-trim-on-reset, capture-abort behavior unchanged.

## Validation

- Full GPU suite 0 failures; capture/green-ctx tests 11/11; DegenerationTest 5/5; `make verify-fast` green (perf gate + degen smoke).
- Decode perf (same harness as the Phase-0 baseline, 5 isolated trials, spec-OFF, Qwen3-Coder-30B NVFP4): tg256 402.59 -> 402.92 — noise. Logged in `docs/audit/PERF_LOG.md`.
- The "Engine teardown: cleared a leaked CUDA error (graph update constraint)" WARN visible in the Degeneration battery is **pre-existing** — reproduced on unmodified main the same day (the ExecUpdate->reinstantiate fallback has always left the sticky error for the teardown net). Candidate one-line follow-up noted in PERF_LOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fTwmujYTCJmRBRr1xoevs