### PR TITLE
fix(graph): clear sticky error after expected exec-update fallback

### DIFF
--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -299,6 +299,10 @@ bool CudaGraphCapture::end_capture_and_update() {
             return true;
         }
         // Update failed (topology changed) — fall through to reinstantiate.
+        // Clear the sticky per-thread error the failed update left behind:
+        // this fallback is expected and handled, but the stale error used to
+        // linger until engine teardown's leak net cleared it (WARN noise).
+        (void)cudaGetLastError();
         graph_exec_.reset();
     }
 


### PR DESCRIPTION
One-line follow-up noted in `docs/audit/PERF_LOG.md` (2026-07-17 graph-RAII entry): the ExecUpdate->reinstantiate fallback in `CudaGraphCapture::end_capture_and_update` is expected and handled, but left the sticky per-thread CUDA error to linger until engine teardown's leak net cleared it (WARN noise in every run that exercises the fallback).

Clear it at the fallback site.

**Validation**: DegenerationTest 5/5 — the "Engine teardown: cleared a leaked CUDA error (graph update constraint)" WARN no longer appears; `make verify-fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fTwmujYTCJmRBRr1xoevs