### PR TITLE
Token-Recycling spec-decode: adjacency drafter + multi-candidate verify (flag-gated, default off) + perf audit 2026-07-23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/activation.cu
     src/compute/embedding.cu
     src/compute/sampling.cu
+    src/compute/rowwise_topm.cu
     src/compute/sampling_topk_topp.cu
     src/compute/sampling_penalties.cu
     src/compute/sampling_filters.cu
@@ -277,6 +278,7 @@ set(IMP_RUNTIME_SOURCES
     src/runtime/engine_sampling_stop.cpp
     src/runtime/ngram_draft.cpp
     src/runtime/suffix_draft.cpp
+    src/runtime/token_recycle_draft.cpp
     src/vision/vision_pipeline.cpp
     src/runtime/constraint_manager.cpp
     src/runtime/vram_budget.cpp
@@ -529,6 +531,7 @@ if(IMP_BUILD_TESTS)
         tests/test_rope_override.cpp
         tests/test_ngram_draft.cpp
         tests/test_suffix_draft.cpp
+        tests/test_token_recycle_draft.cpp
         tests/test_routing_decision.cpp
         tests/test_think_stop_logic.cpp
         tests/test_stream_pipeline.cpp
@@ -589,6 +592,7 @@ if(IMP_BUILD_TESTS)
         tests/test_reduce.cu
         tests/test_softmax.cu
         tests/test_sampling.cu
+        tests/test_rowwise_topm.cu
         tests/test_executor_kernels.cu
         tests/test_hadamard.cu
         tests/test_mmq_q4k_imma_layout.cu
@@ -650,6 +654,7 @@ if(IMP_BUILD_TESTS)
         tests/test_fp8_kv_cache.cu
         tests/test_kv_cache_write.cu
         tests/test_kv_gather.cu
+        tests/test_kv_block_copy.cu
         tests/test_green_ctx.cu
         tests/test_capture_abort.cu
         tests/test_prefix_cache_equiv.cpp

--- a/docs/audit/PERF_AUDIT_2026_07_23.md
+++ b/docs/audit/PERF_AUDIT_2026_07_23.md
@@ -1,0 +1,157 @@
+# Adversarial Performance Audit — 2026-07-23
+
+Append-only. Fresh measurement pass over every prior "at the ceiling" conclusion,
+questioning all previously-refuted levers. Host verified healthy before every
+number (Q8 gate tg128 = 287.2 vs baseline 288.02, band [275, 290]; clocks
+2890 MHz SM / 13801 MHz mem / ~500 W sampled DURING load, spread 0.05%).
+Commit: f95c84aa (+ this audit). Method per docs/BENCHMARKING.md; spec-OFF via
+`--set speculative.ngram=false`; nsys with `--cuda-graph-trace=node` (graphs ON).
+
+## Fresh time-budget maps (measured this session)
+
+### Decode, dense NVFP4 (Qwen3-14B-NVFP4, tg256@512 spec-off = 170.6 tok/s)
+
+nsys graphs-ON kernel shares: `gemv_nvfp4_gate_up_fused` 42.1%,
+`gemv_nvfp4_residual` 29.9%, `gemv_nvfp4_qkv_fused` 10.5%, lm_head
+(`gemv_nvfp4_multirow_fp32`) 4.5% → **~87% of the step is the NVFP4 weight
+sweep**. Attention (splitk_fp8 + reduce) ~3.6%, rmsnorm 3.1%, everything else
+<2% each. Step time 5.88 ms vs 4.6 ms pure weight-stream minimum (8.3 GB @
+1792 GB/s) → **e2e decode runs at ~80% of the absolute weight-bandwidth wall.**
+The remaining 20% has 6 refuted kernel levers against it (2026-05→07). No
+factor-level gain exists inside the step. CONFIRMS the 2026-07-22 ceiling.
+
+### Decode, MoE NVFP4 (Qwen3-Coder-30B-A3B-FP4, tg256@128 spec-off = 385 under nsys)
+
+Expert GEMVs (`moe_gate_up` 21.5% + `moe_decode_mr` 13.8%) = 35%; dense-side
+GEMVs (qkv 10.2% + residual 9.8%) = 20%; attention 10%; routing
+(topk_gating 6.1% + gemv_gate_fp32 5.1% + weighted_sum 1.9%) = 13%; norms/rope/
+kv-write/swiglu ≈ 14%; lm_head 4.4%. Byte math: expert gate_up streams
+~14.2 MB in 11.2 µs ≈ 1266 GB/s = **71% HBM**; expert down ~7.1 MB in 7.2 µs ≈
+55%. Kernel-sum ≈ 2.32 ms vs measured step 2.6 ms. The nominal "2.4× headroom
+vs pure active-byte minimum" lives in scatter structure + many small kernels —
+the launch/latency class was refuted under graphs+PDL twice (2026-07-13
+`qwen30b_launch_lever_class_refuted`, mr_nr sweep). No factor here either.
+
+### Prefill (Coder-30B pp4096 single-chunk = 59.8k tok/s; Q8 pp512 = 13.6k; 14B-NVFP4 pp512 = 26.3k)
+
+- **The "legacy materialized causal_softmax + cuBLAS ≈ 18% of prefill" claim is
+  dead — 0 launches of `causal_softmax` in any fresh profile** (also confirmed
+  by audits 2026-06-07 and DISPATCH_BASELINE_2026-07-17). FA2 family carries
+  31% of pp4096 time, grouped-GEMM CUTLASS 20%, quant/permute/scatter ~10%.
+- MoE prefill leads vLLM single-seq (#558 closed 2026-07-22; today's pp4096
+  number is far above the bar). Prefill is not gated (2.6× cuBLAS restart
+  variance) and not the mission bottleneck. Not a lever.
+
+## The re-derived conclusion
+
+Single-stream decode is comprehensively bandwidth/structure-bound; prefill
+leads. **The only factor-level lever on this chip is more accepted tokens per
+weight sweep — speculation quality.** Fresh evidence that the machinery is
+ready and the drafter is the sole gap:
+
+1. **Verify is cheap and lossless.** On the self-repetitive bench prompt the
+   existing suffix/n-gram drafter emits 3-token drafts, 100% accepted, lifting
+   Qwen3-14B-NVFP4 tg 170.6 → 220–237 (**+29–39%** at k=4..32; chunk-4 verify
+   step ≈ 2.2× a decode step, so 4 emitted tokens / 2.2 steps ≈ 1.8×). The
+   k-sweep also shows verify cost is flat once the chunk fits the capture
+   bucket (tg 216–236 for k = 4..32, all noise-band).
+2. **The drafter never fires on reasoning text.** Qwen3-14B-NVFP4, real
+   reasoning prompt, 1024 tokens: `drafted=0 accepted=0`, spec-on == spec-off
+   (170 vs 177 tok/s, loop-mechanics noise). Coder-30B-A3B on the same prompt:
+   **only 19 of 101 probe steps produce any draft** (miss rate 81%); when it
+   fires it pays 10 tok/verify — net just +5% (389→414). The entire
+   speculation upside on reasoning/agentic prose — the GOAL's core workload —
+   is untapped.
+3. Scoreboard context: the "14B tg 225" hero number is spec-ON on repetitive
+   bench text; the true spec-off decode is 170.6. Speculation already delivers
+   +32% where it engages. Reasoning gets 0%.
+
+## Ranked levers
+
+### #1 Token-Recycling adjacency drafter + multi-candidate verify (BUILD — plan docs/plans/2026-07-22-token-recycling-spec-tree.md)
+
+- **Measured now:** 0% spec engagement on reasoning (dense), 19% engagement
+  (MoE). Verify economics measured: chunk-4 ≈ 2.2× decode step ⇒ break-even
+  accept ≈ 2.2 tok/verify; every accepted token beyond that is ~pure gain.
+- **Expected:** +20–50% decode on reasoning-heavy agentic output (Token
+  Recycling, ACL 2025: ~2× lossless on general text; conservative here because
+  code/structured text already benefits). Roofline-clean: speculation is the
+  only mechanism that amortizes the 8.3 GB weight sweep over >1 token.
+- **Risk:** moderate — lossless-by-construction (greedy argmax verify is the
+  safety net); worst case is wasted verify compute, gated per-milestone.
+  Blast radius: `engine_spec_ngram.cpp` draft-fallback hook + new drafter
+  files + `greedy_argmax_all` top-K extension. Flag-gated
+  (`speculative.token_recycling`, default off) for clean A/B.
+- **Acceptance criteria (hard):** on the reasoning-prompt battery,
+  spec-ON(TR) wall-clock decode ≥ +10% vs spec-OFF on Qwen3-14B-NVFP4 with
+  byte-identical greedy output; no regression on the bench-prompt path or
+  `verify-fast`; kill per plan if accept stays < 1.3 tok/verify at milestone 3.
+
+### #2 Cheapen the verify step itself (supporting lever for #1)
+
+Chunk-4 verify at 2.2× a decode step is more than the GEMM bytes justify
+(weights are read once either way; M=4 vs M=1 is ≤1.2× on the GEMV side).
+The overhead sits in the ctx-tier attention + eager-loop host work (#964
+measured the tier effect; #1001 already cut the GEMMs). Every 0.1× shaved off
+verify cost lowers the break-even accept for #1 linearly. Measure-first via
+nsys on a verify-heavy run; only build if a ≥0.3× reduction is visible.
+
+### #3 MoE decode expert-GEMV streaming (LOW confidence — do not build now)
+
+Expert gate_up at 71% / down at 55% HBM leaves nominally ~1.3–1.8× inside the
+MoE window (35% of step) ⇒ ≤ +15% e2e best case. Adjacent levers were refuted
+(mr_nr, launch fusion, splitk cap). Revisit only with a concrete ncu stall
+analysis showing a fixable structural stall, not before.
+
+Everything else touched this pass (prefill coverage, legacy attention path,
+launch classes, cuBLAS variance as a mean-shift lever, routing overhead) is
+either already closed, refuted under graphs, or not on the gated metric.
+
+---
+
+## Implementation results (same session, lever #1 milestones 1–3)
+
+Shipped flag-gated (`speculative.token_recycling`, default OFF):
+adjacency table (`token_recycle_draft.{h,cpp}`), top-M logit harvest in the
+verify lm-head pass (`rowwise_topm.cu` + `greedy_argmax_all` extension), and
+the **route-(a) multi-candidate verify** — per-candidate private KV blocks
+via the existing per-row block tables (`kv_get_block_id` resolves reads AND
+writes per row at n_sequences>1), each candidate re-forwards t0 into its own
+partial-block copy (`KVCache::copy_blocks_device`), winner block copied back
+before rollback. No token-level mask needed; hybrid/MoE/MLA/SWA/penalties/MTP
+excluded (linear fallback). 15 new host/GPU tests; full GPU suite green;
+verify-fast green; greedy output byte-identical to spec-off (both linear and
+multi-candidate arms).
+
+**Measured (Qwen3-14B-NVFP4, reasoning prompt, healthy host):**
+
+| arm | tg tok/s | engagement | emitted/verify |
+|---|---|---|---|
+| spec-off | 170.7–171.4 | — | — |
+| default (suffix) | 171–178 | 4 verifies/1024 tok | 13.75 when firing |
+| TR linear (m1+2) | 168–170 | doomed after 8–13 | 1.55–1.88 |
+| TR multi-candidate | 168–170 (doom-protected) | 12 verifies | 2.00 |
+| TR mc, suffix off, no doom | 116–129 | 370 verifies/1024 | 1.74–1.86 |
+
+**Verdict: the drafter works (0 → ~2.0 emitted/verify on reasoning) but the
+verify step is too expensive for it to pay.** Break-even accept = verify
+cost / decode-step cost ≈ 1.9–2.2 today. Fresh decomposition of the
+captured verify step (nsys, bucket 17, ctx tier 4096): wall ≈ 18 ms vs
+decode step 5.9 ms, split into
+
+1. **~8.2 ms M=17 GEMMs running as CUTLASS NVFP4 kernels** (≈200 launches ×
+   39–51 µs) — on native-NVFP4 ST models the `verify_nvfp4_gemm` overlay
+   (#1001) does not engage, so the chunk pays the prefill GEMM path at
+   ~55–60% of the GEMV-equivalent effective bandwidth (GEMV sum ≈ 4.8 ms
+   for the same weights).
+2. **~7 ms host overhead** — `cudaStreamSynchronize` is 45% of total API
+   time (avg 3.9 ms/call on WSL2/WDDM), plus per-step staging H2D and the
+   mc copy-back sync.
+
+**Follow-up (the actual unlock, = lever #2):** route native-NVFP4 M≤17
+verify chunks through the multirow GEMV kernels (`gemv_nvfp4_*_mr`) instead
+of CUTLASS, and cut the per-verify sync/staging overhead. Getting the
+verify step to ~1.2× a decode step drops break-even accept to ~1.2 — the
+measured TR accept of 1.7–2.0 then yields **+40–65% decode on reasoning**
+without any drafter improvement. Token-Recycling stays default-off until
+that lands.

--- a/docs/plans/2026-07-22-token-recycling-spec-tree.md
+++ b/docs/plans/2026-07-22-token-recycling-spec-tree.md
@@ -1,7 +1,12 @@
 # Token-Recycling multi-candidate speculative decode for reasoning/agentic text
 
-**Status:** proposed (2026-07-22). Multi-week. The one durable lever left for
->10% single-stream decode, per the 2026-07-22 ceiling campaign.
+**Status:** milestones 1–3 implemented 2026-07-23 (flag-gated
+`speculative.token_recycling`, default OFF; route (a) multi-candidate via
+per-candidate private KV blocks — no mask needed). Measured: accept lifted
+0 → 1.7–2.0 emitted/verify on reasoning, but net-neutral at today's verify
+step cost (~2x a decode step). **Blocked on cheapening the verify step**
+(M≤17 CUTLASS GEMMs → multirow GEMV overlay + per-verify sync/staging cuts);
+see docs/audit/PERF_AUDIT_2026_07_23.md for the full decomposition.
 
 ## Motivation (measured, not assumed)
 

--- a/docs/plans/2026-07-22-token-recycling-spec-tree.md
+++ b/docs/plans/2026-07-22-token-recycling-spec-tree.md
@@ -1,0 +1,125 @@
+# Token-Recycling multi-candidate speculative decode for reasoning/agentic text
+
+**Status:** proposed (2026-07-22). Multi-week. The one durable lever left for
+>10% single-stream decode, per the 2026-07-22 ceiling campaign.
+
+## Motivation (measured, not assumed)
+
+Single-stream decode is comprehensively at the HBM/compute ceiling on every hot
+path (dense NVFP4 GEMV 66–70% HBM; MoE 38%; #558 MoE-prefill closed — imp leads
+vLLM). The only remaining way past the bandwidth wall at batch=1 is **more
+accepted tokens per weight-sweep** — i.e. better speculation than the shipped
+n-gram/prompt-lookup.
+
+**imp's n-gram is dead on reasoning/agentic prose.** Measured 2026-07-22,
+Qwen3-14B-NVFP4, real reasoning prompt (200 tok):
+
+```
+[spec-ngram] verify_steps=0 miss_steps=18 drafted=0 accepted=0 (0.0%)
+```
+
+Prompt-lookup only fires when the output repeats a suffix already in context
+(code, structured text — Coder-30B hits 15.9 tok/verify). On fresh reasoning it
+finds no match → 0 drafts → plain decode. This is exactly the GOAL's core
+agentic use-case, and imp leaves the single durable lever unused there.
+
+**Linear low-order drafting does NOT fix it** (measured, don't repeat): a
+`speculative.min_match` sweep 1/2/3/6 on the same reasoning prompt left total
+time flat (1739–1764 ms). Mechanism: imp swaps the fast async-graph decode loop
+for the eager verify loop while spec is active; a linear top-1 draft's accept
+(9–12%, 2.5–2.9 tok/verify at low min_match) can't amortize the eager overhead.
+min_match=6 gives 7 tok/verify but fires ~never on fresh text. Precision and
+recall both wash out for a single linear path.
+
+**The win needs a TREE / multi-candidate verify** (Token Recycling, ACL 2025,
+arXiv 2408.08696, ~2× lossless on general text; LogitSpec, arXiv 2507.01449,
+2.61× training-free). Key economic enabler already in imp: the verify chunk
+cost is **~flat in k** (config comment, `speculative.k=16`) up to the capture
+bucket — so a wide candidate set is nearly free, and each extra accepted token
+is ~pure gain.
+
+## Design
+
+### 1. Adjacency table (the drafter)
+Global (engine-scoped, cross-request) `token -> top-M likely next tokens`,
+built from the model's own top-K logits per decode step. `<2 MB` at M=8 over a
+150k vocab. This is the Token-Recycling adjacency: for each emitted token `v`,
+record the step's top-K logit ids as `v`'s successors (recency-ordered). Unlike
+n-gram it fires on unigram context (the last token has almost always been seen)
+→ it drafts on fresh reasoning text where suffix matching finds nothing.
+
+Requires top-K logit extraction per step. imp already computes greedy argmax
+(top-1); extend to a device-side top-K after the lm_head. In the verify loop
+`greedy_argmax_all` already runs the lm_head per chunk position — extend it to
+emit top-K there for free. In the plain-decode/miss path, the top-K costs a
+small per-step device top-K; gate it behind the new flag.
+
+### 2. Tree / multi-candidate draft
+BFS the adjacency from the last token to build a small draft tree (depth 3–4,
+branching 2–4) within the k=16 budget. Verify the whole tree in one chunk
+forward and accept the best root-to-leaf path.
+
+### 3. Verify — the hard part
+imp's verify is **linear** today (one draft chunk, longest-prefix accept via
+`greedy_argmax_all`; `engine_spec_ngram.cpp` `step_spec_verify_`). Two routes to
+a tree/multi-candidate verify, in increasing risk:
+
+- **(a) Multi-candidate linear, disjoint KV blocks** (lower risk). Emit N
+  independent linear draft candidates. Write each candidate's tokens into its
+  OWN KV block(s) so the existing `decode_attn_route` per-row `context_lens` +
+  row block-tables (already present, `engine_spec_ngram.cpp:557`) isolate each
+  candidate. Accept the candidate with the longest matching prefix. Cost: wastes
+  KV blocks (1+/candidate, rolled back after) and re-computes shared prefixes,
+  but needs NO new attention mask. Prove the win here first.
+- **(b) True tree, token-level mask** (higher risk, higher win). Shared prefixes,
+  block-diagonal causal mask over the <32-token chunk so each node attends only
+  its ancestors. Needs a token-level mask in the FA2-tile / paged-decode verify
+  kernel — the multi-week core. Only pursue if (a) proves the accept-rate lifts.
+
+### 4. Integration point
+`engine_spec_ngram.cpp` `step_spec_verify_`, ~line 354:
+`if (draft.empty() && mtp_spec_decode_enabled()) draft = mtp_take_draft_(*req)`.
+Add the adjacency/tree draft as a fallback **exactly parallel to the MTP
+fallback** — the entire verify/accept/rollback/stats machinery consumes a plain
+`std::vector<int32_t>` (linear) unchanged; the tree route needs the per-row
+staging in the same function. New flag `speculative.token_recycling` (default
+off) for clean A/B. The lossless argmax-accept is the correctness safety net:
+even a wrong draft/mask can only cost speed, never token identity — as long as
+the verify attention is correct per candidate.
+
+## Incremental milestones (measure at each; STOP if a step doesn't lift accept)
+
+1. Adjacency table (host-side, from emitted tokens) + linear fallback draft.
+   Expect ≈ the measured net-neutral baseline — this validates the plumbing, not
+   a win.
+2. Top-K logit extraction → richer adjacency; re-measure linear accept.
+3. **Multi-candidate linear verify via disjoint-KV `decode_attn_route`** (route
+   a). First real win attempt — target >1.5 accepted tok/verify on reasoning.
+4. True tree + token-level mask (route b) — only if 3 shows the accept lift.
+
+## Measurement contract (critical — the default bench hides this)
+- **NEVER measure on `--bench`**: its prompt is self-repetitive → n-gram already
+  ~99.9% accept, so it measures the verify path, not the reasoning gap this
+  targets. Use real reasoning/creative prompts via `--prompt` or the server.
+- Metric: `[spec-ngram]` accept% + tok/verify, and spec-ON vs spec-OFF wall-clock
+  decode tok/s on the SAME reasoning prompt (3+ trials, warm clocks).
+- Guard the async-loop-vs-eager trade: the win must beat the eager-verify
+  overhead the linear draft could not.
+
+## Risks / kill criteria
+- Route (a) accept stays <1.3 tok/verify on reasoning → tree unlikely to pay;
+  reconsider (LogitSpec-style next-next retrieval is a cheaper alternative).
+- Token-level mask breaks the lossless guarantee if attention leaks across
+  candidates → gate every step on a greedy-identity check vs spec-OFF.
+- Hybrid/GDN recurrent state: the existing hybrid verify snapshot/restore
+  (`spec_state_scratch_`) must extend to the multi-candidate case, or gate
+  token_recycling to non-recurrent requests first.
+
+## Expected payoff
+Token Recycling reports ~2× lossless on general text; realistically **+20–50%
+decode on reasoning-heavy agentic workloads** where n-gram is currently 0%.
+Code/structured agentic text already benefits from n-gram, so this is additive
+on the reasoning half of the agentic mission, not a uniform speedup.
+
+See memory `perf_ceiling_reality_and_spec_headroom_2026_07_22` for the full
+campaign evidence.

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -471,6 +471,19 @@ draft_ctx_cap        = 2048
 moe                  = true
 # Draft tokens proposed per verify step (verify cost is ~flat in k).
 k                    = 16
+# Token-Recycling adjacency drafting (arXiv 2408.08696): engine-scoped
+# `token -> top-M successors` table fed from emitted bigrams and the
+# model's own verify-chunk top-K logits; drafts where suffix/n-gram find
+# nothing (fresh reasoning prose). recycle_width > 1 verifies that many
+# candidates per chunk on the dense decode-attn route (per-candidate
+# private KV blocks, lossless argmax accept). EXPERIMENTAL: measured
+# accept 1.7-2.0 emitted/verify on reasoning (2026-07-23) — at the
+# current ~2x verify-step cost that is net-neutral; default OFF until
+# the verify step gets cheaper (see docs/audit/PERF_AUDIT_2026_07_23.md).
+token_recycling      = false
+recycle_slots        = 8
+recycle_depth        = 8
+recycle_width        = 4
 # Suffix-indexed drafting (SuffixDecoding-style): hash-indexed suffix
 # matching instead of a per-step backward scan, continuations picked by
 # frequency vote across all occurrences, and adaptive draft length — a

--- a/src/compute/rowwise_topm.cu
+++ b/src/compute/rowwise_topm.cu
@@ -1,0 +1,69 @@
+#include "compute/rowwise_topm.h"
+#include "core/logging.h"
+
+#include <cfloat>
+
+namespace imp {
+
+// One block per row; m sequential masked argmax passes (same block-reduce
+// shape as rowwise_argmax_partial_kernel, tie-break = lowest index). The
+// already-selected indices sit in shared memory and are skipped on later
+// passes.
+__global__ void rowwise_topm_kernel(const float* __restrict__ logits, int V, int m,
+                                    int32_t* __restrict__ out) {
+    const int row = blockIdx.x;
+    const float* lg = logits + static_cast<int64_t>(row) * V;
+    const int tid = threadIdx.x;
+    __shared__ int s_sel[kRowwiseTopMMax];
+    __shared__ float s_val[256];
+    __shared__ int s_idx[256];
+    for (int pass = 0; pass < m; ++pass) {
+        float best = -FLT_MAX;
+        int best_idx = V;  // sentinel: loses every tie-break
+        for (int i = tid; i < V; i += blockDim.x) {
+            bool taken = false;
+            for (int e = 0; e < pass; ++e)
+                if (s_sel[e] == i) {
+                    taken = true;
+                    break;
+                }
+            if (taken)
+                continue;
+            const float v = lg[i];
+            if (v > best || (v == best && i < best_idx)) {
+                best = v;
+                best_idx = i;
+            }
+        }
+        s_val[tid] = best;
+        s_idx[tid] = best_idx;
+        __syncthreads();
+        for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                if (s_val[tid + s] > s_val[tid] ||
+                    (s_val[tid + s] == s_val[tid] && s_idx[tid + s] < s_idx[tid])) {
+                    s_val[tid] = s_val[tid + s];
+                    s_idx[tid] = s_idx[tid + s];
+                }
+            }
+            __syncthreads();
+        }
+        if (tid == 0) {
+            s_sel[pass] = s_idx[0];
+            out[static_cast<int64_t>(row) * m + pass] = s_idx[0];
+        }
+        __syncthreads();
+    }
+}
+
+void rowwise_topm(const float* d_logits, int rows, int vocab, int m, int32_t* d_out,
+                  cudaStream_t stream) {
+    if (rows <= 0 || vocab <= 0 || m <= 0 || !d_logits || !d_out)
+        return;
+    if (m > kRowwiseTopMMax)
+        m = kRowwiseTopMMax;
+    rowwise_topm_kernel<<<rows, 256, 0, stream>>>(d_logits, vocab, m, d_out);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+}  // namespace imp

--- a/src/compute/rowwise_topm.h
+++ b/src/compute/rowwise_topm.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// Row-wise top-M logit indices (best first, ties -> lowest index), written
+// as d_out[row * m + rank]. M is capped at kRowwiseTopMMax. Used to harvest
+// the model's own successor candidates from the spec-verify chunk for the
+// Token-Recycling adjacency table (speculative.token_recycling) — the
+// result feeds a host-side drafter, so it is deliberately simple: m masked
+// argmax passes per row, one block per row (rows <= chunk_pad ~ 32, cost
+// << 1% of a verify step).
+inline constexpr int kRowwiseTopMMax = 16;
+
+void rowwise_topm(const float* d_logits, int rows, int vocab, int m, int32_t* d_out,
+                  cudaStream_t stream);
+
+}  // namespace imp

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -151,10 +151,15 @@ public:
     // so row j additionally penalizes d_draft[0..j-1] — the same set the
     // eager path would have accumulated by that step. repeat_last_n != 0 is
     // the caller's responsibility to gate (window semantics not replicated).
+    // d_topm/topm (optional): additionally write each row's top-M logit ids
+    // (best first, post-penalty — same distribution the argmax decides on)
+    // to d_topm[row * topm + rank]. Harvested by the Token-Recycling
+    // adjacency drafter (speculative.token_recycling).
     void greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream,
                            const int32_t* d_hist = nullptr, int n_hist = 0,
                            const int32_t* d_draft = nullptr, float rep_pen = 1.0f,
-                           float freq_pen = 0.0f, float pres_pen = 0.0f);
+                           float freq_pen = 0.0f, float pres_pen = 0.0f,
+                           int32_t* d_topm = nullptr, int topm = 0);
 
     // Materialize the LM-head projection of hidden_[0..n_rows) into d_out
     // ([n_rows, vocab_size] fp32) — same batched re-projection as

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -24,6 +24,7 @@
 #include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
 #include "compute/layernorm.h"
+#include "compute/rowwise_topm.h"
 #include "core/logging.h"
 #include "core/tensor.h"
 #include "quant/nvfp4_gemm.h"
@@ -383,7 +384,8 @@ __global__ void verify_penalties_kernel(float* __restrict__ logits, int row0, in
 
 void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream,
                                       const int32_t* d_hist, int n_hist, const int32_t* d_draft,
-                                      float rep_pen, float freq_pen, float pres_pen) {
+                                      float rep_pen, float freq_pen, float pres_pen,
+                                      int32_t* d_topm, int topm) {
     if (!initialized_ || n_rows <= 0 || d_out == nullptr) {
         return;
     }
@@ -441,6 +443,9 @@ void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t s
         IMP_CUDA_CHECK_LAUNCH();
         rowwise_argmax_reduce_kernel<<<1, 32, 0, stream>>>(pvals, pidxs, csz, d_out + row0);
         IMP_CUDA_CHECK_LAUNCH();
+        if (d_topm && topm > 0)
+            rowwise_topm(static_cast<const float*>(lg.data), csz, V, topm,
+                         d_topm + static_cast<int64_t>(row0) * topm, stream);
     });
 }
 

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -271,6 +271,10 @@ KVCache::KVCache(int n_layers, const std::vector<int>& n_kv_heads_per_layer,
 }
 
 KVCache::~KVCache() {
+    if (d_copy_meta_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(d_copy_meta_));
+        d_copy_meta_ = nullptr;
+    }
     if (scale_pool_) {
         if (alloc_)
             alloc_->free(scale_pool_);
@@ -489,6 +493,90 @@ size_t KVCache::scale_block_bytes(int layer) const {
         return layer_scale_block_bytes_[layer];
     }
     return scale_block_bytes_;
+}
+
+// ── copy_blocks_device ───────────────────────────────────────────────
+namespace {
+
+struct KVCopyPairs {
+    int src[KVCache::kCopyMaxPairs];
+    int dst[KVCache::kCopyMaxPairs];
+};
+
+// grid: (n_layers, 4, n_pairs); blockIdx.y section: 0=K, 1=V, 2=K-scales,
+// 3=V-scales. meta layout per layer: {k_off, v_off, block_bytes,
+// k_scale_off, v_scale_off, scale_bytes}.
+__global__ void kv_block_copy_kernel(char* pool, char* spool, const size_t* __restrict__ meta,
+                                     KVCopyPairs pairs) {
+    const size_t* m = meta + 6ull * blockIdx.x;
+    const int sec = blockIdx.y;
+    char* base = (sec < 2) ? pool : spool;
+    if (base == nullptr)
+        return;
+    const size_t bytes = (sec < 2) ? m[2] : m[5];
+    if (bytes == 0)
+        return;
+    const size_t off = (sec == 0) ? m[0] : (sec == 1) ? m[1] : (sec == 2) ? m[3] : m[4];
+    const char* s = base + off + static_cast<size_t>(pairs.src[blockIdx.z]) * bytes;
+    char* d = base + off + static_cast<size_t>(pairs.dst[blockIdx.z]) * bytes;
+    const bool vec_ok = bytes % 16 == 0 && (reinterpret_cast<uintptr_t>(s) % 16 == 0) &&
+                        (reinterpret_cast<uintptr_t>(d) % 16 == 0);
+    if (vec_ok) {
+        const uint4* s4 = reinterpret_cast<const uint4*>(s);
+        uint4* d4 = reinterpret_cast<uint4*>(d);
+        for (size_t i = threadIdx.x; i < bytes / 16; i += blockDim.x)
+            d4[i] = s4[i];
+    } else {
+        for (size_t i = threadIdx.x; i < bytes; i += blockDim.x)
+            d[i] = s[i];
+    }
+}
+
+}  // namespace
+
+void KVCache::copy_blocks_device(const int* srcs, const int* dsts, int n_pairs,
+                                 cudaStream_t stream) {
+    if (n_pairs <= 0 || !srcs || !dsts)
+        return;
+    if (n_pairs > kCopyMaxPairs)
+        n_pairs = kCopyMaxPairs;
+    if (!d_copy_meta_) {
+        std::vector<size_t> meta(6ull * n_layers_);
+        for (int l = 0; l < n_layers_; ++l) {
+            size_t* m = meta.data() + 6ull * l;
+            if (layer_is_swa(l)) {
+                // Separate id space — never copied here (route excludes SWA).
+                m[2] = m[5] = 0;
+                continue;
+            }
+            m[0] = static_cast<char*>(k_ptr(l, 0)) - static_cast<char*>(pool_);
+            m[1] = static_cast<char*>(v_ptr(l, 0)) - static_cast<char*>(pool_);
+            m[2] = layer_block_bytes_.empty() ? block_bytes_ : layer_block_bytes_[l];
+            if (scale_pool_ && k_scale_ptr(l, 0)) {
+                m[3] = static_cast<char*>(k_scale_ptr(l, 0)) - static_cast<char*>(scale_pool_);
+                m[4] = static_cast<char*>(v_scale_ptr(l, 0)) - static_cast<char*>(scale_pool_);
+                m[5] = scale_block_bytes(l);
+            } else {
+                m[3] = m[4] = m[5] = 0;
+            }
+        }
+        if (cudaMalloc(&d_copy_meta_, meta.size() * sizeof(size_t)) != cudaSuccess) {
+            d_copy_meta_ = nullptr;
+            return;
+        }
+        IMP_CUDA_CHECK_LOG(cudaMemcpy(d_copy_meta_, meta.data(), meta.size() * sizeof(size_t),
+                                      cudaMemcpyHostToDevice));
+    }
+    KVCopyPairs pairs{};
+    for (int i = 0; i < n_pairs; ++i) {
+        pairs.src[i] = srcs[i];
+        pairs.dst[i] = dsts[i];
+    }
+    dim3 grid(n_layers_, scale_pool_ ? 4 : 2, n_pairs);
+    kv_block_copy_kernel<<<grid, 256, 0, stream>>>(static_cast<char*>(pool_),
+                                                   static_cast<char*>(scale_pool_),
+                                                   static_cast<const size_t*>(d_copy_meta_), pairs);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/tensor.h"
+#include <cuda_runtime.h>
 #include <cstdint>
 #include <cstddef>
 #include <vector>
@@ -67,6 +68,16 @@ public:
     // Returns scale_block_bytes_ for the standard path.
     size_t scale_block_bytes(int layer) const;
 
+    // Whole-block D2D copy across all layers (+ scale regions when present):
+    // dsts[i] becomes a byte-identical copy of srcs[i]. One kernel launch,
+    // pairs passed by value (no H2D staging). Multi-candidate spec-verify
+    // staging (speculative.token_recycling, route (a)): each candidate gets
+    // a private copy of the committed partial block, the winner's block is
+    // copied back. SWA layer groups are skipped (separate id space; the
+    // multi-candidate route excludes SWA models).
+    static constexpr int kCopyMaxPairs = 16;
+    void copy_blocks_device(const int* srcs, const int* dsts, int n_pairs, cudaStream_t stream);
+
     // Capacity queries
     int num_free_blocks() const;
     int total_blocks() const;
@@ -110,6 +121,11 @@ private:
     // Layout: 2x blocks per layer (K scales region + V scales region).
     void* scale_pool_ = nullptr;
     size_t scale_block_bytes_ = 0;  // block_size * n_kv_heads * sizeof(half)
+
+    // copy_blocks_device per-layer offset table (lazy device upload):
+    // 6 size_t per layer {k_off, v_off, block_bytes, k_scale_off,
+    // v_scale_off, scale_bytes}; offsets relative to pool_/scale_pool_.
+    void* d_copy_meta_ = nullptr;
 
     // ── SWA block group state (per-layer ctor only) ──────────────────
     // layer_is_swa_[l] = 1 → layer l's region has swa_max_blocks_ capacity and

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -297,6 +297,10 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("speculative.verify_nvfp4_gemm", cfg.speculative.verify_nvfp4_gemm);
     B("speculative.moe", cfg.speculative.moe);
     I("speculative.k", cfg.speculative.k);
+    B("speculative.token_recycling", cfg.speculative.token_recycling);
+    I("speculative.recycle_slots", cfg.speculative.recycle_slots);
+    I("speculative.recycle_depth", cfg.speculative.recycle_depth);
+    I("speculative.recycle_width", cfg.speculative.recycle_width);
     B("speculative.suffix", cfg.speculative.suffix);
     I("speculative.suffix_k_max", cfg.speculative.suffix_k_max);
     I("speculative.min_match", cfg.speculative.min_match);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -782,6 +782,27 @@ struct RuntimeConfig {
         // trial spread). Batch-1 behavior unchanged. Kill switch for A/B.
         bool batch_rr = true;
         int k = 16;          // draft tokens per verify step (verify cost is ~flat in k)
+        // Token-Recycling adjacency drafting (ACL 2025, arXiv 2408.08696;
+        // plan docs/plans/2026-07-22-token-recycling-spec-tree.md):
+        // engine-scoped cross-request `token -> top-M successors` table fed
+        // from emitted bigrams and the model's own verify-chunk top-K
+        // logits. Fires on unigram context, so it drafts on fresh
+        // reasoning/agentic prose where suffix/n-gram matching finds
+        // nothing (measured 0 drafts on reasoning, 2026-07-22/23). Runs as
+        // a fallback AFTER suffix/n-gram and MTP; lossless via the greedy
+        // argmax verify. Default off until the reasoning A/B proves it.
+        bool token_recycling = false;
+        int recycle_slots = 8;  // successors kept per token (MRU/rank order)
+        int recycle_depth = 8;  // max linear draft length per verify step
+        // Multi-candidate verify (route (a) of the spec-tree plan): when the
+        // decode-attn route is available (dense, non-MLA/SWA/MoE/hybrid, no
+        // penalties/MTP), verify `recycle_width` adjacency candidates in one
+        // chunk — each candidate gets its own t0 row and private copies of
+        // the KV blocks its rows write (per-row block tables), so no token
+        // mask is needed and the argmax accept stays lossless. Rows are
+        // capped at the 17 bucket (width * (1+depth) <= 17), i.e. width 4
+        // -> depth 3. 1 = linear drafting only.
+        int recycle_width = 4;
         // SuffixDecoding-style indexed drafting (arXiv 2411.04975):
         // hash-indexed suffix matching (O(1) amortized vs the legacy O(n)
         // backward scan per verify step) with frequency-voted continuations

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -11,6 +11,7 @@
 #include "runtime/constraint_manager.h"
 #include "runtime/config.h"
 #include "runtime/suffix_draft.h"
+#include "runtime/token_recycle_draft.h"
 #include "runtime/vram_budget.h"
 #include "memory/kv_cache.h"
 #include "memory/kv_cache_manager.h"
@@ -771,6 +772,14 @@ private:
     // Erased when the request finishes.
     SuffixDraftIndex& spec_suffix_index_(const Request& req);
     std::unordered_map<int, SuffixDraftIndex> spec_suffix_idx_;
+    // Token-Recycling adjacency table (speculative.token_recycling):
+    // engine-scoped, cross-request, lazily sized to the model vocab.
+    // Fed in step_spec_verify_ (prompt bigrams once, then new output
+    // tokens incrementally); drafts a linear successor chain when the
+    // suffix/n-gram/MTP sources come up empty.
+    TokenRecycleTable& spec_recycle_table_();
+    void spec_recycle_feed_(Request& req);
+    std::unique_ptr<TokenRecycleTable> spec_recycle_;
     // Device/pinned staging for the verify chunk (lazy-init, K+1 capacity).
     int32_t* d_spec_tokens_ = nullptr;
     int* d_spec_positions_ = nullptr;
@@ -779,6 +788,10 @@ private:
     int* d_spec_context_len_ = nullptr;
     int32_t* d_spec_argmax_ = nullptr;
     int32_t* h_spec_argmax_ = nullptr;  // pinned, chunk_cap entries
+    // Token-Recycling top-M harvest (speculative.token_recycling): per-row
+    // top-M logit ids from the verify chunk, chunk_cap * kRowwiseTopMMax.
+    int32_t* d_spec_topm_ = nullptr;
+    int32_t* h_spec_topm_ = nullptr;  // pinned
     // #964 decode-attention verify route (dense, eager): per-row context lens
     // [chunk_cap] and row-replicated block tables [chunk_cap * table_cap] so
     // the chunk's attention runs the batched-decode split-K kernels — row i

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -41,6 +41,7 @@
 #include "runtime/ngram_draft.h"
 #include "runtime/request.h"
 #include "runtime/suffix_draft.h"
+#include "compute/rowwise_topm.h"
 
 #include <cuda_runtime.h>
 #include <algorithm>
@@ -60,6 +61,13 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
               cudaMalloc(&d_spec_chunk_len_, sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
               cudaMallocHost(&h_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
+              // Token-Recycling top-M harvest — sized to the kernel cap so a
+              // recycle_slots config change never needs a re-alloc (tiny).
+              cudaMalloc(&d_spec_topm_,
+                         static_cast<size_t>(chunk_cap) * kRowwiseTopMMax * sizeof(int32_t)) ==
+                  cudaSuccess &&
+              cudaMallocHost(&h_spec_topm_, static_cast<size_t>(chunk_cap) * kRowwiseTopMMax *
+                                                sizeof(int32_t)) == cudaSuccess &&
               // SWA-group mirror (kv_cache.swa_sizing): same capacity as the
               // main table. Allocated unconditionally so a mid-session gate
               // flip can't leave it null; tiny (max_blocks ints).
@@ -141,6 +149,8 @@ void Engine::free_spec_buffers_() {
     if (d_spec_chunk_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_chunk_len_));
     if (d_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_argmax_));
     if (h_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_argmax_));
+    if (d_spec_topm_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_topm_));
+    if (h_spec_topm_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_topm_));
     d_spec_tokens_ = nullptr;
     d_spec_positions_ = nullptr;
     d_spec_block_table_ = nullptr;
@@ -152,6 +162,8 @@ void Engine::free_spec_buffers_() {
     d_spec_chunk_len_ = nullptr;
     d_spec_argmax_ = nullptr;
     h_spec_argmax_ = nullptr;
+    d_spec_topm_ = nullptr;
+    h_spec_topm_ = nullptr;
     spec_chunk_cap_ = 0;
     spec_block_table_cap_ = 0;
 }
@@ -295,6 +307,34 @@ SuffixDraftIndex& Engine::spec_suffix_index_(const Request& req) {
     return it->second;
 }
 
+TokenRecycleTable& Engine::spec_recycle_table_() {
+    if (!spec_recycle_) {
+        const auto& scfg = runtime_config_.speculative;
+        spec_recycle_ = std::make_unique<TokenRecycleTable>(model_->config_.vocab_size,
+                                                            std::max(1, scfg.recycle_slots));
+    }
+    return *spec_recycle_;
+}
+
+// Ingest this request's not-yet-seen tokens into the engine-scoped
+// adjacency table: prompt bigrams once (spec_recycle_fed == 0), then the
+// new output tokens (every emit path — verify accepts, loop bursts,
+// plain steps — lands in output_tokens, so one cursor covers them all).
+void Engine::spec_recycle_feed_(Request& req) {
+    TokenRecycleTable& tr = spec_recycle_table_();
+    const auto& out = req.output_tokens;
+    if (req.spec_recycle_fed == 0) {
+        const auto& in = req.input_tokens;
+        for (size_t i = 1; i < in.size(); ++i)
+            tr.observe_pair(in[i - 1], in[i]);
+        if (!in.empty() && !out.empty())
+            tr.observe_pair(in.back(), out.front());
+    }
+    for (int i = std::max(1, req.spec_recycle_fed); i < static_cast<int>(out.size()); ++i)
+        tr.observe_pair(out[i - 1], out[i]);
+    req.spec_recycle_fed = static_cast<int>(out.size());
+}
+
 bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t stream, int min_draft) {
     const auto& scfg = runtime_config_.speculative;
     const int kv_bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
@@ -355,15 +395,63 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         draft = mtp_take_draft_(*req);
         draft_from_mtp = !draft.empty();
     }
+    // Token-Recycling fallback: adjacency draft from the last emitted token.
+    // Fires on unigram context — exactly the fresh reasoning/agentic prose
+    // where the suffix/n-gram sources measured 0 drafts (2026-07-22/23).
+    // Preferred shape is the multi-candidate chunk (route (a), `mc` below):
+    // `recycle_width` candidates verified at once lift the per-step accept
+    // where a single linear chain measured below the verify break-even
+    // (1.55-1.9 emitted/verify vs ~1.9x step cost, 2026-07-23). Falls back
+    // to the linear chain when the decode-attn route (or its gates) is
+    // unavailable. Same shallow-depth economics as above for the linear
+    // form: at long context a depth-1 chain does not pay for the verify.
+    std::vector<std::vector<int32_t>> mc;  // multi-candidate rows (route a)
+    int mc_depth = 0;
+    if (runtime_config_.speculative.token_recycling) {
+        spec_recycle_feed_(*req);
+        const bool penalties_active = req->repetition_penalty != 1.0f ||
+                                      req->frequency_penalty != 0.0f ||
+                                      req->presence_penalty != 0.0f;
+        // Route (a) preconditions: per-row block tables exist only on the
+        // decode-attn verify route; the grouped rows are incompatible with
+        // the linear-draft penalty replication and the MTP row consumer.
+        const bool mc_route_ok = scfg.verify_decode_attn && ssm_state_ == nullptr &&
+                                 !model_->profile().is_moe && !model_->config().is_mla() &&
+                                 !swa_sizing_active_ && !penalties_active &&
+                                 !mtp_spec_decode_enabled();
+        if (draft.empty()) {
+            const int width = std::min(8, std::max(1, scfg.recycle_width));
+            // Row budget: width * (1 + depth) <= 17 (the mid capture bucket)
+            // keeps the per-row context walks at linear-chunk cost.
+            const int depth_cap = std::max(1, 17 / std::max(2, width) - 1);
+            const int depth = std::min({std::max(1, scfg.recycle_depth), depth_cap, k});
+            auto cands = spec_recycle_table_().draft_candidates(
+                req->output_tokens.back(), width, depth);
+            if (mc_route_ok && width > 1 && cands.size() > 1) {
+                mc = std::move(cands);
+                mc_depth = 0;
+                for (const auto& c : mc)
+                    mc_depth = std::max(mc_depth, static_cast<int>(c.size()));
+            } else if (!cands.empty()) {
+                draft = std::move(cands.front());
+                if (static_cast<int>(draft.size()) < 2 && scfg.shallow_draft_ctx > 0 &&
+                    req->context_len() > scfg.shallow_draft_ctx && ssm_state_ == nullptr &&
+                    !(model_->profile().is_moe && scfg.moe &&
+                      model_->profile().moe_experts_nvfp4))
+                    draft.clear();
+            }
+        }
+    }
+    const bool mc_on = !mc.empty();
     // #1003 batch-RR economics: at batch > 1 the WHOLE batch waits for the
     // verify forward (~1.4-2.6x a decode step) while only this request
     // benefits — a shallow draft is net-negative (measured -10% aggregate at
     // batch 4 on shallow drafts). Soft-decline below the caller's depth
     // floor: no miss accounting, no give-up pressure — the request decodes
     // batched this step and gets its next turn with a hopefully deeper draft.
-    if (min_draft > 0 && static_cast<int>(draft.size()) < min_draft)
+    if (min_draft > 0 && (mc_on ? mc_depth : static_cast<int>(draft.size())) < min_draft)
         return false;
-    if (draft.empty()) {
+    if (draft.empty() && !mc_on) {
         spec_stats_.miss_steps++;
         if (++req->spec_consecutive_misses >= scfg.give_up_after && scfg.give_up_after > 0 &&
             !req->spec_ngram_given_up) {
@@ -384,10 +472,15 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         return false;  // no usable draft — normal decode step
     }
 
-    // Verify chunk = [t0, d1..dK]: t0 is the last emitted (not yet forwarded)
-    // token; positions p0..p0+K with p0 = context_len-1.
+    // Verify chunk. Linear: [t0, d1..dK], positions p0..p0+K. Multi-candidate
+    // (route a): mc.size() candidate groups of (1 + mc_depth) rows each —
+    // every candidate re-forwards t0 itself (its KV lands in the candidate's
+    // PRIVATE block copy, see the mc staging below), so no row is shared and
+    // no token-level mask is needed. K doubles as the stats/economics depth
+    // (winner-depth proxy in mc mode — the verify cost is ~flat in rows).
     const int32_t t0 = req->output_tokens.back();
-    int K = static_cast<int>(draft.size());
+    const int mc_rows_per_cand = mc_on ? (1 + mc_depth) : 0;
+    int K = mc_on ? mc_depth : static_cast<int>(draft.size());
     const int p0 = req->context_len() - 1;
 
     // attn_scores_ capacity clamp (same rule as chunked prefill):
@@ -397,14 +490,25 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         if (s_cap > 0) {
             const int64_t cap2 = static_cast<int64_t>(s_cap) * s_cap;
             const int64_t ctx_end = static_cast<int64_t>(p0) + 1 + K;
-            while (K > 0 && static_cast<int64_t>(K + 1) * ctx_end > cap2) --K;
-            if (K <= 0) {
-                spec_stats_.miss_steps++;
-                return false;
+            if (mc_on) {
+                // The grouped chunk doesn't shrink gracefully — decline the
+                // step instead (only reachable at extreme context).
+                const int64_t rows = static_cast<int64_t>(mc.size()) * mc_rows_per_cand;
+                if (rows * ctx_end > cap2) {
+                    spec_stats_.miss_steps++;
+                    return false;
+                }
+            } else {
+                while (K > 0 && static_cast<int64_t>(K + 1) * ctx_end > cap2) --K;
+                if (K <= 0) {
+                    spec_stats_.miss_steps++;
+                    return false;
+                }
             }
         }
     }
-    const int chunk_len = K + 1;
+    const int chunk_len =
+        mc_on ? static_cast<int>(mc.size()) * mc_rows_per_cand : K + 1;
     // Graph-captured verify (#847): pad the chunk up to its bucket length so
     // one cached graph serves every draft length in the bucket. Pad rows
     // (copies of t0 at positions after every real row) are causally invisible
@@ -431,11 +535,22 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
 
     const int blocks_needed = (ctx_len + kv_bs - 1) / kv_bs;
 
+    // mc: per-candidate PRIVATE blocks for the block indices the candidate
+    // rows write (positions p0..p0+mc_depth). They are ordinary appended
+    // table entries beyond blocks_needed — the per-row tables below alias
+    // them in place of the canonical entries, and the post-accept rollback
+    // frees them like any other rejected-draft block.
+    const int mc_bp = mc_on ? p0 / kv_bs : 0;
+    const int mc_n_priv = mc_on ? (p0 + mc_depth) / kv_bs - mc_bp + 1 : 0;
+    const int mc_priv_base = blocks_needed;
+    const int blocks_target =
+        blocks_needed + (mc_on ? static_cast<int>(mc.size()) * mc_n_priv : 0);
+
     // KV blocks for all chunk positions (mirror step_decode's append loop).
     // On allocation failure, trim back to the pre-step valid length (p0 KV
     // entries: t0 has not been forwarded yet) and fall through to the normal
     // decode path.
-    while (static_cast<int>(kv_manager_->block_table(req->id).size()) < blocks_needed) {
+    while (static_cast<int>(kv_manager_->block_table(req->id).size()) < blocks_target) {
         int new_block = kv_manager_->append_block(req->id);
         if (new_block < 0) {
             // KV exhausted. The old evict_lru fallback freed a LIVE sequence (no
@@ -478,14 +593,26 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         return false;
     }
 
-    // Upload chunk metadata.
-    std::vector<int32_t> h_tokens;
-    h_tokens.reserve(chunk_pad);
-    h_tokens.push_back(t0);
-    h_tokens.insert(h_tokens.end(), draft.begin(), draft.begin() + K);
-    h_tokens.resize(chunk_pad, t0);  // bucket padding
-    std::vector<int> h_positions(chunk_pad);
-    for (int i = 0; i < chunk_pad; ++i) h_positions[i] = p0 + i;
+    // Upload chunk metadata. mc: candidate c's rows are
+    // [t0, cand_c...] at positions p0..p0+len_c; short candidates and the
+    // bucket padding fill with t0 rows whose argmax is never consulted (their
+    // KV writes land in dead slots — private-block tails past the accepted
+    // length, or canonical slots past the rollback point).
+    std::vector<int32_t> h_tokens(chunk_pad, t0);
+    std::vector<int> h_positions(chunk_pad, p0);
+    if (mc_on) {
+        for (size_t c = 0; c < mc.size(); ++c) {
+            const int r0 = static_cast<int>(c) * mc_rows_per_cand;
+            for (int j = 0; j < mc_rows_per_cand; ++j) {
+                h_positions[r0 + j] = p0 + j;
+                if (j > 0 && j - 1 < static_cast<int>(mc[c].size()))
+                    h_tokens[r0 + j] = mc[c][j - 1];
+            }
+        }
+    } else {
+        for (int i = 0; i < K; ++i) h_tokens[1 + i] = draft[i];
+        for (int i = 0; i < chunk_pad; ++i) h_positions[i] = p0 + i;
+    }
 
     auto check = [&](cudaError_t err, const char* op) {
         if (err != cudaSuccess) {
@@ -558,15 +685,42 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         std::vector<int> h_row_lens(chunk_pad);
         // Pad rows (i >= chunk_len, capture-bucket fill) attend a single
         // token: their output is never read, and a 1-token walk keeps the
-        // per-row KV traffic at real-chunk cost.
-        for (int i = 0; i < chunk_pad; ++i)
-            h_row_lens[i] = (i < chunk_len) ? (p0 + i + 1) : 1;
+        // per-row KV traffic at real-chunk cost. mc: row (c, j) attends
+        // p0+j+1 tokens through the candidate's aliased table; rows past a
+        // short candidate's length are pads too.
+        if (mc_on) {
+            for (int i = 0; i < chunk_pad; ++i) {
+                if (i >= chunk_len) {
+                    h_row_lens[i] = 1;
+                    continue;
+                }
+                const int c = i / mc_rows_per_cand;
+                const int j = i % mc_rows_per_cand;
+                const bool real = j == 0 || j - 1 < static_cast<int>(mc[c].size());
+                h_row_lens[i] = real ? (p0 + j + 1) : 1;
+            }
+        } else {
+            for (int i = 0; i < chunk_pad; ++i)
+                h_row_lens[i] = (i < chunk_len) ? (p0 + i + 1) : 1;
+        }
         h_spec_row_tables_.assign(
             static_cast<size_t>(chunk_pad) * spec_block_table_cap_, 0);
         for (int i = 0; i < chunk_pad; ++i)
             std::copy(block_table.begin(), block_table.end(),
                       h_spec_row_tables_.begin() +
                           static_cast<size_t>(i) * spec_block_table_cap_);
+        // mc: alias each candidate's written block indices [mc_bp ..
+        // mc_bp + mc_n_priv) to its private appended blocks — reads of the
+        // committed prefix stay canonical, writes are candidate-isolated.
+        if (mc_on) {
+            for (int i = 0; i < chunk_len; ++i) {
+                const int c = i / mc_rows_per_cand;
+                int32_t* row = h_spec_row_tables_.data() +
+                               static_cast<size_t>(i) * spec_block_table_cap_;
+                for (int t = 0; t < mc_n_priv; ++t)
+                    row[mc_bp + t] = block_table[mc_priv_base + c * mc_n_priv + t];
+            }
+        }
         if (check(cudaMemcpyAsync(d_spec_row_ctx_lens_, h_row_lens.data(),
                                   chunk_pad * sizeof(int), cudaMemcpyHostToDevice, stream),
                   "row ctx lens H2D") &&
@@ -588,6 +742,29 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         }
         // On H2D failure the state keeps the plain single-sequence chunk
         // fields and the FA2 prefill path serves the forward (correct, slow).
+    }
+    if (mc_on) {
+        // The grouped chunk is only correct with per-row tables engaged.
+        if (!state.chunk_decode_attn) {
+            kv_manager_->rollback(req->id, p0);
+            spec_stats_.miss_steps++;
+            return false;
+        }
+        // Seed each candidate's private partial block with the committed
+        // rows of the canonical one (positions [mc_bp*kv_bs, p0) — t0 is
+        // forwarded by the candidate itself). A block-aligned p0 has no
+        // committed rows in mc_bp; the private block starts fresh.
+        if (p0 % kv_bs != 0) {
+            int srcs[KVCache::kCopyMaxPairs];
+            int dsts[KVCache::kCopyMaxPairs];
+            const int n_pairs =
+                std::min(static_cast<int>(mc.size()), KVCache::kCopyMaxPairs);
+            for (int c = 0; c < n_pairs; ++c) {
+                srcs[c] = block_table[mc_bp];
+                dsts[c] = block_table[mc_priv_base + c * mc_n_priv];
+            }
+            kv_cache_raw_->copy_blocks_device(srcs, dsts, n_pairs, stream);
+        }
     }
 
     // Hybrid (SSM/GDN): bind the recurrent state and preserve the committed
@@ -656,14 +833,28 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         n_hist = pstate.n_penalty_tokens;
     }
 
-    // Greedy token for every chunk position, D2H, host compare.
+    // Greedy token for every chunk position, D2H, host compare. With
+    // token_recycling the same lm-head pass also harvests each row's top-M
+    // logit ids for the adjacency table (the model's own successor
+    // candidates — Token Recycling's feed signal).
+    const int recycle_m =
+        runtime_config_.speculative.token_recycling
+            ? std::min({std::max(1, runtime_config_.speculative.recycle_slots),
+                        kRowwiseTopMMax})
+            : 0;
     executor_->greedy_argmax_all(chunk_len, d_spec_argmax_, stream, d_hist, n_hist,
                                  d_spec_tokens_ + 1, req->repetition_penalty,
-                                 req->frequency_penalty, req->presence_penalty);
-    const bool argmax_ok =
+                                 req->frequency_penalty, req->presence_penalty,
+                                 recycle_m > 0 ? d_spec_topm_ : nullptr, recycle_m);
+    bool argmax_ok =
         check(cudaMemcpyAsync(h_spec_argmax_, d_spec_argmax_, chunk_len * sizeof(int32_t),
-                              cudaMemcpyDeviceToHost, stream), "argmax D2H") &&
-        check(cudaStreamSynchronize(stream), "verify sync");
+                              cudaMemcpyDeviceToHost, stream), "argmax D2H");
+    if (argmax_ok && recycle_m > 0)
+        argmax_ok = check(cudaMemcpyAsync(h_spec_topm_, d_spec_topm_,
+                                          static_cast<size_t>(chunk_len) * recycle_m *
+                                              sizeof(int32_t),
+                                          cudaMemcpyDeviceToHost, stream), "topm D2H");
+    argmax_ok = argmax_ok && check(cudaStreamSynchronize(stream), "verify sync");
     if (!argmax_ok) {
         // No tokens were emitted; leave the request exactly as before the
         // step (the chunk forward advanced hybrid state — restore it).
@@ -677,8 +868,10 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
 
     if (getenv("IMP_SPEC_TRACE")) {
         std::string s = "[verify] p0=" + std::to_string(p0) + " t0=" + std::to_string(t0) +
-                        " draft=[";
-        for (int j = 0; j < K; ++j) s += std::to_string(draft[j]) + (j + 1 < K ? "," : "");
+                        (mc_on ? " mc_cands=" + std::to_string(mc.size()) : "") + " draft=[";
+        const auto& dref = mc_on ? mc[0] : draft;
+        for (size_t j = 0; j < dref.size(); ++j)
+            s += std::to_string(dref[j]) + (j + 1 < dref.size() ? "," : "");
         s += "] argmax=[";
         for (int j = 0; j < chunk_len; ++j)
             s += std::to_string(h_spec_argmax_[j]) + (j + 1 < chunk_len ? "," : "");
@@ -686,12 +879,35 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         IMP_LOG_INFO("%s", s.c_str());
     }
 
-    // Accept the longest matching prefix and emit tokens through the same
-    // per-token bookkeeping as the eager decode path.
+    // Accept and emit through the same per-token bookkeeping as the eager
+    // decode path. mc: pick the candidate with the longest matching prefix
+    // first (ties -> higher adjacency rank), then run the shared emit loop
+    // over that candidate's rows.
+    int mc_row0 = 0;                     // row offset of the winning group
+    const std::vector<int32_t>* acc = &draft;  // tokens the emit loop verifies against
+    if (mc_on) {
+        int best_c = 0, best_m = -1;
+        for (size_t c = 0; c < mc.size(); ++c) {
+            const int r0 = static_cast<int>(c) * mc_rows_per_cand;
+            int m = 0;
+            while (m < static_cast<int>(mc[c].size()) && h_spec_argmax_[r0 + m] == mc[c][m])
+                ++m;
+            if (m > best_m) {
+                best_m = m;
+                best_c = static_cast<int>(c);
+            }
+        }
+        mc_row0 = best_c * mc_rows_per_cand;
+        acc = &mc[best_c];
+    }
+    // Linear: K (attn-scores clamp may have trimmed the staged chunk below
+    // draft.size()). mc: the winning candidate's full length.
+    const int acc_len = mc_on ? static_cast<int>(acc->size()) : K;
     int matched = 0;  // accepted draft tokens (their KV entries are valid)
     int emitted = 0;
-    for (int j = 0; j < chunk_len; ++j) {
-        const int32_t tokj = h_spec_argmax_[j];
+    for (int j = 0; j + mc_row0 < chunk_len; ++j) {
+        if (mc_on && j > acc_len) break;  // stay inside the winning group
+        const int32_t tokj = h_spec_argmax_[mc_row0 + j];
         req->output_tokens.push_back(tokj);
         track_think_state(*req, tokj);
         emitted++;
@@ -706,13 +922,52 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
             finish_request(req);
             break;
         }
-        if (j >= K || tokj != draft[j]) break;  // bonus token reached or draft diverged
+        if (j >= acc_len || tokj != (*acc)[j]) break;  // bonus reached or draft diverged
         matched++;
         // Entering a budgeted think block mid-chunk: the budget forcing lives
         // in the loop/eager path — stop extending; the accepted prefix stays.
         if (req->think_budget > 0.0f && req->in_think_block) break;
     }
     kv_manager_->touch(req->id);
+
+    // mc: materialize the winner's KV — copy its private block(s) covering
+    // the accepted span [p0, p0+matched] back over the canonical entries,
+    // then sync before the rollback below frees the private blocks (a freed
+    // block re-allocated by a concurrent prefill on another stream must not
+    // race the in-flight copy).
+    if (mc_on && req->status != RequestStatus::FINISHED) {
+        const int mc_best_c = mc_row0 / mc_rows_per_cand;
+        int srcs[KVCache::kCopyMaxPairs];
+        int dsts[KVCache::kCopyMaxPairs];
+        int n_pairs = std::min((p0 + matched) / kv_bs - mc_bp + 1, KVCache::kCopyMaxPairs);
+        for (int t = 0; t < n_pairs; ++t) {
+            srcs[t] = block_table[mc_priv_base + mc_best_c * mc_n_priv + t];
+            dsts[t] = block_table[mc_bp + t];
+        }
+        kv_cache_raw_->copy_blocks_device(srcs, dsts, n_pairs, stream);
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+    }
+
+    // Token-Recycling: feed the model's own top-M successor candidates for
+    // every real chunk row into the adjacency table — rejected rows
+    // included (the prediction is the model's, valid regardless of
+    // acceptance; that breadth is what makes the next draft fire).
+    if (recycle_m > 0) {
+        TokenRecycleTable& tr = spec_recycle_table_();
+        for (int j = 0; j < chunk_len; ++j) {
+            int32_t tok;
+            if (mc_on) {
+                const int c = j / mc_rows_per_cand;
+                const int r = j % mc_rows_per_cand;
+                if (r > static_cast<int>(mc[c].size()))
+                    continue;  // pad row of a short candidate
+                tok = (r == 0) ? t0 : mc[c][r - 1];
+            } else {
+                tok = (j == 0) ? t0 : draft[j - 1];
+            }
+            tr.observe_topk(tok, h_spec_topm_ + static_cast<size_t>(j) * recycle_m, recycle_m);
+        }
+    }
 
     // MTP bookkeeping runs BEFORE the hybrid re-forward below — it consumes
     // this chunk's hidden rows, which the re-forward overwrites.

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -71,6 +71,10 @@ struct Request {
     // tables) re-trips the acceptance economics after every re-arm window —
     // once doomed, give-up is final for this request.
     bool spec_acceptance_doomed = false;
+    // Token-Recycling feed cursor (speculative.token_recycling): output
+    // tokens up to this index are already ingested into the engine's
+    // adjacency table; prompt bigrams are fed once when it is 0.
+    int spec_recycle_fed = 0;
     // Per-request n-gram speculation override (tri-state): -1 = use the global
     // speculative.ngram default, 0 = force OFF, 1 = force ON. Lets a code-gen
     // request opt into speculation while a short tool-arg generation skips it

--- a/src/runtime/token_recycle_draft.cpp
+++ b/src/runtime/token_recycle_draft.cpp
@@ -1,0 +1,87 @@
+#include "runtime/token_recycle_draft.h"
+
+#include <algorithm>
+
+namespace imp {
+
+TokenRecycleTable::TokenRecycleTable(int vocab_size, int slots)
+    : vocab_(vocab_size), slots_(slots),
+      succ_(static_cast<size_t>(vocab_size) * slots, -1) {}
+
+void TokenRecycleTable::observe_pair(int32_t prev, int32_t next) {
+    if (!valid_(prev) || !valid_(next))
+        return;
+    int32_t* r = row_(prev);
+    // Find existing occurrence (or the end of the used region).
+    int pos = slots_ - 1;
+    for (int i = 0; i < slots_; ++i) {
+        if (r[i] == next || r[i] == -1) {
+            pos = i;
+            break;
+        }
+    }
+    // Shift [0, pos) down one and put `next` at the front (MRU).
+    for (int i = pos; i > 0; --i)
+        r[i] = r[i - 1];
+    r[0] = next;
+}
+
+void TokenRecycleTable::observe_topk(int32_t token, const int32_t* ids, int n) {
+    if (!valid_(token) || !ids)
+        return;
+    // Promote in reverse rank order so ids[0] ends up in slot 0.
+    for (int i = n - 1; i >= 0; --i)
+        observe_pair(token, ids[i]);
+}
+
+std::vector<int32_t> TokenRecycleTable::draft_linear(int32_t t0, int k) const {
+    std::vector<int32_t> out;
+    int32_t cur = t0;
+    for (int i = 0; i < k; ++i) {
+        if (!valid_(cur))
+            break;
+        int32_t s = row_(cur)[0];
+        if (s < 0)
+            break;
+        out.push_back(s);
+        cur = s;
+    }
+    return out;
+}
+
+std::vector<std::vector<int32_t>> TokenRecycleTable::draft_candidates(int32_t t0, int width,
+                                                                      int depth) const {
+    std::vector<std::vector<int32_t>> out;
+    if (!valid_(t0) || width <= 0 || depth <= 0)
+        return out;
+    const int n = std::min(width, slots_);
+    for (int c = 0; c < n; ++c) {
+        const int32_t first = row_(t0)[c];
+        if (first < 0)
+            break;  // slots are packed front-first
+        std::vector<int32_t> cand;
+        cand.push_back(first);
+        int32_t cur = first;
+        for (int j = 1; j < depth; ++j) {
+            const int32_t s = row_(cur)[0];
+            if (s < 0)
+                break;
+            cand.push_back(s);
+            cur = s;
+        }
+        out.push_back(std::move(cand));
+    }
+    return out;
+}
+
+bool TokenRecycleTable::has(int32_t token) const {
+    return valid_(token) && row_(token)[0] >= 0;
+}
+
+int32_t TokenRecycleTable::successor(int32_t token, int slot) const {
+    if (!valid_(token) || slot < 0 || slot >= slots_)
+        return -1;
+    return row_(token)[slot];
+}
+
+}  // namespace imp

--- a/src/runtime/token_recycle_draft.h
+++ b/src/runtime/token_recycle_draft.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace imp {
+
+// Token-Recycling adjacency drafter (Token Recycling, ACL 2025, arXiv
+// 2408.08696; plan: docs/plans/2026-07-22-token-recycling-spec-tree.md).
+//
+// Engine-scoped, cross-request table `token -> top-M likely successors`
+// (MRU/rank ordered, -1 = empty). Fed from (a) emitted-token bigrams and
+// (b) the model's own per-step top-K logit ids harvested in the verify
+// chunk. Unlike suffix/n-gram prompt-lookup it fires on unigram context —
+// the last emitted token has almost always been seen — so it drafts on
+// fresh reasoning text where suffix matching finds nothing. Drafts are
+// verified losslessly (greedy argmax accept), so a wrong draft can only
+// cost speed, never token identity.
+//
+// Host memory: vocab_size * slots * 4 B (150k vocab @ M=8 ≈ 4.8 MiB).
+class TokenRecycleTable {
+public:
+    TokenRecycleTable(int vocab_size, int slots);
+
+    // Record that `next` followed `prev` in emitted text. Promotes `next`
+    // to the front slot of `prev` (MRU, deduplicated). Out-of-range ids
+    // are ignored.
+    void observe_pair(int32_t prev, int32_t next);
+
+    // Record the model's top-K successor candidates for `token` (best
+    // first, e.g. from the verify-chunk logits). Establishes rank order:
+    // ids[0] lands in slot 0. Out-of-range ids are skipped.
+    void observe_topk(int32_t token, const int32_t* ids, int n);
+
+    // Follow the front-slot successor chain from t0 for up to k tokens.
+    // Stops early when a token has no successors. Cycles are allowed —
+    // bounded by k; the lossless verify is the safety net.
+    std::vector<int32_t> draft_linear(int32_t t0, int k) const;
+
+    // Multi-candidate draft (route (a) of the spec-tree plan): up to
+    // `width` candidates, one per recorded successor of t0 (rank order);
+    // candidate i starts with successor(t0, i) and continues along
+    // front-slot chains up to `depth` tokens. Empty when t0 is unseen.
+    std::vector<std::vector<int32_t>> draft_candidates(int32_t t0, int width, int depth) const;
+
+    // True when `token` has at least one recorded successor.
+    bool has(int32_t token) const;
+
+    // Successor id in `slot` (0 = most recent / best), -1 when empty or
+    // out of range. Exposed for tests and the tree drafter.
+    int32_t successor(int32_t token, int slot) const;
+
+private:
+    bool valid_(int32_t tok) const { return tok >= 0 && tok < vocab_; }
+    int32_t* row_(int32_t tok) { return succ_.data() + static_cast<size_t>(tok) * slots_; }
+    const int32_t* row_(int32_t tok) const {
+        return succ_.data() + static_cast<size_t>(tok) * slots_;
+    }
+
+    int vocab_;
+    int slots_;
+    std::vector<int32_t> succ_;  // vocab_ * slots_, -1 = empty
+};
+
+}  // namespace imp

--- a/tests/test_kv_block_copy.cu
+++ b/tests/test_kv_block_copy.cu
@@ -1,0 +1,94 @@
+// GPU tests for KVCache::copy_blocks_device — whole-block D2D copy across
+// all layers (+ scale regions), used by the multi-candidate spec verify
+// (speculative.token_recycling route (a)): each candidate gets a private
+// copy of the committed partial block; the winner's block is copied back.
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include "memory/kv_cache.h"
+
+#include <vector>
+
+namespace imp {
+namespace {
+
+void fill_block(KVCache& c, int block, uint8_t seed) {
+    for (int l = 0; l < c.n_layers(); ++l) {
+        std::vector<uint8_t> pat(c.block_bytes());
+        for (size_t i = 0; i < pat.size(); ++i)
+            pat[i] = static_cast<uint8_t>(seed + l + i);
+        cudaMemcpy(c.k_ptr(l, block), pat.data(), pat.size(), cudaMemcpyHostToDevice);
+        for (auto& b : pat) b ^= 0xA5;
+        cudaMemcpy(c.v_ptr(l, block), pat.data(), pat.size(), cudaMemcpyHostToDevice);
+        if (c.k_scale_ptr(l, block)) {
+            std::vector<uint8_t> sp(c.scale_block_bytes(l), static_cast<uint8_t>(seed ^ l));
+            cudaMemcpy(c.k_scale_ptr(l, block), sp.data(), sp.size(), cudaMemcpyHostToDevice);
+            for (auto& b : sp) b ^= 0x5A;
+            cudaMemcpy(c.v_scale_ptr(l, block), sp.data(), sp.size(), cudaMemcpyHostToDevice);
+        }
+    }
+}
+
+bool blocks_equal(KVCache& c, int a, int b) {
+    for (int l = 0; l < c.n_layers(); ++l) {
+        std::vector<uint8_t> pa(c.block_bytes()), pb(c.block_bytes());
+        cudaMemcpy(pa.data(), c.k_ptr(l, a), pa.size(), cudaMemcpyDeviceToHost);
+        cudaMemcpy(pb.data(), c.k_ptr(l, b), pb.size(), cudaMemcpyDeviceToHost);
+        if (pa != pb) return false;
+        cudaMemcpy(pa.data(), c.v_ptr(l, a), pa.size(), cudaMemcpyDeviceToHost);
+        cudaMemcpy(pb.data(), c.v_ptr(l, b), pb.size(), cudaMemcpyDeviceToHost);
+        if (pa != pb) return false;
+        if (c.k_scale_ptr(l, a)) {
+            std::vector<uint8_t> sa(c.scale_block_bytes(l)), sb(c.scale_block_bytes(l));
+            cudaMemcpy(sa.data(), c.k_scale_ptr(l, a), sa.size(), cudaMemcpyDeviceToHost);
+            cudaMemcpy(sb.data(), c.k_scale_ptr(l, b), sb.size(), cudaMemcpyDeviceToHost);
+            if (sa != sb) return false;
+            cudaMemcpy(sa.data(), c.v_scale_ptr(l, a), sa.size(), cudaMemcpyDeviceToHost);
+            cudaMemcpy(sb.data(), c.v_scale_ptr(l, b), sb.size(), cudaMemcpyDeviceToHost);
+            if (sa != sb) return false;
+        }
+    }
+    return true;
+}
+
+TEST(KVBlockCopy, FP16SingleCopy) {
+    KVCache c(4, /*n_kv_heads=*/2, /*head_dim=*/64, QType::F16, /*max_blocks=*/8);
+    fill_block(c, 1, 17);
+    fill_block(c, 3, 99);
+    const int src = 1, dst = 3;
+    c.copy_blocks_device(&src, &dst, 1, /*stream=*/nullptr);
+    cudaDeviceSynchronize();
+    EXPECT_TRUE(blocks_equal(c, 1, 3));
+}
+
+TEST(KVBlockCopy, FP8FanOutFromOneSource) {
+    KVCache c(3, 2, 64, QType::FP8_E4M3, 8);
+    fill_block(c, 0, 42);
+    fill_block(c, 2, 1);
+    fill_block(c, 4, 2);
+    const int srcs[2] = {0, 0};
+    const int dsts[2] = {2, 4};
+    c.copy_blocks_device(srcs, dsts, 2, nullptr);
+    cudaDeviceSynchronize();
+    EXPECT_TRUE(blocks_equal(c, 0, 2));
+    EXPECT_TRUE(blocks_equal(c, 0, 4));
+}
+
+TEST(KVBlockCopy, UntouchedBlockStaysIntact) {
+    KVCache c(2, 2, 64, QType::F16, 8);
+    fill_block(c, 0, 5);
+    fill_block(c, 1, 66);
+    fill_block(c, 2, 77);
+    const int src = 0, dst = 2;
+    c.copy_blocks_device(&src, &dst, 1, nullptr);
+    cudaDeviceSynchronize();
+    // Block 1 must not be modified by copying 0 -> 2.
+    std::vector<uint8_t> p(c.block_bytes()), q(c.block_bytes());
+    for (size_t i = 0; i < p.size(); ++i)
+        q[i] = static_cast<uint8_t>(66 + 0 + i);  // layer 0 pattern from fill_block
+    cudaMemcpy(p.data(), c.k_ptr(0, 1), p.size(), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(p, q);
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_rowwise_topm.cu
+++ b/tests/test_rowwise_topm.cu
@@ -1,0 +1,79 @@
+// GPU tests for the row-wise top-M logit extraction
+// (src/compute/rowwise_topm.cu) feeding the Token-Recycling adjacency
+// table from the spec-verify chunk (speculative.token_recycling).
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include "compute/rowwise_topm.h"
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// CPU reference: indices of the m largest values, ties -> lowest index first.
+std::vector<int32_t> ref_topm(const std::vector<float>& row, int m) {
+    std::vector<int32_t> idx(row.size());
+    std::iota(idx.begin(), idx.end(), 0);
+    std::stable_sort(idx.begin(), idx.end(), [&](int32_t a, int32_t b) {
+        if (row[a] != row[b]) return row[a] > row[b];
+        return a < b;
+    });
+    idx.resize(m);
+    return idx;
+}
+
+std::vector<int32_t> run_topm(const std::vector<float>& logits, int rows, int V, int m) {
+    float* d_logits = nullptr;
+    int32_t* d_out = nullptr;
+    cudaMalloc(&d_logits, logits.size() * sizeof(float));
+    cudaMalloc(&d_out, static_cast<size_t>(rows) * m * sizeof(int32_t));
+    cudaMemcpy(d_logits, logits.data(), logits.size() * sizeof(float), cudaMemcpyHostToDevice);
+    rowwise_topm(d_logits, rows, V, m, d_out, /*stream=*/nullptr);
+    std::vector<int32_t> out(static_cast<size_t>(rows) * m);
+    cudaMemcpy(out.data(), d_out, out.size() * sizeof(int32_t), cudaMemcpyDeviceToHost);
+    cudaFree(d_logits);
+    cudaFree(d_out);
+    return out;
+}
+
+TEST(RowwiseTopM, MatchesCpuReference) {
+    const int rows = 3, V = 4099, m = 4;
+    std::vector<float> logits(static_cast<size_t>(rows) * V);
+    // Deterministic pseudo-random values, distinct per position.
+    uint32_t s = 123456789u;
+    for (auto& v : logits) {
+        s = s * 1664525u + 1013904223u;
+        v = static_cast<float>(s % 100000u) / 1000.0f - 50.0f;
+    }
+    auto out = run_topm(logits, rows, V, m);
+    for (int r = 0; r < rows; ++r) {
+        std::vector<float> row(logits.begin() + static_cast<size_t>(r) * V,
+                               logits.begin() + static_cast<size_t>(r + 1) * V);
+        auto ref = ref_topm(row, m);
+        for (int j = 0; j < m; ++j)
+            EXPECT_EQ(out[r * m + j], ref[j]) << "row " << r << " rank " << j;
+    }
+}
+
+TEST(RowwiseTopM, TieBreaksLowestIndex) {
+    const int V = 1024;
+    std::vector<float> logits(V, 1.0f);  // all tied
+    auto out = run_topm(logits, 1, V, 3);
+    EXPECT_EQ(out[0], 0);
+    EXPECT_EQ(out[1], 1);
+    EXPECT_EQ(out[2], 2);
+}
+
+TEST(RowwiseTopM, M1MatchesArgmax) {
+    const int V = 2048;
+    std::vector<float> logits(V, 0.0f);
+    logits[777] = 42.0f;
+    auto out = run_topm(logits, 1, V, 1);
+    EXPECT_EQ(out[0], 777);
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_token_recycle_draft.cpp
+++ b/tests/test_token_recycle_draft.cpp
@@ -1,0 +1,140 @@
+// Host-side tests for the Token-Recycling adjacency drafter
+// (src/runtime/token_recycle_draft.cpp) used by speculative decoding.
+// Design: docs/plans/2026-07-22-token-recycling-spec-tree.md (Token
+// Recycling, ACL 2025, arXiv 2408.08696).
+
+#include "runtime/token_recycle_draft.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using imp::TokenRecycleTable;
+
+namespace {
+
+TEST(TokenRecycle, EmptyOnUnseenToken) {
+    TokenRecycleTable t(100, 4);
+    EXPECT_FALSE(t.has(7));
+    EXPECT_TRUE(t.draft_linear(7, 8).empty());
+}
+
+TEST(TokenRecycle, PairChainDraft) {
+    TokenRecycleTable t(100, 4);
+    // Observed stream: 1 -> 2 -> 3 -> 4
+    t.observe_pair(1, 2);
+    t.observe_pair(2, 3);
+    t.observe_pair(3, 4);
+    auto d = t.draft_linear(1, 8);
+    ASSERT_EQ(d.size(), 3u);  // chain ends at 4 (no successor)
+    EXPECT_EQ(d[0], 2);
+    EXPECT_EQ(d[1], 3);
+    EXPECT_EQ(d[2], 4);
+}
+
+TEST(TokenRecycle, TruncatesAtK) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);
+    t.observe_pair(2, 3);
+    t.observe_pair(3, 4);
+    auto d = t.draft_linear(1, 2);
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[0], 2);
+    EXPECT_EQ(d[1], 3);
+}
+
+TEST(TokenRecycle, MostRecentPairWins) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);
+    t.observe_pair(1, 3);  // newer observation takes the front slot
+    auto d = t.draft_linear(1, 1);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 3);
+}
+
+TEST(TokenRecycle, RepeatedPairPromotesNotDuplicates) {
+    TokenRecycleTable t(100, 2);
+    t.observe_pair(1, 2);
+    t.observe_pair(1, 3);
+    t.observe_pair(1, 2);  // promote 2 back to front; 3 must survive in slot 1
+    auto d = t.draft_linear(1, 1);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 2);
+    EXPECT_EQ(t.successor(1, 1), 3);
+}
+
+TEST(TokenRecycle, SlotsEvictOldest) {
+    TokenRecycleTable t(100, 2);
+    t.observe_pair(1, 10);
+    t.observe_pair(1, 11);
+    t.observe_pair(1, 12);  // evicts 10 (LRU with 2 slots)
+    EXPECT_EQ(t.successor(1, 0), 12);
+    EXPECT_EQ(t.successor(1, 1), 11);
+    EXPECT_EQ(t.successor(1, 2), -1);  // out of slots
+}
+
+TEST(TokenRecycle, TopKObservationSetsRankOrder) {
+    TokenRecycleTable t(100, 4);
+    const int32_t ids[3] = {5, 6, 7};  // model's top-3 for token 1, best first
+    t.observe_topk(1, ids, 3);
+    EXPECT_EQ(t.successor(1, 0), 5);
+    EXPECT_EQ(t.successor(1, 1), 6);
+    EXPECT_EQ(t.successor(1, 2), 7);
+    auto d = t.draft_linear(1, 1);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 5);
+}
+
+TEST(TokenRecycle, SelfLoopChainStillBounded) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 1);  // degenerate self-successor
+    auto d = t.draft_linear(1, 5);
+    ASSERT_EQ(d.size(), 5u);  // bounded by k, verify is the safety net
+    for (int32_t v : d) EXPECT_EQ(v, 1);
+}
+
+TEST(TokenRecycle, IgnoresOutOfRangeIds) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 200);   // next out of vocab — dropped
+    t.observe_pair(-1, 2);    // prev invalid — dropped
+    t.observe_pair(200, 2);   // prev out of vocab — dropped
+    EXPECT_FALSE(t.has(1));
+    EXPECT_TRUE(t.draft_linear(1, 4).empty());
+    const int32_t ids[2] = {150, 3};  // out-of-range entry skipped, valid kept
+    t.observe_topk(1, ids, 2);
+    EXPECT_EQ(t.successor(1, 0), 3);
+    EXPECT_EQ(t.successor(1, 1), -1);
+}
+
+TEST(TokenRecycle, CandidatesBranchAtRoot) {
+    TokenRecycleTable t(100, 4);
+    const int32_t ids[3] = {5, 6, 7};  // top-3 successors of 1
+    t.observe_topk(1, ids, 3);
+    t.observe_pair(5, 50);  // chain continuations
+    t.observe_pair(6, 60);
+    // 3 candidates, depth 2: [5,50], [6,60], [7] (7 has no successor).
+    auto c = t.draft_candidates(1, 3, 2);
+    ASSERT_EQ(c.size(), 3u);
+    ASSERT_EQ(c[0].size(), 2u);
+    EXPECT_EQ(c[0][0], 5);
+    EXPECT_EQ(c[0][1], 50);
+    ASSERT_EQ(c[1].size(), 2u);
+    EXPECT_EQ(c[1][0], 6);
+    EXPECT_EQ(c[1][1], 60);
+    ASSERT_EQ(c[2].size(), 1u);
+    EXPECT_EQ(c[2][0], 7);
+}
+
+TEST(TokenRecycle, CandidatesLimitedBySlots) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);  // only one successor known
+    auto c = t.draft_candidates(1, 4, 3);
+    ASSERT_EQ(c.size(), 1u);
+    EXPECT_EQ(c[0][0], 2);
+}
+
+TEST(TokenRecycle, CandidatesEmptyOnUnseenRoot) {
+    TokenRecycleTable t(100, 4);
+    EXPECT_TRUE(t.draft_candidates(9, 4, 3).empty());
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

**Adversarial perf audit** (`docs/audit/PERF_AUDIT_2026_07_23.md`): a fresh nsys/ncu measurement pass over every prior ceiling conclusion. Confirms: dense NVFP4 decode runs at ~80% of the absolute weight-bandwidth wall, MoE expert GEMVs at 55-71% HBM, prefill leads with zero legacy-softmax launches — the one factor-level lever left is speculation quality on reasoning text (0 drafts dense / 81% miss rate MoE, measured).

**Implements plan milestones 1-3** (`docs/plans/2026-07-22-token-recycling-spec-tree.md`), all behind `speculative.token_recycling` (default **OFF**):

- `TokenRecycleTable` — engine-scoped `token -> top-M successors`, fed from emitted bigrams + the model's own verify-chunk top-K logits (new `rowwise_topm` kernel in the verify lm-head pass).
- **Route (a) multi-candidate verify** — `recycle_width` candidates per chunk, each with its own t0 row and *private copies of the KV blocks its rows write* (the per-row block tables already resolve reads AND writes per row; new `KVCache::copy_blocks_device` seeds/collects the partial block). No token-level attention mask needed; winner = longest argmax prefix; lossless by construction.

## Measured (Qwen3-14B-NVFP4, reasoning prompt, healthy host)

| arm | tg tok/s | emitted/verify |
|---|---|---|
| spec-off | 170.7-171.4 | — |
| TR multi-candidate (doom-protected) | 168-170 | 2.00 |
| TR forced always-on | 116-129 | 1.74-1.86 |

**The drafter works (accept 0 -> ~2.0 on reasoning) but does not pay yet**: the verify step costs ~2x a decode step, so break-even accept is ~1.9-2.2. Fresh decomposition puts the cost in (1) ~8.2 ms of M=17 CUTLASS GEMMs that bypass the NVFP4 overlay on ST-native models (GEMV-equivalent ~4.8 ms) and (2) ~7 ms host sync/staging (cudaStreamSynchronize = 45% of API time on WSL2). Cheapening the verify to ~1.2x a decode step turns the measured accept into **+40-65% reasoning decode** with no drafter change — that follow-up is the next lever.

## Verification

- 15 new host/GPU tests (adjacency semantics, rowwise top-M vs CPU reference, KV block copy); full GPU suite green (0 failures, model-gated skips only)
- `make verify-fast` green (decode/prefill gates, graphs 2.5x, smoke)
- Greedy output **byte-identical** to spec-off with the flag on (linear and multi-candidate arms) and on the default path (no default behavior change)

**No auto-merge**: per the audit's own rule (no merge without a proven speedup) this ships the flag-gated foundation + measurement; the default stays off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV