### PR TITLE
perf(spec): single-sweep batched-GEMV verify route, bucket 4, verify telemetry (#1055 tranche 1-3)

### DIFF
--- a/docs/audit/PERF_AUDIT_2026_07_23.md
+++ b/docs/audit/PERF_AUDIT_2026_07_23.md
@@ -187,12 +187,21 @@ today, ~11–13 ms reachable):
 1. **Small-M NVFP4 GEMM efficiency — same root as issue #1055.** The
    M≤128 CUTLASS class runs at ~half effective bandwidth; fixing it serves
    the verify chunk AND the short-prompt prefill (~3–4 ms at pp128).
-2. **Exempt head/embed weights from the prefill-capture dequant gate**
-   (only layer weights can hit the captured M>1 fallback) → re-enables
-   prefill graphs on 14B/Coder/Nemotron/35B ST heroes, saves the eager
-   launch-gap share (~2–3 ms at pp128, more on launch-overhead-sensitive
-   WSL2 days; failure mode if wrong is a loud capture abort, not silent
-   corruption).
+2. ~~Exempt head/embed weights from the prefill-capture dequant gate~~ —
+   **BUILT AND REFUTED (same day, reverted).** The gate's stated reason IS
+   wrong (the ~1.5 GiB lm_head dequant target blocks capture although the
+   captured prefill runs the lm_head at M=1 only — the exemption worked and
+   capture engaged cleanly), but enabling capture on ST-native NVFP4 models
+   measured net-NEGATIVE to neutral: interleaved A/B on 14B-NVFP4, 8–30
+   reps, `runtime.prefill_graph` on/off — pp128 15.3–23.6 ms (on) vs
+   12.6–15.3 ms (off); with a capture hysteresis added (capture only on
+   repeated geometry) still 13.3 vs 12.8 ms at 30 reps. Root cause: the
+   NVFP4-ST eager prefill issues only ~240 CUTLASS launches, so graph
+   replay saves nothing, while capture/instantiate costs ~3–9 ms whenever
+   the geometry or engine resets (every CLI/bench rep; 13 instantiates in a
+   10-rep run). GGUF (Q8) keeps a marginal capture win (25.0 vs 26.3 ms at
+   pp128) — its default stays as-is. The misleading WARN is cosmetic; the
+   real short-prompt lever is the small-M GEMM path (item 1 / issue #1055).
 3. Coder-30B pp128 anomaly (24.3 ms > pp512's 21.5 ms): grouped-GEMM
    tokens-per-expert collapse at small batch — needs its own scoping.
 4. Multi-turn TTFT is already served by the prefix cache (23× flat,

--- a/docs/audit/PERF_AUDIT_2026_07_23.md
+++ b/docs/audit/PERF_AUDIT_2026_07_23.md
@@ -204,6 +204,23 @@ net-positive if the verify ratio drops below ~1.3× (then ≈ +8–15% at the
 measured accept), which is the remaining host-overhead / small-M-CUTLASS
 work on #1055.
 
+**Verify-ratio close-out (third tranche):** permanent `ms/verify` telemetry
+added to the `[spec-ngram]` line — ground truth says the bucket-3 verify
+wall is **7.8–8.0 ms = 1.30–1.35× a decode step** (the earlier 1.53× was a
+flawed tg-derived estimate); the issue-#1055 ≤1.4× criterion is met by the
+GEMV route alone. Consolidated pinned staging (one H2D for tokens/
+positions/row-lens/scalars instead of six pageable copies, pinned row
+tables, one combined argmax+topm D2H) lands in the noise (wall unchanged,
+tg 320→331) — the wall is GPU-dominated. A verify-burst chain (verify →
+draft → verify without returning to the scheduler) measured **−14% and was
+reverted** (it disrupts the miss-burst pattern; misses 10→19). The
+remaining effective gap is ~1.3 ms/step of eager-loop scheduler/API tax
+between verifies — structural, needs verify-in-loop. CUTLASS small-M for
+buckets ≥5 scoped, not built: both shipped tiles are M=128 (cooperative
+128×128×128, small-N pingpong 128×64×128) and the SfAtom scale layout is
+built from 128-row atoms — a smaller-M instantiation is its own
+compile-and-sweep session.
+
 **TR verdict (cold single-request): still accept-limited.** Linear chain
 first-hop hit ≈ 0.44, deeper hops collapse → emitted ≈ 1.4/verify vs the
 now-1.5× break-even; streak-gating trades recall for precision without net

--- a/docs/audit/PERF_AUDIT_2026_07_23.md
+++ b/docs/audit/PERF_AUDIT_2026_07_23.md
@@ -192,6 +192,18 @@ Greedy output stays byte-identical (spec-off vs suffix vs TR); full GPU
 suite + verify-fast green (decode-gate FAIL on the morning run = the known
 cross-day drift, 279 vs pin 288 at healthy clocks, identical pre-change).
 
+**Warm cross-request table MEASURED (server agent-loop, 10-turn growing
+conversation, 400 tok/turn, think-budget 0, prefix cache on):** spec-off
+163.9 tok/s · TR (suffix off) 163.1 · default suffix 165.7. The warm table
+lifts TR accept from 1.44 (cold CLI) to **1.77 emitted/verify — and
+plateaus immediately** (flat across all 10 turns / 4000 tokens, ~18% of
+output via verifies, no doom). At the current ~1.5× verify cost that is
+exactly break-even → neutral. **The "warm table = win condition"
+hypothesis is refuted for this model/workload class**; TR only becomes
+net-positive if the verify ratio drops below ~1.3× (then ≈ +8–15% at the
+measured accept), which is the remaining host-overhead / small-M-CUTLASS
+work on #1055.
+
 **TR verdict (cold single-request): still accept-limited.** Linear chain
 first-hop hit ≈ 0.44, deeper hops collapse → emitted ≈ 1.4/verify vs the
 now-1.5× break-even; streak-gating trades recall for precision without net

--- a/docs/audit/PERF_AUDIT_2026_07_23.md
+++ b/docs/audit/PERF_AUDIT_2026_07_23.md
@@ -158,6 +158,52 @@ that lands.
 
 ---
 
+## Lever #2 build results (issue #1055, same branch, second session)
+
+**Correction to the premise:** the batched GEMV (`gemv_nvfp4_kpar_mb_*`)
+reads the weight once per **MR=4 activation tile**, not once per chunk —
+at M=17 that is 5 weight sweeps ≈ 3.5× worse than CUTLASS. The GEMV route
+only wins in the single-tile regime. What shipped:
+
+1. **Native ST-NVFP4 verify chunks at M≤4 route to the batched GEMV**
+   (`executor_gemm_dispatch.cu`, sibling of the #1001 GGUF overlay; same
+   weight + linear micro-scales the M=1 decode GEMV reads). New MR=3 tile
+   instantiation (bucket 3 previously paid `<2>+<1>` = two sweeps), new
+   `gemm_nvfp4_batched_acc` (beta=1) so the o/down residual GEMMs route
+   too; GGUF overlay extended to beta=1 as well. `prefill_routes_
+   cutlass_nvfp4_` mirror kept in sync. Buckets ≥5 stay CUTLASS by design.
+2. **Capture bucket 4** added (chunk 4 = one MR=4 sweep; previously padded
+   into bucket 5 = two sweeps).
+3. mc copy-back sync skipped in single-stream steady state; TR defaults
+   re-tuned (depth 3 / width 1 / new `recycle_min_streak` precision gate).
+
+**Measured (Qwen3-14B-NVFP4, drift-day, all A/Bs interleaved same-session,
+kill-switch `speculative.verify_nvfp4_gemm`):**
+
+| workload | before | after |
+|---|---|---|
+| bench k=2 (bucket-3 verifies, capture on) | 239 | **320 tok/s (+34%)** |
+| bench k=16 (3-tok suffix drafts → now bucket 4) | 304 | **353 tok/s (+16%)** |
+| verify step (bucket 3, ctx ~600) | 12.3 ms | **9.2 ms** (ratio vs decode 2.05× → 1.53×) |
+| TR forced on reasoning (was bucket 17) | 112–129 | 165–166 (≈ spec-off) |
+| Q6_K GGUF k=2 (beta-1 overlay) | 158.9 | 158.6 (neutral) |
+
+Greedy output stays byte-identical (spec-off vs suffix vs TR); full GPU
+suite + verify-fast green (decode-gate FAIL on the morning run = the known
+cross-day drift, 279 vs pin 288 at healthy clocks, identical pre-change).
+
+**TR verdict (cold single-request): still accept-limited.** Linear chain
+first-hop hit ≈ 0.44, deeper hops collapse → emitted ≈ 1.4/verify vs the
+now-1.5× break-even; streak-gating trades recall for precision without net
+gain; multi-candidate at bucket 4 (2×depth-1) measured 151 tok/s (worse).
+The reasoning +15% needs either sub-1.3× verify cost (remaining: ~2.5 ms
+host + non-GEMM GPU per step) or a warm cross-request table (server agent
+loops — unmeasured; the CLI cold-start is the worst case). TR default
+stays OFF; the #1055 verify-cost work benefits the DEFAULT suffix path
+wherever drafts are ≤3 tokens (+16–34% measured above).
+
+---
+
 ## TTFT addendum (same session): the short-prompt floor
 
 Prefill wall by prompt size, warm engine, 5 reps (healthy host):

--- a/docs/audit/PERF_AUDIT_2026_07_23.md
+++ b/docs/audit/PERF_AUDIT_2026_07_23.md
@@ -155,3 +155,45 @@ verify step to ~1.2× a decode step drops break-even accept to ~1.2 — the
 measured TR accept of 1.7–2.0 then yields **+40–65% decode on reasoning**
 without any drafter improvement. Token-Recycling stays default-off until
 that lands.
+
+---
+
+## TTFT addendum (same session): the short-prompt floor
+
+Prefill wall by prompt size, warm engine, 5 reps (healthy host):
+
+| pp | 14B-NVFP4 | Coder-30B-FP4 |
+|---|---|---|
+| 32 | 18.8 ms (1.7k tok/s) | 14.7 ms |
+| 128 | 12.0 ms (10.6k) | **24.3 ms** (5.3k) |
+| 512 | 19.8 ms (25.8k) | 21.5 ms (23.8k) |
+| 2048 | 62.0 ms (33.0k) | 40.3 ms (50.8k) |
+
+Short prompts — the agentic incremental-turn case — sit on a **~12–25 ms
+floor** while the same GEMM work at pp2048 streams at 33–50k tok/s; two
+anomalies (14B pp32 > pp128; Coder pp128 > pp512) mark path-selection
+effects, not noise. Decomposition at 14B pp128 (nsys): ~9 ms GPU in M=128
+CUTLASS NVFP4 GEMMs at ~51% of the weight-sweep bandwidth bound (4.6 ms
+ideal) + ~2.5–10 ms host/launch gaps — **prefill graph capture is disabled
+on every ST-native NVFP4 hero** because the workspace gate treats the
+~1.5 GiB fp16 dequant target of the **lm_head** as capture-blocking
+(`executor_workspace_buffers.cu` kCap=512 MiB check sets
+`nvfp4_dequant_uncapturable_`), even though prefill only ever runs the
+lm_head at M=1 (last position) and never through the M>1 dequant fallback.
+
+TTFT levers, ranked (short-prompt TTFT ≈ prefill + 1 decode step ≈ 18–30 ms
+today, ~11–13 ms reachable):
+
+1. **Small-M NVFP4 GEMM efficiency — same root as issue #1055.** The
+   M≤128 CUTLASS class runs at ~half effective bandwidth; fixing it serves
+   the verify chunk AND the short-prompt prefill (~3–4 ms at pp128).
+2. **Exempt head/embed weights from the prefill-capture dequant gate**
+   (only layer weights can hit the captured M>1 fallback) → re-enables
+   prefill graphs on 14B/Coder/Nemotron/35B ST heroes, saves the eager
+   launch-gap share (~2–3 ms at pp128, more on launch-overhead-sensitive
+   WSL2 days; failure mode if wrong is a loud capture abort, not silent
+   corruption).
+3. Coder-30B pp128 anomaly (24.3 ms > pp512's 21.5 ms): grouped-GEMM
+   tokens-per-expert collapse at small batch — needs its own scoping.
+4. Multi-turn TTFT is already served by the prefix cache (23× flat,
+   2026-07-15); long-context TTFT (8k–64k) is pinned and healthy (#1022).

--- a/docs/plans/2026-07-22-token-recycling-spec-tree.md
+++ b/docs/plans/2026-07-22-token-recycling-spec-tree.md
@@ -2,11 +2,16 @@
 
 **Status:** milestones 1–3 implemented 2026-07-23 (flag-gated
 `speculative.token_recycling`, default OFF; route (a) multi-candidate via
-per-candidate private KV blocks — no mask needed). Measured: accept lifted
-0 → 1.7–2.0 emitted/verify on reasoning, but net-neutral at today's verify
-step cost (~2x a decode step). **Blocked on cheapening the verify step**
-(M≤17 CUTLASS GEMMs → multirow GEMV overlay + per-verify sync/staging cuts);
-see docs/audit/PERF_AUDIT_2026_07_23.md for the full decomposition.
+per-candidate private KV blocks — no mask needed). Verify cost cut the same
+day (#1055 first tranche: single-sweep batched-GEMV route for chunks ≤4,
+2.05× → 1.53× a decode step; bench k=2 +34%). Measured end state: accept
+1.44 cold / **1.77 warm** (server agent-loop, plateaus immediately) vs the
+~1.5× break-even → **neutral in both cold and warm cases — the warm-table
+hypothesis is refuted for this class**. Route (b) (true tree mask) is NOT
+warranted by these accept numbers (kill criterion §Risks: <1.3 applies to
+the deeper-hop accept, which collapses to ~0.05). TR stays default-off;
+re-evaluate only if the remaining #1055 work pushes the verify ratio below
+~1.3×. Full numbers: docs/audit/PERF_AUDIT_2026_07_23.md.
 
 ## Motivation (measured, not assumed)
 

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -474,16 +474,20 @@ k                    = 16
 # Token-Recycling adjacency drafting (arXiv 2408.08696): engine-scoped
 # `token -> top-M successors` table fed from emitted bigrams and the
 # model's own verify-chunk top-K logits; drafts where suffix/n-gram find
-# nothing (fresh reasoning prose). recycle_width > 1 verifies that many
-# candidates per chunk on the dense decode-attn route (per-candidate
-# private KV blocks, lossless argmax accept). EXPERIMENTAL: measured
-# accept 1.7-2.0 emitted/verify on reasoning (2026-07-23) — at the
-# current ~2x verify-step cost that is net-neutral; default OFF until
-# the verify step gets cheaper (see docs/audit/PERF_AUDIT_2026_07_23.md).
+# nothing (fresh reasoning prose). recycle_depth 3 keeps the chunk in
+# capture bucket 4 = one batched-GEMV weight sweep (#1055);
+# recycle_min_streak only drafts re-confirmed successors (precision gate);
+# recycle_width > 1 verifies that many candidates per chunk (measured: the
+# accept lift does not pay for the bigger chunk — keep 1). EXPERIMENTAL,
+# default OFF: cold-start accept on fresh reasoning measures ~1.4
+# emitted/verify vs the ~1.5x verify break-even (2026-07-23, single
+# request; the cross-request warm table is the open question — see
+# docs/audit/PERF_AUDIT_2026_07_23.md).
 token_recycling      = false
 recycle_slots        = 8
-recycle_depth        = 8
-recycle_width        = 4
+recycle_depth        = 3
+recycle_width        = 1
+recycle_min_streak   = 1
 # Suffix-indexed drafting (SuffixDecoding-style): hash-indexed suffix
 # matching instead of a per-step backward scan, continuations picked by
 # frequency vote across all occurrences, and adaptive draft length — a

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -721,7 +721,7 @@ private:
     // dedupe at the QKV / gate-up call sites — must be CONSERVATIVE: a
     // false negative just re-quantizes; a false positive would skip with a
     // stale scratch.
-    bool prefill_routes_cutlass_nvfp4_(TensorID id) const;
+    bool prefill_routes_cutlass_nvfp4_(TensorID id, int M) const;
     // MoE forward-pass phase helpers. The per-call locals live in the
     // MoeFfnContext struct declared just above the GraphExecutor class.
     void moe_ffn_phase1_setup_(int layer, cudaStream_t stream);

--- a/src/exec/executor_attention_qkv.cu
+++ b/src/exec/executor_attention_qkv.cu
@@ -303,9 +303,9 @@
                     // once (Q's dispatch) and let K/V skip the re-quantize
                     // via the act-quant hint. Bit-identical reuse.
                     GemmContext kv_ctx = ctx;
-                    if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.wq_id) &&
-                        prefill_routes_cutlass_nvfp4_(ly.wk_id) &&
-                        (ly.wv.data == nullptr || prefill_routes_cutlass_nvfp4_(ly.wv_id))) {
+                    if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.wq_id, n) &&
+                        prefill_routes_cutlass_nvfp4_(ly.wk_id, n) &&
+                        (ly.wv.data == nullptr || prefill_routes_cutlass_nvfp4_(ly.wv_id, n))) {
                         kv_ctx = ctx.with_act_quant_hint(no.data, n,
                                                          static_cast<int>(no.shape[1]));
                     }

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -239,8 +239,8 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                     // gate's dispatch quantizes it into the activation
                     // scratch, up skips the re-quantize (act-quant hint).
                     GemmContext up_ctx = ctx;
-                    if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.w_gate_id) &&
-                        prefill_routes_cutlass_nvfp4_(ly.w_up_id)) {
+                    if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.w_gate_id, n) &&
+                        prefill_routes_cutlass_nvfp4_(ly.w_up_id, n)) {
                         up_ctx = ctx.with_act_quant_hint(no.data, n,
                                                          static_cast<int>(no.shape[1]));
                     }

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -120,11 +120,16 @@ static void gemm_dispatch_uncached_fallback(const Tensor& input, const Tensor& w
 // shared activation scratch). Every earlier-return route in gemm_via_handle_
 // must answer false here.
 // ---------------------------------------------------------------------------
-bool GraphExecutor::prefill_routes_cutlass_nvfp4_(TensorID id) const {
+bool GraphExecutor::prefill_routes_cutlass_nvfp4_(TensorID id, int M) const {
     if (id == kInvalidTensorID)
         return false;
     const auto& h = registry_.handle(id);
     if (h.primary_tier != StorageTier::CUTLASS_NVFP4)
+        return false;
+    // #1055: small-M verify chunks divert to the batched NVFP4 GEMV overlay
+    // (native branch in gemm_via_handle_) — no CUTLASS activation quant.
+    if (cur_spec_verify_ && runtime_config().speculative.verify_nvfp4_gemm && M <= 4 &&
+        h.source_data != nullptr && h.source_scales != nullptr)
         return false;
     StorageTier prefill =
         (h.prefill_tier != StorageTier::Undefined) ? h.prefill_tier : h.primary_tier;
@@ -275,17 +280,45 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         // read NVFP4 directly via the CUTLASS prefill block below (and the
         // prefill_routes_cutlass_nvfp4_ mirror above must stay in sync with
         // every earlier return here — dequantable sources answer false there).
-        if (ctx.spec_verify_small_m && ctx.beta == 0.0f && M <= 33 &&
+        if (ctx.spec_verify_small_m && (ctx.beta == 0.0f || ctx.beta == 1.0f) && M <= 33 &&
             input.qtype == QType::F16 && output.qtype == QType::F16 &&
             h.source_data != nullptr && dequant_gpu_supported(h.source_qtype)) {
             auto it = ctx.wcache->nvfp4.find(h.source_data);
             if (it != ctx.wcache->nvfp4.end()) {
-                gemm_nvfp4_batched(it->second, reinterpret_cast<const half*>(input.data),
-                                   reinterpret_cast<half*>(output.data),
-                                   static_cast<int>(h.shape[0]), static_cast<int>(h.shape[1]),
-                                   M, ctx.stream);
+                // beta=1 (o/down residual add, #1055): accumulate variant —
+                // previously these two fell through to the per-chunk dequant
+                // path the overlay exists to avoid.
+                auto& fn = (ctx.beta == 1.0f) ? gemm_nvfp4_batched_acc : gemm_nvfp4_batched;
+                fn(it->second, reinterpret_cast<const half*>(input.data),
+                   reinterpret_cast<half*>(output.data), static_cast<int>(h.shape[0]),
+                   static_cast<int>(h.shape[1]), M, ctx.stream);
                 return;
             }
+        }
+        // #1055: native ST-NVFP4 verify chunks. The CUTLASS prefill block
+        // below serves them correctly but at ~51% of the weight-sweep
+        // bandwidth for tiny M (measured 200 launches x 39-51 us per bucket-17
+        // verify). The batched GEMV reads the weight once per MR=4 activation
+        // tile, so it only wins in the single-tile regime — hard cap M <= 4
+        // (bucket 3 + the 4-row edge); larger chunks stay on CUTLASS (5+
+        // weight sweeps at M=17 would be ~3.5x worse). Same weight + linear
+        // micro-scales the M=1 decode GEMV reads (source_data/source_scales),
+        // so verify rows stay in the decode kernel family (argmax parity).
+        if (ctx.spec_verify_small_m && (ctx.beta == 0.0f || ctx.beta == 1.0f) && M <= 4 &&
+            input.qtype == QType::F16 && output.qtype == QType::F16 &&
+            h.primary_tier == StorageTier::CUTLASS_NVFP4 && h.source_data != nullptr &&
+            h.source_scales != nullptr && !dequant_gpu_supported(h.source_qtype)) {
+            NvFP4QuantResult nv;
+            nv.packed_data = const_cast<void*>(h.source_data);
+            nv.micro_scales = h.source_scales;
+            nv.tensor_scale = h.source_tensor_scale;
+            nv.N = h.shape[0];
+            nv.K = h.shape[1] * 2;
+            auto& fn = (ctx.beta == 1.0f) ? gemm_nvfp4_batched_acc : gemm_nvfp4_batched;
+            fn(nv, reinterpret_cast<const half*>(input.data),
+               reinterpret_cast<half*>(output.data), static_cast<int>(nv.N),
+               static_cast<int>(nv.K), M, ctx.stream);
+            return;
         }
 
         // Q4_K HMMA GEMM: in-SMEM dequant + FP16 HMMA m16n8k16 tile kernel.

--- a/src/quant/nvfp4_gemm.h
+++ b/src/quant/nvfp4_gemm.h
@@ -46,6 +46,9 @@ void gemv_nvfp4_kpar_batched_fp32(const NvFP4QuantResult& A, const half* x, floa
 // FP32 LM-head variant above.
 void gemm_nvfp4_batched(const NvFP4QuantResult& A, const half* x, half* y, int N_out, int K,
                         int n_act, cudaStream_t stream);
+// beta=1 twin: y += A @ x (o/down residual-add verify GEMMs, #1055).
+void gemm_nvfp4_batched_acc(const NvFP4QuantResult& A, const half* x, half* y, int N_out, int K,
+                            int n_act, cudaStream_t stream);
 
 // Fused QKV: 3 weight matrices, shared input, separate outputs
 void gemv_nvfp4_qkv_fused(const NvFP4QuantResult& wq, const NvFP4QuantResult& wk, const NvFP4QuantResult& wv,

--- a/src/quant/nvfp4_gemv_dense.cu
+++ b/src/quant/nvfp4_gemv_dense.cu
@@ -435,6 +435,11 @@ void gemv_nvfp4_kpar_batched_fp32(const NvFP4QuantResult& A, const half* x, floa
             pdl::launch(gemv_nvfp4_kpar_mb_fp32_kernel<4>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
                         pd, ms, ts, xm, ym, N_out, K);
             used = 4;
+        } else if (rem == 3) {
+            // Bucket-3 verify lm_head: one sweep instead of <2>+<1> (#1055).
+            pdl::launch(gemv_nvfp4_kpar_mb_fp32_kernel<3>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 3;
         } else if (rem >= 2) {
             pdl::launch(gemv_nvfp4_kpar_mb_fp32_kernel<2>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
                         pd, ms, ts, xm, ym, N_out, K);
@@ -450,8 +455,9 @@ void gemv_nvfp4_kpar_batched_fp32(const NvFP4QuantResult& A, const half* x, floa
 
 // FP16-output twin of gemv_nvfp4_kpar_mb_fp32_kernel for spec-verify chunk
 // GEMMs (#998): one block per weight row n, the row decoded once and reused
-// across the MR activation rows of this launch.
-template <int MR>
+// across the MR activation rows of this launch. kAcc adds into the existing
+// output (cuBLAS beta=1 semantics) for the o/down residual-add GEMMs (#1055).
+template <int MR, bool kAcc = false>
 __global__ void __launch_bounds__(kKparThreads) gemv_nvfp4_kpar_mb_fp16_kernel(
     const uint8_t* __restrict__ packed_data, const uint8_t* __restrict__ micro_scales, float tensor_scale,
     const half* __restrict__ x, half* __restrict__ y, int N_out, int K) {
@@ -508,8 +514,12 @@ __global__ void __launch_bounds__(kKparThreads) gemv_nvfp4_kpar_mb_fp16_kernel(
 #pragma unroll
     for (int m = 0; m < MR; ++m) {
         float total = reduce_kpar(acc[m], tid, warp_sums);
-        if (tid == 0)
-            y[(int64_t)m * N_out + n] = __float2half(total);
+        if (tid == 0) {
+            half* yp = y + (int64_t)m * N_out + n;
+            if (kAcc)
+                total += __half2float(*yp);
+            *yp = __float2half(total);
+        }
         __syncthreads();  // reuse warp_sums for the next activation row
     }
 }
@@ -531,6 +541,12 @@ void gemm_nvfp4_batched(const NvFP4QuantResult& A, const half* x, half* y, int N
             pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<4>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
                         pd, ms, ts, xm, ym, N_out, K);
             used = 4;
+        } else if (rem == 3) {
+            // Dedicated 3-row tile: capture bucket 3 (the k=2 verify chunk)
+            // otherwise pays TWO weight sweeps (<2> + <1>) — #1055.
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<3>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
+                        pd, ms, ts, xm, ym, N_out, K);
+            used = 3;
         } else if (rem >= 2) {
             pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<2>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
                         pd, ms, ts, xm, ym, N_out, K);
@@ -538,6 +554,39 @@ void gemm_nvfp4_batched(const NvFP4QuantResult& A, const half* x, half* y, int N
         } else {
             pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<1>, dim3(N_out), dim3(kKparThreads), size_t(0), stream,
                         pd, ms, ts, xm, ym, N_out, K);
+            used = 1;
+        }
+        done += used;
+    }
+}
+
+// beta=1 twin: y[m,n] += A[n,:] @ x[m,:] (o/down residual-add verify GEMMs).
+void gemm_nvfp4_batched_acc(const NvFP4QuantResult& A, const half* x, half* y, int N_out, int K,
+                            int n_act, cudaStream_t stream) {
+    const auto* pd = reinterpret_cast<const uint8_t*>(A.packed_data);
+    const auto* ms = reinterpret_cast<const uint8_t*>(A.micro_scales);
+    const float ts = A.tensor_scale;
+    int done = 0;
+    while (done < n_act) {
+        const int rem = n_act - done;
+        const half* xm = x + (int64_t)done * K;
+        half* ym = y + (int64_t)done * N_out;
+        int used;
+        if (rem >= 4) {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<4, true>, dim3(N_out), dim3(kKparThreads),
+                        size_t(0), stream, pd, ms, ts, xm, ym, N_out, K);
+            used = 4;
+        } else if (rem == 3) {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<3, true>, dim3(N_out), dim3(kKparThreads),
+                        size_t(0), stream, pd, ms, ts, xm, ym, N_out, K);
+            used = 3;
+        } else if (rem >= 2) {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<2, true>, dim3(N_out), dim3(kKparThreads),
+                        size_t(0), stream, pd, ms, ts, xm, ym, N_out, K);
+            used = 2;
+        } else {
+            pdl::launch(gemv_nvfp4_kpar_mb_fp16_kernel<1, true>, dim3(N_out), dim3(kKparThreads),
+                        size_t(0), stream, pd, ms, ts, xm, ym, N_out, K);
             used = 1;
         }
         done += used;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -301,6 +301,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("speculative.recycle_slots", cfg.speculative.recycle_slots);
     I("speculative.recycle_depth", cfg.speculative.recycle_depth);
     I("speculative.recycle_width", cfg.speculative.recycle_width);
+    I("speculative.recycle_min_streak", cfg.speculative.recycle_min_streak);
     B("speculative.suffix", cfg.speculative.suffix);
     I("speculative.suffix_k_max", cfg.speculative.suffix_k_max);
     I("speculative.min_match", cfg.speculative.min_match);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -793,7 +793,16 @@ struct RuntimeConfig {
         // argmax verify. Default off until the reasoning A/B proves it.
         bool token_recycling = false;
         int recycle_slots = 8;  // successors kept per token (MRU/rank order)
-        int recycle_depth = 8;  // max linear draft length per verify step
+        // Linear draft length. Default 3 -> chunk 4 -> capture bucket 4 =
+        // exactly one batched-GEMV weight sweep (M=4, #1055); deeper chains
+        // pad into bucket 5+ and pay a second sweep.
+        int recycle_depth = 3;
+        // Precision gate (#1055): only draft hops whose front slot was
+        // re-confirmed at least this many times (bigram repeated / model
+        // top-1 stable). A verify step costs ~1.4x a decode step while a
+        // miss just rides the async-loop burst — precision beats recall.
+        // 0 = draft on any known successor.
+        int recycle_min_streak = 1;
         // Multi-candidate verify (route (a) of the spec-tree plan): when the
         // decode-attn route is available (dense, non-MLA/SWA/MoE/hybrid, no
         // penalties/MTP), verify `recycle_width` adjacency candidates in one
@@ -801,8 +810,12 @@ struct RuntimeConfig {
         // the KV blocks its rows write (per-row block tables), so no token
         // mask is needed and the argmax accept stays lossless. Rows are
         // capped at the 17 bucket (width * (1+depth) <= 17), i.e. width 4
-        // -> depth 3. 1 = linear drafting only.
-        int recycle_width = 4;
+        // -> depth 3. Default 1 (linear): at bucket 17 the chunk GEMMs run
+        // CUTLASS at ~51% effective bandwidth (measured 2026-07-23) — the
+        // multi-candidate accept lift (2.0 vs 1.44 emitted/verify) does not
+        // pay for the 2x-costlier chunk; linear bucket-4 chunks ride the
+        // single-sweep batched GEMV instead.
+        int recycle_width = 1;
         // SuffixDecoding-style indexed drafting (arXiv 2411.04975):
         // hash-indexed suffix matching (O(1) amortized vs the legacy O(n)
         // backward scan per verify step) with frequency-voted continuations

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -781,24 +781,30 @@ private:
     void spec_recycle_feed_(Request& req);
     std::unique_ptr<TokenRecycleTable> spec_recycle_;
     // Device/pinned staging for the verify chunk (lazy-init, K+1 capacity).
+    // #1055: tokens/positions/row-ctx-lens + the 3 length scalars live in ONE
+    // device block (d_spec_stage_) with a pinned host twin — one H2D per
+    // step; the named pointers below are stable sub-pointers into it.
+    // Same layout trick for [argmax | topm] — one D2H per step.
+    int32_t* d_spec_stage_ = nullptr;
+    int32_t* h_spec_stage_ = nullptr;  // pinned twin of d_spec_stage_
     int32_t* d_spec_tokens_ = nullptr;
     int* d_spec_positions_ = nullptr;
     int* d_spec_block_table_ = nullptr;
     int* d_spec_block_table_swa_ = nullptr;  // SWA-group mirror (kv_cache.swa_sizing)
     int* d_spec_context_len_ = nullptr;
-    int32_t* d_spec_argmax_ = nullptr;
-    int32_t* h_spec_argmax_ = nullptr;  // pinned, chunk_cap entries
+    int32_t* d_spec_argmax_ = nullptr;  // head of the [argmax | topm] block
+    int32_t* h_spec_argmax_ = nullptr;  // pinned, [argmax | topm] twin
     // Token-Recycling top-M harvest (speculative.token_recycling): per-row
     // top-M logit ids from the verify chunk, chunk_cap * kRowwiseTopMMax.
-    int32_t* d_spec_topm_ = nullptr;
-    int32_t* h_spec_topm_ = nullptr;  // pinned
+    int32_t* d_spec_topm_ = nullptr;  // = d_spec_argmax_ + chunk_cap
+    int32_t* h_spec_topm_ = nullptr;  // = h_spec_argmax_ + chunk_cap
     // #964 decode-attention verify route (dense, eager): per-row context lens
     // [chunk_cap] and row-replicated block tables [chunk_cap * table_cap] so
     // the chunk's attention runs the batched-decode split-K kernels — row i
     // becomes a same-KV "sequence" with ctx p0+1+i (causality via lengths).
-    int* d_spec_row_ctx_lens_ = nullptr;
+    int* d_spec_row_ctx_lens_ = nullptr;  // sub-pointer into d_spec_stage_
     int* d_spec_row_block_tables_ = nullptr;
-    std::vector<int32_t> h_spec_row_tables_;  // host staging, reused per step
+    int32_t* h_spec_row_tables_pinned_ = nullptr;  // pinned staging, chunk_cap * table_cap
     int spec_chunk_cap_ = 0;
     int spec_block_table_cap_ = 0;
     // Hybrid (SSM/GDN) verify: device scratch holding the committed
@@ -816,6 +822,7 @@ private:
         long long drafted = 0;       // draft tokens proposed
         long long accepted = 0;      // draft tokens accepted
         long long emitted = 0;       // tokens emitted by verify steps
+        double verify_wall_ms = 0;   // host wall inside step_spec_verify_ (verify steps only)
     };
     SpecStats spec_stats_{};
 

--- a/src/runtime/engine_spec_capture.cpp
+++ b/src/runtime/engine_spec_capture.cpp
@@ -76,7 +76,9 @@ int Engine::spec_capture_bucket_(int chunk_len) const {
     // draft padded to 9 rows baked 5 splits instead of 21 and the per-CTA
     // KV walk grew 4x (251 vs 65 us/layer at 16k). Finer buckets keep the
     // baked split geometry close to the real chunk; pad rows attend 1 token.
-    for (int b : {3, 5, 9, 17, 33}) {
+    // 4 = the token-recycling depth-3 chunk (#1055): exactly one batched-GEMV
+    // weight sweep (MR=4); padding it into 5 pays a second sweep.
+    for (int b : {3, 4, 5, 9, 17, 33}) {
         if (chunk_len <= b && b <= cap)
             return b;
     }

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -45,6 +45,7 @@
 
 #include <cuda_runtime.h>
 #include <algorithm>
+#include <chrono>
 #include <vector>
 
 namespace imp {
@@ -53,34 +54,45 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
     if (spec_chunk_cap_ >= chunk_cap && spec_block_table_cap_ >= max_blocks)
         return true;
     free_spec_buffers_();
-    bool ok = cudaMalloc(&d_spec_tokens_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
-              cudaMalloc(&d_spec_positions_, chunk_cap * sizeof(int)) == cudaSuccess &&
+    // #1055 consolidated staging: tokens/positions/row-ctx-lens (chunk_cap
+    // each) + {ctx_len, past_len, chunk_len} live in ONE device block with a
+    // PINNED host twin — a single small H2D per verify step instead of six
+    // (pageable-source async copies stage through a driver buffer on WSL2).
+    // The captured graphs bake the sub-pointers; the block is allocated once
+    // per capacity, so they stay stable. Same trick for argmax+topm D2H.
+    const size_t stage_ints = 3ull * chunk_cap + 3;
+    const size_t out_ints = static_cast<size_t>(chunk_cap) * (1 + kRowwiseTopMMax);
+    bool ok = cudaMalloc(&d_spec_stage_, stage_ints * sizeof(int32_t)) == cudaSuccess &&
+              cudaMallocHost(&h_spec_stage_, stage_ints * sizeof(int32_t)) == cudaSuccess &&
+              cudaMalloc(&d_spec_argmax_, out_ints * sizeof(int32_t)) == cudaSuccess &&
+              cudaMallocHost(&h_spec_argmax_, out_ints * sizeof(int32_t)) == cudaSuccess &&
               cudaMalloc(&d_spec_block_table_, max_blocks * sizeof(int)) == cudaSuccess &&
-              cudaMalloc(&d_spec_context_len_, sizeof(int)) == cudaSuccess &&
-              cudaMalloc(&d_spec_past_len_, sizeof(int)) == cudaSuccess &&
-              cudaMalloc(&d_spec_chunk_len_, sizeof(int)) == cudaSuccess &&
-              cudaMalloc(&d_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
-              cudaMallocHost(&h_spec_argmax_, chunk_cap * sizeof(int32_t)) == cudaSuccess &&
-              // Token-Recycling top-M harvest — sized to the kernel cap so a
-              // recycle_slots config change never needs a re-alloc (tiny).
-              cudaMalloc(&d_spec_topm_,
-                         static_cast<size_t>(chunk_cap) * kRowwiseTopMMax * sizeof(int32_t)) ==
-                  cudaSuccess &&
-              cudaMallocHost(&h_spec_topm_, static_cast<size_t>(chunk_cap) * kRowwiseTopMMax *
-                                                sizeof(int32_t)) == cudaSuccess &&
               // SWA-group mirror (kv_cache.swa_sizing): same capacity as the
               // main table. Allocated unconditionally so a mid-session gate
               // flip can't leave it null; tiny (max_blocks ints).
               cudaMalloc(&d_spec_block_table_swa_, max_blocks * sizeof(int)) == cudaSuccess &&
               // #964 decode-attention verify route staging (see engine.h).
-              cudaMalloc(&d_spec_row_ctx_lens_, chunk_cap * sizeof(int)) == cudaSuccess &&
               cudaMalloc(&d_spec_row_block_tables_,
-                         static_cast<size_t>(chunk_cap) * max_blocks * sizeof(int)) == cudaSuccess;
+                         static_cast<size_t>(chunk_cap) * max_blocks * sizeof(int)) ==
+                  cudaSuccess &&
+              cudaMallocHost(&h_spec_row_tables_pinned_,
+                             static_cast<size_t>(chunk_cap) * max_blocks * sizeof(int32_t)) ==
+                  cudaSuccess;
     if (!ok) {
         IMP_LOG_WARN("spec-ngram: buffer allocation failed — speculation disabled this step");
         free_spec_buffers_();
         return false;
     }
+    // Sub-pointer layout (all int32): [tokens | positions | row_ctx_lens |
+    // ctx_len, past_len, chunk_len] and [argmax | topm].
+    d_spec_tokens_ = d_spec_stage_;
+    d_spec_positions_ = d_spec_stage_ + chunk_cap;
+    d_spec_row_ctx_lens_ = d_spec_stage_ + 2ull * chunk_cap;
+    d_spec_context_len_ = d_spec_stage_ + 3ull * chunk_cap;
+    d_spec_past_len_ = d_spec_context_len_ + 1;
+    d_spec_chunk_len_ = d_spec_context_len_ + 2;
+    d_spec_topm_ = d_spec_argmax_ + chunk_cap;
+    h_spec_topm_ = h_spec_argmax_ + chunk_cap;
     spec_chunk_cap_ = chunk_cap;
     spec_block_table_cap_ = max_blocks;
     return true;
@@ -90,14 +102,16 @@ void Engine::log_spec_stats_() const {
     if (spec_stats_.verify_steps + spec_stats_.miss_steps == 0)
         return;
     IMP_LOG_INFO("[spec-ngram] verify_steps=%lld miss_steps=%lld drafted=%lld accepted=%lld "
-                 "(%.1f%%) emitted=%lld (%.2f tok/verify)",
+                 "(%.1f%%) emitted=%lld (%.2f tok/verify, %.2f ms/verify)",
                  spec_stats_.verify_steps, spec_stats_.miss_steps, spec_stats_.drafted,
                  spec_stats_.accepted,
                  spec_stats_.drafted ? 100.0 * spec_stats_.accepted / spec_stats_.drafted : 0.0,
                  spec_stats_.emitted,
                  spec_stats_.verify_steps
                      ? static_cast<double>(spec_stats_.emitted) / spec_stats_.verify_steps
-                     : 0.0);
+                     : 0.0,
+                 spec_stats_.verify_steps ? spec_stats_.verify_wall_ms / spec_stats_.verify_steps
+                                          : 0.0);
 }
 
 // Hybrid verify: scratch slab holding the committed recurrent state across
@@ -138,25 +152,26 @@ void Engine::free_spec_buffers_() {
         spec_state_scratch_ = nullptr;
         spec_state_scratch_bytes_ = 0;
     }
-    if (d_spec_tokens_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_tokens_));
-    if (d_spec_positions_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_positions_));
+    // d_spec_tokens_/positions_/row_ctx_lens_/context_len_/past_len_/
+    // chunk_len_ are sub-pointers into d_spec_stage_; d_spec_topm_ into
+    // d_spec_argmax_ — only the block heads are freed.
+    if (d_spec_stage_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_stage_));
+    if (h_spec_stage_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_stage_));
     if (d_spec_block_table_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_));
     if (d_spec_block_table_swa_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_block_table_swa_));
-    if (d_spec_row_ctx_lens_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_row_ctx_lens_));
     if (d_spec_row_block_tables_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_row_block_tables_));
-    if (d_spec_context_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_context_len_));
-    if (d_spec_past_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_past_len_));
-    if (d_spec_chunk_len_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_chunk_len_));
+    if (h_spec_row_tables_pinned_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_row_tables_pinned_));
     if (d_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_argmax_));
     if (h_spec_argmax_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_argmax_));
-    if (d_spec_topm_) IMP_CUDA_CHECK_LOG(cudaFree(d_spec_topm_));
-    if (h_spec_topm_) IMP_CUDA_CHECK_LOG(cudaFreeHost(h_spec_topm_));
+    d_spec_stage_ = nullptr;
+    h_spec_stage_ = nullptr;
     d_spec_tokens_ = nullptr;
     d_spec_positions_ = nullptr;
     d_spec_block_table_ = nullptr;
     d_spec_block_table_swa_ = nullptr;
     d_spec_row_ctx_lens_ = nullptr;
     d_spec_row_block_tables_ = nullptr;
+    h_spec_row_tables_pinned_ = nullptr;
     d_spec_context_len_ = nullptr;
     d_spec_past_len_ = nullptr;
     d_spec_chunk_len_ = nullptr;
@@ -484,6 +499,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     // PRIVATE block copy, see the mc staging below), so no row is shared and
     // no token-level mask is needed. K doubles as the stats/economics depth
     // (winner-depth proxy in mc mode — the verify cost is ~flat in rows).
+    const auto verify_t0 = std::chrono::steady_clock::now();
     const int32_t t0 = req->output_tokens.back();
     const int mc_rows_per_cand = mc_on ? (1 + mc_depth) : 0;
     int K = mc_on ? mc_depth : static_cast<int>(draft.size());
@@ -599,26 +615,42 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         return false;
     }
 
-    // Upload chunk metadata. mc: candidate c's rows are
-    // [t0, cand_c...] at positions p0..p0+len_c; short candidates and the
-    // bucket padding fill with t0 rows whose argmax is never consulted (their
-    // KV writes land in dead slots — private-block tails past the accepted
-    // length, or canonical slots past the rollback point).
-    std::vector<int32_t> h_tokens(chunk_pad, t0);
-    std::vector<int> h_positions(chunk_pad, p0);
+    // Stage chunk metadata into the pinned block and upload with ONE H2D
+    // (#1055): [tokens | positions | row_ctx_lens | ctx_len, past_len,
+    // chunk_len]. mc: candidate c's rows are [t0, cand_c...] at positions
+    // p0..p0+len_c; short candidates and the bucket padding fill with t0
+    // rows whose argmax is never consulted (their KV writes land in dead
+    // slots — private-block tails past the accepted length, or canonical
+    // slots past the rollback point). Row ctx lens: real rows attend
+    // p0+i+1 (per-row causality), pads attend 1 token — consumed only on
+    // the decode-attn route, harmless otherwise.
+    const int cap = spec_chunk_cap_;
+    int32_t* h_tokens = h_spec_stage_;
+    int32_t* h_positions = h_spec_stage_ + cap;
+    int32_t* h_row_lens = h_spec_stage_ + 2ull * cap;
+    for (int i = 0; i < chunk_pad; ++i) {
+        h_tokens[i] = t0;
+        h_positions[i] = mc_on ? p0 : p0 + i;
+        h_row_lens[i] = 1;
+    }
     if (mc_on) {
         for (size_t c = 0; c < mc.size(); ++c) {
             const int r0 = static_cast<int>(c) * mc_rows_per_cand;
             for (int j = 0; j < mc_rows_per_cand; ++j) {
                 h_positions[r0 + j] = p0 + j;
+                const bool real = j == 0 || j - 1 < static_cast<int>(mc[c].size());
+                h_row_lens[r0 + j] = real ? (p0 + j + 1) : 1;
                 if (j > 0 && j - 1 < static_cast<int>(mc[c].size()))
                     h_tokens[r0 + j] = mc[c][j - 1];
             }
         }
     } else {
         for (int i = 0; i < K; ++i) h_tokens[1 + i] = draft[i];
-        for (int i = 0; i < chunk_pad; ++i) h_positions[i] = p0 + i;
+        for (int i = 0; i < chunk_len; ++i) h_row_lens[i] = p0 + i + 1;
     }
+    h_spec_stage_[3ull * cap] = ctx_len;
+    h_spec_stage_[3ull * cap + 1] = p0;
+    h_spec_stage_[3ull * cap + 2] = chunk_len;
 
     auto check = [&](cudaError_t err, const char* op) {
         if (err != cudaSuccess) {
@@ -627,23 +659,15 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         }
         return true;
     };
-    if (!check(cudaMemcpyAsync(d_spec_tokens_, h_tokens.data(), chunk_pad * sizeof(int32_t),
-                               cudaMemcpyHostToDevice, stream), "tokens H2D") ||
-        !check(cudaMemcpyAsync(d_spec_positions_, h_positions.data(), chunk_pad * sizeof(int),
-                               cudaMemcpyHostToDevice, stream), "positions H2D") ||
+    if (!check(cudaMemcpyAsync(d_spec_stage_, h_spec_stage_,
+                               (3ull * cap + 3) * sizeof(int32_t), cudaMemcpyHostToDevice,
+                               stream), "stage H2D") ||
         !check(cudaMemcpyAsync(d_spec_block_table_, block_table.data(), n_blocks * sizeof(int),
                                cudaMemcpyHostToDevice, stream), "block table H2D") ||
         (swa_sizing_active_ && !swa_block_table.empty() &&
          !check(cudaMemcpyAsync(d_spec_block_table_swa_, swa_block_table.data(),
                                 static_cast<int>(swa_block_table.size()) * sizeof(int),
-                                cudaMemcpyHostToDevice, stream), "swa block table H2D")) ||
-        !check(cudaMemcpyAsync(d_spec_context_len_, &ctx_len, sizeof(int), cudaMemcpyHostToDevice,
-                               stream), "context len H2D") ||
-        (capture_on &&
-         (!check(cudaMemcpyAsync(d_spec_past_len_, &p0, sizeof(int), cudaMemcpyHostToDevice,
-                                 stream), "past len H2D") ||
-          !check(cudaMemcpyAsync(d_spec_chunk_len_, &chunk_len, sizeof(int),
-                                 cudaMemcpyHostToDevice, stream), "chunk len H2D"))))
+                                cudaMemcpyHostToDevice, stream), "swa block table H2D")))
         return false;
 
     // Forward the chunk through the standard continuation-prefill path.
@@ -688,32 +712,14 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     // across CTAs) instead of the small-M prefill FA2 tile + full-context
     // FP16 KV gather (557 vs ~44 us/layer at 16k, nsys 2026-07-12).
     if (decode_attn_route) {
-        std::vector<int> h_row_lens(chunk_pad);
-        // Pad rows (i >= chunk_len, capture-bucket fill) attend a single
-        // token: their output is never read, and a 1-token walk keeps the
-        // per-row KV traffic at real-chunk cost. mc: row (c, j) attends
-        // p0+j+1 tokens through the candidate's aliased table; rows past a
-        // short candidate's length are pads too.
-        if (mc_on) {
-            for (int i = 0; i < chunk_pad; ++i) {
-                if (i >= chunk_len) {
-                    h_row_lens[i] = 1;
-                    continue;
-                }
-                const int c = i / mc_rows_per_cand;
-                const int j = i % mc_rows_per_cand;
-                const bool real = j == 0 || j - 1 < static_cast<int>(mc[c].size());
-                h_row_lens[i] = real ? (p0 + j + 1) : 1;
-            }
-        } else {
-            for (int i = 0; i < chunk_pad; ++i)
-                h_row_lens[i] = (i < chunk_len) ? (p0 + i + 1) : 1;
-        }
-        h_spec_row_tables_.assign(
-            static_cast<size_t>(chunk_pad) * spec_block_table_cap_, 0);
+        // Row ctx lens were staged with the chunk metadata above (pads and
+        // short-candidate tails attend 1 token: their output is never read,
+        // and a 1-token walk keeps the per-row KV traffic at real-chunk
+        // cost). Only the row-replicated tables remain — pinned staging,
+        // one H2D of the used region.
         for (int i = 0; i < chunk_pad; ++i)
             std::copy(block_table.begin(), block_table.end(),
-                      h_spec_row_tables_.begin() +
+                      h_spec_row_tables_pinned_ +
                           static_cast<size_t>(i) * spec_block_table_cap_);
         // mc: alias each candidate's written block indices [mc_bp ..
         // mc_bp + mc_n_priv) to its private appended blocks — reads of the
@@ -721,17 +727,15 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         if (mc_on) {
             for (int i = 0; i < chunk_len; ++i) {
                 const int c = i / mc_rows_per_cand;
-                int32_t* row = h_spec_row_tables_.data() +
+                int32_t* row = h_spec_row_tables_pinned_ +
                                static_cast<size_t>(i) * spec_block_table_cap_;
                 for (int t = 0; t < mc_n_priv; ++t)
                     row[mc_bp + t] = block_table[mc_priv_base + c * mc_n_priv + t];
             }
         }
-        if (check(cudaMemcpyAsync(d_spec_row_ctx_lens_, h_row_lens.data(),
-                                  chunk_pad * sizeof(int), cudaMemcpyHostToDevice, stream),
-                  "row ctx lens H2D") &&
-            check(cudaMemcpyAsync(d_spec_row_block_tables_, h_spec_row_tables_.data(),
-                                  h_spec_row_tables_.size() * sizeof(int32_t),
+        if (check(cudaMemcpyAsync(d_spec_row_block_tables_, h_spec_row_tables_pinned_,
+                                  static_cast<size_t>(chunk_pad) * spec_block_table_cap_ *
+                                      sizeof(int32_t),
                                   cudaMemcpyHostToDevice, stream),
                   "row block tables H2D")) {
             state.chunk_decode_attn = true;
@@ -852,15 +856,16 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
                                  d_spec_tokens_ + 1, req->repetition_penalty,
                                  req->frequency_penalty, req->presence_penalty,
                                  recycle_m > 0 ? d_spec_topm_ : nullptr, recycle_m);
+    // One D2H covers [argmax | topm] (contiguous block, #1055); without the
+    // harvest only the argmax prefix is copied.
+    const size_t d2h_ints =
+        recycle_m > 0
+            ? static_cast<size_t>(spec_chunk_cap_) + static_cast<size_t>(chunk_len) * recycle_m
+            : static_cast<size_t>(chunk_len);
     bool argmax_ok =
-        check(cudaMemcpyAsync(h_spec_argmax_, d_spec_argmax_, chunk_len * sizeof(int32_t),
-                              cudaMemcpyDeviceToHost, stream), "argmax D2H");
-    if (argmax_ok && recycle_m > 0)
-        argmax_ok = check(cudaMemcpyAsync(h_spec_topm_, d_spec_topm_,
-                                          static_cast<size_t>(chunk_len) * recycle_m *
-                                              sizeof(int32_t),
-                                          cudaMemcpyDeviceToHost, stream), "topm D2H");
-    argmax_ok = argmax_ok && check(cudaStreamSynchronize(stream), "verify sync");
+        check(cudaMemcpyAsync(h_spec_argmax_, d_spec_argmax_, d2h_ints * sizeof(int32_t),
+                              cudaMemcpyDeviceToHost, stream), "argmax D2H") &&
+        check(cudaStreamSynchronize(stream), "verify sync");
     if (!argmax_ok) {
         // No tokens were emitted; leave the request exactly as before the
         // step (the chunk forward advanced hybrid state — restore it).
@@ -1020,6 +1025,9 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     spec_stats_.drafted += K;
     spec_stats_.accepted += matched;
     spec_stats_.emitted += emitted;
+    spec_stats_.verify_wall_ms +=
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - verify_t0)
+            .count();
     // (request-end stats logging lives in finish_request)
 
     // Acceptance economics: structured-but-mutating content (number tables,

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -425,15 +425,21 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
             // keeps the per-row context walks at linear-chunk cost.
             const int depth_cap = std::max(1, 17 / std::max(2, width) - 1);
             const int depth = std::min({std::max(1, scfg.recycle_depth), depth_cap, k});
-            auto cands = spec_recycle_table_().draft_candidates(
-                req->output_tokens.back(), width, depth);
-            if (mc_route_ok && width > 1 && cands.size() > 1) {
-                mc = std::move(cands);
-                mc_depth = 0;
-                for (const auto& c : mc)
-                    mc_depth = std::max(mc_depth, static_cast<int>(c.size()));
-            } else if (!cands.empty()) {
-                draft = std::move(cands.front());
+            if (mc_route_ok && width > 1) {
+                auto cands = spec_recycle_table_().draft_candidates(
+                    req->output_tokens.back(), width, depth);
+                if (cands.size() > 1) {
+                    mc = std::move(cands);
+                    mc_depth = 0;
+                    for (const auto& c : mc)
+                        mc_depth = std::max(mc_depth, static_cast<int>(c.size()));
+                } else if (!cands.empty()) {
+                    draft = std::move(cands.front());
+                }
+            } else {
+                draft = spec_recycle_table_().draft_linear(
+                    req->output_tokens.back(), depth,
+                    std::max(0, scfg.recycle_min_streak));
                 if (static_cast<int>(draft.size()) < 2 && scfg.shallow_draft_ctx > 0 &&
                     req->context_len() > scfg.shallow_draft_ctx && ssm_state_ == nullptr &&
                     !(model_->profile().is_moe && scfg.moe &&
@@ -931,10 +937,15 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     kv_manager_->touch(req->id);
 
     // mc: materialize the winner's KV — copy its private block(s) covering
-    // the accepted span [p0, p0+matched] back over the canonical entries,
-    // then sync before the rollback below frees the private blocks (a freed
-    // block re-allocated by a concurrent prefill on another stream must not
-    // race the in-flight copy).
+    // the accepted span [p0, p0+matched] back over the canonical entries.
+    // The rollback below frees the private blocks; a freed block re-used by
+    // work on ANOTHER stream (a concurrent prefill on pf_stream) must not
+    // race the in-flight copy, so sync first — but only when such a stream
+    // can exist. Single-stream steady state (batch=1, no prefill queued —
+    // the CLI/agent case) skips the sync: every later consumer of the pool
+    // enqueues on this same stream, which is ordered after the copy.
+    // (WSL2 measures cudaStreamSynchronize at 1-4 ms — per verify step that
+    // sync alone was a double-digit share of the TR verify cost.)
     if (mc_on && req->status != RequestStatus::FINISHED) {
         const int mc_best_c = mc_row0 / mc_rows_per_cand;
         int srcs[KVCache::kCopyMaxPairs];
@@ -945,7 +956,10 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
             dsts[t] = block_table[mc_bp + t];
         }
         kv_cache_raw_->copy_blocks_device(srcs, dsts, n_pairs, stream);
-        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+        const bool other_stream_may_reuse =
+            !sched_prefill_batch_.empty() || sched_decode_batch_.size() > 1;
+        if (other_stream_may_reuse)
+            IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
     }
 
     // Token-Recycling: feed the model's own top-M successor candidates for

--- a/src/runtime/token_recycle_draft.cpp
+++ b/src/runtime/token_recycle_draft.cpp
@@ -6,16 +6,23 @@ namespace imp {
 
 TokenRecycleTable::TokenRecycleTable(int vocab_size, int slots)
     : vocab_(vocab_size), slots_(slots),
-      succ_(static_cast<size_t>(vocab_size) * slots, -1) {}
+      succ_(static_cast<size_t>(vocab_size) * slots, -1),
+      streak_(static_cast<size_t>(vocab_size), 0) {}
 
-void TokenRecycleTable::observe_pair(int32_t prev, int32_t next) {
-    if (!valid_(prev) || !valid_(next))
-        return;
+// MRU slot shuffle only — returns true when `next` was already recorded
+// (a RE-observation). Streak accounting stays with the callers.
+bool TokenRecycleTable::promote_(int32_t prev, int32_t next) {
     int32_t* r = row_(prev);
     // Find existing occurrence (or the end of the used region).
     int pos = slots_ - 1;
+    bool existed = false;
     for (int i = 0; i < slots_; ++i) {
-        if (r[i] == next || r[i] == -1) {
+        if (r[i] == next) {
+            pos = i;
+            existed = true;
+            break;
+        }
+        if (r[i] == -1) {
             pos = i;
             break;
         }
@@ -24,21 +31,51 @@ void TokenRecycleTable::observe_pair(int32_t prev, int32_t next) {
     for (int i = pos; i > 0; --i)
         r[i] = r[i - 1];
     r[0] = next;
+    return existed;
+}
+
+void TokenRecycleTable::observe_pair(int32_t prev, int32_t next) {
+    if (!valid_(prev) || !valid_(next))
+        return;
+    // Streak = the front slot is a RE-observed pair (seen before, not
+    // necessarily consecutively — consecutive-only measured ~zero recall on
+    // fresh reasoning text: 2 drafts in 1024 tokens). A brand-new successor
+    // resets it.
+    streak_[prev] = promote_(prev, next)
+                        ? static_cast<uint8_t>(std::min(255, streak_[prev] + 1))
+                        : uint8_t{0};
 }
 
 void TokenRecycleTable::observe_topk(int32_t token, const int32_t* ids, int n) {
-    if (!valid_(token) || !ids)
+    if (!valid_(token) || !ids || n <= 0)
         return;
+    // Streak follows the model's rank-0 candidate: re-observed -> confirm,
+    // brand-new -> reset. Lower ranks only refresh the slot pool.
+    bool front_existed = false;
+    if (valid_(ids[0])) {
+        const int32_t* r = row_(token);
+        for (int i = 0; i < slots_; ++i)
+            if (r[i] == ids[0]) {
+                front_existed = true;
+                break;
+            }
+    }
     // Promote in reverse rank order so ids[0] ends up in slot 0.
     for (int i = n - 1; i >= 0; --i)
-        observe_pair(token, ids[i]);
+        if (valid_(ids[i]))
+            promote_(token, ids[i]);
+    streak_[token] = front_existed
+                         ? static_cast<uint8_t>(std::min(255, streak_[token] + 1))
+                         : uint8_t{0};
 }
 
-std::vector<int32_t> TokenRecycleTable::draft_linear(int32_t t0, int k) const {
+std::vector<int32_t> TokenRecycleTable::draft_linear(int32_t t0, int k, int min_streak) const {
     std::vector<int32_t> out;
     int32_t cur = t0;
     for (int i = 0; i < k; ++i) {
         if (!valid_(cur))
+            break;
+        if (streak_[cur] < min_streak)
             break;
         int32_t s = row_(cur)[0];
         if (s < 0)

--- a/src/runtime/token_recycle_draft.h
+++ b/src/runtime/token_recycle_draft.h
@@ -33,9 +33,11 @@ public:
     void observe_topk(int32_t token, const int32_t* ids, int n);
 
     // Follow the front-slot successor chain from t0 for up to k tokens.
-    // Stops early when a token has no successors. Cycles are allowed —
-    // bounded by k; the lossless verify is the safety net.
-    std::vector<int32_t> draft_linear(int32_t t0, int k) const;
+    // Stops early when a token has no successors, or (min_streak > 0) when
+    // its front slot has not been CONFIRMED min_streak times — a verify step
+    // costs ~1.4x a decode step, so precision beats recall (#1055). Cycles
+    // are allowed — bounded by k; the lossless verify is the safety net.
+    std::vector<int32_t> draft_linear(int32_t t0, int k, int min_streak = 0) const;
 
     // Multi-candidate draft (route (a) of the spec-tree plan): up to
     // `width` candidates, one per recorded successor of t0 (rank order);
@@ -52,6 +54,7 @@ public:
 
 private:
     bool valid_(int32_t tok) const { return tok >= 0 && tok < vocab_; }
+    bool promote_(int32_t prev, int32_t next);
     int32_t* row_(int32_t tok) { return succ_.data() + static_cast<size_t>(tok) * slots_; }
     const int32_t* row_(int32_t tok) const {
         return succ_.data() + static_cast<size_t>(tok) * slots_;
@@ -60,6 +63,9 @@ private:
     int vocab_;
     int slots_;
     std::vector<int32_t> succ_;  // vocab_ * slots_, -1 = empty
+    // Consecutive re-confirmations of the front slot: observe_pair bumps it
+    // when `next` already IS the front, resets it when the front changes.
+    std::vector<uint8_t> streak_;  // vocab_
 };
 
 }  // namespace imp

--- a/tests/test_nvfp4_gemm_batched.cu
+++ b/tests/test_nvfp4_gemm_batched.cu
@@ -114,5 +114,62 @@ TEST_F(GemmNvfp4Batched, MatchesDequantRefAtNarrowDims) {
     run_case(704, 2816, 7);
 }
 
+// Accumulate (beta=1) variant for the o/down residual-add GEMMs (#1055):
+// y must end as W@x + y_prev, matching cuBLAS beta=1 semantics.
+TEST_F(GemmNvfp4Batched, AccumulateAddsIntoOutput) {
+    const int N = 1024, K = 2048, M = 3;
+    std::vector<half> h_w(static_cast<size_t>(N) * K);
+    std::vector<half> h_a(static_cast<size_t>(M) * K);
+    std::vector<half> h_res(static_cast<size_t>(M) * N);
+    for (size_t i = 0; i < h_w.size(); ++i)
+        h_w[i] = __float2half(((static_cast<int>(i * 13u) % 27) - 13) * 0.01f);
+    for (size_t i = 0; i < h_a.size(); ++i)
+        h_a[i] = __float2half(((static_cast<int>(i * 7u) % 23) - 11) * 0.02f);
+    for (size_t i = 0; i < h_res.size(); ++i)
+        h_res[i] = __float2half(((static_cast<int>(i * 5u) % 19) - 9) * 0.05f);
+
+    half *d_w = nullptr, *d_a = nullptr, *d_y = nullptr, *d_y_ref = nullptr;
+    cudaMalloc(&d_w, h_w.size() * sizeof(half));
+    cudaMalloc(&d_a, h_a.size() * sizeof(half));
+    cudaMalloc(&d_y, h_res.size() * sizeof(half));
+    cudaMalloc(&d_y_ref, h_res.size() * sizeof(half));
+    cudaMemcpy(d_w, h_w.data(), h_w.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_a, h_a.data(), h_a.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_y, h_res.data(), h_res.size() * sizeof(half), cudaMemcpyHostToDevice);
+
+    int64_t wshape[2] = {N, K};
+    Tensor w_t(d_w, QType::F16, 2, wshape, true);
+    NvFP4QuantResult qr;
+    quantize_fp16_to_nvfp4(w_t, qr, stream_);
+    cudaStreamSynchronize(stream_);
+
+    gemm_nvfp4_batched_acc(qr, d_a, d_y, N, K, M, stream_);
+    cudaStreamSynchronize(stream_);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+    // Reference: plain batched into a zero buffer, then add residual on host.
+    cudaMemsetAsync(d_y_ref, 0, h_res.size() * sizeof(half), stream_);
+    gemm_nvfp4_batched(qr, d_a, d_y_ref, N, K, M, stream_);
+    cudaStreamSynchronize(stream_);
+
+    std::vector<half> h_y(h_res.size()), h_y_ref(h_res.size());
+    cudaMemcpy(h_y.data(), d_y, h_y.size() * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_y_ref.data(), d_y_ref, h_y_ref.size() * sizeof(half), cudaMemcpyDeviceToHost);
+
+    float max_abs_diff = 0.0f;
+    for (size_t i = 0; i < h_y.size(); ++i) {
+        float want = __half2float(h_y_ref[i]) + __half2float(h_res[i]);
+        float got = __half2float(h_y[i]);
+        max_abs_diff = std::max(max_abs_diff, std::fabs(got - want));
+    }
+    EXPECT_LT(max_abs_diff, 0.05f) << "accumulate variant diverges from ref + residual";
+
+    free_nvfp4_result(qr);
+    cudaFree(d_w);
+    cudaFree(d_a);
+    cudaFree(d_y);
+    cudaFree(d_y_ref);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_token_recycle_draft.cpp
+++ b/tests/test_token_recycle_draft.cpp
@@ -137,4 +137,56 @@ TEST(TokenRecycle, CandidatesEmptyOnUnseenRoot) {
     EXPECT_TRUE(t.draft_candidates(9, 4, 3).empty());
 }
 
+// Streak gating (#1055): a verify step costs ~1.4x a decode step, so drafts
+// should only fire on CONFIRMED bigrams — the front slot must have repeated
+// at least min_streak times. Fresh (streak-0) successors extend nothing.
+TEST(TokenRecycle, StreakGateBlocksUnconfirmedBigram) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);  // first sighting: streak 0
+    EXPECT_TRUE(t.draft_linear(1, 4, /*min_streak=*/1).empty());
+    t.observe_pair(1, 2);  // repeat confirms: streak 1
+    auto d = t.draft_linear(1, 4, 1);
+    ASSERT_EQ(d.size(), 1u);  // 2 has no confirmed successor -> chain ends
+    EXPECT_EQ(d[0], 2);
+}
+
+TEST(TokenRecycle, StreakResetsOnBrandNewSuccessor) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);
+    t.observe_pair(1, 2);  // streak 1
+    t.observe_pair(1, 3);  // brand-new successor -> streak resets
+    EXPECT_TRUE(t.draft_linear(1, 4, 1).empty());
+}
+
+TEST(TokenRecycle, StreakCountsNonConsecutiveRepeats) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);
+    t.observe_pair(1, 3);  // interleaved successor
+    t.observe_pair(1, 2);  // 2 re-observed -> confirmed despite the gap
+    auto d = t.draft_linear(1, 4, 1);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 2);
+}
+
+TEST(TokenRecycle, MinStreakZeroKeepsOldBehavior) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);
+    auto d = t.draft_linear(1, 4, 0);
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0], 2);
+}
+
+TEST(TokenRecycle, StreakGateAppliesPerHop) {
+    TokenRecycleTable t(100, 4);
+    t.observe_pair(1, 2);
+    t.observe_pair(1, 2);  // 1->2 confirmed
+    t.observe_pair(2, 3);
+    t.observe_pair(2, 3);  // 2->3 confirmed
+    t.observe_pair(3, 4);  // 3->4 unconfirmed
+    auto d = t.draft_linear(1, 8, 1);
+    ASSERT_EQ(d.size(), 2u);  // stops before the unconfirmed hop
+    EXPECT_EQ(d[0], 2);
+    EXPECT_EQ(d[1], 3);
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary

Recovery PR: these five commits were orphaned on the #1054 branch when its auto-merge fired at the first green Build (the known auto-merge race). Cherry-picked onto fresh main; the code tree is byte-identical to the GPU-validated branch tip.

**Verify-step cost work for issue #1055** (the spec-verify chunks that suffix/n-gram and token-recycling drafting ride):

- **Native ST-NVFP4 verify chunks at M<=4 route to the single-sweep batched GEMV** instead of CUTLASS (~51% effective bandwidth at tiny M). New MR=3 tile (bucket 3 previously paid two weight sweeps), new beta=1 accumulate variant so the o/down residual GEMMs route too (GGUF overlay extended to beta=1 as well). Buckets >= 5 stay CUTLASS by design — the batched GEMV re-reads the weight per MR=4 tile, so it only wins in the single-tile regime.
- **Capture bucket 4**: chunk-4 verifies (3-token drafts) run one MR=4 sweep instead of padding into bucket 5 (two sweeps).
- **Permanent `ms/verify` telemetry** in the `[spec-ngram]` line (host wall inside the verify step).
- Consolidated pinned staging: one H2D per verify step (tokens/positions/row-lens/scalars in one pinned block) instead of six pageable copies; pinned row tables; one combined argmax+topm D2H.
- Token-recycling default geometry re-tuned (depth 3 / width 1 / `recycle_min_streak` precision gate); mc copy-back sync skipped in single-stream steady state.
- Audit doc: TTFT decomposition, lm_head-capture-exemption refutation, warm-table measurement, verify-ratio close-out.

## Measured (Qwen3-14B-NVFP4, interleaved kill-switch A/Bs)

| workload | before | after |
|---|---|---|
| bench k=2 (bucket-3 verifies, capture on) | 239 | **320 tok/s (+34%)** |
| bench k=16 (3-token suffix drafts -> bucket 4) | 304 | **353 tok/s (+16%)** |
| verify step wall (bucket 3) | 12.3 ms | **7.8 ms (1.33x a decode step)** |

Spec-OFF decode (the gated baseline metric) is untouched — all changes are gated on the spec-verify path. No baseline refresh needed.

## Verification

- Greedy output byte-identical across spec-off / default-suffix / token-recycling arms
- Full GPU suite 0 failures; `make verify-fast` all-PASS (incl. decode gate)
- 22 new/updated unit tests green (TokenRecycle streak semantics, GemmNvfp4Batched incl. accumulate variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV