### PR TITLE
feat(spec): verify-in-loop phase 1 — device TR adjacency + loop-body step kernel (#1055)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/embedding.cu
     src/compute/sampling.cu
     src/compute/rowwise_topm.cu
+    src/compute/token_recycle_device.cu
     src/compute/sampling_topk_topp.cu
     src/compute/sampling_penalties.cu
     src/compute/sampling_filters.cu
@@ -593,6 +594,8 @@ if(IMP_BUILD_TESTS)
         tests/test_softmax.cu
         tests/test_sampling.cu
         tests/test_rowwise_topm.cu
+        tests/test_token_recycle_device.cu
+        tests/test_tr_verify_step.cu
         tests/test_executor_kernels.cu
         tests/test_hadamard.cu
         tests/test_mmq_q4k_imma_layout.cu

--- a/docs/plans/2026-07-23-verify-in-loop.md
+++ b/docs/plans/2026-07-23-verify-in-loop.md
@@ -1,0 +1,93 @@
+# Verify-in-loop: conditional-graph token-recycling verify (#1055)
+
+**Status:** phase 1 built 2026-07-23 — device adjacency table
+(`src/compute/token_recycle_device.{h,cu}`, semantics pinned equal to the
+host table) and the complete loop-body tail kernel `tr_verify_step`
+(accept + ring emission + EOS/stop/budget/ceiling exits + adjacency feed +
+next-draft + chunk staging; `tr_verify_step_conditional` variant sets the
+WHILE handle), 7 GPU tests green. **Remaining (phase 2, next session):**
+(a) `TrVerifyLoopRunner` — own class, NOT surgery on the decode
+ConditionalRunner: conditional node + body capture of
+[capture-mode chunk forward → `greedy_argmax_all`(+top-M) →
+`tr_verify_step_conditional`] + mapped ring/done plumbing (reuse map with
+file:line refs lives in the 2026-07-23 session notes / #1055 comments);
+(b) engine wiring: `speculative.recycle_loop` flag, KV burst
+pre-allocation (prepare_graph_loop pattern), first-chunk host staging,
+drain-resume with think tracking (step_async_graph_resume pattern), KV
+reconcile at burst end; device table becomes the single drafter source
+when the flag is on (probes read it via tiny D2H). Riskiest unknown:
+the capture-mode verify forward inside a conditional WHILE body under
+Relaxed capture mode — probe FIRST.
+
+Goal: remove the ~1.3 ms/step host
+scheduler/API tax between spec-verify steps (measured; effective verify
+ratio ~1.5× vs the 1.33× intra-step wall) by running the whole
+draft→verify→accept cycle as a conditional CUDA-graph WHILE loop, host
+only draining tokens — the spec-verify analog of the async decode loop.
+
+## Why token-recycling is the loop-able drafter
+
+The suffix/n-gram drafters are host data structures. The TR adjacency
+table is `vocab × slots` int32 + a streak byte — device-resident
+(`src/compute/token_recycle_device.{h,cu}`, semantics pinned equal to the
+host table by tests), and its inputs (accepted tokens, verify top-M
+logits) are already on device. Drafting becomes a table walk in the loop
+body; no host round-trip anywhere in the cycle.
+
+## Loop body (fixed bucket-4 chunk, one iteration)
+
+1. **`tr_verify_step_kernel`** (serial `<<<1,32>>>`, the post_decode_step
+   analog): given the previous iteration's argmax buffer + staged draft —
+   compare, emit `1+matched` accepted tokens into the mapped ring
+   (token-count counter, not step counter), check EOS/stop per emitted
+   token, advance device position/context by the emission, feed the
+   adjacency (pairs along accepted path + top-M harvest rows), walk the
+   table for the NEXT draft (depth 3, min_streak) and stage the next
+   chunk (tokens/positions/row-ctx-lens/past_len/chunk_len — all device
+   buffers the capture-mode forward already reads), and set the
+   conditional handle to 0 on: draft miss, EOS/stop, step/token limit,
+   or context reaching the baked tier ceiling.
+2. **Verify forward**: the existing capture-mode chunk forward
+   (`spec_verify_chunk` + `chunk_decode_attn` route, n_tokens = 4,
+   device `d_past_len`/`d_chunk_len`/per-row ctx lens) captured INLINE
+   into the body (the async-loop pattern), not nested as a child graph.
+3. **`greedy_argmax_all`** over the 4 rows (+ top-M harvest) — already
+   device-side and capture-compatible.
+
+Iteration order note: the kernel runs accept-for-the-PREVIOUS-forward
+first, then stages the next draft — so the body is
+[accept+draft+stage → forward → argmax] with the first accept seeded as
+a no-op (launch stages draft 0 host-side).
+
+## KV correctness without device rollback
+
+Blocks are pre-allocated for the whole burst (prepare_graph_loop
+pattern). Rejected draft rows leave stale KV at positions ≥ the new p0 —
+but the NEXT chunk re-writes exactly those positions (its rows cover
+p0'..p0'+3 and KV-write precedes attention per layer), so no read ever
+sees stale entries. The host reconciles the KV manager once at burst end
+(rollback to the final context length).
+
+## Reuse (mapped, from the async decode loop)
+
+conditional node + WHILE handle, mapped ring + `__threadfence_system`
+publish protocol, `try_finish_burst` done-flag (NOT cudaStreamQuery —
+known WSL2 lie), rearm vs fresh capture, KV burst pre-allocation, host
+drain with think tracking (`step_async_graph_resume` does
+`track_think_state` per drained token — think stays host-side), split-K
+non-pipeline fallback under capture (automatic), PDL edge conversion.
+
+## v1 gates (all fall back to the eager verify path)
+
+dense non-MLA/SWA/MoE/hybrid only (= decode-attn route), greedy, no
+penalties/DRY/bias/logprobs/constraints, no think-budget-in-think, flag
+`speculative.recycle_loop` (default off). New runner lives in its own
+class (`TrVerifyLoopRunner`) — the decode ConditionalRunner's stability
+is hard-won; no surgery there.
+
+## Kill criteria
+
+- Loop-body capture fails on the chunk forward under the body's capture
+  mode → fall back eager, keep the flag off.
+- Measured effective verify cost in-loop not ≤ ~1.25× a decode step, or
+  TR reasoning A/B still ≤ spec-off warm → document, revert default.

--- a/src/compute/token_recycle_device.cu
+++ b/src/compute/token_recycle_device.cu
@@ -1,0 +1,288 @@
+#include "compute/token_recycle_device.h"
+#include "core/logging.h"
+
+namespace imp {
+
+namespace {
+
+// Serial MRU promote — the device mirror of TokenRecycleTable::promote_.
+// Returns true when `next` was already recorded (re-observation).
+__device__ bool tr_promote(int32_t* succ, uint8_t* streak, int slots, int32_t prev,
+                           int32_t next) {
+    int32_t* r = succ + static_cast<int64_t>(prev) * slots;
+    int pos = slots - 1;
+    bool existed = false;
+    for (int i = 0; i < slots; ++i) {
+        if (r[i] == next) {
+            pos = i;
+            existed = true;
+            break;
+        }
+        if (r[i] == -1) {
+            pos = i;
+            break;
+        }
+    }
+    for (int i = pos; i > 0; --i)
+        r[i] = r[i - 1];
+    r[0] = next;
+    return existed;
+}
+
+__device__ void tr_observe_pair_dev(int32_t* succ, uint8_t* streak, int vocab, int slots,
+                                    int32_t prev, int32_t next) {
+    if (prev < 0 || prev >= vocab || next < 0 || next >= vocab)
+        return;
+    const bool existed = tr_promote(succ, streak, slots, prev, next);
+    streak[prev] = existed ? static_cast<uint8_t>(min(255, streak[prev] + 1)) : uint8_t{0};
+}
+
+__global__ void tr_init_kernel(int32_t* succ, uint8_t* streak, int64_t n_succ, int vocab) {
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < n_succ)
+        succ[i] = -1;
+    if (i < vocab)
+        streak[i] = 0;
+}
+
+__global__ void tr_observe_pairs_kernel(int32_t* succ, uint8_t* streak, int vocab, int slots,
+                                        const int32_t* __restrict__ toks, int n) {
+    if (threadIdx.x != 0 || blockIdx.x != 0)
+        return;  // serial by design — MRU promotion is order-dependent
+    for (int i = 1; i < n; ++i)
+        tr_observe_pair_dev(succ, streak, vocab, slots, toks[i - 1], toks[i]);
+}
+
+__global__ void tr_observe_topk_kernel(int32_t* succ, uint8_t* streak, int vocab, int slots,
+                                       const int32_t* __restrict__ row_tokens,
+                                       const int32_t* __restrict__ topm, int rows, int m) {
+    if (threadIdx.x != 0 || blockIdx.x != 0)
+        return;  // serial by design
+    for (int r = 0; r < rows; ++r) {
+        const int32_t tok = row_tokens[r];
+        if (tok < 0 || tok >= vocab)
+            continue;
+        const int32_t* ids = topm + static_cast<int64_t>(r) * m;
+        // Streak follows the rank-0 candidate vs the PRE-update row content
+        // (host observe_topk semantics).
+        bool front_existed = false;
+        const int32_t front = ids[0];
+        if (front >= 0 && front < vocab) {
+            const int32_t* row = succ + static_cast<int64_t>(tok) * slots;
+            for (int i = 0; i < slots; ++i)
+                if (row[i] == front) {
+                    front_existed = true;
+                    break;
+                }
+        }
+        for (int i = m - 1; i >= 0; --i)
+            if (ids[i] >= 0 && ids[i] < vocab)
+                tr_promote(succ, streak, slots, tok, ids[i]);
+        streak[tok] = front_existed ? static_cast<uint8_t>(min(255, streak[tok] + 1))
+                                    : uint8_t{0};
+    }
+}
+
+__global__ void tr_draft_kernel(const int32_t* __restrict__ succ,
+                                const uint8_t* __restrict__ streak, int vocab, int slots,
+                                const int32_t* __restrict__ last_token, int depth,
+                                int min_streak, int32_t* __restrict__ out_draft,
+                                int32_t* __restrict__ out_len) {
+    if (threadIdx.x != 0 || blockIdx.x != 0)
+        return;
+    int32_t cur = *last_token;
+    int len = 0;
+    for (int i = 0; i < depth; ++i) {
+        if (cur < 0 || cur >= vocab)
+            break;
+        if (streak[cur] < min_streak)
+            break;
+        const int32_t s = succ[static_cast<int64_t>(cur) * slots];
+        if (s < 0)
+            break;
+        out_draft[len++] = s;
+        cur = s;
+    }
+    *out_len = len;
+}
+
+// Accept the just-verified chunk, feed the adjacency, draft + stage the
+// next chunk, emit accepted tokens to the ring, and decide whether the
+// loop continues. Single-threaded by design (order-dependent bookkeeping,
+// a handful of slot shuffles — the post_decode_step_kernel pattern).
+template <bool kHasHandle>
+__global__ void tr_verify_step_kernel(TrLoopView v, TrLoopParams p,
+                                      cudaGraphConditionalHandle handle) {
+    if (threadIdx.x != 0 || blockIdx.x != 0)
+        return;
+    int32_t* succ = v.tab.succ;
+    uint8_t* streak = v.tab.streak;
+    const int vocab = v.tab.vocab;
+    const int slots = v.tab.slots;
+
+    const int L = *v.chunk_len;
+    const int p0 = *v.past_len;
+    int count = *v.emit_count;
+    int emitted = 0;
+    int exit_reason = 0;
+    int32_t last = v.tokens[0];
+
+    for (int j = 0; j < L; ++j) {
+        if (count + emitted >= p.token_limit) {
+            exit_reason = 3;  // budget
+            break;
+        }
+        const int32_t tok = v.argmax[j];
+        v.ring[count + emitted] = tok;
+        ++emitted;
+        tr_observe_pair_dev(succ, streak, vocab, slots, last, tok);
+        last = tok;
+        bool stop = tok == p.eos_id;
+        for (int s = 0; !stop && s < p.n_stop_ids; ++s)
+            stop = tok == p.stop_ids[s];
+        if (stop) {
+            exit_reason = 2;  // stop token
+            break;
+        }
+        if (j == L - 1)
+            break;  // bonus token reached
+        if (tok != v.tokens[j + 1])
+            break;  // divergence — tok becomes the next t0
+    }
+
+    // Top-M harvest over the real rows (the model's own candidates — valid
+    // regardless of acceptance; this breadth is what makes drafts fire).
+    if (p.topm > 0 && v.topm != nullptr) {
+        for (int j = 0; j < L; ++j) {
+            const int32_t tok = v.tokens[j];
+            if (tok < 0 || tok >= vocab)
+                continue;
+            const int32_t* ids = v.topm + static_cast<int64_t>(j) * p.topm;
+            bool front_existed = false;
+            if (ids[0] >= 0 && ids[0] < vocab) {
+                const int32_t* row = succ + static_cast<int64_t>(tok) * slots;
+                for (int i = 0; i < slots; ++i)
+                    if (row[i] == ids[0]) {
+                        front_existed = true;
+                        break;
+                    }
+            }
+            for (int i = p.topm - 1; i >= 0; --i)
+                if (ids[i] >= 0 && ids[i] < vocab)
+                    tr_promote(succ, streak, slots, tok, ids[i]);
+            streak[tok] = front_existed ? static_cast<uint8_t>(min(255, streak[tok] + 1))
+                                        : uint8_t{0};
+        }
+    }
+
+    count += emitted;
+    *v.emit_count = count;
+    __threadfence_system();
+    *v.ring_count_mapped = count;
+
+    if (exit_reason == 0 && count >= p.token_limit)
+        exit_reason = 3;
+
+    const int new_p0 = p0 + emitted;
+    if (exit_reason == 0) {
+        // Draft the next chunk from the last emitted (not yet forwarded) token.
+        int32_t draft[8];
+        int len = 0;
+        int32_t cur = last;
+        const int depth = p.depth < 8 ? p.depth : 8;
+        for (int i = 0; i < depth; ++i) {
+            if (cur < 0 || cur >= vocab)
+                break;
+            if (streak[cur] < p.min_streak)
+                break;
+            const int32_t s = succ[static_cast<int64_t>(cur) * slots];
+            if (s < 0)
+                break;
+            draft[len++] = s;
+            cur = s;
+        }
+        if (len == 0) {
+            exit_reason = 1;  // draft miss — hand back to the host
+        } else if (new_p0 + p.chunk_pad > p.ctx_ceiling) {
+            exit_reason = 4;  // baked context ceiling reached
+        } else {
+            const int newL = len + 1;
+            for (int i = 0; i < p.chunk_pad; ++i) {
+                v.tokens[i] = (i == 0) ? last : (i <= len ? draft[i - 1] : last);
+                v.positions[i] = new_p0 + i;
+                v.row_ctx_lens[i] = (i < newL) ? (new_p0 + i + 1) : 1;
+            }
+            *v.chunk_len = newL;
+            *v.past_len = new_p0;
+            *v.ctx_len = new_p0 + p.chunk_pad;
+        }
+    }
+    *v.exit_reason = exit_reason;
+    if (kHasHandle && exit_reason != 0)
+        cudaGraphSetConditional(handle, 0);
+}
+
+}  // namespace
+
+void tr_verify_step(const TrLoopView& v, const TrLoopParams& p, bool /*no_handle*/,
+                    cudaStream_t stream) {
+    tr_verify_step_kernel<false><<<1, 32, 0, stream>>>(v, p, cudaGraphConditionalHandle{});
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+void tr_verify_step_conditional(const TrLoopView& v, const TrLoopParams& p,
+                                cudaGraphConditionalHandle handle, cudaStream_t stream) {
+    tr_verify_step_kernel<true><<<1, 32, 0, stream>>>(v, p, handle);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+bool tr_device_init(TrDeviceTable& t, int vocab, int slots, cudaStream_t stream) {
+    t.vocab = vocab;
+    t.slots = slots;
+    const int64_t n_succ = static_cast<int64_t>(vocab) * slots;
+    if (cudaMalloc(&t.succ, n_succ * sizeof(int32_t)) != cudaSuccess)
+        return false;
+    if (cudaMalloc(&t.streak, vocab) != cudaSuccess) {
+        cudaFree(t.succ);
+        t.succ = nullptr;
+        return false;
+    }
+    const int64_t n = n_succ > vocab ? n_succ : vocab;
+    tr_init_kernel<<<static_cast<unsigned>((n + 255) / 256), 256, 0, stream>>>(t.succ, t.streak,
+                                                                               n_succ, vocab);
+    IMP_CUDA_CHECK_LAUNCH();
+    return true;
+}
+
+void tr_device_free(TrDeviceTable& t) {
+    if (t.succ)
+        IMP_CUDA_CHECK_LOG(cudaFree(t.succ));
+    if (t.streak)
+        IMP_CUDA_CHECK_LOG(cudaFree(t.streak));
+    t = TrDeviceTable{};
+}
+
+void tr_observe_pairs(TrDeviceTable& t, const int32_t* d_toks, int n, cudaStream_t stream) {
+    if (n < 2)
+        return;
+    tr_observe_pairs_kernel<<<1, 32, 0, stream>>>(t.succ, t.streak, t.vocab, t.slots, d_toks, n);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+void tr_observe_topk(TrDeviceTable& t, const int32_t* d_row_tokens, const int32_t* d_topm,
+                     int rows, int m, cudaStream_t stream) {
+    if (rows <= 0 || m <= 0)
+        return;
+    tr_observe_topk_kernel<<<1, 32, 0, stream>>>(t.succ, t.streak, t.vocab, t.slots,
+                                                 d_row_tokens, d_topm, rows, m);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+void tr_draft(TrDeviceTable& t, const int32_t* d_last_token, int depth, int min_streak,
+              int32_t* d_out_draft, int32_t* d_out_len, cudaStream_t stream) {
+    tr_draft_kernel<<<1, 32, 0, stream>>>(t.succ, t.streak, t.vocab, t.slots, d_last_token,
+                                          depth, min_streak, d_out_draft, d_out_len);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+}  // namespace imp

--- a/src/compute/token_recycle_device.h
+++ b/src/compute/token_recycle_device.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace imp {
+
+// Device-side Token-Recycling adjacency table (#1055 verify-in-loop): the
+// `token -> top-M successors` table lives in device memory so the draft walk
+// and the observe updates can run INSIDE a conditional-graph verify loop
+// with no host round-trip. Semantics are kept exactly equal to the host
+// TokenRecycleTable (MRU promote, re-observation streak) — the loop path
+// and the eager host path must draft identically from the same stream
+// (pinned by tests/test_token_recycle_device.cu).
+//
+// The observe kernels run single-threaded on purpose: updates are a few
+// slot shuffles per accepted token (microseconds), and MRU promotion is order-
+// dependent — serial execution IS the specification.
+struct TrDeviceTable {
+    int32_t* succ = nullptr;   // vocab * slots, -1 = empty (MRU front-first)
+    uint8_t* streak = nullptr; // vocab, re-observation count of the front slot
+    int vocab = 0;
+    int slots = 0;
+};
+
+// Allocate + zero-init (succ = -1, streak = 0). Returns false on OOM.
+bool tr_device_init(TrDeviceTable& t, int vocab, int slots, cudaStream_t stream);
+void tr_device_free(TrDeviceTable& t);
+
+// Observe consecutive pairs of a token sequence: (toks[i-1] -> toks[i]).
+void tr_observe_pairs(TrDeviceTable& t, const int32_t* d_toks, int n, cudaStream_t stream);
+
+// Observe the model's top-M successor candidates per row (best first):
+// row r records d_topm[r*m .. r*m+m) as successors of d_row_tokens[r].
+void tr_observe_topk(TrDeviceTable& t, const int32_t* d_row_tokens, const int32_t* d_topm,
+                     int rows, int m, cudaStream_t stream);
+
+// Walk the front-slot chain from *d_last_token (device scalar) for up to
+// `depth` hops, gated on streak >= min_streak per hop. Writes the chain to
+// d_out_draft and its length to *d_out_len.
+void tr_draft(TrDeviceTable& t, const int32_t* d_last_token, int depth, int min_streak,
+              int32_t* d_out_draft, int32_t* d_out_len, cudaStream_t stream);
+
+// ── verify-in-loop step kernel (#1055) ─────────────────────────────────
+// The accept+draft+stage tail of the conditional verify-loop body (the
+// post_decode_step analog). See docs/plans/2026-07-23-verify-in-loop.md.
+
+// Device-pointer bundle (passed by value into the kernel launch).
+struct TrLoopView {
+    TrDeviceTable tab;
+    // Chunk staging (the capture-mode verify forward reads these).
+    int32_t* tokens = nullptr;        // [chunk_pad]
+    int32_t* positions = nullptr;     // [chunk_pad]
+    int32_t* row_ctx_lens = nullptr;  // [chunk_pad]
+    int32_t* ctx_len = nullptr;       // scalar
+    int32_t* past_len = nullptr;      // scalar (p0)
+    int32_t* chunk_len = nullptr;     // scalar (real rows)
+    // Verify outputs of the forward that just ran.
+    const int32_t* argmax = nullptr;  // [chunk_pad]
+    const int32_t* topm = nullptr;    // [chunk_pad * m]
+    // Emission + loop state.
+    int32_t* ring = nullptr;               // mapped device ptr, [token capacity]
+    int32_t* ring_count_mapped = nullptr;  // mapped publish counter (host-visible)
+    int32_t* emit_count = nullptr;         // device authoritative counter
+    int32_t* exit_reason = nullptr;        // 0=continue 1=miss 2=stop 3=budget 4=ctx-ceiling
+};
+
+struct TrLoopParams {
+    int chunk_pad = 4;
+    int depth = 3;
+    int min_streak = 1;
+    int topm = 0;                       // 0 = no harvest
+    int32_t eos_id = -1;
+    const int32_t* stop_ids = nullptr;  // device, optional
+    int n_stop_ids = 0;
+    int token_limit = 0;                // total ring tokens allowed this burst
+    int ctx_ceiling = 0;                // p0' + chunk_pad must stay <= this
+};
+
+// Standalone (non-graph) launcher used by tests and the eager fallback; the
+// loop runner embeds the same kernel with a conditional handle.
+void tr_verify_step(const TrLoopView& v, const TrLoopParams& p, bool no_handle,
+                    cudaStream_t stream);
+// Graph-embedded variant: sets the conditional handle to 0 on exit.
+void tr_verify_step_conditional(const TrLoopView& v, const TrLoopParams& p,
+                                cudaGraphConditionalHandle handle, cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_token_recycle_device.cu
+++ b/tests/test_token_recycle_device.cu
@@ -1,0 +1,114 @@
+// Device-side Token-Recycling adjacency table (src/compute/token_recycle_device.cu)
+// for the verify-in-loop design (#1055): the draft walk, MRU promote and
+// streak semantics must match the host TokenRecycleTable exactly — the loop
+// path drafts on-device, the eager path on-host, and both must produce the
+// same drafts from the same observation stream.
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include "compute/token_recycle_device.h"
+#include "runtime/token_recycle_draft.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace imp {
+namespace {
+
+class TrDevice : public ::testing::Test {
+protected:
+    void SetUp() override { cudaStreamCreate(&stream_); }
+    void TearDown() override { cudaStreamDestroy(stream_); }
+    cudaStream_t stream_ = nullptr;
+};
+
+// Feed the same pseudo-random token stream to host and device tables via
+// observe_pairs; drafts from every token must agree at min_streak 0 and 1.
+TEST_F(TrDevice, PairStreamMatchesHostReference) {
+    const int vocab = 200, slots = 4, n = 400;
+    std::vector<int32_t> stream_toks(n);
+    uint32_t s = 42;
+    for (auto& t : stream_toks) {
+        s = s * 1664525u + 1013904223u;
+        t = static_cast<int32_t>(s % 50);  // small range -> repeats -> streaks
+    }
+
+    TokenRecycleTable host(vocab, slots);
+    for (int i = 1; i < n; ++i)
+        host.observe_pair(stream_toks[i - 1], stream_toks[i]);
+
+    TrDeviceTable dev{};
+    ASSERT_TRUE(tr_device_init(dev, vocab, slots, stream_));
+    int32_t* d_toks = nullptr;
+    cudaMalloc(&d_toks, n * sizeof(int32_t));
+    cudaMemcpyAsync(d_toks, stream_toks.data(), n * sizeof(int32_t), cudaMemcpyHostToDevice,
+                    stream_);
+    tr_observe_pairs(dev, d_toks, n, stream_);
+
+    int32_t* d_last = nullptr;
+    int32_t *d_draft = nullptr, *d_len = nullptr;
+    cudaMalloc(&d_last, sizeof(int32_t));
+    cudaMalloc(&d_draft, 8 * sizeof(int32_t));
+    cudaMalloc(&d_len, sizeof(int32_t));
+
+    for (int ms = 0; ms <= 1; ++ms) {
+        for (int32_t t0 = 0; t0 < 50; ++t0) {
+            cudaMemcpyAsync(d_last, &t0, sizeof(int32_t), cudaMemcpyHostToDevice, stream_);
+            tr_draft(dev, d_last, /*depth=*/3, /*min_streak=*/ms, d_draft, d_len, stream_);
+            int32_t len = -1;
+            int32_t got[8];
+            cudaMemcpyAsync(&len, d_len, sizeof(int32_t), cudaMemcpyDeviceToHost, stream_);
+            cudaMemcpyAsync(got, d_draft, 8 * sizeof(int32_t), cudaMemcpyDeviceToHost, stream_);
+            cudaStreamSynchronize(stream_);
+            auto want = host.draft_linear(t0, 3, ms);
+            ASSERT_EQ(len, static_cast<int32_t>(want.size()))
+                << "t0=" << t0 << " min_streak=" << ms;
+            for (int j = 0; j < len; ++j)
+                EXPECT_EQ(got[j], want[j]) << "t0=" << t0 << " j=" << j << " ms=" << ms;
+        }
+    }
+
+    cudaFree(d_toks);
+    cudaFree(d_last);
+    cudaFree(d_draft);
+    cudaFree(d_len);
+    tr_device_free(dev);
+}
+
+// Top-K observation: rank order + streak follow the host semantics.
+TEST_F(TrDevice, TopkObservationMatchesHostReference) {
+    const int vocab = 100, slots = 4, rows = 3, m = 3;
+    TokenRecycleTable host(vocab, slots);
+    TrDeviceTable dev{};
+    ASSERT_TRUE(tr_device_init(dev, vocab, slots, stream_));
+
+    const int32_t row_tokens[rows] = {5, 6, 5};
+    const int32_t topm[rows * m] = {10, 11, 12,   20, 21, 22,   10, 13, 11};
+    for (int r = 0; r < rows; ++r)
+        host.observe_topk(row_tokens[r], topm + r * m, m);
+
+    int32_t *d_rt = nullptr, *d_tm = nullptr;
+    cudaMalloc(&d_rt, sizeof(row_tokens));
+    cudaMalloc(&d_tm, sizeof(topm));
+    cudaMemcpyAsync(d_rt, row_tokens, sizeof(row_tokens), cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(d_tm, topm, sizeof(topm), cudaMemcpyHostToDevice, stream_);
+    tr_observe_topk(dev, d_rt, d_tm, rows, m, stream_);
+
+    // Compare the full visible state: successors of 5 and 6 + drafts.
+    std::vector<int32_t> succ(static_cast<size_t>(vocab) * slots);
+    cudaMemcpyAsync(succ.data(), dev.succ, succ.size() * sizeof(int32_t),
+                    cudaMemcpyDeviceToHost, stream_);
+    cudaStreamSynchronize(stream_);
+    for (int32_t tok : {5, 6}) {
+        for (int sl = 0; sl < slots; ++sl)
+            EXPECT_EQ(succ[static_cast<size_t>(tok) * slots + sl], host.successor(tok, sl))
+                << "tok=" << tok << " slot=" << sl;
+    }
+
+    cudaFree(d_rt);
+    cudaFree(d_tm);
+    tr_device_free(dev);
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_tr_verify_step.cu
+++ b/tests/test_tr_verify_step.cu
@@ -1,0 +1,213 @@
+// tr_verify_step: the device accept+draft+stage kernel that forms the tail
+// of the verify-in-loop conditional body (#1055, docs/plans/2026-07-23-
+// verify-in-loop.md). Driven here WITHOUT a graph: the test stages chunk 0,
+// then plays model "argmax" outputs into the buffer and steps the kernel,
+// checking ring emission, position advance, next-chunk staging, adjacency
+// updates and the exit reasons.
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include "compute/token_recycle_device.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace imp {
+namespace {
+
+constexpr int kPad = 4;   // bucket-4 chunk
+constexpr int kM = 3;     // top-M harvest width
+
+class TrVerifyStep : public ::testing::Test {
+protected:
+    void SetUp() override {
+        cudaStreamCreate(&stream_);
+        ASSERT_TRUE(tr_device_init(tab_, /*vocab=*/100, /*slots=*/4, stream_));
+        cudaMalloc(&d_stage_, (3 * kPad + 3) * sizeof(int32_t));
+        cudaMalloc(&d_argmax_, kPad * sizeof(int32_t));
+        cudaMalloc(&d_topm_, kPad * kM * sizeof(int32_t));
+        cudaMalloc(&d_emit_count_, sizeof(int32_t));
+        cudaMalloc(&d_exit_reason_, sizeof(int32_t));
+        cudaHostAlloc(&h_ring_, 64 * sizeof(int32_t), cudaHostAllocMapped);
+        cudaHostGetDevicePointer(&d_ring_, h_ring_, 0);
+        cudaHostAlloc(&h_count_, sizeof(int32_t), cudaHostAllocMapped);
+        cudaHostGetDevicePointer(&d_count_mapped_, h_count_, 0);
+        cudaMemsetAsync(d_emit_count_, 0, sizeof(int32_t), stream_);
+        cudaMemsetAsync(d_exit_reason_, 0, sizeof(int32_t), stream_);
+        *h_count_ = 0;
+    }
+    void TearDown() override {
+        tr_device_free(tab_);
+        cudaFree(d_stage_);
+        cudaFree(d_argmax_);
+        cudaFree(d_topm_);
+        cudaFree(d_emit_count_);
+        cudaFree(d_exit_reason_);
+        cudaFreeHost(h_ring_);
+        cudaFreeHost(h_count_);
+        cudaStreamDestroy(stream_);
+    }
+
+    TrLoopView view() {
+        TrLoopView v{};
+        v.tab = tab_;
+        v.tokens = d_stage_;
+        v.positions = d_stage_ + kPad;
+        v.row_ctx_lens = d_stage_ + 2 * kPad;
+        v.ctx_len = d_stage_ + 3 * kPad;
+        v.past_len = d_stage_ + 3 * kPad + 1;
+        v.chunk_len = d_stage_ + 3 * kPad + 2;
+        v.argmax = d_argmax_;
+        v.topm = d_topm_;
+        v.ring = d_ring_;
+        v.ring_count_mapped = d_count_mapped_;
+        v.emit_count = d_emit_count_;
+        v.exit_reason = d_exit_reason_;
+        return v;
+    }
+
+    TrLoopParams params() {
+        TrLoopParams p{};
+        p.chunk_pad = kPad;
+        p.depth = 3;
+        p.min_streak = 0;
+        p.topm = kM;
+        p.eos_id = 99;
+        p.token_limit = 64;
+        p.ctx_ceiling = 4096;
+        return p;
+    }
+
+    // Host-side stage of the first chunk (the launch-time seed).
+    void seed_chunk(int32_t t0, const std::vector<int32_t>& draft, int p0) {
+        int32_t stage[3 * kPad + 3];
+        const int L = 1 + static_cast<int>(draft.size());
+        for (int i = 0; i < kPad; ++i) {
+            stage[i] = (i == 0) ? t0 : (i <= static_cast<int>(draft.size()) ? draft[i - 1] : t0);
+            stage[kPad + i] = p0 + i;
+            stage[2 * kPad + i] = (i < L) ? (p0 + i + 1) : 1;
+        }
+        stage[3 * kPad] = p0 + kPad;
+        stage[3 * kPad + 1] = p0;
+        stage[3 * kPad + 2] = L;
+        cudaMemcpyAsync(d_stage_, stage, sizeof(stage), cudaMemcpyHostToDevice, stream_);
+    }
+
+    void set_argmax(const std::vector<int32_t>& v) {
+        int32_t a[kPad] = {0, 0, 0, 0};
+        for (size_t i = 0; i < v.size() && i < kPad; ++i) a[i] = v[i];
+        cudaMemcpyAsync(d_argmax_, a, sizeof(a), cudaMemcpyHostToDevice, stream_);
+        int32_t tm[kPad * kM];
+        for (int i = 0; i < kPad * kM; ++i) tm[i] = 1 + (i % 7);  // arbitrary valid ids
+        cudaMemcpyAsync(d_topm_, tm, sizeof(tm), cudaMemcpyHostToDevice, stream_);
+    }
+
+    int32_t stage_at(int idx) {
+        int32_t v;
+        cudaMemcpy(&v, d_stage_ + idx, sizeof(int32_t), cudaMemcpyDeviceToHost);
+        return v;
+    }
+    int32_t exit_reason() {
+        int32_t v;
+        cudaMemcpy(&v, d_exit_reason_, sizeof(int32_t), cudaMemcpyDeviceToHost);
+        return v;
+    }
+
+    cudaStream_t stream_ = nullptr;
+    TrDeviceTable tab_{};
+    int32_t* d_stage_ = nullptr;
+    int32_t* d_argmax_ = nullptr;
+    int32_t* d_topm_ = nullptr;
+    int32_t* d_emit_count_ = nullptr;
+    int32_t* d_exit_reason_ = nullptr;
+    int32_t* h_ring_ = nullptr;
+    int32_t* d_ring_ = nullptr;
+    int32_t* h_count_ = nullptr;
+    int32_t* d_count_mapped_ = nullptr;
+};
+
+// Full accept: draft [2,3] all match, bonus 4 -> emit [2,3,4]; next chunk
+// staged from token 4 with the chain the adjacency has learned.
+TEST_F(TrVerifyStep, FullAcceptEmitsAndStagesNext) {
+    // Teach the table 4 -> 5 -> 6 so the next draft exists.
+    const int32_t chain[3] = {4, 5, 6};
+    int32_t* d_chain;
+    cudaMalloc(&d_chain, sizeof(chain));
+    cudaMemcpyAsync(d_chain, chain, sizeof(chain), cudaMemcpyHostToDevice, stream_);
+    tr_observe_pairs(tab_, d_chain, 3, stream_);
+
+    seed_chunk(/*t0=*/1, {2, 3}, /*p0=*/10);  // chunk rows: [1,2,3,pad] L=3
+    set_argmax({2, 3, 4, 0});                 // rows agree, bonus = 4
+    tr_verify_step(view(), params(), /*no_handle=*/true, stream_);
+    cudaStreamSynchronize(stream_);
+
+    EXPECT_EQ(*h_count_, 3);
+    EXPECT_EQ(h_ring_[0], 2);
+    EXPECT_EQ(h_ring_[1], 3);
+    EXPECT_EQ(h_ring_[2], 4);
+    EXPECT_EQ(exit_reason(), 0);              // loop continues
+    EXPECT_EQ(stage_at(0), 4);                // next t0 = bonus
+    EXPECT_EQ(stage_at(1), 5);                // next draft from adjacency
+    EXPECT_EQ(stage_at(kPad), 13);            // next p0 = 10 + 3
+    EXPECT_EQ(stage_at(3 * kPad + 1), 13);    // past_len
+    cudaFree(d_chain);
+}
+
+// Partial accept: draft [2,3], model diverges at row 1 -> emit [2, 7].
+TEST_F(TrVerifyStep, PartialAcceptStopsAtDivergence) {
+    const int32_t chain[2] = {7, 8};
+    int32_t* d_chain;
+    cudaMalloc(&d_chain, sizeof(chain));
+    cudaMemcpyAsync(d_chain, chain, sizeof(chain), cudaMemcpyHostToDevice, stream_);
+    tr_observe_pairs(tab_, d_chain, 2, stream_);
+
+    seed_chunk(1, {2, 3}, 10);
+    set_argmax({2, 7, 0, 0});  // row0 matches draft(2), row1 says 7 != 3
+    tr_verify_step(view(), params(), true, stream_);
+    cudaStreamSynchronize(stream_);
+
+    EXPECT_EQ(*h_count_, 2);
+    EXPECT_EQ(h_ring_[0], 2);
+    EXPECT_EQ(h_ring_[1], 7);
+    EXPECT_EQ(exit_reason(), 0);
+    EXPECT_EQ(stage_at(0), 7);              // next t0 = the diverging token
+    EXPECT_EQ(stage_at(1), 8);              // drafted from 7 -> 8
+    EXPECT_EQ(stage_at(3 * kPad + 1), 12);  // p0 10 + 2 emitted
+    cudaFree(d_chain);
+}
+
+// Miss exit: bonus token has no successor -> emit, then exit_reason=miss.
+TEST_F(TrVerifyStep, MissExitsLoop) {
+    seed_chunk(1, {2}, 10);
+    set_argmax({2, 50, 0, 0});  // accept 2, bonus 50 (no successors known)
+    tr_verify_step(view(), params(), true, stream_);
+    cudaStreamSynchronize(stream_);
+    EXPECT_EQ(*h_count_, 2);
+    EXPECT_EQ(exit_reason(), 1);  // 1 = draft miss
+}
+
+// EOS mid-chunk: truncates the emission at EOS and exits.
+TEST_F(TrVerifyStep, EosTruncatesAndExits) {
+    seed_chunk(1, {99, 3}, 10);   // draft contains EOS(99)
+    set_argmax({99, 0, 0, 0});    // model emits EOS at row 0
+    tr_verify_step(view(), params(), true, stream_);
+    cudaStreamSynchronize(stream_);
+    EXPECT_EQ(*h_count_, 1);
+    EXPECT_EQ(h_ring_[0], 99);
+    EXPECT_EQ(exit_reason(), 2);  // 2 = stop token
+}
+
+// Token budget exit.
+TEST_F(TrVerifyStep, TokenLimitExits) {
+    seed_chunk(1, {2, 3}, 10);
+    set_argmax({2, 3, 4, 0});
+    auto p = params();
+    p.token_limit = 2;  // only 2 tokens allowed
+    tr_verify_step(view(), p, true, stream_);
+    cudaStreamSynchronize(stream_);
+    EXPECT_EQ(*h_count_, 2);      // truncated at the budget
+    EXPECT_EQ(exit_reason(), 3);  // 3 = budget
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Phase 1 of the verify-in-loop design (`docs/plans/2026-07-23-verify-in-loop.md`): eliminate the measured ~1.3 ms/step host scheduler/API tax between spec-verify steps by running the draft->verify->accept cycle inside a conditional CUDA-graph WHILE loop — the async-decode-loop analog for speculation.

**Why token-recycling is the loop-able drafter:** the adjacency table is `vocab x slots` int32 + a streak byte — fully device-resident — and its inputs (accepted tokens, verify top-M logits) are already on device. Drafting becomes a table walk inside the loop body; no host round-trip anywhere in the cycle.

**This PR is inert** (new files + tests only, zero engine wiring, zero behavior change):

- `src/compute/token_recycle_device.{h,cu}` — device adjacency table with MRU-promote/streak semantics pinned equal to the host `TokenRecycleTable` (equivalence tested on random observation streams at min_streak 0 and 1).
- `tr_verify_step[_conditional]` — the complete loop-body tail kernel: accept the verified chunk, emit `1+matched` tokens to the mapped ring (`__threadfence_system` publish protocol), EOS/stop/budget/ctx-ceiling exits (conditional handle -> 0), adjacency feed (accepted-path pairs + top-M harvest), next-draft walk and full next-chunk staging into the same device buffers the capture-mode verify forward reads.
- 7 GPU tests covering table equivalence and all five step-kernel behaviors (full accept / partial accept / miss exit / EOS exit / budget exit), driven without a graph.

Phase 2 (mapped in the plan doc with reuse coordinates): `TrVerifyLoopRunner` (conditional node + body capture of forward -> argmax -> step kernel) + engine wiring behind `speculative.recycle_loop`. Riskiest unknown flagged first: capture-mode verify forward inside a conditional WHILE body under Relaxed capture.

Verification: 7 new GPU tests + 17 host TR tests green; `make verify-fast` all-PASS; file-size gate OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV