### PR TITLE
feat(kv): SWA window snapshots — prefix caching under swa_sizing + 128K TTFT reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   can hold) more than 64K.
 
 ### Added
+- **SWA window snapshots (`kv_cache.swa_snapshot_mb`)**: prefix caching and
+  SWA-aware KV sizing now combine — the engine packs each prefill-end
+  window of the sliding-window layers into a device LRU store (same pattern
+  as the hybrid recurrent-state snapshots) and restores it at admission on
+  a prefix-cache hit, so warm multi-turn reuse works with the windowed-KV
+  savings. Opt-in budget in MiB (0 = off: `swa_sizing=auto` keeps yielding
+  to prefix caching). Reuse is capped at snapshot boundaries (one per
+  prefill end).
 - **Qwen-Coder XML tool-call grammar**: `tool_choice=required`/forced and
   `strict:true` on templates teaching the `<function=NAME>`/`<parameter=KEY>`
   raw-text dialect (Qwen3-Coder, Qwen3.6) are now enforced by a dedicated

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -200,6 +200,18 @@ The Qwen3-8B defaults cell was re-measured 2026-07-12 on `f3c228a0` after
 | Qwen3.6-35B-A3B | NVFP4 | 14 887 | **264.3** | IMA crash (#963/#967), then 72.7 streaming (#969) |
 | Qwen3.6-35B-A3B | Q4_K_M (GGUF) | 9 436 (pp16384) | **234.2** | 69.6 under streaming + silent OOB reads (#967/#969) |
 
+**128K single-chunk prefill reference** (2026-07-24, commit `d8bc45a8`, CUDA
+13.3, healthy-host clocks sampled during the run — 13 801 MHz mem / ~575 W):
+Qwen3-14B **NVFP4** `pp131072 = 3 792 tok/s` (34.6 s TTFT), command
+`imp-cli --model Qwen3-14B-NVFP4 --bench --bench-pp 131072 --bench-reps 5
+--prefill-chunk-size 0 --max-tokens 1 --temperature 0 --max-seq-len 140000`.
+The auto `max_seq_len` ceiling is 128K since `d8bc45a8`. The Q6_K GGUF
+north-star model cannot host this measurement on 32 GB (its KV pool tops out
+near 75K tokens beside the dual GGUF+NVFP4 weight residency), which is why
+the CI TTFT gate band in `tests/perf_baseline_north_star.json` ends at
+pp65536 — the 64K row is that model's VRAM-feasible ceiling, not a coverage
+gap.
+
 What the first sweep found and what fixed it:
 
 - **#963/#967**: StreamingLLM's middle-block eviction retained the window

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -133,6 +133,15 @@ bitdecoding_residual_tokens = 0
 # snapshot-based reuse is a follow-up); use it for long single-sequence
 # contexts where KV VRAM is the bottleneck. "off" disables entirely.
 swa_sizing                  = auto
+# SWA window snapshots: device budget (MiB) for packed windowed-layer KV
+# snapshots, which make prefix caching valid UNDER swa_sizing — the snapshot
+# restores the trailing window at the reuse boundary, analogous to the
+# recurrent_snapshot_mb store for hybrids. One snapshot per prefill end, LRU
+# within the budget. With a budget set, swa_sizing=auto no longer yields to
+# prefix caching and the server gets both: the KV savings AND warm-prefix
+# reuse capped at snapshot boundaries. 0 = off (auto yields, on force-
+# disables prefix caching).
+swa_snapshot_mb             = 0
 
 [rope]
 # Runtime RoPE-scaling override: stretch a model's usable context past its

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -579,4 +579,37 @@ void KVCache::copy_blocks_device(const int* srcs, const int* dsts, int n_pairs,
     IMP_CUDA_CHECK_LAUNCH();
 }
 
+// ── batched_copy_device ──────────────────────────────────────────────
+// One CTA per desc; uint4 fast path when src/dst/bytes are 16-byte aligned
+// (block and scale regions are — pool offsets are multiples of the block
+// byte sizes), byte loop otherwise.
+
+static __global__ void kv_batched_copy_kernel(const KVCache::CopyDesc* descs, int n) {
+    const int d = blockIdx.x;
+    if (d >= n)
+        return;
+    const char* src = static_cast<const char*>(descs[d].src);
+    char* dst = static_cast<char*>(descs[d].dst);
+    const size_t bytes = descs[d].bytes;
+    const bool aligned = ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst) |
+                           bytes) & 15u) == 0;
+    if (aligned) {
+        const uint4* s = reinterpret_cast<const uint4*>(src);
+        uint4* t = reinterpret_cast<uint4*>(dst);
+        const size_t n16 = bytes / 16;
+        for (size_t i = threadIdx.x; i < n16; i += blockDim.x)
+            t[i] = s[i];
+    } else {
+        for (size_t i = threadIdx.x; i < bytes; i += blockDim.x)
+            dst[i] = src[i];
+    }
+}
+
+void KVCache::batched_copy_device(const CopyDesc* d_descs, int n, cudaStream_t stream) {
+    if (!d_descs || n <= 0)
+        return;
+    kv_batched_copy_kernel<<<n, 256, 0, stream>>>(d_descs, n);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
 }  // namespace imp

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -78,12 +78,27 @@ public:
     static constexpr int kCopyMaxPairs = 16;
     void copy_blocks_device(const int* srcs, const int* dsts, int n_pairs, cudaStream_t stream);
 
+    // Generic batched D2D copy: one kernel launch executes n independent
+    // {src, dst, bytes} copies (SWA window snapshot pack/restore). Descs must
+    // be device-resident; 16-byte-aligned fast path, byte fallback otherwise.
+    struct CopyDesc {
+        const void* src;
+        void* dst;
+        size_t bytes;
+    };
+    static void batched_copy_device(const CopyDesc* d_descs, int n, cudaStream_t stream);
+
     // Capacity queries
     int num_free_blocks() const;
     int total_blocks() const;
 
     // Accessors
     size_t block_bytes() const;
+    // Per-layer block bytes (per-layer ctor); falls back to the scalar.
+    size_t block_bytes(int layer) const {
+        return layer_block_bytes_.empty() ? block_bytes_
+                                          : layer_block_bytes_[static_cast<size_t>(layer)];
+    }
     int block_size() const { return block_size_; }
     int n_layers() const;
     int n_kv_heads() const;

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -43,6 +43,14 @@ void KVCacheManager::rollback_partial_allocation(int seq_id, std::vector<int>& b
 KVCacheManager::KVCacheManager(std::unique_ptr<KVCache> cache) : cache_(std::move(cache)) {}
 
 KVCacheManager::~KVCacheManager() {
+    if (h_swa_descs_) {
+        cudaFreeHost(h_swa_descs_);
+        h_swa_descs_ = nullptr;
+    }
+    if (d_swa_descs_) {
+        cudaFree(d_swa_descs_);
+        d_swa_descs_ = nullptr;
+    }
     if (residual_pool_ && residual_alloc_) {
         residual_alloc_->free(residual_pool_);
         residual_pool_ = nullptr;
@@ -857,6 +865,173 @@ const std::vector<int>& KVCacheManager::swa_block_table(int seq_id) const {
     if (it == seq_swa_blocks_.end())
         return empty;
     return it->second;
+}
+
+// ─── SWA window snapshots (prefix caching for SWA-sized models) ──────
+
+bool KVCacheManager::enable_swa_snapshots() {
+    if (swa_window_ <= 0 || !cache_->swa_enabled())
+        return false;
+    if (swa_snap_bytes_ > 0)
+        return true;  // already enabled
+    const int bs = cache_->block_size();
+    swa_snap_layers_.clear();
+    for (int l = 0; l < cache_->n_layers(); ++l)
+        if (cache_->layer_is_swa(l))
+            swa_snap_layers_.push_back(l);
+    if (swa_snap_layers_.empty())
+        return false;
+    // Max live blocks per layer at any block-aligned position: the trailing
+    // window plus slack, ceil-aligned, plus the partial boundary block.
+    swa_snap_win_blocks_ = (swa_window_ + swa_slack_ + bs - 1) / bs + 1;
+    // Slab layout per dense layer j: [K slots][V slots][K scale][V scale],
+    // each region swa_snap_win_blocks_ entries of the layer's byte sizes.
+    swa_snap_layer_off_.clear();
+    size_t off = 0;
+    for (int l : swa_snap_layers_) {
+        swa_snap_layer_off_.push_back(off);
+        const size_t kvb = cache_->block_bytes(l);
+        const size_t scb = cache_->k_scale_ptr(l, 0) ? cache_->scale_block_bytes(l) : 0;
+        off += static_cast<size_t>(swa_snap_win_blocks_) * 2 * (kvb + scb);
+    }
+    swa_snap_bytes_ = off;
+    const int cap =
+        static_cast<int>(swa_snap_layers_.size()) * swa_snap_win_blocks_ * 4;
+    if (cudaMallocHost(reinterpret_cast<void**>(&h_swa_descs_),
+                       static_cast<size_t>(cap) * sizeof(KVCache::CopyDesc)) != cudaSuccess ||
+        cudaMalloc(reinterpret_cast<void**>(&d_swa_descs_),
+                   static_cast<size_t>(cap) * sizeof(KVCache::CopyDesc)) != cudaSuccess) {
+        IMP_LOG_WARN("KVCacheManager: SWA snapshot desc alloc failed — snapshots disabled");
+        if (h_swa_descs_) {
+            cudaFreeHost(h_swa_descs_);
+            h_swa_descs_ = nullptr;
+        }
+        swa_snap_bytes_ = 0;
+        return false;
+    }
+    swa_desc_cap_ = cap;
+    IMP_LOG_INFO("KVCacheManager: SWA snapshots enabled (%zu KiB/snapshot, %d layers x %d blocks)",
+                 swa_snap_bytes_ >> 10, static_cast<int>(swa_snap_layers_.size()),
+                 swa_snap_win_blocks_);
+    return true;
+}
+
+int KVCacheManager::swa_first_live_block(int upto_tokens) const {
+    const int bs = cache_->block_size();
+    const long long dead = static_cast<long long>(upto_tokens) - swa_window_ - swa_slack_;
+    return dead > 0 ? static_cast<int>(dead / bs) : 0;
+}
+
+bool KVCacheManager::swa_snapshot_copy_(int seq_id, int upto_tokens, void* slab, bool to_slab,
+                                        cudaStream_t stream) {
+    const int bs = cache_->block_size();
+    if (upto_tokens <= 0 || upto_tokens % bs != 0)
+        return false;
+    const int end_b = upto_tokens / bs;
+    const int first = swa_first_live_block(upto_tokens);
+    const int count = end_b - first;
+    if (count <= 0 || count > swa_snap_win_blocks_)
+        return false;
+    auto it = seq_swa_blocks_.find(seq_id);
+    if (it == seq_swa_blocks_.end() || static_cast<int>(it->second.size()) < end_b)
+        return false;
+    const auto& swa = it->second;
+    int n = 0;
+    char* slab_c = static_cast<char*>(slab);
+    for (size_t j = 0; j < swa_snap_layers_.size(); ++j) {
+        const int l = swa_snap_layers_[j];
+        const size_t kvb = cache_->block_bytes(l);
+        const size_t scb = cache_->k_scale_ptr(l, 0) ? cache_->scale_block_bytes(l) : 0;
+        char* base = slab_c + swa_snap_layer_off_[j];
+        char* k_area = base;
+        char* v_area = base + static_cast<size_t>(swa_snap_win_blocks_) * kvb;
+        char* ks_area = v_area + static_cast<size_t>(swa_snap_win_blocks_) * kvb;
+        char* vs_area = ks_area + static_cast<size_t>(swa_snap_win_blocks_) * scb;
+        for (int i = 0; i < count; ++i) {
+            const int id = swa[first + i];
+            if (id < 0)
+                return false;  // hole inside the live window — invariant broken
+            auto put = [&](void* cache_ptr, char* area, size_t bytes) {
+                if (!bytes)
+                    return;
+                KVCache::CopyDesc& d = h_swa_descs_[n++];
+                char* slab_ptr = area + static_cast<size_t>(i) * bytes;
+                d.src = to_slab ? cache_ptr : static_cast<void*>(slab_ptr);
+                d.dst = to_slab ? static_cast<void*>(slab_ptr) : cache_ptr;
+                d.bytes = bytes;
+            };
+            put(cache_->k_ptr(l, id), k_area, kvb);
+            put(cache_->v_ptr(l, id), v_area, kvb);
+            if (scb) {
+                put(cache_->k_scale_ptr(l, id), ks_area, scb);
+                put(cache_->v_scale_ptr(l, id), vs_area, scb);
+            }
+        }
+    }
+    if (n == 0 || n > swa_desc_cap_)
+        return false;
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_swa_descs_, h_swa_descs_,
+                                       static_cast<size_t>(n) * sizeof(KVCache::CopyDesc),
+                                       cudaMemcpyHostToDevice, stream));
+    KVCache::batched_copy_device(d_swa_descs_, n, stream);
+    return true;
+}
+
+bool KVCacheManager::swa_snapshot_pack(int seq_id, int upto_tokens, void* slab,
+                                       cudaStream_t stream) {
+    if (swa_snap_bytes_ == 0 || !slab)
+        return false;
+    return swa_snapshot_copy_(seq_id, upto_tokens, slab, /*to_slab=*/true, stream);
+}
+
+bool KVCacheManager::swa_snapshot_restore(int seq_id, int upto_tokens, const void* slab,
+                                          cudaStream_t stream) {
+    if (swa_snap_bytes_ == 0 || !slab)
+        return false;
+    const int bs = cache_->block_size();
+    if (upto_tokens <= 0 || upto_tokens % bs != 0)
+        return false;
+    const int end_b = upto_tokens / bs;
+    auto git = seq_blocks_.find(seq_id);
+    if (git == seq_blocks_.end() || static_cast<int>(git->second.size()) < end_b)
+        return false;
+    auto& swa = seq_swa_blocks_[seq_id];
+    if (swa.size() < git->second.size())
+        swa.resize(git->second.size(), -1);
+    const int first = swa_first_live_block(upto_tokens);
+    std::vector<int> fresh;
+    fresh.reserve(static_cast<size_t>(end_b - first));
+    for (int b = first; b < end_b; ++b) {
+        if (swa[b] >= 0)
+            continue;  // already prepared (shouldn't happen on a fresh seq)
+        int id = cache_->allocate_swa_block();
+        if (id < 0) {
+            for (int f : fresh)
+                cache_->free_swa_block(f);
+            for (int b2 = first; b2 < end_b; ++b2)
+                if (std::find(fresh.begin(), fresh.end(), swa[b2]) != fresh.end())
+                    swa[b2] = -1;
+            IMP_LOG_WARN("KVCacheManager: SWA snapshot restore failed (group exhausted) — "
+                         "seq %d falls back to full prefill",
+                         seq_id);
+            return false;
+        }
+        swa[b] = id;
+        fresh.push_back(id);
+    }
+    int& cursor = swa_trim_cursor_[seq_id];
+    cursor = std::max(cursor, first);
+    if (!swa_snapshot_copy_(seq_id, upto_tokens, const_cast<void*>(slab), /*to_slab=*/false,
+                            stream)) {
+        for (int b = first; b < end_b; ++b) {
+            if (swa[b] >= 0 && std::find(fresh.begin(), fresh.end(), swa[b]) != fresh.end()) {
+                cache_->free_swa_block(swa[b]);
+                swa[b] = -1;
+            }
+        }
+        return false;
+    }
+    return true;
 }
 
 // ─── Speculative decoding rollback ───────────────────────────────────

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -170,6 +170,28 @@ public:
     // Empty vector if unknown seq or SWA sizing disabled.
     const std::vector<int>& swa_block_table(int seq_id) const;
 
+    // ── SWA window snapshots (prefix caching for SWA-sized models) ───
+    //
+    // A snapshot is the packed KV content of the live SWA window blocks at
+    // a block-aligned position P: for each SWA layer, blocks
+    // [swa_first_live_block(P), P/bs). Restoring it into a fresh sequence
+    // makes a prefix-cache hit at P valid for windowed layers (their
+    // earlier blocks were trailing-freed and cannot back reuse).
+    // enable_swa_snapshots() precomputes the slab layout and allocates the
+    // copy-desc staging; must be called after enable_swa_sizing.
+    bool enable_swa_snapshots();
+    // Fixed slab size (bytes) of one snapshot; 0 until enabled.
+    size_t swa_snapshot_bytes() const { return swa_snap_bytes_; }
+    int swa_first_live_block(int upto_tokens) const;
+    // Pack seq's live window blocks at exactly upto_tokens into slab
+    // (device, >= swa_snapshot_bytes()). False if a needed block is a hole.
+    bool swa_snapshot_pack(int seq_id, int upto_tokens, void* slab, cudaStream_t stream);
+    // Allocate window blocks for a sequence whose global prefix [0, upto)
+    // was reused from the prefix cache and fill them from slab. Table slots
+    // before the window stay -1 holes. False on SWA-group exhaustion
+    // (allocated blocks are released; caller falls back to full prefill).
+    bool swa_snapshot_restore(int seq_id, int upto_tokens, const void* slab, cudaStream_t stream);
+
     // ── Speculative decoding rollback ────────────────────────────────
 
     // Truncate a sequence's block table to fit `new_seq_len` tokens.
@@ -340,6 +362,20 @@ private:
     std::unordered_map<int, int> swa_trim_cursor_;
     int swa_window_ = 0;  // 0 = SWA sizing disabled
     int swa_slack_ = 0;
+
+    // ── SWA snapshot state (enable_swa_snapshots) ────────────────────
+    std::vector<int> swa_snap_layers_;      // SWA layer indices, ascending
+    std::vector<size_t> swa_snap_layer_off_;  // slab byte offset per dense idx
+    int swa_snap_win_blocks_ = 0;           // max live blocks per layer
+    size_t swa_snap_bytes_ = 0;             // total slab bytes
+    KVCache::CopyDesc* h_swa_descs_ = nullptr;  // pinned staging
+    KVCache::CopyDesc* d_swa_descs_ = nullptr;
+    int swa_desc_cap_ = 0;
+    // Build pack (to_slab=true) or restore (to_slab=false) descs for the
+    // seq's SWA table slots [swa_first_live_block(upto), upto/bs) across
+    // all SWA layers and run them in one launch.
+    bool swa_snapshot_copy_(int seq_id, int upto_tokens, void* slab, bool to_slab,
+                            cudaStream_t stream);
 
     // ── LRU tracking ─────────────────────────────────────────────────
     // Doubly-linked list of seq_ids; most recently used at the *tail*.

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -130,6 +130,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("kv_cache.bitdecoding_residual_tokens", cfg.kv_cache.bitdecoding_residual_tokens);
     B("kv_cache.bitdecoding_qk", cfg.kv_cache.bitdecoding_qk);
     S("kv_cache.swa_sizing", cfg.kv_cache.swa_sizing);
+    I("kv_cache.swa_snapshot_mb", cfg.kv_cache.swa_snapshot_mb);
 
     // [rope]
     S("rope.scaling", cfg.rope.scaling);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -177,6 +177,15 @@ struct RuntimeConfig {
         // follow-up); "off" disables. Legacy bools map to on/off.
         std::string swa_sizing = "auto";
 
+        // SWA window snapshots: device budget (MiB) for packed windowed-layer
+        // KV snapshots — what makes prefix caching valid under SWA sizing
+        // (freed window blocks cannot back reuse; the snapshot restores the
+        // trailing window at the reuse boundary, like the recurrent-state
+        // snapshots do for hybrids). One snapshot per prefill end, LRU.
+        // 0 = off: swa_sizing=auto then yields to prefix caching, and
+        // swa_sizing=on force-disables it.
+        int swa_snapshot_mb = 0;
+
         SwaSizingMode swa_sizing_mode() const {
             if (swa_sizing == "auto")
                 return SwaSizingMode::Auto;

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -93,6 +93,10 @@ Engine::~Engine() {
         IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_swa_));
         async_d_block_tables_swa_ = nullptr;
     }
+    if (swa_snap_slab_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(swa_snap_slab_));
+        swa_snap_slab_ = nullptr;
+    }
     if (async_d_banned_tokens_) {
         IMP_CUDA_CHECK_LOG(cudaFree(async_d_banned_tokens_));
         async_d_banned_tokens_ = nullptr;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -527,6 +527,10 @@ private:
     // shared history (see docs — dense models need KV blocks only; hybrids
     // additionally need the recurrent state at the skip boundary).
     std::unique_ptr<RecurrentSnapshotStore> recurrent_snapshots_;
+    // SWA window snapshots (kv_cache.swa_snapshot_mb): packed windowed-layer
+    // KV per prefix hash — makes prefix caching valid under SWA sizing.
+    std::unique_ptr<RecurrentSnapshotStore> swa_snapshots_;
+    void* swa_snap_slab_ = nullptr;  // pack/save scratch, swa_snapshot_bytes()
     // Hybrid decode fairness: round-robin rotation state for the batch-1
     // recurrent decode (quantum-based; see step_decode).
     int hybrid_active_req_ = -1;    // request id currently holding the decode slice
@@ -981,6 +985,12 @@ private:
     int hybrid_prefix_reuse_limit_(Request& req);
     int hybrid_snapshot_end_(const Request& req) const;  // block-aligned save position, 0 = none
     void maybe_save_recurrent_snapshot_(const Request& req, int snap_end, cudaStream_t stream);
+    // SWA window snapshots (kv_cache.swa_snapshot_mb, engine_sampling_stop.cpp):
+    // same admission/save pattern as the hybrid pair, but the state is the
+    // packed windowed-layer KV instead of the recurrent slab.
+    int swa_prefix_reuse_limit_(Request& req);
+    int snapshot_end_(const Request& req) const;  // hybrid or SWA save position, 0 = none
+    void maybe_save_swa_snapshot_(const Request& req, int snap_end, cudaStream_t stream);
     void finish_request(std::shared_ptr<Request>& req);
 
     // ── step() sub-phases ─────────────────────────────────────────────

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -135,9 +135,11 @@ bool Engine::init_kv_cache() {
             off_reason = "green contexts (cross-stream block reuse unordered)";
         else if (runtime_config_.runtime.deterministic)
             off_reason = "deterministic mode (unbounded graph loop would be burst-chunked)";
-        else if (swa_mode == SwaSizingMode::Auto && config_.use_prefix_caching)
+        else if (swa_mode == SwaSizingMode::Auto && config_.use_prefix_caching &&
+                 runtime_config_.kv_cache.swa_snapshot_mb <= 0)
             off_reason = "auto mode yields to prefix caching (freed window blocks cannot back "
-                         "prefix reuse; set kv_cache.swa_sizing=on to force the KV savings)";
+                         "prefix reuse; set kv_cache.swa_snapshot_mb to combine, or "
+                         "kv_cache.swa_sizing=on to force the KV savings)";
         if (off_reason) {
             IMP_LOG_INFO("kv_cache.swa_sizing=%s ignored: %s",
                          runtime_config_.kv_cache.swa_sizing.c_str(), off_reason);
@@ -158,14 +160,16 @@ bool Engine::init_kv_cache() {
                                  ? runtime_config_.runtime.decode_burst
                                  : 512;
             swa_burst_cap_tokens_ = std::max(chunk_peak, burst_peak);
-            // Prefix caching cannot reuse freed window blocks. Auto mode
-            // yielded above, so only an explicit "on" reaches this point —
-            // honor the forced opt-in by disabling prefix caching
-            // (snapshot-based SWA reuse is a follow-up).
-            if (config_.use_prefix_caching) {
+            // Prefix caching cannot reuse freed window blocks on its own.
+            // With a SWA snapshot budget the two coexist (the store below
+            // restores the window at the reuse boundary); without one, only
+            // an explicit "on" reaches this point — honor the forced opt-in
+            // by disabling prefix caching.
+            if (config_.use_prefix_caching && runtime_config_.kv_cache.swa_snapshot_mb <= 0) {
                 config_.use_prefix_caching = false;
                 IMP_LOG_INFO("kv_cache.swa_sizing=on: prefix caching disabled (freed window "
-                             "blocks cannot back prefix reuse)");
+                             "blocks cannot back prefix reuse; set kv_cache.swa_snapshot_mb "
+                             "to combine)");
             }
             // StreamingLLM auto-enable frees middle blocks of the GLOBAL
             // table — redundant and conflicting here.
@@ -332,6 +336,41 @@ bool Engine::init_kv_cache() {
                     "server.recurrent_snapshot_mb=%d)",
                     budget_mb);
             }
+        }
+    }
+
+    // SWA window snapshots (kv_cache.swa_snapshot_mb): under SWA sizing,
+    // global-layer KV blocks alone cannot back a prefix-cache hit — the
+    // windowed layers' earlier blocks were trailing-freed, so the reused
+    // prefix would leave their window as holes. The store keeps the packed
+    // window at each prefill-end prefix hash and restores it at admission.
+    // Without a working store the coexistence the gate allowed is invalid —
+    // fall back to prefix caching off (mirrors the hybrid rule above).
+    if (swa_sizing_active_ && kv_manager_->prefix_caching_enabled()) {
+        const int budget_mb = runtime_config_.kv_cache.swa_snapshot_mb;
+        if (budget_mb > 0 && kv_manager_->enable_swa_snapshots()) {
+            const size_t slab_bytes = kv_manager_->swa_snapshot_bytes();
+            if (cudaMalloc(&swa_snap_slab_, slab_bytes) == cudaSuccess) {
+                swa_snapshots_ = std::make_unique<RecurrentSnapshotStore>();
+                swa_snapshots_->init(slab_bytes, static_cast<size_t>(budget_mb) << 20);
+                if (swa_snapshots_->enabled()) {
+                    scheduler_->set_prefix_reuse_limit(
+                        [this](Request& r) { return swa_prefix_reuse_limit_(r); });
+                    IMP_LOG_INFO("SWA snapshots: %d MiB budget, %zu KiB/snapshot, capacity %d",
+                                 budget_mb, slab_bytes >> 10, swa_snapshots_->capacity());
+                } else {
+                    swa_snapshots_.reset();
+                    IMP_CUDA_CHECK_LOG(cudaFree(swa_snap_slab_));
+                    swa_snap_slab_ = nullptr;
+                }
+            }
+        }
+        if (!swa_snapshots_) {
+            kv_manager_->set_prefix_caching_enabled(false);
+            config_.use_prefix_caching = false;
+            IMP_LOG_INFO("Prefix caching disabled under SWA sizing (snapshot store off — "
+                         "kv_cache.swa_snapshot_mb=%d)",
+                         budget_mb);
         }
     }
 

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -380,5 +380,73 @@ void Engine::maybe_save_recurrent_snapshot_(const Request& req, int snap_end, cu
     }
 }
 
+// ─── SWA window snapshots (prefix caching under SWA sizing) ─────────────
+//
+// Same admission/save pattern as the hybrid pair above, but the restorable
+// state is the packed windowed-layer KV (the trailing window at the reuse
+// boundary) instead of a recurrent slab. Hybrid models are excluded from
+// SWA sizing, so at most one of the two snapshot stores is live.
+
+int Engine::swa_prefix_reuse_limit_(Request& req) {
+    req.swa_restore.reset();
+    if (!swa_snapshots_ || !swa_snapshots_->enabled())
+        return 0;
+    // Restoring means starting prefill at offset > 0 — a chunked continuation.
+    if (!supports_chunked_prefill_())
+        return 0;
+    if (req.vision_emb || req.image || vision_.has_input())
+        return 0;
+    const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    const int total = static_cast<int>(req.input_tokens.size());
+    std::vector<size_t> hashes;
+    int cached = kv_manager_->longest_cached_prefix_blocks(req.input_tokens, hashes);
+    // At least one token must remain to forward (the model needs logits).
+    int max_b = std::min(cached, (total - 1) / bs);
+    for (int b = max_b; b >= 1; --b) {
+        auto entry = swa_snapshots_->find(hashes[b - 1]);
+        if (entry && entry->n_tokens == b * bs) {
+            req.swa_restore = std::move(entry);
+            return b;
+        }
+    }
+    return 0;
+}
+
+int Engine::snapshot_end_(const Request& req) const {
+    if (ssm_state_)
+        return hybrid_snapshot_end_(req);
+    if (!swa_snapshots_ || !swa_snapshots_->enabled())
+        return 0;
+    if (!supports_chunked_prefill_())
+        return 0;
+    if (req.vision_emb || req.image || vision_.has_input())
+        return 0;
+    const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    return (static_cast<int>(req.input_tokens.size()) / bs) * bs;
+}
+
+void Engine::maybe_save_swa_snapshot_(const Request& req, int snap_end, cudaStream_t stream) {
+    if (!swa_snapshots_ || !swa_snapshots_->enabled() || !swa_snap_slab_ || snap_end <= 0)
+        return;
+    const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    size_t key = 0;
+    for (int b = 0; b < snap_end / bs; ++b) {
+        key = KVCacheManager::compute_block_hash(
+            std::span<const int32_t>(req.input_tokens).subspan(static_cast<size_t>(b) * bs, bs), key);
+    }
+    if (swa_snapshots_->contains(key))
+        return;  // identical prefix already snapshotted (e.g. it was just restored)
+    if (!kv_manager_->swa_snapshot_pack(req.id, snap_end, swa_snap_slab_, stream))
+        return;  // window not fully resident (shouldn't happen mid-prefill)
+    if (swa_snapshots_->save(key, snap_end, swa_snap_slab_, stream)) {
+        // Same visibility rule as the recurrent save: the slab pack + store
+        // copy must complete before decode (possibly on another stream)
+        // mutates the window blocks. One sync per prefill.
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+        IMP_LOG_DEBUG("SwaSnapshot: saved %d-token window for req %d (%d/%d slots)", snap_end,
+                      req.id, swa_snapshots_->size(), swa_snapshots_->capacity());
+    }
+}
+
 
 }  // namespace imp

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -748,12 +748,12 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         is_last_chunk = false;
     }
 
-    // Recurrent-state snapshot boundary (hybrid prefix caching): end a chunk
+    // Snapshot boundary (hybrid recurrent state / SWA window): end a chunk
     // exactly at the largest block-aligned prompt position so the state there
     // can be captured — the snapshot is only restorable where reused KV
     // blocks cover the whole prefix, and only full blocks are cacheable. The
     // extra tail chunk is at most block_size-1 tokens.
-    const int snap_end = hybrid_snapshot_end_(*req);
+    const int snap_end = snapshot_end_(*req);
     if (snap_end > offset && snap_end < offset + chunk_len) {
         chunk_len = snap_end - offset;
         is_last_chunk = false;
@@ -771,6 +771,27 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     // the window its queries/continuation-gathers read back into. Trimming of
     // blocks that fell out of the window happens after the chunk commits.
     if (swa_sizing_active_) {
+        // SWA snapshot restore (prefix-cache hit): fill the window blocks at
+        // exactly the reused-prefix boundary BEFORE the continuation chunk's
+        // gathers read them. Without the restored window the reused global
+        // prefix is unusable (windowed layers would attend holes) — treat a
+        // failed restore like a swa_prepare failure below.
+        if (req->swa_restore && offset > 0 && offset == req->cached_tokens) {
+            const auto& entry = *req->swa_restore;
+            const bool ok = entry.data && entry.n_tokens == offset && swa_snapshots_ &&
+                            swa_snapshots_->entry_bytes() == kv_manager_->swa_snapshot_bytes() &&
+                            kv_manager_->swa_snapshot_restore(req->id, offset, entry.data,
+                                                              pf_stream);
+            req->swa_restore.reset();
+            if (!ok) {
+                IMP_LOG_WARN("SwaSnapshot: restore failed for req %d at %d tokens — cancelling",
+                             req->id, offset);
+                kv_manager_->free_sequence(req->id);
+                req->status = RequestStatus::CANCELLED;
+                return;
+            }
+            IMP_LOG_DEBUG("SwaSnapshot: restored %d-token window for req %d", offset, req->id);
+        }
         kv_manager_->swa_trim(req->id, offset);
         if (!kv_manager_->swa_prepare(req->id, offset, ctx_len)) {
             kv_manager_->free_sequence(req->id);
@@ -947,9 +968,11 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         IMP_LOG_DEBUG("Chunked prefill: req %d chunk [%d, %d) of %d", req->id, offset, offset + chunk_len,
                       total_input);
         // The chunk ended exactly at the snapshot boundary — capture the
-        // recurrent state now, before the next chunk advances it.
-        if (snap_end > 0 && req->prefill_offset == snap_end)
+        // recurrent state / SWA window now, before the next chunk advances it.
+        if (snap_end > 0 && req->prefill_offset == snap_end) {
             maybe_save_recurrent_snapshot_(*req, snap_end, pf_stream);
+            maybe_save_swa_snapshot_(*req, snap_end, pf_stream);
+        }
     } else if (req->embedding_request) {
         // Embedding request (#1005): last chunk — forward, pool, finish.
         // No sampling, no DECODING transition; the request rides the normal
@@ -1034,9 +1057,12 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
 
         // Block-aligned prompt: the snapshot boundary coincides with the last
         // chunk's end — capture after the forward (the sampling above only
-        // reads logits, never the recurrent state).
-        if (snap_end == total_input)
+        // reads logits, never the recurrent state; the SWA window blocks are
+        // not mutated until the first decode step).
+        if (snap_end == total_input) {
             maybe_save_recurrent_snapshot_(*req, snap_end, pf_stream);
+            maybe_save_swa_snapshot_(*req, snap_end, pf_stream);
+        }
 
         if (req->mirostat == 2)
             req->mirostat_mu = state.mirostat_mu;

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -130,6 +130,10 @@ struct Request {
     // matches a stored snapshot. Restored into the request's recurrent slot
     // on the first prefill chunk instead of zeroing (engine_sampling_stop).
     std::shared_ptr<const struct RecurrentSnapshotEntry> recurrent_restore;
+    // SWA window snapshot (kv_cache.swa_snapshot_mb): packed windowed-layer
+    // KV at exactly `cached_tokens`, restored into fresh SWA blocks on the
+    // first prefill chunk so a prefix-cache hit is valid under SWA sizing.
+    std::shared_ptr<const struct RecurrentSnapshotEntry> swa_restore;
     // Pin this request's full prompt blocks in the prefix cache at finish
     // (Anthropic cache_control / OpenAI-route cache_prompt). Pinned blocks
     // survive eviction until the pin budget recycles them (FIFO).

--- a/tests/perf_baseline_north_star.json
+++ b/tests/perf_baseline_north_star.json
@@ -20,7 +20,7 @@
       "pp32768": 8053.95,
       "pp65536": 5790.49
     },
-    "_ttft_note": "pp8192..pp65536 pinned 2026-07-16 (#1022 long-context TTFT gate), Qwen3-14B Q6_K single-chunk prefill (--prefill-chunk-size 0), 5 reps, verified-healthy host (mem 13801 MHz / ~570 W); cross-restart spread <0.5% at 32k (large-context prefill is compute/bandwidth-bound, not cuBLAS-algo-volatile like pp512). TTFT ms: 8k=717 / 16k=1632 / 32k=4069 / 64k=11318.",
+    "_ttft_note": "pp8192..pp65536 pinned 2026-07-16 (#1022 long-context TTFT gate), Qwen3-14B Q6_K single-chunk prefill (--prefill-chunk-size 0), 5 reps, verified-healthy host (mem 13801 MHz / ~570 W); cross-restart spread <0.5% at 32k (large-context prefill is compute/bandwidth-bound, not cuBLAS-algo-volatile like pp512). TTFT ms: 8k=717 / 16k=1632 / 32k=4069 / 64k=11318. The band ends at 64K by VRAM, not neglect: pp131072 needs 8192 KV blocks and this model's pool tops out ~4700 blocks on 32 GB (measured 2026-07-24, request rejected) — the 128K reference lives in docs/BENCHMARKS.md on Qwen3-14B-NVFP4 (3792 tok/s).",
     "decode_tps": {
       "tg128": 166.00,
       "tg128_at_ctx_2048": 149.54

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -52,6 +52,10 @@ TEST(RuntimeConfigTest, SwaSizingTriState) {
     // Unknown value falls back to Off (never silently forces sizing on).
     cfg.apply_overrides({"kv_cache.swa_sizing=banana"});
     EXPECT_EQ(cfg.kv_cache.swa_sizing_mode(), SwaSizingMode::Off);
+    // SWA snapshot budget: off by default, plain int binder.
+    EXPECT_EQ(RuntimeConfig{}.kv_cache.swa_snapshot_mb, 0);
+    cfg.apply_overrides({"kv_cache.swa_snapshot_mb=512"});
+    EXPECT_EQ(cfg.kv_cache.swa_snapshot_mb, 512);
 }
 
 // The long-context FP8-KV quality gate (kv_cache.dtype=auto): only arch families

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -1616,6 +1616,107 @@ TEST(KVCacheManagerTest, SwaRollback) {
     EXPECT_EQ(static_cast<int>(mgr.block_table(0).size()), 5);
 }
 
+// SWA window snapshots (kv_cache.swa_snapshot_mb): pack the live window of a
+// sequence into a slab, restore it into a fresh sequence with a reused
+// global prefix — the restored blocks must be byte-identical, private, and
+// placed at the same positional slots with holes before the window.
+TEST(KVCacheManagerTest, SwaSnapshotPackRestoreRoundtrip) {
+    SKIP_IF_NO_CUDA();
+
+    const int bs = 16;
+    const int n_layers = 2;
+    std::vector<int> nkv(n_layers, 4), hd(n_layers, 64);
+    std::vector<char> is_swa = {1, 0};
+    auto cache = std::make_unique<KVCache>(n_layers, nkv, hd, QType::F16, 256, bs, nullptr, is_swa,
+                                           /*swa_max*/ 16);
+    KVCache* raw = cache.get();
+    KVCacheManager mgr(std::move(cache));
+    mgr.enable_swa_sizing(/*window*/ 2 * bs, /*slack*/ bs);
+    ASSERT_TRUE(mgr.enable_swa_snapshots());
+    ASSERT_GT(mgr.swa_snapshot_bytes(), 0u);
+    // first live block at 160 tokens: (160 - 32 - 16) / 16 = 7.
+    EXPECT_EQ(mgr.swa_first_live_block(160), 7);
+
+    // Sequence 0: 10 global blocks (160 tokens), live window blocks 7..9.
+    ASSERT_TRUE(mgr.allocate_blocks(0, 10));
+    ASSERT_TRUE(mgr.swa_prepare(0, 160));
+    std::vector<int> swa0 = mgr.swa_block_table(0);
+    const size_t kvb = raw->block_bytes(0);
+    std::vector<char> pat(kvb);
+    for (int b = 7; b < 10; ++b) {
+        std::fill(pat.begin(), pat.end(), static_cast<char>(0x40 + b));
+        ASSERT_EQ(cudaMemcpy(raw->k_ptr(0, swa0[b]), pat.data(), kvb, cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        std::fill(pat.begin(), pat.end(), static_cast<char>(0x60 + b));
+        ASSERT_EQ(cudaMemcpy(raw->v_ptr(0, swa0[b]), pat.data(), kvb, cudaMemcpyHostToDevice),
+                  cudaSuccess);
+    }
+    void* slab = nullptr;
+    ASSERT_EQ(cudaMalloc(&slab, mgr.swa_snapshot_bytes()), cudaSuccess);
+    ASSERT_TRUE(mgr.swa_snapshot_pack(0, 160, slab, nullptr));
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+
+    // Fresh sequence 1 whose global prefix [0, 160) was reused: restore.
+    ASSERT_TRUE(mgr.allocate_blocks(1, 10));
+    ASSERT_TRUE(mgr.swa_snapshot_restore(1, 160, slab, nullptr));
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+    const auto& swa1 = mgr.swa_block_table(1);
+    ASSERT_EQ(static_cast<int>(swa1.size()), 10);
+    for (int b = 0; b < 7; ++b)
+        EXPECT_EQ(swa1[b], -1) << "pre-window block " << b << " must stay a hole";
+    std::vector<char> got(kvb);
+    for (int b = 7; b < 10; ++b) {
+        ASSERT_GE(swa1[b], 0);
+        EXPECT_NE(swa1[b], swa0[b]) << "restored block must be a private fresh allocation";
+        ASSERT_EQ(cudaMemcpy(got.data(), raw->k_ptr(0, swa1[b]), kvb, cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        EXPECT_EQ(got.front(), static_cast<char>(0x40 + b));
+        EXPECT_EQ(got.back(), static_cast<char>(0x40 + b));
+        ASSERT_EQ(cudaMemcpy(got.data(), raw->v_ptr(0, swa1[b]), kvb, cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        EXPECT_EQ(got.front(), static_cast<char>(0x60 + b));
+    }
+    // Continuation prepare extends the restored table without touching it.
+    ASSERT_TRUE(mgr.swa_prepare(1, 160, 176));
+    cudaFree(slab);
+    mgr.free_sequence(0);
+    mgr.free_sequence(1);
+    EXPECT_EQ(mgr.kv_cache()->num_free_swa_blocks(), 16);
+}
+
+// Restore on an exhausted SWA group fails cleanly: partial allocations are
+// released and the caller can fall back to a full prefill.
+TEST(KVCacheManagerTest, SwaSnapshotRestoreExhaustionRollsBack) {
+    SKIP_IF_NO_CUDA();
+
+    const int bs = 16;
+    std::vector<int> nkv(2, 4), hd(2, 64);
+    std::vector<char> is_swa = {1, 0};
+    // Group of 4: seq 0's window takes 3, leaving only 1 free.
+    auto cache = std::make_unique<KVCache>(2, nkv, hd, QType::F16, 256, bs, nullptr, is_swa,
+                                           /*swa_max*/ 4);
+    KVCacheManager mgr(std::move(cache));
+    mgr.enable_swa_sizing(2 * bs, bs);
+    ASSERT_TRUE(mgr.enable_swa_snapshots());
+
+    ASSERT_TRUE(mgr.allocate_blocks(0, 10));
+    ASSERT_TRUE(mgr.swa_prepare(0, 160));
+    void* slab = nullptr;
+    ASSERT_EQ(cudaMalloc(&slab, mgr.swa_snapshot_bytes()), cudaSuccess);
+    ASSERT_TRUE(mgr.swa_snapshot_pack(0, 160, slab, nullptr));
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+
+    const int free_before = mgr.kv_cache()->num_free_swa_blocks();
+    ASSERT_EQ(free_before, 1);
+    ASSERT_TRUE(mgr.allocate_blocks(1, 10));
+    EXPECT_FALSE(mgr.swa_snapshot_restore(1, 160, slab, nullptr));
+    EXPECT_EQ(mgr.kv_cache()->num_free_swa_blocks(), free_before)
+        << "failed restore must release its partial allocations";
+    cudaFree(slab);
+    mgr.free_sequence(0);
+    mgr.free_sequence(1);
+}
+
 // Regression for #963: StreamingLLM middle-block eviction must retain the
 // block containing the decode kernels' window start. The paged decode
 // kernels compute window_start_block = floor((ctx_len - window) /


### PR DESCRIPTION
Closes the last open item from the #1004 line of work: SWA-aware KV sizing and prefix caching now combine instead of excluding each other.

## What

- **`kv_cache.swa_snapshot_mb` (opt-in, default 0)**: a device LRU store (second instance of the hybrid `RecurrentSnapshotStore`) keeps the packed windowed-layer KV — the trailing window at each prefill-end prefix hash. On a prefix-cache hit the window is restored into fresh SWA blocks at admission, so the reused global prefix is valid for windowed layers too (their earlier blocks were trailing-freed). Reuse is capped at snapshot boundaries, one snapshot per prefill end — the same semantics hybrids already have.
- With a budget set, `swa_sizing=auto` no longer yields to prefix caching and `on` no longer force-disables it: serving gets the windowed-KV savings AND warm-prefix TTFT.
- Mechanics: `KVCache::batched_copy_device` (desc-driven, one launch, uint4 fast path), `KVCacheManager::swa_snapshot_pack/restore` (hole-preserving positional table rebuild, trim-cursor advance, clean rollback on SWA-group exhaustion), save hooks riding the existing hybrid snapshot boundary (`snapshot_end_`). Hybrid and SWA stores are mutually exclusive (hybrids are excluded from SWA sizing).
- **128K TTFT reference** (from the same follow-up list): `docs/BENCHMARKS.md` gains pp131072 on Qwen3-14B-NVFP4 = **3792 tok/s** (34.6 s, healthy clocks sampled during the run, commit-anchored). The north-star `_ttft_note` now documents why the CI gate band ends at 64K: the Q6_K model's KV pool tops out ~75K tokens on 32 GB (measured — pp131072 gets KV-rejected), so 64K is that model's VRAM ceiling, not a coverage gap.

## Validation (RTX 5090)

- Unit (GPU): pack→restore roundtrip byte-identical across layers/slots, restored blocks private, pre-window slots stay `-1` holes, trim cursor advanced; exhaustion path releases partial allocations (2 new tests in `test-core`).
- E2E (gemma-3-12b server, greedy + det-GEMM): 2-turn conversation with a 1763-token prompt — turn 2 reports `cached_tokens: 1760/1791` (snapshot found + window restored; without a snapshot the reuse limit returns 0), answer references both needle and full-context facts, and is **byte-identical** to a cold full-prefill of the same conversation. Sizing + prefix caching + snapshots active together in the logs.
- Full GPU suite green; verify-fast green (decode within gate; prefill WARNs are the documented restart-variance class).

No perf-baseline refresh: feature is opt-in and `--bench` pins `swa_sizing=off`.

Follow-up candidates (not in this PR): default budget for SWA models after a serving-workload sweep; snapshot-at-generation-end for tighter multi-turn reuse (same limitation as hybrids today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV