### PR TITLE
feat(kv): SWA snapshot at generation end — full-transcript warm reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,13 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   window of the sliding-window layers into a device LRU store (same pattern
   as the hybrid recurrent-state snapshots) and restores it at admission on
   a prefix-cache hit, so warm multi-turn reuse works with the windowed-KV
-  savings. Opt-in budget in MiB (0 = off: `swa_sizing=auto` keeps yielding
-  to prefix caching). Reuse is capped at snapshot boundaries (one per
-  prefill end).
+  savings. Snapshots are also saved at request finish over the same span
+  the finish path hash-registers, so the next agent turn reuses the whole
+  previous transcript (generated tokens included) — measured on a growing
+  6-turn transcript: cache-hit coverage identical to full-length-KV prefix
+  caching. Opt-in budget in MiB, default 0 (kept opt-in by measurement: the
+  pack/copy path costs ~50-90 ms warm TTFT per turn, which only pays for
+  itself at 16K+ contexts where the windowed-KV savings buy real reach).
 - **Qwen-Coder XML tool-call grammar**: `tool_choice=required`/forced and
   `strict:true` on templates teaching the `<function=NAME>`/`<parameter=KEY>`
   raw-text dialect (Qwen3-Coder, Qwen3.6) are now enforced by a dedicated

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -136,11 +136,17 @@ swa_sizing                  = auto
 # SWA window snapshots: device budget (MiB) for packed windowed-layer KV
 # snapshots, which make prefix caching valid UNDER swa_sizing — the snapshot
 # restores the trailing window at the reuse boundary, analogous to the
-# recurrent_snapshot_mb store for hybrids. One snapshot per prefill end, LRU
-# within the budget. With a budget set, swa_sizing=auto no longer yields to
-# prefix caching and the server gets both: the KV savings AND warm-prefix
-# reuse capped at snapshot boundaries. 0 = off (auto yields, on force-
-# disables prefix caching).
+# recurrent_snapshot_mb store for hybrids. Saved at each prefill end AND at
+# request finish (so the next agent turn reuses the whole previous
+# transcript, generated tokens included), LRU within the budget. With a
+# budget set, swa_sizing=auto no longer yields to prefix caching and the
+# server gets both: the KV savings AND warm-prefix reuse.
+# WHEN TO ENABLE (measured 2026-07-24, gemma-3-12b): cache-hit coverage is
+# identical to full-length-KV prefix caching, but each save/restore costs
+# ~50-90 ms warm TTFT per turn (window pack + store copy). Worth it for
+# LONG contexts (16K+), where windowed layers stop scaling with context and
+# VRAM headroom buys real reach; leave off for short-turn serving. 0 = off
+# (auto yields to prefix caching, on force-disables it).
 swa_snapshot_mb             = 0
 
 [rope]

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -936,6 +936,24 @@ bool KVCacheManager::swa_snapshot_copy_(int seq_id, int upto_tokens, void* slab,
     if (it == seq_swa_blocks_.end() || static_cast<int>(it->second.size()) < end_b)
         return false;
     const auto& swa = it->second;
+    // Generation-end saves pack at the block-FLOOR of the live context, so
+    // the lowest slack blocks may already be trimmed. Restore-time queries
+    // at positions >= upto never read below floor((upto - window)/bs); keep
+    // one extra boundary block (the #963 floor/ceil lesson) and zero-fill
+    // tolerated holes below that — a masked position contributes exactly 0
+    // regardless of KV bytes, and zeros can never produce NaN scores.
+    const int needed_start =
+        std::max(first, (upto_tokens - swa_window_) / bs - 1);
+    bool zero_filled = false;
+    if (to_slab) {
+        for (int b = first; b < needed_start; ++b) {
+            if (swa[b] < 0) {
+                IMP_CUDA_CHECK_LOG(cudaMemsetAsync(slab, 0, swa_snap_bytes_, stream));
+                zero_filled = true;
+                break;
+            }
+        }
+    }
     int n = 0;
     char* slab_c = static_cast<char*>(slab);
     for (size_t j = 0; j < swa_snap_layers_.size(); ++j) {
@@ -949,8 +967,11 @@ bool KVCacheManager::swa_snapshot_copy_(int seq_id, int upto_tokens, void* slab,
         char* vs_area = ks_area + static_cast<size_t>(swa_snap_win_blocks_) * scb;
         for (int i = 0; i < count; ++i) {
             const int id = swa[first + i];
-            if (id < 0)
-                return false;  // hole inside the live window — invariant broken
+            if (id < 0) {
+                if (to_slab && zero_filled && first + i < needed_start)
+                    continue;  // tolerated trimmed slack block — stays zero
+                return false;  // hole inside the read-relevant window
+            }
             auto put = [&](void* cache_ptr, char* area, size_t bytes) {
                 if (!bytes)
                     return;

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -525,6 +525,11 @@ void Engine::finish_request_release_(std::shared_ptr<Request>& req) {
             forwarded.insert(forwarded.end(), req->input_tokens.begin(), req->input_tokens.end());
             forwarded.insert(forwarded.end(), req->output_tokens.begin(), req->output_tokens.end() - 1);
             kv_manager_->register_block_hashes(req->id, forwarded);
+            // SWA window snapshot over the SAME span: without it the hashed
+            // generated blocks are unusable under SWA sizing (the next turn's
+            // reuse limit stops at the last snapshot boundary — the prefill
+            // end). Must run before free_sequence recycles the window blocks.
+            maybe_save_swa_snapshot_span_(req->id, forwarded, stream_);
         } else {
             kv_manager_->register_block_hashes(req->id, req->input_tokens);
         }

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -18,6 +18,7 @@
 #include "memory/kv_cache_manager.h"
 #include "memory/ssm_state.h"
 #include "memory/recurrent_snapshot_store.h"
+#include <span>
 #include "memory/layer_offload.h"
 #include "memory/vram_allocator.h"
 #include "exec/executor.h"
@@ -991,6 +992,8 @@ private:
     int swa_prefix_reuse_limit_(Request& req);
     int snapshot_end_(const Request& req) const;  // hybrid or SWA save position, 0 = none
     void maybe_save_swa_snapshot_(const Request& req, int snap_end, cudaStream_t stream);
+    void maybe_save_swa_snapshot_span_(int seq_id, std::span<const int32_t> tokens,
+                                       cudaStream_t stream);
     void finish_request(std::shared_ptr<Request>& req);
 
     // ── step() sub-phases ─────────────────────────────────────────────

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -426,25 +426,41 @@ int Engine::snapshot_end_(const Request& req) const {
 }
 
 void Engine::maybe_save_swa_snapshot_(const Request& req, int snap_end, cudaStream_t stream) {
-    if (!swa_snapshots_ || !swa_snapshots_->enabled() || !swa_snap_slab_ || snap_end <= 0)
+    (void)snap_end;  // recomputed from the span (block floor)
+    maybe_save_swa_snapshot_span_(req.id, std::span<const int32_t>(req.input_tokens), stream);
+}
+
+// Core save: snapshot the seq's live window at the block-floor of `tokens`.
+// Called at the prefill snapshot boundary (tokens = the prompt) and at
+// request finish (tokens = prompt + generated-minus-final, the same span
+// finish_request_release_ registers block hashes for) — the finish save is
+// what lets the NEXT agent turn reuse the whole previous transcript instead
+// of only up to the last prefill end.
+void Engine::maybe_save_swa_snapshot_span_(int seq_id, std::span<const int32_t> tokens,
+                                           cudaStream_t stream) {
+    if (!swa_snapshots_ || !swa_snapshots_->enabled() || !swa_snap_slab_)
         return;
     const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    const int snap_end = (static_cast<int>(tokens.size()) / bs) * bs;
+    if (snap_end <= 0)
+        return;
     size_t key = 0;
     for (int b = 0; b < snap_end / bs; ++b) {
-        key = KVCacheManager::compute_block_hash(
-            std::span<const int32_t>(req.input_tokens).subspan(static_cast<size_t>(b) * bs, bs), key);
+        key = KVCacheManager::compute_block_hash(tokens.subspan(static_cast<size_t>(b) * bs, bs),
+                                                 key);
     }
     if (swa_snapshots_->contains(key))
         return;  // identical prefix already snapshotted (e.g. it was just restored)
-    if (!kv_manager_->swa_snapshot_pack(req.id, snap_end, swa_snap_slab_, stream))
-        return;  // window not fully resident (shouldn't happen mid-prefill)
+    if (!kv_manager_->swa_snapshot_pack(seq_id, snap_end, swa_snap_slab_, stream))
+        return;  // read-relevant window not fully resident
     if (swa_snapshots_->save(key, snap_end, swa_snap_slab_, stream)) {
         // Same visibility rule as the recurrent save: the slab pack + store
         // copy must complete before decode (possibly on another stream)
-        // mutates the window blocks. One sync per prefill.
+        // mutates the window blocks — and at finish, before free_sequence
+        // recycles them. One sync per save.
         IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-        IMP_LOG_DEBUG("SwaSnapshot: saved %d-token window for req %d (%d/%d slots)", snap_end,
-                      req.id, swa_snapshots_->size(), swa_snapshots_->capacity());
+        IMP_LOG_DEBUG("SwaSnapshot: saved %d-token window for seq %d (%d/%d slots)", snap_end,
+                      seq_id, swa_snapshots_->size(), swa_snapshots_->capacity());
     }
 }
 

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -1684,6 +1684,68 @@ TEST(KVCacheManagerTest, SwaSnapshotPackRestoreRoundtrip) {
     EXPECT_EQ(mgr.kv_cache()->num_free_swa_blocks(), 16);
 }
 
+// Generation-end saves pack at the block-FLOOR of the live context; with a
+// non-block-aligned slack the lowest slack block can already be trimmed.
+// The pack must tolerate holes below the read-relevant boundary (zero-fill)
+// and the restore must reproduce the live blocks byte-identically.
+TEST(KVCacheManagerTest, SwaSnapshotFinishPackToleratesTrimmedSlack) {
+    SKIP_IF_NO_CUDA();
+
+    const int bs = 16;
+    std::vector<int> nkv(2, 4), hd(2, 64);
+    std::vector<char> is_swa = {1, 0};
+    auto cache = std::make_unique<KVCache>(2, nkv, hd, QType::F16, 256, bs, nullptr, is_swa,
+                                           /*swa_max*/ 16);
+    KVCache* raw = cache.get();
+    KVCacheManager mgr(std::move(cache));
+    mgr.enable_swa_sizing(/*window*/ 2 * bs, /*slack*/ 17);  // slack NOT block-aligned
+    ASSERT_TRUE(mgr.enable_swa_snapshots());
+
+    // Live context 170 tokens (11-block table): live span starts at block
+    // (170-49)/16 = 7. The finish save packs at floor(170/16)*16 = 160,
+    // where first_live(160) = (160-49)/16 = 6 — slot 6 is a trimmed hole
+    // below the read boundary (160-32)/16 - 1 = 7.
+    ASSERT_TRUE(mgr.allocate_blocks(0, 11));
+    ASSERT_TRUE(mgr.swa_prepare(0, 170));
+    std::vector<int> swa0 = mgr.swa_block_table(0);
+    EXPECT_EQ(swa0[6], -1) << "slot 6 must be a hole for this scenario";
+    const size_t kvb = raw->block_bytes(0);
+    std::vector<char> pat(kvb);
+    for (int b = 7; b < 10; ++b) {
+        ASSERT_GE(swa0[b], 0);
+        std::fill(pat.begin(), pat.end(), static_cast<char>(0x40 + b));
+        ASSERT_EQ(cudaMemcpy(raw->k_ptr(0, swa0[b]), pat.data(), kvb, cudaMemcpyHostToDevice),
+                  cudaSuccess);
+    }
+    void* slab = nullptr;
+    ASSERT_EQ(cudaMalloc(&slab, mgr.swa_snapshot_bytes()), cudaSuccess);
+    ASSERT_TRUE(mgr.swa_snapshot_pack(0, 160, slab, nullptr));
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+
+    ASSERT_TRUE(mgr.allocate_blocks(1, 10));
+    ASSERT_TRUE(mgr.swa_snapshot_restore(1, 160, slab, nullptr));
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+    const auto& swa1 = mgr.swa_block_table(1);
+    std::vector<char> got(kvb);
+    // Tolerated slot restores as zeros (never read: below the window of any
+    // continuation query at >= 160).
+    ASSERT_GE(swa1[6], 0);
+    ASSERT_EQ(cudaMemcpy(got.data(), raw->k_ptr(0, swa1[6]), kvb, cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(got.front(), 0);
+    EXPECT_EQ(got.back(), 0);
+    for (int b = 7; b < 10; ++b) {
+        ASSERT_GE(swa1[b], 0);
+        ASSERT_EQ(cudaMemcpy(got.data(), raw->k_ptr(0, swa1[b]), kvb, cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        EXPECT_EQ(got.front(), static_cast<char>(0x40 + b));
+        EXPECT_EQ(got.back(), static_cast<char>(0x40 + b));
+    }
+    cudaFree(slab);
+    mgr.free_sequence(0);
+    mgr.free_sequence(1);
+}
+
 // Restore on an exhausted SWA group fails cleanly: partial allocations are
 // released and the caller can fall back to a full prefill.
 TEST(KVCacheManagerTest, SwaSnapshotRestoreExhaustionRollsBack) {


### PR DESCRIPTION
Follow-up to #1062, closing its first follow-up candidate: SWA snapshots are now also saved at request finish, over the same prompt+generated span the finish path already hash-registers — so the NEXT agent turn reuses the whole previous transcript under SWA sizing, not just up to the last prefill-end boundary.

## What

- `maybe_save_swa_snapshot_span_` (shared core for the prefill-boundary and finish saves), called from `finish_request_release_` before `free_sequence` recycles the window blocks.
- Finish-time packs sit at the block-FLOOR of the live context; with a non-block-aligned slack the lowest slack block can already be trimmed. The pack now tolerates holes below the read-relevant boundary (`floor((P-window)/bs)-1`, keeping the #963 one-block margin) by zero-filling the slab — a masked position contributes exactly 0 regardless of KV bytes, and zeros cannot produce NaN scores. New GPU unit test pins the tolerated-hole pack + zero restore (constructible only with non-aligned slack, e.g. slack=17).
- Config guidance: a 6-turn growing-transcript sweep (gemma-3-12b, det-GEMM, spec off) measured **identical cache-hit coverage** vs full-length-KV prefix caching (the generation-end save is what closes the gap), ~50-90 ms warm TTFT per turn pack/copy cost, decode neutral. **Default stays 0 (opt-in)** — the cost only pays for itself at 16K+ contexts where the windowed-KV savings buy real reach; `imp.conf.example` documents the when-to-enable call. Shaving the save path (async, delta-pack) is the route to a default flip.

## Validation

- e2e (gemma-3-12b server): turn-2 `cached_tokens` **1920/1942** (full turn-1 transcript incl. 147 generated tokens) vs 1760 (prefill-end only) before this change; correct answers.
- 3 GPU unit tests green (`test-core --gtest_filter='*SwaSnapshot*'`); verify-fast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV