### PR TITLE
perf(kv): drop redundant prefill-boundary SWA snapshot sync + ms telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,12 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   previous transcript (generated tokens included) — measured on a growing
   6-turn transcript: cache-hit coverage identical to full-length-KV prefix
   caching. Opt-in budget in MiB, default 0 (kept opt-in by measurement: the
-  pack/copy path costs ~50-90 ms warm TTFT per turn, which only pays for
-  itself at 16K+ contexts where the windowed-KV savings buy real reach).
+  snapshot machinery is ~free — ~0.1 ms enqueue, and the prefill-boundary
+  save needs no stream sync at all (SWA blocks are sequence-private; the
+  first-token D2H orders every later writer behind the pack) — but the
+  sized attention route trades ~+50-100 ms warm TTFT per turn at 1-2K
+  contexts for faster prefill at long ones (+8% at 13K) plus the KV
+  savings; per-save/restore ms telemetry logs at INFO).
 - **Qwen-Coder XML tool-call grammar**: `tool_choice=required`/forced and
   `strict:true` on templates teaching the `<function=NAME>`/`<parameter=KEY>`
   raw-text dialect (Qwen3-Coder, Qwen3.6) are now enforced by a dedicated

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -142,11 +142,14 @@ swa_sizing                  = auto
 # budget set, swa_sizing=auto no longer yields to prefix caching and the
 # server gets both: the KV savings AND warm-prefix reuse.
 # WHEN TO ENABLE (measured 2026-07-24, gemma-3-12b): cache-hit coverage is
-# identical to full-length-KV prefix caching, but each save/restore costs
-# ~50-90 ms warm TTFT per turn (window pack + store copy). Worth it for
-# LONG contexts (16K+), where windowed layers stop scaling with context and
-# VRAM headroom buys real reach; leave off for short-turn serving. 0 = off
-# (auto yields to prefix caching, on force-disables it).
+# identical to full-length-KV prefix caching, and the snapshot machinery
+# itself is ~free (~0.1 ms enqueue per save/restore, <=1 ms finish sync).
+# The tradeoff is the sized attention route: ~+50-100 ms warm TTFT per turn
+# at SHORT contexts (1-2K), but FASTER prefill at long ones (+8% at 13K,
+# growing with context as windowed layers stop scaling) plus the KV VRAM
+# savings. Enable for long-context workloads (~8K+); leave off for
+# short-turn serving. 0 = off (auto yields to prefix caching, on
+# force-disables it).
 swa_snapshot_mb             = 0
 
 [rope]

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -528,8 +528,10 @@ void Engine::finish_request_release_(std::shared_ptr<Request>& req) {
             // SWA window snapshot over the SAME span: without it the hashed
             // generated blocks are unusable under SWA sizing (the next turn's
             // reuse limit stops at the last snapshot boundary — the prefill
-            // end). Must run before free_sequence recycles the window blocks.
-            maybe_save_swa_snapshot_span_(req->id, forwarded, stream_);
+            // end). Must run before free_sequence recycles the window blocks;
+            // hard_sync because those blocks are re-allocatable the moment
+            // free_sequence returns (writers on other streams).
+            maybe_save_swa_snapshot_span_(req->id, forwarded, stream_, /*hard_sync=*/true);
         } else {
             kv_manager_->register_block_hashes(req->id, req->input_tokens);
         }

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -993,7 +993,7 @@ private:
     int snapshot_end_(const Request& req) const;  // hybrid or SWA save position, 0 = none
     void maybe_save_swa_snapshot_(const Request& req, int snap_end, cudaStream_t stream);
     void maybe_save_swa_snapshot_span_(int seq_id, std::span<const int32_t> tokens,
-                                       cudaStream_t stream);
+                                       cudaStream_t stream, bool hard_sync);
     void finish_request(std::shared_ptr<Request>& req);
 
     // ── step() sub-phases ─────────────────────────────────────────────

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -427,7 +427,8 @@ int Engine::snapshot_end_(const Request& req) const {
 
 void Engine::maybe_save_swa_snapshot_(const Request& req, int snap_end, cudaStream_t stream) {
     (void)snap_end;  // recomputed from the span (block floor)
-    maybe_save_swa_snapshot_span_(req.id, std::span<const int32_t>(req.input_tokens), stream);
+    maybe_save_swa_snapshot_span_(req.id, std::span<const int32_t>(req.input_tokens), stream,
+                                  /*hard_sync=*/false);
 }
 
 // Core save: snapshot the seq's live window at the block-floor of `tokens`.
@@ -437,7 +438,7 @@ void Engine::maybe_save_swa_snapshot_(const Request& req, int snap_end, cudaStre
 // what lets the NEXT agent turn reuse the whole previous transcript instead
 // of only up to the last prefill end.
 void Engine::maybe_save_swa_snapshot_span_(int seq_id, std::span<const int32_t> tokens,
-                                           cudaStream_t stream) {
+                                           cudaStream_t stream, bool hard_sync) {
     if (!swa_snapshots_ || !swa_snapshots_->enabled() || !swa_snap_slab_)
         return;
     const int bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
@@ -451,16 +452,37 @@ void Engine::maybe_save_swa_snapshot_span_(int seq_id, std::span<const int32_t> 
     }
     if (swa_snapshots_->contains(key))
         return;  // identical prefix already snapshotted (e.g. it was just restored)
+    const auto t0 = std::chrono::steady_clock::now();
     if (!kv_manager_->swa_snapshot_pack(seq_id, snap_end, swa_snap_slab_, stream))
         return;  // read-relevant window not fully resident
     if (swa_snapshots_->save(key, snap_end, swa_snap_slab_, stream)) {
-        // Same visibility rule as the recurrent save: the slab pack + store
-        // copy must complete before decode (possibly on another stream)
-        // mutates the window blocks — and at finish, before free_sequence
-        // recycles them. One sync per save.
-        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
-        IMP_LOG_DEBUG("SwaSnapshot: saved %d-token window for seq %d (%d/%d slots)", snap_end,
-                      seq_id, swa_snapshots_->size(), swa_snapshots_->capacity());
+        const auto t1 = std::chrono::steady_clock::now();
+        // Sync policy (measured 2026-07-24: the prefill-boundary sync waited
+        // ~50 ms on in-flight prefill compute and was the entire warm-TTFT
+        // cost of the feature; enqueue is ~0.1 ms):
+        //  - prefill-boundary save (hard_sync=false): NO sync needed. SWA
+        //    blocks are private to this sequence; the only later writers are
+        //    this request's own later chunks (same stream, ordered) and its
+        //    decode steps — which start only after the host read the first
+        //    sampled token via a D2H on this same stream, enqueued after the
+        //    pack. Stream order + host causality make the pack complete
+        //    before any writer can touch the window. Store-buffer recycling
+        //    is stream-ordered too (all snapshot copies ride pf_stream).
+        //  - finish save (hard_sync=true): free_sequence recycles the window
+        //    blocks immediately after we return; a third request already in
+        //    decode can grab and write them on ANOTHER stream with no
+        //    ordering against the pack. Sync — measured ~1 ms (idle stream).
+        if (hard_sync)
+            IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));
+        const auto t2 = std::chrono::steady_clock::now();
+        // Permanent telemetry (ms/verify precedent): one line per save —
+        // rare (<= 2 per request) and the only way to attribute warm-TTFT
+        // cost between the enqueue half and the sync half.
+        IMP_LOG_INFO("SwaSnapshot: saved %d-token window for seq %d (%d/%d slots, "
+                     "enqueue %.2f ms + sync %.2f ms)",
+                     snap_end, seq_id, swa_snapshots_->size(), swa_snapshots_->capacity(),
+                     std::chrono::duration<double, std::milli>(t1 - t0).count(),
+                     std::chrono::duration<double, std::milli>(t2 - t1).count());
     }
 }
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -777,6 +777,7 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         // prefix is unusable (windowed layers would attend holes) — treat a
         // failed restore like a swa_prepare failure below.
         if (req->swa_restore && offset > 0 && offset == req->cached_tokens) {
+            const auto rt0 = std::chrono::steady_clock::now();
             const auto& entry = *req->swa_restore;
             const bool ok = entry.data && entry.n_tokens == offset && swa_snapshots_ &&
                             swa_snapshots_->entry_bytes() == kv_manager_->swa_snapshot_bytes() &&
@@ -790,7 +791,11 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
                 req->status = RequestStatus::CANCELLED;
                 return;
             }
-            IMP_LOG_DEBUG("SwaSnapshot: restored %d-token window for req %d", offset, req->id);
+            IMP_LOG_INFO("SwaSnapshot: restored %d-token window for req %d (enqueue %.2f ms)",
+                         offset, req->id,
+                         std::chrono::duration<double, std::milli>(
+                             std::chrono::steady_clock::now() - rt0)
+                             .count());
         }
         kv_manager_->swa_trim(req->id, offset);
         if (!kv_manager_->swa_prepare(req->id, offset, ctx_len)) {


### PR DESCRIPTION
Follow-up to #1063 (the 'shave the save path' route toward a default flip), with a measurement-driven correction of the guidance.

## What

- **Prefill-boundary save: no stream sync.** The measured ~50 ms sync was waiting on in-flight prefill compute — and it is provably redundant: SWA blocks are sequence-private, later prefill chunks are same-stream-ordered, and decode for the request starts only after the host observed the first sampled token via a D2H enqueued after the pack. Stream order + host causality guarantee the pack completes before any writer can touch the window. The **finish save keeps its sync** (~1 ms on an idle stream): `free_sequence` recycles the blocks immediately, and a third request already decoding can grab and write them on an unordered stream.
- **Permanent per-save/restore ms telemetry at INFO** (`ms/verify` precedent, ≤2 lines/request): `enqueue X ms + sync Y ms`. This is what falsified the earlier attribution.
- **Corrected when-to-enable guidance** (imp.conf.example/CHANGELOG): the snapshot machinery is ~free (~0.1 ms enqueue, ≤1 ms finish sync). The real tradeoff is the sized attention route: ~+50-100 ms warm TTFT/turn at 1-2K contexts, but **+8.4% faster cold prefill at 13.4K** (1760 vs 1909 ms, gemma-3-12b interleaved-config A/B) — the sign flips in the few-K range, so the guidance now says ~8K+, not 16K+.

## Measurements (gemma-3-12b, det-GEMM)

| | before | after |
|---|---|---|
| prefill-boundary save sync | 47.8-50.6 ms | **0.00 ms** (removed) |
| finish save sync | ~1 ms | ~1 ms (kept, justified) |
| save/restore enqueue | ~0.1 ms | ~0.1 ms |
| cold pp13403 sizing on vs off | — | 1760 vs 1909 ms (**+8.4%**) |

Cache-hit coverage and outputs unchanged (3 SwaSnapshot unit tests + sweep re-run green; verify-fast green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV