### PR TITLE
fix(spec): auto-disable recycle_loop on GGUF-source models (#1060 matrix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   transcripts run 50-150K tokens; VRAM and the model's declared context
   still bound the auto pick, so this only extends models that declare (and
   can hold) more than 64K.
+- **`speculative.recycle_loop` auto-disables on GGUF-source models** (with a
+  log line): the bucket-4 verify chunk forward rides the dequant prefill
+  path there, so every verify pays source dequant — measured −9.5%
+  (Qwen3-8B-Q8) and −28.8% (Qwen3-14B-Q6K) vs spec-off, while the ST-NVFP4
+  route wins +38–97%. See issue #1060 for the flip-matrix data.
 
 ### Added
 - **SWA window snapshots (`kv_cache.swa_snapshot_mb`)**: prefix caching and

--- a/src/runtime/engine_tr_loop.cpp
+++ b/src/runtime/engine_tr_loop.cpp
@@ -47,6 +47,17 @@ bool Engine::try_launch_tr_verify_loop_(std::shared_ptr<Request>& req, cudaStrea
     if (tr_loop_doomed_ || !scfg.recycle_loop || !scfg.token_recycling ||
         !config_.use_cuda_graphs || !scfg.capture || mtp_spec_decode_enabled())
         return false;
+    // Native-ST-NVFP4 only: on GGUF-source models the bucket-4 verify chunk
+    // forward rides the dequant prefill path — every verify pays source
+    // dequant, and the loop regresses instead of winning (measured
+    // 2026-07-24: -9.5% Qwen3-8B-Q8, -28.8% Qwen3-14B-Q6K vs spec-off; the
+    // +38-97% wins are on the ST-NVFP4 small-M verify route, #1055).
+    if (!model_->config().is_nvfp4_prequant) {
+        tr_loop_doomed_ = true;
+        IMP_LOG_INFO("recycle_loop: disabled — GGUF-source model pays source dequant per "
+                     "verify chunk (see issue #1060, measured -9.5%%/-28.8%%)");
+        return false;
+    }
     if (tr_loop_runner_.launch_in_flight())
         return false;
     // v1 gates: greedy, no penalties / logit shaping / constraints / budget


### PR DESCRIPTION
First tranche of the #1060 flip matrix produced a decisive negative: on GGUF-source dense models the verify-in-loop REGRESSES — measured −9.5% (Qwen3-8B-Q8) and −28.8% (Qwen3-14B-Q6K) vs spec-off (interleaved same-host A/Bs, det-GEMM, greedy, 1024-token reasoning generation), while the ST-NVFP4 route wins +38–97%. Root cause: the bucket-4 verify chunk forward rides the dequant prefill path on GGUF sources, paying source dequant per verify; the loop economics only work on the native-ST-NVFP4 small-M verify route (#1055).

This PR gates `try_launch_tr_verify_loop_` on `is_nvfp4_prequant` with a one-time INFO log, so the experimental flag can no longer regress GGUF runs. Verified: guard fires on Qwen3-8B-Q8 (log line, no loop builds), loop still engages on Qwen3-14B-NVFP4. Byte-identity vs spec-off held on the GGUF path pre-gating. Full data in the #1060 comment; remaining matrix items (degen soak, server penalty story, healthy-host gate) stay open there.

verify-fast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV