### PR TITLE
feat(spec): recycle_loop server story — opt-in default penalties + think-budget burst cap (#1060)

### DIFF
--- a/src/runtime/engine_tr_loop.cpp
+++ b/src/runtime/engine_tr_loop.cpp
@@ -23,9 +23,11 @@
 #include "runtime/engine.h"
 #include "runtime/request.h"
 #include "compute/rowwise_topm.h"
+#include "runtime/think_stop_logic.h"
 
 #include <cuda_runtime.h>
 #include <chrono>
+#include <climits>
 #include <thread>
 #include <vector>
 
@@ -60,15 +62,37 @@ bool Engine::try_launch_tr_verify_loop_(std::shared_ptr<Request>& req, cudaStrea
     }
     if (tr_loop_runner_.launch_in_flight())
         return false;
-    // v1 gates: greedy, no penalties / logit shaping / constraints / budget
-    // forcing — the in-loop argmax is penalty-free by construction.
+    // v1 gates: greedy, no penalties / logit shaping / constraints — the
+    // in-loop argmax is penalty-free by construction.
     const bool greedy = req->temperature <= 0.0f || req->top_k == 1;
     if (!greedy || req->repetition_penalty != 1.0f || req->frequency_penalty != 0.0f ||
         req->presence_penalty != 0.0f || req->dry_multiplier != 0.0f || req->mirostat != 0 ||
         !req->logit_bias.empty() || req->logprobs || req->json_mode ||
-        !req->json_schema.empty() || !req->tool_constraint_tools.empty() || req->constraints ||
-        req->think_budget > 0.0f)
+        !req->json_schema.empty() || !req->tool_constraint_tools.empty() || req->constraints)
         return false;
+    // Think budget (design: "no think-budget-IN-think"): forcing injects a
+    // host-side think-end exactly at the budget boundary, which the
+    // autonomous loop cannot do. Instead of gating the whole request, cap
+    // the burst so the loop exits AT the boundary — the host recount then
+    // forces on the drained tokens. Out of think (or budget spent →
+    // decline), forcing cannot fire and the loop runs uncapped. The server
+    // default think_budget=0.5 previously kept the loop off for every
+    // server request (#1060 server story).
+    int think_cap = INT_MAX;
+    if (req->think_budget > 0.0f && think_end_id_ >= 0) {
+        bool thinking = false;
+        const int n_reason = think_logic::count_reasoning_tokens(
+            req->output_tokens, think_start_id_, think_end_id_, req->started_in_think, thinking);
+        if (thinking) {
+            const int frac_limit = static_cast<int>(req->max_tokens * req->think_budget);
+            const int reserve_limit =
+                static_cast<int>(req->max_tokens) - think_logic::kMaxAnswerReserve;
+            const int think_limit = frac_limit > reserve_limit ? frac_limit : reserve_limit;
+            think_cap = think_limit - n_reason;
+            if (think_cap <= 0)
+                return false;  // forcing is due now — the host path handles it
+        }
+    }
     // Dense decode-attn route only (the per-row block tables are the
     // mask-free multi-row mechanism the chunk forward relies on).
     if (!scfg.verify_decode_attn || ssm_state_ != nullptr || model_->profile().is_moe ||
@@ -93,6 +117,8 @@ bool Engine::try_launch_tr_verify_loop_(std::shared_ptr<Request>& req, cudaStrea
     int token_limit = remaining;
     if (scfg.burst > 0 && token_limit > scfg.burst)
         token_limit = scfg.burst;
+    if (token_limit > think_cap)
+        token_limit = think_cap;
     if (token_limit < 8)
         return false;  // not worth a launch
 

--- a/tools/imp-server/handlers_chat.cpp
+++ b/tools/imp-server/handlers_chat.cpp
@@ -119,7 +119,13 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
     bool echo = body.value("echo", false);
     float min_p = body.value("min_p", 0.0f);
     float typical_p = body.value("typical_p", 1.0f);
-    float repetition_penalty = body.value("repetition_penalty", 1.05f);
+    // Default follows the recycle_loop opt-in rule (see
+    // parse_chat_request_params — operator opt-in beats the implicit 1.05).
+    float repetition_penalty = body.value(
+        "repetition_penalty", (state.runtime_config.speculative.recycle_loop &&
+                               state.runtime_config.speculative.token_recycling)
+                                  ? 1.0f
+                                  : 1.05f);
     float frequency_penalty = body.value("frequency_penalty", 0.0f);
     float presence_penalty = body.value("presence_penalty", 0.0f);
     int repeat_last_n = body.value("repeat_last_n", 0);

--- a/tools/imp-server/handlers_chat_params.cpp
+++ b/tools/imp-server/handlers_chat_params.cpp
@@ -120,7 +120,17 @@ bool parse_chat_request_params(const httplib::Request& req, httplib::Response& r
 
     ctx.params.min_p = body.value("min_p", 0.0f);
     ctx.params.typical_p = body.value("typical_p", 1.0f);
-    ctx.params.repetition_penalty = body.value("repetition_penalty", 1.05f);
+    // recycle_loop opt-in (#1060 server penalty story): the mild 1.05
+    // anti-repetition default would gate the verify loop off for every
+    // request that never asked for penalties — the operator's explicit
+    // speculative.recycle_loop opt-in wins over the implicit default.
+    // Explicit repetition_penalty values (and the harmony-channel override
+    // below, gpt-oss is MoE-excluded from the loop anyway) still apply.
+    const float default_rep_pen = (state.runtime_config.speculative.recycle_loop &&
+                                   state.runtime_config.speculative.token_recycling)
+                                      ? 1.0f
+                                      : 1.05f;
+    ctx.params.repetition_penalty = body.value("repetition_penalty", default_rep_pen);
     ctx.params.frequency_penalty = body.value("frequency_penalty", 0.0f);
     ctx.params.presence_penalty = body.value("presence_penalty", 0.0f);
     ctx.params.repeat_last_n = body.value("repeat_last_n", 0);


### PR DESCRIPTION
Resolves the 'server penalty support' + 'degen battery/soak' items of the #1060 flip matrix.

## What

Two implicit server defaults kept the verify loop off for every server request — `repetition_penalty=1.05` and `think_budget=0.5`:

1. **Server**: when the operator opted into `speculative.recycle_loop` (+`token_recycling`), requests without an explicit `repetition_penalty` default to **1.0** instead of 1.05. Explicit values and the gpt-oss harmony-channel override still win (MoE is loop-excluded anyway). Rationale: the operator's explicit experimental opt-in beats a mild implicit default whose purpose (breaking pathological repetition) the soak below re-validates for this configuration.
2. **Engine**: the blanket `think_budget > 0` gate becomes the design-intended **'no think-budget-IN-think'** rule (design doc, PR #1057): while thinking with a budget armed, the launch caps the burst to `think_limit − n_reasoning` (same formula as `should_force_think_end`) so the loop exits AT the budget boundary and the host recount forces the think-end on drained tokens; once out of think, forcing cannot fire and the loop runs uncapped. Budget already spent → decline (host path forces immediately).

## Validation (Qwen3-14B-NVFP4 server, loop opt-in)

- Loop now engages on plain default requests (TrVerifyLoop builds in logs; previously zero).
- **degen_suite**: 41 checks; the only loop-attributable delta vs a no-loop control server is the `stream == nonstream` temp=0 equality check — a greedy near-tie resolving differently between the loop's batched-verify FP route and the eager route (engagement-dependent, #957 cross-path class; a direct repro shows the stream drain detokenizes correctly and all routes agree on an unambiguous prompt). Pre-existing on BOTH arms: `json_object` emits malformed JSON on this model — separate issue.
- **Soak**: 2000-token greedy long-run — no repetition (max word run 1, distinct-tail 0.71); 3-turn conversation grammatical/topical; stderr clean of CUDA/NaN/fallback markers.

For the flip matrix this leaves: healthy-host gate re-validation, and the stream-vs-nonstream near-tie consistency question documented above (acceptable for an opt-in experimental flag; a conditional default should weigh it).

verify-fast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV