### PR TITLE
fix(constrain): json_object FSM lost object context after nested container close (#1067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   jump-ahead work as on the JSON dialect.
 
 ### Fixed
+- **Schema-less `json_object` FSM emitted structurally invalid JSON** (#1067):
+  every container close popped its own stack continuation but then resumed
+  in the *grandparent's* context, and number/literal ends popped without a
+  matching push — after a nested array closed inside an object the FSM
+  believed it was in an array, accepting `,"bare-string"` + `]]` (and
+  rejecting valid nested documents like `{"a":{"b":1},"c":2}`). Openers now
+  push their continuation and every close pops-and-uses it; covered by
+  `JsonConstrainFsmTest` and the degen_suite constrained category on
+  Qwen3-14B-NVFP4. json_schema mode (separate FSM) was never affected.
 - **Tool-call enforcement now derives from the post-load template**: the
   constraint was collected before `ensure_model_loaded`, so auto-load-on-
   first-request and cross-model requests baked a grammar from the previous

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -193,12 +193,18 @@ bool JsonConstrainer::advance_char(char c) {
     ws_run_ = 0;
 
     switch (current_state_) {
+        // Stack discipline: every opener pushes its CONTINUATION — the state
+        // the parser resumes in after the construct closes — and every close
+        // pops and *uses* it (empty stack -> DONE). The old code popped the
+        // continuation but then peeked the grandparent's entry instead, so a
+        // nested array closing inside an object left the FSM in array
+        // context, accepting `,"bare-string"` + `]]` (#1067).
         case JsonState::START:
+            // Root construct: continuation after it closes is DONE, which the
+            // empty-stack fallback in the close handlers provides — no push.
             if (c == '{') {
-                state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::OBJECT_START;
             } else if (c == '[') {
-                state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::ARRAY_START;
             } else {
                 return false;
@@ -210,9 +216,9 @@ bool JsonConstrainer::advance_char(char c) {
                 current_state_ = JsonState::IN_STRING;
                 state_stack_.push_back(JsonState::AFTER_KEY);
             } else if (c == '}') {
+                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
-                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
             } else {
                 return false;
             }
@@ -227,11 +233,13 @@ bool JsonConstrainer::advance_char(char c) {
             break;
 
         case JsonState::AFTER_COLON:
+            // Every value form pushes AFTER_VALUE — scalars too: their end
+            // handlers pop the continuation, so a missing push here made
+            // them steal the enclosing container's entry.
             if (c == '"') {
                 state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::IN_STRING;
             } else if (c == '{') {
-                // Push the AFTER_VALUE to restore after nested object
                 state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::OBJECT_START;
             } else if (c == '[') {
@@ -240,16 +248,20 @@ bool JsonConstrainer::advance_char(char c) {
             } else if (c == 't') {
                 target_literal_ = "true";
                 partial_literal_ = "t";
+                state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::IN_LITERAL;
             } else if (c == 'f') {
                 target_literal_ = "false";
                 partial_literal_ = "f";
+                state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::IN_LITERAL;
             } else if (c == 'n') {
                 target_literal_ = "null";
                 partial_literal_ = "n";
+                state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::IN_LITERAL;
             } else if ((c >= '0' && c <= '9') || c == '-') {
+                state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::IN_NUMBER;
             } else {
                 return false;
@@ -261,9 +273,9 @@ bool JsonConstrainer::advance_char(char c) {
                 // Next key in object
                 current_state_ = JsonState::OBJECT_START;
             } else if (c == '}') {
+                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
-                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
             } else {
                 return false;
             }
@@ -271,9 +283,9 @@ bool JsonConstrainer::advance_char(char c) {
 
         case JsonState::ARRAY_START:
             if (c == ']') {
+                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
-                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
             } else if (c == '"') {
                 state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::IN_STRING;
@@ -286,16 +298,20 @@ bool JsonConstrainer::advance_char(char c) {
             } else if (c == 't') {
                 target_literal_ = "true";
                 partial_literal_ = "t";
+                state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::IN_LITERAL;
             } else if (c == 'f') {
                 target_literal_ = "false";
                 partial_literal_ = "f";
+                state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::IN_LITERAL;
             } else if (c == 'n') {
                 target_literal_ = "null";
                 partial_literal_ = "n";
+                state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::IN_LITERAL;
             } else if ((c >= '0' && c <= '9') || c == '-') {
+                state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::IN_NUMBER;
             } else {
                 return false;
@@ -306,9 +322,9 @@ bool JsonConstrainer::advance_char(char c) {
             if (c == ',') {
                 current_state_ = JsonState::ARRAY_START;
             } else if (c == ']') {
+                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
                 if (!state_stack_.empty())
                     state_stack_.pop_back();
-                current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
             } else {
                 return false;
             }

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -78,6 +78,17 @@ public:
     // Get max tokens to finish (force-close open structures near limit)
     int closing_tokens_needed() const { return static_cast<int>(state_stack_.size()); }
 
+    // Strict-simulate `text` from the current state without mutating it —
+    // true iff every char is a legal grammar continuation. Public for the
+    // FSM unit tests; apply_mask uses it for whole-token validation.
+    bool sim_token_valid(const std::string& text);
+
+    // Advance the FSM over raw text (tests use this to reach mid-document
+    // states; the decode path goes through update()).
+    void advance_text(const std::string& text) {
+        for (char c : text) advance_char(c);
+    }
+
     // Allow the model to emit a free-form preamble before strict JSON
     // enforcement starts. close_token>=0 enables close-token mode (reasoning
     // models with </think>); close_token<0 + max_tokens>0 enables budget-only
@@ -136,10 +147,6 @@ private:
 
     // Compute allowed category mask from current FSM state
     uint16_t compute_allowed_mask() const;
-
-    // Whole-token strict validation: snapshot the FSM, advance over the
-    // token text, restore. True iff every char is a legal continuation.
-    bool sim_token_valid(const std::string& text);
 
     // Advance FSM by one character
     bool advance_char(char c);

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -95,6 +95,54 @@ TEST(JsonConstrainTest, ClassifyNumbers) {
 }
 
 // ===========================================================================
+// FSM grammar tests (#1067) — a container close must restore the continuation
+// pushed at its matching opener. The old code popped it and *peeked the
+// grandparent's* continuation instead, so after `[..., {"k": [..]` the `]`
+// left the FSM in array context and it accepted `,"bare-string"` + `]]`.
+// ===========================================================================
+TEST(JsonConstrainFsmTest, Issue1067NestedArrayCloseKeepsObjectContext) {
+    JsonConstrainer c;
+    // Exact shape from the degen_suite repro: object inside array, whose last
+    // value is an array — then a dangling key and ']]' closing the '{'.
+    EXPECT_FALSE(c.sim_token_valid(
+        "[\"_classifications\",{\"sentiment\":\"positive\","
+        "\"topics\":[\"phone\",\"camera\"],\"score\"  ]]"));
+}
+
+TEST(JsonConstrainFsmTest, ValidNestedDocumentsAccepted) {
+    JsonConstrainer c;
+    EXPECT_TRUE(c.sim_token_valid("[\"a\",{\"k\":\"v\",\"t\":[\"x\",\"y\"],\"n\":1}]"));
+    EXPECT_TRUE(c.sim_token_valid("{\"a\":{\"b\":1},\"c\":2}"));
+    EXPECT_TRUE(c.sim_token_valid("{\"a\":[true,false,null],\"b\":{\"c\":[1,2.5e3]}}"));
+    EXPECT_TRUE(c.sim_token_valid("[[1,2],[3,4]]"));
+    EXPECT_TRUE(c.sim_token_valid("[{\"a\":1},{\"b\":2}]"));
+}
+
+TEST(JsonConstrainFsmTest, MismatchedClosersRejected) {
+    JsonConstrainer c;
+    EXPECT_FALSE(c.sim_token_valid("{\"a\":1]"));
+    EXPECT_FALSE(c.sim_token_valid("[1}"));
+    EXPECT_FALSE(c.sim_token_valid("[[1,2]]]"));
+    EXPECT_FALSE(c.sim_token_valid("{\"a\":{\"b\":1}}}"));
+}
+
+TEST(JsonConstrainFsmTest, TrailingContentAfterRootRejected) {
+    JsonConstrainer c;
+    EXPECT_FALSE(c.sim_token_valid("{\"a\":1}{"));
+    EXPECT_FALSE(c.sim_token_valid("[1] 2"));
+}
+
+TEST(JsonConstrainFsmTest, MidDocumentStateAfterNestedArrayClose) {
+    JsonConstrainer c;
+    c.advance_text("{\"t\":[1,2]");
+    // Back in the object after the nested array closed: ']' is illegal, a
+    // comma must be followed by a key (not a bare value).
+    EXPECT_FALSE(c.sim_token_valid("]"));
+    EXPECT_TRUE(c.sim_token_valid(",\"k\":3}"));
+    EXPECT_FALSE(c.sim_token_valid(",5"));
+}
+
+// ===========================================================================
 // Test 9: GPU mask kernel — constrain_mask_kernel masks invalid tokens
 // ===========================================================================
 TEST(JsonConstrainTest, MaskAllowsValidTokens) {


### PR DESCRIPTION
Fixes #1067.

## Root cause

Every container close in `JsonConstrainer::advance_char` popped its own continuation off the state stack but then resumed in the state **peeked from the new stack top** — the grandparent's continuation. Number/literal ends additionally popped without ever having pushed. Once an object nested inside an array closed one of its own nested containers, the FSM resumed in array context, so it accepted a comma + bare string + `]]` closing the `{` — exactly the degen_suite repro:

```
["_classifications",{"sentiment":"positive","topics":["phone","camera","upgrade"],"sentiment_confidence_score"  ]]
```

The same depth mistracking also **rejected valid** nested documents (`{"a":{"b":1},"c":2}`: the scalar end stole the enclosing container's continuation → premature DONE → the trailing `,"c":2}` was masked off). It only surfaced on 14B-NVFP4 because the bug needs a container close whose parent continuation differs from the grandparent's (object-in-array shapes); flat outputs never hit it. json_schema mode (separate `sim_advance` FSM) was never affected — matches the issue's observation that json_schema checks pass.

## Fix

Consistent continuation-stack discipline: every opener (containers **and** scalar values) pushes the state to resume after it closes; every close pops and uses exactly that entry (empty stack → DONE). Root constructs push nothing and rely on the empty-stack fallback.

## Validation

- New `JsonConstrainFsmTest` battery (host-only, runs in CI `Build`): #1067 repro shape rejected, valid nested docs accepted, mismatched closers/trailing content rejected, mid-document continuation checks. Red before the fix (repro accepted AND valid nested docs rejected), green after. `sim_token_valid`/`advance_text` made public as the test surface.
- `test-moe-gdn` constrain suites green (JsonConstrain 16, SchemaConstrain/ToolCall 30).
- E2E on Qwen3-14B-NVFP4: degen_suite `constrained` category green (json_object check was the failing one), full 41-check battery 0 FAIL, and a forced nested json_object request in the issue's shape returns valid JSON.

## Perf note

Not a hot-path change — the FSM only runs under an active json constraint. The local decode gate read low tonight (274.96 vs band floor 275, healthy clocks 2895 MHz SM / 13801 mem / 489 W sampled during bench — depressed-host evening state, see #526): interleaved A/B fix-vs-main on the gate metric measured flat (fix 256.29–257.36 vs main 256.20–256.31 tok/s, Q8 tg128, warmup discarded). Baseline untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zsb5GjgrBGqEAYVHmyieV