### PR TITLE
fix(spec): per-request economics guard for the verify-in-loop (#1060)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 ## [Unreleased]
 
 ### Changed
+- **`speculative.recycle_loop` now gives up per request when it is not paying
+  for itself** (#1060 follow-up). A cold adjacency table exits the verify loop
+  after ~1 token, pays the graph-launch + KV-rollback + miss-burst detour and
+  relaunches; that cycle — not the loop body — is what cost −6…−9% on generic
+  prompts and refuted the default flip. After a 4-miss-exit sample, an average
+  below `speculative.recycle_loop_min_emit` (default 4.0, 0 disables the guard)
+  hands the request back to the async graph loop, mirroring the eager-TR
+  `acceptance_poor` and `mtp_econ_min_emit` guards that already existed.
+  Measured on Qwen3-14B-NVFP4 (1024-tok greedy, 3 trials, interleaved, healthy
+  host: 2835-2880 MHz SM / 13801 MHz mem / ~510 W): the loss against loop-off
+  shrinks from −7.8% / −6.2% / −13.0% to −0.3% / −2.7% / −3.0% on
+  planning / math / repetitive prompts. **The flag stays default-OFF**: no
+  prompt class measured *faster* with the loop than without it, so this is
+  damage control for opt-in users, not a flip enabler. The residual cost is
+  the one-time loop-graph instantiation, which is paid before the guard can
+  judge. Note that switching paths mid-generation can flip greedy near-ties
+  (the #957 FP-summation-order class), so output stays coherent but is not
+  guaranteed bit-identical to a run that never entered the loop — the same
+  property the existing n-gram give-up already has.
 - **SWA-aware KV sizing is now tri-state `auto|on|off` (default `auto`)**:
   auto takes the sliding-window KV savings (gpt-oss ~2×, gemma-3/4 ~5-6× KV
   tokens; measured −14% peak VRAM on gpt-oss-20b at 131K context) only when

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -516,6 +516,13 @@ recycle_min_streak   = 1
 # decode-attn-route models, greedy, no penalties; anything else falls
 # back to the eager paths.
 recycle_loop         = false
+# Verify-in-loop economics guard (#1060): after a 4-miss-exit sample, fewer
+# than this many tokens emitted per miss-exit burst on average dooms the
+# loop for the request. A cold adjacency table exits the loop after ~1
+# token and pays the launch + rollback + miss-burst detour on every
+# relaunch — that cycle, not the loop itself, is what cost -6..-9% on
+# generic prompts. 0 disables the guard (raw-economics measurement).
+recycle_loop_min_emit = 4.0
 # Suffix-indexed drafting (SuffixDecoding-style): hash-indexed suffix
 # matching instead of a per-step backward scan, continuations picked by
 # frequency vote across all occurrences, and adaptive draft length — a

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -304,6 +304,7 @@ void apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("speculative.recycle_width", cfg.speculative.recycle_width);
     I("speculative.recycle_min_streak", cfg.speculative.recycle_min_streak);
     B("speculative.recycle_loop", cfg.speculative.recycle_loop);
+    F("speculative.recycle_loop_min_emit", cfg.speculative.recycle_loop_min_emit);
     B("speculative.suffix", cfg.speculative.suffix);
     I("speculative.suffix_k_max", cfg.speculative.suffix_k_max);
     I("speculative.min_match", cfg.speculative.min_match);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -849,6 +849,15 @@ struct RuntimeConfig {
         // dense decode-attn-route models, greedy, no penalties (v1).
         // Falls back to the eager path on any capture failure.
         bool recycle_loop = false;
+        // Verify-in-loop economics guard (#1060): after a 4-miss-exit sample,
+        // an average of fewer than this many tokens emitted per miss-exit
+        // burst dooms the loop FOR THE REQUEST — the launch + rollback +
+        // miss-burst detour of a relaunch cycle cannot amortize below it.
+        // This is what separates the two measured arms: reasoning prose runs
+        // long bursts (+38-97%), generic prose exits after ~1 token and paid
+        // that detour for the whole generation (-6..-9%, the #1060 flip
+        // refutation). 0 disables the guard (raw-economics measurement).
+        float recycle_loop_min_emit = 4.0f;
         // SuffixDecoding-style indexed drafting (arXiv 2411.04975):
         // hash-indexed suffix matching (O(1) amortized vs the legacy O(n)
         // backward scan per verify step) with frequency-voted continuations

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -799,6 +799,7 @@ private:
     bool tr_loop_doomed_ = false;           // capture failed once — never retry
     int tr_loop_backoff_req_ = -1;          // miss-exit backoff (see engine_tr_loop.cpp)
     size_t tr_loop_backoff_out_ = 0;
+    size_t tr_loop_launch_out_ = 0;  // output size at burst launch (economics)
     // Device/pinned staging for the verify chunk (lazy-init, K+1 capacity).
     // #1055: tokens/positions/row-ctx-lens + the 3 length scalars live in ONE
     // device block (d_spec_stage_) with a pinned host twin — one H2D per

--- a/src/runtime/engine_tr_loop.cpp
+++ b/src/runtime/engine_tr_loop.cpp
@@ -62,6 +62,8 @@ bool Engine::try_launch_tr_verify_loop_(std::shared_ptr<Request>& req, cudaStrea
     }
     if (tr_loop_runner_.launch_in_flight())
         return false;
+    if (req->tr_loop_given_up)
+        return false;  // economics verdict is final for this request
     // v1 gates: greedy, no penalties / logit shaping / constraints — the
     // in-loop argmax is penalty-free by construction.
     const bool greedy = req->temperature <= 0.0f || req->top_k == 1;
@@ -266,6 +268,7 @@ bool Engine::try_launch_tr_verify_loop_(std::shared_ptr<Request>& req, cudaStrea
     }
     tr_loop_req_ = req;
     tr_loop_initial_p0_ = p0;
+    tr_loop_launch_out_ = req->output_tokens.size();
     IMP_LOG_DEBUG("TrVerifyLoop: launched (p0=%d limit=%d)", p0, token_limit);
     return true;
 }
@@ -324,6 +327,28 @@ bool Engine::step_tr_loop_resume_(cudaStream_t stream) {
         // token is not yet forwarded), exactly the eager-path invariant.
         kv_manager_->rollback(req->id, req->context_len() - 1);
         kv_manager_->touch(req->id);
+        // Economics: only miss exits enter the relaunch cycle (stop/budget/
+        // ceiling either end the request or are one-offs), so only they are
+        // fair evidence. Below the break-even average the loop is handed back
+        // to the async graph loop for the rest of the request.
+        if (exit_reason == 1) {
+            const int emitted = static_cast<int>(req->output_tokens.size()) -
+                                static_cast<int>(tr_loop_launch_out_);
+            req->tr_loop_miss_bursts++;
+            req->tr_loop_miss_emitted += std::max(0, emitted);
+            constexpr int kTrEconSample = 4;  // fair sample before judging
+            const float min_emit = runtime_config_.speculative.recycle_loop_min_emit;
+            if (min_emit > 0.0f && req->tr_loop_miss_bursts >= kTrEconSample &&
+                static_cast<float>(req->tr_loop_miss_emitted) <
+                    static_cast<float>(req->tr_loop_miss_bursts) * min_emit) {
+                req->tr_loop_given_up = true;
+                IMP_LOG_INFO(
+                    "recycle_loop: req %d gave up (uneconomic: %d tokens over %d "
+                    "miss-exit bursts, below %.1f/burst) — async graph loop from here on",
+                    req->id, req->tr_loop_miss_emitted, req->tr_loop_miss_bursts,
+                    static_cast<double>(min_emit));
+            }
+        }
         if (exit_reason == 1 && req->status == RequestStatus::DECODING) {
             // Draft miss on a (still) cold table — produce miss_burst tokens
             // via the async decode loop before the next launch, and hand it

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -78,6 +78,14 @@ struct Request {
     // Verify-in-loop: prompt+output pairs already seeded into the DEVICE
     // adjacency table (once per request, at first loop launch).
     bool tr_dev_prompt_fed = false;
+    // Verify-in-loop economics (#1060): miss-exit bursts and the tokens they
+    // emitted. A cold/draft-poor context exits the loop after ~1 token, pays
+    // the graph-launch + rollback + miss-burst detour, and relaunches — the
+    // cycle that made the default-ON arm lose on generic prose. Sticky
+    // give-up once the average falls below speculative.recycle_loop_min_emit.
+    int tr_loop_miss_bursts = 0;
+    int tr_loop_miss_emitted = 0;
+    bool tr_loop_given_up = false;
     // Per-request n-gram speculation override (tri-state): -1 = use the global
     // speculative.ngram default, 0 = force OFF, 1 = force ON. Lets a code-gen
     // request opt into speculation while a short tool-arg generation skips it


### PR DESCRIPTION
## What

`speculative.recycle_loop` now gives up **per request** when the loop is not paying for itself, via the new `speculative.recycle_loop_min_emit` (default 4.0, 0 disables the guard).

## Why

A cold adjacency table exits the verify loop after ~1 token, pays the graph-launch + KV-rollback + miss-burst detour, and relaunches. That cycle — not the loop body — is what cost −6…−9% on generic prompts and refuted the default flip in #1060.

The other two drafters already guard against their own version of this:

- eager token-recycling / n-gram: `acceptance_poor` (≥8 verifies, <15% accepted)
- MTP: `mtp_econ_min_emit` (8-verify sample, avg emitted/verify)

The loop had no such guard — only a permanent `tr_loop_doomed_` for setup failures and GGUF sources. This closes that gap. #1060 named exactly this as a re-open condition ("acceptance-doomed loop (mirror eager TR doom)").

## Measured

Qwen3-14B-NVFP4, 1024-tok greedy, 3 trials, interleaved, healthy host (2835–2880 MHz SM / 13801 MHz mem / ~510 W). Loss vs loop-off:

| prompt class | before | after |
|---|---|---|
| planning | −7.8% | **−0.3%** |
| math | −6.2% | **−2.7%** |
| repetitive | −13.0% | **−3.0%** |

The before-column reproduces the 2026-07-25 flip measurement (−9% planning / −6% math) on a fresh host day, which validates the harness.

## The flag stays default-OFF

No prompt class measured *faster* with the loop than without it, so this is damage control for opt-in users, **not** a flip enabler. An isolating arm (eager TR without the loop) shows the residual cost is the one-time loop-graph instantiation, which is paid before the guard can judge — a pre-launch readiness check on the adjacency table, not a post-hoc verdict, is what a flip would need.

## Correctness note

Switching paths mid-generation can flip greedy near-ties (the #957 FP-summation-order class): output stays coherent but is not guaranteed bit-identical to a run that never entered the loop — the same property the existing n-gram give-up has. Verified over the server JSON route with one fresh process per (arm, prompt); the divergences are equivalent alternative phrasings, with no degeneration. Worth recording: the loop is **not** universally lossless even without this change — an ungated-loop arm also diverged from loop-off on one prompt, so the "byte-identical" result in the #1055 notes holds for those prompts, not in general.

`make verify-fast` green (decode −1.86%, within the 3% gate; prefill warnings are the known cuBLAS restart variance). No baseline refresh: the default path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa