### PR TITLE
test(constrain): generative property batteries for both FSMs, in the CPU lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+- **Generative property batteries for both constrained-decode FSMs**, running in
+  the CPU `unit` lane. The constrained-decode surface has shipped seven grammar
+  bugs (#517, #650, #761, #850, #1002, #1014, #1067), every one found by a
+  symptom and none by a test, while GOAL.md release bar 7 makes "valid,
+  terminating JSON under any sampler state" a release blocker. The existing
+  batteries are example-based *and* live in the GPU lane, so CI — which has no
+  GPU runner — never guarded this class on a pull request.
+  `test_json_constrain_property.cpp` generates random JSON and checks the
+  schema-less FSM against **nlohmann/json as an independent oracle**;
+  `test_schema_constrain_property.cpp` co-generates a schema plus a conforming
+  document (nlohmann does not validate schemas, so conformance is known by
+  construction) and checks both directions. Shared invariants: accept every
+  valid/conforming document, accept every prefix of one, never enter a dead-end
+  state with no legal continuation (release bar 7 as an invariant), and reject
+  structurally impossible continuations — swapped closers, trailing content
+  after the root, objects missing required properties, arrays below `minItems`,
+  values outside an `enum`.
+  Both batteries were validated by mutation, not just by passing: against the
+  pre-#1068 FSM three json_object properties fail (reproducing the #1067
+  signature `[{"k0":true]]`), and with the `minItems` check disabled exactly
+  `RejectsArrayBelowMinItems` fails.
+  `SchemaConstrainer` gains `init_grammar_for_test()` (installs the grammar
+  without the tokenizer classification and device buffers that only `apply_mask`
+  needs) and `token_legal()` becomes public — the same test-hook treatment
+  #1068 gave `JsonConstrainer::sim_token_valid`.
+
 ### Changed
 - **`speculative.recycle_loop` now gives up per request when it is not paying
   for itself** (#1060 follow-up). A cold adjacency table exits the verify loop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,11 @@ if(IMP_BUILD_TESTS)
         tests/test_safetensors_loader.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
+        # Generative FSM battery for the schema-less json_object grammar. Lives
+        # in the CPU lane on purpose: the FSM is CUDA-free without init(), and
+        # every past grammar bug escaped CI because its tests need a GPU.
+        tests/test_json_constrain_property.cpp
+        tests/test_schema_constrain_property.cpp
         tests/test_weight_snapshot.cpp
         tests/test_rope_override.cpp
         tests/test_ngram_draft.cpp

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -90,6 +90,17 @@ SchemaConstrainer::~SchemaConstrainer() {
         IMP_CUDA_CHECK_LOG(cudaFree(d_allowed_mask_));
 }
 
+bool SchemaConstrainer::init_grammar_for_test(std::unique_ptr<SchemaNode> schema) {
+    schema_ = std::move(schema);
+    if (!schema_)
+        return false;
+    // No tokenizer classification and no device buffers: token_legal() walks
+    // the frame stack only, which is all the CPU grammar battery needs.
+    reset();
+    initialized_ = true;
+    return true;
+}
+
 bool SchemaConstrainer::init(const Tokenizer& tok, std::unique_ptr<SchemaNode> schema) {
     schema_ = std::move(schema);
     if (!schema_)

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -106,6 +106,14 @@ public:
     // Initialize with tokenizer (classifies all tokens) and schema.
     bool init(const Tokenizer& tok, std::unique_ptr<SchemaNode> schema);
 
+    // Grammar-only init for the CPU FSM tests: installs the schema and the
+    // frame stack, skipping the tokenizer classification and the device
+    // buffers that only apply_mask needs. Lets the generative battery run in
+    // the `unit` lane — the grammar bugs this surface has shipped (#761, #850,
+    // #1014) all escaped CI, which has no GPU runner. Not for engine use:
+    // apply_mask/update by token id require the full init above.
+    bool init_grammar_for_test(std::unique_ptr<SchemaNode> schema);
+
     // Apply logit mask before sampling.
     void apply_mask(float* d_logits, int vocab_size, cudaStream_t stream);
 
@@ -123,6 +131,14 @@ public:
     // fires. The caller drafts the canonical tokenization of this text and
     // verifies by sampling (see the constrained-pipeline jump-ahead).
     int forced_text(std::string& out, int max_chars) const;
+
+    // True iff emitting the whole token keeps the schema satisfiable: every
+    // char is a legal transition and nothing trails past the root close. This
+    // catches multi-char tokens that span phase transitions (`{}`, `":"`,
+    // `"Why`, integer `0.98`) which the first-char category mask misses.
+    // Public for the FSM unit tests; apply_mask uses it for whole-token
+    // validation.
+    bool token_legal(const std::string& text) const;
 
     // Reset for a new generation with the same schema.
     void reset();
@@ -238,12 +254,6 @@ private:
     // (on stack_) and per-token mask simulation (on a cloned stack), so there
     // is one source of truth for the schema grammar.
     bool sim_advance(std::vector<SchemaFrame>& stk, char c) const;
-
-    // True iff emitting the whole token keeps the schema satisfiable: every
-    // char is a legal transition and nothing trails past the root close. This
-    // catches multi-char tokens that span phase transitions (`{}`, `":"`,
-    // `"Why`, integer `0.98`) which the first-char category mask misses.
-    bool token_legal(const std::string& text) const;
 
     // Find property schema by key name
     const SchemaNode* find_property(const SchemaNode* obj, const std::string& key) const;

--- a/tests/test_json_constrain_property.cpp
+++ b/tests/test_json_constrain_property.cpp
@@ -1,0 +1,238 @@
+// ===========================================================================
+// Property tests for the schema-less json_object FSM (JsonConstrainer).
+//
+// The example-based batteries next door encode bugs we already shipped
+// (#517, #650, #761, #850, #1014, #1067 — every one found by a symptom, none
+// by a test). These tests attack the same surface generatively instead: a
+// random document generator plus nlohmann/json as an INDEPENDENT oracle, so a
+// grammar regression fails here without anyone having to imagine the shape
+// first. GOAL.md release bar 7 ("valid, terminating JSON under any sampler
+// state") is the contract under test.
+//
+// CPU-only by construction: the default-constructed JsonConstrainer touches no
+// CUDA (its device pointers stay null without init(), so the destructor frees
+// nothing), which puts these in the `unit` lane — the lane CI actually runs.
+// That matters: the FSM lives in a .cu, so every bug above escaped CI, which
+// has no GPU runner.
+//
+// Determinism: one fixed seed, and every failure message prints the exact
+// document so a failure is reproducible without re-rolling the dice.
+// ===========================================================================
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "compute/json_constrain.h"
+
+#include <random>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+constexpr uint32_t kSeed = 0x5EED1067;  // fixed: failures must reproduce
+
+// --- Random valid-JSON generator -------------------------------------------
+// ASCII only and escape-free on purpose: non-ASCII in constrained strings is a
+// known, deliberate limitation of the token classifier, not a grammar bug, and
+// mixing it in here would produce false failures rather than findings.
+
+std::string gen_string(std::mt19937& rng) {
+    static const char kAlphabet[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ0123456789_ -";
+    std::uniform_int_distribution<int> len(0, 8);
+    std::uniform_int_distribution<size_t> ch(0, sizeof(kAlphabet) - 2);
+    std::string s = "\"";
+    int n = len(rng);
+    for (int i = 0; i < n; i++)
+        s += kAlphabet[ch(rng)];
+    return s + "\"";
+}
+
+std::string gen_number(std::mt19937& rng) {
+    static const char* kNumbers[] = {"0", "1", "-1", "42", "-0.5", "2.5", "1e3", "1.5e-2", "1234567890"};
+    std::uniform_int_distribution<size_t> pick(0, sizeof(kNumbers) / sizeof(kNumbers[0]) - 1);
+    return kNumbers[pick(rng)];
+}
+
+std::string gen_value(std::mt19937& rng, int depth);
+
+std::string gen_object(std::mt19937& rng, int depth) {
+    std::uniform_int_distribution<int> count(0, 3);
+    int n = count(rng);
+    std::string s = "{";
+    for (int i = 0; i < n; i++) {
+        if (i)
+            s += ",";
+        // Keys must be unique — a duplicate key is legal JSON for nlohmann but
+        // the FSM tracks emitted keys, so it would be an unfair comparison.
+        s += "\"k" + std::to_string(i) + "\":" + gen_value(rng, depth + 1);
+    }
+    return s + "}";
+}
+
+std::string gen_array(std::mt19937& rng, int depth) {
+    std::uniform_int_distribution<int> count(0, 3);
+    int n = count(rng);
+    std::string s = "[";
+    for (int i = 0; i < n; i++) {
+        if (i)
+            s += ",";
+        s += gen_value(rng, depth + 1);
+    }
+    return s + "]";
+}
+
+std::string gen_value(std::mt19937& rng, int depth) {
+    // Past depth 3 only scalars, so documents stay bounded.
+    std::uniform_int_distribution<int> pick(0, depth < 3 ? 6 : 4);
+    switch (pick(rng)) {
+        case 0:
+            return gen_string(rng);
+        case 1:
+            return gen_number(rng);
+        case 2:
+            return "true";
+        case 3:
+            return "false";
+        case 4:
+            return "null";
+        case 5:
+            return gen_object(rng, depth);
+        default:
+            return gen_array(rng, depth);
+    }
+}
+
+// Root of a JSON document is an object or an array.
+std::string gen_document(std::mt19937& rng) {
+    std::uniform_int_distribution<int> pick(0, 1);
+    return pick(rng) ? gen_object(rng, 0) : gen_array(rng, 0);
+}
+
+// ===========================================================================
+// P1 — Soundness: every document the oracle calls valid must be accepted.
+// This is the direction #1067 broke (valid nested docs were REJECTED:
+// `{"a":{"b":1},"c":2}` hit a premature DONE).
+// ===========================================================================
+TEST(JsonConstrainPropertyTest, AcceptsEveryValidDocument) {
+    std::mt19937 rng(kSeed);
+    for (int i = 0; i < 2000; i++) {
+        const std::string doc = gen_document(rng);
+        ASSERT_TRUE(nlohmann::json::accept(doc)) << "generator produced invalid JSON: " << doc;
+        JsonConstrainer c;
+        EXPECT_TRUE(c.sim_token_valid(doc)) << "FSM rejected valid document: " << doc;
+    }
+}
+
+// ===========================================================================
+// P2 — Prefix closure: the FSM is a prefix machine. Every prefix of a valid
+// document must stay legal, because that is exactly the state the model is in
+// mid-generation. A rejected prefix means a dead end the sampler cannot escape.
+// ===========================================================================
+TEST(JsonConstrainPropertyTest, AcceptsEveryPrefixOfValidDocument) {
+    std::mt19937 rng(kSeed + 1);
+    for (int i = 0; i < 500; i++) {
+        const std::string doc = gen_document(rng);
+        for (size_t cut = 1; cut < doc.size(); cut++) {
+            const std::string prefix = doc.substr(0, cut);
+            JsonConstrainer c;
+            EXPECT_TRUE(c.sim_token_valid(prefix))
+                << "FSM rejected prefix [" << prefix << "] of valid document " << doc;
+        }
+    }
+}
+
+// ===========================================================================
+// P3 — No dead ends: from any prefix of a valid document at least one ASCII
+// continuation must be legal. This is release-bar 7 ("terminating JSON under
+// any sampler state") stated as an invariant: a state with an all-masked
+// vocabulary would leave the sampler with nothing to emit.
+// ===========================================================================
+TEST(JsonConstrainPropertyTest, NoDeadEndStates) {
+    std::mt19937 rng(kSeed + 2);
+    for (int i = 0; i < 300; i++) {
+        const std::string doc = gen_document(rng);
+        for (size_t cut = 1; cut < doc.size(); cut++) {
+            const std::string prefix = doc.substr(0, cut);
+            bool any_legal = false;
+            for (int ch = 0x20; ch < 0x7F && !any_legal; ch++) {
+                JsonConstrainer c;
+                c.advance_text(prefix);
+                if (c.sim_token_valid(std::string(1, static_cast<char>(ch))))
+                    any_legal = true;
+            }
+            EXPECT_TRUE(any_legal) << "dead end: no legal continuation after [" << prefix << "] (document "
+                                   << doc << ")";
+        }
+    }
+}
+
+// ===========================================================================
+// P4 — Rejection: mutations that cannot be a prefix of ANY valid document must
+// be rejected. Two families that are structurally guaranteed to be illegal:
+//   (a) swapped closer  — '}' <-> ']' at the final position
+//   (b) trailing content after the root value closes
+// (a) is the shape #1067 accepted (`,"bare-string"` then `]]` while the FSM
+// believed it was in array context).
+// ===========================================================================
+TEST(JsonConstrainPropertyTest, RejectsSwappedFinalCloser) {
+    std::mt19937 rng(kSeed + 3);
+    int checked = 0;
+    for (int i = 0; i < 1000; i++) {
+        std::string doc = gen_document(rng);
+        const char last = doc.back();
+        doc.back() = (last == '}') ? ']' : '}';
+        ASSERT_FALSE(nlohmann::json::accept(doc)) << "oracle thinks swapped closer is valid: " << doc;
+        JsonConstrainer c;
+        EXPECT_FALSE(c.sim_token_valid(doc)) << "FSM accepted mismatched closer: " << doc;
+        checked++;
+    }
+    EXPECT_GT(checked, 0);
+}
+
+TEST(JsonConstrainPropertyTest, RejectsTrailingContentAfterRoot) {
+    static const char* kTrailers[] = {"{", "[", "\"", "1", "}", "]", ",", ":", "x"};
+    std::mt19937 rng(kSeed + 4);
+    for (int i = 0; i < 1000; i++) {
+        const std::string doc = gen_document(rng);
+        for (const char* t : kTrailers) {
+            const std::string mutated = doc + t;
+            ASSERT_FALSE(nlohmann::json::accept(mutated)) << "oracle accepts trailing: " << mutated;
+            JsonConstrainer c;
+            EXPECT_FALSE(c.sim_token_valid(mutated)) << "FSM accepted trailing content: " << mutated;
+        }
+    }
+}
+
+// ===========================================================================
+// P5 — Structural truncation: cutting a document short and closing it with the
+// WRONG bracket must be rejected. Catches context confusion one level up, the
+// exact failure mode of #1067 (close popped its own frame but resumed in the
+// grandparent's state).
+// ===========================================================================
+TEST(JsonConstrainPropertyTest, RejectsWrongCloserAtNestedDepth) {
+    std::mt19937 rng(kSeed + 5);
+    int exercised = 0;
+    for (int i = 0; i < 1500; i++) {
+        const std::string doc = gen_document(rng);
+        for (size_t cut = 1; cut < doc.size(); cut++) {
+            // Only prefixes whose next real char is a closer are interesting:
+            // append the OTHER closer and it must be refused.
+            const char next = doc[cut];
+            if (next != '}' && next != ']')
+                continue;
+            const std::string prefix = doc.substr(0, cut);
+            const std::string wrong = prefix + (next == '}' ? ']' : '}');
+            JsonConstrainer c;
+            if (c.sim_token_valid(wrong)) {
+                ADD_FAILURE() << "FSM accepted wrong closer: [" << wrong << "] (document " << doc << ")";
+            }
+            exercised++;
+        }
+    }
+    EXPECT_GT(exercised, 0) << "generator produced no nested closers — test is vacuous";
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_schema_constrain_property.cpp
+++ b/tests/test_schema_constrain_property.cpp
@@ -1,0 +1,226 @@
+// ===========================================================================
+// Property tests for the json_schema FSM (SchemaConstrainer).
+//
+// Companion to test_json_constrain_property.cpp, which covers the schema-less
+// json_object grammar. This file attacks the schema-driven side, where #761
+// (runaway digit run), #850 (backslash in keys) and #1014 (minItems/maxItems
+// unenforced) shipped — each found by a symptom, none by a test.
+//
+// No external oracle: nlohmann validates JSON syntax but not JSON Schema, so
+// the generator emits a schema and a CONFORMING document together. Conformance
+// is known by construction, which makes both directions testable — accept the
+// conforming document, reject the constructed violations.
+//
+// CPU-only: init_grammar_for_test() installs the grammar without the tokenizer
+// classification and device buffers that only apply_mask needs, so this runs in
+// the `unit` lane. That is the point — CI has no GPU runner, so the GPU-lane
+// batteries next door never guarded these bugs on a pull request.
+// ===========================================================================
+
+#include <gtest/gtest.h>
+
+#include "compute/json_schema.h"
+#include "compute/schema_constrain.h"
+
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+constexpr uint32_t kSeed = 0x5C4E3A01;
+
+struct Generated {
+    std::string schema;  // JSON Schema text
+    std::string doc;     // a document that conforms to it, by construction
+};
+
+// Every generated object makes ALL properties required and emits them in
+// schema order: the tightest, least ambiguous shape, so a rejection is a real
+// finding rather than the FSM exercising a legitimate freedom.
+Generated gen_node(std::mt19937& rng, int depth) {
+    std::uniform_int_distribution<int> pick(0, depth < 2 ? 6 : 4);
+    switch (pick(rng)) {
+        case 0:
+            return {R"({"type":"string"})", "\"abc\""};
+        case 1:
+            return {R"({"type":"integer"})", "42"};
+        case 2:
+            return {R"({"type":"number"})", "2.5"};
+        case 3:
+            return {R"({"type":"boolean"})", "true"};
+        case 4:
+            return {R"({"type":"string","enum":["red","green"]})", "\"green\""};
+        case 5: {  // object
+            std::uniform_int_distribution<int> n(1, 3);
+            const int count = n(rng);
+            std::string props, req, doc = "{";
+            for (int i = 0; i < count; i++) {
+                Generated child = gen_node(rng, depth + 1);
+                const std::string key = "p" + std::to_string(i);
+                if (i) {
+                    props += ",";
+                    req += ",";
+                    doc += ",";
+                }
+                props += "\"" + key + "\":" + child.schema;
+                req += "\"" + key + "\"";
+                doc += "\"" + key + "\":" + child.doc;
+            }
+            return {R"({"type":"object","properties":{)" + props + R"(},"required":[)" + req + "]}",
+                    doc + "}"};
+        }
+        default: {  // array with an explicit minItems the document satisfies
+            Generated item = gen_node(rng, depth + 1);
+            std::uniform_int_distribution<int> n(1, 3);
+            const int count = n(rng);
+            std::string doc = "[";
+            for (int i = 0; i < count; i++) {
+                if (i)
+                    doc += ",";
+                doc += item.doc;
+            }
+            return {R"({"type":"array","items":)" + item.schema + R"(,"minItems":)" + std::to_string(count) +
+                        "}",
+                    doc + "]"};
+        }
+    }
+}
+
+// Root must be an object or array.
+Generated gen_document(std::mt19937& rng) {
+    for (;;) {
+        Generated g = gen_node(rng, 0);
+        if (!g.doc.empty() && (g.doc.front() == '{' || g.doc.front() == '['))
+            return g;
+    }
+}
+
+// Build a constrainer over `schema_json`; returns nullptr if the schema fails
+// to parse (a generator bug, which the caller asserts on).
+std::unique_ptr<SchemaConstrainer> make_fsm(const std::string& schema_json) {
+    auto schema = parse_json_schema(schema_json);
+    if (!schema)
+        return nullptr;
+    auto sc = std::make_unique<SchemaConstrainer>();
+    if (!sc->init_grammar_for_test(std::move(schema)))
+        return nullptr;
+    return sc;
+}
+
+// ===========================================================================
+// P1 — Soundness: a document built to satisfy its schema must be accepted.
+// ===========================================================================
+TEST(SchemaConstrainPropertyTest, AcceptsConformingDocument) {
+    std::mt19937 rng(kSeed);
+    for (int i = 0; i < 500; i++) {
+        Generated g = gen_document(rng);
+        auto sc = make_fsm(g.schema);
+        ASSERT_NE(sc, nullptr) << "schema failed to parse: " << g.schema;
+        EXPECT_TRUE(sc->token_legal(g.doc))
+            << "FSM rejected conforming document\n  schema: " << g.schema << "\n  doc:    " << g.doc;
+    }
+}
+
+// ===========================================================================
+// P2 — Prefix closure: every prefix of a conforming document must stay legal,
+// since that is the state the model occupies mid-generation.
+// ===========================================================================
+TEST(SchemaConstrainPropertyTest, AcceptsEveryPrefixOfConformingDocument) {
+    std::mt19937 rng(kSeed + 1);
+    for (int i = 0; i < 200; i++) {
+        Generated g = gen_document(rng);
+        auto sc = make_fsm(g.schema);
+        ASSERT_NE(sc, nullptr);
+        for (size_t cut = 1; cut < g.doc.size(); cut++) {
+            EXPECT_TRUE(sc->token_legal(g.doc.substr(0, cut)))
+                << "FSM rejected prefix [" << g.doc.substr(0, cut) << "]\n  schema: " << g.schema
+                << "\n  doc:    " << g.doc;
+        }
+    }
+}
+
+// ===========================================================================
+// P3 — required enforcement: closing an object before its required properties
+// are emitted must be refused. `{}` against a schema with required keys is the
+// minimal case (the shape PrematureObjectCloseRejected pins by example).
+// ===========================================================================
+TEST(SchemaConstrainPropertyTest, RejectsObjectMissingRequiredProperties) {
+    std::mt19937 rng(kSeed + 2);
+    int exercised = 0;
+    for (int i = 0; i < 500; i++) {
+        Generated g = gen_document(rng);
+        if (g.doc.front() != '{')
+            continue;
+        auto sc = make_fsm(g.schema);
+        ASSERT_NE(sc, nullptr);
+        EXPECT_FALSE(sc->token_legal("{}"))
+            << "FSM accepted empty object despite required properties\n  schema: " << g.schema;
+        exercised++;
+    }
+    EXPECT_GT(exercised, 0) << "no object roots generated — test would be vacuous";
+}
+
+// ===========================================================================
+// P4 — minItems enforcement (#1014): closing an array before minItems are
+// emitted must be refused.
+// ===========================================================================
+TEST(SchemaConstrainPropertyTest, RejectsArrayBelowMinItems) {
+    std::mt19937 rng(kSeed + 3);
+    int exercised = 0;
+    for (int i = 0; i < 500; i++) {
+        Generated g = gen_document(rng);
+        if (g.doc.front() != '[')
+            continue;
+        auto sc = make_fsm(g.schema);
+        ASSERT_NE(sc, nullptr);
+        // The generator always sets minItems >= 1, so the empty array violates.
+        EXPECT_FALSE(sc->token_legal("[]"))
+            << "FSM accepted empty array below minItems\n  schema: " << g.schema;
+        exercised++;
+    }
+    EXPECT_GT(exercised, 0) << "no array roots generated — test would be vacuous";
+}
+
+// ===========================================================================
+// P5 — no dead ends: from any prefix of a conforming document at least one
+// ASCII continuation must remain legal (release-bar 7: the sampler must always
+// have something valid to emit).
+// ===========================================================================
+TEST(SchemaConstrainPropertyTest, NoDeadEndStates) {
+    std::mt19937 rng(kSeed + 4);
+    for (int i = 0; i < 150; i++) {
+        Generated g = gen_document(rng);
+        auto sc = make_fsm(g.schema);
+        ASSERT_NE(sc, nullptr);
+        for (size_t cut = 1; cut < g.doc.size(); cut++) {
+            const std::string prefix = g.doc.substr(0, cut);
+            bool any_legal = false;
+            for (int ch = 0x20; ch < 0x7F && !any_legal; ch++) {
+                if (sc->token_legal(prefix + static_cast<char>(ch)))
+                    any_legal = true;
+            }
+            EXPECT_TRUE(any_legal) << "dead end after [" << prefix << "]\n  schema: " << g.schema
+                                   << "\n  doc:    " << g.doc;
+        }
+    }
+}
+
+// ===========================================================================
+// P6 — enum enforcement: a string value outside the enum must be refused at
+// the point it becomes unambiguous.
+// ===========================================================================
+TEST(SchemaConstrainPropertyTest, RejectsValueOutsideEnum) {
+    auto sc = make_fsm(
+        R"({"type":"object","properties":{"c":{"type":"string","enum":["red","green"]}},"required":["c"]})");
+    ASSERT_NE(sc, nullptr);
+    EXPECT_TRUE(sc->token_legal(R"({"c":"red"})"));
+    EXPECT_TRUE(sc->token_legal(R"({"c":"green"})"));
+    EXPECT_FALSE(sc->token_legal(R"({"c":"blue"})"));
+    EXPECT_FALSE(sc->token_legal(R"({"c":"redd"})"));  // valid prefix, invalid whole
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## Why

The constrained-decode surface has shipped **seven grammar bugs** — #517, #650, #761, #850, #1002, #1014, #1067 — and every single one was found by a symptom, none by a test. Meanwhile GOAL.md release bar 7 makes *"valid, terminating JSON under any sampler state"* a release blocker.

Two structural reasons this class keeps escaping:

1. The existing batteries are **example-based** — they encode the bug we already found, so the next shape sails through.
2. They live in the **GPU lane** (`test-moe-gdn`), and CI has no GPU runner. This class was never guarded on a pull request at all.

## What

Two generative batteries, both CPU-only so they run in `ctest -L unit` — the lane CI actually executes:

- **`test_json_constrain_property.cpp`** — random JSON documents checked against **nlohmann/json as an independent oracle**.
- **`test_schema_constrain_property.cpp`** — co-generates a schema *and* a conforming document (nlohmann validates JSON syntax but not JSON Schema, so conformance is known by construction), which makes both directions testable.

Shared invariants:

| Property | Guards |
|---|---|
| accept every valid/conforming document | the direction #1067 broke (valid nested docs rejected) |
| accept every prefix of one | the FSM is a prefix machine; a rejected prefix is a dead end mid-generation |
| no dead-end states | release bar 7 as an invariant — the sampler must always have a legal continuation |
| reject swapped closers / trailing content | the shape #1067 accepted |
| reject objects missing required properties | premature-close class |
| reject arrays below `minItems` | #1014 |
| reject values outside an `enum` | enum enforcement |

## Validated by mutation, not by passing

A green test proves nothing on its own, so both batteries were run against deliberately broken FSMs:

- Against the **pre-#1068** grammar, three json_object properties fail and reproduce the original signature verbatim: `FSM accepted wrong closer: [{"k0":true]]`.
- With the **`minItems` check disabled**, exactly `RejectsArrayBelowMinItems` fails and the other five stay green.

I also checked the generator is not vacuous (avg document 18.6 chars, max 133, 721/2000 nested) — a battery that generates `{}` two thousand times would pass just as happily.

## Production-code change

`SchemaConstrainer` gains `init_grammar_for_test()` (installs the grammar without the tokenizer classification and device buffers that only `apply_mask` needs — `init()` allocates device memory, which is what kept this surface out of the CPU lane), and `token_legal()` becomes public. This is the same test-hook treatment #1068 gave `JsonConstrainer::sim_token_valid`.

## Verification

`make verify-fast` green (decode −0.22% vs baseline; the prefill warnings are the known cuBLAS restart variance). `test-core` runs the 12 new tests with **no GPU present** — 547 tests, 487 pass, the rest are the usual GPU skips. No baseline refresh: no engine path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa