### PR TITLE
docs(spec): record recycle_loop as a measured loss, mark it experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Changed
+- **`speculative.recycle_loop` is documented as a measured loss** and marked
+  experimental in `imp.conf.example` / `config.h`. A nine-class sweep
+  (planning, math, repetitive, reasoning self-talk, enumeration, templated
+  code, free prose, long explanation, chain-over-list; Qwen3-14B-NVFP4,
+  1024-tok greedy, interleaved, healthy host) found **no** prompt class where
+  the loop beats the same configuration with the loop off; isolated against
+  eager `token_recycling` it costs a consistent **5.6–8.3%**, and the loop
+  verifiably runs in those arms. The +38–97% recorded at #1055 was real (an
+  era-image bisect rules out a regression from #1059–#1066) but came from a
+  prompt class that was never recorded and has not been re-found. No code
+  behaviour changes — the flag was and stays default-OFF; this replaces the
+  speedup claim the config docs still advertised, and adds an explicit
+  do-not-extend note (the MoE reach was investigated on 2026-07-25 and
+  dropped: the loop is never even reached there, because the async graph loop
+  owns the whole generation once the eager drafter finds nothing).
+
 ### Added
 - **Generative property batteries for both constrained-decode FSMs**, running in
   the CPU `unit` lane. The constrained-decode surface has shipped seven grammar
@@ -77,8 +94,9 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
 - **`speculative.recycle_loop` auto-disables on GGUF-source models** (with a
   log line): the bucket-4 verify chunk forward rides the dequant prefill
   path there, so every verify pays source dequant — measured −9.5%
-  (Qwen3-8B-Q8) and −28.8% (Qwen3-14B-Q6K) vs spec-off, while the ST-NVFP4
-  route wins +38–97%. See issue #1060 for the flip-matrix data.
+  (Qwen3-8B-Q8) and −28.8% (Qwen3-14B-Q6K) vs spec-off. (The ST-NVFP4 route
+  was recorded at +38–97% at the time; see the 2026-07-25 entry below — that
+  win has since failed to reproduce.) See issue #1060 for the flip-matrix data.
 
 ### Added
 - **SWA window snapshots (`kv_cache.swa_snapshot_mb`)**: prefix caching and

--- a/docs/plans/2026-07-23-verify-in-loop.md
+++ b/docs/plans/2026-07-23-verify-in-loop.md
@@ -1,5 +1,24 @@
 # Verify-in-loop: conditional-graph token-recycling verify (#1055)
 
+> **UPDATE 2026-07-25 — the win below is NOT reproducible; the flag is a
+> measured loss on everything since tried.** A nine-class sweep (planning,
+> math, repetitive, reasoning self-talk, enumeration, templated code, free
+> prose, long explanation, chain-over-list; Qwen3-14B-NVFP4, 1024-tok greedy,
+> interleaved, healthy host at 2835-2880 MHz SM / 13801 MHz mem / ~510 W)
+> found **no** class where the loop beats the same configuration with the loop
+> off. Isolated against eager `token_recycling` (same flags, loop off) it costs
+> a consistent **5.6-8.3%**; the loop demonstrably runs in those arms
+> ("verify loop built" appears, three graph instantiations per 1024 tokens).
+> An era-image bisect on 2026-07-25 rules out a regression from #1059-#1066,
+> so the numbers below were real — but the prompt class that produced them was
+> never recorded and has not been re-found. `speculative.recycle_loop_min_emit`
+> (#1060) bounds the damage to −0.3..−3.0% rather than creating a win.
+> **Do not extend the flag's reach (MoE, constrained decoding) before a win is
+> reproduced first.** Note also that the "byte-identical" claim below holds for
+> those three prompts, not in general: a 2026-07-25 server-route check found the
+> ungated loop diverging from loop-off on one prompt (greedy near-ties flipping,
+> the #957 FP-summation-order class; output stays coherent).
+
 **Status: PHASE 2 BUILT AND MEASURED 2026-07-23** — `TrVerifyLoopRunner`
 (`src/runtime/tr_verify_loop.{h,cu}`) + engine wiring
 (`src/runtime/engine_tr_loop.cpp`) behind `speculative.recycle_loop`

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -510,18 +510,29 @@ recycle_width        = 1
 recycle_min_streak   = 1
 # Verify-in-loop (#1055 phase 2): run the whole draft->verify->accept
 # cycle as a conditional CUDA-graph WHILE loop (device drafting, host only
-# drains tokens). Requires token_recycling. Measured on Qwen3-14B-NVFP4
-# reasoning (2026-07-23, byte-identical greedy output): +38-97% cold
-# single-request, +19% warm multi-turn server. v1 scope: dense
-# decode-attn-route models, greedy, no penalties; anything else falls
-# back to the eager paths.
+# drains tokens). Requires token_recycling. v1 scope: dense
+# decode-attn-route models, greedy, no penalties; anything else falls back
+# to the eager paths.
+#
+# EXPERIMENTAL — the measured expectation is a LOSS, leave it off. The
+# +38-97% recorded on Qwen3-14B-NVFP4 reasoning (2026-07-23) came from a
+# prompt class that was never pinned down: a nine-class sweep on 2026-07-25
+# (planning, math, repetitive, reasoning self-talk, enumeration, templated
+# code, free prose, long explanation, chain-over-list; 1024-tok greedy,
+# interleaved, healthy host) found no class where the loop beats the same
+# config with the loop off — isolated against eager token_recycling it
+# costs a consistent 5.6-8.3%. An era-image bisect rules out a regression
+# from #1059-#1066, so the old win was real but is not reproducible from
+# the record.
 recycle_loop         = false
 # Verify-in-loop economics guard (#1060): after a 4-miss-exit sample, fewer
 # than this many tokens emitted per miss-exit burst on average dooms the
 # loop for the request. A cold adjacency table exits the loop after ~1
 # token and pays the launch + rollback + miss-burst detour on every
-# relaunch — that cycle, not the loop itself, is what cost -6..-9% on
-# generic prompts. 0 disables the guard (raw-economics measurement).
+# relaunch — that cycle is what cost -6..-9% on generic prompts. The guard
+# cuts it to -0.3..-3.0%; it bounds damage, it does not create a win (the
+# residual is the one-time loop-graph instantiation, paid before the guard
+# can judge). 0 disables the guard (raw-economics measurement).
 recycle_loop_min_emit = 4.0
 # Suffix-indexed drafting (SuffixDecoding-style): hash-indexed suffix
 # matching instead of a per-step backward scan, continuations picked by

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -848,15 +848,30 @@ struct RuntimeConfig {
         // the ~1.3 ms/step scheduler/API tax. Requires token_recycling;
         // dense decode-attn-route models, greedy, no penalties (v1).
         // Falls back to the eager path on any capture failure.
+        //
+        // EXPERIMENTAL, and the measured expectation is a LOSS. The +38-97%
+        // recorded at #1055 came from a prompt class that has never been
+        // pinned down: a 2026-07-25 sweep over nine classes (planning, math,
+        // repetitive, reasoning self-talk, enumeration, templated code, free
+        // prose, long explanation, chain-over-list; Qwen3-14B-NVFP4,
+        // 1024-tok greedy, interleaved, healthy host) found NO class where
+        // the loop beats the same config with the loop off — isolated
+        // against eager token_recycling it costs a consistent 5.6-8.3%.
+        // An era-image bisect (2026-07-25) rules out a regression from
+        // #1059-#1066, so the old win was real but is not reproducible from
+        // the record. Do not enable expecting a speedup, and do not extend
+        // the flag's reach (e.g. to MoE) before a win is reproduced first.
         bool recycle_loop = false;
         // Verify-in-loop economics guard (#1060): after a 4-miss-exit sample,
         // an average of fewer than this many tokens emitted per miss-exit
         // burst dooms the loop FOR THE REQUEST — the launch + rollback +
         // miss-burst detour of a relaunch cycle cannot amortize below it.
-        // This is what separates the two measured arms: reasoning prose runs
-        // long bursts (+38-97%), generic prose exits after ~1 token and paid
-        // that detour for the whole generation (-6..-9%, the #1060 flip
-        // refutation). 0 disables the guard (raw-economics measurement).
+        // It bounds the damage rather than producing a win: a cold table
+        // exits after ~1 token and would otherwise pay that detour for the
+        // whole generation (-6..-9%, the #1060 flip refutation). The guard
+        // cuts that to -0.3..-3.0%, but the residual is the one-time
+        // loop-graph instantiation, which is paid before the guard can
+        // judge. 0 disables the guard (raw-economics measurement).
         float recycle_loop_min_emit = 4.0f;
         // SuffixDecoding-style indexed drafting (arXiv 2411.04975):
         // hash-indexed suffix matching (O(1) amortized vs the legacy O(n)


### PR DESCRIPTION
## Why

The config docs advertised **"+38-97% cold single-request, +19% warm multi-turn server"** for `speculative.recycle_loop`. That number is from #1055 and was real — but it does not reproduce, and the docs were setting up anyone who reads them to enable a flag that costs throughput.

## The measurement

Nine prompt classes, Qwen3-14B-NVFP4, 1024-tok greedy, interleaved, healthy host (2835–2880 MHz SM / 13801 MHz mem / ~510 W). Three arms so the two flags are separable:

- **A** = no TR at all · **D** = eager `token_recycling`, loop off · **C** = same + `recycle_loop`

| prompt class | A | D | C | D vs A | **C vs D** |
|---|---|---|---|---|---|
| selftalk | 171.10 | 168.84 | 159.46 | −1.3% | **−5.6%** |
| enumerate | 172.19 | 175.62 | 160.96 | +2.0% | **−8.3%** |
| template | 171.27 | 172.19 | 158.21 | +0.5% | **−8.1%** |
| chain | 173.00 | 171.22 | 157.99 | −1.0% | **−7.7%** |
| explain | 173.05 | 173.12 | 159.12 | +0.0% | **−8.1%** |
| prose | 173.37 | 172.39 | 158.97 | −0.6% | **−7.8%** |

Plus the three classes measured earlier the same day (planning, math, repetitive): same direction. **No class wins.** The eager TR drafter is neutral; the loop is what costs.

Notably arm A sits at ~172 tok/s across the board — essentially the spec-off decode rate (170.6), i.e. the eager drafter finds almost nothing on these prompts. That is exactly the zone where a unigram-adjacency drafter should have its edge over the `min_match=6` suffix matcher, and it still loses.

## Why this is a loss and not a measurement artifact

- The loop **verifiably runs** in the C arms: `TrVerifyLoop: verify loop built` appears, three graph instantiations per 1024 tokens.
- An era-image bisect (2026-07-25) rules out a regression from #1059–#1066, so the original win was genuine — the prompt class that produced it was simply never recorded and has not been re-found.
- `recycle_loop_min_emit` (#1060) bounds the damage to −0.3…−3.0%; it does not create a win. The residual is the one-time loop-graph instantiation, paid before the guard can judge.

## What changes

Docs only — **no behaviour change**, the flag was and stays default-OFF. `imp.conf.example` and `config.h` now state the measured expectation, and the #1055 plan doc gets an update banner instead of a rewritten history.

Two things I also corrected while here:

- An explicit **do-not-extend** note. Extending the flag to MoE was investigated on 2026-07-25 and dropped: the loop is never reached there at all, because `step_async_graph_resume()` precedes `step_decode()` and the async graph loop owns the whole generation once the eager drafter finds nothing. Gate logs proved it — every hit had `max_tokens=2`, i.e. came from the warmup request only.
- The **"byte-identical"** claim in the plan doc, which holds for those three #1055 prompts but not in general: a server-route check found the ungated loop diverging from loop-off on one prompt (greedy near-ties flipping, the #957 FP-summation-order class; output stays coherent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa