### PR TITLE
fix(roofline): repin ncu path + preflight profiler binaries

### DIFF
--- a/tools/roofline/config.json
+++ b/tools/roofline/config.json
@@ -21,7 +21,7 @@
     }
   },
   "ncu": {
-    "binary": "/opt/nvidia/nsight-compute/2026.2.0/ncu",
+    "binary": "/opt/nvidia/nsight-compute/2026.2.1/ncu",
     "clock_control": "base",
     "launch_count": 120,
     "skip_fraction": 0.45,

--- a/tools/roofline/rl_measure.py
+++ b/tools/roofline/rl_measure.py
@@ -187,7 +187,32 @@ def check_gpu_free():
             + "\n  ".join(procs + gpu_containers))
 
 
+def check_profilers(cfg):
+    """Abort when a configured profiler binary is missing. The paths are pinned
+    to an exact toolkit version, so a host-side Nsight upgrade silently breaks
+    them: the binary is bind-mounted into the container, a missing source path
+    makes docker fail the container with rc=127, and every ncu pass dies while
+    the nsys passes keep succeeding. That failure only surfaces as a
+    'cells with errors' line after the whole sweep (hours), and the run is
+    written with no ncu data at all — found the hard way when ncu 2026.2.0 ->
+    2026.2.1 left `roofline measure` producing nsys-only runs."""
+    missing = [f"{tool}: {cfg[tool]['binary']}"
+               for tool in ("ncu", "nsys")
+               if not os.path.exists(cfg[tool]["binary"])]
+    if missing:
+        import glob
+        hints = []
+        for tool, root in (("ncu", "/opt/nvidia/nsight-compute"),
+                           ("nsys", "/opt/nvidia/nsight-systems")):
+            found = sorted(glob.glob(f"{root}/*"))
+            if found:
+                hints.append(f"  installed {tool} versions: {', '.join(os.path.basename(f) for f in found)}")
+        raise SystemExit("profiler binary missing (fix tools/roofline/config.json):\n  "
+                         + "\n  ".join(missing) + ("\n" + "\n".join(hints) if hints else ""))
+
+
 def measure(cfg, restarts, model_keys, shape_keys, note="", dry_run=False):
+    check_profilers(cfg)
     if not dry_run:
         check_gpu_free()
     classify = build_classifier(cfg)


### PR DESCRIPTION
## What broke

`tools/roofline/config.json` pinned ncu to an exact toolkit version, `/opt/nvidia/nsight-compute/2026.2.0/ncu`. The host now carries **2026.2.1**, so the bind-mount source stopped existing and every ncu pass died with `OCI runtime ... failed to create shim task` (rc=127) — while the nsys passes kept succeeding.

The sweep then **still wrote a run**, with no ncu data in it, and surfaced the failure only as a trailing `cells with errors` line after the whole hours-long sweep. So `roofline measure` has been silently producing nsys-only runs, and the 2026-07-11 pin is the last complete baseline.

## Fix

- repin to `2026.2.1`
- `check_profilers()` — aborts **before the first container** when a configured profiler binary is missing, and lists what is actually installed:

```
profiler binary missing (fix tools/roofline/config.json):
  ncu: /opt/nvidia/nsight-compute/9999.9.9/ncu
  installed ncu versions: 2025.4.0, 2026.2.1
  installed nsys versions: 2026.1.3
```

## Verification

- repinned path → a `nvfp4-moe/tg256` cell produces full ncu kernel data again (per-kernel `dram__bytes`, `l1tex__t_sector_hit_rate`, durations)
- bogus path → preflight exits 1 immediately instead of burning the sweep

No history/pin files are included: the runs made while diagnosing this were single-cell and `-dirty`, so they are not valid pins and would only pollute the trend data.

## Caveat for the next pin refresh

The `nvfp4-hybrid` ncu pass **hung for ~1 h** on this WSL2 box (GPU idle at 3 %, container `unhealthy`) and had to be killed. That is consistent with the multi-pass-replay caveat already documented in the ncu config comment (device-memory backup vs TMA-using CUTLASS sm120 kernels). The `dense` and `moe` cells complete normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa