### PR TITLE
fix(roofline): bound ncu passes and clean up wedged containers

### DIFF
--- a/tools/roofline/config.json
+++ b/tools/roofline/config.json
@@ -1,6 +1,6 @@
 {
   "config_version": 4,
-  "comment": "Pinned roofline measurement config. Changing counters/shapes bumps config_version — runs are only comparable within the same version.",
+  "comment": "Pinned roofline measurement config. Changing counters/shapes bumps config_version \u2014 runs are only comparable within the same version.",
   "gpu": {
     "name": "NVIDIA GeForce RTX 5090 (GB202, sm_120a)",
     "sm_count": 170,
@@ -42,9 +42,9 @@
         "sm__sass_thread_inst_executed_op_hadd_pred_on.sum",
         "sm__sass_thread_inst_executed_op_hmul_pred_on.sum"
       ],
-      "sass_comment": "SASS counters tolerate no companion counter (even gpu__time_duration flips the pass count and TMA kernels die on multi-pass replay) — the group carries no time; class time comes from the base group (identical --launch-skip/--launch-count window)."
+      "sass_comment": "SASS counters tolerate no companion counter (even gpu__time_duration flips the pass count and TMA kernels die on multi-pass replay) \u2014 the group carries no time; class time comes from the base group (identical --launch-skip/--launch-count window)."
     },
-    "tc_groups_comment": "One sm__ops_path counter per single-pass invocation (each rides with time+bytes so the invocation yields a self-contained FLOP rate). Per model family only the dtypes that can occur in imp's hot path are measured; FLOP counts are workload-deterministic, so TC + SASS groups run on restart 0 only — restarts 1/2 re-measure only the base group (time/bytes variance).",
+    "tc_groups_comment": "One sm__ops_path counter per single-pass invocation (each rides with time+bytes so the invocation yields a self-contained FLOP rate). Per model family only the dtypes that can occur in imp's hot path are measured; FLOP counts are workload-deterministic, so TC + SASS groups run on restart 0 only \u2014 restarts 1/2 re-measure only the base group (time/bytes variance).",
     "tc_groups_by_family": {
       "gguf-q8": [
         "sm__ops_path_tensor_src_fp16_dst_fp32.sum",
@@ -92,7 +92,9 @@
       "sm__sass_thread_inst_executed_op_hfma_pred_on.sum",
       "sm__sass_thread_inst_executed_op_hadd_pred_on.sum",
       "sm__sass_thread_inst_executed_op_hmul_pred_on.sum"
-    ]
+    ],
+    "timeout_s": 900,
+    "timeout_comment": "Per ncu group. A healthy decode pass is ~2 min; the old 3600 s meant a wedged pass (observed on nvfp4-hybrid decode, GPU idle at 3%) stalled the sweep for an hour. On timeout the named container is force-removed and the cell is marked failed."
   },
   "nsys": {
     "binary": "/opt/nvidia/nsight-systems/2026.1.3/target-linux-x64/nsys",
@@ -140,7 +142,7 @@
         "pp2048",
         "tg256"
       ],
-      "comment": "hd=256 dense GGUF (gemma-3): since #932 fa2_hd256 is default-on — this cell tracks whether the legacy materialized cuBLAS attention path still appears (it dominated pre-#932) + gemv_gguf decode (no NVFP4 fast-path)"
+      "comment": "hd=256 dense GGUF (gemma-3): since #932 fa2_hd256 is default-on \u2014 this cell tracks whether the legacy materialized cuBLAS attention path still appears (it dominated pre-#932) + gemv_gguf decode (no NVFP4 fast-path)"
     },
     "nvfp4-hybrid": {
       "path": "/models/Qwen3.6-35B-A3B-NVFP4",
@@ -152,7 +154,7 @@
       "path": "/models/gpt-oss-20b",
       "family": "nvfp4",
       "arch": "moe",
-      "comment": "gpt-oss-20b MXFP4 SafeTensors hero (#984 decode-tie vs llama.cpp): BF16 dense + NVFP4-converted experts, attention sinks + alternating SWA. Added additively under config_version 4 — the accompanying regex additions (gpt_oss_glu / bias / moe_add_*_bias) can only match kernels absent from all pre-existing cells (cv4 pin measured 0 unclassified), so cv4 runs stay comparable."
+      "comment": "gpt-oss-20b MXFP4 SafeTensors hero (#984 decode-tie vs llama.cpp): BF16 dense + NVFP4-converted experts, attention sinks + alternating SWA. Added additively under config_version 4 \u2014 the accompanying regex additions (gpt_oss_glu / bias / moe_add_*_bias) can only match kernels absent from all pre-existing cells (cv4 pin measured 0 unclassified), so cv4 runs stay comparable."
     }
   },
   "shapes": {
@@ -182,7 +184,7 @@
     }
   },
   "capture_regex": {
-    "comment": "ncu --kernel-name matches the demangled base name WITHOUT namespaces — CUTLASS kernels are plain 'device_kernel', imp:: kernels their bare names. 'cutlass' alone never matches.",
+    "comment": "ncu --kernel-name matches the demangled base name WITHOUT namespaces \u2014 CUTLASS kernels are plain 'device_kernel', imp:: kernels their bare names. 'cutlass' alone never matches.",
     "prefill": "fmha|flash_attention|causal_softmax|softcap|gemm|gemv|device_kernel|cutlass|nvjet|nvf4|xmma|quantize_fp16|dequant|rmsnorm|rope|qknorm|mmq_|q8_split|quantize_act_fast|q6k_repack|quantize_fp16_to_int8",
     "decode": "gemv|nvjet|device_kernel|paged_attention|rmsnorm|rope|qknorm|write_kv|argmax|topk|softmax|apply_|residual"
   },

--- a/tools/roofline/rl_measure.py
+++ b/tools/roofline/rl_measure.py
@@ -21,9 +21,29 @@ def _log(msg):
     sys.stdout.flush()
 
 
-def _run_cmd(cmd, timeout=1800):
+def _run_cmd(cmd, timeout=1800, container=None):
+    """Run a measurement command, returning (CompletedProcess, seconds).
+
+    A timeout is reported as rc=124 rather than raised: an ncu pass that wedges
+    must cost one cell, not the whole sweep. `container` names the docker
+    container to force-remove on timeout — killing the `docker run` CLIENT does
+    NOT stop the container, so without this it keeps holding the GPU and every
+    following cell dies on "a driver resource was unavailable". Both failure
+    modes were observed 2026-07-25: an nvfp4-hybrid decode pass wedged with the
+    GPU idle at 3% and sat there until it was killed by hand."""
     t0 = time.time()
-    p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        if container:
+            subprocess.run(["docker", "rm", "-f", container], capture_output=True, text=True)
+
+        def _dec(v):
+            return v.decode(errors="replace") if isinstance(v, bytes) else (v or "")
+
+        p = subprocess.CompletedProcess(
+            cmd, returncode=124, stdout=_dec(e.stdout),
+            stderr=f"TIMEOUT after {timeout}s (container {container or '?'} force-removed)")
     dt = time.time() - t0
     return p, dt
 
@@ -124,7 +144,8 @@ def measure_cell(cfg, classify, raw_dir, model_key, shape_key, restart, dry_run=
         # unavailable" when ncu sessions run back-to-back — transient, recovers
         # after a pause. Retry with backoff before declaring the group failed.
         for attempt in range(3):
-            p, dt = _run_cmd(ncu_cmd, timeout=3600)
+            p, dt = _run_cmd(ncu_cmd, timeout=cfg['ncu'].get('timeout_s', 900),
+                             container=rl_ncu.container_name(gbase))
             ok = p.returncode == 0 and os.path.exists(rep_path)
             transient = "resource was unavailable" in (p.stdout + p.stderr) \
                 or p.returncode == 9

--- a/tools/roofline/rl_ncu.py
+++ b/tools/roofline/rl_ncu.py
@@ -4,6 +4,7 @@ import csv
 import gzip
 import io
 import os
+import re
 import subprocess
 
 
@@ -70,6 +71,12 @@ def parse_csv_gz(csv_gz_path, metric_names):
     return launches
 
 
+def container_name(out_base_name):
+    """Deterministic container name per ncu group, so a timeout can clean up."""
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", out_base_name)
+    return f"roofline_ncu_{safe}"
+
+
 def docker_ncu_cmd(cfg, kernel_regex, launch_skip, launch_count, out_host_dir,
                    out_base_name, imp_cli_args, metrics, extra_env=None):
     d = cfg["docker"]
@@ -79,6 +86,9 @@ def docker_ncu_cmd(cfg, kernel_regex, launch_skip, launch_count, out_host_dir,
         env_flags += ["-e", f"{k}={v}"]
     return [
         "docker", "run", "--rm", "--gpus", "all", "--privileged",
+        # Named so a wedged pass can be force-removed on timeout (see
+        # rl_measure._run_cmd) — an orphaned container keeps the GPU.
+        "--name", container_name(out_base_name),
         "-u", f"{os.getuid()}:{os.getgid()}", "-w", "/tmp",
         "-v", f"{d['models_mount']}:/models",
         "-v", f"{out_host_dir}:/out",


### PR DESCRIPTION
## Why

A wedged ncu pass used to cost the whole sweep. Observed 2026-07-25 on the `nvfp4-hybrid` decode cell: the pass sat for **~1 h** with the GPU idle at 3 % and the container marked `unhealthy`, and had to be killed by hand.

Three separate problems, all fixed here:

| # | Problem | Effect |
|---|---|---|
| 1 | timeout was **3600 s** per ncu group | a healthy decode pass is ~2 min, so a wedge stalled the sweep for an hour |
| 2 | `TimeoutExpired` propagated out of the retry loop | the timeout aborted the **entire sweep** instead of failing one cell |
| 3 | the ncu container was **unnamed** | nothing could stop it — killing the `docker run` *client* does not stop the container, so it kept the GPU and every following cell would have died on "a driver resource was unavailable" |

## Fix

- `ncu.timeout_s` (default **900**), configurable
- `_run_cmd` reports **rc=124** like `timeout(1)` instead of raising, so the existing group-error path handles it
- containers named per group, **force-removed on timeout**

## Verified

With a 5 s test timeout on `nvfp4-dense/tg256`:

```
FAILED rc=124: TIMEOUT after 5s (container roofline_ncu_nvfp4-dense_tg256_r0_full force-removed)
```

Sweep continues, run written with the cell marked failed, no container left behind, GPU free afterwards.

## Scope

This does **not** fix the underlying hybrid-decode wedge — that is multi-pass kernel replay against TMA-using CUTLASS kernels on this WSL2 driver, the same reason prefill already runs single-pass metric groups (see `config.json` `ncu.replay_comment`). That cell still needs single-pass decode groups. This change only makes its failure cheap instead of sweep-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa