### PR TITLE
fix(roofline): single-pass metric groups for decode too (unwedges hybrid)

### DIFF
--- a/tools/roofline/config.json
+++ b/tools/roofline/config.json
@@ -1,5 +1,5 @@
 {
-  "config_version": 4,
+  "config_version": 5,
   "comment": "Pinned roofline measurement config. Changing counters/shapes bumps config_version \u2014 runs are only comparable within the same version.",
   "gpu": {
     "name": "NVIDIA GeForce RTX 5090 (GB202, sm_120a)",
@@ -25,25 +25,7 @@
     "clock_control": "base",
     "launch_count": 120,
     "skip_fraction": 0.45,
-    "replay_comment": "Multi-pass kernel replay needs a device-memory backup, and on this WSL2 consumer driver that dies with a driver-resource error the moment a TMA-using kernel (cuBLAS nvjet_*, CUTLASS sm120) is profiled. Application replay is no alternative for prefill: cuBLAS re-autotunes per process, kernel sequences differ across passes -> ncu 'Skipped'. PREFILL therefore runs several SINGLE-PASS ncu invocations per cell (prefill_groups; max ~6 plain counters per pass, only ONE sm__ops_path_* per pass). DECODE has no TMA kernels in the hot path and keeps one multi-pass kernel-replay invocation with the full decode_metrics set.",
-    "prefill_groups": {
-      "base": [
-        "gpu__time_duration.sum",
-        "dram__bytes.sum",
-        "gpc__cycles_elapsed.avg.per_second",
-        "sm__warps_active.avg.pct_of_peak_sustained_active",
-        "l1tex__t_sector_hit_rate.pct"
-      ],
-      "sass": [
-        "sm__sass_thread_inst_executed_op_ffma_pred_on.sum",
-        "sm__sass_thread_inst_executed_op_fadd_pred_on.sum",
-        "sm__sass_thread_inst_executed_op_fmul_pred_on.sum",
-        "sm__sass_thread_inst_executed_op_hfma_pred_on.sum",
-        "sm__sass_thread_inst_executed_op_hadd_pred_on.sum",
-        "sm__sass_thread_inst_executed_op_hmul_pred_on.sum"
-      ],
-      "sass_comment": "SASS counters tolerate no companion counter (even gpu__time_duration flips the pass count and TMA kernels die on multi-pass replay) \u2014 the group carries no time; class time comes from the base group (identical --launch-skip/--launch-count window)."
-    },
+    "replay_comment": "Multi-pass kernel replay needs a device-memory backup, and on this WSL2 consumer driver that dies with a driver-resource error the moment a TMA-using kernel (cuBLAS nvjet_*, CUTLASS sm120) is profiled. Application replay is no alternative for prefill: cuBLAS re-autotunes per process, kernel sequences differ across passes -> ncu 'Skipped'. BOTH phases therefore run several SINGLE-PASS ncu invocations per cell (metric_groups; max ~6 plain counters per pass, only ONE sm__ops_path_* per pass). Decode used to be exempt on the assumption that it has no TMA kernels in the hot path \u2014 WRONG: the nvfp4-hybrid decode cell wedged indefinitely on 2026-07-25 (GPU idle at 3%, container unhealthy, killed by hand) because CUTLASS grouped GEMM runs there too. dense/moe survived, which is why the assumption held for so long.",
     "tc_groups_comment": "One sm__ops_path counter per single-pass invocation (each rides with time+bytes so the invocation yields a self-contained FLOP rate). Per model family only the dtypes that can occur in imp's hot path are measured; FLOP counts are workload-deterministic, so TC + SASS groups run on restart 0 only \u2014 restarts 1/2 re-measure only the base group (time/bytes variance).",
     "tc_groups_by_family": {
       "gguf-q8": [
@@ -73,28 +55,27 @@
       "gemm_grouped_nvfp4"
     ],
     "fp4_flops_per_tensor_inst": 16384,
-    "decode_metrics": [
-      "gpu__time_duration.sum",
-      "dram__bytes.sum",
-      "gpc__cycles_elapsed.avg.per_second",
-      "sm__warps_active.avg.pct_of_peak_sustained_active",
-      "l1tex__t_sector_hit_rate.pct",
-      "sm__ops_path_tensor_src_fp4_fp6_dst_fp16.sum",
-      "sm__ops_path_tensor_src_fp4_fp6_dst_fp32.sum",
-      "sm__ops_path_tensor_src_fp8_dst_fp16.sum",
-      "sm__ops_path_tensor_src_fp8_dst_fp32.sum",
-      "sm__ops_path_tensor_src_fp16_dst_fp16.sum",
-      "sm__ops_path_tensor_src_fp16_dst_fp32.sum",
-      "sm__ops_path_tensor_src_int8.sum",
-      "sm__sass_thread_inst_executed_op_ffma_pred_on.sum",
-      "sm__sass_thread_inst_executed_op_fadd_pred_on.sum",
-      "sm__sass_thread_inst_executed_op_fmul_pred_on.sum",
-      "sm__sass_thread_inst_executed_op_hfma_pred_on.sum",
-      "sm__sass_thread_inst_executed_op_hadd_pred_on.sum",
-      "sm__sass_thread_inst_executed_op_hmul_pred_on.sum"
-    ],
     "timeout_s": 900,
-    "timeout_comment": "Per ncu group. A healthy decode pass is ~2 min; the old 3600 s meant a wedged pass (observed on nvfp4-hybrid decode, GPU idle at 3%) stalled the sweep for an hour. On timeout the named container is force-removed and the cell is marked failed."
+    "timeout_comment": "Per ncu group. A healthy decode pass is ~2 min; the old 3600 s meant a wedged pass (observed on nvfp4-hybrid decode, GPU idle at 3%) stalled the sweep for an hour. On timeout the named container is force-removed and the cell is marked failed.",
+    "metric_groups": {
+      "base": [
+        "gpu__time_duration.sum",
+        "dram__bytes.sum",
+        "gpc__cycles_elapsed.avg.per_second",
+        "sm__warps_active.avg.pct_of_peak_sustained_active",
+        "l1tex__t_sector_hit_rate.pct"
+      ],
+      "sass": [
+        "sm__sass_thread_inst_executed_op_ffma_pred_on.sum",
+        "sm__sass_thread_inst_executed_op_fadd_pred_on.sum",
+        "sm__sass_thread_inst_executed_op_fmul_pred_on.sum",
+        "sm__sass_thread_inst_executed_op_hfma_pred_on.sum",
+        "sm__sass_thread_inst_executed_op_hadd_pred_on.sum",
+        "sm__sass_thread_inst_executed_op_hmul_pred_on.sum"
+      ],
+      "sass_comment": "SASS counters tolerate no companion counter (even gpu__time_duration flips the pass count and TMA kernels die on multi-pass replay) \u2014 the group carries no time; class time comes from the base group (identical --launch-skip/--launch-count window).",
+      "groups_comment": "Single-pass metric groups for BOTH phases. Multi-pass kernel replay needs a device-memory backup that dies (or wedges) on TMA-using kernels on this WSL2 consumer driver; decode used to run all 18 metrics in one multi-pass invocation, which is why the nvfp4-hybrid decode cell hung indefinitely (2026-07-25) while dense/moe happened to survive. Same grouping as prefill: each invocation stays single-pass."
+    }
   },
   "nsys": {
     "binary": "/opt/nvidia/nsight-systems/2026.1.3/target-linux-x64/nsys",

--- a/tools/roofline/rl_measure.py
+++ b/tools/roofline/rl_measure.py
@@ -117,21 +117,21 @@ def measure_cell(cfg, classify, raw_dir, model_key, shape_key, restart, dry_run=
     cell["ncu_launch_skip"] = skip
     cell["ncu_launch_count"] = launch_count
 
-    if shape["phase"] == "decode":
-        groups = {"full": cfg["ncu"]["decode_metrics"]}
+    # Both phases use single-pass metric groups: one multi-pass invocation wedges
+    # on TMA-using kernels on this WSL2 driver (decode used to do that and hung
+    # the nvfp4-hybrid cell indefinitely — see config.json groups_comment).
+    groups = {k: v for k, v in cfg["ncu"]["metric_groups"].items()
+              if not k.endswith("_comment")}
+    if restart == 0:
+        # TC ops + SASS FLOP counts are workload-deterministic — restart 0 only.
+        for m in cfg["ncu"]["tc_groups_by_family"][model["family"]]:
+            if "tensor_src_" in m:
+                gname = "tc_" + m.split("tensor_src_")[1].rsplit(".", 1)[0]
+            else:
+                gname = "tc_pipe"
+            groups[gname] = cfg["ncu"]["tc_group_base"] + [m]
     else:
-        groups = {k: v for k, v in cfg["ncu"]["prefill_groups"].items()
-                  if not k.endswith("_comment")}
-        if restart == 0:
-            # TC ops + SASS FLOP counts are workload-deterministic — restart 0 only.
-            for m in cfg["ncu"]["tc_groups_by_family"][model["family"]]:
-                if "tensor_src_" in m:
-                    gname = "tc_" + m.split("tensor_src_")[1].rsplit(".", 1)[0]
-                else:
-                    gname = "tc_pipe"
-                groups[gname] = cfg["ncu"]["tc_group_base"] + [m]
-        else:
-            groups = {"base": groups["base"]}
+        groups = {"base": groups["base"]}
 
     cell["ncu_groups"] = {}
     for gname, metrics in groups.items():


### PR DESCRIPTION
## Why

Decode ran all 18 metrics in **one multi-pass ncu invocation**, exempted from the single-pass grouping prefill uses. The exemption rested on an assumption recorded in `ncu.replay_comment`:

> DECODE has no TMA kernels in the hot path and keeps one multi-pass kernel-replay invocation

That is wrong. CUTLASS grouped GEMM runs in the hybrid decode path, so multi-pass kernel replay wedges there exactly as it does in prefill. The `nvfp4-hybrid` decode cell hung for **~1 h** on 2026-07-25 (GPU idle at 3 %, container `unhealthy`, killed by hand). `dense` and `moe` happened to survive — which is why the assumption held so long, and why the last complete pin is from 07-11.

## Fix

Both phases now use the same single-pass `metric_groups` (renamed from `prefill_groups`); TC/SASS groups stay restart-0 only.

**Verified** — the previously wedging cell now completes all six groups, ~2–3 min each, no errors:

```
ncu base → ncu sass → ncu tc_pipe → ncu tc_fp8_dst_fp32
→ ncu tc_fp16_dst_fp32 → ncu tc_fp16_dst_fp16 → run written
```

## config_version 4 → 5

This changes *how* decode counters are collected, so it is not the additive kind of change cv4 allowed. Runs must not be compared across the boundary, and `rl_regress` enforces exactly that.

**No history is committed here**, so `latest` stays the cv4 run and the CI gate keeps passing against the cv4 baseline (verified locally: `OK: no kernel class > 5.0% below baseline cf1b382a`). The next `make roofline-pin` produces the first cv5 pin and **must move `history/BASELINE` with it**.

## First data out of the unwedged cell

Worth recording, because the aggregate hid it: the 07-11 report's `gemv_nvfp4 @ nvfp4-hybrid = 25.9%` averages several kernels. The individual `gemv_nvfp4_kpar_kernel` sits at **15.7 % of decode time running at 132 GB/s = 7.4 % of roofline** — by far the worst kernel in that model, and invisible until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa