### PR TITLE
docs(roadmap): record that a live SSE frontend needs no server work

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,6 +41,19 @@ A ranked audit of what still separates imp from "best agentic engine on a 5090".
 
 Explicitly **not** gaps: continuous batching, prefix caching, per-request LoRA, embeddings, the OpenAI / Anthropic / Responses APIs, `/metrics`, suspend/resume, and the sampler surface (DRY, mirostat, typical_p, logit_bias) all ship today. Multi-GPU remains a non-goal.
 
+### Built-in live UI -- feasible, unscoped
+
+A browser frontend rendering the SSE stream live is **already possible against the server as it ships** (assessed 2026-07-26); no engine or protocol work is required:
+
+- Streaming is the real OpenAI wire format -- `text/event-stream` via `set_chunked_content_provider`, `data: {...}\n\n` chunks, terminating `data: [DONE]` (`handlers_chat_stream.cpp`).
+- CORS is wide open for any origin, preflight included -- `Access-Control-Allow-Origin: *` plus an `OPTIONS` catch-all (`main.cpp`), so a page served from anywhere can call the API directly, without a proxy.
+- Client disconnect is detected on the token loop (`is_writable`), so closing the tab cancels generation instead of leaving the GPU running.
+- `reasoning_content` and tool calls already arrive as separate stream channels, so a collapsible thinking pane and streamed tool calls need no server change.
+
+The only client-side constraint: `EventSource` is GET-only, so a frontend consumes the stream with `fetch()` + `ReadableStream` -- the standard approach.
+
+What is actually missing is a place to put it: the server has no static file serving (no `set_mount_point`), so a bundled UI would need that one route -- and then the UI itself, which is the real cost. Note this is **not** on the `GOAL.md` surface commitment (HTTP server, C API, CLI); it is a convenience, not a mission item, and shipping one adds a frontend to maintain. Listed here because the engine-side answer is unambiguous: nothing blocks it.
+
 ## Performance work
 
 The batch=1 *competitive campaigns* are closed as programs -- every lever they left open either shipped or was refuted by measurement -- but targeted wins keep landing where new levers appear:


### PR DESCRIPTION
Follow-up to #1076. Adds a **Built-in live UI -- feasible, unscoped** subsection to the roadmap's gap audit.

Question asked: is an SSE stream from the HTTP server, rendered live in a frontend, feasible? Assessed against the code as it ships — the answer is yes, with **no engine or protocol work required**:

- `handlers_chat_stream.cpp` — real OpenAI wire format: `text/event-stream`, chunked content provider, `data: {...}\n\n`, terminating `data: [DONE]`.
- `main.cpp` — `Access-Control-Allow-Origin: *` plus an `OPTIONS` catch-all, so a page from any origin calls the API directly, no proxy.
- Client disconnect is detected on the token loop (`is_writable`) → closing the tab cancels generation.
- `reasoning_content` and tool calls are already separate stream channels → collapsible thinking pane and streamed tool calls need no server change.

Only client-side constraint noted: `EventSource` is GET-only, so a frontend uses `fetch()` + `ReadableStream`.

What is actually missing: static file serving (no `set_mount_point`) plus the UI itself, which is the real cost. Recorded with the caveat that a UI is **not** on the `GOAL.md` surface commitment (HTTP server, C API, CLI) — a convenience with a maintenance tail, not a mission item.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa