### PR TITLE
fix(kv): make an undersized swa_snapshot_mb say so, and document how to size it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   dependencies — for anything richer, point Open WebUI at the same server.
 
 ### Fixed
+- **An undersized `kv_cache.swa_snapshot_mb` silently cost prefix caching.** One
+  SWA snapshot is several hundred MiB (350 on gemma-3-12b); a budget below that
+  leaves the store off, and prefix caching is then disabled with it — strictly
+  worse than `swa_snapshot_mb=0`, which keeps caching and yields the SWA savings
+  instead. The log said only "snapshot store off", so the two cases were
+  indistinguishable. It now warns with the required size and both ways out, and
+  `imp.conf.example` documents how to size it. Validated on gemma-3-12b at a
+  sufficient budget: SWA sizing and prefix caching run together, 2720 prompt
+  tokens served from cache, warm TTFT 853 -> 400 ms, warm output byte-identical
+  to cold.
 - **Llama 3.2 tool calls were dropped.** Llama 3.2 emits a bare JSON object
   (`{"name": F, "parameters": {...}}`) where 3.1 used the `<function=F>`
   envelope; imp understood only the envelope, so a correct call — model and

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -150,6 +150,10 @@ swa_sizing                  = auto
 # savings. Enable for long-context workloads (~8K+); leave off for
 # short-turn serving. 0 = off (auto yields to prefix caching, on
 # force-disables it).
+# SIZE IT PROPERLY: one snapshot is (windowed layers x window blocks) and can
+# run several hundred MiB (350 MiB on gemma-3-12b). A budget BELOW one snapshot
+# is worse than 0 — the store stays off and prefix caching is disabled with it,
+# so you lose both. The server logs the required size when this happens.
 swa_snapshot_mb             = 0
 
 [rope]

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -368,9 +368,22 @@ bool Engine::init_kv_cache() {
         if (!swa_snapshots_) {
             kv_manager_->set_prefix_caching_enabled(false);
             config_.use_prefix_caching = false;
-            IMP_LOG_INFO("Prefix caching disabled under SWA sizing (snapshot store off — "
-                         "kv_cache.swa_snapshot_mb=%d)",
-                         budget_mb);
+            // Say WHY and WHAT TO DO. A budget below one snapshot silently costs
+            // prefix caching — strictly worse than swa_snapshot_mb=0, which keeps
+            // caching and yields the SWA savings instead. Without the required
+            // size in the message there is no way to tell those apart from a log.
+            const size_t need_mb = (kv_manager_->swa_snapshot_bytes() + (1u << 20) - 1) >> 20;
+            if (budget_mb > 0 && static_cast<size_t>(budget_mb) < need_mb) {
+                IMP_LOG_WARN("Prefix caching DISABLED: kv_cache.swa_snapshot_mb=%d is below one "
+                             "snapshot (%zu MiB). Set it to >=%zu to run SWA sizing AND prefix "
+                             "caching together, or to 0 to keep prefix caching and drop the SWA "
+                             "savings.",
+                             budget_mb, need_mb, need_mb);
+            } else {
+                IMP_LOG_INFO("Prefix caching disabled under SWA sizing (snapshot store off — "
+                             "kv_cache.swa_snapshot_mb=%d)",
+                             budget_mb);
+            }
         }
     }
 


### PR DESCRIPTION
Clearing the follow-up backlog. Three findings, only one needed code.

## Two were already done — the memory note was stale

- **#1003 batch>1 spec default-flip**: the healthy-host matrix *was* measured and the flag is default-ON. `config.h` carries the numbers (Coder-30B NVFP4: code-edit +7.9/+11.0% at batch 8, +2.6/+4.4% at 16, diverse chat neutral).
- **128K TTFT band**: closed by the baseline's own note — Q6_K tops out near 75K on 32 GB by VRAM, and the 128K reference lives in `BENCHMARKS.md` on NVFP4. Not a gap, a ceiling.

## SWA snapshot reuse works — with a trap in front of it

Validated on gemma-3-12b at a sufficient budget: **SWA sizing and prefix caching run together**, 2720 prompt tokens served from cache, warm TTFT **853 → 400 ms**, warm output **byte-identical** to cold.

But at `kv_cache.swa_snapshot_mb=256` the store stays off — one snapshot on that model is **350 MiB** — and prefix caching is disabled along with it. That is *strictly worse* than `swa_snapshot_mb=0`, which keeps caching and merely yields the SWA savings. The log said only `"snapshot store off"`, which cannot distinguish "you asked for this" from "your budget was 27% too small".

Now:

```
Prefix caching DISABLED: kv_cache.swa_snapshot_mb=256 is below one snapshot
(350 MiB). Set it to >=350 to run SWA sizing AND prefix caching together, or
to 0 to keep prefix caching and drop the SWA savings.
```

`imp.conf.example` gains the sizing note.

**Not changed**: the fallback itself. Recovering automatically would mean re-initialising the KV cache after it is already sized — real risk for a case a clear message solves.

`test-core` 517 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQf5BRBYTMx7Q5QDWNhMqa