### PR TITLE
fix(constrain): close four RFC 8259 holes in the JSON/schema FSMs (#1104)

### DIFF
--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -84,7 +84,18 @@ void JsonConstrainer::reset() {
     partial_literal_.clear();
     target_literal_.clear();
     ws_run_ = 0;
+    enter_number_('0');  // clear the number sub-state (see #1104)
+    num_need_digit_ = false;
     preamble_.reset();
+}
+
+// Seed the RFC 8259 number sub-state on entry. `c` is the first character of
+// the number: a bare '-' still owes its first digit, a digit does not.
+void JsonConstrainer::enter_number_(char c) {
+    num_seen_frac_ = false;
+    num_seen_exp_ = false;
+    num_exp_sign_ok_ = false;
+    num_need_digit_ = (c == '-');
 }
 
 uint16_t JsonConstrainer::compute_allowed_mask() const {
@@ -278,6 +289,7 @@ bool JsonConstrainer::advance_char(char c) {
             } else if ((c >= '0' && c <= '9') || c == '-') {
                 state_stack_.push_back(JsonState::AFTER_VALUE);
                 current_state_ = JsonState::IN_NUMBER;
+                enter_number_(c);
             } else {
                 return false;
             }
@@ -334,6 +346,7 @@ bool JsonConstrainer::advance_char(char c) {
             } else if ((c >= '0' && c <= '9') || c == '-') {
                 state_stack_.push_back(JsonState::ARRAY_AFTER_VALUE);
                 current_state_ = JsonState::IN_NUMBER;
+                enter_number_(c);
             } else {
                 return false;
             }
@@ -381,8 +394,40 @@ bool JsonConstrainer::advance_char(char c) {
             current_state_ = JsonState::IN_STRING;
             break;
 
-        case JsonState::IN_NUMBER:
-            if (!((c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-')) {
+        case JsonState::IN_NUMBER: {
+            // RFC 8259 number grammar. The old test accepted every one of
+            // '.', 'e', 'E', '+', '-' unconditionally, which made "3.5.5.5"
+            // legal and left a degenerating model with no forced way out (#1104).
+            bool ok = false;
+            if (c >= '0' && c <= '9') {
+                ok = true;
+                num_need_digit_ = false;
+                num_exp_sign_ok_ = false;
+            } else if (c == '.') {
+                ok = !num_seen_frac_ && !num_seen_exp_ && !num_need_digit_;
+                if (ok) {
+                    num_seen_frac_ = true;
+                    num_need_digit_ = true;  // frac = "." 1*DIGIT
+                }
+            } else if (c == 'e' || c == 'E') {
+                ok = !num_seen_exp_ && !num_need_digit_;
+                if (ok) {
+                    num_seen_exp_ = true;
+                    num_exp_sign_ok_ = true;
+                    num_need_digit_ = true;  // exp = e [sign] 1*DIGIT
+                }
+            } else if (c == '+' || c == '-') {
+                ok = num_exp_sign_ok_;
+                if (ok) {
+                    num_exp_sign_ok_ = false;
+                    num_need_digit_ = true;
+                }
+            }
+            if (!ok) {
+                // A number still owing a digit ("3.", "1e", "-") is incomplete:
+                // nothing may terminate it, not even a structural char.
+                if (num_need_digit_)
+                    return false;
                 // Number ended — this char is part of the parent context
                 // Pop back to parent and re-process this character
                 current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
@@ -391,6 +436,7 @@ bool JsonConstrainer::advance_char(char c) {
                 return advance_char(c);  // re-process in parent context
             }
             break;
+        }
 
         case JsonState::IN_LITERAL:
             // Strict: the char must be the literal's next expected char
@@ -422,6 +468,11 @@ bool JsonConstrainer::sim_token_valid(const std::string& text) {
     const std::string plit = partial_literal_;
     const std::string tlit = target_literal_;
     const int ws = ws_run_;
+    // The number sub-state is part of the FSM and MUST round-trip too — a
+    // simulated token that walks into a number would otherwise leave
+    // num_seen_frac_/num_need_digit_ mutated on the real state (#1104).
+    const bool nfrac = num_seen_frac_, nexp = num_seen_exp_;
+    const bool nsign = num_exp_sign_ok_, ndig = num_need_digit_;
     std::vector<JsonState> stack_copy = state_stack_;
 
     bool ok = true;
@@ -437,6 +488,10 @@ bool JsonConstrainer::sim_token_valid(const std::string& text) {
     (void)depth;
     partial_literal_ = plit;
     target_literal_ = tlit;
+    num_seen_frac_ = nfrac;
+    num_seen_exp_ = nexp;
+    num_exp_sign_ok_ = nsign;
+    num_need_digit_ = ndig;
     ws_run_ = ws;
     return ok;
 }

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -102,6 +102,40 @@ uint16_t JsonConstrainer::compute_allowed_mask() const {
     // Whitespace is legal between any JSON tokens, but cap the run length —
     // see advance_char. (EOS has its own CAT_EOS bit, allowed in DONE only.)
     constexpr int kMaxWsRun = 32;
+
+    // Force-close near the budget (#1104). A constrainer can forbid illegal
+    // tokens but cannot force termination, so a model inside a long string or
+    // a whitespace flood runs to max_tokens and returns a truncated document
+    // that no client can parse. Once only just enough tokens remain to shut
+    // everything that is open, narrow the mask to exactly the closers. The
+    // estimate deliberately errs high (the string's parent frame is already on
+    // the stack), because closing a few tokens early is strictly better than
+    // returning unparseable output. Disabled while the budget is unknown (-1).
+    force_close_active_ = false;
+    if (remaining_budget_ >= 0 && current_state_ != JsonState::DONE) {
+        const bool in_escape = (current_state_ == JsonState::IN_STRING_ESCAPE);
+        const bool in_string = (current_state_ == JsonState::IN_STRING ||
+                                current_state_ == JsonState::OBJECT_KEY);
+        // state_stack_ holds only the RETURN states of *nested* values, not the
+        // container we are currently inside — at `{"a"` the stack is empty
+        // while a '}' is still owed. Count that container explicitly, or the
+        // narrowing releases one token too early and the document is truncated
+        // anyway (observed: needed=0 in AFTER_KEY with an object still open).
+        const bool in_container = (current_state_ != JsonState::START && current_state_ != JsonState::DONE);
+        const int needed = static_cast<int>(state_stack_.size()) + (in_container ? 1 : 0) +
+                           (in_escape   ? 2
+                            : in_string ? 1
+                                        : 0);
+        if (remaining_budget_ <= needed) {
+            force_close_active_ = true;
+            if (in_escape)
+                return CAT_STRING_CHAR;  // finish the escape, close on the next tick
+            if (in_string)
+                return CAT_QUOTE;  // close the string, then the structures
+            return CAT_CLOSE_BRACE | CAT_CLOSE_BRACKET;
+        }
+    }
+
     uint16_t mask = (ws_run_ < kMaxWsRun) ? CAT_WHITESPACE : 0;
 
     switch (current_state_) {
@@ -206,6 +240,17 @@ bool JsonConstrainer::advance_char(char c) {
     // whole-token simulation in apply_mask() uses it to reject tokens whose
     // FIRST char passes the category mask but whose tail violates the
     // grammar (e.g. the single token "[]." — '.' after a completed value).
+    // Whitespace TERMINATES a number, it does not continue one: "1.  1" is not
+    // a JSON number, yet the blanket skip below kept the FSM in IN_NUMBER and
+    // let the emitted text interleave digits with spaces (#1104). Close the
+    // number first, then let the whitespace be skipped in the parent state.
+    if (current_state_ == JsonState::IN_NUMBER && (c == ' ' || c == '\t' || c == '\n' || c == '\r')) {
+        if (num_need_digit_)
+            return false;  // "1." / "1e" / "-" cannot end here
+        current_state_ = state_stack_.empty() ? JsonState::DONE : state_stack_.back();
+        if (!state_stack_.empty())
+            state_stack_.pop_back();
+    }
     if (current_state_ != JsonState::IN_STRING && current_state_ != JsonState::IN_STRING_ESCAPE &&
         (c == ' ' || c == '\t' || c == '\n' || c == '\r')) {
         ws_run_++;
@@ -507,6 +552,20 @@ void JsonConstrainer::update(int32_t token) {
     }
 }
 
+// Inside a string, a token that carries no '"' and no '\\' cannot change the
+// FSM state — the old shortcut concluded from that it must be legal and skipped
+// the whole-token simulation. It can still be ILLEGAL: JSON forbids raw control
+// characters (U+0000-U+001F) in strings, advance_char rejects them, and the
+// shortcut walked straight past that guard. A model then emitted a raw newline
+// inside a string and the reply did not parse (#1104).
+static bool string_token_needs_simulation(const std::string& text) {
+    for (char c : text) {
+        if (c == '"' || c == '\\' || static_cast<unsigned char>(c) < 0x20)
+            return true;
+    }
+    return false;
+}
+
 void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t stream) {
     if (!initialized_ || !d_token_categories_ || !d_allowed_mask_)
         return;
@@ -541,8 +600,7 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
             const std::string& text = token_texts_[i];
             if (token_categories_[i] == CAT_EOS) {
                 allow = 1;  // EOS already gated by the mask (DONE state only)
-            } else if (in_string && text.find('"') == std::string::npos &&
-                       text.find('\\') == std::string::npos) {
+            } else if (in_string && !string_token_needs_simulation(text)) {
                 allow = 1;
             } else {
                 allow = sim_token_valid(text) ? 1 : 0;
@@ -550,6 +608,34 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
         }
         token_allow_[i] = allow;
         n_allowed += allow;
+    }
+
+    // Force-close safety net: the narrowed mask offers only closers, and a
+    // closer is not legal in every state — after a key the grammar demands
+    // ':' and a value first. Narrowing there leaves nothing legal, which used
+    // to drop straight into the EOS guard below and end the reply mid-document
+    // with finish_reason="stop" (worse than the truncation it was meant to
+    // prevent). Retry once with the ordinary mask: force-close may help, it
+    // must never make the outcome worse.
+    if (n_allowed == 0 && force_close_active_) {
+        const int saved = remaining_budget_;
+        remaining_budget_ = -1;  // disable narrowing for this recompute
+        mask = compute_allowed_mask();
+        remaining_budget_ = saved;
+        for (int i = 0; i < n_classified; i++) {
+            uint8_t allow = 0;
+            if ((token_categories_[i] & mask) != 0) {
+                const std::string& text = token_texts_[i];
+                if (token_categories_[i] == CAT_EOS)
+                    allow = 1;
+                else if (in_string && !string_token_needs_simulation(text))
+                    allow = 1;
+                else
+                    allow = sim_token_valid(text) ? 1 : 0;
+            }
+            token_allow_[i] = allow;
+            n_allowed += allow;
+        }
     }
 
     // Empty-allow guard: if NOTHING passes (over-tight schema/state combo),

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -79,6 +79,12 @@ public:
     // Reset FSM for a new generation.
     void reset();
 
+    // Output tokens still available to the request. Once only just enough
+    // remain to close every open structure, the mask narrows to the closers so
+    // the document always ends well-formed instead of being truncated (#1104).
+    // -1 (default) disables the narrowing entirely.
+    void set_remaining_budget(int n) { remaining_budget_ = n; }
+
     // Check if initialized
     bool is_initialized() const { return initialized_; }
 
@@ -89,6 +95,12 @@ public:
     // true iff every char is a legal grammar continuation. Public for the
     // FSM unit tests; apply_mask uses it for whole-token validation.
     bool sim_token_valid(const std::string& text);
+
+    // Category mask the decode path would apply right now. Public for the FSM
+    // unit tests: apply_mask() needs an initialised GPU vocabulary, but the
+    // force-close narrowing (#1104) lives in this mask, not in the grammar
+    // simulator, so sim_token_valid() cannot observe it.
+    uint16_t allowed_categories_for_test() const { return compute_allowed_mask(); }
 
     // Advance the FSM over raw text (tests use this to reach mid-document
     // states; the decode path goes through update()).
@@ -148,6 +160,8 @@ private:
     bool num_seen_exp_ = false;     // an 'e'/'E' has been consumed
     bool num_exp_sign_ok_ = false;  // '+'/'-' legal only right after 'e'/'E'
     bool num_need_digit_ = false;   // a digit is required next (after '-', '.', 'e', sign)
+    int remaining_budget_ = -1;     // see set_remaining_budget
+    mutable bool force_close_active_ = false;  // last compute_allowed_mask() narrowed
     std::string partial_literal_;  // for tracking partial "true"/"false"/"null"
     std::string target_literal_;   // full expected literal
 

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -139,6 +139,15 @@ private:
     // Consecutive whitespace chars in non-string states (escape-hatch cap,
     // see advance_char/compute_allowed_mask).
     int ws_run_ = 0;
+    // JSON number sub-state (RFC 8259: [minus] int [frac] [exp]). Without it
+    // IN_NUMBER accepted '.', 'e', 'E', '+', '-' an unlimited number of times,
+    // so "3.5.5.5.5…" was a legal continuation and a model that wandered into
+    // a number could never be forced out of it — the request then ran to
+    // max_tokens and returned truncated, unparseable JSON (#1104).
+    bool num_seen_frac_ = false;    // a '.' has been consumed
+    bool num_seen_exp_ = false;     // an 'e'/'E' has been consumed
+    bool num_exp_sign_ok_ = false;  // '+'/'-' legal only right after 'e'/'E'
+    bool num_need_digit_ = false;   // a digit is required next (after '-', '.', 'e', sign)
     std::string partial_literal_;  // for tracking partial "true"/"false"/"null"
     std::string target_literal_;   // full expected literal
 
@@ -157,6 +166,7 @@ private:
 
     // Advance FSM by one character
     bool advance_char(char c);
+    void enter_number_(char c);  // seed the RFC 8259 number sub-state (#1104)
 };
 
 }  // namespace imp

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -1006,6 +1006,8 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                         f.phase = SchemaPhase::NUMBER_VALUE;
                         f.string_len = (c >= '0' && c <= '9') ? 1 : 0;  // digit count
                         f.num_leading_zero = (c == '0');                // "0..." forbids more int digits
+                        f.num_frac = f.num_exp = f.num_sign_ok = false;
+                        f.num_need_digit = (c == '-');  // a bare '-' still owes a digit
                         return true;
                     }
                     return false;
@@ -1288,19 +1290,46 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                 if (f.string_len == 0) {  // first digit (came after a leading '-')
                     f.num_leading_zero = (c == '0');
                     f.string_len = 1;
+                    f.num_need_digit = false;
                     return true;
                 }
                 if (f.num_leading_zero)
                     return false;  // JSON forbids leading zeros: `0` then digit
                 f.string_len++;
+                f.num_need_digit = false;
+                f.num_sign_ok = false;
                 return true;
             }
             if (!is_int && (c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-')) {
+                bool ok = false;
+                if (c == '.') {
+                    ok = !f.num_frac && !f.num_exp && !f.num_need_digit;
+                    if (ok) {
+                        f.num_frac = true;
+                        f.num_need_digit = true;
+                    }
+                } else if (c == 'e' || c == 'E') {
+                    ok = !f.num_exp && !f.num_need_digit;
+                    if (ok) {
+                        f.num_exp = true;
+                        f.num_sign_ok = true;
+                        f.num_need_digit = true;
+                    }
+                } else {  // '+' / '-'
+                    ok = f.num_sign_ok;
+                    if (ok) {
+                        f.num_sign_ok = false;
+                        f.num_need_digit = true;
+                    }
+                }
+                if (!ok)
+                    return false;
                 f.num_leading_zero = false;  // fractional/exponent part — int rule done
                 return true;
             }
-            // Any other char ends the number — legal only if >=1 digit was seen.
-            if (f.string_len == 0)
+            // Any other char ends the number — legal only if >=1 digit was seen
+            // and the number does not still owe one ("3.", "1e", "-").
+            if (f.string_len == 0 || f.num_need_digit)
                 return false;
             stk.pop_back();
             sim_fixup_parent(stk);

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -96,6 +96,15 @@ struct SchemaFrame {
     // (JSON forbids leading zeros: `0` is fine, `09` is not). Cleared once a
     // '.'/'e' is seen. Guards integer/number degeneration like `0999...`.
     bool num_leading_zero = false;
+
+    // RFC 8259 number sub-state. Without it the NUMBER_VALUE phase accepted
+    // '.', 'e', 'E', '+', '-' unconditionally, so "3.5.5.5…" was legal and a
+    // degenerating model could not be forced to close the number (#1104 —
+    // same defect as JsonConstrainer's IN_NUMBER).
+    bool num_frac = false;        // a '.' has been consumed
+    bool num_exp = false;         // an 'e'/'E' has been consumed
+    bool num_sign_ok = false;     // '+'/'-' legal only right after 'e'/'E'
+    bool num_need_digit = false;  // a digit is required next
 };
 
 class SchemaConstrainer {

--- a/src/exec/executor.cu
+++ b/src/exec/executor.cu
@@ -61,8 +61,13 @@ inline void apply_constraint_mask(const imp::InferenceState& st, float* logits, 
         st.regex_constrainer->apply_mask(logits, vocab, stream);
     else if (st.schema_constrainer)
         st.schema_constrainer->apply_mask(logits, vocab, stream);
-    else if (st.json_constrainer)
+    else if (st.json_constrainer) {
+        // Budget-aware close (#1104): hand the remaining output allowance to
+        // the FSM so it can force the document shut before max_tokens cuts it
+        // mid-structure. Harmless when the engine leaves it at -1.
+        st.json_constrainer->set_remaining_budget(st.constrain_remaining_tokens);
         st.json_constrainer->apply_mask(logits, vocab, stream);
+    }
 }
 
 }  // namespace

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -131,6 +131,13 @@ struct InferenceState {
     SchemaConstrainer* schema_constrainer = nullptr;
     RegexConstrainer* regex_constrainer = nullptr;
     GrammarConstrainer* grammar_constrainer = nullptr;
+    // Output tokens still available to this request (max_tokens - produced).
+    // A constrainer can forbid illegal tokens but cannot force termination, so
+    // a model that wanders — an unterminated string, a whitespace flood — runs
+    // to the limit and returns truncated, unparseable JSON. With the budget
+    // known, the mask narrows to the closers once only just enough tokens
+    // remain to shut the document (#1104). -1 = unknown, no narrowing.
+    int constrain_remaining_tokens = -1;
 
     // Logit bias (host-side, applied via cudaMemcpy before sampling)
     const std::pair<int32_t, float>* logit_bias = nullptr;

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -531,6 +531,9 @@ int Engine::step_constrained_pipeline() {
     //    last harvested token and uploaded stream-ordered behind the
     //    producer of those logits.
     p.state.seed = engine_internal::compute_step_seed(*req);
+    // Remaining output allowance for the force-close mask (#1104) — the
+    // pipeline keeps its own InferenceState, so it must be refreshed per tick.
+    p.state.constrain_remaining_tokens = req->max_tokens - static_cast<int>(req->output_tokens.size());
     // Think-budget enforcement (mirrors fill_sampling_params): when the
     // reasoning budget is exhausted mid-think, force </think> this step.
     p.state.force_token = -1;

--- a/src/runtime/engine_sampling_stop.cpp
+++ b/src/runtime/engine_sampling_stop.cpp
@@ -149,6 +149,9 @@ void Engine::fill_sampling_params(Request& req, InferenceState& state) const {
     state.frequency_penalty = req.frequency_penalty;
     state.presence_penalty = req.presence_penalty;
     state.repeat_last_n = req.repeat_last_n;
+    // Remaining output allowance — the JSON constrainer uses it to force the
+    // document closed before max_tokens truncates it mid-structure (#1104).
+    state.constrain_remaining_tokens = req.max_tokens - static_cast<int>(req.output_tokens.size());
     state.dry_multiplier = req.dry_multiplier;
     state.dry_base = req.dry_base;
     state.dry_allowed_length = req.dry_allowed_length;

--- a/tests/test_json_constrain_property.cpp
+++ b/tests/test_json_constrain_property.cpp
@@ -310,16 +310,28 @@ TEST(JsonConstrainFsm, NumberGrammarMatchesRfc8259) {
         const char* num;
         bool valid;
     };
-    const Case cases[] =
-        {
-            {"0", true},       {"-0", true},     {"3", true},    {"3.5", true},
-            {"1e5", true},     {"1E5", true},    {"1e+5", true}, {"1e-5", true},
-            {"-2.5e-3", true}, {"3.5.5", false},                // second decimal point — the #1104 shape
-            {"1e5e5", false},                                   // second exponent
-            {"1e+-5", false},                                   // double sign
-            {"3-5", false},                                     // sign inside the mantissa
-            {"1.2e", false},   {"3.", false},    {"-", false},  // incomplete: still owe a digit
-        };
+    const Case cases[] = {
+        {"0", true},
+        {"-0", true},
+        {"3", true},
+        {"3.5", true},
+        {"1e5", true},
+        {"1E5", true},
+        {"1e+5", true},
+        {"1e-5", true},
+        {"-2.5e-3", true},
+        {"3.5.5", false},  // second decimal point — the #1104 shape
+        {"1e5e5", false},  // second exponent
+        {"1e+-5", false},  // double sign
+        {"3-5", false},    // sign inside the mantissa
+        {"1.2e", false},
+        {"3.", false},
+        {"-", false},  // incomplete: still owe a digit
+        // Whitespace ends a number; it must never splice one back together.
+        {"1 ", true},
+        {"1.  1", false},
+        {"1.  ", false},
+    };
     for (const auto& c : cases) {
         JsonConstrainer fsm;
         // Wrap in an object so the number sits in a real value position, and
@@ -340,5 +352,58 @@ TEST(JsonConstrainFsm, SimulationDoesNotMutateNumberSubState) {
     EXPECT_TRUE(fsm.sim_token_valid("e5"));   // exponent still available afterwards
     EXPECT_TRUE(fsm.sim_token_valid("}"));    // and the number can still be closed
 }
+// --- #1104 part 2: force-close near the token budget ------------------------
+// The grammar fix alone still let a wandering model run to max_tokens inside a
+// long string, returning a truncated document. With the remaining allowance
+// known, the mask must narrow to the closers.
+TEST(JsonConstrainFsm, ForceCloseNarrowsMaskWhenBudgetIsSpent) {
+    // Deep inside a string value: {"a":"xxxx  → open object + open string.
+    // The narrowing is a MASK decision, so assert on the category mask —
+    // sim_token_valid() answers grammar legality, and "y" is legal in a string
+    // no matter how little budget is left.
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\":\"xxxx");
+
+    fsm.set_remaining_budget(100);
+    EXPECT_TRUE(fsm.allowed_categories_for_test() & CAT_STRING_CHAR)
+        << "narrowing engaged while the budget was comfortable";
+
+    fsm.set_remaining_budget(1);
+    const uint16_t tight = fsm.allowed_categories_for_test();
+    EXPECT_FALSE(tight & CAT_STRING_CHAR) << "string content still allowed with no budget left";
+    EXPECT_TRUE(tight & CAT_QUOTE) << "closing quote must stay available";
+
+    fsm.set_remaining_budget(-1);
+    EXPECT_TRUE(fsm.allowed_categories_for_test() & CAT_STRING_CHAR)
+        << "narrowing engaged with an unknown budget";
+}
+
+// Once the structures are closed the document must be completable, not stuck.
+TEST(JsonConstrainFsm, ForceCloseStillReachesAValidDocument) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\":\"xx");
+    fsm.set_remaining_budget(1);
+    ASSERT_TRUE(fsm.allowed_categories_for_test() & CAT_QUOTE);
+    fsm.advance_text("\"");  // close the string
+    EXPECT_TRUE(fsm.allowed_categories_for_test() & CAT_CLOSE_BRACE)
+        << "object closer unavailable after closing the string";
+    EXPECT_TRUE(fsm.sim_token_valid("}")) << "grammar rejects the closer the mask offers";
+}
+
+// #1104: raw control characters must never reach a string. The grammar has
+// always rejected them; apply_mask's in-string fast path skipped the check for
+// any token without a quote or a backslash, which is exactly what a newline
+// token is. Pinned at the grammar level here — the fast path is a GPU path,
+// but it now defers to the same rule.
+TEST(JsonConstrainFsm, RejectsRawControlCharsInsideStrings) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"k\":\"abc");
+    EXPECT_FALSE(fsm.sim_token_valid("\n")) << "raw newline accepted inside a string";
+    EXPECT_FALSE(fsm.sim_token_valid("de\nf")) << "raw newline accepted mid-token";
+    EXPECT_FALSE(fsm.sim_token_valid("\t")) << "raw tab accepted inside a string";
+    EXPECT_TRUE(fsm.sim_token_valid("def")) << "ordinary string content rejected";
+    EXPECT_TRUE(fsm.sim_token_valid("\\n")) << "ESCAPED newline must stay legal";
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_json_constrain_property.cpp
+++ b/tests/test_json_constrain_property.cpp
@@ -286,5 +286,59 @@ TEST(JsonConstrainPropertyTest, RejectsWrongCloserAtNestedDepth) {
     EXPECT_GT(exercised, 0) << "generator produced no nested closers — test is vacuous";
 }
 
+// --- #1104 probe: does the number FSM reject a second decimal point? --------
+// The live failure on Qwen3.6-35B-A3B-NVFP4 was `{"city":    3.5.5.5.5...`,
+// i.e. the mask admitted `.` inside an already-fractional number. If the FSM
+// itself accepts that, the bug is grammar-level and CPU-reproducible; if it
+// rejects it, the mask is right and something bypasses it at decode time.
+TEST(JsonConstrainFsm, RejectsSecondDecimalPointInNumber) {
+    JsonConstrainer c;
+    c.advance_text("{\"city\":");
+    EXPECT_TRUE(c.sim_token_valid("3.5")) << "FSM rejected a plain fractional number";
+
+    JsonConstrainer d;
+    d.advance_text("{\"city\": 3.5");
+    EXPECT_FALSE(d.sim_token_valid(".5"))
+        << "FSM accepted a SECOND decimal point — this is the #1104 output shape";
+    EXPECT_FALSE(d.sim_token_valid(".")) << "FSM accepted '.' after a fractional number";
+}
+
+// Full RFC 8259 number grammar, both directions. The permissive version
+// accepted every one of these malformed forms.
+TEST(JsonConstrainFsm, NumberGrammarMatchesRfc8259) {
+    struct Case {
+        const char* num;
+        bool valid;
+    };
+    const Case cases[] =
+        {
+            {"0", true},       {"-0", true},     {"3", true},    {"3.5", true},
+            {"1e5", true},     {"1E5", true},    {"1e+5", true}, {"1e-5", true},
+            {"-2.5e-3", true}, {"3.5.5", false},                // second decimal point — the #1104 shape
+            {"1e5e5", false},                                   // second exponent
+            {"1e+-5", false},                                   // double sign
+            {"3-5", false},                                     // sign inside the mantissa
+            {"1.2e", false},   {"3.", false},    {"-", false},  // incomplete: still owe a digit
+        };
+    for (const auto& c : cases) {
+        JsonConstrainer fsm;
+        // Wrap in an object so the number sits in a real value position, and
+        // require the document to close — an incomplete number must not be
+        // terminable by '}'.
+        const std::string doc = std::string("{\"v\":") + c.num + "}";
+        EXPECT_EQ(fsm.sim_token_valid(doc), c.valid)
+            << "number '" << c.num << "' judged " << (c.valid ? "invalid" : "valid")
+            << " — document: " << doc;
+    }
+}
+
+// The simulator must not leak number sub-state onto the live FSM.
+TEST(JsonConstrainFsm, SimulationDoesNotMutateNumberSubState) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"v\":3.5");
+    EXPECT_FALSE(fsm.sim_token_valid(".5"));  // walks into the number, then unwinds
+    EXPECT_TRUE(fsm.sim_token_valid("e5"));   // exponent still available afterwards
+    EXPECT_TRUE(fsm.sim_token_valid("}"));    // and the number can still be closed
+}
 }  // namespace
 }  // namespace imp

--- a/tests/test_schema_constrain_property.cpp
+++ b/tests/test_schema_constrain_property.cpp
@@ -222,5 +222,36 @@ TEST(SchemaConstrainPropertyTest, RejectsValueOutsideEnum) {
     EXPECT_FALSE(sc->token_legal(R"({"c":"redd"})"));  // valid prefix, invalid whole
 }
 
+// ===========================================================================
+// #1104 — the schema FSM carried the same permissive number grammar as
+// JsonConstrainer: '.', 'e', 'E', '+', '-' were accepted unconditionally in
+// NUMBER_VALUE, so "3.5.5.5…" was legal and a degenerating model could not be
+// forced to close the number. Live symptom: the reply ran to max_tokens and
+// came back as truncated, unparseable JSON.
+// ===========================================================================
+TEST(SchemaConstrainPropertyTest, NumberGrammarMatchesRfc8259) {
+    const std::string schema = R"({"type":"object","properties":{"v":{"type":"number"}},)"
+                               R"("required":["v"],"additionalProperties":false})";
+    struct Case {
+        const char* num;
+        bool valid;
+    };
+    const Case cases[] = {
+        {"0", true},      {"-0", true},   {"3", true},       {"3.5", true},    {"1e5", true},
+        {"1E5", true},    {"1e+5", true}, {"-2.5e-3", true}, {"3.5.5", false},  // second decimal point — the
+                                                                                // observed shape
+        {"1e5e5", false},                                // second exponent
+        {"1e+-5", false},                                // double sign
+        {"3.", false},    {"1e", false},  {"-", false},  // incomplete: still owe a digit
+    };
+    for (const auto& c : cases) {
+        auto sc = make_fsm(schema);
+        ASSERT_NE(sc, nullptr);
+        const std::string doc = std::string("{\"v\":") + c.num + "}";
+        EXPECT_EQ(sc->token_legal(doc), c.valid) << "number '" << c.num << "' judged "
+                                                 << (c.valid ? "invalid" : "valid") << " — document: " << doc;
+    }
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
Partly addresses #1104. Four genuine grammar defects, each CPU-reproducible with a test that fails before the change. **The issue stays open** — see "What this does not fix".

## The defects

**1. Number grammar accepted anything (both FSMs).** Once a number had started, `.`, `e`, `E`, `+`, `-` were admitted unconditionally with no record of what had already been seen:

```cpp
// json_constrain.cu:384 (before)
case JsonState::IN_NUMBER:
    if (!((c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-')) {
```

`3.5.5.5.5…` was therefore a *legal* continuation, so a model that slipped into a number could never be forced out of it and ran to `max_tokens`. `schema_constrain.cu:1298` carried the identical defect in `NUMBER_VALUE`, so `json_schema` failed the same way — fixing only `json_object` would have left half the surface broken.

**2. Whitespace spliced numbers back together.** `advance_char` skipped whitespace in every non-string state, so the FSM stayed in `IN_NUMBER` across it and the emitted text could interleave digits with spaces (`1.  1  1`) — internally consistent, not valid JSON.

**3. Raw control characters reached strings.** `advance_char` has always rejected them (`json_constrain.cu:422`), but `apply_mask`'s in-string fast path skipped whole-token simulation for any token without a quote or backslash — which is exactly what a newline token is. The shortcut walked straight past an existing guard.

**4. Nothing forced a document shut near `max_tokens`.** `closing_tokens_needed()` was documented as doing precisely that and was referenced nowhere in the tree.

## Fixes

RFC 8259 number sub-state in both FSMs (fraction seen, exponent seen, sign only right after `e`/`E`, outstanding digit obligation; an incomplete `3.` / `1e` / `-` can no longer be terminated by a structural char either). Whitespace now terminates a number. The fast path defers to the control-char rule. And the mask narrows to the closers once only just enough budget remains, driven by `InferenceState::constrain_remaining_tokens`, set per step on **both** the eager and the pipelined decode path.

Two traps worth recording, both caught by measurement rather than review:

- `sim_token_valid()` snapshots and restores FSM state around whole-token simulation; the new fields had to join that snapshot, or every simulated number would have corrupted the live FSM — a subtler bug than the one being fixed. `SimulationDoesNotMutateNumberSubState` pins it.
- The force-close estimate first used stack depth, but `state_stack_` holds only the return states of *nested* values — at `{"a"` it is empty while a `}` is still owed.

## Known gap in the force-close, stated not hidden

The distance to a valid ending is **state-dependent**: from `AFTER_KEY` the grammar demands `:` and a value before any closer is legal. Narrowing there leaves nothing legal and drops into the empty-allow guard, ending the reply mid-document with `finish_reason="stop"` — worse than the truncation it was meant to prevent. It therefore retries once with the ordinary mask before that guard runs, so force-close can help and can never make the outcome worse.

The real remedy is a per-state minimum-completion function (shortest legal path to a terminal state, and the next step along it). That is its own change with its own tests.

## What this does not fix

Measured on Qwen3.6-35B-A3B-NVFP4, first constrained request, 5 fresh starts each:

| build | unparseable replies |
|---|---|
| unmodified `main` | 3/5 |
| this branch | 3/5 |

The failure *shape* changed (`3.5.5.5.5…` became `3.59`), the rate did not. The dominant cause on this model is not the grammar — it is the model degenerating into a long string and hitting `max_tokens`, which no grammar can prevent and which the force-close cannot rescue from the states above.

## The structural finding

Three of the four defects exist because the grammar is implemented **more than once**: `advance_char` (the declared "single grammar source of truth"), the category mask, the fast-path heuristic, and separately again in the schema FSM. Each copy was missing a rule the others had.

`test_json_constrain_property.cpp` already generates random documents but only asserts the *acceptance* direction. A differential property test in both directions — anything a reference parser rejects, the FSM must reject — would have found all four at once. Recommended as the follow-up instead of a fifth patch.

## Verification

- `test-core`: 620 tests, 531 passed, 0 new failures (failing set byte-identical to the untouched baseline image).
- `verify-fast`: all stages green — decode −2.40%, pp512 −1.53%, pp4096 −1.82%, graphs-on gate 2.25x, degeneration smoke passed.