### PR TITLE
docs(memory): step 9 is complete — retire the superseded aggregate row

### DIFF
--- a/docs/MEMORY_ARCHITECTURE.md
+++ b/docs/MEMORY_ARCHITECTURE.md
@@ -1038,7 +1038,7 @@ design above, so the argument that produced the original shape stays readable.
 | 7b — VMM backend implementation | not started | |
 | 8 — `compute/` statics | not started | |
 | 9a — `--mem-report` with named charges | **done** | `feat(memory): --mem-report — name the charges the pool notes cannot see` |
-| 9b — admission control, `--vram-budget` as a cap, CI peak gate | not started | |
+| **A7 step 9 complete** (9a + 9b.1–9b.5) | | criterion 5 is *not* claimed — see B38 |
 
 ### I1 allowlist baseline
 


### PR DESCRIPTION
9b.1–9b.5 all landed in #1109 and #1110; the old aggregate `9b` row still read "not started". A stale line in a status table makes the whole table untrustworthy, which is the opposite of what it is for.

Criterion 5 stays explicitly unclaimed — AUDIT B38 records the ~1.8 GiB of un-migrated tenants plus the ~1.7 GiB CUDA context that a budget cannot cover.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8