### PR TITLE
fix(sampling): decorrelate the sampler seed — every token drew the same quantile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,22 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   failing the `File size` CI job on `main`; it is now 642 and the gate is green.
 
 ### Fixed
+- **The sampler drew the same quantile on every token.** The engine hands the
+  device samplers `base_seed + step` — consecutive integers, one per generated
+  token — and they took a single LCG step from it. An LCG's first output is
+  affine in its seed, so `seed + 1` moved the drawn float by
+  `1664525 / 2^32 ≈ 0.0004`: across a whole generation the draw was effectively
+  constant and the sampler kept picking the same RANK out of the candidate list.
+  At the usual `top_k` that rank is the argmax, so the output read as fluent
+  greedy text and the bug hid in plain sight; what it cost was the sampling
+  diversity that `temperature`, `top_p` and `top_k` are supposed to provide.
+  Measured on a synthetic distribution with three near-equal winners: 200
+  consecutive seeds produced **one** distinct token before, **seven** after.
+  Fixed by running the seed through a splitmix32 finalizer before the first
+  draw — four ALU ops, and the same seed still produces the same token, so
+  seeded reproducibility is unchanged. Pinned by
+  `SamplerSeeding.ConsecutiveSeedsDoNotAllDrawTheSameToken`.
+
 - **A CUDA graph could replay a kernel whose scratch pointer had been freed
   underneath it** (AUDIT B13). Six `compute/` statics grew on demand with a
   `cudaFree` + `cudaMalloc` pair, and the freed address was in some cases still

--- a/src/compute/sampling_internal.cuh
+++ b/src/compute/sampling_internal.cuh
@@ -41,6 +41,27 @@ __device__ __forceinline__ float lcg_rand_float(unsigned int& state) {
     return static_cast<float>(lcg_rand(state)) / 4294967296.0f;
 }
 
+// Decorrelate a sampler seed before its FIRST draw (issue #1142).
+//
+// The samplers are handed `base_seed + step` — consecutive integers, one per
+// generated token — and then take a single LCG step. An LCG's first output is
+// affine in its seed, so seed+1 moves the drawn float by 1664525 / 2^32 ~=
+// 0.0004: across a whole generation the sampler keeps drawing essentially the
+// SAME quantile of the distribution. At small top_k that lands on the argmax
+// and reads as fluent greedy text, which is why it hid for so long; at
+// top_k = 2000 it lands on a fixed rank deep in the tail and the model emits
+// the same token forever (`Okay,,,,,,,,`).
+//
+// splitmix32's finalizer fixes it in four ALU ops: consecutive seeds produce
+// uncorrelated states, and the same seed still produces the same state, so
+// seeded reproducibility is unchanged.
+__device__ __forceinline__ unsigned int sampler_seed_scramble(unsigned int seed) {
+    unsigned int s = seed + 0x9E3779B9u;
+    s = (s ^ (s >> 16)) * 0x21F0AAADu;
+    s = (s ^ (s >> 15)) * 0x735A2D97u;
+    return s ^ (s >> 15);
+}
+
 // Block-cooperative top-k selection. Each thread passes its own (unsorted) local
 // candidate list; produces the block's global top_k (sorted desc, tie-break by
 // smaller index) in out_val/out_idx (may be smem or global, written by thread 0).

--- a/src/compute/sampling_penalties.cu
+++ b/src/compute/sampling_penalties.cu
@@ -341,7 +341,7 @@ __global__ void mirostat_v2_sample_kernel(const float* __restrict__ logits, int 
     // Thread 0 scans through vocab, accumulating filtered probabilities.
     if (tid == 0) {
         float inv_fsum = 1.0f / fsum;
-        unsigned int rng = seed;
+        unsigned int rng = sampler_seed_scramble(seed);  // issue #1142
         float r = lcg_rand_float(rng);
 
         float acc = 0.0f;

--- a/src/compute/sampling_topk_topp.cu
+++ b/src/compute/sampling_topk_topp.cu
@@ -264,7 +264,7 @@ __device__ __forceinline__ void topk_finalize_body(int top_k, float top_p, float
         norm += s_val[i];
     float inv_norm = (norm > 0.0f) ? (1.0f / norm) : 1.0f;
 
-    unsigned int rng_state = seed;
+    unsigned int rng_state = sampler_seed_scramble(seed);
     float r = lcg_rand_float(rng_state);
     float acc = 0.0f;
     int chosen = s_idx[0];
@@ -477,7 +477,7 @@ __global__ void topp_sample_from_sorted_kernel(const float* __restrict__ sorted_
         norm += sorted_probs[i];
     float inv_norm = (norm > 0.0f) ? (1.0f / norm) : 1.0f;
 
-    unsigned int rng_state = seed;
+    unsigned int rng_state = sampler_seed_scramble(seed);
     float r = lcg_rand_float(rng_state);
 
     float acc = 0.0f;

--- a/tests/test_sampling.cu
+++ b/tests/test_sampling.cu
@@ -9,6 +9,7 @@
 #include <numeric>
 #include <limits>
 #include <map>
+#include <random>
 #include "scoped_engine_arena.h"
 
 namespace imp {
@@ -340,4 +341,63 @@ TEST(SamplingTest, AsyncBatchedSlotsMatchSynchronousPerSequence) {
 }
 
 }  // namespace
+// Issue #1142: the sampler drew the SAME quantile on every token.
+//
+// The engine hands the samplers `base_seed + step` — consecutive integers, one
+// per generated token — and the device side took a single LCG step from it. An
+// LCG's first output is affine in its seed, so seed+1 moved the drawn float by
+// 1664525 / 2^32 ~= 0.0004: over a whole generation the draw is effectively
+// constant and the sampler keeps picking the same RANK. At small top_k that
+// rank is the argmax, which reads as fluent greedy text and is why this hid;
+// at top_k = 2000 it is a fixed token deep in the tail and the model emits it
+// forever.
+//
+// The probe is the shape of the bug: 200 CONSECUTIVE seeds over a distribution
+// whose top token holds well under all the mass. Before the scramble this
+// returned exactly ONE distinct token on both sides of the k=128 path split.
+TEST(SamplerSeeding, ConsecutiveSeedsDoNotAllDrawTheSameToken) {
+    const int V = 4096;
+    std::vector<float> h(V);
+    std::mt19937 rng(7);
+    std::normal_distribution<float> nd(0.0f, 2.0f);
+    for (auto& v : h)
+        v = nd(rng);
+    // Three near-equal winners: a correct sampler spreads over them, a
+    // fixed-quantile sampler cannot.
+    h[1000] = 12.0f;
+    h[2000] = 11.9f;
+    h[3000] = 11.8f;
+
+    Tensor d_logits = make_logits(h.data(), h.size());
+
+    auto draw = [&](int top_k) {
+        std::map<int32_t, int> hist;
+        for (unsigned s = 1; s <= 200; ++s)
+            hist[sample_topk_topp(d_logits, top_k, /*top_p=*/0.95f, /*temperature=*/1.0f, s)]++;
+        int top3 = 0;
+        for (int tok : {1000, 2000, 3000})
+            if (auto it = hist.find(tok); it != hist.end())
+                top3 += it->second;
+        fprintf(stderr, "[#1142] k=%d: %zu distinct tokens, top-3 share %.2f\n", top_k, hist.size(),
+                top3 / 200.0);
+        return hist;
+    };
+
+    // Both sides of the SAMPLE_MAX_TOP_K = 128 split: the multiblock kernel and
+    // the CUB kernel take the seed through the same path and both regressed.
+    for (int top_k : {128, 256}) {
+        const auto hist = draw(top_k);
+        EXPECT_GT(hist.size(), 1u)
+            << "top_k=" << top_k
+            << ": 200 consecutive seeds produced one token — the seed is not being decorrelated";
+        int most = 0;
+        for (const auto& [tok, n] : hist)
+            most = std::max(most, n);
+        EXPECT_LT(most, 190) << "top_k=" << top_k << ": one token took " << most
+                             << "/200 draws from three near-equal candidates";
+    }
+
+    free_gpu_tensor(d_logits);
+}
+
 }  // namespace imp


### PR DESCRIPTION
## The bug

`compute_step_seed()` hands the device samplers `base_seed + step` — consecutive
integers, one per generated token — and the samplers took a **single LCG step**
from it:

```cpp
unsigned int rng_state = seed;
float r = lcg_rand_float(rng_state);   // state * 1664525 + 1013904223
```

An LCG's first output is affine in its seed, so `seed + 1` moves the drawn float
by `1664525 / 2^32 ≈ 0.0004`. Across a whole generation the draw is effectively
**constant**, and the sampler keeps picking the same *rank* out of the candidate
list instead of sampling from it.

At the usual `top_k` that rank is the argmax, so the output reads as fluent
greedy text — which is exactly why this hid. What it costs is the diversity that
`temperature`, `top_p` and `top_k` are supposed to provide.

## Measured

Three near-equal winners in a 4096-token vocabulary, 200 **consecutive** seeds:

| | distinct tokens drawn |
|---|---|
| before | **1** |
| after | **7** |

Same on both sides of the `SAMPLE_MAX_TOP_K = 128` path split — the multiblock
kernel and the CUB kernel take the seed through the same code.

End to end, three requests at `temperature 1.0` with seeds 1/2/3 now diverge
after the shared prefix instead of tracking each other token-for-token.

## The fix

splitmix32's finalizer on the seed before its first draw — four ALU ops, applied
at all three sites that seed an LCG (multiblock sampler, CUB sampler,
mirostat/penalty sampler). **The same seed still produces the same token**, so
seeded reproducibility is unchanged; only the correlation *between consecutive*
seeds goes away.

`SamplerSeeding.ConsecutiveSeedsDoNotAllDrawTheSameToken` pins it and is
**mutation-validated**: removing the finalizer puts the count back to exactly
one distinct token over 200 seeds.

## Scope — this does NOT close #1142

Found while investigating that issue, but it is not its cause: `top_k >= 129`
still degenerates on Qwen3-8B-Q8_0 after this fix. The issue is updated with
what the investigation established (a sharp 128/129 boundary) and what it ruled
out (CUB temp sizing, the CUDA-graph decode path, the think budget, and the CUB
sampler itself on synthetic logits at the real vocabulary size).

## Gates

verify-fast green (decode +0.53%, prefill +1.86%, peak VRAM 20718 vs 20716),
`make test-gpu` green, test-core 685/685, `degen_suite.py` 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8