### PR TITLE
fix(sampling): top_k above 128 sampled the previous step's candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,21 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   failing the `File size` CI job on `main`; it is now 642 and the gate is green.
 
 ### Fixed
+- **`top_k` above 128 sampled from the PREVIOUS decode step's candidates**
+  (issue #1142). Requests over `SAMPLE_MAX_TOP_K` take a CUB path that ran
+  `cub::DeviceTopK::MaxPairs` to pick the candidates and then radix-sorted just
+  those. Instrumented on Qwen3-8B-Q8_0 at `top_k=129`, that call fills all 129
+  slots on the first invocation, writes **nothing** on the second while still
+  returning `cudaSuccess`, and from the fourth fails permanently with
+  `invalid device ordinal` — same thread, same stream, device 0, no pending
+  error beforehand. Nothing checked the return code, so the sampler kept
+  drawing from whatever the previous step had left in the buffer, and the model
+  emitted `Okay,,,,,,,,` for the rest of the budget. The two-step plan is
+  replaced by one full-vocabulary descending sort — the scratch was already
+  sized for it — and the return code is now checked. `degen_suite.py` gains
+  `top_k` 129 and 2000 cases; the whole path had no coverage, which is why this
+  shipped.
+
 - **The sampler drew the same quantile on every token.** The engine hands the
   device samplers `base_seed + step` — consecutive integers, one per generated
   token — and they took a single LCG step from it. An LCG's first output is

--- a/src/compute/sampling_topk_topp.cu
+++ b/src/compute/sampling_topk_topp.cu
@@ -530,22 +530,12 @@ struct CubSortScratch {
         d_vals_in = reinterpret_cast<int32_t*>(vi.data());
         d_vals_out = reinterpret_cast<int32_t*>(vo.data());
         d_max_sum = reinterpret_cast<float*>(ms.data());
-        // Query CUB temp storage requirements: take max of full RadixSort
-        // (fallback) and DeviceTopK (preferred) + a small RadixSort over the
-        // top-K results (to produce sorted output for top-p).
+        // Query CUB temp storage: one full-vocabulary descending radix sort.
+        // (The DeviceTopK + small-sort plan this used to size for is gone —
+        // see the sampler for why, issue #1142.)
         temp_bytes = 0;
-        size_t rs_full_bytes = 0;
-        cub::DeviceRadixSort::SortPairsDescending(nullptr, rs_full_bytes, d_keys_in, d_keys_out, d_vals_in,
+        cub::DeviceRadixSort::SortPairsDescending(nullptr, temp_bytes, d_keys_in, d_keys_out, d_vals_in,
                                                   d_vals_out, vocab_size, 0, 32, stream);
-        size_t topk_bytes = 0;
-        cub::DeviceTopK::MaxPairs(nullptr, topk_bytes, d_keys_in, d_keys_out, d_vals_in, d_vals_out,
-                                  vocab_size, vocab_size,
-                                  ::cuda::execution::require(::cuda::execution::determinism::not_guaranteed,
-                                                             ::cuda::execution::output_ordering::unsorted));
-        size_t rs_topk_bytes = 0;
-        cub::DeviceRadixSort::SortPairsDescending(nullptr, rs_topk_bytes, d_keys_in, d_keys_out, d_vals_in,
-                                                  d_vals_out, vocab_size, 0, 32, stream);
-        temp_bytes = std::max({rs_full_bytes, topk_bytes, rs_topk_bytes});
         auto tmp = engine_arena().take_bytes(temp_bytes);
         if (tmp.empty()) {
             *this = CubSortScratch{};
@@ -621,37 +611,36 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
                                                                            sc.d_keys_in, sc.d_vals_in);
     IMP_CUDA_CHECK_LAUNCH();
 
-    // Step 3: extract top_k via DeviceTopK (unsorted), then sort just those k.
-    // Much faster than a full radix sort over the whole vocab when k << vocab.
+    // Step 3: sort the whole vocabulary by probability, descending. The top_k
+    // entries the sampler needs are then simply the head of the result.
     //
-    // TODO(determinism): even in deterministic mode the candidate SET and the
-    // subsequent descending radix sort by probability are reproducible (the
-    // FP sum above is now fixed-order, and the probs are a pure function of the
-    // logits), so the sampled token is reproducible for distinct
-    // probabilities. The one residual gap is exact ties: DeviceTopK is invoked
-    // with determinism::not_guaranteed and SortPairsDescending on equal keys is
-    // not guaranteed stable on the int32 value, so two tokens with bit-identical
-    // probability could swap order between runs. For a fully tie-stable top-k
-    // here, fold the vocab index into the sort key (e.g. sort by (prob, -index))
-    // or request cub determinism::guaranteed when this stochastic path needs
-    // bit-exact reproducibility under ties. The single-block path
-    // (top_k <= MAX_TOP_K) already tie-breaks by index and is fully
-    // deterministic; this CUB path only runs for top_k > MAX_TOP_K (128).
+    // This used to run cub::DeviceTopK::MaxPairs first and radix-sort only the
+    // k survivors, which is asymptotically the better plan when k << vocab.
+    // It is gone because it does not work here (issue #1142): instrumented on
+    // Qwen3-8B-Q8_0 at top_k=129, MaxPairs writes all 129 slots on the first
+    // call, writes NOTHING on the second while still returning cudaSuccess,
+    // and from the fourth call on fails permanently with `invalid device
+    // ordinal` — same thread, same stream, device 0, no pending error before
+    // the call. The stale candidates left behind are what the model then
+    // samples from, which is the `Okay,,,,,,,,` loop the issue reports.
+    //
+    // Nothing checked the return code, so the failure was silent. The full
+    // sort is one well-trodden CUB entry point instead of two, the scratch is
+    // already sized for it (`rs_full_bytes` in ensure()), and it only runs at
+    // all when a request asks for top_k > MAX_TOP_K, which is rare and which
+    // the caller has already opted into paying for.
     {
-        size_t tk_bytes = sc.temp_bytes;
-        cub::DeviceTopK::MaxPairs(sc.d_temp, tk_bytes, sc.d_keys_in, sc.d_keys_out, sc.d_vals_in,
-                                  sc.d_vals_out, vocab_size, top_k,
-                                  ::cuda::execution::require(::cuda::execution::determinism::not_guaranteed,
-                                                             ::cuda::execution::output_ordering::unsorted));
         size_t rs_bytes = sc.temp_bytes;
-        // In-place sort: copy outputs back to inputs as the source for the
-        // small sort, write sorted result to outputs.
-        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(sc.d_keys_in, sc.d_keys_out, top_k * sizeof(float),
-                                           cudaMemcpyDeviceToDevice, stream));
-        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(sc.d_vals_in, sc.d_vals_out, top_k * sizeof(int32_t),
-                                           cudaMemcpyDeviceToDevice, stream));
-        cub::DeviceRadixSort::SortPairsDescending(sc.d_temp, rs_bytes, sc.d_keys_in, sc.d_keys_out,
-                                                  sc.d_vals_in, sc.d_vals_out, top_k, 0, 32, stream);
+        cudaError_t rc = cub::DeviceRadixSort::SortPairsDescending(sc.d_temp, rs_bytes, sc.d_keys_in,
+                                                                   sc.d_keys_out, sc.d_vals_in, sc.d_vals_out,
+                                                                   vocab_size, 0, 32, stream);
+        if (rc != cudaSuccess) {
+            IMP_LOG_ERROR(
+                "sample_topk_topp_cub: CUB sort failed (%s) for vocab=%d top_k=%d — no token "
+                "sampled",
+                cudaGetErrorString(rc), vocab_size, top_k);
+            return 0;
+        }
     }
 
     // Step 4: Top-p filter + sample from sorted top-k

--- a/tests/test_sampling.cu
+++ b/tests/test_sampling.cu
@@ -400,4 +400,46 @@ TEST(SamplerSeeding, ConsecutiveSeedsDoNotAllDrawTheSameToken) {
     free_gpu_tensor(d_logits);
 }
 
+// Issue #1142: the CUB path (top_k > SAMPLE_MAX_TOP_K) served STALE candidates.
+//
+// cub::DeviceTopK::MaxPairs filled its output on the first call, wrote nothing
+// on the second while still returning cudaSuccess, and failed permanently with
+// `invalid device ordinal` from the fourth — all on one thread, one stream,
+// device 0. Nobody checked the return code, so the sampler kept drawing from
+// whatever the previous call had left in the buffer. On a real model that is a
+// token loop; every existing test missed it for one reason:
+//
+//   THE LOGITS HAVE TO CHANGE BETWEEN CALLS. Feed the same distribution twice
+//   and the stale candidates ARE the correct candidates, so a broken run is
+//   indistinguishable from a working one. This test moves the winner every
+//   iteration, which is what a real decode step does.
+TEST(SamplerCubPath, EachCallSamplesFromItsOwnLogitsNotThePreviousCalls) {
+    const int V = 151936;   // the vocabulary the issue was reported on
+    const int top_k = 200;  // > SAMPLE_MAX_TOP_K, so the CUB path runs
+    std::vector<float> h(V, -20.0f);
+
+    int wrong_step = -1, wrong_token = -1, expected = -1;
+    for (int step = 0; step < 12 && wrong_step < 0; ++step) {
+        // One unmistakable winner, moved to a fresh place every step.
+        const int winner = 1000 + step * 7919;
+        std::fill(h.begin(), h.end(), -20.0f);
+        h[winner] = 30.0f;
+
+        Tensor d_logits = make_logits(h.data(), h.size());
+        const int32_t got = sample_topk_topp(d_logits, top_k, /*top_p=*/0.95f, /*temperature=*/0.7f,
+                                             1234u + step);
+        free_gpu_tensor(d_logits);
+
+        if (got != winner) {
+            wrong_step = step;
+            wrong_token = got;
+            expected = winner;
+        }
+    }
+
+    EXPECT_EQ(wrong_step, -1) << "step " << wrong_step << " sampled token " << wrong_token
+                              << " but its logits put all the mass on " << expected
+                              << " — the candidate list came from an earlier call";
+}
+
 }  // namespace imp

--- a/tools/analysis/degen_suite.py
+++ b/tools/analysis/degen_suite.py
@@ -432,6 +432,24 @@ class Suite:
         self.record("repetition", "temp=1.2 finish_reason set",
                     r["finish"] in ("stop", "length"), f"finish={r['finish']}")
 
+        # Large top_k — the CUB sampler path (> SAMPLE_MAX_TOP_K = 128). It had
+        # NO coverage here, which is why issue #1142 shipped: DeviceTopK served
+        # STALE candidates from the previous decode step and the model emitted
+        # `Okay,,,,,,,,` for the whole budget, while every top_k the battery
+        # used stayed on the multiblock path and looked fine. Two values, one
+        # just past the boundary and one far past it.
+        for k in (129, 2000):
+            r = self.srv.chat(
+                [{"role": "user", "content": "Name three seas."}],
+                max_tokens=n, temperature=0.9, seed=42, top_k=k,
+            )
+            text = r["reasoning"] + " " + r["content"]
+            self.record("repetition", f"top_k={k} (CUB path) loop-free",
+                        not ngram_loop(text) and max_token_run(text) <= 8,
+                        text[-160:].replace("\n", " "))
+            self.record("repetition", f"top_k={k} vocabulary diversity > 0.25",
+                        unique_ratio(text) > 0.25, f"ratio={unique_ratio(text):.2f}")
+
     # -- think-leak ---------------------------------------------------------
     def cat_think_leak(self):
         if not self.is_reasoning:


### PR DESCRIPTION
Closes #1142.

## What was happening

Requests with `top_k > SAMPLE_MAX_TOP_K` take a CUB path that picked candidates
with `cub::DeviceTopK::MaxPairs` and then radix-sorted just those k.
Instrumented on Qwen3-8B-Q8_0 at `top_k=129`:

| call | result |
|---|---|
| 1 | fills all 129 slots |
| 2 | writes **nothing** — and returns `cudaSuccess` |
| 4+ | fails permanently with **`invalid device ordinal`** |

One thread, one stream, device 0, no pending error before the call (all logged).
**Nothing checked the return code**, so the sampler kept drawing from whatever
the previous decode step had left in the buffer. The probe that found it shows
step 3's candidate list still carrying step 1's entries, duplicated:

```
step 1  head p/idx: 0.999882/0  0.000118/11  4.0e-09/6313  ...
step 3  head p/idx: 0.999979/5692  0.999882/0  0.000118/11  ...
                    ^ this step     ^^^^^^^^^^^^^^^^^^^^^^^ step 1's, still there
```

On a real model that is the `Okay,,,,,,,,` loop the issue reports.

## The fix

One full-vocabulary descending sort instead of top-k-then-sort. The scratch was
**already sized for exactly that** (`rs_full_bytes` was the max of the three
temp queries), so this removes a CUB entry point rather than adding one, and the
return code is now checked instead of discarded. The extra cost is a full sort,
on a path that only runs when a request explicitly asks for `top_k > 128`.

Verified on the reported repro — `top_k` 40 / 129 / 500 / 2000 all coherent,
where 129 and up previously looped:

```
k=129: '1. Mediterranean Sea  \n2. Caribbean Sea  \n3. South China Sea'
k=2000: '1. Mediterranean Sea  \n2. Caribbean Sea  \n3. South China Sea'
```

## What this ruled out along the way

So the next reader does not re-chase them — each measured, not reasoned:

- **CUB temp sizing** — flat at 28 671 B for k ∈ {128, 2000, 20000, V} at
  V=151936, and the reserve is the max over all three queries.
- **The CUDA-graph decode path** — reproduces with `cuda_graphs=never`.
- **The think budget** — reproduces with `think_budget: 0` (the `</think>` spam
  in the output made this the obvious suspect; it is not it).
- **The CUB sampler on synthetic logits** — at V=151936 it puts 90–95 % of draws
  on the winners for k ∈ {128, 129, 2000}.
- **Filter ordering** — both paths call the same `apply_row_filters_`.
- **Seed correlation** — a real bug, fixed separately in #1143, but not this one.

## Coverage, stated honestly

`degen_suite.py` gains `top_k` 129 and 2000 cases. **The path had none**, which
is why this shipped: every value the battery used stayed on the multiblock path.
Run against a main-built image the new cases do catch it (`top_k=2000`,
vocabulary ratio **0.20** against the 0.25 floor).

That guard is **stochastic** — the underlying CUB failure is state-dependent and
`top_k=129` passed on main in the same run. The deterministic guard is the code
change itself (a plain radix sort has no such failure mode) plus the checked
return code.

The unit test `SamplerCubPath.EachCallSamplesFromItsOwnLogitsNotThePreviousCalls`
pins the contract — each call must sample from its own logits, with the winner
moving between calls, because feeding the same distribution twice makes a broken
run indistinguishable from a working one. **It does not reproduce the original
failure in the test harness**; the reproduction is the server-level one above.

## Gates

verify-fast green (decode +0.01%, prefill +1.41%, peak VRAM 20718 vs 20716),
`make test-gpu` green, test-core 685/685, `degen_suite.py` 41/41 plus the four
new checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8