### PR TITLE
fix(constrain): reserve the JSON allow list at init, never mask silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,21 @@ All notable changes since v0.6. Format loosely follows [Keep a Changelog](https:
   failing the `File size` CI job on `main`; it is now 642 and the gate is green.
 
 ### Fixed
+- **The first `response_format` request after a model load could come back
+  unconstrained** (issue #1104). `JsonConstrainer` allocated its per-token allow
+  list lazily inside `apply_mask()` — on the serving path, mid-decode — and on a
+  model that loads with almost no free VRAM left the allocation failed, at which
+  point `apply_mask` returned **without applying any mask and without logging**.
+  The reply then decoded unconstrained: prose where JSON was promised,
+  deterministic and byte-identical across restarts, first request per process
+  only (later ones found memory and worked), and invisible in
+  `imp_constrained_eager_fallback_total` because no fallback was taken. The
+  three sibling constrainers — regex, grammar, schema — have always allocated
+  this at init and failed the load loudly; the JSON one was the outlier. It now
+  does the same, and the unreachable path logs instead of masking nothing.
+  Verified against a `main` build on the reported model
+  (Qwen3.6-35B-A3B-NVFP4): request 1 invalid there, valid here.
+
 - **`top_k` above 128 sampled from the PREVIOUS decode step's candidates**
   (issue #1142). Requests over `SAMPLE_MAX_TOP_K` take a CUB path that ran
   `cub::DeviceTopK::MaxPairs` to pick the candidates and then radix-sorted just

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -1,6 +1,8 @@
 #include "compute/json_constrain.h"
 #include "compute/constrain_common.h"
 #include "core/logging.h"
+
+#include <mutex>
 #include <cuda_runtime.h>
 #include <cfloat>
 #include <cstring>
@@ -69,6 +71,24 @@ bool JsonConstrainer::init(const Tokenizer& tok) {
     err = cudaMalloc(&d_allowed_mask_, sizeof(uint16_t));
     if (err != cudaSuccess) {
         IMP_LOG_ERROR("JsonConstrainer: failed to allocate mask buffer: %s", cudaGetErrorString(err));
+        return false;
+    }
+
+    // Per-token allow list. Allocated HERE, not on first use (issue #1104).
+    // The lazy version allocated it inside apply_mask() — i.e. mid-decode, on
+    // the serving path — and on a model that loads with no free VRAM left
+    // (#1103) the allocation failed and apply_mask returned WITHOUT applying
+    // any mask and without logging. The request then decoded unconstrained and
+    // returned prose where JSON was promised: deterministic, first request per
+    // process, invisible in `imp_constrained_eager_fallback_total` because no
+    // fallback was taken. The three sibling constrainers (regex, grammar,
+    // schema) have always allocated this at init and failed the load loudly;
+    // this one was the outlier.
+    err = cudaMalloc(&d_token_allow_, static_cast<size_t>(vocab_size_));
+    if (err != cudaSuccess) {
+        IMP_LOG_ERROR("JsonConstrainer: failed to allocate the %d-token allow list: %s", vocab_size_,
+                      cudaGetErrorString(err));
+        d_token_allow_ = nullptr;
         return false;
     }
 
@@ -651,13 +671,26 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
     }
 
     if (!d_token_allow_) {
-        if (cudaMalloc(&d_token_allow_, vocab_size) != cudaSuccess) {
-            d_token_allow_ = nullptr;
-            return;
-        }
+        // Unreachable after a successful initialize(), which is the point: a
+        // constrainer that cannot mask must SAY so rather than let the request
+        // decode unconstrained and look like a model that ignored the schema
+        // (issue #1104).
+        static std::once_flag once;
+        std::call_once(once, [] {
+            IMP_LOG_ERROR(
+                "JsonConstrainer: no device allow list — the reply will NOT be constrained. "
+                "This should be impossible after initialize(); please report it.");
+        });
+        return;
     }
+    // Clamp to what initialize() reserved. The model's lm_head can be WIDER
+    // than the tokenizer (padding rows), and the host list is sized to the
+    // model — but the kernel returns before touching token_allow[idx] for
+    // idx >= n_classified, so the tokenizer-sized device buffer is exactly
+    // enough and copying the model width would run off the end of it.
+    const size_t allow_bytes = std::min(static_cast<size_t>(vocab_size), static_cast<size_t>(vocab_size_));
     IMP_CUDA_CHECK_LOG(
-        cudaMemcpyAsync(d_token_allow_, token_allow_.data(), vocab_size, cudaMemcpyHostToDevice, stream));
+        cudaMemcpyAsync(d_token_allow_, token_allow_.data(), allow_bytes, cudaMemcpyHostToDevice, stream));
 
     uint16_t any_mask = 0xFFFF;  // per-token allow already encodes the category mask
     IMP_CUDA_CHECK_LOG(

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -134,6 +134,12 @@ public:
                                        std::move(close_suffix), thinking_open);
     }
 
+    // Is the per-token allow list resident? True after a successful
+    // initialize() and never false again — the point of issue #1104, where it
+    // was allocated lazily inside apply_mask() and a failure there produced a
+    // silently UNCONSTRAINED reply instead of a refused one.
+    bool has_device_allow_list() const { return d_token_allow_ != nullptr; }
+
 private:
     bool initialized_ = false;
     int vocab_size_ = 0;

--- a/tests/test_json_constrain.cu
+++ b/tests/test_json_constrain.cu
@@ -641,5 +641,48 @@ TEST(JsonConstrainTest, ModelVocabLargerThanTokenizerMasksPadding) {
     }
 }
 
+// Issue #1104: a constrainer that cannot mask must never decode SILENTLY
+// unconstrained.
+//
+// The device allow list used to be allocated lazily inside apply_mask() — on
+// the serving path, mid-decode. On a model that loads with no free VRAM left
+// (#1103) that allocation failed and apply_mask returned without masking and
+// without logging, so the first constrained request per process came back as
+// prose where JSON was promised: deterministic, byte-identical across restarts,
+// and invisible in `imp_constrained_eager_fallback_total` because no fallback
+// was taken. The three sibling constrainers (regex, grammar, schema) have
+// always allocated this at init and failed the load loudly.
+//
+// This pins the property that makes the failure impossible rather than
+// unlikely: after init() reports success, the allow list is already resident.
+TEST(JsonConstrainTest, InitReservesTheAllowListSoApplyMaskNeverAllocates) {
+    SKIP_IF_NO_CUDA();
+
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "{", "\"", "}", "0"};
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+
+    JsonConstrainer jc;
+    ASSERT_TRUE(jc.init(tok));
+    EXPECT_TRUE(jc.has_device_allow_list())
+        << "init() succeeded without reserving the allow list — apply_mask would allocate on the "
+           "serving path, and a failure there masks nothing at all (issue #1104)";
+
+    // And the very first apply_mask already constrains: no warm-up call needed.
+    const int vocab = static_cast<int>(toks.size());
+    std::vector<float> h(vocab, 1.0f);
+    float* d = nullptr;
+    ASSERT_EQ(cudaMalloc(&d, vocab * sizeof(float)), cudaSuccess);
+    cudaMemcpy(d, h.data(), vocab * sizeof(float), cudaMemcpyHostToDevice);
+    jc.apply_mask(d, vocab, 0);
+    cudaDeviceSynchronize();
+    cudaMemcpy(h.data(), d, vocab * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d);
+
+    EXPECT_GT(h[3], -1e30f) << "'{' must open the document on the FIRST masked step";
+    EXPECT_FLOAT_EQ(h[5], -FLT_MAX) << "'}' cannot open a document — the first step must already mask";
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
Closes #1104.

## What was happening

`JsonConstrainer` allocated its per-token allow list **lazily inside
`apply_mask()`** — on the serving path, mid-decode — and the failure path was:

```cpp
if (cudaMalloc(&d_token_allow_, vocab_size) != cudaSuccess) {
    d_token_allow_ = nullptr;
    return;                      // no mask, no log
}
```

On a model that loads with almost no free VRAM left, that allocation fails and
the request decodes **unconstrained**. It accounts for every observation in the
issue:

| observation | explanation |
|---|---|
| deterministic, byte-identical across restarts | unconstrained greedy at `temperature: 0` |
| first request per process only | later requests find memory and succeed |
| 35B NVFP4 affected, small Q8 model not | the 35B loads at ~640 MiB free |
| `imp_constrained_eager_fallback_total == 0` | no fallback was taken — it is a silent no-op |

The three sibling constrainers — regex, grammar, schema — have **always**
allocated this buffer in `initialize()` and failed the load loudly. The JSON one
was the outlier.

## The fix

Allocate it in `initialize()` like the siblings, and make the now-unreachable
path in `apply_mask()` log once instead of masking nothing. A constrainer that
cannot constrain must say so rather than hand back a plausible-looking reply.

The copy is clamped to the reserved size: the model's `lm_head` can be **wider**
than the tokenizer, the host list is sized to the model, and the kernel returns
before touching `token_allow[idx]` for `idx >= n_classified` — so the
tokenizer-sized buffer is exactly enough, and copying the model width would run
off the end of it. `ModelVocabLargerThanTokenizerMasksPadding` covers that case
and passes.

## Verified against the reported repro

`main`-built image vs this branch, model from the issue
(`Qwen3.6-35B-A3B-NVFP4`, `IMP_KV_FP8=1`), the issue's exact four sequential
`json_object` requests at `temperature: 0`:

```
main    req 1: INVALID  '{"city": \n   \n\n\n\n\n\n\n{"city": \n   \n\n\n...'
        req 2: VALID    req 3: VALID

this    req 1: VALID    '{\n \t"city":\t"Berlin",\n \t"population":\t3677472\n}'
        req 2-4: VALID
```

## Test

`JsonConstrainTest.InitReservesTheAllowListSoApplyMaskNeverAllocates` pins the
property that makes the failure impossible rather than unlikely — after `init()`
reports success the allow list is resident, and the *first* `apply_mask` already
constrains. **Mutation-validated**: putting the allocation back into
`apply_mask` fails it with exactly that message.

## Gates

verify-fast green (decode +0.48%, prefill +2.07%, peak VRAM 20718 vs 20716),
`make test-gpu` green, test-core 685/685, alloc-sites and file-size gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8