### PR TITLE
fix(loader): flatten >4-D tensors instead of silently dropping them

### DIFF
--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -421,15 +421,38 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
         }
 
         int ndim = static_cast<int>(shape_val->arr.size());
-        if (ndim > kMaxDims) {
-            n_dropped_too_many_dims++;
-            warn_drop(tensor_name.c_str(), "shape ndim exceeds engine kMaxDims");
-            continue;
-        }
-
         int64_t shape[kMaxDims] = {};
-        for (int d = 0; d < ndim; d++) {
-            shape[d] = shape_val->arr[d].as_int();
+        if (ndim > kMaxDims) {
+            // Was: drop with a WARN. That loses a weight and only says so in a
+            // log line — Qwen3-VL's patch embed is [1024, 3, 2, 16, 16] and
+            // vanished exactly that way.
+            //
+            // Flatten the trailing dims into dim 1 instead: [d0, d1..dn] ->
+            // [d0, d1*..*dn]. The element order is untouched (row-major), so
+            // this is a pure reinterpretation, and it is the only shape imp's
+            // GEMM path could consume in any case. It is also the RIGHT shape
+            // for the tensors that actually arrive this way: a patch-embed
+            // convolution whose kernel equals its stride is a linear projection
+            // of flattened patches, i.e. exactly a [out_ch, in_ch*kt*kh*kw]
+            // matrix.
+            //
+            // A genuine sliding-window convolution would lose its window
+            // structure here — but it was being DROPPED before, so nothing can
+            // regress, and the INFO line makes the reinterpretation visible
+            // rather than silent.
+            int64_t tail = 1;
+            for (int d = 1; d < ndim; d++)
+                tail *= shape_val->arr[d].as_int();
+            shape[0] = shape_val->arr[0].as_int();
+            shape[1] = tail;
+            IMP_LOG_WARN("SafeTensors %s: tensor '%s' has %d dims; flattening trailing dims to [%lld, %lld]",
+                         path.c_str(), tensor_name.c_str(), ndim, static_cast<long long>(shape[0]),
+                         static_cast<long long>(shape[1]));
+            ndim = 2;
+        } else {
+            for (int d = 0; d < ndim; d++) {
+                shape[d] = shape_val->arr[d].as_int();
+            }
         }
 
         const JValue* offsets_val = jobj_find(tensor_meta, "data_offsets");

--- a/tests/test_safetensors_loader.cpp
+++ b/tests/test_safetensors_loader.cpp
@@ -215,5 +215,35 @@ TEST(SafeTensorsMalformedEntryWarnings, OffsetByteCountMismatchWarns) {
     EXPECT_NE(captured.find("byte count"), std::string::npos) << captured;
 }
 
+// A tensor with more dims than the engine's kMaxDims used to be DROPPED with a
+// WARN — which silently loses a weight. Qwen3-VL's patch embed is
+// [1024, 3, 2, 16, 16] and vanished exactly that way. It is now flattened to
+// [d0, d1*..*dn] instead: element order is row-major and untouched, so this is
+// a pure reinterpretation, and it is the only shape the GEMM path could consume.
+TEST(SafeTensorsHighDimTensors, FlattenedInsteadOfDropped) {
+    // [2, 3, 2, 2, 2] F32 = 48 elements = 192 bytes. Flattens to [2, 24].
+    const std::string header =
+        "{\"conv5d\": {\"dtype\": \"F32\", \"shape\": [2, 3, 2, 2, 2], \"data_offsets\": [0, 192]}}";
+    std::string path = write_temp_blob(header, 192);
+    ASSERT_FALSE(path.empty());
+
+    testing::internal::CaptureStderr();
+    auto model = load_safetensors(path);
+    std::string captured = testing::internal::GetCapturedStderr();
+    std::remove(path.c_str());
+
+    // Whether a Model is built depends on what else sits next to the temp file,
+    // so that is not asserted here — the shard scan is what this test is about.
+    (void)model;
+    EXPECT_NE(captured.find("conv5d"), std::string::npos) << captured;
+    EXPECT_NE(captured.find("flattening"), std::string::npos)
+        << "Expected the reinterpretation to be logged, not silent. Captured: " << captured;
+    EXPECT_NE(captured.find("[2, 24]"), std::string::npos)
+        << "Expected the flattened shape in the log. Captured: " << captured;
+    // The old behaviour must be gone: nothing dropped for dimensionality.
+    EXPECT_EQ(captured.find("ndim exceeds"), std::string::npos)
+        << "High-dim tensors must no longer be dropped. Captured: " << captured;
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
A SafeTensors entry with more dims than the engine's `kMaxDims` (4) was
**dropped** with a WARN. That loses a weight and only says so in a log line.
Qwen3-VL's patch embed is `[1024, 3, 2, 16, 16]` and vanished exactly that way:

```
dropping tensor 'model.visual.patch_embed.proj.weight' — shape ndim exceeds engine kMaxDims
```

## What it does now

Flattens the trailing dims into dim 1: `[d0, d1..dn]` → `[d0, d1*..*dn]`. Element
order is row-major and untouched, so this is a **pure reinterpretation** — and it
is the only shape imp's GEMM path could consume anyway.

It is also the *right* shape for the tensors that actually arrive this way: a
patch-embed convolution whose kernel equals its stride is a linear projection of
flattened patches, i.e. exactly an `[out_ch, in_ch*kt*kh*kw]` matrix. Qwen3-VL's
now loads as **`[1024, 1536]`** = 3·2·16·16, confirmed against the real
checkpoint.

A genuine sliding-window convolution *would* lose its window structure here —
but it was being dropped before, so nothing can regress, and the message is a
WARN so the reinterpretation is visible rather than silent. (WARN rather than
INFO deliberately: imp's INFO goes to stdout, and a shape reinterpretation
belongs with the other loader diagnostics on stderr.)

## Test

`tests/test_safetensors_loader.cpp` asserts a `[2,3,2,2,2]` entry is kept,
logged, and reported as `[2, 24]` — and that the old `ndim exceeds` drop is gone.
Full `test-core`: 696 pass.

Independent of #1163 (both branch from main); this one fixes the loader for any
checkpoint, not just Qwen3-VL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8