### PR TITLE
feat(vision): qwen_smart_resize — the dynamic-resolution target size

### DIFF
--- a/src/vision/image_processor.cpp
+++ b/src/vision/image_processor.cpp
@@ -7,9 +7,55 @@
 #include "vision/image_processor.h"
 #include "core/logging.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace imp {
+
+namespace {
+
+// Python's round(): ties go to the EVEN integer. std::round ties away from
+// zero, which differs at exact .5 and would silently shift the token count.
+int64_t round_half_to_even(double v) {
+    const double r = std::nearbyint(v);  // honours the default FE_TONEAREST = ties-to-even
+    return static_cast<int64_t>(r);
+}
+
+int64_t round_to_factor(double v, int factor) { return round_half_to_even(v / factor) * factor; }
+
+}  // namespace
+
+SmartResize qwen_smart_resize(int height, int width, int factor, int64_t min_pixels, int64_t max_pixels) {
+    SmartResize out;
+    if (height <= 0 || width <= 0 || factor <= 0)
+        return out;
+    const int lo = std::min(height, width), hi = std::max(height, width);
+    if (static_cast<double>(hi) / static_cast<double>(lo) > 200.0) {
+        IMP_LOG_WARN("smart_resize: aspect ratio %d:%d exceeds the 200:1 limit", hi, lo);
+        return out;
+    }
+
+    int64_t h_bar = round_to_factor(height, factor);
+    int64_t w_bar = round_to_factor(width, factor);
+    const double area = static_cast<double>(height) * static_cast<double>(width);
+
+    if (h_bar * w_bar > max_pixels) {
+        const double beta = std::sqrt(area / static_cast<double>(max_pixels));
+        h_bar = std::max<int64_t>(factor, static_cast<int64_t>(std::floor(height / beta / factor)) * factor);
+        w_bar = std::max<int64_t>(factor, static_cast<int64_t>(std::floor(width / beta / factor)) * factor);
+    } else if (h_bar * w_bar < min_pixels) {
+        // Deliberately no max(factor, ...) guard here — upstream has none, and
+        // ceil() cannot land below one factor for a positive input anyway.
+        const double beta = std::sqrt(static_cast<double>(min_pixels) / area);
+        h_bar = static_cast<int64_t>(std::ceil(height * beta / factor)) * factor;
+        w_bar = static_cast<int64_t>(std::ceil(width * beta / factor)) * factor;
+    }
+
+    out.height = static_cast<int>(h_bar);
+    out.width = static_cast<int>(w_bar);
+    out.ok = (out.height > 0 && out.width > 0);
+    return out;
+}
 
 static bool preprocess_pixels(const uint8_t* rgb, int w, int h, int target_size, const float mean[3],
                               const float std[3], ImageData& out) {

--- a/src/vision/image_processor.h
+++ b/src/vision/image_processor.h
@@ -13,6 +13,30 @@ struct ImageData {
     int height = 0;
 };
 
+// Qwen-VL "smart resize": the target size for a dynamic-resolution vision
+// encoder. Both dimensions come out divisible by `factor` (patch_size *
+// merge_size — 32 for Qwen3-VL), the total pixel count is pulled into
+// [min_pixels, max_pixels], and the aspect ratio is preserved as closely as
+// those two allow.
+//
+// Ported from transformers' `smart_resize` (qwen2_vl image processing), which
+// Qwen3-VL reuses. Two details are faithful to it on purpose:
+//   - the initial rounding is Python's round(), i.e. BANKER'S rounding (ties to
+//     even), not round-half-away-from-zero. They differ for exact .5 — a
+//     16px side with factor 32 gives 0 in Python and 1 with std::round — and a
+//     silent one-step difference here changes the token count for the whole
+//     image;
+//   - the max_pixels branch floors with a `max(factor, ...)` guard and the
+//     min_pixels branch ceils WITHOUT one. Not symmetric, and not a typo.
+//
+// `ok` is false when the aspect ratio exceeds 200:1, which upstream raises on.
+struct SmartResize {
+    int height = 0;
+    int width = 0;
+    bool ok = false;
+};
+SmartResize qwen_smart_resize(int height, int width, int factor, int64_t min_pixels, int64_t max_pixels);
+
 // Load image from file, resize to target_size x target_size, normalize, convert to FP16 CHW.
 bool load_and_preprocess_image(const std::string& path, int target_size, const float mean[3],
                                const float std[3], ImageData& out);

--- a/tests/test_vision_preprocess.cpp
+++ b/tests/test_vision_preprocess.cpp
@@ -216,5 +216,77 @@ TEST(VisionPreprocess, FileEntryPointMatchesMemoryPath) {
     EXPECT_FALSE(load_and_preprocess_image("/nonexistent/imp_no_such_image.bmp", 2, mean, stdv, from_file));
 }
 
+// ---------------------------------------------------------------------------
+// qwen_smart_resize — the dynamic-resolution target size (Qwen3-VL).
+// Oracle: transformers' smart_resize (qwen2_vl image processing), reproduced by
+// hand below for each case. factor 32 = patch_size 16 * merge_size 2; the pixel
+// bounds are the staged Qwen3-VL-4B preprocessor_config.json (65536 / 16777216).
+// ---------------------------------------------------------------------------
+constexpr int kFactor = 32;
+constexpr int64_t kMinPx = 65536;     // 256^2
+constexpr int64_t kMaxPx = 16777216;  // 4096^2
+
+TEST(QwenSmartResize, AlreadyAlignedAndInRangeIsUnchanged) {
+    // 640x480: both divisible by 32, 307200 px sits inside the bounds.
+    auto r = qwen_smart_resize(480, 640, kFactor, kMinPx, kMaxPx);
+    ASSERT_TRUE(r.ok);
+    EXPECT_EQ(r.height, 480);
+    EXPECT_EQ(r.width, 640);
+}
+
+TEST(QwenSmartResize, BelowMinPixelsScalesUp) {
+    // 100x100 -> round(3.125)*32 = 96 each; 9216 < 65536, so the min branch
+    // runs: beta = sqrt(65536/10000) = 2.56, ceil(100*2.56/32)*32 = 256.
+    auto r = qwen_smart_resize(100, 100, kFactor, kMinPx, kMaxPx);
+    ASSERT_TRUE(r.ok);
+    EXPECT_EQ(r.height, 256);
+    EXPECT_EQ(r.width, 256);
+    EXPECT_GE(static_cast<int64_t>(r.height) * r.width, kMinPx);
+}
+
+TEST(QwenSmartResize, AboveMaxPixelsScalesDown) {
+    // 8000x8000 -> 64e6 px > max; beta = sqrt(64e6/16777216), which lands
+    // exactly on 4096x4096 = max_pixels.
+    auto r = qwen_smart_resize(8000, 8000, kFactor, kMinPx, kMaxPx);
+    ASSERT_TRUE(r.ok);
+    EXPECT_EQ(r.height, 4096);
+    EXPECT_EQ(r.width, 4096);
+    EXPECT_LE(static_cast<int64_t>(r.height) * r.width, kMaxPx);
+}
+
+// The one case where Python's round() and std::round() disagree and it CHANGES
+// THE RESULT, not just an intermediate. 16/32 is exactly 0.5: ties-to-even
+// gives 0, ties-away gives 1.
+//   ties-to-even (correct): h_bar 0 -> product 0 < min -> min branch -> 32x2912
+//   ties-away  (wrong):     h_bar 32 -> product 65536 == min, no branch -> 32x2048
+// A silent one-step difference here changes the image's token count.
+TEST(QwenSmartResize, TiesRoundToEvenLikePython) {
+    auto r = qwen_smart_resize(16, 2048, kFactor, kMinPx, kMaxPx);
+    ASSERT_TRUE(r.ok);
+    EXPECT_EQ(r.height, 32);
+    EXPECT_EQ(r.width, 2912) << "ties-away rounding would give 2048 here";
+}
+
+TEST(QwenSmartResize, RejectsExtremeAspectRatio) {
+    // Upstream raises above 200:1; imp reports it instead of returning a size.
+    auto r = qwen_smart_resize(1, 300, kFactor, kMinPx, kMaxPx);
+    EXPECT_FALSE(r.ok);
+}
+
+TEST(QwenSmartResize, RejectsDegenerateInput) {
+    EXPECT_FALSE(qwen_smart_resize(0, 100, kFactor, kMinPx, kMaxPx).ok);
+    EXPECT_FALSE(qwen_smart_resize(100, 100, 0, kMinPx, kMaxPx).ok);
+}
+
+TEST(QwenSmartResize, OutputIsAlwaysFactorAligned) {
+    for (int h : {37, 100, 255, 512, 1023, 4000})
+        for (int w : {41, 100, 257, 640, 1919, 5000}) {
+            auto r = qwen_smart_resize(h, w, kFactor, kMinPx, kMaxPx);
+            ASSERT_TRUE(r.ok) << h << "x" << w;
+            EXPECT_EQ(r.height % kFactor, 0) << h << "x" << w;
+            EXPECT_EQ(r.width % kFactor, 0) << h << "x" << w;
+        }
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
First code step of the Qwen3-VL plan (#1165), piece 7's sizing half.

imp's image preprocessing resizes to a square `target_size`. A
dynamic-resolution encoder needs the Qwen rule instead: both dimensions
divisible by `patch_size × merge_size` (32), total pixel count pulled into
`[min_pixels, max_pixels]`, aspect ratio preserved as closely as those allow.

Ported from transformers' `smart_resize` **by reading the source**, not from
recollection. Two details are faithful on purpose, and are why this has its own
tests:

**Ties round to even.** The initial rounding is Python's `round()`. `std::round`
ties away from zero and the two differ at exact `.5`. `TiesRoundToEvenLikePython`
pins a case where it changes the **result**, not just an intermediate:

| input | ties-to-even (correct) | ties-away (wrong) |
|---|---|---|
| 16 × 2048 | **32 × 2912** | 32 × 2048 |

`h_bar` starts at 0 rather than 32, which puts the product below `min_pixels` and
routes through the scale-up branch. A silent one-step difference here changes the
token count for the whole image.

**The clamp branches are asymmetric.** `max_pixels` floors with a
`max(factor, …)` guard; `min_pixels` ceils *without* one. That is upstream's
shape, not a typo, and it is reproduced rather than tidied.

Also recorded because it reads wrong: the bounds in `preprocessor_config.json`
are **pixel counts** despite being spelled `shortest_edge` / `longest_edge` —
65536 = 256² and 16777216 = 4096².

## Tests

7 cases: aligned/in-range passthrough, both clamp branches with hand-computed
expectations, the ties case above, degenerate input, the 200:1 aspect-ratio
refusal, and a sweep asserting factor alignment across 36 shapes. Full
`test-core`: 702 pass.

Remaining in piece 7: the resample + normalise + patchify into the
`3·2·16·16 = 1536` order the flattened `patch_embed` expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8