### PR TITLE
feat(vision): qwen_patchify — image to the patch vectors patch_embed expects

### DIFF
--- a/src/vision/image_processor.cpp
+++ b/src/vision/image_processor.cpp
@@ -82,6 +82,66 @@ static bool preprocess_pixels(const uint8_t* rgb, int w, int h, int target_size,
     return true;
 }
 
+bool qwen_patchify(const uint8_t* rgb, int width, int height, const QwenPatchifyConfig& cfg,
+                   QwenPatches& out) {
+    if (!rgb || width <= 0 || height <= 0 || cfg.patch_size <= 0 || cfg.merge_size <= 0 ||
+        cfg.temporal_patch_size <= 0)
+        return false;
+
+    const int factor = cfg.patch_size * cfg.merge_size;
+    const SmartResize rs = qwen_smart_resize(height, width, factor, cfg.min_pixels, cfg.max_pixels);
+    if (!rs.ok)
+        return false;
+
+    // Upstream resamples with PIL BICUBIC. Catmull-Rom is the closest filter stb
+    // offers; the two are not bit-identical and do not need to be — a resampling
+    // difference of this size is far below what the encoder is sensitive to, and
+    // claiming PIL parity would be false.
+    std::vector<uint8_t> resized(static_cast<size_t>(rs.height) * rs.width * 3);
+    if (!stbir_resize(rgb, width, height, width * 3, resized.data(), rs.width, rs.height, rs.width * 3,
+                      STBIR_RGB, STBIR_TYPE_UINT8, STBIR_EDGE_CLAMP, STBIR_FILTER_CATMULLROM))
+        return false;
+
+    const int P = cfg.patch_size, M = cfg.merge_size, T = cfg.temporal_patch_size;
+    const int gh = rs.height / P, gw = rs.width / P;
+    const int C = 3;
+    out.grid_h = gh;
+    out.grid_w = gw;
+    out.tokens = gh * gw;
+    out.features = C * T * P * P;
+    out.data.assign(static_cast<size_t>(out.tokens) * out.features, __float2half(0.0f));
+
+    // Token index follows (gh/M, gw/M, M, M); inside a token, (C, T, ph, pw).
+    size_t tok = 0;
+    for (int bh = 0; bh < gh / M; ++bh) {
+        for (int bw = 0; bw < gw / M; ++bw) {
+            for (int mh = 0; mh < M; ++mh) {
+                for (int mw = 0; mw < M; ++mw, ++tok) {
+                    const int patch_row = bh * M + mh;
+                    const int patch_col = bw * M + mw;
+                    half* dst = out.data.data() + tok * out.features;
+                    for (int c = 0; c < C; ++c) {
+                        for (int ph = 0; ph < P; ++ph) {
+                            const int y = patch_row * P + ph;
+                            for (int pw = 0; pw < P; ++pw) {
+                                const int x = patch_col * P + pw;
+                                const uint8_t raw = resized[(static_cast<size_t>(y) * rs.width + x) * 3 + c];
+                                const float v = (raw / 255.0f - cfg.mean[c]) / cfg.std[c];
+                                // The temporal axis is a repeat for a still image.
+                                for (int t = 0; t < T; ++t) {
+                                    const size_t idx = ((static_cast<size_t>(c) * T + t) * P + ph) * P + pw;
+                                    dst[idx] = __float2half(v);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return true;
+}
+
 bool load_and_preprocess_image(const std::string& path, int target_size, const float mean[3],
                                const float std[3], ImageData& out) {
     int w, h, channels;

--- a/src/vision/image_processor.h
+++ b/src/vision/image_processor.h
@@ -37,6 +37,44 @@ struct SmartResize {
 };
 SmartResize qwen_smart_resize(int height, int width, int factor, int64_t min_pixels, int64_t max_pixels);
 
+// Qwen-VL patchification: an image becomes [tokens, C*T*P*P] FP16, which is
+// exactly what the flattened `patch_embed` matrix ([1024, 1536] for Qwen3-VL)
+// multiplies. Ported from transformers' Qwen2VLImageProcessorFast — the
+// ordering below is read off its reshape/permute, not inferred, because two
+// parts of it are not what one would guess:
+//
+//   - TOKEN order is grouped by 2x2 MERGE BLOCK, not raster:
+//     (grid_h/merge, grid_w/merge, merge_h, merge_w). The patch merger later
+//     consumes four CONSECUTIVE tokens, which only works because of this.
+//   - WITHIN a token the layout is (C, T, patch_h, patch_w) — channel-major,
+//     then the temporal axis. For a still image the temporal axis is a plain
+//     REPEAT of the same spatial patch (upstream `expand`), not a second frame.
+//
+// grid_h/grid_w count patches, so tokens == grid_h * grid_w. Both are even
+// because smart_resize aligns to patch_size * merge_size.
+struct QwenPatches {
+    std::vector<half> data;  // [tokens, channels * temporal * patch * patch]
+    int grid_h = 0;          // in patches
+    int grid_w = 0;
+    int tokens = 0;
+    int features = 0;  // channels * temporal * patch * patch
+};
+
+struct QwenPatchifyConfig {
+    int patch_size = 16;
+    int merge_size = 2;
+    int temporal_patch_size = 2;
+    int64_t min_pixels = 65536;     // 256^2 — a PIXEL COUNT, despite upstream
+    int64_t max_pixels = 16777216;  // 4096^2  spelling it shortest/longest_edge
+    float mean[3] = {0.5f, 0.5f, 0.5f};
+    float std[3] = {0.5f, 0.5f, 0.5f};
+};
+
+// Resize (smart_resize target, Catmull-Rom), rescale to [0,1], normalise, and
+// patchify. Returns false on a decode/size failure. `rgb` is [h, w, 3] u8.
+bool qwen_patchify(const uint8_t* rgb, int width, int height, const QwenPatchifyConfig& cfg,
+                   QwenPatches& out);
+
 // Load image from file, resize to target_size x target_size, normalize, convert to FP16 CHW.
 bool load_and_preprocess_image(const std::string& path, int target_size, const float mean[3],
                                const float std[3], ImageData& out);

--- a/tests/test_vision_preprocess.cpp
+++ b/tests/test_vision_preprocess.cpp
@@ -288,5 +288,99 @@ TEST(QwenSmartResize, OutputIsAlwaysFactorAligned) {
         }
 }
 
+// ---------------------------------------------------------------------------
+// qwen_patchify — layout, not values. The two orderings below are the ones the
+// encoder silently depends on and that guessing gets wrong:
+//   - tokens are grouped by 2x2 MERGE BLOCK, not raster;
+//   - inside a token the layout is (C, T, ph, pw), and T is a REPEAT.
+// Oracle: the reshape/permute in Qwen2VLImageProcessorFast.
+// ---------------------------------------------------------------------------
+
+// An RGB image where every patch-sized tile carries a distinct constant, so a
+// token's content identifies which patch it came from.
+std::vector<uint8_t> patch_id_image(int side, int patch) {
+    std::vector<uint8_t> img(static_cast<size_t>(side) * side * 3);
+    const int g = side / patch;
+    for (int y = 0; y < side; ++y)
+        for (int x = 0; x < side; ++x) {
+            const int pid = (y / patch) * g + (x / patch);
+            for (int c = 0; c < 3; ++c)
+                img[(static_cast<size_t>(y) * side + x) * 3 + c] = static_cast<uint8_t>(pid * 16 + c);
+        }
+    return img;
+}
+
+QwenPatchifyConfig patchify_test_cfg(int side) {
+    QwenPatchifyConfig c;
+    // Pin the geometry so smart_resize is a no-op and the test controls the grid.
+    c.min_pixels = 1;
+    c.max_pixels = static_cast<int64_t>(side) * side;
+    return c;
+}
+
+TEST(QwenPatchify, GridAndShape) {
+    const int side = 64, P = 16;
+    auto img = patch_id_image(side, P);
+    QwenPatches out;
+    ASSERT_TRUE(qwen_patchify(img.data(), side, side, patchify_test_cfg(side), out));
+    EXPECT_EQ(out.grid_h, 4);
+    EXPECT_EQ(out.grid_w, 4);
+    EXPECT_EQ(out.tokens, 16);
+    EXPECT_EQ(out.features, 3 * 2 * P * P);  // C*T*P*P = 1536
+    EXPECT_EQ(out.data.size(), static_cast<size_t>(out.tokens) * out.features);
+}
+
+// Token k must be the k-th patch in MERGE-BLOCK order, not raster order. For a
+// 4x4 patch grid with merge 2 the block order is:
+//   block(0,0): patches 0,1,4,5    block(0,1): patches 2,3,6,7
+//   block(1,0): patches 8,9,12,13  block(1,1): patches 10,11,14,15
+TEST(QwenPatchify, TokensAreGroupedByMergeBlockNotRaster) {
+    const int side = 64, P = 16;
+    auto img = patch_id_image(side, P);
+    QwenPatches out;
+    ASSERT_TRUE(qwen_patchify(img.data(), side, side, patchify_test_cfg(side), out));
+
+    const int expect[16] = {0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15};
+    for (int t = 0; t < 16; ++t) {
+        // channel 0, temporal 0, first pixel of the patch.
+        const float v = __half2float(out.data[static_cast<size_t>(t) * out.features]);
+        const float want = (expect[t] * 16) / 255.0f * 2.0f - 1.0f;  // mean/std 0.5
+        EXPECT_NEAR(v, want, 0.02f) << "token " << t << " came from the wrong patch";
+    }
+}
+
+TEST(QwenPatchify, ChannelMajorAndTemporalIsARepeat) {
+    const int side = 64, P = 16, T = 2;
+    auto img = patch_id_image(side, P);
+    QwenPatches out;
+    ASSERT_TRUE(qwen_patchify(img.data(), side, side, patchify_test_cfg(side), out));
+
+    const half* tok0 = out.data.data();
+    for (int c = 0; c < 3; ++c) {
+        const size_t base = (static_cast<size_t>(c) * T + 0) * P * P;
+        const size_t rep = (static_cast<size_t>(c) * T + 1) * P * P;
+        // The temporal axis repeats the same spatial patch...
+        for (int i = 0; i < P * P; ++i)
+            EXPECT_EQ(__half2float(tok0[base + i]), __half2float(tok0[rep + i]))
+                << "temporal slot 1 must repeat slot 0 (channel " << c << ", elem " << i << ")";
+        // ...and channels stay distinct, so the layout really is channel-major.
+        if (c > 0) {
+            const size_t prev = (static_cast<size_t>(c - 1) * T + 0) * P * P;
+            EXPECT_NE(__half2float(tok0[base]), __half2float(tok0[prev]))
+                << "channels " << c - 1 << " and " << c << " must not alias";
+        }
+    }
+}
+
+TEST(QwenPatchify, RejectsBadInput) {
+    QwenPatches out;
+    QwenPatchifyConfig c = patchify_test_cfg(64);
+    std::vector<uint8_t> img(64 * 64 * 3, 0);
+    EXPECT_FALSE(qwen_patchify(nullptr, 64, 64, c, out));
+    EXPECT_FALSE(qwen_patchify(img.data(), 0, 64, c, out));
+    c.patch_size = 0;
+    EXPECT_FALSE(qwen_patchify(img.data(), 64, 64, c, out));
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
Completes piece 7 of the Qwen3-VL plan (#1165). An image now becomes
`[tokens, C·T·P·P]` FP16 — exactly what the flattened `patch_embed` matrix
(`[1024, 1536]`) multiplies. Resize to the `smart_resize` target (#1166),
rescale, normalise, patchify.

## Why this is its own tested unit: the ordering

Read off `Qwen2VLImageProcessorFast`'s `reshape`/`permute(0, 2, 5, 3, 6, 1, 4, 7)`
rather than inferred, because two parts are not what one would guess **and would
fail silently**:

**Tokens are grouped by 2×2 merge block, not raster.** For a 4×4 patch grid:

| order | tokens |
|---|---|
| what you'd guess (raster) | 0, 1, 2, 3, 4, 5, … |
| actual | **0, 1, 4, 5,  2, 3, 6, 7,  8, 9, 12, 13,  10, 11, 14, 15** |

The patch merger later consumes four **consecutive** tokens — that only works
because of this grouping.

**Within a token the layout is `(C, T, ph, pw)`** — channel-major, then the
temporal axis; and for a still image that axis is a plain **repeat** of the same
spatial patch (upstream `expand`), not a second frame.

Both orderings were derived twice independently — once for the implementation,
once for the test expectation — and agree. The ordering test uses an image where
every patch carries a distinct constant, so a token's content identifies which
patch it came from; a raster-ordered implementation fails it immediately.

## Stated rather than glossed

Upstream resamples with PIL BICUBIC; stb offers Catmull-Rom. They are **not**
bit-identical and this does not claim they are — the difference is far below
what the encoder is sensitive to, and pretending to parity would be false.

## Tests

4 cases (grid/shape, merge-block token order, channel-major + temporal repeat,
bad input). Full `test-core`: 707 pass.

With this, **image → patch vectors is complete**. The vision tower loader and
encoder now have a real consumer to be built against rather than being dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8