### PR TITLE
feat(vision): Qwen3-VL vision tensor mapping + model slots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ set(IMP_EXEC_SOURCES
 set(IMP_VISION_SOURCES
     src/vision/vision_model.cpp
     src/vision/vision_loader.cpp
+    src/vision/qwen3vl_vision_map.cpp
     src/vision/image_processor.cpp
     src/vision/vision_encoder.cu
 )
@@ -590,6 +591,7 @@ if(IMP_BUILD_TESTS)
         tests/test_safetensors_loader.cpp
         tests/test_safetensors_writer.cpp
         tests/test_awq_calibration.cpp
+        tests/test_qwen3vl_vision_map.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
         # Generative FSM battery for the schema-less json_object grammar. Lives

--- a/src/vision/qwen3vl_vision_map.cpp
+++ b/src/vision/qwen3vl_vision_map.cpp
@@ -1,0 +1,127 @@
+#include "vision/qwen3vl_vision_map.h"
+
+#include <cstdlib>
+
+namespace imp {
+
+namespace {
+
+using Slot = Qwen3VLVisionSlot;
+
+bool starts_with(const std::string& s, const char* p) { return s.rfind(p, 0) == 0; }
+
+// Parse "<digits>." at `pos`, advancing past the dot. Returns -1 if there is no
+// digit run followed by a dot — a name like `blocks.x.norm1.weight` must fall
+// through to Unknown rather than be silently read as block 0.
+int take_index(const std::string& s, size_t& pos) {
+    size_t start = pos;
+    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
+        ++pos;
+    if (pos == start || pos >= s.size() || s[pos] != '.')
+        return -1;
+    const int v = std::atoi(s.substr(start, pos - start).c_str());
+    ++pos;  // skip '.'
+    return v;
+}
+
+// The block/merger sub-names are identical between the two, so share the tail.
+Slot merger_tail(const std::string& tail) {
+    if (tail == "norm.weight")
+        return Slot::MergerNormWeight;
+    if (tail == "norm.bias")
+        return Slot::MergerNormBias;
+    if (tail == "linear_fc1.weight")
+        return Slot::MergerFc1Weight;
+    if (tail == "linear_fc1.bias")
+        return Slot::MergerFc1Bias;
+    if (tail == "linear_fc2.weight")
+        return Slot::MergerFc2Weight;
+    if (tail == "linear_fc2.bias")
+        return Slot::MergerFc2Bias;
+    return Slot::Unknown;
+}
+
+}  // namespace
+
+Qwen3VLVisionRef qwen3vl_map_vision_tensor(const std::string& name) {
+    Qwen3VLVisionRef ref;
+
+    if (name == "patch_embed.proj.weight") {
+        ref.slot = Slot::PatchEmbedWeight;
+        return ref;
+    }
+    if (name == "patch_embed.proj.bias") {
+        ref.slot = Slot::PatchEmbedBias;
+        return ref;
+    }
+    if (name == "pos_embed.weight") {
+        ref.slot = Slot::PosEmbed;
+        return ref;
+    }
+
+    if (starts_with(name, "blocks.")) {
+        size_t pos = 7;  // strlen("blocks.")
+        const int idx = take_index(name, pos);
+        if (idx < 0)
+            return ref;
+        const std::string tail = name.substr(pos);
+        ref.index = idx;
+        if (tail == "norm1.weight")
+            ref.slot = Slot::Norm1Weight;
+        else if (tail == "norm1.bias")
+            ref.slot = Slot::Norm1Bias;
+        else if (tail == "attn.qkv.weight")
+            ref.slot = Slot::QkvWeight;
+        else if (tail == "attn.qkv.bias")
+            ref.slot = Slot::QkvBias;
+        else if (tail == "attn.proj.weight")
+            ref.slot = Slot::ProjWeight;
+        else if (tail == "attn.proj.bias")
+            ref.slot = Slot::ProjBias;
+        else if (tail == "norm2.weight")
+            ref.slot = Slot::Norm2Weight;
+        else if (tail == "norm2.bias")
+            ref.slot = Slot::Norm2Bias;
+        else if (tail == "mlp.linear_fc1.weight")
+            ref.slot = Slot::Fc1Weight;
+        else if (tail == "mlp.linear_fc1.bias")
+            ref.slot = Slot::Fc1Bias;
+        else if (tail == "mlp.linear_fc2.weight")
+            ref.slot = Slot::Fc2Weight;
+        else if (tail == "mlp.linear_fc2.bias")
+            ref.slot = Slot::Fc2Bias;
+        if (ref.slot == Slot::Unknown)
+            ref.index = -1;
+        return ref;
+    }
+
+    // DeepStack mergers must be tested BEFORE the main merger: the main one is
+    // `merger.*` and these are `deepstack_merger_list.<i>.*`, so there is no
+    // prefix overlap — but keeping the order explicit documents that they are
+    // distinct, not variants of one another.
+    if (starts_with(name, "deepstack_merger_list.")) {
+        size_t pos = 22;  // strlen("deepstack_merger_list.")
+        const int idx = take_index(name, pos);
+        if (idx < 0)
+            return ref;
+        const Slot s = merger_tail(name.substr(pos));
+        if (s != Slot::Unknown) {
+            ref.slot = s;
+            ref.index = idx;
+        }
+        return ref;
+    }
+
+    if (starts_with(name, "merger.")) {
+        const Slot s = merger_tail(name.substr(7));
+        if (s != Slot::Unknown) {
+            ref.slot = s;
+            ref.index = -1;  // the main merger
+        }
+        return ref;
+    }
+
+    return ref;
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_map.h
+++ b/src/vision/qwen3vl_vision_map.h
@@ -1,0 +1,54 @@
+#pragma once
+
+// Qwen3-VL vision-tower tensor names -> slots.
+//
+// Split out as a pure function because this is where a vision tower silently
+// goes wrong: a misrouted name does not crash, it produces a plausible-looking
+// encoder that returns unrelated embeddings. Keeping it free of Tensor and file
+// I/O means it can be tested exhaustively against the real name list without a
+// checkpoint or a GPU.
+//
+// Names come from `model.visual.*` in the checkpoint (the `model.visual.`
+// prefix is NOT included — callers strip it, as weight_map already does).
+
+#include <string>
+
+namespace imp {
+
+enum class Qwen3VLVisionSlot {
+    Unknown = 0,
+    PatchEmbedWeight,
+    PatchEmbedBias,
+    PosEmbed,
+    // Per-block (block index in `index`)
+    Norm1Weight,
+    Norm1Bias,
+    QkvWeight,  // fused [3*hidden, hidden]; the loader slices it into q/k/v
+    QkvBias,
+    ProjWeight,
+    ProjBias,
+    Norm2Weight,
+    Norm2Bias,
+    Fc1Weight,
+    Fc1Bias,
+    Fc2Weight,
+    Fc2Bias,
+    // Mergers. `index` is -1 for the main merger and 0..n-1 for DeepStack ones.
+    MergerNormWeight,
+    MergerNormBias,
+    MergerFc1Weight,
+    MergerFc1Bias,
+    MergerFc2Weight,
+    MergerFc2Bias,
+};
+
+struct Qwen3VLVisionRef {
+    Qwen3VLVisionSlot slot = Qwen3VLVisionSlot::Unknown;
+    int index = -1;  // block index, or DeepStack merger index; -1 when N/A
+};
+
+// Returns slot == Unknown for anything not recognised, so a caller can report
+// leftovers instead of silently ignoring them.
+Qwen3VLVisionRef qwen3vl_map_vision_tensor(const std::string& name);
+
+}  // namespace imp

--- a/src/vision/vision_model.h
+++ b/src/vision/vision_model.h
@@ -22,6 +22,29 @@ struct VisionConfig {
     // norm, 2D axial NEOX RoPE, sandwich post-norms, GeGLU FFN, scale-1 attn).
     bool is_gemma4v = false;
     float rope_theta = 0.0f;  // gemma4v vision RoPE base (100.0)
+
+    // Qwen3-VL: dynamic resolution (no fixed image_size — num_patches varies per
+    // image), fused QKV, plain (non-gated) MLP, and a two-layer patch merger
+    // instead of a single projection. See docs/plans/2026-07-31-qwen3-vl-vision.md.
+    bool is_qwen3vl = false;
+    int merge_size = 1;           // spatial merge factor (2 => 2x2 patches per token)
+    int temporal_patch_size = 1;  // still images repeat along this axis
+    int out_hidden_size = 0;      // merger output width (the LM's d_model)
+    // Vision blocks whose hidden state is tapped for DeepStack. NOTE these index
+    // VISION blocks; the LM-side injection happens at LM layers 0..n-1, a
+    // different index space entirely.
+    std::vector<int> deepstack_indexes;
+};
+
+// Qwen3-VL patch merger: norm -> fc1 -> GELU -> fc2. The main merger normalises
+// BEFORE the 2x2 concat (norm width = hidden_size) and each DeepStack merger
+// normalises AFTER it (norm width = hidden_size * merge_size^2). Upstream calls
+// that flag `use_postshuffle_norm`; here the norm tensor's own width says which
+// it is, so nothing needs to be remembered.
+struct VisionMergerWeights {
+    Tensor norm_w, norm_b;
+    Tensor fc1_w, fc1_b;
+    Tensor fc2_w, fc2_b;
 };
 
 struct VisionLayerWeights {
@@ -50,6 +73,11 @@ struct VisionModel {
 
     // Post-encoder LayerNorm
     Tensor post_norm_w, post_norm_b;
+
+    // Qwen3-VL mergers: `merger` produces the image tokens the LM consumes;
+    // `deepstack_mergers` are the extra taps, one per config.deepstack_indexes.
+    VisionMergerWeights merger;
+    std::vector<VisionMergerWeights> deepstack_mergers;
 
     // Multimodal projector
     Tensor mm_pre_norm_w;   // RMSNorm before linear projection

--- a/tests/test_qwen3vl_vision_map.cpp
+++ b/tests/test_qwen3vl_vision_map.cpp
@@ -1,0 +1,119 @@
+// Qwen3-VL vision tensor-name mapping.
+//
+// This is tested exhaustively because a misrouted vision weight does not crash:
+// it yields an encoder that runs and returns embeddings unrelated to the image.
+// The oracle is the real name list from the staged Qwen3-VL-4B-Instruct
+// checkpoint (315 tensors under `model.visual.`), reconstructed here so the test
+// needs neither the checkpoint nor a GPU.
+
+#include "vision/qwen3vl_vision_map.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+using Slot = Qwen3VLVisionSlot;
+
+// The checkpoint's `model.visual.*` names with the prefix stripped, for the real
+// geometry: depth 24, 3 DeepStack mergers.
+std::vector<std::string> real_name_list() {
+    std::vector<std::string> names = {"patch_embed.proj.weight", "patch_embed.proj.bias", "pos_embed.weight"};
+    for (int b = 0; b < 24; ++b) {
+        const std::string p = "blocks." + std::to_string(b) + ".";
+        for (const char* t :
+             {"norm1.weight", "norm1.bias", "attn.qkv.weight", "attn.qkv.bias", "attn.proj.weight",
+              "attn.proj.bias", "norm2.weight", "norm2.bias", "mlp.linear_fc1.weight", "mlp.linear_fc1.bias",
+              "mlp.linear_fc2.weight", "mlp.linear_fc2.bias"})
+            names.push_back(p + t);
+    }
+    for (const char* t : {"norm.weight", "norm.bias", "linear_fc1.weight", "linear_fc1.bias",
+                          "linear_fc2.weight", "linear_fc2.bias"})
+        names.push_back(std::string("merger.") + t);
+    for (int d = 0; d < 3; ++d) {
+        const std::string p = "deepstack_merger_list." + std::to_string(d) + ".";
+        for (const char* t : {"norm.weight", "norm.bias", "linear_fc1.weight", "linear_fc1.bias",
+                              "linear_fc2.weight", "linear_fc2.bias"})
+            names.push_back(p + t);
+    }
+    return names;
+}
+
+TEST(Qwen3VLVisionMap, EveryRealTensorIsRecognisedExactlyOnce) {
+    const auto names = real_name_list();
+    ASSERT_EQ(names.size(), 315u) << "the checkpoint has 315 model.visual.* tensors";
+
+    std::set<std::pair<int, int>> seen;  // (slot, index) must be unique
+    for (const auto& n : names) {
+        const auto r = qwen3vl_map_vision_tensor(n);
+        ASSERT_NE(r.slot, Slot::Unknown) << "unmapped: " << n;
+        const auto key = std::make_pair(static_cast<int>(r.slot), r.index);
+        EXPECT_TRUE(seen.insert(key).second) << "two tensors map to the same slot: " << n;
+    }
+    EXPECT_EQ(seen.size(), names.size());
+}
+
+// The main merger and the DeepStack mergers share sub-names. Routing a
+// DeepStack tensor into the main merger would still produce a running encoder.
+TEST(Qwen3VLVisionMap, MainMergerAndDeepstackAreDistinct) {
+    const auto main_m = qwen3vl_map_vision_tensor("merger.linear_fc1.weight");
+    EXPECT_EQ(main_m.slot, Slot::MergerFc1Weight);
+    EXPECT_EQ(main_m.index, -1) << "the main merger must be index -1";
+
+    for (int d = 0; d < 3; ++d) {
+        const auto ds = qwen3vl_map_vision_tensor("deepstack_merger_list." + std::to_string(d) +
+                                                  ".linear_fc1.weight");
+        EXPECT_EQ(ds.slot, Slot::MergerFc1Weight);
+        EXPECT_EQ(ds.index, d) << "DeepStack merger index must survive";
+    }
+}
+
+TEST(Qwen3VLVisionMap, BlockIndexIsParsedNotAssumed) {
+    for (int b : {0, 1, 9, 10, 23}) {
+        const auto r = qwen3vl_map_vision_tensor("blocks." + std::to_string(b) + ".attn.qkv.weight");
+        EXPECT_EQ(r.slot, Slot::QkvWeight);
+        EXPECT_EQ(r.index, b);
+    }
+}
+
+// A non-numeric or missing index must NOT silently become block 0 — that would
+// stack every layer's weights onto the first one.
+TEST(Qwen3VLVisionMap, MalformedIndexIsUnknownNotZero) {
+    for (const char* n : {"blocks.x.norm1.weight", "blocks..norm1.weight", "blocks.norm1.weight",
+                          "deepstack_merger_list.x.norm.weight"}) {
+        const auto r = qwen3vl_map_vision_tensor(n);
+        EXPECT_EQ(r.slot, Slot::Unknown) << n;
+        EXPECT_EQ(r.index, -1) << n;
+    }
+}
+
+TEST(Qwen3VLVisionMap, UnrelatedNamesAreUnknown) {
+    for (const char* n : {"", "blocks.0.attn.q_proj.weight", "merger.linear_fc3.weight", "patch_embed.proj",
+                          "pos_embed", "language_model.layers.0.mlp.up_proj.weight"}) {
+        EXPECT_EQ(qwen3vl_map_vision_tensor(n).slot, Slot::Unknown) << n;
+    }
+}
+
+// Every block slot must be reachable — a typo in one of the twelve tails would
+// otherwise only show up as a null tensor much later.
+TEST(Qwen3VLVisionMap, AllTwelvePerBlockSlotsAreCovered) {
+    std::set<int> slots;
+    for (const char* t :
+         {"norm1.weight", "norm1.bias", "attn.qkv.weight", "attn.qkv.bias", "attn.proj.weight",
+          "attn.proj.bias", "norm2.weight", "norm2.bias", "mlp.linear_fc1.weight", "mlp.linear_fc1.bias",
+          "mlp.linear_fc2.weight", "mlp.linear_fc2.bias"}) {
+        const auto r = qwen3vl_map_vision_tensor(std::string("blocks.7.") + t);
+        ASSERT_NE(r.slot, Slot::Unknown) << t;
+        EXPECT_EQ(r.index, 7);
+        slots.insert(static_cast<int>(r.slot));
+    }
+    EXPECT_EQ(slots.size(), 12u) << "two block tails collapsed onto one slot";
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
The mapping layer of the Qwen3-VL vision loader, landed on its own because it is
**the part that fails silently**: a misrouted vision weight does not crash, it
produces an encoder that runs and returns embeddings unrelated to the image. So
it is a pure function over names — no `Tensor`, no file I/O — and tested
exhaustively against the real 315-name list without needing the checkpoint or a
GPU.

## `VisionModel` gains what Qwen3-VL needs and nothing more

Most of the existing per-layer struct already fits:

| Qwen3-VL | existing slot |
|---|---|
| `norm1` / `norm2` | `ln1_*` / `ln2_*` (LayerNorm **with bias**, which is what these are) |
| `attn.proj` | `wo` / `bo` |
| `mlp.linear_fc1` / `fc2` | `ffn_up_*` / `ffn_down_*` |
| *(no gate)* | `ffn_gate_w` stays null |

New are the two-layer patch mergers — and the norm width is the thing to
respect: the main merger normalises **before** the 2×2 concat (`[1024]`), each
DeepStack merger **after** it (`[4096]`). Upstream calls that
`use_postshuffle_norm`; here the tensor's own width says which it is, so nothing
has to be remembered.

Also recorded in the config comment because it is *the* trap in this model:
`deepstack_indexes` are **vision block** indices, while the LM-side injection
happens at LM layers 0..n-1 — a different index space.

## Tests (6)

- every real tensor maps **exactly once** — 315 names, no two to the same slot;
- main merger (`index == -1`) and DeepStack mergers (`index == d`) stay distinct
  despite sharing sub-names;
- block indices are parsed, not assumed;
- **a malformed index yields `Unknown`, not block 0** — otherwise every layer's
  weights would stack onto the first;
- unrelated names are `Unknown` (so leftovers can be reported, not ignored);
- all twelve per-block tails reach twelve *distinct* slots, so a typo in one
  cannot collapse two.

Full `test-core`: 713 pass.

Loading and the encoder forward follow — plan in
`docs/plans/2026-07-31-qwen3-vl-vision.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8