### PR TITLE
feat(vision): parse Qwen3-VL vision_config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,7 @@ set(IMP_VISION_SOURCES
     src/vision/vision_model.cpp
     src/vision/vision_loader.cpp
     src/vision/qwen3vl_vision_map.cpp
+    src/vision/qwen3vl_vision_config.cpp
     src/vision/image_processor.cpp
     src/vision/vision_encoder.cu
 )
@@ -592,6 +593,7 @@ if(IMP_BUILD_TESTS)
         tests/test_safetensors_writer.cpp
         tests/test_awq_calibration.cpp
         tests/test_qwen3vl_vision_map.cpp
+        tests/test_qwen3vl_vision_config.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
         # Generative FSM battery for the schema-less json_object grammar. Lives

--- a/src/vision/qwen3vl_vision_config.cpp
+++ b/src/vision/qwen3vl_vision_config.cpp
@@ -1,0 +1,113 @@
+#include "vision/qwen3vl_vision_config.h"
+
+#include <cmath>
+
+namespace imp {
+
+namespace {
+
+const JValue* find(const JValue& v, const char* key) {
+    if (v.type != JType::OBJECT)
+        return nullptr;
+    for (const auto& [k, val] : v.obj)
+        if (k == key)
+            return &val;
+    return nullptr;
+}
+
+// Missing and present-but-not-a-number are the same failure here: both mean the
+// geometry is not what this parser assumes.
+bool get_int(const JValue& v, const char* key, int& out) {
+    const JValue* f = find(v, key);
+    if (!f || f->type != JType::NUMBER)
+        return false;
+    out = static_cast<int>(f->as_int());
+    return true;
+}
+
+}  // namespace
+
+bool parse_qwen3vl_vision_config(const JValue& vision_cfg, VisionConfig& out, std::string& err) {
+    // Everything lands in a scratch config first: a partially-filled VisionConfig
+    // is worse than none, because the caller cannot tell which fields are real.
+    VisionConfig c;
+    int depth = 0, hidden = 0, heads = 0, inter = 0, patch = 0, merge = 0, temporal = 0;
+    int out_hidden = 0, num_pos = 0;
+
+    struct Field {
+        const char* key;
+        int* dst;
+    };
+    const Field required[] = {
+        {"depth", &depth},
+        {"hidden_size", &hidden},
+        {"num_heads", &heads},
+        {"intermediate_size", &inter},
+        {"patch_size", &patch},
+        {"spatial_merge_size", &merge},
+        {"temporal_patch_size", &temporal},
+        {"out_hidden_size", &out_hidden},
+        {"num_position_embeddings", &num_pos},
+    };
+    for (const auto& f : required) {
+        if (!get_int(vision_cfg, f.key, *f.dst)) {
+            err = std::string("vision_config: missing or non-numeric '") + f.key + "'";
+            return false;
+        }
+        if (*f.dst <= 0) {
+            err = std::string("vision_config: '") + f.key + "' must be positive";
+            return false;
+        }
+    }
+
+    if (hidden % heads != 0) {
+        err = "vision_config: hidden_size is not divisible by num_heads";
+        return false;
+    }
+
+    // The learned position embedding is a SQUARE grid that gets resampled per
+    // image. A non-square count means this parser has the wrong model.
+    const int grid = static_cast<int>(std::lround(std::sqrt(static_cast<double>(num_pos))));
+    if (grid * grid != num_pos) {
+        err = "vision_config: num_position_embeddings is not a perfect square";
+        return false;
+    }
+
+    c.is_qwen3vl = true;
+    c.num_layers = depth;
+    c.hidden_size = hidden;
+    c.num_heads = heads;
+    c.head_dim = hidden / heads;
+    c.intermediate_size = inter;
+    c.patch_size = patch;
+    c.merge_size = merge;
+    c.temporal_patch_size = temporal;
+    c.out_hidden_size = out_hidden;
+    c.pos_embed_grid = grid;
+    // Dynamic resolution: there is no fixed image_size or patch count. Leaving
+    // the inherited defaults in place would be a lie the encoder could read.
+    c.image_size = 0;
+    c.num_patches = 0;
+    c.num_image_tokens = 0;
+
+    const JValue* ds = find(vision_cfg, "deepstack_visual_indexes");
+    if (ds && ds->type == JType::ARRAY) {
+        for (const auto& e : ds->arr) {
+            if (e.type != JType::NUMBER) {
+                err = "vision_config: deepstack_visual_indexes holds a non-number";
+                return false;
+            }
+            const int idx = static_cast<int>(e.as_int());
+            if (idx < 0 || idx >= depth) {
+                err = "vision_config: deepstack index out of range for depth";
+                return false;
+            }
+            c.deepstack_indexes.push_back(idx);
+        }
+    }
+
+    out = c;
+    return true;
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_config.h
+++ b/src/vision/qwen3vl_vision_config.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Parse a Qwen3-VL `vision_config` block into VisionConfig.
+//
+// Its own TU for two reasons: hf_config_loader.cpp is already at its size limit,
+// and this is a different failure mode from the tensor-name mapping next door —
+// a wrong name silently misroutes one weight, a wrong geometry silently
+// mis-shapes every buffer.
+
+#include "model/json_util.h"
+#include "vision/vision_model.h"
+
+#include <string>
+
+namespace imp {
+
+// Fills the Qwen3-VL fields of `out` from a `vision_config` object.
+//
+// Returns false — leaving `out` UNTOUCHED — when a required field is missing or
+// inconsistent, so a half-filled geometry can never reach the encoder. `err`
+// then names what was wrong. Checked: every dimension positive, hidden_size
+// divisible by num_heads, and num_position_embeddings a perfect square (it is a
+// square grid: 2304 = 48^2).
+bool parse_qwen3vl_vision_config(const JValue& vision_cfg, VisionConfig& out, std::string& err);
+
+}  // namespace imp

--- a/src/vision/vision_model.h
+++ b/src/vision/vision_model.h
@@ -30,6 +30,11 @@ struct VisionConfig {
     int merge_size = 1;           // spatial merge factor (2 => 2x2 patches per token)
     int temporal_patch_size = 1;  // still images repeat along this axis
     int out_hidden_size = 0;      // merger output width (the LM's d_model)
+    // Side of the LEARNED position-embedding grid (48 for Qwen3-VL, from
+    // num_position_embeddings = 2304). A real image rarely has this grid, so the
+    // table is resampled per image — this is the SOURCE resolution, not the
+    // image's.
+    int pos_embed_grid = 0;
     // Vision blocks whose hidden state is tapped for DeepStack. NOTE these index
     // VISION blocks; the LM-side injection happens at LM layers 0..n-1, a
     // different index space entirely.

--- a/tests/test_qwen3vl_vision_config.cpp
+++ b/tests/test_qwen3vl_vision_config.cpp
@@ -1,0 +1,137 @@
+// Qwen3-VL vision_config parsing.
+//
+// A wrong geometry here silently mis-shapes every encoder buffer, so the parser
+// refuses rather than half-fills, and these tests pin that: on any rejection the
+// output must be left untouched.
+//
+// Oracle: the `vision_config` of the staged Qwen3-VL-4B-Instruct config.json.
+
+#include "vision/qwen3vl_vision_config.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace imp {
+namespace {
+
+// The real block, verbatim.
+const char* kRealVisionConfig = R"({
+  "deepstack_visual_indexes": [5, 11, 17],
+  "depth": 24,
+  "hidden_act": "gelu_pytorch_tanh",
+  "hidden_size": 1024,
+  "in_channels": 3,
+  "initializer_range": 0.02,
+  "intermediate_size": 4096,
+  "model_type": "qwen3_vl",
+  "num_heads": 16,
+  "num_position_embeddings": 2304,
+  "out_hidden_size": 2560,
+  "patch_size": 16,
+  "spatial_merge_size": 2,
+  "temporal_patch_size": 2
+})";
+
+JValue parse(const std::string& text) {
+    JsonParser p(text.data(), text.size());
+    return p.parse();
+}
+
+TEST(Qwen3VLVisionConfig, ParsesTheRealCheckpoint) {
+    VisionConfig c;
+    std::string err;
+    ASSERT_TRUE(parse_qwen3vl_vision_config(parse(kRealVisionConfig), c, err)) << err;
+
+    EXPECT_TRUE(c.is_qwen3vl);
+    EXPECT_EQ(c.num_layers, 24);
+    EXPECT_EQ(c.hidden_size, 1024);
+    EXPECT_EQ(c.num_heads, 16);
+    EXPECT_EQ(c.head_dim, 64);  // derived, not read
+    EXPECT_EQ(c.intermediate_size, 4096);
+    EXPECT_EQ(c.patch_size, 16);
+    EXPECT_EQ(c.merge_size, 2);
+    EXPECT_EQ(c.temporal_patch_size, 2);
+    EXPECT_EQ(c.out_hidden_size, 2560);
+    EXPECT_EQ(c.pos_embed_grid, 48) << "2304 = 48^2";
+    ASSERT_EQ(c.deepstack_indexes.size(), 3u);
+    EXPECT_EQ(c.deepstack_indexes[0], 5);
+    EXPECT_EQ(c.deepstack_indexes[2], 17);
+}
+
+// Dynamic resolution: there is no fixed image size or patch count. Inheriting
+// the SigLIP defaults (896 / 4096 / 256) would be a lie the encoder could read
+// and size buffers from.
+TEST(Qwen3VLVisionConfig, ClearsTheFixedResolutionFields) {
+    VisionConfig c;  // starts with the SigLIP defaults
+    ASSERT_NE(c.image_size, 0);
+    ASSERT_NE(c.num_patches, 0);
+    std::string err;
+    ASSERT_TRUE(parse_qwen3vl_vision_config(parse(kRealVisionConfig), c, err)) << err;
+    EXPECT_EQ(c.image_size, 0);
+    EXPECT_EQ(c.num_patches, 0);
+    EXPECT_EQ(c.num_image_tokens, 0);
+}
+
+TEST(Qwen3VLVisionConfig, RejectionLeavesTheOutputUntouched) {
+    VisionConfig before;
+    VisionConfig c = before;
+    std::string err;
+    // depth missing entirely.
+    const char* bad = R"({"hidden_size": 1024, "num_heads": 16})";
+    EXPECT_FALSE(parse_qwen3vl_vision_config(parse(bad), c, err));
+    EXPECT_FALSE(err.empty()) << "a rejection must say what was wrong";
+    EXPECT_FALSE(c.is_qwen3vl) << "output must not be half-filled on rejection";
+    EXPECT_EQ(c.hidden_size, before.hidden_size);
+    EXPECT_EQ(c.num_layers, before.num_layers);
+}
+
+TEST(Qwen3VLVisionConfig, RejectsInconsistentGeometry) {
+    std::string base = kRealVisionConfig;
+    VisionConfig c;
+    std::string err;
+
+    // hidden_size not divisible by num_heads.
+    auto bad_heads = base;
+    bad_heads.replace(bad_heads.find("\"num_heads\": 16"), 15, "\"num_heads\": 15");
+    EXPECT_FALSE(parse_qwen3vl_vision_config(parse(bad_heads), c, err));
+    EXPECT_NE(err.find("divisible"), std::string::npos) << err;
+
+    // num_position_embeddings not a perfect square.
+    auto bad_pos = base;
+    bad_pos.replace(bad_pos.find("\"num_position_embeddings\": 2304"), 31,
+                    "\"num_position_embeddings\": 2305");
+    EXPECT_FALSE(parse_qwen3vl_vision_config(parse(bad_pos), c, err));
+    EXPECT_NE(err.find("perfect square"), std::string::npos) << err;
+
+    // A non-positive dimension.
+    auto bad_depth = base;
+    bad_depth.replace(bad_depth.find("\"depth\": 24"), 11, "\"depth\": 0 ");
+    EXPECT_FALSE(parse_qwen3vl_vision_config(parse(bad_depth), c, err));
+    EXPECT_NE(err.find("positive"), std::string::npos) << err;
+}
+
+// A DeepStack tap pointing past the last block would index out of bounds at
+// encode time, long after the config was read.
+TEST(Qwen3VLVisionConfig, RejectsDeepstackIndexOutOfRange) {
+    std::string bad = kRealVisionConfig;
+    bad.replace(bad.find("[5, 11, 17]"), 11, "[5, 11, 24]");
+    VisionConfig c;
+    std::string err;
+    EXPECT_FALSE(parse_qwen3vl_vision_config(parse(bad), c, err));
+    EXPECT_NE(err.find("out of range"), std::string::npos) << err;
+}
+
+// DeepStack is optional; a model without it must still parse.
+TEST(Qwen3VLVisionConfig, MissingDeepstackIsFine) {
+    std::string no_ds = kRealVisionConfig;
+    no_ds.replace(no_ds.find("\"deepstack_visual_indexes\": [5, 11, 17],"), 40, "");
+    VisionConfig c;
+    std::string err;
+    ASSERT_TRUE(parse_qwen3vl_vision_config(parse(no_ds), c, err)) << err;
+    EXPECT_TRUE(c.deepstack_indexes.empty());
+    EXPECT_EQ(c.num_layers, 24);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
`vision_config` was only ever **detected** — to emit the *"vision tower will be
skipped"* warning — never read. This parses it into `VisionConfig`.

## It refuses rather than half-fills

On any rejection the output is left **untouched** and `err` names the problem. A
partially-filled `VisionConfig` is worse than none: the caller cannot tell which
fields are real. Checked:

- every dimension present, numeric and positive;
- `hidden_size` divisible by `num_heads`;
- `num_position_embeddings` a **perfect square** — it is a square grid
  (2304 = 48²), and a non-square count means this parser has the wrong model;
- DeepStack indices **in range for the depth** — an out-of-range tap would
  otherwise only blow up at encode time, long after the config was read.

## It clears the fixed-resolution fields

Qwen3-VL is dynamic-resolution: no `image_size`, no fixed patch count. Leaving
the inherited SigLIP defaults (896 / 4096 / 256) in place would be **a lie the
encoder could read and size buffers from**, so they are zeroed explicitly.

## Placement

Its own TU: `hf_config_loader.cpp` is already at its size limit, and this is a
different failure mode from the tensor-name mapping next door — a wrong name
misroutes one weight, a wrong geometry mis-shapes every buffer.

## Tests (6)

Against the real `vision_config` block from the staged checkpoint, including
that a rejection leaves the output untouched, that the fixed-resolution fields
are cleared, and that a missing (optional) DeepStack list still parses. Full
`test-core`: 719 pass.

Next: the loader itself. `WeightMap::apply_weights` is the hook — it already has
both the tensors and the model — but where `VisionConfig`/`VisionModel` live
relative to `Model` is a layering call (today `model/` does not depend on
`vision/`), and that deserves deciding rather than defaulting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8