### PR TITLE
feat(vision): load the Qwen3-VL vision tower from the checkpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ set(IMP_VISION_SOURCES
     src/vision/vision_loader.cpp
     src/vision/qwen3vl_vision_map.cpp
     src/vision/qwen3vl_vision_config.cpp
+    src/vision/qwen3vl_vision_load.cpp
     src/vision/image_processor.cpp
     src/vision/vision_encoder.cu
 )
@@ -594,6 +595,7 @@ if(IMP_BUILD_TESTS)
         tests/test_awq_calibration.cpp
         tests/test_qwen3vl_vision_map.cpp
         tests/test_qwen3vl_vision_config.cpp
+        tests/test_qwen3vl_vision_load.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
         # Generative FSM battery for the schema-less json_object grammar. Lives

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -1,5 +1,7 @@
 #include "model/hf_config_loader.h"
 #include "model/json_util.h"
+#include "vision/qwen3vl_vision_config.h"
+#include "vision/vision_model.h"
 #include "model/llm_compressor_loader.h"
 #include "core/logging.h"
 #include "runtime/process_diag.h"
@@ -70,7 +72,8 @@ ModelArch HFConfigLoader::map_architecture(const std::string& hf_arch) {
 
 // ---- load_config ----
 
-bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg) {
+bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg,
+                                 std::unique_ptr<VisionModel>* out_vision_tower) {
     std::string path = model_dir + "/config.json";
     JValue root;
     if (!parse_json_file(path, root))
@@ -727,14 +730,39 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg)
     // cases don't silently degrade to text-only.
     const JValue* vc = jobj_find(root, "vision_config");
     if (vc && vc->type == JType::OBJECT) {
-        std::string model_type;
-        jobj_get_string(*vc, "model_type", model_type);
-        IMP_LOG_WARN(
-            "Multimodal model detected (vision_config present, model_type='%s'). "
-            "imp's SafeTensors loader handles only the language head; the "
-            "vision tower will be skipped. Multimodal SafeTensors support is "
-            "a separate audit item (#18).",
-            model_type.empty() ? "?" : model_type.c_str());
+        std::string vision_type;
+        jobj_get_string(*vc, "model_type", vision_type);
+        // Qwen3-VL's tower is understood: parse its geometry here and let
+        // weight_map fill the weights. Everything else still degrades to
+        // text-only, loudly.
+        bool parsed = false;
+        if (vision_type == "qwen3_vl" && out_vision_tower) {
+            auto tower = std::make_unique<VisionModel>();
+            std::string verr;
+            if (parse_qwen3vl_vision_config(*vc, tower->config, verr)) {
+                *out_vision_tower = std::move(tower);
+                parsed = true;
+                IMP_LOG_INFO(
+                    "Qwen3-VL vision tower: depth=%d hidden=%d heads=%d patch=%d merge=%d "
+                    "pos_grid=%dx%d out=%d deepstack=%zu",
+                    (*out_vision_tower)->config.num_layers, (*out_vision_tower)->config.hidden_size,
+                    (*out_vision_tower)->config.num_heads, (*out_vision_tower)->config.patch_size,
+                    (*out_vision_tower)->config.merge_size, (*out_vision_tower)->config.pos_embed_grid,
+                    (*out_vision_tower)->config.pos_embed_grid, (*out_vision_tower)->config.out_hidden_size,
+                    (*out_vision_tower)->config.deepstack_indexes.size());
+            } else {
+                // Refusing beats loading a tower whose geometry we misread.
+                IMP_LOG_WARN("Qwen3-VL vision_config rejected (%s) — continuing text-only", verr.c_str());
+            }
+        }
+        if (!parsed) {
+            IMP_LOG_WARN(
+                "Multimodal model detected (vision_config present, model_type='%s'). "
+                "imp's SafeTensors loader handles only the language head; the "
+                "vision tower will be skipped. Multimodal SafeTensors support is "
+                "a separate audit item (#18).",
+                vision_type.empty() ? "?" : vision_type.c_str());
+        }
     }
 
     if (cfg.arch == ModelArch::GENERIC) {

--- a/src/model/hf_config_loader.h
+++ b/src/model/hf_config_loader.h
@@ -4,16 +4,24 @@
 #include "model/model_arch.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace imp {
 
+struct VisionModel;  // vision/vision_model.h — only a pointer is needed here
+
 struct HFConfigLoader {
     // Load config.json from model directory, populate ModelConfig.
     // Returns true if config.json was found and parsed successfully.
     // Only overwrites cfg fields that are present in the JSON.
-    static bool load_config(const std::string& model_dir, ModelConfig& cfg);
+    // `out_vision_tower` is optional: when non-null AND the checkpoint carries a
+    // vision tower this loader understands, it receives a VisionModel with only
+    // its `config` filled — the weights are weight_map's half. Left null for
+    // every text-only path, so nothing else changes.
+    static bool load_config(const std::string& model_dir, ModelConfig& cfg,
+                            std::unique_ptr<VisionModel>* out_vision_tower = nullptr);
 
     // Sampling and stop-condition defaults shipped by the model author in
     // generation_config.json. Sentinel values (<0 for floats, -1 for ints,

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -3,6 +3,8 @@
 #include "core/logging.h"
 #include "memory/mem_account.h"  // trim_device_mempool
 #include "memory/weight_snapshot.h"
+// Complete type needed here: ~Model destroys the unique_ptr<VisionModel>.
+#include "vision/vision_model.h"
 #include <cuda_runtime.h>
 #include <algorithm>
 #include <cctype>

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -16,6 +16,12 @@
 namespace imp {
 
 class WeightUploadLog;
+// The vision tower of a multimodal checkpoint. Held by Model — not by the
+// pipeline — because its weights come from the SAME checkpoint and are views
+// into the same mapping, so its lifetime IS the model's. Forward-declared so
+// model/ keeps no header dependency on vision/; only model.cpp (destructor) and
+// weight_map.cpp (which fills it) include the definition.
+struct VisionModel;
 
 class Model {
 public:
@@ -155,6 +161,10 @@ public:
     bool sources_consumed_ = false;         // Phase-4b freed source tensors (#830)
     bool device_sources_mutated_ = false;   // in-place transformed device sources
     std::unique_ptr<WeightUploadLog> upload_log_;
+    // Null unless the checkpoint carries one. Populated in two steps by the
+    // parties that own each half: the config loader fills `->config` from
+    // config.json, weight_map fills the tensors from the shard map.
+    std::unique_ptr<VisionModel> vision_tower;
     int last_warm_hits_ = 0;
     // Path the loader was invoked with (GGUF file or SafeTensors directory).
     // Used to derive the on-disk warm-cache location and its fingerprint

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -836,7 +836,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
     ModelConfig& cfg = model->config_;
 
     // 1. Try config.json (authoritative for all hyperparams)
-    bool has_config = HFConfigLoader::load_config(model_dir, cfg);
+    bool has_config = HFConfigLoader::load_config(model_dir, cfg, &model->vision_tower);
 
     // 2. Detect architecture from weights if config.json didn't provide it
     if (!has_config || cfg.arch == ModelArch::GENERIC) {

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -1,4 +1,5 @@
 #include "model/weight_map.h"
+#include "vision/qwen3vl_vision_load.h"
 #include "model/tensor_kind_matcher.h"
 #include "core/logging.h"
 #include <string>
@@ -356,6 +357,8 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
             // they ever appear in the main shard, drop them here.
             const std::string visual_prefix = "model.visual.";
             if (name.compare(0, visual_prefix.size(), visual_prefix) == 0) {
+                // Routed into the vision tower below when there is one; still
+                // skipped here either way, since these are not LM weights.
                 ++skipped;
                 continue;
             }
@@ -1318,6 +1321,27 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
         "WeightMap (%s): assigned %d tensors, skipped %d, "
         "layers=%d, experts=%d",
         model_arch_name(arch_), assigned, skipped, model.config_.n_layers, model.config_.n_experts);
+
+    // Vision tower, when the config loader recognised one. Its weights ride in
+    // the same shard map as the LM's — that is why Model owns it — but they are
+    // routed by their own mapper, not by the LM matchers above.
+    if (model.vision_tower) {
+        Qwen3VLVisionLoadStats vstats;
+        std::string verr;
+        if (load_qwen3vl_vision_tensors(tensors, *model.vision_tower, vstats, verr)) {
+            IMP_LOG_INFO("Vision tower: %d tensors assigned (%zu blocks, %zu deepstack mergers)",
+                         vstats.assigned, model.vision_tower->layers.size(),
+                         model.vision_tower->deepstack_mergers.size());
+        } else {
+            // Drop it rather than hand the encoder a tower with null slots —
+            // that would surface as a garbage embedding many layers later.
+            IMP_LOG_WARN(
+                "Vision tower incomplete (%s; %d assigned, %d unknown, %d missing) — "
+                "continuing text-only",
+                verr.c_str(), vstats.assigned, vstats.unknown, vstats.missing);
+            model.vision_tower.reset();
+        }
+    }
 
     if (assigned == 0) {
         IMP_LOG_ERROR("WeightMap: no tensors were assigned -- check weight names");

--- a/src/vision/qwen3vl_vision_load.cpp
+++ b/src/vision/qwen3vl_vision_load.cpp
@@ -1,0 +1,291 @@
+#include "vision/qwen3vl_vision_load.h"
+
+#include "core/logging.h"
+#include "vision/qwen3vl_vision_map.h"
+
+namespace imp {
+
+namespace {
+
+using Slot = Qwen3VLVisionSlot;
+
+constexpr const char* kVisualPrefix = "model.visual.";
+
+VisionMergerWeights* merger_for(VisionModel& m, int index) {
+    if (index < 0)
+        return &m.merger;
+    if (index < static_cast<int>(m.deepstack_mergers.size()))
+        return &m.deepstack_mergers[static_cast<size_t>(index)];
+    return nullptr;
+}
+
+// Assign into the slot, refusing to overwrite. A second tensor landing in the
+// same slot means the mapper and this router disagree, which would otherwise
+// show up as "the encoder uses whichever came last in hash order".
+bool put(Tensor& dst, const Tensor& src, const char* what, std::string& err) {
+    if (dst.data != nullptr) {
+        err = std::string("two tensors claim the same slot: ") + what;
+        return false;
+    }
+    dst = src;
+    return true;
+}
+
+// The shape every slot must have, derived from the config alone. `ndim == 0`
+// means "no expectation".
+struct Expect {
+    int ndim = 0;
+    int64_t d0 = 0;
+    int64_t d1 = 0;
+};
+
+Expect expected_for(Slot s, int index, const VisionConfig& c) {
+    const int64_t h = c.hidden_size;
+    const int64_t f = c.intermediate_size;
+    // A merged token is the 2x2 spatial block concatenated, so every merger
+    // tensor is sized in this unit rather than in hidden_size.
+    const int64_t m = static_cast<int64_t>(c.merge_size) * c.merge_size * h;
+    const int64_t grid = static_cast<int64_t>(c.pos_embed_grid) * c.pos_embed_grid;
+    // in_channels is 3 for every published Qwen3-VL. It is not parsed from the
+    // config, so a hypothetical single-channel variant is refused here with an
+    // explicit shape mismatch rather than silently mis-strided.
+    const int64_t patch_in = int64_t(3) * c.temporal_patch_size * c.patch_size * c.patch_size;
+
+    switch (s) {
+        case Slot::PatchEmbedWeight:
+            return {2, h, patch_in};  // conv3d weight, flattened by the loader
+        case Slot::PosEmbed:
+            return {2, grid, h};
+        case Slot::QkvWeight:
+            return {2, 3 * h, h};
+        case Slot::QkvBias:
+            return {1, 3 * h, 0};
+        case Slot::ProjWeight:
+            return {2, h, h};
+        case Slot::Fc1Weight:
+            return {2, f, h};
+        case Slot::Fc1Bias:
+            return {1, f, 0};
+        case Slot::Fc2Weight:
+            return {2, h, f};
+        case Slot::PatchEmbedBias:
+        case Slot::Norm1Weight:
+        case Slot::Norm1Bias:
+        case Slot::Norm2Weight:
+        case Slot::Norm2Bias:
+        case Slot::ProjBias:
+        case Slot::Fc2Bias:
+            return {1, h, 0};
+        // Merger norm placement is only visible in the shape: the main merger
+        // normalises BEFORE the 2x2 concat (width hidden_size), the DeepStack
+        // mergers AFTER it (width merge^2 * hidden_size). Getting this backwards
+        // normalises the wrong axis and still runs, so it is checked here.
+        case Slot::MergerNormWeight:
+        case Slot::MergerNormBias:
+            return {1, index < 0 ? h : m, 0};
+        case Slot::MergerFc1Weight:
+            return {2, m, m};
+        case Slot::MergerFc1Bias:
+            return {1, m, 0};
+        case Slot::MergerFc2Weight:
+            return {2, c.out_hidden_size, m};
+        case Slot::MergerFc2Bias:
+            return {1, c.out_hidden_size, 0};
+        default:
+            return {};
+    }
+}
+
+bool shape_ok(const Tensor& t, const Expect& e, const char* what, std::string& err) {
+    if (e.ndim == 0)
+        return true;
+    const bool ok = t.ndim == e.ndim && t.shape[0] == e.d0 && (e.ndim < 2 || t.shape[1] == e.d1);
+    if (ok)
+        return true;
+    err = std::string("vision tensor '") + what + "' has shape [" + std::to_string(t.shape[0]) +
+          (t.ndim > 1 ? ", " + std::to_string(t.shape[1]) : "") + "] (ndim " + std::to_string(t.ndim) +
+          "), config implies [" + std::to_string(e.d0) + (e.ndim > 1 ? ", " + std::to_string(e.d1) : "") +
+          "]";
+    return false;
+}
+
+}  // namespace
+
+bool load_qwen3vl_vision_tensors(const std::unordered_map<std::string, Tensor>& tensors, VisionModel& out,
+                                 Qwen3VLVisionLoadStats& stats, std::string& err) {
+    const VisionConfig& cfg = out.config;
+    if (!cfg.is_qwen3vl || cfg.num_layers <= 0) {
+        err = "vision config was not parsed before loading tensors";
+        return false;
+    }
+    out.layers.resize(static_cast<size_t>(cfg.num_layers));
+    out.deepstack_mergers.resize(cfg.deepstack_indexes.size());
+
+    const size_t plen = std::char_traits<char>::length(kVisualPrefix);
+    for (const auto& [name, t] : tensors) {
+        if (name.compare(0, plen, kVisualPrefix) != 0)
+            continue;
+        const std::string local = name.substr(plen);
+        const Qwen3VLVisionRef ref = qwen3vl_map_vision_tensor(local);
+        if (ref.slot == Slot::Unknown) {
+            // Reported, never ignored: an unrecognised vision tensor means this
+            // checkpoint is not shaped the way the mapper assumes.
+            IMP_LOG_WARN("Qwen3-VL vision: unrecognised tensor '%s'", name.c_str());
+            stats.unknown++;
+            continue;
+        }
+        // Checked before routing: a shape that contradicts the config means the
+        // config and the checkpoint describe different models, and every later
+        // consumer would read it as a stride.
+        if (!shape_ok(t, expected_for(ref.slot, ref.index, cfg), local.c_str(), err))
+            return false;
+
+        bool ok = true;
+        switch (ref.slot) {
+            case Slot::PatchEmbedWeight:
+                ok = put(out.patch_embd_w, t, local.c_str(), err);
+                break;
+            case Slot::PatchEmbedBias:
+                ok = put(out.patch_embd_b, t, local.c_str(), err);
+                break;
+            case Slot::PosEmbed:
+                ok = put(out.position_embd, t, local.c_str(), err);
+                break;
+            case Slot::MergerNormWeight:
+            case Slot::MergerNormBias:
+            case Slot::MergerFc1Weight:
+            case Slot::MergerFc1Bias:
+            case Slot::MergerFc2Weight:
+            case Slot::MergerFc2Bias: {
+                VisionMergerWeights* m = merger_for(out, ref.index);
+                if (!m) {
+                    err = "DeepStack merger index " + std::to_string(ref.index) +
+                          " has no slot (config lists " + std::to_string(out.deepstack_mergers.size()) + ")";
+                    return false;
+                }
+                Tensor* dst = nullptr;
+                switch (ref.slot) {
+                    case Slot::MergerNormWeight:
+                        dst = &m->norm_w;
+                        break;
+                    case Slot::MergerNormBias:
+                        dst = &m->norm_b;
+                        break;
+                    case Slot::MergerFc1Weight:
+                        dst = &m->fc1_w;
+                        break;
+                    case Slot::MergerFc1Bias:
+                        dst = &m->fc1_b;
+                        break;
+                    case Slot::MergerFc2Weight:
+                        dst = &m->fc2_w;
+                        break;
+                    default:
+                        dst = &m->fc2_b;
+                        break;
+                }
+                ok = put(*dst, t, local.c_str(), err);
+                break;
+            }
+            default: {
+                if (ref.index < 0 || ref.index >= cfg.num_layers) {
+                    err = "vision block index " + std::to_string(ref.index) + " exceeds depth " +
+                          std::to_string(cfg.num_layers);
+                    return false;
+                }
+                VisionLayerWeights& L = out.layers[static_cast<size_t>(ref.index)];
+                Tensor* dst = nullptr;
+                switch (ref.slot) {
+                    case Slot::Norm1Weight:
+                        dst = &L.ln1_w;
+                        break;
+                    case Slot::Norm1Bias:
+                        dst = &L.ln1_b;
+                        break;
+                    // The fused QKV stays whole here; splitting it into wq/wk/wv
+                    // is the uploader's job, since the split is a view of device
+                    // memory and this runs before upload.
+                    case Slot::QkvWeight:
+                        dst = &L.wq;
+                        break;
+                    case Slot::QkvBias:
+                        dst = &L.bq;
+                        break;
+                    case Slot::ProjWeight:
+                        dst = &L.wo;
+                        break;
+                    case Slot::ProjBias:
+                        dst = &L.bo;
+                        break;
+                    case Slot::Norm2Weight:
+                        dst = &L.ln2_w;
+                        break;
+                    case Slot::Norm2Bias:
+                        dst = &L.ln2_b;
+                        break;
+                    case Slot::Fc1Weight:
+                        dst = &L.ffn_up_w;
+                        break;
+                    case Slot::Fc1Bias:
+                        dst = &L.ffn_up_b;
+                        break;
+                    case Slot::Fc2Weight:
+                        dst = &L.ffn_down_w;
+                        break;
+                    default:
+                        dst = &L.ffn_down_b;
+                        break;
+                }
+                ok = put(*dst, t, local.c_str(), err);
+                break;
+            }
+        }
+        if (!ok)
+            return false;
+        stats.assigned++;
+    }
+
+    // A null slot is the failure this function exists to catch: the encoder
+    // would read it as a garbage embedding many layers later.
+    auto require = [&](const Tensor& t, const char* what) {
+        if (t.data == nullptr) {
+            stats.missing++;
+            if (err.empty())
+                err = std::string("vision tower is missing ") + what;
+        }
+    };
+    require(out.patch_embd_w, "patch_embed.proj.weight");
+    require(out.patch_embd_b, "patch_embed.proj.bias");
+    require(out.position_embd, "pos_embed.weight");
+    for (size_t i = 0; i < out.layers.size(); ++i) {
+        const VisionLayerWeights& L = out.layers[i];
+        const std::string p = "blocks." + std::to_string(i) + ".";
+        require(L.ln1_w, (p + "norm1.weight").c_str());
+        require(L.ln1_b, (p + "norm1.bias").c_str());
+        require(L.wq, (p + "attn.qkv.weight").c_str());
+        require(L.bq, (p + "attn.qkv.bias").c_str());
+        require(L.wo, (p + "attn.proj.weight").c_str());
+        require(L.bo, (p + "attn.proj.bias").c_str());
+        require(L.ln2_w, (p + "norm2.weight").c_str());
+        require(L.ln2_b, (p + "norm2.bias").c_str());
+        require(L.ffn_up_w, (p + "mlp.linear_fc1.weight").c_str());
+        require(L.ffn_up_b, (p + "mlp.linear_fc1.bias").c_str());
+        require(L.ffn_down_w, (p + "mlp.linear_fc2.weight").c_str());
+        require(L.ffn_down_b, (p + "mlp.linear_fc2.bias").c_str());
+    }
+    auto require_merger = [&](const VisionMergerWeights& m, const char* what) {
+        require(m.norm_w, what);
+        require(m.norm_b, what);
+        require(m.fc1_w, what);
+        require(m.fc1_b, what);
+        require(m.fc2_w, what);
+        require(m.fc2_b, what);
+    };
+    require_merger(out.merger, "merger");
+    for (size_t i = 0; i < out.deepstack_mergers.size(); ++i)
+        require_merger(out.deepstack_mergers[i], "a deepstack merger");
+
+    return stats.missing == 0;
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_load.h
+++ b/src/vision/qwen3vl_vision_load.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// Fill a Qwen3-VL VisionModel's tensors from a loaded shard map.
+//
+// The config half must already be in place (parse_qwen3vl_vision_config); this
+// only routes weights. Kept apart from the mapping and the config parse because
+// each has its own failure mode, and this one's is "a slot stayed null" —
+// which the encoder would hit much later as a garbage embedding.
+
+#include "core/tensor.h"
+#include "vision/vision_model.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace imp {
+
+struct Qwen3VLVisionLoadStats {
+    int assigned = 0;
+    int unknown = 0;  // model.visual.* names the mapper did not recognise
+    int missing = 0;  // slots the checkpoint never filled
+};
+
+// `tensors` is the full shard map (names as they appear in the checkpoint).
+// Only `model.visual.*` entries are touched. Returns false with `err` set when a
+// required slot is missing or a shape contradicts the config — a vision tower
+// with a null slot must not reach the encoder.
+bool load_qwen3vl_vision_tensors(const std::unordered_map<std::string, Tensor>& tensors, VisionModel& out,
+                                 Qwen3VLVisionLoadStats& stats, std::string& err);
+
+}  // namespace imp

--- a/tests/test_qwen3vl_vision_load.cpp
+++ b/tests/test_qwen3vl_vision_load.cpp
@@ -1,0 +1,258 @@
+// Routing the Qwen3-VL vision weights into the tower.
+//
+// The failure this guards is silent: a tower that loads with a null slot, or
+// with the merger norms swapped, still runs and returns embeddings unrelated to
+// the image. So the loader refuses, and these tests pin what it refuses.
+//
+// Oracle: the tensor names AND shapes of the staged Qwen3-VL-4B-Instruct
+// checkpoint, reconstructed here so the test needs neither it nor a GPU.
+
+#include "vision/qwen3vl_vision_load.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// Descriptors only — nothing dereferences the data, but a null pointer is how
+// the loader spells "missing", so it has to be non-null.
+char g_dummy[64];
+
+Tensor tensor(std::vector<int64_t> shape) {
+    Tensor t;
+    t.data = g_dummy;
+    t.qtype = QType::F16;
+    t.ndim = static_cast<int>(shape.size());
+    for (size_t i = 0; i < shape.size(); ++i)
+        t.shape[i] = shape[i];
+    t.compute_strides();
+    return t;
+}
+
+VisionConfig real_config() {
+    VisionConfig c;
+    c.is_qwen3vl = true;
+    c.num_layers = 24;
+    c.hidden_size = 1024;
+    c.num_heads = 16;
+    c.head_dim = 64;
+    c.intermediate_size = 4096;
+    c.patch_size = 16;
+    c.merge_size = 2;
+    c.temporal_patch_size = 2;
+    c.out_hidden_size = 2560;
+    c.pos_embed_grid = 48;
+    c.deepstack_indexes = {5, 11, 17};
+    return c;
+}
+
+// The real 315 `model.visual.*` tensors with their real shapes.
+std::unordered_map<std::string, Tensor> real_checkpoint() {
+    std::unordered_map<std::string, Tensor> m;
+    auto add = [&](const std::string& n, std::vector<int64_t> s) { m["model.visual." + n] = tensor(s); };
+
+    // conv3d [1024, 3, 2, 16, 16], flattened to 2-D by the SafeTensors loader.
+    add("patch_embed.proj.weight", {1024, 1536});
+    add("patch_embed.proj.bias", {1024});
+    add("pos_embed.weight", {2304, 1024});
+    for (int b = 0; b < 24; ++b) {
+        const std::string p = "blocks." + std::to_string(b) + ".";
+        add(p + "norm1.weight", {1024});
+        add(p + "norm1.bias", {1024});
+        add(p + "attn.qkv.weight", {3072, 1024});
+        add(p + "attn.qkv.bias", {3072});
+        add(p + "attn.proj.weight", {1024, 1024});
+        add(p + "attn.proj.bias", {1024});
+        add(p + "norm2.weight", {1024});
+        add(p + "norm2.bias", {1024});
+        add(p + "mlp.linear_fc1.weight", {4096, 1024});
+        add(p + "mlp.linear_fc1.bias", {4096});
+        add(p + "mlp.linear_fc2.weight", {1024, 4096});
+        add(p + "mlp.linear_fc2.bias", {1024});
+    }
+    // Main merger: norm sits BEFORE the 2x2 concat, so it is hidden-wide.
+    add("merger.norm.weight", {1024});
+    add("merger.norm.bias", {1024});
+    add("merger.linear_fc1.weight", {4096, 4096});
+    add("merger.linear_fc1.bias", {4096});
+    add("merger.linear_fc2.weight", {2560, 4096});
+    add("merger.linear_fc2.bias", {2560});
+    // DeepStack mergers: norm sits AFTER the concat, so it is four times wider.
+    for (int d = 0; d < 3; ++d) {
+        const std::string p = "deepstack_merger_list." + std::to_string(d) + ".";
+        add(p + "norm.weight", {4096});
+        add(p + "norm.bias", {4096});
+        add(p + "linear_fc1.weight", {4096, 4096});
+        add(p + "linear_fc1.bias", {4096});
+        add(p + "linear_fc2.weight", {2560, 4096});
+        add(p + "linear_fc2.bias", {2560});
+    }
+    return m;
+}
+
+VisionModel fresh_tower() {
+    VisionModel v;
+    v.config = real_config();
+    return v;
+}
+
+TEST(Qwen3VLVisionLoad, LoadsTheRealCheckpoint) {
+    auto tensors = real_checkpoint();
+    ASSERT_EQ(tensors.size(), 315u);
+
+    VisionModel v = fresh_tower();
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    ASSERT_TRUE(load_qwen3vl_vision_tensors(tensors, v, st, err)) << err;
+
+    EXPECT_EQ(st.assigned, 315);
+    EXPECT_EQ(st.unknown, 0);
+    EXPECT_EQ(st.missing, 0);
+    ASSERT_EQ(v.layers.size(), 24u);
+    ASSERT_EQ(v.deepstack_mergers.size(), 3u);
+
+    // Spot-check that the routing landed where the encoder will look, not just
+    // that nothing was null.
+    EXPECT_EQ(v.layers[7].wq.shape[0], 3072) << "the fused QKV must stay whole";
+    EXPECT_EQ(v.layers[7].ffn_down_w.shape[1], 4096);
+    EXPECT_EQ(v.patch_embd_w.shape[1], 1536);
+    EXPECT_EQ(v.position_embd.shape[0], 2304);
+    EXPECT_EQ(v.merger.norm_w.shape[0], 1024);
+    EXPECT_EQ(v.deepstack_mergers[2].norm_w.shape[0], 4096);
+}
+
+// The whole reason this returns bool: a tower with a hole must not reach the
+// encoder, where it would read as a garbage embedding many layers later.
+TEST(Qwen3VLVisionLoad, RefusesWhenASlotStaysNull) {
+    auto tensors = real_checkpoint();
+    tensors.erase("model.visual.blocks.13.attn.proj.bias");
+
+    VisionModel v = fresh_tower();
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    EXPECT_FALSE(load_qwen3vl_vision_tensors(tensors, v, st, err));
+    EXPECT_EQ(st.missing, 1);
+    EXPECT_NE(err.find("blocks.13.attn.proj.bias"), std::string::npos) << err;
+}
+
+// Main merger normalises before the 2x2 concat, DeepStack after it. Swapping
+// them normalises the wrong axis and still runs — only the shape says which.
+TEST(Qwen3VLVisionLoad, RefusesSwappedMergerNormWidths) {
+    auto tensors = real_checkpoint();
+    tensors["model.visual.merger.norm.weight"] = tensor({4096});
+
+    VisionModel v = fresh_tower();
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    EXPECT_FALSE(load_qwen3vl_vision_tensors(tensors, v, st, err));
+    EXPECT_NE(err.find("merger.norm.weight"), std::string::npos) << err;
+    EXPECT_NE(err.find("1024"), std::string::npos) << "the message must name the expected width: " << err;
+}
+
+TEST(Qwen3VLVisionLoad, RefusesAShapeTheConfigContradicts) {
+    struct Case {
+        const char* name;
+        std::vector<int64_t> shape;
+    };
+    const Case cases[] = {
+        {"model.visual.blocks.0.attn.qkv.weight", {1024, 1024}},  // not fused
+        {"model.visual.pos_embed.weight", {2305, 1024}},          // wrong grid
+        {"model.visual.patch_embed.proj.weight", {1024, 768}},    // temporal axis dropped
+        {"model.visual.merger.linear_fc2.weight", {2560, 1024}},  // pre-concat width
+        {"model.visual.blocks.3.norm1.weight", {1024, 1}},        // wrong rank
+    };
+    for (const auto& c : cases) {
+        auto tensors = real_checkpoint();
+        tensors[c.name] = tensor(c.shape);
+        VisionModel v = fresh_tower();
+        Qwen3VLVisionLoadStats st;
+        std::string err;
+        EXPECT_FALSE(load_qwen3vl_vision_tensors(tensors, v, st, err)) << c.name;
+        EXPECT_NE(err.find("shape"), std::string::npos) << c.name << ": " << err;
+    }
+}
+
+// LM weights ride in the same shard map. Touching them here would double-assign
+// tensors the WeightMap owns.
+TEST(Qwen3VLVisionLoad, IgnoresEverythingOutsideTheVisualPrefix) {
+    auto tensors = real_checkpoint();
+    tensors["model.language_model.layers.0.mlp.up_proj.weight"] = tensor({9728, 2560});
+    tensors["lm_head.weight"] = tensor({151936, 2560});
+    tensors["visual.blocks.0.norm1.weight"] = tensor({1024});  // prefix-like, not the prefix
+
+    VisionModel v = fresh_tower();
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    ASSERT_TRUE(load_qwen3vl_vision_tensors(tensors, v, st, err)) << err;
+    EXPECT_EQ(st.assigned, 315);
+    EXPECT_EQ(st.unknown, 0);
+}
+
+// An unrecognised vision tensor is reported but not fatal: a future checkpoint
+// may carry extras, and refusing the whole tower over one would be worse than
+// loading it and saying so.
+TEST(Qwen3VLVisionLoad, CountsUnknownVisualTensorsWithoutFailing) {
+    auto tensors = real_checkpoint();
+    tensors["model.visual.some_future_head.weight"] = tensor({8, 8});
+
+    VisionModel v = fresh_tower();
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    EXPECT_TRUE(load_qwen3vl_vision_tensors(tensors, v, st, err)) << err;
+    EXPECT_EQ(st.unknown, 1);
+    EXPECT_EQ(st.assigned, 315);
+}
+
+// Order matters: the config parse sizes the layer and merger vectors. Running
+// this first would resize to zero and route every block into nothing.
+TEST(Qwen3VLVisionLoad, RefusesAnUnparsedConfig) {
+    VisionModel v;  // is_qwen3vl still false
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    EXPECT_FALSE(load_qwen3vl_vision_tensors(real_checkpoint(), v, st, err));
+    EXPECT_NE(err.find("not parsed"), std::string::npos) << err;
+    EXPECT_EQ(st.assigned, 0);
+}
+
+// A DeepStack tap the config does not list has nowhere to go. Silently dropping
+// it would leave the LM injecting one embedding fewer than the checkpoint has.
+TEST(Qwen3VLVisionLoad, RefusesADeepstackMergerWithNoConfiguredSlot) {
+    auto tensors = real_checkpoint();
+    // Shaped correctly, so the refusal can only come from the missing slot.
+    const std::pair<const char*, std::vector<int64_t>> extra[] = {
+        {"norm.weight", {4096}},
+        {"norm.bias", {4096}},
+        {"linear_fc1.weight", {4096, 4096}},
+        {"linear_fc1.bias", {4096}},
+        {"linear_fc2.weight", {2560, 4096}},
+        {"linear_fc2.bias", {2560}},
+    };
+    for (const auto& [tail, shape] : extra)
+        tensors[std::string("model.visual.deepstack_merger_list.3.") + tail] = tensor(shape);
+
+    VisionModel v = fresh_tower();
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    EXPECT_FALSE(load_qwen3vl_vision_tensors(tensors, v, st, err));
+    EXPECT_NE(err.find("no slot"), std::string::npos) << err;
+}
+
+// Depth comes from the config, so a checkpoint with more blocks is a mismatch,
+// not something to grow into.
+TEST(Qwen3VLVisionLoad, RefusesABlockIndexPastTheConfiguredDepth) {
+    auto tensors = real_checkpoint();
+    tensors["model.visual.blocks.24.norm1.weight"] = tensor({1024});
+
+    VisionModel v = fresh_tower();
+    Qwen3VLVisionLoadStats st;
+    std::string err;
+    EXPECT_FALSE(load_qwen3vl_vision_tensors(tensors, v, st, err));
+    EXPECT_NE(err.find("exceeds depth"), std::string::npos) << err;
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Fifth piece of gap 2 (`docs/plans/2026-07-31-qwen3-vl-vision.md`), after `smart_resize` (#1166), `patchify` (#1167), the name mapping (#1168) and the config parse (#1169).

## What

The vision weights already rode in the same shard map as the LM's — the WeightMap counted 315 of them under `model.visual.` and dropped them on the floor. This routes them into a `VisionModel` instead, in the two halves that have different owners:

- `HFConfigLoader::load_config` gains an optional `out_vision_tower`; when the checkpoint carries a `vision_config` this loader understands, it fills the geometry. Left null on every text-only path, so nothing else changes.
- `WeightMap::apply_weights` fills the tensors, right after its own log line.

`Model` owns the tower because its weights come from the same checkpoint and are views into the same mapping, so its lifetime *is* the model's. It is forward-declared, so `model/` keeps no header dependency on `vision/` — only `model.cpp` (out-of-line destructor) and `weight_map.cpp` include the definition.

## Why it refuses so much

The failure this loader exists to catch is silent. A tower that loads with a null slot, or with the merger norms swapped, still runs; it just returns embeddings unrelated to the image, many layers downstream. So:

- every slot is **required** — a null one fails the load and names the tensor;
- every shape is **checked against the config** before routing;
- a tower that does not come out whole is **dropped with a WARN**, and the model continues text-only, rather than being handed to the encoder.

The merger-norm check is the sharp one. The main merger normalises **before** the 2×2 spatial concat (width `hidden_size` = 1024), the DeepStack mergers **after** it (width `merge_size² · hidden_size` = 4096). Nothing in the tensor names distinguishes them — only the shape does, and getting it backwards normalises the wrong axis while still running.

An unrecognised `model.visual.*` name is counted and warned about but is **not** fatal: a future checkpoint may carry extras, and refusing a whole tower over one is worse than loading it and saying so.

## Verification

Against the staged `Qwen3-VL-4B-Instruct`:

```
Qwen3-VL vision tower: depth=24 hidden=1024 heads=16 patch=16 merge=2 pos_grid=48x48 out=2560 deepstack=3
WeightMap (qwen3): assigned 398 tensors, skipped 315, layers=36, experts=0
Vision tower: 315 tensors assigned (24 blocks, 3 deepstack mergers)
```

315 assigned, 0 unknown, 0 missing. Text half untouched: the model still answers `'Red, blue, green'`, `degen_suite` reads 34 checks / 0 FAIL, and text-only Qwen3-0.6B is unaffected (`assigned 311 tensors, skipped 0, layers=28`).

Nine new host tests (`tests/test_qwen3vl_vision_load.cpp`) reconstruct the real 315 names **and shapes**, so they need neither the checkpoint nor a GPU. They pin: the full load, a missing slot, swapped merger-norm widths, five contradicted shapes, LM tensors in the same map being ignored, an unknown vision tensor being non-fatal, an unparsed config, a DeepStack merger with no configured slot, and a block index past the configured depth.

`test-core` green (779 ran / 719 passed / 60 GPU-skipped), file-size and alloc-sites gates clean.

## Not in this PR

Encoder forward, 3-axis M-RoPE, DeepStack injection. The tower is loaded, not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8