### PR TITLE
feat(vision): the Qwen3-VL encoder forward, against a CPU reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,10 @@ set(IMP_VISION_SOURCES
     src/vision/qwen3vl_vision_map.cpp
     src/vision/qwen3vl_vision_config.cpp
     src/vision/qwen3vl_vision_load.cpp
+    src/vision/qwen3vl_vision_grid.cpp
+    src/vision/qwen3vl_vision_upload.cpp
+    src/vision/qwen3vl_encoder_kernels.cu
+    src/vision/qwen3vl_encoder.cu
     src/vision/image_processor.cpp
     src/vision/vision_encoder.cu
 )
@@ -596,6 +600,7 @@ if(IMP_BUILD_TESTS)
         tests/test_qwen3vl_vision_map.cpp
         tests/test_qwen3vl_vision_config.cpp
         tests/test_qwen3vl_vision_load.cpp
+        tests/test_qwen3vl_vision_grid.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
         # Generative FSM battery for the schema-less json_object grammar. Lives
@@ -803,6 +808,7 @@ if(IMP_BUILD_TESTS)
         tests/test_prefix_cache_e2e.cpp
         tests/test_determinism_e2e.cpp
         tests/test_vision_golden.cu
+        tests/test_qwen3vl_encoder.cu
     )
 
     set(IMP_TEST_BINARIES

--- a/src/core/cuda_static_reset.cpp
+++ b/src/core/cuda_static_reset.cpp
@@ -13,6 +13,7 @@ void reset_static_cuda_state() {
     attention_cublas_reset_static_cuda_state();
     attention_mxfp4_prefill_reset_static_cuda_state();
     vision_encoder_reset_static_cuda_state();
+    qwen3vl_encoder_reset_static_cuda_state();
     // gemm_cutlass_sm120 / gemm_cutlass_mxfp4 have no hook: A7 step 8 deleted
     // the lazily-grown CUTLASS workspaces they existed to re-arm.
     fmha_sm120_reset_static_cuda_state();

--- a/src/core/cuda_static_reset.h
+++ b/src/core/cuda_static_reset.h
@@ -29,6 +29,7 @@ void gemm_grouped_nvfp4_smallM_reset_static_cuda_state();   // compute/gemm_grou
 void attention_cublas_reset_static_cuda_state();            // compute/attention_cublas.cu
 void attention_mxfp4_prefill_reset_static_cuda_state();     // compute/attention_mxfp4_prefill.cu
 void vision_encoder_reset_static_cuda_state();              // vision/vision_encoder.cu
+void qwen3vl_encoder_reset_static_cuda_state();             // vision/qwen3vl_encoder.cu
 void fmha_sm120_reset_static_cuda_state();                  // compute/attention_fmha_sm120.cu
 void fmha_mxfp4_reset_static_cuda_state();                  // compute/attention_fmha_mxfp4_sm120.cu
 void moe_batch_reset_static_cuda_state();                   // exec/executor_forward_moe_batch.cu

--- a/src/vision/qwen3vl_encoder.cu
+++ b/src/vision/qwen3vl_encoder.cu
@@ -1,0 +1,302 @@
+#include "vision/qwen3vl_encoder.h"
+
+#include "core/logging.h"
+#include "memory/vram_allocator.h"
+#include "vision/qwen3vl_encoder_kernels.h"
+
+#include <cublas_v2.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace imp {
+
+namespace {
+
+// Query rows per attention pass. The score matrix is the only buffer that grows
+// with tokens^2, so it is the one that gets chunked rather than sized for the
+// worst case.
+constexpr int kAttnChunk = 512;
+constexpr float kLayerNormEps = 1e-6f;
+constexpr float kVisionRopeTheta = 10000.0f;
+
+cublasHandle_t s_handle = nullptr;
+
+cublasHandle_t handle() {
+    if (!s_handle) {
+        cublasCreate(&s_handle);
+        cublasSetMathMode(s_handle, CUBLAS_TF32_TENSOR_OP_MATH);
+    }
+    return s_handle;
+}
+
+// C[M, N] = alpha * A[M, K] @ B[N, K]^T, all row-major. Weights come off the
+// checkpoint as [out, in], which is exactly B.
+void gemm_nt(const half* A, const half* B, half* C, int M, int N, int K, float alpha, float beta,
+             cudaStream_t stream) {
+    cublasSetStream(handle(), stream);
+    // FP32 accumulation: the FFN down-projection sums 4096 terms, and FP16
+    // accumulation overflows there for high-magnitude tokens.
+    cublasGemmEx(handle(), CUBLAS_OP_T, CUBLAS_OP_N, N, M, K, &alpha, B, CUDA_R_16F, K, A, CUDA_R_16F, K,
+                 &beta, C, CUDA_R_16F, N, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+}
+
+}  // namespace
+
+// Pre-cudaDeviceReset hook (see core/cuda_static_reset.h).
+void qwen3vl_encoder_reset_static_cuda_state() {
+    if (s_handle) {
+        (void)cublasDestroy(s_handle);
+        s_handle = nullptr;
+    }
+}
+
+Qwen3VLEncoder::~Qwen3VLEncoder() { free_buffers(); }
+
+void Qwen3VLEncoder::free_buffers() {
+    if (alloc_) {
+        for (void* p : allocs_)
+            alloc_->free(p);
+    }
+    allocs_.clear();
+    d_hidden_ = d_normed_ = d_proj_ = d_qkv_ = nullptr;
+    d_q_ = d_k_ = d_v_ = d_attn_ = d_scores_ = d_ffn_ = nullptr;
+    d_merge_norm_ = d_merge_fc_ = nullptr;
+    d_row_ = d_col_ = d_taps_ = nullptr;
+    d_weights_ = nullptr;
+    max_tokens_ = 0;
+}
+
+int Qwen3VLEncoder::merged_tokens(int tokens) const {
+    if (!model_)
+        return 0;
+    const int unit = model_->config.merge_size * model_->config.merge_size;
+    return tokens / unit;
+}
+
+bool Qwen3VLEncoder::init(const VisionModel& model, VRAMAllocator* alloc, int max_tokens) {
+    free_buffers();
+    if (!alloc || max_tokens <= 0) {
+        IMP_LOG_ERROR("Qwen3-VL encoder: needs an allocator and a positive token budget");
+        return false;
+    }
+    const VisionConfig& c = model.config;
+    if (!c.is_qwen3vl) {
+        IMP_LOG_ERROR("Qwen3-VL encoder: config is not a Qwen3-VL vision config");
+        return false;
+    }
+    const int unit = c.merge_size * c.merge_size;
+    if (max_tokens % unit != 0) {
+        IMP_LOG_ERROR("Qwen3-VL encoder: token budget %d is not a multiple of the merge unit %d", max_tokens,
+                      unit);
+        return false;
+    }
+    model_ = &model;
+    alloc_ = alloc;
+    max_tokens_ = max_tokens;
+
+    const int64_t n = max_tokens;
+    const int64_t H = c.hidden_size;
+    bool ok = true;
+    auto take = [&](int64_t elems, size_t elem_bytes, const char* tag) -> void* {
+        if (!ok)
+            return nullptr;
+        void* p = alloc->allocate(static_cast<size_t>(elems) * elem_bytes, tag);
+        if (!p) {
+            IMP_LOG_ERROR("Qwen3-VL encoder: out of VRAM for %s", tag);
+            ok = false;
+            return nullptr;
+        }
+        allocs_.push_back(p);
+        return p;
+    };
+    auto take_half = [&](int64_t elems, const char* tag) {
+        return static_cast<half*>(take(elems, sizeof(half), tag));
+    };
+
+    d_hidden_ = take_half(n * H, "vision_enc_hidden");
+    d_normed_ = take_half(n * H, "vision_enc_normed");
+    d_proj_ = take_half(n * H, "vision_enc_proj");
+    d_qkv_ = take_half(n * 3 * H, "vision_enc_qkv");
+    d_q_ = take_half(n * H, "vision_enc_q");
+    d_k_ = take_half(n * H, "vision_enc_k");
+    d_v_ = take_half(n * H, "vision_enc_v");
+    d_attn_ = take_half(n * H, "vision_enc_attn");
+    d_scores_ = take_half(static_cast<int64_t>(c.num_heads) * std::min<int64_t>(kAttnChunk, n) * n,
+                          "vision_enc_scores");
+    d_ffn_ = take_half(n * c.intermediate_size, "vision_enc_ffn");
+    d_merge_norm_ = take_half(n * H, "vision_enc_merge_norm");
+    d_merge_fc_ = take_half(n * H, "vision_enc_merge_fc");
+    d_row_ = static_cast<int32_t*>(take(n, sizeof(int32_t), "vision_enc_row"));
+    d_col_ = static_cast<int32_t*>(take(n, sizeof(int32_t), "vision_enc_col"));
+    d_taps_ = static_cast<int32_t*>(take(n * kQwenVisionPosTaps, sizeof(int32_t), "vision_enc_taps"));
+    d_weights_ = static_cast<float*>(take(n * kQwenVisionPosTaps, sizeof(float), "vision_enc_weights"));
+
+    if (!ok) {
+        free_buffers();
+        return false;
+    }
+    IMP_LOG_INFO("Qwen3-VL encoder ready: up to %d patches (%d merged tokens)", max_tokens,
+                 merged_tokens(max_tokens));
+    return true;
+}
+
+bool Qwen3VLEncoder::attention(int tokens, cudaStream_t stream) {
+    const VisionConfig& c = model_->config;
+    const int heads = c.num_heads;
+    const int hd = c.head_dim;
+    const float scale = 1.0f / std::sqrt(static_cast<float>(hd));
+    const float zero = 0.0f;
+    cublasSetStream(handle(), stream);
+
+    for (int c0 = 0; c0 < tokens; c0 += kAttnChunk) {
+        const int rows = std::min(kAttnChunk, tokens - c0);
+
+        // scores[h] = Q[h][c0 : c0+rows] @ K[h]^T * scale   -> [rows, tokens]
+        cublasStatus_t st = cublasGemmStridedBatchedEx(
+            handle(), CUBLAS_OP_T, CUBLAS_OP_N, tokens, rows, hd, &scale, d_k_, CUDA_R_16F, hd,
+            static_cast<long long>(tokens) * hd, d_q_ + static_cast<int64_t>(c0) * hd, CUDA_R_16F, hd,
+            static_cast<long long>(tokens) * hd, &zero, d_scores_, CUDA_R_16F, tokens,
+            static_cast<long long>(rows) * tokens, heads, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+        if (st != CUBLAS_STATUS_SUCCESS) {
+            IMP_LOG_ERROR("Qwen3-VL encoder: QK^T failed (%d)", static_cast<int>(st));
+            return false;
+        }
+
+        // Every head's chunk is contiguous, so one launch normalises them all.
+        launch_qwen3vl_softmax_rows(d_scores_, heads * rows, tokens, stream);
+
+        // out[h][c0 : c0+rows] = scores[h] @ V[h]   -> [rows, head_dim]
+        const float one = 1.0f;
+        st = cublasGemmStridedBatchedEx(handle(), CUBLAS_OP_N, CUBLAS_OP_N, hd, rows, tokens, &one, d_v_,
+                                        CUDA_R_16F, hd, static_cast<long long>(tokens) * hd, d_scores_,
+                                        CUDA_R_16F, tokens, static_cast<long long>(rows) * tokens, &zero,
+                                        d_attn_ + static_cast<int64_t>(c0) * hd, CUDA_R_16F, hd,
+                                        static_cast<long long>(tokens) * hd, heads, CUBLAS_COMPUTE_32F,
+                                        CUBLAS_GEMM_DEFAULT);
+        if (st != CUBLAS_STATUS_SUCCESS) {
+            IMP_LOG_ERROR("Qwen3-VL encoder: attn@V failed (%d)", static_cast<int>(st));
+            return false;
+        }
+    }
+    return true;
+}
+
+bool Qwen3VLEncoder::run_merger(const VisionMergerWeights& m, const half* d_hidden, int tokens, half* d_out,
+                                cudaStream_t stream) {
+    const VisionConfig& c = model_->config;
+    const int unit = c.merge_size * c.merge_size;
+    const int merged = tokens / unit;
+    const int wide = c.hidden_size * unit;
+
+    // The norm's own width says where it sits relative to the 2x2 concat: the
+    // main merger normalises each patch (hidden_size), the DeepStack mergers
+    // normalise the concatenated token (merge^2 * hidden_size). Same bytes
+    // either way — only the row length differs.
+    const bool postshuffle = m.norm_w.shape[0] == wide;
+    if (postshuffle)
+        launch_qwen3vl_layernorm(d_hidden, static_cast<const half*>(m.norm_w.data),
+                                 static_cast<const half*>(m.norm_b.data), d_merge_norm_, merged, wide,
+                                 kLayerNormEps, stream);
+    else
+        launch_qwen3vl_layernorm(d_hidden, static_cast<const half*>(m.norm_w.data),
+                                 static_cast<const half*>(m.norm_b.data), d_merge_norm_, tokens,
+                                 c.hidden_size, kLayerNormEps, stream);
+
+    gemm_nt(d_merge_norm_, static_cast<const half*>(m.fc1_w.data), d_merge_fc_, merged, wide, wide, 1.0f,
+            0.0f, stream);
+    launch_qwen3vl_add_bias(d_merge_fc_, static_cast<const half*>(m.fc1_b.data), merged, wide, stream);
+    // nn.GELU(), i.e. the exact erf form — NOT the tanh approximation the block
+    // MLP uses. Same symbol upstream, different function.
+    launch_qwen3vl_gelu_erf(d_merge_fc_, static_cast<int64_t>(merged) * wide, stream);
+
+    gemm_nt(d_merge_fc_, static_cast<const half*>(m.fc2_w.data), d_out, merged, c.out_hidden_size, wide, 1.0f,
+            0.0f, stream);
+    launch_qwen3vl_add_bias(d_out, static_cast<const half*>(m.fc2_b.data), merged, c.out_hidden_size, stream);
+    return true;
+}
+
+bool Qwen3VLEncoder::encode(const half* d_patches, const QwenVisionGrid& grid, half* d_out,
+                            const std::vector<half*>& d_deepstack_out, cudaStream_t stream) {
+    if (!model_ || !d_hidden_) {
+        IMP_LOG_ERROR("Qwen3-VL encoder: encode before init");
+        return false;
+    }
+    const VisionConfig& c = model_->config;
+    const int n = grid.tokens;
+    if (n <= 0 || n > max_tokens_) {
+        IMP_LOG_ERROR("Qwen3-VL encoder: %d patches exceeds the %d-patch budget", n, max_tokens_);
+        return false;
+    }
+    if (!d_deepstack_out.empty() && d_deepstack_out.size() != c.deepstack_indexes.size()) {
+        IMP_LOG_ERROR("Qwen3-VL encoder: %zu DeepStack outputs for %zu taps", d_deepstack_out.size(),
+                      c.deepstack_indexes.size());
+        return false;
+    }
+
+    const int H = c.hidden_size;
+    const int features = static_cast<int>(model_->patch_embd_w.shape[1]);
+
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_row_, grid.row.data(), static_cast<size_t>(n) * sizeof(int32_t),
+                                       cudaMemcpyHostToDevice, stream));
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_col_, grid.col.data(), static_cast<size_t>(n) * sizeof(int32_t),
+                                       cudaMemcpyHostToDevice, stream));
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_taps_, grid.pos_taps.data(), grid.pos_taps.size() * sizeof(int32_t),
+                                       cudaMemcpyHostToDevice, stream));
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_weights_, grid.pos_weights.data(),
+                                       grid.pos_weights.size() * sizeof(float), cudaMemcpyHostToDevice,
+                                       stream));
+
+    // Patch embedding. The checkpoint's Conv3d has kernel == stride == the whole
+    // patch, so it is a plain matrix product against the flattened weight.
+    gemm_nt(d_patches, static_cast<const half*>(model_->patch_embd_w.data), d_hidden_, n, H, features, 1.0f,
+            0.0f, stream);
+    launch_qwen3vl_add_bias(d_hidden_, static_cast<const half*>(model_->patch_embd_b.data), n, H, stream);
+    launch_qwen3vl_pos_embed_add(d_hidden_, static_cast<const half*>(model_->position_embd.data), d_taps_,
+                                 d_weights_, n, H, kQwenVisionPosTaps, stream);
+
+    size_t next_tap = 0;
+    for (int l = 0; l < c.num_layers; ++l) {
+        const VisionLayerWeights& L = model_->layers[static_cast<size_t>(l)];
+
+        launch_qwen3vl_layernorm(d_hidden_, static_cast<const half*>(L.ln1_w.data),
+                                 static_cast<const half*>(L.ln1_b.data), d_normed_, n, H, kLayerNormEps,
+                                 stream);
+        gemm_nt(d_normed_, static_cast<const half*>(L.wq.data), d_qkv_, n, 3 * H, H, 1.0f, 0.0f, stream);
+        launch_qwen3vl_add_bias(d_qkv_, static_cast<const half*>(L.bq.data), n, 3 * H, stream);
+        launch_qwen3vl_split_qkv_rope(d_qkv_, d_row_, d_col_, d_q_, d_k_, d_v_, n, c.num_heads, c.head_dim,
+                                      kVisionRopeTheta, stream);
+        if (!attention(n, stream))
+            return false;
+        launch_qwen3vl_merge_heads(d_attn_, d_normed_, n, c.num_heads, c.head_dim, stream);
+        gemm_nt(d_normed_, static_cast<const half*>(L.wo.data), d_proj_, n, H, H, 1.0f, 0.0f, stream);
+        launch_qwen3vl_add_bias(d_proj_, static_cast<const half*>(L.bo.data), n, H, stream);
+        launch_qwen3vl_residual_add(d_hidden_, d_proj_, static_cast<int64_t>(n) * H, stream);
+
+        launch_qwen3vl_layernorm(d_hidden_, static_cast<const half*>(L.ln2_w.data),
+                                 static_cast<const half*>(L.ln2_b.data), d_normed_, n, H, kLayerNormEps,
+                                 stream);
+        gemm_nt(d_normed_, static_cast<const half*>(L.ffn_up_w.data), d_ffn_, n, c.intermediate_size, H, 1.0f,
+                0.0f, stream);
+        launch_qwen3vl_add_bias(d_ffn_, static_cast<const half*>(L.ffn_up_b.data), n, c.intermediate_size,
+                                stream);
+        launch_qwen3vl_gelu_tanh(d_ffn_, static_cast<int64_t>(n) * c.intermediate_size, stream);
+        gemm_nt(d_ffn_, static_cast<const half*>(L.ffn_down_w.data), d_proj_, n, H, c.intermediate_size, 1.0f,
+                0.0f, stream);
+        launch_qwen3vl_add_bias(d_proj_, static_cast<const half*>(L.ffn_down_b.data), n, H, stream);
+        launch_qwen3vl_residual_add(d_hidden_, d_proj_, static_cast<int64_t>(n) * H, stream);
+
+        // DeepStack taps read the block's OUTPUT, and `deepstack_indexes` is
+        // sorted, so a running cursor is enough.
+        if (next_tap < c.deepstack_indexes.size() && c.deepstack_indexes[next_tap] == l) {
+            if (!d_deepstack_out.empty() && !run_merger(model_->deepstack_mergers[next_tap], d_hidden_, n,
+                                                        d_deepstack_out[next_tap], stream))
+                return false;
+            ++next_tap;
+        }
+    }
+
+    return run_merger(model_->merger, d_hidden_, n, d_out, stream);
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_encoder.h
+++ b/src/vision/qwen3vl_encoder.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// The Qwen3-VL vision encoder forward.
+//
+// Unlike the fixed-resolution encoder next door, this one has no `image_size`:
+// the token count comes from the image. Buffers are therefore sized once to a
+// configured maximum and the forward runs over whatever prefix an image needs,
+// which is also why attention is chunked over query rows — a full
+// [heads, tokens, tokens] score matrix is the one buffer that grows
+// quadratically and would dominate everything else.
+
+#include "vision/qwen3vl_vision_grid.h"
+#include "vision/vision_model.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <vector>
+
+namespace imp {
+
+class VRAMAllocator;
+
+class Qwen3VLEncoder {
+public:
+    Qwen3VLEncoder() = default;
+    ~Qwen3VLEncoder();
+    Qwen3VLEncoder(const Qwen3VLEncoder&) = delete;
+    Qwen3VLEncoder& operator=(const Qwen3VLEncoder&) = delete;
+
+    // `model` must already be uploaded (qwen3vl_upload_vision_tower). Its
+    // lifetime must outlast this encoder — only the pointer is kept.
+    bool init(const VisionModel& model, VRAMAllocator* alloc, int max_tokens);
+    void free_buffers();
+
+    int max_tokens() const { return max_tokens_; }
+    // Merged image tokens produced for a `tokens`-patch image.
+    int merged_tokens(int tokens) const;
+
+    // d_patches: [grid.tokens, features] FP16 device, in the patchifier's
+    //   merge-block token order.
+    // d_out: [merged_tokens, out_hidden_size] FP16 device, caller-allocated.
+    // d_deepstack_out: one buffer per config.deepstack_indexes, same shape as
+    //   d_out. Empty is allowed and simply skips the taps.
+    bool encode(const half* d_patches, const QwenVisionGrid& grid, half* d_out,
+                const std::vector<half*>& d_deepstack_out, cudaStream_t stream);
+
+private:
+    bool run_merger(const VisionMergerWeights& m, const half* d_hidden, int tokens, half* d_out,
+                    cudaStream_t stream);
+    bool attention(int tokens, cudaStream_t stream);
+
+    const VisionModel* model_ = nullptr;
+    VRAMAllocator* alloc_ = nullptr;
+    int max_tokens_ = 0;
+
+    half* d_hidden_ = nullptr;  // [max_tokens, hidden]
+    half* d_normed_ = nullptr;  // [max_tokens, hidden]
+    half* d_proj_ = nullptr;    // [max_tokens, hidden]
+    half* d_qkv_ = nullptr;     // [max_tokens, 3*hidden]
+    half* d_q_ = nullptr;       // [heads, max_tokens, head_dim]
+    half* d_k_ = nullptr;
+    half* d_v_ = nullptr;
+    half* d_attn_ = nullptr;        // [heads, max_tokens, head_dim]
+    half* d_scores_ = nullptr;      // [heads, chunk, max_tokens]
+    half* d_ffn_ = nullptr;         // [max_tokens, intermediate]
+    half* d_merge_norm_ = nullptr;  // [max_tokens, hidden] (== [merged, merge^2*hidden])
+    half* d_merge_fc_ = nullptr;    // [merged, merge^2*hidden]
+
+    int32_t* d_row_ = nullptr;
+    int32_t* d_col_ = nullptr;
+    int32_t* d_taps_ = nullptr;
+    float* d_weights_ = nullptr;
+
+    std::vector<void*> allocs_;
+};
+
+}  // namespace imp

--- a/src/vision/qwen3vl_encoder_kernels.cu
+++ b/src/vision/qwen3vl_encoder_kernels.cu
@@ -1,0 +1,245 @@
+#include "vision/qwen3vl_encoder_kernels.h"
+
+#include <cmath>
+
+namespace imp {
+
+namespace {
+
+constexpr int kBlock = 256;
+
+__global__ void pos_embed_add_kernel(half* __restrict__ hidden, const half* __restrict__ table,
+                                     const int32_t* __restrict__ taps, const float* __restrict__ weights,
+                                     int dim, int taps_per_token) {
+    const int token = blockIdx.x;
+    const int32_t* my_taps = taps + static_cast<int64_t>(token) * taps_per_token;
+    const float* my_w = weights + static_cast<int64_t>(token) * taps_per_token;
+    half* row = hidden + static_cast<int64_t>(token) * dim;
+
+    for (int j = threadIdx.x; j < dim; j += blockDim.x) {
+        float acc = __half2float(row[j]);
+        for (int t = 0; t < taps_per_token; ++t) {
+            const float w = my_w[t];
+            // A zero weight is the common case at the grid edges; skipping the
+            // load matters because these are scattered rows.
+            if (w != 0.0f)
+                acc += w * __half2float(table[static_cast<int64_t>(my_taps[t]) * dim + j]);
+        }
+        row[j] = __float2half(acc);
+    }
+}
+
+// One block per row, FP32 accumulation. `dim` is 1024 or 4096 here, so a plain
+// two-pass block reduction is both simple and enough.
+__global__ void layernorm_kernel(const half* __restrict__ x, const half* __restrict__ weight,
+                                 const half* __restrict__ bias, half* __restrict__ out, int dim, float eps) {
+    extern __shared__ float smem[];
+    const int row = blockIdx.x;
+    const half* xr = x + static_cast<int64_t>(row) * dim;
+    half* outr = out + static_cast<int64_t>(row) * dim;
+
+    float sum = 0.0f;
+    for (int j = threadIdx.x; j < dim; j += blockDim.x)
+        sum += __half2float(xr[j]);
+    smem[threadIdx.x] = sum;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s)
+            smem[threadIdx.x] += smem[threadIdx.x + s];
+        __syncthreads();
+    }
+    const float mean = smem[0] / dim;
+    __syncthreads();
+
+    float var = 0.0f;
+    for (int j = threadIdx.x; j < dim; j += blockDim.x) {
+        const float d = __half2float(xr[j]) - mean;
+        var += d * d;
+    }
+    smem[threadIdx.x] = var;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s)
+            smem[threadIdx.x] += smem[threadIdx.x + s];
+        __syncthreads();
+    }
+    const float inv_std = rsqrtf(smem[0] / dim + eps);
+
+    for (int j = threadIdx.x; j < dim; j += blockDim.x) {
+        const float v = (__half2float(xr[j]) - mean) * inv_std;
+        outr[j] = __float2half(v * __half2float(weight[j]) + __half2float(bias[j]));
+    }
+}
+
+__global__ void add_bias_kernel(half* __restrict__ x, const half* __restrict__ bias, int64_t n, int dim) {
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < n)
+        x[i] = __float2half(__half2float(x[i]) + __half2float(bias[i % dim]));
+}
+
+__global__ void residual_add_kernel(half* __restrict__ dst, const half* __restrict__ src, int64_t n) {
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < n)
+        dst[i] = __float2half(__half2float(dst[i]) + __half2float(src[i]));
+}
+
+__global__ void gelu_tanh_kernel(half* __restrict__ x, int64_t n) {
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= n)
+        return;
+    const float v = __half2float(x[i]);
+    const float inner = 0.7978845608028654f * (v + 0.044715f * v * v * v);
+    x[i] = __float2half(0.5f * v * (1.0f + tanhf(inner)));
+}
+
+__global__ void gelu_erf_kernel(half* __restrict__ x, int64_t n) {
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= n)
+        return;
+    const float v = __half2float(x[i]);
+    x[i] = __float2half(0.5f * v * (1.0f + erff(v * 0.7071067811865476f)));
+}
+
+// One block per (head, token). Reads the fused row once, writes q/k/v into the
+// per-head layout the batched attention GEMMs want, and rotates q/k on the way.
+__global__ void split_qkv_rope_kernel(const half* __restrict__ qkv, const int32_t* __restrict__ row_id,
+                                      const int32_t* __restrict__ col_id, half* __restrict__ q,
+                                      half* __restrict__ k, half* __restrict__ v, int tokens, int heads,
+                                      int head_dim, float theta) {
+    const int head = blockIdx.y;
+    const int token = blockIdx.x;
+    const int hidden = heads * head_dim;
+    const int half_rot = head_dim / 2;  // rotated pair distance
+    const int quarter = half_rot / 2;   // where the row axis hands over to the column axis
+    const int64_t src = static_cast<int64_t>(token) * 3 * hidden + head * head_dim;
+    const int64_t dst = (static_cast<int64_t>(head) * tokens + token) * head_dim;
+
+    for (int j = threadIdx.x; j < head_dim; j += blockDim.x)
+        v[dst + j] = qkv[src + 2 * hidden + j];
+
+    const float r = static_cast<float>(row_id[token]);
+    const float c = static_cast<float>(col_id[token]);
+    for (int j = threadIdx.x; j < half_rot; j += blockDim.x) {
+        // The rotary index j runs over head_dim/2 angles; the first quarter of
+        // head_dim is driven by the row, the second by the column.
+        const int fi = (j < quarter) ? j : (j - quarter);
+        const float pos = (j < quarter) ? r : c;
+        const float inv_freq = __powf(theta, -static_cast<float>(2 * fi) / static_cast<float>(half_rot));
+        const float ang = pos * inv_freq;
+        float cs, sn;
+        __sincosf(ang, &sn, &cs);
+
+        const float q0 = __half2float(qkv[src + j]);
+        const float q1 = __half2float(qkv[src + j + half_rot]);
+        q[dst + j] = __float2half(q0 * cs - q1 * sn);
+        q[dst + j + half_rot] = __float2half(q1 * cs + q0 * sn);
+
+        const float k0 = __half2float(qkv[src + hidden + j]);
+        const float k1 = __half2float(qkv[src + hidden + j + half_rot]);
+        k[dst + j] = __float2half(k0 * cs - k1 * sn);
+        k[dst + j + half_rot] = __float2half(k1 * cs + k0 * sn);
+    }
+}
+
+__global__ void softmax_rows_kernel(half* __restrict__ scores, int cols) {
+    extern __shared__ float smem[];
+    const int64_t base = static_cast<int64_t>(blockIdx.x) * cols;
+
+    float m = -INFINITY;
+    for (int j = threadIdx.x; j < cols; j += blockDim.x)
+        m = fmaxf(m, __half2float(scores[base + j]));
+    smem[threadIdx.x] = m;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s)
+            smem[threadIdx.x] = fmaxf(smem[threadIdx.x], smem[threadIdx.x + s]);
+        __syncthreads();
+    }
+    const float row_max = smem[0];
+    __syncthreads();
+
+    float sum = 0.0f;
+    for (int j = threadIdx.x; j < cols; j += blockDim.x) {
+        const float e = __expf(__half2float(scores[base + j]) - row_max);
+        scores[base + j] = __float2half(e);
+        sum += e;
+    }
+    smem[threadIdx.x] = sum;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s)
+            smem[threadIdx.x] += smem[threadIdx.x + s];
+        __syncthreads();
+    }
+    const float inv = 1.0f / smem[0];
+    for (int j = threadIdx.x; j < cols; j += blockDim.x)
+        scores[base + j] = __float2half(__half2float(scores[base + j]) * inv);
+}
+
+__global__ void merge_heads_kernel(const half* __restrict__ per_head, half* __restrict__ out, int tokens,
+                                   int heads, int head_dim) {
+    const int token = blockIdx.x;
+    const int hidden = heads * head_dim;
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        const int head = j / head_dim;
+        const int d = j % head_dim;
+        out[static_cast<int64_t>(token) * hidden + j] =
+            per_head[(static_cast<int64_t>(head) * tokens + token) * head_dim + d];
+    }
+}
+
+int reduce_threads(int dim) {
+    int t = 32;
+    while (t < dim && t < 1024)
+        t *= 2;
+    return t;
+}
+
+}  // namespace
+
+void launch_qwen3vl_pos_embed_add(half* hidden, const half* table, const int32_t* taps, const float* weights,
+                                  int tokens, int dim, int taps_per_token, cudaStream_t stream) {
+    pos_embed_add_kernel<<<tokens, kBlock, 0, stream>>>(hidden, table, taps, weights, dim, taps_per_token);
+}
+
+void launch_qwen3vl_layernorm(const half* x, const half* weight, const half* bias, half* out, int rows,
+                              int dim, float eps, cudaStream_t stream) {
+    const int threads = reduce_threads(dim);
+    layernorm_kernel<<<rows, threads, threads * sizeof(float), stream>>>(x, weight, bias, out, dim, eps);
+}
+
+void launch_qwen3vl_add_bias(half* x, const half* bias, int rows, int dim, cudaStream_t stream) {
+    const int64_t n = static_cast<int64_t>(rows) * dim;
+    add_bias_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(x, bias, n, dim);
+}
+
+void launch_qwen3vl_residual_add(half* dst, const half* src, int64_t n, cudaStream_t stream) {
+    residual_add_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(dst, src, n);
+}
+
+void launch_qwen3vl_gelu_tanh(half* x, int64_t n, cudaStream_t stream) {
+    gelu_tanh_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(x, n);
+}
+
+void launch_qwen3vl_gelu_erf(half* x, int64_t n, cudaStream_t stream) {
+    gelu_erf_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(x, n);
+}
+
+void launch_qwen3vl_split_qkv_rope(const half* qkv, const int32_t* row, const int32_t* col, half* q, half* k,
+                                   half* v, int tokens, int heads, int head_dim, float theta,
+                                   cudaStream_t stream) {
+    dim3 grid(tokens, heads);
+    split_qkv_rope_kernel<<<grid, 64, 0, stream>>>(qkv, row, col, q, k, v, tokens, heads, head_dim, theta);
+}
+
+void launch_qwen3vl_softmax_rows(half* scores, int rows, int cols, cudaStream_t stream) {
+    const int threads = reduce_threads(cols);
+    softmax_rows_kernel<<<rows, threads, threads * sizeof(float), stream>>>(scores, cols);
+}
+
+void launch_qwen3vl_merge_heads(const half* per_head, half* out, int tokens, int heads, int head_dim,
+                                cudaStream_t stream) {
+    merge_heads_kernel<<<tokens, kBlock, 0, stream>>>(per_head, out, tokens, heads, head_dim);
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_encoder_kernels.h
+++ b/src/vision/qwen3vl_encoder_kernels.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// Element-wise and layout kernels of the Qwen3-VL vision encoder.
+//
+// Split from the forward orchestration so that editing a kernel does not
+// re-`ptxas` the cuBLAS plumbing, and vice versa.
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace imp {
+
+// hidden[i, :] += sum_t weights[i, t] * table[taps[i, t], :]
+// The learned position table is a fixed square grid; this is its bilinear
+// resample onto this image's grid, precomputed on the host as a gather.
+void launch_qwen3vl_pos_embed_add(half* hidden, const half* table, const int32_t* taps, const float* weights,
+                                  int tokens, int dim, int taps_per_token, cudaStream_t stream);
+
+// LayerNorm with weight AND bias (eps 1e-6), over the last dimension.
+void launch_qwen3vl_layernorm(const half* x, const half* weight, const half* bias, half* out, int rows,
+                              int dim, float eps, cudaStream_t stream);
+
+void launch_qwen3vl_add_bias(half* x, const half* bias, int rows, int dim, cudaStream_t stream);
+void launch_qwen3vl_residual_add(half* dst, const half* src, int64_t n, cudaStream_t stream);
+
+// The encoder uses BOTH GELU variants, and not by accident: the block MLP uses
+// `gelu_pytorch_tanh` (config `hidden_act`) while the patch mergers use
+// `nn.GELU()`, which is the exact erf form.
+void launch_qwen3vl_gelu_tanh(half* x, int64_t n, cudaStream_t stream);
+void launch_qwen3vl_gelu_erf(half* x, int64_t n, cudaStream_t stream);
+
+// Split the fused QKV projection [tokens, 3*heads*head_dim] into per-head
+// [heads][tokens][head_dim] and rotate q/k by the encoder's 2-D RoPE in one
+// pass. The first half of each head's rotary dims is driven by the patch ROW,
+// the second half by its COLUMN; the rotation itself is the half-split (NeoX)
+// form, not interleaved.
+void launch_qwen3vl_split_qkv_rope(const half* qkv, const int32_t* row, const int32_t* col, half* q, half* k,
+                                   half* v, int tokens, int heads, int head_dim, float theta,
+                                   cudaStream_t stream);
+
+// Row-wise softmax in FP32 over `cols`, in place.
+void launch_qwen3vl_softmax_rows(half* scores, int rows, int cols, cudaStream_t stream);
+
+// [heads][tokens][head_dim] -> [tokens, heads*head_dim]
+void launch_qwen3vl_merge_heads(const half* per_head, half* out, int tokens, int heads, int head_dim,
+                                cudaStream_t stream);
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_grid.cpp
+++ b/src/vision/qwen3vl_vision_grid.cpp
@@ -1,0 +1,97 @@
+#include "vision/qwen3vl_vision_grid.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace imp {
+
+namespace {
+
+// One axis of the bilinear resample, with align_corners=True — which is what
+// Qwen3-VL uses, and which is why the endpoints land exactly on the table's
+// first and last entry instead of half a texel inside them.
+//
+// `taps` are clamped into the table; `distance` deliberately is NOT computed
+// from the clamped value. At the last index that leaves the second tap with
+// weight 0, which is the whole point: it must not contribute.
+struct AxisTaps {
+    int32_t tap[2];
+    float weight[2];
+};
+
+AxisTaps axis_taps(int index, int size, int side) {
+    // float32 throughout, matching the reference. The floor below sits on an
+    // exact integer whenever the grids line up, so the precision of this
+    // division decides whether a token gets one tap or two.
+    const float src = static_cast<float>(index) * static_cast<float>(side - 1) /
+                      static_cast<float>(std::max(size - 1, 1));
+    const float base = std::floor(src);
+    AxisTaps a{};
+    for (int o = 0; o < 2; ++o) {
+        const int t = static_cast<int>(base) + o;
+        a.tap[o] = static_cast<int32_t>(std::clamp(t, 0, side - 1));
+        a.weight[o] = std::max(0.0f, 1.0f - std::fabs(src - base - static_cast<float>(o)));
+    }
+    return a;
+}
+
+}  // namespace
+
+bool qwen3vl_build_vision_grid(int grid_h, int grid_w, int merge, int pos_side, QwenVisionGrid& out,
+                               std::string& err) {
+    if (grid_h <= 0 || grid_w <= 0) {
+        err = "vision grid must be positive";
+        return false;
+    }
+    if (merge <= 0) {
+        err = "spatial merge size must be positive";
+        return false;
+    }
+    if (grid_h % merge != 0 || grid_w % merge != 0) {
+        err = "vision grid " + std::to_string(grid_h) + "x" + std::to_string(grid_w) +
+              " is not a multiple of the spatial merge size " + std::to_string(merge);
+        return false;
+    }
+    if (pos_side <= 0) {
+        err = "position-embedding grid side must be positive";
+        return false;
+    }
+
+    const int tokens = grid_h * grid_w;
+    QwenVisionGrid g;
+    g.tokens = tokens;
+    g.row.resize(static_cast<size_t>(tokens));
+    g.col.resize(static_cast<size_t>(tokens));
+    g.pos_taps.resize(static_cast<size_t>(tokens) * kQwenVisionPosTaps);
+    g.pos_weights.resize(static_cast<size_t>(tokens) * kQwenVisionPosTaps);
+
+    const int blocks_w = grid_w / merge;
+    for (int i = 0; i < tokens; ++i) {
+        // Undo the patchifier's merge-block grouping: tokens arrive as
+        // (block_row, block_col, in_row, in_col), not as raster order.
+        const int in_col = i % merge;
+        const int in_row = (i / merge) % merge;
+        const int block_col = (i / (merge * merge)) % blocks_w;
+        const int block_row = i / (merge * merge * blocks_w);
+        const int r = block_row * merge + in_row;
+        const int c = block_col * merge + in_col;
+        g.row[static_cast<size_t>(i)] = r;
+        g.col[static_cast<size_t>(i)] = c;
+
+        const AxisTaps h = axis_taps(r, grid_h, pos_side);
+        const AxisTaps w = axis_taps(c, grid_w, pos_side);
+        // Separable: the 2-D tap is the outer product of the two axes.
+        for (int a = 0; a < 2; ++a) {
+            for (int b = 0; b < 2; ++b) {
+                const size_t k = static_cast<size_t>(i) * kQwenVisionPosTaps + a * 2 + b;
+                g.pos_taps[k] = h.tap[a] * pos_side + w.tap[b];
+                g.pos_weights[k] = h.weight[a] * w.weight[b];
+            }
+        }
+    }
+
+    out = std::move(g);
+    return true;
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_grid.h
+++ b/src/vision/qwen3vl_vision_grid.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// The per-token grid math of the Qwen3-VL encoder, on the host.
+//
+// Two things the encoder needs before it can run a single GEMM, both pure
+// integer/float arithmetic over the patch grid, and both easy to get subtly
+// wrong in a way that still produces a running encoder:
+//
+//   - the (row, col) each token sits at, which is NOT its raster position —
+//     tokens come out of the patchifier grouped by spatial-merge block;
+//   - how to resample the learned square position-embedding table (48x48 for
+//     Qwen3-VL) onto this image's grid, expressed as four gather taps and four
+//     weights per token.
+//
+// Kept on the host and in its own file because it is the part with a real
+// oracle: a bilinear resample of an affine table must reproduce the affine
+// function exactly, which pins taps and weights independently of each other.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace imp {
+
+struct QwenVisionGrid {
+    int tokens = 0;
+    // Patch coordinates per token, in the order the patchifier emits tokens.
+    // These are the position ids the encoder's 2-D RoPE rotates by.
+    std::vector<int32_t> row;  // [tokens]
+    std::vector<int32_t> col;  // [tokens]
+    // Bilinear resample of the learned position table, as a gather: four flat
+    // indices into a `pos_side * pos_side` table and four weights per token.
+    std::vector<int32_t> pos_taps;   // [tokens * 4]
+    std::vector<float> pos_weights;  // [tokens * 4]
+};
+
+inline constexpr int kQwenVisionPosTaps = 4;
+
+// `grid_h`/`grid_w` count patches and must both be multiples of `merge` —
+// smart_resize guarantees that, and a grid that is not would silently drop the
+// tail of the last merge block. `pos_side` is the side of the learned table.
+// Returns false with `err` set rather than producing a half-filled grid.
+bool qwen3vl_build_vision_grid(int grid_h, int grid_w, int merge, int pos_side, QwenVisionGrid& out,
+                               std::string& err);
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_load.cpp
+++ b/src/vision/qwen3vl_vision_load.cpp
@@ -247,45 +247,49 @@ bool load_qwen3vl_vision_tensors(const std::unordered_map<std::string, Tensor>& 
 
     // A null slot is the failure this function exists to catch: the encoder
     // would read it as a garbage embedding many layers later.
-    auto require = [&](const Tensor& t, const char* what) {
+    qwen3vl_visit_vision_tensors(out, [&](Tensor& t, const std::string& what) {
         if (t.data == nullptr) {
             stats.missing++;
             if (err.empty())
-                err = std::string("vision tower is missing ") + what;
+                err = "vision tower is missing " + what;
         }
-    };
-    require(out.patch_embd_w, "patch_embed.proj.weight");
-    require(out.patch_embd_b, "patch_embed.proj.bias");
-    require(out.position_embd, "pos_embed.weight");
-    for (size_t i = 0; i < out.layers.size(); ++i) {
-        const VisionLayerWeights& L = out.layers[i];
-        const std::string p = "blocks." + std::to_string(i) + ".";
-        require(L.ln1_w, (p + "norm1.weight").c_str());
-        require(L.ln1_b, (p + "norm1.bias").c_str());
-        require(L.wq, (p + "attn.qkv.weight").c_str());
-        require(L.bq, (p + "attn.qkv.bias").c_str());
-        require(L.wo, (p + "attn.proj.weight").c_str());
-        require(L.bo, (p + "attn.proj.bias").c_str());
-        require(L.ln2_w, (p + "norm2.weight").c_str());
-        require(L.ln2_b, (p + "norm2.bias").c_str());
-        require(L.ffn_up_w, (p + "mlp.linear_fc1.weight").c_str());
-        require(L.ffn_up_b, (p + "mlp.linear_fc1.bias").c_str());
-        require(L.ffn_down_w, (p + "mlp.linear_fc2.weight").c_str());
-        require(L.ffn_down_b, (p + "mlp.linear_fc2.bias").c_str());
-    }
-    auto require_merger = [&](const VisionMergerWeights& m, const char* what) {
-        require(m.norm_w, what);
-        require(m.norm_b, what);
-        require(m.fc1_w, what);
-        require(m.fc1_b, what);
-        require(m.fc2_w, what);
-        require(m.fc2_b, what);
-    };
-    require_merger(out.merger, "merger");
-    for (size_t i = 0; i < out.deepstack_mergers.size(); ++i)
-        require_merger(out.deepstack_mergers[i], "a deepstack merger");
+    });
 
     return stats.missing == 0;
+}
+
+void qwen3vl_visit_vision_tensors(VisionModel& model,
+                                  const std::function<void(Tensor&, const std::string&)>& fn) {
+    fn(model.patch_embd_w, "patch_embed.proj.weight");
+    fn(model.patch_embd_b, "patch_embed.proj.bias");
+    fn(model.position_embd, "pos_embed.weight");
+    for (size_t i = 0; i < model.layers.size(); ++i) {
+        VisionLayerWeights& L = model.layers[i];
+        const std::string p = "blocks." + std::to_string(i) + ".";
+        fn(L.ln1_w, p + "norm1.weight");
+        fn(L.ln1_b, p + "norm1.bias");
+        fn(L.wq, p + "attn.qkv.weight");
+        fn(L.bq, p + "attn.qkv.bias");
+        fn(L.wo, p + "attn.proj.weight");
+        fn(L.bo, p + "attn.proj.bias");
+        fn(L.ln2_w, p + "norm2.weight");
+        fn(L.ln2_b, p + "norm2.bias");
+        fn(L.ffn_up_w, p + "mlp.linear_fc1.weight");
+        fn(L.ffn_up_b, p + "mlp.linear_fc1.bias");
+        fn(L.ffn_down_w, p + "mlp.linear_fc2.weight");
+        fn(L.ffn_down_b, p + "mlp.linear_fc2.bias");
+    }
+    auto visit_merger = [&](VisionMergerWeights& m, const std::string& p) {
+        fn(m.norm_w, p + "norm.weight");
+        fn(m.norm_b, p + "norm.bias");
+        fn(m.fc1_w, p + "linear_fc1.weight");
+        fn(m.fc1_b, p + "linear_fc1.bias");
+        fn(m.fc2_w, p + "linear_fc2.weight");
+        fn(m.fc2_b, p + "linear_fc2.bias");
+    };
+    visit_merger(model.merger, "merger.");
+    for (size_t i = 0; i < model.deepstack_mergers.size(); ++i)
+        visit_merger(model.deepstack_mergers[i], "deepstack_merger_list." + std::to_string(i) + ".");
 }
 
 }  // namespace imp

--- a/src/vision/qwen3vl_vision_load.h
+++ b/src/vision/qwen3vl_vision_load.h
@@ -10,6 +10,7 @@
 #include "core/tensor.h"
 #include "vision/vision_model.h"
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 
@@ -27,5 +28,15 @@ struct Qwen3VLVisionLoadStats {
 // with a null slot must not reach the encoder.
 bool load_qwen3vl_vision_tensors(const std::unordered_map<std::string, Tensor>& tensors, VisionModel& out,
                                  Qwen3VLVisionLoadStats& stats, std::string& err);
+
+// Visit every tensor slot of the tower exactly once, with the checkpoint name it
+// came from. Single source of truth on purpose: the load-completeness check and
+// the device upload both walk this list, so a slot added to one cannot be
+// forgotten by the other — which would leave the encoder reading a host pointer
+// from the device.
+//
+// `model.layers` and `model.deepstack_mergers` must already be sized.
+void qwen3vl_visit_vision_tensors(VisionModel& model,
+                                  const std::function<void(Tensor&, const std::string&)>& fn);
 
 }  // namespace imp

--- a/src/vision/qwen3vl_vision_upload.cpp
+++ b/src/vision/qwen3vl_vision_upload.cpp
@@ -1,0 +1,121 @@
+#include "vision/qwen3vl_vision_upload.h"
+
+#include "core/logging.h"
+#include "memory/vram_allocator.h"
+#include "vision/qwen3vl_vision_load.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstring>
+#include <vector>
+
+namespace imp {
+
+namespace {
+
+// BF16 is the top 16 bits of the FP32 pattern, so widening is a shift — no
+// table, no rounding decision. F16 is already the target and F32 is a plain
+// narrowing; anything else means this checkpoint is not what the loader thinks.
+bool to_fp16(const Tensor& t, std::vector<half>& out, std::string& err) {
+    const int64_t n = t.numel();
+    out.resize(static_cast<size_t>(n));
+    switch (t.qtype) {
+        case QType::F16:
+            std::memcpy(out.data(), t.data, static_cast<size_t>(n) * sizeof(half));
+            return true;
+        case QType::BF16: {
+            const uint16_t* src = static_cast<const uint16_t*>(t.data);
+            for (int64_t i = 0; i < n; ++i) {
+                const uint32_t bits = static_cast<uint32_t>(src[i]) << 16;
+                float f;
+                std::memcpy(&f, &bits, sizeof(f));
+                out[static_cast<size_t>(i)] = __float2half(f);
+            }
+            return true;
+        }
+        case QType::F32: {
+            const float* src = static_cast<const float*>(t.data);
+            for (int64_t i = 0; i < n; ++i)
+                out[static_cast<size_t>(i)] = __float2half(src[i]);
+            return true;
+        }
+        default:
+            err = std::string("vision tower tensor has unsupported dtype ") + qtype_name(t.qtype);
+            return false;
+    }
+}
+
+}  // namespace
+
+bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, size_t& bytes_out,
+                                 std::string& err) {
+    if (!alloc) {
+        err = "no VRAM allocator for the vision tower";
+        return false;
+    }
+
+    // Collected first, applied last: on any failure the already-allocated blocks
+    // are released and every Tensor still points at the host mapping, which is
+    // the only state the caller can safely drop the tower from.
+    struct Pending {
+        Tensor* slot;
+        void* device;
+        size_t bytes;
+    };
+    std::vector<Pending> pending;
+    std::vector<half> staging;
+    size_t total = 0;
+    bool ok = true;
+
+    qwen3vl_visit_vision_tensors(model, [&](Tensor& t, const std::string& what) {
+        if (!ok)
+            return;
+        if (t.data == nullptr || t.on_device) {
+            err = "vision tower slot '" + what + "' is not a host tensor";
+            ok = false;
+            return;
+        }
+        if (!to_fp16(t, staging, err)) {
+            err += " (" + what + ")";
+            ok = false;
+            return;
+        }
+        const size_t bytes = staging.size() * sizeof(half);
+        void* d = alloc->allocate(bytes, "vision_tower");
+        if (!d) {
+            err = "out of VRAM uploading vision tower tensor '" + what + "'";
+            ok = false;
+            return;
+        }
+        if (cudaMemcpy(d, staging.data(), bytes, cudaMemcpyHostToDevice) != cudaSuccess) {
+            alloc->free(d);
+            err = "upload failed for vision tower tensor '" + what + "'";
+            ok = false;
+            return;
+        }
+        pending.push_back({&t, d, bytes});
+        total += bytes;
+    });
+
+    if (!ok) {
+        for (const auto& p : pending)
+            alloc->free(p.device);
+        return false;
+    }
+
+    for (const auto& p : pending) {
+        p.slot->data = p.device;
+        p.slot->qtype = QType::F16;
+        p.slot->on_device = true;
+        p.slot->compute_strides();
+        model.gpu_allocs.push_back(p.device);
+    }
+    model.allocator = alloc;
+    bytes_out = total;
+    IMP_LOG_INFO("Vision tower: %zu tensors uploaded, %.1f MiB", pending.size(),
+                 static_cast<double>(total) / (1024.0 * 1024.0));
+    return true;
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_upload.h
+++ b/src/vision/qwen3vl_vision_upload.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// Move a loaded Qwen3-VL vision tower from the host mapping onto the device.
+//
+// The checkpoint is BF16; the encoder runs in FP16. Conversion happens here,
+// once, so the forward never sees a source dtype. Every tensor slot is rewritten
+// in place to point at device memory, so the tower is either fully resident or
+// unchanged — a half-uploaded tower would dereference a host pointer on the
+// device, which does not fault, it just reads garbage.
+
+#include "vision/vision_model.h"
+
+#include <string>
+
+namespace imp {
+
+class VRAMAllocator;
+
+// `alloc` may be null, in which case the tower is left alone and this returns
+// false — the encoder has no fallback for host-resident weights.
+bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, size_t& bytes_out,
+                                 std::string& err);
+
+}  // namespace imp

--- a/src/vision/vision_model.cpp
+++ b/src/vision/vision_model.cpp
@@ -1,4 +1,5 @@
 #include "vision/vision_model.h"
+#include "memory/vram_allocator.h"
 #include <cuda_runtime.h>
 
 namespace imp {
@@ -7,10 +8,15 @@ VisionModel::~VisionModel() { free_gpu(); }
 
 void VisionModel::free_gpu() {
     for (void* ptr : gpu_allocs) {
-        if (ptr)
+        if (!ptr)
+            continue;
+        if (allocator)
+            allocator->free(ptr);
+        else
             cudaFree(ptr);
     }
     gpu_allocs.clear();
+    allocator = nullptr;
 }
 
 }  // namespace imp

--- a/src/vision/vision_model.h
+++ b/src/vision/vision_model.h
@@ -5,6 +5,8 @@
 
 namespace imp {
 
+class VRAMAllocator;
+
 struct VisionConfig {
     int image_size = 896;
     int patch_size = 14;
@@ -96,8 +98,11 @@ struct VisionModel {
     // Transformer layers
     std::vector<VisionLayerWeights> layers;
 
-    // GPU allocations for cleanup
+    // GPU allocations for cleanup. Released through `allocator` when one is set
+    // (the Qwen3-VL path, so the VRAM ledger stays accurate) and with a plain
+    // cudaFree otherwise (the legacy GGUF mmproj path).
     std::vector<void*> gpu_allocs;
+    VRAMAllocator* allocator = nullptr;
 
     int lm_d_model = 0;  // LLM hidden dimension (from mm_proj output)
 

--- a/tests/test_qwen3vl_encoder.cu
+++ b/tests/test_qwen3vl_encoder.cu
@@ -1,0 +1,462 @@
+// Qwen3-VL vision encoder forward, against an independent CPU reference.
+//
+// The end-to-end oracle for this encoder ("the model describes the picture")
+// only exists once the LM side is wired, and it does not localise a fault. So
+// this test builds a small synthetic tower, runs it through the GPU encoder and
+// through a from-scratch double-precision reimplementation of the reference
+// semantics, and compares. Mutation-checked — each of these fails this test:
+// swapping the two RoPE axes, halving the RoPE frequency exponent, reading the
+// fused QKV in the wrong order, flattening the merger-norm placement, dropping
+// the position embedding, dropping the attention scale, dropping a residual.
+// (The merge-block token order is NOT covered here: the grid is an input to both
+// sides, so it cancels. `test_qwen3vl_vision_grid.cpp` owns that one.)
+//
+// One thing it does NOT cover, measured rather than assumed: the block MLP's
+// tanh-GELU and the mergers' erf-GELU differ by at most 4.7e-4, which is below
+// one FP16 ulp at magnitude 1 (9.8e-4). Swapping them is invisible at this
+// precision, so the code follows upstream on the strength of the reference, not
+// of a test.
+//
+// The reference is written from `modeling_qwen3_vl.py`, not from the kernels.
+
+#include "memory/vram_allocator.h"
+#include "vision/qwen3vl_encoder.h"
+#include "vision/qwen3vl_vision_grid.h"
+#include "vision/qwen3vl_vision_upload.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// A tower small enough to reference on the CPU but structurally identical to the
+// real one: fused QKV, two-axis RoPE, 2x2 merge, a DeepStack tap.
+constexpr int kHidden = 32;
+constexpr int kHeads = 4;
+constexpr int kHeadDim = kHidden / kHeads;  // 8 -> half_rot 4, quarter 2
+constexpr int kInter = 64;
+constexpr int kDepth = 3;
+constexpr int kMerge = 2;
+constexpr int kOutHidden = 16;
+constexpr int kPosSide = 6;
+constexpr int kPatch = 2;
+constexpr int kTemporal = 1;
+constexpr int kFeatures = 3 * kTemporal * kPatch * kPatch;  // 12
+constexpr int kUnit = kMerge * kMerge;                      // 4
+constexpr int kWide = kHidden * kUnit;                      // 128
+constexpr float kEps = 1e-6f;
+constexpr float kTheta = 10000.0f;
+
+// Deterministic, small, and zero-mean so the FP16 path has headroom.
+struct Rng {
+    uint64_t s = 0x9E3779B97F4A7C15ull;
+    // Uniform in [-1, 1).
+    float next() {
+        s = s * 6364136223846793005ull + 1442695040888963407ull;
+        return static_cast<float>((s >> 40) & 0xFFFF) / 32767.5f - 1.0f;
+    }
+};
+
+std::vector<float> randoms(Rng& rng, size_t n, float scale = 1.0f, float centre = 0.0f) {
+    std::vector<float> v(n);
+    for (auto& x : v)
+        x = centre + scale * rng.next();
+    return v;
+}
+
+// Magnitudes matter here, and not for realism's sake. With small random gains
+// the LayerNorms shrink every activation, the attention logits land within
+// +-0.01, softmax comes out near-uniform, and the whole rotary embedding stops
+// influencing the output — a mutation that swaps the two RoPE axes then passes.
+// So norms get a gain near 1 and linears get Xavier-scaled weights, which puts
+// the logits in a range where attention actually chooses.
+enum class Init { NormWeight, NormBias, Linear, Bias, Table };
+
+std::vector<float> init_values(Rng& rng, Init kind, size_t n, int64_t fan_in) {
+    switch (kind) {
+        case Init::NormWeight:
+            return randoms(rng, n, 0.15f, 1.0f);
+        case Init::NormBias:
+            return randoms(rng, n, 0.05f);
+        case Init::Linear:
+            return randoms(rng, n, std::sqrt(3.0f / static_cast<float>(std::max<int64_t>(fan_in, 1))));
+        case Init::Bias:
+            return randoms(rng, n, 0.05f);
+        default:
+            return randoms(rng, n, 0.5f);
+    }
+}
+
+Tensor host_tensor(std::vector<float>& storage, std::vector<int64_t> shape) {
+    Tensor t;
+    t.data = storage.data();
+    t.qtype = QType::F32;
+    t.ndim = static_cast<int>(shape.size());
+    for (size_t i = 0; i < shape.size(); ++i)
+        t.shape[i] = shape[i];
+    t.compute_strides();
+    return t;
+}
+
+// Owns every host buffer so the Tensors in the VisionModel stay valid until the
+// upload has copied them.
+struct SyntheticTower {
+    std::vector<std::vector<float>> storage;
+    VisionModel model;
+
+    void add(Rng& rng, Init kind, Tensor& slot, std::vector<int64_t> shape) {
+        size_t n = 1;
+        for (int64_t d : shape)
+            n *= static_cast<size_t>(d);
+        storage.push_back(init_values(rng, kind, n, shape.size() > 1 ? shape[1] : 1));
+        slot = host_tensor(storage.back(), std::move(shape));
+    }
+};
+
+// Host copies of the weights, kept as float so the reference never reads device
+// memory or FP16.
+struct RefWeights {
+    std::vector<float> pe_w, pe_b, pos;
+    struct Layer {
+        std::vector<float> ln1_w, ln1_b, qkv_w, qkv_b, o_w, o_b, ln2_w, ln2_b, up_w, up_b, dn_w, dn_b;
+    };
+    std::vector<Layer> layers;
+    struct Merger {
+        std::vector<float> nw, nb, w1, b1, w2, b2;
+        bool postshuffle = false;
+    };
+    Merger main;
+    std::vector<Merger> deep;
+};
+
+// --- reference pieces -------------------------------------------------------
+
+void layernorm(const double* x, const float* w, const float* b, double* out, int rows, int dim) {
+    for (int r = 0; r < rows; ++r) {
+        const double* xr = x + static_cast<size_t>(r) * dim;
+        double* o = out + static_cast<size_t>(r) * dim;
+        double mean = 0.0;
+        for (int j = 0; j < dim; ++j)
+            mean += xr[j];
+        mean /= dim;
+        double var = 0.0;
+        for (int j = 0; j < dim; ++j)
+            var += (xr[j] - mean) * (xr[j] - mean);
+        var /= dim;
+        const double inv = 1.0 / std::sqrt(var + kEps);
+        for (int j = 0; j < dim; ++j)
+            o[j] = (xr[j] - mean) * inv * w[j] + b[j];
+    }
+}
+
+// out[rows, N] = x[rows, K] @ W[N, K]^T + bias[N]
+void linear(const double* x, const float* w, const float* b, double* out, int rows, int N, int K) {
+    for (int r = 0; r < rows; ++r) {
+        for (int n = 0; n < N; ++n) {
+            double acc = b ? b[n] : 0.0;
+            for (int k = 0; k < K; ++k)
+                acc += x[static_cast<size_t>(r) * K + k] * w[static_cast<size_t>(n) * K + k];
+            out[static_cast<size_t>(r) * N + n] = acc;
+        }
+    }
+}
+
+double gelu_tanh(double v) {
+    return 0.5 * v * (1.0 + std::tanh(0.7978845608028654 * (v + 0.044715 * v * v * v)));
+}
+double gelu_erf(double v) { return 0.5 * v * (1.0 + std::erf(v * 0.7071067811865476)); }
+
+void merger_ref(const RefWeights::Merger& m, const std::vector<double>& hidden, int tokens,
+                std::vector<double>& out) {
+    const int merged = tokens / kUnit;
+    std::vector<double> normed(static_cast<size_t>(tokens) * kHidden);
+    if (m.postshuffle)
+        layernorm(hidden.data(), m.nw.data(), m.nb.data(), normed.data(), merged, kWide);
+    else
+        layernorm(hidden.data(), m.nw.data(), m.nb.data(), normed.data(), tokens, kHidden);
+
+    std::vector<double> fc1(static_cast<size_t>(merged) * kWide);
+    linear(normed.data(), m.w1.data(), m.b1.data(), fc1.data(), merged, kWide, kWide);
+    for (auto& v : fc1)
+        v = gelu_erf(v);
+    out.assign(static_cast<size_t>(merged) * kOutHidden, 0.0);
+    linear(fc1.data(), m.w2.data(), m.b2.data(), out.data(), merged, kOutHidden, kWide);
+}
+
+void reference_forward(const RefWeights& W, const std::vector<float>& patches, const QwenVisionGrid& grid,
+                       std::vector<double>& out, std::vector<std::vector<double>>& deep_out) {
+    const int n = grid.tokens;
+    std::vector<double> x(static_cast<size_t>(n) * kFeatures);
+    for (size_t i = 0; i < x.size(); ++i)
+        x[i] = patches[i];
+
+    std::vector<double> h(static_cast<size_t>(n) * kHidden);
+    linear(x.data(), W.pe_w.data(), W.pe_b.data(), h.data(), n, kHidden, kFeatures);
+    for (int i = 0; i < n; ++i)
+        for (int t = 0; t < kQwenVisionPosTaps; ++t) {
+            const double wt = grid.pos_weights[static_cast<size_t>(i) * kQwenVisionPosTaps + t];
+            const int idx = grid.pos_taps[static_cast<size_t>(i) * kQwenVisionPosTaps + t];
+            for (int j = 0; j < kHidden; ++j)
+                h[static_cast<size_t>(i) * kHidden + j] += wt * W.pos[static_cast<size_t>(idx) * kHidden + j];
+        }
+
+    const int half_rot = kHeadDim / 2;
+    const int quarter = half_rot / 2;
+    size_t tap = 0;
+    for (int l = 0; l < kDepth; ++l) {
+        const auto& L = W.layers[static_cast<size_t>(l)];
+        std::vector<double> normed(h.size());
+        layernorm(h.data(), L.ln1_w.data(), L.ln1_b.data(), normed.data(), n, kHidden);
+        std::vector<double> qkv(static_cast<size_t>(n) * 3 * kHidden);
+        linear(normed.data(), L.qkv_w.data(), L.qkv_b.data(), qkv.data(), n, 3 * kHidden, kHidden);
+
+        // [tokens, 3, heads, head_dim] -> per-head q/k/v, then the two-axis
+        // rotation: first quarter of the head follows the row, second the column.
+        std::vector<double> q(static_cast<size_t>(kHeads) * n * kHeadDim), k(q.size()), v(q.size());
+        for (int i = 0; i < n; ++i) {
+            for (int hd = 0; hd < kHeads; ++hd) {
+                const size_t src = static_cast<size_t>(i) * 3 * kHidden + hd * kHeadDim;
+                const size_t dst = (static_cast<size_t>(hd) * n + i) * kHeadDim;
+                for (int d = 0; d < kHeadDim; ++d)
+                    v[dst + d] = qkv[src + 2 * kHidden + d];
+                for (int j = 0; j < half_rot; ++j) {
+                    const int fi = (j < quarter) ? j : (j - quarter);
+                    const double pos = (j < quarter) ? grid.row[i] : grid.col[i];
+                    const double inv_freq = std::pow(kTheta, -static_cast<double>(2 * fi) / half_rot);
+                    const double ang = pos * inv_freq;
+                    const double cs = std::cos(ang), sn = std::sin(ang);
+                    const double q0 = qkv[src + j], q1 = qkv[src + j + half_rot];
+                    q[dst + j] = q0 * cs - q1 * sn;
+                    q[dst + j + half_rot] = q1 * cs + q0 * sn;
+                    const double k0 = qkv[src + kHidden + j], k1 = qkv[src + kHidden + j + half_rot];
+                    k[dst + j] = k0 * cs - k1 * sn;
+                    k[dst + j + half_rot] = k1 * cs + k0 * sn;
+                }
+            }
+        }
+
+        // Full bidirectional attention over the image's tokens.
+        std::vector<double> attn(static_cast<size_t>(n) * kHidden);
+        const double scale = 1.0 / std::sqrt(static_cast<double>(kHeadDim));
+        for (int hd = 0; hd < kHeads; ++hd) {
+            for (int i = 0; i < n; ++i) {
+                std::vector<double> s(static_cast<size_t>(n));
+                double m = -1e300;
+                for (int j = 0; j < n; ++j) {
+                    double acc = 0.0;
+                    for (int d = 0; d < kHeadDim; ++d)
+                        acc += q[(static_cast<size_t>(hd) * n + i) * kHeadDim + d] *
+                               k[(static_cast<size_t>(hd) * n + j) * kHeadDim + d];
+                    s[static_cast<size_t>(j)] = acc * scale;
+                    m = std::max(m, s[static_cast<size_t>(j)]);
+                }
+                double sum = 0.0;
+                for (auto& e : s) {
+                    e = std::exp(e - m);
+                    sum += e;
+                }
+                for (int d = 0; d < kHeadDim; ++d) {
+                    double acc = 0.0;
+                    for (int j = 0; j < n; ++j)
+                        acc += s[static_cast<size_t>(j)] *
+                               v[(static_cast<size_t>(hd) * n + j) * kHeadDim + d];
+                    attn[static_cast<size_t>(i) * kHidden + hd * kHeadDim + d] = acc / sum;
+                }
+            }
+        }
+
+        std::vector<double> proj(h.size());
+        linear(attn.data(), L.o_w.data(), L.o_b.data(), proj.data(), n, kHidden, kHidden);
+        for (size_t i = 0; i < h.size(); ++i)
+            h[i] += proj[i];
+
+        layernorm(h.data(), L.ln2_w.data(), L.ln2_b.data(), normed.data(), n, kHidden);
+        std::vector<double> ff(static_cast<size_t>(n) * kInter);
+        linear(normed.data(), L.up_w.data(), L.up_b.data(), ff.data(), n, kInter, kHidden);
+        for (auto& e : ff)
+            e = gelu_tanh(e);
+        linear(ff.data(), L.dn_w.data(), L.dn_b.data(), proj.data(), n, kHidden, kInter);
+        for (size_t i = 0; i < h.size(); ++i)
+            h[i] += proj[i];
+
+        if (tap < W.deep.size() && l == 1) {  // the tap this tower declares
+            deep_out.emplace_back();
+            merger_ref(W.deep[tap], h, n, deep_out.back());
+            ++tap;
+        }
+    }
+    merger_ref(W.main, h, n, out);
+}
+
+// --- fixture ----------------------------------------------------------------
+
+bool gpu_available() {
+    int n = 0;
+    return cudaGetDeviceCount(&n) == cudaSuccess && n > 0;
+}
+
+void fill_config(VisionConfig& c) {
+    c.is_qwen3vl = true;
+    c.num_layers = kDepth;
+    c.hidden_size = kHidden;
+    c.num_heads = kHeads;
+    c.head_dim = kHeadDim;
+    c.intermediate_size = kInter;
+    c.patch_size = kPatch;
+    c.merge_size = kMerge;
+    c.temporal_patch_size = kTemporal;
+    c.out_hidden_size = kOutHidden;
+    c.pos_embed_grid = kPosSide;
+    c.deepstack_indexes = {1};
+}
+
+// `grid_h` x `grid_w` patches through both implementations.
+void run_case(int grid_h, int grid_w) {
+    const int kTokens = grid_h * grid_w;
+    const int kMerged = kTokens / kUnit;
+
+    Rng rng;
+    SyntheticTower tower;
+    fill_config(tower.model.config);
+    tower.model.layers.resize(kDepth);
+    tower.model.deepstack_mergers.resize(1);
+
+    RefWeights W;
+    W.layers.resize(kDepth);
+
+    // Every weight is generated once and handed to both sides: the tower (which
+    // gets uploaded as FP16) and the reference (which keeps the float values).
+    auto add = [&](Init kind, Tensor& slot, std::vector<int64_t> shape) -> std::vector<float> {
+        tower.add(rng, kind, slot, std::move(shape));
+        return tower.storage.back();
+    };
+
+    W.pe_w = add(Init::Linear, tower.model.patch_embd_w, {kHidden, kFeatures});
+    W.pe_b = add(Init::Bias, tower.model.patch_embd_b, {kHidden});
+    W.pos = add(Init::Table, tower.model.position_embd, {kPosSide * kPosSide, kHidden});
+
+    for (int l = 0; l < kDepth; ++l) {
+        VisionLayerWeights& L = tower.model.layers[static_cast<size_t>(l)];
+        RefWeights::Layer& R = W.layers[static_cast<size_t>(l)];
+        R.ln1_w = add(Init::NormWeight, L.ln1_w, {kHidden});
+        R.ln1_b = add(Init::NormBias, L.ln1_b, {kHidden});
+        R.qkv_w = add(Init::Linear, L.wq, {3 * kHidden, kHidden});
+        R.qkv_b = add(Init::Bias, L.bq, {3 * kHidden});
+        R.o_w = add(Init::Linear, L.wo, {kHidden, kHidden});
+        R.o_b = add(Init::Bias, L.bo, {kHidden});
+        R.ln2_w = add(Init::NormWeight, L.ln2_w, {kHidden});
+        R.ln2_b = add(Init::NormBias, L.ln2_b, {kHidden});
+        R.up_w = add(Init::Linear, L.ffn_up_w, {kInter, kHidden});
+        R.up_b = add(Init::Bias, L.ffn_up_b, {kInter});
+        R.dn_w = add(Init::Linear, L.ffn_down_w, {kHidden, kInter});
+        R.dn_b = add(Init::Bias, L.ffn_down_b, {kHidden});
+    }
+
+    auto fill_merger = [&](VisionMergerWeights& m, RefWeights::Merger& r, bool postshuffle) {
+        r.postshuffle = postshuffle;
+        const int norm_w = postshuffle ? kWide : kHidden;
+        r.nw = add(Init::NormWeight, m.norm_w, {norm_w});
+        r.nb = add(Init::NormBias, m.norm_b, {norm_w});
+        r.w1 = add(Init::Linear, m.fc1_w, {kWide, kWide});
+        r.b1 = add(Init::Bias, m.fc1_b, {kWide});
+        r.w2 = add(Init::Linear, m.fc2_w, {kOutHidden, kWide});
+        r.b2 = add(Init::Bias, m.fc2_b, {kOutHidden});
+    };
+    fill_merger(tower.model.merger, W.main, false);
+    W.deep.resize(1);
+    fill_merger(tower.model.deepstack_mergers[0], W.deep[0], true);
+
+    VRAMAllocator alloc;
+    ASSERT_TRUE(alloc.init(0.10f));
+    size_t bytes = 0;
+    std::string err;
+    ASSERT_TRUE(qwen3vl_upload_vision_tower(tower.model, &alloc, bytes, err)) << err;
+    EXPECT_GT(bytes, 0u);
+
+    QwenVisionGrid grid;
+    ASSERT_TRUE(qwen3vl_build_vision_grid(grid_h, grid_w, kMerge, kPosSide, grid, err)) << err;
+    ASSERT_EQ(grid.tokens, kTokens);
+
+    const std::vector<float> patches = randoms(rng, static_cast<size_t>(kTokens) * kFeatures, 1.0f);
+    std::vector<half> patches_h(patches.size());
+    for (size_t i = 0; i < patches.size(); ++i)
+        patches_h[i] = __float2half(patches[i]);
+
+    half* d_patches = static_cast<half*>(alloc.allocate(patches_h.size() * sizeof(half), "test_patches"));
+    half* d_out = static_cast<half*>(
+        alloc.allocate(static_cast<size_t>(kMerged) * kOutHidden * sizeof(half), "test_out"));
+    half* d_deep = static_cast<half*>(
+        alloc.allocate(static_cast<size_t>(kMerged) * kOutHidden * sizeof(half), "test_deep"));
+    ASSERT_NE(d_patches, nullptr);
+    ASSERT_NE(d_out, nullptr);
+    ASSERT_NE(d_deep, nullptr);
+    ASSERT_EQ(cudaMemcpy(d_patches, patches_h.data(), patches_h.size() * sizeof(half),
+                         cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    Qwen3VLEncoder enc;
+    ASSERT_TRUE(enc.init(tower.model, &alloc, kTokens));
+    EXPECT_EQ(enc.merged_tokens(kTokens), kMerged);
+    ASSERT_TRUE(enc.encode(d_patches, grid, d_out, {d_deep}, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    std::vector<half> got(static_cast<size_t>(kMerged) * kOutHidden);
+    std::vector<half> got_deep(got.size());
+    ASSERT_EQ(cudaMemcpy(got.data(), d_out, got.size() * sizeof(half), cudaMemcpyDeviceToHost), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(got_deep.data(), d_deep, got_deep.size() * sizeof(half), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    std::vector<double> want;
+    std::vector<std::vector<double>> want_deep;
+    reference_forward(W, patches, grid, want, want_deep);
+    ASSERT_EQ(want.size(), got.size());
+    ASSERT_EQ(want_deep.size(), 1u);
+
+    auto compare = [](const std::vector<half>& g, const std::vector<double>& w, const char* what) {
+        double scale = 1e-3;
+        for (double v : w)
+            scale = std::max(scale, std::fabs(v));
+        for (size_t i = 0; i < w.size(); ++i)
+            EXPECT_NEAR(__half2float(g[i]), w[i], 0.03 * scale) << what << " element " << i;
+    };
+    compare(got, want, "merged output");
+    compare(got_deep, want_deep[0], "deepstack output");
+
+    // A guard against a reference that is trivially satisfiable: the two mergers
+    // must not agree, or "matches" would mean nothing.
+    double spread = 0.0;
+    for (size_t i = 0; i < want.size(); ++i)
+        spread = std::max(spread, std::fabs(want[i] - want_deep[0][i]));
+    EXPECT_GT(spread, 1e-3) << "main and DeepStack outputs are indistinguishable";
+
+    enc.free_buffers();
+    alloc.free(d_patches);
+    alloc.free(d_out);
+    alloc.free(d_deep);
+    tower.model.free_gpu();
+}
+
+TEST(Qwen3VLEncoder, MatchesAnIndependentCpuReference) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+    run_case(4, 6);
+}
+
+// Attention is chunked over query rows, so a single-chunk image never exercises
+// the strides that advance between chunks. This grid crosses the boundary.
+TEST(Qwen3VLEncoder, MatchesTheReferenceAcrossAttentionChunks) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+    run_case(34, 36);  // 1224 patches > one 512-row chunk
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_qwen3vl_vision_grid.cpp
+++ b/tests/test_qwen3vl_vision_grid.cpp
@@ -1,0 +1,184 @@
+// Qwen3-VL encoder grid math: token order, RoPE positions, position-embedding
+// resample.
+//
+// Every failure here is silent — the encoder runs either way and returns
+// embeddings that are merely wrong. So the resample is tested against a real
+// oracle rather than against itself: a bilinear interpolation of a table that is
+// an AFFINE function of (row, col) must reproduce that affine function exactly
+// at the resampled coordinate. That pins the taps and the weights independently,
+// without reimplementing the formula under test.
+
+#include "vision/qwen3vl_vision_grid.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+QwenVisionGrid build(int h, int w, int merge = 2, int side = 48) {
+    QwenVisionGrid g;
+    std::string err;
+    EXPECT_TRUE(qwen3vl_build_vision_grid(h, w, merge, side, g, err)) << err;
+    return g;
+}
+
+// The patchifier emits tokens grouped by 2x2 merge block, so the merger can
+// consume four CONSECUTIVE tokens. Raster order would still run and would put
+// four unrelated patches in every merged token.
+TEST(Qwen3VLVisionGrid, TokenOrderIsMergeBlockGroupedNotRaster) {
+    const auto g = build(4, 4);
+    ASSERT_EQ(g.tokens, 16);
+
+    // 4x4 grid, merge 2 -> raster indices 0,1,4,5, 2,3,6,7, 8,9,12,13, 10,11,14,15
+    const int expect_raster[16] = {0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15};
+    for (int i = 0; i < 16; ++i) {
+        const int raster = g.row[i] * 4 + g.col[i];
+        EXPECT_EQ(raster, expect_raster[i]) << "token " << i;
+    }
+}
+
+TEST(Qwen3VLVisionGrid, EveryPatchAppearsExactlyOnce) {
+    for (auto [h, w] : {std::pair{4, 6}, std::pair{8, 8}, std::pair{2, 10}, std::pair{6, 2}}) {
+        const auto g = build(h, w);
+        std::set<int> seen;
+        for (int i = 0; i < g.tokens; ++i) {
+            ASSERT_GE(g.row[i], 0);
+            ASSERT_LT(g.row[i], h);
+            ASSERT_GE(g.col[i], 0);
+            ASSERT_LT(g.col[i], w);
+            EXPECT_TRUE(seen.insert(g.row[i] * w + g.col[i]).second) << h << "x" << w << " token " << i;
+        }
+        EXPECT_EQ(static_cast<int>(seen.size()), h * w);
+    }
+}
+
+// A partition of unity. If the weights did not sum to 1 the position embedding
+// would be scaled per token, which reads as a strange but plausible encoder.
+TEST(Qwen3VLVisionGrid, InterpolationWeightsSumToOne) {
+    for (auto [h, w] : {std::pair{4, 4}, std::pair{32, 48}, std::pair{96, 64}, std::pair{2, 2}}) {
+        const auto g = build(h, w);
+        for (int i = 0; i < g.tokens; ++i) {
+            float s = 0.0f;
+            for (int t = 0; t < kQwenVisionPosTaps; ++t)
+                s += g.pos_weights[i * kQwenVisionPosTaps + t];
+            EXPECT_NEAR(s, 1.0f, 1e-5f) << h << "x" << w << " token " << i;
+        }
+    }
+}
+
+// The oracle: resampling an affine table must return the affine function at the
+// source coordinate. align_corners maps target index i on an axis of length n to
+// source i*(side-1)/(n-1), so the expected value is known in closed form.
+TEST(Qwen3VLVisionGrid, ResamplesAnAffineTableExactly) {
+    const int side = 48;
+    // table(r, c) = 3 - 0.25*r + 0.5*c
+    auto table = [](int r, int c) { return 3.0 - 0.25 * r + 0.5 * c; };
+
+    for (auto [h, w] : {std::pair{4, 4}, std::pair{48, 48}, std::pair{96, 32}, std::pair{30, 70}}) {
+        const auto g = build(h, w, 2, side);
+        for (int i = 0; i < g.tokens; ++i) {
+            double got = 0.0;
+            for (int t = 0; t < kQwenVisionPosTaps; ++t) {
+                const int idx = g.pos_taps[i * kQwenVisionPosTaps + t];
+                got += static_cast<double>(g.pos_weights[i * kQwenVisionPosTaps + t]) *
+                       table(idx / side, idx % side);
+            }
+            const double src_r = g.row[i] * static_cast<double>(side - 1) / std::max(h - 1, 1);
+            const double src_c = g.col[i] * static_cast<double>(side - 1) / std::max(w - 1, 1);
+            EXPECT_NEAR(got, 3.0 - 0.25 * src_r + 0.5 * src_c, 1e-4)
+                << h << "x" << w << " token " << i << " (r=" << g.row[i] << ", c=" << g.col[i] << ")";
+        }
+    }
+}
+
+// align_corners: the four corners of the image must land exactly on the four
+// corners of the learned table, with no second tap bleeding in.
+TEST(Qwen3VLVisionGrid, CornersLandExactlyOnTheTableCorners) {
+    const int side = 48, h = 30, w = 70;
+    const auto g = build(h, w, 2, side);
+    const std::pair<int, int> corners[] = {{0, 0}, {0, w - 1}, {h - 1, 0}, {h - 1, w - 1}};
+    for (auto [cr, cc] : corners) {
+        int found = -1;
+        for (int i = 0; i < g.tokens && found < 0; ++i)
+            if (g.row[i] == cr && g.col[i] == cc)
+                found = i;
+        ASSERT_GE(found, 0) << cr << "," << cc;
+        const int want = (cr == 0 ? 0 : side - 1) * side + (cc == 0 ? 0 : side - 1);
+        float total = 0.0f;
+        for (int t = 0; t < kQwenVisionPosTaps; ++t) {
+            const float wt = g.pos_weights[found * kQwenVisionPosTaps + t];
+            if (wt > 0.0f) {
+                EXPECT_EQ(g.pos_taps[found * kQwenVisionPosTaps + t], want) << cr << "," << cc;
+                total += wt;
+            }
+        }
+        EXPECT_NEAR(total, 1.0f, 1e-6f);
+    }
+}
+
+// A grid the same size as the table must be an identity gather, not a blur.
+TEST(Qwen3VLVisionGrid, MatchingGridIsAnIdentityGather) {
+    const int side = 48;
+    const auto g = build(side, side, 2, side);
+    for (int i = 0; i < g.tokens; ++i) {
+        const int want = g.row[i] * side + g.col[i];
+        float mass_on_target = 0.0f, mass_elsewhere = 0.0f;
+        for (int t = 0; t < kQwenVisionPosTaps; ++t) {
+            const float wt = g.pos_weights[i * kQwenVisionPosTaps + t];
+            (g.pos_taps[i * kQwenVisionPosTaps + t] == want ? mass_on_target : mass_elsewhere) += wt;
+        }
+        EXPECT_NEAR(mass_on_target, 1.0f, 1e-6f) << "token " << i;
+        EXPECT_NEAR(mass_elsewhere, 0.0f, 1e-6f) << "token " << i;
+    }
+}
+
+TEST(Qwen3VLVisionGrid, TapsStayInsideTheTable) {
+    const int side = 48;
+    for (auto [h, w] : {std::pair{2, 2}, std::pair{4, 4}, std::pair{200, 4}, std::pair{48, 96}}) {
+        const auto g = build(h, w, 2, side);
+        for (size_t k = 0; k < g.pos_taps.size(); ++k) {
+            EXPECT_GE(g.pos_taps[k], 0);
+            EXPECT_LT(g.pos_taps[k], side * side);
+        }
+    }
+}
+
+// A grid that is not a multiple of the merge size would drop the tail of the
+// last block — silently, since the token count still comes out of the loop.
+TEST(Qwen3VLVisionGrid, RefusesAGridThatIsNotAMultipleOfTheMergeSize) {
+    QwenVisionGrid g;
+    std::string err;
+    EXPECT_FALSE(qwen3vl_build_vision_grid(5, 4, 2, 48, g, err));
+    EXPECT_NE(err.find("multiple"), std::string::npos) << err;
+    EXPECT_FALSE(qwen3vl_build_vision_grid(4, 5, 2, 48, g, err));
+    EXPECT_NE(err.find("multiple"), std::string::npos) << err;
+    EXPECT_EQ(g.tokens, 0) << "a rejection must not leave a half-built grid";
+}
+
+TEST(Qwen3VLVisionGrid, RefusesNonPositiveDimensions) {
+    QwenVisionGrid g;
+    std::string err;
+    EXPECT_FALSE(qwen3vl_build_vision_grid(0, 4, 2, 48, g, err));
+    EXPECT_FALSE(qwen3vl_build_vision_grid(4, 0, 2, 48, g, err));
+    EXPECT_FALSE(qwen3vl_build_vision_grid(4, 4, 0, 48, g, err));
+    EXPECT_FALSE(qwen3vl_build_vision_grid(4, 4, 2, 0, g, err));
+}
+
+// merge == 1 is the degenerate case the same code has to keep handling: token
+// order collapses to raster.
+TEST(Qwen3VLVisionGrid, MergeOneIsRasterOrder) {
+    const auto g = build(3, 5, 1);
+    ASSERT_EQ(g.tokens, 15);
+    for (int i = 0; i < 15; ++i) {
+        EXPECT_EQ(g.row[i], i / 5);
+        EXPECT_EQ(g.col[i], i % 5);
+    }
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Sixth piece of gap 2 (`docs/plans/2026-07-31-qwen3-vl-vision.md`). The tower loaded in #1170 now runs.

## What

Three pieces, split by what each can get wrong on its own:

| File | Job |
|---|---|
| `vision/qwen3vl_vision_grid.{h,cpp}` | Host grid math: which patch each token sits at, and the position-table resample as gather taps + weights |
| `vision/qwen3vl_vision_upload.{h,cpp}` | BF16 checkpoint → FP16 device, all-or-nothing |
| `vision/qwen3vl_encoder.{h,cu}` + `qwen3vl_encoder_kernels.{h,cu}` | The forward |

Notes on each:

- **Grid.** The position table is a fixed 48×48 learned grid; a real image almost never has that grid, so it is resampled per image (bilinear, `align_corners=True`). Expressed as four taps and four weights per token, computed once on the host.
- **Upload.** Allocates through `VRAMAllocator` and rolls back every block on any failure, because a half-uploaded tower does not fault — it reads a host pointer on the device and returns garbage. The slot list is now shared with the loader's completeness check (`qwen3vl_visit_vision_tensors`), so a slot added to one cannot be forgotten by the other.
- **Encoder.** Patch embed → position embed → 24 blocks (fused QKV, two-axis RoPE, full bidirectional attention, ungated MLP) → mergers, with the DeepStack taps at blocks 5/11/17. Attention is **chunked over query rows**: the score matrix is the only buffer that grows quadratically, and sizing it for the worst case would dominate every other allocation.

## Verification

The end-to-end oracle ("the model describes the picture") needs the LM side, which is not built yet, and it does not localise a fault. So the encoder is compared against a **from-scratch double-precision reimplementation of `modeling_qwen3_vl.py`** on a synthetic tower with the same structure, plus an affine-table oracle for the grid math that pins taps and weights independently of the formula under test.

Mutation-checked — each of these fails the test:

| Mutation | |
|---|---|
| RoPE row/col axes swapped | caught |
| RoPE frequency exponent halved | caught |
| Fused QKV read in the wrong order | caught |
| Merger-norm placement flattened | caught |
| Position embedding dropped | caught |
| Attention scale dropped | caught |
| Attention residual dropped | caught |
| Attention chunk offset dropped | caught (large case only) |
| Raster instead of merge-block token order | caught by the grid test |

That last chunk-offset row is what proves the second test case really crosses a chunk boundary: the small case stays green and only the 1224-patch case fails.

### Two findings worth stating rather than hiding

- **The first version of this test could not catch the RoPE mutation.** Small random gains made every LayerNorm shrink its activations until the attention logits sat within ±0.01 and softmax came out near-uniform — the rotary embedding had no influence on the output at all. Weights are now initialised at realistic magnitudes (norm gain near 1, Xavier linears), and the comment says why.
- **The two GELU variants are not distinguishable here.** The block MLP's tanh-GELU and the mergers' erf-GELU differ by at most `4.7e-4`, which is below one FP16 ulp at magnitude 1 (`9.8e-4`). Swapping them is invisible at this precision. The code follows upstream on the strength of the reference, and the test says so instead of implying coverage it does not have.

`test-core` green, file-size and alloc-sites gates clean. The encoder tests are GPU-lane (no CI runner); both pass locally on the 5090.

## Not in this PR

3-axis M-RoPE in the LM forward, DeepStack injection at LM layers 0/1/2, and the preprocessing→encoder→LM wiring. The encoder runs; nothing calls it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8