### PR TITLE
feat(rope): three-axis M-RoPE, off by default and bit-identical when equal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,6 +632,7 @@ if(IMP_BUILD_TESTS)
         tests/test_library_reserve_cache.cpp
         tests/test_weight_snapshot.cpp
         tests/test_rope_override.cpp
+        tests/test_mrope_config.cpp
         tests/test_ngram_draft.cpp
         tests/test_suffix_draft.cpp
         tests/test_token_recycle_draft.cpp
@@ -683,6 +684,7 @@ if(IMP_BUILD_TESTS)
 
     imp_add_test_module(test-compute SOURCES
         tests/test_rope.cu
+        tests/test_mrope.cu
         tests/test_gpt_oss_yarn_ref.cu
         tests/test_layernorm.cu
         tests/test_mla.cu

--- a/src/compute/rope.cu
+++ b/src/compute/rope.cu
@@ -35,6 +35,28 @@ struct RopeTraits<__half> {
     }
 };
 
+// Which position axis drives this rotary pair. Returns `fallback` unchanged
+// when M-RoPE is off, so the single-axis path keeps computing exactly what it
+// computed before.
+__device__ __forceinline__ int mrope_position(const MRopeParams& m, int fallback, int pair_idx,
+                                              int token_idx) {
+    if (!m.positions)
+        return fallback;
+    int axis;
+    if (m.interleaved) {
+        const int r = pair_idx % 3;
+        if (r == 1 && pair_idx < 3 * m.sec_h)
+            axis = 1;
+        else if (r == 2 && pair_idx < 3 * m.sec_w)
+            axis = 2;
+        else
+            axis = 0;
+    } else {
+        axis = (pair_idx < m.sec_t) ? 0 : (pair_idx < m.sec_t + m.sec_h) ? 1 : 2;
+    }
+    return m.positions[static_cast<int64_t>(axis) * m.stride + token_idx];
+}
+
 // --------------------------------------------------------------------------
 // Unified RoPE kernel with YaRN support (FP32 and FP16 via template)
 // --------------------------------------------------------------------------
@@ -43,7 +65,7 @@ __global__ void rope_forward_kernel(T* __restrict__ Q, T* __restrict__ K, const 
                                     int batch, int seq_len, int n_heads, int n_kv_heads, int head_dim,
                                     float theta, float inv_scaling, int rope_pairs, bool neox,
                                     float ext_factor, float attn_factor, float corr_dim_0, float corr_dim_1,
-                                    const float* __restrict__ longrope_inv_freqs) {
+                                    const float* __restrict__ longrope_inv_freqs, MRopeParams mrope) {
     using Traits = RopeTraits<T>;
 
     const int token_idx = blockIdx.x;
@@ -53,7 +75,7 @@ __global__ void rope_forward_kernel(T* __restrict__ Q, T* __restrict__ K, const 
     if (pair_idx >= rope_pairs)
         return;
 
-    const int pos = positions[token_idx];
+    const int pos = mrope_position(mrope, positions[token_idx], pair_idx, token_idx);
 
     float cos_val, sin_val;
     if (longrope_inv_freqs) {
@@ -111,17 +133,17 @@ __global__ void rope_forward_kernel(T* __restrict__ Q, T* __restrict__ K, const 
 // Explicit template instantiations
 template __global__ void rope_forward_kernel<float>(float*, float*, const int*, int, int, int, int, int,
                                                     float, float, int, bool, float, float, float, float,
-                                                    const float*);
+                                                    const float*, MRopeParams);
 template __global__ void rope_forward_kernel<__half>(__half*, __half*, const int*, int, int, int, int, int,
                                                      float, float, int, bool, float, float, float, float,
-                                                     const float*);
+                                                     const float*, MRopeParams);
 
 // --------------------------------------------------------------------------
 // Host dispatch
 // --------------------------------------------------------------------------
 void rope_forward(Tensor& Q, Tensor& K, const int* positions, int head_dim, float theta, float scaling,
                   int rope_dim, bool neox, float ext_factor, float attn_factor, const float* corr_dims,
-                  cudaStream_t stream, const float* longrope_inv_freqs) {
+                  cudaStream_t stream, const float* longrope_inv_freqs, MRopeParams mrope) {
     const int batch = static_cast<int>(Q.shape[0]);
     const int seq_len = static_cast<int>(Q.shape[1]);
     const int n_heads = static_cast<int>(Q.shape[2]);
@@ -151,13 +173,13 @@ void rope_forward(Tensor& Q, Tensor& K, const int* positions, int head_dim, floa
             pdl::launch(rope_forward_kernel<float>, grid, block, 0, stream, static_cast<float*>(Q.data),
                         static_cast<float*>(K.data), positions, batch, seq_len, n_heads, n_kv_heads, head_dim,
                         theta, inv_scaling, pairs, neox, ext_factor, attn_factor, cd0, cd1,
-                        longrope_inv_freqs);
+                        longrope_inv_freqs, mrope);
             break;
         case QType::F16:
             pdl::launch(rope_forward_kernel<__half>, grid, block, 0, stream, static_cast<__half*>(Q.data),
                         static_cast<__half*>(K.data), positions, batch, seq_len, n_heads, n_kv_heads,
                         head_dim, theta, inv_scaling, pairs, neox, ext_factor, attn_factor, cd0, cd1,
-                        longrope_inv_freqs);
+                        longrope_inv_freqs, mrope);
             break;
         default:
             break;
@@ -191,9 +213,9 @@ __global__ void qknorm_rope_fused_fp16_kernel(
     const __half* __restrict__ k_norm_w, const int* __restrict__ positions, int n_heads, int n_kv_heads,
     int head_dim, float eps, float theta, float inv_scaling, int rope_pairs, bool neox, float weight_offset,
     float ext_factor, float attn_factor, float corr_dim_0, float corr_dim_1,
-    const float* __restrict__ longrope_inv_freqs) {
+    const float* __restrict__ longrope_inv_freqs, MRopeParams mrope) {
     const int head_idx = blockIdx.x;
-    const int pos = positions[0];
+    const int pos_text = positions[0];
 
     extern __shared__ float smem[];
     float* reduce_buf = smem;
@@ -225,6 +247,8 @@ __global__ void qknorm_rope_fused_fp16_kernel(
         __syncthreads();
 
         for (int pair = threadIdx.x; pair < rope_pairs; pair += blockDim.x) {
+            // Decode runs one token, so the axis rows are single entries.
+            const int pos = mrope_position(mrope, pos_text, pair, 0);
             float cos_val, sin_val;
             if (longrope_inv_freqs) {
                 // Pre-computed effective frequencies (see gguf_loader.cpp rope_freqs conversion)
@@ -287,6 +311,8 @@ __global__ void qknorm_rope_fused_fp16_kernel(
         __syncthreads();
 
         for (int pair = threadIdx.x; pair < rope_pairs; pair += blockDim.x) {
+            // Decode runs one token, so the axis rows are single entries.
+            const int pos = mrope_position(mrope, pos_text, pair, 0);
             float cos_val, sin_val;
             if (longrope_inv_freqs) {
                 // Pre-computed effective frequencies (see gguf_loader.cpp rope_freqs conversion)
@@ -323,7 +349,7 @@ void qknorm_rope_fused(half* Q, half* K, const half* q_norm_weight, const half* 
                        int n_kv_heads, int head_dim, float eps, const int* positions, float theta,
                        float scaling, int rope_dim, bool neox, cudaStream_t stream, float weight_offset,
                        float ext_factor, float attn_factor, const float* corr_dims,
-                       const float* longrope_inv_freqs) {
+                       const float* longrope_inv_freqs, MRopeParams mrope) {
     const int max_heads = (n_heads > n_kv_heads) ? n_heads : n_kv_heads;
     if (max_heads == 0 || head_dim == 0)
         return;
@@ -346,7 +372,7 @@ void qknorm_rope_fused(half* Q, half* K, const half* q_norm_weight, const half* 
                 reinterpret_cast<const __half*>(q_norm_weight),
                 reinterpret_cast<const __half*>(k_norm_weight), positions, n_heads, n_kv_heads, head_dim, eps,
                 theta, inv_scaling, rope_pairs, neox, weight_offset, ext_factor, attn_factor, cd0, cd1,
-                longrope_inv_freqs);
+                longrope_inv_freqs, mrope);
 }
 
 // --------------------------------------------------------------------------

--- a/src/compute/rope.h
+++ b/src/compute/rope.h
@@ -6,6 +6,25 @@
 
 namespace imp {
 
+// M-RoPE (Qwen-VL family): rotary pairs are driven by three position axes —
+// text/time, image height, image width — instead of one.
+//
+// `positions` is [3, stride]: axis-major, one row of `stride` token positions
+// each. A null pointer is the whole opt-out: every rotary pair then reads the
+// single `positions` argument of the call, which is exactly what every
+// text-only model does today. A non-null pointer whose three rows are equal
+// produces the same angles as that path and must stay bit-identical to it —
+// that is the invariant a text prompt on a VL model relies on.
+struct MRopeParams {
+    const int* positions = nullptr;
+    int stride = 0;                       // tokens per axis row
+    int sec_t = 0, sec_h = 0, sec_w = 0;  // half-counts, summing to rope_dim/2
+    // Qwen3-VL interleaves the axes across the spectrum (T,H,W,T,H,W,... then a
+    // T tail); Qwen2-VL takes three contiguous blocks. Different dimensions get
+    // different angles, so the layouts are not interchangeable.
+    bool interleaved = false;
+};
+
 // Fused RoPE on Q and K tensors in-place
 // rope_dim: if > 0, only rotate the first rope_dim dimensions; rest unchanged.
 //           if 0, rotate all head_dim dimensions (default).
@@ -19,7 +38,7 @@ namespace imp {
 void rope_forward(Tensor& Q, Tensor& K, const int* positions, int head_dim, float theta = 10000.0f,
                   float scaling = 1.0f, int rope_dim = 0, bool neox = false, float ext_factor = 0.0f,
                   float attn_factor = 1.0f, const float* corr_dims = nullptr, cudaStream_t stream = nullptr,
-                  const float* longrope_inv_freqs = nullptr);
+                  const float* longrope_inv_freqs = nullptr, MRopeParams mrope = {});
 
 // Fused QK-norm + RoPE for decode (n=1, FP16).
 // Applies per-head RMSNorm on Q and K, then RoPE, in a single kernel launch.
@@ -31,7 +50,7 @@ void qknorm_rope_fused(half* Q, half* K, const half* q_norm_weight, const half* 
                        float scaling = 1.0f, int rope_dim = 0, bool neox = false,
                        cudaStream_t stream = nullptr, float weight_offset = 0.0f, float ext_factor = 0.0f,
                        float attn_factor = 1.0f, const float* corr_dims = nullptr,
-                       const float* longrope_inv_freqs = nullptr);
+                       const float* longrope_inv_freqs = nullptr, MRopeParams mrope = {});
 
 // Precompute YaRN correction dimension boundaries.
 // dims[0] = start (below: full NTK interpolation)

--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -203,6 +203,40 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg,
             jobj_get_float(*rope_params, "partial_rotary_factor", partial_factor);
         }
     }
+
+    // M-RoPE section split. It lives under `rope_scaling` in older configs and
+    // under `rope_parameters` in newer ones (Qwen3-VL), so both are checked —
+    // reading only one silently leaves a multimodal model on single-axis RoPE.
+    for (const char* key : {"rope_scaling", "rope_parameters"}) {
+        const JValue* obj = jobj_find(eff, key);
+        if (!obj || obj->type != JType::OBJECT)
+            continue;
+        const JValue* sec = jobj_find(*obj, "mrope_section");
+        if (sec && sec->type == JType::ARRAY && sec->arr.size() == 3) {
+            bool ok = true;
+            int parsed[3] = {0, 0, 0};
+            for (size_t i = 0; i < 3; ++i) {
+                if (sec->arr[i].type != JType::NUMBER || sec->arr[i].as_int() < 0)
+                    ok = false;
+                else
+                    parsed[i] = static_cast<int>(sec->arr[i].as_int());
+            }
+            if (ok) {
+                for (int i = 0; i < 3; ++i)
+                    cfg.mrope_section[i] = parsed[i];
+            } else {
+                IMP_LOG_WARN("mrope_section under '%s' is malformed — ignoring it", key);
+            }
+        }
+        // Booleans arrive as NUMBER 0.0/1.0 from this parser.
+        const JValue* inter = jobj_find(*obj, "mrope_interleaved");
+        if (inter && inter->type == JType::NUMBER)
+            cfg.mrope_interleaved = inter->num_val != 0.0;
+    }
+    if (cfg.has_mrope()) {
+        IMP_LOG_INFO("M-RoPE section [%d, %d, %d]%s", cfg.mrope_section[0], cfg.mrope_section[1],
+                     cfg.mrope_section[2], cfg.mrope_interleaved ? " (interleaved)" : "");
+    }
     if (partial_factor > 0.0f && partial_factor < 1.0f) {
         int hd_for_rope = (cfg.head_dim > 0) ? cfg.head_dim
                                              : (cfg.n_heads > 0 ? cfg.d_model / cfg.n_heads : 0);

--- a/src/model/model_config.h
+++ b/src/model/model_config.h
@@ -54,16 +54,30 @@ struct ModelConfig {
     int rope_dim = 0;       // 0 = full head_dim, 84 = partial
     bool rope_neox = true;  // true = NeoX/split (i, i+d/2), false = interleaved (2i, 2i+1)
 
+    // M-RoPE (Qwen-VL family): the rotary pairs are split across three position
+    // axes — text/time, image height, image width. Half-counts, summing to
+    // rope_dim/2 (Qwen3-VL: [24, 20, 20] for rope_dim 128). All zero means the
+    // model has no M-RoPE and every rotary pair follows the single text
+    // position, which is also what a text-only prompt reduces to on a model
+    // that does have it.
+    int mrope_section[3] = {0, 0, 0};
+    // Qwen3-VL interleaves the three axes across the frequency spectrum
+    // (T,H,W,T,H,W,... then T for the tail) instead of taking three contiguous
+    // blocks, "preserving frequency continuity" per upstream. The two layouts
+    // rotate different dimensions by different angles, so this is not cosmetic.
+    bool mrope_interleaved = false;
+    bool has_mrope() const { return mrope_section[1] > 0 || mrope_section[2] > 0; }
+
     // MLA (DeepSeek-V2/V3). kv_lora_rank > 0 selects the MLA path.
-    int   kv_lora_rank      = 0;     // 512 (V2-Lite) / 1024 (V3)
-    int   q_lora_rank       = 0;     // 0 = full Q projection (V2-Lite); >0 = Q down/up LoRA (V3)
-    int   qk_rope_head_dim  = 0;     // 64  — decoupled RoPE key dims
-    int   qk_nope_head_dim  = 0;     // 128 — non-RoPE key dims
-    int   v_head_dim        = 0;     // 128 — value head dim
+    int kv_lora_rank = 0;      // 512 (V2-Lite) / 1024 (V3)
+    int q_lora_rank = 0;       // 0 = full Q projection (V2-Lite); >0 = Q down/up LoRA (V3)
+    int qk_rope_head_dim = 0;  // 64  — decoupled RoPE key dims
+    int qk_nope_head_dim = 0;  // 128 — non-RoPE key dims
+    int v_head_dim = 0;        // 128 — value head dim
     // YaRN mscale used for the softmax attention-scale adjustment.
     // Stores rope_scaling.mscale_all_dim if present, else rope_scaling.mscale.
     // For DeepSeek-V2-Lite both are 0.707; the distinction matters for V3.
-    float mla_mscale        = 1.0f;
+    float mla_mscale = 1.0f;
     // Raw rope_scaling.mscale (the numerator of the RoPE cos/sin scale).
     // HF DeepseekV2YarnRotaryEmbedding scales cos/sin by the RATIO
     //   yarn_get_mscale(factor, mscale) / yarn_get_mscale(factor, mscale_all_dim),
@@ -71,9 +85,9 @@ struct ModelConfig {
     // NOT yarn_get_mscale(factor, mscale_all_dim). Kept separate from
     // mla_mscale (= mscale_all_dim, used by the softmax scale) so the rope
     // factor below can form the ratio instead of double-applying the mscale.
-    float mla_mscale_num    = 1.0f;
-    bool  is_mla() const { return kv_lora_rank > 0; }
-    int   first_k_dense_replace = 0; // layers [0, k) use dense FFN even in a MoE model
+    float mla_mscale_num = 1.0f;
+    bool is_mla() const { return kv_lora_rank > 0; }
+    int first_k_dense_replace = 0;  // layers [0, k) use dense FFN even in a MoE model
     // NoPE attention (Nemotron-H family): attention layers use NO rotary
     // embedding — position is carried by the recurrent (Mamba) layers.
     bool rope_attn_disabled = false;
@@ -186,9 +200,9 @@ struct ModelConfig {
 // This helper returns mscale_adj^2 when the config is an MLA model with
 // YaRN factor > 1, and 1.0f otherwise (leaving non-MLA models unaffected).
 inline float mla_attention_scale_multiplier(const ModelConfig& cfg) {
-    if (!cfg.is_mla() || cfg.rope_freq_scale <= 1.0f) return 1.0f;
-    const float mscale_adj =
-        0.1f * cfg.mla_mscale * std::log(cfg.rope_freq_scale) + 1.0f;
+    if (!cfg.is_mla() || cfg.rope_freq_scale <= 1.0f)
+        return 1.0f;
+    const float mscale_adj = 0.1f * cfg.mla_mscale * std::log(cfg.rope_freq_scale) + 1.0f;
     return mscale_adj * mscale_adj;
 }
 
@@ -222,13 +236,13 @@ struct TransformerLayer {
     // kv_a_layernorm: RMSNorm weight on the 512-dim latent (never quantized).
     // kv_b_proj: up-projection, output 16*(128+128)=4096.
     Tensor kv_a_proj, kv_a_layernorm, kv_b_proj;
-    Tensor q_bias, k_bias, v_bias;         // Attention biases (Qwen2)
-    Tensor o_bias;                         // Output-projection bias (gpt-oss)
-    Tensor attn_sinks;                     // Per-head sink logits [n_heads] (gpt-oss)
-    Tensor router_bias;                    // Router logits bias [n_experts] (gpt-oss)
-    Tensor expert_gate_bias;               // Per-expert gate bias [ne, d_ff] (gpt-oss, de-interleaved)
-    Tensor expert_up_bias;                 // Per-expert up bias [ne, d_ff] (gpt-oss, de-interleaved)
-    Tensor expert_down_bias;               // Per-expert down bias [ne, d_model] (gpt-oss)
+    Tensor q_bias, k_bias, v_bias;  // Attention biases (Qwen2)
+    Tensor o_bias;                  // Output-projection bias (gpt-oss)
+    Tensor attn_sinks;              // Per-head sink logits [n_heads] (gpt-oss)
+    Tensor router_bias;             // Router logits bias [n_experts] (gpt-oss)
+    Tensor expert_gate_bias;        // Per-expert gate bias [ne, d_ff] (gpt-oss, de-interleaved)
+    Tensor expert_up_bias;          // Per-expert up bias [ne, d_ff] (gpt-oss, de-interleaved)
+    Tensor expert_down_bias;        // Per-expert down bias [ne, d_model] (gpt-oss)
     // gpt-oss raw checkpoint slots (HF MXFP4 layout, consumed at upload):
     Tensor expert_gate_up_packed_blocks;   // U8 [ne, 2*d_ff, K/32, 16] e2m1, rows interleaved g0,u0,g1,...
     Tensor expert_gate_up_packed_scales;   // U8 [ne, 2*d_ff, K/32] ue8m0

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -71,9 +71,10 @@ Engine::~Engine() {
     // Serving would make the next engine's init look like an I2 violation.
     set_alloc_phase(AllocPhase::Loading);
     if (const uint64_t n = steady_state_allocations(); n > 0) {
-        IMP_LOG_WARN("I2: %llu device allocation(s) were made while serving — "
-                     "see the per-tag warnings above (criterion 3 requires zero)",
-                     static_cast<unsigned long long>(n));
+        IMP_LOG_WARN(
+            "I2: %llu device allocation(s) were made while serving — "
+            "see the per-tag warnings above (criterion 3 requires zero)",
+            static_cast<unsigned long long>(n));
     }
     MemAccount::instance().sampler_stop();
     MemAccount::instance().report("shutdown");
@@ -251,13 +252,19 @@ bool Engine::enable_mtp_spec_decode(int k) {
     ws->rope_neox = model_->config_.rope_neox;
     ws->rms_norm_eps = model_->config_.rms_norm_eps;
     ws->rope_dim = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : mtp_head_dim;
-    // mrope section split. Qwen3.6 ships mrope_section = [11, 11, 10]
-    // (half-counts; full rope_dim = 64 = 2*(11+11+10)). imp doesn't load
-    // this from config yet — hardcoded here based on the on-disk spec.
+    // mrope section split. Read from config when the checkpoint carries one
+    // (Qwen3-VL: [24, 20, 20]); the Qwen3.6 constant below stays as the
+    // fallback for checkpoints that ship the split only in their spec.
     // For text-only generation all 3 positions are equal, so this is
     // mathematically equivalent to standard partial-rope; the section
     // split matters only for true multimodal tokens.
-    if (ws->rope_dim == 64) {
+    const ModelConfig& mc = model_->config_;
+    if (mc.has_mrope() &&
+        mc.mrope_section[0] + mc.mrope_section[1] + mc.mrope_section[2] == ws->rope_dim / 2) {
+        ws->mrope_sec0 = mc.mrope_section[0];
+        ws->mrope_sec1 = mc.mrope_section[1];
+        ws->mrope_sec2 = mc.mrope_section[2];
+    } else if (ws->rope_dim == 64) {
         ws->mrope_sec0 = 11;
         ws->mrope_sec1 = 11;
         ws->mrope_sec2 = 10;
@@ -860,12 +867,12 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         // capture_ctx_cap mirrors engine_spec_capture.cpp: the chunk-capture
         // scratch is sized from min(the configured cap, max_seq_len), and is
         // charged only when speculation can actually take that path.
-        const int capture_cap =
-            runtime_config_.speculative.capture
-                ? (config_.max_seq_len > 0
-                       ? std::min(runtime_config_.speculative.capture_ctx_cap, config_.max_seq_len)
-                       : runtime_config_.speculative.capture_ctx_cap)
-                : 0;
+        const int capture_cap = runtime_config_.speculative.capture
+                                    ? (config_.max_seq_len > 0
+                                           ? std::min(runtime_config_.speculative.capture_ctx_cap,
+                                                      config_.max_seq_len)
+                                           : runtime_config_.speculative.capture_ctx_cap)
+                                    : 0;
         const auto d = exec_t2_demand(*model_, config_.max_seq_len, config_.max_batch_size,
                                       config_.use_fp8_prefill, runtime_config_.attention.mla_absorb,
                                       capture_cap);
@@ -979,12 +986,12 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // Measured on Qwen3-8B this is the difference between 82.5 % and 98.3 %
     // accounted, i.e. criterion 6 met instead of missed, with no config change.
     // Falls back to the charged value when warmup was skipped (MXFP4, Gemma-4).
-    MemAccount::instance().set_named_charges(
-        ctx_baseline_bytes,
-        measured_library_reserve_ != SIZE_MAX
-            ? measured_library_reserve_
-            : engine_internal::library_reserve_charge(runtime_config_.vram.library_reserve_mb),
-        engine_arena().capacity(), engine_arena().high_water());
+    MemAccount::instance().set_named_charges(ctx_baseline_bytes,
+                                             measured_library_reserve_ != SIZE_MAX
+                                                 ? measured_library_reserve_
+                                                 : engine_internal::library_reserve_charge(
+                                                       runtime_config_.vram.library_reserve_mb),
+                                             engine_arena().capacity(), engine_arena().high_water());
     MemAccount::instance().sampler_start(2000);
     MemAccount::instance().report("init_complete");
 

--- a/tests/test_mrope.cu
+++ b/tests/test_mrope.cu
@@ -1,0 +1,264 @@
+// M-RoPE: three position axes instead of one.
+//
+// This touches the rotary path of EVERY model, so the first thing it has to
+// prove is that it changes nothing. Two invariants carry that:
+//
+//   1. With M-RoPE off (null pointer) the output must be bit-identical to the
+//      pre-change kernel — which is testable as "identical to the same call
+//      with the parameter defaulted", since that is the only path text-only
+//      models take.
+//   2. With M-RoPE on but all three axes carrying the SAME position — what a
+//      text-only prompt on a VL model looks like — the output must be
+//      bit-identical to the single-axis path. Not merely close: the angles are
+//      the same number, so every bit must match.
+//
+// Only then does the three-axis behaviour itself get checked, against a CPU
+// reference of the interleaved layout read off `Qwen3VLTextRotaryEmbedding.
+// apply_interleaved_mrope`.
+
+#include "compute/rope.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+namespace imp {
+namespace {
+
+constexpr int kHeads = 4;
+constexpr int kKvHeads = 2;
+constexpr int kHeadDim = 128;
+constexpr int kPairs = kHeadDim / 2;  // 64
+constexpr int kTokens = 5;
+constexpr float kTheta = 5000000.0f;
+// Qwen3-VL's split: 24 + 20 + 20 = 64 pairs.
+constexpr int kSecT = 24, kSecH = 20, kSecW = 20;
+
+bool gpu_available() {
+    int n = 0;
+    return cudaGetDeviceCount(&n) == cudaSuccess && n > 0;
+}
+
+struct DeviceRun {
+    std::vector<float> q, k;
+};
+
+std::vector<float> ramp(size_t n, float start) {
+    std::vector<float> v(n);
+    for (size_t i = 0; i < n; ++i)
+        v[i] = start + 0.013f * static_cast<float>(i % 97) - 0.6f;
+    return v;
+}
+
+// Runs rope_forward on FP32 Q/K and brings the result back.
+DeviceRun run_rope(const std::vector<float>& q_in, const std::vector<float>& k_in,
+                   const std::vector<int>& positions, const std::vector<int>* mrope_positions,
+                   bool interleaved) {
+    float *d_q = nullptr, *d_k = nullptr;
+    int *d_pos = nullptr, *d_mrope = nullptr;
+    EXPECT_EQ(cudaMalloc(&d_q, q_in.size() * sizeof(float)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&d_k, k_in.size() * sizeof(float)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&d_pos, positions.size() * sizeof(int)), cudaSuccess);
+    cudaMemcpy(d_q, q_in.data(), q_in.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_k, k_in.data(), k_in.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_pos, positions.data(), positions.size() * sizeof(int), cudaMemcpyHostToDevice);
+
+    MRopeParams mrope;
+    if (mrope_positions) {
+        EXPECT_EQ(cudaMalloc(&d_mrope, mrope_positions->size() * sizeof(int)), cudaSuccess);
+        cudaMemcpy(d_mrope, mrope_positions->data(), mrope_positions->size() * sizeof(int),
+                   cudaMemcpyHostToDevice);
+        mrope.positions = d_mrope;
+        mrope.stride = kTokens;
+        mrope.sec_t = kSecT;
+        mrope.sec_h = kSecH;
+        mrope.sec_w = kSecW;
+        mrope.interleaved = interleaved;
+    }
+
+    const int64_t qshape[4] = {1, kTokens, kHeads, kHeadDim};
+    const int64_t kshape[4] = {1, kTokens, kKvHeads, kHeadDim};
+    Tensor Q(d_q, QType::F32, 4, qshape, true);
+    Tensor K(d_k, QType::F32, 4, kshape, true);
+    rope_forward(Q, K, d_pos, kHeadDim, kTheta, 1.0f, /*rope_dim=*/0, /*neox=*/true, 0.0f, 1.0f, nullptr,
+                 nullptr, nullptr, mrope);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    DeviceRun out;
+    out.q.resize(q_in.size());
+    out.k.resize(k_in.size());
+    cudaMemcpy(out.q.data(), d_q, q_in.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(out.k.data(), d_k, k_in.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_pos);
+    if (d_mrope)
+        cudaFree(d_mrope);
+    return out;
+}
+
+void expect_bit_identical(const std::vector<float>& a, const std::vector<float>& b, const char* what) {
+    ASSERT_EQ(a.size(), b.size());
+    size_t differing = 0;
+    for (size_t i = 0; i < a.size(); ++i)
+        if (std::memcmp(&a[i], &b[i], sizeof(float)) != 0)
+            ++differing;
+    EXPECT_EQ(differing, 0u) << what << ": " << differing << " of " << a.size() << " floats differ";
+}
+
+// The invariant every existing model depends on.
+TEST(MRope, TextOnlyPositionsAreBitIdenticalToSingleAxis) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const auto q = ramp(static_cast<size_t>(kTokens) * kHeads * kHeadDim, 0.4f);
+    const auto k = ramp(static_cast<size_t>(kTokens) * kKvHeads * kHeadDim, -0.3f);
+    std::vector<int> pos(kTokens);
+    for (int i = 0; i < kTokens; ++i)
+        pos[i] = 7 + i * 3;  // arbitrary, non-contiguous
+
+    const DeviceRun single = run_rope(q, k, pos, nullptr, false);
+
+    // All three axes carry the text position — a text-only prompt on a VL model.
+    std::vector<int> three(static_cast<size_t>(3) * kTokens);
+    for (int a = 0; a < 3; ++a)
+        for (int i = 0; i < kTokens; ++i)
+            three[static_cast<size_t>(a) * kTokens + i] = pos[i];
+
+    for (bool interleaved : {true, false}) {
+        const DeviceRun same = run_rope(q, k, pos, &three, interleaved);
+        expect_bit_identical(single.q, same.q, interleaved ? "Q (interleaved)" : "Q (sectioned)");
+        expect_bit_identical(single.k, same.k, interleaved ? "K (interleaved)" : "K (sectioned)");
+    }
+}
+
+// CPU reference of the interleaved layout: pair j follows axis j%3 inside that
+// axis's interleave region, and the text axis everywhere else.
+int expected_axis_interleaved(int pair) {
+    const int r = pair % 3;
+    if (r == 1 && pair < 3 * kSecH)
+        return 1;
+    if (r == 2 && pair < 3 * kSecW)
+        return 2;
+    return 0;
+}
+
+int expected_axis_sectioned(int pair) {
+    if (pair < kSecT)
+        return 0;
+    if (pair < kSecT + kSecH)
+        return 1;
+    return 2;
+}
+
+void check_against_reference(bool interleaved) {
+    const auto q = ramp(static_cast<size_t>(kTokens) * kHeads * kHeadDim, 0.4f);
+    const auto k = ramp(static_cast<size_t>(kTokens) * kKvHeads * kHeadDim, -0.3f);
+    std::vector<int> pos(kTokens);
+    std::vector<int> three(static_cast<size_t>(3) * kTokens);
+    for (int i = 0; i < kTokens; ++i) {
+        pos[i] = 100 + i;                      // T
+        three[i] = pos[i];                     //
+        three[kTokens + i] = 40 + 2 * i;       // H
+        three[2 * kTokens + i] = 900 - 5 * i;  // W
+    }
+
+    const DeviceRun got = run_rope(q, k, pos, &three, interleaved);
+
+    for (int t = 0; t < kTokens; ++t) {
+        for (int h = 0; h < kHeads; ++h) {
+            for (int p = 0; p < kPairs; ++p) {
+                const int axis = interleaved ? expected_axis_interleaved(p) : expected_axis_sectioned(p);
+                const double position = three[static_cast<size_t>(axis) * kTokens + t];
+                const double freq = 1.0 / std::pow(static_cast<double>(kTheta),
+                                                   (2.0 * p) / static_cast<double>(kHeadDim));
+                const double angle = position * freq;
+                const size_t base = (static_cast<size_t>(t) * kHeads + h) *
+                                    kHeadDim;  // NeoX pairs (p, p + kPairs)
+                const double q0 = q[base + p], q1 = q[base + p + kPairs];
+                EXPECT_NEAR(got.q[base + p], q0 * std::cos(angle) - q1 * std::sin(angle), 2e-3)
+                    << "token " << t << " head " << h << " pair " << p << " axis " << axis;
+                EXPECT_NEAR(got.q[base + p + kPairs], q0 * std::sin(angle) + q1 * std::cos(angle), 2e-3)
+                    << "token " << t << " head " << h << " pair " << p << " axis " << axis;
+            }
+        }
+    }
+}
+
+TEST(MRope, InterleavedLayoutMatchesTheReference) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+    check_against_reference(true);
+}
+
+TEST(MRope, SectionedLayoutMatchesTheReference) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+    check_against_reference(false);
+}
+
+// The two layouts must actually differ, or "matches the reference" would be
+// satisfied by either implementation.
+TEST(MRope, TheTwoLayoutsDisagreeOnDistinctAxes) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const auto q = ramp(static_cast<size_t>(kTokens) * kHeads * kHeadDim, 0.4f);
+    const auto k = ramp(static_cast<size_t>(kTokens) * kKvHeads * kHeadDim, -0.3f);
+    std::vector<int> pos(kTokens);
+    std::vector<int> three(static_cast<size_t>(3) * kTokens);
+    for (int i = 0; i < kTokens; ++i) {
+        pos[i] = 100 + i;
+        three[i] = pos[i];
+        three[kTokens + i] = 40 + 2 * i;
+        three[2 * kTokens + i] = 900 - 5 * i;
+    }
+    const DeviceRun a = run_rope(q, k, pos, &three, true);
+    const DeviceRun b = run_rope(q, k, pos, &three, false);
+    float worst = 0.0f;
+    for (size_t i = 0; i < a.q.size(); ++i)
+        worst = std::max(worst, std::fabs(a.q[i] - b.q[i]));
+    EXPECT_GT(worst, 1e-2f) << "interleaved and sectioned M-RoPE produced the same rotation";
+}
+
+// The H and W axes only reach their interleave regions; everything else must
+// still follow the text axis. A layout that leaked H into the tail would show
+// up here and nowhere else.
+TEST(MRope, TailPairsBeyondTheInterleaveRegionFollowTheTextAxis) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const auto q = ramp(static_cast<size_t>(kTokens) * kHeads * kHeadDim, 0.4f);
+    const auto k = ramp(static_cast<size_t>(kTokens) * kKvHeads * kHeadDim, -0.3f);
+    std::vector<int> pos(kTokens, 11);
+    std::vector<int> only_text(static_cast<size_t>(3) * kTokens);
+    std::vector<int> wild_hw(static_cast<size_t>(3) * kTokens);
+    for (int i = 0; i < kTokens; ++i) {
+        only_text[i] = wild_hw[i] = 11;
+        only_text[kTokens + i] = only_text[2 * kTokens + i] = 11;
+        wild_hw[kTokens + i] = 777;  // H and W wildly different
+        wild_hw[2 * kTokens + i] = 4242;
+    }
+    const DeviceRun base = run_rope(q, k, pos, &only_text, true);
+    const DeviceRun wild = run_rope(q, k, pos, &wild_hw, true);
+
+    const int interleave_end = 3 * (kSecH > kSecW ? kSecH : kSecW);  // 60
+    for (int p = interleave_end; p < kPairs; ++p) {
+        for (int t = 0; t < kTokens; ++t) {
+            const size_t base_idx = (static_cast<size_t>(t) * kHeads) * kHeadDim + p;
+            EXPECT_FLOAT_EQ(base.q[base_idx], wild.q[base_idx]) << "tail pair " << p << " moved with H/W";
+        }
+    }
+    // ...and inside the region it MUST move, or the previous loop proves nothing.
+    float moved = 0.0f;
+    for (int p = 0; p < interleave_end; ++p)
+        moved = std::max(moved, std::fabs(base.q[p] - wild.q[p]));
+    EXPECT_GT(moved, 1e-2f);
+}
+
+}  // namespace
+}  // namespace imp

--- a/tests/test_mrope_config.cpp
+++ b/tests/test_mrope_config.cpp
@@ -1,0 +1,90 @@
+// Reading `mrope_section` out of an HF config.
+//
+// The section split lives under `rope_scaling` in the Qwen2-VL generation and
+// under `rope_parameters` in Qwen3-VL. Reading only one of them leaves a
+// multimodal model silently on single-axis RoPE — which still generates text,
+// just with every image token positioned as if it were a text token.
+
+#include "model/hf_config_loader.h"
+#include "model/json_util.h"
+#include "model/model_config.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+namespace imp {
+namespace {
+
+// The loader reads a directory, so each case is written to one.
+class MRopeConfig : public ::testing::Test {
+protected:
+    void SetUp() override {
+        dir_ = std::string(std::tmpnam(nullptr)) + "_mrope";
+        ::system(("mkdir -p " + dir_).c_str());
+    }
+    void TearDown() override { ::system(("rm -rf " + dir_).c_str()); }
+
+    ModelConfig load(const std::string& json) {
+        std::ofstream f(dir_ + "/config.json");
+        f << json;
+        f.close();
+        ModelConfig cfg;
+        EXPECT_TRUE(HFConfigLoader::load_config(dir_, cfg));
+        return cfg;
+    }
+
+    std::string dir_;
+};
+
+const char* kBody = R"("hidden_size": 2560, "num_attention_heads": 32, "num_key_value_heads": 8,
+    "num_hidden_layers": 36, "vocab_size": 151936, "head_dim": 128)";
+
+TEST_F(MRopeConfig, ReadsTheSplitFromRopeParameters) {
+    const ModelConfig cfg = load(std::string("{") + kBody + R"(,
+        "rope_parameters": {"rope_theta": 5000000.0, "mrope_section": [24, 20, 20],
+                            "mrope_interleaved": true}})");
+    EXPECT_TRUE(cfg.has_mrope());
+    EXPECT_EQ(cfg.mrope_section[0], 24);
+    EXPECT_EQ(cfg.mrope_section[1], 20);
+    EXPECT_EQ(cfg.mrope_section[2], 20);
+    EXPECT_TRUE(cfg.mrope_interleaved);
+}
+
+TEST_F(MRopeConfig, ReadsTheSplitFromRopeScaling) {
+    const ModelConfig cfg = load(std::string("{") + kBody + R"(,
+        "rope_scaling": {"type": "mrope", "mrope_section": [16, 24, 24]}})");
+    EXPECT_TRUE(cfg.has_mrope());
+    EXPECT_EQ(cfg.mrope_section[0], 16);
+    EXPECT_EQ(cfg.mrope_section[1], 24);
+    EXPECT_EQ(cfg.mrope_section[2], 24);
+    EXPECT_FALSE(cfg.mrope_interleaved) << "absent means the contiguous layout";
+}
+
+// Every text-only model must come out with M-RoPE off, so nothing in the hot
+// path changes for them.
+TEST_F(MRopeConfig, TextOnlyConfigLeavesMRopeOff) {
+    const ModelConfig cfg = load(std::string("{") + kBody + R"(,
+        "rope_theta": 1000000.0, "rope_scaling": {"type": "yarn", "factor": 4.0}})");
+    EXPECT_FALSE(cfg.has_mrope());
+    EXPECT_EQ(cfg.mrope_section[0], 0);
+    EXPECT_EQ(cfg.mrope_section[1], 0);
+    EXPECT_EQ(cfg.mrope_section[2], 0);
+}
+
+// A malformed split must not half-apply: two of three axes would put the H and
+// W rotations on the wrong dimensions.
+TEST_F(MRopeConfig, MalformedSplitIsIgnoredWholesale) {
+    for (const char* bad :
+         {R"([24, 20])", R"([24, 20, 20, 20])", R"([24, "20", 20])", R"([24, -1, 20])", R"("24,20,20")"}) {
+        const ModelConfig cfg = load(std::string("{") + kBody + R"(, "rope_parameters": {"mrope_section": )" +
+                                     bad + "}}");
+        EXPECT_FALSE(cfg.has_mrope()) << bad;
+        EXPECT_EQ(cfg.mrope_section[0], 0) << bad;
+    }
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Piece 6 of gap 2 (`docs/plans/2026-07-31-qwen3-vl-vision.md`) — the one the plan says should land on its own, because it is the only piece that can regress models that have nothing to do with vision.

## What imp had

The M-RoPE section split existed in exactly one place: the MTP draft head, hardcoded to `[11, 11, 10]` with an explicit *"imp doesn't load this from config yet"* and, by its own comment, only ever exercised where all three positions are equal — i.e. equivalent to plain partial-rope. The rotary path the real forward uses had no notion of it at all.

## What this adds

- `MRopeParams` on `rope_forward` and `qknorm_rope_fused` (prefill and the decode fast path).
- `mrope_section` / `mrope_interleaved` in `ModelConfig`, read from **both** `rope_scaling` (Qwen2-VL era) and `rope_parameters` (Qwen3-VL). Reading only one leaves a multimodal model on single-axis RoPE with no error at all.
- The MTP head now takes its split from the config when the checkpoint carries one, keeping the old constant as the fallback.

## It has to change nothing first

This is the hot path of every model, so the opt-out is the null pointer: `MRopeParams::positions == nullptr` makes the kernel compute the same angle from the same single position array it always did. Nothing in the tree passes the parameter yet, so nothing else changes.

The invariant that matters beyond that is the second one, and it is a test:

> With M-RoPE **on** but all three axes carrying the same position — what a text-only prompt on a VL model looks like — the output must be **bit-identical** to the single-axis path.

Not "close". Every bit. It passes for both layouts.

## Both layouts, because they are not interchangeable

Qwen3-VL **interleaves** the axes across the frequency spectrum (`T,H,W,T,H,W,...` then a `T` tail past the interleave region); Qwen2-VL takes three **contiguous** blocks. Different dimensions get different angles. Implementing only the interleaved form would put a Qwen2-VL checkpoint's H and W rotations on the wrong dimensions, silently — so both exist and `mrope_interleaved` selects between them. A test asserts the two layouts actually disagree on distinct axes, so "matches the reference" cannot be satisfied by either one.

A malformed `mrope_section` is ignored wholesale rather than half-applied: two of three axes landing would be worse than none.

## Regression evidence

| Check | Result |
|---|---|
| test-core / test-compute / test-attention / test-kv / test-quant / test-text | all green (test-compute: 204 tests) |
| `degen_suite.py` vs served Qwen3-4B-Q8 | 34 checks, 0 FAIL |
| Decode A/B, 4 interleaved trials, 10 reps each, warm clocks, Qwen3-4B-Q8 | branch median **282.5** tok/s vs main **273.8** |

The A/B arms overlap heavily — within-arm spread reaches 13% on this box — so the two are indistinguishable. No measurable cost, and the direction of the difference is noise, not a win.

## Not in this PR

Computing the per-token `(t, h, w)` ids (HF's `get_rope_index`) and passing them in. That belongs with the image-token wiring, where the mask of which positions came from the image is built anyway. This PR is the mechanism plus the config read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8