### PR TITLE
feat(rope): per-token (t, h, w) positions for prompts containing images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ set(IMP_MODEL_SOURCES
     src/model/sentencepiece_loader.cpp
     src/model/json_util.cpp
     src/model/hf_config_loader.cpp
+    src/model/mrope_positions.cpp
     src/model/hf_hub.cpp
     src/model/weight_map.cpp
     src/model/weight_upload.cu
@@ -639,6 +640,7 @@ if(IMP_BUILD_TESTS)
         tests/test_think_stop_logic.cpp
         tests/test_stream_pipeline.cpp
         tests/test_vision_preprocess.cpp
+        tests/test_mrope_positions.cpp
         tests/test_mla.cpp
     )
     if(IMP_BUILD_SERVER)

--- a/src/model/mrope_positions.cpp
+++ b/src/model/mrope_positions.cpp
@@ -1,0 +1,78 @@
+#include "model/mrope_positions.h"
+
+#include <algorithm>
+
+namespace imp {
+
+bool qwen_build_mrope_positions(const std::vector<uint8_t>& is_image,
+                                const std::vector<MRopeImageGrid>& grids, int start_pos,
+                                std::vector<int32_t>& out, int& next_pos, std::string& err) {
+    const size_t n = is_image.size();
+    if (start_pos < 0) {
+        err = "start position must not be negative";
+        return false;
+    }
+    for (size_t g = 0; g < grids.size(); ++g) {
+        if (grids[g].rows <= 0 || grids[g].cols <= 0) {
+            err = "image " + std::to_string(g) + " has an empty grid";
+            return false;
+        }
+    }
+
+    std::vector<int32_t> pos(3 * n);
+    auto set = [&](size_t token, int t, int h, int w) {
+        pos[token] = t;
+        pos[n + token] = h;
+        pos[2 * n + token] = w;
+    };
+
+    size_t i = 0;
+    size_t next_grid = 0;
+    int cur = start_pos;
+    while (i < n) {
+        if (!is_image[i]) {
+            // Text advances all three axes in lockstep.
+            set(i, cur, cur, cur);
+            ++cur;
+            ++i;
+            continue;
+        }
+        // One contiguous image run.
+        size_t run = 0;
+        while (i + run < n && is_image[i + run])
+            ++run;
+        if (next_grid >= grids.size()) {
+            err = "more image runs in the prompt than image grids (" + std::to_string(grids.size()) + ")";
+            return false;
+        }
+        const MRopeImageGrid& g = grids[next_grid];
+        if (static_cast<size_t>(g.tokens()) != run) {
+            err = "image " + std::to_string(next_grid) + " has " + std::to_string(g.tokens()) + " tokens (" +
+                  std::to_string(g.rows) + "x" + std::to_string(g.cols) + ") but the prompt reserves " +
+                  std::to_string(run);
+            return false;
+        }
+        // Raster order over the merged grid: the same order the vision merger
+        // emits its tokens in, so token k sits at (k / cols, k % cols).
+        for (int k = 0; k < g.tokens(); ++k)
+            set(i + static_cast<size_t>(k), cur, cur + k / g.cols, cur + k % g.cols);
+        // An image costs max(rows, cols) positions, not rows*cols — the axes
+        // advance in parallel, so the longer side is what the next token has to
+        // clear.
+        cur += std::max(g.rows, g.cols);
+        i += run;
+        ++next_grid;
+    }
+
+    if (next_grid != grids.size()) {
+        err = "prompt contains " + std::to_string(next_grid) + " image runs but " +
+              std::to_string(grids.size()) + " grids were supplied";
+        return false;
+    }
+
+    out = std::move(pos);
+    next_pos = cur;
+    return true;
+}
+
+}  // namespace imp

--- a/src/model/mrope_positions.h
+++ b/src/model/mrope_positions.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// The (t, h, w) position each token gets when a prompt contains images.
+//
+// Text tokens advance all three axes together, so a text-only prompt comes out
+// identical to `0, 1, 2, ...` on every axis — which is what makes M-RoPE a no-op
+// there. An image instead lays its tokens out on a grid: every token of the
+// image shares one temporal position, and its height and width positions are its
+// row and column within the image. The whole image then advances the running
+// position by only `max(rows, cols)`, not by its token count, which is why a
+// picture costs far fewer positions than tokens.
+//
+// Getting this wrong does not crash: the model reads the image as if its tokens
+// were laid out somewhere else, and describes a different picture.
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace imp {
+
+// One image's grid AFTER the vision merger, i.e. in LM tokens: `rows * cols`
+// tokens, laid out in raster order.
+struct MRopeImageGrid {
+    int rows = 0;
+    int cols = 0;
+    int tokens() const { return rows * cols; }
+};
+
+// `is_image[i]` marks token i as belonging to an image. Image runs must be
+// contiguous and their lengths must match `grids` in order — a mismatch means
+// the placeholder expansion and the preprocessor disagree, and is refused here
+// rather than silently mis-positioning the rest of the prompt.
+//
+// `start_pos` is the position the first token takes (0 for a fresh prompt, the
+// continuation point when appending). `out` is filled as [3, n_tokens],
+// axis-major, ready for MRopeParams. `next_pos` receives the position a token
+// appended after this sequence would take.
+bool qwen_build_mrope_positions(const std::vector<uint8_t>& is_image,
+                                const std::vector<MRopeImageGrid>& grids, int start_pos,
+                                std::vector<int32_t>& out, int& next_pos, std::string& err);
+
+}  // namespace imp

--- a/tests/test_mrope_positions.cpp
+++ b/tests/test_mrope_positions.cpp
@@ -1,0 +1,169 @@
+// (t, h, w) positions for a prompt containing images.
+//
+// The failure mode is not a crash: wrong positions mean the model reads the
+// image as if its tokens sat somewhere else on the grid, and describes a
+// different picture. The oracle is `Qwen3VLModel.get_rope_index` /
+// `get_vision_position_ids`, reimplemented here as explicit expectations rather
+// than as a second copy of the loop.
+
+#include "model/mrope_positions.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+struct Built {
+    std::vector<int32_t> pos;
+    int next = 0;
+    size_t n = 0;
+
+    int t(size_t i) const { return pos[i]; }
+    int h(size_t i) const { return pos[n + i]; }
+    int w(size_t i) const { return pos[2 * n + i]; }
+};
+
+Built build(const std::vector<uint8_t>& mask, const std::vector<MRopeImageGrid>& grids, int start = 0) {
+    Built b;
+    b.n = mask.size();
+    std::string err;
+    EXPECT_TRUE(qwen_build_mrope_positions(mask, grids, start, b.pos, b.next, err)) << err;
+    return b;
+}
+
+// The invariant that keeps M-RoPE a no-op for every text-only model.
+TEST(MRopePositions, TextOnlyIsPlainAscendingOnAllThreeAxes) {
+    const Built b = build(std::vector<uint8_t>(7, 0), {});
+    for (size_t i = 0; i < 7; ++i) {
+        EXPECT_EQ(b.t(i), static_cast<int>(i));
+        EXPECT_EQ(b.h(i), static_cast<int>(i));
+        EXPECT_EQ(b.w(i), static_cast<int>(i));
+    }
+    EXPECT_EQ(b.next, 7);
+}
+
+TEST(MRopePositions, ContinuationStartsWhereTheCallerSays) {
+    const Built b = build(std::vector<uint8_t>(3, 0), {}, 100);
+    EXPECT_EQ(b.t(0), 100);
+    EXPECT_EQ(b.t(2), 102);
+    EXPECT_EQ(b.next, 103);
+}
+
+// An image: one shared temporal position, row/column on the other two axes, in
+// raster order over the MERGED grid.
+TEST(MRopePositions, ImageTokensCarryTheirRowAndColumn) {
+    // 2 text, then a 2x3 image (6 tokens), then 2 text.
+    std::vector<uint8_t> mask = {0, 0, 1, 1, 1, 1, 1, 1, 0, 0};
+    const Built b = build(mask, {{2, 3}});
+
+    EXPECT_EQ(b.t(0), 0);
+    EXPECT_EQ(b.t(1), 1);
+    // Image starts at position 2.
+    for (int k = 0; k < 6; ++k) {
+        const size_t i = 2 + static_cast<size_t>(k);
+        EXPECT_EQ(b.t(i), 2) << "token " << k << ": all image tokens share one temporal position";
+        EXPECT_EQ(b.h(i), 2 + k / 3) << "token " << k;
+        EXPECT_EQ(b.w(i), 2 + k % 3) << "token " << k;
+    }
+}
+
+// The whole point of the layout: six tokens cost three positions, not six.
+TEST(MRopePositions, AnImageCostsMaxOfRowsAndColsNotItsTokenCount) {
+    std::vector<uint8_t> mask = {0, 1, 1, 1, 1, 1, 1, 0};
+    const Built b = build(mask, {{2, 3}});
+    EXPECT_EQ(b.t(0), 0);
+    // Image occupies positions 1..3 on the width axis (1 + max(2,3) - 1 = 3).
+    EXPECT_EQ(b.t(7), 4) << "the token after the image resumes at 1 + max(rows, cols)";
+    EXPECT_EQ(b.h(7), 4);
+    EXPECT_EQ(b.w(7), 4);
+    EXPECT_EQ(b.next, 5);
+
+    // A tall image costs its row count instead.
+    const Built tall = build({1, 1, 1, 1, 1, 1, 0}, {{3, 2}});
+    EXPECT_EQ(tall.t(6), 3);
+    EXPECT_EQ(tall.next, 4);
+}
+
+TEST(MRopePositions, TwoImagesEachAdvanceIndependently) {
+    // img(1x2) text img(2x2)
+    std::vector<uint8_t> mask = {1, 1, 0, 1, 1, 1, 1};
+    const Built b = build(mask, {{1, 2}, {2, 2}});
+
+    EXPECT_EQ(b.h(0), 0);
+    EXPECT_EQ(b.w(0), 0);
+    EXPECT_EQ(b.w(1), 1);
+    // First image costs max(1,2) = 2, so the text token sits at 2.
+    EXPECT_EQ(b.t(2), 2);
+    // Second image starts at 3.
+    EXPECT_EQ(b.t(3), 3);
+    EXPECT_EQ(b.h(3), 3);
+    EXPECT_EQ(b.w(3), 3);
+    EXPECT_EQ(b.h(6), 4);
+    EXPECT_EQ(b.w(6), 4);
+    EXPECT_EQ(b.next, 5);  // 3 + max(2,2)
+}
+
+TEST(MRopePositions, ASingleImageWithNoTextAround) {
+    const Built b = build({1, 1, 1, 1}, {{2, 2}});
+    EXPECT_EQ(b.h(0), 0);
+    EXPECT_EQ(b.w(3), 1);
+    EXPECT_EQ(b.next, 2);
+}
+
+// A run length that does not match the grid means the placeholder expansion and
+// the preprocessor disagree. Every position after it would be shifted.
+TEST(MRopePositions, RefusesARunThatDoesNotMatchItsGrid) {
+    std::vector<int32_t> out;
+    int next = 0;
+    std::string err;
+    EXPECT_FALSE(qwen_build_mrope_positions({0, 1, 1, 1, 0}, {{2, 2}}, 0, out, next, err));
+    EXPECT_NE(err.find("4 tokens"), std::string::npos) << err;
+    EXPECT_NE(err.find("reserves 3"), std::string::npos) << err;
+}
+
+TEST(MRopePositions, RefusesAGridCountMismatch) {
+    std::vector<int32_t> out;
+    int next = 0;
+    std::string err;
+    // Two runs, one grid.
+    EXPECT_FALSE(qwen_build_mrope_positions({1, 0, 1}, {{1, 1}}, 0, out, next, err));
+    EXPECT_NE(err.find("more image runs"), std::string::npos) << err;
+    // One run, two grids.
+    err.clear();
+    EXPECT_FALSE(qwen_build_mrope_positions({1, 0}, {{1, 1}, {1, 1}}, 0, out, next, err));
+    EXPECT_NE(err.find("grids were supplied"), std::string::npos) << err;
+}
+
+TEST(MRopePositions, RefusesAnEmptyGrid) {
+    std::vector<int32_t> out;
+    int next = 0;
+    std::string err;
+    EXPECT_FALSE(qwen_build_mrope_positions({1}, {{0, 3}}, 0, out, next, err));
+    EXPECT_NE(err.find("empty grid"), std::string::npos) << err;
+}
+
+TEST(MRopePositions, EmptySequenceIsFine) {
+    std::vector<int32_t> out;
+    int next = -1;
+    std::string err;
+    EXPECT_TRUE(qwen_build_mrope_positions({}, {}, 5, out, next, err)) << err;
+    EXPECT_TRUE(out.empty());
+    EXPECT_EQ(next, 5);
+}
+
+// Two adjacent images with no text between them are one contiguous run of image
+// tokens, and must NOT be read as a single image.
+TEST(MRopePositions, AdjacentImagesWithoutSeparatorAreRefused) {
+    std::vector<int32_t> out;
+    int next = 0;
+    std::string err;
+    // 4 contiguous image tokens, declared as two 1x2 images.
+    EXPECT_FALSE(qwen_build_mrope_positions({1, 1, 1, 1}, {{1, 2}, {1, 2}}, 0, out, next, err));
+    EXPECT_FALSE(err.empty()) << "a merged run must not silently become one image";
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
The M-RoPE kernel in #1172 takes three position axes; this computes them. Ported from `Qwen3VLModel.get_rope_index` / `get_vision_position_ids`. Host-only, no GPU, no dependency on the vision tower — it works on the token mask plus each image's merged grid.

## What the layout is

- **Text** tokens advance all three axes in lockstep, so a text-only prompt comes out as `0, 1, 2, ...` on every axis. That is exactly what makes M-RoPE a no-op for text-only models, and it is pinned by a test rather than assumed.
- **An image** lays its tokens on a grid: every token shares one temporal position, and its height/width positions are its row and column, in raster order over the **merged** grid — the order the vision merger emits tokens in.

The part worth stating plainly: **an image advances the running position by `max(rows, cols)`, not by its token count.** A 2×3 image is six tokens but costs three positions. Getting that wrong shifts every position after the image while still producing fluent text about the wrong thing.

## What it refuses

Each of these means the placeholder expansion and the preprocessor disagree, and everything downstream would be silently shifted:

- a run whose length does not match its grid (`"image 0 has 4 tokens (2x2) but the prompt reserves 3"`);
- more image runs than grids, or fewer;
- an empty grid;
- two adjacent images with no separator — they form one contiguous run and are refused rather than read as a single larger image.

## Verification

11 host tests. Mutation-checked — each of these fails them:

| Mutation | |
|---|---|
| Advance by token count instead of `max(rows, cols)` | caught |
| Column-major instead of raster order | caught |
| Text advancing only the temporal axis | caught |
| Image grid not offset by the running position | caught |

`test-core` green (739 tests), file-size and alloc-sites gates clean.

## Not in this PR

Wiring it to the kernel — that needs the image-token mask, which is built where the placeholder expansion happens. This is the computation, tested on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8