### PR TITLE
feat(vision): image bytes to LM embeddings for Qwen3-VL, and a real-checkpoint test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ set(IMP_VISION_SOURCES
     src/vision/qwen3vl_vision_upload.cpp
     src/vision/qwen3vl_encoder_kernels.cu
     src/vision/qwen3vl_encoder.cu
+    src/vision/qwen3vl_pipeline.cpp
     src/vision/image_processor.cpp
     src/vision/vision_encoder.cu
 )
@@ -809,6 +810,7 @@ if(IMP_BUILD_TESTS)
         tests/test_determinism_e2e.cpp
         tests/test_vision_golden.cu
         tests/test_qwen3vl_encoder.cu
+        tests/test_qwen3vl_pipeline.cu
     )
 
     set(IMP_TEST_BINARIES

--- a/src/vision/qwen3vl_pipeline.cpp
+++ b/src/vision/qwen3vl_pipeline.cpp
@@ -1,0 +1,190 @@
+#include "vision/qwen3vl_pipeline.h"
+
+#include "core/logging.h"
+#include "memory/vram_allocator.h"
+#include "vision/image_processor.h"
+#include "vision/qwen3vl_vision_grid.h"
+#include "vision/qwen3vl_vision_upload.h"
+
+#include "stb_image.h"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <memory>
+
+namespace imp {
+
+Qwen3VLPipeline::~Qwen3VLPipeline() { free_buffers(); }
+
+void Qwen3VLPipeline::free_buffers() {
+    encoder_.reset();
+    // Order matters: the tower's slots point into `allocs_`, so they are
+    // invalidated before the memory goes away rather than after.
+    if (tower_ && uploaded_tower_)
+        qwen3vl_release_vision_tower(*tower_);
+    uploaded_tower_ = false;
+    if (alloc_)
+        for (void* p : allocs_)
+            alloc_->free(p);
+    allocs_.clear();
+    d_patches_ = nullptr;
+    d_out_ = nullptr;
+    d_deepstack_.clear();
+    max_patches_ = 0;
+}
+
+int64_t Qwen3VLPipeline::max_pixels() const {
+    if (!tower_)
+        return 0;
+    const int p = tower_->config.patch_size;
+    return static_cast<int64_t>(max_patches_) * p * p;
+}
+
+bool Qwen3VLPipeline::init(VisionModel& tower, VRAMAllocator& alloc, int max_patches) {
+    free_buffers();
+    const VisionConfig& c = tower.config;
+    if (!c.is_qwen3vl) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: the tower is not a Qwen3-VL vision model");
+        return false;
+    }
+    const int unit = c.merge_size * c.merge_size;
+    if (max_patches <= 0 || max_patches % unit != 0) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: patch budget %d must be positive and a multiple of %d", max_patches,
+                      unit);
+        return false;
+    }
+    tower_ = &tower;
+    alloc_ = &alloc;
+    max_patches_ = max_patches;
+
+    // Idempotent: a tower already on the device (a second pipeline over the same
+    // model) is left alone rather than uploaded twice.
+    if (!tower.patch_embd_w.on_device) {
+        size_t bytes = 0;
+        std::string err;
+        if (!qwen3vl_upload_vision_tower(tower, &alloc, allocs_, bytes, err)) {
+            IMP_LOG_ERROR("Qwen3-VL pipeline: %s", err.c_str());
+            free_buffers();
+            return false;
+        }
+        uploaded_tower_ = true;
+    }
+
+    encoder_ = std::make_unique<Qwen3VLEncoder>();
+    if (!encoder_->init(tower, &alloc, max_patches)) {
+        free_buffers();
+        return false;
+    }
+
+    const int features = static_cast<int>(tower.patch_embd_w.shape[1]);
+    const int merged = max_patches / unit;
+    bool ok = true;
+    auto take = [&](size_t bytes, const char* tag) -> half* {
+        if (!ok)
+            return nullptr;
+        void* p = alloc.allocate(bytes, tag);
+        if (!p) {
+            IMP_LOG_ERROR("Qwen3-VL pipeline: out of VRAM for %s", tag);
+            ok = false;
+            return nullptr;
+        }
+        allocs_.push_back(p);
+        return static_cast<half*>(p);
+    };
+    d_patches_ = take(static_cast<size_t>(max_patches) * features * sizeof(half), "vision_patches");
+    const size_t emb_bytes = static_cast<size_t>(merged) * c.out_hidden_size * sizeof(half);
+    d_out_ = take(emb_bytes, "vision_embeddings");
+    d_deepstack_.resize(c.deepstack_indexes.size());
+    for (size_t i = 0; i < d_deepstack_.size(); ++i)
+        d_deepstack_[i] = take(emb_bytes, "vision_deepstack");
+    if (!ok) {
+        free_buffers();
+        return false;
+    }
+
+    IMP_LOG_INFO("Qwen3-VL pipeline ready: <= %d patches (%d image tokens, %lld pixels)", max_patches, merged,
+                 static_cast<long long>(max_pixels()));
+    return true;
+}
+
+bool Qwen3VLPipeline::encode_rgb(const uint8_t* rgb, int width, int height, Qwen3VLImage& out,
+                                 cudaStream_t stream) {
+    if (!encoder_) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: encode before init");
+        return false;
+    }
+    const VisionConfig& c = tower_->config;
+
+    QwenPatchifyConfig pc;
+    pc.patch_size = c.patch_size;
+    pc.merge_size = c.merge_size;
+    pc.temporal_patch_size = c.temporal_patch_size;
+    // The budget is a hard ceiling here, not a preference: every workspace was
+    // sized from it, so an image is scaled down to fit rather than refused.
+    pc.max_pixels = std::min<int64_t>(pc.max_pixels, max_pixels());
+
+    QwenPatches patches;
+    if (!qwen_patchify(rgb, width, height, pc, patches)) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: could not patchify a %dx%d image", width, height);
+        return false;
+    }
+    if (patches.tokens > max_patches_) {
+        // smart_resize honours max_pixels, so this means the two disagree —
+        // worth an error rather than a silent truncation.
+        IMP_LOG_ERROR("Qwen3-VL pipeline: %d patches exceeds the %d-patch budget", patches.tokens,
+                      max_patches_);
+        return false;
+    }
+
+    QwenVisionGrid grid;
+    std::string err;
+    if (!qwen3vl_build_vision_grid(patches.grid_h, patches.grid_w, c.merge_size, c.pos_embed_grid, grid,
+                                   err)) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: %s", err.c_str());
+        return false;
+    }
+
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_patches_, patches.data.data(), patches.data.size() * sizeof(half),
+                                       cudaMemcpyHostToDevice, stream));
+
+    std::vector<half*> deep(d_deepstack_.begin(), d_deepstack_.end());
+    if (!encoder_->encode(d_patches_, grid, d_out_, deep, stream))
+        return false;
+
+    const int unit = c.merge_size * c.merge_size;
+    out.grid_rows = patches.grid_h / c.merge_size;
+    out.grid_cols = patches.grid_w / c.merge_size;
+    out.tokens = patches.tokens / unit;
+    out.d_embeddings = d_out_;
+    out.d_deepstack.assign(d_deepstack_.begin(), d_deepstack_.end());
+    IMP_LOG_INFO("Qwen3-VL: %dx%d image -> %dx%d patches -> %d image tokens", width, height, patches.grid_h,
+                 patches.grid_w, out.tokens);
+    return true;
+}
+
+bool Qwen3VLPipeline::encode_file(const std::string& path, Qwen3VLImage& out, cudaStream_t stream) {
+    int w = 0, h = 0, ch = 0;
+    uint8_t* rgb = stbi_load(path.c_str(), &w, &h, &ch, 3);
+    if (!rgb) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: could not read image '%s'", path.c_str());
+        return false;
+    }
+    const bool ok = encode_rgb(rgb, w, h, out, stream);
+    stbi_image_free(rgb);
+    return ok;
+}
+
+bool Qwen3VLPipeline::encode_memory(const uint8_t* data, size_t len, Qwen3VLImage& out, cudaStream_t stream) {
+    int w = 0, h = 0, ch = 0;
+    uint8_t* rgb = stbi_load_from_memory(data, static_cast<int>(len), &w, &h, &ch, 3);
+    if (!rgb) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: could not decode a %zu-byte image", len);
+        return false;
+    }
+    const bool ok = encode_rgb(rgb, w, h, out, stream);
+    stbi_image_free(rgb);
+    return ok;
+}
+
+}  // namespace imp

--- a/src/vision/qwen3vl_pipeline.h
+++ b/src/vision/qwen3vl_pipeline.h
@@ -1,0 +1,78 @@
+#pragma once
+
+// Image bytes to LM-ready embeddings, for Qwen3-VL.
+//
+// Separate from `VisionPipeline` (the GGUF mmproj path) because the two differ
+// in the thing that shapes everything else: that one has a fixed
+// `num_image_tokens` from config, this one has none. The token count comes from
+// the image, so buffers are sized to a patch budget and each image uses a
+// prefix of them.
+//
+// The tower's weights live in the Model — they came from the same checkpoint —
+// so this holds a reference, not ownership, and uploads them to the device on
+// first init.
+
+#include "vision/qwen3vl_encoder.h"
+#include "vision/vision_model.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace imp {
+
+class VRAMAllocator;
+
+// One encoded image. The buffers belong to the pipeline and stay valid until
+// the next encode call.
+struct Qwen3VLImage {
+    int grid_rows = 0;  // merged grid — LM tokens, not patches
+    int grid_cols = 0;
+    int tokens = 0;  // grid_rows * grid_cols
+    const half* d_embeddings = nullptr;
+    // One per `config.deepstack_indexes`, same shape as `d_embeddings`. These
+    // are added into the LM's hidden state at its FIRST layers, not at the
+    // vision blocks they were tapped from.
+    std::vector<const half*> d_deepstack;
+};
+
+class Qwen3VLPipeline {
+public:
+    Qwen3VLPipeline() = default;
+    ~Qwen3VLPipeline();
+    Qwen3VLPipeline(const Qwen3VLPipeline&) = delete;
+    Qwen3VLPipeline& operator=(const Qwen3VLPipeline&) = delete;
+
+    // `tower` must be a loaded Qwen3-VL vision tower; it is uploaded to the
+    // device here if it is still host-resident. `max_patches` bounds the image
+    // size this pipeline will accept — it sizes every workspace, so it is also
+    // what an oversized image is rejected against.
+    bool init(VisionModel& tower, VRAMAllocator& alloc, int max_patches);
+
+    bool is_ready() const { return encoder_ != nullptr; }
+    int max_patches() const { return max_patches_; }
+    // Largest image, in pixels, this pipeline's patch budget allows.
+    int64_t max_pixels() const;
+
+    bool encode_file(const std::string& path, Qwen3VLImage& out, cudaStream_t stream);
+    bool encode_memory(const uint8_t* data, size_t len, Qwen3VLImage& out, cudaStream_t stream);
+
+private:
+    bool encode_rgb(const uint8_t* rgb, int width, int height, Qwen3VLImage& out, cudaStream_t stream);
+    void free_buffers();
+
+    VisionModel* tower_ = nullptr;
+    VRAMAllocator* alloc_ = nullptr;
+    std::unique_ptr<Qwen3VLEncoder> encoder_;
+    int max_patches_ = 0;
+    // Whether THIS pipeline uploaded the tower, and so has to invalidate it.
+    bool uploaded_tower_ = false;
+
+    half* d_patches_ = nullptr;
+    half* d_out_ = nullptr;
+    std::vector<half*> d_deepstack_;
+    std::vector<void*> allocs_;
+};
+
+}  // namespace imp

--- a/src/vision/qwen3vl_vision_upload.cpp
+++ b/src/vision/qwen3vl_vision_upload.cpp
@@ -48,8 +48,8 @@ bool to_fp16(const Tensor& t, std::vector<half>& out, std::string& err) {
 
 }  // namespace
 
-bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, size_t& bytes_out,
-                                 std::string& err) {
+bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, std::vector<void*>& out_allocs,
+                                 size_t& bytes_out, std::string& err) {
     if (!alloc) {
         err = "no VRAM allocator for the vision tower";
         return false;
@@ -109,13 +109,21 @@ bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, size_
         p.slot->qtype = QType::F16;
         p.slot->on_device = true;
         p.slot->compute_strides();
-        model.gpu_allocs.push_back(p.device);
+        out_allocs.push_back(p.device);
     }
-    model.allocator = alloc;
     bytes_out = total;
     IMP_LOG_INFO("Vision tower: %zu tensors uploaded, %.1f MiB", pending.size(),
                  static_cast<double>(total) / (1024.0 * 1024.0));
     return true;
+}
+
+void qwen3vl_release_vision_tower(VisionModel& model) {
+    qwen3vl_visit_vision_tensors(model, [](Tensor& t, const std::string&) {
+        if (t.on_device) {
+            t.data = nullptr;
+            t.on_device = false;
+        }
+    });
 }
 
 }  // namespace imp

--- a/src/vision/qwen3vl_vision_upload.h
+++ b/src/vision/qwen3vl_vision_upload.h
@@ -11,6 +11,7 @@
 #include "vision/vision_model.h"
 
 #include <string>
+#include <vector>
 
 namespace imp {
 
@@ -18,7 +19,18 @@ class VRAMAllocator;
 
 // `alloc` may be null, in which case the tower is left alone and this returns
 // false — the encoder has no fallback for host-resident weights.
-bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, size_t& bytes_out,
-                                 std::string& err);
+//
+// The device blocks are appended to `out_allocs` and belong to the CALLER, not
+// to the VisionModel. That is deliberate: a tower holding pointers into an
+// allocator it does not own is a use-after-free the moment a teardown order
+// puts the allocator first. The caller frees them and calls
+// `qwen3vl_release_vision_tower` to invalidate the tower in the same breath.
+bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, std::vector<void*>& out_allocs,
+                                 size_t& bytes_out, std::string& err);
+
+// Point every tensor slot back at nothing. Call this when the device blocks the
+// upload handed out are released, so a tower that outlives them cannot be
+// mistaken for a usable one.
+void qwen3vl_release_vision_tower(VisionModel& model);
 
 }  // namespace imp

--- a/src/vision/vision_model.cpp
+++ b/src/vision/vision_model.cpp
@@ -1,5 +1,4 @@
 #include "vision/vision_model.h"
-#include "memory/vram_allocator.h"
 #include <cuda_runtime.h>
 
 namespace imp {
@@ -8,15 +7,10 @@ VisionModel::~VisionModel() { free_gpu(); }
 
 void VisionModel::free_gpu() {
     for (void* ptr : gpu_allocs) {
-        if (!ptr)
-            continue;
-        if (allocator)
-            allocator->free(ptr);
-        else
+        if (ptr)
             cudaFree(ptr);
     }
     gpu_allocs.clear();
-    allocator = nullptr;
 }
 
 }  // namespace imp

--- a/src/vision/vision_model.h
+++ b/src/vision/vision_model.h
@@ -98,11 +98,12 @@ struct VisionModel {
     // Transformer layers
     std::vector<VisionLayerWeights> layers;
 
-    // GPU allocations for cleanup. Released through `allocator` when one is set
-    // (the Qwen3-VL path, so the VRAM ledger stays accurate) and with a plain
-    // cudaFree otherwise (the legacy GGUF mmproj path).
+    // GPU allocations for cleanup (the legacy GGUF mmproj path, which allocates
+    // them itself). The Qwen3-VL path does NOT use this: its device copies are
+    // owned by the pipeline that made them, because a VisionModel outliving the
+    // allocator it borrowed from is a use-after-free waiting for a teardown
+    // order to expose it.
     std::vector<void*> gpu_allocs;
-    VRAMAllocator* allocator = nullptr;
 
     int lm_d_model = 0;  // LLM hidden dimension (from mm_proj output)
 

--- a/tests/test_qwen3vl_encoder.cu
+++ b/tests/test_qwen3vl_encoder.cu
@@ -378,7 +378,8 @@ void run_case(int grid_h, int grid_w) {
     ASSERT_TRUE(alloc.init(0.10f));
     size_t bytes = 0;
     std::string err;
-    ASSERT_TRUE(qwen3vl_upload_vision_tower(tower.model, &alloc, bytes, err)) << err;
+    std::vector<void*> tower_allocs;
+    ASSERT_TRUE(qwen3vl_upload_vision_tower(tower.model, &alloc, tower_allocs, bytes, err)) << err;
     EXPECT_GT(bytes, 0u);
 
     QwenVisionGrid grid;
@@ -441,7 +442,9 @@ void run_case(int grid_h, int grid_w) {
     alloc.free(d_patches);
     alloc.free(d_out);
     alloc.free(d_deep);
-    tower.model.free_gpu();
+    qwen3vl_release_vision_tower(tower.model);
+    for (void* p : tower_allocs)
+        alloc.free(p);
 }
 
 TEST(Qwen3VLEncoder, MatchesAnIndependentCpuReference) {

--- a/tests/test_qwen3vl_pipeline.cu
+++ b/tests/test_qwen3vl_pipeline.cu
@@ -1,0 +1,160 @@
+// Image bytes through the real Qwen3-VL tower.
+//
+// The synthetic encoder test (`test_qwen3vl_encoder.cu`) proves the algorithm
+// against a CPU reference; this proves the plumbing against the actual
+// checkpoint — real shapes (hidden 1024, head_dim 64, 24 blocks, 3 DeepStack
+// taps), real patch counts, real smart_resize output. Those are exactly the
+// things a synthetic tower with round numbers cannot catch.
+//
+// Skipped unless IMP_TEST_MODEL_QWEN3VL points at a Qwen3-VL checkpoint
+// directory, so it costs nothing where the model is not staged.
+
+#include "memory/vram_allocator.h"
+#include "model/model.h"
+#include "model/safetensors_loader.h"
+#include "vision/image_processor.h"
+#include "vision/qwen3vl_pipeline.h"
+#include "vision/vision_model.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+const char* model_dir() { return std::getenv("IMP_TEST_MODEL_QWEN3VL"); }
+
+std::vector<float> read_back(const half* d, size_t n) {
+    std::vector<half> h(n);
+    EXPECT_EQ(cudaMemcpy(h.data(), d, n * sizeof(half), cudaMemcpyDeviceToHost), cudaSuccess);
+    std::vector<float> f(n);
+    for (size_t i = 0; i < n; ++i)
+        f[i] = __half2float(h[i]);
+    return f;
+}
+
+class Qwen3VLPipelineTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!model_dir())
+            GTEST_SKIP() << "IMP_TEST_MODEL_QWEN3VL not set";
+        model_ = load_safetensors(model_dir(), /*load_mtp_head=*/false);
+        ASSERT_NE(model_, nullptr);
+        ASSERT_NE(model_->vision_tower, nullptr) << "checkpoint carries no vision tower";
+        ASSERT_TRUE(alloc_.init(0.10f));
+        // 4096 patches = a 1024x1024 image at patch 16, and enough to cross the
+        // encoder's attention chunk boundary.
+        ASSERT_TRUE(pipeline_.init(*model_->vision_tower, alloc_, 4096));
+    }
+
+    std::unique_ptr<Model> model_;
+    VRAMAllocator alloc_;
+    Qwen3VLPipeline pipeline_;
+};
+
+TEST_F(Qwen3VLPipelineTest, EncodesTheFixtureImage) {
+    Qwen3VLImage img;
+    ASSERT_TRUE(pipeline_.encode_file("tests/fixtures/vision_test_64.png", img, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    const VisionConfig& c = model_->vision_tower->config;
+    EXPECT_GT(img.tokens, 0);
+    EXPECT_EQ(img.tokens, img.grid_rows * img.grid_cols);
+    ASSERT_EQ(img.d_deepstack.size(), c.deepstack_indexes.size());
+
+    const size_t n = static_cast<size_t>(img.tokens) * c.out_hidden_size;
+    const auto emb = read_back(img.d_embeddings, n);
+
+    // A NaN or an inf here means an overflow somewhere in 24 blocks, and it
+    // would reach the LM as a token that poisons the whole sequence.
+    double max_abs = 0.0;
+    for (float v : emb) {
+        ASSERT_TRUE(std::isfinite(v)) << "non-finite embedding";
+        max_abs = std::max<double>(max_abs, std::fabs(v));
+    }
+    EXPECT_GT(max_abs, 1e-3) << "the encoder returned an all-zero embedding";
+    EXPECT_LT(max_abs, 1e4) << "embedding magnitude suggests an overflow";
+
+    for (size_t d = 0; d < img.d_deepstack.size(); ++d) {
+        const auto ds = read_back(img.d_deepstack[d], n);
+        for (float v : ds)
+            ASSERT_TRUE(std::isfinite(v)) << "non-finite DeepStack embedding, tap " << d;
+        double diff = 0.0;
+        for (size_t i = 0; i < n; ++i)
+            diff = std::max<double>(diff, std::fabs(ds[i] - emb[i]));
+        EXPECT_GT(diff, 1e-3) << "DeepStack tap " << d << " is indistinguishable from the main output";
+    }
+}
+
+// The encoder feeds a KV cache and a prefix cache downstream; a run-to-run
+// difference would surface there as a cache that never hits.
+TEST_F(Qwen3VLPipelineTest, TheSameImageEncodesIdentically) {
+    Qwen3VLImage a;
+    ASSERT_TRUE(pipeline_.encode_file("tests/fixtures/vision_test_64.png", a, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    const size_t n = static_cast<size_t>(a.tokens) * model_->vision_tower->config.out_hidden_size;
+    const auto first = read_back(a.d_embeddings, n);
+
+    Qwen3VLImage b;
+    ASSERT_TRUE(pipeline_.encode_file("tests/fixtures/vision_test_64.png", b, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    ASSERT_EQ(b.tokens, a.tokens);
+    const auto second = read_back(b.d_embeddings, n);
+
+    for (size_t i = 0; i < n; ++i)
+        ASSERT_FLOAT_EQ(first[i], second[i]) << "element " << i;
+}
+
+// The counterweight to the test above: an encoder that ignored its input would
+// also be perfectly reproducible.
+TEST_F(Qwen3VLPipelineTest, DifferentImagesEncodeDifferently) {
+    const char* other = std::getenv("IMP_TEST_IMAGE_ALT");
+    if (!other)
+        GTEST_SKIP() << "IMP_TEST_IMAGE_ALT not set";
+
+    Qwen3VLImage a, b;
+    ASSERT_TRUE(pipeline_.encode_file("tests/fixtures/vision_test_64.png", a, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    const size_t na = static_cast<size_t>(a.tokens) * model_->vision_tower->config.out_hidden_size;
+    const auto first = read_back(a.d_embeddings, na);
+
+    ASSERT_TRUE(pipeline_.encode_file(other, b, nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    const size_t nb = static_cast<size_t>(b.tokens) * model_->vision_tower->config.out_hidden_size;
+    const auto second = read_back(b.d_embeddings, nb);
+
+    if (a.tokens != b.tokens)
+        SUCCEED() << "different images produced different token counts (" << a.tokens << " vs " << b.tokens
+                  << ")";
+    else {
+        double diff = 0.0;
+        for (size_t i = 0; i < na; ++i)
+            diff = std::max<double>(diff, std::fabs(first[i] - second[i]));
+        EXPECT_GT(diff, 1e-2) << "two different images produced the same embedding";
+    }
+}
+
+// The token count is what the prompt has to reserve placeholders for. If the
+// pipeline and `smart_resize` disagreed, every position after the image would
+// shift.
+TEST_F(Qwen3VLPipelineTest, TokenCountMatchesTheResizedGrid) {
+    Qwen3VLImage img;
+    ASSERT_TRUE(pipeline_.encode_file("tests/fixtures/vision_test_64.png", img, nullptr));
+    const VisionConfig& c = model_->vision_tower->config;
+    const int factor = c.patch_size * c.merge_size;
+    const SmartResize sr = qwen_smart_resize(64, 64, factor, 65536, pipeline_.max_pixels());
+    ASSERT_TRUE(sr.ok);
+    EXPECT_EQ(img.grid_rows, sr.height / factor);
+    EXPECT_EQ(img.grid_cols, sr.width / factor);
+    EXPECT_EQ(img.tokens, (sr.height / factor) * (sr.width / factor));
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Ties the pieces from #1166–#1171 together. `Qwen3VLPipeline::encode_file` takes a path and returns the merged image tokens plus the three DeepStack taps, with the grid the LM needs in order to reserve the right number of placeholders.

Separate from `VisionPipeline` (the GGUF mmproj path) because the two differ in the thing that shapes everything else: that one has a fixed `num_image_tokens` from config, this one has none. The count comes from the image, so workspaces are sized to a patch budget and each image uses a prefix of them — and the budget is a **ceiling that pulls `max_pixels` down**, not a check that refuses the image.

## The bug this found

Running it against the real checkpoint **segfaulted on teardown**, and the cause was a design error shipped in #1171: `VisionModel::allocator` held a raw `VRAMAllocator*`. The test fixture destroys the allocator before the model, so the tower's `free_gpu()` called through a dead allocator. Any teardown order that puts the allocator first has the same bug — this is not a test artifact.

Ownership is **inverted** rather than the order patched:

- `qwen3vl_upload_vision_tower` now hands its device blocks to the **caller**, which owns and frees them;
- `qwen3vl_release_vision_tower` invalidates the tower's slots in the same breath;
- `VisionModel::allocator` is gone, and the legacy GGUF path is back to its own `cudaFree`, which is what it always did.

A tower can no longer outlive the memory it points at without saying so.

## Verification

Against the staged `Qwen3-VL-4B-Instruct` (skipped when `IMP_TEST_MODEL_QWEN3VL` is unset — costs nothing where the model is not staged):

```
Qwen3-VL: 64x64 image     -> 16x16 patches ->  64 image tokens
Qwen3-VL: 1795x2397 image -> 72x54 patches -> 972 image tokens
```

That second one is 3888 patches, so the **real** tower also crosses the encoder's 512-row attention chunk boundary — not just the synthetic one in #1171.

Checked: every embedding finite, non-zero and bounded; each DeepStack tap distinguishable from the main output; the same image twice **bit-identical** (a prefix cache depends on that); and two different images **not** identical, which is what makes the previous check mean anything.

`test-core` green, file-size and alloc-sites gates clean.

### Aside

`~/models/gemma-3-4b-vl/test_bus.jpg` is 177 bytes — a truncated download, not an image. It fails to decode. `test_cat.jpg` and `test_pizza.jpg` are fine.

## Not in this PR

Placing the embeddings into the prompt: the image-token expansion, the embedding replacement at those positions, and the DeepStack adds at LM layers 0/1/2. The pipeline produces the tokens; nothing consumes them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8