### PR TITLE
feat(vision): DeepStack injection into the LM's first layers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,7 @@ set(IMP_VISION_SOURCES
     src/vision/qwen3vl_encoder.cu
     src/vision/image_processor.cpp
     src/vision/vision_encoder.cu
+    src/vision/deepstack_inject.cu
 )
 
 set(IMP_API_SOURCES
@@ -807,6 +808,7 @@ if(IMP_BUILD_TESTS)
         tests/test_lora.cpp
         tests/test_prefix_cache_e2e.cpp
         tests/test_determinism_e2e.cpp
+        tests/test_deepstack_inject.cu
         tests/test_vision_golden.cu
         tests/test_qwen3vl_encoder.cu
     )

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -1,4 +1,5 @@
 #include "exec/executor.h"
+#include "vision/deepstack_inject.h"
 #include "exec/executor_gemv_helpers.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
@@ -531,6 +532,21 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         // Also dump the FP32 shadow so we can diff FP32-truth vs FP16-view vs llama.cpp.
         if (fp32_accum_buf_) {
             dump_tensor_npy("C_fp32_shadow", view_tokens(fp32_hidden_, n), stream, i, decode_step);
+        }
+
+        // DeepStack: add the vision taps into the hidden state after each of
+        // the first `n_deepstack` layers, at image-token positions only. The
+        // taps came from vision blocks 5/11/17 but land here at layers 0/1/2 —
+        // a different index space, and the reason this is keyed on `i` rather
+        // than on any vision-side number.
+        // `is_prefill` is part of the condition, not an optimisation: image
+        // tokens only ever exist in the prompt, and a decode graph captured
+        // with this branch taken would bake the add into every replay.
+        if (state.is_prefill && i < state.n_deepstack && state.deepstack_embeddings[i] &&
+            state.n_vision_tokens > 0 && state.vision_token_id >= 0 && h.qtype == QType::F16) {
+            launch_add_vision_embeddings(static_cast<half*>(h.data), state.token_ids,
+                                         state.deepstack_embeddings[i], state.vision_token_id, n, cfg.d_model,
+                                         state.n_vision_tokens, stream);
         }
 
         if (i == max_layer - 1) {

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -159,6 +159,15 @@ struct InferenceState {
     int vision_token_id = -1;                 // <image_soft_token> ID
     int n_vision_tokens = 0;                  // 256
 
+    // DeepStack (Qwen3-VL): extra visual features ADDED at the image-token
+    // positions after each of the LM's first `n_deepstack` layers. Indexed by
+    // LM layer, NOT by the vision block the feature was tapped from — those are
+    // blocks 5/11/17 and these are layers 0/1/2. Each entry has the same shape
+    // as `vision_embeddings`.
+    static constexpr int kMaxDeepStack = 4;
+    const half* deepstack_embeddings[kMaxDeepStack] = {};
+    int n_deepstack = 0;
+
     // Early exit: run only the first exit_layer layers (-1 = all layers).
     // Used by self-speculative decoding to generate cheap draft tokens.
     int exit_layer = -1;

--- a/src/vision/deepstack_inject.cu
+++ b/src/vision/deepstack_inject.cu
@@ -1,0 +1,56 @@
+#include "vision/deepstack_inject.h"
+
+#include "core/logging.h"
+
+namespace imp {
+
+namespace {
+
+// One block per image token. The scan for the k-th placeholder mirrors the
+// embedding-replacement kernel deliberately: both have to agree on which
+// position is the k-th image token, and reading the same way is the cheapest
+// way to keep them from drifting apart.
+__global__ void add_vision_embeddings_kernel(half* __restrict__ hidden, const int32_t* __restrict__ token_ids,
+                                             const half* __restrict__ embeddings, int vision_token_id,
+                                             int n_tokens, int d_model, int n_vision_tokens) {
+    const int vision_idx = blockIdx.x;
+    if (vision_idx >= n_vision_tokens)
+        return;
+
+    int count = 0;
+    int token_pos = -1;
+    for (int i = 0; i < n_tokens; ++i) {
+        if (token_ids[i] == vision_token_id) {
+            if (count == vision_idx) {
+                token_pos = i;
+                break;
+            }
+            ++count;
+        }
+    }
+    if (token_pos < 0)
+        return;
+
+    // FP32 accumulation: the hidden state after a few layers and the merger's
+    // output are both O(1..10), and adding them in FP16 would round twice.
+    for (int d = threadIdx.x; d < d_model; d += blockDim.x) {
+        const int64_t at = static_cast<int64_t>(token_pos) * d_model + d;
+        hidden[at] = __float2half(__half2float(hidden[at]) +
+                                  __half2float(embeddings[static_cast<int64_t>(vision_idx) * d_model + d]));
+    }
+}
+
+}  // namespace
+
+void launch_add_vision_embeddings(half* hidden, const int32_t* token_ids, const half* embeddings,
+                                  int vision_token_id, int n_tokens, int d_model, int n_vision_tokens,
+                                  cudaStream_t stream) {
+    if (n_vision_tokens <= 0 || !embeddings || !token_ids)
+        return;
+    add_vision_embeddings_kernel<<<n_vision_tokens, 256, 0, stream>>>(hidden, token_ids, embeddings,
+                                                                      vision_token_id, n_tokens, d_model,
+                                                                      n_vision_tokens);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+}  // namespace imp

--- a/src/vision/deepstack_inject.h
+++ b/src/vision/deepstack_inject.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// DeepStack: extra visual features added into the LM's hidden state after its
+// FIRST few layers, at image-token positions only.
+//
+// Two things about this are easy to get backwards, and neither fails loudly:
+//
+//   - The taps come from vision blocks 5/11/17, but they are injected at LM
+//     layers 0/1/2. Two different index spaces; upstream only ever writes
+//     `layer_idx in range(len(embeds))`.
+//   - It is an ADD onto the existing hidden state, not a replace. The initial
+//     image embedding was already written at those positions by the embedding
+//     replacement; this stacks on top of it.
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace imp {
+
+// hidden[p, :] += embeddings[k, :] for the k-th token whose id is
+// `vision_token_id`. `n_vision_tokens` bounds k, so a prompt with more
+// placeholders than the encoder produced leaves the surplus untouched rather
+// than reading past the buffer.
+void launch_add_vision_embeddings(half* hidden, const int32_t* token_ids, const half* embeddings,
+                                  int vision_token_id, int n_tokens, int d_model, int n_vision_tokens,
+                                  cudaStream_t stream);
+
+}  // namespace imp

--- a/tests/test_deepstack_inject.cu
+++ b/tests/test_deepstack_inject.cu
@@ -1,0 +1,160 @@
+// DeepStack injection: add visual features at image-token positions.
+//
+// Two mistakes this guards, both of which leave a running model:
+//   - adding at the wrong positions (text tokens, or the wrong occurrence);
+//   - replacing instead of adding, which throws away everything the first
+//     layers computed for those positions.
+
+#include "vision/deepstack_inject.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace imp {
+namespace {
+
+constexpr int kD = 8;
+constexpr int kImageToken = 77;
+
+bool gpu_available() {
+    int n = 0;
+    return cudaGetDeviceCount(&n) == cudaSuccess && n > 0;
+}
+
+struct InjectResult {
+    std::vector<float> hidden;
+};
+
+InjectResult inject(const std::vector<int32_t>& tokens, const std::vector<float>& hidden_in,
+                    const std::vector<float>& emb, int n_vision_tokens) {
+    const int n = static_cast<int>(tokens.size());
+    std::vector<half> h(hidden_in.size()), e(emb.size());
+    for (size_t i = 0; i < hidden_in.size(); ++i)
+        h[i] = __float2half(hidden_in[i]);
+    for (size_t i = 0; i < emb.size(); ++i)
+        e[i] = __float2half(emb[i]);
+
+    half *d_h = nullptr, *d_e = nullptr;
+    int32_t* d_t = nullptr;
+    EXPECT_EQ(cudaMalloc(&d_h, h.size() * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&d_e, std::max<size_t>(e.size(), 1) * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&d_t, tokens.size() * sizeof(int32_t)), cudaSuccess);
+    cudaMemcpy(d_h, h.data(), h.size() * sizeof(half), cudaMemcpyHostToDevice);
+    if (!e.empty())
+        cudaMemcpy(d_e, e.data(), e.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_t, tokens.data(), tokens.size() * sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    launch_add_vision_embeddings(d_h, d_t, d_e, kImageToken, n, kD, n_vision_tokens, nullptr);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    cudaMemcpy(h.data(), d_h, h.size() * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaFree(d_h);
+    cudaFree(d_e);
+    cudaFree(d_t);
+
+    InjectResult r;
+    r.hidden.resize(h.size());
+    for (size_t i = 0; i < h.size(); ++i)
+        r.hidden[i] = __half2float(h[i]);
+    return r;
+}
+
+std::vector<float> ramp(size_t n, float base) {
+    std::vector<float> v(n);
+    for (size_t i = 0; i < n; ++i)
+        v[i] = base + 0.25f * static_cast<float>(i % 13);
+    return v;
+}
+
+TEST(DeepStackInject, AddsAtImageTokensAndLeavesTextAlone) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    //          0    1     2     3     4     5
+    const std::vector<int32_t> tokens = {5, kImageToken, kImageToken, 9, kImageToken, 3};
+    const auto hidden = ramp(tokens.size() * kD, 1.0f);
+    const auto emb = ramp(3 * kD, -0.5f);
+
+    const InjectResult r = inject(tokens, hidden, emb, 3);
+
+    int vision_idx = 0;
+    for (size_t t = 0; t < tokens.size(); ++t) {
+        for (int d = 0; d < kD; ++d) {
+            const size_t at = t * kD + d;
+            if (tokens[t] == kImageToken) {
+                const float want = hidden[at] + emb[static_cast<size_t>(vision_idx) * kD + d];
+                EXPECT_NEAR(r.hidden[at], want, 2e-2) << "token " << t << " dim " << d;
+            } else {
+                EXPECT_FLOAT_EQ(r.hidden[at], hidden[at]) << "text token " << t << " was touched";
+            }
+        }
+        if (tokens[t] == kImageToken)
+            ++vision_idx;
+    }
+}
+
+// Replacing would discard whatever the first layers produced at those
+// positions, which is a different model, not a subtly worse one.
+TEST(DeepStackInject, AddsRatherThanReplaces) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const std::vector<int32_t> tokens = {kImageToken, kImageToken};
+    const std::vector<float> hidden(tokens.size() * kD, 3.0f);
+    const std::vector<float> emb(tokens.size() * kD, 0.5f);
+    const InjectResult r = inject(tokens, hidden, emb, 2);
+    for (float v : r.hidden)
+        EXPECT_NEAR(v, 3.5f, 1e-2) << "a replace would read 0.5 here";
+}
+
+// Two injections in a row must stack — that is what "DeepStack" means, and it
+// is how layers 0, 1 and 2 each contribute.
+TEST(DeepStackInject, RepeatedInjectionsAccumulate) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const std::vector<int32_t> tokens = {kImageToken};
+    std::vector<float> hidden(kD, 1.0f);
+    const std::vector<float> emb(kD, 0.25f);
+    for (int round = 0; round < 3; ++round)
+        hidden = inject(tokens, hidden, emb, 1).hidden;
+    for (float v : hidden)
+        EXPECT_NEAR(v, 1.75f, 1e-2);
+}
+
+// A prompt with more placeholders than the encoder produced must leave the
+// surplus untouched rather than read past the embedding buffer.
+TEST(DeepStackInject, SurplusPlaceholdersAreLeftAlone) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const std::vector<int32_t> tokens = {kImageToken, kImageToken, kImageToken};
+    const auto hidden = ramp(tokens.size() * kD, 2.0f);
+    const auto emb = ramp(1 * kD, 0.5f);
+    const InjectResult r = inject(tokens, hidden, emb, 1);  // only ONE embedding
+
+    for (int d = 0; d < kD; ++d)
+        EXPECT_NEAR(r.hidden[d], hidden[d] + emb[d], 2e-2);
+    for (size_t at = kD; at < hidden.size(); ++at)
+        EXPECT_FLOAT_EQ(r.hidden[at], hidden[at]) << "position " << at / kD << " was written";
+}
+
+TEST(DeepStackInject, NoImageTokensIsANoOp) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const std::vector<int32_t> tokens = {1, 2, 3};
+    const auto hidden = ramp(tokens.size() * kD, 4.0f);
+    const auto emb = ramp(2 * kD, 1.0f);
+    const InjectResult r = inject(tokens, hidden, emb, 2);
+    for (size_t i = 0; i < hidden.size(); ++i)
+        EXPECT_FLOAT_EQ(r.hidden[i], hidden[i]);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
The last compute piece of the Qwen3-VL path. The vision encoder taps three intermediate feature maps (#1171 produces them); this adds them into the LM's hidden state.

## Two things that are easy to get backwards

Neither fails loudly, so both are stated in the code and pinned by tests:

- **The index spaces differ.** The taps come from vision blocks 5/11/17 but are injected at **LM layers 0/1/2** — upstream only ever writes `layer_idx in range(len(deepstack_visual_embeds))`. The hook is keyed on the LM layer index; nothing vision-side reaches it.
- **It is an ADD, not a replace.** The initial image embedding was already written at those positions by the existing embedding replacement; DeepStack stacks on top of what the first layers made of it. A test pins this, because replacing would produce a *different model*, not a subtly worse one.

`is_prefill` is part of the hook's condition rather than an optimisation: image tokens only ever exist in the prompt, and a decode graph captured with this branch taken would bake the add into every replay.

## Scope

Off by default and invisible to everything else — `InferenceState::n_deepstack` is 0 unless something sets it, and nothing does yet. The kernel and the hook are here; the wiring that fills them is the next piece.

## Verification

Five host-visible GPU tests: adds at image tokens and leaves text alone, adds rather than replaces, repeated injections accumulate (that is what "DeepStack" means), surplus placeholders are left alone rather than reading past the buffer, and no image tokens is a no-op.

Regression, since this touches the layer loop of every model:

| Check | Result |
|---|---|
| test-core / test-compute / test-attention / test-kv / test-quant / test-text | all green |
| `degen_suite.py` vs served Qwen3-4B-Q8 | 34 checks, 0 FAIL |
| File size / alloc sites | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8