### PR TITLE
feat(model): expand a chat template's image placeholder to the encoder's count

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ set(IMP_MODEL_SOURCES
     src/model/json_util.cpp
     src/model/hf_config_loader.cpp
     src/model/mrope_positions.cpp
+    src/model/image_placeholders.cpp
     src/model/hf_hub.cpp
     src/model/weight_map.cpp
     src/model/weight_upload.cu
@@ -641,6 +642,7 @@ if(IMP_BUILD_TESTS)
         tests/test_weight_snapshot.cpp
         tests/test_rope_override.cpp
         tests/test_mrope_config.cpp
+        tests/test_image_placeholders.cpp
         tests/test_ngram_draft.cpp
         tests/test_suffix_draft.cpp
         tests/test_token_recycle_draft.cpp

--- a/src/model/image_placeholders.cpp
+++ b/src/model/image_placeholders.cpp
@@ -1,0 +1,44 @@
+#include "model/image_placeholders.h"
+
+namespace imp {
+
+bool expand_image_placeholders(std::vector<int32_t>& tokens, int32_t pad_id, const std::vector<int>& counts,
+                               std::string& err) {
+    size_t found = 0;
+    for (int32_t t : tokens)
+        if (t == pad_id)
+            ++found;
+    if (found != counts.size()) {
+        err = "prompt holds " + std::to_string(found) + " image placeholder(s) but " +
+              std::to_string(counts.size()) + " image(s) were encoded";
+        return false;
+    }
+    for (size_t k = 0; k < counts.size(); ++k) {
+        if (counts[k] <= 0) {
+            err = "image " + std::to_string(k) + " produced no tokens";
+            return false;
+        }
+    }
+    if (found == 0)
+        return true;
+
+    size_t total = tokens.size();
+    for (int c : counts)
+        total += static_cast<size_t>(c) - 1;
+
+    std::vector<int32_t> out;
+    out.reserve(total);
+    size_t k = 0;
+    for (int32_t t : tokens) {
+        if (t != pad_id) {
+            out.push_back(t);
+            continue;
+        }
+        out.insert(out.end(), static_cast<size_t>(counts[k]), pad_id);
+        ++k;
+    }
+    tokens = std::move(out);
+    return true;
+}
+
+}  // namespace imp

--- a/src/model/image_placeholders.h
+++ b/src/model/image_placeholders.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Expand the single image placeholder a chat template emits into the number of
+// tokens the vision encoder actually produced.
+//
+// Qwen-VL templates render `<|vision_start|><|image_pad|><|vision_end|>` with
+// exactly ONE `<|image_pad|>`, because at template time nobody knows how big
+// the image will be after `smart_resize`. The processor expands it afterwards.
+// Doing the same on the token sequence — rather than teaching each chat-template
+// family about images — keeps multi-turn, multiple images and system prompts
+// working without duplicating template logic.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace imp {
+
+// Replaces the k-th occurrence of `pad_id` with `counts[k]` copies of it.
+// Refuses when the number of placeholders and the number of images disagree:
+// that means the prompt and the encoder are describing different inputs, and
+// every position after the mismatch would be shifted.
+bool expand_image_placeholders(std::vector<int32_t>& tokens, int32_t pad_id, const std::vector<int>& counts,
+                               std::string& err);
+
+}  // namespace imp

--- a/tests/test_image_placeholders.cpp
+++ b/tests/test_image_placeholders.cpp
@@ -1,0 +1,93 @@
+// Expanding a chat template's single image placeholder to the encoder's token
+// count.
+//
+// A miscount here does not crash: the embedding replacement fills whatever
+// placeholders it finds, and every position after the image is shifted, so the
+// model reads a coherent prompt that says something else.
+
+#include "model/image_placeholders.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+constexpr int32_t kPad = 151655;  // <|image_pad|>
+
+TEST(ImagePlaceholders, ExpandsTheSinglePlaceholder) {
+    std::vector<int32_t> t = {1, 2, kPad, 3, 4};
+    std::string err;
+    ASSERT_TRUE(expand_image_placeholders(t, kPad, {3}, err)) << err;
+    EXPECT_EQ(t, (std::vector<int32_t>{1, 2, kPad, kPad, kPad, 3, 4}));
+}
+
+TEST(ImagePlaceholders, ExpandsEachImageToItsOwnCount) {
+    std::vector<int32_t> t = {kPad, 7, kPad};
+    std::string err;
+    ASSERT_TRUE(expand_image_placeholders(t, kPad, {2, 3}, err)) << err;
+    EXPECT_EQ(t, (std::vector<int32_t>{kPad, kPad, 7, kPad, kPad, kPad}));
+}
+
+TEST(ImagePlaceholders, ACountOfOneLeavesTheSequenceUnchanged) {
+    const std::vector<int32_t> before = {5, kPad, 6};
+    std::vector<int32_t> t = before;
+    std::string err;
+    ASSERT_TRUE(expand_image_placeholders(t, kPad, {1}, err)) << err;
+    EXPECT_EQ(t, before);
+}
+
+TEST(ImagePlaceholders, NoImagesAndNoPlaceholdersIsANoOp) {
+    const std::vector<int32_t> before = {1, 2, 3};
+    std::vector<int32_t> t = before;
+    std::string err;
+    ASSERT_TRUE(expand_image_placeholders(t, kPad, {}, err)) << err;
+    EXPECT_EQ(t, before);
+}
+
+// The two mismatch directions. Either one means the prompt and the encoder
+// describe different inputs.
+TEST(ImagePlaceholders, RefusesACountMismatch) {
+    std::string err;
+    std::vector<int32_t> a = {kPad};
+    EXPECT_FALSE(expand_image_placeholders(a, kPad, {4, 4}, err));
+    EXPECT_NE(err.find("1 image placeholder"), std::string::npos) << err;
+
+    std::vector<int32_t> b = {kPad, kPad};
+    err.clear();
+    EXPECT_FALSE(expand_image_placeholders(b, kPad, {4}, err));
+    EXPECT_NE(err.find("2 image placeholder"), std::string::npos) << err;
+
+    std::vector<int32_t> c = {1, 2};
+    err.clear();
+    EXPECT_FALSE(expand_image_placeholders(c, kPad, {4}, err));
+}
+
+TEST(ImagePlaceholders, RefusesAnImageThatProducedNothing) {
+    std::vector<int32_t> t = {kPad};
+    std::string err;
+    EXPECT_FALSE(expand_image_placeholders(t, kPad, {0}, err));
+    EXPECT_NE(err.find("no tokens"), std::string::npos) << err;
+    EXPECT_EQ(t.size(), 1u) << "a rejection must leave the sequence alone";
+}
+
+// A rejection must not have half-expanded the sequence first.
+TEST(ImagePlaceholders, RejectionLeavesTheSequenceUntouched) {
+    const std::vector<int32_t> before = {kPad, 9, kPad, 8};
+    std::vector<int32_t> t = before;
+    std::string err;
+    EXPECT_FALSE(expand_image_placeholders(t, kPad, {3}, err));
+    EXPECT_EQ(t, before);
+}
+
+TEST(ImagePlaceholders, HandlesAdjacentPlaceholders) {
+    std::vector<int32_t> t = {kPad, kPad};
+    std::string err;
+    ASSERT_TRUE(expand_image_placeholders(t, kPad, {2, 2}, err)) << err;
+    EXPECT_EQ(t.size(), 4u);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Prerequisite for the Qwen3-VL prompt path.

Qwen-VL chat templates render `<|vision_start|><|image_pad|><|vision_end|>` with exactly **one** `<|image_pad|>`, because at template time nobody knows how big the image will be after `smart_resize` — the 64×64 fixture becomes 64 tokens, a 1795×2397 photo becomes 972. Upstream's processor expands the placeholder afterwards; this does the same, on the token sequence.

Doing it on tokens rather than teaching each chat-template family about images keeps multi-turn, multiple images and system prompts working without duplicating template logic, and it is the same operation for every VL family.

## What it refuses

A miscount does not crash: the embedding replacement fills whatever placeholders it finds, and every position after the image shifts, so the model reads a coherent prompt that says something else. So:

- both mismatch directions are refused (more placeholders than images, and fewer);
- an image that produced no tokens is refused;
- a rejection leaves the sequence **untouched** rather than half-expanded.

8 host tests, `test-core` green, gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8