### PR TITLE
feat(server): images over /v1/chat/completions for Qwen3-VL

### DIFF
--- a/src/compute/rope.cu
+++ b/src/compute/rope.cu
@@ -41,7 +41,7 @@ struct RopeTraits<__half> {
 __device__ __forceinline__ int mrope_position(const MRopeParams& m, int fallback, int pair_idx,
                                               int token_idx) {
     if (!m.positions)
-        return fallback + (m.pos_delta ? *m.pos_delta : 0);
+        return fallback + (m.pos_delta ? m.pos_delta[token_idx] : 0);
     int axis;
     if (m.interleaved) {
         const int r = pair_idx % 3;

--- a/src/compute/rope.h
+++ b/src/compute/rope.h
@@ -28,9 +28,15 @@ struct MRopeParams {
     // plus a per-request constant — and an image makes that constant NEGATIVE,
     // because it occupied more tokens than it cost positions.
     //
-    // It is a DEVICE pointer, not an int, on purpose: the decode position is
-    // advanced device-side inside a captured graph, and a baked-in scalar would
-    // freeze the value of whichever request was live at capture time.
+    // A DEVICE array of `stride` entries, one per token — not a scalar, and not
+    // host-computed. Two reasons, both learned the hard way:
+    //   - the decode position is advanced device-side inside a captured graph,
+    //     so a baked-in scalar would freeze whichever request was live at
+    //     capture time;
+    //   - a decode batch mixes requests, and an image request's offset must not
+    //     reach a text request sharing the step.
+    // Deriving from the same device `positions` the rest of the kernel reads is
+    // what keeps the batched and single-sequence paths from drifting apart.
     const int* pos_delta = nullptr;
 };
 

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -198,6 +198,11 @@ public:
     // caller needs this BEFORE tokenizing, because the chat template emits one
     // placeholder and the prompt has to hold this many.
     int pending_image_tokens() const;
+    // Server path: CPU-only patchify (safe off the batch worker) and the token
+    // count the prompt must reserve for it.
+    bool preprocess_image_qwen(const uint8_t* data, size_t len, QwenPatches& out) const;
+    int image_tokens_of(const QwenPatches& patches) const;
+    bool has_qwen_vision() const noexcept { return qwen_vision_.is_ready(); }
     // Vision: set image for next generation. Returns false if no mmproj loaded.
     [[nodiscard]] bool set_image(const std::string& path);
     [[nodiscard]] bool set_image_from_memory(const uint8_t* data, size_t len);
@@ -593,11 +598,6 @@ private:
     int mrope_prefill_cap_ = 0;
     int32_t* d_mrope_decode_ = nullptr;
     int mrope_decode_cap_ = 0;
-    // One int on the device: the running request's M-RoPE position delta. Read
-    // by the rotary kernels at replay time, so a captured decode graph picks up
-    // the current request's value instead of the one live at capture.
-    int* d_mrope_delta_ = nullptr;
-    void publish_mrope_delta_(int delta, cudaStream_t stream);
     // Binds M-RoPE onto a SINGLE-request decode state (graph templates, the
     // speculative chunk). Generated text needs only the scalar delta, so this
     // is the whole binding for every decode path.
@@ -616,13 +616,23 @@ private:
     // delta, replicated across all three axes (generated text is not an image).
     void bind_mrope_decode_(InferenceState& state, const std::vector<std::shared_ptr<Request>>& reqs,
                             cudaStream_t stream);
-    // Attaches the pending Qwen3-VL image to a request on its first prefill
-    // chunk: embeddings, DeepStack taps, and the (t, h, w) layout derived from
-    // where the image placeholders sit in its prompt.
+    // Moves the CLI's single pending image onto the first request that reserves
+    // placeholders for it. The server bypasses this and sets
+    // `Request::qwen_patches` itself, because it admits images concurrently.
     bool attach_qwen_image_(Request& req);
+    // Batch-worker half: patches -> this request's own device buffers.
+    // Takes the stream the CALLER will read the result on. Encoding on the
+    // engine's own stream and reading on the prefill stream is unsynchronised:
+    // the buffer is freshly allocated but may be RECYCLED memory still holding
+    // the previous request's image, so the race does not surface as garbage —
+    // it surfaces as an answer about the last picture.
+    bool encode_qwen_image_for_(Request& req, cudaStream_t stream);
+    // Prompt-side half: where the image sits and what it costs in positions.
+    bool build_qwen_layout_(Request& req, const Qwen3VLImage& shape);
 
-    Qwen3VLImage qwen_image_{};
-    bool qwen_image_pending_ = false;
+    // CLI only: one image, preprocessed on the caller's thread, waiting for the
+    // next request that has placeholders for it.
+    std::shared_ptr<QwenPatches> qwen_pending_patches_;
     int32_t qwen_image_pad_id_ = -1;
     // Constraint FSM state lives per-request (Request::constraints) — a
     // single engine-global manager let any concurrent prefill/finish clobber

--- a/src/runtime/engine_qwen3vl.cpp
+++ b/src/runtime/engine_qwen3vl.cpp
@@ -11,6 +11,9 @@
 
 #include "runtime/engine.h"
 
+#include <fstream>
+
+#include "core/buffer.h"
 #include "core/logging.h"
 #include "exec/inference_state.h"
 #include "runtime/engine_internal.h"
@@ -64,31 +67,11 @@ void Engine::bind_mrope_(InferenceState& state, int n_tokens, int32_t*& buf, int
     state.mrope.interleaved = mc.mrope_interleaved;
 }
 
-// Decode usually runs as a CUDA-graph REPLAY, which never revisits the host
-// binding — it only dereferences the pointer baked in at capture. So the delta
-// has to be CURRENT on the device before the first replay, which is why it is
-// published at prefill rather than only where the decode state is built.
-void Engine::publish_mrope_delta_(int delta, cudaStream_t stream) {
-    if (!d_mrope_delta_) {
-        d_mrope_delta_ = static_cast<int*>(vram_alloc_.allocate(sizeof(int), "mrope_delta"));
-        if (!d_mrope_delta_) {
-            IMP_LOG_ERROR("M-RoPE: could not allocate the decode delta");
-            return;
-        }
-    }
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_mrope_delta_, &delta, sizeof(int), cudaMemcpyHostToDevice, stream));
-}
-
 void Engine::bind_mrope_prefill_(InferenceState& state, const Request& req, int offset, int chunk_len,
                                  cudaStream_t stream) {
     const ModelConfig& mc = model_->config_;
     if (!mc.has_mrope() || chunk_len <= 0)
         return;
-
-    // Published at the START of the request's prefill, so it is in place before
-    // the first decode replay — and reset here for a request without an image.
-    if (offset == 0)
-        publish_mrope_delta_(req.mrope_pos_delta, stream);
 
     const size_t n_prompt = req.input_tokens.size();
     h_mrope_scratch_.assign(static_cast<size_t>(3) * chunk_len, 0);
@@ -108,13 +91,13 @@ void Engine::bind_mrope_prefill_(InferenceState& state, const Request& req, int 
 }
 
 void Engine::bind_mrope_single_(InferenceState& state, const Request& req, cudaStream_t stream) {
+    (void)stream;
     const ModelConfig& mc = model_->config_;
-    if (!mc.has_mrope())
+    // No delta buffer means no image, and a zero offset — which is what the
+    // unbound path already computes, bit for bit.
+    if (!mc.has_mrope() || !req.mrope_delta_dev)
         return;
-    publish_mrope_delta_(req.mrope_pos_delta, stream);
-    if (!d_mrope_delta_)
-        return;
-    state.mrope.pos_delta = d_mrope_delta_;
+    state.mrope.pos_delta = static_cast<const int*>(req.mrope_delta_dev->ptr());
     state.mrope.sec_t = mc.mrope_section[0];
     state.mrope.sec_h = mc.mrope_section[1];
     state.mrope.sec_w = mc.mrope_section[2];
@@ -127,25 +110,38 @@ void Engine::bind_mrope_decode_(InferenceState& state, const std::vector<std::sh
     if (!mc.has_mrope() || reqs.empty())
         return;
 
-    // Generated text advances all three axes together, so the whole layout
-    // collapses to one number per request. That is what makes this safe inside
-    // a captured graph: `positions` is advanced device-side during replay and
-    // the delta rides alongside it, rather than a host-filled array that a
-    // replay would never see refreshed.
-    int delta = reqs[0]->mrope_pos_delta;
-    for (const auto& r : reqs) {
-        if (r->mrope_pos_delta != delta) {
-            // Mixed batch: one scalar cannot serve both. Refuse rather than
-            // apply one request's image offset to another's text.
-            IMP_LOG_WARN("M-RoPE: decode batch mixes position deltas — skipping the offset this step");
-            state.mrope = MRopeParams{};
+    // One offset per token, because a batch mixes an image request (negative
+    // offset) with text requests (zero). The kernel adds it to the device
+    // `positions` it already reads, so this path and the single-sequence one
+    // compute the same number from the same source.
+    const int n = static_cast<int>(reqs.size());
+    bool any = false;
+    h_mrope_scratch_.assign(static_cast<size_t>(n), 0);
+    for (int i = 0; i < n; ++i) {
+        h_mrope_scratch_[static_cast<size_t>(i)] = reqs[i]->mrope_pos_delta;
+        any = any || reqs[i]->mrope_pos_delta != 0;
+    }
+    if (!any)
+        return;  // all text: identical to the unbound path, bit for bit
+
+    if (!d_mrope_decode_ || n > mrope_decode_cap_) {
+        if (d_mrope_decode_ && mrope_decode_cap_ > 0) {
+            // Sized once; a captured graph holds this pointer.
+            IMP_LOG_ERROR("M-RoPE: decode batch of %d exceeds the %d it was sized for", n, mrope_decode_cap_);
             return;
         }
+        const int want = std::max(n, std::max(1, config_.max_batch_size));
+        d_mrope_decode_ = static_cast<int32_t*>(
+            vram_alloc_.allocate(static_cast<size_t>(want) * sizeof(int32_t), "mrope_delta"));
+        if (!d_mrope_decode_)
+            return;
+        mrope_decode_cap_ = want;
     }
-    publish_mrope_delta_(delta, stream);
-    if (!d_mrope_delta_)
-        return;
-    state.mrope.pos_delta = d_mrope_delta_;
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_mrope_decode_, h_mrope_scratch_.data(),
+                                       static_cast<size_t>(n) * sizeof(int32_t), cudaMemcpyHostToDevice,
+                                       stream));
+    state.mrope.pos_delta = d_mrope_decode_;
+    state.mrope.stride = n;
     state.mrope.sec_t = mc.mrope_section[0];
     state.mrope.sec_h = mc.mrope_section[1];
     state.mrope.sec_w = mc.mrope_section[2];
@@ -159,10 +155,6 @@ void Engine::free_mrope_buffers_() {
             *b = nullptr;
         }
     }
-    if (d_mrope_delta_) {
-        vram_alloc_.free(d_mrope_delta_);
-        d_mrope_delta_ = nullptr;
-    }
     mrope_prefill_cap_ = 0;
     mrope_decode_cap_ = 0;
 }
@@ -171,45 +163,100 @@ void Engine::free_mrope_buffers_() {
 // Here rather than in engine.cpp because they are the Qwen3-VL half of the
 // vision surface and belong next to the layout code above.
 
+// Set-image is CPU-only for Qwen3-VL: it patchifies and stops there. That is
+// what lets the caller learn the token count before tokenizing, and it keeps
+// GPU work off whichever thread happened to call.
 bool Engine::set_image(const std::string& path) {
-    // Qwen3-VL first: its tower came in with the checkpoint, so a model can
-    // have one without any mmproj being configured.
     if (qwen_vision_.is_ready()) {
-        if (!qwen_vision_.encode_file(path, qwen_image_, stream_))
+        std::ifstream f(path, std::ios::binary);
+        if (!f) {
+            IMP_LOG_ERROR("Qwen3-VL: could not open image '%s'", path.c_str());
             return false;
-        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream_));
-        qwen_image_pending_ = true;
-        return true;
+        }
+        const std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(f)),
+                                         std::istreambuf_iterator<char>());
+        return set_image_from_memory(bytes.data(), bytes.size());
     }
     return vision_.set_image(path, stream_);
 }
 
 bool Engine::set_image_from_memory(const uint8_t* data, size_t len) {
     if (qwen_vision_.is_ready()) {
-        if (!qwen_vision_.encode_memory(data, len, qwen_image_, stream_))
+        auto patches = std::make_shared<QwenPatches>();
+        if (!qwen_vision_.preprocess(data, len, *patches))
             return false;
-        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream_));
-        qwen_image_pending_ = true;
+        qwen_pending_patches_ = std::move(patches);
         return true;
     }
     return vision_.set_image_from_memory(data, len, stream_);
 }
 
 void Engine::clear_image() {
-    qwen_image_pending_ = false;
+    qwen_pending_patches_.reset();
     vision_.clear_image();
 }
 
-int Engine::pending_image_tokens() const { return qwen_image_pending_ ? qwen_image_.tokens : 0; }
+bool Engine::preprocess_image_qwen(const uint8_t* data, size_t len, QwenPatches& out) const {
+    return qwen_vision_.is_ready() && qwen_vision_.preprocess(data, len, out);
+}
 
-bool Engine::attach_qwen_image_(Request& req) {
-    if (!qwen_image_pending_ || req.vision_emb || qwen_image_pad_id_ < 0)
+int Engine::image_tokens_of(const QwenPatches& patches) const {
+    return qwen_vision_.merged_tokens_of(patches);
+}
+
+int Engine::pending_image_tokens() const {
+    return qwen_pending_patches_ ? qwen_vision_.merged_tokens_of(*qwen_pending_patches_) : 0;
+}
+
+// Turns a request's CPU-preprocessed image into its own device buffers and its
+// own (t, h, w) layout. Runs on the batch worker: it drives the GPU, so it
+// cannot be on an HTTP thread.
+bool Engine::encode_qwen_image_for_(Request& req, cudaStream_t stream) {
+    if (!req.qwen_patches || !qwen_vision_.is_ready() || qwen_image_pad_id_ < 0)
         return false;
 
-    // Where the image sits in the prompt. The placeholders were expanded to the
-    // encoder's token count before the request was submitted; if they were not,
-    // the layout below would be built for a different prompt than the one the
-    // embeddings land in, so the mismatch is fatal rather than tolerated.
+    const int tokens = qwen_vision_.merged_tokens_of(*req.qwen_patches);
+    const size_t bytes = qwen_vision_.embedding_bytes(tokens);
+    if (tokens <= 0 || bytes == 0) {
+        IMP_LOG_ERROR("Qwen3-VL: image produced no tokens");
+        req.qwen_patches.reset();
+        return false;
+    }
+
+    // Per-request buffers, so two concurrent image requests cannot share one
+    // encoder output. shared_ptr<Buffer> frees on the last reference, which is
+    // what keeps the cancel paths from needing a lifecycle of their own.
+    auto emb = std::make_shared<Buffer>(Buffer::device(bytes));
+    if (!*emb)
+        return false;
+    const int taps = qwen_vision_.deepstack_taps();
+    std::vector<std::shared_ptr<Buffer>> deep;
+    std::vector<half*> deep_ptrs;
+    deep.reserve(static_cast<size_t>(taps));
+    for (int i = 0; i < taps; ++i) {
+        auto b = std::make_shared<Buffer>(Buffer::device(bytes));
+        if (!*b)
+            return false;
+        deep_ptrs.push_back(b->as<half>());
+        deep.push_back(std::move(b));
+    }
+
+    Qwen3VLImage shape;
+    if (!qwen_vision_.encode_patches_to(*req.qwen_patches, emb->as<half>(), deep_ptrs, shape, stream))
+        return false;
+    req.qwen_patches.reset();  // host pixels no longer needed
+
+    if (!build_qwen_layout_(req, shape))
+        return false;
+    req.vision_emb = std::move(emb);
+    req.deepstack_emb = std::move(deep);
+    return true;
+}
+
+// The prompt-side half: which positions hold the image, and what that costs the
+// M-RoPE sequence. Kept apart from the encode because it is pure bookkeeping
+// over the token ids and fails for entirely different reasons.
+bool Engine::build_qwen_layout_(Request& req, const Qwen3VLImage& shape) {
     std::vector<uint8_t> is_image(req.input_tokens.size(), 0);
     int found = 0;
     for (size_t i = 0; i < req.input_tokens.size(); ++i)
@@ -217,21 +264,17 @@ bool Engine::attach_qwen_image_(Request& req) {
             is_image[i] = 1;
             ++found;
         }
-    if (found == 0) {
-        // This prompt has no image in it. Leave the pending one alone rather
-        // than consuming or complaining about it — a text turn between two
-        // image turns is ordinary.
-        return false;
-    }
-    if (found != qwen_image_.tokens) {
+    if (found != shape.tokens) {
+        // The prompt and the encoder describe different images. Every position
+        // after the mismatch would be shifted, so this is fatal, not tolerated.
         IMP_LOG_ERROR("Qwen3-VL: prompt reserves %d image tokens but the encoder produced %d", found,
-                      qwen_image_.tokens);
+                      shape.tokens);
         return false;
     }
 
     std::string err;
     int next_pos = 0;
-    const std::vector<MRopeImageGrid> grids = {{qwen_image_.grid_rows, qwen_image_.grid_cols}};
+    const std::vector<MRopeImageGrid> grids = {{shape.grid_rows, shape.grid_cols}};
     if (!qwen_build_mrope_positions(is_image, grids, 0, req.mrope_positions, next_pos, err)) {
         IMP_LOG_ERROR("Qwen3-VL: %s", err.c_str());
         return false;
@@ -240,12 +283,37 @@ bool Engine::attach_qwen_image_(Request& req) {
     // it cost positions — and it is what keeps generation continuing where the
     // prompt left off instead of jumping past a gap.
     req.mrope_pos_delta = next_pos - static_cast<int>(req.input_tokens.size());
-
+    // Its own device copy: decode replays dereference this pointer, and a
+    // shared one would let a concurrent request's prefill change it mid-run.
+    auto delta_buf = std::make_shared<Buffer>(Buffer::device(sizeof(int)));
+    if (!*delta_buf)
+        return false;
+    IMP_CUDA_CHECK_LOG(
+        cudaMemcpy(delta_buf->ptr(), &req.mrope_pos_delta, sizeof(int), cudaMemcpyHostToDevice));
+    req.mrope_delta_dev = std::move(delta_buf);
     req.vision_token_id = qwen_image_pad_id_;
-    req.n_vision_tokens = qwen_image_.tokens;
-    qwen_image_pending_ = false;
-    IMP_LOG_INFO("Qwen3-VL: attached %d image tokens (%dx%d), position delta %d", qwen_image_.tokens,
-                 qwen_image_.grid_rows, qwen_image_.grid_cols, req.mrope_pos_delta);
+    req.n_vision_tokens = shape.tokens;
+    IMP_LOG_INFO("Qwen3-VL: %d image tokens (%dx%d), position delta %d", shape.tokens, shape.grid_rows,
+                 shape.grid_cols, req.mrope_pos_delta);
+    return true;
+}
+
+// CLI path: one pending image on the engine, moved onto the first request that
+// reserves placeholders for it. The server does not use this — it sets
+// `req.qwen_patches` directly, because it admits image requests concurrently.
+bool Engine::attach_qwen_image_(Request& req) {
+    if (!qwen_pending_patches_ || req.qwen_patches || req.vision_emb)
+        return false;
+    bool has_pad = false;
+    for (int32_t t : req.input_tokens)
+        if (t == qwen_image_pad_id_) {
+            has_pad = true;
+            break;
+        }
+    if (!has_pad)
+        return false;  // this prompt has no image; the pending one may be a later request's
+    req.qwen_patches = std::move(qwen_pending_patches_);
+    qwen_pending_patches_.reset();
     return true;
 }
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -491,8 +491,16 @@ bool Engine::prefill_allocate_kv_blocks_(std::shared_ptr<Request>& req, int kv_b
     // Embedding requests mean-pool EVERY position's hidden state — a
     // prefix-cache hit would skip the reused prefix's forward and silently
     // bias the pooled vector (#1005). Same class as the ppl_capture guard.
-    if (kv_manager_->prefix_caching_enabled() && existing == 0 && offset == 0 &&
-        !ppl_capture_.active && !req->embedding_request) {
+    // Image requests are the third member of that class, and the sharpest: the
+    // prefix cache is content-addressed on TOKEN IDS, and every image token
+    // carries the SAME id (<|image_pad|> / the soft token). Two requests with
+    // different pictures therefore produce identical prefixes, and the second
+    // one silently answers about the first one's image. Observed: a photo of a
+    // pizza described as "a tabby cat sitting outdoors". Applies to the mmproj
+    // path too, not just Qwen3-VL — the ids are just as uniform there.
+    const bool has_image = req->image || req->qwen_patches || req->vision_emb || req->n_vision_tokens > 0;
+    if (kv_manager_->prefix_caching_enabled() && existing == 0 && offset == 0 && !ppl_capture_.active &&
+        !req->embedding_request && !has_image) {
         prefix_reused = kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens);
         if (prefix_reused < 0) {
             // KV exhausted even after cached-block reclamation. The old fallback
@@ -816,10 +824,22 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         return;  // caller already set req->status = CANCELLED
     }
 
-    // First chunk of a request is where a pending image becomes this request's:
-    // it needs the prompt's final token layout, which only exists now.
+    // First chunk of a request is where its image becomes device-resident: the
+    // layout needs the prompt's final token sequence, which only exists now.
+    // The CLI leaves its image pending on the engine; the server puts it on the
+    // request itself. Both end up in `encode_qwen_image_for_`.
     if (offset == 0)
         (void)attach_qwen_image_(*req);
+    // Not gated on `offset == 0`: `qwen_patches` is cleared by the encode, so
+    // this runs exactly once regardless of how the prompt is chunked.
+    {
+        if (req->qwen_patches && !encode_qwen_image_for_(*req, pf_stream)) {
+            IMP_LOG_ERROR("Qwen3-VL: image encode failed — cancelling request %llu",
+                          static_cast<unsigned long long>(req->id));
+            req->status = RequestStatus::CANCELLED;
+            return;
+        }
+    }
 
     // Build InferenceState
     InferenceState state;
@@ -827,14 +847,14 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     state.positions = d_positions;
     state.n_tokens = chunk_len;
     bind_mrope_prefill_(state, *req, offset, chunk_len, pf_stream);
-    if (req->n_vision_tokens > 0 && req->vision_token_id >= 0 && qwen_image_.d_embeddings) {
-        state.vision_embeddings = qwen_image_.d_embeddings;
+    if (req->n_vision_tokens > 0 && req->vision_token_id >= 0 && req->vision_emb) {
+        state.vision_embeddings = req->vision_emb->as<half>();
         state.vision_token_id = req->vision_token_id;
         state.n_vision_tokens = req->n_vision_tokens;
-        state.n_deepstack = std::min<int>(static_cast<int>(qwen_image_.d_deepstack.size()),
+        state.n_deepstack = std::min<int>(static_cast<int>(req->deepstack_emb.size()),
                                           InferenceState::kMaxDeepStack);
         for (int d = 0; d < state.n_deepstack; ++d)
-            state.deepstack_embeddings[d] = qwen_image_.d_deepstack[d];
+            state.deepstack_embeddings[d] = req->deepstack_emb[d]->as<half>();
     }
     state.kv_cache = kv_cache_raw_;
     state.block_tables = d_block_tables;
@@ -1146,7 +1166,12 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
             finish_request(req);
         } else {
             req->status = RequestStatus::DECODING;
-            if (kv_manager_->prefix_caching_enabled()) {
+            // Publishing is as unsound as reading for an image request: these
+            // blocks would be offered to any later prompt with the same token
+            // ids, and every image token has the SAME id. A text request that
+            // happens to share the prefix would inherit a picture's KV.
+            const bool had_image = req->n_vision_tokens > 0 || req->image || req->vision_emb;
+            if (kv_manager_->prefix_caching_enabled() && !had_image) {
                 kv_manager_->register_block_hashes(req->id, req->input_tokens);
             }
         }

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -9,7 +9,8 @@
 namespace imp {
 
 // Forward declares to keep CUDA / buffer headers out of this widely-included file.
-struct ImageData;  // src/vision/image_processor.h
+struct ImageData;
+struct QwenPatches;  // vision/image_processor.h
 class Buffer;      // src/core/buffer.h
 
 // Per-token log probability information (for logprobs output)
@@ -248,7 +249,12 @@ struct Request {
     int32_t vision_token_id = -1;
     int n_vision_tokens = 0;
 
-    // Qwen3-VL. `deepstack_emb` holds one buffer per vision tap, each the same
+    // Qwen3-VL, per-request. `qwen_patches` is the CPU-preprocessed image set by
+    // the server thread; the batch worker turns it into `vision_emb` +
+    // `deepstack_emb` on admission and clears it. Per-request rather than
+    // engine-global because the server admits image requests concurrently.
+    std::shared_ptr<QwenPatches> qwen_patches;
+    // `deepstack_emb` holds one buffer per vision tap, each the same
     // shape as `vision_emb`; they are ADDED at the LM's first layers.
     std::vector<std::shared_ptr<Buffer>> deepstack_emb;
     // Per-token (t, h, w) positions for the PROMPT, [3, input_tokens.size()].
@@ -259,6 +265,11 @@ struct Request {
     // rows*cols tokens, so this is negative whenever the prompt held one, and
     // `context_len()` alone would leave a gap the model never saw in training.
     int mrope_pos_delta = 0;
+    // The same number, on the device, owned by THIS request. Engine-global
+    // would be a cross-request corruption: decode replays read the pointer at
+    // replay time, so a concurrent request's prefill would overwrite the value
+    // a different sequence is mid-generation on.
+    std::shared_ptr<Buffer> mrope_delta_dev;
 
     int context_len() const { return static_cast<int>(input_tokens.size() + output_tokens.size()); }
 

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -71,7 +71,18 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
                     continue;
                 }
                 // Reserve blocks, using prefix caching when enabled.
-                if (kv_manager_->prefix_caching_enabled()) {
+                //
+                // An image request is excluded, and the reason is not caution:
+                // the prefix cache is content-addressed on TOKEN IDS, and every
+                // image token carries the SAME id (<|image_pad|> / the soft
+                // token). Two requests with different pictures therefore share
+                // a long identical prefix, and the second one silently answers
+                // about the first one's image. Observed: a pizza described as
+                // "a tabby cat sitting outdoors". Holds for the mmproj path
+                // too — its ids are just as uniform.
+                const bool has_image = req->image || req->qwen_patches || req->vision_emb ||
+                                       req->n_vision_tokens > 0;
+                if (kv_manager_->prefix_caching_enabled() && !has_image) {
                     // Hybrid models cap reuse at the recurrent-snapshot
                     // boundary (and attach the snapshot to the request).
                     int max_reuse = prefix_reuse_limit_ ? prefix_reuse_limit_(*req) : -1;

--- a/src/vision/qwen3vl_pipeline.cpp
+++ b/src/vision/qwen3vl_pipeline.cpp
@@ -108,27 +108,95 @@ bool Qwen3VLPipeline::init(VisionModel& tower, VRAMAllocator& alloc, int max_pat
     return true;
 }
 
+QwenPatchifyConfig Qwen3VLPipeline::patchify_config() const {
+    QwenPatchifyConfig pc;
+    if (tower_) {
+        const VisionConfig& c = tower_->config;
+        pc.patch_size = c.patch_size;
+        pc.merge_size = c.merge_size;
+        pc.temporal_patch_size = c.temporal_patch_size;
+        // The budget is a hard ceiling here, not a preference: every workspace
+        // was sized from it, so an image is scaled down to fit rather than
+        // refused.
+        pc.max_pixels = std::min<int64_t>(pc.max_pixels, max_pixels());
+    }
+    return pc;
+}
+
+int Qwen3VLPipeline::merged_tokens_of(const QwenPatches& p) const {
+    if (!tower_)
+        return 0;
+    const int unit = tower_->config.merge_size * tower_->config.merge_size;
+    return unit > 0 ? p.tokens / unit : 0;
+}
+
+size_t Qwen3VLPipeline::embedding_bytes(int tokens) const {
+    if (!tower_ || tokens <= 0)
+        return 0;
+    return static_cast<size_t>(tokens) * tower_->config.out_hidden_size * sizeof(half);
+}
+
+int Qwen3VLPipeline::deepstack_taps() const {
+    return tower_ ? static_cast<int>(tower_->config.deepstack_indexes.size()) : 0;
+}
+
+bool Qwen3VLPipeline::preprocess(const uint8_t* data, size_t len, QwenPatches& out) const {
+    if (!tower_)
+        return false;
+    int w = 0, h = 0, ch = 0;
+    uint8_t* rgb = stbi_load_from_memory(data, static_cast<int>(len), &w, &h, &ch, 3);
+    if (!rgb) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: could not decode a %zu-byte image", len);
+        return false;
+    }
+    const bool ok = qwen_patchify(rgb, w, h, patchify_config(), out);
+    stbi_image_free(rgb);
+    if (!ok)
+        IMP_LOG_ERROR("Qwen3-VL pipeline: could not patchify a %dx%d image", w, h);
+    return ok;
+}
+
+bool Qwen3VLPipeline::encode_patches_to(const QwenPatches& patches, half* d_out,
+                                        const std::vector<half*>& d_deepstack, Qwen3VLImage& shape_out,
+                                        cudaStream_t stream) {
+    if (!encode_patches(patches, shape_out, stream))
+        return false;
+    const size_t bytes = embedding_bytes(shape_out.tokens);
+    if (d_out)
+        IMP_CUDA_CHECK_LOG(
+            cudaMemcpyAsync(d_out, shape_out.d_embeddings, bytes, cudaMemcpyDeviceToDevice, stream));
+    for (size_t i = 0; i < d_deepstack.size() && i < shape_out.d_deepstack.size(); ++i)
+        if (d_deepstack[i])
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_deepstack[i], shape_out.d_deepstack[i], bytes,
+                                               cudaMemcpyDeviceToDevice, stream));
+    // Point the shape at the caller's memory so nothing keeps a handle on the
+    // shared scratch, which the next request overwrites.
+    shape_out.d_embeddings = d_out;
+    shape_out.d_deepstack.assign(d_deepstack.begin(), d_deepstack.end());
+    return true;
+}
+
 bool Qwen3VLPipeline::encode_rgb(const uint8_t* rgb, int width, int height, Qwen3VLImage& out,
                                  cudaStream_t stream) {
     if (!encoder_) {
         IMP_LOG_ERROR("Qwen3-VL pipeline: encode before init");
         return false;
     }
-    const VisionConfig& c = tower_->config;
-
-    QwenPatchifyConfig pc;
-    pc.patch_size = c.patch_size;
-    pc.merge_size = c.merge_size;
-    pc.temporal_patch_size = c.temporal_patch_size;
-    // The budget is a hard ceiling here, not a preference: every workspace was
-    // sized from it, so an image is scaled down to fit rather than refused.
-    pc.max_pixels = std::min<int64_t>(pc.max_pixels, max_pixels());
-
     QwenPatches patches;
-    if (!qwen_patchify(rgb, width, height, pc, patches)) {
+    if (!qwen_patchify(rgb, width, height, patchify_config(), patches)) {
         IMP_LOG_ERROR("Qwen3-VL pipeline: could not patchify a %dx%d image", width, height);
         return false;
     }
+    IMP_LOG_INFO("Qwen3-VL: %dx%d image -> %dx%d patches", width, height, patches.grid_h, patches.grid_w);
+    return encode_patches(patches, out, stream);
+}
+
+bool Qwen3VLPipeline::encode_patches(const QwenPatches& patches, Qwen3VLImage& out, cudaStream_t stream) {
+    if (!encoder_) {
+        IMP_LOG_ERROR("Qwen3-VL pipeline: encode before init");
+        return false;
+    }
+    const VisionConfig& c = tower_->config;
     if (patches.tokens > max_patches_) {
         // smart_resize honours max_pixels, so this means the two disagree —
         // worth an error rather than a silent truncation.
@@ -158,8 +226,6 @@ bool Qwen3VLPipeline::encode_rgb(const uint8_t* rgb, int width, int height, Qwen
     out.tokens = patches.tokens / unit;
     out.d_embeddings = d_out_;
     out.d_deepstack.assign(d_deepstack_.begin(), d_deepstack_.end());
-    IMP_LOG_INFO("Qwen3-VL: %dx%d image -> %dx%d patches -> %d image tokens", width, height, patches.grid_h,
-                 patches.grid_w, out.tokens);
     return true;
 }
 
@@ -176,15 +242,10 @@ bool Qwen3VLPipeline::encode_file(const std::string& path, Qwen3VLImage& out, cu
 }
 
 bool Qwen3VLPipeline::encode_memory(const uint8_t* data, size_t len, Qwen3VLImage& out, cudaStream_t stream) {
-    int w = 0, h = 0, ch = 0;
-    uint8_t* rgb = stbi_load_from_memory(data, static_cast<int>(len), &w, &h, &ch, 3);
-    if (!rgb) {
-        IMP_LOG_ERROR("Qwen3-VL pipeline: could not decode a %zu-byte image", len);
+    QwenPatches patches;
+    if (!preprocess(data, len, patches))
         return false;
-    }
-    const bool ok = encode_rgb(rgb, w, h, out, stream);
-    stbi_image_free(rgb);
-    return ok;
+    return encode_patches(patches, out, stream);
 }
 
 }  // namespace imp

--- a/src/vision/qwen3vl_pipeline.h
+++ b/src/vision/qwen3vl_pipeline.h
@@ -12,6 +12,7 @@
 // so this holds a reference, not ownership, and uploads them to the device on
 // first init.
 
+#include "vision/image_processor.h"  // QwenPatches
 #include "vision/qwen3vl_encoder.h"
 #include "vision/vision_model.h"
 
@@ -58,8 +59,28 @@ public:
     bool encode_file(const std::string& path, Qwen3VLImage& out, cudaStream_t stream);
     bool encode_memory(const uint8_t* data, size_t len, Qwen3VLImage& out, cudaStream_t stream);
 
+    // --- Per-request path (the server) --------------------------------
+    // CPU only — decode, resize, patchify. Safe to call off the batch worker
+    // (an HTTP handler thread), and it is what tells the caller how many image
+    // tokens the prompt has to reserve, BEFORE any GPU work happens.
+    bool preprocess(const uint8_t* data, size_t len, QwenPatches& out) const;
+    // Image tokens a patchified image becomes.
+    int merged_tokens_of(const QwenPatches& p) const;
+    // Bytes one request's embedding buffer needs (same for each DeepStack tap).
+    size_t embedding_bytes(int tokens) const;
+    int deepstack_taps() const;
+
+    // Encode into the CALLER's buffers. Runs through the pipeline's own stable
+    // scratch first and copies out, because the encoder's workspaces are sized
+    // once and shared — a per-request output would mean re-sizing per image.
+    // Serialized: the caller must be the sole GPU driver (the batch worker).
+    bool encode_patches_to(const QwenPatches& patches, half* d_out, const std::vector<half*>& d_deepstack,
+                           Qwen3VLImage& shape_out, cudaStream_t stream);
+
 private:
     bool encode_rgb(const uint8_t* rgb, int width, int height, Qwen3VLImage& out, cudaStream_t stream);
+    bool encode_patches(const QwenPatches& patches, Qwen3VLImage& out, cudaStream_t stream);
+    QwenPatchifyConfig patchify_config() const;
     void free_buffers();
 
     VisionModel* tower_ = nullptr;

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -7,6 +7,7 @@
 
 #include "handlers.h"
 #include "handlers_internal.h"
+#include "model/image_placeholders.h"
 #include "utils.h"
 #include "tool_call.h"
 #include "anthropic.h"
@@ -200,16 +201,32 @@ bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, Ch
     // binds it per-request on admission, so a vision request batches like text.
     // Soft-token placeholders are injected by apply_with_image() below.
     if (ctx.snap.has_vision_request) {
-        auto img = std::make_shared<imp::ImageData>();
-        if (!state.ctx->engine->preprocess_image(ctx.params.image_data.data(), ctx.params.image_data.size(),
-                                                 *img)) {
+        auto fail = [&] {
             res.status = 400;
             json error = {
                 {"error", {{"message", "Failed to process image"}, {"type", "invalid_request_error"}}}};
             res.set_content(dump_safe(error), "application/json");
             return false;
+        };
+        if (state.ctx->engine->has_qwen_vision()) {
+            // Dynamic resolution: patchify now (CPU only) so the token count is
+            // known before the prompt is tokenized — the placeholders have to be
+            // expanded to exactly that many.
+            auto patches = std::make_shared<imp::QwenPatches>();
+            if (!state.ctx->engine->preprocess_image_qwen(ctx.params.image_data.data(),
+                                                          ctx.params.image_data.size(), *patches))
+                return fail();
+            ctx.snap.qwen_image_tokens = state.ctx->engine->image_tokens_of(*patches);
+            if (ctx.snap.qwen_image_tokens <= 0)
+                return fail();
+            ctx.snap.qwen_patches = std::move(patches);
+        } else {
+            auto img = std::make_shared<imp::ImageData>();
+            if (!state.ctx->engine->preprocess_image(ctx.params.image_data.data(),
+                                                     ctx.params.image_data.size(), *img))
+                return fail();
+            ctx.snap.vision_image = std::move(img);
         }
-        ctx.snap.vision_image = std::move(img);
     }
 
     // Thinking mode default: ON for think models in plain chat. These models
@@ -276,7 +293,30 @@ bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, Ch
                                 ctx.snap.enable_thinking;
 
     // Tokenize with chat template (with image tokens if vision is active)
-    if (ctx.snap.have_template && ctx.snap.has_vision_request) {
+    if (ctx.snap.have_template && ctx.snap.qwen_patches) {
+        // The chat template renders ONE <|image_pad|> — at template time nobody
+        // knows how big the image will be after smart_resize. Put the vision
+        // block in front of the first user turn, render, then expand.
+        auto msgs = ctx.params.chat_msgs;
+        for (auto& m : msgs)
+            if (m.role == "user") {
+                m.content = "<|vision_start|><|image_pad|><|vision_end|>" + m.content;
+                break;
+            }
+        ctx.snap.tokens = ctx.snap.chat_tpl.apply(*ctx.snap.tok, msgs, ctx.snap.suppress_thinking,
+                                                  force_thinking);
+        const int32_t pad_id = ctx.snap.tok->find_token("<|image_pad|>");
+        std::string exp_err;
+        if (pad_id < 0 ||
+            !imp::expand_image_placeholders(ctx.snap.tokens, pad_id, {ctx.snap.qwen_image_tokens}, exp_err)) {
+            res.status = 400;
+            json error = {{"error",
+                           {{"message", pad_id < 0 ? "tokenizer has no <|image_pad|>" : exp_err},
+                            {"type", "invalid_request_error"}}}};
+            res.set_content(dump_safe(error), "application/json");
+            return false;
+        }
+    } else if (ctx.snap.have_template && ctx.snap.has_vision_request) {
         ctx.snap.tokens = ctx.snap.chat_tpl.apply_with_image(*ctx.snap.tok, ctx.params.chat_msgs, 256,
                                                              ctx.snap.suppress_thinking, force_thinking);
     } else if (ctx.snap.have_template && ctx.snap.tools_via_jinja) {
@@ -538,7 +578,8 @@ std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
                                                  const std::vector<int32_t>& input_tokens, int completion_idx,
                                                  bool stream) {
     auto req = std::make_shared<imp::Request>();
-    req->image = ctx.snap.vision_image;  // per-request vision (null for text)
+    req->image = ctx.snap.vision_image;         // per-request vision (null for text)
+    req->qwen_patches = ctx.snap.qwen_patches;  // dynamic-resolution route (null otherwise)
     req->input_tokens = input_tokens;
     req->max_tokens = ctx.params.max_tokens;
     req->temperature = ctx.params.temperature;

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -115,6 +115,11 @@ struct ChatStateSnapshot {
     // req->image at every request-build site. The batch worker encodes + binds
     // it per-request (no engine pause). Null for text-only requests.
     std::shared_ptr<imp::ImageData> vision_image;
+    // Qwen3-VL takes the other route: a dynamic-resolution image is patchified
+    // here (CPU only) and its token count is known BEFORE tokenizing, because
+    // the prompt has to reserve exactly that many placeholders.
+    std::shared_ptr<imp::QwenPatches> qwen_patches;
+    int qwen_image_tokens = 0;
     std::vector<int32_t> stop_token_ids;
     imp::ChatTemplateFamily tpl_family = imp::ChatTemplateFamily::CHATML;
     std::vector<imp::ToolFunction> tool_defs;


### PR DESCRIPTION
The CLI route shipped in #1178; this is the HTTP one. Same split the mmproj path already uses — CPU preprocessing on the request thread, GPU encode on the batch worker — but **per-request throughout**, because the server admits image requests concurrently.

```
HTTP thread  : decode + smart_resize + patchify -> QwenPatches on the request.
               The token count is known HERE, which is what lets the prompt
               reserve exactly that many placeholders before tokenizing.
batch worker : patches -> this request's own embedding and DeepStack buffers,
               its own (t, h, w) layout, its own decode offset.
```

## Verification

Against the staged `Qwen3-VL-4B-Instruct`, a cat photo and a pizza photo:

- sequentially, **in both orders**, repeatedly — each described correctly;
- **four concurrent image requests plus one text request** — all correct, and the concurrent answers are **byte-identical** to the sequential ones.

## Three bugs this found, in order of severity

### 1. The prefix cache was serving one request's picture to another

It is content-addressed on **token ids**, and every image token carries the **same** id (`<|image_pad|>`, or the soft token on the mmproj path). Two requests with different pictures therefore share a long identical prefix, and the second one answered about the first one's image:

> **Q:** *(pizza photo)* "What food is this?"
> **A:** "Actually, this is not food—it's a **cat**. The image shows a tabby cat sitting outdoors…"

Image requests now neither **read from** nor **publish to** the cache. Publishing is as unsound as reading: a later *text* prompt sharing the prefix would inherit a picture's KV.

**This was a pre-existing bug on the mmproj path**, not something the new code introduced — the ids are just as uniform there.

There are **two** reuse sites — `engine_scheduler.cpp` and `scheduler.cpp`. Guarding one and testing only through the CLI would have looked exactly like a fix; the second one is what the server actually uses.

### 2. The decode position offset was engine-global

Decode replays dereference that pointer *at replay time*, so a concurrent request's prefill overwrote the value another sequence was mid-generation on. Symptom: `"ThisThisThisThis…"`. It lives on the `Request` now.

### 3. The two decode paths computed the offset from different sources

The batched path used host `context_len()`; the single-sequence path used device `positions`. They agree until a captured graph runs ahead of the host — then a single token comes out wrong (`"a domestic shorth brown"`). Both now add a **per-token** offset to the same device positions.

## Known cost

An image request cannot use the prefix cache **at all**, so a multi-turn conversation about one picture re-prefills it every turn. The right fix is to fold an image content hash into the block hash rather than skip the cache — that is a KV-manager change and does not belong here.

## Regression

| Check | Result |
|---|---|
| test-core / compute / attention / kv / quant / text / moe-gdn / e2e | all green |
| `degen_suite.py` vs served Qwen3-4B-Q8 | 34 checks, 0 FAIL |
| Text prefix caching still active | second identical text prompt reports `cached_tokens: 400` |
| File size / alloc sites | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8