### PR TITLE
fix(kv): salt the prefix cache with the image, instead of skipping it

### DIFF
--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -442,13 +442,14 @@ bool KVCacheManager::can_allocate(int num_blocks) const {
 // ─── Content-addressed prefix caching ────────────────────────────────
 
 int KVCacheManager::longest_cached_prefix_blocks(std::span<const int32_t> tokens,
-                                                 std::vector<size_t>& chain_hashes) const {
+                                                 std::vector<size_t>& chain_hashes,
+                                                 size_t content_salt) const {
     chain_hashes.clear();
     const int num_tokens = static_cast<int>(tokens.size());
     const int full_blocks = num_tokens / cache_->block_size();
     int cached = 0;
     bool chain_intact = true;
-    size_t parent_hash = 0;
+    size_t parent_hash = content_salt;
     for (int b = 0; b < full_blocks; ++b) {
         size_t h = compute_block_hash(
             tokens.subspan(static_cast<size_t>(b) * cache_->block_size(), cache_->block_size()),
@@ -464,7 +465,7 @@ int KVCacheManager::longest_cached_prefix_blocks(std::span<const int32_t> tokens
 }
 
 int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int32_t> tokens,
-                                                int max_reuse_blocks) {
+                                                int max_reuse_blocks, size_t content_salt) {
     const int num_tokens = static_cast<int>(tokens.size());
     if (num_tokens <= 0)
         return 0;
@@ -486,7 +487,7 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
 
     auto& hashes = seq_block_hashes_[seq_id];
     int reused_blocks = 0;
-    size_t parent_hash = 0;
+    size_t parent_hash = content_salt;
     // Reuse must form a contiguous prefix: once a block misses (or the
     // caller's cap is reached), later hash hits must NOT be shared — the
     // caller skips prefill for reused*block_size tokens, so a hole would
@@ -591,7 +592,7 @@ int KVCacheManager::allocate_blocks_with_prefix(int seq_id, std::span<const int3
     return reused_blocks;
 }
 
-void KVCacheManager::register_block_hashes(int seq_id, std::span<const int32_t> tokens) {
+void KVCacheManager::register_block_hashes(int seq_id, std::span<const int32_t> tokens, size_t content_salt) {
     const int num_tokens = static_cast<int>(tokens.size());
     if (!prefix_caching_enabled_)
         return;
@@ -604,7 +605,7 @@ void KVCacheManager::register_block_hashes(int seq_id, std::span<const int32_t> 
     int total_blocks = static_cast<int>(blocks.size());
 
     auto& hashes = seq_block_hashes_[seq_id];
-    size_t parent_hash = 0;
+    size_t parent_hash = content_salt;
 
     for (int b = 0; b < total_blocks; ++b) {
         int block_start = b * cache_->block_size();

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -91,21 +91,29 @@ public:
     // the recurrent-snapshot boundary so prefill never re-writes shared
     // blocks beyond the restorable state position.
     // Returns -1 on allocation failure.
+    //
+    // `content_salt` seeds the hash chain. It exists because the cache is
+    // addressed by TOKEN IDS, and that is not enough for a multimodal prompt:
+    // every image token carries the same id, so two requests with different
+    // pictures produce identical prefixes and the second one would inherit the
+    // first one's KV. Passing a hash of the image content makes the two chains
+    // diverge from block 0, so a hit requires the same tokens AND the same
+    // picture. 0 for text, which is the unchanged behaviour.
     [[nodiscard]] int allocate_blocks_with_prefix(int seq_id, std::span<const int32_t> tokens,
-                                                  int max_reuse_blocks = -1);
+                                                  int max_reuse_blocks = -1, size_t content_salt = 0);
 
     // Read-only probe: length (in blocks) of the longest fully-cached
     // contiguous block prefix for `tokens`, without allocating anything.
     // Fills `chain_hashes` with the chained hash of every FULL block of
     // `tokens` (independent of cache state). Used by the hybrid recurrent-
     // snapshot lookup to pick a restore boundary before allocation.
-    int longest_cached_prefix_blocks(std::span<const int32_t> tokens,
-                                     std::vector<size_t>& chain_hashes) const;
+    int longest_cached_prefix_blocks(std::span<const int32_t> tokens, std::vector<size_t>& chain_hashes,
+                                     size_t content_salt = 0) const;
 
     // Register the block hashes for a sequence after prefill completes.
     // This must be called so that future sequences can match against
     // these blocks. `tokens` is the full token sequence.
-    void register_block_hashes(int seq_id, std::span<const int32_t> tokens);
+    void register_block_hashes(int seq_id, std::span<const int32_t> tokens, size_t content_salt = 0);
 
     // Number of cached (unreferenced) blocks in the hash table.
     int num_cached_blocks() const;

--- a/src/model/image_placeholders.cpp
+++ b/src/model/image_placeholders.cpp
@@ -41,4 +41,13 @@ bool expand_image_placeholders(std::vector<int32_t>& tokens, int32_t pad_id, con
     return true;
 }
 
+size_t image_content_hash(const uint8_t* data, size_t len) {
+    size_t h = 0xcbf29ce484222325ULL;
+    for (size_t i = 0; i < len; ++i) {
+        h ^= data[i];
+        h *= 0x100000001b3ULL;
+    }
+    return h ? h : 1;  // 0 is the cache's "no image" sentinel
+}
+
 }  // namespace imp

--- a/src/model/image_placeholders.h
+++ b/src/model/image_placeholders.h
@@ -23,4 +23,9 @@ namespace imp {
 bool expand_image_placeholders(std::vector<int32_t>& tokens, int32_t pad_id, const std::vector<int>& counts,
                                std::string& err);
 
+// FNV-1a over an image's bytes. Used as the prefix cache's content salt, so a
+// hit needs the same tokens AND the same picture. Never returns 0 — that value
+// means "no image" to the cache, and an all-zero image must not claim it.
+size_t image_content_hash(const uint8_t* data, size_t len);
+
 }  // namespace imp

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -633,6 +633,9 @@ private:
     // CLI only: one image, preprocessed on the caller's thread, waiting for the
     // next request that has placeholders for it.
     std::shared_ptr<QwenPatches> qwen_pending_patches_;
+    // Hash of the image currently pending on the engine (the CLI's single
+    // image), stamped onto the request that picks it up.
+    size_t pending_image_hash_ = 0;
     int32_t qwen_image_pad_id_ = -1;
     // Constraint FSM state lives per-request (Request::constraints) — a
     // single engine-global manager let any concurrent prefill/finish clobber

--- a/src/runtime/engine_qwen3vl.cpp
+++ b/src/runtime/engine_qwen3vl.cpp
@@ -17,6 +17,7 @@
 #include "core/logging.h"
 #include "exec/inference_state.h"
 #include "runtime/engine_internal.h"
+#include "model/image_placeholders.h"
 #include "model/mrope_positions.h"
 #include "runtime/request.h"
 
@@ -186,13 +187,18 @@ bool Engine::set_image_from_memory(const uint8_t* data, size_t len) {
         if (!qwen_vision_.preprocess(data, len, *patches))
             return false;
         qwen_pending_patches_ = std::move(patches);
+        pending_image_hash_ = image_content_hash(data, len);
         return true;
     }
+    // The mmproj path stores its image inside VisionPipeline, but the hash has
+    // to reach the request either way — see the note at the prefill guard.
+    pending_image_hash_ = image_content_hash(data, len);
     return vision_.set_image_from_memory(data, len, stream_);
 }
 
 void Engine::clear_image() {
     qwen_pending_patches_.reset();
+    pending_image_hash_ = 0;
     vision_.clear_image();
 }
 
@@ -313,7 +319,9 @@ bool Engine::attach_qwen_image_(Request& req) {
     if (!has_pad)
         return false;  // this prompt has no image; the pending one may be a later request's
     req.qwen_patches = std::move(qwen_pending_patches_);
+    req.vision_content_hash = pending_image_hash_;
     qwen_pending_patches_.reset();
+    pending_image_hash_ = 0;
     return true;
 }
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -491,17 +491,18 @@ bool Engine::prefill_allocate_kv_blocks_(std::shared_ptr<Request>& req, int kv_b
     // Embedding requests mean-pool EVERY position's hidden state — a
     // prefix-cache hit would skip the reused prefix's forward and silently
     // bias the pooled vector (#1005). Same class as the ppl_capture guard.
-    // Image requests are the third member of that class, and the sharpest: the
-    // prefix cache is content-addressed on TOKEN IDS, and every image token
-    // carries the SAME id (<|image_pad|> / the soft token). Two requests with
-    // different pictures therefore produce identical prefixes, and the second
-    // one silently answers about the first one's image. Observed: a photo of a
-    // pizza described as "a tabby cat sitting outdoors". Applies to the mmproj
-    // path too, not just Qwen3-VL — the ids are just as uniform there.
+    // An image request participates only through its content hash: the cache is
+    // addressed by TOKEN IDS, every image token carries the SAME id, and two
+    // different pictures would otherwise share a long prefix and the second one
+    // would answer about the first one's picture. A request that carries an
+    // image but reports no hash is excluded outright — a missed plumbing site
+    // must degrade to "no reuse", never to "the previous picture".
     const bool has_image = req->image || req->qwen_patches || req->vision_emb || req->n_vision_tokens > 0;
+    const bool cacheable = !has_image || req->vision_content_hash != 0;
     if (kv_manager_->prefix_caching_enabled() && existing == 0 && offset == 0 && !ppl_capture_.active &&
-        !req->embedding_request && !has_image) {
-        prefix_reused = kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens);
+        !req->embedding_request && cacheable) {
+        prefix_reused = kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens, -1,
+                                                                 req->vision_content_hash);
         if (prefix_reused < 0) {
             // KV exhausted even after cached-block reclamation. The old fallback
             // evicted live sequences (every lru_order_ entry is live; no
@@ -828,8 +829,15 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
     // layout needs the prompt's final token sequence, which only exists now.
     // The CLI leaves its image pending on the engine; the server puts it on the
     // request itself. Both end up in `encode_qwen_image_for_`.
-    if (offset == 0)
+    if (offset == 0) {
         (void)attach_qwen_image_(*req);
+        // The legacy global-image path (imp_set_image + the mmproj pipeline)
+        // never puts anything on the request, so the prefix-cache guard below
+        // cannot see it. Stamp the hash here, or an interactive session that
+        // switches pictures would match the previous one's blocks.
+        if (req->vision_content_hash == 0 && vision_.has_input() && vision_.is_available())
+            req->vision_content_hash = pending_image_hash_;
+    }
     // Not gated on `offset == 0`: `qwen_patches` is cleared by the encode, so
     // this runs exactly once regardless of how the prompt is chunked.
     {
@@ -1166,13 +1174,11 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
             finish_request(req);
         } else {
             req->status = RequestStatus::DECODING;
-            // Publishing is as unsound as reading for an image request: these
-            // blocks would be offered to any later prompt with the same token
-            // ids, and every image token has the SAME id. A text request that
-            // happens to share the prefix would inherit a picture's KV.
+            // Publish under the same salt these blocks were looked up with, so
+            // they can only ever be offered to a prompt with the same picture.
             const bool had_image = req->n_vision_tokens > 0 || req->image || req->vision_emb;
-            if (kv_manager_->prefix_caching_enabled() && !had_image) {
-                kv_manager_->register_block_hashes(req->id, req->input_tokens);
+            if (kv_manager_->prefix_caching_enabled() && (!had_image || req->vision_content_hash != 0)) {
+                kv_manager_->register_block_hashes(req->id, req->input_tokens, req->vision_content_hash);
             }
         }
     }

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -254,6 +254,13 @@ struct Request {
     // `deepstack_emb` on admission and clears it. Per-request rather than
     // engine-global because the server admits image requests concurrently.
     std::shared_ptr<QwenPatches> qwen_patches;
+    // Hash of this request's image bytes, seeded into the prefix cache's block
+    // chain. Without it the cache matches on token ids alone, and every image
+    // token has the same id — so a second request would inherit the first
+    // one's picture. Non-zero whenever the request carries an image; a request
+    // that has one but reports 0 is refused the cache entirely, so a missed
+    // plumbing site degrades to "no reuse" instead of "wrong picture".
+    size_t vision_content_hash = 0;
     // `deepstack_emb` holds one buffer per vision tap, each the same
     // shape as `vision_emb`; they are ADDED at the LM's first layers.
     std::vector<std::shared_ptr<Buffer>> deepstack_emb;

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -72,22 +72,22 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
                 }
                 // Reserve blocks, using prefix caching when enabled.
                 //
-                // An image request is excluded, and the reason is not caution:
-                // the prefix cache is content-addressed on TOKEN IDS, and every
-                // image token carries the SAME id (<|image_pad|> / the soft
-                // token). Two requests with different pictures therefore share
-                // a long identical prefix, and the second one silently answers
-                // about the first one's image. Observed: a pizza described as
-                // "a tabby cat sitting outdoors". Holds for the mmproj path
-                // too — its ids are just as uniform.
+                // An image request participates only through its content hash:
+                // the cache is addressed by TOKEN IDS, every image token carries
+                // the SAME id, and two different pictures would otherwise share
+                // a long prefix. A request that carries an image but reports no
+                // hash is excluded outright, so a missed plumbing site degrades
+                // to "no reuse" rather than "the previous picture".
                 const bool has_image = req->image || req->qwen_patches || req->vision_emb ||
                                        req->n_vision_tokens > 0;
-                if (kv_manager_->prefix_caching_enabled() && !has_image) {
+                const bool cacheable = !has_image || req->vision_content_hash != 0;
+                if (kv_manager_->prefix_caching_enabled() && cacheable) {
                     // Hybrid models cap reuse at the recurrent-snapshot
                     // boundary (and attach the snapshot to the request).
                     int max_reuse = prefix_reuse_limit_ ? prefix_reuse_limit_(*req) : -1;
-                    int reused =
-                        kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens, max_reuse);
+                    int reused = kv_manager_->allocate_blocks_with_prefix(req->id, req->input_tokens,
+                                                                          max_reuse,
+                                                                          req->vision_content_hash);
                     if (reused < 0) {
                         ++it;
                         continue;

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -208,6 +208,10 @@ bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, Ch
             res.set_content(dump_safe(error), "application/json");
             return false;
         };
+        // Salts the prefix cache so a hit needs the same picture, not just the
+        // same token ids (every image token shares one id).
+        ctx.snap.vision_content_hash = imp::image_content_hash(ctx.params.image_data.data(),
+                                                               ctx.params.image_data.size());
         if (state.ctx->engine->has_qwen_vision()) {
             // Dynamic resolution: patchify now (CPU only) so the token count is
             // known before the prompt is tokenized — the placeholders have to be
@@ -580,6 +584,7 @@ std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
     auto req = std::make_shared<imp::Request>();
     req->image = ctx.snap.vision_image;         // per-request vision (null for text)
     req->qwen_patches = ctx.snap.qwen_patches;  // dynamic-resolution route (null otherwise)
+    req->vision_content_hash = ctx.snap.vision_content_hash;
     req->input_tokens = input_tokens;
     req->max_tokens = ctx.params.max_tokens;
     req->temperature = ctx.params.temperature;

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -120,6 +120,7 @@ struct ChatStateSnapshot {
     // the prompt has to reserve exactly that many placeholders.
     std::shared_ptr<imp::QwenPatches> qwen_patches;
     int qwen_image_tokens = 0;
+    size_t vision_content_hash = 0;
     std::vector<int32_t> stop_token_ids;
     imp::ChatTemplateFamily tpl_family = imp::ChatTemplateFamily::CHATML;
     std::vector<imp::ToolFunction> tool_defs;


### PR DESCRIPTION
#1179 excluded image requests from prefix caching, because the cache is content-addressed on **token ids** and every image token carries the same id — two requests with different pictures shared a prefix, and the second answered about the first one's image. That closed the correctness hole but cost the most common vision workload: asking follow-up questions about one picture re-prefilled the whole image every turn.

## The fix

The block hash already chains from a parent hash. Seeding that chain with a hash of the image bytes makes the two chains diverge from block 0, so **a hit needs the same tokens AND the same picture**. Nothing else about the hashing changes, and text keeps a zero salt — its behaviour is bit-identical.

Measured on the staged `Qwen3-VL-4B-Instruct`, over HTTP:

| request | `cached_tokens` | answer |
|---|---:|---|
| cat #1 | 0 | "This is a cat…" |
| cat #2 | **976** | "This is a cat…" |
| pizza #1 | **0** | "This is a pizza…" |
| pizza #2 | **768** | "This is a pizza…" |
| cat #3 | **976** | "This is a cat…" |

Same picture reuses; different picture does not; alternating works.

## The safety net stays

A request that carries an image but reports **no** hash is refused the cache outright. A plumbing site someone forgets therefore degrades to *"no reuse"*, never to *"the previous picture"* — the failure mode this whole thread has been about.

That guard is also why the **legacy global-image path** (`imp_set_image` + the mmproj pipeline) needs explicit handling: it stores the image inside `VisionPipeline` and puts nothing on the request, so the guard cannot see it. The hash is stamped onto the request at admission instead. Without that, an interactive session switching pictures would still match the old blocks — a pre-existing hole this PR closes rather than inherits.

## Regression

| Check | Result |
|---|---|
| test-core / compute / attention / kv / quant / text / moe-gdn / e2e | all green |
| `degen_suite.py` vs served Qwen3-4B-Q8 | 34 checks, 0 FAIL |
| 4 concurrent image requests + 1 text request | all correct |
| Text prefix caching | unchanged — 400 cached tokens on a repeated text prompt |
| File size / alloc sites | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJoZy798rnWiuDrGFgSMT8