### PR TITLE
fix(vision): two ways an image was silently not the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ there instead of retelling it.
   violation.
 
 ### Fixed
+- **An image that spanned a prefill chunk boundary got the wrong half of
+  itself.** Both vision kernels find "the k-th image token" by scanning the span
+  they are handed, which under chunked prefill is one chunk — so a second chunk
+  restarted at the image's *first* embeddings. Reachable on defaults (chunks are
+  2048 and Qwen3's FP8-KV path is chunk-eligible) as soon as enough text precedes
+  the picture. Pinned by `tests/test_vision_chunk_offset.cu`.
+- **`/image` in the interactive CLI loaded a picture the prompt never
+  referenced.** The multi-turn path branched on the mmproj tower alone, so on
+  Qwen3-VL it rendered a prompt with no image tokens: "Image loaded", then an
+  answer given as if there were no image.
 - **`imp-quantize` silently produced a broken MoE checkpoint.** "MoE is left
   unquantized" only ever applied to 3-D stacked tensors; the HF-standard
   per-expert 2-D layout was quantized and produced a model that loaded and then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,6 +817,7 @@ if(IMP_BUILD_TESTS)
         tests/test_prefix_cache_e2e.cpp
         tests/test_determinism_e2e.cpp
         tests/test_deepstack_inject.cu
+        tests/test_vision_chunk_offset.cu
         tests/test_vision_golden.cu
         tests/test_qwen3vl_encoder.cu
         tests/test_qwen3vl_pipeline.cu

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -306,10 +306,10 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         extern void launch_replace_vision_embeddings(half * hidden, const int32_t* token_ids,
                                                      const half* vision_emb, int vision_token_id,
                                                      int n_tokens, int d_model, int n_vision_tokens,
-                                                     cudaStream_t stream);
+                                                     int emb_offset, cudaStream_t stream);
         launch_replace_vision_embeddings(static_cast<half*>(h.data), state.token_ids, state.vision_embeddings,
                                          state.vision_token_id, n, cfg.d_model, state.n_vision_tokens,
-                                         stream);
+                                         state.vision_emb_offset, stream);
     }
 
     debug_tensor_stats("after_embedding", h, stream);
@@ -546,7 +546,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             state.n_vision_tokens > 0 && state.vision_token_id >= 0 && h.qtype == QType::F16) {
             launch_add_vision_embeddings(static_cast<half*>(h.data), state.token_ids,
                                          state.deepstack_embeddings[i], state.vision_token_id, n, cfg.d_model,
-                                         state.n_vision_tokens, stream);
+                                         state.n_vision_tokens, state.vision_emb_offset, stream);
         }
 
         if (i == max_layer - 1) {

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -158,7 +158,13 @@ struct InferenceState {
     // Vision: when non-null, replace vision_token_id positions with vision embeddings
     const half* vision_embeddings = nullptr;  // [n_vision_tokens, d_model] FP16 on device
     int vision_token_id = -1;                 // <image_soft_token> ID
-    int n_vision_tokens = 0;                  // 256
+    int n_vision_tokens = 0;                  // total in the buffer, across all chunks
+
+    // How many image tokens EARLIER chunks already placed. `token_ids` is one
+    // chunk, so without this the k-th placeholder of a later chunk would take
+    // the k-th embedding of the image — the wrong picture region, silently.
+    // Zero whenever the prompt is prefilled in one go.
+    int vision_emb_offset = 0;
 
     // DeepStack (Qwen3-VL): extra visual features ADDED at the image-token
     // positions after each of the LM's first `n_deepstack` layers. Indexed by

--- a/src/model/image_placeholders.cpp
+++ b/src/model/image_placeholders.cpp
@@ -1,5 +1,7 @@
 #include "model/image_placeholders.h"
 
+#include <algorithm>
+
 namespace imp {
 
 bool expand_image_placeholders(std::vector<int32_t>& tokens, int32_t pad_id, const std::vector<int>& counts,
@@ -48,6 +50,16 @@ size_t image_content_hash(const uint8_t* data, size_t len) {
         h *= 0x100000001b3ULL;
     }
     return h ? h : 1;  // 0 is the cache's "no image" sentinel
+}
+
+int image_tokens_before(const std::vector<int32_t>& tokens, int32_t pad_id, int upto) {
+    if (upto <= 0)
+        return 0;
+    const size_t end = std::min(static_cast<size_t>(upto), tokens.size());
+    int n = 0;
+    for (size_t i = 0; i < end; ++i)
+        n += (tokens[i] == pad_id);
+    return n;
 }
 
 }  // namespace imp

--- a/src/model/image_placeholders.h
+++ b/src/model/image_placeholders.h
@@ -28,4 +28,11 @@ bool expand_image_placeholders(std::vector<int32_t>& tokens, int32_t pad_id, con
 // means "no image" to the cache, and an all-zero image must not claim it.
 size_t image_content_hash(const uint8_t* data, size_t len);
 
+// How many image tokens sit before `upto` — the embedding index a chunk
+// starting there must resume from. The vision kernels scan the chunk they are
+// handed, so without this a run of image tokens crossing a chunk boundary
+// silently restarts at the image's first embedding. `upto` is clamped, so a
+// prefix-cache offset past the prompt is not a special case for the caller.
+int image_tokens_before(const std::vector<int32_t>& tokens, int32_t pad_id, int upto);
+
 }  // namespace imp

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -26,6 +26,7 @@
 #include "runtime/batch.h"
 #include "runtime/think_stop_logic.h"
 #include "compute/mtp_forward.h"
+#include "model/image_placeholders.h"
 #include "memory/kv_cache.h"
 #include "compute/sampling.h"
 #include "compute/layernorm.h"
@@ -859,6 +860,14 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
         state.vision_embeddings = req->vision_emb->as<half>();
         state.vision_token_id = req->vision_token_id;
         state.n_vision_tokens = req->n_vision_tokens;
+        // The kernels index placeholders within the chunk they are handed, so
+        // they need to know how many this request already placed. A long enough
+        // prompt puts an image across a chunk boundary (chunks default to 2048),
+        // and without this the second chunk would re-use the image's FIRST
+        // embeddings — the wrong region of the picture, with nothing failing.
+        // Counted over the whole prompt so a prefix-cache hit, which starts at
+        // `cached_tokens`, is covered by the same arithmetic.
+        state.vision_emb_offset = image_tokens_before(req->input_tokens, req->vision_token_id, offset);
         state.n_deepstack = std::min<int>(static_cast<int>(req->deepstack_emb.size()),
                                           InferenceState::kMaxDeepStack);
         for (int d = 0; d < state.n_deepstack; ++d)

--- a/src/vision/deepstack_inject.cu
+++ b/src/vision/deepstack_inject.cu
@@ -12,9 +12,12 @@ namespace {
 // way to keep them from drifting apart.
 __global__ void add_vision_embeddings_kernel(half* __restrict__ hidden, const int32_t* __restrict__ token_ids,
                                              const half* __restrict__ embeddings, int vision_token_id,
-                                             int n_tokens, int d_model, int n_vision_tokens) {
+                                             int n_tokens, int d_model, int n_vision_tokens, int emb_offset) {
+    // Placeholder index within this call's token span; the embedding it wants
+    // sits `emb_offset` further into the buffer (see the header).
     const int vision_idx = blockIdx.x;
-    if (vision_idx >= n_vision_tokens)
+    const int emb_idx = vision_idx + emb_offset;
+    if (emb_idx >= n_vision_tokens)
         return;
 
     int count = 0;
@@ -36,7 +39,7 @@ __global__ void add_vision_embeddings_kernel(half* __restrict__ hidden, const in
     for (int d = threadIdx.x; d < d_model; d += blockDim.x) {
         const int64_t at = static_cast<int64_t>(token_pos) * d_model + d;
         hidden[at] = __float2half(__half2float(hidden[at]) +
-                                  __half2float(embeddings[static_cast<int64_t>(vision_idx) * d_model + d]));
+                                  __half2float(embeddings[static_cast<int64_t>(emb_idx) * d_model + d]));
     }
 }
 
@@ -44,12 +47,17 @@ __global__ void add_vision_embeddings_kernel(half* __restrict__ hidden, const in
 
 void launch_add_vision_embeddings(half* hidden, const int32_t* token_ids, const half* embeddings,
                                   int vision_token_id, int n_tokens, int d_model, int n_vision_tokens,
-                                  cudaStream_t stream) {
+                                  int emb_offset, cudaStream_t stream) {
     if (n_vision_tokens <= 0 || !embeddings || !token_ids)
         return;
-    add_vision_embeddings_kernel<<<n_vision_tokens, 256, 0, stream>>>(hidden, token_ids, embeddings,
-                                                                      vision_token_id, n_tokens, d_model,
-                                                                      n_vision_tokens);
+    // Everything from emb_offset on is still unwritten; blocks past that would
+    // only read out of bounds.
+    const int remaining = n_vision_tokens - emb_offset;
+    if (emb_offset < 0 || remaining <= 0)
+        return;
+    add_vision_embeddings_kernel<<<remaining, 256, 0, stream>>>(hidden, token_ids, embeddings,
+                                                                vision_token_id, n_tokens, d_model,
+                                                                n_vision_tokens, emb_offset);
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/src/vision/deepstack_inject.h
+++ b/src/vision/deepstack_inject.h
@@ -18,12 +18,18 @@
 
 namespace imp {
 
-// hidden[p, :] += embeddings[k, :] for the k-th token whose id is
-// `vision_token_id`. `n_vision_tokens` bounds k, so a prompt with more
-// placeholders than the encoder produced leaves the surplus untouched rather
-// than reading past the buffer.
+// hidden[p, :] += embeddings[emb_offset + k, :] for the k-th token in THIS call
+// whose id is `vision_token_id`. `n_vision_tokens` bounds `emb_offset + k`, so a
+// prompt with more placeholders than the encoder produced leaves the surplus
+// untouched rather than reading past the buffer.
+//
+// `emb_offset` is how many image tokens the caller already consumed. Under
+// chunked prefill `token_ids` is one CHUNK, so the k-th placeholder in a later
+// chunk is NOT the k-th of the image — without the offset a run of image tokens
+// that straddles a chunk boundary gets the FIRST embeddings again in the second
+// chunk, which is silently the wrong picture rather than a crash.
 void launch_add_vision_embeddings(half* hidden, const int32_t* token_ids, const half* embeddings,
                                   int vision_token_id, int n_tokens, int d_model, int n_vision_tokens,
-                                  cudaStream_t stream);
+                                  int emb_offset, cudaStream_t stream);
 
 }  // namespace imp

--- a/src/vision/vision_encoder.cu
+++ b/src/vision/vision_encoder.cu
@@ -356,10 +356,14 @@ __global__ void mul_tensors_kernel(const half* __restrict__ a, const half* __res
 __global__ void replace_vision_embeddings_v2_kernel(half* __restrict__ hidden,
                                                     const int32_t* __restrict__ token_ids,
                                                     const half* __restrict__ vision_emb, int vision_token_id,
-                                                    int n_tokens, int d_model, int n_vision_tokens) {
-    // blockIdx.x = sequential vision token index
+                                                    int n_tokens, int d_model, int n_vision_tokens,
+                                                    int emb_offset) {
+    // blockIdx.x = vision token index within THIS call's token span. Under
+    // chunked prefill that span is one chunk, so the embedding this position
+    // wants sits `emb_offset` further into the buffer.
     int vision_idx = blockIdx.x;
-    if (vision_idx >= n_vision_tokens)
+    int emb_idx = vision_idx + emb_offset;
+    if (emb_idx >= n_vision_tokens)
         return;
 
     // Find the vision_idx-th occurrence of vision_token_id
@@ -379,7 +383,7 @@ __global__ void replace_vision_embeddings_v2_kernel(half* __restrict__ hidden,
 
     // Copy vision embedding into hidden state
     for (int d = threadIdx.x; d < d_model; d += blockDim.x) {
-        hidden[token_pos * d_model + d] = vision_emb[vision_idx * d_model + d];
+        hidden[token_pos * d_model + d] = vision_emb[emb_idx * d_model + d];
     }
 }
 
@@ -940,14 +944,19 @@ bool VisionEncoder::encode_impl_gemma4v(const half* d_pixels, half* d_output, cu
 }
 
 // ---- Public kernel launcher for embedding replacement ----
+// `emb_offset` is how many image tokens earlier chunks already placed; see
+// vision/deepstack_inject.h, whose kernel has to agree with this one.
 void launch_replace_vision_embeddings(half* hidden, const int32_t* token_ids, const half* vision_emb,
                                       int vision_token_id, int n_tokens, int d_model, int n_vision_tokens,
-                                      cudaStream_t stream) {
+                                      int emb_offset, cudaStream_t stream) {
     if (n_vision_tokens <= 0)
         return;
-    replace_vision_embeddings_v2_kernel<<<n_vision_tokens, 256, 0, stream>>>(hidden, token_ids, vision_emb,
-                                                                             vision_token_id, n_tokens,
-                                                                             d_model, n_vision_tokens);
+    const int remaining = n_vision_tokens - emb_offset;
+    if (emb_offset < 0 || remaining <= 0)
+        return;
+    replace_vision_embeddings_v2_kernel<<<remaining, 256, 0, stream>>>(hidden, token_ids, vision_emb,
+                                                                       vision_token_id, n_tokens, d_model,
+                                                                       n_vision_tokens, emb_offset);
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/tests/test_deepstack_inject.cu
+++ b/tests/test_deepstack_inject.cu
@@ -49,7 +49,8 @@ InjectResult inject(const std::vector<int32_t>& tokens, const std::vector<float>
         cudaMemcpy(d_e, e.data(), e.size() * sizeof(half), cudaMemcpyHostToDevice);
     cudaMemcpy(d_t, tokens.data(), tokens.size() * sizeof(int32_t), cudaMemcpyHostToDevice);
 
-    launch_add_vision_embeddings(d_h, d_t, d_e, kImageToken, n, kD, n_vision_tokens, nullptr);
+    launch_add_vision_embeddings(d_h, d_t, d_e, kImageToken, n, kD, n_vision_tokens, /*emb_offset=*/0,
+                                 nullptr);
     EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
     cudaMemcpy(h.data(), d_h, h.size() * sizeof(half), cudaMemcpyDeviceToHost);

--- a/tests/test_image_placeholders.cpp
+++ b/tests/test_image_placeholders.cpp
@@ -89,5 +89,31 @@ TEST(ImagePlaceholders, HandlesAdjacentPlaceholders) {
     EXPECT_EQ(t.size(), 4u);
 }
 
+// `image_tokens_before` is where a chunk learns which embedding to resume from.
+// Off by one here is not a crash — it shifts the whole rest of the image by one
+// position, which reads as a slightly wrong answer.
+TEST(ImageTokensBefore, CountsOnlyWhatPrecedesTheChunk) {
+    //                             0     1     2     3     4     5
+    const std::vector<int32_t> t = {9, kPad, kPad, 8, kPad, 7};
+    EXPECT_EQ(image_tokens_before(t, kPad, 0), 0) << "the first chunk resumes from nothing";
+    EXPECT_EQ(image_tokens_before(t, kPad, 1), 0) << "the boundary token itself is not yet placed";
+    EXPECT_EQ(image_tokens_before(t, kPad, 2), 1);
+    EXPECT_EQ(image_tokens_before(t, kPad, 3), 2);
+    EXPECT_EQ(image_tokens_before(t, kPad, 5), 3);
+    EXPECT_EQ(image_tokens_before(t, kPad, 6), 3) << "whole prompt";
+}
+
+TEST(ImageTokensBefore, ClampsRatherThanReadingPastTheEnd) {
+    const std::vector<int32_t> t = {kPad, 5};
+    EXPECT_EQ(image_tokens_before(t, kPad, 99), 1);
+    EXPECT_EQ(image_tokens_before(t, kPad, -3), 0);
+    EXPECT_EQ(image_tokens_before({}, kPad, 4), 0);
+}
+
+TEST(ImageTokensBefore, TextOnlyPromptsResumeFromZero) {
+    const std::vector<int32_t> t = {1, 2, 3, 4};
+    EXPECT_EQ(image_tokens_before(t, kPad, 4), 0);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tests/test_vision_chunk_offset.cu
+++ b/tests/test_vision_chunk_offset.cu
@@ -1,0 +1,200 @@
+// Image tokens under CHUNKED prefill.
+//
+// Both vision kernels are handed one chunk at a time and locate "the k-th
+// placeholder" by scanning the token ids they were given. That span is the
+// chunk, not the prompt, so on its own the k-th placeholder of a second chunk
+// looks like the k-th placeholder of the image. It is not — and taking the
+// image's first embeddings again is the wrong region of the picture, produced
+// silently: no error, no crash, a model that still answers.
+//
+// Chunked prefill is reachable with defaults here (chunk size 2048, and
+// `supports_chunked_prefill_` admits Qwen3 with FP8 KV, which is the default KV
+// dtype for that family), so a prompt with enough text before its image puts an
+// image run across a boundary.
+//
+// The guard is `emb_offset`: how many image tokens earlier chunks consumed.
+// Both kernels have to agree on it, which is why they are tested together.
+
+#include "vision/deepstack_inject.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace imp {
+
+// Declared where it is used (src/exec/executor_forward.cu); no header.
+void launch_replace_vision_embeddings(half* hidden, const int32_t* token_ids, const half* vision_emb,
+                                      int vision_token_id, int n_tokens, int d_model, int n_vision_tokens,
+                                      int emb_offset, cudaStream_t stream);
+
+namespace {
+
+constexpr int kD = 4;
+constexpr int kImg = 42;
+
+bool gpu_available() {
+    int n = 0;
+    return cudaGetDeviceCount(&n) == cudaSuccess && n > 0;
+}
+
+// One embedding per image token, each filled with a distinct value, so a wrong
+// index is visible as a wrong number rather than as noise.
+std::vector<float> distinct_embeddings(int n_vision_tokens) {
+    std::vector<float> e(static_cast<size_t>(n_vision_tokens) * kD);
+    for (int k = 0; k < n_vision_tokens; ++k)
+        for (int d = 0; d < kD; ++d)
+            e[static_cast<size_t>(k) * kD + d] = 1.0f + static_cast<float>(k);
+    return e;
+}
+
+enum class Op { Replace, Add };
+
+// Run one chunk through one of the two kernels and return the hidden state.
+std::vector<float> run_chunk(Op op, const std::vector<int32_t>& chunk_tokens,
+                             const std::vector<float>& hidden_in, const std::vector<float>& emb,
+                             int n_vision_tokens, int emb_offset) {
+    const int n = static_cast<int>(chunk_tokens.size());
+    std::vector<half> h(hidden_in.size()), e(emb.size());
+    for (size_t i = 0; i < hidden_in.size(); ++i)
+        h[i] = __float2half(hidden_in[i]);
+    for (size_t i = 0; i < emb.size(); ++i)
+        e[i] = __float2half(emb[i]);
+
+    half *d_h = nullptr, *d_e = nullptr;
+    int32_t* d_t = nullptr;
+    EXPECT_EQ(cudaMalloc(&d_h, h.size() * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&d_e, e.size() * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&d_t, chunk_tokens.size() * sizeof(int32_t)), cudaSuccess);
+    cudaMemcpy(d_h, h.data(), h.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_e, e.data(), e.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_t, chunk_tokens.data(), chunk_tokens.size() * sizeof(int32_t), cudaMemcpyHostToDevice);
+
+    if (op == Op::Replace)
+        launch_replace_vision_embeddings(d_h, d_t, d_e, kImg, n, kD, n_vision_tokens, emb_offset, nullptr);
+    else
+        launch_add_vision_embeddings(d_h, d_t, d_e, kImg, n, kD, n_vision_tokens, emb_offset, nullptr);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    cudaMemcpy(h.data(), d_h, h.size() * sizeof(half), cudaMemcpyDeviceToHost);
+    cudaFree(d_h);
+    cudaFree(d_e);
+    cudaFree(d_t);
+
+    std::vector<float> out(h.size());
+    for (size_t i = 0; i < h.size(); ++i)
+        out[i] = __half2float(h[i]);
+    return out;
+}
+
+// The prompt is [text, IMG, IMG, IMG, IMG, text] split after position 2, so the
+// image run straddles the boundary: 2 of its 4 tokens land in each chunk.
+struct SplitPrompt {
+    std::vector<int32_t> chunk0{7, kImg, kImg};
+    std::vector<int32_t> chunk1{kImg, kImg, 8};
+    int n_vision_tokens = 4;
+    int consumed_by_chunk0 = 2;
+};
+
+TEST(VisionChunkOffset, SecondChunkTakesTheEmbeddingsItsPositionsEarned) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const SplitPrompt p;
+    const auto emb = distinct_embeddings(p.n_vision_tokens);
+    const std::vector<float> hidden(p.chunk1.size() * kD, 0.0f);
+
+    const auto out = run_chunk(Op::Replace, p.chunk1, hidden, emb, p.n_vision_tokens, p.consumed_by_chunk0);
+
+    // Positions 0 and 1 of this chunk are the image's tokens 2 and 3.
+    for (int d = 0; d < kD; ++d) {
+        EXPECT_NEAR(out[0 * kD + d], 3.0f, 1e-3) << "took embedding 0 (the first chunk's) instead of 2";
+        EXPECT_NEAR(out[1 * kD + d], 4.0f, 1e-3) << "took embedding 1 (the first chunk's) instead of 3";
+        EXPECT_NEAR(out[2 * kD + d], 0.0f, 1e-3) << "text token was overwritten";
+    }
+}
+
+TEST(VisionChunkOffset, DeepStackFollowsTheSameOffset) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const SplitPrompt p;
+    const auto emb = distinct_embeddings(p.n_vision_tokens);
+    const std::vector<float> hidden(p.chunk1.size() * kD, 10.0f);
+
+    const auto out = run_chunk(Op::Add, p.chunk1, hidden, emb, p.n_vision_tokens, p.consumed_by_chunk0);
+
+    // An ADD, so 10 + the right embedding. The two kernels must not disagree
+    // about which position gets which feature, or DeepStack stacks a tap from
+    // one part of the image onto the embedding of another.
+    for (int d = 0; d < kD; ++d) {
+        EXPECT_NEAR(out[0 * kD + d], 13.0f, 2e-2) << "added embedding 0 instead of 2";
+        EXPECT_NEAR(out[1 * kD + d], 14.0f, 2e-2) << "added embedding 1 instead of 3";
+        EXPECT_NEAR(out[2 * kD + d], 10.0f, 2e-2) << "text token was touched";
+    }
+}
+
+// The first chunk is the case that already worked; it must keep working, since
+// offset 0 is what every unchunked prompt passes.
+TEST(VisionChunkOffset, FirstChunkIsUnchangedAtOffsetZero) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const SplitPrompt p;
+    const auto emb = distinct_embeddings(p.n_vision_tokens);
+    const std::vector<float> hidden(p.chunk0.size() * kD, 0.0f);
+
+    const auto out = run_chunk(Op::Replace, p.chunk0, hidden, emb, p.n_vision_tokens, 0);
+
+    for (int d = 0; d < kD; ++d) {
+        EXPECT_NEAR(out[0 * kD + d], 0.0f, 1e-3) << "text token was overwritten";
+        EXPECT_NEAR(out[1 * kD + d], 1.0f, 1e-3);
+        EXPECT_NEAR(out[2 * kD + d], 2.0f, 1e-3);
+    }
+}
+
+// Reassembling both chunks must reproduce the unchunked result exactly —
+// the property the offset exists to preserve.
+TEST(VisionChunkOffset, ChunkedMatchesUnchunked) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const SplitPrompt p;
+    const auto emb = distinct_embeddings(p.n_vision_tokens);
+
+    std::vector<int32_t> whole = p.chunk0;
+    whole.insert(whole.end(), p.chunk1.begin(), p.chunk1.end());
+    const std::vector<float> zero_whole(whole.size() * kD, 0.0f);
+    const auto unchunked = run_chunk(Op::Replace, whole, zero_whole, emb, p.n_vision_tokens, 0);
+
+    const std::vector<float> zero0(p.chunk0.size() * kD, 0.0f);
+    const std::vector<float> zero1(p.chunk1.size() * kD, 0.0f);
+    auto a = run_chunk(Op::Replace, p.chunk0, zero0, emb, p.n_vision_tokens, 0);
+    const auto b = run_chunk(Op::Replace, p.chunk1, zero1, emb, p.n_vision_tokens, p.consumed_by_chunk0);
+    a.insert(a.end(), b.begin(), b.end());
+
+    ASSERT_EQ(a.size(), unchunked.size());
+    for (size_t i = 0; i < a.size(); ++i)
+        EXPECT_NEAR(a[i], unchunked[i], 1e-3) << "chunked and unchunked disagree at " << i;
+}
+
+// A chunk whose image tokens are entirely behind us must not write at all,
+// rather than read past the embedding buffer.
+TEST(VisionChunkOffset, OffsetPastTheBufferWritesNothing) {
+    if (!gpu_available())
+        GTEST_SKIP() << "no CUDA device";
+
+    const std::vector<int32_t> tokens{kImg, kImg};
+    const auto emb = distinct_embeddings(2);
+    const std::vector<float> hidden(tokens.size() * kD, 5.0f);
+
+    const auto out = run_chunk(Op::Replace, tokens, hidden, emb, /*n_vision_tokens=*/2, /*emb_offset=*/2);
+
+    for (float v : out)
+        EXPECT_NEAR(v, 5.0f, 1e-3) << "wrote with nothing left to write";
+}
+
+}  // namespace
+}  // namespace imp

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -516,7 +516,7 @@ int main(int argc, char** argv) {
                 if (err != IMP_SUCCESS) {
                     fprintf(stderr, "Error loading image: %s\n", imp_error_string(err));
                 } else {
-                    printf("Image loaded: %s\n", img_path.c_str());
+                    printf("Image loaded: %s (applies to your next message)\n", img_path.c_str());
                 }
                 continue;
             }
@@ -525,7 +525,28 @@ int main(int argc, char** argv) {
                 // Multi-turn: append user message and apply full template
                 history.push_back({"user", input});
                 std::vector<int32_t> tokens;
-                if (ctx->engine->has_vision_input()) {
+                // Same three-way split as the single-prompt path below: a
+                // pending Qwen-VL image has a count only the encoder knows, an
+                // mmproj image has a fixed one, and most turns have neither.
+                // Testing only `has_vision_input()` here — which is the mmproj
+                // tower alone — rendered a prompt with no image tokens at all,
+                // so a picture loaded with /image was never referenced and the
+                // model answered as if it had not been given one.
+                const int pending_img_tokens = imp_pending_image_tokens(ctx);
+                if (pending_img_tokens > 0) {
+                    std::vector<imp::ChatMessage> msgs = history;
+                    msgs.back().content = "<|vision_start|><|image_pad|><|vision_end|>" + msgs.back().content;
+                    tokens = chat_tpl.apply(*tok, msgs);
+                    const int32_t pad_id = tok->find_token("<|image_pad|>");
+                    std::string exp_err;
+                    if (pad_id < 0 ||
+                        !imp::expand_image_placeholders(tokens, pad_id, {pending_img_tokens}, exp_err)) {
+                        fprintf(stderr, "Error placing image tokens: %s\n",
+                                pad_id < 0 ? "tokenizer has no <|image_pad|>" : exp_err.c_str());
+                        history.pop_back();
+                        continue;
+                    }
+                } else if (ctx->engine->has_vision_input()) {
                     tokens = chat_tpl.apply_with_image(*tok, history, 256);
                 } else {
                     tokens = chat_tpl.apply(*tok, history);


### PR DESCRIPTION
Two failures found while syncing the vision docs. Neither errors, crashes, or produces a shape mismatch — both leave a model that still answers.

### An image spanning a chunk boundary got the wrong half of itself

Both vision kernels locate "the k-th image token" by scanning the token ids they were handed. Under chunked prefill that span is one **chunk**, not the prompt — so the first placeholder of a second chunk looked like the first placeholder of the image and took embedding 0 again. A different region of the picture, written silently.

**Reachable on defaults, not theoretically:** chunks are 2048 and `supports_chunked_prefill_` admits `FP8_E4M3` KV, which is the default dtype for Qwen3. Any prompt with enough text before its picture straddles a boundary.

The M-RoPE binding right next door already handled this correctly — `bind_mrope_prefill_` indexes `mrope_positions` by `offset + i`. Only the embedding writes did not.

Both kernels now take `emb_offset` (how many image tokens earlier chunks consumed) and skip blocks with nothing left to write rather than reading past the buffer. It comes from `image_tokens_before()`, counted over the whole prompt so a prefix-cache hit starting at `cached_tokens` needs no special case.

### `/image` in the interactive CLI loaded a picture the prompt never referenced

The multi-turn branch tested `has_vision_input()` — the mmproj tower alone. On Qwen3-VL that is false, so it fell through to a plain template render: no image tokens in the prompt, the pending image never attached. The user got `Image loaded`, then an answer written as if there were none. The single-prompt path had the correct three-way split already; this mirrors it.

### Evidence

- `tests/test_vision_chunk_offset.cu` drives both kernels over a prompt split across a boundary and asserts chunked == unchunked.
- **Mutation-validated.** Reverting either kernel's index fails 3 of the 5 tests (the offset-0 and bounds cases correctly stay green); an off-by-one in `image_tokens_before` fails its counting test. Both mutations were asserted present before measuring.
- End to end on `Qwen3-VL-4B-Instruct`: 81-token prompt, 64 image tokens, `--prefill-chunk-size 48` so the boundary falls inside the image. The model still places the squares correctly ("one red in the upper left"). Not bit-identical to the unchunked run, which is expected for chunked prefill — that path has its own gate with looser thresholds.
- `make build` + `make verify-fast` against the freshly built image: decode +0.60%, prefill +0.22%, pp4096 +0.34%, peak VRAM +0.01%, degeneration smoke green.

Note for whoever hits this next: `verify-fast` re-execs into the `imp:test` container with `IMP_VERIFY_SKIP_BUILD=1`, so it measures whatever that image already holds. A pre-push run does **not** test the code being pushed unless `make build` ran first — two perf failures on this branch were the stale image plus host drift, and the numbers above are from a rebuilt one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B