### PR TITLE
docs: cut CLAUDE.md to what is not already in a skill

### DIFF
--- a/.claude/skills/building-and-testing/SKILL.md
+++ b/.claude/skills/building-and-testing/SKILL.md
@@ -52,6 +52,13 @@ runs the real CI lane (`ctest -L unit`). **But build the IMAGE for anything you 
 or push** — benchmarks, the perf gate and `verify-fast` must never read `build-dev/`,
 where a stale object would hide. `make dev-clean` removes it (root-owned; never `sudo`).
 
+**`verify-fast` does not build — it measures whatever `imp:test` already holds.** On a
+host without cmake it re-execs into that image with `IMP_VERIFY_SKIP_BUILD=1` and prints
+`SKIP build`. So a pre-push run does NOT test the code being pushed unless `make build`
+ran first: the gate can pass on code you deleted, or fail on a regression that is not
+yours. Read that `SKIP build` line before believing either result — a decode failure
+against a stale image is host drift by construction, since the binary did not change.
+
 **`make test-unit` is NOT the CI lane.** It runs `imp-tests-unit` (~37 tests); CI runs `ctest -L unit` → **`test-core`** (550+) + test-text + an e2e subset. A new CPU test belongs in `test-core`, and the honest no-GPU check is `docker run --rm imp:test test-core` (no `--gpus`). Green in `imp-tests-unit` says nothing about CI.
 
 Tool binaries in the image: `imp-server`, `imp-cli`, `imp-bench`, and `imp-quantize` (offline BF16/FP16 → NVFP4 conversion, experimental — see `quant-formats`). A new tool needs BOTH a `cp` in the builder stage and a `COPY --from=builder` line in the Dockerfile, or it silently isn't in the image.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,11 @@
 
 From-scratch C++23/CUDA LLM inference engine targeting **exactly one chip: NVIDIA Blackwell `sm_120a`** (RTX 5090 / GB202, 32 GB GDDR7, 1792 GB/s, native FP4 tensor cores). No portability layer, no FP16 dequant fallback in the hot path. ~100k LOC (src/ + include/). See [`docs/architecture.md`](docs/architecture.md) (canonical narrative) and [`docs/sm120.md`](docs/sm120.md).
 
+**This file is the router, not the manual.** It holds what applies to every task; the playbooks live in the skills below and are loaded on demand. If something here is also in a skill, the skill is the copy that gets maintained.
+
 ## Where to start (task → entry point)
 
-Match the task, invoke that skill first; the skills below are imp-specific and carry the detailed playbooks.
+Match the task, invoke that skill first.
 
 | Task | Start here |
 |------|-----------|
@@ -22,128 +24,74 @@ Match the task, invoke that skill first; the skills below are imp-specific and c
 
 Canonical references: `docs/architecture.md` (narrative), `docs/sm120.md` (hardware), `docs/MEMORY_ARCHITECTURE.md` (memory subsystem: tiers, allocators, invariants I1-I7), `AGENTS.md` (subagent roles + guardrails), `docs/BENCHMARKING.md` (measurement contract).
 
-## Memory work: two rules that cost real time when ignored
+## Two facts about this box that mislead rather than fail
 
-- **A successful `cudaMalloc` proves nothing about free VRAM on this box.** WDDM
-  oversubscribes into host memory and returns `cudaSuccess` — 28 GiB succeeds
-  with 22.6 GiB reported free. Measure *bandwidth* to tell resident from
-  spilled: ~1530 GB/s vs ~237 GB/s. That 6.5x cliff is the mechanism behind
-  #1103 (55 vs 391 tok/s), and it is why "0 MiB free" is a correctness problem
-  and not just a tight fit.
+- **A successful `cudaMalloc` proves nothing about free VRAM.** WDDM oversubscribes
+  into host memory and returns `cudaSuccess` — 28 GiB succeeds with 22.6 GiB
+  reported free. Measure *bandwidth* to tell resident from spilled: ~1530 vs
+  ~237 GB/s. That 6.5x cliff is the mechanism behind #1103 (55 vs 391 tok/s), so
+  "0 MiB free" is a correctness problem, not a tight fit.
 - **Free VRAM only ever decreases within a process.** WSL2/WDDM never returns a
-  process's peak commitment, even though every CUDA-level release succeeds. Any
-  sizing decision read from `cudaMemGetInfo` is reading a moving floor — which
-  is the whole argument for planning capacity instead of discovering it.
+  process's peak commitment, however cleanly CUDA released it. Anything sized off
+  `cudaMemGetInfo` is reading a moving floor — which is why capacity is planned,
+  not discovered.
 
 ## Build & test
 
-**Before using the GPU, ALWAYS check that it is free.** Run any GPU job (`make test-gpu`, benchmarks, profiling, inference) only after confirming no other process is using the card: `docker ps -q | wc -l` MUST be `0` and `nvidia-smi` must show no active compute processes (idle ~30°C, low power draw). A busy GPU corrupts benchmark numbers and can OOM; never start GPU work on a card that is already in use.
+**Before any GPU job — tests, benchmarks, profiling, inference — check the card is free.** `nvidia-smi` must show no compute processes. A busy GPU corrupts numbers and can OOM. Re-check before *each* job, not once per session.
 
-The host has **no CUDA toolkit** by design — build inside Docker. `build/` is created root-owned by the container; remove it via a throwaway container, never `sudo` on the host.
+The host has **no CUDA toolkit** by design — build inside Docker. `build/` and `build-dev/` are root-owned by the container; remove them via `make dev-clean` or a throwaway container, never `sudo`.
 
 ```
-make dev           # INCREMENTAL build — use this to iterate (see below)
-make dev-test      # incremental build + `ctest -L unit` (the actual CI lane)
-make build         # full Docker image (CUDA 13.3) — the gate, not the loop
-make test-unit     # CPU/host unit tests (imp-tests-unit — NOT the CI lane)
-make test-gpu      # GPU tests (requires RTX 5090)
-make verify-fast   # ~90s pre-push gate
-make verify        # ~5min full
-make install-hooks # pre-push hook: runs verify-fast on src/include/tools/tests changes
-make format        # clang-format
+make dev / make dev-test   # incremental (2-14 s) + the real CI lane — iterate here
+make build                 # full image (~3.5 min) — the gate, benchmarks, pre-push
+make verify-fast           # ~90 s pre-push gate    make verify   # ~5 min full
 ```
 
-- **Never run bare `make format`.** The repo is *not* uniformly clang-formatted
-  (untouched files violate the current style), so formatting whole files rewrites
-  hundreds of lines you did not touch. CI only checks *changed* lines. Format the
-  files you created; for files you edited, format nothing and hand-fix only the
-  lines you added. To check yourself, intersect the violation list with your own
-  added lines rather than trusting a clean `format-check`.
-- Targets exist for `bench`, `test-perf`, `test-golden`, `test-vision`, `gen-perf-baseline`, `verify-north-star`, `verify-chunked`, `tidy` (clang-tidy, advisory), `sanitize`, and the roofline pipeline (`roofline-measure`, `roofline-pin`, `roofline-regress` — see `tools/roofline/README.md`).
-- Configure presets live in `CMakePresets.json` (`default`/`ci`/`debug`/`relwithdebinfo`); dependency pins are single-sourced in `cmake/imp-deps.cmake` (the Dockerfile takes them as build-args). sm_120a is selected via raw gencode (CMake <3.31 workaround); 120f PTX fallback covers non-5090 SKUs.
-- See also: [`AGENTS.md`](AGENTS.md) (subagent roles + guardrails) and [`docs/BENCHMARKING.md`](docs/BENCHMARKING.md) (measurement methodology contract).
+`make build` for anything you *measure* or push; `make dev` for everything else. `make test-unit` is a different binary from the CI lane — green there is not green in CI. Details, target list and CI job names: skill **building-and-testing**.
 
-### Iterate with `make dev`, gate with `make build`
-
-`make build` recompiles the whole tree inside a fresh image every time — ~3.5 min
-whether you changed one line or a hundred. Ten edit-compile cycles is half an hour
-of waiting, and that is the single largest avoidable cost of working here.
-
-`make dev` mounts the tree into the toolchain image and runs ninja against a
-persistent `build-dev/`. Measured on this box:
-
-| after… | `make build` | `make dev` |
-|---|---:|---:|
-| nothing | ~210 s | **2.4 s** |
-| one test file | ~210 s | **4.9 s** |
-| one kernel `.cu` | ~210 s | **6.8 s** |
-| one server TU | ~210 s | **13.9 s** |
-
-Codegen is identical (both `-march=x86-64-v3`, same toolchain layers), so dev
-binaries are valid to run tests against — `make dev-test` runs `ctest -L unit`,
-which is the lane CI actually gates on (`make test-unit` runs a *different*
-binary; green there is not green in CI).
-
-**Where `make dev` is the wrong tool:**
-- **Benchmarks and the perf gate.** Always measure the image. An incremental tree
-  is exactly where a stale object hides, and baselines get re-pinned off measured
-  numbers.
-- **Before pushing.** `verify-fast` and CI build the image from a clean tree.
-- `build-dev/` is root-owned; remove it with `make dev-clean`, never `sudo`.
+**Never run bare `make format`.** The repo is not uniformly clang-formatted, so formatting a whole file rewrites hundreds of lines you did not touch. CI checks *changed* lines only: format files you created, and for files you edited intersect the violation list with your own added lines rather than trusting a clean `format-check`.
 
 ## Conventions
 
-- **The CHANGELOG is a changelog, not a journal.** One to three lines per
-  entry: what changed for the reader, plus the number or issue that makes it
-  checkable. The investigation — hypotheses, what was ruled out, how it was
-  measured — goes to `docs/` or `docs/MISSION_JOURNAL.md`, and the entry links
-  there. Entries had drifted to 20-40 lines each and `[Unreleased]` to 649,
-  which is how a changelog stops being read.
-- **English only in the repo.** All PRs (title + body), commit messages, code comments, docs, and `.md` files are written entirely in English. (Chat replies to the user stay German per global instructions — this rule covers artifacts that land in the repository or on GitHub.)
-- **Always branch off `main` and `gh pr create --base main`.** Never stack PRs (squash-merge + stacking caused recovery-PR cascades). Prefer fewer, batched PRs over one-per-fix.
-- **Performance is gated.** `tests/perf_baseline.json` is the canonical baseline (CI: 3% decode / 5% prefill thresholds). Refresh via `scripts/gen_perf_baseline.sh` when a change intentionally moves perf, and say so in the PR.
-- Runtime config lives in `src/runtime/config.h` as `RuntimeConfig` (loaded from `imp.conf` + `--config` + `--set`; the only env vars still seeded are `IMP_DETERMINISTIC` and `IMP_FMHA_FA2` — the rest of the legacy `IMP_*` surface was retired 2026-07-07). Don't reintroduce ad-hoc env-var reads.
-- Internal errors throw and are translated to `ImpError` at the `src/api/imp_api.cpp` boundary — this is intentional, don't convert those throws to status returns.
-- Match surrounding code style; keep it simple and direct, no speculative abstraction.
+- **The CHANGELOG is a changelog, not a journal.** One to three lines per entry:
+  what changed for the reader, plus the number that makes it checkable. The
+  investigation goes to `docs/` or `docs/MISSION_JOURNAL.md` and the entry links
+  there.
+- **English only in the repo.** PRs, commits, comments, docs, `.md` files. (Chat
+  replies to the user stay German — this covers artifacts that land in the repo
+  or on GitHub.)
+- **Always branch off `main` and `gh pr create --base main`.** Never stack PRs
+  (squash-merge + stacking caused recovery-PR cascades). Prefer fewer, batched PRs.
+- **Performance is gated.** `tests/perf_baseline.json` is canonical (3% decode /
+  5% prefill). Refresh via `scripts/gen_perf_baseline.sh` only when a change
+  intentionally moves perf, and say so in the PR.
+- Runtime config is `RuntimeConfig` in `src/runtime/config.h` (`imp.conf` +
+  `--config` + `--set`). The only env vars still seeded are `IMP_DETERMINISTIC`
+  and `IMP_FMHA_FA2`; don't reintroduce ad-hoc env reads.
+- Internal errors throw and are translated to `ImpError` at the
+  `src/api/imp_api.cpp` boundary — intentional, don't convert them to status returns.
+- Match surrounding code style; simple and direct, no speculative abstraction.
 
-## File Layout & Size
+## File size
 
-The real cost of an oversized file here is **recompile blast radius**, not line count.
-Each `.cu` is one translation unit: touching a kernel in a 1.5k-LOC `.cu` re-`ptxas`es
-the whole TU (the slowest sm_120a build stage) with no intra-file parallelism, and a
-fat header re-triggers every includer. Optimize for compile-time isolation:
+The cost of an oversized file here is **recompile blast radius**, not line count: each `.cu` is one translation unit, so touching a kernel in a 1.5k-LOC `.cu` re-`ptxas`es the whole thing with no intra-file parallelism. One logical unit per file; split kernel / launch wrapper / explicit instantiations when recompiles bite.
 
-- **One logical unit per file** — one kernel concept, one module. If a `.cu` bundles
-  several unrelated kernels, that's a split candidate.
-- **Separate kernel definition / host launch-wrapper / explicit template
-  instantiations.** When recompiles bite, move explicit instantiations into their own
-  `.cu` so a kernel edit doesn't re-build every instantiation.
-- **Line-count thresholds are a proxy/smell, not the metric.** The gate
-  `tools/check_filesize.py` (config `tools/filesize_thresholds.toml`) measures *code*
-  LOC (comments + blanks stripped) per category — kernel `.cu` warn>500/hard>600, normal
-  TU warn>600/hard>800, header warn>500/hard>700. It runs in CI as the `File size` job
-  (advisory warn step + blocking hard step); a hard-review violation fails CI.
-- **A legitimately monolithic file is fine** — add it to `[allow]` in the toml **with a
-  reason** (the gate rejects an empty reason). Don't split for splitting's sake. Current
-  baseline + per-file rationale: `docs/audit/AUDIT_FILESIZE.md`.
-
-## Benchmarking gotchas
-
-- **The GPU is water-cooled and never warm** — do NOT insert temperature cooldown waits between benchmarks (it idles ~30°C and does not thermal-throttle). A decode drop across a sweep is a real regression or stale baseline, never heat.
-- **The GPU downclocks at idle and takes ~1s for clocks to ramp up under load.** The first ~1s of any benchmark runs at reduced clocks and reads artificially LOW — this (not heat) is the dominant cold-start bench artifact (it produced a spurious −42% in one A/B that re-measured +20% clean). **Always warm the clocks before timed reps**: precede the measured run with a discarded warmup run (or busy-spin >1s); imp's built-in `Warmup...` is too few iterations to cover the 1s ramp. Never trust a cold single-shot number.
-- cuBLAS prefill varies up to **2.6× across container restarts** and drifts under sustained load — use **decode** for A/B and follow the bench methodology (`CUBLAS_WORKSPACE_CONFIG=:4096:8`, 10 reps, 3+ trials, one model per process / isolated).
-- **Decode is stable within a session but can read 8–15% low for a whole day** (host/driver state on this WSL2 box; issue #526: identical builds measured tg 238 on one day, 278 the next — full methodology both times). Before trusting a cross-day decode delta or refreshing the baseline, sample `nvidia-smi --query-gpu=clocks.sm,clocks.mem,power.draw` DURING the bench: healthy load = ~2850 MHz SM / 13801 MHz mem / ~500 W. Lower mem clock or power = depressed host state, not a regression. GPU history: `gpu-stats` skill (7-day retention).
-- nsys with CUDA Graphs ON hides captured kernels — profile with `--no-cuda-graphs` to see the true decode kernel mix.
-- **`gemm.deterministic` is not the determinism switch — `runtime.deterministic_gemm` is.** On FA2-served configs the engine skips the legacy deterministic-cuBLAS forcing and says so in the init log. Without the right flag the forward varies run to run: two identical calibration passes differed on **94% of recorded per-channel floats** and moved a quantized model's PPL by 1.6% (2026-07-31). Anything you intend to *diff* across runs — calibration files, layer dumps, logit traces — needs `runtime.deterministic_gemm=true`, and it is worth asserting reproducibility (run twice, compare checksums) before drawing a conclusion from the difference.
-- **Container-written outputs are owned by the container user.** `imp-quantize --out`, calibration files and `build/` cannot be deleted from the host; a failed `rm -rf` leaves a *stale* directory that the next run only partly overwrites — which looks like a result, not an error. Clear them from a throwaway container (`docker run --rm -v … --entrypoint /bin/sh imp:test -c 'rm -rf …'`), and make bind-mounted output dirs writable (`chmod 777`) before the container writes into them.
+`tools/check_filesize.py` gates *code* LOC (comments and blanks stripped) and runs in CI as `File size`. A legitimately monolithic file belongs in `[allow]` in `tools/filesize_thresholds.toml` **with a reason** — don't split for splitting's sake. Rationale per file: `docs/audit/AUDIT_FILESIZE.md`.
 
 ## Hardware reality (sm_120 ≠ datacenter Blackwell)
 
-- **No `tcgen05` / TMEM / wgmma / TMA-WS grouped GEMM.** FP4 path is `mma.sync` `mxf4nvf4` with FA2-style block-scaling. Ignore B200/`sm_100` (FlashAttention-4-style) kernel designs unless porting.
-- **No FP4 cuBLASLt kernels on sm_120** → CUTLASS is the primary GEMM path. Dependency pins are single-sourced in `cmake/imp-deps.cmake` (the Dockerfile takes them as build-args via `scripts/dep_build_args.sh`; bump only that one file). FP8 prefill is unavailable on sm_120.
-- For GGUF, weights are converted to an NVFP4 decode cache at init (bandwidth win on the decode hot path); prefill stays full-precision via source dequant. `nvfp4_beneficial` weights skip the FP16 cache.
-- Docker build cache must **not** use `--mount=type=cache` (silently invalidates test results).
+- **No `tcgen05` / TMEM / wgmma / TMA-WS grouped GEMM.** The FP4 path is
+  `mma.sync` `mxf4nvf4` with FA2-style block-scaling. Ignore B200/`sm_100`
+  (FlashAttention-4-style) kernel designs unless porting.
+- **No FP4 cuBLASLt kernels on sm_120** → CUTLASS is the primary GEMM path; FP8
+  prefill is unavailable. Dependency pins are single-sourced in
+  `cmake/imp-deps.cmake` — bump only that file.
+- For GGUF, weights become an NVFP4 decode cache at init (bandwidth win on the
+  decode hot path); prefill stays full-precision via source dequant.
+- Docker build cache must **not** use `--mount=type=cache` (silently invalidates
+  test results).
 
 ## After hot-path changes
 
-Verify the model still produces coherent output (no repetition loops / token-stuck / state corruption) after touching the forward pass, MoE routing, KV cache, GDN state, or CUDA-graph capture.
+Verify the model still produces coherent output (no repetition loops / token-stuck / state corruption) after touching the forward pass, MoE routing, KV cache, GDN state, or CUDA-graph capture. Skill **check-degeneration**.


### PR DESCRIPTION
**149 → 97 lines.**

CLAUDE.md is in context for every turn; the skills load only when their task comes up. Anything duplicated between them is paid for constantly and maintained in two places — and two sections had become near-verbatim copies:

| Section | Where it already lives | Action |
|---|---|---|
| Benchmarking gotchas (9 lines) | `benchmark-cuda` STOP #1-#4, same numbers | dropped |
| "Iterate with `make dev`" (27 lines + timing table) | `building-and-testing`, verbatim | reduced to the one rule that picks between them |
| Build target list, CMake presets | `building-and-testing` | reduced to three commands + pointer |

The two entries filed under "benchmarking" that were not about benchmarking — `runtime.deterministic_gemm` and container-owned output dirs — are covered by `building-and-testing`, `quant-formats` and `check-degeneration`, so they went with that section rather than being rehomed.

**Kept in full, because no skill carries them** (checked, not assumed):

- the task → skill router, which is the point of the file;
- the two WSL2/WDDM memory facts (a successful `cudaMalloc` proves nothing; free VRAM only decreases) — these mislead rather than fail, which is what makes them expensive;
- the conventions block (CHANGELOG rule, English-only, branching, perf gate, `RuntimeConfig`, the error boundary);
- **the GPU-is-free check** — only `benchmark-cuda` mentions it, but the rule applies to every GPU job;
- **"intersect the format violations with your own added lines"** — appears in no skill, and is the difference between a clean diff and a 300-line reformat.

Added a header stating that this file is the router and the skill is the copy that gets maintained, so the next thing to grow lands in a skill instead of here.

### Also: one trap documented for the first time

`building-and-testing` gains something that cost real time this session and was written down nowhere: **`verify-fast` does not build.** On a host without cmake it re-execs into the `imp:test` image with `IMP_VERIFY_SKIP_BUILD=1` and prints `SKIP build`, so a pre-push run does not test the code being pushed unless `make build` ran first. It can pass on code you deleted, or fail on a regression that is not yours — which is exactly what happened here: two decode failures against a 9-hour-old image, then +0.60% once rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B